### PR TITLE
feat(Core/Algebra): to_additive and closure API for IsSubquotient

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -9,6 +9,7 @@ import Linglib.Core.Algebra.Group.Aperiodic
 import Linglib.Core.Algebra.Group.End
 import Linglib.Core.Algebra.Group.Idempotent
 import Linglib.Core.Algebra.Group.Pseudovariety
+import Linglib.Core.Algebra.Group.Submonoid.Operations
 import Linglib.Core.Algebra.Group.Subquotient
 import Linglib.Core.Algebra.Group.WithOne
 import Linglib.Core.Algebra.IdempotentPower

--- a/Linglib/Core/Algebra/Group/Submonoid/Operations.lean
+++ b/Linglib/Core/Algebra/Group/Submonoid/Operations.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Group.Submonoid.Operations`, beside
+`MulEquiv.ofLeftInverse'`.
+-/
+import Mathlib.Algebra.Group.Submonoid.Operations
+
+/-!
+# `MulEquiv.ofInjective'`
+
+An injective monoid homomorphism is a `MulEquiv` onto its range — the `MulOneClass`
+counterpart of the group-level `MonoidHom.ofInjective`, packaging `MulEquiv.ofLeftInverse'`
+at an injectivity hypothesis. Primed like `MulEquiv.ofLeftInverse'`: the unprimed name is
+reserved for the `f.range` version.
+-/
+
+/-- An injective monoid homomorphism is a `MulEquiv` onto its range — the `MulOneClass`
+counterpart of `MonoidHom.ofInjective`. -/
+@[to_additive /-- An injective additive monoid homomorphism is an `AddEquiv` onto its
+range. -/]
+noncomputable def MulEquiv.ofInjective' {M N : Type*} [MulOneClass M] [MulOneClass N]
+    {f : M →* N} (hf : Function.Injective f) : M ≃* MonoidHom.mrange f :=
+  MulEquiv.ofLeftInverse' f (Function.leftInverse_invFun hf)

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -15,12 +15,11 @@ import Mathlib.SetTheory.Cardinal.Finite
 # Subquotients of monoids
 
 A monoid `T` is a *subquotient* of a monoid `S` when `T` is a homomorphic image of a
-submonoid of `S` — the relation called *division*, written `T ≼ S`, in finite semigroup
-theory [eilenberg-1976], and a *section* for groups. This file defines the relation and
-proves it transitive, closed under products, and, on finite monoids, antisymmetric up to
-isomorphism. In finite semigroup theory the classes closed under subquotients and finite
-products are the pseudovarieties, and the syntactic monoid of a language is a subquotient of
-every monoid recognizing it.
+submonoid of `S` — *division* (`T ≼ S`) in finite semigroup theory [eilenberg-1976], a
+*section* in group theory. This file defines the relation and proves it transitive, closed
+under products, and, on finite monoids, antisymmetric up to isomorphism. The classes of
+finite monoids closed under subquotients and finite products are the pseudovarieties, and
+the syntactic monoid of a language is a subquotient of every monoid recognizing it.
 
 ## Main definitions
 

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Algebra.Group.Submonoid.Operations
+import Mathlib.GroupTheory.Congruence.Basic
 import Mathlib.SetTheory.Cardinal.NatCard
 
 /-!
@@ -39,27 +40,44 @@ variable {T S R : Type*} [Monoid T] [Monoid S] [Monoid R]
 
 /-- `T` is a **subquotient** of `S` when `T` is a homomorphic image of a submonoid of `S` —
 the **division** `T ≼ S` of finite semigroup theory [eilenberg-1976]. -/
+@[to_additive /-- `T` is a **subquotient** of `S` when `T` is a homomorphic image of an
+additive submonoid of `S`. -/]
 def IsSubquotient (T S : Type*) [Monoid T] [Monoid S] : Prop :=
   ∃ (N : Submonoid S) (f : N →* T), Function.Surjective f
 
 /-- A homomorphic image is a subquotient. -/
+@[to_additive]
 theorem IsSubquotient.of_surjective (f : S →* T) (hf : Function.Surjective f) :
     IsSubquotient T S :=
   ⟨⊤, f.comp Submonoid.topEquiv.toMonoidHom, hf.comp Submonoid.topEquiv.surjective⟩
 
 /-- An embedded monoid is a subquotient. -/
