### PR TITLE
feat(Core/Computability): OneSidedChanges; wave-2 collapses; Dependence flat

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -77,7 +77,7 @@ import Linglib.Core.Computability.NonContextFree.BlockWitness
 import Linglib.Core.Computability.NonRegular.AnBn
 import Linglib.Core.Computability.StarFree
 import Linglib.Core.Computability.Direction
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
 import Linglib.Core.Computability.Subsequential

--- a/Linglib/Core/Computability/Dependence.lean
+++ b/Linglib/Core/Computability/Dependence.lean
@@ -27,6 +27,8 @@ independently editable flanks.
   flipped by far perturbations on either side
 * `RequiresBothSides f`: the target is changed, and either far perturbation alone
   reverts it
+* `OneSidedChanges f`: every changed cell is determined by one side of its input
+  alone
 * `flankWord x fill y n`: a target buried in a filler run with editable flanks
 
 ## Main theorems
@@ -34,6 +36,8 @@ independently editable flanks.
 * `unboundedDependence_iff`: every margin fails at some output coordinate
 * `RequiresBothSides.of_flanks`: the three-map witness template — a map is excluded
   by three target-cell observations
+* `IsNonInteractingBimachineComputable.oneSidedChanges`: a non-interacting bimachine
+  changes each cell from one side
 * `IsLeftSubsequential.boundedDependence_right`: a length-preserving left-subsequential
   function depends boundedly on the right
 * `Mealy.leftDetermined`, `Mealy.boundedDependence_right`: a sequential machine is
@@ -53,6 +57,9 @@ witnesses. The forms are margin-indexed rather than fixed-index because a fixed
 target has only finitely many positions to its left.
 The predicates place no in-range guard on target coordinates: for length-preserving
 maps an out-of-range coordinate is `none` on both sides of any perturbation.
+
+[UPSTREAM] candidate: `Mathlib.Computability.Dependence`, the window-dependence
+companion of the transducer files.
 -/
 
 namespace Subregular
@@ -123,6 +130,20 @@ far side reverts it to the identity. -/
 def RequiresBothSides (f : List α → List α) : Prop :=
   ∀ d, ∃ (base : List α) (i : ℕ), i < base.length ∧ (f base)[i]? ≠ base[i]? ∧
     ∀ s, ∃ u, IsFarPerturbation base u i d s ∧ u[i]? = base[i]? ∧ (f u)[i]? = u[i]?
+
+/-- Every changed cell is determined by the input on one side of it alone — which
+side may vary from cell to cell. -/
+def OneSidedChanges (f : List α → List α) : Prop :=
+  ∀ (w : List α) (i : ℕ), (f w)[i]? ≠ w[i]? →
+    ∃ s : Direction, List.DependsAt (fun u => (f u)[i]?) (s.window i 0) w
+
+/-- A map that requires both sides has a change no single side determines. -/
+theorem RequiresBothSides.not_oneSidedChanges {f : List α → List α}
+    (hf : RequiresBothSides f) : ¬ OneSidedChanges f := fun hs =>
+  have ⟨base, i, _, hchange, hw⟩ := hf 0
+  have ⟨s, hdet⟩ := hs base i hchange
+  have ⟨_, ⟨hlen, hag⟩, hsym, hrev⟩ := hw s
+  hchange ((hdet hlen.symm hag).trans (hrev.trans hsym))
 
 /-- Requiring both sides strengthens two-sided unbounded dependence. -/
 theorem RequiresBothSides.twoSidedUnboundedDependence {f : List α → List α}
@@ -355,6 +376,32 @@ theorem conjBM.requiresBothSides : RequiresBothSides conjBM.run :=
   .of_flanks (fun d => by omega) (fun d => by omega)
     (fun d => by rw [conjBM.run_flankWord_mid]; decide)
     (conjBM.run_flankWord_mid false true) (conjBM.run_flankWord_mid true false)
