### PR TITLE
refactor(Phonology/Subregular): demote dependence lattice from Core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -74,7 +74,6 @@ import Linglib.Core.Computability.ContextFreeGrammar.Pumping
 import Linglib.Core.Computability.ContextFreeGrammar.Tree
 import Linglib.Core.Computability.ContextFreeGrammar.Weighted
 import Linglib.Core.Computability.Definite
-import Linglib.Core.Computability.Dependence
 import Linglib.Core.Computability.ElgotMezei
 import Linglib.Core.Computability.Lens
 import Linglib.Core.Computability.Mealy
@@ -1350,6 +1349,7 @@ import Linglib.Phonology.Subregular.Aperiodicity
 import Linglib.Phonology.Subregular.BMRS
 import Linglib.Phonology.Subregular.Boundary
 import Linglib.Phonology.Subregular.ContainsFactor
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Phonology.Subregular.ForbidPairs
 import Linglib.Phonology.Subregular.ForbiddenPairs
 import Linglib.Phonology.Subregular.Harmony

--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -9,7 +9,7 @@ import Linglib.Core.Data.Fintype.Transfer
 import Linglib.Core.Data.List.Fold
 
 /-!
-# Bimachines and non-interaction
+# Bimachines
 
 A `Bimachine` ([schutzenberger-1961]; [eilenberg-1974]) reads its input in both
 directions: a left automaton scans `→`, a right automaton scans `←`, and output `i` is
