### PR TITLE
refactor(Semantics): dissolve typeRaise into Quantification.individual

### DIFF
--- a/Linglib/Semantics/Composition/TypeShifting.lean
+++ b/Linglib/Semantics/Composition/TypeShifting.lean
@@ -37,7 +37,6 @@ namespace Semantics.Composition.TypeShifting
 
 open Intensional
 open Quantification
-open Intensional.Conjunction (typeRaise)
 
 variable {E W : Type}
 
@@ -274,10 +273,6 @@ theorem THE_ident [DecidableEq E] (domain : List E) (j : E)
   simp only [THE, iota_ident domain j hmem hnd, Option.map]
 
 end PartialShifts
-
-/-- `individual = Conjunction.typeRaise` -/
-theorem individual_eq_typeRaise (j : E) :
-    individual j = (typeRaise (W := W) j) := rfl
 
 /-- Coherence of the three readings of "the king" ([partee-1987] §3.2).
     When `iota` succeeds, the `e`, `⟨e,t⟩`, and `⟨⟨e,t⟩,t⟩` readings are

--- a/Linglib/Semantics/Intensional/Conjunction.lean
+++ b/Linglib/Semantics/Intensional/Conjunction.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Intensional.Defs
+import Linglib.Semantics.Quantification.Defs
 
 /-!
 # Generalized Conjunction
@@ -111,27 +112,23 @@ theorem genDisj_lambda_distribution {E W : Type} {σ τ : Ty}
     genDisj (σ ⇒ τ) E W f g = λ v => genDisj τ E W (f v) (g v) := rfl
 
 -- ════════════════════════════════════════════════════════════════
--- § Type-Raising and Coordination
+-- § Coordination of entities
 -- ════════════════════════════════════════════════════════════════
 
-section TypeRaising
+section EntityCoordination
 
-/-- Type-raise an entity to a GQ: `e ↦ λP.P(e)` -/
-def typeRaise {E W : Type} (e : Denot E W .e) : Denot E W ((.e ⇒ .t) ⇒ .t) :=
-  λ p => p e
+open Quantification (individual)
 
-/-- Coordinated entities: `λP. P(e₁) ∧ P(e₂)` -/
+/-- Coordinated entities: `λP. P(e₁) ∧ P(e₂)` — type-raise each entity
+via `Quantification.individual` and conjoin the quantifiers. -/
 def coordEntities {E W : Type} (e1 e2 : Denot E W .e) : Denot E W ((.e ⇒ .t) ⇒ .t) :=
-  genConj ((.e ⇒ .t) ⇒ .t) E W (typeRaise e1) (typeRaise e2)
-
-theorem typeRaise_preserves {E W : Type} (e : Denot E W .e) (p : Denot E W (.e ⇒ .t)) :
-    typeRaise e p = p e := rfl
+  genConj ((.e ⇒ .t) ⇒ .t) E W (individual e1) (individual e2)
 
 theorem coordEntities_both_satisfy {E W : Type} (e1 e2 : Denot E W .e)
     (p : Denot E W (.e ⇒ .t)) :
     coordEntities e1 e2 p = (p e1 ∧ p e2) := rfl
 
-end TypeRaising
+end EntityCoordination
 
 -- ════════════════════════════════════════════════════════════════
 -- § M&S Decomposition: ☉ + MU (INCL) + J
