### PR TITLE
refactor(Semantics/Composition): root Cont namespace; Cont/Writer renames

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1538,7 +1538,7 @@ import Linglib.Semantics.Classifier.Composition
 import Linglib.Semantics.Classifier.Defs
 import Linglib.Semantics.Classifier.TypeN
 import Linglib.Semantics.Composition.Combinator
-import Linglib.Semantics.Composition.Continuation
+import Linglib.Semantics.Composition.Cont
 import Linglib.Semantics.Composition.Coordination
 import Linglib.Semantics.Composition.CoordinatorOp
 import Linglib.Semantics.Composition.LexEntry
@@ -1547,7 +1547,7 @@ import Linglib.Semantics.Composition.Reduction
 import Linglib.Semantics.Composition.Scope
 import Linglib.Semantics.Composition.Tree
 import Linglib.Semantics.Composition.TypeShifting
-import Linglib.Semantics.Composition.WriterMonad
+import Linglib.Semantics.Composition.Writer
 import Linglib.Semantics.Conditionals.Basic
 import Linglib.Semantics.Conditionals.ConditionalType
 import Linglib.Semantics.Conditionals.Counterfactual

--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -2,38 +2,41 @@ import Mathlib.Control.Monad.Cont
 
 /-!
 # LOWER for the continuation monad
-[barker-2002] [shan-2001] [charlow-2014] [barker-shan-2014]
 
-`Cont.lower` evaluates a `Cont A A` computation with the identity
-continuation — the LOWER of [barker-shan-2014] and the evaluation
-operation of continuation semantics ([barker-2002]; monadic formulation
-[shan-2001], developed by [charlow-2014]). The lemmas record how `lower`
-computes on `pure`/`>>=`/`<*>` chains.
+A value of `Cont R A := (A → R) → R` (`Mathlib.Control.Monad.Cont`) is a
+computation handed its own future: given a continuation `A → R` saying
+how the rest of the derivation will use its result, it produces the
+final answer — and may consult that continuation zero, one, or many
+times. `Cont.lower` ends the computation: once the answer type equals
+the value type, applying the identity continuation extracts the result.
+`pure` is the converse embedding — a value wrapped so that any
+continuation applies to it directly — and lowering undoes it
+(`Cont.lower_pure`).
 
-The linguistic reading — continuized values as scope-takers, bind order
-as scope order — lives with the consumers: the composition engine's
-`PredAbs` (`Composition/Tree.lean`), `Studies/BumfordCharlow2024.lean`,
-and `Studies/Charlow2020.lean`.
+What `lower` returns on composite computations is the substance of this
+file: a chain of binds lowers to nested application, nested in exactly
+the order of the binds, while the applicative combination `<$> … <*>`
+always nests left over right. That contrast carries the linguistic
+reading: continuized values model scope-taking expressions
+([barker-2002]), `lower` is [barker-shan-2014]'s LOWER ("scope-taking
+is done"), and free bind order — read as free quantifier scope by
+[shan-2001] and [charlow-2014] — is exactly what the order-fixed
+applicative fragment withholds. The applications live with the
+composition engine (`PredAbs` in `Composition/Tree.lean`) and its
+studies (`Studies/BumfordCharlow2024.lean`, `Studies/Charlow2020.lean`).
 
 ## Main definitions
 
 - `Cont.lower`: evaluation with the identity continuation
-
-## Main statements
-
-- `Cont.lower_bind_pure`, `Cont.lower_bind_bind_pure`,
-  `Cont.lower_bind₃_pure`: `lower` of a bind chain is nested
-  application, in bind order
-- `Cont.lower_map_seq`: `lower` of the applicative combination is
-  nested application in fixed left-to-right order
 -/
 
 namespace Cont
 
-/-- Evaluation with the identity continuation — [barker-shan-2014]'s
-LOWER at `B := A`. Their own LOWER pins the answer type to the atomic
-clause category `S`; the pinning carries their crossover account and is
-not imposed here. -/
+/-- Evaluation with the identity continuation (functional programming's
+`evalCont`, which mathlib does not provide) — [barker-shan-2014]'s LOWER
+at `B := A`. Their own LOWER pins the answer type to the atomic clause
+category `S`; the pinning carries their crossover account and is not
+imposed here. -/
 def lower {A : Type*} (m : Cont A A) : A := m.run id
 
 /-- LOWER ∘ LIFT = id: `pure` is [barker-shan-2014]'s LIFT (Montague

--- a/Linglib/Semantics/Composition/Continuation.lean
+++ b/Linglib/Semantics/Composition/Continuation.lean
@@ -1,90 +1,84 @@
 import Mathlib.Control.Monad.Cont
 
 /-!
-# Continuations for scope-taking
+# LOWER for the continuation monad
 [barker-2002] [shan-2001] [charlow-2014] [barker-shan-2014]
 
