### PR TITLE
refactor(Core/Computability): spell out SFST as SubsequentialTransducer

### DIFF
--- a/Linglib/Core/Computability/Subregular/Logic/Transduction.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/Transduction.lean
@@ -15,7 +15,8 @@ deletion, and insertion. Non-order-preserving maps (reordering via an explicit s
 are the non-local extension and are deliberately out of scope here.
 
 Composition of transductions (`applyComp`) models an iterated derivation: each step is a local
-transduction; the composite is a regular function (closed under composition in `SFST`) though not
+transduction; the composite is a regular function (closed under composition in
+`SubsequentialTransducer`) though not
 in general itself quantifier-free.
 
 ## Main definitions
@@ -62,7 +63,8 @@ def apply (T : Transduction α β) (w : WordModel α) : WordModel β :=
 @[simp] theorem apply_nil (T : Transduction α β) : T.apply [] = [] := rfl
 
 /-- Composition of transductions — one cyclic derivation step after another. The composite is a
-regular function (closed under composition in `SFST`), though not in general quantifier-free. -/
+regular function (closed under composition in `SubsequentialTransducer`), though not in general
+quantifier-free. -/
 def applyComp (T₂ : Transduction β γ) (T₁ : Transduction α β) [DecidableEq β]
     (w : WordModel α) : WordModel γ :=
   T₂.apply (T₁.apply w)

--- a/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
+++ b/Linglib/Core/Computability/Subregular/Logic/WordModel.lean
@@ -12,7 +12,7 @@ closure of successor and is not part of the quantifier-free fragment.
 The carrier is `List α` itself: a string *is* its word model. This is deliberately where
 mathlib stops — it has strings (`List`/`FreeMonoid`) and automata (`DFA`, `MyhillNerode`)
 but no model-theoretic word structure — and it keeps the logic layer directly composable
-with `Subregular`'s string functions (`Subregular.IsInputStrictlyLocal`, `SFST`).
+with `Subregular`'s string functions (`Subregular.IsInputStrictlyLocal`, `SubsequentialTransducer`).
 
 ## Main definitions
 

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -26,15 +26,18 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
 
 ## Main definitions
 
-* `SFST σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet `β`,
+* `SubsequentialTransducer σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet
+  `β`,
   and a state-final output emitted at the end of the input
-* `SFST.run`, `SFST.runRight`: the left-to-right and right-to-left passes
-* `SFST.comp`: the product machine, computing the composite function
-* `SFST.reindex`: lifts an equivalence on states to an equivalence on machines
-* `Mealy.toSFST`, `SFST.toMealy`: the synchronous and block machine views of each
+* `SubsequentialTransducer.run`, `SubsequentialTransducer.runRight`: the left-to-right and
+  right-to-left passes
+* `SubsequentialTransducer.comp`: the product machine, computing the composite function
+* `SubsequentialTransducer.reindex`: lifts an equivalence on states to an equivalence on machines
+* `Mealy.toSubsequentialTransducer`, `SubsequentialTransducer.toMealy`: the synchronous and block
+  machine views of each
   other, mutually inverse on singleton-output transducers with no final flush
 * `IsLeftSubsequential f`, `IsRightSubsequential f`, `IsSubsequential d f`: `f` is
-  computed by some finite-state `SFST` scanning in the given direction
+  computed by some finite-state `SubsequentialTransducer` scanning in the given direction
 
 ## Main theorems
 
@@ -43,8 +46,10 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
   [schutzenberger-1977]
 * `isRightSubsequential_iff_left_reverse`: the left and right classes are isomorphic
   via reverse-conjugation
-* `IsMealyComputable.isLeftSubsequential`, `SFST.isMealyComputable`: the synchronous
-  class sits inside the block class, and a singleton-output SFST falls back into it
+* `IsMealyComputable.isLeftSubsequential`, `SubsequentialTransducer.isMealyComputable`: the
+  synchronous
+  class sits inside the block class, and a singleton-output SubsequentialTransducer falls back into
+  it
 * `IsLeftSubsequential.bounded_delay`: a left-subsequential function withholds at most
   a bounded suffix, since it can only be sitting on a state-final output
 
@@ -56,9 +61,10 @@ contested — [sakarovitch-2009] calls this class simply *sequential* (reserving
 sequential* for the empty-final-output case) and flags his own terminology as
 unconventional, quoting [bruyere-reutenauer-1999] that "the word sub-sequential is
 unfortunate". We keep the Choffrut spelling, so `Mealy` computes the *pure sequential*
-length-preserving functions and `SFST` the subsequential ones.
+length-preserving functions and `SubsequentialTransducer` the subsequential ones.
 
-`SFST` models the *total* subsequential functions: `step` is total and every input is
+`SubsequentialTransducer` models the *total* subsequential functions: `step` is total and every
+input is
 accepted, so `run` is a total function. This restricts the literature's class — a sink
 state does not recover partiality, since out-of-domain inputs still emit output — so
 the classification predicates below are about total functions only. On empty input
@@ -82,10 +88,10 @@ namespace Subregular
 
 variable {σ α β : Type*}
 
-/-- A subsequential finite-state transducer (SFST) is a set of states (`σ`), a
+/-- A subsequential finite-state transducer (SubsequentialTransducer) is a set of states (`σ`), a
 starting state (`start`), a transition function (`step`), a per-symbol output
 function (`output`) and a state-final output (`finalOutput`). -/
-structure SFST (σ α β : Type*) where
+structure SubsequentialTransducer (σ α β : Type*) where
   /-- Starting state. -/
   start : σ
   /-- Transition function. -/
@@ -95,12 +101,12 @@ structure SFST (σ α β : Type*) where
   /-- Output emitted on terminating in a state. -/
   finalOutput : σ → List β
 
-instance [Inhabited σ] : Inhabited (SFST σ α β) :=
+instance [Inhabited σ] : Inhabited (SubsequentialTransducer σ α β) :=
   ⟨⟨default, fun s _ => s, fun _ _ => [], fun _ => []⟩⟩
 
-namespace SFST
+namespace SubsequentialTransducer
 
-variable (T : SFST σ α β)
+variable (T : SubsequentialTransducer σ α β)
 
 /-- `T.stateAfter s x` is the state reached from `s` after consuming the input `x`. -/
 def stateAfter (s : σ) : List α → σ := List.foldl T.step s
@@ -171,7 +177,7 @@ variable {τ : Type*}
 
 /-- Lifts an equivalence on states to an equivalence on subsequential transducers. -/
 @[simps apply_start apply_step apply_output apply_finalOutput]
-def reindex (g : σ ≃ τ) : SFST σ α β ≃ SFST τ α β where
+def reindex (g : σ ≃ τ) : SubsequentialTransducer σ α β ≃ SubsequentialTransducer τ α β where
   toFun T := {
     start := g T.start
     step := fun t x => g (T.step (g.symm t) x)
@@ -215,12 +221,12 @@ def reindex (g : σ ≃ τ) : SFST σ α β ≃ SFST τ α β where
 
 section Comp
 
-variable {γ σ' : Type*} (T₂ : SFST σ' β γ) (T₁ : SFST σ α β)
+variable {γ σ' : Type*} (T₂ : SubsequentialTransducer σ' β γ) (T₁ : SubsequentialTransducer σ α β)
 
 /-- `T₂.comp T₁` feeds each output block of `T₁` to `T₂` — the classical product
 construction [schutzenberger-1977] — computing `T₂.run ∘ T₁.run` (`run_comp`). -/
 @[simps]
-def comp : SFST (σ' × σ) α γ where
+def comp : SubsequentialTransducer (σ' × σ) α γ where
   start := (T₂.start, T₁.start)
   step p x := (T₂.stateAfter p.1 (T₁.output p.2 x), T₁.step p.2 x)
   output p x := T₂.emitted p.1 (T₁.output p.2 x)
@@ -237,11 +243,12 @@ def comp : SFST (σ' × σ) α γ where
 
 end Comp
 
-end SFST
+end SubsequentialTransducer
 
 /-! ### Synchronous machines as block transducers
 
-A `Mealy` machine is an `SFST` emitting singleton blocks with an empty final flush; a
+A `Mealy` machine is a `SubsequentialTransducer` emitting singleton blocks with an empty final
+flush; a
 block transducer of that shape is a `Mealy` machine. The two views are mutually
 inverse. -/
 
@@ -249,44 +256,50 @@ section Synchronous
 
 variable {σ α β : Type*}
 
-/-- View a synchronous transducer as a block `SFST`: singleton outputs, empty flush. -/
-def Mealy.toSFST (T : Mealy σ α β) : SFST σ α β where
+/-- View a synchronous transducer as a block `SubsequentialTransducer`: singleton outputs, empty
+flush. -/
+def Mealy.toSubsequentialTransducer (T : Mealy σ α β) : SubsequentialTransducer σ α β where
   start := T.initial
   step := T.step
   output s x := [T.output s x]
   finalOutput _ := []
 
-@[simp] theorem Mealy.toSFST_runFrom (T : Mealy σ α β) (s : σ) (xs : List α) :
-    T.toSFST.runFrom s xs = T.runFrom s xs := by
+@[simp] theorem Mealy.toSubsequentialTransducer_runFrom (T : Mealy σ α β) (s : σ) (xs : List α) :
+    T.toSubsequentialTransducer.runFrom s xs = T.runFrom s xs := by
   induction xs generalizing s with
   | nil => rfl
-  | cons x xs ih => rw [SFST.runFrom_cons, Mealy.runFrom_cons, ih]; rfl
+  | cons x xs ih => rw [SubsequentialTransducer.runFrom_cons, Mealy.runFrom_cons, ih]; rfl
 
-@[simp] theorem Mealy.toSFST_run (T : Mealy σ α β) : T.toSFST.run = T.run :=
-  funext fun xs => T.toSFST_runFrom T.initial xs
+@[simp] theorem Mealy.toSubsequentialTransducer_run (T : Mealy σ α β) :
+    T.toSubsequentialTransducer.run = T.run :=
+  funext fun xs => T.toSubsequentialTransducer_runFrom T.initial xs
 
 /-- View a block transducer emitting exactly one symbol per input symbol as a synchronous
 machine: the singleton output block is the emitted letter. -/
 @[simps]
-def SFST.toMealy (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1) : Mealy σ α β where
+def SubsequentialTransducer.toMealy (T : SubsequentialTransducer σ α β)
+    (hs : ∀ s x, (T.output s x).length = 1) : Mealy σ α β where
   initial := T.start
   step := T.step
   output s x := (T.output s x).head (List.ne_nil_of_length_pos (by rw [hs]; omega))
 
-@[simp] theorem Mealy.toMealy_toSFST (T : Mealy σ α β) :
-    T.toSFST.toMealy (fun _ _ => rfl) = T := rfl
+@[simp] theorem Mealy.toMealy_toSubsequentialTransducer (T : Mealy σ α β) :
+    T.toSubsequentialTransducer.toMealy (fun _ _ => rfl) = T := rfl
 
-theorem SFST.toMealy_runFrom (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+theorem SubsequentialTransducer.toMealy_runFrom (T : SubsequentialTransducer σ α β)
+    (hs : ∀ s x, (T.output s x).length = 1)
     (hf : ∀ s, T.finalOutput s = []) (s : σ) (xs : List α) :
     (T.toMealy hs).runFrom s xs = T.runFrom s xs := by
   induction xs generalizing s with
   | nil => simp [hf]
   | cons x xs ih =>
     obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
-    simp only [Mealy.runFrom_cons, SFST.runFrom_cons, toMealy_output, toMealy_step, ih, ha,
+    simp only [Mealy.runFrom_cons, SubsequentialTransducer.runFrom_cons, toMealy_output,
+    toMealy_step, ih, ha,
       List.head_cons, List.singleton_append]
 
-theorem SFST.toMealy_run (T : SFST σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+theorem SubsequentialTransducer.toMealy_run (T : SubsequentialTransducer σ α β)
+    (hs : ∀ s x, (T.output s x).length = 1)
     (hf : ∀ s, T.finalOutput s = []) : (T.toMealy hs).run = T.run :=
   funext fun xs => T.toMealy_runFrom hs hf T.start xs
 
@@ -296,18 +309,18 @@ end Synchronous
 
 variable {α β γ : Type*} {f : List α → List β} {g : List β → List γ}
 
-/-- A function `f : List α → List β` is *left-subsequential* if some SFST with a
+/-- A function `f : List α → List β` is *left-subsequential* if some SubsequentialTransducer with a
 finite state space computes it via left-to-right scan [mohri-1997]. -/
 def IsLeftSubsequential (f : List α → List β) : Prop :=
-  ∃ (σ : Type) (_ : Fintype σ) (T : SFST σ α β), T.run = f
+  ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f
 
-/-- A function `f : List α → List β` is *right-subsequential* if some SFST with a
+/-- A function `f : List α → List β` is *right-subsequential* if some SubsequentialTransducer with a
 finite state space computes it via right-to-left scan (`runRight`). -/
 def IsRightSubsequential (f : List α → List β) : Prop :=
-  ∃ (σ : Type) (_ : Fintype σ) (T : SFST σ α β), T.runRight = f
+  ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f
 
 /-- A function `f : List α → List β` is *subsequential in direction `d`* if some
-finite-state SFST computes it via the corresponding scan direction. -/
+finite-state SubsequentialTransducer computes it via the corresponding scan direction. -/
 def IsSubsequential (d : Direction) (f : List α → List β) : Prop :=
   match d with
   | .left => IsLeftSubsequential f
@@ -319,50 +332,57 @@ def IsSubsequential (d : Direction) (f : List α → List β) : Prop :=
 @[simp] theorem isSubsequential_right :
     IsSubsequential .right f ↔ IsRightSubsequential f := Iff.rfl
 
-/-- `f` is left-subsequential if and only if it is computed by a finite-state SFST.
+/-- `f` is left-subsequential if and only if it is computed by a finite-state
+SubsequentialTransducer.
 This is more general than using the definition of `IsLeftSubsequential` directly, as
 the state type `σ` is universe-polymorphic. -/
 theorem isLeftSubsequential_iff.{v} :
     IsLeftSubsequential f
-      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SFST σ α β), T.run = f :=
+      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f :=
   exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨SFST.reindex e T, (T.run_reindex e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨SFST.reindex e T, (T.run_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.run_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.run_reindex e).trans hT⟩)
 
 /-- `f` is right-subsequential if and only if it is computed via `runRight` by a
-finite-state SFST. This is more general than using the definition of
+finite-state SubsequentialTransducer. This is more general than using the definition of
 `IsRightSubsequential` directly, as the state type `σ` is universe-polymorphic. -/
 theorem isRightSubsequential_iff.{v} :
     IsRightSubsequential f
-      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SFST σ α β), T.runRight = f :=
+      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f :=
   exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨SFST.reindex e T, (T.runRight_reindex e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨SFST.reindex e T, (T.runRight_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
 
-/-- Every finite-state SFST computes a left-subsequential function, whatever the
+/-- Every finite-state SubsequentialTransducer computes a left-subsequential function, whatever the
 universe of its state type. -/
-theorem SFST.isLeftSubsequential {σ : Type*} [Fintype σ] (T : SFST σ α β) :
+theorem SubsequentialTransducer.isLeftSubsequential {σ : Type*} [Fintype σ]
+    (T : SubsequentialTransducer σ α β) :
     IsLeftSubsequential T.run :=
   isLeftSubsequential_iff.mpr ⟨σ, inferInstance, T, rfl⟩
 
-/-- Every finite-state SFST computes a right-subsequential function via `runRight`. -/
-theorem SFST.isRightSubsequential {σ : Type*} [Fintype σ] (T : SFST σ α β) :
+/-- Every finite-state SubsequentialTransducer computes a right-subsequential function via
+`runRight`. -/
+theorem SubsequentialTransducer.isRightSubsequential {σ : Type*} [Fintype σ]
+    (T : SubsequentialTransducer σ α β) :
     IsRightSubsequential T.runRight :=
   isRightSubsequential_iff.mpr ⟨σ, inferInstance, T, rfl⟩
 
-/-- Every finite-state SFST emitting one symbol per input symbol and flushing nothing at
+/-- Every finite-state SubsequentialTransducer emitting one symbol per input symbol and flushing
+nothing at
 the end computes a Mealy-computable function. -/
-theorem SFST.isMealyComputable {σ : Type*} [Fintype σ] (T : SFST σ α β)
+theorem SubsequentialTransducer.isMealyComputable {σ : Type*} [Fintype σ]
+    (T : SubsequentialTransducer σ α β)
     (hs : ∀ s x, (T.output s x).length = 1) (hf : ∀ s, T.finalOutput s = []) :
     IsMealyComputable T.run :=
   T.toMealy_run hs hf ▸ (T.toMealy hs).isMealyComputable
 
-/-- A Mealy-computable function is left-subsequential, since `Mealy.toSFST` presents a
+/-- A Mealy-computable function is left-subsequential, since `Mealy.toSubsequentialTransducer`
+presents a
 synchronous machine as a block transducer emitting singleton blocks. -/
 theorem IsMealyComputable.isLeftSubsequential (hf : IsMealyComputable f) :
     IsLeftSubsequential f := by
   obtain ⟨σ, _, T, rfl⟩ := hf
-  exact T.toSFST_run ▸ T.toSFST.isLeftSubsequential
+  exact T.toSubsequentialTransducer_run ▸ T.toSubsequentialTransducer.isLeftSubsequential
 
 /-- A function is right-subsequential iff its reverse-conjugate is left-subsequential:
 the two classes are isomorphic via the involution `f ↦ List.reverse ∘ f ∘ List.reverse`. -/
@@ -370,7 +390,8 @@ theorem isRightSubsequential_iff_left_reverse :
     IsRightSubsequential f
       ↔ IsLeftSubsequential (fun xs => (f xs.reverse).reverse) :=
   ⟨fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [← hT]⟩,
-   fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [SFST.runRight, hT]⟩⟩
+   fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [SubsequentialTransducer.runRight,
+   hT]⟩⟩
 
 /-- A left-subsequential function has bounded delay: on any input `u` it has already
 emitted a prefix of `f u` shared with `f (u ++ v)` for every continuation `v`,
@@ -395,7 +416,7 @@ theorem IsLeftSubsequential.exists_getElem?_append_eq (hf : IsLeftSubsequential 
     fun u v i hi => T.getElem?_run_append u v ?_⟩
   have hN := Finset.le_sup (f := fun s => (T.finalOutput s).length)
     (Finset.mem_univ (T.stateAfter T.start u))
-  simp only [SFST.run, SFST.runFrom, List.length_append] at hi
+  simp only [SubsequentialTransducer.run, SubsequentialTransducer.runFrom, List.length_append] at hi
   omega
 
 /-- `f` is not left-subsequential if for every `N` some images `f u` and `f (u ++ v)`
@@ -411,7 +432,7 @@ theorem not_isLeftSubsequential_of_diverging
   exact hne (hN u v i hi)
 
 /-- Left-subsequential functions are closed under composition, by the classical
-product construction [schutzenberger-1977] (`SFST.comp`). -/
+product construction [schutzenberger-1977] (`SubsequentialTransducer.comp`). -/
 theorem IsLeftSubsequential.comp (hg : IsLeftSubsequential g)
     (hf : IsLeftSubsequential f) : IsLeftSubsequential (g ∘ f) := by
   obtain ⟨σ₁, _, T₁, rfl⟩ := hf

--- a/Linglib/Phonology/Subregular/ISL.lean
+++ b/Linglib/Phonology/Subregular/ISL.lean
@@ -33,7 +33,7 @@ function-level subregular hierarchy.
 * `isRightInputStrictlyLocal_iff_left_reverse`: the right class is the
   reverse-conjugate of the left class.
 * `isLeftInputStrictlyLocal_left_subsequential`: every Left-ISL
-  function is Left-Subsequential, witnessed by `ISLRule.toFinSFST`.
+  function is Left-Subsequential, witnessed by `ISLRule.toFinSubsequentialTransducer`.
 * `flatMap_isLeftInputStrictlyLocal_one`,
   `filterMap_isLeftInputStrictlyLocal_one` — letterwise homomorphisms and
   erasing (tier) projections are the `k = 1` specialisation.
@@ -54,7 +54,7 @@ variable {α β : Type*}
 /-- The "list of length at most `n`" subtype is finite when `α` is. The
 witness is a surjection from `Σ m : Fin (n + 1), List.Vector α m` (which
 has a `Fintype` instance via `Mathlib.Data.Fintype.{Sigma,Vector}`). Used
-to give ISL/OSL projections into SFST a manifestly-finite state space
+to give ISL/OSL projections into SubsequentialTransducer a manifestly-finite state space
 (matching [mohri-1997]'s finite-state assumption). Uses `classical`
 to discharge the `DecidableEq` side condition without imposing it on
 consumers (matches mathlib pattern for finite types over `Fintype α`). -/
@@ -259,41 +259,43 @@ theorem filterMap_isLeftInputStrictlyLocal_one (g : α → Option β) :
 
 /-! ### ISL ⊆ Subsequential
 
-`ISLRule.toFinSFST` projects an ISL rule into a finite-state SFST whose
+`ISLRule.toFinSubsequentialTransducer` projects an ISL rule into a finite-state
+SubsequentialTransducer whose
 state space is the bounded input window `{l : List α // l.length ≤ k - 1}`.
 The `[Fintype α]` constraint matches the source literature [mohri-1997]:
 every subsequential model has a finite alphabet and finite state by
 definition. The inclusion theorem
 rides on the run-equality. Co-located on the source side because the
-dependency direction (SFST in `Subsequential.lean`; ISL projects into
+dependency direction (SubsequentialTransducer in `Subsequential.lean`; ISL projects into
 it) forces both construction and cast into this file. -/
 
-/-- Construction: every ISL rule induces a **finite-state** SFST whose
+/-- Construction: every ISL rule induces a **finite-state** SubsequentialTransducer whose
 state is the bounded input window `{l : List α // l.length ≤ k - 1}`,
 and whose `finalOutput` is empty. The state is manifestly finite via
 `fintypeListLengthLE`, witnessing ISL ⊆ Subsequential under the source
 literature's finite-state assumption. -/
-def ISLRule.toFinSFST {k : ℕ} [Fintype α] (r : ISLRule k α β) :
-    SFST {l : List α // l.length ≤ k - 1} α β where
+def ISLRule.toFinSubsequentialTransducer {k : ℕ} [Fintype α] (r : ISLRule k α β) :
+    SubsequentialTransducer {l : List α // l.length ≤ k - 1} α β where
   start := ⟨[], Nat.zero_le _⟩
   step w x := ⟨(w.val ++ [x]).rtake (k - 1), List.length_rtake_le _ _⟩
   output w x := r.windowOutput w.val x
   finalOutput _ := []
 
-/-- The finite-state SFST induced by an ISL rule computes the same
+/-- The finite-state SubsequentialTransducer induced by an ISL rule computes the same
 string function. -/
-theorem ISLRule.toFinSFST_run_eq_apply {k : ℕ} [Fintype α] (r : ISLRule k α β) :
-    r.toFinSFST.run = r.apply := by
+theorem ISLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} [Fintype α] (r : ISLRule k α β) :
+    r.toFinSubsequentialTransducer.run = r.apply := by
   funext input
-  show SFST.runFrom r.toFinSFST ⟨[], Nat.zero_le _⟩ input
+  show SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer ⟨[], Nat.zero_le _⟩ input
     = ISLRule.applyAux r [] input
   suffices h : ∀ (w : {l : List α // l.length ≤ k - 1}),
-      SFST.runFrom r.toFinSFST w input = ISLRule.applyAux r w.val input from h _
+      SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer w input = ISLRule.applyAux r
+      w.val input from h _
   intro w
   induction input generalizing w with
   | nil => rfl
   | cons x xs ih =>
-    rw [SFST.runFrom_cons]
+    rw [SubsequentialTransducer.runFrom_cons]
     exact congrArg _ (ih _)
 
 /-- **Left-ISL ⊆ Left-Subsequential** (over a finite input alphabet).
@@ -303,14 +305,16 @@ theorem isLeftInputStrictlyLocal_left_subsequential {k : ℕ} [Fintype α]
     {f : List α → List β} (h : IsLeftInputStrictlyLocal k f) :
     IsLeftSubsequential f := by
   obtain ⟨r, hr⟩ := h
-  have heq : r.toFinSFST.run = f := r.toFinSFST_run_eq_apply.trans hr
-  exact heq ▸ r.toFinSFST.isLeftSubsequential
+  have heq : r.toFinSubsequentialTransducer.run = f :=
+    r.toFinSubsequentialTransducer_run_eq_apply.trans hr
+  exact heq ▸ r.toFinSubsequentialTransducer.isLeftSubsequential
 
 /-- A single-symbol left-ISL rule is Mealy-computable. The bounded input window that makes
-`ISLRule.toFinSFST` finite-state is already the synchronous state. -/
+`ISLRule.toFinSubsequentialTransducer` finite-state is already the synchronous state. -/
 theorem isMealyComputable_of_ISLRule {k : ℕ} [Fintype α] (r : ISLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsMealyComputable r.apply :=
-  r.toFinSFST_run_eq_apply ▸ r.toFinSFST.isMealyComputable (fun w x => hs w.val x) fun _ => rfl
+  r.toFinSubsequentialTransducer_run_eq_apply ▸ r.toFinSubsequentialTransducer.isMealyComputable
+  (fun w x => hs w.val x) fun _ => rfl
 
 /-- **Right-ISL ⊆ Right-Subsequential**, derived from the Left- side via
 the reverse-conjugation lemmas. The Right-ISL ↔ Left-ISL and

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -32,7 +32,7 @@ ISL ⊊ OSL ⊊ Subsequential.
 * `isRightOutputStrictlyLocal_iff_left_reverse`: Right-OSL is the
   reverse-conjugate of Left-OSL.
 * `isLeftOutputStrictlyLocal_left_subsequential`: Left-OSL ⊆
-  Left-Subsequential, via `OSLRule.toFinSFST`.
+  Left-Subsequential, via `OSLRule.toFinSubsequentialTransducer`.
 
 ## Implementation notes
 
@@ -161,40 +161,42 @@ theorem isRightOutputStrictlyLocal_iff_left_reverse {k : ℕ}
 
 /-! ### OSL ⊆ Subsequential
 
-`OSLRule.toFinSFST` projects an OSL rule into an SFST whose state is
+`OSLRule.toFinSubsequentialTransducer` projects an OSL rule into a SubsequentialTransducer whose
+state is
 the bounded output window (length ≤ k − 1). The inclusion rides on the
 run-equality plus the `Fintype` instance for the bounded-window subtype
 (reusing `Subregular.fintypeListLengthLE`). Co-located on the source
-side because the dependency direction (`Subregular.SFST`; OSL projects
+side because the dependency direction (`Subregular.SubsequentialTransducer`; OSL projects
 into it) forces both construction and cast into this file.
 
 The output alphabet `[Fintype β]` constraint matches [mohri-1997]'s
 finite-alphabet assumption — the state space (a bounded output window)
 is finite precisely when the output alphabet is. -/
 
-/-- Construction: every Left-OSL rule induces an SFST whose state is the
+/-- Construction: every Left-OSL rule induces a SubsequentialTransducer whose state is the
 output window — a list of output symbols of length at most `k − 1` —
 and whose `finalOutput` is empty. -/
-def OSLRule.toFinSFST {k : ℕ} (r : OSLRule k α β) :
-    SFST {l : List β // l.length ≤ k - 1} α β where
+def OSLRule.toFinSubsequentialTransducer {k : ℕ} (r : OSLRule k α β) :
+    SubsequentialTransducer {l : List β // l.length ≤ k - 1} α β where
   start := ⟨[], Nat.zero_le _⟩
   step w x := ⟨(w.val ++ r.windowOutput w.val x).rtake (k - 1), List.length_rtake_le _ _⟩
   output w x := r.windowOutput w.val x
   finalOutput _ := []
 
-/-- The SFST induced by an OSL rule computes the same string function. -/
-theorem OSLRule.toFinSFST_run_eq_apply {k : ℕ} (r : OSLRule k α β) :
-    r.toFinSFST.run = r.apply := by
+/-- The SubsequentialTransducer induced by an OSL rule computes the same string function. -/
+theorem OSLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} (r : OSLRule k α β) :
+    r.toFinSubsequentialTransducer.run = r.apply := by
   funext input
-  show SFST.runFrom r.toFinSFST ⟨[], Nat.zero_le _⟩ input
+  show SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer ⟨[], Nat.zero_le _⟩ input
          = OSLRule.applyAux r [] input
   suffices h : ∀ w : {l : List β // l.length ≤ k - 1},
-      SFST.runFrom r.toFinSFST w input = OSLRule.applyAux r w.val input from h _
+      SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer w input = OSLRule.applyAux r
+      w.val input from h _
   intro w
   induction input generalizing w with
   | nil => rfl
   | cons x xs ih =>
-    rw [SFST.runFrom_cons]
+    rw [SubsequentialTransducer.runFrom_cons]
     exact congrArg _ (ih _)
 
 /-- **Left-OSL ⊆ Left-Subsequential** (over a finite output alphabet).
@@ -204,14 +206,16 @@ theorem isLeftOutputStrictlyLocal_left_subsequential {k : ℕ} [Fintype β]
     {f : List α → List β} (h : IsLeftOutputStrictlyLocal k f) :
     IsLeftSubsequential f := by
   obtain ⟨r, hr⟩ := h
-  have heq : r.toFinSFST.run = f := r.toFinSFST_run_eq_apply.trans hr
-  exact heq ▸ r.toFinSFST.isLeftSubsequential
+  have heq : r.toFinSubsequentialTransducer.run = f :=
+    r.toFinSubsequentialTransducer_run_eq_apply.trans hr
+  exact heq ▸ r.toFinSubsequentialTransducer.isLeftSubsequential
 
 /-- A single-symbol left-OSL rule is Mealy-computable, with the bounded output window as
 the synchronous state. -/
 theorem isMealyComputable_of_OSLRule {k : ℕ} [Fintype β] (r : OSLRule k α β)
     (hs : ∀ w x, (r.windowOutput w x).length = 1) : IsMealyComputable r.apply :=
-  r.toFinSFST_run_eq_apply ▸ r.toFinSFST.isMealyComputable (fun w x => hs w.val x) fun _ => rfl
+  r.toFinSubsequentialTransducer_run_eq_apply ▸ r.toFinSubsequentialTransducer.isMealyComputable
+  (fun w x => hs w.val x) fun _ => rfl
 
 /-- **Right-OSL ⊆ Right-Subsequential**, derived from the Left- side via
 the reverse-conjugation lemmas. The Right-OSL ↔ Left-OSL and

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -213,7 +213,7 @@ per [aksenova-rawski-graf-heinz-2020]:
   Heinz-Rawski-Tanner 2011 tier-strictly-local family applied to
   function classes).
 
-The non-trivial-tier classification is **deferred** (the SFST witness
+The non-trivial-tier classification is **deferred** (the SubsequentialTransducer witness
 needs to thread the tier projection's state alongside the
 predicate-evaluation state); the identity-tier case is discharged below.
 Land the general witness here once a Studies file consumes it. -/
@@ -223,7 +223,7 @@ namespace Subregular.TierRule
 variable {α : Type*}
 
 /-- The prediction function shared by `applyAt` (under identity tier +
-left side) and the SFST construction: given an "accumulated last
+left side) and the SubsequentialTransducer construction: given an "accumulated last
 context" option, compute the feature value the rule predicts. -/
 def predictFromCtx (r : TierRule α) : Option α → Option Bool
   | none => r.default
@@ -235,28 +235,29 @@ def predictFromCtx (r : TierRule α) : Option α → Option Bool
                       | .disagree => !v)
 
 /-- The `last context-matching segment` of a list as `Option α`. State
-representation for the SFST below: the last input segment so far that
+representation for the SubsequentialTransducer below: the last input segment so far that
 satisfies `targetIsContext`. -/
 def lastContextOf (r : TierRule α) (xs : List α) : Option α :=
   (xs.filter (fun x => decide (r.targetIsContext x))).getLast?
 
-/-- SFST witness for the identity-tier, left-side `applyToString`:
+/-- SubsequentialTransducer witness for the identity-tier, left-side `applyToString`:
 state tracks the last `targetIsContext`-matching input segment. -/
-def toIdTierSFST (r : TierRule α) : SFST (Option α) α (Option Bool) where
+def toIdTierSubsequentialTransducer (r : TierRule α) :
+    SubsequentialTransducer (Option α) α (Option Bool) where
   start := none
   step st s := if r.targetIsContext s then some s else st
   output st _ := [predictFromCtx r st]
   finalOutput _ := []
 
-/-- The SFST's state after one step matches the running `lastContextOf`. -/
-@[simp] lemma toIdTierSFST_step (r : TierRule α) (st : Option α) (s : α) :
-    r.toIdTierSFST.step st s = if r.targetIsContext s then some s else st := rfl
+/-- The SubsequentialTransducer's state after one step matches the running `lastContextOf`. -/
+@[simp] lemma toIdTierSubsequentialTransducer_step (r : TierRule α) (st : Option α) (s : α) :
+    r.toIdTierSubsequentialTransducer.step st s = if r.targetIsContext s then some s else st := rfl
 
-@[simp] lemma toIdTierSFST_output (r : TierRule α) (st : Option α) (s : α) :
-    r.toIdTierSFST.output st s = [predictFromCtx r st] := rfl
+@[simp] lemma toIdTierSubsequentialTransducer_output (r : TierRule α) (st : Option α) (s : α) :
+    r.toIdTierSubsequentialTransducer.output st s = [predictFromCtx r st] := rfl
 
 /-- `lastContextOf` extends by one step: appending a single segment to
-the past updates the running last-context exactly as the SFST step
+the past updates the running last-context exactly as the SubsequentialTransducer step
 does. -/
 lemma lastContextOf_append_singleton (r : TierRule α) (past : List α) (x : α) :
     r.lastContextOf (past ++ [x])
@@ -276,18 +277,20 @@ lemma applyAt_eq_predictFromCtx (r : TierRule α)
   unfold applyAt predictFromCtx lastContextOf
   exact id_tier_left_is_strict_local r h_id h_side past
 
-/-- **The SFST computes `applyToString`.** Generalised over the SFST's
+/-- **The SubsequentialTransducer computes `applyToString`.** Generalised over the
+SubsequentialTransducer's
 starting state (which represents the lastContextOf of some virtual
 past) and the corresponding past. -/
-lemma toIdTierSFST_runFrom_eq_applyToStringAux (r : TierRule α)
+lemma toIdTierSubsequentialTransducer_runFrom_eq_applyToStringAux (r : TierRule α)
     (h_id : r.tier = TierProjection.id) (h_side : r.side = .left)
     (past : List α) (input : List α) :
-    r.toIdTierSFST.runFrom (r.lastContextOf past) input
+    r.toIdTierSubsequentialTransducer.runFrom (r.lastContextOf past) input
       = applyToString.applyToStringAux r input past := by
   induction input generalizing past with
   | nil => rfl
   | cons x xs ih =>
-    rw [SFST.runFrom_cons, toIdTierSFST_output, toIdTierSFST_step]
+    rw [SubsequentialTransducer.runFrom_cons, toIdTierSubsequentialTransducer_output,
+    toIdTierSubsequentialTransducer_step]
     rw [show (if r.targetIsContext x then some x else r.lastContextOf past)
           = r.lastContextOf (past ++ [x]) from
         (r.lastContextOf_append_singleton past x).symm]
@@ -296,17 +299,18 @@ lemma toIdTierSFST_runFrom_eq_applyToStringAux (r : TierRule α)
 
 /-- **Identity-tier left-side TierRules reify to Left-Subsequential
 functions.** Closes audit D6 with a real witness construction (not a
-sorry): the SFST has state `Option α` (last-context-matching segment
+sorry): the SubsequentialTransducer has state `Option α` (last-context-matching segment
 seen) and emits the rule's prediction at each step. -/
 theorem applyToString_isLeftSubsequential_of_id_tier [Fintype α]
     (r : TierRule α) (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) :
     IsLeftSubsequential r.applyToString := by
-  have h_run : r.toIdTierSFST.run = r.applyToString := by
+  have h_run : r.toIdTierSubsequentialTransducer.run = r.applyToString := by
     funext input
-    show r.toIdTierSFST.runFrom none input = applyToString.applyToStringAux r input []
+    show r.toIdTierSubsequentialTransducer.runFrom none input =
+      applyToString.applyToStringAux r input []
     -- `none = lastContextOf []` definitionally
-    exact r.toIdTierSFST_runFrom_eq_applyToStringAux h_id h_side [] input
-  exact h_run ▸ r.toIdTierSFST.isLeftSubsequential
+    exact r.toIdTierSubsequentialTransducer_runFrom_eq_applyToStringAux h_id h_side [] input
+  exact h_run ▸ r.toIdTierSubsequentialTransducer.isLeftSubsequential
 
 /-! ### Myopia: the tier-rule prediction has no look-ahead -/
 

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -69,7 +69,7 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
    formaliser-invented alphabet from the previous version of this file
    (which conflated [+ATR] with the spreading trigger) is replaced.
 2. Encodes the **rightward [+ATR] spreading** half of Maasai harmony
-   as both a `SFST` and an `OSLRule`. Single-direction iterative
+   as both a `SubsequentialTransducer` and an `OSLRule`. Single-direction iterative
    spreading is **Output-Strictly-Local** ([chandlee-eyraud-heinz-2015],
    the result [meinhardt-mai-bakovic-mccollum-2024] builds on) — the
    output decision at each position depends on whether the immediately
@@ -201,11 +201,11 @@ def rightwardATR_osl : OSLRule 2 Seg Seg where
     | .recL, .recH :: _ => [.recH]
     | .recL, _ => [.recL]
 
-/-- Equivalent SFST for the same map: state tracks whether spread is
+/-- Equivalent SubsequentialTransducer for the same map: state tracks whether spread is
 active. Demonstrates that the rule has both an OSL representation
 (above) and a Subsequential representation (here) — the latter being
 the umbrella class. -/
-def rightwardATR : SFST Bool Seg Seg where
+def rightwardATR : SubsequentialTransducer Bool Seg Seg where
   start := false
   step spreading s :=
     match s with
@@ -256,7 +256,7 @@ example : rightwardATR.run [.recL, .recL] = [.recL, .recL] := by decide
 
 example : rightwardATR_osl.apply [.recL, .recL] = [.recL, .recL] := by decide
 
-/-- **Two SFSTs / OSL rules agree** on the encoded examples. (Full
+/-- **Two SubsequentialTransducers / OSL rules agree** on the encoded examples. (Full
 extensional equivalence on all inputs would require a separate
 induction; this is the expected agreement on paper-cited cases.) -/
 example : rightwardATR.run [.dom, .recL, .a, .recL]
@@ -279,7 +279,7 @@ theorem rightwardATR_osl_isLeftOutputStrictlyLocal :
   rightwardATR_osl.isLeftOutputStrictlyLocal_apply
 
 /-- **Rightward [+ATR] spreading is also Left-Subsequential** (a weaker
-claim than OSL but the umbrella class). Witness: the SFST. -/
+claim than OSL but the umbrella class). Witness: the SubsequentialTransducer. -/
 theorem rightwardATR_isLeftSubsequential :
     IsLeftSubsequential rightwardATR.run :=
   rightwardATR.isLeftSubsequential


### PR DESCRIPTION
`SFST` appears in neither Sakarovitch's *Elements of Automata Theory* nor the Filiot–Reynier 2016 survey — unlike `DFA`/`NFA`, which mathlib uses because they are universally recognized, it is a computational-phonology coinage. Spelled out to `SubsequentialTransducer` (145 occurrences, 7 files), with signature lines rewrapped to the 100-column limit.

`Subsequential` itself stays: Sakarovitch calls this object *sequential*, but §V.1.2.1 is titled "Some unconventional terminology" and Remark 1.2 concedes he calls sequential "that which is commonly called (following Schützenberger) sub-sequential". His own bibliography cites Choffrut and Reutenauer on *subsequential* transducers and functions, so the current name is the conventional one.