### PR TITLE
feat(Core/Computability): Elgot–Mezei composition into a bimachine

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -79,6 +79,7 @@ import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Computability.Definite
 import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Direction
+import Linglib.Core.Computability.ElgotMezei
 import Linglib.Core.Computability.Lens
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.MyhillNerode

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -47,8 +47,8 @@ Only the left state is threaded through the run (`Bimachine.runFrom`); the recur
 reads each tail's right state on the spot. The class existentials pin state types at
 `Type 0`; the universe-polymorphic `isBimachineComputable_iff` and
 `isNonInteractingBimachineComputable_iff` recover generality. The identification of
-`IsBimachineComputable` with the total length-preserving regular functions is classical
-and not formalized here.
+`IsBimachineComputable` with the total rational functions preserving the empty word is
+classical and not formalized here; `ElgotMezei.lean` proves the composition half.
 
 [UPSTREAM] candidate: `Mathlib.Computability.Bimachine`.
 -/
@@ -400,8 +400,8 @@ end ToBimachine
 
 /-! ### The bimachine-computable class -/
 
-/-- Computability by a finite bimachine — classically, the total length-preserving
-regular functions. -/
+/-- Computability by a finite bimachine — classically, the total rational functions
+preserving the empty word. -/
 def IsBimachineComputable (f : List α → List β) : Prop :=
   ∃ (L : Type) (_ : Fintype L) (R : Type) (_ : Fintype R) (B : Bimachine L R α β),
     B.run = f

