### PR TITLE
docs(Core/Computability): match the DFA.lean docstring register

### DIFF
--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -95,7 +95,7 @@ theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
   refine IsStarFree.of_recognizes (M := L.syntacticMonoid) h.2 (L.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, L.toSyntacticMonoid u = m ∧ u ∈ L} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
-  exact (mem_iff_of_syntacticCon ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
+  exact (mem_iff_of_syntacticEquiv ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
 
 /-- **The full language is star-free** — recognized by the trivial monoid. -/
 theorem isStarFree_univ : IsStarFree (Set.univ : Language α) :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -208,17 +208,23 @@ theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacti
 
 /-! ### Boolean combinations -/
 
-theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
+section
+
+variable (L M : Language α)
+
+theorem syntacticCon_compl : Lᶜ.syntacticCon = L.syntacticCon :=
   Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
-theorem inf_syntacticCon_le_syntacticCon_inf (L M : Language α) :
+theorem inf_syntacticCon_le_syntacticCon_inf :
     L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon :=
   fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
-theorem ker_prod_toSyntacticMonoid (L M : Language α) :
+theorem ker_prod_toSyntacticMonoid :
     Con.ker (L.toSyntacticMonoid.prod M.toSyntacticMonoid) =
       L.syntacticCon ⊓ M.syntacticCon :=
   Con.ext fun _ _ => by simp [Prod.ext_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+
+end
 
 /-! ### Right quotient -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -121,21 +121,17 @@ def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (Fre
 theorem syntacticClass_surjective : Function.Surjective L.syntacticClass :=
   Con.mk'_surjective.comp FreeMonoid.ofList.surjective
 
-variable {L}
+variable {L} {u v : List α}
 
-/-- Two words share a syntactic class iff no two-sided context distinguishes them as `L`-members,
-the word-level form of `syntacticCon_iff`. -/
-theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
-    ∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L := by
-  simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
+theorem syntacticClass_eq_iff : L.syntacticClass u = L.syntacticClass v ↔ L.SyntacticEquiv u v :=
+  L.toSyntacticMonoid_eq_iff
 
-theorem mem_iff_of_syntacticClass_eq {u v : List α}
-    (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L :=
-  mem_iff_of_syntacticEquiv (syntacticClass_eq_iff.mp h)
+theorem mem_iff_of_syntacticClass_eq (h : L.syntacticClass u = L.syntacticClass v) :
+    u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv (syntacticClass_eq_iff.mp h)
 
-/-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the same as the
-reversed-word equality in `L`. The syntactic monoid of `L.reverse` is `L`'s, opposite. -/
-theorem syntacticClass_reverse_eq_iff {u v : List α} :
+/-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the reversed-word equality
+in `L`. -/
+theorem syntacticClass_reverse_eq_iff :
     L.reverse.syntacticClass u = L.reverse.syntacticClass v ↔
       L.syntacticClass u.reverse = L.syntacticClass v.reverse := by
   rw [syntacticClass_eq_iff, syntacticClass_eq_iff]

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -96,10 +96,6 @@ theorem syntacticCon_iff :
     L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
   Iff.rfl
 
-variable {L} in
-theorem mem_iff_of_syntacticCon (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L :=
-  mem_iff_of_syntacticEquiv h
-
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
 abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
 
@@ -109,6 +105,11 @@ def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L)
 theorem toSyntacticMonoid_eq_iff :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
   Con.eq _
+
+variable {L}
+
+theorem mem_iff_of_syntacticCon (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L :=
+  mem_iff_of_syntacticEquiv h
 
 end
 
@@ -150,12 +151,10 @@ theorem syntacticClass_reverse_eq_iff {u v : List α} :
 
 /-! ### Universal property -/
 
-/-- `φ` *recognizes* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some
-`S ⊆ M`. -/
+/-- `φ` *recognizes* `L` when `L` is a union of `φ`-fibres. -/
 def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
   ∃ S : Set M, L = φ ⁻¹' S
 
-/-- An `L`-recognizing hom's kernel lies below `syntacticCon L`, the coarsest such congruence. -/
 theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
     (hrec : Recognizes φ L) : Con.ker φ ≤ syntacticCon L := by
   intro u v huv
@@ -172,8 +171,7 @@ theorem recognizes_of_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoi
   exact (mem_iff_of_syntacticCon (h (Con.ker_apply.mpr hφ))).mp hu
 
 /-- **Universal property of the syntactic monoid**: a hom recognizes `L` exactly when its
-kernel refines the syntactic congruence — `syntacticCon L` is the coarsest `L`-recognizing
-congruence, so every recognizer factors through `toSyntacticMonoid`. -/
+kernel refines the syntactic congruence. -/
 theorem recognizes_iff_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoid α →* M} :
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=
   ⟨ker_le_syntacticCon_of_recognizes, recognizes_of_ker_le_syntacticCon⟩

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -81,16 +81,16 @@ theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈
 
 end
 
+section
+
+variable {u v : FreeMonoid α}
+
 /-- The *syntactic congruence* of `L` identifies two words when no two-sided context distinguishes
 them as `L`-members. -/
 def syntacticCon : Con (FreeMonoid α) where
   r u v := L.SyntacticEquiv u.toList v.toList
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
   mul' hab hcd := hab.append hcd
-
-section
-
-variable {u v : FreeMonoid α}
 
 theorem syntacticCon_iff :
     L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
@@ -105,11 +105,6 @@ def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L)
 theorem toSyntacticMonoid_eq_iff :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
   Con.eq _
-
-variable {L}
-
-theorem mem_iff_of_syntacticCon (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L :=
-  mem_iff_of_syntacticEquiv h
 
 end
 
@@ -168,7 +163,7 @@ theorem recognizes_of_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoi
     (h : Con.ker φ ≤ syntacticCon L) : Recognizes φ L := by
   refine ⟨φ '' L, Set.ext fun w => ⟨fun hw => ⟨w, hw, rfl⟩, ?_⟩⟩
   rintro ⟨u, hu, hφ⟩
-  exact (mem_iff_of_syntacticCon (h (Con.ker_apply.mpr hφ))).mp hu
+  exact (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu
 
 /-- **Universal property of the syntactic monoid**: a hom recognizes `L` exactly when its
 kernel refines the syntactic congruence. -/

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -142,8 +142,12 @@ theorem syntacticClass_reverse_eq_iff :
 def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
   ∃ S : Set M, L = φ ⁻¹' S
 
-theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
-    (hrec : Recognizes φ L) : Con.ker φ ≤ syntacticCon L := by
+section
+
+variable {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
+
+theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
+    Con.ker φ ≤ syntacticCon L := by
   intro u v huv
   rw [syntacticCon_iff]
   obtain ⟨S, rfl⟩ := hrec
@@ -151,17 +155,19 @@ theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoi
   intro x y
   simp [Con.ker_apply.mp huv]
 
-theorem recognizes_of_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
-    (h : Con.ker φ ≤ syntacticCon L) : Recognizes φ L := by
+theorem recognizes_of_ker_le_syntacticCon (h : Con.ker φ ≤ syntacticCon L) :
+    Recognizes φ L := by
   refine ⟨φ '' L, Set.ext fun w => ⟨fun hw => ⟨w, hw, rfl⟩, ?_⟩⟩
   rintro ⟨u, hu, hφ⟩
   exact (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu
 
 /-- **Universal property of the syntactic monoid**: a hom recognizes `L` exactly when its
 kernel refines the syntactic congruence. -/
-theorem recognizes_iff_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoid α →* M} :
+theorem recognizes_iff_ker_le_syntacticCon :
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=
   ⟨ker_le_syntacticCon_of_recognizes, recognizes_of_ker_le_syntacticCon⟩
+
+end
 
 theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
   recognizes_of_ker_le_syntacticCon (Con.mk'_ker _).le

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -79,6 +79,12 @@ theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv
 theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
+theorem SyntacticEquiv.reverse_iff :
+    L.reverse.SyntacticEquiv u v ↔ L.SyntacticEquiv u.reverse v.reverse := by
+  refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;>
+    simpa only [mem_reverse, List.reverse_append, List.reverse_reverse, List.append_assoc] using
+      h y.reverse x.reverse
+
 end
 
 section
@@ -133,12 +139,8 @@ theorem mem_iff_of_syntacticClass_eq (h : L.syntacticClass u = L.syntacticClass 
 in `L`. -/
 theorem syntacticClass_reverse_eq_iff :
     L.reverse.syntacticClass u = L.reverse.syntacticClass v ↔
-      L.syntacticClass u.reverse = L.syntacticClass v.reverse := by
-  rw [syntacticClass_eq_iff, syntacticClass_eq_iff]
-  refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;>
-    · have := h y.reverse x.reverse
-      simpa only [Language.mem_reverse, List.reverse_append, List.reverse_reverse,
-        List.append_assoc] using this
+      L.syntacticClass u.reverse = L.syntacticClass v.reverse :=
+  syntacticClass_eq_iff.trans (SyntacticEquiv.reverse_iff.trans syntacticClass_eq_iff.symm)
 
 /-! ### Universal property -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -180,12 +180,13 @@ theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
 
 /-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action. -/
 theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by
-  refine le_antisymm (fun {u v} h => L.toDFA.transitionHom_eq_iff.mpr fun s => ?_) ?_
-  · obtain ⟨x, hx⟩ := s.2
-    refine Subtype.ext ?_
-    rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
-    exact Set.ext fun y => h x y
-  · simpa using ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA)
+  refine le_antisymm ?_ (by simpa using
+    ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA))
+  intro u v h
+  refine L.toDFA.transitionHom_eq_iff.mpr fun s => ?_
+  obtain ⟨x, hx⟩ := s.2
+  simp only [Subtype.ext_iff, evalFrom_toDFA, ← hx, ← leftQuotient_append]
+  exact Set.ext (h x)
 
 /-! ### Myhill–Nerode -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -190,23 +190,19 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
 
 /-! ### Myhill–Nerode -/
 
-/-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
 theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
   haveI := h.finite_range_leftQuotient.to_subtype
   show Finite (syntacticCon L).Quotient
   rw [syntacticCon_eq_ker_transitionHom]
   exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
 
-/-- A language with finite syntactic monoid is regular (reverse Myhill–Nerode). The left-quotient
-map factors through the syntactic monoid, so a finite quotient forces finitely many left
-quotients. -/
 theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
   refine Language.IsRegular.of_finite_range_leftQuotient ?_
   let g : L.syntacticMonoid → Language α :=
     Quot.lift (fun w => L.leftQuotient w.toList) fun _ _ huv => Set.ext (huv [])
   exact (Set.finite_range g).subset fun _ ⟨x, hx⟩ => ⟨Quot.mk _ (FreeMonoid.ofList x), hx⟩
 
-/-- Myhill–Nerode (syntactic-monoid form): `L` is regular iff `L.syntacticMonoid` is finite. -/
+/-- **Myhill–Nerode**, syntactic-monoid form: `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
   ⟨IsRegular.finite_syntacticMonoid, IsRegular.of_finite_syntacticMonoid⟩
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -33,8 +33,8 @@ of states.
 
 ## Main theorems
 
-- `Language.recognizes_iff_ker_le_syntacticCon`: the universal property — a hom recognizes `L`
-  exactly when its kernel refines the syntactic congruence
+- `Language.recognizes_iff_ker_le_syntacticCon`: the syntactic congruence is the coarsest
+  congruence saturating `L` — a hom recognizes `L` exactly when its kernel refines it
 - `Language.syntacticCon_eq_ker_transitionHom`: the intrinsic congruence is the kernel of the
   transition action of `L.toDFA`
 - `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form
@@ -160,8 +160,6 @@ theorem recognizes_of_ker_le_syntacticCon (h : Con.ker φ ≤ syntacticCon L) :
   rintro ⟨u, hu, hφ⟩
   exact (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu
 
-/-- **Universal property of the syntactic monoid**: a hom recognizes `L` exactly when its
-kernel refines the syntactic congruence. -/
 theorem recognizes_iff_ker_le_syntacticCon :
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=
   ⟨ker_le_syntacticCon_of_recognizes, recognizes_of_ker_le_syntacticCon⟩

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -54,34 +54,35 @@ variable {α : Type*} (L : Language α)
 them as `L`-members. -/
 def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
-variable {L}
+section
+
+variable {L} {u u' v v' w : List α}
 
 @[refl] theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
 
-@[symm] theorem SyntacticEquiv.symm {u v : List α} (h : L.SyntacticEquiv u v) :
-    L.SyntacticEquiv v u := fun x y => (h x y).symm
+@[symm] theorem SyntacticEquiv.symm (h : L.SyntacticEquiv u v) : L.SyntacticEquiv v u :=
+  fun x y => (h x y).symm
 
-@[trans] theorem SyntacticEquiv.trans {u v w : List α} (h : L.SyntacticEquiv u v)
-    (h' : L.SyntacticEquiv v w) : L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
+@[trans] theorem SyntacticEquiv.trans (h : L.SyntacticEquiv u v) (h' : L.SyntacticEquiv v w) :
+    L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
 
-theorem SyntacticEquiv.compl_iff {u v : List α} :
-    Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
+theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
 /-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
 both syntactic congruences. -/
-theorem SyntacticEquiv.append {u u' v v' : List α} (h : L.SyntacticEquiv u u')
-    (h' : L.SyntacticEquiv v v') : L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
+theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
+    L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
   have h1 := h x (v ++ y)
   have h2 := h' (x ++ u') y
   simp only [← List.append_assoc] at h1 h2 ⊢
   exact h1.trans h2
 
 /-- Syntactically equivalent words agree on membership: take the empty context. -/
-theorem mem_iff_of_syntacticEquiv {u v : List α} (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
+theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
   simpa using h [] []
 
-variable (L)
+end
 
 /-- The *syntactic congruence* of `L` identifies two words when no two-sided context distinguishes
 them as `L`-members. -/

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -148,9 +148,8 @@ variable {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
 
 theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
     Con.ker φ ≤ syntacticCon L := by
-  intro u v huv
-  rw [syntacticCon_iff]
   obtain ⟨S, rfl⟩ := hrec
+  intro u v huv
   change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
   intro x y
   simp [Con.ker_apply.mp huv]

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -169,8 +169,7 @@ theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
 
 /-! ### Connection to the minimal DFA -/
 
-/-- A DFA's transition action recognizes the language it accepts: the accepting words are those
-whose transformation carries the start state into `M.accept`. -/
+/-- A DFA's transition action recognizes the language it accepts. -/
 theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
     Recognizes M.transitionHom M.accepts :=
   ⟨{t | t.unop M.start ∈ M.accept}, rfl⟩
@@ -180,8 +179,7 @@ theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
   induction w using List.reverseRecOn <;>
     simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
 
-/-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action — the
-two-sided context definition agrees with the transition-monoid quotient. -/
+/-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action. -/
 theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by
   refine le_antisymm (fun {u v} h => L.toDFA.transitionHom_eq_iff.mpr fun s => ?_) ?_
   · obtain ⟨x, hx⟩ := s.2
@@ -190,7 +188,7 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
     exact Set.ext fun y => h x y
   · simpa using ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA)
 
-/-! ### Regularity implies a finite syntactic monoid -/
+/-! ### Myhill–Nerode -/
 
 /-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
 theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
@@ -198,8 +196,6 @@ theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticM
   show Finite (syntacticCon L).Quotient
   rw [syntacticCon_eq_ker_transitionHom]
   exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
-
-/-! ### A finite syntactic monoid implies regularity -/
 
 /-- A language with finite syntactic monoid is regular (reverse Myhill–Nerode). The left-quotient
 map factors through the syntactic monoid, so a finite quotient forces finitely many left

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -88,13 +88,17 @@ def syntacticCon : Con (FreeMonoid α) where
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
   mul' hab hcd := hab.append hcd
 
-theorem syntacticCon_iff {u v : FreeMonoid α} :
+section
+
+variable {u v : FreeMonoid α}
+
+theorem syntacticCon_iff :
     L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
   Iff.rfl
 
 variable {L} in
-theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
-    u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv h
+theorem mem_iff_of_syntacticCon (h : L.syntacticCon u v) : u ∈ L ↔ v ∈ L :=
+  mem_iff_of_syntacticEquiv h
 
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
 abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
@@ -102,14 +106,15 @@ abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
 def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
-theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
+theorem toSyntacticMonoid_eq_iff :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
   Con.eq _
 
+end
+
 /-! ### The syntactic class of a word -/
 
-/-- The *syntactic class* of a word `w` is its image in the syntactic monoid — the literature's
-`η(w)`, applied to a `List α` rather than a bundled `FreeMonoid α`. -/
+/-- The *syntactic class* of a word `w` is its image in the syntactic monoid. -/
 def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
 
 @[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := map_one _

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -192,7 +192,7 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
 
 /-- A regular language has a finite syntactic monoid (forward Myhill–Nerode). -/
 theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
-  have : Finite (Set.range L.leftQuotient) := h.finite_range_leftQuotient.to_subtype
+  haveI := h.finite_range_leftQuotient.to_subtype
   show Finite (syntacticCon L).Quotient
   rw [syntacticCon_eq_ker_transitionHom]
   exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
@@ -201,15 +201,10 @@ theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticM
 map factors through the syntactic monoid, so a finite quotient forces finitely many left
 quotients. -/
 theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
-  apply Language.IsRegular.of_finite_range_leftQuotient
-  have factor : ∀ u v : FreeMonoid α, L.syntacticCon u v →
-      L.leftQuotient u.toList = L.leftQuotient v.toList := by
-    intro u v huv
-    ext y; rw [mem_leftQuotient, mem_leftQuotient]; exact huv [] y
-  let g : L.syntacticMonoid → Language α := Quot.lift (fun w => L.leftQuotient w.toList) factor
-  refine (Set.finite_range g).subset ?_
-  rintro _ ⟨x, rfl⟩
-  exact ⟨Quot.mk _ (FreeMonoid.ofList x), rfl⟩
+  refine Language.IsRegular.of_finite_range_leftQuotient ?_
+  let g : L.syntacticMonoid → Language α :=
+    Quot.lift (fun w => L.leftQuotient w.toList) fun _ _ huv => Set.ext (huv [])
+  exact (Set.finite_range g).subset fun _ ⟨x, hx⟩ => ⟨Quot.mk _ (FreeMonoid.ofList x), hx⟩
 
 /-- Myhill–Nerode (syntactic-monoid form): `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -69,8 +69,6 @@ variable {L} {u u' v v' w : List α}
 theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
-/-- Syntactic equivalence is a congruence for concatenation — the multiplicativity step shared by
-both syntactic congruences. -/
 theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
     L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
   have h1 := h x (v ++ y)

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -151,14 +151,12 @@ theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
   obtain ⟨S, rfl⟩ := hrec
   intro u v huv
   change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
-  intro x y
   simp [Con.ker_apply.mp huv]
 
 theorem recognizes_of_ker_le_syntacticCon (h : Con.ker φ ≤ syntacticCon L) :
-    Recognizes φ L := by
-  refine ⟨φ '' L, Set.ext fun w => ⟨fun hw => ⟨w, hw, rfl⟩, ?_⟩⟩
-  rintro ⟨u, hu, hφ⟩
-  exact (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu
+    Recognizes φ L :=
+  ⟨φ '' L, (Set.subset_preimage_image φ L).antisymm
+    fun _ ⟨_, hu, hφ⟩ => (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu⟩
 
 theorem recognizes_iff_ker_le_syntacticCon :
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -70,20 +70,14 @@ theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈
     L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
 
 theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
-    L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
-  have h1 := h x (v ++ y)
-  have h2 := h' (x ++ u') y
-  simp only [← List.append_assoc] at h1 h2 ⊢
-  exact h1.trans h2
+    L.SyntacticEquiv (u ++ v) (u' ++ v') := by grind [SyntacticEquiv]
 
 theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
 theorem SyntacticEquiv.reverse_iff :
     L.reverse.SyntacticEquiv u v ↔ L.SyntacticEquiv u.reverse v.reverse := by
-  refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;>
-    simpa only [mem_reverse, List.reverse_append, List.reverse_reverse, List.append_assoc] using
-      h y.reverse x.reverse
+  refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;> simpa using h y.reverse x.reverse
 
 end
 
@@ -155,7 +149,7 @@ theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoi
   obtain ⟨S, rfl⟩ := hrec
   change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
   intro x y
-  simp only [Set.mem_preimage, map_mul, Con.ker_apply.mp huv]
+  simp [Con.ker_apply.mp huv]
 
 theorem recognizes_of_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
     (h : Con.ker φ ≤ syntacticCon L) : Recognizes φ L := by
@@ -193,8 +187,7 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
     refine Subtype.ext ?_
     rw [evalFrom_toDFA, evalFrom_toDFA, ← hx, ← leftQuotient_append, ← leftQuotient_append]
     exact Set.ext fun y => h x y
-  · simpa only [accepts_toDFA] using
-      ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA)
+  · simpa using ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA)
 
 /-! ### Regularity implies a finite syntactic monoid -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -76,7 +76,6 @@ theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv
   simp only [← List.append_assoc] at h1 h2 ⊢
   exact h1.trans h2
 
-/-- Syntactically equivalent words agree on membership: take the empty context. -/
 theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
   simpa using h [] []
 
@@ -161,8 +160,6 @@ theorem ker_le_syntacticCon_of_recognizes {M : Type*} [Monoid M] {φ : FreeMonoi
   intro x y
   simp only [Set.mem_preimage, map_mul, Con.ker_apply.mp huv]
 
-/-- Conversely, any hom whose kernel refines `syntacticCon L` recognizes `L`
-(witness `S = φ '' L`). -/
 theorem recognizes_of_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
     (h : Con.ker φ ≤ syntacticCon L) : Recognizes φ L := by
   refine ⟨φ '' L, Set.ext fun w => ⟨fun hw => ⟨w, hw, rfl⟩, ?_⟩⟩

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -91,14 +91,11 @@ def syntacticCon : Con (FreeMonoid α) where
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
   mul' hab hcd := hab.append hcd
 
-/-- The syntactic congruence is two-sided context equivalence — by definition. -/
 theorem syntacticCon_iff {u v : FreeMonoid α} :
     L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
   Iff.rfl
 
 variable {L} in
-/-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
-`syntacticCon L` (take the empty two-sided context). -/
 theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
     u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv h
 
@@ -181,7 +178,6 @@ theorem recognizes_iff_ker_le_syntacticCon {M : Type*} [Monoid M] {φ : FreeMono
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=
   ⟨ker_le_syntacticCon_of_recognizes, recognizes_of_ker_le_syntacticCon⟩
 
-/-- The syntactic morphism is itself an `L`-recognizer (the canonical one). -/
 theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
   recognizes_of_ker_le_syntacticCon (Con.mk'_ker _).le
 
@@ -193,8 +189,6 @@ theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
     Recognizes M.transitionHom M.accepts :=
   ⟨{t | t.unop M.start ∈ M.accept}, rfl⟩
 
-/-- Evaluating the minimal DFA `L.toDFA` from a quotient state `s` along `w` lands on the left
-quotient of `s` by `w`. -/
 @[simp] theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
   induction w using List.reverseRecOn <;>

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -83,8 +83,8 @@ theorem mem_iff_of_syntacticEquiv {u v : List α} (h : L.SyntacticEquiv u v) : u
 
 variable (L)
 
-/-- The *syntactic congruence* of `L`: two words are congruent when no two-sided context
-distinguishes them as `L`-members. -/
+/-- The *syntactic congruence* of `L` identifies two words when no two-sided context distinguishes
+them as `L`-members. -/
 def syntacticCon : Con (FreeMonoid α) where
   r u v := L.SyntacticEquiv u.toList v.toList
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
@@ -101,7 +101,7 @@ variable {L} in
 theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
     u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv h
 
-/-- The *syntactic monoid* of `L`: the quotient of `FreeMonoid α` by the syntactic congruence. -/
+/-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
 abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
 
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
@@ -113,8 +113,8 @@ theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
 
 /-! ### The syntactic class of a word -/
 
-/-- The *syntactic class* of a word `w`: its image in the syntactic monoid (the literature's
-`η(w)`, applied to a `List α` rather than a bundled `FreeMonoid α`). -/
+/-- The *syntactic class* of a word `w` is its image in the syntactic monoid — the literature's
+`η(w)`, applied to a `List α` rather than a bundled `FreeMonoid α`. -/
 def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
 
 @[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := map_one _
@@ -127,8 +127,8 @@ theorem syntacticClass_surjective : Function.Surjective L.syntacticClass :=
 
 variable {L}
 
-/-- Word-level form of `syntacticCon_iff`: two words share a syntactic class iff no two-sided
-context distinguishes them as `L`-members. -/
+/-- Two words share a syntactic class iff no two-sided context distinguishes them as `L`-members,
+the word-level form of `syntacticCon_iff`. -/
 theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
     ∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L := by
   simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
@@ -262,8 +262,8 @@ theorem ker_prod_toSyntacticMonoid (L M : Language α) :
       L.syntacticCon ⊓ M.syntacticCon :=
   Con.ext fun _ _ => by simp [Prod.ext_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
 
-/-- The **right quotient** `L u⁻¹`: the words that land in `L` when `u` is appended. The left
-quotient is mathlib's `Language.leftQuotient`. -/
+/-- The **right quotient** `L u⁻¹` is the set of words that land in `L` when `u` is appended. The
+left quotient is mathlib's `Language.leftQuotient`. -/
 def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
 
 @[simp] theorem mem_rightQuotient {L : Language α} {u w : List α} :

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -202,35 +202,27 @@ theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.I
     Quot.lift (fun w => L.leftQuotient w.toList) fun _ _ huv => Set.ext (huv [])
   exact (Set.finite_range g).subset fun _ ⟨x, hx⟩ => ⟨Quot.mk _ (FreeMonoid.ofList x), hx⟩
 
-/-- **Myhill–Nerode**, syntactic-monoid form: `L` is regular iff `L.syntacticMonoid` is finite. -/
+/-- `L` is regular iff `L.syntacticMonoid` is finite. -/
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
   ⟨IsRegular.finite_syntacticMonoid, IsRegular.of_finite_syntacticMonoid⟩
 
-/-! ### Complement- and intersection-invariance
+/-! ### Boolean combinations -/
 
-Generic syntactic-monoid facts about boolean combinations, used by any class defined through the
-syntactic monoid (e.g. `Language.IsStarFree`, and `Monoid.Pseudovariety.langs` in general). -/
-
-/-- The syntactic congruence is complement-invariant: a two-sided context distinguishes `u` from
-`v` for `L` exactly when it does for `Lᶜ`. -/
 theorem syntacticCon_compl (L : Language α) : Lᶜ.syntacticCon = L.syntacticCon :=
   Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
-/-- The meet of the two syntactic congruences refines that of the intersection: if no `L`-context
-and no `M`-context distinguishes `u` from `v`, then no `(L ⊓ M)`-context does either. -/
 theorem inf_syntacticCon_le_syntacticCon_inf (L M : Language α) :
     L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon :=
   fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
-/-- The kernel of the pairing of the two syntactic morphisms is exactly the meet of the two
-syntactic congruences (a word's class in the product is the pair of its classes). -/
 theorem ker_prod_toSyntacticMonoid (L M : Language α) :
     Con.ker (L.toSyntacticMonoid.prod M.toSyntacticMonoid) =
       L.syntacticCon ⊓ M.syntacticCon :=
   Con.ext fun _ _ => by simp [Prod.ext_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
 
-/-- The **right quotient** `L u⁻¹` is the set of words that land in `L` when `u` is appended. The
-left quotient is mathlib's `Language.leftQuotient`. -/
+/-! ### Right quotient -/
+
+/-- The *right quotient* `L u⁻¹` is the set of words that land in `L` when `u` is appended. -/
 def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
 
 @[simp] theorem mem_rightQuotient {L : Language α} {u w : List α} :

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -99,7 +99,7 @@ theorem syntacticCon_iff :
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
 abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
 
-/-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
+/-- The *syntactic morphism* of `L` projects `FreeMonoid α` onto the syntactic monoid. -/
 def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
 theorem toSyntacticMonoid_eq_iff :

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -176,8 +176,7 @@ theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
 
 @[simp] theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
-  induction w using List.reverseRecOn <;>
-    simp_all [DFA.evalFrom_append_singleton, step_toDFA, leftQuotient_append]
+  induction w using List.reverseRecOn <;> simp_all [leftQuotient_append]
 
 /-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action. -/
 theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -28,22 +28,23 @@ theorem reads `L.IsRegular ↔ Finite L.syntacticMonoid`.
 
 ## Main definitions
 
-* `Language.syntacticCon L : Con (FreeMonoid α)`: the syntactic congruence (two-sided context
-  equivalence).
-* `Language.syntacticMonoid L`: the quotient monoid `(syntacticCon L).Quotient`.
-* `Language.toSyntacticMonoid L`: the projection `FreeMonoid α →* L.syntacticMonoid`.
-* `Language.syntacticClass L w`: the syntactic class of a word `w : List α`.
-* `Language.Recognizes φ L`: `φ` recognizes `L`, i.e. `L` is a union of `φ`-fibres.
+- `Language.syntacticCon`: the syntactic congruence, two-sided context equivalence
+- `Language.syntacticMonoid`: the quotient monoid `(syntacticCon L).Quotient`
+- `Language.toSyntacticMonoid`: the projection `FreeMonoid α →* L.syntacticMonoid`
+- `Language.syntacticClass`: the syntactic class of a word
+- `Language.Recognizes`: `φ` recognizes `L`, i.e. `L` is a union of `φ`-fibres
 
-## Main results
+## Main theorems
 
-* `Language.syntacticClass_eq_iff`: two words share a syntactic class iff no two-sided context
-  distinguishes them, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
-* `Language.syntacticCon_eq_ker_transitionHom`: the intrinsic congruence is the kernel of the
-  transition action of `L.toDFA`.
-* `Language.ker_le_syntacticCon_of_recognizes`: the syntactic congruence is the coarsest congruence
-  recognizing `L`, so every recognizing hom factors through `toSyntacticMonoid` via `Con.lift`.
-* `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form.
+- `Language.recognizes_iff_ker_le_syntacticCon`: the universal property — a hom recognizes `L`
+  exactly when its kernel refines the syntactic congruence
+- `Language.syntacticCon_eq_ker_transitionHom`: the intrinsic congruence is the kernel of the
+  transition action of `L.toDFA`
+- `Language.isRegular_iff_finite_syntacticMonoid`: the Myhill–Nerode theorem in monoid form
+
+## References
+
+* [pin-mfa]
 -/
 
 namespace Language
@@ -100,7 +101,6 @@ theorem syntacticCon_iff {u v : FreeMonoid α} :
   Iff.rfl
 
 variable {L} in
-
 /-- Words congruent under the syntactic congruence agree on membership of `L`: `L` is saturated by
 `syntacticCon L` (take the empty two-sided context). -/
 theorem mem_iff_of_syntacticCon {u v : FreeMonoid α} (h : L.syntacticCon u v) :
@@ -114,7 +114,6 @@ instance : Monoid (syntacticMonoid L) := inferInstanceAs (Monoid (syntacticCon L
 /-- The canonical projection sending each word to its syntactic class; the underlying `Con.mk'`. -/
 def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
 
-/-- The syntactic projection identifies two words iff they are syntactically congruent. -/
 theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
   Con.eq _
@@ -136,7 +135,6 @@ theorem syntacticClass_surjective : Function.Surjective L.syntacticClass := fun 
   exact ⟨u.toList, congrArg L.toSyntacticMonoid (FreeMonoid.ofList_toList u)⟩
 
 variable {L} in
-
 /-- Word-level form of `syntacticCon_iff`: two words share a syntactic class iff no two-sided
 context distinguishes them as `L`-members. -/
 theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
@@ -144,14 +142,11 @@ theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntactic
   simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
 
 variable {L} in
-
-/-- `L` is saturated by syntactic class: equal class implies equal membership. -/
 theorem mem_iff_of_syntacticClass_eq {u v : List α}
     (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L := by
   simpa using syntacticClass_eq_iff.mp h [] []
 
 variable {L} in
-
 /-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the same as the
 reversed-word equality in `L`. The syntactic monoid of `L.reverse` is `L`'s, opposite. -/
 theorem syntacticClass_reverse_eq_iff {u v : List α} :

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -58,6 +58,9 @@ section
 
 variable {L} {u u' v v' w : List α}
 
+theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
+  simpa using h [] []
+
 @[refl] theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
 
 @[symm] theorem SyntacticEquiv.symm (h : L.SyntacticEquiv u v) : L.SyntacticEquiv v u :=
@@ -72,9 +75,6 @@ theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv
   have h2 := h' (x ++ u') y
   simp only [← List.append_assoc] at h1 h2 ⊢
   exact h1.trans h2
-
-theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
-  simpa using h [] []
 
 theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -51,8 +51,7 @@ variable {α : Type*} (L : Language α)
 /-! ### The syntactic congruence and monoid -/
 
 /-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
-them as `L`-members. Both syntactic congruences — on `FreeMonoid α` here and on `FreeSemigroup α`
-in `Language.syntacticSemigroupCon` — are this one relation, read on their respective carriers. -/
+them as `L`-members. -/
 def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
 variable {L}
@@ -131,19 +130,18 @@ theorem syntacticClass_surjective : Function.Surjective L.syntacticClass := fun 
   obtain ⟨u, rfl⟩ := Quotient.exists_rep s
   exact ⟨u.toList, congrArg L.toSyntacticMonoid (FreeMonoid.ofList_toList u)⟩
 
-variable {L} in
+variable {L}
+
 /-- Word-level form of `syntacticCon_iff`: two words share a syntactic class iff no two-sided
 context distinguishes them as `L`-members. -/
 theorem syntacticClass_eq_iff {u v : List α} : L.syntacticClass u = L.syntacticClass v ↔
     ∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L := by
   simp only [syntacticClass, toSyntacticMonoid_eq_iff, syntacticCon_iff, FreeMonoid.toList_ofList]
 
-variable {L} in
 theorem mem_iff_of_syntacticClass_eq {u v : List α}
     (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L := by
   simpa using syntacticClass_eq_iff.mp h [] []
 
-variable {L} in
 /-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the same as the
 reversed-word equality in `L`. The syntactic monoid of `L.reverse` is `L`'s, opposite. -/
 theorem syntacticClass_reverse_eq_iff {u v : List α} :
@@ -156,8 +154,6 @@ theorem syntacticClass_reverse_eq_iff {u v : List α} :
         List.append_assoc] using this
 
 /-! ### Universal property -/
-
-variable {L}
 
 /-- `φ` *recognizes* `L` when `L` is a union of `φ`-fibres, i.e. `L = φ ⁻¹' S` for some
 `S ⊆ M`. -/

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -18,13 +18,10 @@ The *syntactic monoid* of a language `L : Language α` is the quotient of the fr
 `FreeMonoid α` by the *syntactic congruence*: two words are identified when no two-sided context
 distinguishes them as `L`-members, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
 
-The syntactic congruence is defined directly as this two-sided context equivalence, and identified
-with the kernel of the minimal DFA's transition action (the *transition monoid* of `L.toDFA`, see
-`Linglib.Core.Computability.TransitionMonoid`) via `Language.syntacticCon_eq_ker_transitionHom`.
-This is the two-sided refinement of `Mathlib.Computability.MyhillNerode`, which builds the one-sided
-right-Nerode quotient (`Language.leftQuotient`) and proves regularity ↔ finitely many left
-quotients. It carries a *monoid* structure rather than just a set of states, and its Myhill–Nerode
-theorem reads `L.IsRegular ↔ Finite L.syntacticMonoid`.
+It is the coarsest congruence saturating `L`, so every recognizing homomorphism factors through it,
+and it is finite exactly when `L` is regular. This is the two-sided refinement of the one-sided
+right-Nerode quotient `Language.leftQuotient`, carrying a monoid structure rather than a bare set
+of states.
 
 ## Main definitions
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -66,9 +66,6 @@ variable {L} {u u' v v' w : List α}
 @[trans] theorem SyntacticEquiv.trans (h : L.SyntacticEquiv u v) (h' : L.SyntacticEquiv v w) :
     L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
 
-theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
-  forall_congr' fun _ => forall_congr' fun _ => not_iff_not
-
 theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
     L.SyntacticEquiv (u ++ v) (u' ++ v') := fun x y => by
   have h1 := h x (v ++ y)
@@ -78,6 +75,9 @@ theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv
 
 theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
   simpa using h [] []
+
+theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
+  forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
 end
 

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -109,7 +109,7 @@ theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
   refine V.langs_of_recognizes h.2 (Lb.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, Lb.toSyntacticMonoid u = m ∧ u ∈ Lb} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
-  exact (mem_iff_of_syntacticCon ((toSyntacticMonoid_eq_iff (L := Lb)).mp hu)).mp hmem
+  exact (mem_iff_of_syntacticEquiv ((toSyntacticMonoid_eq_iff (L := Lb)).mp hu)).mp hmem
 
 /-! ### Closure under quotients
 


### PR DESCRIPTION
Register pass on SyntacticMonoid.lean, following the comparison done for TransitionMonoid.lean in #1684.

- `-` bullets in `Name`: description form, no trailing periods; `## Main theorems` rather than `## Main results`, per DFA.lean
- `## References` citing [pin-mfa], as MyhillNerode.lean carries one
- `variable {L} in` binds the following declaration directly (MyhillNerode.lean)
- dropped two docstrings that only restated their theorem
- trimmed the module docstring to the mathematics: the second paragraph was duplicating the `Main theorems` bullets and citing module paths that will not survive upstreaming

Depends on #1685 (same file).