### PR TITLE
feat(Phonology/Subregular): rewrite rules are ISL or subsequential

### DIFF
--- a/Linglib/Core/Data/List/DropRight.lean
+++ b/Linglib/Core/Data/List/DropRight.lean
@@ -69,6 +69,15 @@ theorem rtake_append_of_length_le {n : ℕ} (l₁ l₂ : List α) (h : l₂.leng
     (l₁ ++ l₂).rtake n = l₁.rtake (n - l₂.length) ++ l₂ := by
   simp [rtake_eq_reverse_take_reverse, take_append, take_of_length_le, h]
 
+/-- Truncating to a suffix window before appending is the same as truncating after: the
+last `n` symbols are enough state to compute the next window. -/
+theorem rtake_append_rtake (n : ℕ) (l₁ l₂ : List α) :
+    (l₁.rtake n ++ l₂).rtake n = (l₁ ++ l₂).rtake n := by
+  rcases le_or_gt n l₂.length with h | h
+  · rw [rtake_append_of_le_length _ _ h, rtake_append_of_le_length _ _ h]
+  · rw [rtake_append_of_length_le _ _ h.le, rtake_append_of_length_le _ _ h.le, rtake_rtake,
+      min_eq_left (Nat.sub_le _ _)]
+
 /-- A middle block of length `≥ n` screens off everything to its left: the last `n` symbols
 of `a ++ u ++ y` do not depend on `a`. -/
 theorem rtake_append_append_of_le_length {n : ℕ} (a u y : List α) (h : n ≤ u.length) :

--- a/Linglib/Phonology/Subregular/LocalRewrite.lean
+++ b/Linglib/Phonology/Subregular/LocalRewrite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Phonology.Segmental.Basic
+import Linglib.Phonology.Subregular.ISL
 
 /-!
 # Local phonological rewrite rules
@@ -27,6 +28,18 @@ constraint-based frameworks such as `Phonology/OptimalityTheory/`).
 * `Rule` — the `target / effect / leftContext / rightContext` schema.
 * `Rule.apply` — a single left-to-right scan with simultaneous application.
 * `derive` — an ordered-rule cascade (extrinsic ordering, the SPE convention).
+* `Rule.toISLRule`, `Rule.toSubsequentialTransducer` — the two machine
+  presentations of a rule.
+
+## Main results
+
+* `matchRightContext_take`, `matchLeftContext_rtake` — a context of length `n`
+  reads at most `n` symbols, so both matchers factor through a bounded window.
+* `Rule.isLeftInputStrictlyLocal` — a rule with no right context is
+  `(|leftContext| + 1)`-Left-ISL.
+* `Rule.isLeftSubsequential` — over a finite segment alphabet every rule is
+  Left-Subsequential, via a transducer that delays emission by `|rightContext|`
+  symbols and flushes the buffer at the word end.
 
 ## Implementation notes
 
@@ -40,10 +53,13 @@ Iterative spreading lies in the strictly larger Output Strictly Local class
 
 ## Todo
 
-* Prove `Rule.apply` is a `k`-Left-ISL function with
-  `k = r.leftContext.length + r.rightContext.length + 1`, exhibiting an `ISLRule`
-  over `List Segment` with word boundaries internalised
-  (cf. `Subregular.ISLRule`).
+* `Rule.apply` over **boundary-augmented** input. Padding the string with word
+  boundaries turns the right context into lookahead the padding pays for, and
+  the rule becomes `k`-Left-ISL with
+  `k = r.leftContext.length + r.rightContext.length + 1`. Over raw strings that
+  statement does not hold in general — a bounded left window cannot see the
+  right context — which is why `Rule.isLeftInputStrictlyLocal` assumes an empty
+  right context and `Rule.isLeftSubsequential` is what survives without it.
 -/
 
 namespace Subregular.LocalRewrite
@@ -144,5 +160,191 @@ where
 previous rule (extrinsic ordering, the SPE convention). -/
 def derive (rules : List Rule) (input : List Segment) : List Segment :=
   rules.foldl (fun s r => r.apply s) input
