### PR TITLE
feat(Studies): Barker 2002 scope islands; his island rule is reset

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -48,7 +48,8 @@ def lower [Pure m] (c : ContT r m r) : m r := c.run pure
   bind_pure x
 
 /-- Lower, then re-lift: `reset c = monadLift (lower c)` —
-[charlow-2014]'s Reset, after [danvy-filinski-1990]. -/
+[charlow-2014]'s Reset, after [danvy-filinski-1990]; [barker-2002]'s
+scope-island rule is an instance. -/
 def reset {r' : Type u} [Monad m] (c : ContT r m r) : ContT r' m r :=
   monadLift (lower c)
 

--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -133,6 +133,56 @@ theorem every_man_saw_a_woman_surface :
       (vpRule (pure saw') (aDet (pure woman')))) =
     ∀ x, man' x → ∃ y, woman' y ∧ saw' y x := rfl
 
+/-! ### Bounding scope displacement (§2.5)
+
+His (20b) adjusts the S rule so that the clause's continuation applies
+to the already-evaluated clause: quantifiers inside can no longer see
+material outside. The adjustment "can only be made for syntactic
+categories whose direct (i.e., uncontinuized) type is t". -/
+
+/-- His (20b): the island-adjusted S rule — the clause's continuation
+applies to the evaluated clause. -/
+def sRuleIsland (np : Cont Prop E) (vp : Cont Prop (E → Prop)) : Cont Prop Prop :=
+  λ p => p (sRuleVP np vp id)
+
+/-- Linglib note (not in the paper): (20b) is the substrate's
+`ContT.reset` — lower the clause, then re-lift it. -/
+theorem sRuleIsland_eq_reset (np : Cont Prop E) (vp : Cont Prop (E → Prop)) :
+    sRuleIsland np vp = ContT.reset (sRuleVP np vp) := rfl
+
+/-- The island output simulates its evaluated clause in the §5 sense:
+what escapes an island is a value, never a scope-taker. -/
+theorem sRuleIsland_simulates (np : Cont Prop E) (vp : Cont Prop (E → Prop)) :
+    ∀ g, sRuleIsland np vp g = g (ContT.lower (sRuleVP np vp)) :=
+  λ _ => rfl
+
+/-- The Appendix's `VP → Vs S` rule, verb priority: `⟦Vs⟧(⟦S⟧)`. -/
+def vsRule (vs : Cont Prop (Prop → E → Prop)) (s : Cont Prop Prop) :
+    Cont Prop (E → Prop) :=
+  priorityFirst (λ T p => T p) vs s
+
+variable (thought' : Prop → E → Prop)
+
+/-- His (21): *A man thought everyone saw Mary* with the embedded clause
+islanded evaluates to his (21b), `∃y. man y ∧ thought(∀x. saw m x) y` —
+*everyone* "is not able to take scope outside of the embedded clause". -/
+theorem a_man_thought_everyone_saw_mary :
+    ContT.lower (sRuleVP (aDet (pure man'))
+      (vsRule (pure thought')
+        (sRuleIsland everyone (vpRule (pure saw') (individual m))))) =
+    ∃ y, man' y ∧ thought' (∀ x, saw' m x) y := rfl
+
+/-- Clause-boundedness sharpened: with the embedded clause islanded, the
+matrix priority choice is inert — his "all scopings of (21a) are
+logically equivalent to (21b)". -/
+theorem thought_island_priority_inert :
+    sRuleNP (aDet (pure man'))
+      (vsRule (pure thought')
+        (sRuleIsland everyone (vpRule (pure saw') (individual m)))) =
+    sRuleVP (aDet (pure man'))
+      (vsRule (pure thought')
+        (sRuleIsland everyone (vpRule (pure saw') (individual m)))) := rfl
+
 /-! ### Generalized coordination (§4)
 
 His (30): *and* "distributes the continuation belonging to the


### PR DESCRIPTION
Continues #1736 with the paper's §2.5: the island-adjusted S rule (his (20b)) as `sRuleIsland`, his clause-boundedness example (21) evaluating to the printed (21b) by `rfl` (*A man thought everyone saw Mary* — *everyone* trapped), and `thought_island_priority_inert` for his "all scopings are logically equivalent" claim.

Substrate implication, recorded both ways: (20b) is definitionally `ContT.reset` (`sRuleIsland_eq_reset`), so the delimiter landed from Charlow 2014 has an NL instance already in the founding 2002 paper — one clause added to `reset`'s docstring. `sRuleIsland_simulates` ties islands to the §5 Simulation machinery: what escapes an island is a value, never a scope-taker.