### PR TITLE
refactor(Core/Probability): mathlib-register Gumbel, rewrite GumbelLuce

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -290,6 +290,7 @@ import Linglib.Core.Probability.EvalLemmas
 import Linglib.Core.Probability.Finite
 import Linglib.Core.Probability.Gaussian
 import Linglib.Core.Probability.GibbsVariational
+import Linglib.Core.Probability.Gumbel
 import Linglib.Core.Probability.Hypergeometric
 import Linglib.Core.Probability.JointPosterior
 import Linglib.Core.Probability.LogitChoice

--- a/Linglib/Core/Optimization/Decoder.lean
+++ b/Linglib/Core/Optimization/Decoder.lean
@@ -27,7 +27,7 @@ Noise-kernel-based decoders live in `NoiseKernel.lean`.
 `softmaxDecoder α` interpolates between soft and hard optimization: as
 `α → ∞`, the softmax distribution concentrates on the unique maximizer
 (when one exists), recovering `argmaxDecoder` — `softmax_argmax_limit` in
-`Core.Agent.RationalAction`.
+`Core.Probability.Choice.RationalAction`.
 
 ## Semiring connection
 

--- a/Linglib/Core/Optimization/NoiseKernel.lean
+++ b/Linglib/Core/Optimization/NoiseKernel.lean
@@ -1,5 +1,4 @@
 import Linglib.Core.Optimization.Decoder
-import Linglib.Core.Probability.Choice.GumbelLuce
 
 /-!
 # Noise kernels — random utility models
@@ -28,8 +27,8 @@ The noise distribution determines the choice rule. Three classical results:
 | Normal(0, σ²)      | probit (Φ-based)    | binary case via Thurstone V  |
 
 The Gumbel ↔ softmax equivalence is McFadden's theorem (proved as
-`mcfaddenIntegral_eq_softmax` in `Core.Agent.GumbelLuce`). The Gaussian
-binary case is Thurstone Case V (`Core.Agent.Thurstone`); the n-ary
+`rumMaxProb_gumbel_eq_softmax` in `Core.Probability.Choice.GumbelLuce`). The Gaussian
+binary case is Thurstone Case V (`Processing.Psychophysics.Thurstone`); the n-ary
 Gaussian case requires multivariate normal integration and is not yet
 implemented as a `Decoder`.
 
@@ -39,7 +38,7 @@ The `Decoder` interface is the *what* (a probability distribution over
 candidates). `NoiseKernel` is the *why* (a noise distribution that
 induces it via argmax). Two different noise distributions can yield
 the same decoder up to numerical approximation (Gumbel ≈ Gaussian via
-the logistic-Φ approximation, see `Core.Agent.Thurstone` §4), and the
+the logistic-Φ approximation, see `Processing.Psychophysics.Thurstone` §4), and the
 same noise distribution can yield different decoders at different
 temperatures. Separating the layers lets us state and use those
 correspondences cleanly.
@@ -102,10 +101,10 @@ noncomputable def toDecoder {Cand : Type*} : NoiseKernel → Decoder Cand ℝ
 theorem dirac_eq_argmaxDecoder {Cand : Type*} :
     (NoiseKernel.dirac.toDecoder : Decoder Cand ℝ) = argmaxDecoder := rfl
 
-/-- McFadden's theorem at the decoder level: the Gumbel(0, 1/α) kernel's
+/-- Lemma 1 of [mcfadden-1974] at the decoder level: the Gumbel(0, 1/α) kernel's
     decoder is exactly `softmaxDecoder α`. By definition; the underlying
-    RUM-to-softmax identity is `mcfaddenIntegral_eq_softmax` in
-    `Core.Agent.GumbelLuce`. -/
+    RUM-to-softmax identity is `rumMaxProb_gumbel_eq_softmax` in
+    `Core.Probability.Choice.GumbelLuce`. -/
 theorem gumbel_eq_softmaxDecoder {Cand : Type*} (α : ℝ) :
     (NoiseKernel.gumbel α).toDecoder = (softmaxDecoder α : Decoder Cand ℝ) := rfl
 

--- a/Linglib/Core/Probability/Choice/GumbelLuce.lean
+++ b/Linglib/Core/Probability/Choice/GumbelLuce.lean
@@ -1,440 +1,142 @@
+import Linglib.Core.Probability.Gumbel
+import Linglib.Core.Probability.RandomUtility
 import Linglib.Core.Probability.Choice.RationalAction
-import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
-import Mathlib.MeasureTheory.Integral.IntegralEqImproper
-import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 
 /-!
-# Gumbel–Luce equivalence (McFadden's theorem) [mcfadden-1974]
+# Gumbel–Luce equivalence [mcfadden-1974]
 
-The exact algebraic connection between Gumbel noise in a random utility model
-(RUM) and the Luce choice rule (softmax) [luce-1959].
+A random utility model assigns each alternative `i` the utility `uᵢ + εᵢ` and
+chooses the maximizer; with i.i.d. Gumbel noise the choice probabilities are
+exactly softmax, `P(i) = exp(uᵢ/β) / ∑ⱼ exp(uⱼ/β)`. The Gumbel→softmax
+direction is due to [marschak-1960] and, in the constructive form given here,
+to Holman and Marley (via [luce-suppes-1965]); [mcfadden-1974] proves it as
+his Lemma 1 and credits them. McFadden's own contribution is the converse, Lemma 2:
+among translation-complete i.i.d. noise distributions only the Gumbel family
+yields the Luce rule [luce-1959]. Uniqueness genuinely needs choice sets of
+size ≥ 3: for binary choice the logistic form does not pin down Gumbel noise
+(Yellott [yellott-1977]; compare the binary probit in
+`Core/Probability/RandomUtility.lean`).
 
-A RUM assigns each alternative `i` a random utility `Uᵢ = uᵢ + εᵢ`, with `uᵢ`
-deterministic and `εᵢ` random noise, and predicts `P(i chosen) = P(Uᵢ = maxⱼ Uⱼ)`.
-When the `εᵢ` are i.i.d. Gumbel(0, β), this probability is exactly softmax:
+The distribution layer (density, measure, CDF, max-stability, and the
+max-probability integral) lives in `Core/Probability/Gumbel.lean`; this file
+gives it the random-utility reading.
 
-    `P(i chosen) = exp(uᵢ/β) / Σⱼ exp(uⱼ/β) = softmax((1/β) • u)ᵢ`.
+## Main definitions
 
-The proof reduces to the Laplace integral `∫₀^∞ exp(-S·t) dt = 1/S` after the
-change of variables `t = exp(-x/β)`. The Gaussian-noise counterpart (Thurstone
-Case V, the normal CDF) is in `Thurstone.lean`.
+* `RationalAction.fromGumbelRUM`: the Luce agent of a Gumbel RUM, defined as
+  `fromSoftmax` at inverse temperature `β⁻¹`.
 
 ## Main results
 
-* `integral_exp_neg_mul_Ioi_zero` — the Laplace integral `∫₀^∞ exp(-S·t) dt = 1/S`.
-* `mcfaddenIntegral_eq_softmax` — McFadden's theorem (algebraic core).
-* `gumbelMaxProb_is_mcfaddenIntegral` — the measure-theoretic content: the Gumbel
-  max-probability integral equals `mcfaddenIntegral`.
-* `mcfaddenIntegral_binary` — the binary case is the logistic function.
-* `gumbel_from_functional_eq` — uniqueness: the Gumbel CDF is the only max-CDF
-  satisfying the defining functional equation.
+* `rumMaxProb_gumbel_eq_softmax`: Lemma 1 of [mcfadden-1974] — the Gumbel
+  max-probability integral is softmax.
+* `rumMaxProb_gumbel_binary`: the binary case is the logistic function.
+* `gumbel_from_functional_eq`, `eq_cdf_gumbelMeasure_of_functional_eq`: the
+  terminal step of Lemma 2 — a noise CDF satisfying `G(x-c) = G(x)^{exp c}`
+  is Gumbel. McFadden derives that equation only for positive-integer `exp c`
+  (duplicated alternatives) and extends by monotonicity; the derivation of the
+  equation from the softmax form and translation completeness is not
+  formalized here.
 -/
 
 namespace Core
 
