### PR TITLE
refactor(Pragmatics/RSA): Prop meanings throughout the RSA pipeline

### DIFF
--- a/Linglib/Pragmatics/RSA/Canonical.lean
+++ b/Linglib/Pragmatics/RSA/Canonical.lean
@@ -37,15 +37,15 @@ comparison of utilities / conditional-joint sums.
 * `RSA.Canonical.L1Intent` — pair-choice pragmatic listener: the speaker chooses an
   (utterance, latent) pair, the listener observes only the utterance
   (`PMF.emissionPosterior`).
-* `RSA.Canonical.boolS1` — the Boolean-model speaker as an exact rational.
+* `RSA.Canonical.ratS1` — the propositional-model speaker as an exact rational.
 
 ## Main statements
 
 * `RSA.Canonical.S1_prefers_iff` — speaker preference ↔ utility comparison.
 * `RSA.Canonical.L1_world_prefers_iff` / `L1_latent_prefers_iff` — listener marginal
   preference ↔ conditional-joint-sum comparison.
-* `RSA.Canonical.S1_eq_ofReal` — the power-utility speaker over a Boolean model
-  equals `ENNReal.ofReal` of `boolS1`.
+* `RSA.Canonical.S1_eq_ofReal` — the power-utility speaker over a propositional
+  model equals `ENNReal.ofReal` of `ratS1`.
 
 ## Implementation notes
 
@@ -420,155 +420,156 @@ theorem L1_uniform_event_lt_iff {W Lat U : Type*} [Fintype W] [Fintype Lat]
     (ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _))
     (ENNReal.inv_ne_top.mpr (Nat.cast_ne_zero.mpr Fintype.card_ne_zero))
 
-/-! ### Boolean-meaning literal listeners with latent interpretations
+/-! ### Propositional-meaning literal listeners with latent interpretations
 
-The [bergen-levy-goodman-2016] lexical-uncertainty shape: a Boolean meaning
+The [bergen-levy-goodman-2016] lexical-uncertainty shape: a decidable meaning
 per latent interpretation, the literal listener uniform on the extension. -/
 
-section BoolModel
+section PredModel
 
 variable {W I U : Type*} [Fintype W]
-variable (m : I → U → W → Bool) (hne : ∀ i u, (RSA.extensionOf (m i) u).Nonempty)
+variable (m : I → U → W → Prop) [∀ i u, DecidablePred (m i u)]
+  (hne : ∀ i u, (RSA.extensionOf (m i) u).Nonempty)
 
 /-- Per-interpretation literal listener: uniform on the extension. -/
-noncomputable def L0OfBool (i : I) (u : U) : PMF W :=
-  RSA.L0OfBoolMeaning (m i) u (hne i u)
+noncomputable def L0OfPred (i : I) (u : U) : PMF W :=
+  RSA.L0OfPred (m i) u (hne i u)
 
-theorem L0OfBool_ne_zero {i : I} {u : U} {w : W} (h : m i u w = true) :
-    L0OfBool m hne i u w ≠ 0 :=
-  (PMF.mem_support_iff _ _).mp ((RSA.mem_support_L0OfBoolMeaning_iff _ w).mpr h)
+theorem L0OfPred_ne_zero {i : I} {u : U} {w : W} (h : m i u w) :
+    L0OfPred m hne i u w ≠ 0 :=
+  (PMF.mem_support_iff _ _).mp ((RSA.mem_support_L0OfPred_iff _ w).mpr h)
 
-theorem L0OfBool_eq_zero {i : I} {u : U} {w : W} (h : m i u w ≠ true) :
-    L0OfBool m hne i u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+theorem L0OfPred_eq_zero {i : I} {u : U} {w : W} (h : ¬ m i u w) :
+    L0OfPred m hne i u w = 0 :=
+  RSA.L0OfPred_apply_of_not_mem _ h
 
-/-- Weight of the power-utility speaker over a Boolean model: the inverse
+/-- Weight of the power-utility speaker over a propositional model: the inverse
 extension size, to the `α`. -/
-theorem powWeight_L0OfBool_of_mem {α : ℕ} {w : W} {i : I} {u : U} (k : ℕ)
-    (h : m i u w = true) (hk : (RSA.extensionOf (m i) u).card = k) :
-    powWeight α (L0OfBool m hne) (w, i) u = ((k : ℝ≥0∞)⁻¹) ^ α := by
-  show (L0OfBool m hne i u w) ^ α = _
-  rw [L0OfBool, RSA.L0OfBoolMeaning_apply_of_mem _ h, hk]
+theorem powWeight_L0OfPred_of_mem {α : ℕ} {w : W} {i : I} {u : U} (k : ℕ)
+    (h : m i u w) (hk : (RSA.extensionOf (m i) u).card = k) :
+    powWeight α (L0OfPred m hne) (w, i) u = ((k : ℝ≥0∞)⁻¹) ^ α := by
+  show (L0OfPred m hne i u w) ^ α = _
+  rw [L0OfPred, RSA.L0OfPred_apply_of_mem _ h, hk]
 
-theorem powWeight_L0OfBool_of_not_mem {α : ℕ} (hα : α ≠ 0) {w : W} {i : I} {u : U}
-    (h : m i u w ≠ true) : powWeight α (L0OfBool m hne) (w, i) u = 0 := by
-  show (L0OfBool m hne i u w) ^ α = 0
-  rw [L0OfBool_eq_zero m hne h, zero_pow hα]
+theorem powWeight_L0OfPred_of_not_mem {α : ℕ} (hα : α ≠ 0) {w : W} {i : I} {u : U}
+    (h : ¬ m i u w) : powWeight α (L0OfPred m hne) (w, i) u = 0 := by
+  show (L0OfPred m hne i u w) ^ α = 0
+  rw [L0OfPred_eq_zero m hne h, zero_pow hα]
 
-/-- One-dominator bound over a Boolean model: if `u'` is also applicable with
+/-- One-dominator bound over a propositional model: if `u'` is also applicable with
 an extension smaller by an `ℕ`-certificate factor, `u` is produced with
 probability below `(n+1)⁻¹`. -/
-theorem S1_L0OfBool_lt_inv_succ_of_dominator {α : ℕ} [Fintype U]
-    [ViableSpeaker (powUtility α (L0OfBool m hne))]
+theorem S1_L0OfPred_lt_inv_succ_of_dominator {α : ℕ} [Fintype U]
+    [ViableSpeaker (powUtility α (L0OfPred m hne))]
     {w : W} {i : I} {u u' : U} {n k k' : ℕ} (huu' : u ≠ u')
-    (hu : m i u w = true) (hu' : m i u' w = true)
+    (hu : m i u w) (hu' : m i u' w)
     (hk : (RSA.extensionOf (m i) u).card = k)
     (hk' : (RSA.extensionOf (m i) u').card = k')
     (hα : α ≠ 0) (hcert : n * k' ^ α < k ^ α) :
-    S1 (powUtility α (L0OfBool m hne)) (w, i) u < ((n : ℝ≥0∞) + 1)⁻¹ := by
+    S1 (powUtility α (L0OfPred m hne)) (w, i) u < ((n : ℝ≥0∞) + 1)⁻¹ := by
   refine S1_powUtility_lt_inv_succ α _ (Finset.notMem_singleton.mpr huu') ?_
-  rw [Finset.sum_singleton, powWeight_L0OfBool_of_mem m hne k hu hk,
-      powWeight_L0OfBool_of_mem m hne k' hu' hk']
+  rw [Finset.sum_singleton, powWeight_L0OfPred_of_mem m hne k hu hk,
+      powWeight_L0OfPred_of_mem m hne k' hu' hk']
   refine ENNReal.natCast_mul_inv_pow_lt hα (fun h0 => ?_) hcert
   subst h0
   rw [Finset.card_eq_zero] at hk'
   exact absurd (hk' ▸ RSA.mem_extensionOf.mpr hu') (Finset.notMem_empty _)
 
-/-- The Boolean-model speaker never assigns zero mass to a true utterance —
+/-- The propositional-model speaker never assigns zero mass to a true utterance —
 the witness for pragmatic-listener positivity obligations. -/
-theorem S1_L0OfBool_ne_zero {α : ℕ} [Fintype U]
-    [ViableSpeaker (powUtility α (L0OfBool m hne))]
-    {i : I} {u : U} {w : W} (h : m i u w = true) :
-    S1 (powUtility α (L0OfBool m hne)) (w, i) u ≠ 0 :=
-  S1_ne_zero _ (show (α : EReal) * ENNReal.log (L0OfBool m hne i u w) ≠ ⊥ from
-    natCast_mul_log_ne_bot α (L0OfBool_ne_zero m hne h))
+theorem S1_L0OfPred_ne_zero {α : ℕ} [Fintype U]
+    [ViableSpeaker (powUtility α (L0OfPred m hne))]
+    {i : I} {u : U} {w : W} (h : m i u w) :
+    S1 (powUtility α (L0OfPred m hne)) (w, i) u ≠ 0 :=
+  S1_ne_zero _ (show (α : EReal) * ENNReal.log (L0OfPred m hne i u w) ≠ ⊥ from
+    natCast_mul_log_ne_bot α (L0OfPred_ne_zero m hne h))
 
-/-! ### Exact rational evaluation over a Boolean model
+/-! ### Exact rational evaluation over a propositional model
 
-`boolS1` computes the Boolean-model speaker as an exact rational and
+`ratS1` computes the propositional-model speaker as an exact rational and
 `S1_eq_ofReal` bridges it to `S1`; concrete masses and pooled sums then
 reduce to `ℚ` arithmetic (`norm_num`). -/
 
-/-- Exact rational unnormalised speaker weight over a Boolean model. -/
-def boolWeight (α : ℕ) (i : I) (w : W) (u : U) : ℚ :=
+/-- Exact rational unnormalised speaker weight over a propositional model. -/
+def ratWeight (α : ℕ) (i : I) (w : W) (u : U) : ℚ :=
   if m i u w then ((RSA.extensionOf (m i) u).card : ℚ)⁻¹ ^ α else 0
 
-/-- Exact rational partition function over a Boolean model. -/
-def boolPartition (α : ℕ) [Fintype U] (i : I) (w : W) : ℚ :=
-  ∑ u : U, boolWeight m α i w u
+/-- Exact rational partition function over a propositional model. -/
+def ratPartition (α : ℕ) [Fintype U] (i : I) (w : W) : ℚ :=
+  ∑ u : U, ratWeight m α i w u
 
-/-- Exact rational normalised speaker mass over a Boolean model. -/
-def boolS1 (α : ℕ) [Fintype U] (i : I) (w : W) (u : U) : ℚ :=
-  boolWeight m α i w u / boolPartition m α i w
+/-- Exact rational normalised speaker mass over a propositional model. -/
+def ratS1 (α : ℕ) [Fintype U] (i : I) (w : W) (u : U) : ℚ :=
+  ratWeight m α i w u / ratPartition m α i w
 
-theorem boolWeight_nonneg (α : ℕ) (i : I) (w : W) (u : U) :
-    0 ≤ boolWeight m α i w u := by
-  unfold boolWeight; split <;> positivity
+theorem ratWeight_nonneg (α : ℕ) (i : I) (w : W) (u : U) :
+    0 ≤ ratWeight m α i w u := by
+  unfold ratWeight; split <;> positivity
 
 theorem powWeight_eq_ofReal {α : ℕ} (hα : α ≠ 0) (i : I) (w : W) (u : U) :
-    powWeight α (L0OfBool m hne) (w, i) u = ENNReal.ofReal (boolWeight m α i w u) := by
-  unfold boolWeight
+    powWeight α (L0OfPred m hne) (w, i) u = ENNReal.ofReal (ratWeight m α i w u) := by
+  unfold ratWeight
   split
   · next h =>
-    rw [powWeight_L0OfBool_of_mem m hne _ h rfl]
+    rw [powWeight_L0OfPred_of_mem m hne _ h rfl]
     push_cast
     have hc : (0 : ℝ) < (RSA.extensionOf (m i) u).card := by
       exact_mod_cast Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
     rw [ENNReal.ofReal_pow (by positivity), ENNReal.ofReal_inv_of_pos hc,
       ENNReal.ofReal_natCast]
   · next h =>
-    rw [powWeight_L0OfBool_of_not_mem m hne hα (by simpa using h)]
+    rw [powWeight_L0OfPred_of_not_mem m hne hα h]
     push_cast
     rw [ENNReal.ofReal_zero]
 
 variable [Fintype U]
 
 theorem tsum_powWeight_eq_ofReal {α : ℕ} (hα : α ≠ 0) (i : I) (w : W) :
-    (∑' u, powWeight α (L0OfBool m hne) (w, i) u)
-      = ENNReal.ofReal (boolPartition m α i w) := by
-  rw [tsum_fintype, boolPartition]
+    (∑' u, powWeight α (L0OfPred m hne) (w, i) u)
+      = ENNReal.ofReal (ratPartition m α i w) := by
+  rw [tsum_fintype, ratPartition]
   push_cast
   rw [ENNReal.ofReal_sum_of_nonneg
-    (fun u _ => by exact_mod_cast boolWeight_nonneg m α i w u)]
+    (fun u _ => by exact_mod_cast ratWeight_nonneg m α i w u)]
   exact Finset.sum_congr rfl fun u _ => powWeight_eq_ofReal m hne hα i w u
 
-theorem boolPartition_pos {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
-    (hα : α ≠ 0) (i : I) (w : W) : 0 < boolPartition m α i w := by
-  rcases ViableSpeaker.some_finite (score := powUtility α (L0OfBool m hne)) (w, i) with ⟨u', hu'⟩
-  refine Finset.sum_pos' (fun v _ => boolWeight_nonneg m α i w v) ⟨u', Finset.mem_univ _, ?_⟩
-  have hm : m i u' w = true := by
+theorem ratPartition_pos {α : ℕ} [ViableSpeaker (powUtility α (L0OfPred m hne))]
+    (hα : α ≠ 0) (i : I) (w : W) : 0 < ratPartition m α i w := by
+  rcases ViableSpeaker.some_finite (score := powUtility α (L0OfPred m hne)) (w, i) with ⟨u', hu'⟩
+  refine Finset.sum_pos' (fun v _ => ratWeight_nonneg m α i w v) ⟨u', Finset.mem_univ _, ?_⟩
+  have hm : m i u' w := by
     by_contra hm
-    exact hu' (by rw [powUtility, L0OfBool_eq_zero m hne hm, ENNReal.log_zero,
+    exact hu' (by rw [powUtility, L0OfPred_eq_zero m hne hm, ENNReal.log_zero,
       EReal.mul_bot_of_pos (by exact_mod_cast Nat.pos_of_ne_zero hα)])
   have hc : 0 < (RSA.extensionOf (m i) u').card := Finset.card_pos.mpr (hne i u')
-  rw [boolWeight, if_pos hm]
+  rw [ratWeight, if_pos hm]
   positivity
 
-theorem boolS1_nonneg (α : ℕ) (i : I) (w : W) (u : U) : 0 ≤ boolS1 m α i w u :=
-  div_nonneg (boolWeight_nonneg m α i w u)
-    (Finset.sum_nonneg fun v _ => boolWeight_nonneg m α i w v)
+theorem ratS1_nonneg (α : ℕ) (i : I) (w : W) (u : U) : 0 ≤ ratS1 m α i w u :=
+  div_nonneg (ratWeight_nonneg m α i w u)
+    (Finset.sum_nonneg fun v _ => ratWeight_nonneg m α i w v)
 
-/-- Exact rational value of the power-utility speaker over a Boolean model. -/
-theorem S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
+/-- Exact rational value of the power-utility speaker over a propositional model. -/
+theorem S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfPred m hne))]
     (hα : α ≠ 0) (i : I) (w : W) (u : U) :
-    S1 (powUtility α (L0OfBool m hne)) (w, i) u = ENNReal.ofReal (boolS1 m α i w u) := by
-  have hz := boolPartition_pos m hne hα i w
+    S1 (powUtility α (L0OfPred m hne)) (w, i) u = ENNReal.ofReal (ratS1 m α i w u) := by
+  have hz := ratPartition_pos m hne hα i w
   rw [S1_powUtility_eq_normalize, PMF.normalize_apply, powWeight_eq_ofReal m hne hα,
     tsum_powWeight_eq_ofReal m hne hα, ← ENNReal.ofReal_inv_of_pos (by exact_mod_cast hz),
-    ← ENNReal.ofReal_mul (by exact_mod_cast boolWeight_nonneg m α i w u), boolS1]
+    ← ENNReal.ofReal_mul (by exact_mod_cast ratWeight_nonneg m α i w u), ratS1]
   push_cast [div_eq_mul_inv]
   ring_nf
 
-/-- Any finite family of Boolean-model speaker masses sums to the `ofReal` of
-the corresponding `boolS1` sum — the workhorse for pooled-latent reductions. -/
-theorem sum_S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfBool m hne))]
+/-- Any finite family of propositional-model speaker masses sums to the `ofReal` of
+the corresponding `ratS1` sum — the workhorse for pooled-latent reductions. -/
+theorem sum_S1_eq_ofReal {α : ℕ} [ViableSpeaker (powUtility α (L0OfPred m hne))]
     (hα : α ≠ 0) {ι : Type*} (s : Finset ι) (st : ι → W × I) (uu : ι → U) :
-    (∑ x ∈ s, S1 (powUtility α (L0OfBool m hne)) (st x) (uu x))
-      = ENNReal.ofReal (∑ x ∈ s, boolS1 m α (st x).2 (st x).1 (uu x)) := by
+    (∑ x ∈ s, S1 (powUtility α (L0OfPred m hne)) (st x) (uu x))
+      = ENNReal.ofReal (∑ x ∈ s, ratS1 m α (st x).2 (st x).1 (uu x)) := by
   rw [ENNReal.ofReal_sum_of_nonneg
-    (fun x _ => by exact_mod_cast boolS1_nonneg m α (st x).2 (st x).1 (uu x))]
+    (fun x _ => by exact_mod_cast ratS1_nonneg m α (st x).2 (st x).1 (uu x))]
   exact Finset.sum_congr rfl fun x _ => S1_eq_ofReal m hne hα (st x).2 (st x).1 (uu x)
 
-end BoolModel
+end PredModel
 
 end RSA.Canonical

--- a/Linglib/Pragmatics/RSA/Operators.lean
+++ b/Linglib/Pragmatics/RSA/Operators.lean
@@ -107,40 +107,39 @@ theorem L0OfMeaning_apply_le_iff (meaning : U → W → ℝ≥0∞) (u : U)
       meaning u w₁ ≤ meaning u w₂ :=
   PMF.normalize_le_iff_le _ _ _ _ _
 
-/-! ## L0 from a Boolean meaning (uniform on extension) -/
+/-! ## L0 from a propositional meaning (uniform on extension) -/
 
-/-- Extension of a Boolean meaning at utterance `u`: the `Finset` of worlds
-the meaning is true at. The `[Fintype W]`/`[DecidableEq W]` machinery is used
-implicitly via `Finset.univ.filter`. -/
-def extensionOf [Fintype W] (m : U → W → Bool) (u : U) : Finset W :=
-  Finset.univ.filter (fun w => m u w)
+/-- Extension of a meaning at utterance `u`: the `Finset` of worlds where the
+meaning holds. -/
+def extensionOf [Fintype W] (m : U → W → Prop) (u : U) [DecidablePred (m u)] : Finset W :=
+  Finset.univ.filter (m u)
 
-@[simp] theorem mem_extensionOf [Fintype W] {m : U → W → Bool} {u : U} {w : W} :
-    w ∈ extensionOf m u ↔ m u w = true := by
+@[simp] theorem mem_extensionOf [Fintype W] {m : U → W → Prop} {u : U}
+    [DecidablePred (m u)] {w : W} : w ∈ extensionOf m u ↔ m u w := by
   simp [extensionOf]
 
-/-- Literal listener for a Boolean meaning: uniform distribution on the
-extension. Specialisation of `L0OfMeaning` to the case where each meaning
-value is `0` or `1` and the extension is non-empty. The `(extensionOf m u).Nonempty`
+/-- Literal listener for a propositional meaning: uniform distribution on the
+extension. Specialisation of `L0OfMeaning` to the case where each meaning value
+is `0` or `1` and the extension is non-empty. The `(extensionOf m u).Nonempty`
 hypothesis is `PMF.uniformOfFinset`'s API. -/
-noncomputable def L0OfBoolMeaning [Fintype W] (m : U → W → Bool) (u : U)
+noncomputable def L0OfPred [Fintype W] (m : U → W → Prop) (u : U) [DecidablePred (m u)]
     (h : (extensionOf m u).Nonempty) : PMF W :=
   PMF.uniformOfFinset (extensionOf m u) h
 
-theorem L0OfBoolMeaning_apply_of_mem [Fintype W] {m : U → W → Bool} {u : U}
-    (h : (extensionOf m u).Nonempty) {w : W} (hw : m u w = true) :
-    L0OfBoolMeaning m u h w = ((extensionOf m u).card : ℝ≥0∞)⁻¹ :=
+theorem L0OfPred_apply_of_mem [Fintype W] {m : U → W → Prop} {u : U} [DecidablePred (m u)]
+    (h : (extensionOf m u).Nonempty) {w : W} (hw : m u w) :
+    L0OfPred m u h w = ((extensionOf m u).card : ℝ≥0∞)⁻¹ :=
   PMF.uniformOfFinset_apply_of_mem _ (mem_extensionOf.mpr hw)
 
-theorem L0OfBoolMeaning_apply_of_not_mem [Fintype W] {m : U → W → Bool} {u : U}
-    (h : (extensionOf m u).Nonempty) {w : W} (hw : m u w ≠ true) :
-    L0OfBoolMeaning m u h w = 0 :=
+theorem L0OfPred_apply_of_not_mem [Fintype W] {m : U → W → Prop} {u : U} [DecidablePred (m u)]
+    (h : (extensionOf m u).Nonempty) {w : W} (hw : ¬ m u w) :
+    L0OfPred m u h w = 0 :=
   PMF.uniformOfFinset_apply_of_notMem _ (fun hMem => hw (mem_extensionOf.mp hMem))
 
-@[simp] theorem mem_support_L0OfBoolMeaning_iff [Fintype W] {m : U → W → Bool} {u : U}
-    (h : (extensionOf m u).Nonempty) (w : W) :
-    w ∈ (L0OfBoolMeaning m u h).support ↔ m u w = true := by
-  rw [L0OfBoolMeaning, PMF.mem_support_uniformOfFinset_iff, mem_extensionOf]
+@[simp] theorem mem_support_L0OfPred_iff [Fintype W] {m : U → W → Prop} {u : U}
+    [DecidablePred (m u)] (h : (extensionOf m u).Nonempty) (w : W) :
+    w ∈ (L0OfPred m u h).support ↔ m u w := by
+  rw [L0OfPred, PMF.mem_support_uniformOfFinset_iff, mem_extensionOf]
 
 /-! ## S1: Pragmatic Speaker (belief-based) -/
 

--- a/Linglib/Pragmatics/RSA/Silence.lean
+++ b/Linglib/Pragmatics/RSA/Silence.lean
@@ -25,7 +25,7 @@ null utterance).
 ## Main definitions
 
 - `WithSilence U` — `Option U`, where `none` = silence.
-- `liftMeaning m` — extends `m : U → W → Bool` to `WithSilence U → W → Bool`,
+- `liftMeaning m` — extends `m : U → W → Prop` to `WithSilence U → W → Prop`,
   with silence true at every world.
 - `extensionOf_liftMeaning_none` — silence's extension is the whole world
   space.
@@ -53,15 +53,20 @@ abbrev WithSilence (U : Type*) := Option U
 
 /-- Lift a meaning function to handle silence. Silence is "vacuously honest"
 — true at every world (commits to nothing). -/
-def liftMeaning (m : U → W → Bool) : WithSilence U → W → Bool
+def liftMeaning (m : U → W → Prop) : WithSilence U → W → Prop
   | some u, w => m u w
-  | none,   _ => true
+  | none,   _ => True
 
-@[simp] theorem liftMeaning_some (m : U → W → Bool) (u : U) (w : W) :
+instance (m : U → W → Prop) [∀ u, DecidablePred (m u)] :
+    ∀ x, DecidablePred (liftMeaning m x)
+  | some _, _ => inferInstanceAs (Decidable (m _ _))
+  | none, _ => .isTrue trivial
+
+@[simp] theorem liftMeaning_some (m : U → W → Prop) (u : U) (w : W) :
     liftMeaning m (some u) w = m u w := rfl
 
-@[simp] theorem liftMeaning_none (m : U → W → Bool) (w : W) :
-    liftMeaning m none w = true := rfl
+@[simp] theorem liftMeaning_none (m : U → W → Prop) (w : W) :
+    liftMeaning m none w := trivial
 
 /-! ### Costed silence
 
@@ -93,16 +98,18 @@ largest possible, hence the smallest uniform literal-listener value. -/
 
 variable [Fintype W]
 
-@[simp] theorem extensionOf_liftMeaning_none (m : U → W → Bool) :
+variable (m : U → W → Prop) [∀ u, DecidablePred (m u)]
+
+@[simp] theorem extensionOf_liftMeaning_none :
     extensionOf (liftMeaning m) (none : WithSilence U) = Finset.univ := by
   ext w; simp
 
-theorem card_extensionOf_liftMeaning_none (m : U → W → Bool) :
+theorem card_extensionOf_liftMeaning_none :
     (extensionOf (liftMeaning m) (none : WithSilence U)).card = Fintype.card W := by
   simp
 
 /-- Every paper-utterance's extension is contained in silence's. -/
-theorem extensionOf_liftMeaning_some_subset (m : U → W → Bool) (u : U) :
+theorem extensionOf_liftMeaning_some_subset (u : U) :
     extensionOf (liftMeaning m) (some u) ⊆ extensionOf (liftMeaning m) none := by
   simp
 

--- a/Linglib/Studies/Alsop2024.lean
+++ b/Linglib/Studies/Alsop2024.lean
@@ -20,7 +20,7 @@ every*; truth conditions in their Table 2); `L0(s|u,p) ∝ P(s)·⟦u⟧ᵖ(s)`;
 `S1(u,p|s) ∝ exp(α·log L0)` over all 12 pairs; `L1(s,p|u) ∝ P(s)·S1(u,p|s)`
 with parse-marginal `L1(s|u)`. Speaker optimality `α = 100`, equal costs.
 
-Instantiated on the canonical pipeline: `L0` is `RSA.Canonical.L0OfBool`
+Instantiated on the canonical pipeline: `L0` is `RSA.Canonical.L0OfPred`
 over the Table-2 matrix, the joint speaker is `RSA.Canonical.S1` with
 `powUtility`, the parse-marginal speaker is its `PMF.map` along
 `Parse.utt`, and the pragmatic listener is `RSA.Canonical.L1`.
@@ -116,19 +116,22 @@ def Parse.utt : Parse → Utterance
   | .evA | .evB | .evC | .evD => .mayEvery
 
 /-- Truth conditions for each utterance–parse pair (their Table 2). -/
-def meaning : Parse → FCIState → Bool
-  | .sA, s => (s matches .onlyS | .only1 | .anyNum | .only2 | .sOr2 | .pOr2)
-  | .sB, s => (s matches .onlyS | .only1 | .anyNum | .sOr2)
-  | .sC, s => (s matches .onlyS)
-  | .pA, s => (s matches .onlyP | .only1 | .anyNum | .only2 | .sOr2 | .pOr2)
-  | .pB, s => (s matches .onlyP | .only1 | .anyNum | .pOr2)
-  | .pC, s => (s matches .onlyP)
-  | .anyA, s => (s matches .only1 | .anyNum | .only2 | .sOr2 | .pOr2)
-  | .anyB, s => (s matches .only1 | .anyNum)
-  | .evA, s => (s matches .only1 | .anyNum | .only2 | .sOr2 | .pOr2)
-  | .evB, s => (s matches .anyNum | .only2 | .sOr2 | .pOr2)
-  | .evC, s => (s matches .only1 | .anyNum)
-  | .evD, s => (s matches .only2)
+def meaning : Parse → FCIState → Prop
+  | .sA, s => s = .onlyS ∨ s = .only1 ∨ s = .anyNum ∨ s = .only2 ∨ s = .sOr2 ∨ s = .pOr2
+  | .sB, s => s = .onlyS ∨ s = .only1 ∨ s = .anyNum ∨ s = .sOr2
+  | .sC, s => s = .onlyS
+  | .pA, s => s = .onlyP ∨ s = .only1 ∨ s = .anyNum ∨ s = .only2 ∨ s = .sOr2 ∨ s = .pOr2
+  | .pB, s => s = .onlyP ∨ s = .only1 ∨ s = .anyNum ∨ s = .pOr2
+  | .pC, s => s = .onlyP
+  | .anyA, s => s = .only1 ∨ s = .anyNum ∨ s = .only2 ∨ s = .sOr2 ∨ s = .pOr2
+  | .anyB, s => s = .only1 ∨ s = .anyNum
+  | .evA, s => s = .only1 ∨ s = .anyNum ∨ s = .only2 ∨ s = .sOr2 ∨ s = .pOr2
+  | .evB, s => s = .anyNum ∨ s = .only2 ∨ s = .sOr2 ∨ s = .pOr2
+  | .evC, s => s = .only1 ∨ s = .anyNum
+  | .evD, s => s = .only2
+
+instance (p : Parse) : DecidablePred (meaning p) := fun _ => by
+  cases p <;> unfold meaning <;> infer_instance
 
 private theorem ext_nonempty : ∀ (_ : Unit) (p : Parse),
     (RSA.extensionOf (fun q => meaning q) p).Nonempty := by
@@ -140,19 +143,19 @@ private theorem ext_nonempty : ∀ (_ : Unit) (p : Parse),
 /-- Per-parse literal listener (eq. (36) at a uniform state prior):
 uniform on the parse's extension. -/
 noncomputable abbrev l0 : Unit → Parse → PMF FCIState :=
-  L0OfBool (fun _ p => meaning p) ext_nonempty
+  L0OfPred (fun _ p => meaning p) ext_nonempty
 
 instance (α : ℕ) : ViableSpeaker (powUtility α l0) :=
   viableSpeaker_powUtility_of_witness α l0 fun s => by
     obtain ⟨w, ⟨⟩⟩ := s
     cases w
-    · exact ⟨.sA, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.pA, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.anyB, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.anyB, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.evD, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.evB, L0OfBool_ne_zero _ _ (by decide)⟩
-    · exact ⟨.evB, L0OfBool_ne_zero _ _ (by decide)⟩
+    · exact ⟨.sA, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.pA, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.anyB, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.anyB, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.evD, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.evB, L0OfPred_ne_zero _ _ (by decide)⟩
+    · exact ⟨.evB, L0OfPred_ne_zero _ _ (by decide)⟩
 
 /-- The joint speaker over utterance–parse pairs (eqs. (37)–(38)):
 `S1(u,p|s) ∝ L0(s|u,p)^α`, equal costs. -/
@@ -194,7 +197,7 @@ private theorem speakerU_mayS (α : ℕ) (s : FCIState × Unit) :
 
 theorem marginal_ne_zero (α : ℕ) (u : Utterance) :
     PMF.marginal (speakerU α) prior u ≠ 0 := by
-  have key : ∀ (w : FCIState) (p : Parse), Parse.utt p = u → meaning p w = true →
+  have key : ∀ (w : FCIState) (p : Parse), Parse.utt p = u → meaning p w →
       PMF.marginal (speakerU α) prior u ≠ 0 := by
     intro w p hpu hpw
     refine PMF.marginal_ne_zero _ _ u (a := (w, ())) ?_ ?_
@@ -202,7 +205,7 @@ theorem marginal_ne_zero (α : ℕ) (u : Utterance) :
     · rw [speakerU_apply, ← hpu]
       intro hz
       exact S1_ne_zero (powUtility α l0)
