### PR TITLE
refactor(Core/Computability): align the two variety halves; complete recognition API

### DIFF
--- a/Linglib/Core/Computability/QFLogic.lean
+++ b/Linglib/Core/Computability/QFLogic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.List.Basic
 
 /-!
@@ -8,8 +13,8 @@ by applying the successor/predecessor partial functions; formulas are boolean co
 atomic label/equality/definedness tests. Because successor is a *function*, a QF term reaches a
 *bounded* neighbourhood of its variable with no quantifiers — the syntactic counterpart of
 strict locality (an existential like `∃w,y[succ w x ∧ succ x y ∧ …]` collapses to the
-quantifier-free `… (pred x) ∧ … (succ x)`). `Transduction.leftLocal_isLeftISL` makes this
-precise: a QF-definable transduction with bounded guards is input-strictly-local.
+quantifier-free `… (pred x) ∧ … (succ x)`). A QF-definable transduction whose guards have
+bounded predecessor depth therefore depends only on a bounded left window.
 
 ## Main definitions
 
@@ -71,8 +76,7 @@ theorem succ?_congr {w w' : List α} (h : w.length = w'.length) : succ? w = succ
 theorem pred?_congr {w w' : List α} (h : w.length = w'.length) : pred? w = pred? w' := by
   funext n; cases n <;> simp [pred?, h]
 
-
-variable {α V : Type*}
+variable {V : Type*}
 
 /-- Quantifier-free **terms**: a variable, or the successor/predecessor of a term. The
 `succ`/`pred` chains give bounded-window reach without quantifiers. -/
@@ -177,8 +181,10 @@ instance QF.instDecidableRealize (w : List α) (ρ : V → ℕ) :
   | .tru      => isTrue trivial
   | .fls      => isFalse not_false
   | .neg φ    => @instDecidableNot _ (QF.instDecidableRealize w ρ φ)
-  | .conj φ ψ => @instDecidableAnd _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
-  | .disj φ ψ => @instDecidableOr _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
+  | .conj φ ψ =>
+      @instDecidableAnd _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
+  | .disj φ ψ =>
+      @instDecidableOr _ _ (QF.instDecidableRealize w ρ φ) (QF.instDecidableRealize w ρ ψ)
 
 /-- `t` is an initial position: in-domain with no predecessor. -/
 def QF.initial (t : Term V) : QF α V :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -98,6 +98,7 @@ theorem syntacticCon_iff {u v : FreeMonoid α} :
   Iff.rfl
 
 variable {L} in
+
 /-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
 `syntacticCon L` (take the empty two-sided context). -/
 theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
@@ -133,6 +134,7 @@ theorem syntacticClass_surjective : Function.Surjective L.syntacticClass := fun 
   exact ⟨u.toList, congrArg L.toSyntacticMonoid (FreeMonoid.ofList_toList u)⟩
 
 variable {L} in
+
 /-- Word-level form of `syntacticCon_iff`: two words share a syntactic class iff no two-sided
 context distinguishes them as `L`-members. -/
 theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
@@ -140,12 +142,14 @@ theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntactic
   simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
 
 variable {L} in
