### PR TITLE
fix(Studies/FrankeBergen2020): joint utterance-parse choice for LI/GI

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -284,6 +284,7 @@ import Linglib.Core.Probability.Decision.Duality
 import Linglib.Core.Probability.Decision.ExperimentDesign
 import Linglib.Core.Probability.DirichletMultinomial
 import Linglib.Core.Probability.ENNRealArith
+import Linglib.Core.Probability.EmissionPosterior
 import Linglib.Core.Probability.Entropy
 import Linglib.Core.Probability.Eval
 import Linglib.Core.Probability.EvalLemmas

--- a/Linglib/Core/Probability/EmissionPosterior.lean
+++ b/Linglib/Core/Probability/EmissionPosterior.lean
@@ -1,0 +1,131 @@
+import Linglib.Core.Probability.JointPosterior
+
+/-!
+# Emission posterior: inferring a partially observed joint action
+
+For a kernel `κ : α → PMF (β × γ)` emitting a *pair* of which only the first
+component is observed, `PMF.emissionPosterior κ μ b` is the Bayesian posterior
+over `α × γ` — the state together with the unobserved component — given the
+observation `b`: the normalization of `(a, g) ↦ μ a · κ a (b, g)`.
+
+This is the dual of `JointPosterior.lean`: there the *state* is a product and
+the observation is total (`posterior` at `α := γ × δ` needs no new definition);
+here the *emission* is a product and the observation is partial, which no
+`PMF`-valued kernel into `β` can express (`(a, g) ↦ κ a (b, g)` sums to the
+`γ`-marginal, not to `1`). At `γ := Unit` the construction collapses to
+`PMF.posterior` up to the product-with-`Unit` equivalence.
+
+The observation marginal is `PMF.marginal` of the `fst`-projected kernel, so
+positivity witnesses come from `marginal_ne_zero` via `fst_apply_ne_zero`.
+
+## Main definitions
+
+* `PMF.emissionPosterior` — posterior over `α × γ` from observing the first
+  component of a jointly emitted pair.
+
+## Main results
+
+* `emissionPosterior_fst_lt_iff` / `emissionPosterior_snd_lt_iff` — marginal
+  comparisons reduce to prior-weighted emission sums; the observation marginal
+  cancels.
+* `emissionPosterior_uniform_fst_lt_iff` / `_uniform_snd_lt_iff` — at a uniform
+  prior the prior cancels too, leaving bare emission sums.
+-/
+
+namespace PMF
+
+open scoped ENNReal
+
+variable {α β γ : Type*} [Fintype β] [Fintype γ] [DecidableEq β]
+
+/-- The total score of an emission posterior is the observation marginal:
+`∑ (a, g), μ a · κ a (b, g) = marginal (fun a => (κ a).fst) μ b`. -/
+theorem tsum_emission_score_eq (κ : α → PMF (β × γ)) (μ : PMF α) (b : β) :
+    (∑' x : α × γ, μ x.1 * κ x.1 (b, x.2)) = marginal (fun a => (κ a).fst) μ b := by
+  rw [ENNReal.tsum_prod']
+  show (∑' a, ∑' g, μ a * κ a (b, g)) = (μ.bind fun a => (κ a).fst) b
+  rw [PMF.bind_apply]
+  exact tsum_congr fun a => by rw [ENNReal.tsum_mul_left, tsum_fintype, ← fst_apply]
+
+/-- **Emission posterior**: the conditional distribution over state and
+unobserved emission component `(a, g)`, given that the kernel `κ` emitted a
+pair with observed first component `b`. -/
+noncomputable def emissionPosterior (κ : α → PMF (β × γ)) (μ : PMF α) (b : β)
+    (h : marginal (fun a => (κ a).fst) μ b ≠ 0) : PMF (α × γ) :=
+  PMF.normalize (fun x => μ x.1 * κ x.1 (b, x.2))
+    (by rw [tsum_emission_score_eq]; exact h)
+    (by rw [tsum_emission_score_eq]; exact marginal_ne_top _ μ b)
+
+theorem emissionPosterior_apply (κ : α → PMF (β × γ)) (μ : PMF α) (b : β)
+    (h : marginal (fun a => (κ a).fst) μ b ≠ 0) (x : α × γ) :
+    emissionPosterior κ μ b h x
+      = μ x.1 * κ x.1 (b, x.2) * (marginal (fun a => (κ a).fst) μ b)⁻¹ := by
+  rw [emissionPosterior, PMF.normalize_apply, tsum_emission_score_eq]
+
+/-- A single witness `(a, g)` with `μ a ≠ 0` and `κ a (b, g) ≠ 0` makes the
+observation marginal non-zero — the positivity discharge for
+`emissionPosterior`. -/
+theorem emission_marginal_ne_zero (κ : α → PMF (β × γ)) (μ : PMF α) {a : α} {b : β}
+    {g : γ} (hμ : μ a ≠ 0) (hκ : κ a (b, g) ≠ 0) :
+    marginal (fun a => (κ a).fst) μ b ≠ 0 :=
+  marginal_ne_zero _ μ b hμ (fst_apply_ne_zero (x := (b, g)) hκ)
+
+variable [Fintype α]
+
+/-- **State-marginal comparison**: the observation marginal cancels, leaving
+prior-weighted emission sums over the unobserved component. -/
+theorem emissionPosterior_fst_lt_iff [DecidableEq α] (κ : α → PMF (β × γ))
+    (μ : PMF α) (b : β) (h : marginal (fun a => (κ a).fst) μ b ≠ 0) (a₁ a₂ : α) :
+    (emissionPosterior κ μ b h).fst a₁ < (emissionPosterior κ μ b h).fst a₂
+      ↔ (∑ g : γ, μ a₁ * κ a₁ (b, g)) < ∑ g : γ, μ a₂ * κ a₂ (b, g) := by
+  rw [fst_apply, fst_apply]
+  simp_rw [emissionPosterior_apply]
+  rw [← Finset.sum_mul, ← Finset.sum_mul]
+  exact ENNReal.mul_lt_mul_iff_left
+    (ENNReal.inv_ne_zero.mpr (marginal_ne_top _ μ b))
+    (ENNReal.inv_ne_top.mpr h)
+
+/-- **Emission-marginal comparison**: companion of `emissionPosterior_fst_lt_iff`
+for the unobserved component. -/
+theorem emissionPosterior_snd_lt_iff [DecidableEq γ] (κ : α → PMF (β × γ))
+    (μ : PMF α) (b : β) (h : marginal (fun a => (κ a).fst) μ b ≠ 0) (g₁ g₂ : γ) :
+    (emissionPosterior κ μ b h).snd g₁ < (emissionPosterior κ μ b h).snd g₂
+      ↔ (∑ a : α, μ a * κ a (b, g₁)) < ∑ a : α, μ a * κ a (b, g₂) := by
+  rw [snd_apply, snd_apply]
+  simp_rw [emissionPosterior_apply]
+  rw [← Finset.sum_mul, ← Finset.sum_mul]
+  exact ENNReal.mul_lt_mul_iff_left
+    (ENNReal.inv_ne_zero.mpr (marginal_ne_top _ μ b))
+    (ENNReal.inv_ne_top.mpr h)
+
+/-- At a uniform prior the prior cancels: state comparison reduces to bare
+emission sums over the unobserved component. -/
+theorem emissionPosterior_uniform_fst_lt_iff [DecidableEq α] [Nonempty α]
+    (κ : α → PMF (β × γ)) (b : β)
+    (h : marginal (fun a => (κ a).fst) (PMF.uniformOfFintype α) b ≠ 0) (a₁ a₂ : α) :
+    (emissionPosterior κ (PMF.uniformOfFintype α) b h).fst a₁
+        < (emissionPosterior κ (PMF.uniformOfFintype α) b h).fst a₂
+      ↔ (∑ g : γ, κ a₁ (b, g)) < ∑ g : γ, κ a₂ (b, g) := by
+  rw [emissionPosterior_fst_lt_iff]
+  simp only [PMF.uniformOfFintype_apply]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+  exact ENNReal.mul_lt_mul_iff_right
+    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
+    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero))
+
+/-- At a uniform prior the prior cancels: emission-component comparison reduces
+to bare emission sums over states. -/
+theorem emissionPosterior_uniform_snd_lt_iff [DecidableEq γ] [Nonempty α]
+    (κ : α → PMF (β × γ)) (b : β)
+    (h : marginal (fun a => (κ a).fst) (PMF.uniformOfFintype α) b ≠ 0) (g₁ g₂ : γ) :
+    (emissionPosterior κ (PMF.uniformOfFintype α) b h).snd g₁
+        < (emissionPosterior κ (PMF.uniformOfFintype α) b h).snd g₂
+      ↔ (∑ a : α, κ a (b, g₁)) < ∑ a : α, κ a (b, g₂) := by
+  rw [emissionPosterior_snd_lt_iff]
+  simp only [PMF.uniformOfFintype_apply]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+  exact ENNReal.mul_lt_mul_iff_right
+    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
+    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero))
+
+end PMF

--- a/Linglib/Pragmatics/RSA/Canonical.lean
+++ b/Linglib/Pragmatics/RSA/Canonical.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Probability.Softmax
 import Linglib.Core.Probability.JointPosterior
+import Linglib.Core.Probability.EmissionPosterior
 import Linglib.Pragmatics.RSA.Operators
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLog
 
