### PR TITLE
refactor(Phonology/Subregular): demote boundary augmentation from Core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -67,7 +67,6 @@ import Linglib.Core.Combinatorics.Antimatroid
 import Linglib.Core.Combinatorics.RootedTree.Aut
 import Linglib.Core.Combinatorics.RootedTree.ContractUnary
 import Linglib.Core.Computability.Bimachine
-import Linglib.Core.Computability.Boundary
 import Linglib.Core.Computability.ContextFreeGrammar.Closure
 import Linglib.Core.Computability.ContextFreeGrammar.InterRegular
 import Linglib.Core.Computability.ContextFreeGrammar.Map
@@ -1349,6 +1348,7 @@ import Linglib.Phonology.Prosody.Word
 import Linglib.Phonology.Subregular.Agree
 import Linglib.Phonology.Subregular.Aperiodicity
 import Linglib.Phonology.Subregular.BMRS
+import Linglib.Phonology.Subregular.Boundary
 import Linglib.Phonology.Subregular.ContainsFactor
 import Linglib.Phonology.Subregular.ForbidPairs
 import Linglib.Phonology.Subregular.ForbiddenPairs

--- a/Linglib/Phonology/Subregular/Boundary.lean
+++ b/Linglib/Phonology/Subregular/Boundary.lean
@@ -19,7 +19,7 @@ the hierarchy quantifies over are a generic list combinator and live in
 
 ## Main definitions
 
-* `Augmented α`: the boundary-augmented alphabet `List (Option α)`,
+* `Augmented α`: boundary-augmented strings `List (Option α)`,
   with `none` the boundary marker.
 * `boundary k w`: `w` injected into `Augmented α` and padded with
   `k - 1` boundary markers on each side.
@@ -44,7 +44,7 @@ variable {α : Type*}
 
 /-! ### Boundary augmentation -/
 
-/-- The boundary-augmented alphabet: original symbols (`some a`) plus the
+/-- Boundary-augmented strings: original symbols (`some a`) plus the
 boundary marker `none`. -/
 abbrev Augmented (α : Type*) := List (Option α)
 

--- a/Linglib/Phonology/Subregular/StrictlyLocal.lean
+++ b/Linglib/Phonology/Subregular/StrictlyLocal.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Computability.Language
-import Linglib.Core.Computability.Boundary
+import Linglib.Phonology.Subregular.Boundary
 import Linglib.Core.Data.List.Factors
 
 /-!

--- a/Linglib/Processing/Lexical/Discriminative/Coding.lean
+++ b/Linglib/Processing/Lexical/Discriminative/Coding.lean
@@ -1,5 +1,5 @@
 import Linglib.Processing.Lexical.Discriminative.Defs
-import Linglib.Core.Computability.Boundary
+import Linglib.Phonology.Subregular.Boundary
 import Linglib.Core.Data.List.Factors
 
 /-!


### PR DESCRIPTION
Boundary.lean is the subregular program's ⋊/⋉ padding convention (and cites three program papers, against the Core citation rule); after #1707 its only importers are Phonology/Subregular/StrictlyLocal and Processing's discriminative coding, so it moves beside its consumers. Also fixes the docstring calling `Augmented α` an alphabet — it is the augmented-string type. The pinning bridge targets (`List.config`/`List.window`) stay in Core/Data/List.