### PR TITLE
refactor(Studies): Barker2002 formalizes the paper's own fragment

### DIFF
--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -1,96 +1,208 @@
-import Linglib.Studies.HeimKratzer1998
+import Linglib.Semantics.Quantification.Defs
+import Linglib.Semantics.Composition.Cont
 
 /-!
 # Barker (2002): Continuations and the Nature of Quantification
 
-[barker-2002]'s thesis is that the generalized-quantifier type is the
-continuation type — a fact the carrier states as
-`Quantification.quantifier_eq_cont` — and that this identification does
-real work: continuizing application and varying the evaluation order
-derives quantification in situ, with the two orders yielding the two
-scope readings of a transitive clause. This study carries out that
-derivation and checks the paper's coverage claim against movement: on the
-shared toy model, the two evaluation orders compute exactly the two
-propositions [heim-kratzer-1998]'s quantifier raising derives, with no
-movement and no storage.
+Formalizes [barker-2002]'s continuized grammar. The Continuation
+Hypothesis (his (2)) is that quantificational NPs denote functions on
+their own continuations; continuizing an ordinary grammar (the schema in
+his (9)/(31)) then derives generalized quantifiers, in-situ scope
+displacement, and scope ambiguity, with no movement, storage, or
+type-shifting. This file follows the paper's own development: the arity-2
+instances of the Continuation Schema (his (35)), his grammar (10) with
+the quantificational entries (13) and the expository determiners (16),
+his worked derivations (11)–(17), the priority ambiguity of (18), his
+generalized coordination (30) with the examples in (27), and the §5
+Simulation Theorem with its Lemma, proved by the paper's own
+generalize-the-continuation argument.
+
+Not formalized: the Appendix's choice-function fragment ((39)–(41)),
+which retypes quantificational determiners over choice functions — the
+paper flags (15)/(16) as expository and the Appendix as the real
+fragment, so that half remains future work. Barker's transitive verbs
+take their object first (`saw m j` is "John saw Mary"); all statements
+below follow that convention.
 -/
 
 namespace Barker2002
 
-open Quantification (Quantifier individual every_sem some_sem)
-open Semantics.Montague
-open Semantics.Montague.ToyLexicon (person_sem)
+open Quantification (Quantifier individual)
 
-variable {α E : Type}
+variable {α β γ E : Type}
 
-/-! ### Scope ambiguity as evaluation order
+/-! ### The Continuation Schema at arity 2
 
-Continuized application can evaluate the function's or the argument's
-continuation first. On a transitive clause the two orders deliver the
-two relative scopes — ambiguity without movement. -/
+His (9)/(35): a lexical item continuizes to the unit `λb̄. b̄(⟦B⟧)` —
+the monadic `pure`, which at NP type is `Quantification.individual` —
+and a binary rule with direct meaning `M` continuizes to `n! = 2` rules,
+one per evaluation order. The daughter evaluated first takes PRIORITY
+(his term): its quantifiers take wide scope. -/
 
-/-- Continuized application, function's continuation first: the left
-quantifier takes wide scope. -/
-def combineFunFirst (mf : Cont Prop (α → Prop)) (mx : Cont Prop α) : Cont Prop Prop :=
-  mf <*> mx
+/-- The f-instance of the Continuation Schema (his (35)): priority to
+the first daughter. -/
+def priorityFirst (M : α → β → γ) (m₁ : Cont Prop α) (m₂ : Cont Prop β) :
+    Cont Prop γ :=
+  λ κ => m₁ (λ x₁ => m₂ (λ x₂ => κ (M x₁ x₂)))
 
-/-- Continuized application, argument's continuation first: the right
-quantifier takes wide scope. -/
-def combineArgFirst (mf : Cont Prop (α → Prop)) (mx : Cont Prop α) : Cont Prop Prop :=
-  λ κ => mx (λ x => mf (λ f => κ (f x)))
+/-- The g-instance of the Continuation Schema (his (35)): priority to
+the second daughter. -/
+def prioritySecond (M : α → β → γ) (m₁ : Cont Prop α) (m₂ : Cont Prop β) :
+    Cont Prop γ :=
+  λ κ => m₂ (λ x₂ => m₁ (λ x₁ => κ (M x₁ x₂)))
 