+@[to_additive]
 theorem IsSubquotient.of_injective (f : T →* S) (hf : Function.Injective f) :
     IsSubquotient T S :=
   have e := MulEquiv.ofBijective f.mrangeRestrict
     ⟨fun _ _ h => hf (congrArg Subtype.val h), f.mrangeRestrict_surjective⟩
   ⟨MonoidHom.mrange f, e.symm.toMonoidHom, e.symm.surjective⟩
 
+@[to_additive]
 theorem _root_.MulEquiv.isSubquotient (e : T ≃* S) : IsSubquotient T S :=
   IsSubquotient.of_surjective e.symm.toMonoidHom e.symm.surjective
 
+/-- A submonoid is a subquotient. -/
+@[to_additive]
+theorem _root_.Submonoid.isSubquotient (N : Submonoid S) : IsSubquotient N S :=
+  IsSubquotient.of_injective N.subtype N.subtype_injective
+
+/-- A congruence quotient is a subquotient. -/
+@[to_additive]
+theorem _root_.Con.isSubquotient_quotient (c : Con S) : IsSubquotient c.Quotient S :=
+  IsSubquotient.of_surjective c.mk' c.mk'_surjective
+
+@[to_additive]
 theorem IsSubquotient.refl (T : Type*) [Monoid T] : IsSubquotient T T :=
   (MulEquiv.refl T).isSubquotient
 
+@[to_additive]
 theorem IsSubquotient.trans (hTS : IsSubquotient T S) (hSR : IsSubquotient S R) :
     IsSubquotient T R := by
   obtain ⟨N, f, hf⟩ := hTS
@@ -72,15 +90,18 @@ theorem IsSubquotient.trans (hTS : IsSubquotient T S) (hSR : IsSubquotient S R) 
   exact ⟨(N.comap g).map M.subtype, (f.comp (g.submonoidComap N)).comp e.symm.toMonoidHom,
     (hf.comp hcomap).comp e.symm.surjective⟩
 
+@[to_additive]
 theorem isSubquotient_prod_left (T S : Type*) [Monoid T] [Monoid S] :
     IsSubquotient T (T × S) :=
   IsSubquotient.of_injective (MonoidHom.inl T S) fun _ _ h => congrArg Prod.fst h
 
+@[to_additive]
 theorem isSubquotient_prod_right (T S : Type*) [Monoid T] [Monoid S] :
     IsSubquotient T (S × T) :=
   IsSubquotient.of_injective (MonoidHom.inr S T) fun _ _ h => congrArg Prod.snd h
 
 /-- A subquotient of a finite monoid is no larger. -/
+@[to_additive]
 theorem IsSubquotient.card_le [Finite S] (h : IsSubquotient T S) :
     Nat.card T ≤ Nat.card S := by
   obtain ⟨N, f, hf⟩ := h
@@ -89,6 +110,7 @@ theorem IsSubquotient.card_le [Finite S] (h : IsSubquotient T S) :
 
 /-- Finite monoids that are subquotients of each other are isomorphic ([eilenberg-1976]):
 division is antisymmetric up to `MulEquiv` on finite monoids. -/
+@[to_additive]
 theorem IsSubquotient.nonempty_mulEquiv [Finite T] [Finite S] (hTS : IsSubquotient T S)
     (hST : IsSubquotient S T) : Nonempty (T ≃* S) := by
   have hcard : Nat.card T = Nat.card S := le_antisymm hTS.card_le hST.card_le

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -15,9 +15,10 @@ import Mathlib.SetTheory.Cardinal.Finite
 # Subquotients of monoids
 
 A monoid `T` is a *subquotient* of a monoid `S` when `T` is a homomorphic image of a
-submonoid of `S` — *division* (`T ≼ S`) in finite semigroup theory [eilenberg-1976], a
-*section* in group theory. This file defines the relation and proves it transitive, closed
-under products, and, on finite monoids, antisymmetric up to isomorphism.
+submonoid of `S`. In finite semigroup theory the relation is called *division* (`T ≼ S`)
+[eilenberg-1976]; in group theory, a *section*. This file defines the relation and proves
+it transitive, closed under products, and, on finite monoids, antisymmetric up to
+isomorphism.
 
 ## Main definitions
 

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -26,11 +26,12 @@ isomorphism.
 
 ## Implementation notes
 
