### PR TITLE
feat(Core/Computability/Subregular): SL = suffix substitution closure

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -112,6 +112,7 @@ import Linglib.Core.Data.List.Bookend
 import Linglib.Core.Data.List.Chain
 import Linglib.Core.Data.List.Destutter
 import Linglib.Core.Data.List.EqOn
+import Linglib.Core.Dynamics.SymbolicDynamics.Word
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
 import Linglib.Core.Data.List.Fold

--- a/Linglib.lean
+++ b/Linglib.lean
@@ -112,7 +112,7 @@ import Linglib.Core.Data.List.Bookend
 import Linglib.Core.Data.List.Chain
 import Linglib.Core.Data.List.Destutter
 import Linglib.Core.Data.List.EqOn
-import Linglib.Core.Dynamics.SymbolicDynamics.Word
+import Linglib.Core.Data.List.Config
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Data.List.Factors
 import Linglib.Core.Data.List.Fold

--- a/Linglib/Core/Computability/Subregular/Language/Boundary.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Boundary.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Data.List.Chain
+import Linglib.Core.Dynamics.SymbolicDynamics.Word
 import Linglib.Core.Data.List.Factors
 
 /-!
@@ -65,11 +66,11 @@ lemma length_boundary : (boundary k w).length = w.length + 2 * (k - 1) := by
 
 end Boundary
 
-/-! ### Position discrimination and pinning
+/-! ### Position discrimination and the configuration bridge
 
-An infix of `boundary k y` that shows a boundary marker is *anchored*: a marker
-followed by letters pins them to the start of `y`, letters followed by a marker pin
-them to the end, and an all-letter infix reflects to an infix of `y`. -/
+Entries of `boundary k y` are values of the word's two-sided configuration
+(`List.config`), shifted by the pad width; consequently the `k`-factors of the
+augmented word are exactly its windows (`List.window`). -/
 
 section Pinning
 
@@ -117,140 +118,51 @@ lemma of_getElem?_boundary_eq_none {j : ℕ}
   · exact absurd h (by simp)
   · exact .inr (by omega)
 
-private lemma letters_of_offset {δ : ℕ}
-    (hδ : ∀ i (_ : i < 1 + l.length),
-      (boundary k y)[i + δ]? = ([none] ++ l.map some)[i]?) :
-    ∀ i (_ : i < l.length), (boundary k y)[1 + i + δ]? = some (some l[i]) :=
-  fun i hilt => by
-    have := hδ (1 + i) (by omega)
-    rwa [List.getElem?_append_right (by simp), List.length_singleton,
-      Nat.add_sub_cancel_left, List.getElem?_map, List.getElem?_eq_getElem hilt,
-      Option.map_some] at this
+/-- Boundary entries are configuration values, shifted by the pad width. -/
+lemma getElem?_boundary_eq_config {q : ℕ} (h : q < w.length + 2 * (k - 1)) :
+    (boundary k w)[q]? = some (w.config ((q : ℤ) - (k - 1 : ℕ))) := by
+  rw [getElem?_boundary]
+  split_ifs with h1 h2
+  · rw [List.config_neg (by omega)]
+  · have hlt : q - (k - 1) < w.length := by omega
+    rw [show ((q : ℤ) - (k - 1 : ℕ)) = ((q - (k - 1) : ℕ) : ℤ) by omega,
+      List.config_natCast, List.getElem?_eq_getElem hlt, Option.map_some]
+  · rw [List.config_eq_none_iff.mpr (.inr (by omega))]
 
-/-- Letters right after a boundary marker are word-initial. -/
-lemma prefix_of_boundary_infix (hl : l ≠ [])
-    (h : ([none] ++ l.map some) <:+: boundary k y) : l <+: y := by
-  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
-  have hi := letters_of_offset (l := l) fun i hi => hδ i (by simp; omega)
-  have h0 : (boundary k y)[δ]? = some none := by simpa using hδ 0 (by simp)
-  have hpos := List.length_pos_of_ne_nil hl
-  obtain ⟨hk1, hy0⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
-  have hpin : 1 + δ = k - 1 := by
-    rcases of_getElem?_boundary_eq_none h0 with hlt | hge
-    · omega
-    · have := (List.getElem?_eq_some_iff.mp hy0).1
+/-- The `k`-factors of the augmented word are exactly its windows over
+`[1 - k, w.length)`. -/
+lemma mem_kFactors_boundary_iff {f : List (Option α)} (hk : 1 ≤ k) :
+    f ∈ List.kFactors k (boundary k y) ↔
+      ∃ i : ℤ, 1 - k ≤ i ∧ i < y.length ∧ f = List.window k y i := by
+  rw [List.mem_kFactors]
+  constructor
+  · rintro ⟨hinf, hlen⟩
+    obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp hinf
+    have hbound : δ + k ≤ y.length + 2 * (k - 1) := by
+      by_contra hc
+      have h1 := hδ (k - 1) (by omega)
+      rw [List.getElem?_eq_none
+        (show (boundary k y).length ≤ k - 1 + δ by rw [length_boundary]; omega)] at h1
+      have h2 := List.getElem?_eq_none_iff.mp h1.symm
       omega
