### PR TITLE
refactor(Core/Computability): rename CFGTree to DerivationTree

### DIFF
--- a/Linglib/Core/Computability/ContextFreeGrammar/Pumping.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Pumping.lean
@@ -15,8 +15,8 @@ The CFL pumping property (`HasCFLPumpingProperty`) is defined over mathlib's
 
 The proof follows the standard textbook argument via derivation trees:
 
-1. **`exists_valid_tree`** ✓ (in `CFGTree.lean`)
-2. **`yield_length_le_of_height`** ✓ (in `CFGTree.lean`)
+1. **`exists_valid_tree`** ✓ (in `DerivationTree.lean`)
+2. **`yield_length_le_of_height`** ✓ (in `DerivationTree.lean`)
 3. **`pumping_from_tall_tree`** ✓: pigeonhole + subtree replacement +
    `validFor_derives`
 -/
@@ -45,7 +45,7 @@ private theorem flatten_replicate_succ_right {T : Type*} (l : List T) (n : Nat) 
 
 set_option maxHeartbeats 800000 in
 theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
-    (t : CFGTree T g.NT) (ht : t.ValidFor g)
+    (t : DerivationTree T g.NT) (ht : t.ValidFor g)
     (hroot : t.rootSymbol = .nonterminal g.initial)
     (hyield_long : t.yield.length ≥ g.pumpingConstant) :
     ∃ u v x y z : List T,
@@ -57,7 +57,7 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
   classical
   -- Step 1: Pick min-size valid tree with same yield and root
   obtain ⟨t_min, ht_min_v, ht_min_y, ht_min_r, ht_min_minimal⟩ :=
-    CFGTree.exists_min_size_tree t ht
+    DerivationTree.exists_min_size_tree t ht
   -- Step 2: Establish t_min.height > g.rules.card
   have htmin_tall : t_min.height > g.rules.card := by
     by_contra hle
@@ -73,7 +73,7 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
     omega
   -- Step 3: Max-descent path of length t_min.height - 1
   obtain ⟨p, hp_len, hpath⟩ :=
