### PR TITLE
fix(Studies): bimachine audit repairs + bundled NonInteraction

### DIFF
--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -32,8 +32,9 @@ restriction on the Elgot–Mezei factorization, not a consequence of it.
 * `Bimachine L R α β`: machine with left states `L`, right states `R`, alphabets `α`, `β`
 * `Bimachine.run`: the computed function
 * `IsBimachineComputable f`: `f` is computed by some finite bimachine
-* `Bimachine.IsNonInteracting`: the cell output is an order-independent union of
-  one-sided change-rules over the identity
+* `Bimachine.NonInteraction`, `Bimachine.IsNonInteracting`: a decomposition of the
+  cell output as an order-independent union of one-sided change-rules over the
+  identity, and its existence
 * `IsNonInteractingBimachineComputable f`: `f` is computed by some non-interacting
   finite bimachine
 
@@ -321,56 +322,73 @@ inert. -/
 @[simp] theorem unite_eq_self_iff {cL cR a : α} : unite cL cR a = a ↔ cL = a ∧ cR = a := by
   grind [unite]
 
-/-- A bimachine over a single alphabet is non-interacting when its cell output is an
-order-independent union of one-sided change-rules over the identity default — `ωL` and
-`ωR` each propose a change for their side, the output takes whichever fires, and the
-union commutes (`unite_comm_iff`: the proposals agree wherever both fire). Neither side
-can *suppress* the other's change; that suppression is exactly what interaction would
-require. -/
-def IsNonInteracting (B : Bimachine L R α α) : Prop :=
-  ∃ (ωL : L → α → α) (ωR : R → α → α),
-    (∀ l a r, unite (ωL l a) (ωR r a) a = unite (ωR r a) (ωL l a) a) ∧
-    ∀ l a r, B.output l a r = unite (ωL l a) (ωR r a) a
+/-- A non-interacting decomposition of a bimachine: a change-rule per side over the
+identity default, whose union is order-independent and produces the cell output. -/
+structure NonInteraction (B : Bimachine L R α α) where
+  /-- The change the left context proposes for the current symbol. -/
+  ruleL : L → α → α
+  /-- The change the right context proposes for the current symbol. -/
+  ruleR : R → α → α
+  /-- The union of the two proposals is order-independent (`unite_comm_iff`: they agree
+  wherever both fire), so neither side can suppress the other's change. -/
+  unite_comm : ∀ l a r, unite (ruleL l a) (ruleR r a) a = unite (ruleR r a) (ruleL l a) a
+  /-- The cell output is the union of the two proposals. -/
+  output_eq : ∀ l a r, B.output l a r = unite (ruleL l a) (ruleR r a) a
+
+/-- A bimachine over a single alphabet is non-interacting when it admits a
+non-interacting decomposition (`NonInteraction`) of its cell output. -/
+def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
 
 /-- The output at a cell is determined by one side alone: fixing the input symbol and
 one context state already fixes it. -/
 def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
   (∀ r', B.output l a r' = B.output l a r) ∨ (∀ l', B.output l' a r = B.output l a r)
 
-/-- At every cell whose output differs from the input symbol, a non-interacting
-bimachine is one-sided: the change is the left rule's alone or the right rule's alone.
+variable {B : Bimachine L R α α}
+
+/-- At every cell whose output differs from the input symbol, a decomposed bimachine is
+one-sided: the change is the left rule's alone or the right rule's alone.
 Order-independence of the union is what makes the firing side's value independent of
 the other side's state. -/
-theorem IsNonInteracting.oneSidedAt_of_change {B : Bimachine L R α α}
-    (h : B.IsNonInteracting) {l : L} {a : α} {r : R} (hne : B.output l a r ≠ a) :
-    B.OneSidedAt l a r := by
-  obtain ⟨ωL, ωR, hcomm, hω⟩ := h
-  by_cases hL : ωL l a = a
-  · have hR : ωR r a ≠ a := fun hR => hne (by simp only [hω, hL, hR, unite_left_self])
+theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : α}
+    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
+  by_cases hL : w.ruleL l a = a
+  · have hR : w.ruleR r a ≠ a := fun hR =>
+      hne (by simp only [w.output_eq, hL, hR, unite_left_self])
     refine .inr fun l' => ?_
