### PR TITLE
style(Studies): lift recurring determiner binders in Barker2002

### DIFF
--- a/Linglib/Studies/Barker2002.lean
+++ b/Linglib/Studies/Barker2002.lean
@@ -25,6 +25,7 @@ namespace Barker2002
 open Quantification (Quantifier individual)
 
 variable {α β γ E : Type} (np : Cont Prop E) (vp : Cont Prop (E → Prop))
+variable (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop))
 
 /-! ### The grammar
 
@@ -43,9 +44,9 @@ def sRuleNP : Cont Prop Prop :=
   (λ x P => P x) <$> np <*> vp
 
 /-- The VP rule, verb priority. -/
-def vpRule (vt : Cont Prop (E → E → Prop)) (np : Cont Prop E) :
+def vpRule (vt : Cont Prop (E → E → Prop)) (obj : Cont Prop E) :
     Cont Prop (E → Prop) :=
-  vt <*> np
+  vt <*> obj
 
 /-- *everyone*: a universal over the continuation. -/
 def everyone : Quantifier E := λ k => ∀ x, k x
@@ -62,13 +63,11 @@ def everyCF : Cont Prop ((E → Prop) → E) := λ D => ∀ f, D f
 def aCF : Cont Prop ((E → Prop) → E) := λ D => ∃ f, D f
 
 /-- The NP rule, determiner priority. -/
-def npRuleDet (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop)) :
-    Cont Prop E :=
+def npRuleDet : Cont Prop E :=
   det <*> n
 
 /-- The NP rule, nominal priority. -/
-def npRuleN (det : Cont Prop ((E → Prop) → E)) (n : Cont Prop (E → Prop)) :
-    Cont Prop E :=
+def npRuleN : Cont Prop E :=
   (λ P D => D P) <$> n <*> det
 
 /-- The paper's expository *every*, typed as a generalized quantifier. -/


### PR DESCRIPTION
Supersedes #1749. The `det`/`n` pair recurs in both NP rules — lifted to the `variable` block, same rule as the earlier `np`/`vp` lift. `vpRule`'s inline `np` binder shadowed the lifted section variable — renamed `obj`, which it is (the S rules' `np` is the subject; same type, different role). `vt`/`vs` stay inline (single use each).