### PR TITLE
feat(Studies): continuation scope bridges across QR, Set, and Glue

### DIFF
--- a/Linglib/Semantics/Composition/Continuation.lean
+++ b/Linglib/Semantics/Composition/Continuation.lean
@@ -7,9 +7,9 @@ import Mathlib.Control.Monad.Cont
 Scope-taking expressions denote values of the continuation monad
 `Cont R A := (A → R) → R` (`Mathlib.Control.Monad.Cont`): continuations for
 quantifier scope originate with [barker-2002]; the monadic framing is
-[shan-2001], developed by [charlow-2014]. Consumers: higher-order dynamic
-GQs (`Studies/Charlow2021.lean`) and the effects fragment of
-`Studies/BumfordCharlow2024.lean`.
+[shan-2001], developed by [charlow-2014]. Consumers: the effects fragment
+of `Studies/BumfordCharlow2024.lean` and the Set-morphism bridge of
+`Studies/Charlow2020.lean`.
 
 ## Main definitions
 
@@ -21,6 +21,9 @@ GQs (`Studies/Charlow2021.lean`) and the effects fragment of
 
 - `Cont.lower_bind_pure` and variants: lowering a chain of binds is nested
   generalized-quantifier application — relative scope is bind order.
+- `Cont.lower_map_seq`: applicative composition fixes surface scope —
+  the monadic/applicative contrast localizes [barker-shan-2014]'s linear
+  scope bias.
 -/
 
 namespace Semantics.Composition.Continuation
@@ -62,6 +65,13 @@ scope. -/
 theorem Cont.lower_bind_bind_pure (q₁ q₂ : Cont S E) (rel : E → E → S) :
     Cont.lower (q₁ >>= λ x => q₂ >>= λ y => pure (rel x y)) =
     q₁ (λ x => q₂ (λ y => rel x y)) := rfl
+
+/-- Applicative composition fixes surface scope: `<$>`/`<*>` evaluate
+left-to-right, so the left quantifier outscopes the right — the shape of
+[barker-shan-2014]'s combination schema and the source of their linear
+scope bias. Inverse scope requires the monadic reordering above. -/
+theorem Cont.lower_map_seq (q₁ q₂ : Cont S E) (rel : E → E → S) :
+    Cont.lower (rel <$> q₁ <*> q₂) = q₁ (λ x => q₂ (λ y => rel x y)) := rfl
 
 /-- The bind-order pattern extends to arbitrary depth. -/
 theorem Cont.lower_bind₃_pure (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :

--- a/Linglib/Studies/Asudeh2022.lean
+++ b/Linglib/Studies/Asudeh2022.lean
@@ -5,6 +5,7 @@ import Linglib.Semantics.Composition.LexEntry
 import Linglib.Semantics.Composition.Scope
 import Linglib.Semantics.Quantification.Quantifier
 import Linglib.Semantics.Composition.Tree
+import Linglib.Studies.HeimKratzer1998
 
 /-!
 # Glue Semantics
@@ -429,47 +430,15 @@ theorem glue_inverse_false : ¬glue_inverse_meaning := by
 
 /-! Both Glue and QR are extensionally equivalent on the canonical
     scope example: both yield exactly {∀>∃, ∃>∀} with the same
-    truth values. The QR side is computed via `interp` from
-    `Composition/Tree.lean`, connecting Glue to the H&K composition
-    engine. -/
+    truth values. The QR side is the H&K engine's output:
+    `qrReading` is exactly what `interp` computes on
+    [heim-kratzer-1998]'s QR trees (`qrReading_surface_computed`,
+    `qrReading_inverse_computed`). -/
 
 open Semantics.Scope
 open Syntax
 open Semantics.Composition.Tree
 open Intensional.Variables
-
-/-- Lexicon for the QR bridge (matching QuantifierComposition). -/
-private def bridgeLex : Lexicon ToyEntity Unit := λ word =>
-  match word with
-  | "every" => some ⟨Ty.det, (every_sem : Denot ToyEntity Unit Ty.det)⟩
-  | "some" => some ⟨Ty.det, (some_sem : Denot ToyEntity Unit Ty.det)⟩
-  | "person" => some ⟨.e ⇒ .t, person_sem⟩
-  | "sees" => some ⟨.e ⇒ .e ⇒ .t, ToyLexicon.sees_sem⟩
-  | _ => none
-
-private def g₀ : Core.Assignment ToyEntity := λ _ => .john
-
-/-- Surface scope QR tree (∀>∃):
-    `[S [DP every person] [1 [S [DP some person] [2 [S t₁ [VP sees t₂]]]]]]` -/
-private def qr_surface : Tree Unit String :=
-  .bin
-    (.bin (.leaf "every") (.leaf "person"))
-    (.binder 1
-      (.bin
-        (.bin (.leaf "some") (.leaf "person"))
-        (.binder 2
-          (.bin (.tr 1) (.bin (.leaf "sees") (.tr 2))))))
-
-/-- Inverse scope QR tree (∃>∀):
-    `[S [DP some person] [2 [S [DP every person] [1 [S t₁ [VP sees t₂]]]]]]` -/
-private def qr_inverse : Tree Unit String :=
-  .bin
-    (.bin (.leaf "some") (.leaf "person"))
-    (.binder 2
-      (.bin
-        (.bin (.leaf "every") (.leaf "person"))
-        (.binder 1
-          (.bin (.tr 1) (.bin (.leaf "sees") (.tr 2))))))
 
 /-- Map ScopeConfig to propositions via Glue evaluation. -/
 def glueReading : ScopeConfig → Prop
