### PR TITLE
fix(Subregular/Function): name the two-sided dependence predicate

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -290,7 +290,7 @@ theorem flankWord_congr_right {y' : α} (h : k ≠ n + 1) :
   split_ifs <;> rfl
 
 /-- `f` requires both sides: some target changes under `f`, yet perturbing either far
-side reverts it to the identity. Unlike `IsUnboundedSemiambient`, a two-sided union
+side reverts it to the identity. Unlike `TwoSidedUnboundedDependence`, a two-sided union
 never satisfies this — removing one trigger leaves the other, so the output stays
 changed. -/
 def RequiresBothSides (f : List α → List α) : Prop :=
@@ -323,11 +323,11 @@ theorem RequiresBothSides.of_flanks {f : List α → List α}
       ⟨by simp, fun k hk => flankWord_congr_right (by omega)⟩, by rw [hmid, hmid],
       by rw [hrevR, hmid]⟩
 
-/-- Requiring both sides strengthens unbounded semiambience: a reverted target is in
-particular a flipped one. The converse fails (a two-sided union is semiambient but
+/-- Requiring both sides strengthens two-sided unbounded dependence: a reverted target is
+in particular a flipped one. The converse fails (a two-sided union has the dependence but
 reverts under neither side alone). -/
-theorem RequiresBothSides.isUnboundedSemiambient {f : List α → List α}
-    (hf : RequiresBothSides f) : IsUnboundedSemiambient f := fun d =>
+theorem RequiresBothSides.twoSidedUnboundedDependence {f : List α → List α}
+    (hf : RequiresBothSides f) : TwoSidedUnboundedDependence f := fun d =>
   have ⟨base, i, hi, hchange, hw⟩ := hf d
   ⟨base, i, hi, fun s =>
     have ⟨u, hp, hsym, hrev⟩ := hw s

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -9,7 +9,7 @@ import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.Defs
 
 /-!
-# Side-determinacy: myopia and unbounded semiambience
+# Side-determinacy: myopia and two-sided dependence
 
 Locality predicates on string functions for the function-level subregular hierarchy.
 The kernel `OutputDependsOn f i K` says output coordinate `i` of `f` is fixed by the
@@ -17,8 +17,8 @@ input positions in `K`. Two notions are instances:
 
 * **Myopia** (the "no look-ahead" condition): a side's influence on the output is
   *bounded*.
-* **Unbounded semiambience**: some target is swayed from *either* side, arbitrarily far
-  away — each side alone suffices, so no *one* side determines the target.
+* **Two-sided unbounded dependence**: some target is swayed from *either* side,
+  arbitrarily far away — each side alone suffices to change it.
 
 ## Main definitions
 
@@ -26,7 +26,7 @@ input positions in `K`. Two notions are instances:
 * `UnboundedDependence f s` — for every distance `d`, some output flips under a
   perturbation strictly beyond `d` on side `s`.
 * `IsMyopicTowards f s` — the negation: dependence on side `s` is bounded.
-* `IsUnboundedSemiambient` — co-located form: for every `d`, ONE base word with a
+* `TwoSidedUnboundedDependence` — co-located form: for every `d`, ONE base word with a
   target that flips under a far-left perturbation and under a far-right one.
 
 ## Main theorems
@@ -39,16 +39,21 @@ input positions in `K`. Two notions are instances:
 The predicates are **distance-based** (`∀ d, ∃ word + target`), not fixed-index. A
 fixed target index has only finitely many positions to its left, so a fixed-index
 "unbounded left dependence" is unsatisfiable; the unbounded distance must be witnessed
-by ever-longer words. The co-located `IsUnboundedSemiambient` keeps both
+by ever-longer words. The co-located `TwoSidedUnboundedDependence` keeps both
 perturbations on a single shared base, so any computing automaton hits one context
 where neither side alone fixes the output.
 
-Semiambience is *not* the weak-determinism boundary: a map can be
-`IsUnboundedSemiambient` yet weakly deterministic (a two-sided *union* is perturbed at
-one output by either side, but neither side alone reverts it). The
-not-weakly-deterministic classification is driven by the strictly stronger
-`RequiresBothSides` (in `Bimachine.lean`), where perturbing either far side reverts
-the target to the identity — *both* sides are needed at once, which is the boundary.
+`TwoSidedUnboundedDependence` is *not* the weak-determinism boundary: a map can satisfy
+it yet be weakly deterministic (a two-sided *union* is perturbed at one output by either
+side, but neither side alone reverts it). The not-weakly-deterministic classification is
+driven by the strictly stronger `RequiresBothSides` (in `Bimachine.lean`), where
+perturbing either far side reverts the target to the identity — *both* sides are needed
+at once, which is the boundary.
+
+The name is deliberately descriptive rather than borrowed. Being changeable from either
+side is compatible with every individual output coordinate still being fixed by a single
+side, so this predicate separates neither of the two standard classes on its own: it is
+implied by needing both sides at once, and is also satisfied by maps that never do.
 -/
 
 namespace Subregular
@@ -118,34 +123,34 @@ def IsFarPerturbation (base u : List α) (i d : ℕ) (s : Direction) : Prop :=
     | .left => AgreeFrom base u (i - d)
     | .right => AgreeUpto base u (i + d)
 
-/-- **Unbounded semiambience**, co-located: for every `d`, one base word with a target
-`i` whose output flips under a far perturbation on either side. Co-location keeps both
-flips on a single base (one automaton context). Each side alone sways the target, so
+/-- Two-sided unbounded dependence, co-located: for every `d`, one base word with a
+target `i` whose output flips under a far perturbation on either side. Co-location keeps
+both flips on a single base (one automaton context). Each side alone sways the target, so
 this is weaker than needing both at once (`RequiresBothSides`). -/
-def IsUnboundedSemiambient (f : List α → List β) : Prop :=
+def TwoSidedUnboundedDependence (f : List α → List β) : Prop :=
   ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧
     ∀ s, ∃ u, IsFarPerturbation base u i d s ∧ (f base)[i]? ≠ (f u)[i]?
 
-/-- Co-located semiambience yields unbounded dependence on the left. -/
-theorem IsUnboundedSemiambient.left {f : List α → List β}
-    (h : IsUnboundedSemiambient f) : UnboundedDependence f .left := by
+/-- Co-located two-sided dependence yields unbounded dependence on the left. -/
+theorem TwoSidedUnboundedDependence.left {f : List α → List β}
+    (h : TwoSidedUnboundedDependence f) : UnboundedDependence f .left := by
   intro d
   obtain ⟨base, i, hi, hw⟩ := h d
   obtain ⟨uL, ⟨hlen, hag⟩, hne⟩ := hw .left
   exact ⟨base, uL, i, hlen.symm, hi, hag, hne⟩
 
 /-- …and on the right. -/
-theorem IsUnboundedSemiambient.right {f : List α → List β}
-    (h : IsUnboundedSemiambient f) : UnboundedDependence f .right := by
+theorem TwoSidedUnboundedDependence.right {f : List α → List β}
+    (h : TwoSidedUnboundedDependence f) : UnboundedDependence f .right := by
   intro d
   obtain ⟨base, i, hi, hw⟩ := h d
   obtain ⟨uR, ⟨hlen, hag⟩, hne⟩ := hw .right
   exact ⟨base, uR, i, hlen.symm, hi, hag, hne⟩
 
-/-- **Semiambient ⟹ not myopic** (either side): a real consequence, since semiambience
-exhibits unbounded dependence on each side. -/
-theorem IsUnboundedSemiambient.not_myopic {f : List α → List β}
-    (h : IsUnboundedSemiambient f) (s : Direction) : ¬ IsMyopicTowards f s := by
+/-- A map with two-sided unbounded dependence is myopic towards neither side, since it
+exhibits unbounded dependence on each. -/
+theorem TwoSidedUnboundedDependence.not_myopic {f : List α → List β}
+    (h : TwoSidedUnboundedDependence f) (s : Direction) : ¬ IsMyopicTowards f s := by
   cases s with
   | left => exact not_not_intro h.left
   | right => exact not_not_intro h.right

--- a/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
+++ b/Linglib/Core/Computability/Subregular/Function/SideDeterminacy.lean
@@ -155,26 +155,24 @@ theorem IsUnboundedSemiambient.not_myopic {f : List α → List β}
 @[simp] theorem not_isMyopicTowards_iff {f : List α → List β} {s : Direction} :
     ¬ IsMyopicTowards f s ↔ UnboundedDependence f s := not_not
 
-/-- **Prefix-determined ⟹ right-myopic.** A map each of whose output coordinates is
-fixed by the input's *strict prefix* (`{k | k < i}`) has no rightward look-ahead, so
-it is myopic towards the right. (The canonical left-to-right scan has this shape.) -/
-theorem IsMyopicTowards.right_of_prefixDetermined {f : List α → List β}
-    (h : ∀ i, OutputDependsOn f i {k | k < i}) : IsMyopicTowards f .right := by
-  intro hunb
-  obtain ⟨u, v, i, hlen, _, hag, hne⟩ := hunb 0
-  exact hne (h i u v hlen fun k hk => hag k (by simp only [Set.mem_setOf_eq] at hk; omega))
-
-/-- Output coordinate `i` is fixed by the prefix `{k | k ≤ i}` (the right side is
-irrelevant) — the footprint shape of a left-to-right transducer. -/
+/-- Output coordinate `i` is fixed by the prefix `{k | k ≤ i}`, the footprint shape of a
+left-to-right transducer. -/
 def LeftDetermined (f : List α → List β) (i : ℕ) : Prop := OutputDependsOn f i {k | k ≤ i}
 
-/-- **Left-determined everywhere ⟹ right-myopic.** If every output coordinate is fixed
-by its prefix `{k | k ≤ i}`, the map has no rightward look-ahead. -/
+/-- A map whose every output coordinate is fixed by its prefix `{k | k ≤ i}` has no
+rightward look-ahead. -/
 theorem IsMyopicTowards.right_of_leftDetermined {f : List α → List β}
     (h : ∀ i, LeftDetermined f i) : IsMyopicTowards f .right := by
   intro hunb
   obtain ⟨u, v, i, hlen, _, hag, hne⟩ := hunb 0
   exact hne (h i u v hlen fun k hk => hag k (by simp only [Set.mem_setOf_eq] at hk; omega))
+
+/-- A map whose every output coordinate is fixed by the input's *strict* prefix
+`{k | k < i}` has no rightward look-ahead; the canonical left-to-right scan has this
+shape. The strict hypothesis is the stronger one, so this follows by `OutputDependsOn.mono`. -/
+theorem IsMyopicTowards.right_of_prefixDetermined {f : List α → List β}
+    (h : ∀ i, OutputDependsOn f i {k | k < i}) : IsMyopicTowards f .right :=
+  IsMyopicTowards.right_of_leftDetermined fun i => (h i).mono fun _ hk => Nat.le_of_lt hk
 
 /-! ### Synchronous machines have no look-ahead
 

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -334,14 +334,8 @@ strict prefix `{k | k < i}`. -/
 theorem applyToString_prefixDetermined (r : TierRule α) (i : ℕ) :
     OutputDependsOn r.applyToString i {k | k < i} := by
   intro u v hlen hag
-  rw [applyToString_getElem?, applyToString_getElem?, hlen]
-  have htake : u.take i = v.take i := by
-    apply List.ext_getElem?
-    intro k
-    rcases lt_or_ge k i with hk | hk
-    · simpa only [List.getElem?_take_of_lt hk] using hag k hk
-    · simp [List.getElem?_take_eq_none hk]
-  rw [htake]
+  rw [applyToString_getElem?, applyToString_getElem?, hlen,
+    take_eq_of_agree fun k hk => hag k hk]
 
 /-- **The tier-rule prediction mechanism is right-myopic** — it has no look-ahead.
 Consequently no tier-rule-based prediction (the formal core of a `Harmony.System`) can

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -28,7 +28,7 @@ derived `utp.surfaces_def`. The map is `utp.map`, the surfacing set `plateau`.
 The map is the flagship *unbounded circumambient* process: whether a position changes
 depends on unboundedly distant material on **both** sides, in the strong witness form
 `utp.requiresBothSides` — perturbing either far side alone reverts the change — with
-the weaker `utp.isUnboundedSemiambient` as a corollary, which
+the weaker `utp.twoSidedUnboundedDependence` as a corollary, which
 feeds the weak-determinism exclusion theorems of `Studies/Jardine2016Tone` (bimachine
 rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
@@ -559,10 +559,9 @@ conjunction, so deleting either flanking H reverts the plateau target. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map :=
   utp.requiresBothSides_of_surfaces_iff fun _ _ => utp.surfaces_iff
 
-/-- UTP is unbounded semiambient, a corollary of its circumambience: whether a position
-changes depends on
-unboundedly distant material on both sides. -/
-theorem utp.isUnboundedSemiambient : IsUnboundedSemiambient utp.map :=
-  utp.requiresBothSides.isUnboundedSemiambient
+/-- UTP has two-sided unbounded dependence, a corollary of its circumambience: whether a
+position changes depends on unboundedly distant material on both sides. -/
+theorem utp.twoSidedUnboundedDependence : TwoSidedUnboundedDependence utp.map :=
+  utp.requiresBothSides.twoSidedUnboundedDependence
 
 end Tone.Plateauing

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -27,7 +27,7 @@ representation (§4.1: `H` a H-toned TBU, `O` the paper's Ø).
 
 The map itself and its plateau/circumambience API live in `Phonology/Tone/Plateauing`
 (the rule set (36) as `utp.map_toneless`/`utp.map_single`/`utp.map_plateau`; definition (2) as
-`utp.isUnboundedSemiambient`); this file keeps the paper's theorems about it.
+`utp.twoSidedUnboundedDependence`); this file keeps the paper's theorems about it.
 
 ## Main definitions
 

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -38,10 +38,10 @@ is myopic; Tutrugbu is the segmental case the myopic-side replies do not dissolv
 
 `Seg` is a toy alphabet (prefix vowels ±high × ±ATR-surface; root ±ATR). `tutrugbuATR`
 implements the conditional-blocking rule faithfully; the paper's exx. (3)-(8) are
-decide-checked as stimulus contrasts. `tutrugbu_isUnboundedSemiambient` and
+decide-checked as stimulus contrasts. `tutrugbu_twoSidedUnboundedDependence` and
 `tutrugbu_nonmyopic` connect it to the substrate predicates in `SideDeterminacy.lean`,
 and `tutrugbu_requiresBothSides` is the circumambience proper — both sides needed at
-once, which semiambience alone does not give.
+once, which the two-sided dependence alone does not give.
 
 The machine-level classification (circumambient ⟹ non-deterministic, *not* weakly
 deterministic) is what that witness feeds.
@@ -248,13 +248,13 @@ theorem baseR_get_target (d : ℕ) : (tutrugbuATR (baseR d))[d + 1]? = some .vLo
   rw [tutrugbuATR_baseR]
   simp [baseR, pre]
 
-/-- **Tutrugbu ATR harmony is unbounded semiambient**
-([mccollum-bakovic-mai-meinhardt-2020] §3, def. 13) — the weaker two-sided diagnostic;
-full circumambience is `tutrugbu_requiresBothSides`. At the medial target (index `d+1`):
+/-- **Tutrugbu ATR harmony has two-sided unbounded dependence** — the weaker diagnostic;
+its circumambience proper ([mccollum-bakovic-mai-meinhardt-2020] §3, def. 13) is
+`tutrugbu_requiresBothSides`. At the medial target (index `d+1`):
 the base harmonises it ([+ATR]); flipping the initial-σ height `d` syllables to the left
 blocks it; flipping the root `d` syllables to the right removes the trigger — both from
 the one base word. -/
-theorem tutrugbu_isUnboundedSemiambient : IsUnboundedSemiambient tutrugbuATR := by
+theorem tutrugbu_twoSidedUnboundedDependence : TwoSidedUnboundedDependence tutrugbuATR := by
   intro d
   refine ⟨base d, d + 1, ?_, fun s => ?_⟩
   · -- the target is in-domain: d + 1 < (base d).length  (= 2d+3)
@@ -292,7 +292,7 @@ theorem tutrugbu_isUnboundedSemiambient : IsUnboundedSemiambient tutrugbuATR := 
 the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
 nonmyopic side argued by [walker-2010]. -/
 theorem tutrugbu_nonmyopic (s : Direction) : ¬ IsMyopicTowards tutrugbuATR s :=
-  tutrugbu_isUnboundedSemiambient.not_myopic s
+  tutrugbu_twoSidedUnboundedDependence.not_myopic s
 
 /-- The input symbol at the target index is the recessive `.vLo` (for any initial and
 root): the prefix sequence places a `[−high]` vowel there. -/

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -77,8 +77,8 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
    ex 1a-ii from the paper (encoded in the toy alphabet).
 4. Proves the **bidirectional** dominant-recessive map `maasai` is
    **weakly deterministic** (`maasai_weaklyDeterministic`) via a
-   non-interacting bimachine, and unbounded *semiambient*
-   (`maasai_isUnboundedSemiambient`) — a predicate Tutrugbu also
+   non-interacting bimachine, with two-sided unbounded dependence
+   (`maasai_twoSidedUnboundedDependence`) — a predicate Tutrugbu also
    satisfies — while *not* `RequiresBothSides`
    (`maasai_not_requiresBothSides`). That asymmetry is the WD/ND boundary
    [meinhardt-mai-bakovic-mccollum-2024] draws.
@@ -296,7 +296,7 @@ of two independent spreading passes, so it is **weakly deterministic**
 ([meinhardt-mai-bakovic-mccollum-2024], unbounded *semiambient*): the bimachine `maasaiBM`
 tracks a dominant seen on each side and its output is literally a `unite` of one-sided
 rules. A recessive's surface ATR still co-varies with information unboundedly far on
-either side, so `maasai` satisfies `IsUnboundedSemiambient` — as does Tutrugbu. The
+either side, so `maasai` satisfies `TwoSidedUnboundedDependence` — as does Tutrugbu. The
 contrast is exactly the WD/ND boundary the paper draws: only Tutrugbu is *circumambient*,
 needing both sides at once (`RequiresBothSides`), which Maasai never does. -/
 
@@ -381,12 +381,14 @@ the bidirectional dominant-recessive spread is a non-interacting bimachine. -/
 theorem maasai_weaklyDeterministic : IsBimachineWeaklyDeterministic maasai :=
   maasaiBM_run ▸ isBimachineWeaklyDeterministic maasaiBM maasaiBM_isNonInteracting
 
-/-- **Maasai is unbounded semiambient** — at every distance, a medial recessive's ATR
-flips under a dominant placed far to the left *or* far to the right, each side alone
-sufficing. Tutrugbu satisfies this too (`tutrugbu_isUnboundedSemiambient`); the
-difference is that Maasai does *not* `RequiresBothSides`, so it stays weakly
-deterministic. -/
-theorem maasai_isUnboundedSemiambient : IsUnboundedSemiambient maasai := by
+/-- **Maasai has two-sided unbounded dependence** — at every distance, a medial
+recessive's ATR flips under a dominant placed far to the left *or* far to the right,
+each side alone sufficing. Tutrugbu satisfies this too
+(`tutrugbu_twoSidedUnboundedDependence`); the difference is that Maasai does *not*
+`RequiresBothSides`, so it stays weakly deterministic. The paper's positive
+classification of Maasai as unbounded *semiambient* — every target fixed by information
+from at most one side — is the stronger claim, and is not formalized here. -/
+theorem maasai_twoSidedUnboundedDependence : TwoSidedUnboundedDependence maasai := by
   intro d
   refine ⟨List.replicate (2 * d + 3) .recL, d + 1, by simp; omega, fun s => ?_⟩
   match s with
@@ -419,11 +421,11 @@ theorem maasai_not_requiresBothSides : ¬ RequiresBothSides maasai := fun h =>
 /-- Strictness witness `synchronous ⊊ WD`: Maasai is weakly deterministic yet not
 Mealy-computable. A Mealy-computable map is right-myopic
 (`IsMealyComputable.isRightMyopic`), but Maasai's bidirectional spread is not
-(`maasai_isUnboundedSemiambient`). The stronger `¬ IsLeftSubsequential maasai` (the
+(`maasai_twoSidedUnboundedDependence`). The stronger `¬ IsLeftSubsequential maasai` (the
 *block* class) is not yet formalized: a block transducer can delay output, so it
 needs the bounded-delay route (`IsLeftSubsequential.bounded_delay`) rather than the
 myopia shortcut — see the TODO in `Function/Bimachine.lean`. -/
 theorem maasai_not_mealyComputable : ¬ IsMealyComputable maasai := fun h =>
-  maasai_isUnboundedSemiambient.not_myopic .right h.isRightMyopic
+  maasai_twoSidedUnboundedDependence.not_myopic .right h.isRightMyopic
 
 end MeinhardtEtAl2024


### PR DESCRIPTION
SideDeterminacy audit. `IsUnboundedSemiambient` asserted a term for a property it does not have — and so did `IsUnboundedCircumambient` before it.

- Renamed to `TwoSidedUnboundedDependence`. Per [meinhardt-mai-bakovic-mccollum-2024] §2.3, circumambient (Def. 2) = some target needs *both* sides, semiambient (Def. 3) = every target is fixed by *at most one*, and the two are exclusive. This predicate is neither: Maasai satisfies it, and `RequiresBothSides` implies it — so under the old name that implication read "circumambient ⟹ semiambient". Circumambience proper is `RequiresBothSides`; Def. 3 stays unformalized.
- `IsMyopicTowards.right_of_prefixDetermined` now derives from `right_of_leftDetermined` via `OutputDependsOn.mono`, the strict-prefix hypothesis being the stronger one.
- `TierRule.applyToString_prefixDetermined` folded into `take_eq_of_agree`, which it already imported.