### PR TITLE
refactor(Core/Computability): ofWindow transducer, dedupe projections

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -102,6 +102,7 @@ import Linglib.Core.Computability.Variety.OmegaEquations
 import Linglib.Core.Computability.Variety.Definite
 import Linglib.Core.Computability.Variety.SemigroupLangs
 import Linglib.Core.Data.Fin.Tuple.Basic
+import Linglib.Core.Data.Fintype.List
 import Linglib.Core.Data.Fintype.Sets
 import Linglib.Core.Data.Fintype.Transfer
 import Linglib.Core.Data.List.Bookend

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Fintype.Prod
 import Mathlib.Data.Finset.Lattice.Fold
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Data.Fintype.Transfer
+import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Computability.Direction
 
 /-!
@@ -18,74 +19,51 @@ import Linglib.Core.Computability.Direction
 A function `f : List α → List β` is *subsequential* when it is computed by a
 deterministic finite-state transducer with state-final output [schutzenberger-1977]
 [mohri-1997]. Subsequential functions form a proper subclass of the rational functions
-(the functional rational relations) [filiot-reynier-2016].
-
-The class has *left* and *right* variants according to scan direction; the two are
-isomorphic under input/output reversal (`f` is right-subsequential iff
-`List.reverse ∘ f ∘ List.reverse` is left-subsequential).
+(the functional rational relations) [filiot-reynier-2016]. The class has *left* and
+*right* variants by scan direction, isomorphic under reverse-conjugation.
 
 ## Main definitions
 
-* `SubsequentialTransducer σ α β`: transducer with states `σ`, input alphabet `α`,
-  output alphabet `β`, and a state-final output emitted at the end of the input
-* `SubsequentialTransducer.run`, `SubsequentialTransducer.runRight`: the left-to-right
-  and right-to-left passes, built from `stateAfter`, `emitted`, and `runFrom`
-* `SubsequentialTransducer.comp`: the product machine, computing the composite function
-* `SubsequentialTransducer.reindex`: lifts an equivalence on states to an equivalence on
-  machines
-* `Mealy.toSubsequentialTransducer`, `SubsequentialTransducer.toMealy`: the synchronous
-  and block machine views of each other, mutually inverse on singleton-output
-  transducers with no final flush
-* `IsLeftSubsequential f`, `IsRightSubsequential f`, `IsSubsequential d f`: `f` is
-  computed by some finite-state `SubsequentialTransducer` scanning in the given direction
+* `SubsequentialTransducer σ α β`: the machine; `run` and `runRight` are its two passes
+* `SubsequentialTransducer.comp`: the product machine
+* `SubsequentialTransducer.ofWindow`: the sliding-window transducer
+* `Mealy.toSubsequentialTransducer`, `SubsequentialTransducer.toMealy`: mutually inverse
+  views of the synchronous machines as singleton-output, empty-flush block transducers
+* `IsLeftSubsequential`, `IsRightSubsequential`, `IsSubsequential d`: computability by a
+  finite-state transducer in the given scan direction
 
 ## Main theorems
 
-* `IsLeftSubsequential.comp` (and the right/direction variants): subsequential
-  functions are closed under composition, by the classical product construction
+* `IsLeftSubsequential.comp`: closure under composition, by the product construction
   [mohri-1997]
-* `isRightSubsequential_iff_left_reverse`: the left and right classes are isomorphic
-  via reverse-conjugation
+* `isRightSubsequential_iff_left_reverse`: the left and right classes are
+  reverse-conjugate
 * `isLeftSubsequential_iff`, `isRightSubsequential_iff`: the universe-polymorphic
   characterizations
-* `IsMealyComputable.isLeftSubsequential`, `SubsequentialTransducer.isMealyComputable`:
-  the synchronous class sits inside the block class, and a singleton-output transducer
-  with no final flush falls back into it
-* `IsLeftSubsequential.bounded_delay`: a left-subsequential function withholds at most
-  a bounded suffix, since it can only be sitting on a state-final output
+* `IsMealyComputable.isLeftSubsequential`: the synchronous class sits inside the block
+  class
+* `IsLeftSubsequential.bounded_delay`: at most a bounded suffix is withheld
 
 ## Implementation notes
 