-open Real MeasureTheory Set BigOperators Finset Filter
-
-/-! ### The Gumbel distribution -/
-
-/-- The Gumbel CDF with location 0 and scale `β`:
-
-    `F(x; β) = exp(-exp(-x/β))`
-
-    The Type I extreme value distribution. Used as the noise distribution
-    in the Luce/McFadden random utility model. -/
-noncomputable def gumbelCDF (β : ℝ) (x : ℝ) : ℝ :=
-  exp (-exp (-x / β))
-
-/-- The Gumbel PDF with location 0 and scale `β`:
-
-    `f(x; β) = (1/β) · exp(-x/β) · exp(-exp(-x/β))` -/
-noncomputable def gumbelPDF (β : ℝ) (x : ℝ) : ℝ :=
-  (1 / β) * exp (-x / β) * exp (-exp (-x / β))
-
-/-- The Gumbel CDF is strictly positive. -/
-theorem gumbelCDF_pos (β : ℝ) (x : ℝ) : 0 < gumbelCDF β x :=
-  exp_pos _
-
-/-- The Gumbel CDF is at most 1. -/
-theorem gumbelCDF_le_one (β : ℝ) (x : ℝ) : gumbelCDF β x ≤ 1 :=
-  exp_le_one_iff.mpr (neg_nonpos.mpr (le_of_lt (exp_pos _)))
-
-/-- The Gumbel PDF is positive when β > 0. -/
-theorem gumbelPDF_pos {β : ℝ} (hβ : 0 < β) (x : ℝ) : 0 < gumbelPDF β x := by
-  simp only [gumbelPDF]
-  apply mul_pos (mul_pos _ (exp_pos _)) (exp_pos _)
-  exact div_pos one_pos hβ
-
-/-! ### The Laplace integral `∫₀^∞ exp(-S·t) dt = 1/S` -/
-
-/-- The Laplace integral: `∫₀^∞ exp(-S·t) dt = 1/S` for `S > 0`.
-
-    This is the core computation in McFadden's theorem. After the change of
-    variables `t = exp(-x/β)` in the Gumbel max-probability integral, the
-    problem reduces to this exponential integral.
-
-    Follows directly from Mathlib's `integral_exp_mul_Ioi` with `a = -S`
-    and `c = 0`. -/
-theorem integral_exp_neg_mul_Ioi_zero {S : ℝ} (hS : 0 < S) :
-    ∫ t in Ioi (0 : ℝ), exp (-S * t) = 1 / S := by
-  have h := integral_exp_mul_Ioi (show -S < (0 : ℝ) by linarith) (0 : ℝ)
-  simp only [mul_zero, exp_zero] at h
-  rw [h, neg_div_neg_eq]
-
-/-! ### McFadden's theorem: the algebraic core -/
-
-section McFadden
-
-variable {ι : Type*} [Fintype ι]
-
-/-- The McFadden integral for alternative `i` with scale `β`:
-
-    `Iᵢ = exp(uᵢ/β) · ∫₀^∞ exp(-S·t) dt`
-
-    where `S = Σⱼ exp(uⱼ/β)` is the partition function.
-
-    After the change of variables `t = exp(-x/β)` in the original
-    Gumbel density integral, the max-probability `P(Uᵢ = max_j Uⱼ)` takes
-    this form. See `gumbelMaxProb_is_mcfaddenIntegral`. -/
-noncomputable def mcfaddenIntegral (u : ι → ℝ) (β : ℝ) (i : ι) : ℝ :=
-  exp (u i / β) * ∫ t in Ioi (0 : ℝ), exp (-(∑ j : ι, exp (u j / β)) * t)
-
-section Softmax
-
-variable [Nonempty ι] (u : ι → ℝ) {β : ℝ}
-
-/-- **McFadden's theorem (algebraic core)** — Lemma 1 of [mcfadden-1974]:
-    the McFadden integral equals softmax. For utilities `u` and scale `β`,
-
-    `exp(uᵢ/β) · ∫₀^∞ exp(-S·t) dt = exp(uᵢ/β) / S = softmax((1/β) • u)ᵢ`,
-
-    where `S = Σⱼ exp(uⱼ/β)`. The identity is purely algebraic and holds for
-    every `β` (the RUM-relevant case is `β > 0`). [mcfadden-1974] assumes i.i.d.
-    Weibull (Gnedenko extreme-value) noise with CDF `exp(-e^{-ε})` and derives the
-    softmax selection probability `Pᵢ = e^{Vᵢ} / Σ e^{Vⱼ}`; the probabilistic
-    interpretation is formalized in `gumbelMaxProb_is_mcfaddenIntegral`. -/
-theorem mcfaddenIntegral_eq_softmax (i : ι) :
-    mcfaddenIntegral u β i = softmax ((1 / β) • u) i := by
-  simp only [mcfaddenIntegral, softmax, Pi.smul_apply, smul_eq_mul]
-  have hS : 0 < ∑ j : ι, exp (u j / β) :=
-    Finset.sum_pos (λ j _ => exp_pos _) ⟨Classical.arbitrary ι, mem_univ _⟩
-  rw [integral_exp_neg_mul_Ioi_zero hS]
-  simp_rw [show ∀ j : ι, u j / β = (1 / β) * u j from λ j => by ring]
-  rw [mul_one_div]
-
-/-- The McFadden integrals sum to 1 (they form a probability distribution). -/
-theorem mcfaddenIntegral_sum :
-    ∑ i : ι, mcfaddenIntegral u β i = 1 := by
-  simp_rw [mcfaddenIntegral_eq_softmax]
-  exact softmax_sum_eq_one ((1 / β) • u)
-
-/-- Each McFadden integral is positive. -/
-theorem mcfaddenIntegral_pos (i : ι) :
-    0 < mcfaddenIntegral u β i := by
-  rw [mcfaddenIntegral_eq_softmax]
-  exact softmax_pos ((1 / β) • u) i
-
-end Softmax
-
-end McFadden
-
-/-! ### Binary case: McFadden equals the logistic function -/
-
-section Binary
-
-variable (u : Fin 2 → ℝ) {β : ℝ}
-
-/-- **Binary McFadden = logistic**: for two alternatives, the McFadden integral
-    reduces to the logistic function.
-
-    `mcfaddenIntegral([u₁, u₂], β)(0) = Real.sigmoid((u₁ - u₂) / β)`
-
-    This is the exact Gumbel-Luce result for binary choice: if `ε₁, ε₂` are
-    i.i.d. Gumbel(0, β), then `P(u₁+ε₁ > u₂+ε₂) = Real.sigmoid((u₁-u₂)/β)`.
-
-    Compare with Thurstone Case V (`Thurstone.lean`):
-    `P(u₁+η₁ > u₂+η₂) = Φ((u₁-u₂)/(σ√2))` for Gaussian noise η. -/
-theorem mcfaddenIntegral_binary :
-    mcfaddenIntegral u β 0 = Real.sigmoid ((u 0 - u 1) / β) := by
-  rw [mcfaddenIntegral_eq_softmax, softmax_binary]
-  congr 1; ring
-
-/-- The binary McFadden integral for alternative 1 is the complement. -/
-theorem mcfaddenIntegral_binary_one :
-    mcfaddenIntegral u β 1 = 1 - Real.sigmoid ((u 0 - u 1) / β) := by
-  have hsum := mcfaddenIntegral_sum (u := u) (β := β)
-  rw [Fin.sum_univ_two] at hsum
-  linarith [mcfaddenIntegral_binary (u := u) (β := β)]
-
-end Binary
-
-/-! ### The Gumbel RUM as a `RationalAction` -/
+open Real MeasureTheory Set Filter ProbabilityTheory
 
 section GumbelRUM
 
-variable {ι : Type*} [Fintype ι]
+variable {ι : Type*} [Fintype ι] [DecidableEq ι] [Nonempty ι] {β : ℝ}
 
-/-- Construct a `RationalAction` from a Gumbel RUM.
+/-- **Gumbel RUM ⟹ softmax** (Lemma 1 of [mcfadden-1974], due to Holman and
+    Marley via Luce and Suppes): the max-probability integral of utilities `u`
+    under i.i.d. Gumbel(0, β) noise equals `softmax ((1/β) • u)`.
 
