### PR TITLE
refactor(Semantics/Composition): rename ContT.lower to ContT.eval

### DIFF
--- a/Linglib/Semantics/Composition/Cont.lean
+++ b/Linglib/Semantics/Composition/Cont.lean
@@ -3,12 +3,12 @@ import Mathlib.Control.Monad.Cont
 /-!
 # Evaluating continuation computations
 
-`ContT.lower` finishes a continuation computation by handing it the
+`ContT.eval` finishes a continuation computation by handing it the
 trivial continuation `pure` — [charlow-2014]'s Lowering, Haskell's
-`evalCont`, the LOWER of [barker-shan-2014]. The `lower_*` simp lemmas
+`evalCont`, the LOWER of [barker-shan-2014]. The `eval_*` simp lemmas
 mirror `ContT`'s `run_*` set: a chain of binds evaluates in bind order
 and the applicative combination left-to-right, which is what lets bind
-order model quantifier scope. `ContT.reset` lowers and then re-lifts,
+order model quantifier scope. `ContT.reset` evaluates and re-lifts,
 delimiting scope the way scope islands do. For the linguistic
 applications see `Studies/BumfordCharlow2024.lean` and
 `Studies/Charlow2020.lean`.
@@ -24,48 +24,48 @@ namespace ContT
 
 variable {r α β : Type u} {m : Type u → Type v}
 
-/-- Evaluation at the trivial continuation: `lower c = c.run pure`. -/
-def lower [Pure m] (c : ContT r m r) : m r := c.run pure
+/-- Evaluation at the trivial continuation: `eval c = c.run pure`. -/
+def eval [Pure m] (c : ContT r m r) : m r := c.run pure
 
 /-! ### Interaction with the monad operations -/
 
-@[simp] theorem lower_pure [Pure m] (a : r) :
-    lower (pure a : ContT r m r) = pure a := rfl
+@[simp] theorem eval_pure [Pure m] (a : r) :
+    eval (pure a : ContT r m r) = pure a := rfl
 
-@[simp] theorem lower_bind [Pure m] (c : ContT r m α) (f : α → ContT r m r) :
-    lower (c >>= f) = c.run λ x => lower (f x) := rfl
+@[simp] theorem eval_bind [Pure m] (c : ContT r m α) (f : α → ContT r m r) :
+    eval (c >>= f) = c.run λ x => eval (f x) := rfl
 
-@[simp] theorem lower_map [Pure m] (f : α → r) (c : ContT r m α) :
-    lower (f <$> c) = c.run λ x => pure (f x) := rfl
+@[simp] theorem eval_map [Pure m] (f : α → r) (c : ContT r m α) :
+    eval (f <$> c) = c.run λ x => pure (f x) := rfl
 
-@[simp] theorem lower_seq [Pure m] (mf : ContT r m (α → r)) (mx : ContT r m α) :
-    lower (mf <*> mx) = mf.run λ f => mx.run λ x => pure (f x) := rfl
+@[simp] theorem eval_seq [Pure m] (mf : ContT r m (α → r)) (mx : ContT r m α) :
+    eval (mf <*> mx) = mf.run λ f => mx.run λ x => pure (f x) := rfl
 
-/-! ### Lowering lifted computations -/
+/-! ### Evaluating lifted computations -/
 
-@[simp] theorem lower_monadLift [Monad m] [LawfulMonad m] (x : m r) :
-    lower (monadLift x : ContT r m r) = x :=
+@[simp] theorem eval_monadLift [Monad m] [LawfulMonad m] (x : m r) :
+    eval (monadLift x : ContT r m r) = x :=
   bind_pure x
 
