### PR TITLE
refactor(Core/Computability): syntactic monoid review follow-ups

### DIFF
--- a/Linglib/Core/Algebra/Group/Pseudovariety.lean
+++ b/Linglib/Core/Algebra/Group/Pseudovariety.lean
@@ -17,7 +17,7 @@ A **pseudovariety** of finite monoids ([eilenberg-1976], [almeida-1995]) is a cl
 monoids closed under taking submonoids, quotients (homomorphic images), and finite direct products
 (the empty product being the trivial monoid). Pseudovarieties are the algebraic side of the
 Eilenberg correspondence: the recognizable-language classes closed under the boolean / quotient /
-inverse-homomorphism operations are exactly `{L | L.syntacticMonoid ∈ V}` for `V` a pseudovariety.
+inverse-homomorphism operations are exactly `{L | L.SyntacticMonoid ∈ V}` for `V` a pseudovariety.
 
 ## Main definitions
 

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -45,13 +45,13 @@ Star-free = `FO[<]`-definable = counter-free ([mcnaughton-papert-1971]). -/
 def IsStarFree (L : Language α) : Prop := Monoid.aperiodicVariety.langs L
 
 /-- Star-free unfolds to: regular with an aperiodic syntactic monoid. -/
-theorem isStarFree_iff : L.IsStarFree ↔ L.IsRegular ∧ Monoid.IsAperiodic L.syntacticMonoid :=
+theorem isStarFree_iff : L.IsStarFree ↔ L.IsRegular ∧ Monoid.IsAperiodic L.SyntacticMonoid :=
   Iff.rfl
 
 theorem IsStarFree.isRegular (h : L.IsStarFree) : L.IsRegular := h.1
 
 theorem IsStarFree.isAperiodic (h : L.IsStarFree) :
-    Monoid.IsAperiodic L.syntacticMonoid := h.2
+    Monoid.IsAperiodic L.SyntacticMonoid := h.2
 
 /-- **Star-free languages are closed under complement.** -/
 theorem IsStarFree.compl (h : L.IsStarFree) : Lᶜ.IsStarFree :=