-    CFGTree.exists_pos_max_descent t_min (t_min.height - 1) (by omega)
+    DerivationTree.exists_pos_max_descent t_min (t_min.height - 1) (by omega)
   -- Step 4: Restricted pigeonhole. Use Finset.range (#rules + 1) with shift.
   -- offset = p.length - #rules. Indices in [offset, offset + #rules].
   have hoffset_le : p.length - g.rules.card + g.rules.card = p.length := by omega
@@ -88,13 +88,13 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
     match sub, hsub_h_ge with
     | .node nt children, _ => exact ⟨nt, children, hsub_at⟩
   let f : Nat → ContextFreeRule T g.NT := fun k =>
-    (CFGTree.ruleAt? t_min (p.take (k + offset))).getD ⟨g.initial, []⟩
+    (DerivationTree.ruleAt? t_min (p.take (k + offset))).getD ⟨g.initial, []⟩
   have hf_in : ∀ k ∈ Finset.range (g.rules.card + 1), f k ∈ g.rules := by
     intro k hk
     simp at hk
     have hk_off_le : k + offset ≤ p.length := by simp [offset]; omega
     obtain ⟨nt, children, hsub_k⟩ := hroot_at (k + offset) hk_off_le
-    obtain ⟨hrule_eq, hrule_in⟩ := CFGTree.ruleAt?_mem_rules t_min ht_min_v
+    obtain ⟨hrule_eq, hrule_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
       (p.take (k + offset)) nt children hsub_k
     show f k ∈ g.rules
     simp only [f, hrule_eq, Option.getD_some]
@@ -120,26 +120,26 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
   -- Get the subtrees and rules at i, j
   obtain ⟨nt_o, ch_o, hsub_o⟩ := hroot_at i hi_le
   obtain ⟨nt_i, ch_i, hsub_i⟩ := hroot_at j hj_le
-  obtain ⟨hrule_o, hrule_o_in⟩ := CFGTree.ruleAt?_mem_rules t_min ht_min_v
+  obtain ⟨hrule_o, hrule_o_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
     (p.take i) nt_o ch_o hsub_o
-  obtain ⟨hrule_i, hrule_i_in⟩ := CFGTree.ruleAt?_mem_rules t_min ht_min_v
+  obtain ⟨hrule_i, hrule_i_in⟩ := DerivationTree.ruleAt?_mem_rules t_min ht_min_v
     (p.take j) nt_i ch_i hsub_i
-  have hfa : f a = ⟨nt_o, ch_o.map CFGTree.rootSymbol⟩ := by
-    change (CFGTree.ruleAt? t_min (p.take i)).getD _ = _
+  have hfa : f a = ⟨nt_o, ch_o.map DerivationTree.rootSymbol⟩ := by
+    change (DerivationTree.ruleAt? t_min (p.take i)).getD _ = _
     rw [hrule_o]; rfl
-  have hfb : f b = ⟨nt_i, ch_i.map CFGTree.rootSymbol⟩ := by
-    change (CFGTree.ruleAt? t_min (p.take j)).getD _ = _
+  have hfb : f b = ⟨nt_i, ch_i.map DerivationTree.rootSymbol⟩ := by
+    change (DerivationTree.ruleAt? t_min (p.take j)).getD _ = _
     rw [hrule_i]; rfl
   have hroot_eq : nt_o = nt_i := by
-    have hh : (⟨nt_o, ch_o.map CFGTree.rootSymbol⟩ : ContextFreeRule T g.NT) =
-        ⟨nt_i, ch_i.map CFGTree.rootSymbol⟩ := by rw [← hfa, ← hfb, hfeq]
+    have hh : (⟨nt_o, ch_o.map DerivationTree.rootSymbol⟩ : ContextFreeRule T g.NT) =
+        ⟨nt_i, ch_i.map DerivationTree.rootSymbol⟩ := by rw [← hfa, ← hfb, hfeq]
     exact ContextFreeRule.mk.injEq _ _ _ _ |>.mp hh |>.1
   -- t_outer = .node nt_o ch_o, t_inner = .node nt_i ch_i
   -- t_outer has same root nonterminal as t_inner
-  set t_outer : CFGTree T g.NT := .node nt_o ch_o with ht_outer_def
-  set t_inner : CFGTree T g.NT := .node nt_i ch_i with ht_inner_def
+  set t_outer : DerivationTree T g.NT := .node nt_o ch_o with ht_outer_def
+  set t_inner : DerivationTree T g.NT := .node nt_i ch_i with ht_inner_def
   have hroot_o_eq_i : t_outer.rootSymbol = t_inner.rootSymbol := by
-    show CFGTree.rootSymbol (.node nt_o ch_o) = CFGTree.rootSymbol (.node nt_i ch_i)
+    show DerivationTree.rootSymbol (.node nt_o ch_o) = DerivationTree.rootSymbol (.node nt_i ch_i)
     show Symbol.nonterminal nt_o = Symbol.nonterminal nt_i
     rw [hroot_eq]
   -- Bound on t_outer.height
@@ -160,14 +160,14 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
     show t_min.subtreeAt? (p.take i ++ (p.take j).drop i) = _
     rw [← hsubtree_path_eq]; exact hsub_i
   have hsub_inner_in_outer : t_outer.subtreeAt? p_inner_rel = some t_inner := by
-    rw [CFGTree.subtreeAt?_append] at hp_inner_compose
+    rw [DerivationTree.subtreeAt?_append] at hp_inner_compose
     rw [show t_min.subtreeAt? p_outer = some t_outer from hsub_o] at hp_inner_compose
     simpa using hp_inner_compose
   -- Step 6: Yield decomposition
   obtain ⟨u, z, hyield_t, hreplace_t⟩ :=
-    CFGTree.yield_replaceAt_decomp t_min p_outer t_outer hsub_o
+    DerivationTree.yield_replaceAt_decomp t_min p_outer t_outer hsub_o
   obtain ⟨v, y, hyield_outer, hreplace_outer⟩ :=
-    CFGTree.yield_replaceAt_decomp t_outer p_inner_rel t_inner hsub_inner_in_outer
+    DerivationTree.yield_replaceAt_decomp t_outer p_inner_rel t_inner hsub_inner_in_outer
   -- x := t_inner.yield
   let x := t_inner.yield
   -- t.yield = u ++ v ++ x ++ y ++ z (via t_min)
@@ -182,7 +182,7 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
       rw [hyield_outer]
     rw [← ht_outer_yield_eq]
     have hbound := yield_length_le_of_height g t_outer
-      (CFGTree.subtreeAt?_validFor t_min ht_min_v p_outer t_outer hsub_o)
+      (DerivationTree.subtreeAt?_validFor t_min ht_min_v p_outer t_outer hsub_o)
     have hpow_le : g.maxBranch ^ t_outer.height ≤ g.maxBranch ^ (g.rules.card + 1) :=
       Nat.pow_le_pow_right (by have := g.maxBranch_ge_two; omega) ht_outer_h_le
     unfold ContextFreeGrammar.pumpingConstant
@@ -204,20 +204,20 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
       show (t_min.replaceAt p_outer t_inner).yield = t_min.yield
       rw [hreplace_t t_inner, hyield_t, ht_outer_yield_eq_inner]
     have hvalid_replaced : t_replaced.ValidFor g := by
-      apply CFGTree.validFor_replaceAt t_min p_outer t_outer t_inner hsub_o
+      apply DerivationTree.validFor_replaceAt t_min p_outer t_outer t_inner hsub_o
         hroot_o_eq_i.symm ht_min_v
-      exact CFGTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
+      exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
     have hroot_replaced : t_replaced.rootSymbol = t_min.rootSymbol := by
       show (t_min.replaceAt p_outer t_inner).rootSymbol = t_min.rootSymbol
       cases hp_outer_eq : p_outer with
       | nil =>
         have hto_eq_tmin : t_outer = t_min := by
           have h0 : t_min.subtreeAt? [] = some t_outer := by rw [← hp_outer_eq]; exact hsub_o
-          simp [CFGTree.subtreeAt?] at h0; exact h0.symm
-        simp [CFGTree.replaceAt]
+          simp [DerivationTree.subtreeAt?] at h0; exact h0.symm
+        simp [DerivationTree.replaceAt]
         rw [← hroot_o_eq_i, ← hto_eq_tmin]
       | cons hh tt =>
-        exact CFGTree.rootSymbol_replaceAt_cons t_min hh tt t_inner
+        exact DerivationTree.rootSymbol_replaceAt_cons t_min hh tt t_inner
     -- size strict decrease
     have hsize_lt : t_replaced.size < t_min.size := by
       have hi_size_lt : t_inner.size < t_outer.size := by
@@ -236,8 +236,8 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
           · exact ⟨a, b, rfl⟩
         have hsub' : t_outer.subtreeAt? (idx :: rest) = some t_inner := by
           rw [← hp_eq]; exact hsub_inner_in_outer
-        exact CFGTree.size_subtreeAt?_lt_of_cons t_outer idx rest t_inner hsub'
-      exact CFGTree.size_replaceAt_lt t_min p_outer t_outer t_inner hsub_o hi_size_lt
+        exact DerivationTree.size_subtreeAt?_lt_of_cons t_outer idx rest t_inner hsub'
+      exact DerivationTree.size_replaceAt_lt t_min p_outer t_outer t_inner hsub_o hi_size_lt
     -- Apply minimality
     have := ht_min_minimal t_replaced hvalid_replaced
       (by rw [hyield_replaced]; exact ht_min_y)
@@ -246,12 +246,12 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
   -- Step 9: Pumping iteration
   refine ⟨u, v, x, y, z, hyield_decomp, hvxy_bound, hvy_pos, ?_⟩
   -- For ∀ i, prove the pumped string is in g.language
-  -- Define pumpInner : Nat → CFGTree, with yield = v^i ++ x ++ y^i
+  -- Define pumpInner : Nat → DerivationTree, with yield = v^i ++ x ++ y^i
   intro k
   -- pumpInner k: replace t_inner with itself k times (giving v^k ++ x ++ y^k yield in t_outer's slot)
   -- Then graft into t_min at p_outer.
   -- For brevity, define recursively and prove by induction.
-  let pumpInner : Nat → CFGTree T g.NT := fun n => Nat.rec t_inner
+  let pumpInner : Nat → DerivationTree T g.NT := fun n => Nat.rec t_inner
     (fun _ prev => t_outer.replaceAt p_inner_rel prev) n
   have hpump_yield : ∀ n, (pumpInner n).yield =
       List.flatten (List.replicate n v) ++ x ++ List.flatten (List.replicate n y) := by
@@ -273,23 +273,23 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
       show (t_outer.replaceAt p_inner_rel (pumpInner m)).rootSymbol = _
       cases hp_rel_eq : p_inner_rel with
       | nil =>
-        simp [CFGTree.replaceAt]
+        simp [DerivationTree.replaceAt]
         exact ih
       | cons hh tt =>
-        exact (CFGTree.rootSymbol_replaceAt_cons t_outer hh tt (pumpInner m)).trans hroot_o_eq_i
+        exact (DerivationTree.rootSymbol_replaceAt_cons t_outer hh tt (pumpInner m)).trans hroot_o_eq_i
   have hpump_valid : ∀ n, (pumpInner n).ValidFor g := by
     intro n
     induction n with
     | zero =>
       show t_inner.ValidFor g
-      exact CFGTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
+      exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hp_inner_compose
     | succ m ih =>
       show (t_outer.replaceAt p_inner_rel (pumpInner m)).ValidFor g
-      apply CFGTree.validFor_replaceAt t_outer p_inner_rel t_inner (pumpInner m)
+      apply DerivationTree.validFor_replaceAt t_outer p_inner_rel t_inner (pumpInner m)
         hsub_inner_in_outer
       · -- (pumpInner m).rootSymbol = t_inner.rootSymbol
         exact hpump_root m
-      · exact CFGTree.subtreeAt?_validFor t_min ht_min_v _ _ hsub_o
+      · exact DerivationTree.subtreeAt?_validFor t_min ht_min_v _ _ hsub_o
       · exact ih
   -- Final pumped tree
   let final := t_min.replaceAt p_outer (pumpInner k)
@@ -299,7 +299,7 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
     rw [hreplace_t (pumpInner k), hpump_yield k]
     simp [List.append_assoc]
   have hfinal_valid : final.ValidFor g := by
-    apply CFGTree.validFor_replaceAt t_min p_outer t_outer (pumpInner k) hsub_o
+    apply DerivationTree.validFor_replaceAt t_min p_outer t_outer (pumpInner k) hsub_o
     · exact (hpump_root k).trans hroot_o_eq_i.symm
     · exact ht_min_v
     · exact hpump_valid k
@@ -309,17 +309,17 @@ theorem pumping_from_tall_tree {T : Type*} (g : ContextFreeGrammar T)
     | nil =>
       have hto_eq_tmin : t_outer = t_min := by
         have h0 : t_min.subtreeAt? [] = some t_outer := by rw [← hp_outer_eq]; exact hsub_o
-        simp [CFGTree.subtreeAt?] at h0; exact h0.symm
-      simp [CFGTree.replaceAt]
+        simp [DerivationTree.subtreeAt?] at h0; exact h0.symm
+      simp [DerivationTree.replaceAt]
       rw [hpump_root k, ← hroot_o_eq_i, hto_eq_tmin, ht_min_r, hroot]
     | cons hh tt =>
-      exact (CFGTree.rootSymbol_replaceAt_cons t_min hh tt (pumpInner k)).trans
+      exact (DerivationTree.rootSymbol_replaceAt_cons t_min hh tt (pumpInner k)).trans
         (by rw [ht_min_r, hroot])
   -- Conclude: final.yield ∈ g.language
   show (u ++ List.flatten (List.replicate k v) ++ x ++
         List.flatten (List.replicate k y) ++ z) ∈ g.language
   rw [← hfinal_yield]
-  have h := CFGTree.validFor_derives final hfinal_valid
+  have h := DerivationTree.validFor_derives final hfinal_valid
   rw [hfinal_root] at h
   exact h
 

--- a/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
+++ b/Linglib/Core/Computability/ContextFreeGrammar/Tree.lean
@@ -5,53 +5,53 @@ import Linglib.Core.Order.Branching
 /-!
 # Derivation Trees for Context-Free Grammars
 
-`CFGTree T N` is a derivation tree whose leaves hold terminal symbols of type `T`
+`DerivationTree T N` is a derivation tree whose leaves hold terminal symbols of type `T`
 and whose internal nodes hold a nonterminal of type `N` together with a list of
 children. The file provides:
 
-- `ValidFor g` — validity: every internal node matches a production rule in `g`
-- `yield` / `yieldList` — terminal frontier (left-to-right)
-- `subtreeAt?` / `replaceAt` — position-based subtree access and replacement
-- `validFor_derives` — soundness: a valid tree derives its yield from its root
-- Tree existence (`exists_valid_tree`) and height–yield bounds
-- Size measure, minimality, pigeonhole on derivation paths
+* `ValidFor g`: validity — every internal node matches a production rule in `g`.
+* `yield` / `yieldList`: the terminal frontier, left-to-right.
+* `subtreeAt?` / `replaceAt`: position-based subtree access and replacement.
+* `validFor_derives`: soundness — a valid tree derives its yield from its root.
+* `exists_valid_tree`: tree existence, with height–yield bounds.
+* `size`: the size measure, with minimality and a pigeonhole on derivation paths.
 -/
 /-- A derivation tree for a context-free grammar.
     Leaves hold terminal symbols; internal nodes hold a nonterminal
     and a list of children (matching a production rule's RHS). -/
-inductive CFGTree (T N : Type*) where
-  | leaf (t : T) : CFGTree T N
-  | node (nt : N) (children : List (CFGTree T N)) : CFGTree T N
+inductive DerivationTree (T N : Type*) where
+  | leaf (t : T) : DerivationTree T N
+  | node (nt : N) (children : List (DerivationTree T N)) : DerivationTree T N
 
-namespace CFGTree
+namespace DerivationTree
 
 variable {T N : Type*}
 
 /-- The root symbol of a subtree. -/
-def rootSymbol : CFGTree T N → Symbol T N
+def rootSymbol : DerivationTree T N → Symbol T N
   | .leaf t => .terminal t
   | .node nt _ => .nonterminal nt
 
 mutual
 /-- The terminal frontier (yield) of a derivation tree, read left to right. -/
-def yield : CFGTree T N → List T
+def yield : DerivationTree T N → List T
   | .leaf t => [t]
   | .node _ children => yieldList children
 
 /-- Concatenate yields of a list of subtrees. -/
-def yieldList : List (CFGTree T N) → List T
+def yieldList : List (DerivationTree T N) → List T
   | [] => []
   | t :: ts => t.yield ++ yieldList ts
 end
 
 mutual
 /-- The height: 0 for leaves, 1 + max child height for nodes. -/
-def height : CFGTree T N → Nat
+def height : DerivationTree T N → Nat
   | .leaf _ => 0
   | .node _ children => 1 + heightMax children
 
 /-- Maximum height among a list of subtrees. -/
-def heightMax : List (CFGTree T N) → Nat
+def heightMax : List (DerivationTree T N) → Nat
   | [] => 0
   | t :: ts => max t.height (heightMax ts)
 end
@@ -59,9 +59,9 @@ end
 /-- A derivation tree is valid for a CFG if every internal node (A, children)
     corresponds to a rule A → [rootSymbol c₁, ..., rootSymbol cₖ], and all
     children are themselves valid. -/
-inductive ValidFor (g : ContextFreeGrammar T) : CFGTree T g.NT → Prop where
+inductive ValidFor (g : ContextFreeGrammar T) : DerivationTree T g.NT → Prop where
   | leaf (t : T) : ValidFor g (.leaf t)
-  | node (nt : g.NT) (children : List (CFGTree T g.NT))
+  | node (nt : g.NT) (children : List (DerivationTree T g.NT))
     (hrule : ⟨nt, children.map rootSymbol⟩ ∈ g.rules)
     (hchildren : ∀ c ∈ children, ValidFor g c) :
     ValidFor g (.node nt children)
@@ -78,14 +78,14 @@ mutual
     used by any weighted-CFG analysis (PCFG corpus probability,
     Dirichlet posterior, etc.). -/
 def ruleCount (r : ContextFreeRule T N) :
-    CFGTree T N → ℕ
+    DerivationTree T N → ℕ
   | .leaf _ => 0
   | .node nt cs =>
       (if r = ⟨nt, cs.map rootSymbol⟩ then 1 else 0) + ruleCountList r cs
 
 /-- List version of `ruleCount` (mutual companion). -/
 def ruleCountList (r : ContextFreeRule T N) :
-    List (CFGTree T N) → ℕ
+    List (DerivationTree T N) → ℕ
   | [] => 0
   | t :: ts => ruleCount r t + ruleCountList r ts
 end
@@ -93,39 +93,39 @@ end
 /-- Total number of times rule `r` is used across a corpus `D` of
     derivation trees. -/
 def corpusRuleCount (r : ContextFreeRule T N)
-    (D : Multiset (CFGTree T N)) : ℕ :=
+    (D : Multiset (DerivationTree T N)) : ℕ :=
   (D.map (ruleCount r)).sum
 
 /-- Empty corpus contributes no rule applications. -/
 @[simp]
 theorem corpusRuleCount_zero (r : ContextFreeRule T N) :
-    corpusRuleCount r (0 : Multiset (CFGTree T N)) = 0 := by
+    corpusRuleCount r (0 : Multiset (DerivationTree T N)) = 0 := by
   simp [corpusRuleCount]
 
 /-- Corpus rule counts add over disjoint corpora — `corpusRuleCount`
     is a `Multiset` sum over `ruleCount`, which respects multiset
     addition by `Multiset.map_add` + `Multiset.sum_add`. -/
 theorem corpusRuleCount_add (r : ContextFreeRule T N)
-    (D₁ D₂ : Multiset (CFGTree T N)) :
+    (D₁ D₂ : Multiset (DerivationTree T N)) :
     corpusRuleCount r (D₁ + D₂) = corpusRuleCount r D₁ + corpusRuleCount r D₂ := by
   unfold corpusRuleCount
   rw [Multiset.map_add, Multiset.sum_add]
 
 end RuleCount
 
-end CFGTree
+end DerivationTree
 
 -- ============================================================================
 -- CFL Pumping Lemma — Helper Lemmas
 -- ============================================================================
 
-private theorem CFGTree.height_le_heightMax {T N : Type*}
-    {t : CFGTree T N} {ts : List (CFGTree T N)}
-    (ht : t ∈ ts) : t.height ≤ CFGTree.heightMax ts := by
+private theorem DerivationTree.height_le_heightMax {T N : Type*}
+    {t : DerivationTree T N} {ts : List (DerivationTree T N)}
+    (ht : t ∈ ts) : t.height ≤ DerivationTree.heightMax ts := by
   induction ts with
   | nil => simp at ht
   | cons s ss ih =>
-    simp only [CFGTree.heightMax]
+    simp only [DerivationTree.heightMax]
     rcases List.mem_cons.mp ht with rfl | h
     · exact le_max_left _ _
     · exact le_trans (ih h) (le_max_right _ _)
@@ -190,24 +190,24 @@ private theorem ContextFreeGrammar.maxBranch_ge_output {T : Type*} (g : ContextF
     ⟨r, Multiset.mem_toList.mpr (Finset.mem_val.mpr hr), rfl⟩
 
 /-- Sum of children's yields is at most `|children| * b ^ heightMax`. -/
-private theorem CFGTree.yieldList_le {T N : Type*} (b : Nat) (_hb : b ≥ 2)
-    (ts : List (CFGTree T N))
+private theorem DerivationTree.yieldList_le {T N : Type*} (b : Nat) (_hb : b ≥ 2)
+    (ts : List (DerivationTree T N))
     (hbound : ∀ c ∈ ts, c.yield.length ≤ b ^ c.height) :
-    (CFGTree.yieldList ts).length ≤ ts.length * b ^ CFGTree.heightMax ts := by
+    (DerivationTree.yieldList ts).length ≤ ts.length * b ^ DerivationTree.heightMax ts := by
   induction ts with
-  | nil => simp [CFGTree.yieldList, CFGTree.heightMax]
+  | nil => simp [DerivationTree.yieldList, DerivationTree.heightMax]
   | cons t rest ih =>
-    simp only [CFGTree.yieldList, List.length_append, List.length_cons, CFGTree.heightMax]
+    simp only [DerivationTree.yieldList, List.length_append, List.length_cons, DerivationTree.heightMax]
     have ht := hbound t (List.mem_cons_self ..)
     have hrest := ih (fun c hc => hbound c (List.mem_cons_of_mem t hc))
-    have hle_t : b ^ t.height ≤ b ^ (max t.height (CFGTree.heightMax rest)) :=
+    have hle_t : b ^ t.height ≤ b ^ (max t.height (DerivationTree.heightMax rest)) :=
       Nat.pow_le_pow_right (by omega) (le_max_left _ _)
-    have hle_rest : b ^ (CFGTree.heightMax rest) ≤
-        b ^ (max t.height (CFGTree.heightMax rest)) :=
+    have hle_rest : b ^ (DerivationTree.heightMax rest) ≤
+        b ^ (max t.height (DerivationTree.heightMax rest)) :=
       Nat.pow_le_pow_right (by omega) (le_max_right _ _)
-    set p := b ^ (max t.height (CFGTree.heightMax rest))
+    set p := b ^ (max t.height (DerivationTree.heightMax rest))
     have h1 : t.yield.length ≤ p := le_trans ht hle_t
-    have h2 : (CFGTree.yieldList rest).length ≤ rest.length * p :=
+    have h2 : (DerivationTree.yieldList rest).length ≤ rest.length * p :=
       le_trans hrest (Nat.mul_le_mul_left _ hle_rest)
     have h3 : (rest.length + 1) * p = p + rest.length * p := by
       rw [Nat.add_mul, Nat.one_mul, Nat.add_comm]
@@ -313,19 +313,19 @@ private theorem Derives.of_terminal {t : T} {v : List (Symbol T g.NT)}
 
 /-- The yield of a list of leaves is the original list of terminals. -/
 private theorem yieldList_leaves (w : List T) :
-    CFGTree.yieldList (w.map (CFGTree.leaf : T → CFGTree T g.NT)) = w := by
+    DerivationTree.yieldList (w.map (DerivationTree.leaf : T → DerivationTree T g.NT)) = w := by
   induction w with
   | nil => rfl
   | cons t ts ih =>
-    simp only [List.map_cons, CFGTree.yieldList, CFGTree.yield, List.singleton_append, ih]
+    simp only [List.map_cons, DerivationTree.yieldList, DerivationTree.yield, List.singleton_append, ih]
 
 /-- `yieldList` distributes over list concatenation. -/
-private theorem yieldList_append {N : Type*} (xs ys : List (CFGTree T N)) :
-    CFGTree.yieldList (xs ++ ys) = CFGTree.yieldList xs ++ CFGTree.yieldList ys := by
+private theorem yieldList_append {N : Type*} (xs ys : List (DerivationTree T N)) :
+    DerivationTree.yieldList (xs ++ ys) = DerivationTree.yieldList xs ++ DerivationTree.yieldList ys := by
   induction xs with
-  | nil => simp [CFGTree.yieldList]
+  | nil => simp [DerivationTree.yieldList]
   | cons x xs ih =>
-    simp only [List.cons_append, CFGTree.yieldList, ih, List.append_assoc]
+    simp only [List.cons_append, DerivationTree.yieldList, ih, List.append_assoc]
 
 set_option maxHeartbeats 800000 in
 /-- **Forest existence.** For any sentential form `sf` deriving a terminal string `w`,
@@ -333,14 +333,14 @@ set_option maxHeartbeats 800000 in
     concatenated yields equal `w`. -/
 private theorem forest_exists {sf : List (Symbol T g.NT)} {w : List T}
     (h : g.Derives sf (w.map Symbol.terminal)) :
-    ∃ trees : List (CFGTree T g.NT),
-      trees.map CFGTree.rootSymbol = sf ∧
+    ∃ trees : List (DerivationTree T g.NT),
+      trees.map DerivationTree.rootSymbol = sf ∧
       (∀ t ∈ trees, t.ValidFor g) ∧
-      CFGTree.yieldList trees = w := by
+      DerivationTree.yieldList trees = w := by
   induction h using Relation.ReflTransGen.head_induction_on with
   | refl =>
-    refine ⟨w.map (CFGTree.leaf : T → CFGTree T g.NT), ?_, ?_, ?_⟩
-    · simp [List.map_map, Function.comp_def, CFGTree.rootSymbol]
+    refine ⟨w.map (DerivationTree.leaf : T → DerivationTree T g.NT), ?_, ?_, ?_⟩
+    · simp [List.map_map, Function.comp_def, DerivationTree.rootSymbol]
     · intro t ht
       simp only [List.mem_map] at ht
       obtain ⟨_, _, rfl⟩ := ht
@@ -355,28 +355,28 @@ private theorem forest_exists {sf : List (Symbol T g.NT)} {w : List T}
     let prefix' := forest_c.take pLen
     let middle := (forest_c.drop pLen).take outLen
     let suffix := forest_c.drop (pLen + outLen)
-    let new_node : CFGTree T g.NT := .node r.input middle
+    let new_node : DerivationTree T g.NT := .node r.input middle
     let new_forest := prefix' ++ [new_node] ++ suffix
-    have hprefix_root : prefix'.map CFGTree.rootSymbol = p := by
-      have h1 : (forest_c.take pLen).map CFGTree.rootSymbol =
-          (forest_c.map CFGTree.rootSymbol).take pLen := by rw [List.map_take]
+    have hprefix_root : prefix'.map DerivationTree.rootSymbol = p := by
+      have h1 : (forest_c.take pLen).map DerivationTree.rootSymbol =
+          (forest_c.map DerivationTree.rootSymbol).take pLen := by rw [List.map_take]
       rw [show prefix' = forest_c.take pLen from rfl, h1, hroot, hc]
       simp [pLen]
-    have hmiddle_root : middle.map CFGTree.rootSymbol = r.output := by
-      have h1 : ((forest_c.drop pLen).take outLen).map CFGTree.rootSymbol =
-          ((forest_c.map CFGTree.rootSymbol).drop pLen).take outLen := by
+    have hmiddle_root : middle.map DerivationTree.rootSymbol = r.output := by
+      have h1 : ((forest_c.drop pLen).take outLen).map DerivationTree.rootSymbol =
+          ((forest_c.map DerivationTree.rootSymbol).drop pLen).take outLen := by
         rw [List.map_take, List.map_drop]
       rw [show middle = (forest_c.drop pLen).take outLen from rfl, h1, hroot, hc]
       simp [pLen, outLen, List.append_assoc]
-    have hsuffix_root : suffix.map CFGTree.rootSymbol = q := by
-      have h1 : (forest_c.drop (pLen + outLen)).map CFGTree.rootSymbol =
-          (forest_c.map CFGTree.rootSymbol).drop (pLen + outLen) := by
+    have hsuffix_root : suffix.map DerivationTree.rootSymbol = q := by
+      have h1 : (forest_c.drop (pLen + outLen)).map DerivationTree.rootSymbol =
+          (forest_c.map DerivationTree.rootSymbol).drop (pLen + outLen) := by
         rw [List.map_drop]
       rw [show suffix = forest_c.drop (pLen + outLen) from rfl, h1, hroot, hc]
       simp [pLen, outLen, List.append_assoc]
     refine ⟨new_forest, ?_, ?_, ?_⟩
     · rw [hsf]
-      show (prefix' ++ [new_node] ++ suffix).map CFGTree.rootSymbol =
+      show (prefix' ++ [new_node] ++ suffix).map DerivationTree.rootSymbol =
            p ++ [Symbol.nonterminal r.input] ++ q
       simp only [List.map_append, List.map_cons, List.map_nil]
       rw [hprefix_root, hsuffix_root]
@@ -395,7 +395,7 @@ private theorem forest_exists {sf : List (Symbol T g.NT)} {w : List T}
             exact List.mem_of_mem_drop this
           exact hvalid c this
       · exact hvalid t (List.mem_of_mem_drop ht)
-    · show CFGTree.yieldList new_forest = w
+    · show DerivationTree.yieldList new_forest = w
       have h_decomp : forest_c = prefix' ++ middle ++ suffix := by
         show forest_c = forest_c.take pLen ++ (forest_c.drop pLen).take outLen ++
                         forest_c.drop (pLen + outLen)
@@ -403,14 +403,14 @@ private theorem forest_exists {sf : List (Symbol T g.NT)} {w : List T}
                         ← List.take_append_drop outLen (forest_c.drop pLen),
                         List.drop_drop]
         rw [List.append_assoc]
-      have hy_orig : CFGTree.yieldList (prefix' ++ middle ++ suffix) = w := by
+      have hy_orig : DerivationTree.yieldList (prefix' ++ middle ++ suffix) = w := by
         rw [← h_decomp]; exact hyield
       rw [yieldList_append, yieldList_append] at hy_orig
-      show CFGTree.yieldList (prefix' ++ [new_node] ++ suffix) = w
+      show DerivationTree.yieldList (prefix' ++ [new_node] ++ suffix) = w
       rw [yieldList_append, yieldList_append]
-      have h_node_yield : CFGTree.yieldList [new_node] = CFGTree.yieldList middle := by
-        show CFGTree.yieldList [new_node] = CFGTree.yieldList middle
-        simp [CFGTree.yieldList, CFGTree.yield, new_node]
+      have h_node_yield : DerivationTree.yieldList [new_node] = DerivationTree.yieldList middle := by
+        show DerivationTree.yieldList [new_node] = DerivationTree.yieldList middle
+        simp [DerivationTree.yieldList, DerivationTree.yield, new_node]
       rw [h_node_yield]
       exact hy_orig
 
@@ -426,7 +426,7 @@ end ContextFreeGrammar
     the rewritten nonterminal back into a single node tree. -/
 theorem exists_valid_tree {T : Type*} (g : ContextFreeGrammar T)
     (w : List T) (hw : w ∈ g.language) :
-    ∃ t : CFGTree T g.NT,
+    ∃ t : DerivationTree T g.NT,
       t.ValidFor g ∧ t.yield = w ∧ t.rootSymbol = .nonterminal g.initial := by
   have hd : g.Derives [Symbol.nonterminal g.initial] (w.map Symbol.terminal) := hw
   obtain ⟨trees, hroot, hvalid, hyield⟩ := ContextFreeGrammar.forest_exists hd
@@ -437,10 +437,10 @@ theorem exists_valid_tree {T : Type*} (g : ContextFreeGrammar T)
   | [t], _ =>
     refine ⟨t, ?_, ?_, ?_⟩
     · exact hvalid t (List.mem_singleton.mpr rfl)
-    · have hy : CFGTree.yieldList [t] = w := hyield
-      simp only [CFGTree.yieldList, List.append_nil] at hy
+    · have hy : DerivationTree.yieldList [t] = w := hyield
+      simp only [DerivationTree.yieldList, List.append_nil] at hy
       exact hy
-    · have hr : [t].map CFGTree.rootSymbol = [Symbol.nonterminal g.initial] := hroot
+    · have hr : [t].map DerivationTree.rootSymbol = [Symbol.nonterminal g.initial] := hroot
       simp at hr; exact hr
 
 set_option maxHeartbeats 400000 in
@@ -451,25 +451,25 @@ set_option maxHeartbeats 400000 in
     1 = b⁰ leaves. A node with children c₁...cₖ (k ≤ b) has
     |yield| = Σᵢ |yield(cᵢ)| ≤ k · b^(max heights) ≤ b · b^(h-1) = b^h. -/
 theorem yield_length_le_of_height {T : Type*} (g : ContextFreeGrammar T)
-    (t : CFGTree T g.NT) (ht : t.ValidFor g) :
+    (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
     t.yield.length ≤ g.maxBranch ^ t.height := by
   match t, ht with
-  | .leaf _, _ => simp [CFGTree.yield, CFGTree.height]
+  | .leaf _, _ => simp [DerivationTree.yield, DerivationTree.height]
   | .node nt children, .node _ _ hrule hvalid =>
-    simp only [CFGTree.yield, CFGTree.height]
+    simp only [DerivationTree.yield, DerivationTree.height]
     have hchildren_bound : ∀ c ∈ children, c.yield.length ≤ g.maxBranch ^ c.height :=
       fun c hc => yield_length_le_of_height g c (hvalid c hc)
-    have hlist := CFGTree.yieldList_le g.maxBranch g.maxBranch_ge_two children hchildren_bound
+    have hlist := DerivationTree.yieldList_le g.maxBranch g.maxBranch_ge_two children hchildren_bound
     have hlen : children.length ≤ g.maxBranch := by
-      have heq : children.length = (children.map CFGTree.rootSymbol).length := by simp
+      have heq : children.length = (children.map DerivationTree.rootSymbol).length := by simp
       rw [heq]
-      show (children.map CFGTree.rootSymbol).length ≤ g.maxBranch
-      have : (children.map CFGTree.rootSymbol).length =
-          (ContextFreeRule.mk nt (children.map CFGTree.rootSymbol)).output.length := rfl
+      show (children.map DerivationTree.rootSymbol).length ≤ g.maxBranch
+      have : (children.map DerivationTree.rootSymbol).length =
+          (ContextFreeRule.mk nt (children.map DerivationTree.rootSymbol)).output.length := rfl
       rw [this]
-      exact g.maxBranch_ge_output ⟨nt, children.map CFGTree.rootSymbol⟩ hrule
+      exact g.maxBranch_ge_output ⟨nt, children.map DerivationTree.rootSymbol⟩ hrule
     set b := g.maxBranch
-    set hm := CFGTree.heightMax children
+    set hm := DerivationTree.heightMax children
     have h1 : children.length * b ^ hm ≤ b * b ^ hm := Nat.mul_le_mul_right _ hlen
     have h2 : b * b ^ hm = b ^ (1 + hm) := by
       rw [show 1 + hm = hm + 1 from by omega, Nat.pow_succ']
@@ -479,7 +479,7 @@ termination_by sizeOf t
 -- Pumping Infrastructure: Position-based Subtree Access
 -- ============================================================================
 
-namespace CFGTree
+namespace DerivationTree
 
 variable {T N : Type*}
 
@@ -487,7 +487,7 @@ variable {T N : Type*}
 abbrev Pos := List Nat
 
 /-- Subtree at a given position. Returns `none` if the path is invalid. -/
-def subtreeAt? : CFGTree T N → Pos → Option (CFGTree T N)
+def subtreeAt? : DerivationTree T N → Pos → Option (DerivationTree T N)
   | t, [] => some t
   | .leaf _, _ :: _ => none
   | .node _ children, i :: rest =>
@@ -495,7 +495,7 @@ def subtreeAt? : CFGTree T N → Pos → Option (CFGTree T N)
 
 /-- Replace the subtree at a given position. If the path is invalid, returns the
     original tree unchanged. -/
-def replaceAt : CFGTree T N → Pos → CFGTree T N → CFGTree T N
+def replaceAt : DerivationTree T N → Pos → DerivationTree T N → DerivationTree T N
   | _, [], new => new
   | .leaf t, _ :: _, _ => .leaf t
   | .node nt children, i :: rest, new =>
@@ -505,8 +505,8 @@ def replaceAt : CFGTree T N → Pos → CFGTree T N → CFGTree T N
       .node nt children
 
 /-- Replacing a subtree at a non-root position preserves the root symbol. -/
-theorem rootSymbol_replaceAt_cons (t : CFGTree T N) (i : Nat) (rest : Pos)
-    (new : CFGTree T N) :
+theorem rootSymbol_replaceAt_cons (t : DerivationTree T N) (i : Nat) (rest : Pos)
+    (new : DerivationTree T N) :
     (t.replaceAt (i :: rest) new).rootSymbol = t.rootSymbol := by
   match t with
   | .leaf _ => rfl
@@ -517,11 +517,11 @@ theorem rootSymbol_replaceAt_cons (t : CFGTree T N) (i : Nat) (rest : Pos)
 
 /-- Yield decomposition: replacing a subtree at position `p` produces yield
     `pre ++ new.yield ++ post`, where `pre`/`post` are the surrounding context. -/
-theorem yield_replaceAt_decomp (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
+theorem yield_replaceAt_decomp (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
     (h : t.subtreeAt? p = some sub) :
     ∃ pre post : List T,
       t.yield = pre ++ sub.yield ++ post ∧
-      ∀ new : CFGTree T N, (t.replaceAt p new).yield = pre ++ new.yield ++ post := by
+      ∀ new : DerivationTree T N, (t.replaceAt p new).yield = pre ++ new.yield ++ post := by
   induction p generalizing t with
   | nil =>
     simp [subtreeAt?] at h
@@ -548,7 +548,7 @@ theorem yield_replaceAt_decomp (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
             _ = children.take i ++ children[i] :: children.drop (i+1) := by
                 congr 1; exact List.drop_eq_getElem_cons hi_lt
             _ = children.take i ++ child :: children.drop (i+1) := by rw [hget]
-        have hsplit_set : ∀ new : CFGTree T N,
+        have hsplit_set : ∀ new : DerivationTree T N,
             children.set i new = children.take i ++ new :: children.drop (i+1) := by
           intro new
           clear hsplit_orig hget hi h hyield_inner hreplace_inner ih
@@ -591,7 +591,7 @@ theorem yield_replaceAt_decomp (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
 
 /-- Replacing a subtree of the same root symbol preserves validity. -/
 theorem validFor_replaceAt {g : ContextFreeGrammar T}
-    (t : CFGTree T g.NT) (p : Pos) (sub new : CFGTree T g.NT)
+    (t : DerivationTree T g.NT) (p : Pos) (sub new : DerivationTree T g.NT)
     (h : t.subtreeAt? p = some sub)
     (hroot : new.rootSymbol = sub.rootSymbol)
     (ht_valid : t.ValidFor g) (hnew_valid : new.ValidFor g) :
@@ -651,9 +651,9 @@ theorem validFor_replaceAt {g : ContextFreeGrammar T}
             · subst hc_eq; exact hchild_replace_valid
 
 /-- Among a nonempty list of trees, there is one with maximum height. -/
-private theorem exists_max_height (c : CFGTree T N) (cs : List (CFGTree T N)) :
-    ∃ c_max ∈ (c :: cs : List (CFGTree T N)),
-      ∀ c' ∈ (c :: cs : List (CFGTree T N)), c'.height ≤ c_max.height := by
+private theorem exists_max_height (c : DerivationTree T N) (cs : List (DerivationTree T N)) :
+    ∃ c_max ∈ (c :: cs : List (DerivationTree T N)),
+      ∀ c' ∈ (c :: cs : List (DerivationTree T N)), c'.height ≤ c_max.height := by
   induction cs generalizing c with
   | nil =>
     refine ⟨c, List.mem_singleton.mpr rfl, ?_⟩
@@ -688,8 +688,8 @@ private theorem exists_max_height (c : CFGTree T N) (cs : List (CFGTree T N)) :
 -- ============================================================================
 
 /-- For a max-height list, find the max-height element. -/
-private theorem exists_max_height_child (c : CFGTree T N) (cs : List (CFGTree T N)) :
-    ∃ c_max ∈ (c :: cs : List (CFGTree T N)),
+private theorem exists_max_height_child (c : DerivationTree T N) (cs : List (DerivationTree T N)) :
+    ∃ c_max ∈ (c :: cs : List (DerivationTree T N)),
       c_max.height = heightMax (c :: cs) := by
   induction cs generalizing c with
   | nil => exact ⟨c, by simp, by simp [heightMax]⟩
@@ -726,7 +726,7 @@ private theorem exists_max_height_child (c : CFGTree T N) (cs : List (CFGTree T 
 
 /-- For a tree of height ≥ k+1, there exists a position list of length k
     such that the subtree at that position has height ≥ 1 (i.e., is a `.node`). -/
-theorem exists_pos_of_height (t : CFGTree T N) (k : Nat) (h : t.height ≥ k + 1) :
+theorem exists_pos_of_height (t : DerivationTree T N) (k : Nat) (h : t.height ≥ k + 1) :
     ∃ p : Pos, p.length = k ∧ ∃ sub, t.subtreeAt? p = some sub ∧ sub.height ≥ 1 := by
   induction k generalizing t with
   | zero => exact ⟨[], rfl, t, rfl, h⟩
@@ -751,7 +751,7 @@ theorem exists_pos_of_height (t : CFGTree T N) (k : Nat) (h : t.height ≥ k + 1
 
 /-- Stronger: extract a max-descent path of length k, with subtree at depth i
     having height = t.height - i. -/
-theorem exists_pos_max_descent (t : CFGTree T N) (k : Nat) (h : t.height ≥ k + 1) :
+theorem exists_pos_max_descent (t : DerivationTree T N) (k : Nat) (h : t.height ≥ k + 1) :
     ∃ p : Pos, p.length = k ∧
       ∀ i, i ≤ k → ∃ sub, t.subtreeAt? (p.take i) = some sub ∧ sub.height = t.height - i := by
   induction k generalizing t with
@@ -796,7 +796,7 @@ theorem exists_pos_max_descent (t : CFGTree T N) (k : Nat) (h : t.height ≥ k +
             omega
 
 /-- subtreeAt? splits along path concatenation. -/
-theorem subtreeAt?_append (t : CFGTree T N) (p1 p2 : Pos) :
+theorem subtreeAt?_append (t : DerivationTree T N) (p1 p2 : Pos) :
     t.subtreeAt? (p1 ++ p2) = (t.subtreeAt? p1).bind (·.subtreeAt? p2) := by
   induction p1 generalizing t with
   | nil => simp [subtreeAt?]
@@ -810,7 +810,7 @@ theorem subtreeAt?_append (t : CFGTree T N) (p1 p2 : Pos) :
       · simp [ih]
 
 /-- For a valid tree and a path that descends, each prefix subtree is a `.node`. -/
-theorem spine_node_at_prefix (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
+theorem spine_node_at_prefix (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
     (hsub : t.subtreeAt? p = some sub) (hsub_h : sub.height ≥ 1)
     (k : Nat) (hk : k < p.length + 1) :
     ∃ nt children, t.subtreeAt? (p.take k) = some (.node nt children) := by
@@ -842,8 +842,8 @@ theorem spine_node_at_prefix (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
           exact ih child hsub k' hk'
 
 /-- Validity propagates through subtreeAt?. -/
-theorem subtreeAt?_validFor {g : ContextFreeGrammar T} (t : CFGTree T g.NT)
-    (ht : t.ValidFor g) (p : Pos) (sub : CFGTree T g.NT)
+theorem subtreeAt?_validFor {g : ContextFreeGrammar T} (t : DerivationTree T g.NT)
+    (ht : t.ValidFor g) (p : Pos) (sub : DerivationTree T g.NT)
     (hsub : t.subtreeAt? p = some sub) : sub.ValidFor g := by
   induction p generalizing t with
   | nil => simp [subtreeAt?] at hsub; subst hsub; exact ht
@@ -866,21 +866,21 @@ theorem subtreeAt?_validFor {g : ContextFreeGrammar T} (t : CFGTree T g.NT)
           exact ih child (hchildren child hchild_in) hsub
 
 /-- Extract the rule used at a position (option-valued). -/
-def ruleAt? {g : ContextFreeGrammar T} (t : CFGTree T g.NT) (p : Pos) :
+def ruleAt? {g : ContextFreeGrammar T} (t : DerivationTree T g.NT) (p : Pos) :
     Option (ContextFreeRule T g.NT) :=
   match t.subtreeAt? p with
   | some (.node nt children) => some ⟨nt, children.map rootSymbol⟩
   | _ => none
 
 /-- For a valid tree at a `.node` subtree, ruleAt? returns the matching rule in g.rules. -/
-theorem ruleAt?_mem_rules {g : ContextFreeGrammar T} (t : CFGTree T g.NT)
-    (ht : t.ValidFor g) (p : Pos) (nt : g.NT) (children : List (CFGTree T g.NT))
+theorem ruleAt?_mem_rules {g : ContextFreeGrammar T} (t : DerivationTree T g.NT)
+    (ht : t.ValidFor g) (p : Pos) (nt : g.NT) (children : List (DerivationTree T g.NT))
     (hsub : t.subtreeAt? p = some (.node nt children)) :
     ruleAt? t p = some ⟨nt, children.map rootSymbol⟩ ∧
     ⟨nt, children.map rootSymbol⟩ ∈ g.rules := by
   refine ⟨?_, ?_⟩
   · simp [ruleAt?, hsub]
-  · have hsub_valid : (CFGTree.node nt children).ValidFor g :=
+  · have hsub_valid : (DerivationTree.node nt children).ValidFor g :=
       subtreeAt?_validFor t ht p (.node nt children) hsub
     match hsub_valid with
     | .node _ _ hrule _ => exact hrule
@@ -890,21 +890,21 @@ theorem ruleAt?_mem_rules {g : ContextFreeGrammar T} (t : CFGTree T g.NT)
 -- ============================================================================
 
 mutual
-def size : CFGTree T N → Nat
+def size : DerivationTree T N → Nat
   | .leaf _ => 1
   | .node _ children => 1 + sizeList children
 
-def sizeList : List (CFGTree T N) → Nat
+def sizeList : List (DerivationTree T N) → Nat
   | [] => 0
   | t :: ts => t.size + sizeList ts
 end
 
-theorem size_pos (t : CFGTree T N) : t.size ≥ 1 := by
+theorem size_pos (t : DerivationTree T N) : t.size ≥ 1 := by
   match t with
   | .leaf _ => simp [size]
   | .node _ _ => simp [size]
 
-theorem sizeList_le_of_mem {t : CFGTree T N} {ts : List (CFGTree T N)} (h : t ∈ ts) :
+theorem sizeList_le_of_mem {t : DerivationTree T N} {ts : List (DerivationTree T N)} (h : t ∈ ts) :
     t.size ≤ sizeList ts := by
   induction ts with
   | nil => simp at h
@@ -914,7 +914,7 @@ theorem sizeList_le_of_mem {t : CFGTree T N} {ts : List (CFGTree T N)} (h : t �
     · omega
     · have := ih h; omega
 
-theorem size_subtreeAt?_le (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
+theorem size_subtreeAt?_le (t : DerivationTree T N) (p : Pos) (sub : DerivationTree T N)
     (h : t.subtreeAt? p = some sub) : sub.size ≤ t.size := by
   induction p generalizing t with
   | nil =>
@@ -934,8 +934,8 @@ theorem size_subtreeAt?_le (t : CFGTree T N) (p : Pos) (sub : CFGTree T N)
         have := sizeList_le_of_mem (hget ▸ List.getElem_mem hi_lt)
         simp [size]; omega
 
-theorem size_subtreeAt?_lt_of_cons (t : CFGTree T N) (i : Nat) (rest : Pos)
-    (sub : CFGTree T N) (h : t.subtreeAt? (i :: rest) = some sub) :
+theorem size_subtreeAt?_lt_of_cons (t : DerivationTree T N) (i : Nat) (rest : Pos)
+    (sub : DerivationTree T N) (h : t.subtreeAt? (i :: rest) = some sub) :
     sub.size < t.size := by
   match t with
   | .leaf _ => simp [subtreeAt?] at h
@@ -950,7 +950,7 @@ theorem size_subtreeAt?_lt_of_cons (t : CFGTree T N) (i : Nat) (rest : Pos)
       have := sizeList_le_of_mem (hget ▸ List.getElem_mem hi_lt)
       simp [size]; omega
 
-theorem sizeList_set (l : List (CFGTree T N)) (i : Nat) (x : CFGTree T N) (hi : i < l.length) :
+theorem sizeList_set (l : List (DerivationTree T N)) (i : Nat) (x : DerivationTree T N) (hi : i < l.length) :
     sizeList (l.set i x) + l[i].size = sizeList l + x.size := by
   induction l generalizing i with
   | nil => simp at hi
@@ -965,7 +965,7 @@ theorem sizeList_set (l : List (CFGTree T N)) (i : Nat) (x : CFGTree T N) (hi : 
       omega
 
 /-- Replacing a subtree with a strictly smaller one gives a strictly smaller tree. -/
-theorem size_replaceAt_lt (t : CFGTree T N) (p : Pos) (sub new : CFGTree T N)
+theorem size_replaceAt_lt (t : DerivationTree T N) (p : Pos) (sub new : DerivationTree T N)
     (h : t.subtreeAt? p = some sub) (hlt : new.size < sub.size) :
     (t.replaceAt p new).size < t.size := by
   induction p generalizing t with
@@ -995,17 +995,17 @@ theorem size_replaceAt_lt (t : CFGTree T N) (p : Pos) (sub new : CFGTree T N)
         omega
 
 /-- Existence of minimum-size valid tree with given yield and root. -/
-theorem exists_min_size_tree {g : ContextFreeGrammar T} (t : CFGTree T g.NT) (ht : t.ValidFor g) :
-    ∃ t_min : CFGTree T g.NT,
+theorem exists_min_size_tree {g : ContextFreeGrammar T} (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
+    ∃ t_min : DerivationTree T g.NT,
       t_min.ValidFor g ∧
       t_min.yield = t.yield ∧
       t_min.rootSymbol = t.rootSymbol ∧
-      ∀ t' : CFGTree T g.NT,
+      ∀ t' : DerivationTree T g.NT,
         t'.ValidFor g → t'.yield = t.yield →
         t'.rootSymbol = t.rootSymbol →
         t_min.size ≤ t'.size := by
   classical
-  let P : Nat → Prop := fun n => ∃ t' : CFGTree T g.NT,
+  let P : Nat → Prop := fun n => ∃ t' : DerivationTree T g.NT,
     t'.ValidFor g ∧ t'.yield = t.yield ∧ t'.rootSymbol = t.rootSymbol ∧ t'.size = n
   have hP_ne : ∃ n, P n := ⟨t.size, t, ht, rfl, rfl, rfl⟩
   obtain ⟨t_min, ht_min_v, ht_min_y, ht_min_r, ht_min_s⟩ := Nat.find_spec hP_ne
@@ -1017,8 +1017,8 @@ theorem exists_min_size_tree {g : ContextFreeGrammar T} (t : CFGTree T g.NT) (ht
 
 /-- Pigeonhole: along a long-enough valid path, two prefixes have same root nonterminal. -/
 theorem exists_repeat_root {g : ContextFreeGrammar T}
-    (t : CFGTree T g.NT) (ht : t.ValidFor g)
-    (p : Pos) (sub : CFGTree T g.NT)
+    (t : DerivationTree T g.NT) (ht : t.ValidFor g)
+    (p : Pos) (sub : DerivationTree T g.NT)
     (hsub : t.subtreeAt? p = some sub) (hsub_h : sub.height ≥ 1)
     (hlen : p.length ≥ g.rules.card) :
     ∃ i j : Nat, i < j ∧ j ≤ p.length ∧
@@ -1076,63 +1076,63 @@ theorem exists_repeat_root {g : ContextFreeGrammar T}
 -- ============================================================================
 
 private theorem derives_yieldList {T : Type*} {g : ContextFreeGrammar T}
-    (ts : List (CFGTree T g.NT))
+    (ts : List (DerivationTree T g.NT))
     (hvalid : ∀ t ∈ ts, g.Derives [t.rootSymbol] (t.yield.map Symbol.terminal)) :
-    g.Derives (ts.map CFGTree.rootSymbol) ((CFGTree.yieldList ts).map Symbol.terminal) := by
+    g.Derives (ts.map DerivationTree.rootSymbol) ((DerivationTree.yieldList ts).map Symbol.terminal) := by
   induction ts with
   | nil => exact Relation.ReflTransGen.refl
   | cons c cs ih =>
-    simp only [List.map_cons, CFGTree.yieldList, List.map_append]
-    show g.Derives ([c.rootSymbol] ++ cs.map CFGTree.rootSymbol)
-      (c.yield.map Symbol.terminal ++ (CFGTree.yieldList cs).map Symbol.terminal)
+    simp only [List.map_cons, DerivationTree.yieldList, List.map_append]
+    show g.Derives ([c.rootSymbol] ++ cs.map DerivationTree.rootSymbol)
+      (c.yield.map Symbol.terminal ++ (DerivationTree.yieldList cs).map Symbol.terminal)
     exact ((hvalid c (List.mem_cons_self ..)).append_right _).trans
       ((ih (fun t ht => hvalid t (List.mem_cons_of_mem _ ht))).append_left _)
 
 theorem validFor_derives {T : Type*} {g : ContextFreeGrammar T}
-    (t : CFGTree T g.NT) (ht : t.ValidFor g) :
+    (t : DerivationTree T g.NT) (ht : t.ValidFor g) :
     g.Derives [t.rootSymbol] (t.yield.map Symbol.terminal) := by
   match t, ht with
   | .leaf _, _ => exact Relation.ReflTransGen.refl
   | .node nt children, .node _ _ hrule hchildren =>
     exact (ContextFreeGrammar.Produces.single
-      ⟨⟨nt, children.map CFGTree.rootSymbol⟩, hrule,
+      ⟨⟨nt, children.map DerivationTree.rootSymbol⟩, hrule,
        ContextFreeRule.Rewrites.input_output⟩).trans
       (derives_yieldList children (fun c hc => validFor_derives c (hchildren c hc)))
 termination_by t
 
-end CFGTree
+end DerivationTree
 
 /-! ### Rose-tree interface instances
 
-`CFGTree.Pos` is the Gorn address — exactly
+`DerivationTree.Pos` is the Gorn address — exactly
 `Core.Order.TreePath.toList` — so the generic
 `Core.Order.Branching.subtreeAt` walks the same positions as
 `subtreeAt?`. The structural `size`/`height`/`yield` above remain the
 kernel-computable specializations of the generic API. -/
 
-namespace CFGTree
+namespace DerivationTree
 
 variable {T N : Type*}
 
-instance : Core.Order.Branching (CFGTree T N) where
+instance : Core.Order.Branching (DerivationTree T N) where
   children
     | .leaf _ => []
     | .node _ cs => cs
 
 @[simp] theorem branching_children_leaf (t : T) :
-    Core.Order.Branching.children (CFGTree.leaf (N := N) t) = [] := rfl
+    Core.Order.Branching.children (DerivationTree.leaf (N := N) t) = [] := rfl
 
-@[simp] theorem branching_children_node (nt : N) (cs : List (CFGTree T N)) :
-    Core.Order.Branching.children (CFGTree.node nt cs) = cs := rfl
+@[simp] theorem branching_children_node (nt : N) (cs : List (DerivationTree T N)) :
+    Core.Order.Branching.children (DerivationTree.node nt cs) = cs := rfl
 
-instance : Core.Order.IsFiniteBranching (CFGTree T N) :=
+instance : Core.Order.IsFiniteBranching (DerivationTree T N) :=
   .ofMeasure sizeOf fun {c t} hc => by
     cases t with
     | leaf _ => simp at hc
     | node nt cs =>
       simp only [branching_children_node] at hc
       have := List.sizeOf_lt_of_mem hc
-      simp only [CFGTree.node.sizeOf_spec]
+      simp only [DerivationTree.node.sizeOf_spec]
       omega
 
-end CFGTree
+end DerivationTree

--- a/Linglib/Core/Order/Branching.lean
+++ b/Linglib/Core/Order/Branching.lean
@@ -34,7 +34,7 @@ class + `Is…` Prop mixin, like `RootedTree` + `IsPredArchimedean`).
 
 Known instance candidates across the library (2026-06-06 audit):
 `Syntax.Tree` (constituency), `NanoTree` (Nanosyntax features),
-`CFGTree` (CFG derivations — `subtreeAt` is classical Gorn
+`DerivationTree` (CFG derivations — `subtreeAt` is classical Gorn
 addressing), `RoseTree` (Hopf-algebra
 trees), `FreeMagma` (bare phrase structure), Dependency-Grammar
 positions.

--- a/Linglib/Morphology/FragmentGrammars/AdaptorGrammar.lean
+++ b/Linglib/Morphology/FragmentGrammars/AdaptorGrammar.lean
@@ -167,14 +167,14 @@ ag(X, Y; A) = ∏_{A ∈ V} [DMPCFG-factor on X^A] · [PYP-factor on Y^A]
 Inherits the DMPCFG part from `DMPCFG.lhsFactor` (via `extends`);
 adds the PYP factor per LHS.
 -/
-noncomputable def corpusProbGivenTables (D : Multiset (CFGTree T G.NT))
+noncomputable def corpusProbGivenTables (D : Multiset (DerivationTree T G.NT))
     (Y : TableAssignment G) : ℝ :=
   ∏ a ∈ G.rules.image (·.input),
     M.toDMPCFG.lhsFactor a D * M.pypFactor a Y
 
 /-- AG corpus probability is nonnegative on any table assignment.
     Each per-LHS factor is `[DMPCFG-positive] · [PYP-nonneg]`. -/
-theorem corpusProbGivenTables_nonneg (D : Multiset (CFGTree T G.NT))
+theorem corpusProbGivenTables_nonneg (D : Multiset (DerivationTree T G.NT))
     (Y : TableAssignment G) : 0 ≤ M.corpusProbGivenTables D Y := by
   unfold corpusProbGivenTables
   apply Finset.prod_nonneg
@@ -196,7 +196,7 @@ def emptyTables (G : ContextFreeGrammar T) : TableAssignment G :=
     `DMPCFG.lhsFactor a 0 · PitmanYor.partitionProb (empty) = 1 · 1`. -/
 @[simp]
 theorem corpusProbGivenTables_empty :
-    M.corpusProbGivenTables (0 : Multiset (CFGTree T G.NT)) (emptyTables G) = 1 := by
+    M.corpusProbGivenTables (0 : Multiset (DerivationTree T G.NT)) (emptyTables G) = 1 := by
   unfold corpusProbGivenTables
   apply Finset.prod_eq_one
   intro a ha
@@ -240,7 +240,7 @@ estimation. -/
     `MultinomialPCFG`. The PYP component does not contribute — see the
     section docstring above. -/
 noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) : MultinomialPCFG G :=
+    (D : Multiset (DerivationTree T G.NT)) : MultinomialPCFG G :=
   M.toDMPCFG.posteriorMAP D
 
 /-- **Coherence.** AG's posterior-MAP MultinomialPCFG agrees with
@@ -248,7 +248,7 @@ noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
     `rfl` — AG's rule-weight inference IS DMPCFG's rule-weight
     inference. The "prior tower" claim made formal at this layer. -/
 theorem posteriorMAP_eq_toDMPCFG [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = M.toDMPCFG.posteriorMAP D := rfl
 
 /-! ## Conjugacy decomposition (mirror of DMPCFG)
@@ -263,7 +263,7 @@ layer too. -/
 /-- AG's posterior update: bump the underlying DMPCFG's pseudo-counts
     by the corpus rule counts (Dirichlet conjugacy on the DMPCFG
     component), leave PYP table state unchanged. -/
-noncomputable def posterior (D : Multiset (CFGTree T G.NT)) : AdaptorGrammar G :=
+noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : AdaptorGrammar G :=
   { M with toDMPCFG := M.toDMPCFG.posterior D }
 
 /-- AG's mode in `MultinomialPCFG`-space: the mode of the underlying
@@ -279,7 +279,7 @@ theorem posterior_zero : M.posterior 0 = M := by
   ext1 <;> simp [posterior, DMPCFG.posterior_zero]
 
 /-- Incrementality at the AG layer (delegated to `DMPCFG.posterior_add`). -/
-theorem posterior_add (D₁ D₂ : Multiset (CFGTree T G.NT)) :
+theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
     M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
   ext1 <;> simp [posterior, DMPCFG.posterior_add]
 
@@ -287,7 +287,7 @@ theorem posterior_add (D₁ D₂ : Multiset (CFGTree T G.NT)) :
     mode ∘ posterior`, holding by `rfl` because both AG operations
     delegate through DMPCFG's. -/
 theorem posteriorMAP_eq_mode_posterior [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = (M.posterior D).mode :=
   M.toDMPCFG.posteriorMAP_eq_mode_posterior D
 

--- a/Linglib/Morphology/FragmentGrammars/CFGFragment.lean
+++ b/Linglib/Morphology/FragmentGrammars/CFGFragment.lean
@@ -14,7 +14,7 @@ full derivation tree into fragments stored in memoized Pitman–Yor
 tables.
 
 This file provides the partial-tree data type and the embedding from
-`CFGTree` (which represents complete derivations only).
+`DerivationTree` (which represents complete derivations only).
 
 ## Main definitions
 
@@ -27,13 +27,13 @@ This file provides the partial-tree data type and the embedding from
   slots.
 - `CFGFragment.ofCFGTree` — embedding of complete derivations.
 
-## Relation to `CFGTree`
+## Relation to `DerivationTree`
 
-`CFGTree T N` is a derivation tree where every leaf carries a
+`DerivationTree T N` is a derivation tree where every leaf carries a
 terminal `T`. `CFGFragment T N` allows leaves to carry either a
-terminal `T` or an open nonterminal `N`. Every `CFGTree` embeds as
+terminal `T` or an open nonterminal `N`. Every `DerivationTree` embeds as
 a complete `CFGFragment` via `ofCFGTree`; the inverse projection
-(complete fragment → `CFGTree`) and the round-trip theorems are
+(complete fragment → `DerivationTree`) and the round-trip theorems are
 deferred to a Phase 3 file when fragment-grammar composition needs
 them.
 
@@ -99,21 +99,21 @@ def isCompleteList : List (CFGFragment T N) → Bool
 end
 
 mutual
-/-- Embed a `CFGTree` (which has only terminal leaves) as a complete
+/-- Embed a `DerivationTree` (which has only terminal leaves) as a complete
     `CFGFragment`. -/
-def ofCFGTree : CFGTree T N → CFGFragment T N
+def ofCFGTree : DerivationTree T N → CFGFragment T N
   | .leaf t => .leaf (.terminal t)
   | .node nt cs => CFGFragment.node nt (ofCFGTreeList cs)
 
 /-- Pointwise lift of `ofCFGTree` to lists. -/
-def ofCFGTreeList : List (CFGTree T N) → List (CFGFragment T N)
+def ofCFGTreeList : List (DerivationTree T N) → List (CFGFragment T N)
   | [] => []
   | t :: ts => ofCFGTree t :: ofCFGTreeList ts
 end
 
 mutual
 /-- `ofCFGTree` always produces a complete fragment. -/
-theorem ofCFGTree_isComplete (t : CFGTree T N) :
+theorem ofCFGTree_isComplete (t : DerivationTree T N) :
     (ofCFGTree t).isComplete = true := by
   match t with
   | .leaf _ => rfl
@@ -122,7 +122,7 @@ theorem ofCFGTree_isComplete (t : CFGTree T N) :
     exact ofCFGTreeList_isCompleteList cs
 
 /-- List version of `ofCFGTree_isComplete`. -/
-theorem ofCFGTreeList_isCompleteList (ts : List (CFGTree T N)) :
+theorem ofCFGTreeList_isCompleteList (ts : List (DerivationTree T N)) :
     isCompleteList (ofCFGTreeList ts) = true := by
   match ts with
   | [] => rfl
@@ -134,28 +134,28 @@ end
 
 mutual
 /-- Yields agree under the `ofCFGTree` embedding. -/
-theorem yieldT_ofCFGTree (t : CFGTree T N) :
+theorem yieldT_ofCFGTree (t : DerivationTree T N) :
     (ofCFGTree t).yieldT = t.yield := by
   match t with
   | .leaf _ => rfl
   | .node _ cs =>
-    show yieldTList (ofCFGTreeList cs) = CFGTree.yieldList cs
+    show yieldTList (ofCFGTreeList cs) = DerivationTree.yieldList cs
     exact yieldTList_ofCFGTreeList cs
 
 /-- List version of `yieldT_ofCFGTree`. -/
-theorem yieldTList_ofCFGTreeList (ts : List (CFGTree T N)) :
-    yieldTList (ofCFGTreeList ts) = CFGTree.yieldList ts := by
+theorem yieldTList_ofCFGTreeList (ts : List (DerivationTree T N)) :
+    yieldTList (ofCFGTreeList ts) = DerivationTree.yieldList ts := by
   match ts with
   | [] => rfl
   | t :: rest =>
     show (ofCFGTree t).yieldT ++ yieldTList (ofCFGTreeList rest) =
-         t.yield ++ CFGTree.yieldList rest
+         t.yield ++ DerivationTree.yieldList rest
     rw [yieldT_ofCFGTree t, yieldTList_ofCFGTreeList rest]
 end
 
 mutual
 /-- The embedding produces no open slots. -/
-theorem yieldNT_ofCFGTree (t : CFGTree T N) :
+theorem yieldNT_ofCFGTree (t : DerivationTree T N) :
     (ofCFGTree t).yieldNT = [] := by
   match t with
   | .leaf _ => rfl
@@ -164,7 +164,7 @@ theorem yieldNT_ofCFGTree (t : CFGTree T N) :
     exact yieldNTList_ofCFGTreeList cs
 
 /-- List version of `yieldNT_ofCFGTree`. -/
-theorem yieldNTList_ofCFGTreeList (ts : List (CFGTree T N)) :
+theorem yieldNTList_ofCFGTreeList (ts : List (DerivationTree T N)) :
     yieldNTList (ofCFGTreeList ts) = [] := by
   match ts with
   | [] => rfl

--- a/Linglib/Morphology/FragmentGrammars/Comparisons.lean
+++ b/Linglib/Morphology/FragmentGrammars/Comparisons.lean
@@ -73,7 +73,7 @@ theorem dmpcfg_corpus_strictly_couples
     {T : Type} [DecidableEq T] :
     ∃ (G : ContextFreeGrammar T) (_ : DecidableEq G.NT)
       (_ : ∀ a : G.NT, Nonempty (G.RulesWithLHS a))
-      (M : DMPCFG G) (D : Multiset (CFGTree T G.NT)),
+      (M : DMPCFG G) (D : Multiset (DerivationTree T G.NT)),
       ENNReal.ofReal (M.corpusProb D) ≠ (M.posteriorMAP D).corpusProb D := by
   -- TODO: concrete 2-rule grammar + 2-derivation corpus + numeric inequality.
   -- Architecture is in place; only the witness construction is deferred.

--- a/Linglib/Morphology/FragmentGrammars/DMPCFG.lean
+++ b/Linglib/Morphology/FragmentGrammars/DMPCFG.lean
@@ -49,9 +49,9 @@ of derivations, not a draw from the unlabeled-count distribution.)
 ## Main definitions
 
 - `DMPCFG G` — per-rule Dirichlet pseudo-counts.
-- Rule application counts (`CFGTree.ruleCount`,
-  `CFGTree.corpusRuleCount`) are CFGTree-level operations in
-  `Core/Computability/CFGTree.lean`; opened into this namespace.
+- Rule application counts (`DerivationTree.ruleCount`,
+  `DerivationTree.corpusRuleCount`) are DerivationTree-level operations in
+  `Core/Computability/DerivationTree.lean`; opened into this namespace.
 - `DMPCFG.lhsUrn` — per-LHS `PolyaUrn` over the subtype of rules
   with that LHS.
 - `DMPCFG.lhsCounts` — per-LHS corpus counts as a function on the
@@ -100,7 +100,7 @@ namespace DMPCFG
 
 variable {T : Type} [DecidableEq T] {G : ContextFreeGrammar T} [DecidableEq G.NT]
 
-open CFGTree (corpusRuleCount corpusRuleCount_zero corpusRuleCount_add)
+open DerivationTree (corpusRuleCount corpusRuleCount_zero corpusRuleCount_add)
 
 variable (M : DMPCFG G)
 
@@ -114,7 +114,7 @@ noncomputable def lhsUrn (a : G.NT) :
   pseudo_pos := fun ⟨r, hr⟩ => M.pseudo_pos r (Finset.mem_filter.mp hr).1
 
 /-- Per-LHS corpus rule-count vector as a function on the subtype. -/
-def lhsCounts (a : G.NT) (D : Multiset (CFGTree T G.NT)) :
+def lhsCounts (a : G.NT) (D : Multiset (DerivationTree T G.NT)) :
     G.RulesWithLHS a → ℕ :=
   fun ⟨r, _⟩ => corpusRuleCount r D
 
@@ -126,7 +126,7 @@ of the corpus rule-counts under the per-LHS pseudo-counts.
   Γ(Σ π_i^A) / Γ(Σ π_i^A + Σ x_i^A)  ·  ∏_i Γ(π_i^A + x_i^A) / Γ(π_i^A) .
 ```
 -/
-noncomputable def lhsFactor (a : G.NT) (D : Multiset (CFGTree T G.NT)) : ℝ :=
+noncomputable def lhsFactor (a : G.NT) (D : Multiset (DerivationTree T G.NT)) : ℝ :=
   (M.lhsUrn a).seqProb (lhsCounts a D)
 
 /--
@@ -135,7 +135,7 @@ over LHSs that appear in the grammar of the per-LHS Pólya factor.
 LHSs with no rules in `G` contribute trivially (empty image term)
 so the product is over `G.rules.image (·.input)`.
 -/
-noncomputable def corpusProb (D : Multiset (CFGTree T G.NT)) : ℝ :=
+noncomputable def corpusProb (D : Multiset (DerivationTree T G.NT)) : ℝ :=
   ∏ a ∈ G.rules.image (·.input), M.lhsFactor a D
 
 omit [DecidableEq T] in
@@ -149,12 +149,12 @@ theorem nonempty_rulesWithLHS_of_mem_image {a : G.NT}
 /-- The per-LHS factor is strictly positive when the LHS has rules.
     Direct corollary of `PolyaUrn.seqProb_pos`. -/
 theorem lhsFactor_pos {a : G.NT} (ha : a ∈ G.rules.image (·.input))
-    (D : Multiset (CFGTree T G.NT)) : 0 < M.lhsFactor a D := by
+    (D : Multiset (DerivationTree T G.NT)) : 0 < M.lhsFactor a D := by
   haveI := nonempty_rulesWithLHS_of_mem_image ha
   exact (M.lhsUrn a).seqProb_pos _
 
 /-- DMPCFG corpus probabilities are nonnegative (in fact, positive). -/
-theorem corpusProb_nonneg (D : Multiset (CFGTree T G.NT)) :
+theorem corpusProb_nonneg (D : Multiset (DerivationTree T G.NT)) :
     0 ≤ M.corpusProb D := by
   unfold corpusProb
   apply Finset.prod_nonneg
@@ -164,7 +164,7 @@ theorem corpusProb_nonneg (D : Multiset (CFGTree T G.NT)) :
 /-- Per-LHS counts vanish on the empty corpus. -/
 @[simp]
 theorem lhsCounts_zero (a : G.NT) :
-    lhsCounts (G := G) a (0 : Multiset (CFGTree T G.NT)) = fun _ => 0 := by
+    lhsCounts (G := G) a (0 : Multiset (DerivationTree T G.NT)) = fun _ => 0 := by
   funext ⟨r, _⟩
   simp [lhsCounts]
 
@@ -172,7 +172,7 @@ theorem lhsCounts_zero (a : G.NT) :
     per-LHS Pólya factor is `seqProb` on the all-zero count
     vector, which equals 1 by `PolyaUrn.seqProb_zero`. -/
 @[simp]
-theorem corpusProb_zero : M.corpusProb (0 : Multiset (CFGTree T G.NT)) = 1 := by
+theorem corpusProb_zero : M.corpusProb (0 : Multiset (DerivationTree T G.NT)) = 1 := by
   unfold corpusProb
   apply Finset.prod_eq_one
   intro a ha
@@ -202,7 +202,7 @@ in practice `r ∈ G.rules` makes the denominator positive — see
 `mapWeight_denom_pos`).
 -/
 noncomputable def mapWeight (r : ContextFreeRule T G.NT)
-    (D : Multiset (CFGTree T G.NT)) : ℝ :=
+    (D : Multiset (DerivationTree T G.NT)) : ℝ :=
   (M.pseudo r + (corpusRuleCount r D : ℝ)) /
     ∑ r' ∈ G.rules.filter (·.input = r.input),
       (M.pseudo r' + (corpusRuleCount r' D : ℝ))
@@ -218,7 +218,7 @@ noncomputable def mapWeight (r : ContextFreeRule T G.NT)
     once for their grammar+LHS pair, or `haveI` the witness locally. -/
 theorem mapWeight_denom_pos {a : G.NT}
     [hne : Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     0 < ∑ r' ∈ G.rules.filter (·.input = a),
         (M.pseudo r' + (corpusRuleCount r' D : ℝ)) := by
   obtain ⟨⟨r₀, hr₀_in⟩⟩ := hne
@@ -238,7 +238,7 @@ theorem mapWeight_denom_pos {a : G.NT}
     bucket). The `Nonempty` instance for `RulesWithLHS r.input` is
     synthesised internally from `hr`. -/
 theorem mapWeight_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (CFGTree T G.NT)) : 0 < M.mapWeight r D := by
+    (D : Multiset (DerivationTree T G.NT)) : 0 < M.mapWeight r D := by
   unfold mapWeight
   apply div_pos
   · have h1 : 0 < M.pseudo r := M.pseudo_pos r hr
@@ -250,7 +250,7 @@ theorem mapWeight_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
 
 /-- Corollary: `mapWeight` is nonnegative for rules in `G`. -/
 theorem mapWeight_nonneg {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (CFGTree T G.NT)) : 0 ≤ M.mapWeight r D :=
+    (D : Multiset (DerivationTree T G.NT)) : 0 ≤ M.mapWeight r D :=
   (M.mapWeight_pos hr D).le
 
 /-- Empty-corpus reduction: `mapWeight` collapses to the prior
@@ -258,7 +258,7 @@ theorem mapWeight_nonneg {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
     The Dirichlet posterior with no data IS the prior. -/
 @[simp]
 theorem mapWeight_zero (r : ContextFreeRule T G.NT) :
-    M.mapWeight r (0 : Multiset (CFGTree T G.NT)) =
+    M.mapWeight r (0 : Multiset (DerivationTree T G.NT)) =
       M.pseudo r / ∑ r' ∈ G.rules.filter (·.input = r.input), M.pseudo r' := by
   unfold mapWeight
   simp [corpusRuleCount_zero]
@@ -272,7 +272,7 @@ theorem mapWeight_zero (r : ContextFreeRule T G.NT) :
 theorem mapWeight_lt_mapWeight_iff_of_same_lhs
     {r r' : ContextFreeRule T G.NT} (hr'_in : r' ∈ G.rules)
     (h_lhs : r.input = r'.input)
-    {D : Multiset (CFGTree T G.NT)} :
+    {D : Multiset (DerivationTree T G.NT)} :
     M.mapWeight r D < M.mapWeight r' D ↔
       M.pseudo r + (corpusRuleCount r D : ℝ) <
         M.pseudo r' + (corpusRuleCount r' D : ℝ) := by
@@ -289,7 +289,7 @@ theorem mapWeight_lt_mapWeight_iff_of_same_lhs
 theorem mapWeight_lt_mapWeight_of_same_lhs
     {r r' : ContextFreeRule T G.NT} (hr'_in : r' ∈ G.rules)
     (h_lhs : r.input = r'.input)
-    {D : Multiset (CFGTree T G.NT)}
+    {D : Multiset (DerivationTree T G.NT)}
     (h_num : M.pseudo r + (corpusRuleCount r D : ℝ) <
              M.pseudo r' + (corpusRuleCount r' D : ℝ)) :
     M.mapWeight r D < M.mapWeight r' D :=
@@ -303,7 +303,7 @@ theorem mapWeight_lt_mapWeight_of_same_lhs
     posterior mass function. -/
 theorem mapWeight_sum_eq_one_of_lhs {a : G.NT}
     [Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     ∑ r ∈ G.rules.filter (·.input = a), M.mapWeight r D = 1 := by
   have hdenom_pos := M.mapWeight_denom_pos (a := a) D
   have h_rewrite : ∀ r ∈ G.rules.filter (·.input = a),
@@ -338,7 +338,7 @@ than a follow-up theorem. -/
     `ENNReal.ofReal (M.mapWeight r D)` — see `mapWeightPMF_apply`. -/
 noncomputable def mapWeightPMF {a : G.NT}
     [Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     PMF (G.RulesWithLHS a) :=
   PMF.ofFintype
     (fun x => ENNReal.ofReal (M.mapWeight x.1 D))
@@ -362,7 +362,7 @@ noncomputable def mapWeightPMF {a : G.NT}
 @[simp]
 theorem mapWeightPMF_apply {a : G.NT}
     [Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) (r : G.RulesWithLHS a) :
+    (D : Multiset (DerivationTree T G.NT)) (r : G.RulesWithLHS a) :
     M.mapWeightPMF D r = ENNReal.ofReal (M.mapWeight r.1 D) := rfl
 
 /-- PMF comparison lemma: at a shared LHS, the per-LHS posterior
@@ -375,7 +375,7 @@ theorem mapWeightPMF_apply {a : G.NT}
 theorem mapWeightPMF_lt_iff {a : G.NT}
     [Nonempty (G.RulesWithLHS a)]
     (r₁ r₂ : G.RulesWithLHS a)
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.mapWeightPMF D r₁ < M.mapWeightPMF D r₂ ↔
       M.pseudo r₁.1 + (corpusRuleCount r₁.1 D : ℝ) <
         M.pseudo r₂.1 + (corpusRuleCount r₂.1 D : ℝ) := by
@@ -419,7 +419,7 @@ boundary collapse. -/
     Returns `0/0 = 0` (Lean convention) outside the well-defined
     regime; theorems carry the well-definedness hypothesis. -/
 noncomputable def posteriorMode (M : DMPCFG G)
-    (r : ContextFreeRule T G.NT) (D : Multiset (CFGTree T G.NT)) : ℝ :=
+    (r : ContextFreeRule T G.NT) (D : Multiset (DerivationTree T G.NT)) : ℝ :=
   (M.pseudo r + (corpusRuleCount r D : ℝ) - 1) /
     ∑ r' ∈ G.rules.filter (·.input = r.input),
       (M.pseudo r' + (corpusRuleCount r' D : ℝ) - 1)
@@ -428,14 +428,14 @@ noncomputable def posteriorMode (M : DMPCFG G)
     bucket exceeds 1 in the posterior. Equivalent to "the Dirichlet
     posterior has its mode strictly in the simplex interior." -/
 def PosteriorModeWellDefined (M : DMPCFG G) (a : G.NT)
-    (D : Multiset (CFGTree T G.NT)) : Prop :=
+    (D : Multiset (DerivationTree T G.NT)) : Prop :=
   ∀ r ∈ G.rules.filter (·.input = a), 1 < M.pseudo r + (corpusRuleCount r D : ℝ)
 
 /-- The mode denominator is positive when the well-definedness
     condition holds. Each summand exceeds 0 by hypothesis. -/
 theorem posteriorMode_denom_pos {a : G.NT}
     [hne : Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT))
+    (D : Multiset (DerivationTree T G.NT))
     (h : M.PosteriorModeWellDefined a D) :
     0 < ∑ r' ∈ G.rules.filter (·.input = a),
         (M.pseudo r' + (corpusRuleCount r' D : ℝ) - 1) := by
@@ -452,7 +452,7 @@ theorem posteriorMode_denom_pos {a : G.NT}
     well-definedness condition holds. The numerator and denominator
     are both positive. -/
 theorem posteriorMode_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
-    (D : Multiset (CFGTree T G.NT))
+    (D : Multiset (DerivationTree T G.NT))
     (h : M.PosteriorModeWellDefined r.input D) :
     0 < M.posteriorMode r D := by
   unfold posteriorMode
@@ -471,7 +471,7 @@ theorem posteriorMode_pos {r : ContextFreeRule T G.NT} (hr : r ∈ G.rules)
 theorem posteriorMode_lt_iff_of_same_lhs
     {r r' : ContextFreeRule T G.NT} (hr'_in : r' ∈ G.rules)
     (h_lhs : r.input = r'.input)
-    {D : Multiset (CFGTree T G.NT)}
+    {D : Multiset (DerivationTree T G.NT)}
     (h_wd : M.PosteriorModeWellDefined r'.input D) :
     M.posteriorMode r D < M.posteriorMode r' D ↔
       M.pseudo r + (corpusRuleCount r D : ℝ) <
@@ -494,7 +494,7 @@ theorem posteriorMode_lt_iff_of_same_lhs
     productivity-ranking claims." -/
 theorem mapWeight_lt_iff_posteriorMode_lt {r r' : ContextFreeRule T G.NT}
     (hr'_in : r' ∈ G.rules) (h_lhs : r.input = r'.input)
-    {D : Multiset (CFGTree T G.NT)}
+    {D : Multiset (DerivationTree T G.NT)}
     (h_wd : M.PosteriorModeWellDefined r'.input D) :
     M.mapWeight r D < M.mapWeight r' D ↔
       M.posteriorMode r D < M.posteriorMode r' D := by
@@ -525,7 +525,7 @@ kind of object than a point in weight space. The two relate via this
     `MultinomialPCFG` itself): the construction can't deliver a
     multinomial PCFG over a grammar with empty LHS buckets. -/
 noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) : MultinomialPCFG G :=
+    (D : Multiset (DerivationTree T G.NT)) : MultinomialPCFG G :=
   ⟨fun a => M.mapWeightPMF (a := a) D⟩
 
 /-- The posterior MAP `MultinomialPCFG`'s per-LHS PMF unfolds to
@@ -534,7 +534,7 @@ noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
     bridge demo use direct application without `rw`), and tagging
     `simp` risks loops in unfamiliar simp contexts. -/
 theorem posteriorMAP_rulePMF [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) (a : G.NT) :
+    (D : Multiset (DerivationTree T G.NT)) (a : G.NT) :
     (M.posteriorMAP D).rulePMF a = M.mapWeightPMF D := rfl
 
 /-! ## Conjugacy decomposition: posterior + mode
@@ -557,7 +557,7 @@ an unspoken consequence. -/
 /-- The Dirichlet-conjugate posterior update: given a corpus, bump
     each rule's Dirichlet pseudo-count by that rule's corpus count.
     Stays inside the `DMPCFG` type — that's the point of conjugacy. -/
-noncomputable def posterior (D : Multiset (CFGTree T G.NT)) : DMPCFG G where
+noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : DMPCFG G where
   pseudo r := M.pseudo r + (corpusRuleCount r D : ℝ)
   pseudo_pos r hr := by
     have h1 : 0 < M.pseudo r := M.pseudo_pos r hr
@@ -576,7 +576,7 @@ theorem posterior_zero : M.posterior 0 = M := by
     sequentially with `D₁` then `D₂`. Bayesian update is associative
     over disjoint data — the actual content of "the prior commutes
     with corpus aggregation." Follows from `corpusRuleCount_add`. -/
-theorem posterior_add (D₁ D₂ : Multiset (CFGTree T G.NT)) :
+theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
     M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
   ext r
   show M.pseudo r + ((corpusRuleCount r (D₁ + D₂) : ℕ) : ℝ) =
@@ -601,7 +601,7 @@ noncomputable def mode [∀ a : G.NT, Nonempty (G.RulesWithLHS a)] :
     projection). The Bayesian-MAP estimator stops being a primitive
     and becomes a derived composition. -/
 theorem posteriorMAP_eq_mode_posterior [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = (M.posterior D).mode := by
   show M.posteriorMAP D = (M.posterior D).posteriorMAP 0
   apply MultinomialPCFG.ext

--- a/Linglib/Morphology/FragmentGrammars/FragmentGrammar.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentGrammar.lean
@@ -169,7 +169,7 @@ The AG part is inherited from `AdaptorGrammar.corpusProbGivenTables`
 binomial factors.
 -/
 noncomputable def corpusProbGivenStorage
-    (D : Multiset (CFGTree T G.NT))
+    (D : Multiset (DerivationTree T G.NT))
     (Y : AdaptorGrammar.TableAssignment G)
     (Z : HaltCounts G) : ℝ :=
   M.toAdaptorGrammar.corpusProbGivenTables D Y *
@@ -202,7 +202,7 @@ theorem fgFactor_pos (r : ContextFreeRule T G.NT) (i : ℕ) (z : ℕ × ℕ) :
 
 /-- FG corpus probability is nonnegative on any storage assignment. -/
 theorem corpusProbGivenStorage_nonneg
-    (D : Multiset (CFGTree T G.NT))
+    (D : Multiset (DerivationTree T G.NT))
     (Y : AdaptorGrammar.TableAssignment G)
     (Z : HaltCounts G) : 0 ≤ M.corpusProbGivenStorage D Y Z := by
   unfold corpusProbGivenStorage
@@ -243,7 +243,7 @@ theorem fgFactor_zero (r : ContextFreeRule T G.NT) (i : ℕ) :
     product is `1`. -/
 @[simp]
 theorem corpusProbGivenStorage_empty :
-    M.corpusProbGivenStorage (0 : Multiset (CFGTree T G.NT))
+    M.corpusProbGivenStorage (0 : Multiset (DerivationTree T G.NT))
       (AdaptorGrammar.emptyTables G) (emptyHaltCounts G) = 1 := by
   unfold corpusProbGivenStorage
   rw [show M.toAdaptorGrammar.corpusProbGivenTables 0 (AdaptorGrammar.emptyTables G) = 1
@@ -277,7 +277,7 @@ is the architectural payoff: the family-of-priors structure
     The beta-binomial halt prior contributes a multiplicative factor
     to corpus probability but does not alter rule-weight inference. -/
 noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) : MultinomialPCFG G :=
+    (D : Multiset (DerivationTree T G.NT)) : MultinomialPCFG G :=
   M.toAdaptorGrammar.posteriorMAP D
 
 /-- **Coherence (one step).** FG's posterior-MAP agrees with AG's
@@ -285,7 +285,7 @@ noncomputable def posteriorMAP [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
     of AG; rule-weight inference is unchanged. -/
 theorem posteriorMAP_eq_toAdaptorGrammar
     [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = M.toAdaptorGrammar.posteriorMAP D := rfl
 
 /-- **Coherence (two steps).** FG's posterior-MAP agrees with the
@@ -293,7 +293,7 @@ theorem posteriorMAP_eq_toAdaptorGrammar
     three collapses to a single canonical MultinomialPCFG by `rfl`. -/
 theorem posteriorMAP_eq_toDMPCFG
     [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = M.toAdaptorGrammar.toDMPCFG.posteriorMAP D := rfl
 
 /-! ## Conjugacy decomposition (mirror of AG / DMPCFG)
@@ -307,7 +307,7 @@ extends-chain is structurally orthogonal to rule-weight inference). -/
 
 /-- FG's posterior update: bump the underlying AG/DMPCFG, leave
     halt-prior pseudo-counts unchanged. -/
-noncomputable def posterior (D : Multiset (CFGTree T G.NT)) : FragmentGrammar G :=
+noncomputable def posterior (D : Multiset (DerivationTree T G.NT)) : FragmentGrammar G :=
   { M with toAdaptorGrammar := M.toAdaptorGrammar.posterior D }
 
 /-- FG's mode in `MultinomialPCFG`-space: delegates through AG to
@@ -322,7 +322,7 @@ theorem posterior_zero : M.posterior 0 = M := by
   ext1 <;> simp [posterior, AdaptorGrammar.posterior_zero]
 
 /-- Incrementality at the FG layer. -/
-theorem posterior_add (D₁ D₂ : Multiset (CFGTree T G.NT)) :
+theorem posterior_add (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
     M.posterior (D₁ + D₂) = (M.posterior D₁).posterior D₂ := by
   ext1 <;> simp [posterior, AdaptorGrammar.posterior_add]
 
@@ -330,7 +330,7 @@ theorem posterior_add (D₁ D₂ : Multiset (CFGTree T G.NT)) :
     mode ∘ posterior`, holding by `rfl` because all FG operations
     delegate through DMPCFG. -/
 theorem posteriorMAP_eq_mode_posterior [∀ a : G.NT, Nonempty (G.RulesWithLHS a)]
-    (D : Multiset (CFGTree T G.NT)) :
+    (D : Multiset (DerivationTree T G.NT)) :
     M.posteriorMAP D = (M.posterior D).mode :=
   M.toAdaptorGrammar.toDMPCFG.posteriorMAP_eq_mode_posterior D
 

--- a/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
+++ b/Linglib/Morphology/FragmentGrammars/FragmentLambda.lean
@@ -730,13 +730,13 @@ end
     (x : α) (r : R) (i : ℕ) :
     (LazyTree.fragment x : LazyTree α β R).collectHaltCounts r i = (0, 0) := rfl
 
--- Project a `LazyTree α β R` to a `CFGTree β α`. Returns `none` if the tree
--- contains any `.fragment` leaf (incomplete sub-derivation, no CFGTree image).
--- The rule field on `.branch` is dropped — CFGTree records derivations,
+-- Project a `LazyTree α β R` to a `DerivationTree β α`. Returns `none` if the tree
+-- contains any `.fragment` leaf (incomplete sub-derivation, no DerivationTree image).
+-- The rule field on `.branch` is dropped — DerivationTree records derivations,
 -- not which rule produced them.
 mutual
 /-- See module note above on `toCFGTree?` semantics. -/
-def toCFGTree? {α β R : Type} : LazyTree α β R → Option (CFGTree β α)
+def toCFGTree? {α β R : Type} : LazyTree α β R → Option (DerivationTree β α)
   | .terminal t      => some (.leaf t)
   | .fragment _      => none
   | .branch _ x kids =>
@@ -746,7 +746,7 @@ def toCFGTree? {α β R : Type} : LazyTree α β R → Option (CFGTree β α)
 
 /-- List-recursion helper for `toCFGTree?`. -/
 def toCFGTreesList {α β R : Type} :
-    List (LazyTree α β R) → Option (List (CFGTree β α))
+    List (LazyTree α β R) → Option (List (DerivationTree β α))
   | []      => some []
   | k :: ks =>
     match toCFGTree? k with
@@ -762,7 +762,7 @@ end
 
 @[simp] theorem toCFGTree?_fragment {α β R : Type} (x : α) :
     (LazyTree.fragment x : LazyTree α β R).toCFGTree?
-      = (none : Option (CFGTree β α)) := rfl
+      = (none : Option (DerivationTree β α)) := rfl
 
 end LazyTree
 
@@ -821,13 +821,13 @@ def slotToFinpartition {D : Type} (s : PYPSlot D) :
 table assignment + per-(rule, position) halt counts. -/
 abbrev CorpusCounts (T : Type) [DecidableEq T] (G : ContextFreeGrammar T)
     [DecidableEq G.NT] : Type :=
-  Multiset (CFGTree T G.NT) × AdaptorGrammar.TableAssignment G ×
+  Multiset (DerivationTree T G.NT) × AdaptorGrammar.TableAssignment G ×
   FragmentGrammar.HaltCounts G
 
 /-- Extract corpus-counts triple `(D, Y, Z)` from a completed sample.
 Maps a `LazyTree` (with PYP final state) into `CorpusCounts T G`:
 
-- `D : Multiset (CFGTree T G.NT)` — the underlying derivation trees
+- `D : Multiset (DerivationTree T G.NT)` — the underlying derivation trees
 - `Y : AdaptorGrammar.TableAssignment G` — table-level reuse counts
 - `Z : FragmentGrammar.HaltCounts G` — recurse/halt counts per (rule, position)
 
@@ -843,14 +843,14 @@ Maps a `LazyTree` (with PYP final state) into `CorpusCounts T G`:
   branch in `slotToFinpartition` is only reached for non-wellformed
   slots (impossible by sampler invariant; future work proves it).
 - `D` is real (via `LazyTree.toCFGTree?`): if the tree projects to a complete
-  `CFGTree` (no fragment-leaves), `D` is the singleton multiset of that
+  `DerivationTree` (no fragment-leaves), `D` is the singleton multiset of that
   derivation; otherwise (`.fragment` somewhere in the tree) `D` is empty —
   incomplete samples contribute no derivation. -/
 noncomputable def samplesToCorpusCounts
     (tree : LazyTree G.NT T (ContextFreeRule T G.NT))
     (finalState : PYPState G.NT (LazyTree G.NT T (ContextFreeRule T G.NT))) :
     CorpusCounts T G :=
-  (tree.toCFGTree?.elim 0 ({·} : CFGTree T G.NT → Multiset _),
+  (tree.toCFGTree?.elim 0 ({·} : DerivationTree T G.NT → Multiset _),
    fun A => slotToFinpartition (finalState.slots A),
    fun r i => tree.collectHaltCounts r i)
 

--- a/Linglib/Morphology/FragmentGrammars/MultinomialPCFG.lean
+++ b/Linglib/Morphology/FragmentGrammars/MultinomialPCFG.lean
@@ -194,14 +194,14 @@ mutual
     instantiates, leaves contribute `1`. Invalid rules (those not in
     `G.rules`) contribute `0` via `ruleProb`'s default. -/
 noncomputable def derivProb (W : MultinomialPCFG G) :
-    CFGTree T G.NT → ℝ≥0∞
+    DerivationTree T G.NT → ℝ≥0∞
   | .leaf _ => 1
   | .node nt cs =>
-      W.ruleProb ⟨nt, cs.map CFGTree.rootSymbol⟩ * derivProbList W cs
+      W.ruleProb ⟨nt, cs.map DerivationTree.rootSymbol⟩ * derivProbList W cs
 
 /-- Product of derivation probabilities over a list of subtrees. -/
 noncomputable def derivProbList (W : MultinomialPCFG G) :
-    List (CFGTree T G.NT) → ℝ≥0∞
+    List (DerivationTree T G.NT) → ℝ≥0∞
   | [] => 1
   | t :: ts => derivProb W t * derivProbList W ts
 end
@@ -215,13 +215,13 @@ but deferred (`corpusProb_eq_prod_pow_count`) until `derivRuleCount`
 is extracted from `DMPCFG` to a shared substrate file.
 -/
 noncomputable def corpusProb (W : MultinomialPCFG G)
-    (D : Multiset (CFGTree T G.NT)) : ℝ≥0∞ :=
+    (D : Multiset (DerivationTree T G.NT)) : ℝ≥0∞ :=
   (D.map W.derivProb).prod
 
 /-- The empty corpus has probability `1` — the empty product. -/
 @[simp]
 theorem corpusProb_zero (W : MultinomialPCFG G) :
-    W.corpusProb (0 : Multiset (CFGTree T G.NT)) = 1 := by
+    W.corpusProb (0 : Multiset (DerivationTree T G.NT)) = 1 := by
   unfold corpusProb
   rw [Multiset.map_zero, Multiset.prod_zero]
 
@@ -238,7 +238,7 @@ the analogous theorem for `DMPCFG.corpusProb` *fails* (because the
 Pólya factor couples derivations through shared rule counts).
 -/
 theorem corpusProb_add (W : MultinomialPCFG G)
-    (D₁ D₂ : Multiset (CFGTree T G.NT)) :
+    (D₁ D₂ : Multiset (DerivationTree T G.NT)) :
     W.corpusProb (D₁ + D₂) = W.corpusProb D₁ * W.corpusProb D₂ := by
   unfold corpusProb
   rw [Multiset.map_add, Multiset.prod_add]
@@ -297,16 +297,16 @@ For valid trees the two coincide.
 
 **Status: stated, sorried.** Proof requires (1) per-tree count-form
 `derivProb t = ∏_{r ∈ G.rules} ruleProb r ^ ruleCount r t` for valid
-`t`, by mutual induction on `CFGTree`/`derivProb`'s mutual structure;
+`t`, by mutual induction on `DerivationTree`/`derivProb`'s mutual structure;
 then (2) Multiset induction on `D` using `corpusProb_add` +
 `corpusRuleCount_add` + `Finset.prod_pow_add`. The mutual induction
 in (1) is the hard part — Lean's auto-generated `derivProb.induct`
 needs careful handling. Architecture is in place; mechanical proof
 deferred to a focused session. -/
 theorem corpusProb_eq_prod_pow_count (W : MultinomialPCFG G)
-    (D : Multiset (CFGTree T G.NT)) (h : ∀ t ∈ D, t.ValidFor G) :
+    (D : Multiset (DerivationTree T G.NT)) (h : ∀ t ∈ D, t.ValidFor G) :
     W.corpusProb D =
-      ∏ r ∈ G.rules, (W.ruleProb r) ^ (CFGTree.corpusRuleCount r D) := by
+      ∏ r ∈ G.rules, (W.ruleProb r) ^ (DerivationTree.corpusRuleCount r D) := by
   -- TODO: prove via per-tree count-form + Multiset induction
   sorry
 

--- a/Linglib/Studies/ODonnell2015.lean
+++ b/Linglib/Studies/ODonnell2015.lean
@@ -343,19 +343,19 @@ theorem dmpcfgFromObserved_pseudo_respects_productivity
     than +1, so the conclusion holds for realistic data; the
     hypothesis is the abstract minimum that suffices. -/
 theorem dmpcfgFromObserved_mapWeightPMF_lt_of_count_gap
-    (D : Multiset (CFGTree Sym SuffixNT))
-    (h : CFGTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
-         CFGTree.corpusRuleCount (N := SuffixNT) rIon D) :
+    (D : Multiset (DerivationTree Sym SuffixNT))
+    (h : DerivationTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
+         DerivationTree.corpusRuleCount (N := SuffixNT) rIon D) :
     dmpcfgFromObserved.mapWeightPMF D nNess <
         dmpcfgFromObserved.mapWeightPMF D nIon := by
   rw [DMPCFG.mapWeightPMF_lt_iff]
   show pseudoVal rNess +
-        (CFGTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) <
+        (DerivationTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) <
       pseudoVal rIon +
-        (CFGTree.corpusRuleCount (N := SuffixNT) rIon D : ℝ)
+        (DerivationTree.corpusRuleCount (N := SuffixNT) rIon D : ℝ)
   rw [pseudoVal_rNess, pseudoVal_rIon]
-  have h' : (CFGTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) + 1 <
-            (CFGTree.corpusRuleCount (N := SuffixNT) rIon D : ℝ) := by
+  have h' : (DerivationTree.corpusRuleCount (N := SuffixNT) rNess D : ℝ) + 1 <
+            (DerivationTree.corpusRuleCount (N := SuffixNT) rIon D : ℝ) := by
     exact_mod_cast h
   linarith
 
@@ -372,9 +372,9 @@ theorem dmpcfgFromObserved_mapWeightPMF_prior_lt :
     dmpcfgFromObserved.mapWeightPMF 0 nIon <
       dmpcfgFromObserved.mapWeightPMF 0 nNess := by
   rw [DMPCFG.mapWeightPMF_lt_iff]
-  show pseudoVal rIon + (CFGTree.corpusRuleCount (N := SuffixNT) rIon 0 : ℝ) <
-       pseudoVal rNess + (CFGTree.corpusRuleCount (N := SuffixNT) rNess 0 : ℝ)
-  rw [CFGTree.corpusRuleCount_zero, CFGTree.corpusRuleCount_zero,
+  show pseudoVal rIon + (DerivationTree.corpusRuleCount (N := SuffixNT) rIon 0 : ℝ) <
+       pseudoVal rNess + (DerivationTree.corpusRuleCount (N := SuffixNT) rNess 0 : ℝ)
+  rw [DerivationTree.corpusRuleCount_zero, DerivationTree.corpusRuleCount_zero,
       pseudoVal_rIon, pseudoVal_rNess]
   norm_num
 
@@ -412,9 +412,9 @@ theorem dmpcfgFromObserved_posteriorMAP_prior_lt :
     Fragment Grammars — gives a different posterior structure that
     doesn't collapse productivity into raw frequency. -/
 theorem dmpcfgFromObserved_mapWeightPMF_prior_and_posterior_disagree
-    (D : Multiset (CFGTree Sym SuffixNT))
-    (h : CFGTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
-         CFGTree.corpusRuleCount (N := SuffixNT) rIon D) :
+    (D : Multiset (DerivationTree Sym SuffixNT))
+    (h : DerivationTree.corpusRuleCount (N := SuffixNT) rNess D + 1 <
+         DerivationTree.corpusRuleCount (N := SuffixNT) rIon D) :
     -- Prior: ness > ion at empty corpus
     (dmpcfgFromObserved.mapWeightPMF 0 nIon <
       dmpcfgFromObserved.mapWeightPMF 0 nNess) ∧


### PR DESCRIPTION
`CFGTree` was an acronym identifier for what the literature calls a *derivation tree* — the term used throughout Pin's `Handbook of Automata Theory` (2021). The file's own module docstring already said "Derivation Trees"; only the identifier lagged. 304 occurrences across 11 files, mechanical.

Also brings that docstring's bullets to the colon-separated `*` form adopted in #1659, since the file uses the minority marker.