+
+/-! ### Bounded context windows
+
+A context list of length `n` inspects at most `n` symbols, so both matchers
+factor through a bounded window — the right one through a prefix, the left one
+through a suffix. The word boundary is what makes this delicate: it matches
+exactly when the string is exhausted, so a window must be long enough to tell
+a genuinely short string from a truncated one. A window of the context's own
+length is: it is exhausted only when the string is. -/
+
+theorem matchRightContext_take (ctx : List ContextElem) (right : List Segment) :
+    matchRightContext ctx (right.take ctx.length) = matchRightContext ctx right := by
+  induction ctx generalizing right with
+  | nil => rfl
+  | cons c rest ih => cases c <;> cases right <;> simp [matchRightContext, ih]
+
+theorem matchLeftContext_rtake (ctx : List ContextElem) (left : List Segment) :
+    matchLeftContext ctx (left.rtake ctx.length) = matchLeftContext ctx left := by
+  have h : (left.rtake ctx.length).reverse = left.reverse.take ctx.reverse.length := by
+    simp [List.rtake_eq_reverse_take_reverse]
+  rw [matchLeftContext, h, matchRightContext_take, matchLeftContext]
+
+/-! ### The verdict at a position -/
+
+/-- The output block a rule contributes at one position: the effect applied when
+target, left context `w` and right context `d` all match, and the untouched
+segment otherwise. -/
+def Rule.verdict (r : Rule) (w : List Segment) (s : Segment) (d : List Segment) :
+    List Segment :=
+  if decide (r.target ≤ s) && matchLeftContext r.leftContext w
+      && matchRightContext r.rightContext d then
+    (r.effect.apply s).toList
+  else [s]
+
+/-- `Rule.apply` emits one `Rule.verdict` per input position. -/
+theorem Rule.apply_go_cons (r : Rule) (left : List Segment) (s : Segment)
+    (right : List Segment) :
+    Rule.apply.go r left (s :: right)
+      = r.verdict left s right ++ Rule.apply.go r (left ++ [s]) right := by
+  cases hc : decide (r.target ≤ s) && matchLeftContext r.leftContext left
+      && matchRightContext r.rightContext right <;>
+    cases he : r.effect.apply s <;> simp [Rule.apply.go, Rule.verdict, hc, he]
+
+/-- The verdict reads only the last `|leftContext|` symbols of the prefix. -/
+theorem Rule.verdict_rtake (r : Rule) (w : List Segment) (s : Segment) (d : List Segment) :
+    r.verdict (w.rtake r.leftContext.length) s d = r.verdict w s d := by
+  rw [Rule.verdict, Rule.verdict, matchLeftContext_rtake]
+
+/-- The verdict reads only the first `|rightContext|` symbols of the suffix. -/
+theorem Rule.verdict_append (r : Rule) (w : List Segment) (s : Segment) (d e : List Segment)
+    (h : r.rightContext.length ≤ d.length) : r.verdict w s (d ++ e) = r.verdict w s d := by
+  rw [Rule.verdict, Rule.verdict, ← matchRightContext_take r.rightContext d,
+    ← matchRightContext_take r.rightContext (d ++ e), List.take_append_of_le_length h]
+
+/-! ### The bounded-window scan -/
+
+/-- `Rule.apply` rewritten to carry only the last `|leftContext|` input symbols:
+the unbounded prefix of `Rule.apply.go` is replaced by the window the rule can
+actually inspect. -/
+def Rule.scan (r : Rule) (w : List Segment) : List Segment → List Segment
+  | [] => []
+  | s :: right =>
+    r.verdict w s right ++ r.scan ((w ++ [s]).rtake r.leftContext.length) right
+
+/-- Truncating the prefix to the rule's left-context length loses nothing. -/
+theorem Rule.scan_rtake (r : Rule) (left right : List Segment) :
+    r.scan (left.rtake r.leftContext.length) right = Rule.apply.go r left right := by
+  induction right generalizing left with
+  | nil => rfl
+  | cons s right ih =>
+    rw [Rule.scan, Rule.verdict_rtake, List.rtake_append_rtake, ih, Rule.apply_go_cons]
+
+/-- `Rule.apply` is the bounded-window scan started from the empty window. -/
+theorem Rule.apply_eq_scan (r : Rule) : r.apply = r.scan [] := by
+  funext input
+  show Rule.apply.go r [] input = _
+  simpa using (r.scan_rtake [] input).symm
+
+/-! ### No right context: Input Strict Locality
+
+With `rightContext = []` a verdict depends only on the last `|leftContext|`
+input symbols and the current one — exactly the `(|leftContext| + 1)`-ISL
+window of [chandlee-2014], [chandlee-heinz-2018]. -/
+
+/-- The ISL rule computing a rewrite with no right context. The hypothesis is
+the applicability condition: with a nonempty `rightContext` the lookahead `[]`
+supplied here is the end-of-word one, not the one `Rule.apply` uses. -/
+def Rule.toISLRule (r : Rule) (_h : r.rightContext = []) :
+    ISLRule (r.leftContext.length + 1) Segment Segment where
+  windowOutput w s := r.verdict w s []
+
+private theorem Rule.applyAux_toISLRule (r : Rule) (h : r.rightContext = [])
+    (w input : List Segment) : (r.toISLRule h).applyAux w input = r.scan w input := by
+  induction input generalizing w with
+  | nil => rfl
+  | cons s xs ih =>
+    have hv : (r.toISLRule h).windowOutput w s = r.verdict w s xs := by
+      show r.verdict w s [] = r.verdict w s xs
+      simp [Rule.verdict, h, matchRightContext]
+    rw [ISLRule.applyAux_cons, hv, Nat.add_sub_cancel, Rule.scan, ih]
+
+theorem Rule.toISLRule_apply (r : Rule) (h : r.rightContext = []) :
+    (r.toISLRule h).apply = r.apply := by
+  funext input
+  show (r.toISLRule h).applyAux [] input = _
+  rw [r.applyAux_toISLRule h, Rule.apply_eq_scan]
+
+/-- **A rewrite rule with no right context is Left-ISL**, with `k` one more than
+the length of its left context. -/
+theorem Rule.isLeftInputStrictlyLocal (r : Rule) (h : r.rightContext = []) :
+    IsLeftInputStrictlyLocal (r.leftContext.length + 1) r.apply :=
+  ⟨r.toISLRule h, r.toISLRule_apply h⟩
+
+/-! ### The general case: left-subsequentiality
+
+A nonempty right context is lookahead, which a left-to-right scan cannot have.
+The transducer buys it with delay: it leaves the last `|rightContext|` segments
+unjudged in a buffer, so that the oldest buffered segment always has its full
+right context in hand, and judges what remains buffered against the word end in
+`finalOutput`. That final flush is what the right context costs — `ofWindow`,
+and with it every ISL rule, emits nothing at the end. -/
+
+/-- The delayed-emission state: the left window of the oldest undecided segment,
+paired with the lookahead buffer of segments whose right context is still
+incomplete. -/
+abbrev Rule.State (r : Rule) : Type :=
+  {l : List Segment // l.length ≤ r.leftContext.length} ×
+    {l : List Segment // l.length ≤ r.rightContext.length}
+
+/-- The delayed transducer for an arbitrary rewrite rule. Reading `x` appends it
+to the buffer; whatever that pushes out of the buffer has acquired its full right
+context, so it is judged and enters the left window. `finalOutput` judges the
+remaining buffer against the end of the word, where a short lookahead is exactly
+what `matchRightContext` expects. -/
+def Rule.toSubsequentialTransducer (r : Rule) :
+    SubsequentialTransducer r.State Segment Segment where
+  start := (⟨[], Nat.zero_le _⟩, ⟨[], Nat.zero_le _⟩)
+  step s x :=
+    (⟨(s.1.val ++ (s.2.val ++ [x]).rdrop r.rightContext.length).rtake r.leftContext.length,
+        List.length_rtake_le _ _⟩,
+      ⟨(s.2.val ++ [x]).rtake r.rightContext.length, List.length_rtake_le _ _⟩)
+  output s x :=
+    ((s.2.val ++ [x]).rdrop r.rightContext.length).flatMap fun b =>
+      r.verdict s.1.val b ((s.2.val ++ [x]).rtake r.rightContext.length)
+  finalOutput s := r.scan s.1.val s.2.val
+
+/-- From any state the delayed transducer judges the buffer and the remaining
+input together: the delay is invisible in the total output. -/
+theorem Rule.runFrom_toSubsequentialTransducer (r : Rule) (s : r.State)
+    (input : List Segment) :
+    r.toSubsequentialTransducer.runFrom s input = r.scan s.1.val (s.2.val ++ input) := by
+  induction input generalizing s with
+  | nil => simp [Rule.toSubsequentialTransducer]
+  | cons x xs ih =>
+    obtain ⟨⟨w, hw⟩, buf, hbuf⟩ := s
+    rw [SubsequentialTransducer.runFrom_cons, ih]
+    simp only [Rule.toSubsequentialTransducer, show buf ++ x :: xs = (buf ++ [x]) ++ xs by simp]
+    rcases Nat.lt_or_ge buf.length r.rightContext.length with h | h
+    · have hle : (buf ++ [x]).length ≤ r.rightContext.length := by simp; omega
+      rw [show (buf ++ [x]).rdrop r.rightContext.length = [] by simp [List.rdrop]; omega,
+        List.rtake_of_length_le hle]
+      simp [List.rtake_of_length_le hw]
+    · obtain ⟨b, rest, hb⟩ : ∃ b rest, buf ++ [x] = b :: rest :=
+        List.exists_cons_of_ne_nil (by simp)
+      have hrest : rest.length = r.rightContext.length := by
+        have hl := congrArg List.length hb; simp at hl; omega
+      rw [hb, show (b :: rest).rdrop r.rightContext.length = [b] by simp [List.rdrop, hrest],
+        show (b :: rest).rtake r.rightContext.length = rest by simp [List.rtake, hrest],
+        List.cons_append, Rule.scan, r.verdict_append w b rest xs hrest.ge]
+      simp
+
+/-- The delayed transducer computes the rule. -/
+theorem Rule.run_toSubsequentialTransducer (r : Rule) :
+    r.toSubsequentialTransducer.run = r.apply := by
+  funext input
+  rw [SubsequentialTransducer.run, r.runFrom_toSubsequentialTransducer]
+  simp [Rule.apply_eq_scan, Rule.toSubsequentialTransducer]
+
+/-- **Every local rewrite rule is Left-Subsequential.** `Segment` is a partial
+valuation of the 26 features of [hayes-2009], so it is finite but carries no
+`Fintype` instance (its `Flat` slots are deliberately opaque); the hypothesis
+supplies the finite alphabet [mohri-1997] assumes without forcing a
+`3 ^ 26`-element enumeration on every consumer of this file. -/
+theorem Rule.isLeftSubsequential [Fintype Segment] (r : Rule) :
+    IsLeftSubsequential r.apply :=
+  r.run_toSubsequentialTransducer ▸ r.toSubsequentialTransducer.isLeftSubsequential
 
 end Subregular.LocalRewrite


### PR DESCRIPTION
Closes `LocalRewrite.lean`'s classification TODO, correctly rescoped: a rule with no right context is `(|leftContext| + 1)`-Left-ISL (tighter than the TODO's bound), and over a finite segment alphabet every rule is Left-Subsequential — via a delayed-emission transducer whose `finalOutput` flushes the `|rightContext|`-symbol lookahead buffer at the word end, the library's first machine whose final flush is load-bearing.

- shared spine: `Rule.verdict`/`Rule.scan` recast `Rule.apply` as one verdict per position over a bounded window; `matchLeftContext_rtake`/`matchRightContext_take` prove a context of length `n` reads at most `n` symbols (word-boundary exhaustion included)
- `List.rtake_append_rtake` joins its siblings in `Core/Data/List/DropRight.lean`
- no existing definition changed; the 14 importers see only additions. `[Fintype Segment]` is a genuine hypothesis (`Flat` slots are deliberately opaque); the boundary-augmented full-ISL statement remains the TODO, now with the reason it fails over raw strings