-Scope-taking expressions denote values of the continuation monad
-`Cont R A := (A → R) → R` (`Mathlib.Control.Monad.Cont`): continuations for
-quantifier scope originate with [barker-2002]; the monadic framing is
-[shan-2001], developed by [charlow-2014]. Consumers: the effects fragment
-of `Studies/BumfordCharlow2024.lean` and the Set-morphism bridge of
-`Studies/Charlow2020.lean`.
+`Cont.lower` evaluates a `Cont A A` computation with the identity
+continuation — the LOWER of [barker-shan-2014] and the evaluation
+operation of continuation semantics ([barker-2002]; monadic formulation
+[shan-2001], developed by [charlow-2014]). The lemmas record how `lower`
+computes on `pure`/`>>=`/`<*>` chains.
+
+The linguistic reading — continuized values as scope-takers, bind order
+as scope order — lives with the consumers: the composition engine's
+`PredAbs` (`Composition/Tree.lean`), `Studies/BumfordCharlow2024.lean`,
+and `Studies/Charlow2020.lean`.
 
 ## Main definitions
 
-- `Cont.lower`: evaluate with the identity continuation — "scope-taking is
-  done". `pure` is Montague lift ([barker-shan-2014]'s LIFT), and
-  `Cont.lower_pure` is LOWER ∘ LIFT = id.
+- `Cont.lower`: evaluation with the identity continuation
 
 ## Main statements
 
-- `Cont.lower_bind_pure` and variants: lowering a chain of binds is nested
-  generalized-quantifier application — relative scope is bind order.
-- `Cont.lower_map_seq`: applicative composition fixes surface scope —
-  the monadic/applicative contrast localizes [barker-shan-2014]'s linear
-  scope bias.
+- `Cont.lower_bind_pure`, `Cont.lower_bind_bind_pure`,
+  `Cont.lower_bind₃_pure`: `lower` of a bind chain is nested
+  application, in bind order
+- `Cont.lower_map_seq`: `lower` of the applicative combination is
+  nested application in fixed left-to-right order
 -/
 
-namespace Semantics.Composition.Continuation
+namespace Cont
 
-/-- LOWER: evaluate with the identity continuation — [barker-shan-2014]'s
-"scope-taking is done", at `B := A`. Their own LOWER pins the answer type to
-the atomic clause category `S`; the pinning carries their crossover account
-and is not imposed here. -/
-def Cont.lower {A : Type*} (m : Cont A A) : A := m.run id
+/-- Evaluation with the identity continuation — [barker-shan-2014]'s
+LOWER at `B := A`. Their own LOWER pins the answer type to the atomic
+clause category `S`; the pinning carries their crossover account and is
+not imposed here. -/
+def lower {A : Type*} (m : Cont A A) : A := m.run id
 
-/-- LOWER ∘ LIFT = id: `pure : A → Cont R A` is [barker-shan-2014]'s LIFT
-(Montague lift), and lowering it recovers the value. -/
-@[simp] theorem Cont.lower_pure {A : Type*} (a : A) :
-    Cont.lower (pure a) = a := rfl
+/-- LOWER ∘ LIFT = id: `pure` is [barker-shan-2014]'s LIFT (Montague
+lift). -/
+@[simp] theorem lower_pure {A : Type*} (a : A) : lower (pure a) = a := rfl
 
-/-! ### Scope as bind order
+/-! ### `lower` on `pure`/`bind`/`seq` chains
 
