### PR TITLE
refactor(Semantics/Quantification): identification lemmas to carrier

### DIFF
--- a/Linglib/Semantics/Quantification/Quantifier.lean
+++ b/Linglib/Semantics/Quantification/Quantifier.lean
@@ -1,6 +1,8 @@
 import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Quantification.Basic
 import Linglib.Semantics.Quantification.Counting
+import Linglib.Semantics.Composition.Cont
+import Linglib.Semantics.Composition.Combinator
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Order.GaloisConnection.Defs
 
@@ -21,6 +23,22 @@ types are [partee-1987]'s, in `Semantics.Composition.TypeShifting`.
 namespace Quantification
 
 variable {E : Type}
+
+/-! ### The continuation identification
+
+These are `rfl`: the carrier definitionally coincides with the
+continuation monad at answer type `Prop`, first exploited for natural
+language by [barker-2002] (see `Studies/Barker2002.lean`). -/
+
+/-- The quantifier type is the continuation type: a quantifier is a
+computation handed its own scope. -/
+theorem quantifier_eq_cont : Quantifier E = Cont Prop E := rfl
+
+/-- Montague lift is the continuation monad's unit. -/
+theorem individual_eq_pure (a : E) : individual a = (pure a : Cont Prop E) := rfl
+
+/-- Montague lift is combinatory logic's type-raising combinator `T`. -/
+theorem individual_eq_T (a : E) : individual a = Combinator.T (β := Prop) a := rfl
 
 /-! ### Predicative content and existential closure -/
 

--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -1,47 +1,33 @@
-import Linglib.Semantics.Quantification.Defs
-import Linglib.Semantics.Composition.Cont
-import Linglib.Semantics.Composition.Combinator
+import Linglib.Studies.HeimKratzer1998
 
 /-!
 # Barker (2002): Continuations and the Nature of Quantification
 
-[barker-2002]'s thesis is an identification: the generalized-quantifier
-type is the continuation type. A quantificational noun phrase denotes a
-function on its own continuation, so quantification is what continuation
-passing looks like in natural language — no movement or storage needed.
-This study states the identification over linglib's carriers: `Quantifier`
-is `Cont Prop` definitionally, Montague lift (`individual`) is the monadic
-unit and the `T` combinator, and continuizing application in its two
-possible evaluation orders yields exactly the two scope readings of a
-transitive clause, which is the paper's account of scope ambiguity.
+[barker-2002]'s thesis is that the generalized-quantifier type is the
+continuation type — a fact the carrier states as
+`Quantification.quantifier_eq_cont` — and that this identification does
+real work: continuizing application and varying the evaluation order
+derives quantification in situ, with the two orders yielding the two
+scope readings of a transitive clause. This study carries out that
+derivation and checks the paper's coverage claim against movement: on the
+shared toy model, the two evaluation orders compute exactly the two
+propositions [heim-kratzer-1998]'s quantifier raising derives, with no
+movement and no storage.
 -/
 
 namespace Barker2002
 
-open Quantification (Quantifier individual)
+open Quantification (Quantifier individual every_sem some_sem)
+open Semantics.Montague
+open Semantics.Montague.ToyLexicon (person_sem)
 
 variable {α E : Type}
-
-/-! ### The identification -/
-
-/-- The generalized-quantifier type is the continuation type: a
-quantifier is a computation handed its own scope. -/
-theorem quantifier_eq_cont : Quantifier α = Cont Prop α := rfl
-
-/-- A proper name denotes its lifted individual, and lifting is the
-continuation monad's unit. -/
-theorem individual_eq_pure (a : α) : individual a = (pure a : Cont Prop α) := rfl
-
-/-- The same lift is combinatory logic's `T` (type-raising), closing the
-circle with the categorial tradition. -/
-theorem individual_eq_T (a : α) : individual a = Combinator.T (β := Prop) a := rfl
 
 /-! ### Scope ambiguity as evaluation order
 
 Continuized application can evaluate the function's or the argument's
