### PR TITLE
refactor(Core/Computability): revConj dual for left/right classes

### DIFF
--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -87,14 +87,6 @@ def lState : List α → L := B.lStateAfter B.lInit
 /-- Right state after scanning a suffix right-to-left. -/
 def rState (suf : List α) : R := suf.foldr (fun a r => B.rStep r a) B.rInit
 
-@[simp] theorem lStateAfter_nil (l : L) : B.lStateAfter l [] = l := rfl
-@[simp] theorem lStateAfter_cons (l : L) (x : α) (xs : List α) :
-    B.lStateAfter l (x :: xs) = B.lStateAfter (B.lStep l x) xs := rfl
-@[simp] theorem lState_nil : B.lState [] = B.lInit := rfl
-@[simp] theorem rState_nil : B.rState [] = B.rInit := rfl
-@[simp] theorem rState_cons (x : α) (xs : List α) :
-    B.rState (x :: xs) = B.rStep (B.rState xs) x := rfl
-
 /-- `B.runFrom l x` runs `B` on `x` threading the left state from `l`; each tail's
 right state is read on the spot. -/
 def runFrom : L → List α → List β
@@ -104,9 +96,21 @@ def runFrom : L → List α → List β
 /-- The computed function. -/
 def run : List α → List β := B.runFrom B.lInit
 
-@[simp] theorem runFrom_nil (l : L) : B.runFrom l [] = [] := rfl
-@[simp] theorem runFrom_cons (l : L) (x : α) (xs : List α) :
+section
+variable (l : L) (x : α) (xs : List α)
+
+@[simp] theorem lStateAfter_nil : B.lStateAfter l [] = l := rfl
+@[simp] theorem lStateAfter_cons : B.lStateAfter l (x :: xs) = B.lStateAfter (B.lStep l x) xs :=
+  rfl
+@[simp] theorem lState_nil : B.lState [] = B.lInit := rfl
+@[simp] theorem rState_nil : B.rState [] = B.rInit := rfl
+@[simp] theorem rState_cons : B.rState (x :: xs) = B.rStep (B.rState xs) x := rfl
+
+@[simp] theorem runFrom_nil : B.runFrom l [] = [] := rfl
+@[simp] theorem runFrom_cons :
     B.runFrom l (x :: xs) = B.output l x (B.rState xs) ++ B.runFrom (B.lStep l x) xs := rfl
+
+end
 
 /-! ### Letter-to-letter bimachines
 

--- a/Linglib/Core/Computability/Direction.lean
+++ b/Linglib/Core/Computability/Direction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Data.List.Basic
 import Mathlib.Order.Interval.Set.Defs
 import Mathlib.Order.Nat
 
@@ -11,8 +12,9 @@ import Mathlib.Order.Nat
 
 The orientation of a left-to-right vs right-to-left scan, shared by the transducer
 machines and the side-determinacy predicates of the subregular function theory, with
-the window of positions a direction cuts around a target coordinate. Extracted to its
-own leaf so the footprint-predicate file (`Dependence.lean`) does not have to depend on
+the window of positions a direction cuts around a target coordinate, and the reverse
+conjugation `revConj` realizing the flip on string functions. Extracted to its own
+leaf so the footprint-predicate file (`Dependence.lean`) does not have to depend on
 the transducer machine file just to name a `left`/`right` tag.
 -/
 
@@ -37,5 +39,30 @@ def Direction.window : Direction → ℕ → ℕ → Set ℕ
 
 @[simp, grind =] theorem Direction.window_right {i d : ℕ} :
     Direction.right.window i d = Set.Iic (i + d) := rfl
