### PR TITLE
docs(Semantics/Composition): descriptive module title for Cont

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -1,7 +1,7 @@
 import Mathlib.Control.Monad.Cont
 
 /-!
-# LOWER for the continuation monad
+# Evaluating continuation computations
 
 A value of `Cont R A := (A → R) → R` (`Mathlib.Control.Monad.Cont`) is a
 computation handed its own future: given a continuation `A → R` saying


### PR DESCRIPTION
Mathlib titles are plain descriptive noun phrases ("Continuation Monad", "Images and preimages of sets", "Lift filters along filter and set functions") — the operator name LOWER stays in prose with its citation. "LOWER for the continuation monad" → "Evaluating continuation computations".