### PR TITLE
refactor(Semantics/Composition): compositional lower simp set

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -5,13 +5,13 @@ import Mathlib.Control.Monad.Cont
 
 `Cont.lower` evaluates a computation `Cont A A` at the identity
 continuation — Haskell's `evalCont`, which `Mathlib.Control.Monad.Cont`
-does not provide. The lemmas compute `lower` over `pure`/`>>=`/`<*>`
-chains: binds nest in bind order, the applicative combination
-left-to-right. In continuation semantics `lower` is
-[barker-shan-2014]'s LOWER (theirs restricts the answer type to the
-clause category), and the bind-order dependence is the
-monadic account of quantifier scope ([barker-2002], [shan-2001],
-[charlow-2014]); see `Studies/BumfordCharlow2024.lean` and
+does not provide. The `lower_pure`/`lower_bind`/`lower_map`/`lower_seq`
+simp set mirrors `ContT`'s `run_*` lemmas; under it, bind chains
+evaluate in bind order and the applicative combination left-to-right.
+In continuation semantics `lower` is [barker-shan-2014]'s LOWER (theirs
+restricts the answer type to the clause category), and the bind-order
+dependence is the monadic account of quantifier scope ([barker-2002],
+[shan-2001], [charlow-2014]); see `Studies/BumfordCharlow2024.lean` and
 `Studies/Charlow2020.lean`.
 
 ## References
