### PR TITLE
feat(Semantics/Composition): generalize lower to ContT; add reset

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -3,15 +3,14 @@ import Mathlib.Control.Monad.Cont
 /-!
 # Evaluating continuation computations
 
-`Cont.lower` evaluates a computation `Cont A A` at the identity
-continuation — Haskell's `evalCont`, which `Mathlib.Control.Monad.Cont`
-does not provide. The `lower_pure`/`lower_bind`/`lower_map`/`lower_seq`
-simp set mirrors `ContT`'s `run_*` lemmas; under it, bind chains
-evaluate in bind order and the applicative combination left-to-right.
-In continuation semantics `lower` is [barker-shan-2014]'s LOWER (theirs
-restricts the answer type to the clause category), and the bind-order
-dependence is the monadic account of quantifier scope ([barker-2002],
-[shan-2001], [charlow-2014]); see `Studies/BumfordCharlow2024.lean` and
+`ContT.lower` finishes a continuation computation by handing it the
+trivial continuation `pure` — [charlow-2014]'s Lowering, Haskell's
+`evalCont`, the LOWER of [barker-shan-2014]. The `lower_*` simp lemmas
+mirror `ContT`'s `run_*` set: a chain of binds evaluates in bind order
+and the applicative combination left-to-right, which is what lets bind
+order model quantifier scope. `ContT.reset` lowers and then re-lifts,
+delimiting scope the way scope islands do. For the linguistic
+applications see `Studies/BumfordCharlow2024.lean` and
 `Studies/Charlow2020.lean`.
 
 ## References