-  have hylen : ∀ i (_ : i < l.length), y[i]? = some l[i] := fun i hilt => by
-    have := (of_getElem?_boundary_eq_some (hi i hilt)).2
-    rwa [show 1 + i + δ - (k - 1) = i by omega] at this
-  rw [List.prefix_iff_eq_take]
-  apply List.ext_getElem?
-  intro i
-  rcases lt_or_ge i l.length with hilt | hile
-  · rw [List.getElem?_take_of_lt hilt, hylen i hilt, List.getElem?_eq_getElem hilt]
-  · rw [List.getElem?_take_eq_none hile, List.getElem?_eq_none hile]
-
-/-- Letters right before a boundary marker are word-final. -/
-lemma suffix_of_boundary_infix (hl : l ≠ [])
-    (h : (l.map some ++ [none]) <:+: boundary k y) : l <:+ y := by
-  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
-  have hi : ∀ i (_ : i < l.length), (boundary k y)[i + δ]? = some (some l[i]) :=
-    fun i hilt => by
-      have := hδ i (by simp; omega)
-      rwa [List.getElem?_append_left (by simpa using hilt), List.getElem?_map,
-        List.getElem?_eq_getElem hilt, Option.map_some] at this
-  have hnone : (boundary k y)[l.length + δ]? = some none := by
-    have := hδ l.length (by simp)
-    rw [List.getElem?_append_right (by simp)] at this
-    simpa using this
-  have hpos := List.length_pos_of_ne_nil hl
-  obtain ⟨hk0, -⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
-  have hbounds : ∀ i (_ : i < l.length), i + δ - (k - 1) < y.length := fun i hilt =>
-    (List.getElem?_eq_some_iff.mp (of_getElem?_boundary_eq_some (hi i hilt)).2).1
-  have hpin : l.length + δ = k - 1 + y.length := by
-    rcases of_getElem?_boundary_eq_none hnone with hlt | hge
-    · omega
-    · have := hbounds (l.length - 1) (by omega)
-      omega
-  have hly : l.length ≤ y.length := by
-    have := hbounds 0 hpos
-    omega
-  have hylen : ∀ i (_ : i < l.length), y[y.length - l.length + i]? = some l[i] :=
-    fun i hilt => by
-      have := (of_getElem?_boundary_eq_some (hi i hilt)).2
-      rwa [show i + δ - (k - 1) = y.length - l.length + i by omega] at this
-  rw [List.suffix_iff_eq_drop]
-  apply List.ext_getElem?
-  intro i
-  rcases lt_or_ge i l.length with hilt | hile
-  · rw [List.getElem?_drop, hylen i hilt, List.getElem?_eq_getElem hilt]
-  · rw [List.getElem?_eq_none hile, List.getElem?_eq_none (by simp; omega)]
-
-/-- An all-letter infix reflects to an infix of the word. -/
-lemma infix_of_boundary_infix (h : l.map some <:+: boundary k y) : l <:+: y := by
-  rcases eq_or_ne l [] with rfl | hl
-  · exact List.nil_infix
-  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
-  have hi : ∀ i (_ : i < l.length), (boundary k y)[i + δ]? = some (some l[i]) :=
-    fun i hilt => by
-      have := hδ i (by simpa using hilt)
-      rwa [List.getElem?_map, List.getElem?_eq_getElem hilt, Option.map_some] at this
-  have hk0 := (of_getElem?_boundary_eq_some (hi 0 (List.length_pos_of_ne_nil hl))).1
-  refine (List.isInfix_iff_exists_offset _ _).mpr ⟨δ - (k - 1), fun i hilt => ?_⟩
-  have := (of_getElem?_boundary_eq_some (hi i hilt)).2
-  rw [show i + δ - (k - 1) = i + (δ - (k - 1)) by omega] at this
-  rw [this, List.getElem?_eq_getElem hilt]
-
-/-- Letters flanked by boundary markers on both sides are the whole word. -/
-lemma eq_of_boundary_infix (hl : l ≠ [])
-    (h : ([none] ++ l.map some ++ [none]) <:+: boundary k y) : y = l := by
-  have hpre : l <+: y :=
-    prefix_of_boundary_infix hl ((List.prefix_append _ _).isInfix.trans h)
-  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
-  have hi := letters_of_offset (l := l) fun i hi => by
-    have := hδ i (by simp; omega)
-    rwa [List.getElem?_append_left (by simp; omega)] at this
-  have h0 : (boundary k y)[δ]? = some none := by
-    have := hδ 0 (by simp)
-    simpa using this
-  have hpos := List.length_pos_of_ne_nil hl
-  obtain ⟨hk1, hy0⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
-  have hpin : 1 + δ = k - 1 := by
-    rcases of_getElem?_boundary_eq_none h0 with hlt | hge
-    · omega
-    · have := (List.getElem?_eq_some_iff.mp hy0).1
-      omega
-  have hlast : (boundary k y)[1 + l.length + δ]? = some none := by
-    have h' := hδ (1 + l.length)
-      (by simp only [List.length_append, List.length_map, List.length_singleton]; omega)
-    rwa [show ([none] ++ l.map some ++ [none] : List (Option α))[1 + l.length]?
-        = some none by
-      rw [List.getElem?_append_right (by simp; omega)]
-      simp only [List.length_append, List.length_map, List.length_singleton]
-      rw [show 1 + l.length - (1 + l.length) = 0 by omega]
-      rfl] at h'
-  have hyle : y.length ≤ l.length := by
-    rcases of_getElem?_boundary_eq_none hlast with hlt | hge
-    · omega
-    · omega
-  exact (hpre.eq_of_length (le_antisymm hpre.length_le hyle)).symm
-
-/-- A boundary-only infix of full width forces the empty word. -/
-lemma eq_nil_of_boundary_infix (hk : 2 ≤ k)
-    (h : List.replicate k (none : Option α) <:+: boundary k y) : y = [] := by
-  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
-  have hi : ∀ i (_ : i < k), (boundary k y)[i + δ]? = some none := fun i hilt => by
-    have := hδ i (by simpa using hilt)
-    rwa [List.getElem?_replicate, if_pos hilt] at this
-  rcases of_getElem?_boundary_eq_none (hi 0 (by omega)) with hlt | hge
-  · have := of_getElem?_boundary_eq_none (hi (k - 1 - δ) (by omega))
-    rw [show k - 1 - δ + δ = k - 1 by omega] at this
-    rcases this with h' | h'
-    · omega
-    · exact List.length_eq_zero_iff.mp (by omega)
-  · have := (List.getElem?_eq_some_iff.mp (hi (k - 1) (by omega))).1
-    rw [length_boundary] at this
-    omega
+    refine ⟨(δ : ℤ) - (k - 1 : ℕ), by omega, by omega, ?_⟩
+    apply List.ext_getElem?
+    intro j
+    rcases lt_or_ge j k with hj | hj
+    · rw [List.getElem?_window hj]
+      have h1 := (hδ j (by omega)).symm
+      rw [getElem?_boundary_eq_config (q := j + δ) (by omega)] at h1
+      rw [h1, show ((j + δ : ℕ) : ℤ) - ((k - 1 : ℕ) : ℤ) = (δ : ℤ) - (k - 1 : ℕ) + (j : ℕ)
+        by omega]
+    · rw [List.getElem?_eq_none (by omega), List.getElem?_eq_none (by simpa using hj)]
+  · rintro ⟨i, h1, h2, rfl⟩
+    refine ⟨(List.isInfix_iff_exists_offset _ _).mpr
+      ⟨(i + (k - 1 : ℕ)).toNat, fun j hj => ?_⟩, by simp⟩
+    rw [List.length_window] at hj
+    rw [List.getElem?_window hj,
+      getElem?_boundary_eq_config (q := j + (i + (k - 1 : ℕ)).toNat) (by omega),
+      show ((j + (i + (k - 1 : ℕ)).toNat : ℕ) : ℤ) - ((k - 1 : ℕ) : ℤ) = i + (j : ℕ)
+        by omega]
 
 end Pinning
 

--- a/Linglib/Core/Computability/Subregular/Language/Boundary.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Boundary.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Data.List.Chain
+import Linglib.Core.Data.List.Factors
 
 /-!
 # Subregular Languages: Boundary Augmentation
@@ -63,6 +64,195 @@ lemma length_boundary : (boundary k w).length = w.length + 2 * (k - 1) := by
   simp [boundary]; omega
 
 end Boundary
