### PR TITLE
refactor(Core/Computability): define non-CF witnesses as makeString ranges

### DIFF
--- a/Linglib/Core/Computability/NonContextFree/AmBnCmDn.lean
+++ b/Linglib/Core/Computability/NonContextFree/AmBnCmDn.lean
@@ -1,256 +1,135 @@
 import Linglib.Core.Computability.NonContextFree.AnBnCnDn
 
 /-!
-# {aᵐbⁿcᵐdⁿ}: two-parameter four-symbol non-context-free witness
+# `{aᵐbⁿcᵐdⁿ}`: a two-parameter four-symbol non-context-free witness
 
-The two-parameter relaxation of `anbncndn`: case-sorted strings with
-`a-count = c-count` and `b-count = d-count` (the diagonal pairs only —
-not all four counts equal). Strict superset of `anbncndn`; this is the
-language [shieber-1985]'s argument that Swiss German is not weakly
-context-free actually requires.
+The two-parameter relaxation of `anbncndn`: case-sorted strings whose `a`- and `c`-counts agree
+and whose `b`- and `d`-counts agree — the diagonal pairs only, not all four counts equal. A
+strict superset of `anbncndn`, and the language [shieber-1985]'s argument that Swiss German is
+not weakly context-free actually requires.
 
-## Pumping
+Pumping runs on the **diagonal witness `makeString_anbncndn p`**, which lies in `ambncmdn`
+because equal-all-four implies the diagonal pairs match. Deleting the pumped window breaks one
+of the two diagonal equalities rather than all four — the substantive content beyond `AnBnCnDn`.
 
-The witness is the **diagonal `makeString_anbncndn p`** (which lies in
-`ambncmdn`, since equal-all-four implies the diagonal pairs match).
-Pumping breaks one of the two diagonal equalities rather than all four
-— hence the substantive content of this file beyond `AnBnCnDn`.
+## Main definitions
 
-The proof uses the shared adjacency lemmas (`not_a_and_c_in_vxy`,
-`not_b_and_d_in_vxy`) and filter machinery (`filter_count`,
-`filter_eq_nil_of_not_mem`, `fourSymbol_filter_total`) re-exported from
-`AnBnCnDn`.
+* `makeString_ambncmdn m n`: the witness word `aᵐbⁿcᵐdⁿ`.
+* `ambncmdn`: the language `{aᵐbⁿcᵐdⁿ | m, n ≥ 0}`, as the range of `makeString_ambncmdn`.
+
+## Main results
+
+* `ambncmdn_not_pumpable`: `ambncmdn` lacks the CFL pumping property.
+* `ambncmdn_not_contextFree`: `ambncmdn` is not context-free.
 -/
 
-/-- The language `{aᵐbⁿcᵐdⁿ | m, n ≥ 0}`: case-sorted strings with
-    `a-count = c-count` and `b-count = d-count`. Membership requires
-    the case-sorted shape AND the two diagonal-count equalities. -/
-def isInLanguage_ambncmdn (w : FourString) : Bool :=
-  match w with
-  | [] => true
-  | _ =>
-    let na := w.filter (· == .a) |>.length
-    let nb := w.filter (· == .b) |>.length
-    let nc := w.filter (· == .c) |>.length
-    let nd := w.filter (· == .d) |>.length
-    na == nc && nb == nd &&
-    w == List.replicate na .a ++ List.replicate nb .b ++
-         List.replicate nc .c ++ List.replicate nd .d
-
-/-- Generate `aᵐbⁿcᵐdⁿ`. -/
-def makeString_ambncmdn (m n : Nat) : FourString :=
+/-- The witness word `aᵐbⁿcᵐdⁿ`. -/
+def makeString_ambncmdn (m n : ℕ) : FourString :=
   List.replicate m .a ++ List.replicate n .b ++
   List.replicate m .c ++ List.replicate n .d
 
-#guard isInLanguage_ambncmdn []
-#guard isInLanguage_ambncmdn (makeString_ambncmdn 0 0)
-#guard isInLanguage_ambncmdn (makeString_ambncmdn 1 1)
-#guard isInLanguage_ambncmdn (makeString_ambncmdn 2 3)
-#guard isInLanguage_ambncmdn (makeString_ambncmdn 3 1)
-#guard !isInLanguage_ambncmdn [.a, .b, .c]
-#guard !isInLanguage_ambncmdn [.a, .a, .b, .c, .c, .d, .d]
+/-- The language `{aᵐbⁿcᵐdⁿ | m, n ≥ 0}`, as the range of `makeString_ambncmdn`. -/
+def ambncmdn : Language FourSymbol := {w | ∃ m n, w = makeString_ambncmdn m n}
 
-/-- The language `{aᵐbⁿcᵐdⁿ}` as a mathlib `Language`. -/
-def ambncmdn : Language FourSymbol := {w | isInLanguage_ambncmdn w = true}
-
-/-- Unfold `isInLanguage_ambncmdn` on a nonempty string. -/
-private theorem isInLang_ambncmdn_nonempty (w : FourString) (h : w ≠ []) :
-    isInLanguage_ambncmdn w = (
-      let na := (w.filter (· == .a)).length
-      let nb := (w.filter (· == .b)).length
-      let nc := (w.filter (· == .c)).length
-      let nd := (w.filter (· == .d)).length
-      na == nc && nb == nd &&
-      w == List.replicate na .a ++ List.replicate nb .b ++
-           List.replicate nc .c ++ List.replicate nd .d) := by
-  unfold isInLanguage_ambncmdn
-  match w, h with
-  | _ :: _, _ => rfl
-
-/-- Diagonal-count equalities extracted from ambncmdn membership. -/
-private theorem counts_ambncmdn_of_inLanguage (w : FourString) (hne : w ≠ [])
-    (hin : isInLanguage_ambncmdn w = true) :
-    (w.filter (· == .a)).length = (w.filter (· == .c)).length ∧
-    (w.filter (· == .b)).length = (w.filter (· == .d)).length := by
-  unfold isInLanguage_ambncmdn at hin
-  match w, hne with
-  | _ :: _, _ =>
-    simp only [Bool.and_eq_true, beq_iff_eq] at hin
-    exact ⟨hin.1.1, hin.1.2⟩
-
-/-- The diagonal witness `makeString_anbncndn n` lies in `ambncmdn` (since
-    `na = nb = nc = nd = n` satisfies the weaker `na = nc ∧ nb = nd`). -/
-theorem makeString_anbncndn_in_ambncmdn (n : Nat) :
-    makeString_anbncndn n ∈ ambncmdn := by
-  show isInLanguage_ambncmdn (makeString_anbncndn n) = true
-  cases n with
-  | zero => rfl
-  | succ k =>
-    have hne : makeString_anbncndn (k + 1) ≠ [] := by
-      simp [makeString_anbncndn, List.replicate_succ]
-    rw [isInLang_ambncmdn_nonempty _ hne]
-    simp only [filter_count, beq_self_eq_true, Bool.and_self, Bool.true_and]
-    change (makeString_anbncndn (k + 1) == makeString_anbncndn (k + 1)) = true
-    exact beq_self_eq_true _
-
-/-- Asymmetric witness `makeString_ambncmdn m n` lies in `ambncmdn`. -/
-theorem makeString_ambncmdn_in_language (m n : Nat) :
-    makeString_ambncmdn m n ∈ ambncmdn := by
-  show isInLanguage_ambncmdn (makeString_ambncmdn m n) = true
-  by_cases hempty : makeString_ambncmdn m n = []
-  · rw [hempty]; rfl
-  · rw [isInLang_ambncmdn_nonempty _ hempty]
-    have hca : ((makeString_ambncmdn m n).filter (· == .a)).length = m := by
-      simp only [makeString_ambncmdn, List.filter_append, List.filter_replicate,
-                 List.length_append, List.length_nil]
-      simp (config := { decide := true })
-    have hcb : ((makeString_ambncmdn m n).filter (· == .b)).length = n := by
-      simp only [makeString_ambncmdn, List.filter_append, List.filter_replicate,
-                 List.length_append, List.length_nil]
-      simp (config := { decide := true })
-    have hcc : ((makeString_ambncmdn m n).filter (· == .c)).length = m := by
-      simp only [makeString_ambncmdn, List.filter_append, List.filter_replicate,
-                 List.length_append, List.length_nil]
-      simp (config := { decide := true })
-    have hcd : ((makeString_ambncmdn m n).filter (· == .d)).length = n := by
-      simp only [makeString_ambncmdn, List.filter_append, List.filter_replicate,
-                 List.length_append, List.length_nil]
-      simp (config := { decide := true })
-    simp only [hca, hcb, hcc, hcd, beq_self_eq_true, Bool.and_self, Bool.true_and]
-    show (makeString_ambncmdn m n == makeString_ambncmdn m n) = true
-    exact beq_self_eq_true _
-
-/-- Membership characterization: every string in `ambncmdn` equals
-    `makeString_ambncmdn m n` for some `m, n`. -/
+/-- Membership characterization: every string in `ambncmdn` equals `makeString_ambncmdn m n`
+for some `m, n`. -/
 theorem mem_ambncmdn_iff (w : FourString) :