+
+/-- Changed cells of a non-interacting bimachine's run are each determined by a
+single side, `OneSidedAt` transported to words. -/
+theorem IsNonInteractingBimachineComputable.oneSidedChanges [DecidableEq α]
+    {f : List α → List α} (hf : IsNonInteractingBimachineComputable f) :
+    OneSidedChanges f := by
+  obtain ⟨L, _, R, _, B, rfl, hni⟩ := hf
+  intro xs i hchange
+  rcases lt_or_ge i xs.length with hi | hi
+  · have ha : xs[i]? = some xs[i] := List.getElem?_eq_getElem hi
+    have hcell : B.output (B.lState (xs.take i)) xs[i] (B.rState (xs.drop (i + 1)))
+        ≠ xs[i] :=
+      fun h => hchange (by rw [B.getElem?_run, ha, Option.map_some, h])
+    rcases hni.oneSidedAt_of_change hcell with hR | hL
+    · refine ⟨.right, fun v hlen hag => ?_⟩
+      have hv : v[i]? = some xs[i] := (hag.getElem?_eq (by simp)).symm.trans ha
+      show (B.run xs)[i]? = (B.run v)[i]?
+      rw [B.getElem?_run, B.getElem?_run, ha, hv, Option.map_some, Option.map_some,
+        ← hag.take_eq (by omega), hR (B.rState (v.drop (i + 1)))]
+    · refine ⟨.left, fun v hlen hag => ?_⟩
+      have hv : v[i]? = some xs[i] := (hag.getElem?_eq (by simp)).symm.trans ha
+      show (B.run xs)[i]? = (B.run v)[i]?
+      rw [B.getElem?_run, B.getElem?_run, ha, hv, Option.map_some, Option.map_some,
+        ← hag.drop_eq (by omega), hL (B.lState (v.take i))]
+  · exact absurd (by rw [List.getElem?_eq_none (by simpa using hi),
+      List.getElem?_eq_none hi]) hchange
 
 /-- The non-interacting class is proper inside the bimachine-computable functions —
 `conjBM` is computed by a bimachine, but by no non-interacting one. -/

--- a/Linglib/Core/Computability/MyhillNerode.lean
+++ b/Linglib/Core/Computability/MyhillNerode.lean
@@ -19,12 +19,13 @@ Given `f : List α → List β` and a word `u`, the *residual* of `f` by `u` is 
 function `v ↦ (f (u ++ v)).drop u.length` — what `f` appends after reading `u` — and
 the *coresidual* of `f` by a suffix `y` is `u ↦ (f (u ++ y)).take u.length` — what `f`
 emits before reaching `y`. A function is Mealy-computable if and only if it is
-length-preserving, prefix-preserving, and has finitely many residuals — the
-Myhill–Nerode argument for the minimal sequential machine of [holcombe-1982]. A
+length-preserving, prefix-preserving, and has finitely many residuals — the Nerode
+criterion for sequential functions ([eilenberg-1974] [holcombe-1982]). A
 function is bimachine-computable if and only if it is length-preserving with finitely
 many residuals and finitely many coresiduals: residual classes are the left states,
 coresidual classes the right states, and the two-step exchange through representatives
-makes the cell output well-defined — the canonical bimachine of [eilenberg-1974].
+makes the cell output well-defined — the two-sided Nerode criterion for the bimachines
+of [eilenberg-1974].
 
 ## Main definitions
 