@@ -484,6 +453,17 @@ def qrReading : ScopeConfig → Prop
       (λ x => some_sem person_sem (λ y => sees_sem y x))
   | .inverse => some_sem person_sem
       (λ y => every_sem person_sem (λ x => sees_sem y x))
+
+/-- The QR side is computed, not hand-written: `interp` on
+[heim-kratzer-1998]'s surface QR tree yields exactly `qrReading .surface`. -/
+theorem qrReading_surface_computed :
+    interp ToyEntity Unit HeimKratzer1998.quantLex HeimKratzer1998.g₀
+      HeimKratzer1998.tree_surface = some ⟨.t, qrReading .surface⟩ := rfl
+
+/-- Likewise for the inverse QR tree. -/
+theorem qrReading_inverse_computed :
+    interp ToyEntity Unit HeimKratzer1998.quantLex HeimKratzer1998.g₀
+      HeimKratzer1998.tree_inverse = some ⟨.t, qrReading .inverse⟩ := rfl
 
 /-- QR surface scope produces the same Prop as Glue. -/
 theorem qr_surface_agrees :

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.Composition.Continuation
 import Linglib.Semantics.Composition.WriterMonad
 import Mathlib.Data.Set.Functor
 import Linglib.Semantics.Composition.Tree
+import Linglib.Studies.HeimKratzer1998
 import Linglib.Pragmatics.Expressives.Basic
 import Linglib.Semantics.Quantification.Quantifier
 import Linglib.Semantics.Reference.Binding
@@ -732,9 +733,26 @@ section TreeEngine
 `Tree.interp` is polymorphic over the effect functor: the same type-driven
 engine that implements H&K at `M = Id` lifts through any `[Applicative M]`.
 At the FA mode that lifting is literally the meta-combinator **A** — a
-framework-level identity, no toy lexicon required. Worked tree-level
-derivations at `M = Cont` (scope) and `M = Writer` (CI) are not yet
-formalized; the scope derivations of §6 run on bind chains directly. -/
+framework-level identity, no toy lexicon required. -/
+
+open HeimKratzer1998 in
+/-- **The scope effect forecloses QR**: at `M = Cont Prop` the engine has
+no entity-distributor (`PredAbs (Cont R) := ⟨none⟩`, §5), so the
+inverse-scope QR derivation that `interp` computes at `M = Id`
+(`HeimKratzer1998.interp_computes_inverse`) fails outright. The reading
+§6 derives by bind reordering is unreachable by movement-plus-abstraction
+under the scope effect: Cont and QR are not notational variants. -/
+theorem cont_blocks_qr :
+    interp ToyEntity Unit (M := Cont Prop)
+      (Lexicon.lift (Cont Prop) quantLex) g₀ tree_inverse = none := rfl
+
+open HeimKratzer1998 in
+/-- Surface-scope QR fails equally: any PA (`.bind`) node is stuck under
+`Cont`. Scope under the effect comes only from bind order (§6), never
+from movement. -/
+theorem cont_blocks_qr_surface :
+    interp ToyEntity Unit (M := Cont Prop)
+      (Lexicon.lift (Cont Prop) quantLex) g₀ tree_surface = none := rfl
 
 /-! The engine's FA mode applies the function daughter to the argument through
 `Applicative`'s `<*>` — the substrate lemma `Tree.tryFA_forward`. With

--- a/Linglib/Studies/Charlow2018.lean
+++ b/Linglib/Studies/Charlow2018.lean
@@ -2,7 +2,7 @@ import Mathlib.Data.Set.Functor
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Intensional.Variables
 import Linglib.Core.Logic.Assignment
-import Linglib.Semantics.Composition.Continuation
+import Mathlib.Control.Monad.Cont
 import Linglib.Semantics.Reference.Binding
 
 /-!