-The relation compares carriers-with-instances, not terms of one type, so there is no `Trans`
-or `Preorder` instance to register; transitivity and antisymmetry-up-to-`MulEquiv` are
-standalone lemmas. Every statement also holds verbatim at `MulOneClass`; the file is stated
-at `Monoid` deliberately, since the relation's home theory and the additive translation
-(`AddMonoid.IsSubquotient`) are monoid-theoretic.
+The relation takes carriers together with their instances, so it is not a binary relation
+on a type: there is no `Preorder` instance to register, and the `trans` tactic rejects
+relations with instance arguments, so transitivity and antisymmetry-up-to-`MulEquiv` are
+standalone lemmas (`@[refl]` does apply). Every statement also holds at `MulOneClass`; the
+file is stated at `Monoid` deliberately — the `Monoid`/`AddMonoid` namespaces, and with
+them the additive translation `AddMonoid.IsSubquotient`, are monoid-theoretic.
 -/
 
 namespace Monoid

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -109,18 +109,22 @@ theorem IsSubquotient.card_le [Finite S] (h : IsSubquotient T S) :
   exact (Nat.card_le_card_of_surjective f hf).trans
     (Nat.card_le_card_of_injective N.subtype N.subtype_injective)
 
+/-- A subquotient of maximal cardinality is an isomorph. -/
+@[to_additive /-- A subquotient of maximal cardinality is an isomorph. -/]
+theorem IsSubquotient.nonempty_mulEquiv_of_card_le [Finite S] (hTS : IsSubquotient T S)
+    (hle : Nat.card S ≤ Nat.card T) : Nonempty (T ≃* S) := by
+  obtain ⟨N, f, hf⟩ := hTS
+  have hNS : Nat.card N ≤ Nat.card S := Nat.card_le_card_of_injective _ N.subtype_injective
+  have hSN : Nat.card S ≤ Nat.card N := hle.trans (Nat.card_le_card_of_surjective f hf)
+  exact ⟨(MulEquiv.ofBijective f (hf.bijective_of_nat_card_le (hNS.trans hle))).symm.trans
+    (MulEquiv.ofBijective N.subtype (N.subtype_injective.bijective_of_nat_card_le hSN))⟩
+
 /-- Finite monoids that are subquotients of each other are isomorphic ([eilenberg-1976]). -/
 @[to_additive /-- Finite additive monoids that are subquotients of each other are
 isomorphic. -/]
 theorem IsSubquotient.nonempty_mulEquiv [Finite S] (hTS : IsSubquotient T S)
     (hST : IsSubquotient S T) : Nonempty (T ≃* S) := by
   have := hTS.finite
-  have hcard : Nat.card T = Nat.card S := le_antisymm hTS.card_le hST.card_le
-  obtain ⟨N, f, hf⟩ := hTS
-  have hNS : Nat.card N ≤ Nat.card S := Nat.card_le_card_of_injective _ N.subtype_injective
-  have hTN : Nat.card T ≤ Nat.card N := Nat.card_le_card_of_surjective f hf
-  exact ⟨(MulEquiv.ofBijective f (hf.bijective_of_nat_card_le (hNS.trans hcard.ge))).symm.trans
-    (MulEquiv.ofBijective N.subtype (N.subtype_injective.bijective_of_nat_card_le
-      (hcard ▸ hTN)))⟩
+  exact hTS.nonempty_mulEquiv_of_card_le hST.card_le
 
 end Monoid

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -17,9 +17,7 @@ import Mathlib.SetTheory.Cardinal.Finite
 A monoid `T` is a *subquotient* of a monoid `S` when `T` is a homomorphic image of a
 submonoid of `S` — *division* (`T ≼ S`) in finite semigroup theory [eilenberg-1976], a
 *section* in group theory. This file defines the relation and proves it transitive, closed
-under products, and, on finite monoids, antisymmetric up to isomorphism. The classes of
-finite monoids closed under subquotients and finite products are the pseudovarieties, and
-the syntactic monoid of a language is a subquotient of every monoid recognizing it.
+under products, and, on finite monoids, antisymmetric up to isomorphism.
 
 ## Main definitions
 

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -23,15 +23,6 @@ isomorphism.
 ## Main definitions
 
 * `Monoid.IsSubquotient T S`: `T` is a homomorphic image of a submonoid of `S`.
-
-## Implementation notes
-
-The relation takes carriers together with their instances, so it is not a binary relation
-on a type: there is no `Preorder` instance to register, and the `trans` tactic rejects
-relations with instance arguments, so transitivity and antisymmetry-up-to-`MulEquiv` are
-standalone lemmas (`@[refl]` does apply). Every statement also holds at `MulOneClass`; the
-file is stated at `Monoid` deliberately — the `Monoid`/`AddMonoid` namespaces, and with
-them the additive translation `AddMonoid.IsSubquotient`, are monoid-theoretic.
 -/
 
 namespace Monoid

