### PR TITLE
feat(Core/Computability): closure under quotients for both langs operators

### DIFF
--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -7,6 +7,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.Algebra.Free
+import Mathlib.Data.Fintype.Option
 
 /-!
 # The syntactic semigroup of a language
@@ -106,5 +107,26 @@ theorem syntacticSemigroupCon_compl : Lᶜ.syntacticSemigroupCon = L.syntacticSe
   ext u v
   simp only [syntacticSemigroupCon_iff, SyntacticEquiv]
   exact ⟨fun h x y => not_iff_not.mp (h x y), fun h x y => not_iff_not.mpr (h x y)⟩
+
+/-- Conversely, a finite syntactic semigroup forces a finite syntactic monoid: the monoid is
+covered by the semigroup together with the identity, which is Eilenberg's `M_A = S_A ∪ {1}`. -/
+theorem finite_syntacticMonoid_of_finite_syntacticSemigroup [Finite L.syntacticSemigroup] :
+    Finite L.syntacticMonoid := by
+  refine .of_surjective (β := L.syntacticMonoid)
+    (Option.elim · 1 L.syntacticSemigroupToMonoid) fun m => ?_
+  obtain ⟨w, rfl⟩ := L.syntacticClass_surjective m
+  match w with
+  | [] => exact ⟨none, L.syntacticClass_nil.symm⟩
+  | c :: w => exact ⟨some (L.toSyntacticSemigroup ⟨c, w⟩), rfl⟩
+
+/-- **Myhill–Nerode, semigroup form**: a language is regular exactly when its syntactic semigroup
+is finite. -/
+theorem isRegular_iff_finite_syntacticSemigroup :
+    L.IsRegular ↔ Finite L.syntacticSemigroup :=
+  ⟨fun h => haveI := finite_syntacticMonoid h; inferInstance,
+   fun _ => isRegular_of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup⟩
+
+theorem isRegular_of_finite_syntacticSemigroup (h : Finite L.syntacticSemigroup) : L.IsRegular :=
+  L.isRegular_iff_finite_syntacticSemigroup.2 h
 
 end Language

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -113,4 +113,53 @@ theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
   exact (mem_iff_of_syntacticCon ((toSyntacticMonoid_eq_iff (L := Lb)).mp hu)).mp hmem
 
+/-! ### Closure under quotients
+
+Eilenberg's fourth axiom for a variety of languages ([eilenberg-1976] VII.3.3, stated there for
+letters; [pin-mfa] Ch. XIII §3 states it for words, equivalently). The syntactic congruence of a
+quotient is coarser than that of the language, so the syntactic monoid of the quotient is a
+quotient of the original's. -/
+
+/-- The **right quotient** `L u⁻¹`: the words that land in `L` when `u` is appended. The left
+quotient is mathlib's `Language.leftQuotient`. -/
+def _root_.Language.rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
+
+@[simp] theorem _root_.Language.mem_rightQuotient {L : Language α} {u w : List α} :
+    w ∈ L.rightQuotient u ↔ w ++ u ∈ L := Iff.rfl
+
+/-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
+left context. -/
+theorem _root_.Language.syntacticCon_le_leftQuotient (L : Language α) (u : List α) :
+    L.syntacticCon ≤ (L.leftQuotient u).syntacticCon := fun {p q} h x y => by
+  have := h (u ++ x) y
+  simpa [Language.mem_leftQuotient, List.append_assoc] using this
+
+/-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
+right context. -/
+theorem _root_.Language.syntacticCon_le_rightQuotient (L : Language α) (u : List α) :
+    L.syntacticCon ≤ (L.rightQuotient u).syntacticCon := fun {p q} h x y => by
+  have := h x (y ++ u)
+  simpa [Language.mem_rightQuotient, List.append_assoc] using this
+
+variable {V}
+
+/-- A coarser syntactic congruence keeps the language in `V.langs`. -/
+private theorem langs_of_syntacticCon_le {M : Language α} (h : V.langs L)
+    (hle : L.syntacticCon ≤ M.syntacticCon) : V.langs M := by
+  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite L.syntacticCon.Quotient := inferInstanceAs (Finite L.syntacticMonoid)
+  have hsurj : Function.Surjective (Con.map L.syntacticCon M.syntacticCon hle) :=
+    Con.lift_surjective_of_surjective _ Con.mk'_surjective
+  haveI : Finite M.syntacticMonoid := .of_surjective _ hsurj
+  haveI : Finite M.syntacticCon.Quotient := inferInstanceAs (Finite M.syntacticMonoid)
+  exact ⟨isRegular_of_finite_syntacticMonoid ‹_›, V.quot hsurj h.2⟩
+
+/-- **Closure under left quotient** — Eilenberg's axiom VII.3.3. -/
+theorem langs_leftQuotient (h : V.langs L) (u : List α) : V.langs (L.leftQuotient u) :=
+  langs_of_syntacticCon_le h (L.syntacticCon_le_leftQuotient u)
+
+/-- **Closure under right quotient** — Eilenberg's axiom VII.3.3. -/
+theorem langs_rightQuotient (h : V.langs L) (u : List α) : V.langs (L.rightQuotient u) :=
+  langs_of_syntacticCon_le h (L.syntacticCon_le_rightQuotient u)
+
 end Monoid.Pseudovariety

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -7,6 +7,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.Semigroup.Pseudovariety
 import Linglib.Core.Computability.SyntacticSemigroup