@@ -237,7 +237,7 @@ Shan & Barker's continuation-based composition is built on two
 combinators (Lift/Scope) that directly instantiate the applicative
 functor for continuations `Cᵣ a := (a → r) → r`. The operations are
 definitionally `pure` and `<*>` for `Cont R`
-(`Mathlib.Control.Monad.Cont`, via `Composition/Continuation.lean`). -/
+(`Mathlib.Control.Monad.Cont`). -/
 
 section ContinuationApplicative
 

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Set.Functor
 import Linglib.Studies.Charlow2018
+import Linglib.Semantics.Composition.Continuation
 import Linglib.Semantics.Composition.TypeShifting
 
 /-!
@@ -157,6 +158,22 @@ extensional `∃ p, m p ∧ p` (existence of a true member), avoiding
 `propext` issues when propositions are logically but not definitionally
 equal to `True`. -/
 def existsClosure (m : Prop → Prop) : Prop := ∃ p, m p ∧ p
+
+open Semantics.Composition.Continuation in
+/-- A set of alternatives as a scope-taker: the canonical Set→Cont
+morphism sends `m` to the continuized value holding of some member —
+[charlow-2020]'s thesis that alternative sets take scope the way
+quantifiers do. -/
+def setToCont {A : Type} (m : Set A) : Cont Prop A := λ κ => ∃ x, x ∈ m ∧ κ x
+
+open Semantics.Composition.Continuation in
+/-- **↓ is LOWER through the Set→Cont morphism**: existential closure of
+a proposition set is exactly lowering (`Cont.lower`) its continuized
+image. The tree's two scope-effect carriers — `Set` for alternatives
+([charlow-2020]), `Cont` for quantifier scope — share one evaluation
+operation. -/
+theorem lower_setToCont (m : Set Prop) :
+    Cont.lower (setToCont m) = existsClosure m := rfl
 
 /-! ### §4 Bridge to `Studies/Charlow2018.lean`
 

--- a/Linglib/Studies/Charlow2021.lean
+++ b/Linglib/Studies/Charlow2021.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Dynamic.CDRT
 import Linglib.Semantics.Dynamic.Update
-import Linglib.Semantics.Composition.Continuation
+import Mathlib.Control.Monad.Cont
 import Linglib.Semantics.Mereology
 import Mathlib.Control.Monad.Writer
 import Mathlib.Data.List.Sublists
@@ -35,9 +35,9 @@ side by side:
   pointwise system's overgeneration.
 * `Evar`, `Mvar`, `CardTest`, `exactlyN_pw`: pointwise dynamic GQ operators;
   `pseudoCumulative` and `cumulative` are the two competing LFs.
-* `TowerGQ`, `exactlyN_tower`: scope-taking GQs via the substrate `Cont`
-  monad; `cumulativeTower_eq_cumulative` proves the tower derivation yields
-  `cumulative`.
+* `TowerGQ`, `exactlyN_tower`: scope-taking GQs via the `Cont` monad
+  (`Mathlib.Control.Monad.Cont`); `cumulativeTower_eq_cumulative` proves
+  the tower derivation yields `cumulative`.
 * `Completeness`, `subtypeOf`: the complete/incomplete type discipline;
   `pseudo_cumulative_illtyped` rules out the bad LF.
 * `PostSupp`: bi-dimensional meanings as mathlib's `WriterT (Update S) Id`,
@@ -219,7 +219,7 @@ section Tower
 variable {R S E : Type*} [RegisterStructure R S E] [PartialOrder E] [Fintype E]
 
 /-- Higher-order dynamic GQ type, `(Q → t) → t` with `Q ::= (e→t)→t`
-(eq. 24), rendered via the substrate continuation monad with answer type
+(eq. 24), rendered via the continuation monad with answer type
 `Update S` and the scope argument flattened to `Update S → Update S` (the
 dref is supplied by the GQ itself). §3.4 introduces [barker-shan-2014]-style
 tower notation for these meanings. -/


### PR DESCRIPTION
Follow-up to #1718: the cross-framework theorems the audit ranked highest.

- `cont_blocks_qr`(`_surface`): `Tree.interp` at `M = Cont Prop` returns `none` on [heim-kratzer-1998]'s QR trees — `PredAbs (Cont R) := ⟨none⟩` is now a theorem-visible prediction (scope effect forecloses movement-plus-abstraction), filling the empty TreeEngine section.
- `lower_setToCont`: Charlow 2020's ↓ is `Cont.lower` through the Set→Cont morphism; `Cont.lower_map_seq`: applicative composition fixes surface scope (Barker & Shan's linear scope bias, stated on the substrate).
- Asudeh2022: dead private QR-tree copies deleted and `qrReading` proven equal to the engine's `interp` output, making its bridge docstring true; Charlow2018/2021's vestigial `Continuation` imports swapped for `Mathlib.Control.Monad.Cont`.