-continuation first. The two orders are interdefinable choices, and on a
-transitive clause they deliver the two relative scopes — ambiguity
-without movement. -/
+continuation first. On a transitive clause the two orders deliver the
+two relative scopes — ambiguity without movement. -/
 
 /-- Continuized application, function's continuation first: the left
 quantifier takes wide scope. -/
@@ -65,11 +51,46 @@ theorem combineArgFirst_inverse (q₁ q₂ : Quantifier E) (rel : E → E → Pr
     ContT.lower (combineArgFirst (rel <$> (q₁ : Cont Prop E)) q₂) =
     q₂ (λ y => q₁ (λ x => rel x y)) := rfl
 
-/-- On lifted individuals the two orders agree — scope ambiguity is
-detectable only for genuine quantifiers, so continuizing the whole
-grammar is harmless for names. -/
+/-- On lifted individuals the two orders agree — continuizing the whole
+grammar is harmless for names; ambiguity is detectable only for genuine
+quantifiers. -/
 theorem combine_orders_agree_on_individuals (a b : E) (rel : E → E → Prop) :
     ContT.lower (combineFunFirst (rel <$> individual a) (individual b)) =
     ContT.lower (combineArgFirst (rel <$> individual a) (individual b)) := rfl
+
+/-! ### The same readings as movement
+
+The paper's coverage claim: in-situ continuized application derives
+exactly the readings quantifier raising derives. On the toy model of
+`Studies/HeimKratzer1998.lean`, the two evaluation orders of "every
+person sees some person" compute the two QR propositions on the nose. -/
+
+/-- Function-first evaluation computes QR's surface-scope proposition. -/
+theorem funFirst_eq_qr_surface :
+    ContT.lower (combineFunFirst
+      ((λ x y => ToyLexicon.sees_sem y x) <$>
+        (every_sem person_sem : Quantifier ToyEntity))
+      (some_sem person_sem)) = HeimKratzer1998.surfaceScopeProp := rfl
+
+/-- Argument-first evaluation computes QR's inverse-scope proposition. -/
+theorem argFirst_eq_qr_inverse :
+    ContT.lower (combineArgFirst
+      ((λ x y => ToyLexicon.sees_sem y x) <$>
+        (every_sem person_sem : Quantifier ToyEntity))
+      (some_sem person_sem)) = HeimKratzer1998.inverseScopeProp := rfl
+
+/-- The ambiguity is semantically real: the two evaluation orders yield
+genuinely different propositions on the toy model. -/
+theorem evaluation_orders_differ :
+    ContT.lower (combineFunFirst
+      ((λ x y => ToyLexicon.sees_sem y x) <$>
+        (every_sem person_sem : Quantifier ToyEntity))
+      (some_sem person_sem)) ≠
+    ContT.lower (combineArgFirst
+      ((λ x y => ToyLexicon.sees_sem y x) <$>
+        (every_sem person_sem : Quantifier ToyEntity))
+      (some_sem person_sem)) := by
+  rw [funFirst_eq_qr_surface, argFirst_eq_qr_inverse]
+  exact HeimKratzer1998.scope_readings_differ
 
 end Barker2002


### PR DESCRIPTION
Follow-up to #1734, per review: the three identification lemmas (`quantifier_eq_cont`, `individual_eq_pure`, `individual_eq_T`) are `rfl` facts about the carrier, not theoretical commitments — they move into `Quantifier.lean` where the definitions live (`Cont`/`Combinator` are cycle-free mathlib-veneer imports).

`Studies/Barker2002.lean` now does the paper's work instead of restating identities: the two evaluation orders of continuized application are proved to compute exactly [heim-kratzer-1998]'s two QR propositions on the shared toy model (`funFirst_eq_qr_surface`, `argFirst_eq_qr_inverse`, `evaluation_orders_differ`) — the paper's coverage-without-movement claim as theorems.