### PR TITLE
feat(Core/Computability): boolean closure for the +-variety langs operator

### DIFF
--- a/Linglib/Core/Algebra/Free.lean
+++ b/Linglib/Core/Algebra/Free.lean
@@ -26,4 +26,7 @@ def toList (u : FreeSemigroup α) : List α := u.head :: u.tail
 @[simp] theorem toList_mul (u v : FreeSemigroup α) :
     (u * v).toList = u.toList ++ v.toList := rfl
 
+/-- The free semigroup is the *nonempty* words. -/
+@[simp] theorem toList_ne_nil (u : FreeSemigroup α) : u.toList ≠ [] := List.cons_ne_nil _ _
+
 end FreeSemigroup

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -5,9 +5,10 @@ Authors: Robert Hawkins
 
 [UPSTREAM] candidate: `Mathlib.Computability.SyntacticSemigroup`.
 -/
+import Linglib.Core.Algebra.Free
 import Linglib.Core.Computability.SyntacticMonoid
 import Linglib.Core.GroupTheory.Congruence.Hom
-import Linglib.Core.Algebra.Free
+import Mathlib.Algebra.Group.Prod
 import Mathlib.Data.Fintype.Option
 
 /-!
@@ -126,5 +127,38 @@ theorem isRegular_iff_finite_syntacticSemigroup :
 
 theorem isRegular_of_finite_syntacticSemigroup (h : Finite L.syntacticSemigroup) : L.IsRegular :=
   L.isRegular_iff_finite_syntacticSemigroup.2 h
+/-! ### Meets of syntactic congruences -/
+
+/-- Words indistinguishable for both `L` and `M` are indistinguishable for `L ⊓ M`. -/
+theorem inf_syntacticSemigroupCon_le_syntacticSemigroupCon_inf (L M : Language α) :
+    L.syntacticSemigroupCon ⊓ M.syntacticSemigroupCon ≤ (L ⊓ M).syntacticSemigroupCon := by
+  rw [Con.le_def]
+  intro u v huv x y
+  rw [Con.inf_iff_and, syntacticSemigroupCon_iff, syntacticSemigroupCon_iff] at huv
+  exact and_congr (huv.1 x y) (huv.2 x y)
+
+/-- The kernel of the pairing of the two syntactic morphisms is the meet of the two syntactic
+congruences. -/
+theorem ker_prod_toSyntacticSemigroup (L M : Language α) :
+    Con.ker (L.toSyntacticSemigroup.prod M.toSyntacticSemigroup) =
+      L.syntacticSemigroupCon ⊓ M.syntacticSemigroupCon :=
+  Con.ext fun u v => by
+    rw [Con.ker_rel, MulHom.prod_apply, MulHom.prod_apply, Prod.ext_iff,
+      toSyntacticSemigroup_eq_iff, toSyntacticSemigroup_eq_iff, Con.inf_iff_and]
+
+/-- **The syntactic semigroup does not see the empty word.** Its congruence quantifies only over
+nonempty words, so adjoining `[]` to a language leaves it unchanged. This is the `+`-variety
+semantics working as intended ([eilenberg-1976] indexes varieties of sets on `Σ⁺`), and it is why
+`Semigroup.Pseudovariety.langs` cannot distinguish `L` from `insert [] L`. -/
+theorem syntacticSemigroupCon_insert_nil (L : Language α) :
+    (insert [] L).syntacticSemigroupCon = L.syntacticSemigroupCon :=
+  Con.ext fun u v => by
+    have h : ∀ (x : List α) (w : FreeSemigroup α) (y : List α),
+        x ++ w.toList ++ y ∈ insert [] L ↔ x ++ w.toList ++ y ∈ L := fun x w y => by
+      refine (Set.mem_insert_iff).trans (or_iff_right ?_)
+      intro hnil
+      exact absurd (List.append_eq_nil_iff.mp (List.append_eq_nil_iff.mp hnil).1).2
+        (FreeSemigroup.toList_ne_nil w)
+    exact forall_congr' fun x => forall_congr' fun y => iff_congr (h x u y) (h x v y)
 
 end Language

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -42,7 +42,6 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 `+`-variety side of the Eilenberg correspondence. -/
 def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticSemigroup
 
