### PR TITLE
docs(Semantics/Composition): equation-style docstrings for Cont, Writer

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -8,7 +8,8 @@ continuation — Haskell's `evalCont`, which `Mathlib.Control.Monad.Cont`
 does not provide. The lemmas compute `lower` over `pure`/`>>=`/`<*>`
 chains: binds nest in bind order, the applicative combination
 left-to-right. In continuation semantics `lower` is
-[barker-shan-2014]'s LOWER, and the bind-order dependence is the
+[barker-shan-2014]'s LOWER (theirs restricts the answer type to the
+clause category), and the bind-order dependence is the
 monadic account of quantifier scope ([barker-2002], [shan-2001],
 [charlow-2014]); see `Studies/BumfordCharlow2024.lean` and
 `Studies/Charlow2020.lean`.
@@ -20,14 +21,10 @@ monadic account of quantifier scope ([barker-2002], [shan-2001],
 
 namespace Cont
 
-/-- `lower m` evaluates `m` at the identity continuation — Haskell's
-`evalCont`, and the LOWER of continuation semantics
-([barker-shan-2014]'s version restricts the answer type to the clause
-category). -/
+/-- Evaluation at the identity continuation: `lower m = m id`. -/
 def lower {A : Type*} (m : Cont A A) : A := m.run id
 
-/-- LOWER ∘ LIFT = id: `pure` is [barker-shan-2014]'s LIFT (Montague
-lift). -/
+/-- `lower` is a left inverse of `pure`: LOWER ∘ LIFT is the identity. -/
 @[simp] theorem lower_pure {A : Type*} (a : A) : lower (pure a) = a := rfl
 
 /-! ### `lower` on `pure`/`bind`/`seq` chains

--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -3,26 +3,15 @@ import Mathlib.Control.Monad.Cont
 /-!
 # Evaluating continuation computations
 
-A continuation computation `Cont R A := (A → R) → R` produces its answer
-from a continuation `A → R` describing how the result will be used, and
-may invoke that continuation any number of times. This file defines
-`Cont.lower`, which ends a computation of type `Cont A A` by applying
-the identity continuation (Haskell's `evalCont`, not present in
-`Mathlib.Control.Monad.Cont`), and proves that `lower` turns a chain of
-binds into function application nested in bind order, while the
-applicative combination nests in fixed left-to-right order.
-
-In continuation semantics, continuized terms model scope-taking
-expressions ([barker-2002]) and `lower` is the LOWER operation of
-[barker-shan-2014]; the contrast between free bind order and fixed
-applicative order is the monadic account of quantifier scope
-([shan-2001], [charlow-2014]). These applications live in
-`Composition/Tree.lean` (`PredAbs`), `Studies/BumfordCharlow2024.lean`,
-and `Studies/Charlow2020.lean`.
-
-## Main definitions
-
-- `Cont.lower`: evaluation with the identity continuation
+`Cont.lower` evaluates a computation `Cont A A` at the identity
+continuation — Haskell's `evalCont`, which `Mathlib.Control.Monad.Cont`
+does not provide. The lemmas compute `lower` over `pure`/`>>=`/`<*>`
+chains: binds nest in bind order, the applicative combination
+left-to-right. In continuation semantics `lower` is
+[barker-shan-2014]'s LOWER, and the bind-order dependence is the
+monadic account of quantifier scope ([barker-2002], [shan-2001],
+[charlow-2014]); see `Studies/BumfordCharlow2024.lean` and
+`Studies/Charlow2020.lean`.
 
 ## References
 

--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -20,11 +20,10 @@ monadic account of quantifier scope ([barker-2002], [shan-2001],
 
 namespace Cont
 
-/-- Evaluation with the identity continuation (functional programming's
-`evalCont`, which mathlib does not provide) — [barker-shan-2014]'s LOWER
-at `B := A`. Their own LOWER pins the answer type to the atomic clause
-category `S`; the pinning carries their crossover account and is not
-imposed here. -/
+/-- `lower m` evaluates `m` at the identity continuation — Haskell's
+`evalCont`, and the LOWER of continuation semantics
+([barker-shan-2014]'s version restricts the answer type to the clause
+category). -/
 def lower {A : Type*} (m : Cont A A) : A := m.run id
 
 /-- LOWER ∘ LIFT = id: `pure` is [barker-shan-2014]'s LIFT (Montague

--- a/Linglib/Semantics/Composition/Writer.lean
+++ b/Linglib/Semantics/Composition/Writer.lean
@@ -42,13 +42,13 @@ namespace Writer
 
 variable {ω : Type u} {P A B : Type u}
 
-/-- Construct a Writer computation from a value and a log. -/
+/-- The computation with value `a` and log `w`: `mk a w = ⟨(a, w)⟩`. -/
 protected def mk (a : A) (w : ω) : Writer ω A := WriterT.mk (a, w)
 
-/-- The at-issue value of a Writer computation. -/
+/-- The at-issue value of a Writer computation: `val m = m.run.1`. -/
 def val (m : Writer ω A) : A := m.run.1
 
-/-- The accumulated side-effect log of a Writer computation. -/
+/-- The accumulated log of a Writer computation: `log m = m.run.2`. -/
 def log (m : Writer ω A) : ω := m.run.2
 
 @[ext]
@@ -60,10 +60,9 @@ protected theorem ext {m₁ m₂ : Writer ω A}
 
 @[simp] theorem log_mk (a : A) (w : ω) : (Writer.mk a w).log = w := rfl
 
-/-- **tell** (write): log a single item. Used by CI-contributing expressions
-to add propositions to the side-issue dimension; in [giorgolo-asudeh-2012]:
+/-- Log a single item: `tell p = mk () [p]` — [giorgolo-asudeh-2012]'s
 `write(t) = ⟨⊥, {t}⟩`. (`PUnit` rather than `Unit` keeps it
-universe-polymorphic; at `Type 0` they coincide.) -/
+universe-polymorphic.) -/
 def tell (p : P) : Writer (List P) PUnit := Writer.mk PUnit.unit [p]
 
 /-! ### Projection lemmas for list logs -/


### PR DESCRIPTION
Supersedes #1726/#1727 (closed unmerged; both folded in). Module doc compressed to `Control/Monad/Writer.lean` scale; declaration docstrings give the defining equation (`lower m = m id`, `val m = m.run.1`, `tell p = mk () [p]`) in the `Set.image`/`Combinator.B` style, with literature commentary confined to the module doc.