-    w ∈ ambncmdn ↔ ∃ m n, w = makeString_ambncmdn m n := by
-  constructor
-  · intro hw
-    by_cases hempty : w = []
-    · exact ⟨0, 0, by rw [hempty]; rfl⟩
-    · have heq := isInLang_ambncmdn_nonempty w hempty
-      have hw' : isInLanguage_ambncmdn w = true := hw
-      rw [heq] at hw'
-      simp only [Bool.and_eq_true, beq_iff_eq] at hw'
-      obtain ⟨⟨h_ac, h_bd⟩, h_eq⟩ := hw'
-      refine ⟨(w.filter (· == .a)).length, (w.filter (· == .b)).length, ?_⟩
-      have hc_eq : (w.filter (· == .c)).length = (w.filter (· == .a)).length := h_ac.symm
-      have hd_eq : (w.filter (· == .d)).length = (w.filter (· == .b)).length := h_bd.symm
-      calc w
-          = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .b)).length .b ++
-              List.replicate (w.filter (· == .c)).length .c ++
-              List.replicate (w.filter (· == .d)).length .d := h_eq
-        _ = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .b)).length .b ++
-              List.replicate (w.filter (· == .a)).length .c ++
-              List.replicate (w.filter (· == .b)).length .d := by
-              rw [hc_eq, hd_eq]
-        _ = makeString_ambncmdn (w.filter (· == .a)).length
-              (w.filter (· == .b)).length := rfl
-  · rintro ⟨m, n, rfl⟩
-    exact makeString_ambncmdn_in_language m n
+    w ∈ ambncmdn ↔ ∃ m n, w = makeString_ambncmdn m n := Iff.rfl
 
-set_option maxHeartbeats 800000 in
-/-- Pumping breaks ambncmdn membership. The witness is the diagonal
-    `makeString_anbncndn p`. Deleting v and y must break either the
-    `a-count = c-count` equality or the `b-count = d-count` equality,
-    depending on which two adjacent blocks vxy intersects. -/
-theorem pump_breaks_ambncmdn (p : Nat) (_hp : p > 0) :
-    let w := makeString_anbncndn p
+theorem makeString_ambncmdn_in_language (m n : ℕ) : makeString_ambncmdn m n ∈ ambncmdn :=
+  ⟨m, n, rfl⟩
+
+/-- The diagonal witness lies in `ambncmdn`: `aⁿbⁿcⁿdⁿ` *is* `aᵐbⁿcᵐdⁿ` at `m = n`. -/
+theorem makeString_anbncndn_in_ambncmdn (n : ℕ) : makeString_anbncndn n ∈ ambncmdn :=
+  ⟨n, n, rfl⟩
+
+@[simp] theorem count_a_makeString_ambncmdn (m n : ℕ) :
+    (makeString_ambncmdn m n).count .a = m := by
+  simp [makeString_ambncmdn, List.count_replicate]
+
+@[simp] theorem count_b_makeString_ambncmdn (m n : ℕ) :
+    (makeString_ambncmdn m n).count .b = n := by
+  simp [makeString_ambncmdn, List.count_replicate]
+
+@[simp] theorem count_c_makeString_ambncmdn (m n : ℕ) :
+    (makeString_ambncmdn m n).count .c = m := by
+  simp [makeString_ambncmdn, List.count_replicate]
+
+@[simp] theorem count_d_makeString_ambncmdn (m n : ℕ) :
+    (makeString_ambncmdn m n).count .d = n := by
+  simp [makeString_ambncmdn, List.count_replicate]
+
+/-- Pumping breaks `ambncmdn` membership. Deleting `v` and `y` must break either the
+`a`-count = `c`-count equality or the `b`-count = `d`-count equality, depending on which
+blocks the window meets. -/
+theorem pump_breaks_ambncmdn (p : ℕ) (_hp : 0 < p) :
     ∀ u v x y z : FourString,
-      w = u ++ v ++ x ++ y ++ z →
+      makeString_anbncndn p = u ++ v ++ x ++ y ++ z →
       (v ++ x ++ y).length ≤ p →
       (v.length + y.length) ≥ 1 →