-
 /-- **Closure under complement** — immediate from complement-invariance of the syntactic
 congruence (`Language.syntacticSemigroupCon_compl`). -/
 theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
@@ -90,5 +89,28 @@ theorem langs_leftQuotient (h : V.langs L) (u : List α) : V.langs (L.leftQuotie
 /-- **Closure under right quotient** — Eilenberg's axiom VII.3.3. -/
 theorem langs_rightQuotient (h : V.langs L) (u : List α) : V.langs (L.rightQuotient u) :=
   langs_of_syntacticSemigroupCon_le h (L.syntacticSemigroupCon_le_rightQuotient u)
+/-- **Closure under intersection** — the syntactic semigroup of `L ⊓ M` is a quotient of a
+subsemigroup of `L.syntacticSemigroup × M.syntacticSemigroup`, which is in `V` by
+`prod`/`sub`/`quot`. -/
+theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊓ M) := by
+  refine ⟨hL.1.inf hM.1, ?_⟩
+  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid hL.1
+  haveI : Finite M.syntacticMonoid := finite_syntacticMonoid hM.1
+  haveI : Finite (L ⊓ M).syntacticMonoid := finite_syntacticMonoid (hL.1.inf hM.1)
+  set φ := L.toSyntacticSemigroup.prod M.toSyntacticSemigroup with hφ
+  haveI : Finite (Con.ker φ).Quotient := .of_injective _ (Con.kerLiftMulHom_injective φ)
+  have hker : V.mem (Con.ker φ).Quotient :=
+    V.sub (Con.kerLiftMulHom_injective φ) (V.prod hL.2 hM.2)
+  have hle : Con.ker φ ≤ (L ⊓ M).syntacticSemigroupCon := by
+    rw [hφ, ker_prod_toSyntacticSemigroup]
+    exact inf_syntacticSemigroupCon_le_syntacticSemigroupCon_inf L M
+  haveI : Finite (L ⊓ M).syntacticSemigroupCon.Quotient :=
+    inferInstanceAs (Finite (L ⊓ M).syntacticSemigroup)
+  exact V.quot (Con.mapMulHom_surjective _ _ hle) hker
+
+/-- **Closure under union** — by De Morgan, `L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ`. -/
+theorem langs_sup {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊔ M) := by
+  rw [show L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ by rw [compl_inf, compl_compl, compl_compl]]
+  exact V.langs_compl (V.langs_inf (V.langs_compl hL) (V.langs_compl hM))
 
 end Semigroup.Pseudovariety


### PR DESCRIPTION
Boolean closure on the semigroup side, mirroring `Monoid.Pseudovariety.langs_inf`/`langs_sup`.

- `inf_syntacticSemigroupCon_le_syntacticSemigroupCon_inf` and `ker_prod_toSyntacticSemigroup`: literal mirrors of the monoid lemmas, except that the kernel one needs `Con.ker_rel` — `Con.ker_apply` is `MulOneClass`-only.
- `langs_inf` uses the `MulHom` congruence kit from #1670/#1671: `Con.kerLiftMulHom_injective` gives `V.sub` its injection and `Con.mapMulHom_surjective` gives `V.quot` its surjection. The monoid `Con.kerLift` is not applicable here, since `Semigroup.Pseudovariety.sub` takes `S →ₙ* T` — this is what that kit was for.
- `langs_sup` by De Morgan.

Also turns a docstring claim into a theorem. `syntacticSemigroupCon_insert_nil` proves the syntactic semigroup cannot see the empty word, so `langs` cannot distinguish `L` from `insert [] L`. That is the `+`-variety semantics working as intended — [eilenberg-1976] indexes varieties of sets on `Σ⁺` — and it is better stated as a lemma than asserted in prose. It needed `FreeSemigroup.toList_ne_nil`, which I had dropped as unused; it is restored now that it has a consumer.

Independent of #1672: regularity here comes from `IsRegular.inf`, not the semigroup Myhill–Nerode bridge. `langs_of_recognizes`/`univ`/`bot`/`comap` do need that bridge and follow once #1672 lands.