--- a/Linglib/Core/Computability/Subregular/Function/Dependence.lean
+++ b/Linglib/Core/Computability/Subregular/Function/Dependence.lean
@@ -222,6 +222,22 @@ theorem IsFarPerturbation.flankWord_right {i d : ℕ} (y' : α) (h : i + d ≤ n
     IsFarPerturbation (flankWord x fill y n) (flankWord x fill y' n) i d .right :=
   ⟨by simp, fun k hk => by grind [getElem?_flankWord]⟩
 
+/-- A `d`-indexed family of flank words whose target's image flips under changing
+either flank alone has two-sided unbounded dependence. -/
+theorem TwoSidedUnboundedDependence.of_flanks {fill xOn yOn xOff yOff : α}
+    {n t : ℕ → ℕ} (ht : ∀ d, d < t d) (hn : ∀ d, t d + d ≤ n d)
+    (hL : ∀ d, (f (flankWord xOn fill yOn (n d)))[t d]?
+      ≠ (f (flankWord xOff fill yOn (n d)))[t d]?)
+    (hR : ∀ d, (f (flankWord xOn fill yOn (n d)))[t d]?
+      ≠ (f (flankWord xOn fill yOff (n d)))[t d]?) :
+    TwoSidedUnboundedDependence f := by
+  intro d
+  have h₁ := ht d; have h₂ := hn d
+  refine ⟨flankWord xOn fill yOn (n d), t d, by rw [length_flankWord]; omega, fun s => ?_⟩
+  match s with
+  | .left => exact ⟨_, .flankWord_left xOff (ht d), hL d⟩
+  | .right => exact ⟨_, .flankWord_right yOff (hn d), hR d⟩
+
 /-- A `d`-indexed family of flank words whose target sits `d`-far from both flanks,
 changed in the base and reverted by flipping either flank alone, requires both sides. -/
 theorem RequiresBothSides.of_flanks {f : List α → List α}

--- a/Linglib/Core/Data/List/EqOn.lean
+++ b/Linglib/Core/Data/List/EqOn.lean
@@ -50,6 +50,15 @@ def DependsOn (g : List α → γ) (K : Set ℕ) : Prop :=
 theorem DependsOn.mono (hKK' : K ⊆ K') (h : DependsOn g K) : DependsOn g K' :=
   fun _ _ hl hag => h hl (hag.mono hKK')
 
+/-- `g` is determined at `w` by the positions in `K`: any equal-length list agreeing
+with `w` on `K` has the same image. The pointwise form of `List.DependsOn`. -/
+def DependsAt (g : List α → γ) (K : Set ℕ) (w : List α) : Prop :=
+  ∀ ⦃v : List α⦄, w.length = v.length → Set.EqOn (w[·]?) (v[·]?) K → g w = g v
+
+/-- Window dependence is pointwise dependence everywhere. -/
+theorem dependsOn_iff_forall_dependsAt {g : List α → γ} {K : Set ℕ} :
+    DependsOn g K ↔ ∀ w, DependsAt g K w := Iff.rfl
+
 /-- `g` factors through the input's length and its restriction to `K`. -/
 theorem dependsOn_iff_factorsThrough :
     DependsOn g K ↔

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Fintype.Option
 import Linglib.Core.Computability.Subregular.Language.TierProjection
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 
 /-!
 # TierProjection-based rules (`TierRule`)

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Finset.Max
 import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Data.List.TakeDrop
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.Hull

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.List.TakeDrop
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 
 /-!
 # Tonal surfacing processes

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Bimachine
 import Linglib.Phonology.Autosegmental.OCP

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -248,55 +248,6 @@ theorem baseR_get_target (d : ℕ) : (tutrugbuATR (baseR d))[d + 1]? = some .vLo
   rw [tutrugbuATR_baseR]
   simp [baseR, pre]
 
-/-- **Tutrugbu ATR harmony has two-sided unbounded dependence** — the weaker diagnostic;
-its circumambience proper ([mccollum-bakovic-mai-meinhardt-2020] §3, def. 13) is
-`tutrugbu_requiresBothSides`. At the medial target (index `d+1`):
-the base harmonises it ([+ATR]); flipping the initial-σ height `d` syllables to the left
-blocks it; flipping the root `d` syllables to the right removes the trigger — both from
-the one base word. -/
-theorem tutrugbu_twoSidedUnboundedDependence : TwoSidedUnboundedDependence tutrugbuATR := by
-  intro d
-  refine ⟨base d, d + 1, ?_, fun s => ?_⟩
-  · -- the target is in-domain: d + 1 < (base d).length  (= 2d+3)
-    simp only [base, pre, List.length_cons, List.length_append, List.length_replicate,
-      List.length_nil]; omega
-  match s with
-  | .left =>
-    refine ⟨baseL d, ⟨?_, ?_⟩, ?_⟩
-    · simp only [baseL, base, pre, List.length_cons, List.length_append,
-        List.length_replicate, List.length_nil]
-    · -- agreement on `Ici 1`: they share the tail from index 1
-      intro k hk
-      simp only [Direction.window_left, Set.mem_Ici] at hk
-      cases k with
-      | zero => omega
-      | succ k' =>
-        simp only [base, baseL, pre, List.cons_append, List.getElem?_cons_succ]
-    · rw [base_get_target, baseL_get_target]; decide
-  | .right =>
-    refine ⟨baseR d, ⟨?_, ?_⟩, ?_⟩
-    · simp only [baseR, base, pre, List.length_cons, List.length_append,
-        List.length_replicate, List.length_nil]
-    · -- agreement on `Iic ((d+1)+d)`: they differ only at the root index
-      intro k hk
-      simp only [Direction.window_right, Set.mem_Iic] at hk
-      have hpre_len : (pre Seg.vLo d).length = 2 * d + 2 := by
-        simp only [pre, List.length_cons, List.length_append, List.length_replicate]
-        omega
-      show (base d)[k]? = (baseR d)[k]?
-      rw [show base d = pre Seg.vLo d ++ [.rP] from rfl,
-          show baseR d = pre Seg.vLo d ++ [.rM] from rfl,
-          List.getElem?_append_left (by omega : k < (pre Seg.vLo d).length),
-          List.getElem?_append_left (by omega : k < (pre Seg.vLo d).length)]
-    · rw [base_get_target, baseR_get_target]; decide
-
-/-- **Tutrugbu ATR harmony is non-myopic** — the attested "variation on sour grapes"
-([mccollum-bakovic-mai-meinhardt-2020]; [wilson-2006]). A segmental counterexample to
-the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
-nonmyopic side argued by [walker-2010]. -/
-theorem tutrugbu_nonmyopic (s : Direction) : UnboundedDependence tutrugbuATR s :=
-  tutrugbu_twoSidedUnboundedDependence.unboundedDependence s
-
 /-- The input symbol at the target index is the recessive `.vLo` (for any initial and
 root): the prefix sequence places a `[−high]` vowel there. -/
 theorem pre_get_target (init : Seg) (d : ℕ) : (pre init d)[d + 1]? = some .vLo := by
@@ -353,6 +304,18 @@ theorem tutrugbu_requiresBothSides : RequiresBothSides tutrugbuATR := by
           List.getElem?_append_left (by omega : k < (pre Seg.vLo d).length)]
     · rw [hRin, hbin]
     · rw [baseR_get_target, hRin]
+
+/-- **Tutrugbu ATR harmony has two-sided unbounded dependence** — the weaker
+diagnostic, derived from the requires-both-sides witness. -/
+theorem tutrugbu_twoSidedUnboundedDependence : TwoSidedUnboundedDependence tutrugbuATR :=
+  tutrugbu_requiresBothSides.twoSidedUnboundedDependence
+
+/-- **Tutrugbu ATR harmony is non-myopic** — the attested "variation on sour grapes"
+([mccollum-bakovic-mai-meinhardt-2020]; [wilson-2006]). A segmental counterexample to
+the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
+nonmyopic side argued by [walker-2010]. -/
+theorem tutrugbu_nonmyopic (s : Direction) : UnboundedDependence tutrugbuATR s :=
+  tutrugbu_twoSidedUnboundedDependence.unboundedDependence s
 
 /-- **Tutrugbu ATR harmony is not weakly deterministic** — it needs the full
 non-deterministic regular power, above the weakly-deterministic upper bound of

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Bimachine
 
 /-!
@@ -316,6 +316,12 @@ the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
 nonmyopic side argued by [walker-2010]. -/
 theorem tutrugbu_nonmyopic (s : Direction) : UnboundedDependence tutrugbuATR s :=
   tutrugbu_twoSidedUnboundedDependence.unboundedDependence s
+
+/-- **Tutrugbu is not semiambient** — where Maasai's changes are each licensed by one
+side (`MeinhardtEtAl2024.maasai_semiambient`), Tutrugbu's harmonisation cell cannot
+be: the trigger sits on one side and the blocker on the other. -/
+theorem tutrugbu_not_semiambient : ¬ OneSidedChanges tutrugbuATR :=
+  tutrugbu_requiresBothSides.not_oneSidedChanges
 
 /-- **Tutrugbu ATR harmony is not weakly deterministic** — it needs the full
 non-deterministic regular power, above the weakly-deterministic upper bound of

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -375,29 +375,20 @@ each side alone sufficing. Tutrugbu satisfies this too
 classification of Maasai as unbounded *semiambient* — every target fixed by information
 from at most one side — is the stronger claim, and is not formalized here. -/
 theorem maasai_twoSidedUnboundedDependence : TwoSidedUnboundedDependence maasai := by
-  intro d
-  refine ⟨List.replicate (2 * d + 3) .recL, d + 1, by simp; omega, fun s => ?_⟩
-  match s with
-  | .left =>
-    refine ⟨(List.replicate (2 * d + 3) .recL).set 0 .dom,
-      ⟨by simp, fun k (hk : _ ≤ k) => (List.getElem?_set_ne (by omega)).symm⟩, ?_⟩
-    simp only [maasai]
-    rw [List.getElem?_map, List.getElem?_map, List.getElem?_set_ne (by omega : 0 ≠ d + 1)]
-    have hd : hasDom ((List.replicate (2 * d + 3) .recL).set 0 .dom) = true := by
-      simp only [hasDom, List.any_eq_true]
-      exact ⟨Seg.dom, List.mem_set (by simp) Seg.dom, rfl⟩
-    have hb : hasDom (List.replicate (2 * d + 3) .recL) = false := by simp [hasDom]
-    simp [hd, hb, (by omega : d + 1 < 2 * d + 3)]
-  | .right =>
-    refine ⟨(List.replicate (2 * d + 3) .recL).set (2 * d + 2) .dom,
-      ⟨by simp, fun k (hk : k ≤ _) => (List.getElem?_set_ne (by omega)).symm⟩, ?_⟩
-    simp only [maasai]
-    rw [List.getElem?_map, List.getElem?_map, List.getElem?_set_ne (by omega : 2 * d + 2 ≠ d + 1)]
-    have hd : hasDom ((List.replicate (2 * d + 3) .recL).set (2 * d + 2) .dom) = true := by
-      simp only [hasDom, List.any_eq_true]
-      exact ⟨Seg.dom, List.mem_set (by simp) Seg.dom, rfl⟩
-    have hb : hasDom (List.replicate (2 * d + 3) .recL) = false := by simp [hasDom]
-    simp [hd, hb, (by omega : d + 1 < 2 * d + 3)]
+  refine .of_flanks (fill := Seg.recL) (xOn := Seg.recL) (yOn := Seg.recL)
+    (xOff := Seg.dom) (yOff := Seg.dom)
+    (n := fun d => 2 * d + 1) (t := fun d => d + 1)
+    (fun d => by omega) (fun d => by omega) (fun d => ?_) (fun d => ?_) <;>
+  · have hb : hasDom (flankWord Seg.recL Seg.recL Seg.recL (2 * d + 1)) = false := by
+      simp [hasDom, flankWord]
+    have hp : ∀ y, hasDom (flankWord Seg.dom Seg.recL y (2 * d + 1)) = true := fun y => by
+      simp [hasDom, flankWord]
+    have hp' : ∀ x, hasDom (flankWord x Seg.recL Seg.dom (2 * d + 1)) = true := fun x => by
+      simp [hasDom, flankWord]
+    simp only [maasai, List.getElem?_map,
+      getElem?_flankWord_mid (show 0 < d + 1 by omega) (show d + 1 ≤ 2 * d + 1 by omega),
+      hb, hp, hp']
+    decide
 
 /-- Hence Maasai does **not** require both sides — it escapes the teeth, unlike Tutrugbu.
 Covariation (both languages) and interaction (Tutrugbu only) come apart. -/
@@ -409,10 +400,17 @@ Mealy-computable — the length-preserving-stratum reading of [heinz-lai-2013]'s
 `LSF, RSF ⊆ WD` corollary being strict, with `maasai` as their own dominant-recessive
 witness (their Thms. 6 and 7). A Mealy-computable map is right-myopic
 (`IsMealyComputable.boundedDependence_right`), but Maasai's bidirectional spread is not
-(`maasai_twoSidedUnboundedDependence`). TODO: the stronger `¬ IsLeftSubsequential
-maasai` (the *block* class) — a block transducer can delay output, so it needs the
-bounded-delay route (`IsLeftSubsequential.bounded_delay`), not the myopia shortcut. -/
+(`maasai_twoSidedUnboundedDependence`); the block-class exclusion is
+`maasai_not_leftSubsequential`. -/
 theorem maasai_not_mealyComputable : ¬ IsMealyComputable maasai := fun h =>
   maasai_twoSidedUnboundedDependence.unboundedDependence .right h.boundedDependence_right
+
+/-- **Maasai is not left-subsequential** — the *block* class is excluded too: `maasai`
+is length-preserving, so a left-subsequential computer's delay bound would cap its
+right dependence (`IsLeftSubsequential.boundedDependence_right`), but the spread's
+right dependence is unbounded. -/
+theorem maasai_not_leftSubsequential : ¬ IsLeftSubsequential maasai := fun h =>
+  maasai_twoSidedUnboundedDependence.unboundedDependence .right
+    (h.boundedDependence_right fun xs => by simp [maasai])
 
 end MeinhardtEtAl2024

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -7,7 +7,7 @@ import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Subregular.Function.ISL
 import Linglib.Core.Computability.Subregular.Function.OSL
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Subregular.Function.Dependence
+import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Bimachine
 
 /-!
@@ -373,7 +373,7 @@ each side alone sufficing. Tutrugbu satisfies this too
 (`tutrugbu_twoSidedUnboundedDependence`); the difference is that Maasai does *not*
 `RequiresBothSides`, so it stays weakly deterministic. The paper's positive
 classification of Maasai as unbounded *semiambient* — every target fixed by information
-from at most one side — is the stronger claim, and is not formalized here. -/
+from at most one side — is the stronger claim, `maasai_semiambient`. -/
 theorem maasai_twoSidedUnboundedDependence : TwoSidedUnboundedDependence maasai := by
   refine .of_flanks (fill := Seg.recL) (xOn := Seg.recL) (yOn := Seg.recL)
     (xOff := Seg.dom) (yOff := Seg.dom)
@@ -389,6 +389,11 @@ theorem maasai_twoSidedUnboundedDependence : TwoSidedUnboundedDependence maasai 
       getElem?_flankWord_mid (show 0 < d + 1 by omega) (show d + 1 ≤ 2 * d + 1 by omega),
       hb, hp, hp']
     decide
+
+/-- **Maasai is semiambient** — the paper's positive classification: every harmonised
+cell is licensed by one side alone, the far dominant that triggers it. -/
+theorem maasai_semiambient : OneSidedChanges maasai :=
+  maasai_weaklyDeterministic.oneSidedChanges
 
 /-- Hence Maasai does **not** require both sides — it escapes the teeth, unlike Tutrugbu.
 Covariation (both languages) and interaction (Tutrugbu only) come apart. -/


### PR DESCRIPTION
Completes the Meinhardt classification square and the dependence layer's upstream positioning:
- `List.DependsAt` (EqOn.lean): the pointwise form of `List.DependsOn` (`ContinuousAt` pattern; the iff is `Iff.rfl`).
- `OneSidedChanges f`: every changed cell is determined by one side of its input alone — the change-guard is load-bearing (unchanged cells legitimately need both sides). Bridges: `RequiresBothSides.not_oneSidedChanges` (term proof) and `IsNonInteractingBimachineComputable.oneSidedChanges` (the orphaned `OneSidedAt`'s first consumer).
- Studies: `maasai_semiambient` (the paper's positive classification, previously flagged unformalized) and `tutrugbu_not_semiambient` — the paper's term lives in the study names, the descriptive name in Core.
- `Dependence.lean` graduates flat (zero program-layer imports since the refoundation) with an UPSTREAM marker.
- Plus the wave-2 collapses: `TSUD.of_flanks`, Maasai block-class exclusion via R1, McCollum TSUD dedup (−37).