-    The score function is `exp(uᵢ/β)`, which gives Luce's choice rule.
-    This is the *exact* optimal policy under i.i.d. Gumbel noise
-    (by McFadden's theorem), not an approximation. -/
-noncomputable def RationalAction.fromGumbelRUM (u : ι → ℝ) (β : ℝ) :
-    RationalAction Unit ι where
-  score := λ _ i => exp (u i / β)
-  score_nonneg := λ _ _ => le_of_lt (exp_pos _)
+    [mcfadden-1974] states the unit-scale case; the `β`-generalization is
+    standard (the scale of the noise is not separately identified from the
+    scale of `u`). -/
+theorem rumMaxProb_gumbel_eq_softmax (u : ι → ℝ) (hβ : 0 < β) (i : ι) :
+    rumMaxProb (gumbelPDFReal 0 β) (fun x => cdf (gumbelMeasure 0 β) x) u i =
+      softmax ((1 / β) • u) i := by
+  have hpdf : ∀ x v : ℝ, gumbelPDFReal 0 β (x - v) = gumbelPDFReal v β x := by
+    intro x v; simp [gumbelPDFReal]
+  have hcdf : ∀ x v : ℝ, cdf (gumbelMeasure 0 β) (x - v) = cdf (gumbelMeasure v β) x := by
+    intro x v; rw [cdf_gumbelMeasure_eq hβ, cdf_gumbelMeasure_eq hβ, sub_zero]
+  simp only [rumMaxProb, hpdf, hcdf]
+  rw [integral_gumbelPDFReal_mul_prod_cdf u hβ i]
+  simp only [softmax, Pi.smul_apply, smul_eq_mul]
+  simp_rw [show ∀ j : ι, u j / β = 1 / β * u j from fun j => by ring]
 
-/-- The Gumbel RUM policy equals the McFadden integral (= softmax). -/
-theorem RationalAction.fromGumbelRUM_policy [Nonempty ι] (u : ι → ℝ) {β : ℝ} (i : ι) :
-    (RationalAction.fromGumbelRUM u β).policy () i =
-    mcfaddenIntegral u β i := by
-  rw [mcfaddenIntegral_eq_softmax]
-  simp only [RationalAction.policy, RationalAction.fromGumbelRUM,
-             RationalAction.totalScore, softmax, Pi.smul_apply, smul_eq_mul]
-  have hne : ∑ j : ι, exp (u j / β) ≠ 0 :=
-    ne_of_gt (Finset.sum_pos (λ j _ => exp_pos _) ⟨Classical.arbitrary ι, mem_univ _⟩)
-  rw [if_neg hne]
-  congr 1
-  · congr 1; ring
-  · congr 1; ext j; congr 1; ring
+/-- The Gumbel RUM policy sums to 1 over alternatives — inherited from
+    `softmax_sum_eq_one` through `rumMaxProb_gumbel_eq_softmax`. -/
+theorem rumMaxProb_gumbel_sum (u : ι → ℝ) (hβ : 0 < β) :
+    ∑ i : ι, rumMaxProb (gumbelPDFReal 0 β) (fun x => cdf (gumbelMeasure 0 β) x) u i = 1 := by
+  simp_rw [rumMaxProb_gumbel_eq_softmax _ hβ]
+  exact softmax_sum_eq_one ((1 / β) • u)
 
 end GumbelRUM
 
-/-! ### Measure-theoretic content: the Gumbel max-probability integral -/
+/-! ### Binary case: the logistic function -/
 
-/-- `gumbelMaxCDF S β x = exp(-S · exp(-x/β))`: the CDF of the maximum random
-    utility (a scaled Gumbel), the antiderivative core of the McFadden integral. -/
-private noncomputable abbrev gumbelMaxCDF (S β x : ℝ) : ℝ := exp (-S * exp (-x / β))
-
-/-- `gumbelMaxProbAntideriv C S β x = (C/S) · gumbelMaxCDF S β x`: the
-    antiderivative used in the FTC computation of the max-probability integral. -/
-private noncomputable abbrev gumbelMaxProbAntideriv (C S β x : ℝ) : ℝ :=
-  C / S * gumbelMaxCDF S β x
-
-private lemma hasDerivAt_exp_neg_div {β : ℝ} (x : ℝ) :
-    HasDerivAt (fun x => exp (-x / β)) (exp (-x / β) * (-1 / β)) x := by
-  have h := hasDerivAt_id x |>.neg.div_const β
-  exact (Real.hasDerivAt_exp _).comp x (h.congr_deriv (by simp [neg_div]))
-
-private lemma hasDerivAt_gumbelMaxCDF (S β x : ℝ) :
-    HasDerivAt (gumbelMaxCDF S β)
-      (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β)))) x :=
-  ((hasDerivAt_exp_neg_div (β := β) x).const_mul (-S)).exp
-
-private lemma hasDerivAt_gumbelMaxProbAntideriv (C S β x : ℝ) :
-    HasDerivAt (gumbelMaxProbAntideriv C S β)
-      (C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β))))) x :=
-  (hasDerivAt_gumbelMaxCDF S β x).const_mul (C / S)
-
-private lemma tendsto_gumbelMaxCDF_atTop {β : ℝ} (hβ : 0 < β) (S : ℝ) :
-    Tendsto (gumbelMaxCDF S β) atTop (nhds 1) := by
-  show Tendsto (fun x => exp (-S * exp (-x / β))) atTop (nhds 1)
-  rw [show (1 : ℝ) = exp 0 from exp_zero.symm]
-  exact (continuous_exp.tendsto 0).comp (by
-    rw [show (0 : ℝ) = -S * 0 from by ring]
-    exact (tendsto_exp_atBot.comp
-      (tendsto_neg_atTop_atBot.atBot_div_const hβ)).const_mul (-S))
-
-private lemma tendsto_gumbelMaxCDF_atBot {S β : ℝ} (hS : 0 < S) (hβ : 0 < β) :
-    Tendsto (gumbelMaxCDF S β) atBot (nhds 0) := by
-  show Tendsto (fun x => exp (-S * exp (-x / β))) atBot (nhds 0)
-  exact tendsto_exp_atBot.comp
-    ((tendsto_exp_atTop.comp
-      (tendsto_neg_atBot_atTop.atTop_div_const hβ)).const_mul_atTop_of_neg
-      (neg_lt_zero.mpr hS))
-
-private lemma tendsto_gumbelMaxProbAntideriv_atTop (C : ℝ) {S β : ℝ} (hβ : 0 < β) :
-    Tendsto (gumbelMaxProbAntideriv C S β) atTop (nhds (C / S)) := by
-  show Tendsto (fun x => C / S * gumbelMaxCDF S β x) atTop (nhds (C / S))
-  simpa using (tendsto_gumbelMaxCDF_atTop hβ S).const_mul (C / S)
-
-private lemma tendsto_gumbelMaxProbAntideriv_atBot (C : ℝ) {S β : ℝ} (hS : 0 < S) (hβ : 0 < β) :
-    Tendsto (gumbelMaxProbAntideriv C S β) atBot (nhds 0) := by
-  show Tendsto (fun x => C / S * gumbelMaxCDF S β x) atBot (nhds 0)
-  simpa using (tendsto_gumbelMaxCDF_atBot hS hβ).const_mul (C / S)
-
-private lemma gumbelMaxProbAntideriv_deriv_nonneg {C S β : ℝ}
-    (hC : 0 ≤ C) (hS : 0 < S) (hβ : 0 < β) (x : ℝ) :
-    0 ≤ C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β)))) := by
-  show 0 ≤ C / S * (exp (-S * exp (-x / β)) * (-S * (exp (-x / β) * (-1 / β))))
-  have : C / S * (exp (-S * exp (-x / β)) * (-S * (exp (-x / β) * (-1 / β)))) =
-      C / (S * β) * (exp (-S * exp (-x / β)) * (S * exp (-x / β))) := by field_simp
-  rw [this]; exact mul_nonneg (div_nonneg hC (by positivity))
-    (mul_nonneg (le_of_lt (exp_pos _)) (by positivity))
-
-private lemma gumbelMaxProbAntideriv_integrableOn_Ioi {C S β : ℝ}
-    (hC : 0 ≤ C) (hS : 0 < S) (hβ : 0 < β) :
-    IntegrableOn
-      (fun x => C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β)))))
-      (Set.Ioi 0) :=
-  integrableOn_Ioi_deriv_of_nonneg'
-    (fun x _ => hasDerivAt_gumbelMaxProbAntideriv C S β x)
-    (fun x _ => gumbelMaxProbAntideriv_deriv_nonneg hC hS hβ x)
-    (tendsto_gumbelMaxProbAntideriv_atTop C hβ)
-
-private lemma gumbelMaxProbAntideriv_integrableOn_Iic {C S β : ℝ}
-    (hC : 0 ≤ C) (hS : 0 < S) (hβ : 0 < β) :
-    IntegrableOn
-      (fun x => C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β)))))
-      (Set.Iic 0) := by
-  set f := fun x => C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β))))
-  have hcont : Continuous f := by
-    show Continuous fun x =>
-      C / S * (exp (-S * exp (-x / β)) * (-S * (exp (-x / β) * (-1 / β))))
-    fun_prop
-  have hfi : ∀ c : ℝ, IntegrableOn f (Set.Ioc c 0) := fun c => hcont.integrableOn_Ioc
-  have hint : ∀ c : ℝ, IntervalIntegrable f volume c 0 := fun c => hcont.intervalIntegrable c 0
-  have hftc : ∀ c ≤ (0 : ℝ), ∫ x in c..0, f x =
-      gumbelMaxProbAntideriv C S β 0 - gumbelMaxProbAntideriv C S β c := by
-    intro c hc
-    exact intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hc
-      (fun x _ => (hasDerivAt_gumbelMaxProbAntideriv C S β x).continuousAt.continuousWithinAt)
-      (fun x _ => hasDerivAt_gumbelMaxProbAntideriv C S β x) (hint c)
-  have hnorm_eq : ∀ c ≤ (0 : ℝ), ∫ x in c..0, ‖f x‖ = ∫ x in c..0, f x := by
-    intro c hc; congr 1; ext x
-    exact norm_of_nonneg (gumbelMaxProbAntideriv_deriv_nonneg hC hS hβ x)
-  refine integrableOn_Iic_of_intervalIntegral_norm_tendsto
-    (gumbelMaxProbAntideriv C S β 0) 0 hfi tendsto_id ?_
-  have hlim : Tendsto (fun c => gumbelMaxProbAntideriv C S β 0 - gumbelMaxProbAntideriv C S β c)
-      atBot (nhds (gumbelMaxProbAntideriv C S β 0)) := by
-    have h : Tendsto (fun c => gumbelMaxProbAntideriv C S β 0 - gumbelMaxProbAntideriv C S β c)
-        atBot (nhds (gumbelMaxProbAntideriv C S β 0 - 0)) :=
-      tendsto_const_nhds.sub (tendsto_gumbelMaxProbAntideriv_atBot C hS hβ)
-    rwa [sub_zero] at h
-  exact hlim.congr' (by
-    filter_upwards [Filter.Iic_mem_atBot (0 : ℝ)] with c (hc : c ≤ 0)
-    rw [hnorm_eq c hc, hftc c hc])
-
-private lemma gumbelMaxProbAntideriv_deriv_integrable {C S β : ℝ}
-    (hC : 0 ≤ C) (hS : 0 < S) (hβ : 0 < β) :
-    Integrable
-      (fun x => C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β))))) := by
-  rw [← integrableOn_univ, show (Set.univ : Set ℝ) = Set.Iic 0 ∪ Set.Ioi 0
-    from (Set.Iic_union_Ioi).symm]
-  exact IntegrableOn.union
-    (gumbelMaxProbAntideriv_integrableOn_Iic hC hS hβ)
-    (gumbelMaxProbAntideriv_integrableOn_Ioi hC hS hβ)
-
-private theorem gumbelMaxProbAntideriv_integral {C S β : ℝ}
-    (hC : 0 ≤ C) (hS : 0 < S) (hβ : 0 < β) :
-    ∫ x : ℝ, C / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β)))) =
-    C / S := by
-  have := integral_of_hasDerivAt_of_tendsto
-    (fun x => hasDerivAt_gumbelMaxProbAntideriv C S β x)
-    (gumbelMaxProbAntideriv_deriv_integrable hC hS hβ)
-    (tendsto_gumbelMaxProbAntideriv_atBot C hS hβ)
-    (tendsto_gumbelMaxProbAntideriv_atTop C hβ)
-  linarith
-
-private lemma gumbelMaxProb_integrand_eq {n : ℕ}
-    (u : Fin n → ℝ) (β : ℝ) (hβ : 0 < β) (i : Fin n) (x : ℝ) :
-    gumbelPDF β (x - u i) * ∏ j ∈ univ.erase i, gumbelCDF β (x - u j) =
-    exp (u i / β) / (∑ j : Fin n, exp (u j / β)) *
-      (gumbelMaxCDF (∑ j : Fin n, exp (u j / β)) β x *
-       (-(∑ j : Fin n, exp (u j / β)) * (exp (-x / β) * (-1 / β)))) := by
-  simp only [gumbelPDF, gumbelCDF]
-  set S := ∑ j : Fin n, exp (u j / β)
-  have hS_ne : S ≠ 0 := ne_of_gt (Finset.sum_pos (fun j _ => exp_pos _) ⟨i, mem_univ _⟩)
-  have hβ_ne : β ≠ 0 := ne_of_gt hβ
-  have h_prod : exp (-exp (-(x - u i) / β)) *
-      ∏ j ∈ univ.erase i, exp (-exp (-(x - u j) / β)) =
-      gumbelMaxCDF S β x := by
-    rw [Finset.mul_prod_erase univ (fun j => exp (-exp (-(x - u j) / β))) (mem_univ i)]
-    rw [← exp_sum]
-    show exp (∑ j : Fin n, -exp (-(x - u j) / β)) = exp (-S * exp (-x / β))
-    congr 1
-    simp_rw [show ∀ j : Fin n, -(x - u j) / β = u j / β + (-x / β) from fun j => by ring,
-             exp_add]
-    rw [Finset.sum_neg_distrib, ← Finset.sum_mul]
-    ring
-  have h_exp : exp (-(x - u i) / β) = exp (u i / β) * exp (-x / β) := by
-    rw [show -(x - u i) / β = u i / β + (-x / β) from by ring, exp_add]
-  rw [show (1 / β * exp (-(x - u i) / β) * exp (-exp (-(x - u i) / β))) *
-      ∏ j ∈ univ.erase i, exp (-exp (-(x - u j) / β)) =
-      1 / β * exp (-(x - u i) / β) *
-      (exp (-exp (-(x - u i) / β)) * ∏ j ∈ univ.erase i, exp (-exp (-(x - u j) / β)))
-      from by ring]
-  rw [h_prod, h_exp]
-  show 1 / β * (exp (u i / β) * exp (-x / β)) * gumbelMaxCDF S β x =
-    exp (u i / β) / S * (gumbelMaxCDF S β x * (-S * (exp (-x / β) * (-1 / β))))
-  field_simp
-
-/-- **Gumbel RUM = McFadden integral** — the measure-theoretic content of
-    Lemma 1 in [mcfadden-1974].
-
-    If `ε₁, …, εₙ` are i.i.d. Gumbel(0, β), then the probability that alternative
-    `i` attains the maximum random utility equals the McFadden integral:
-
-    `P(uᵢ + εᵢ = maxⱼ(uⱼ + εⱼ)) = mcfaddenIntegral u β i`
-
-    The proof uses the antiderivative `G(x) = (C/S) · exp(-S · exp(-x/β))` with
-    `C = exp(uᵢ/β)` and `S = Σⱼ exp(uⱼ/β)`: by the FTC on ℝ
-    (`integral_of_hasDerivAt_of_tendsto`), `∫ G' = C/S = mcfaddenIntegral`. -/
-theorem gumbelMaxProb_is_mcfaddenIntegral
-    {n : ℕ} (u : Fin n → ℝ) (β : ℝ) (hβ : 0 < β) (i : Fin n) :
-    (∫ x : ℝ, gumbelPDF β (x - u i) *
-      ∏ j ∈ univ.erase i, gumbelCDF β (x - u j))
-    = mcfaddenIntegral u β i := by
-  have hS : 0 < ∑ j : Fin n, exp (u j / β) :=
-    Finset.sum_pos (fun j _ => exp_pos _) ⟨i, mem_univ _⟩
-  simp_rw [gumbelMaxProb_integrand_eq u β hβ i]
-  rw [gumbelMaxProbAntideriv_integral (le_of_lt (exp_pos _)) hS hβ]
-  simp only [mcfaddenIntegral]
-  rw [integral_exp_neg_mul_Ioi_zero hS]
-  ring
-
-/-! ### Uniqueness: Gumbel is the only distribution yielding softmax
-
-McFadden's Lemma 2 shows that the Gumbel distribution is the **only** i.i.d. noise
-distribution yielding the softmax (Luce) choice rule. The key step: if the max-CDF
-`G` satisfies the functional equation `G(x - c) = G(x) ^ exp c` for all `x, c`, then
-`G` is a Gumbel CDF `G(t) = exp(-α · exp(-t))` with `α = -log(G 0) > 0`. Setting
-`x = 0`, `c = -t` gives `G t = G 0 ^ exp(-t)`, then `G 0 ^ y = exp(log(G 0) · y)` via
-`rpow_def_of_pos`. -/
-
-/-- If a function G satisfies the functional equation
-    `G(x - c) = G(x) ^ exp(c)` for all `x, c ∈ ℝ`,
-    and `0 < G(0) < 1`, then G is a Gumbel CDF:
-
-    `G(t) = exp(-α · exp(-t))` where `α = -log(G(0)) > 0`.
-
-    This is the core of McFadden's Lemma 2: the functional equation
-    characterizing the max-CDF uniquely determines the Gumbel family. The
-    hypothesis `G 0 < 1` is unused in this proof but pins down `α > 0`
-    (see `gumbel_alpha_pos`), excluding the degenerate `α = 0` case. -/
-theorem gumbel_from_functional_eq (G : ℝ → ℝ)
-    (hG0_pos : 0 < G 0) (_hG0_lt : G 0 < 1)
-    (hfe : ∀ x c : ℝ, G (x - c) = (G x) ^ (exp c)) :
-    ∀ t : ℝ, G t = exp (-(-log (G 0)) * exp (-t)) := by
-  intro t
-  -- Set x = 0, c = -t in the functional equation
-  have h := hfe 0 (-t)
-  simp only [zero_sub, neg_neg] at h
-  -- h : G t = (G 0) ^ exp (-t)
-  rw [h, rpow_def_of_pos hG0_pos]
-  -- Goal: exp (log (G 0) * exp (-t)) = exp (-(-log (G 0)) * exp (-t))
+/-- **Binary Gumbel RUM = logistic**: for two alternatives the choice
+    probability is `sigmoid ((u 0 - u 1) / β)`. Compare Thurstone Case V
+    (`Processing/Psychophysics/Thurstone.lean`): `Φ((u 0 - u 1)/(σ√2))` for
+    Gaussian noise. By [yellott-1977] the two are indistinguishable on binary
+    data alone. -/
+theorem rumMaxProb_gumbel_binary (u : Fin 2 → ℝ) {β : ℝ} (hβ : 0 < β) :
+    rumMaxProb (gumbelPDFReal 0 β) (fun x => cdf (gumbelMeasure 0 β) x) u 0 =
+      Real.sigmoid ((u 0 - u 1) / β) := by
+  rw [rumMaxProb_gumbel_eq_softmax u hβ 0, softmax_binary]
   congr 1; ring
 
