### PR TITLE
refactor(Core/Computability): map transport primitive, windowRun

### DIFF
--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -154,55 +154,56 @@ theorem getElem?_run (w : B.LetterToLetter) (x : List α) (i : ℕ) :
 
 end LetterToLetter
 
-/-! ### Reindexing states -/
+/-! ### Transport along state equivalences -/
 
 variable {L' R' : Type*}
 
-/-- Lifts equivalences on the two state spaces to an equivalence on bimachines. -/
-@[simps apply_lInit apply_lStep apply_rInit apply_rStep apply_output]
+/-- Transport a bimachine along equivalences on the two state spaces. -/
+@[simps]
+def map (eL : L ≃ L') (eR : R ≃ R') (B : Bimachine L R α β) : Bimachine L' R' α β where
+  lInit := eL B.lInit
+  lStep l a := eL (B.lStep (eL.symm l) a)
+  rInit := eR B.rInit
+  rStep r a := eR (B.rStep (eR.symm r) a)
+  output l a r := B.output (eL.symm l) a (eR.symm r)
+
+@[simp] theorem map_refl : map (Equiv.refl L) (Equiv.refl R) B = B := rfl
+
+@[simp] theorem map_map {L'' R'' : Type*} (eL : L ≃ L') (eR : R ≃ R') (eL' : L' ≃ L'')
+    (eR' : R' ≃ R'') : map eL' eR' (map eL eR B) = map (eL.trans eL') (eR.trans eR') B := rfl
+
+@[simp] theorem lStateAfter_map (eL : L ≃ L') (eR : R ≃ R') (l' : L') (pre : List α) :
+    (map eL eR B).lStateAfter l' pre = eL (B.lStateAfter (eL.symm l') pre) := by
+  induction pre generalizing l' <;> simp [*]
+
+@[simp] theorem lState_map (eL : L ≃ L') (eR : R ≃ R') (pre : List α) :
+    (map eL eR B).lState pre = eL (B.lState pre) := by
+  simp [lState]
+
+@[simp] theorem rState_map (eL : L ≃ L') (eR : R ≃ R') (suf : List α) :
+    (map eL eR B).rState suf = eR (B.rState suf) :=
+  List.foldr_hom eR fun x y => by simp
+
+@[simp] theorem runFrom_map (eL : L ≃ L') (eR : R ≃ R') (l' : L') (xs : List α) :
+    (map eL eR B).runFrom l' xs = B.runFrom (eL.symm l') xs := by
+  induction xs generalizing l' <;> simp [*]
+
+@[simp] theorem run_map (eL : L ≃ L') (eR : R ≃ R') :
+    (map eL eR B).run = B.run := by
+  funext xs; simp [run]
+
+/-- `map` as an equivalence of bimachines. -/
 def reindex (eL : L ≃ L') (eR : R ≃ R') : Bimachine L R α β ≃ Bimachine L' R' α β where
-  toFun B := {
-    lInit := eL B.lInit
-    lStep := fun l a => eL (B.lStep (eL.symm l) a)
-    rInit := eR B.rInit
-    rStep := fun r a => eR (B.rStep (eR.symm r) a)
-    output := fun l a r => B.output (eL.symm l) a (eR.symm r)
-  }
-  invFun B := {
-    lInit := eL.symm B.lInit
-    lStep := fun l a => eL.symm (B.lStep (eL l) a)
-    rInit := eR.symm B.rInit
-    rStep := fun r a => eR.symm (B.rStep (eR r) a)
-    output := fun l a r => B.output (eL l) a (eR r)
-  }
+  toFun := map eL eR
+  invFun := map eL.symm eR.symm
   left_inv B := by simp
   right_inv B := by simp
 
-@[simp] theorem reindex_refl : reindex (Equiv.refl L) (Equiv.refl R) B = B := rfl
+@[simp] theorem coe_reindex (eL : L ≃ L') (eR : R ≃ R') :
+    ⇑(reindex (α := α) (β := β) eL eR) = map eL eR := rfl
 
 @[simp] theorem symm_reindex (eL : L ≃ L') (eR : R ≃ R') :
     (reindex (α := α) (β := β) eL eR).symm = reindex eL.symm eR.symm := rfl
