### PR TITLE
docs(blog): dedupe bib keys, fix shan-2005 DOI, retype charlow-2021

### DIFF
--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4750,6 +4750,7 @@
   title     = {Adjointness in Foundations},
   journal   = {Dialectica},
   volume    = {23},
+  number    = {3--4},
   pages     = {281--296},
   doi       = {10.1111/j.1746-8361.1969.tb01194.x},
   subfield  = {semantics/dynamic},
@@ -12193,6 +12194,7 @@
   series    = {Dissertations in Linguistics},
   isbn      = {9781881526728},
   subfield  = {semantics/lexical},
+  validated = {true},
   role      = {formalized},
   sources   = {Studies/Barker1995.lean}
 }
@@ -14617,11 +14619,11 @@
   role      = {formalized},
   sources   = {Studies/BumfordCharlow2024.lean}
 }
-@article{charlow-2021,
+@unpublished{charlow-2021,
   author    = {Charlow, Simon},
   year      = {2021},
   title     = {Post-Suppositions and Semantic Theory},
-  journal   = {Journal of Semantics},
+  note      = {Manuscript; accepted at Journal of Semantics},
   url       = {https://lingbuzz.net/lingbuzz/003243},
   subfield  = {semantics/dynamic},
   validated = {true},
@@ -14674,7 +14676,6 @@
   year      = {2005},
   title     = {Linguistic Side Effects},
   school    = {Harvard University},
-  doi       = {10.1093/oso/9780199204373.003.0004},
   subfield  = {semantics/dynamic},
   validated = {true},
   role      = {cited},
@@ -18318,7 +18319,7 @@
 @article{sag-etal-2020,
   author    = {Sag, Ivan A. and Chaves, Rui P. and Abeill{\'e}, Anne and Estigarribia, Bruno and Flickinger, Dan and Kay, Paul and Michaelis, Laura A. and M{\"u}ller, Stefan and Pullum, Geoffrey K. and Van Eynde, Frank and Wasow, Thomas},
   year      = {2020},
-  title     = {Lessons from the English auxiliary system},
+  title     = {Lessons from the {E}nglish auxiliary system},
   journal   = {Journal of Linguistics},
   volume    = {56},
   number    = {1},
@@ -19451,34 +19452,6 @@
   validated = {true},
   role      = {cited},
   sources   = {Syntax/ConstructionGrammar/Inheritance.lean;Syntax/ConstructionGrammar/Licensing.lean}
-}
-@article{sag-etal-2020,
-  author    = {Sag, Ivan A. and Chaves, Rui P. and Abeillé, Anne and Estigarribia, Bruno and Flickinger, Dan and Kay, Paul and Michaelis, Laura A. and Müller, Stefan and Pullum, Geoffrey K. and Van Eynde, Frank and Wasow, Thomas},
-  year      = {2020},
-  title     = {Lessons from the {E}nglish auxiliary system},
-  journal   = {Journal of Linguistics},
-  volume    = {56},
-  number    = {1},
-  pages     = {87--155},
-  doi       = {10.1017/S002222671800052X},
-  subfield  = {syntax},
-  validated = {true},
-  role      = {cited},
-  sources   = {Studies/SagEtAl2020.lean;Studies/Sag2010.lean;Syntax/HPSG/Construction.lean}
-}
-@article{bouma-malouf-sag-2001,
-  author    = {Bouma, Gosse and Malouf, Robert and Sag, Ivan A.},
-  year      = {2001},
-  title     = {Satisfying constraints on extraction and adjunction},
-  journal   = {Natural Language \& Linguistic Theory},
-  volume    = {19},
-  number    = {1},
-  pages     = {1--65},
-  doi       = {10.1023/A:1006473306778},
-  subfield  = {syntax},
-  validated = {true},
-  role      = {cited},
-  sources   = {Syntax/HPSG/Construction.lean;Studies/SagWasowBender2003.lean}
 }
 @incollection{pullum-scholz-2001,
   author    = {Pullum, Geoffrey K. and Scholz, Barbara C.},
@@ -24334,17 +24307,7 @@
   role      = {primary},
   sources   = {Studies/GiorgoloAsudeh2012.lean}
 }% REF: Shan (2001). Monads for Natural Language Semantics.
-@inproceedings{shan-2001,
-  author    = {Shan, Chung-chieh},
-  year      = {2001},
-  title     = {Monads for Natural Language Semantics},
-  booktitle = {Proceedings of the ESSLLI 2001 Student Session},
-  pages     = {285--298},
-  editor    = {Striegnitz, Kristina},
-  subfield  = {semantics},
-  role      = {foundational},
-  sources   = {Studies/GiorgoloAsudeh2012.lean;Semantics/Composition/WriterMonad.lean}
-}% ══════════════════════════════════════════════════════════════════════════════
+% ══════════════════════════════════════════════════════════════════════════════
 @article{giulianelli-etal-2026,
   author    = {Giulianelli, Mario and Wallbridge, Sarenne and Cotterell, Ryan and Fern\'{a}ndez, Raquel},
   year      = {2026},
@@ -36615,19 +36578,6 @@
   role      = {cited}
 }
 
-@article{lawvere-1969,
-  author    = {Lawvere, F. William},
-  year      = {1969},
-  title     = {Adjointness in Foundations},
-  journal   = {Dialectica},
-  volume    = {23},
-  number    = {3--4},
-  pages     = {281--296},
-  doi       = {10.1111/j.1746-8361.1969.tb01194.x},
-  subfield  = {logic/category-theory},
-  role      = {foundational}
-}
-
 @article{goldschmidt-zwarts-2016,
   author    = {Goldschmidt, Anja and Zwarts, Joost},
   year      = {2016},
@@ -37089,17 +37039,6 @@
   validated = {true},
   role      = {formalized},
   sources   = {Studies/Gasparri2025.lean}
-}
-@book{barker-1995,
-  author    = {Barker, Chris},
-  year      = {1995},
-  title     = {Possessive Descriptions},
-  publisher = {CSLI Publications},
-  address   = {Stanford, CA},
-  subfield  = {semantics/lexical},
-  validated = {true},
-  role      = {cited},
-  sources   = {Studies/Barker1995.lean}
 }
 @article{peters-westerstahl-2013,
   author    = {Peters, Stanley and Westerst\r{a}hl, Dag},


### PR DESCRIPTION
Bib hygiene from the Continuation.lean audit, all verified against CrossRef/publisher records.

- Dedupe 5 duplicated keys (`shan-2001`, `barker-1995`, `lawvere-1969`, `sag-etal-2020`, `bouma-malouf-sag-2001`), merging the richer fields into the surviving entry.
- `shan-2005`: drop DOI that resolves to the 2007 *Direct Compositionality* chapter, not the Harvard thesis.
- `charlow-2021`: `@article` in *Journal of Semantics* → `@unpublished` (accepted, not yet published), matching `charlow-2018`'s handling.