-/-- The scale parameter α = -log(G(0)) is positive when 0 < G(0) < 1. -/
-theorem gumbel_alpha_pos (G : ℝ → ℝ)
-    (hG0_pos : 0 < G 0) (hG0_lt : G 0 < 1) :
-    0 < -log (G 0) := by
-  rw [neg_pos]
-  exact log_neg hG0_pos hG0_lt
+/-! ### The Gumbel RUM as a `RationalAction` -/
 
-/-- When G(0) = e⁻¹ (i.e., α = 1), the functional equation gives the
-    standard Gumbel CDF: G(t) = exp(-exp(-t)). -/
-theorem gumbel_standard_from_functional_eq (G : ℝ → ℝ)
-    (hG0 : G 0 = exp (-1))
-    (hfe : ∀ x c : ℝ, G (x - c) = (G x) ^ (exp c)) :
-    ∀ t : ℝ, G t = exp (-exp (-t)) := by
-  have hG0_pos : 0 < G 0 := by rw [hG0]; exact exp_pos _
-  have hG0_lt : G 0 < 1 := by rw [hG0]; exact exp_lt_one_iff.mpr (by linarith)
-  have h := gumbel_from_functional_eq G hG0_pos hG0_lt hfe
-  intro t
-  rw [h t]
+section RationalAgent
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The Luce agent of a Gumbel RUM: score `exp(uᵢ/β)`. This is `fromSoftmax`
+    at inverse temperature `β⁻¹` — exact under i.i.d. Gumbel(0, β) noise by
+    Lemma 1 of [mcfadden-1974], not an approximation. -/
+noncomputable def RationalAction.fromGumbelRUM (u : ι → ℝ) (β : ℝ) :
+    RationalAction Unit ι :=
+  RationalAction.fromSoftmax (fun _ => u) β⁻¹
+
+/-- The Gumbel RUM policy is softmax at inverse temperature `β⁻¹`. -/
+theorem RationalAction.fromGumbelRUM_policy [Nonempty ι] (u : ι → ℝ) {β : ℝ} (i : ι) :
+    (RationalAction.fromGumbelRUM u β).policy () i = softmax (β⁻¹ • u) i := by
+  rw [RationalAction.fromGumbelRUM, RationalAction.fromSoftmax_policy_eq]
+
+end RationalAgent
+
+/-! ### Uniqueness: the terminal step of McFadden's Lemma 2
+
+Lemma 2 of [mcfadden-1974] assumes softmax selection probabilities on every
+finite subset of a universe, representative utilities ranging over all of ℝ,
+and i.i.d. noise with a *translation complete* CDF `G`; it concludes `G` is
+Gumbel. Playing duplicated alternatives off against each other yields
+`G(x - log K) = G(x)^K` for positive integers `K`, which extends to the real
+functional equation by monotonicity. The theorems below formalize the terminal
+step only: solving the (real-strength) functional equation. -/
+
+/-- A noise CDF satisfying `G(x - c) = G(x) ^ exp c` with `0 < G 0` has the
+    Gumbel form `G(t) = exp (log (G 0) · exp (-t))`. -/
+theorem gumbel_from_functional_eq (G : ℝ → ℝ) (hG0_pos : 0 < G 0)
+    (hfe : ∀ x c : ℝ, G (x - c) = (G x) ^ (exp c)) (t : ℝ) :
+    G t = exp (log (G 0) * exp (-t)) := by
+  have h := hfe 0 (-t)
+  simp only [zero_sub, neg_neg] at h
+  rw [h, rpow_def_of_pos hG0_pos]
+
+/-- With the nondegeneracy bound `G 0 < 1`, the functional equation pins `G`
+    to an honest Gumbel CDF: `G = cdf (gumbelMeasure (log (-log (G 0))) 1)`. -/
+theorem eq_cdf_gumbelMeasure_of_functional_eq (G : ℝ → ℝ) (hG0_pos : 0 < G 0)
+    (hG0_lt : G 0 < 1) (hfe : ∀ x c : ℝ, G (x - c) = (G x) ^ (exp c)) (t : ℝ) :
+    G t = cdf (gumbelMeasure (log (-log (G 0))) 1) t := by
+  have hα : 0 < -log (G 0) := neg_pos.mpr (log_neg hG0_pos hG0_lt)
+  rw [gumbel_from_functional_eq G hG0_pos hfe t, cdf_gumbelMeasure_eq one_pos]
   congr 1