-The name follows [choffrut-1977] and [mohri-1997]: *sequential* for a deterministic
-transducer with no state-final output, *subsequential* once one is added. The usage is
-contested — [sakarovitch-2009] calls this class simply *sequential* (reserving *pure
-sequential* for the empty-final-output case) and flags his own terminology as
-unconventional, quoting [bruyere-reutenauer-1999] that "the word sub-sequential is
-unfortunate". We keep the Choffrut spelling, so `Mealy` is the letter-to-letter case —
-empty final output, one output symbol per input symbol — and `SubsequentialTransducer`
-the general one.
+The name follows [choffrut-1977] and [mohri-1997]: *sequential* without state-final
+output, *subsequential* with. [sakarovitch-2009] instead calls this class *sequential*
+(and the empty-flush case *pure sequential*), flagging his own usage as unconventional
+(cf. [bruyere-reutenauer-1999]); we keep the Choffrut spelling. `Mealy` is the
+letter-to-letter case.
 
-`SubsequentialTransducer` models the *total* subsequential functions: `step` is total
-and every input is accepted, so `run` is a total function. This restricts the
-literature's class — a sink state does not recover partiality, since out-of-domain
-inputs still emit output — so the classification predicates below are about total
-functions only. On empty input `run` emits `finalOutput start` alone; the
-initial-output function of [sakarovitch-2009] is omitted.
-
-`run` and `runFrom` keep disjoint simp normal forms, as with `DFA.eval`/`DFA.evalFrom`:
-`run_nil` is simp but there is no `run_cons`; switch to `runFrom` via `simp [run]`.
+`step` is total and every input is accepted, so `run` models the *total* subsequential
+functions only — a sink state does not recover partiality, since out-of-domain inputs
+still emit output. On empty input `run` emits `finalOutput start`; the initial-output
+function of [sakarovitch-2009] is omitted. `run` and `runFrom` keep disjoint simp
+normal forms, as with `DFA.eval`/`DFA.evalFrom`: switch via `simp [run]`.
 
 ## TODO
 
-* The characterization of [choffrut-1977]: a rational function is subsequential iff it
-  has *bounded variation* — for every `l` there is an `L` with `d (f x) (f y) ≤ L`
-  whenever `d x y ≤ l`, for the prefix distance `d x y = |x⁻¹y|` taken in the free group
-  — which is decidable on a transducer realizing it via the twinning condition. Neither
-  bounded variation nor twinning is formalized here; `bounded_delay` is a much weaker
-  consequence of subsequentiality, not this characterization.
-* Onward canonical forms and minimization.
-* Two-way subsequential functions (two-way deterministic transducers).
-* p-subsequential functions [mohri-1997] (multiple outputs per input).
+* Choffrut's theorem [choffrut-1977]: a rational function is subsequential iff it has
+  bounded variation, decidably via the twinning condition; `bounded_delay` is a much
+  weaker consequence. Onward, canonical forms and minimization.
+* Two-way transducers; p-subsequential functions [mohri-1997].
 -/
 
 namespace Subregular
