### PR TITLE
refactor(Core/Algebra): file the Finite instances at their mathlib homes

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -6,9 +6,11 @@ and their interfaces. See README.md for documentation links.
 import Linglib.Core.Algebra.Free
 import Linglib.Core.Algebra.FreeMonoid.Destutter
 import Linglib.Core.Algebra.Group.Aperiodic
+import Linglib.Core.Algebra.Group.End
 import Linglib.Core.Algebra.Group.Idempotent
 import Linglib.Core.Algebra.Group.Pseudovariety
 import Linglib.Core.Algebra.IdempotentPower
+import Linglib.Core.Algebra.Opposites
 import Linglib.Core.Algebra.Order.ToIntervalMod
 import Linglib.Core.Algebra.PreLie.GuinOudom
 import Linglib.Core.Algebra.PreLie.OudomGuinCirc

--- a/Linglib/Core/Algebra/Group/End.lean
+++ b/Linglib/Core/Algebra/Group/End.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Group.End`, where `Function.End` is defined.
+-/
+import Mathlib.Algebra.Group.End
+import Mathlib.Data.Finite.Prod
+
+/-!
+# Finiteness of the endomorphism monoid
+
+`Function.End α` is a plain `def` for `α → α`, so instance search does not see through it.
+-/
+
+/-- `Function.End α` is a plain `def`, so `Finite` does not see through it to `α → α`. -/
+instance Function.End.instFinite {α : Type*} [Finite α] : Finite (Function.End α) :=
+  inferInstanceAs (Finite (α → α))

--- a/Linglib/Core/Algebra/Opposites.lean
+++ b/Linglib/Core/Algebra/Opposites.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Opposites`, where `MulOpposite` is defined.
+-/
+import Mathlib.Algebra.Opposites
+import Mathlib.Data.Finite.Defs
+
+/-!
+# Finiteness of the multiplicative opposite
+
+`MulOpposite α` carries no multiplication of its own here: it is finite exactly when `α` is.
+-/
+
+instance MulOpposite.instFinite {α : Type*} [Finite α] : Finite αᵐᵒᵖ :=
+  Finite.of_equiv α MulOpposite.opEquiv

--- a/Linglib/Core/Computability/TransitionMonoid.lean
+++ b/Linglib/Core/Computability/TransitionMonoid.lean
@@ -3,13 +3,12 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 
-[UPSTREAM] candidate: `Mathlib.Computability.TransitionMonoid`. The two `Finite` instances belong
-further upstream, in `Mathlib.Algebra.Group.End` and `Mathlib.Algebra.Group.Opposite`.
+[UPSTREAM] candidate: `Mathlib.Computability.TransitionMonoid`.
 -/
+import Linglib.Core.Algebra.Group.End
+import Linglib.Core.Algebra.Opposites
 import Mathlib.Algebra.FreeMonoid.Basic
-import Mathlib.Algebra.Group.End
 import Mathlib.Computability.DFA
-import Mathlib.Data.Finite.Prod
 import Mathlib.GroupTheory.Congruence.Basic
 import Mathlib.GroupTheory.Congruence.Hom
 
@@ -33,13 +32,6 @@ so as a `MonoidHom` its target is the opposite monoid `(Function.End σ)ᵐᵒ�
 -/
 
 universe u v
-
-/-- `Function.End α` is a plain `def`, so `Finite` does not see through it to `α → α`. -/
-instance Function.End.instFinite {α : Type*} [Finite α] : Finite (Function.End α) :=
-  inferInstanceAs (Finite (α → α))
-
-instance MulOpposite.instFinite {α : Type*} [Finite α] : Finite αᵐᵒᵖ :=
-  Finite.of_equiv α MulOpposite.opEquiv
 
 namespace DFA
 


### PR DESCRIPTION
Follow-up to the `TransitionMonoid.lean` audit. `Finite (Function.End α)` and `Finite αᵐᵒᵖ` are not automata content, and mathlib has neither. Split into `Core/Algebra/Group/End.lean` and `Core/Algebra/Opposites.lean`, mirroring the mathlib files that define `Function.End` and `MulOpposite`, so each can be upstreamed on its own.

Leaves `TransitionMonoid.lean` as three defs and two lemmas about DFAs.