### PR TITLE
refactor(Core/Computability): drop Subregular namespace; types to root

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -78,7 +78,6 @@ import Linglib.Core.Computability.ContextFreeGrammar.Tree
 import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Computability.Definite
 import Linglib.Core.Computability.Dependence
-import Linglib.Core.Computability.Direction
 import Linglib.Core.Computability.ElgotMezei
 import Linglib.Core.Computability.Lens
 import Linglib.Core.Computability.Mealy
@@ -89,6 +88,7 @@ import Linglib.Core.Computability.NonContextFree.AnBnCnDn
 import Linglib.Core.Computability.NonContextFree.BlockWitness
 import Linglib.Core.Computability.NonRegular.AnBn
 import Linglib.Core.Computability.PiecewiseTestable
+import Linglib.Core.Computability.ScanDirection
 import Linglib.Core.Computability.StarFree
 import Linglib.Core.Computability.StrictlyLocal
 import Linglib.Core.Computability.StrictlyPiecewise

--- a/Linglib/Core/Computability/Aperiodicity.lean
+++ b/Linglib/Core/Computability/Aperiodicity.lean
@@ -49,13 +49,13 @@ regular.
 
 The SL and SP scanners share scaffolding *names* (`scanDFA`, `scanHom`, `evalFrom_none`,
 `isStarFree_of_language_succ`, …). Since `private` is module-scoped, each class's scaffolding is
-walled off in its own namespace — `Subregular.SL` and `Subregular.SP` — so the colliding names
+walled off in its own namespace — `SLGrammar` and `SPGrammar` — so the colliding names
 become distinct full names.
 -/
 
 open List
 
-namespace Subregular.SL
+namespace SLGrammar
 
 variable {α : Type*}
 
@@ -306,9 +306,9 @@ private theorem isStarFree_of_language_succ (L : Language α) [Finite α]
     (fun w => ?_)
   rw [← hL, Set.mem_setOf_eq, scanHom_unop_apply, ← DFA.evalFrom_of_append, alive_iff_mem_language]
 
-end Subregular.SL
+end SLGrammar
 
-namespace Subregular.SP
+namespace SPGrammar
 
 variable {α : Type*}
 
@@ -597,13 +597,12 @@ private theorem isStarFree_of_language_succ (L : Language α) [Finite α]
     rw [← hL]
     exact iff_of_false (fun h => h0 (h [] (Nat.zero_le _) (List.nil_sublist w))) (by simp)
 
-end Subregular.SP
+end SPGrammar
 
 namespace Language
 
 variable {α : Type*} [Finite α]
 
-open Subregular
 
 /-- **Strictly local languages are star-free** ([mcnaughton-papert-1971]). Over a finite
 alphabet, the local scanner remembering the last `k - 1` symbols is a finite aperiodic