-/-- Lower, then re-lift: `reset c = monadLift (lower c)` —
+/-- Evaluate, then re-lift: `reset c = monadLift (eval c)` —
 [charlow-2014]'s Reset, after [danvy-filinski-1990]; [barker-2002]'s
 scope-island rule is an instance. -/
 def reset {r' : Type u} [Monad m] (c : ContT r m r) : ContT r' m r :=
-  monadLift (lower c)
+  monadLift (eval c)
 
 /-- `reset` is transparent to lifted effects: effects escape islands,
 scope-takers do not. -/
 theorem reset_monadLift {r' : Type u} [Monad m] [LawfulMonad m] (x : m r) :
     reset (monadLift x : ContT r m r) = (monadLift x : ContT r' m r) :=
-  congrArg monadLift (lower_monadLift x)
+  congrArg monadLift (eval_monadLift x)
 
-/-- Lifting, combining, and lowering is just combining in `m`:
+/-- Lifting, combining, and evaluating is just combining in `m`:
 scopal combination subsumes applicative combination. -/
-theorem lower_seq_monadLift [Monad m] [LawfulMonad m]
+theorem eval_seq_monadLift [Monad m] [LawfulMonad m]
     (f : α → β → r) (x : m α) (y : m β) :
-    lower (f <$> (monadLift x : ContT r m α) <*> monadLift y) =
+    eval (f <$> (monadLift x : ContT r m α) <*> monadLift y) =
     f <$> x <*> y := by
-  simp only [lower, seq_eq_bind_map, bind_map_left, run_bind, run_map,
+  simp only [eval, seq_eq_bind_map, bind_map_left, run_bind, run_map,
     run_monadLift, Function.comp_def, bind_pure_comp]
 
 end ContT

--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -62,7 +62,7 @@ def aDet (n : Cont Prop (E → Prop)) : Quantifier E :=
 /-! ### The worked derivations
 
 Sentences evaluate by applying the trivial continuation `λp.p` — the
-substrate's `ContT.lower`. Nothing biases toward linear or inverse
+substrate's `ContT.eval`. Nothing biases toward linear or inverse
 scope: *Every man saw a woman* gets its inverse reading under VP
 priority (the reading the paper prints) and its surface reading under
 subject priority. -/
@@ -71,26 +71,26 @@ variable (j m : E) (left' slept' man' woman' : E → Prop) (saw' : E → E → P
 
 /-- *John left*. -/
 theorem john_left :
-    ContT.lower (sRuleVP (individual j) (pure left')) = left' j := rfl
+    ContT.eval (sRuleVP (individual j) (pure left')) = left' j := rfl
 
 /-- *Everyone left*. -/
 theorem everyone_left :
-    ContT.lower (sRuleVP everyone (pure left')) = ∀ x, left' x := rfl
+    ContT.eval (sRuleVP everyone (pure left')) = ∀ x, left' x := rfl
 
 /-- *John saw everyone*, in situ. -/
 theorem john_saw_everyone :
-    ContT.lower (sRuleVP (individual j) (vpRule (pure saw') everyone)) =
+    ContT.eval (sRuleVP (individual j) (vpRule (pure saw') everyone)) =
     ∀ x, saw' x j := rfl
 
 /-- *Every man saw a woman*, VP priority: the inverse reading. -/
 theorem every_man_saw_a_woman_inverse :
-    ContT.lower (sRuleVP (everyDet (pure man'))
+    ContT.eval (sRuleVP (everyDet (pure man'))
       (vpRule (pure saw') (aDet (pure woman')))) =
     ∃ y, woman' y ∧ ∀ x, man' x → saw' y x := rfl
 
 /-- *Every man saw a woman*, subject priority: the surface reading. -/
 theorem every_man_saw_a_woman_surface :
-    ContT.lower (sRuleNP (everyDet (pure man'))
+    ContT.eval (sRuleNP (everyDet (pure man'))
       (vpRule (pure saw') (aDet (pure woman')))) =
     ∀ x, man' x → ∃ y, woman' y ∧ saw' y x := rfl
 
@@ -116,7 +116,7 @@ variable (thought' : Prop → E → Prop)
 /-- *A man thought everyone saw Mary*: *everyone* is trapped in the
 complement. -/
 theorem a_man_thought_everyone_saw_mary :
-    ContT.lower (sRuleVP (aDet (pure man'))
+    ContT.eval (sRuleVP (aDet (pure man'))
       (vsRule (pure thought')
         (sRuleIsland everyone (vpRule (pure saw') (individual m))))) =
     ∃ y, man' y ∧ thought' (∀ x, saw' m x) y := rfl
@@ -138,12 +138,12 @@ def coord (l r : Cont Prop α) : Cont Prop α := λ k => l k ∧ r k
 
 /-- *John left and slept*. -/
 theorem john_left_and_slept :
-    ContT.lower (sRuleVP (individual j) (coord (pure left') (pure slept'))) =
+    ContT.eval (sRuleVP (individual j) (coord (pure left') (pure slept'))) =
     (left' j ∧ slept' j) := rfl
 
 /-- *John and Mary left*. -/
 theorem john_and_mary_left :
-    ContT.lower (sRuleVP (coord (individual j) (individual m)) (pure left')) =
+    ContT.eval (sRuleVP (coord (individual j) (individual m)) (pure left')) =
     (left' j ∧ left' m) := rfl
 
 /-! ### The Simulation Theorem
@@ -153,7 +153,7 @@ the trivial continuation to its direct meaning, under either priority.
 The paper's "simulating" hypothesis — `c g = g m` for every
 continuation `g` — says exactly that `c` is the unit
 (`simulating_iff`), so its Lemma is the applicative unit laws and its
-Theorem is the substrate's `lower_*` simp set; the quantificational
+Theorem is the substrate's `eval_*` simp set; the quantificational
 entries are exactly the non-units. -/
 
 /-- Simulating in the paper's sense is being a unit. -/
@@ -169,6 +169,6 @@ theorem simulation_orders_agree (M : α → β → γ) (m₁ : α) (m₂ : β) :
 /-- A schema-derived sentence evaluates at the trivial continuation to
 its direct meaning. -/
 theorem simulation (M : α → β → Prop) (m₁ : α) (m₂ : β) :
-    ContT.lower (M <$> (pure m₁ : Cont Prop α) <*> pure m₂) = M m₁ m₂ := rfl
+    ContT.eval (M <$> (pure m₁ : Cont Prop α) <*> pure m₂) = M m₁ m₂ := rfl
 
 end Barker2002

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -64,7 +64,7 @@ S&B substrate in linglib yet.
 
 ## Implementation notes
 
-Scope-as-bind-order rests on `ContT.lower` (`Composition/Cont.lean`);
+Scope-as-bind-order rests on `ContT.eval` (`Composition/Cont.lean`);
 the §6 agreements are definitional instances of its `lower_*` laws.
 The eject combinators (`Ū`/`Ũ`/`⊿`) of Figure 10 are not formalized.
 -/
@@ -91,7 +91,7 @@ The W effect is mathlib's `Writer (List P)` (= `WriterT (List P) Id`), whose
 `Functor`/`Applicative`/`Monad` instances come from mathlib, with
 `LawfulMonad` and the `val`/`log`/`tell` surface in
 `Composition/Writer.lean`. The `Cont R` monad is mathlib's
-(`Mathlib.Control.Monad.Cont`); its linguistics surface (`ContT.lower`)
+(`Mathlib.Control.Monad.Cont`); its linguistics surface (`ContT.eval`)
 lives in `Composition/Cont.lean`. -/
 
 -- ════════════════════════════════════════════════════════════════════
@@ -431,7 +431,7 @@ linglib infrastructure to the effect/handler pattern.
 - `aside`: Log a CI proposition (= `Writer.tell`)
 
 **Handlers** (eliminate computational context):
-- `handleScope`: Lower a `Cont` to its result (= `ContT.lower`)
+- `handleScope`: Lower a `Cont` to its result (= `ContT.eval`)
 - `handleCI`: Extract at-issue value and CI log from `Writer` -/
 
 section EffectOps
@@ -442,8 +442,8 @@ variable {R : Type} {P : Type} {α : Type}
 def aside (p : P) : Writer (List P) Unit := Writer.tell p
 
 /-- Handle the scope effect by evaluating with the identity continuation.
-    Alias for `ContT.lower`. -/
-def handleScope (m : Cont R R) : R := ContT.lower m
+    Alias for `ContT.eval`. -/
+def handleScope (m : Cont R R) : R := ContT.eval m
 
 /-- Handle CI effects by extracting the value and accumulated log. -/
 def handleCI (m : Writer (List P) α) : α × List P := (m.val, m.log)
@@ -483,7 +483,7 @@ Connect the effect framework to existing linglib constructions, proving
 that independently-developed linglib modules are instances of the
 effect-driven architecture. The W and C effects need no bridge:
 `Writer`'s monadic application is mathlib's `<*>`, and
-`handleScope := ContT.lower` by definition. -/
+`handleScope := ContT.eval` by definition. -/
 
 section CIBridge
 
@@ -847,14 +847,14 @@ application by definition.
 Scope ambiguity in the Cont framework is not a special mechanism: it is
 the *order of monadic bind*. Surface scope = bind the subject first;
 inverse scope = bind the object first. The bind order IS the scope order,
-and `lower` IS GQ application.
+and `eval` IS GQ application.
 
 This establishes Cont as a *general* scope framework, with QR trees as
 one particular syntax for specifying bind order. -/
 
 section GeneralScopeAgreement
 
-/-! The generic scope-as-bind-order facts are the `ContT.lower_*` simp
+/-! The generic scope-as-bind-order facts are the `ContT.eval_*` simp
 set in `Composition/Cont.lean`; the §6 theorems above are definitional
 instances. What remains here is the bridge to QR trees. -/
 
@@ -875,7 +875,7 @@ theorem qr_cont_structural_agreement {E W : Type}
     (q : Cont Prop E)
     (body : DenotG E W .t) (n : Nat) (g : Core.Assignment E) :
     q (lambdaAbsG n body g) =
-    ContT.lower (q >>= λ x => pure (body (g[n ↦ x]))) := rfl
+    ContT.eval (q >>= λ x => pure (body (g[n ↦ x]))) := rfl
 
 end GeneralScopeAgreement
 

--- a/Linglib/Studies/Charlow2020.lean
+++ b/Linglib/Studies/Charlow2020.lean
@@ -166,12 +166,12 @@ quantifiers do. -/
 def setToCont {A : Type} (m : Set A) : Cont Prop A := λ κ => ∃ x, x ∈ m ∧ κ x
 
 /-- **↓ is LOWER through the Set→Cont morphism**: existential closure of
-a proposition set is exactly lowering (`ContT.lower`) its continuized
+a proposition set is exactly lowering (`ContT.eval`) its continuized
 image. The tree's two scope-effect carriers — `Set` for alternatives
 ([charlow-2020]), `Cont` for quantifier scope — share one evaluation
 operation. -/
-theorem lower_setToCont (m : Set Prop) :
-    ContT.lower (setToCont m) = existsClosure m := rfl
+theorem eval_setToCont (m : Set Prop) :
+    ContT.eval (setToCont m) = existsClosure m := rfl
 
 /-! ### §4 Bridge to `Studies/Charlow2018.lean`
 


### PR DESCRIPTION
`eval` is the library-normal name: it completes mtl's `runContT`/`evalContT` pairing with mathlib's `run`, matches mathlib's evaluation vocabulary, and frees `lower` from the order-theoretic reading (`lowerBounds`) it would carry upstream. The continuation-semantics name LOWER stays in the docstring, as the literature gloss — the same division as `individual`/Montague lift. Simp set renamed `eval_*`; three consumer studies swept.