### PR TITLE
feat(Core/Algebra): semigroup pseudovarieties and the +-variety langs operator

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -3,6 +3,7 @@
 /-
 A Lean 4 library for formal linguistics, covering semantics, pragmatics,
 and their interfaces. See README.md for documentation links.
+import Linglib.Core.Algebra.Free
 import Linglib.Core.Algebra.FreeMonoid.Destutter
 import Linglib.Core.Algebra.Group.Aperiodic
 import Linglib.Core.Algebra.Group.Idempotent
@@ -51,6 +52,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
 import Linglib.Core.Algebra.RotaBaxter
 import Linglib.Core.Algebra.RotaBaxterLaurent
+import Linglib.Core.Algebra.Semigroup.IdempotentPower
+import Linglib.Core.Algebra.Semigroup.Pseudovariety
 import Linglib.Core.Analysis.Convex.Function
 import Linglib.Core.Analysis.LeastSquares
 import Linglib.Core.Analysis.SpecialFunctions.Log.NegMulLog
@@ -95,6 +98,7 @@ import Linglib.Core.Computability.Variety.Correspondence
 import Linglib.Core.Computability.Variety.Equations
 import Linglib.Core.Computability.Variety.Langs
 import Linglib.Core.Computability.Variety.OmegaEquations
+import Linglib.Core.Computability.Variety.SemigroupLangs
 import Linglib.Core.Computability.WordModel
 import Linglib.Core.Data.Fin.Tuple.Basic
 import Linglib.Core.Data.Fintype.Sets