+import Linglib.Core.Computability.Variety.Langs
+import Linglib.Core.GroupTheory.Congruence.Hom
 
 /-!
 # The language-side operator of a semigroup pseudovariety
@@ -49,5 +51,45 @@ theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
   show V.mem (syntacticSemigroupCon Lᶜ).Quotient
   rw [syntacticSemigroupCon_compl]
   exact h.2
+
+/-! ### Closure under quotients
+
+Eilenberg's axiom VII.3.3, on the `+` side. The argument is the monoid one: a quotient's syntactic
+congruence is coarser, so its syntactic semigroup is a quotient of the original's. -/
+
+theorem _root_.Language.syntacticSemigroupCon_le_leftQuotient (L : Language α) (u : List α) :
+    L.syntacticSemigroupCon ≤ (L.leftQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
+  have := h (u ++ x) y
+  simpa [Language.mem_leftQuotient, List.append_assoc] using this
+
+theorem _root_.Language.syntacticSemigroupCon_le_rightQuotient (L : Language α) (u : List α) :
+    L.syntacticSemigroupCon ≤ (L.rightQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
+  have := h x (y ++ u)
+  simpa [Language.mem_rightQuotient, List.append_assoc] using this
+
+variable {V}
+
+/-- A coarser syntactic congruence keeps the language in `V.langs`. -/
+private theorem langs_of_syntacticSemigroupCon_le {M : Language α} (h : V.langs L)
+    (hle : L.syntacticSemigroupCon ≤ M.syntacticSemigroupCon) : V.langs M := by
+  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite L.syntacticSemigroupCon.Quotient :=
+    inferInstanceAs (Finite L.syntacticSemigroup)
+  have hsurj : Function.Surjective
+      (Con.mapMulHom L.syntacticSemigroupCon M.syntacticSemigroupCon hle) :=
+    Con.mapMulHom_surjective _ _ hle
+  haveI : Finite M.syntacticSemigroup := .of_surjective _ hsurj
+  haveI : Finite M.syntacticSemigroupCon.Quotient :=
+    inferInstanceAs (Finite M.syntacticSemigroup)
+  exact ⟨M.isRegular_of_finite_syntacticSemigroup ‹Finite M.syntacticSemigroup›,
+    V.quot hsurj h.2⟩
+
+/-- **Closure under left quotient** — Eilenberg's axiom VII.3.3. -/
+theorem langs_leftQuotient (h : V.langs L) (u : List α) : V.langs (L.leftQuotient u) :=
+  langs_of_syntacticSemigroupCon_le h (L.syntacticSemigroupCon_le_leftQuotient u)
+
+/-- **Closure under right quotient** — Eilenberg's axiom VII.3.3. -/
+theorem langs_rightQuotient (h : V.langs L) (u : List α) : V.langs (L.rightQuotient u) :=
+  langs_of_syntacticSemigroupCon_le h (L.syntacticSemigroupCon_le_rightQuotient u)
 
 end Semigroup.Pseudovariety


### PR DESCRIPTION
Reading the sources turned up a missing axiom. Eilenberg's definition of a variety of languages ([eilenberg-1976] VII, Theorem 3.2) has **four** conditions: (3.1) complement, (3.2) intersection, (3.3) **the quotients `a⁻¹A` and `Aa⁻¹`**, (3.4) inverse morphism. [pin-mfa] Ch. XIII §3 states the modern form, quantifying (3) over words rather than letters. Neither `langs` operator had (3.3).

- `Language.rightQuotient` (mathlib has `leftQuotient` only).
- `syntacticCon_le_leftQuotient` / `_rightQuotient` and their semigroup twins: a quotient's syntactic congruence is coarser, since the quotienting word is absorbed into the context.
- `langs_leftQuotient` / `langs_rightQuotient` on **both** operators, via a shared private lemma — a coarser congruence makes the syntactic monoid a quotient of the original, so `V.quot` applies.
- `Language.isRegular_iff_finite_syntacticSemigroup`: Myhill–Nerode in semigroup form. The semigroup side needed it because `IsRegular` was previously reachable only through the syntactic monoid; the converse direction covers `M_A` by `S_A ∪ {1}`, which is Eilenberg's own construction.

Also confirmed from the sources, for the record: Eilenberg's Exercise 3.7 decomposes (3.4) for a `*`-variety into a **non-erasing** morphism condition plus alphabet extension — so the eventual semigroup `langs_comap` must quantify over `FreeSemigroup α →ₙ* FreeSemigroup β`, not monoid morphisms.