### PR TITLE
refactor(Subregular/Function): automata vocabulary for the dependence predicates

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -76,10 +76,10 @@ import Linglib.Core.Computability.NonContextFree.BlockWitness
 import Linglib.Core.Computability.NonRegular.AnBn
 import Linglib.Core.Computability.StarFree
 import Linglib.Core.Computability.Subregular.Function.Bimachine
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Linglib.Core.Computability.Subregular.Function.Defs
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
 import Linglib.Core.Computability.Subregular.Function.Subsequential
 import Linglib.Core.Computability.Subregular.Language.Algebra.Equations
 import Linglib.Core.Computability.Subregular.Language.Algebra.Pin

--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Fintype.EquivFin
 import Linglib.Core.Computability.Mealy
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Linglib.Core.Data.List.Fold
 
 /-!
@@ -40,7 +40,7 @@ bimachine — the weakly-deterministic functions.
 
 * `IsLeftSubsequential ⊊ IsBimachineWeaklyDeterministic`. No witness is formalized here.
   Note that non-myopia refutes only *synchronous* computability, via
-  `IsMealyComputable.isRightMyopic`: a block transducer may delay its output, so its
+  `IsMealyComputable.boundedDependence_right`: a block transducer may delay its output, so its
   coordinate `i` is not fixed by the prefix, and excluding one takes the bounded-delay
   route (`IsLeftSubsequential.bounded_delay`) instead.
 -/
@@ -208,9 +208,8 @@ variable {α : Type*} {x fill y a : α} {n k : ℕ} {p : α → Bool}
 
 The recurring witness family for two-sided unboundedness: a target buried in a filler
 run, with independently editable flanks. `RequiresBothSides.of_flanks` packages the
-whole assembly — a map is excluded by exhibiting only the images of the base and the
-two single-flank perturbations at the target. This is the three-map method of
-[yolyan-2025] §5.3, as an object. -/
+whole assembly — a map is excluded by exhibiting only three images, those of the base
+and of the two single-flank perturbations, at the target coordinate. -/
 
 /-- A flank-controlled word: `x`, then `n` copies of `fill`, then `y`. -/
 def flankWord (x fill y : α) (n : ℕ) : List α := x :: (List.replicate n fill ++ [y])

--- a/Linglib/Core/Computability/Subregular/Function/Defs.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Defs.lean
@@ -10,7 +10,7 @@ import Mathlib.Logic.Basic
 
 The orientation of a left-to-right vs right-to-left scan, shared by the transducer
 machines and the side-determinacy predicates of `Core/Computability/Subregular/Function/`.
-Extracted to its own leaf so the footprint-predicate file (`SideDeterminacy.lean`) does
+Extracted to its own leaf so the footprint-predicate file (`Dependence.lean`) does
 not have to depend on the transducer machine file just to name a `left`/`right` tag.
 -/
 

--- a/Linglib/Core/Computability/Subregular/Function/Dependence.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Dependence.lean
@@ -9,14 +9,14 @@ import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.Defs
 
 /-!
-# Side-determinacy: myopia and two-sided dependence
+# How far an output coordinate depends on its input
 
-Locality predicates on string functions for the function-level subregular hierarchy.
-The kernel `OutputDependsOn f i K` says output coordinate `i` of `f` is fixed by the
-input positions in `K`. Two notions are instances:
+Dependence predicates on string functions. The kernel `OutputDependsOn f i K` says
+output coordinate `i` of `f` is fixed by the input positions in `K`. Two notions are
+instances:
 
-* **Myopia** (the "no look-ahead" condition): a side's influence on the output is
-  *bounded*.
+* **Bounded dependence** on a side: that side's influence on the output reaches only a
+  bounded distance, so a transducer scanning from it needs no unbounded context.
 * **Two-sided unbounded dependence**: some target is swayed from *either* side,
   arbitrarily far away — each side alone suffices to change it.
 
@@ -25,14 +25,15 @@ input positions in `K`. Two notions are instances:
 * `OutputDependsOn` — output coord `i` determined by input positions in `K`.
 * `UnboundedDependence f s` — for every distance `d`, some output flips under a
   perturbation strictly beyond `d` on side `s`.
-* `IsMyopicTowards f s` — the negation: dependence on side `s` is bounded.
+* `BoundedDependence f s` — the negation: dependence on side `s` is bounded.
 * `TwoSidedUnboundedDependence` — co-located form: for every `d`, ONE base word with a
   target that flips under a far-left perturbation and under a far-right one.
 
 ## Main theorems
 
-* `Mealy.isRightMyopic`, `IsMealyComputable.isRightMyopic` — a synchronous machine is
-  prefix-determined at every coordinate, hence has no rightward look-ahead.
+* `Mealy.boundedDependence_right`, `IsMealyComputable.boundedDependence_right` — a
+  sequential machine is prefix-determined at every coordinate, so nothing to its right
+  influences it.
 
 ## Implementation notes
 