--- a/Linglib/Core/Algebra/Free.lean
+++ b/Linglib/Core/Algebra/Free.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Free`. Upstreaming requires `@[to_additive]` with a
+`FreeAddSemigroup.toList` counterpart, as every declaration in that file is additivized.
+-/
+import Mathlib.Algebra.Free
+
+/-!
+# The word underlying a free-semigroup element
+
+`FreeSemigroup α` is presented in mathlib as a `head`/`tail` pair, with no conversion to `List α`.
+`FreeSemigroup.toList` supplies it; the free semigroup is the nonempty words, so the conversion is
+`head :: tail` and multiplication becomes concatenation.
+-/
+
+namespace FreeSemigroup
+
+variable {α : Type*}
+
+/-- The nonempty word underlying a free-semigroup element. -/
+def toList (u : FreeSemigroup α) : List α := u.head :: u.tail
+
+@[simp] theorem toList_mul (u v : FreeSemigroup α) :
+    (u * v).toList = u.toList ++ v.toList := rfl
+
+end FreeSemigroup

--- a/Linglib/Core/Algebra/Semigroup/IdempotentPower.lean
+++ b/Linglib/Core/Algebra/Semigroup/IdempotentPower.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Group.Semigroup.IdempotentPower`.
+-/
+import Linglib.Core.Algebra.IdempotentPower
+import Mathlib.Algebra.Group.WithOne.Basic
+import Mathlib.Data.Fintype.Option
+
+/-!
+# Idempotent powers in a finite semigroup
+
+Every element of a finite semigroup has an idempotent positive power. This is the basic
+structural fact behind the equational description of semigroup pseudovarieties: it is what makes
+a homomorphic image of a member a member, since a preimage of an idempotent need not itself be
+idempotent, but an idempotent *power* of a preimage is one and has the same image.
+
+The monoid case is `Monoid.exists_pos_pow_isIdempotent`. The semigroup case is obtained from it by
+adjoining an identity: `WithOne S` is a finite monoid, positive powers of a coerced element are
+themselves coerced, and `WithOne.coe_inj` transfers idempotency back.
+
+## Main results
+
+* `Semigroup.exists_isIdempotentElem`: a finite nonempty semigroup contains an idempotent.
+* `Semigroup.exists_isIdempotentElem_map_eq`: a surjective homomorphism onto a semigroup lifts an
+  idempotent to an idempotent — the form the pseudovariety quotient-closure proof consumes.
+-/
+
+namespace WithOne
+
+variable {S : Type*} [Semigroup S]
+
+/-- `WithOne S` is `Option S`, so it inherits finiteness. -/
+instance instFinite [Finite S] : Finite (WithOne S) := inferInstanceAs (Finite (Option S))
+
+/-- Idempotency is detected by the coercion into `WithOne`. -/
+@[simp] theorem isIdempotentElem_coe {e : S} :
+    IsIdempotentElem ((e : WithOne S)) ↔ IsIdempotentElem e := by
+  rw [IsIdempotentElem, ← WithOne.coe_mul, WithOne.coe_inj]; rfl
+
+/-- A positive power of a coerced element of `WithOne S` is itself coerced. -/
+theorem exists_coe_pow (x : S) : ∀ n : ℕ, 0 < n → ∃ y : S, (x : WithOne S) ^ n = y
+  | 1, _ => ⟨x, pow_one _⟩
+  | n + 2, _ => by
+    obtain ⟨y, hy⟩ := exists_coe_pow x (n + 1) n.succ_pos
+    exact ⟨x * y, by rw [pow_succ', hy, ← WithOne.coe_mul]⟩
+
+end WithOne
+
+namespace Semigroup
+
+variable {S T : Type*} [Semigroup S] [Semigroup T]
+
+variable [Finite S]
+
+/-- Every element has an idempotent positive power, with the exponent realized in `WithOne S`.
+The `WithOne` shape is the proof device; `exists_isIdempotentElem` and
+`exists_isIdempotentElem_map_eq` are the statements consumers want. -/
+private theorem exists_pos_pow_isIdempotentElem_coe (x : S) :
+    ∃ (n : ℕ) (e : S), 0 < n ∧ (x : WithOne S) ^ n = e ∧ IsIdempotentElem e := by
+  obtain ⟨n, hn, hidem⟩ := Monoid.exists_pos_pow_isIdempotent (x : WithOne S)
+  obtain ⟨e, he⟩ := WithOne.exists_coe_pow x n hn
+  exact ⟨n, e, hn, he, WithOne.isIdempotentElem_coe.1 (he ▸ hidem)⟩
+
+/-- **A finite nonempty semigroup contains an idempotent.** -/
+theorem exists_isIdempotentElem [Nonempty S] : ∃ e : S, IsIdempotentElem e :=
+  have ⟨x⟩ := ‹Nonempty S›
+  have ⟨_, e, _, _, he⟩ := exists_pos_pow_isIdempotentElem_coe x
+  ⟨e, he⟩
+
+/-- A surjective homomorphism lifts an idempotent to an idempotent: replace a preimage by an
+idempotent power of it, which the homomorphism still sends to the (idempotent) target. -/
+theorem exists_isIdempotentElem_map_eq {f : S →ₙ* T} (hf : Function.Surjective f) {e' : T}
+    (he' : IsIdempotentElem e') : ∃ e : S, IsIdempotentElem e ∧ f e = e' := by
+  obtain ⟨x, rfl⟩ := hf e'
+  obtain ⟨n, e, hn, he, hidem⟩ := exists_pos_pow_isIdempotentElem_coe x
+  refine ⟨e, hidem, ?_⟩
+  have hmap : (WithOne.mapMulHom f) ((x : WithOne S) ^ n) = ((f x : T) : WithOne T) ^ n := by
+    rw [map_pow, WithOne.mapMulHom_coe]
+  rw [he, WithOne.mapMulHom_coe] at hmap
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  rwa [(WithOne.isIdempotentElem_coe.2 he').pow_succ_eq, WithOne.coe_inj] at hmap
+
+end Semigroup

--- a/Linglib/Core/Algebra/Semigroup/Pseudovariety.lean
+++ b/Linglib/Core/Algebra/Semigroup/Pseudovariety.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Group.Semigroup.Pseudovariety`.
+-/
+import Linglib.Core.Algebra.Semigroup.IdempotentPower
+import Mathlib.Algebra.Group.Prod
+import Mathlib.Algebra.Group.PUnit
+
+/-!
+# Pseudovarieties of finite semigroups
+
+A **pseudovariety of finite semigroups** ([eilenberg-1976]) is a class of finite semigroups closed
+under subsemigroups, quotients, and finite direct products. It is the semigroup-side counterpart of
+`Monoid.Pseudovariety`, and the two are not interchangeable: the classes `D`, `K` and `LI` below
+are semigroup varieties that collapse over monoids, since applying their defining condition to the
+idempotent `1` forces triviality.
+
+The conditions are stated on idempotents, as Eilenberg states them: `D` is `Se = e`
+([eilenberg-1976] VIII.4.1) and `LI` is `eSe = e` (VIII.5.1), with `K` the left-right dual of `D`.
+Quotient closure is where the semigroup case departs from the monoid one — a preimage of an
+idempotent need not be idempotent — and is discharged by
+`Semigroup.exists_isIdempotentElem_map_eq`.
+
+## Main definitions
+
+* `Semigroup.Pseudovariety`: a class of finite semigroups closed under subsemigroup, quotient,
+  product.
+* `Semigroup.IsDefinite`, `IsReverseDefinite`, `IsLocallyTrivial`: the defining conditions of
+  `D`, `K`, `LI`.
+* `Semigroup.definiteVariety`, `reverseDefiniteVariety`, `locallyTrivialVariety`: the bundled
+  pseudovarieties.
+
+## Implementation notes
+
+`mem` is a total predicate over `Type u` semigroups, mirroring `Monoid.Pseudovariety`; the
+finiteness characteristic of a *pseudo*variety lives on the closure-field hypotheses. The variety
+`N` of nilpotent semigroups is the intersection of `D` and `K` and is not bundled here.
+-/
+
+universe u
+
+namespace Semigroup
+
+/-- A **pseudovariety of finite semigroups**: a class closed under subsemigroups, quotients, and
+finite products. Closure is phrased via injective/surjective `MulHom`s (the divisor form). -/
+structure Pseudovariety where
+  /-- The semigroups belonging to the pseudovariety. -/
+  mem : ∀ (S : Type u) [Semigroup S], Prop
+  /-- Closed under subsemigroups: an injective homomorphism into a member has member domain. -/
+  sub : ∀ {S T : Type u} [Semigroup S] [Semigroup T] [Finite S] [Finite T] {f : S →ₙ* T},
+    Function.Injective f → mem T → mem S
+  /-- Closed under quotients: a surjective homomorphism from a member has member codomain. -/
+  quot : ∀ {S T : Type u} [Semigroup S] [Semigroup T] [Finite S] [Finite T] {f : S →ₙ* T},
+    Function.Surjective f → mem S → mem T
+  /-- Closed under binary products. -/
+  prod : ∀ {S T : Type u} [Semigroup S] [Semigroup T] [Finite S] [Finite T],
+    mem S → mem T → mem (S × T)
+  /-- Contains the trivial semigroup (the empty product). -/
+  memUnit : mem PUnit.{u + 1}
+
+namespace Pseudovariety
+
+variable (V : Pseudovariety.{u})
+
+/-- Closed under isomorphism (a special case of `quot`). -/
+theorem mem_of_mulEquiv {S T : Type u} [Semigroup S] [Semigroup T] [Finite S] [Finite T]
+    (e : S ≃* T) (h : V.mem S) : V.mem T :=
+  V.quot (f := e.toMulHom) e.surjective h
+
+end Pseudovariety
+
+variable {S T : Type*} [Semigroup S] [Semigroup T]
+
+/-! ### The conditions defining `D`, `K` and `LI` -/
+
+/-- A finite semigroup is **definite** when every idempotent absorbs on the left: `Se = e`
+([eilenberg-1976] VIII.4.1). -/
+def IsDefinite (S : Type*) [Semigroup S] : Prop :=
+  ∀ e : S, IsIdempotentElem e → ∀ s : S, s * e = e
+
+/-- A finite semigroup is **reverse definite** when every idempotent absorbs on the right — the
+left-right dual of `IsDefinite`. -/
+def IsReverseDefinite (S : Type*) [Semigroup S] : Prop :=
+  ∀ e : S, IsIdempotentElem e → ∀ s : S, e * s = e
+
+/-- A finite semigroup is **locally trivial** when every idempotent absorbs on both sides at once:
+`eSe = e` ([eilenberg-1976] VIII.5.1). This is the condition behind the generalized definite
+languages. -/
+def IsLocallyTrivial (S : Type*) [Semigroup S] : Prop :=
+  ∀ e : S, IsIdempotentElem e → ∀ s : S, e * s * e = e
+
+/-! ### Closure properties -/
+
+theorem IsDefinite.of_injective {f : S →ₙ* T} (hf : Function.Injective f) (h : IsDefinite T) :
+    IsDefinite S := fun e he s => hf <| by rw [map_mul, h (f e) (he.map f) (f s)]
+
+theorem IsReverseDefinite.of_injective {f : S →ₙ* T} (hf : Function.Injective f)
+    (h : IsReverseDefinite T) : IsReverseDefinite S := fun e he s => hf <| by
+  rw [map_mul, h (f e) (he.map f) (f s)]
+
+theorem IsLocallyTrivial.of_injective {f : S →ₙ* T} (hf : Function.Injective f)
+    (h : IsLocallyTrivial T) : IsLocallyTrivial S := fun e he s => hf <| by
+  rw [map_mul, map_mul, h (f e) (he.map f) (f s)]
+
+theorem IsDefinite.prod (hS : IsDefinite S) (hT : IsDefinite T) : IsDefinite (S × T) := by
+  rintro ⟨e₁, e₂⟩ he ⟨s₁, s₂⟩
+  exact Prod.ext (hS e₁ (congrArg Prod.fst he) s₁) (hT e₂ (congrArg Prod.snd he) s₂)
+
+theorem IsReverseDefinite.prod (hS : IsReverseDefinite S) (hT : IsReverseDefinite T) :
+    IsReverseDefinite (S × T) := by
+  rintro ⟨e₁, e₂⟩ he ⟨s₁, s₂⟩
+  exact Prod.ext (hS e₁ (congrArg Prod.fst he) s₁) (hT e₂ (congrArg Prod.snd he) s₂)
+
+theorem IsLocallyTrivial.prod (hS : IsLocallyTrivial S) (hT : IsLocallyTrivial T) :
+    IsLocallyTrivial (S × T) := by
+  rintro ⟨e₁, e₂⟩ he ⟨s₁, s₂⟩
+  exact Prod.ext (hS e₁ (congrArg Prod.fst he) s₁) (hT e₂ (congrArg Prod.snd he) s₂)
+
+/-- **`D` collapses over monoids**: a definite monoid is trivial, since the condition applied to
+the idempotent `1` gives `s = s * 1 = 1`. This is why `D`, `K` and `LI` are semigroup varieties. -/
+theorem IsDefinite.subsingleton {M : Type*} [Monoid M] (h : IsDefinite M) : Subsingleton M :=
+  ⟨fun a b => by rw [← mul_one a, h 1 .one a, ← mul_one b, h 1 .one b]⟩
+
+/-- A definite semigroup is locally trivial: apply `Se = e` at the element `e * s`. -/
+theorem IsDefinite.isLocallyTrivial (h : IsDefinite S) : IsLocallyTrivial S :=
+  fun e he s => h e he (e * s)
+
+/-- A reverse definite semigroup is locally trivial: apply `eS = e` twice. -/
+theorem IsReverseDefinite.isLocallyTrivial (h : IsReverseDefinite S) : IsLocallyTrivial S :=
+  fun e he s => by rw [h e he s, h e he e]
+
+variable [Finite S]
+
+theorem IsDefinite.of_surjective {f : S →ₙ* T} (hf : Function.Surjective f) (h : IsDefinite S) :
+    IsDefinite T := by
+  intro e' he' t
+  obtain ⟨e, he, rfl⟩ := exists_isIdempotentElem_map_eq hf he'
+  obtain ⟨s, rfl⟩ := hf t
+  rw [← map_mul, h e he s]
+
+theorem IsReverseDefinite.of_surjective {f : S →ₙ* T} (hf : Function.Surjective f)
+    (h : IsReverseDefinite S) : IsReverseDefinite T := by
+  intro e' he' t
+  obtain ⟨e, he, rfl⟩ := exists_isIdempotentElem_map_eq hf he'
+  obtain ⟨s, rfl⟩ := hf t
+  rw [← map_mul, h e he s]
+
+theorem IsLocallyTrivial.of_surjective {f : S →ₙ* T} (hf : Function.Surjective f)
+    (h : IsLocallyTrivial S) : IsLocallyTrivial T := by
+  intro e' he' t
+  obtain ⟨e, he, rfl⟩ := exists_isIdempotentElem_map_eq hf he'
+  obtain ⟨s, rfl⟩ := hf t
+  rw [← map_mul, ← map_mul, h e he s]
+
+/-! ### The bundled pseudovarieties -/
+
+/-- The pseudovariety **D** of definite semigroups. -/
+def definiteVariety : Pseudovariety.{u} where
+  mem S := IsDefinite S
+  sub hf h := h.of_injective hf
+  quot hf h := h.of_surjective hf
+  prod hS hT := hS.prod hT
+  memUnit _ _ _ := rfl
+
+/-- The pseudovariety **K** of reverse definite semigroups. -/
+def reverseDefiniteVariety : Pseudovariety.{u} where
+  mem S := IsReverseDefinite S
+  sub hf h := h.of_injective hf
+  quot hf h := h.of_surjective hf
+  prod hS hT := hS.prod hT
+  memUnit _ _ _ := rfl
+
+/-- The pseudovariety **LI** of locally trivial semigroups. -/
+def locallyTrivialVariety : Pseudovariety.{u} where
+  mem S := IsLocallyTrivial S
+  sub hf h := h.of_injective hf
+  quot hf h := h.of_surjective hf
+  prod hS hT := hS.prod hT
+  memUnit _ _ _ := rfl
+
+@[simp] theorem mem_definiteVariety {S : Type u} [Semigroup S] :
+    definiteVariety.mem S ↔ IsDefinite S := Iff.rfl
+
+@[simp] theorem mem_reverseDefiniteVariety {S : Type u} [Semigroup S] :
+    reverseDefiniteVariety.mem S ↔ IsReverseDefinite S := Iff.rfl
+
+@[simp] theorem mem_locallyTrivialVariety {S : Type u} [Semigroup S] :
+    locallyTrivialVariety.mem S ↔ IsLocallyTrivial S := Iff.rfl
+
+end Semigroup

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -50,17 +50,43 @@ variable {α : Type*} (L : Language α)
 
 /-! ### The syntactic congruence and monoid -/
 
+/-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
+them as `L`-members. Both syntactic congruences — on `FreeMonoid α` here and on `FreeSemigroup α`
+in `Language.syntacticSemigroupCon` — are this one relation, read on their respective carriers. -/
+def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
+
+variable {L}
+
+@[refl] theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
+
+@[symm] theorem SyntacticEquiv.symm {u v : List α} (h : L.SyntacticEquiv u v) :
+    L.SyntacticEquiv v u := fun x y => (h x y).symm
+
+@[trans] theorem SyntacticEquiv.trans {u v w : List α} (h : L.SyntacticEquiv u v)
+    (h' : L.SyntacticEquiv v w) : L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
+
+/-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
+both syntactic congruences. -/
+theorem SyntacticEquiv.append {u u' v v' : List α} (h : L.SyntacticEquiv u u')
+    (h' : L.SyntacticEquiv v v') : L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
+  have h1 := h x (v ++ y)
+  have h2 := h' (x ++ u') y
+  simp only [← List.append_assoc] at h1 h2 ⊢
+  exact h1.trans h2
+
+/-- Syntactically equivalent words agree on membership: take the empty context. -/
+theorem mem_iff_of_syntacticEquiv {u v : List α} (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
+  have := h [] []
+  simpa using this
+
+variable (L)
+
 /-- The *syntactic congruence* of `L`: two words are congruent when no two-sided context
 distinguishes them as `L`-members. -/
 def syntacticCon : Con (FreeMonoid α) where
-  r u v := ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L
-  iseqv :=
-    ⟨fun _ _ _ => Iff.rfl, fun h x y => (h x y).symm, fun h h' x y => (h x y).trans (h' x y)⟩
-  mul' {a b c d} hab hcd x y := by
-    have h1 := hab x (c.toList ++ y)
-    have h2 := hcd (x ++ b.toList) y
-    simp only [FreeMonoid.toList_mul, ← List.append_assoc] at h1 h2 ⊢
-    exact h1.trans h2
+  r u v := L.SyntacticEquiv u.toList v.toList
+  iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
+  mul' hab hcd := hab.append hcd
 
 /-- The syntactic congruence is two-sided context equivalence — by definition. -/
 theorem syntacticCon_iff {u v : FreeMonoid α} :

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 [UPSTREAM] candidate: `Mathlib.Computability.SyntacticSemigroup`.
 -/
 import Linglib.Core.Computability.SyntacticMonoid
-import Mathlib.Algebra.Free
+import Linglib.Core.Algebra.Free
 
 /-!
 # The syntactic semigroup of a language
@@ -18,86 +18,38 @@ the classes `D`, `K`, `LI`, `N` are varieties of *semigroups*, not of monoids. O
 those classes collapse, since the definite condition applied to the idempotent `1` forces
 triviality; stating them on `FreeSemigroup α` is what avoids the collapse.
 
-`Language.SyntacticEquiv` is the underlying two-sided context relation, shared with
-`Language.syntacticCon`: the two congruences differ only in the monoid they live on.
+`Language.SyntacticEquiv` is the underlying two-sided context relation, defined with
+`Language.syntacticCon`: both congruences are that one relation read on their own carrier, and
+share its multiplicativity lemma `SyntacticEquiv.append`.
 
 ## Main definitions
 
-* `Language.SyntacticEquiv`: two words are equivalent when no two-sided context separates them.
 * `Language.syntacticSemigroupCon`: the syntactic congruence on `FreeSemigroup α`.
 * `Language.syntacticSemigroup`: the quotient semigroup.
 * `Language.toSyntacticSemigroup`: the projection, as a `MulHom`.
-* `FreeSemigroup.toList`: the nonempty word underlying a free-semigroup element.
 
 ## Main results
 
-* `Language.syntacticSemigroupClass_eq_iff`: two nonempty words share a class exactly when no
-  two-sided context separates them.
+* `Language.syntacticSemigroupToMonoid_injective`: the syntactic semigroup embeds in the
+  syntactic monoid.
 
 ## Implementation notes
 
-The projection is built by hand rather than with `Con.mk'`, which mathlib provides only as
-`M →* c.Quotient` for `[Monoid M]`; there is no `MulHom`-valued projection for a `Con` over a plain
-`Mul`. `FreeSemigroup.toList` is likewise absent from mathlib.
+The projection is `Con.mkMulHom`, mathlib's `MulHom`-valued quotient map for a `Con` over a plain
+`Mul` (the monoid-valued `Con.mk'` would not apply). `FreeSemigroup.toList` is absent from mathlib
+and is supplied by `Linglib.Core.Algebra.Free`.
 -/
-
-namespace FreeSemigroup
-
-variable {α : Type*}
-
-/-- The nonempty word underlying a free-semigroup element. -/
-def toList (u : FreeSemigroup α) : List α := u.head :: u.tail
-
-@[simp] theorem toList_of (a : α) : (of a).toList = [a] := rfl
-
-@[simp] theorem toList_mul (u v : FreeSemigroup α) :
-    (u * v).toList = u.toList ++ v.toList := rfl
-
-@[simp] theorem toList_ne_nil (u : FreeSemigroup α) : u.toList ≠ [] := List.cons_ne_nil _ _
-
-@[simp] theorem length_toList (u : FreeSemigroup α) : u.toList.length = u.length := rfl
-
-theorem toList_injective : Function.Injective (toList (α := α)) := by
-  rintro ⟨a, s⟩ ⟨b, t⟩ h
-  simpa [toList, and_comm] using h
-
-end FreeSemigroup
 
 namespace Language
 
 variable {α : Type*} (L : Language α)
-
-/-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
-them as `L`-members. This is the relation underlying both syntactic congruences. -/
-def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
-
-variable {L} in
-theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
-
-variable {L} in
-theorem SyntacticEquiv.symm {u v : List α} (h : L.SyntacticEquiv u v) : L.SyntacticEquiv v u :=
-  fun x y => (h x y).symm
-
-variable {L} in
-theorem SyntacticEquiv.trans {u v w : List α} (h : L.SyntacticEquiv u v)
-    (h' : L.SyntacticEquiv v w) : L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
-
-variable {L} in
-/-- Syntactically equivalent words agree on membership: take the empty context. -/
-theorem mem_iff_of_syntacticEquiv {u v : List α} (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
-  have := h [] []
-  simpa using this
 
 /-- The **syntactic congruence** on the free semigroup: the syntactic equivalence of the
 underlying nonempty words. -/
 def syntacticSemigroupCon : Con (FreeSemigroup α) where
   r u v := L.SyntacticEquiv u.toList v.toList
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
-  mul' {a b c d} hab hcd x y := by
-    have h1 := hab x (c.toList ++ y)
-    have h2 := hcd (x ++ b.toList) y
-    simp only [FreeSemigroup.toList_mul, ← List.append_assoc] at h1 h2 ⊢
-    exact h1.trans h2
+  mul' hab hcd := hab.append hcd
 
 theorem syntacticSemigroupCon_iff {u v : FreeSemigroup α} :
     L.syntacticSemigroupCon u v ↔ L.SyntacticEquiv u.toList v.toList := Iff.rfl
@@ -110,9 +62,8 @@ instance : Semigroup (syntacticSemigroup L) :=
   inferInstanceAs (Semigroup (syntacticSemigroupCon L).Quotient)
 
 /-- The canonical projection sending a nonempty word to its syntactic class. -/
-def toSyntacticSemigroup : FreeSemigroup α →ₙ* L.syntacticSemigroup where
-  toFun := (syntacticSemigroupCon L).toQuotient
-  map_mul' _ _ := rfl
+def toSyntacticSemigroup : FreeSemigroup α →ₙ* L.syntacticSemigroup :=
+  Con.mkMulHom (syntacticSemigroupCon L)
 
 theorem toSyntacticSemigroup_eq_iff {u v : FreeSemigroup α} :
     L.toSyntacticSemigroup u = L.toSyntacticSemigroup v ↔ L.syntacticSemigroupCon u v :=
@@ -121,20 +72,39 @@ theorem toSyntacticSemigroup_eq_iff {u v : FreeSemigroup α} :
 theorem toSyntacticSemigroup_surjective : Function.Surjective L.toSyntacticSemigroup :=
   fun s => Quotient.exists_rep s
 
-/-- The syntactic class of a nonempty word. -/
-def syntacticSemigroupClass (u : FreeSemigroup α) : L.syntacticSemigroup :=
-  L.toSyntacticSemigroup u
+/-! ### Relation to the syntactic monoid -/
 
-@[simp] theorem syntacticSemigroupClass_mul (u v : FreeSemigroup α) :
-    L.syntacticSemigroupClass (u * v)
-      = L.syntacticSemigroupClass u * L.syntacticSemigroupClass v := rfl
+/-- The syntactic semigroup embeds into the syntactic monoid: a nonempty word is sent to its
+class in the monoid. It is injective because both quotients are by the same context relation. -/
+def syntacticSemigroupToMonoid : L.syntacticSemigroup →ₙ* L.syntacticMonoid where
+  toFun := Quotient.lift (fun u : FreeSemigroup α => L.syntacticClass u.toList)
+    fun _ _ h => syntacticClass_eq_iff.mpr h
+  map_mul' := by rintro ⟨u⟩ ⟨v⟩; exact L.syntacticClass_append u.toList v.toList
 
-variable {L} in
-/-- Two nonempty words share a syntactic class exactly when no two-sided context distinguishes
-them as `L`-members. -/
-theorem syntacticSemigroupClass_eq_iff {u v : FreeSemigroup α} :
-    L.syntacticSemigroupClass u = L.syntacticSemigroupClass v
-      ↔ ∀ x y : List α, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
-  toSyntacticSemigroup_eq_iff L
+@[simp] theorem syntacticSemigroupToMonoid_apply (u : FreeSemigroup α) :
+    L.syntacticSemigroupToMonoid (L.toSyntacticSemigroup u) = L.syntacticClass u.toList := rfl
+
+
+theorem syntacticSemigroupToMonoid_injective :
+    Function.Injective L.syntacticSemigroupToMonoid := by
+  rintro ⟨u⟩ ⟨v⟩ h
+  exact Quotient.sound (syntacticClass_eq_iff.mp h)
+
+/-- A regular language has a finite syntactic semigroup, since it embeds in the syntactic
+monoid. -/
+instance instFiniteSyntacticSemigroup [Finite L.syntacticMonoid] :
+    Finite L.syntacticSemigroup :=
+  .of_injective _ L.syntacticSemigroupToMonoid_injective
+
+/-- A regular language has a finite syntactic semigroup. -/
+theorem finite_syntacticSemigroup (h : L.IsRegular) : Finite L.syntacticSemigroup :=
+  haveI := finite_syntacticMonoid h
+  inferInstance
+
+/-- The syntactic congruence is complement-invariant, as on the monoid side. -/
+theorem syntacticSemigroupCon_compl : Lᶜ.syntacticSemigroupCon = L.syntacticSemigroupCon := by
+  ext u v
+  simp only [syntacticSemigroupCon_iff, SyntacticEquiv]
+  exact ⟨fun h x y => not_iff_not.mp (h x y), fun h x y => not_iff_not.mpr (h x y)⟩
 
 end Language

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Computability.Variety.SemigroupLangs`.
+-/
+import Linglib.Core.Algebra.Semigroup.Pseudovariety
+import Linglib.Core.Computability.SyntacticSemigroup
+
+/-!
+# The language-side operator of a semigroup pseudovariety
+
+For a pseudovariety `V` of finite semigroups, `V.langs` collects the regular languages whose
+syntactic *semigroup* lies in `V`. This is the `+`-variety half of the Eilenberg correspondence
+([eilenberg-1976] Ch. VII), the counterpart of `Monoid.Pseudovariety.langs`.
+
+The semigroup half is what the classes `D`, `K`, `LI` require: they are not monoid varieties, so
+they have no image under the monoid-side operator.
+
+## Main definitions
+
+* `Semigroup.Pseudovariety.langs`: the languages whose syntactic semigroup lies in `V`.
+
+## Main results
+
+* `Semigroup.Pseudovariety.langs_compl`: closure under complement, from complement-invariance of
+  the syntactic congruence.
+-/
+
+universe u
+
+namespace Semigroup.Pseudovariety
+
+open Language
+
+variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
+
+/-- The languages over `α` whose (necessarily finite) syntactic semigroup lies in `V` — the
+`+`-variety side of the Eilenberg correspondence. -/
+def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticSemigroup
+
+theorem langs_def : V.langs L ↔ L.IsRegular ∧ V.mem L.syntacticSemigroup := Iff.rfl
+
+/-- **Closure under complement** — immediate from complement-invariance of the syntactic
+congruence (`Language.syntacticSemigroupCon_compl`). -/
+theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
+  refine ⟨h.1.compl, ?_⟩
+  show V.mem (syntacticSemigroupCon Lᶜ).Quotient
+  rw [syntacticSemigroupCon_compl]
+  exact h.2
+
+end Semigroup.Pseudovariety


### PR DESCRIPTION
Recovers work stranded when #1668 squash-merged its first commit only; everything here was reviewed and rebuilt against current main.

Builds the semigroup half of the Eilenberg correspondence, which linglib lacked entirely — `D`, `K`, `LI` are varieties of *semigroups* and collapse over monoids, now a theorem rather than a claim (`IsDefinite.subsingleton`).

- `Semigroup.exists_isIdempotentElem_map_eq`: a surjective hom lifts an idempotent — what quotient-closure needs, since a preimage of an idempotent need not be idempotent. Proved by adjoining an identity and borrowing the monoid result, so it does not duplicate the `MulSeq` work in flight upstream (leanprover-community/mathlib4#41822).
- `Semigroup.Pseudovariety` with `D`/`K`/`LI` stated on idempotents as [eilenberg-1976] states them (VIII.4.1 `Se = e`, VIII.5.1 `eSe = e`), using mathlib's `IsIdempotentElem`.
- `Semigroup.Pseudovariety.langs` with complement closure; finiteness transfers because the syntactic semigroup embeds in the syntactic monoid.
- `Language.SyntacticEquiv` is now genuinely shared: both congruences are that one relation on their own carrier, with a common `SyntacticEquiv.append`.

`langs_inf`/`sup`/`comap` need a small semigroup `Con` kit (`liftMulHom`, `kerLiftMulHom`, `mapMulHom`) that mathlib provides only for monoids; that is the next PR and it also simplifies the existing monoid `Langs.lean`.