-    by_cases hL' : ωL l' a = a
-    · simp only [hω, hL, hL', unite_left_self]
-    · simp only [hω, hL, unite_left_self, unite_of_left_ne hL']
-      exact unite_comm_iff.mp (hcomm l' a r) hL' hR
-  · exact .inl fun r' => by simp only [hω, unite_of_left_ne hL]
+    by_cases hL' : w.ruleL l' a = a
+    · simp only [w.output_eq, hL, hL', unite_left_self]
+    · simp only [w.output_eq, hL, unite_left_self, unite_of_left_ne hL']
+      exact unite_comm_iff.mp (w.unite_comm l' a r) hL' hR
+  · exact .inl fun r' => by simp only [w.output_eq, unite_of_left_ne hL]
 
-/-- Non-interaction transports along state reindexing: the one-sided rules compose
-with `eL.symm` and `eR.symm`. -/
-theorem IsNonInteracting.reindex {L' R' : Type*} {B : Bimachine L R α α}
-    (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
-    (Bimachine.reindex eL eR B).IsNonInteracting :=
-  have ⟨ωL, ωR, hcomm, hω⟩ := h
-  ⟨fun l a => ωL (eL.symm l) a, fun r a => ωR (eR.symm r) a,
-   fun _ a _ => hcomm _ a _, fun _ a _ => hω _ a _⟩
+/-- At every cell whose output differs from the input symbol, a non-interacting
+bimachine is one-sided. -/
+theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting) {l : L} {a : α}
+    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r :=
+  h.elim fun w => w.oneSidedAt_of_change hne
 
-/-- Under a non-interacting cell decomposition, a word whose run leaves target `i`
-unchanged has both of its change-proposals inert there. -/
-theorem inert_of_reverting {B : Bimachine L R α α} {ωL : L → α → α} {ωR : R → α → α}
-    (hω : ∀ l a r, B.output l a r = unite (ωL l a) (ωR r a) a) {u : List α} {i : ℕ} {a : α}
-    (hsym : u[i]? = some a) (hrev : (B.run u)[i]? = u[i]?) :
-    ωL (B.lState (u.take i)) a = a ∧ ωR (B.rState (u.drop (i + 1))) a = a := by
+/-- Transports a decomposition along state reindexing: the rules compose with
+`eL.symm` and `eR.symm`. -/
+def NonInteraction.reindex {L' R' : Type*} (w : B.NonInteraction) (eL : L ≃ L')
+    (eR : R ≃ R') : (Bimachine.reindex eL eR B).NonInteraction where
+  ruleL l a := w.ruleL (eL.symm l) a
+  ruleR r a := w.ruleR (eR.symm r) a
+  unite_comm _ a _ := w.unite_comm _ a _
+  output_eq _ a _ := w.output_eq _ a _
+
+/-- Non-interaction transports along state reindexing. -/
+theorem IsNonInteracting.reindex {L' R' : Type*} (h : B.IsNonInteracting) (eL : L ≃ L')
+    (eR : R ≃ R') : (Bimachine.reindex eL eR B).IsNonInteracting :=
+  h.map (·.reindex eL eR)
+
+/-- A word whose run leaves target `i` unchanged has both of its change-proposals inert
+there. -/
+theorem NonInteraction.inert_of_reverting (w : B.NonInteraction) {u : List α} {i : ℕ}
+    {a : α} (hsym : u[i]? = some a) (hrev : (B.run u)[i]? = u[i]?) :
+    w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
   refine unite_eq_self_iff.mp (Option.some_injective _ (Eq.symm ?_))
-  rw [← hsym, ← hrev, B.getElem?_run, hsym, Option.map_some, hω]
+  rw [← hsym, ← hrev, B.getElem?_run, hsym, Option.map_some, w.output_eq]
 
 end Bimachine
 
@@ -418,9 +436,9 @@ theorem IsNonInteractingBimachineComputable.of_mealyComputable {f : List α → 
     (h : IsMealyComputable f) : IsNonInteractingBimachineComputable f :=
   have ⟨_, _, T, hT⟩ := h
   hT ▸ T.toBimachine_run ▸ T.toBimachine.isNonInteractingBimachineComputable
-    ⟨T.output, fun _ a => a,
-     fun _ a _ => (Bimachine.unite_right_self _ a).trans (Bimachine.unite_left_self _ a).symm,
-     fun _ a _ => (Bimachine.unite_right_self _ a).symm⟩
+    ⟨⟨T.output, fun _ a => a,
+      fun _ a _ => (Bimachine.unite_right_self _ a).trans (Bimachine.unite_left_self _ a).symm,
+      fun _ a _ => (Bimachine.unite_right_self _ a).symm⟩⟩
 
 /-- A map that requires both sides is computed by no non-interacting bimachine. At the
 witness the base changes but each far perturbation reverts: the right perturbation
@@ -428,7 +446,7 @@ keeps the left state, forcing `ωL` inert at this cell; the left perturbation ke
 right state, forcing `ωR` inert; yet the base needs one of them to fire. -/
 theorem RequiresBothSides.not_isNonInteractingBimachineComputable {f : List α → List α}
     (hf : RequiresBothSides f) : ¬ IsNonInteractingBimachineComputable f := by
-  rintro ⟨L, _, R, _, B, rfl, ωL, ωR, -, hω⟩
+  rintro ⟨L, _, R, _, B, rfl, ⟨w⟩⟩
   obtain ⟨base, i, hi, hchange, hw⟩ := hf 0
   obtain ⟨uL, ⟨-, hLag⟩, hLsym, hLrev⟩ := hw .left
   obtain ⟨uR, ⟨-, hRag⟩, hRsym, hRrev⟩ := hw .right
@@ -436,10 +454,10 @@ theorem RequiresBothSides.not_isNonInteractingBimachineComputable {f : List α �
   -- decompose the base's cell, retarget each side's state to the perturbation that
   -- shares it, and silence both rules by `inert_of_reverting`
   apply hchange
-  rw [B.getElem?_run, List.getElem?_eq_getElem hi, Option.map_some, hω,
+  rw [B.getElem?_run, List.getElem?_eq_getElem hi, Option.map_some, w.output_eq,
     hRag.take_eq (by omega), hLag.drop_eq (by omega),
-    (Bimachine.inert_of_reverting hω (hRsym.trans (List.getElem?_eq_getElem hi)) hRrev).1,
-    (Bimachine.inert_of_reverting hω (hLsym.trans (List.getElem?_eq_getElem hi)) hLrev).2,
+    (w.inert_of_reverting (hRsym.trans (List.getElem?_eq_getElem hi)) hRrev).1,
+    (w.inert_of_reverting (hLsym.trans (List.getElem?_eq_getElem hi)) hLrev).2,
     Bimachine.unite_right_self]
 
 end NonInteraction

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -31,10 +31,10 @@ restriction on the Elgot–Mezei factorization, not a consequence of it.
 
 * `Bimachine L R α β`: machine with left states `L`, right states `R`, alphabets `α`, `β`
 * `Bimachine.run`: the computed function
-* `IsBimachineComputable f`: `f` is computed by some finite bimachine
 * `Bimachine.NonInteraction`, `Bimachine.IsNonInteracting`: a decomposition of the
   cell output as an order-independent union of one-sided change-rules over the
   identity, and its existence
+* `IsBimachineComputable f`: `f` is computed by some finite bimachine
 * `IsNonInteractingBimachineComputable f`: `f` is computed by some non-interacting
   finite bimachine
 
@@ -223,6 +223,114 @@ theorem getElem?_ofFlags_run (x : List α) (i : ℕ) :
       = x[i]?.map fun a => out ((x.take i).any pL) a ((x.drop (i + 1)).any pR) := by
   simp [getElem?_run]
 
+/-! ### Non-interacting decompositions -/
+
+/-- The output at a cell is determined by one side alone: fixing the input symbol and
+one context state already fixes it. -/
+def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
+  (∀ r', B.output l a r' = B.output l a r) ∨ (∀ l', B.output l' a r = B.output l a r)
+
+section
+
+variable [DecidableEq α]
+
+/-- `unite cL cR a` takes the left proposal if it fires (`≠ a`), else the right one —
+the union of two change proposals over the identity default `a`. The tie-break is
+asymmetric (when both fire the left wins) but inert under the order-independence
+`IsNonInteracting` requires. -/
+def unite (cL cR a : α) : α := if cL = a then cR else cL
+
+/-- With the right proposal inert, the union is whatever the left one proposes. -/
+@[simp] theorem unite_right_self (cL a : α) : unite cL a a = cL := by
+  grind [unite]
+
+/-- With the left proposal inert, the union is whatever the right one proposes. -/
+@[simp] theorem unite_left_self (cR a : α) : unite a cR a = cR := if_pos rfl
+
+/-- A firing left proposal wins. -/
+theorem unite_of_left_ne {cL a : α} (h : cL ≠ a) (cR : α) : unite cL cR a = cL := if_neg h
+
+/-- The union is order-independent exactly when the proposals agree wherever both
+fire. -/
+theorem unite_comm_iff {cL cR a : α} :
+    unite cL cR a = unite cR cL a ↔ (cL ≠ a → cR ≠ a → cL = cR) := by
+  grind [unite]
+
+/-- The combined value is the default exactly when *both* one-sided proposals are
+inert. -/
+@[simp] theorem unite_eq_self_iff {cL cR a : α} : unite cL cR a = a ↔ cL = a ∧ cR = a := by
+  grind [unite]
+
+/-- A non-interacting decomposition of a bimachine: a change-rule per side over the
+identity default, whose union is order-independent and produces the cell output. -/
+structure NonInteraction (B : Bimachine L R α α) where
+  /-- The change the left context proposes for the current symbol. -/
+  ruleL : L → α → α
+  /-- The change the right context proposes for the current symbol. -/
+  ruleR : R → α → α
+  /-- The union of the two proposals is order-independent (`unite_comm_iff`: they agree
+  wherever both fire), so neither side can suppress the other's change. -/
+  unite_comm : ∀ l a r, unite (ruleL l a) (ruleR r a) a = unite (ruleR r a) (ruleL l a) a
+  /-- The cell output is the union of the two proposals. -/
+  output_eq : ∀ l a r, B.output l a r = unite (ruleL l a) (ruleR r a) a
+
+/-- A bimachine over a single alphabet is non-interacting when it admits a
+non-interacting decomposition (`NonInteraction`) of its cell output. -/
+def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
+
+variable {B : Bimachine L R α α}
+
+/-- A firing left rule alone determines the output. -/
+theorem NonInteraction.output_eq_ruleL (w : B.NonInteraction) {l : L} {a : α} {r : R}
+    (hL : w.ruleL l a ≠ a) : B.output l a r = w.ruleL l a :=
+  (w.output_eq l a r).trans (unite_of_left_ne hL _)
+
+/-- A firing right rule alone determines the output — order-independence of the union
+is what silences the left state. -/
+theorem NonInteraction.output_eq_ruleR (w : B.NonInteraction) {l : L} {a : α} {r : R}
+    (hR : w.ruleR r a ≠ a) : B.output l a r = w.ruleR r a :=
+  (w.output_eq l a r).trans ((w.unite_comm l a r).trans (unite_of_left_ne hR _))
+
+/-- At every cell whose output differs from the input symbol, a decomposed bimachine is
+one-sided: the change is the left rule's alone or the right rule's alone. -/
+theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : α}
+    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
+  by_cases hL : w.ruleL l a = a
+  · have hR : w.ruleR r a ≠ a := fun hR =>
+      hne ((w.output_eq l a r).trans (unite_eq_self_iff.mpr ⟨hL, hR⟩))
+    exact .inr fun l' => (w.output_eq_ruleR hR).trans (w.output_eq_ruleR hR).symm
+  · exact .inl fun r' => (w.output_eq_ruleL hL).trans (w.output_eq_ruleL hL).symm
+
+/-- At every cell whose output differs from the input symbol, a non-interacting
+bimachine is one-sided. -/
+theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting) {l : L} {a : α}
+    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r :=
+  h.elim fun w => w.oneSidedAt_of_change hne
+
+/-- Transports a decomposition along state reindexing: the rules compose with
+`eL.symm` and `eR.symm`. -/
+def NonInteraction.reindex {L' R' : Type*} (w : B.NonInteraction) (eL : L ≃ L')
+    (eR : R ≃ R') : (Bimachine.reindex eL eR B).NonInteraction where
+  ruleL l a := w.ruleL (eL.symm l) a
+  ruleR r a := w.ruleR (eR.symm r) a
+  unite_comm _ a _ := w.unite_comm _ a _
+  output_eq _ a _ := w.output_eq _ a _
+
+/-- Non-interaction transports along state reindexing. -/
+theorem IsNonInteracting.reindex {L' R' : Type*} (h : B.IsNonInteracting) (eL : L ≃ L')
+    (eR : R ≃ R') : (Bimachine.reindex eL eR B).IsNonInteracting :=
+  h.map (·.reindex eL eR)
+
+/-- A word whose run leaves target `i` unchanged has both of its change-proposals inert
+there. -/
+theorem NonInteraction.inert_of_reverting (w : B.NonInteraction) {u : List α} {i : ℕ}
+    {a : α} (hsym : u[i]? = some a) (hrev : (B.run u)[i]? = u[i]?) :
+    w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
+  refine unite_eq_self_iff.mp (Option.some_injective _ (Eq.symm ?_))
+  rw [← hsym, ← hrev, B.getElem?_run, hsym, Option.map_some, w.output_eq]
+
+end
+
 end Bimachine
 
 /-! ### Sequential machines as bimachines -/
@@ -287,128 +395,17 @@ theorem IsBimachineComputable.of_mealyComputable {f : List α → List β}
   have ⟨_, _, T, hT⟩ := h
   hT ▸ T.toBimachine_run ▸ T.toBimachine.isBimachineComputable
 
-/-! ### Non-interacting bimachines -/
 
-section NonInteraction
+/-! ### The non-interacting class -/
+
+section
 
 variable [DecidableEq α]
-
-namespace Bimachine
-
-/-- `unite cL cR a` takes the left proposal if it fires (`≠ a`), else the right one —
-the union of two change proposals over the identity default `a`. The tie-break is
-asymmetric (when both fire the left wins) but inert under the order-independence
-`IsNonInteracting` requires. -/
-def unite (cL cR a : α) : α := if cL = a then cR else cL
-
-/-- With the right proposal inert, the union is whatever the left one proposes. -/
-@[simp] theorem unite_right_self (cL a : α) : unite cL a a = cL := by
-  grind [unite]
-
-/-- With the left proposal inert, the union is whatever the right one proposes. -/
-@[simp] theorem unite_left_self (cR a : α) : unite a cR a = cR := if_pos rfl
-
-/-- A firing left proposal wins. -/
-theorem unite_of_left_ne {cL a : α} (h : cL ≠ a) (cR : α) : unite cL cR a = cL := if_neg h
-
-/-- The union is order-independent exactly when the proposals agree wherever both
-fire. -/
-theorem unite_comm_iff {cL cR a : α} :
-    unite cL cR a = unite cR cL a ↔ (cL ≠ a → cR ≠ a → cL = cR) := by
-  grind [unite]
-
-/-- The combined value is the default exactly when *both* one-sided proposals are
-inert. -/
-@[simp] theorem unite_eq_self_iff {cL cR a : α} : unite cL cR a = a ↔ cL = a ∧ cR = a := by
-  grind [unite]
-
-/-- A non-interacting decomposition of a bimachine: a change-rule per side over the
-identity default, whose union is order-independent and produces the cell output. -/
-structure NonInteraction (B : Bimachine L R α α) where
-  /-- The change the left context proposes for the current symbol. -/
-  ruleL : L → α → α
-  /-- The change the right context proposes for the current symbol. -/
-  ruleR : R → α → α
-  /-- The union of the two proposals is order-independent (`unite_comm_iff`: they agree
-  wherever both fire), so neither side can suppress the other's change. -/
-  unite_comm : ∀ l a r, unite (ruleL l a) (ruleR r a) a = unite (ruleR r a) (ruleL l a) a
-  /-- The cell output is the union of the two proposals. -/
-  output_eq : ∀ l a r, B.output l a r = unite (ruleL l a) (ruleR r a) a
-
-/-- A bimachine over a single alphabet is non-interacting when it admits a
-non-interacting decomposition (`NonInteraction`) of its cell output. -/
-def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
-
-/-- The output at a cell is determined by one side alone: fixing the input symbol and
-one context state already fixes it. -/
-def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
-  (∀ r', B.output l a r' = B.output l a r) ∨ (∀ l', B.output l' a r = B.output l a r)
-
-variable {B : Bimachine L R α α}
-
-/-- A firing left rule alone determines the output. -/
-theorem NonInteraction.output_eq_ruleL (w : B.NonInteraction) {l : L} {a : α} {r : R}
-    (hL : w.ruleL l a ≠ a) : B.output l a r = w.ruleL l a :=
-  (w.output_eq l a r).trans (unite_of_left_ne hL _)
-
-/-- A firing right rule alone determines the output — order-independence of the union
-is what silences the left state. -/
-theorem NonInteraction.output_eq_ruleR (w : B.NonInteraction) {l : L} {a : α} {r : R}
-    (hR : w.ruleR r a ≠ a) : B.output l a r = w.ruleR r a :=
-  (w.output_eq l a r).trans ((w.unite_comm l a r).trans (unite_of_left_ne hR _))
-
-/-- At every cell whose output differs from the input symbol, a decomposed bimachine is
-one-sided: the change is the left rule's alone or the right rule's alone. -/
-theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : α}
-    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
-  by_cases hL : w.ruleL l a = a
-  · have hR : w.ruleR r a ≠ a := fun hR =>
-      hne ((w.output_eq l a r).trans (unite_eq_self_iff.mpr ⟨hL, hR⟩))
-    exact .inr fun l' => (w.output_eq_ruleR hR).trans (w.output_eq_ruleR hR).symm
-  · exact .inl fun r' => (w.output_eq_ruleL hL).trans (w.output_eq_ruleL hL).symm
-
-/-- At every cell whose output differs from the input symbol, a non-interacting
-bimachine is one-sided. -/
-theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting) {l : L} {a : α}
-    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r :=
-  h.elim fun w => w.oneSidedAt_of_change hne
-
-/-- Transports a decomposition along state reindexing: the rules compose with
-`eL.symm` and `eR.symm`. -/
-def NonInteraction.reindex {L' R' : Type*} (w : B.NonInteraction) (eL : L ≃ L')
-    (eR : R ≃ R') : (Bimachine.reindex eL eR B).NonInteraction where
-  ruleL l a := w.ruleL (eL.symm l) a
-  ruleR r a := w.ruleR (eR.symm r) a
-  unite_comm _ a _ := w.unite_comm _ a _
-  output_eq _ a _ := w.output_eq _ a _
-
-/-- Non-interaction transports along state reindexing. -/
-theorem IsNonInteracting.reindex {L' R' : Type*} (h : B.IsNonInteracting) (eL : L ≃ L')
-    (eR : R ≃ R') : (Bimachine.reindex eL eR B).IsNonInteracting :=
-  h.map (·.reindex eL eR)
-
-/-- A word whose run leaves target `i` unchanged has both of its change-proposals inert
-there. -/
-theorem NonInteraction.inert_of_reverting (w : B.NonInteraction) {u : List α} {i : ℕ}
-    {a : α} (hsym : u[i]? = some a) (hrev : (B.run u)[i]? = u[i]?) :
-    w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
-  refine unite_eq_self_iff.mp (Option.some_injective _ (Eq.symm ?_))
-  rw [← hsym, ← hrev, B.getElem?_run, hsym, Option.map_some, w.output_eq]
-
-end Bimachine
 
 /-- Computability by a non-interacting finite bimachine. -/
 def IsNonInteractingBimachineComputable (f : List α → List α) : Prop :=
   ∃ (L : Type) (_ : Fintype L) (R : Type) (_ : Fintype R) (B : Bimachine L R α α),
     B.run = f ∧ B.IsNonInteracting
-
-/-- A function computed by a non-interacting bimachine is in particular
-bimachine-computable. -/
-theorem IsBimachineComputable.of_nonInteracting {f : List α → List α}
-    (h : IsNonInteractingBimachineComputable f) : IsBimachineComputable f :=
-  have ⟨_, _, _, _, B, hB, _⟩ := h
-  hB ▸ B.isBimachineComputable
-
 /-- `f` is computed by a non-interacting finite bimachine if and only if it is computed
 by one with state types in any universes. -/
 theorem isNonInteractingBimachineComputable_iff.{v, w} {f : List α → List α} :
@@ -429,11 +426,17 @@ theorem Bimachine.isNonInteractingBimachineComputable {L R : Type*} [Fintype L]
     IsNonInteractingBimachineComputable B.run :=
   isNonInteractingBimachineComputable_iff.mpr ⟨L, inferInstance, R, inferInstance, B, rfl, h⟩
 
+/-- A function computed by a non-interacting bimachine is in particular
+bimachine-computable. -/
+theorem IsBimachineComputable.of_nonInteracting {f : List α → List α}
+    (h : IsNonInteractingBimachineComputable f) : IsBimachineComputable f :=
+  have ⟨_, _, _, _, B, hB, _⟩ := h
+  hB ▸ B.isBimachineComputable
+
 /-- Functions computed by non-interacting bimachines are length-preserving. -/
 theorem IsNonInteractingBimachineComputable.length_eq {f : List α → List α}
     (h : IsNonInteractingBimachineComputable f) (x : List α) : (f x).length = x.length :=
   (IsBimachineComputable.of_nonInteracting h).length_eq x
-
 /-- A Mealy-computable function is computed by a non-interacting bimachine: the
 bimachine view (`Mealy.toBimachine`) has a trivial right automaton, so the cell output
 is a one-sided rule with `ωR` the identity. -/
@@ -465,7 +468,7 @@ theorem RequiresBothSides.not_isNonInteractingBimachineComputable {f : List α �
     (w.inert_of_reverting (hLsym.trans (List.getElem?_eq_getElem hi)) hLrev).2,
     Bimachine.unite_right_self]
 
-end NonInteraction
+end
 
 /-! ### Strictness: non-interacting ⊊ bimachine-computable
 

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -278,23 +278,24 @@ structure NonInteraction (B : Bimachine L R α α) where
 non-interacting decomposition (`NonInteraction`) of its cell output. -/
 def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
 
-variable {B : Bimachine L R α α}
+variable {L' R' : Type*} {B : Bimachine L R α α} (w : B.NonInteraction) {l : L} {a : α}
+  {r : R}
 
 /-- A firing left rule alone determines the output. -/
-theorem NonInteraction.output_eq_ruleL (w : B.NonInteraction) {l : L} {a : α} {r : R}
-    (hL : w.ruleL l a ≠ a) : B.output l a r = w.ruleL l a :=
+theorem NonInteraction.output_eq_ruleL (hL : w.ruleL l a ≠ a) :
+    B.output l a r = w.ruleL l a :=
   (w.output_eq l a r).trans (unite_of_left_ne hL _)
 
 /-- A firing right rule alone determines the output — order-independence of the union
 is what silences the left state. -/
-theorem NonInteraction.output_eq_ruleR (w : B.NonInteraction) {l : L} {a : α} {r : R}
-    (hR : w.ruleR r a ≠ a) : B.output l a r = w.ruleR r a :=
+theorem NonInteraction.output_eq_ruleR (hR : w.ruleR r a ≠ a) :
+    B.output l a r = w.ruleR r a :=
   (w.output_eq l a r).trans ((w.unite_comm l a r).trans (unite_of_left_ne hR _))
 
 /-- At every cell whose output differs from the input symbol, a decomposed bimachine is
 one-sided: the change is the left rule's alone or the right rule's alone. -/
-theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : α}
-    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
+theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction)
+    (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
   by_cases hL : w.ruleL l a = a
   · have hR : w.ruleR r a ≠ a := fun hR =>
       hne ((w.output_eq l a r).trans (unite_eq_self_iff.mpr ⟨hL, hR⟩))
@@ -303,28 +304,28 @@ theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : 
 
 /-- At every cell whose output differs from the input symbol, a non-interacting
 bimachine is one-sided. -/
-theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting) {l : L} {a : α}
-    {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r :=
+theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting)
+    (hne : B.output l a r ≠ a) : B.OneSidedAt l a r :=
   h.elim fun w => w.oneSidedAt_of_change hne
 
 /-- Transports a decomposition along state reindexing: the rules compose with
 `eL.symm` and `eR.symm`. -/
-def NonInteraction.reindex {L' R' : Type*} (w : B.NonInteraction) (eL : L ≃ L')
-    (eR : R ≃ R') : (Bimachine.reindex eL eR B).NonInteraction where
+def NonInteraction.reindex (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.reindex eL eR B).NonInteraction where
   ruleL l a := w.ruleL (eL.symm l) a
   ruleR r a := w.ruleR (eR.symm r) a
   unite_comm _ a _ := w.unite_comm _ a _
   output_eq _ a _ := w.output_eq _ a _
 
 /-- Non-interaction transports along state reindexing. -/
-theorem IsNonInteracting.reindex {L' R' : Type*} (h : B.IsNonInteracting) (eL : L ≃ L')
-    (eR : R ≃ R') : (Bimachine.reindex eL eR B).IsNonInteracting :=
+theorem IsNonInteracting.reindex (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.reindex eL eR B).IsNonInteracting :=
   h.map (·.reindex eL eR)
 
 /-- A word whose run leaves target `i` unchanged has both of its change-proposals inert
 there. -/
-theorem NonInteraction.inert_of_reverting (w : B.NonInteraction) {u : List α} {i : ℕ}
-    {a : α} (hsym : u[i]? = some a) (hrev : (B.run u)[i]? = u[i]?) :
+theorem NonInteraction.inert_of_reverting {u : List α} {i : ℕ} (hsym : u[i]? = some a)
+    (hrev : (B.run u)[i]? = u[i]?) :
     w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
   refine unite_eq_self_iff.mp (Option.some_injective _ (Eq.symm ?_))
   rw [← hsym, ← hrev, B.getElem?_run, hsym, Option.map_some, w.output_eq]
@@ -498,24 +499,21 @@ private theorem conjBM_flankWord {x y : ConjSym} {n k : ℕ} (h0 : 0 < k) (hk : 
     any_drop_flankWord (by decide) (by omega) (by omega)]
   simp
 
-/-- The conjunctive change requires both sides: with a mark on each flank the medial
-symbol flips, and demoting either mark alone reverts it — the three-map template
-(`RequiresBothSides.of_flanks`) applied to a `d`-margined flank word. -/
-theorem conjBM.requiresBothSides : RequiresBothSides conjBM.run :=
-  .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
-    (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1) (t := fun d => d + 1)
-    (by decide) (fun d => ⟨by omega, by omega⟩)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-    (fun d => by rw [conjBM_flankWord (by omega) (by omega)]; rfl)
-
-/-- The non-interacting class is proper inside the bimachine-computable functions —
-`conjBM` is computed by a bimachine, but by no non-interacting one. -/
+/-- The non-interacting class is proper inside the bimachine-computable functions:
+`conjBM` is computed by a bimachine, but — with a mark on each flank the medial symbol
+flips, and demoting either mark alone reverts it — it requires both sides
+(`RequiresBothSides.of_flanks`), so no non-interacting bimachine computes it. -/
 theorem setOf_isNonInteractingBimachineComputable_ssubset :
     {f : List ConjSym → List ConjSym | IsNonInteractingBimachineComputable f} ⊂
       {f | IsBimachineComputable f} :=
+  have key : RequiresBothSides conjBM.run :=
+    .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
+      (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1)
+      (t := fun d => d + 1) (by decide) (fun d => ⟨by omega, by omega⟩)
+      (fun d => conjBM_flankWord (by omega) (by omega))
+      (fun d => conjBM_flankWord (by omega) (by omega))
+      (fun d => conjBM_flankWord (by omega) (by omega))
   ⟨fun _ h => IsBimachineComputable.of_nonInteracting h,
-   fun h => conjBM.requiresBothSides.not_isNonInteractingBimachineComputable
-     (h conjBM.isBimachineComputable)⟩
+   fun h => key.not_isNonInteractingBimachineComputable (h conjBM.isBimachineComputable)⟩
 
 end Subregular

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Data.Fintype.EquivFin
-import Mathlib.Tactic.DeriveFintype
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Data.Fintype.Transfer
 import Linglib.Core.Computability.Subregular.Function.Dependence
@@ -473,47 +472,36 @@ end
 
 /-! ### Strictness: non-interacting ⊊ bimachine-computable
 
-A *conjunctive* change — a symbol flipped iff a mark occurs on **both** sides — is
-bimachine-computable but `RequiresBothSides`, so no non-interacting bimachine computes
+A *conjunctive* change — a symbol raised iff a mark occurs on **both** sides — is
+bimachine-computable but requires both sides, so no non-interacting bimachine computes
 it. -/
 
-/-- The three-symbol alphabet for the conjunctive witness — a `mark`, a `neutral`
-symbol, and the `flipped` form the neutral symbol takes when both sides are marked. -/
-inductive ConjSym | mark | neutral | flipped
-  deriving DecidableEq, Repr, Fintype
+/-- The conjunctive flag bimachine: a `false` cell is raised exactly when a `true`
+occurs on both sides. -/
+def conjBM : Bimachine Bool Bool Bool Bool := .ofFlags id id fun l s r => s || (l && r)
 
-/-- A neutral symbol flips iff a `mark` occurs on **both** sides — a flag bimachine
-(`ofFlags`) tracking a mark on each side, whose cell genuinely needs both flags
-(`l && r`). -/
-def conjBM : Bimachine Bool Bool ConjSym ConjSym :=
-  .ofFlags (· == .mark) (· == .mark) fun l s r =>
-    if (l && r) && s == .neutral then .flipped else s
+/-- In the middle of a `d`-margined flank word, `conjBM` computes the conjunction of
+the two flanks. -/
+private theorem conjBM_run_mid (x y : Bool) (d : ℕ) :
+    (conjBM.run (flankWord x false y (2 * d + 1)))[d + 1]? = some (x && y) := by
+  rw [conjBM, Bimachine.getElem?_ofFlags_run, getElem?_flankWord_mid (by omega) (by omega),
+    any_take_flankWord rfl (by omega) (by omega), any_drop_flankWord rfl (by omega) (by omega)]
+  rfl
 
-/-- Inside the filler run of a flank word, `conjBM` flips the neutral symbol exactly when
-both flanks are marks. -/
-private theorem conjBM_flankWord {x y : ConjSym} {n k : ℕ} (h0 : 0 < k) (hk : k ≤ n) :
-    (conjBM.run (flankWord x .neutral y n))[k]?
-      = some (if x == .mark && y == .mark then .flipped else .neutral) := by
-  rw [conjBM, Bimachine.getElem?_ofFlags_run, getElem?_flankWord_mid h0 hk,
-    any_take_flankWord (by decide) h0 (by omega),
-    any_drop_flankWord (by decide) (by omega) (by omega)]
-  simp
+/-- The conjunctive change requires both sides: with a mark on each flank the medial
+cell is raised, and demoting either mark alone reverts it — the three-map template, one
+map per argument. -/
+theorem conjBM.requiresBothSides : RequiresBothSides conjBM.run :=
+  .of_flanks (by decide) (fun d => ⟨by omega, by omega⟩) (conjBM_run_mid true true)
+    (conjBM_run_mid false true) (conjBM_run_mid true false)
 
-/-- The non-interacting class is proper inside the bimachine-computable functions:
-`conjBM` is computed by a bimachine, but — with a mark on each flank the medial symbol
-flips, and demoting either mark alone reverts it — it requires both sides
-(`RequiresBothSides.of_flanks`), so no non-interacting bimachine computes it. -/
+/-- The non-interacting class is proper inside the bimachine-computable functions —
+`conjBM` is computed by a bimachine, but by no non-interacting one. -/
 theorem setOf_isNonInteractingBimachineComputable_ssubset :
-    {f : List ConjSym → List ConjSym | IsNonInteractingBimachineComputable f} ⊂
+    {f : List Bool → List Bool | IsNonInteractingBimachineComputable f} ⊂
       {f | IsBimachineComputable f} :=
-  have key : RequiresBothSides conjBM.run :=
-    .of_flanks (fill := .neutral) (on := .flipped) (xOn := .mark) (yOn := .mark)
-      (xOff := .neutral) (yOff := .neutral) (n := fun d => 2 * d + 1)
-      (t := fun d => d + 1) (by decide) (fun d => ⟨by omega, by omega⟩)
-      (fun d => conjBM_flankWord (by omega) (by omega))
-      (fun d => conjBM_flankWord (by omega) (by omega))
-      (fun d => conjBM_flankWord (by omega) (by omega))
   ⟨fun _ h => IsBimachineComputable.of_nonInteracting h,
-   fun h => key.not_isNonInteractingBimachineComputable (h conjBM.isBimachineComputable)⟩
+   fun h => conjBM.requiresBothSides.not_isNonInteractingBimachineComputable
+     (h conjBM.isBimachineComputable)⟩
 
 end Subregular

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -337,24 +337,24 @@ end Bimachine
 
 section ToBimachine
 
-variable {σ : Type*}
+variable {σ : Type*} (T : Mealy σ α β)
 
 /-- A sequential machine as the bimachine whose left automaton does all the work and
 whose right automaton is trivial. -/
 @[simps]
-def Mealy.toBimachine (T : Mealy σ α β) : Bimachine σ Unit α β where
+def Mealy.toBimachine : Bimachine σ Unit α β where
   lInit := T.initial
   lStep := T.step
   rInit := ()
   rStep _ _ := ()
   output l a _ := T.output l a
 
-@[simp] theorem Mealy.toBimachine_runFrom (T : Mealy σ α β) (s : σ) (xs : List α) :
+@[simp] theorem Mealy.toBimachine_runFrom (s : σ) (xs : List α) :
     T.toBimachine.runFrom s xs = T.runFrom s xs := by
   induction xs generalizing s <;> simp [*]
 
 /-- The bimachine view computes the same string function. -/
-@[simp] theorem Mealy.toBimachine_run (T : Mealy σ α β) : T.toBimachine.run = T.run :=
+@[simp] theorem Mealy.toBimachine_run : T.toBimachine.run = T.run :=
   funext fun xs => T.toBimachine_runFrom T.initial xs
 
 end ToBimachine

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -346,21 +346,26 @@ def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
 
 variable {B : Bimachine L R α α}
 
+/-- A firing left rule alone determines the output. -/
+theorem NonInteraction.output_eq_ruleL (w : B.NonInteraction) {l : L} {a : α} {r : R}
+    (hL : w.ruleL l a ≠ a) : B.output l a r = w.ruleL l a :=
+  (w.output_eq l a r).trans (unite_of_left_ne hL _)
+
+/-- A firing right rule alone determines the output — order-independence of the union
+is what silences the left state. -/
+theorem NonInteraction.output_eq_ruleR (w : B.NonInteraction) {l : L} {a : α} {r : R}
+    (hR : w.ruleR r a ≠ a) : B.output l a r = w.ruleR r a :=
+  (w.output_eq l a r).trans ((w.unite_comm l a r).trans (unite_of_left_ne hR _))
+
 /-- At every cell whose output differs from the input symbol, a decomposed bimachine is
-one-sided: the change is the left rule's alone or the right rule's alone.
-Order-independence of the union is what makes the firing side's value independent of
-the other side's state. -/
+one-sided: the change is the left rule's alone or the right rule's alone. -/
 theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction) {l : L} {a : α}
     {r : R} (hne : B.output l a r ≠ a) : B.OneSidedAt l a r := by
   by_cases hL : w.ruleL l a = a
   · have hR : w.ruleR r a ≠ a := fun hR =>
-      hne (by simp only [w.output_eq, hL, hR, unite_left_self])
-    refine .inr fun l' => ?_
-    by_cases hL' : w.ruleL l' a = a
-    · simp only [w.output_eq, hL, hL', unite_left_self]
-    · simp only [w.output_eq, hL, unite_left_self, unite_of_left_ne hL']
-      exact unite_comm_iff.mp (w.unite_comm l' a r) hL' hR
-  · exact .inl fun r' => by simp only [w.output_eq, unite_of_left_ne hL]
+      hne ((w.output_eq l a r).trans (unite_eq_self_iff.mpr ⟨hL, hR⟩))
+    exact .inr fun l' => (w.output_eq_ruleR hR).trans (w.output_eq_ruleR hR).symm
+  · exact .inl fun r' => (w.output_eq_ruleL hL).trans (w.output_eq_ruleL hL).symm
 
 /-- At every cell whose output differs from the input symbol, a non-interacting
 bimachine is one-sided. -/

--- a/Linglib/Core/Computability/Subregular/Function/Dependence.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Dependence.lean
@@ -239,6 +239,22 @@ theorem exists_ge_flankWord_eq_some_iff (hfill : fill ≠ a) (h0 : 0 < k)
   simp [getElem?_flankWord_eq_some_iff hfill, and_or_left, exists_or,
     eq_false (by omega : ¬ (k ≤ 0)), hk]
 
+/-- A window reaching at most the filler run contains `a` iff the left flank is `a`. -/
+theorem mem_take_flankWord_iff (hfill : fill ≠ a) (h0 : 0 < k) (hk : k ≤ n + 1) :
+    a ∈ (flankWord x fill y n).take k ↔ x = a := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  rw [flankWord, List.take_succ_cons, List.take_append_of_le_length (by simp; omega),
+    List.take_replicate]
+  simp [List.mem_replicate, eq_comm, hfill]
+
+/-- A window past the left flank contains `a` iff the right flank is `a`. -/
+theorem mem_drop_flankWord_iff (hfill : fill ≠ a) (h0 : 0 < k) (hk : k ≤ n + 1) :
+    a ∈ (flankWord x fill y n).drop k ↔ y = a := by
+  obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+  rw [flankWord, List.drop_succ_cons, List.drop_append_of_le_length (by simp; omega),
+    List.drop_replicate]
+  simp [List.mem_replicate, eq_comm, hfill]
+
 /-- A flag over a window reaching at most the filler run reads the left flank — the
 `ofFlags` counterpart of `exists_le_flankWord_eq_some_iff`. -/
 theorem any_take_flankWord (hfill : p fill = false) (h0 : 0 < k) (hk : k ≤ n + 1) :

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -554,7 +554,7 @@ example : utp.map [.H, .O, .O, .H] = [.H, .H, .H, .H] := by decide
 Whether the target surfaces is controlled by unboundedly distant flanks: instantiate
 the flank-witness template with `2d+2` toneless TBUs between the flanks. -/
 
-/-- UTP requires both sides ([heinz-lai-2013]): its trigger is the two-sided window
+/-- UTP requires both sides ([jardine-2016]): its trigger is the two-sided window
 conjunction, so deleting either flanking H reverts the plateau target. -/
 theorem utp.requiresBothSides : RequiresBothSides utp.map :=
   utp.requiresBothSides_of_surfaces_iff fun _ _ => utp.surfaces_iff

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -50,9 +50,6 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 * `utp_fullyRegular` — §7: UTP is regular but neither subsequential nor weakly
   deterministic.
 
-Contrast `Studies/MeinhardtEtAl2024`: Maasai ATR spreading is unbounded *semiambient*
-yet weakly deterministic; UTP's `RequiresBothSides` — circumambience proper — pushes it
-above that bound.
 -/
 
 namespace Jardine2016Tone

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -301,10 +301,11 @@ theorem pre_get_target (init : Seg) (d : ℕ) : (pre init d)[d + 1]? = some .vLo
   rw [List.getElem?_append_right (by simp)]
   simp
 
-/-- **Tutrugbu ATR harmony requires both sides** ([meinhardt-mai-bakovic-mccollum-2024]
-Def. 2): at the medial target the base spreads ([+ATR]), but flipping the initial height
-to the far left *or* the root ATR to the far right reverts it to its [−ATR] input — the
-suppression structure no union of one-sided rules can produce. -/
+/-- **Tutrugbu ATR harmony requires both sides** — the strong witness form of the
+paper's unbounded circumambience (its def. 13): at the medial target the base spreads
+([+ATR]), but flipping the initial height to the far left *or* the root ATR to the far
+right reverts it to its [−ATR] input — the suppression structure no union of one-sided
+rules can produce. -/
 theorem tutrugbu_requiresBothSides : RequiresBothSides tutrugbuATR := by
   intro d
   have hpl : (pre Seg.vLo d).length = 2 * d + 2 := by

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -322,9 +322,9 @@ def maasaiBM : Bimachine Bool Bool Seg Seg :=
 
 /-- `maasaiBM`'s cell output is a `unite` of one-sided raise-rules. -/
 theorem maasaiBM_isNonInteracting : maasaiBM.IsNonInteracting :=
-  ⟨fun l s => if l && s == .recL then .recH else s,
-   fun r s => if r && s == .recL then .recH else s,
-   by decide, by intro l s r; cases s <;> cases l <;> cases r <;> rfl⟩
+  ⟨⟨fun l s => if l && s == .recL then .recH else s,
+    fun r s => if r && s == .recL then .recH else s,
+    by decide, by intro l s r; cases s <;> cases l <;> cases r <;> rfl⟩⟩
 
 private theorem hasDom_split (xs : List Seg) (i : ℕ) (hi : i < xs.length) :
     hasDom xs = (hasDom (xs.take i) || hasDom (xs.drop (i + 1)) || (xs[i] == .dom)) := by

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -23,37 +23,42 @@ Eastern Nilotic ATR harmony per [meinhardt-mai-bakovic-mccollum-2024].
 tightening of the [heinz-lai-2013] Weakly Deterministic (WD) function
 class. Their thesis:
 
-* **Bidirectional** iterative ATR harmony in Maasai and Turkana (Eastern
-  Nilotic) is *attested* and **WD** — a composition of two subsequential
-  FSTs reading from opposite directions, where the two passes do not
-  interact in the technical sense the paper formalises (§4.2).
-* Hypothetical *unbounded-circumambient* "sour grapes" patterns
-  ([wilson-2003]; [wilson-2006]) are *unattested* and
-  **non-deterministic** — the inner and outer passes interact, placing
-  the function strictly above WD in the hierarchy (Fig. 1).
+* **Bidirectional** iterative ATR harmony in Maasai (Eastern Nilotic) is
+  *attested* and **WD** — unbounded *semiambient*: every target depends
+  on one side at a time (though the side may vary), so its two
+  contradirectional subsequential passes do not interact in the technical
+  sense the paper formalises (§4).
+* Turkana, identical to Maasai but for a set of exceptionally dominant
+  [-ATR] suffix vowels, is *attested* and **non-deterministic** —
+  unbounded *circumambient*: some targets depend on both sides at once,
+  so the passes must interact. "The Maasai pattern is weakly
+  deterministic, and the Turkana pattern is not" (end of §2.3): the
+  paper's ND case is attested, not merely the hypothetical sour grapes
+  ([wilson-2003]; [wilson-2006]) it also places above WD.
 * The original Heinz-Lai 2013 WD definition was too permissive,
   admitting some unattested patterns; Meinhardt et al. patch it by
   formalising the *interaction* condition explicitly (§4).
 
 ## Maasai dominant/recessive harmony (paper §3.1, p. 1203)
 
-The empirically critical fact (paper p. 1203, "(non-exceptional)
+The empirically critical fact (paper p. 1203): "(non-exceptional)
 dominant vowels are underlyingly specified for the spreading value of
-the harmonic feature, [+ATR]"): **dominance is a lexical property of
-the root**, independent of the surface ATR value of any individual
-segment. A dominant root *triggers* spreading regardless of its
-constituent vowels' phonetic ATR; a recessive root does not.
+the harmonic feature, [+ATR]" — dominance is an underlying featural
+specification on vowels, carried by roots and by suffixes alike (the
+paper shows both root- and suffix-controlled spreading), not a diacritic
+property of roots. A dominant vowel *triggers* spreading; recessive
+vowels harmonise.
 
 The bidirectional Maasai pattern (paper p. 1193, ex 1a):
 
-* (i) Full bidirectional spreading from a dominant root: /kɪ-√noŋ-ʊ/ →
-  [ki-√noŋ-u] '1pl-love-pres' — [+ATR] spreads from the (dominant)
+* (i) Full bidirectional spreading from a dominant root: /kɪ-√ñorr-ʊ/ →
+  [ki-√ñorr-u] '1pl-love-pres' — [+ATR] spreads from the (dominant)
   root in both directions, raising recessive prefix /ɪ/ to [i] and
   recessive suffix /ʊ/ to [u].
-* (ii) Leftward spread blocked by /a/: /ɪ-√as-ɪʃɔ-rɛ/ → [ɪ-√as-iʃo-re]
-  '2sg-do-intr-appl' — the spreading [+ATR] reaches the rightward
-  vowels but is blocked leftward by the opaque /a/, leaving the prefix
-  /ɪ/ unchanged.
+* (ii) Leftward spread blocked by /a/: /ɪ-√as-ɪʃɔ-re/ → [ɪ-√as-iʃo-re]
+  '2sg-do-intr-appl' — the dominant applied suffix `-re` triggers
+  leftward [+ATR] spread, raising /ɪʃɔ/ to [iʃo]; the opaque /a/ of the
+  root blocks it, leaving the prefix /ɪ/ unchanged.
 
 ## What this file does (audit-corrected)
 
@@ -84,12 +89,14 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
 ## What this file does NOT do
 
 * Does not encode the full Maasai/Turkana paradigms — only the minimal
-  pair sufficient to illustrate substrate use. Paper §§3–4 contains
-  far richer data including back-rounding harmony interactions and
-  exceptional roots.
-* Does not prove sour-grapes patterns are non-deterministic
-  (impossibility argument requires a sophisticated pumping-style
-  reasoning, deferred to a follow-up dedicated to negative results).
+  pair sufficient to illustrate substrate use. Paper §§3–4 add the
+  re-paired low vowel (raised /A/ surfaces as [o]), opaque /A/ blocking,
+  glides disrupting harmony, and Turkana's exceptionally dominant
+  [-ATR] suffix vowels.
+* Does not formalize Turkana — the paper's *attested* non-deterministic
+  half. Its exceptionally dominant [-ATR] suffixes make the pattern
+  unbounded circumambient, so the `RequiresBothSides` machinery applies
+  directly; this is the natural next arc.
 * Models the bidirectional map directly (`maasai`: raise a recessive iff
   a dominant occurs anywhere) rather than as an explicit two-pass
   composition `leftwardATR.runRight ∘ rightwardATR.run`, and omits the
@@ -125,10 +132,10 @@ p. 1203. Four symbols stand in for the relevant phonological contrasts:
 
 * `recL` — a recessive [-ATR] vowel (e.g., /ɪ/, /ʊ/). Surfaces as
   [-ATR] absent harmony; raises to [+ATR] under spread.
-* `recH` — a recessive [+ATR] vowel (e.g., /i/, /u/). Already [+ATR];
-  passes spread through.
-* `dom` — a dominant vowel. Triggers [+ATR] spread regardless of its
-  own surface quality (the paper's load-bearing distinction).
+* `recH` — a recessive vowel surfacing [+ATR] (e.g., /i/, /u/): the
+  raised form of `recL`, and transparent to further spread.
+* `dom` — a dominant vowel: underlyingly specified [+ATR], the trigger
+  of spreading (the paper's load-bearing distinction).
 * `a` — the opaque /a/. Blocks spread.
 
 Consonants are omitted as they are transparent to the harmony. -/
@@ -310,35 +317,14 @@ def maasai (xs : List Seg) : List Seg :=
 
 /-- The non-interacting bimachine: each side's state tracks a dominant seen on that side;
 a recessive raises if *either* side has one — a union of one-sided rules. -/
-def maasaiBM : Bimachine Bool Bool Seg Seg where
-  lInit := false
-  lStep l s := l || (s == .dom)
-  rInit := false
-  rStep r s := r || (s == .dom)
-  output l s r := if (l || r) && s == .recL then .recH else s
+def maasaiBM : Bimachine Bool Bool Seg Seg :=
+  .ofFlags (· == .dom) (· == .dom) fun l s r => if (l || r) && s == .recL then .recH else s
 
 /-- `maasaiBM`'s cell output is a `unite` of one-sided raise-rules. -/
 theorem maasaiBM_isNonInteracting : maasaiBM.IsNonInteracting :=
   ⟨fun l s => if l && s == .recL then .recH else s,
    fun r s => if r && s == .recL then .recH else s,
    by decide, by intro l s r; cases s <;> cases l <;> cases r <;> rfl⟩
-
-/-- The left state after a prefix is exactly "a dominant occurs in it". -/
-theorem maasaiBM_lState (xs : List Seg) : maasaiBM.lState xs = xs.any (· == .dom) := by
-  show xs.foldl (fun l s => l || (s == .dom)) false = xs.any (· == .dom)
-  have : ∀ (acc : Bool) (ys : List Seg), ys.foldl (fun l s => l || (s == .dom)) acc
-      = (acc || ys.any (· == .dom)) := by
-    intro acc ys; induction ys generalizing acc with
-    | nil => simp
-    | cons y ys ih => simp [ih, Bool.or_assoc]
-  simpa using this false xs
-
-/-- The right state after a suffix is exactly "a dominant occurs in it". -/
-theorem maasaiBM_rState (xs : List Seg) : maasaiBM.rState xs = xs.any (· == .dom) := by
-  show xs.foldr (fun s r => r || (s == .dom)) false = xs.any (· == .dom)
-  induction xs with
-  | nil => rfl
-  | cons y ys ih => simp [ih, Bool.or_comm]
 
 private theorem hasDom_split (xs : List Seg) (i : ℕ) (hi : i < xs.length) :
     hasDom xs = (hasDom (xs.take i) || hasDom (xs.drop (i + 1)) || (xs[i] == .dom)) := by
@@ -354,7 +340,9 @@ private theorem hasDom_split (xs : List Seg) (i : ℕ) (hi : i < xs.length) :
 private theorem maasaiBM_cell_eq (xs : List Seg) (i : ℕ) (hi : i < xs.length) :
     maasaiBM.output (maasaiBM.lState (xs.take i)) xs[i] (maasaiBM.rState (xs.drop (i + 1)))
     = if hasDom xs && xs[i] == .recL then .recH else xs[i] := by
-  rw [maasaiBM_lState, maasaiBM_rState, hasDom_split xs i hi]
+  simp only [maasaiBM, Bimachine.ofFlags_lState, Bimachine.ofFlags_rState,
+    Bimachine.ofFlags_output]
+  rw [hasDom_split xs i hi]
   show (if (((xs.take i).any (· == .dom) || (xs.drop (i + 1)).any (· == .dom)) && xs[i] == .recL)
       then .recH else xs[i]) =
     (if (((xs.take i).any (· == .dom) || (xs.drop (i + 1)).any (· == .dom) || (xs[i] == .dom))
@@ -417,12 +405,13 @@ theorem maasai_not_requiresBothSides : ¬ RequiresBothSides maasai := fun h =>
   h.not_isNonInteractingBimachineComputable maasai_weaklyDeterministic
 
 /-- Strictness witness `synchronous ⊊ WD`: Maasai is weakly deterministic yet not
-Mealy-computable. A Mealy-computable map is right-myopic
+Mealy-computable — the length-preserving-stratum reading of [heinz-lai-2013]'s
+`LSF, RSF ⊆ WD` corollary being strict, with `maasai` as their own dominant-recessive
+witness (their Thms. 6 and 7). A Mealy-computable map is right-myopic
 (`IsMealyComputable.boundedDependence_right`), but Maasai's bidirectional spread is not
-(`maasai_twoSidedUnboundedDependence`). The stronger `¬ IsLeftSubsequential maasai` (the
-*block* class) is not yet formalized: a block transducer can delay output, so it
-needs the bounded-delay route (`IsLeftSubsequential.bounded_delay`) rather than the
-myopia shortcut — see the TODO in `Function/Bimachine.lean`. -/
+(`maasai_twoSidedUnboundedDependence`). TODO: the stronger `¬ IsLeftSubsequential
+maasai` (the *block* class) — a block transducer can delay output, so it needs the
+bounded-delay route (`IsLeftSubsequential.bounded_delay`), not the myopia shortcut. -/
 theorem maasai_not_mealyComputable : ¬ IsMealyComputable maasai := fun h =>
   maasai_twoSidedUnboundedDependence.not_boundedDependence .right h.boundedDependence_right
 

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -18,9 +18,9 @@ The engine is `not_isBmrsWeaklyDeterministic_of_requiresBothSides`: the paper's 
 template (Thms. 5.2–5.5), consuming the same `Subregular.RequiresBothSides` witness
 that excludes the *bimachine* rendering of weak determinism
 (`RequiresBothSides.not_isNonInteractingBimachineComputable`). Whether the two
-definitions coincide is the paper's own open question (§6.3, against
-[meinhardt-mai-bakovic-mccollum-2024]); feeding both exclusions one witness object
-states it structurally without resolving it. The proof here streamlines the paper's:
+definitions coincide is the paper's own open question (§6.1, on the μ-conserving
+proposal of [meinhardt-mai-bakovic-mccollum-2024]); feeding both exclusions one witness
+object states it structurally without resolving it. The proof here streamlines the paper's:
 on either perturbation the input value is unchanged, so ⊙ collapses to conjunction and
 *both* one-sided outputs are forced true; each transports to the base word by one-sided
 locality (`Eval.congr_agreeUpto`/`congr_agreeFrom`), and recombining forces the base
@@ -28,7 +28,9 @@ unchanged — no case-split through Prop. 4.2 needed. Only the `d = 0` instance 
 witness is used: one-sidedness is global, not window-bounded.
 
 Instances: Sour Grapes harmony (Thm. 5.2 — the first proof of the [heinz-lai-2013]
-conjecture, via [padgett-1995]/[wilson-2003]'s pathology), and — through the shared
+conjecture under the paper's Def. 5.1; under the original definition the conjecture is
+false, [lamont-ohara-smith-2019] Thm. 3.1 — via [padgett-1995]/[wilson-2003]'s
+pathology), and — through the shared
 witnesses already in the library — Tutrugbu ATR harmony (Prop. 5.5,
 [mccollum-bakovic-mai-meinhardt-2020]), Luganda unbounded tonal plateauing
 ([jardine-2016]), and Copperbelt Bemba high-tone spreading (Prop. 5.4), the latter
@@ -133,49 +135,20 @@ def sourGrapes (w : List SG) : List SG :=
   w.mapIdx fun i σ =>
     if σ = .minus ∧ .plus ∈ w.take i ∧ .blk ∉ w.drop i then .plus else σ
 
-/-- The witness family: a mutable middle flanked by `d`-margins, with an editable head
-(trigger site) and tail (blocker site). -/
-private def sg (u v : SG) (d : ℕ) : List SG :=
-  u :: (List.replicate (2 * d + 1) .minus ++ [v])
-
-private theorem sg_length {u v : SG} {d : ℕ} : (sg u v d).length = 2 * d + 3 := by
-  simp [sg]
-
-private theorem sg_getElem? {u v : SG} {d k : ℕ} :
-    (sg u v d)[k]? = if k = 0 then some u else if k = 2 * d + 2 then some v
-      else if k < 2 * d + 2 then some .minus else none := by
-  rcases k with _ | k
-  · rfl
-  · simp only [sg, List.getElem?_cons_succ, List.getElem?_append, List.getElem?_replicate,
-      List.length_replicate, List.getElem?_cons, List.getElem?_nil]
-    split_ifs <;> first | rfl | omega | (exfalso; omega)
-
-/-- The head is the only trigger site: `+` precedes the middle iff the head is `+`. -/
-private theorem sg_plus_mem_take {u v : SG} {d : ℕ} :
-    .plus ∈ (sg u v d).take (d + 1) ↔ u = .plus := by
-  rw [sg, List.take_succ_cons, List.take_append_of_le_length (by simp; omega),
-    List.take_replicate]
-  simp [eq_comm, List.mem_replicate]
-
-/-- The tail is the only blocker site: `⊟` follows the middle iff the tail is `⊟`. -/
-private theorem sg_blk_mem_drop {u v : SG} {d : ℕ} :
-    .blk ∈ (sg u v d).drop (d + 1) ↔ v = .blk := by
-  rw [sg, List.drop_succ_cons, List.drop_append_of_le_length (by simp; omega),
-    List.drop_replicate]
-  simp [eq_comm, List.mem_replicate]
-
-/-- The middle of the witness: spreads iff the head triggers and the tail is clear. -/
-private theorem sourGrapes_sg_mid {u v : SG} {d : ℕ} :
-    (sourGrapes (sg u v d))[d + 1]? =
+/-- The middle of the flank witness spreads iff the head triggers and the tail is
+clear. -/
+private theorem sourGrapes_flankWord_mid {u v : SG} {d : ℕ} :
+    (sourGrapes (flankWord u .minus v (2 * d + 1)))[d + 1]? =
       some (if u = .plus ∧ v ≠ .blk then .plus else .minus) := by
-  have hmid : (sg u v d)[d + 1]? = some .minus := by
-    rw [sg_getElem?]
-    split_ifs <;> first | rfl | omega | (exfalso; omega)
-  rw [sourGrapes, List.getElem?_mapIdx, hmid, Option.map_some]
+  rw [sourGrapes, List.getElem?_mapIdx, getElem?_flankWord_mid (by omega) (by omega),
+    Option.map_some]
   by_cases h : u = .plus ∧ v ≠ .blk
-  · rw [if_pos h, if_pos ⟨rfl, sg_plus_mem_take.mpr h.1, fun hb => h.2 (sg_blk_mem_drop.mp hb)⟩]
+  · rw [if_pos h, if_pos ⟨rfl,
+      (mem_take_flankWord_iff (by decide) (by omega) (by omega)).mpr h.1,
+      fun hb => h.2 ((mem_drop_flankWord_iff (by decide) (by omega) (by omega)).mp hb)⟩]
   · rw [if_neg h, if_neg fun ⟨_, ht, hd⟩ =>
-      h ⟨sg_plus_mem_take.mp ht, fun hv => hd (sg_blk_mem_drop.mpr hv)⟩]
+      h ⟨(mem_take_flankWord_iff (by decide) (by omega) (by omega)).mp ht,
+        fun hv => hd ((mem_drop_flankWord_iff (by decide) (by omega) (by omega)).mpr hv)⟩]
 
 /-- Sour Grapes requires both sides: the middle of `+ −…− −` spreads, but neither the
 triggerless `− −…− −` (far-left perturbation) nor the blocked `+ −…− ⊟` (far-right)
@@ -184,27 +157,20 @@ theorem sourGrapes_requiresBothSides : RequiresBothSides sourGrapes :=
   RequiresBothSides.of_flanks (fill := SG.minus) (on := SG.plus) (xOn := SG.plus)
     (yOn := SG.minus) (xOff := SG.minus) (yOff := SG.blk) (n := fun d => 2 * d + 1)
     (t := fun d => d + 1) (by decide) (fun d => ⟨by omega, by omega⟩)
-    (fun d => by
-      rw [show flankWord SG.plus SG.minus SG.minus (2 * d + 1) = sg .plus .minus d from
-        rfl, sourGrapes_sg_mid]
-      simp)
-    (fun d => by
-      rw [show flankWord SG.minus SG.minus SG.minus (2 * d + 1) = sg .minus .minus d from
-        rfl, sourGrapes_sg_mid]
-      simp)
-    (fun d => by
-      rw [show flankWord SG.plus SG.minus SG.blk (2 * d + 1) = sg .plus .blk d from
-        rfl, sourGrapes_sg_mid]
-      simp)
+    (fun d => by rw [sourGrapes_flankWord_mid]; simp)
+    (fun d => by rw [sourGrapes_flankWord_mid]; simp)
+    (fun d => by rw [sourGrapes_flankWord_mid]; simp)
 
-/-- **Thm. 5.2** — the first proof of the [heinz-lai-2013] conjecture. -/
+/-- **Thm. 5.2** — the first proof of the [heinz-lai-2013] conjecture, under the
+paper's Def. 5.1 (under the original definition it is false,
+[lamont-ohara-smith-2019] Thm. 3.1). -/
 theorem sourGrapes_not_bmrsWeaklyDeterministic :
     ¬ IsBmrsWeaklyDeterministic sourGrapes :=
   not_isBmrsWeaklyDeterministic_of_requiresBothSides sourGrapes_requiresBothSides
 
 /-- The same witness excludes the *bimachine* rendering of weak determinism — the two
 exclusions consume one object, which is the sharpest formal statement available of the
-paper's §6.3 open question (are the two definitions equivalent?). -/
+paper's §6.1 open question (are the two definitions equivalent?). -/
 theorem sourGrapes_not_bimachineWeaklyDeterministic :
     ¬ IsNonInteractingBimachineComputable sourGrapes :=
   sourGrapes_requiresBothSides.not_isNonInteractingBimachineComputable
@@ -260,69 +226,48 @@ def bemba : Tone.Surfacing BTone where
   surfaces_of_hi h := ⟨(List.getElem?_eq_some_iff.mp h).1, .inl h⟩
   decSurfaces _ _ := inferInstance
 
-/-- The witness family: flanks `x`, `y` around a toneless fill wide enough that the
-bounded two-TBU spread never reaches the middle. -/
-private def bw (x y : BTone) (d : ℕ) : List BTone :=
-  x :: (List.replicate (2 * d + 4) .L ++ [y])
-
-private theorem bw_length {x y : BTone} {d : ℕ} : (bw x y d).length = 2 * d + 6 := by
-  simp [bw]
-
-private theorem bw_getElem? {x y : BTone} {d k : ℕ} :
-    (bw x y d)[k]? = if k = 0 then some x else if k = 2 * d + 5 then some y
-      else if k < 2 * d + 5 then some .L else none := by
-  rcases k with _ | k
-  · rfl
-  · simp only [bw, List.getElem?_cons_succ, List.getElem?_append, List.getElem?_replicate,
-      List.length_replicate, List.getElem?_cons, List.getElem?_nil]
-    split_ifs <;> first | rfl | exact ‹False›.elim | omega
-
-/-- In the lone-trigger word, the middle surfaces: the initial H is the last H, so the
-unbounded spread reaches it. -/
-private theorem bembaSurfaces_bw_HL {d : ℕ} : bembaSurfaces (bw .H .L d) (d + 3) := by
-  refine ⟨by rw [bw_length]; omega, .inr (.inr ⟨0, by omega, ?_, fun k hk hkH => ?_⟩)⟩
-  · rw [bw_getElem?]
-    split_ifs <;> first | rfl | omega
-  · rw [bw_length] at hk
-    rw [bw_getElem?] at hkH
-    split_ifs at hkH <;> first | omega | exact BTone.noConfusion (Option.some.inj hkH)
+/-- In the lone-trigger flank word, the middle surfaces: the initial H is the last H,
+so the unbounded spread reaches it. -/
+private theorem bembaSurfaces_flankWord_HL {d : ℕ} :
+    bembaSurfaces (flankWord .H .L .L (2 * d + 4)) (d + 3) := by
+  refine ⟨by rw [length_flankWord]; omega,
+    .inr (.inr ⟨0, by omega, getElem?_flankWord_zero, fun k hk hkH => ?_⟩)⟩
+  rw [length_flankWord] at hk
+  rw [getElem?_flankWord] at hkH
+  split_ifs at hkH <;> first | omega | exact BTone.noConfusion (Option.some.inj hkH)
 
 /-- With a second H at the end, the middle does not surface: the bounded spread stops
 two TBUs in, and the unbounded spread now belongs to the final H. -/
-private theorem not_bembaSurfaces_bw_HH {d : ℕ} : ¬ bembaSurfaces (bw .H .H d) (d + 3) := by
+private theorem not_bembaSurfaces_flankWord_HH {d : ℕ} :
+    ¬ bembaSurfaces (flankWord .H .L .H (2 * d + 4)) (d + 3) := by
   rintro ⟨-, h | ⟨j, hj, hjH, hspread⟩ | ⟨j, hj, hjH, hlast⟩⟩
-  · rw [bw_getElem?] at h
+  · rw [getElem?_flankWord] at h
     split_ifs at h <;> first | omega | exact BTone.noConfusion (Option.some.inj h)
-  · rw [bw_getElem?] at hjH
+  · rw [getElem?_flankWord] at hjH
     split_ifs at hjH <;> first | omega | exact BTone.noConfusion (Option.some.inj hjH)
   · have hj0 : j = 0 := by
-      rw [bw_getElem?] at hjH
+      rw [getElem?_flankWord] at hjH
       split_ifs at hjH <;> first | omega | exact BTone.noConfusion (Option.some.inj hjH)
-    have := hlast (2 * d + 5) (by rw [bw_length]; omega) (by
-      rw [bw_getElem?]
-      split_ifs <;> first | rfl | omega)
+    have := hlast (2 * d + 5) (by rw [length_flankWord]; omega) getElem?_flankWord_last
     omega
 
 /-- With no trigger at all, the middle does not surface. -/
-private theorem not_bembaSurfaces_bw_LL {d : ℕ} : ¬ bembaSurfaces (bw .L .L d) (d + 3) := by
-  have hnoH : ∀ k, (bw .L .L d)[k]? ≠ some BTone.H := fun k => by
-    rw [bw_getElem?]
+private theorem not_bembaSurfaces_flankWord_LL {d : ℕ} :
+    ¬ bembaSurfaces (flankWord .L .L .L (2 * d + 4)) (d + 3) := by
+  have hnoH : ∀ k, (flankWord BTone.L .L .L (2 * d + 4))[k]? ≠ some BTone.H := fun k => by
+    rw [getElem?_flankWord]
     split_ifs <;> first | exact fun h => BTone.noConfusion (Option.some.inj h) | simp
   rintro ⟨-, h | ⟨j, -, hjH, -⟩ | ⟨j, -, hjH, -⟩⟩
   exacts [hnoH _ h, hnoH _ hjH, hnoH _ hjH]
 
 /-- Bemba spreading requires both sides: the middle of `H L…L L` spreads (unbounded, no
 blocker), but neither the triggerless far-left flip nor the far-right H (which bounds
-the spread to two TBUs) changes it. -/
+the spread to two TBUs) changes it — `Tone.Surfacing`'s flank template, from the three
+surfacing facts alone. -/
 theorem bemba_requiresBothSides : RequiresBothSides bemba.map :=
-  RequiresBothSides.of_flanks (fill := BTone.L) (on := BTone.H) (xOn := BTone.H)
-    (yOn := BTone.L) (xOff := BTone.L) (yOff := BTone.H) (n := fun d => 2 * d + 4)
-    (t := fun d => d + 3) (by decide) (fun d => ⟨by omega, by omega⟩)
-    (fun d => bemba.map_getElem?_hi_iff.mpr bembaSurfaces_bw_HL)
-    (fun d => bemba.map_getElem?_lo_iff.mpr
-      ⟨by rw [length_flankWord]; omega, not_bembaSurfaces_bw_LL⟩)
-    (fun d => bemba.map_getElem?_lo_iff.mpr
-      ⟨by rw [length_flankWord]; omega, not_bembaSurfaces_bw_HH⟩)
+  bemba.requiresBothSides_of_flanks (n := fun d => 2 * d + 4) (t := fun d => d + 3)
+    (fun d => ⟨by omega, by omega⟩) (fun d => bembaSurfaces_flankWord_HL)
+    (fun d => not_bembaSurfaces_flankWord_LL) (fun d => not_bembaSurfaces_flankWord_HH)
 
 /-- **Prop. 5.4**: Bemba high-tone spreading is not weakly deterministic. -/
 theorem bemba_not_bmrsWeaklyDeterministic : ¬ IsBmrsWeaklyDeterministic bemba.map :=

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -27935,6 +27935,20 @@
 % REF: Lamont (2022). Directional Constraint Evaluation Solves the Problem
 % of Ties in Harmonic Serialism. Linguistic Inquiry 53(3):617-632.
 % DOI deliberately omitted pending verification.
+@inproceedings{lamont-ohara-smith-2019,
+  author    = {Lamont, Andrew and O'Hara, Charlie and Smith, Caitlin},
+  year      = {2019},
+  title     = {Weakly deterministic transformations are subregular},
+  booktitle = {Proceedings of the 16th Workshop on Computational Research in Phonetics, Phonology, and Morphology},
+  pages     = {196--205},
+  doi       = {10.18653/v1/W19-4223},
+  url       = {https://aclanthology.org/W19-4223/},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Yolyan2025.lean}
+}
+
 @article{lamont-2022a,
   author    = {Lamont, Andrew},
   year      = {2022},


### PR DESCRIPTION
Study-file half of the Bimachine.lean audit (#1647), plus one Core commit stranded by its merge.

- `MeinhardtEtAl2024`: restores the paper's actual classification — Turkana is the *attested non-deterministic* case ("the Maasai pattern is weakly deterministic, and the Turkana pattern is not"), the study asserted the inverse; fixes misquoted data (√ñorr, `-re` trigger) and the dominance gloss; `maasaiBM` via `ofFlags` instead of hand-rolled folds.
- `Yolyan2025`: local `sg`/`bw` witness families dissolved into the Core `flankWord` template (new `mem_take/mem_drop_flankWord_iff`); Bemba routed through `Surfacing.requiresBothSides_of_flanks`; Meinhardt comparison is §6.1 not §6.3; Lamont–O'Hara–Smith 2019 qualifier on the Heinz–Lai conjecture (bib entry ACL-verified).
- `McCollumEtAl2020` cites its own def. 13 for circumambience (fixes a 2020→2024 chronology violation); `Plateauing` UTP cite → Jardine 2016; `Jardine2016Tone` forward-contrast removed.
- `Bimachine.NonInteraction` bundled as a structure (`IsNonInteracting := Nonempty …`), with `reindex` as a construction and `inert_of_reverting` as a lemma about the witness.