### PR TITLE
docs(Subregular/Function): anchor bimachines and the sequential naming

### DIFF
--- a/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Bimachine.lean
@@ -11,15 +11,20 @@ import Linglib.Core.Data.List.Fold
 /-!
 # Bimachines and weak determinism
 
-A `Bimachine` (Schützenberger; [mohri-1997]) computes a letter-to-letter string function
-using **both** directions of context: a left automaton scans `→` and assigns a left state
-to each position, a right automaton scans `←` and assigns a right state, and the output at
-position `i` is `out (leftState before i) (input i) (rightState after i)`.
+A `Bimachine` ([eilenberg-1974]; [mohri-1997]) computes a letter-to-letter string
+function using **both** directions of context: a left automaton scans `→` and assigns a
+left state to each position, a right automaton scans `←` and assigns a right state, and
+the output at position `i` is `out (leftState before i) (input i) (rightState after i)`.
+Bimachines are exactly the transducers of the semi-monomial representations, so by the
+decomposition theorem of [elgot-mezei-1965] they compute the rational functions — every
+one factors as a left-to-right scan followed by a right-to-left one.
 
 A bimachine over a single alphabet is **non-interacting** when its output is a *union of
 one-sided change-rules over the identity*: each side may add its own change, but neither
 can suppress the other's. `IsBimachineWeaklyDeterministic` is computability by such a
-bimachine — the weakly-deterministic functions.
+bimachine. Note that non-interaction is an extra restriction on the Elgot–Mezei
+factorization, not a consequence of it: the two scans are always available, and the
+condition is that neither suppresses the other.
 
 ## Main results
 

--- a/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Subsequential.lean
@@ -48,6 +48,14 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
 
 ## Implementation notes
 
+The name follows [choffrut-1977] and [mohri-1997]: *sequential* for a deterministic
+transducer with no state-final output, *subsequential* once one is added. The usage is
+contested — [sakarovitch-2009] calls this class simply *sequential* (reserving *pure
+sequential* for the empty-final-output case) and flags his own terminology as
+unconventional, quoting [bruyere-reutenauer-1999] that "the word sub-sequential is
+unfortunate". We keep the Choffrut spelling, so `Mealy` computes the *pure sequential*
+length-preserving functions and `SFST` the subsequential ones.
+
 `SFST` models the *total* subsequential functions: `step` is total and every input is
 accepted, so `run` is a total function. This restricts the literature's class — a sink
 state does not recover partiality, since out-of-domain inputs still emit output — so

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30329,6 +30329,56 @@
   sources   = {Core/Computability/MyhillNerode.lean}
 }
 
+@book{sakarovitch-2009,
+  author    = {Sakarovitch, Jacques},
+  year      = {2009},
+  title     = {Elements of Automata Theory},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  isbn      = {9780521844253},
+  note      = {Translated by Reuben Thomas},
+  subfield  = {phonology/subregular},
+  role      = {foundational},
+  validated = {true}
+}
+
+@book{eilenberg-1974,
+  author    = {Eilenberg, Samuel},
+  year      = {1974},
+  title     = {Automata, Languages and Machines, Volume A},
+  publisher = {Academic Press},
+  address   = {New York},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true}
+}
+
+@article{elgot-mezei-1965,
+  author    = {Elgot, Calvin C. and Mezei, Jorge E.},
+  year      = {1965},
+  title     = {On relations defined by generalized finite automata},
+  journal   = {IBM Journal of Research and Development},
+  volume    = {9},
+  number    = {1},
+  pages     = {47--68},
+  doi       = {10.1147/rd.91.0047},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true}
+}
+
+@article{bruyere-reutenauer-1999,
+  author    = {Bruy{\`e}re, V{\'e}ronique and Reutenauer, Christophe},
+  year      = {1999},
+  title     = {A proof of Choffrut's theorem on subsequential functions},
+  journal   = {Theoretical Computer Science},
+  volume    = {215},
+  pages     = {329--335},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true}
+}
+
 @article{mohri-1997,
   author    = {Mohri, Mehryar},
   year      = {1997},


### PR DESCRIPTION
Grounds the transducer cone in the automata literature, from Sakarovitch's *Elements of Automata Theory*.

- `Bimachine.lean` had no source for the class it defines. Bimachines are [eilenberg-1974]'s, and are exactly the transducers of semi-monomial representations, so [elgot-mezei-1965] gives the factorization every rational function admits. Weak determinism is an extra *non-interaction* restriction on that factorization, not a consequence of it — worth saying, since the two scans are always available.
- Records that *sequential* vs *subsequential* is contested: we follow [choffrut-1977]/[mohri-1997], while [sakarovitch-2009] calls this class simply sequential and flags his own usage as unconventional, quoting [bruyere-reutenauer-1999]. No rename — just a note so the divergence is visible.
- Four bib entries added; Elgot–Mezei's DOI verified against both Sakarovitch's bibliography and an independent lookup.