@@ -18,23 +18,11 @@ compute exactly the rational functions ([elgot-mezei-1965]; they are the transdu
 [schutzenberger-1976]'s semi-monomial representations, see [sakarovitch-2009]); the
 letter-to-letter machines here compute the total length-preserving ones.
 
-A bimachine over a single alphabet is **non-interacting** when its output is an
-order-independent union of one-sided change-rules over the identity: each side may add
-its own change, the sides agree wherever both fire, and neither can suppress the
-other's.
-`IsNonInteractingBimachineComputable` is computability by such a bimachine — an extra
-restriction on the Elgot–Mezei factorization, not a consequence of it.
-
 ## Main definitions
 
 * `Bimachine L R α β`: machine with left states `L`, right states `R`, alphabets `α`, `β`
 * `Bimachine.run`: the computed function
-* `Bimachine.NonInteraction`, `Bimachine.IsNonInteracting`: a decomposition of the
-  cell output as an order-independent union of one-sided change-rules over the
-  identity, and its existence
 * `IsBimachineComputable f`: `f` is computed by some finite bimachine
-* `IsNonInteractingBimachineComputable f`: `f` is computed by some non-interacting
-  finite bimachine
 
 ## Main theorems
 
@@ -45,8 +33,8 @@ restriction on the Elgot–Mezei factorization, not a consequence of it.
 
 Only the left state is threaded through the run (`Bimachine.runFrom`); the recursion
 reads each tail's right state on the spot. The class existentials pin state types at
-`Type 0`; the universe-polymorphic `isBimachineComputable_iff` and
-`isNonInteractingBimachineComputable_iff` recover generality. The identification of
+`Type 0`; the universe-polymorphic `isBimachineComputable_iff` recovers generality.
+The identification of
 `IsBimachineComputable` with the total rational functions preserving the empty word is
 classical and not formalized here; `ElgotMezei.lean` proves the composition half.
 
@@ -260,118 +248,6 @@ theorem getElem?_ofFlags_run (x : List α) (i : ℕ) :
       = x[i]?.map fun a => out ((x.take i).any pL) a ((x.drop (i + 1)).any pR) := by
   simp [(ofFlags_letterToLetter pL pR out).getElem?_run, ofFlags_letterToLetter]
 
-/-! ### Non-interacting decompositions -/
-
-/-- The output at a cell is determined by one side alone: fixing the input symbol and
-one context state already fixes it. -/
-def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
-  (∀ r', B.output l a r' = B.output l a r) ∨ (∀ l', B.output l' a r = B.output l a r)
-
-section
-
-variable [DecidableEq α]
-
-/-- `unite cL cR a` takes the left proposal if it fires (`≠ a`), else the right one —
-the union of two change proposals over the identity default `a`. The tie-break is
-asymmetric (when both fire the left wins) but inert under the order-independence
-`IsNonInteracting` requires. -/
-def unite (cL cR a : α) : α := if cL = a then cR else cL
-
-/-- With the right proposal inert, the union is whatever the left one proposes. -/
-@[simp] theorem unite_right_self (cL a : α) : unite cL a a = cL := by
-  grind [unite]
-
-/-- With the left proposal inert, the union is whatever the right one proposes. -/
-@[simp] theorem unite_left_self (cR a : α) : unite a cR a = cR := if_pos rfl
-
-/-- A firing left proposal wins. -/
-theorem unite_of_left_ne {cL a : α} (h : cL ≠ a) (cR : α) : unite cL cR a = cL := if_neg h
-
-/-- The union is order-independent exactly when the proposals agree wherever both
-fire. -/
-theorem unite_comm_iff {cL cR a : α} :
-    unite cL cR a = unite cR cL a ↔ (cL ≠ a → cR ≠ a → cL = cR) := by
-  grind [unite]
-
-/-- The combined value is the default exactly when *both* one-sided proposals are
-inert. -/
-@[simp] theorem unite_eq_self_iff {cL cR a : α} : unite cL cR a = a ↔ cL = a ∧ cR = a := by
-  grind [unite]
-
-/-- A non-interacting decomposition of a bimachine: a change-rule per side over the
-identity default, whose union is order-independent and produces the cell output. -/
-structure NonInteraction (B : Bimachine L R α α) where
-  /-- The change the left context proposes for the current symbol. -/
-  ruleL : L → α → α
-  /-- The change the right context proposes for the current symbol. -/
-  ruleR : R → α → α
-  /-- The union of the two proposals is order-independent (`unite_comm_iff`: they agree
-  wherever both fire), so neither side can suppress the other's change. -/
-  unite_comm : ∀ l a r, unite (ruleL l a) (ruleR r a) a = unite (ruleR r a) (ruleL l a) a
-  /-- The cell output is the union of the two proposals. -/
-  output_eq : ∀ l a r, B.output l a r = [unite (ruleL l a) (ruleR r a) a]
-
-/-- A bimachine over a single alphabet is non-interacting when it admits a
-non-interacting decomposition (`NonInteraction`) of its cell output. -/
-def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
-
-variable {L' R' : Type*} {B : Bimachine L R α α} (w : B.NonInteraction) {l : L} {a : α}
-  {r : R}
-
-/-- A non-interacting decomposition exhibits the bimachine as letter-to-letter. -/
-def NonInteraction.letterToLetter : B.LetterToLetter :=
-  ⟨fun l a r => unite (w.ruleL l a) (w.ruleR r a) a, w.output_eq⟩
-
-/-- A firing left rule alone determines the output. -/
-theorem NonInteraction.output_eq_ruleL (hL : w.ruleL l a ≠ a) :
-    B.output l a r = [w.ruleL l a] :=
-  (w.output_eq l a r).trans (by rw [unite_of_left_ne hL])
-
-/-- A firing right rule alone determines the output — order-independence of the union
-is what silences the left state. -/
-theorem NonInteraction.output_eq_ruleR (hR : w.ruleR r a ≠ a) :
-    B.output l a r = [w.ruleR r a] :=
-  (w.output_eq l a r).trans (by rw [w.unite_comm l a r, unite_of_left_ne hR])
-
-/-- At every cell whose output differs from the input symbol, a decomposed bimachine is
-one-sided: the change is the left rule's alone or the right rule's alone. -/
-theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction)
-    (hne : B.output l a r ≠ [a]) : B.OneSidedAt l a r := by
-  by_cases hL : w.ruleL l a = a
-  · have hR : w.ruleR r a ≠ a := fun hR =>
-      hne ((w.output_eq l a r).trans (by rw [unite_eq_self_iff.mpr ⟨hL, hR⟩]))
-    exact .inr fun l' => (w.output_eq_ruleR hR).trans (w.output_eq_ruleR hR).symm
-  · exact .inl fun r' => (w.output_eq_ruleL hL).trans (w.output_eq_ruleL hL).symm
-
-/-- At every cell whose output differs from the input symbol, a non-interacting
-bimachine is one-sided. -/
-theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting)
-    (hne : B.output l a r ≠ [a]) : B.OneSidedAt l a r :=
-  h.elim fun w => w.oneSidedAt_of_change hne
-
-/-- Transport a decomposition along state equivalences. -/
-def NonInteraction.map (eL : L ≃ L') (eR : R ≃ R') :
-    (Bimachine.map eL eR B).NonInteraction where
-  ruleL l a := w.ruleL (eL.symm l) a
-  ruleR r a := w.ruleR (eR.symm r) a
-  unite_comm _ a _ := w.unite_comm _ a _
-  output_eq _ a _ := w.output_eq _ a _
-
-/-- Non-interaction transports along state reindexing. -/
-theorem IsNonInteracting.map (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
-    (Bimachine.map eL eR B).IsNonInteracting :=
-  Nonempty.map (·.map eL eR) h
-
-/-- A decomposed bimachine fixes cell `i` exactly when both change-proposals are inert
-at its two context states. -/
-theorem NonInteraction.getElem?_run_eq_iff {u : List α} {i : ℕ} (hsym : u[i]? = some a) :
-    (B.run u)[i]? = u[i]? ↔
-      w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
-  rw [w.letterToLetter.getElem?_run u i, hsym, Option.map_some, Option.some_inj]
-  exact unite_eq_self_iff
-
-end
-
 end Bimachine
 
 /-! ### Sequential machines as bimachines -/
@@ -459,59 +335,3 @@ theorem IsBimachineComputable.of_mealyComputable {f : List α → List β}
     (h : IsMealyComputable f) : IsBimachineComputable f :=
   have ⟨_, _, T, hT⟩ := h
   hT ▸ T.toBimachine_run ▸ T.toBimachine.isBimachineComputable
-
-/-! ### The non-interacting class -/
-
-section
-
-variable [DecidableEq α]
-
-/-- Computability by a non-interacting finite bimachine. -/
-def IsNonInteractingBimachineComputable (f : List α → List α) : Prop :=
-  ∃ (L : Type) (_ : Fintype L) (R : Type) (_ : Fintype R) (B : Bimachine L R α α),
-    B.run = f ∧ B.IsNonInteracting
-/-- `f` is computed by a non-interacting finite bimachine if and only if it is computed
-by one with state types in any universes. -/
-theorem isNonInteractingBimachineComputable_iff.{v, w} {f : List α → List α} :
-    IsNonInteractingBimachineComputable f
-      ↔ ∃ (L : Type v) (_ : Fintype L) (R : Type w) (_ : Fintype R)
-          (B : Bimachine L R α α), B.run = f ∧ B.IsNonInteracting :=
-  exists_fintype₂_congr
-    (fun eL eR ⟨B, hB, h⟩ =>
-      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
-    (fun eL eR ⟨B, hB, h⟩ =>
-      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
-
-/-- A non-interacting finite-state bimachine witnesses
-`IsNonInteractingBimachineComputable` for its `run`, whatever the universes of its
-state types (`IsNonInteracting.map`). -/
-theorem Bimachine.isNonInteractingBimachineComputable {L R : Type*} [Fintype L]
-    [Fintype R] (B : Bimachine L R α α) (h : B.IsNonInteracting) :
-    IsNonInteractingBimachineComputable B.run :=
-  isNonInteractingBimachineComputable_iff.mpr ⟨L, inferInstance, R, inferInstance, B, rfl, h⟩
-
-/-- A function computed by a non-interacting bimachine is in particular
-bimachine-computable. -/
-theorem IsBimachineComputable.of_nonInteracting {f : List α → List α}
-    (h : IsNonInteractingBimachineComputable f) : IsBimachineComputable f :=
-  have ⟨_, _, _, _, B, hB, _⟩ := h
-  hB ▸ B.isBimachineComputable
-
-/-- Functions computed by non-interacting bimachines are length-preserving. -/
-theorem IsNonInteractingBimachineComputable.length_eq {f : List α → List α}
-    (h : IsNonInteractingBimachineComputable f) (x : List α) : (f x).length = x.length :=
-  have ⟨_, _, _, _, _, hB, ⟨w⟩⟩ := h
-  hB ▸ w.letterToLetter.length_run x
-/-- A Mealy-computable function is computed by a non-interacting bimachine: the
-bimachine view (`Mealy.toBimachine`) has a trivial right automaton, so the cell output
-is a one-sided rule with `ωR` the identity. -/
-theorem IsNonInteractingBimachineComputable.of_mealyComputable {f : List α → List α}
-    (h : IsMealyComputable f) : IsNonInteractingBimachineComputable f :=
-  have ⟨_, _, T, hT⟩ := h
-  hT ▸ T.toBimachine_run ▸ T.toBimachine.isNonInteractingBimachineComputable
-    ⟨⟨T.output, fun _ a => a,
-      fun _ a _ => (Bimachine.unite_right_self _ a).trans (Bimachine.unite_left_self _ a).symm,
-      fun _ a _ => by simp⟩⟩
-
-end
-

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.List.Basic
 import Mathlib.Logic.Equiv.Defs
 import Linglib.Core.Data.Fintype.Transfer
+import Linglib.Core.Data.List.EqOn
 import Linglib.Core.Data.List.Fold
 
 /-!
@@ -339,3 +340,21 @@ theorem IsMealyComputable.isRegular_preimage {f : List α → List β}
   obtain ⟨τ, _, M, rfl⟩ := hL
   exact ⟨σ × τ, inferInstance, M.comapMealy T, M.accepts_comapMealy T⟩
 
+
+/-! ### Causality -/
+
+/-- A sequential machine's output coordinate `i` depends only on the input prefix
+`Set.Iic i`. -/
+theorem Mealy.dependsOn_run_Iic {σ : Type*} (T : Mealy σ α β) (i : ℕ) :
+    List.DependsOn (fun u => (T.run u)[i]?) (Set.Iic i) := by
+  intro u v hlen hag
+  show (T.run u)[i]? = (T.run v)[i]?
+  rw [T.getElem?_run u, T.getElem?_run v, hag.getElem?_eq (Set.mem_Iic.mpr le_rfl),
+    List.take_eq_of_agree fun k hk => hag.getElem?_eq (Set.mem_Iic.mpr hk.le)]
+
+/-- A Mealy-computable map's output coordinate `i` depends only on the input prefix
+`Set.Iic i`. -/
+theorem IsMealyComputable.dependsOn_Iic {f : List α → List β}
+    (hf : IsMealyComputable f) (i : ℕ) : List.DependsOn (fun u => (f u)[i]?) (Set.Iic i) := by
+  obtain ⟨σ, _, T, rfl⟩ := hf
+  exact T.dependsOn_run_Iic i

--- a/Linglib/Core/Computability/Subsequential.lean
+++ b/Linglib/Core/Computability/Subsequential.lean
@@ -11,6 +11,7 @@ import Mathlib.Data.Finset.Lattice.Fold
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Data.Fintype.Transfer
 import Linglib.Core.Data.List.DropRight
+import Linglib.Core.Data.List.EqOn
 import Linglib.Core.Computability.ScanDirection
 
 /-!
@@ -450,6 +451,22 @@ theorem IsLeftSubsequential.exists_getElem?_append_eq (hf : IsLeftSubsequential 
     simp only [List.length_append] at hlen
     omega
   rw [hu, huv, List.getElem?_append_left hip, List.getElem?_append_left hip]
+
+/-- A length-preserving left-subsequential function is oblivious to input beyond a fixed
+margin of each output coordinate: the delay bound of `exists_getElem?_append_eq` caps how
+far to the right an output coordinate can look. -/
+theorem IsLeftSubsequential.exists_dependsOn_Iic
+    (hlen : ∀ w, (f w).length = w.length) (hf : IsLeftSubsequential f) :
+    ∃ N, ∀ i, List.DependsOn (fun u => (f u)[i]?) (Set.Iic (i + N)) := by
+  obtain ⟨N, hN⟩ := hf.exists_getElem?_append_eq
+  refine ⟨N, fun i u v _ hag => ?_⟩
+  show (f u)[i]? = (f v)[i]?
+  have key : ∀ w : List α, (f (w.take (i + N + 1)))[i]? = (f w)[i]? := fun w => by
+    rcases lt_or_ge w.length (i + N + 1) with h | h
+    · rw [List.take_of_length_le h.le]
+    · conv_rhs => rw [← List.take_append_drop (i + N + 1) w]
+      exact hN _ _ i (by rw [hlen, List.length_take]; omega)
+  rw [← key u, ← key v, hag.take_eq (by omega)]
 
 /-- `f` is not left-subsequential if for every `N` some images `f u` and `f (u ++ v)`
 disagree more than `N` positions before the end of `f u` — the contrapositive of

--- a/Linglib/Phonology/Subregular/Dependence.lean
+++ b/Linglib/Phonology/Subregular/Dependence.lean
@@ -16,7 +16,10 @@ single margin caps the influence of side `s` at every output coordinate,
 `TwoSidedUnboundedDependence` places one target under the influence of both sides,
 and `RequiresBothSides` demands both sides at once. `flankWord` is the witness family
 instantiating the negative side: a target buried in a filler run between two
-independently editable flanks.
+independently editable flanks. The **non-interacting** bimachines — the weak-determinism
+class of [meinhardt-mai-bakovic-mccollum-2024], whose cell output is an order-independent
+union of one-sided change-rules over the identity — live here with their exclusion and
+separation theorems.
 
 ## Main definitions
 
@@ -30,6 +33,10 @@ independently editable flanks.
 * `OneSidedChanges f`: every changed cell is determined by one side of its input
   alone
 * `flankWord x fill y n`: a target buried in a filler run with editable flanks
+* `Bimachine.NonInteraction`, `Bimachine.IsNonInteracting`: the cell output decomposed
+  as an order-independent union of one-sided change-rules over the identity
+* `IsNonInteractingBimachineComputable f`: `f` is computed by some non-interacting
+  finite bimachine
 
 ## Main theorems
 
@@ -57,9 +64,6 @@ witnesses. The forms are margin-indexed rather than fixed-index because a fixed
 target has only finitely many positions to its left.
 The predicates place no in-range guard on target coordinates: for length-preserving
 maps an out-of-range coordinate is `none` on both sides of any perturbation.
-
-[UPSTREAM] candidate: `Mathlib.Computability.Dependence`, the window-dependence
-companion of the transducer files.
 -/
 
 open Set
@@ -280,6 +284,180 @@ theorem RequiresBothSides.of_flanks {f : List α → List α}
 
 end FlankWitness
 
+/-! ### Non-interacting bimachines: the apparatus -/
+
+namespace Bimachine
+
+variable {L R : Type*}
+
+/-! ### Non-interacting decompositions -/
+
+/-- The output at a cell is determined by one side alone: fixing the input symbol and
+one context state already fixes it. -/
+def OneSidedAt (B : Bimachine L R α β) (l : L) (a : α) (r : R) : Prop :=
+  (∀ r', B.output l a r' = B.output l a r) ∨ (∀ l', B.output l' a r = B.output l a r)
+
+section
+
+variable [DecidableEq α]
+
+/-- `unite cL cR a` takes the left proposal if it fires (`≠ a`), else the right one —
+the union of two change proposals over the identity default `a`. The tie-break is
+asymmetric (when both fire the left wins) but inert under the order-independence
+`IsNonInteracting` requires. -/
+def unite (cL cR a : α) : α := if cL = a then cR else cL
+
+/-- With the right proposal inert, the union is whatever the left one proposes. -/
+@[simp] theorem unite_right_self (cL a : α) : unite cL a a = cL := by
+  grind [unite]
+
+/-- With the left proposal inert, the union is whatever the right one proposes. -/
+@[simp] theorem unite_left_self (cR a : α) : unite a cR a = cR := if_pos rfl
+
+/-- A firing left proposal wins. -/
+theorem unite_of_left_ne {cL a : α} (h : cL ≠ a) (cR : α) : unite cL cR a = cL := if_neg h
+
+/-- The union is order-independent exactly when the proposals agree wherever both
+fire. -/
+theorem unite_comm_iff {cL cR a : α} :
+    unite cL cR a = unite cR cL a ↔ (cL ≠ a → cR ≠ a → cL = cR) := by
+  grind [unite]
+
+/-- The combined value is the default exactly when *both* one-sided proposals are
+inert. -/
+@[simp] theorem unite_eq_self_iff {cL cR a : α} : unite cL cR a = a ↔ cL = a ∧ cR = a := by
+  grind [unite]
+
+/-- A non-interacting decomposition of a bimachine: a change-rule per side over the
+identity default, whose union is order-independent and produces the cell output. -/
+structure NonInteraction (B : Bimachine L R α α) where
+  /-- The change the left context proposes for the current symbol. -/
+  ruleL : L → α → α
+  /-- The change the right context proposes for the current symbol. -/
+  ruleR : R → α → α
+  /-- The union of the two proposals is order-independent (`unite_comm_iff`: they agree
+  wherever both fire), so neither side can suppress the other's change. -/
+  unite_comm : ∀ l a r, unite (ruleL l a) (ruleR r a) a = unite (ruleR r a) (ruleL l a) a
+  /-- The cell output is the union of the two proposals. -/
+  output_eq : ∀ l a r, B.output l a r = [unite (ruleL l a) (ruleR r a) a]
+
+/-- A bimachine over a single alphabet is non-interacting when it admits a
+non-interacting decomposition (`NonInteraction`) of its cell output. -/
+def IsNonInteracting (B : Bimachine L R α α) : Prop := Nonempty B.NonInteraction
+
+variable {L' R' : Type*} {B : Bimachine L R α α} (w : B.NonInteraction) {l : L} {a : α}
+  {r : R}
+
+/-- A non-interacting decomposition exhibits the bimachine as letter-to-letter. -/
+def NonInteraction.letterToLetter : B.LetterToLetter :=
+  ⟨fun l a r => unite (w.ruleL l a) (w.ruleR r a) a, w.output_eq⟩
+
+/-- A firing left rule alone determines the output. -/
+theorem NonInteraction.output_eq_ruleL (hL : w.ruleL l a ≠ a) :
+    B.output l a r = [w.ruleL l a] :=
+  (w.output_eq l a r).trans (by rw [unite_of_left_ne hL])
+
+/-- A firing right rule alone determines the output — order-independence of the union
+is what silences the left state. -/
+theorem NonInteraction.output_eq_ruleR (hR : w.ruleR r a ≠ a) :
+    B.output l a r = [w.ruleR r a] :=
+  (w.output_eq l a r).trans (by rw [w.unite_comm l a r, unite_of_left_ne hR])
+
+/-- At every cell whose output differs from the input symbol, a decomposed bimachine is
+one-sided: the change is the left rule's alone or the right rule's alone. -/
+theorem NonInteraction.oneSidedAt_of_change (w : B.NonInteraction)
+    (hne : B.output l a r ≠ [a]) : B.OneSidedAt l a r := by
+  by_cases hL : w.ruleL l a = a
+  · have hR : w.ruleR r a ≠ a := fun hR =>
+      hne ((w.output_eq l a r).trans (by rw [unite_eq_self_iff.mpr ⟨hL, hR⟩]))
+    exact .inr fun l' => (w.output_eq_ruleR hR).trans (w.output_eq_ruleR hR).symm
+  · exact .inl fun r' => (w.output_eq_ruleL hL).trans (w.output_eq_ruleL hL).symm
+
+/-- At every cell whose output differs from the input symbol, a non-interacting
+bimachine is one-sided. -/
+theorem IsNonInteracting.oneSidedAt_of_change (h : B.IsNonInteracting)
+    (hne : B.output l a r ≠ [a]) : B.OneSidedAt l a r :=
+  h.elim fun w => w.oneSidedAt_of_change hne
+
+/-- Transport a decomposition along state equivalences. -/
+def NonInteraction.map (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.map eL eR B).NonInteraction where
+  ruleL l a := w.ruleL (eL.symm l) a
+  ruleR r a := w.ruleR (eR.symm r) a
+  unite_comm _ a _ := w.unite_comm _ a _
+  output_eq _ a _ := w.output_eq _ a _
+
+/-- Non-interaction transports along state reindexing. -/
+theorem IsNonInteracting.map (h : B.IsNonInteracting) (eL : L ≃ L') (eR : R ≃ R') :
+    (Bimachine.map eL eR B).IsNonInteracting :=
+  Nonempty.map (·.map eL eR) h
+
+/-- A decomposed bimachine fixes cell `i` exactly when both change-proposals are inert
+at its two context states. -/
+theorem NonInteraction.getElem?_run_eq_iff {u : List α} {i : ℕ} (hsym : u[i]? = some a) :
+    (B.run u)[i]? = u[i]? ↔
+      w.ruleL (B.lState (u.take i)) a = a ∧ w.ruleR (B.rState (u.drop (i + 1))) a = a := by
+  rw [w.letterToLetter.getElem?_run u i, hsym, Option.map_some, Option.some_inj]
+  exact unite_eq_self_iff
+
+end
+end Bimachine
+
+/-! ### The non-interacting class -/
+
+section
+
+variable [DecidableEq α]
+
+/-- Computability by a non-interacting finite bimachine. -/
+def IsNonInteractingBimachineComputable (f : List α → List α) : Prop :=
+  ∃ (L : Type) (_ : Fintype L) (R : Type) (_ : Fintype R) (B : Bimachine L R α α),
+    B.run = f ∧ B.IsNonInteracting
+/-- `f` is computed by a non-interacting finite bimachine if and only if it is computed
+by one with state types in any universes. -/
+theorem isNonInteractingBimachineComputable_iff.{v, w} {f : List α → List α} :
+    IsNonInteractingBimachineComputable f
+      ↔ ∃ (L : Type v) (_ : Fintype L) (R : Type w) (_ : Fintype R)
+          (B : Bimachine L R α α), B.run = f ∧ B.IsNonInteracting :=
+  exists_fintype₂_congr
+    (fun eL eR ⟨B, hB, h⟩ =>
+      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
+    (fun eL eR ⟨B, hB, h⟩ =>
+      ⟨.map eL eR B, (B.run_map eL eR).trans hB, h.map eL eR⟩)
+
+/-- A non-interacting finite-state bimachine witnesses
+`IsNonInteractingBimachineComputable` for its `run`, whatever the universes of its
+state types (`IsNonInteracting.map`). -/
+theorem Bimachine.isNonInteractingBimachineComputable {L R : Type*} [Fintype L]
+    [Fintype R] (B : Bimachine L R α α) (h : B.IsNonInteracting) :
+    IsNonInteractingBimachineComputable B.run :=
+  isNonInteractingBimachineComputable_iff.mpr ⟨L, inferInstance, R, inferInstance, B, rfl, h⟩
+
+/-- A function computed by a non-interacting bimachine is in particular
+bimachine-computable. -/
+theorem IsBimachineComputable.of_nonInteracting {f : List α → List α}
+    (h : IsNonInteractingBimachineComputable f) : IsBimachineComputable f :=
+  have ⟨_, _, _, _, B, hB, _⟩ := h
+  hB ▸ B.isBimachineComputable
+
+/-- Functions computed by non-interacting bimachines are length-preserving. -/
+theorem IsNonInteractingBimachineComputable.length_eq {f : List α → List α}
+    (h : IsNonInteractingBimachineComputable f) (x : List α) : (f x).length = x.length :=
+  have ⟨_, _, _, _, _, hB, ⟨w⟩⟩ := h
+  hB ▸ w.letterToLetter.length_run x
+/-- A Mealy-computable function is computed by a non-interacting bimachine: the
+bimachine view (`Mealy.toBimachine`) has a trivial right automaton, so the cell output
+is a one-sided rule with `ωR` the identity. -/
+theorem IsNonInteractingBimachineComputable.of_mealyComputable {f : List α → List α}
+    (h : IsMealyComputable f) : IsNonInteractingBimachineComputable f :=
+  have ⟨_, _, T, hT⟩ := h
+  hT ▸ T.toBimachine_run ▸ T.toBimachine.isNonInteractingBimachineComputable
+    ⟨⟨T.output, fun _ a => a,
+      fun _ a _ => (Bimachine.unite_right_self _ a).trans (Bimachine.unite_left_self _ a).symm,
+      fun _ a _ => by simp⟩⟩
+
+end
+
 /-! ### Machines bound dependence
 
 A length-preserving left-subsequential function depends boundedly on the right: the
@@ -295,22 +473,12 @@ variable {σ : Type*}
 theorem IsLeftSubsequential.boundedDependence_right
     (hlen : ∀ w, (f w).length = w.length) (hf : IsLeftSubsequential f) :
     BoundedDependence f .right := by
-  obtain ⟨N, hN⟩ := hf.exists_getElem?_append_eq
-  refine ⟨N, fun i u v _ hag => ?_⟩
-  show (f u)[i]? = (f v)[i]?
-  have key : ∀ w : List α, (f (w.take (i + N + 1)))[i]? = (f w)[i]? := fun w => by
-    rcases lt_or_ge w.length (i + N + 1) with h | h
-    · rw [List.take_of_length_le h.le]
-    · conv_rhs => rw [← List.take_append_drop (i + N + 1) w]
-      exact hN _ _ i (by rw [hlen, List.length_take]; omega)
-  rw [← key u, ← key v, hag.take_eq (by omega)]
+  obtain ⟨N, hN⟩ := hf.exists_dependsOn_Iic hlen
+  exact ⟨N, hN⟩
 
 /-- A sequential machine is left-determined at every coordinate. -/
-theorem Mealy.leftDetermined (T : Mealy σ α β) (i : ℕ) : LeftDetermined T.run i := by
-  intro u v hlen hag
-  show (T.run u)[i]? = (T.run v)[i]?
-  rw [T.getElem?_run u, T.getElem?_run v, hag.getElem?_eq (mem_Iic.mpr le_rfl),
-    List.take_eq_of_agree fun k hk => hag.getElem?_eq (mem_Iic.mpr hk.le)]
+theorem Mealy.leftDetermined (T : Mealy σ α β) (i : ℕ) : LeftDetermined T.run i :=
+  T.dependsOn_run_Iic i
 
 /-- A sequential machine's output never depends on input to its right. -/
 theorem Mealy.boundedDependence_right (T : Mealy σ α β) : BoundedDependence T.run .right :=
@@ -318,9 +486,8 @@ theorem Mealy.boundedDependence_right (T : Mealy σ α β) : BoundedDependence T
 
 /-- A Mealy-computable map is left-determined at every coordinate. -/
 theorem IsMealyComputable.leftDetermined {f : List α → List β}
-    (hf : IsMealyComputable f) (i : ℕ) : LeftDetermined f i := by
-  obtain ⟨σ, _, T, rfl⟩ := hf
-  exact T.leftDetermined i
+    (hf : IsMealyComputable f) (i : ℕ) : LeftDetermined f i :=
+  hf.dependsOn_Iic i
 
 /-- A Mealy-computable map's output never depends on input to its right. -/
 theorem IsMealyComputable.boundedDependence_right {f : List α → List β}

--- a/Linglib/Phonology/Subregular/TierRule.lean
+++ b/Linglib/Phonology/Subregular/TierRule.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Fintype.Option
 import Linglib.Phonology.Subregular.TierProjection
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 
 /-!
 # TierProjection-based rules (`TierRule`)

--- a/Linglib/Phonology/Tone/Plateauing.lean
+++ b/Linglib/Phonology/Tone/Plateauing.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Mathlib.Data.Finset.Max
 import Mathlib.Order.Interval.Finset.Nat
 import Linglib.Core.Data.List.TakeDrop
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Phonology.Autosegmental.OCP
 import Linglib.Phonology.Autosegmental.Junction
 import Linglib.Phonology.Autosegmental.Hull

--- a/Linglib/Phonology/Tone/Surfacing.lean
+++ b/Linglib/Phonology/Tone/Surfacing.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.List.TakeDrop
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 
 /-!
 # Tonal surfacing processes

--- a/Linglib/Studies/Jardine2016Tone.lean
+++ b/Linglib/Studies/Jardine2016Tone.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Core.Computability.Mealy
 import Linglib.Core.Computability.Bimachine
 import Linglib.Core.Computability.ElgotMezei

--- a/Linglib/Studies/McCollumEtAl2020.lean
+++ b/Linglib/Studies/McCollumEtAl2020.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Core.Computability.Bimachine
 
 /-!

--- a/Linglib/Studies/MeinhardtEtAl2024.lean
+++ b/Linglib/Studies/MeinhardtEtAl2024.lean
@@ -7,7 +7,7 @@ import Linglib.Core.Computability.Mealy
 import Linglib.Phonology.Subregular.ISL
 import Linglib.Phonology.Subregular.OSL
 import Linglib.Core.Computability.Subsequential
-import Linglib.Core.Computability.Dependence
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Core.Computability.Bimachine
 
 /-!

--- a/Linglib/Studies/Yolyan2025.lean
+++ b/Linglib/Studies/Yolyan2025.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Computability.Bimachine
+import Linglib.Phonology.Subregular.Dependence
 import Linglib.Phonology.Subregular.BMRS
 import Linglib.Phonology.Tone.Plateauing
 import Linglib.Studies.McCollumEtAl2020


### PR DESCRIPTION
Dependence.lean had zero Core consumers (all six importers are phonology files) and its headline theorem separates the non-interacting bimachines — the weak-determinism program's class [meinhardt-mai-bakovic-mccollum-2024], with no math-literature existence. Three-way split:

- The classical residue moves into the machine files as API: `Mealy.dependsOn_run_Iic` / `IsMealyComputable.dependsOn_Iic` (causality of sequential machines) and `IsLeftSubsequential.exists_dependsOn_Iic` (the delay bound as a dependence margin).
- The witness lattice, flankWord family, the NonInteraction apparatus (extracted from Core/Bimachine.lean, where it sat citation-free), and the separation theorem demote to Phonology/Subregular/Dependence.lean beside their consumers, now with the program citation restored.
- Choffrut bounded variation (the ℕ∞-modulus characterization of subsequentiality) is the classical theorem that would justify an upstream dependence file; queued, not formalized here.