+
+/-! ### Reverse conjugation
+
+The action of flipping scan direction on string functions: right-scan function classes
+are the `revConj`-images of the left-scan ones, so their theory transports along the
+involution rather than being restated. -/
+
+variable {α β γ : Type*}
+
+/-- Conjugation by `List.reverse`: compute on the reversed input, reverse the result. -/
+def revConj (f : List α → List β) : List α → List β := fun xs => (f xs.reverse).reverse
+
+@[simp] theorem revConj_revConj (f : List α → List β) : revConj (revConj f) = f := by
+  funext xs; simp [revConj]
+
+theorem revConj_comp (g : List β → List γ) (f : List α → List β) :
+    revConj (g ∘ f) = revConj g ∘ revConj f := by
+  funext xs; simp [revConj]
+
+@[simp] theorem revConj_id : revConj (id : List α → List α) = id := by
+  funext xs; simp [revConj]
+
+theorem revConj_eq_iff {h : List α → List β} {f : List α → List β} :
+    revConj h = f ↔ h = revConj f := by
+  constructor <;> rintro rfl <;> simp
 
 end Subregular

--- a/Linglib/Core/Computability/ElgotMezei.lean
+++ b/Linglib/Core/Computability/ElgotMezei.lean
@@ -108,7 +108,7 @@ theorem IsRightSubsequential.isBimachineComputable_comp {f : List α → List β
     {g : List β → List γ} (hg : IsRightSubsequential g) (hf : IsLeftSubsequential f)
     (hnil : g (f []) = []) : IsBimachineComputable (g ∘ f) := by
   classical
-  obtain ⟨σ₂, _, T₂, rfl⟩ := hg
+  obtain ⟨σ₂, _, T₂, rfl⟩ := isRightSubsequential_iff.mp hg
   obtain ⟨σ₁, _, T₁, rfl⟩ := hf
   exact ⟨_, inferInstance, _, inferInstance, T₂.rightComp T₁, T₂.rightComp_run T₁ hnil⟩
 

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -108,55 +108,55 @@ def run : List α → List β := T.runFrom T.initial
 /-- `T.runRight x` runs `T` right-to-left on the input `x`. -/
 def runRight (xs : List α) : List β := (T.run xs.reverse).reverse
 
-@[simp] theorem runFrom_nil (s : σ) : T.runFrom s [] = [] := rfl
-@[simp] theorem runFrom_cons (s : σ) (x : α) (xs : List α) :
-    T.runFrom s (x :: xs) = T.output s x :: T.runFrom (T.step s x) xs := rfl
-@[simp] theorem stateAfter_nil (s : σ) : T.stateAfter s [] = s := rfl
-@[simp] theorem stateAfter_cons (s : σ) (x : α) (xs : List α) :
-    T.stateAfter s (x :: xs) = T.stateAfter (T.step s x) xs := rfl
+section
+variable (s : σ) (x : α) (xs ys : List α)
 
-theorem stateAfter_append (s : σ) (xs ys : List α) :
-    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
+@[simp] theorem runFrom_nil : T.runFrom s [] = [] := rfl
+@[simp] theorem runFrom_cons :
+    T.runFrom s (x :: xs) = T.output s x :: T.runFrom (T.step s x) xs := rfl
+@[simp] theorem stateAfter_nil : T.stateAfter s [] = s := rfl
+@[simp] theorem stateAfter_cons : T.stateAfter s (x :: xs) = T.stateAfter (T.step s x) xs := rfl
+
+theorem stateAfter_append : T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
   List.foldl_append
 
-theorem runFrom_append (s : σ) (xs ys : List α) :
+theorem runFrom_append :
     T.runFrom s (xs ++ ys) = T.runFrom s xs ++ T.runFrom (T.stateAfter s xs) ys := by
   induction xs generalizing s <;> simp [*]
 
 /-- The run is length-preserving (one output symbol per input symbol). -/
-@[simp] theorem length_runFrom (s : σ) (xs : List α) :
-    (T.runFrom s xs).length = xs.length := by
+@[simp] theorem length_runFrom : (T.runFrom s xs).length = xs.length := by
   induction xs generalizing s <;> simp [*]
 
-@[simp] theorem length_run (xs : List α) :
-    (T.run xs).length = xs.length := T.length_runFrom T.initial xs
+@[simp] theorem length_run : (T.run xs).length = xs.length := T.length_runFrom T.initial xs
 
-@[simp] theorem length_runRight (xs : List α) :
-    (T.runRight xs).length = xs.length := by simp [runRight]
+@[simp] theorem length_runRight : (T.runRight xs).length = xs.length := by simp [runRight]
 
-@[simp] theorem runRight_reverse (xs : List α) :
-    T.runRight xs.reverse = (T.run xs).reverse := by simp [runRight]
+@[simp] theorem runRight_reverse : T.runRight xs.reverse = (T.run xs).reverse := by
+  simp [runRight]
 
 @[simp] theorem runRight_nil : T.runRight [] = [] := rfl
 
 /-- The right-to-left pass emits the head output at the state reached over the entire
 reversed tail: the right scan reads the future. -/
-@[simp] theorem runRight_cons (x : α) (xs : List α) :
+@[simp] theorem runRight_cons :
     T.runRight (x :: xs)
       = T.output (T.stateAfter T.initial xs.reverse) x :: T.runRight xs := by
   simp [runRight, run, runFrom_append]
 
 /-- Output coordinate `i` of the run is the output at the state reached after the
 first `i` input symbols. -/
-theorem getElem?_runFrom (s : σ) (xs : List α) (i : ℕ) :
+theorem getElem?_runFrom (i : ℕ) :
     (T.runFrom s xs)[i]? = xs[i]?.map (T.output (T.stateAfter s (xs.take i))) := by
   induction xs generalizing s i <;> cases i <;> simp [*]
 
 /-- Output coordinate `i` of `T.run` is the output at the state reached after the
 first `i` input symbols. -/
-theorem getElem?_run (xs : List α) (i : ℕ) :
+theorem getElem?_run (i : ℕ) :
     (T.run xs)[i]? = xs[i]?.map (T.output (T.stateAfter T.initial (xs.take i))) :=
   T.getElem?_runFrom T.initial xs i
+
+end
 
 /-! ### Composition -/
 

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -103,16 +103,20 @@ def run : List α → List β := T.runFrom T.start
 /-- `T.runRight x` runs `T` right-to-left on the input `x`. -/
 def runRight (xs : List α) : List β := (T.run xs.reverse).reverse
 
-@[simp] theorem stateAfter_nil (s : σ) : T.stateAfter s [] = s := rfl
-@[simp] theorem stateAfter_cons (s : σ) (x : α) (xs : List α) :
-    T.stateAfter s (x :: xs) = T.stateAfter (T.step s x) xs := rfl
-@[simp] theorem emitted_nil (s : σ) : T.emitted s [] = [] := rfl
-@[simp] theorem emitted_cons (s : σ) (x : α) (xs : List α) :
+theorem runRight_eq_revConj_run : T.runRight = revConj T.run := rfl
+
+section
+variable (s : σ) (x : α) (xs ys : List α)
+
+@[simp] theorem stateAfter_nil : T.stateAfter s [] = s := rfl
+@[simp] theorem stateAfter_cons : T.stateAfter s (x :: xs) = T.stateAfter (T.step s x) xs := rfl
+@[simp] theorem emitted_nil : T.emitted s [] = [] := rfl
+@[simp] theorem emitted_cons :
     T.emitted s (x :: xs) = T.output s x ++ T.emitted (T.step s x) xs := rfl
 
-@[simp] theorem runFrom_nil (s : σ) : T.runFrom s [] = T.finalOutput s := rfl
+@[simp] theorem runFrom_nil : T.runFrom s [] = T.finalOutput s := rfl
 
-@[simp] theorem runFrom_cons (s : σ) (x : α) (xs : List α) :
+@[simp] theorem runFrom_cons :
     T.runFrom s (x :: xs) = T.output s x ++ T.runFrom (T.step s x) xs := by
   simp [runFrom]
 
@@ -120,24 +124,25 @@ def runRight (xs : List α) : List β := (T.run xs.reverse).reverse
 
 @[simp] theorem runRight_nil : T.runRight [] = (T.finalOutput T.start).reverse := rfl
 
-@[simp] theorem runRight_reverse (xs : List α) :
-    T.runRight xs.reverse = (T.run xs).reverse := by simp [runRight]
+@[simp] theorem runRight_reverse : T.runRight xs.reverse = (T.run xs).reverse := by
+  simp [runRight]
 
-theorem stateAfter_append (s : σ) (xs ys : List α) :
-    T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
+theorem stateAfter_append : T.stateAfter s (xs ++ ys) = T.stateAfter (T.stateAfter s xs) ys :=
   List.foldl_append
 
-theorem emitted_append (s : σ) (xs ys : List α) :
+theorem emitted_append :
     T.emitted s (xs ++ ys) = T.emitted s xs ++ T.emitted (T.stateAfter s xs) ys := by
   induction xs generalizing s <;> simp [*]
 
-theorem runFrom_append (s : σ) (xs ys : List α) :
+theorem runFrom_append :
     T.runFrom s (xs ++ ys) = T.emitted s xs ++ T.runFrom (T.stateAfter s xs) ys := by
   simp [runFrom, emitted_append, stateAfter_append]
 
-theorem run_append (xs ys : List α) :
+theorem run_append :
     T.run (xs ++ ys) = T.emitted T.start xs ++ T.runFrom (T.stateAfter T.start xs) ys :=
   T.runFrom_append T.start xs ys
+
+end
 
 /-! ### Transport along state equivalences -/
 
@@ -346,10 +351,11 @@ transducer computes it via left-to-right scan [mohri-1997]. -/
 def IsLeftSubsequential (f : List α → List β) : Prop :=
   ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.run = f
 
-/-- A function `f : List α → List β` is *right-subsequential* if some finite-state
-transducer computes it via right-to-left scan (`runRight`). -/
+/-- A function `f : List α → List β` is *right-subsequential* if its reverse-conjugate
+is left-subsequential — equivalently, some finite-state transducer computes it via
+right-to-left scan (`isRightSubsequential_iff`). -/
 def IsRightSubsequential (f : List α → List β) : Prop :=
-  ∃ (σ : Type) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f
+  IsLeftSubsequential (revConj f)
 
 /-- A function `f : List α → List β` is *subsequential in direction `d`* if some
 finite-state SubsequentialTransducer computes it via the corresponding scan direction. -/
@@ -372,13 +378,20 @@ theorem isLeftSubsequential_iff.{v} :
     (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.run_map e).trans hT⟩)
     (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.run_map e).trans hT⟩)
 
