### PR TITLE
refactor(Semantics/Quantification): rename NPQ to Quantifier

### DIFF
--- a/Linglib/Semantics/Composition/TypeShifting.lean
+++ b/Linglib/Semantics/Composition/TypeShifting.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Intensional.Defs
+import Linglib.Semantics.Quantification.Defs
 import Linglib.Semantics.Intensional.Conjunction
 import Linglib.Semantics.Modification.Basic
 import Mathlib.Order.Hom.BoundedLattice
@@ -30,6 +31,7 @@ which extend the same type-shift to kinds and bare plurals.
 namespace Semantics.Composition.TypeShifting
 
 open Intensional
+open Quantification
 open Intensional.Conjunction (typeRaise)
 
 variable {E W : Type}
@@ -37,7 +39,7 @@ variable {E W : Type}
 section TotalShifts
 
 /-- Type-raising: `lift(j) = λP. P(j)` -/
-def lift (j : E) : ((E → Prop) → Prop) :=
+def lift (j : E) : Quantifier E :=
   fun P => P j
 
 /-- Singleton property: `ident(j) = λx. [j = x]`.
@@ -53,11 +55,11 @@ proposition into a question denotation when an embedding predicate (e.g.
 a Predicate of Relevance like `care`) selects only for questions. The shape
 mirrors `ident` one type-theoretic level up: entities ↦ singleton properties
 becomes propositions ↦ singleton questions. -/
-def propIdent (p : (W → Prop)) : ((W → Prop) → Prop) :=
+def propIdent (p : (W → Prop)) : Quantifier W :=
   fun q => p = q
 
 /-- Predicative content of a GQ: `BE(Q) = λx. Q(λy. y = x)` -/
-def BE (Q : ((E → Prop) → Prop)) : (E → Prop) :=
+def BE (Q : Quantifier E) : (E → Prop) :=
   fun x => Q (fun y => y = x)
 
 /-- Predicativize: extensional counterpart of Chierchia's ∪ (up) operator.
@@ -89,7 +91,7 @@ private lemma finset_inf_fun_eval {ι α : Type*}
   | cons x s hx ih => simp only [Finset.inf_cons, Pi.inf_apply, ih]
 
 /-- `BE` is a `BoundedLatticeHom` (Partee §3.3, Fact 1). -/
-def BE_hom (E : Type) : BoundedLatticeHom (((E → Prop) → Prop)) ((E → Prop)) where
+def BE_hom (E : Type) : BoundedLatticeHom (Quantifier E) ((E → Prop)) where
   toFun := BE
   map_sup' _ _ := rfl
   map_inf' _ _ := rfl
@@ -112,14 +114,14 @@ theorem BE_lift_eq_ident (j : E) :
     `atom_x` correctly. Then monotonicity determines `f(Q)(x)` for arbitrary
     `Q` by cases on `Q(P_x)`. -/
 theorem BE_unique [Fintype E] [DecidableEq E]
-    (f : BoundedLatticeHom (((E → Prop) → Prop)) ((E → Prop)))
+    (f : BoundedLatticeHom (Quantifier E) ((E → Prop)))
     (hcomm : ∀ j : E, f (lift j) = ident j) :
-    ∀ Q : ((E → Prop) → Prop), f Q = BE Q := by
+    ∀ Q : Quantifier E, f Q = BE Q := by
   intro Q; funext x
   show f Q x = Q (fun j => j = x)
-  let lit : E → ((E → Prop) → Prop) := fun j =>
-    if j = x then (lift j : ((E → Prop) → Prop)) else (lift j)ᶜ
-  let atom_x : ((E → Prop) → Prop) := Finset.inf Finset.univ lit
+  let lit : E → Quantifier E := fun j =>
+    if j = x then (lift j : Quantifier E) else (lift j)ᶜ
+  let atom_x : Quantifier E := Finset.inf Finset.univ lit
   let f_lit : E → (E → Prop) := fun j =>
     if j = x then (ident j : (E → Prop)) else (ident j)ᶜ
   -- Step 1: f maps each literal correctly
