### PR TITLE
feat(Core/GroupTheory): universal property for the MulHom quotient lift

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -127,6 +127,7 @@ import Linglib.Core.Data.RoseTree.Nonplanar
 import Linglib.Core.Data.RoseTree.Perm
 import Linglib.Core.Data.RoseTree.Traversable
 import Linglib.Core.Data.Setoid.Basic
+import Linglib.Core.GroupTheory.Congruence.Hom
 import Linglib.Core.InformationTheory.KullbackLeibler.Basic
 import Linglib.Core.InformationTheory.KullbackLeibler.Cond
 import Linglib.Core.InformationTheory.MutualInformation
@@ -154,7 +155,6 @@ import Linglib.Core.Logic.Bilattice.Representation
 import Linglib.Core.Logic.Consequence
 import Linglib.Core.Logic.CylindricAlgebra
 import Linglib.Core.Logic.Duality
-import Linglib.Core.GroupTheory.Congruence.Hom
 import Linglib.Core.Logic.FactorsThroughOn
 import Linglib.Core.Logic.FirstOrder.Binders
 import Linglib.Core.Logic.FirstOrder.Comparative

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -67,6 +67,10 @@ variable {L}
 
 /-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
 both syntactic congruences. -/
+theorem SyntacticEquiv.compl_iff {u v : List α} :
+    Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
+  forall_congr' fun _ => forall_congr' fun _ => not_iff_not
+
 theorem SyntacticEquiv.append {u u' v v' : List α} (h : L.SyntacticEquiv u u')
     (h' : L.SyntacticEquiv v v') : L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
   have h1 := h x (v ++ y)
@@ -97,10 +101,7 @@ variable {L} in
 /-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
 `syntacticCon L` (take the empty two-sided context). -/
 theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
-    u ∈ L ↔ v ∈ L := by
-  have := h [] []
-  simp only [List.nil_append, List.append_nil] at this
-  exact this
+    u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv h
 
 /-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
 def syntacticMonoid : Type _ := (syntacticCon L).Quotient
@@ -260,9 +261,7 @@ syntactic monoid (e.g. `Language.IsStarFree`, and `Monoid.Pseudovariety.langs` i
 /-- The syntactic congruence is complement-invariant: a two-sided context distinguishes `u` from
 `v` for `L` exactly when it does for `Lᶜ`. -/
 theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
-  Con.ext fun u v => by
-    rw [syntacticCon_iff, syntacticCon_iff]
-    exact forall_congr' fun _ => forall_congr' fun _ => not_iff_not
+  Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
 /-- The syntactic monoid is complement-invariant. -/
 theorem syntacticMonoid_compl (L : Language α) : Lᶜ.syntacticMonoid = L.syntacticMonoid := by

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 [UPSTREAM] candidate: `Mathlib.Computability.SyntacticSemigroup`.
 -/
 import Linglib.Core.Computability.SyntacticMonoid
+import Linglib.Core.GroupTheory.Congruence.Hom
 import Linglib.Core.Algebra.Free
 
 /-!
@@ -70,7 +71,7 @@ theorem toSyntacticSemigroup_eq_iff {u v : FreeSemigroup α} :
   Con.eq _
 
 theorem toSyntacticSemigroup_surjective : Function.Surjective L.toSyntacticSemigroup :=
-  fun s => Quotient.exists_rep s
+  Con.mkMulHom_surjective _
 
 /-! ### Relation to the syntactic monoid -/
 
@@ -83,7 +84,6 @@ def syntacticSemigroupToMonoid : L.syntacticSemigroup →ₙ* L.syntacticMonoid 
 
 @[simp] theorem syntacticSemigroupToMonoid_apply (u : FreeSemigroup α) :
     L.syntacticSemigroupToMonoid (L.toSyntacticSemigroup u) = L.syntacticClass u.toList := rfl
-
 
 theorem syntacticSemigroupToMonoid_injective :
     Function.Injective L.syntacticSemigroupToMonoid := by
@@ -102,9 +102,7 @@ theorem finite_syntacticSemigroup (h : L.IsRegular) : Finite L.syntacticSemigrou
   inferInstance
 
 /-- The syntactic congruence is complement-invariant, as on the monoid side. -/
-theorem syntacticSemigroupCon_compl : Lᶜ.syntacticSemigroupCon = L.syntacticSemigroupCon := by
-  ext u v
-  simp only [syntacticSemigroupCon_iff, SyntacticEquiv]
-  exact ⟨fun h x y => not_iff_not.mp (h x y), fun h x y => not_iff_not.mpr (h x y)⟩
+theorem syntacticSemigroupCon_compl : Lᶜ.syntacticSemigroupCon = L.syntacticSemigroupCon :=
+  Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
 end Language

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -46,7 +46,6 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 language-side operator of the Eilenberg correspondence. -/
 def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticMonoid
 
-theorem langs_def : V.langs L ↔ L.IsRegular ∧ V.mem L.syntacticMonoid := Iff.rfl
 
 /-- **Engine.** A language recognized by a finite monoid in `V` lies in `V.langs`: the syntactic
 monoid is a quotient of a submonoid of the recognizer, hence in `V`. Generalizes

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -40,7 +40,6 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 `+`-variety side of the Eilenberg correspondence. -/
 def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticSemigroup
 
-theorem langs_def : V.langs L ↔ L.IsRegular ∧ V.mem L.syntacticSemigroup := Iff.rfl
 
 /-- **Closure under complement** — immediate from complement-invariance of the syntactic
 congruence (`Language.syntacticSemigroupCon_compl`). -/

--- a/Linglib/Core/GroupTheory/Congruence/Hom.lean
+++ b/Linglib/Core/GroupTheory/Congruence/Hom.lean
@@ -15,22 +15,23 @@ import Mathlib.GroupTheory.Congruence.Hom
 Mathlib's `Con` API for quotient homomorphisms — `Con.lift`, `Con.kerLift`, `Con.map` and the
 isomorphism theorems — lives in `section MulOneClass` and is `MonoidHom`-valued. Its `section Mul`
 provides only `Con.mkMulHom`, `Con.ker`, `Con.mapGen`, `Con.mapOfSurjective` and
-`Con.correspondence`. This file supplies the `MulHom`-valued lift, kernel lift and map, which is
-what a quotient argument over a bare `Semigroup` needs.
+`Con.correspondence`. This file adds the `MulHom`-valued lift, together with its universal
+property, the kernel lift, and the map induced by a coarsening.
 
 Homomorphisms are *consumed* through `MulHomClass` and *produced* as concrete `→ₙ*`, following
-`Con.ker` and `Con.mapOfSurjective`.
+`Con.ker` and `Con.mapOfSurjective`. The cost of consuming through `MulHomClass` is that the
+universal-property statements coerce the argument, as in `liftMulHom_comp_mkMulHom`.
 
 ## Main definitions
 
 * `Con.liftMulHom`: the homomorphism induced on the quotient by one constant on the classes.
-* `Con.kerLiftMulHom`: the injective homomorphism induced by `f` on the quotient by its kernel.
-* `Con.mapMulHom`: the surjection `c.Quotient →ₙ* d.Quotient` induced by `c ≤ d`.
+* `Con.kerLiftMulHom`: the homomorphism induced by `f` on the quotient by its kernel.
+* `Con.mapMulHom`: the homomorphism `c.Quotient →ₙ* d.Quotient` induced by `c ≤ d`.
 
 ## Main results
 
-* `Con.kerLiftMulHom_injective`: the kernel lift is injective — the divisor half of the first
-  isomorphism theorem, which is what closure-under-quotient arguments actually consume.
+* `Con.mulHom_ext`, `Con.liftMulHom_unique`: the universal property of the quotient.
+* `Con.kerLiftMulHom_injective`: the kernel lift is injective.
 -/
 
 variable {M N : Type*} [Mul M] [Mul N] {F : Type*} [FunLike F M N] [MulHomClass F M N]
@@ -49,12 +50,36 @@ def liftMulHom (f : F) (H : c ≤ Con.ker f) : c.Quotient →ₙ* N where
 @[simp] theorem liftMulHom_coe (f : F) (H : c ≤ Con.ker f) (x : M) :
     c.liftMulHom f H (x : c.Quotient) = f x := rfl
 
+@[simp] theorem liftMulHom_comp_mkMulHom (f : F) (H : c ≤ Con.ker f) :
+    (c.liftMulHom f H).comp (mkMulHom c) = (f : M →ₙ* N) := rfl
+
+/-- The quotient map is surjective. -/
+theorem mkMulHom_surjective : Function.Surjective (mkMulHom c) := Quotient.mk''_surjective
+
+variable {c} in
 theorem liftMulHom_surjective_of_surjective {f : F} (H : c ≤ Con.ker f)
     (hf : Function.Surjective f) : Function.Surjective (c.liftMulHom f H) := fun y =>
   have ⟨w, hw⟩ := hf y
   ⟨(w : c.Quotient), hw⟩
 
-variable {c}
+/-- Every homomorphism out of the quotient is the lift of its restriction. -/
+theorem liftMulHom_apply_mkMulHom (f : c.Quotient →ₙ* N) :
+    (c.liftMulHom (f.comp (mkMulHom c)) fun _ _ h => congrArg f (c.eq.2 h)) = f := by
+  ext x; rcases x with ⟨⟩; rfl
+
+/-- **Extensionality for homomorphisms out of a congruence quotient**: they agree as soon as they
+agree on the quotient map. -/
+@[ext] theorem mulHom_ext {f g : c.Quotient →ₙ* N}
+    (h : f.comp (mkMulHom c) = g.comp (mkMulHom c)) : f = g := by
+  rw [← liftMulHom_apply_mkMulHom c f, ← liftMulHom_apply_mkMulHom c g]; congr 1
+
+theorem liftMulHom_funext (f g : c.Quotient →ₙ* N) (h : ∀ a : M, f a = g a) : f = g :=
+  mulHom_ext c <| DFunLike.ext _ _ h
+
+/-- **The universal property**: the lift is the unique homomorphism restricting to `f`. -/
+theorem liftMulHom_unique {f : F} (H : c ≤ Con.ker f) (g : c.Quotient →ₙ* N)
+    (Hg : g.comp (mkMulHom c) = (f : M →ₙ* N)) : g = c.liftMulHom f H :=
+  mulHom_ext c (Hg.trans (liftMulHom_comp_mkMulHom c f H).symm)
 
 /-- The homomorphism induced by `f` on the quotient by its kernel. -/
 def kerLiftMulHom (f : F) : (Con.ker f).Quotient →ₙ* N := liftMulHom _ f le_rfl
@@ -62,18 +87,15 @@ def kerLiftMulHom (f : F) : (Con.ker f).Quotient →ₙ* N := liftMulHom _ f le_
 @[simp] theorem kerLiftMulHom_coe (f : F) (x : M) :
     kerLiftMulHom f (x : (Con.ker f).Quotient) = f x := rfl
 
-/-- **The kernel lift is injective.** This is the half of the first isomorphism theorem that
-quotient arguments consume: it exhibits `(ker f).Quotient` as a sub-object of `N`. -/
-theorem kerLiftMulHom_injective (f : F) : Function.Injective (kerLiftMulHom f) := by
-  rintro ⟨x⟩ ⟨y⟩ h
-  exact Con.eq _ |>.2 <| (Con.ker_rel f).2 h
+/-- The kernel lift is injective: it exhibits `(ker f).Quotient` as a sub-object of `N`, which is
+what closure-under-quotient arguments consume. -/
+theorem kerLiftMulHom_injective (f : F) : Function.Injective (kerLiftMulHom f) := fun x y =>
+  Con.induction_on₂ x y fun _ _ => (Con.ker f).eq.2
 
 theorem kerLiftMulHom_surjective_of_surjective {f : F} (hf : Function.Surjective f) :
-    Function.Surjective (kerLiftMulHom f) := liftMulHom_surjective_of_surjective _ le_rfl hf
+    Function.Surjective (kerLiftMulHom f) := liftMulHom_surjective_of_surjective le_rfl hf
 
-variable (c)
-
-/-- The surjection of quotients induced by a coarsening `c ≤ d`. -/
+/-- The homomorphism of quotients induced by a coarsening `c ≤ d`. -/
 def mapMulHom (d : Con M) (h : c ≤ d) : c.Quotient →ₙ* d.Quotient :=
   c.liftMulHom (d.mkMulHom) (by rw [Con.ker_mkMulHom_eq]; exact h)
 
@@ -81,7 +103,7 @@ def mapMulHom (d : Con M) (h : c ≤ d) : c.Quotient →ₙ* d.Quotient :=
     c.mapMulHom d h (x : c.Quotient) = (x : d.Quotient) := rfl
 
 theorem mapMulHom_surjective (d : Con M) (h : c ≤ d) :
-    Function.Surjective (c.mapMulHom d h) := fun x => by
-  rcases x with ⟨x⟩; exact ⟨(x : c.Quotient), rfl⟩
+    Function.Surjective (c.mapMulHom d h) :=
+  liftMulHom_surjective_of_surjective _ d.mkMulHom_surjective
 
 end Con


### PR DESCRIPTION
Follow-up to #1670, whose merge landed before these review fixes were pushed.

`Con.liftMulHom` shipped without its universal property; mathlib gives the monoid `Con.lift` five companion lemmas. Without them `ext` on `f = g` for `f g : c.Quotient →ₙ* N` peels to `x : c.Quotient` rather than `x : M`.

- Adds `liftMulHom_comp_mkMulHom`, `liftMulHom_apply_mkMulHom`, `@[ext] mulHom_ext`, `liftMulHom_funext`, `liftMulHom_unique`.
- Adds `Con.mkMulHom_surjective` (the `Mul`-level analogue of `Con.mk'_surjective`), which golfs `mapMulHom_surjective` and `Language.toSyntacticSemigroup_surjective` to one line each.
- `kerLiftMulHom_injective` now mirrors mathlib's `Con.kerLift_injective` instead of routing through the `Iff.rfl` `Con.ker_rel`; drops a cancelling `variable` pair; import moved to its sorted slot.
- Finishes the `SyntacticEquiv` deduplication: `mem_iff_of_syntacticCon` and both `*_compl` congruence lemmas now reuse the shared relation via a new `SyntacticEquiv.compl_iff`.
- Drops the two dead `langs_def` `rfl`-bridges.