### PR TITLE
feat(Core/Algebra): extend a free-semigroup hom to the free monoid

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -5,6 +5,7 @@ A Lean 4 library for formal linguistics, covering semantics, pragmatics,
 and their interfaces. See README.md for documentation links.
 import Linglib.Core.Algebra.Free
 import Linglib.Core.Algebra.FreeMonoid.Destutter
+import Linglib.Core.Algebra.FreeMonoid.FreeSemigroup
 import Linglib.Core.Algebra.Group.Aperiodic
 import Linglib.Core.Algebra.Group.End
 import Linglib.Core.Algebra.Group.Idempotent

--- a/Linglib/Core/Algebra/Free.lean
+++ b/Linglib/Core/Algebra/Free.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 [UPSTREAM] candidate: `Mathlib.Algebra.Free`. Upstreaming requires `@[to_additive]` with a
 `FreeAddSemigroup.toList` counterpart, as every declaration in that file is additivized.
 -/
-import Mathlib.Algebra.Free
+import Mathlib.Algebra.FreeMonoid.FreeSemigroup
 
 /-!
 # The word underlying a free-semigroup element
@@ -29,8 +29,18 @@ def toList (u : FreeSemigroup α) : List α := u.head :: u.tail
 /-- The free semigroup is the *nonempty* words. -/
 @[simp] theorem toList_ne_nil (u : FreeSemigroup α) : u.toList ≠ [] := List.cons_ne_nil _ _
 
+theorem toFreeMonoid_eq_ofList (u : FreeSemigroup α) :
+    toFreeMonoid u = FreeMonoid.ofList u.toList := by
+  cases u; exact toFreeMonoid_mk_eq_cons _ _
+
 theorem toList_injective : Function.Injective (toList (α := α)) := by
   rintro ⟨a, s⟩ ⟨b, t⟩ h
   simpa [toList, and_comm] using h
+
+/-- Every word is empty or comes from the free semigroup — the free-level `M_A = S_A ∪ {1}`. -/
+theorem eq_nil_or_exists_toList (w : List α) : w = [] ∨ ∃ u : FreeSemigroup α, u.toList = w := by
+  rcases eq_one_or_toFreeMonoid (FreeMonoid.ofList w) with h | ⟨u, hu⟩
+  · exact Or.inl (FreeMonoid.ofList.injective (h.trans FreeMonoid.ofList_nil.symm))
+  · exact Or.inr ⟨u, by simpa [toFreeMonoid_eq_ofList] using hu⟩
 
 end FreeSemigroup

--- a/Linglib/Core/Algebra/FreeMonoid/FreeSemigroup.lean
+++ b/Linglib/Core/Algebra/FreeMonoid/FreeSemigroup.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.FreeMonoid.FreeSemigroup`, where
+`FreeMonoid.equivWithOneFreeSemigroup` already lives.
+-/
+import Mathlib.Algebra.FreeMonoid.FreeSemigroup
+import Mathlib.Algebra.Group.WithOne.Basic
+
+/-!
+# Transporting a free-semigroup homomorphism to the free monoid
+
+A homomorphism out of `FreeSemigroup α` extends to one out of `FreeMonoid α` by adjoining an
+identity to its codomain. Composing `WithOne.lift` — the universal property of `WithOne` — with
+`FreeMonoid.equivWithOneFreeSemigroup` gives that extension directly.
+
+The empty word is sent to `1`, so statements quantified over two-sided contexts need no case
+analysis on whether a context is empty: the missing factor is the identity.
+-/
+
+namespace FreeSemigroup
+
+variable {α T : Type*} [Semigroup T] (η : FreeSemigroup α →ₙ* T)
+
+/-- A free-semigroup homomorphism, extended to the free monoid by adjoining an identity to its
+codomain. -/
+noncomputable def toWithOneHom : FreeMonoid α →* WithOne T :=
+  (WithOne.lift (WithOne.coeMulHom.comp η)).comp
+    FreeMonoid.equivWithOneFreeSemigroup.toMonoidHom
+
+@[simp] theorem toWithOneHom_one : toWithOneHom η 1 = 1 := map_one _
+
+@[simp] theorem toWithOneHom_of (x : α) :
+    toWithOneHom η (FreeMonoid.of x) = (η (of x) : WithOne T) := by
+  simp [toWithOneHom, FreeMonoid.equivWithOneFreeSemigroup]
+
+@[simp] theorem toWithOneHom_toFreeMonoid (u : FreeSemigroup α) :
+    toWithOneHom η (toFreeMonoid u) = (η u : WithOne T) := by
+  induction u using FreeSemigroup.recOnMul with
+  | ih1 x => simp
+  | ih2 x y _ hy => simp [map_mul, hy]
+
+end FreeSemigroup


### PR DESCRIPTION
Foundation for replacing `SyntacticSemigroup.lean`'s `ctx` case-analysis with the `WithOne` transport.

`FreeSemigroup.toWithOneHom` composes `WithOne.lift` — the universal property of adjoining an identity — with mathlib's `FreeMonoid.equivWithOneFreeSemigroup`, extending `η : FreeSemigroup α →ₙ* T` to `FreeMonoid α →* WithOne T`.

The point is `toWithOneHom_one`: the empty word maps to `1`. `ctx`'s four-case match exists only because a semigroup has no identity to fill an empty two-sided context, and here it does.

Filed at the path mirroring `Mathlib.Algebra.FreeMonoid.FreeSemigroup`, where `equivWithOneFreeSemigroup` lives, so it upstreams into that file. Depends on no linglib content — mathlib supplies every piece.