-
-@[simp] theorem lStateAfter_reindex (eL : L ≃ L') (eR : R ≃ R') (l' : L') (pre : List α) :
-    (reindex eL eR B).lStateAfter l' pre = eL (B.lStateAfter (eL.symm l') pre) := by
-  induction pre generalizing l' <;> simp [*]
-
-@[simp] theorem lState_reindex (eL : L ≃ L') (eR : R ≃ R') (pre : List α) :
-    (reindex eL eR B).lState pre = eL (B.lState pre) := by
-  simp [lState]
-
-@[simp] theorem rState_reindex (eL : L ≃ L') (eR : R ≃ R') (suf : List α) :
-    (reindex eL eR B).rState suf = eR (B.rState suf) :=
-  List.foldr_hom eR fun x y => by simp
-
-@[simp] theorem runFrom_reindex (eL : L ≃ L') (eR : R ≃ R') (l' : L') (xs : List α) :
-    (reindex eL eR B).runFrom l' xs = B.runFrom (eL.symm l') xs := by
-  induction xs generalizing l' <;> simp [*]
-
-/-- The reindexed bimachine computes the same string function. -/
-@[simp] theorem run_reindex (eL : L ≃ L') (eR : R ≃ R') :
-    (reindex eL eR B).run = B.run := by
-  funext xs; simp [run]
 
 /-- Cells agree exactly when the underlying word-valued outputs do. -/
 theorem LetterToLetter.cell_inj {B : Bimachine L R α β} (w : B.LetterToLetter)
@@ -211,8 +212,8 @@ theorem LetterToLetter.cell_inj {B : Bimachine L R α β} (w : B.LetterToLetter)
   rw [w.output_eq, w.output_eq]; simp
 
 /-- Letter-to-letter-ness transports along state reindexing. -/
-def LetterToLetter.reindex {L' R' : Type*} {B : Bimachine L R α β} (w : B.LetterToLetter)
-    (eL : L ≃ L') (eR : R ≃ R') : (Bimachine.reindex eL eR B).LetterToLetter :=
+def LetterToLetter.map {L' R' : Type*} {B : Bimachine L R α β} (w : B.LetterToLetter)
+    (eL : L ≃ L') (eR : R ≃ R') : (Bimachine.map eL eR B).LetterToLetter :=
   ⟨fun l a r => w.cell (eL.symm l) a (eR.symm r), fun _ _ _ => w.output_eq _ _ _⟩
 
 /-! ### Flag bimachines
@@ -346,19 +347,18 @@ theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting)
     (hne : B.output l a r ≠ [a]) : B.OneSidedAt l a r :=
   h.elim fun w => w.oneSidedAt_of_change hne
 
-/-- Transports a decomposition along state reindexing: the rules compose with
-`eL.symm` and `eR.symm`. -/
-def NonInteraction.reindex (eL : L ≃ L') (eR : R ≃ R') :
-    (Bimachine.reindex eL eR B).NonInteraction where
+/-- Transport a decomposition along state equivalences. -/
+def NonInteraction.map (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.map eL eR B).NonInteraction where
   ruleL l a := w.ruleL (eL.symm l) a
   ruleR r a := w.ruleR (eR.symm r) a
   unite_comm _ a _ := w.unite_comm _ a _
   output_eq _ a _ := w.output_eq _ a _
 
 /-- Non-interaction transports along state reindexing. -/
