### PR TITLE
refactor(Core/Probability): Prop events in the ofScores marginal API

### DIFF
--- a/Linglib/Core/Probability/Scores.lean
+++ b/Linglib/Core/Probability/Scores.lean
@@ -267,17 +267,19 @@ theorem prod_ofScores_lt {ι : Type*} (s : Finset ι) (fb₁ fb₂ : ι → Fall
 /-! ### Event marginals -/
 
 /-- Mass of a decidable event under a `ℚ≥0` weight vector. -/
-def eventMass (g : σ → ℚ≥0) (P : σ → Bool) : ℚ≥0 :=
+def eventMass (g : σ → ℚ≥0) (P : σ → Prop) [DecidablePred P] : ℚ≥0 :=
   ∑ x, if P x then g x else 0
 
-theorem ofScores_event_eq (fb : Fallback σ) (f : σ → ℚ≥0) (P : σ → Bool) :
+theorem ofScores_event_eq (fb : Fallback σ) (f : σ → ℚ≥0) (P : σ → Prop)
+    [DecidablePred P] :
     (∑' x, if P x then ofScores fb f x else 0)
       = ((eventMass (scoresWith fb f) P : ℝ≥0) : ℝ≥0∞) := by
   rw [tsum_fintype, eventMass, NNRat.cast_sum, ENNReal.ofNNReal_finsetSum]
   exact Finset.sum_congr rfl fun x _ => by
     by_cases h : P x <;> simp [h, ofScores_apply]
 
-theorem ofScores_event_lt (fb : Fallback σ) (f : σ → ℚ≥0) {P Q : σ → Bool}
+theorem ofScores_event_lt (fb : Fallback σ) (f : σ → ℚ≥0) {P Q : σ → Prop}
+    [DecidablePred P] [DecidablePred Q]
     (h : eventMass (scoresWith fb f) P < eventMass (scoresWith fb f) Q) :
     (∑' x, if P x then ofScores fb f x else 0)
       < ∑' x, if Q x then ofScores fb f x else 0 := by
@@ -286,7 +288,7 @@ theorem ofScores_event_lt (fb : Fallback σ) (f : σ → ℚ≥0) {P Q : σ → 
 
 theorem ofScores_event_lt_cross {τ : Type*} [Fintype τ]
     (fb₁ : Fallback σ) (fb₂ : Fallback τ) (f : σ → ℚ≥0) (g : τ → ℚ≥0)
-    {P : σ → Bool} {Q : τ → Bool}
+    {P : σ → Prop} {Q : τ → Prop} [DecidablePred P] [DecidablePred Q]
     (h : eventMass (scoresWith fb₁ f) P < eventMass (scoresWith fb₂ g) Q) :
     (∑' x, if P x then ofScores fb₁ f x else 0)
       < ∑' y, if Q y then ofScores fb₂ g y else 0 := by
@@ -296,7 +298,7 @@ theorem ofScores_event_lt_cross {τ : Type*} [Fintype τ]
 /-- Exact-value form: an event mass that is a rational literal on the ℚ≥0
 face is that literal on the PMF face. -/
 theorem ofScores_event_eq_ratCast (fb : Fallback σ) (f : σ → ℚ≥0)
-    (P : σ → Bool) {q : ℚ≥0} (h : eventMass (scoresWith fb f) P = q) :
+    (P : σ → Prop) [DecidablePred P] {q : ℚ≥0} (h : eventMass (scoresWith fb f) P = q) :
     (∑' x, if P x then ofScores fb f x else 0) = ((q : ℝ≥0) : ℝ≥0∞) := by
   rw [ofScores_event_eq, h]
 

--- a/Linglib/Studies/BarnettEtAl2022.lean
+++ b/Linglib/Studies/BarnettEtAl2022.lean
@@ -66,24 +66,30 @@ instance : Fintype StickWorld where
   complete := fun x => by cases x <;> simp
 
 /-- Whether a stick is available in a given world. -/
-def worldContains : StickWorld → Stick → Bool
-  | .w123, .s1 | .w123, .s2 | .w123, .s3 => true
-  | .w124, .s1 | .w124, .s2 | .w124, .s4 => true
-  | .w125, .s1 | .w125, .s2 | .w125, .s5 => true
-  | .w134, .s1 | .w134, .s3 | .w134, .s4 => true
-  | .w135, .s1 | .w135, .s3 | .w135, .s5 => true
-  | .w145, .s1 | .w145, .s4 | .w145, .s5 => true
-  | .w234, .s2 | .w234, .s3 | .w234, .s4 => true
-  | .w235, .s2 | .w235, .s3 | .w235, .s5 => true
-  | .w245, .s2 | .w245, .s4 | .w245, .s5 => true
-  | .w345, .s3 | .w345, .s4 | .w345, .s5 => true
-  | _, _ => false
+def worldContains : StickWorld → Stick → Prop
+  | .w123, .s1 | .w123, .s2 | .w123, .s3 => True
+  | .w124, .s1 | .w124, .s2 | .w124, .s4 => True
+  | .w125, .s1 | .w125, .s2 | .w125, .s5 => True
+  | .w134, .s1 | .w134, .s3 | .w134, .s4 => True
+  | .w135, .s1 | .w135, .s3 | .w135, .s5 => True
+  | .w145, .s1 | .w145, .s4 | .w145, .s5 => True
+  | .w234, .s2 | .w234, .s3 | .w234, .s4 => True
+  | .w235, .s2 | .w235, .s3 | .w235, .s5 => True
+  | .w245, .s2 | .w245, .s4 | .w245, .s5 => True
+  | .w345, .s3 | .w345, .s4 | .w345, .s5 => True
+  | _, _ => False
+
+instance : ∀ w u, Decidable (worldContains w u) := fun w u => by
+  cases w <;> cases u <;> (unfold worldContains; infer_instance)
 
 /-- A world is "longer" if the average stick length exceeds the midpoint (3);
 equivalently, the three sticks sum past 9. 4 of 10 worlds qualify. -/
-def longer : StickWorld → Bool
-  | .w145 | .w235 | .w245 | .w345 => true
-  | _ => false
+def longer : StickWorld → Prop
+  | .w145 | .w235 | .w245 | .w345 => True
+  | _ => False
+
+instance : DecidablePred longer := fun w => by
+  cases w <;> (unfold longer; infer_instance)
 
 /-! ### Persuasive-speaker scores -/
 
@@ -124,7 +130,7 @@ noncomputable def l0 (u : Stick) : PMF StickWorld :=
   .ofScores .uniform fun w => if worldContains w u then 1 else 0
 
 /-- Event marginal of the literal listener. -/
-noncomputable def l0Event (u : Stick) (P : StickWorld → Bool) : ℝ≥0∞ :=
+noncomputable def l0Event (u : Stick) (P : StickWorld → Prop) [DecidablePred P] : ℝ≥0∞ :=
   ∑' w, if P w then l0 u w else 0
 
 /-- Persuasive speaker (eq. 8 at β = 2). -/
@@ -137,7 +143,7 @@ noncomputable def l1w (u : Stick) : PMF StickWorld :=
   .ofScores .uniform fun w => PMF.scoresWith .uniform (s1Score w) u
 
 /-- Event marginal of the pragmatic listener. -/
-noncomputable def l1Event (u : Stick) (P : StickWorld → Bool) : ℝ≥0∞ :=
+noncomputable def l1Event (u : Stick) (P : StickWorld → Prop) [DecidablePred P] : ℝ≥0∞ :=
   ∑' w, if P w then l1w u w else 0
 
 open scoped ENNReal
@@ -147,7 +153,7 @@ open scoped ENNReal
 /-- L0(longer|s5) > L0(¬longer|s5): stick 5 is positive evidence for "longer".
 4 of 6 worlds containing s5 are longer, vs 2 not-longer. -/
 theorem l0_s5_positive :
-    l0Event .s5 (fun w => !longer w) < l0Event .s5 longer :=
+    l0Event .s5 (fun w => ¬ longer w) < l0Event .s5 longer :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-- L0(longer|s5) > L0(longer|s4): stick 5 provides stronger evidence than s4. -/
@@ -157,7 +163,7 @@ theorem l0_s5_strongest : l0Event .s4 longer < l0Event .s5 longer :=
 /-- L0(¬longer|s1) > L0(longer|s1): stick 1 is evidence against "longer".
 Only 1 of 6 worlds containing s1 is longer. -/
 theorem l0_s1_negative :
-    l0Event .s1 longer < l0Event .s1 (fun w => !longer w) :=
+    l0Event .s1 longer < l0Event .s1 (fun w => ¬ longer w) :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-- L0(longer|·) is monotonically increasing in stick length. This structural
@@ -183,13 +189,13 @@ the ¬longer mass (p. 172: "the absence of strong evidence from a speaker
 who would be highly motivated to show it statistically implies that no
 such evidence exists"). -/
 theorem weak_evidence_effect :
-    l1Event .s4 longer < l1Event .s4 (fun w => !longer w) :=
+    l1Event .s4 longer < l1Event .s4 (fun w => ¬ longer w) :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-- Strong evidence works: the strongest available evidence cannot be
 explained away by the absence of something better. -/
 theorem strong_evidence_works :
-    l1Event .s5 (fun w => !longer w) < l1Event .s5 longer :=
+    l1Event .s5 (fun w => ¬ longer w) < l1Event .s5 longer :=
   PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### Bridge Theorems -/
@@ -226,7 +232,7 @@ Stick 4 has positive argStr at L0 (1/2 > 2/5), yet L1 assigns more mass
 to ¬longer than longer after seeing s4. -/
 theorem argStr_positive_but_backfires :
     hasPositiveArgStr (l0LongerQ .s4 : ℚ) priorLonger ∧
-    l1Event .s4 longer < l1Event .s4 (fun w => !longer w) :=
+    l1Event .s4 longer < l1Event .s4 (fun w => ¬ longer w) :=
   ⟨s4_positive_argStr, weak_evidence_effect⟩
 
 /-! ### Experimental Design & Behavioral Data -/
@@ -415,7 +421,7 @@ theorem model_predicts_interaction :
     -- Model: L0 (literal) — s4 is positive evidence
     hasPositiveArgStr (l0LongerQ .s4 : ℚ) priorLonger ∧
     -- Model: L1 (pragmatic) — s4 backfires
-    l1Event .s4 longer < l1Event .s4 (fun w => !longer w) ∧
+    l1Event .s4 longer < l1Event .s4 (fun w => ¬ longer w) ∧
     -- Data: pragmatic group shows backfire
     pragmaticResult.meanSlider < 50 ∧
     -- Data: literal group shows no backfire

--- a/Linglib/Studies/QingGoodmanLassiter2016.lean
+++ b/Linglib/Studies/QingGoodmanLassiter2016.lean
@@ -272,13 +272,6 @@ noncomputable def l1WorldEvent (qud : QUD) (u : Utterance)
     (P : WorldState → Prop) [DecidablePred P] : ℝ≥0∞ :=
   ∑' w, if P w then l1World qud u w else 0
 
-/-- `PMF.ofScores_event_lt` indexes events by `WorldState → Bool`; this is the
-`decide` transport that lets the event predictions below cite it. -/
-private theorem l1WorldEvent_eq_decide (qud : QUD) (u : Utterance)
-    (P : WorldState → Prop) [DecidablePred P] :
-    l1WorldEvent qud u P = ∑' w, if decide (P w) then l1World qud u w else 0 := by
-  simp [l1WorldEvent]
-
 /-! ### Listener predictions -/
 
 /-! ### QUD_now symmetry -/
@@ -295,9 +288,8 @@ theorem qud_now_wTT_eq_wFT :
 /-- L1 infers the QUD answer now=T from "didn't stop smoking". -/
 theorem qud_answer_now_true :
     l1WorldEvent .now (some .notStopped) (fun w => ¬ w.now) <
-      l1WorldEvent .now (some .notStopped) (·.now) := by
-  rw [l1WorldEvent_eq_decide, l1WorldEvent_eq_decide]
-  exact PMF.ofScores_event_lt _ _ (by decide +kernel)
+      l1WorldEvent .now (some .notStopped) (·.now) :=
+  PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### World elimination
 
@@ -356,9 +348,8 @@ theorem now_context_dispreferred :
 /-- "Stopped smoking" → L1 infers now=F (the assertion). -/
 theorem stopped_qud_answer :
     l1WorldEvent .now (some .stopped) (·.now) <
-      l1WorldEvent .now (some .stopped) (fun w => ¬ w.now) := by
-  rw [l1WorldEvent_eq_decide, l1WorldEvent_eq_decide]
-  exact PMF.ofScores_event_lt _ _ (by decide +kernel)
+      l1WorldEvent .now (some .stopped) (fun w => ¬ w.now) :=
+  PMF.ofScores_event_lt _ _ (by decide +kernel)
 
 /-! ### Structural properties -/
 


### PR DESCRIPTION
Migrates `PMF.eventMass` / `ofScores_event_eq` / `ofScores_event_lt` / `_lt_cross` / `_eq_ratCast` from Bool-indexed to Prop + `DecidablePred` events — the surface #1754 left pinned. QGL2016's decide-transport bridge dissolves; BarnettEtAl2022's `longer`/`worldContains` become Props; ScontrasTonhauser2025 needed no change (Bool-field coercion).