-      ∃ i : Nat, (u ++ List.flatten (List.replicate i v) ++ x ++
+      ∃ i : ℕ, (u ++ List.flatten (List.replicate i v) ++ x ++
                    List.flatten (List.replicate i y) ++ z) ∉ ambncmdn := by
-  intro w u v x y z hw hvxy_len hvy_len
-  use 0
+  intro u v x y z hw hvxy hvy
+  refine ⟨0, ?_⟩
   simp only [List.replicate_zero, List.flatten_nil, List.append_nil]
+  rintro ⟨m, n, hm⟩
   have hw' : makeString_anbncndn p = u ++ (v ++ x ++ y) ++ z := by
-    have : w = u ++ v ++ x ++ y ++ z := hw
-    simp only [List.append_assoc] at this ⊢; exact this
-  have hac := not_a_and_c_in_vxy p u (v ++ x ++ y) z hw' hvxy_len
-  have hbd := not_b_and_d_in_vxy p u (v ++ x ++ y) z hw' hvxy_len
-  show ¬ (isInLanguage_ambncmdn (u ++ x ++ z) = true)
-  intro hin
-  have huxz_ne : u ++ x ++ z ≠ [] := by
-    intro h
-    have huxz0 : u.length + x.length + z.length = 0 := by
-      have := congr_arg List.length h
-      simp only [List.length_append, List.length_nil] at this; omega
-    have hlen : u.length + v.length + x.length + y.length + z.length = 4 * p := by
-      have := congr_arg List.length hw'.symm
-      simp only [makeString_anbncndn, List.length_append, List.length_replicate] at this; omega
-    have hvxy_len' : v.length + x.length + y.length ≤ p := by
-      simp only [List.length_append] at hvxy_len; omega
-    omega
-  obtain ⟨h_ac, h_bd⟩ := counts_ambncmdn_of_inLanguage _ huxz_ne hin
-  -- For each symbol, count(uxz, s) + count(vy, s) = p
+    simp only [List.append_assoc] at hw ⊢; exact hw
+  have hac := not_a_and_c_in_vxy p u (v ++ x ++ y) z hw' hvxy
+  have hbd := not_b_and_d_in_vxy p u (v ++ x ++ y) z hw' hvxy
+  -- for each symbol: its count in `u ++ x ++ z`, plus those in `v` and `y`, is `p`
   have hrel : ∀ s : FourSymbol,
-      ((u ++ x ++ z).filter (· == s)).length +
-      (v.filter (· == s)).length + (y.filter (· == s)).length = p := by
-    intro s
-    have h1 := filter_count p s; rw [hw'] at h1
-    simp only [List.filter_append, List.length_append] at h1 ⊢; omega
-  -- count(vy, a) = count(vy, c) and count(vy, b) = count(vy, d)
-  have hac_vy : (v.filter (· == .a)).length + (y.filter (· == .a)).length =
-                (v.filter (· == .c)).length + (y.filter (· == .c)).length := by
-    have h_a := hrel .a; have h_c := hrel .c; omega
-  have hbd_vy : (v.filter (· == .b)).length + (y.filter (· == .b)).length =
-                (v.filter (· == .d)).length + (y.filter (· == .d)).length := by
-    have h_b := hrel .b; have h_d := hrel .d; omega
-  -- Show all four counts in vy are 0, contradicting |vy| ≥ 1
-  have ha_vy_zero : (v.filter (· == .a)).length + (y.filter (· == .a)).length = 0 := by
+      (u ++ x ++ z).count s + v.count s + y.count s = p := fun s => by
+    have h1 : (makeString_anbncndn p).count s = p := count_makeString_anbncndn p s
+    rw [hw] at h1
+    simp only [List.count_append] at h1 ⊢
+    omega
+  -- the two diagonal equalities transfer from `u ++ x ++ z` to the deleted window
+  have hac_vy : v.count .a + y.count .a = v.count .c + y.count .c := by
+    have ha := hrel .a; have hc := hrel .c
+    rw [hm] at ha hc; simp only [count_a_makeString_ambncmdn,
+      count_c_makeString_ambncmdn] at ha hc; omega
+  have hbd_vy : v.count .b + y.count .b = v.count .d + y.count .d := by
+    have hb := hrel .b; have hd := hrel .d
+    rw [hm] at hb hd; simp only [count_b_makeString_ambncmdn,
+      count_d_makeString_ambncmdn] at hb hd; omega
+  -- the window is too short to meet both blocks of either diagonal pair, so both are empty
+  have ha_zero : v.count .a + y.count .a = 0 := by
     by_cases ha : FourSymbol.a ∈ v ++ x ++ y
-    · have hc_notin : FourSymbol.c ∉ v ++ x ++ y := fun hc => hac ⟨ha, hc⟩
-      have hcv : FourSymbol.c ∉ v :=
-        fun h => hc_notin (List.mem_append_left _ (List.mem_append_left _ h))
-      have hcy : FourSymbol.c ∉ y :=
-        fun h => hc_notin (List.mem_append_right _ h)
-      rw [filter_eq_nil_of_not_mem v .c hcv, filter_eq_nil_of_not_mem y .c hcy] at hac_vy
-      simp only [List.length_nil, Nat.add_zero] at hac_vy; omega
-    · have hav : FourSymbol.a ∉ v :=
-        fun h => ha (List.mem_append_left _ (List.mem_append_left _ h))
-      have hay : FourSymbol.a ∉ y :=
-        fun h => ha (List.mem_append_right _ h)
-      rw [filter_eq_nil_of_not_mem v .a hav, filter_eq_nil_of_not_mem y .a hay]
-      simp only [List.length_nil, Nat.add_zero]
-  have hb_vy_zero : (v.filter (· == .b)).length + (y.filter (· == .b)).length = 0 := by
+    · have hc : FourSymbol.c ∉ v ++ x ++ y := fun hc => hac ⟨ha, hc⟩
+      have hcv : v.count .c = 0 := List.count_eq_zero.mpr fun h =>
+        hc (List.mem_append_left _ (List.mem_append_left _ h))
+      have hcy : y.count .c = 0 := List.count_eq_zero.mpr fun h => hc (List.mem_append_right _ h)
+      omega
+    · have hav : v.count .a = 0 := List.count_eq_zero.mpr fun h =>
+        ha (List.mem_append_left _ (List.mem_append_left _ h))
+      have hay : y.count .a = 0 := List.count_eq_zero.mpr fun h => ha (List.mem_append_right _ h)
+      omega
+  have hb_zero : v.count .b + y.count .b = 0 := by
     by_cases hb : FourSymbol.b ∈ v ++ x ++ y
-    · have hd_notin : FourSymbol.d ∉ v ++ x ++ y := fun hd => hbd ⟨hb, hd⟩
-      have hdv : FourSymbol.d ∉ v :=
-        fun h => hd_notin (List.mem_append_left _ (List.mem_append_left _ h))
-      have hdy : FourSymbol.d ∉ y :=
-        fun h => hd_notin (List.mem_append_right _ h)
-      rw [filter_eq_nil_of_not_mem v .d hdv, filter_eq_nil_of_not_mem y .d hdy] at hbd_vy
-      simp only [List.length_nil, Nat.add_zero] at hbd_vy; omega
-    · have hbv : FourSymbol.b ∉ v :=
-        fun h => hb (List.mem_append_left _ (List.mem_append_left _ h))
-      have hby : FourSymbol.b ∉ y :=
-        fun h => hb (List.mem_append_right _ h)
-      rw [filter_eq_nil_of_not_mem v .b hbv, filter_eq_nil_of_not_mem y .b hby]
-      simp only [List.length_nil, Nat.add_zero]
-  have hc_vy_zero : (v.filter (· == .c)).length + (y.filter (· == .c)).length = 0 := by
-    omega
-  have hd_vy_zero : (v.filter (· == .d)).length + (y.filter (· == .d)).length = 0 := by
-    omega
-  have hv_total := fourSymbol_filter_total v
-  have hy_total := fourSymbol_filter_total y
+    · have hd : FourSymbol.d ∉ v ++ x ++ y := fun hd => hbd ⟨hb, hd⟩
+      have hdv : v.count .d = 0 := List.count_eq_zero.mpr fun h =>
+        hd (List.mem_append_left _ (List.mem_append_left _ h))
+      have hdy : y.count .d = 0 := List.count_eq_zero.mpr fun h => hd (List.mem_append_right _ h)
+      omega
+    · have hbv : v.count .b = 0 := List.count_eq_zero.mpr fun h =>
+        hb (List.mem_append_left _ (List.mem_append_left _ h))
+      have hby : y.count .b = 0 := List.count_eq_zero.mpr fun h => hb (List.mem_append_right _ h)
+      omega
+  -- all four counts vanish in `v` and `y`, so the deleted window was empty
+  have hv := fourSymbol_count_total v
+  have hy := fourSymbol_count_total y
   omega
 
-/-- `{aᵐbⁿcᵐdⁿ}` does NOT have the CFL pumping property. -/
-theorem ambncmdn_not_pumpable :
-    ¬ HasCFLPumpingProperty ambncmdn := by
-  intro ⟨p, hp, hpump⟩
-  have hw_in := makeString_anbncndn_in_ambncmdn p
-  have hw_len : (makeString_anbncndn p).length ≥ p := by
-    simp only [makeString_anbncndn, List.length_append, List.length_replicate]; omega
-  obtain ⟨u, v, x, y, z, hw, hvxy, hvy, hall⟩ := hpump _ hw_in hw_len
+/-- `{aᵐbⁿcᵐdⁿ}` does not have the CFL pumping property. -/
+theorem ambncmdn_not_pumpable : ¬ HasCFLPumpingProperty ambncmdn := by
+  rintro ⟨p, hp, hpump⟩
+  obtain ⟨u, v, x, y, z, hw, hvxy, hvy, hall⟩ :=
+    hpump _ (makeString_anbncndn_in_ambncmdn p) (by rw [length_makeString_anbncndn]; omega)
   obtain ⟨i, hbreak⟩ := pump_breaks_ambncmdn p hp u v x y z hw hvxy hvy
   exact hbreak (hall i)
 
-/-- {aᵐbⁿcᵐdⁿ} is not context-free. The two-parameter relaxation that
-    [shieber-1985]'s Swiss German argument actually requires. -/
+/-- `{aᵐbⁿcᵐdⁿ}` is not context-free — the two-parameter relaxation that [shieber-1985]'s
+Swiss German argument requires. -/
 theorem ambncmdn_not_contextFree : ¬ Language.IsContextFree ambncmdn :=
   not_isContextFree_of_not_pumpable ambncmdn ambncmdn_not_pumpable

--- a/Linglib/Core/Computability/NonContextFree/AnBnCn.lean
+++ b/Linglib/Core/Computability/NonContextFree/AnBnCn.lean
@@ -2,54 +2,60 @@ import Linglib.Core.Computability.ContextFreeGrammar.Pumping
 import Linglib.Core.Computability.NonContextFree.BlockWitness
 
 /-!
-# {aⁿbⁿcⁿ}: a three-symbol non-context-free witness language
+# `{aⁿbⁿcⁿ}`: a three-symbol non-context-free witness
 
-The classical three-symbol non-context-free witness `anbnc = {aⁿbⁿcⁿ | n ≥ 0}`,
-proven non-context-free via the CFL pumping lemma + the unified adjacency
-lemma in `BlockWitness`.
+The classical three-symbol witness `anbnc = {aⁿbⁿcⁿ | n ≥ 0}`, shown non-context-free by the
+CFL pumping lemma together with the adjacency lemma of `BlockWitness`: a pumped window short
+enough to fit inside the witness cannot meet both the `a`-block and the `c`-block, so pumping
+down leaves some symbol's count untouched while shortening the word.
 
-Independent of `AnBnCnDn` and `AmBnCmDn` — uses its own `ThreeSymbol`
-alphabet and parallel filter-count machinery.
+Independent of `AnBnCnDn` and `AmBnCmDn`: it uses its own `ThreeSymbol` alphabet.
+
+## Main definitions
+
+* `makeString_anbnc n`: the witness word `aⁿbⁿcⁿ`.
+* `anbnc`: the language `{aⁿbⁿcⁿ | n ≥ 0}`, as the range of `makeString_anbnc`.
+
+## Main results
+
+* `anbnc_not_pumpable`: `anbnc` lacks the CFL pumping property.
+* `anbnc_not_contextFree`: `anbnc` is not context-free.
 -/
 
-/-- Alphabet for {aⁿbⁿcⁿ}. -/
+/-- Alphabet for `{aⁿbⁿcⁿ}`. -/
 inductive ThreeSymbol where
   | a | b | c
   deriving DecidableEq, Repr
 
-instance : LawfulBEq ThreeSymbol where
-  eq_of_beq {x y} h := by cases x <;> cases y <;> first | rfl | exact absurd h (by decide)
-  rfl {x} := by cases x <;> decide
-
-/-- The language {aⁿbⁿcⁿ | n ≥ 0}. -/
-def isInLanguage_anbnc (w : List ThreeSymbol) : Bool :=
-  match w with
-  | [] => true
-  | _ =>
-    let na := w.filter (· == .a) |>.length
-    let nb := w.filter (· == .b) |>.length
-    let nc := w.filter (· == .c) |>.length
-    na == nb && nb == nc &&
-    w == List.replicate na .a ++ List.replicate nb .b ++ List.replicate nc .c
-
-/-- Generate aⁿbⁿcⁿ. -/
-def makeString_anbnc (n : Nat) : List ThreeSymbol :=
+/-- The witness word `aⁿbⁿcⁿ`. -/
+def makeString_anbnc (n : ℕ) : List ThreeSymbol :=
   List.replicate n .a ++ List.replicate n .b ++ List.replicate n .c
 
-#guard isInLanguage_anbnc (makeString_anbnc 3)
+/-- The language `{aⁿbⁿcⁿ | n ≥ 0}`, as the range of `makeString_anbnc`. -/
+def anbnc : Language ThreeSymbol := {w | ∃ n, w = makeString_anbnc n}
 
-/-- The language {aⁿbⁿcⁿ | n ≥ 0} as a mathlib `Language`. -/
-def anbnc : Language ThreeSymbol := {w | isInLanguage_anbnc w = true}
+/-- Membership characterization: every string in `anbnc` is `makeString_anbnc n` for some `n`.
+Consumed by the homomorphic reduction `aⁿbⁿcⁿdⁿ → aⁿbⁿcⁿ` in `AnBnCnDn`. -/
+theorem mem_anbnc_iff (w : List ThreeSymbol) : w ∈ anbnc ↔ ∃ n, w = makeString_anbnc n := Iff.rfl
+
+theorem makeString_anbnc_mem (n : ℕ) : makeString_anbnc n ∈ anbnc := ⟨n, rfl⟩
+
+/-- Each of the three symbols occurs exactly `n` times in the witness. -/
+@[simp] theorem count_makeString_anbnc (n : ℕ) (s : ThreeSymbol) :
+    (makeString_anbnc n).count s = n := by
+  cases s <;> simp [makeString_anbnc, List.count_replicate]
+
+@[simp] theorem length_makeString_anbnc (n : ℕ) : (makeString_anbnc n).length = 3 * n := by
+  simp [makeString_anbnc]; omega
 
 /-- The three-symbol witness is structurally `BlockWitness [a, b, c] n`. -/
-private theorem makeString_anbnc_eq_blockwitness (n : Nat) :
-    makeString_anbnc n =
-      BlockWitness ([ThreeSymbol.a, .b, .c] : List ThreeSymbol) n := by
+private theorem makeString_anbnc_eq_blockwitness (n : ℕ) :
+    makeString_anbnc n = BlockWitness ([ThreeSymbol.a, .b, .c] : List ThreeSymbol) n := by
   simp [makeString_anbnc, BlockWitness, List.flatMap_cons, List.flatMap_nil,
         List.append_nil, List.append_assoc]
 
-/-- Adjacency in the ThreeSymbol witness via the unified `BlockWitness.not_both_in_vxy`. -/
-private theorem not_a_and_c_in_vxy3 (p : Nat) (u vxy z : List ThreeSymbol)
+/-- A window short enough to fit inside the witness cannot meet both the `a`- and `c`-blocks. -/
+private theorem not_a_and_c_in_vxy3 (p : ℕ) (u vxy z : List ThreeSymbol)
     (hw : makeString_anbnc p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
     ¬(ThreeSymbol.a ∈ vxy ∧ ThreeSymbol.c ∈ vxy) :=
   BlockWitness.not_both_in_vxy
@@ -57,149 +63,48 @@ private theorem not_a_and_c_in_vxy3 (p : Nat) (u vxy z : List ThreeSymbol)
     (i := 0) (j := 2) rfl rfl (by decide)
     (makeString_anbnc_eq_blockwitness p ▸ hw) hvxy
 
-private theorem filter_count3 (n : Nat) (s : ThreeSymbol) :
-    ((makeString_anbnc n).filter (· == s)).length = n := by
-  simp only [makeString_anbnc, List.filter_append, List.filter_replicate, List.length_append]
-  cases s <;> simp (config := { decide := true })
+/-- `{aⁿbⁿcⁿ}` does not have the CFL pumping property.
 
-private theorem filter_eq_nil3 (l : List ThreeSymbol) (s : ThreeSymbol) (h : s ∉ l) :
-    l.filter (· == s) = [] := by
-  rw [List.filter_eq_nil_iff]
-  intro x hx heq; exact h (beq_iff_eq.mp heq ▸ hx)
-
-private theorem counts_eq3 (w : List ThreeSymbol) (hne : w ≠ [])
-    (hin : isInLanguage_anbnc w = true) :
-    (w.filter (· == .a)).length = (w.filter (· == .b)).length ∧
-    (w.filter (· == .b)).length = (w.filter (· == .c)).length := by
-  unfold isInLanguage_anbnc at hin
-  match w, hne with
-  | _ :: _, _ =>
-    simp only [Bool.and_eq_true, beq_iff_eq] at hin
-    exact ⟨hin.1.1, hin.1.2⟩
-
-private theorem threeSymbol_filter_total (l : List ThreeSymbol) :
-    (l.filter (· == .a)).length + (l.filter (· == .b)).length +
-    (l.filter (· == .c)).length = l.length := by
-  induction l with
-  | nil => simp
-  | cons h t ih =>
-    simp only [List.filter_cons, List.length_cons]
-    cases h <;> simp <;> omega
-
-private theorem isInLang3_nonempty (w : List ThreeSymbol) (h : w ≠ []) :
-    isInLanguage_anbnc w = (
-      let na := (w.filter (· == .a)).length
-      let nb := (w.filter (· == .b)).length
-      let nc := (w.filter (· == .c)).length
-      na == nb && nb == nc &&
-      w == List.replicate na .a ++ List.replicate nb .b ++ List.replicate nc .c) := by
-  unfold isInLanguage_anbnc; match w, h with | _ :: _, _ => rfl
-
-private theorem makeString_anbnc_in_language (n : Nat) :
-    makeString_anbnc n ∈ anbnc := by
-  show isInLanguage_anbnc (makeString_anbnc n) = true
-  cases n with
-  | zero => rfl
-  | succ k =>
-    have hne : makeString_anbnc (k + 1) ≠ [] := by
-      simp [makeString_anbnc, List.replicate_succ]
-    rw [isInLang3_nonempty _ hne]
-    simp only [filter_count3, beq_self_eq_true, Bool.and_self, Bool.true_and]
-    change (makeString_anbnc (k + 1) == makeString_anbnc (k + 1)) = true
-    exact beq_self_eq_true _
-
-/-- Membership characterization: every string in `anbnc` is `makeString_anbnc n`
-    for some `n`. Mirror of `mem_anbncndn_iff`; consumed by the homomorphic
-    reduction aⁿbⁿcⁿdⁿ → aⁿbⁿcⁿ in `AnBnCnDn`. -/
-theorem mem_anbnc_iff (w : List ThreeSymbol) :
-    w ∈ anbnc ↔ ∃ n, w = makeString_anbnc n := by
-  constructor
-  · intro hw
-    by_cases hempty : w = []
-    · exact ⟨0, by rw [hempty]; rfl⟩
-    · have heq := isInLang3_nonempty w hempty
-      have hw' : isInLanguage_anbnc w = true := hw
-      rw [heq] at hw'
-      simp only [Bool.and_eq_true, beq_iff_eq] at hw'
-      obtain ⟨⟨h_ab, h_bc⟩, h_eq⟩ := hw'
-      refine ⟨(w.filter (· == .a)).length, ?_⟩
-      have hb_eq : (w.filter (· == .b)).length = (w.filter (· == .a)).length := h_ab.symm
-      have hc_eq : (w.filter (· == .c)).length = (w.filter (· == .a)).length :=
-        h_bc.symm.trans h_ab.symm
-      calc w
-          = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .b)).length .b ++
-              List.replicate (w.filter (· == .c)).length .c := h_eq
-        _ = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .a)).length .b ++
-              List.replicate (w.filter (· == .a)).length .c := by rw [hb_eq, hc_eq]
-        _ = makeString_anbnc (w.filter (· == .a)).length := rfl
-  · rintro ⟨n, rfl⟩
-    exact makeString_anbnc_in_language n
-
-set_option maxHeartbeats 800000 in
-/-- {aⁿbⁿcⁿ} does NOT have the CFL pumping property. -/
-theorem anbnc_not_pumpable :
-    ¬ HasCFLPumpingProperty anbnc := by
-  intro ⟨p, hp, hpump⟩
-  have hw_in := makeString_anbnc_in_language p
-  have hw_len : (makeString_anbnc p).length ≥ p := by
-    simp only [makeString_anbnc, List.length_append, List.length_replicate]; omega
-  obtain ⟨u, v, x, y, z, hw, hvxy, hvy, hall⟩ := hpump _ hw_in hw_len
+Pumping down to `i = 0` gives `u ++ x ++ z = makeString_anbnc m`, so *every* symbol occurs `m`
+times there. The pumped-out window is too short to meet both the `a`- and the `c`-block, so one
+of those two symbols is absent from `v` and `y` — forcing `m = p`, while the removed window
+makes the word strictly shorter. -/
+theorem anbnc_not_pumpable : ¬ HasCFLPumpingProperty anbnc := by
+  rintro ⟨p, hp, hpump⟩
+  obtain ⟨u, v, x, y, z, hw, hvxy, hvy, hall⟩ :=
+    hpump _ (makeString_anbnc_mem p) (by rw [length_makeString_anbnc]; omega)
+  obtain ⟨m, hm⟩ := hall 0
+  simp only [List.replicate_zero, List.flatten_nil, List.append_nil] at hm
   have hw' : makeString_anbnc p = u ++ (v ++ x ++ y) ++ z := by