-theorem IsNonInteracting.reindex (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
-    (Bimachine.reindex eL eR B).IsNonInteracting :=
-  h.map (·.reindex eL eR)
+theorem IsNonInteracting.map (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.map eL eR B).IsNonInteracting :=
+  Nonempty.map (·.map eL eR) h
 
 /-- A decomposed bimachine fixes cell `i` exactly when both change-proposals are inert
 at its two context states. -/
@@ -413,8 +413,8 @@ theorem isBimachineComputable_iff.{v, w} {f : List α → List β} :
       ↔ ∃ (L : Type v) (_ : Fintype L) (R : Type w) (_ : Fintype R)
           (B : Bimachine L R α β), B.run = f :=
   exists_fintype₂_congr
-    (fun eL eR ⟨B, hB⟩ => ⟨.reindex eL eR B, (B.run_reindex eL eR).trans hB⟩)
-    (fun eL eR ⟨B, hB⟩ => ⟨.reindex eL eR B, (B.run_reindex eL eR).trans hB⟩)
+    (fun eL eR ⟨B, hB⟩ => ⟨.map eL eR B, (B.run_map eL eR).trans hB⟩)
+    (fun eL eR ⟨B, hB⟩ => ⟨.map eL eR B, (B.run_map eL eR).trans hB⟩)
 
 /-- Every finite-state bimachine computes a bimachine-computable function, whatever
 the universes of its state types. -/
@@ -436,9 +436,9 @@ theorem isLengthPreservingBimachineComputable_iff.{v, w} {f : List α → List �
           (B : Bimachine L R α β), B.IsLetterToLetter ∧ B.run = f :=
   exists_fintype₂_congr
     (fun eL eR ⟨B, ⟨w⟩, hB⟩ =>
-      ⟨.reindex eL eR B, ⟨w.reindex eL eR⟩, (B.run_reindex eL eR).trans hB⟩)
+      ⟨.map eL eR B, ⟨w.map eL eR⟩, (B.run_map eL eR).trans hB⟩)
     (fun eL eR ⟨B, ⟨w⟩, hB⟩ =>
-      ⟨.reindex eL eR B, ⟨w.reindex eL eR⟩, (B.run_reindex eL eR).trans hB⟩)
+      ⟨.map eL eR B, ⟨w.map eL eR⟩, (B.run_map eL eR).trans hB⟩)
 
 /-- A length-preserving bimachine-computable function is bimachine-computable. -/
 theorem IsBimachineComputable.of_lengthPreserving {f : List α → List β}
@@ -476,13 +476,13 @@ theorem isNonInteractingBimachineComputable_iff.{v, w} {f : List α → List α}
           (B : Bimachine L R α α), B.run = f ∧ B.IsNonInteracting :=
   exists_fintype₂_congr
     (fun eL eR ⟨B, hB, h⟩ =>
-      ⟨.reindex eL eR B, (B.run_reindex eL eR).trans hB, h.reindex eL eR⟩)
+      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
     (fun eL eR ⟨B, hB, h⟩ =>
-      ⟨.reindex eL eR B, (B.run_reindex eL eR).trans hB, h.reindex eL eR⟩)
+      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
 
 /-- A non-interacting finite-state bimachine witnesses
 `IsNonInteractingBimachineComputable` for its `run`, whatever the universes of its
-state types (`IsNonInteracting.reindex`). -/
+state types (`IsNonInteracting.map`). -/
 theorem Bimachine.isNonInteractingBimachineComputable {L R : Type*} [Fintype L]
     [Fintype R] (B : Bimachine L R α α) (h : B.IsNonInteracting) :
     IsNonInteractingBimachineComputable B.run :=

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -29,7 +29,7 @@ instance must be supplied for the finite-state class `IsMealyComputable`.
 * `Mealy.comp`: the cascade connection, computing the composite function
 * `Mealy.ofFn`: the single-state machine applying a fixed symbol map letter-wise
 * `Mealy.ofFlag`: the one-bit machine tracking whether an earlier symbol satisfies `p`
-* `Mealy.reindex`: lifts an equivalence on states to an equivalence on machines
+* `Mealy.map`: transport along an equivalence on states
 * `IsMealyComputable f`: `f` is computed by some finite-state `Mealy`
 * `DFA.comapMealy`: pulls an acceptor back along a transducer
 
@@ -59,7 +59,8 @@ residuals is in `Core/Computability/MyhillNerode.lean`.
 
 ## TODO
 
-* Mealy machine homomorphisms [holcombe-1982], with `reindex` as the isomorphism case.
+* Mealy machine homomorphisms [holcombe-1982], with `map` at an equivalence as the
+  isomorphism case.
 * The right-scan mirror via reverse conjugation.
 * Moore machines (state-determined output) and the Mealy–Moore equivalence: same
   states one way, `σ × β` states the other, so the computable classes coincide.