+
 /-- `L` is saturated by syntactic class: equal class implies equal membership. -/
 theorem mem_iff_of_syntacticClass_eq {u v : List α}
     (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L := by
   simpa using syntacticClass_eq_iff.mp h [] []
 
 variable {L} in
+
 /-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the same as the
 reversed-word equality in `L`. The syntactic monoid of `L.reverse` is `L`'s, opposite. -/
 theorem syntacticClass_reverse_eq_iff {u v : List α} :
@@ -263,10 +267,6 @@ syntactic monoid (e.g. `Language.IsStarFree`, and `Monoid.Pseudovariety.langs` i
 theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
   Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
-/-- The syntactic monoid is complement-invariant. -/
-theorem syntacticMonoid_compl (L : Language α) : Lᶜ.syntacticMonoid = L.syntacticMonoid := by
-  unfold syntacticMonoid; rw [syntacticCon_compl]
-
 /-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
 and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
 theorem inf_syntacticCon_le_syntacticCon_inf (L M : Language α) :
@@ -284,5 +284,12 @@ theorem ker_prod_toSyntacticMonoid (L M : Language α) :
   Con.ext fun u v => by
     rw [Con.ker_apply, MonoidHom.prod_apply, MonoidHom.prod_apply, Prod.ext_iff,
       toSyntacticMonoid_eq_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+
+/-- The **right quotient** `L u⁻¹`: the words that land in `L` when `u` is appended. The left
+quotient is mathlib's `Language.leftQuotient`. -/
+def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
+
+@[simp] theorem mem_rightQuotient {L : Language α} {u w : List α} :
+    w ∈ L.rightQuotient u ↔ w ++ u ∈ L := Iff.rfl
 
 end Language

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -28,6 +28,7 @@ share its multiplicativity lemma `SyntacticEquiv.append`.
 ## Main definitions
 
 * `Language.syntacticSemigroupCon`: the syntactic congruence on `FreeSemigroup α`.
+* `Language.RecognizesSemigroup`: recognition of a language by a homomorphism to a semigroup.
 * `Language.syntacticSemigroup`: the quotient semigroup.
 * `Language.toSyntacticSemigroup`: the projection, as a `MulHom`.
 
@@ -35,6 +36,11 @@ share its multiplicativity lemma `SyntacticEquiv.append`.
 
 * `Language.syntacticSemigroupToMonoid_injective`: the syntactic semigroup embeds in the
   syntactic monoid.
+* `Language.isRegular_iff_finite_syntacticSemigroup`: Myhill–Nerode in semigroup form.
+* `Language.ker_le_syntacticSemigroupCon_of_recognizes`: the syntactic congruence is the coarsest
+  one recognizing `L`.
+* `Language.syntacticSemigroupCon_insert_nil`: the syntactic semigroup does not see the empty
+  word.
 
 ## Implementation notes
 
@@ -98,6 +104,12 @@ instance instFiniteSyntacticSemigroup [Finite L.syntacticMonoid] :
     Finite L.syntacticSemigroup :=
   .of_injective _ L.syntacticSemigroupToMonoid_injective
 
+/-- The quotient presentation of the syntactic semigroup inherits finiteness, so the closure
+proofs need not restate it. -/
+instance instFiniteSyntacticSemigroupConQuotient [Finite L.syntacticMonoid] :
+    Finite (syntacticSemigroupCon L).Quotient :=
+  inferInstanceAs (Finite L.syntacticSemigroup)
+
 /-- A regular language has a finite syntactic semigroup. -/
 theorem finite_syntacticSemigroup (h : L.IsRegular) : Finite L.syntacticSemigroup :=
   haveI := finite_syntacticMonoid h
@@ -122,11 +134,13 @@ theorem finite_syntacticMonoid_of_finite_syntacticSemigroup [Finite L.syntacticS
 is finite. -/
 theorem isRegular_iff_finite_syntacticSemigroup :
     L.IsRegular ↔ Finite L.syntacticSemigroup :=
-  ⟨fun h => haveI := finite_syntacticMonoid h; inferInstance,
-   fun _ => isRegular_of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup⟩
+  ⟨L.finite_syntacticSemigroup,
+   fun _ =>
+     isRegular_of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup⟩
 
 theorem isRegular_of_finite_syntacticSemigroup (h : Finite L.syntacticSemigroup) : L.IsRegular :=
   L.isRegular_iff_finite_syntacticSemigroup.2 h
+
 /-! ### Meets of syntactic congruences -/
 
 /-- Words indistinguishable for both `L` and `M` are indistinguishable for `L ⊓ M`. -/
@@ -150,7 +164,7 @@ theorem ker_prod_toSyntacticSemigroup (L M : Language α) :
 nonempty words, so adjoining `[]` to a language leaves it unchanged. This is the `+`-variety
 semantics working as intended ([eilenberg-1976] indexes varieties of sets on `Σ⁺`), and it is why
 `Semigroup.Pseudovariety.langs` cannot distinguish `L` from `insert [] L`. -/
-theorem syntacticSemigroupCon_insert_nil (L : Language α) :
+theorem syntacticSemigroupCon_insert_nil :
     (insert [] L).syntacticSemigroupCon = L.syntacticSemigroupCon :=
   Con.ext fun u v => by
     have h : ∀ (x : List α) (w : FreeSemigroup α) (y : List α),
@@ -199,5 +213,23 @@ theorem ker_le_syntacticSemigroupCon_of_recognizes {T : Type*} [Semigroup T]
   obtain ⟨P, hP⟩ := hrec
   intro u v huv x y
   rw [← toList_ctx x u y, ← toList_ctx x v y, hP, hP, map_ctx η huv]
+
+/-- Conversely, a hom whose kernel refines the syntactic congruence recognizes `L`: take the
+image of `L`'s nonempty words. -/
+theorem recognizesSemigroup_of_ker_le {T : Type*} [Semigroup T] {η : FreeSemigroup α →ₙ* T}
+    (h : Con.ker η ≤ L.syntacticSemigroupCon) : L.RecognizesSemigroup η :=
+  ⟨η '' {u | u.toList ∈ L}, fun w =>
+    ⟨fun hw => ⟨w, hw, rfl⟩, fun ⟨_, hu, hη⟩ =>
+      (mem_iff_of_syntacticEquiv (h ((Con.ker_rel η).mpr hη))).mp hu⟩⟩
+
+/-- Recognition is exactly refinement of the syntactic congruence. -/
+theorem recognizesSemigroup_iff_ker_le {T : Type*} [Semigroup T] {η : FreeSemigroup α →ₙ* T} :
+    L.RecognizesSemigroup η ↔ Con.ker η ≤ L.syntacticSemigroupCon :=
+  ⟨L.ker_le_syntacticSemigroupCon_of_recognizes, L.recognizesSemigroup_of_ker_le⟩
+
+/-- The syntactic projection recognizes its own language. -/
+theorem recognizesSemigroup_toSyntacticSemigroup :
+    L.RecognizesSemigroup L.toSyntacticSemigroup :=
+  L.recognizesSemigroup_of_ker_le fun {_ _} h => (Con.eq _).mp ((Con.ker_rel _).mp h)
 
 end Language

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -46,7 +46,6 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 language-side operator of the Eilenberg correspondence. -/
 def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticMonoid
 
-
 /-- **Engine.** A language recognized by a finite monoid in `V` lies in `V.langs`: the syntactic
 monoid is a quotient of a submonoid of the recognizer, hence in `V`. Generalizes
 `Language.IsStarFree.of_recognizes`. -/
@@ -118,13 +117,6 @@ Eilenberg's fourth axiom for a variety of languages ([eilenberg-1976] VII.3.3, s
 letters; [pin-mfa] Ch. XIII §3 states it for words, equivalently). The syntactic congruence of a
 quotient is coarser than that of the language, so the syntactic monoid of the quotient is a
 quotient of the original's. -/
-
-/-- The **right quotient** `L u⁻¹`: the words that land in `L` when `u` is appended. The left
-quotient is mathlib's `Language.leftQuotient`. -/
-def _root_.Language.rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
-
-@[simp] theorem _root_.Language.mem_rightQuotient {L : Language α} {u w : List α} :
-    w ∈ L.rightQuotient u ↔ w ++ u ∈ L := Iff.rfl
 
 /-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
 left context. -/

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -7,7 +7,6 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.Semigroup.Pseudovariety
 import Linglib.Core.Computability.SyntacticSemigroup
-import Linglib.Core.Computability.Variety.Langs
 import Linglib.Core.GroupTheory.Congruence.Hom
 
 /-!
@@ -26,8 +25,13 @@ they have no image under the monoid-side operator.
 
 ## Main results
 
-* `Semigroup.Pseudovariety.langs_compl`: closure under complement, from complement-invariance of
-  the syntactic congruence.
+* `Semigroup.Pseudovariety.langs_compl` / `langs_inf` / `langs_sup`: boolean closure.
+* `Semigroup.Pseudovariety.langs_leftQuotient` / `langs_rightQuotient`: closure under quotients.
+* `Semigroup.Pseudovariety.langs_comap`: closure under inverse homomorphism of free semigroups.
+* `Semigroup.Pseudovariety.langs_of_recognizes`: a language recognized by a finite semigroup in
+  `V` lies in `V.langs` — the engine behind `langs_univ` and `langs_bot`.
+
+Together these are the four conditions of [eilenberg-1976] VII, Theorem 3.2.
 -/
 
 universe u
@@ -65,20 +69,18 @@ theorem _root_.Language.syntacticSemigroupCon_le_rightQuotient (L : Language α)
   have := h x (y ++ u)
   simpa [Language.mem_rightQuotient, List.append_assoc] using this
 
+section Quotients
+
 variable {V}
 
 /-- A coarser syntactic congruence keeps the language in `V.langs`. -/
 private theorem langs_of_syntacticSemigroupCon_le {M : Language α} (h : V.langs L)
     (hle : L.syntacticSemigroupCon ≤ M.syntacticSemigroupCon) : V.langs M := by
   haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
-  haveI : Finite L.syntacticSemigroupCon.Quotient :=
-    inferInstanceAs (Finite L.syntacticSemigroup)
   have hsurj : Function.Surjective
       (Con.mapMulHom L.syntacticSemigroupCon M.syntacticSemigroupCon hle) :=
     Con.mapMulHom_surjective _ _ hle
   haveI : Finite M.syntacticSemigroup := .of_surjective _ hsurj
-  haveI : Finite M.syntacticSemigroupCon.Quotient :=
-    inferInstanceAs (Finite M.syntacticSemigroup)
   exact ⟨M.isRegular_of_finite_syntacticSemigroup ‹Finite M.syntacticSemigroup›,
     V.quot hsurj h.2⟩
 
@@ -89,6 +91,9 @@ theorem langs_leftQuotient (h : V.langs L) (u : List α) : V.langs (L.leftQuotie
 /-- **Closure under right quotient** — Eilenberg's axiom VII.3.3. -/
 theorem langs_rightQuotient (h : V.langs L) (u : List α) : V.langs (L.rightQuotient u) :=
   langs_of_syntacticSemigroupCon_le h (L.syntacticSemigroupCon_le_rightQuotient u)
+
+end Quotients
+
 /-- **Closure under intersection** — the syntactic semigroup of `L ⊓ M` is a quotient of a
 subsemigroup of `L.syntacticSemigroup × M.syntacticSemigroup`, which is in `V` by
 `prod`/`sub`/`quot`. -/
@@ -124,15 +129,12 @@ theorem langs_of_recognizes {T : Type u} [Semigroup T] [Finite T] (hT : V.mem T)
   have hkerMem : V.mem (Con.ker η).Quotient := V.sub (Con.kerLiftMulHom_injective η) hT
   have hsurj := Con.mapMulHom_surjective (Con.ker η) L.syntacticSemigroupCon hle
   haveI : Finite L.syntacticSemigroup := .of_surjective _ hsurj
-  haveI : Finite L.syntacticSemigroupCon.Quotient :=
-    inferInstanceAs (Finite L.syntacticSemigroup)
   exact ⟨L.isRegular_of_finite_syntacticSemigroup ‹_›, V.quot hsurj hkerMem⟩
 
 /-- **The full language** — recognized by the trivial semigroup, which is in every
 pseudovariety. -/
 theorem langs_univ : V.langs (⊤ : Language α) := by
-  refine V.langs_of_recognizes (T := PUnit.{u + 1}) V.memUnit
-    { toFun := fun _ => PUnit.unit, map_mul' := fun _ _ => rfl } Set.univ ?_
+  refine V.langs_of_recognizes V.memUnit (1 : FreeSemigroup α →ₙ* PUnit.{u + 1}) Set.univ ?_
   intro _
   exact iff_of_true trivial (Set.mem_univ _)
 


### PR DESCRIPTION
Review fixes on the completed keystone.

- **Binder divergence.** A `variable {V}` made `langs_inf`/`sup`/`of_recognizes`/`univ`/`comap` take `V` *implicitly* on the semigroup side where the monoid twin takes it explicitly. Scoped to the quotient block, so the two halves now diff cleanly.
- **False dependency edge.** `Language.rightQuotient` was defined inside `namespace Monoid.Pseudovariety`, which was the *only* reason the semigroup half imported the monoid half. Rehomed to `SyntacticMonoid.lean` (both halves already import it); import dropped.
- **`RecognizesSemigroup` was half-built** — defined, used once, with none of the trio its monoid twin ships. Adds `recognizesSemigroup_of_ker_le`, `_iff_ker_le`, `_toSyntacticSemigroup`.
- **Missing instance.** `Finite (syntacticSemigroupCon L).Quotient` was worked around with `inferInstanceAs` at four sites; now an instance, and the workarounds are gone.
- Deletes `Language.syntacticMonoid_compl`: zero consumers, and it cannot do the job it was written for — a `Type`-level equality cannot transport the algebraic instance, so the `rw [syntacticCon_compl]` route is the only one that works.
- Copyright header on `QFLogic.lean` (it and `Transduction.lean` were the only headerless files in `Core/Computability/`), a duplicated `variable {α}`, stale "Main results" lists in both new files, three over-long lines, blank-line normalisation.