@@ -241,6 +219,44 @@ def comp : SubsequentialTransducer (σ' × σ) α γ where
   funext xs; simp [run, Function.comp]
 
 end Comp
+
+/-! ### Window transducers -/
+
+section OfWindow
+
+variable {γ : Type*}
+
+/-- The sliding-window transducer: the state is a window of at most `n` symbols of `γ`,
+`out` emits an output block from the window and the current symbol, and `upd` chooses
+what the window accumulates — `fun _ x => [x]` tracks the input, `out` itself the
+output. -/
+@[simps]
+def ofWindow (n : ℕ) (out : List γ → α → List β) (upd : List γ → α → List γ) :
+    SubsequentialTransducer {l : List γ // l.length ≤ n} α β where
+  start := ⟨[], Nat.zero_le _⟩
+  step w x := ⟨(w.val ++ upd w.val x).rtake n, List.length_rtake_le _ _⟩
+  output w x := out w.val x
+  finalOutput _ := []
+
+variable {n : ℕ} {out : List γ → α → List β} {upd : List γ → α → List γ}
+
+/-- The window transducer runs any recursion that emits `out` and extends the window by
+`upd` — the master run-equality behind the ISL/OSL projections. -/
+theorem runFrom_ofWindow (go : List γ → List α → List β) (hnil : ∀ w, go w [] = [])
+    (hcons : ∀ w x xs, go w (x :: xs) = out w x ++ go ((w ++ upd w x).rtake n) xs) :
+    ∀ (w : {l : List γ // l.length ≤ n}) (xs : List α),
+      (ofWindow n out upd).runFrom w xs = go w.val xs := by
+  intro w xs
+  induction xs generalizing w with
+  | nil => simp [hnil]
+  | cons x xs ih => rw [runFrom_cons, hcons]; exact congrArg _ (ih _)
+
+theorem run_ofWindow (go : List γ → List α → List β) (hnil : ∀ w, go w [] = [])
+    (hcons : ∀ w x xs, go w (x :: xs) = out w x ++ go ((w ++ upd w x).rtake n) xs) :
+    (ofWindow n out upd).run = go [] :=
+  funext fun xs => runFrom_ofWindow go hnil hcons ⟨[], Nat.zero_le _⟩ xs
+
+end OfWindow
 
 end SubsequentialTransducer
 

--- a/Linglib/Core/Data/Fintype/List.lean
+++ b/Linglib/Core/Data/Fintype/List.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fintype.Sigma
+import Mathlib.Data.Fintype.Vector
+
+/-!
+# Finiteness of bounded-length lists
+
+Over a finite alphabet, the lists of length at most `n` form a finite type — the state
+space of window-based transducers.
+-/
+
+/-- The "lists of length at most `n`" subtype is finite when `α` is: it is a surjective
+image of `Σ m : Fin (n + 1), List.Vector α m`. Uses `classical` for the `DecidableEq`
+side condition rather than imposing it on consumers. -/
+noncomputable instance List.fintypeSubtypeLengthLE {α : Type*} [Fintype α] (n : ℕ) :
+    Fintype {l : List α // l.length ≤ n} := by
+  classical
+  exact Fintype.ofSurjective
+    (fun (s : Σ m : Fin (n + 1), List.Vector α m) =>
+      (⟨s.snd.toList, by
+        rw [List.Vector.toList_length]
+        exact Nat.lt_succ_iff.mp s.fst.isLt⟩ :
+        {l : List α // l.length ≤ n}))
+    (fun l => ⟨⟨⟨l.val.length, Nat.lt_succ_iff.mpr l.property⟩,
+                  ⟨l.val, rfl⟩⟩, rfl⟩)

--- a/Linglib/Phonology/Subregular/ISL.lean
+++ b/Linglib/Phonology/Subregular/ISL.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Data.List.Basic
-import Mathlib.Data.Fintype.Sigma
-import Mathlib.Data.Fintype.Vector
+import Linglib.Core.Data.Fintype.List
 import Linglib.Core.Data.List.DropRight
 import Linglib.Core.Computability.Subsequential
 
@@ -50,25 +49,6 @@ threaded window to length `k - 1`.
 namespace Subregular
 
 variable {α β : Type*}
-
-/-- The "list of length at most `n`" subtype is finite when `α` is. The
-witness is a surjection from `Σ m : Fin (n + 1), List.Vector α m` (which
-has a `Fintype` instance via `Mathlib.Data.Fintype.{Sigma,Vector}`). Used
-to give ISL/OSL projections into SubsequentialTransducer a manifestly-finite state space
-(matching [mohri-1997]'s finite-state assumption). Uses `classical`
-to discharge the `DecidableEq` side condition without imposing it on
-consumers (matches mathlib pattern for finite types over `Fintype α`). -/
-noncomputable instance fintypeListLengthLE {α : Type*} [Fintype α] (n : ℕ) :
-    Fintype {l : List α // l.length ≤ n} := by
-  classical
-  exact Fintype.ofSurjective
-    (fun (s : Σ m : Fin (n + 1), List.Vector α m) =>
-      (⟨s.snd.toList, by
-        rw [List.Vector.toList_length]
-        exact Nat.lt_succ_iff.mp s.fst.isLt⟩ :
-        {l : List α // l.length ≤ n}))
-    (fun l => ⟨⟨⟨l.val.length, Nat.lt_succ_iff.mpr l.property⟩,
-                  ⟨l.val, rfl⟩⟩, rfl⟩)
 
 /-- A **k-Input-Strictly-Local rule** over input alphabet `α` and output
 alphabet `β`. The single field `windowOutput` consumes the
@@ -259,44 +239,24 @@ theorem filterMap_isLeftInputStrictlyLocal_one (g : α → Option β) :
 
 /-! ### ISL ⊆ Subsequential
 
-`ISLRule.toFinSubsequentialTransducer` projects an ISL rule into a finite-state
-SubsequentialTransducer whose
-state space is the bounded input window `{l : List α // l.length ≤ k - 1}`.
-The `[Fintype α]` constraint matches the source literature [mohri-1997]:
-every subsequential model has a finite alphabet and finite state by
-definition. The inclusion theorem
-rides on the run-equality. Co-located on the source side because the
-dependency direction (SubsequentialTransducer in `Subsequential.lean`; ISL projects into
+`ISLRule.toFinSubsequentialTransducer` projects an ISL rule into the sliding-window
+transducer `SubsequentialTransducer.ofWindow`, with the bounded *input* window
+`{l : List α // l.length ≤ k - 1}` as state. Co-located on the source side because the
+dependency direction (the transducer lives in `Subsequential.lean`; ISL projects into
 it) forces both construction and cast into this file. -/
 
-/-- Construction: every ISL rule induces a **finite-state** SubsequentialTransducer whose
-state is the bounded input window `{l : List α // l.length ≤ k - 1}`,
-and whose `finalOutput` is empty. The state is manifestly finite via
-`fintypeListLengthLE`, witnessing ISL ⊆ Subsequential under the source
-literature's finite-state assumption. -/
-def ISLRule.toFinSubsequentialTransducer {k : ℕ} [Fintype α] (r : ISLRule k α β) :
-    SubsequentialTransducer {l : List α // l.length ≤ k - 1} α β where
-  start := ⟨[], Nat.zero_le _⟩
-  step w x := ⟨(w.val ++ [x]).rtake (k - 1), List.length_rtake_le _ _⟩
-  output w x := r.windowOutput w.val x
-  finalOutput _ := []
+/-- Every ISL rule induces a window transducer tracking the last `k - 1` *input*
+symbols, with empty `finalOutput`. Finite-state over a finite alphabet
+(`List.fintypeSubtypeLengthLE`), witnessing ISL ⊆ Subsequential under the source
+literature's finite-state assumption [mohri-1997]. -/
+def ISLRule.toFinSubsequentialTransducer {k : ℕ} (r : ISLRule k α β) :
+    SubsequentialTransducer {l : List α // l.length ≤ k - 1} α β :=
+  .ofWindow (k - 1) r.windowOutput fun _ x => [x]
 
-/-- The finite-state SubsequentialTransducer induced by an ISL rule computes the same
-string function. -/
-theorem ISLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} [Fintype α] (r : ISLRule k α β) :
-    r.toFinSubsequentialTransducer.run = r.apply := by
-  funext input
-  show SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer ⟨[], Nat.zero_le _⟩ input
-    = ISLRule.applyAux r [] input
-  suffices h : ∀ (w : {l : List α // l.length ≤ k - 1}),
-      SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer w input = ISLRule.applyAux r
-      w.val input from h _
-  intro w
-  induction input generalizing w with
-  | nil => rfl
-  | cons x xs ih =>
-    rw [SubsequentialTransducer.runFrom_cons]
-    exact congrArg _ (ih _)
+/-- The window transducer induced by an ISL rule computes the same string function. -/
+theorem ISLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} (r : ISLRule k α β) :
+    r.toFinSubsequentialTransducer.run = r.apply :=
+  SubsequentialTransducer.run_ofWindow r.applyAux (fun _ => rfl) fun _ _ _ => rfl
 
 /-- **Left-ISL ⊆ Left-Subsequential** (over a finite input alphabet).
 The `[Fintype α]` matches [mohri-1997]'s finite-alphabet assumption

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -161,43 +161,26 @@ theorem isRightOutputStrictlyLocal_iff_left_reverse {k : ℕ}
 
 /-! ### OSL ⊆ Subsequential
 
-`OSLRule.toFinSubsequentialTransducer` projects an OSL rule into a SubsequentialTransducer whose
-state is
-the bounded output window (length ≤ k − 1). The inclusion rides on the
-run-equality plus the `Fintype` instance for the bounded-window subtype
-(reusing `Subregular.fintypeListLengthLE`). Co-located on the source
-side because the dependency direction (`Subregular.SubsequentialTransducer`; OSL projects
-into it) forces both construction and cast into this file.
+`OSLRule.toFinSubsequentialTransducer` projects an OSL rule into the sliding-window
+transducer `SubsequentialTransducer.ofWindow`, with the bounded *output* window
+(length ≤ k − 1) as state. Co-located on the source side because the dependency
+direction (the transducer lives in `Subsequential.lean`; OSL projects into it) forces
+both construction and cast into this file.
 
 The output alphabet `[Fintype β]` constraint matches [mohri-1997]'s
 finite-alphabet assumption — the state space (a bounded output window)
 is finite precisely when the output alphabet is. -/
 
-/-- Construction: every Left-OSL rule induces a SubsequentialTransducer whose state is the
-output window — a list of output symbols of length at most `k − 1` —
-and whose `finalOutput` is empty. -/
+/-- Every Left-OSL rule induces a window transducer tracking the last `k − 1` *output*
+symbols (the window accumulates what `windowOutput` emits), with empty `finalOutput`. -/
 def OSLRule.toFinSubsequentialTransducer {k : ℕ} (r : OSLRule k α β) :
-    SubsequentialTransducer {l : List β // l.length ≤ k - 1} α β where
-  start := ⟨[], Nat.zero_le _⟩
-  step w x := ⟨(w.val ++ r.windowOutput w.val x).rtake (k - 1), List.length_rtake_le _ _⟩
-  output w x := r.windowOutput w.val x
-  finalOutput _ := []
+    SubsequentialTransducer {l : List β // l.length ≤ k - 1} α β :=
+  .ofWindow (k - 1) r.windowOutput r.windowOutput
 
-/-- The SubsequentialTransducer induced by an OSL rule computes the same string function. -/
+/-- The window transducer induced by an OSL rule computes the same string function. -/
 theorem OSLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} (r : OSLRule k α β) :
-    r.toFinSubsequentialTransducer.run = r.apply := by
-  funext input
-  show SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer ⟨[], Nat.zero_le _⟩ input
-         = OSLRule.applyAux r [] input
-  suffices h : ∀ w : {l : List β // l.length ≤ k - 1},
-      SubsequentialTransducer.runFrom r.toFinSubsequentialTransducer w input = OSLRule.applyAux r
-      w.val input from h _
-  intro w
-  induction input generalizing w with
-  | nil => rfl
-  | cons x xs ih =>
-    rw [SubsequentialTransducer.runFrom_cons]
-    exact congrArg _ (ih _)
+    r.toFinSubsequentialTransducer.run = r.apply :=
+  SubsequentialTransducer.run_ofWindow r.applyAux (fun _ => rfl) fun _ _ _ => rfl
 
 /-- **Left-OSL ⊆ Left-Subsequential** (over a finite output alphabet).
 The `[Fintype β]` matches [mohri-1997]'s finite-alphabet assumption

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -297,20 +297,33 @@ lemma toIdTierSubsequentialTransducer_runFrom_eq_applyToStringAux (r : TierRule 
     rw [ih (past ++ [x]), ← r.applyAt_eq_predictFromCtx h_id h_side]
     rfl
 
+/-- Under identity tier + left side, the transducer computes `applyToString`
+(`none = lastContextOf []` definitionally). -/
+lemma toIdTierSubsequentialTransducer_run (r : TierRule α)
+    (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) :
+    r.toIdTierSubsequentialTransducer.run = r.applyToString := by
+  funext input
+  show r.toIdTierSubsequentialTransducer.runFrom none input =
+    applyToString.applyToStringAux r input []
+  exact r.toIdTierSubsequentialTransducer_runFrom_eq_applyToStringAux h_id h_side [] input
+
 /-- **Identity-tier left-side TierRules reify to Left-Subsequential
 functions.** Closes audit D6 with a real witness construction (not a
 sorry): the SubsequentialTransducer has state `Option α` (last-context-matching segment
 seen) and emits the rule's prediction at each step. -/
 theorem applyToString_isLeftSubsequential_of_id_tier [Fintype α]
     (r : TierRule α) (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) :
-    IsLeftSubsequential r.applyToString := by
-  have h_run : r.toIdTierSubsequentialTransducer.run = r.applyToString := by
-    funext input
-    show r.toIdTierSubsequentialTransducer.runFrom none input =
-      applyToString.applyToStringAux r input []
-    -- `none = lastContextOf []` definitionally
-    exact r.toIdTierSubsequentialTransducer_runFrom_eq_applyToStringAux h_id h_side [] input
-  exact h_run ▸ r.toIdTierSubsequentialTransducer.isLeftSubsequential
+    IsLeftSubsequential r.applyToString :=
+  r.toIdTierSubsequentialTransducer_run h_id h_side ▸
+    r.toIdTierSubsequentialTransducer.isLeftSubsequential
+
+/-- The identity-tier transducer emits one symbol per input symbol with no final flush,
+so the map is Mealy-computable — the machine form of the myopia results below. -/
+theorem applyToString_isMealyComputable_of_id_tier [Fintype α]
+    (r : TierRule α) (h_id : r.tier = TierProjection.id) (h_side : r.side = .left) :
+    IsMealyComputable r.applyToString :=
+  r.toIdTierSubsequentialTransducer_run h_id h_side ▸
+    r.toIdTierSubsequentialTransducer.isMealyComputable (fun _ _ => rfl) fun _ => rfl
 
 /-! ### Myopia: the tier-rule prediction has no look-ahead -/
 

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -99,7 +99,7 @@ Per CLAUDE.md "stimulus contrasts" discipline for Studies files:
   directly; this is the natural next arc.
 * Models the bidirectional map directly (`maasai`: raise a recessive iff
   a dominant occurs anywhere) rather than as an explicit two-pass
-  composition `leftwardATR.runRight ∘ rightwardATR.run`, and omits the
+  composition of a rightward and a leftward transducer, and omits the
   opaque /a/ blocking — the non-opaque core already exhibits weak
   determinism and the WD/ND covariation contrast.
 
@@ -201,26 +201,6 @@ def rightwardATR_osl : OSLRule 2 Seg Seg where
     | .recL, .recH :: _ => [.recH]
     | .recL, _ => [.recL]
 
-/-- Equivalent SubsequentialTransducer for the same map: state tracks whether spread is
-active. Demonstrates that the rule has both an OSL representation
-(above) and a Subsequential representation (here) — the latter being
-the umbrella class. -/
-def rightwardATR : SubsequentialTransducer Bool Seg Seg where
-  start := false
-  step spreading s :=
-    match s with
-    | .a => false
-    | .dom => true
-    | .recH => true
-    | .recL => spreading
-  output spreading s :=
-    match s with
-    | .a => [.a]
-    | .dom => [.recH]
-    | .recH => [.recH]
-    | .recL => if spreading then [.recH] else [.recL]
-  finalOutput _ := []
-
 -- ============================================================================
 -- § 3: Worked Examples (paper p. 1193, ex 1a, simplified)
 -- ============================================================================
@@ -231,36 +211,21 @@ the following recessive vowel.
 Toy encoding of the rightward portion of /kɪ-√noŋ-ʊ/ → [ki-√noŋ-u]:
 input `[dom, recL]` (a dominant root vowel followed by a recessive
 suffix vowel) → output `[recH, recH]`. -/
-example : rightwardATR.run [.dom, .recL] = [.recH, .recH] := by decide
-
 example : rightwardATR_osl.apply [.dom, .recL] = [.recH, .recH] := by decide
 
 /-- **Ex 1a-ii (rightward half)**: spread continues across multiple
 recessive vowels. -/
-example : rightwardATR.run [.dom, .recL, .recL] = [.recH, .recH, .recH] := by
-  decide
-
 example : rightwardATR_osl.apply [.dom, .recL, .recL] = [.recH, .recH, .recH] := by
   decide
 
 /-- **Blocking**: /a/ blocks rightward spread; recessive vowels after
 /a/ remain [-ATR]. -/
-example : rightwardATR.run [.dom, .a, .recL] = [.recH, .a, .recL] := by decide
-
 example : rightwardATR_osl.apply [.dom, .a, .recL] = [.recH, .a, .recL] := by
   decide
 
 /-- **No spread without dominant trigger**: a string of recessive vowels
 with no dominant root passes through unchanged. -/
-example : rightwardATR.run [.recL, .recL] = [.recL, .recL] := by decide
-
 example : rightwardATR_osl.apply [.recL, .recL] = [.recL, .recL] := by decide
-
-/-- **Two SubsequentialTransducers / OSL rules agree** on the encoded examples. (Full
-extensional equivalence on all inputs would require a separate
-induction; this is the expected agreement on paper-cited cases.) -/
-example : rightwardATR.run [.dom, .recL, .a, .recL]
-        = rightwardATR_osl.apply [.dom, .recL, .a, .recL] := by decide
 
 -- ============================================================================
 -- § 4: Subregular Classification
@@ -278,15 +243,9 @@ theorem rightwardATR_osl_isLeftOutputStrictlyLocal :
     IsLeftOutputStrictlyLocal 2 rightwardATR_osl.apply :=
   rightwardATR_osl.isLeftOutputStrictlyLocal_apply
 
-/-- **Rightward [+ATR] spreading is also Left-Subsequential** (a weaker
-claim than OSL but the umbrella class). Witness: the SubsequentialTransducer. -/
-theorem rightwardATR_isLeftSubsequential :
-    IsLeftSubsequential rightwardATR.run :=
-  rightwardATR.isLeftSubsequential
-
-/-- Since OSL ⊆ Left-Subsequential
-(`isLeftOutputStrictlyLocal_left_subsequential`), the OSL classification
-automatically lifts. -/
+/-- **Rightward [+ATR] spreading is also Left-Subsequential** — the umbrella class,
+lifted from the OSL classification via OSL ⊆ Left-Subsequential
+(`isLeftOutputStrictlyLocal_left_subsequential`). -/
 theorem rightwardATR_osl_isLeftSubsequential :
     IsLeftSubsequential rightwardATR_osl.apply :=
   isLeftOutputStrictlyLocal_left_subsequential


### PR DESCRIPTION
Adds `SubsequentialTransducer.ofWindow` (sliding-window transducer) with a master run-equality, so the verbatim-duplicated ISL/OSL window constructions and their identical inductions collapse to one-line instantiations.

- `fintypeListLengthLE` moves from `ISL.lean` to `Core/Data/Fintype/List.lean` as `List.fintypeSubtypeLengthLE` (pure math, was stranded in Phonology)
- deletes MeinhardtEtAl2024's redundant hand-rolled `rightwardATR` transducer and its decide-table "agreement" examples — the OSL rule already carries both classifications
- TierRule: run-equality factored out of the subsequentiality proof; adds `applyToString_isMealyComputable_of_id_tier` (its unconditional myopia lemmas stay — they cover all rules, not just the id-tier case)
- `Subsequential.lean` module docstring tightened to mathlib register