-  -- Goal: -(-log (G 0)) * exp (-t) = -exp (-t)
-  rw [hG0, log_exp]; ring
+  rw [div_one, show -(t - log (-log (G 0))) = log (-log (G 0)) + -t from by ring,
+    exp_add, exp_log hα]
+  ring
 
 end Core

--- a/Linglib/Core/Probability/Gumbel.lean
+++ b/Linglib/Core/Probability/Gumbel.lean
@@ -1,0 +1,212 @@
+import Mathlib.Probability.CDF
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+
+/-!
+# Gumbel distribution
+
+The Gumbel (Type I extreme value) distribution over ℝ, in the register of
+`Mathlib.Probability.Distributions.*`: density → measure via `withDensity` →
+CDF as a theorem. Application-agnostic — the random-utility reading lives in
+`Core/Probability/Choice/GumbelLuce.lean`.
+
+## Main definitions
+
+* `gumbelPDFReal`: the density `β⁻¹ · exp(-(x-μ)/β) · exp(-exp(-(x-μ)/β))`
+  with location `μ` and scale `β`.
+* `gumbelPDF`: the ℝ≥0∞-valued density.
+* `gumbelMeasure`: the Gumbel measure, `volume.withDensity (gumbelPDF μ β)`.
+
+## Main results
+
+* `cdf_gumbelMeasure_eq`: the CDF is `exp(-exp(-(x-μ)/β))`.
+* `prod_cdf_gumbelMeasure`: max-stability — the product of Gumbel CDFs with
+  common scale is the Gumbel CDF at location `β * log (∑ exp (uⱼ/β))`.
+* `integral_gumbelPDFReal_mul_prod_cdf`: the max-probability integral of a
+  Gumbel random-utility family evaluates to `exp(uᵢ/β) / ∑ⱼ exp(uⱼ/β)`.
+
+## Mathlib upstream candidates
+
+Mathlib has no Gumbel (or any extreme-value) distribution (verified 2026-08-01
+against `Mathlib.Probability.Distributions.*`); this whole file follows the
+`Pareto.lean` template and is an upstream candidate. `integrableOn_gumbelPDFReal_Iic`
+inlines a reflection argument because mathlib has `integrableOn_Ioi_deriv_of_nonneg'`
+but no `Iic` mirror — that general lemma is a separate small upstream candidate.
+-/
+
+namespace Core
+
+open scoped ENNReal NNReal
+open MeasureTheory Real Set Filter Topology ProbabilityTheory
+
+variable {μ β x : ℝ}
+
+/-! ### Density -/
+
+section GumbelPDF
+
+/-- The pdf of the Gumbel distribution with location `μ` and scale `β`. -/
+noncomputable def gumbelPDFReal (μ β x : ℝ) : ℝ :=
+  β⁻¹ * exp (-((x - μ) / β)) * exp (-exp (-((x - μ) / β)))
+
+/-- The pdf of the Gumbel distribution, as a function valued in `ℝ≥0∞`. -/
+noncomputable def gumbelPDF (μ β x : ℝ) : ℝ≥0∞ := ENNReal.ofReal (gumbelPDFReal μ β x)
+
+@[fun_prop]
+lemma measurable_gumbelPDFReal (μ β : ℝ) : Measurable (gumbelPDFReal μ β) := by
+  unfold gumbelPDFReal; fun_prop
+
+@[fun_prop]
+lemma stronglyMeasurable_gumbelPDFReal (μ β : ℝ) :
+    StronglyMeasurable (gumbelPDFReal μ β) := (measurable_gumbelPDFReal μ β).stronglyMeasurable
+
+lemma gumbelPDFReal_pos (hβ : 0 < β) (μ x : ℝ) : 0 < gumbelPDFReal μ β x := by
+  unfold gumbelPDFReal; positivity
+
+lemma gumbelPDFReal_nonneg (hβ : 0 ≤ β) (μ x : ℝ) : 0 ≤ gumbelPDFReal μ β x := by
+  unfold gumbelPDFReal; positivity
+
+/-- The Gumbel cdf `exp (-exp (-(x - μ)/β))` is an antiderivative of the pdf. -/
+lemma hasDerivAt_gumbelCDF (μ β x : ℝ) :
+    HasDerivAt (fun y => exp (-exp (-((y - μ) / β)))) (gumbelPDFReal μ β x) x := by
+  have h : HasDerivAt (fun y => -exp (-((y - μ) / β)))
+      (-(exp (-((x - μ) / β)) * -(1 / β))) x :=
+    ((Real.hasDerivAt_exp _).comp x (((hasDerivAt_id x).sub_const μ).div_const β).neg).neg
+  refine h.exp.congr_deriv ?_
+  simp only [gumbelPDFReal]; ring
+
+lemma tendsto_gumbelCDF_atTop (hβ : 0 < β) (μ : ℝ) :
+    Tendsto (fun y => exp (-exp (-((y - μ) / β)))) atTop (𝓝 1) := by
+  have hz : Tendsto (fun y : ℝ => -((y - μ) / β)) atTop atBot :=
+    tendsto_neg_atTop_atBot.comp ((tendsto_atTop_add_const_right _ (-μ)
+      tendsto_id).atTop_div_const hβ |>.congr (by intro y; simp only [id_eq]; ring))
+  simpa [Function.comp_def] using
+    (continuous_exp.tendsto 0).comp (by simpa using (tendsto_exp_atBot.comp hz).neg)
+
+lemma tendsto_gumbelCDF_atBot (hβ : 0 < β) (μ : ℝ) :
+    Tendsto (fun y => exp (-exp (-((y - μ) / β)))) atBot (𝓝 0) := by
+  have hz : Tendsto (fun y : ℝ => -((y - μ) / β)) atBot atTop :=
+    tendsto_neg_atBot_atTop.comp ((tendsto_atBot_add_const_right _ (-μ)
+      tendsto_id).atBot_div_const hβ |>.congr (by intro y; simp only [id_eq]; ring))
+  exact tendsto_exp_atBot.comp (tendsto_neg_atTop_atBot.comp (tendsto_exp_atTop.comp hz))
+
+lemma integrableOn_gumbelPDFReal_Ioi (hβ : 0 < β) (μ a : ℝ) :
+    IntegrableOn (gumbelPDFReal μ β) (Ioi a) :=
+  integrableOn_Ioi_deriv_of_nonneg' (fun x _ => hasDerivAt_gumbelCDF μ β x)
+    (fun x _ => (gumbelPDFReal_pos hβ μ x).le) (tendsto_gumbelCDF_atTop hβ μ)
+
+lemma integrableOn_gumbelPDFReal_Iic (hβ : 0 < β) (μ a : ℝ) :
+    IntegrableOn (gumbelPDFReal μ β) (Iic a) := by
+  have hrefl : IntegrableOn (fun x => gumbelPDFReal μ β (-x)) (Ioi (-a)) :=
+    integrableOn_Ioi_deriv_of_nonneg' (g := fun x => -exp (-exp (-((-x - μ) / β))))
+      (fun x _ => (((hasDerivAt_gumbelCDF μ β (-x)).comp x (hasDerivAt_neg x)).neg).congr_deriv
+        (by ring))
+      (fun x _ => (gumbelPDFReal_pos hβ μ (-x)).le)
+      (by simpa [Function.comp_def] using
+        ((tendsto_gumbelCDF_atBot hβ μ).comp tendsto_neg_atTop_atBot).neg)
+  refine ((Measure.measurePreserving_neg (volume : Measure ℝ)).integrableOn_comp_preimage
+    (MeasurableEquiv.neg ℝ).measurableEmbedding).mp ?_
+  rw [show Neg.neg ⁻¹' (Iic a) = Ici (-a) from by ext y; simp,
+    integrableOn_Ici_iff_integrableOn_Ioi]
+  simpa [Function.comp_def] using hrefl
+
+lemma integrable_gumbelPDFReal (hβ : 0 < β) (μ : ℝ) : Integrable (gumbelPDFReal μ β) := by
+  rw [← integrableOn_univ, ← Iic_union_Ioi (a := (0 : ℝ))]
+  exact (integrableOn_gumbelPDFReal_Iic hβ μ 0).union (integrableOn_gumbelPDFReal_Ioi hβ μ 0)
+
+/-- The pdf of the Gumbel distribution integrates to `1`. -/
+lemma integral_gumbelPDFReal_eq_one (hβ : 0 < β) (μ : ℝ) : ∫ x, gumbelPDFReal μ β x = 1 := by
+  simpa using integral_of_hasDerivAt_of_tendsto (fun x => hasDerivAt_gumbelCDF μ β x)
+    (integrable_gumbelPDFReal hβ μ) (tendsto_gumbelCDF_atBot hβ μ) (tendsto_gumbelCDF_atTop hβ μ)
+
+@[simp]
+lemma lintegral_gumbelPDF_eq_one (hβ : 0 < β) (μ : ℝ) : ∫⁻ x, gumbelPDF μ β x = 1 := by
+  simp only [gumbelPDF]
+  rw [← ofReal_integral_eq_lintegral_ofReal (integrable_gumbelPDFReal hβ μ)
+    (.of_forall fun x => gumbelPDFReal_nonneg hβ.le μ x), integral_gumbelPDFReal_eq_one hβ μ,
+    ENNReal.ofReal_one]
+
+end GumbelPDF
+
+/-! ### Measure and CDF -/
+
+/-- Measure defined by the Gumbel distribution. -/
+noncomputable def gumbelMeasure (μ β : ℝ) : Measure ℝ := volume.withDensity (gumbelPDF μ β)
+
+lemma isProbabilityMeasure_gumbelMeasure (hβ : 0 < β) (μ : ℝ) :
+    IsProbabilityMeasure (gumbelMeasure μ β) where
+  measure_univ := by simp [gumbelMeasure, lintegral_gumbelPDF_eq_one hβ μ]
+
+section GumbelCDF
+
+lemma cdf_gumbelMeasure_eq_integral (hβ : 0 < β) (μ x : ℝ) :
+    cdf (gumbelMeasure μ β) x = ∫ y in Iic x, gumbelPDFReal μ β y := by
+  have : IsProbabilityMeasure (gumbelMeasure μ β) := isProbabilityMeasure_gumbelMeasure hβ μ
+  rw [cdf_eq_real, gumbelMeasure, measureReal_def, withDensity_apply _ measurableSet_Iic]
+  refine (integral_eq_lintegral_of_nonneg_ae ?_ ?_).symm
+  · exact ae_of_all _ fun y => gumbelPDFReal_nonneg hβ.le μ y
+  · fun_prop
+
+/-- The cdf of the Gumbel distribution is `exp (-exp (-(x - μ)/β))`. -/
+lemma cdf_gumbelMeasure_eq (hβ : 0 < β) (μ x : ℝ) :
+    cdf (gumbelMeasure μ β) x = exp (-exp (-((x - μ) / β))) := by
+  rw [cdf_gumbelMeasure_eq_integral hβ μ x,
+    integral_Iic_of_hasDerivAt_of_tendsto' (fun y _ => hasDerivAt_gumbelCDF μ β y)
+      (integrableOn_gumbelPDFReal_Iic hβ μ x) (tendsto_gumbelCDF_atBot hβ μ), sub_zero]
+
+end GumbelCDF
+
+/-! ### Max-stability and the max-probability integral -/
+
+section MaxStability
+
+variable {ι : Type*} [Fintype ι] [Nonempty ι]
+
+private lemma sum_exp_pos (u : ι → ℝ) (β : ℝ) : (0:ℝ) < ∑ j : ι, exp (u j / β) :=
+  Finset.sum_pos (fun _ _ => exp_pos _) ⟨Classical.arbitrary ι, Finset.mem_univ _⟩
+
+/-- **Max-stability of the Gumbel family**: the product of independent Gumbel
+CDFs with common scale `β` is Gumbel with scale `β` and location
+`β * log (∑ exp (uⱼ/β))`. -/
+theorem prod_cdf_gumbelMeasure (u : ι → ℝ) (hβ : 0 < β) (x : ℝ) :
+    ∏ j : ι, cdf (gumbelMeasure (u j) β) x
+      = cdf (gumbelMeasure (β * log (∑ j : ι, exp (u j / β))) β) x := by
+  simp only [cdf_gumbelMeasure_eq hβ, ← exp_sum]
+  congr 1
+  rw [Finset.sum_neg_distrib]
+  congr 1
+  rw [show -((x - β * log (∑ j : ι, exp (u j / β))) / β)
+        = log (∑ j : ι, exp (u j / β)) + -(x/β) from by field_simp; ring,
+      exp_add, exp_log (sum_exp_pos u β), Finset.sum_mul]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [show -((x - u j) / β) = u j / β + -(x/β) from by ring, exp_add]
+
+/-- The max-probability integral of a Gumbel random-utility family: the density
+formula for the event that alternative `i` attains the maximum evaluates to
+`exp(uᵢ/β) / ∑ⱼ exp(uⱼ/β)`. -/
+theorem integral_gumbelPDFReal_mul_prod_cdf [DecidableEq ι] (u : ι → ℝ) (hβ : 0 < β)
+    (i : ι) :
+    (∫ x, gumbelPDFReal (u i) β x *
+        ∏ j ∈ Finset.univ.erase i, cdf (gumbelMeasure (u j) β) x)
+      = exp (u i / β) / ∑ j : ι, exp (u j / β) := by
+  have key : ∀ x : ℝ, gumbelPDFReal (u i) β x * ∏ j ∈ Finset.univ.erase i,
+      cdf (gumbelMeasure (u j) β) x
+      = exp (u i / β) / (∑ j : ι, exp (u j / β)) *
+          gumbelPDFReal (β * log (∑ j : ι, exp (u j / β))) β x := by
+    intro x
+    rw [show ∏ j ∈ Finset.univ.erase i, cdf (gumbelMeasure (u j) β) x
+        = (∏ j : ι, cdf (gumbelMeasure (u j) β) x) / cdf (gumbelMeasure (u i) β) x from by
+      rw [← Finset.mul_prod_erase Finset.univ _ (Finset.mem_univ i)]
+      field_simp [cdf_gumbelMeasure_eq hβ, exp_ne_zero],
+      prod_cdf_gumbelMeasure u hβ x, cdf_gumbelMeasure_eq hβ, cdf_gumbelMeasure_eq hβ]
+    simp only [gumbelPDFReal]
+    rw [show -((x - β * log (∑ j : ι, exp (u j / β))) / β)
+          = log (∑ j : ι, exp (u j / β)) + -(x/β) from by field_simp; ring,
+      exp_add, exp_log (sum_exp_pos u β),
+      show -((x - u i) / β) = u i / β + -(x/β) from by ring, exp_add]
+    field_simp
+  simp_rw [key, integral_const_mul, integral_gumbelPDFReal_eq_one hβ, mul_one]
+
+end MaxStability
+
+end Core