@@ -75,7 +75,7 @@ theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
     (hM : Monoid.IsAperiodic M) (η : FreeMonoid α →* M) (P : Set M)
     (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : L.IsStarFree := by
   have hle : Con.ker η ≤ L.syntacticCon :=
-    ker_le_syntacticCon_of_recognizes ⟨P, Set.ext hL⟩
+    ker_le_syntacticCon_of_recognizes ⟨P, fun w => by simpa using hL w.toList⟩
   have hker : Monoid.IsAperiodic (Con.ker η).Quotient :=
     (hM.of_injective (MonoidHom.mrange η).subtype_injective).of_mulEquiv
       (Con.quotientKerEquivRange η).symm
@@ -91,11 +91,11 @@ star-free upper bound across a string-rewriting projection (e.g. tier erasure: `
 theorem IsStarFree.comap {α β : Type*} {L : Language β} (h : L.IsStarFree)
     (φ : FreeMonoid α →* FreeMonoid β) :
     Language.IsStarFree {w : List α | φ (FreeMonoid.ofList w) ∈ L} := by
-  have : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
-  refine IsStarFree.of_recognizes (M := L.syntacticMonoid) h.2 (L.toSyntacticMonoid.comp φ)
+  have : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  refine IsStarFree.of_recognizes (M := L.SyntacticMonoid) h.2 (L.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, L.toSyntacticMonoid u = m ∧ u ∈ L} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
-  exact (mem_iff_of_syntacticEquiv ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
+  exact (SyntacticEquiv.mem_iff ((toSyntacticMonoid_eq_iff (L := L)).mp hu)).mp hmem
 
 /-- **The full language is star-free** — recognized by the trivial monoid. -/
 theorem isStarFree_univ : IsStarFree (Set.univ : Language α) :=

--- a/Linglib/Core/Computability/StarFree.lean
+++ b/Linglib/Core/Computability/StarFree.lean
@@ -74,8 +74,7 @@ inside `SF`: exhibit a finite aperiodic recognizer. Stays universe-polymorphic i
 theorem IsStarFree.of_recognizes {M : Type*} [Monoid M] [Finite M]
     (hM : Monoid.IsAperiodic M) (η : FreeMonoid α →* M) (P : Set M)
     (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : L.IsStarFree := by
-  have hle : Con.ker η ≤ L.syntacticCon :=
-    ker_le_syntacticCon_of_recognizes ⟨P, fun w => by simpa using hL w.toList⟩
+  have hle : Con.ker η ≤ L.syntacticCon := ker_le_syntacticCon_of_recognizes ⟨P, Set.ext hL⟩
   have hker : Monoid.IsAperiodic (Con.ker η).Quotient :=
     (hM.of_injective (MonoidHom.mrange η).subtype_injective).of_mulEquiv
       (Con.quotientKerEquivRange η).symm

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -96,6 +96,13 @@ def syntacticCon (L : Language α) : Con (FreeMonoid α) where
 theorem syntacticCon_iff {u v : FreeMonoid α} :
     L.syntacticCon u v ↔ L.SyntacticEquiv u.toList v.toList := Iff.rfl
 
+/-- The syntactic congruence refines the Nerode equivalence uniformly: `u` and `v` are related
+when their left quotients agree in every left context. -/
+theorem syntacticCon_iff_leftQuotient {u v : FreeMonoid α} :
+    L.syntacticCon u v ↔
+      ∀ x, L.leftQuotient (x ++ u.toList) = L.leftQuotient (x ++ v.toList) :=
+  forall_congr' fun _ => Set.ext_iff.symm
+
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
 abbrev SyntacticMonoid (L : Language α) := (syntacticCon L).Quotient
 
@@ -180,15 +187,17 @@ theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
   induction w using List.reverseRecOn <;> simp_all [leftQuotient_append]
 
+/-- The kernel of the minimal DFA's transition action has the same left-quotient
+characterization as the syntactic congruence. -/
+theorem ker_transitionHom_toDFA_iff {u v : FreeMonoid α} :
+    Con.ker L.toDFA.transitionHom u v ↔
+      ∀ x, L.leftQuotient (x ++ u.toList) = L.leftQuotient (x ++ v.toList) := by
+  simp only [Con.ker_apply, DFA.transitionHom_eq_iff, Set.forall_subtype_range_iff,
+    Subtype.ext_iff, evalFrom_toDFA, ← leftQuotient_append]
+
 /-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action. -/
-theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom := by
-  refine le_antisymm ?_ (by simpa using
-    ker_le_syntacticCon_of_recognizes (recognizes_transitionHom L.toDFA))
-  intro u v h
-  refine L.toDFA.transitionHom_eq_iff.mpr fun s => ?_
-  obtain ⟨x, hx⟩ := s.2
-  simp only [Subtype.ext_iff, evalFrom_toDFA, ← hx, ← leftQuotient_append]
-  exact Set.ext (h x)
+theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom :=
+  Con.ext fun _ _ => syntacticCon_iff_leftQuotient.trans ker_transitionHom_toDFA_iff.symm
 
 /-! ### Myhill–Nerode -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -133,8 +133,8 @@ theorem mem_iff_of_syntacticClass_eq {u v : List α}
 
 theorem syntacticClass_reverse_eq_iff {u v : List α} :
     L.reverse.syntacticClass u = L.reverse.syntacticClass v ↔
-      L.syntacticClass u.reverse = L.syntacticClass v.reverse :=
-  syntacticClass_eq_iff.trans (SyntacticEquiv.reverse_iff.trans syntacticClass_eq_iff.symm)
+      L.syntacticClass u.reverse = L.syntacticClass v.reverse := by
+  simp [syntacticClass_eq_iff, SyntacticEquiv.reverse_iff]
 
 /-! ### Universal property -/
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -192,8 +192,7 @@ characterization as the syntactic congruence. -/
 theorem ker_transitionHom_toDFA_iff {u v : FreeMonoid α} :
     Con.ker L.toDFA.transitionHom u v ↔
       ∀ x, L.leftQuotient (x ++ u.toList) = L.leftQuotient (x ++ v.toList) := by
-  simp only [Con.ker_apply, DFA.transitionHom_eq_iff, Set.forall_subtype_range_iff,
-    Subtype.ext_iff, evalFrom_toDFA, ← leftQuotient_append]
+  simp [DFA.transitionHom_eq_iff, Subtype.ext_iff, ← leftQuotient_append]
 
 /-- The intrinsic syntactic congruence is the kernel of the minimal DFA's transition action. -/
 theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.transitionHom :=
@@ -233,7 +232,7 @@ theorem ker_prod_toSyntacticMonoid {L' : Language α} :
 
 /-! ### Quotients -/
 
-/-- The *right quotient* `L u⁻¹` is the set of words that land in `L` when `u` is appended. -/
+/-- The *right quotient* of `L` by `u` is the set of prefixes `w` such that `w ++ u` is in `L`. -/
 def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
 
 @[simp] theorem mem_rightQuotient {u w : List α} :
@@ -246,19 +245,14 @@ theorem rightQuotient_append (L : Language α) (u v : List α) :
     L.rightQuotient (u ++ v) = (L.rightQuotient v).rightQuotient u := by
   ext w; simp [List.append_assoc]
 
-/-- Right quotients are left quotients of the reversal. -/
 theorem rightQuotient_eq_reverse_leftQuotient (L : Language α) (u : List α) :
     L.rightQuotient u = (L.reverse.leftQuotient u.reverse).reverse := by
   ext w; simp [List.reverse_append]
 
-/-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
-left context. -/
 theorem syntacticCon_le_leftQuotient (L : Language α) (u : List α) :
     L.syntacticCon ≤ (L.leftQuotient u).syntacticCon := fun {p q} h x y => by
   simpa [List.append_assoc] using h (u ++ x) y
 
-/-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
-right context. -/
 theorem syntacticCon_le_rightQuotient (L : Language α) (u : List α) :
     L.syntacticCon ≤ (L.rightQuotient u).syntacticCon := fun {p q} h x y => by
   simpa [List.append_assoc] using h x (y ++ u)

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -48,17 +48,18 @@ monoid structure rather than a bare set of states.
 
 namespace Language
 
-variable {α : Type*} (L : Language α)
+variable {α : Type*} {L : Language α}
 
 /-! ### Syntactic equivalence -/
 
 /-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
 them as `L`-members. -/
-def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
+def SyntacticEquiv (L : Language α) (u v : List α) : Prop :=
+  ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
 namespace SyntacticEquiv
 
-variable {L} {u u' v v' w : List α}
+variable {u u' v v' w : List α}
 
 @[refl] theorem refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
 
@@ -71,7 +72,6 @@ variable {L} {u u' v v' w : List α}
 theorem append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
     L.SyntacticEquiv (u ++ v) (u' ++ v') := by grind [SyntacticEquiv]
 
-/-- Syntactically equivalent words are equi-members: specialize to the empty context. -/
 theorem mem_iff (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
   simpa using h [] []
 
@@ -88,63 +88,55 @@ end SyntacticEquiv
 
 /-- The *syntactic congruence* of `L` identifies two words when no two-sided context distinguishes
 them as `L`-members. -/
-def syntacticCon : Con (FreeMonoid α) where
+def syntacticCon (L : Language α) : Con (FreeMonoid α) where
   r u v := L.SyntacticEquiv u.toList v.toList
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
   mul' hab hcd := hab.append hcd
 
+theorem syntacticCon_iff {u v : FreeMonoid α} :
+    L.syntacticCon u v ↔ L.SyntacticEquiv u.toList v.toList := Iff.rfl
+
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
-abbrev SyntacticMonoid := (syntacticCon L).Quotient
+abbrev SyntacticMonoid (L : Language α) := (syntacticCon L).Quotient
 
 /-- The *syntactic morphism* of `L` projects `FreeMonoid α` onto the syntactic monoid. -/
-def toSyntacticMonoid : FreeMonoid α →* L.SyntacticMonoid := (syntacticCon L).mk'
+def toSyntacticMonoid (L : Language α) : FreeMonoid α →* L.SyntacticMonoid := (syntacticCon L).mk'
 
-theorem ker_toSyntacticMonoid : Con.ker L.toSyntacticMonoid = L.syntacticCon :=
-  Con.mk'_ker _
-
-section
-
-variable {L} {u v : FreeMonoid α}
-
-theorem syntacticCon_iff : L.syntacticCon u v ↔ L.SyntacticEquiv u.toList v.toList := Iff.rfl
-
-theorem toSyntacticMonoid_eq_iff :
+theorem toSyntacticMonoid_eq_iff {u v : FreeMonoid α} :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
   Con.eq _
 
-end
+theorem ker_toSyntacticMonoid (L : Language α) : Con.ker L.toSyntacticMonoid = L.syntacticCon :=
+  Con.mk'_ker _
 
 /-! ### The syntactic class of a word -/
 
 /-- The *syntactic class* of a word `w` is its image in the syntactic monoid. -/
-def syntacticClass (w : List α) : L.SyntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
+def syntacticClass (L : Language α) (w : List α) : L.SyntacticMonoid :=
+  L.toSyntacticMonoid (FreeMonoid.ofList w)
 
-@[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := map_one _
+@[simp] theorem syntacticClass_nil (L : Language α) : L.syntacticClass [] = 1 := map_one _
 
-@[simp] theorem syntacticClass_append (u v : List α) :
+@[simp] theorem syntacticClass_append (L : Language α) (u v : List α) :
     L.syntacticClass (u ++ v) = L.syntacticClass u * L.syntacticClass v := map_mul _ _ _
 
-theorem syntacticClass_surjective : Function.Surjective L.syntacticClass :=
+theorem syntacticClass_surjective (L : Language α) : Function.Surjective L.syntacticClass :=
   Con.mk'_surjective.comp FreeMonoid.ofList.surjective
 
-section
-
-variable {L} {u v : List α}
-
-theorem syntacticClass_eq_iff : L.syntacticClass u = L.syntacticClass v ↔ L.SyntacticEquiv u v :=
+theorem syntacticClass_eq_iff {u v : List α} :
+    L.syntacticClass u = L.syntacticClass v ↔ L.SyntacticEquiv u v :=
   toSyntacticMonoid_eq_iff
 
-theorem mem_iff_of_syntacticClass_eq (h : L.syntacticClass u = L.syntacticClass v) :
-    u ∈ L ↔ v ∈ L := (syntacticClass_eq_iff.mp h).mem_iff
+theorem mem_iff_of_syntacticClass_eq {u v : List α}
+    (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L :=
+  (syntacticClass_eq_iff.mp h).mem_iff
 
 /-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the reversed-word equality
 in `L`. -/
-theorem syntacticClass_reverse_eq_iff :
+theorem syntacticClass_reverse_eq_iff {u v : List α} :
     L.reverse.syntacticClass u = L.reverse.syntacticClass v ↔
       L.syntacticClass u.reverse = L.syntacticClass v.reverse :=
   syntacticClass_eq_iff.trans (SyntacticEquiv.reverse_iff.trans syntacticClass_eq_iff.symm)
-
-end
 
 /-! ### Universal property -/
 
@@ -155,7 +147,7 @@ def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language 
 
 section
 
-variable {L} {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
+variable {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
 
 theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
     Con.ker φ ≤ syntacticCon L := by
@@ -180,14 +172,10 @@ theorem recognizes_iff_ker_le_syntacticCon :
 
 end
 
-theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
+theorem recognizes_toSyntacticMonoid (L : Language α) : Recognizes L.toSyntacticMonoid L :=
   recognizes_of_ker_le_syntacticCon L.ker_toSyntacticMonoid.le
 
 /-! ### Connection to the minimal DFA -/
-
-section
-
-variable {L}
 
 /-- A DFA's transition action recognizes the language it accepts. -/
 theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
@@ -208,13 +196,7 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
   simp only [Subtype.ext_iff, evalFrom_toDFA, ← hx, ← leftQuotient_append]
   exact Set.ext (h x)
 
-end
-
 /-! ### Myhill–Nerode -/
-
-section
-
-variable {L}
 
 theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.SyntacticMonoid := by
   haveI := h.finite_range_leftQuotient.to_subtype
@@ -232,57 +214,49 @@ theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.SyntacticMonoid) : L.I
 theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.SyntacticMonoid :=
   ⟨IsRegular.finite_syntacticMonoid, IsRegular.of_finite_syntacticMonoid⟩
 
-end
-
 /-! ### Boolean combinations -/
-
-section
-
-variable {L} {L' : Language α}
 
 theorem syntacticCon_compl : Lᶜ.syntacticCon = L.syntacticCon :=
   Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
-theorem inf_syntacticCon_le_syntacticCon_inf :
+theorem inf_syntacticCon_le_syntacticCon_inf {L' : Language α} :
     L.syntacticCon ⊓ L'.syntacticCon ≤ (L ⊓ L').syntacticCon :=
   fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
-theorem ker_prod_toSyntacticMonoid :
+theorem ker_prod_toSyntacticMonoid {L' : Language α} :
     Con.ker (L.toSyntacticMonoid.prod L'.toSyntacticMonoid) =
       L.syntacticCon ⊓ L'.syntacticCon := by
   rw [Con.ker_prod, ker_toSyntacticMonoid, ker_toSyntacticMonoid]
 
-end
-
 /-! ### Quotients -/
 
 /-- The *right quotient* `L u⁻¹` is the set of words that land in `L` when `u` is appended. -/
-def rightQuotient (u : List α) : Language α := {w | w ++ u ∈ L}
+def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
 
 @[simp] theorem mem_rightQuotient {u w : List α} :
     w ∈ L.rightQuotient u ↔ w ++ u ∈ L := Iff.rfl
 
-@[simp] theorem rightQuotient_nil : L.rightQuotient [] = L := by
+@[simp] theorem rightQuotient_nil (L : Language α) : L.rightQuotient [] = L := by
   ext w; simp
 
-theorem rightQuotient_append (u v : List α) :
+theorem rightQuotient_append (L : Language α) (u v : List α) :
     L.rightQuotient (u ++ v) = (L.rightQuotient v).rightQuotient u := by
   ext w; simp [List.append_assoc]
 
 /-- Right quotients are left quotients of the reversal. -/
-theorem rightQuotient_eq_reverse_leftQuotient (u : List α) :
+theorem rightQuotient_eq_reverse_leftQuotient (L : Language α) (u : List α) :
     L.rightQuotient u = (L.reverse.leftQuotient u.reverse).reverse := by
   ext w; simp [List.reverse_append]
 
 /-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
 left context. -/
-theorem syntacticCon_le_leftQuotient (u : List α) :
+theorem syntacticCon_le_leftQuotient (L : Language α) (u : List α) :
     L.syntacticCon ≤ (L.leftQuotient u).syntacticCon := fun {p q} h x y => by
   simpa [List.append_assoc] using h (u ++ x) y
 
 /-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
 right context. -/
-theorem syntacticCon_le_rightQuotient (u : List α) :
+theorem syntacticCon_le_rightQuotient (L : Language α) (u : List α) :
     L.syntacticCon ≤ (L.rightQuotient u).syntacticCon := fun {p q} h x y => by
   simpa [List.append_assoc] using h x (y ++ u)
 

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -52,7 +52,7 @@ variable {α : Type*} {L : Language α}
 
 /-! ### Syntactic equivalence -/
 
-/-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
+/-- Two words are *syntactically equivalent* for `L` when no two-sided context distinguishes
 them as `L`-members. -/
 def SyntacticEquiv (L : Language α) (u v : List α) : Prop :=
   ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
@@ -131,8 +131,6 @@ theorem mem_iff_of_syntacticClass_eq {u v : List α}
     (h : L.syntacticClass u = L.syntacticClass v) : u ∈ L ↔ v ∈ L :=
   (syntacticClass_eq_iff.mp h).mem_iff
 
-/-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the reversed-word equality
-in `L`. -/
 theorem syntacticClass_reverse_eq_iff {u v : List α} :
     L.reverse.syntacticClass u = L.reverse.syntacticClass v ↔
       L.syntacticClass u.reverse = L.syntacticClass v.reverse :=

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -140,10 +140,10 @@ theorem syntacticClass_reverse_eq_iff {u v : List α} :
 
 /-! ### Universal property -/
 
-/-- `φ` *recognizes* `L` when membership is decided by the `φ`-image — `L` is a union of
+/-- `φ` *recognizes* `L` when `L` is the `FreeMonoid.ofList`-pullback of a union of
 `φ`-fibres. -/
 def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
-  ∃ S : Set M, ∀ w : FreeMonoid α, w.toList ∈ L ↔ φ w ∈ S
+  ∃ S : Set M, L = FreeMonoid.ofList ⁻¹' (φ ⁻¹' S)
 
 section
 
@@ -151,19 +151,15 @@ variable {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
 
 theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
     Con.ker φ ≤ syntacticCon L := by
-  obtain ⟨S, hS⟩ := hrec
+  obtain ⟨S, rfl⟩ := hrec
   intro u v huv x y
-  calc x ++ u.toList ++ y ∈ L
-      ↔ φ (.ofList x) * φ u * φ (.ofList y) ∈ S := by
-        simpa [FreeMonoid.toList_mul] using hS (.ofList x * u * .ofList y)
-    _ ↔ φ (.ofList x) * φ v * φ (.ofList y) ∈ S := by rw [Con.ker_apply.mp huv]
-    _ ↔ x ++ v.toList ++ y ∈ L := by
-        simpa [FreeMonoid.toList_mul] using (hS (.ofList x * v * .ofList y)).symm
+  show φ (.ofList (x ++ u.toList ++ y)) ∈ S ↔ φ (.ofList (x ++ v.toList ++ y)) ∈ S
+  simp [FreeMonoid.ofList_append, FreeMonoid.ofList_toList, map_mul, Con.ker_apply.mp huv]
 
 theorem recognizes_of_ker_le_syntacticCon (h : Con.ker φ ≤ syntacticCon L) :
     Recognizes φ L :=
-  ⟨φ '' {u : FreeMonoid α | u.toList ∈ L}, fun w =>
-    ⟨fun hw => ⟨w, hw, rfl⟩, fun ⟨_, hu, hφ⟩ =>
+  ⟨φ '' (FreeMonoid.ofList '' L), Set.ext fun w =>
+    ⟨fun hw => ⟨.ofList w, ⟨w, hw, rfl⟩, rfl⟩, fun ⟨_, ⟨u, hu, rfl⟩, hφ⟩ =>
       (SyntacticEquiv.mem_iff (h (Con.ker_apply.mpr hφ))).mp hu⟩⟩
 
 theorem recognizes_iff_ker_le_syntacticCon :
@@ -180,7 +176,7 @@ theorem recognizes_toSyntacticMonoid (L : Language α) : Recognizes L.toSyntacti
 /-- A DFA's transition action recognizes the language it accepts. -/
 theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
     Recognizes M.transitionHom M.accepts :=
-  ⟨{t | t.unop M.start ∈ M.accept}, fun _ => Iff.rfl⟩
+  ⟨{t | t.unop M.start ∈ M.accept}, rfl⟩
 
 @[simp] theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -10,6 +10,7 @@ congruence.
 import Mathlib.Computability.MyhillNerode
 import Mathlib.Data.Set.Finite.Range
 import Linglib.Core.Computability.TransitionMonoid
+import Linglib.Core.GroupTheory.Congruence.Hom
 
 /-!
 # The syntactic monoid of a language
@@ -18,18 +19,19 @@ The *syntactic monoid* of a language `L : Language α` is the quotient of the fr
 `FreeMonoid α` by the *syntactic congruence*: two words are identified when no two-sided context
 distinguishes them as `L`-members, `∀ x y, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L`.
 
-It is the coarsest congruence saturating `L`, so every recognizing homomorphism factors through it,
-and it is finite exactly when `L` is regular. This is the two-sided refinement of the one-sided
-right-Nerode quotient `Language.leftQuotient`, carrying a monoid structure rather than a bare set
-of states.
+It is the coarsest congruence saturating `L`, so the syntactic morphism factors through every
+recognizing homomorphism, and the quotient is finite exactly when `L` is regular. This is the
+two-sided refinement of the one-sided right-Nerode quotient `Language.leftQuotient`, carrying a
+monoid structure rather than a bare set of states.
 
 ## Main definitions
 
 - `Language.syntacticCon`: the syntactic congruence, two-sided context equivalence
-- `Language.syntacticMonoid`: the quotient monoid `(syntacticCon L).Quotient`
-- `Language.toSyntacticMonoid`: the projection `FreeMonoid α →* L.syntacticMonoid`
+- `Language.SyntacticMonoid`: the quotient monoid `(syntacticCon L).Quotient`
+- `Language.toSyntacticMonoid`: the projection `FreeMonoid α →* L.SyntacticMonoid`
 - `Language.syntacticClass`: the syntactic class of a word
 - `Language.Recognizes`: `φ` recognizes `L`, i.e. `L` is a union of `φ`-fibres
+- `Language.rightQuotient`: the right-quotient dual of `Language.leftQuotient`
 
 ## Main theorems
 
@@ -48,7 +50,7 @@ namespace Language
 
 variable {α : Type*} (L : Language α)
 
-/-! ### The syntactic congruence and monoid -/
+/-! ### Syntactic equivalence -/
 
 /-- Two words are **syntactically equivalent** for `L` when no two-sided context distinguishes
 them as `L`-members. -/
@@ -57,9 +59,6 @@ def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ 
 section
 
 variable {L} {u u' v v' w : List α}
-
-theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
-  simpa using h [] []
 
 @[refl] theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
 
@@ -72,6 +71,10 @@ theorem mem_iff_of_syntacticEquiv (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈
 theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
     L.SyntacticEquiv (u ++ v) (u' ++ v') := by grind [SyntacticEquiv]
 
+/-- Syntactically equivalent words are equi-members: specialize to the empty context. -/
+theorem SyntacticEquiv.mem_iff (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
+  simpa using h [] []
+
 theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
@@ -81,9 +84,7 @@ theorem SyntacticEquiv.reverse_iff :
 
 end
 
-section
-
-variable {u v : FreeMonoid α}
+/-! ### The syntactic congruence and monoid -/
 
 /-- The *syntactic congruence* of `L` identifies two words when no two-sided context distinguishes
 them as `L`-members. -/
@@ -92,15 +93,20 @@ def syntacticCon : Con (FreeMonoid α) where
   iseqv := ⟨fun _ => .refl _, .symm, .trans⟩
   mul' hab hcd := hab.append hcd
 
-theorem syntacticCon_iff :
-    L.syntacticCon u v ↔ ∀ x y, x ++ u.toList ++ y ∈ L ↔ x ++ v.toList ++ y ∈ L :=
-  Iff.rfl
-
 /-- The *syntactic monoid* of `L` is the quotient of `FreeMonoid α` by the syntactic congruence. -/
-abbrev syntacticMonoid : Type _ := (syntacticCon L).Quotient
+abbrev SyntacticMonoid := (syntacticCon L).Quotient
 
 /-- The *syntactic morphism* of `L` projects `FreeMonoid α` onto the syntactic monoid. -/
-def toSyntacticMonoid : FreeMonoid α →* L.syntacticMonoid := (syntacticCon L).mk'
+def toSyntacticMonoid : FreeMonoid α →* L.SyntacticMonoid := (syntacticCon L).mk'
+
+theorem ker_toSyntacticMonoid : Con.ker L.toSyntacticMonoid = L.syntacticCon :=
+  Con.mk'_ker _
+
+section
+
+variable {L} {u v : FreeMonoid α}
+
+theorem syntacticCon_iff : L.syntacticCon u v ↔ L.SyntacticEquiv u.toList v.toList := Iff.rfl
 
 theorem toSyntacticMonoid_eq_iff :
     L.toSyntacticMonoid u = L.toSyntacticMonoid v ↔ L.syntacticCon u v :=
@@ -111,7 +117,7 @@ end
 /-! ### The syntactic class of a word -/
 
 /-- The *syntactic class* of a word `w` is its image in the syntactic monoid. -/
-def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
+def syntacticClass (w : List α) : L.SyntacticMonoid := L.toSyntacticMonoid (FreeMonoid.ofList w)
 
 @[simp] theorem syntacticClass_nil : L.syntacticClass [] = 1 := map_one _
 
@@ -121,13 +127,15 @@ def syntacticClass (w : List α) : L.syntacticMonoid := L.toSyntacticMonoid (Fre
 theorem syntacticClass_surjective : Function.Surjective L.syntacticClass :=
   Con.mk'_surjective.comp FreeMonoid.ofList.surjective
 
+section
+
 variable {L} {u v : List α}
 
 theorem syntacticClass_eq_iff : L.syntacticClass u = L.syntacticClass v ↔ L.SyntacticEquiv u v :=
-  L.toSyntacticMonoid_eq_iff
+  toSyntacticMonoid_eq_iff
 
 theorem mem_iff_of_syntacticClass_eq (h : L.syntacticClass u = L.syntacticClass v) :
-    u ∈ L ↔ v ∈ L := mem_iff_of_syntacticEquiv (syntacticClass_eq_iff.mp h)
+    u ∈ L ↔ v ∈ L := (syntacticClass_eq_iff.mp h).mem_iff
 
 /-- **Reverse duality**: a syntactic-class equality in `L.reverse` is the reversed-word equality
 in `L`. -/
@@ -136,27 +144,35 @@ theorem syntacticClass_reverse_eq_iff :
       L.syntacticClass u.reverse = L.syntacticClass v.reverse :=
   syntacticClass_eq_iff.trans (SyntacticEquiv.reverse_iff.trans syntacticClass_eq_iff.symm)
 
+end
+
 /-! ### Universal property -/
 
-/-- `φ` *recognizes* `L` when `L` is a union of `φ`-fibres. -/
+/-- `φ` *recognizes* `L` when membership is decided by the `φ`-image — `L` is a union of
+`φ`-fibres. -/
 def Recognizes {M : Type*} [Monoid M] (φ : FreeMonoid α →* M) (L : Language α) : Prop :=
-  ∃ S : Set M, L = φ ⁻¹' S
+  ∃ S : Set M, ∀ w : FreeMonoid α, w.toList ∈ L ↔ φ w ∈ S
 
 section
 
-variable {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
+variable {L} {M : Type*} [Monoid M] {φ : FreeMonoid α →* M}
 
 theorem ker_le_syntacticCon_of_recognizes (hrec : Recognizes φ L) :
     Con.ker φ ≤ syntacticCon L := by
-  obtain ⟨S, rfl⟩ := hrec
-  intro u v huv
-  change ∀ x y : FreeMonoid α, x * u * y ∈ φ ⁻¹' S ↔ x * v * y ∈ φ ⁻¹' S
-  simp [Con.ker_apply.mp huv]
+  obtain ⟨S, hS⟩ := hrec
+  intro u v huv x y
+  calc x ++ u.toList ++ y ∈ L
+      ↔ φ (.ofList x) * φ u * φ (.ofList y) ∈ S := by
+        simpa [FreeMonoid.toList_mul] using hS (.ofList x * u * .ofList y)
+    _ ↔ φ (.ofList x) * φ v * φ (.ofList y) ∈ S := by rw [Con.ker_apply.mp huv]
+    _ ↔ x ++ v.toList ++ y ∈ L := by
+        simpa [FreeMonoid.toList_mul] using (hS (.ofList x * v * .ofList y)).symm
 
 theorem recognizes_of_ker_le_syntacticCon (h : Con.ker φ ≤ syntacticCon L) :
     Recognizes φ L :=
-  ⟨φ '' L, (Set.subset_preimage_image φ L).antisymm
-    fun _ ⟨_, hu, hφ⟩ => (mem_iff_of_syntacticEquiv (h (Con.ker_apply.mpr hφ))).mp hu⟩
+  ⟨φ '' {u : FreeMonoid α | u.toList ∈ L}, fun w =>
+    ⟨fun hw => ⟨w, hw, rfl⟩, fun ⟨_, hu, hφ⟩ =>
+      (SyntacticEquiv.mem_iff (h (Con.ker_apply.mpr hφ))).mp hu⟩⟩
 
 theorem recognizes_iff_ker_le_syntacticCon :
     Recognizes φ L ↔ Con.ker φ ≤ syntacticCon L :=
@@ -165,14 +181,18 @@ theorem recognizes_iff_ker_le_syntacticCon :
 end
 
 theorem recognizes_toSyntacticMonoid : Recognizes L.toSyntacticMonoid L :=
-  recognizes_of_ker_le_syntacticCon (Con.mk'_ker _).le
+  recognizes_of_ker_le_syntacticCon L.ker_toSyntacticMonoid.le
 
 /-! ### Connection to the minimal DFA -/
+
+section
+
+variable {L}
 
 /-- A DFA's transition action recognizes the language it accepts. -/
 theorem recognizes_transitionHom {σ : Type*} (M : DFA α σ) :
     Recognizes M.transitionHom M.accepts :=
-  ⟨{t | t.unop M.start ∈ M.accept}, rfl⟩
+  ⟨{t | t.unop M.start ∈ M.accept}, fun _ => Iff.rfl⟩
 
 @[simp] theorem evalFrom_toDFA (s : Set.range L.leftQuotient) (w : List α) :
     (L.toDFA.evalFrom s w).val = s.val.leftQuotient w := by
@@ -188,50 +208,82 @@ theorem syntacticCon_eq_ker_transitionHom : L.syntacticCon = Con.ker L.toDFA.tra
   simp only [Subtype.ext_iff, evalFrom_toDFA, ← hx, ← leftQuotient_append]
   exact Set.ext (h x)
 
+end
+
 /-! ### Myhill–Nerode -/
 
-theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.syntacticMonoid := by
+section
+
+variable {L}
+
+theorem IsRegular.finite_syntacticMonoid (h : L.IsRegular) : Finite L.SyntacticMonoid := by
   haveI := h.finite_range_leftQuotient.to_subtype
   show Finite (syntacticCon L).Quotient
   rw [syntacticCon_eq_ker_transitionHom]
   exact Finite.of_equiv _ (DFA.transitionMonoidEquiv L.toDFA).symm.toEquiv
 
-theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.syntacticMonoid) : L.IsRegular := by
+theorem IsRegular.of_finite_syntacticMonoid (h : Finite L.SyntacticMonoid) : L.IsRegular := by
   refine Language.IsRegular.of_finite_range_leftQuotient ?_
-  let g : L.syntacticMonoid → Language α :=
-    Quot.lift (fun w => L.leftQuotient w.toList) fun _ _ huv => Set.ext (huv [])
-  exact (Set.finite_range g).subset fun _ ⟨x, hx⟩ => ⟨Quot.mk _ (FreeMonoid.ofList x), hx⟩
+  let g : L.SyntacticMonoid → Language α :=
+    fun c => Con.liftOn c (fun w => L.leftQuotient w.toList) fun _ _ huv => Set.ext (huv [])
+  exact (Set.finite_range g).subset fun _ ⟨x, hx⟩ => ⟨(FreeMonoid.ofList x : FreeMonoid α), hx⟩
 
-/-- `L` is regular iff `L.syntacticMonoid` is finite. -/
-theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.syntacticMonoid :=
+/-- `L` is regular iff `L.SyntacticMonoid` is finite. -/
+theorem isRegular_iff_finite_syntacticMonoid : L.IsRegular ↔ Finite L.SyntacticMonoid :=
   ⟨IsRegular.finite_syntacticMonoid, IsRegular.of_finite_syntacticMonoid⟩
+
+end
 
 /-! ### Boolean combinations -/
 
 section
 
-variable (L M : Language α)
+variable {L} {L' : Language α}
 
 theorem syntacticCon_compl : Lᶜ.syntacticCon = L.syntacticCon :=
   Con.ext fun _ _ => SyntacticEquiv.compl_iff
 
 theorem inf_syntacticCon_le_syntacticCon_inf :
-    L.syntacticCon ⊓ M.syntacticCon ≤ (L ⊓ M).syntacticCon :=
+    L.syntacticCon ⊓ L'.syntacticCon ≤ (L ⊓ L').syntacticCon :=
   fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
 theorem ker_prod_toSyntacticMonoid :
-    Con.ker (L.toSyntacticMonoid.prod M.toSyntacticMonoid) =
-      L.syntacticCon ⊓ M.syntacticCon :=
-  Con.ext fun _ _ => by simp [Prod.ext_iff, toSyntacticMonoid_eq_iff, Con.inf_iff_and]
+    Con.ker (L.toSyntacticMonoid.prod L'.toSyntacticMonoid) =
+      L.syntacticCon ⊓ L'.syntacticCon := by
+  rw [Con.ker_prod, ker_toSyntacticMonoid, ker_toSyntacticMonoid]
 
 end
 
-/-! ### Right quotient -/
+/-! ### Quotients -/
 
 /-- The *right quotient* `L u⁻¹` is the set of words that land in `L` when `u` is appended. -/
-def rightQuotient (L : Language α) (u : List α) : Language α := {w | w ++ u ∈ L}
+def rightQuotient (u : List α) : Language α := {w | w ++ u ∈ L}
 
-@[simp] theorem mem_rightQuotient {L : Language α} {u w : List α} :
+@[simp] theorem mem_rightQuotient {u w : List α} :
     w ∈ L.rightQuotient u ↔ w ++ u ∈ L := Iff.rfl
+
+@[simp] theorem rightQuotient_nil : L.rightQuotient [] = L := by
+  ext w; simp
+
+theorem rightQuotient_append (u v : List α) :
+    L.rightQuotient (u ++ v) = (L.rightQuotient v).rightQuotient u := by
+  ext w; simp [List.append_assoc]
+
+/-- Right quotients are left quotients of the reversal. -/
+theorem rightQuotient_eq_reverse_leftQuotient (u : List α) :
+    L.rightQuotient u = (L.reverse.leftQuotient u.reverse).reverse := by
+  ext w; simp [List.reverse_append]
+
+/-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
+left context. -/
+theorem syntacticCon_le_leftQuotient (u : List α) :
+    L.syntacticCon ≤ (L.leftQuotient u).syntacticCon := fun {p q} h x y => by
+  simpa [List.append_assoc] using h (u ++ x) y
+
+/-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
+right context. -/
+theorem syntacticCon_le_rightQuotient (u : List α) :
+    L.syntacticCon ≤ (L.rightQuotient u).syntacticCon := fun {p q} h x y => by
+  simpa [List.append_assoc] using h x (y ++ u)
 
 end Language

--- a/Linglib/Core/Computability/SyntacticMonoid.lean
+++ b/Linglib/Core/Computability/SyntacticMonoid.lean
@@ -56,33 +56,33 @@ variable {α : Type*} (L : Language α)
 them as `L`-members. -/
 def SyntacticEquiv (u v : List α) : Prop := ∀ x y : List α, x ++ u ++ y ∈ L ↔ x ++ v ++ y ∈ L
 
-section
+namespace SyntacticEquiv
 
 variable {L} {u u' v v' w : List α}
 
-@[refl] theorem SyntacticEquiv.refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
+@[refl] theorem refl (u : List α) : L.SyntacticEquiv u u := fun _ _ => Iff.rfl
 
-@[symm] theorem SyntacticEquiv.symm (h : L.SyntacticEquiv u v) : L.SyntacticEquiv v u :=
+@[symm] theorem symm (h : L.SyntacticEquiv u v) : L.SyntacticEquiv v u :=
   fun x y => (h x y).symm
 
-@[trans] theorem SyntacticEquiv.trans (h : L.SyntacticEquiv u v) (h' : L.SyntacticEquiv v w) :
+@[trans] theorem trans (h : L.SyntacticEquiv u v) (h' : L.SyntacticEquiv v w) :
     L.SyntacticEquiv u w := fun x y => (h x y).trans (h' x y)
 
-theorem SyntacticEquiv.append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
+theorem append (h : L.SyntacticEquiv u u') (h' : L.SyntacticEquiv v v') :
     L.SyntacticEquiv (u ++ v) (u' ++ v') := by grind [SyntacticEquiv]
 
 /-- Syntactically equivalent words are equi-members: specialize to the empty context. -/
-theorem SyntacticEquiv.mem_iff (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
+theorem mem_iff (h : L.SyntacticEquiv u v) : u ∈ L ↔ v ∈ L := by
   simpa using h [] []
 
-theorem SyntacticEquiv.compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
+theorem compl_iff : Lᶜ.SyntacticEquiv u v ↔ L.SyntacticEquiv u v :=
   forall_congr' fun _ => forall_congr' fun _ => not_iff_not
 
-theorem SyntacticEquiv.reverse_iff :
+theorem reverse_iff :
     L.reverse.SyntacticEquiv u v ↔ L.SyntacticEquiv u.reverse v.reverse := by
   refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;> simpa using h y.reverse x.reverse
 
-end
+end SyntacticEquiv
 
 /-! ### The syntactic congruence and monoid -/
 

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -26,7 +26,7 @@ idempotent `1` forces triviality; stating them on `FreeSemigroup α` is what avo
 ## Main definitions
 
 - `Language.syntacticSemigroupCon`: the syntactic congruence on `FreeSemigroup α`
-- `Language.syntacticSemigroup`: the quotient semigroup
+- `Language.SyntacticSemigroup`: the quotient semigroup
 - `Language.toSyntacticSemigroup`: the projection, as a `MulHom`
 - `Language.RecognizesSemigroup`: recognition of a language by a homomorphism to a semigroup
 
@@ -72,10 +72,10 @@ theorem syntacticSemigroupCon_iff :
 
 /-- The **syntactic semigroup** of `L`: the quotient of `FreeSemigroup α` by the syntactic
 congruence. -/
-abbrev syntacticSemigroup : Type _ := (syntacticSemigroupCon L).Quotient
+abbrev SyntacticSemigroup := (syntacticSemigroupCon L).Quotient
 
 /-- The *syntactic morphism* of `L` projects `FreeSemigroup α` onto the syntactic semigroup. -/
-def toSyntacticSemigroup : FreeSemigroup α →ₙ* L.syntacticSemigroup :=
+def toSyntacticSemigroup : FreeSemigroup α →ₙ* L.SyntacticSemigroup :=
   Con.mkMulHom (syntacticSemigroupCon L)
 
 theorem toSyntacticSemigroup_eq_iff :
@@ -87,11 +87,14 @@ end
 theorem toSyntacticSemigroup_surjective : Function.Surjective L.toSyntacticSemigroup :=
   Con.mkMulHom_surjective _
 
+theorem ker_toSyntacticSemigroup : Con.ker L.toSyntacticSemigroup = L.syntacticSemigroupCon :=
+  Con.ker_mkMulHom_eq _
+
 /-! ### Relation to the syntactic monoid -/
 
 /-- The syntactic semigroup embeds into the syntactic monoid: a nonempty word is sent to its
 class in the monoid. It is injective because both quotients are by the same context relation. -/
-def syntacticSemigroupToMonoid : L.syntacticSemigroup →ₙ* L.syntacticMonoid where
+def syntacticSemigroupToMonoid : L.SyntacticSemigroup →ₙ* L.SyntacticMonoid where
   toFun := Quotient.lift (fun u : FreeSemigroup α => L.syntacticClass u.toList)
     fun _ _ h => syntacticClass_eq_iff.mpr h
   map_mul' := by rintro ⟨u⟩ ⟨v⟩; exact L.syntacticClass_append u.toList v.toList
@@ -104,15 +107,15 @@ theorem syntacticSemigroupToMonoid_injective :
   rintro ⟨u⟩ ⟨v⟩ h
   exact Quotient.sound (syntacticClass_eq_iff.mp h)
 
-instance instFiniteSyntacticSemigroup [Finite L.syntacticMonoid] :
-    Finite L.syntacticSemigroup :=
+instance instFiniteSyntacticSemigroup [Finite L.SyntacticMonoid] :
+    Finite L.SyntacticSemigroup :=
   .of_injective _ L.syntacticSemigroupToMonoid_injective
 
 /-- Conversely, a finite syntactic semigroup forces a finite syntactic monoid: the monoid is
 covered by the semigroup together with the identity, which is Eilenberg's `M_A = S_A ∪ {1}`. -/
-theorem finite_syntacticMonoid_of_finite_syntacticSemigroup [Finite L.syntacticSemigroup] :
-    Finite L.syntacticMonoid := by
-  refine .of_surjective (β := L.syntacticMonoid)
+theorem finite_syntacticMonoid_of_finite_syntacticSemigroup [Finite L.SyntacticSemigroup] :
+    Finite L.SyntacticMonoid := by
+  refine .of_surjective (β := L.SyntacticMonoid)
     (Option.elim · 1 L.syntacticSemigroupToMonoid) fun m => ?_
   obtain ⟨w, rfl⟩ := L.syntacticClass_surjective m
   match w with
@@ -125,16 +128,16 @@ section
 
 variable {L}
 
-theorem IsRegular.finite_syntacticSemigroup (h : L.IsRegular) : Finite L.syntacticSemigroup :=
+theorem IsRegular.finite_syntacticSemigroup (h : L.IsRegular) : Finite L.SyntacticSemigroup :=
   haveI := IsRegular.finite_syntacticMonoid h
   inferInstance
 
-theorem IsRegular.of_finite_syntacticSemigroup (h : Finite L.syntacticSemigroup) : L.IsRegular :=
+theorem IsRegular.of_finite_syntacticSemigroup (h : Finite L.SyntacticSemigroup) : L.IsRegular :=
   IsRegular.of_finite_syntacticMonoid L.finite_syntacticMonoid_of_finite_syntacticSemigroup
 
-/-- `L` is regular iff `L.syntacticSemigroup` is finite. -/
+/-- `L` is regular iff `L.SyntacticSemigroup` is finite. -/
 theorem isRegular_iff_finite_syntacticSemigroup :
-    L.IsRegular ↔ Finite L.syntacticSemigroup :=
+    L.IsRegular ↔ Finite L.SyntacticSemigroup :=
   ⟨IsRegular.finite_syntacticSemigroup, IsRegular.of_finite_syntacticSemigroup⟩
 
 end
@@ -146,19 +149,32 @@ theorem syntacticSemigroupCon_compl : Lᶜ.syntacticSemigroupCon = L.syntacticSe
 
 section
 
-variable (L M : Language α)
+variable (L L' : Language α)
 
 theorem inf_syntacticSemigroupCon_le_syntacticSemigroupCon_inf :
-    L.syntacticSemigroupCon ⊓ M.syntacticSemigroupCon ≤ (L ⊓ M).syntacticSemigroupCon :=
+    L.syntacticSemigroupCon ⊓ L'.syntacticSemigroupCon ≤ (L ⊓ L').syntacticSemigroupCon :=
   fun {_ _} huv x y => and_congr (huv.1 x y) (huv.2 x y)
 
 theorem ker_prod_toSyntacticSemigroup :
-    Con.ker (L.toSyntacticSemigroup.prod M.toSyntacticSemigroup) =
-      L.syntacticSemigroupCon ⊓ M.syntacticSemigroupCon :=
-  Con.ext fun _ _ => by
-    simp [Con.ker_rel, Prod.ext_iff, toSyntacticSemigroup_eq_iff, Con.inf_iff_and]
+    Con.ker (L.toSyntacticSemigroup.prod L'.toSyntacticSemigroup) =
+      L.syntacticSemigroupCon ⊓ L'.syntacticSemigroupCon := by
+  rw [Con.ker_prodMulHom, ker_toSyntacticSemigroup, ker_toSyntacticSemigroup]
 
 end
+
+/-! ### Quotients -/
+
+/-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
+left context. -/
+theorem syntacticSemigroupCon_le_leftQuotient (u : List α) :
+    L.syntacticSemigroupCon ≤ (L.leftQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
+  simpa [List.append_assoc] using h (u ++ x) y
+
+/-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
+right context. -/
+theorem syntacticSemigroupCon_le_rightQuotient (u : List α) :
+    L.syntacticSemigroupCon ≤ (L.rightQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
+  simpa [List.append_assoc] using h x (y ++ u)
 
 /-- **The syntactic semigroup does not see the empty word.** Its congruence quantifies only over
 nonempty words, so adjoining `[]` to a language leaves it unchanged. This is the `+`-variety
@@ -177,9 +193,7 @@ theorem syntacticSemigroupCon_insert_nil :
 
 /-! ### Recognition by a semigroup
 
-The monoid notion `Language.Recognizes` is the set equation `L = φ ⁻¹' S`. That cannot be stated
-here: `η ⁻¹' P` is a set of `FreeSemigroup α`, whereas a `Language α` is a set of `List α`. The
-pointwise form below says the same thing about nonempty words, and says nothing about `[]` — which
+The pointwise form of `Language.Recognizes`, on nonempty words. It says nothing about `[]` — which
 is right, since the syntactic semigroup does not see it (`syntacticSemigroupCon_insert_nil`). -/
 
 /-- `η` **recognizes** `L` when membership of a nonempty word is decided by its image. -/
@@ -219,7 +233,7 @@ theorem recognizesSemigroup_of_ker_le (h : Con.ker η ≤ L.syntacticSemigroupCo
     L.RecognizesSemigroup η :=
   ⟨η '' {u | u.toList ∈ L}, fun w =>
     ⟨fun hw => ⟨w, hw, rfl⟩, fun ⟨_, hu, hη⟩ =>
-      (mem_iff_of_syntacticEquiv (h ((Con.ker_rel η).mpr hη))).mp hu⟩⟩
+      (SyntacticEquiv.mem_iff (h ((Con.ker_rel η).mpr hη))).mp hu⟩⟩
 
 theorem recognizesSemigroup_iff_ker_le :
     L.RecognizesSemigroup η ↔ Con.ker η ≤ L.syntacticSemigroupCon :=
@@ -229,6 +243,6 @@ end
 
 theorem recognizesSemigroup_toSyntacticSemigroup :
     L.RecognizesSemigroup L.toSyntacticSemigroup :=
-  L.recognizesSemigroup_of_ker_le fun {_ _} h => (Con.eq _).mp ((Con.ker_rel _).mp h)
+  L.recognizesSemigroup_of_ker_le L.ker_toSyntacticSemigroup.le
 
 end Language

--- a/Linglib/Core/Computability/SyntacticSemigroup.lean
+++ b/Linglib/Core/Computability/SyntacticSemigroup.lean
@@ -193,8 +193,10 @@ theorem syntacticSemigroupCon_insert_nil :
 
 /-! ### Recognition by a semigroup
 
-The pointwise form of `Language.Recognizes`, on nonempty words. It says nothing about `[]` — which
-is right, since the syntactic semigroup does not see it (`syntacticSemigroupCon_insert_nil`). -/
+`Language.Recognizes` pulls the fibre equation back along `FreeMonoid.ofList`; `FreeSemigroup α`
+omits the empty word, so no such pullback exists and recognition is stated pointwise on nonempty
+words. It says nothing about `[]` — which is right, since the syntactic semigroup does not see it
+(`syntacticSemigroupCon_insert_nil`). -/
 
 /-- `η` **recognizes** `L` when membership of a nonempty word is decided by its image. -/
 def RecognizesSemigroup {T : Type*} [Semigroup T] (η : FreeSemigroup α →ₙ* T)

--- a/Linglib/Core/Computability/Variety/Correspondence.lean
+++ b/Linglib/Core/Computability/Variety/Correspondence.lean
@@ -256,7 +256,7 @@ theorem mem_langToVariety_varietyToLang (V : Pseudovariety.{u}) {M : Type u} [Mo
   have hφ : Function.Surjective φ := fun m => ⟨FreeMonoid.of m, rfl⟩
   -- The fibre language of each `m : M`.
   let Lm : M → Language M := fun m => {w | φ (FreeMonoid.ofList w) = m}
-  have hrec : ∀ m, Language.Recognizes φ (Lm m) := fun m => ⟨{m}, fun _ => Iff.rfl⟩
+  have hrec : ∀ m, Language.Recognizes φ (Lm m) := fun m => ⟨{m}, rfl⟩
   have hkerle : ∀ m, Con.ker φ ≤ (Lm m).syntacticCon := fun m =>
     Language.ker_le_syntacticCon_of_recognizes (hrec m)
   -- Each fibre language lies in `V.langs`, recognized by the finite monoid `M ∈ V`.

--- a/Linglib/Core/Computability/Variety/Correspondence.lean
+++ b/Linglib/Core/Computability/Variety/Correspondence.lean
@@ -142,7 +142,7 @@ def varietyToLang (V : Pseudovariety.{u}) : LanguageVariety.{u} where
 syntactic monoids of the languages in `𝒱`. -/
 def langToVariety (𝒱 : LanguageVariety.{u}) : Pseudovariety.{u} :=
   Pseudovariety.generated (fun (M : Type u) _ => ∃ (α : Type u) (L : Language α),
-    𝒱.lang L ∧ Nonempty (M ≃* L.syntacticMonoid))
+    𝒱.lang L ∧ Nonempty (M ≃* L.SyntacticMonoid))
 
 @[simp] theorem mem_varietyToLang (V : Pseudovariety.{u}) {α : Type u} (L : Language α) :
     (varietyToLang V).lang L ↔ V.langs L := Iff.rfl
@@ -157,17 +157,17 @@ theorem eilenberg_galoisConnection :
   · -- `langToVariety 𝒱 ≤ V` ⟹ `𝒱 ≤ varietyToLang V`.
     intro hle α L h𝒱L
     have hreg : L.IsRegular := 𝒱.regular h𝒱L
-    haveI : Finite L.syntacticMonoid := Language.IsRegular.finite_syntacticMonoid hreg
-    have hgen : (langToVariety 𝒱).mem L.syntacticMonoid :=
+    haveI : Finite L.SyntacticMonoid := Language.IsRegular.finite_syntacticMonoid hreg
+    have hgen : (langToVariety 𝒱).mem L.SyntacticMonoid :=
       Pseudovariety.subset_generated ⟨α, L, h𝒱L, ⟨MulEquiv.refl _⟩⟩
-    exact ⟨hreg, hle L.syntacticMonoid hgen⟩
+    exact ⟨hreg, hle L.SyntacticMonoid hgen⟩
   · -- `𝒱 ≤ varietyToLang V` ⟹ `langToVariety 𝒱 ≤ V`.
     intro hle
     apply Pseudovariety.generated_le
     intro N _ _ hSN
     obtain ⟨α, L, h𝒱L, ⟨e⟩⟩ := hSN
-    have hVmem : V.mem L.syntacticMonoid := (hle α L h𝒱L).2
-    haveI : Finite L.syntacticMonoid := Language.IsRegular.finite_syntacticMonoid (𝒱.regular h𝒱L)
+    have hVmem : V.mem L.SyntacticMonoid := (hle α L h𝒱L).2
+    haveI : Finite L.SyntacticMonoid := Language.IsRegular.finite_syntacticMonoid (𝒱.regular h𝒱L)
     haveI : Finite N := Finite.of_equiv _ e.symm.toEquiv
     exact V.mem_of_mulEquiv e.symm hVmem
 
@@ -256,21 +256,21 @@ theorem mem_langToVariety_varietyToLang (V : Pseudovariety.{u}) {M : Type u} [Mo
   have hφ : Function.Surjective φ := fun m => ⟨FreeMonoid.of m, rfl⟩
   -- The fibre language of each `m : M`.
   let Lm : M → Language M := fun m => {w | φ (FreeMonoid.ofList w) = m}
-  have hrec : ∀ m, Language.Recognizes φ (Lm m) := fun m => ⟨{m}, rfl⟩
+  have hrec : ∀ m, Language.Recognizes φ (Lm m) := fun m => ⟨{m}, fun _ => Iff.rfl⟩
   have hkerle : ∀ m, Con.ker φ ≤ (Lm m).syntacticCon := fun m =>
     Language.ker_le_syntacticCon_of_recognizes (hrec m)
   -- Each fibre language lies in `V.langs`, recognized by the finite monoid `M ∈ V`.
   have hlangs : ∀ m, V.langs (Lm m) := fun m => V.langs_of_recognizes hM φ {m} (fun _ => Iff.rfl)
-  haveI : ∀ m, Finite (Lm m).syntacticMonoid := fun m =>
+  haveI : ∀ m, Finite (Lm m).SyntacticMonoid := fun m =>
     Language.IsRegular.finite_syntacticMonoid (hlangs m).1
   -- Each fibre's syntactic monoid is a generator, hence in any `W` containing the generators.
   intro W hW
-  have hWsyn : ∀ m, W.mem (Lm m).syntacticMonoid := fun m =>
+  have hWsyn : ∀ m, W.mem (Lm m).SyntacticMonoid := fun m =>
     hW _ ⟨M, Lm m, hlangs m, ⟨MulEquiv.refl _⟩⟩
   -- The finite product of those syntactic monoids lies in `W`.
-  have hProd : W.mem (∀ m : M, (Lm m).syntacticMonoid) := pi_mem W hWsyn
+  have hProd : W.mem (∀ m : M, (Lm m).SyntacticMonoid) := pi_mem W hWsyn
   -- The joint syntactic morphism and the fact that its kernel is exactly `ker φ`.
-  let Ψ : FreeMonoid M →* (∀ m : M, (Lm m).syntacticMonoid) :=
+  let Ψ : FreeMonoid M →* (∀ m : M, (Lm m).SyntacticMonoid) :=
     MonoidHom.pi (fun m => (Lm m).toSyntacticMonoid)
   have hkereq : Con.ker φ = Con.ker Ψ := by
     apply le_antisymm
@@ -284,7 +284,7 @@ theorem mem_langToVariety_varietyToLang (V : Pseudovariety.{u}) {M : Type u} [Mo
         congrFun (Con.ker_apply.mp huv) (φ u)
       have hcon : (Lm (φ u)).syntacticCon u v :=
         (Language.toSyntacticMonoid_eq_iff (L := Lm (φ u))).mp hu
-      have hmem := ((Language.syntacticCon_iff (Lm (φ u))).mp hcon) [] []
+      have hmem := (Language.syntacticCon_iff.mp hcon) [] []
       simp only [List.nil_append, List.append_nil] at hmem
       have hmemu : u.toList ∈ Lm (φ u) := by
         show φ (FreeMonoid.ofList u.toList) = φ u
@@ -293,7 +293,7 @@ theorem mem_langToVariety_varietyToLang (V : Pseudovariety.{u}) {M : Type u} [Mo
       rw [FreeMonoid.ofList_toList] at hmemv
       exact Con.ker_apply.mpr hmemv.symm
   -- `M ≃* (ker φ).Quotient = (ker Ψ).Quotient ↪ ∏`, an injective hom into the product.
-  let g : M →* (∀ m : M, (Lm m).syntacticMonoid) :=
+  let g : M →* (∀ m : M, (Lm m).SyntacticMonoid) :=
     (Con.kerLift Ψ).comp ((Con.quotientKerEquivOfSurjective φ hφ).symm.trans
       (hkereq ▸ MulEquiv.refl _)).toMonoidHom
   have hginj : Function.Injective g := by

--- a/Linglib/Core/Computability/Variety/Definite.lean
+++ b/Linglib/Core/Computability/Variety/Definite.lean
@@ -34,7 +34,7 @@ theorems.
   `Language.IsReverseDefinite.syntacticEquiv_append_right`: screening at each edge.
 * `Language.IsDefinite.isRegular`, `Language.IsReverseDefinite.isRegular`: over a finite alphabet
   the edge projection bounds the syntactic monoid, so the language is regular. This is what the
-  omega-power theorems assume rather than derive, taking `[Finite L.syntacticMonoid]` throughout.
+  omega-power theorems assume rather than derive, taking `[Finite L.SyntacticMonoid]` throughout.
 * `Language.isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation` and its **K** mirror: the
   pseudovariety and omega-power algebraizations agree.
 * `Language.langs_definiteVariety_iff`, `Language.langs_reverseDefiniteVariety_iff`: the
@@ -121,7 +121,7 @@ theorem IsDefinite.isRegular [Finite α] (h : L.IsDefinite k) : L.IsRegular :=
 Idempotence lets `e` be represented by an arbitrarily long word, and screening then makes the left
 factor invisible. -/
 theorem IsDefinite.isDefinite_syntacticSemigroup (h : L.IsDefinite k) :
-    Semigroup.IsDefinite L.syntacticSemigroup := by
+    Semigroup.IsDefinite L.SyntacticSemigroup := by
   intro e he s
   obtain ⟨u, rfl⟩ := L.toSyntacticSemigroup_surjective e
   obtain ⟨t, rfl⟩ := L.toSyntacticSemigroup_surjective s
@@ -179,7 +179,7 @@ theorem IsReverseDefinite.isRegular [Finite α] (h : L.IsReverseDefinite k) : L.
 /-- **The syntactic semigroup of a reverse-definite language is reverse definite**: `e * s = e` for
 idempotent `e`. -/
 theorem IsReverseDefinite.isReverseDefinite_syntacticSemigroup (h : L.IsReverseDefinite k) :
-    Semigroup.IsReverseDefinite L.syntacticSemigroup := by
+    Semigroup.IsReverseDefinite L.SyntacticSemigroup := by
   intro e he s
   obtain ⟨u, rfl⟩ := L.toSyntacticSemigroup_surjective e
   obtain ⟨t, rfl⟩ := L.toSyntacticSemigroup_surjective s
@@ -211,7 +211,7 @@ private theorem omegaPow_eq_self {M : Type*} [Monoid M] [Finite M] {m : M}
 
 /-- The syntactic monoid is the syntactic semigroup with an identity adjoined: every element is
 the class of the empty word or the image of one of the semigroup. -/
-theorem eq_one_or_mem_range_syntacticSemigroupToMonoid (s : L.syntacticMonoid) :
+theorem eq_one_or_mem_range_syntacticSemigroupToMonoid (s : L.SyntacticMonoid) :
     s = 1 ∨ s ∈ Set.range L.syntacticSemigroupToMonoid := by
   obtain ⟨w, rfl⟩ := L.syntacticClass_surjective s
   rcases w with _ | ⟨a, l⟩
@@ -219,7 +219,7 @@ theorem eq_one_or_mem_range_syntacticSemigroupToMonoid (s : L.syntacticMonoid) :
   · exact Or.inr ⟨L.toSyntacticSemigroup ⟨a, l⟩, rfl⟩
 
 /-- The range of the embedding is a subsemigroup, hence closed under positive powers. -/
-private theorem pow_succ_mem_range {m : L.syntacticMonoid}
+private theorem pow_succ_mem_range {m : L.SyntacticMonoid}
     (hm : m ∈ Set.range L.syntacticSemigroupToMonoid) (n : ℕ) :
     m ^ (n + 1) ∈ Set.range L.syntacticSemigroupToMonoid := by
   induction n with
@@ -231,9 +231,9 @@ private theorem pow_succ_mem_range {m : L.syntacticMonoid}
 
 section OmegaEquations
 
-variable [Finite L.syntacticMonoid]
+variable [Finite L.SyntacticMonoid]
 
-private theorem omegaPow_mem_range {m : L.syntacticMonoid}
+private theorem omegaPow_mem_range {m : L.SyntacticMonoid}
     (hm : m ∈ Set.range L.syntacticSemigroupToMonoid) :
     Monoid.omegaPow m ∈ Set.range L.syntacticSemigroupToMonoid := by
   obtain ⟨n, hn⟩ : ∃ n, Monoid.omegaPowExponent m = n + 1 :=
@@ -244,7 +244,7 @@ private theorem omegaPow_mem_range {m : L.syntacticMonoid}
 /-- The omega-power of a nonempty word's class is the image of an idempotent of the syntactic
 semigroup — the correspondence the two algebraizations run through. -/
 private theorem exists_isIdempotentElem_map_eq_omegaPow {w : List α} (hw : w ≠ []) :
-    ∃ e : L.syntacticSemigroup, IsIdempotentElem e ∧
+    ∃ e : L.SyntacticSemigroup, IsIdempotentElem e ∧
       L.syntacticSemigroupToMonoid e = Monoid.omegaPow (L.syntacticClass w) := by
   obtain ⟨a, l, rfl⟩ := List.exists_cons_of_ne_nil hw
   have hm : L.syntacticClass (a :: l) ∈ Set.range L.syntacticSemigroupToMonoid :=
@@ -256,7 +256,7 @@ private theorem exists_isIdempotentElem_map_eq_omegaPow {w : List α} (hw : w �
 /-- **The two algebraizations of D agree**: the syntactic semigroup is definite exactly when the
 syntactic monoid satisfies Pin's omega-power equation. -/
 theorem isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation :
-    Semigroup.IsDefinite L.syntacticSemigroup ↔ L.omegaDefiniteEquation := by
+    Semigroup.IsDefinite L.SyntacticSemigroup ↔ L.omegaDefiniteEquation := by
   constructor
   · intro hD s w hw
     obtain ⟨e, he, hem⟩ := exists_isIdempotentElem_map_eq_omegaPow (L := L) hw
@@ -277,7 +277,7 @@ theorem isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation :
 /-- **The two algebraizations of K agree** — the mirror of
 `isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation`. -/
 theorem isReverseDefinite_syntacticSemigroup_iff_omegaReverseDefiniteEquation :
-    Semigroup.IsReverseDefinite L.syntacticSemigroup ↔ L.omegaReverseDefiniteEquation := by
+    Semigroup.IsReverseDefinite L.SyntacticSemigroup ↔ L.omegaReverseDefiniteEquation := by
   constructor
   · intro hK s w hw
     obtain ⟨e, he, hem⟩ := exists_isIdempotentElem_map_eq_omegaPow (L := L) hw
@@ -302,7 +302,7 @@ exactly the definite languages. -/
 theorem langs_definiteVariety_iff [Finite α] :
     Semigroup.definiteVariety.langs L ↔ ∃ k, L.IsDefinite k := by
   refine ⟨fun h => ?_, fun ⟨_, hk⟩ => hk.langs⟩
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   exact exists_isDefinite_of_satisfies_omegaDefiniteEquation
     (isDefinite_syntacticSemigroup_iff_omegaDefiniteEquation.1 h.2)
 
@@ -311,7 +311,7 @@ exactly the reverse-definite languages. -/
 theorem langs_reverseDefiniteVariety_iff [Finite α] :
     Semigroup.reverseDefiniteVariety.langs L ↔ ∃ k, L.IsReverseDefinite k := by
   refine ⟨fun h => ?_, fun ⟨_, hk⟩ => hk.langs⟩
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   exact exists_isReverseDefinite_of_satisfies_omegaReverseDefiniteEquation
     (isReverseDefinite_syntacticSemigroup_iff_omegaReverseDefiniteEquation.1 h.2)
 

--- a/Linglib/Core/Computability/Variety/Equations.lean
+++ b/Linglib/Core/Computability/Variety/Equations.lean
@@ -62,7 +62,7 @@ def kReverseDefiniteEquation : Prop :=
 
 /-- The generalized-definite (`ℒℐ`) equation: `[αs] * s * [αs] = [αs]` (`|αs| = k`). -/
 def kGeneralizedDefiniteEquation : Prop :=
-  ∀ (s : L.syntacticMonoid) (αs : List α), αs.length = k →
+  ∀ (s : L.SyntacticMonoid) (αs : List α), αs.length = k →
     L.syntacticClass αs * s * L.syntacticClass αs = L.syntacticClass αs
 
 variable {L} {k}

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -44,7 +44,7 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 
 /-- The languages over `α` whose (necessarily finite) syntactic monoid lies in `V` — the
 language-side operator of the Eilenberg correspondence. -/
-def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticMonoid
+def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.SyntacticMonoid
 
 /-- **Engine.** A language recognized by a finite monoid in `V` lies in `V.langs`: the syntactic
 monoid is a quotient of a submonoid of the recognizer, hence in `V`. Generalizes
@@ -52,12 +52,13 @@ monoid is a quotient of a submonoid of the recognizer, hence in `V`. Generalizes
 theorem langs_of_recognizes {N : Type u} [Monoid N] [Finite N] (hN : V.mem N)
     (η : FreeMonoid α →* N) (P : Set N)
     (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : V.langs L := by
-  have hle : Con.ker η ≤ L.syntacticCon := ker_le_syntacticCon_of_recognizes ⟨P, Set.ext hL⟩
+  have hle : Con.ker η ≤ L.syntacticCon :=
+    ker_le_syntacticCon_of_recognizes ⟨P, fun w => by simpa using hL w.toList⟩
   haveI : Finite (Con.ker η).Quotient := .of_injective _ (Con.kerLift_injective η)
   have hkerMem : V.mem (Con.ker η).Quotient := V.sub (Con.kerLift_injective η) hN
   have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) :=
     Con.lift_surjective_of_surjective _ Con.mk'_surjective
-  haveI : Finite L.syntacticMonoid := Finite.of_surjective _ hsurj
+  haveI : Finite L.SyntacticMonoid := Finite.of_surjective _ hsurj
   exact ⟨IsRegular.of_finite_syntacticMonoid ‹_›, V.quot hsurj hkerMem⟩
 
 /-- **Closure under complement** — immediate from complement-invariance of the syntactic monoid. -/
@@ -68,18 +69,18 @@ theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
   exact h.2
 
 /-- **Closure under intersection** — the syntactic monoid of `L ⊓ M` is a quotient of a submonoid
-of `L.syntacticMonoid × M.syntacticMonoid`, which is in `V` by `prod`/`sub`/`quot`. -/
+of `L.SyntacticMonoid × M.SyntacticMonoid`, which is in `V` by `prod`/`sub`/`quot`. -/
 theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊓ M) := by
   refine ⟨hL.1.inf hM.1, ?_⟩
   set φ := L.toSyntacticMonoid.prod M.toSyntacticMonoid with hφ
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
-  haveI : Finite M.syntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
-  have hprod : V.mem (L.syntacticMonoid × M.syntacticMonoid) := V.prod hL.2 hM.2
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
+  haveI : Finite M.SyntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
+  have hprod : V.mem (L.SyntacticMonoid × M.SyntacticMonoid) := V.prod hL.2 hM.2
   haveI : Finite (Con.ker φ).Quotient := .of_injective _ (Con.kerLift_injective φ)
   have hker : V.mem (Con.ker φ).Quotient := V.sub (Con.kerLift_injective φ) hprod
   have hle : Con.ker φ ≤ (L ⊓ M).syntacticCon := by
-    rw [hφ, ker_prod_toSyntacticMonoid]; exact inf_syntacticCon_le_syntacticCon_inf L M
-  haveI : Finite (L ⊓ M).syntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
+    rw [hφ, ker_prod_toSyntacticMonoid]; exact inf_syntacticCon_le_syntacticCon_inf
+  haveI : Finite (L ⊓ M).SyntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
   exact V.quot (f := Con.map (Con.ker φ) _ hle)
     (Con.lift_surjective_of_surjective _ Con.mk'_surjective) hker
 
@@ -100,16 +101,16 @@ theorem langs_bot : V.langs (⊥ : Language α) := by
 
 /-- **Closure under inverse homomorphism.** If `Lb` over `β` is in `V.langs` and
 `φ : FreeMonoid α →* FreeMonoid β` is any monoid hom, the preimage language is in `V.langs`. The
-recognizer is `Lb.toSyntacticMonoid.comp φ` into the finite `Lb.syntacticMonoid ∈ V`. Generalizes
+recognizer is `Lb.toSyntacticMonoid.comp φ` into the finite `Lb.SyntacticMonoid ∈ V`. Generalizes
 `Language.IsStarFree.comap`. -/
 theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
     (φ : FreeMonoid α →* FreeMonoid β) :
     V.langs {w : List α | φ (FreeMonoid.ofList w) ∈ Lb} := by
-  haveI : Finite Lb.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite Lb.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   refine V.langs_of_recognizes h.2 (Lb.toSyntacticMonoid.comp φ)
     {m | ∃ u : FreeMonoid β, Lb.toSyntacticMonoid u = m ∧ u ∈ Lb} fun w => ?_
   refine ⟨fun hw => ⟨φ (FreeMonoid.ofList w), rfl, hw⟩, fun ⟨u, hu, hmem⟩ => ?_⟩
-  exact (mem_iff_of_syntacticEquiv ((toSyntacticMonoid_eq_iff (L := Lb)).mp hu)).mp hmem
+  exact (SyntacticEquiv.mem_iff ((toSyntacticMonoid_eq_iff (L := Lb)).mp hu)).mp hmem
 
 /-! ### Closure under quotients
 
@@ -118,29 +119,15 @@ letters; [pin-mfa] Ch. XIII §3 states it for words, equivalently). The syntacti
 quotient is coarser than that of the language, so the syntactic monoid of the quotient is a
 quotient of the original's. -/
 
-/-- Syntactic equivalence for `L` implies it for any left quotient of `L`: prepend `u` to the
-left context. -/
-theorem _root_.Language.syntacticCon_le_leftQuotient (L : Language α) (u : List α) :
-    L.syntacticCon ≤ (L.leftQuotient u).syntacticCon := fun {p q} h x y => by
-  have := h (u ++ x) y
-  simpa [Language.mem_leftQuotient, List.append_assoc] using this
-
-/-- Syntactic equivalence for `L` implies it for any right quotient of `L`: append `u` to the
-right context. -/
-theorem _root_.Language.syntacticCon_le_rightQuotient (L : Language α) (u : List α) :
-    L.syntacticCon ≤ (L.rightQuotient u).syntacticCon := fun {p q} h x y => by
-  have := h x (y ++ u)
-  simpa [Language.mem_rightQuotient, List.append_assoc] using this
-
 variable {V}
 
 /-- A coarser syntactic congruence keeps the language in `V.langs`. -/
 private theorem langs_of_syntacticCon_le {M : Language α} (h : V.langs L)
     (hle : L.syntacticCon ≤ M.syntacticCon) : V.langs M := by
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   have hsurj : Function.Surjective (Con.map L.syntacticCon M.syntacticCon hle) :=
     Con.lift_surjective_of_surjective _ Con.mk'_surjective
-  haveI : Finite M.syntacticMonoid := .of_surjective _ hsurj
+  haveI : Finite M.SyntacticMonoid := .of_surjective _ hsurj
   exact ⟨IsRegular.of_finite_syntacticMonoid ‹_›, V.quot hsurj h.2⟩
 
 /-- **Closure under left quotient** — Eilenberg's axiom VII.3.3. -/

--- a/Linglib/Core/Computability/Variety/Langs.lean
+++ b/Linglib/Core/Computability/Variety/Langs.lean
@@ -52,8 +52,7 @@ monoid is a quotient of a submonoid of the recognizer, hence in `V`. Generalizes
 theorem langs_of_recognizes {N : Type u} [Monoid N] [Finite N] (hN : V.mem N)
     (η : FreeMonoid α →* N) (P : Set N)
     (hL : ∀ w : List α, w ∈ L ↔ η (FreeMonoid.ofList w) ∈ P) : V.langs L := by
-  have hle : Con.ker η ≤ L.syntacticCon :=
-    ker_le_syntacticCon_of_recognizes ⟨P, fun w => by simpa using hL w.toList⟩
+  have hle : Con.ker η ≤ L.syntacticCon := ker_le_syntacticCon_of_recognizes ⟨P, Set.ext hL⟩
   haveI : Finite (Con.ker η).Quotient := .of_injective _ (Con.kerLift_injective η)
   have hkerMem : V.mem (Con.ker η).Quotient := V.sub (Con.kerLift_injective η) hN
   have hsurj : Function.Surjective (Con.map (Con.ker η) L.syntacticCon hle) :=

--- a/Linglib/Core/Computability/Variety/OmegaEquations.lean
+++ b/Linglib/Core/Computability/Variety/OmegaEquations.lean
@@ -17,7 +17,7 @@ Four basic varieties of finite semigroups, characterized by **omega-power equati
 the syntactic monoid. Eilenberg states them on idempotents: `𝒟` is the variety of
 semigroups with `Se = e` for every idempotent `e` ([eilenberg-1976] VIII.4.1), and `ℒℐ`
 — the locally trivial semigroups — those with `eSe = e` (VIII.5.1). Writing the
-idempotent as an omega power `[w]^ω` turns each into an equation on `L.syntacticMonoid`:
+idempotent as an omega power `[w]^ω` turns each into an equation on `L.SyntacticMonoid`:
 
 | Variety | Equation | Meaning |
 |---|---|---|
@@ -29,7 +29,7 @@ idempotent as an omega power `[w]^ω` turns each into an equation on `L.syntacti
 Where `[w]^ω = Monoid.omegaPow (L.syntacticClass w)`
 is the unique idempotent in the cyclic submonoid of `[w]` (see
 `Linglib/Core/Algebra/IdempotentPower.lean`). The variables `s` range
-over `L.syntacticMonoid` and `w` over non-empty `List α`
+over `L.SyntacticMonoid` and `w` over non-empty `List α`
 (alphabet-relativized form — see `Equations.lean` for the trivial-letter
 counterexample motivating the non-empty-`w` restriction).
 
@@ -53,7 +53,7 @@ algebraic automata theory.
 * `Language.omegaCofiniteEquation L`: conjunction of the above two.
 * `Language.omegaGeneralizedDefiniteEquation L`: `[w]^ω · s · [w]^ω = [w]^ω`.
 
-All four require `[Finite L.syntacticMonoid]` (equivalent to `L` being
+All four require `[Finite L.SyntacticMonoid]` (equivalent to `L` being
 regular, by `IsRegular.finite_syntacticMonoid`).
 
 ## Main results
@@ -106,7 +106,7 @@ namespace Language
 variable {α : Type*}
 
 /-- **Pin's algebraic equation for definite languages**:
-`∀ s : L.syntacticMonoid, ∀ w : List α, w ≠ [] → s · [w]^ω = [w]^ω`.
+`∀ s : L.SyntacticMonoid, ∀ w : List α, w ≠ [] → s · [w]^ω = [w]^ω`.
 
 The non-empty `w` quantifier (alphabet-relativized form) handles the
 trivial-letter case the same way `kDefiniteEquation` does — see the
@@ -114,8 +114,8 @@ counterexample in `Equations.lean`. Despite living in a sibling file
 to Lambert's `kDefiniteEquation`, this is a *classical* Pin/Eilenberg
 omega-power equation, not Lambert-specific — hence the namespace is
 `Language` (no author-named namespace). -/
-def omegaDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
-  ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
+def omegaDefiniteEquation (L : Language α) [Finite L.SyntacticMonoid] : Prop :=
+  ∀ (s : L.SyntacticMonoid) (w : List α), w ≠ [] →
     s * Monoid.omegaPow (L.syntacticClass w) =
     Monoid.omegaPow (L.syntacticClass w)
 
@@ -141,7 +141,7 @@ private lemma freeMonoid_ofList_pow_length (w : List α) (n : ℕ) :
 of length `≥ k` is **left-absorbing**. -/
 private lemma left_absorbing_of_kDefiniteEquation {L : Language α} {k : ℕ}
     (hkEq : Language.kDefiniteEquation L k)
-    {v : List α} (hv : k ≤ v.length) (s : L.syntacticMonoid) :
+    {v : List α} (hv : k ≤ v.length) (s : L.SyntacticMonoid) :
     s * L.syntacticClass v =
     L.syntacticClass v := by
   set vM := L.syntacticClass v with hvM_def
@@ -174,14 +174,14 @@ representative `w^(N·k)` (length `N·k·|w| ≥ k`) of `[w]^ω`. The `k = 0`
 case forces the syntactic monoid to be trivial, so the equation holds
 vacuously. -/
 theorem IsDefinite.satisfies_omegaDefiniteEquation
-    {L : Language α} {k : ℕ} [Finite L.syntacticMonoid]
+    {L : Language α} {k : ℕ} [Finite L.SyntacticMonoid]
     (hk : L.IsDefinite k) : omegaDefiniteEquation L := by
   intro s w hw
   set wM := L.syntacticClass w with hwM_def
   have hkEq := IsDefinite.satisfies_kDefiniteEquation hk
   by_cases hk0 : k = 0
   · subst hk0
-    have hM_triv : ∀ x : L.syntacticMonoid, x = 1 := fun x => by
+    have hM_triv : ∀ x : L.SyntacticMonoid, x = 1 := fun x => by
       have := hkEq [] rfl x
       simpa using this
     rw [hM_triv s, hM_triv (Monoid.omegaPow wM), one_mul]
@@ -214,13 +214,13 @@ theorem IsDefinite.satisfies_omegaDefiniteEquation
 `i.val < j.val` of indices into `v` whose prefixes have the same
 syntactic class, conclude that `[v]` is left-absorbing. -/
 private lemma left_absorbing_of_pigeonhole
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
     (h_eq : L.syntacticClass (v.take i_lo) =
             L.syntacticClass (v.take i_hi))
-    (s : L.syntacticMonoid) :
+    (s : L.SyntacticMonoid) :
     s * L.syntacticClass v =
     L.syntacticClass v := by
   -- Decompose v = pre ++ middle ++ suf, where pre has length i_lo,
@@ -281,26 +281,26 @@ private lemma left_absorbing_of_pigeonhole
   rw [h_v_omega, ← mul_assoc, h s middle h_middle_ne]
 
 /-- Under Pin's omega-power equation, the syntactic class of any word
-of length `≥ Nat.card L.syntacticMonoid` is left-absorbing. -/
+of length `≥ Nat.card L.SyntacticMonoid` is left-absorbing. -/
 private lemma left_absorbing_of_omegaDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaDefiniteEquation L)
-    {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
-    (s : L.syntacticMonoid) :
+    {v : List α} (hv : Nat.card L.SyntacticMonoid ≤ v.length)
+    (s : L.SyntacticMonoid) :
     s * L.syntacticClass v =
     L.syntacticClass v := by
   classical
-  haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
-  have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
+  haveI : Fintype L.SyntacticMonoid := Fintype.ofFinite _
+  have hNat : Nat.card L.SyntacticMonoid = Fintype.card L.SyntacticMonoid :=
     Nat.card_eq_fintype_card
   rw [hNat] at hv
   -- Pigeonhole on the |M|+1 prefixes v.take 0, …, v.take |M|.
-  have hcard : Fintype.card L.syntacticMonoid <
-               Fintype.card (Fin (Fintype.card L.syntacticMonoid + 1)) := by
+  have hcard : Fintype.card L.SyntacticMonoid <
+               Fintype.card (Fin (Fintype.card L.SyntacticMonoid + 1)) := by
     rw [Fintype.card_fin]; omega
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
-      (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
+      (fun n : Fin (Fintype.card L.SyntacticMonoid + 1) =>
         L.syntacticClass (v.take n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
@@ -313,12 +313,12 @@ private lemma left_absorbing_of_omegaDefiniteEquation
 
 /-- **Pin's theorem (reverse direction)**: if a regular language's
 syntactic monoid satisfies Pin's omega-power equation, then `L` is
-`k`-definite for some `k` (specifically, `k = Fintype.card L.syntacticMonoid`). -/
+`k`-definite for some `k` (specifically, `k = Fintype.card L.SyntacticMonoid`). -/
 theorem exists_isDefinite_of_satisfies_omegaDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaDefiniteEquation L) :
     ∃ k, L.IsDefinite k := by
-  refine ⟨Nat.card L.syntacticMonoid, ?_⟩
+  refine ⟨Nat.card L.SyntacticMonoid, ?_⟩
   apply isDefinite_of_satisfies_kDefiniteEquation
   intro αs hαs_len s
   exact left_absorbing_of_omegaDefiniteEquation h (by rw [hαs_len]) s
@@ -327,7 +327,7 @@ theorem exists_isDefinite_of_satisfies_omegaDefiniteEquation
 (necessarily finite) syntactic monoid satisfies Pin's omega-power
 equation. -/
 theorem exists_isDefinite_iff_satisfies_omegaDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid] :
+    {L : Language α} [Finite L.SyntacticMonoid] :
     (∃ k, L.IsDefinite k) ↔ omegaDefiniteEquation L := by
   refine ⟨fun ⟨_, hk⟩ => IsDefinite.satisfies_omegaDefiniteEquation hk, ?_⟩
   exact exists_isDefinite_of_satisfies_omegaDefiniteEquation
@@ -338,12 +338,12 @@ theorem exists_isDefinite_iff_satisfies_omegaDefiniteEquation
 
 /-- **Pin's algebraic equation for reverse-definite languages**
 ([almeida-1995]):
-`∀ s : L.syntacticMonoid, ∀ w : List α, w ≠ [] → [w]^ω · s = [w]^ω`.
+`∀ s : L.SyntacticMonoid, ∀ w : List α, w ≠ [] → [w]^ω · s = [w]^ω`.
 
 Mirror of `omegaDefiniteEquation` with right-multiplication instead of
 left. Same alphabet-relativized non-empty `w` quantifier. -/
-def omegaReverseDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
-  ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
+def omegaReverseDefiniteEquation (L : Language α) [Finite L.SyntacticMonoid] : Prop :=
+  ∀ (s : L.SyntacticMonoid) (w : List α), w ≠ [] →
     Monoid.omegaPow (L.syntacticClass w) * s =
     Monoid.omegaPow (L.syntacticClass w)
 
@@ -353,7 +353,7 @@ of length `≥ k` is right-absorbing, decomposing `v = pre ++ suf` with
 `pre` of length `k`. -/
 private lemma right_absorbing_of_kReverseDefiniteEquation {L : Language α} {k : ℕ}
     (hkEq : Language.kReverseDefiniteEquation L k)
-    {v : List α} (hv : k ≤ v.length) (s : L.syntacticMonoid) :
+    {v : List α} (hv : k ≤ v.length) (s : L.SyntacticMonoid) :
     L.syntacticClass v * s =
     L.syntacticClass v := by
   set vM := L.syntacticClass v with hvM_def
@@ -375,14 +375,14 @@ private lemma right_absorbing_of_kReverseDefiniteEquation {L : Language α} {k :
 language's syntactic monoid satisfies Pin's right-absorbing
 omega-power equation. Mirror of `IsDefinite.satisfies_omegaDefiniteEquation`. -/
 theorem IsReverseDefinite.satisfies_omegaReverseDefiniteEquation
-    {L : Language α} {k : ℕ} [Finite L.syntacticMonoid]
+    {L : Language α} {k : ℕ} [Finite L.SyntacticMonoid]
     (hk : L.IsReverseDefinite k) : omegaReverseDefiniteEquation L := by
   intro s w hw
   set wM := L.syntacticClass w with hwM_def
   have hkEq := IsReverseDefinite.satisfies_kReverseDefiniteEquation hk
   by_cases hk0 : k = 0
   · subst hk0
-    have hM_triv : ∀ x : L.syntacticMonoid, x = 1 := fun x => by
+    have hM_triv : ∀ x : L.SyntacticMonoid, x = 1 := fun x => by
       have := hkEq [] rfl x
       simpa using this
     rw [hM_triv s, hM_triv (Monoid.omegaPow wM), mul_one]
@@ -416,13 +416,13 @@ For suffixes, smaller index ⇒ longer suffix, so `[v.drop i_lo]` is the
 longer one. The decomposition is
 `v.drop i_lo = middle ++ v.drop i_hi` where `middle = (v.drop i_lo).take (i_hi - i_lo)`. -/
 private lemma right_absorbing_of_pigeonhole
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaReverseDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
     (h_eq : L.syntacticClass (v.drop i_lo) =
             L.syntacticClass (v.drop i_hi))
-    (s : L.syntacticMonoid) :
+    (s : L.SyntacticMonoid) :
     L.syntacticClass v * s =
     L.syntacticClass v := by
   -- v = pre ++ middle ++ suf, where pre = v.take i_lo,
@@ -491,26 +491,26 @@ private lemma right_absorbing_of_pigeonhole
   rw [h_v_omega, mul_assoc, h s middle h_middle_ne]
 
 /-- Under Pin's reverse-definite equation, the syntactic class of any
-word of length `≥ Nat.card L.syntacticMonoid` is right-absorbing. -/
+word of length `≥ Nat.card L.SyntacticMonoid` is right-absorbing. -/
 private lemma right_absorbing_of_omegaReverseDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaReverseDefiniteEquation L)
-    {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
-    (s : L.syntacticMonoid) :
+    {v : List α} (hv : Nat.card L.SyntacticMonoid ≤ v.length)
+    (s : L.SyntacticMonoid) :
     L.syntacticClass v * s =
     L.syntacticClass v := by
   classical
-  haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
-  have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
+  haveI : Fintype L.SyntacticMonoid := Fintype.ofFinite _
+  have hNat : Nat.card L.SyntacticMonoid = Fintype.card L.SyntacticMonoid :=
     Nat.card_eq_fintype_card
   rw [hNat] at hv
   -- Pigeonhole on |M|+1 SUFFIXES v.drop 0, …, v.drop |M|.
-  have hcard : Fintype.card L.syntacticMonoid <
-               Fintype.card (Fin (Fintype.card L.syntacticMonoid + 1)) := by
+  have hcard : Fintype.card L.SyntacticMonoid <
+               Fintype.card (Fin (Fintype.card L.SyntacticMonoid + 1)) := by
     rw [Fintype.card_fin]; omega
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
-      (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
+      (fun n : Fin (Fintype.card L.SyntacticMonoid + 1) =>
         L.syntacticClass (v.drop n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
@@ -524,10 +524,10 @@ private lemma right_absorbing_of_omegaReverseDefiniteEquation
 syntactic monoid satisfies Pin's reverse-definite omega-power equation,
 then `L` is reverse-`k`-definite for some `k`. -/
 theorem exists_isReverseDefinite_of_satisfies_omegaReverseDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaReverseDefiniteEquation L) :
     ∃ k, L.IsReverseDefinite k := by
-  refine ⟨Nat.card L.syntacticMonoid, ?_⟩
+  refine ⟨Nat.card L.SyntacticMonoid, ?_⟩
   apply isReverseDefinite_of_satisfies_kReverseDefiniteEquation
   intro αs hαs_len s
   exact right_absorbing_of_omegaReverseDefiniteEquation h (by rw [hαs_len]) s
@@ -536,7 +536,7 @@ theorem exists_isReverseDefinite_of_satisfies_omegaReverseDefiniteEquation
 `k` iff its (necessarily finite) syntactic monoid satisfies Pin's
 reverse-definite omega-power equation. -/
 theorem exists_isReverseDefinite_iff_satisfies_omegaReverseDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid] :
+    {L : Language α} [Finite L.SyntacticMonoid] :
     (∃ k, L.IsReverseDefinite k) ↔ omegaReverseDefiniteEquation L := by
   refine ⟨fun ⟨_, hk⟩ => IsReverseDefinite.satisfies_omegaReverseDefiniteEquation hk, ?_⟩
   exact exists_isReverseDefinite_of_satisfies_omegaReverseDefiniteEquation
@@ -549,7 +549,7 @@ theorem exists_isReverseDefinite_iff_satisfies_omegaReverseDefiniteEquation
 ([almeida-1995]): `𝒩 = ⟦sx^ω = x^ω = x^ω s⟧`.
 The conjunction of D's left-absorbing equation and K's right-absorbing
 equation. -/
-def omegaCofiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
+def omegaCofiniteEquation (L : Language α) [Finite L.SyntacticMonoid] : Prop :=
   omegaDefiniteEquation L ∧ omegaReverseDefiniteEquation L
 
 /-- **Pin's N-theorem (forward direction)**: a finite-or-cofinite
@@ -558,7 +558,7 @@ omega-power equations. Composes the substrate lemma
 `IsFiniteOrCofinite.exists_isDefinite_and_isReverseDefinite` (in
 `Core/Computability/Definite.lean`) with the Pin D and Pin K iff theorems. -/
 theorem IsFiniteOrCofinite.satisfies_omegaCofiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : IsFiniteOrCofinite L) : omegaCofiniteEquation L := by
   obtain ⟨⟨k, hD⟩, ⟨k', hRD⟩⟩ := h.exists_isDefinite_and_isReverseDefinite
   exact ⟨IsDefinite.satisfies_omegaDefiniteEquation hD,
@@ -573,7 +573,7 @@ Requires `[Finite α]` because the language-level reverse direction
 `Core/Computability/Definite.lean`) needs it: with infinite α, words of
 bounded length need not form a finite set. -/
 theorem isFiniteOrCofinite_of_satisfies_omegaCofiniteEquation [Finite α]
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaCofiniteEquation L) : IsFiniteOrCofinite L := by
   obtain ⟨hD, hRD⟩ := h
   exact isFiniteOrCofinite_of_isDefinite_and_isReverseDefinite
@@ -584,7 +584,7 @@ theorem isFiniteOrCofinite_of_satisfies_omegaCofiniteEquation [Finite α]
 finite-or-cofinite iff its syntactic monoid satisfies the conjunction
 of Pin's D and K omega-power equations. -/
 theorem isFiniteOrCofinite_iff_satisfies_omegaCofiniteEquation [Finite α]
-    {L : Language α} [Finite L.syntacticMonoid] :
+    {L : Language α} [Finite L.SyntacticMonoid] :
     IsFiniteOrCofinite L ↔ omegaCofiniteEquation L :=
   ⟨IsFiniteOrCofinite.satisfies_omegaCofiniteEquation,
    isFiniteOrCofinite_of_satisfies_omegaCofiniteEquation⟩
@@ -602,8 +602,8 @@ Lambert (paper p. 25) notes this simplified one-variable form is
 equivalent to the more general two-variable form
 `x^ω · s · z^ω = x^ω · z^ω`; the equivalence proof itself uses
 omega-power idempotence. -/
-def omegaGeneralizedDefiniteEquation (L : Language α) [Finite L.syntacticMonoid] : Prop :=
-  ∀ (s : L.syntacticMonoid) (w : List α), w ≠ [] →
+def omegaGeneralizedDefiniteEquation (L : Language α) [Finite L.SyntacticMonoid] : Prop :=
+  ∀ (s : L.SyntacticMonoid) (w : List α), w ≠ [] →
     Monoid.omegaPow (L.syntacticClass w) * s *
     Monoid.omegaPow (L.syntacticClass w) =
     Monoid.omegaPow (L.syntacticClass w)
@@ -618,7 +618,7 @@ first `k` chars of `v`) and same length-`k` right-suffix (the last
 `k` chars of `v`). The omega-power identity `[w]^N · s · [w]^N = [w]^N`
 follows by lifting through `[w]^(N·k) = omegaPow [w]`. -/
 theorem IsGeneralizedDefinite.satisfies_omegaGeneralizedDefiniteEquation
-    {L : Language α} {k : ℕ} [Finite L.syntacticMonoid]
+    {L : Language α} {k : ℕ} [Finite L.SyntacticMonoid]
     (hk : L.IsGeneralizedDefinite k) :
     omegaGeneralizedDefiniteEquation L := by
   intro s w hw
@@ -629,14 +629,14 @@ theorem IsGeneralizedDefinite.satisfies_omegaGeneralizedDefiniteEquation
     subst hk0
     have h_takeAt_right_zero : ∀ v : List α, Edge.right.takeAt 0 v = [] := by
       intro v; show v.drop (v.length - 0) = []; simp
-    have hM_triv : ∀ x : L.syntacticMonoid, x = 1 := by
+    have hM_triv : ∀ x : L.SyntacticMonoid, x = 1 := by
       intro x
       obtain ⟨u, hu⟩ := Quotient.exists_rep x
       rw [show x = L.toSyntacticMonoid u from hu.symm,
-          show (1 : L.syntacticMonoid) = L.toSyntacticMonoid 1 from
+          show (1 : L.SyntacticMonoid) = L.toSyntacticMonoid 1 from
             (L.toSyntacticMonoid.map_one).symm]
       apply Quotient.sound
-      refine (syntacticCon_iff L).mpr ?_
+      refine syntacticCon_iff.mpr ?_
       intro p q
       show p ++ FreeMonoid.toList u ++ q ∈ L ↔ p ++ FreeMonoid.toList 1 ++ q ∈ L
       apply isGeneralizedDefinite_iff_edges.mp hk
@@ -702,13 +702,13 @@ form, sharing all of the prefix-pigeonhole substrate (h_pre_idemp,
 h_iter, h_pre_omega) but using Pin LI's two-sided absorption instead
 of D's one-sided absorption to close. -/
 private lemma sandwich_absorbing_of_pigeonhole
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaGeneralizedDefiniteEquation L)
     {v : List α}
     {i_lo i_hi : ℕ} (hij : i_lo < i_hi) (hi_hi_le : i_hi ≤ v.length)
     (h_eq : L.syntacticClass (v.take i_lo) =
             L.syntacticClass (v.take i_hi))
-    (s : L.syntacticMonoid) :
+    (s : L.SyntacticMonoid) :
     L.syntacticClass v * s *
     L.syntacticClass v =
     L.syntacticClass v := by
@@ -764,29 +764,29 @@ private lemma sandwich_absorbing_of_pigeonhole
   rw [h_pin]
 
 /-- Under Pin's LI omega-power equation, the syntactic class of any
-word of length `≥ Nat.card L.syntacticMonoid` is **sandwich-absorbing**:
+word of length `≥ Nat.card L.SyntacticMonoid` is **sandwich-absorbing**:
 `[v] · s · [v] = [v]` for any `s`. Mirror of
 `left_absorbing_of_omegaDefiniteEquation` for the LI sandwich form. -/
 private lemma sandwich_absorbing_of_omegaGeneralizedDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaGeneralizedDefiniteEquation L)
-    {v : List α} (hv : Nat.card L.syntacticMonoid ≤ v.length)
-    (s : L.syntacticMonoid) :
+    {v : List α} (hv : Nat.card L.SyntacticMonoid ≤ v.length)
+    (s : L.SyntacticMonoid) :
     L.syntacticClass v * s *
     L.syntacticClass v =
     L.syntacticClass v := by
   classical
-  haveI : Fintype L.syntacticMonoid := Fintype.ofFinite _
-  have hNat : Nat.card L.syntacticMonoid = Fintype.card L.syntacticMonoid :=
+  haveI : Fintype L.SyntacticMonoid := Fintype.ofFinite _
+  have hNat : Nat.card L.SyntacticMonoid = Fintype.card L.SyntacticMonoid :=
     Nat.card_eq_fintype_card
   rw [hNat] at hv
   -- Pigeonhole on the |M|+1 prefixes v.take 0, …, v.take |M|.
-  have hcard : Fintype.card L.syntacticMonoid <
-               Fintype.card (Fin (Fintype.card L.syntacticMonoid + 1)) := by
+  have hcard : Fintype.card L.SyntacticMonoid <
+               Fintype.card (Fin (Fintype.card L.SyntacticMonoid + 1)) := by
     rw [Fintype.card_fin]; omega
   obtain ⟨i, j, h_ne, h_eq⟩ :=
     Fintype.exists_ne_map_eq_of_card_lt
-      (fun n : Fin (Fintype.card L.syntacticMonoid + 1) =>
+      (fun n : Fin (Fintype.card L.SyntacticMonoid + 1) =>
         L.syntacticClass (v.take n.val))
       hcard
   have h_val_ne : i.val ≠ j.val := fun h => h_ne (Fin.ext h)
@@ -799,17 +799,17 @@ private lemma sandwich_absorbing_of_omegaGeneralizedDefiniteEquation
 /-- **Pin's ℒℐ-theorem (reverse direction)**: if a regular language's
 syntactic monoid satisfies Pin's LI omega-power equation, then `L` is
 generalized-`k`-definite for some `k` (specifically,
-`k = Nat.card L.syntacticMonoid`).
+`k = Nat.card L.SyntacticMonoid`).
 
 Proof: `sandwich_absorbing_of_omegaGeneralizedDefiniteEquation` lifts the
 omega-power equation to a finite-`k` sandwich on length-`k` words; this
 is exactly `kGeneralizedDefiniteEquation L k`, which by Lambert Prop 58
 (reverse direction in `Equations.lean`) gives `L.IsGeneralizedDefinite k`. -/
 theorem exists_isGeneralizedDefinite_of_satisfies_omegaGeneralizedDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid]
+    {L : Language α} [Finite L.SyntacticMonoid]
     (h : omegaGeneralizedDefiniteEquation L) :
     ∃ k, L.IsGeneralizedDefinite k := by
-  refine ⟨Nat.card L.syntacticMonoid, ?_⟩
+  refine ⟨Nat.card L.SyntacticMonoid, ?_⟩
   apply isGeneralizedDefinite_of_satisfies_kGeneralizedDefiniteEquation
   intro s αs hαs_len
   exact sandwich_absorbing_of_omegaGeneralizedDefiniteEquation h (by rw [hαs_len]) s
@@ -818,7 +818,7 @@ theorem exists_isGeneralizedDefinite_of_satisfies_omegaGeneralizedDefiniteEquati
 some `k` iff its syntactic monoid satisfies Pin's LI omega-power
 equation. -/
 theorem exists_isGeneralizedDefinite_iff_satisfies_omegaGeneralizedDefiniteEquation
-    {L : Language α} [Finite L.syntacticMonoid] :
+    {L : Language α} [Finite L.SyntacticMonoid] :
     (∃ k, L.IsGeneralizedDefinite k) ↔ omegaGeneralizedDefiniteEquation L := by
   refine ⟨fun ⟨_, hk⟩ =>
     IsGeneralizedDefinite.satisfies_omegaGeneralizedDefiniteEquation hk, ?_⟩

--- a/Linglib/Core/Computability/Variety/SemigroupLangs.lean
+++ b/Linglib/Core/Computability/Variety/SemigroupLangs.lean
@@ -44,7 +44,7 @@ variable (V : Pseudovariety.{u}) {α : Type u} {L : Language α}
 
 /-- The languages over `α` whose (necessarily finite) syntactic semigroup lies in `V` — the
 `+`-variety side of the Eilenberg correspondence. -/
-def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.syntacticSemigroup
+def langs (L : Language α) : Prop := L.IsRegular ∧ V.mem L.SyntacticSemigroup
 
 /-- **Closure under complement** — immediate from complement-invariance of the syntactic
 congruence (`Language.syntacticSemigroupCon_compl`). -/
@@ -59,16 +59,6 @@ theorem langs_compl (h : V.langs L) : V.langs Lᶜ := by
 Eilenberg's axiom VII.3.3, on the `+` side. The argument is the monoid one: a quotient's syntactic
 congruence is coarser, so its syntactic semigroup is a quotient of the original's. -/
 
-theorem _root_.Language.syntacticSemigroupCon_le_leftQuotient (L : Language α) (u : List α) :
-    L.syntacticSemigroupCon ≤ (L.leftQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
-  have := h (u ++ x) y
-  simpa [Language.mem_leftQuotient, List.append_assoc] using this
-
-theorem _root_.Language.syntacticSemigroupCon_le_rightQuotient (L : Language α) (u : List α) :
-    L.syntacticSemigroupCon ≤ (L.rightQuotient u).syntacticSemigroupCon := fun {p q} h x y => by
-  have := h x (y ++ u)
-  simpa [Language.mem_rightQuotient, List.append_assoc] using this
-
 section Quotients
 
 variable {V}
@@ -76,12 +66,12 @@ variable {V}
 /-- A coarser syntactic congruence keeps the language in `V.langs`. -/
 private theorem langs_of_syntacticSemigroupCon_le {M : Language α} (h : V.langs L)
     (hle : L.syntacticSemigroupCon ≤ M.syntacticSemigroupCon) : V.langs M := by
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   have hsurj : Function.Surjective
       (Con.mapMulHom L.syntacticSemigroupCon M.syntacticSemigroupCon hle) :=
     Con.mapMulHom_surjective _ _ hle
-  haveI : Finite M.syntacticSemigroup := .of_surjective _ hsurj
-  exact ⟨IsRegular.of_finite_syntacticSemigroup ‹Finite M.syntacticSemigroup›,
+  haveI : Finite M.SyntacticSemigroup := .of_surjective _ hsurj
+  exact ⟨IsRegular.of_finite_syntacticSemigroup ‹Finite M.SyntacticSemigroup›,
     V.quot hsurj h.2⟩
 
 /-- **Closure under left quotient** — Eilenberg's axiom VII.3.3. -/
@@ -95,13 +85,13 @@ theorem langs_rightQuotient (h : V.langs L) (u : List α) : V.langs (L.rightQuot
 end Quotients
 
 /-- **Closure under intersection** — the syntactic semigroup of `L ⊓ M` is a quotient of a
-subsemigroup of `L.syntacticSemigroup × M.syntacticSemigroup`, which is in `V` by
+subsemigroup of `L.SyntacticSemigroup × M.SyntacticSemigroup`, which is in `V` by
 `prod`/`sub`/`quot`. -/
 theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs (L ⊓ M) := by
   refine ⟨hL.1.inf hM.1, ?_⟩
-  haveI : Finite L.syntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
-  haveI : Finite M.syntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
-  haveI : Finite (L ⊓ M).syntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
+  haveI : Finite L.SyntacticMonoid := IsRegular.finite_syntacticMonoid hL.1
+  haveI : Finite M.SyntacticMonoid := IsRegular.finite_syntacticMonoid hM.1
+  haveI : Finite (L ⊓ M).SyntacticMonoid := IsRegular.finite_syntacticMonoid (hL.1.inf hM.1)
   set φ := L.toSyntacticSemigroup.prod M.toSyntacticSemigroup with hφ
   haveI : Finite (Con.ker φ).Quotient := .of_injective _ (Con.kerLiftMulHom_injective φ)
   have hker : V.mem (Con.ker φ).Quotient :=
@@ -110,7 +100,7 @@ theorem langs_inf {M : Language α} (hL : V.langs L) (hM : V.langs M) : V.langs 
     rw [hφ, ker_prod_toSyntacticSemigroup]
     exact inf_syntacticSemigroupCon_le_syntacticSemigroupCon_inf L M
   haveI : Finite (L ⊓ M).syntacticSemigroupCon.Quotient :=
-    inferInstanceAs (Finite (L ⊓ M).syntacticSemigroup)
+    inferInstanceAs (Finite (L ⊓ M).SyntacticSemigroup)
   exact V.quot (Con.mapMulHom_surjective _ _ hle) hker
 
 /-- **Closure under union** — by De Morgan, `L ⊔ M = (Lᶜ ⊓ Mᶜ)ᶜ`. -/
@@ -128,7 +118,7 @@ theorem langs_of_recognizes {T : Type u} [Semigroup T] [Finite T] (hT : V.mem T)
   haveI : Finite (Con.ker η).Quotient := .of_injective _ (Con.kerLiftMulHom_injective η)
   have hkerMem : V.mem (Con.ker η).Quotient := V.sub (Con.kerLiftMulHom_injective η) hT
   have hsurj := Con.mapMulHom_surjective (Con.ker η) L.syntacticSemigroupCon hle
-  haveI : Finite L.syntacticSemigroup := .of_surjective _ hsurj
+  haveI : Finite L.SyntacticSemigroup := .of_surjective _ hsurj
   exact ⟨IsRegular.of_finite_syntacticSemigroup ‹_›, V.quot hsurj hkerMem⟩
 
 /-- **The full language** — recognized by the trivial semigroup, which is in every
@@ -149,7 +139,7 @@ semigroup has no erasing morphisms. -/
 theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
     (φ : FreeSemigroup α →ₙ* FreeSemigroup β) :
     V.langs {w : List α | ∃ u : FreeSemigroup α, u.toList = w ∧ (φ u).toList ∈ Lb} := by
-  haveI : Finite Lb.syntacticMonoid := IsRegular.finite_syntacticMonoid h.1
+  haveI : Finite Lb.SyntacticMonoid := IsRegular.finite_syntacticMonoid h.1
   refine V.langs_of_recognizes h.2 (Lb.toSyntacticSemigroup.comp φ)
     {m | ∃ u : FreeSemigroup β, Lb.toSyntacticSemigroup u = m ∧ u.toList ∈ Lb} ?_
   intro w
@@ -158,6 +148,6 @@ theorem langs_comap {β : Type u} {Lb : Language β} (h : V.langs Lb)
     obtain rfl : u = w := FreeSemigroup.toList_injective hu
     exact ⟨φ u, rfl, hmem⟩
   · rintro ⟨v, hv, hmem⟩
-    exact ⟨w, rfl, (mem_iff_of_syntacticEquiv (Lb.toSyntacticSemigroup_eq_iff.mp hv)).mp hmem⟩
+    exact ⟨w, rfl, (SyntacticEquiv.mem_iff (Lb.toSyntacticSemigroup_eq_iff.mp hv)).mp hmem⟩
 
 end Semigroup.Pseudovariety

--- a/Linglib/Core/GroupTheory/Congruence/Hom.lean
+++ b/Linglib/Core/GroupTheory/Congruence/Hom.lean
@@ -7,6 +7,7 @@ Authors: Robert Hawkins
 Upstreaming needs `@[to_additive]` on each declaration, and the monoid `Con.lift`/`Con.map`
 should then be re-derived from these, as `Con.mk'` already is from `Con.mkMulHom`.
 -/
+import Mathlib.Algebra.Group.Prod
 import Mathlib.GroupTheory.Congruence.Hom
 
 /-!
@@ -32,6 +33,8 @@ universal-property statements coerce the argument, as in `liftMulHom_comp_mkMulH
 
 * `Con.mulHom_ext`, `Con.liftMulHom_unique`: the universal property of the quotient.
 * `Con.kerLiftMulHom_injective`: the kernel lift is injective.
+* `Con.ker_prod`, `Con.ker_prodMulHom`: the kernel of a paired homomorphism is the meet of the
+  kernels.
 -/
 
 variable {M N : Type*} [Mul M] [Mul N] {F : Type*} [FunLike F M N] [MulHomClass F M N]
@@ -105,5 +108,17 @@ def mapMulHom (d : Con M) (h : c ≤ d) : c.Quotient →ₙ* d.Quotient :=
 theorem mapMulHom_surjective (d : Con M) (h : c ≤ d) :
     Function.Surjective (c.mapMulHom d h) :=
   liftMulHom_surjective_of_surjective _ d.mkMulHom_surjective
+
+/-! ### Kernels of paired homomorphisms -/
+
+/-- The kernel of a paired homomorphism is the meet of the kernels. -/
+theorem ker_prodMulHom {N' : Type*} [Mul N'] (f : M →ₙ* N) (g : M →ₙ* N') :
+    Con.ker (f.prod g) = Con.ker f ⊓ Con.ker g :=
+  Con.ext fun _ _ => by simp [Con.ker_rel, Prod.ext_iff, Con.inf_iff_and]
+
+/-- The kernel of a paired monoid homomorphism is the meet of the kernels. -/
+theorem ker_prod {M N N' : Type*} [MulOneClass M] [MulOneClass N] [MulOneClass N']
+    (f : M →* N) (g : M →* N') : Con.ker (f.prod g) = Con.ker f ⊓ Con.ker g :=
+  Con.ext fun _ _ => by simp [Con.ker_rel, Prod.ext_iff, Con.inf_iff_and]
 
 end Con


### PR DESCRIPTION
Second mathlib-review pass on `SyntacticMonoid.lean` and its semigroup sibling, against current main.

- pointwise `Recognizes` (kills the `FreeMonoid`/`List` defeq crossings; mirrors `RecognizesSemigroup`); `SyntacticMonoid`/`SyntacticSemigroup` type casing
- general `Con.ker_prod`/`Con.ker_prodMulHom` in `Core/GroupTheory/Congruence/Hom.lean`; `ker_toSyntactic*` API; `Con.liftOn` instead of raw `Quot` in Myhill–Nerode
- `syntacticCon_le_leftQuotient`/`_rightQuotient` pairs hoisted from `Variety/` into the syntactic files; `rightQuotient` nil/append/reverse-duality API; section-scoped variable polarity, universal-property docstring direction fixed