--- a/Linglib/Core/Algebra/Group/Subquotient.lean
+++ b/Linglib/Core/Algebra/Group/Subquotient.lean
@@ -2,105 +2,116 @@
 Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
+
+[UPSTREAM] candidate: `Mathlib.Algebra.Group.Subquotient`, beside the GreensRelations stack;
+split `Defs`/`Finite` at upstream time (the cardinality import doubles the import cone).
 -/
-import Mathlib.Algebra.Group.Submonoid.Operations
-import Mathlib.GroupTheory.Congruence.Basic
-import Mathlib.SetTheory.Cardinal.NatCard
+import Linglib.Core.Algebra.Group.Submonoid.Operations
+import Mathlib.Algebra.Group.Prod
+import Mathlib.GroupTheory.Congruence.Hom
+import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Subquotients of monoids
 
-A monoid `T` is a **subquotient** of a monoid `S` when `T` is a homomorphic image of a
-submonoid of `S` — the relation called **division** (`T ≼ S`) in finite semigroup theory
-[eilenberg-1976], and a *section* for groups. It is the comparison order of the algebraic
-theory of automata: pseudovarieties are the division-closed classes, and the syntactic monoid
-of a language is a subquotient of every monoid recognising it.
+A monoid `T` is a *subquotient* of a monoid `S` when `T` is a homomorphic image of a
+submonoid of `S` — the relation called *division*, written `T ≼ S`, in finite semigroup
+theory [eilenberg-1976], and a *section* for groups. This file defines the relation and
+proves it transitive, closed under products, and, on finite monoids, antisymmetric up to
+isomorphism. In finite semigroup theory the classes closed under subquotients and finite
+products are the pseudovarieties, and the syntactic monoid of a language is a subquotient of
+every monoid recognizing it.
 
 ## Main definitions
 
 * `Monoid.IsSubquotient T S`: `T` is a homomorphic image of a submonoid of `S`.
 
-## Main results
-
-* `Monoid.IsSubquotient.trans`: the subquotient relation is transitive.
-* `Monoid.IsSubquotient.card_le`: a subquotient of a finite monoid is no larger.
-* `Monoid.IsSubquotient.nonempty_mulEquiv`: finite monoids that are subquotients of each
-  other are isomorphic.
-
 ## Implementation notes
 
 The relation compares carriers-with-instances, not terms of one type, so there is no `Trans`
 or `Preorder` instance to register; transitivity and antisymmetry-up-to-`MulEquiv` are
-standalone lemmas.
+standalone lemmas. Every statement also holds verbatim at `MulOneClass`; the file is stated
+at `Monoid` deliberately, since the relation's home theory and the additive translation
+(`AddMonoid.IsSubquotient`) are monoid-theoretic.
 -/
 
 namespace Monoid
 
 variable {T S R : Type*} [Monoid T] [Monoid S] [Monoid R]
 
-/-- `T` is a **subquotient** of `S` when `T` is a homomorphic image of a submonoid of `S` —
-the **division** `T ≼ S` of finite semigroup theory [eilenberg-1976]. -/
-@[to_additive /-- `T` is a **subquotient** of `S` when `T` is a homomorphic image of an
-additive submonoid of `S`. -/]
+/-- A monoid `T` is a *subquotient* of `S` when it is a homomorphic image of a submonoid
+of `S`. -/
+@[to_additive /-- An additive monoid `T` is a *subquotient* of `S` when it is a homomorphic
+image of an additive submonoid of `S`. -/]
 def IsSubquotient (T S : Type*) [Monoid T] [Monoid S] : Prop :=
   ∃ (N : Submonoid S) (f : N →* T), Function.Surjective f
 
-/-- A homomorphic image is a subquotient. -/
 @[to_additive]
 theorem IsSubquotient.of_surjective (f : S →* T) (hf : Function.Surjective f) :
     IsSubquotient T S :=
   ⟨⊤, f.comp Submonoid.topEquiv.toMonoidHom, hf.comp Submonoid.topEquiv.surjective⟩
 