-        (PMF.coe_mul_log_ne_bot (by positivity) (L0OfBool_ne_zero _ _ hpw))
+        (PMF.coe_mul_log_ne_bot (by positivity) (L0OfPred_ne_zero _ _ hpw))
         (Finset.sum_eq_zero_iff.mp hz p
           (Finset.mem_filter.mpr ⟨Finset.mem_univ p, rfl⟩))
   cases u
@@ -239,9 +242,9 @@ theorem speakerU_onlyS_mayAny (α : ℕ) (hα : α ≠ 0) :
     speakerU α (.onlyS, ()) .mayAny = 0 := by
   rw [speakerU_mayAny,
       show speaker α (.onlyS, ()) .anyA = 0 from
-        S1_powUtility_eq_zero α l0 hα (L0OfBool_eq_zero _ _ (by decide)),
+        S1_powUtility_eq_zero α l0 hα (L0OfPred_eq_zero _ _ (by decide)),
       show speaker α (.onlyS, ()) .anyB = 0 from
-        S1_powUtility_eq_zero α l0 hα (L0OfBool_eq_zero _ _ (by decide)),
+        S1_powUtility_eq_zero α l0 hα (L0OfPred_eq_zero _ _ (by decide)),
       add_zero]
 
 /-- Hearing *may any*, the listener assigns zero posterior to Only-S. -/
@@ -258,7 +261,7 @@ theorem speakerU_onlyS_mayEvery (α : ℕ) (hα : α ≠ 0) :
         = {Parse.evA, Parse.evB, Parse.evC, Parse.evD} from by decide]
   refine Finset.sum_eq_zero fun p hp => ?_
   fin_cases hp <;>
-    exact S1_powUtility_eq_zero α l0 hα (L0OfBool_eq_zero _ _ (by decide))
+    exact S1_powUtility_eq_zero α l0 hα (L0OfPred_eq_zero _ _ (by decide))
 
 /-- Hearing *may every*, the listener assigns zero posterior to Only-S. -/
 theorem mayEvery_rules_out_onlyS (α : ℕ) (hα : α ≠ 0) :
@@ -281,8 +284,8 @@ theorem s1_prefers_strong_parse {α : ℕ} (hα : α ≠ 0) :
       ENNReal.mul_lt_mul_iff_left
         (ENNReal.inv_ne_zero.mpr (tsum_powWeight_ne_top α l0 _))
         (ENNReal.inv_ne_top.mpr (tsum_powWeight_ne_zero α l0 _)),
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) card_anyB]
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) card_anyB]
   exact ENNReal.pow_lt_pow_left hα
     (ENNReal.inv_lt_inv' (show (2 : ℝ≥0∞) < 5 by norm_num))
 
@@ -313,18 +316,18 @@ private theorem third_lt_speakerU_only1 :
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_singleton,
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) card_sA,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_sB,
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) card_anyB]
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) card_sA,
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_sB,
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) card_anyB]
   -- 2·6⁻¹⁰⁰ + 2·4⁻¹⁰⁰ + 2·5⁻¹⁰⁰ + 2⁻¹⁰⁰ < 2·2⁻¹⁰⁰
   calc _ = (2 : ℝ≥0∞) * ((6 : ℝ≥0∞)⁻¹) ^ 100 + 2 * ((4 : ℝ≥0∞)⁻¹) ^ 100
         + 2 * ((5 : ℝ≥0∞)⁻¹) ^ 100 + ((2 : ℝ≥0∞)⁻¹) ^ 100 := by ring
@@ -356,18 +359,18 @@ private theorem third_lt_speakerU_anyNum :
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_singleton,
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) card_sA,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_sB,
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_evB,
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) card_anyB]
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) card_sA,
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_sB,
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_evB,
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) card_anyB]
   -- 2·6⁻¹⁰⁰ + 3·4⁻¹⁰⁰ + 2·5⁻¹⁰⁰ + 2⁻¹⁰⁰ < 2·2⁻¹⁰⁰ (extra 4⁻¹⁰⁰: parse 35b)
   calc _ = (2 : ℝ≥0∞) * ((6 : ℝ≥0∞)⁻¹) ^ 100 + 3 * ((4 : ℝ≥0∞)⁻¹) ^ 100
         + 2 * ((5 : ℝ≥0∞)⁻¹) ^ 100 + ((2 : ℝ≥0∞)⁻¹) ^ 100 := by ring
@@ -388,9 +391,9 @@ private theorem speakerU_only2_lt_ninth :
   rw [speakerU_mayAny,
       show speaker 100 (.only2, ()) .anyB = 0 from
         S1_powUtility_eq_zero 100 l0 (by norm_num)
-          (L0OfBool_eq_zero _ _ (by decide)),
+          (L0OfPred_eq_zero _ _ (by decide)),
       add_zero]
-  exact S1_L0OfBool_lt_inv_succ_of_dominator _ _ (by decide) (by decide)
+  exact S1_L0OfPred_lt_inv_succ_of_dominator _ _ (by decide) (by decide)
     (by decide) card_anyA card_evD (by norm_num) (by norm_num)
 
 private theorem speakerU_sOr2_lt_ninth :
@@ -398,9 +401,9 @@ private theorem speakerU_sOr2_lt_ninth :
   rw [speakerU_mayAny,
       show speaker 100 (.sOr2, ()) .anyB = 0 from
         S1_powUtility_eq_zero 100 l0 (by norm_num)
-          (L0OfBool_eq_zero _ _ (by decide)),
+          (L0OfPred_eq_zero _ _ (by decide)),
       add_zero]
-  exact S1_L0OfBool_lt_inv_succ_of_dominator (u' := Parse.evB) _ _ (by decide)
+  exact S1_L0OfPred_lt_inv_succ_of_dominator (u' := Parse.evB) _ _ (by decide)
     (by decide) (by decide) card_anyA card_evB (by norm_num) (by norm_num)
 
 private theorem speakerU_pOr2_lt_ninth :
@@ -408,9 +411,9 @@ private theorem speakerU_pOr2_lt_ninth :
   rw [speakerU_mayAny,
       show speaker 100 (.pOr2, ()) .anyB = 0 from
         S1_powUtility_eq_zero 100 l0 (by norm_num)
-          (L0OfBool_eq_zero _ _ (by decide)),
+          (L0OfPred_eq_zero _ _ (by decide)),
       add_zero]
-  exact S1_L0OfBool_lt_inv_succ_of_dominator (u' := Parse.evB) _ _ (by decide)
+  exact S1_L0OfPred_lt_inv_succ_of_dominator (u' := Parse.evB) _ _ (by decide)
     (by decide) (by decide) card_anyA card_evB (by norm_num) (by norm_num)
 
 /-- **The exclusiveness implicature** (their Table 3): hearing *may any*
@@ -471,18 +474,18 @@ private theorem half_lt_speakerU_onlyS_mayS :
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_singleton,
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) card_sA,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_sB,
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 1 (by decide) (by decide)]
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) card_sA,
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_sB,
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 1 (by decide) (by decide)]
   -- 6⁻¹⁰⁰ + 4⁻¹⁰⁰ < 1 · 1⁻¹⁰⁰
   calc _ = ((6 : ℝ≥0∞)⁻¹) ^ 100 + ((4 : ℝ≥0∞)⁻¹) ^ 100 := by ring
     _ ≤ ((4 : ℝ≥0∞)⁻¹) ^ 100 + ((4 : ℝ≥0∞)⁻¹) ^ 100 :=
@@ -516,18 +519,18 @@ private theorem Z_sOr2 :
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_singleton,
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) card_sA,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_sB,
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-      powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide)]
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) card_sA,
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_sB,
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+      powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide)]
   push_cast
   ring
 
@@ -536,10 +539,10 @@ private theorem speakerU_sOr2_mayS_lt_half :
   rw [speakerU_mayS,
       show speaker 100 (.sOr2, ()) .sC = 0 from
         S1_powUtility_eq_zero 100 l0 (by norm_num)
-          (L0OfBool_eq_zero _ _ (by decide)),
+          (L0OfPred_eq_zero _ _ (by decide)),
       add_zero, sum_S1_eq_mul_inv,
-      powWeight_L0OfBool_of_mem _ _ 6 (by decide) card_sA,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) card_sB,
+      powWeight_L0OfPred_of_mem _ _ 6 (by decide) card_sA,
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) card_sB,
       show (((1 : ℕ) : ℝ≥0∞) + 1)⁻¹ = 2⁻¹ from by norm_num,
       ← division_def,
       ENNReal.div_lt_iff (Or.inl (tsum_powWeight_ne_zero 100 l0 _))
@@ -575,16 +578,16 @@ private theorem Z_only1_lt_Z_anyNum :
       < ∑' r, powWeight 100 l0 (.anyNum, ()) r := by
   apply ENNReal.tsum_lt_tsum (tsum_powWeight_ne_top 100 l0 _) (i := Parse.evB)
   · intro p
-    by_cases h1 : meaning p FCIState.only1 = true
-    · have h2 : meaning p FCIState.anyNum = true := by
+    by_cases h1 : meaning p FCIState.only1
+    · have h2 : meaning p FCIState.anyNum := by
         revert h1; cases p <;> decide
-      rw [powWeight_L0OfBool_of_mem (fun _ q => meaning q) ext_nonempty _ h1 rfl,
-          powWeight_L0OfBool_of_mem (fun _ q => meaning q) ext_nonempty _ h2 rfl]
-    · rw [powWeight_L0OfBool_of_not_mem (fun _ q => meaning q) ext_nonempty
+      rw [powWeight_L0OfPred_of_mem (fun _ q => meaning q) ext_nonempty _ h1 rfl,
+          powWeight_L0OfPred_of_mem (fun _ q => meaning q) ext_nonempty _ h2 rfl]
+    · rw [powWeight_L0OfPred_of_not_mem (fun _ q => meaning q) ext_nonempty
             (by norm_num) h1]
       exact zero_le
-  · rw [powWeight_L0OfBool_of_not_mem _ _ (by norm_num) (by decide),
-        powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide)]
+  · rw [powWeight_L0OfPred_of_not_mem _ _ (by norm_num) (by decide),
+        powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide)]
     exact ENNReal.pow_pos (ENNReal.inv_pos.mpr (by norm_num)) 100
 
 /-- **The asymmetry the paper's Table 3 rounds away**: at a uniform prior,