@@ -623,7 +622,7 @@ theorem IsStrictlyLocal.isStarFree {L : Language α} {k : ℕ} (h : L.IsStrictly
     · simpa [hg] using fun f _ (hf : f = []) => hf ▸ hg
     · simp only [hg, if_false, Set.mem_empty_iff_false, iff_false, not_forall]
       exact ⟨[], List.nil_infix, rfl, hg⟩
-  · exact SL.isStarFree_of_language_succ G n L hG
+  · exact SLGrammar.isStarFree_of_language_succ G n L hG
 
 /-- **Strictly piecewise languages are star-free** ([heinz-rogers-2010]
 [mcnaughton-papert-1971]). Over a finite alphabet, the subsequence scanner remembering the
@@ -643,6 +642,6 @@ theorem IsStrictlyPiecewise.isStarFree {L : Language α} {k : ℕ} (h : L.IsStri
       exact fun s (hs : s.length ≤ 0) _ => List.length_eq_zero_iff.mp (Nat.le_zero.mp hs) ▸ hg
     · simp only [hg, if_neg, not_false_iff, Set.mem_empty_iff_false, iff_false, not_forall]
       exact ⟨[], le_rfl, List.nil_sublist _, hg⟩
-  · exact SP.isStarFree_of_language_succ G n L hG
+  · exact SPGrammar.isStarFree_of_language_succ G n L hG
 
 end Language

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -53,8 +53,6 @@ classical and not formalized here; `ElgotMezei.lean` proves the composition half
 [UPSTREAM] candidate: `Mathlib.Computability.Bimachine`.
 -/
 
-namespace Subregular
-
 variable {L R α β : Type*}
 
 /-- A bimachine is a left automaton scanning left to right, a right automaton scanning
@@ -517,4 +515,3 @@ theorem IsNonInteractingBimachineComputable.of_mealyComputable {f : List α → 
 
 end
 
-end Subregular

--- a/Linglib/Core/Computability/Boundary.lean
+++ b/Linglib/Core/Computability/Boundary.lean
@@ -19,16 +19,16 @@ the hierarchy quantifies over are a generic list combinator and live in
 
 ## Main definitions
 
-* `Subregular.Augmented α`: the boundary-augmented alphabet `List (Option α)`,
+* `Augmented α`: the boundary-augmented alphabet `List (Option α)`,
   with `none` the boundary marker.
-* `Subregular.boundary k w`: `w` injected into `Augmented α` and padded with
+* `boundary k w`: `w` injected into `Augmented α` and padded with
   `k - 1` boundary markers on each side.
-* `Subregular.IsBoundaryVacuous R`: `R` holds whenever either argument is the
+* `IsBoundaryVacuous R`: `R` holds whenever either argument is the
   boundary marker `none`.
 
 ## Main results
 
-* `Subregular.IsBoundaryVacuous.isChain_boundary_two_iff`: boundary padding does
+* `IsBoundaryVacuous.isChain_boundary_two_iff`: boundary padding does
   not change `IsChain`-membership for a boundary-vacuous relation.
 
 ## Implementation notes
@@ -39,8 +39,6 @@ one-fresh-symbol extension `Option α` (`none` = boundary, `some a` = original
 symbol): a single marker suffices because boundary symbols only ever occur at
 fixed positions, so the two edges are never confused.
 -/
-
-namespace Subregular
 
 variable {α : Type*}
 
@@ -189,4 +187,3 @@ lemma isChain_boundary_two_iff (hR : IsBoundaryVacuous R) (ys : List α) :
 
 end IsBoundaryVacuous
 
-end Subregular

--- a/Linglib/Core/Computability/ContainsFactor.lean
+++ b/Linglib/Core/Computability/ContainsFactor.lean
@@ -31,7 +31,6 @@ Star-free = `FO[<]`-definable = counter-free ([schutzenberger-1965] [mcnaughton-
 * `Language.isStarFree_avoidsFactor`: `{x | ¬ c <:+: x}` is star-free, `α` arbitrary.
 -/
 
-open Subregular
 
 namespace Language.ContainsFactor
 

--- a/Linglib/Core/Computability/Definite.lean
+++ b/Linglib/Core/Computability/Definite.lean
@@ -24,7 +24,7 @@ tests prefix and suffix jointly ([pin-mfa]).
 
 ## Main definitions
 
-* `Subregular.Edge` and `Subregular.Edge.takeAt`: a string edge and its length-`k`
+* `Edge` and `Edge.takeAt`: a string edge and its length-`k`
   substring (`right` = suffix, `left` = prefix).
 * `Language.IsDefinite`, `Language.IsReverseDefinite`, `Language.IsGeneralizedDefinite`
   — membership factoring through the suffix, prefix, and joint edge projections.
@@ -38,8 +38,6 @@ tests prefix and suffix jointly ([pin-mfa]).
   finite alphabet, `𝒩 = 𝒟 ∩ 𝒦` [pin-mfa]: a language is finite-or-cofinite iff it
   is definite and reverse-definite.
 -/
-
-namespace Subregular
 
 variable {α : Type*}
 
@@ -114,13 +112,10 @@ private lemma takeAt_left_eq_of_bridge {k k' : ℕ} {w₁ w₂ : List α}
   rw [Edge.takeAt_left, Edge.takeAt_left,
     List.take_append_of_le_length (by rw [List.length_take]; omega), List.take_take, min_self]
 
-end Subregular
-
 namespace Language
 
 variable {α : Type*}
 
-open Subregular
 
 /-! ### The definite family -/
 

--- a/Linglib/Core/Computability/Dependence.lean
+++ b/Linglib/Core/Computability/Dependence.lean
@@ -62,8 +62,6 @@ maps an out-of-range coordinate is `none` on both sides of any perturbation.
 companion of the transducer files.
 -/
 
-namespace Subregular
-
 open Set
 
 variable {α β : Type*} {f : List α → List β}
@@ -76,26 +74,26 @@ def LeftDetermined (f : List α → List β) (i : ℕ) : Prop :=
 
 /-- An equal-length variant of `base` differing only beyond the `d`-margin of target
 `i` on side `s`. -/
-def IsFarPerturbation (base u : List α) (i d : ℕ) (s : Direction) : Prop :=
+def IsFarPerturbation (base u : List α) (i d : ℕ) (s : ScanDirection) : Prop :=
   u.length = base.length ∧ EqOn (base[·]?) (u[·]?) (s.window i d)
 
 /-- `f` depends boundedly on side `s`: a single margin caps, at every output
 coordinate, how far input on side `s` can matter. -/
-def BoundedDependence (f : List α → List β) (s : Direction) : Prop :=
+def BoundedDependence (f : List α → List β) (s : ScanDirection) : Prop :=
   ∃ N, ∀ i, List.DependsOn (fun u => (f u)[i]?) (s.window i N)
 
 /-- `f` depends unboundedly on side `s`. -/
-def UnboundedDependence (f : List α → List β) (s : Direction) : Prop :=
+def UnboundedDependence (f : List α → List β) (s : ScanDirection) : Prop :=
   ¬ BoundedDependence f s
 
 /-- `f` fails unbounded dependence on side `s` exactly when its dependence there is
 bounded. -/
-@[simp] theorem not_unboundedDependence_iff {s : Direction} :
+@[simp] theorem not_unboundedDependence_iff {s : ScanDirection} :
     ¬ UnboundedDependence f s ↔ BoundedDependence f s := not_not
 
 /-- Unbounded dependence coordinate-wise: every margin fails at some output
 coordinate. -/
-theorem unboundedDependence_iff {s : Direction} :
+theorem unboundedDependence_iff {s : ScanDirection} :
     UnboundedDependence f s ↔
       ∀ N, ∃ i, ¬ List.DependsOn (fun u => (f u)[i]?) (s.window i N) := by
   simp [UnboundedDependence, BoundedDependence]
@@ -119,7 +117,7 @@ def TwoSidedUnboundedDependence (f : List α → List β) : Prop :=
 
 /-- Co-located two-sided dependence yields unbounded dependence on either side. -/
 theorem TwoSidedUnboundedDependence.unboundedDependence
-    (h : TwoSidedUnboundedDependence f) (s : Direction) : UnboundedDependence f s :=
+    (h : TwoSidedUnboundedDependence f) (s : ScanDirection) : UnboundedDependence f s :=
   unboundedDependence_iff.mpr fun N =>
     have ⟨_, i, _, hw⟩ := h N
     have ⟨_, ⟨hlen, hag⟩, hne⟩ := hw s
@@ -135,7 +133,7 @@ def RequiresBothSides (f : List α → List α) : Prop :=
 side may vary from cell to cell. -/
 def OneSidedChanges (f : List α → List α) : Prop :=
   ∀ (w : List α) (i : ℕ), (f w)[i]? ≠ w[i]? →
-    ∃ s : Direction, List.DependsAt (fun u => (f u)[i]?) (s.window i 0) w
+    ∃ s : ScanDirection, List.DependsAt (fun u => (f u)[i]?) (s.window i 0) w
 
 /-- A map that requires both sides has a change no single side determines. -/
 theorem RequiresBothSides.not_oneSidedChanges {f : List α → List α}
@@ -418,4 +416,3 @@ theorem setOf_isNonInteractingBimachineComputable_ssubset :
 
 end Machines
 
-end Subregular

--- a/Linglib/Core/Computability/ElgotMezei.lean
+++ b/Linglib/Core/Computability/ElgotMezei.lean
@@ -40,8 +40,6 @@ at all.
   bimachine (`IsLengthPreservingBimachineComputable`).
 -/
 
-namespace Subregular
-
 variable {α β γ σ₁ σ₂ : Type*}
 
 namespace SubsequentialTransducer
@@ -122,4 +120,3 @@ theorem Mealy.isBimachineComputable_runRight_comp [Fintype σ₁] [Fintype σ₂
   rw [isRightSubsequential_iff_left_reverse]
   simpa using T₂.isMealyComputable.isLeftSubsequential
 
-end Subregular

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -70,8 +70,6 @@ residuals is in `Core/Computability/MyhillNerode.lean`.
   from the language Myhill–Nerode theorem.
 -/
 
-namespace Subregular
-
 variable {σ α β : Type*}
 
 /-- A Mealy machine is a set of states (`σ`), a starting state (`initial`), a
@@ -341,4 +339,3 @@ theorem IsMealyComputable.isRegular_preimage {f : List α → List β}
   obtain ⟨τ, _, M, rfl⟩ := hL
   exact ⟨σ × τ, inferInstance, M.comapMealy T, M.accepts_comapMealy T⟩
 
-end Subregular

--- a/Linglib/Core/Computability/MyhillNerode.lean
+++ b/Linglib/Core/Computability/MyhillNerode.lean
@@ -46,8 +46,6 @@ bimachine of [reutenauer-schutzenberger-1991], surveyed in [filiot-reynier-2016]
 the existing file, with `residual` beside `Language.leftQuotient`).
 -/
 
-namespace Subregular
-
 variable {α β : Type*} (f : List α → List β)
 
 /-- The *residual* of `f` by `u` is what `f` appends after reading `u` — the analogue
@@ -155,7 +153,6 @@ theorem isMealyComputable_iff_residual {f : List α → List β} :
         ∧ (Set.range (residual f)).Finite :=
   ⟨fun hf => ⟨hf.length_eq, hf.isPrefix, hf.finite_range_residual⟩,
    fun h => isMealyComputable_of_residual h.1 h.2.1 h.2.2⟩
-
 
 /-! ### Coresiduals -/
 
@@ -340,4 +337,3 @@ theorem isLengthPreservingBimachineComputable_iff_residual {f : List α → List
   ⟨fun hf => ⟨hf.length_eq, hf.finite_range_residual, hf.finite_range_coresidual⟩,
    fun h => isLengthPreservingBimachineComputable_of_residual h.1 h.2.1 h.2.2⟩
 
-end Subregular

--- a/Linglib/Core/Computability/PiecewiseTestable.lean
+++ b/Linglib/Core/Computability/PiecewiseTestable.lean
@@ -26,8 +26,6 @@ piecewise analogue of locally testable over strictly local.
 * Closure under complement comes from `Function.FactorsThrough.comp_left`.
 -/
 
-namespace Subregular
-
 open List
 
 variable {α : Type*}
@@ -49,11 +47,8 @@ lemma subseqSet_eq_iff {k : ℕ} {w₁ w₂ : List α}
     s <+ w₁ ↔ s <+ w₂ := by
   simpa [hlen] using Set.ext_iff.mp heq s
 
-end Subregular
-
 namespace Language
 
-open Subregular
 
 variable {α : Type*}
 

--- a/Linglib/Core/Computability/ScanDirection.lean
+++ b/Linglib/Core/Computability/ScanDirection.lean
@@ -18,33 +18,33 @@ leaf so the footprint-predicate file (`Dependence.lean`) does not have to depend
 the transducer machine file just to name a `left`/`right` tag.
 -/
 
-namespace Subregular
-
 /-- The orientation of an FST scan: `left` consumes input head-first, `right`
 tail-first (via `List.reverse` conjugation). The two scan modes give rise to
 distinct function classes — isomorphic under reversal but not equal as
 subclasses of the rational functions over un-reversed strings. -/
-inductive Direction
+inductive ScanDirection
   | left
   | right
   deriving DecidableEq, Repr
 
 /-- The input positions not `d`-far from target `i` on side `s`. -/
-def Direction.window : Direction → ℕ → ℕ → Set ℕ
+def ScanDirection.window : ScanDirection → ℕ → ℕ → Set ℕ
   | .left, i, d => Set.Ici (i - d)
   | .right, i, d => Set.Iic (i + d)
 
-@[simp, grind =] theorem Direction.window_left {i d : ℕ} :
-    Direction.left.window i d = Set.Ici (i - d) := rfl
+@[simp, grind =] theorem ScanDirection.window_left {i d : ℕ} :
+    ScanDirection.left.window i d = Set.Ici (i - d) := rfl
 
-@[simp, grind =] theorem Direction.window_right {i d : ℕ} :
-    Direction.right.window i d = Set.Iic (i + d) := rfl
+@[simp, grind =] theorem ScanDirection.window_right {i d : ℕ} :
+    ScanDirection.right.window i d = Set.Iic (i + d) := rfl
 
 /-! ### Reverse conjugation
 
 The action of flipping scan direction on string functions: right-scan function classes
-are the `revConj`-images of the left-scan ones, so their theory transports along the
-involution rather than being restated. -/
+are the `List.revConj`-images of the left-scan ones, so their theory transports along
+the involution rather than being restated. -/
+
+namespace List
 
 variable {α β γ : Type*}
 
@@ -65,4 +65,5 @@ theorem revConj_eq_iff {h : List α → List β} {f : List α → List β} :
     revConj h = f ↔ h = revConj f := by
   constructor <;> rintro rfl <;> simp
 
-end Subregular
+end List
+

--- a/Linglib/Core/Computability/StrictlyLocal.lean
+++ b/Linglib/Core/Computability/StrictlyLocal.lean
@@ -18,10 +18,10 @@ permitted `k`-factors, and `w ∈ L` iff every `k`-factor of `boundary k w` lies
 
 ## Main definitions
 
-* `Subregular.SLGrammar α`: a grammar is just a set of permitted factors over
+* `SLGrammar α`: a grammar is just a set of permitted factors over
   `Augmented α`; the locality width `k` is supplied to `language`, not baked in.
-* `Subregular.SLGrammar.language k`: the `Language α` it generates at width `k`.
-* `Subregular.SLGrammar.ofForbidden`: the grammar of a forbidden-factor set (its
+* `SLGrammar.language k`: the `Language α` it generates at width `k`.
+* `SLGrammar.ofForbidden`: the grammar of a forbidden-factor set (its
   complement).
 * `Language.IsStrictlyLocal L k`: `L` is strictly `k`-local.
 * `Language.SuffixSubstitutionClosed L k`: members sharing a length-`(k − 1)` window
@@ -34,8 +34,6 @@ permitted `k`-factors, and `w ∈ L` iff every `k`-factor of `boundary k w` lies
   split into the two members' shared parts, and conversely the canonical grammar of
   licensed factors regenerates the language by stitching a member window-by-window.
 -/
-
-namespace Subregular
 
 variable {α : Type*}
 
@@ -106,13 +104,10 @@ theorem one_le_sum_count_of_not_mem_ofForbidden_language
 
 end SLGrammar
 
-end Subregular
-
 namespace Language
 
 variable {α : Type*}
 
-open Subregular
 
 /-- A language `L` is **strictly `k`-local** iff some `SLGrammar α` generates it at
 width `k`. Witness-style, mirroring `Language.IsRegular`/`Language.IsContextFree`

--- a/Linglib/Core/Computability/StrictlyPiecewise.lean
+++ b/Linglib/Core/Computability/StrictlyPiecewise.lean
@@ -16,9 +16,9 @@ factors, SP_k constrains long-distance co-occurrence via subsequences.
 
 ## Main definitions
 
-* `Subregular.SPGrammar α`: a set of permitted subsequences; the width `k` is
+* `SPGrammar α`: a set of permitted subsequences; the width `k` is
   supplied to `language`, not baked into the carrier.
-* `Subregular.SPGrammar.language k`: the `Language α` it generates: every subsequence of
+* `SPGrammar.language k`: the `Language α` it generates: every subsequence of
   `w` of length at most `k` must be permitted.
 * `Language.IsStrictlyPiecewise L k`: `L` is strictly `k`-piecewise.
 
@@ -32,10 +32,8 @@ factors, SP_k constrains long-distance co-occurrence via subsequences.
 `List.Sublist` (`<+`) is mathlib's non-contiguous "is a subsequence of", exactly the
 SP primitive. Unlike SL no boundary augmentation is needed, since subsequences are blind
 to position; the "≤ k" (rather than "exactly k") bound is instead what keeps words shorter
-than `k` distinguishable, matching `Subregular.subseqSet`.
+than `k` distinguishable, matching `subseqSet`.
 -/
-
-namespace Subregular
 
 open List
 
@@ -85,13 +83,11 @@ instance decidableMemLanguage (k : ℕ) (G : SPGrammar α)
 
 end SPGrammar
 
-end Subregular
-
 namespace Language
 
 variable {α : Type*} {L : Language α} {k : ℕ}
 
-open List Subregular
+open List
 
 /-- A language `L` is **strictly `k`-piecewise** iff some `SPGrammar α` generates it
 at width `k`. -/

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Finset.Lattice.Fold
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Data.Fintype.Transfer
 import Linglib.Core.Data.List.DropRight
-import Linglib.Core.Computability.Direction
+import Linglib.Core.Computability.ScanDirection
 
 /-!
 # Subsequential functions and finite-state transducers
@@ -58,8 +58,6 @@ state does not recover partiality — and the initial-output function of
 * Canonical forms and minimization; two-way transducers; p-subsequential functions.
 -/
 
-namespace Subregular
-
 variable {σ α β : Type*}
 
 /-- A subsequential finite-state transducer is a set of states (`σ`), a starting state
@@ -103,7 +101,7 @@ def run : List α → List β := T.runFrom T.start
 /-- `T.runRight x` runs `T` right-to-left on the input `x`. -/
 def runRight (xs : List α) : List β := (T.run xs.reverse).reverse
 
-theorem runRight_eq_revConj_run : T.runRight = revConj T.run := rfl
+theorem runRight_eq_revConj_run : T.runRight = List.revConj T.run := rfl
 
 section
 variable (s : σ) (x : α) (xs ys : List α)
@@ -355,11 +353,11 @@ def IsLeftSubsequential (f : List α → List β) : Prop :=
 is left-subsequential — equivalently, some finite-state transducer computes it via
 right-to-left scan (`isRightSubsequential_iff`). -/
 def IsRightSubsequential (f : List α → List β) : Prop :=
-  IsLeftSubsequential (revConj f)
+  IsLeftSubsequential (List.revConj f)
 
 /-- A function `f : List α → List β` is *subsequential in direction `d`* if some
 finite-state SubsequentialTransducer computes it via the corresponding scan direction. -/
-def IsSubsequential (d : Direction) (f : List α → List β) : Prop :=
+def IsSubsequential (d : ScanDirection) (f : List α → List β) : Prop :=
   match d with
   | .left => IsLeftSubsequential f
   | .right => IsRightSubsequential f
@@ -385,13 +383,13 @@ theorem isRightSubsequential_iff.{v} :
   constructor
   · intro h
     obtain ⟨σ, _, T, hT⟩ :=
-      isLeftSubsequential_iff.mp (show IsLeftSubsequential (revConj f) from h)
+      isLeftSubsequential_iff.mp (show IsLeftSubsequential (List.revConj f) from h)
     exact ⟨σ, inferInstance, T, by
-      rw [SubsequentialTransducer.runRight_eq_revConj_run, hT, revConj_revConj]⟩
+      rw [SubsequentialTransducer.runRight_eq_revConj_run, hT, List.revConj_revConj]⟩
   · rintro ⟨σ, _, T, rfl⟩
-    show IsLeftSubsequential (revConj T.runRight)
+    show IsLeftSubsequential (List.revConj T.runRight)
     exact isLeftSubsequential_iff.mpr ⟨σ, inferInstance, T, by
-      rw [SubsequentialTransducer.runRight_eq_revConj_run, revConj_revConj]⟩
+      rw [SubsequentialTransducer.runRight_eq_revConj_run, List.revConj_revConj]⟩
 
 /-- Every finite-state transducer computes a left-subsequential function, whatever the
 universe of its state type. -/
@@ -421,7 +419,7 @@ theorem isLeftSubsequential_id : IsLeftSubsequential (id : List α → List α) 
   isMealyComputable_id.isLeftSubsequential
 
 /-- A function is right-subsequential iff its reverse-conjugate is left-subsequential —
-definitionally: the right class is the `revConj`-image of the left class. -/
+definitionally: the right class is the `List.revConj`-image of the left class. -/
 theorem isRightSubsequential_iff_left_reverse :
     IsRightSubsequential f
       ↔ IsLeftSubsequential (fun xs => (f xs.reverse).reverse) :=
@@ -476,15 +474,14 @@ theorem IsLeftSubsequential.comp (hg : IsLeftSubsequential g)
 /-- Right-subsequential closure under composition: conjugate the left closure. -/
 theorem IsRightSubsequential.comp (hg : IsRightSubsequential g)
     (hf : IsRightSubsequential f) : IsRightSubsequential (g ∘ f) := by
-  show IsLeftSubsequential (revConj (g ∘ f))
-  rw [revConj_comp]
+  show IsLeftSubsequential (List.revConj (g ∘ f))
+  rw [List.revConj_comp]
   exact IsLeftSubsequential.comp hg hf
 
 /-- Subsequential functions are closed under composition in either scan direction. -/
-theorem IsSubsequential.comp {d : Direction} (hg : IsSubsequential d g)
+theorem IsSubsequential.comp {d : ScanDirection} (hg : IsSubsequential d g)
     (hf : IsSubsequential d f) : IsSubsequential d (g ∘ f) :=
   match d, hg, hf with
   | .left, hg, hf => IsLeftSubsequential.comp hg hf
   | .right, hg, hf => IsRightSubsequential.comp hg hf
 
-end Subregular

--- a/Linglib/Core/Computability/Variety/Definite.lean
+++ b/Linglib/Core/Computability/Variety/Definite.lean
@@ -44,7 +44,7 @@ theorems.
 
 namespace Language
 
-open Subregular FreeSemigroup
+open FreeSemigroup
 
 variable {α : Type*} {L : Language α} {k : ℕ}
 

--- a/Linglib/Core/Computability/Variety/Equations.lean
+++ b/Linglib/Core/Computability/Variety/Equations.lean
@@ -42,7 +42,6 @@ syntactic *semigroup* (no empty word); we keep mathlib's `Con (FreeMonoid α)` m
 and recover the characterization through this letter-sequence quantification.
 -/
 
-open Subregular
 
 namespace Language
 

--- a/Linglib/Core/Computability/Variety/OmegaEquations.lean
+++ b/Linglib/Core/Computability/Variety/OmegaEquations.lean
@@ -99,7 +99,6 @@ fork that substrate here; consume it from mathlib when it merges.
 * [mcnaughton-papert-1971] (variety theory of finite monoids).
 -/
 
-open Subregular
 
 namespace Language
 

--- a/Linglib/Phonology/Subregular/ISL.lean
+++ b/Linglib/Phonology/Subregular/ISL.lean
@@ -113,13 +113,13 @@ def IsLeftInputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
 /-- `f : List α → List β` is **k-Right-Input-Strictly-Local** iff its reverse-conjugate
 is k-Left-ISL — some `k`-ISL rule computes it via right-to-left scan. -/
 def IsRightInputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
-  IsLeftInputStrictlyLocal k (revConj f)
+  IsLeftInputStrictlyLocal k (List.revConj f)
 
-/-- Direction-parameterised ISL predicate. Mirrors the OSL/Subseq
+/-- ScanDirection-parameterised ISL predicate. Mirrors the OSL/Subseq
 umbrella style; concrete claims should typically use one of
 `IsLeftInputStrictlyLocal` / `IsRightInputStrictlyLocal` directly for
 clarity. -/
-def IsInputStrictlyLocal (d : Direction) (k : ℕ)
+def IsInputStrictlyLocal (d : ScanDirection) (k : ℕ)
     (f : List α → List β) : Prop :=
   match d with
   | .left => IsLeftInputStrictlyLocal k f
@@ -271,16 +271,16 @@ theorem isMealyComputable_of_ISLRule {k : ℕ} [Fintype α] (r : ISLRule k α β
       fun _ => rfl
 
 /-- **Right-ISL ⊆ Right-Subsequential**: the left inclusion at the reverse-conjugate,
-since both right classes are the `revConj`-images of their left classes. -/
+since both right classes are the `List.revConj`-images of their left classes. -/
 theorem isRightInputStrictlyLocal_right_subsequential {k : ℕ} [Fintype α]
     {f : List α → List β} (h : IsRightInputStrictlyLocal k f) :
     IsRightSubsequential f :=
   isLeftInputStrictlyLocal_left_subsequential h
 
-/-- Direction-parameterised: ISL_d ⊆ Subseq_d for both directions (over
+/-- ScanDirection-parameterised: ISL_d ⊆ Subseq_d for both directions (over
 a finite input alphabet). Delegates to the Left- / Right- specialised
 theorems. -/
-theorem isInputStrictlyLocal_isSubsequential {d : Direction} {k : ℕ}
+theorem isInputStrictlyLocal_isSubsequential {d : ScanDirection} {k : ℕ}
     [Fintype α] {f : List α → List β} (h : IsInputStrictlyLocal d k f) :
     IsSubsequential d f := by
   cases d with

--- a/Linglib/Phonology/Subregular/OSL.lean
+++ b/Linglib/Phonology/Subregular/OSL.lean
@@ -114,10 +114,10 @@ def IsLeftOutputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
 reverse-conjugate is k-Left-OSL — some `k`-OSL rule computes it via right-to-left
 scan. -/
 def IsRightOutputStrictlyLocal (k : ℕ) (f : List α → List β) : Prop :=
-  IsLeftOutputStrictlyLocal k (revConj f)
+  IsLeftOutputStrictlyLocal k (List.revConj f)
 
-/-- Direction-parameterised OSL predicate. -/
-def IsOutputStrictlyLocal (d : Direction) (k : ℕ) (f : List α → List β) : Prop :=
+/-- ScanDirection-parameterised OSL predicate. -/
+def IsOutputStrictlyLocal (d : ScanDirection) (k : ℕ) (f : List α → List β) : Prop :=
   match d with
   | .left => IsLeftOutputStrictlyLocal k f
   | .right => IsRightOutputStrictlyLocal k f
@@ -195,16 +195,16 @@ theorem isMealyComputable_of_OSLRule {k : ℕ} [Fintype β] (r : OSLRule k α β
       fun _ => rfl
 
 /-- **Right-OSL ⊆ Right-Subsequential**: the left inclusion at the reverse-conjugate,
-since both right classes are the `revConj`-images of their left classes. -/
+since both right classes are the `List.revConj`-images of their left classes. -/
 theorem isRightOutputStrictlyLocal_right_subsequential {k : ℕ} [Fintype β]
     {f : List α → List β} (h : IsRightOutputStrictlyLocal k f) :
     IsRightSubsequential f :=
   isLeftOutputStrictlyLocal_left_subsequential h
 
-/-- **Direction-parameterised OSL ⊆ Subsequential umbrella**: in both
+/-- **ScanDirection-parameterised OSL ⊆ Subsequential umbrella**: in both
 scan directions, OSL functions are subsequential. Delegates to the
 Left- / Right- specialised theorems. -/
-theorem isOutputStrictlyLocal_isSubsequential {d : Direction} {k : ℕ}
+theorem isOutputStrictlyLocal_isSubsequential {d : ScanDirection} {k : ℕ}
     [Fintype β] {f : List α → List β} (h : IsOutputStrictlyLocal d k f) :
     IsSubsequential d f := by
   cases d with

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -83,12 +83,11 @@ def Relation.flip : Relation → Relation
     - `.left` — `Rel(A, F) / C __` : context precedes the target
     - `.right` — `Rel(A, F) / __ C` : context follows the target
 
-    Aliased to `Subregular.Direction` so the same `.left` / `.right` cases used
-    by `Function/Subsequential.lean::Direction` (FST scan direction) and
-    by this file (context side of a tier rule) reduce to one inductive
-    type. The two roles read differently in prose but are isomorphic in
-    Lean. -/
-abbrev Side := Subregular.Direction
+    Aliased to `ScanDirection` so the same `.left` / `.right` cases used by
+    `Subsequential.lean` (FST scan direction) and by this file (context side
+    of a tier rule) reduce to one inductive type. The two roles read
+    differently in prose but are isomorphic in Lean. -/
+abbrev Side := ScanDirection
 
 /-- A tier-based alternation rule over alphabet `α`: project the word onto a tier,
     find the adjacent context segment on `side`, and fill the target's feature by

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -59,7 +59,7 @@ rendering) and `Studies/Yolyan2025` (BMRS rendering).
 
 namespace Tone.Plateauing
 
-open Subregular
+
 
 /-! ### The tone-bearing-unit alphabet -/
 

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -93,7 +93,6 @@ theorem Surfaces.lt_length {P : Surfacing α} {w : List α} {i : ℕ}
     (h : P.Surfaces w i) : i < w.length :=
   P.lt_length h
 
-open Subregular in
 /-- **The flank-witness template, at the surfacing level**: a process whose surfacing at
 a `d`-margined target in a flank word is switched on by the base flanks and off by
 either single flip requires both sides — supply only the three surfacing facts. -/
@@ -112,7 +111,6 @@ theorem requiresBothSides_of_flanks {xOn yOn xOff yOff : α} {n t : ℕ → ℕ}
     (fun d => P.map_getElem?_lo_iff.mpr ⟨by simpa using hlen d, hoffL d⟩)
     (fun d => P.map_getElem?_lo_iff.mpr ⟨hlen d, hoffR d⟩)
 
-open Subregular in
 /-- **Conjunctive two-sided triggers require both sides**: a process that surfaces the
 marked tone exactly where one occurrence lies at-or-before and one at-or-after needs
 unboundedly distant information on both sides — the flank witness family is generic. -/

--- a/Linglib/Processing/Lexical/Discriminative/Coding.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Coding.lean
@@ -9,10 +9,10 @@ import Linglib.Core.Data.List.Factors
 The interfaces by which linguistic objects feed the discriminative lexicon
 ([heitmeier-chuang-baayen-2026] ch. 4-5). A `Linearizable` type yields a
 symbol string; its cues are the `k`-factors of the boundary-augmented
-string — the same windowing as subregular locality (`Subregular.SLGrammar`)
+string — the same windowing as subregular locality (`SLGrammar`)
 — and its form vector is the binary cue indicator (Box 4.2: the `C` matrix
 holds only 1s and 0s, not counts; the count refinement is where strict
-locality's unit margin lives, `Subregular.SLGrammar`). A `SemanticPrimitives`
+locality's unit margin lives, `SLGrammar`). A `SemanticPrimitives`
 type yields a multiset of atomic semantic primitives — a lexeme plus
 inflectional-function tags (the book's term, ch. 5) — and `conceptualize`
 builds its meaning vector as the sum of primitive embeddings: the book's
@@ -26,7 +26,7 @@ decompositions. The stem-exponent fourth proportional of
 
 namespace Processing.Lexical.Discriminative
 
-open Subregular
+
 
 /-! ### Form side -/
 

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -56,7 +56,7 @@ The map itself and its plateau/circumambience API live in `Phonology/Tone/Platea
 
 namespace Jardine2016Tone
 
-open Subregular Tone.Plateauing
+open Tone.Plateauing
 
 variable {w : List TBU} {i j k : ℕ}
 

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -49,8 +49,7 @@ deterministic) is what that witness feeds.
 
 namespace McCollumEtAl2020
 
-open Subregular
-open Subregular (Direction)
+
 
 /-! ### Alphabet and the conditional-blocking rule -/
 
@@ -285,7 +284,7 @@ theorem tutrugbu_requiresBothSides : RequiresBothSides tutrugbuATR := by
     · simp only [baseL, base, pre, List.length_cons, List.length_append,
         List.length_replicate, List.length_nil]
     · intro k hk
-      simp only [Direction.window_left, Set.mem_Ici] at hk
+      simp only [ScanDirection.window_left, Set.mem_Ici] at hk
       cases k with
       | zero => omega
       | succ k' => simp only [base, baseL, pre, List.cons_append, List.getElem?_cons_succ]
@@ -296,7 +295,7 @@ theorem tutrugbu_requiresBothSides : RequiresBothSides tutrugbuATR := by
     · simp only [baseR, base, pre, List.length_cons, List.length_append,
         List.length_replicate, List.length_nil]
     · intro k hk
-      simp only [Direction.window_right, Set.mem_Iic] at hk
+      simp only [ScanDirection.window_right, Set.mem_Iic] at hk
       show (base d)[k]? = (baseR d)[k]?
       rw [show base d = pre Seg.vLo d ++ [.rP] from rfl,
           show baseR d = pre Seg.vLo d ++ [.rM] from rfl,
@@ -314,7 +313,7 @@ theorem tutrugbu_twoSidedUnboundedDependence : TwoSidedUnboundedDependence tutru
 ([mccollum-bakovic-mai-meinhardt-2020]; [wilson-2006]). A segmental counterexample to
 the myopia generalisation defended by [kimper-2012] and [mascaro-2019], on the
 nonmyopic side argued by [walker-2010]. -/
-theorem tutrugbu_nonmyopic (s : Direction) : UnboundedDependence tutrugbuATR s :=
+theorem tutrugbu_nonmyopic (s : ScanDirection) : UnboundedDependence tutrugbuATR s :=
   tutrugbu_twoSidedUnboundedDependence.unboundedDependence s
 
 /-- **Tutrugbu is not semiambient** — where Maasai's changes are each licensed by one

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -148,8 +148,8 @@ theorem not_isBmrsWeaklyDeterministic_of_requiresBothSides {f : List α → List
   obtain ⟨base, i, hi, hchange, hw⟩ := hf 0
   obtain ⟨uL, ⟨hLlen, hLag⟩, hLsym, hLrev⟩ := hw .left
   obtain ⟨uR, ⟨hRlen, hRag⟩, hRsym, hRrev⟩ := hw .right
-  simp only [Direction.window_left, Nat.sub_zero] at hLag
-  simp only [Direction.window_right, Nat.add_zero] at hRag
+  simp only [ScanDirection.window_left, Nat.sub_zero] at hLag
+  simp only [ScanDirection.window_right, Nat.add_zero] at hRag
   set σ := base[i]'hi with hσ
   have hbase : base[i]? = some σ := List.getElem?_eq_getElem hi
   -- the far-left run: the target is unchanged, so both components are forced true


### PR DESCRIPTION
Closes the namespace item open since the alignment arc (#1658–#1667): the 13 Core/Computability files drop `namespace Subregular`, putting the machine and language types at root, mathlib-style (`DFA`/`NFA`/`Language` precedent). `Phonology/Subregular/` keeps the namespace — it is the research program's vocabulary at the theory layer.

- `Direction` → `ScanDirection` (file renamed to match; a bare root `Direction` is too generic), `revConj` → `List.revConj` (joining the `List.rtake` extension precedent)
- Aperiodicity's internal scanner namespaces `Subregular.SL`/`SP` → `SLGrammar`/`SPGrammar`
- stranded `open Subregular` sites classified by import cone: stripped where only Core is imported, kept where Phonology/Subregular still exports the namespace
- no declarations renamed beyond the two above; qualified references and docstring mentions updated