-/-- An embedded monoid is a subquotient. -/
-@[to_additive]
-theorem IsSubquotient.of_injective (f : T →* S) (hf : Function.Injective f) :
-    IsSubquotient T S :=
-  have e := MulEquiv.ofBijective f.mrangeRestrict
-    ⟨fun _ _ h => hf (congrArg Subtype.val h), f.mrangeRestrict_surjective⟩
-  ⟨MonoidHom.mrange f, e.symm.toMonoidHom, e.symm.surjective⟩
-
 @[to_additive]
 theorem _root_.MulEquiv.isSubquotient (e : T ≃* S) : IsSubquotient T S :=
   IsSubquotient.of_surjective e.symm.toMonoidHom e.symm.surjective
 
-/-- A submonoid is a subquotient. -/
+@[to_additive (attr := refl)]
+theorem IsSubquotient.refl (T : Type*) [Monoid T] : IsSubquotient T T :=
+  (MulEquiv.refl T).isSubquotient
+
 @[to_additive]
 theorem _root_.Submonoid.isSubquotient (N : Submonoid S) : IsSubquotient N S :=
-  IsSubquotient.of_injective N.subtype N.subtype_injective
+  ⟨N, .id _, Function.surjective_id⟩
 
-/-- A congruence quotient is a subquotient. -/
 @[to_additive]
 theorem _root_.Con.isSubquotient_quotient (c : Con S) : IsSubquotient c.Quotient S :=
   IsSubquotient.of_surjective c.mk' c.mk'_surjective
 
 @[to_additive]
-theorem IsSubquotient.refl (T : Type*) [Monoid T] : IsSubquotient T T :=
-  (MulEquiv.refl T).isSubquotient
+theorem _root_.MonoidHom.isSubquotient_mrange (f : S →* T) :
+    IsSubquotient (MonoidHom.mrange f) S :=
+  IsSubquotient.of_surjective f.mrangeRestrict f.mrangeRestrict_surjective
 
 @[to_additive]
 theorem IsSubquotient.trans (hTS : IsSubquotient T S) (hSR : IsSubquotient S R) :
     IsSubquotient T R := by
   obtain ⟨N, f, hf⟩ := hTS
   obtain ⟨M, g, hg⟩ := hSR
-  have hcomap : Function.Surjective (g.submonoidComap N) := by
-    rintro ⟨n, hn⟩
-    obtain ⟨m, rfl⟩ := hg n
-    exact ⟨⟨m, hn⟩, rfl⟩
   have e := Submonoid.equivMapOfInjective (N.comap g) M.subtype M.subtype_injective
   exact ⟨(N.comap g).map M.subtype, (f.comp (g.submonoidComap N)).comp e.symm.toMonoidHom,
-    (hf.comp hcomap).comp e.symm.surjective⟩
+    (hf.comp (g.submonoidComap_surjective_of_surjective N hg)).comp e.symm.surjective⟩
 
 @[to_additive]