--- a/Linglib/Core/Computability/ElgotMezei.lean
+++ b/Linglib/Core/Computability/ElgotMezei.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fintype.Pi
+import Linglib.Core.Computability.Bimachine
+import Linglib.Core.Computability.Subsequential
+
+/-!
+# Elgot–Mezei composition
+
+Feeding a right-to-left transducer the output of a left-to-right one gives a bimachine:
+the left automaton is the first machine, and the right automaton carries the *map* taking
+a state of the first machine to the state the second reaches over the image of the
+suffix. We show that a right-subsequential function after a left-subsequential one is
+bimachine-computable as soon as the composite preserves the empty word — the composition
+half of [elgot-mezei-1965]'s decomposition theorem ([sakarovitch-2009], Cor. V.2.5). The
+decomposition half, that every rational function factors this way ([sakarovitch-2009],
+Th. V.2.2), is not formalized here.
+
+## Main definitions
+
+* `SubsequentialTransducer.rightComp`: the bimachine running `T₂` right-to-left over the
+  output of `T₁`
+
+## Implementation notes
+
+The empty-word hypothesis is not an artifact of the construction: `Bimachine.run [] = []`,
+so a composite whose flushes emit anything on the empty input is computed by no bimachine
+at all.
+
+[UPSTREAM] candidate: `Mathlib.Computability.Bimachine`.
+
+## TODO
+
+* The decomposition half: every bimachine-computable function is a right-subsequential
+  function after a left-subsequential one.
+* The letter-to-letter refinement: `Mealy` after `Mealy` gives a length-preserving
+  bimachine (`IsLengthPreservingBimachineComputable`).
+-/
+
+namespace Subregular
+
+variable {α β γ σ₁ σ₂ : Type*}
+
+namespace SubsequentialTransducer
+
+variable (T₂ : SubsequentialTransducer σ₂ β γ) (T₁ : SubsequentialTransducer σ₁ α β)
+
+/-- `T₂.rightComp T₁` is the bimachine reading `T₁` left to right and `T₂` right to left
+over `T₁`'s output. Its right state is the map sending the `T₁`-state entering the suffix
+to the `T₂`-state over the image of that suffix, `T₁`'s flush already consumed; the two
+flags mark the ends of the input, where `T₂`'s flush and the image of `T₁`'s flush are
+emitted. -/
+@[simps]
+def rightComp : Bimachine (Bool × σ₁) (Bool × (σ₁ → σ₂)) α γ where
+  lInit := (true, T₁.start)
+  lStep l a := (false, T₁.step l.2 a)
+  rInit := (true, fun s => T₂.stateAfter T₂.start (T₁.finalOutput s).reverse)
+  rStep r a := (false, fun s => T₂.stateAfter (r.2 (T₁.step s a)) (T₁.output s a).reverse)
+  output l a r :=
+    (if l.1 then T₂.runFrom (r.2 (T₁.step l.2 a)) (T₁.output l.2 a).reverse
+      else T₂.emitted (r.2 (T₁.step l.2 a)) (T₁.output l.2 a).reverse).reverse
+      ++ (if r.1 then (T₂.emitted T₂.start (T₁.finalOutput (T₁.step l.2 a)).reverse).reverse
+        else [])
+
+@[simp] theorem rightComp_rState_fst (suf : List α) :
+    ((T₂.rightComp T₁).rState suf).1 = suf.isEmpty := by
+  cases suf <;> rfl
+
+@[simp] theorem rightComp_rState_snd (suf : List α) (s : σ₁) :
+    ((T₂.rightComp T₁).rState suf).2 s
+      = T₂.stateAfter T₂.start (T₁.runFrom s suf).reverse := by
+  induction suf generalizing s <;> simp [stateAfter_append, *]
+
+/-- Each cell emits the reverse of what `T₂` produces over the reversed image of the
+input: its whole run at the left end, its emission alone — no flush — elsewhere. -/
+theorem rightComp_runFrom (b : Bool) (s : σ₁) (a : α) (xs : List α) :
+    (T₂.rightComp T₁).runFrom (b, s) (a :: xs)
+      = (if b then T₂.runFrom T₂.start (T₁.runFrom s (a :: xs)).reverse
+          else T₂.emitted T₂.start (T₁.runFrom s (a :: xs)).reverse).reverse := by
+  induction xs generalizing b s a <;>
+    cases b <;> simp [runFrom, emitted_append, stateAfter_append, *]
+
+/-- The bimachine computes the composite on every nonempty input — the empty word is the
+only obstruction. -/
+theorem rightComp_run_cons (a : α) (xs : List α) :
+    (T₂.rightComp T₁).run (a :: xs) = T₂.runRight (T₁.run (a :: xs)) := by
+  rw [Bimachine.run, rightComp_lInit, rightComp_runFrom]
+  simp [runRight, run]
+
+/-- The bimachine computes `T₂.runRight ∘ T₁.run`, given that the composite preserves the
+empty word. -/
+theorem rightComp_run (h : T₂.runRight (T₁.run []) = []) :
+    (T₂.rightComp T₁).run = T₂.runRight ∘ T₁.run := by
+  funext xs
+  cases xs with
+  | nil => simpa [Bimachine.run] using h.symm
+  | cons a xs => exact T₂.rightComp_run_cons T₁ a xs
+
+end SubsequentialTransducer
+
+/-- **Elgot–Mezei composition**: a right-subsequential function after a left-subsequential
+one is bimachine-computable, as soon as the composite preserves the empty word (as every
+bimachine-computable function does). -/
+theorem IsRightSubsequential.isBimachineComputable_comp {f : List α → List β}
+    {g : List β → List γ} (hg : IsRightSubsequential g) (hf : IsLeftSubsequential f)
+    (hnil : g (f []) = []) : IsBimachineComputable (g ∘ f) := by
+  classical
+  obtain ⟨σ₂, _, T₂, rfl⟩ := hg
+  obtain ⟨σ₁, _, T₁, rfl⟩ := hf
+  exact ⟨_, inferInstance, _, inferInstance, T₂.rightComp T₁, T₂.rightComp_run T₁ hnil⟩
+
+/-- The synchronous case: a `Mealy` machine run right to left over the output of another
+is a bimachine, with no side condition since both passes preserve the empty word. -/
+theorem Mealy.isBimachineComputable_runRight_comp [Fintype σ₁] [Fintype σ₂]
+    (T₂ : Mealy σ₂ β γ) (T₁ : Mealy σ₁ α β) :
+    IsBimachineComputable (T₂.runRight ∘ T₁.run) := by
+  refine IsRightSubsequential.isBimachineComputable_comp ?_
+    T₁.isMealyComputable.isLeftSubsequential rfl
+  rw [isRightSubsequential_iff_left_reverse]
+  simpa using T₂.isMealyComputable.isLeftSubsequential
+
+end Subregular

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -7,6 +7,7 @@ import Linglib.Core.Computability.Subsequential
 import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Bimachine
+import Linglib.Core.Computability.ElgotMezei
 import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Tone.Basic
@@ -29,7 +30,6 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 
 ## Main definitions
 