--- a/Linglib/Core/Probability/LogitChoice.lean
+++ b/Linglib/Core/Probability/LogitChoice.lean
@@ -17,7 +17,7 @@ properties are surveyed in [franke-degen-2023].
 It is the domain-neutral logit core shared across the library: RSA speakers and
 listeners (pragmatics), MaxEnt / Noisy HG (phonology), and rational-action agents
 (`Core.RationalAction`) all build on it. With the Gumbel→softmax result
-(`mcfaddenIntegral_eq_softmax`) it is the logit sibling of the probit choice rule
+(`rumMaxProb_gumbel_eq_softmax`) it is the logit sibling of the probit choice rule
 (`gaussianChoiceProb`).
 
 `[UPSTREAM]`: Mathlib has `Real.exp` / `Real.sigmoid` but no `softmax` /

--- a/Linglib/Core/Probability/RandomUtility.lean
+++ b/Linglib/Core/Probability/RandomUtility.lean
@@ -10,7 +10,9 @@ choosing the first is `Φ(Δ / σ)`, where `Φ` is the standard normal CDF
 (`Core.normalCDF`). Equivalently it is `P(X > 0)` for `X ~ N(Δ, σ²)`.
 
 This is the **probit** choice rule — the Gaussian sibling of the **logit**
-(softmax) choice rule that arises from Gumbel noise (`mcfaddenIntegral_binary`).
+(softmax) choice rule that arises from Gumbel noise (`rumMaxProb_gumbel_eq_softmax`
+in `Core/Probability/Choice/GumbelLuce.lean`). `rumMaxProb` below is the shared
+n-ary carrier both noise families instantiate.
 It is the shared, domain-neutral core that [thurstone-1927]'s Case V model of
 discriminal processes (`Core.ThurstoneCaseV`, psychophysics) and Noisy Harmonic
 Grammar ([boersma-pater-2016], phonology) both *instantiate*: neither depends on
@@ -75,5 +77,17 @@ theorem gaussianChoiceProb_strictMono (hσ : 0 < σ) :
   intro a b h
   simp only [gaussianChoiceProb]
   exact normalCDF_strictMono (div_lt_div_of_pos_right h hσ)