+theorem IsSubquotient.of_injective (f : T →* S) (hf : Function.Injective f) :
+    IsSubquotient T S :=
+  (MulEquiv.ofInjective' hf).isSubquotient.trans (MonoidHom.mrange f).isSubquotient
+
+@[to_additive isSubquotient_prod_left]
 theorem isSubquotient_prod_left (T S : Type*) [Monoid T] [Monoid S] :
     IsSubquotient T (T × S) :=
-  IsSubquotient.of_injective (MonoidHom.inl T S) fun _ _ h => congrArg Prod.fst h
+  IsSubquotient.of_injective (MonoidHom.inl T S) (Prod.mk_left_injective 1)
 
-@[to_additive]
+@[to_additive isSubquotient_prod_right]
 theorem isSubquotient_prod_right (T S : Type*) [Monoid T] [Monoid S] :
     IsSubquotient T (S × T) :=
-  IsSubquotient.of_injective (MonoidHom.inr S T) fun _ _ h => congrArg Prod.snd h
+  IsSubquotient.of_injective (MonoidHom.inr S T) (Prod.mk_right_injective 1)
 
-/-- A subquotient of a finite monoid is no larger. -/
+/-- Subquotients are closed under componentwise products. -/
+@[to_additive IsSubquotient.prod /-- Subquotients are closed under componentwise
+products. -/]
+theorem IsSubquotient.prod {T' S' : Type*} [Monoid T'] [Monoid S']
+    (h : IsSubquotient T S) (h' : IsSubquotient T' S') :
+    IsSubquotient (T × T') (S × S') := by
+  obtain ⟨N, f, hf⟩ := h
+  obtain ⟨N', f', hf'⟩ := h'
+  exact ⟨N.prod N', (f.prodMap f').comp (N.prodEquiv N').toMonoidHom,
+    (hf.prodMap hf').comp (N.prodEquiv N').surjective⟩
+
+@[to_additive]
+theorem IsSubquotient.finite [Finite S] (h : IsSubquotient T S) : Finite T := by
+  obtain ⟨N, f, hf⟩ := h
+  exact .of_surjective f hf
+
 @[to_additive]
 theorem IsSubquotient.card_le [Finite S] (h : IsSubquotient T S) :
     Nat.card T ≤ Nat.card S := by
@@ -108,20 +119,18 @@ theorem IsSubquotient.card_le [Finite S] (h : IsSubquotient T S) :
   exact (Nat.card_le_card_of_surjective f hf).trans
     (Nat.card_le_card_of_injective N.subtype N.subtype_injective)
 
-/-- Finite monoids that are subquotients of each other are isomorphic ([eilenberg-1976]):
-division is antisymmetric up to `MulEquiv` on finite monoids. -/
-@[to_additive]
-theorem IsSubquotient.nonempty_mulEquiv [Finite T] [Finite S] (hTS : IsSubquotient T S)
+/-- Finite monoids that are subquotients of each other are isomorphic ([eilenberg-1976]). -/
+@[to_additive /-- Finite additive monoids that are subquotients of each other are
+isomorphic. -/]
+theorem IsSubquotient.nonempty_mulEquiv [Finite S] (hTS : IsSubquotient T S)
     (hST : IsSubquotient S T) : Nonempty (T ≃* S) := by
+  have := hTS.finite
   have hcard : Nat.card T = Nat.card S := le_antisymm hTS.card_le hST.card_le
   obtain ⟨N, f, hf⟩ := hTS
-  have hN : Nat.card N = Nat.card S :=
-    le_antisymm (Nat.card_le_card_of_injective N.subtype N.subtype_injective)
-      (hcard ▸ Nat.card_le_card_of_surjective f hf)
-  have hbij : Function.Bijective f :=
-    (Nat.bijective_iff_surjective_and_card f).mpr ⟨hf, by rw [hN, hcard]⟩
-  have hbij' : Function.Bijective N.subtype :=
-    (Nat.bijective_iff_injective_and_card N.subtype).mpr ⟨N.subtype_injective, hN⟩
-  exact ⟨(MulEquiv.ofBijective f hbij).symm.trans (MulEquiv.ofBijective N.subtype hbij')⟩
+  have hNS : Nat.card N ≤ Nat.card S := Nat.card_le_card_of_injective _ N.subtype_injective
+  have hTN : Nat.card T ≤ Nat.card N := Nat.card_le_card_of_surjective f hf
+  exact ⟨(MulEquiv.ofBijective f (hf.bijective_of_nat_card_le (hNS.trans hcard.ge))).symm.trans
+    (MulEquiv.ofBijective N.subtype (N.subtype_injective.bijective_of_nat_card_le
+      (hcard ▸ hTN)))⟩
 
 end Monoid


### PR DESCRIPTION
Upstream polish for Subquotient.lean, folding two mathlib-reviewer audits and the register rulings:

- `@[to_additive]` throughout, generating the full `AddMonoid.IsSubquotient` API — including the must-fix name overrides on the product lemmas (bare to_additive generated `isSubquotient_sum_left` for a lemma about the Prod type).
- New API: `IsSubquotient.prod` (componentwise closure — what pseudovariety theory needs), `.finite` (finiteness descends; drops `[Finite T]` from the antisymmetry theorem), `Submonoid.isSubquotient`, `Con.isSubquotient_quotient`, `MonoidHom.isSubquotient_mrange`, `@[to_additive (attr := refl)]` on refl.
- Proof golf from the reviews: `trans` via `submonoidComap_surjective_of_surjective`, antisymmetry via the `bijective_of_nat_card_le` pair; leaf imports corrected (`Congruence.Hom`, `Cardinal.Finite`, explicit `Algebra.Group.Prod`).
- `MulEquiv.ofInjective'` (primed per mathlib's reserved-name comment above `ofLeftInverse'`) extracted to its upstream-mirroring leaf `Core/Algebra/Group/Submonoid/Operations.lean`; `of_injective` is now the compositional one-liner.
- Docstring register: mathlib-anatomy module doc (Main definitions restored, Main results cut as basic API), decl-strings stripped to the def plus the Eilenberg antisymmetry theorem.