### PR TITLE
feat(Studies): Barker 2002 Appendix choice-function determiners

### DIFF
--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -14,8 +14,10 @@ boundedness, generalized coordination, and the Simulation Theorem,
 following the paper's own proof. Barker's transitive verbs take the
 object first: `saw m j` is "John saw Mary".
 
-The Appendix's choice-function fragment is not formalized; the
-determiners here are the ones the paper marks as expository.
+The earlier derivations use the determiners the paper marks as
+expository; the Appendix's choice-function determiners and their
+four-reading prediction for *Someone saw a friend of everyone* close
+the file. The *the friend of* chains are not formalized.
 -/
 
 namespace Barker2002
@@ -161,14 +163,76 @@ theorem simulating_iff {c : Cont Prop α} {a : α} :
     (∀ g, c g = g a) ↔ c = pure a :=
   ⟨funext, λ h g => by subst h; rfl⟩
 
-/-- "The result is the same, in the absence of quantification." -/
-theorem simulation_orders_agree (M : α → β → γ) (m₁ : α) (m₂ : β) :
-    M <$> (pure m₁ : Cont Prop α) <*> pure m₂ =
-    flip M <$> pure m₂ <*> pure m₁ := rfl
+/-- "The result is the same, in the absence of quantification": a unit
+daughter makes the priority choice inert. -/
+theorem simulation_orders_agree (M : α → β → γ) (a : α) (c : Cont Prop β) :
+    M <$> (pure a : Cont Prop α) <*> c = flip M <$> c <*> pure a := rfl
 
 /-- A schema-derived sentence evaluates at the trivial continuation to
 its direct meaning. -/
 theorem simulation (M : α → β → Prop) (m₁ : α) (m₂ : β) :
     ContT.eval (M <$> (pure m₁ : Cont Prop α) <*> pure m₂) = M m₁ m₂ := rfl
+
+/-! ### The Appendix fragment: determiners as choice functions
+
+The real fragment types *the* as a choice function and a
+quantificational determiner at the continuized determiner type,
+quantifying over choice functions; Barker leaves the restriction to
+proper choice functions to the choice-function literature, and so do
+we. On *Someone saw a friend of everyone* the fragment yields four
+readings rather than the factorial six: every node with a unit daughter
+is priority-inert (`simulation_orders_agree`), so only the S node and
+the object NP contribute choices, and the two excluded scopings are
+exactly those splitting the object's quantifiers around the subject. -/
+
+/-- *every* quantifies over choice functions. -/
+def everyCF : Cont Prop ((E → Prop) → E) := λ D => ∀ f, D f
+
+/-- *a* as an existential over choice functions. -/
+def aCF : Cont Prop ((E → Prop) → E) := λ D => ∃ f, D f
+
+/-- The NP rule, determiner priority. -/
+def npRuleDet (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop)) :
+    Cont Prop E :=
+  det <*> n
+
+/-- The NP rule, nominal priority. -/
+def npRuleN (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop)) :
+    Cont Prop E :=
+  (λ P D => D P) <$> n <*> det
+
+variable (friendOf : E → E → Prop)
+
+/-- *John saw every man*: for every way of choosing a man, John saw
+him. -/
+theorem john_saw_every_man :
+    ContT.eval (sRuleVP (individual j)
+      (vpRule (pure saw') (npRuleDet everyCF (pure man')))) =
+    ∀ f : (E → Prop) → E, saw' (f man') j := rfl
+
+/-- *Someone saw a friend of everyone*: subject wide, determiner over
+nominal. -/
+theorem someone_saw_a_friend_of_everyone_yfx :
+    ContT.eval (sRuleNP someone (vpRule (pure saw')
+      (npRuleDet aCF (pure friendOf <*> everyone)))) =
+    ∃ y, ∃ f : (E → Prop) → E, ∀ x, saw' (f (friendOf x)) y := rfl
+
+/-- Subject wide, nominal over determiner. -/
+theorem someone_saw_a_friend_of_everyone_yxf :
+    ContT.eval (sRuleNP someone (vpRule (pure saw')
+      (npRuleN aCF (pure friendOf <*> everyone)))) =
+    ∃ y, ∀ x, ∃ f : (E → Prop) → E, saw' (f (friendOf x)) y := rfl
+
+/-- Object wide, determiner over nominal. -/
+theorem someone_saw_a_friend_of_everyone_fxy :
+    ContT.eval (sRuleVP someone (vpRule (pure saw')
+      (npRuleDet aCF (pure friendOf <*> everyone)))) =
+    ∃ f : (E → Prop) → E, ∀ x, ∃ y, saw' (f (friendOf x)) y := rfl
+
+/-- Object wide, nominal over determiner. -/
+theorem someone_saw_a_friend_of_everyone_xfy :
+    ContT.eval (sRuleVP someone (vpRule (pure saw')
+      (npRuleN aCF (pure friendOf <*> everyone)))) =
+    ∀ x, ∃ f : (E → Prop) → E, ∃ y, saw' (f (friendOf x)) y := rfl
 
 end Barker2002


### PR DESCRIPTION
Closes the study's declared gap: the Appendix's real fragment, with determiners quantifying over choice functions (Barker's proper-choice-function caveat noted as he notes it). His printed derivation *John saw every man* → `∀ f, saw (f man) j` and all four printed readings of *Someone saw a friend of everyone* hold by `rfl`.

The four-not-six prediction falls out structurally: `simulation_orders_agree` generalizes to the one-sided form — any unit daughter makes the priority choice inert, by `rfl` — so only the S node and the object NP contribute choices (2×2 = 4), and the two excluded scopings are exactly those splitting the object's quantifiers around the subject, his Integrity constraint. Only the *the friend of* chains remain unformalized.