@@ -161,7 +163,7 @@ theorem BE_unique [Fintype E] [DecidableEq E]
       -- hj : (lift j)ᶜ R, i.e. ¬R j. Goal: R j = (j = x)
       exact propext ⟨fun hr => absurd hr hj, fun heq => absurd heq h⟩
   -- Step 5: conclude by cases on Q(fun j => j = x)
-  have hatom_le : ∀ S : ((E → Prop) → Prop), S (fun j => j = x) → atom_x ≤ S := by
+  have hatom_le : ∀ S : Quantifier E, S (fun j => j = x) → atom_x ≤ S := by
     intro S hS R hR
     have : R = fun j => j = x := hatom_point R hR
     rw [this]; exact hS
@@ -180,15 +182,15 @@ theorem BE_unique [Fintype E] [DecidableEq E]
     exact propext ⟨fun h => absurd h hfQc2, fun h => absurd h hQPx⟩
 
 /-- `BE(Q₁ ∧ Q₂) = BE(Q₁) ∧ BE(Q₂)` -/
-theorem BE_conj (Q₁ Q₂ : ((E → Prop) → Prop)) :
+theorem BE_conj (Q₁ Q₂ : Quantifier E) :
     BE (fun P => Q₁ P ∧ Q₂ P) = (fun x => BE Q₁ x ∧ BE Q₂ x) := rfl
 
 /-- `BE(Q₁ ∨ Q₂) = BE(Q₁) ∨ BE(Q₂)` -/
-theorem BE_disj (Q₁ Q₂ : ((E → Prop) → Prop)) :
+theorem BE_disj (Q₁ Q₂ : Quantifier E) :
     BE (fun P => Q₁ P ∨ Q₂ P) = (fun x => BE Q₁ x ∨ BE Q₂ x) := rfl
 
 /-- `BE(¬Q) = ¬BE(Q)` -/
-theorem BE_neg (Q : ((E → Prop) → Prop)) :
+theorem BE_neg (Q : Quantifier E) :
     BE (fun P => ¬(Q P)) = (fun x => ¬(BE Q x)) := rfl
 
 end BooleanHomomorphism
@@ -196,7 +198,7 @@ end BooleanHomomorphism
 section PartialShifts
 
 /-- Partial inverse of `lift`. Defined when `Q` is a principal ultrafilter. -/
-noncomputable def lower (domain : List E) (Q : ((E → Prop) → Prop)) : Option E :=
+noncomputable def lower (domain : List E) (Q : Quantifier E) : Option E :=
   match domain.filter (fun j => @decide (Q (fun x => x = j)) (Classical.dec _)) with
   | [j] => some j
   | _ => none
@@ -217,7 +219,7 @@ noncomputable def NOM (domain : List E) (P : (E → Prop)) : Option E :=
   iota domain P
 
 /-- Existential closure: `A(P) = λQ. ∃x. P(x) ∧ Q(x)` -/
-def A (domain : List E) (P : (E → Prop)) : ((E → Prop) → Prop) :=
+def A (domain : List E) (P : (E → Prop)) : Quantifier E :=
   fun Q => ∃ x ∈ domain, P x ∧ Q x
 
 /-- THE: Presuppositional type-shifter for definites ([partee-1987] Figure 1).
@@ -226,7 +228,7 @@ def A (domain : List E) (P : (E → Prop)) : ((E → Prop) → Prop) :=
     Maps `⟨e,t⟩ → ⟨⟨e,t⟩,t⟩` (partial). Unlike `A` (which is total), `THE`
     presupposes existence and uniqueness. Connects to the semantics of "the"
     in `Semantics.Definiteness`. -/
-noncomputable def THE (domain : List E) (P : (E → Prop)) : Option (((E → Prop) → Prop)) :=
+noncomputable def THE (domain : List E) (P : (E → Prop)) : Option (Quantifier E) :=
   (iota domain P).map lift
 
 /-- Helper: for a nodup list, filtering for equality gives a singleton or empty. -/