@@ -111,8 +112,9 @@ def UnboundedDependence (f : List α → List β) : Direction → Prop
   | .right => ∀ d, ∃ (u v : List α) (i : ℕ), u.length = v.length ∧ i < u.length ∧
                 AgreeUpto u v (i + d) ∧ (f u)[i]? ≠ (f v)[i]?
 
-/-- **Myopia towards `s`**: dependence on side `s` is bounded. -/
-def IsMyopicTowards (f : List α → List β) (s : Direction) : Prop :=
+/-- Dependence on side `s` is bounded: no target is swayed from arbitrarily far away on
+that side. -/
+def BoundedDependence (f : List α → List β) (s : Direction) : Prop :=
   ¬ UnboundedDependence f s
 
 /-- An equal-length variant of `base` differing only beyond the `d`-margin of target
@@ -147,50 +149,51 @@ theorem TwoSidedUnboundedDependence.right {f : List α → List β}
   obtain ⟨uR, ⟨hlen, hag⟩, hne⟩ := hw .right
   exact ⟨base, uR, i, hlen.symm, hi, hag, hne⟩
 
-/-- A map with two-sided unbounded dependence is myopic towards neither side, since it
-exhibits unbounded dependence on each. -/
-theorem TwoSidedUnboundedDependence.not_myopic {f : List α → List β}
-    (h : TwoSidedUnboundedDependence f) (s : Direction) : ¬ IsMyopicTowards f s := by
+/-- A map with two-sided unbounded dependence has bounded dependence on neither side,
+since it exhibits unbounded dependence on each. -/
+theorem TwoSidedUnboundedDependence.not_boundedDependence {f : List α → List β}
+    (h : TwoSidedUnboundedDependence f) (s : Direction) : ¬ BoundedDependence f s := by
   cases s with
   | left => exact not_not_intro h.left
   | right => exact not_not_intro h.right
 
-/-- `f` is non-myopic towards `s` exactly when it has unbounded dependence there
-(`IsMyopicTowards` is by definition the negation of `UnboundedDependence`). -/
-@[simp] theorem not_isMyopicTowards_iff {f : List α → List β} {s : Direction} :
-    ¬ IsMyopicTowards f s ↔ UnboundedDependence f s := not_not
+/-- `f` fails bounded dependence towards `s` exactly when it has unbounded dependence there
+(`BoundedDependence` is by definition the negation of `UnboundedDependence`). -/
+@[simp] theorem not_boundedDependence_iff {f : List α → List β} {s : Direction} :
+    ¬ BoundedDependence f s ↔ UnboundedDependence f s := not_not
 
 /-- Output coordinate `i` is fixed by the prefix `{k | k ≤ i}`, the footprint shape of a
 left-to-right transducer. -/
 def LeftDetermined (f : List α → List β) (i : ℕ) : Prop := OutputDependsOn f i {k | k ≤ i}
 
-/-- A map whose every output coordinate is fixed by its prefix `{k | k ≤ i}` has no
-rightward look-ahead. -/
-theorem IsMyopicTowards.right_of_leftDetermined {f : List α → List β}
-    (h : ∀ i, LeftDetermined f i) : IsMyopicTowards f .right := by
+/-- A map whose every output coordinate is fixed by its prefix `{k | k ≤ i}` depends
+boundedly on the right — trivially so, since nothing to the right matters at all. -/
+theorem BoundedDependence.right_of_leftDetermined {f : List α → List β}
+    (h : ∀ i, LeftDetermined f i) : BoundedDependence f .right := by
   intro hunb
   obtain ⟨u, v, i, hlen, _, hag, hne⟩ := hunb 0
   exact hne (h i u v hlen fun k hk => hag k (by simp only [Set.mem_setOf_eq] at hk; omega))
 
 /-- A map whose every output coordinate is fixed by the input's *strict* prefix
-`{k | k < i}` has no rightward look-ahead; the canonical left-to-right scan has this
-shape. The strict hypothesis is the stronger one, so this follows by `OutputDependsOn.mono`. -/
-theorem IsMyopicTowards.right_of_prefixDetermined {f : List α → List β}
-    (h : ∀ i, OutputDependsOn f i {k | k < i}) : IsMyopicTowards f .right :=
-  IsMyopicTowards.right_of_leftDetermined fun i => (h i).mono fun _ hk => Nat.le_of_lt hk
+`{k | k < i}` depends boundedly on the right; the canonical left-to-right scan has this
+shape. The strict hypothesis is the stronger one, so this follows by
+`OutputDependsOn.mono`. -/
+theorem BoundedDependence.right_of_prefixDetermined {f : List α → List β}
+    (h : ∀ i, OutputDependsOn f i {k | k < i}) : BoundedDependence f .right :=
+  BoundedDependence.right_of_leftDetermined fun i => (h i).mono fun _ hk => Nat.le_of_lt hk
 