-    have : _ = u ++ v ++ x ++ y ++ z := hw
-    simp only [List.append_assoc] at this ⊢; exact this
+    simp only [List.append_assoc] at hw ⊢; exact hw
   have hcontig := not_a_and_c_in_vxy3 p u (v ++ x ++ y) z hw' hvxy
-  suffices ∃ i, (u ++ List.flatten (List.replicate i v) ++ x ++
-      List.flatten (List.replicate i y) ++ z) ∉ anbnc by
-    obtain ⟨i, hbreak⟩ := this
-    exact hbreak (hall i)
-  use 0
-  simp only [List.replicate_zero, List.flatten_nil, List.append_nil]
-  show ¬ (isInLanguage_anbnc (u ++ x ++ z) = true)
-  intro hin
-  have huxz_ne : u ++ x ++ z ≠ [] := by
-    intro h
-    have huxz0 : u.length + x.length + z.length = 0 := by
-      have := congr_arg List.length h; simp only [List.length_append, List.length_nil] at this; omega
-    have hlen : u.length + v.length + x.length + y.length + z.length = 3 * p := by
-      have := congr_arg List.length hw'.symm
-      simp only [makeString_anbnc, List.length_append, List.length_replicate] at this; omega
-    have : v.length + x.length + y.length ≤ p := by
-      simp only [List.length_append] at hvxy; omega
+  have hcount : ∀ s : ThreeSymbol, p = m + v.count s + y.count s := fun s => by
+    have h1 : (makeString_anbnc p).count s = p := count_makeString_anbnc p s
+    have h2 : (u ++ x ++ z).count s = m := by rw [hm]; exact count_makeString_anbnc m s
+    rw [hw] at h1
+    simp only [List.count_append] at h1 h2
     omega
