### PR TITLE
refactor(Core/Computability): hoist Finite instances out of DFA namespace

### DIFF
--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -7,6 +7,8 @@ Authors: Robert Hawkins
 `Mathlib.Computability.MyhillNerode`'s residual program to the two-sided
 congruence.
 -/
+import Mathlib.Computability.MyhillNerode
+import Mathlib.Data.Set.Finite.Range
 import Linglib.Core.Computability.TransitionMonoid
 
 /-!

--- a/Linglib/Core/Computability/TransitionMonoid.lean
+++ b/Linglib/Core/Computability/TransitionMonoid.lean
@@ -3,14 +3,13 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 
-[UPSTREAM] candidate: `Mathlib.Computability.TransitionMonoid`.
+[UPSTREAM] candidate: `Mathlib.Computability.TransitionMonoid`. The two `Finite` instances belong
+further upstream, in `Mathlib.Algebra.Group.End` and `Mathlib.Algebra.Group.Opposite`.
 -/
 import Mathlib.Algebra.FreeMonoid.Basic
 import Mathlib.Algebra.Group.End
 import Mathlib.Computability.DFA
-import Mathlib.Computability.MyhillNerode
 import Mathlib.Data.Finite.Prod
-import Mathlib.Data.Set.Finite.Range
 import Mathlib.GroupTheory.Congruence.Basic
 import Mathlib.GroupTheory.Congruence.Hom
 
@@ -22,20 +21,25 @@ words — foundational algebraic automata theory (syntactic monoid, Schützenber
 Eilenberg variety theory), currently absent from mathlib.
 
 A word `w` acts on a state `s` of `M : DFA α σ` by `s ↦ M.evalFrom s w`. Reading `u` then `v`
-(`evalFrom_of_append`) makes this a *right* action — an anti-homomorphism into `Function.End σ` — so
-as a `MonoidHom` its target is the opposite monoid `(Function.End σ)ᵐᵒᵖ`.
+(`evalFrom_of_append`) makes this a *right* action — an anti-homomorphism into `Function.End σ` —
+so as a `MonoidHom` its target is the opposite monoid `(Function.End σ)ᵐᵒᵖ`.
 
-* `DFA.transitionHom M : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ`: the transition action.
-* `DFA.transitionMonoid M : Submonoid (Function.End σ)ᵐᵒᵖ`: its range, the transition monoid.
-* `DFA.transitionMonoidEquiv M`: the first iso theorem: `(Con.ker M.transitionHom).Quotient ≃*`
-  the transition monoid.
-* `Finite (Function.End σ)` / `Finite M.transitionMonoid` instances (these do not auto-synthesize
-  from `Finite σ`, so we register them here once).
+## Main definitions
+
+* `DFA.transitionHom`: the transition action `FreeMonoid α →* (Function.End σ)ᵐᵒᵖ`.
+* `DFA.transitionMonoid`: its range, a `Submonoid (Function.End σ)ᵐᵒᵖ`.
+* `DFA.transitionMonoidEquiv`: the first isomorphism theorem, presenting the transition monoid as
+  `(Con.ker M.transitionHom).Quotient`.
 -/
 
-noncomputable section
-
 universe u v
+
+/-- `Function.End α` is a plain `def`, so `Finite` does not see through it to `α → α`. -/
+instance Function.End.instFinite {α : Type*} [Finite α] : Finite (Function.End α) :=
+  inferInstanceAs (Finite (α → α))
+
+instance MulOpposite.instFinite {α : Type*} [Finite α] : Finite αᵐᵒᵖ :=
+  Finite.of_equiv α MulOpposite.opEquiv
 
 namespace DFA
 
@@ -45,7 +49,8 @@ variable {α : Type u} {σ : Type v} (M : DFA α σ)
 def transitionHom : FreeMonoid α →* (Function.End σ)ᵐᵒᵖ where
   toFun w := MulOpposite.op fun s => M.evalFrom s w.toList
   map_one' := rfl
-  map_mul' u v := MulOpposite.unop_injective <| funext fun s => M.evalFrom_of_append s u.toList v.toList
+  map_mul' u v := MulOpposite.unop_injective <|
+    funext fun s => M.evalFrom_of_append s u.toList v.toList
 
 @[simp]
 theorem unop_transitionHom_apply (w : FreeMonoid α) (s : σ) :
@@ -60,20 +65,11 @@ theorem transitionHom_eq_iff {u v : FreeMonoid α} : M.transitionHom u = M.trans
 def transitionMonoid : Submonoid (Function.End σ)ᵐᵒᵖ := MonoidHom.mrange M.transitionHom
 
 /-- First isomorphism theorem: the transition monoid as a quotient of `FreeMonoid α`. -/
-def transitionMonoidEquiv : (Con.ker M.transitionHom).Quotient ≃* M.transitionMonoid :=
+noncomputable def transitionMonoidEquiv :
+    (Con.ker M.transitionHom).Quotient ≃* M.transitionMonoid :=
   Con.quotientKerEquivRange _
 
-/-- `Function.End σ` is finite when `σ` is (not found automatically through the `def`). -/
-instance Function.End.instFinite [Finite σ] : Finite (Function.End σ) :=
-  Finite.of_equiv (σ → σ) (Equiv.refl _)
-
-/-- `(Function.End σ)ᵐᵒᵖ` is finite when `σ` is (likewise not found automatically). -/
-instance instFiniteEndMop [Finite σ] : Finite (Function.End σ)ᵐᵒᵖ :=
-  Finite.of_equiv (Function.End σ) MulOpposite.opEquiv
-
-instance transitionMonoid.instFinite [Finite σ] : Finite (transitionMonoid M) :=
+instance instFiniteTransitionMonoid [Finite σ] : Finite (transitionMonoid M) :=
   inferInstanceAs (Finite (MonoidHom.mrange M.transitionHom))
 
 end DFA
-
-end


### PR DESCRIPTION
Audit of `TransitionMonoid.lean`.

- `Function.End.instFinite` and the `ᵐᵒᵖ` one were declared inside `namespace DFA`, so they were really `DFA.Function.End.instFinite` — moved to the root namespace and generalised (the opposite instance holds for any `Finite α`, nothing to do with `Function.End`).
- `noncomputable section` covered the whole file; only `transitionMonoidEquiv` needs it.
- `MyhillNerode` and `Set.Finite.Range` are used by `SyntacticMonoid.lean`, not here — moved to the file that uses them.