### PR TITLE
feat(Core/Computability): complete the +-variety closure keystone

### DIFF
--- a/Linglib/Core/Algebra/Free.lean
+++ b/Linglib/Core/Algebra/Free.lean
@@ -29,4 +29,8 @@ def toList (u : FreeSemigroup α) : List α := u.head :: u.tail
 /-- The free semigroup is the *nonempty* words. -/
 @[simp] theorem toList_ne_nil (u : FreeSemigroup α) : u.toList ≠ [] := List.cons_ne_nil _ _
 
+theorem toList_injective : Function.Injective (toList (α := α)) := by
+  rintro ⟨a, s⟩ ⟨b, t⟩ h
+  simpa [toList, and_comm] using h
+
 end FreeSemigroup

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -161,4 +161,43 @@ theorem syntacticSemigroupCon_insert_nil (L : Language α) :
         (FreeSemigroup.toList_ne_nil w)
     exact forall_congr' fun x => forall_congr' fun y => iff_congr (h x u y) (h x v y)
 
+/-! ### Recognition by a finite semigroup
+
+The monoid notion `Language.Recognizes` is the set equation `L = φ ⁻¹' S`. That cannot be stated
+here: `η ⁻¹' P` is a set of `FreeSemigroup α`, whereas a `Language α` is a set of `List α`. The
+pointwise form below says the same thing about nonempty words, and says nothing about `[]` — which
+is right, since the syntactic semigroup does not see it (`syntacticSemigroupCon_insert_nil`). -/
+
+/-- `η` **recognizes** `L` when membership of a nonempty word is decided by its image. -/
+def RecognizesSemigroup {T : Type*} [Semigroup T] (η : FreeSemigroup α →ₙ* T)
+    (L : Language α) : Prop :=
+  ∃ P : Set T, ∀ w : FreeSemigroup α, w.toList ∈ L ↔ η w ∈ P
+
+/-- A nonempty word in a two-sided context, as an element of the free semigroup. The four cases
+are needed because an empty context contributes no factor to multiply through. -/
+private def ctx (x : List α) (u : FreeSemigroup α) (y : List α) : FreeSemigroup α :=
+  match x, y with
+  | [], [] => u
+  | [], c :: y => u * ⟨c, y⟩
+  | a :: x, [] => ⟨a, x⟩ * u
+  | a :: x, c :: y => ⟨a, x⟩ * u * ⟨c, y⟩
+
+private theorem toList_ctx (x : List α) (u : FreeSemigroup α) (y : List α) :
+    (ctx x u y).toList = x ++ u.toList ++ y := by
+  cases x <;> cases y <;> simp [ctx, FreeSemigroup.toList]
+
+private theorem map_ctx {T : Type*} [Semigroup T] (η : FreeSemigroup α →ₙ* T)
+    {u v : FreeSemigroup α} (h : η u = η v) (x y : List α) :
+    η (ctx x u y) = η (ctx x v y) := by
+  cases x <;> cases y <;> simp [ctx, map_mul, h]
+
+/-- A recognizing hom's kernel lies below `syntacticSemigroupCon L`, the coarsest such
+congruence. -/
+theorem ker_le_syntacticSemigroupCon_of_recognizes {T : Type*} [Semigroup T]
+    {η : FreeSemigroup α →ₙ* T} (hrec : L.RecognizesSemigroup η) :
+    Con.ker η ≤ L.syntacticSemigroupCon := by
+  obtain ⟨P, hP⟩ := hrec
+  intro u v huv x y
+  rw [← toList_ctx x u y, ← toList_ctx x v y, hP, hP, map_ctx η huv]
+
 end Language

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -113,4 +113,49 @@ theorem langs_sup {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs 
   rw [show L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ by rw [compl_inf, compl_compl, compl_compl]]
   exact V.langs_compl (V.langs_inf (V.langs_compl hL) (V.langs_compl hM))
 
+/-- **Engine.** A language recognized by a finite semigroup in `V` lies in `V.langs`: the
+syntactic semigroup is a quotient of a subsemigroup of the recognizer. -/
+theorem langs_of_recognizes {T : Type u} [Semigroup T] [Finite T] (hT : V.mem T)
+    (η : FreeSemigroup α →ₙ* T) (P : Set T)
+    (hL : ∀ w : FreeSemigroup α, w.toList ∈ L ↔ η w ∈ P) : V.langs L := by
+  have hle : Con.ker η ≤ L.syntacticSemigroupCon :=
+    L.ker_le_syntacticSemigroupCon_of_recognizes ⟨P, hL⟩
+  haveI : Finite (Con.ker η).Quotient := .of_injective _ (Con.kerLiftMulHom_injective η)
+  have hkerMem : V.mem (Con.ker η).Quotient := V.sub (Con.kerLiftMulHom_injective η) hT
+  have hsurj := Con.mapMulHom_surjective (Con.ker η) L.syntacticSemigroupCon hle
+  haveI : Finite L.syntacticSemigroup := .of_surjective _ hsurj
+  haveI : Finite L.syntacticSemigroupCon.Quotient :=
+    inferInstanceAs (Finite L.syntacticSemigroup)
+  exact ⟨L.isRegular_of_finite_syntacticSemigroup ‹_›, V.quot hsurj hkerMem⟩
+
+/-- **The full language** — recognized by the trivial semigroup, which is in every
+pseudovariety. -/
+theorem langs_univ : V.langs (⊤ : Language α) := by
+  refine V.langs_of_recognizes (T := PUnit.{u + 1}) V.memUnit
+    { toFun := fun _ => PUnit.unit, map_mul' := fun _ _ => rfl } Set.univ ?_
+  intro _
+  exact iff_of_true trivial (Set.mem_univ _)
+
+/-- **The empty language** — `⊥ = ⊤ᶜ`. -/
+theorem langs_bot : V.langs (⊥ : Language α) := by
+  simpa using V.langs_compl V.langs_univ
+
+/-- **Closure under inverse homomorphism** — Eilenberg's fourth axiom, on the `+` side. The
+morphism is between free *semigroups*: [eilenberg-1976] VII, Exercise 3.7 shows that the
+`*`-variety form of this axiom decomposes into a non-erasing morphism condition, and a free
+semigroup has no erasing morphisms. -/
+theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
+    (φ : FreeSemigroup α →ₙ* FreeSemigroup β) :
+    V.langs {w : List α | ∃ u : FreeSemigroup α, u.toList = w ∧ (φ u).toList ∈ Lb} := by
+  haveI : Finite Lb.syntacticMonoid := finite_syntacticMonoid h.1
+  refine V.langs_of_recognizes h.2 (Lb.toSyntacticSemigroup.comp φ)
+    {m | ∃ u : FreeSemigroup β, Lb.toSyntacticSemigroup u = m ∧ u.toList ∈ Lb} ?_
+  intro w
+  constructor
+  · rintro ⟨u, hu, hmem⟩
+    obtain rfl : u = w := FreeSemigroup.toList_injective hu
+    exact ⟨φ u, rfl, hmem⟩
+  · rintro ⟨v, hv, hmem⟩
+    exact ⟨w, rfl, (mem_iff_of_syntacticEquiv (Lb.toSyntacticSemigroup_eq_iff.mp hv)).mp hmem⟩
+
 end Semigroup.Pseudovariety


### PR DESCRIPTION
Completes `Semigroup.Pseudovariety.langs` against [eilenberg-1976] VII, Theorem 3.2: complement, intersection, quotients, inverse morphism — plus the recognition engine and `⊤`/`⊥`.

- `Language.RecognizesSemigroup`: the monoid notion is the set equation `L = φ ⁻¹' S`, which cannot be stated here — `η ⁻¹' P` is a set of `FreeSemigroup α` while a `Language α` is a set of `List α`. The pointwise form says the same about nonempty words and nothing about `[]`, which is right: the syntactic semigroup cannot see it.
- `ker_le_syntacticSemigroupCon_of_recognizes` needs a private `ctx` with four cases. The monoid proof pushes a morphism through `x * u * y`; on the `+` side an empty context contributes no factor, so the contexts must be assembled by case.
- `langs_of_recognizes` is the engine; `langs_univ`/`langs_bot` follow from it and `langs_compl`.
- `langs_comap` quantifies over `FreeSemigroup α →ₙ* FreeSemigroup β`. [eilenberg-1976] VII Exercise 3.7 decomposes the `*`-variety form of this axiom into a *non-erasing* morphism condition plus alphabet extension; a free semigroup has no erasing morphisms, so this is the honest `+` statement. It needed `FreeSemigroup.toList_injective`, restored now that it has a consumer.

With this, `D`/`K`/`LI` can be defined as `V.langs` instances and inherit their closure theory from the keystone instead of re-deriving it.