-/-! ### Synchronous machines have no look-ahead
+/-! ### Sequential machines do not depend on the right
 
 Output coordinate `i` of a `Mealy` machine is fixed by the input prefix `[0..i]`, so the
-synchronous class is myopic towards the right. Block transducers need not be: one that
-delays output, emitting `[]` and then `[x, y]`, has its coordinate `0` depend on input
-position `1`. -/
+sequential class depends boundedly on the right. Machines emitting blocks need not: one
+that delays output, emitting `[]` and then `[x, y]`, has its coordinate `0` depend on
+input position `1`. -/
 
 section Synchronous
 
 variable {σ : Type*}
 
-/-- A synchronous machine is left-determined at every coordinate: output `i` depends only
+/-- A sequential machine is left-determined at every coordinate: output `i` depends only
 on the input prefix `{k | k ≤ i}`. -/
 theorem Mealy.leftDetermined (T : Mealy σ α β) (i : ℕ) : LeftDetermined T.run i := by
   intro u v hlen hag
@@ -198,9 +201,9 @@ theorem Mealy.leftDetermined (T : Mealy σ α β) (i : ℕ) : LeftDetermined T.r
   rw [T.getElem?_run u, T.getElem?_run v, hag i le_rfl,
     take_eq_of_agree fun k hk => hag k hk.le]
 
-/-- A synchronous machine is right-myopic: it has no look-ahead. -/
-theorem Mealy.isRightMyopic (T : Mealy σ α β) : IsMyopicTowards T.run .right :=
-  IsMyopicTowards.right_of_leftDetermined T.leftDetermined
+/-- A sequential machine's output never depends on input to its right. -/
+theorem Mealy.boundedDependence_right (T : Mealy σ α β) : BoundedDependence T.run .right :=
+  BoundedDependence.right_of_leftDetermined T.leftDetermined
 
 /-- A Mealy-computable map is left-determined at every coordinate. -/
 theorem IsMealyComputable.leftDetermined {f : List α → List β}
@@ -208,10 +211,10 @@ theorem IsMealyComputable.leftDetermined {f : List α → List β}
   obtain ⟨σ, _, T, rfl⟩ := hf
   exact T.leftDetermined i
 