@@ -163,7 +164,7 @@ section Comp
 variable {γ σ' : Type*} (T₂ : Mealy σ' β γ) (T₁ : Mealy σ α β)
 
 /-- `T₂.comp T₁` feeds the outputs of `T₁` to `T₂` — the cascade connection of
-[holcombe-1982] — computing `T₂.run ∘ T₁.run` (`run_comp`). -/
+[holcombe-1982] — computing `T₂.run ∘ T₁.run`. -/
 @[simps]
 def comp : Mealy (σ' × σ) α γ where
   initial := (T₂.initial, T₁.initial)
@@ -228,42 +229,44 @@ theorem getElem?_ofFlag_runRight (xs : List α) (i : ℕ) :
   | nil => simp
   | cons x xs ih => cases i <;> simp [*]
 
-/-! ### Reindexing states -/
+/-! ### Transport along state equivalences -/
 
 variable {τ : Type*}
 
-/-- Lifts an equivalence on states to an equivalence on Mealy machines. -/
-@[simps apply_initial apply_step apply_output]
+/-- Transport a Mealy machine along an equivalence on states. -/
+@[simps]
+def map (g : σ ≃ τ) (T : Mealy σ α β) : Mealy τ α β where
+  initial := g T.initial
+  step t x := g (T.step (g.symm t) x)
+  output t x := T.output (g.symm t) x
+
+@[simp] theorem map_refl : map (Equiv.refl σ) T = T := rfl
+
+@[simp] theorem map_map {υ : Type*} (g : σ ≃ τ) (h : τ ≃ υ) :
+    map h (map g T) = map (g.trans h) T := rfl
+
+@[simp] theorem stateAfter_map (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (map g T).stateAfter t xs = g (T.stateAfter (g.symm t) xs) := by
+  induction xs generalizing t <;> simp [*]
+
+@[simp] theorem runFrom_map (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (map g T).runFrom t xs = T.runFrom (g.symm t) xs := by
+  induction xs generalizing t <;> simp [*]
+
+@[simp] theorem run_map (g : σ ≃ τ) : (map g T).run = T.run := by
+  funext xs; simp [run]
+
+/-- `map` as an equivalence of machines. -/
 def reindex (g : σ ≃ τ) : Mealy σ α β ≃ Mealy τ α β where
-  toFun T := {
-    initial := g T.initial
-    step := fun t x => g (T.step (g.symm t) x)
-    output := fun t x => T.output (g.symm t) x
-  }
-  invFun T := {
-    initial := g.symm T.initial
-    step := fun s x => g.symm (T.step (g s) x)
-    output := fun s x => T.output (g s) x
-  }
+  toFun := map g
+  invFun := map g.symm
   left_inv T := by simp
   right_inv T := by simp
 
-@[simp] theorem reindex_refl : reindex (Equiv.refl σ) T = T := rfl
+@[simp] theorem coe_reindex (g : σ ≃ τ) : ⇑(reindex (α := α) (β := β) g) = map g := rfl
 
 @[simp] theorem symm_reindex (g : σ ≃ τ) :
     (reindex (α := α) (β := β) g).symm = reindex g.symm := rfl
-
-@[simp] theorem stateAfter_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
-    (reindex g T).stateAfter t xs = g (T.stateAfter (g.symm t) xs) := by
-  induction xs generalizing t <;> simp [*]
-
-@[simp] theorem runFrom_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
-    (reindex g T).runFrom t xs = T.runFrom (g.symm t) xs := by
-  induction xs generalizing t <;> simp [*]
-
-/-- The reindexed machine computes the same string function. -/
-@[simp] theorem run_reindex (g : σ ≃ τ) : (reindex g T).run = T.run := by
-  funext xs; simp [run]
 
 end Mealy
 
@@ -273,15 +276,13 @@ end Mealy
 def IsMealyComputable (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : Mealy σ α β), T.run = f
 
-/-- `f` is Mealy-computable if and only if it is computed by a finite-state `Mealy`
-machine. This is more general than using the definition of `IsMealyComputable`
-directly, as the state type `σ` is universe-polymorphic. -/
+/-- The universe-polymorphic form of `IsMealyComputable`. -/
 theorem isMealyComputable_iff.{v} {f : List α → List β} :
     IsMealyComputable f
       ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : Mealy σ α β), T.run = f :=
   exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨Mealy.reindex e T, (T.run_reindex e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨Mealy.reindex e T, (T.run_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨Mealy.map e T, (T.run_map e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨Mealy.map e T, (T.run_map e).trans hT⟩)
 
 /-- Every finite-state `Mealy` computes a Mealy-computable function, whatever the
 universe of its state type. -/

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -138,8 +138,6 @@ theorem emitted_append (s : σ) (xs ys : List α) :
     T.emitted s (xs ++ ys) = T.emitted s xs ++ T.emitted (T.stateAfter s xs) ys := by
   induction xs generalizing s <;> simp [*]
 
-/-- Running on `xs ++ ys` emits the output over `xs`, then runs on `ys` from the
-reached state. -/
 theorem runFrom_append (s : σ) (xs ys : List α) :
     T.runFrom s (xs ++ ys) = T.emitted s xs ++ T.runFrom (T.stateAfter s xs) ys := by
   simp [runFrom, emitted_append, stateAfter_append]
@@ -148,51 +146,53 @@ theorem run_append (xs ys : List α) :
     T.run (xs ++ ys) = T.emitted T.start xs ++ T.runFrom (T.stateAfter T.start xs) ys :=
   T.runFrom_append T.start xs ys
 
-/-! ### Reindexing states -/
+/-! ### Transport along state equivalences -/
 
 variable {τ : Type*}
 
-/-- Lifts an equivalence on states to an equivalence on subsequential transducers. -/
-@[simps apply_start apply_step apply_output apply_finalOutput]
+/-- Transport a transducer along an equivalence on states. -/
+@[simps]
+def map (g : σ ≃ τ) (T : SubsequentialTransducer σ α β) : SubsequentialTransducer τ α β where
+  start := g T.start
+  step t x := g (T.step (g.symm t) x)
+  output t x := T.output (g.symm t) x
+  finalOutput t := T.finalOutput (g.symm t)
+
+@[simp] theorem map_refl : map (Equiv.refl σ) T = T := rfl
+
+@[simp] theorem map_map {υ : Type*} (g : σ ≃ τ) (h : τ ≃ υ) :
+    map h (map g T) = map (g.trans h) T := rfl
+
+@[simp] theorem stateAfter_map (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (map g T).stateAfter t xs = g (T.stateAfter (g.symm t) xs) := by
+  induction xs generalizing t <;> simp [*]
+
+@[simp] theorem emitted_map (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (map g T).emitted t xs = T.emitted (g.symm t) xs := by
+  induction xs generalizing t <;> simp [*]
+
+@[simp] theorem runFrom_map (g : σ ≃ τ) (t : τ) (xs : List α) :
+    (map g T).runFrom t xs = T.runFrom (g.symm t) xs := by
+  simp [runFrom]
+
+@[simp] theorem run_map (g : σ ≃ τ) : (map g T).run = T.run := by
+  funext xs; simp [run]
+
+@[simp] theorem runRight_map (g : σ ≃ τ) : (map g T).runRight = T.runRight := by
+  funext xs; simp [runRight]
+
+/-- `map` as an equivalence of machines. -/
 def reindex (g : σ ≃ τ) : SubsequentialTransducer σ α β ≃ SubsequentialTransducer τ α β where
-  toFun T := {
-    start := g T.start
-    step := fun t x => g (T.step (g.symm t) x)
-    output := fun t x => T.output (g.symm t) x
-    finalOutput := fun t => T.finalOutput (g.symm t)
-  }
-  invFun T := {
-    start := g.symm T.start
-    step := fun s x => g.symm (T.step (g s) x)
-    output := fun s x => T.output (g s) x
-    finalOutput := fun s => T.finalOutput (g s)
-  }
+  toFun := map g
+  invFun := map g.symm
   left_inv T := by simp
   right_inv T := by simp
 
-@[simp] theorem reindex_refl : reindex (Equiv.refl σ) T = T := rfl
+@[simp] theorem coe_reindex (g : σ ≃ τ) :
+    ⇑(reindex (α := α) (β := β) g) = map g := rfl
 
 @[simp] theorem symm_reindex (g : σ ≃ τ) :
     (reindex (α := α) (β := β) g).symm = reindex g.symm := rfl
-
-@[simp] theorem stateAfter_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
-    (reindex g T).stateAfter t xs = g (T.stateAfter (g.symm t) xs) := by
-  induction xs generalizing t <;> simp [*]
-
-@[simp] theorem emitted_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
-    (reindex g T).emitted t xs = T.emitted (g.symm t) xs := by
-  induction xs generalizing t <;> simp [*]
-
-@[simp] theorem runFrom_reindex (g : σ ≃ τ) (t : τ) (xs : List α) :
-    (reindex g T).runFrom t xs = T.runFrom (g.symm t) xs := by
-  simp [runFrom]
-
-/-- The reindexed machine computes the same string function. -/
-@[simp] theorem run_reindex (g : σ ≃ τ) : (reindex g T).run = T.run := by
-  funext xs; simp [run]
-
-@[simp] theorem runRight_reindex (g : σ ≃ τ) : (reindex g T).runRight = T.runRight := by
-  funext xs; simp [runRight]
 
 /-! ### Composition -/
 
@@ -201,7 +201,7 @@ section Comp
 variable {γ σ' : Type*} (T₂ : SubsequentialTransducer σ' β γ) (T₁ : SubsequentialTransducer σ α β)
 
 /-- `T₂.comp T₁` feeds each output block of `T₁` to `T₂` — the classical product
-construction [mohri-1997] — computing `T₂.run ∘ T₁.run` (`run_comp`). -/
+construction [mohri-1997] — computing `T₂.run ∘ T₁.run`. -/
 @[simps]
 def comp : SubsequentialTransducer (σ' × σ) α γ where
   start := (T₂.start, T₁.start)
@@ -226,10 +226,9 @@ section OfWindow
 
 variable {γ : Type*}
 
-/-- The sliding-window transducer: the state is a window of at most `n` symbols of `γ`,
-`out` emits an output block from the window and the current symbol, and `upd` chooses
-what the window accumulates — `fun _ x => [x]` tracks the input, `out` itself the
-output. -/
+/-- The transducer whose state is a window of the last `n` accumulated symbols. `out`
+emits from the window and the current symbol; `upd` chooses what the window accumulates
+(`fun _ x => [x]` for the input, `out` for the output). -/
 @[simps]
 def ofWindow (n : ℕ) (out : List γ → α → List β) (upd : List γ → α → List γ) :
     SubsequentialTransducer {l : List γ // l.length ≤ n} α β where
@@ -238,23 +237,23 @@ def ofWindow (n : ℕ) (out : List γ → α → List β) (upd : List γ → α 
   output w x := out w.val x
   finalOutput _ := []
 
+/-- The window recursion computed by `ofWindow`; each step emits `out` and extends the
+window by `upd`, truncated to length `n`. -/
+def windowRun (n : ℕ) (out : List γ → α → List β) (upd : List γ → α → List γ) :
+    List γ → List α → List β
+  | _, [] => []
+  | w, x :: xs => out w x ++ windowRun n out upd ((w ++ upd w x).rtake n) xs
+
 variable {n : ℕ} {out : List γ → α → List β} {upd : List γ → α → List γ}
 
-/-- The window transducer runs any recursion that emits `out` and extends the window by
-`upd` — the master run-equality behind the ISL/OSL projections. -/
-theorem runFrom_ofWindow (go : List γ → List α → List β) (hnil : ∀ w, go w [] = [])
-    (hcons : ∀ w x xs, go w (x :: xs) = out w x ++ go ((w ++ upd w x).rtake n) xs) :
-    ∀ (w : {l : List γ // l.length ≤ n}) (xs : List α),
-      (ofWindow n out upd).runFrom w xs = go w.val xs := by
-  intro w xs
+theorem runFrom_ofWindow (w : {l : List γ // l.length ≤ n}) (xs : List α) :
+    (ofWindow n out upd).runFrom w xs = windowRun n out upd w.val xs := by
   induction xs generalizing w with
-  | nil => simp [hnil]
-  | cons x xs ih => rw [runFrom_cons, hcons]; exact congrArg _ (ih _)
+  | nil => simp [windowRun]
+  | cons x xs ih => rw [runFrom_cons, windowRun]; exact congrArg _ (ih _)
 
-theorem run_ofWindow (go : List γ → List α → List β) (hnil : ∀ w, go w [] = [])
-    (hcons : ∀ w x xs, go w (x :: xs) = out w x ++ go ((w ++ upd w x).rtake n) xs) :
-    (ofWindow n out upd).run = go [] :=
-  funext fun xs => runFrom_ofWindow go hnil hcons ⟨[], Nat.zero_le _⟩ xs
+theorem run_ofWindow : (ofWindow n out upd).run = windowRun n out upd [] :=
+  funext fun xs => runFrom_ofWindow ⟨[], Nat.zero_le _⟩ xs
 
 end OfWindow
 
@@ -356,25 +355,21 @@ def IsSubsequential (d : Direction) (f : List α → List β) : Prop :=
 @[simp] theorem isSubsequential_right_iff :
     IsSubsequential .right f ↔ IsRightSubsequential f := Iff.rfl
 
-/-- `f` is left-subsequential if and only if it is computed by a finite-state
-transducer. This is more general than using the definition of `IsLeftSubsequential`
-directly, as the state type `σ` is universe-polymorphic. -/
+/-- The universe-polymorphic form of `IsLeftSubsequential`. -/
 theorem isLeftSubsequential_iff.{v} :
     IsLeftSubsequential f
       ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f :=
   exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.run_reindex e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.run_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.run_map e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.run_map e).trans hT⟩)
 
-/-- `f` is right-subsequential if and only if it is computed via `runRight` by a
-finite-state transducer. This is more general than using the definition of
-`IsRightSubsequential` directly, as the state type `σ` is universe-polymorphic. -/
+/-- The universe-polymorphic form of `IsRightSubsequential`. -/
 theorem isRightSubsequential_iff.{v} :
     IsRightSubsequential f
       ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f :=
   exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.reindex e T, (T.runRight_reindex e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.runRight_map e).trans hT⟩)
+    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.runRight_map e).trans hT⟩)
 
 /-- Every finite-state transducer computes a left-subsequential function, whatever the
 universe of its state type. -/
@@ -420,11 +415,10 @@ theorem isRightSubsequential_iff_left_reverse :
    fun ⟨σ, _, T, hT⟩ =>
      ⟨σ, inferInstance, T, by funext xs; simp [SubsequentialTransducer.runRight, hT]⟩⟩
 
-/-- A left-subsequential function has bounded delay: on any input `u` it has already
-emitted a prefix of `f u` shared with `f (u ++ v)` for every continuation `v`,
-withholding at most the longest state-final output. This is immediate from having a
-state-final output at all, and is much weaker than [choffrut-1977]'s bounded-variation
-characterization — it compares `u` only with its own extensions. -/
+/-- A left-subsequential function withholds at most the longest state-final output:
+`f u` and `f (u ++ v)` share a prefix covering all but boundedly many symbols of `f u`.
+Much weaker than [choffrut-1977]'s bounded-variation characterization — this compares
+`u` only with its own extensions. -/
 theorem IsLeftSubsequential.bounded_delay (hf : IsLeftSubsequential f) :
     ∃ N : ℕ, ∀ u v : List α, ∃ p su sv : List β,
       f u = p ++ su ∧ f (u ++ v) = p ++ sv ∧ su.length ≤ N := by
@@ -449,7 +443,7 @@ theorem IsLeftSubsequential.exists_getElem?_append_eq (hf : IsLeftSubsequential 
 
 /-- `f` is not left-subsequential if for every `N` some images `f u` and `f (u ++ v)`
 disagree more than `N` positions before the end of `f u` — the contrapositive of
-`bounded_delay`, since no bound on the withheld suffix can then exist. -/
+`bounded_delay`. -/
 theorem not_isLeftSubsequential_of_diverging
     (h : ∀ N, ∃ (u v : List α) (i : ℕ),
       i + N < (f u).length ∧ (f u)[i]? ≠ (f (u ++ v))[i]?) :

--- a/Linglib/Phonology/Subregular/ISL.lean
+++ b/Linglib/Phonology/Subregular/ISL.lean
@@ -253,10 +253,20 @@ def ISLRule.toFinSubsequentialTransducer {k : ℕ} (r : ISLRule k α β) :
     SubsequentialTransducer {l : List α // l.length ≤ k - 1} α β :=
   .ofWindow (k - 1) r.windowOutput fun _ x => [x]
 
+/-- `ISLRule.applyAux` is the canonical window recursion accumulating the input. -/
+theorem ISLRule.applyAux_eq_windowRun {k : ℕ} (r : ISLRule k α β) :
+    r.applyAux = SubsequentialTransducer.windowRun (k - 1) r.windowOutput fun _ x => [x] := by
+  funext w xs
+  induction xs generalizing w with
+  | nil => rfl
+  | cons x xs ih =>
+    rw [ISLRule.applyAux_cons, SubsequentialTransducer.windowRun]
+    exact congrArg _ (ih _)
+
 /-- The window transducer induced by an ISL rule computes the same string function. -/
 theorem ISLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} (r : ISLRule k α β) :
     r.toFinSubsequentialTransducer.run = r.apply :=
-  SubsequentialTransducer.run_ofWindow r.applyAux (fun _ => rfl) fun _ _ _ => rfl
+  SubsequentialTransducer.run_ofWindow.trans (congrFun r.applyAux_eq_windowRun []).symm
 
 /-- **Left-ISL ⊆ Left-Subsequential** (over a finite input alphabet).
 The `[Fintype α]` matches [mohri-1997]'s finite-alphabet assumption

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -177,10 +177,20 @@ def OSLRule.toFinSubsequentialTransducer {k : ℕ} (r : OSLRule k α β) :
     SubsequentialTransducer {l : List β // l.length ≤ k - 1} α β :=
   .ofWindow (k - 1) r.windowOutput r.windowOutput
 
+/-- `OSLRule.applyAux` is the canonical window recursion accumulating the output. -/
+theorem OSLRule.applyAux_eq_windowRun {k : ℕ} (r : OSLRule k α β) :
+    r.applyAux = SubsequentialTransducer.windowRun (k - 1) r.windowOutput r.windowOutput := by
+  funext w xs
+  induction xs generalizing w with
+  | nil => rfl
+  | cons x xs ih =>
+    rw [OSLRule.applyAux_cons, SubsequentialTransducer.windowRun]
+    exact congrArg _ (ih _)
+
 /-- The window transducer induced by an OSL rule computes the same string function. -/
 theorem OSLRule.toFinSubsequentialTransducer_run_eq_apply {k : ℕ} (r : OSLRule k α β) :
     r.toFinSubsequentialTransducer.run = r.apply :=
-  SubsequentialTransducer.run_ofWindow r.applyAux (fun _ => rfl) fun _ _ _ => rfl
+  SubsequentialTransducer.run_ofWindow.trans (congrFun r.applyAux_eq_windowRun []).symm
 
 /-- **Left-OSL ⊆ Left-Subsequential** (over a finite output alphabet).
 The `[Fintype β]` matches [mohri-1997]'s finite-alphabet assumption


### PR DESCRIPTION
Factors the one-directional `map` out of `reindex` in all three machine files (Mealy, SubsequentialTransducer, Bimachine): `reindex g := ⟨map g, map g.symm, …⟩`, transport-lemma ladders restated on `map`, functoriality (`map_refl`/`map_map`) making the Equiv proofs one-word simps. First brick of the machine-homomorphism roadmap in Mealy's TODO.

- `ofWindow`'s recursion-hypothesis plumbing replaced by the named `windowRun` with one run-equality; ISL/OSL equate their `applyAux` to it
- declaration-docstring register pass: docstrings dropped on self-reading lemmas, rationale clauses cut, universe-polymorphic iffs to one sentence