-  obtain ⟨hab, hbc⟩ := counts_eq3 _ huxz_ne hin
-  have hrel : ∀ s : ThreeSymbol,
-      ((u ++ x ++ z).filter (· == s)).length +
-      (v.filter (· == s)).length + (y.filter (· == s)).length = p := by
-    intro s
-    have h1 := filter_count3 p s; rw [hw'] at h1
-    simp only [List.filter_append, List.length_append] at h1 ⊢; omega
-  have h3k : 3 * ((u ++ x ++ z).filter (· == .a)).length = (u ++ x ++ z).length := by
-    have := threeSymbol_filter_total (u ++ x ++ z); omega
-  have hlen_uxz : (u ++ x ++ z).length + (v.length + y.length) = 3 * p := by
-    have hlen : (makeString_anbnc p).length = 3 * p := by
-      simp [makeString_anbnc, List.length_append, List.length_replicate]; omega
-    rw [hw'] at hlen; simp only [List.length_append] at hlen ⊢; omega
-  have hk_eq_p : ((u ++ x ++ z).filter (· == .a)).length = p := by
-    by_cases ha : ThreeSymbol.a ∈ (v ++ x ++ y)
-    · have hc : ThreeSymbol.c ∉ (v ++ x ++ y) := fun hc => hcontig ⟨ha, hc⟩
-      have hcv : ThreeSymbol.c ∉ v :=
-        fun h => hc (List.mem_append_left _ (List.mem_append_left _ h))
-      have hcy : ThreeSymbol.c ∉ y :=
-        fun h => hc (List.mem_append_right _ h)
-      have hrc := hrel .c
-      rw [filter_eq_nil3 v .c hcv, filter_eq_nil3 y .c hcy] at hrc
-      simp only [List.length_nil, Nat.add_zero] at hrc; omega
-    · have hav : ThreeSymbol.a ∉ v :=
-        fun h => ha (List.mem_append_left _ (List.mem_append_left _ h))
-      have hay : ThreeSymbol.a ∉ y :=
-        fun h => ha (List.mem_append_right _ h)
-      have hra := hrel .a
-      rw [filter_eq_nil3 v .a hav, filter_eq_nil3 y .a hay] at hra
-      simp only [List.length_nil, Nat.add_zero] at hra; exact hra
+  have hlen : 3 * p = 3 * m + v.length + y.length := by
+    have h1 : (makeString_anbnc p).length = 3 * p := length_makeString_anbnc p
+    have h2 : (u ++ x ++ z).length = 3 * m := by rw [hm]; exact length_makeString_anbnc m
+    rw [hw] at h1
+    simp only [List.length_append] at h1 h2
+    omega
+  have hpm : p = m := by
+    by_cases ha : ThreeSymbol.a ∈ v ++ x ++ y
+    · have hc : ThreeSymbol.c ∉ v ++ x ++ y := fun hc => hcontig ⟨ha, hc⟩
+      have hcv : v.count .c = 0 := List.count_eq_zero.mpr fun h =>
+        hc (List.mem_append_left _ (List.mem_append_left _ h))
+      have hcy : y.count .c = 0 := List.count_eq_zero.mpr fun h => hc (List.mem_append_right _ h)
+      have := hcount .c
+      omega
+    · have hav : v.count .a = 0 := List.count_eq_zero.mpr fun h =>
+        ha (List.mem_append_left _ (List.mem_append_left _ h))
+      have hay : y.count .a = 0 := List.count_eq_zero.mpr fun h => ha (List.mem_append_right _ h)
+      have := hcount .a
+      omega
   omega
 
-/-- {aⁿbⁿcⁿ} is not context-free. -/
+/-- `{aⁿbⁿcⁿ}` is not context-free. -/
 theorem anbnc_not_contextFree : ¬ Language.IsContextFree anbnc :=
   not_isContextFree_of_not_pumpable anbnc anbnc_not_pumpable

--- a/Linglib/Core/Computability/NonContextFree/AnBnCnDn.lean
+++ b/Linglib/Core/Computability/NonContextFree/AnBnCnDn.lean
@@ -3,30 +3,33 @@ import Linglib.Core.Computability.NonContextFree.AnBnCn
 import Linglib.Core.Computability.ContextFreeGrammar.Closure
 
 /-!
-# {aⁿbⁿcⁿdⁿ}: a four-symbol non-context-free witness language
+# `{aⁿbⁿcⁿdⁿ}`: a four-symbol non-context-free witness
 
 The single-parameter four-symbol witness `anbncndn = {aⁿbⁿcⁿdⁿ | n ≥ 0}`.
-Membership requires `na = nb = nc = nd` (all four counts equal) **and** the
-sorted shape `aⁿbⁿcⁿdⁿ`.
 
-Non-context-freeness is **derived by closure, not re-proved by pumping**: the
-erasing homomorphism `dropD : d ↦ ε` maps `anbncndn` exactly onto the irreducible
-counting core `anbnc = {aⁿbⁿcⁿ}` (`AnBnCn`), so `anbncndn_not_contextFree`
-follows from `anbnc_not_contextFree` through `Language.IsContextFree.stringMap`
-(the hom-closure root in `Map`, run contrapositively via `Closure`). aⁿbⁿcⁿdⁿ is
-the *nested-counting* case; the genuinely *crossing* witness that [shieber-1985]'s
-Swiss-German argument requires is the two-parameter `ambncmdn` sibling, which does
-not reduce by single-symbol erasure.
+Non-context-freeness is **derived by closure, not re-proved by pumping**: the erasing
+homomorphism `dropD : d ↦ ε` maps `anbncndn` exactly onto the counting core
+`anbnc = {aⁿbⁿcⁿ}`, so `anbncndn_not_contextFree` follows from `anbnc_not_contextFree` through
+`Language.IsContextFree.stringMap`. `aⁿbⁿcⁿdⁿ` is the *nested*-counting case; the genuinely
+*crossing* witness is the two-parameter `ambncmdn` sibling, which does not reduce by
+single-symbol erasure.
 
-This file also hosts the **shared `FourSymbol` substrate** consumed by the
-two-parameter relaxation in `NonContextFree.AmBnCmDn`:
+This file also hosts the `FourSymbol` substrate shared with `NonContextFree.AmBnCmDn`: the
+alphabet, the witness-form bridge to `BlockWitness`, and the two adjacency consequences.
 
-* The alphabet (`FourSymbol`, `FourString`, `LawfulBEq`).
-* Witness-form bridges (`makeString_anbncndn_eq_blockwitness`).
-* Adjacency consequences via `BlockWitness.not_both_in_vxy`
-  (`not_a_and_c_in_vxy`, `not_b_and_d_in_vxy`).
-* Filter-count machinery (`filter_count`, `filter_eq_nil_of_not_mem`,
-  `fourSymbol_filter_total`).
+## Main definitions
+
+* `FourSymbol`, `FourString`: the shared four-letter alphabet and its words.
+* `makeString_anbncndn n`: the witness word `aⁿbⁿcⁿdⁿ`.
+* `anbncndn`: the language `{aⁿbⁿcⁿdⁿ | n ≥ 0}`, as the range of `makeString_anbncndn`.
+* `dropD`: the erasing homomorphism `d ↦ ε` witnessing the reduction to `anbnc`.
+
+## Main results
+
+* `not_a_and_c_in_vxy` / `not_b_and_d_in_vxy`: a window of length `≤ p` cannot meet two
+  blocks that are not adjacent.
+* `stringMap_dropD_anbncndn`: `dropD` maps `anbncndn` onto `anbnc`.
+* `anbncndn_not_contextFree`: `anbncndn` is not context-free.
 -/
 
 /-- Alphabet for the four-symbol counting witness languages. -/
@@ -34,190 +37,94 @@ inductive FourSymbol where
   | a | b | c | d
   deriving DecidableEq, Repr
 
-instance : LawfulBEq FourSymbol where
-  eq_of_beq {x y} h := by cases x <;> cases y <;> first | rfl | exact absurd h (by decide)
-  rfl {x} := by cases x <;> decide
-
+/-- Words over the four-symbol alphabet. -/
 abbrev FourString := List FourSymbol
 
-/-- The language {aⁿbⁿcⁿdⁿ | n ≥ 0}: the pedagogical four-symbol counting language. The
-    genuinely *crossing* witness that [shieber-1985]'s Swiss-German non-context-freeness
-    argument requires is the two-parameter `ambncmdn` sibling; this single-parameter
-    language is the nested-counting case (cf. [bresnan-etal-1982] on Dutch cross-serial
-    word order, which is itself only weakly context-free). -/
-def isInLanguage_anbncndn (w : FourString) : Bool :=
-  match w with
-  | [] => true
-  | _ =>
-    let na := w.filter (· == .a) |>.length
-    let nb := w.filter (· == .b) |>.length
-    let nc := w.filter (· == .c) |>.length
-    let nd := w.filter (· == .d) |>.length
-    na == nb && nb == nc && nc == nd &&
-    w == List.replicate na .a ++ List.replicate nb .b ++
-         List.replicate nc .c ++ List.replicate nd .d
-
-/-- Generate aⁿbⁿcⁿdⁿ. -/
-def makeString_anbncndn (n : Nat) : FourString :=
+/-- The witness word `aⁿbⁿcⁿdⁿ`. -/
+def makeString_anbncndn (n : ℕ) : FourString :=
   List.replicate n .a ++ List.replicate n .b ++
   List.replicate n .c ++ List.replicate n .d
 
-#guard isInLanguage_anbncndn []
-#guard isInLanguage_anbncndn (makeString_anbncndn 0)
-#guard isInLanguage_anbncndn (makeString_anbncndn 1)
-#guard isInLanguage_anbncndn (makeString_anbncndn 2)
-#guard isInLanguage_anbncndn (makeString_anbncndn 3)
-#guard !isInLanguage_anbncndn [.a, .b, .c]
-#guard !isInLanguage_anbncndn [.a, .a, .b, .c, .c, .d]
+/-- The language `{aⁿbⁿcⁿdⁿ | n ≥ 0}`, as the range of `makeString_anbncndn`. -/
+def anbncndn : Language FourSymbol := {w | ∃ n, w = makeString_anbncndn n}
 
-/-- The language {aⁿbⁿcⁿdⁿ | n ≥ 0} as a mathlib `Language`. -/
-def anbncndn : Language FourSymbol := {w | isInLanguage_anbncndn w = true}
+/-- Membership characterization: every string in `anbncndn` is `makeString_anbncndn n` for
+some `n`. -/
+theorem mem_anbncndn_iff (w : FourString) :
+    w ∈ anbncndn ↔ ∃ n, w = makeString_anbncndn n := Iff.rfl
 
-/-- Unfold `isInLanguage_anbncndn` on a nonempty string. -/
-private theorem isInLang_nonempty (w : FourString) (h : w ≠ []) :
-    isInLanguage_anbncndn w = (
-      let na := (w.filter (· == .a)).length
-      let nb := (w.filter (· == .b)).length
-      let nc := (w.filter (· == .c)).length
-      let nd := (w.filter (· == .d)).length
-      na == nb && nb == nc && nc == nd &&
-      w == List.replicate na .a ++ List.replicate nb .b ++
-           List.replicate nc .c ++ List.replicate nd .d) := by
-  unfold isInLanguage_anbncndn
-  match w, h with
-  | _ :: _, _ => rfl
+theorem makeString_in_language (n : ℕ) : makeString_anbncndn n ∈ anbncndn := ⟨n, rfl⟩
 
--- ============================================================================
--- Shared FourSymbol substrate (consumed by AmBnCmDn for the diagonal witness)
--- ============================================================================
+/-- Each of the four symbols occurs exactly `n` times in the witness. Shared with `AmBnCmDn`,
+which pumps over the same diagonal witness. -/
+@[simp] theorem count_makeString_anbncndn (n : ℕ) (s : FourSymbol) :
+    (makeString_anbncndn n).count s = n := by
+  cases s <;> simp [makeString_anbncndn, List.count_replicate]
 
-/-- Each symbol's filter count in `makeString_anbncndn n` equals `n`. Shared
-    with `AmBnCmDn` (which pumps over the same diagonal witness). -/
-theorem filter_count (n : Nat) (s : FourSymbol) :
-    ((makeString_anbncndn n).filter (· == s)).length = n := by
-  simp only [makeString_anbncndn, List.filter_append, List.filter_replicate, List.length_append]
-  cases s <;> simp (config := { decide := true })
+@[simp] theorem length_makeString_anbncndn (n : ℕ) :
+    (makeString_anbncndn n).length = 4 * n := by
+  simp [makeString_anbncndn]; omega
+
+/-- The four symbol counts of a word sum to its length. -/
+theorem fourSymbol_count_total (l : FourString) :
+    l.count .a + l.count .b + l.count .c + l.count .d = l.length := by
+  induction l with
+  | nil => simp
+  | cons h t ih => cases h <;> simp <;> omega
 
 /-- The four-symbol witness is structurally `BlockWitness [a, b, c, d] n`. -/
-theorem makeString_anbncndn_eq_blockwitness (n : Nat) :
+theorem makeString_anbncndn_eq_blockwitness (n : ℕ) :
     makeString_anbncndn n =
       BlockWitness ([FourSymbol.a, .b, .c, .d] : List FourSymbol) n := by
   simp [makeString_anbncndn, BlockWitness, List.flatMap_cons, List.flatMap_nil,
         List.append_nil, List.append_assoc]
 
-/-- Adjacency in the FourSymbol witness via the unified `BlockWitness.not_both_in_vxy`.
-    Each instance is a one-line invocation parameterized by symbol indices. -/
-private theorem not_both_in_vxy_FourSymbol {s t : FourSymbol} {i j : Nat}
+/-- Adjacency in the `FourSymbol` witness via the unified `BlockWitness.not_both_in_vxy`:
+each instance is a one-line invocation parameterized by symbol indices. -/
+private theorem not_both_in_vxy_FourSymbol {s t : FourSymbol} {i j : ℕ}
     (hi : ([FourSymbol.a, .b, .c, .d] : List FourSymbol)[i]? = some s)
     (hj : ([FourSymbol.a, .b, .c, .d] : List FourSymbol)[j]? = some t)
-    (hij : j ≥ i + 2) (p : Nat) (u vxy z : FourString)
+    (hij : j ≥ i + 2) (p : ℕ) (u vxy z : FourString)
     (hw : makeString_anbncndn p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
     ¬ (s ∈ vxy ∧ t ∈ vxy) :=
   BlockWitness.not_both_in_vxy
     (by decide : ([FourSymbol.a, .b, .c, .d] : List FourSymbol).Nodup)
     hi hj hij (makeString_anbncndn_eq_blockwitness p ▸ hw) hvxy
 
-theorem not_a_and_c_in_vxy (p : Nat) (u vxy z : FourString)
+theorem not_a_and_c_in_vxy (p : ℕ) (u vxy z : FourString)
     (hw : makeString_anbncndn p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
     ¬(FourSymbol.a ∈ vxy ∧ FourSymbol.c ∈ vxy) :=
   not_both_in_vxy_FourSymbol (i := 0) (j := 2) rfl rfl (by decide) p u vxy z hw hvxy
 
-theorem not_b_and_d_in_vxy (p : Nat) (u vxy z : FourString)
+theorem not_b_and_d_in_vxy (p : ℕ) (u vxy z : FourString)
     (hw : makeString_anbncndn p = u ++ vxy ++ z) (hvxy : vxy.length ≤ p) :
     ¬(FourSymbol.b ∈ vxy ∧ FourSymbol.d ∈ vxy) :=
   not_both_in_vxy_FourSymbol (i := 1) (j := 3) rfl rfl (by decide) p u vxy z hw hvxy
 
-theorem filter_eq_nil_of_not_mem (l : FourString) (s : FourSymbol) (h : s ∉ l) :
-    l.filter (· == s) = [] := by
-  rw [List.filter_eq_nil_iff]
-  intro x hx heq; exact h (beq_iff_eq.mp heq ▸ hx)
+/-! ### Non-context-freeness by homomorphic reduction to `{aⁿbⁿcⁿ}` -/
 
-theorem fourSymbol_filter_total (l : FourString) :
-    (l.filter (· == .a)).length + (l.filter (· == .b)).length +
-    (l.filter (· == .c)).length + (l.filter (· == .d)).length = l.length := by
-  induction l with
-  | nil => simp
-  | cons h t ih =>
-    simp only [List.filter_cons, List.length_cons]
-    cases h <;> simp <;> omega
-
--- ============================================================================
--- Membership characterizations
--- ============================================================================
-
-/-- makeString_anbncndn n is always in {aⁿbⁿcⁿdⁿ}. -/
-theorem makeString_in_language (n : Nat) :
-    makeString_anbncndn n ∈ anbncndn := by
-  show isInLanguage_anbncndn (makeString_anbncndn n) = true
-  cases n with
-  | zero => rfl
-  | succ k =>
-    have hne : makeString_anbncndn (k + 1) ≠ [] := by
-      simp [makeString_anbncndn, List.replicate_succ]
-    rw [isInLang_nonempty _ hne]
-    simp only [filter_count, beq_self_eq_true, Bool.and_self, Bool.true_and]
-    change (makeString_anbncndn (k + 1) == makeString_anbncndn (k + 1)) = true
-    exact beq_self_eq_true _
-
-/-- Membership characterization: every string in `anbncndn` is `makeString_anbncndn n`
-    for some `n`. The converse to `makeString_in_language`. -/
-theorem mem_anbncndn_iff (w : FourString) :
-    w ∈ anbncndn ↔ ∃ n, w = makeString_anbncndn n := by
-  constructor
-  · intro hw
-    by_cases hempty : w = []
-    · exact ⟨0, by rw [hempty]; rfl⟩
-    · have heq := isInLang_nonempty w hempty
-      have hw' : isInLanguage_anbncndn w = true := hw
-      rw [heq] at hw'
-      simp only [Bool.and_eq_true, beq_iff_eq] at hw'
-      obtain ⟨⟨⟨h_ab, h_bc⟩, h_cd⟩, h_eq⟩ := hw'
-      refine ⟨(w.filter (· == .a)).length, ?_⟩
-      have hb_eq : (w.filter (· == .b)).length = (w.filter (· == .a)).length := h_ab.symm
-      have hc_eq : (w.filter (· == .c)).length = (w.filter (· == .a)).length :=
-        h_bc.symm.trans h_ab.symm
-      have hd_eq : (w.filter (· == .d)).length = (w.filter (· == .a)).length :=
-        h_cd.symm.trans (h_bc.symm.trans h_ab.symm)
-      calc w
-          = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .b)).length .b ++
-              List.replicate (w.filter (· == .c)).length .c ++
-              List.replicate (w.filter (· == .d)).length .d := h_eq
-        _ = List.replicate (w.filter (· == .a)).length .a ++
-              List.replicate (w.filter (· == .a)).length .b ++
-              List.replicate (w.filter (· == .a)).length .c ++
-              List.replicate (w.filter (· == .a)).length .d := by
-              rw [hb_eq, hc_eq, hd_eq]
-        _ = makeString_anbncndn (w.filter (· == .a)).length := rfl
-  · rintro ⟨n, rfl⟩
-    exact makeString_in_language n
-
--- ============================================================================
--- Non-context-freeness by homomorphic reduction to {aⁿbⁿcⁿ}
--- ============================================================================
-
-/-- The erasing homomorphism `d ↦ ε` (per-symbol map; the string action is
-    `List.flatMap dropD`, the free-monoid lift), relabelling the surviving a/b/c into
-    the `ThreeSymbol` alphabet. The witness for the reduction aⁿbⁿcⁿdⁿ → aⁿbⁿcⁿ. -/
+/-- The erasing homomorphism `d ↦ ε` (a per-symbol map; the string action is
+`List.flatMap dropD`, the free-monoid lift), relabelling the surviving `a`/`b`/`c` into the
+`ThreeSymbol` alphabet. -/
 def dropD : FourSymbol → List ThreeSymbol
   | FourSymbol.a => [ThreeSymbol.a]
   | FourSymbol.b => [ThreeSymbol.b]
   | FourSymbol.c => [ThreeSymbol.c]
   | FourSymbol.d => []
 
-private theorem flatten_replicate_singleton {α : Type*} (n : Nat) (x : α) :
+private theorem flatten_replicate_singleton {α : Type*} (n : ℕ) (x : α) :
     (List.replicate n [x]).flatten = List.replicate n x := by
   induction n with
   | zero => rfl
   | succ k ih => simp [List.replicate_succ, ih]
 
-private theorem flatten_replicate_nil {α : Type*} (n : Nat) :
+private theorem flatten_replicate_nil {α : Type*} (n : ℕ) :
     (List.replicate n ([] : List α)).flatten = [] := by
   induction n with
   | zero => rfl
   | succ k ih => simp [List.replicate_succ, ih]
 
-private theorem dropD_replicate (n : Nat) (s : FourSymbol) :
+private theorem dropD_replicate (n : ℕ) (s : FourSymbol) :
     List.flatMap dropD (List.replicate n s) =
       List.flatten (List.replicate n (dropD s)) := by
   induction n with
@@ -226,28 +133,24 @@ private theorem dropD_replicate (n : Nat) (s : FourSymbol) :
     rw [List.replicate_succ, List.flatMap_cons, ih, List.replicate_succ, List.flatten_cons]
 
 /-- `dropD` erases the `dⁿ` block and relabels, sending the witness to `makeString_anbnc n`. -/
-@[simp] theorem dropD_makeString (n : Nat) :
+@[simp] theorem dropD_makeString (n : ℕ) :
     List.flatMap dropD (makeString_anbncndn n) = makeString_anbnc n := by
   simp only [makeString_anbncndn, List.flatMap_append, dropD_replicate, dropD,
              flatten_replicate_singleton, flatten_replicate_nil, List.append_nil, makeString_anbnc]
 
-/-- `dropD` maps `anbncndn` exactly onto the counting core `anbnc`. This image
-    equality is what powers the closure reduction. -/
+/-- `dropD` maps `anbncndn` exactly onto the counting core `anbnc`. This image equality is what
+powers the closure reduction. -/
 theorem stringMap_dropD_anbncndn : Language.stringMap dropD anbncndn = anbnc := by
   ext w
   rw [Language.mem_stringMap]
   constructor
-  · rintro ⟨v, hv, rfl⟩
-    obtain ⟨n, rfl⟩ := (mem_anbncndn_iff v).mp hv
-    rw [dropD_makeString]
-    exact (mem_anbnc_iff _).mpr ⟨n, rfl⟩
-  · intro hw
-    obtain ⟨n, rfl⟩ := (mem_anbnc_iff w).mp hw
+  · rintro ⟨v, ⟨n, rfl⟩, rfl⟩
+    exact ⟨n, (dropD_makeString n).symm ▸ rfl⟩
+  · rintro ⟨n, rfl⟩
     exact ⟨makeString_anbncndn n, makeString_in_language n, dropD_makeString n⟩
 
-/-- **{aⁿbⁿcⁿdⁿ} is not context-free** — derived by closure from the counting
-    core `anbnc_not_contextFree` via the erasing homomorphism `dropD`, rather than
-    re-proved by pumping. -/
+/-- `{aⁿbⁿcⁿdⁿ}` is not context-free — derived by closure from `anbnc_not_contextFree` via the
+erasing homomorphism `dropD`, rather than re-proved by pumping. -/
 theorem anbncndn_not_contextFree : ¬ Language.IsContextFree anbncndn :=
   Language.not_isContextFree_of_stringMap_not dropD
     (by rw [stringMap_dropD_anbncndn]; exact anbnc_not_contextFree)

--- a/Linglib/Core/Computability/NonContextFree/BlockWitness.lean
+++ b/Linglib/Core/Computability/NonContextFree/BlockWitness.lean
@@ -100,7 +100,7 @@ theorem filter_count [DecidableEq α]
       simp [ht_notin]
     · have hbeq : (t == s) = false := by
         rw [beq_eq_false_iff_ne]; exact fun h => hst h.symm
-      simp only [hbeq, List.length_nil, List.mem_cons]
+      simp only [hbeq, List.mem_cons]
       have : ¬ (s = t) := hst
       simp [this]
 
@@ -142,7 +142,7 @@ theorem getElem?_eq {symbols : List α} {p : Nat} (hp : 0 < p) (i : Nat) :
         rw [List.length_replicate]; exact hi
       rw [List.getElem?_append_left hi_len, List.getElem?_replicate]
       have hp_ne : p ≠ 0 := Nat.pos_iff_ne_zero.mp hp
-      simp [hp_ne, hi]
+      simp [hi]
       have hdiv : i / p = 0 := Nat.div_eq_of_lt hi
       rw [hdiv]; rfl
     · -- i ≥ p; look up in the rest


### PR DESCRIPTION
The three non-context-free witness languages were each defined by a `Bool`-valued decision procedure and then *proved* equal to the range of their `makeString` — so the language's actual mathematical definition was a downstream theorem. Defining them as the range directly makes `mem_*_iff` an `Iff.rfl` and deletes the decision procedures, which had no consumers outside their own files.

- Drops `isInLanguage_*` and its unfolding lemmas, 15 `#guard`s, two `maxHeartbeats 800000` bumps, two hand-rolled `LawfulBEq` instances (derivable), and the bespoke filter-count machinery in favour of core's `List.count`.
- Public surface is unchanged, so no consumer needed touching: `Studies/Shieber1985`, `Studies/PullumGazdar1982`, `Studies/KuhlmannKollerSatta2015` and `Syntax/CCG/GenerativeCapacity` all build as-is.
- Also clears the two pre-existing unused-simp-arg warnings in `BlockWitness`; the directory is now warning-free.