+
+/-! ### Position discrimination and pinning
+
+An infix of `boundary k y` that shows a boundary marker is *anchored*: a marker
+followed by letters pins them to the start of `y`, letters followed by a marker pin
+them to the end, and an all-letter infix reflects to an infix of `y`. -/
+
+section Pinning
+
+variable {k : ℕ} {w y l : List α}
+
+/-- The augmented string's entries by region: left pad, letters, right pad. -/
+lemma getElem?_boundary (j : ℕ) :
+    (boundary k w)[j]? =
+      if j < k - 1 then some none
+      else if j < k - 1 + w.length then (w[j - (k - 1)]?).map some
+      else if j < w.length + 2 * (k - 1) then some none
+      else none := by
+  unfold boundary
+  rcases lt_or_ge j (k - 1) with h1 | h1
+  · rw [if_pos h1, List.getElem?_append_left (by simp; omega),
+      List.getElem?_append_left (by simpa using h1), List.getElem?_replicate, if_pos h1]
+  rcases lt_or_ge j (k - 1 + w.length) with h2 | h2
+  · rw [if_neg (by omega), if_pos h2, List.getElem?_append_left (by simp; omega),
+      List.getElem?_append_right (by simpa using h1), List.getElem?_map,
+      List.length_replicate]
+  rcases lt_or_ge j (w.length + 2 * (k - 1)) with h3 | h3
+  · rw [if_neg (by omega), if_neg (by omega), if_pos h3,
+      List.getElem?_append_right (by simp; omega), List.getElem?_replicate,
+      if_pos (by simp; omega)]
+  · rw [if_neg (by omega), if_neg (by omega), if_neg (by omega),
+      List.getElem?_eq_none (by simp; omega)]
+
+/-- A letter entry sits in the letter region. -/
+lemma of_getElem?_boundary_eq_some {j : ℕ} {a : α}
+    (h : (boundary k w)[j]? = some (some a)) :
+    k - 1 ≤ j ∧ w[j - (k - 1)]? = some a := by
+  rw [getElem?_boundary] at h
+  split_ifs at h with h1 h2 h3
+  · exact absurd h (by simp)
+  · exact ⟨by omega, by simpa using h⟩
+  · exact absurd h (by simp)
+
+/-- A marker entry sits in one of the pads. -/
+lemma of_getElem?_boundary_eq_none {j : ℕ}
+    (h : (boundary k w)[j]? = some (none : Option α)) :
+    j < k - 1 ∨ k - 1 + w.length ≤ j := by
+  rw [getElem?_boundary] at h
+  split_ifs at h with h1 h2 h3
+  · exact .inl h1
+  · exact absurd h (by simp)
+  · exact .inr (by omega)
+
+private lemma letters_of_offset {δ : ℕ}
+    (hδ : ∀ i (_ : i < 1 + l.length),
+      (boundary k y)[i + δ]? = ([none] ++ l.map some)[i]?) :
+    ∀ i (_ : i < l.length), (boundary k y)[1 + i + δ]? = some (some l[i]) :=
+  fun i hilt => by
+    have := hδ (1 + i) (by omega)
+    rwa [List.getElem?_append_right (by simp), List.length_singleton,
+      Nat.add_sub_cancel_left, List.getElem?_map, List.getElem?_eq_getElem hilt,
+      Option.map_some] at this
+
+/-- Letters right after a boundary marker are word-initial. -/
+lemma prefix_of_boundary_infix (hl : l ≠ [])
+    (h : ([none] ++ l.map some) <:+: boundary k y) : l <+: y := by
+  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
+  have hi := letters_of_offset (l := l) fun i hi => hδ i (by simp; omega)
+  have h0 : (boundary k y)[δ]? = some none := by simpa using hδ 0 (by simp)
+  have hpos := List.length_pos_of_ne_nil hl
+  obtain ⟨hk1, hy0⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
+  have hpin : 1 + δ = k - 1 := by
+    rcases of_getElem?_boundary_eq_none h0 with hlt | hge
+    · omega
+    · have := (List.getElem?_eq_some_iff.mp hy0).1
+      omega
+  have hylen : ∀ i (_ : i < l.length), y[i]? = some l[i] := fun i hilt => by
+    have := (of_getElem?_boundary_eq_some (hi i hilt)).2
+    rwa [show 1 + i + δ - (k - 1) = i by omega] at this
+  rw [List.prefix_iff_eq_take]
+  apply List.ext_getElem?
+  intro i
+  rcases lt_or_ge i l.length with hilt | hile
+  · rw [List.getElem?_take_of_lt hilt, hylen i hilt, List.getElem?_eq_getElem hilt]
+  · rw [List.getElem?_take_eq_none hile, List.getElem?_eq_none hile]
+
+/-- Letters right before a boundary marker are word-final. -/
+lemma suffix_of_boundary_infix (hl : l ≠ [])
+    (h : (l.map some ++ [none]) <:+: boundary k y) : l <:+ y := by
+  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
+  have hi : ∀ i (_ : i < l.length), (boundary k y)[i + δ]? = some (some l[i]) :=
+    fun i hilt => by
+      have := hδ i (by simp; omega)
+      rwa [List.getElem?_append_left (by simpa using hilt), List.getElem?_map,
+        List.getElem?_eq_getElem hilt, Option.map_some] at this
+  have hnone : (boundary k y)[l.length + δ]? = some none := by
+    have := hδ l.length (by simp)
+    rw [List.getElem?_append_right (by simp)] at this
+    simpa using this
+  have hpos := List.length_pos_of_ne_nil hl
+  obtain ⟨hk0, -⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
+  have hbounds : ∀ i (_ : i < l.length), i + δ - (k - 1) < y.length := fun i hilt =>
+    (List.getElem?_eq_some_iff.mp (of_getElem?_boundary_eq_some (hi i hilt)).2).1
+  have hpin : l.length + δ = k - 1 + y.length := by
+    rcases of_getElem?_boundary_eq_none hnone with hlt | hge
+    · omega
+    · have := hbounds (l.length - 1) (by omega)
+      omega
+  have hly : l.length ≤ y.length := by
+    have := hbounds 0 hpos
+    omega
+  have hylen : ∀ i (_ : i < l.length), y[y.length - l.length + i]? = some l[i] :=
+    fun i hilt => by
+      have := (of_getElem?_boundary_eq_some (hi i hilt)).2
+      rwa [show i + δ - (k - 1) = y.length - l.length + i by omega] at this
+  rw [List.suffix_iff_eq_drop]
+  apply List.ext_getElem?
+  intro i
+  rcases lt_or_ge i l.length with hilt | hile
+  · rw [List.getElem?_drop, hylen i hilt, List.getElem?_eq_getElem hilt]
+  · rw [List.getElem?_eq_none hile, List.getElem?_eq_none (by simp; omega)]
+
+/-- An all-letter infix reflects to an infix of the word. -/
+lemma infix_of_boundary_infix (h : l.map some <:+: boundary k y) : l <:+: y := by
+  rcases eq_or_ne l [] with rfl | hl
+  · exact List.nil_infix
+  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
+  have hi : ∀ i (_ : i < l.length), (boundary k y)[i + δ]? = some (some l[i]) :=
+    fun i hilt => by
+      have := hδ i (by simpa using hilt)
+      rwa [List.getElem?_map, List.getElem?_eq_getElem hilt, Option.map_some] at this
+  have hk0 := (of_getElem?_boundary_eq_some (hi 0 (List.length_pos_of_ne_nil hl))).1
+  refine (List.isInfix_iff_exists_offset _ _).mpr ⟨δ - (k - 1), fun i hilt => ?_⟩
+  have := (of_getElem?_boundary_eq_some (hi i hilt)).2
+  rw [show i + δ - (k - 1) = i + (δ - (k - 1)) by omega] at this
+  rw [this, List.getElem?_eq_getElem hilt]
+
+/-- Letters flanked by boundary markers on both sides are the whole word. -/
+lemma eq_of_boundary_infix (hl : l ≠ [])
+    (h : ([none] ++ l.map some ++ [none]) <:+: boundary k y) : y = l := by
+  have hpre : l <+: y :=
+    prefix_of_boundary_infix hl ((List.prefix_append _ _).isInfix.trans h)
+  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
+  have hi := letters_of_offset (l := l) fun i hi => by
+    have := hδ i (by simp; omega)
+    rwa [List.getElem?_append_left (by simp; omega)] at this
+  have h0 : (boundary k y)[δ]? = some none := by
+    have := hδ 0 (by simp)
+    simpa using this
+  have hpos := List.length_pos_of_ne_nil hl
+  obtain ⟨hk1, hy0⟩ := of_getElem?_boundary_eq_some (hi 0 hpos)
+  have hpin : 1 + δ = k - 1 := by
+    rcases of_getElem?_boundary_eq_none h0 with hlt | hge
+    · omega
+    · have := (List.getElem?_eq_some_iff.mp hy0).1
+      omega
+  have hlast : (boundary k y)[1 + l.length + δ]? = some none := by
+    have h' := hδ (1 + l.length)
+      (by simp only [List.length_append, List.length_map, List.length_singleton]; omega)
+    rwa [show ([none] ++ l.map some ++ [none] : List (Option α))[1 + l.length]?
+        = some none by
+      rw [List.getElem?_append_right (by simp; omega)]
+      simp only [List.length_append, List.length_map, List.length_singleton]
+      rw [show 1 + l.length - (1 + l.length) = 0 by omega]
+      rfl] at h'
+  have hyle : y.length ≤ l.length := by
+    rcases of_getElem?_boundary_eq_none hlast with hlt | hge
+    · omega
+    · omega
+  exact (hpre.eq_of_length (le_antisymm hpre.length_le hyle)).symm
+
+/-- A boundary-only infix of full width forces the empty word. -/
+lemma eq_nil_of_boundary_infix (hk : 2 ≤ k)
+    (h : List.replicate k (none : Option α) <:+: boundary k y) : y = [] := by
+  obtain ⟨δ, hδ⟩ := (List.isInfix_iff_exists_offset _ _).mp h
+  have hi : ∀ i (_ : i < k), (boundary k y)[i + δ]? = some none := fun i hilt => by
+    have := hδ i (by simpa using hilt)
+    rwa [List.getElem?_replicate, if_pos hilt] at this
+  rcases of_getElem?_boundary_eq_none (hi 0 (by omega)) with hlt | hge
+  · have := of_getElem?_boundary_eq_none (hi (k - 1 - δ) (by omega))
+    rw [show k - 1 - δ + δ = k - 1 by omega] at this
+    rcases this with h' | h'
+    · omega
+    · exact List.length_eq_zero_iff.mp (by omega)
+  · have := (List.getElem?_eq_some_iff.mp (hi (k - 1) (by omega))).1
+    rw [length_boundary] at this
+    omega
+
+end Pinning
 
 /-! ### Boundary-vacuous relations -/
 