-In the monadic framing, relative quantifier scope is the *order of monadic
-bind* — surface scope binds the subject first, inverse scope the object
-first — and `Cont.lower` is generalized-quantifier application
-([shan-2001], [charlow-2014]). Free bind order contrasts with
-[barker-shan-2014]'s combination schema, whose fixed left-to-right
-evaluation (their linear scope bias) derives inverse scope from multi-level
-towers instead. -/
+A bind chain lowers to nested application in the order of the binds —
+the free reordering read as scope order by [shan-2001]/[charlow-2014] —
+while the applicative combination is fixed left-to-right
+([barker-shan-2014]'s combination schema and linear scope bias). -/
 
-section ScopeAsBindOrder
+section LowerChains
 
 universe u
 
 variable {E S : Type u}
 
-/-- Lowering a continuized quantifier against a pure scope is plain GQ
-application. -/
-theorem Cont.lower_bind_pure (q : Cont S E) (scope : E → S) :
-    Cont.lower (q >>= λ x => pure (scope x)) = q scope := rfl
+/-- `lower` of a bind against a `pure`d function is application. -/
+theorem lower_bind_pure (q : Cont S E) (scope : E → S) :
+    lower (q >>= λ x => pure (scope x)) = q scope := rfl
 
-/-- Nested binds compute nested GQ application: the outer bind takes wide
-scope. -/
-theorem Cont.lower_bind_bind_pure (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    Cont.lower (q₁ >>= λ x => q₂ >>= λ y => pure (rel x y)) =
+/-- `lower` of nested binds is nested application: the outer bind
+applies outermost. -/
+theorem lower_bind_bind_pure (q₁ q₂ : Cont S E) (rel : E → E → S) :
+    lower (q₁ >>= λ x => q₂ >>= λ y => pure (rel x y)) =
     q₁ (λ x => q₂ (λ y => rel x y)) := rfl
 
-/-- Applicative composition fixes surface scope: `<$>`/`<*>` evaluate
-left-to-right, so the left quantifier outscopes the right — the shape of
-[barker-shan-2014]'s combination schema and the source of their linear
-scope bias. Inverse scope requires the monadic reordering above. -/
-theorem Cont.lower_map_seq (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    Cont.lower (rel <$> q₁ <*> q₂) = q₁ (λ x => q₂ (λ y => rel x y)) := rfl
-
-/-- The bind-order pattern extends to arbitrary depth. -/
-theorem Cont.lower_bind₃_pure (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :
-    Cont.lower (q₁ >>= λ x => q₂ >>= λ y => q₃ >>= λ z => pure (rel x y z)) =
+/-- The bind-chain pattern at depth three. -/
+theorem lower_bind₃_pure (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :
+    lower (q₁ >>= λ x => q₂ >>= λ y => q₃ >>= λ z => pure (rel x y z)) =
     q₁ (λ x => q₂ (λ y => q₃ (λ z => rel x y z))) := rfl
 
-/-- When every meaning is `pure`-wrapped, `Cont` composition reduces to
-function application: the effect-free fragment embeds into `Cont`
-([charlow-2018]). -/
-theorem Cont.lower_pure_bind_pure {A : Type u} (f : A → S) (x : A) :
-    Cont.lower ((pure f : Cont S (A → S)) >>= λ g =>
+/-- `lower` of the applicative combination is nested application in
+fixed left-to-right order. -/
+theorem lower_map_seq (q₁ q₂ : Cont S E) (rel : E → E → S) :
+    lower (rel <$> q₁ <*> q₂) = q₁ (λ x => q₂ (λ y => rel x y)) := rfl
+
+/-- On `pure`-wrapped values, `lower` of a bind chain reduces to
+function application ([charlow-2018]). -/
+theorem lower_pure_bind_pure {A : Type u} (f : A → S) (x : A) :
+    lower ((pure f : Cont S (A → S)) >>= λ g =>
       (pure x : Cont S A) >>= λ y => pure (g y)) = f x := rfl
 
-end ScopeAsBindOrder
+end LowerChains
 
-end Semantics.Composition.Continuation
+end Cont

--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -32,7 +32,7 @@ Two effect-discipline choices, both visible rather than stipulated:
   effects fire first whichever daughter is the function. At `M = Cont R`
   this makes surface scope the default reading; inverse scope requires
   reordering the evaluation (QR, or `bind`-order permutation — see
-  `Composition/Continuation.lean` and `Studies/BumfordCharlow2024.lean`).
+  `Composition/Cont.lean` and `Studies/BumfordCharlow2024.lean`).
 * **PA is a capability, not a given** (`PredAbs`): it needs an
   entity-distributor `(E → M (Denot ty)) → M (E → Denot ty)`,
   which `Id` has and scope-type effects lack. See the `PredAbs` docstring.

--- a/Linglib/Semantics/Composition/Writer.lean
+++ b/Linglib/Semantics/Composition/Writer.lean
@@ -2,10 +2,11 @@ import Mathlib.Control.Monad.Writer
 
 /-!
 # Writer Monad for Compositional Side-Effects
-[giorgolo-asudeh-2012] [shan-2001]
 
 The Writer monad `⟨M, η, ⋆⟩` models meaning dimensions that accumulate
-side-effect information during compositional interpretation:
+side-effect information during compositional interpretation —
+[giorgolo-asudeh-2012]'s application of [shan-2001]'s
+monads-for-semantics program:
 
 - **M** (the functor): maps a type `A` to paired values `A × List P`
 - **η** (unit/pure): lifts a value with an empty log

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -72,7 +72,6 @@ The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 namespace BumfordCharlow2024
 
 open Semantics.Composition
-open Semantics.Composition.Continuation
 open Semantics.Composition.Tree
 open Pragmatics.Expressives
 open Quantification

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -1,5 +1,5 @@
-import Linglib.Semantics.Composition.Continuation
-import Linglib.Semantics.Composition.WriterMonad
+import Linglib.Semantics.Composition.Cont
+import Linglib.Semantics.Composition.Writer
 import Mathlib.Data.Set.Functor
 import Linglib.Semantics.Composition.Tree
 import Linglib.Studies.HeimKratzer1998
@@ -22,8 +22,8 @@ formalizes that framework over linglib's effect carriers:
 
 | Effect | Type | linglib carrier |
 |--------|------|-----------------|
-| Scope | `(α → ρ) → ρ` | `Cont R A` (`Composition/Continuation`) |
-| CI / supplementation | `α × List P` | `Writer (List P) A` (`Composition/WriterMonad`) |
+| Scope | `(α → ρ) → ρ` | `Cont R A` (`Composition/Cont`) |
+| CI / supplementation | `α × List P` | `Writer (List P) A` (`Composition/Writer`) |
 | Input (binding) | `ι → α` | Reader (`Reference/Binding`) |
 | Output (antecedent) | `α × ι` | `Prod` |
 | Indeterminacy | `{α}` | `Set` |
@@ -65,7 +65,7 @@ S&B substrate in linglib yet.
 ## Implementation notes
 
 Scope-as-bind-order (`Cont.lower_bind_pure` et al.) lives with the
-`Cont` monad in `Composition/Continuation`; this study consumes it.
+`Cont` monad in `Composition/Cont`; this study consumes it.
 The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 -/
 
@@ -90,9 +90,9 @@ open Semantics.Montague.ToyLexicon (student_sem person_sem)
 The W effect is mathlib's `Writer (List P)` (= `WriterT (List P) Id`), whose
 `Functor`/`Applicative`/`Monad` instances come from mathlib, with
 `LawfulMonad` and the `val`/`log`/`tell` surface in
-`Composition/WriterMonad.lean`. The `Cont R` monad is mathlib's
+`Composition/Writer.lean`. The `Cont R` monad is mathlib's
 (`Mathlib.Control.Monad.Cont`); its linguistics surface (`Cont.lower`)
-lives in `Composition/Continuation.lean`. -/
+lives in `Composition/Cont.lean`. -/
 
 -- ════════════════════════════════════════════════════════════════════
 -- §2 Meta-Combinators
@@ -863,7 +863,7 @@ section GeneralScopeAgreement
 
 /-! The generic scope-as-bind-order facts (`Cont.lower_bind_pure`,
 `Cont.lower_bind_bind_pure`) live with the `Cont` monad in
-`Composition/Continuation`; the §6 theorems above are proved by them.
+`Composition/Cont`; the §6 theorems above are proved by them.
 What remains here is the bridge to QR trees. -/
 
 /-- **QR scope = Cont scope via lambdaAbsG**: the structural connection

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.Set.Functor
 import Linglib.Studies.Charlow2018
-import Linglib.Semantics.Composition.Continuation
+import Linglib.Semantics.Composition.Cont
 import Linglib.Semantics.Composition.TypeShifting
 
 /-!

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -159,14 +159,12 @@ extensional `∃ p, m p ∧ p` (existence of a true member), avoiding
 equal to `True`. -/
 def existsClosure (m : Prop → Prop) : Prop := ∃ p, m p ∧ p
 
-open Semantics.Composition.Continuation in
 /-- A set of alternatives as a scope-taker: the canonical Set→Cont
 morphism sends `m` to the continuized value holding of some member —
 [charlow-2020]'s thesis that alternative sets take scope the way
 quantifiers do. -/
 def setToCont {A : Type} (m : Set A) : Cont Prop A := λ κ => ∃ x, x ∈ m ∧ κ x
 
-open Semantics.Composition.Continuation in
 /-- **↓ is LOWER through the Set→Cont morphism**: existential closure of
 a proposition set is exactly lowering (`Cont.lower`) its continuized
 image. The tree's two scope-effect carriers — `Set` for alternatives

--- a/Linglib/Studies/GiorgoloAsudeh2012.lean
+++ b/Linglib/Studies/GiorgoloAsudeh2012.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Composition.WriterMonad
+import Linglib.Semantics.Composition.Writer
 import Linglib.Pragmatics.Expressives.Basic
 import Linglib.Semantics.Presupposition.ProjectiveContent
 


### PR DESCRIPTION
Supersedes #1721 (closed unmerged) with the full register cleanup.

- `Cont` API moves from the path-stuttering `Semantics.Composition.Continuation.Cont.*` to root `namespace Cont` (the `Writer` precedent); three consumer `open`s deleted.
- `Continuation.lean` → `Cont.lean`, `WriterMonad.lean` → `Writer.lean`: veneer files named for the mathlib type they extend; 13 import/prose sites swept.
- Module docstrings to mathlib register: expository prose with citations inline (no bare key block, no Main-statements inventory). `Cont.lower` notes it is FP's `evalCont`, which mathlib does not provide (verified against current mathlib4 docs).