-/-- A Mealy-computable map is right-myopic: it has no look-ahead. -/
-theorem IsMealyComputable.isRightMyopic {f : List α → List β}
-    (hf : IsMealyComputable f) : IsMyopicTowards f .right :=
-  IsMyopicTowards.right_of_leftDetermined hf.leftDetermined
+/-- A Mealy-computable map's output never depends on input to its right. -/
+theorem IsMealyComputable.boundedDependence_right {f : List α → List β}
+    (hf : IsMealyComputable f) : BoundedDependence f .right :=
+  BoundedDependence.right_of_leftDetermined hf.leftDetermined
 
 end Synchronous
 

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -386,8 +386,8 @@ theorem IsLeftSubsequential.exists_getElem?_append_eq (hf : IsLeftSubsequential 
   omega
 
 /-- `f` is not left-subsequential if for every `N` some images `f u` and `f (u ++ v)`
-disagree more than `N` positions before the end of `f u` (e.g. unbounded tonal
-plateauing, [jardine-2016]). -/
+disagree more than `N` positions before the end of `f u` — the contrapositive of
+`bounded_delay`, since no bound on the withheld suffix can then exist. -/
 theorem not_isLeftSubsequential_of_diverging
     (h : ∀ N, ∃ (u v : List α) (i : ℕ),
       i + N < (f u).length ∧ (f u)[i]? ≠ (f (u ++ v))[i]?) :

--- a/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/BMRS.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subregular.Logic.QFLogic
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Mathlib.Data.Finset.Basic
 
 /-!

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Fintype.Option
 import Linglib.Core.Computability.TierProjection
 import Linglib.Core.Computability.Subregular.Function.Subsequential
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 
 /-!
 # TierProjection-based rules (`TierRule`)
@@ -340,8 +340,8 @@ theorem applyToString_prefixDetermined (r : TierRule α) (i : ℕ) :
 /-- **The tier-rule prediction mechanism is right-myopic** — it has no look-ahead.
 Consequently no tier-rule-based prediction (the formal core of a `Harmony.System`) can
 compute a *non-myopic* harmony, such as an unbounded-circumambient pattern. -/
-theorem applyToString_isRightMyopic (r : TierRule α) :
-    IsMyopicTowards r.applyToString .right :=
-  IsMyopicTowards.right_of_prefixDetermined (applyToString_prefixDetermined r)
+theorem applyToString_boundedDependence_right (r : TierRule α) :
+    BoundedDependence r.applyToString .right :=
+  BoundedDependence.right_of_prefixDetermined (applyToString_prefixDetermined r)
 
 end Subregular.TierRule

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subregular.Function.Subsequential
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 import Linglib.Core.Computability.Subregular.Function.Bimachine

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 
 /-!
@@ -39,7 +39,7 @@ is myopic; Tutrugbu is the segmental case the myopic-side replies do not dissolv
 `Seg` is a toy alphabet (prefix vowels ±high × ±ATR-surface; root ±ATR). `tutrugbuATR`
 implements the conditional-blocking rule faithfully; the paper's exx. (3)-(8) are
 decide-checked as stimulus contrasts. `tutrugbu_twoSidedUnboundedDependence` and
-`tutrugbu_nonmyopic` connect it to the substrate predicates in `SideDeterminacy.lean`,
+`tutrugbu_nonmyopic` connect it to the substrate predicates in `Dependence.lean`,
 and `tutrugbu_requiresBothSides` is the circumambience proper — both sides needed at
 once, which the two-sided dependence alone does not give.
 
@@ -291,8 +291,8 @@ theorem tutrugbu_twoSidedUnboundedDependence : TwoSidedUnboundedDependence tutru
 ([mccollum-bakovic-mai-meinhardt-2020]; [wilson-2006]). A segmental counterexample to
 the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
 nonmyopic side argued by [walker-2010]. -/
-theorem tutrugbu_nonmyopic (s : Direction) : ¬ IsMyopicTowards tutrugbuATR s :=
-  tutrugbu_twoSidedUnboundedDependence.not_myopic s
+theorem tutrugbu_nonmyopic (s : Direction) : ¬ BoundedDependence tutrugbuATR s :=
+  tutrugbu_twoSidedUnboundedDependence.not_boundedDependence s
 
 /-- The input symbol at the target index is the recessive `.vLo` (for any initial and
 root): the prefix sequence places a `[−high]` vowel there. -/

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -3,13 +3,11 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
 import Linglib.Core.Computability.Subregular.Function.Subsequential
-import Linglib.Core.Computability.Mealy
-import Linglib.Core.Computability.Subregular.Function.Bimachine
-import Linglib.Core.Computability.Subregular.Function.OSL
-import Linglib.Core.Computability.Subregular.Function.SideDeterminacy
+import Linglib.Core.Computability.Subregular.Function.Dependence
 import Linglib.Core.Computability.Subregular.Function.Bimachine
 
 /-!
@@ -420,12 +418,12 @@ theorem maasai_not_requiresBothSides : ¬ RequiresBothSides maasai := fun h =>
 
 /-- Strictness witness `synchronous ⊊ WD`: Maasai is weakly deterministic yet not
 Mealy-computable. A Mealy-computable map is right-myopic
-(`IsMealyComputable.isRightMyopic`), but Maasai's bidirectional spread is not
+(`IsMealyComputable.boundedDependence_right`), but Maasai's bidirectional spread is not
 (`maasai_twoSidedUnboundedDependence`). The stronger `¬ IsLeftSubsequential maasai` (the
 *block* class) is not yet formalized: a block transducer can delay output, so it
 needs the bounded-delay route (`IsLeftSubsequential.bounded_delay`) rather than the
 myopia shortcut — see the TODO in `Function/Bimachine.lean`. -/
 theorem maasai_not_mealyComputable : ¬ IsMealyComputable maasai := fun h =>
-  maasai_twoSidedUnboundedDependence.not_myopic .right h.isRightMyopic
+  maasai_twoSidedUnboundedDependence.not_boundedDependence .right h.boundedDependence_right
 
 end MeinhardtEtAl2024


### PR DESCRIPTION
The upstreamable transducer cone was running on phonology coinages. Replaced with self-describing names a mathematician reads directly.

- `IsMyopicTowards` → `BoundedDependence` ("myopia" is from the harmony literature). It is *defined* as `¬ UnboundedDependence`, so the fix is to stop borrowing a term rather than to import a different one; the pair now reads together. `SideDeterminacy.lean` → `Dependence.lean` for the same reason.
- Class prose aligned to the transducer literature's *sequential* / *rational* / *regular*, per the Filiot–Reynier survey.
- Dropped the last two linguistics citations from the upstreamable cone: `[jardine-2016]` plus an "unbounded tonal plateauing" example in `Subsequential.lean`, and `[yolyan-2025] §5.3` on `RequiresBothSides.of_flanks` (an unverified section number besides).
- Studies files keep the phonology vocabulary — `tutrugbu_nonmyopic` stays, since there the paper's term is the right one.