--- a/Linglib/Core/Computability/Subregular/Language/Boundary.lean
+++ b/Linglib/Core/Computability/Subregular/Language/Boundary.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Data.List.Chain
-import Linglib.Core.Dynamics.SymbolicDynamics.Word
+import Linglib.Core.Data.List.Config
 import Linglib.Core.Data.List.Factors
 
 /-!

--- a/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
@@ -24,6 +24,14 @@ permitted `k`-factors, and `w ∈ L` iff every `k`-factor of `boundary k w` lies
 * `Subregular.SLGrammar.ofForbidden` — the grammar of a forbidden-factor set (its
   complement).
 * `Language.IsStrictlyLocal L k` — `L` is strictly `k`-local.
+* `Language.SuffixSubstitutionClosed L k` — members sharing a length-`(k − 1)` window
+  admit suffix crossover.
+
+## Main results
+
+* `Language.IsStrictlyLocal.suffixSubstitutionClosed` — strictly local languages are
+  closed under suffix substitution (the classical characterization's easy direction;
+  the converse, by stitching a witness through the canonical grammar, is TODO).
 -/
 
 namespace Subregular
@@ -98,5 +106,50 @@ width `k`. Witness-style, mirroring `Language.IsRegular`/`Language.IsContextFree
 ("L is regular iff some DFA accepts L"). -/
 def IsStrictlyLocal (L : Language α) (k : ℕ) : Prop :=
   ∃ G : SLGrammar α, G.language k = L
+
+/-! ### Suffix substitution closure -/
+
+/-- `L` is closed under **suffix substitution** at width `k`: two members sharing a
+length-`(k − 1)` window admit the crossover of their suffixes at it. -/
+def SuffixSubstitutionClosed (L : Language α) (k : ℕ) : Prop :=
+  ∀ u₁ v₁ u₂ v₂ x : List α, x.length = k - 1 →
+    u₁ ++ x ++ v₁ ∈ L → u₂ ++ x ++ v₂ ∈ L → u₁ ++ x ++ v₂ ∈ L
+
+/-- A strictly local language is closed under suffix substitution: every `k`-factor of
+the crossover lies in the shared left part — a factor of the first member — or in the
+shared window-and-right part — a factor of the second. -/
+theorem IsStrictlyLocal.suffixSubstitutionClosed {L : Language α} {k : ℕ}
+    (h : L.IsStrictlyLocal k) : L.SuffixSubstitutionClosed k := by
+  obtain ⟨G, rfl⟩ := h
+  intro u₁ v₁ u₂ v₂ x hx h₁ h₂ f hf
+  rw [List.mem_kFactors] at hf
+  obtain ⟨⟨s, t, hst⟩, hlen⟩ := hf
+  have hPfx : ∀ v : List α, (List.replicate (k - 1) none ++ (u₁ ++ x).map some)
+      <+: boundary k (u₁ ++ x ++ v) := fun v =>
+    ⟨v.map some ++ List.replicate (k - 1) none, by simp [boundary, List.append_assoc]⟩
+  have hSfx : ∀ u : List α, ((x ++ v₂).map some ++ List.replicate (k - 1) none)
+      <:+ boundary k (u ++ x ++ v₂) := fun u =>
+    ⟨List.replicate (k - 1) none ++ u.map some, by simp [boundary, List.append_assoc]⟩
+  rcases le_or_gt (s.length + k) (k - 1 + (u₁.length + x.length)) with hcase | hcase
+  · apply h₁
+    rw [List.mem_kFactors]
+    refine ⟨List.IsInfix.trans ?_ (hPfx v₁).isInfix, hlen⟩
+    have hsf : s ++ f <+: List.replicate (k - 1) none ++ (u₁ ++ x).map some := by
+      refine List.prefix_of_prefix_length_le
+        ⟨t, by simpa [List.append_assoc] using hst⟩ (hPfx v₂) ?_
+      simp only [List.length_append, List.length_replicate, List.length_map, hlen]
+      omega
+    exact (List.suffix_append s f).isInfix.trans hsf.isInfix
+  · apply h₂
+    rw [List.mem_kFactors]
+    refine ⟨List.IsInfix.trans ?_ (hSfx u₂).isInfix, hlen⟩
+    have hft : f ++ t <:+ (x ++ v₂).map some ++ List.replicate (k - 1) none := by
+      refine List.suffix_of_suffix_length_le
+        ⟨s, by simpa [List.append_assoc] using hst⟩ (hSfx u₁) ?_
+      have hL := congrArg List.length hst
+      simp only [List.length_append, length_boundary, hlen] at hL
+      simp only [List.length_append, List.length_map, List.length_replicate, hlen]
+      omega
+    exact (List.prefix_append f t).isInfix.trans hft.isInfix
 
 end Language

--- a/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
@@ -29,9 +29,10 @@ permitted `k`-factors, and `w ∈ L` iff every `k`-factor of `boundary k w` lies
 
 ## Main results
 
-* `Language.IsStrictlyLocal.suffixSubstitutionClosed` — strictly local languages are
-  closed under suffix substitution (the classical characterization's easy direction;
-  the converse, by stitching a witness through the canonical grammar, is TODO).
+* `Language.isStrictlyLocal_iff_suffixSubstitutionClosed` — for `k ≥ 2`, strict
+  `k`-locality is exactly closure under suffix substitution: the crossover's factors
+  split into the two members' shared parts, and conversely the canonical grammar of
+  licensed factors regenerates the language by stitching a member window-by-window.
 -/
 
 namespace Subregular
@@ -163,5 +164,233 @@ theorem IsStrictlyLocal.suffixSubstitutionClosed {L : Language α} {k : ℕ}
       simp only [List.length_append, List.length_map, List.length_replicate, hlen]
       omega
     exact (List.prefix_append f t).isInfix.trans hft.isInfix
+
+/-- A suffix-substitution-closed language is strictly local: the canonical grammar of
+all licensed member-factors regenerates it, stitching a member left-to-right through
+the shared windows. -/
+theorem SuffixSubstitutionClosed.isStrictlyLocal {L : Language α} {k : ℕ} (hk : 2 ≤ k)
+    (h : L.SuffixSubstitutionClosed k) : L.IsStrictlyLocal k := by
+  refine ⟨{f | ∃ z ∈ L, f ∈ List.kFactors k (boundary k z)}, ?_⟩
+  ext w
+  rw [SLGrammar.mem_language_iff_window (by omega)]
+  refine ⟨fun hw => ?_, fun hw i h1 h2 =>
+    ⟨w, hw, (mem_kFactors_boundary_iff (by omega)).mpr ⟨i, h1, h2, rfl⟩⟩⟩
+  have hwin : ∀ i : ℤ, 1 - (k : ℤ) ≤ i → i < w.length →
+      ∃ y ∈ L, ∃ q : ℤ, 1 - (k : ℤ) ≤ q ∧ q < y.length ∧
+        ∀ j : ℕ, j < k → y.config (q + j) = w.config (i + j) := by
+    intro i hi1 hi2
+    obtain ⟨y, hy, hf⟩ := hw i hi1 hi2
+    obtain ⟨q, hq1, hq2, hq3⟩ := (mem_kFactors_boundary_iff (by omega)).mp hf
+    exact ⟨y, hy, q, hq1, hq2, fun j hj => (List.window_eq_window_iff.mp hq3 j hj).symm⟩
+  clear hw
+  rcases eq_or_ne w [] with rfl | hne
+  · -- the empty word: any witness for its all-blank window is itself empty
+    obtain ⟨y, hy, q, hq1, hq2, hmatch⟩ := hwin (1 - k) le_rfl (by simp; omega)
+    have hall : ∀ j : ℕ, j < k → y.config (q + j) = none := fun j hj => by
+      rw [hmatch j hj, List.config_nil]
+    have hnil : y = [] := by
+      rcases lt_or_ge q 0 with hq0 | hq0
+      · have h0 := hall (-q).toNat (by omega)
+        rw [show q + (((-q).toNat : ℕ) : ℤ) = 0 by omega] at h0
+        have hc := List.config_eq_none_iff.mp h0
+        exact List.length_eq_zero_iff.mp (by omega)
+      · have hc := List.config_eq_none_iff.mp (by simpa using hall 0 (by omega))
+        exact List.length_eq_zero_iff.mp (by omega)
+    exact hnil ▸ hy
+  have hn1 : 0 < w.length := List.length_pos_of_ne_nil hne
+  rcases lt_or_ge w.length (k - 1) with hsmall | hbig
+  · -- short word: the window at `w.length + 1 - k` shows both edges, pinning its
+    -- witness to the whole word
+    obtain ⟨y, hy, q, hq1, hq2, hmatch⟩ := hwin ((w.length : ℤ) + 1 - k)
+      (by omega) (by omega)
+    have hnone : y.config (q + ((k - 2 - w.length : ℕ) : ℤ)) = none := by
+      rw [hmatch _ (by omega),
+        show ((w.length : ℤ) + 1 - k) + ((k - 2 - w.length : ℕ) : ℤ) = -1 by omega,
+        List.config_neg (show (-1 : ℤ) < 0 by omega)]
+    have hsome : y.config (q + ((k - 1 - w.length : ℕ) : ℤ)) = w.config 0 := by
+      rw [hmatch _ (by omega),
+        show ((w.length : ℤ) + 1 - k) + ((k - 1 - w.length : ℕ) : ℤ) = 0 by omega]
+    obtain ⟨a, ha⟩ : ∃ a, w.config 0 = some a := by
+      rw [show (0 : ℤ) = ((0 : ℕ) : ℤ) by simp, List.config_natCast]
+      exact ⟨_, List.getElem?_eq_getElem (by omega)⟩
+    obtain ⟨hb1, hb2⟩ := List.bounds_of_config_eq_some (hsome.trans ha)
+    have hpin : q = (w.length : ℤ) + 1 - k := by
+      rcases List.config_eq_none_iff.mp hnone with hc | hc <;> omega
+    suffices hyw : y = w by exact hyw ▸ hy
+    apply List.eq_of_config_agree
+    intro j hj
+    rcases lt_or_ge j ((w.length : ℤ) + 1 - k) with hji | hji
+    · rw [List.config_neg (by omega), List.config_neg (by omega)]
+    · have hjw : ((j - ((w.length : ℤ) + 1 - k)).toNat) < k := by omega
+      have hmt := hmatch _ hjw
+      rwa [hpin, show ((w.length : ℤ) + 1 - k)
+          + (((j - ((w.length : ℤ) + 1 - k)).toNat : ℕ) : ℤ) = j by omega] at hmt
+  · -- long word: march a member along the word, then cut its tail
+    have march : ∀ c : ℕ, c ≤ w.length →
+        ∃ z ∈ L, ∀ j : ℤ, j < (c : ℤ) → z.config j = w.config j := by
+      intro c
+      induction c with
+      | zero =>
+        intro _
+        obtain ⟨y, hy, -⟩ := hwin (1 - k) le_rfl (by omega)
+        exact ⟨y, hy, fun j hj => by
+          rw [List.config_neg (by omega), List.config_neg (by omega)]⟩
+      | succ c ih =>
+        intro hc1
+        obtain ⟨y, hy, q, hq1, hq2, hmatch⟩ := hwin ((c : ℤ) + 1 - k)
+          (by omega) (by omega)
+        rcases lt_or_ge c (k - 1) with hcA | hcB
+        · -- pin phase: the window shows the left edge, so the match is aligned
+          have hnone : y.config (q + ((k - 2 - c : ℕ) : ℤ)) = none := by
+            rw [hmatch _ (by omega),
+              show ((c : ℤ) + 1 - k) + ((k - 2 - c : ℕ) : ℤ) = -1 by omega,
+              List.config_neg (show (-1 : ℤ) < 0 by omega)]
+          have hsome : y.config (q + ((k - 1 - c : ℕ) : ℤ)) = w.config 0 := by
+            rw [hmatch _ (by omega),
+              show ((c : ℤ) + 1 - k) + ((k - 1 - c : ℕ) : ℤ) = 0 by omega]
+          obtain ⟨a, ha⟩ : ∃ a, w.config 0 = some a := by
+            rw [show (0 : ℤ) = ((0 : ℕ) : ℤ) by simp, List.config_natCast]
+            exact ⟨_, List.getElem?_eq_getElem (by omega)⟩
+          obtain ⟨hb1, hb2⟩ := List.bounds_of_config_eq_some (hsome.trans ha)
+          have hpin : q = (c : ℤ) + 1 - k := by
+            rcases List.config_eq_none_iff.mp hnone with hc0 | hc0 <;> omega
+          refine ⟨y, hy, fun j hj => ?_⟩
+          rcases lt_or_ge j ((c : ℤ) + 1 - k) with hji | hji
+          · rw [List.config_neg (by omega), List.config_neg (by omega)]
+          · have hjw : ((j - ((c : ℤ) + 1 - k)).toNat) < k := by omega
+            have hmt := hmatch _ hjw
+            rwa [hpin, show ((c : ℤ) + 1 - k)
+                + (((j - ((c : ℤ) + 1 - k)).toNat : ℕ) : ℤ) = j by omega] at hmt
+        · -- crossover phase: an all-letter window; substitute its suffix into the
+          -- marched member
+          obtain ⟨z, hz, hzag⟩ := ih (by omega)
+          have hq0 : 0 ≤ q := by
+            have h0 := hmatch 0 (by omega)
+            rw [show ((c : ℤ) + 1 - k) + ((0 : ℕ) : ℤ) = ((c + 1 - k : ℕ) : ℤ) by omega,
+              List.config_natCast] at h0
+            have h3 := h0.trans (List.getElem?_eq_getElem
+              (show c + 1 - k < w.length by omega))
+            have := (List.bounds_of_config_eq_some h3).1
+            omega
+          have hqtop : q + k ≤ y.length := by
+            have hlast := hmatch (k - 1) (by omega)
+            rw [show ((c : ℤ) + 1 - k) + ((k - 1 : ℕ) : ℤ) = ((c : ℕ) : ℤ) by omega,
+              List.config_natCast] at hlast
+            have h3 := hlast.trans (List.getElem?_eq_getElem (show c < w.length by omega))
+            have := (List.bounds_of_config_eq_some h3).2
+            omega
+          have hmid : (y.drop q.toNat).take k = (w.drop (c + 1 - k)).take k := by
+            apply List.ext_getElem?
+            intro t
+            rcases lt_or_ge t k with ht | ht
+            · rw [List.getElem?_take_of_lt ht, List.getElem?_take_of_lt ht,
+                List.getElem?_drop, List.getElem?_drop]
+              have hmt := hmatch t ht
+              rwa [show q + (t : ℕ) = ((q.toNat + t : ℕ) : ℤ) by omega,
+                show ((c : ℤ) + 1 - k) + (t : ℕ) = ((c + 1 - k + t : ℕ) : ℤ) by omega,
+                List.config_natCast, List.config_natCast] at hmt
+            · rw [List.getElem?_take_eq_none ht, List.getElem?_take_eq_none ht]
+          have hwmid : (w.drop (c + 1 - k)).take (k - 1) ++ [w[c]'(by omega)]
+              = (w.drop (c + 1 - k)).take k := by
+            rw [show ([w[c]'(by omega)] : List α)
+                = ((w.drop (c + 1 - k)).drop (k - 1)).take 1 from by
+              rw [List.drop_drop, show (c + 1 - k) + (k - 1) = c by omega,
+                List.drop_eq_getElem_cons (show c < w.length by omega)]
+              rfl]
+            rw [← List.take_add, show (k - 1) + 1 = k by omega]
+          have hysplit : y = y.take q.toNat
+              ++ ((w.drop (c + 1 - k)).take k ++ y.drop (q.toNat + k)) := by
+            conv_lhs => rw [← List.take_append_drop q.toNat y,
+              ← List.take_append_drop k (y.drop q.toNat)]
+            rw [hmid, List.drop_drop]
+          have hzsplit : z = (w.take (c + 1 - k) ++ (w.drop (c + 1 - k)).take (k - 1))
+              ++ z.drop c := by
+            conv_lhs => rw [← List.take_append_drop c z]
+            rw [List.take_eq_of_config_agree hzag,
+              show w.take c = w.take (c + 1 - k) ++ (w.drop (c + 1 - k)).take (k - 1)
+                from by rw [← List.take_add, show (c + 1 - k) + (k - 1) = c by omega]]
+          have hxlen : ((w.drop (c + 1 - k)).take (k - 1)).length = k - 1 := by
+            simp
+            omega
+          have hy2 : (y.take q.toNat ++ (w.drop (c + 1 - k)).take (k - 1))
+              ++ ([w[c]'(by omega)] ++ y.drop (q.toNat + k)) ∈ L := by
+            have hyass : y = (y.take q.toNat ++ (w.drop (c + 1 - k)).take (k - 1))
+                ++ ([w[c]'(by omega)] ++ y.drop (q.toNat + k)) := by
+              conv_lhs => rw [hysplit, ← hwmid]
+              simp [List.append_assoc]
+            exact hyass ▸ hy
+          have hnew := h (w.take (c + 1 - k)) (z.drop c) (y.take q.toNat)
+            ([w[c]'(by omega)] ++ y.drop (q.toNat + k))
+            ((w.drop (c + 1 - k)).take (k - 1)) hxlen (hzsplit ▸ hz) hy2
+          have htake : w.take (c + 1 - k) ++ (w.drop (c + 1 - k)).take k
+              = w.take (c + 1) := by
+            rw [← List.take_add, show (c + 1 - k) + k = c + 1 by omega]
+          have hz' : w.take (c + 1) ++ y.drop (q.toNat + k) ∈ L := by
+            have heq : w.take (c + 1) ++ y.drop (q.toNat + k)
+                = (w.take (c + 1 - k) ++ (w.drop (c + 1 - k)).take (k - 1))
+                  ++ ([w[c]'(by omega)] ++ y.drop (q.toNat + k)) := by
+              rw [← htake, ← hwmid]
+              simp [List.append_assoc]
+            exact heq ▸ hnew
+          refine ⟨w.take (c + 1) ++ y.drop (q.toNat + k), hz', fun j hj => ?_⟩
+          rcases lt_or_ge j 0 with hj0 | hj0
+          · rw [List.config_neg hj0, List.config_neg hj0]
+          · rw [List.config_append_left (by simp; omega), List.config_take (by omega)]
+    -- cut the marched member's tail with the final window
+    obtain ⟨z, hz, hzag⟩ := march w.length le_rfl
+    obtain ⟨y, hy, q, hq1, hq2, hmatch⟩ := hwin ((w.length : ℤ) + 1 - k)
+      (by omega) (by omega)
+    have hq0 : 0 ≤ q := by
+      have h0 := hmatch 0 (by omega)
+      rw [show ((w.length : ℤ) + 1 - k) + ((0 : ℕ) : ℤ) = ((w.length + 1 - k : ℕ) : ℤ)
+          by omega, List.config_natCast] at h0
+      have h3 := h0.trans (List.getElem?_eq_getElem
+        (show w.length + 1 - k < w.length by omega))
+      have := (List.bounds_of_config_eq_some h3).1
+      omega
+    have hnone : y.config (q + ((k - 1 : ℕ) : ℤ)) = none := by
+      rw [hmatch _ (by omega),
+        show ((w.length : ℤ) + 1 - k) + ((k - 1 : ℕ) : ℤ) = ((w.length : ℕ) : ℤ) by omega,
+        List.config_natCast, List.getElem?_eq_none le_rfl]
+    have hsome : y.config (q + ((k - 2 : ℕ) : ℤ)) = w.config ((w.length - 1 : ℕ) : ℤ) := by
+      rw [hmatch _ (by omega),
+        show ((w.length : ℤ) + 1 - k) + ((k - 2 : ℕ) : ℤ) = ((w.length - 1 : ℕ) : ℤ)
+          by omega]
+    obtain ⟨a, ha⟩ : ∃ a, w.config ((w.length - 1 : ℕ) : ℤ) = some a := by
+      rw [List.config_natCast]
+      exact ⟨_, List.getElem?_eq_getElem (by omega)⟩
+    obtain ⟨hb1, hb2⟩ := List.bounds_of_config_eq_some (hsome.trans ha)
+    have hylen : (y.length : ℤ) = q + k - 1 := by
+      rcases List.config_eq_none_iff.mp hnone with hc | hc <;> omega
+    have hyfin : y = y.take q.toNat ++ w.drop (w.length + 1 - k) := by
+      conv_lhs => rw [← List.take_append_drop q.toNat y]
+      congr 1
+      apply List.ext_getElem?
+      intro t
+      rcases lt_or_ge t (k - 1) with ht | ht
+      · rw [List.getElem?_drop, List.getElem?_drop]
+        have hmt := hmatch t (by omega)
+        rwa [show q + (t : ℕ) = ((q.toNat + t : ℕ) : ℤ) by omega,
+          show ((w.length : ℤ) + 1 - k) + (t : ℕ) = ((w.length + 1 - k + t : ℕ) : ℤ)
+            by omega, List.config_natCast, List.config_natCast] at hmt
+      · rw [List.getElem?_eq_none (by simp; omega), List.getElem?_eq_none (by simp; omega)]
+    have hzw : z = w ++ z.drop w.length := by
+      conv_lhs => rw [← List.take_append_drop w.length z]
+      rw [List.take_eq_of_config_agree hzag, List.take_length]
+    have hxlen : (w.drop (w.length + 1 - k)).length = k - 1 := by
+      simp
+      omega
+    have hnew := h (w.take (w.length + 1 - k)) (z.drop w.length) (y.take q.toNat) []
+      (w.drop (w.length + 1 - k)) hxlen
+      (by rw [List.take_append_drop]; exact hzw ▸ hz)
+      (by rw [List.append_nil]; exact hyfin ▸ hy)
+    rwa [List.take_append_drop, List.append_nil] at hnew
+
+/-- **The suffix-substitution characterization of strict locality**: for widths
+`k ≥ 2`, a language is strictly `k`-local if and only if it is closed under suffix
+substitution at `k`. -/
+theorem isStrictlyLocal_iff_suffixSubstitutionClosed {L : Language α} {k : ℕ}
+    (hk : 2 ≤ k) : L.IsStrictlyLocal k ↔ L.SuffixSubstitutionClosed k :=
+  ⟨IsStrictlyLocal.suffixSubstitutionClosed, fun hL => hL.isStrictlyLocal hk⟩
 
 end Language

--- a/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/Subregular/Language/StrictlyLocal.lean
@@ -64,6 +64,18 @@ def ofForbidden (forbidden : Set (Augmented α)) : SLGrammar α := forbiddenᶜ
       ↔ ∀ f ∈ List.kFactors k (boundary k w), f ∉ forbidden :=
   Iff.rfl
 
+/-- Membership in an SL language, position-indexed: every window over
+`[1 - k, w.length)` is permitted. -/
+theorem mem_language_iff_window {k : ℕ} {G : SLGrammar α} {w : List α} (hk : 1 ≤ k) :
+    w ∈ G.language k ↔ ∀ i : ℤ, 1 - k ≤ i → i < w.length → List.window k w i ∈ G := by
+  rw [mem_language]
+  constructor
+  · intro h i h1 h2
+    exact h _ ((mem_kFactors_boundary_iff hk).mpr ⟨i, h1, h2, rfl⟩)
+  · intro h f hf
+    obtain ⟨i, h1, h2, rfl⟩ := (mem_kFactors_boundary_iff hk).mp hf
+    exact h i h1 h2
+
 /-! ### Count-vector characterisation
 
 Membership in a forbidden-factor SL language is a zero-test of a single

--- a/Linglib/Core/Data/List/Config.lean
+++ b/Linglib/Core/Data/List/Config.lean
@@ -7,22 +7,16 @@ import Mathlib.Data.List.Basic
 import Mathlib.Data.List.OfFn
 
 /-!
-# Words as configurations of the full shift
+# Words as blank-padded indexed families
 
-A finite word `w : List α` determines a configuration of the full shift
-`ℤ → Option α` — the vocabulary of `Mathlib.Dynamics.SymbolicDynamics`: letters on
-`[0, w.length)`, blank (`none`) elsewhere (`List.config`). Its width-`k` window at
-`i` (`List.window`) is the restriction to `[i, i + k)`, a finite pattern. Facts about
-factors of boundary-augmented words become position-indexed facts about
-configurations, where alignment is carried by the index: a window entry is a letter
-or a blank according to a single interval test, so occurrence pinning is interval
-arithmetic. The topological layer (cylinders, subshifts) stays in
-`Mathlib.Dynamics.SymbolicDynamics.Basic`; this file is the combinatorial word case.
+`List.config` reads a word as a two-sided indexed family `ℤ → Option α`: letters on
+`[0, w.length)`, blank (`none`) elsewhere; `List.window k w i` is its width-`k` slice
+at `i`. Position-indexed statements about words replace factor-of-augmented-word
+bookkeeping: a window entry is a letter or a blank according to a single interval
+test, so occurrence pinning is interval arithmetic.
 
-[UPSTREAM] candidate: `Mathlib.Dynamics.SymbolicDynamics.Word`, a sibling of
-`Basic.lean`: finite words as the finitely-supported points of the full shift over
-`Option α` at `G = ℤ`, the first bridge between `Mathlib.Computability` languages
-and subshifts.
+[UPSTREAM] candidate: `Mathlib.Data.List`, on the `List.toFinsupp` precedent — a list
+as an indexed family with a default.
 -/
 
 namespace List

--- a/Linglib/Core/Dynamics/SymbolicDynamics/Word.lean
+++ b/Linglib/Core/Dynamics/SymbolicDynamics/Word.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.OfFn
+
+/-!
+# Words as configurations of the full shift
+
+A finite word `w : List α` determines a configuration of the full shift
+`ℤ → Option α` — the vocabulary of `Mathlib.Dynamics.SymbolicDynamics`: letters on
+`[0, w.length)`, blank (`none`) elsewhere (`List.config`). Its width-`k` window at
+`i` (`List.window`) is the restriction to `[i, i + k)`, a finite pattern. Facts about
+factors of boundary-augmented words become position-indexed facts about
+configurations, where alignment is carried by the index: a window entry is a letter
+or a blank according to a single interval test, so occurrence pinning is interval
+arithmetic. The topological layer (cylinders, subshifts) stays in
+`Mathlib.Dynamics.SymbolicDynamics.Basic`; this file is the combinatorial word case.
+
+[UPSTREAM] candidate: `Mathlib.Dynamics.SymbolicDynamics.Word`, a sibling of
+`Basic.lean`: finite words as the finitely-supported points of the full shift over
+`Option α` at `G = ℤ`, the first bridge between `Mathlib.Computability` languages
+and subshifts.
+-/
+
+namespace List
+
+variable {α : Type*} {w y u v : List α} {i q : ℤ} {a : α} {k : ℕ}
+
+/-- The two-sided configuration of a word: letters on `[0, w.length)`, blank
+elsewhere. -/
+def config (w : List α) : ℤ → Option α :=
+  fun i => if 0 ≤ i then w[i.toNat]? else none
+
+@[simp] lemma config_natCast (w : List α) (n : ℕ) : w.config n = w[n]? := by
+  simp [config]
+
+lemma config_neg (h : i < 0) : w.config i = none := by
+  rw [config, if_neg (by omega)]
+
+@[simp] lemma config_nil : ([] : List α).config i = none := by
+  rw [config]
+  split_ifs <;> simp
+
+lemma config_eq_none_iff : w.config i = none ↔ i < 0 ∨ (w.length : ℤ) ≤ i := by
+  rw [config]
+  split_ifs with h0
+  · rw [List.getElem?_eq_none_iff]
+    omega
+  · exact iff_of_true rfl (.inl (by omega))
+
+lemma bounds_of_config_eq_some (h : w.config i = some a) : 0 ≤ i ∧ i < w.length := by
+  rw [config] at h
+  split_ifs at h with h0
+  exact ⟨h0, by have := (List.getElem?_eq_some_iff.mp h).1; omega⟩
+
+lemma getElem?_of_config_eq_some (h : w.config i = some a) : w[i.toNat]? = some a := by
+  rw [config] at h
+  split_ifs at h with h0
+  exact h
+
+/-- Agreement of configurations up to the word's length forces equality. -/
+lemma eq_of_config_agree (h : ∀ j : ℤ, j ≤ (w.length : ℤ) → y.config j = w.config j) :
+    y = w := by
+  have hy : y.length ≤ w.length := by
+    have h1 := h (w.length : ℤ) le_rfl
+    rw [config_natCast, config_natCast, List.getElem?_eq_none le_rfl,
+      List.getElem?_eq_none_iff] at h1
+    exact h1
+  apply List.ext_getElem?
+  intro n
+  rcases lt_or_ge n w.length with hn | hn
+  · have := h n (by omega)
+    rwa [config_natCast, config_natCast] at this
+  · rw [List.getElem?_eq_none hn, List.getElem?_eq_none (by omega)]
+
+/-- Agreement of configurations below `c` transfers `c`-prefixes. -/
+lemma take_eq_of_config_agree {c : ℕ}
+    (h : ∀ j : ℤ, j < (c : ℤ) → y.config j = w.config j) : y.take c = w.take c := by
+  apply List.ext_getElem?
+  intro n
+  rcases lt_or_ge n c with hn | hn
+  · rw [List.getElem?_take_of_lt hn, List.getElem?_take_of_lt hn]
+    have := h n (by omega)
+    rwa [config_natCast, config_natCast] at this
+  · rw [List.getElem?_take_eq_none hn, List.getElem?_take_eq_none hn]
+
+lemma config_append_left (h : i < (u.length : ℤ)) : (u ++ v).config i = u.config i := by
+  rw [config, config]
+  split_ifs with h0
+  · rw [List.getElem?_append_left (by omega)]
+  · rfl
+
+lemma config_take {c : ℕ} (h : i < (c : ℤ)) : (w.take c).config i = w.config i := by
+  rw [config, config]
+  split_ifs with h0
+  · rw [List.getElem?_take_of_lt (by omega)]
+  · rfl
+
+/-! ### Windows -/
+
+/-- The width-`k` window of `w` at `i`: the configuration restricted to `[i, i + k)`. -/
+def window (k : ℕ) (w : List α) (i : ℤ) : List (Option α) :=
+  List.ofFn fun j : Fin k => w.config (i + (j : ℕ))
+
+@[simp] lemma length_window : (window k w i).length = k := by simp [window]
+
+lemma getElem?_window {j : ℕ} (h : j < k) :
+    (window k w i)[j]? = some (w.config (i + j)) := by
+  rw [window, List.getElem?_ofFn]
+  simp [h]
+
+lemma window_eq_window_iff :
+    window k w i = window k y q ↔ ∀ j : ℕ, j < k → w.config (i + j) = y.config (q + j) := by
+  constructor
+  · intro h j hj
+    have := congrArg (fun l => l[j]?) h
+    simp only [getElem?_window hj] at this
+    exact Option.some_injective _ this
+  · intro h
+    apply List.ext_getElem?
+    intro j
+    rcases lt_or_ge j k with hj | hj
+    · rw [getElem?_window hj, getElem?_window hj, h j hj]
+    · rw [List.getElem?_eq_none (by simpa using hj),
+        List.getElem?_eq_none (by simpa using hj)]
+
+end List


### PR DESCRIPTION
The SL keystone, complete, on a new positional substrate:
- `Core/Data/List/Config.lean` (new): a word as a blank-padded indexed family `ℤ → Option α` (`List.config`) with width-`k` windows (`List.window`) — plain list material (`List.toFinsupp` precedent), position-indexed so occurrence pinning is interval arithmetic.
- `Boundary.lean`: the augmented word's entries are `config` values (`getElem?_boundary_eq_config`); its `k`-factors are exactly the windows over `[1−k, |w|)` (`mem_kFactors_boundary_iff`). The five pinning lemmas dissolve.
- `StrictlyLocal.lean`: `SuffixSubstitutionClosed`, positional membership, and **`isStrictlyLocal_iff_suffixSubstitutionClosed`** at `2 ≤ k` — forward by splitting crossover factors; converse by stitching a member through the canonical grammar window-by-window (pin phase, crossover phase, tail cut; ε via its all-blank window).