@@ -19,53 +19,27 @@ monadic account of quantifier scope ([barker-2002], [shan-2001],
 - <https://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Cont.html#v:evalCont>
 -/
 
-namespace Cont
-
-/-- Evaluation at the identity continuation: `lower m = m id`. -/
-def lower {A : Type*} (m : Cont A A) : A := m.run id
-
-/-- `lower` is a left inverse of `pure`: LOWER ∘ LIFT is the identity. -/
-@[simp] theorem lower_pure {A : Type*} (a : A) : lower (pure a) = a := rfl
-
-/-! ### `lower` on `pure`/`bind`/`seq` chains
-
-A bind chain lowers to nested application in the order of the binds —
-the free reordering read as scope order by [shan-2001]/[charlow-2014] —
-while the applicative combination is fixed left-to-right
-([barker-shan-2014]'s combination schema and linear scope bias). -/
-
-section LowerChains
-
 universe u
 
-variable {E S : Type u}
+namespace Cont
 
-/-- `lower` of a bind against a `pure`d function is application. -/
-theorem lower_bind_pure (q : Cont S E) (scope : E → S) :
-    lower (q >>= λ x => pure (scope x)) = q scope := rfl
+variable {α β : Type u}
 
-/-- `lower` of nested binds is nested application: the outer bind
-applies outermost. -/
-theorem lower_bind_bind_pure (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    lower (q₁ >>= λ x => q₂ >>= λ y => pure (rel x y)) =
-    q₁ (λ x => q₂ (λ y => rel x y)) := rfl
+/-- Evaluation at the identity continuation: `lower m = m id`. -/
+def lower (m : Cont α α) : α := m.run id
 
-/-- The bind-chain pattern at depth three. -/
-theorem lower_bind₃_pure (q₁ q₂ q₃ : Cont S E) (rel : E → E → E → S) :
-    lower (q₁ >>= λ x => q₂ >>= λ y => q₃ >>= λ z => pure (rel x y z)) =
-    q₁ (λ x => q₂ (λ y => q₃ (λ z => rel x y z))) := rfl
+/-! ### Interaction with the monad operations -/
 
-/-- `lower` of the applicative combination is nested application in
-fixed left-to-right order. -/
-theorem lower_map_seq (q₁ q₂ : Cont S E) (rel : E → E → S) :
-    lower (rel <$> q₁ <*> q₂) = q₁ (λ x => q₂ (λ y => rel x y)) := rfl
+/-- `lower` is a left inverse of `pure`: LOWER ∘ LIFT is the identity. -/
+@[simp] theorem lower_pure (a : α) : lower (pure a) = a := rfl
 
-/-- On `pure`-wrapped values, `lower` of a bind chain reduces to
-function application ([charlow-2018]). -/
-theorem lower_pure_bind_pure {A : Type u} (f : A → S) (x : A) :
-    lower ((pure f : Cont S (A → S)) >>= λ g =>
-      (pure x : Cont S A) >>= λ y => pure (g y)) = f x := rfl
+@[simp] theorem lower_bind (m : Cont β α) (f : α → Cont β β) :
+    lower (m >>= f) = m.run λ x => lower (f x) := rfl
 
-end LowerChains
+@[simp] theorem lower_map (f : α → β) (m : Cont β α) :
+    lower (f <$> m) = m.run f := rfl
+
+@[simp] theorem lower_seq (mf : Cont β (α → β)) (mx : Cont β α) :
+    lower (mf <*> mx) = mf.run λ f => mx.run f := rfl
 
 end Cont

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -64,8 +64,8 @@ S&B substrate in linglib yet.
 
 ## Implementation notes
 
-Scope-as-bind-order (`Cont.lower_bind_pure` et al.) lives with the
-`Cont` monad in `Composition/Cont`; this study consumes it.
+Scope-as-bind-order rests on `Cont.lower` (`Composition/Cont.lean`);
+the §6 agreements are definitional instances of its `lower_*` laws.
 The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 -/
 
@@ -645,24 +645,21 @@ def some_as_cont (restrictor : ToyEntity → Prop) :
 /-- Lowering a scope-taking quantifier = applying it to the scope. -/
 theorem scope_lower_eq_gq_id (restrictor scope' : ToyEntity → Prop) :
     handleScope (gqAsCont (every_sem restrictor) >>= λ x => pure (scope' x)) =
-    every_sem restrictor scope' :=
-  Cont.lower_bind_pure (every_sem restrictor) scope'
+    every_sem restrictor scope' := rfl
 
 /-- Scope resolution via Cont agrees with direct GQ application for
     "every student sleeps": the Cont derivation produces the same Prop. -/
 theorem scope_agrees_with_qr_everyStudentSleeps :
     handleScope (gqAsCont (every_sem student_sem) >>=
       λ x => pure (ToyLexicon.sleeps_sem x)) =
-    every_sem student_sem ToyLexicon.sleeps_sem :=
-  Cont.lower_bind_pure (every_sem student_sem) ToyLexicon.sleeps_sem
+    every_sem student_sem ToyLexicon.sleeps_sem := rfl
 
 /-- Scope resolution via Cont agrees with direct GQ application for
     "some student sleeps". -/
 theorem scope_agrees_with_qr_someStudentSleeps :
     handleScope (gqAsCont (some_sem student_sem) >>=
       λ x => pure (ToyLexicon.sleeps_sem x)) =
-    some_sem student_sem ToyLexicon.sleeps_sem :=
-  Cont.lower_bind_pure (some_sem student_sem) ToyLexicon.sleeps_sem
+    some_sem student_sem ToyLexicon.sleeps_sem := rfl
 
 /-- Surface scope (∀>∃) via continuation composition agrees with direct
     GQ application. -/
@@ -671,9 +668,7 @@ theorem scope_surface_agrees_with_qr :
       gqAsCont (some_sem person_sem) >>= λ y =>
         pure (ToyLexicon.sees_sem y x)) =
     every_sem person_sem
-      (λ x => some_sem person_sem (λ y => ToyLexicon.sees_sem y x)) :=
-  Cont.lower_bind_bind_pure (every_sem person_sem) (some_sem person_sem)
-    (λ x y => ToyLexicon.sees_sem y x)
+      (λ x => some_sem person_sem (λ y => ToyLexicon.sees_sem y x)) := rfl
 
 /-- Inverse scope (∃>∀) via continuation composition agrees with direct
     GQ application. -/
@@ -682,9 +677,7 @@ theorem scope_inverse_agrees_with_qr :
       gqAsCont (every_sem person_sem) >>= λ x =>
         pure (ToyLexicon.sees_sem y x)) =
     some_sem person_sem
-      (λ y => every_sem person_sem (λ x => ToyLexicon.sees_sem y x)) :=
-  Cont.lower_bind_bind_pure (some_sem person_sem) (every_sem person_sem)
-    ToyLexicon.sees_sem
+      (λ y => every_sem person_sem (λ x => ToyLexicon.sees_sem y x)) := rfl
 
 /-- Surface scope reading holds in the toy model. -/
 theorem surface_scope_via_cont :
@@ -861,10 +854,9 @@ one particular syntax for specifying bind order. -/
 
 section GeneralScopeAgreement
 
-/-! The generic scope-as-bind-order facts (`Cont.lower_bind_pure`,
-`Cont.lower_bind_bind_pure`) live with the `Cont` monad in
-`Composition/Cont`; the §6 theorems above are proved by them.
-What remains here is the bridge to QR trees. -/
+/-! The generic scope-as-bind-order facts are the `Cont.lower_*` simp
+set in `Composition/Cont.lean`; the §6 theorems above are definitional
+instances. What remains here is the bridge to QR trees. -/
 
 /-- **QR scope = Cont scope via lambdaAbsG**: the structural connection
     between QR trees and Cont derivations.
@@ -883,8 +875,7 @@ theorem qr_cont_structural_agreement {E W : Type}
     (q : (E → Prop) → Prop)
     (body : DenotG E W .t) (n : Nat) (g : Core.Assignment E) :
     q (lambdaAbsG n body g) =
-    Cont.lower (q >>= λ x => pure (body (g[n ↦ x]))) :=
-  (Cont.lower_bind_pure q (λ x => body (g[n ↦ x]))).symm
+    Cont.lower (q >>= λ x => pure (body (g[n ↦ x]))) := rfl
 
 end GeneralScopeAgreement
 


### PR DESCRIPTION
Replaces the five shape-specific chain lemmas (`lower_bind_pure`, `lower_bind_bind_pure`, `lower_bind₃_pure`, `lower_map_seq`, `lower_pure_bind_pure`) with the compositional `@[simp]` set `lower_pure`/`lower_bind`/`lower_map`/`lower_seq` — the `lower` mirror of upstream `ContT`'s `run_*` lemmas, stated through `.run` with neutral variable names. BumfordCharlow2024's §6 instances revert to `rfl` (they mix API levels by design — Cont derivation = bare GQ application — which is definitional, not simp-shaped).