-/-- The universe-polymorphic form of `IsRightSubsequential`. -/
+/-- The universe-polymorphic form of `IsRightSubsequential`, in the `runRight` shape. -/
 theorem isRightSubsequential_iff.{v} :
     IsRightSubsequential f
-      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f :=
-  exists_fintype_congr
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.runRight_map e).trans hT⟩)
-    (fun e ⟨T, hT⟩ => ⟨SubsequentialTransducer.map e T, (T.runRight_map e).trans hT⟩)
+      ↔ ∃ (σ : Type v) (_ : Fintype σ) (T : SubsequentialTransducer σ α β), T.runRight = f := by
+  constructor
+  · intro h
+    obtain ⟨σ, _, T, hT⟩ :=
+      isLeftSubsequential_iff.mp (show IsLeftSubsequential (revConj f) from h)
+    exact ⟨σ, inferInstance, T, by
+      rw [SubsequentialTransducer.runRight_eq_revConj_run, hT, revConj_revConj]⟩
+  · rintro ⟨σ, _, T, rfl⟩
+    show IsLeftSubsequential (revConj T.runRight)
+    exact isLeftSubsequential_iff.mpr ⟨σ, inferInstance, T, by
+      rw [SubsequentialTransducer.runRight_eq_revConj_run, revConj_revConj]⟩
 
 /-- Every finite-state transducer computes a left-subsequential function, whatever the
 universe of its state type. -/