@@ -46,8 +47,6 @@ Non-latent models take `St = W` and use the foundation `PMF.posterior_lt_iff_sco
 directly (the `latent = Unit` collapse). The `IsCovering ⇒ ViableSpeaker (rsaUtility …)`
 bridge for standard informativity speakers is added when first needed.
 -/
-
-set_option autoImplicit false
 
 namespace RSA.Canonical
 
@@ -188,7 +187,91 @@ theorem L1_latent_eq_iff [DecidableEq Lat] (S : W × Lat → PMF U)
           = ∑ w : W, joint (w, l₂) * S (w, l₂) u :=
   PMF.posterior_snd_eq_iff S joint u h l₁ l₂
 
+/-- At a uniform joint prior the prior cancels: world preference reduces to
+comparing pooled speaker sums over the latent. -/
+@[rsa]
+theorem L1_uniform_world_prefers_iff [DecidableEq W] [Nonempty (W × Lat)]
+    (S : W × Lat → PMF U) (u : U)
+    (h : PMF.marginal S (PMF.uniformOfFintype (W × Lat)) u ≠ 0) (w₁ w₂ : W) :
+    (L1 S (PMF.uniformOfFintype _) u h).fst w₁ < (L1 S (PMF.uniformOfFintype _) u h).fst w₂
+      ↔ (∑ l : Lat, S (w₁, l) u) < ∑ l : Lat, S (w₂, l) u := by
+  rw [L1_world_prefers_iff]
+  simp only [PMF.uniformOfFintype_apply]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+  exact ENNReal.mul_lt_mul_iff_right
+    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
+    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero))
+
+/-- Latent companion of `L1_uniform_world_prefers_iff`. -/
+@[rsa]
+theorem L1_uniform_latent_prefers_iff [DecidableEq Lat] [Nonempty (W × Lat)]
+    (S : W × Lat → PMF U) (u : U)
+    (h : PMF.marginal S (PMF.uniformOfFintype (W × Lat)) u ≠ 0) (l₁ l₂ : Lat) :
+    (L1 S (PMF.uniformOfFintype _) u h).snd l₁ < (L1 S (PMF.uniformOfFintype _) u h).snd l₂
+      ↔ (∑ w : W, S (w, l₁) u) < ∑ w : W, S (w, l₂) u := by
+  rw [L1_latent_prefers_iff]
+  simp only [PMF.uniformOfFintype_apply]
+  rw [← Finset.mul_sum, ← Finset.mul_sum]
+  exact ENNReal.mul_lt_mul_iff_right
+    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
+    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero))
+
 end Listener
+
+/-! ### Pair-choice pragmatic listener
+
+For models where the speaker chooses an (utterance, latent) **pair** — the
+[franke-bergen-2020] lexical/global-intentions architecture, where the latent
+is the speaker's *intended meaning* rather than part of its state — the
+listener observes only the utterance and infers the joint (world, latent) via
+`PMF.emissionPosterior`. Contrast `L1`: there the latent is drawn with the
+world by the prior and each `(world, latent)` state has its own normalized
+speaker; here one speaker per world normalizes over (utterance, latent) pairs,
+so a pair's overall informativity drives the posterior. -/
+
+section IntentListener
+
+variable {W Lat U : Type*} [Fintype W] [Fintype Lat] [Fintype U] [DecidableEq U]
+
+/-- The **pair-choice pragmatic listener**: the posterior over `world × latent`
+given the observed utterance component of a jointly chosen (utterance, latent)
+action. -/
+noncomputable def L1Intent (S : W → PMF (U × Lat)) (prior : PMF W) (u : U)
+    (h : PMF.marginal (fun w => (S w).fst) prior u ≠ 0) : PMF (W × Lat) :=
+  PMF.emissionPosterior S prior u h
+
+/-- At a uniform world prior, `L1Intent` world preference reduces to pooled
+speaker sums over the latent. -/
+@[rsa]
+theorem L1Intent_uniform_world_prefers_iff [DecidableEq W] [Nonempty W]
+    (S : W → PMF (U × Lat)) (u : U)
+    (h : PMF.marginal (fun w => (S w).fst) (PMF.uniformOfFintype W) u ≠ 0) (w₁ w₂ : W) :
+    (L1Intent S (PMF.uniformOfFintype W) u h).fst w₁
+        < (L1Intent S (PMF.uniformOfFintype W) u h).fst w₂
+      ↔ (∑ l : Lat, S w₁ (u, l)) < ∑ l : Lat, S w₂ (u, l) :=
+  PMF.emissionPosterior_uniform_fst_lt_iff S u h w₁ w₂
+
+/-- At a uniform world prior, `L1Intent` latent preference reduces to pooled
+speaker sums over worlds. -/
+@[rsa]
+theorem L1Intent_uniform_latent_prefers_iff [DecidableEq Lat] [Nonempty W]
+    (S : W → PMF (U × Lat)) (u : U)
+    (h : PMF.marginal (fun w => (S w).fst) (PMF.uniformOfFintype W) u ≠ 0) (l₁ l₂ : Lat) :
+    (L1Intent S (PMF.uniformOfFintype W) u h).snd l₁
+        < (L1Intent S (PMF.uniformOfFintype W) u h).snd l₂
+      ↔ (∑ w : W, S w (u, l₁)) < ∑ w : W, S w (u, l₂) :=
+  PMF.emissionPosterior_uniform_snd_lt_iff S u h l₁ l₂
+
+/-- A single world `w` where the pair `(u, l)` has positive speaker mass makes
+the utterance marginal non-zero — the positivity discharge for `L1Intent` at a
+uniform prior. -/
+theorem L1Intent_uniform_marginal_ne_zero [Nonempty W] (S : W → PMF (U × Lat))
+    {w : W} {u : U} {l : Lat} (h : S w (u, l) ≠ 0) :
+    PMF.marginal (fun w => (S w).fst) (PMF.uniformOfFintype W) u ≠ 0 :=
+  PMF.emission_marginal_ne_zero S (PMF.uniformOfFintype W)
+    (((PMF.uniformOfFintype W).mem_support_iff w).mp (PMF.mem_support_uniformOfFintype _)) h
+
+end IntentListener
 
 /-! ### Power-utility informativity speakers
 
@@ -388,6 +471,103 @@ theorem S1_L0OfBool_lt_inv_succ_of_dominator {α : ℕ} [Fintype U]
   subst h0
   rw [Finset.card_eq_zero] at hk'
   exact absurd (hk' ▸ RSA.mem_extensionOf.mpr hu') (Finset.notMem_empty _)
+
+/-- The Boolean-model speaker never assigns zero mass to a true utterance —
+the witness for pragmatic-listener positivity obligations. -/
+theorem S1_L0OfBool_ne_zero {α : ℕ} [Fintype U]
+    [ViableSpeaker (powUtility α (L0OfBool m hne))]
+    {i : I} {u : U} {w : W} (h : m i u w = true) :
+    S1 (powUtility α (L0OfBool m hne)) (w, i) u ≠ 0 :=
+  S1_ne_zero _ (show (α : EReal) * ENNReal.log (L0OfBool m hne i u w) ≠ ⊥ from
+    natCast_mul_log_ne_bot α (L0OfBool_ne_zero m hne h))
+
+/-! ### Exact rational evaluation over a Boolean model
+
+The speaker over a Boolean model takes exact rational values: `boolWeight` is
+the unnormalised weight `|ext|⁻ᵅ` at a true utterance, `boolPartition` the
+partition sum, and `boolS1` their ratio. `S1_eq_ofReal` bridges once; every
+concrete mass and pooled sum then reduces to `ℚ` arithmetic (`norm_num`), with
+no per-value `ENNReal` bookkeeping. -/
+
+/-- Exact rational unnormalised speaker weight over a Boolean model. -/
+def boolWeight (α : ℕ) (i : I) (w : W) (u : U) : ℚ :=
+  if m i u w then ((RSA.extensionOf (m i) u).card : ℚ)⁻¹ ^ α else 0
+
+/-- Exact rational partition function over a Boolean model. -/
+def boolPartition (α : ℕ) [Fintype U] (i : I) (w : W) : ℚ :=
+  ∑ u : U, boolWeight m α i w u
+
+/-- Exact rational normalised speaker mass over a Boolean model. -/
+def boolS1 (α : ℕ) [Fintype U] (i : I) (w : W) (u : U) : ℚ :=
+  boolWeight m α i w u / boolPartition m α i w
+
+theorem boolWeight_nonneg (α : ℕ) (i : I) (w : W) (u : U) :
+    0 ≤ boolWeight m α i w u := by
+  unfold boolWeight; split <;> positivity
+
+theorem powWeight_eq_ofReal {α : ℕ} (hα : α ≠ 0) (i : I) (w : W) (u : U) :
+    powWeight α (L0OfBool m hne) (w, i) u = ENNReal.ofReal (boolWeight m α i w u) := by
+  unfold boolWeight
+  split
+  · next h =>
+    rw [powWeight_L0OfBool_of_mem m hne _ h rfl]
+    push_cast
+    have hc : (0 : ℝ) < (RSA.extensionOf (m i) u).card := by
+      exact_mod_cast Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
+    rw [ENNReal.ofReal_pow (by positivity), ENNReal.ofReal_inv_of_pos hc,
+      ENNReal.ofReal_natCast]
+  · next h =>
+    rw [powWeight_L0OfBool_of_not_mem m hne hα (by simpa using h)]
+    push_cast
+    rw [ENNReal.ofReal_zero]
+
+variable [Fintype U]
+
+theorem tsum_powWeight_eq_ofReal {α : ℕ} (hα : α ≠ 0) (i : I) (w : W) :
+    (∑' u, powWeight α (L0OfBool m hne) (w, i) u)
+      = ENNReal.ofReal (boolPartition m α i w) := by
+  rw [tsum_fintype, boolPartition]
+  push_cast
+  rw [ENNReal.ofReal_sum_of_nonneg
+    (fun u _ => by exact_mod_cast boolWeight_nonneg m α i w u)]
+  exact Finset.sum_congr rfl fun u _ => powWeight_eq_ofReal m hne hα i w u
+
+theorem boolPartition_pos {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
+    (hα : α ≠ 0) (i : I) (w : W) : 0 < boolPartition m α i w := by
+  rcases ViableSpeaker.some_finite (score := powUtility α (L0OfBool m hne)) (w, i) with ⟨u', hu'⟩
+  refine Finset.sum_pos' (fun v _ => boolWeight_nonneg m α i w v) ⟨u', Finset.mem_univ _, ?_⟩
+  have hm : m i u' w = true := by
+    by_contra hm
+    exact hu' (by rw [powUtility, L0OfBool_eq_zero m hne hm, ENNReal.log_zero,
+      EReal.mul_bot_of_pos (by exact_mod_cast Nat.pos_of_ne_zero hα)])
+  have hc : 0 < (RSA.extensionOf (m i) u').card := Finset.card_pos.mpr (hne i u')
+  rw [boolWeight, if_pos hm]
+  positivity
+
+theorem boolS1_nonneg (α : ℕ) (i : I) (w : W) (u : U) : 0 ≤ boolS1 m α i w u :=
+  div_nonneg (boolWeight_nonneg m α i w u)
+    (Finset.sum_nonneg fun v _ => boolWeight_nonneg m α i w v)
+
+/-- Exact rational value of the power-utility speaker over a Boolean model. -/
+theorem S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
+    (hα : α ≠ 0) (i : I) (w : W) (u : U) :
+    S1 (powUtility α (L0OfBool m hne)) (w, i) u = ENNReal.ofReal (boolS1 m α i w u) := by
+  have hz := boolPartition_pos m hne hα i w
+  rw [S1_powUtility_eq_normalize, PMF.normalize_apply, powWeight_eq_ofReal m hne hα,
+    tsum_powWeight_eq_ofReal m hne hα, ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hz),
+    ← ENNReal.ofReal_mul (by exact_mod_cast boolWeight_nonneg m α i w u), boolS1]
+  push_cast [div_eq_mul_inv]
+  ring_nf
+
+/-- Any finite family of Boolean-model speaker masses sums to the `ofReal` of
+the corresponding `boolS1` sum — the workhorse for pooled-latent reductions. -/
+theorem sum_S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
+    (hα : α ≠ 0) {ι : Type*} (s : Finset ι) (st : ι → W × I) (uu : ι → U) :
+    (∑ x ∈ s, S1 (powUtility α (L0OfBool m hne)) (st x) (uu x))
+      = ENNReal.ofReal (∑ x ∈ s, boolS1 m α (st x).2 (st x).1 (uu x)) := by
+  rw [ENNReal.ofReal_sum_of_nonneg
+    (fun x _ => by exact_mod_cast boolS1_nonneg m α (st x).2 (st x).1 (uu x))]
+  exact Finset.sum_congr rfl fun x _ => S1_eq_ofReal m hne hα (st x).2 (st x).1 (uu x)
 
 end BoolModel
 

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -6,8 +6,8 @@ import Mathlib.Tactic.DeriveFintype
 # [franke-bergen-2020] — Grammatically generated implicature readings
 
 "Theory-driven statistical modeling for semantics and pragmatics: A case study
-on grammatically generated implicature readings" compares four RSA models of
-the **nested Aristotelians** "Q₁ of the aliens drank Q₂ of their water"
+on grammatically generated implicature readings" compares four RSA models
+([frank-goodman-2012]) of the **nested Aristotelians** "Q₁ of the aliens drank Q₂ of their water"
 (Q ∈ {none, some, all}): 7 world states (which alien types — none-drinkers,
 some-drinkers, all-drinkers — exist), 9 utterances, and 8 grammatical parses
 (subsets of {M, O, I} EXH positions) generating the readings of the paper's

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -1,47 +1,65 @@
 import Linglib.Pragmatics.RSA.Canonical
+import Linglib.Semantics.Exhaustification.InnocentExclusion
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# [franke-bergen-2020] — GI-RSA for Nested Aristotelians
-[franke-bergen-2020] [fox-2007] [franke-2011]
+# [franke-bergen-2020] — Grammatically generated implicature readings
 
-"Theory-driven statistical modeling for semantics and pragmatics:
-A case study on grammatically generated implicature readings"
+"Theory-driven statistical modeling for semantics and pragmatics: A case study
+on grammatically generated implicature readings" compares four RSA models of
+the **nested Aristotelians** "Q₁ of the aliens drank Q₂ of their water"
+(Q ∈ {none, some, all}): 7 world states (which alien types — none-drinkers,
+some-drinkers, all-drinkers — exist), 9 utterances, and 8 grammatical parses
+(subsets of {M, O, I} EXH positions) generating the readings of the paper's
+Table 1.
 
-## The Model
+## The four models
 
-Domain: Nested Aristotelian sentences "Q₁ of the aliens drank Q₂ of their
-water" with Q₁, Q₂ ∈ {none, some, all}. 7 world states based on which
-alien types exist (none-drinkers, some-drinkers, all-drinkers). 8 grammatical
-parses (subsets of {M, O, I} EXH positions) as latent variables.
+The models differ in **where the parse enters the speaker function** — the
+paper's central architectural contrast (its §3.3):
 
-The Global Intentions (GI) model treats the parse as a latent variable:
-the speaker chooses both an utterance and a parse, the listener marginalizes
-over parses to recover the world state.
+* **Vanilla** (§3.1): literal parse only; `PMF.posterior` over worlds.
+* **LU** (§3.2): each speaker has a *fixed* lexicon `l ∈ {lit, OI}` — the parse
+  is an **argument** of the speaker (eq. 11, per-lexicon normalization), and
+  the listener marginalizes the latent lexicon (eqs. 12–13; `Canonical.L1`).
+  Lexical uncertainty follows [bergen-levy-goodman-2016] and [potts-etal-2016];
+  the paper adds an S2/L2 layer after [lassiter-goodman-2017] (eqs. 14a–14b),
+  which we omit — our L1-only LU preserves the wNS-over-wNA ordering proved
+  below, though the paper's LU-L2 concentrates on wNSA (eq. 15), which is why
+  the paper counts SS-production data *against* LU.
+* **LI** (§3.3): the speaker **chooses** an (utterance, parse) pair with
+  `l ∈ {lit, I, O, OI}` — the parse is an **output** of the speaker function
+  (eq. 18a): one softmax over pairs per world. The listener infers the joint
+  (world, parse) from the utterance alone (`Canonical.L1Intent`).
+* **GI** (§3.4): as LI but over all 8 parses (eq. 21a). The paper stresses
+  (its §3.3) that enlarging LU's latent instead would be "conceptually highly
+  implausible" — pair choice, not per-parse normalization, is what separates
+  LI/GI from LU.
 
-- **L0**: L0(w|u,g) ∝ ⟦u⟧ᵍ(w) (meaning under parse g)
-- **S1**: S1(u,g|w) ∝ L0(w|u,g)^α · P(g)
-- **L1**: L1(w|u) ∝ P(w) · Σ_g S1(u,g|w)
+All four share the Boolean semantics `exhMeaning` and the α = 2 informativity
+exponent (a modeling choice; the paper's MLEs are α ≈ 0.9–1.4). The paper's
+cost term `c(u)` for *none*-initial utterances (estimated) and error term ε
+(fixed at 0.045) are omitted; every prediction below is robust to this except
+`vanilla_ss_prefers_wNA`, which is the paper's own cost-free illustration
+(eq. 10) and reverses at the fitted cost.
 
-Exhaustification uses compositional enrichment at inner/outer quantifier
-positions: Exh(Q) conjoins Q with the negation of all strictly stronger
-lexical alternatives on the {some, all} scale ([fox-2007]). Only
-Exh(some) = "some but not all" is non-vacuous; Exh(all) and Exh(none)
-have no strictly stronger alternative.
+## Exhaustification (appendix, defs. A1–A4)
 
-At matrix position, EXH uses exh_MW (eq. A2): negate the LITERAL meanings
-of sentential alternatives that are strictly stronger than the sub-matrix
-enriched meaning, with a noncontradictory fallback. Sentential alternatives
-are the cross-product of scale-mate substitutions ({some, all}) for each
-on-scale quantifier. "none" is treated as off-scale; the paper notes
-(fn. 7) that including "not all" as an alternative to "none" has negligible
-effect on predictions.
+In-situ EXH at the inner/outer quantifier conjoins with the negation of
+strictly stronger lexical alternatives on the scale — only Exh(some) = "some
+but not all" is non-vacuous ([fox-2007]). Matrix EXH (eq. A2) negates the
+LITERAL meanings of the strictly stronger sentential alternatives (A3b: proper
+subsets of the sub-matrix enriched meaning), with a noncontradictory fallback.
+Sentential alternatives (A3a) substitute lexical alternatives per position:
+`some ↔ all`, and `not all` for `none` (analyzed as *not some*;
+[levinson-2000]) — so alternative sentences range over a fourth quantifier
+`notAll` that is not itself an utterance, the paper's grammatical-vs-utterance
+alternatives distinction. Including the `none ~ not all` alternative gives NN
+its distinct matrix-parse row in Table 1 (the paper's fn. 7); the paper's own
+comparison of this alternative construction with Gotzner & Romoli's
+([gotzner-romoli-2018]) favors it by a Bayes factor of ~1,530.
 
-Parameters: α = 2 (modeling choice; the paper estimates α jointly with cost
-and error parameters, reporting MLE ≈ 1.3 for GI), uniform priors. The
-paper's cost term c(u) for "none"-initial utterances and error term ε are
-omitted; the qualitative predictions below are robust to these simplifications.
-
-## Qualitative Findings
+## Findings
 
 | # | Finding | Theorem |
 |---|---------|---------|
@@ -49,60 +67,38 @@ omitted; the qualitative predictions below are robust to these simplifications.
 | 2 | SS exhaustifies outer Q | `ss_outer_exh` |
 | 3 | AA identifies unique world | `aa_identifies` |
 | 4 | AS exhaustifies inner Q | `as_inner_exh` |
-| 5 | Full EXH preferred for SS | `ss_parse_pref` |
+| 5 | GI's parse posterior for SS peaks at M | `ss_m_parse_pref` |
 | 6 | Vanilla gets SS wrong (prefers wNA) | `vanilla_ss_prefers_wNA` |
 | 7 | GI gets SS right (prefers wNS) | `gi_ss_prefers_wNS` |
-| 8 | LU gets SS→wNS right | `lu_ss_prefers_wNS` |
+| 8 | LU keeps wNS over wNA | `lu_ss_prefers_wNS` |
 | 9 | LI derives outer exh for SS | `li_ss_outer_exh` |
 | 10 | LI also gets SS→wNS right | `li_ss_prefers_wNS` |
 
-## Model Comparison
-
-All four models share **one per-parse speaker** `S(w, p)` (the softmax at
-exponent `α = 2` of the parse-`p` literal listener), because the speaker at a
-`(world, parse)` state depends only on that parse's Boolean meaning. They differ
-only in the *latent space* the pragmatic listener marginalises over — a joint
-`PMF (World × Latent)` posterior (`RSA.Canonical.L1`) with a uniform prior:
-- **Vanilla** (§3.1): latent `Unit` — literal parse only (`S(·, .none)`)
-- **LU** (§3.2): latent `LULex` (2 lexica) — simplified to L1
-  (the paper adds an S2/L2 layer following [potts-etal-2016]; our L1-only
-  approximation suffices for qualitative predictions)
-- **LI** (§3.3): latent `LIParse` (4 parses) — speaker chooses parse
-- **GI** (§3.4): latent `Parse` (8 parses) — full parse space
-
-The listener predictions are decided by exact `PMF` evaluation: each speaker
-mass `S(w, p) u` is a rational `ENNReal.ofReal` value (`s_*` lemmas below),
-and each theorem reduces via `RSA.Canonical.L1_world_prefers_iff` (or
-`_latent_prefers_iff`) to a comparison of pooled speaker sums over the latent.
-
-Bayesian model comparison: GI achieves 0.956 posterior probability,
-LI = 0.033, LU = 0.010, vanilla = 0.
+Finding 5 is the model-side face of the paper's explanation of GI's win:
+⟦SS⟧^M = {wNS} (`m_ss_singleton`) "uniquely singles out this world state"
+(eq. 22), M-parses are unavailable to LI and LU (`li_excludes_matrix`,
+`lu_excludes_matrix`), and Bayesian comparison on the paper's production +
+comprehension data gives GI 0.956 posterior probability (LI 0.033, LU 0.01,
+vanilla 0; the paper's Table 2). Predictions are decided by exact rational
+evaluation: `RSA.Canonical.S1_eq_ofReal` reduces each speaker mass to a `ℚ`
+value and each listener preference to a `ℚ` comparison closed by `norm_num`.
 -/
-
-set_option autoImplicit false
 
 namespace FrankeBergen2020
 
 open scoped ENNReal
+open RSA.Canonical
 
--- ============================================================================
--- §1. Domain Types
--- ============================================================================
+/-! ### Domain -/
 
-/-- Aristotelian quantifiers: none, some, all. -/
+/-- Aristotelian quantifiers: the utterance vocabulary. -/
 inductive AristQuant where
-  | none : AristQuant
-  | some_ : AristQuant
-  | all : AristQuant
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype AristQuant where
-  elems := {.none, .some_, .all}
-  complete := fun x => by cases x <;> simp
+  | none | some | all
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
 /-- The 7 world states, distinguished by which alien types exist.
-    Three types: N (drank none), S (drank some but not all), A (drank all).
-    Worlds are the 7 non-empty subsets of {N, S, A}. -/
+Three types: N (drank none), S (drank some but not all), A (drank all).
+Worlds are the 7 non-empty subsets of {N, S, A}. -/
 inductive World where
   | wN    -- only N-type aliens
   | wNS   -- N and S types
@@ -111,22 +107,14 @@ inductive World where
   | wS    -- only S-type aliens
   | wSA   -- S and A types
   | wA    -- only A-type aliens
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype World where
-  elems := {.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA}
-  complete := fun x => by cases x <;> simp
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
 /-- The 9 nested Aristotelian utterances: Q_outer × Q_inner. -/
 inductive Utterance where
   | nn | ns | na
   | sn | ss | sa
-  | an | as_ | aa
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype Utterance where
-  elems := {.nn, .ns, .na, .sn, .ss, .sa, .an, .as_, .aa}
-  complete := fun x => by cases x <;> simp
+  | an | as | aa
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
 /-- The 8 grammatical parses: subsets of {M, O, I} EXH positions. -/
 inductive Parse where
@@ -134,15 +122,7 @@ inductive Parse where
   | m | o | i
   | mo | mi | oi
   | moi
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype Parse where
-  elems := {.none, .m, .o, .i, .mo, .mi, .oi, .moi}
-  complete := fun x => by cases x <;> simp
-
--- ============================================================================
--- §2. Accessors
--- ============================================================================
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
 /-- Whether N-type aliens (drank none) exist. -/
 def World.hasN : World → Bool
@@ -162,25 +142,14 @@ def World.hasA : World → Bool
 /-- Outer quantifier of an utterance. -/
 def Utterance.outer : Utterance → AristQuant
   | .nn | .ns | .na => .none
-  | .sn | .ss | .sa => .some_
-  | .an | .as_ | .aa => .all
+  | .sn | .ss | .sa => .some
+  | .an | .as | .aa => .all
 
 /-- Inner quantifier of an utterance. -/
 def Utterance.inner : Utterance → AristQuant
   | .nn | .sn | .an => .none
-  | .ns | .ss | .as_ => .some_
+  | .ns | .ss | .as => .some
   | .na | .sa | .aa => .all
-
-/-- Construct an utterance from outer × inner quantifiers. -/
-def Utterance.mk : AristQuant → AristQuant → Utterance
-  | .none, .none => .nn | .none, .some_ => .ns | .none, .all => .na
-  | .some_, .none => .sn | .some_, .some_ => .ss | .some_, .all => .sa
-  | .all, .none => .an | .all, .some_ => .as_ | .all, .all => .aa
-
-/-- Whether a quantifier is on the lexical scale {some, all}. -/
-def AristQuant.onScale : AristQuant → Bool
-  | .some_ | .all => true
-  | .none => false
 
 /-- Whether parse includes EXH at inner position. -/
 def Parse.hasI : Parse → Bool
@@ -197,1178 +166,650 @@ def Parse.hasM : Parse → Bool
   | .m | .mo | .mi | .moi => true
   | _ => false
 
--- ============================================================================
--- §3. Compositional Semantics
--- ============================================================================
+/-! ### Alternative quantifiers
 
-/-- Inner VP satisfaction: which alien types satisfy "drank Q"?
-    - Q = none: N-types satisfy (drank none of their water)
-    - Q = some: S-types and A-types satisfy (drank some)
-    - Q = all: only A-types satisfy (drank all) -/
-def innerTypeSat (qi : AristQuant) : Bool × Bool × Bool :=
-  match qi with
+Sentential alternatives (A3a) substitute *lexical alternatives* per quantifier
+position: `some ↔ all`, and `not all` for `none`. `not all` occurs only in
+alternative sentences, never as an utterance — the paper's grammatical
+alternatives outstrip its utterance alternatives. -/
+
+/-- Quantifiers available in sentential alternatives: the utterance
+quantifiers plus *not all*, the lexical alternative of *none*. -/
+inductive AltQuant where
+  | none | some | all | notAll
+  deriving DecidableEq, Repr
+
+/-- Utterance quantifiers are alternative quantifiers. -/
+def AristQuant.toAlt : AristQuant → AltQuant
+  | .none => .none
+  | .some => .some
+  | .all => .all
+
+/-- Scale-mate candidates at a quantifier position of a sentential
+alternative: the quantifier itself and its lexical alternatives. -/
+def AristQuant.altCandidates : AristQuant → List AltQuant
+  | .none => [.none, .notAll]
+  | .some => [.some, .all]
+  | .all => [.all, .some]
+
+/-! ### Compositional semantics -/
+
+/-- Inner VP satisfaction: which alien types satisfy "drank Q"? -/
+def AltQuant.innerTypeSat : AltQuant → Bool × Bool × Bool
   | .none => (true, false, false)
-  | .some_ => (false, true, true)
+  | .some => (false, true, true)
   | .all => (false, false, true)
+  | .notAll => (true, true, false)
 
-/-- Outer quantifier evaluation: does the world satisfy "Q_outer of the
-    aliens [satisfy inner VP]"? `nSat`, `sSat`, `aSat` indicate which
-    alien types satisfy the inner VP. -/
-def outerEval (qo : AristQuant) (nSat sSat aSat : Bool) (w : World) : Bool :=
-  match qo with
+/-- Outer quantifier evaluation: does the world satisfy "Q of the aliens
+[satisfy inner VP]"? `nSat`, `sSat`, `aSat` say which alien types satisfy
+the inner VP. -/
+def AltQuant.outerEval (q : AltQuant) (nSat sSat aSat : Bool) (w : World) : Bool :=
+  match q with
   | .none => !(w.hasN && nSat) && !(w.hasS && sSat) && !(w.hasA && aSat)
-  | .some_ => (w.hasN && nSat) || (w.hasS && sSat) || (w.hasA && aSat)
+  | .some => (w.hasN && nSat) || (w.hasS && sSat) || (w.hasA && aSat)
   | .all => (!w.hasN || nSat) && (!w.hasS || sSat) && (!w.hasA || aSat)
+  | .notAll => !((!w.hasN || nSat) && (!w.hasS || sSat) && (!w.hasA || aSat))
 
-/-- Literal meaning: compose inner VP satisfaction with outer quantifier. -/
-def literalMeaning (u : Utterance) (w : World) : Bool :=
-  let (nSat, sSat, aSat) := innerTypeSat u.inner
-  outerEval u.outer nSat sSat aSat w
+/-- A sentential alternative: a pair of alternative quantifiers. -/
+abbrev AltSentence := AltQuant × AltQuant
 
--- ============================================================================
--- §4. Compositional Exhaustification
--- ============================================================================
+/-- Literal meaning of a sentential alternative. -/
+def altLiteral (a : AltSentence) : World → Bool :=
+  let (nSat, sSat, aSat) := a.2.innerTypeSat
+  a.1.outerEval nSat sSat aSat
+
+/-- Literal meaning of an utterance. -/
+def literalMeaning (u : Utterance) : World → Bool :=
+  altLiteral (u.outer.toAlt, u.inner.toAlt)
+
+/-! ### Compositional exhaustification -/
 
 /-- All 7 worlds for enumeration. -/
 def allWorlds : List World := [.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA]
 
 /-- Inner VP satisfaction after EXH enrichment. Only "some" is enrichable:
-    Exh(some) = "some but not all" — satisfied by S-types only (not A-types).
-    Exh(none) and Exh(all) are vacuous (no strictly stronger alternative). -/
+Exh(some) = "some but not all" — satisfied by S-types only. Exh(none) and
+Exh(all) are vacuous (no strictly stronger lexical alternative). -/
 def enrichedInnerTypeSat (qi : AristQuant) (hasI : Bool) : Bool × Bool × Bool :=
-  if hasI && qi == .some_ then
+  if hasI && qi == .some then
     (false, true, false)  -- only S-types satisfy "some but not all"
   else
-    innerTypeSat qi
+    qi.toAlt.innerTypeSat
 
-/-- The lexical scale: {some, all}. -/
-def scale : List AristQuant := [.some_, .all]
+/-- Sentential alternatives at matrix position (A3a): the cross-product of
+scale-mate candidates for the two quantifier positions. -/
+def matrixAlts (u : Utterance) : List AltSentence :=
+  (u.outer.altCandidates.map fun o => u.inner.altCandidates.map fun i => (o, i)).flatten
 
-/-- Sentential alternatives at matrix position: cross-product of
-    scale-mate substitutions for each scalar item in the utterance.
-    Non-scalar positions are held fixed. -/
-def matrixAlts (u : Utterance) : List Utterance :=
-  let outers := if u.outer.onScale then scale else [u.outer]
-  let inners := if u.inner.onScale then scale else [u.inner]
-  (outers.map fun o => inners.map fun i => Utterance.mk o i).flatten
+/-- Exhaustified meaning under a given parse.
 
-/-- Exhaustified meaning under a given parse, using compositional enrichment.
-
-    Inner/outer EXH enrich quantifiers in situ (at the quantifier level, not
-    the sentence level), following the paper's Appendix. Only "some" →
-    "some but not all" is a meaningful enrichment; Exh(all) and Exh(none)
-    are vacuous (no strictly stronger lexical alternative on the scale).
-
-    Matrix EXH uses exh_MW with a strength filter: negate the LITERAL
-    meanings of sentential alternatives that are strictly stronger than
-    the enriched (sub-matrix) meaning. Fall back to no matrix EXH if
-    the conjunction is contradictory (eq. A2). -/
+Inner/outer EXH enrich quantifiers in situ; only "some" → "some but not all"
+is non-vacuous. Matrix EXH (eq. A2) conjoins the sub-matrix meaning with the
+negations of the LITERAL meanings of the strictly stronger sentential
+alternatives (A3b: literal meaning a *proper* subset of the sub-matrix
+enriched meaning — properness alone filters, so an utterance's own literal
+meaning survives as an alternative when a parse weakens it, as for NS under
+MI), falling back to the sub-matrix meaning on contradiction. -/
 def exhMeaning (p : Parse) (u : Utterance) : World → Bool :=
-  -- Step 1: Compute inner predicate (enriched if I ∈ parse)
+  -- Step 1: inner predicate (enriched if I ∈ parse)
   let (nSat, sSat, aSat) := enrichedInnerTypeSat u.inner p.hasI
-  -- Step 2: Apply outer quantifier
-  let baseMeaning := outerEval u.outer nSat sSat aSat
-  -- Step 3: Outer EXH (if O ∈ parse and outer Q = some)
-  -- Exh_O(some) = some ∧ ¬all: "some but not all types satisfy inner pred"
+  -- Step 2: outer quantifier
+  let base := AltQuant.outerEval u.outer.toAlt nSat sSat aSat
+  -- Step 3: outer EXH (if O ∈ parse and outer Q = some): some ∧ ¬all
   let afterO :=
-    if p.hasO && u.outer == .some_ then
-      let allMeaning := outerEval .all nSat sSat aSat
-      fun w => baseMeaning w && !allMeaning w
-    else baseMeaning
-  -- Step 4: Matrix EXH (if M ∈ parse)
-  -- Uses MW with strength filter on LITERAL alternative meanings (eq. A2)
+    if p.hasO && u.outer == .some then
+      fun w => base w && !(AltQuant.outerEval .all nSat sSat aSat w)
+    else base
+  -- Step 4: matrix EXH (if M ∈ parse), eq. A2
   if p.hasM then
-    let enriched := afterO  -- meaning under parse without M
-    -- Filter: keep sentential alternatives strictly stronger than enriched
-    -- (S'^lit ⊂ enriched, proper subset)
     let strongerAlts := (matrixAlts u).filter fun a =>
-      a != u &&
-      allWorlds.all (fun w => if literalMeaning a w then enriched w else true) &&
-      allWorlds.any (fun w => enriched w && !literalMeaning a w)
-    -- Negate all stronger alternatives' LITERAL meanings (MW style)
-    let result : World → Bool := fun w =>
-      enriched w && strongerAlts.all fun a => !literalMeaning a w
-    -- Noncontradictory check (eq. A2): if empty, fall back to enriched
-    if allWorlds.any result then result else enriched
+      allWorlds.all (fun w => !altLiteral a w || afterO w) &&
+      allWorlds.any (fun w => afterO w && !altLiteral a w)
+    let result : World → Bool := fun w => afterO w && strongerAlts.all fun a => !altLiteral a w
+    if allWorlds.any result then result else afterO
   else afterO
 
--- ============================================================================
--- §5. Verification Theorems
--- ============================================================================
+/-! ### Truth-table verification (the paper's Table 1) -/
 
-/-- Literal SS is true at 6 of 7 worlds (all except wN). -/
-theorem ss_literal_count :
-    (allWorlds.filter (literalMeaning .ss)).length = 6 := by native_decide
+/-- EXH_I(SS): inner EXH enriches "some" to "some but not all", so the outer
+"some" requires an S-type — {wNS, wNSA, wS, wSA}. -/
+theorem exh_i_ss :
+    allWorlds.map (exhMeaning .i .ss) = [false, true, false, true, true, true, false] := by
+  decide
 
-/-- EXH_I(SS) = worlds with S-types (compositional: "some aliens drank
-    some but not all"). Inner EXH enriches "some" to "some but not all",
-    so S-types satisfy the VP but A-types do not. The outer "some"
-    requires at least one S-type, giving {wNS, wNSA, wS, wSA}. -/
-theorem exh_i_ss : exhMeaning .i .ss .wNS = true
-    ∧ exhMeaning .i .ss .wNSA = true
-    ∧ exhMeaning .i .ss .wS = true
-    ∧ exhMeaning .i .ss .wSA = true
-    ∧ exhMeaning .i .ss .wN = false
-    ∧ exhMeaning .i .ss .wNA = false
-    ∧ exhMeaning .i .ss .wA = false := by
-  exact ⟨by native_decide, by native_decide, by native_decide,
-         by native_decide, by native_decide, by native_decide,
-         by native_decide⟩
+/-- EXH_OI(SS) = {wNS, wNSA, wSA}: outer "some but not all" alien types satisfy
+the enriched inner predicate; wS drops because there all types satisfy it. -/
+theorem exh_oi_ss :
+    allWorlds.map (exhMeaning .oi .ss) = [false, true, false, true, false, true, false] := by
+  decide
 
-/-- EXH_OI(SS) = {wNS, wNSA, wSA} — outer "some but not all" alien types
-    satisfy the enriched inner predicate. wS excluded because at wS all
-    types (just S) satisfy the inner pred, so "all" would be true. -/
-theorem exh_oi_ss : exhMeaning .oi .ss .wNS = true
-    ∧ exhMeaning .oi .ss .wNSA = true
-    ∧ exhMeaning .oi .ss .wSA = true
-    ∧ exhMeaning .oi .ss .wS = false := by
-  exact ⟨by native_decide, by native_decide, by native_decide,
-         by native_decide⟩
-
-/-- EXH_MOI(SS) = EXH_OI(SS) = {wNS, wNSA, wSA} — matrix EXH is vacuous
-    here because no sentential alternative is strictly stronger than
-    the OI-enriched meaning. -/
-theorem exh_moi_ss : ∀ w : World,
-    exhMeaning .moi .ss w = exhMeaning .oi .ss w := by native_decide
+/-- EXH_MOI(SS) = EXH_OI(SS): matrix EXH is vacuous at MOI — no sentential
+alternative's literal meaning is a proper subset of the OI-enriched meaning. -/
+theorem exh_moi_ss : ∀ w : World, exhMeaning .moi .ss w = exhMeaning .oi .ss w := by
+  decide
 
 /-- AA is true only at wA under all parses. -/
-theorem aa_singleton : ∀ p : Parse, ∀ w : World,
-    exhMeaning p .aa w = (w == .wA) := by native_decide
+theorem aa_singleton : ∀ p : Parse, ∀ w : World, exhMeaning p .aa w = (w == .wA) := by
+  decide
 
-/-- Full truth table for SS across key parses, matching Table 1 of the paper.
-    Format: (parse, [wN, wNS, wNA, wNSA, wS, wSA, wA]). -/
+/-- Table 1, SS: the four reading families (lit / I / OI / M). -/
 theorem table1_ss :
-    -- lit: SS true everywhere except wN
     (allWorlds.map (exhMeaning .none .ss) = [false, true, true, true, true, true, true])
-    -- I: inner EXH keeps worlds with S-types
     ∧ (allWorlds.map (exhMeaning .i .ss) = [false, true, false, true, true, true, false])
-    -- OI: outer "some but not all" excludes wS (only S-types → all satisfy)
     ∧ (allWorlds.map (exhMeaning .oi .ss) = [false, true, false, true, false, true, false])
-    -- MOI: same as OI (matrix EXH vacuous here)
-    ∧ (allWorlds.map (exhMeaning .moi .ss) = [false, true, false, true, false, true, false])
-    := by exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
+    ∧ (allWorlds.map (exhMeaning .m .ss) = [false, true, false, false, false, false, false]) := by
+  decide
 
--- ============================================================================
--- §6. Latent spaces of the four models
--- ============================================================================
+/-- Table 1, NN: matrix-free parses give {wS, wSA, wA}; matrix parses negate
+the strictly stronger "none of the aliens drank not all of their water"
+(= {wA}), dropping wA — the paper's fn. 7 reading, available only because
+`not all` is a lexical alternative of `none`. -/
+theorem table1_nn :
+    (∀ p : Parse, p.hasM = false →
+      allWorlds.map (exhMeaning p .nn) = [false, false, false, false, true, true, true])
+    ∧ (∀ p : Parse, p.hasM = true →
+      allWorlds.map (exhMeaning p .nn) = [false, false, false, false, true, true, false]) := by
+  decide
 
-/-- LU lexicon: literal or OI (inner + outer EXH). Each speaker has a
-    fixed lexicon; the listener marginalizes over the two lexica to infer
-    the world state. Mirrors the [potts-etal-2016] architecture. -/
+/-- Table 1, NS: literal {wN}; inner EXH weakens to {wN, wNA, wA}; adding
+matrix EXH then negates the sentence's own (strictly stronger) literal
+meaning, giving {wNA, wA}. -/
+theorem table1_ns :
+    (allWorlds.map (exhMeaning .none .ns) = [true, false, false, false, false, false, false])
+    ∧ (allWorlds.map (exhMeaning .i .ns) = [true, false, true, false, false, false, true])
+    ∧ (allWorlds.map (exhMeaning .mi .ns) = [false, false, true, false, false, false, true]) := by
+  decide
+
+/-- Table 1, AN: maximally informative — only wN. All parses agree. -/
+theorem table1_an : ∀ p : Parse,
+    allWorlds.map (exhMeaning p .an) = [true, false, false, false, false, false, false] := by
+  decide
+
+/-- Table 1, AA: only wA. All parses agree (cf. `aa_singleton`). -/
+theorem table1_aa : ∀ p : Parse,
+    allWorlds.map (exhMeaning p .aa) = [false, false, false, false, false, false, true] := by
+  decide
+
+/-- Table 1, SA: "some drank all" requires an A-type; EXH_O enriches outer
+"some" to "some but not all", excluding wA. -/
+theorem table1_sa :
+    (allWorlds.map (exhMeaning .none .sa) = [false, false, true, true, false, true, true])
+    ∧ (allWorlds.map (exhMeaning .o .sa) = [false, false, true, true, false, true, false]) := by
+  decide
+
+/-- Table 1, NA: "none drank all" = {wN, wNS, wS}; matrix EXH negates the
+stronger NS (= {wN}), removing wN. -/
+theorem table1_na :
+    (allWorlds.map (exhMeaning .none .na) = [true, true, false, false, true, false, false])
+    ∧ (allWorlds.map (exhMeaning .m .na) = [false, true, false, false, true, false, false]) := by
+  decide
+
+/-- Table 1, SN: "some drank none" = {wN, wNS, wNA, wNSA}; outer EXH (or
+matrix EXH) negates AN = {wN}. -/
+theorem table1_sn :
+    (allWorlds.map (exhMeaning .none .sn) = [true, true, true, true, false, false, false])
+    ∧ (allWorlds.map (exhMeaning .o .sn) = [false, true, true, true, false, false, false]) := by
+  decide
+
+/-- Table 1, AS: "all drank some" = {wS, wSA, wA}; EXH_I narrows to wS;
+matrix EXH without I negates AA, excluding wA. -/
+theorem table1_as :
+    (allWorlds.map (exhMeaning .none .as) = [false, false, false, false, true, true, true])
+    ∧ (allWorlds.map (exhMeaning .i .as) = [false, false, false, false, true, false, false])
+    ∧ (allWorlds.map (exhMeaning .m .as) = [false, false, false, false, true, true, false]) := by
+  decide
+
+/-- Literal meaning is the empty parse's exhaustified meaning. -/
+theorem literal_eq_exh_none : ∀ u : Utterance, ∀ w : World,
+    literalMeaning u w = exhMeaning .none u w := by decide
+
+/-- ⟦SS⟧^M = {wNS}: matrix EXH narrows SS to a single world — the reading
+that "uniquely singles out this world state" (eq. 22) and drives GI's win. -/
+theorem m_ss_singleton : ∀ w : World, exhMeaning .m .ss w = (w == .wNS) := by decide
+
+/-- The paper's matrix operator (eq. A2) is **not** Fox-style innocent
+exclusion ([fox-2007]): on SS's own sentential alternatives with the
+OI-enriched prejacent, innocent exclusion excludes SA, AS, and AA and narrows
+⟦SS⟧^OI to {wNS}, while A2's strictly-stronger filter comes up empty and MOI
+keeps all of {wNS, wNSA, wSA} — witness wSA. -/
+theorem moi_ss_ne_innocent_exclusion :
+    exhMeaning .moi .ss .wSA = true
+      ∧ World.wSA ∉ Exhaustification.innocent.exh
+          (Exhaustification.altsFromPreds ((matrixAlts .ss).map altLiteral))
+          (Exhaustification.predToFinset (exhMeaning .oi .ss)) := by
+  decide
+
+/-! ### Latent spaces -/
+
+/-- LU lexicon: literal or OI (inner + outer EXH). Each speaker has a fixed
+lexicon; the listener marginalizes over the two lexica. -/
 inductive LULex where
   | lit | oi
-  deriving DecidableEq, Repr, Inhabited
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
-instance : Fintype LULex where
-  elems := {.lit, .oi}
-  complete := fun x => by cases x <;> simp
-
-/-- Map LU lexicon to the corresponding Parse. -/
+/-- Map LU lexicon to the corresponding parse. -/
 def LULex.toParse : LULex → Parse
-  | .lit => .none | .oi => .oi
+  | .lit => .none
+  | .oi => .oi
 
-/-- LI parse: lit, I, O, or OI. The speaker actively chooses a parse per
-    utterance (unlike LU, where each speaker has a fixed lexicon). -/
+/-- LI parse: lit, I, O, or OI — matrix-EXH parses are unavailable. -/
 inductive LIParse where
   | lit | i | o | oi
-  deriving DecidableEq, Repr, Inhabited
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
-instance : Fintype LIParse where
-  elems := {.lit, .i, .o, .oi}
-  complete := fun x => by cases x <;> simp
-
-/-- Map LI parse to the full Parse type. -/
+/-- Map LI parse to the full parse space. -/
 def LIParse.toParse : LIParse → Parse
-  | .lit => .none | .i => .i | .o => .o | .oi => .oi
+  | .lit => .none
+  | .i => .i
+  | .o => .o
+  | .oi => .oi
 
--- ============================================================================
--- §7. The shared per-parse speaker
--- ============================================================================
+/-- LI cannot access matrix EXH: no LI parse includes M. -/
+theorem li_excludes_matrix : ∀ l : LIParse, l.toParse.hasM = false := by decide
 
-/-! All four models share **one speaker family** `S : World × Parse → PMF
-Utterance`: the [frank-goodman-2012] softmax at exponent `α = 2` of the
-per-parse literal listener `L0(· | u, p)` (uniform on `exhMeaning p u`'s
-extension). The speaker at state `(w, p)` depends only on parse `p`'s Boolean
-meaning, so vanilla / LU / LI / GI differ *only* in the latent space their
-pragmatic listener marginalises over. Built on the `RSA.Canonical` PMF
-pipeline (`powUtility`/`L0OfBool`), so `S = PMF.normalize (L0^2)`
-(`RSA.Canonical.S1_powUtility_eq_normalize`). -/
+/-- LU cannot access matrix EXH: neither lexicon includes M. -/
+theorem lu_excludes_matrix : ∀ l : LULex, l.toParse.hasM = false := by decide
+
+/-! ### Speakers
+
+The per-parse speaker `speaker (w, p) ∝ L0(w | ·, p)²` (eq. 11, the parse an
+*argument*) serves vanilla and LU. The LI/GI speakers (eqs. 18a/21a, the parse
+an *output*) run the same power utility over (utterance, parse) *pairs*: one
+softmax per world across the whole pair space, so a pair's overall
+informativity — not its within-parse share — drives production. -/
 
 /-- Every utterance is true at some world under every parse, so each per-parse
-literal listener is well-defined (`L0OfBool`'s nonempty-extension obligation). -/
+literal listener is well-defined. -/
 theorem ext_nonempty (p : Parse) (u : Utterance) :
-    (RSA.extensionOf (exhMeaning p) u).Nonempty := by
-  cases p <;> cases u <;> decide
+    (RSA.extensionOf (exhMeaning p) u).Nonempty := by cases p <;> cases u <;> decide
 
-/-- The per-parse literal listener `L0(· | u, p) : PMF World`, uniform on the
-extension of `exhMeaning p u`. -/
-noncomputable def L0m : Parse → Utterance → PMF World :=
-  RSA.Canonical.L0OfBool exhMeaning ext_nonempty
+/-- The per-parse literal listener `L0(· | u, p)`, uniform on the extension of
+`exhMeaning p u`. -/
+noncomputable abbrev L0 : Parse → Utterance → PMF World :=
+  L0OfBool exhMeaning ext_nonempty
 
-/-- Every `(world, parse)` state has an applicable (true) utterance — the
-`ViableSpeaker` witness that makes the softmax speaker well-defined. -/
+/-- Every `(world, parse)` state has a true utterance. -/
 theorem exists_true (w : World) (p : Parse) : ∃ u, exhMeaning p u w = true := by
   cases w <;> cases p <;> decide
 
-noncomputable instance : RSA.Canonical.ViableSpeaker (RSA.Canonical.powUtility 2 L0m) :=
-  RSA.Canonical.viableSpeaker_powUtility_of_witness 2 L0m (fun s => by
-    obtain ⟨w, p⟩ := s
-    obtain ⟨u, hu⟩ := exists_true w p
-    exact ⟨u, RSA.Canonical.L0OfBool_ne_zero exhMeaning ext_nonempty hu⟩)
+noncomputable instance : ViableSpeaker (powUtility 2 L0) :=
+  viableSpeaker_powUtility_of_witness 2 L0 fun s => by
+    obtain ⟨u, hu⟩ := exists_true s.1 s.2
+    exact ⟨u, L0OfBool_ne_zero exhMeaning ext_nonempty hu⟩
 
-/-- The shared pragmatic speaker `S(w, p) ∝ L0(w | ·, p)^2` (α = 2, no cost). -/
-noncomputable def S : World × Parse → PMF Utterance :=
-  RSA.Canonical.S1 (RSA.Canonical.powUtility 2 L0m)
+/-- The per-parse (fixed-lexicon) speaker of the vanilla and LU models. -/
+noncomputable def speaker : World × Parse → PMF Utterance := S1 (powUtility 2 L0)
 
-/-- LU speaker: the shared speaker re-indexed by the 2-lexicon latent. -/
-noncomputable def luS (s : World × LULex) : PMF Utterance := S (s.1, s.2.toParse)
+/-- LU speaker: the per-parse speaker re-indexed by the 2-lexicon latent. -/
+noncomputable def luSpeaker (s : World × LULex) : PMF Utterance := speaker (s.1, s.2.toParse)
 
-/-- LI speaker: the shared speaker re-indexed by the 4-parse latent. -/
-noncomputable def liS (s : World × LIParse) : PMF Utterance := S (s.1, s.2.toParse)
+/-- Vanilla speaker: the per-parse speaker at the literal parse. -/
+noncomputable def vanillaSpeaker (w : World) : PMF Utterance := speaker (w, .none)
 
-/-- Vanilla speaker: the shared speaker at the literal parse only. -/
-noncomputable def vanillaS (w : World) : PMF Utterance := S (w, .none)
+/-- GI meaning family: an (utterance, parse) pair means its parse's reading.
+The `Unit` index is the degenerate latent of the `L0OfBool` shape. -/
+def giMeaning : Unit → Utterance × Parse → World → Bool := fun _ x => exhMeaning x.2 x.1
 
--- ============================================================================
--- §8. Speaker mass as exact rationals
--- ============================================================================
+theorem gi_ext_nonempty (i : Unit) (x : Utterance × Parse) :
+    (RSA.extensionOf (giMeaning i) x).Nonempty := ext_nonempty x.2 x.1
 
-/-! Each speaker mass `S(w, p) u` is an exact rational: `0` when `exhMeaning
-p u w` is false, else `|ext(p,u)|⁻² / Z(w,p)` where `Z(w,p) = Σ_u |ext(p,u)|⁻²`
-sums over utterances true at `w`. The `pw_*` lemmas give the unnormalised
-weight `L0^2`; the `Z_*` lemmas the partition; the `s_*` lemmas the normalised
-mass as `ENNReal.ofReal q`. Cards are certified by `decide`, arithmetic by
-`norm_num`. -/
+noncomputable abbrev giL0 : Unit → Utterance × Parse → PMF World :=
+  L0OfBool giMeaning gi_ext_nonempty
 
-/-- Unnormalised speaker weight at a true utterance: `|ext(p,u)|⁻²`. -/
-theorem pw_true {p : Parse} {u : Utterance} {w : World} {k : ℕ}
-    (h : exhMeaning p u w = true) (hk : (RSA.extensionOf (exhMeaning p) u).card = k) :
-    RSA.Canonical.powWeight 2 L0m (w, p) u = ENNReal.ofReal ((k : ℝ)⁻¹ ^ 2) := by
-  have hpos : 0 < k := hk ▸ Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
-  simp only [L0m]
-  rw [RSA.Canonical.powWeight_L0OfBool_of_mem exhMeaning ext_nonempty k h hk,
-    ENNReal.ofReal_pow (by positivity),
-    ENNReal.ofReal_inv_of_pos (by exact_mod_cast hpos), ENNReal.ofReal_natCast]
+noncomputable instance : ViableSpeaker (powUtility 2 giL0) :=
+  viableSpeaker_powUtility_of_witness 2 giL0 fun s => by
+    obtain ⟨u, hu⟩ := exists_true s.1 .none
+    exact ⟨(u, .none), L0OfBool_ne_zero giMeaning gi_ext_nonempty hu⟩
 
-/-- Unnormalised speaker weight at a false utterance: `0` (as `ofReal 0`, so
-partition sums combine uniformly through `ENNReal.ofReal_add`). -/
-theorem pw_false {p : Parse} {u : Utterance} {w : World}
-    (h : exhMeaning p u w = false) :
-    RSA.Canonical.powWeight 2 L0m (w, p) u = ENNReal.ofReal 0 := by
-  rw [ENNReal.ofReal_zero]
-  simp only [L0m]
-  exact RSA.Canonical.powWeight_L0OfBool_of_not_mem exhMeaning ext_nonempty (by decide)
-    (by rw [h]; decide)
+/-- The GI speaker (eq. 21a): one softmax over all 72 (utterance, parse)
+pairs at each world. -/
+noncomputable def giSpeaker (w : World) : PMF (Utterance × Parse) :=
+  S1 (powUtility 2 giL0) (w, ())
 
-/-- Enumeration of the nine utterances (for partition sums). -/
-theorem sumU (f : Utterance → ℝ≥0∞) :
-    ∑' u, f u = f .nn + f .ns + f .na + f .sn + f .ss + f .sa + f .an + f .as_ + f .aa := by
-  rw [tsum_fintype,
-    show (Finset.univ : Finset Utterance)
-      = {.nn, .ns, .na, .sn, .ss, .sa, .an, .as_, .aa} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_singleton]
-  ring
+/-- LI meaning family: as `giMeaning`, over the 4 matrix-free parses. -/
+def liMeaning : Unit → Utterance × LIParse → World → Bool := fun _ x => exhMeaning x.2.toParse x.1
 
-/-- Normalised speaker mass at a true utterance: `|ext(p,u)|⁻² / Z(w,p)`, as an
-exact `ENNReal.ofReal` rational. `hZ` supplies the partition `Z(w,p)`. -/
-theorem S_val {p : Parse} {u : Utterance} {w : World} {k : ℕ} {z q : ℝ}
-    (h : exhMeaning p u w = true) (hk : (RSA.extensionOf (exhMeaning p) u).card = k)
-    (hz : 0 < z)
-    (hZ : (∑' u', RSA.Canonical.powWeight 2 L0m (w, p) u') = ENNReal.ofReal z)
-    (hq : (k : ℝ)⁻¹ ^ 2 / z = q) :
-    S (w, p) u = ENNReal.ofReal q := by
-  unfold S
-  rw [RSA.Canonical.S1_powUtility_eq_normalize, PMF.normalize_apply, pw_true h hk, hZ,
-    ← ENNReal.ofReal_inv_of_pos hz, ← ENNReal.ofReal_mul (by positivity), ← div_eq_mul_inv, hq]
+theorem li_ext_nonempty (i : Unit) (x : Utterance × LIParse) :
+    (RSA.extensionOf (liMeaning i) x).Nonempty := ext_nonempty x.2.toParse x.1
 
-/-- Normalised speaker mass at a false utterance: `0`. -/
-theorem S_zero {p : Parse} {u : Utterance} {w : World}
-    (h : exhMeaning p u w = false) : S (w, p) u = 0 := by
-  unfold S
-  rw [RSA.Canonical.S1_powUtility_eq_normalize, PMF.normalize_apply, pw_false h,
-    ENNReal.ofReal_zero, zero_mul]
+noncomputable abbrev liL0 : Unit → Utterance × LIParse → PMF World :=
+  L0OfBool liMeaning li_ext_nonempty
 
-/-- `S_zero` in `ofReal 0` form, so pooled parse sums combine uniformly. -/
-theorem S_zero' {p : Parse} {u : Utterance} {w : World}
-    (h : exhMeaning p u w = false) : S (w, p) u = ENNReal.ofReal 0 := by
-  rw [ENNReal.ofReal_zero]; exact S_zero h
+noncomputable instance : ViableSpeaker (powUtility 2 liL0) :=
+  viableSpeaker_powUtility_of_witness 2 liL0 fun s => by
+    obtain ⟨u, hu⟩ := exists_true s.1 .none
+    exact ⟨(u, .lit), L0OfBool_ne_zero liMeaning li_ext_nonempty hu⟩
 
-/-- The shared speaker never assigns zero mass to a true utterance — the
-witness for the pragmatic listener's marginal-nonzero obligations. -/
-theorem S_ne_zero {p : Parse} {u : Utterance} {w : World}
-    (h : exhMeaning p u w = true) : S (w, p) u ≠ 0 := by
-  have hpos : 0 < (RSA.extensionOf (exhMeaning p) u).card :=
-    Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
-  unfold S
-  rw [RSA.Canonical.S1_powUtility_eq_normalize, ← PMF.mem_support_iff,
-    PMF.mem_support_normalize_iff, pw_true h rfl, ne_eq, ENNReal.ofReal_eq_zero, not_le]
-  exact pow_pos (inv_pos.mpr (by exact_mod_cast hpos)) 2
+/-- The LI speaker (eq. 18a): one softmax over the 36 (utterance, parse)
+pairs with matrix-free parses. -/
+noncomputable def liSpeaker (w : World) : PMF (Utterance × LIParse) :=
+  S1 (powUtility 2 liL0) (w, ())
 
-/-- Partition `Z(wNS, none) = 1/9 + 1/16 + 1/36 = 29/144` (SS-worlds: na, sn, ss). -/
-theorem Z_none_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .none) u') = ENNReal.ofReal (29 / 144) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 4) (by decide) (by decide),
-    pw_true (k := 6) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1
-  norm_num
+/-! ### The four pragmatic listeners -/
 
-/-- `S(wNS, none) ss = 4/29`. -/
-theorem s_none_wNS_ss : S (.wNS, .none) .ss = ENNReal.ofReal (4 / 29) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wNS (by norm_num)
-
-/-- Enumeration of the eight parses (for the GI latent marginal). -/
-theorem sumParse (f : Parse → ℝ≥0∞) :
-    ∑ p : Parse, f p = f .none + f .m + f .o + f .i + f .mo + f .mi + f .oi + f .moi := by
-  rw [show (Finset.univ : Finset Parse) = {.none, .m, .o, .i, .mo, .mi, .oi, .moi} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-  ring
-
-/-! ### `wNS` partition and speaker masses (SS) -/
-
-theorem Z_m_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .m) u') = ENNReal.ofReal (49 / 36) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 1) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_o_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .o) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_i_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .i) u') = ENNReal.ofReal (17 / 72) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_true (k := 4) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mo_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .mo) u') = ENNReal.ofReal (17 / 36) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mi_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .mi) u') = ENNReal.ofReal (61 / 144) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 4) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_oi_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .oi) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_moi_wNS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNS, .moi) u') = ENNReal.ofReal (17 / 36) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_m_wNS_ss : S (.wNS, .m) .ss = ENNReal.ofReal (36 / 49) :=
-  S_val (k := 1) (by decide) (by decide) (by norm_num) Z_m_wNS (by norm_num)
-theorem s_o_wNS_ss : S (.wNS, .o) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_o_wNS (by norm_num)
-theorem s_i_wNS_ss : S (.wNS, .i) .ss = ENNReal.ofReal (9 / 34) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_i_wNS (by norm_num)
-theorem s_mo_wNS_ss : S (.wNS, .mo) .ss = ENNReal.ofReal (4 / 17) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_mo_wNS (by norm_num)
-theorem s_mi_wNS_ss : S (.wNS, .mi) .ss = ENNReal.ofReal (9 / 61) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_mi_wNS (by norm_num)
-theorem s_oi_wNS_ss : S (.wNS, .oi) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_oi_wNS (by norm_num)
-theorem s_moi_wNS_ss : S (.wNS, .moi) .ss = ENNReal.ofReal (4 / 17) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_moi_wNS (by norm_num)
-
-theorem sumP_wNS_ss :
-    (∑ p : Parse, S (.wNS, p) .ss) = ENNReal.ofReal (21415141 / 8841462) := by
-  rw [sumParse, s_none_wNS_ss, s_m_wNS_ss, s_o_wNS_ss, s_i_wNS_ss, s_mo_wNS_ss, s_mi_wNS_ss,
-    s_oi_wNS_ss, s_moi_wNS_ss]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-/-! ### `wNSA` partition and speaker masses (SS) -/
-
-theorem Z_none_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .none) u') = ENNReal.ofReal (11 / 72) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_true (k := 6) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_o_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .o) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_i_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .i) u') = ENNReal.ofReal (3 / 16) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_true (k := 4) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mo_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .mo) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mi_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .mi) u') = ENNReal.ofReal (41 / 144) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 4) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_oi_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .oi) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_moi_wNSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNSA, .moi) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_none_wNSA_ss : S (.wNSA, .none) .ss = ENNReal.ofReal (2 / 11) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wNSA (by norm_num)
-theorem s_o_wNSA_ss : S (.wNSA, .o) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_o_wNSA (by norm_num)
-theorem s_i_wNSA_ss : S (.wNSA, .i) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_i_wNSA (by norm_num)
-theorem s_mo_wNSA_ss : S (.wNSA, .mo) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_mo_wNSA (by norm_num)
-theorem s_mi_wNSA_ss : S (.wNSA, .mi) .ss = ENNReal.ofReal (9 / 41) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_mi_wNSA (by norm_num)
-theorem s_oi_wNSA_ss : S (.wNSA, .oi) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_oi_wNSA (by norm_num)
-theorem s_moi_wNSA_ss : S (.wNSA, .moi) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_moi_wNSA (by norm_num)
-
-theorem sumP_wNSA_ss :
-    (∑ p : Parse, S (.wNSA, p) .ss) = ENNReal.ofReal (2798 / 1353) := by
-  rw [sumParse, s_none_wNSA_ss, S_zero' (w := .wNSA) (p := .m) (u := .ss) (by decide),
-    s_o_wNSA_ss, s_i_wNSA_ss, s_mo_wNSA_ss, s_mi_wNSA_ss, s_oi_wNSA_ss, s_moi_wNSA_ss]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-/-! ### `wS` partition and speaker masses (SS and AS) -/
-
-theorem Z_none_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .none) u') = ENNReal.ofReal (13 / 36) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 6) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_m_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .m) u') = ENNReal.ofReal (11 / 18) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 2) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_o_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .o) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_i_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .i) u') = ENNReal.ofReal (185 / 144) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 1) (by decide) (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mo_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .mo) u') = ENNReal.ofReal (11 / 18) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 2) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_true (k := 2) (by decide) (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mi_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .mi) u') = ENNReal.ofReal (205 / 144) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 2) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 1) (by decide) (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_oi_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .oi) u') = ENNReal.ofReal (11 / 9) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_true (k := 1) (by decide) (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_moi_wS :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wS, .moi) u') = ENNReal.ofReal (49 / 36) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 2) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_true (k := 1) (by decide) (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_none_wS_ss : S (.wS, .none) .ss = ENNReal.ofReal (1 / 13) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wS (by norm_num)
-theorem s_i_wS_ss : S (.wS, .i) .ss = ENNReal.ofReal (9 / 185) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_i_wS (by norm_num)
-theorem s_mi_wS_ss : S (.wS, .mi) .ss = ENNReal.ofReal (9 / 205) :=
-  S_val (k := 4) (by decide) (by decide) (by norm_num) Z_mi_wS (by norm_num)
-
-theorem s_none_wS_as : S (.wS, .none) .as_ = ENNReal.ofReal (4 / 13) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_none_wS (by norm_num)
-theorem s_m_wS_as : S (.wS, .m) .as_ = ENNReal.ofReal (9 / 22) :=
-  S_val (k := 2) (by decide) (by decide) (by norm_num) Z_m_wS (by norm_num)
-theorem s_o_wS_as : S (.wS, .o) .as_ = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_o_wS (by norm_num)
-theorem s_i_wS_as : S (.wS, .i) .as_ = ENNReal.ofReal (144 / 185) :=
-  S_val (k := 1) (by decide) (by decide) (by norm_num) Z_i_wS (by norm_num)
-theorem s_mo_wS_as : S (.wS, .mo) .as_ = ENNReal.ofReal (9 / 22) :=
-  S_val (k := 2) (by decide) (by decide) (by norm_num) Z_mo_wS (by norm_num)
-theorem s_mi_wS_as : S (.wS, .mi) .as_ = ENNReal.ofReal (144 / 205) :=
-  S_val (k := 1) (by decide) (by decide) (by norm_num) Z_mi_wS (by norm_num)
-theorem s_oi_wS_as : S (.wS, .oi) .as_ = ENNReal.ofReal (9 / 11) :=
-  S_val (k := 1) (by decide) (by decide) (by norm_num) Z_oi_wS (by norm_num)
-theorem s_moi_wS_as : S (.wS, .moi) .as_ = ENNReal.ofReal (36 / 49) :=
-  S_val (k := 1) (by decide) (by decide) (by norm_num) Z_moi_wS (by norm_num)
-
-/-! ### `wNA`, `wSA`, `wA` partitions and speaker masses -/
-
-theorem Z_none_wNA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNA, .none) u') = ENNReal.ofReal (11 / 72) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_true (k := 6) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_o_wNA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNA, .o) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_mo_wNA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wNA, .mo) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_none_wNA_ss : S (.wNA, .none) .ss = ENNReal.ofReal (2 / 11) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wNA (by norm_num)
-theorem s_o_wNA_ss : S (.wNA, .o) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_o_wNA (by norm_num)
-theorem s_mo_wNA_ss : S (.wNA, .mo) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_mo_wNA (by norm_num)
-
-theorem Z_none_wSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wSA, .none) u') = ENNReal.ofReal (5 / 16) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_true (k := 6) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_moi_wSA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wSA, .moi) u') = ENNReal.ofReal (1 / 3) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_true (k := 3) (by decide) (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_none_wSA_ss : S (.wSA, .none) .ss = ENNReal.ofReal (4 / 45) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wSA (by norm_num)
-theorem s_moi_wSA_ss : S (.wSA, .moi) .ss = ENNReal.ofReal (1 / 3) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_moi_wSA (by norm_num)
-
-theorem Z_none_wA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wA, .none) u') = ENNReal.ofReal (21 / 16) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_true (k := 6) (by decide) (by decide),
-    pw_true (k := 4) (by decide) (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 1) (by decide) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem Z_o_wA :
-    (∑' u', RSA.Canonical.powWeight 2 L0m (.wA, .o) u') = ENNReal.ofReal (11 / 9) := by
-  rw [sumU, pw_true (k := 3) (by decide) (by decide), pw_false (by decide), pw_false (by decide),
-    pw_false (by decide), pw_false (by decide), pw_false (by decide), pw_false (by decide),
-    pw_true (k := 3) (by decide) (by decide), pw_true (k := 1) (by decide) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by positivity) (by positivity)]
-  congr 1; norm_num
-
-theorem s_none_wA_ss : S (.wA, .none) .ss = ENNReal.ofReal (4 / 189) :=
-  S_val (k := 6) (by decide) (by decide) (by norm_num) Z_none_wA (by norm_num)
-theorem s_none_wA_as : S (.wA, .none) .as_ = ENNReal.ofReal (16 / 189) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_none_wA (by norm_num)
-theorem s_o_wA_as : S (.wA, .o) .as_ = ENNReal.ofReal (1 / 11) :=
-  S_val (k := 3) (by decide) (by decide) (by norm_num) Z_o_wA (by norm_num)
-
-/-! ### Pooled speaker sums for the remaining worlds -/
-
-theorem sumP_wS_ss : (∑ p : Parse, S (.wS, p) .ss) = ENNReal.ofReal (16711 / 98605) := by
-  rw [sumParse, s_none_wS_ss, S_zero' (w := .wS) (p := .m) (u := .ss) (by decide),
-    S_zero' (w := .wS) (p := .o) (u := .ss) (by decide), s_i_wS_ss,
-    S_zero' (w := .wS) (p := .mo) (u := .ss) (by decide), s_mi_wS_ss,
-    S_zero' (w := .wS) (p := .oi) (u := .ss) (by decide),
-    S_zero' (w := .wS) (p := .moi) (u := .ss) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumP_wNA_ss : (∑ p : Parse, S (.wNA, p) .ss) = ENNReal.ofReal (28 / 33) := by
-  rw [sumParse, s_none_wNA_ss, S_zero' (w := .wNA) (p := .m) (u := .ss) (by decide), s_o_wNA_ss,
-    S_zero' (w := .wNA) (p := .i) (u := .ss) (by decide), s_mo_wNA_ss,
-    S_zero' (w := .wNA) (p := .mi) (u := .ss) (by decide),
-    S_zero' (w := .wNA) (p := .oi) (u := .ss) (by decide),
-    S_zero' (w := .wNA) (p := .moi) (u := .ss) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumP_wS_as :
-    (∑ p : Parse, S (.wS, p) .as_) = ENNReal.ofReal (716367317 / 159444285) := by
-  rw [sumParse, s_none_wS_as, s_m_wS_as, s_o_wS_as, s_i_wS_as, s_mo_wS_as, s_mi_wS_as,
-    s_oi_wS_as, s_moi_wS_as]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumP_wA_as : (∑ p : Parse, S (.wA, p) .as_) = ENNReal.ofReal (365 / 2079) := by
-  rw [sumParse, s_none_wA_as, S_zero' (w := .wA) (p := .m) (u := .as_) (by decide), s_o_wA_as,
-    S_zero' (w := .wA) (p := .i) (u := .as_) (by decide),
-    S_zero' (w := .wA) (p := .mo) (u := .as_) (by decide),
-    S_zero' (w := .wA) (p := .mi) (u := .as_) (by decide),
-    S_zero' (w := .wA) (p := .oi) (u := .as_) (by decide),
-    S_zero' (w := .wA) (p := .moi) (u := .as_) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-/-- `AA` is false at `wSA` under every parse, so its pooled speaker sum is `0`. -/
-theorem sumP_wSA_aa : (∑ p : Parse, S (.wSA, p) .aa) = 0 :=
-  Finset.sum_eq_zero fun p _ => S_zero (by rw [aa_singleton]; decide)
-
-/-! ### Latent pooling over worlds (parse-preference) -/
-
-/-- Enumeration of the seven worlds (for the GI parse marginal). -/
-theorem sumWorld (f : World → ℝ≥0∞) :
-    ∑ w : World, f w = f .wN + f .wNS + f .wNA + f .wNSA + f .wS + f .wSA + f .wA := by
-  rw [show (Finset.univ : Finset World) = {.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_singleton]
-  ring
-
-theorem sumW_none_ss :
-    (∑ w : World, S (w, .none) .ss) = ENNReal.ofReal (2698343 / 3918915) := by
-  rw [sumWorld, S_zero' (w := .wN) (p := .none) (u := .ss) (by decide), s_none_wNS_ss,
-    s_none_wNA_ss, s_none_wNSA_ss, s_none_wS_ss, s_none_wSA_ss, s_none_wA_ss]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumW_moi_ss : (∑ w : World, S (w, .moi) .ss) = ENNReal.ofReal (46 / 51) := by
-  rw [sumWorld, S_zero' (w := .wN) (p := .moi) (u := .ss) (by decide), s_moi_wNS_ss,
-    S_zero' (w := .wNA) (p := .moi) (u := .ss) (by decide), s_moi_wNSA_ss,
-    S_zero' (w := .wS) (p := .moi) (u := .ss) (by decide), s_moi_wSA_ss,
-    S_zero' (w := .wA) (p := .moi) (u := .ss) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-/-! ### LU / LI pooling over the smaller latent spaces -/
-
-theorem sumLULex (f : LULex → ℝ≥0∞) : ∑ l : LULex, f l = f .lit + f .oi := by
-  rw [show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_singleton]
-
-theorem sumLU_wNS_ss : (∑ l : LULex, luS (.wNS, l) .ss) = ENNReal.ofReal (41 / 87) := by
-  rw [sumLULex]
-  show S (.wNS, .none) .ss + S (.wNS, .oi) .ss = _
-  rw [s_none_wNS_ss, s_oi_wNS_ss, ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumLU_wNA_ss : (∑ l : LULex, luS (.wNA, l) .ss) = ENNReal.ofReal (2 / 11) := by
-  rw [sumLULex]
-  show S (.wNA, .none) .ss + S (.wNA, .oi) .ss = _
-  rw [s_none_wNA_ss, S_zero' (w := .wNA) (p := .oi) (u := .ss) (by decide),
-    ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumLIParse (f : LIParse → ℝ≥0∞) :
-    ∑ l : LIParse, f l = f .lit + f .i + f .o + f .oi := by
-  rw [show (Finset.univ : Finset LIParse) = {.lit, .i, .o, .oi} from by decide,
-    Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_insert (by decide),
-    Finset.sum_singleton]
-  ring
-
-theorem sumLI_wNS_ss : (∑ l : LIParse, liS (.wNS, l) .ss) = ENNReal.ofReal (3163 / 2958) := by
-  rw [sumLIParse]
-  show S (.wNS, .none) .ss + S (.wNS, .i) .ss + S (.wNS, .o) .ss + S (.wNS, .oi) .ss = _
-  rw [s_none_wNS_ss, s_i_wNS_ss, s_o_wNS_ss, s_oi_wNS_ss]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumLI_wS_ss : (∑ l : LIParse, liS (.wS, l) .ss) = ENNReal.ofReal (302 / 2405) := by
-  rw [sumLIParse]
-  show S (.wS, .none) .ss + S (.wS, .i) .ss + S (.wS, .o) .ss + S (.wS, .oi) .ss = _
-  rw [s_none_wS_ss, s_i_wS_ss, S_zero' (w := .wS) (p := .o) (u := .ss) (by decide),
-    S_zero' (w := .wS) (p := .oi) (u := .ss) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
-theorem sumLI_wNA_ss : (∑ l : LIParse, liS (.wNA, l) .ss) = ENNReal.ofReal (17 / 33) := by
-  rw [sumLIParse]
-  show S (.wNA, .none) .ss + S (.wNA, .i) .ss + S (.wNA, .o) .ss + S (.wNA, .oi) .ss = _
-  rw [s_none_wNA_ss, S_zero' (w := .wNA) (p := .i) (u := .ss) (by decide), s_o_wNA_ss,
-    S_zero' (w := .wNA) (p := .oi) (u := .ss) (by decide)]
-  repeat rw [← ENNReal.ofReal_add (by norm_num) (by norm_num)]
-  congr 1; norm_num
-
--- ============================================================================
--- §9. The four pragmatic listeners
--- ============================================================================
-
-/-- GI (§3.4): joint posterior over `World × Parse` (8 parses). -/
-noncomputable def giListener (u : Utterance)
-    (h : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) u ≠ 0) :
-    PMF (World × Parse) :=
-  RSA.Canonical.L1 S (PMF.uniformOfFintype (World × Parse)) u h
-
-/-- LU (§3.2): joint posterior over `World × LULex`. -/
-noncomputable def luListener (u : Utterance)
-    (h : PMF.marginal luS (PMF.uniformOfFintype (World × LULex)) u ≠ 0) :
-    PMF (World × LULex) :=
-  RSA.Canonical.L1 luS (PMF.uniformOfFintype (World × LULex)) u h
-
-/-- LI (§3.3): joint posterior over `World × LIParse`. -/
-noncomputable def liListener (u : Utterance)
-    (h : PMF.marginal liS (PMF.uniformOfFintype (World × LIParse)) u ≠ 0) :
-    PMF (World × LIParse) :=
-  RSA.Canonical.L1 liS (PMF.uniformOfFintype (World × LIParse)) u h
-
-/-- Vanilla (§3.1): posterior over `World` for the single literal parse. -/
+/-- Vanilla listener (eq. 9): posterior over worlds. -/
 noncomputable def vanillaListener (u : Utterance)
-    (h : PMF.marginal vanillaS (PMF.uniformOfFintype World) u ≠ 0) : PMF World :=
-  PMF.posterior vanillaS (PMF.uniformOfFintype World) u h
+    (h : PMF.marginal vanillaSpeaker (PMF.uniformOfFintype World) u ≠ 0) : PMF World :=
+  PMF.posterior vanillaSpeaker (PMF.uniformOfFintype World) u h
 
--- ============================================================================
--- §10. Predictions
--- ============================================================================
+/-- LU listener (eqs. 12–13): joint posterior over `World × LULex` — the
+lexicon is part of the state, drawn with the world. -/
+noncomputable def luListener (u : Utterance)
+    (h : PMF.marginal luSpeaker (PMF.uniformOfFintype (World × LULex)) u ≠ 0) :
+    PMF (World × LULex) :=
+  L1 luSpeaker (PMF.uniformOfFintype (World × LULex)) u h
 
-/-! ### Listener-preference reductions
+/-- LI listener (eq. 18b): posterior over `World × LIParse` from the observed
+utterance component of the speaker's pair choice. -/
+noncomputable def liListener (u : Utterance)
+    (h : PMF.marginal (fun w => (liSpeaker w).fst) (PMF.uniformOfFintype World) u ≠ 0) :
+    PMF (World × LIParse) :=
+  L1Intent liSpeaker (PMF.uniformOfFintype World) u h
 
-Each pragmatic listener's preference cancels the uniform joint prior, leaving a
-comparison of pooled speaker sums over the model's latent space (`L1_world_/
-_latent_prefers_iff`). -/
+/-- GI listener (eq. 21b): posterior over `World × Parse` from the observed
+utterance component of the speaker's pair choice. -/
+noncomputable def giListener (u : Utterance)
+    (h : PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) u ≠ 0) :
+    PMF (World × Parse) :=
+  L1Intent giSpeaker (PMF.uniformOfFintype World) u h
 
-/-- GI world preference reduces to the pooled speaker sum over the 8 parses. -/
-theorem giListener_fst_lt (u : Utterance)
-    (h : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) u ≠ 0) (w₁ w₂ : World) :
-    (giListener u h).fst w₁ < (giListener u h).fst w₂ ↔
-      (∑ p : Parse, S (w₁, p) u) < ∑ p : Parse, S (w₂, p) u := by
-  unfold giListener
-  rw [RSA.Canonical.L1_world_prefers_iff]
-  simp only [PMF.uniformOfFintype_apply]
-  rw [← Finset.mul_sum, ← Finset.mul_sum]
-  exact ENNReal.mul_lt_mul_iff_right
-    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top (Fintype.card (World × Parse))))
-    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr (Fintype.card_ne_zero (α := World × Parse))))
+/-! ### Exact rational reductions
 
-/-- GI parse preference reduces to the pooled speaker sum over the 7 worlds. -/
-theorem giListener_snd_lt (u : Utterance)
-    (h : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) u ≠ 0) (l₁ l₂ : Parse) :
-    (giListener u h).snd l₁ < (giListener u h).snd l₂ ↔
-      (∑ w : World, S (w, l₁) u) < ∑ w : World, S (w, l₂) u := by
-  unfold giListener
-  rw [RSA.Canonical.L1_latent_prefers_iff]
-  simp only [PMF.uniformOfFintype_apply]
-  rw [← Finset.mul_sum, ← Finset.mul_sum]
-  exact ENNReal.mul_lt_mul_iff_right
-    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top (Fintype.card (World × Parse))))
-    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr (Fintype.card_ne_zero (α := World × Parse))))
+Each listener preference reduces (uniform prior cancelling) to a comparison of
+pooled speaker sums, which `S1_eq_ofReal`/`sum_S1_eq_ofReal` evaluate as exact
+rationals; `norm_num` closes the resulting `ℚ` inequalities against the
+partition values below. -/
 
-/-- LU world preference reduces to the pooled speaker sum over the 2 lexica. -/
-theorem luListener_fst_lt (u : Utterance)
-    (h : PMF.marginal luS (PMF.uniformOfFintype (World × LULex)) u ≠ 0) (w₁ w₂ : World) :
-    (luListener u h).fst w₁ < (luListener u h).fst w₂ ↔
-      (∑ l : LULex, luS (w₁, l) u) < ∑ l : LULex, luS (w₂, l) u := by
-  unfold luListener
-  rw [RSA.Canonical.L1_world_prefers_iff]
-  simp only [PMF.uniformOfFintype_apply]
-  rw [← Finset.mul_sum, ← Finset.mul_sum]
-  exact ENNReal.mul_lt_mul_iff_right
-    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top (Fintype.card (World × LULex))))
-    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr (Fintype.card_ne_zero (α := World × LULex))))
+private theorem univU : (Finset.univ : Finset Utterance)
+    = {.nn, .ns, .na, .sn, .ss, .sa, .an, .as, .aa} := by decide
 
-/-- LI world preference reduces to the pooled speaker sum over the 4 parses. -/
-theorem liListener_fst_lt (u : Utterance)
-    (h : PMF.marginal liS (PMF.uniformOfFintype (World × LIParse)) u ≠ 0) (w₁ w₂ : World) :
-    (liListener u h).fst w₁ < (liListener u h).fst w₂ ↔
-      (∑ l : LIParse, liS (w₁, l) u) < ∑ l : LIParse, liS (w₂, l) u := by
-  unfold liListener
-  rw [RSA.Canonical.L1_world_prefers_iff]
-  simp only [PMF.uniformOfFintype_apply]
-  rw [← Finset.mul_sum, ← Finset.mul_sum]
-  exact ENNReal.mul_lt_mul_iff_right
-    (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top (Fintype.card (World × LIParse))))
-    (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr (Fintype.card_ne_zero (α := World × LIParse))))
+private theorem univP : (Finset.univ : Finset Parse)
+    = {.none, .m, .o, .i, .mo, .mi, .oi, .moi} := by decide
+
+private theorem univW : (Finset.univ : Finset World)
+    = {.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA} := by decide
+
+private theorem univLU : (Finset.univ : Finset LULex) = {.lit, .oi} := by decide
+
+private theorem univLI : (Finset.univ : Finset LIParse) = {.lit, .i, .o, .oi} := by decide
+
+/-! GI partitions `Z(w) = Σ_{(u,p)} |ext(u,p)|⁻²` over the 72 pairs. -/
+
+private theorem zGI_wN : boolPartition giMeaning 2 () World.wN = 307/24 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wNS : boolPartition giMeaning 2 () World.wNS = 23/6 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wNA : boolPartition giMeaning 2 () World.wNA = 23/9 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wNSA : boolPartition giMeaning 2 () World.wNSA = 157/72 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wS : boolPartition giMeaning 2 () World.wS = 559/72 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wSA : boolPartition giMeaning 2 () World.wSA = 10/3 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+private theorem zGI_wA : boolPartition giMeaning 2 () World.wA = 229/24 := by
+  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
+
+/-! LI partitions over the 36 matrix-free pairs. -/
+
+private theorem zLI_wNS : boolPartition liMeaning 2 () World.wNS = 53/48 := by
+  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
+
+private theorem zLI_wNA : boolPartition liMeaning 2 () World.wNA = 19/18 := by
+  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
+
+private theorem zLI_wS : boolPartition liMeaning 2 () World.wS = 461/144 := by
+  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+    Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
+
+/-! Per-parse partitions (vanilla and LU). -/
+
+private theorem zNone_wNS : boolPartition exhMeaning 2 (.none : Parse) World.wNS = 29/144 := by
+  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univU, univW]
+
+private theorem zNone_wNA : boolPartition exhMeaning 2 (.none : Parse) World.wNA = 11/72 := by
+  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univU, univW]
+
+private theorem zOI_wNS : boolPartition exhMeaning 2 (.oi : Parse) World.wNS = 1/3 := by
+  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univU, univW]
+
+private theorem zOI_wNA : boolPartition exhMeaning 2 (.oi : Parse) World.wNA = 1/3 := by
+  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univU, univW]
+
+/-! Pooled speaker sums in `ofReal`-of-`ℚ` form. -/
+
+private theorem gi_sum_eq (w : World) (u : Utterance) :
+    (∑ p : Parse, giSpeaker w (u, p))
+      = ENNReal.ofReal (∑ p : Parse, boolS1 giMeaning 2 () w (u, p)) :=
+  sum_S1_eq_ofReal giMeaning gi_ext_nonempty (by norm_num) Finset.univ
+    (fun _ => (w, ())) (fun p => (u, p))
+
+private theorem gi_sumW_eq (p : Parse) (u : Utterance) :
+    (∑ w : World, giSpeaker w (u, p))
+      = ENNReal.ofReal (∑ w : World, boolS1 giMeaning 2 () w (u, p)) :=
+  sum_S1_eq_ofReal giMeaning gi_ext_nonempty (by norm_num) Finset.univ
+    (fun w => (w, ())) (fun _ => (u, p))
+
+private theorem li_sum_eq (w : World) (u : Utterance) :
+    (∑ l : LIParse, liSpeaker w (u, l))
+      = ENNReal.ofReal (∑ l : LIParse, boolS1 liMeaning 2 () w (u, l)) :=
+  sum_S1_eq_ofReal liMeaning li_ext_nonempty (by norm_num) Finset.univ
+    (fun _ => (w, ())) (fun l => (u, l))
+
+private theorem speaker_eq (p : Parse) (w : World) (u : Utterance) :
+    speaker (w, p) u = ENNReal.ofReal (boolS1 exhMeaning 2 p w u) :=
+  S1_eq_ofReal exhMeaning ext_nonempty (by norm_num) p w u
+
+private theorem lu_sum_eq (w : World) (u : Utterance) :
+    (∑ l : LULex, luSpeaker (w, l) u)
+      = ENNReal.ofReal (boolS1 exhMeaning 2 (.none : Parse) w u
+          + boolS1 exhMeaning 2 (.oi : Parse) w u) := by
+  rw [show (Finset.univ : Finset LULex) = {.lit, .oi} from univLU,
+    Finset.sum_insert (by decide), Finset.sum_singleton]
+  show speaker (w, .none) u + speaker (w, .oi) u = _
+  rw [speaker_eq, speaker_eq,
+    ← ENNReal.ofReal_add (by exact_mod_cast boolS1_nonneg exhMeaning 2 _ w u)
+      (by exact_mod_cast boolS1_nonneg exhMeaning 2 _ w u)]
+
+private theorem vanilla_eq (w : World) (u : Utterance) :
+    vanillaSpeaker w u = ENNReal.ofReal (boolS1 exhMeaning 2 (.none : Parse) w u) :=
+  S1_eq_ofReal exhMeaning ext_nonempty (by norm_num) .none w u
+
+/-! Listener-preference reductions to `ℚ`. -/
+
+private theorem gi_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
+    (hq : (∑ p : Parse, boolS1 giMeaning 2 () w₁ (u, p))
+        < ∑ p : Parse, boolS1 giMeaning 2 () w₂ (u, p)) :
+    (giListener u h).fst w₁ < (giListener u h).fst w₂ := by
+  have h₀ : (0 : ℚ) ≤ ∑ p : Parse, boolS1 giMeaning 2 () w₁ (u, p) :=
+    Finset.sum_nonneg fun p _ => boolS1_nonneg giMeaning 2 () w₁ (u, p)
+  rw [giListener, L1Intent_uniform_world_prefers_iff, gi_sum_eq, gi_sum_eq,
+    ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
+  exact_mod_cast hq
+
+private theorem gi_snd_lt {u : Utterance} (h) {p₁ p₂ : Parse}
+    (hq : (∑ w : World, boolS1 giMeaning 2 () w (u, p₁))
+        < ∑ w : World, boolS1 giMeaning 2 () w (u, p₂)) :
+    (giListener u h).snd p₁ < (giListener u h).snd p₂ := by
+  have h₀ : (0 : ℚ) ≤ ∑ w : World, boolS1 giMeaning 2 () w (u, p₁) :=
+    Finset.sum_nonneg fun w _ => boolS1_nonneg giMeaning 2 () w (u, p₁)
+  rw [giListener, L1Intent_uniform_latent_prefers_iff, gi_sumW_eq, gi_sumW_eq,
+    ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
+  exact_mod_cast hq
+
+private theorem li_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
+    (hq : (∑ l : LIParse, boolS1 liMeaning 2 () w₁ (u, l))
+        < ∑ l : LIParse, boolS1 liMeaning 2 () w₂ (u, l)) :
+    (liListener u h).fst w₁ < (liListener u h).fst w₂ := by
+  have h₀ : (0 : ℚ) ≤ ∑ l : LIParse, boolS1 liMeaning 2 () w₁ (u, l) :=
+    Finset.sum_nonneg fun l _ => boolS1_nonneg liMeaning 2 () w₁ (u, l)
+  rw [liListener, L1Intent_uniform_world_prefers_iff, li_sum_eq, li_sum_eq,
+    ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
+  exact_mod_cast hq
+
+private theorem lu_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
+    (hq : boolS1 exhMeaning 2 (.none : Parse) w₁ u + boolS1 exhMeaning 2 (.oi : Parse) w₁ u
+        < boolS1 exhMeaning 2 (.none : Parse) w₂ u + boolS1 exhMeaning 2 (.oi : Parse) w₂ u) :
+    (luListener u h).fst w₁ < (luListener u h).fst w₂ := by
+  have h₀ : (0 : ℚ) ≤ boolS1 exhMeaning 2 (.none : Parse) w₁ u
+      + boolS1 exhMeaning 2 (.oi : Parse) w₁ u :=
+    add_nonneg (boolS1_nonneg exhMeaning 2 _ w₁ u) (boolS1_nonneg exhMeaning 2 _ w₁ u)
+  rw [luListener, L1_uniform_world_prefers_iff, lu_sum_eq, lu_sum_eq,
+    ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
+  exact_mod_cast hq
+
+private theorem vanilla_lt {u : Utterance} (h) {w₁ w₂ : World}
+    (hq : boolS1 exhMeaning 2 (.none : Parse) w₁ u < boolS1 exhMeaning 2 (.none : Parse) w₂ u) :
+    (vanillaListener u h) w₁ < (vanillaListener u h) w₂ := by
+  have h₀ : (0 : ℚ) ≤ boolS1 exhMeaning 2 (.none : Parse) w₁ u :=
+    boolS1_nonneg exhMeaning 2 _ w₁ u
+  rw [vanillaListener, PMF.posterior_lt_iff_kernel_lt_of_uniform, vanilla_eq, vanilla_eq,
+    ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
+  exact_mod_cast hq
 
 /-! ### Marginal-nonzero witnesses -/
 
-theorem gi_marg_ss : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) .ss ≠ 0 :=
-  PMF.marginal_ne_zero S (PMF.uniformOfFintype (World × Parse)) .ss (a := (.wNS, .none))
-    (((PMF.uniformOfFintype (World × Parse)).mem_support_iff (.wNS, .none)).mp
-      (PMF.mem_support_uniformOfFintype _))
-    (S_ne_zero (by decide))
+theorem gi_marg_ss :
+    PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .ss ≠ 0 :=
+  L1Intent_uniform_marginal_ne_zero giSpeaker
+    (show giSpeaker .wNS (.ss, .none) ≠ 0 from
+      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
 
-theorem gi_marg_aa : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) .aa ≠ 0 :=
-  PMF.marginal_ne_zero S (PMF.uniformOfFintype (World × Parse)) .aa (a := (.wA, .none))
-    (((PMF.uniformOfFintype (World × Parse)).mem_support_iff (.wA, .none)).mp
-      (PMF.mem_support_uniformOfFintype _))
-    (S_ne_zero (by decide))
+theorem gi_marg_aa :
+    PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .aa ≠ 0 :=
+  L1Intent_uniform_marginal_ne_zero giSpeaker
+    (show giSpeaker .wA (.aa, .none) ≠ 0 from
+      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
 
-theorem gi_marg_as : PMF.marginal S (PMF.uniformOfFintype (World × Parse)) .as_ ≠ 0 :=
-  PMF.marginal_ne_zero S (PMF.uniformOfFintype (World × Parse)) .as_ (a := (.wS, .none))
-    (((PMF.uniformOfFintype (World × Parse)).mem_support_iff (.wS, .none)).mp
-      (PMF.mem_support_uniformOfFintype _))
-    (S_ne_zero (by decide))
+theorem gi_marg_as :
+    PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .as ≠ 0 :=
+  L1Intent_uniform_marginal_ne_zero giSpeaker
+    (show giSpeaker .wS (.as, .none) ≠ 0 from
+      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
 
-theorem lu_marg_ss : PMF.marginal luS (PMF.uniformOfFintype (World × LULex)) .ss ≠ 0 := by
-  refine PMF.marginal_ne_zero luS (PMF.uniformOfFintype (World × LULex)) .ss (a := (.wNS, .lit))
+theorem li_marg_ss :
+    PMF.marginal (fun w => (liSpeaker w).fst) (PMF.uniformOfFintype World) .ss ≠ 0 :=
+  L1Intent_uniform_marginal_ne_zero liSpeaker
+    (show liSpeaker .wNS (.ss, .lit) ≠ 0 from
+      S1_L0OfBool_ne_zero liMeaning li_ext_nonempty (by decide))
+
+theorem lu_marg_ss :
+    PMF.marginal luSpeaker (PMF.uniformOfFintype (World × LULex)) .ss ≠ 0 :=
+  PMF.marginal_ne_zero luSpeaker (PMF.uniformOfFintype (World × LULex)) .ss
+    (a := (.wNS, .lit))
     (((PMF.uniformOfFintype (World × LULex)).mem_support_iff (.wNS, .lit)).mp
-      (PMF.mem_support_uniformOfFintype _)) ?_
-  show S (.wNS, .none) .ss ≠ 0
-  exact S_ne_zero (by decide)
+      (PMF.mem_support_uniformOfFintype _))
+    (show speaker (.wNS, .none) .ss ≠ 0 from
+      S1_L0OfBool_ne_zero exhMeaning ext_nonempty (by decide))
 
-theorem li_marg_ss : PMF.marginal liS (PMF.uniformOfFintype (World × LIParse)) .ss ≠ 0 := by
-  refine PMF.marginal_ne_zero liS (PMF.uniformOfFintype (World × LIParse)) .ss (a := (.wNS, .lit))
-    (((PMF.uniformOfFintype (World × LIParse)).mem_support_iff (.wNS, .lit)).mp
-      (PMF.mem_support_uniformOfFintype _)) ?_
-  show S (.wNS, .none) .ss ≠ 0
-  exact S_ne_zero (by decide)
-
-theorem vanilla_marg_ss : PMF.marginal vanillaS (PMF.uniformOfFintype World) .ss ≠ 0 := by
-  refine PMF.marginal_ne_zero vanillaS (PMF.uniformOfFintype World) .ss (a := .wNS)
+theorem vanilla_marg_ss :
+    PMF.marginal vanillaSpeaker (PMF.uniformOfFintype World) .ss ≠ 0 :=
+  PMF.marginal_ne_zero vanillaSpeaker (PMF.uniformOfFintype World) .ss (a := .wNS)
     (((PMF.uniformOfFintype World).mem_support_iff .wNS).mp
-      (PMF.mem_support_uniformOfFintype _)) ?_
-  show S (.wNS, .none) .ss ≠ 0
-  exact S_ne_zero (by decide)
+      (PMF.mem_support_uniformOfFintype _))
+    (show speaker (.wNS, .none) .ss ≠ 0 from
+      S1_L0OfBool_ne_zero exhMeaning ext_nonempty (by decide))
 
 /-! ### The ten qualitative findings -/
 
-/-- SS exhaustifies inner quantifier: L1 prefers wNS (N and S types, no A)
-    over wNSA (all three types including A). Inner EXH negates "some drank all",
-    disfavoring worlds with A-type aliens. -/
+/-- SS exhaustifies the inner quantifier: GI's listener prefers wNS (no A-type
+aliens) to wNSA. -/
 theorem ss_inner_exh :
-    (giListener .ss gi_marg_ss).fst .wNS > (giListener .ss gi_marg_ss).fst .wNSA := by
-  rw [gt_iff_lt, giListener_fst_lt, sumP_wNSA_ss, sumP_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (giListener .ss gi_marg_ss).fst .wNSA < (giListener .ss gi_marg_ss).fst .wNS :=
+  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wNSA])
 
-/-- SS exhaustifies outer quantifier: L1 prefers wNS (mixed N+S types)
-    over wS (only S-type). At wS, "all aliens drank some but not all" would
-    be true, but outer EXH negates the "all" reading. -/
+/-- SS exhaustifies the outer quantifier: GI's listener prefers wNS (mixed
+types) to wS, where "all aliens drank some but not all" would hold. -/
 theorem ss_outer_exh :
-    (giListener .ss gi_marg_ss).fst .wNS > (giListener .ss gi_marg_ss).fst .wS := by
-  rw [gt_iff_lt, giListener_fst_lt, sumP_wS_ss, sumP_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (giListener .ss gi_marg_ss).fst .wS < (giListener .ss gi_marg_ss).fst .wNS :=
+  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wS])
 
-/-- AA correctly identifies the unique world where all aliens drank all: L1
-    prefers wA over wSA. AA is false at wSA under every parse (pooled sum `0`),
-    while at wA the literal parse already makes it true. -/
+/-- AA identifies the unique world where all aliens drank all: wA over wSA
+(where AA is false under every parse). -/
 theorem aa_identifies :
-    (giListener .aa gi_marg_aa).fst .wA > (giListener .aa gi_marg_aa).fst .wSA := by
-  rw [gt_iff_lt, giListener_fst_lt, sumP_wSA_aa]
-  exact pos_iff_ne_zero.mpr fun hz =>
-    S_ne_zero (p := .none) (w := .wA) (by decide)
-      (Finset.sum_eq_zero_iff.mp hz .none (Finset.mem_univ _))
+    (giListener .aa gi_marg_aa).fst .wSA < (giListener .aa gi_marg_aa).fst .wA :=
+  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wSA, zGI_wA])
 
-/-- AS exhaustifies inner: L1 prefers wS (all aliens are "some" drinkers)
-    over wA (all aliens are "all" drinkers). -/
+/-- AS exhaustifies the inner quantifier: GI's listener prefers wS (all aliens
+are some-but-not-all drinkers) to wA. -/
 theorem as_inner_exh :
-    (giListener .as_ gi_marg_as).fst .wS > (giListener .as_ gi_marg_as).fst .wA := by
-  rw [gt_iff_lt, giListener_fst_lt, sumP_wA_as, sumP_wS_as,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (giListener .as gi_marg_as).fst .wA < (giListener .as gi_marg_as).fst .wS :=
+  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wS, zGI_wA])
 
-/-- Full exhaustification is preferred: for SS, the GI parse marginal assigns
-    more probability to the fully exhaustified parse (MOI) than to the literal
-    parse (NONE). -/
-theorem ss_parse_pref :
-    (giListener .ss gi_marg_ss).snd .moi > (giListener .ss gi_marg_ss).snd .none := by
-  rw [gt_iff_lt, giListener_snd_lt, sumW_none_ss, sumW_moi_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+/-- GI's parse posterior for SS peaks at the matrix-only parse M — the
+model-side face of the paper's explanation for GI's win: ⟦SS⟧^M = {wNS}
+uniquely identifies the state SS is in fact used for. Under per-parse
+normalization (the LU architecture) M would rank only mid-field; pair choice
+is what lets the maximally informative parse dominate. -/
+theorem ss_m_parse_pref : ∀ p : Parse, p ≠ .m →
+    (giListener .ss gi_marg_ss).snd p < (giListener .ss gi_marg_ss).snd .m := by
+  intro p hp
+  cases p
+  case m => exact absurd rfl hp
+  all_goals
+    exact gi_snd_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+      Finset.filter_insert, Finset.filter_singleton, univW, zGI_wN, zGI_wNS, zGI_wNA,
+      zGI_wNSA, zGI_wS, zGI_wSA, zGI_wA])
 
-/-- Vanilla RSA hearing SS prefers wNA over wNS — the wrong prediction.
-    Without exhaustification SS is literally true at 6/7 worlds, and the
-    competing utterances make wNA "win" more of the S1 score. Production data
-    show SS is used for wNS, evidence for grammatical enrichment. -/
+/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction: without
+exhaustification SS is literally true at 6 of 7 worlds and competing utterances
+absorb wNS. The paper's cost-free illustration (eq. 10); its direction reverses
+at the paper's fitted cost for *none*-initial utterances. -/
 theorem vanilla_ss_prefers_wNA :
-    (vanillaListener .ss vanilla_marg_ss) .wNA > (vanillaListener .ss vanilla_marg_ss) .wNS := by
-  rw [gt_iff_lt]
-  unfold vanillaListener
-  rw [PMF.posterior_lt_iff_kernel_lt_of_uniform]
-  show S (.wNS, .none) .ss < S (.wNA, .none) .ss
-  rw [s_none_wNS_ss, s_none_wNA_ss, ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (vanillaListener .ss vanilla_marg_ss) .wNS < (vanillaListener .ss vanilla_marg_ss) .wNA :=
+  vanilla_lt _ (by norm_num +decide [boolS1, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univW, zNone_wNS, zNone_wNA])
 
-/-- GI correctly predicts the opposite: SS → wNS, not wNA. The exhaustified
-    parses concentrate probability on worlds with S-types but not A-types. -/
+/-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
-    (giListener .ss gi_marg_ss).fst .wNS > (giListener .ss gi_marg_ss).fst .wNA := by
-  rw [gt_iff_lt, giListener_fst_lt, sumP_wNA_ss, sumP_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (giListener .ss gi_marg_ss).fst .wNA < (giListener .ss gi_marg_ss).fst .wNS :=
+  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wNA])
 
-/-- LU also gets the key SS prediction right: wNS > wNA. The OI lexicon gives
-    ⟦SS⟧^OI = {wNS, wNSA, wSA}, which excludes wNA, tipping the balance. -/
+/-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA. (The
+paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15.) -/
 theorem lu_ss_prefers_wNS :
-    (luListener .ss lu_marg_ss).fst .wNS > (luListener .ss lu_marg_ss).fst .wNA := by
-  rw [gt_iff_lt, luListener_fst_lt, sumLU_wNA_ss, sumLU_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (luListener .ss lu_marg_ss).fst .wNA < (luListener .ss lu_marg_ss).fst .wNS :=
+  lu_fst_lt _ (by norm_num +decide [boolS1, boolWeight, RSA.extensionOf,
+    Finset.filter_insert, Finset.filter_singleton, univW,
+    zNone_wNS, zNone_wNA, zOI_wNS, zOI_wNA])
 
-/-- LI derives outer exhaustification for SS via the OI parse:
-    ⟦SS⟧^OI = {wNS, wNSA, wSA} pins down worlds with mixed types (wNS > wS). -/
+/-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
-    (liListener .ss li_marg_ss).fst .wNS > (liListener .ss li_marg_ss).fst .wS := by
-  rw [gt_iff_lt, liListener_fst_lt, sumLI_wS_ss, sumLI_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
+    (liListener .ss li_marg_ss).fst .wS < (liListener .ss li_marg_ss).fst .wNS :=
+  li_fst_lt _ (by norm_num +decide [boolS1, boolWeight, liMeaning, LIParse.toParse,
+    RSA.extensionOf, Finset.filter_insert, Finset.filter_singleton, univLI, univW,
+    zLI_wNS, zLI_wS])
 
-/-- LI also gets the wNS > wNA ordering that vanilla misses. -/
+/-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
 theorem li_ss_prefers_wNS :
-    (liListener .ss li_marg_ss).fst .wNS > (liListener .ss li_marg_ss).fst .wNA := by
-  rw [gt_iff_lt, liListener_fst_lt, sumLI_wNA_ss, sumLI_wNS_ss,
-    ENNReal.ofReal_lt_ofReal_iff (by norm_num)]
-  norm_num
-
--- ============================================================================
--- §11. Extended Truth Table Verification
--- ============================================================================
-
-/-- NN is vacuously exhaustified: "none" is off-scale, so EXH at any
-    position has no alternatives to exclude. All parses agree. -/
-theorem table1_nn :
-    ∀ p : Parse, allWorlds.map (exhMeaning p .nn) =
-      [false, false, false, false, true, true, true] := by native_decide
-
-/-- AN is maximally informative: all types must satisfy "drank none."
-    Only wN (all N-types) works. All parses agree. -/
-theorem table1_an :
-    ∀ p : Parse, allWorlds.map (exhMeaning p .an) =
-      [true, false, false, false, false, false, false] := by native_decide
-
-/-- AA is maximally informative: all types must satisfy "drank all."
-    Only wA works. All parses agree (already proved in aa_singleton). -/
-theorem table1_aa :
-    ∀ p : Parse, allWorlds.map (exhMeaning p .aa) =
-      [false, false, false, false, false, false, true] := by native_decide
-
-/-- NS lit = {wN}: "none drank some" requires no type to satisfy
-    "drank some." S-types and A-types satisfy, so they must be absent.
-    Only wN (all N-types) works. -/
-theorem table1_ns :
-    allWorlds.map (exhMeaning .none .ns) =
-      [true, false, false, false, false, false, false] := by native_decide
-
-/-- SA: "some drank all" requires ≥1 A-type. EXH_I vacuous (inner=all).
-    EXH_O enriches outer "some" to "some but not all," excluding wA
-    (where all types are A → "all" would hold). -/
-theorem table1_sa :
-    (allWorlds.map (exhMeaning .none .sa) =
-      [false, false, true, true, false, true, true])
-    ∧ (allWorlds.map (exhMeaning .o .sa) =
-      [false, false, true, true, false, true, false]) := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- NA: "none drank all" requires no A-types. True at {wN, wNS, wS}.
-    Matrix EXH negates the stronger alternative NS (= "none drank some" =
-    {wN}), removing wN. -/
-theorem table1_na :
-    (allWorlds.map (exhMeaning .none .na) =
-      [true, true, false, false, true, false, false])
-    ∧ (allWorlds.map (exhMeaning .m .na) =
-      [false, true, false, false, true, false, false]) := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- SN: "some drank none" requires ≥1 N-type. True at {wN, wNS, wNA, wNSA}.
-    EXH_O enriches outer "some" to "some but not all," negating AN = {wN}.
-    Matrix EXH gives the same result (M ⊆ O for SN). -/
-theorem table1_sn :
-    (allWorlds.map (exhMeaning .none .sn) =
-      [true, true, true, true, false, false, false])
-    ∧ (allWorlds.map (exhMeaning .o .sn) =
-      [false, true, true, true, false, false, false]) := by
-  exact ⟨by native_decide, by native_decide⟩
-
-/-- AS: "all drank some" requires every type to satisfy "drank some."
-    EXH_I enriches to "all drank [some but not all]" — only S-types satisfy,
-    so only wS (all S-types) works. Matrix EXH without I negates AA,
-    excluding wA (where "all drank all" holds). -/
-theorem table1_as_full :
-    (allWorlds.map (exhMeaning .none .as_) =
-      [false, false, false, false, true, true, true])
-    ∧ (allWorlds.map (exhMeaning .i .as_) =
-      [false, false, false, false, true, false, false])
-    ∧ (allWorlds.map (exhMeaning .m .as_) =
-      [false, false, false, false, true, true, false]) := by
-  exact ⟨by native_decide, by native_decide, by native_decide⟩
-
--- ============================================================================
--- §12. Structural Properties
--- ============================================================================
-
-/-- Literal meaning equals exhaustified meaning under the empty parse. -/
-theorem literal_eq_exh_none : ∀ u : Utterance, ∀ w : World,
-    literalMeaning u w = exhMeaning .none u w := by native_decide
-
-/-- ⟦SS⟧^M = {wNS}: matrix EXH narrows SS to a single world.
-    This is the paper's key finding (§6): the M reading "uniquely singles
-    out this world state" (p. e86, eq. 22), giving GI its decisive
-    advantage over LI and LU. -/
-theorem m_ss_singleton : ∀ w : World,
-    exhMeaning .m .ss w = (w == .wNS) := by native_decide
-
-/-- LI cannot access M-containing parses: none of {lit, I, O, OI}
-    include matrix EXH. This excludes ⟦SS⟧^M from LI's parse space. -/
-theorem li_excludes_matrix : ∀ l : LIParse,
-    l.toParse.hasM = false := by decide
-
-/-- LU cannot access M-containing parses: neither lit nor OI
-    include matrix EXH. This excludes ⟦SS⟧^M from LU's parse space. -/
-theorem lu_excludes_matrix : ∀ l : LULex,
-    l.toParse.hasM = false := by decide
-
-/-- The latent space grows across models: 1 → 2 → 4 → 8. -/
-theorem latent_space_hierarchy :
-    Fintype.card Unit = 1 ∧
-    Fintype.card LULex = 2 ∧
-    Fintype.card LIParse = 4 ∧
-    Fintype.card Parse = 8 := by decide
-
--- ============================================================================
--- §13. Cross-Study Bridges
--- ============================================================================
-
-/-! ## Connection to [potts-etal-2016]
-
-The LU model here uses latent `LULex` (2 lexica: lit, OI), the same
-latent-variable architecture as [potts-etal-2016]'s weak/strong "some"
-lexica. Both implement Bergen et al.'s lexical uncertainty via the pragmatic
-listener's marginalisation over a latent lexicon — no special `LUScenario`
-infrastructure needed. Our LU uses L1 only; the paper adds an S2/L2
-layer (eqs. 14a-14b) for production predictions.
-
-## Connection to [cremers-wilcox-spector-2023]
-
-Cremers et al. test 9 model variants, including EXH-LU and RSA-LI, which
-correspond to our LU and LI listeners (`luListener`, `liListener`). Their key
-finding —
-grammatical models (EXH-LU, RSA-LI) block anti-exhaustivity regardless
-of prior bias — is consistent with our LU and LI predictions: both
-correctly derive exhaustification for SS (`lu_ss_prefers_wNS`,
-`li_ss_outer_exh`), concentrating probability on the exhaustified worlds.
-
-## Connection to [franke-2011]
-
-The matrix EXH in `exhMeaning` uses exh_MW: conjoin the sub-matrix meaning
-with the negation of all strictly stronger alternatives' literal meanings.
-[franke-2011] proves that IBR fixed points equal exh_MW for scalar
-games (`Franke2011.r1_eq_exhMW_under_totality`). This grounds the matrix
-position of our GI model in game-theoretic equilibrium semantics.
-
-## Connection to [fox-2007]
-
-The exhaustification implementation uses compositional enrichment at
-inner/outer quantifier positions (scale-mate substitution on {some, all})
-and MW-style sentential alternative negation at matrix position. The models
-differ only in which EXH positions are available to the speaker/listener,
-demonstrating that the key theoretical question is not HOW to exhaustify
-but WHERE EXH can be inserted and WHO controls the insertion (grammar vs.
-speaker vs. listener).
-
-## Why GI wins (§6)
-
-The decisive advantage of GI over LI and LU is the M parse:
-`m_ss_singleton` proves ⟦SS⟧^M = {wNS}, and `li_excludes_matrix` /
-`lu_excludes_matrix` prove that M-containing parses are structurally
-unavailable to the smaller models. Only GI can access the reading that
-uniquely identifies wNS, explaining its superior production predictions
-for SS (Figure 5, Figure 7c). -/
+    (liListener .ss li_marg_ss).fst .wNA < (liListener .ss li_marg_ss).fst .wNS :=
+  li_fst_lt _ (by norm_num +decide [boolS1, boolWeight, liMeaning, LIParse.toParse,
+    RSA.extensionOf, Finset.filter_insert, Finset.filter_singleton, univLI, univW,
+    zLI_wNS, zLI_wNA])
 
 end FrankeBergen2020


### PR DESCRIPTION
LI/GI were formalized with per-(world, parse) speaker normalization — the architecture the paper rejects (e85); its eqs. 18a/21a choose (utterance, parse) pairs jointly. Rebuilt on a new partial-observation posterior, with the paper's actual alternative set (none/not-all lexical alternatives; A3b properness filter), so all 72 Table 1 cells now verify, including NN's distinct matrix row and NS under MI/MOI.

- `PMF.emissionPosterior` + `RSA.Canonical.L1Intent` + exact-ℚ Bool-model evaluator in `Canonical.BoolModel` (replaces the 640-line hand-computed mass wall; RitchieSchiller2024 dedup queued as follow-up)
- new `ss_m_parse_pref` (GI's parse posterior for SS peaks at M — the paper's explanation of GI's win, false under the old normalization) and `moi_ss_ne_innocent_exclusion` (eq. A2 ≠ Fox-style innocent exclusion, decide-checked)
- docstring corrections (drops the Cremers-2023 chronology-violating section and the inaccurate Franke-2011 bridge; adds missing citations); `native_decide` → `decide` throughout