-* `utpBM` — a bimachine computing UTP.
 * `markLeft`, `resolve` — the (43) two-pass decomposition over the `?`-enlarged alphabet.
 * `toAR` — the (40) translation into autosegmental representations.
 
@@ -42,6 +42,8 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
   one-sided rules expresses UTP's conjunctive trigger.
 * `utp_markup_decomposition` — (43): with the mark `?`, UTP is right-subsequential after
   left-subsequential; weak determinism forbids exactly this enlargement.
+* `utp_isBimachineComputable` — §4.2: UTP is regular, the (43) decomposition read through
+  Elgot–Mezei composition.
 * `readTBU_linearize_realize` — §4.4: the TBU string is the linearization of the realized
   AR ((37a)), so string look-ahead is timing-tier look-ahead.
 * `links_realizeMerged_utp`, `upper_realizeMerged_utp` — the OCP-merged realization of
@@ -57,37 +59,6 @@ namespace Jardine2016Tone
 open Subregular Tone.Plateauing
 
 variable {w : List TBU} {i j k : ℕ}
-
-/-! ### UTP is regular
-
-§4.2 exhibits a nondeterministic FST (Fig. 5); here UTP is computed by a bimachine — one
-deterministic pass per direction — so what fails below is one-directional determinism. -/
-
-/-- The UTP bimachine: each side flags "a H occurs on my side"; a toneless cell surfaces
-H exactly when both flags are set. -/
-def utpBM : Bimachine Bool Bool TBU TBU :=
-  .ofFlags (· == .H) (· == .H) fun l a r => if a == .H || (l && r) then .H else .O
-
-/-- The bimachine computes UTP. -/
-theorem utpBM_run : utpBM.run = utp.map := by
-  funext w
-  refine List.ext_getElem? fun i => ?_
-  rw [utpBM, Bimachine.getElem?_ofFlags_run, utp.map_getElem?]
-  cases h : w[i]? with
-  | none => rfl
-  | some a =>
-    simp only [Option.map_some]
-    congr 1
-    have hb : (a == TBU.H || ((w.take i).any (· == .H) && (w.drop (i + 1)).any (· == .H)))
-        = true ↔ utp.Surfaces w i := by
-      rw [utp.surfaces_split h]; simp [List.any_eq_true]
-    by_cases hs : utp.Surfaces w i
-    · rw [if_pos (hb.mpr hs), if_pos hs]
-    · rw [if_neg (fun hbt => hs (hb.mp hbt)), if_neg hs]
-
-/-- UTP is regular (§4.2): computable by a finite bimachine. -/
-theorem utp_isBimachineComputable : IsBimachineComputable utp.map :=
-  utpBM_run ▸ utpBM.isBimachineComputable
 
 /-! ### UTP is not subsequential
 
@@ -192,6 +163,14 @@ theorem utp_markup_decomposition :
   have heq : (fun xs : List Mark => (resolve xs.reverse).reverse) = resolveRight.run := by
     funext xs; simp [resolve]
   exact heq ▸ resolveRight.isMealyComputable.isLeftSubsequential
+
+/-- UTP is regular (§4.2): the (43) decomposition is a right-subsequential pass after a
+left-subsequential one, and such a composite is computed by a bimachine — one
+deterministic pass per direction ([elgot-mezei-1965]). So what fails above is
+one-directional determinism, not finite-state computability. -/
+theorem utp_isBimachineComputable : IsBimachineComputable utp.map :=
+  have ⟨hL, hR, heq⟩ := utp_markup_decomposition
+  heq ▸ hR.isBimachineComputable_comp hL rfl
 
 /-! ### The autosegmental grounding ((40), §4.4)
 


### PR DESCRIPTION
`ElgotMezei.lean`: a right-subsequential function after a left-subsequential one is bimachine-computable, given the composite preserves the empty word (necessary: `Bimachine.run [] = []`) — the composition half of [elgot-mezei-1965], Sakarovitch Cor. V.2.5. The bimachine's right states are maps `σ₁ → σ₂` (the right pass runs over the image of the suffix), with two Bool flags handling the flushes at the word edges; the Mealy corollary needs no side condition.

- `Jardine2016Tone`: `utp_isBimachineComputable` now derives from the paper's own (43) decomposition; the hand-built `utpBM` and its extensional proof are deleted (−32 lines)
- `Bimachine.lean`: fixes the stale "length-preserving regular functions" gloss on `IsBimachineComputable` (rational functions preserving the empty word)