-/-- Function-first evaluation of a transitive clause is surface scope:
-the subject quantifier outscopes the object. -/
-theorem combineFunFirst_surface (q₁ q₂ : Quantifier E) (rel : E → E → Prop) :
-    ContT.lower (combineFunFirst (rel <$> (q₁ : Cont Prop E)) q₂) =
-    q₁ (λ x => q₂ (λ y => rel x y)) := rfl
+/-- Linglib note (not in the paper): the f-schema is the applicative
+combination on `Cont Prop`, connecting Barker's rules to the substrate's
+`lower_*` lemmas. -/
+theorem priorityFirst_eq_seq (M : α → β → γ) (m₁ : Cont Prop α) (m₂ : Cont Prop β) :
+    priorityFirst M m₁ m₂ = M <$> m₁ <*> m₂ := rfl
 
-/-- Argument-first evaluation of the same clause is inverse scope: the
-object quantifier outscopes the subject. -/
-theorem combineArgFirst_inverse (q₁ q₂ : Quantifier E) (rel : E → E → Prop) :
-    ContT.lower (combineArgFirst (rel <$> (q₁ : Cont Prop E)) q₂) =
-    q₂ (λ y => q₁ (λ x => rel x y)) := rfl
+/-! ### The grammar
 
-/-- On lifted individuals the two orders agree — continuizing the whole
-grammar is harmless for names; ambiguity is detectable only for genuine
-quantifiers. -/
-theorem combine_orders_agree_on_individuals (a b : E) (rel : E → E → Prop) :
-    ContT.lower (combineFunFirst (rel <$> individual a) (individual b)) =
-    ContT.lower (combineArgFirst (rel <$> individual a) (individual b)) := rfl
+His (10): `S → NP VP` interprets as `⟦VP⟧(⟦NP⟧)` and `VP → Vt NP` as
+`⟦Vt⟧(⟦NP⟧)`. Rule (10a) gives the VP priority (= his (18a)); (18b) is
+the same syntax with subject priority. (10b) gives the verb priority. -/
 
-/-! ### The same readings as movement
+/-- His (10a)/(18a): the S rule with VP priority — VP-internal
+quantifiers outscope the subject. -/
+def sRuleVP (np : Cont Prop E) (vp : Cont Prop (E → Prop)) : Cont Prop Prop :=
+  prioritySecond (λ x P => P x) np vp
 
-The paper's coverage claim: in-situ continuized application derives
-exactly the readings quantifier raising derives. On the toy model of
-`Studies/HeimKratzer1998.lean`, the two evaluation orders of "every
-person sees some person" compute the two QR propositions on the nose. -/
+/-- His (18b): the S rule with subject priority — the subject takes
+wide scope. -/
+def sRuleNP (np : Cont Prop E) (vp : Cont Prop (E → Prop)) : Cont Prop Prop :=
+  priorityFirst (λ x P => P x) np vp
 
-/-- Function-first evaluation computes QR's surface-scope proposition. -/
-theorem funFirst_eq_qr_surface :
-    ContT.lower (combineFunFirst
-      ((λ x y => ToyLexicon.sees_sem y x) <$>
-        (every_sem person_sem : Quantifier ToyEntity))
-      (some_sem person_sem)) = HeimKratzer1998.surfaceScopeProp := rfl
+/-- His (10b): the VP rule, verb priority. -/
+def vpRule (vt : Cont Prop (E → E → Prop)) (np : Cont Prop E) :
+    Cont Prop (E → Prop) :=
+  priorityFirst (λ R x => R x) vt np
 
-/-- Argument-first evaluation computes QR's inverse-scope proposition. -/
-theorem argFirst_eq_qr_inverse :
-    ContT.lower (combineArgFirst
-      ((λ x y => ToyLexicon.sees_sem y x) <$>
-        (every_sem person_sem : Quantifier ToyEntity))
-      (some_sem person_sem)) = HeimKratzer1998.inverseScopeProp := rfl
+/-- His (13a): *everyone* wraps a universal around its continuation. -/
+def everyone : Quantifier E := λ k => ∀ x, k x
 
