### PR TITLE
refactor(Semantics/Composition): adopt mathlib Cont, fix attribution

### DIFF
--- a/Linglib/Semantics/Composition/Continuation.lean
+++ b/Linglib/Semantics/Composition/Continuation.lean
@@ -1,154 +1,79 @@
-import Mathlib.Tactic.Basic
+import Mathlib.Control.Monad.Cont
 
 /-!
-# Continuation Monad
-[barker-shan-2014] [charlow-2021]
+# Continuations for scope-taking
+[barker-2002] [shan-2001] [charlow-2014] [barker-shan-2014]
 
-General-purpose continuation monad, following [barker-shan-2014].
-The type `Cont R A := (A → R) → R` underlies lifted question types
-(Lifted.lean), higher-order dynamic GQs, and
-scope-taking expressions generally.
+Scope-taking expressions denote values of the continuation monad
+`Cont R A := (A → R) → R` (`Mathlib.Control.Monad.Cont`): continuations for
+quantifier scope originate with [barker-2002]; the monadic framing is
+[shan-2001], developed by [charlow-2014]. Consumers: higher-order dynamic
+GQs (`Studies/Charlow2021.lean`) and the effects fragment of
+`Studies/BumfordCharlow2024.lean`.
 
-## Key definitions
+## Main definitions
 
-- `Cont R A`: the continuation monad
-- `Cont.pure`, `Cont.bind`, `Cont.map`: monad operations
-- `Cont.lower`: Barker & Shan's LOWER (evaluate with identity continuation)
-- `Tower C B A`: Barker & Shan's tower abbreviation `(A → B) → C`
+- `Cont.lower`: evaluate with the identity continuation — "scope-taking is
+  done". `pure` is Montague lift ([barker-shan-2014]'s LIFT), and
+  `Cont.lower_pure` is LOWER ∘ LIFT = id.
 
+## Main statements
+
+- `Cont.lower_bind_pure` and variants: lowering a chain of binds is nested
+  generalized-quantifier application — relative scope is bind order.
 -/
 
 namespace Semantics.Composition.Continuation
 
-universe u v w
+/-- LOWER: evaluate with the identity continuation — [barker-shan-2014]'s
+"scope-taking is done", at `B := A`. Their own LOWER pins the answer type to
+the atomic clause category `S`; the pinning carries their crossover account
+and is not imposed here. -/
+def Cont.lower {A : Type*} (m : Cont A A) : A := m.run id
 
-/-- The continuation monad: `(A → R) → R`.
-    An expression of type `Cont R A` takes a continuation `A → R` and
-    produces a result of type `R`. -/
-def Cont (R : Type u) (A : Type v) := (A → R) → R
-
-variable {R : Type u} {A : Type v} {B : Type w}
-
-/-- Monadic unit: wrap a value for any continuation.
-    `pure a = λκ. κ(a)` -/
-def Cont.pure (a : A) : Cont R A := λ κ => κ a
-
-/-- Monadic bind: sequence two continuized computations.
-    `m >>= f = λκ. m(λa. f(a)(κ))` -/
-def Cont.bind (m : Cont R A) (f : A → Cont R B) : Cont R B :=
-  λ κ => m (λ a => f a κ)
-
-/-- Functorial map: apply a function under the continuation.
-    `map f m = λκ. m(λa. κ(f(a)))` -/
-def Cont.map (f : A → B) (m : Cont R A) : Cont R B :=
-  λ κ => m (λ a => κ (f a))
-
-/-- LOWER: evaluate a `Cont A A` with the identity continuation.
-    Barker & Shan's key operation for "scope-taking is done." -/
-def Cont.lower (m : Cont A A) : A := m id
-
-/-- Tower type abbreviation: `(A → B) → C`.
-    In Barker & Shan's notation, this is the flat reading of
-    ```
-      C | B
-      ─────
-        A
-    ``` -/
-abbrev Tower (C : Type u) (B : Type v) (A : Type w) := (A → B) → C
-
-
-/-! The continuation monad's laws (left/right identity, associativity, and the
-functor laws) are exactly those of `LawfulMonad`, so we register `Cont R` as a
-lawful monad rather than restating them as standalone `rfl` theorems. `R` is
-fixed to `Type` (not universe-polymorphic) for Lean's `Monad` class. -/
-
-section Instances
-
-variable {R : Type}
-
-instance : Functor (Cont R) where
-  map := Cont.map
-
-instance : Pure (Cont R) where
-  pure := Cont.pure
-
-instance : Bind (Cont R) where
-  bind := Cont.bind
-
-instance : Seq (Cont R) where
-  seq mf mx := Cont.bind mf (λ f => Cont.map f (mx ()))
-
-instance : Monad (Cont R) where
-
-instance : LawfulMonad (Cont R) where
-  map_const := rfl
-  id_map _ := rfl
-  comp_map _ _ _ := rfl
-  bind_pure_comp _ _ := rfl
-  pure_bind _ _ := rfl
-  bind_assoc _ _ _ := rfl
-  bind_map _ _ := rfl
-  pure_seq _ _ := rfl
-  seq_pure _ _ := rfl
-  seq_assoc _ _ _ := rfl
-  seqLeft_eq _ _ := rfl
-  seqRight_eq _ _ := rfl
-  map_pure _ _ := rfl
-
-end Instances
-
-/-- Lower of pure is identity. (Not a monad law — a fact about `Cont.lower`.) -/
-theorem Cont.lower_pure (a : A) : Cont.lower (Cont.pure a) = a := rfl
+/-- LOWER ∘ LIFT = id: `pure : A → Cont R A` is [barker-shan-2014]'s LIFT
+(Montague lift), and lowering it recovers the value. -/
+@[simp] theorem Cont.lower_pure {A : Type*} (a : A) :
+    Cont.lower (pure a) = a := rfl
 
 /-! ### Scope as bind order
 