@@ -602,10 +605,10 @@ theorem exclusiveness_strict_asymmetry :
   rw [listener, L1_uniform_event_lt_iff, Finset.sum_singleton,
       Finset.sum_singleton, speakerU_mayAny, speakerU_mayAny,
       sum_S1_eq_mul_inv, sum_S1_eq_mul_inv,
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) card_anyB,
-      powWeight_L0OfBool_of_mem _ _ 5 (by decide) card_anyA,
-      powWeight_L0OfBool_of_mem _ _ 2 (by decide) card_anyB]
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) card_anyB,
+      powWeight_L0OfPred_of_mem _ _ 5 (by decide) card_anyA,
+      powWeight_L0OfPred_of_mem _ _ 2 (by decide) card_anyB]
   exact (ENNReal.mul_lt_mul_iff_right
       (ne_of_gt (lt_of_lt_of_le
         (ENNReal.pow_pos (ENNReal.inv_pos.mpr (by norm_num)) 100) le_self_add))

--- a/Linglib/Studies/BellerGerstenberg2025.lean
+++ b/Linglib/Studies/BellerGerstenberg2025.lean
@@ -150,11 +150,17 @@ This is the **core** of the semantics, omitting the soft constraints
 - enabled: W ∨ S — necessity or sufficiency, not just how (Eq. 5)
 - caused: H ∧ (W ∨ S) — how-cause plus counterfactual (core of Eq. 6)
 - madeNoDifference: ¬W ∧ ¬H ∧ ¬S — no causal involvement (hard version of Eq. 7) -/
-def expressionMeaning (cw : CausalWorld) : CausalExpression → Bool
-  | .affected => cw.whether || cw.how || cw.sufficient
-  | .enabled => cw.whether || cw.sufficient
-  | .caused => cw.how && (cw.whether || cw.sufficient)
-  | .madeNoDifference => !cw.whether && !cw.how && !cw.sufficient
+def expressionMeaning (cw : CausalWorld) : CausalExpression → Prop
+  | .affected => cw.whether ∨ cw.how ∨ cw.sufficient
+  | .enabled => cw.whether ∨ cw.sufficient
+  | .caused => cw.how ∧ (cw.whether ∨ cw.sufficient)
+  | .madeNoDifference => ¬ cw.whether ∧ ¬ cw.how ∧ ¬ cw.sufficient
+
+instance (cw : CausalWorld) : ∀ u, Decidable (expressionMeaning cw u)
+  | .affected => inferInstanceAs (Decidable (_ ∨ _))
+  | .enabled => inferInstanceAs (Decidable (_ ∨ _))
+  | .caused => inferInstanceAs (Decidable (_ ∧ _))
+  | .madeNoDifference => inferInstanceAs (Decidable (_ ∧ _))
 
 
 -- ============================================================================
@@ -165,15 +171,13 @@ def expressionMeaning (cw : CausalWorld) : CausalExpression → Bool
 
 "Caused" is the most specific expression (p. 349). -/
 theorem caused_implies_enabled (cw : CausalWorld) :
-    expressionMeaning cw .caused → expressionMeaning cw .enabled := by
-  simp only [expressionMeaning, Bool.and_eq_true, Bool.or_eq_true]
-  intro ⟨_, h_ws⟩; exact h_ws
+    expressionMeaning cw .caused → expressionMeaning cw .enabled :=
+  And.right
 
 /-- "enabled" implies "affected": W ∨ S → W ∨ H ∨ S. -/
 theorem enabled_implies_affected (cw : CausalWorld) :
-    expressionMeaning cw .enabled → expressionMeaning cw .affected := by
-  simp only [expressionMeaning]
-  cases cw.whether <;> cases cw.how <;> cases cw.sufficient <;> decide
+    expressionMeaning cw .enabled → expressionMeaning cw .affected :=
+  Or.imp_right Or.inr
 
 /-- Full scalar chain: caused → enabled → affected. -/
 theorem caused_implies_affected (cw : CausalWorld) :
@@ -182,9 +186,8 @@ theorem caused_implies_affected (cw : CausalWorld) :
 
 /-- "madeNoDifference" is the negation of "affected" (Boolean version). -/
 theorem madeNoDifference_iff_not_affected (cw : CausalWorld) :
-    expressionMeaning cw .madeNoDifference ↔ !expressionMeaning cw .affected := by
-  simp only [expressionMeaning]
-  cases cw.whether <;> cases cw.how <;> cases cw.sufficient <;> decide
+    expressionMeaning cw .madeNoDifference ↔ ¬ expressionMeaning cw .affected := by
+  simp only [expressionMeaning, not_or]
 
 
 -- ============================================================================
@@ -279,8 +282,8 @@ pragmatic speaker normalises literal informativity over expressions
 posterior against the uniform world prior. The fitted model (Experiment 2)
 uses λ = 40.18, but α = 1 suffices for the qualitative predictions. -/
 
-/-- Boolean meaning in speaker argument order (expression first). -/
-abbrev sem (u : CausalExpression) (cw : CausalWorld) : Bool := expressionMeaning cw u
+/-- Literal meaning in speaker argument order (expression first). -/
+abbrev sem (u : CausalExpression) (cw : CausalWorld) : Prop := expressionMeaning cw u
 
 private theorem ext_nonempty (u : CausalExpression) :
     (RSA.extensionOf sem u).Nonempty := by
@@ -288,28 +291,28 @@ private theorem ext_nonempty (u : CausalExpression) :
 
 /-- Literal listener `L0(·|u)`: uniform on the expression's extension. -/
 noncomputable def L0 (u : CausalExpression) : PMF CausalWorld :=
-  RSA.L0OfBoolMeaning sem u (ext_nonempty u)
+  RSA.L0OfPred sem u (ext_nonempty u)
 
 /-- L0 mass at a world where the expression holds: inverse extension size. -/
 private theorem L0_apply_of_true {u : CausalExpression} {cw : CausalWorld} (k : ℕ)
-    (h : sem u cw = true) (hk : (RSA.extensionOf sem u).card = k) :
+    (h : sem u cw) (hk : (RSA.extensionOf sem u).card = k) :
     L0 u cw = (k : ℝ≥0∞)⁻¹ := by
-  rw [L0, RSA.L0OfBoolMeaning_apply_of_mem _ h, hk]
+  rw [L0, RSA.L0OfPred_apply_of_mem _ h, hk]
 
 private theorem L0_apply_of_false {u : CausalExpression} {cw : CausalWorld}
-    (h : sem u cw = false) :
+    (h : ¬ sem u cw) :
     L0 u cw = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ (by simp [h])
+  RSA.L0OfPred_apply_of_not_mem _ h
 
 private theorem L0_ne_zero {u : CausalExpression} {cw : CausalWorld}
-    (h : sem u cw = true) : L0 u cw ≠ 0 :=
-  (PMF.mem_support_iff _ _).mp ((RSA.mem_support_L0OfBoolMeaning_iff _ cw).mpr h)
+    (h : sem u cw) : L0 u cw ≠ 0 :=
+  (PMF.mem_support_iff _ _).mp ((RSA.mem_support_L0OfPred_iff _ cw).mpr h)
 
 private theorem s1_ne_zero (cw : CausalWorld) :
     ∑' u, (L0 u cw : ℝ≥0∞) ^ (1 : ℝ) * 1 ≠ 0 := by
   simp only [ENNReal.rpow_one, mul_one]
   rw [tsum_fintype]
-  obtain ⟨u, hu⟩ : ∃ u, sem u cw = true := by
+  obtain ⟨u, hu⟩ : ∃ u, sem u cw := by
     revert cw; decide
   intro h
   exact L0_ne_zero hu (Finset.sum_eq_zero_iff.mp h u (Finset.mem_univ _))
@@ -328,7 +331,7 @@ noncomputable def S1 (cw : CausalWorld) : PMF CausalExpression :=
 noncomputable def worldPrior : PMF CausalWorld := PMF.uniformOfFintype CausalWorld
 
 private theorem marg_ne_zero {u : CausalExpression} (cw : CausalWorld)
-    (h : sem u cw = true) :
+    (h : sem u cw) :
     PMF.marginal S1 worldPrior u ≠ 0 :=
   PMF.marginal_ne_zero S1 worldPrior u
     ((worldPrior.mem_support_iff cw).mp (PMF.mem_support_uniformOfFintype cw))
@@ -358,7 +361,7 @@ theorem S1_le_iff (cw : CausalWorld) (u₁ u₂ : CausalExpression) :
 /-- Cross-world vacuous zero: where the expression is false the speaker
 assigns it no mass, so any world where it holds wins. -/
 private theorem S1_lt_of_zero_pos {cw₁ cw₂ : CausalWorld} {u : CausalExpression}
-    (h₁ : sem u cw₁ = false) (h₂ : sem u cw₂ = true) :
+    (h₁ : ¬ sem u cw₁) (h₂ : sem u cw₂) :
     S1 cw₁ u < S1 cw₂ u := by
   unfold S1 RSA.S1Belief
   exact PMF.normalize_lt_of_apply_zero_pos _ _ (s1_ne_zero cw₁) (s1_ne_top cw₁)
@@ -561,31 +564,31 @@ def world_caused : CausalWorld := ⟨true, true, false⟩
 /-- In W-only world, "enabled" is true but "caused" is false.
 Speaker would use "enabled" (Scenario 2-like). -/
 theorem W_only_enabled_not_caused :
-    expressionMeaning world_W_only .enabled = true ∧
-    expressionMeaning world_W_only .caused = false := by
+    expressionMeaning world_W_only .enabled ∧
+    ¬ expressionMeaning world_W_only .caused := by
   constructor <;> native_decide
 
 /-- In H-only world, only "affected" applies among the positive expressions. -/
 theorem H_only_affected_only :
-    expressionMeaning world_H_only .affected = true ∧
-    expressionMeaning world_H_only .enabled = false ∧
-    expressionMeaning world_H_only .caused = false := by
+    expressionMeaning world_H_only .affected ∧
+    ¬ expressionMeaning world_H_only .enabled ∧
+    ¬ expressionMeaning world_H_only .caused := by
   refine ⟨?_, ?_, ?_⟩ <;> native_decide
 
 /-- In full world, all positive expressions apply. -/
 theorem full_world_all_true :
-    expressionMeaning world_full .affected = true ∧
-    expressionMeaning world_full .enabled = true ∧
-    expressionMeaning world_full .caused = true ∧
-    expressionMeaning world_full .madeNoDifference = false := by
+    expressionMeaning world_full .affected ∧
+    expressionMeaning world_full .enabled ∧
+    expressionMeaning world_full .caused ∧
+    ¬ expressionMeaning world_full .madeNoDifference := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
 
 /-- In none world, only "madeNoDifference" applies. -/
 theorem none_world_only_negative :
-    expressionMeaning world_none .affected = false ∧
-    expressionMeaning world_none .enabled = false ∧
-    expressionMeaning world_none .caused = false ∧
-    expressionMeaning world_none .madeNoDifference = true := by
+    ¬ expressionMeaning world_none .affected ∧
+    ¬ expressionMeaning world_none .enabled ∧
+    ¬ expressionMeaning world_none .caused ∧
+    expressionMeaning world_none .madeNoDifference := by
   refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
 
 
@@ -890,7 +893,7 @@ theorem solo_causalWorld :
     produces the correct pragmatic prediction. -/
 theorem solo_cause_chain :
     let cw := causalWorldFromModel soloModel Valuation.empty .cause .effect
-    expressionMeaning cw .caused = true ∧
+    expressionMeaning cw .caused ∧
     S1 cw .caused > S1 cw .enabled ∧
     S1 cw .caused > S1 cw .affected := by
   refine ⟨?_, ?_, ?_⟩ <;> rw [solo_causalWorld]

--- a/Linglib/Studies/ChampollionAlsopGrosu2019.lean
+++ b/Linglib/Studies/ChampollionAlsopGrosu2019.lean
@@ -97,42 +97,52 @@ instance : DecidablePred HasEI
   | .anyNumber | .onlyBoth => .isFalse id
 
 /-- Interpretation function ℐ₁ (the paper's (6)). -/
-def I1 : Utterance → FCState → Bool
-  | .a, .onlyB => false
-  | .a, _ => true
-  | .b, .onlyA => false
-  | .b, _ => true
-  | .or_, _ => true
-  | .and_, .anyNumber | .and_, .onlyBoth => true
-  | .and_, _ => false
+def I1 : Utterance → FCState → Prop
+  | .a, .onlyB => False
+  | .a, _ => True
+  | .b, .onlyA => False
+  | .b, _ => True
+  | .or_, _ => True
+  | .and_, .anyNumber | .and_, .onlyBoth => True
+  | .and_, _ => False
+
+instance : ∀ u, DecidablePred (I1 u) := fun u w => by
+  cases u <;> cases w <;> first | exact .isTrue trivial | exact .isFalse id
 
 /-- Interpretation function ℐ₂ (the paper's (7)). -/
-def I2 : Utterance → FCState → Bool
-  | .a, .onlyA => true
-  | .a, _ => false
-  | .b, .onlyB => true
-  | .b, _ => false
-  | .or_, .onlyBoth => false
-  | .or_, _ => true
-  | .and_, .onlyBoth => true
-  | .and_, _ => false
+def I2 : Utterance → FCState → Prop
+  | .a, .onlyA => True
+  | .a, _ => False
+  | .b, .onlyB => True
+  | .b, _ => False
+  | .or_, .onlyBoth => False
+  | .or_, _ => True
+  | .and_, .onlyBoth => True
+  | .and_, _ => False
+
+instance : ∀ u, DecidablePred (I2 u) := fun u w => by
+  cases u <;> cases w <;> first | exact .isTrue trivial | exact .isFalse id
 
 /-- Meaning indexed by interpretation function. -/
-def interpMeaning : Interp → Utterance → FCState → Bool
+def interpMeaning : Interp → Utterance → FCState → Prop
   | .literal => I1
   | .exhaustified => I2
 
+instance : ∀ i u, DecidablePred (interpMeaning i u)
+  | .literal, u => inferInstanceAs (DecidablePred (I1 u))
+  | .exhaustified, u => inferInstanceAs (DecidablePred (I2 u))
+
 /-- ℐ₂ refines ℐ₁: exhaustification only strengthens. -/
-theorem I2_refines_I1 : ∀ u w, I2 u w = true → I1 u w = true := by decide
+theorem I2_refines_I1 : ∀ u w, I2 u w → I1 u w := by decide
 
 /-- ℐ₁(Or) is literally true everywhere — maximally uninformative. -/
-theorem I1_or_everywhere : ∀ w, I1 .or_ w = true := by decide
+theorem I1_or_everywhere : ∀ w, I1 .or_ w := by decide
 
 /-- ℐ₂(Or) excludes exactly Only Both. -/
-theorem I2_or_excludes_onlyBoth : ∀ w, I2 .or_ w = true ↔ w ≠ .onlyBoth := by decide
+theorem I2_or_excludes_onlyBoth : ∀ w, I2 .or_ w ↔ w ≠ .onlyBoth := by decide
 
 /-- ℐ₂(A) singles out exactly Only A — the risk the speaker avoids. -/
-theorem I2_a_singleton : ∀ w, I2 .a w = true ↔ w = .onlyA := by decide
+theorem I2_a_singleton : ∀ w, I2 .a w ↔ w = .onlyA := by decide
 
 /-! ### ENNReal budget helpers -/
 
@@ -161,7 +171,7 @@ def nonEiPairs : Finset (FCState × Interp) := Finset.univ.filter (fun p => ¬ H
 /-! ### The basic model, uniform prior
 
 At a uniform world prior the paper's `P_L0(w|u,ℐ) ∝ ℐ(u,w)·P(w)` is uniform
-on the extension, i.e. `RSA.Canonical.L0OfBool`. Exact S1(Or) values at
+on the extension, i.e. `RSA.Canonical.L0OfPred`. Exact S1(Or) values at
 α = 2, for reference: ℐ₁ row 16/41, 16/41, 8/33, 8/83, 8/83; ℐ₂ row 1/17,
 1/17, 1, 1, 0 (states in Table-2 order). -/
 
@@ -176,15 +186,15 @@ theorem ext_nonempty (i : Interp) (u : Utterance) :
 
 /-- Literal listener of the basic model. -/
 noncomputable abbrev l0 : Interp → Utterance → PMF FCState :=
-  L0OfBool interpMeaning ext_nonempty
+  L0OfPred interpMeaning ext_nonempty
 
 instance : ViableSpeaker (powUtility 2 l0) :=
   viableSpeaker_powUtility_of_witness 2 l0 fun s => by
     obtain ⟨w, i⟩ := s
     cases i <;> cases w <;>
       first
-        | exact ⟨.or_, L0OfBool_ne_zero _ _ (by decide)⟩
-        | exact ⟨.and_, L0OfBool_ne_zero _ _ (by decide)⟩
+        | exact ⟨.or_, L0OfPred_ne_zero _ _ (by decide)⟩
+        | exact ⟨.and_, L0OfPred_ne_zero _ _ (by decide)⟩
 
 /-- The pragmatic speaker of the basic model (the paper's `P_S1`, α = 2). -/
 noncomputable abbrev speaker : FCState × Interp → PMF Utterance :=
@@ -197,16 +207,16 @@ noncomputable abbrev prior : PMF (FCState × Interp) := PMF.uniformOfFintype _
 of the avoidance mechanism (paper §3.3). -/
 theorem speaker_or_onlyOne_exh : speaker (.onlyOne, .exhaustified) .or_ = 1 :=
   S1_powUtility_eq_one 2 l0 two_ne_zero .or_ fun u' hu' => by
-    cases u' <;> first | exact absurd rfl hu' | exact L0OfBool_eq_zero _ _ (by decide)
+    cases u' <;> first | exact absurd rfl hu' | exact L0OfPred_eq_zero _ _ (by decide)
 
 /-- Under ℐ₂ at Any Number, Or is the only applicable utterance. -/
 theorem speaker_or_anyNumber_exh : speaker (.anyNumber, .exhaustified) .or_ = 1 :=
   S1_powUtility_eq_one 2 l0 two_ne_zero .or_ fun u' hu' => by
-    cases u' <;> first | exact absurd rfl hu' | exact L0OfBool_eq_zero _ _ (by decide)
+    cases u' <;> first | exact absurd rfl hu' | exact L0OfPred_eq_zero _ _ (by decide)
 
 /-- Under ℐ₂ at Only Both, Or is inapplicable. -/
 theorem speaker_or_onlyBoth_exh : speaker (.onlyBoth, .exhaustified) .or_ = 0 :=
-  S1_powUtility_eq_zero 2 l0 two_ne_zero (L0OfBool_eq_zero _ _ (by decide))
+  S1_powUtility_eq_zero 2 l0 two_ne_zero (L0OfPred_eq_zero _ _ (by decide))
 
 /-- The avoidance mechanism at S1: under ℐ₂ at Only A the bare disjunct
 strictly beats the disjunction (16/17 vs 1/17). -/
@@ -215,8 +225,8 @@ theorem speaker_prefers_a_at_onlyA_exh :
   show S1 (powUtility 2 l0) (.onlyA, .exhaustified) .or_
     < S1 (powUtility 2 l0) (.onlyA, .exhaustified) .a
   rw [S1_powUtility_eq_normalize, PMF.normalize_lt_iff_lt,
-      powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-      powWeight_L0OfBool_of_mem _ _ 1 (by decide) (by decide)]
+      powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+      powWeight_L0OfPred_of_mem _ _ 1 (by decide) (by decide)]
   exact ENNReal.pow_lt_pow_left two_ne_zero
     (ENNReal.inv_lt_inv.mpr (Nat.cast_lt.mpr (by norm_num)))
 
@@ -232,32 +242,32 @@ noncomputable abbrev listener (u : Utterance)
   L1 speaker prior u h
 
 private theorem speaker_or_onlyA_lit_lt_half : speaker (.onlyA, .literal) .or_ < 2⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 1) (k := 5) (k' := 4)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 1) (k := 5) (k' := 4)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
 private theorem speaker_or_onlyB_lit_lt_half : speaker (.onlyB, .literal) .or_ < 2⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 1) (k := 5) (k' := 4)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 1) (k := 5) (k' := 4)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
 private theorem speaker_or_anyNumber_lit_lt_quarter : speaker (.anyNumber, .literal) .or_ < 4⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
 private theorem speaker_or_onlyBoth_lit_lt_quarter : speaker (.onlyBoth, .literal) .or_ < 4⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .and_) (n := 3) (k := 5) (k' := 2)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
 private theorem speaker_or_onlyA_exh_lt_quarter : speaker (.onlyA, .exhaustified) .or_ < 4⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 3) (k := 4) (k' := 1)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .a) (n := 3) (k := 4) (k' := 1)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
 private theorem speaker_or_onlyB_exh_lt_quarter : speaker (.onlyB, .exhaustified) .or_ < 4⁻¹ :=
-  (S1_L0OfBool_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 3) (k := 4) (k' := 1)
+  (S1_L0OfPred_lt_inv_succ_of_dominator _ _ (u' := .b) (n := 3) (k := 4) (k' := 1)
     (by decide) (by decide) (by decide) (by decide) (by decide) two_ne_zero
     (by norm_num)).trans_le (by norm_num)
 
@@ -266,10 +276,10 @@ private theorem speaker_or_onlyA_lit_gt_quarter : 4⁻¹ < speaker (.onlyA, .lit
     rw [show (Finset.univ.erase Utterance.or_) = {.a, .b, .and_} from by decide,
         Finset.sum_insert (by decide), Finset.sum_insert (by decide),
         Finset.sum_singleton,
-        powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-        powWeight_L0OfBool_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfBool_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfBool_of_mem _ _ 5 (by decide) (by decide),
+        powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
+        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
+        powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
         add_zero, add_zero]
     exact ENNReal.inv_pow_lt_natCast_mul_inv_pow (by norm_num) (by norm_num)
       (by norm_num)).trans_le' (by norm_num)
@@ -279,10 +289,10 @@ private theorem speaker_or_onlyB_lit_gt_quarter : 4⁻¹ < speaker (.onlyB, .lit
     rw [show (Finset.univ.erase Utterance.or_) = {.a, .b, .and_} from by decide,
         Finset.sum_insert (by decide), Finset.sum_insert (by decide),
         Finset.sum_singleton,
-        powWeight_L0OfBool_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfBool_of_mem _ _ 4 (by decide) (by decide),
-        powWeight_L0OfBool_of_not_mem _ _ two_ne_zero (by decide),
-        powWeight_L0OfBool_of_mem _ _ 5 (by decide) (by decide),
+        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
+        powWeight_L0OfPred_of_mem _ _ 4 (by decide) (by decide),
+        powWeight_L0OfPred_of_not_mem _ _ two_ne_zero (by decide),
+        powWeight_L0OfPred_of_mem _ _ 5 (by decide) (by decide),
         zero_add, add_zero]
     exact ENNReal.inv_pow_lt_natCast_mul_inv_pow (by norm_num) (by norm_num)
       (by norm_num)).trans_le' (by norm_num)
@@ -375,7 +385,7 @@ def biasedWeight : FCState → ℕ
 private theorem wB_tsum_ne_zero (i : Interp) (u : Utterance) :
     (∑' w, if interpMeaning i u w then (biasedWeight w : ℝ≥0∞) else 0) ≠ 0 := by
   intro hz
-  have key : ∀ w : FCState, interpMeaning i u w = true → False := fun w hw => by
+  have key : ∀ w : FCState, interpMeaning i u w → False := fun w hw => by
     have h := ENNReal.tsum_eq_zero.mp hz w
     rw [if_pos hw, Nat.cast_eq_zero] at h
     exact absurd h (by cases w <;> simp [biasedWeight])
@@ -399,13 +409,13 @@ noncomputable abbrev l0B (i : Interp) (u : Utterance) : PMF FCState :=
   PMF.normalize _ (wB_tsum_ne_zero i u) (wB_tsum_ne_top i u)
 
 private theorem l0B_ne_zero {i : Interp} {u : Utterance} {w : FCState}
-    (h : interpMeaning i u w = true) : l0B i u w ≠ 0 := by
+    (h : interpMeaning i u w) : l0B i u w ≠ 0 := by
   rw [PMF.normalize_apply, if_pos h]
   exact mul_ne_zero (by rw [Nat.cast_ne_zero]; cases w <;> simp [biasedWeight])
     (ENNReal.inv_ne_zero.mpr (wB_tsum_ne_top i u))
 
 private theorem l0B_eq_zero {i : Interp} {u : Utterance} {w : FCState}
-    (h : interpMeaning i u w ≠ true) : l0B i u w = 0 := by
+    (h : ¬ interpMeaning i u w) : l0B i u w = 0 := by
   rw [PMF.normalize_apply, if_neg h, zero_mul]
 
 instance : ViableSpeaker (powUtility 2 l0B) :=
@@ -493,6 +503,6 @@ under ℐ₂ (states in Table-2 order), so given Or the FCI score sum 66/41
 again dominates the non-FCI sum ≈ 0.87: the avoidance mechanism between the
 bare disjuncts and Or does not depend on And. The formalisation is omitted
 for space; it instantiates the same `RSA.Canonical.powUtility` pipeline over
-the four-utterance meaning table with `.null` mapped to `fun _ => true`. -/
+the four-utterance meaning table with `.null` mapped to `fun _ => True`. -/
 
 end ChampollionAlsopGrosu2019

--- a/Linglib/Studies/DegenEtAl2020.lean
+++ b/Linglib/Studies/DegenEtAl2020.lean
@@ -180,34 +180,37 @@ theorem noise_grounds_asymmetry :
 
 /-! ### Boolean baseline -/
 
-/-- Boolean (zero-noise) meaning: a feature matches (`true`) or not. -/
-def φbool : Utterance → World → Bool
-  | .big, .bigBlue => true | .big, .bigRed => true | .big, .smallBlue => false
-  | .small, .bigBlue => false | .small, .bigRed => false | .small, .smallBlue => true
-  | .blue, .bigBlue => true | .blue, .bigRed => false | .blue, .smallBlue => true
-  | .red, .bigBlue => false | .red, .bigRed => true | .red, .smallBlue => false
-  | .bigBlue, .bigBlue => true | .bigBlue, .bigRed => false | .bigBlue, .smallBlue => false
-  | .bigRed, .bigBlue => false | .bigRed, .bigRed => true | .bigRed, .smallBlue => false
-  | .smallBlue, .bigBlue => false | .smallBlue, .bigRed => false | .smallBlue, .smallBlue => true
+/-- Boolean (zero-noise) meaning: a feature matches or it does not. -/
+def φbool : Utterance → World → Prop
+  | .big, .bigBlue => True | .big, .bigRed => True | .big, .smallBlue => False
+  | .small, .bigBlue => False | .small, .bigRed => False | .small, .smallBlue => True
+  | .blue, .bigBlue => True | .blue, .bigRed => False | .blue, .smallBlue => True
+  | .red, .bigBlue => False | .red, .bigRed => True | .red, .smallBlue => False
+  | .bigBlue, .bigBlue => True | .bigBlue, .bigRed => False | .bigBlue, .smallBlue => False
+  | .bigRed, .bigBlue => False | .bigRed, .bigRed => True | .bigRed, .smallBlue => False
+  | .smallBlue, .bigBlue => False | .smallBlue, .bigRed => False | .smallBlue, .smallBlue => True
+
+instance (u : Utterance) : DecidablePred (φbool u) := fun w => by
+  cases u <;> cases w <;> first | exact isTrue trivial | exact isFalse id
 
 private theorem extBool_nonempty (u : Utterance) : (extensionOf φbool u).Nonempty := by
   cases u <;> decide
 
 /-- Boolean literal listener: uniform on the extension. -/
-noncomputable def boolL0 (u : Utterance) : PMF World := L0OfBoolMeaning φbool u (extBool_nonempty u)
+noncomputable def boolL0 (u : Utterance) : PMF World := L0OfPred φbool u (extBool_nonempty u)
 
-private theorem boolL0_ne_zero {u : Utterance} {w : World} (h : φbool u w = true) :
+private theorem boolL0_ne_zero {u : Utterance} {w : World} (h : φbool u w) :
     boolL0 u w ≠ 0 :=
-  (PMF.mem_support_iff _ _).mp ((mem_support_L0OfBoolMeaning_iff _ w).mpr h)
+  (PMF.mem_support_iff _ _).mp ((mem_support_L0OfPred_iff _ w).mpr h)
 
 theorem boolL0_small_target : boolL0 .small target = 1 := by
-  rw [boolL0, L0OfBoolMeaning_apply_of_mem (extBool_nonempty .small)
-      (show φbool .small target = true from by decide),
+  rw [boolL0, L0OfPred_apply_of_mem (extBool_nonempty .small)
+      (show φbool .small target from trivial),
     show (extensionOf φbool .small).card = 1 from by decide]; simp
 
 theorem boolL0_smallBlue_target : boolL0 .smallBlue target = 1 := by
-  rw [boolL0, L0OfBoolMeaning_apply_of_mem (extBool_nonempty .smallBlue)
-      (show φbool .smallBlue target = true from by decide),
+  rw [boolL0, L0OfPred_apply_of_mem (extBool_nonempty .smallBlue)
+      (show φbool .smallBlue target from trivial),
     show (extensionOf φbool .smallBlue).card = 1 from by decide]; simp
 
 private theorem boolS1_ne_zero (w : World) : ∑' u, (boolL0 u w : ℝ≥0∞) ^ (1:ℝ) * 1 ≠ 0 := by
@@ -341,30 +344,33 @@ theorem nominal_basic_beats_super : nomS1 .dalmatian .super < nomS1 .dalmatian .
   rw [ENNReal.ofReal_lt_ofReal_iff (by norm_num)]; norm_num
 
 /-- Boolean (crisp) typicality. -/
-def φtypBool : NomUtterance → NomWorld → Bool
-  | .sub, .dalmatian => true | .sub, .cat => false | .sub, .bird => false
-  | .basic, .dalmatian => true | .basic, .cat => false | .basic, .bird => false
-  | .super, .dalmatian => true | .super, .cat => true | .super, .bird => true
+def φtypBool : NomUtterance → NomWorld → Prop
+  | .sub, .dalmatian => True | .sub, .cat => False | .sub, .bird => False
+  | .basic, .dalmatian => True | .basic, .cat => False | .basic, .bird => False
+  | .super, .dalmatian => True | .super, .cat => True | .super, .bird => True
+
+instance (u : NomUtterance) : DecidablePred (φtypBool u) := fun w => by
+  cases u <;> cases w <;> first | exact isTrue trivial | exact isFalse id
 
 private theorem extNomBool_nonempty (u : NomUtterance) : (extensionOf φtypBool u).Nonempty := by
   cases u <;> decide
 
 /-- Boolean nominal literal listener. -/
 noncomputable def nomBoolL0 (u : NomUtterance) : PMF NomWorld :=
-  L0OfBoolMeaning φtypBool u (extNomBool_nonempty u)
+  L0OfPred φtypBool u (extNomBool_nonempty u)
 
-private theorem nomBoolL0_ne_zero {u : NomUtterance} {w : NomWorld} (h : φtypBool u w = true) :
+private theorem nomBoolL0_ne_zero {u : NomUtterance} {w : NomWorld} (h : φtypBool u w) :
     nomBoolL0 u w ≠ 0 :=
-  (PMF.mem_support_iff _ _).mp ((mem_support_L0OfBoolMeaning_iff _ w).mpr h)
+  (PMF.mem_support_iff _ _).mp ((mem_support_L0OfPred_iff _ w).mpr h)
 
 theorem nomBoolL0_sub : nomBoolL0 .sub .dalmatian = 1 := by
-  rw [nomBoolL0, L0OfBoolMeaning_apply_of_mem (extNomBool_nonempty .sub)
-      (show φtypBool .sub .dalmatian = true from by decide),
+  rw [nomBoolL0, L0OfPred_apply_of_mem (extNomBool_nonempty .sub)
+      (show φtypBool .sub .dalmatian from trivial),
     show (extensionOf φtypBool .sub).card = 1 from by decide]; simp
 
 theorem nomBoolL0_basic : nomBoolL0 .basic .dalmatian = 1 := by
-  rw [nomBoolL0, L0OfBoolMeaning_apply_of_mem (extNomBool_nonempty .basic)
-      (show φtypBool .basic .dalmatian = true from by decide),
+  rw [nomBoolL0, L0OfPred_apply_of_mem (extNomBool_nonempty .basic)
+      (show φtypBool .basic .dalmatian from trivial),
     show (extensionOf φtypBool .basic).card = 1 from by decide]; simp
 
 private theorem nomBoolS1_ne_zero (w : NomWorld) : ∑' u, (nomBoolL0 u w : ℝ≥0∞) ^ (1:ℝ) * 1 ≠ 0 := by

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -1,5 +1,7 @@
 import Linglib.Pragmatics.RSA.Canonical
+import Linglib.Pragmatics.Implicature.SomeAll
 import Linglib.Semantics.Exhaustification.InnocentExclusion
+import Mathlib.Data.List.ProdSigma
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -7,16 +9,18 @@ import Mathlib.Tactic.DeriveFintype
 
 [franke-bergen-2020] compares four RSA models ([frank-goodman-2012]) of the
 nested Aristotelians "Q₁ of the aliens drank Q₂ of their water"
-(Q ∈ {none, some, all}): 7 world states (which alien types — none-, some-,
-all-drinkers — exist), 9 utterances, and 8 grammatical parses (subsets of
-{M, O, I} EXH positions), whose readings are the paper's Table 1
-(`table1_ss` … `table1_as`). The models differ in where the parse enters the
-speaker: vanilla (§3.1) has only the literal parse; LU (§3.2) fixes a lexicon
-`l ∈ {lit, OI}` per speaker — the parse an *argument* of the speaker (eq. 11)
-and a latent the listener marginalizes ([bergen-levy-goodman-2016],
-[potts-etal-2016]); the LI (§3.3) and GI (§3.4) speakers instead *choose* an
-(utterance, parse) pair (eqs. 18a/21a), over the 4 matrix-free parses resp.
-all 8 — one softmax over pairs per world, read by `RSA.Canonical.L1Intent`.
+(Q ∈ {none, some, all}). An alien's drinking amount is a `SomeAllWorld`; a
+world state is the nonempty set of amounts realized by at least one alien
+(7 states); a parse is the set of EXH insertion sites among matrix/outer/inner
+(8 parses); the readings are the paper's Table 1 (`table1_ss` … `table1_as`,
+each row characterized by a membership predicate). The models differ in where
+the parse enters the speaker: vanilla (§3.1) has only the literal parse; LU
+(§3.2) fixes a lexicon `l ∈ {lit, OI}` per speaker — the parse an *argument*
+of the speaker (eq. 11) and a latent the listener marginalizes
+([bergen-levy-goodman-2016], [potts-etal-2016]); the LI (§3.3) and GI (§3.4)
+speakers instead *choose* an (utterance, parse) pair (eqs. 18a/21a), over the
+4 matrix-free parses resp. all 8 — one softmax over pairs per world, read by
+`RSA.Canonical.L1Intent`.
 
 We show that GI corrects the SS interpretation vanilla gets wrong
 (`vanilla_ss_prefers_wNA` vs `gi_ss_prefers_wNS`), and that its parse
@@ -58,53 +62,49 @@ open RSA.Canonical
 
 /-! ### Domain -/
 
+/-- An alien's drinking amount: none, some but not all, or all of its water. -/
+abbrev AlienType := SomeAllWorld
+
+/-- A world state is the set of drinking amounts realized by at least one
+alien — a nonempty subset of the three amounts. -/
+def World := {s : Finset AlienType // s.Nonempty}
+
+instance : DecidableEq World := Subtype.instDecidableEq
+instance : Fintype World := Subtype.fintype _
+
+/-- The seven world states, named by the alien types present: N drank none,
+S drank some but not all, A drank all. -/
+def wN : World := ⟨{.none}, Finset.singleton_nonempty _⟩
+def wNS : World := ⟨{.none, .someNotAll}, by decide⟩
+def wNA : World := ⟨{.none, .all}, by decide⟩
+def wNSA : World := ⟨{.none, .someNotAll, .all}, by decide⟩
+def wS : World := ⟨{.someNotAll}, Finset.singleton_nonempty _⟩
+def wSA : World := ⟨{.someNotAll, .all}, by decide⟩
+def wA : World := ⟨{.all}, Finset.singleton_nonempty _⟩
+
+instance : Nonempty World := ⟨wN⟩
+
+/-- EXH insertion sites: applying to the whole sentence, the outer
+quantifier, or the inner quantifier. -/
+inductive ExhPosition where
+  | matrix | outer | inner
+  deriving DecidableEq, Fintype
+
+/-- A parse is the set of EXH insertion sites. -/
+abbrev Parse := Finset ExhPosition
+
 /-- Aristotelian quantifiers: the utterance vocabulary. -/
 inductive AristQuant where
   | none | some | all
-  deriving DecidableEq, Repr, Inhabited, Fintype
+  deriving DecidableEq, Repr, Fintype
 
-/-- The 7 world states, distinguished by which alien types exist.
-Three types: N (drank none), S (drank some but not all), A (drank all).
-Worlds are the 7 non-empty subsets of {N, S, A}. -/
-inductive World where
-  | wN    -- only N-type aliens
-  | wNS   -- N and S types
-  | wNA   -- N and A types
-  | wNSA  -- all three types
-  | wS    -- only S-type aliens
-  | wSA   -- S and A types
-  | wA    -- only A-type aliens
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- The 9 nested Aristotelian utterances: Q_outer × Q_inner. -/
+/-- The 9 nested Aristotelian utterances, named outer-then-inner:
+`.ns` is "None of the aliens drank some of their water". -/
 inductive Utterance where
   | nn | ns | na
   | sn | ss | sa
   | an | as | aa
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- The 8 grammatical parses: subsets of {M, O, I} EXH positions. -/
-inductive Parse where
-  | none   -- literal (no EXH)
-  | m | o | i
-  | mo | mi | oi
-  | moi
-  deriving DecidableEq, Repr, Inhabited, Fintype
-
-/-- Whether N-type aliens (drank none) exist. -/
-def World.hasN : World → Bool
-  | .wN | .wNS | .wNA | .wNSA => true
-  | _ => false
-
-/-- Whether S-type aliens (drank some but not all) exist. -/
-def World.hasS : World → Bool
-  | .wS | .wNS | .wSA | .wNSA => true
-  | _ => false
-
-/-- Whether A-type aliens (drank all) exist. -/
-def World.hasA : World → Bool
-  | .wA | .wNA | .wSA | .wNSA => true
-  | _ => false
+  deriving DecidableEq, Repr, Fintype
 
 /-- Outer quantifier of an utterance. -/
 def Utterance.outer : Utterance → AristQuant
@@ -118,21 +118,6 @@ def Utterance.inner : Utterance → AristQuant
   | .ns | .ss | .as => .some
   | .na | .sa | .aa => .all
 
-/-- Whether parse includes EXH at inner position. -/
-def Parse.hasI : Parse → Bool
-  | .i | .mi | .oi | .moi => true
-  | _ => false
-
-/-- Whether parse includes EXH at outer position. -/
-def Parse.hasO : Parse → Bool
-  | .o | .mo | .oi | .moi => true
-  | _ => false
-
-/-- Whether parse includes EXH at matrix position. -/
-def Parse.hasM : Parse → Bool
-  | .m | .mo | .mi | .moi => true
-  | _ => false
-
 /-! ### Alternative quantifiers
 
 Sentential alternatives (A3a) substitute lexical alternatives per quantifier
@@ -144,11 +129,11 @@ inductive AltQuant where
   | none | some | all | notAll
   deriving DecidableEq, Repr
 
-/-- Utterance quantifiers are alternative quantifiers. -/
-def AristQuant.toAlt : AristQuant → AltQuant
-  | .none => .none
-  | .some => .some
-  | .all => .all
+instance : Coe AristQuant AltQuant where
+  coe
+    | .none => .none
+    | .some => .some
+    | .all => .all
 
 /-- Scale-mate candidates at a quantifier position of a sentential
 alternative: the quantifier itself and its lexical alternatives. -/
@@ -159,182 +144,200 @@ def AristQuant.altCandidates : AristQuant → List AltQuant
 
 /-! ### Compositional semantics -/
 
-/-- Inner VP satisfaction: which alien types satisfy "drank Q"? -/
-def AltQuant.innerTypeSat : AltQuant → Bool × Bool × Bool
-  | .none => (true, false, false)
-  | .some => (false, true, true)
-  | .all => (false, false, true)
-  | .notAll => (true, true, false)
+/-- Satisfaction of "drank Q" by an alien of a given amount, via the
+`SomeAllWorld` meanings. -/
+def AltQuant.sat : AltQuant → AlienType → Prop
+  | .none => fun t => ¬ t.atLeastOne
+  | .some => SomeAllWorld.atLeastOne
+  | .all => SomeAllWorld.universal
+  | .notAll => SomeAllWorld.notUniversal
 
-/-- Outer quantifier evaluation: does the world satisfy "Q of the aliens
-[satisfy inner VP]"? `nSat`, `sSat`, `aSat` say which alien types satisfy
-the inner VP. -/
-def AltQuant.outerEval (q : AltQuant) (nSat sSat aSat : Bool) (w : World) : Bool :=
-  match q with
-  | .none => !(w.hasN && nSat) && !(w.hasS && sSat) && !(w.hasA && aSat)
-  | .some => (w.hasN && nSat) || (w.hasS && sSat) || (w.hasA && aSat)
-  | .all => (!w.hasN || nSat) && (!w.hasS || sSat) && (!w.hasA || aSat)
-  | .notAll => !((!w.hasN || nSat) && (!w.hasS || sSat) && (!w.hasA || aSat))
+instance : ∀ q : AltQuant, DecidablePred q.sat
+  | .none, _ => inferInstanceAs (Decidable ¬ _)
+  | .some, t => inferInstanceAs (Decidable (SomeAllWorld.atLeastOne t))
+  | .all, t => inferInstanceAs (Decidable (SomeAllWorld.universal t))
+  | .notAll, t => inferInstanceAs (Decidable (SomeAllWorld.notUniversal t))
+
+/-- Quantifier denotation over the alien types realized in a world. -/
+def AltQuant.eval : AltQuant → World → (AlienType → Prop) → Prop
+  | .none, w, sat => ∀ t ∈ w.val, ¬ sat t
+  | .some, w, sat => ∃ t ∈ w.val, sat t
+  | .all, w, sat => ∀ t ∈ w.val, sat t
+  | .notAll, w, sat => ¬ ∀ t ∈ w.val, sat t
+
+instance : ∀ (q : AltQuant) (w : World) (sat : AlienType → Prop) [DecidablePred sat],
+    Decidable (q.eval w sat)
+  | .none, _, _, _ => inferInstanceAs (Decidable (∀ _ ∈ _, ¬ _))
+  | .some, _, _, _ => inferInstanceAs (Decidable (∃ _ ∈ _, _))
+  | .all, _, _, _ => inferInstanceAs (Decidable (∀ _ ∈ _, _))
+  | .notAll, _, _, _ => inferInstanceAs (Decidable (¬ ∀ _ ∈ _, _))
+
+/-- *not all* is the negation of *all* — definitionally, where the Bool
+version transcribed the negated clause by hand. -/
+theorem eval_notAll_iff (w : World) (sat : AlienType → Prop) :
+    AltQuant.eval .notAll w sat ↔ ¬ AltQuant.eval .all w sat := Iff.rfl
+
+/-- *none* is the negation of *some*. -/
+theorem eval_none_iff (w : World) (sat : AlienType → Prop) :
+    AltQuant.eval .none w sat ↔ ¬ AltQuant.eval .some w sat := by
+  simp [AltQuant.eval]
 
 /-- A sentential alternative: a pair of alternative quantifiers. -/
 abbrev AltSentence := AltQuant × AltQuant
 
 /-- Literal meaning of a sentential alternative. -/
-def altLiteral (a : AltSentence) : World → Bool :=
-  let (nSat, sSat, aSat) := a.2.innerTypeSat
-  a.1.outerEval nSat sSat aSat
+def altLiteral (a : AltSentence) (w : World) : Prop := a.1.eval w a.2.sat
+
+instance (a : AltSentence) : DecidablePred (altLiteral a) := fun _ =>
+  inferInstanceAs (Decidable (AltQuant.eval _ _ _))
 
 /-- Literal meaning of an utterance. -/
-def literalMeaning (u : Utterance) : World → Bool :=
-  altLiteral (u.outer.toAlt, u.inner.toAlt)
+def literalMeaning (u : Utterance) : World → Prop := altLiteral (↑u.outer, ↑u.inner)
+
+instance (u : Utterance) : DecidablePred (literalMeaning u) :=
+  inferInstanceAs (DecidablePred (altLiteral _))
 
 /-! ### Compositional exhaustification -/
 
-/-- All 7 worlds for enumeration. -/
-def allWorlds : List World := [.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA]
-
-/-- Inner VP satisfaction after EXH enrichment. Only "some" is enrichable:
-Exh(some) = "some but not all" — satisfied by S-types only. Exh(none) and
-Exh(all) are vacuous (no strictly stronger lexical alternative). -/
-def enrichedInnerTypeSat (qi : AristQuant) (hasI : Bool) : Bool × Bool × Bool :=
-  if hasI && qi == .some then
-    (false, true, false)  -- only S-types satisfy "some but not all"
-  else
-    qi.toAlt.innerTypeSat
-
-/-- Sentential alternatives at matrix position (A3a): the cross-product of
-scale-mate candidates for the two quantifier positions. -/
+/-- Sentential alternatives at matrix position (A3a): scale-mate candidates
+at the two quantifier positions. -/
 def matrixAlts (u : Utterance) : List AltSentence :=
-  (u.outer.altCandidates.map fun o => u.inner.altCandidates.map fun i => (o, i)).flatten
+  u.outer.altCandidates ×ˢ u.inner.altCandidates
 
-/-- Exhaustified meaning under a parse. Inner/outer EXH enrich *some* to
-"some but not all" in situ; matrix EXH (eq. A2) negates the literal meanings
-of the strictly stronger sentential alternatives (A3b: proper subsets of the
-sub-matrix meaning), falling back to the sub-matrix meaning on contradiction. -/
-def exhMeaning (p : Parse) (u : Utterance) : World → Bool :=
-  -- Step 1: inner predicate (enriched if I ∈ parse)
-  let (nSat, sSat, aSat) := enrichedInnerTypeSat u.inner p.hasI
-  -- Step 2: outer quantifier
-  let base := AltQuant.outerEval u.outer.toAlt nSat sSat aSat
-  -- Step 3: outer EXH (if O ∈ parse and outer Q = some): some ∧ ¬all
-  let afterO :=
-    if p.hasO && u.outer == .some then
-      fun w => base w && !(AltQuant.outerEval .all nSat sSat aSat w)
-    else base
-  -- Step 4: matrix EXH (if M ∈ parse), eq. A2
-  if p.hasM then
-    let strongerAlts := (matrixAlts u).filter fun a =>
-      allWorlds.all (fun w => !altLiteral a w || afterO w) &&
-      allWorlds.any (fun w => afterO w && !altLiteral a w)
-    let result : World → Bool := fun w => afterO w && strongerAlts.all fun a => !altLiteral a w
-    if allWorlds.any result then result else afterO
-  else afterO
+/-- Inner satisfaction after EXH enrichment: Exh(some) = "some but not all",
+the `.someNotAll` amount exactly; Exh(none) and Exh(all) are vacuous. -/
+def enrichedSat (qi : AristQuant) (p : Parse) : AlienType → Prop :=
+  if ExhPosition.inner ∈ p ∧ qi = .some then
+    fun t => t.atLeastOne ∧ t.notUniversal
+  else (↑qi : AltQuant).sat
 
-/-! ### Truth-table verification (the paper's Table 1) -/
+instance (qi : AristQuant) (p : Parse) : DecidablePred (enrichedSat qi p) := fun t => by
+  unfold enrichedSat; split <;> infer_instance
 
-/-- EXH_I(SS): inner EXH enriches "some" to "some but not all", so the outer
-"some" requires an S-type — {wNS, wNSA, wS, wSA}. -/
-theorem exh_i_ss :
-    allWorlds.map (exhMeaning .i .ss) = [false, true, false, true, true, true, false] := by
-  decide
+/-- The sub-matrix reading: in-situ enrichments, with outer EXH (Exh(some) at
+the outer position) as an implication guard. -/
+def subMatrix (p : Parse) (u : Utterance) (w : World) : Prop :=
+  AltQuant.eval (↑u.outer) w (enrichedSat u.inner p)
+  ∧ (ExhPosition.outer ∈ p ∧ u.outer = .some →
+      ¬ AltQuant.eval .all w (enrichedSat u.inner p))
 
-/-- EXH_OI(SS) = {wNS, wNSA, wSA}: outer "some but not all" alien types satisfy
-the enriched inner predicate; wS drops because there all types satisfy it. -/
-theorem exh_oi_ss :
-    allWorlds.map (exhMeaning .oi .ss) = [false, true, false, true, false, true, false] := by
-  decide
+instance (p : Parse) (u : Utterance) : DecidablePred (subMatrix p u) := fun _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
 
-/-- EXH_MOI(SS) = EXH_OI(SS): matrix EXH is vacuous at MOI — no sentential
-alternative's literal meaning is a proper subset of the OI-enriched meaning. -/
-theorem exh_moi_ss : ∀ w : World, exhMeaning .moi .ss w = exhMeaning .oi .ss w := by
-  decide
+/-- A sentential alternative is strictly stronger than the sub-matrix reading
+(A3b: proper subset — an utterance's own literal meaning qualifies when a
+parse weakens it, as for NS under MI). -/
+def StrictlyStronger (p : Parse) (u : Utterance) (a : AltSentence) : Prop :=
+  (∀ w, altLiteral a w → subMatrix p u w) ∧ ∃ w, subMatrix p u w ∧ ¬ altLiteral a w
 
-/-- AA is true only at wA under all parses. -/
-theorem aa_singleton : ∀ p : Parse, ∀ w : World, exhMeaning p .aa w = (w == .wA) := by
-  decide
+instance (p : Parse) (u : Utterance) (a : AltSentence) :
+    Decidable (StrictlyStronger p u a) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
-/-- Table 1, SS: the four reading families (lit / I / OI / M). -/
+/-- The matrix-exhaustified reading: the sub-matrix reading with every
+strictly stronger sentential alternative's literal meaning negated. -/
+def matrixExh (p : Parse) (u : Utterance) (w : World) : Prop :=
+  subMatrix p u w ∧ ∀ a ∈ matrixAlts u, StrictlyStronger p u a → ¬ altLiteral a w
+
+instance (p : Parse) (u : Utterance) : DecidablePred (matrixExh p u) := fun _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Exhaustified meaning under a parse: the matrix-exhaustified reading when
+M is in the parse and that reading is noncontradictory, else the sub-matrix
+reading (eq. A2). -/
+def exhMeaning (p : Parse) (u : Utterance) (w : World) : Prop :=
+  if ExhPosition.matrix ∈ p ∧ ∃ w', matrixExh p u w' then matrixExh p u w
+  else subMatrix p u w
+
+instance (p : Parse) (u : Utterance) : DecidablePred (exhMeaning p u) := fun w => by
+  unfold exhMeaning; split <;> infer_instance
+
+/-! ### Truth-table verification (the paper's Table 1)
+
+Each reading is characterized by a membership predicate on the world's
+alien-type set, rather than transcribed as a truth vector. -/
+
+/-- Table 1, SS: literal true except at wN; inner EXH requires an S-type;
+outer EXH additionally excludes wS; matrix EXH pins wNS. -/
 theorem table1_ss :
-    (allWorlds.map (exhMeaning .none .ss) = [false, true, true, true, true, true, true])
-    ∧ (allWorlds.map (exhMeaning .i .ss) = [false, true, false, true, true, true, false])
-    ∧ (allWorlds.map (exhMeaning .oi .ss) = [false, true, false, true, false, true, false])
-    ∧ (allWorlds.map (exhMeaning .m .ss) = [false, true, false, false, false, false, false]) := by
+    (∀ w, exhMeaning ∅ .ss w ↔ w ≠ wN)
+    ∧ (∀ w, exhMeaning {.inner} .ss w ↔ .someNotAll ∈ w.val)
+    ∧ (∀ w, exhMeaning {.outer, .inner} .ss w ↔ (.someNotAll ∈ w.val ∧ w ≠ wS))
+    ∧ (∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS) :=
+  ⟨by decide, by decide, by decide, by decide⟩
+
+/-- EXH_MOI(SS) = EXH_OI(SS): matrix EXH is vacuous at MOI. -/
+theorem exh_moi_ss : ∀ w,
+    exhMeaning {.matrix, .outer, .inner} .ss w ↔ exhMeaning {.outer, .inner} .ss w := by
   decide
 
-/-- Table 1, NN: matrix parses additionally negate "none drank not all"
-(= {wA}) — the fn. 7 reading from the `none ~ not all` alternative. -/
+/-- Table 1, NN: no N-types; matrix parses additionally negate "none drank
+not all" (= {wA}) — the fn. 7 reading from the `none ~ not all` alternative. -/
 theorem table1_nn :
-    (∀ p : Parse, p.hasM = false →
-      allWorlds.map (exhMeaning p .nn) = [false, false, false, false, true, true, true])
-    ∧ (∀ p : Parse, p.hasM = true →
-      allWorlds.map (exhMeaning p .nn) = [false, false, false, false, true, true, false]) := by
-  decide
+    (∀ p : Parse, .matrix ∉ p → ∀ w, exhMeaning p .nn w ↔ .none ∉ w.val)
+    ∧ (∀ p : Parse, .matrix ∈ p → ∀ w, exhMeaning p .nn w ↔ (.none ∉ w.val ∧ w ≠ wA)) :=
+  ⟨by decide, by decide⟩
 
-/-- Table 1, NS: inner EXH weakens NS, so under MI matrix EXH negates the
-sentence's own now-stronger literal meaning {wN} (A3b filters by properness
-alone), giving {wNA, wA}. -/
+/-- Table 1, NS: inner EXH weakens NS to the S-free worlds, so under MI
+matrix EXH negates the sentence's own now-stronger literal meaning {wN}. -/
 theorem table1_ns :
-    (allWorlds.map (exhMeaning .none .ns) = [true, false, false, false, false, false, false])
-    ∧ (allWorlds.map (exhMeaning .i .ns) = [true, false, true, false, false, false, true])
-    ∧ (allWorlds.map (exhMeaning .mi .ns) = [false, false, true, false, false, false, true]) := by
-  decide
+    (∀ w, exhMeaning ∅ .ns w ↔ w = wN)
+    ∧ (∀ w, exhMeaning {.inner} .ns w ↔ .someNotAll ∉ w.val)
+    ∧ (∀ w, exhMeaning {.matrix, .inner} .ns w ↔ (.someNotAll ∉ w.val ∧ w ≠ wN)) :=
+  ⟨by decide, by decide, by decide⟩
 
-/-- Table 1, AN: maximally informative — only wN. All parses agree. -/
-theorem table1_an : ∀ p : Parse,
-    allWorlds.map (exhMeaning p .an) = [true, false, false, false, false, false, false] := by
-  decide
+/-- Table 1, AN: only wN, under every parse. -/
+theorem table1_an : ∀ p : Parse, ∀ w, exhMeaning p .an w ↔ w = wN := by decide
 
-/-- Table 1, AA: only wA. All parses agree (cf. `aa_singleton`). -/
-theorem table1_aa : ∀ p : Parse,
-    allWorlds.map (exhMeaning p .aa) = [false, false, false, false, false, false, true] := by
-  decide
+/-- Table 1, AA: only wA, under every parse. -/
+theorem table1_aa : ∀ p : Parse, ∀ w, exhMeaning p .aa w ↔ w = wA := by decide
 
-/-- Table 1, SA: "some drank all" requires an A-type; EXH_O enriches outer
-"some" to "some but not all", excluding wA. -/
+/-- Table 1, SA: an A-type exists; outer EXH excludes wA. -/
 theorem table1_sa :
-    (allWorlds.map (exhMeaning .none .sa) = [false, false, true, true, false, true, true])
-    ∧ (allWorlds.map (exhMeaning .o .sa) = [false, false, true, true, false, true, false]) := by
-  decide
+    (∀ w, exhMeaning ∅ .sa w ↔ .all ∈ w.val)
+    ∧ (∀ w, exhMeaning {.outer} .sa w ↔ (.all ∈ w.val ∧ w ≠ wA)) :=
+  ⟨by decide, by decide⟩
 
-/-- Table 1, NA: "none drank all" = {wN, wNS, wS}; matrix EXH negates the
-stronger NS (= {wN}), removing wN. -/
+/-- Table 1, NA: no A-types; matrix EXH negates the stronger NS = {wN}. -/
 theorem table1_na :
-    (allWorlds.map (exhMeaning .none .na) = [true, true, false, false, true, false, false])
-    ∧ (allWorlds.map (exhMeaning .m .na) = [false, true, false, false, true, false, false]) := by
-  decide
+    (∀ w, exhMeaning ∅ .na w ↔ .all ∉ w.val)
+    ∧ (∀ w, exhMeaning {.matrix} .na w ↔ (.all ∉ w.val ∧ w ≠ wN)) :=
+  ⟨by decide, by decide⟩
 
-/-- Table 1, SN: "some drank none" = {wN, wNS, wNA, wNSA}; outer EXH (or
-matrix EXH) negates AN = {wN}. -/
+/-- Table 1, SN: an N-type exists; outer EXH negates AN = {wN}. -/
 theorem table1_sn :
-    (allWorlds.map (exhMeaning .none .sn) = [true, true, true, true, false, false, false])
-    ∧ (allWorlds.map (exhMeaning .o .sn) = [false, true, true, true, false, false, false]) := by
-  decide
+    (∀ w, exhMeaning ∅ .sn w ↔ .none ∈ w.val)
+    ∧ (∀ w, exhMeaning {.outer} .sn w ↔ (.none ∈ w.val ∧ w ≠ wN)) :=
+  ⟨by decide, by decide⟩
 
-/-- Table 1, AS: "all drank some" = {wS, wSA, wA}; EXH_I narrows to wS;
-matrix EXH without I negates AA, excluding wA. -/
+/-- Table 1, AS: no N-types; inner EXH pins wS; matrix EXH without I
+negates AA, excluding wA. -/
 theorem table1_as :
-    (allWorlds.map (exhMeaning .none .as) = [false, false, false, false, true, true, true])
-    ∧ (allWorlds.map (exhMeaning .i .as) = [false, false, false, false, true, false, false])
-    ∧ (allWorlds.map (exhMeaning .m .as) = [false, false, false, false, true, true, false]) := by
-  decide
+    (∀ w, exhMeaning ∅ .as w ↔ .none ∉ w.val)
+    ∧ (∀ w, exhMeaning {.inner} .as w ↔ w = wS)
+    ∧ (∀ w, exhMeaning {.matrix} .as w ↔ (.none ∉ w.val ∧ w ≠ wA)) :=
+  ⟨by decide, by decide, by decide⟩
 
 /-- Literal meaning is the empty parse's exhaustified meaning. -/
-theorem literal_eq_exh_none : ∀ u : Utterance, ∀ w : World,
-    literalMeaning u w = exhMeaning .none u w := by decide
+theorem literal_eq_exh_none : ∀ u : Utterance, ∀ w,
+    literalMeaning u w ↔ exhMeaning ∅ u w := by decide
 
 /-- ⟦SS⟧^M = {wNS}: matrix EXH narrows SS to a single world — the reading
 that "uniquely singles out this world state" (eq. 22) and drives GI's win. -/
-theorem m_ss_singleton : ∀ w : World, exhMeaning .m .ss w = (w == .wNS) := by decide
+theorem m_ss_singleton : ∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS :=
+  table1_ss.2.2.2
 
 /-- The matrix operator (eq. A2) is not Fox-style innocent exclusion
 ([fox-2007]): at MOI its strictly-stronger filter is empty and ⟦SS⟧^MOI keeps
 wSA, which innocent exclusion over the same alternatives excludes. -/
 theorem moi_ss_ne_innocent_exclusion :
-    exhMeaning .moi .ss .wSA = true
-      ∧ World.wSA ∉ Exhaustification.innocent.exh
-          (Exhaustification.altsFromPreds ((matrixAlts .ss).map altLiteral))
-          (Exhaustification.predToFinset (exhMeaning .oi .ss)) := by
-  decide
+    exhMeaning {.matrix, .outer, .inner} .ss wSA
+      ∧ wSA ∉ Exhaustification.innocent.exh
+          (Exhaustification.altsFromPreds
+            ((matrixAlts .ss).map fun a w => decide (altLiteral a w)))
+          (Exhaustification.predToFinset
+            fun w => decide (exhMeaning {.outer, .inner} .ss w)) :=
+  ⟨by decide, by decide⟩
 
 /-! ### Latent spaces -/
 
@@ -342,30 +345,32 @@ theorem moi_ss_ne_innocent_exclusion :
 lexicon; the listener marginalizes over the two lexica. -/
 inductive LULex where
   | lit | oi
-  deriving DecidableEq, Repr, Inhabited, Fintype
+  deriving DecidableEq, Repr, Fintype
+
+instance : Nonempty LULex := ⟨.lit⟩
 
 /-- Map LU lexicon to the corresponding parse. -/
 def LULex.toParse : LULex → Parse
-  | .lit => .none
-  | .oi => .oi
+  | .lit => ∅
+  | .oi => {.outer, .inner}
 
 /-- LI parse: lit, I, O, or OI — matrix-EXH parses are unavailable. -/
 inductive LIParse where
   | lit | i | o | oi
-  deriving DecidableEq, Repr, Inhabited, Fintype
+  deriving DecidableEq, Repr, Fintype
 
 /-- Map LI parse to the full parse space. -/
 def LIParse.toParse : LIParse → Parse
-  | .lit => .none
-  | .i => .i
-  | .o => .o
-  | .oi => .oi
+  | .lit => ∅
+  | .i => {.inner}
+  | .o => {.outer}
+  | .oi => {.outer, .inner}
 
 /-- LI cannot access matrix EXH: no LI parse includes M. -/
-theorem li_excludes_matrix : ∀ l : LIParse, l.toParse.hasM = false := by decide
+theorem li_excludes_matrix : ∀ l : LIParse, .matrix ∉ l.toParse := by decide
 
 /-- LU cannot access matrix EXH: neither lexicon includes M. -/
-theorem lu_excludes_matrix : ∀ l : LULex, l.toParse.hasM = false := by decide
+theorem lu_excludes_matrix : ∀ l : LULex, .matrix ∉ l.toParse := by decide
 
 /-! ### Speakers
 
@@ -375,22 +380,21 @@ softmax per world. -/
 
 /-- Every utterance is true at some world under every parse, so each per-parse
 literal listener is well-defined. -/
-theorem ext_nonempty (p : Parse) (u : Utterance) :
-    (RSA.extensionOf (exhMeaning p) u).Nonempty := by cases p <;> cases u <;> decide
+theorem ext_nonempty : ∀ (p : Parse) (u : Utterance),
+    (RSA.extensionOf (exhMeaning p) u).Nonempty := by decide
 
 /-- The per-parse literal listener `L0(· | u, p)`, uniform on the extension of
 `exhMeaning p u`. -/
 noncomputable abbrev L0 : Parse → Utterance → PMF World :=
-  L0OfBool exhMeaning ext_nonempty
+  L0OfPred exhMeaning ext_nonempty
 
 /-- Every `(world, parse)` state has a true utterance. -/
-theorem exists_true (w : World) (p : Parse) : ∃ u, exhMeaning p u w = true := by
-  cases w <;> cases p <;> decide
+theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide
 
 noncomputable instance : ViableSpeaker (powUtility 2 L0) :=
   viableSpeaker_powUtility_of_witness 2 L0 fun s => by
     obtain ⟨u, hu⟩ := exists_true s.1 s.2
-    exact ⟨u, L0OfBool_ne_zero exhMeaning ext_nonempty hu⟩
+    exact ⟨u, L0OfPred_ne_zero exhMeaning ext_nonempty hu⟩
 
 /-- The per-parse (fixed-lexicon) speaker of the vanilla and LU models. -/
 noncomputable def speaker : World × Parse → PMF Utterance := S1 (powUtility 2 L0)
@@ -399,22 +403,25 @@ noncomputable def speaker : World × Parse → PMF Utterance := S1 (powUtility 2
 noncomputable def luSpeaker (s : World × LULex) : PMF Utterance := speaker (s.1, s.2.toParse)
 
 /-- Vanilla speaker: the per-parse speaker at the literal parse. -/
-noncomputable def vanillaSpeaker (w : World) : PMF Utterance := speaker (w, .none)
+noncomputable def vanillaSpeaker (w : World) : PMF Utterance := speaker (w, ∅)
 
-/-- The GI meaning family (`Unit`-indexed to fit `L0OfBool`): an
+/-- The GI meaning family (`Unit`-indexed to fit `L0OfPred`): an
 (utterance, parse) pair means its parse's reading. -/
-def giMeaning : Unit → Utterance × Parse → World → Bool := fun _ x => exhMeaning x.2 x.1
+def giMeaning : Unit → Utterance × Parse → World → Prop := fun _ x => exhMeaning x.2 x.1
+
+instance (i : Unit) (x : Utterance × Parse) : DecidablePred (giMeaning i x) :=
+  inferInstanceAs (DecidablePred (exhMeaning x.2 x.1))
 
 theorem gi_ext_nonempty (i : Unit) (x : Utterance × Parse) :
     (RSA.extensionOf (giMeaning i) x).Nonempty := ext_nonempty x.2 x.1
 
 noncomputable abbrev giL0 : Unit → Utterance × Parse → PMF World :=
-  L0OfBool giMeaning gi_ext_nonempty
+  L0OfPred giMeaning gi_ext_nonempty
 
 noncomputable instance : ViableSpeaker (powUtility 2 giL0) :=
   viableSpeaker_powUtility_of_witness 2 giL0 fun s => by
-    obtain ⟨u, hu⟩ := exists_true s.1 .none
-    exact ⟨(u, .none), L0OfBool_ne_zero giMeaning gi_ext_nonempty hu⟩
+    obtain ⟨u, hu⟩ := exists_true s.1 ∅
+    exact ⟨(u, ∅), L0OfPred_ne_zero giMeaning gi_ext_nonempty hu⟩
 
 /-- The GI speaker (eq. 21a): one softmax over all 72 (utterance, parse)
 pairs at each world. -/
@@ -422,18 +429,22 @@ noncomputable def giSpeaker (w : World) : PMF (Utterance × Parse) :=
   S1 (powUtility 2 giL0) (w, ())
 
 /-- The LI meaning family: `giMeaning` restricted to matrix-free parses. -/
-def liMeaning : Unit → Utterance × LIParse → World → Bool := fun _ x => exhMeaning x.2.toParse x.1
+def liMeaning : Unit → Utterance × LIParse → World → Prop :=
+  fun _ x => exhMeaning x.2.toParse x.1
+
+instance (i : Unit) (x : Utterance × LIParse) : DecidablePred (liMeaning i x) :=
+  inferInstanceAs (DecidablePred (exhMeaning x.2.toParse x.1))
 
 theorem li_ext_nonempty (i : Unit) (x : Utterance × LIParse) :
     (RSA.extensionOf (liMeaning i) x).Nonempty := ext_nonempty x.2.toParse x.1
 
 noncomputable abbrev liL0 : Unit → Utterance × LIParse → PMF World :=
-  L0OfBool liMeaning li_ext_nonempty
+  L0OfPred liMeaning li_ext_nonempty
 
 noncomputable instance : ViableSpeaker (powUtility 2 liL0) :=
   viableSpeaker_powUtility_of_witness 2 liL0 fun s => by
-    obtain ⟨u, hu⟩ := exists_true s.1 .none
-    exact ⟨(u, .lit), L0OfBool_ne_zero liMeaning li_ext_nonempty hu⟩
+    obtain ⟨u, hu⟩ := exists_true s.1 ∅
+    exact ⟨(u, .lit), L0OfPred_ne_zero liMeaning li_ext_nonempty hu⟩
 
 /-- The LI speaker (eq. 18a): one softmax over the 36 (utterance, parse)
 pairs with matrix-free parses. -/
@@ -478,10 +489,11 @@ private theorem univU : (Finset.univ : Finset Utterance)
     = {.nn, .ns, .na, .sn, .ss, .sa, .an, .as, .aa} := by decide
 
 private theorem univP : (Finset.univ : Finset Parse)
-    = {.none, .m, .o, .i, .mo, .mi, .oi, .moi} := by decide
+    = {∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
+       {.outer, .inner}, {.matrix, .outer, .inner}} := by decide
 
 private theorem univW : (Finset.univ : Finset World)
-    = {.wN, .wNS, .wNA, .wNSA, .wS, .wSA, .wA} := by decide
+    = {wN, wNS, wNA, wNSA, wS, wSA, wA} := by decide
 
 private theorem univLU : (Finset.univ : Finset LULex) = {.lit, .oi} := by decide
 
@@ -489,154 +501,154 @@ private theorem univLI : (Finset.univ : Finset LIParse) = {.lit, .i, .o, .oi} :=
 
 /-! GI partitions `Z(w) = Σ_{(u,p)} |ext(u,p)|⁻²` over the 72 pairs. -/
 
-private theorem zGI_wN : boolPartition giMeaning 2 () World.wN = 307/24 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wN : ratPartition giMeaning 2 () wN = 307/24 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wNS : boolPartition giMeaning 2 () World.wNS = 23/6 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wNS : ratPartition giMeaning 2 () wNS = 23/6 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wNA : boolPartition giMeaning 2 () World.wNA = 23/9 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wNA : ratPartition giMeaning 2 () wNA = 23/9 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wNSA : boolPartition giMeaning 2 () World.wNSA = 157/72 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wNSA : ratPartition giMeaning 2 () wNSA = 157/72 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wS : boolPartition giMeaning 2 () World.wS = 559/72 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wS : ratPartition giMeaning 2 () wS = 559/72 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wSA : boolPartition giMeaning 2 () World.wSA = 10/3 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wSA : ratPartition giMeaning 2 () wSA = 10/3 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
-private theorem zGI_wA : boolPartition giMeaning 2 () World.wA = 229/24 := by
-  norm_num +decide [boolPartition, boolWeight, giMeaning, RSA.extensionOf,
+private theorem zGI_wA : ratPartition giMeaning 2 () wA = 229/24 := by
+  norm_num +decide [ratPartition, ratWeight, giMeaning, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univP, univW]
 
 /-! LI partitions over the 36 matrix-free pairs. -/
 
-private theorem zLI_wNS : boolPartition liMeaning 2 () World.wNS = 53/48 := by
-  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+private theorem zLI_wNS : ratPartition liMeaning 2 () wNS = 53/48 := by
+  norm_num +decide [ratPartition, ratWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
 
-private theorem zLI_wNA : boolPartition liMeaning 2 () World.wNA = 19/18 := by
-  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+private theorem zLI_wNA : ratPartition liMeaning 2 () wNA = 19/18 := by
+  norm_num +decide [ratPartition, ratWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
 
-private theorem zLI_wS : boolPartition liMeaning 2 () World.wS = 461/144 := by
-  norm_num +decide [boolPartition, boolWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
+private theorem zLI_wS : ratPartition liMeaning 2 () wS = 461/144 := by
+  norm_num +decide [ratPartition, ratWeight, liMeaning, LIParse.toParse, RSA.extensionOf,
     Fintype.sum_prod_type, Finset.filter_insert, Finset.filter_singleton, univU, univLI, univW]
 
 /-! Per-parse partitions (vanilla and LU). -/
 
-private theorem zNone_wNS : boolPartition exhMeaning 2 (.none : Parse) World.wNS = 29/144 := by
-  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+private theorem zNone_wNS : ratPartition exhMeaning 2 (∅ : Parse) wNS = 29/144 := by
+  norm_num +decide [ratPartition, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univU, univW]
 
-private theorem zNone_wNA : boolPartition exhMeaning 2 (.none : Parse) World.wNA = 11/72 := by
-  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+private theorem zNone_wNA : ratPartition exhMeaning 2 (∅ : Parse) wNA = 11/72 := by
+  norm_num +decide [ratPartition, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univU, univW]
 
-private theorem zOI_wNS : boolPartition exhMeaning 2 (.oi : Parse) World.wNS = 1/3 := by
-  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+private theorem zOI_wNS : ratPartition exhMeaning 2 ({.outer, .inner} : Parse) wNS = 1/3 := by
+  norm_num +decide [ratPartition, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univU, univW]
 
-private theorem zOI_wNA : boolPartition exhMeaning 2 (.oi : Parse) World.wNA = 1/3 := by
-  norm_num +decide [boolPartition, boolWeight, RSA.extensionOf,
+private theorem zOI_wNA : ratPartition exhMeaning 2 ({.outer, .inner} : Parse) wNA = 1/3 := by
+  norm_num +decide [ratPartition, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univU, univW]
 
 /-! Pooled speaker sums in `ofReal`-of-`ℚ` form. -/
 
 private theorem gi_sum_eq (w : World) (u : Utterance) :
     (∑ p : Parse, giSpeaker w (u, p))
-      = ENNReal.ofReal (∑ p : Parse, boolS1 giMeaning 2 () w (u, p)) :=
+      = ENNReal.ofReal (∑ p : Parse, ratS1 giMeaning 2 () w (u, p)) :=
   sum_S1_eq_ofReal giMeaning gi_ext_nonempty (by norm_num) Finset.univ
     (fun _ => (w, ())) (fun p => (u, p))
 
 private theorem gi_sumW_eq (p : Parse) (u : Utterance) :
     (∑ w : World, giSpeaker w (u, p))
-      = ENNReal.ofReal (∑ w : World, boolS1 giMeaning 2 () w (u, p)) :=
+      = ENNReal.ofReal (∑ w : World, ratS1 giMeaning 2 () w (u, p)) :=
   sum_S1_eq_ofReal giMeaning gi_ext_nonempty (by norm_num) Finset.univ
     (fun w => (w, ())) (fun _ => (u, p))
 
 private theorem li_sum_eq (w : World) (u : Utterance) :
     (∑ l : LIParse, liSpeaker w (u, l))
-      = ENNReal.ofReal (∑ l : LIParse, boolS1 liMeaning 2 () w (u, l)) :=
+      = ENNReal.ofReal (∑ l : LIParse, ratS1 liMeaning 2 () w (u, l)) :=
   sum_S1_eq_ofReal liMeaning li_ext_nonempty (by norm_num) Finset.univ
     (fun _ => (w, ())) (fun l => (u, l))
 
 private theorem speaker_eq (p : Parse) (w : World) (u : Utterance) :
-    speaker (w, p) u = ENNReal.ofReal (boolS1 exhMeaning 2 p w u) :=
+    speaker (w, p) u = ENNReal.ofReal (ratS1 exhMeaning 2 p w u) :=
   S1_eq_ofReal exhMeaning ext_nonempty (by norm_num) p w u
 
 private theorem lu_sum_eq (w : World) (u : Utterance) :
     (∑ l : LULex, luSpeaker (w, l) u)
-      = ENNReal.ofReal (boolS1 exhMeaning 2 (.none : Parse) w u
-          + boolS1 exhMeaning 2 (.oi : Parse) w u) := by
+      = ENNReal.ofReal (ratS1 exhMeaning 2 (∅ : Parse) w u
+          + ratS1 exhMeaning 2 ({.outer, .inner} : Parse) w u) := by
   rw [show (Finset.univ : Finset LULex) = {.lit, .oi} from univLU,
     Finset.sum_insert (by decide), Finset.sum_singleton]
-  show speaker (w, .none) u + speaker (w, .oi) u = _
+  show speaker (w, ∅) u + speaker (w, {.outer, .inner}) u = _
   rw [speaker_eq, speaker_eq,
-    ← ENNReal.ofReal_add (by exact_mod_cast boolS1_nonneg exhMeaning 2 _ w u)
-      (by exact_mod_cast boolS1_nonneg exhMeaning 2 _ w u)]
-
-private theorem vanilla_eq (w : World) (u : Utterance) :
-    vanillaSpeaker w u = ENNReal.ofReal (boolS1 exhMeaning 2 (.none : Parse) w u) :=
-  S1_eq_ofReal exhMeaning ext_nonempty (by norm_num) .none w u
+    ← ENNReal.ofReal_add (by exact_mod_cast ratS1_nonneg exhMeaning 2 _ w u)
+      (by exact_mod_cast ratS1_nonneg exhMeaning 2 _ w u)]
 
 /-! Listener-preference reductions to `ℚ`. -/
 
 private theorem gi_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
-    (hq : (∑ p : Parse, boolS1 giMeaning 2 () w₁ (u, p))
-        < ∑ p : Parse, boolS1 giMeaning 2 () w₂ (u, p)) :
+    (hq : (∑ p : Parse, ratS1 giMeaning 2 () w₁ (u, p))
+        < ∑ p : Parse, ratS1 giMeaning 2 () w₂ (u, p)) :
     (giListener u h).fst w₁ < (giListener u h).fst w₂ := by
-  have h₀ : (0 : ℚ) ≤ ∑ p : Parse, boolS1 giMeaning 2 () w₁ (u, p) :=
-    Finset.sum_nonneg fun p _ => boolS1_nonneg giMeaning 2 () w₁ (u, p)
+  have h₀ : (0 : ℚ) ≤ ∑ p : Parse, ratS1 giMeaning 2 () w₁ (u, p) :=
+    Finset.sum_nonneg fun p _ => ratS1_nonneg giMeaning 2 () w₁ (u, p)
   rw [giListener, L1Intent_uniform_world_prefers_iff, gi_sum_eq, gi_sum_eq,
     ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
   exact_mod_cast hq
 
 private theorem gi_snd_lt {u : Utterance} (h) {p₁ p₂ : Parse}
-    (hq : (∑ w : World, boolS1 giMeaning 2 () w (u, p₁))
-        < ∑ w : World, boolS1 giMeaning 2 () w (u, p₂)) :
+    (hq : (∑ w : World, ratS1 giMeaning 2 () w (u, p₁))
+        < ∑ w : World, ratS1 giMeaning 2 () w (u, p₂)) :
     (giListener u h).snd p₁ < (giListener u h).snd p₂ := by
-  have h₀ : (0 : ℚ) ≤ ∑ w : World, boolS1 giMeaning 2 () w (u, p₁) :=
-    Finset.sum_nonneg fun w _ => boolS1_nonneg giMeaning 2 () w (u, p₁)
+  have h₀ : (0 : ℚ) ≤ ∑ w : World, ratS1 giMeaning 2 () w (u, p₁) :=
+    Finset.sum_nonneg fun w _ => ratS1_nonneg giMeaning 2 () w (u, p₁)
   rw [giListener, L1Intent_uniform_latent_prefers_iff, gi_sumW_eq, gi_sumW_eq,
     ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
   exact_mod_cast hq
 
 private theorem li_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
-    (hq : (∑ l : LIParse, boolS1 liMeaning 2 () w₁ (u, l))
-        < ∑ l : LIParse, boolS1 liMeaning 2 () w₂ (u, l)) :
+    (hq : (∑ l : LIParse, ratS1 liMeaning 2 () w₁ (u, l))
+        < ∑ l : LIParse, ratS1 liMeaning 2 () w₂ (u, l)) :
     (liListener u h).fst w₁ < (liListener u h).fst w₂ := by
-  have h₀ : (0 : ℚ) ≤ ∑ l : LIParse, boolS1 liMeaning 2 () w₁ (u, l) :=
-    Finset.sum_nonneg fun l _ => boolS1_nonneg liMeaning 2 () w₁ (u, l)
+  have h₀ : (0 : ℚ) ≤ ∑ l : LIParse, ratS1 liMeaning 2 () w₁ (u, l) :=
+    Finset.sum_nonneg fun l _ => ratS1_nonneg liMeaning 2 () w₁ (u, l)
   rw [liListener, L1Intent_uniform_world_prefers_iff, li_sum_eq, li_sum_eq,
     ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
   exact_mod_cast hq
 
 private theorem lu_fst_lt {u : Utterance} (h) {w₁ w₂ : World}
-    (hq : boolS1 exhMeaning 2 (.none : Parse) w₁ u + boolS1 exhMeaning 2 (.oi : Parse) w₁ u
-        < boolS1 exhMeaning 2 (.none : Parse) w₂ u + boolS1 exhMeaning 2 (.oi : Parse) w₂ u) :
+    (hq : ratS1 exhMeaning 2 (∅ : Parse) w₁ u
+          + ratS1 exhMeaning 2 ({.outer, .inner} : Parse) w₁ u
+        < ratS1 exhMeaning 2 (∅ : Parse) w₂ u
+          + ratS1 exhMeaning 2 ({.outer, .inner} : Parse) w₂ u) :
     (luListener u h).fst w₁ < (luListener u h).fst w₂ := by
-  have h₀ : (0 : ℚ) ≤ boolS1 exhMeaning 2 (.none : Parse) w₁ u
-      + boolS1 exhMeaning 2 (.oi : Parse) w₁ u :=
-    add_nonneg (boolS1_nonneg exhMeaning 2 _ w₁ u) (boolS1_nonneg exhMeaning 2 _ w₁ u)
+  have h₀ : (0 : ℚ) ≤ ratS1 exhMeaning 2 (∅ : Parse) w₁ u
+      + ratS1 exhMeaning 2 ({.outer, .inner} : Parse) w₁ u :=
+    add_nonneg (ratS1_nonneg exhMeaning 2 _ w₁ u) (ratS1_nonneg exhMeaning 2 _ w₁ u)
   rw [luListener, L1_uniform_world_prefers_iff, lu_sum_eq, lu_sum_eq,
     ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
   exact_mod_cast hq
 
 private theorem vanilla_lt {u : Utterance} (h) {w₁ w₂ : World}
-    (hq : boolS1 exhMeaning 2 (.none : Parse) w₁ u < boolS1 exhMeaning 2 (.none : Parse) w₂ u) :
+    (hq : ratS1 exhMeaning 2 (∅ : Parse) w₁ u < ratS1 exhMeaning 2 (∅ : Parse) w₂ u) :
     (vanillaListener u h) w₁ < (vanillaListener u h) w₂ := by
-  have h₀ : (0 : ℚ) ≤ boolS1 exhMeaning 2 (.none : Parse) w₁ u :=
-    boolS1_nonneg exhMeaning 2 _ w₁ u
-  rw [vanillaListener, PMF.posterior_lt_iff_kernel_lt_of_uniform, vanilla_eq, vanilla_eq,
+  have h₀ : (0 : ℚ) ≤ ratS1 exhMeaning 2 (∅ : Parse) w₁ u :=
+    ratS1_nonneg exhMeaning 2 _ w₁ u
+  rw [vanillaListener, PMF.posterior_lt_iff_kernel_lt_of_uniform]
+  show speaker (w₁, ∅) u < speaker (w₂, ∅) u
+  rw [speaker_eq, speaker_eq,
     ENNReal.ofReal_lt_ofReal_iff (by exact_mod_cast lt_of_le_of_lt h₀ hq)]
   exact_mod_cast hq
 
@@ -645,115 +657,122 @@ private theorem vanilla_lt {u : Utterance} (h) {w₁ w₂ : World}
 theorem gi_marg_ss :
     PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .ss ≠ 0 :=
   L1Intent_uniform_marginal_ne_zero giSpeaker
-    (show giSpeaker .wNS (.ss, .none) ≠ 0 from
-      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
+    (show giSpeaker wNS (.ss, ∅) ≠ 0 from
+      S1_L0OfPred_ne_zero giMeaning gi_ext_nonempty (by decide))
 
 theorem gi_marg_aa :
     PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .aa ≠ 0 :=
   L1Intent_uniform_marginal_ne_zero giSpeaker
-    (show giSpeaker .wA (.aa, .none) ≠ 0 from
-      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
+    (show giSpeaker wA (.aa, ∅) ≠ 0 from
+      S1_L0OfPred_ne_zero giMeaning gi_ext_nonempty (by decide))
 
 theorem gi_marg_as :
     PMF.marginal (fun w => (giSpeaker w).fst) (PMF.uniformOfFintype World) .as ≠ 0 :=
   L1Intent_uniform_marginal_ne_zero giSpeaker
-    (show giSpeaker .wS (.as, .none) ≠ 0 from
-      S1_L0OfBool_ne_zero giMeaning gi_ext_nonempty (by decide))
+    (show giSpeaker wS (.as, ∅) ≠ 0 from
+      S1_L0OfPred_ne_zero giMeaning gi_ext_nonempty (by decide))
 
 theorem li_marg_ss :
     PMF.marginal (fun w => (liSpeaker w).fst) (PMF.uniformOfFintype World) .ss ≠ 0 :=
   L1Intent_uniform_marginal_ne_zero liSpeaker
-    (show liSpeaker .wNS (.ss, .lit) ≠ 0 from
-      S1_L0OfBool_ne_zero liMeaning li_ext_nonempty (by decide))
+    (show liSpeaker wNS (.ss, .lit) ≠ 0 from
+      S1_L0OfPred_ne_zero liMeaning li_ext_nonempty (by decide))
 
 theorem lu_marg_ss :
     PMF.marginal luSpeaker (PMF.uniformOfFintype (World × LULex)) .ss ≠ 0 :=
   PMF.marginal_ne_zero luSpeaker (PMF.uniformOfFintype (World × LULex)) .ss
-    (a := (.wNS, .lit))
-    (((PMF.uniformOfFintype (World × LULex)).mem_support_iff (.wNS, .lit)).mp
+    (a := (wNS, .lit))
+    (((PMF.uniformOfFintype (World × LULex)).mem_support_iff (wNS, .lit)).mp
       (PMF.mem_support_uniformOfFintype _))
-    (show speaker (.wNS, .none) .ss ≠ 0 from
-      S1_L0OfBool_ne_zero exhMeaning ext_nonempty (by decide))
+    (show speaker (wNS, ∅) .ss ≠ 0 from
+      S1_L0OfPred_ne_zero exhMeaning ext_nonempty (by decide))
 
 theorem vanilla_marg_ss :
     PMF.marginal vanillaSpeaker (PMF.uniformOfFintype World) .ss ≠ 0 :=
-  PMF.marginal_ne_zero vanillaSpeaker (PMF.uniformOfFintype World) .ss (a := .wNS)
-    (((PMF.uniformOfFintype World).mem_support_iff .wNS).mp
+  PMF.marginal_ne_zero vanillaSpeaker (PMF.uniformOfFintype World) .ss (a := wNS)
+    (((PMF.uniformOfFintype World).mem_support_iff wNS).mp
       (PMF.mem_support_uniformOfFintype _))
-    (show speaker (.wNS, .none) .ss ≠ 0 from
-      S1_L0OfBool_ne_zero exhMeaning ext_nonempty (by decide))
+    (show speaker (wNS, ∅) .ss ≠ 0 from
+      S1_L0OfPred_ne_zero exhMeaning ext_nonempty (by decide))
 
 /-! ### The ten qualitative findings -/
 
 /-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
 theorem ss_inner_exh :
-    (giListener .ss gi_marg_ss).fst .wNSA < (giListener .ss gi_marg_ss).fst .wNS :=
-  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    (giListener .ss gi_marg_ss).fst wNSA < (giListener .ss gi_marg_ss).fst wNS :=
+  gi_fst_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wNSA])
 
 /-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
 theorem ss_outer_exh :
-    (giListener .ss gi_marg_ss).fst .wS < (giListener .ss gi_marg_ss).fst .wNS :=
-  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    (giListener .ss gi_marg_ss).fst wS < (giListener .ss gi_marg_ss).fst wNS :=
+  gi_fst_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wS])
 
 /-- AA identifies the unique world where all aliens drank all: wA over wSA. -/
 theorem aa_identifies :
-    (giListener .aa gi_marg_aa).fst .wSA < (giListener .aa gi_marg_aa).fst .wA :=
-  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    (giListener .aa gi_marg_aa).fst wSA < (giListener .aa gi_marg_aa).fst wA :=
+  gi_fst_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wSA, zGI_wA])
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :
-    (giListener .as gi_marg_as).fst .wA < (giListener .as gi_marg_as).fst .wS :=
-  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    (giListener .as gi_marg_as).fst wA < (giListener .as gi_marg_as).fst wS :=
+  gi_fst_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wS, zGI_wA])
 
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
 uniquely identifies wNS (eq. 22). Pair choice drives this: under per-parse
 normalization M would not dominate. -/
-theorem ss_m_parse_pref : ∀ p : Parse, p ≠ .m →
-    (giListener .ss gi_marg_ss).snd p < (giListener .ss gi_marg_ss).snd .m := by
+theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
+    (giListener .ss gi_marg_ss).snd p < (giListener .ss gi_marg_ss).snd {.matrix} := by
+  have key : ∀ p ∈ ({∅, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
+      {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse),
+      (giListener .ss gi_marg_ss).snd p < (giListener .ss gi_marg_ss).snd {.matrix} := by
+    intro p hp
+    fin_cases hp <;>
+      exact gi_snd_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
+        Finset.filter_insert, Finset.filter_singleton, univW, zGI_wN, zGI_wNS, zGI_wNA,
+        zGI_wNSA, zGI_wS, zGI_wSA, zGI_wA])
   intro p hp
-  cases p
-  case m => exact absurd rfl hp
-  all_goals
-    exact gi_snd_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
-      Finset.filter_insert, Finset.filter_singleton, univW, zGI_wN, zGI_wNS, zGI_wNA,
-      zGI_wNSA, zGI_wS, zGI_wSA, zGI_wA])
+  refine key p ?_
+  have hu : p ∈ (Finset.univ : Finset Parse) := Finset.mem_univ p
+  rw [univP] at hu
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hu ⊢
+  tauto
 
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction (the
 cost-free illustration of eq. 10; the direction reverses at the fitted cost). -/
 theorem vanilla_ss_prefers_wNA :
-    (vanillaListener .ss vanilla_marg_ss) .wNS < (vanillaListener .ss vanilla_marg_ss) .wNA :=
-  vanilla_lt _ (by norm_num +decide [boolS1, boolWeight, RSA.extensionOf,
+    (vanillaListener .ss vanilla_marg_ss) wNS < (vanillaListener .ss vanilla_marg_ss) wNA :=
+  vanilla_lt _ (by norm_num +decide [ratS1, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univW, zNone_wNS, zNone_wNA])
 
 /-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
-    (giListener .ss gi_marg_ss).fst .wNA < (giListener .ss gi_marg_ss).fst .wNS :=
-  gi_fst_lt _ (by norm_num +decide [boolS1, boolWeight, giMeaning, RSA.extensionOf,
+    (giListener .ss gi_marg_ss).fst wNA < (giListener .ss gi_marg_ss).fst wNS :=
+  gi_fst_lt _ (by norm_num +decide [ratS1, ratWeight, giMeaning, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univP, univW, zGI_wNS, zGI_wNA])
 
 /-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA (the
 paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
 theorem lu_ss_prefers_wNS :
-    (luListener .ss lu_marg_ss).fst .wNA < (luListener .ss lu_marg_ss).fst .wNS :=
-  lu_fst_lt _ (by norm_num +decide [boolS1, boolWeight, RSA.extensionOf,
+    (luListener .ss lu_marg_ss).fst wNA < (luListener .ss lu_marg_ss).fst wNS :=
+  lu_fst_lt _ (by norm_num +decide [ratS1, ratWeight, RSA.extensionOf,
     Finset.filter_insert, Finset.filter_singleton, univW,
     zNone_wNS, zNone_wNA, zOI_wNS, zOI_wNA])
 
 /-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
-    (liListener .ss li_marg_ss).fst .wS < (liListener .ss li_marg_ss).fst .wNS :=
-  li_fst_lt _ (by norm_num +decide [boolS1, boolWeight, liMeaning, LIParse.toParse,
+    (liListener .ss li_marg_ss).fst wS < (liListener .ss li_marg_ss).fst wNS :=
+  li_fst_lt _ (by norm_num +decide [ratS1, ratWeight, liMeaning, LIParse.toParse,
     RSA.extensionOf, Finset.filter_insert, Finset.filter_singleton, univLI, univW,
     zLI_wNS, zLI_wS])
 
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
 theorem li_ss_prefers_wNS :
-    (liListener .ss li_marg_ss).fst .wNA < (liListener .ss li_marg_ss).fst .wNS :=
-  li_fst_lt _ (by norm_num +decide [boolS1, boolWeight, liMeaning, LIParse.toParse,
+    (liListener .ss li_marg_ss).fst wNA < (liListener .ss li_marg_ss).fst wNS :=
+  li_fst_lt _ (by norm_num +decide [ratS1, ratWeight, liMeaning, LIParse.toParse,
     RSA.extensionOf, Finset.filter_insert, Finset.filter_singleton, univLI, univW,
     zLI_wNS, zLI_wNA])
 

--- a/Linglib/Studies/GoodmanStuhlmuller2013.lean
+++ b/Linglib/Studies/GoodmanStuhlmuller2013.lean
@@ -60,20 +60,30 @@ inductive QUtt where
   | none_ | some_ | all
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-def qMeaning : QUtt → WorldState → Bool
-  | .none_, s => s.toNat == 0
-  | .some_, s => s.toNat ≥ 1
-  | .all,   s => s.toNat == 3
+def qMeaning : QUtt → WorldState → Prop
+  | .none_, s => s.toNat = 0
+  | .some_, s => 1 ≤ s.toNat
+  | .all,   s => s.toNat = 3
+
+instance : ∀ q : QUtt, DecidablePred (qMeaning q)
+  | .none_, s => inferInstanceAs (Decidable (s.toNat = 0))
+  | .some_, s => inferInstanceAs (Decidable (1 ≤ s.toNat))
+  | .all,   s => inferInstanceAs (Decidable (s.toNat = 3))
 
 /-- Numeral alternative set (lower-bound semantics). -/
 inductive NumUtt where
   | one | two | three
   deriving DecidableEq, Repr, Inhabited, Fintype
 
-def lbMeaning : NumUtt → WorldState → Bool
-  | .one,   s => s.toNat ≥ 1
-  | .two,   s => s.toNat ≥ 2
-  | .three, s => s.toNat ≥ 3
+def lbMeaning : NumUtt → WorldState → Prop
+  | .one,   s => 1 ≤ s.toNat
+  | .two,   s => 2 ≤ s.toNat
+  | .three, s => 3 ≤ s.toNat
+
+instance : ∀ n : NumUtt, DecidablePred (lbMeaning n)
+  | .one,   s => inferInstanceAs (Decidable (1 ≤ s.toNat))
+  | .two,   s => inferInstanceAs (Decidable (2 ≤ s.toNat))
+  | .three, s => inferInstanceAs (Decidable (3 ≤ s.toNat))
 
 /-- **Speaker access** = number of objects (out of 3) the speaker observes:
 a `Fin 4` indexed at 0..3, so `a.val` is the access value and
@@ -151,12 +161,11 @@ theorem obsKernel_eq_ofReal (a : Access) (w : WorldState) (k : Fin (a.val + 1)) 
 
 /-- A world `s` is compatible with observing `k.val` successes out of `a.val`
 draws iff the hypergeometric numerator at `(K=s.toNat, k=k.val)` is non-zero. -/
-def obsCompatible (a : Access) (k : Fin (a.val + 1)) (s : WorldState) : Bool :=
-  k.val ≤ s.toNat && a.val - k.val ≤ 3 - s.toNat
+def obsCompatible (a : Access) (k : Fin (a.val + 1)) (s : WorldState) : Prop :=
+  k.val ≤ s.toNat ∧ a.val - k.val ≤ 3 - s.toNat
 
-theorem obsCompatible_iff {a : Access} {k : Fin (a.val + 1)} {s : WorldState} :
-    obsCompatible a k s = true ↔ k.val ≤ s.toNat ∧ a.val - k.val ≤ 3 - s.toNat := by
-  simp [obsCompatible]
+instance (a : Access) (k : Fin (a.val + 1)) : DecidablePred (obsCompatible a k) := fun s =>
+  inferInstanceAs (Decidable (k.val ≤ s.toNat ∧ a.val - k.val ≤ 3 - s.toNat))
 
 /-- A witness world at which `obsKernel a · k` is positive: the world whose
 count matches `k.val` (clamped to ≤ 3). -/
@@ -175,10 +184,10 @@ private theorem witnessWorld_toNat : ∀ {n : ℕ}, n ≤ 3 → (witnessWorld n)
   | n + 4, h => absurd h (by omega)
 
 private theorem witnessWorld_obsCompatible (a : Access) (k : Fin (a.val + 1)) :
-    obsCompatible a k (witnessWorld k.val) = true := by
+    obsCompatible a k (witnessWorld k.val) := by
   have hk : k.val ≤ a.val := Nat.lt_succ_iff.mp k.isLt
   have ha := a.val_le_three
-  rw [obsCompatible_iff, witnessWorld_toNat (hk.trans ha)]
+  rw [obsCompatible, witnessWorld_toNat (hk.trans ha)]
   omega
 
 /-! ### Speaker belief — `PMF.posterior` of `obsKernel` -/
@@ -186,8 +195,7 @@ private theorem witnessWorld_obsCompatible (a : Access) (k : Fin (a.val + 1)) :
 private theorem obsMarginal_ne_zero (a : Access) (k : Fin (a.val + 1)) :
     PMF.marginal (obsKernel a) worldPrior k ≠ 0 :=
   PMF.marginal_ne_zero _ worldPrior k (worldPrior_ne_zero (witnessWorld k.val))
-    ((obsKernel_apply_ne_zero_iff a _ k).mpr
-      (obsCompatible_iff.mp (witnessWorld_obsCompatible a k)))
+    ((obsKernel_apply_ne_zero_iff a _ k).mpr (witnessWorld_obsCompatible a k))
 
 /-- Speaker's posterior over worlds given a count observation. -/
 noncomputable def speakerBelief (a : Access) (k : Fin (a.val + 1)) : PMF WorldState :=
@@ -197,19 +205,17 @@ noncomputable def speakerBelief (a : Access) (k : Fin (a.val + 1)) : PMF WorldSt
 
 /-- An utterance `u` is quality-OK at observation `(a, k)` iff `u` is true at
 every world compatible with `(a, k)`. -/
-def qualityOk (m : U → WorldState → Bool)
-    (a : Access) (k : Fin (a.val + 1)) (u : U) : Bool :=
-  [WorldState.s0, .s1, .s2, .s3].all fun s => !obsCompatible a k s || m u s
+def qualityOk (m : U → WorldState → Prop)
+    (a : Access) (k : Fin (a.val + 1)) (u : U) : Prop :=
+  ∀ s, obsCompatible a k s → m u s
 
-private theorem meaning_true_of_qualityOk {m : U → WorldState → Bool}
-    {a : Access} {k : Fin (a.val + 1)} {u : U} (hq : qualityOk m a k u = true)
-    {s : WorldState} (hs : obsCompatible a k s = true) : m u s = true := by
-  have h := List.all_eq_true.mp hq s (by cases s <;> simp)
-  simpa [hs] using h
+instance (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)]
+    (a : Access) (k : Fin (a.val + 1)) : DecidablePred (qualityOk m a k) := fun u =>
+  inferInstanceAs (Decidable (∀ s, obsCompatible a k s → m u s))
 
 /-- Uniform-on-extension literal probability. -/
 noncomputable def lexReal [Fintype U]
-    (m : U → WorldState → Bool) (u : U) (s : WorldState) : ℝ :=
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (u : U) (s : WorldState) : ℝ :=
   if m u s then ((RSA.extensionOf m u).card : ℝ)⁻¹ else 0
 
 /-- `toReal` projection of `speakerBelief`. -/
@@ -219,14 +225,13 @@ noncomputable def beliefReal (a : Access) (k : Fin (a.val + 1)) (s : WorldState)
 /-- Speaker score: `softmaxBelief` over the literal probabilities, filtered
 by `qualityOk`. -/
 noncomputable abbrev s1Score [Fintype U]
-    (m : U → WorldState → Bool) (α : ℝ)
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (α : ℝ)
     (a : Access) (k : Fin (a.val + 1)) (u : U) : ℝ≥0∞ :=
-  RSA.softmaxBelief (lexReal m) (beliefReal a k) α
-    (fun u' => qualityOk m a k u' = true) u
+  RSA.softmaxBelief (lexReal m) (beliefReal a k) α (qualityOk m a k) u
 
 /-- Speaker conditional on observation. -/
 noncomputable def S1g [Fintype U]
-    (m : U → WorldState → Bool) (α : ℝ)
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (α : ℝ)
     (a : Access) (k : Fin (a.val + 1))
     (h0 : ∑' u, s1Score m α a k u ≠ 0) : PMF U :=
   PMF.normalize (s1Score m α a k ·) h0
@@ -240,7 +245,8 @@ defined at every `k`, not just kernel-supported ones. The cover hypothesis
 `WithSilence`, this is automatic via `cover_silent`. -/
 
 noncomputable def marginalSpeaker [Fintype U]
-    (m : U → WorldState → Bool) (α : ℝ) (a : Access) (w : WorldState)
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)]
+    (α : ℝ) (a : Access) (w : WorldState)
     (hCov : ∀ k : Fin (a.val + 1), ∃ u : U, qualityOk m a k u) :
     PMF U :=
   (obsKernel a w).bind fun k =>
@@ -249,17 +255,17 @@ noncomputable def marginalSpeaker [Fintype U]
 
 /-- Pragmatic listener: Bayesian inversion of the marginal speaker. -/
 noncomputable def L1 [Fintype U]
-    (m : U → WorldState → Bool) (α : ℝ) (a : Access)
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (α : ℝ) (a : Access)
     (hCov : ∀ k : Fin (a.val + 1), ∃ u : U, qualityOk m a k u) (u : U)
     (hMarg : PMF.marginal (fun w => marginalSpeaker m α a w hCov) worldPrior u ≠ 0) :
     PMF WorldState :=
   PMF.posterior (fun w => marginalSpeaker m α a w hCov) worldPrior u hMarg
 
-/-- Silence is universally `qOk`: `liftMeaning m none = true` at every world,
+/-- Silence is universally `qOk` — `liftMeaning m none` holds at every world,
 so the cover hypothesis is universally satisfiable. -/
-theorem cover_silent (m : U → WorldState → Bool) (a : Access) :
+theorem cover_silent (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (a : Access) :
     ∀ k : Fin (a.val + 1), ∃ u : WithSilence U, qualityOk (liftMeaning m) a k u :=
-  fun _ => ⟨none, by simp [qualityOk]⟩
+  fun _ => ⟨none, fun _ _ => trivial⟩
 
 /-! ### Observation-kernel value table
 
@@ -345,7 +351,7 @@ to one `S1g` evaluation; at partial access it expands to the 2- or 3-term
 kernel-weighted sum. -/
 
 private theorem marginalSpeaker_a3_apply
-    [Fintype U] (m : U → WorldState → Bool) (w : WorldState)
+    [Fintype U] (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (w : WorldState)
     (hCov : ∀ k : Fin (Access.a3.val + 1), ∃ u : U, qualityOk m .a3 k u) (u : U) :
     marginalSpeaker m 1 .a3 w hCov u =
       S1g m 1 .a3 ⟨w.toNat, by cases w <;> decide⟩
@@ -360,7 +366,7 @@ private theorem marginalSpeaker_a3_apply
     rw [h, zero_mul]
 
 private theorem marginalSpeaker_a1_apply
-    [Fintype U] (m : U → WorldState → Bool) (w : WorldState)
+    [Fintype U] (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (w : WorldState)
     (hCov : ∀ k : Fin (Access.a1.val + 1), ∃ u : U, qualityOk m .a1 k u) (u : U) :
     marginalSpeaker m 1 .a1 w hCov u =
       obsKernel .a1 w ⟨0, by decide⟩ *
@@ -376,7 +382,7 @@ private theorem marginalSpeaker_a1_apply
   rfl
 
 private theorem marginalSpeaker_a2_apply
-    [Fintype U] (m : U → WorldState → Bool) (w : WorldState)
+    [Fintype U] (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)] (w : WorldState)
     (hCov : ∀ k : Fin (Access.a2.val + 1), ∃ u : U, qualityOk m .a2 k u) (u : U) :
     marginalSpeaker m 1 .a2 w hCov u =
       obsKernel .a2 w ⟨0, by decide⟩ *
@@ -420,13 +426,13 @@ private theorem extensionOf_lbLifted_silent_card :
 /-! ### Generic `s1Score` evaluation
 
 When `qOk u` passes, `liftMeaning`-lifted utterances have a uniform lex
-value on the belief support (because: `qOk` ⇒ `m u s = true` at all
+value on the belief support (because: `qOk` ⇒ `m u s` holds at all
 compatible `s` ⊇ belief support ⇒ `lex u s = 1/(card extension)`).
 `softmaxBelief_uniform_on_support` then collapses
 `s1Score = ENNReal.ofReal (1/c)`. -/
 
 private theorem belief_support_compat (a : Access) (k : Fin (a.val + 1)) (s : WorldState)
-    (h : beliefReal a k s ≠ 0) : obsCompatible a k s = true := by
+    (h : beliefReal a k s ≠ 0) : obsCompatible a k s := by
   unfold beliefReal at h
   have hb : speakerBelief a k s ≠ 0 := by
     intro h'; exact h (h' ▸ ENNReal.toReal_zero)
@@ -434,7 +440,7 @@ private theorem belief_support_compat (a : Access) (k : Fin (a.val + 1)) (s : Wo
   rw [PMF.posterior_apply] at hb
   have h_kernel : obsKernel a s k ≠ 0 := by
     intro h_zero; apply hb; rw [h_zero, mul_zero, zero_mul]
-  exact obsCompatible_iff.mpr ((obsKernel_apply_ne_zero_iff a s k).mp h_kernel)
+  exact (obsKernel_apply_ne_zero_iff a s k).mp h_kernel
 
 private theorem belief_sum_eq_one (a : Access) (k : Fin (a.val + 1)) :
     (∑ s : WorldState, beliefReal a k s) = 1 := by
@@ -449,19 +455,17 @@ private theorem belief_sum_eq_one (a : Access) (k : Fin (a.val + 1)) :
 where `c = (extensionOf m u).card`. -/
 private theorem s1Score_uniform_apply
     [Fintype U] [DecidableEq U]
-    (m : U → WorldState → Bool) (a : Access) (k : Fin (a.val + 1))
+    (m : U → WorldState → Prop) [∀ u, DecidablePred (m u)]
+    (a : Access) (k : Fin (a.val + 1))
     (u : WithSilence U) (c : ℕ) (hc : c ≠ 0)
-    (h_qok : qualityOk (liftMeaning m) a k u = true)
+    (h_qok : qualityOk (liftMeaning m) a k u)
     (h_card : (RSA.extensionOf (liftMeaning m) u).card = c) :
     s1Score (liftMeaning m) 1 a k u = ENNReal.ofReal (1/c : ℝ) := by
-  show RSA.softmaxBelief (lexReal (liftMeaning m)) (beliefReal a k) 1
-        (fun u' => qualityOk (liftMeaning m) a k u' = true) u = _
   refine RSA.softmaxBelief_uniform_on_support _ _ _ _ (1/c : ℝ) h_qok ?_ ?_
     (belief_sum_eq_one a k)
   · intro s hbelief
-    have hmu := meaning_true_of_qualityOk h_qok (belief_support_compat a k s hbelief)
     unfold lexReal
-    rw [if_pos hmu, h_card]
+    rw [if_pos (h_qok s (belief_support_compat a k s hbelief)), h_card]
     field_simp
   · positivity
 

--- a/Linglib/Studies/GrusdtLassiterFranke2022.lean
+++ b/Linglib/Studies/GrusdtLassiterFranke2022.lean
@@ -158,15 +158,18 @@ Truth values from Table 2:
 - **if A then C** (P(C|A) ≥ 0.9): s1 ✓, s2 ✓, s3 ✗
 - **C** (P(C) ≥ 0.9): s1 ✓, s2 ✗, s3 ✗
 - **A and C** (P(A∧C) ≥ 0.9): s1 ✗, s2 ✗, s3 ✗ -/
-def assertable' : Utt → State → Bool
-  | .likelyC,      _   => true
-  | .conditional,  .s1 => true
-  | .conditional,  .s2 => true
-  | .conditional,  .s3 => false
-  | .C,            .s1 => true
-  | .C,            .s2 => false
-  | .C,            .s3 => false
-  | .conjAC,       _   => false
+def assertable' : Utt → State → Prop
+  | .likelyC,      _   => True
+  | .conditional,  .s1 => True
+  | .conditional,  .s2 => True
+  | .conditional,  .s3 => False
+  | .C,            .s1 => True
+  | .C,            .s2 => False
+  | .C,            .s3 => False
+  | .conjAC,       _   => False
+
+instance (u : Utt) : DecidablePred (assertable' u) := fun s => by
+  cases u <;> cases s <;> first | exact isTrue trivial | exact isFalse id
 
 
 -- ============================================================================
@@ -228,28 +231,28 @@ abbrev ext (u : Utt) : Finset State := RSA.extensionOf assertable' u
 
 /-- Literal-listener weight `L0(s | u)` at α = 1: uniform on the extension,
 `1/|ext u|` where `u` is assertable at `s`, else `0`. For the three assertable
-utterances this coincides with `RSA.L0OfBoolMeaning`
-(`litWeight_eq_L0OfBoolMeaning`); the never-assertable `conjAC` is weightless. -/
+utterances this coincides with `RSA.L0OfPred` (`litWeight_eq_L0OfPred`); the
+never-assertable `conjAC` is weightless. -/
 noncomputable def litWeight (s : State) (u : Utt) : ℝ≥0∞ :=
-  if assertable' u s = true then ((ext u).card : ℝ≥0∞)⁻¹ else 0
+  if assertable' u s then ((ext u).card : ℝ≥0∞)⁻¹ else 0
 
 theorem litWeight_of_true {s : State} {u : Utt} {k : ℕ}
-    (h : assertable' u s = true) (hk : (ext u).card = k) :
+    (h : assertable' u s) (hk : (ext u).card = k) :
     litWeight s u = ((k : ℝ≥0∞))⁻¹ := by
   unfold litWeight; rw [if_pos h, hk]
 
-theorem litWeight_of_false {s : State} {u : Utt} (h : assertable' u s = false) :
+theorem litWeight_of_false {s : State} {u : Utt} (h : ¬ assertable' u s) :
     litWeight s u = 0 := by
-  unfold litWeight; rw [if_neg (by simp [h])]
+  unfold litWeight; rw [if_neg h]
 
 /-- Where an utterance is assertable somewhere, `litWeight` is exactly the
 canonical literal listener uniform on the extension; `conjAC` gets `0`. -/
-theorem litWeight_eq_L0OfBoolMeaning (s : State) {u : Utt} (h : (ext u).Nonempty) :
-    litWeight s u = RSA.L0OfBoolMeaning assertable' u h s := by
+theorem litWeight_eq_L0OfPred (s : State) {u : Utt} (h : (ext u).Nonempty) :
+    litWeight s u = RSA.L0OfPred assertable' u h s := by
   unfold litWeight
-  by_cases hu : assertable' u s = true
-  · rw [if_pos hu, RSA.L0OfBoolMeaning_apply_of_mem h hu]
-  · rw [if_neg hu, RSA.L0OfBoolMeaning_apply_of_not_mem h hu]
+  by_cases hu : assertable' u s
+  · rw [if_pos hu, RSA.L0OfPred_apply_of_mem h hu]
+  · rw [if_neg hu, RSA.L0OfPred_apply_of_not_mem h hu]
 
 theorem litWeight_ne_top (s : State) (u : Utt) : litWeight s u ≠ ⊤ := by
   unfold litWeight
@@ -263,24 +266,28 @@ theorem litWeight_ne_top (s : State) (u : Utt) : litWeight s u ≠ ⊤ := by
 `conditional` in {s1, s2}, `C` in {s1}, `conjAC` in none. -/
 
 theorem lw_likelyC (s : State) : litWeight s .likelyC = 3⁻¹ := by
-  rw [litWeight_of_true rfl (show (ext .likelyC).card = 3 from by decide)]; norm_num
+  rw [litWeight_of_true (show assertable' .likelyC s from trivial)
+    (show (ext .likelyC).card = 3 from by decide)]; norm_num
 
 theorem lw_s1_conditional : litWeight .s1 .conditional = 2⁻¹ := by
-  rw [litWeight_of_true rfl (show (ext .conditional).card = 2 from by decide)]; norm_num
+  rw [litWeight_of_true (show assertable' .conditional .s1 from trivial)
+    (show (ext .conditional).card = 2 from by decide)]; norm_num
 
 theorem lw_s2_conditional : litWeight .s2 .conditional = 2⁻¹ := by
-  rw [litWeight_of_true rfl (show (ext .conditional).card = 2 from by decide)]; norm_num
+  rw [litWeight_of_true (show assertable' .conditional .s2 from trivial)
+    (show (ext .conditional).card = 2 from by decide)]; norm_num
 
-theorem lw_s3_conditional : litWeight .s3 .conditional = 0 := litWeight_of_false rfl
+theorem lw_s3_conditional : litWeight .s3 .conditional = 0 := litWeight_of_false id
 
 theorem lw_s1_C : litWeight .s1 .C = 1 := by
-  rw [litWeight_of_true rfl (show (ext .C).card = 1 from by decide)]; norm_num
+  rw [litWeight_of_true (show assertable' .C .s1 from trivial)
+    (show (ext .C).card = 1 from by decide)]; norm_num
 
-theorem lw_s2_C : litWeight .s2 .C = 0 := litWeight_of_false rfl
+theorem lw_s2_C : litWeight .s2 .C = 0 := litWeight_of_false id
 
-theorem lw_s3_C : litWeight .s3 .C = 0 := litWeight_of_false rfl
+theorem lw_s3_C : litWeight .s3 .C = 0 := litWeight_of_false id
 
-theorem lw_conjAC (s : State) : litWeight s .conjAC = 0 := litWeight_of_false rfl
+theorem lw_conjAC (s : State) : litWeight s .conjAC = 0 := litWeight_of_false id
 
 private theorem tsum_litWeight_ne_zero (s : State) : (∑' u, litWeight s u) ≠ 0 :=
   ENNReal.summable.tsum_ne_zero_iff.mpr
@@ -541,31 +548,31 @@ theorem l1_likelyC_prefers_s3 :
     condition: assertable iff P(C|A) ≥ θ. Since we use the direct truth
     table, we verify consistency with the WorldState probabilities. -/
 theorem conditional_assertable_iff_high_pCGivenA :
-    (assertable' .conditional .s1 = true ∧ ws1.pCGivenA ≥ θ) ∧
-    (assertable' .conditional .s2 = true ∧ ws2.pCGivenA ≥ θ) ∧
-    (assertable' .conditional .s3 = false ∧ ws3.pCGivenA < θ) := by
-  refine ⟨⟨rfl, ?_⟩, ⟨rfl, ?_⟩, ⟨rfl, ?_⟩⟩ <;> native_decide
+    (assertable' .conditional .s1 ∧ ws1.pCGivenA ≥ θ) ∧
+    (assertable' .conditional .s2 ∧ ws2.pCGivenA ≥ θ) ∧
+    (¬ assertable' .conditional .s3 ∧ ws3.pCGivenA < θ) := by
+  refine ⟨⟨trivial, ?_⟩, ⟨trivial, ?_⟩, ⟨id, ?_⟩⟩ <;> native_decide
 
 /-- "C" is assertable iff P(C) ≥ 0.9. -/
 theorem C_assertable_iff_high_pC :
-    (assertable' .C .s1 = true ∧ ws1.pC ≥ 9/10) ∧
-    (assertable' .C .s2 = false ∧ ws2.pC < 9/10) ∧
-    (assertable' .C .s3 = false ∧ ws3.pC < 9/10) := by
-  refine ⟨⟨rfl, ?_⟩, ⟨rfl, ?_⟩, ⟨rfl, ?_⟩⟩ <;> native_decide
+    (assertable' .C .s1 ∧ ws1.pC ≥ 9/10) ∧
+    (¬ assertable' .C .s2 ∧ ws2.pC < 9/10) ∧
+    (¬ assertable' .C .s3 ∧ ws3.pC < 9/10) := by
+  refine ⟨⟨trivial, ?_⟩, ⟨id, ?_⟩, ⟨id, ?_⟩⟩ <;> native_decide
 
 /-- "likely C" is assertable in all states (P(C) ≥ 0.5 everywhere). -/
 theorem likelyC_always_assertable :
-    (assertable' .likelyC .s1 = true ∧ ws1.pC ≥ 1/2) ∧
-    (assertable' .likelyC .s2 = true ∧ ws2.pC ≥ 1/2) ∧
-    (assertable' .likelyC .s3 = true ∧ ws3.pC ≥ 1/2) := by
-  refine ⟨⟨rfl, ?_⟩, ⟨rfl, ?_⟩, ⟨rfl, ?_⟩⟩ <;> native_decide
+    (assertable' .likelyC .s1 ∧ ws1.pC ≥ 1/2) ∧
+    (assertable' .likelyC .s2 ∧ ws2.pC ≥ 1/2) ∧
+    (assertable' .likelyC .s3 ∧ ws3.pC ≥ 1/2) := by
+  refine ⟨⟨trivial, ?_⟩, ⟨trivial, ?_⟩, ⟨trivial, ?_⟩⟩ <;> native_decide
 
 /-- "A and C" is never assertable (P(A∧C) < 0.9 in all states). -/
 theorem conjAC_never_assertable :
-    assertable' .conjAC .s1 = false ∧
-    assertable' .conjAC .s2 = false ∧
-    assertable' .conjAC .s3 = false := by
-  exact ⟨rfl, rfl, rfl⟩
+    ¬ assertable' .conjAC .s1 ∧
+    ¬ assertable' .conjAC .s2 ∧
+    ¬ assertable' .conjAC .s3 :=
+  ⟨id, id, id⟩
 
 
 -- ============================================================================

--- a/Linglib/Studies/HawkinsGweonGoodman2021.lean
+++ b/Linglib/Studies/HawkinsGweonGoodman2021.lean
@@ -13,7 +13,7 @@ so each agent allocates effort via a mixture weight `w ∈ [0,1]`, and the optim
 effort depends on the partner's expected effort.
 
 Two PMF reference games formalize the task, built on the canonical operators
-(`RSA.L0OfBoolMeaning`, `RSA.S1Belief`, `PMF.posterior`):
+(`RSA.L0OfPred`, `RSA.S1Belief`, `PMF.posterior`):
 * egocentric (`egoL0`/`egoS1`/`egoL1`) — three visible objects, shape alone
   identifies the target.
 * asymmetric (`asymL0`/`asymS1`/`asymL1`) — a hidden object behind an occlusion,
@@ -96,34 +96,49 @@ def Utt.cost : Utt → ℕ
 
 /-- Does utterance apply to an entity with given feature-match profile?
     For each feature the utterance mentions, the entity must match the target. -/
-def Utt.applies (u : Utt) (shapeOk colorOk textureOk : Bool) : Bool :=
-  let s := match u with | .s | .sc | .st | .sct => shapeOk | _ => true
-  let c := match u with | .c | .sc | .ct | .sct => colorOk | _ => true
-  let t := match u with | .t | .st | .ct | .sct => textureOk | _ => true
-  s && c && t
+def Utt.applies (u : Utt) (shapeOk colorOk textureOk : Prop) : Prop :=
+  let s := match u with | .s | .sc | .st | .sct => shapeOk | _ => True
+  let c := match u with | .c | .sc | .ct | .sct => colorOk | _ => True
+  let t := match u with | .t | .st | .ct | .sct => textureOk | _ => True
+  s ∧ c ∧ t
+
+instance (u : Utt) (p q r : Prop) [Decidable p] [Decidable q] [Decidable r] :
+    Decidable (u.applies p q r) := by
+  cases u <;> exact inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
 /-- Egocentric literal meaning: does utterance apply to visible object?
     Target matches on all features. d1 differs only on shape. d2 differs on all. -/
-def egoMeaning (u : Utt) (w : VisObj) : Bool :=
+def egoMeaning (u : Utt) (w : VisObj) : Prop :=
   match w with
-  | .target => true
-  | .d1 => u.applies false true true
-  | .d2 => u.applies false false false
+  | .target => True
+  | .d1 => u.applies False True True
+  | .d2 => u.applies False False False
+
+instance : ∀ u, DecidablePred (egoMeaning u)
+  | _, .target => .isTrue trivial
+  | u, .d1 => inferInstanceAs (Decidable (u.applies False True True))
+  | u, .d2 => inferInstanceAs (Decidable (u.applies False False False))
 
 /-- Asymmetric literal meaning: includes hidden object behind occlusion.
     The hidden object's match profile is the latent variable `l = (matchShape, matchColor, matchTexture)`.
     Each feature independently matches target with P = 1/4. -/
-def asymMeaning (l : Bool × Bool × Bool) (u : Utt) (w : AsymObj) : Bool :=
+def asymMeaning (l : Bool × Bool × Bool) (u : Utt) (w : AsymObj) : Prop :=
   match w with
-  | .target => true
-  | .d1 => u.applies false true true
-  | .d2 => u.applies false false false
+  | .target => True
+  | .d1 => u.applies False True True
+  | .d2 => u.applies False False False
   | .hidden => u.applies l.1 l.2.1 l.2.2
+
+instance (l : Bool × Bool × Bool) : ∀ u, DecidablePred (asymMeaning l u)
+  | _, .target => .isTrue trivial
+  | u, .d1 => inferInstanceAs (Decidable (u.applies False True True))
+  | u, .d2 => inferInstanceAs (Decidable (u.applies False False False))
+  | u, .hidden => inferInstanceAs (Decidable (u.applies l.1 l.2.1 l.2.2))
 
 /-! ### Model
 
 Both configurations use the canonical PMF reference-game operators
-(`RSA.L0OfBoolMeaning`, `RSA.S1Belief`, `PMF.posterior`), as in
+(`RSA.L0OfPred`, `RSA.S1Belief`, `PMF.posterior`), as in
 `Studies/TesslerFranke2020PMF`: `L0` is
 uniform on an utterance's extension, `S1` is the belief-based speaker with
 `α = 2` and no cost, and `L1` is the Bayesian posterior under a uniform world
@@ -137,26 +152,26 @@ open scoped ENNReal
 /-- Every utterance applies to the target (it matches on all features), so each
 extension is non-empty. -/
 theorem egoExtension_nonempty (u : Utt) : (RSA.extensionOf egoMeaning u).Nonempty :=
-  ⟨.target, RSA.mem_extensionOf.mpr rfl⟩
+  ⟨.target, RSA.mem_extensionOf.mpr trivial⟩
 
 /-- Literal listener: uniform on the extension of `egoMeaning u`. -/
 noncomputable def egoL0 (u : Utt) : PMF VisObj :=
-  RSA.L0OfBoolMeaning egoMeaning u (egoExtension_nonempty u)
+  RSA.L0OfPred egoMeaning u (egoExtension_nonempty u)
 
-theorem egoL0_apply_of_false {u : Utt} {w : VisObj} (h : egoMeaning u w ≠ true) :
+theorem egoL0_apply_of_false {u : Utt} {w : VisObj} (h : ¬ egoMeaning u w) :
     egoL0 u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+  RSA.L0OfPred_apply_of_not_mem _ h
 
-theorem egoL0_apply_of_true {u : Utt} {w : VisObj} (h : egoMeaning u w = true) :
+theorem egoL0_apply_of_true {u : Utt} {w : VisObj} (h : egoMeaning u w) :
     egoL0 u w = ((RSA.extensionOf egoMeaning u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+  RSA.L0OfPred_apply_of_mem _ h
 
-theorem egoL0_ne_zero_of_applies {u : Utt} {w : VisObj} (h : egoMeaning u w = true) :
+theorem egoL0_ne_zero_of_applies {u : Utt} {w : VisObj} (h : egoMeaning u w) :
     egoL0 u w ≠ 0 := by
-  rw [← PMF.mem_support_iff, egoL0, RSA.mem_support_L0OfBoolMeaning_iff]; exact h
+  rw [← PMF.mem_support_iff, egoL0, RSA.mem_support_L0OfPred_iff]; exact h
 
 theorem egoL0_null_ne_zero (w : VisObj) : egoL0 .null w ≠ 0 :=
-  egoL0_ne_zero_of_applies (by cases w <;> rfl)
+  egoL0_ne_zero_of_applies (by cases w <;> decide)
 
 private theorem egoScore_tsum_ne_zero (w : VisObj) :
     ∑' u, (egoL0 u w : ℝ≥0∞) ^ (2 : ℝ) * (1 : ℝ≥0∞) ≠ 0 := by
@@ -173,12 +188,12 @@ private theorem egoScore_tsum_ne_top (w : VisObj) :
 noncomputable def egoS1 (w : VisObj) : PMF Utt :=
   RSA.S1Belief egoL0 (fun _ => 1) 2 w (egoScore_tsum_ne_zero w) (egoScore_tsum_ne_top w)
 
-theorem egoS1_eq_zero_of_not_applies {u : Utt} {w : VisObj} (h : egoMeaning u w ≠ true) :
+theorem egoS1_eq_zero_of_not_applies {u : Utt} {w : VisObj} (h : ¬ egoMeaning u w) :
     egoS1 w u = 0 := by
   rw [egoS1, RSA.S1Belief_apply, egoL0_apply_of_false h, ENNReal.zero_rpow_of_pos (by norm_num)]
   simp
 
-theorem egoS1_ne_zero_of_applies {u : Utt} {w : VisObj} (h : egoMeaning u w = true) :
+theorem egoS1_ne_zero_of_applies {u : Utt} {w : VisObj} (h : egoMeaning u w) :
     egoS1 w u ≠ 0 :=
   RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ (egoL0_ne_zero_of_applies h) one_ne_zero
 
@@ -188,7 +203,7 @@ noncomputable def egoWorldPrior : PMF VisObj := PMF.uniformOfFintype VisObj
 theorem egoMarginal_ne_zero (u : Utt) : PMF.marginal egoS1 egoWorldPrior u ≠ 0 :=
   PMF.marginal_ne_zero _ _ _
     ((egoWorldPrior.mem_support_iff .target).mp (PMF.mem_support_uniformOfFintype _))
-    (egoS1_ne_zero_of_applies rfl)
+    (egoS1_ne_zero_of_applies trivial)
 
 /-- Pragmatic listener: Bayesian posterior of `egoS1` under the uniform prior. -/
 noncomputable def egoL1 (u : Utt) : PMF VisObj :=
@@ -197,7 +212,7 @@ noncomputable def egoL1 (u : Utt) : PMF VisObj :=
 /-- An utterance applying only to the target makes the listener certain: the
 posterior puts full mass on the target. -/
 theorem egoL1_eq_one_of_unique {u : Utt}
-    (h : ∀ w, w ≠ .target → egoMeaning u w ≠ true) : egoL1 u .target = 1 := by
+    (h : ∀ w, w ≠ .target → ¬ egoMeaning u w) : egoL1 u .target = 1 := by
   rw [egoL1]
   exact PMF.posterior_eq_one_of_singleton_score_support _ _ _ _ _
     (fun w' hne => Or.inr (egoS1_eq_zero_of_not_applies (h w' hne)))
@@ -214,27 +229,27 @@ abbrev Profile := Bool × Bool × Bool
 
 theorem asymExtension_nonempty (l : Profile) (u : Utt) :
     (RSA.extensionOf (asymMeaning l) u).Nonempty :=
-  ⟨.target, RSA.mem_extensionOf.mpr rfl⟩
+  ⟨.target, RSA.mem_extensionOf.mpr trivial⟩
 
 /-- Literal listener under hidden profile `l`. -/
 noncomputable def asymL0 (l : Profile) (u : Utt) : PMF AsymObj :=
-  RSA.L0OfBoolMeaning (asymMeaning l) u (asymExtension_nonempty l u)
+  RSA.L0OfPred (asymMeaning l) u (asymExtension_nonempty l u)
 
 theorem asymL0_apply_of_false {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w ≠ true) : asymL0 l u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+    (h : ¬ asymMeaning l u w) : asymL0 l u w = 0 :=
+  RSA.L0OfPred_apply_of_not_mem _ h
 
 theorem asymL0_apply_of_true {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w = true) :
+    (h : asymMeaning l u w) :
     asymL0 l u w = ((RSA.extensionOf (asymMeaning l) u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+  RSA.L0OfPred_apply_of_mem _ h
 
 theorem asymL0_ne_zero_of_applies {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w = true) : asymL0 l u w ≠ 0 := by
-  rw [← PMF.mem_support_iff, asymL0, RSA.mem_support_L0OfBoolMeaning_iff]; exact h
+    (h : asymMeaning l u w) : asymL0 l u w ≠ 0 := by
+  rw [← PMF.mem_support_iff, asymL0, RSA.mem_support_L0OfPred_iff]; exact h
 
 theorem asymL0_null_ne_zero (l : Profile) (w : AsymObj) : asymL0 l .null w ≠ 0 :=
-  asymL0_ne_zero_of_applies (by cases w <;> rfl)
+  asymL0_ne_zero_of_applies (by cases w <;> trivial)
 
 private theorem asymScore_tsum_ne_zero (l : Profile) (w : AsymObj) :
     ∑' u, (asymL0 l u w : ℝ≥0∞) ^ (2 : ℝ) * (1 : ℝ≥0∞) ≠ 0 := by
@@ -252,12 +267,12 @@ noncomputable def asymS1 (l : Profile) (w : AsymObj) : PMF Utt :=
   RSA.S1Belief (asymL0 l) (fun _ => 1) 2 w (asymScore_tsum_ne_zero l w) (asymScore_tsum_ne_top l w)
 
 theorem asymS1_eq_zero_of_not_applies {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w ≠ true) : asymS1 l w u = 0 := by
+    (h : ¬ asymMeaning l u w) : asymS1 l w u = 0 := by
   rw [asymS1, RSA.S1Belief_apply, asymL0_apply_of_false h, ENNReal.zero_rpow_of_pos (by norm_num)]
   simp
 
 theorem asymS1_ne_zero_of_applies {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w = true) : asymS1 l w u ≠ 0 :=
+    (h : asymMeaning l u w) : asymS1 l w u ≠ 0 :=
   RSA.S1Belief_apply_ne_zero_of_pos _ _ _ _ _ _ (asymL0_ne_zero_of_applies h) one_ne_zero
 
 /-- Latent prior weight: `1` per matching feature, `3` per non-match. -/
@@ -292,12 +307,12 @@ noncomputable def asymMarginalSpeaker (w : AsymObj) : PMF Utt :=
   RSA.marginalizeKernel latentPrior asymS1 w
 
 theorem asymMarginalSpeaker_eq_zero_of_not_applies {u : Utt} {w : AsymObj}
-    (h : ∀ l, asymMeaning l u w ≠ true) : asymMarginalSpeaker w u = 0 := by
+    (h : ∀ l, ¬ asymMeaning l u w) : asymMarginalSpeaker w u = 0 := by
   rw [asymMarginalSpeaker, RSA.marginalizeKernel_apply, ENNReal.tsum_eq_zero]
   exact fun l => by rw [asymS1_eq_zero_of_not_applies (h l), mul_zero]
 
 theorem asymMarginalSpeaker_ne_zero_of_applies {l : Profile} {u : Utt} {w : AsymObj}
-    (h : asymMeaning l u w = true) : asymMarginalSpeaker w u ≠ 0 := by
+    (h : asymMeaning l u w) : asymMarginalSpeaker w u ≠ 0 := by
   rw [← PMF.mem_support_iff, asymMarginalSpeaker, RSA.mem_support_marginalizeKernel_iff]
   exact ⟨l, latentPrior_ne_zero l, asymS1_ne_zero_of_applies h⟩
 
@@ -308,7 +323,7 @@ theorem asymMarginal_ne_zero (u : Utt) :
     PMF.marginal asymMarginalSpeaker asymWorldPrior u ≠ 0 :=
   PMF.marginal_ne_zero _ _ _
     ((asymWorldPrior.mem_support_iff .target).mp (PMF.mem_support_uniformOfFintype _))
-    (asymMarginalSpeaker_ne_zero_of_applies (l := (true, true, true)) rfl)
+    (asymMarginalSpeaker_ne_zero_of_applies (l := (true, true, true)) trivial)
 
 /-- Pragmatic listener: posterior of the latent-marginalized speaker. -/
 noncomputable def asymL1 (u : Utt) : PMF AsymObj :=
@@ -320,8 +335,8 @@ noncomputable def asymL1 (u : Utt) : PMF AsymObj :=
 The literal semantics is intersective predicate modification [heim-kratzer-1998]:
 each mentioned feature is an intersective adjective — `Modifier.intersective`
 applied to a feature property — and `grounding_ego_meaning` shows `egoMeaning`
-is exactly their iterated conjunction. This grounds the `Bool` RSA meaning in
-the project-canonical Prop-valued modifier rather than a local copy. -/
+is exactly their iterated conjunction, grounding the RSA meaning in the
+project-canonical modifier rather than a local copy. -/
 
 namespace MontaguGrounding
 
@@ -351,7 +366,7 @@ def compositionalMeaning : Utt → VisObj → Prop
 /-- **Grounding**: the RSA literal meaning `egoMeaning` holds exactly when the
 intersective predicate modification of the mentioned feature adjectives does. -/
 theorem grounding_ego_meaning (u : Utt) (w : VisObj) :
-    egoMeaning u w = true ↔ compositionalMeaning u w := by
+    egoMeaning u w ↔ compositionalMeaning u w := by
   cases u <;> cases w <;>
     simp only [compositionalMeaning, Modifier.intersective_apply, shapeP, colorP, textureP] <;>
     decide
@@ -373,8 +388,8 @@ theorem ego_shape_identifies_target : egoL1 .s .target > egoL1 .s .d1 := by
   rw [gt_iff_lt]
   unfold egoL1 egoWorldPrior
   rw [PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      egoS1_eq_zero_of_not_applies (by decide : egoMeaning .s .d1 ≠ true)]
-  exact pos_iff_ne_zero.mpr (egoS1_ne_zero_of_applies rfl)
+      egoS1_eq_zero_of_not_applies (by decide : ¬ egoMeaning .s .d1)]
+  exact pos_iff_ne_zero.mpr (egoS1_ne_zero_of_applies trivial)
 
 /-- The listener is equally confident about the target whether hearing
 shape-only or the full description: both apply only to the target among visible
@@ -389,8 +404,8 @@ target: both apply only to the target, so both have `L0 = 1` and equal score. -/
 theorem ego_S1_indifferent : ¬(egoS1 .target .sct > egoS1 .target .s) := by
   rw [gt_iff_lt, not_lt, egoS1, RSA.S1Belief_apply_le_iff_score_le]
   have h : egoL0 .sct .target = egoL0 .s .target := by
-    rw [egoL0_apply_of_true (by decide : egoMeaning .sct .target = true),
-        egoL0_apply_of_true (by decide : egoMeaning .s .target = true),
+    rw [egoL0_apply_of_true (by decide : egoMeaning .sct .target),
+        egoL0_apply_of_true (by decide : egoMeaning .s .target),
         show (RSA.extensionOf egoMeaning .sct).card = 1 from by decide,
         show (RSA.extensionOf egoMeaning .s).card = 1 from by decide]
   exact le_of_eq (by rw [h])
@@ -405,8 +420,8 @@ theorem asym_S1_prefers_specificity_when_shape_matches :
     asymS1 (true, false, false) .target .sct > asymS1 (true, false, false) .target .s := by
   rw [gt_iff_lt, asymS1, RSA.S1Belief_apply_lt_iff_score_lt, mul_one, mul_one]
   apply ENNReal.rpow_lt_rpow _ (by norm_num : (0 : ℝ) < 2)
-  rw [asymL0_apply_of_true (by decide : asymMeaning (true, false, false) .s .target = true),
-      asymL0_apply_of_true (by decide : asymMeaning (true, false, false) .sct .target = true),
+  rw [asymL0_apply_of_true (by decide : asymMeaning (true, false, false) .s .target),
+      asymL0_apply_of_true (by decide : asymMeaning (true, false, false) .sct .target),
       show (RSA.extensionOf (asymMeaning (true, false, false)) .s).card = 2 from by decide,
       show (RSA.extensionOf (asymMeaning (true, false, false)) .sct).card = 1 from by decide]
   norm_num
@@ -418,8 +433,8 @@ theorem asym_S1_indifferent_when_no_match :
       asymS1 (false, false, false) .target .s) := by
   rw [gt_iff_lt, not_lt, asymS1, RSA.S1Belief_apply_le_iff_score_le]
   have h : asymL0 (false, false, false) .sct .target = asymL0 (false, false, false) .s .target := by
-    rw [asymL0_apply_of_true (by decide : asymMeaning (false, false, false) .sct .target = true),
-        asymL0_apply_of_true (by decide : asymMeaning (false, false, false) .s .target = true),
+    rw [asymL0_apply_of_true (by decide : asymMeaning (false, false, false) .sct .target),
+        asymL0_apply_of_true (by decide : asymMeaning (false, false, false) .s .target),
         show (RSA.extensionOf (asymMeaning (false, false, false)) .sct).card = 1 from by decide,
         show (RSA.extensionOf (asymMeaning (false, false, false)) .s).card = 1 from by decide]
   exact le_of_eq (by rw [h])
@@ -431,9 +446,9 @@ theorem asym_L1_identifies_target : asymL1 .s .target > asymL1 .s .d1 := by
   rw [gt_iff_lt]
   unfold asymL1 asymWorldPrior
   rw [PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      asymMarginalSpeaker_eq_zero_of_not_applies (by decide : ∀ l, asymMeaning l .s .d1 ≠ true)]
+      asymMarginalSpeaker_eq_zero_of_not_applies (by decide : ∀ l, ¬ asymMeaning l .s .d1)]
   exact pos_iff_ne_zero.mpr
-    (asymMarginalSpeaker_ne_zero_of_applies (l := (false, false, false)) rfl)
+    (asymMarginalSpeaker_ne_zero_of_applies (l := (false, false, false)) trivial)
 
 /-- **Paper prediction**: under asymmetry, the full description yields a higher
 listener posterior for the target than shape-only — the hidden object can match

--- a/Linglib/Studies/Kennedy2015PMF.lean
+++ b/Linglib/Studies/Kennedy2015PMF.lean
@@ -26,7 +26,7 @@ dominance patterns.
 ## Reused from `Kennedy2015.lean`
 
 * `KCard`, `KUtt` — domain types
-* `kMean` — Boolean meaning matrix (Prop-valued; we lift to Bool)
+* `kMean` — the meaning matrix, consumed directly by `RSA.extensionOf`
 -/
 
 set_option autoImplicit false
@@ -38,17 +38,10 @@ open scoped ENNReal
 instance : Nonempty KCard := ⟨0⟩
 instance : Nonempty KUtt := ⟨.bare3⟩
 
-/-- Boolean meaning, derived from `kMean` via `decide`. -/
-noncomputable def kMeanBool (u : KUtt) (w : KCard) : Bool := decide (kMean u w)
-
-/-- The Bool form agrees with the Prop form. -/
-theorem kMeanBool_iff (u : KUtt) (w : KCard) : kMeanBool u w = true ↔ kMean u w :=
-  decide_eq_true_iff
-
-/-! ## §1. L0 — uniform on extension via `RSA.L0OfBoolMeaning` -/
+/-! ## §1. L0 — uniform on extension via `RSA.L0OfPred` -/
 
 noncomputable abbrev extension (u : KUtt) : Finset KCard :=
-  RSA.extensionOf kMeanBool u
+  RSA.extensionOf kMean u
 
 theorem extension_nonempty (u : KUtt) : (extension u).Nonempty := by
   cases u
@@ -59,21 +52,21 @@ theorem extension_nonempty (u : KUtt) : (extension u).Nonempty := by
   · exact ⟨3, RSA.mem_extensionOf.mpr (by decide)⟩
 
 noncomputable def L0 (u : KUtt) : PMF KCard :=
-  RSA.L0OfBoolMeaning kMeanBool u (extension_nonempty u)
+  RSA.L0OfPred kMean u (extension_nonempty u)
 
 @[simp] theorem mem_support_L0_iff (u : KUtt) (w : KCard) :
-    w ∈ (L0 u).support ↔ kMeanBool u w = true :=
-  RSA.mem_support_L0OfBoolMeaning_iff _ _
+    w ∈ (L0 u).support ↔ kMean u w :=
+  RSA.mem_support_L0OfPred_iff _ _
 
-theorem L0_apply_of_true {u : KUtt} {w : KCard} (h : kMeanBool u w = true) :
+theorem L0_apply_of_true {u : KUtt} {w : KCard} (h : kMean u w) :
     L0 u w = ((extension u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+  RSA.L0OfPred_apply_of_mem _ h
 
-theorem L0_apply_of_false {u : KUtt} {w : KCard} (h : kMeanBool u w ≠ true) :
+theorem L0_apply_of_false {u : KUtt} {w : KCard} (h : ¬ kMean u w) :
     L0 u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+  RSA.L0OfPred_apply_of_not_mem _ h
 
-private theorem L0_apply_ne_zero {u : KUtt} {w : KCard} (h : kMeanBool u w = true) :
+private theorem L0_apply_ne_zero {u : KUtt} {w : KCard} (h : kMean u w) :
     L0 u w ≠ 0 := by
   rw [← PMF.mem_support_iff, mem_support_L0_iff]; exact h
 
@@ -89,7 +82,7 @@ template. -/
 theorem L0_tsum_utterance_ne_top (w : KCard) : ∑' u, (L0 u w : ℝ≥0∞) ≠ ∞ :=
   PMF.tsum_apply_ne_top (fun u => L0 u) w
 
-private theorem tsum_L0_ne_zero_at {u : KUtt} {w : KCard} (h : kMeanBool u w = true) :
+private theorem tsum_L0_ne_zero_at {u : KUtt} {w : KCard} (h : kMean u w) :
     (∑' u', (L0 u' w : ℝ≥0∞)) ≠ 0 :=
   PMF.tsum_apply_ne_zero L0 (a := u) (L0_apply_ne_zero h)
 
@@ -111,7 +104,7 @@ noncomputable def worldPrior : PMF KCard := PMF.uniformOfFintype KCard
 theorem worldPrior_ne_zero (w : KCard) : worldPrior w ≠ 0 :=
   (worldPrior.mem_support_iff w).mp (PMF.mem_support_uniformOfFintype w)
 
-private theorem S1_ne_zero_at {u : KUtt} {w : KCard} (h : kMeanBool u w = true) :
+private theorem S1_ne_zero_at {u : KUtt} {w : KCard} (h : kMean u w) :
     S1 w u ≠ 0 := by
   rw [S1_eq_normalize (tsum_L0_ne_zero_at h), ← PMF.mem_support_iff,
       PMF.mem_support_normalize_iff]
@@ -138,8 +131,8 @@ theorem S1_3_lt_S1_4_for_moreThan3 :
   rw [S1_eq_normalize (tsum_L0_ne_zero_at (u := .bare3) (by decide)),
       S1_eq_normalize (tsum_L0_ne_zero_at (u := .moreThan3) (by decide))]
   exact PMF.normalize_lt_of_apply_zero_pos _ _ _ _ _ _ _
-    (L0_apply_of_false (by decide : kMeanBool .moreThan3 (3 : KCard) ≠ true))
-    (L0_apply_ne_zero (by decide : kMeanBool .moreThan3 (4 : KCard) = true))
+    (L0_apply_of_false (by decide : ¬ kMean .moreThan3 (3 : KCard)))
+    (L0_apply_ne_zero (by decide : kMean .moreThan3 (4 : KCard)))
 
 /-- L1("moreThan3") prefers .4 over .3 — Class A excludes the boundary semantically. -/
 theorem classA_no_competition_at_boundary :
@@ -154,8 +147,8 @@ theorem S1_4_lt_S1_3_for_bare3 :
   rw [S1_eq_normalize (tsum_L0_ne_zero_at (u := .moreThan3) (by decide)),
       S1_eq_normalize (tsum_L0_ne_zero_at (u := .bare3) (by decide))]
   exact PMF.normalize_lt_of_apply_zero_pos _ _ _ _ _ _ _
-    (L0_apply_of_false (by decide : kMeanBool .bare3 (4 : KCard) ≠ true))
-    (L0_apply_ne_zero (by decide : kMeanBool .bare3 (3 : KCard) = true))
+    (L0_apply_of_false (by decide : ¬ kMean .bare3 (4 : KCard)))
+    (L0_apply_ne_zero (by decide : kMean .bare3 (3 : KCard)))
 
 /-- L1("bare 3") peaked at .3 — bare numeral exact reading. -/
 theorem bare_peaked_with_kennedy_alternatives :
@@ -170,8 +163,8 @@ theorem S1_3_lt_S1_2_for_fewerThan3 :
   rw [S1_eq_normalize (tsum_L0_ne_zero_at (u := .bare3) (by decide)),
       S1_eq_normalize (tsum_L0_ne_zero_at (u := .fewerThan3) (by decide))]
   exact PMF.normalize_lt_of_apply_zero_pos _ _ _ _ _ _ _
-    (L0_apply_of_false (by decide : kMeanBool .fewerThan3 (3 : KCard) ≠ true))
-    (L0_apply_ne_zero (by decide : kMeanBool .fewerThan3 (2 : KCard) = true))
+    (L0_apply_of_false (by decide : ¬ kMean .fewerThan3 (3 : KCard)))
+    (L0_apply_ne_zero (by decide : kMean .fewerThan3 (2 : KCard)))
 
 /-- L1("fewerThan3") prefers .2 over .3 — upper Class A excludes boundary. -/
 theorem upper_classA_no_competition :
@@ -193,11 +186,11 @@ private theorem univ_KUtt :
 private theorem Z3 : (∑' u : KUtt, L0 u (3 : KCard)) = 1 + 3⁻¹ + 4⁻¹ := by
   rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
-      L0_apply_of_true (show kMeanBool .bare3 (3 : KCard) = true by decide),
-      L0_apply_of_false (show kMeanBool .moreThan3 (3 : KCard) ≠ true by decide),
-      L0_apply_of_false (show kMeanBool .fewerThan3 (3 : KCard) ≠ true by decide),
-      L0_apply_of_true (show kMeanBool .atLeast3 (3 : KCard) = true by decide),
-      L0_apply_of_true (show kMeanBool .atMost3 (3 : KCard) = true by decide),
+      L0_apply_of_true (show kMean .bare3 (3 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .moreThan3 (3 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .fewerThan3 (3 : KCard) by decide),
+      L0_apply_of_true (show kMean .atLeast3 (3 : KCard) by decide),
+      L0_apply_of_true (show kMean .atMost3 (3 : KCard) by decide),
       show (extension .bare3).card = 1 from by decide,
       show (extension .atLeast3).card = 3 from by decide,
       show (extension .atMost3).card = 4 from by decide]
@@ -207,11 +200,11 @@ private theorem Z3 : (∑' u : KUtt, L0 u (3 : KCard)) = 1 + 3⁻¹ + 4⁻¹ := 
 private theorem Z4 : (∑' u : KUtt, L0 u (4 : KCard)) = 2⁻¹ + 3⁻¹ := by
   rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
-      L0_apply_of_false (show kMeanBool .bare3 (4 : KCard) ≠ true by decide),
-      L0_apply_of_true (show kMeanBool .moreThan3 (4 : KCard) = true by decide),
-      L0_apply_of_false (show kMeanBool .fewerThan3 (4 : KCard) ≠ true by decide),
-      L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide),
-      L0_apply_of_false (show kMeanBool .atMost3 (4 : KCard) ≠ true by decide),
+      L0_apply_of_false (show ¬ kMean .bare3 (4 : KCard) by decide),
+      L0_apply_of_true (show kMean .moreThan3 (4 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .fewerThan3 (4 : KCard) by decide),
+      L0_apply_of_true (show kMean .atLeast3 (4 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .atMost3 (4 : KCard) by decide),
       show (extension .moreThan3).card = 2 from by decide,
       show (extension .atLeast3).card = 3 from by decide]
   simp only [Nat.cast_ofNat, zero_add, add_zero]
@@ -219,14 +212,14 @@ private theorem Z4 : (∑' u : KUtt, L0 u (4 : KCard)) = 2⁻¹ + 3⁻¹ := by
 private theorem Z2 : (∑' u : KUtt, L0 u (2 : KCard)) = 3⁻¹ + 4⁻¹ := by
   rw [tsum_fintype, univ_KUtt, Finset.sum_insert (by decide), Finset.sum_insert (by decide),
       Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton,
-      L0_apply_of_false (show kMeanBool .bare3 (2 : KCard) ≠ true by decide),
-      L0_apply_of_false (show kMeanBool .moreThan3 (2 : KCard) ≠ true by decide),
-      L0_apply_of_true (show kMeanBool .fewerThan3 (2 : KCard) = true by decide),
-      L0_apply_of_false (show kMeanBool .atLeast3 (2 : KCard) ≠ true by decide),
-      L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide),
+      L0_apply_of_false (show ¬ kMean .bare3 (2 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .moreThan3 (2 : KCard) by decide),
+      L0_apply_of_true (show kMean .fewerThan3 (2 : KCard) by decide),
+      L0_apply_of_false (show ¬ kMean .atLeast3 (2 : KCard) by decide),
+      L0_apply_of_true (show kMean .atMost3 (2 : KCard) by decide),
       show (extension .fewerThan3).card = 3 from by decide,
       show (extension .atMost3).card = 4 from by decide]
-  simp only [Nat.cast_ofNat, zero_add, add_zero]
+  simp only [Nat.cast_ofNat, zero_add]
 
 private theorem Z4_lt_Z3 :
     (∑' u : KUtt, L0 u (4 : KCard)) < ∑' u : KUtt, L0 u (3 : KCard) := by
@@ -246,12 +239,12 @@ theorem classB_strengthened_above_bare :
     L1 .atLeast3 (4 : KCard) > L1 .atLeast3 (3 : KCard) := by
   unfold L1 worldPrior
   rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atLeast3 (3 : KCard) = true by decide)),
-      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atLeast3 (4 : KCard) = true by decide))]
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMean .atLeast3 (3 : KCard) by decide)),
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMean .atLeast3 (4 : KCard) by decide))]
   apply PMF.normalize_lt_of_apply_eq_of_sum_lt
-  · rw [L0_apply_of_true (show kMeanBool .atLeast3 (3 : KCard) = true by decide),
-        L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide)]
-  · rw [L0_apply_of_true (show kMeanBool .atLeast3 (4 : KCard) = true by decide)]
+  · rw [L0_apply_of_true (show kMean .atLeast3 (3 : KCard) by decide),
+        L0_apply_of_true (show kMean .atLeast3 (4 : KCard) by decide)]
+  · rw [L0_apply_of_true (show kMean .atLeast3 (4 : KCard) by decide)]
     exact ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _)
   · exact PMF.apply_ne_top _ _
   · exact Z4_lt_Z3
@@ -262,12 +255,12 @@ theorem upper_classB_strengthened_below_bare :
     L1 .atMost3 (2 : KCard) > L1 .atMost3 (3 : KCard) := by
   unfold L1 worldPrior
   rw [gt_iff_lt, PMF.posterior_lt_iff_kernel_lt_of_uniform,
-      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atMost3 (3 : KCard) = true by decide)),
-      S1_eq_normalize (tsum_L0_ne_zero_at (show kMeanBool .atMost3 (2 : KCard) = true by decide))]
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMean .atMost3 (3 : KCard) by decide)),
+      S1_eq_normalize (tsum_L0_ne_zero_at (show kMean .atMost3 (2 : KCard) by decide))]
   apply PMF.normalize_lt_of_apply_eq_of_sum_lt
-  · rw [L0_apply_of_true (show kMeanBool .atMost3 (3 : KCard) = true by decide),
-        L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide)]
-  · rw [L0_apply_of_true (show kMeanBool .atMost3 (2 : KCard) = true by decide)]
+  · rw [L0_apply_of_true (show kMean .atMost3 (3 : KCard) by decide),
+        L0_apply_of_true (show kMean .atMost3 (2 : KCard) by decide)]
+  · rw [L0_apply_of_true (show kMean .atMost3 (2 : KCard) by decide)]
     exact ENNReal.inv_ne_zero.mpr (ENNReal.natCast_ne_top _)
   · exact PMF.apply_ne_top _ _
   · exact Z2_lt_Z3

--- a/Linglib/Studies/PottsEtAl2016.lean
+++ b/Linglib/Studies/PottsEtAl2016.lean
@@ -49,7 +49,7 @@ model (19c), whose listener marginalizes over the full refinement lattice
 The PMF stack mirrors [goodman-stuhlmuller-2013]'s latent-uncertainty model
 on mathlib `PMF`, with `Latent := Lexicon`:
 
-* `L0 lex u : PMF World` — `RSA.L0OfBoolMeaning` (uniform on the extension).
+* `L0 lex u : PMF World` — `RSA.L0OfPred` (uniform on the extension).
 * `S1 lex w : PMF Utterance` — `RSA.S1Belief (L0 lex) (fun _ => 1) 1 w`
   (α = 1, no utterance cost): normalises `L0 lex u w` over utterances.
 * `marginalSpeaker w : PMF Utterance` — `RSA.marginalizeKernel` of `S1`
@@ -149,18 +149,24 @@ def predCount (sq : ShotQ) (lex : Lexicon) (w : World) : Nat :=
     | .strong => w.numScoredNotAced
 
 /-- Truth value of a statement in a world under a lexicon. -/
-def stmtTruth (lex : Lexicon) : Stmt → World → Bool
+def stmtTruth (lex : Lexicon) : Stmt → World → Prop
   | (pq, sq), w =>
     let n := predCount sq lex w
     match pq with
-    | .every => n == 3
-    | .exactlyOne => n == 1
-    | .no => n == 0
+    | .every => n = 3
+    | .exactlyOne => n = 1
+    | .no => n = 0
+
+instance (lex : Lexicon) : ∀ s, DecidablePred (stmtTruth lex s)
+  | (pq, _), _ => by cases pq <;> exact Nat.decEq _ _
 
 /-- Truth value of an utterance under a lexicon: `stmtTruth` with silence
 true at every world. -/
-def utteranceTruth (lex : Lexicon) : Utterance → World → Bool :=
+def utteranceTruth (lex : Lexicon) : Utterance → World → Prop :=
   RSA.liftMeaning (stmtTruth lex)
+
+instance (lex : Lexicon) : ∀ u, DecidablePred (utteranceTruth lex u) :=
+  inferInstanceAs (∀ u, DecidablePred (RSA.liftMeaning (stmtTruth lex) u))
 
 /-! ### Structural properties
 
@@ -170,12 +176,12 @@ extension under each outer quantifier. -/
 
 /-- Lexica agree on all "all"-utterances; the lexicon only refines "some". -/
 theorem lexica_agree_on_all :
-    ∀ pq w, utteranceTruth .weak (some (pq, .all)) w =
+    ∀ pq w, utteranceTruth .weak (some (pq, .all)) w ↔
             utteranceTruth .strong (some (pq, .all)) w := by decide
 
 /-- Lexica agree on all "none"-utterances. -/
 theorem lexica_agree_on_none :
-    ∀ pq w, utteranceTruth .weak (some (pq, .none_)) w =
+    ∀ pq w, utteranceTruth .weak (some (pq, .none_)) w ↔
             utteranceTruth .strong (some (pq, .none_)) w := by decide
 
 /-- DE context: strong "some" *widens* the set of true worlds relative to weak.
@@ -184,8 +190,8 @@ theorem lexica_agree_on_none :
     - Strong "some": NNN, NNA, NAA, AAA satisfy (4 worlds)
     Widening makes the utterance less informative under the strong lexicon. -/
 theorem de_enrichment_widens :
-    (Finset.univ.filter (fun w => utteranceTruth .weak (some (.no, .some_)) w = true)).card <
-    (Finset.univ.filter (fun w => utteranceTruth .strong (some (.no, .some_)) w = true)).card := by
+    (Finset.univ.filter (utteranceTruth .weak (some (.no, .some_)))).card <
+    (Finset.univ.filter (utteranceTruth .strong (some (.no, .some_)))).card := by
   decide
 
 /-- UE context: strong "some" *narrows* the set of true worlds relative to weak.
@@ -194,13 +200,13 @@ theorem de_enrichment_widens :
     - Strong "some": only SSS satisfies (1 world)
     Narrowing makes the utterance more informative under the strong lexicon. -/
 theorem ue_enrichment_narrows :
-    (Finset.univ.filter (fun w => utteranceTruth .strong (some (.every, .some_)) w = true)).card <
-    (Finset.univ.filter (fun w => utteranceTruth .weak (some (.every, .some_)) w = true)).card := by
+    (Finset.univ.filter (utteranceTruth .strong (some (.every, .some_)))).card <
+    (Finset.univ.filter (utteranceTruth .weak (some (.every, .some_)))).card := by
   decide
 
 /-! ### Literal listener `L0`
 
-Per-lexicon literal listener via `RSA.L0OfBoolMeaning`: uniform on the
+Per-lexicon literal listener via `RSA.L0OfPred`: uniform on the
 extension of the (lexicon-parameterised) meaning function. Every utterance has
 a non-empty extension (every quantifier is true at some world, and `null` is
 true everywhere), so the `Nonempty` precondition is universal. -/
@@ -214,7 +220,7 @@ theorem ext_nonempty (lex : Lexicon) (u : Utterance) :
 
 /-- Per-lexicon literal listener: uniform on the extension. -/
 noncomputable def L0 (lex : Lexicon) (u : Utterance) : PMF World :=
-  RSA.L0OfBoolMeaning (utteranceTruth lex) u (ext_nonempty lex u)
+  RSA.L0OfPred (utteranceTruth lex) u (ext_nonempty lex u)
 
 /-- Closed-form `L0` value: `ENNReal.ofReal (1 / |extension|)` at true worlds,
 `0` otherwise. The `pmf_eval_simps`-friendly if-form. -/
@@ -225,19 +231,19 @@ theorem L0_apply (lex : Lexicon) (u : Utterance) (w : World) :
       else 0 := by
   unfold L0
   by_cases h : utteranceTruth lex u w
-  · rw [if_pos h, RSA.L0OfBoolMeaning_apply_of_mem _ h,
+  · rw [if_pos h, RSA.L0OfPred_apply_of_mem _ h,
         ← ENNReal.ofReal_natCast, ← ENNReal.ofReal_inv_of_pos]
     exact_mod_cast Finset.card_pos.mpr (ext_nonempty lex u)
-  · rw [if_neg h, RSA.L0OfBoolMeaning_apply_of_not_mem _ (by simpa using h)]
+  · rw [if_neg h, RSA.L0OfPred_apply_of_not_mem _ h]
 
 /-- `L0 lex none w = ofReal (1/10)`: silence is true at every world, so its
 extension is all 10 worlds. Used to discharge the speaker normaliser's
 positivity hypothesis. -/
 theorem L0_null (lex : Lexicon) (w : World) :
     L0 lex none w = ENNReal.ofReal ((10 : ℝ))⁻¹ := by
-  rw [L0_apply, if_pos (by simp [utteranceTruth]),
+  rw [L0_apply, if_pos (show utteranceTruth lex none w from trivial),
       show RSA.extensionOf (utteranceTruth lex) none = Finset.univ by
-        simp [utteranceTruth],
+        ext w; simp [utteranceTruth],
       show (Finset.univ : Finset World).card = 10 by rfl]
   norm_num
 
@@ -403,14 +409,14 @@ theorem S1_apply (lex : Lexicon) (w : World) (u : Utterance) :
 /-- Speaker value when the utterance is **false** at the world: `L0 = 0`, so
 `S1 = 0`. -/
 private theorem S1_eq_zero (lex : Lexicon) (w : World) (u : Utterance)
-    (h : utteranceTruth lex u w = false) : S1 lex w u = 0 := by
-  rw [S1_apply, score_eq, L0_apply, if_neg (by rw [h]; simp)]; simp
+    (h : ¬ utteranceTruth lex u w) : S1 lex w u = 0 := by
+  rw [S1_apply, score_eq, L0_apply, if_neg h]; simp
 
 /-- Speaker value when the utterance is **true**: `ofReal (1/c · 1/Z)`, computed
 from the extension cardinality `c` and the partition `Z`. -/
 private theorem S1_eq_ofReal (lex : Lexicon) (w : World) (u : Utterance)
     (c : ℕ) (hc : 0 < c) (zr : ℝ) (hzr : 0 < zr)
-    (htrue : utteranceTruth lex u w = true)
+    (htrue : utteranceTruth lex u w)
     (hcard : (RSA.extensionOf (utteranceTruth lex) u).card = c)
     (hZ : Z lex w = ENNReal.ofReal zr) :
     S1 lex w u = ENNReal.ofReal ((c : ℝ)⁻¹ * zr⁻¹) := by
@@ -603,16 +609,16 @@ private theorem predCount_lt_four (sq : ShotQ) (lex : Lexicon) (w : World) :
 
 /-- "Every player hit X" ↔ `worldMeaning 3 .all` applied to `predCount`. -/
 theorem outer_every_grounded (sq : ShotQ) (lex : Lexicon) (w : World) :
-    utteranceTruth lex (some (.every, sq)) w =
+    utteranceTruth lex (some (.every, sq)) w ↔
     Alternatives.Quantifiers.worldMeaning 3 .all
-      ⟨⟨predCount sq lex w, predCount_lt_four sq lex w⟩⟩ := by
+      ⟨⟨predCount sq lex w, predCount_lt_four sq lex w⟩⟩ = true := by
   cases sq <;> cases lex <;> cases w <;> decide
 
 /-- "No player hit X" ↔ `worldMeaning 3 .none_` applied to `predCount`. -/
 theorem outer_no_grounded (sq : ShotQ) (lex : Lexicon) (w : World) :
-    utteranceTruth lex (some (.no, sq)) w =
+    utteranceTruth lex (some (.no, sq)) w ↔
     Alternatives.Quantifiers.worldMeaning 3 .none_
-      ⟨⟨predCount sq lex w, predCount_lt_four sq lex w⟩⟩ := by
+      ⟨⟨predCount sq lex w, predCount_lt_four sq lex w⟩⟩ = true := by
   cases sq <;> cases lex <;> cases w <;> decide
 
 /-! ### Cross-study connections

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -103,23 +103,40 @@ abbrev Utterance := WithSilence Assertion
     `Features.ChangeOfState.CoSType` at the world's temporal projections —
     presupposition and assertion by construction
     (`Features.ChangeOfState.CoSType.eval_iff`), not by bridge theorem. -/
-def assertionMeaning : Assertion → WorldState → Bool
+def assertionMeaning : Assertion → WorldState → Prop
   | .smokes,            w => w.now
-  | .doesntSmoke,       w => !w.now
+  | .doesntSmoke,       w => ¬ w.now
   | .smoked,            w => w.past
-  | .didntSmoke,        w => !w.past
+  | .didntSmoke,        w => ¬ w.past
   | .always,      w => Features.ChangeOfState.CoSType.continuation.eval w.past w.now
-  | .notAlways,   w => !Features.ChangeOfState.CoSType.continuation.eval w.past w.now
+  | .notAlways,   w => ¬ Features.ChangeOfState.CoSType.continuation.eval w.past w.now
   | .stopped,    w => Features.ChangeOfState.CoSType.cessation.eval w.past w.now
-  | .notStopped, w => !Features.ChangeOfState.CoSType.cessation.eval w.past w.now
+  | .notStopped, w => ¬ Features.ChangeOfState.CoSType.cessation.eval w.past w.now
   | .started,    w => Features.ChangeOfState.CoSType.inception.eval w.past w.now
-  | .notStarted, w => !Features.ChangeOfState.CoSType.inception.eval w.past w.now
-  | .never,       w => !w.past && !w.now
-  | .notNever,    w => !(!w.past && !w.now)
+  | .notStarted, w => ¬ Features.ChangeOfState.CoSType.inception.eval w.past w.now
+  | .never,       w => ¬ w.past ∧ ¬ w.now
+  | .notNever,    w => ¬ (¬ w.past ∧ ¬ w.now)
+
+instance : ∀ a : Assertion, DecidablePred (assertionMeaning a)
+  | .smokes,      _ => inferInstanceAs (Decidable (_ = true))
+  | .doesntSmoke, _ => inferInstanceAs (Decidable (¬ _))
+  | .smoked,      _ => inferInstanceAs (Decidable (_ = true))
+  | .didntSmoke,  _ => inferInstanceAs (Decidable (¬ _))
+  | .always,      _ => inferInstanceAs (Decidable (_ = true))
+  | .notAlways,   _ => inferInstanceAs (Decidable (¬ _))
+  | .stopped,     _ => inferInstanceAs (Decidable (_ = true))
+  | .notStopped,  _ => inferInstanceAs (Decidable (¬ _))
+  | .started,     _ => inferInstanceAs (Decidable (_ = true))
+  | .notStarted,  _ => inferInstanceAs (Decidable (¬ _))
+  | .never,       _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .notNever,    _ => inferInstanceAs (Decidable (¬ _))
 
 /-- Literal truth conditions lifted to `Utterance`: silence is universally
 true (`RSA.liftMeaning`). -/
-def literalMeaning : Utterance → WorldState → Bool := liftMeaning assertionMeaning
+def literalMeaning : Utterance → WorldState → Prop := liftMeaning assertionMeaning
+
+instance : ∀ u : Utterance, DecidablePred (literalMeaning u) :=
+  inferInstanceAs (∀ u, DecidablePred (liftMeaning assertionMeaning u))
 
 open Features.ChangeOfState (CoSType)
 /-! ### Context sets -/
@@ -141,16 +158,27 @@ inductive ContextSet where
   deriving DecidableEq, Repr, Inhabited, Fintype
 
 /-- World-context compatibility: w ∈ C. -/
-def compatibleBool : ContextSet → WorldState → Bool
+def compatible : ContextSet → WorldState → Prop
   | .pastTrue,          w => w.past
-  | .pastFalse,         w => !w.past
+  | .pastFalse,         w => ¬ w.past
   | .nowTrue,           w => w.now
-  | .nowFalse,          w => !w.now
-  | .pastTrueNowTrue,   w => w.past && w.now
-  | .pastTrueNowFalse,  w => w.past && !w.now
-  | .pastFalseNowTrue,  w => !w.past && w.now
-  | .pastFalseNowFalse, w => !w.past && !w.now
-  | .universe,          _ => true
+  | .nowFalse,          w => ¬ w.now
+  | .pastTrueNowTrue,   w => w.past ∧ w.now
+  | .pastTrueNowFalse,  w => w.past ∧ ¬ w.now
+  | .pastFalseNowTrue,  w => ¬ w.past ∧ w.now
+  | .pastFalseNowFalse, w => ¬ w.past ∧ ¬ w.now
+  | .universe,          _ => True
+
+instance : ∀ cs : ContextSet, DecidablePred (compatible cs)
+  | .pastTrue,          _ => inferInstanceAs (Decidable (_ = true))
+  | .pastFalse,         _ => inferInstanceAs (Decidable (¬ _))
+  | .nowTrue,           _ => inferInstanceAs (Decidable (_ = true))
+  | .nowFalse,          _ => inferInstanceAs (Decidable (¬ _))
+  | .pastTrueNowTrue,   _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .pastTrueNowFalse,  _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .pastFalseNowTrue,  _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .pastFalseNowFalse, _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .universe,          _ => isTrue trivial
 
 /-! ### QUD -/
 
@@ -195,7 +223,7 @@ def contextPrior : ContextSet → ℚ≥0
 prior cancels, and empty extensions normalize to the zero row). -/
 def l0Score (cs : ContextSet) (u : Utterance) : WorldState → ℚ≥0 :=
   PMF.normalizeScores fun w =>
-    if compatibleBool cs w && literalMeaning u w then 1 else 0
+    if compatible cs w ∧ literalMeaning u w then 1 else 0
 
 /-- QUD aggregation of the literal listener (eq. 5): sum over the QUD cell. -/
 def qAgg (qud : QUD) (cs : ContextSet) (u : Utterance) : WorldState → ℚ≥0
@@ -241,8 +269,15 @@ noncomputable def l1Ctx (qud : QUD) (u : Utterance) : PMF ContextSet :=
 
 /-- Event marginal of the world-side listener. -/
 noncomputable def l1WorldEvent (qud : QUD) (u : Utterance)
-    (P : WorldState → Bool) : ℝ≥0∞ :=
+    (P : WorldState → Prop) [DecidablePred P] : ℝ≥0∞ :=
   ∑' w, if P w then l1World qud u w else 0
+
+/-- `PMF.ofScores_event_lt` indexes events by `WorldState → Bool`; this is the
+`decide` transport that lets the event predictions below cite it. -/
+private theorem l1WorldEvent_eq_decide (qud : QUD) (u : Utterance)
+    (P : WorldState → Prop) [DecidablePred P] :
+    l1WorldEvent qud u P = ∑' w, if decide (P w) then l1World qud u w else 0 := by
+  simp [l1WorldEvent]
 
 /-! ### Listener predictions -/
 
@@ -259,9 +294,10 @@ theorem qud_now_wTT_eq_wFT :
 
 /-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
-    l1WorldEvent .now (some .notStopped) (fun w => !w.now) <
-      l1WorldEvent .now (some .notStopped) (·.now) :=
-  PMF.ofScores_event_lt _ _ (by decide +kernel)
+    l1WorldEvent .now (some .notStopped) (fun w => ¬ w.now) <
+      l1WorldEvent .now (some .notStopped) (·.now) := by
+  rw [l1WorldEvent_eq_decide, l1WorldEvent_eq_decide]
+  exact PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### World elimination
 
@@ -320,37 +356,41 @@ theorem now_context_dispreferred :
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
     l1WorldEvent .now (some .stopped) (·.now) <
-      l1WorldEvent .now (some .stopped) (fun w => !w.now) :=
-  PMF.ofScores_event_lt _ _ (by decide +kernel)
+      l1WorldEvent .now (some .stopped) (fun w => ¬ w.now) := by
+  rw [l1WorldEvent_eq_decide, l1WorldEvent_eq_decide]
+  exact PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### Structural properties -/
 
 /-- "didn't stop smoking" excludes exactly the stopping world. -/
 theorem notStopped_compatible_worlds (w : WorldState) :
-    literalMeaning (some .notStopped) w = true ↔ w ≠ .wTF := by cases w <;> decide
+    literalMeaning (some .notStopped) w ↔ w ≠ .wTF := by cases w <;> decide
 
 /-- Under a +past context set, "didn't stop" is maximally informative for
 QUD_now: it narrows to exactly wTT. -/
 theorem notStopped_informative_in_pastTrue (w : WorldState) :
-    (compatibleBool .pastTrue w && literalMeaning (some .notStopped) w) = true ↔
+    (compatible .pastTrue w ∧ literalMeaning (some .notStopped) w) ↔
       w = .wTT := by cases w <;> decide
 
 /-- "stopped smoking" denotes exactly the stopping world (T,F). -/
 theorem stopped_world (w : WorldState) :
-    literalMeaning (some .stopped) w = true ↔ w = .wTF := by cases w <;> decide
+    literalMeaning (some .stopped) w ↔ w = .wTF := by cases w <;> decide
 
 /-- "always smoked" denotes exactly (T,T). -/
 theorem alwaysSmoked_world (w : WorldState) :
-    literalMeaning (some .always) w = true ↔ w = .wTT := by cases w <;> decide
+    literalMeaning (some .always) w ↔ w = .wTT := by cases w <;> decide
 
 /-- "never smoked" denotes exactly (F,F). -/
 theorem neverSmoked_world (w : WorldState) :
-    literalMeaning (some .never) w = true ↔ w = .wFF := by cases w <;> decide
+    literalMeaning (some .never) w ↔ w = .wFF := by cases w <;> decide
 
 /-- Context sets that entail past=T (used for measuring projection). -/
-def entailsPast : ContextSet → Bool
-  | .pastTrue | .pastTrueNowTrue | .pastTrueNowFalse => true
-  | _ => false
+def entailsPast : ContextSet → Prop
+  | .pastTrue | .pastTrueNowTrue | .pastTrueNowFalse => True
+  | _ => False
+
+instance : DecidablePred entailsPast := fun cs => by
+  cases cs <;> first | exact isTrue trivial | exact isFalse id
 
 /-- 3 of 9 context sets entail past=T. -/
 theorem three_entail_past :

--- a/Linglib/Studies/RitchieSchiller2024.lean
+++ b/Linglib/Studies/RitchieSchiller2024.lean
@@ -278,10 +278,14 @@ instance : Fintype Utterance where
   elems := ({Utterance.everyEmpty, Utterance.someEmpty} : Finset Utterance)
   complete := λ x => by cases x <;> simp
 
-/-- Literal meaning under a given DDRP scale (Bool for RSA computation). -/
-def utteranceMeaning (scale : SpatialScale) : Utterance → World → Bool
-  | .everyEmpty, w => decide (everyBottleEmpty scale w)
-  | .someEmpty, w => decide (someBottleEmpty scale w)
+/-- Literal meaning under a given DDRP scale. -/
+def utteranceMeaning (scale : SpatialScale) : Utterance → World → Prop
+  | .everyEmpty, w => everyBottleEmpty scale w
+  | .someEmpty, w => someBottleEmpty scale w
+
+instance (scale : SpatialScale) : ∀ u, DecidablePred (utteranceMeaning scale u)
+  | .everyEmpty, w => inferInstanceAs (Decidable (everyBottleEmpty scale w))
+  | .someEmpty, w => inferInstanceAs (Decidable (someBottleEmpty scale w))
 
 /-- R&S §3.2: Three cognitive heuristics collectively determine which domain
     restrictions are defaults. Each heuristic assigns a relevance score to a
@@ -350,15 +354,15 @@ private theorem ext_nonempty (scale : SpatialScale) (u : Utterance) :
 
 /-- Per-scale literal listener: uniform on the utterance's world extension. -/
 noncomputable def L0 : SpatialScale → Utterance → PMF World :=
-  RSA.Canonical.L0OfBool utteranceMeaning ext_nonempty
+  RSA.Canonical.L0OfPred utteranceMeaning ext_nonempty
 
 private theorem some_always_true (w : World) (l : SpatialScale) :
-    utteranceMeaning l .someEmpty w = true := by
+    utteranceMeaning l .someEmpty w := by
   cases w <;> cases l <;> decide
 
 noncomputable instance : RSA.Canonical.ViableSpeaker (RSA.Canonical.powUtility 1 L0) :=
   RSA.Canonical.viableSpeaker_powUtility_of_witness 1 L0 fun s =>
-    ⟨.someEmpty, RSA.Canonical.L0OfBool_ne_zero utteranceMeaning ext_nonempty
+    ⟨.someEmpty, RSA.Canonical.L0OfPred_ne_zero utteranceMeaning ext_nonempty
       (some_always_true s.1 s.2)⟩
 
 /-- Shared pragmatic speaker `S(w, scale) ∝ L0(w | ·, scale)` (α = 1, no cost). -/
@@ -367,21 +371,21 @@ noncomputable def S : World × SpatialScale → PMF Utterance :=
 
 /-- Unnormalised speaker weight at a true utterance: `|ext(scale, u)|⁻¹`. -/
 private theorem pw_true {l : SpatialScale} {u : Utterance} {w : World} {k : ℕ}
-    (h : utteranceMeaning l u w = true)
+    (h : utteranceMeaning l u w)
     (hk : (RSA.extensionOf (utteranceMeaning l) u).card = k) :
     RSA.Canonical.powWeight 1 L0 (w, l) u = ENNReal.ofReal (k : ℝ)⁻¹ := by
   have hpos : 0 < k := hk ▸ Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
   simp only [L0]
-  rw [RSA.Canonical.powWeight_L0OfBool_of_mem utteranceMeaning ext_nonempty k h hk, pow_one,
+  rw [RSA.Canonical.powWeight_L0OfPred_of_mem utteranceMeaning ext_nonempty k h hk, pow_one,
     ENNReal.ofReal_inv_of_pos (by exact_mod_cast hpos), ENNReal.ofReal_natCast]
 
 private theorem pw_false {l : SpatialScale} {u : Utterance} {w : World}
-    (h : utteranceMeaning l u w = false) :
+    (h : ¬ utteranceMeaning l u w) :
     RSA.Canonical.powWeight 1 L0 (w, l) u = ENNReal.ofReal 0 := by
   rw [ENNReal.ofReal_zero]
   simp only [L0]
-  exact RSA.Canonical.powWeight_L0OfBool_of_not_mem utteranceMeaning ext_nonempty
-    one_ne_zero (by rw [h]; decide)
+  exact RSA.Canonical.powWeight_L0OfPred_of_not_mem utteranceMeaning ext_nonempty
+    one_ne_zero h
 
 private theorem sumU (f : Utterance → ℝ≥0∞) :
     ∑' u, f u = f .everyEmpty + f .someEmpty := by
@@ -391,7 +395,7 @@ private theorem sumU (f : Utterance → ℝ≥0∞) :
 
 /-- Normalised speaker mass at a true utterance, as an exact rational. -/
 private theorem S_val {l : SpatialScale} {u : Utterance} {w : World} {k : ℕ} {z q : ℝ}
-    (h : utteranceMeaning l u w = true)
+    (h : utteranceMeaning l u w)
     (hk : (RSA.extensionOf (utteranceMeaning l) u).card = k) (hz : 0 < z)
     (hZ : (∑' u', RSA.Canonical.powWeight 1 L0 (w, l) u') = ENNReal.ofReal z)
     (hq : (k : ℝ)⁻¹ / z = q) :
@@ -402,14 +406,14 @@ private theorem S_val {l : SpatialScale} {u : Utterance} {w : World} {k : ℕ} {
 
 /-- Normalised speaker mass at a false utterance: `0`. -/
 private theorem S_zero {l : SpatialScale} {u : Utterance} {w : World}
-    (h : utteranceMeaning l u w = false) : S (w, l) u = 0 := by
+    (h : ¬ utteranceMeaning l u w) : S (w, l) u = 0 := by
   unfold S
   rw [RSA.Canonical.S1_powUtility_eq_normalize, PMF.normalize_apply, pw_false h,
     ENNReal.ofReal_zero, zero_mul]
 
 /-- The speaker never assigns zero mass to a true utterance. -/
 private theorem S_ne_zero {l : SpatialScale} {u : Utterance} {w : World}
-    (h : utteranceMeaning l u w = true) : S (w, l) u ≠ 0 := by
+    (h : utteranceMeaning l u w) : S (w, l) u ≠ 0 := by
   have hpos : 0 < (RSA.extensionOf (utteranceMeaning l) u).card :=
     Finset.card_pos.mpr ⟨w, RSA.mem_extensionOf.mpr h⟩
   unfold S

--- a/Linglib/Studies/ScontrasPearl2021.lean
+++ b/Linglib/Studies/ScontrasPearl2021.lean
@@ -326,9 +326,13 @@ def Latent.qud : Latent → QUD
 
 /-- RSA meaning derived from `scopeTruth`.
     Null utterance is always true (uninformative baseline). -/
-def uttMeaning : ScopeReading → Utt → JumpOutcome → Bool
-  | _, .null, _ => true
-  | s, .everyNot, w => scopeTruth s w
+def uttMeaning (s : ScopeReading) : Utt → JumpOutcome → Prop
+  | .null, _ => True
+  | .everyNot, w => scopeTruth s w = true
+
+instance (s : ScopeReading) : ∀ u, DecidablePred (uttMeaning s u)
+  | .null, _ => isTrue trivial
+  | .everyNot, w => inferInstanceAs (Decidable (scopeTruth s w = true))
 
 /-- 2-horse domain for grounding truth conditions in quantifier semantics. -/
 inductive Horse where | h1 | h2 deriving DecidableEq
@@ -415,7 +419,7 @@ theorem scopeDerivation_matches_scopeTruth :
     by the RSA config matches the compositional scope derivation. -/
 theorem rsa_meaning_from_scope_derivation :
     ∀ (lat : Latent) (w : JumpOutcome),
-    (uttMeaning lat.scope .everyNot w = true) ↔
+    uttMeaning lat.scope .everyNot w ↔
     (everyHorseDidntJump w).meaningAt (readingToScopeConfig lat.scope) := by
   intro lat w; cases lat <;>
     simp only [Latent.scope, readingToScopeConfig, everyHorseDidntJump, uttMeaning, scopeTruth]
@@ -582,11 +586,11 @@ noncomputable def worldPrior : PMF JumpOutcome := PMF.uniformOfFintype JumpOutco
 theorem worldPrior_ne_zero (w : JumpOutcome) : worldPrior w ≠ 0 :=
   (worldPrior.mem_support_iff w).mp (PMF.mem_support_uniformOfFintype w)
 
-/-! #### L0 as `RSA.L0OfBoolMeaning`
+/-! #### L0 as `RSA.L0OfPred`
 
-`uttMeaning lat.scope u w` is `Bool`-valued, so L0 is uniform on the
-extension. Each scope reading induces its own L0 distribution (the meaning
-function's first argument is `ScopeReading`, not just `Utt`). -/
+`uttMeaning lat.scope u` is a decidable predicate over worlds, so L0 is
+uniform on the extension. Each scope reading induces its own L0 distribution
+(the meaning function's first argument is `ScopeReading`, not just `Utt`). -/
 
 /-- Extension of `uttMeaning s u`: the worlds where `u` is true under scope `s`. -/
 abbrev extension (s : ScopeReading) (u : Utt) : Finset JumpOutcome :=
@@ -597,25 +601,25 @@ theorem extension_nonempty (s : ScopeReading) (u : Utt) : (extension s u).Nonemp
   -- both surface and inverse readings of everyNot are true at `.zero`.
   refine ⟨.zero, ?_⟩
   rw [RSA.mem_extensionOf]
-  cases s <;> cases u <;> rfl
+  cases s <;> cases u <;> trivial
 
 /-- Literal listener: uniform on the extension of `uttMeaning lat.scope u`. -/
 noncomputable def L0 (s : ScopeReading) (u : Utt) : PMF JumpOutcome :=
-  RSA.L0OfBoolMeaning (uttMeaning s) u (extension_nonempty s u)
+  RSA.L0OfPred (uttMeaning s) u (extension_nonempty s u)
 
 @[simp] theorem mem_support_L0_iff (s : ScopeReading) (u : Utt) (w : JumpOutcome) :
-    w ∈ (L0 s u).support ↔ uttMeaning s u w = true :=
-  RSA.mem_support_L0OfBoolMeaning_iff _ _
+    w ∈ (L0 s u).support ↔ uttMeaning s u w :=
+  RSA.mem_support_L0OfPred_iff _ _
 
 theorem L0_apply_of_true {s : ScopeReading} {u : Utt} {w : JumpOutcome}
-    (h : uttMeaning s u w = true) :
+    (h : uttMeaning s u w) :
     L0 s u w = ((extension s u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+  RSA.L0OfPred_apply_of_mem _ h
 
 theorem L0_apply_of_false {s : ScopeReading} {u : Utt} {w : JumpOutcome}
-    (h : uttMeaning s u w ≠ true) :
+    (h : ¬ uttMeaning s u w) :
     L0 s u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+  RSA.L0OfPred_apply_of_not_mem _ h
 
 /-! #### QUD projection facts on ℝ≥0∞ -/
 
@@ -659,7 +663,7 @@ noncomputable def s1Weight (α : ℝ) (lat : Latent) (w : JumpOutcome) (u : Utt)
 theorem L0_null_ne_zero (s : ScopeReading) (w : JumpOutcome) :
     L0 s .null w ≠ 0 := by
   rw [← PMF.mem_support_iff, mem_support_L0_iff]
-  cases s <;> rfl
+  trivial
 
 theorem s1Weight_null_ne_zero {α : ℝ} (hα : 0 < α) (lat : Latent) (w : JumpOutcome) :
     s1Weight α lat w .null ≠ 0 := by
@@ -784,14 +788,14 @@ Structurally generic: constructs cover witnesses for universal-extension
 utterances. -/
 theorem extension_null_eq_univ (s : ScopeReading) :
     extension s .null = Finset.univ := by
-  ext w; simp [extension, RSA.mem_extensionOf]; cases s <;> cases w <;> rfl
+  ext w; simp [extension, RSA.mem_extensionOf, uttMeaning]
 
 /-! L0 values at each (scope, utterance, world) — the leaves every
 comparison below reduces to. -/
 
 private lemma L0_null_apply (sc : ScopeReading) (w : JumpOutcome) :
     L0 sc .null w = (3 : ℝ≥0∞)⁻¹ := by
-  rw [L0_apply_of_true (by cases sc <;> rfl), extension_null_eq_univ]; rfl
+  rw [L0_apply_of_true (show uttMeaning sc .null w from trivial), extension_null_eq_univ]; rfl
 
 private lemma L0_surf_en : ∀ w, L0 .surface .everyNot w =
     if w = .zero then 1 else 0
@@ -867,8 +871,7 @@ theorem S1g_zero_gt_one_for_some_latent {α : ℝ} (hα : 0 < α) :
       refine ENNReal.rpow_le_rpow ?_ hα.le
       show qProj .none_ (fun w' => L0 .inverse u w') .zero ≤
            qProj .none_ (fun w' => L0 .inverse u w') .one
-      cases u <;> simp [qProj, L0_null_apply, L0_inv_en] <;>
-        exact le_self_add
+      cases u <;> simp [qProj, L0_null_apply, L0_inv_en]
 
 /-- Baseline L1 ordering `L1(zero | everyNot) > L1(one | everyNot)` for
 every α > 0: cancel the marginal and the uniform world prior, then compare
@@ -1084,9 +1087,13 @@ def Latent10.qud : Latent10 → QUD5
 
 /-- RSA meaning for the two-not model, parameterized by numeral reading.
     Null utterance is always true (uninformative baseline). -/
-def uttMeaning (nr : NumeralReading) : ScopeReading → Utt → JumpOutcome4 → Bool
-  | _, .null, _ => true
-  | s, .twoNot, w => twoNotTruth nr s w
+def uttMeaning (nr : NumeralReading) (s : ScopeReading) : Utt → JumpOutcome4 → Prop
+  | .null, _ => True
+  | .twoNot, w => twoNotTruth nr s w = true
+
+instance (nr : NumeralReading) (s : ScopeReading) : ∀ u, DecidablePred (uttMeaning nr s u)
+  | .null, _ => isTrue trivial
+  | .twoNot, w => inferInstanceAs (Decidable (twoNotTruth nr s w = true))
 
 open Intensional (Denot)
 open Quantification (exactly_n_sem at_least_n_sem)
@@ -1240,11 +1247,11 @@ theorem exact_vs_atleast_endorsement : s2 .atLeast .w2 .twoNot < s2 .exact .w2 .
     has exactly 1 true world (w2), while under at-least it has 3 (w0–w2).
     This drives the endorsement difference via S1 informativity. -/
 theorem exact_surface_singleton :
-    (List.filter (uttMeaning .exact .surface .twoNot) [.w0, .w1, .w2, .w3, .w4]).length = 1 := by
+    (Finset.univ.filter (uttMeaning .exact .surface .twoNot)).card = 1 := by
   decide
 
 theorem atLeast_surface_triple :
-    (List.filter (uttMeaning .atLeast .surface .twoNot) [.w0, .w1, .w2, .w3, .w4]).length = 3 := by
+    (Finset.univ.filter (uttMeaning .atLeast .surface .twoNot)).card = 3 := by
   decide
 
 /-- Exact inverse has 4 true worlds (w0,w1,w3,w4) — very uninformative.
@@ -1252,13 +1259,13 @@ theorem atLeast_surface_triple :
     contributes nothing at w2 (it's false there), explaining why surface
     scope dominates the S2 prediction under exact semantics. -/
 theorem exact_inverse_quad :
-    (List.filter (uttMeaning .exact .inverse .twoNot) [.w0, .w1, .w2, .w3, .w4]).length = 4 := by
+    (Finset.univ.filter (uttMeaning .exact .inverse .twoNot)).card = 4 := by
   decide
 
 /-- At-least inverse has 2 true worlds (w0,w1) — more informative than
     exact inverse's 4, but still less informative than exact surface's 1. -/
 theorem atLeast_inverse_double :
-    (List.filter (uttMeaning .atLeast .inverse .twoNot) [.w0, .w1, .w2, .w3, .w4]).length = 2 := by
+    (Finset.univ.filter (uttMeaning .atLeast .inverse .twoNot)).card = 2 := by
   decide
 
 /-! ### The structural face: exact-vs-at-least necessity (§4.2.2)
@@ -1310,7 +1317,7 @@ theorem extension4_nonempty (nr : NumeralReading) (s : ScopeReading) (u : TwoNot
   -- For `null`: w0 always works (null is universally true).
   -- For `twoNot`: case split — exact surface is true ONLY at w2; other cases have w0.
   cases u
-  case null => exact ⟨.w0, by rw [RSA.mem_extensionOf]; cases nr <;> cases s <;> rfl⟩
+  case null => exact ⟨.w0, by rw [RSA.mem_extensionOf]; trivial⟩
   case twoNot =>
     cases nr <;> cases s
     case exact.surface => exact ⟨.w2, by rw [RSA.mem_extensionOf]; rfl⟩
@@ -1326,17 +1333,17 @@ extension's cardinality. -/
 /-- TwoNot literal listener: uniform on extension under given numeral reading. -/
 noncomputable def L0_4 (nr : NumeralReading) (s : ScopeReading) (u : TwoNot.Utt) :
     PMF JumpOutcome4 :=
-  RSA.L0OfBoolMeaning (TwoNot.uttMeaning nr s) u (extension4_nonempty nr s u)
+  RSA.L0OfPred (TwoNot.uttMeaning nr s) u (extension4_nonempty nr s u)
 
 theorem L0_4_apply_of_true {nr : NumeralReading} {s : ScopeReading} {u : TwoNot.Utt}
-    {w : JumpOutcome4} (h : TwoNot.uttMeaning nr s u w = true) :
+    {w : JumpOutcome4} (h : TwoNot.uttMeaning nr s u w) :
     L0_4 nr s u w = ((extension4 nr s u).card : ℝ≥0∞)⁻¹ :=
-  RSA.L0OfBoolMeaning_apply_of_mem _ h
+  RSA.L0OfPred_apply_of_mem _ h
 
 theorem L0_4_apply_of_false {nr : NumeralReading} {s : ScopeReading} {u : TwoNot.Utt}
-    {w : JumpOutcome4} (h : TwoNot.uttMeaning nr s u w ≠ true) :
+    {w : JumpOutcome4} (h : ¬ TwoNot.uttMeaning nr s u w) :
     L0_4 nr s u w = 0 :=
-  RSA.L0OfBoolMeaning_apply_of_not_mem _ h
+  RSA.L0OfPred_apply_of_not_mem _ h
 
 /-! #### The L0 concentration contrast
 
@@ -1357,8 +1364,8 @@ under at-least, the L0 dilutes across 3 worlds → less informative → lower
 S2 endorsement. The structural mechanism behind paper's Figure 7. -/
 theorem L0_exact_gt_atLeast_at_w2 :
     L0_4 .atLeast .surface .twoNot .w2 < L0_4 .exact .surface .twoNot .w2 := by
-  rw [L0_4_apply_of_true (by decide : TwoNot.uttMeaning .exact .surface .twoNot .w2 = true),
-      L0_4_apply_of_true (by decide : TwoNot.uttMeaning .atLeast .surface .twoNot .w2 = true),
+  rw [L0_4_apply_of_true (by decide : TwoNot.uttMeaning .exact .surface .twoNot .w2),
+      L0_4_apply_of_true (by decide : TwoNot.uttMeaning .atLeast .surface .twoNot .w2),
       extension4_exact_surface_twoNot, extension4_atLeast_surface_twoNot]
   -- Goal: ((Finset.card {w0, w1, w2} : ℕ) : ℝ≥0∞)⁻¹ < ((Finset.card {w2} : ℕ) : ℝ≥0∞)⁻¹
   -- = (3 : ℝ≥0∞)⁻¹ < (1 : ℝ≥0∞)⁻¹ = 1
@@ -1382,8 +1389,8 @@ L0 is positive (surface twoNot true). -/
 theorem L0_exact_zero_atLeast_pos_at_w0 :
     L0_4 .exact .surface .twoNot .w0 = 0 ∧ L0_4 .atLeast .surface .twoNot .w0 ≠ 0 := by
   refine ⟨?_, ?_⟩
-  · exact L0_4_apply_of_false (by decide : TwoNot.uttMeaning .exact .surface .twoNot .w0 ≠ true)
-  · rw [L0_4_apply_of_true (by decide : TwoNot.uttMeaning .atLeast .surface .twoNot .w0 = true),
+  · exact L0_4_apply_of_false (by decide : ¬ TwoNot.uttMeaning .exact .surface .twoNot .w0)
+  · rw [L0_4_apply_of_true (by decide : TwoNot.uttMeaning .atLeast .surface .twoNot .w0),
         extension4_atLeast_surface_twoNot]
     -- Goal: ((Finset.card {w0, w1, w2} : ℕ) : ℝ≥0∞)⁻¹ ≠ 0
     -- = (3 : ℝ≥0∞)⁻¹ ≠ 0; true since 3 ≠ ⊤

--- a/Linglib/Studies/TesslerFranke2020PMF.lean
+++ b/Linglib/Studies/TesslerFranke2020PMF.lean
@@ -62,16 +62,20 @@ abbrev NegLexicon := NegationType
 /-- Utterance meaning parameterized by thresholds and lexicon, grounded in
 shared `Degree` predicates. -/
 def utteranceMeaning (θ₁ θ₂ : HThreshold) (L : NegLexicon)
-    (u : Utterance) (d : HappinessDeg) : Bool :=
+    (u : Utterance) (d : HappinessDeg) : Prop :=
   match u with
   | .happy => positiveMeaning d θ₁
-  | .notHappy => !positiveMeaning d θ₁
+  | .notHappy => ¬ positiveMeaning d θ₁
   | .unhappy => match L with
     | .contrary => negativeMeaning d θ₂
-    | .contradictory => !positiveMeaning d θ₁
+    | .contradictory => ¬ positiveMeaning d θ₁
   | .notUnhappy => match L with
-    | .contrary => !negativeMeaning d θ₂
+    | .contrary => ¬ negativeMeaning d θ₂
     | .contradictory => positiveMeaning d θ₁
+
+instance (θ₁ θ₂ : HThreshold) (L : NegLexicon) (u : Utterance) :
+    DecidablePred (utteranceMeaning θ₁ θ₂ L u) := fun d => by
+  unfold utteranceMeaning; cases u <;> cases L <;> infer_instance
 
 /-- Utterance cost (morphological complexity): `C(un-) = 2`, `C(not) = 3`,
 combined additively. -/
@@ -86,10 +90,10 @@ instance : Nonempty HappinessDeg := ⟨deg 0⟩
 instance : Nonempty Utterance := ⟨.happy⟩
 instance : Nonempty LatentState := ⟨(thr 0, thr 0, .contrary)⟩
 
-/-! ## §1. L0 — uniform on extension via `RSA.L0OfBoolMeaning` -/
+/-! ## §1. L0 — uniform on extension via `RSA.L0OfPred` -/
 
 /-- Lexicon as a function from latent state. -/
-abbrev meaningAt (l : LatentState) : Utterance → HappinessDeg → Bool :=
+abbrev meaningAt (l : LatentState) : Utterance → HappinessDeg → Prop :=
   utteranceMeaning l.1 l.2.1 l.2.2
 
 /-- Extension of `meaningAt l u`. -/

--- a/Linglib/Studies/Warstadt2022.lean
+++ b/Linglib/Studies/Warstadt2022.lean
@@ -84,29 +84,41 @@ instance : Fintype GCQUD where
   complete := λ q => by cases q <;> simp
 
 /-- Truth conditions from Table 1. All negations are Boolean. -/
-def gcAssertionMeaning : GCAssertion → GCWorld → Bool
-  | .us, .usCitizen => true
-  | .us, _ => false
-  | .notUS, .usCitizen => false
-  | .notUS, _ => true
-  | .greenCard, .gcHolder => true
-  | .greenCard, _ => false
-  | .notGreenCard, .gcHolder => false
-  | .notGreenCard, _ => true
+def gcAssertionMeaning : GCAssertion → GCWorld → Prop
+  | .us, .usCitizen => True
+  | .us, _ => False
+  | .notUS, .usCitizen => False
+  | .notUS, _ => True
+  | .greenCard, .gcHolder => True
+  | .greenCard, _ => False
+  | .notGreenCard, .gcHolder => False
+  | .notGreenCard, _ => True
+
+instance (a : GCAssertion) : DecidablePred (gcAssertionMeaning a) := fun w => by
+  cases a <;> cases w <;> first | exact isTrue trivial | exact isFalse id
 
 /-- Utterance-level meaning: silence is universally true. -/
-def gcMeaning : GCUtterance → GCWorld → Bool := liftMeaning gcAssertionMeaning
+def gcMeaning : GCUtterance → GCWorld → Prop := liftMeaning gcAssertionMeaning
+
+instance : ∀ u : GCUtterance, DecidablePred (gcMeaning u) :=
+  inferInstanceAs (∀ u, DecidablePred (liftMeaning gcAssertionMeaning u))
 
 /-- QUD answer function: maps each QUD to a world's answer. -/
-def gcQUDAnswer : GCQUD → GCWorld → Bool
-  | .needVisa, .nonUS => true
-  | .needVisa, _ => false
-  | .freeDrink, .gcHolder => true
-  | .freeDrink, _ => false
+def gcQUDAnswer : GCQUD → GCWorld → Prop
+  | .needVisa, .nonUS => True
+  | .needVisa, _ => False
+  | .freeDrink, .gcHolder => True
+  | .freeDrink, _ => False
+
+instance (q : GCQUD) : DecidablePred (gcQUDAnswer q) := fun w => by
+  cases q <;> cases w <;> first | exact isTrue trivial | exact isFalse id
 
 /-- QUD projection: two worlds are equivalent iff they give the same QUD answer. -/
-def gcQUDProject (q : GCQUD) (w1 w2 : GCWorld) : Bool :=
-  gcQUDAnswer q w1 == gcQUDAnswer q w2
+def gcQUDProject (q : GCQUD) (w1 w2 : GCWorld) : Prop :=
+  gcQUDAnswer q w1 ↔ gcQUDAnswer q w2
+
+instance (q : GCQUD) (w1 w2 : GCWorld) : Decidable (gcQUDProject q w1 w2) :=
+  inferInstanceAs (Decidable (_ ↔ _))
 
 /-- Uniform world prior. -/
 def gcWorldPrior (_w : GCWorld) : ℚ := 1 / 3
@@ -120,32 +132,33 @@ def greenCardPartialProp : PartialProp GCWorld where
   presup := λ w => match w with | .usCitizen => False | _ => True
   assertion := λ w => match w with | .gcHolder => True | _ => False
 
-/-- The Boolean meaning of "green card" decomposes as presupposition ∧ assertion. -/
-theorem gcMeaning_greenCard_eq_prprop (w : GCWorld) :
-    (gcMeaning (some .greenCard) w = true) ↔ (greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w) := by
+/-- The meaning of "green card" decomposes as presupposition ∧ assertion. -/
+theorem gcMeaning_greenCard_iff_prprop (w : GCWorld) :
+    gcMeaning (some .greenCard) w ↔
+      greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w := by
   cases w <;> simp [gcMeaning, gcAssertionMeaning, greenCardPartialProp]
 
 /-- "not green card" is Boolean negation of "green card". -/
-theorem gcMeaning_notGreenCard_eq_neg (w : GCWorld) :
-    gcMeaning (some .notGreenCard) w = !gcMeaning (some .greenCard) w := by
-  cases w <;> rfl
+theorem gcMeaning_notGreenCard_iff_not (w : GCWorld) :
+    gcMeaning (some .notGreenCard) w ↔ ¬ gcMeaning (some .greenCard) w := by
+  cases w <;> decide
 
 /-- "not US" is Boolean negation of "US". -/
-theorem gcMeaning_notUS_eq_neg (w : GCWorld) :
-    gcMeaning (some .notUS) w = !gcMeaning (some .us) w := by
-  cases w <;> rfl
+theorem gcMeaning_notUS_iff_not (w : GCWorld) :
+    gcMeaning (some .notUS) w ↔ ¬ gcMeaning (some .us) w := by
+  cases w <;> decide
 
 /-- needVisa QUD partition: {usCitizen, gcHolder} (no) vs {nonUS} (yes). -/
 theorem gcQUD_needVisa_partition :
-    gcQUDProject .needVisa .usCitizen .gcHolder = true ∧
-    gcQUDProject .needVisa .usCitizen .nonUS = false := by
-  exact ⟨rfl, rfl⟩
+    gcQUDProject .needVisa .usCitizen .gcHolder ∧
+    ¬ gcQUDProject .needVisa .usCitizen .nonUS := by
+  decide
 
 /-- freeDrink QUD partition: {usCitizen, nonUS} (no) vs {gcHolder} (yes). -/
 theorem gcQUD_freeDrink_partition :
-    gcQUDProject .freeDrink .usCitizen .nonUS = true ∧
-    gcQUDProject .freeDrink .usCitizen .gcHolder = false := by
-  exact ⟨rfl, rfl⟩
+    gcQUDProject .freeDrink .usCitizen .nonUS ∧
+    ¬ gcQUDProject .freeDrink .usCitizen .gcHolder := by
+  decide
 
 
 /-! ## Family-Genus-Species Example (Table 2) -/
@@ -195,24 +208,30 @@ def allFGSUtterances : List FGSUtterance :=
 /-- Truth conditions from Table 2.
 
 Respects the taxonomic hierarchy: Olympic sprinter ⊂ runner ⊂ athlete. -/
-def fgsAssertionMeaning : FGSAssertion → FGSWorld → Bool
-  | .olympicSprinter, .olympicSprinter => true
-  | .olympicSprinter, _ => false
-  | .notOlympicSprinter, .olympicSprinter => false
-  | .notOlympicSprinter, _ => true
-  | .runner, .olympicSprinter => true
-  | .runner, .runner => true
-  | .runner, _ => false
-  | .notRunner, .olympicSprinter => false
-  | .notRunner, .runner => false
-  | .notRunner, _ => true
-  | .athlete, .nonAthlete => false
-  | .athlete, _ => true
-  | .notAthlete, .nonAthlete => true
-  | .notAthlete, _ => false
+def fgsAssertionMeaning : FGSAssertion → FGSWorld → Prop
+  | .olympicSprinter, .olympicSprinter => True
+  | .olympicSprinter, _ => False
+  | .notOlympicSprinter, .olympicSprinter => False
+  | .notOlympicSprinter, _ => True
+  | .runner, .olympicSprinter => True
+  | .runner, .runner => True
+  | .runner, _ => False
+  | .notRunner, .olympicSprinter => False
+  | .notRunner, .runner => False
+  | .notRunner, _ => True
+  | .athlete, .nonAthlete => False
+  | .athlete, _ => True
+  | .notAthlete, .nonAthlete => True
+  | .notAthlete, _ => False
+
+instance (a : FGSAssertion) : DecidablePred (fgsAssertionMeaning a) := fun w => by
+  cases a <;> cases w <;> first | exact isTrue trivial | exact isFalse id
 
 /-- Utterance-level meaning: silence is universally true. -/
-def fgsMeaning : FGSUtterance → FGSWorld → Bool := liftMeaning fgsAssertionMeaning
+def fgsMeaning : FGSUtterance → FGSWorld → Prop := liftMeaning fgsAssertionMeaning
+
+instance : ∀ u : FGSUtterance, DecidablePred (fgsMeaning u) :=
+  inferInstanceAs (∀ u, DecidablePred (liftMeaning fgsAssertionMeaning u))
 
 /-- Non-uniform world prior from Table 2 (percentages). -/
 def fgsWorldPrior : FGSWorld → ℚ
@@ -222,45 +241,48 @@ def fgsWorldPrior : FGSWorld → ℚ
   | .nonAthlete => 84 / 100
 
 /-- Max QUD (full world identification). -/
-def fgsQUDProject (w1 w2 : FGSWorld) : Bool := w1 == w2
+def fgsQUDProject (w1 w2 : FGSWorld) : Prop := w1 = w2
+
+instance (w1 w2 : FGSWorld) : Decidable (fgsQUDProject w1 w2) :=
+  inferInstanceAs (Decidable (w1 = w2))
 
 -- Genus-species hierarchy verification
 
 /-- Olympic sprinter entails runner. -/
 theorem olympicSprinter_entails_runner (w : FGSWorld) :
-    fgsMeaning (some .olympicSprinter) w = true → fgsMeaning (some .runner) w = true := by
-  cases w <;> simp [fgsMeaning, fgsAssertionMeaning]
+    fgsMeaning (some .olympicSprinter) w → fgsMeaning (some .runner) w := by
+  cases w <;> decide
 
 /-- Runner entails athlete. -/
 theorem runner_entails_athlete (w : FGSWorld) :
-    fgsMeaning (some .runner) w = true → fgsMeaning (some .athlete) w = true := by
-  cases w <;> simp [fgsMeaning, fgsAssertionMeaning]
+    fgsMeaning (some .runner) w → fgsMeaning (some .athlete) w := by
+  cases w <;> decide
 
 /-- Olympic sprinter entails athlete (transitivity). -/
 theorem olympicSprinter_entails_athlete (w : FGSWorld) :
-    fgsMeaning (some .olympicSprinter) w = true → fgsMeaning (some .athlete) w = true := by
-  cases w <;> simp [fgsMeaning, fgsAssertionMeaning]
+    fgsMeaning (some .olympicSprinter) w → fgsMeaning (some .athlete) w := by
+  cases w <;> decide
 
 /-- Boolean negation: not Olympic sprinter = ¬ Olympic sprinter. -/
-theorem fgsMeaning_notOS_eq_neg (w : FGSWorld) :
-    fgsMeaning (some .notOlympicSprinter) w = !fgsMeaning (some .olympicSprinter) w := by
-  cases w <;> rfl
+theorem fgsMeaning_notOS_iff_not (w : FGSWorld) :
+    fgsMeaning (some .notOlympicSprinter) w ↔ ¬ fgsMeaning (some .olympicSprinter) w := by
+  cases w <;> decide
 
 /-- Boolean negation: not runner = ¬ runner. -/
-theorem fgsMeaning_notRunner_eq_neg (w : FGSWorld) :
-    fgsMeaning (some .notRunner) w = !fgsMeaning (some .runner) w := by
-  cases w <;> rfl
+theorem fgsMeaning_notRunner_iff_not (w : FGSWorld) :
+    fgsMeaning (some .notRunner) w ↔ ¬ fgsMeaning (some .runner) w := by
+  cases w <;> decide
 
 /-- Boolean negation: not athlete = ¬ athlete. -/
-theorem fgsMeaning_notAthlete_eq_neg (w : FGSWorld) :
-    fgsMeaning (some .notAthlete) w = !fgsMeaning (some .athlete) w := by
-  cases w <;> rfl
+theorem fgsMeaning_notAthlete_iff_not (w : FGSWorld) :
+    fgsMeaning (some .notAthlete) w ↔ ¬ fgsMeaning (some .athlete) w := by
+  cases w <;> decide
 
 /-- FGS priors sum to 1. -/
 theorem fgsWorldPrior_sum :
     fgsWorldPrior .olympicSprinter + fgsWorldPrior .runner +
     fgsWorldPrior .otherAthlete + fgsWorldPrior .nonAthlete = 1 := by
-  native_decide
+  norm_num [fgsWorldPrior]
 
 -- ============================================================================
 -- Part II: RSA Context Types and PartialProp Connection
@@ -286,11 +308,14 @@ def allGCContexts : List GCContext :=
 theorem allGCContexts_length : allGCContexts.length = 8 := rfl
 
 /-- A world is compatible with a context iff the context includes it. -/
-def gcCompatible (c : GCContext) (w : GCWorld) : Bool :=
+def gcCompatible (c : GCContext) (w : GCWorld) : Prop :=
   match w with
   | .usCitizen => c.usCitizen
   | .gcHolder => c.gcHolder
   | .nonUS => c.nonUS
+
+instance (c : GCContext) : DecidablePred (gcCompatible c) := fun w => by
+  cases w <;> exact inferInstanceAs (Decidable (_ = true))
 
 def gcContextPrior (_c : GCContext) : ℚ := 1 / 8
 
@@ -314,12 +339,15 @@ def allFGSContexts : List FGSContext :=
 
 theorem allFGSContexts_length : allFGSContexts.length = 16 := rfl
 
-def fgsCompatible (c : FGSContext) (w : FGSWorld) : Bool :=
+def fgsCompatible (c : FGSContext) (w : FGSWorld) : Prop :=
   match w with
   | .olympicSprinter => c.olympicSprinter
   | .runner => c.runner
   | .otherAthlete => c.otherAthlete
   | .nonAthlete => c.nonAthlete
+
+instance (c : FGSContext) : DecidablePred (fgsCompatible c) := fun w => by
+  cases w <;> exact inferInstanceAs (Decidable (_ = true))
 
 def fgsContextPrior (_c : FGSContext) : ℚ := 1 / 16
 
@@ -329,20 +357,24 @@ inductive FGSQUD where
 
 def allFGSQUDs : List FGSQUD := [.identity]
 
-def fgsQUDProjectBridge : FGSQUD → FGSWorld → FGSWorld → Bool
+def fgsQUDProjectBridge : FGSQUD → FGSWorld → FGSWorld → Prop
   | .identity, w1, w2 => fgsQUDProject w1 w2
+
+instance (q : FGSQUD) (w1 w2 : FGSWorld) : Decidable (fgsQUDProjectBridge q w1 w2) :=
+  match q with
+  | .identity => inferInstanceAs (Decidable (fgsQUDProject w1 w2))
 
 /-! ## PartialProp Connection -/
 
-/-- The Boolean meaning of "green card" decomposes as presupposition ∧ assertion. -/
+/-- The meaning of "green card" decomposes as presupposition ∧ assertion. -/
 theorem greenCard_meaning_from_prprop (w : GCWorld) :
-    (gcMeaning (some .greenCard) w = true) ↔
-    (greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w) :=
-  gcMeaning_greenCard_eq_prprop w
+    gcMeaning (some .greenCard) w ↔
+      greenCardPartialProp.presup w ∧ greenCardPartialProp.assertion w :=
+  gcMeaning_greenCard_iff_prprop w
 
 /-- "not green card" is Boolean negation — no presupposition in the semantics. -/
 theorem notGreenCard_is_boolean_negation (w : GCWorld) :
-    gcMeaning (some .notGreenCard) w = !gcMeaning (some .greenCard) w :=
-  gcMeaning_notGreenCard_eq_neg w
+    gcMeaning (some .notGreenCard) w ↔ ¬ gcMeaning (some .greenCard) w :=
+  gcMeaning_notGreenCard_iff_not w
 
 end Warstadt2022


### PR DESCRIPTION
Migrates the RSA meaning API from `Bool` to `Prop` + `DecidablePred` (`extensionOf`, `L0OfBoolMeaning` → `L0OfPred`, `liftMeaning`; `boolWeight/boolPartition/boolS1` → `ratWeight/ratPartition/ratS1`) and all 14 consumer studies with it.

- FrankeBergen2020 additionally gets the mathlib-shaped domain: `World` as nonempty `Finset SomeAllWorld` subtype, `Parse := Finset ExhPosition`, one quantifier evaluator with the notAll/none dualities derived (`Iff.rfl`) instead of hand-transcribed, Table 1 rows as membership characterizations
- replaces a pre-existing `native_decide` in Warstadt2022 with `norm_num`