-/-- The ambiguity is semantically real: the two evaluation orders yield
-genuinely different propositions on the toy model. -/
-theorem evaluation_orders_differ :
-    ContT.lower (combineFunFirst
-      ((λ x y => ToyLexicon.sees_sem y x) <$>
-        (every_sem person_sem : Quantifier ToyEntity))
-      (some_sem person_sem)) ≠
-    ContT.lower (combineArgFirst
-      ((λ x y => ToyLexicon.sees_sem y x) <$>
-        (every_sem person_sem : Quantifier ToyEntity))
-      (some_sem person_sem)) := by
-  rw [funFirst_eq_qr_surface, argFirst_eq_qr_inverse]
-  exact HeimKratzer1998.scope_readings_differ
+/-- His (13b): *someone* wraps an existential around its continuation. -/
+def someone : Quantifier E := λ k => ∃ x, k x
+
+/-- His (16): expository *every* — takes a continuized nominal, returns
+an NP meaning. (The paper's real fragment retypes determiners over
+choice functions, his (39); not formalized here.) -/
+def everyDet (n : Cont Prop (E → Prop)) : Quantifier E :=
+  λ k => n (λ P => ∀ x, P x → k x)
+
+/-- His (16): expository *a*/*some*. -/
+def aDet (n : Cont Prop (E → Prop)) : Quantifier E :=
+  λ k => n (λ P => ∃ x, P x ∧ k x)
+
+/-! ### The worked derivations
+
+The paper evaluates sentences by "applying to the trivial continuation"
+`λp.p` (his (12)) — the substrate's `ContT.lower`. -/
+
+variable (j m : E) (left' slept' man' woman' : E → Prop) (saw' : E → E → Prop)
+
+/-- His (11)–(12): *John left* evaluates to `left j`. -/
+theorem john_left :
+    ContT.lower (sRuleVP (individual j) (pure left')) = left' j := rfl
+
+/-- p. 220: *Everyone left* "smoothly evaluates to `∀x. left x`". -/
+theorem everyone_left :
+    ContT.lower (sRuleVP everyone (pure left')) = ∀ x, left' x := rfl
+
+/-- His (14): *John saw everyone* evaluates to `∀x. saw x j` — in situ,
+with "no type clash or asymmetry between quantificational NPs occurring
+in subject and non-subject positions". -/
+theorem john_saw_everyone :
+    ContT.lower (sRuleVP (individual j) (vpRule (pure saw') everyone)) =
+    ∀ x, saw' x j := rfl
+
+/-- His (17c): *Every man saw a woman* under the VP-priority S rule is
+**inverse** scope, `∃y. woman y ∧ ∀x. man x → saw y x` — the paper's
+demonstration that "nothing in the continuation mechanism itself biases
+towards linear scope or inverse scope". -/
+theorem every_man_saw_a_woman_inverse :
+    ContT.lower (sRuleVP (everyDet (pure man'))
+      (vpRule (pure saw') (aDet (pure woman')))) =
+    ∃ y, woman' y ∧ ∀ x, man' x → saw' y x := rfl
+
+/-- His §2.4: the same sentence under the subject-priority rule (18b) is
+surface scope. (The paper derives this reading via (18b) but does not
+print the formula.) -/
+theorem every_man_saw_a_woman_surface :
+    ContT.lower (sRuleNP (everyDet (pure man'))
+      (vpRule (pure saw') (aDet (pure woman')))) =
+    ∀ x, man' x → ∃ y, woman' y ∧ saw' y x := rfl
+
+/-! ### Generalized coordination (§4)
+
+His (30): *and* "distributes the continuation belonging to the
+coordinate structure across the conjuncts" — one rule for every
+category, with no conjoinable-type recursion. -/
+
+/-- His (30): coordination at any category. -/
+def coord (l r : Cont Prop α) : Cont Prop α := λ k => l k ∧ r k
+
+/-- His (27b): *John left and slept*. -/
+theorem john_left_and_slept :
+    ContT.lower (sRuleVP (individual j) (coord (pure left') (pure slept'))) =
+    (left' j ∧ slept' j) := rfl
+
+/-- His (27d): *John and Mary left* — NP coordination through the same
+rule. -/
+theorem john_and_mary_left :
+    ContT.lower (sRuleVP (coord (individual j) (individual m)) (pure left')) =
+    (left' j ∧ left' m) := rfl
+
+/-! ### The Simulation Theorem (§5)
+
+Continuization is conservative: on schema-derived meanings, evaluation
+at the trivial continuation recovers the direct meaning, for **every**
+choice of priority. The paper proves this via a Lemma generalizing the
+trivial continuation to an arbitrary one — `m̂(λx.g(x)) = g(m)` — and
+we follow that proof shape: the lexical case is definitional, and each
+binary case discharges the daughters' hypotheses from the innermost
+continuation out. -/
+
+/-- §5's Lemma, lexical case: the unit satisfies `m̂(g) = g(m)`. -/
+theorem simulation_pure (a : α) (g : α → Prop) :
+    (pure a : Cont Prop α) g = g a := rfl
+
+/-- §5's Lemma, arity-2 f-case: if both daughters simulate their direct
+meanings, so does their priority-first combination. -/
+theorem simulation_priorityFirst (M : α → β → γ) {c₁ : Cont Prop α}
+    {c₂ : Cont Prop β} {m₁ : α} {m₂ : β}
+    (h₁ : ∀ g, c₁ g = g m₁) (h₂ : ∀ g, c₂ g = g m₂) :
+    ∀ g, priorityFirst M c₁ c₂ g = g (M m₁ m₂) := by
+  intro g
+  show c₁ _ = _
+  rw [h₁]
+  exact h₂ _
+
+/-- §5's Lemma, arity-2 g-case. -/
+theorem simulation_prioritySecond (M : α → β → γ) {c₁ : Cont Prop α}
+    {c₂ : Cont Prop β} {m₁ : α} {m₂ : β}
+    (h₁ : ∀ g, c₁ g = g m₁) (h₂ : ∀ g, c₂ g = g m₂) :
+    ∀ g, prioritySecond M c₁ c₂ g = g (M m₁ m₂) := by
+  intro g
+  show c₂ _ = _
+  rw [h₂]
+  exact h₁ _
+
+/-- §5's order-independence: on simulating daughters the two priorities
+agree — "the result is the same, in the absence of quantification". The
+quantificational entries (13) are exactly the meanings that break the
+hypotheses, which is the paper's own delimitation of the theorem. -/
+theorem simulation_orders_agree (M : α → β → γ) {c₁ : Cont Prop α}
+    {c₂ : Cont Prop β} {m₁ : α} {m₂ : β}
+    (h₁ : ∀ g, c₁ g = g m₁) (h₂ : ∀ g, c₂ g = g m₂) :
+    priorityFirst M c₁ c₂ = prioritySecond M c₁ c₂ := by
+  funext g
+  rw [simulation_priorityFirst M h₁ h₂ g, simulation_prioritySecond M h₁ h₂ g]
+
+/-- §5's Simulation Theorem: a simulating sentence meaning evaluates at
+the trivial continuation to its direct meaning. -/
+theorem simulation (c : Cont Prop Prop) (p : Prop) (h : ∀ g, c g = g p) :
+    ContT.lower c = p :=
+  h id
 
 end Barker2002


### PR DESCRIPTION
Per review: a study file does exactly what the paper does. The linglib-fixture comparison section is replaced by the paper's own content, formalized from the full text (all example numbers verified against it):

- The Continuation Schema at arity 2 (his (35)) as `priorityFirst`/`prioritySecond`, with his grammar (10), quantificational entries (13), and expository determiners (16) — the Appendix's choice-function fragment is flagged as not formalized.
- His worked derivations by `rfl`: (11)–(12), *Everyone left* (p. 220), (14), and (17c) — inverse scope, as the paper prints it — plus the surface reading the paper derives via (18b) but never prints, marked as such.
- Generalized coordination (30) with examples (27b)/(27d).
- The §5 Simulation Theorem and its Lemma, proved by the paper's own generalize-the-continuation argument; `simulation_orders_agree` is his "the result is the same, in the absence of quantification", with the quantificational entries as the paper's own delimitation.
- Object-first verb convention (`saw m j`) preserved throughout; one linglib-attributed note connects the f-schema to the substrate's applicative combination.