### PR TITLE
fix(Core/Computability): correct Subsequential citations and register

### DIFF
--- a/Linglib/Core/Computability/Direction.lean
+++ b/Linglib/Core/Computability/Direction.lean
@@ -11,8 +11,9 @@ import Mathlib.Order.Nat
 
 The orientation of a left-to-right vs right-to-left scan, shared by the transducer
 machines and the side-determinacy predicates of the subregular function theory, with
-the window of positions a direction cuts around a target coordinate. Extracted to its own leaf so the footprint-predicate file (`Dependence.lean`) does
-not have to depend on the transducer machine file just to name a `left`/`right` tag.
+the window of positions a direction cuts around a target coordinate. Extracted to its
+own leaf so the footprint-predicate file (`Dependence.lean`) does not have to depend on
+the transducer machine file just to name a `left`/`right` tag.
 -/
 
 namespace Subregular
@@ -20,7 +21,7 @@ namespace Subregular
 /-- The orientation of an FST scan: `left` consumes input head-first, `right`
 tail-first (via `List.reverse` conjugation). The two scan modes give rise to
 distinct function classes — isomorphic under reversal but not equal as
-subclasses of the regular functions over un-reversed strings. -/
+subclasses of the rational functions over un-reversed strings. -/
 inductive Direction
   | left
   | right

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -27,6 +27,7 @@ instance must be supplied for the finite-state class `IsMealyComputable`.
 * `Mealy σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet `β`
 * `Mealy.run`, `Mealy.runRight`: the left-to-right and right-to-left passes
 * `Mealy.comp`: the cascade connection, computing the composite function
+* `Mealy.ofFn`: the single-state machine applying a fixed symbol map letter-wise
 * `Mealy.ofFlag`: the one-bit machine tracking whether an earlier symbol satisfies `p`
 * `Mealy.reindex`: lifts an equivalence on states to an equivalence on machines
 * `IsMealyComputable f`: `f` is computed by some finite-state `Mealy`
@@ -47,10 +48,9 @@ instance must be supplied for the finite-state class `IsMealyComputable`.
 ## Implementation notes
 
 The functions computed by Mealy machines are the *sequential functions* of algebraic
-automata theory [holcombe-1982]. For length-preserving functions the class coincides
-with the letter-to-letter restriction of the *subsequential* functions [mohri-1997],
-since length preservation forces a subsequential machine's state-final output to be
-empty.
+automata theory [holcombe-1982]. `SubsequentialTransducer` generalizes to word-block
+outputs and a state-final output [mohri-1997]; `Mealy.toSubsequentialTransducer`
+exhibits a Mealy machine as the singleton-output, empty-flush case.
 
 [UPSTREAM] candidate: `Mathlib.Computability.Mealy`.
 
@@ -175,9 +175,23 @@ def comp : Mealy (σ' × σ) α γ where
   induction xs generalizing p <;> simp [*]
 
 @[simp] theorem run_comp : (T₂.comp T₁).run = T₂.run ∘ T₁.run := by
-  funext xs; simp [run, Function.comp]
+  funext xs; simp [run]
 
 end Comp
+
+/-! ### Letter-wise machines -/
+
+/-- The single-state machine applying `h` to every symbol. -/
+def ofFn (h : α → β) : Mealy Unit α β where
+  initial := ()
+  step _ _ := ()
+  output _ := h
+
+@[simp] theorem ofFn_output (h : α → β) (u : Unit) : (ofFn h).output u = h := rfl
+
+@[simp] theorem ofFn_run (h : α → β) (xs : List α) : (ofFn h).run xs = xs.map h := by
+  show (ofFn h).runFrom () xs = _
+  induction xs <;> simp [*]
 
 /-! ### Flag machines -/
 
@@ -282,6 +296,12 @@ theorem IsMealyComputable.comp {γ : Type*} {g : List β → List γ} {f : List 
   obtain ⟨σ₂, _, T₂, rfl⟩ := hg
   obtain ⟨σ₁, _, T₁, rfl⟩ := hf
   exact ⟨σ₂ × σ₁, inferInstance, T₂.comp T₁, T₂.run_comp T₁⟩
+
+theorem isMealyComputable_map (h : α → β) : IsMealyComputable (List.map h) :=
+  funext (Mealy.ofFn_run h) ▸ (Mealy.ofFn h).isMealyComputable
+
+theorem isMealyComputable_id : IsMealyComputable (id : List α → List α) := by
+  simpa using isMealyComputable_map (id : α → α)
 
 /-! ### Pulling back acceptors -/
 

--- a/Linglib/Core/Computability/MyhillNerode.lean
+++ b/Linglib/Core/Computability/MyhillNerode.lean
@@ -122,12 +122,6 @@ theorem isMealyComputable_of_stateSummary
   · rw [List.getElem?_eq_none hi, List.getElem?_eq_none ((hlen xs).le.trans hi),
       Option.map_none]
 
-/-- The identity is Mealy-computable, via a one-state summary. -/
-theorem isMealyComputable_id : IsMealyComputable (id : List α → List α) :=
-  isMealyComputable_of_stateSummary
-    (fun _ => ()) (fun _ _ => ()) (fun _ x => x)
-    (fun _ _ => rfl) (fun _ _ _ => by simp) (fun _ => rfl)
-
 /-- A length-preserving, prefix-preserving function with finitely many residuals is
 Mealy-computable: the residuals themselves are the states. -/
 theorem isMealyComputable_of_residual {f : List α → List β}

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -18,7 +18,7 @@ import Linglib.Core.Computability.Direction
 A function `f : List α → List β` is *subsequential* when it is computed by a
 deterministic finite-state transducer with state-final output [schutzenberger-1977]
 [mohri-1997]. Subsequential functions form a proper subclass of the rational functions
-(the functional regular relations).
+(the functional rational relations) [filiot-reynier-2016].
 
 The class has *left* and *right* variants according to scan direction; the two are
 isomorphic under input/output reversal (`f` is right-subsequential iff
@@ -26,16 +26,16 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
 
 ## Main definitions
 
-* `SubsequentialTransducer σ α β`: transducer with states `σ`, input alphabet `α`, output alphabet
-  `β`,
-  and a state-final output emitted at the end of the input
-* `SubsequentialTransducer.run`, `SubsequentialTransducer.runRight`: the left-to-right and
-  right-to-left passes
+* `SubsequentialTransducer σ α β`: transducer with states `σ`, input alphabet `α`,
+  output alphabet `β`, and a state-final output emitted at the end of the input
+* `SubsequentialTransducer.run`, `SubsequentialTransducer.runRight`: the left-to-right
+  and right-to-left passes, built from `stateAfter`, `emitted`, and `runFrom`
 * `SubsequentialTransducer.comp`: the product machine, computing the composite function
-* `SubsequentialTransducer.reindex`: lifts an equivalence on states to an equivalence on machines
-* `Mealy.toSubsequentialTransducer`, `SubsequentialTransducer.toMealy`: the synchronous and block
-  machine views of each
-  other, mutually inverse on singleton-output transducers with no final flush
+* `SubsequentialTransducer.reindex`: lifts an equivalence on states to an equivalence on
+  machines
+* `Mealy.toSubsequentialTransducer`, `SubsequentialTransducer.toMealy`: the synchronous
+  and block machine views of each other, mutually inverse on singleton-output
+  transducers with no final flush
 * `IsLeftSubsequential f`, `IsRightSubsequential f`, `IsSubsequential d f`: `f` is
   computed by some finite-state `SubsequentialTransducer` scanning in the given direction
 
@@ -43,13 +43,14 @@ isomorphic under input/output reversal (`f` is right-subsequential iff
 
 * `IsLeftSubsequential.comp` (and the right/direction variants): subsequential
   functions are closed under composition, by the classical product construction
-  [schutzenberger-1977]
+  [mohri-1997]
 * `isRightSubsequential_iff_left_reverse`: the left and right classes are isomorphic
   via reverse-conjugation
-* `IsMealyComputable.isLeftSubsequential`, `SubsequentialTransducer.isMealyComputable`: the
-  synchronous
-  class sits inside the block class, and a singleton-output SubsequentialTransducer falls back into
-  it
+* `isLeftSubsequential_iff`, `isRightSubsequential_iff`: the universe-polymorphic
+  characterizations
+* `IsMealyComputable.isLeftSubsequential`, `SubsequentialTransducer.isMealyComputable`:
+  the synchronous class sits inside the block class, and a singleton-output transducer
+  with no final flush falls back into it
 * `IsLeftSubsequential.bounded_delay`: a left-subsequential function withholds at most
   a bounded suffix, since it can only be sitting on a state-final output
 
@@ -60,16 +61,19 @@ transducer with no state-final output, *subsequential* once one is added. The us
 contested — [sakarovitch-2009] calls this class simply *sequential* (reserving *pure
 sequential* for the empty-final-output case) and flags his own terminology as
 unconventional, quoting [bruyere-reutenauer-1999] that "the word sub-sequential is
-unfortunate". We keep the Choffrut spelling, so `Mealy` computes the *pure sequential*
-length-preserving functions and `SubsequentialTransducer` the subsequential ones.
+unfortunate". We keep the Choffrut spelling, so `Mealy` is the letter-to-letter case —
+empty final output, one output symbol per input symbol — and `SubsequentialTransducer`
+the general one.
 
-`SubsequentialTransducer` models the *total* subsequential functions: `step` is total and every
-input is
-accepted, so `run` is a total function. This restricts the literature's class — a sink
-state does not recover partiality, since out-of-domain inputs still emit output — so
-the classification predicates below are about total functions only. On empty input
-`run` emits `finalOutput start` alone; the initial-output component of [mohri-1997] is
-omitted.
+`SubsequentialTransducer` models the *total* subsequential functions: `step` is total
+and every input is accepted, so `run` is a total function. This restricts the
+literature's class — a sink state does not recover partiality, since out-of-domain
+inputs still emit output — so the classification predicates below are about total
+functions only. On empty input `run` emits `finalOutput start` alone; the
+initial-output function of [sakarovitch-2009] is omitted.
+
+`run` and `runFrom` keep disjoint simp normal forms, as with `DFA.eval`/`DFA.evalFrom`:
+`run_nil` is simp but there is no `run_cons`; switch to `runFrom` via `simp [run]`.
 
 ## TODO
 
@@ -88,9 +92,9 @@ namespace Subregular
 
 variable {σ α β : Type*}
 
-/-- A subsequential finite-state transducer (SubsequentialTransducer) is a set of states (`σ`), a
-starting state (`start`), a transition function (`step`), a per-symbol output
-function (`output`) and a state-final output (`finalOutput`). -/
+/-- A subsequential finite-state transducer is a set of states (`σ`), a starting state
+(`start`), a transition function (`step`), a per-symbol output function (`output`) and
+a state-final output (`finalOutput`). -/
 structure SubsequentialTransducer (σ α β : Type*) where
   /-- Starting state. -/
   start : σ
@@ -162,14 +166,9 @@ theorem runFrom_append (s : σ) (xs ys : List α) :
     T.runFrom s (xs ++ ys) = T.emitted s xs ++ T.runFrom (T.stateAfter s xs) ys := by
   simp [runFrom, emitted_append, stateAfter_append]
 
-/-- Coordinates within the emitted prefix are stable under extending the input. -/
-theorem getElem?_run_append (u v : List α) {i : ℕ}
-    (hi : i < (T.emitted T.start u).length) :
-    (T.run u)[i]? = (T.run (u ++ v))[i]? := by
-  simp only [run]
-  rw [runFrom_append]
-  unfold runFrom
-  rw [List.getElem?_append_left hi, List.getElem?_append_left hi]
+theorem run_append (xs ys : List α) :
+    T.run (xs ++ ys) = T.emitted T.start xs ++ T.runFrom (T.stateAfter T.start xs) ys :=
+  T.runFrom_append T.start xs ys
 
 /-! ### Reindexing states -/
 
@@ -224,7 +223,7 @@ section Comp
 variable {γ σ' : Type*} (T₂ : SubsequentialTransducer σ' β γ) (T₁ : SubsequentialTransducer σ α β)
 
 /-- `T₂.comp T₁` feeds each output block of `T₁` to `T₂` — the classical product
-construction [schutzenberger-1977] — computing `T₂.run ∘ T₁.run` (`run_comp`). -/
+construction [mohri-1997] — computing `T₂.run ∘ T₁.run` (`run_comp`). -/
 @[simps]
 def comp : SubsequentialTransducer (σ' × σ) α γ where
   start := (T₂.start, T₁.start)
@@ -247,17 +246,14 @@ end SubsequentialTransducer
 
 /-! ### Synchronous machines as block transducers
 
-A `Mealy` machine is a `SubsequentialTransducer` emitting singleton blocks with an empty final
-flush; a
-block transducer of that shape is a `Mealy` machine. The two views are mutually
-inverse. -/
+A `Mealy` machine is a `SubsequentialTransducer` emitting singleton blocks with an
+empty final flush; a block transducer of that shape is a `Mealy` machine. The two views
+are mutually inverse. -/
 
 section Synchronous
 
-variable {σ α β : Type*}
-
-/-- View a synchronous transducer as a block `SubsequentialTransducer`: singleton outputs, empty
-flush. -/
+/-- View a synchronous transducer as a block `SubsequentialTransducer`: singleton
+outputs, empty flush. -/
 def Mealy.toSubsequentialTransducer (T : Mealy σ α β) : SubsequentialTransducer σ α β where
   start := T.initial
   step := T.step
@@ -286,6 +282,19 @@ def SubsequentialTransducer.toMealy (T : SubsequentialTransducer σ α β)
 @[simp] theorem Mealy.toMealy_toSubsequentialTransducer (T : Mealy σ α β) :
     T.toSubsequentialTransducer.toMealy (fun _ _ => rfl) = T := rfl
 
+/-- The round trip in the other direction: a singleton-output transducer with no final
+flush is its own synchronous view. -/
+theorem SubsequentialTransducer.toSubsequentialTransducer_toMealy
+    (T : SubsequentialTransducer σ α β) (hs : ∀ s x, (T.output s x).length = 1)
+    (hf : ∀ s, T.finalOutput s = []) :
+    (T.toMealy hs).toSubsequentialTransducer = T := by
+  obtain ⟨start, step, output, finalOutput⟩ := T
+  dsimp only at hs hf ⊢
+  refine SubsequentialTransducer.mk.injEq .. ▸ ⟨rfl, rfl, funext fun s => funext fun x => ?_,
+    funext fun s => (hf s).symm⟩
+  obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
+  simp [SubsequentialTransducer.toMealy, ha]
+
 theorem SubsequentialTransducer.toMealy_runFrom (T : SubsequentialTransducer σ α β)
     (hs : ∀ s x, (T.output s x).length = 1)
     (hf : ∀ s, T.finalOutput s = []) (s : σ) (xs : List α) :
@@ -295,8 +304,7 @@ theorem SubsequentialTransducer.toMealy_runFrom (T : SubsequentialTransducer σ 
   | cons x xs ih =>
     obtain ⟨a, ha⟩ := List.length_eq_one_iff.mp (hs s x)
     simp only [Mealy.runFrom_cons, SubsequentialTransducer.runFrom_cons, toMealy_output,
-    toMealy_step, ih, ha,
-      List.head_cons, List.singleton_append]
+      toMealy_step, ih, ha, List.head_cons, List.singleton_append]
 
 theorem SubsequentialTransducer.toMealy_run (T : SubsequentialTransducer σ α β)
     (hs : ∀ s x, (T.output s x).length = 1)
@@ -307,15 +315,15 @@ end Synchronous
 
 /-! ### Subsequential classification predicates -/
 
-variable {α β γ : Type*} {f : List α → List β} {g : List β → List γ}
+variable {γ : Type*} {f : List α → List β} {g : List β → List γ}
 
-/-- A function `f : List α → List β` is *left-subsequential* if some SubsequentialTransducer with a
-finite state space computes it via left-to-right scan [mohri-1997]. -/
+/-- A function `f : List α → List β` is *left-subsequential* if some finite-state
+transducer computes it via left-to-right scan [mohri-1997]. -/
 def IsLeftSubsequential (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f
 
-/-- A function `f : List α → List β` is *right-subsequential* if some SubsequentialTransducer with a
-finite state space computes it via right-to-left scan (`runRight`). -/
+/-- A function `f : List α → List β` is *right-subsequential* if some finite-state
+transducer computes it via right-to-left scan (`runRight`). -/
 def IsRightSubsequential (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f
 
@@ -326,16 +334,15 @@ def IsSubsequential (d : Direction) (f : List α → List β) : Prop :=
   | .left => IsLeftSubsequential f
   | .right => IsRightSubsequential f
 
-@[simp] theorem isSubsequential_left :
+@[simp] theorem isSubsequential_left_iff :
     IsSubsequential .left f ↔ IsLeftSubsequential f := Iff.rfl
 
-@[simp] theorem isSubsequential_right :
+@[simp] theorem isSubsequential_right_iff :
     IsSubsequential .right f ↔ IsRightSubsequential f := Iff.rfl
 
 /-- `f` is left-subsequential if and only if it is computed by a finite-state
-SubsequentialTransducer.
-This is more general than using the definition of `IsLeftSubsequential` directly, as
-the state type `σ` is universe-polymorphic. -/
+transducer. This is more general than using the definition of `IsLeftSubsequential`
+directly, as the state type `σ` is universe-polymorphic. -/
 theorem isLeftSubsequential_iff.{v} :
     IsLeftSubsequential f
       ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f :=
@@ -344,7 +351,7 @@ theorem isLeftSubsequential_iff.{v} :
     (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.run_reindex e).trans hT⟩)
 
 /-- `f` is right-subsequential if and only if it is computed via `runRight` by a
-finite-state SubsequentialTransducer. This is more general than using the definition of
+finite-state transducer. This is more general than using the definition of
 `IsRightSubsequential` directly, as the state type `σ` is universe-polymorphic. -/
 theorem isRightSubsequential_iff.{v} :
     IsRightSubsequential f
@@ -353,36 +360,40 @@ theorem isRightSubsequential_iff.{v} :
     (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
     (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
 
-/-- Every finite-state SubsequentialTransducer computes a left-subsequential function, whatever the
+/-- Every finite-state transducer computes a left-subsequential function, whatever the
 universe of its state type. -/
 theorem SubsequentialTransducer.isLeftSubsequential {σ : Type*} [Fintype σ]
     (T : SubsequentialTransducer σ α β) :
     IsLeftSubsequential T.run :=
   isLeftSubsequential_iff.mpr ⟨σ, inferInstance, T, rfl⟩
 
-/-- Every finite-state SubsequentialTransducer computes a right-subsequential function via
+/-- Every finite-state transducer computes a right-subsequential function via
 `runRight`. -/
 theorem SubsequentialTransducer.isRightSubsequential {σ : Type*} [Fintype σ]
     (T : SubsequentialTransducer σ α β) :
     IsRightSubsequential T.runRight :=
   isRightSubsequential_iff.mpr ⟨σ, inferInstance, T, rfl⟩
 
-/-- Every finite-state SubsequentialTransducer emitting one symbol per input symbol and flushing
-nothing at
-the end computes a Mealy-computable function. -/
+/-- Every finite-state transducer emitting one symbol per input symbol and flushing
+nothing at the end computes a Mealy-computable function. -/
 theorem SubsequentialTransducer.isMealyComputable {σ : Type*} [Fintype σ]
     (T : SubsequentialTransducer σ α β)
     (hs : ∀ s x, (T.output s x).length = 1) (hf : ∀ s, T.finalOutput s = []) :
     IsMealyComputable T.run :=
   T.toMealy_run hs hf ▸ (T.toMealy hs).isMealyComputable
 
-/-- A Mealy-computable function is left-subsequential, since `Mealy.toSubsequentialTransducer`
-presents a
-synchronous machine as a block transducer emitting singleton blocks. -/
+/-- A Mealy-computable function is left-subsequential: `Mealy.toSubsequentialTransducer`
+presents a synchronous machine as a block transducer emitting singleton blocks. -/
 theorem IsMealyComputable.isLeftSubsequential (hf : IsMealyComputable f) :
     IsLeftSubsequential f := by
   obtain ⟨σ, _, T, rfl⟩ := hf
   exact T.toSubsequentialTransducer_run ▸ T.toSubsequentialTransducer.isLeftSubsequential
+
+theorem isLeftSubsequential_map (h : α → β) : IsLeftSubsequential (List.map h) :=
+  (isMealyComputable_map h).isLeftSubsequential
+
+theorem isLeftSubsequential_id : IsLeftSubsequential (id : List α → List α) :=
+  isMealyComputable_id.isLeftSubsequential
 
 /-- A function is right-subsequential iff its reverse-conjugate is left-subsequential:
 the two classes are isomorphic via the involution `f ↦ List.reverse ∘ f ∘ List.reverse`. -/
@@ -390,8 +401,8 @@ theorem isRightSubsequential_iff_left_reverse :
     IsRightSubsequential f
       ↔ IsLeftSubsequential (fun xs => (f xs.reverse).reverse) :=
   ⟨fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [← hT]⟩,
-   fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [SubsequentialTransducer.runRight,
-   hT]⟩⟩
+   fun ⟨σ, _, T, hT⟩ =>
+     ⟨σ, inferInstance, T, by funext xs; simp [SubsequentialTransducer.runRight, hT]⟩⟩
 
 /-- A left-subsequential function has bounded delay: on any input `u` it has already
 emitted a prefix of `f u` shared with `f (u ++ v)` for every continuation `v`,
@@ -411,13 +422,14 @@ theorem IsLeftSubsequential.bounded_delay (hf : IsLeftSubsequential f) :
 positions before its end are stable under extending the input. -/
 theorem IsLeftSubsequential.exists_getElem?_append_eq (hf : IsLeftSubsequential f) :
     ∃ N : ℕ, ∀ u v i, i + N < (f u).length → (f u)[i]? = (f (u ++ v))[i]? := by
-  obtain ⟨σ, _, T, rfl⟩ := hf
-  refine ⟨Finset.univ.sup fun s => (T.finalOutput s).length,
-    fun u v i hi => T.getElem?_run_append u v ?_⟩
-  have hN := Finset.le_sup (f := fun s => (T.finalOutput s).length)
-    (Finset.mem_univ (T.stateAfter T.start u))
-  simp only [SubsequentialTransducer.run, SubsequentialTransducer.runFrom, List.length_append] at hi
-  omega
+  obtain ⟨N, hN⟩ := hf.bounded_delay
+  refine ⟨N, fun u v i hi => ?_⟩
+  obtain ⟨p, su, sv, hu, huv, hsu⟩ := hN u v
+  have hip : i < p.length := by
+    have hlen := congrArg List.length hu
+    simp only [List.length_append] at hlen
+    omega
+  rw [hu, huv, List.getElem?_append_left hip, List.getElem?_append_left hip]
 
 /-- `f` is not left-subsequential if for every `N` some images `f u` and `f (u ++ v)`
 disagree more than `N` positions before the end of `f u` — the contrapositive of
@@ -432,7 +444,7 @@ theorem not_isLeftSubsequential_of_diverging
   exact hne (hN u v i hi)
 
 /-- Left-subsequential functions are closed under composition, by the classical
-product construction [schutzenberger-1977] (`SubsequentialTransducer.comp`). -/
+product construction [mohri-1997] (`SubsequentialTransducer.comp`). -/
 theorem IsLeftSubsequential.comp (hg : IsLeftSubsequential g)
     (hf : IsLeftSubsequential f) : IsLeftSubsequential (g ∘ f) := by
   obtain ⟨σ₁, _, T₁, rfl⟩ := hf

--- a/Linglib/Phonology/Subregular/Transduction.lean
+++ b/Linglib/Phonology/Subregular/Transduction.lean
@@ -21,8 +21,7 @@ relabelling, deletion, and insertion. Non-order-preserving maps (reordering via 
 output successor) are the non-local extension and are deliberately out of scope here.
 
 Composition of transductions (`applyComp`) models an iterated derivation: each step is a local
-transduction; the composite is a regular function (closed under composition in
-`SubsequentialTransducer`) though not in general itself quantifier-free.
+transduction, though the composite is not in general itself quantifier-free.
 
 ## Main definitions
 
@@ -73,9 +72,8 @@ def apply (T : Transduction α β) (w : List α) : List β :=
 
 @[simp] theorem apply_nil (T : Transduction α β) : T.apply [] = [] := rfl
 
-/-- Composition of transductions — one cyclic derivation step after another. The composite is a
-regular function (closed under composition in `SubsequentialTransducer`), though not in general
-itself quantifier-free. -/
+/-- Composition of transductions — one cyclic derivation step after another; the composite is
+not in general itself quantifier-free. -/
 def applyComp (T₂ : Transduction β γ) (T₁ : Transduction α β) [DecidableEq β]
     (w : List α) : List γ :=
   T₂.apply (T₁.apply w)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -30146,9 +30146,9 @@
 % ══════════════════════════════════════════════════════════════════════════════
 %  phonology/subregular — foundational substrate references
 %
-%  These four entries support the Linglib/Core/Computability/Subregular/
-%  cluster (Basic, StrictlyLocal, Piecewise, LocallyTestable, Definite, Tier,
-%  Hierarchy, ForbiddenPairs) plus the Belth2026 study consumer.
+%  These four entries support the subregular language files (flat under
+%  Linglib/Core/Computability/ and Linglib/Phonology/Subregular/) plus the
+%  Belth2026 study consumer.
 % ══════════════════════════════════════════════════════════════════════════════
 
 % REF: Heinz, Rawal & Tanner (2011). Tier-based Strictly Local Constraints
@@ -30165,7 +30165,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Studies/Belth2026.lean;Phonology/OCP.lean;Core/Computability/Subregular/Language/ForbiddenPairs.lean}
+  sources   = {Studies/Belth2026.lean;Phonology/OCP.lean;Phonology/Subregular/ForbiddenPairs.lean}
 }
 
 % REF: Heinz & Rogers (2010). Estimating Strictly Piecewise Distributions.
@@ -30182,7 +30182,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Language/Aperiodicity.lean;Core/Computability/Subregular/Language/Boundary.lean}
+  sources   = {Core/Computability/Aperiodicity.lean;Core/Computability/Boundary.lean}
 }
 
 % REF: Rogers & Pullum (2011). Aural Pattern Recognition Experiments and
@@ -30200,7 +30200,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Language/Definite.lean}
+  sources   = {Core/Computability/Definite.lean}
 }
 
 % REF: Lambert (2022). Unifying Classification Schemes for Languages and
@@ -30217,13 +30217,13 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Studies/Belth2026.lean;Core/Computability/Subregular/Language/Definite.lean}
+  sources   = {Studies/Belth2026.lean;Core/Computability/Definite.lean}
 }
 
 % ──────────────────────────────────────────────────────────────────────────────
 %  phonology/subregular — function-level hierarchy (ISL/OSL/Subseq/WD)
 %
-%  Entries below support Linglib/Core/Computability/Subregular/Function/ —
+%  Entries below support the function-level files (Linglib/Phonology/Subregular/) —
 %  the function-level (string-to-string map) analogue of the language-level
 %  hierarchy above. All entries verified against the References section of
 %  Meinhardt et al 2024 NLLT 42:1191-1232 (Fig 1 is the canonical 2024
@@ -30241,7 +30241,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/ISL.lean}
+  sources   = {Phonology/Subregular/ISL.lean}
 }
 
 % REF: Chandlee, Eyraud & Heinz (2015). Output Strictly Local Functions.
@@ -30259,7 +30259,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/OSL.lean}
+  sources   = {Phonology/Subregular/OSL.lean}
 }
 
 % REF: Chandlee & Heinz (2018). Strict Locality and Phonological Maps.
@@ -30277,7 +30277,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/ISL.lean;Phonology/Subregular/LocalRewrite.lean;Phonology/OCP.lean}
+  sources   = {Phonology/Subregular/ISL.lean;Phonology/Subregular/LocalRewrite.lean;Phonology/OCP.lean}
 }
 
 % REF: Mohri (1997). Finite-State Transducers in Language and Speech
@@ -30354,7 +30354,7 @@
   subfield  = {phonology/subregular},
   role      = {cited},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/Subsequential.lean}
+  sources   = {Core/Computability/Subsequential.lean}
 }
 
 @article{reutenauer-schutzenberger-1991,
@@ -30464,7 +30464,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/Subsequential.lean; Core/Computability/Mealy.lean}
+  sources   = {Core/Computability/Subsequential.lean; Core/Computability/Mealy.lean}
 }
 
 % REF: Heinz & Lai (2013). Vowel Harmony and Subsequentiality.
@@ -30482,7 +30482,7 @@
   subfield  = {phonology/subregular},
   role      = {foundational},
   validated = {true},
-  sources   = {Core/Computability/Subregular/Function/Subsequential.lean;Studies/MeinhardtEtAl2024.lean}
+  sources   = {Core/Computability/Subsequential.lean;Studies/MeinhardtEtAl2024.lean}
 }
 
 % REF: Meinhardt, Mai, Baković & McCollum (2024). Weak determinism and the
@@ -34325,7 +34325,7 @@
   url       = {https://aclanthology.org/Q19-1010/},
   subfield  = {phonology/autosegmental},
   role      = {formalized},
-  sources   = {Phonology/OCP.lean;Core/Computability/Subregular/Logic/QFLogic.lean;Phonology/Subregular/OCP.lean;Core/Computability/Subregular/Logic/LocalityBridge.lean}
+  sources   = {Phonology/OCP.lean;Phonology/Subregular/QF.lean;Phonology/Subregular/OCP.lean;Phonology/Subregular/LocalityBridge.lean}
 }
 
 % REF: Burness & McMullin (2020). Multi-Tiered Strictly Local Functions.
@@ -34362,7 +34362,7 @@
   doi       = {10.1007/978-3-030-40608-0_10},
   subfield  = {phonology/autosegmental},
   role      = {cited},
-  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+  sources   = {Phonology/Subregular/BMRS.lean}
 }
 
 % REF: Shih & Inkelas (2014). Reframing the TBU in an ABC+Q approach
@@ -37269,7 +37269,7 @@
   url       = {https://arxiv.org/abs/2302.03074},
   subfield  = {phonology/computational},
   role      = {cited},
-  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+  sources   = {Phonology/Subregular/BMRS.lean}
 }
 
 @article{chandlee-jardine-2021,
@@ -37283,7 +37283,7 @@
   doi       = {10.1353/lan.2021.0045},
   subfield  = {phonology/computational},
   role      = {cited},
-  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+  sources   = {Phonology/Subregular/BMRS.lean}
 }
 
 @article{kozen-1983,
@@ -37297,7 +37297,7 @@
   doi       = {10.1016/0304-3975(82)90125-6},
   subfield  = {logic},
   role      = {cited},
-  sources   = {Core/Computability/Subregular/Logic/ModalMu.lean}
+  sources   = {Studies/YolyanComer2026.lean}
 }
 
 @article{yolyan-2025,
@@ -37310,7 +37310,7 @@
   doi       = {10.1007/s10849-025-09429-9},
   subfield  = {phonology/computational},
   role      = {formalized},
-  sources   = {Core/Computability/Subregular/Logic/BMRS.lean}
+  sources   = {Phonology/Subregular/BMRS.lean}
 }
 
 @inproceedings{yolyan-comer-2026,
@@ -37322,7 +37322,7 @@
   publisher = {Association for Computational Linguistics},
   subfield  = {phonology/computational},
   role      = {formalized},
-  sources   = {Core/Computability/Subregular/Logic/BMRS.lean;Core/Computability/Subregular/Logic/ModalMu.lean}
+  sources   = {Phonology/Subregular/BMRS.lean;Studies/YolyanComer2026.lean}
 }
 
 @inproceedings{koser-jardine-2020,


### PR DESCRIPTION
Source-verified audit of `Subsequential.lean` (with its `Mealy.lean` seam): corrects the composition construction misattributed to Schützenberger 1977 (it is Mohri 1997's Theorem 1 construction verbatim), the "functional regular relations" gloss (rational, in Filiot–Reynier's vocabulary), the initial-output note (Sakarovitch's extension, not Mohri's), and the false "length preservation forces empty flush" justification in `Mealy.lean`.

- repairs the SFST-rename rewrap damage and redundant `variable` re-declarations
- derives `exists_getElem?_append_eq` from `bounded_delay` (replacing a duplicate machine proof); adds `run_append`, the missing `toMealy` round-trip, `Mealy.ofFn`, and identity/map instances, deduplicating MyhillNerode's `isMealyComputable_id`
- updates stale `sources` paths in `references.bib`