@@ -19,27 +18,53 @@ dependence is the monadic account of quantifier scope ([barker-2002],
 - <https://hackage.haskell.org/package/mtl-2.2.2/docs/Control-Monad-Cont.html#v:evalCont>
 -/
 
-universe u
+universe u v
 
-namespace Cont
+namespace ContT
 
-variable {α β : Type u}
+variable {r α β : Type u} {m : Type u → Type v}
 
-/-- Evaluation at the identity continuation: `lower m = m id`. -/
-def lower (m : Cont α α) : α := m.run id
+/-- Evaluation at the trivial continuation: `lower c = c.run pure`. -/
+def lower [Pure m] (c : ContT r m r) : m r := c.run pure
 
 /-! ### Interaction with the monad operations -/
 
-/-- `lower` is a left inverse of `pure`: LOWER ∘ LIFT is the identity. -/
-@[simp] theorem lower_pure (a : α) : lower (pure a) = a := rfl
+@[simp] theorem lower_pure [Pure m] (a : r) :
+    lower (pure a : ContT r m r) = pure a := rfl
 
-@[simp] theorem lower_bind (m : Cont β α) (f : α → Cont β β) :
-    lower (m >>= f) = m.run λ x => lower (f x) := rfl
+@[simp] theorem lower_bind [Pure m] (c : ContT r m α) (f : α → ContT r m r) :
+    lower (c >>= f) = c.run λ x => lower (f x) := rfl
 
-@[simp] theorem lower_map (f : α → β) (m : Cont β α) :
-    lower (f <$> m) = m.run f := rfl
+@[simp] theorem lower_map [Pure m] (f : α → r) (c : ContT r m α) :
+    lower (f <$> c) = c.run λ x => pure (f x) := rfl
 
-@[simp] theorem lower_seq (mf : Cont β (α → β)) (mx : Cont β α) :
-    lower (mf <*> mx) = mf.run λ f => mx.run f := rfl
+@[simp] theorem lower_seq [Pure m] (mf : ContT r m (α → r)) (mx : ContT r m α) :
+    lower (mf <*> mx) = mf.run λ f => mx.run λ x => pure (f x) := rfl
 
-end Cont
+/-! ### Lowering lifted computations -/
+
+@[simp] theorem lower_monadLift [Monad m] [LawfulMonad m] (x : m r) :
+    lower (monadLift x : ContT r m r) = x :=
+  bind_pure x
+
+/-- Lower, then re-lift: `reset c = monadLift (lower c)` —
+[charlow-2014]'s Reset, after [danvy-filinski-1990]. -/
+def reset {r' : Type u} [Monad m] (c : ContT r m r) : ContT r' m r :=
+  monadLift (lower c)
+
+/-- `reset` is transparent to lifted effects: effects escape islands,
+scope-takers do not. -/
+theorem reset_monadLift {r' : Type u} [Monad m] [LawfulMonad m] (x : m r) :
+    reset (monadLift x : ContT r m r) = (monadLift x : ContT r' m r) :=
+  congrArg monadLift (lower_monadLift x)
+
+/-- Lifting, combining, and lowering is just combining in `m`:
+scopal combination subsumes applicative combination. -/
+theorem lower_seq_monadLift [Monad m] [LawfulMonad m]
+    (f : α → β → r) (x : m α) (y : m β) :
+    lower (f <$> (monadLift x : ContT r m α) <*> monadLift y) =
+    f <$> x <*> y := by
+  simp only [lower, seq_eq_bind_map, bind_map_left, run_bind, run_map,
+    run_monadLift, Function.comp_def, bind_pure_comp]
+
+end ContT

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -64,7 +64,7 @@ S&B substrate in linglib yet.
 
 ## Implementation notes
 
-Scope-as-bind-order rests on `Cont.lower` (`Composition/Cont.lean`);
+Scope-as-bind-order rests on `ContT.lower` (`Composition/Cont.lean`);
 the §6 agreements are definitional instances of its `lower_*` laws.
 The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 -/
@@ -91,7 +91,7 @@ The W effect is mathlib's `Writer (List P)` (= `WriterT (List P) Id`), whose
 `Functor`/`Applicative`/`Monad` instances come from mathlib, with
 `LawfulMonad` and the `val`/`log`/`tell` surface in
 `Composition/Writer.lean`. The `Cont R` monad is mathlib's
-(`Mathlib.Control.Monad.Cont`); its linguistics surface (`Cont.lower`)
+(`Mathlib.Control.Monad.Cont`); its linguistics surface (`ContT.lower`)
 lives in `Composition/Cont.lean`. -/
 
 -- ════════════════════════════════════════════════════════════════════
@@ -431,7 +431,7 @@ linglib infrastructure to the effect/handler pattern.
 - `aside`: Log a CI proposition (= `Writer.tell`)
 
 **Handlers** (eliminate computational context):
-- `handleScope`: Lower a `Cont` to its result (= `Cont.lower`)
+- `handleScope`: Lower a `Cont` to its result (= `ContT.lower`)
 - `handleCI`: Extract at-issue value and CI log from `Writer` -/
 
 section EffectOps
@@ -442,8 +442,8 @@ variable {R : Type} {P : Type} {α : Type}
 def aside (p : P) : Writer (List P) Unit := Writer.tell p
 
 /-- Handle the scope effect by evaluating with the identity continuation.
-    Alias for `Cont.lower`. -/
-def handleScope (m : Cont R R) : R := Cont.lower m
+    Alias for `ContT.lower`. -/
+def handleScope (m : Cont R R) : R := ContT.lower m
 
 /-- Handle CI effects by extracting the value and accumulated log. -/
 def handleCI (m : Writer (List P) α) : α × List P := (m.val, m.log)
@@ -483,7 +483,7 @@ Connect the effect framework to existing linglib constructions, proving
 that independently-developed linglib modules are instances of the
 effect-driven architecture. The W and C effects need no bridge:
 `Writer`'s monadic application is mathlib's `<*>`, and
-`handleScope := Cont.lower` by definition. -/
+`handleScope := ContT.lower` by definition. -/
 
 section CIBridge
 
@@ -854,7 +854,7 @@ one particular syntax for specifying bind order. -/
 
 section GeneralScopeAgreement
 
-/-! The generic scope-as-bind-order facts are the `Cont.lower_*` simp
+/-! The generic scope-as-bind-order facts are the `ContT.lower_*` simp
 set in `Composition/Cont.lean`; the §6 theorems above are definitional
 instances. What remains here is the bridge to QR trees. -/
 
@@ -872,10 +872,10 @@ instances. What remains here is the bridge to QR trees. -/
     how scope order is *specified* (tree structure vs bind order),
     not in what they *compute*. -/
 theorem qr_cont_structural_agreement {E W : Type}
-    (q : (E → Prop) → Prop)
+    (q : Cont Prop E)
     (body : DenotG E W .t) (n : Nat) (g : Core.Assignment E) :
     q (lambdaAbsG n body g) =
-    Cont.lower (q >>= λ x => pure (body (g[n ↦ x]))) := rfl
+    ContT.lower (q >>= λ x => pure (body (g[n ↦ x]))) := rfl
 
 end GeneralScopeAgreement
 

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -166,12 +166,12 @@ quantifiers do. -/
 def setToCont {A : Type} (m : Set A) : Cont Prop A := λ κ => ∃ x, x ∈ m ∧ κ x
 
 /-- **↓ is LOWER through the Set→Cont morphism**: existential closure of
-a proposition set is exactly lowering (`Cont.lower`) its continuized
+a proposition set is exactly lowering (`ContT.lower`) its continuized
 image. The tree's two scope-effect carriers — `Set` for alternatives
 ([charlow-2020]), `Cont` for quantifier scope — share one evaluation
 operation. -/
 theorem lower_setToCont (m : Set Prop) :
-    Cont.lower (setToCont m) = existsClosure m := rfl
+    ContT.lower (setToCont m) = existsClosure m := rfl
 
 /-! ### §4 Bridge to `Studies/Charlow2018.lean`
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4839,6 +4839,18 @@
   validated = {true},
   sources   = {arXiv journal-ref},
 }
+@inproceedings{danvy-filinski-1990,
+  author    = {Danvy, Olivier and Filinski, Andrzej},
+  year      = {1990},
+  title     = {Abstracting Control},
+  booktitle = {Proceedings of the 1990 ACM Conference on LISP and Functional Programming},
+  pages     = {151--160},
+  doi       = {10.1145/91556.91622},
+  subfield  = {semantics/dynamic},
+  role      = {foundational},
+  validated = {true},
+  sources   = {CrossRef},
+}
 @inproceedings{abramsky-sadrzadeh-2014,
   author    = {Abramsky, Samson and Sadrzadeh, Mehrnoosh},
   year      = {2014},


### PR DESCRIPTION
Adopts the literature's own general form: `ContT.lower c := c.run pure` is Charlow 2014's monadic Lowering (`m↓ := m η`) verbatim, with the previous `Cont.lower` as the definitional `Id` case; the `lower_*` simp set generalizes with it (all still `rfl`).

- `ContT.reset := monadLift ∘ lower` (Charlow 2014's scope-island delimiter, after Danvy–Filinski 1990, new verified bib entry), landed with its content: `reset_monadLift` (effects escape islands, scope-takers don't) and `lower_seq_monadLift` (scopal combination subsumes applicative combination) — the file's first `LawfulMonad`-substantive theorems.
- Docstring corrections from the literature survey: Barker & Shan generality axis stated correctly, `barker-2002` no longer credited for the monadic account; module doc rewritten in plain language.
- Consumers swept (`Cont.lower` → `ContT.lower`); `qr_cont_structural_agreement` now binds its quantifier at `Cont Prop E` (the generalized signature no longer infers the monad from a raw GQ type).