+
+/-! ### The n-ary max-probability integral -/
+
+open MeasureTheory in
+/-- The max-probability integral of a random utility model with i.i.d. noise:
+the density formula `∫ pdf(x - uᵢ) · ∏_{j≠i} cdf(x - uⱼ) dx` for the event that
+alternative `i` attains the maximum utility `uᵢ + εᵢ`. The Gumbel instance
+evaluates to softmax (`rumMaxProb_gumbel_eq_softmax`); the Gaussian instance is
+the n-ary Thurstone model. -/
+noncomputable def rumMaxProb {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (pdf cdf : ℝ → ℝ) (u : ι → ℝ) (i : ι) : ℝ :=
+  ∫ x : ℝ, pdf (x - u i) * ∏ j ∈ Finset.univ.erase i, cdf (x - u j)
 
 end Core

--- a/Linglib/Phonology/HarmonicGrammar/OTLimit.lean
+++ b/Linglib/Phonology/HarmonicGrammar/OTLimit.lean
@@ -21,7 +21,7 @@ The argument has two components:
 
 2. **MaxEnt concentration** (`softmax_argmax_limit`): as α → ∞, the MaxEnt
    distribution softmax(α·H) concentrates on the argmax of H — i.e., the HG
-   winner. This is proved in `Core.Agent.RationalAction`.
+   winner. This is proved in `Core.Probability.Choice.RationalAction`.
 
 Together: MaxEnt(α → ∞) → HG winner = OT winner.
 

--- a/Linglib/Processing/Psychophysics/GaussianChoice.lean
+++ b/Linglib/Processing/Psychophysics/GaussianChoice.lean
@@ -190,7 +190,7 @@ they differ only in the noise distribution:
 | Gumbel-Luce | Gumbel(0, β)      | `logistic((u_a-u_b)/β)` | `GumbelLuce.lean` |
 
 The Gumbel-Luce model gives **exactly** the softmax (Luce) choice rule
-(McFadden's theorem, `mcfaddenIntegral_eq_softmax`). The Thurstone model
+(Lemma 1 of [mcfadden-1974], `rumMaxProb_gumbel_eq_softmax`). The Thurstone model
 gives the normal CDF. These agree up to the Gaussian-logistic approximation
 `Φ(y·√3/π) ≈ logistic(y)` (max error ~0.023, variance matching;
 see `thurstone_luce_identity`).
@@ -210,10 +210,11 @@ it equates the variances `σ² · 2` (Gaussian difference) and `β² · π²/3`
 
     The two models are both RUMs; they agree when `Φ ≈ logistic`, i.e.,
     when the variance-matched scale `β = σ√6/π` (see `thurstoneLuceK`). -/
-theorem gumbelRUM_binary_eq_logistic (d' β : ℝ) (_hβ : 0 < β) :
-    mcfaddenIntegral (λ i : Fin 2 => if i = 0 then d' / 2 else -(d' / 2)) β 0
+theorem gumbelRUM_binary_eq_logistic (d' β : ℝ) (hβ : 0 < β) :
+    rumMaxProb (gumbelPDFReal 0 β) (fun x => ProbabilityTheory.cdf (gumbelMeasure 0 β) x)
+      (λ i : Fin 2 => if i = 0 then d' / 2 else -(d' / 2)) 0
     = Real.sigmoid (d' / β) := by
-  rw [mcfaddenIntegral_binary]
+  rw [rumMaxProb_gumbel_binary _ hβ]
   congr 1
   simp only [↓reduceIte]
   have h1 : ¬(1 : Fin 2) = (0 : Fin 2) := by decide
@@ -222,7 +223,7 @@ theorem gumbelRUM_binary_eq_logistic (d' β : ℝ) (_hβ : 0 < β) :
 
 /-! ## Stevens → Thurstone → SDT chain
 
-The two `Core/Agent/` psychophysics primitives — `StevensScale` (Stevens'
+The two psychophysics primitives — `StevensScale` (Stevens'
 power law `ψ(s) = k · sⁿ`, the deterministic intensity-to-percept mapping) and
 `SDTModel` (signal detection, the noisy discrimination operator) — sit in
 *different regimes*:

--- a/Linglib/Processing/Psychophysics/SignalDetection.lean
+++ b/Linglib/Processing/Psychophysics/SignalDetection.lean
@@ -42,7 +42,7 @@ two free and one derived:
 Under uniform prior odds and 0–1 loss, the Bayes-optimal criterion is `c = 0`
 (`β = 1`); under prior odds `π_N / π_S` it is `c* = log(π_N / π_S) / d'`.
 
-## Connection to Luce's choice framework (McFadden's theorem, exact)
+## Connection to Luce's choice framework (Gumbel–Luce equivalence, exact)
 
 Under the symmetric parameterization, the likelihood ratio at observation `x`
 (measured from the midpoint between the two distribution means) is
@@ -53,7 +53,7 @@ and the observer's "choice" between reporting signal vs noise follows a Luce
 model with `v(signal) / v(noise) = L(x)`. We construct this Luce model as
 `SDTModel.toLuceAt`, defined directly as a `RationalAction.fromGumbelRUM` with
 binary utilities `(d' · x, 0)` and scale `β = 1`. The signal probability and
-odds-ratio properties are then immediate corollaries of `mcfaddenIntegral_binary`
+odds-ratio properties are then immediate corollaries of `softmax_binary`
 and `RationalAction.fromGumbelRUM_policy` — making the SDT/Gumbel-Luce
 equivalence formally exact for binary detection (UNVERIFIED: [luce-1959]
 §2.E gives this as the original choice-theoretic framing).
@@ -379,9 +379,9 @@ section LuceEmbedding
 /-! ## SDT as a Luce model — exact via McFadden's theorem
 
 The SDT signal/noise choice is a binary Gumbel-Luce RUM: with utilities
-`(d' · x, 0)` and unit Gumbel scale `β = 1`, the McFadden integral reduces
+`(d' · x, 0)` and unit Gumbel scale `β = 1`, the Gumbel max-probability reduces
 to the SDT Luce policy exactly. The signal-probability and odds-ratio
-properties below are immediate corollaries of `mcfaddenIntegral_binary` and
+properties below are immediate corollaries of `softmax_binary` and
 `RationalAction.fromGumbelRUM_policy`. -/
 
 /-- The Gaussian likelihood ratio at observation `x`, given `d'`, in the
@@ -422,7 +422,7 @@ theorem SDTModel.likelihoodRatioAt_pos (m : SDTModel) (x : ℝ) :
     `(L(x), 1)`, the Bayesian-posterior-odds form under uniform prior.
 
     The Luce policy `P("signal" | x) = L(x) / (L(x) + 1)` is then immediate
-    from `mcfaddenIntegral_binary` (proved as `toLuceAt_signal_prob` below).
+    from `softmax_binary` (proved as `toLuceAt_signal_prob` below).
 
     *Note*: the construction depends on `m.dPrime` and the observation `x`,
     not on `m.criterion`. The criterion enters only at decision time (the
@@ -436,14 +436,14 @@ noncomputable def SDTModel.toLuceAt (m : SDTModel) (x : ℝ) :
 @[simp]
 theorem SDTModel.toLuceAt_score_signal (m : SDTModel) (x : ℝ) :
     (m.toLuceAt x).score () (0 : Fin 2) = m.likelihoodRatioAt x := by
-  simp [SDTModel.toLuceAt, RationalAction.fromGumbelRUM,
+  simp [SDTModel.toLuceAt, RationalAction.fromGumbelRUM, RationalAction.fromSoftmax,
         SDTModel.likelihoodRatioAt, likelihoodRatio]
 
 /-- The score on "noise" (action 1) is `1` (the Gumbel-RUM score with utility 0). -/
 @[simp]
 theorem SDTModel.toLuceAt_score_noise (m : SDTModel) (x : ℝ) :
     (m.toLuceAt x).score () (1 : Fin 2) = 1 := by
-  simp [SDTModel.toLuceAt, RationalAction.fromGumbelRUM]
+  simp [SDTModel.toLuceAt, RationalAction.fromGumbelRUM, RationalAction.fromSoftmax]
 
 /-- The Luce odds ratio `score(signal) / score(noise)` equals the likelihood
     ratio — the core SDT/Luce identification.
@@ -456,21 +456,17 @@ theorem SDTModel.toLuceAt_odds_ratio (m : SDTModel) (x : ℝ) :
   rw [m.toLuceAt_score_signal, m.toLuceAt_score_noise, div_one]
 
 /-- The Luce signal probability `L(x) / (L(x) + 1)`, derived as a corollary of
-    `mcfaddenIntegral_binary` via `RationalAction.fromGumbelRUM_policy`. -/
+    `softmax_binary` via `RationalAction.fromGumbelRUM_policy`. -/
 theorem SDTModel.toLuceAt_signal_prob (m : SDTModel) (x : ℝ) :
     (m.toLuceAt x).policy () (0 : Fin 2) =
     m.likelihoodRatioAt x / (m.likelihoodRatioAt x + 1) := by
-  rw [SDTModel.toLuceAt, RationalAction.fromGumbelRUM_policy,
-      mcfaddenIntegral_binary]
   have h01 : ¬(1 : Fin 2) = (0 : Fin 2) := by decide
-  simp only [Fin.isValue, ↓reduceIte, h01, sub_zero, div_one, Real.sigmoid_def,
-             SDTModel.likelihoodRatioAt, likelihoodRatio]
-  rw [show m.dPrime * x = -(-(m.dPrime * x)) from by ring,
-      show -(-(m.dPrime * x)) = -(-1 * (m.dPrime * x)) from by ring,
-      neg_mul, one_mul, neg_neg]
-  -- Goal: (1 + exp(-(d'·x)))⁻¹ = exp(d'·x) / (exp(d'·x) + 1)
-  have hpos : (0 : ℝ) < Real.exp (m.dPrime * x) := exp_pos _
+  rw [SDTModel.toLuceAt, RationalAction.fromGumbelRUM_policy, softmax_binary]
+  simp only [Pi.smul_apply, smul_eq_mul, Fin.isValue, ↓reduceIte, h01, inv_one, one_mul,
+             mul_zero, sub_zero, Real.sigmoid_def, SDTModel.likelihoodRatioAt,
+             likelihoodRatio]
   rw [Real.exp_neg]
+  have h := (Real.exp_pos (m.dPrime * x)).ne'
   field_simp
 
 end LuceEmbedding
@@ -578,8 +574,8 @@ where `k = π/√3 ≈ 1.814` is the variance-matching constant:
 This is the Thurstone-Luce bridge for the detection context: both SDT
 (Gaussian noise) and the Gumbel-Luce model (Gumbel noise) are Random
 Utility Models. The Gumbel-Luce model gives **exactly** logistic
-probabilities (McFadden's theorem; see `gumbelMaxProb_is_mcfaddenIntegral`
-in `GumbelLuce.lean`). The Gaussian model gives `Φ`. These agree up to the
+probabilities (Lemma 1 of [mcfadden-1974]; see `integral_gumbelPDFReal_mul_prod_cdf`
+in `Core/Probability/Gumbel.lean`). The Gaussian model gives `Φ`. These agree up to the
 numerical approximation `Φ ≈ logistic`.
 
 The constant `k = π/√3` equals `thurstoneLuceK(1/√2)`, unifying the SDT

--- a/Linglib/Studies/DongEtAl2026PMF.lean
+++ b/Linglib/Studies/DongEtAl2026PMF.lean
@@ -56,7 +56,7 @@ The cross-question `argmax` selection of the policy is out of scope: the
 results here concern the per-question clarify-or-commit decision.
 
 This PMF/`ℝ≥0∞` formulation parallels the `ℝ`-valued expected-information-gain
-substrate `Core.Agent.ExperimentDesign.eig` (with value function `V U`):
+substrate `Core.Probability.Decision.ExperimentDesign.eig` (with value function `V U`):
 `V_le_Vpost` is the PMF analogue of `ExperimentDesign.eig_nonneg_of_convex`
 and of `TsvilodubEtAl2026.evpi_nonneg`.
 
@@ -71,7 +71,7 @@ logistic gate (`TsvilodubEtAl2026.softGateRule`).
 * Discharge the claim that EVPI (`TsvilodubEtAl2026.evpi`) is the upper
   bound on VoI for any question into a theorem
   `worthAsking c U b κ → c < EVPI`.
-* Relate `VoI` / `V_le_Vpost` to `Core.Agent.ExperimentDesign.eig` /
+* Relate `VoI` / `V_le_Vpost` to `Core.Probability.Decision.ExperimentDesign.eig` /
   `eig_nonneg_of_convex` (bridging the `ℝ≥0∞`-on-`PMF` and `ℝ`-on-`Fintype`
   carriers) so the two statements of "information has nonnegative value" become
   one fact.

--- a/Linglib/Studies/Flemming2021.lean
+++ b/Linglib/Studies/Flemming2021.lean
@@ -62,19 +62,17 @@ open Core.Optimization Constraints HarmonicGrammar Core Real
 -- § 1: MaxEnt as Gumbel RUM (McFadden)
 -- ============================================================================
 
-/-- **MaxEnt = Gumbel RUM** ([flemming-2021] §4/§10): MaxEnt probability
-    is exactly the McFadden integral with Gumbel scale β = 1.
-
-    This formalizes the RUM connection: MaxEnt adds i.i.d. Gumbel noise to
-    candidate harmonies, and by McFadden's theorem
-    (`mcfaddenIntegral_eq_softmax`), the resulting choice probability is
-    softmax — i.e., the standard MaxEnt formula. -/
-theorem maxent_eq_gumbelRUM {C : Type} [Fintype C] [Nonempty C] {n : ℕ}
+/-- **MaxEnt = Gumbel RUM** ([flemming-2021] §4/§10): the max-probability
+    integral of a RUM with candidate harmonies as utilities and i.i.d.
+    Gumbel(0, 1) noise is exactly the MaxEnt (softmax) formula, by Lemma 1 of
+    [mcfadden-1974] (`rumMaxProb_gumbel_eq_softmax`). -/
+theorem maxent_eq_gumbelRUM {C : Type} [Fintype C] [Nonempty C] [DecidableEq C] {n : ℕ}
     (con : CON C n) (w : Fin n → ℝ) (c : C) :
-    mcfaddenIntegral (harmonyScore con w) 1 c =
+    rumMaxProb (gumbelPDFReal 0 1) (fun x => ProbabilityTheory.cdf (gumbelMeasure 0 1) x)
+      (harmonyScore con w) c =
     softmax (harmonyScore con w) c := by
-  rw [mcfaddenIntegral_eq_softmax]
-  simp only [div_one, one_smul]
+  rw [rumMaxProb_gumbel_eq_softmax _ one_pos c]
+  norm_num [one_smul]
 
 -- ============================================================================
 -- § 2: MaxEnt Logit Uniformity (eq (10))

--- a/Linglib/Studies/GoldwaterJohnson2003.lean
+++ b/Linglib/Studies/GoldwaterJohnson2003.lean
@@ -12,7 +12,7 @@ of output y given input x as:
   `Pr(y|x) = exp(Σ wᵢfᵢ(y,x)) / Z(x)`
 
 This IS `softmax(harmonyScore constraints, 1)` — the same `softmax` from
-`Core.Agent.RationalAction` used throughout linglib for RSA pragmatics.
+`Core.Probability.Choice.RationalAction` used throughout linglib for RSA pragmatics.
 The phonology–pragmatics connection is structural: both are log-linear
 models over weighted features, differing only in what the features measure.
 
@@ -63,7 +63,7 @@ noncomputable def gjProb {I O : Type} [Fintype O] {n : ℕ}
     `softmax(harmonyScore con w, 1)`.
 
     The same `softmax` function powers RSA pragmatic reasoning
-    (`Core.Agent.RationalAction`): both phonological grammar and
+    (`Core.Probability.Choice.RationalAction`): both phonological grammar and
     pragmatic inference are log-linear models over weighted features. -/
 theorem eq1_is_softmax {I O : Type} [Fintype O] {n : ℕ}
     (con : CON (I × O) n) (w : Fin n → ℝ) (i : I) (o : O) :
@@ -105,7 +105,7 @@ noncomputable def regularizedObjective {I O : Type} [Fintype O] {n : ℕ}
     and `rᵢ = Σₖ≠ⱼ wₖ(−cₖ(yᵢ,x))`. The first term is affine (hence concave);
     the second is convex (`logSumExpOffset_convex`). Concave − convex = concave.
 
-    This is `logConditional_concaveOn` from `Core.Agent.RationalAction`. -/
+    This is `logConditional_concaveOn` from `Core.Probability.Choice.RationalAction`. -/
 theorem concavity {ι : Type*} [Fintype ι] [Nonempty ι] (s r : ι → ℝ) (y : ι) :
     ConcaveOn ℝ Set.univ
       (fun wⱼ => (wⱼ * s y + r y) - logSumExp (wⱼ • s + r)) :=
@@ -126,7 +126,7 @@ theorem concavity {ι : Type*} [Fintype ι] [Nonempty ι] (s r : ι → ℝ) (y 
     At the maximum, this derivative is zero, so `sᵧ = E_P[s]`: the
     observed feature value equals the expected feature value.
 
-    This is `hasDerivAt_logConditional` from `Core.Agent.RationalAction`. -/
+    This is `hasDerivAt_logConditional` from `Core.Probability.Choice.RationalAction`. -/
 theorem gradient {ι : Type*} [Fintype ι] [Nonempty ι]
     (s r : ι → ℝ) (y : ι) (wⱼ : ℝ) :
     HasDerivAt (fun w => (w * s y + r y) - logSumExp (w • s + r))

--- a/Linglib/Studies/Jaeger2007.lean
+++ b/Linglib/Studies/Jaeger2007.lean
@@ -25,7 +25,7 @@ Gradient Ascent (SGA) for Maximum Entropy models. This unifies two traditions:
 2. **Correct gradient** (§4, eq (2)): The per-weight gradient of MaxEnt
    log-likelihood is `E_emp[cⱼ] − E_r̄[cⱼ]` — observed minus expected
    feature value. This is `hasDerivAt_logConditional` from
-   `Core.Agent.RationalAction`, instantiated as `gradient` in
+   `Core.Probability.Choice.RationalAction`, instantiated as `gradient` in
    [goldwater-johnson-2003].
 
 3. **Convergence guarantee** (§4): SGA converges to the global maximum

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -1523,6 +1523,46 @@
   subfield  = {pragmatics/rsa},
   role      = {foundational},
   sources   = {Core/Probability/Choice/GumbelLuce.lean}
+}
+@article{yellott-1977,
+  author    = {Yellott, Jr., John I.},
+  year      = {1977},
+  title     = {The relationship between {Luce's} Choice Axiom, {Thurstone's} Theory of Comparative Judgment, and the double exponential distribution},
+  journal   = {Journal of Mathematical Psychology},
+  volume    = {15},
+  number    = {2},
+  pages     = {109--144},
+  doi       = {10.1016/0022-2496(77)90026-8},
+  subfield  = {pragmatics/rsa},
+  validated = {true},
+  role      = {cited},
+  sources   = {Core/Probability/Choice/GumbelLuce.lean}
+}
+@incollection{marschak-1960,
+  author    = {Marschak, Jacob},
+  year      = {1960},
+  title     = {Binary-choice constraints and random utility indicators},
+  booktitle = {Mathematical Methods in the Social Sciences, 1959},
+  editor    = {Arrow, Kenneth J. and Karlin, Samuel and Suppes, Patrick},
+  publisher = {Stanford University Press},
+  address   = {Stanford, CA},
+  subfield  = {pragmatics/rsa},
+  validated = {true},
+  role      = {cited},
+  sources   = {Core/Probability/Choice/GumbelLuce.lean}
+}
+@incollection{luce-suppes-1965,
+  author    = {Luce, R. Duncan and Suppes, Patrick},
+  year      = {1965},
+  title     = {Preference, utility, and subjective probability},
+  booktitle = {Handbook of Mathematical Psychology, Vol.\ III},
+  editor    = {Luce, R. Duncan and Bush, Robert R. and Galanter, Eugene},
+  publisher = {Wiley},
+  address   = {New York},
+  subfield  = {pragmatics/rsa},
+  validated = {true},
+  role      = {cited},
+  sources   = {Core/Probability/Choice/GumbelLuce.lean}
 }% REF: Csiszár, I. & Tusnády, G. (1984). Information geometry and alternating minimization procedures.
 @incollection{speas-tenny-2003,
   author    = {Speas, Peggy and Tenny, Carol L.},


### PR DESCRIPTION
From the GumbelLuce audit, targeting "what would actually go in mathlib": mathlib has no Gumbel (or any extreme-value) distribution, so the universal half becomes a genuine upstream candidate and the RUM half becomes thin glue.

- New `Core/Probability/Gumbel.lean` in the `Mathlib/Probability/Distributions` register (density → `withDensity` measure → CDF as a theorem → max-stability → the max-probability integral), location-scale, replacing the old bare-ℝ `gumbelCDF`/`gumbelPDF` pair that was stipulated in the wrong order (CDF primitive, never connected to its density) and the 150-line private FTC block.
- `GumbelLuce.lean` rewritten: shared n-ary RUM carrier `rumMaxProb` lands in `RandomUtility.lean` (parallel to the probit side); `mcfaddenIntegral` — an unevaluated proof intermediate consumers were quantifying over — is gone, with `Flemming2021`/`GaussianChoice`/`SignalDetection` restated over `rumMaxProb`/`softmax`/`sigmoid` (Flemming's MaxEnt=RUM theorem now states the claim its docstring made); `fromGumbelRUM` is defined through `fromSoftmax`.
- Attribution fixes verified against the McFadden 1974 PDF: Lemma 1 credited to Marschak and Holman–Marley per McFadden's own p. 111 note; the uniqueness section now states Lemma 2's hypotheses and its terminal-step scope; Yellott 1977 binary non-uniqueness noted; verified bib entries `yellott-1977`/`marschak-1960`/`luce-suppes-1965` added; stale `Core.Agent.*` doc paths swept.