### PR TITLE
docs(Core/Computability): anchor canonical bimachine on Reutenauer-Schutzenberger

### DIFF
--- a/Linglib/Core/Computability/MyhillNerode.lean
+++ b/Linglib/Core/Computability/MyhillNerode.lean
@@ -24,8 +24,8 @@ criterion for sequential functions ([eilenberg-1974] [holcombe-1982]). A
 function is bimachine-computable if and only if it is length-preserving with finitely
 many residuals and finitely many coresiduals: residual classes are the left states,
 coresidual classes the right states, and the two-step exchange through representatives
-makes the cell output well-defined — the two-sided Nerode criterion for the bimachines
-of [eilenberg-1974].
+makes the cell output well-defined — the length-preserving stratum of the canonical
+bimachine of [reutenauer-schutzenberger-1991], surveyed in [filiot-reynier-2016].
 
 ## Main definitions
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30357,6 +30357,36 @@
   sources   = {Core/Computability/Subregular/Function/Subsequential.lean}
 }
 
+@article{reutenauer-schutzenberger-1991,
+  author    = {Reutenauer, Christophe and Sch\"utzenberger, Marcel-Paul},
+  year      = {1991},
+  title     = {Minimization of Rational Word Functions},
+  journal   = {SIAM Journal on Computing},
+  volume    = {20},
+  number    = {4},
+  pages     = {669--685},
+  doi       = {10.1137/0220042},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Computability/MyhillNerode.lean}
+}
+
+@article{filiot-reynier-2016,
+  author    = {Filiot, Emmanuel and Reynier, Pierre-Alain},
+  year      = {2016},
+  title     = {Transducers, Logic and Algebra for Functions of Finite Words},
+  journal   = {ACM SIGLOG News},
+  volume    = {3},
+  number    = {3},
+  pages     = {4--19},
+  doi       = {10.1145/2984450.2984453},
+  subfield  = {phonology/subregular},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Computability/MyhillNerode.lean}
+}
+
 @article{choffrut-1977,
   author    = {Choffrut, Christian},
   year      = {1977},


### PR DESCRIPTION
Primary-source verification pass: the canonical bimachine theorem is [reutenauer-schutzenberger-1991] (SIAM J. Comput. 20(4), DOI-verified), surveyed in [filiot-reynier-2016] (SIGLOG News 3(3)) whose bimachine definition matches `Bimachine` verbatim. Both added to the bib; `MyhillNerode.lean`'s module doc now attributes the two-sided criterion as the length-preserving stratum of their canonical bimachine, with [eilenberg-1974] keeping only the object.