@@ -334,7 +336,7 @@ Applications:
 -/
 
 /-- A GQ is a principal ultrafilter iff it equals `lift(j)` for some entity. -/
-def isPrincipalUltrafilter (domain : List E) (Q : ((E → Prop) → Prop)) : Prop :=
+def isPrincipalUltrafilter (domain : List E) (Q : Quantifier E) : Prop :=
   ∃ j ∈ domain, Q = lift j
 
 /-- Helper: `(∃ x ∈ domain, j = x ∧ P x) ↔ P j` when `j ∈ domain`. -/
@@ -545,7 +547,7 @@ section GaloisStructure
 
     `Q` is upward-closed when `Q(P)` and `P ≤ P'` imply `Q(P')`.
     Equivalently, `Monotone Q` in the pointwise order on `⟨e,t⟩`. -/
-def UpwardGQ (E : Type) := { Q : ((E → Prop) → Prop) // Monotone Q }
+def UpwardGQ (E : Type) := { Q : Quantifier E // Monotone Q }
 
 instance : PartialOrder (UpwardGQ E) := Subtype.partialOrder _
 

--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -103,11 +103,11 @@ inductive PossessionRelationType where
 
 /-! ### Bridge to type ⟨1⟩ quantifiers -/
 
-/-- Possessive as a type ⟨1⟩ quantifier (NPQ):
+/-- Possessive as a type ⟨1⟩ quantifier (Quantifier):
 `⟦John's⟧ = fun R P ↦ ∃ y, R possessor y ∧ P y`. Not isomorphism-invariant: it
 depends on the identity of the possessor, not just cardinalities. -/
 def asNPQ {E : Type*} (possessor : E) (R : E → E → Bool) :
-    Quantification.NPQ E :=
+    Quantification.Quantifier E :=
   fun P => ∃ y : E, R possessor y = true ∧ P y
 
 end Possessive

--- a/Linglib/Semantics/Possessive/GQ.lean
+++ b/Linglib/Semantics/Possessive/GQ.lean
@@ -65,7 +65,7 @@ def Poss (Q₁ : GQ α) (C : α → Prop) (Q₂ : GQ α) (R : α → α → Prop
     Narrowing stays in the scope, preserving possessive existential import
     ("John's dogs bark" requires John to own a dog).
     [peters-westerstahl-2006] (7.44)–(7.45), pp. 259–260 (Possʷ). -/
-def PossW (Q : NPQ α) (Q₂ : GQ α) (R : α → α → Prop) : GQ α :=
+def PossW (Q : Quantifier α) (Q₂ : GQ α) (R : α → α → Prop) : GQ α :=
   fun A B => Q (fun a => dom A R a ∧ Q₂ (fun y => A y ∧ R a y) B)
 
 /-! ### Conservativity (P&W (7.29)) -/
@@ -96,7 +96,7 @@ theorem poss_conservative {Q₁ Q₂ : GQ α} (C : α → Prop) (R : α → α �
 
 /-- Conservativity inheritance for the type ⟨1⟩ variant.
     [peters-westerstahl-2006] remark after (7.44). -/
-theorem possW_conservative {Q : NPQ α} {Q₂ : GQ α} (R : α → α → Prop)
+theorem possW_conservative {Q : Quantifier α} {Q₂ : GQ α} (R : α → α → Prop)
     (h₂ : Conservative Q₂) : Conservative (PossW Q Q₂ R) := by
   intro A B
   unfold PossW
@@ -192,7 +192,7 @@ theorem carrierGQ_existential_import {γ E S : Type*}
 
 /-! ### Bridge to Barker's type ⟨1⟩ possessive -/
 
-/-- [barker-2011]'s possessive NPQ (`⟦John's⟧ = fun P => ∃ y, R j y ∧ P y`,
+/-- [barker-2011]'s possessive Quantifier (`⟦John's⟧ = fun P => ∃ y, R j y ∧ P y`,
     `Possessive.asNPQ`) is `PossW` at a Montagovian individual with
     existential `Q₂` and trivial possessee restrictor — the possessee class is
     folded into `R` by Barker's π shift. -/

--- a/Linglib/Semantics/Quantification/Defs.lean
+++ b/Linglib/Semantics/Quantification/Defs.lean
@@ -359,23 +359,27 @@ def adjRestrict (q : GQ α) (adj : α → Prop) : GQ α :=
 
 /-! #### Type ⟨1⟩ shifts (P&W Ch.2-3) -/
 
-/-- NP denotation (type ⟨1⟩): a property of properties.
-    This is the model-agnostic version of `Ty.ett` from TypeShifting.lean.
-    P&W §2.1: an NP like "every student" denotes a set of sets. -/
-abbrev NPQ (α : Type*) := (α → Prop) → Prop
+/-- Type ⟨1⟩ quantifier: a property of properties — a quantifier proper
+    in [barwise-cooper-1981]'s sense ("a quantifier is a set of sets";
+    NPs denote quantifiers, determiners denote functions from properties
+    to them). P&W §2.1. Definitionally `Cont Prop α`: quantifiers are
+    the scope-taking continuations. -/
+abbrev Quantifier (α : Type*) := (α → Prop) → Prop
 
 /-- Restriction: given a GQ Q and restrictor A, produce the type ⟨1⟩
     quantifier Q^[A] (P&W §3.2.2). `restrict Q A B = Q A B`. -/
-def restrict (q : GQ α) (A : α → Prop) : NPQ α := q A
+def restrict (q : GQ α) (A : α → Prop) : Quantifier α := q A
 
 /-- A type ⟨1⟩ quantifier Q "lives on" A iff Q(B) ↔ Q(A ∩ B) for all B.
     P&W §3.2.2: the restricted quantifier depends only on elements of A. -/
-def LivesOn (Q : NPQ α) (A : α → Prop) : Prop :=
+def LivesOn (Q : Quantifier α) (A : α → Prop) : Prop :=
   ∀ B, Q B ↔ Q (fun x => A x ∧ B x)
 
 /-- Montagovian individual: the type ⟨1⟩ quantifier I_a = {X : a ∈ X}.
-    P&W §3.2.3: an entity lifts to the principal ultrafilter it generates. -/
-def individual (a : α) : NPQ α := fun P => P a
+    P&W §3.2.3: an entity lifts to the principal ultrafilter it generates.
+    This is Montague lift — [partee-1987]'s LIFT and the continuation
+    `pure`. -/
+def individual (a : α) : Quantifier α := fun P => P a
 
 /-! ### Mathlib Bridge -/
 

--- a/Linglib/Semantics/Quantification/Generators.lean
+++ b/Linglib/Semantics/Quantification/Generators.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Quantification.Defs
 [xiang-2016] [elliott-nicolae-sauerland-2022]
 
 Conjunction and disjunction GQs as iterated meet/join of Montagovian
-individual quantifiers in the NPQ Boolean algebra.
+individual quantifiers in the Quantifier Boolean algebra.
 
 Given a domain of entities, each entity lifts to its principal ultrafilter
 (`individual`). The conjunction GQ over a subset X is the infimum
@@ -15,7 +15,7 @@ quantification over X as lattice operations.
 
 ## Architecture
 
-`NPQ α = (α → Prop) → Prop` inherits a full `BooleanAlgebra` from
+`Quantifier α = (α → Prop) → Prop` inherits a full `BooleanAlgebra` from
 Mathlib's Pi instances over `Prop`. All definitions here are stated
 directly in terms of Mathlib's `⊓`/`⊔`/`⊤`/`⊥`/`≤`. The propositional
 characterizations (`conjGQ X P ↔ ∀ x ∈ X, P x`,
@@ -58,7 +58,7 @@ variable {α : Type*}
 
     [xiang-2016]: conjunction GQs range over non-empty subsets of an
     entity domain, generating the "conjunctive" answers to questions. -/
-def conjGQ (X : List α) : NPQ α :=
+def conjGQ (X : List α) : Quantifier α :=
   X.foldr (fun a acc => individual a ⊓ acc) ⊤
 
 /-- Disjunction GQ: iterated join of individual quantifiers.
@@ -66,7 +66,7 @@ def conjGQ (X : List α) : NPQ α :=
     ⊔(X) = ⨆_{x ∈ X} individual(x)
 
     [xiang-2016]: disjunction GQs generate "disjunctive" answers. -/
-def disjGQ (X : List α) : NPQ α :=
+def disjGQ (X : List α) : Quantifier α :=
   X.foldr (fun a acc => individual a ⊔ acc) ⊥
 
 /-! ### Recursive Decomposition -/
@@ -143,8 +143,8 @@ theorem disjGQ_singleton (a : α) :
 /-! ### Lattice-Theoretic Characterization -/
 
 /-! `conjGQ X` is the greatest lower bound (infimum) and `disjGQ X` the
-    least upper bound (supremum) of `{individual a | a ∈ X}` in the NPQ
-    lattice. These use Mathlib's `≤` on `NPQ α`, which is pointwise
+    least upper bound (supremum) of `{individual a | a ∈ X}` in the Quantifier
+    lattice. These use Mathlib's `≤` on `Quantifier α`, which is pointwise
     implication: `f ≤ g ↔ ∀ P, f P → g P` for the Pi-of-Prop ordering. -/
 
 /-- conjGQ X ≤ individual a for every a ∈ X: the iterated meet is below
@@ -156,7 +156,7 @@ theorem conjGQ_le_individual (a : α) (X : List α) (ha : a ∈ X) :
 
 /-- conjGQ X is the greatest lower bound of {individual a | a ∈ X}:
     any Q below every individual in X is below conjGQ X. -/
-theorem le_conjGQ (Q : NPQ α) (X : List α)
+theorem le_conjGQ (Q : Quantifier α) (X : List α)
     (h : ∀ a ∈ X, Q ≤ individual a) :
     Q ≤ conjGQ X := by
   intro P hQ
@@ -173,7 +173,7 @@ theorem individual_le_disjGQ (a : α) (X : List α) (ha : a ∈ X) :
 
 /-- disjGQ X is the least upper bound of {individual a | a ∈ X}:
     any Q above every individual in X is above disjGQ X. -/
-theorem disjGQ_le (Q : NPQ α) (X : List α)
+theorem disjGQ_le (Q : Quantifier α) (X : List α)
     (h : ∀ a ∈ X, individual a ≤ Q) :
     disjGQ X ≤ Q := by
   intro P hDisj
@@ -185,7 +185,7 @@ theorem disjGQ_le (Q : NPQ α) (X : List α)
 /-- conjGQ is antimonotone in the subset ordering: more conjuncts produce
     a stronger (more restrictive) quantifier.
 
-    X ⊆ Y → ⊓(Y) ≤ ⊓(X) in the NPQ lattice. -/
+    X ⊆ Y → ⊓(Y) ≤ ⊓(X) in the Quantifier lattice. -/
 theorem conjGQ_antitone {X Y : List α} (h : ∀ x, x ∈ X → x ∈ Y)
     (P : α → Prop) : conjGQ Y P → conjGQ X P := by
   rw [conjGQ_iff_forall, conjGQ_iff_forall]
@@ -193,7 +193,7 @@ theorem conjGQ_antitone {X Y : List α} (h : ∀ x, x ∈ X → x ∈ Y)
 
 /-- disjGQ is monotone: more disjuncts produce a weaker quantifier.
 
-    X ⊆ Y → ⊔(X) ≤ ⊔(Y) in the NPQ lattice. -/
+    X ⊆ Y → ⊔(X) ≤ ⊔(Y) in the Quantifier lattice. -/
 theorem disjGQ_monotone {X Y : List α} (h : ∀ x, x ∈ X → x ∈ Y)
     (P : α → Prop) : disjGQ X P → disjGQ Y P := by
   rw [disjGQ_iff_exists, disjGQ_iff_exists]
@@ -209,7 +209,7 @@ theorem conjGQ_le_disjGQ {X : List α} (hne : X ≠ [])
   obtain ⟨x, hx⟩ := List.exists_mem_of_ne_nil X hne
   exact ⟨x, hx, h x hx⟩
 
-/-- ⊓(X) ≤ ⊔(X) when X ≠ ∅: conjunction below disjunction in the NPQ
+/-- ⊓(X) ≤ ⊔(X) when X ≠ ∅: conjunction below disjunction in the Quantifier
     lattice. Lattice-order form of `conjGQ_le_disjGQ`. -/
 theorem conjGQ_le_disjGQ' {X : List α} (hne : X ≠ []) :
     conjGQ X ≤ disjGQ X := fun P => conjGQ_le_disjGQ hne P
@@ -219,7 +219,7 @@ theorem conjGQ_le_disjGQ' {X : List α} (hne : X ≠ []) :
 /-- Individual quantifiers are join-prime: individual(a) ≤ ⊔(X) iff a ∈ X.
 
     This is a deep lattice-theoretic characterization: individual
-    quantifiers are the atoms of the NPQ Boolean algebra, and they detect
+    quantifiers are the atoms of the Quantifier Boolean algebra, and they detect
     membership in disjunctive quantifiers. It is the formal foundation
     for Dayal's ANS identifying which individual satisfies the answer. -/
 theorem individual_le_disjGQ_iff [DecidableEq α] (a : α) (X : List α) :
@@ -256,7 +256,7 @@ theorem conjGQ_le_individual_iff [DecidableEq α] (a : α) (X : List α) :
       ¬(∃x∈X. P(x)) ↔ ∀x∈X. ¬P(x)
 
     Note: these are distinct from the BooleanAlgebra complement laws
-    on NPQ α. The lattice complement `(conjGQ X)ᶜ` negates the
+    on Quantifier α. The lattice complement `(conjGQ X)ᶜ` negates the
     *output*; De Morgan negates the *input predicate*. -/
 
 /-- De Morgan for conjunction: negating each argument swaps ∀ to ∃. -/
@@ -331,13 +331,13 @@ def nonemptySubsets (l : List α) : List (List α) :=
     For a domain of n entities, produces 2ⁿ − 1 conjunction GQs,
     one per non-empty subset. Singleton subsets produce individual
     quantifiers; the full set produces the strongest (most conjuncts). -/
-def conjGQs (dom : List α) : List (NPQ α) :=
+def conjGQs (dom : List α) : List (Quantifier α) :=
   (nonemptySubsets dom).map conjGQ
 
 /-- All disjunction GQs from non-empty subsets of a domain.
 
     disjGQs(dom) = {⊔(X) | ∅ ≠ X ⊆ dom} -/
-def disjGQs (dom : List α) : List (NPQ α) :=
+def disjGQs (dom : List α) : List (Quantifier α) :=
   (nonemptySubsets dom).map disjGQ
 
 end Quantification

--- a/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
+++ b/Linglib/Studies/AlonsoOvalleMoghiseh2025b.lean
@@ -51,7 +51,7 @@ set_option autoImplicit false
 
 namespace AlonsoOvalleMoghiseh2025b
 
-open Quantification (NPQ conjGQ disjGQ conjGQs disjGQs nonemptySubsets
+open Quantification (Quantifier conjGQ disjGQ conjGQs disjGQs nonemptySubsets
   conjGQ_iff_forall disjGQ_iff_exists conjGQ_le_individual individual_le_disjGQ
   conjGQ_le_disjGQ' individual)
 
@@ -110,7 +110,7 @@ theorem bought_distributive (w : World) :
 
     ⟦Q⟧(dom) = {λw. Q(λe. bought(e, w)) | Q ∈ ⊓(dom) ∪ ⊔(dom)}
 
-    Since `NPQ Entity = (Entity → Prop) → Prop`, we use the propositional
+    Since `Quantifier Entity = (Entity → Prop) → Prop`, we use the propositional
     characterization `conjGQ_iff_forall` / `disjGQ_iff_exists` to compute
     a Bool result from the Bool predicate `bought`. -/
 def hamblinSet (dom : List Entity) : List (World → Bool) :=
@@ -191,18 +191,18 @@ def ciDomain : List Entity := allEntities.filter (fun e => decide (isAtom e))
     - `individual_le_disjGQ`: individual(a) ≤ ⊔(X) for a ∈ X
     - `conjGQ_le_disjGQ'`: ⊓(X) ≤ ⊔(X) for non-empty X
 
-    The bridge `npq_le_entails` lifts NPQ lattice `≤` to the study's
+    The bridge `npq_le_entails` lifts Quantifier lattice `≤` to the study's
     propositional `entails`, connecting the abstract lattice structure
     to the concrete model. -/
 
-/-- NPQ lattice ordering lifts to propositional entailment via `bought`.
-    If Q₁ ≤ Q₂ in the NPQ lattice, and p₁/p₂ are the propositions
+/-- Quantifier lattice ordering lifts to propositional entailment via `bought`.
+    If Q₁ ≤ Q₂ in the Quantifier lattice, and p₁/p₂ are the propositions
     obtained by applying Q₁/Q₂ to `bought` at each world, then p₁
     entails p₂.
 
     This is the key bridge connecting the lattice-theoretic GQ
     infrastructure to the study's propositional entailment relation. -/
-private theorem npq_le_entails {Q₁ Q₂ : NPQ Entity}
+private theorem npq_le_entails {Q₁ Q₂ : Quantifier Entity}
     {p₁ p₂ : World → Bool}
     (hp₁ : ∀ w, p₁ w = true ↔ Q₁ (λ e => bought e w = true))
     (hp₂ : ∀ w, p₂ w = true ↔ Q₂ (λ e => bought e w = true))
@@ -248,7 +248,7 @@ theorem atoms_independent :
   ⟨rfl, rfl⟩
 
 /-- B(t1) ∧ B(t2) entails each atom individually (conjunction elimination).
-    Structural proof: ⊓({t1,t2}) ≤ individual(tᵢ) in the NPQ lattice
+    Structural proof: ⊓({t1,t2}) ≤ individual(tᵢ) in the Quantifier lattice
     (`conjGQ_le_individual`), lifted to propositional entailment via
     `npq_le_entails`. -/
 theorem conj_entails_atoms :
@@ -260,7 +260,7 @@ theorem conj_entails_atoms :
     (conjGQ_le_individual .t2 _ (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..))))⟩
 
 /-- B(t1) entails any disjunction containing it (disjunction introduction).
-    Structural proof: individual(t1) ≤ ⊔(X) for t1 ∈ X in the NPQ lattice
+    Structural proof: individual(t1) ≤ ⊔(X) for t1 ∈ X in the Quantifier lattice
     (`individual_le_disjGQ`), lifted to propositional entailment. -/
 theorem atom_entails_containing_disj :
     entails (bought .t1) (λ w => bought .t1 w || bought .t2 w) = true ∧


### PR DESCRIPTION
The type ⟨1⟩ carrier `(α → Prop) → Prop` gets its literature name: Barwise & Cooper's *quantifier* ("a quantifier is a set of sets"; NPs denote quantifiers, determiners map properties to them) replaces the syntactic-label abbreviation `NPQ`.

- `Composition/TypeShifting.lean` now imports the carrier and states its 18 anonymous `((E → Prop) → Prop)` signatures as `Quantifier E` — the two halves of the type ⟨1⟩ story reference each other for the first time.
- `individual`'s docstring records the identification with Montague lift / Partee's LIFT / continuation `pure`; `Quantifier`'s notes it is definitionally `Cont Prop α`.
- Question-semantics files where `NPQ` means *negative polar question* are untouched.