@@ -142,23 +139,25 @@ end TypeRaising
 
 DP conjunction decomposes into three operations:
 - ☉ (`msShift`): individual → singleton set (= Partee's `ident`)
-- MU (`typeRaise`): singleton set → GQ via subset inclusion (INCL)
+- MU (`Quantification.individual`): entity → GQ via subset inclusion (INCL)
 - J (`genConj`): generalized conjunction on GQs
 -/
 
 section MSDecomposition
 
+open Quantification (individual)
+
 /-- ☉: M&S type-shifter. Individual → singleton property. -/
 def msShift {E W : Type} (x : Denot E W .e) : Denot E W (.e ⇒ .t) :=
   λ y => x = y
 
-/-- MU particle semantics = typeRaise. -/
+/-- MU particle semantics = `Quantification.individual`. -/
 abbrev inclFunc {E W : Type} (x : Denot E W .e) : Denot E W ((.e ⇒ .t) ⇒ .t) :=
-  typeRaise x
+  individual x
 
 /-- Full M&S derivation: J(MU(e₁), MU(e₂)) = coordEntities e₁ e₂. -/
 theorem ms_full_derivation {E W : Type} (e1 e2 : Denot E W .e) :
-    genConj ((.e ⇒ .t) ⇒ .t) E W (typeRaise e1) (typeRaise e2) =
+    genConj ((.e ⇒ .t) ⇒ .t) E W (individual e1) (individual e2) =
     coordEntities e1 e2 := rfl
 
 end MSDecomposition

--- a/Linglib/Studies/BillEtAl2025.lean
+++ b/Linglib/Studies/BillEtAl2025.lean
@@ -43,10 +43,10 @@ alternative accounts.
 
 The M&S decomposition maps directly onto Montague/Conjunction.lean:
 - J = `genConj` (Partee & Rooth's generalized conjunction / set intersection)
-- MU = `typeRaise` (INCL on singletons = type-raising; structural `abbrev`)
+- MU = `individual` (INCL on singletons = type-raising; structural `abbrev`)
 - ☉ = `msShift` (individual → singleton set)
 
-`coordEntities` is defined AS `genConj(typeRaise e₁, typeRaise e₂)`,
+`coordEntities` is defined AS `genConj(individual e₁, individual e₂)`,
 so the M&S derivation is the definition itself, not a theorem.
 `mu_is_distributive_check` proves this equals Link's `distMaximal` on pairs.
 
@@ -469,17 +469,18 @@ The M&S decomposition maps onto operations in Montague/Conjunction.lean:
 | M&S piece | Semantic operation | Conjunction.lean |
 |-----------|-------------------|-----------------|
 | ☉         | {x} formation     | `msShift` (= Partee's `ident`) |
-| MU        | INCL (subset)     | `typeRaise` (structural `abbrev`) |
+| MU        | INCL (subset)     | `individual` (structural `abbrev`) |
 | J         | Set intersection  | `genConj` at GQ type |
 
-MU IS `typeRaise` — the identity is structural (an `abbrev`), not a
-theorem. `coordEntities` is defined AS `genConj(typeRaise e₁, typeRaise e₂)`,
+MU IS `individual` — the identity is structural (an `abbrev`), not a
+theorem. `coordEntities` is defined AS `genConj(individual e₁, individual e₂)`,
 so the M&S derivation is the definition itself. The result
 P(e₁) ∧ P(e₂) equals Link's `distMaximal P {e₁, e₂}`
 (`mu_is_distributive_check`).
 -/
 
 open Intensional.Conjunction in
+open Quantification (individual) in
 /--
 Type-raising an entity and checking subset inclusion of its singleton
 is equivalent to applying the predicate directly.
@@ -487,17 +488,18 @@ is equivalent to applying the predicate directly.
 This is the core of the M&S decomposition: the roundtrip through
 ☉ + MU + J recovers ordinary conjunction semantics.
 -/
-theorem typeRaise_incl_reduces {E W : Type} (e : E) (p : E → Prop) :
-    typeRaise (E := E) (W := W) e p = p e := rfl
+theorem individual_incl_reduces {E : Type} (e : E) (p : E → Prop) :
+    individual (α := E) e p = p e := rfl
 
 open Intensional.Conjunction in
+open Quantification (individual) in
 /--
 Full M&S derivation: "DP₁ and DP₂ VP" via ☉ + MU + J
 yields the same result as Partee & Rooth's `coordEntities`.
 -/
 theorem ms_decomposition_eq_coord {E W : Type} (e1 e2 : E)
     (p : E → Prop) :
-    (typeRaise (E := E) (W := W) e1 p ∧ typeRaise (E := E) (W := W) e2 p) =
+    (individual (α := E) e1 p ∧ individual (α := E) e2 p) =
       coordEntities (E := E) (W := W) e1 e2 p := rfl
 
 -- ============================================================================
@@ -513,11 +515,11 @@ individually and conjoin.
 
 | Framework | Operation | Result |
 |-----------|-----------|--------|
-| M&S       | J(typeRaise(e₁), typeRaise(e₂))(P) | P(e₁) ∧ P(e₂) |
+| M&S       | J(individual(e₁), individual(e₂))(P) | P(e₁) ∧ P(e₂) |
 | Link      | distMaximal P {e₁, e₂} w | P(e₁) ∧ P(e₂) |
 
-The M&S side is structural: `coordEntities` IS `genConj(typeRaise e₁,
-typeRaise e₂)` by definition, and MU IS `typeRaise` by `abbrev`.
+The M&S side is structural: `coordEntities` IS `genConj(individual e₁,
+individual e₂)` by definition, and MU IS `individual` by `abbrev`.
 The Link side is independently structural: `distMaximal` IS
 `decide (∀ a ∈ x, P a w)`.
 
@@ -527,7 +529,7 @@ are different — but it proves the same operation is being computed.
 
 This explains WHY MU particles are universally additive particles
 (`mu_additive_generalization`): additive "also/too" IS the distributive
-check on a single atom (`typeRaise e P = P e = distMaximal P {e}`).
+check on a single atom (`individual e P = P e = distMaximal P {e}`).
 Conjunction is the two-atom case. Link's `distr_atom_part` is the
 general case for arbitrary pluralities.
 -/
@@ -535,6 +537,7 @@ general case for arbitrary pluralities.
 section MUDistributivity
 
 open Intensional.Conjunction
+open Quantification (individual)
 open Semantics.Plurality
 open Semantics.Plurality.Distributivity
 
@@ -544,7 +547,7 @@ M&S conjunction = Link's distributive predication for pairs.
 `coordEntities e₁ e₂ P = distMaximal (fun a _ => P a) {e₁, e₂} ()`
 
 Both sides compute `P(e₁) ∧ P(e₂)`:
-- LHS by definition (`coordEntities` = `genConj(typeRaise e₁, typeRaise e₂)`)
+- LHS by definition (`coordEntities` = `genConj(individual e₁, individual e₂)`)
 - RHS by `distMaximal_pair`
 
 This can't be an `abbrev` — the types are different (Montague

--- a/Linglib/Studies/Champollion2016.lean
+++ b/Linglib/Studies/Champollion2016.lean
@@ -14,12 +14,12 @@ individuals folded into *and*; they are derived by silent type-shifters (Existen
 Choice Raising, Intersection, Minimization). Two results, both routing through the
 `Coordinator.op` API:
 
-* **The type-shift `⊔ ↦ ⊓` is guarded, not free.** Partee's lift `typeRaise : e → GQ`
+* **The type-shift `⊔ ↦ ⊓` is guarded, not free.** Montague's lift `individual : e → GQ`
   (`x ↦ λP. P x`) relates the individual-join `x ⊔ y` to the GQ-meet
   `Coordinator.op .j` (= `⊓`) of the raised individuals *exactly on the predicates that
-  distribute the join* (`typeRaise_join_eq_op_iff`). It is NOT a clean anti-homomorphism:
+  distribute the join* (`individual_join_eq_op_iff`). It is NOT a clean anti-homomorphism:
   for a **collective** predicate (`met`/`gather`) the two diverge
-  (`typeRaise_join_ne_op_collective`) — which is *why* Champollion needs Raising +
+  (`individual_join_ne_op_collective`) — which is *why* Champollion needs Raising +
   Minimization rather than reducing collectivity to raising + intersection. The guard is
   grounded in Link distributivity: Link's `ᴰ`-closed predicates satisfy it under
   join-prime atoms (`linkD_distributiveOverJoin`).
@@ -34,9 +34,9 @@ Choice Raising, Intersection, Minimization). Two results, both routing through t
 
 ## Main results
 
-* `typeRaise_join_eq_op_iff` — the type-shift `⊔ ↦ ⊓` holds at `P` iff `P` distributes the join.
-* `typeRaise_join_eq_op_of_distributive`, `linkD_distributiveOverJoin` — the guard is Link distributivity.
-* `collective_not_distributiveOverJoin`, `typeRaise_join_ne_op_of_not_distributive` — a collective predicate breaks the type-shift.
+* `individual_join_eq_op_iff` — the type-shift `⊔ ↦ ⊓` holds at `P` iff `P` distributes the join.
+* `individual_join_eq_op_of_distributive`, `linkD_distributiveOverJoin` — the guard is Link distributivity.
+* `collective_not_distributiveOverJoin`, `individual_join_ne_op_of_not_distributive` — a collective predicate breaks the type-shift.
 * `setProduct_overgenerates` — H&Z's set-product *and* gets *No man and no woman smiled* wrong; `op .j` gets it right.
 -/
 
@@ -44,6 +44,7 @@ namespace Champollion2016
 
 open Intensional
 open Intensional.Conjunction
+open Quantification (individual)
 open Semantics.Plurality.Algebra
 
 /-! ### The type-shift `⊔ ↦ ⊓` is guarded to distributive predicates
@@ -65,40 +66,40 @@ variable {E W : Type} [SemilatticeSup E]
 def DistributiveOverJoin {E : Type*} [SemilatticeSup E] (P : E → Prop) : Prop :=
   ∀ x y : E, P (x ⊔ y) ↔ (P x ∧ P y)
 
-/-- `typeRaise (x ⊔ y)` applied to `P` is `P (x ⊔ y)` (Montague's lift). -/
-theorem typeRaise_join_apply (x y : E) (P : E → Prop) :
-    typeRaise (W := W) (x ⊔ y : E) P = P (x ⊔ y : E) := rfl
+/-- `individual (x ⊔ y)` applied to `P` is `P (x ⊔ y)` (Montague's lift). -/
+theorem individual_join_apply (x y : E) (P : E → Prop) :
+    individual (x ⊔ y : E) P = P (x ⊔ y : E) := rfl
 
 omit [SemilatticeSup E] in
 /-- `coordEntities` (the intersective `and` of two raised individuals) IS the GQ-meet
     `Coordinator.op .j` — [champollion-2016-coordination]'s `INT` (eq. 16) as the
     Boolean `⊓` at the GQ type (flow-through bucket (a): `genConj` is `op`). -/
 theorem coordEntities_eq_opj (x y : E) :
-    coordEntities (W := W) x y = Coordinator.op .j (typeRaise x) (typeRaise y) := rfl
+    coordEntities (W := W) x y = Coordinator.op .j (individual x) (individual y) := rfl
 
 omit [SemilatticeSup E] in
 /-- The intersective `and` of two raised individuals applied to `P` is `P x ∧ P y`. The
     two-atom case of Link distributive predication: it equals `distMaximal P {x, y}` (see
     [bill-etal-2025] `mu_is_distributive_check`). -/
-theorem op_typeRaise_apply (x y : E) (P : E → Prop) :
-    Coordinator.op .j (typeRaise (W := W) x) (typeRaise (W := W) y) P = (P x ∧ P y) := rfl
+theorem op_individual_apply (x y : E) (P : E → Prop) :
+    Coordinator.op .j (individual x) (individual y) P = (P x ∧ P y) := rfl
 
 /-- **The type-shift `⊔ ↦ ⊓`, guarded.** Type-raising the individual-join `x ⊔ y` agrees
     with the GQ-meet `Coordinator.op .j` of the raised individuals *at `P`* iff `P`
     distributes this join. The bare anti-homomorphism (for all `P`) is therefore FALSE;
     distributivity is exactly the guard. -/
-theorem typeRaise_join_eq_op_iff (x y : E) (P : E → Prop) :
-    (typeRaise (W := W) (x ⊔ y : E) P
-        ↔ Coordinator.op .j (typeRaise (W := W) x) (typeRaise (W := W) y) P)
+theorem individual_join_eq_op_iff (x y : E) (P : E → Prop) :
+    (individual (x ⊔ y : E) P
+        ↔ Coordinator.op .j (individual x) (individual y) P)
       ↔ (P (x ⊔ y : E) ↔ (P x ∧ P y)) := Iff.rfl
 
-/-- For a distributive predicate the type-shift holds: `typeRaise (x ⊔ y)` agrees with the
+/-- For a distributive predicate the type-shift holds: `individual (x ⊔ y)` agrees with the
     GQ-meet on `P`. -/
-theorem typeRaise_join_eq_op_of_distributive (x y : E) {P : E → Prop}
+theorem individual_join_eq_op_of_distributive (x y : E) {P : E → Prop}
     (hP : DistributiveOverJoin P) :
-    typeRaise (W := W) (x ⊔ y : E) P
-      ↔ Coordinator.op .j (typeRaise (W := W) x) (typeRaise (W := W) y) P :=
-  (typeRaise_join_eq_op_iff x y P).mpr (hP x y)
+    individual (x ⊔ y : E) P
+      ↔ Coordinator.op .j (individual x) (individual y) P :=
+  (individual_join_eq_op_iff x y P).mpr (hP x y)
 
 /-- **The guard is Link distributivity.** A Link `ᴰ`-closed predicate `ᴰQ`
     ([link-1987]) distributes every join, given join-prime atoms ([link-1983]). So
@@ -118,27 +119,27 @@ theorem linkD_distributiveOverJoin {E : Type*} [SemilatticeSup E]
     · exact hy z h hAtom
 
 /-- A Link `ᴰ`-closed predicate licenses the type-shift `⊔ ↦ ⊓`. -/
-theorem typeRaise_join_eq_op_of_linkD (hJP : AtomJoinPrime E) (x y : E) (Q : E → Prop) :
-    typeRaise (W := W) (x ⊔ y : E) (D Q : E → Prop)
-      ↔ Coordinator.op .j (typeRaise (W := W) x) (typeRaise (W := W) y) (D Q : E → Prop) :=
-  typeRaise_join_eq_op_of_distributive x y (linkD_distributiveOverJoin hJP Q)
+theorem individual_join_eq_op_of_linkD (hJP : AtomJoinPrime E) (x y : E) (Q : E → Prop) :
+    individual (x ⊔ y : E) (D Q : E → Prop)
+      ↔ Coordinator.op .j (individual x) (individual y) (D Q : E → Prop) :=
+  individual_join_eq_op_of_distributive x y (linkD_distributiveOverJoin hJP Q)
 
 /-- **The guard is necessary, lifted to the type-shift.** A predicate that does NOT
     distribute the join breaks the `⊔ ↦ ⊓` agreement at the witnessing pair: there
-    `typeRaise (x ⊔ y)` and the GQ-meet `Coordinator.op .j` come apart. -/
-theorem typeRaise_join_ne_op_of_not_distributive {P : E → Prop}
+    `individual (x ⊔ y)` and the GQ-meet `Coordinator.op .j` come apart. -/
+theorem individual_join_ne_op_of_not_distributive {P : E → Prop}
     (h : ¬ DistributiveOverJoin P) :
-    ∃ x y : E, ¬ (typeRaise (W := W) (x ⊔ y : E) P
-                    ↔ Coordinator.op .j (typeRaise (W := W) x) (typeRaise (W := W) y) P) := by
+    ∃ x y : E, ¬ (individual (x ⊔ y : E) P
+                    ↔ Coordinator.op .j (individual x) (individual y) P) := by
   simp only [DistributiveOverJoin, not_forall] at h
   obtain ⟨x, y, hxy⟩ := h
-  exact ⟨x, y, fun hiff => hxy ((typeRaise_join_eq_op_iff x y P).mp hiff)⟩
+  exact ⟨x, y, fun hiff => hxy ((individual_join_eq_op_iff x y P).mp hiff)⟩
 
 end TypeShift
 
 /-- **A collective predicate breaks the guard.** True of the plural `{false, true}`
     (`John and Mary met`) but of neither part (`Finset Bool`, `∪` as `⊔`): this collective
-    predicate is not `DistributiveOverJoin`, so by `typeRaise_join_ne_op_of_not_distributive`
+    predicate is not `DistributiveOverJoin`, so by `individual_join_ne_op_of_not_distributive`
     it breaks the type-shift `⊔ ↦ ⊓`. This is why Champollion derives collectivity via
     silent Raising + Minimization rather than via raising + intersection. -/
 theorem collective_not_distributiveOverJoin :


### PR DESCRIPTION
Continues the Montague-lift dedup from #1732: `Intensional.Conjunction.typeRaise` was `Quantification.individual` verbatim (their equality bridge was already `rfl`). The def and its bridge theorem (`individual_eq_typeRaise`) are deleted; `coordEntities`, the Mitrović–Sauerland MU decomposition, and the Champollion 2016 / Bill et al. 2025 studies now reference `individual` directly (theorem names swept, e.g. `individual_join_eq_op_iff`).

Not dissolved, deliberately: `semPropName` (TTR's Type-valued carrier) and `barePluralTranslation` (Bool-valued) are lift at genuinely different carriers; CCG's `typeRaised` is an unrelated enum.