-Scope ambiguity in the continuation framework is the *order of monadic
+In the monadic framing, relative quantifier scope is the *order of monadic
 bind* — surface scope binds the subject first, inverse scope the object
-first — and `lower` is generalized-quantifier application
-([barker-shan-2014]). These hold for any quantifier and predicate. -/
+first — and `Cont.lower` is generalized-quantifier application
+([shan-2001], [charlow-2014]). Free bind order contrasts with
+[barker-shan-2014]'s combination schema, whose fixed left-to-right
+evaluation (their linear scope bias) derives inverse scope from multi-level
+towers instead. -/
 
 section ScopeAsBindOrder
 
-variable {E S : Type}
+universe u
 
-/-- Lowering a `Cont`-wrapped quantifier with a pure scope predicate is
-plain GQ application: `lower (Q >>= λx. pure (P x)) = Q P`. -/
-theorem cont_scope_reduce (q : Cont S E) (scope : E → S) :
-    Cont.lower (Cont.bind q (fun x => Cont.pure (scope x))) = q scope := rfl
+variable {E S : Type u}
 
-/-- Nested `Cont` binds compute nested GQ application; the bind nesting
-determines scope order. -/
-theorem cont_scope_double (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    Cont.lower (Cont.bind q₁ (fun x =>
-      Cont.bind q₂ (fun y => Cont.pure (rel x y)))) =
-    q₁ (fun x => q₂ (fun y => rel x y)) := rfl
+/-- Lowering a continuized quantifier against a pure scope is plain GQ
+application. -/
+theorem Cont.lower_bind_pure (q : Cont S E) (scope : E → S) :
+    Cont.lower (q >>= λ x => pure (scope x)) = q scope := rfl
 
-/-- **Scope ambiguity = bind order**: the two readings of `Q₁ R Q₂` are
-`Q₁` nested outside `Q₂` vs `Q₂` outside `Q₁`, each reducing to GQ
-application in the corresponding order. -/
-theorem scope_ambiguity_is_bind_order (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    Cont.lower (Cont.bind q₁ (fun x =>
-      Cont.bind q₂ (fun y => Cont.pure (rel x y)))) =
-    q₁ (fun x => q₂ (fun y => rel x y))
-    ∧
-    Cont.lower (Cont.bind q₂ (fun y =>
-      Cont.bind q₁ (fun x => Cont.pure (rel x y)))) =
-    q₂ (fun y => q₁ (fun x => rel x y)) :=
-  ⟨rfl, rfl⟩
+/-- Nested binds compute nested GQ application: the outer bind takes wide
+scope. -/
+theorem Cont.lower_bind_bind_pure (q₁ q₂ : Cont S E) (rel : E → E → S) :
+    Cont.lower (q₁ >>= λ x => q₂ >>= λ y => pure (rel x y)) =
+    q₁ (λ x => q₂ (λ y => rel x y)) := rfl
 
 /-- The bind-order pattern extends to arbitrary depth. -/
-theorem cont_scope_triple (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :
-    Cont.lower (Cont.bind q₁ (fun x =>
-      Cont.bind q₂ (fun y =>
-        Cont.bind q₃ (fun z => Cont.pure (rel x y z))))) =
-    q₁ (fun x => q₂ (fun y => q₃ (fun z => rel x y z))) := rfl
+theorem Cont.lower_bind₃_pure (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :
+    Cont.lower (q₁ >>= λ x => q₂ >>= λ y => q₃ >>= λ z => pure (rel x y z)) =
+    q₁ (λ x => q₂ (λ y => q₃ (λ z => rel x y z))) := rfl
 
-/-- When all meanings are `Cont.pure`-wrapped, `Cont` composition reduces
-to function application — the non-scope-taking (Reader) fragment embeds
-into `Cont` ([charlow-2018]). -/
-theorem cont_pure_is_fa {A : Type} (f : A → S) (x : A) :
-    Cont.lower (Cont.bind (Cont.pure f) (fun g =>
-      Cont.bind (Cont.pure x) (fun y => Cont.pure (g y)))) = f x := rfl
+/-- When every meaning is `pure`-wrapped, `Cont` composition reduces to
+function application: the effect-free fragment embeds into `Cont`
+([charlow-2018]). -/
+theorem Cont.lower_pure_bind_pure {A : Type u} (f : A → S) (x : A) :
+    Cont.lower ((pure f : Cont S (A → S)) >>= λ g =>
+      (pure x : Cont S A) >>= λ y => pure (g y)) = f x := rfl
 
 end ScopeAsBindOrder
 

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -63,7 +63,7 @@ S&B substrate in linglib yet.
 
 ## Implementation notes
 
-Scope-as-bind-order (`scope_ambiguity_is_bind_order` et al.) lives with the
+Scope-as-bind-order (`Cont.lower_bind_pure` et al.) lives with the
 `Cont` monad in `Composition/Continuation`; this study consumes it.
 The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 -/
@@ -90,8 +90,9 @@ open Semantics.Montague.ToyLexicon (student_sem person_sem)
 The W effect is mathlib's `Writer (List P)` (= `WriterT (List P) Id`), whose
 `Functor`/`Applicative`/`Monad` instances come from mathlib, with
 `LawfulMonad` and the `val`/`log`/`tell` surface in
-`Composition/WriterMonad.lean`. The `Cont R` instances live with the
-type in `Composition/Continuation.lean`. -/
+`Composition/WriterMonad.lean`. The `Cont R` monad is mathlib's
+(`Mathlib.Control.Monad.Cont`); its linguistics surface (`Cont.lower`)
+lives in `Composition/Continuation.lean`. -/
 
 -- ════════════════════════════════════════════════════════════════════
 -- §2 Meta-Combinators
@@ -480,18 +481,9 @@ end PredAbsInstances
 
 Connect the effect framework to existing linglib constructions, proving
 that independently-developed linglib modules are instances of the
-effect-driven architecture. -/
-
-section WriterBridge
-
--- `Writer`'s monadic application IS `<*>` (mathlib's `WriterT` instance),
--- so no bridge theorem is needed for the W effect.
-
-/-- Lowering a Cont is handling the scope effect. -/
-theorem cont_lower_is_handleScope {R : Type} (m : Cont R R) :
-    Cont.lower m = handleScope m := rfl
-
-end WriterBridge
+effect-driven architecture. The W and C effects need no bridge:
+`Writer`'s monadic application is mathlib's `<*>`, and
+`handleScope := Cont.lower` by definition. -/
 
 section CIBridge
 
@@ -640,10 +632,6 @@ def gqAsCont {E : Type} (gq : (E → Prop) → Prop) : Cont Prop E :=
 def contAsGQ {E : Type} (c : Cont Prop E) : (E → Prop) → Prop :=
   c
 
-/-- Round-trip: GQ → Cont → GQ is identity. -/
-theorem gq_cont_roundtrip {E : Type} (gq : (E → Prop) → Prop) :
-    contAsGQ (gqAsCont gq) = gq := rfl
-
 /-- `every_sem` applied to a restrictor is a `Cont Prop Entity` value. -/
 def every_as_cont (restrictor : ToyEntity → Prop) :
     Cont Prop ToyEntity :=
@@ -656,47 +644,53 @@ def some_as_cont (restrictor : ToyEntity → Prop) :
 
 /-- Lowering a scope-taking quantifier = applying it to the scope. -/
 theorem scope_lower_eq_gq_id (restrictor scope' : ToyEntity → Prop) :
-    handleScope (gqAsCont (every_sem restrictor) |>.bind
-      (λ x => Cont.pure (scope' x))) =
-    every_sem restrictor scope' := rfl
+    handleScope (gqAsCont (every_sem restrictor) >>= λ x => pure (scope' x)) =
+    every_sem restrictor scope' :=
+  Cont.lower_bind_pure (every_sem restrictor) scope'
 
 /-- Scope resolution via Cont agrees with direct GQ application for
     "every student sleeps": the Cont derivation produces the same Prop. -/
 theorem scope_agrees_with_qr_everyStudentSleeps :
-    handleScope (gqAsCont (every_sem student_sem) |>.bind
-      (λ x => Cont.pure (ToyLexicon.sleeps_sem x))) =
-    every_sem student_sem ToyLexicon.sleeps_sem := rfl
+    handleScope (gqAsCont (every_sem student_sem) >>=
+      λ x => pure (ToyLexicon.sleeps_sem x)) =
+    every_sem student_sem ToyLexicon.sleeps_sem :=
+  Cont.lower_bind_pure (every_sem student_sem) ToyLexicon.sleeps_sem
 
 /-- Scope resolution via Cont agrees with direct GQ application for
     "some student sleeps". -/
 theorem scope_agrees_with_qr_someStudentSleeps :
-    handleScope (gqAsCont (some_sem student_sem) |>.bind
-      (λ x => Cont.pure (ToyLexicon.sleeps_sem x))) =
-    some_sem student_sem ToyLexicon.sleeps_sem := rfl
+    handleScope (gqAsCont (some_sem student_sem) >>=
+      λ x => pure (ToyLexicon.sleeps_sem x)) =
+    some_sem student_sem ToyLexicon.sleeps_sem :=
+  Cont.lower_bind_pure (some_sem student_sem) ToyLexicon.sleeps_sem
 
 /-- Surface scope (∀>∃) via continuation composition agrees with direct
     GQ application. -/
 theorem scope_surface_agrees_with_qr :
-    handleScope (gqAsCont (every_sem person_sem) |>.bind
-      (λ x => gqAsCont (some_sem person_sem) |>.bind
-        (λ y => Cont.pure (ToyLexicon.sees_sem y x)))) =
+    handleScope (gqAsCont (every_sem person_sem) >>= λ x =>
+      gqAsCont (some_sem person_sem) >>= λ y =>
+        pure (ToyLexicon.sees_sem y x)) =
     every_sem person_sem
-      (λ x => some_sem person_sem (λ y => ToyLexicon.sees_sem y x)) := rfl
+      (λ x => some_sem person_sem (λ y => ToyLexicon.sees_sem y x)) :=
+  Cont.lower_bind_bind_pure (every_sem person_sem) (some_sem person_sem)
+    (λ x y => ToyLexicon.sees_sem y x)
 
 /-- Inverse scope (∃>∀) via continuation composition agrees with direct
     GQ application. -/
 theorem scope_inverse_agrees_with_qr :
-    handleScope (gqAsCont (some_sem person_sem) |>.bind
-      (λ y => gqAsCont (every_sem person_sem) |>.bind
-        (λ x => Cont.pure (ToyLexicon.sees_sem y x)))) =
+    handleScope (gqAsCont (some_sem person_sem) >>= λ y =>
+      gqAsCont (every_sem person_sem) >>= λ x =>
+        pure (ToyLexicon.sees_sem y x)) =
     some_sem person_sem
-      (λ y => every_sem person_sem (λ x => ToyLexicon.sees_sem y x)) := rfl
+      (λ y => every_sem person_sem (λ x => ToyLexicon.sees_sem y x)) :=
+  Cont.lower_bind_bind_pure (some_sem person_sem) (every_sem person_sem)
+    ToyLexicon.sees_sem
 
 /-- Surface scope reading holds in the toy model. -/
 theorem surface_scope_via_cont :
-    handleScope (gqAsCont (every_sem person_sem) |>.bind
-      (λ x => gqAsCont (some_sem person_sem) |>.bind
-        (λ y => Cont.pure (ToyLexicon.sees_sem y x)))) := by
+    handleScope (gqAsCont (every_sem person_sem) >>= λ x =>
+      gqAsCont (some_sem person_sem) >>= λ y =>
+        pure (ToyLexicon.sees_sem y x)) := by
   intro x hpx
   cases x with
   | john => exact ⟨.mary, trivial, trivial⟩
@@ -705,9 +699,9 @@ theorem surface_scope_via_cont :
 
 /-- Inverse scope reading does not hold in the toy model. -/
 theorem inverse_scope_via_cont :
-    ¬handleScope (gqAsCont (some_sem person_sem) |>.bind
-      (λ y => gqAsCont (every_sem person_sem) |>.bind
-        (λ x => Cont.pure (ToyLexicon.sees_sem y x)))) := by
+    ¬handleScope (gqAsCont (some_sem person_sem) >>= λ y =>
+      gqAsCont (every_sem person_sem) >>= λ x =>
+        pure (ToyLexicon.sees_sem y x)) := by
   intro ⟨y, _, hy⟩
   cases y with
   | john => exact absurd (hy .john trivial) id
@@ -717,12 +711,12 @@ theorem inverse_scope_via_cont :
 /-- The two scope orderings via Cont yield genuinely different readings,
     matching `HeimKratzer1998.scope_readings_differ`. -/
 theorem cont_scope_readings_differ :
-    (handleScope (gqAsCont (every_sem person_sem) |>.bind
-      (λ x => gqAsCont (some_sem person_sem) |>.bind
-        (λ y => Cont.pure (ToyLexicon.sees_sem y x))))) ≠
-    (handleScope (gqAsCont (some_sem person_sem) |>.bind
-      (λ y => gqAsCont (every_sem person_sem) |>.bind
-        (λ x => Cont.pure (ToyLexicon.sees_sem y x))))) := by
+    (handleScope (gqAsCont (every_sem person_sem) >>= λ x =>
+      gqAsCont (some_sem person_sem) >>= λ y =>
+        pure (ToyLexicon.sees_sem y x))) ≠
+    (handleScope (gqAsCont (some_sem person_sem) >>= λ y =>
+      gqAsCont (every_sem person_sem) >>= λ x =>
+        pure (ToyLexicon.sees_sem y x))) := by
   intro h
   have hS := surface_scope_via_cont
   have hI := inverse_scope_via_cont
@@ -739,8 +733,8 @@ section TreeEngine
 engine that implements H&K at `M = Id` lifts through any `[Applicative M]`.
 At the FA mode that lifting is literally the meta-combinator **A** — a
 framework-level identity, no toy lexicon required. Worked tree-level
-derivations at `M = Cont` (scope) and `M = Writer` (CI) live in
-`Studies/BumfordCharlow2024.lean` alongside the toy-model demonstrations. -/
+derivations at `M = Cont` (scope) and `M = Writer` (CI) are not yet
+formalized; the scope derivations of §6 run on bind chains directly. -/
 
 /-! The engine's FA mode applies the function daughter to the argument through
 `Applicative`'s `<*>` — the substrate lemma `Tree.tryFA_forward`. With
@@ -830,8 +824,8 @@ end BindingBridge
 
 /-! ### §7 General scope agreement
 
-The ScopeBridge section (§6) proved Cont ↔ QR agreement for the toy model
-via `native_decide`. Here we prove the agreement is *structural*: it holds
+The ScopeBridge section (§6) proved Cont ↔ QR agreement for the toy model.
+Here we prove the agreement is *structural*: it holds
 for any type, any quantifier, and any predicate — not because we checked
 all cases, but because the two approaches compute the same function.
 
@@ -850,9 +844,10 @@ one particular syntax for specifying bind order. -/
 
 section GeneralScopeAgreement
 
-/-! The generic scope-as-bind-order facts (`scope_ambiguity_is_bind_order`
-et al.) now live with the `Cont` monad in `Composition/Continuation`; this
-study consumes them. What remains here is the bridge to QR trees. -/
+/-! The generic scope-as-bind-order facts (`Cont.lower_bind_pure`,
+`Cont.lower_bind_bind_pure`) live with the `Cont` monad in
+`Composition/Continuation`; the §6 theorems above are proved by them.
+What remains here is the bridge to QR trees. -/
 
 /-- **QR scope = Cont scope via lambdaAbsG**: the structural connection
     between QR trees and Cont derivations.
@@ -871,7 +866,8 @@ theorem qr_cont_structural_agreement {E W : Type}
     (q : (E → Prop) → Prop)
     (body : DenotG E W .t) (n : Nat) (g : Core.Assignment E) :
     q (lambdaAbsG n body g) =
-    Cont.lower (Cont.bind q (fun x => Cont.pure (body (g[n ↦ x])))) := rfl
+    Cont.lower (q >>= λ x => pure (body (g[n ↦ x]))) :=
+  (Cont.lower_bind_pure q (λ x => body (g[n ↦ x]))).symm
 
 end GeneralScopeAgreement
 
@@ -888,11 +884,11 @@ the same operation `f e e`:
 |--------|-----------|------------|------|
 | [heim-kratzer-1998] | `denotGJoin` (μ) | `λg. f g g` | `Variables.lean` |
 | [barker-shan-2014] | `W` (duplicator) | `W κ x = κ x x` | `Binding.lean` |
-| | `adj_ε` (co-unit) | `ε(f e, e) = (f e) e` | `Effects.lean` §4 |
+| | `adj_ε` (co-unit) | `ε(f e, e) = (f e) e` | §2 above |
 
 The individual two-way bridges exist:
 - `denotGJoin_is_W` (`Charlow2018.lean`)
-- `adj_counit_yields_W` (`Effects.lean` §4)
+- `adj_counit_yields_W` (§2 above)
 
 Here we close the triangle with a single three-way theorem. -/
 
@@ -935,7 +931,7 @@ end BindingUnification
 
 /-! ### §9 Indeterminacy effect
 
-The **indeterminacy** effect — labeled `S` in's
+The **indeterminacy** effect — labeled `S` in the paper's
 Table 2 — is the set monad `(S, η, ⫝̸)` from [charlow-2020],
 formalized in `Studies/Charlow2020.lean`.
 

--- a/Linglib/Studies/Charlow2018.lean
+++ b/Linglib/Studies/Charlow2018.lean
@@ -236,23 +236,20 @@ end SetApplicative
 Shan & Barker's continuation-based composition is built on two
 combinators (Lift/Scope) that directly instantiate the applicative
 functor for continuations `Cᵣ a := (a → r) → r`. The operations are
-definitionally `Cont.pure` and the `<*>` derived from
-`Composition/Continuation.lean`'s monad instance. -/
+definitionally `pure` and `<*>` for `Cont R`
+(`Mathlib.Control.Monad.Cont`, via `Composition/Continuation.lean`). -/
 
 section ContinuationApplicative
 
-open Semantics.Composition.Continuation
-
 variable {R A B : Type}
 
-/-- Eq. (16): `ρ x := λκ. κ x` = `Cont.pure`. -/
+/-- Eq. (16): `ρ x := λκ. κ x` = `pure`. -/
 theorem cont_pure_eq (x : A) :
-    (fun (κ : A → R) => κ x) = Cont.pure x := rfl
+    (fun (κ : A → R) => κ x) = (pure x : Cont R A) := rfl
 
 /-- Eq. (17): `m ⊛ n := λκ. m(λf. n(λx. κ(f x)))` = Cont `<*>`. -/
 theorem cont_ap_eq (m : Cont R (A → B)) (n : Cont R A) :
-    (fun (κ : B → R) => m (fun f => n (fun x => κ (f x)))) =
-    Cont.bind m (fun f => Cont.map f n) := rfl
+    (fun (κ : B → R) => m (fun f => n (fun x => κ (f x)))) = m <*> n := rfl
 
 end ContinuationApplicative
 

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -70,7 +70,6 @@ namespace Charlow2021
 open DynamicSemantics
 open DynamicSemantics.Update (test seq closure neg)
 open DynamicSemantics.CCP (IsDistributive)
-open Semantics.Composition.Continuation
 open scoped DynamicSemantics.Update
 
 /-! ### Witness models: the cumulative-reading puzzle


### PR DESCRIPTION
Continuation.lean re-implemented `Mathlib.Control.Monad.Cont` (same carrier, same universe profile); it now imports it and keeps only the linguistics-facing surface (`Cont.lower`, scope-as-bind-order lemmas).

- Scope lemmas renamed mathlib-style (`Cont.lower_bind_pure` etc.) and now proved-by, not re-derived, in BumfordCharlow2024 §6; vacuous self-bridges (`cont_lower_is_handleScope`, `gq_cont_roundtrip`) and the dead `Tower` abbrev deleted.
- Attribution corrected: the monadic framing is Shan 2001 / Charlow 2014, not Barker & Shan 2014 (whose combination schema fixes left-to-right evaluation); the docstring's phantom `Lifted.lean` pointer and the false "R fixed to Type" universe claim removed.
- Stale consumer prose fixed (native_decide claim, dissolved `Effects.lean` pointers, stripped citation).