### PR TITLE
refactor(Core/Computability): mathlib review pass on syntactic monoid

### DIFF
--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -83,7 +83,7 @@ theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
     Finite.of_equiv _ (Con.quotientKerEquivRange η).symm.toEquiv
   have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) :=
     Con.lift_surjective_of_surjective _ Con.mk'_surjective
-  exact ⟨isRegular_of_finite_syntacticMonoid (Finite.of_surjective _ hsurj),
+  exact ⟨IsRegular.of_finite_syntacticMonoid (Finite.of_surjective _ hsurj),
     hker.of_surjective hsurj⟩
 
 /-- **Star-free languages are closed under inverse homomorphism.** The engine for transferring a
@@ -91,7 +91,7 @@ star-free upper bound across a string-rewriting projection (e.g. tier erasure: `
 theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
     (φ : FreeMonoid α →* FreeMonoid β) :
     Language.IsStarFree {w : List α | φ (FreeMonoid.ofList w) ∈ L} := by
-  have : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  have : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   refine IsStarFree.of_recognizes (M := L.syntacticMonoid) h.2 (L.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, L.toSyntacticMonoid u = m ∧ u ∈ L} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -67,12 +67,12 @@ variable {L}
 @[trans] theorem SyntacticEquiv.trans {u v w : List α} (h : L.SyntacticEquiv u v)
     (h' : L.SyntacticEquiv v w) : L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
 
-/-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
-both syntactic congruences. -/
 theorem SyntacticEquiv.compl_iff {u v : List α} :
     Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
+/-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
+both syntactic congruences. -/
 theorem SyntacticEquiv.append {u u' v v' : List α} (h : L.SyntacticEquiv u u')
     (h' : L.SyntacticEquiv v v') : L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
   have h1 := h x (v ++ y)
@@ -82,8 +82,7 @@ theorem SyntacticEquiv.append {u u' v v' : List α} (h : L.SyntacticEquiv u u')
 
 /-- Syntactically equivalent words agree on membership: take the empty context. -/
 theorem mem_iff_of_syntacticEquiv {u v : List α} (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
-  have := h [] []
-  simpa using this
+  simpa using h [] []
 
 variable (L)
 
@@ -107,9 +106,7 @@ theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
     u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv h
 
 /-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
-def syntacticMonoid : Type _ := (syntacticCon L).Quotient
-
-instance : Monoid (syntacticMonoid L) := inferInstanceAs (Monoid (syntacticCon L).Quotient)
+abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
 
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
 def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
@@ -125,15 +122,13 @@ theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
 `η(w)`, applied to a `List α` rather than a bundled `FreeMonoid α`). -/
 def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
 
-@[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := by simp [syntacticClass]
+@[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := map_one _
 
 @[simp] theorem syntacticClass_append (u v : List α) :
-    L.syntacticClass (u ++ v) = L.syntacticClass u * L.syntacticClass v := by
-  simp [syntacticClass, FreeMonoid.ofList_append]
+    L.syntacticClass (u ++ v) = L.syntacticClass u * L.syntacticClass v := map_mul _ _ _
 
-theorem syntacticClass_surjective : Function.Surjective L.syntacticClass := fun s => by
-  obtain ⟨u, rfl⟩ := Quotient.exists_rep s
-  exact ⟨u.toList, congrArg L.toSyntacticMonoid (FreeMonoid.ofList_toList u)⟩
+theorem syntacticClass_surjective : Function.Surjective L.syntacticClass :=
+  Con.mk'_surjective.comp FreeMonoid.ofList.surjective
 
 variable {L} in
 
@@ -147,8 +142,8 @@ variable {L} in
 
 /-- `L` is saturated by syntactic class: equal class implies equal membership. -/
 theorem mem_iff_of_syntacticClass_eq {u v : List α}
-    (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L := by
-  simpa using syntacticClass_eq_iff.mp h [] []
+    (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L :=
+  mem_iff_of_syntacticEquiv (syntacticClass_eq_iff.mp h)
 
 variable {L} in
 
@@ -198,16 +193,20 @@ theorem recognizes_iff_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMono
   ⟨ker_le_syntacticCon_of_recognizes, recognizes_of_ker_le_syntacticCon⟩
 
 /-- The syntactic morphism is itself an `L`-recognizer (the canonical one). -/
-theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L := by
-  apply recognizes_of_ker_le_syntacticCon
-  intro u v h
-  exact (Con.eq _).mp (Con.ker_apply.mp h)
+theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
+  recognizes_of_ker_le_syntacticCon (Con.mk'_ker _).le
 
 /-! ### Connection to the minimal DFA -/
 
+/-- A DFA's transition action recognizes the language it accepts: the accepting words are those
+whose transformation carries the start state into `M.accept`. -/
+theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
+    Recognizes M.transitionHom M.accepts :=
+  ⟨{t | t.unop M.start ∈ M.accept}, rfl⟩
+
 /-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along `w` lands on the left
 quotient of `s` by `w`. -/
-theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
+@[simp] theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
   induction w using List.reverseRecOn <;>
     simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
@@ -215,25 +214,18 @@ theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
 /-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action — the
 two-sided context definition agrees with the transition-monoid quotient. -/
 theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by
-  ext u v
-  rw [syntacticCon_iff, Con.ker_apply, DFA.transitionHom_eq_iff]
-  constructor
-  · intro h s
-    apply Subtype.ext
-    obtain ⟨x, hx⟩ := s.2
+  refine le_antisymm (fun {u v} h => L.toDFA.transitionHom_eq_iff.mpr fun s => ?_) ?_
+  · obtain ⟨x, hx⟩ := s.2
+    refine Subtype.ext ?_
     rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
-    ext y
-    rw [mem_leftQuotient, mem_leftQuotient]
-    exact h x y
-  · intro h x y
-    have h' := congrArg Subtype.val (h ⟨L.leftQuotient x, ⟨x, rfl⟩⟩)
-    rw [evalFrom_toDFA, evalFrom_toDFA, ← leftQuotient_append, ← leftQuotient_append] at h'
-    rw [← mem_leftQuotient, ← mem_leftQuotient, h']
+    exact Set.ext fun y => h x y
+  · simpa only [accepts_toDFA] using
+      ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA)
 
 /-! ### Regularity implies a finite syntactic monoid -/
 
 /-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
-theorem finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
+theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
   have : Finite (Set.range L.leftQuotient) := h.finite_range_leftQuotient.to_subtype
   show Finite (syntacticCon L).Quotient
   rw [syntacticCon_eq_ker_transitionHom]
@@ -244,7 +236,7 @@ theorem finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := b
 /-- A language with finite syntactic monoid is regular (reverse Myhill–Nerode). The left-quotient
 map factors through the syntactic monoid, so a finite quotient forces finitely many left
 quotients. -/
-theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
+theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
   apply Language.IsRegular.of_finite_range_leftQuotient
   have factor : ∀ u v : FreeMonoid α, L.syntacticCon u v →
       L.leftQuotient u.toList = L.leftQuotient v.toList := by
@@ -257,7 +249,7 @@ theorem isRegular_of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.I
 
 /-- Myhill–Nerode (syntactic-monoid form): `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
-  ⟨finite_syntacticMonoid, isRegular_of_finite_syntacticMonoid⟩
+  ⟨IsRegular.finite_syntacticMonoid, IsRegular.of_finite_syntacticMonoid⟩
 
 /-! ### Complement- and intersection-invariance
 
@@ -272,20 +264,15 @@ theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCo
 /-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
 and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
 theorem inf_syntacticCon_le_syntacticCon_inf (L M : Language α) :
-    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon := by
-  rw [Con.le_def]
-  intro u v huv x y
-  rw [Con.inf_iff_and, syntacticCon_iff, syntacticCon_iff] at huv
-  exact and_congr (huv.1 x y) (huv.2 x y)
+    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon :=
+  fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
 /-- The kernel of the pairing of the two syntactic morphisms is exactly the meet of the two
 syntactic congruences (a word's class in the product is the pair of its classes). -/
 theorem ker_prod_toSyntacticMonoid (L M : Language α) :
     Con.ker (L.toSyntacticMonoid.prod M.toSyntacticMonoid) =
       L.syntacticCon ⊓ M.syntacticCon :=
-  Con.ext fun u v => by
-    rw [Con.ker_apply, MonoidHom.prod_apply, MonoidHom.prod_apply, Prod.ext_iff,
-      toSyntacticMonoid_eq_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+  Con.ext fun _ _ => by simp [Prod.ext_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
 
 /-- The **right quotient** `L u⁻¹`: the words that land in `L` when `u` is appended. The left
 quotient is mathlib's `Language.leftQuotient`. -/

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -65,10 +65,7 @@ theorem syntacticSemigroupCon_iff {u v : FreeSemigroup α} :
 
 /-- The **syntactic semigroup** of `L`: the quotient of `FreeSemigroup α` by the syntactic
 congruence. -/
-def syntacticSemigroup : Type _ := (syntacticSemigroupCon L).Quotient
-
-instance : Semigroup (syntacticSemigroup L) :=
-  inferInstanceAs (Semigroup (syntacticSemigroupCon L).Quotient)
+abbrev syntacticSemigroup : Type _ := (syntacticSemigroupCon L).Quotient
 
 /-- The canonical projection sending a nonempty word to its syntactic class. -/
 def toSyntacticSemigroup : FreeSemigroup α →ₙ* L.syntacticSemigroup :=
@@ -104,15 +101,9 @@ instance instFiniteSyntacticSemigroup [Finite L.syntacticMonoid] :
     Finite L.syntacticSemigroup :=
   .of_injective _ L.syntacticSemigroupToMonoid_injective
 
-/-- The quotient presentation of the syntactic semigroup inherits finiteness, so the closure
-proofs need not restate it. -/
-instance instFiniteSyntacticSemigroupConQuotient [Finite L.syntacticMonoid] :
-    Finite (syntacticSemigroupCon L).Quotient :=
-  inferInstanceAs (Finite L.syntacticSemigroup)
-
 /-- A regular language has a finite syntactic semigroup. -/
 theorem finite_syntacticSemigroup (h : L.IsRegular) : Finite L.syntacticSemigroup :=
-  haveI := finite_syntacticMonoid h
+  haveI := IsRegular.finite_syntacticMonoid h
   inferInstance
 
 /-- The syntactic congruence is complement-invariant, as on the monoid side. -/
@@ -136,7 +127,7 @@ theorem isRegular_iff_finite_syntacticSemigroup :
     L.IsRegular ↔ Finite L.syntacticSemigroup :=
   ⟨L.finite_syntacticSemigroup,
    fun _ =>
-     isRegular_of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup⟩
+     IsRegular.of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup⟩
 
 theorem isRegular_of_finite_syntacticSemigroup (h : Finite L.syntacticSemigroup) : L.IsRegular :=
   L.isRegular_iff_finite_syntacticSemigroup.2 h

--- a/Linglib/Core/Computability/Variety/Correspondence.lean
+++ b/Linglib/Core/Computability/Variety/Correspondence.lean
@@ -157,7 +157,7 @@ theorem eilenberg_galoisConnection :
   · -- `langToVariety 𝒱 ≤ V` ⟹ `𝒱 ≤ varietyToLang V`.
     intro hle α L h𝒱L
     have hreg : L.IsRegular := 𝒱.regular h𝒱L
-    haveI : Finite L.syntacticMonoid := Language.finite_syntacticMonoid hreg
+    haveI : Finite L.syntacticMonoid := Language.IsRegular.finite_syntacticMonoid hreg
     have hgen : (langToVariety 𝒱).mem L.syntacticMonoid :=
       Pseudovariety.subset_generated ⟨α, L, h𝒱L, ⟨MulEquiv.refl _⟩⟩
     exact ⟨hreg, hle L.syntacticMonoid hgen⟩
@@ -167,7 +167,7 @@ theorem eilenberg_galoisConnection :
     intro N _ _ hSN
     obtain ⟨α, L, h𝒱L, ⟨e⟩⟩ := hSN
     have hVmem : V.mem L.syntacticMonoid := (hle α L h𝒱L).2
-    haveI : Finite L.syntacticMonoid := Language.finite_syntacticMonoid (𝒱.regular h𝒱L)
+    haveI : Finite L.syntacticMonoid := Language.IsRegular.finite_syntacticMonoid (𝒱.regular h𝒱L)
     haveI : Finite N := Finite.of_equiv _ e.symm.toEquiv
     exact V.mem_of_mulEquiv e.symm hVmem
 
@@ -262,7 +262,7 @@ theorem mem_langToVariety_varietyToLang (V : Pseudovariety.{u}) {M : Type u} [Mo
   -- Each fibre language lies in `V.langs`, recognized by the finite monoid `M ∈ V`.
   have hlangs : ∀ m, V.langs (Lm m) := fun m => V.langs_of_recognizes hM φ {m} (fun _ => Iff.rfl)
   haveI : ∀ m, Finite (Lm m).syntacticMonoid := fun m =>
-    Language.finite_syntacticMonoid (hlangs m).1
+    Language.IsRegular.finite_syntacticMonoid (hlangs m).1
   -- Each fibre's syntactic monoid is a generator, hence in any `W` containing the generators.
   intro W hW
   have hWsyn : ∀ m, W.mem (Lm m).syntacticMonoid := fun m =>

--- a/Linglib/Core/Computability/Variety/Definite.lean
+++ b/Linglib/Core/Computability/Variety/Definite.lean
@@ -55,7 +55,7 @@ alphabet: the projection is a section, and its image consists of words of length
 private theorem isRegular_of_syntacticClass_takeAt [Finite α] (e : Edge)
     (h : ∀ w : List α, L.syntacticClass (e.takeAt k w) = L.syntacticClass w) : L.IsRegular := by
   haveI : Finite {w : List α // w.length ≤ k} := (List.finite_length_le α k).to_subtype
-  refine isRegular_of_finite_syntacticMonoid (Finite.of_surjective
+  refine IsRegular.of_finite_syntacticMonoid (Finite.of_surjective
     (fun w : {w : List α // w.length ≤ k} => L.syntacticClass w.1) fun m => ?_)
   obtain ⟨u, rfl⟩ := L.syntacticClass_surjective m
   exact ⟨⟨e.takeAt k u, by rw [Edge.length_takeAt]; exact min_le_left _ _⟩, h u⟩
@@ -302,7 +302,7 @@ exactly the definite languages. -/
 theorem langs_definiteVariety_iff [Finite α] :
     Semigroup.definiteVariety.langs L ↔ ∃ k, L.IsDefinite k := by
   refine ⟨fun h => ?_, fun ⟨_, hk⟩ => hk.langs⟩
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   exact exists_isDefinite_of_satisfies_omegaDefiniteEquation
     (isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation.1 h.2)
 
@@ -311,7 +311,7 @@ exactly the reverse-definite languages. -/
 theorem langs_reverseDefiniteVariety_iff [Finite α] :
     Semigroup.reverseDefiniteVariety.langs L ↔ ∃ k, L.IsReverseDefinite k := by
   refine ⟨fun h => ?_, fun ⟨_, hk⟩ => hk.langs⟩
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   exact exists_isReverseDefinite_of_satisfies_omegaReverseDefiniteEquation
     (isReverseDefinite_syntacticSemigroup_iff_omegaReverseDefiniteEquation.1 h.2)
 

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -58,7 +58,7 @@ theorem langs_of_recognizes {N : Type u} [Monoid N] [Finite N] (hN : V.mem N)
   have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) :=
     Con.lift_surjective_of_surjective _ Con.mk'_surjective
   haveI : Finite L.syntacticMonoid := Finite.of_surjective _ hsurj
-  exact ⟨isRegular_of_finite_syntacticMonoid ‹_›, V.quot hsurj hkerMem⟩
+  exact ⟨IsRegular.of_finite_syntacticMonoid ‹_›, V.quot hsurj hkerMem⟩
 
 /-- **Closure under complement** — immediate from complement-invariance of the syntactic monoid. -/
 theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
@@ -72,14 +72,14 @@ of `L.syntacticMonoid × M.syntacticMonoid`, which is in `V` by `prod`/`sub`/`qu
 theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊓ M) := by
   refine ⟨hL.1.inf hM.1, ?_⟩
   set φ := L.toSyntacticMonoid.prod M.toSyntacticMonoid with hφ
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid hL.1
-  haveI : Finite M.syntacticMonoid := finite_syntacticMonoid hM.1
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
+  haveI : Finite M.syntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
   have hprod : V.mem (L.syntacticMonoid × M.syntacticMonoid) := V.prod hL.2 hM.2
   haveI : Finite (Con.ker φ).Quotient := .of_injective _ (Con.kerLift_injective φ)
   have hker : V.mem (Con.ker φ).Quotient := V.sub (Con.kerLift_injective φ) hprod
   have hle : Con.ker φ ≤ (L ⊓ M).syntacticCon := by
     rw [hφ, ker_prod_toSyntacticMonoid]; exact inf_syntacticCon_le_syntacticCon_inf L M
-  haveI : Finite (L ⊓ M).syntacticMonoid := finite_syntacticMonoid (hL.1.inf hM.1)
+  haveI : Finite (L ⊓ M).syntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
   exact V.quot (f := Con.map (Con.ker φ) _ hle)
     (Con.lift_surjective_of_surjective _ Con.mk'_surjective) hker
 
@@ -105,7 +105,7 @@ recognizer is `Lb.toSyntacticMonoid.comp φ` into the finite `Lb.syntacticMonoid
 theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
     (φ : FreeMonoid α →* FreeMonoid β) :
     V.langs {w : List α | φ (FreeMonoid.ofList w) ∈ Lb} := by
-  haveI : Finite Lb.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite Lb.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   refine V.langs_of_recognizes h.2 (Lb.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, Lb.toSyntacticMonoid u = m ∧ u ∈ Lb} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
@@ -137,13 +137,11 @@ variable {V}
 /-- A coarser syntactic congruence keeps the language in `V.langs`. -/
 private theorem langs_of_syntacticCon_le {M : Language α} (h : V.langs L)
     (hle : L.syntacticCon ≤ M.syntacticCon) : V.langs M := by
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
-  haveI : Finite L.syntacticCon.Quotient := inferInstanceAs (Finite L.syntacticMonoid)
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   have hsurj : Function.Surjective (Con.map L.syntacticCon M.syntacticCon hle) :=
     Con.lift_surjective_of_surjective _ Con.mk'_surjective
   haveI : Finite M.syntacticMonoid := .of_surjective _ hsurj
-  haveI : Finite M.syntacticCon.Quotient := inferInstanceAs (Finite M.syntacticMonoid)
-  exact ⟨isRegular_of_finite_syntacticMonoid ‹_›, V.quot hsurj h.2⟩
+  exact ⟨IsRegular.of_finite_syntacticMonoid ‹_›, V.quot hsurj h.2⟩
 
 /-- **Closure under left quotient** — Eilenberg's axiom VII.3.3. -/
 theorem langs_leftQuotient (h : V.langs L) (u : List α) : V.langs (L.leftQuotient u) :=

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -76,7 +76,7 @@ variable {V}
 /-- A coarser syntactic congruence keeps the language in `V.langs`. -/
 private theorem langs_of_syntacticSemigroupCon_le {M : Language α} (h : V.langs L)
     (hle : L.syntacticSemigroupCon ≤ M.syntacticSemigroupCon) : V.langs M := by
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   have hsurj : Function.Surjective
       (Con.mapMulHom L.syntacticSemigroupCon M.syntacticSemigroupCon hle) :=
     Con.mapMulHom_surjective _ _ hle
@@ -99,9 +99,9 @@ subsemigroup of `L.syntacticSemigroup × M.syntacticSemigroup`, which is in `V` 
 `prod`/`sub`/`quot`. -/
 theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊓ M) := by
   refine ⟨hL.1.inf hM.1, ?_⟩
-  haveI : Finite L.syntacticMonoid := finite_syntacticMonoid hL.1
-  haveI : Finite M.syntacticMonoid := finite_syntacticMonoid hM.1
-  haveI : Finite (L ⊓ M).syntacticMonoid := finite_syntacticMonoid (hL.1.inf hM.1)
+  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
+  haveI : Finite M.syntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
+  haveI : Finite (L ⊓ M).syntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
   set φ := L.toSyntacticSemigroup.prod M.toSyntacticSemigroup with hφ
   haveI : Finite (Con.ker φ).Quotient := .of_injective _ (Con.kerLiftMulHom_injective φ)
   have hker : V.mem (Con.ker φ).Quotient :=
@@ -149,7 +149,7 @@ semigroup has no erasing morphisms. -/
 theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
     (φ : FreeSemigroup α →ₙ* FreeSemigroup β) :
     V.langs {w : List α | ∃ u : FreeSemigroup α, u.toList = w ∧ (φ u).toList ∈ Lb} := by
-  haveI : Finite Lb.syntacticMonoid := finite_syntacticMonoid h.1
+  haveI : Finite Lb.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   refine V.langs_of_recognizes h.2 (Lb.toSyntacticSemigroup.comp φ)
     {m | ∃ u : FreeSemigroup β, Lb.toSyntacticSemigroup u = m ∧ u.toList ∈ Lb} ?_
   intro w


### PR DESCRIPTION
Acts on a mathlib-reviewer audit of `SyntacticMonoid.lean`.

- `IsRegular.finite_syntacticMonoid` / `IsRegular.of_finite_syntacticMonoid`, matching `MyhillNerode.lean`'s `IsRegular.finite_range_leftQuotient` pair that this file already calls.
- `syntacticMonoid` and `syntacticSemigroup` become `abbrev`; their opacity was being worked around at four sites, all now deleted along with two bridging instances.
- A docstring described multiplicativity but sat on the complement lemma — moved to `SyntacticEquiv.append`.
- New `recognizes_transitionHom`: a DFA's transition action recognizes its own language, cutting `syntacticCon_eq_ker_transitionHom` from 15 lines to 8 by making its `≥` half an application of the universal property.
- `evalFrom_toDFA` gains `@[simp]`, matching mathlib's four `*_toDFA` lemmas; eight proofs golfed to terminal closers.