@@ -407,14 +420,12 @@ theorem isLeftSubsequential_map (h : α → β) : IsLeftSubsequential (List.map 
 theorem isLeftSubsequential_id : IsLeftSubsequential (id : List α → List α) :=
   isMealyComputable_id.isLeftSubsequential
 
-/-- A function is right-subsequential iff its reverse-conjugate is left-subsequential:
-the two classes are isomorphic via the involution `f ↦ List.reverse ∘ f ∘ List.reverse`. -/
+/-- A function is right-subsequential iff its reverse-conjugate is left-subsequential —
+definitionally: the right class is the `revConj`-image of the left class. -/
 theorem isRightSubsequential_iff_left_reverse :
     IsRightSubsequential f
       ↔ IsLeftSubsequential (fun xs => (f xs.reverse).reverse) :=
-  ⟨fun ⟨σ, _, T, hT⟩ => ⟨σ, inferInstance, T, by funext xs; simp [← hT]⟩,
-   fun ⟨σ, _, T, hT⟩ =>
-     ⟨σ, inferInstance, T, by funext xs; simp [SubsequentialTransducer.runRight, hT]⟩⟩
+  Iff.rfl
 
 /-- A left-subsequential function withholds at most the longest state-final output:
 `f u` and `f (u ++ v)` share a prefix covering all but boundedly many symbols of `f u`.
@@ -455,19 +466,19 @@ theorem not_isLeftSubsequential_of_diverging
   exact hne (hN u v i hi)
 
 /-- Left-subsequential functions are closed under composition, by the classical
-product construction [mohri-1997] (`SubsequentialTransducer.comp`). -/
+product construction [mohri-1997]. -/
 theorem IsLeftSubsequential.comp (hg : IsLeftSubsequential g)
     (hf : IsLeftSubsequential f) : IsLeftSubsequential (g ∘ f) := by
   obtain ⟨σ₁, _, T₁, rfl⟩ := hf
   obtain ⟨σ₂, _, T₂, rfl⟩ := hg
   exact ⟨σ₂ × σ₁, inferInstance, T₂.comp T₁, T₂.run_comp T₁⟩
 
-/-- Right-subsequential closure under composition, derived from the left counterpart
-via `isRightSubsequential_iff_left_reverse`. -/
+/-- Right-subsequential closure under composition: conjugate the left closure. -/
 theorem IsRightSubsequential.comp (hg : IsRightSubsequential g)
     (hf : IsRightSubsequential f) : IsRightSubsequential (g ∘ f) := by
-  rw [isRightSubsequential_iff_left_reverse] at hg hf ⊢
-  simpa [Function.comp_def, List.reverse_reverse] using hg.comp hf
+  show IsLeftSubsequential (revConj (g ∘ f))
+  rw [revConj_comp]
+  exact IsLeftSubsequential.comp hg hf
 
 /-- Subsequential functions are closed under composition in either scan direction. -/
 theorem IsSubsequential.comp {d : Direction} (hg : IsSubsequential d g)

--- a/Linglib/Phonology/Subregular/ISL.lean
+++ b/Linglib/Phonology/Subregular/ISL.lean
@@ -110,12 +110,10 @@ end ISLRule
 def IsLeftInputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
   ∃ r : ISLRule k α β, r.apply = f
 
-/-- `f : List α → List β` is **k-Right-Input-Strictly-Local** iff some
-`k`-ISL rule computes it via right-to-left scan. Mirror image of the
-left class via `f ↦ List.reverse ∘ f ∘ List.reverse`; see
-`isRightInputStrictlyLocal_iff_left_reverse`. -/
+/-- `f : List α → List β` is **k-Right-Input-Strictly-Local** iff its reverse-conjugate
+is k-Left-ISL — some `k`-ISL rule computes it via right-to-left scan. -/
 def IsRightInputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
-  ∃ r : ISLRule k α β, (fun input => (r.apply input.reverse).reverse) = f
+  IsLeftInputStrictlyLocal k (revConj f)
 
 /-- Direction-parameterised ISL predicate. Mirrors the OSL/Subseq
 umbrella style; concrete claims should typically use one of
@@ -139,28 +137,13 @@ lemma ISLRule.isLeftInputStrictlyLocal_apply {k : ℕ} (r : ISLRule k α β) :
     IsLeftInputStrictlyLocal k r.apply :=
   ⟨r, rfl⟩
 
-/-- **Reverse-conjugation lemma**: a function is k-Right-ISL iff its
-reverse-conjugate is k-Left-ISL. The two classes are isomorphic via the
-involution `f ↦ List.reverse ∘ f ∘ List.reverse`. -/
+/-- **Reverse-conjugation lemma**: a function is k-Right-ISL iff its reverse-conjugate
+is k-Left-ISL — definitionally, with the conjugated class as primary. -/
 theorem isRightInputStrictlyLocal_iff_left_reverse {k : ℕ}
     (f : List α → List β) :
     IsRightInputStrictlyLocal k f
-      ↔ IsLeftInputStrictlyLocal k (fun xs => (f xs.reverse).reverse) := by
-  refine ⟨?_, ?_⟩
-  · rintro ⟨r, hr⟩
-    refine ⟨r, ?_⟩
-    funext xs
-    have h := congrFun hr xs.reverse
-    rw [List.reverse_reverse] at h
-    show r.apply xs = (f xs.reverse).reverse
-    rw [← h, List.reverse_reverse]
-  · rintro ⟨r, hr⟩
-    refine ⟨r, ?_⟩
-    funext xs
-    show (r.apply xs.reverse).reverse = f xs
-    have h := congrFun hr xs.reverse
-    rw [List.reverse_reverse] at h
-    rw [h, List.reverse_reverse]
+      ↔ IsLeftInputStrictlyLocal k (fun xs => (f xs.reverse).reverse) :=
+  Iff.rfl
 
 /-- The empty-output function is ISL for any `k`. Witness: the rule that
 emits `[]` regardless of window or current symbol. -/
@@ -287,15 +270,12 @@ theorem isMealyComputable_of_ISLRule {k : ℕ} [Fintype α] (r : ISLRule k α β
     (SubsequentialTransducer.LetterToLetter.ofLength fun w x => hs w.val x).isMealyComputable
       fun _ => rfl
 
-/-- **Right-ISL ⊆ Right-Subsequential**, derived from the Left- side via
-the reverse-conjugation lemmas. The Right-ISL ↔ Left-ISL and
-Right-Subseq ↔ Left-Subseq isomorphisms commute. -/
+/-- **Right-ISL ⊆ Right-Subsequential**: the left inclusion at the reverse-conjugate,
+since both right classes are the `revConj`-images of their left classes. -/
 theorem isRightInputStrictlyLocal_right_subsequential {k : ℕ} [Fintype α]
     {f : List α → List β} (h : IsRightInputStrictlyLocal k f) :
-    IsRightSubsequential f := by
-  rw [isRightInputStrictlyLocal_iff_left_reverse] at h
-  rw [isRightSubsequential_iff_left_reverse]
-  exact isLeftInputStrictlyLocal_left_subsequential h
+    IsRightSubsequential f :=
+  isLeftInputStrictlyLocal_left_subsequential h
 
 /-- Direction-parameterised: ISL_d ⊆ Subseq_d for both directions (over
 a finite input alphabet). Delegates to the Left- / Right- specialised

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -110,10 +110,11 @@ iff some `k`-OSL rule computes it via left-to-right scan. -/
 def IsLeftOutputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
   ∃ r : OSLRule k α β, r.apply = f
 
-/-- A function `f : List α → List β` is **k-Right-Output-Strictly-Local**
-iff some `k`-OSL rule computes it via right-to-left scan. -/
+/-- A function `f : List α → List β` is **k-Right-Output-Strictly-Local** iff its
+reverse-conjugate is k-Left-OSL — some `k`-OSL rule computes it via right-to-left
+scan. -/
 def IsRightOutputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
-  ∃ r : OSLRule k α β, (fun input => (r.apply input.reverse).reverse) = f
+  IsLeftOutputStrictlyLocal k (revConj f)
 
 /-- Direction-parameterised OSL predicate. -/
 def IsOutputStrictlyLocal (d : Direction) (k : ℕ) (f : List α → List β) : Prop :=
@@ -133,31 +134,13 @@ lemma OSLRule.isLeftOutputStrictlyLocal_apply {k : ℕ} (r : OSLRule k α β) :
     IsLeftOutputStrictlyLocal k r.apply :=
   ⟨r, rfl⟩
 
-/-- **Reverse-conjugation lemma**: a function is k-Right-OSL iff its
-reverse-conjugate is k-Left-OSL. The two classes are isomorphic via the
-involution `f ↦ List.reverse ∘ f ∘ List.reverse`. -/
+/-- **Reverse-conjugation lemma**: a function is k-Right-OSL iff its reverse-conjugate
+is k-Left-OSL — definitionally, with the conjugated class as primary. -/
 theorem isRightOutputStrictlyLocal_iff_left_reverse {k : ℕ}
     (f : List α → List β) :
     IsRightOutputStrictlyLocal k f
-      ↔ IsLeftOutputStrictlyLocal k (fun xs => (f xs.reverse).reverse) := by
-  refine ⟨?_, ?_⟩
-  · rintro ⟨r, hr⟩
-    refine ⟨r, ?_⟩
-    funext xs
-    have h := congrFun hr xs.reverse
-    -- h : (r.apply xs.reverse.reverse).reverse = f xs.reverse
-    -- = (r.apply xs).reverse = f xs.reverse
-    rw [List.reverse_reverse] at h
-    show r.apply xs = (f xs.reverse).reverse
-    rw [← h, List.reverse_reverse]
-  · rintro ⟨r, hr⟩
-    refine ⟨r, ?_⟩
-    funext xs
-    show (r.apply xs.reverse).reverse = f xs
-    have h := congrFun hr xs.reverse
-    -- h : r.apply xs.reverse = (f xs.reverse.reverse).reverse = (f xs).reverse
-    rw [List.reverse_reverse] at h
-    rw [h, List.reverse_reverse]
+      ↔ IsLeftOutputStrictlyLocal k (fun xs => (f xs.reverse).reverse) :=
+  Iff.rfl
 
 /-! ### OSL ⊆ Subsequential
 
@@ -211,15 +194,12 @@ theorem isMealyComputable_of_OSLRule {k : ℕ} [Fintype β] (r : OSLRule k α β
     (SubsequentialTransducer.LetterToLetter.ofLength fun w x => hs w.val x).isMealyComputable
       fun _ => rfl
 
-/-- **Right-OSL ⊆ Right-Subsequential**, derived from the Left- side via
-the reverse-conjugation lemmas. The Right-OSL ↔ Left-OSL and
-Right-Subseq ↔ Left-Subseq isomorphisms commute. -/
+/-- **Right-OSL ⊆ Right-Subsequential**: the left inclusion at the reverse-conjugate,
+since both right classes are the `revConj`-images of their left classes. -/
 theorem isRightOutputStrictlyLocal_right_subsequential {k : ℕ} [Fintype β]
     {f : List α → List β} (h : IsRightOutputStrictlyLocal k f) :
-    IsRightSubsequential f := by
-  rw [isRightOutputStrictlyLocal_iff_left_reverse] at h
-  rw [isRightSubsequential_iff_left_reverse]
-  exact isLeftOutputStrictlyLocal_left_subsequential h
+    IsRightSubsequential f :=
+  isLeftOutputStrictlyLocal_left_subsequential h
 
 /-- **Direction-parameterised OSL ⊆ Subsequential umbrella**: in both
 scan directions, OSL functions are subsequential. Delegates to the


### PR DESCRIPTION
The OrderDual pattern for scan direction: `revConj` (reverse conjugation, in `Direction.lean` with its involution/functoriality algebra) and right classes defined as `revConj`-images of left classes — `IsRightSubsequential`, `IsRightInputStrictlyLocal`, `IsRightOutputStrictlyLocal`. The three hand-proved reversal iffs become `Iff.rfl`, both right-inclusion proofs collapse to direct left-inclusion applications, and right-composition closure is `revConj_comp` plus the left closure. All public lemma names survive; the only consumer edit is one destructure line in `ElgotMezei`.

- recurring binders (`s`/`x`/`xs`/`ys`, `l`) lifted into scoped sections in the three machine files, per the ≥2-uses golf rule — argument orders unchanged
- decl-register micros: dead docstring pointers dropped, universe-iff docstrings to one sentence