### PR TITLE
style(Studies/FrankeBergen2020): total Table 1 rows and pooled-mass findings

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1408,6 +1408,7 @@ import Linglib.Pragmatics.RSA.Basic
 import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Pragmatics.RSA.Channel
 import Linglib.Pragmatics.RSA.CombinedUtility
+import Linglib.Pragmatics.RSA.Dominates
 import Linglib.Pragmatics.RSA.Gibbs
 import Linglib.Pragmatics.RSA.LatentOperators
 import Linglib.Pragmatics.RSA.LexicalUncertainty

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -675,30 +675,49 @@ theorem speaker_real_singleton_of_profile_replicate {α : ℝ} (hα : 0 < α) {t
         ← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast],
     div_mul_eq_div_div_swap, div_self hx.ne', one_div]
 
+/-- The ℕ-cleared production mass of a choice, pooled over its true states:
+its common-denominator weight times, per true state, the product of the other
+states' cleared partition sums. Pooled evaluation-register hypotheses compare
+these. -/
+def divPowSumColumn (D k : ℕ) (c : C) : ℕ :=
+  (D / (s.sem c).card) ^ k
+    * ∑ t ∈ s.sem c, ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [DecidableEq O] in
+private theorem divPowSumColumn_eq (D k : ℕ) (c : C) :
+    s.divPowSumColumn D k c
+      = ∑ t : T, if t ∈ s.sem c then
+          (D / (s.sem c).card) ^ k
+            * ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
+        else 0 := by
+  rw [divPowSumColumn, Finset.mul_sum, Finset.sum_ite_mem, Finset.univ_inter]
+
 omit [DecidableEq O] in
 /-- Exact speaker mass at a natural rationality, as a ratio of ℕ-valued
 common-denominator sums. -/
-theorem speaker_real_singleton_divPowSum {k D : ℕ} (hk : k ≠ 0) (hD : D ≠ 0) {t : T}
+theorem speaker_real_singleton_divPowSum {k D : ℕ} [NeZero k] [NeZero D] {t : T}
     (hdvd : ∀ n ∈ s.profile t, n ∣ D) (c : C) :
     (s.speaker k t).real {c}
       = (if t ∈ s.sem c then (((D / (s.sem c).card) ^ k : ℕ) : ℝ) else 0)
         / ((s.profile t).divPowSum D k : ℝ) := by
-  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
-  have hDk : ((D : ℝ) ^ k) ≠ 0 := pow_ne_zero k (Nat.cast_ne_zero.mpr hD)
-  rw [s.speaker_real_singleton hα, Multiset.invPowSum_toReal_eq hD k hdvd]
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne k))
+  have hDk : ((D : ℝ) ^ k) ≠ 0 := pow_ne_zero k (Nat.cast_ne_zero.mpr (NeZero.ne D))
+  rw [s.speaker_real_singleton hα, Multiset.invPowSum_toReal_eq (NeZero.ne D) k hdvd]
   split
   · have hcard : (s.sem c).card ∣ D := hdvd _ (Multiset.mem_map_of_mem _ (by
       rw [Finset.mem_val, trueChoices, Finset.mem_filter]
       exact ⟨Finset.mem_univ c, ‹_›⟩))
     have hcard0 : ((s.sem c).card : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr
-      fun h0 => hD (Nat.eq_zero_of_zero_dvd (h0 ▸ hcard))
+      fun h0 => NeZero.ne D (Nat.eq_zero_of_zero_dvd (h0 ▸ hcard))
     have hinv : (((s.sem c).card : ℝ))⁻¹ = ((D / (s.sem c).card : ℕ) : ℝ) / D := by
-      rw [eq_div_iff (Nat.cast_ne_zero.mpr hD),
+      rw [eq_div_iff (Nat.cast_ne_zero.mpr (NeZero.ne D)),
         show (D : ℝ) = ((D / (s.sem c).card : ℕ) : ℝ) * ((s.sem c).card : ℝ) by
           rw [← Nat.cast_mul, Nat.div_mul_cancel hcard],
         mul_comm _ ((s.sem c).card : ℝ), ← mul_assoc, inv_mul_cancel₀ hcard0, one_mul]
     rw [Real.rpow_natCast, hinv, div_pow, ← Nat.cast_pow, ← Nat.cast_pow,
-      div_div_div_comm, div_self (Nat.cast_ne_zero.mpr (pow_ne_zero k hD) : ((D ^ k : ℕ) : ℝ) ≠ 0),
+      div_div_div_comm,
+      div_self (Nat.cast_ne_zero.mpr (pow_ne_zero k (NeZero.ne D)) : ((D ^ k : ℕ) : ℝ) ≠ 0),
       div_one]
   · rw [zero_div, zero_div]
 
@@ -876,17 +895,13 @@ and equal priors: pooled preference between two `o`-shaped choices is the
 ℕ-valued common-denominator comparison over all states — a kernel `decide`.
 The strict inequality carries its own truth witness. -/
 theorem choicePosterior_real_lt_of_divPowSum [s.Expressible] {k D : ℕ}
-    (hk : k ≠ 0) (hD : D ≠ 0) (hdvd : ∀ t : T, ∀ n ∈ s.profile t, n ∣ D)
+    [NeZero k] [NeZero D] (hdvd : ∀ t : T, ∀ n ∈ s.profile t, n ∣ D)
     (hμeq : ∀ t t' : T, μ {t} = μ {t'}) (hμ0 : ∀ t : T, μ {t} ≠ 0)
     {o : O} {c₁ c₂ : C} (h₁ : s.obs c₁ = o) (h₂ : s.obs c₂ = o)
-    (hlt : (∑ t : T, if t ∈ s.sem c₁ then
-        (D / (s.sem c₁).card) ^ k * ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
-      else 0)
-      < ∑ t : T, if t ∈ s.sem c₂ then
-        (D / (s.sem c₂).card) ^ k * ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
-      else 0) :
+    (hlt : s.divPowSumColumn D k c₁ < s.divPowSumColumn D k c₂) :
     (s.choicePosterior k μ o).real {c₁} < (s.choicePosterior k μ o).real {c₂} := by
-  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+  rw [divPowSumColumn_eq, divPowSumColumn_eq] at hlt
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne k))
   obtain ⟨t₀, -, ht₀⟩ := Finset.exists_ne_zero_of_sum_ne_zero
     (Nat.pos_iff_ne_zero.mp (lt_of_le_of_lt (Nat.zero_le _) hlt))
   have hmem₀ : t₀ ∈ s.sem c₂ := by
@@ -903,12 +918,12 @@ theorem choicePosterior_real_lt_of_divPowSum [s.Expressible] {k D : ℕ}
     refine Finset.sum_congr rfl fun t _ => ?_
     rw [show μ.real {t} = μ.real {t₀} from by
         rw [measureReal_def, measureReal_def, hμeq t t₀],
-      s.speaker_real_singleton_divPowSum hk hD (hdvd t)]
+      s.speaker_real_singleton_divPowSum (hdvd t)]
   rw [s.choicePosterior_real_lt_iff ho h₁ h₂, hprior, hprior,
     mul_lt_mul_iff_right₀
       (show (0 : ℝ) < μ.real {t₀} from ENNReal.toReal_pos (hμ0 t₀) (measure_ne_top _ _)),
     sum_div_lt_sum_div_iff fun t => by
-      exact_mod_cast Multiset.divPowSum_pos hD (hdvd t) (s.profile_ne_zero t)]
+      exact_mod_cast Multiset.divPowSum_pos (NeZero.ne D) (hdvd t) (s.profile_ne_zero t)]
   simp only [ite_mul, zero_mul]
   exact_mod_cast hlt
 
@@ -1004,13 +1019,13 @@ theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (
 dividing `D`, listener preference at equal priors is the ℕ-valued
 common-denominator comparison — a kernel `decide`. The strict inequality
 carries its own truth witness. -/
-theorem listener_real_lt_of_divPowSum [s.Expressible] {k D : ℕ} (hk : k ≠ 0) (hD : D ≠ 0)
+theorem listener_real_lt_of_divPowSum [s.Expressible] {k D : ℕ} [NeZero k] [NeZero D]
     {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
     (hdvd₁ : ∀ n ∈ s.profile t₁, n ∣ D) (hdvd₂ : ∀ n ∈ s.profile t₂, n ∣ D)
     (hlt : (s.fiberProfile o t₁).divPowSum D k * (s.profile t₂).divPowSum D k
       < (s.fiberProfile o t₂).divPowSum D k * (s.profile t₁).divPowSum D k) :
     (s.listener k μ o).real {t₁} < (s.listener k μ o).real {t₂} := by
-  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero (NeZero.ne k))
   have hfsub : ∀ t, ∀ n ∈ s.fiberProfile o t, n ∈ s.profile t := fun t n hn =>
     s.profile_eq_fiberProfile_add_restProfile o t ▸ Multiset.mem_add.mpr (Or.inl hn)
   have h₂ : s.fiberProfile o t₂ ≠ 0 :=
@@ -1021,12 +1036,13 @@ theorem listener_real_lt_of_divPowSum [s.Expressible] {k D : ℕ} (hk : k ≠ 0)
       (m₁.invPowSum k).toReal * (m₂.invPowSum k).toReal
         = (m₁.divPowSum D k * m₂.divPowSum D k : ℕ) / ((D : ℝ) ^ k) ^ 2 := by
     intro m₁ m₂ h₁ h₂
-    rw [Multiset.invPowSum_toReal_eq hD k h₁, Multiset.invPowSum_toReal_eq hD k h₂]
+    rw [Multiset.invPowSum_toReal_eq (NeZero.ne D) k h₁,
+      Multiset.invPowSum_toReal_eq (NeZero.ne D) k h₂]
     push_cast
     ring
   rw [key _ _ (fun n hn => hdvd₁ n (hfsub t₁ n hn)) hdvd₂,
     key _ _ (fun n hn => hdvd₂ n (hfsub t₂ n hn)) hdvd₁,
-    div_lt_div_iff_of_pos_right (by positivity)]
+    div_lt_div_iff_of_pos_right (by have := NeZero.ne D; positivity)]
   exact_mod_cast hlt
 
 end Listener

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -443,6 +443,16 @@ noncomputable def speaker (α : ℝ) (util : W → U → EReal) : Kernel W U :=
     speaker α util w {u} = ((α : EReal) * util w u).exp / ∑ u', ((α : EReal) * util w u').exp :=
   Kernel.ofWeights_apply_singleton _ w u
 
+/-- An utterance of utility `⊥` is never produced. -/
+theorem speaker_apply_singleton_eq_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
+    (hbot : (α : EReal) * util w u = ⊥) : speaker α util w {u} = 0 := by
+  rw [speaker_apply_singleton, hbot, EReal.exp_bot, ENNReal.zero_div]
+
+/-- Real form of `speaker_apply_singleton_eq_zero`. -/
+theorem speaker_real_singleton_eq_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
+    (hbot : (α : EReal) * util w u = ⊥) : (speaker α util w).real {u} = 0 := by
+  rw [measureReal_def, speaker_apply_singleton_eq_zero hbot, ENNReal.toReal_zero]
+
 /-- A speaker mass is positive as soon as the utterance's scaled utility is
 not `⊥` and no scaled utility is `⊤`. -/
 theorem speaker_apply_singleton_ne_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
@@ -451,6 +461,18 @@ theorem speaker_apply_singleton_ne_zero {α : ℝ} {util : W → U → EReal} {w
   rw [speaker_apply_singleton, ne_eq, ENNReal.div_eq_zero_iff, not_or]
   exact ⟨by simp [EReal.exp_eq_zero_iff, hbot],
     ENNReal.sum_ne_top.mpr fun u' _ => by simp [EReal.exp_eq_top_iff, htop u']⟩
+
+/-- A speaker mass is positive on reals as soon as the utterance's scaled
+utility is not `⊥` and no scaled utility is `⊤`. -/
+theorem speaker_real_singleton_pos {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
+    (hbot : (α : EReal) * util w u ≠ ⊥) (htop : ∀ u', (α : EReal) * util w u' ≠ ⊤) :
+    0 < (speaker α util w).real {u} := by
+  rw [measureReal_def]
+  refine ENNReal.toReal_pos (speaker_apply_singleton_ne_zero hbot htop) ?_
+  rw [speaker_apply_singleton]
+  exact ENNReal.div_ne_top (by simp [EReal.exp_eq_top_iff, htop u]) fun hz =>
+    hbot (by simpa [EReal.exp_eq_zero_iff] using
+      Finset.sum_eq_zero_iff.mp hz u (Finset.mem_univ u))
 
 omit [MeasurableSingletonClass U] in
 /-- The speaker is Markov as soon as no scaled utility is `⊤` and every

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -581,9 +581,10 @@ variable (W U) in
 /-- A cost-free informativity speaker: rationality, prior beliefs, and a
 truth-conditional semantics. -/
 structure Speaker where
-  /-- The softmax rationality (Degen's α); positive, so that informativity
-  bites (the `α = 0` uniform speaker is degenerate). -/
+  /-- The softmax rationality (Degen's α). -/
   α : ℝ
+  /-- Rationality is positive: at `α = 0` the speaker is uniformly random and
+  support is no longer literal truth. -/
   α_pos : 0 < α
   /-- Prior beliefs about worlds. -/
   prior : Measure W
@@ -607,18 +608,18 @@ class Viable : Prop where
 
 /-- The prior gives every world positive mass. -/
 class Positive : Prop where
-  prior_pos : ∀ w, S.prior {w} ≠ 0
+  prior_ne_zero : ∀ w, S.prior {w} ≠ 0
 
 variable [IsFiniteMeasure S.prior]
 
 omit [MeasurableSpace U] [Fintype W] [MeasurableSingletonClass W] [Fintype U]
   [MeasurableSingletonClass U] in
 theorem prior_real_pos [S.Positive] (w : W) : 0 < S.prior.real {w} :=
-  ENNReal.toReal_pos (Positive.prior_pos w) (measure_ne_top _ _)
+  ENNReal.toReal_pos (Positive.prior_ne_zero w) (measure_ne_top _ _)
 
 theorem L0_apply_singleton_ne_zero [S.Positive] {u : U} {w : W} (h : w ∈ S.sem u) :
     S.L0 u {w} ≠ 0 :=
-  literalListener_apply_singleton_ne_zero S.prior h (Positive.prior_pos w)
+  literalListener_apply_singleton_ne_zero S.prior h (Positive.prior_ne_zero w)
 
 private theorem scaled_utility_ne_top (w : W) (u : U) :
     (S.α : EReal) * utility S.L0 (fun _ => 0) w u ≠ ⊤ := by
@@ -632,7 +633,7 @@ instance [S.Viable] [S.Positive] : IsMarkovKernel S.toKernel :=
 
 /-- The speaker's support is literal truth: an utterance gets positive mass
 exactly on its extension. -/
-@[simp] theorem toKernel_real_pos_iff [S.Positive] (w : W) (u : U) :
+@[simp] theorem toKernel_real_singleton_pos_iff [S.Positive] (w : W) (u : U) :
     0 < (S.toKernel w).real {u} ↔ w ∈ S.sem u := by
   constructor
   · intro h
@@ -650,17 +651,17 @@ exactly on its extension. -/
       (S.scaled_utility_ne_top w)
 
 /-- An utterance outside its extension is never produced. -/
-theorem toKernel_real_eq_zero [S.Positive] {w : W} {u : U} (h : w ∉ S.sem u) :
+theorem toKernel_real_singleton_eq_zero [S.Positive] {w : W} {u : U} (h : w ∉ S.sem u) :
     (S.toKernel w).real {u} = 0 := by
   by_contra hne
-  exact h ((S.toKernel_real_pos_iff w u).mp
+  exact h ((S.toKernel_real_singleton_pos_iff w u).mp
     (lt_of_le_of_ne measureReal_nonneg (Ne.symm hne)))
 
 /-- A true utterance is produced with positive mass. -/
-theorem toKernel_apply_ne_zero [S.Positive] {w : W} {u : U} (h : w ∈ S.sem u) :
+theorem toKernel_apply_singleton_ne_zero [S.Positive] {w : W} {u : U} (h : w ∈ S.sem u) :
     S.toKernel w {u} ≠ 0 := by
   intro h0
-  have hpos := (S.toKernel_real_pos_iff w u).mpr h
+  have hpos := (S.toKernel_real_singleton_pos_iff w u).mpr h
   rw [measureReal_def, h0] at hpos
   simp at hpos
 
@@ -671,16 +672,25 @@ variable [StandardBorelSpace W] [Nonempty W] [S.Viable] [S.Positive]
 /-- The pragmatic listener (eq. 4): the Bayesian inverse of the speaker. -/
 noncomputable def listener : Kernel U W := S.toKernel†S.prior
 
+/-- Pragmatic-listener preference reduces to comparing prior-weighted speaker
+masses; the observation's marginal cancels. -/
+theorem listener_real_singleton_lt_iff {u : U} (hu : (S.toKernel ∘ₘ S.prior) {u} ≠ 0)
+    (w₁ w₂ : W) :
+    (S.listener u).real {w₁} < (S.listener u).real {w₂}
+      ↔ S.prior.real {w₁} * (S.toKernel w₁).real {u}
+        < S.prior.real {w₂} * (S.toKernel w₂).real {u} :=
+  posterior_real_singleton_lt_iff _ _ hu w₁ w₂
+
 /-- Support preference: hearing `u`, the pragmatic listener strictly prefers a
 world in `u`'s extension over one outside it. The truth of `u` at `w₂` also
 witnesses the positive observation marginal. -/
-theorem listener_real_lt_of_support {u : U} {w₁ w₂ : W}
+theorem listener_real_singleton_lt_of_support {u : U} {w₁ w₂ : W}
     (h₁ : w₁ ∉ S.sem u) (h₂ : w₂ ∈ S.sem u) :
     (S.listener u).real {w₁} < (S.listener u).real {w₂} := by
   rw [listener, posterior_real_singleton_lt_iff _ _
-      (comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂) (S.toKernel_apply_ne_zero h₂)),
-    S.toKernel_real_eq_zero h₁, mul_zero]
-  exact mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ u).mpr h₂)
+      (comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂) (S.toKernel_apply_singleton_ne_zero h₂)),
+    S.toKernel_real_singleton_eq_zero h₁, mul_zero]
+  exact mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ u).mpr h₂)
 
 end Listener
 
@@ -697,6 +707,24 @@ variable {X Θ : Type*} [MeasurableSpace X] [Fintype X] [MeasurableSingletonClas
 utterance ([franke-bergen-2020]'s intention listeners). -/
 noncomputable def jointListener : Kernel X (W × Θ) := jointPosterior S.toKernel S.prior
 
+/-- World preference under the joint listener reduces to comparing
+prior-weighted pooled pair masses. -/
+theorem jointListener_fst_real_lt_iff {x : X}
+    (hx : ((S.toKernel ∘ₘ S.prior).map Prod.fst) {x} ≠ 0) (w₁ w₂ : W) :
+    (S.jointListener x).fst.real {w₁} < (S.jointListener x).fst.real {w₂}
+      ↔ (∑ θ, S.prior.real {w₁} * (S.toKernel w₁).real {(x, θ)})
+        < ∑ θ, S.prior.real {w₂} * (S.toKernel w₂).real {(x, θ)} :=
+  jointPosterior_fst_real_lt_iff _ _ hx w₁ w₂
+
+/-- Latent preference under the joint listener reduces to comparing
+prior-weighted per-world masses. -/
+theorem jointListener_snd_real_lt_iff {x : X}
+    (hx : ((S.toKernel ∘ₘ S.prior).map Prod.fst) {x} ≠ 0) (θ₁ θ₂ : Θ) :
+    (S.jointListener x).snd.real {θ₁} < (S.jointListener x).snd.real {θ₂}
+      ↔ (∑ w, S.prior.real {w} * (S.toKernel w).real {(x, θ₁)})
+        < ∑ w, S.prior.real {w} * (S.toKernel w).real {(x, θ₂)} :=
+  jointPosterior_snd_real_lt_iff _ _ hx θ₁ θ₂
+
 /-- World preference by support: if no latent verifies the heard utterance at
 `w₁` and some latent verifies it at `w₂`, the joint listener's world marginal
 strictly prefers `w₂`. -/
@@ -705,13 +733,13 @@ theorem jointListener_fst_real_lt_of_support {x : X} {w₁ w₂ : W}
     (S.jointListener x).fst.real {w₁} < (S.jointListener x).fst.real {w₂} := by
   obtain ⟨θ₂, h₂⟩ := h₂
   rw [jointListener, jointPosterior_fst_real_lt_iff _ _
-      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂)
-        (S.toKernel_apply_ne_zero h₂)),
-    Finset.sum_congr rfl fun θ _ => by rw [S.toKernel_real_eq_zero (h₁ θ), mul_zero],
+      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂)
+        (S.toKernel_apply_singleton_ne_zero h₂)),
+    Finset.sum_congr rfl fun θ _ => by rw [S.toKernel_real_singleton_eq_zero (h₁ θ), mul_zero],
     Finset.sum_const_zero]
   exact Finset.sum_pos' (fun θ _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
     ⟨θ₂, Finset.mem_univ _,
-      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
+      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
 
 /-- Latent preference by support: if no world verifies the heard utterance
 under `θ₁` and some world of positive prior mass verifies it under `θ₂`, the
@@ -721,13 +749,13 @@ theorem jointListener_snd_real_lt_of_support {x : X} {θ₁ θ₂ : Θ}
     (S.jointListener x).snd.real {θ₁} < (S.jointListener x).snd.real {θ₂} := by
   obtain ⟨w₂, h₂⟩ := h₂
   rw [jointListener, jointPosterior_snd_real_lt_iff _ _
-      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂)
-        (S.toKernel_apply_ne_zero h₂)),
-    Finset.sum_congr rfl fun w _ => by rw [S.toKernel_real_eq_zero (h₁ w), mul_zero],
+      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂)
+        (S.toKernel_apply_singleton_ne_zero h₂)),
+    Finset.sum_congr rfl fun w _ => by rw [S.toKernel_real_singleton_eq_zero (h₁ w), mul_zero],
     Finset.sum_const_zero]
   exact Finset.sum_pos' (fun w _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
     ⟨w₂, Finset.mem_univ _,
-      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
+      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
 
 end Joint
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -1018,6 +1018,18 @@ theorem sum_fiber_speaker {α : ℝ} (hα : 0 < α) (o : O) (t : T) :
   simp_rw [speaker, speakerOf_apply_singleton, div_eq_mul_inv, ← Finset.sum_mul]
   rw [s.sum_fiber_rpow_L0 hα, s.sum_rpow_L0 hα, ← div_eq_mul_inv]
 
+omit [DecidableEq O] in
+/-- Exact speaker mass on reals: extension-size weight over the state's
+partition. -/
+theorem speaker_real_singleton {α : ℝ} (hα : 0 < α) (t : T) (c : C) :
+    (s.speaker α t).real {c}
+      = (if t ∈ s.sem c then (((s.sem c).card : ℝ))⁻¹ ^ α else 0)
+        / ((s.profile t).invPowSum α).toReal := by
+  rw [measureReal_def, speaker, speakerOf_apply_singleton, s.sum_rpow_L0 hα,
+    ENNReal.toReal_div, L0_apply_singleton, apply_ite (· ^ α),
+    ENNReal.zero_rpow_of_pos hα, apply_ite ENNReal.toReal, ENNReal.toReal_zero,
+    ← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast]
+
 variable [MeasurableSpace O] [MeasurableSingletonClass O]
 
 omit [Fintype T] [DecidableEq T] [MeasurableSingletonClass T] [Fintype C]
@@ -1138,6 +1150,35 @@ theorem listener_real_lt_iff {o : O}
     ENNReal.toReal_sum (fun c _ =>
       ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
     ENNReal.toReal_sum (fun c _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
+  simp_rw [ENNReal.toReal_mul]
+  exact Iff.rfl
+
+omit [DecidableEq T] in
+/-- Choice preference among `o`-shaped choices reduces to comparing
+prior-weighted speaker masses across states. -/
+theorem choicePosterior_real_lt_iff {o : O}
+    (ho : ((s.speaker α ∘ₘ μ).map s.obs) {o} ≠ 0) {c₁ c₂ : C}
+    (h₁ : s.obs c₁ = o) (h₂ : s.obs c₂ = o) :
+    (s.choicePosterior α μ o).real {c₁} < (s.choicePosterior α μ o).real {c₂}
+      ↔ (∑ t, μ.real {t} * (s.speaker α t).real {c₁})
+        < ∑ t, μ.real {t} * (s.speaker α t).real {c₂} := by
+  have key : ∀ c, s.obs c = o → s.choicePosterior α μ o {c}
+      = (∑ t, μ {t} * s.speaker α t {c}) / ((s.speaker α ∘ₘ μ).map s.obs) {o} :=
+    fun c hc => by
+      rw [choicePosterior, Kernel.snd_apply, ← Measure.snd, Measure.snd_apply_singleton]
+      simp_rw [s.jointListener_apply_singleton ho, if_pos hc, div_eq_mul_inv,
+        ← Finset.sum_mul]
+  have hne : ∀ c : C, (∑ t, μ {t} * s.speaker α t {c}) ≠ ∞ := fun c =>
+    ENNReal.sum_ne_top.mpr fun t _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
+  rw [measureReal_def, measureReal_def, key c₁ h₁, key c₂ h₂,
+    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne c₁) ho) (ENNReal.div_ne_top (hne c₂) ho),
+    ENNReal.div_lt_div_iff_left ho (measure_ne_top _ _),
+    ← ENNReal.toReal_lt_toReal (hne c₁) (hne c₂),
+    ENNReal.toReal_sum (fun t _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
+    ENNReal.toReal_sum (fun t _ =>
       ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
   simp_rw [ENNReal.toReal_mul]
   exact Iff.rfl

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -29,9 +29,10 @@ inequalities via `Multiset.divPowSum`.
   `speaker`, `production`, `jointListener`, `listener`, `choicePosterior`.
 * `RSA.Scenario.pool` — choice-side latents: the speaker chooses the family
   index, normalizing across the pooled pairs (eqs. 18a/21a).
-* `RSA.Scenario.familySpeaker` — state-side latents: the index is a speaker
-  argument, normalization is per-index (eq. 11). `pool_L0` shows the two
-  share their weights — they differ only in the position of the latent.
+* `RSA.Scenario.familySpeaker`, `RSA.Scenario.familyListener` — state-side
+  latents: the index is a speaker argument, normalization is per-index
+  (eqs. 11–13). `pool_L0` shows the two architectures share their weights —
+  they differ only in the position of the latent.
 
 ## Main statements
 
@@ -475,13 +476,6 @@ probability kernel. -/
 class Expressible (s : Scenario T C O) : Prop where
   exists_mem_sem : ∀ t, ∃ c, t ∈ s.sem c
 
-omit [MeasurableSpace T] [DecidableEq T] [MeasurableSingletonClass T] [MeasurableSpace C]
-  [Fintype C] [DiscreteMeasurableSpace C] [Fintype T] in
-/-- A pooled family is expressible as soon as one member is. -/
-theorem Expressible.pool {L : Type*} (f : L → Scenario T C O) (l : L)
-    [h : (f l).Expressible] : (Scenario.pool f).Expressible :=
-  ⟨fun t => let ⟨c, hc⟩ := h.exists_mem_sem t; ⟨(c, l), hc⟩⟩
-
 theorem isMarkovKernel_speaker {α : ℝ} (hα : 0 ≤ α) [s.Expressible] :
     IsMarkovKernel (s.speaker α) :=
   isMarkovKernel_speakerOf hα s.L0 (fun c t => s.L0_apply_singleton_le_one c t)
@@ -608,6 +602,77 @@ theorem speaker_real_singleton {α : ℝ} (hα : 0 < α) (t : T) (c : C) :
     ENNReal.toReal_div, L0_apply_singleton, apply_ite (· ^ α),
     ENNReal.zero_rpow_of_pos hα, apply_ite ENNReal.toReal, ENNReal.toReal_zero,
     ← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast]
+
+omit [DecidableEq O] in
+theorem speaker_real_singleton_eq_zero {α : ℝ} (hα : 0 < α) {t : T} {c : C}
+    (h : t ∉ s.sem c) : (s.speaker α t).real {c} = 0 := by
+  rw [measureReal_def, s.speaker_apply_singleton_eq_zero hα h, ENNReal.toReal_zero]
+
+omit [DecidableEq T] [DecidableEq O] in
+/-- Speaker shares over any set of choices stay within the row's unit mass. -/
+theorem sum_speaker_real_singleton_le_one (α : ℝ) (t : T) (S : Finset C) :
+    ∑ c ∈ S, (s.speaker α t).real {c} ≤ 1 := by
+  have hle : s.speaker α t ↑S ≤ 1 :=
+    le_trans (measure_mono (Set.subset_univ _)) (s.speaker_apply_univ_le_one α t)
+  calc ∑ c ∈ S, (s.speaker α t).real {c}
+      = (s.speaker α t).real ↑S := by
+        simp_rw [measureReal_def, ← ENNReal.toReal_sum fun c _ => measure_ne_top _ _,
+          sum_measure_singleton]
+    _ ≤ 1 := by
+        rw [measureReal_def, ← ENNReal.toReal_one]
+        exact ENNReal.toReal_mono ENNReal.one_ne_top hle
+
+omit [DecidableEq O] in
+/-- Competition: any other true choice caps a share strictly below one. -/
+theorem speaker_real_singleton_lt_one [DecidableEq C] {α : ℝ} (hα : 0 ≤ α) {t : T} (c : C) {c' : C}
+    (hne : c' ≠ c) (hmem' : t ∈ s.sem c') : (s.speaker α t).real {c} < 1 := by
+  have hsum := s.sum_speaker_real_singleton_le_one α t {c, c'}
+  rw [Finset.sum_insert (by simpa using fun h => hne h.symm), Finset.sum_singleton] at hsum
+  have hpos : 0 < (s.speaker α t).real {c'} :=
+    ENNReal.toReal_pos (s.speaker_apply_singleton_ne_zero hα hmem') (measure_ne_top _ _)
+  linarith
+
+omit [DecidableEq O] in
+/-- Informativity monotonicity ([franke-bergen-2020] eq. 7's qualitative
+claim): between two true choices, the one with the strictly smaller extension
+is produced with strictly higher probability, at every positive
+rationality. -/
+theorem speaker_real_singleton_lt_of_card_lt {α : ℝ} (hα : 0 < α) {t : T} {c c' : C}
+    (hmem : t ∈ s.sem c) (hmem' : t ∈ s.sem c')
+    (hcard : (s.sem c').card < (s.sem c).card) :
+    (s.speaker α t).real {c} < (s.speaker α t).real {c'} := by
+  have hterm : s.L0 c {t} ^ α ≠ 0 :=
+    weight_rpow_ne_zero hα.le (s.L0_apply_singleton_ne_zero hmem)
+  have hZ0 : (∑ u, s.L0 u {t} ^ α) ≠ 0 := fun h =>
+    hterm (le_antisymm (le_trans
+      (Finset.single_le_sum (f := fun u => s.L0 u {t} ^ α) (fun u _ => zero_le)
+        (Finset.mem_univ c)) h.le) zero_le)
+  rw [speaker, speakerOf, Kernel.ofWeights_real_singleton_lt_iff t hZ0
+      (ENNReal.sum_ne_top.mpr fun u _ => weight_rpow_ne_top hα.le (s.L0_apply_singleton_le_one u t)),
+    s.L0_apply_singleton, s.L0_apply_singleton, if_pos hmem, if_pos hmem']
+  exact ENNReal.rpow_lt_rpow
+    (ENNReal.inv_lt_inv.2 (by exact_mod_cast hcard)) hα
+
+omit [DecidableEq O] in
+/-- Softmax constant-utility invariance: when every true choice at a state
+has the same extension size, the speaker is uniform on them — each share is
+`m⁻¹` regardless of the rationality. -/
+theorem speaker_real_singleton_of_profile_replicate {α : ℝ} (hα : 0 < α) {t : T} {c : C}
+    {m n : ℕ} (hprof : s.profile t = Multiset.replicate m n) (hmem : t ∈ s.sem c) :
+    (s.speaker α t).real {c} = (m : ℝ)⁻¹ := by
+  have hcmem : (s.sem c).card ∈ s.profile t :=
+    Multiset.mem_map_of_mem _ (by
+      rw [Finset.mem_val, trueChoices, Finset.mem_filter]
+      exact ⟨Finset.mem_univ c, hmem⟩)
+  have hn : (s.sem c).card = n := Multiset.eq_of_mem_replicate (hprof ▸ hcmem)
+  have hn0 : n ≠ 0 := hn ▸ Finset.card_ne_zero_of_mem hmem
+  have hx : (0 : ℝ) < ((n : ℝ))⁻¹ ^ α :=
+    Real.rpow_pos_of_pos (by positivity) α
+  rw [s.speaker_real_singleton hα, if_pos hmem, hprof, hn,
+    show ((Multiset.replicate m n).invPowSum α).toReal = m * ((n : ℝ))⁻¹ ^ α by
+      rw [Multiset.invPowSum_replicate, ENNReal.toReal_mul, ENNReal.toReal_natCast,
+        ← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast],
+    div_mul_eq_div_div_swap, div_self hx.ne', one_div]
 
 omit [DecidableEq O] in
 /-- Exact speaker mass at a natural rationality, as a ratio of ℕ-valued
@@ -993,6 +1058,69 @@ instance (f : L → Scenario T C O) (α : ℝ) : IsFiniteKernel (familySpeaker f
   ⟨⟨1, ENNReal.one_lt_top, fun tl => by
     rw [familySpeaker_apply]
     exact (f tl.2).speaker_apply_univ_le_one α tl.1⟩⟩
+
+section
+
+variable [StandardBorelSpace T] [Nonempty T] [StandardBorelSpace L] [Nonempty L]
+  {μ : Measure (T × L)} [IsFiniteMeasure μ]
+
+/-- The family listener: the Bayesian inverse of the family speaker over the
+joint (state, index) space — [franke-bergen-2020] eqs. 12–13. Bundling the
+posterior keeps consumers' goals first-order in `familyListener`. -/
+noncomputable def familyListener (f : L → Scenario T C O) (α : ℝ)
+    (μ : Measure (T × L)) [IsFiniteMeasure μ] : Kernel C (T × L) :=
+  (familySpeaker f α)†μ
+
+omit [StandardBorelSpace T] [Nonempty T] [StandardBorelSpace L] [Nonempty L] in
+/-- A member's true choice at a positive-prior state witnesses a positive
+observation marginal for the family speaker. -/
+theorem comp_familySpeaker_ne_zero {f : L → Scenario T C O} {α : ℝ} (hα : 0 ≤ α)
+    {μ : Measure (T × L)} (hμ0 : ∀ p : T × L, μ {p} ≠ 0) {t : T} {l : L} {c : C}
+    (hmem : t ∈ (f l).sem c) : ((familySpeaker f α) ∘ₘ μ) {c} ≠ 0 :=
+  comp_apply_singleton_ne_zero _ _ (hμ0 (t, l)) (by
+    rw [familySpeaker_apply]
+    exact (f l).speaker_apply_singleton_ne_zero hα hmem)
+
+/-- State-marginal preference for a latent family at equal priors: the latent
+pools, leaving summed member speaker shares. Any member's true choice at
+either state supplies the positivity side condition. -/
+theorem familyListener_fst_real_lt_iff [Fintype L] (f : L → Scenario T C O) {α : ℝ}
+    (hα : 0 ≤ α) (hμeq : ∀ p q : T × L, μ {p} = μ {q}) (hμ0 : ∀ p : T × L, μ {p} ≠ 0)
+    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) (t₁ t₂ : T) :
+    ((familyListener f α μ) c).fst.real {t₁} < ((familyListener f α μ) c).fst.real {t₂}
+      ↔ (∑ l, ((f l).speaker α t₁).real {c}) < ∑ l, ((f l).speaker α t₂).real {c} := by
+  set p₀ : T × L := Classical.arbitrary _
+  have key : ∀ t : T, (∑ l, μ.real {(t, l)} * ((familySpeaker f α) (t, l)).real {c})
+      = μ.real {p₀} * ∑ l, ((f l).speaker α t).real {c} := fun t => by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun l _ => by
+      rw [familySpeaker_apply, show μ.real {(t, l)} = μ.real {p₀} from by
+        rw [measureReal_def, measureReal_def, hμeq (t, l) p₀]]
+  rw [familyListener,
+    posterior_fst_real_lt_iff _ _ (comp_familySpeaker_ne_zero hα hμ0 hmem), key, key,
+    mul_lt_mul_iff_right₀
+      (show (0 : ℝ) < μ.real {p₀} from ENNReal.toReal_pos (hμ0 p₀) (measure_ne_top _ _))]
+
+/-- Latent-marginal preference for a latent family at equal priors: the
+states pool, leaving summed member speaker shares. -/
+theorem familyListener_snd_real_lt_iff (f : L → Scenario T C O) {α : ℝ}
+    (hα : 0 ≤ α) (hμeq : ∀ p q : T × L, μ {p} = μ {q}) (hμ0 : ∀ p : T × L, μ {p} ≠ 0)
+    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) (l₁ l₂ : L) :
+    ((familyListener f α μ) c).snd.real {l₁} < ((familyListener f α μ) c).snd.real {l₂}
+      ↔ (∑ t, ((f l₁).speaker α t).real {c}) < ∑ t, ((f l₂).speaker α t).real {c} := by
+  set p₀ : T × L := Classical.arbitrary _
+  have key : ∀ l : L, (∑ t, μ.real {(t, l)} * ((familySpeaker f α) (t, l)).real {c})
+      = μ.real {p₀} * ∑ t, ((f l).speaker α t).real {c} := fun l => by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun t _ => by
+      rw [familySpeaker_apply, show μ.real {(t, l)} = μ.real {p₀} from by
+        rw [measureReal_def, measureReal_def, hμeq (t, l) p₀]]
+  rw [familyListener,
+    posterior_snd_real_lt_iff _ _ (comp_familySpeaker_ne_zero hα hμ0 hmem), key, key,
+    mul_lt_mul_iff_right₀
+      (show (0 : ℝ) < μ.real {p₀} from ENNReal.toReal_pos (hμ0 p₀) (measure_ne_top _ _))]
+
+end
 
 end Family
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -1160,36 +1160,21 @@ theorem listener_real_lt_of_support {α : ℝ} (hα : 0 < α) {μ : Measure T}
       mul_pos (ENNReal.toReal_pos hμ (measure_ne_top _ _))
         (s.speaker_real_singleton_pos hα.le hmem)⟩
 
-/-- Certificate form of listener preference at equal priors, uniform in the
-rationality: cross products of fiber and rest profiles strictly dominate
-(the shared fiber-by-fiber terms of the odds comparison cancel). -/
-theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (hα : 0 < α)
+/-- Listener preference at equal priors reduces to the cross-multiplied
+profile comparison, on reals — the evaluation form for pinned rationalities. -/
+theorem listener_real_lt_iff_invPowSum [s.Expressible] {α : ℝ} (hα : 0 < α)
     {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
-    (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c)
-    (hcert : ((s.fiberProfile o t₂).prodMul (s.restProfile o t₁)).StrictDominates
-      ((s.fiberProfile o t₁).prodMul (s.restProfile o t₂))) :
-    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
+    (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c) :
+    ((s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂})
+      ↔ ((s.fiberProfile o t₁).invPowSum α).toReal * ((s.profile t₂).invPowSum α).toReal
+        < ((s.fiberProfile o t₂).invPowSum α).toReal * ((s.profile t₁).invPowSum α).toReal := by
   obtain ⟨c₂, hc₂, hmem⟩ := h₂
   have hWne : ∀ t, (s.fiberProfile o t).invPowSum α ≠ ∞ := fun t =>
     Multiset.invPowSum_ne_top hα.le (s.zero_notMem_fiberProfile o t)
-  have hRne : ∀ t, (s.restProfile o t).invPowSum α ≠ ∞ := fun t =>
-    Multiset.invPowSum_ne_top hα.le (s.zero_notMem_restProfile o t)
   have hZ0 : ∀ t, (s.profile t).invPowSum α ≠ 0 := fun t =>
     (Multiset.invPowSum_pos hα.le (s.profile_ne_zero t)).ne'
   have hZne : ∀ t, (s.profile t).invPowSum α ≠ ∞ := fun t =>
     Multiset.invPowSum_ne_top hα.le (s.zero_notMem_profile t)
-  have hodds : (s.fiberProfile o t₁).invPowSum α * (s.restProfile o t₂).invPowSum α
-      < (s.fiberProfile o t₂).invPowSum α * (s.restProfile o t₁).invPowSum α := by
-    rw [← Multiset.invPowSum_prodMul hα.le, ← Multiset.invPowSum_prodMul hα.le]
-    exact hcert.invPowSum_lt hα.le
-      (Multiset.zero_notMem_prodMul (s.zero_notMem_fiberProfile o t₁)
-        (s.zero_notMem_restProfile o t₂))
-  have hcross : (s.fiberProfile o t₁).invPowSum α * (s.profile t₂).invPowSum α
-      < (s.fiberProfile o t₂).invPowSum α * (s.profile t₁).invPowSum α := by
-    rw [s.profile_eq_fiberProfile_add_restProfile o t₁,
-      s.profile_eq_fiberProfile_add_restProfile o t₂, Multiset.invPowSum_add,
-      Multiset.invPowSum_add, mul_add, mul_add, mul_comm ((s.fiberProfile o t₂).invPowSum α)]
-    exact ENNReal.add_lt_add_left (ENNReal.mul_ne_top (hWne t₁) (hWne t₂)) hodds
   have key : ∀ t : T,
       (∑ c ∈ Finset.univ.filter (s.obs · = o), μ.real {t} * (s.speaker α t).real {c})
         = (μ {t} * ((s.fiberProfile o t).invPowSum α / (s.profile t).invPowSum α)).toReal :=
@@ -1209,8 +1194,40 @@ theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (
     ENNReal.mul_lt_mul_iff_right hμ0 (measure_ne_top _ _),
     ENNReal.div_lt_iff (Or.inl (hZ0 t₁)) (Or.inl (hZne t₁)),
     div_eq_mul_inv, mul_right_comm, ← div_eq_mul_inv,
-    ENNReal.lt_div_iff_mul_lt (Or.inl (hZ0 t₂)) (Or.inl (hZne t₂))]
-  exact hcross
+    ENNReal.lt_div_iff_mul_lt (Or.inl (hZ0 t₂)) (Or.inl (hZne t₂)),
+    ← ENNReal.toReal_lt_toReal
+      (ENNReal.mul_ne_top (hWne t₁) (hZne t₂)) (ENNReal.mul_ne_top (hWne t₂) (hZne t₁)),
+    ENNReal.toReal_mul, ENNReal.toReal_mul]
+
+/-- Certificate form of listener preference at equal priors, uniform in the
+rationality: cross products of fiber and rest profiles strictly dominate
+(the shared fiber-by-fiber terms of the odds comparison cancel). -/
+theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (hα : 0 < α)
+    {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
+    (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c)
+    (hcert : ((s.fiberProfile o t₂).prodMul (s.restProfile o t₁)).StrictDominates
+      ((s.fiberProfile o t₁).prodMul (s.restProfile o t₂))) :
+    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
+  have hWne : ∀ t, (s.fiberProfile o t).invPowSum α ≠ ∞ := fun t =>
+    Multiset.invPowSum_ne_top hα.le (s.zero_notMem_fiberProfile o t)
+  have hodds : (s.fiberProfile o t₁).invPowSum α * (s.restProfile o t₂).invPowSum α
+      < (s.fiberProfile o t₂).invPowSum α * (s.restProfile o t₁).invPowSum α := by
+    rw [← Multiset.invPowSum_prodMul hα.le, ← Multiset.invPowSum_prodMul hα.le]
+    exact hcert.invPowSum_lt hα.le
+      (Multiset.zero_notMem_prodMul (s.zero_notMem_fiberProfile o t₁)
+        (s.zero_notMem_restProfile o t₂))
+  rw [s.listener_real_lt_iff_invPowSum hα hμeq hμ0 h₂,
+    ← ENNReal.toReal_mul, ← ENNReal.toReal_mul,
+    ENNReal.toReal_lt_toReal
+      (ENNReal.mul_ne_top (hWne t₁)
+        (Multiset.invPowSum_ne_top hα.le (s.zero_notMem_profile t₂)))
+      (ENNReal.mul_ne_top (hWne t₂)
+        (Multiset.invPowSum_ne_top hα.le (s.zero_notMem_profile t₁))),
+    s.profile_eq_fiberProfile_add_restProfile o t₁,
+    s.profile_eq_fiberProfile_add_restProfile o t₂, Multiset.invPowSum_add,
+    Multiset.invPowSum_add, mul_add, mul_add, mul_comm ((s.fiberProfile o t₂).invPowSum α)]
+  exact ENNReal.add_lt_add_left
+    (ENNReal.mul_ne_top (hWne t₁) (hWne t₂)) hodds
 
 end Listener
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -1,44 +1,53 @@
 import Mathlib.Probability.Kernel.Posterior
 import Mathlib.Probability.ConditionalProbability
 import Mathlib.MeasureTheory.Measure.Real
-import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 import Linglib.Pragmatics.RSA.Dominates
 
 /-!
 # The Rational Speech Act pipeline on probability kernels
 
-The basic RSA model ([frank-goodman-2012]; [degen-2023] eqs. 1–4) in mathlib's
-probability vocabulary. The literal listener conditions the prior on the
-utterance's extension (`ProbabilityTheory.cond`); the pragmatic speaker is the
-softmax of an `EReal`-valued utility, packaged as a Markov kernel; and the
-pragmatic listener is the Bayesian inverse of the speaker — mathlib's
-posterior kernel `κ†μ`, not a new definition. Predictions are stated on reals
-via `Measure.real`.
+The RSA model ([frank-goodman-2012]; [degen-2023] eqs. 1–4;
+[franke-bergen-2020] eqs. 5–22) in mathlib's probability vocabulary. A
+`RSA.Scenario` bundles a choice space with an extension and an observable
+form per choice; the literal listener is uniform on the extension, the
+speaker is the best response in power-weight form (`ENNReal.rpow` is total,
+so falsity needs no signed utilities), and the listeners are conditionals of
+the joint — rationality and priors are arguments, so findings quantify over
+them. Preference facts come in three registers: support (zero-vs-positive),
+`Multiset.Dominates` certificates on informativity profiles (uniform in the
+rationality), and pinned-rationality evaluation via `Multiset.invPowSum`.
 
 ## Main definitions
 
-* `RSA.literalListener` — eq. 1: the prior conditioned on the extension.
-* `RSA.utility` — eq. 3: informativity minus cost.
-* `RSA.speaker` — eq. 2: the softmax-utility speaker, as a kernel built by
-  `ProbabilityTheory.Kernel.ofWeights`.
+* `RSA.literalListener` — eq. 1: a prior conditioned on the extension.
+* `RSA.speakerOf` — eqs. 2/6–7: the best-response speaker to a listener
+  kernel, as `ProbabilityTheory.Kernel.ofWeights` of `L ^ α`.
+* `RSA.Scenario` — the bundled model: `sem`, `obs`, and the derived `L0`,
+  `speaker`, `production`, `jointListener`, `listener`, `choicePosterior`.
+* `RSA.Scenario.familySpeaker` — eqs. 11–13: state-side latent families
+  (lexical uncertainty); per-index normalization.
 
 ## Main statements
 
 * `ProbabilityTheory.posterior_apply_singleton` — exact Bayes for `κ†μ` at a
   positive-mass observation.
-* `ProbabilityTheory.posterior_real_singleton_lt_iff` — pragmatic-listener
-  preference on reals reduces to prior-weighted speaker masses.
-* `RSA.speaker_real_singleton_lt_iff` — speaker preference reduces to utility
-  comparison.
+* `RSA.Scenario.listener_real_lt_of_support` — hearing `o`, the listener
+  prefers a state verifying `o` over one falsifying it, with no side
+  conditions beyond positive rationality.
+* `RSA.Scenario.listener_real_lt_of_prodMul_strictDominates` — the
+  certificate register: strict domination of fiber-by-rest profile products
+  decides listener preference uniformly in the rationality.
+* `RSA.Scenario.listener_real_lt_iff_invPowSum` — the evaluation register:
+  preference at equal priors is a cross-multiplied `invPowSum` comparison.
 
 ## Implementation notes
 
 All spaces here are finite and discrete; the ⊤ σ-algebra makes every study
-enum standard Borel, so mathlib's disintegration-based posterior applies. Its
-characterization is almost-everywhere, but an ae-fact holds at every atom of
-positive mass (`MeasureTheory.ae_of_singleton_ne_zero`), which yields exact
-Bayes pointwise — no `rnDeriv`. An inapplicable utterance has utility `⊥`
-(weight `0`); `α = 0` gives the uniform speaker since `(0 : EReal) * ⊥ = 0`.
+enum standard Borel, so mathlib's disintegration-based conditionals apply.
+Their characterization is almost-everywhere, but an ae-fact holds at every
+atom of positive mass (`MeasureTheory.ae_of_singleton_ne_zero`), which
+yields exact Bayes pointwise — no `rnDeriv`.
 -/
 
 open MeasureTheory ProbabilityTheory
@@ -111,10 +120,11 @@ theorem ofWeights_real_singleton_lt_iff {w : α → β → ℝ≥0∞} (a : α)
       (ENNReal.div_ne_top (hb b₂) h0),
     ENNReal.div_lt_div_iff_left h0 htop]
 
+omit [MeasurableSingletonClass β] in
 /-- Weight-kernel rows are subprobabilities: normalization gives mass 1 on
 positive finite total weight and 0 otherwise. -/
-instance (w : α → β → ℝ≥0∞) : IsFiniteKernel (ofWeights w) := by
-  refine ⟨⟨1, ENNReal.one_lt_top, fun a => ?_⟩⟩
+theorem ofWeights_apply_univ_le_one (w : α → β → ℝ≥0∞) (a : α) :
+    ofWeights w a Set.univ ≤ 1 := by
   show ((∑ b, w a b)⁻¹ • ∑ b, w a b • Measure.dirac b) Set.univ ≤ 1
   simp only [Measure.smul_apply, Measure.finsetSum_apply, Measure.smul_apply,
     measure_univ, smul_eq_mul, mul_one]
@@ -123,6 +133,9 @@ instance (w : α → β → ℝ≥0∞) : IsFiniteKernel (ofWeights w) := by
   · rcases eq_or_ne (∑ b, w a b) ∞ with htop | htop
     · simp [htop]
     · rw [ENNReal.inv_mul_cancel h0 htop]
+
+instance (w : α → β → ℝ≥0∞) : IsFiniteKernel (ofWeights w) :=
+  ⟨⟨1, ENNReal.one_lt_top, ofWeights_apply_univ_le_one w⟩⟩
 
 end ProbabilityTheory.Kernel
 
@@ -179,19 +192,6 @@ theorem comp_apply_singleton_ne_zero {Ω' 𝓧' : Type*} [MeasurableSpace Ω']
     ← pos_iff_ne_zero, lintegral_pos_iff_support (Kernel.measurable_coe _ (.singleton x))]
   exact lt_of_lt_of_le (pos_iff_ne_zero.mpr hμ)
     (measure_mono (Set.singleton_subset_iff.mpr hκ))
-
-/-- Witness form of the observation-marginal positivity for pair emissions:
-one state with positive prior mass and positive mass on one (observed,
-latent) pair. -/
-theorem map_fst_comp_apply_singleton_ne_zero {Ω' 𝓧' Θ' : Type*}
-    [MeasurableSpace Ω'] [MeasurableSpace 𝓧'] [MeasurableSpace Θ']
-    [MeasurableSingletonClass 𝓧'] [MeasurableSingletonClass Θ']
-    (κ : Kernel Ω' (𝓧' × Θ')) (μ : Measure Ω') {w : Ω'} {x : 𝓧'} {θ : Θ'}
-    (hμ : μ {w} ≠ 0) (hκ : κ w {(x, θ)} ≠ 0) :
-    ((κ ∘ₘ μ).map Prod.fst) {x} ≠ 0 := by
-  rw [Measure.map_apply measurable_fst (.singleton x)]
-  refine fun h => comp_apply_singleton_ne_zero κ μ hμ hκ (measure_mono_null ?_ h)
-  exact Set.singleton_subset_iff.mpr rfl
 
 end ProbabilityTheory
 
@@ -274,133 +274,6 @@ theorem posterior_fst_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableS
 
 end ProbabilityTheory
 
-/-! ### Joint posteriors from partially observed pairs
-
-When a kernel emits a pair of which only the first component is observed —
-RSA's intention models, where the speaker chooses an (utterance, latent) pair
-and the listener hears only the utterance — the listener's joint posterior
-over parameter and latent is the conditional kernel of the reassociated
-joint: the same construction as `ProbabilityTheory.posterior` with a
-reassociation in place of the swap. (When the latent is instead part of the
-state, the joint posterior is plain `κ†μ` at a product parameter space.) -/
-
-namespace ProbabilityTheory
-
-variable {Ω 𝓧 Θ : Type*} [MeasurableSpace Ω] [MeasurableSpace 𝓧] [MeasurableSpace Θ]
-  [StandardBorelSpace Ω] [Nonempty Ω] [StandardBorelSpace Θ] [Nonempty Θ]
-  (κ : Kernel Ω (𝓧 × Θ)) (μ : Measure Ω) [IsFiniteMeasure μ] [IsFiniteKernel κ]
-
-omit [StandardBorelSpace Ω] [Nonempty Ω] [StandardBorelSpace Θ] [Nonempty Θ] in
-lemma measurable_jointReassoc :
-    Measurable fun p : Ω × (𝓧 × Θ) => (p.2.1, (p.1, p.2.2)) :=
-  (measurable_fst.comp measurable_snd).prodMk
-    (measurable_fst.prodMk (measurable_snd.comp measurable_snd))
-
-/-- The distribution of the observed component paired with (parameter,
-latent). -/
-noncomputable def jointObs : Measure (𝓧 × (Ω × Θ)) :=
-  (μ ⊗ₘ κ).map fun p => (p.2.1, (p.1, p.2.2))
-
-instance : IsFiniteMeasure (jointObs κ μ) :=
-  inferInstanceAs (IsFiniteMeasure ((μ ⊗ₘ κ).map _))
-
-omit [StandardBorelSpace Ω] [Nonempty Ω] [StandardBorelSpace Θ] [Nonempty Θ] in
-/-- The observed component of the joint is distributed as the data marginal. -/
-theorem jointObs_fst : (jointObs κ μ).fst = ((κ ∘ₘ μ).map Prod.fst) := by
-  rw [jointObs, Measure.fst,
-    Measure.map_map measurable_fst measurable_jointReassoc,
-    show (Prod.fst ∘ fun p : Ω × (𝓧 × Θ) => (p.2.1, (p.1, p.2.2)))
-      = Prod.fst ∘ Prod.snd from rfl,
-    ← Measure.map_map measurable_fst measurable_snd, ← Measure.snd,
-    Measure.snd_compProd]
-
-/-- The joint posterior over parameter and latent, given the observed first
-component of a jointly chosen pair ([franke-bergen-2020]'s intention
-listeners; the marginalization step of [degen-2023]'s latent-variable
-extensions). -/
-noncomputable def jointPosterior : Kernel 𝓧 (Ω × Θ) :=
-  (jointObs κ μ).condKernel
-
-instance : IsMarkovKernel (jointPosterior κ μ) :=
-  inferInstanceAs (IsMarkovKernel (jointObs κ μ).condKernel)
-
-variable [MeasurableSingletonClass Ω] [MeasurableSingletonClass 𝓧]
-  [MeasurableSingletonClass Θ]
-
-/-- Exact Bayes for the joint posterior at a positive-mass observation. -/
-theorem jointPosterior_apply_singleton {x : 𝓧}
-    (hx : ((κ ∘ₘ μ).map Prod.fst) {x} ≠ 0) (ω : Ω) (θ : Θ) :
-    jointPosterior κ μ x {(ω, θ)}
-      = μ {ω} * κ ω {(x, θ)} / ((κ ∘ₘ μ).map Prod.fst) {x} := by
-  have hd := congrArg (fun m => m ({x} ×ˢ {(ω, θ)}))
-    ((jointObs κ μ).disintegrate (jointObs κ μ).condKernel)
-  beta_reduce at hd
-  rw [Measure.compProd_apply_prod (.singleton x) (.singleton (ω, θ)),
-    lintegral_singleton, jointObs_fst] at hd
-  unfold jointObs at hd
-  rw [Measure.map_apply measurable_jointReassoc
-      ((MeasurableSet.singleton x).prod (.singleton (ω, θ))),
-    show (fun p : Ω × (𝓧 × Θ) => (p.2.1, (p.1, p.2.2))) ⁻¹' ({x} ×ˢ {(ω, θ)})
-        = {ω} ×ˢ {(x, θ)} from by
-      ext ⟨a, b, c⟩
-      simp only [Set.mem_preimage, Set.mem_prod, Set.mem_singleton_iff, Prod.ext_iff]
-      tauto,
-    Measure.compProd_apply_prod (.singleton ω) (.singleton (x, θ)),
-    lintegral_singleton] at hd
-  rw [jointPosterior, ENNReal.eq_div_iff hx (measure_ne_top _ _), mul_comm]
-  unfold jointObs
-  rw [hd]
-  ring
-
-/-- Parameter preference under the joint posterior, on reals: the
-observation's marginal cancels, leaving prior-weighted pooled pair masses. -/
-theorem jointPosterior_fst_real_lt_iff [Fintype Θ] {x : 𝓧}
-    (hx : ((κ ∘ₘ μ).map Prod.fst) {x} ≠ 0) (ω₁ ω₂ : Ω) :
-    (jointPosterior κ μ x).fst.real {ω₁} < (jointPosterior κ μ x).fst.real {ω₂}
-      ↔ (∑ θ, μ.real {ω₁} * (κ ω₁).real {(x, θ)})
-          < ∑ θ, μ.real {ω₂} * (κ ω₂).real {(x, θ)} := by
-  have hne : ∀ ω, (∑ θ, μ {ω} * κ ω {(x, θ)}) ≠ ∞ := fun ω =>
-    ENNReal.sum_ne_top.mpr fun θ _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
-  rw [measureReal_def, measureReal_def, Measure.fst_apply_singleton,
-    Measure.fst_apply_singleton]
-  simp_rw [jointPosterior_apply_singleton κ μ hx, div_eq_mul_inv]
-  rw [← Finset.sum_mul, ← Finset.sum_mul, ← div_eq_mul_inv, ← div_eq_mul_inv,
-    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne ω₁) hx) (ENNReal.div_ne_top (hne ω₂) hx),
-    ENNReal.div_lt_div_iff_left hx (measure_ne_top _ _),
-    ← ENNReal.toReal_lt_toReal (hne ω₁) (hne ω₂),
-    ENNReal.toReal_sum (fun θ _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
-    ENNReal.toReal_sum (fun θ _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
-  simp_rw [ENNReal.toReal_mul]
-  exact Iff.rfl
-
-/-- Latent preference under the joint posterior, on reals. -/
-theorem jointPosterior_snd_real_lt_iff [Fintype Ω] {x : 𝓧}
-    (hx : ((κ ∘ₘ μ).map Prod.fst) {x} ≠ 0) (θ₁ θ₂ : Θ) :
-    (jointPosterior κ μ x).snd.real {θ₁} < (jointPosterior κ μ x).snd.real {θ₂}
-      ↔ (∑ ω, μ.real {ω} * (κ ω).real {(x, θ₁)})
-          < ∑ ω, μ.real {ω} * (κ ω).real {(x, θ₂)} := by
-  have hne : ∀ θ, (∑ ω, μ {ω} * κ ω {(x, θ)}) ≠ ∞ := fun θ =>
-    ENNReal.sum_ne_top.mpr fun ω _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
-  rw [measureReal_def, measureReal_def, Measure.snd_apply_singleton,
-    Measure.snd_apply_singleton]
-  simp_rw [jointPosterior_apply_singleton κ μ hx, div_eq_mul_inv]
-  rw [← Finset.sum_mul, ← Finset.sum_mul, ← div_eq_mul_inv, ← div_eq_mul_inv,
-    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne θ₁) hx) (ENNReal.div_ne_top (hne θ₂) hx),
-    ENNReal.div_lt_div_iff_left hx (measure_ne_top _ _),
-    ← ENNReal.toReal_lt_toReal (hne θ₁) (hne θ₂),
-    ENNReal.toReal_sum (fun ω _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
-    ENNReal.toReal_sum (fun ω _ =>
-      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
-  simp_rw [ENNReal.toReal_mul]
-  exact Iff.rfl
-
-end ProbabilityTheory
-
 /-! ### The RSA pipeline -/
 
 namespace RSA
@@ -442,347 +315,6 @@ theorem isMarkovKernel_literalListener (μ : Measure W) [IsFiniteMeasure μ]
   refine ⟨fun u => ?_⟩
   rw [literalListener, Kernel.ofFunOfCountable, Kernel.coe_mk]
   exact cond_isProbabilityMeasure (h u)
-
-/-- Speaker utility (eq. 3): informativity minus cost, valued in `EReal` so
-that a literally false utterance (`L0 = 0`) has utility `⊥`. -/
-noncomputable def utility (L0 : Kernel U W) (cost : U → ℝ) (w : W) (u : U) : EReal :=
-  ENNReal.log (L0 u {w}) - (cost u : EReal)
-
-/-- The pragmatic speaker (eq. 2): the softmax of the utility at rationality
-`α`, as a kernel from worlds to utterances. -/
-noncomputable def speaker (α : ℝ) (util : W → U → EReal) : Kernel W U :=
-  Kernel.ofWeights fun w u => ((α : EReal) * util w u).exp
-
-@[simp] theorem speaker_apply_singleton (α : ℝ) (util : W → U → EReal) (w : W) (u : U) :
-    speaker α util w {u} = ((α : EReal) * util w u).exp / ∑ u', ((α : EReal) * util w u').exp :=
-  Kernel.ofWeights_apply_singleton _ w u
-
-/-- An utterance of utility `⊥` is never produced. -/
-theorem speaker_apply_singleton_eq_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
-    (hbot : (α : EReal) * util w u = ⊥) : speaker α util w {u} = 0 := by
-  rw [speaker_apply_singleton, hbot, EReal.exp_bot, ENNReal.zero_div]
-
-/-- Real form of `speaker_apply_singleton_eq_zero`. -/
-theorem speaker_real_singleton_eq_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
-    (hbot : (α : EReal) * util w u = ⊥) : (speaker α util w).real {u} = 0 := by
-  rw [measureReal_def, speaker_apply_singleton_eq_zero hbot, ENNReal.toReal_zero]
-
-/-- A speaker mass is positive as soon as the utterance's scaled utility is
-not `⊥` and no scaled utility is `⊤`. -/
-theorem speaker_apply_singleton_ne_zero {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
-    (hbot : (α : EReal) * util w u ≠ ⊥) (htop : ∀ u', (α : EReal) * util w u' ≠ ⊤) :
-    speaker α util w {u} ≠ 0 := by
-  rw [speaker_apply_singleton, ne_eq, ENNReal.div_eq_zero_iff, not_or]
-  exact ⟨by simp [EReal.exp_eq_zero_iff, hbot],
-    ENNReal.sum_ne_top.mpr fun u' _ => by simp [EReal.exp_eq_top_iff, htop u']⟩
-
-/-- A speaker mass is positive on reals as soon as the utterance's scaled
-utility is not `⊥` and no scaled utility is `⊤`. -/
-theorem speaker_real_singleton_pos {α : ℝ} {util : W → U → EReal} {w : W} {u : U}
-    (hbot : (α : EReal) * util w u ≠ ⊥) (htop : ∀ u', (α : EReal) * util w u' ≠ ⊤) :
-    0 < (speaker α util w).real {u} := by
-  rw [measureReal_def]
-  refine ENNReal.toReal_pos (speaker_apply_singleton_ne_zero hbot htop) ?_
-  rw [speaker_apply_singleton]
-  exact ENNReal.div_ne_top (by simp [EReal.exp_eq_top_iff, htop u]) fun hz =>
-    hbot (by simpa [EReal.exp_eq_zero_iff] using
-      Finset.sum_eq_zero_iff.mp hz u (Finset.mem_univ u))
-
-omit [MeasurableSingletonClass U] in
-/-- The speaker is Markov as soon as no scaled utility is `⊤` and every
-world has an applicable (scaled utility `≠ ⊥`) utterance. -/
-theorem isMarkovKernel_speaker {α : ℝ} {util : W → U → EReal}
-    (htop : ∀ w u, (α : EReal) * util w u ≠ ⊤)
-    (hwit : ∀ w, ∃ u, (α : EReal) * util w u ≠ ⊥) :
-    IsMarkovKernel (speaker α util) :=
-  Kernel.isMarkovKernel_ofWeights
-    (fun w => (hwit w).imp fun u hu => by simp [EReal.exp_eq_zero_iff, hu])
-    (fun w u => by simp [EReal.exp_eq_top_iff, htop w u])
-
-omit [Fintype W] [MeasurableSingletonClass W] [Fintype U] [MeasurableSingletonClass U] in
-/-- The cost-free informativity speaker reduces to power weights: the softmax
-weight at `utility L0 0` is `L0^α` — the specialization every exact-zeros
-study instantiates. -/
-theorem exp_mul_utility_zero (α : ℝ) (L0 : Kernel U W) (w : W) (u : U) :
-    ((α : EReal) * utility L0 (fun _ => 0) w u).exp = L0 u {w} ^ α := by
-  rw [utility, EReal.coe_zero, sub_zero, ← ENNReal.log_rpow, ENNReal.exp_log]
-
-/-- The literal listener never takes the value `⊤`: a null extension nulls
-the numerator too. -/
-theorem literalListener_apply_ne_top (μ : Measure W) [IsFiniteMeasure μ]
-    (sem : U → Set W) (u : U) (t : Set W) :
-    literalListener μ sem u t ≠ ∞ := by
-  rw [literalListener_apply]
-  rcases eq_or_ne (μ (sem u)) 0 with h | h
-  · rw [measure_mono_null Set.inter_subset_left h, mul_zero]
-    exact ENNReal.zero_ne_top
-  · exact ENNReal.mul_ne_top (ENNReal.inv_ne_top.mpr h) (measure_ne_top _ _)
-
-/-- The literal listener on reals: the renormalized prior. -/
-theorem literalListener_real_singleton_of_mem (μ : Measure W) [IsFiniteMeasure μ]
-    {sem : U → Set W} {u : U} {w : W} (h : w ∈ sem u) :
-    (literalListener μ sem u).real {w} = μ.real {w} / μ.real (sem u) := by
-  rw [measureReal_def, literalListener_apply_singleton_of_mem μ sem h,
-    ENNReal.toReal_mul, ENNReal.toReal_inv, measureReal_def, measureReal_def,
-    inv_mul_eq_div]
-
-theorem literalListener_real_singleton_of_not_mem (μ : Measure W)
-    {sem : U → Set W} {u : U} {w : W} (h : w ∉ sem u) :
-    (literalListener μ sem u).real {w} = 0 := by
-  rw [measureReal_def, literalListener_apply_singleton_of_not_mem μ sem h,
-    ENNReal.toReal_zero]
-
-/-- A member of a finite-mass extension with positive prior mass has positive
-literal-listener mass. -/
-theorem literalListener_apply_singleton_ne_zero (μ : Measure W) [IsFiniteMeasure μ]
-    {sem : U → Set W} {u : U} {w : W} (h : w ∈ sem u) (hw : μ {w} ≠ 0) :
-    literalListener μ sem u {w} ≠ 0 := by
-  rw [literalListener_apply_singleton_of_mem μ sem h]
-  exact mul_ne_zero (ENNReal.inv_ne_zero.mpr (measure_ne_top _ _)) hw
-
-/-- `(α : EReal) * ENNReal.log x` is bounded above for nonnegative real `α`
-and `x ≠ ⊤` (migrating here from the PMF softmax stack). -/
-theorem coe_mul_log_ne_top {α : ℝ} (hα : 0 ≤ α) {x : ℝ≥0∞} (hx : x ≠ ⊤) :
-    ((α : EReal) * ENNReal.log x) ≠ ⊤ := by
-  rw [EReal.mul_ne_top]
-  exact ⟨Or.inl (EReal.coe_ne_bot _), Or.inl (EReal.coe_nonneg.mpr hα),
-    Or.inl (EReal.coe_ne_top _), Or.inr fun h => hx (ENNReal.log_eq_top_iff.mp h)⟩
-
-/-- `(α : EReal) * ENNReal.log x` is bounded below for nonnegative real `α`
-and `x ≠ 0`. -/
-theorem coe_mul_log_ne_bot {α : ℝ} (hα : 0 ≤ α) {x : ℝ≥0∞} (hx : x ≠ 0) :
-    ((α : EReal) * ENNReal.log x) ≠ ⊥ := by
-  rw [EReal.mul_ne_bot]
-  exact ⟨Or.inl (EReal.coe_ne_bot _), Or.inr fun h => hx (ENNReal.log_eq_bot_iff.mp h),
-    Or.inl (EReal.coe_ne_top _), Or.inl (EReal.coe_nonneg.mpr hα)⟩
-
-omit [MeasurableSingletonClass U] in
-/-- The cost-free informativity speaker is Markov given a nonnegative
-rationality, finite literal-listener values, and an applicable utterance per
-world. -/
-theorem isMarkovKernel_speaker_utility_zero {α : ℝ} (hα : 0 ≤ α) {L0 : Kernel U W}
-    (htop : ∀ u w, L0 u {w} ≠ ∞) (hwit : ∀ w, ∃ u, L0 u {w} ≠ 0) :
-    IsMarkovKernel (speaker α (utility L0 fun _ => 0)) := by
-  refine isMarkovKernel_speaker (fun w u => ?_) fun w => (hwit w).imp fun u hu => ?_
-  · rw [utility, EReal.coe_zero, sub_zero]
-    exact coe_mul_log_ne_top hα (htop u w)
-  · rw [utility, EReal.coe_zero, sub_zero]
-    exact coe_mul_log_ne_bot hα hu
-
-/-- The cost-free informativity speaker on reals: normalized powers of the
-literal listener. -/
-theorem speaker_utility_zero_real_singleton {α : ℝ} (hα : 0 ≤ α) (L0 : Kernel U W)
-    {w : W} (htop : ∀ u', L0 u' {w} ≠ ∞) (u : U) :
-    (speaker α (utility L0 fun _ => 0) w).real {u}
-      = (L0 u {w}).toReal ^ α / ∑ u', (L0 u' {w}).toReal ^ α := by
-  rw [measureReal_def, speaker_apply_singleton]
-  simp_rw [exp_mul_utility_zero]
-  rw [ENNReal.toReal_div,
-    ENNReal.toReal_sum fun u' _ => ENNReal.rpow_ne_top_of_nonneg hα (htop u')]
-  simp_rw [ENNReal.toReal_rpow]
-
-/-! ### The bundled speaker
-
-`RSA.Speaker` packages the theory's data — a rationality, a prior, and a
-semantics — and derives the pipeline: `S.L0` conditions the prior on an
-utterance's extension, `S.toKernel` is the softmax-informativity speaker, and
-the listeners are its Bayesian inverses. Its API states facts at the semantic
-level (membership in extensions), so EReal utilities never surface in
-studies; standing side conditions are the typeclasses `Speaker.Viable` and
-`Speaker.Positive`. -/
-
-variable (W U) in
-/-- A cost-free informativity speaker: rationality, prior beliefs, and a
-truth-conditional semantics. -/
-structure Speaker where
-  /-- The softmax rationality (Degen's α). -/
-  α : ℝ
-  /-- Rationality is positive: at `α = 0` the speaker is uniformly random and
-  support is no longer literal truth. -/
-  α_pos : 0 < α
-  /-- Prior beliefs about worlds. -/
-  prior : Measure W
-  /-- The semantics: each utterance's extension. -/
-  sem : U → Set W
-
-namespace Speaker
-
-section
-variable (S : Speaker W U)
-
-/-- The literal listener (eq. 1). -/
-noncomputable def L0 : Kernel U W := literalListener S.prior S.sem
-
-/-- The speaker kernel (eq. 2 at the informativity utility of eq. 3). -/
-noncomputable def toKernel : Kernel W U := speaker S.α (utility S.L0 fun _ => 0)
-
-/-- Every world has a true utterance. -/
-class Viable : Prop where
-  exists_mem : ∀ w, ∃ u, w ∈ S.sem u
-
-/-- The prior gives every world positive mass. -/
-class Positive : Prop where
-  prior_ne_zero : ∀ w, S.prior {w} ≠ 0
-
-variable [IsFiniteMeasure S.prior]
-
-omit [MeasurableSpace U] [Fintype W] [MeasurableSingletonClass W] [Fintype U]
-  [MeasurableSingletonClass U] in
-theorem prior_real_pos [S.Positive] (w : W) : 0 < S.prior.real {w} :=
-  ENNReal.toReal_pos (Positive.prior_ne_zero w) (measure_ne_top _ _)
-
-theorem L0_apply_singleton_ne_zero [S.Positive] {u : U} {w : W} (h : w ∈ S.sem u) :
-    S.L0 u {w} ≠ 0 :=
-  literalListener_apply_singleton_ne_zero S.prior h (Positive.prior_ne_zero w)
-
-private theorem scaled_utility_ne_top (w : W) (u : U) :
-    (S.α : EReal) * utility S.L0 (fun _ => 0) w u ≠ ⊤ := by
-  rw [utility, EReal.coe_zero, sub_zero]
-  exact coe_mul_log_ne_top S.α_pos.le (literalListener_apply_ne_top S.prior _ u {w})
-
-instance [S.Viable] [S.Positive] : IsMarkovKernel S.toKernel :=
-  isMarkovKernel_speaker_utility_zero S.α_pos.le
-    (fun u w => literalListener_apply_ne_top S.prior _ u {w})
-    fun w => (Viable.exists_mem (S := S) w).imp fun _ h => S.L0_apply_singleton_ne_zero h
-
-/-- The speaker's support is literal truth: an utterance gets positive mass
-exactly on its extension. -/
-@[simp] theorem toKernel_real_singleton_pos_iff [S.Positive] (w : W) (u : U) :
-    0 < (S.toKernel w).real {u} ↔ w ∈ S.sem u := by
-  constructor
-  · intro h
-    by_contra hmem
-    rw [toKernel, speaker_real_singleton_eq_zero (by
-      rw [utility, EReal.coe_zero, sub_zero, L0,
-        literalListener_apply_singleton_of_not_mem S.prior _ hmem, ENNReal.log_zero]
-      exact EReal.mul_bot_of_pos (by exact_mod_cast S.α_pos))] at h
-    exact lt_irrefl 0 h
-  · intro h
-    exact speaker_real_singleton_pos
-      (by
-        rw [utility, EReal.coe_zero, sub_zero]
-        exact coe_mul_log_ne_bot S.α_pos.le (S.L0_apply_singleton_ne_zero h))
-      (S.scaled_utility_ne_top w)
-
-/-- An utterance outside its extension is never produced. -/
-theorem toKernel_real_singleton_eq_zero [S.Positive] {w : W} {u : U} (h : w ∉ S.sem u) :
-    (S.toKernel w).real {u} = 0 := by
-  by_contra hne
-  exact h ((S.toKernel_real_singleton_pos_iff w u).mp
-    (lt_of_le_of_ne measureReal_nonneg (Ne.symm hne)))
-
-/-- A true utterance is produced with positive mass. -/
-theorem toKernel_apply_singleton_ne_zero [S.Positive] {w : W} {u : U} (h : w ∈ S.sem u) :
-    S.toKernel w {u} ≠ 0 := by
-  intro h0
-  have hpos := (S.toKernel_real_singleton_pos_iff w u).mpr h
-  rw [measureReal_def, h0] at hpos
-  simp at hpos
-
-section Listener
-
-variable [StandardBorelSpace W] [Nonempty W] [S.Viable] [S.Positive]
-
-/-- The pragmatic listener (eq. 4): the Bayesian inverse of the speaker. -/
-noncomputable def listener : Kernel U W := S.toKernel†S.prior
-
-/-- Pragmatic-listener preference reduces to comparing prior-weighted speaker
-masses; the observation's marginal cancels. -/
-theorem listener_real_singleton_lt_iff {u : U} (hu : (S.toKernel ∘ₘ S.prior) {u} ≠ 0)
-    (w₁ w₂ : W) :
-    (S.listener u).real {w₁} < (S.listener u).real {w₂}
-      ↔ S.prior.real {w₁} * (S.toKernel w₁).real {u}
-        < S.prior.real {w₂} * (S.toKernel w₂).real {u} :=
-  posterior_real_singleton_lt_iff _ _ hu w₁ w₂
-
-/-- Support preference: hearing `u`, the pragmatic listener strictly prefers a
-world in `u`'s extension over one outside it. The truth of `u` at `w₂` also
-witnesses the positive observation marginal. -/
-theorem listener_real_singleton_lt_of_support {u : U} {w₁ w₂ : W}
-    (h₁ : w₁ ∉ S.sem u) (h₂ : w₂ ∈ S.sem u) :
-    (S.listener u).real {w₁} < (S.listener u).real {w₂} := by
-  rw [listener, posterior_real_singleton_lt_iff _ _
-      (comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂) (S.toKernel_apply_singleton_ne_zero h₂)),
-    S.toKernel_real_singleton_eq_zero h₁, mul_zero]
-  exact mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ u).mpr h₂)
-
-end Listener
-
-end
-
-section Joint
-
-variable {X Θ : Type*} [MeasurableSpace X] [Fintype X] [MeasurableSingletonClass X]
-  [MeasurableSpace Θ] [Fintype Θ] [MeasurableSingletonClass Θ]
-  [StandardBorelSpace Θ] [Nonempty Θ] [StandardBorelSpace W] [Nonempty W]
-  (S : Speaker W (X × Θ)) [IsFiniteMeasure S.prior] [S.Viable] [S.Positive]
-
-/-- The joint pragmatic listener over world and latent, given the heard
-utterance ([franke-bergen-2020]'s intention listeners). -/
-noncomputable def jointListener : Kernel X (W × Θ) := jointPosterior S.toKernel S.prior
-
-/-- World preference under the joint listener reduces to comparing
-prior-weighted pooled pair masses. -/
-theorem jointListener_fst_real_lt_iff {x : X}
-    (hx : ((S.toKernel ∘ₘ S.prior).map Prod.fst) {x} ≠ 0) (w₁ w₂ : W) :
-    (S.jointListener x).fst.real {w₁} < (S.jointListener x).fst.real {w₂}
-      ↔ (∑ θ, S.prior.real {w₁} * (S.toKernel w₁).real {(x, θ)})
-        < ∑ θ, S.prior.real {w₂} * (S.toKernel w₂).real {(x, θ)} :=
-  jointPosterior_fst_real_lt_iff _ _ hx w₁ w₂
-
-/-- Latent preference under the joint listener reduces to comparing
-prior-weighted per-world masses. -/
-theorem jointListener_snd_real_lt_iff {x : X}
-    (hx : ((S.toKernel ∘ₘ S.prior).map Prod.fst) {x} ≠ 0) (θ₁ θ₂ : Θ) :
-    (S.jointListener x).snd.real {θ₁} < (S.jointListener x).snd.real {θ₂}
-      ↔ (∑ w, S.prior.real {w} * (S.toKernel w).real {(x, θ₁)})
-        < ∑ w, S.prior.real {w} * (S.toKernel w).real {(x, θ₂)} :=
-  jointPosterior_snd_real_lt_iff _ _ hx θ₁ θ₂
-
-/-- World preference by support: if no latent verifies the heard utterance at
-`w₁` and some latent verifies it at `w₂`, the joint listener's world marginal
-strictly prefers `w₂`. -/
-theorem jointListener_fst_real_lt_of_support {x : X} {w₁ w₂ : W}
-    (h₁ : ∀ θ, w₁ ∉ S.sem (x, θ)) (h₂ : ∃ θ, w₂ ∈ S.sem (x, θ)) :
-    (S.jointListener x).fst.real {w₁} < (S.jointListener x).fst.real {w₂} := by
-  obtain ⟨θ₂, h₂⟩ := h₂
-  rw [jointListener, jointPosterior_fst_real_lt_iff _ _
-      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂)
-        (S.toKernel_apply_singleton_ne_zero h₂)),
-    Finset.sum_congr rfl fun θ _ => by rw [S.toKernel_real_singleton_eq_zero (h₁ θ), mul_zero],
-    Finset.sum_const_zero]
-  exact Finset.sum_pos' (fun θ _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
-    ⟨θ₂, Finset.mem_univ _,
-      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
-
-/-- Latent preference by support: if no world verifies the heard utterance
-under `θ₁` and some world of positive prior mass verifies it under `θ₂`, the
-joint listener's latent marginal strictly prefers `θ₂`. -/
-theorem jointListener_snd_real_lt_of_support {x : X} {θ₁ θ₂ : Θ}
-    (h₁ : ∀ w, w ∉ S.sem (x, θ₁)) (h₂ : ∃ w, w ∈ S.sem (x, θ₂)) :
-    (S.jointListener x).snd.real {θ₁} < (S.jointListener x).snd.real {θ₂} := by
-  obtain ⟨w₂, h₂⟩ := h₂
-  rw [jointListener, jointPosterior_snd_real_lt_iff _ _
-      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_ne_zero w₂)
-        (S.toKernel_apply_singleton_ne_zero h₂)),
-    Finset.sum_congr rfl fun w _ => by rw [S.toKernel_real_singleton_eq_zero (h₁ w), mul_zero],
-    Finset.sum_const_zero]
-  exact Finset.sum_pos' (fun w _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
-    ⟨w₂, Finset.mem_univ _,
-      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_singleton_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
-
-end Joint
-
-end Speaker
-
-/-- Speaker preference on reals is utility comparison (eq. 2's softmax is
-strictly monotone; the partition function cancels). -/
-theorem speaker_real_singleton_lt_iff {α : ℝ} {util : W → U → EReal} (w : W)
-    (h0 : (∑ u, ((α : EReal) * util w u).exp) ≠ 0)
-    (hZtop : (∑ u, ((α : EReal) * util w u).exp) ≠ ∞) (u₁ u₂ : U) :
-    (speaker α util w).real {u₁} < (speaker α util w).real {u₂}
-      ↔ (α : EReal) * util w u₁ < (α : EReal) * util w u₂ := by
-  rw [speaker, Kernel.ofWeights_real_singleton_lt_iff w h0 hZtop, EReal.exp_lt_exp_iff]
 
 /-! ### The best-response speaker in power-weight form
 
@@ -900,6 +432,10 @@ noncomputable def speaker (α : ℝ) : Kernel T C := speakerOf α s.L0
 
 instance (α : ℝ) : IsFiniteKernel (s.speaker α) :=
   inferInstanceAs (IsFiniteKernel (Kernel.ofWeights _))
+
+omit [DecidableEq T] in
+theorem speaker_apply_univ_le_one (α : ℝ) (t : T) : s.speaker α t Set.univ ≤ 1 :=
+  Kernel.ofWeights_apply_univ_le_one (fun w u => s.L0 u {w} ^ α) t
 
 variable (T C O) in
 /-- Every state has a true choice — the proviso making the speaker a
@@ -1273,6 +809,35 @@ theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (
 end Listener
 
 end
+
+/-! #### State-side latent families
+
+[franke-bergen-2020] eqs. 11–13 (lexical uncertainty): each speaker carries a
+fixed latent index and best-responds within it — normalization is per-index,
+in contrast to the choice-side latents of `jointListener`, whose speaker
+normalizes across the pooled pairs. The weight functions coincide; only the
+normalization differs. -/
+
+section Family
+
+variable {T C O L : Type*} [MeasurableSpace T] [Fintype T] [DecidableEq T]
+  [MeasurableSingletonClass T] [MeasurableSpace C] [Fintype C] [DiscreteMeasurableSpace C]
+  [MeasurableSpace L] [Countable L] [MeasurableSingletonClass L]
+
+/-- The family speaker: the latent index rides in the state. -/
+noncomputable def familySpeaker (f : L → Scenario T C O) (α : ℝ) : Kernel (T × L) C :=
+  Kernel.ofFunOfCountable fun tl => (f tl.2).speaker α tl.1
+
+omit [DecidableEq T] in
+@[simp] theorem familySpeaker_apply (f : L → Scenario T C O) (α : ℝ) (tl : T × L) :
+    familySpeaker f α tl = (f tl.2).speaker α tl.1 := rfl
+
+instance (f : L → Scenario T C O) (α : ℝ) : IsFiniteKernel (familySpeaker f α) :=
+  ⟨⟨1, ENNReal.one_lt_top, fun tl => by
+    rw [familySpeaker_apply]
+    exact (f tl.2).speaker_apply_univ_le_one α tl.1⟩⟩
+
+end Family
 
 end Scenario
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -110,6 +110,19 @@ theorem ofWeights_real_singleton_lt_iff {w : α → β → ℝ≥0∞} (a : α)
       (ENNReal.div_ne_top (hb b₂) h0),
     ENNReal.div_lt_div_iff_left h0 htop]
 
+/-- Weight-kernel rows are subprobabilities: normalization gives mass 1 on
+positive finite total weight and 0 otherwise. -/
+instance (w : α → β → ℝ≥0∞) : IsFiniteKernel (ofWeights w) := by
+  refine ⟨⟨1, ENNReal.one_lt_top, fun a => ?_⟩⟩
+  show ((∑ b, w a b)⁻¹ • ∑ b, w a b • Measure.dirac b) Set.univ ≤ 1
+  simp only [Measure.smul_apply, Measure.finsetSum_apply, Measure.smul_apply,
+    measure_univ, smul_eq_mul, mul_one]
+  rcases eq_or_ne (∑ b, w a b) 0 with h0 | h0
+  · simp [h0]
+  · rcases eq_or_ne (∑ b, w a b) ∞ with htop | htop
+    · simp [htop]
+    · rw [ENNReal.inv_mul_cancel h0 htop]
+
 end ProbabilityTheory.Kernel
 
 /-! ### Exact Bayes for the posterior kernel at atoms -/
@@ -770,4 +783,299 @@ theorem speaker_real_singleton_lt_iff {α : ℝ} {util : W → U → EReal} (w :
       ↔ (α : EReal) * util w u₁ < (α : EReal) * util w u₂ := by
   rw [speaker, Kernel.ofWeights_real_singleton_lt_iff w h0 hZtop, EReal.exp_lt_exp_iff]
 
+/-! ### The best-response speaker in power-weight form
+
+[franke-bergen-2020] eq. 6 ≡ eq. 7: softmax of `α · log L` is, in weight
+form, `L ^ α`. On `ℝ≥0∞` the power is total — an inapplicable utterance has
+weight `0 ^ α = 0` — so falsity needs no `EReal` utilities and no `⊥`/`⊤`
+side conditions. -/
+
+private theorem weight_rpow_ne_zero {α : ℝ} (hα : 0 ≤ α) {x : ℝ≥0∞} (hx : x ≠ 0) :
+    x ^ α ≠ 0 := by
+  rw [ne_eq, ENNReal.rpow_eq_zero_iff, not_or]
+  exact ⟨fun h => hx h.1, fun h => absurd hα (not_le.mpr h.2)⟩
+
+private theorem weight_rpow_ne_top {α : ℝ} (hα : 0 ≤ α) {x : ℝ≥0∞} (hle : x ≤ 1) :
+    x ^ α ≠ ∞ :=
+  ne_top_of_le_ne_top ENNReal.one_ne_top
+    (ENNReal.one_rpow α ▸ ENNReal.rpow_le_rpow hle hα)
+
+/-- The best-response speaker to a listener kernel: power weights
+`L u {w} ^ α` ([franke-bergen-2020] eq. 7, [degen-2023] eq. 2 at the
+informativity utility). -/
+noncomputable def speakerOf (α : ℝ) (L : Kernel U W) : Kernel W U :=
+  Kernel.ofWeights fun w u => L u {w} ^ α
+
+@[simp] theorem speakerOf_apply_singleton (α : ℝ) (L : Kernel U W) (w : W) (u : U) :
+    speakerOf α L w {u} = L u {w} ^ α / ∑ u', L u' {w} ^ α :=
+  Kernel.ofWeights_apply_singleton _ w u
+
+instance (α : ℝ) (L : Kernel U W) : IsFiniteKernel (speakerOf α L) :=
+  inferInstanceAs (IsFiniteKernel (Kernel.ofWeights _))
+
+omit [MeasurableSingletonClass U] in
+/-- The speaker is a probability kernel whenever every state has a true
+utterance ([franke-bergen-2020] eq. 7's proviso). -/
+theorem isMarkovKernel_speakerOf {α : ℝ} (hα : 0 ≤ α) (L : Kernel U W)
+    (hle : ∀ u w, L u {w} ≤ 1) (h0 : ∀ w, ∃ u, L u {w} ≠ 0) :
+    IsMarkovKernel (speakerOf α L) :=
+  Kernel.isMarkovKernel_ofWeights
+    (fun w => (h0 w).imp fun _ hu => weight_rpow_ne_zero hα hu)
+    fun w u => weight_rpow_ne_top hα (hle u w)
+
+/-- A literally false utterance is never produced (positive rationality). -/
+theorem speakerOf_apply_singleton_eq_zero {α : ℝ} (hα : 0 < α) {L : Kernel U W}
+    {w : W} {u : U} (h : L u {w} = 0) : speakerOf α L w {u} = 0 := by
+  rw [speakerOf_apply_singleton, h, ENNReal.zero_rpow_of_pos hα, ENNReal.zero_div]
+
+/-- A literally true utterance is produced with positive mass. -/
+theorem speakerOf_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {L : Kernel U W}
+    {w : W} (hle : ∀ u', L u' {w} ≤ 1) {u : U} (h : L u {w} ≠ 0) :
+    speakerOf α L w {u} ≠ 0 := by
+  rw [speakerOf_apply_singleton, ne_eq, ENNReal.div_eq_zero_iff, not_or]
+  exact ⟨weight_rpow_ne_zero hα h,
+    ENNReal.sum_ne_top.mpr fun u' _ => weight_rpow_ne_top hα (hle u')⟩
+
+/-! ### Choice scenarios
+
+The bundled theory object: a choice space with an extension and an
+observable form for each choice. Rationality and prior are arguments of the
+derived kernels, not data — findings quantify over `α`. [franke-bergen-2020]'s
+vanilla, LI, and GI models are three instantiations (identity observation
+with the bare parse; `Prod.fst` over pair choices, eqs. 18/21); LU places its
+latent in the state instead and is *not* a `Scenario` — its speaker
+normalizes per lexicon, not against the pooled choice space. -/
+
+variable (T C O : Type*) in
+/-- A finite RSA choice scenario: each choice (an utterance, or an
+(utterance, parse) pair) carries an extension and an observable form. -/
+structure Scenario where
+  /-- The extension of each choice. -/
+  sem : C → Finset T
+  /-- The observable form of each choice: what the listener hears. -/
+  obs : C → O
+
+namespace Scenario
+
+section
+
+variable {T C O : Type*} [MeasurableSpace T] [DecidableEq T] [MeasurableSingletonClass T]
+  [MeasurableSpace C] [Fintype C] [DiscreteMeasurableSpace C]
+  (s : Scenario T C O)
+
+/-- The literal listener ([franke-bergen-2020] eq. 5 at the paper's standing
+uniform prior): uniform over the choice's extension. -/
+noncomputable def L0 : Kernel C T :=
+  Kernel.ofFunOfCountable fun c => uniformOn ↑(s.sem c)
+
+theorem L0_apply_singleton (c : C) (t : T) :
+    s.L0 c {t} = if t ∈ s.sem c then ((s.sem c).card : ℝ≥0∞)⁻¹ else 0 := by
+  show uniformOn ↑(s.sem c) {t} = _
+  rw [uniformOn, cond_apply (s.sem c).measurableSet, Measure.count_apply_finset]
+  split
+  · rw [show ↑(s.sem c) ∩ {t} = ({t} : Set T) from
+        Set.inter_eq_self_of_subset_right (by simpa using ‹t ∈ s.sem c›),
+      Measure.count_singleton, mul_one]
+  · rw [show ↑(s.sem c) ∩ {t} = (∅ : Set T) from by
+        simpa [Set.eq_empty_iff_forall_notMem] using ‹t ∉ s.sem c›,
+      measure_empty, mul_zero]
+
+theorem L0_apply_singleton_le_one (c : C) (t : T) : s.L0 c {t} ≤ 1 := by
+  rw [L0_apply_singleton]
+  split
+  · exact ENNReal.inv_le_one.mpr (by exact_mod_cast Finset.card_pos.mpr ⟨t, ‹_›⟩)
+  · exact zero_le_one
+
+theorem L0_apply_singleton_ne_zero {c : C} {t : T} (h : t ∈ s.sem c) :
+    s.L0 c {t} ≠ 0 := by
+  rw [L0_apply_singleton, if_pos h]
+  simp
+
+variable [Fintype T]
+
+/-- The pragmatic speaker ([franke-bergen-2020] eqs. 6–7, 18a, 21a): best
+response at rationality `α`. -/
+noncomputable def speaker (α : ℝ) : Kernel T C := speakerOf α s.L0
+
+instance (α : ℝ) : IsFiniteKernel (s.speaker α) :=
+  inferInstanceAs (IsFiniteKernel (Kernel.ofWeights _))
+
+variable (T C O) in
+/-- Every state has a true choice — the proviso making the speaker a
+probability kernel. -/
+class Expressible (s : Scenario T C O) : Prop where
+  exists_mem_sem : ∀ t, ∃ c, t ∈ s.sem c
+
+theorem isMarkovKernel_speaker {α : ℝ} (hα : 0 ≤ α) [s.Expressible] :
+    IsMarkovKernel (s.speaker α) :=
+  isMarkovKernel_speakerOf hα s.L0 (fun c t => s.L0_apply_singleton_le_one c t)
+    fun t => (Expressible.exists_mem_sem (s := s) t).imp
+      fun _ h => s.L0_apply_singleton_ne_zero h
+
+theorem speaker_apply_singleton_eq_zero {α : ℝ} (hα : 0 < α) {t : T} {c : C}
+    (h : t ∉ s.sem c) : s.speaker α t {c} = 0 :=
+  speakerOf_apply_singleton_eq_zero hα (by rw [s.L0_apply_singleton, if_neg h])
+
+theorem speaker_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {t : T} {c : C}
+    (h : t ∈ s.sem c) : s.speaker α t {c} ≠ 0 :=
+  speakerOf_apply_singleton_ne_zero hα (fun c' => s.L0_apply_singleton_le_one c' t)
+    (s.L0_apply_singleton_ne_zero h)
+
+theorem speaker_real_singleton_eq_zero {α : ℝ} (hα : 0 < α) {t : T} {c : C}
+    (h : t ∉ s.sem c) : (s.speaker α t).real {c} = 0 := by
+  rw [measureReal_def, s.speaker_apply_singleton_eq_zero hα h, ENNReal.toReal_zero]
+
+theorem speaker_real_singleton_pos {α : ℝ} (hα : 0 ≤ α) {t : T} {c : C}
+    (h : t ∈ s.sem c) : 0 < (s.speaker α t).real {c} :=
+  ENNReal.toReal_pos (s.speaker_apply_singleton_ne_zero hα h) (measure_ne_top _ _)
+
+variable [MeasurableSpace O] [MeasurableSingletonClass O] [DecidableEq O]
+
+omit [Fintype T] [DecidableEq T] [MeasurableSingletonClass T] [Fintype C]
+  [MeasurableSingletonClass O] [DecidableEq O] in
+private theorem measurable_obsPair : Measurable fun p : T × C => (s.obs p.2, p) :=
+  (Measurable.of_discrete.comp measurable_snd).prodMk measurable_id
+
+omit [DecidableEq T] [DecidableEq O] in
+/-- A positive-prior state truly described by an `o`-shaped choice witnesses
+a positive observation marginal. -/
+theorem map_obs_comp_ne_zero {α : ℝ} {μ : Measure T} {t : T} {c : C} {o : O}
+    (hμ : μ {t} ≠ 0) (hc : s.obs c = o) (hs : s.speaker α t {c} ≠ 0) :
+    ((s.speaker α ∘ₘ μ).map s.obs) {o} ≠ 0 := by
+  rw [Measure.map_apply Measurable.of_discrete (.singleton o)]
+  intro h
+  exact comp_apply_singleton_ne_zero _ _ hμ hs
+    (measure_mono_null (Set.singleton_subset_iff.mpr (by simp [hc])) h)
+
+section Listener
+
+variable [StandardBorelSpace T] [Nonempty T] [StandardBorelSpace C] [Nonempty C]
+  (α : ℝ) (μ : Measure T) [IsFiniteMeasure μ]
+
+/-- Utterance production ([franke-bergen-2020] eq. 19a): the observable form
+of the speaker's choice. -/
+noncomputable def production (α : ℝ) : Kernel T O := (s.speaker α).map s.obs
+
+/-- The joint distribution of the heard form with the (state, choice) pair. -/
+noncomputable def jointObs : Measure (O × (T × C)) :=
+  (μ ⊗ₘ s.speaker α).map fun p => (s.obs p.2, p)
+
+instance : IsFiniteMeasure (s.jointObs α μ) :=
+  inferInstanceAs (IsFiniteMeasure (Measure.map _ _))
+
+omit [DecidableEq T] [MeasurableSingletonClass O] [DecidableEq O] [StandardBorelSpace T]
+  [Nonempty T] [StandardBorelSpace C] [Nonempty C] [IsFiniteMeasure μ] in
+/-- The heard form is distributed as the production marginal. -/
+theorem jointObs_fst : (s.jointObs α μ).fst = (s.speaker α ∘ₘ μ).map s.obs := by
+  rw [jointObs, Measure.fst, Measure.map_map measurable_fst s.measurable_obsPair,
+    show (Prod.fst ∘ fun p : T × C => (s.obs p.2, p)) = s.obs ∘ Prod.snd from rfl,
+    ← Measure.map_map Measurable.of_discrete measurable_snd, ← Measure.snd,
+    Measure.snd_compProd]
+
+/-- The joint pragmatic listener ([franke-bergen-2020] eqs. 18b/21b):
+posterior over (state, choice) given the heard form. -/
+noncomputable def jointListener : Kernel O (T × C) := (s.jointObs α μ).condKernel
+
+/-- The state posterior ([franke-bergen-2020] eqs. 9/19b): the world marginal
+of the joint listener. -/
+noncomputable def listener : Kernel O T := (s.jointListener α μ).fst
+
+/-- The choice posterior ([franke-bergen-2020] eq. 22, at pairs). -/
+noncomputable def choicePosterior : Kernel O C := (s.jointListener α μ).snd
+
+variable {α μ}
+
+omit [DecidableEq T] in
+/-- Exact Bayes for the joint listener at a positive-mass observation. -/
+theorem jointListener_apply_singleton {o : O}
+    (ho : ((s.speaker α ∘ₘ μ).map s.obs) {o} ≠ 0) (t : T) (c : C) :
+    s.jointListener α μ o {(t, c)}
+      = (if s.obs c = o then μ {t} * s.speaker α t {c} else 0)
+        / ((s.speaker α ∘ₘ μ).map s.obs) {o} := by
+  have hd := congrArg (fun m => m ({o} ×ˢ {(t, c)}))
+    ((s.jointObs α μ).disintegrate (s.jointObs α μ).condKernel)
+  beta_reduce at hd
+  rw [Measure.compProd_apply_prod (.singleton o) (.singleton (t, c)),
+    lintegral_singleton, s.jointObs_fst] at hd
+  unfold jointObs at hd
+  rw [Measure.map_apply s.measurable_obsPair
+      ((MeasurableSet.singleton o).prod (.singleton (t, c)))] at hd
+  by_cases hc : s.obs c = o
+  · rw [show (fun p : T × C => (s.obs p.2, p)) ⁻¹' ({o} ×ˢ {(t, c)}) = {t} ×ˢ {c} from by
+        ext ⟨t', c'⟩
+        simp only [Set.mem_preimage, Set.mem_prod, Set.mem_singleton_iff, Prod.ext_iff]
+        constructor
+        · rintro ⟨_, h1, h2⟩
+          exact ⟨h1, h2⟩
+        · rintro ⟨rfl, rfl⟩
+          exact ⟨hc, rfl, rfl⟩,
+      Measure.compProd_apply_prod (.singleton t) (.singleton c), lintegral_singleton] at hd
+    rw [jointListener, if_pos hc, ENNReal.eq_div_iff ho (measure_ne_top _ _), mul_comm]
+    unfold jointObs
+    rw [hd, mul_comm]
+  · rw [show (fun p : T × C => (s.obs p.2, p)) ⁻¹' ({o} ×ˢ {(t, c)}) = (∅ : Set (T × C)) from by
+        ext ⟨t', c'⟩
+        simp only [Set.mem_preimage, Set.mem_prod, Set.mem_singleton_iff, Prod.ext_iff,
+          Set.mem_empty_iff_false, iff_false]
+        rintro ⟨h, -, rfl⟩
+        exact hc h,
+      measure_empty] at hd
+    rw [jointListener, if_neg hc, ENNReal.zero_div]
+    unfold jointObs
+    exact (mul_eq_zero.mp hd).resolve_right ho
+
+omit [DecidableEq T] in
+/-- Listener preference on reals: the observation's marginal cancels, leaving
+prior-weighted speaker mass pooled over the observation's fiber. -/
+theorem listener_real_lt_iff {o : O}
+    (ho : ((s.speaker α ∘ₘ μ).map s.obs) {o} ≠ 0) (t₁ t₂ : T) :
+    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂}
+      ↔ (∑ c ∈ Finset.univ.filter (s.obs · = o), μ.real {t₁} * (s.speaker α t₁).real {c})
+        < ∑ c ∈ Finset.univ.filter (s.obs · = o), μ.real {t₂} * (s.speaker α t₂).real {c} := by
+  have key : ∀ t : T, s.listener α μ o {t}
+      = (∑ c ∈ Finset.univ.filter (s.obs · = o), μ {t} * s.speaker α t {c})
+        / ((s.speaker α ∘ₘ μ).map s.obs) {o} := fun t => by
+    rw [listener, Kernel.fst_apply, ← Measure.fst, Measure.fst_apply_singleton]
+    simp_rw [s.jointListener_apply_singleton ho, div_eq_mul_inv, ← Finset.sum_mul,
+      ← Finset.sum_filter]
+  have hne : ∀ t : T,
+      (∑ c ∈ Finset.univ.filter (s.obs · = o), μ {t} * s.speaker α t {c}) ≠ ∞ :=
+    fun t => ENNReal.sum_ne_top.mpr fun c _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
+  rw [measureReal_def, measureReal_def, key, key,
+    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne t₁) ho) (ENNReal.div_ne_top (hne t₂) ho),
+    ENNReal.div_lt_div_iff_left ho (measure_ne_top _ _),
+    ← ENNReal.toReal_lt_toReal (hne t₁) (hne t₂),
+    ENNReal.toReal_sum (fun c _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
+    ENNReal.toReal_sum (fun c _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
+  simp_rw [ENNReal.toReal_mul]
+  exact Iff.rfl
+
+/-- Support preference: hearing `o`, the listener strictly prefers a state
+where some `o`-shaped choice is true over one where none is. The witness at
+`t₂` also carries the positive observation marginal — no side conditions. -/
+theorem listener_real_lt_of_support {α : ℝ} (hα : 0 < α) {μ : Measure T}
+    [IsFiniteMeasure μ] {o : O} {t₁ t₂ : T} (hμ : μ {t₂} ≠ 0)
+    (h₁ : ∀ c, s.obs c = o → t₁ ∉ s.sem c) (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c) :
+    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
+  obtain ⟨c₂, hc₂, hmem⟩ := h₂
+  rw [s.listener_real_lt_iff
+      (s.map_obs_comp_ne_zero hμ hc₂ (s.speaker_apply_singleton_ne_zero hα.le hmem)),
+    Finset.sum_congr rfl fun c hc => by
+      rw [s.speaker_real_singleton_eq_zero hα (h₁ c (Finset.mem_filter.mp hc).2), mul_zero],
+    Finset.sum_const_zero]
+  exact Finset.sum_pos' (fun c _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
+    ⟨c₂, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hc₂⟩,
+      mul_pos (ENNReal.toReal_pos hμ (measure_ne_top _ _))
+        (s.speaker_real_singleton_pos hα.le hmem)⟩
+
+end Listener
+
+end
+
+end Scenario
+
 end RSA
+

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -624,8 +624,8 @@ theorem sum_speaker_real_singleton_le_one (α : ℝ) (t : T) (S : Finset C) :
 
 omit [DecidableEq O] in
 /-- Competition: any other true choice caps a share strictly below one. -/
-theorem speaker_real_singleton_lt_one [DecidableEq C] {α : ℝ} (hα : 0 ≤ α) {t : T} (c : C) {c' : C}
-    (hne : c' ≠ c) (hmem' : t ∈ s.sem c') : (s.speaker α t).real {c} < 1 := by
+theorem speaker_real_singleton_lt_one [DecidableEq C] {α : ℝ} (hα : 0 ≤ α) {t : T}
+    {c c' : C} (hne : c' ≠ c) (hmem' : t ∈ s.sem c') : (s.speaker α t).real {c} < 1 := by
   have hsum := s.sum_speaker_real_singleton_le_one α t {c, c'}
   rw [Finset.sum_insert (by simpa using fun h => hne h.symm), Finset.sum_singleton] at hsum
   have hpos : 0 < (s.speaker α t).real {c'} :=
@@ -648,7 +648,8 @@ theorem speaker_real_singleton_lt_of_card_lt {α : ℝ} (hα : 0 < α) {t : T} {
       (Finset.single_le_sum (f := fun u => s.L0 u {t} ^ α) (fun u _ => zero_le)
         (Finset.mem_univ c)) h.le) zero_le)
   rw [speaker, speakerOf, Kernel.ofWeights_real_singleton_lt_iff t hZ0
-      (ENNReal.sum_ne_top.mpr fun u _ => weight_rpow_ne_top hα.le (s.L0_apply_singleton_le_one u t)),
+      (ENNReal.sum_ne_top.mpr fun u _ =>
+        weight_rpow_ne_top hα.le (s.L0_apply_singleton_le_one u t)),
     s.L0_apply_singleton, s.L0_apply_singleton, if_pos hmem, if_pos hmem']
   exact ENNReal.rpow_lt_rpow
     (ENNReal.inv_lt_inv.2 (by exact_mod_cast hcard)) hα
@@ -1086,7 +1087,7 @@ pools, leaving summed member speaker shares. Any member's true choice at
 either state supplies the positivity side condition. -/
 theorem familyListener_fst_real_lt_iff [Fintype L] (f : L → Scenario T C O) {α : ℝ}
     (hα : 0 ≤ α) (hμeq : ∀ p q : T × L, μ {p} = μ {q}) (hμ0 : ∀ p : T × L, μ {p} ≠ 0)
-    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) (t₁ t₂ : T) :
+    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) {t₁ t₂ : T} :
     ((familyListener f α μ) c).fst.real {t₁} < ((familyListener f α μ) c).fst.real {t₂}
       ↔ (∑ l, ((f l).speaker α t₁).real {c}) < ∑ l, ((f l).speaker α t₂).real {c} := by
   set p₀ : T × L := Classical.arbitrary _
@@ -1105,7 +1106,7 @@ theorem familyListener_fst_real_lt_iff [Fintype L] (f : L → Scenario T C O) {�
 states pool, leaving summed member speaker shares. -/
 theorem familyListener_snd_real_lt_iff (f : L → Scenario T C O) {α : ℝ}
     (hα : 0 ≤ α) (hμeq : ∀ p q : T × L, μ {p} = μ {q}) (hμ0 : ∀ p : T × L, μ {p} ≠ 0)
-    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) (l₁ l₂ : L) :
+    {c : C} {t₀ : T} {l₀ : L} (hmem : t₀ ∈ (f l₀).sem c) {l₁ l₂ : L} :
     ((familyListener f α μ) c).snd.real {l₁} < ((familyListener f α μ) c).snd.real {l₂}
       ↔ (∑ t, ((f l₁).speaker α t).real {c}) < ∑ t, ((f l₂).speaker α t).real {c} := by
   set p₀ : T × L := Classical.arbitrary _

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -567,6 +567,172 @@ theorem speaker_utility_zero_real_singleton {α : ℝ} (hα : 0 ≤ α) (L0 : Ke
     ENNReal.toReal_sum fun u' _ => ENNReal.rpow_ne_top_of_nonneg hα (htop u')]
   simp_rw [ENNReal.toReal_rpow]
 
+/-! ### The bundled speaker
+
+`RSA.Speaker` packages the theory's data — a rationality, a prior, and a
+semantics — and derives the pipeline: `S.L0` conditions the prior on an
+utterance's extension, `S.toKernel` is the softmax-informativity speaker, and
+the listeners are its Bayesian inverses. Its API states facts at the semantic
+level (membership in extensions), so EReal utilities never surface in
+studies; standing side conditions are the typeclasses `Speaker.Viable` and
+`Speaker.Positive`. -/
+
+variable (W U) in
+/-- A cost-free informativity speaker: rationality, prior beliefs, and a
+truth-conditional semantics. -/
+structure Speaker where
+  /-- The softmax rationality (Degen's α); positive, so that informativity
+  bites (the `α = 0` uniform speaker is degenerate). -/
+  α : ℝ
+  α_pos : 0 < α
+  /-- Prior beliefs about worlds. -/
+  prior : Measure W
+  /-- The semantics: each utterance's extension. -/
+  sem : U → Set W
+
+namespace Speaker
+
+section
+variable (S : Speaker W U)
+
+/-- The literal listener (eq. 1). -/
+noncomputable def L0 : Kernel U W := literalListener S.prior S.sem
+
+/-- The speaker kernel (eq. 2 at the informativity utility of eq. 3). -/
+noncomputable def toKernel : Kernel W U := speaker S.α (utility S.L0 fun _ => 0)
+
+/-- Every world has a true utterance. -/
+class Viable : Prop where
+  exists_mem : ∀ w, ∃ u, w ∈ S.sem u
+
+/-- The prior gives every world positive mass. -/
+class Positive : Prop where
+  prior_pos : ∀ w, S.prior {w} ≠ 0
+
+variable [IsFiniteMeasure S.prior]
+
+omit [MeasurableSpace U] [Fintype W] [MeasurableSingletonClass W] [Fintype U]
+  [MeasurableSingletonClass U] in
+theorem prior_real_pos [S.Positive] (w : W) : 0 < S.prior.real {w} :=
+  ENNReal.toReal_pos (Positive.prior_pos w) (measure_ne_top _ _)
+
+theorem L0_apply_singleton_ne_zero [S.Positive] {u : U} {w : W} (h : w ∈ S.sem u) :
+    S.L0 u {w} ≠ 0 :=
+  literalListener_apply_singleton_ne_zero S.prior h (Positive.prior_pos w)
+
+private theorem scaled_utility_ne_top (w : W) (u : U) :
+    (S.α : EReal) * utility S.L0 (fun _ => 0) w u ≠ ⊤ := by
+  rw [utility, EReal.coe_zero, sub_zero]
+  exact coe_mul_log_ne_top S.α_pos.le (literalListener_apply_ne_top S.prior _ u {w})
+
+instance [S.Viable] [S.Positive] : IsMarkovKernel S.toKernel :=
+  isMarkovKernel_speaker_utility_zero S.α_pos.le
+    (fun u w => literalListener_apply_ne_top S.prior _ u {w})
+    fun w => (Viable.exists_mem (S := S) w).imp fun _ h => S.L0_apply_singleton_ne_zero h
+
+/-- The speaker's support is literal truth: an utterance gets positive mass
+exactly on its extension. -/
+@[simp] theorem toKernel_real_pos_iff [S.Positive] (w : W) (u : U) :
+    0 < (S.toKernel w).real {u} ↔ w ∈ S.sem u := by
+  constructor
+  · intro h
+    by_contra hmem
+    rw [toKernel, speaker_real_singleton_eq_zero (by
+      rw [utility, EReal.coe_zero, sub_zero, L0,
+        literalListener_apply_singleton_of_not_mem S.prior _ hmem, ENNReal.log_zero]
+      exact EReal.mul_bot_of_pos (by exact_mod_cast S.α_pos))] at h
+    exact lt_irrefl 0 h
+  · intro h
+    exact speaker_real_singleton_pos
+      (by
+        rw [utility, EReal.coe_zero, sub_zero]
+        exact coe_mul_log_ne_bot S.α_pos.le (S.L0_apply_singleton_ne_zero h))
+      (S.scaled_utility_ne_top w)
+
+/-- An utterance outside its extension is never produced. -/
+theorem toKernel_real_eq_zero [S.Positive] {w : W} {u : U} (h : w ∉ S.sem u) :
+    (S.toKernel w).real {u} = 0 := by
+  by_contra hne
+  exact h ((S.toKernel_real_pos_iff w u).mp
+    (lt_of_le_of_ne measureReal_nonneg (Ne.symm hne)))
+
+/-- A true utterance is produced with positive mass. -/
+theorem toKernel_apply_ne_zero [S.Positive] {w : W} {u : U} (h : w ∈ S.sem u) :
+    S.toKernel w {u} ≠ 0 := by
+  intro h0
+  have hpos := (S.toKernel_real_pos_iff w u).mpr h
+  rw [measureReal_def, h0] at hpos
+  simp at hpos
+
+section Listener
+
+variable [StandardBorelSpace W] [Nonempty W] [S.Viable] [S.Positive]
+
+/-- The pragmatic listener (eq. 4): the Bayesian inverse of the speaker. -/
+noncomputable def listener : Kernel U W := S.toKernel†S.prior
+
+/-- Support preference: hearing `u`, the pragmatic listener strictly prefers a
+world in `u`'s extension over one outside it. The truth of `u` at `w₂` also
+witnesses the positive observation marginal. -/
+theorem listener_real_lt_of_support {u : U} {w₁ w₂ : W}
+    (h₁ : w₁ ∉ S.sem u) (h₂ : w₂ ∈ S.sem u) :
+    (S.listener u).real {w₁} < (S.listener u).real {w₂} := by
+  rw [listener, posterior_real_singleton_lt_iff _ _
+      (comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂) (S.toKernel_apply_ne_zero h₂)),
+    S.toKernel_real_eq_zero h₁, mul_zero]
+  exact mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ u).mpr h₂)
+
+end Listener
+
+end
+
+section Joint
+
+variable {X Θ : Type*} [MeasurableSpace X] [Fintype X] [MeasurableSingletonClass X]
+  [MeasurableSpace Θ] [Fintype Θ] [MeasurableSingletonClass Θ]
+  [StandardBorelSpace Θ] [Nonempty Θ] [StandardBorelSpace W] [Nonempty W]
+  (S : Speaker W (X × Θ)) [IsFiniteMeasure S.prior] [S.Viable] [S.Positive]
+
+/-- The joint pragmatic listener over world and latent, given the heard
+utterance ([franke-bergen-2020]'s intention listeners). -/
+noncomputable def jointListener : Kernel X (W × Θ) := jointPosterior S.toKernel S.prior
+
+/-- World preference by support: if no latent verifies the heard utterance at
+`w₁` and some latent verifies it at `w₂`, the joint listener's world marginal
+strictly prefers `w₂`. -/
+theorem jointListener_fst_real_lt_of_support {x : X} {w₁ w₂ : W}
+    (h₁ : ∀ θ, w₁ ∉ S.sem (x, θ)) (h₂ : ∃ θ, w₂ ∈ S.sem (x, θ)) :
+    (S.jointListener x).fst.real {w₁} < (S.jointListener x).fst.real {w₂} := by
+  obtain ⟨θ₂, h₂⟩ := h₂
+  rw [jointListener, jointPosterior_fst_real_lt_iff _ _
+      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂)
+        (S.toKernel_apply_ne_zero h₂)),
+    Finset.sum_congr rfl fun θ _ => by rw [S.toKernel_real_eq_zero (h₁ θ), mul_zero],
+    Finset.sum_const_zero]
+  exact Finset.sum_pos' (fun θ _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
+    ⟨θ₂, Finset.mem_univ _,
+      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
+
+/-- Latent preference by support: if no world verifies the heard utterance
+under `θ₁` and some world of positive prior mass verifies it under `θ₂`, the
+joint listener's latent marginal strictly prefers `θ₂`. -/
+theorem jointListener_snd_real_lt_of_support {x : X} {θ₁ θ₂ : Θ}
+    (h₁ : ∀ w, w ∉ S.sem (x, θ₁)) (h₂ : ∃ w, w ∈ S.sem (x, θ₂)) :
+    (S.jointListener x).snd.real {θ₁} < (S.jointListener x).snd.real {θ₂} := by
+  obtain ⟨w₂, h₂⟩ := h₂
+  rw [jointListener, jointPosterior_snd_real_lt_iff _ _
+      (map_fst_comp_apply_singleton_ne_zero _ _ (Positive.prior_pos w₂)
+        (S.toKernel_apply_ne_zero h₂)),
+    Finset.sum_congr rfl fun w _ => by rw [S.toKernel_real_eq_zero (h₁ w), mul_zero],
+    Finset.sum_const_zero]
+  exact Finset.sum_pos' (fun w _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
+    ⟨w₂, Finset.mem_univ _,
+      mul_pos (S.prior_real_pos w₂) ((S.toKernel_real_pos_iff w₂ (x, θ₂)).mpr h₂)⟩
+
+end Joint
+
+end Speaker
+
 /-- Speaker preference on reals is utility comparison (eq. 2's softmax is
 strictly monotone; the partition function cancels). -/
 theorem speaker_real_singleton_lt_iff {α : ℝ} {util : W → U → EReal} (w : W)

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -2,6 +2,7 @@ import Mathlib.Probability.Kernel.Posterior
 import Mathlib.Probability.ConditionalProbability
 import Mathlib.MeasureTheory.Measure.Real
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
+import Linglib.Pragmatics.RSA.Dominates
 
 /-!
 # The Rational Speech Act pipeline on probability kernels
@@ -929,7 +930,95 @@ theorem speaker_real_singleton_pos {α : ℝ} (hα : 0 ≤ α) {t : T} {c : C}
     (h : t ∈ s.sem c) : 0 < (s.speaker α t).real {c} :=
   ENNReal.toReal_pos (s.speaker_apply_singleton_ne_zero hα h) (measure_ne_top _ _)
 
-variable [MeasurableSpace O] [MeasurableSingletonClass O] [DecidableEq O]
+/-! #### Informativity profiles
+
+The combinatorial shadow of the model: the multiset of extension sizes of a
+state's true choices. Softmax masses are ratios of `Multiset.invPowSum`s over
+profiles, so preference certificates are `Multiset.StrictDominates` facts
+closed by `decide` — uniform in the rationality. -/
+
+variable [DecidableEq O]
+
+/-- The choices true at a state. -/
+def trueChoices (t : T) : Finset C := Finset.univ.filter (t ∈ s.sem ·)
+
+/-- The informativity profile: extension sizes of the true choices. -/
+def profile (t : T) : Multiset ℕ := (s.trueChoices t).val.map fun c => (s.sem c).card
+
+/-- The profile restricted to choices heard as `o`. -/
+def fiberProfile (o : O) (t : T) : Multiset ℕ :=
+  ((s.trueChoices t).filter (s.obs · = o)).val.map fun c => (s.sem c).card
+
+/-- The profile of true choices heard otherwise. -/
+def restProfile (o : O) (t : T) : Multiset ℕ :=
+  ((s.trueChoices t).filter (s.obs · ≠ o)).val.map fun c => (s.sem c).card
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] in
+theorem profile_eq_fiberProfile_add_restProfile (o : O) (t : T) :
+    s.profile t = s.fiberProfile o t + s.restProfile o t := by
+  rw [fiberProfile, restProfile, ← Multiset.map_add, profile]
+  congr 1
+  rw [Finset.filter_val, Finset.filter_val, Multiset.filter_add_not]
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] [DecidableEq O] in
+theorem zero_notMem_profile (t : T) : 0 ∉ s.profile t := by
+  simp only [profile, Multiset.mem_map, not_exists, not_and]
+  intro c hc hcard
+  rw [Finset.mem_val, trueChoices, Finset.mem_filter] at hc
+  exact Finset.card_ne_zero_of_mem hc.2 hcard
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] in
+theorem zero_notMem_fiberProfile (o : O) (t : T) : 0 ∉ s.fiberProfile o t := fun h =>
+  s.zero_notMem_profile t
+    (s.profile_eq_fiberProfile_add_restProfile o t ▸ Multiset.mem_add.mpr (Or.inl h))
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] in
+theorem zero_notMem_restProfile (o : O) (t : T) : 0 ∉ s.restProfile o t := fun h =>
+  s.zero_notMem_profile t
+    (s.profile_eq_fiberProfile_add_restProfile o t ▸ Multiset.mem_add.mpr (Or.inr h))
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] [DecidableEq O] in
+theorem profile_ne_zero [s.Expressible] (t : T) : s.profile t ≠ 0 := by
+  obtain ⟨c, hc⟩ := Expressible.exists_mem_sem (s := s) t
+  intro h
+  rw [profile, Multiset.map_eq_zero, Finset.val_eq_zero] at h
+  exact absurd (Finset.mem_filter.mpr ⟨Finset.mem_univ c, hc⟩)
+    (h ▸ Finset.notMem_empty c)
+
+omit [Fintype T] [DecidableEq O] in
+theorem sum_rpow_L0 {α : ℝ} (hα : 0 < α) (t : T) :
+    ∑ c, s.L0 c {t} ^ α = (s.profile t).invPowSum α := by
+  simp_rw [L0_apply_singleton, apply_ite (· ^ α), ENNReal.zero_rpow_of_pos hα,
+    ← Finset.sum_filter]
+  rw [profile, Multiset.invPowSum, Multiset.map_map]
+  rfl
+
+omit [Fintype T] in
+theorem sum_fiber_rpow_L0 {α : ℝ} (hα : 0 < α) (o : O) (t : T) :
+    ∑ c ∈ Finset.univ.filter (s.obs · = o), s.L0 c {t} ^ α
+      = (s.fiberProfile o t).invPowSum α := by
+  simp_rw [L0_apply_singleton, apply_ite (· ^ α), ENNReal.zero_rpow_of_pos hα,
+    ← Finset.sum_filter]
+  rw [fiberProfile, Multiset.invPowSum, Multiset.map_map,
+    show (Finset.univ.filter (s.obs · = o)).filter (fun c => t ∈ s.sem c)
+      = (s.trueChoices t).filter (s.obs · = o) from by
+    rw [trueChoices, Finset.filter_comm]]
+  rfl
+
+/-- Pooled speaker mass over an observation's fiber is a ratio of profile
+sums — [franke-bergen-2020] eq. 8, structurally. -/
+theorem sum_fiber_speaker {α : ℝ} (hα : 0 < α) (o : O) (t : T) :
+    ∑ c ∈ Finset.univ.filter (s.obs · = o), s.speaker α t {c}
+      = (s.fiberProfile o t).invPowSum α / (s.profile t).invPowSum α := by
+  simp_rw [speaker, speakerOf_apply_singleton, div_eq_mul_inv, ← Finset.sum_mul]
+  rw [s.sum_fiber_rpow_L0 hα, s.sum_rpow_L0 hα, ← div_eq_mul_inv]
+
+variable [MeasurableSpace O] [MeasurableSingletonClass O]
 
 omit [Fintype T] [DecidableEq T] [MeasurableSingletonClass T] [Fintype C]
   [MeasurableSingletonClass O] [DecidableEq O] in
@@ -1070,6 +1159,58 @@ theorem listener_real_lt_of_support {α : ℝ} (hα : 0 < α) {μ : Measure T}
     ⟨c₂, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hc₂⟩,
       mul_pos (ENNReal.toReal_pos hμ (measure_ne_top _ _))
         (s.speaker_real_singleton_pos hα.le hmem)⟩
+
+/-- Certificate form of listener preference at equal priors, uniform in the
+rationality: cross products of fiber and rest profiles strictly dominate
+(the shared fiber-by-fiber terms of the odds comparison cancel). -/
+theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (hα : 0 < α)
+    {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
+    (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c)
+    (hcert : ((s.fiberProfile o t₂).prodMul (s.restProfile o t₁)).StrictDominates
+      ((s.fiberProfile o t₁).prodMul (s.restProfile o t₂))) :
+    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
+  obtain ⟨c₂, hc₂, hmem⟩ := h₂
+  have hWne : ∀ t, (s.fiberProfile o t).invPowSum α ≠ ∞ := fun t =>
+    Multiset.invPowSum_ne_top hα.le (s.zero_notMem_fiberProfile o t)
+  have hRne : ∀ t, (s.restProfile o t).invPowSum α ≠ ∞ := fun t =>
+    Multiset.invPowSum_ne_top hα.le (s.zero_notMem_restProfile o t)
+  have hZ0 : ∀ t, (s.profile t).invPowSum α ≠ 0 := fun t =>
+    (Multiset.invPowSum_pos hα.le (s.profile_ne_zero t)).ne'
+  have hZne : ∀ t, (s.profile t).invPowSum α ≠ ∞ := fun t =>
+    Multiset.invPowSum_ne_top hα.le (s.zero_notMem_profile t)
+  have hodds : (s.fiberProfile o t₁).invPowSum α * (s.restProfile o t₂).invPowSum α
+      < (s.fiberProfile o t₂).invPowSum α * (s.restProfile o t₁).invPowSum α := by
+    rw [← Multiset.invPowSum_prodMul hα.le, ← Multiset.invPowSum_prodMul hα.le]
+    exact hcert.invPowSum_lt hα.le
+      (Multiset.zero_notMem_prodMul (s.zero_notMem_fiberProfile o t₁)
+        (s.zero_notMem_restProfile o t₂))
+  have hcross : (s.fiberProfile o t₁).invPowSum α * (s.profile t₂).invPowSum α
+      < (s.fiberProfile o t₂).invPowSum α * (s.profile t₁).invPowSum α := by
+    rw [s.profile_eq_fiberProfile_add_restProfile o t₁,
+      s.profile_eq_fiberProfile_add_restProfile o t₂, Multiset.invPowSum_add,
+      Multiset.invPowSum_add, mul_add, mul_add, mul_comm ((s.fiberProfile o t₂).invPowSum α)]
+    exact ENNReal.add_lt_add_left (ENNReal.mul_ne_top (hWne t₁) (hWne t₂)) hodds
+  have key : ∀ t : T,
+      (∑ c ∈ Finset.univ.filter (s.obs · = o), μ.real {t} * (s.speaker α t).real {c})
+        = (μ {t} * ((s.fiberProfile o t).invPowSum α / (s.profile t).invPowSum α)).toReal :=
+    fun t => by
+      rw [← Finset.mul_sum, measureReal_def,
+        show (∑ c ∈ Finset.univ.filter (s.obs · = o), (s.speaker α t).real {c})
+          = ((s.fiberProfile o t).invPowSum α / (s.profile t).invPowSum α).toReal from by
+          rw [← s.sum_fiber_speaker hα, ENNReal.toReal_sum fun c _ => measure_ne_top _ _]
+          simp_rw [measureReal_def],
+        ENNReal.toReal_mul]
+  rw [s.listener_real_lt_iff
+      (s.map_obs_comp_ne_zero hμ0 hc₂ (s.speaker_apply_singleton_ne_zero hα.le hmem)),
+    key, key, hμeq,
+    ENNReal.toReal_lt_toReal
+      (ENNReal.mul_ne_top (measure_ne_top _ _) (ENNReal.div_ne_top (hWne t₁) (hZ0 t₁)))
+      (ENNReal.mul_ne_top (measure_ne_top _ _) (ENNReal.div_ne_top (hWne t₂) (hZ0 t₂))),
+    ENNReal.mul_lt_mul_iff_right hμ0 (measure_ne_top _ _),
+    ENNReal.div_lt_iff (Or.inl (hZ0 t₁)) (Or.inl (hZne t₁)),
+    div_eq_mul_inv, mul_right_comm, ← div_eq_mul_inv,
+    ENNReal.lt_div_iff_mul_lt (Or.inl (hZ0 t₂)) (Or.inl (hZne t₂))]
+  exact hcross
 
 end Listener
 

--- a/Linglib/Pragmatics/RSA/Basic.lean
+++ b/Linglib/Pragmatics/RSA/Basic.lean
@@ -14,9 +14,11 @@ form per choice; the literal listener is uniform on the extension, the
 speaker is the best response in power-weight form (`ENNReal.rpow` is total,
 so falsity needs no signed utilities), and the listeners are conditionals of
 the joint — rationality and priors are arguments, so findings quantify over
-them. Preference facts come in three registers: support (zero-vs-positive),
-`Multiset.Dominates` certificates on informativity profiles (uniform in the
-rationality), and pinned-rationality evaluation via `Multiset.invPowSum`.
+them. Preference facts come in two registers, each closed by `decide`:
+`Multiset.StrictDominates` certificates on informativity profiles (strict
+stochastic dominance — uniform in the rationality, with empty fibers as the
+support case), and pinned natural rationality, where comparisons clear to ℕ
+inequalities via `Multiset.divPowSum`.
 
 ## Main definitions
 
@@ -25,21 +27,22 @@ rationality), and pinned-rationality evaluation via `Multiset.invPowSum`.
   kernel, as `ProbabilityTheory.Kernel.ofWeights` of `L ^ α`.
 * `RSA.Scenario` — the bundled model: `sem`, `obs`, and the derived `L0`,
   `speaker`, `production`, `jointListener`, `listener`, `choicePosterior`.
-* `RSA.Scenario.familySpeaker` — eqs. 11–13: state-side latent families
-  (lexical uncertainty); per-index normalization.
+* `RSA.Scenario.pool` — choice-side latents: the speaker chooses the family
+  index, normalizing across the pooled pairs (eqs. 18a/21a).
+* `RSA.Scenario.familySpeaker` — state-side latents: the index is a speaker
+  argument, normalization is per-index (eq. 11). `pool_L0` shows the two
+  share their weights — they differ only in the position of the latent.
 
 ## Main statements
 
 * `ProbabilityTheory.posterior_apply_singleton` — exact Bayes for `κ†μ` at a
   positive-mass observation.
-* `RSA.Scenario.listener_real_lt_of_support` — hearing `o`, the listener
-  prefers a state verifying `o` over one falsifying it, with no side
-  conditions beyond positive rationality.
 * `RSA.Scenario.listener_real_lt_of_prodMul_strictDominates` — the
   certificate register: strict domination of fiber-by-rest profile products
   decides listener preference uniformly in the rationality.
-* `RSA.Scenario.listener_real_lt_iff_invPowSum` — the evaluation register:
-  preference at equal priors is a cross-multiplied `invPowSum` comparison.
+* `RSA.Scenario.listener_real_lt_of_divPowSum`,
+  `RSA.Scenario.choicePosterior_real_lt_of_divPowSum` — the evaluation
+  register: at a natural rationality, preference is a decided ℕ inequality.
 
 ## Implementation notes
 
@@ -164,24 +167,6 @@ theorem posterior_apply_singleton {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (ω
   rw [hrect]
   ring
 
-/-- Pragmatic-listener preference on reals reduces to comparing
-prior-weighted speaker masses on reals; the observation's marginal cancels. -/
-theorem posterior_real_singleton_lt_iff {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0)
-    (ω₁ ω₂ : Ω) :
-    ((κ†μ) x).real {ω₁} < ((κ†μ) x).real {ω₂}
-      ↔ μ.real {ω₁} * (κ ω₁).real {x} < μ.real {ω₂} * (κ ω₂).real {x} := by
-  rw [measureReal_def, measureReal_def, posterior_apply_singleton κ μ hx,
-    posterior_apply_singleton κ μ hx,
-    ENNReal.toReal_lt_toReal
-      (ENNReal.div_ne_top (ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)) hx)
-      (ENNReal.div_ne_top (ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)) hx),
-    ENNReal.div_lt_div_iff_left hx (measure_ne_top _ _),
-    ← ENNReal.toReal_lt_toReal
-      (ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))
-      (ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
-    ENNReal.toReal_mul, ENNReal.toReal_mul]
-  exact Iff.rfl
-
 /-- A single state of positive prior mass and positive emission witnesses a
 positive observation marginal. -/
 theorem comp_apply_singleton_ne_zero {Ω' 𝓧' : Type*} [MeasurableSpace Ω']
@@ -268,6 +253,34 @@ theorem posterior_fst_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableS
     ENNReal.toReal_sum (fun b _ =>
       ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
     ENNReal.toReal_sum (fun b _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
+  simp_rw [ENNReal.toReal_mul]
+  exact Iff.rfl
+
+/-- Marginal listener preference over the latent component of a product
+parameter space, on reals: the states pool. -/
+theorem posterior_snd_real_lt_iff {A B : Type*} [MeasurableSpace A] [MeasurableSpace B]
+    [MeasurableSingletonClass A] [MeasurableSingletonClass B] [Fintype A]
+    [StandardBorelSpace A] [Nonempty A] [StandardBorelSpace B] [Nonempty B]
+    (κ : Kernel (A × B) 𝓧) (μ : Measure (A × B)) [IsFiniteMeasure μ] [IsFiniteKernel κ]
+    {x : 𝓧} (hx : (κ ∘ₘ μ) {x} ≠ 0) (b₁ b₂ : B) :
+    ((κ†μ) x).snd.real {b₁} < ((κ†μ) x).snd.real {b₂}
+      ↔ (∑ a, μ.real {(a, b₁)} * (κ (a, b₁)).real {x})
+          < ∑ a, μ.real {(a, b₂)} * (κ (a, b₂)).real {x} := by
+  have hne : ∀ b : B, (∑ a, μ {(a, b)} * κ (a, b) {x}) ≠ ∞ := fun b =>
+    ENNReal.sum_ne_top.mpr fun a _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)
+  rw [measureReal_def, measureReal_def, Measure.snd_apply_singleton,
+    Measure.snd_apply_singleton]
+  simp_rw [posterior_apply_singleton κ μ hx, div_eq_mul_inv]
+  rw [← Finset.sum_mul, ← Finset.sum_mul, ← div_eq_mul_inv, ← div_eq_mul_inv,
+    ENNReal.toReal_lt_toReal (ENNReal.div_ne_top (hne b₁) hx)
+      (ENNReal.div_ne_top (hne b₂) hx),
+    ENNReal.div_lt_div_iff_left hx (measure_ne_top _ _),
+    ← ENNReal.toReal_lt_toReal (hne b₁) (hne b₂),
+    ENNReal.toReal_sum (fun a _ =>
+      ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
+    ENNReal.toReal_sum (fun a _ =>
       ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _))]
   simp_rw [ENNReal.toReal_mul]
   exact Iff.rfl
@@ -390,6 +403,16 @@ structure Scenario where
 
 namespace Scenario
 
+/-- Pool a family of scenarios into one whose choices carry the family index:
+the speaker *chooses* the index with the utterance, normalizing across the
+whole family ([franke-bergen-2020] eqs. 18a/21a). `familySpeaker` instead
+keeps the index as an argument of the speaker (eq. 11) — with `pool_L0`, the
+paper's observation (p. e86) that the two architectures differ only in the
+position of the latent parameter. -/
+@[simps] def pool {T C O L : Type*} (f : L → Scenario T C O) : Scenario T (C × L) O where
+  sem cl := (f cl.2).sem cl.1
+  obs cl := (f cl.2).obs cl.1
+
 section
 
 variable {T C O : Type*} [MeasurableSpace T] [DecidableEq T] [MeasurableSingletonClass T]
@@ -424,6 +447,15 @@ theorem L0_apply_singleton_ne_zero {c : C} {t : T} (h : t ∈ s.sem c) :
   rw [L0_apply_singleton, if_pos h]
   simp
 
+omit [DecidableEq T] [MeasurableSingletonClass T] in
+/-- Pooling does not change the literal listener: `pool` and `familySpeaker`
+share their weights and differ only in the normalization domain — the
+type-level content of [franke-bergen-2020]'s contrast between eq. 11 and
+eqs. 18a/21a (p. e86). -/
+theorem pool_L0 {L : Type*} [Fintype L] [MeasurableSpace L] [DiscreteMeasurableSpace L]
+    (f : L → Scenario T C O) (c : C) (l : L) :
+    (pool f).L0 (c, l) = (f l).L0 c := rfl
+
 variable [Fintype T]
 
 /-- The pragmatic speaker ([franke-bergen-2020] eqs. 6–7, 18a, 21a): best
@@ -443,6 +475,13 @@ probability kernel. -/
 class Expressible (s : Scenario T C O) : Prop where
   exists_mem_sem : ∀ t, ∃ c, t ∈ s.sem c
 
+omit [MeasurableSpace T] [DecidableEq T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [Fintype C] [DiscreteMeasurableSpace C] [Fintype T] in
+/-- A pooled family is expressible as soon as one member is. -/
+theorem Expressible.pool {L : Type*} (f : L → Scenario T C O) (l : L)
+    [h : (f l).Expressible] : (Scenario.pool f).Expressible :=
+  ⟨fun t => let ⟨c, hc⟩ := h.exists_mem_sem t; ⟨(c, l), hc⟩⟩
+
 theorem isMarkovKernel_speaker {α : ℝ} (hα : 0 ≤ α) [s.Expressible] :
     IsMarkovKernel (s.speaker α) :=
   isMarkovKernel_speakerOf hα s.L0 (fun c t => s.L0_apply_singleton_le_one c t)
@@ -457,14 +496,6 @@ theorem speaker_apply_singleton_ne_zero {α : ℝ} (hα : 0 ≤ α) {t : T} {c :
     (h : t ∈ s.sem c) : s.speaker α t {c} ≠ 0 :=
   speakerOf_apply_singleton_ne_zero hα (fun c' => s.L0_apply_singleton_le_one c' t)
     (s.L0_apply_singleton_ne_zero h)
-
-theorem speaker_real_singleton_eq_zero {α : ℝ} (hα : 0 < α) {t : T} {c : C}
-    (h : t ∉ s.sem c) : (s.speaker α t).real {c} = 0 := by
-  rw [measureReal_def, s.speaker_apply_singleton_eq_zero hα h, ENNReal.toReal_zero]
-
-theorem speaker_real_singleton_pos {α : ℝ} (hα : 0 ≤ α) {t : T} {c : C}
-    (h : t ∈ s.sem c) : 0 < (s.speaker α t).real {c} :=
-  ENNReal.toReal_pos (s.speaker_apply_singleton_ne_zero hα h) (measure_ne_top _ _)
 
 /-! #### Informativity profiles
 
@@ -518,6 +549,18 @@ theorem zero_notMem_restProfile (o : O) (t : T) : 0 ∉ s.restProfile o t := fun
     (s.profile_eq_fiberProfile_add_restProfile o t ▸ Multiset.mem_add.mpr (Or.inr h))
 
 omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] in
+/-- A nonempty fiber profile exhibits an `o`-shaped true choice — certificates
+carry their own truth witnesses. -/
+theorem exists_of_fiberProfile_ne_zero {o : O} {t : T} (h : s.fiberProfile o t ≠ 0) :
+    ∃ c, s.obs c = o ∧ t ∈ s.sem c := by
+  rw [fiberProfile, ne_eq, Multiset.map_eq_zero, Finset.val_eq_zero, ← ne_eq,
+    ← Finset.nonempty_iff_ne_empty] at h
+  obtain ⟨c, hc⟩ := h
+  rw [Finset.mem_filter, trueChoices, Finset.mem_filter] at hc
+  exact ⟨c, hc.2, hc.1.2⟩
+
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
   [DiscreteMeasurableSpace C] [Fintype T] [DecidableEq O] in
 theorem profile_ne_zero [s.Expressible] (t : T) : s.profile t ≠ 0 := by
   obtain ⟨c, hc⟩ := Expressible.exists_mem_sem (s := s) t
@@ -565,6 +608,33 @@ theorem speaker_real_singleton {α : ℝ} (hα : 0 < α) (t : T) (c : C) :
     ENNReal.toReal_div, L0_apply_singleton, apply_ite (· ^ α),
     ENNReal.zero_rpow_of_pos hα, apply_ite ENNReal.toReal, ENNReal.toReal_zero,
     ← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast]
+
+omit [DecidableEq O] in
+/-- Exact speaker mass at a natural rationality, as a ratio of ℕ-valued
+common-denominator sums. -/
+theorem speaker_real_singleton_divPowSum {k D : ℕ} (hk : k ≠ 0) (hD : D ≠ 0) {t : T}
+    (hdvd : ∀ n ∈ s.profile t, n ∣ D) (c : C) :
+    (s.speaker k t).real {c}
+      = (if t ∈ s.sem c then (((D / (s.sem c).card) ^ k : ℕ) : ℝ) else 0)
+        / ((s.profile t).divPowSum D k : ℝ) := by
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+  have hDk : ((D : ℝ) ^ k) ≠ 0 := pow_ne_zero k (Nat.cast_ne_zero.mpr hD)
+  rw [s.speaker_real_singleton hα, Multiset.invPowSum_toReal_eq hD k hdvd]
+  split
+  · have hcard : (s.sem c).card ∣ D := hdvd _ (Multiset.mem_map_of_mem _ (by
+      rw [Finset.mem_val, trueChoices, Finset.mem_filter]
+      exact ⟨Finset.mem_univ c, ‹_›⟩))
+    have hcard0 : ((s.sem c).card : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr
+      fun h0 => hD (Nat.eq_zero_of_zero_dvd (h0 ▸ hcard))
+    have hinv : (((s.sem c).card : ℝ))⁻¹ = ((D / (s.sem c).card : ℕ) : ℝ) / D := by
+      rw [eq_div_iff (Nat.cast_ne_zero.mpr hD),
+        show (D : ℝ) = ((D / (s.sem c).card : ℕ) : ℝ) * ((s.sem c).card : ℝ) by
+          rw [← Nat.cast_mul, Nat.div_mul_cancel hcard],
+        mul_comm _ ((s.sem c).card : ℝ), ← mul_assoc, inv_mul_cancel₀ hcard0, one_mul]
+    rw [Real.rpow_natCast, hinv, div_pow, ← Nat.cast_pow, ← Nat.cast_pow,
+      div_div_div_comm, div_self (Nat.cast_ne_zero.mpr (pow_ne_zero k hD) : ((D ^ k : ℕ) : ℝ) ≠ 0),
+      div_one]
+  · rw [zero_div, zero_div]
 
 variable [MeasurableSpace O] [MeasurableSingletonClass O]
 
@@ -719,26 +789,66 @@ theorem choicePosterior_real_lt_iff {o : O}
   simp_rw [ENNReal.toReal_mul]
   exact Iff.rfl
 
-/-- Support preference: hearing `o`, the listener strictly prefers a state
-where some `o`-shaped choice is true over one where none is. The witness at
-`t₂` also carries the positive observation marginal — no side conditions. -/
-theorem listener_real_lt_of_support {α : ℝ} (hα : 0 < α) {μ : Measure T}
-    [IsFiniteMeasure μ] {o : O} {t₁ t₂ : T} (hμ : μ {t₂} ≠ 0)
-    (h₁ : ∀ c, s.obs c = o → t₁ ∉ s.sem c) (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c) :
-    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
-  obtain ⟨c₂, hc₂, hmem⟩ := h₂
-  rw [s.listener_real_lt_iff
-      (s.map_obs_comp_ne_zero hμ hc₂ (s.speaker_apply_singleton_ne_zero hα.le hmem)),
-    Finset.sum_congr rfl fun c hc => by
-      rw [s.speaker_real_singleton_eq_zero hα (h₁ c (Finset.mem_filter.mp hc).2), mul_zero],
-    Finset.sum_const_zero]
-  exact Finset.sum_pos' (fun c _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
-    ⟨c₂, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hc₂⟩,
-      mul_pos (ENNReal.toReal_pos hμ (measure_ne_top _ _))
-        (s.speaker_real_singleton_pos hα.le hmem)⟩
+private theorem sum_div_lt_sum_div_iff {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {a b z : ι → ℝ}
+    (hz : ∀ i, 0 < z i) :
+    (∑ i, a i / z i) < (∑ i, b i / z i)
+      ↔ (∑ i, a i * ∏ j ∈ Finset.univ.erase i, z j)
+          < ∑ i, b i * ∏ j ∈ Finset.univ.erase i, z j := by
+  have hP : (0 : ℝ) < ∏ j, z j := Finset.prod_pos fun j _ => hz j
+  have key : ∀ f : ι → ℝ, (∑ i, f i / z i) * ∏ j, z j
+      = ∑ i, f i * ∏ j ∈ Finset.univ.erase i, z j := by
+    intro f
+    rw [Finset.sum_mul]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [div_mul_eq_mul_div, ← Finset.prod_erase_mul _ _ (Finset.mem_univ i), ← mul_assoc,
+      mul_div_assoc, div_self (hz i).ne', mul_one]
+  rw [← mul_lt_mul_iff_left₀ hP, key, key]
+
+/-- The evaluation register for the choice posterior at a natural rationality
+and equal priors: pooled preference between two `o`-shaped choices is the
+ℕ-valued common-denominator comparison over all states — a kernel `decide`.
+The strict inequality carries its own truth witness. -/
+theorem choicePosterior_real_lt_of_divPowSum [s.Expressible] {k D : ℕ}
+    (hk : k ≠ 0) (hD : D ≠ 0) (hdvd : ∀ t : T, ∀ n ∈ s.profile t, n ∣ D)
+    (hμeq : ∀ t t' : T, μ {t} = μ {t'}) (hμ0 : ∀ t : T, μ {t} ≠ 0)
+    {o : O} {c₁ c₂ : C} (h₁ : s.obs c₁ = o) (h₂ : s.obs c₂ = o)
+    (hlt : (∑ t : T, if t ∈ s.sem c₁ then
+        (D / (s.sem c₁).card) ^ k * ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
+      else 0)
+      < ∑ t : T, if t ∈ s.sem c₂ then
+        (D / (s.sem c₂).card) ^ k * ∏ t' ∈ Finset.univ.erase t, (s.profile t').divPowSum D k
+      else 0) :
+    (s.choicePosterior k μ o).real {c₁} < (s.choicePosterior k μ o).real {c₂} := by
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+  obtain ⟨t₀, -, ht₀⟩ := Finset.exists_ne_zero_of_sum_ne_zero
+    (Nat.pos_iff_ne_zero.mp (lt_of_le_of_lt (Nat.zero_le _) hlt))
+  have hmem₀ : t₀ ∈ s.sem c₂ := by
+    by_contra h
+    exact ht₀ (if_neg h)
+  have ho : ((s.speaker k ∘ₘ μ).map s.obs) {o} ≠ 0 :=
+    s.map_obs_comp_ne_zero (hμ0 t₀) h₂ (s.speaker_apply_singleton_ne_zero hα.le hmem₀)
+  have hprior : ∀ c : C, (∑ t : T, μ.real {t} * (s.speaker k t).real {c})
+      = μ.real {t₀} * ∑ t : T,
+          (if t ∈ s.sem c then (((D / (s.sem c).card) ^ k : ℕ) : ℝ) else 0)
+            / ((s.profile t).divPowSum D k : ℝ) := by
+    intro c
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl fun t _ => ?_
+    rw [show μ.real {t} = μ.real {t₀} from by
+        rw [measureReal_def, measureReal_def, hμeq t t₀],
+      s.speaker_real_singleton_divPowSum hk hD (hdvd t)]
+  rw [s.choicePosterior_real_lt_iff ho h₁ h₂, hprior, hprior,
+    mul_lt_mul_iff_right₀
+      (show (0 : ℝ) < μ.real {t₀} from ENNReal.toReal_pos (hμ0 t₀) (measure_ne_top _ _)),
+    sum_div_lt_sum_div_iff fun t => by
+      exact_mod_cast Multiset.divPowSum_pos hD (hdvd t) (s.profile_ne_zero t)]
+  simp only [ite_mul, zero_mul]
+  exact_mod_cast hlt
 
 /-- Listener preference at equal priors reduces to the cross-multiplied
-profile comparison, on reals — the evaluation form for pinned rationalities. -/
+profile comparison, on reals: the observation marginal and the shared prior
+cancel. Both registers' closers enter here. -/
 theorem listener_real_lt_iff_invPowSum [s.Expressible] {α : ℝ} (hα : 0 < α)
     {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
     (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c) :
@@ -776,25 +886,28 @@ theorem listener_real_lt_iff_invPowSum [s.Expressible] {α : ℝ} (hα : 0 < α)
       (ENNReal.mul_ne_top (hWne t₁) (hZne t₂)) (ENNReal.mul_ne_top (hWne t₂) (hZne t₁)),
     ENNReal.toReal_mul, ENNReal.toReal_mul]
 
-/-- Certificate form of listener preference at equal priors, uniform in the
-rationality: cross products of fiber and rest profiles strictly dominate
-(the shared fiber-by-fiber terms of the odds comparison cancel). -/
-theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (hα : 0 < α)
-    {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
-    (h₂ : ∃ c, s.obs c = o ∧ t₂ ∈ s.sem c)
+omit [MeasurableSpace T] [MeasurableSingletonClass T] [MeasurableSpace C]
+  [DiscreteMeasurableSpace C] [Fintype T] [MeasurableSpace O] [MeasurableSingletonClass O]
+  [StandardBorelSpace T] [Nonempty T] [StandardBorelSpace C] [Nonempty C]
+  [IsFiniteMeasure μ] in
+/-- The certificate closes the odds comparison: strict domination of the
+fiber-by-rest cross products decides it uniformly in the rationality (the
+shared fiber-by-fiber terms cancel). -/
+theorem invPowSum_odds_lt_of_prodMul_strictDominates {α : ℝ} (hα : 0 < α)
+    {o : O} {t₁ t₂ : T}
     (hcert : ((s.fiberProfile o t₂).prodMul (s.restProfile o t₁)).StrictDominates
       ((s.fiberProfile o t₁).prodMul (s.restProfile o t₂))) :
-    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} := by
+    ((s.fiberProfile o t₁).invPowSum α).toReal * ((s.profile t₂).invPowSum α).toReal
+      < ((s.fiberProfile o t₂).invPowSum α).toReal * ((s.profile t₁).invPowSum α).toReal := by
   have hWne : ∀ t, (s.fiberProfile o t).invPowSum α ≠ ∞ := fun t =>
     Multiset.invPowSum_ne_top hα.le (s.zero_notMem_fiberProfile o t)
   have hodds : (s.fiberProfile o t₁).invPowSum α * (s.restProfile o t₂).invPowSum α
       < (s.fiberProfile o t₂).invPowSum α * (s.restProfile o t₁).invPowSum α := by
     rw [← Multiset.invPowSum_prodMul hα.le, ← Multiset.invPowSum_prodMul hα.le]
-    exact hcert.invPowSum_lt hα.le
+    exact hcert.invPowSum_lt hα
       (Multiset.zero_notMem_prodMul (s.zero_notMem_fiberProfile o t₁)
         (s.zero_notMem_restProfile o t₂))
-  rw [s.listener_real_lt_iff_invPowSum hα hμeq hμ0 h₂,
-    ← ENNReal.toReal_mul, ← ENNReal.toReal_mul,
+  rw [← ENNReal.toReal_mul, ← ENNReal.toReal_mul,
     ENNReal.toReal_lt_toReal
       (ENNReal.mul_ne_top (hWne t₁)
         (Multiset.invPowSum_ne_top hα.le (s.zero_notMem_profile t₂)))
@@ -805,6 +918,50 @@ theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (
     Multiset.invPowSum_add, mul_add, mul_add, mul_comm ((s.fiberProfile o t₂).invPowSum α)]
   exact ENNReal.add_lt_add_left
     (ENNReal.mul_ne_top (hWne t₁) (hWne t₂)) hodds
+
+/-- The certificate register: at equal priors, strict domination of the
+fiber-by-rest profile products decides listener preference uniformly in the
+rationality. The certificate carries its own truth witness, so a finding is a
+single decided `Multiset.StrictDominates` fact. An empty fiber at `t₁` is the
+support case: any nonempty product strictly dominates `0`. -/
+theorem listener_real_lt_of_prodMul_strictDominates [s.Expressible] {α : ℝ} (hα : 0 < α)
+    {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
+    (hcert : ((s.fiberProfile o t₂).prodMul (s.restProfile o t₁)).StrictDominates
+      ((s.fiberProfile o t₁).prodMul (s.restProfile o t₂))) :
+    (s.listener α μ o).real {t₁} < (s.listener α μ o).real {t₂} :=
+  (s.listener_real_lt_iff_invPowSum hα hμeq hμ0
+      (s.exists_of_fiberProfile_ne_zero fun h =>
+        hcert.ne_zero (Multiset.prodMul_eq_zero_iff.mpr (Or.inl h)))).mpr
+    (s.invPowSum_odds_lt_of_prodMul_strictDominates hα hcert)
+
+/-- The evaluation register at a natural rationality: with all profile entries
+dividing `D`, listener preference at equal priors is the ℕ-valued
+common-denominator comparison — a kernel `decide`. The strict inequality
+carries its own truth witness. -/
+theorem listener_real_lt_of_divPowSum [s.Expressible] {k D : ℕ} (hk : k ≠ 0) (hD : D ≠ 0)
+    {o : O} {t₁ t₂ : T} (hμeq : μ {t₁} = μ {t₂}) (hμ0 : μ {t₂} ≠ 0)
+    (hdvd₁ : ∀ n ∈ s.profile t₁, n ∣ D) (hdvd₂ : ∀ n ∈ s.profile t₂, n ∣ D)
+    (hlt : (s.fiberProfile o t₁).divPowSum D k * (s.profile t₂).divPowSum D k
+      < (s.fiberProfile o t₂).divPowSum D k * (s.profile t₁).divPowSum D k) :
+    (s.listener k μ o).real {t₁} < (s.listener k μ o).real {t₂} := by
+  have hα : (0 : ℝ) < k := Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+  have hfsub : ∀ t, ∀ n ∈ s.fiberProfile o t, n ∈ s.profile t := fun t n hn =>
+    s.profile_eq_fiberProfile_add_restProfile o t ▸ Multiset.mem_add.mpr (Or.inl hn)
+  have h₂ : s.fiberProfile o t₂ ≠ 0 :=
+    Multiset.ne_zero_of_divPowSum_ne_zero
+      (Nat.mul_ne_zero_iff.mp (Nat.pos_iff_ne_zero.mp (lt_of_le_of_lt (Nat.zero_le _) hlt))).1
+  rw [s.listener_real_lt_iff_invPowSum hα hμeq hμ0 (s.exists_of_fiberProfile_ne_zero h₂)]
+  have key : ∀ (m₁ m₂ : Multiset ℕ), (∀ n ∈ m₁, n ∣ D) → (∀ n ∈ m₂, n ∣ D) →
+      (m₁.invPowSum k).toReal * (m₂.invPowSum k).toReal
+        = (m₁.divPowSum D k * m₂.divPowSum D k : ℕ) / ((D : ℝ) ^ k) ^ 2 := by
+    intro m₁ m₂ h₁ h₂
+    rw [Multiset.invPowSum_toReal_eq hD k h₁, Multiset.invPowSum_toReal_eq hD k h₂]
+    push_cast
+    ring
+  rw [key _ _ (fun n hn => hdvd₁ n (hfsub t₁ n hn)) hdvd₂,
+    key _ _ (fun n hn => hdvd₂ n (hfsub t₂ n hn)) hdvd₁,
+    div_lt_div_iff_of_pos_right (by positivity)]
+  exact_mod_cast hlt
 
 end Listener
 

--- a/Linglib/Pragmatics/RSA/Dominates.lean
+++ b/Linglib/Pragmatics/RSA/Dominates.lean
@@ -215,6 +215,24 @@ example : StrictDominates {1, 1, 5} {2, 7} := by decide
 
 example : ¬ StrictDominates {1, 2} {1, 2} := by decide
 
+/-- Evaluation form on reals, for pinned exponents. -/
+theorem invPowSum_toReal (hα : 0 ≤ α) (hm : 0 ∉ m) :
+    (m.invPowSum α).toReal = (m.map fun n : ℕ => ((n : ℝ))⁻¹ ^ α).sum := by
+  induction m using Multiset.induction with
+  | empty => simp [invPowSum]
+  | cons n m ih =>
+    have hn : n ≠ 0 := fun h => hm (h ▸ Multiset.mem_cons_self n m)
+    have hhead : ((n : ℝ≥0∞))⁻¹ ^ α ≠ ⊤ := by
+      rw [ne_eq, ENNReal.rpow_eq_top_iff]
+      rintro (⟨-, hneg⟩ | ⟨htop, -⟩)
+      · exact absurd hα (not_le.mpr hneg)
+      · exact hn (by simpa [ENNReal.inv_eq_top] using htop)
+    rw [invPowSum_cons, Multiset.map_cons, Multiset.sum_cons,
+      ENNReal.toReal_add hhead (invPowSum_ne_top hα fun h => hm (Multiset.mem_cons_of_mem h)),
+      ih fun h => hm (Multiset.mem_cons_of_mem h)]
+    congr 1
+    rw [← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast]
+
 theorem zero_notMem_prodMul (hs : 0 ∉ s) (ht : 0 ∉ t) : 0 ∉ prodMul s t := by
   simp only [prodMul, Multiset.mem_map, not_exists, not_and]
   intro p hp h0

--- a/Linglib/Pragmatics/RSA/Dominates.lean
+++ b/Linglib/Pragmatics/RSA/Dominates.lean
@@ -311,6 +311,10 @@ theorem invPowSum_mul_pow_eq_divPowSum {D : ℕ} (hD : D ≠ 0) (k : ℕ) {m : M
       ENNReal.inv_mul_cancel (by positivity) (by simp), mul_one]
     simp [divPowSum]
 
+theorem invPowSum_replicate (α : ℝ) (m n : ℕ) :
+    (Multiset.replicate m n).invPowSum α = m * (n : ℝ≥0∞)⁻¹ ^ α := by
+  rw [invPowSum, map_replicate, sum_replicate, nsmul_eq_mul]
+
 /-- Evaluation form on reals, for symbolic or pinned exponents. -/
 theorem invPowSum_toReal (hα : 0 ≤ α) (hm : 0 ∉ m) :
     (m.invPowSum α).toReal = (m.map fun n : ℕ => ((n : ℝ))⁻¹ ^ α).sum := by

--- a/Linglib/Pragmatics/RSA/Dominates.lean
+++ b/Linglib/Pragmatics/RSA/Dominates.lean
@@ -14,18 +14,25 @@ import Mathlib.Data.Multiset.Bind
 `Multiset.invPowSum α m` sums `n⁻ᵅ` over `m`. `t.Dominates s` says some submultiset of `t`
 matches `s` element-for-element with each matched entry of `t` at most its partner in `s`;
 that alone forces `s.invPowSum α ≤ t.invPowSum α` simultaneously for every exponent
-`0 ≤ α`, and a spare entry of `t` makes the inequality strict.
+`0 ≤ α`. `t.StrictDominates s` adds `¬ s.Dominates t`, which makes the inequality strict
+for every `0 < α`.
 
 Domination is equivalent to a Hall-type counting condition — `s` has no more entries below
-any threshold than `t` has — which decides it with `card s * (card s + card t)` comparisons.
-Certificates therefore close by `decide` for multisets of a few hundred entries, given a
-`maxRecDepth` of roughly `8 * card t`.
+any threshold than `t` has — so it is first-order stochastic dominance of the counting
+distributions, decided with `card s * (card s + card t)` comparisons. Certificates
+therefore close by `decide` for multisets of a few hundred entries, given a `maxRecDepth`
+of roughly `8 * card t`.
+
+At a natural exponent `k` with every entry dividing a common denominator `D`, the sum
+clears to the ℕ-valued `divPowSum D k`, so pinned-exponent comparisons also close by
+`decide`.
 
 ## Main results
 
 * `Multiset.Dominates.invPowSum_le`, `Multiset.StrictDominates.invPowSum_lt`
 * `Multiset.dominates_iff_forall`, `Multiset.dominates_iff_forall_mem`
 * `Multiset.invPowSum_prodMul`
+* `Multiset.invPowSum_mul_pow_eq_divPowSum`
 -/
 
 open scoped ENNReal
@@ -83,12 +90,20 @@ theorem invPowSum_ne_top (hα : 0 ≤ α) (hs : 0 ∉ s) : s.invPowSum α ≠ �
 entry of `t` being at most its partner in `s`. -/
 def Dominates (t s : Multiset ℕ) : Prop := ∃ t' ≤ t, Rel (· ≤ ·) t' s
 
-/-- `t` dominates `s` with an entry of `t` left over. -/
-def StrictDominates (t s : Multiset ℕ) : Prop := ∃ n ∈ t, (t.erase n).Dominates s
+/-- `t.StrictDominates s`: `t` dominates `s` but not conversely. By
+`dominates_iff_forall` this is strict first-order stochastic dominance of the counting
+distributions; it holds as soon as `t` has a spare entry over the matching, or some
+matched entry strictly below its partner. -/
+def StrictDominates (t s : Multiset ℕ) : Prop := t.Dominates s ∧ ¬ s.Dominates t
 
-theorem StrictDominates.dominates (h : t.StrictDominates s) : t.Dominates s := by
-  obtain ⟨n, -, t', ht', hrel⟩ := h
-  exact ⟨t', ht'.trans (erase_le n t), hrel⟩
+theorem StrictDominates.dominates (h : t.StrictDominates s) : t.Dominates s := h.1
+
+theorem StrictDominates.ne_zero (h : t.StrictDominates s) : t ≠ 0 := by
+  rintro rfl
+  obtain ⟨⟨t', ht', hrel⟩, hnd⟩ := h
+  obtain rfl := le_zero.mp ht'
+  obtain rfl := rel_zero_left.mp hrel
+  exact hnd ⟨0, le_rfl, Rel.zero⟩
 
 theorem invPowSum_le_invPowSum_of_rel (hα : 0 ≤ α) (h : Rel (· ≤ ·) t s) :
     s.invPowSum α ≤ t.invPowSum α := by
@@ -102,16 +117,6 @@ theorem Dominates.invPowSum_le (h : t.Dominates s) (hα : 0 ≤ α) :
     s.invPowSum α ≤ t.invPowSum α := by
   obtain ⟨t', ht', hrel⟩ := h
   exact (invPowSum_le_invPowSum_of_rel hα hrel).trans (invPowSum_mono ht')
-
-theorem StrictDominates.invPowSum_lt (h : t.StrictDominates s) (hα : 0 ≤ α) (hs : 0 ∉ s) :
-    s.invPowSum α < t.invPowSum α := by
-  obtain ⟨n, hn, hdom⟩ := h
-  have hpos : 0 < (n : ℝ≥0∞)⁻¹ ^ α := by
-    simpa using invPowSum_pos (m := {n}) hα (by simp)
-  rw [← cons_erase hn, invPowSum_cons, add_comm]
-  rcases eq_or_ne ((t.erase n).invPowSum α) ⊤ with h₁ | h₁
-  · exact h₁ ▸ (invPowSum_ne_top hα hs).lt_top
-  · exact (hdom.invPowSum_le hα).trans_lt (ENNReal.lt_add_right h₁ hpos.ne')
 
 /-! ### The Hall criterion -/
 
@@ -175,7 +180,55 @@ instance decidableDominates : DecidableRel Dominates :=
   fun _ _ => decidable_of_iff _ dominates_iff_forall_mem.symm
 
 instance decidableStrictDominates : DecidableRel StrictDominates :=
-  fun _ _ => Multiset.decidableExistsMultiset
+  fun _ _ => inferInstanceAs (Decidable (_ ∧ _))
+
+theorem dominates_refl (s : Multiset ℕ) : s.Dominates s :=
+  dominates_iff_forall.2 fun _ => le_rfl
+
+/-! ### Strict domination is strict on inverse-power sums -/
+
+private theorem invPowSum_lt_of_rel_of_ne (hα : 0 < α) :
+    ∀ {t s : Multiset ℕ}, Rel (· ≤ ·) t s → t ≠ s → 0 ∉ s →
+      s.invPowSum α < t.invPowSum α := by
+  intro t s hrel
+  induction hrel with
+  | zero => exact fun hne _ => absurd rfl hne
+  | @cons a b as bs hab hrest ih =>
+    intro hne hs
+    have hb : b ≠ 0 := fun h => hs (h ▸ mem_cons_self b bs)
+    have hbs : 0 ∉ bs := fun h => hs (mem_cons_of_mem h)
+    have hbfin : (b : ℝ≥0∞)⁻¹ ^ α ≠ ⊤ :=
+      invPowSum_singleton α b ▸ invPowSum_ne_top hα.le (by simpa [eq_comm] using hb)
+    rcases eq_or_lt_of_le hab with rfl | hlt
+    · rw [invPowSum_cons, invPowSum_cons]
+      exact ENNReal.add_lt_add_left hbfin (ih (fun h => hne (by rw [h])) hbs)
+    · rw [invPowSum_cons, invPowSum_cons]
+      have hhead : (b : ℝ≥0∞)⁻¹ ^ α < (a : ℝ≥0∞)⁻¹ ^ α :=
+        ENNReal.rpow_lt_rpow (ENNReal.inv_lt_inv.2 (by exact_mod_cast hlt)) hα
+      calc (b : ℝ≥0∞)⁻¹ ^ α + bs.invPowSum α
+          < (a : ℝ≥0∞)⁻¹ ^ α + bs.invPowSum α :=
+            ENNReal.add_lt_add_right (invPowSum_ne_top hα.le hbs) hhead
+        _ ≤ (a : ℝ≥0∞)⁻¹ ^ α + as.invPowSum α :=
+            add_le_add le_rfl (invPowSum_le_invPowSum_of_rel hα.le hrest)
+
+theorem StrictDominates.invPowSum_lt (h : t.StrictDominates s) (hα : 0 < α) (hs : 0 ∉ s) :
+    s.invPowSum α < t.invPowSum α := by
+  obtain ⟨⟨t', ht', hrel⟩, hnd⟩ := h
+  rcases eq_or_lt_of_le ht' with rfl | hlt
+  · exact invPowSum_lt_of_rel_of_ne hα hrel
+      (fun h => hnd (by rw [← h]; exact dominates_refl t')) hs
+  · obtain ⟨a, ha⟩ := lt_iff_cons_le.mp hlt
+    have hle : s.invPowSum α ≤ t'.invPowSum α := invPowSum_le_invPowSum_of_rel hα.le hrel
+    rcases eq_or_ne (t'.invPowSum α) ⊤ with h₁ | h₁
+    · exact ((invPowSum_ne_top hα.le hs).lt_top).trans_le
+        (le_trans (le_of_eq h₁.symm) (invPowSum_mono ((le_cons_self t' a).trans ha)))
+    · have hpos : 0 < (a : ℝ≥0∞)⁻¹ ^ α := by
+        simpa using invPowSum_pos (m := {a}) hα.le (by simp)
+      calc s.invPowSum α ≤ t'.invPowSum α := hle
+        _ < (a ::ₘ t').invPowSum α := by
+            rw [invPowSum_cons, add_comm]
+            exact ENNReal.lt_add_right h₁ hpos.ne'
+        _ ≤ t.invPowSum α := invPowSum_mono ha
 
 /-! ### Pairwise products -/
 
@@ -188,6 +241,13 @@ def prodMul (s t : Multiset ℕ) : Multiset ℕ := (s ×ˢ t).map fun p => p.1 *
 theorem cons_prodMul (n : ℕ) (s t : Multiset ℕ) :
     prodMul (n ::ₘ s) t = t.map (n * ·) + prodMul s t := by
   simp [prodMul]
+
+@[simp]
+theorem card_prodMul (s t : Multiset ℕ) : card (prodMul s t) = card s * card t := by
+  simp [prodMul]
+
+theorem prodMul_eq_zero_iff {s t : Multiset ℕ} : prodMul s t = 0 ↔ s = 0 ∨ t = 0 := by
+  rw [← card_eq_zero, card_prodMul, Nat.mul_eq_zero, card_eq_zero, card_eq_zero]
 
 private theorem natCast_inv_rpow_mul (hα : 0 ≤ α) (a b : ℕ) :
     ((a * b : ℕ) : ℝ≥0∞)⁻¹ ^ α = (a : ℝ≥0∞)⁻¹ ^ α * (b : ℝ≥0∞)⁻¹ ^ α := by
@@ -205,17 +265,53 @@ theorem invPowSum_prodMul (hα : 0 ≤ α) (s t : Multiset ℕ) :
   | cons n s ih =>
     rw [cons_prodMul, invPowSum_add, ih, invPowSum_map_mul hα, invPowSum_cons, add_mul]
 
-/-! ### Certificates -/
+theorem zero_notMem_prodMul (hs : 0 ∉ s) (ht : 0 ∉ t) : 0 ∉ prodMul s t := by
+  simp only [prodMul, Multiset.mem_map, not_exists, not_and]
+  intro p hp h0
+  rcases Nat.mul_eq_zero.mp h0 with h | h
+  · exact hs (h ▸ (Multiset.mem_product.mp hp).1)
+  · exact ht (h ▸ (Multiset.mem_product.mp hp).2)
 
-example : Dominates {1, 2, 3} {2, 3} := by decide
+/-! ### Common-denominator power sums -/
 
-example : ¬ Dominates {2, 3} {1, 2} := by decide
+/-- The ℕ-valued common-denominator form of `invPowSum` at a natural exponent:
+`Σ (D/n)ᵏ` over `m`. When every entry divides `D`, `invPowSum k m` is
+`divPowSum D k m / Dᵏ` exactly, so pinned-exponent comparisons clear to ℕ
+inequalities closed by `decide`. -/
+def divPowSum (D k : ℕ) (m : Multiset ℕ) : ℕ := (m.map fun n => (D / n) ^ k).sum
 
-example : StrictDominates {1, 1, 5} {2, 7} := by decide
+@[simp] theorem divPowSum_zero (D k : ℕ) : divPowSum D k 0 = 0 := rfl
 
-example : ¬ StrictDominates {1, 2} {1, 2} := by decide
+theorem ne_zero_of_divPowSum_ne_zero {D k : ℕ} (h : divPowSum D k m ≠ 0) : m ≠ 0 :=
+  fun h0 => h (h0 ▸ rfl)
 
-/-- Evaluation form on reals, for pinned exponents. -/
+theorem divPowSum_pos {D k : ℕ} (hD : D ≠ 0) (h : ∀ n ∈ m, n ∣ D) (hm : m ≠ 0) :
+    0 < divPowSum D k m := by
+  obtain ⟨n, hn⟩ := exists_mem_of_ne_zero hm
+  have hn0 : 0 < n := Nat.pos_of_ne_zero fun h0 => hD (Nat.eq_zero_of_zero_dvd (h0 ▸ h n hn))
+  exact lt_of_lt_of_le
+    (pow_pos (Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hD) (h n hn)) hn0) k)
+    (single_le_sum (fun x _ => Nat.zero_le x) _ (mem_map_of_mem _ hn))
+
+/-- Clearing the common denominator: at a natural exponent, `invPowSum` times `Dᵏ` is the
+ℕ-valued `divPowSum`. -/
+theorem invPowSum_mul_pow_eq_divPowSum {D : ℕ} (hD : D ≠ 0) (k : ℕ) {m : Multiset ℕ}
+    (h : ∀ n ∈ m, n ∣ D) :
+    m.invPowSum k * (D : ℝ≥0∞) ^ k = divPowSum D k m := by
+  induction m using Multiset.induction with
+  | empty => simp
+  | cons n m ih =>
+    have hn : n ∣ D := h n (mem_cons_self n m)
+    have hn0 : n ≠ 0 := fun h0 => hD (Nat.eq_zero_of_zero_dvd (h0 ▸ hn))
+    have hD_eq : (D : ℝ≥0∞) ^ k = ((D / n : ℕ) : ℝ≥0∞) ^ k * (n : ℝ≥0∞) ^ k := by
+      rw [← mul_pow, ← Nat.cast_mul, Nat.div_mul_cancel hn]
+    rw [invPowSum_cons, add_mul, ih fun x hx => h x (mem_cons_of_mem hx),
+      ENNReal.rpow_natCast, ← ENNReal.inv_pow, hD_eq, ← mul_assoc,
+      mul_comm ((n : ℝ≥0∞) ^ k)⁻¹, mul_assoc,
+      ENNReal.inv_mul_cancel (by positivity) (by simp), mul_one]
+    simp [divPowSum]
+
+/-- Evaluation form on reals, for symbolic or pinned exponents. -/
 theorem invPowSum_toReal (hα : 0 ≤ α) (hm : 0 ∉ m) :
     (m.invPowSum α).toReal = (m.map fun n : ℕ => ((n : ℝ))⁻¹ ^ α).sum := by
   induction m using Multiset.induction with
@@ -233,12 +329,28 @@ theorem invPowSum_toReal (hα : 0 ≤ α) (hm : 0 ∉ m) :
     congr 1
     rw [← ENNReal.toReal_rpow, ENNReal.toReal_inv, ENNReal.toReal_natCast]
 
-theorem zero_notMem_prodMul (hs : 0 ∉ s) (ht : 0 ∉ t) : 0 ∉ prodMul s t := by
-  simp only [prodMul, Multiset.mem_map, not_exists, not_and]
-  intro p hp h0
-  rcases Nat.mul_eq_zero.mp h0 with h | h
-  · exact hs (h ▸ (Multiset.mem_product.mp hp).1)
-  · exact ht (h ▸ (Multiset.mem_product.mp hp).2)
+/-- Real form of the common-denominator identity. -/
+theorem invPowSum_toReal_eq {D : ℕ} (hD : D ≠ 0) (k : ℕ) {m : Multiset ℕ}
+    (h : ∀ n ∈ m, n ∣ D) :
+    (m.invPowSum k).toReal = (m.divPowSum D k : ℝ) / (D : ℝ) ^ k := by
+  have hc := congrArg ENNReal.toReal (invPowSum_mul_pow_eq_divPowSum hD k h)
+  rw [ENNReal.toReal_mul, ENNReal.toReal_pow, ENNReal.toReal_natCast,
+    ENNReal.toReal_natCast] at hc
+  rw [eq_div_iff (pow_ne_zero k (Nat.cast_ne_zero.mpr hD))]
+  exact hc
+
+/-! ### Certificates -/
+
+example : Dominates {1, 2, 3} {2, 3} := by decide
+
+example : ¬ Dominates {2, 3} {1, 2} := by decide
+
+example : StrictDominates {1, 1, 5} {2, 7} := by decide
+
+-- termwise-strict domination with no spare entry
+example : StrictDominates {3} {4} := by decide
+
+example : ¬ StrictDominates {1, 2} {1, 2} := by decide
 
 set_option maxRecDepth 2000 in
 example : (prodMul {1, 2, 3, 4} {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}).StrictDominates

--- a/Linglib/Pragmatics/RSA/Dominates.lean
+++ b/Linglib/Pragmatics/RSA/Dominates.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.BigOperators.Ring.Multiset
+import Mathlib.Algebra.Order.BigOperators.Group.Multiset
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import Mathlib.Data.Multiset.Bind
+
+/-!
+# Inverse-power sums over multisets of naturals
+
+`Multiset.invPowSum α m` sums `n⁻ᵅ` over `m`. `t.Dominates s` says some submultiset of `t`
+matches `s` element-for-element with each matched entry of `t` at most its partner in `s`;
+that alone forces `s.invPowSum α ≤ t.invPowSum α` simultaneously for every exponent
+`0 ≤ α`, and a spare entry of `t` makes the inequality strict.
+
+Domination is equivalent to a Hall-type counting condition — `s` has no more entries below
+any threshold than `t` has — which decides it with `card s * (card s + card t)` comparisons.
+Certificates therefore close by `decide` for multisets of a few hundred entries, given a
+`maxRecDepth` of roughly `8 * card t`.
+
+## Main results
+
+* `Multiset.Dominates.invPowSum_le`, `Multiset.StrictDominates.invPowSum_lt`
+* `Multiset.dominates_iff_forall`, `Multiset.dominates_iff_forall_mem`
+* `Multiset.invPowSum_prodMul`
+-/
+
+open scoped ENNReal
+
+namespace Multiset
+
+variable {α : ℝ} {m s t : Multiset ℕ}
+
+/-! ### Inverse-power sums -/
+
+/-- The sum of `n⁻ᵅ` over `m`. Entries equal to `0` contribute `⊤`. -/
+noncomputable def invPowSum (α : ℝ) (m : Multiset ℕ) : ℝ≥0∞ :=
+  (m.map fun n : ℕ => (n : ℝ≥0∞)⁻¹ ^ α).sum
+
+@[simp] theorem invPowSum_zero (α : ℝ) : (0 : Multiset ℕ).invPowSum α = 0 := rfl
+
+@[simp]
+theorem invPowSum_cons (α : ℝ) (n : ℕ) (m : Multiset ℕ) :
+    (n ::ₘ m).invPowSum α = (n : ℝ≥0∞)⁻¹ ^ α + m.invPowSum α := by
+  simp [invPowSum]
+
+@[simp]
+theorem invPowSum_singleton (α : ℝ) (n : ℕ) :
+    ({n} : Multiset ℕ).invPowSum α = (n : ℝ≥0∞)⁻¹ ^ α := by
+  simp [invPowSum]
+
+@[simp]
+theorem invPowSum_add (α : ℝ) (m₁ m₂ : Multiset ℕ) :
+    (m₁ + m₂).invPowSum α = m₁.invPowSum α + m₂.invPowSum α := by
+  simp [invPowSum]
+
+@[gcongr]
+theorem invPowSum_mono (h : s ≤ t) : s.invPowSum α ≤ t.invPowSum α := by
+  obtain ⟨u, rfl⟩ := le_iff_exists_add.1 h
+  simp
+
+theorem invPowSum_pos (hα : 0 ≤ α) (hm : m ≠ 0) : 0 < m.invPowSum α := by
+  obtain ⟨n, hn⟩ := exists_mem_of_ne_zero hm
+  obtain ⟨m', rfl⟩ := exists_cons_of_mem hn
+  rw [invPowSum_cons]
+  exact lt_of_lt_of_le
+    (ENNReal.rpow_pos_of_nonneg (ENNReal.inv_pos.2 (ENNReal.natCast_ne_top n)) hα) le_self_add
+
+theorem invPowSum_ne_top (hα : 0 ≤ α) (hs : 0 ∉ s) : s.invPowSum α ≠ ⊤ := by
+  refine ne_top_of_le_ne_top (by simp) (sum_le_card_nsmul _ 1 ?_)
+  intro x hx
+  obtain ⟨n, hn, rfl⟩ := mem_map.1 hx
+  have hn' : (1 : ℝ≥0∞) ≤ n := by
+    exact_mod_cast Nat.one_le_iff_ne_zero.2 fun h => hs (h ▸ hn)
+  simpa using ENNReal.rpow_le_rpow (ENNReal.inv_le_one.2 hn') hα
+
+/-! ### Domination -/
+
+/-- `t.Dominates s`: some submultiset of `t` matches `s` element-for-element, each matched
+entry of `t` being at most its partner in `s`. -/
+def Dominates (t s : Multiset ℕ) : Prop := ∃ t' ≤ t, Rel (· ≤ ·) t' s
+
+/-- `t` dominates `s` with an entry of `t` left over. -/
+def StrictDominates (t s : Multiset ℕ) : Prop := ∃ n ∈ t, (t.erase n).Dominates s
+
+theorem StrictDominates.dominates (h : t.StrictDominates s) : t.Dominates s := by
+  obtain ⟨n, -, t', ht', hrel⟩ := h
+  exact ⟨t', ht'.trans (erase_le n t), hrel⟩
+
+theorem invPowSum_le_invPowSum_of_rel (hα : 0 ≤ α) (h : Rel (· ≤ ·) t s) :
+    s.invPowSum α ≤ t.invPowSum α := by
+  induction h with
+  | zero => simp
+  | cons hab _ ih =>
+    rw [invPowSum_cons, invPowSum_cons]
+    exact add_le_add (ENNReal.rpow_le_rpow (ENNReal.inv_le_inv.2 (Nat.cast_le.2 hab)) hα) ih
+
+theorem Dominates.invPowSum_le (h : t.Dominates s) (hα : 0 ≤ α) :
+    s.invPowSum α ≤ t.invPowSum α := by
+  obtain ⟨t', ht', hrel⟩ := h
+  exact (invPowSum_le_invPowSum_of_rel hα hrel).trans (invPowSum_mono ht')
+
+theorem StrictDominates.invPowSum_lt (h : t.StrictDominates s) (hα : 0 ≤ α) (hs : 0 ∉ s) :
+    s.invPowSum α < t.invPowSum α := by
+  obtain ⟨n, hn, hdom⟩ := h
+  have hpos : 0 < (n : ℝ≥0∞)⁻¹ ^ α := by
+    simpa using invPowSum_pos (m := {n}) hα (by simp)
+  rw [← cons_erase hn, invPowSum_cons, add_comm]
+  rcases eq_or_ne ((t.erase n).invPowSum α) ⊤ with h₁ | h₁
+  · exact h₁ ▸ (invPowSum_ne_top hα hs).lt_top
+  · exact (hdom.invPowSum_le hα).trans_lt (ENNReal.lt_add_right h₁ hpos.ne')
+
+/-! ### The Hall criterion -/
+
+private theorem exists_min (hs : s ≠ 0) : ∃ x ∈ s, ∀ y ∈ s, x ≤ y :=
+  let h := exists_mem_of_ne_zero hs
+  ⟨Nat.find h, Nat.find_spec h, fun _ hy => Nat.find_min' h hy⟩
+
+theorem card_filter_le_card_filter_of_rel (h : Rel (· ≤ ·) t s) (k : ℕ) :
+    card (s.filter (· ≤ k)) ≤ card (t.filter (· ≤ k)) := by
+  induction h with
+  | zero => simp
+  | @cons a b as bs hab _ ih =>
+    by_cases hb : b ≤ k
+    · have h₁ : (b ::ₘ bs).filter (· ≤ k) = b ::ₘ bs.filter (· ≤ k) := filter_cons_of_pos _ hb
+      have h₂ : (a ::ₘ as).filter (· ≤ k) = a ::ₘ as.filter (· ≤ k) :=
+        filter_cons_of_pos _ (hab.trans hb)
+      simpa [h₁, h₂] using ih
+    · have h₁ : (b ::ₘ bs).filter (· ≤ k) = bs.filter (· ≤ k) := filter_cons_of_neg _ hb
+      exact h₁ ▸ ih.trans (card_le_card (filter_le_filter _ (le_cons_self _ _)))
+
+theorem Dominates.card_filter_le (h : t.Dominates s) (k : ℕ) :
+    card (s.filter (· ≤ k)) ≤ card (t.filter (· ≤ k)) := by
+  obtain ⟨t', ht', hrel⟩ := h
+  exact (card_filter_le_card_filter_of_rel hrel k).trans (card_le_card (filter_le_filter _ ht'))
+
+/-- Greedy matching: pair the least entry of `s` with any entry of `t` below it, which the
+counting condition supplies and which leaves the condition intact for what remains. -/
+theorem dominates_of_forall_mem
+    (h : ∀ k ∈ s, card (s.filter (· ≤ k)) ≤ card (t.filter (· ≤ k))) : t.Dominates s := by
+  induction s using Multiset.strongInductionOn generalizing t with
+  | _ s ih =>
+  rcases eq_or_ne s 0 with rfl | hs
+  · exact ⟨0, zero_le _, Rel.zero⟩
+  obtain ⟨x, hx, hmin⟩ := exists_min hs
+  have hxx : x ∈ s.filter (· ≤ x) := mem_filter.2 ⟨hx, le_rfl⟩
+  obtain ⟨y, hy⟩ := card_pos_iff_exists_mem.1 <|
+    lt_of_lt_of_le (card_pos_iff_exists_mem.2 ⟨x, hxx⟩) (h x hx)
+  obtain ⟨hyt, hyx⟩ := mem_filter.1 hy
+  obtain ⟨t', ht', hrel⟩ := @ih (s.erase x) (erase_lt.2 hx) (t.erase y) fun k hk => by
+    have hxk : x ≤ k := hmin k (mem_of_mem_erase hk)
+    have hsk : s.filter (· ≤ k) = x ::ₘ (s.erase x).filter (· ≤ k) := by
+      conv_lhs => rw [← cons_erase hx]
+      exact filter_cons_of_pos _ hxk
+    have htk : t.filter (· ≤ k) = y ::ₘ (t.erase y).filter (· ≤ k) := by
+      conv_lhs => rw [← cons_erase hyt]
+      exact filter_cons_of_pos _ (hyx.trans hxk)
+    have := h k (mem_of_mem_erase hk)
+    rw [hsk, htk, card_cons, card_cons] at this
+    omega
+  exact ⟨y ::ₘ t', cons_erase hyt ▸ cons_le_cons _ ht', cons_erase hx ▸ Rel.cons hyx hrel⟩
+
+theorem dominates_iff_forall_mem :
+    t.Dominates s ↔ ∀ k ∈ s, card (s.filter (· ≤ k)) ≤ card (t.filter (· ≤ k)) :=
+  ⟨fun h k _ => h.card_filter_le k, dominates_of_forall_mem⟩
+
+theorem dominates_iff_forall :
+    t.Dominates s ↔ ∀ k, card (s.filter (· ≤ k)) ≤ card (t.filter (· ≤ k)) :=
+  ⟨Dominates.card_filter_le, fun h => dominates_of_forall_mem fun k _ => h k⟩
+
+instance decidableDominates : DecidableRel Dominates :=
+  fun _ _ => decidable_of_iff _ dominates_iff_forall_mem.symm
+
+instance decidableStrictDominates : DecidableRel StrictDominates :=
+  fun _ _ => Multiset.decidableExistsMultiset
+
+/-! ### Pairwise products -/
+
+/-- The multiset of pairwise products of `s` and `t`. -/
+def prodMul (s t : Multiset ℕ) : Multiset ℕ := (s ×ˢ t).map fun p => p.1 * p.2
+
+@[simp] theorem zero_prodMul (t : Multiset ℕ) : prodMul 0 t = 0 := rfl
+
+@[simp]
+theorem cons_prodMul (n : ℕ) (s t : Multiset ℕ) :
+    prodMul (n ::ₘ s) t = t.map (n * ·) + prodMul s t := by
+  simp [prodMul]
+
+private theorem natCast_inv_rpow_mul (hα : 0 ≤ α) (a b : ℕ) :
+    ((a * b : ℕ) : ℝ≥0∞)⁻¹ ^ α = (a : ℝ≥0∞)⁻¹ ^ α * (b : ℝ≥0∞)⁻¹ ^ α := by
+  rw [Nat.cast_mul, ENNReal.mul_inv (Or.inr (ENNReal.natCast_ne_top b))
+    (Or.inl (ENNReal.natCast_ne_top a)), ENNReal.mul_rpow_of_nonneg _ _ hα]
+
+theorem invPowSum_map_mul (hα : 0 ≤ α) (n : ℕ) (t : Multiset ℕ) :
+    (t.map (n * ·)).invPowSum α = (n : ℝ≥0∞)⁻¹ ^ α * t.invPowSum α := by
+  simp only [invPowSum, map_map, Function.comp_def, natCast_inv_rpow_mul hα, sum_map_mul_left]
+
+theorem invPowSum_prodMul (hα : 0 ≤ α) (s t : Multiset ℕ) :
+    (prodMul s t).invPowSum α = s.invPowSum α * t.invPowSum α := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons n s ih =>
+    rw [cons_prodMul, invPowSum_add, ih, invPowSum_map_mul hα, invPowSum_cons, add_mul]
+
+/-! ### Certificates -/
+
+example : Dominates {1, 2, 3} {2, 3} := by decide
+
+example : ¬ Dominates {2, 3} {1, 2} := by decide
+
+example : StrictDominates {1, 1, 5} {2, 7} := by decide
+
+example : ¬ StrictDominates {1, 2} {1, 2} := by decide
+
+theorem zero_notMem_prodMul (hs : 0 ∉ s) (ht : 0 ∉ t) : 0 ∉ prodMul s t := by
+  simp only [prodMul, Multiset.mem_map, not_exists, not_and]
+  intro p hp h0
+  rcases Nat.mul_eq_zero.mp h0 with h | h
+  · exact hs (h ▸ (Multiset.mem_product.mp hp).1)
+  · exact ht (h ▸ (Multiset.mem_product.mp hp).2)
+
+set_option maxRecDepth 2000 in
+example : (prodMul {1, 2, 3, 4} {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}).StrictDominates
+    {2, 4, 6, 8, 10} := by decide
+
+set_option maxRecDepth 2000 in
+example : ¬ (prodMul {2, 3} {5, 7, 11, 13, 17}).Dominates {1, 4} := by decide
+
+end Multiset

--- a/Linglib/Pragmatics/RSA/Dominates.lean
+++ b/Linglib/Pragmatics/RSA/Dominates.lean
@@ -20,8 +20,7 @@ for every `0 < α`.
 Domination is equivalent to a Hall-type counting condition — `s` has no more entries below
 any threshold than `t` has — so it is first-order stochastic dominance of the counting
 distributions, decided with `card s * (card s + card t)` comparisons. Certificates
-therefore close by `decide` for multisets of a few hundred entries, given a `maxRecDepth`
-of roughly `8 * card t`.
+therefore close by `decide +kernel` for multisets of a few hundred entries.
 
 At a natural exponent `k` with every entry dividing a common denominator `D`, the sum
 clears to the ℕ-valued `divPowSum D k`, so pinned-exponent comparisons also close by
@@ -356,11 +355,9 @@ example : StrictDominates {3} {4} := by decide
 
 example : ¬ StrictDominates {1, 2} {1, 2} := by decide
 
-set_option maxRecDepth 2000 in
 example : (prodMul {1, 2, 3, 4} {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}).StrictDominates
-    {2, 4, 6, 8, 10} := by decide
+    {2, 4, 6, 8, 10} := by decide +kernel
 
-set_option maxRecDepth 2000 in
-example : ¬ (prodMul {2, 3} {5, 7, 11, 13, 17}).Dominates {1, 4} := by decide
+example : ¬ (prodMul {2, 3} {5, 7, 11, 13, 17}).Dominates {1, 4} := by decide +kernel
 
 end Multiset

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -31,7 +31,7 @@ reading ⟦SS⟧^M = {wNS} "uniquely singles out this world state" (eq. 22,
 model comparison (posterior 0.956 vs LI 0.033, LU 0.01, vanilla 0; Table 2).
 The M-advantage exists *because* the pooled speaker normalizes over pairs:
 under the per-parse normalization the paper rejects (p. e85), O beats M at
-every rationality (`perParse_ss_o_beats_m`). LI and LU still derive the
+every rationality (`perParse_ss_prefers_o`). LI and LU still derive the
 embedded enrichments (`li_ss_outer_exh`, `li_ss_prefers_wNS`,
 `lu_ss_prefers_wNS`).
 
@@ -40,7 +40,7 @@ embedded enrichments (`li_ss_outer_exh`, `li_ss_prefers_wNS`,
 * `table1_*` — the paper's Table 1, one lemma per row, including NN's
   distinct matrix row (fn. 7) from the `none ~ not all` lexical alternative
   ([levinson-2000]).
-* `ss_m_parse_pref` vs `perParse_ss_o_beats_m` — the architectural headline:
+* `ss_m_parse_pref` vs `perParse_ss_prefers_o` — the architectural headline:
   pooled (utterance, parse) choice peaks at M (α = 5), per-parse
   normalization prefers O for every rationality. With
   `RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win
@@ -95,15 +95,15 @@ instance (t : AlienType) (w : World) : Decidable (t ∈ w) :=
 /-- The world with only N-type aliens (each drank none). -/
 def wN : World := ⟨{.none}, Finset.singleton_nonempty _⟩
 /-- The world with N-type and S-type aliens. -/
-def wNS : World := ⟨{.none, .someNotAll}, by decide⟩
+def wNS : World := ⟨{.none, .someNotAll}, by decide +kernel⟩
 /-- The world with N-type and A-type aliens. -/
-def wNA : World := ⟨{.none, .all}, by decide⟩
+def wNA : World := ⟨{.none, .all}, by decide +kernel⟩
 /-- The world with all three alien types. -/
-def wNSA : World := ⟨{.none, .someNotAll, .all}, by decide⟩
+def wNSA : World := ⟨{.none, .someNotAll, .all}, by decide +kernel⟩
 /-- The world with only S-type aliens (each drank some but not all). -/
 def wS : World := ⟨{.someNotAll}, Finset.singleton_nonempty _⟩
 /-- The world with S-type and A-type aliens. -/
-def wSA : World := ⟨{.someNotAll, .all}, by decide⟩
+def wSA : World := ⟨{.someNotAll, .all}, by decide +kernel⟩
 /-- The world with only A-type aliens (each drank all). -/
 def wA : World := ⟨{.all}, Finset.singleton_nonempty _⟩
 
@@ -285,23 +285,23 @@ the world's alien-type set, not a truth vector. -/
 /-- Table 1, NN: no N-types; matrix parses additionally negate "none drank
 not all" (= {wA}) — the fn. 7 reading from the `none ~ not all` alternative. -/
 theorem table1_nn : ∀ (p : Parse) (w : World),
-    exhMeaning p .nn w ↔ (.none ∉ w ∧ (.matrix ∈ p → w ≠ wA)) := by decide
+    exhMeaning p .nn w ↔ (.none ∉ w ∧ (.matrix ∈ p → w ≠ wA)) := by decide +kernel
 
 /-- Table 1, NS: only wN literally; inner EXH weakens to the S-free worlds,
 whereupon matrix EXH negates the sentence's own now-stronger literal {wN}. -/
 theorem table1_ns : ∀ (p : Parse) (w : World),
     exhMeaning p .ns w ↔
       if .inner ∈ p then .someNotAll ∉ w ∧ (.matrix ∈ p → w ≠ wN)
-      else w = wN := by decide
+      else w = wN := by decide +kernel
 
 /-- Table 1, NA: no A-types; matrix EXH negates the stronger NS = {wN}. -/
 theorem table1_na : ∀ (p : Parse) (w : World),
-    exhMeaning p .na w ↔ (.all ∉ w ∧ (.matrix ∈ p → w ≠ wN)) := by decide
+    exhMeaning p .na w ↔ (.all ∉ w ∧ (.matrix ∈ p → w ≠ wN)) := by decide +kernel
 
 /-- Table 1, SN: an N-type exists; outer or matrix EXH negates AN = {wN}. -/
 theorem table1_sn : ∀ (p : Parse) (w : World),
     exhMeaning p .sn w ↔
-      (.none ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wN)) := by decide
+      (.none ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wN)) := by decide +kernel
 
 /-- Table 1, SS: the five row-groups — literal; inner EXH requires an S-type
 (matrix then vacuous); adding outer EXH excludes wS; outer alone keeps mixed
@@ -311,33 +311,33 @@ theorem table1_ss : ∀ (p : Parse) (w : World),
       if .inner ∈ p then .someNotAll ∈ w ∧ (.outer ∈ p → w ≠ wS)
       else if .outer ∈ p then .none ∈ w ∧ w ≠ wN
       else if .matrix ∈ p then w = wNS
-      else w ≠ wN := by decide
+      else w ≠ wN := by decide +kernel
 
 /-- Table 1, SA: an A-type exists; outer or matrix EXH excludes wA. -/
 theorem table1_sa : ∀ (p : Parse) (w : World),
     exhMeaning p .sa w ↔
-      (.all ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wA)) := by decide
+      (.all ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wA)) := by decide +kernel
 
 /-- Table 1, AN: only wN, under every parse. -/
-theorem table1_an : ∀ (p : Parse) (w : World), exhMeaning p .an w ↔ w = wN := by decide
+theorem table1_an : ∀ (p : Parse) (w : World), exhMeaning p .an w ↔ w = wN := by decide +kernel
 
 /-- Table 1, AS: no N-types; inner EXH pins wS; matrix EXH without inner
 negates AA, excluding wA. -/
 theorem table1_as : ∀ (p : Parse) (w : World),
     exhMeaning p .as w ↔
       if .inner ∈ p then w = wS
-      else .none ∉ w ∧ (.matrix ∈ p → w ≠ wA) := by decide
+      else .none ∉ w ∧ (.matrix ∈ p → w ≠ wA) := by decide +kernel
 
 /-- Table 1, AA: only wA, under every parse. -/
-theorem table1_aa : ∀ (p : Parse) (w : World), exhMeaning p .aa w ↔ w = wA := by decide
+theorem table1_aa : ∀ (p : Parse) (w : World), exhMeaning p .aa w ↔ w = wA := by decide +kernel
 
 /-- Literal meaning is the empty parse's exhaustified meaning. -/
 theorem literal_eq_exh_none : ∀ (u : Utterance) (w : World),
-    literalMeaning u w ↔ exhMeaning ∅ u w := by decide
+    literalMeaning u w ↔ exhMeaning ∅ u w := by decide +kernel
 
 /-- ⟦SS⟧^M = {wNS} — the reading that "uniquely singles out this world
 state" (eq. 22) and drives GI's win; the matrix-alone case of `table1_ss`. -/
-theorem m_ss_singleton : ∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS := by decide
+theorem m_ss_singleton : ∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS := by decide +kernel
 
 /-- The matrix operator (eq. A2) is not Fox-style innocent exclusion
 ([fox-2007]): at MOI its strictly-stronger filter is empty and ⟦SS⟧^MOI keeps
@@ -349,7 +349,7 @@ theorem moi_ss_ne_innocent_exclusion :
             ((matrixAlts .ss).map fun a w => decide (altLiteral a w)))
           (Exhaustification.predToFinset
             fun w => decide (exhMeaning {.outer, .inner} .ss w)) :=
-  ⟨by decide, by decide⟩
+  ⟨by decide +kernel, by decide +kernel⟩
 
 /-! ### Latent spaces -/
 
@@ -379,10 +379,10 @@ def LIParse.toParse : LIParse → Parse
   | .oi => {.outer, .inner}
 
 /-- LI cannot access matrix EXH: no LI parse includes M. -/
-theorem li_excludes_matrix : ∀ l : LIParse, .matrix ∉ l.toParse := by decide
+theorem li_excludes_matrix : ∀ l : LIParse, .matrix ∉ l.toParse := by decide +kernel
 
 /-- LU cannot access matrix EXH: neither lexicon includes M. -/
-theorem lu_excludes_matrix : ∀ l : LULex, .matrix ∉ l.toParse := by decide
+theorem lu_excludes_matrix : ∀ l : LULex, .matrix ∉ l.toParse := by decide +kernel
 
 /-! ### Measurable structure -/
 
@@ -429,7 +429,7 @@ theorem prior_singleton_ne_zero (w : World) : prior {w} ≠ 0 := by
   simp
 
 /-- Every `(world, parse)` state has a true utterance. -/
-theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide
+theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide +kernel
 
 /-! ### The models as combinators over one reading family
 
@@ -440,7 +440,7 @@ space — the speaker *chooses* the parse — while LU (eq. 11) fixes the lexico
 as a speaker argument (`RSA.Scenario.familySpeaker`). By
 `RSA.Scenario.pool_L0` the weights agree, so the models differ *only* in the
 position of the latent parameter (p. e86); `ss_m_parse_pref` against
-`perParse_ss_o_beats_m` below turns that difference into diverging
+`perParse_ss_prefers_o` below turns that difference into diverging
 predictions. Rationality is a parameter of the derived kernels, and findings
 quantify over it wherever the paper's argument does. -/
 
@@ -528,9 +528,9 @@ register — the domination certificate provably fails here (wNSA's SS-fiber is
 not stochastically dominated), and the preference degenerates as α → 0. -/
 theorem ss_inner_exh :
     (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} :=
-  gi.listener_real_lt_of_divPowSum (k := 5) (D := 12) (by decide) (by decide)
+  gi.listener_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel) (by decide +kernel)
     (prior_singleton_eq wNSA wNS) (prior_singleton_ne_zero wNS)
-    (by decide) (by decide) (by decide)
+    (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
@@ -538,7 +538,7 @@ the listener prefers wNS to wS. Certificate register. -/
 theorem ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wS} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
-    (prior_singleton_ne_zero wNS) (by decide)
+    (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- AA identifies the unique world where all aliens drank all, for every
@@ -548,7 +548,7 @@ certificate register. -/
 theorem aa_identifies {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .aa).real {wSA} < (gi.listener α prior .aa).real {wA} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wSA wA)
-    (prior_singleton_ne_zero wA) (by decide)
+    (prior_singleton_ne_zero wA) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- AS exhaustifies the inner quantifier for every rationality: hearing AS,
@@ -556,11 +556,11 @@ the listener prefers wS to wA. Certificate register. -/
 theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .as).real {wA} < (gi.listener α prior .as).real {wS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
-    (prior_singleton_ne_zero wS) (by decide)
+    (prior_singleton_ne_zero wS) (by decide +kernel)
 
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
 uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
-Pair choice drives this — see `perParse_ss_o_beats_m` for the contrast.
+Pair choice drives this — see `perParse_ss_prefers_o` for the contrast.
 Evaluation register: as α → 0 the singleton reading's informativity advantage
 vanishes, so no α-free certificate exists. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
@@ -574,9 +574,9 @@ theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
         < ∑ t : World, if t ∈ gi.sem (.ss, ({.matrix} : Parse)) then
           (12 / (gi.sem (.ss, ({.matrix} : Parse))).card) ^ 5
             * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
-        else 0 := by decide
+        else 0 := by decide +kernel
   exact fun p hp =>
-    gi.choicePosterior_real_lt_of_divPowSum (by decide) (by decide) (by decide)
+    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel) (by decide +kernel) (by decide +kernel)
       prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
 
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — for
@@ -586,7 +586,7 @@ cost). Certificate register: {6}·{3,4} = {18,24} strictly dominates
 theorem vanilla_ss_prefers_wNA {α : ℝ} (hα : 0 < α) :
     (vanilla.listener α prior .ss).real {wNS} < (vanilla.listener α prior .ss).real {wNA} :=
   vanilla.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNS wNA)
-    (prior_singleton_ne_zero wNA) (by decide)
+    (prior_singleton_ne_zero wNA) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- GI corrects vanilla's error for every rationality: hearing SS, the
@@ -596,7 +596,7 @@ extension is the spare element. -/
 theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wNA} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
-    (prior_singleton_ne_zero wNS) (by decide)
+    (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- LI derives outer exhaustification for SS at every rationality: wNS over
@@ -604,7 +604,7 @@ wS via the OI parse. Certificate register. -/
 theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wS} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
-    (prior_singleton_ne_zero wNS) (by decide)
+    (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses, at every
@@ -612,7 +612,7 @@ rationality. Certificate register. -/
 theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wNA} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
-    (prior_singleton_ne_zero wNS) (by decide)
+    (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 /-- LU keeps wNS above wNA for every rationality. At wNA only the literal
 lexicon can produce SS, and its share is capped below a third: SS's extension
@@ -625,24 +625,24 @@ theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (luListener α .ss).fst.real {wNA} < (luListener α .ss).fst.real {wNS} := by
   rw [luListener, RSA.Scenario.familyListener_fst_real_lt_iff luFam hα.le
       luPrior_singleton_eq luPrior_singleton_ne_zero
-      (by decide : wNS ∈ (luFam .lit).sem .ss) wNA wNS,
-    show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide,
-    Finset.sum_insert (by decide : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
-    Finset.sum_insert (by decide : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
-    (luFam .oi).speaker_real_singleton_eq_zero hα (by decide : wNA ∉ (luFam .oi).sem .ss),
+      (by decide +kernel : wNS ∈ (luFam .lit).sem .ss) wNA wNS,
+    show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide +kernel,
+    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
+    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
+    (luFam .oi).speaker_real_singleton_eq_zero hα (by decide +kernel : wNA ∉ (luFam .oi).sem .ss),
     (luFam .oi).speaker_real_singleton_of_profile_replicate hα
-      (by decide : (luFam .oi).profile wNS = Multiset.replicate 3 3)
-      (by decide : wNS ∈ (luFam .oi).sem .ss)]
+      (by decide +kernel : (luFam .oi).profile wNS = Multiset.replicate 3 3)
+      (by decide +kernel : wNS ∈ (luFam .oi).sem .ss)]
   have hsum := (luFam .lit).sum_speaker_real_singleton_le_one α wNA {.ss, .sn, .sa}
-  rw [Finset.sum_insert (by decide : Utterance.ss ∉ ({.sn, .sa} : Finset Utterance)),
-    Finset.sum_insert (by decide : Utterance.sn ∉ ({.sa} : Finset Utterance)),
+  rw [Finset.sum_insert (by decide +kernel : Utterance.ss ∉ ({.sn, .sa} : Finset Utterance)),
+    Finset.sum_insert (by decide +kernel : Utterance.sn ∉ ({.sa} : Finset Utterance)),
     Finset.sum_singleton] at hsum
   have hsn := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide : wNA ∈ (luFam .lit).sem .ss) (by decide : wNA ∈ (luFam .lit).sem .sn)
-    (by decide)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss) (by decide +kernel : wNA ∈ (luFam .lit).sem .sn)
+    (by decide +kernel)
   have hsa := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide : wNA ∈ (luFam .lit).sem .ss) (by decide : wNA ∈ (luFam .lit).sem .sa)
-    (by decide)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss) (by decide +kernel : wNA ∈ (luFam .lit).sem .sa)
+    (by decide +kernel)
   have hpos : (0 : ℝ) ≤ ((luFam .lit).speaker α wNS).real {Utterance.ss} :=
     measureReal_nonneg
   linarith
@@ -658,17 +658,17 @@ within the parse erases exactly the informativity advantage of the singleton
 reading ⟦SS⟧^M that the pooled speaker exploits in `ss_m_parse_pref`; with
 `RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win purely
 in the position of the latent parameter (pp. e85–e86). -/
-theorem perParse_ss_o_beats_m {α : ℝ} (hα : 0 < α) :
+theorem perParse_ss_prefers_o {α : ℝ} (hα : 0 < α) :
     (perParseListener α .ss).snd.real {({.matrix} : Parse)}
       < (perParseListener α .ss).snd.real {({.outer} : Parse)} := by
-  have hM0 : ∀ w : World, w ≠ wNS → w ∉ (readings {ExhPosition.matrix}).sem .ss := by decide
+  have hM0 : ∀ w : World, w ≠ wNS → w ∉ (readings {ExhPosition.matrix}).sem .ss := by decide +kernel
   have hOprof : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
-      (readings {ExhPosition.outer}).profile w = Multiset.replicate 3 3 := by decide
+      (readings {ExhPosition.outer}).profile w = Multiset.replicate 3 3 := by decide +kernel
   have hOmem : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
-      w ∈ (readings {ExhPosition.outer}).sem .ss := by decide
+      w ∈ (readings {ExhPosition.outer}).sem .ss := by decide +kernel
   rw [perParseListener, RSA.Scenario.familyListener_snd_real_lt_iff readings hα.le
       perParsePrior_singleton_eq perParsePrior_singleton_ne_zero
-      (by decide : wNS ∈ (readings {ExhPosition.matrix}).sem .ss)
+      (by decide +kernel : wNS ∈ (readings {ExhPosition.matrix}).sem .ss)
       ({.matrix} : Parse) ({.outer} : Parse)]
   calc (∑ w : World, ((readings {ExhPosition.matrix}).speaker α w).real {Utterance.ss})
       = ((readings {ExhPosition.matrix}).speaker α wNS).real {Utterance.ss} :=
@@ -676,11 +676,11 @@ theorem perParse_ss_o_beats_m {α : ℝ} (hα : 0 < α) :
           (readings {ExhPosition.matrix}).speaker_real_singleton_eq_zero hα (hM0 w hw)
     _ < 1 :=
         (readings {ExhPosition.matrix}).speaker_real_singleton_lt_one hα.le Utterance.ss
-          (by decide : Utterance.sn ≠ Utterance.ss)
-          (by decide : wNS ∈ (readings {ExhPosition.matrix}).sem .sn)
+          (by decide +kernel : Utterance.sn ≠ Utterance.ss)
+          (by decide +kernel : wNS ∈ (readings {ExhPosition.matrix}).sem .sn)
     _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World), (3⁻¹ : ℝ) := by
         rw [Finset.sum_const,
-          show ({wNS, wNA, wNSA} : Finset World).card = 3 from by decide]
+          show ({wNS, wNA, wNSA} : Finset World).card = 3 from by decide +kernel]
         norm_num
     _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World),
           ((readings {ExhPosition.outer}).speaker α w).real {Utterance.ss} :=

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -403,9 +403,17 @@ def sem (p : Parse) (u : Utterance) : Set World := {w | exhMeaning p u w}
 instance (p : Parse) (u : Utterance) (w : World) : Decidable (w ∈ sem p u) :=
   inferInstanceAs (Decidable (exhMeaning p u w))
 
-/-- Set form of Table 1's AA row: ⟦AA⟧ = {wA} under every parse. -/
-theorem sem_aa (p : Parse) : sem p .aa = {wA} :=
-  Set.ext fun w => table1_aa p w
+/-- The extension of an utterance under a parse, as a `Finset` — the
+`RSA.Scenario` semantic field. -/
+def ext (p : Parse) (u : Utterance) : Finset World :=
+  Finset.univ.filter (exhMeaning p u)
+
+@[simp] theorem mem_ext {p : Parse} {u : Utterance} {w : World} :
+    w ∈ ext p u ↔ exhMeaning p u w := by
+  simp [ext]
+
+/-- Extension form of Table 1's AA row: ⟦AA⟧ = {wA} under every parse. -/
+theorem ext_aa : ∀ p : Parse, ext p .aa = {wA} := by decide
 
 noncomputable def prior : Measure World := uniformOn Set.univ
 
@@ -463,37 +471,74 @@ normalizes per lexicon rather than against the pooled extension — the
 type-level content of the paper's LU-vs-intentions contrast. -/
 
 /-- The vanilla model: utterances read literally. -/
-@[simps] noncomputable def vanilla : RSA.Speaker World Utterance where
+@[simps] noncomputable def vanillaM : RSA.Speaker World Utterance where
   α := 2
   α_pos := two_pos
   prior := prior
   sem := sem ∅
 
 /-- The GI model: pair choice with all parses available. -/
-@[simps] noncomputable def gi : RSA.Speaker World (Utterance × Parse) where
+@[simps] noncomputable def giM : RSA.Speaker World (Utterance × Parse) where
   α := 2
   α_pos := two_pos
   prior := prior
   sem x := sem x.2 x.1
 
 /-- The LI model: pair choice over matrix-free parses. -/
-@[simps] noncomputable def li : RSA.Speaker World (Utterance × LIParse) where
+@[simps] noncomputable def liM : RSA.Speaker World (Utterance × LIParse) where
   α := 2
   α_pos := two_pos
   prior := prior
   sem x := sem x.2.toParse x.1
 
-instance : IsProbabilityMeasure vanilla.prior := inferInstanceAs (IsProbabilityMeasure prior)
-instance : IsProbabilityMeasure gi.prior := inferInstanceAs (IsProbabilityMeasure prior)
-instance : IsProbabilityMeasure li.prior := inferInstanceAs (IsProbabilityMeasure prior)
+instance : IsProbabilityMeasure vanillaM.prior := inferInstanceAs (IsProbabilityMeasure prior)
+instance : IsProbabilityMeasure giM.prior := inferInstanceAs (IsProbabilityMeasure prior)
+instance : IsProbabilityMeasure liM.prior := inferInstanceAs (IsProbabilityMeasure prior)
 
-instance : vanilla.Positive := ⟨prior_singleton_ne_zero⟩
-instance : gi.Positive := ⟨prior_singleton_ne_zero⟩
-instance : li.Positive := ⟨prior_singleton_ne_zero⟩
+instance : vanillaM.Positive := ⟨prior_singleton_ne_zero⟩
+instance : giM.Positive := ⟨prior_singleton_ne_zero⟩
+instance : liM.Positive := ⟨prior_singleton_ne_zero⟩
 
-instance : vanilla.Viable := ⟨fun w => exists_true w ∅⟩
-instance : gi.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), h⟩⟩
-instance : li.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), h⟩⟩
+instance : vanillaM.Viable := ⟨fun w => exists_true w ∅⟩
+instance : giM.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), h⟩⟩
+instance : liM.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), h⟩⟩
+
+/-! ### The models as choice scenarios
+
+Each model is an `RSA.Scenario`: an extension and an observable form per
+choice, with rationality a parameter of the derived kernels — findings
+quantify over `α` where the paper's argument does. Vanilla chooses bare
+utterances read literally (obs = id); GI chooses over all 72 (utterance,
+parse) pairs (eq. 21a), LI over the 36 matrix-free pairs (eq. 18a), both
+heard through `Prod.fst`. LU's per-lexicon speakers form the `luFam` family
+(eq. 11) — the lexicon sits in the state, not the choice, so LU is *not* one
+`Scenario`: the type-level content of the paper's LU-vs-intentions contrast. -/
+
+/-- The vanilla scenario (§3.1): utterances read literally. -/
+@[simps] def vanilla : RSA.Scenario World Utterance Utterance where
+  sem := ext ∅
+  obs := id
+
+/-- The GI scenario (eq. 21): pair choice with all parses available. -/
+@[simps] def gi : RSA.Scenario World (Utterance × Parse) Utterance where
+  sem x := ext x.2 x.1
+  obs := Prod.fst
+
+/-- The LI scenario (eq. 18): pair choice over matrix-free parses. -/
+@[simps] def li : RSA.Scenario World (Utterance × LIParse) Utterance where
+  sem x := ext x.2.toParse x.1
+  obs := Prod.fst
+
+/-- The LU speaker family (eq. 11): one scenario per lexicon. -/
+@[simps] def luFam (l : LULex) : RSA.Scenario World Utterance Utterance where
+  sem := ext l.toParse
+  obs := id
+
+instance : vanilla.Expressible := ⟨fun w => (exists_true w ∅).imp fun _ h => mem_ext.mpr h⟩
+instance : gi.Expressible :=
+  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), mem_ext.mpr h⟩⟩
+instance : li.Expressible :=
+  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), mem_ext.mpr h⟩⟩
 
 /-- LU's joint prior: the lexicon is drawn with the world. -/
 noncomputable def luPrior : Measure (World × LULex) := uniformOn Set.univ
@@ -509,13 +554,13 @@ noncomputable def luSpeaker : Kernel (World × LULex) Utterance :=
 /-! ### Markov structure -/
 
 theorem giL0_toReal (x : Utterance × Parse) (w : World) :
-    (gi.L0 x {w}).toReal
+    (giM.L0 x {w}).toReal
       = if exhMeaning x.2 x.1 w then ((Finset.univ.filter (exhMeaning x.2 x.1)).card : ℝ)⁻¹
         else 0 :=
   L0_toReal x.2 x.1 w
 
 theorem liL0_toReal (x : Utterance × LIParse) (w : World) :
-    (li.L0 x {w}).toReal
+    (liM.L0 x {w}).toReal
       = if exhMeaning x.2.toParse x.1 w
           then ((Finset.univ.filter (exhMeaning x.2.toParse x.1)).card : ℝ)⁻¹
         else 0 :=
@@ -532,8 +577,8 @@ instance : IsMarkovKernel luSpeaker := by
 
 /-! ### Listeners
 
-Vanilla's pragmatic listener is `vanilla.listener` (eq. 9); the intention
-models' are `gi.jointListener` (eq. 21b) and `li.jointListener` (eq. 18b).
+Vanilla's pragmatic listener is `vanillaM.listener` (eq. 9); the intention
+models' are `giM.jointListener` (eq. 21b) and `liM.jointListener` (eq. 18b).
 LU keeps a bespoke inverse over the joint state (eqs. 12–13). -/
 
 /-- LU listener: Bayesian inverse over the joint (world, lexicon) state. -/
@@ -555,25 +600,25 @@ private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
 
 /-! ### Marginal-positivity witnesses -/
 
-theorem vanilla_marg_ss : (vanilla.toKernel ∘ₘ prior) {Utterance.ss} ≠ 0 :=
+theorem vanilla_marg_ss : (vanillaM.toKernel ∘ₘ prior) {Utterance.ss} ≠ 0 :=
   comp_apply_singleton_ne_zero _ _ (prior_singleton_ne_zero wNS)
-    (vanilla.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
+    (vanillaM.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
-    ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
+    ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := (∅ : Parse))
-    (prior_singleton_ne_zero w) (gi.toKernel_apply_singleton_ne_zero h)
+    (prior_singleton_ne_zero w) (giM.toKernel_apply_singleton_ne_zero h)
 
-theorem gi_marg_ss : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
+theorem gi_marg_ss : ((giM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   gi_marg .ss (w := wNS) (by decide)
 
-theorem gi_marg_as : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.as} ≠ 0 :=
+theorem gi_marg_as : ((giM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.as} ≠ 0 :=
   gi_marg .as (w := wS) (by decide)
 
-theorem li_marg_ss : ((li.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
+theorem li_marg_ss : ((liM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := LIParse.lit)
     (prior_singleton_ne_zero wNS)
-    (li.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
+    (liM.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
@@ -590,21 +635,21 @@ private theorem rpow_two (r : ℝ) : r ^ (2 : ℝ) = r ^ 2 := by
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
 
 private theorem vanillaS_real (w : World) (u : Utterance) :
-    (vanilla.toKernel w).real {u}
+    (vanillaM.toKernel w).real {u}
       = (L0 ∅ u {w}).toReal ^ (2 : ℝ) / ∑ u', (L0 ∅ u' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton vanilla.α_pos.le (L0 ∅)
+  RSA.speaker_utility_zero_real_singleton vanillaM.α_pos.le (L0 ∅)
     (fun u' => RSA.literalListener_apply_ne_top prior _ u' {w}) u
 
 private theorem giS_real (w : World) (x : Utterance × Parse) :
-    (gi.toKernel w).real {x}
-      = (gi.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (gi.L0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton gi.α_pos.le gi.L0
+    (giM.toKernel w).real {x}
+      = (giM.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (giM.L0 x' {w}).toReal ^ (2 : ℝ) :=
+  RSA.speaker_utility_zero_real_singleton giM.α_pos.le giM.L0
     (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem liS_real (w : World) (x : Utterance × LIParse) :
-    (li.toKernel w).real {x}
-      = (li.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (li.L0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton li.α_pos.le li.L0
+    (liM.toKernel w).real {x}
+      = (liM.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (liM.L0 x' {w}).toReal ^ (2 : ℝ) :=
+  RSA.speaker_utility_zero_real_singleton liM.α_pos.le liM.L0
     (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem luS_real (s : World × LULex) (u : Utterance) :
@@ -644,49 +689,49 @@ private theorem zGI (w : World) (z : ℝ)
     (h : (∑ u : Utterance, ∑ p : Parse,
         (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
          else 0) ^ 2) = z) :
-    (∑ x : Utterance × Parse, (gi.L0 x {w}).toReal ^ 2) = z := by
+    (∑ x : Utterance × Parse, (giM.L0 x {w}).toReal ^ 2) = z := by
   rw [Fintype.sum_prod_type]
   simp_rw [giL0_toReal]
   exact h
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wN : (∑ x : Utterance × Parse, (gi.L0 x {wN}).toReal ^ 2) = 307 / 24 :=
+private theorem zGI_wN : (∑ x : Utterance × Parse, (giM.L0 x {wN}).toReal ^ 2) = 307 / 24 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNS : (∑ x : Utterance × Parse, (gi.L0 x {wNS}).toReal ^ 2) = 23 / 6 :=
+private theorem zGI_wNS : (∑ x : Utterance × Parse, (giM.L0 x {wNS}).toReal ^ 2) = 23 / 6 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNA : (∑ x : Utterance × Parse, (gi.L0 x {wNA}).toReal ^ 2) = 23 / 9 :=
+private theorem zGI_wNA : (∑ x : Utterance × Parse, (giM.L0 x {wNA}).toReal ^ 2) = 23 / 9 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNSA : (∑ x : Utterance × Parse, (gi.L0 x {wNSA}).toReal ^ 2) = 157 / 72 :=
+private theorem zGI_wNSA : (∑ x : Utterance × Parse, (giM.L0 x {wNSA}).toReal ^ 2) = 157 / 72 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wS : (∑ x : Utterance × Parse, (gi.L0 x {wS}).toReal ^ 2) = 559 / 72 :=
+private theorem zGI_wS : (∑ x : Utterance × Parse, (giM.L0 x {wS}).toReal ^ 2) = 559 / 72 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wSA : (∑ x : Utterance × Parse, (gi.L0 x {wSA}).toReal ^ 2) = 10 / 3 :=
+private theorem zGI_wSA : (∑ x : Utterance × Parse, (giM.L0 x {wSA}).toReal ^ 2) = 10 / 3 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wA : (∑ x : Utterance × Parse, (gi.L0 x {wA}).toReal ^ 2) = 229 / 24 :=
+private theorem zGI_wA : (∑ x : Utterance × Parse, (giM.L0 x {wA}).toReal ^ 2) = 229 / 24 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
@@ -732,25 +777,25 @@ private theorem zLI (w : World) (z : ℝ)
         (if exhMeaning l.toParse u w
           then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
          else 0) ^ 2) = z) :
-    (∑ x : Utterance × LIParse, (li.L0 x {w}).toReal ^ 2) = z := by
+    (∑ x : Utterance × LIParse, (liM.L0 x {w}).toReal ^ 2) = z := by
   rw [Fintype.sum_prod_type]
   simp_rw [liL0_toReal]
   exact h
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wNS : (∑ x : Utterance × LIParse, (li.L0 x {wNS}).toReal ^ 2) = 53 / 48 :=
+private theorem zLI_wNS : (∑ x : Utterance × LIParse, (liM.L0 x {wNS}).toReal ^ 2) = 53 / 48 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wNA : (∑ x : Utterance × LIParse, (li.L0 x {wNA}).toReal ^ 2) = 19 / 18 :=
+private theorem zLI_wNA : (∑ x : Utterance × LIParse, (liM.L0 x {wNA}).toReal ^ 2) = 19 / 18 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wS : (∑ x : Utterance × LIParse, (li.L0 x {wS}).toReal ^ 2) = 461 / 144 :=
+private theorem zLI_wS : (∑ x : Utterance × LIParse, (liM.L0 x {wS}).toReal ^ 2) = 461 / 144 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
@@ -758,25 +803,25 @@ private theorem zLI_wS : (∑ x : Utterance × LIParse, (li.L0 x {wS}).toReal ^ 
 /-! ### Listener-preference reductions -/
 
 private theorem gi_fst_lt {u : Utterance}
-    (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ p : Parse, prior.real {w₁} * (gi.toKernel w₁).real {(u, p)})
-        < ∑ p : Parse, prior.real {w₂} * (gi.toKernel w₂).real {(u, p)}) :
-    (gi.jointListener u).fst.real {w₁} < (gi.jointListener u).fst.real {w₂} :=
-  (gi.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
+    (hx : ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
+    (h : (∑ p : Parse, prior.real {w₁} * (giM.toKernel w₁).real {(u, p)})
+        < ∑ p : Parse, prior.real {w₂} * (giM.toKernel w₂).real {(u, p)}) :
+    (giM.jointListener u).fst.real {w₁} < (giM.jointListener u).fst.real {w₂} :=
+  (giM.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
 
 private theorem gi_snd_lt {u : Utterance}
-    (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
-    (h : (∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₁)})
-        < ∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₂)}) :
-    (gi.jointListener u).snd.real {p₁} < (gi.jointListener u).snd.real {p₂} :=
-  (gi.jointListener_snd_real_lt_iff hx p₁ p₂).mpr h
+    (hx : ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
+    (h : (∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₁)})
+        < ∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₂)}) :
+    (giM.jointListener u).snd.real {p₁} < (giM.jointListener u).snd.real {p₂} :=
+  (giM.jointListener_snd_real_lt_iff hx p₁ p₂).mpr h
 
 private theorem li_fst_lt {u : Utterance}
-    (hx : ((li.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ l : LIParse, prior.real {w₁} * (li.toKernel w₁).real {(u, l)})
-        < ∑ l : LIParse, prior.real {w₂} * (li.toKernel w₂).real {(u, l)}) :
-    (li.jointListener u).fst.real {w₁} < (li.jointListener u).fst.real {w₂} :=
-  (li.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
+    (hx : ((liM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
+    (h : (∑ l : LIParse, prior.real {w₁} * (liM.toKernel w₁).real {(u, l)})
+        < ∑ l : LIParse, prior.real {w₂} * (liM.toKernel w₂).real {(u, l)}) :
+    (liM.jointListener u).fst.real {w₁} < (liM.jointListener u).fst.real {w₂} :=
+  (liM.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
 
 private theorem lu_fst_lt {u : Utterance}
     (hx : (luSpeaker ∘ₘ luPrior) {u} ≠ 0) {w₁ w₂ : World}
@@ -786,12 +831,12 @@ private theorem lu_fst_lt {u : Utterance}
   rw [luListener, posterior_fst_real_lt_iff luSpeaker luPrior hx]
   exact h
 
-private theorem vanilla_lt {u : Utterance} (hx : (vanilla.toKernel ∘ₘ prior) {u} ≠ 0)
+private theorem vanilla_lt {u : Utterance} (hx : (vanillaM.toKernel ∘ₘ prior) {u} ≠ 0)
     {w₁ w₂ : World}
-    (h : prior.real {w₁} * (vanilla.toKernel w₁).real {u}
-        < prior.real {w₂} * (vanilla.toKernel w₂).real {u}) :
-    (vanilla.listener u).real {w₁} < (vanilla.listener u).real {w₂} :=
-  (vanilla.listener_real_singleton_lt_iff hx w₁ w₂).mpr h
+    (h : prior.real {w₁} * (vanillaM.toKernel w₁).real {u}
+        < prior.real {w₂} * (vanillaM.toKernel w₂).real {u}) :
+    (vanillaM.listener u).real {w₁} < (vanillaM.listener u).real {w₂} :=
+  (vanillaM.listener_real_singleton_lt_iff hx w₁ w₂).mpr h
 
 private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
   rw [luPrior, uniformOn_univ_real_singleton,
@@ -804,77 +849,77 @@ Each finding compares two pooled speaker masses; naming their values keeps
 the findings two-line. -/
 
 private theorem giPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × Parse, (gi.L0 x {w}).toReal ^ 2) = z)
+    (hz : (∑ x : Utterance × Parse, (giM.L0 x {w}).toReal ^ 2) = z)
     (h : (∑ p : Parse,
         (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
          else 0) ^ 2 / z) = v) :
-    (∑ p : Parse, (gi.toKernel w).real {(u, p)}) = v := by
+    (∑ p : Parse, (giM.toKernel w).real {(u, p)}) = v := by
   simp_rw [giS_real, rpow_two, hz, giL0_toReal]
   exact h
 
-private theorem giPool_ss_wNS : (∑ p : Parse, (gi.toKernel wNS).real {(.ss, p)}) = 5 / 12 :=
+private theorem giPool_ss_wNS : (∑ p : Parse, (giM.toKernel wNS).real {(.ss, p)}) = 5 / 12 :=
   giPool _ _ _ _ zGI_wNS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_ss_wNA : (∑ p : Parse, (gi.toKernel wNA).real {(.ss, p)}) = 9 / 92 :=
+private theorem giPool_ss_wNA : (∑ p : Parse, (giM.toKernel wNA).real {(.ss, p)}) = 9 / 92 :=
   giPool _ _ _ _ zGI_wNA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem giPool_ss_wNSA :
-    (∑ p : Parse, (gi.toKernel wNSA).real {(.ss, p)}) = 43 / 157 :=
+    (∑ p : Parse, (giM.toKernel wNSA).real {(.ss, p)}) = 43 / 157 :=
   giPool _ _ _ _ zGI_wNSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_ss_wS : (∑ p : Parse, (gi.toKernel wS).real {(.ss, p)}) = 11 / 559 :=
+private theorem giPool_ss_wS : (∑ p : Parse, (giM.toKernel wS).real {(.ss, p)}) = 11 / 559 :=
   giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_as_wS : (∑ p : Parse, (gi.toKernel wS).real {(.as, p)}) = 340 / 559 :=
+private theorem giPool_as_wS : (∑ p : Parse, (giM.toKernel wS).real {(.as, p)}) = 340 / 559 :=
   giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_as_wA : (∑ p : Parse, (gi.toKernel wA).real {(.as, p)}) = 16 / 687 :=
+private theorem giPool_as_wA : (∑ p : Parse, (giM.toKernel wA).real {(.as, p)}) = 16 / 687 :=
   giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem liPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × LIParse, (li.L0 x {w}).toReal ^ 2) = z)
+    (hz : (∑ x : Utterance × LIParse, (liM.L0 x {w}).toReal ^ 2) = z)
     (h : (∑ l : LIParse,
         (if exhMeaning l.toParse u w
           then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
          else 0) ^ 2 / z) = v) :
-    (∑ l : LIParse, (li.toKernel w).real {(u, l)}) = v := by
+    (∑ l : LIParse, (liM.toKernel w).real {(u, l)}) = v := by
   simp_rw [liS_real, rpow_two, hz, liL0_toReal]
   exact h
 
-private theorem liPool_ss_wNS : (∑ l : LIParse, (li.toKernel wNS).real {(.ss, l)}) = 15 / 53 :=
+private theorem liPool_ss_wNS : (∑ l : LIParse, (liM.toKernel wNS).real {(.ss, l)}) = 15 / 53 :=
   liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem liPool_ss_wNA : (∑ l : LIParse, (li.toKernel wNA).real {(.ss, l)}) = 5 / 38 :=
+private theorem liPool_ss_wNA : (∑ l : LIParse, (liM.toKernel wNA).real {(.ss, l)}) = 5 / 38 :=
   liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem liPool_ss_wS : (∑ l : LIParse, (li.toKernel wS).real {(.ss, l)}) = 13 / 461 :=
+private theorem liPool_ss_wS : (∑ l : LIParse, (liM.toKernel wS).real {(.ss, l)}) = 13 / 461 :=
   liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem vanS_ss_wNS : (vanilla.toKernel wNS).real {Utterance.ss} = 4 / 29 := by
+private theorem vanS_ss_wNS : (vanillaM.toKernel wNS).real {Utterance.ss} = 4 / 29 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
   norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton]
 
-private theorem vanS_ss_wNA : (vanilla.toKernel wNA).real {Utterance.ss} = 2 / 11 := by
+private theorem vanS_ss_wNA : (vanillaM.toKernel wNA).real {Utterance.ss} = 2 / 11 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNA, L0_toReal]
   norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
@@ -902,29 +947,34 @@ private theorem luPool_ss_wNA :
 
 /-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
 theorem ss_inner_exh :
-    (gi.jointListener .ss).fst.real {wNSA} < (gi.jointListener .ss).fst.real {wNS} :=
+    (giM.jointListener .ss).fst.real {wNSA} < (giM.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
     norm_num)
 
 /-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
 theorem ss_outer_exh :
-    (gi.jointListener .ss).fst.real {wS} < (gi.jointListener .ss).fst.real {wNS} :=
+    (giM.jointListener .ss).fst.real {wS} < (giM.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
     norm_num)
 
-/-- AA identifies the unique world where all aliens drank all: AA is false at
-wSA under every parse (Table 1's AA row) and true at wA under the bare parse.
-Purely structural — no masses computed. -/
-theorem aa_identifies :
-    (gi.jointListener .aa).fst.real {wSA} < (gi.jointListener .aa).fst.real {wA} :=
-  gi.jointListener_fst_real_lt_of_support
-    (by simp only [gi_sem, sem_aa]; decide) ⟨∅, by simp only [gi_sem, sem_aa]; decide⟩
+/-- AA identifies the unique world where all aliens drank all, for every
+rationality: AA is false at wSA under every parse (`sem_aa`, Table 1's AA row)
+and true at wA under the bare parse. Purely structural — no masses computed. -/
+theorem aa_identifies {α : ℝ} (hα : 0 < α) :
+    (gi.listener α prior .aa).real {wSA} < (gi.listener α prior .aa).real {wA} :=
+  gi.listener_real_lt_of_support hα (prior_singleton_ne_zero wA)
+    (fun c hc => by
+      obtain ⟨u, p⟩ := c
+      obtain rfl : u = .aa := hc
+      simp only [gi_sem, ext_aa]
+      decide)
+    ⟨(.aa, ∅), rfl, by simp only [gi_sem, ext_aa]; decide⟩
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :
-    (gi.jointListener .as).fst.real {wA} < (gi.jointListener .as).fst.real {wS} :=
+    (giM.jointListener .as).fst.real {wA} < (giM.jointListener .as).fst.real {wS} :=
   gi_fst_lt gi_marg_as (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_as_wA, giPool_as_wS]
     norm_num)
@@ -934,7 +984,7 @@ set_option maxRecDepth 8192 in
 uniquely identifies wNS (eq. 22). Pair choice drives this: under per-parse
 normalization M would not dominate. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
-    (gi.jointListener .ss).snd.real {p} < (gi.jointListener .ss).snd.real {{.matrix}} := by
+    (giM.jointListener .ss).snd.real {p} < (giM.jointListener .ss).snd.real {{.matrix}} := by
   intro p hp
   have hmem : p ∈ ({∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
       {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse) :=
@@ -954,14 +1004,14 @@ theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction (the
 cost-free illustration of eq. 10; the direction reverses at the fitted cost). -/
 theorem vanilla_ss_prefers_wNA :
-    (vanilla.listener .ss).real {wNS} < (vanilla.listener .ss).real {wNA} :=
+    (vanillaM.listener .ss).real {wNS} < (vanillaM.listener .ss).real {wNA} :=
   vanilla_lt vanilla_marg_ss (by
     simp_rw [prior_real_singleton, vanS_ss_wNS, vanS_ss_wNA]
     norm_num)
 
 /-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
-    (gi.jointListener .ss).fst.real {wNA} < (gi.jointListener .ss).fst.real {wNS} :=
+    (giM.jointListener .ss).fst.real {wNA} < (giM.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNA, giPool_ss_wNS]
     norm_num)
@@ -976,14 +1026,14 @@ theorem lu_ss_prefers_wNS :
 
 /-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
-    (li.jointListener .ss).fst.real {wS} < (li.jointListener .ss).fst.real {wNS} :=
+    (liM.jointListener .ss).fst.real {wS} < (liM.jointListener .ss).fst.real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wS, liPool_ss_wNS]
     norm_num)
 
-/-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
+/-- LI also gets the wNS-over-wNA ordering that vanillaM misses. -/
 theorem li_ss_prefers_wNS :
-    (li.jointListener .ss).fst.real {wNA} < (li.jointListener .ss).fst.real {wNS} :=
+    (liM.jointListener .ss).fst.real {wNA} < (liM.jointListener .ss).fst.real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wNA, liPool_ss_wNS]
     norm_num)

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -476,54 +476,41 @@ noncomputable def luPrior : Measure (World × LULex) := uniformOn Set.univ
 instance : IsProbabilityMeasure luPrior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
 
-/-- The LU speaker (eq. 11): the lexicon is an argument, not a choice. -/
-noncomputable def luSpeaker (α : ℝ) : Kernel (World × LULex) Utterance :=
-  RSA.Scenario.familySpeaker luFam α
-
-instance (α : ℝ) : IsFiniteKernel (luSpeaker α) :=
-  inferInstanceAs (IsFiniteKernel (RSA.Scenario.familySpeaker luFam α))
-
 /-- LU listener (eqs. 12–13): Bayesian inverse over the joint state. -/
 noncomputable def luListener (α : ℝ) : Kernel Utterance (World × LULex) :=
-  (luSpeaker α)†luPrior
+  RSA.Scenario.familyListener luFam α luPrior
+
+theorem luPrior_singleton_eq (p q : World × LULex) : luPrior {p} = luPrior {q} := by
+  simp [luPrior, uniformOn_univ]
 
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
-
-private theorem univLU : (Finset.univ : Finset LULex) = {.lit, .oi} := by decide
-
-private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
-  rw [luPrior, uniformOn_univ_real_singleton,
-    show Fintype.card (World × LULex) = 14 from by decide]
-  norm_num
 
 /-! ### The rejected architecture: per-parse normalization -/
 
 /-- The architecture the paper rejects as "conceptually highly implausible"
 (p. e85): the full parse family with the parse as a speaker *argument* —
 eq. 11 with an enlarged latent set, rather than eq. 21a's pooled choice. -/
-noncomputable def perParseSpeaker (α : ℝ) : Kernel (World × Parse) Utterance :=
-  RSA.Scenario.familySpeaker readings α
-
 noncomputable def perParsePrior : Measure (World × Parse) := uniformOn Set.univ
 
 instance : IsProbabilityMeasure perParsePrior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
 
-instance (α : ℝ) : IsFiniteKernel (perParseSpeaker α) :=
-  inferInstanceAs (IsFiniteKernel (RSA.Scenario.familySpeaker readings α))
+private theorem perParsePrior_singleton_eq (p q : World × Parse) :
+    perParsePrior {p} = perParsePrior {q} := by
+  simp [perParsePrior, uniformOn_univ]
 
 private theorem perParsePrior_singleton_ne_zero (s : World × Parse) :
     perParsePrior {s} ≠ 0 := by
   rw [perParsePrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
 
-private theorem perParsePrior_real_singleton (s : World × Parse) :
-    perParsePrior.real {s} = 56⁻¹ := by
-  rw [perParsePrior, uniformOn_univ_real_singleton,
-    show Fintype.card (World × Parse) = 56 from by decide]
-  norm_num
+/-- Listener of the rejected architecture: the Bayesian inverse of the
+per-parse speaker over the joint (world, parse) state. -/
+noncomputable def perParseListener (α : ℝ) : Kernel Utterance (World × Parse) :=
+  RSA.Scenario.familyListener readings α perParsePrior
+
 
 /-! ### The ten findings
 
@@ -534,9 +521,6 @@ odds comparison uniformly. Evaluation findings are genuinely α-dependent
 (their direction degenerates as α → 0) and are pinned at the paper's
 illustrative α = 5, where the comparison clears to a ℕ inequality via
 `Multiset.divPowSum`. -/
-
-private theorem univW : (Finset.univ : Finset World)
-    = {wN, wNS, wNA, wNSA, wS, wSA, wA} := by decide
 
 /-- SS exhaustifies the inner quantifier at the paper's illustrative α = 5:
 hearing SS, the listener prefers wNS to wNSA (eq. 22's regime). Evaluation
@@ -630,90 +614,82 @@ theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) (by decide)
 
-/-- LU keeps wNS above wNA for every rationality: the OI lexicon's ⟦SS⟧
-excludes wNA outright, contributing a constant third of the posterior odds at
-wNS, while wNA's literal-lexicon share stays below a third (the paper's full
-LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
+/-- LU keeps wNS above wNA for every rationality. At wNA only the literal
+lexicon can produce SS, and its share is capped below a third: SS's extension
+strictly exceeds SN's and SA's, so by informativity monotonicity it carries
+the smallest of the three shares. At wNS the OI lexicon alone contributes
+exactly a third — its true choices all have three-world extensions, so its
+speaker is uniform on them. (The paper's full LU-L2 nonetheless concentrates
+on wNSA, eq. 15.) -/
 theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (luListener α .ss).fst.real {wNA} < (luListener α .ss).fst.real {wNS} := by
-  have hκ : luSpeaker α (wNS, LULex.lit) {Utterance.ss} ≠ 0 := by
-    rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
-    exact (luFam .lit).speaker_apply_singleton_ne_zero hα.le (by decide)
-  rw [luListener, posterior_fst_real_lt_iff (luSpeaker α) luPrior
-      (comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit)) hκ)]
-  simp_rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
-  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, luPrior_real_singleton]
-  rw [(luFam .lit).speaker_real_singleton hα, (luFam .oi).speaker_real_singleton hα,
-    (luFam .lit).speaker_real_singleton hα, (luFam .oi).speaker_real_singleton hα,
-    show (luFam .lit).profile wNS = {3, 4, 6} from by decide,
-    show (luFam .lit).profile wNA = {4, 4, 6} from by decide,
-    show (luFam .oi).profile wNS = {3, 3, 3} from by decide,
-    show (luFam .oi).profile wNA = {3, 3, 3} from by decide,
-    Multiset.invPowSum_toReal hα.le (by decide),
-    Multiset.invPowSum_toReal hα.le (by decide),
-    Multiset.invPowSum_toReal hα.le (by decide),
-    show ((luFam LULex.lit).sem Utterance.ss).card = 6 from by decide,
-    show ((luFam LULex.oi).sem Utterance.ss).card = 3 from by decide]
-  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
-    Multiset.sum_cons, Multiset.sum_singleton]
-  norm_num +decide
-  have p6 : (0 : ℝ) < (1 / 6 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
-  have h46 : (1 / 6 : ℝ) ^ α < (1 / 4 : ℝ) ^ α :=
-    Real.rpow_lt_rpow (by norm_num) (by norm_num) hα
-  have keyA : (1 / 6 : ℝ) ^ α / ((1 / 4 : ℝ) ^ α + ((1 / 4 : ℝ) ^ α + (1 / 6 : ℝ) ^ α))
-      < 1 / 3 := by
-    rw [div_lt_iff₀ (by positivity)]
-    linarith
-  have keyB : (1 / 3 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 3 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))
-      = 1 / 3 := by
-    rw [div_eq_iff (by positivity)]
-    ring
-  have keyC : (0 : ℝ) < (1 / 6 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 4 : ℝ) ^ α + (1 / 6 : ℝ) ^ α)) :=
-    div_pos p6 (by positivity)
+  rw [luListener, RSA.Scenario.familyListener_fst_real_lt_iff luFam hα.le
+      luPrior_singleton_eq luPrior_singleton_ne_zero
+      (by decide : wNS ∈ (luFam .lit).sem .ss) wNA wNS,
+    show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide,
+    Finset.sum_insert (by decide : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
+    Finset.sum_insert (by decide : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
+    (luFam .oi).speaker_real_singleton_eq_zero hα (by decide : wNA ∉ (luFam .oi).sem .ss),
+    (luFam .oi).speaker_real_singleton_of_profile_replicate hα
+      (by decide : (luFam .oi).profile wNS = Multiset.replicate 3 3)
+      (by decide : wNS ∈ (luFam .oi).sem .ss)]
+  have hsum := (luFam .lit).sum_speaker_real_singleton_le_one α wNA {.ss, .sn, .sa}
+  rw [Finset.sum_insert (by decide : Utterance.ss ∉ ({.sn, .sa} : Finset Utterance)),
+    Finset.sum_insert (by decide : Utterance.sn ∉ ({.sa} : Finset Utterance)),
+    Finset.sum_singleton] at hsum
+  have hsn := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
+    (by decide : wNA ∈ (luFam .lit).sem .ss) (by decide : wNA ∈ (luFam .lit).sem .sn)
+    (by decide)
+  have hsa := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
+    (by decide : wNA ∈ (luFam .lit).sem .ss) (by decide : wNA ∈ (luFam .lit).sem .sa)
+    (by decide)
+  have hpos : (0 : ℝ) ≤ ((luFam .lit).speaker α wNS).real {Utterance.ss} :=
+    measureReal_nonneg
   linarith
 
-set_option maxRecDepth 1024 in
 /-- The headline divergence, for every rationality: hearing SS, the
 *per-parse-normalized* listener's parse posterior puts more mass on O than on
-M. Renormalizing within each parse erases exactly the informativity advantage
-of the singleton reading ⟦SS⟧^M that the pooled speaker exploits in
-`ss_m_parse_pref`; with `RSA.Scenario.pool_L0` (identical weights), the pair
-locates GI's win purely in the position of the latent parameter
-(pp. e85–e86). -/
+M. The M-share is a single world's, capped below one by competition
+(`RSA.Scenario.speaker_real_singleton_lt_one`), while O's three worlds each
+contribute exactly a third — their true choices all have three-world
+extensions, so each per-parse speaker is uniform on them
+(`RSA.Scenario.speaker_real_singleton_of_profile_replicate`). Renormalizing
+within the parse erases exactly the informativity advantage of the singleton
+reading ⟦SS⟧^M that the pooled speaker exploits in `ss_m_parse_pref`; with
+`RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win purely
+in the position of the latent parameter (pp. e85–e86). -/
 theorem perParse_ss_o_beats_m {α : ℝ} (hα : 0 < α) :
-    (((perParseSpeaker α)†perParsePrior) .ss).snd.real {({.matrix} : Parse)}
-      < (((perParseSpeaker α)†perParsePrior) .ss).snd.real {({.outer} : Parse)} := by
-  have hκ : perParseSpeaker α (wNS, ({.matrix} : Parse)) {Utterance.ss} ≠ 0 := by
-    rw [perParseSpeaker, RSA.Scenario.familySpeaker_apply]
-    exact (readings _).speaker_apply_singleton_ne_zero hα.le (by decide)
-  rw [posterior_snd_real_lt_iff _ _
-      (comp_apply_singleton_ne_zero _ _
-        (perParsePrior_singleton_ne_zero (wNS, {.matrix})) hκ)]
-  simp_rw [perParseSpeaker, RSA.Scenario.familySpeaker_apply]
-  norm_num +decide [univW, Finset.sum_insert, Finset.sum_singleton, perParsePrior_real_singleton]
-  simp only [(readings ({ExhPosition.matrix} : Parse)).speaker_real_singleton hα,
-    (readings ({ExhPosition.outer} : Parse)).speaker_real_singleton hα]
-  norm_num +decide
-  rw [show (readings ({ExhPosition.matrix} : Parse)).profile wNS = {1, 2, 3} from by decide,
-    show (readings ({ExhPosition.outer} : Parse)).profile wNS = {3, 3, 3} from by decide,
-    show (readings ({ExhPosition.outer} : Parse)).profile wNA = {3, 3, 3} from by decide,
-    show (readings ({ExhPosition.outer} : Parse)).profile wNSA = {3, 3, 3} from by decide,
-    show (ext ({ExhPosition.matrix} : Parse) Utterance.ss).card = 1 from by decide,
-    show (ext ({ExhPosition.outer} : Parse) Utterance.ss).card = 3 from by decide,
-    Multiset.invPowSum_toReal hα.le (by decide),
-    Multiset.invPowSum_toReal hα.le (by decide)]
-  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
-    Multiset.sum_cons, Multiset.sum_singleton]
-  norm_num
-  have p2 : (0 : ℝ) < (1 / 2 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
-  have p3 : (0 : ℝ) < (1 / 3 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
-  have keyM : (1 + ((1 / 2 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))⁻¹ < 1 := by
-    rw [inv_lt_one₀ (by positivity)]
-    linarith
-  have keyO : (1 / 3 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 3 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))
-      = 1 / 3 := by
-    rw [div_eq_iff (by positivity)]
-    ring
-  linarith
+    (perParseListener α .ss).snd.real {({.matrix} : Parse)}
+      < (perParseListener α .ss).snd.real {({.outer} : Parse)} := by
+  have hM0 : ∀ w : World, w ≠ wNS → w ∉ (readings {ExhPosition.matrix}).sem .ss := by decide
+  have hOprof : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
+      (readings {ExhPosition.outer}).profile w = Multiset.replicate 3 3 := by decide
+  have hOmem : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
+      w ∈ (readings {ExhPosition.outer}).sem .ss := by decide
+  rw [perParseListener, RSA.Scenario.familyListener_snd_real_lt_iff readings hα.le
+      perParsePrior_singleton_eq perParsePrior_singleton_ne_zero
+      (by decide : wNS ∈ (readings {ExhPosition.matrix}).sem .ss)
+      ({.matrix} : Parse) ({.outer} : Parse)]
+  calc (∑ w : World, ((readings {ExhPosition.matrix}).speaker α w).real {Utterance.ss})
+      = ((readings {ExhPosition.matrix}).speaker α wNS).real {Utterance.ss} :=
+        Finset.sum_eq_single_of_mem wNS (Finset.mem_univ _) fun w _ hw =>
+          (readings {ExhPosition.matrix}).speaker_real_singleton_eq_zero hα (hM0 w hw)
+    _ < 1 :=
+        (readings {ExhPosition.matrix}).speaker_real_singleton_lt_one hα.le Utterance.ss
+          (by decide : Utterance.sn ≠ Utterance.ss)
+          (by decide : wNS ∈ (readings {ExhPosition.matrix}).sem .sn)
+    _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World), (3⁻¹ : ℝ) := by
+        rw [Finset.sum_const,
+          show ({wNS, wNA, wNSA} : Finset World).card = 3 from by decide]
+        norm_num
+    _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World),
+          ((readings {ExhPosition.outer}).speaker α w).real {Utterance.ss} :=
+        Finset.sum_congr rfl fun w hw =>
+          ((readings {ExhPosition.outer}).speaker_real_singleton_of_profile_replicate hα
+            (hOprof w hw) (hOmem w hw)).symm
+    _ ≤ ∑ w : World, ((readings {ExhPosition.outer}).speaker α w).real {Utterance.ss} :=
+        Finset.sum_le_sum_of_subset_of_nonneg (Finset.subset_univ _)
+          fun w _ _ => measureReal_nonneg
+
 
 end FrankeBergen2020

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -517,22 +517,14 @@ per-parse speaker over the joint (world, parse) state. -/
 noncomputable def perParseListener (α : ℝ) : Kernel Utterance (World × Parse) :=
   RSA.Scenario.familyListener readings α perParsePrior
 
-/-! ### The ten findings
-
-Two registers, both closed by `decide`. Certificate findings hold for every
-rationality `α > 0`: a decided `Multiset.StrictDominates` fact — strict
-stochastic dominance of informativity profiles — settles the fiber-by-rest
-odds comparison uniformly. Evaluation findings are genuinely α-dependent
-(their direction degenerates as α → 0) and are pinned at the paper's
-illustrative α = 5, where the comparison clears to a ℕ inequality via
-`Multiset.divPowSum`. -/
+/-! ### The ten findings -/
 
 /-- Hearing "some of the aliens drank some of their water", the pooled
 listener favors the world where no alien drank all of its water over the one
 where some did (inner exhaustification). -/
 theorem ss_inner_exh :
     (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} :=
-  gi.listener_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel) (by decide +kernel)
+  gi.listener_real_lt_of_divPowSum (k := 5) (D := 12)
     (prior_singleton_eq wNSA wNS) (prior_singleton_ne_zero wNS)
     (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
@@ -565,18 +557,12 @@ sentence. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
     (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
       < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := by
-  have hnat : ∀ p : Parse, p ≠ pM →
-      (∑ t : World, if t ∈ gi.sem (.ss, p) then
-          (12 / (gi.sem (.ss, p)).card) ^ 5
-            * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
-        else 0)
-        < ∑ t : World, if t ∈ gi.sem (.ss, pM) then
-          (12 / (gi.sem (.ss, pM)).card) ^ 5
-            * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
-        else 0 := by decide +kernel
+  have hcol : ∀ p : Parse, p ≠ pM →
+      gi.divPowSumColumn 12 5 (.ss, p) < gi.divPowSumColumn 12 5 (.ss, pM) := by
+    decide +kernel
   exact fun p hp =>
-    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel) (by decide +kernel)
-      (by decide +kernel) prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
+    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel)
+      prior_singleton_eq prior_singleton_ne_zero rfl rfl (hcol p hp)
 
 /-- Hearing "some of the aliens drank some of their water", the
 literal-semantics listener favors all-drinkers over some-but-not-all

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -426,6 +426,9 @@ theorem prior_real_singleton (w : World) : prior.real {w} = 7⁻¹ := by
   rw [prior, uniformOn_univ_real_singleton, card_world]
   norm_num
 
+theorem prior_singleton_eq (w w' : World) : prior {w} = prior {w'} := by
+  simp [prior, uniformOn_univ]
+
 theorem prior_singleton_ne_zero (w : World) : prior {w} ≠ 0 := by
   rw [prior, uniformOn_univ, Measure.count_singleton]
   simp
@@ -559,13 +562,6 @@ theorem giL0_toReal (x : Utterance × Parse) (w : World) :
         else 0 :=
   L0_toReal x.2 x.1 w
 
-theorem liL0_toReal (x : Utterance × LIParse) (w : World) :
-    (liM.L0 x {w}).toReal
-      = if exhMeaning x.2.toParse x.1 w
-          then ((Finset.univ.filter (exhMeaning x.2.toParse x.1)).card : ℝ)⁻¹
-        else 0 :=
-  L0_toReal x.2.toParse x.1 w
-
 instance : IsMarkovKernel luSpeaker := by
   refine RSA.isMarkovKernel_speaker (fun s u => ?_) fun s => ?_
   · rw [RSA.utility, EReal.coe_zero, sub_zero]
@@ -612,14 +608,6 @@ theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
 theorem gi_marg_ss : ((giM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   gi_marg .ss (w := wNS) (by decide)
 
-theorem gi_marg_as : ((giM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.as} ≠ 0 :=
-  gi_marg .as (w := wS) (by decide)
-
-theorem li_marg_ss : ((liM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
-  map_fst_comp_apply_singleton_ne_zero _ _ (θ := LIParse.lit)
-    (prior_singleton_ne_zero wNS)
-    (liM.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
-
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
@@ -644,12 +632,6 @@ private theorem giS_real (w : World) (x : Utterance × Parse) :
     (giM.toKernel w).real {x}
       = (giM.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (giM.L0 x' {w}).toReal ^ (2 : ℝ) :=
   RSA.speaker_utility_zero_real_singleton giM.α_pos.le giM.L0
-    (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
-
-private theorem liS_real (w : World) (x : Utterance × LIParse) :
-    (liM.toKernel w).real {x}
-      = (liM.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (liM.L0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton liM.α_pos.le liM.L0
     (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem luS_real (s : World × LULex) (u : Utterance) :
@@ -772,34 +754,6 @@ private theorem zOI_wNA :
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem zLI (w : World) (z : ℝ)
-    (h : (∑ u : Utterance, ∑ l : LIParse,
-        (if exhMeaning l.toParse u w
-          then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
-         else 0) ^ 2) = z) :
-    (∑ x : Utterance × LIParse, (liM.L0 x {w}).toReal ^ 2) = z := by
-  rw [Fintype.sum_prod_type]
-  simp_rw [liL0_toReal]
-  exact h
-
-set_option maxRecDepth 8192 in
-private theorem zLI_wNS : (∑ x : Utterance × LIParse, (liM.L0 x {wNS}).toReal ^ 2) = 53 / 48 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zLI_wNA : (∑ x : Utterance × LIParse, (liM.L0 x {wNA}).toReal ^ 2) = 19 / 18 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zLI_wS : (∑ x : Utterance × LIParse, (liM.L0 x {wS}).toReal ^ 2) = 461 / 144 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
-
 /-! ### Listener-preference reductions -/
 
 private theorem gi_fst_lt {u : Utterance}
@@ -815,13 +769,6 @@ private theorem gi_snd_lt {u : Utterance}
         < ∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₂)}) :
     (giM.jointListener u).snd.real {p₁} < (giM.jointListener u).snd.real {p₂} :=
   (giM.jointListener_snd_real_lt_iff hx p₁ p₂).mpr h
-
-private theorem li_fst_lt {u : Utterance}
-    (hx : ((liM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ l : LIParse, prior.real {w₁} * (liM.toKernel w₁).real {(u, l)})
-        < ∑ l : LIParse, prior.real {w₂} * (liM.toKernel w₂).real {(u, l)}) :
-    (liM.jointListener u).fst.real {w₁} < (liM.jointListener u).fst.real {w₂} :=
-  (liM.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
 
 private theorem lu_fst_lt {u : Utterance}
     (hx : (luSpeaker ∘ₘ luPrior) {u} ≠ 0) {w₁ w₂ : World}
@@ -862,56 +809,11 @@ private theorem giPool_ss_wNS : (∑ p : Parse, (giM.toKernel wNS).real {(.ss, p
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_ss_wNA : (∑ p : Parse, (giM.toKernel wNA).real {(.ss, p)}) = 9 / 92 :=
-  giPool _ _ _ _ zGI_wNA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
 private theorem giPool_ss_wNSA :
     (∑ p : Parse, (giM.toKernel wNSA).real {(.ss, p)}) = 43 / 157 :=
   giPool _ _ _ _ zGI_wNSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem giPool_ss_wS : (∑ p : Parse, (giM.toKernel wS).real {(.ss, p)}) = 11 / 559 :=
-  giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem giPool_as_wS : (∑ p : Parse, (giM.toKernel wS).real {(.as, p)}) = 340 / 559 :=
-  giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem giPool_as_wA : (∑ p : Parse, (giM.toKernel wA).real {(.as, p)}) = 16 / 687 :=
-  giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem liPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × LIParse, (liM.L0 x {w}).toReal ^ 2) = z)
-    (h : (∑ l : LIParse,
-        (if exhMeaning l.toParse u w
-          then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
-         else 0) ^ 2 / z) = v) :
-    (∑ l : LIParse, (liM.toKernel w).real {(u, l)}) = v := by
-  simp_rw [liS_real, rpow_two, hz, liL0_toReal]
-  exact h
-
-private theorem liPool_ss_wNS : (∑ l : LIParse, (liM.toKernel wNS).real {(.ss, l)}) = 15 / 53 :=
-  liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem liPool_ss_wNA : (∑ l : LIParse, (liM.toKernel wNA).real {(.ss, l)}) = 5 / 38 :=
-  liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem liPool_ss_wS : (∑ l : LIParse, (liM.toKernel wS).real {(.ss, l)}) = 13 / 461 :=
-  liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
-    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
-    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem vanS_ss_wNS : (vanillaM.toKernel wNS).real {Utterance.ss} = 4 / 29 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
@@ -952,12 +854,14 @@ theorem ss_inner_exh :
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
     norm_num)
 
-/-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
-theorem ss_outer_exh :
-    (giM.jointListener .ss).fst.real {wS} < (giM.jointListener .ss).fst.real {wNS} :=
-  gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
-    norm_num)
+set_option maxRecDepth 8192 in
+/-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
+the listener prefers wNS to wS. Certificate register: the fiber-by-rest
+cross-product domination closes by `decide`. -/
+theorem ss_outer_exh {α : ℝ} (hα : 0 < α) :
+    (gi.listener α prior .ss).real {wS} < (gi.listener α prior .ss).real {wNS} :=
+  gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
+    (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
 
 /-- AA identifies the unique world where all aliens drank all, for every
 rationality: AA is false at wSA under every parse (`sem_aa`, Table 1's AA row)
@@ -972,12 +876,13 @@ theorem aa_identifies {α : ℝ} (hα : 0 < α) :
       decide)
     ⟨(.aa, ∅), rfl, by simp only [gi_sem, ext_aa]; decide⟩
 
-/-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
-theorem as_inner_exh :
-    (giM.jointListener .as).fst.real {wA} < (giM.jointListener .as).fst.real {wS} :=
-  gi_fst_lt gi_marg_as (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_as_wA, giPool_as_wS]
-    norm_num)
+set_option maxRecDepth 8192 in
+/-- AS exhaustifies the inner quantifier for every rationality: hearing AS,
+the listener prefers wS to wA. Certificate register. -/
+theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
+    (gi.listener α prior .as).real {wA} < (gi.listener α prior .as).real {wS} :=
+  gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
+    (prior_singleton_ne_zero wS) ⟨(.as, ∅), rfl, by decide⟩ (by decide)
 
 set_option maxRecDepth 8192 in
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
@@ -1009,12 +914,16 @@ theorem vanilla_ss_prefers_wNA :
     simp_rw [prior_real_singleton, vanS_ss_wNS, vanS_ss_wNA]
     norm_num)
 
-/-- GI corrects vanilla's error: SS → wNS, not wNA. -/
-theorem gi_ss_prefers_wNS :
-    (giM.jointListener .ss).fst.real {wNA} < (giM.jointListener .ss).fst.real {wNS} :=
-  gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNA, giPool_ss_wNS]
-    norm_num)
+set_option maxRecDepth 8192 in
+/-- GI corrects vanilla's error for every rationality: hearing SS, the
+listener prefers wNS to wNA. Certificate register: wNS's SS-fiber
+{1,3,3,3,3,4,4,6} strictly dominates wNA's {3,3,6} — the M-pair's singleton
+extension is the spare element — and the cross-product certificate closes the
+partition side by `decide`. -/
+theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
+    (gi.listener α prior .ss).real {wNA} < (gi.listener α prior .ss).real {wNS} :=
+  gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
+    (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
 
 /-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA (the
 paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
@@ -1024,18 +933,20 @@ theorem lu_ss_prefers_wNS :
     simp_rw [luPrior_real_singleton, ← Finset.mul_sum, luPool_ss_wNA, luPool_ss_wNS]
     norm_num)
 
-/-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
-theorem li_ss_outer_exh :
-    (liM.jointListener .ss).fst.real {wS} < (liM.jointListener .ss).fst.real {wNS} :=
-  li_fst_lt li_marg_ss (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wS, liPool_ss_wNS]
-    norm_num)
+set_option maxRecDepth 8192 in
+/-- LI derives outer exhaustification for SS at every rationality: wNS over
+wS via the OI parse. Certificate register. -/
+theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
+    (li.listener α prior .ss).real {wS} < (li.listener α prior .ss).real {wNS} :=
+  li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
+    (prior_singleton_ne_zero wNS) ⟨(.ss, .lit), rfl, by decide⟩ (by decide)
 
-/-- LI also gets the wNS-over-wNA ordering that vanillaM misses. -/
-theorem li_ss_prefers_wNS :
-    (liM.jointListener .ss).fst.real {wNA} < (liM.jointListener .ss).fst.real {wNS} :=
-  li_fst_lt li_marg_ss (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wNA, liPool_ss_wNS]
-    norm_num)
+set_option maxRecDepth 8192 in
+/-- LI also gets the wNS-over-wNA ordering that vanilla misses, at every
+rationality. Certificate register. -/
+theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
+    (li.listener α prior .ss).real {wNA} < (li.listener α prior .ss).real {wNS} :=
+  li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
+    (prior_singleton_ne_zero wNS) ⟨(.ss, .lit), rfl, by decide⟩ (by decide)
 
 end FrankeBergen2020

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -624,10 +624,9 @@ theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
       (by decide +kernel : wNS ∈ (luFam .lit).sem .ss)]
   calc (∑ l : LULex, ((luFam l).speaker α wNA).real {.ss})
       = ((luFam .lit).speaker α wNA).real {.ss} :=
-        Finset.sum_eq_single_of_mem LULex.lit (Finset.mem_univ _) fun l _ hl => by
-          cases l
-          · exact absurd rfl hl
-          · exact (luFam .oi).speaker_real_singleton_eq_zero hα
+        Fintype.sum_eq_single LULex.lit fun
+          | .lit, hl => absurd rfl hl
+          | .oi, _ => (luFam .oi).speaker_real_singleton_eq_zero hα
               (by decide +kernel : wNA ∉ (luFam .oi).sem .ss)
     _ < ((luFam .oi).speaker α wNS).real {.ss} := by
         rw [(luFam .oi).speaker_real_singleton_of_profile_replicate hα
@@ -661,7 +660,7 @@ theorem perParse_ss_prefers_o {α : ℝ} (hα : 0 < α) :
       (mem_ext.mpr ((m_ss_singleton wNS).mpr rfl))]
   calc (∑ w : World, ((readings pM).speaker α w).real {.ss})
       = ((readings pM).speaker α wNS).real {.ss} :=
-        Finset.sum_eq_single_of_mem wNS (Finset.mem_univ _) fun w _ hw =>
+        Fintype.sum_eq_single wNS fun w hw =>
           (readings pM).speaker_real_singleton_eq_zero hα fun hmem =>
             hw ((m_ss_singleton w).mp (mem_ext.mp hmem))
     _ < 1 :=

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -536,7 +536,6 @@ theorem ss_inner_exh :
     (prior_singleton_eq wNSA wNS) (prior_singleton_ne_zero wNS)
     (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "some of the aliens drank some of their water", the pooled
 listener favors a world where some alien drank nothing (outer
 exhaustification). -/
@@ -545,7 +544,6 @@ theorem ss_outer_exh {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "all of the aliens drank all of their water", the pooled
 listener favors the unique world where every alien did just that. -/
 theorem aa_identifies {α : ℝ} (hα : 0 < α) :
@@ -553,7 +551,6 @@ theorem aa_identifies {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wSA wA)
     (prior_singleton_ne_zero wA) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "all of the aliens drank some of their water", the pooled
 listener favors the world where every alien drank some but not all (inner
 exhaustification). -/
@@ -589,7 +586,6 @@ theorem vanilla_ss_prefers_wNA {α : ℝ} (hα : 0 < α) :
   vanilla.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNS wNA)
     (prior_singleton_ne_zero wNA) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "some of the aliens drank some of their water", the pooled
 listener favors some-but-not-all drinkers over all-drinkers, as attested. -/
 theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
@@ -597,7 +593,6 @@ theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "some of the aliens drank some of their water", the matrix-free
 pooled listener still favors a world where some alien drank nothing (outer
 exhaustification). -/
@@ -606,7 +601,6 @@ theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
-set_option maxRecDepth 1024 in
 /-- Hearing "some of the aliens drank some of their water", the matrix-free
 pooled listener favors some-but-not-all drinkers over all-drinkers. -/
 theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -596,10 +596,6 @@ private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
 
 /-! ### Marginal-positivity witnesses -/
 
-theorem vanilla_marg_ss : (vanillaM.toKernel ∘ₘ prior) {Utterance.ss} ≠ 0 :=
-  comp_apply_singleton_ne_zero _ _ (prior_singleton_ne_zero wNS)
-    (vanillaM.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
-
 theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
     ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := (∅ : Parse))
@@ -622,11 +618,8 @@ theorem lu_marg_ss : (luSpeaker ∘ₘ luPrior) {Utterance.ss} ≠ 0 :=
 private theorem rpow_two (r : ℝ) : r ^ (2 : ℝ) = r ^ 2 := by
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
 
-private theorem vanillaS_real (w : World) (u : Utterance) :
-    (vanillaM.toKernel w).real {u}
-      = (L0 ∅ u {w}).toReal ^ (2 : ℝ) / ∑ u', (L0 ∅ u' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton vanillaM.α_pos.le (L0 ∅)
-    (fun u' => RSA.literalListener_apply_ne_top prior _ u' {w}) u
+private theorem rpow_five (r : ℝ) : r ^ (5 : ℝ) = r ^ 5 := by
+  rw [show (5 : ℝ) = ((5 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
 
 private theorem giS_real (w : World) (x : Utterance × Parse) :
     (giM.toKernel w).real {x}
@@ -756,13 +749,6 @@ private theorem zOI_wNA :
 
 /-! ### Listener-preference reductions -/
 
-private theorem gi_fst_lt {u : Utterance}
-    (hx : ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ p : Parse, prior.real {w₁} * (giM.toKernel w₁).real {(u, p)})
-        < ∑ p : Parse, prior.real {w₂} * (giM.toKernel w₂).real {(u, p)}) :
-    (giM.jointListener u).fst.real {w₁} < (giM.jointListener u).fst.real {w₂} :=
-  (giM.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
-
 private theorem gi_snd_lt {u : Utterance}
     (hx : ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
     (h : (∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₁)})
@@ -778,13 +764,6 @@ private theorem lu_fst_lt {u : Utterance}
   rw [luListener, posterior_fst_real_lt_iff luSpeaker luPrior hx]
   exact h
 
-private theorem vanilla_lt {u : Utterance} (hx : (vanillaM.toKernel ∘ₘ prior) {u} ≠ 0)
-    {w₁ w₂ : World}
-    (h : prior.real {w₁} * (vanillaM.toKernel w₁).real {u}
-        < prior.real {w₂} * (vanillaM.toKernel w₂).real {u}) :
-    (vanillaM.listener u).real {w₁} < (vanillaM.listener u).real {w₂} :=
-  (vanillaM.listener_real_singleton_lt_iff hx w₁ w₂).mpr h
-
 private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
   rw [luPrior, uniformOn_univ_real_singleton,
     show Fintype.card (World × LULex) = 14 from by decide]
@@ -794,38 +773,6 @@ private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} =
 
 Each finding compares two pooled speaker masses; naming their values keeps
 the findings two-line. -/
-
-private theorem giPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × Parse, (giM.L0 x {w}).toReal ^ 2) = z)
-    (h : (∑ p : Parse,
-        (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
-         else 0) ^ 2 / z) = v) :
-    (∑ p : Parse, (giM.toKernel w).real {(u, p)}) = v := by
-  simp_rw [giS_real, rpow_two, hz, giL0_toReal]
-  exact h
-
-private theorem giPool_ss_wNS : (∑ p : Parse, (giM.toKernel wNS).real {(.ss, p)}) = 5 / 12 :=
-  giPool _ _ _ _ zGI_wNS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem giPool_ss_wNSA :
-    (∑ p : Parse, (giM.toKernel wNSA).real {(.ss, p)}) = 43 / 157 :=
-  giPool _ _ _ _ zGI_wNSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem vanS_ss_wNS : (vanillaM.toKernel wNS).real {Utterance.ss} = 4 / 29 := by
-  simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
-  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton]
-
-private theorem vanS_ss_wNA : (vanillaM.toKernel wNA).real {Utterance.ss} = 2 / 11 := by
-  simp_rw [vanillaS_real, rpow_two, zVan_wNA, L0_toReal]
-  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton]
 
 private theorem luPool_ss_wNS :
     (∑ l : LULex, (luSpeaker (wNS, l)).real {Utterance.ss}) = 41 / 87 := by
@@ -847,12 +794,30 @@ private theorem luPool_ss_wNA :
 
 /-! ### The ten qualitative findings -/
 
-/-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
+set_option maxRecDepth 8192 in
+/-- SS exhaustifies the inner quantifier at the paper's illustrative α = 5:
+hearing SS, the listener prefers wNS to wNSA (eq. 22's regime). Evaluation
+register — the domination certificate provably fails here (wNSA's SS-fiber is
+not termwise matched by wNS's), so profile literals by `decide` plus
+fifth-power arithmetic by `norm_num` decide it. -/
 theorem ss_inner_exh :
-    (giM.jointListener .ss).fst.real {wNSA} < (giM.jointListener .ss).fst.real {wNS} :=
-  gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
-    norm_num)
+    (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} := by
+  rw [gi.listener_real_lt_iff_invPowSum (o := .ss) (by norm_num) (prior_singleton_eq wNSA wNS)
+      (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩,
+    show gi.fiberProfile .ss wNSA = {3, 3, 3, 3, 4, 4, 6} from by decide,
+    show gi.profile wNS
+      = {1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} from by
+      decide,
+    show gi.fiberProfile .ss wNS = {1, 3, 3, 3, 3, 4, 4, 6} from by decide,
+    show gi.profile wNSA
+      = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 6} from by decide,
+    Multiset.invPowSum_toReal (by norm_num) (by decide),
+    Multiset.invPowSum_toReal (by norm_num) (by decide),
+    Multiset.invPowSum_toReal (by norm_num) (by decide),
+    Multiset.invPowSum_toReal (by norm_num) (by decide)]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  norm_num [rpow_five]
 
 set_option maxRecDepth 8192 in
 /-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
@@ -906,13 +871,23 @@ theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction (the
-cost-free illustration of eq. 10; the direction reverses at the fitted cost). -/
+/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — at the
+paper's illustrative α = 5 (eq. 10, cost-free; the direction reverses at the
+fitted cost). Evaluation register. -/
 theorem vanilla_ss_prefers_wNA :
-    (vanillaM.listener .ss).real {wNS} < (vanillaM.listener .ss).real {wNA} :=
-  vanilla_lt vanilla_marg_ss (by
-    simp_rw [prior_real_singleton, vanS_ss_wNS, vanS_ss_wNA]
-    norm_num)
+    (vanilla.listener 5 prior .ss).real {wNS} < (vanilla.listener 5 prior .ss).real {wNA} := by
+  rw [vanilla.listener_real_lt_iff_invPowSum (o := .ss) (by norm_num) (prior_singleton_eq wNS wNA)
+      (prior_singleton_ne_zero wNA) ⟨.ss, rfl, by decide⟩,
+    show vanilla.fiberProfile .ss wNS = {6} from by decide,
+    show vanilla.profile wNA = {4, 4, 6} from by decide,
+    show vanilla.fiberProfile .ss wNA = {6} from by decide,
+    show vanilla.profile wNS = {3, 4, 6} from by decide,
+    Multiset.invPowSum_toReal (by norm_num) (by decide),
+    Multiset.invPowSum_toReal (by norm_num) (by decide),
+    Multiset.invPowSum_toReal (by norm_num) (by decide)]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  norm_num [rpow_five]
 
 set_option maxRecDepth 8192 in
 /-- GI corrects vanilla's error for every rationality: hearing SS, the

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -513,7 +513,6 @@ private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} =
 
 /-! ### The ten qualitative findings -/
 
-set_option maxRecDepth 8192 in
 /-- SS exhaustifies the inner quantifier at the paper's illustrative α = 5:
 hearing SS, the listener prefers wNS to wNSA (eq. 22's regime). Evaluation
 register — the domination certificate provably fails here (wNSA's SS-fiber is
@@ -538,7 +537,7 @@ theorem ss_inner_exh :
     Multiset.sum_cons, Multiset.sum_singleton]
   norm_num [rpow_five]
 
-set_option maxRecDepth 8192 in
+set_option maxRecDepth 1024 in
 /-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
 the listener prefers wNS to wS. Certificate register: the fiber-by-rest
 cross-product domination closes by `decide`. -/
@@ -560,7 +559,7 @@ theorem aa_identifies {α : ℝ} (hα : 0 < α) :
       decide)
     ⟨(.aa, ∅), rfl, by simp only [gi_sem, ext_aa]; decide⟩
 
-set_option maxRecDepth 8192 in
+set_option maxRecDepth 1024 in
 /-- AS exhaustifies the inner quantifier for every rationality: hearing AS,
 the listener prefers wS to wA. Certificate register. -/
 theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
@@ -568,37 +567,28 @@ theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
     (prior_singleton_ne_zero wS) ⟨(.as, ∅), rfl, by decide⟩ (by decide)
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wN : gi.profile wN
     = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 4, 4} := by decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wNS : gi.profile wNS
     = {1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wNA : gi.profile wNA
     = {2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wNSA : gi.profile wNSA
     = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 6} := by decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wS : gi.profile wS
     = {1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by
   decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wSA : gi.profile wSA
     = {2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
 
-set_option maxRecDepth 8192 in
 private theorem giProfile_wA : gi.profile wA
     = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by decide
 
-set_option maxRecDepth 8192 in
-set_option maxHeartbeats 1600000 in
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
 uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
 Pair choice drives this: under per-parse normalization M would not dominate.
@@ -647,7 +637,7 @@ theorem vanilla_ss_prefers_wNA :
     Multiset.sum_cons, Multiset.sum_singleton]
   norm_num [rpow_five]
 
-set_option maxRecDepth 8192 in
+set_option maxRecDepth 1024 in
 /-- GI corrects vanilla's error for every rationality: hearing SS, the
 listener prefers wNS to wNA. Certificate register: wNS's SS-fiber
 {1,3,3,3,3,4,4,6} strictly dominates wNA's {3,3,6} — the M-pair's singleton
@@ -658,7 +648,6 @@ theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
 
-set_option maxRecDepth 8192 in
 /-- LU keeps wNS above wNA at the paper's illustrative α = 5: the OI
 lexicon's ⟦SS⟧ excludes wNA outright, while at wNS both lexica contribute
 (the paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15).
@@ -685,7 +674,6 @@ theorem lu_ss_prefers_wNS :
     LULex.toParse, univW, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton]
 
-set_option maxRecDepth 8192 in
 /-- LI derives outer exhaustification for SS at every rationality: wNS over
 wS via the OI parse. Certificate register. -/
 theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
@@ -693,7 +681,6 @@ theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
     (prior_singleton_ne_zero wNS) ⟨(.ss, .lit), rfl, by decide⟩ (by decide)
 
-set_option maxRecDepth 8192 in
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses, at every
 rationality. Certificate register. -/
 theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -556,12 +556,6 @@ noncomputable def luSpeaker : Kernel (World × LULex) Utterance :=
 
 /-! ### Markov structure -/
 
-theorem giL0_toReal (x : Utterance × Parse) (w : World) :
-    (giM.L0 x {w}).toReal
-      = if exhMeaning x.2 x.1 w then ((Finset.univ.filter (exhMeaning x.2 x.1)).card : ℝ)⁻¹
-        else 0 :=
-  L0_toReal x.2 x.1 w
-
 instance : IsMarkovKernel luSpeaker := by
   refine RSA.isMarkovKernel_speaker (fun s u => ?_) fun s => ?_
   · rw [RSA.utility, EReal.coe_zero, sub_zero]
@@ -596,14 +590,6 @@ private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
 
 /-! ### Marginal-positivity witnesses -/
 
-theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
-    ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
-  map_fst_comp_apply_singleton_ne_zero _ _ (θ := (∅ : Parse))
-    (prior_singleton_ne_zero w) (giM.toKernel_apply_singleton_ne_zero h)
-
-theorem gi_marg_ss : ((giM.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
-  gi_marg .ss (w := wNS) (by decide)
-
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
@@ -620,12 +606,6 @@ private theorem rpow_two (r : ℝ) : r ^ (2 : ℝ) = r ^ 2 := by
 
 private theorem rpow_five (r : ℝ) : r ^ (5 : ℝ) = r ^ 5 := by
   rw [show (5 : ℝ) = ((5 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
-
-private theorem giS_real (w : World) (x : Utterance × Parse) :
-    (giM.toKernel w).real {x}
-      = (giM.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (giM.L0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton giM.α_pos.le giM.L0
-    (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem luS_real (s : World × LULex) (u : Utterance) :
     (luSpeaker s).real {u}
@@ -659,57 +639,6 @@ private theorem univLI : (Finset.univ : Finset LIParse) = {.lit, .i, .o, .oi} :=
 
 The per-world softmax partitions, as real rationals: `Z(w) = Σ |ext|⁻²` over
 the model's choice space. -/
-
-private theorem zGI (w : World) (z : ℝ)
-    (h : (∑ u : Utterance, ∑ p : Parse,
-        (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
-         else 0) ^ 2) = z) :
-    (∑ x : Utterance × Parse, (giM.L0 x {w}).toReal ^ 2) = z := by
-  rw [Fintype.sum_prod_type]
-  simp_rw [giL0_toReal]
-  exact h
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wN : (∑ x : Utterance × Parse, (giM.L0 x {wN}).toReal ^ 2) = 307 / 24 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wNS : (∑ x : Utterance × Parse, (giM.L0 x {wNS}).toReal ^ 2) = 23 / 6 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wNA : (∑ x : Utterance × Parse, (giM.L0 x {wNA}).toReal ^ 2) = 23 / 9 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wNSA : (∑ x : Utterance × Parse, (giM.L0 x {wNSA}).toReal ^ 2) = 157 / 72 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wS : (∑ x : Utterance × Parse, (giM.L0 x {wS}).toReal ^ 2) = 559 / 72 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wSA : (∑ x : Utterance × Parse, (giM.L0 x {wSA}).toReal ^ 2) = 10 / 3 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zGI_wA : (∑ x : Utterance × Parse, (giM.L0 x {wA}).toReal ^ 2) = 229 / 24 :=
-  zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
 
 /-! ### Per-parse and LI partitions -/
 
@@ -748,13 +677,6 @@ private theorem zOI_wNA :
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 /-! ### Listener-preference reductions -/
-
-private theorem gi_snd_lt {u : Utterance}
-    (hx : ((giM.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
-    (h : (∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₁)})
-        < ∑ w : World, prior.real {w} * (giM.toKernel w).real {(u, p₂)}) :
-    (giM.jointListener u).snd.real {p₁} < (giM.jointListener u).snd.real {p₂} :=
-  (giM.jointListener_snd_real_lt_iff hx p₁ p₂).mpr h
 
 private theorem lu_fst_lt {u : Utterance}
     (hx : (luSpeaker ∘ₘ luPrior) {u} ≠ 0) {w₁ w₂ : World}
@@ -850,26 +772,65 @@ theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
     (prior_singleton_ne_zero wS) ⟨(.as, ∅), rfl, by decide⟩ (by decide)
 
 set_option maxRecDepth 8192 in
+private theorem giProfile_wN : gi.profile wN
+    = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 4, 4} := by decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wNS : gi.profile wNS
+    = {1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wNA : gi.profile wNA
+    = {2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wNSA : gi.profile wNSA
+    = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 6} := by decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wS : gi.profile wS
+    = {1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by
+  decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wSA : gi.profile wSA
+    = {2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
+
+set_option maxRecDepth 8192 in
+private theorem giProfile_wA : gi.profile wA
+    = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by decide
+
+set_option maxRecDepth 8192 in
+set_option maxHeartbeats 1600000 in
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
-uniquely identifies wNS (eq. 22). Pair choice drives this: under per-parse
-normalization M would not dominate. -/
+uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
+Pair choice drives this: under per-parse normalization M would not dominate.
+Evaluation register — genuinely α-dependent: as α → 0 the singleton reading's
+informativity advantage vanishes, so no α-free certificate exists. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
-    (giM.jointListener .ss).snd.real {p} < (giM.jointListener .ss).snd.real {{.matrix}} := by
+    (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
+      < (gi.choicePosterior 5 prior .ss).real {(.ss, {.matrix})} := by
   intro p hp
   have hmem : p ∈ ({∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
       {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse) :=
     univP ▸ Finset.mem_univ p
+  have ho : ((gi.speaker 5 ∘ₘ prior).map gi.obs) {Utterance.ss} ≠ 0 :=
+    gi.map_obs_comp_ne_zero (c := (.ss, ∅)) (prior_singleton_ne_zero wNS) rfl
+      (gi.speaker_apply_singleton_ne_zero (by norm_num) (by decide))
   fin_cases hmem <;>
     first
       | exact absurd rfl hp
-      | exact gi_snd_lt gi_marg_ss (by
-          simp_rw [prior_real_singleton, giS_real, rpow_two]
-          norm_num +decide [univW, Finset.sum_insert, Finset.sum_singleton]
-          simp_rw [zGI_wN, zGI_wNS, zGI_wNA, zGI_wNSA, zGI_wS, zGI_wSA, zGI_wA,
-            giL0_toReal]
-          norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+      | (rw [gi.choicePosterior_real_lt_iff ho rfl rfl]
+         simp_rw [gi.speaker_real_singleton (α := 5) (by norm_num), prior_real_singleton]
+         norm_num +decide [-Multiset.invPowSum_cons, -Multiset.invPowSum_singleton,
+           -Multiset.invPowSum_add, -Multiset.invPowSum_zero,
+           univW, Finset.sum_insert, Finset.sum_singleton,
+           giProfile_wN, giProfile_wNS, giProfile_wNA, giProfile_wNSA, giProfile_wS,
+           giProfile_wSA, giProfile_wA, Multiset.invPowSum_toReal,
+           Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+           Multiset.sum_cons, Multiset.sum_singleton, rpow_five, ext,
+           Finset.filter_insert, Finset.filter_singleton,
+           Finset.card_insert_of_notMem, Finset.card_singleton])
 
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — at the
 paper's illustrative α = 5 (eq. 10, cost-free; the direction reverses at the

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -751,21 +751,21 @@ private theorem zLI (w : World) (z : ℝ)
 
 set_option maxRecDepth 8192 in
 private theorem zLI_wNS : (∑ x : Utterance × LIParse, (liL0 x {wNS}).toReal ^ 2) = 53 / 48 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
 private theorem zLI_wNA : (∑ x : Utterance × LIParse, (liL0 x {wNA}).toReal ^ 2) = 19 / 18 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
 private theorem zLI_wS : (∑ x : Utterance × LIParse, (liL0 x {wS}).toReal ^ 2) = 461 / 144 :=
-  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 /-! ### Listener-preference reductions -/
 
@@ -849,16 +849,6 @@ private theorem giPool_ss_wS : (∑ p : Parse, (giSpeaker wS).real {(.ss, p)}) =
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_aa_wSA : (∑ p : Parse, (giSpeaker wSA).real {(.aa, p)}) = 0 :=
-  giPool _ _ _ _ zGI_wSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-private theorem giPool_aa_wA : (∑ p : Parse, (giSpeaker wA).real {(.aa, p)}) = 192 / 229 :=
-  giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
 private theorem giPool_as_wS : (∑ p : Parse, (giSpeaker wS).real {(.as, p)}) = 340 / 559 :=
   giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
@@ -880,19 +870,19 @@ private theorem liPool (u : Utterance) (w : World) (z v : ℝ)
   exact h
 
 private theorem liPool_ss_wNS : (∑ l : LIParse, (liSpeaker wNS).real {(.ss, l)}) = 15 / 53 :=
-  liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem liPool_ss_wNA : (∑ l : LIParse, (liSpeaker wNA).real {(.ss, l)}) = 5 / 38 :=
-  liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem liPool_ss_wS : (∑ l : LIParse, (liSpeaker wS).real {(.ss, l)}) = 13 / 461 :=
-  liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+  liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
+    Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
+    Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem vanS_ss_wNS : (vanillaSpeaker wNS).real {Utterance.ss} = 4 / 29 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
@@ -940,12 +930,36 @@ theorem ss_outer_exh :
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
     norm_num)
 
-/-- AA identifies the unique world where all aliens drank all: wA over wSA. -/
+/-- AA identifies the unique world where all aliens drank all: at wSA the
+utterance is false under every parse, so its pooled mass vanishes; at wA any
+parse gives an applicable pair. Structural — no masses computed. -/
 theorem aa_identifies :
     ((giListener .aa).fst).real {wSA} < ((giListener .aa).fst).real {wA} :=
-  gi_fst_lt gi_marg_aa (by
-    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_aa_wSA, giPool_aa_wA]
-    norm_num)
+  gi_fst_lt gi_marg_aa <| by
+    have hzero : ∀ p : Parse, (giSpeaker wSA).real {(.aa, p)} = 0 := fun p =>
+      RSA.speaker_real_singleton_eq_zero (by
+        rw [RSA.utility, EReal.coe_zero, sub_zero,
+          show giL0 (.aa, p) {wSA} = 0 from
+            RSA.literalListener_apply_singleton_of_not_mem prior _ fun h =>
+              absurd ((table1_aa p wSA).mp h) (by decide),
+          ENNReal.log_zero]
+        exact EReal.mul_bot_of_pos (by norm_num))
+    calc ∑ p : Parse, prior.real {wSA} * (giSpeaker wSA).real {(.aa, p)}
+        = 0 := by simp [hzero]
+      _ < ∑ p : Parse, prior.real {wA} * (giSpeaker wA).real {(.aa, p)} :=
+          Finset.sum_pos'
+            (fun p _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
+            ⟨∅, Finset.mem_univ _,
+              mul_pos (by rw [prior_real_singleton]; norm_num)
+                (RSA.speaker_real_singleton_pos
+                  (by
+                    rw [RSA.utility, EReal.coe_zero, sub_zero]
+                    exact RSA.coe_mul_log_ne_bot (by norm_num)
+                      (L0_ne_zero (p := ∅) (by decide)))
+                  fun x => by
+                    rw [RSA.utility, EReal.coe_zero, sub_zero]
+                    exact RSA.coe_mul_log_ne_top (by norm_num)
+                      (RSA.literalListener_apply_ne_top prior _ x {wA}))⟩
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -814,43 +814,145 @@ private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} =
     show Fintype.card (World × LULex) = 14 from by decide]
   norm_num
 
+/-! ### Pooled speaker masses
+
+Each finding compares two pooled speaker masses; naming their values keeps
+the findings two-line. -/
+
+private theorem giPool (u : Utterance) (w : World) (z v : ℝ)
+    (hz : (∑ x : Utterance × Parse, (giL0 x {w}).toReal ^ 2) = z)
+    (h : (∑ p : Parse,
+        (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
+         else 0) ^ 2 / z) = v) :
+    (∑ p : Parse, (giSpeaker w).real {(u, p)}) = v := by
+  simp_rw [giS_real, rpow_two, hz, giL0_toReal]
+  exact h
+
+private theorem giPool_ss_wNS : (∑ p : Parse, (giSpeaker wNS).real {(.ss, p)}) = 5 / 12 :=
+  giPool _ _ _ _ zGI_wNS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_ss_wNA : (∑ p : Parse, (giSpeaker wNA).real {(.ss, p)}) = 9 / 92 :=
+  giPool _ _ _ _ zGI_wNA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_ss_wNSA :
+    (∑ p : Parse, (giSpeaker wNSA).real {(.ss, p)}) = 43 / 157 :=
+  giPool _ _ _ _ zGI_wNSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_ss_wS : (∑ p : Parse, (giSpeaker wS).real {(.ss, p)}) = 11 / 559 :=
+  giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_aa_wSA : (∑ p : Parse, (giSpeaker wSA).real {(.aa, p)}) = 0 :=
+  giPool _ _ _ _ zGI_wSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_aa_wA : (∑ p : Parse, (giSpeaker wA).real {(.aa, p)}) = 192 / 229 :=
+  giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_as_wS : (∑ p : Parse, (giSpeaker wS).real {(.as, p)}) = 340 / 559 :=
+  giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem giPool_as_wA : (∑ p : Parse, (giSpeaker wA).real {(.as, p)}) = 16 / 687 :=
+  giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem liPool (u : Utterance) (w : World) (z v : ℝ)
+    (hz : (∑ x : Utterance × LIParse, (liL0 x {w}).toReal ^ 2) = z)
+    (h : (∑ l : LIParse,
+        (if exhMeaning l.toParse u w
+          then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
+         else 0) ^ 2 / z) = v) :
+    (∑ l : LIParse, (liSpeaker w).real {(u, l)}) = v := by
+  simp_rw [liS_real, rpow_two, hz, liL0_toReal]
+  exact h
+
+private theorem liPool_ss_wNS : (∑ l : LIParse, (liSpeaker wNS).real {(.ss, l)}) = 15 / 53 :=
+  liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem liPool_ss_wNA : (∑ l : LIParse, (liSpeaker wNA).real {(.ss, l)}) = 5 / 38 :=
+  liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem liPool_ss_wS : (∑ l : LIParse, (liSpeaker wS).real {(.ss, l)}) = 13 / 461 :=
+  liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton])
+
+private theorem vanS_ss_wNS : (vanillaSpeaker wNS).real {Utterance.ss} = 4 / 29 := by
+  simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
+  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton]
+
+private theorem vanS_ss_wNA : (vanillaSpeaker wNA).real {Utterance.ss} = 2 / 11 := by
+  simp_rw [vanillaS_real, rpow_two, zVan_wNA, L0_toReal]
+  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton]
+
+private theorem luPool_ss_wNS :
+    (∑ l : LULex, (luSpeaker (wNS, l)).real {Utterance.ss}) = 41 / 87 := by
+  simp_rw [luS_real, rpow_two]
+  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, LULex.toParse]
+  simp_rw [zVan_wNS, zOI_wNS, L0_toReal]
+  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton]
+
+private theorem luPool_ss_wNA :
+    (∑ l : LULex, (luSpeaker (wNA, l)).real {Utterance.ss}) = 2 / 11 := by
+  simp_rw [luS_real, rpow_two]
+  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, LULex.toParse]
+  simp_rw [zVan_wNA, zOI_wNA, L0_toReal]
+  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
+    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton]
+
 /-! ### The ten qualitative findings -/
 
 /-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
 theorem ss_inner_exh :
     ((giListener .ss).fst).real {wNSA} < ((giListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, giS_real, rpow_two, zGI_wNS, zGI_wNSA, giL0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
+    norm_num)
 
 /-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
 theorem ss_outer_exh :
     ((giListener .ss).fst).real {wS} < ((giListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, giS_real, rpow_two, zGI_wNS, zGI_wS, giL0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
+    norm_num)
 
 /-- AA identifies the unique world where all aliens drank all: wA over wSA. -/
 theorem aa_identifies :
     ((giListener .aa).fst).real {wSA} < ((giListener .aa).fst).real {wA} :=
   gi_fst_lt gi_marg_aa (by
-    simp_rw [prior_real_singleton, giS_real, rpow_two, zGI_wSA, zGI_wA, giL0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_aa_wSA, giPool_aa_wA]
+    norm_num)
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :
     ((giListener .as).fst).real {wA} < ((giListener .as).fst).real {wS} :=
   gi_fst_lt gi_marg_as (by
-    simp_rw [prior_real_singleton, giS_real, rpow_two, zGI_wS, zGI_wA, giL0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_as_wA, giPool_as_wS]
+    norm_num)
 
 set_option maxRecDepth 8192 in
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
@@ -879,48 +981,36 @@ cost-free illustration of eq. 10; the direction reverses at the fitted cost). -/
 theorem vanilla_ss_prefers_wNA :
     (vanillaListener .ss).real {wNS} < (vanillaListener .ss).real {wNA} :=
   vanilla_lt vanilla_marg_ss (by
-    simp_rw [prior_real_singleton, vanillaS_real, rpow_two, zVan_wNS, zVan_wNA, L0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, vanS_ss_wNS, vanS_ss_wNA]
+    norm_num)
 
 /-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
     ((giListener .ss).fst).real {wNA} < ((giListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
-    simp_rw [prior_real_singleton, giS_real, rpow_two, zGI_wNS, zGI_wNA, giL0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNA, giPool_ss_wNS]
+    norm_num)
 
 /-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA (the
 paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
 theorem lu_ss_prefers_wNS :
     ((luListener .ss).fst).real {wNA} < ((luListener .ss).fst).real {wNS} :=
   lu_fst_lt lu_marg_ss (by
-    simp_rw [luPrior_real_singleton, luS_real, rpow_two]
-    norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, LULex.toParse]
-    simp_rw [zVan_wNS, zVan_wNA, zOI_wNS, zOI_wNA, L0_toReal]
-    norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [luPrior_real_singleton, ← Finset.mul_sum, luPool_ss_wNA, luPool_ss_wNS]
+    norm_num)
 
 /-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
     ((liListener .ss).fst).real {wS} < ((liListener .ss).fst).real {wNS} :=
   li_fst_lt li_marg_ss (by
-    simp_rw [prior_real_singleton, liS_real, rpow_two, zLI_wNS, zLI_wS, liL0_toReal]
-    norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wS, liPool_ss_wNS]
+    norm_num)
 
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
 theorem li_ss_prefers_wNS :
     ((liListener .ss).fst).real {wNA} < ((liListener .ss).fst).real {wNS} :=
   li_fst_lt li_marg_ss (by
-    simp_rw [prior_real_singleton, liS_real, rpow_two, zLI_wNS, zLI_wNA, liL0_toReal]
-    norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
+    simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wNA, liPool_ss_wNS]
+    norm_num)
 
 end FrankeBergen2020

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -556,13 +556,9 @@ listener's parse posterior peaks at exhaustification of the whole
 sentence. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
     (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
-      < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := by
-  have hcol : ∀ p : Parse, p ≠ pM →
-      gi.divPowSumColumn 12 5 (.ss, p) < gi.divPowSumColumn 12 5 (.ss, pM) := by
-    decide +kernel
-  exact fun p hp =>
-    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel)
-      prior_singleton_eq prior_singleton_ne_zero rfl rfl (hcol p hp)
+      < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := fun p _ =>
+  gi.choicePosterior_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel)
+    prior_singleton_eq prior_singleton_ne_zero rfl rfl (by revert p; decide +kernel)
 
 /-- Hearing "some of the aliens drank some of their water", the
 literal-semantics listener favors all-drinkers over some-but-not-all

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -527,10 +527,9 @@ odds comparison uniformly. Evaluation findings are genuinely α-dependent
 illustrative α = 5, where the comparison clears to a ℕ inequality via
 `Multiset.divPowSum`. -/
 
-/-- SS exhaustifies the inner quantifier at the paper's illustrative α = 5:
-hearing SS, the listener prefers wNS to wNSA (eq. 22's regime). Evaluation
-register — the domination certificate provably fails here (wNSA's SS-fiber is
-not stochastically dominated), and the preference degenerates as α → 0. -/
+/-- Hearing "some of the aliens drank some of their water", the pooled
+listener favors the world where no alien drank all of its water over the one
+where some did (inner exhaustification). -/
 theorem ss_inner_exh :
     (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} :=
   gi.listener_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel) (by decide +kernel)
@@ -538,36 +537,34 @@ theorem ss_inner_exh :
     (by decide +kernel) (by decide +kernel) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
-the listener prefers wNS to wS. Certificate register. -/
+/-- Hearing "some of the aliens drank some of their water", the pooled
+listener favors a world where some alien drank nothing (outer
+exhaustification). -/
 theorem ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wS} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- AA identifies the unique world where all aliens drank all, for every
-rationality: AA's readings are all {wA} (Table 1), so wSA's AA-fiber is empty
-and any nonempty product strictly dominates it — the support case of the
-certificate register. -/
+/-- Hearing "all of the aliens drank all of their water", the pooled
+listener favors the unique world where every alien did just that. -/
 theorem aa_identifies {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .aa).real {wSA} < (gi.listener α prior .aa).real {wA} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wSA wA)
     (prior_singleton_ne_zero wA) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- AS exhaustifies the inner quantifier for every rationality: hearing AS,
-the listener prefers wS to wA. Certificate register. -/
+/-- Hearing "all of the aliens drank some of their water", the pooled
+listener favors the world where every alien drank some but not all (inner
+exhaustification). -/
 theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .as).real {wA} < (gi.listener α prior .as).real {wS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
     (prior_singleton_ne_zero wS) (by decide +kernel)
 
-/-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
-uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
-Pair choice drives this — see `perParse_ss_prefers_o` for the contrast.
-Evaluation register: as α → 0 the singleton reading's informativity advantage
-vanishes, so no α-free certificate exists. -/
+/-- Hearing "some of the aliens drank some of their water", the pooled
+listener's parse posterior peaks at exhaustification of the whole
+sentence. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
     (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
       < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := by
@@ -584,88 +581,75 @@ theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
     gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel) (by decide +kernel)
       (by decide +kernel) prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
 
-/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — for
-every rationality (cost-free; the direction reverses at the paper's fitted
-cost). Certificate register: {6}·{3,4} = {18,24} strictly dominates
-{6}·{4,4} = {24,24} with a strictly smaller matched entry and no spare. -/
+/-- Hearing "some of the aliens drank some of their water", the
+literal-semantics listener favors all-drinkers over some-but-not-all
+drinkers — opposite to the attested preference. -/
 theorem vanilla_ss_prefers_wNA {α : ℝ} (hα : 0 < α) :
     (vanilla.listener α prior .ss).real {wNS} < (vanilla.listener α prior .ss).real {wNA} :=
   vanilla.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNS wNA)
     (prior_singleton_ne_zero wNA) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- GI corrects vanilla's error for every rationality: hearing SS, the
-listener prefers wNS to wNA. Certificate register: wNS's SS-fiber
-{1,3,3,3,3,4,4,6} strictly dominates wNA's {3,3,6} — the M-pair's singleton
-extension is the spare element. -/
+/-- Hearing "some of the aliens drank some of their water", the pooled
+listener favors some-but-not-all drinkers over all-drinkers, as attested. -/
 theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wNA} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- LI derives outer exhaustification for SS at every rationality: wNS over
-wS via the OI parse. Certificate register. -/
+/-- Hearing "some of the aliens drank some of their water", the matrix-free
+pooled listener still favors a world where some alien drank nothing (outer
+exhaustification). -/
 theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wS} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
 set_option maxRecDepth 1024 in
-/-- LI also gets the wNS-over-wNA ordering that vanilla misses, at every
-rationality. Certificate register. -/
+/-- Hearing "some of the aliens drank some of their water", the matrix-free
+pooled listener favors some-but-not-all drinkers over all-drinkers. -/
 theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wNA} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) (by decide +kernel)
 
-/-- LU keeps wNS above wNA for every rationality. At wNA only the literal
-lexicon can produce SS, and its share is capped below a third: SS's extension
-strictly exceeds SN's and SA's, so by informativity monotonicity it carries
-the smallest of the three shares. At wNS the OI lexicon alone contributes
-exactly a third — its true choices all have three-world extensions, so its
-speaker is uniform on them. (The paper's full LU-L2 nonetheless concentrates
-on wNSA, eq. 15.) -/
+/-- Hearing "some of the aliens drank some of their water", the
+lexical-uncertainty listener favors some-but-not-all drinkers over
+all-drinkers. -/
 theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (luListener α .ss).fst.real {wNA} < (luListener α .ss).fst.real {wNS} := by
   rw [luListener, RSA.Scenario.familyListener_fst_real_lt_iff luFam hα.le
       luPrior_singleton_eq luPrior_singleton_ne_zero
-      (by decide +kernel : wNS ∈ (luFam .lit).sem .ss),
-    show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide +kernel,
-    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)),
-    Finset.sum_singleton,
-    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)),
-    Finset.sum_singleton,
-    (luFam .oi).speaker_real_singleton_eq_zero hα
-      (by decide +kernel : wNA ∉ (luFam .oi).sem .ss),
-    (luFam .oi).speaker_real_singleton_of_profile_replicate hα
-      (by decide +kernel : (luFam .oi).profile wNS = Multiset.replicate 3 3)
-      (by decide +kernel : wNS ∈ (luFam .oi).sem .ss)]
-  have hsum := (luFam .lit).sum_speaker_real_singleton_le_one α wNA {.ss, .sn, .sa}
-  rw [Finset.sum_insert (by decide +kernel : Utterance.ss ∉ ({.sn, .sa} : Finset Utterance)),
-    Finset.sum_insert (by decide +kernel : Utterance.sn ∉ ({.sa} : Finset Utterance)),
-    Finset.sum_singleton] at hsum
-  have hsn := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .sn) (by decide +kernel)
-  have hsa := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .sa) (by decide +kernel)
-  have hpos : (0 : ℝ) ≤ ((luFam .lit).speaker α wNS).real {Utterance.ss} :=
-    measureReal_nonneg
-  linarith
+      (by decide +kernel : wNS ∈ (luFam .lit).sem .ss)]
+  calc (∑ l : LULex, ((luFam l).speaker α wNA).real {.ss})
+      = ((luFam .lit).speaker α wNA).real {.ss} :=
+        Finset.sum_eq_single_of_mem LULex.lit (Finset.mem_univ _) fun l _ hl => by
+          cases l
+          · exact absurd rfl hl
+          · exact (luFam .oi).speaker_real_singleton_eq_zero hα
+              (by decide +kernel : wNA ∉ (luFam .oi).sem .ss)
+    _ < ((luFam .oi).speaker α wNS).real {.ss} := by
+        rw [(luFam .oi).speaker_real_singleton_of_profile_replicate hα
+          (by decide +kernel : (luFam .oi).profile wNS = Multiset.replicate 3 3)
+          (by decide +kernel : wNS ∈ (luFam .oi).sem .ss)]
+        have hsum := (luFam .lit).sum_speaker_real_singleton_le_one α wNA {.ss, .sn, .sa}
+        rw [Finset.sum_insert (by decide), Finset.sum_pair (by decide)] at hsum
+        have hsn := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
+          (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
+          (by decide +kernel : wNA ∈ (luFam .lit).sem .sn) (by decide +kernel)
+        have hsa := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
+          (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
+          (by decide +kernel : wNA ∈ (luFam .lit).sem .sa) (by decide +kernel)
+        linarith
+    _ ≤ ∑ l : LULex, ((luFam l).speaker α wNS).real {.ss} :=
+        Finset.single_le_sum
+          (fun l _ => measureReal_nonneg (μ := (luFam l).speaker α wNS))
+          (Finset.mem_univ LULex.oi)
 
-/-- The headline divergence, for every rationality: hearing SS, the
-*per-parse-normalized* listener's parse posterior puts more mass on O than on
-M. The M-share is a single world's, capped below one by competition
-(`RSA.Scenario.speaker_real_singleton_lt_one`), while O's three worlds each
-contribute exactly a third — their true choices all have three-world
-extensions, so each per-parse speaker is uniform on them
-(`RSA.Scenario.speaker_real_singleton_of_profile_replicate`). Renormalizing
-within the parse erases exactly the informativity advantage of the singleton
-reading ⟦SS⟧^M that the pooled speaker exploits in `ss_m_parse_pref`; with
-`RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win purely
-in the position of the latent parameter (pp. e85–e86). -/
+/-- Hearing "some of the aliens drank some of their water", the per-parse
+listener favors exhaustifying the outer quantifier over exhaustifying the
+whole sentence. -/
 theorem perParse_ss_prefers_o {α : ℝ} (hα : 0 < α) :
     (perParseListener α .ss).snd.real {pM} < (perParseListener α .ss).snd.real {pO} := by
   have hOprof : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -75,6 +75,8 @@ namespace FrankeBergen2020
 open scoped ENNReal
 open MeasureTheory ProbabilityTheory
 
+/-! ## The grammar of readings -/
+
 /-! ### Domain -/
 
 /-- An alien's drinking amount: none, some but not all, or all of its water. -/
@@ -91,6 +93,9 @@ instance : Membership AlienType World := ⟨fun w t => t ∈ w.val⟩
 
 instance (t : AlienType) (w : World) : Decidable (t ∈ w) :=
   inferInstanceAs (Decidable (t ∈ w.val))
+
+instance : MeasurableSpace World := ⊤
+instance : DiscreteMeasurableSpace World := ⟨fun _ => trivial⟩
 
 /-- The world with only N-type aliens (each drank none). -/
 def wN : World := ⟨{.none}, Finset.singleton_nonempty _⟩
@@ -118,6 +123,10 @@ inductive ExhPosition where
 /-- A parse is the set of EXH insertion sites. -/
 abbrev Parse := Finset ExhPosition
 
+instance : MeasurableSpace Parse := ⊤
+instance : DiscreteMeasurableSpace Parse := ⟨fun _ => trivial⟩
+instance : Nonempty Parse := ⟨∅⟩
+
 /-- The matrix-only parse M. -/
 def pM : Parse := {.matrix}
 
@@ -136,6 +145,10 @@ inductive Utterance where
   | sn | ss | sa
   | an | as | aa
   deriving DecidableEq, Repr, Fintype
+
+instance : Nonempty Utterance := ⟨.nn⟩
+instance : MeasurableSpace Utterance := ⊤
+instance : DiscreteMeasurableSpace Utterance := ⟨fun _ => trivial⟩
 
 /-- Outer quantifier of an utterance. -/
 def Utterance.outer : Utterance → AristQuant
@@ -357,25 +370,52 @@ theorem moi_ss_ne_innocent_exclusion :
             fun w => decide (exhMeaning {.outer, .inner} .ss w)) :=
   ⟨by decide +kernel, by decide +kernel⟩
 
-/-! ### Latent spaces -/
+/-- Every `(world, parse)` state has a true utterance. -/
+theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide +kernel
 
-/-- LU lexicon: literal or OI (inner + outer EXH). Each speaker has a fixed
-lexicon; the listener marginalizes over the two lexica. -/
-inductive LULex where
-  | lit | oi
-  deriving DecidableEq, Repr, Fintype
+/-! ## The models -/
 
-instance : Nonempty LULex := ⟨.lit⟩
+/-! ### The reading family and the pooled models
 
-/-- Map LU lexicon to the corresponding parse. -/
-def LULex.toParse : LULex → Parse
-  | .lit => ∅
-  | .oi => {.outer, .inner}
+Each parse yields a scenario (`readings`); the paper's models are combinators
+applied to this single family. Vanilla (§3.1) is the literal member. GI
+(eq. 21a) and LI (eq. 18a) pool (utterance, parse) pairs into one choice
+space — the speaker *chooses* the parse — while LU (eq. 11) fixes the lexicon
+as a speaker argument (`RSA.Scenario.familySpeaker`). By
+`RSA.Scenario.pool_L0` the weights agree, so the models differ *only* in the
+position of the latent parameter (p. e86); `ss_m_parse_pref` against
+`perParse_ss_prefers_o` below turns that difference into diverging
+predictions. Rationality is a parameter of the derived kernels, and findings
+quantify over it wherever the paper's argument does. -/
+
+/-- The extension of an utterance under a parse, as a `Finset` — the
+`RSA.Scenario` semantic field. -/
+def ext (p : Parse) (u : Utterance) : Finset World :=
+  Finset.univ.filter (exhMeaning p u)
+
+@[simp] theorem mem_ext {p : Parse} {u : Utterance} {w : World} :
+    w ∈ ext p u ↔ exhMeaning p u w := by
+  simp [ext]
+
+/-- One scenario per parse: utterances read under it. -/
+@[simps] def readings (p : Parse) : RSA.Scenario World Utterance Utterance where
+  sem := ext p
+  obs := id
+
+/-- The vanilla scenario (§3.1): the literal member of the family. -/
+abbrev vanilla : RSA.Scenario World Utterance Utterance := readings ∅
+
+/-- The GI scenario (eq. 21a): pair choice over the full reading family. -/
+def gi : RSA.Scenario World (Utterance × Parse) Utterance := .pool readings
 
 /-- LI parse: lit, I, O, or OI — matrix-EXH parses are unavailable. -/
 inductive LIParse where
   | lit | i | o | oi
   deriving DecidableEq, Repr, Fintype
+
+instance : Nonempty LIParse := ⟨.lit⟩
+instance : MeasurableSpace LIParse := ⊤
+instance : DiscreteMeasurableSpace LIParse := ⟨fun _ => trivial⟩
 
 /-- Map LI parse to the full parse space. -/
 def LIParse.toParse : LIParse → Parse
@@ -387,40 +427,15 @@ def LIParse.toParse : LIParse → Parse
 /-- LI cannot access matrix EXH: no LI parse includes M. -/
 theorem li_excludes_matrix : ∀ l : LIParse, .matrix ∉ l.toParse := by decide +kernel
 
-/-- LU cannot access matrix EXH: neither lexicon includes M. -/
-theorem lu_excludes_matrix : ∀ l : LULex, .matrix ∉ l.toParse := by decide +kernel
+/-- The LI scenario (eq. 18a): pair choice over the matrix-free parses. -/
+def li : RSA.Scenario World (Utterance × LIParse) Utterance :=
+  .pool fun l => readings l.toParse
 
-/-! ### Measurable structure -/
-
-instance : MeasurableSpace World := ⊤
-instance : DiscreteMeasurableSpace World := ⟨fun _ => trivial⟩
-instance : MeasurableSpace Utterance := ⊤
-instance : DiscreteMeasurableSpace Utterance := ⟨fun _ => trivial⟩
-instance : Nonempty Utterance := ⟨.nn⟩
-instance : MeasurableSpace Parse := ⊤
-instance : DiscreteMeasurableSpace Parse := ⟨fun _ => trivial⟩
-instance : Nonempty Parse := ⟨∅⟩
-instance : MeasurableSpace LULex := ⊤
-instance : DiscreteMeasurableSpace LULex := ⟨fun _ => trivial⟩
-instance : MeasurableSpace LIParse := ⊤
-instance : DiscreteMeasurableSpace LIParse := ⟨fun _ => trivial⟩
-instance : Nonempty LIParse := ⟨.lit⟩
-
-/-! ### The model on kernels
-
-Priors are `uniformOn`; per-parse literal listeners condition the prior on
-the reading's extension; the speakers are the softmax-utility kernel at
-α = 2; the listeners are `κ†μ` (vanilla; LU with the lexicon in the state)
-and `jointPosterior` (LI/GI pair choice). -/
-
-/-- The extension of an utterance under a parse, as a `Finset` — the
-`RSA.Scenario` semantic field. -/
-def ext (p : Parse) (u : Utterance) : Finset World :=
-  Finset.univ.filter (exhMeaning p u)
-
-@[simp] theorem mem_ext {p : Parse} {u : Utterance} {w : World} :
-    w ∈ ext p u ↔ exhMeaning p u w := by
-  simp [ext]
+instance : vanilla.Expressible := ⟨fun w => (exists_true w ∅).imp fun _ h => mem_ext.mpr h⟩
+instance : gi.Expressible :=
+  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), mem_ext.mpr h⟩⟩
+instance : li.Expressible :=
+  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), mem_ext.mpr h⟩⟩
 
 noncomputable def prior : Measure World := uniformOn Set.univ
 
@@ -434,44 +449,25 @@ theorem prior_singleton_ne_zero (w : World) : prior {w} ≠ 0 := by
   rw [prior, uniformOn_univ, Measure.count_singleton]
   simp
 
-/-- Every `(world, parse)` state has a true utterance. -/
-theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide +kernel
-
-/-! ### The models as combinators over one reading family
-
-Each parse yields a scenario (`readings`); the paper's models are combinators
-applied to this single family. Vanilla (§3.1) is the literal member. GI
-(eq. 21a) and LI (eq. 18a) pool (utterance, parse) pairs into one choice
-space — the speaker *chooses* the parse — while LU (eq. 11) fixes the lexicon
-as a speaker argument (`RSA.Scenario.familySpeaker`). By
-`RSA.Scenario.pool_L0` the weights agree, so the models differ *only* in the
-position of the latent parameter (p. e86); `ss_m_parse_pref` against
-`perParse_ss_prefers_o` below turns that difference into diverging
-predictions. Rationality is a parameter of the derived kernels, and findings
-quantify over it wherever the paper's argument does. -/
-
-/-- One scenario per parse: utterances read under it. -/
-@[simps] def readings (p : Parse) : RSA.Scenario World Utterance Utterance where
-  sem := ext p
-  obs := id
-
-/-- The vanilla scenario (§3.1): the literal member of the family. -/
-abbrev vanilla : RSA.Scenario World Utterance Utterance := readings ∅
-
-/-- The GI scenario (eq. 21a): pair choice over the full reading family. -/
-def gi : RSA.Scenario World (Utterance × Parse) Utterance := .pool readings
-
-/-- The LI scenario (eq. 18a): pair choice over the matrix-free parses. -/
-def li : RSA.Scenario World (Utterance × LIParse) Utterance :=
-  .pool fun l => readings l.toParse
-
-instance : vanilla.Expressible := ⟨fun w => (exists_true w ∅).imp fun _ h => mem_ext.mpr h⟩
-instance : gi.Expressible :=
-  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), mem_ext.mpr h⟩⟩
-instance : li.Expressible :=
-  ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), mem_ext.mpr h⟩⟩
-
 /-! ### Lexical uncertainty: the latent as a speaker argument -/
+
+/-- LU lexicon: literal or OI (inner + outer EXH). Each speaker has a fixed
+lexicon; the listener marginalizes over the two lexica. -/
+inductive LULex where
+  | lit | oi
+  deriving DecidableEq, Repr, Fintype
+
+instance : Nonempty LULex := ⟨.lit⟩
+instance : MeasurableSpace LULex := ⊤
+instance : DiscreteMeasurableSpace LULex := ⟨fun _ => trivial⟩
+
+/-- Map LU lexicon to the corresponding parse. -/
+def LULex.toParse : LULex → Parse
+  | .lit => ∅
+  | .oi => {.outer, .inner}
+
+/-- LU cannot access matrix EXH: neither lexicon includes M. -/
+theorem lu_excludes_matrix : ∀ l : LULex, .matrix ∉ l.toParse := by decide +kernel
 
 /-- The LU speaker family (eq. 11): one member of `readings` per lexicon. -/
 def luFam (l : LULex) : RSA.Scenario World Utterance Utterance := readings l.toParse
@@ -517,7 +513,9 @@ per-parse speaker over the joint (world, parse) state. -/
 noncomputable def perParseListener (α : ℝ) : Kernel Utterance (World × Parse) :=
   RSA.Scenario.familyListener readings α perParsePrior
 
-/-! ### The ten findings -/
+/-! ## The findings -/
+
+/-! ### Exhaustified interpretation -/
 
 /-- Hearing "some of the aliens drank some of their water", the pooled
 listener favors the world where no alien drank all of its water over the one
@@ -551,14 +549,7 @@ theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
     (prior_singleton_ne_zero wS) (by decide +kernel)
 
-/-- Hearing "some of the aliens drank some of their water", the pooled
-listener's parse posterior peaks at exhaustification of the whole
-sentence. -/
-theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
-    (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
-      < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := fun p _ =>
-  gi.choicePosterior_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel)
-    prior_singleton_eq prior_singleton_ne_zero rfl rfl (by revert p; decide +kernel)
+/-! ### The model comparison -/
 
 /-- Hearing "some of the aliens drank some of their water", the
 literal-semantics listener favors all-drinkers over some-but-not-all
@@ -621,6 +612,17 @@ theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
         Finset.single_le_sum
           (fun l _ => measureReal_nonneg (μ := (luFam l).speaker α wNS))
           (Finset.mem_univ LULex.oi)
+
+/-! ### The position of the latent parameter -/
+
+/-- Hearing "some of the aliens drank some of their water", the pooled
+listener's parse posterior peaks at exhaustification of the whole
+sentence. -/
+theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
+    (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
+      < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := fun p _ =>
+  gi.choicePosterior_real_lt_of_divPowSum (k := 5) (D := 12) (by decide +kernel)
+    prior_singleton_eq prior_singleton_ne_zero rfl rfl (by revert p; decide +kernel)
 
 /-- Hearing "some of the aliens drank some of their water", the per-parse
 listener favors exhaustifying the outer quantifier over exhaustifying the

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -118,6 +118,12 @@ inductive ExhPosition where
 /-- A parse is the set of EXH insertion sites. -/
 abbrev Parse := Finset ExhPosition
 
+/-- The matrix-only parse M. -/
+def pM : Parse := {.matrix}
+
+/-- The outer-only parse O. -/
+def pO : Parse := {.outer}
+
 /-- Aristotelian quantifiers: the utterance vocabulary. -/
 inductive AristQuant where
   | none | some | all
@@ -337,7 +343,7 @@ theorem literal_eq_exh_none : ∀ (u : Utterance) (w : World),
 
 /-- ⟦SS⟧^M = {wNS} — the reading that "uniquely singles out this world
 state" (eq. 22) and drives GI's win; the matrix-alone case of `table1_ss`. -/
-theorem m_ss_singleton : ∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS := by decide +kernel
+theorem m_ss_singleton : ∀ w, exhMeaning pM .ss w ↔ w = wNS := by decide +kernel
 
 /-- The matrix operator (eq. A2) is not Fox-style innocent exclusion
 ([fox-2007]): at MOI its strictly-stronger filter is empty and ⟦SS⟧^MOI keeps
@@ -497,11 +503,11 @@ noncomputable def perParsePrior : Measure (World × Parse) := uniformOn Set.univ
 instance : IsProbabilityMeasure perParsePrior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
 
-private theorem perParsePrior_singleton_eq (p q : World × Parse) :
+theorem perParsePrior_singleton_eq (p q : World × Parse) :
     perParsePrior {p} = perParsePrior {q} := by
   simp [perParsePrior, uniformOn_univ]
 
-private theorem perParsePrior_singleton_ne_zero (s : World × Parse) :
+theorem perParsePrior_singleton_ne_zero (s : World × Parse) :
     perParsePrior {s} ≠ 0 := by
   rw [perParsePrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
@@ -510,7 +516,6 @@ private theorem perParsePrior_singleton_ne_zero (s : World × Parse) :
 per-parse speaker over the joint (world, parse) state. -/
 noncomputable def perParseListener (α : ℝ) : Kernel Utterance (World × Parse) :=
   RSA.Scenario.familyListener readings α perParsePrior
-
 
 /-! ### The ten findings
 
@@ -563,21 +568,21 @@ uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
 Pair choice drives this — see `perParse_ss_prefers_o` for the contrast.
 Evaluation register: as α → 0 the singleton reading's informativity advantage
 vanishes, so no α-free certificate exists. -/
-theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
+theorem ss_m_parse_pref : ∀ p : Parse, p ≠ pM →
     (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
-      < (gi.choicePosterior 5 prior .ss).real {(.ss, {.matrix})} := by
-  have hnat : ∀ p : Parse, p ≠ {ExhPosition.matrix} →
+      < (gi.choicePosterior 5 prior .ss).real {(.ss, pM)} := by
+  have hnat : ∀ p : Parse, p ≠ pM →
       (∑ t : World, if t ∈ gi.sem (.ss, p) then
           (12 / (gi.sem (.ss, p)).card) ^ 5
             * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
         else 0)
-        < ∑ t : World, if t ∈ gi.sem (.ss, ({.matrix} : Parse)) then
-          (12 / (gi.sem (.ss, ({.matrix} : Parse))).card) ^ 5
+        < ∑ t : World, if t ∈ gi.sem (.ss, pM) then
+          (12 / (gi.sem (.ss, pM)).card) ^ 5
             * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
         else 0 := by decide +kernel
   exact fun p hp =>
-    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel) (by decide +kernel) (by decide +kernel)
-      prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
+    gi.choicePosterior_real_lt_of_divPowSum (by decide +kernel) (by decide +kernel)
+      (by decide +kernel) prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
 
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — for
 every rationality (cost-free; the direction reverses at the paper's fitted
@@ -625,11 +630,14 @@ theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (luListener α .ss).fst.real {wNA} < (luListener α .ss).fst.real {wNS} := by
   rw [luListener, RSA.Scenario.familyListener_fst_real_lt_iff luFam hα.le
       luPrior_singleton_eq luPrior_singleton_ne_zero
-      (by decide +kernel : wNS ∈ (luFam .lit).sem .ss) wNA wNS,
+      (by decide +kernel : wNS ∈ (luFam .lit).sem .ss),
     show (Finset.univ : Finset LULex) = {.lit, .oi} from by decide +kernel,
-    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
-    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)), Finset.sum_singleton,
-    (luFam .oi).speaker_real_singleton_eq_zero hα (by decide +kernel : wNA ∉ (luFam .oi).sem .ss),
+    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)),
+    Finset.sum_singleton,
+    Finset.sum_insert (by decide +kernel : LULex.lit ∉ ({.oi} : Finset LULex)),
+    Finset.sum_singleton,
+    (luFam .oi).speaker_real_singleton_eq_zero hα
+      (by decide +kernel : wNA ∉ (luFam .oi).sem .ss),
     (luFam .oi).speaker_real_singleton_of_profile_replicate hα
       (by decide +kernel : (luFam .oi).profile wNS = Multiset.replicate 3 3)
       (by decide +kernel : wNS ∈ (luFam .oi).sem .ss)]
@@ -638,11 +646,11 @@ theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     Finset.sum_insert (by decide +kernel : Utterance.sn ∉ ({.sa} : Finset Utterance)),
     Finset.sum_singleton] at hsum
   have hsn := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss) (by decide +kernel : wNA ∈ (luFam .lit).sem .sn)
-    (by decide +kernel)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .sn) (by decide +kernel)
   have hsa := (luFam .lit).speaker_real_singleton_lt_of_card_lt hα
-    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss) (by decide +kernel : wNA ∈ (luFam .lit).sem .sa)
-    (by decide +kernel)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .ss)
+    (by decide +kernel : wNA ∈ (luFam .lit).sem .sa) (by decide +kernel)
   have hpos : (0 : ℝ) ≤ ((luFam .lit).speaker α wNS).real {Utterance.ss} :=
     measureReal_nonneg
   linarith
@@ -659,37 +667,32 @@ reading ⟦SS⟧^M that the pooled speaker exploits in `ss_m_parse_pref`; with
 `RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win purely
 in the position of the latent parameter (pp. e85–e86). -/
 theorem perParse_ss_prefers_o {α : ℝ} (hα : 0 < α) :
-    (perParseListener α .ss).snd.real {({.matrix} : Parse)}
-      < (perParseListener α .ss).snd.real {({.outer} : Parse)} := by
-  have hM0 : ∀ w : World, w ≠ wNS → w ∉ (readings {ExhPosition.matrix}).sem .ss := by decide +kernel
+    (perParseListener α .ss).snd.real {pM} < (perParseListener α .ss).snd.real {pO} := by
   have hOprof : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
-      (readings {ExhPosition.outer}).profile w = Multiset.replicate 3 3 := by decide +kernel
+      (readings pO).profile w = Multiset.replicate 3 3 := by decide +kernel
   have hOmem : ∀ w ∈ ({wNS, wNA, wNSA} : Finset World),
-      w ∈ (readings {ExhPosition.outer}).sem .ss := by decide +kernel
+      w ∈ (readings pO).sem .ss := by decide +kernel
   rw [perParseListener, RSA.Scenario.familyListener_snd_real_lt_iff readings hα.le
       perParsePrior_singleton_eq perParsePrior_singleton_ne_zero
-      (by decide +kernel : wNS ∈ (readings {ExhPosition.matrix}).sem .ss)
-      ({.matrix} : Parse) ({.outer} : Parse)]
-  calc (∑ w : World, ((readings {ExhPosition.matrix}).speaker α w).real {Utterance.ss})
-      = ((readings {ExhPosition.matrix}).speaker α wNS).real {Utterance.ss} :=
+      (mem_ext.mpr ((m_ss_singleton wNS).mpr rfl))]
+  calc (∑ w : World, ((readings pM).speaker α w).real {.ss})
+      = ((readings pM).speaker α wNS).real {.ss} :=
         Finset.sum_eq_single_of_mem wNS (Finset.mem_univ _) fun w _ hw =>
-          (readings {ExhPosition.matrix}).speaker_real_singleton_eq_zero hα (hM0 w hw)
+          (readings pM).speaker_real_singleton_eq_zero hα fun hmem =>
+            hw ((m_ss_singleton w).mp (mem_ext.mp hmem))
     _ < 1 :=
-        (readings {ExhPosition.matrix}).speaker_real_singleton_lt_one hα.le Utterance.ss
-          (by decide +kernel : Utterance.sn ≠ Utterance.ss)
-          (by decide +kernel : wNS ∈ (readings {ExhPosition.matrix}).sem .sn)
-    _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World), (3⁻¹ : ℝ) := by
-        rw [Finset.sum_const,
+        (readings pM).speaker_real_singleton_lt_one hα.le
+          (nofun : Utterance.sn ≠ Utterance.ss)
+          (by decide +kernel : wNS ∈ (readings pM).sem .sn)
+    _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World),
+          ((readings pO).speaker α w).real {.ss} := by
+        rw [Finset.sum_eq_card_nsmul fun w hw =>
+            (readings pO).speaker_real_singleton_of_profile_replicate hα
+              (hOprof w hw) (hOmem w hw),
           show ({wNS, wNA, wNSA} : Finset World).card = 3 from by decide +kernel]
         norm_num
-    _ = ∑ w ∈ ({wNS, wNA, wNSA} : Finset World),
-          ((readings {ExhPosition.outer}).speaker α w).real {Utterance.ss} :=
-        Finset.sum_congr rfl fun w hw =>
-          ((readings {ExhPosition.outer}).speaker_real_singleton_of_profile_replicate hα
-            (hOprof w hw) (hOmem w hw)).symm
-    _ ≤ ∑ w : World, ((readings {ExhPosition.outer}).speaker α w).real {Utterance.ss} :=
+    _ ≤ ∑ w : World, ((readings pO).speaker α w).real {.ss} :=
         Finset.sum_le_sum_of_subset_of_nonneg (Finset.subset_univ _)
           fun w _ _ => measureReal_nonneg
-
 
 end FrankeBergen2020

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -394,15 +394,6 @@ the reading's extension; the speakers are the softmax-utility kernel at
 α = 2; the listeners are `κ†μ` (vanilla; LU with the lexicon in the state)
 and `jointPosterior` (LI/GI pair choice). -/
 
-/-- The extension of an utterance under a parse. -/
-def sem (p : Parse) (u : Utterance) : Set World := {w | exhMeaning p u w}
-
-@[simp] theorem mem_sem {p : Parse} {u : Utterance} {w : World} :
-    w ∈ sem p u ↔ exhMeaning p u w := Iff.rfl
-
-instance (p : Parse) (u : Utterance) (w : World) : Decidable (w ∈ sem p u) :=
-  inferInstanceAs (Decidable (exhMeaning p u w))
-
 /-- The extension of an utterance under a parse, as a `Finset` — the
 `RSA.Scenario` semantic field. -/
 def ext (p : Parse) (u : Utterance) : Finset World :=
@@ -435,76 +426,6 @@ theorem prior_singleton_ne_zero (w : World) : prior {w} ≠ 0 := by
 
 /-- Every `(world, parse)` state has a true utterance. -/
 theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide
-
-/-- Per-parse literal listener. -/
-noncomputable def L0 (p : Parse) : Kernel Utterance World :=
-  RSA.literalListener prior (sem p)
-
-theorem L0_ne_zero {p : Parse} {u : Utterance} {w : World} (h : exhMeaning p u w) :
-    L0 p u {w} ≠ 0 :=
-  RSA.literalListener_apply_singleton_ne_zero prior h (prior_singleton_ne_zero w)
-
-/-- Within its extension, L0 mass is the inverse extension cardinality. -/
-theorem L0_real_of_mem {p : Parse} {u : Utterance} {w : World} (h : exhMeaning p u w) :
-    (L0 p u).real {w} = ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹ := by
-  have hk : 0 < (Finset.univ.filter (exhMeaning p u)).card :=
-    Finset.card_pos.mpr ⟨w, by simp [h]⟩
-  rw [L0, RSA.literalListener_real_singleton_of_mem prior h, prior_real_singleton,
-    show sem p u = ↑(Finset.univ.filter (exhMeaning p u)) from by ext w'; simp [sem],
-    prior, uniformOn_univ_real_coe_finset, card_world]
-  rw [div_div_eq_mul_div]
-  push_cast
-  rw [inv_mul_cancel₀ (by norm_num : (7 : ℝ) ≠ 0), one_div]
-
-theorem L0_toReal (p : Parse) (u : Utterance) (w : World) :
-    (L0 p u {w}).toReal
-      = if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
-        else 0 := by
-  split
-  · exact L0_real_of_mem ‹_›
-  · exact RSA.literalListener_real_singleton_of_not_mem prior ‹_›
-
-/-! ### The models as bundled speakers
-
-Each model is an `RSA.Speaker` at α = 2 over its own choice space: vanilla
-chooses bare utterances read literally, GI chooses over all 72 (utterance,
-parse) pairs (eq. 21a), LI over the 36 matrix-free pairs (eq. 18a). LU is
-*not* a `Speaker` over the joint (world, lexicon) state: its utility
-normalizes per lexicon rather than against the pooled extension — the
-type-level content of the paper's LU-vs-intentions contrast. -/
-
-/-- The vanilla model: utterances read literally. -/
-@[simps] noncomputable def vanillaM : RSA.Speaker World Utterance where
-  α := 2
-  α_pos := two_pos
-  prior := prior
-  sem := sem ∅
-
-/-- The GI model: pair choice with all parses available. -/
-@[simps] noncomputable def giM : RSA.Speaker World (Utterance × Parse) where
-  α := 2
-  α_pos := two_pos
-  prior := prior
-  sem x := sem x.2 x.1
-
-/-- The LI model: pair choice over matrix-free parses. -/
-@[simps] noncomputable def liM : RSA.Speaker World (Utterance × LIParse) where
-  α := 2
-  α_pos := two_pos
-  prior := prior
-  sem x := sem x.2.toParse x.1
-
-instance : IsProbabilityMeasure vanillaM.prior := inferInstanceAs (IsProbabilityMeasure prior)
-instance : IsProbabilityMeasure giM.prior := inferInstanceAs (IsProbabilityMeasure prior)
-instance : IsProbabilityMeasure liM.prior := inferInstanceAs (IsProbabilityMeasure prior)
-
-instance : vanillaM.Positive := ⟨prior_singleton_ne_zero⟩
-instance : giM.Positive := ⟨prior_singleton_ne_zero⟩
-instance : liM.Positive := ⟨prior_singleton_ne_zero⟩
-
-instance : vanillaM.Viable := ⟨fun w => exists_true w ∅⟩
-instance : giM.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), h⟩⟩
-instance : liM.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), h⟩⟩
 
 /-! ### The models as choice scenarios
 
@@ -549,44 +470,17 @@ noncomputable def luPrior : Measure (World × LULex) := uniformOn Set.univ
 instance : IsProbabilityMeasure luPrior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
 
-/-- The LU speaker (eq. 11): per-lexicon informativity — the lexicon is an
-argument of the speaker, not a choice. -/
-noncomputable def luSpeaker : Kernel (World × LULex) Utterance :=
-  RSA.speaker 2 fun s u => RSA.utility (L0 s.2.toParse) (fun _ => 0) s.1 u
+/-- The LU speaker (eq. 11): the `luFam` family — the lexicon is an argument
+of the speaker, not a choice. -/
+noncomputable def luSpeaker (α : ℝ) : Kernel (World × LULex) Utterance :=
+  RSA.Scenario.familySpeaker luFam α
 
-/-! ### Markov structure -/
+instance (α : ℝ) : IsFiniteKernel (luSpeaker α) :=
+  inferInstanceAs (IsFiniteKernel (RSA.Scenario.familySpeaker luFam α))
 
-instance : IsMarkovKernel luSpeaker := by
-  refine RSA.isMarkovKernel_speaker (fun s u => ?_) fun s => ?_
-  · rw [RSA.utility, EReal.coe_zero, sub_zero]
-    exact RSA.coe_mul_log_ne_top (by norm_num)
-      (RSA.literalListener_apply_ne_top prior _ u {s.1})
-  · refine (exists_true s.1 s.2.toParse).imp fun u hu => ?_
-    rw [RSA.utility, EReal.coe_zero, sub_zero]
-    exact RSA.coe_mul_log_ne_bot (by norm_num) (L0_ne_zero hu)
-
-/-! ### Listeners
-
-Vanilla's pragmatic listener is `vanillaM.listener` (eq. 9); the intention
-models' are `giM.jointListener` (eq. 21b) and `liM.jointListener` (eq. 18b).
-LU keeps a bespoke inverse over the joint state (eqs. 12–13). -/
-
-/-- LU listener: Bayesian inverse over the joint (world, lexicon) state. -/
-noncomputable def luListener : Kernel Utterance (World × LULex) := luSpeaker†luPrior
-
-/-! ### Utility bounds for positivity witnesses -/
-
-private theorem util_ne_bot {p : Parse} {u : Utterance} {w : World}
-    (h : exhMeaning p u w) :
-    ((2 : ℝ) : EReal) * RSA.utility (L0 p) (fun _ => 0) w u ≠ ⊥ := by
-  rw [RSA.utility, EReal.coe_zero, sub_zero]
-  exact RSA.coe_mul_log_ne_bot (by norm_num) (L0_ne_zero h)
-
-private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
-    ((2 : ℝ) : EReal) * RSA.utility (L0 p) (fun _ => 0) w u ≠ ⊤ := by
-  rw [RSA.utility, EReal.coe_zero, sub_zero]
-  exact RSA.coe_mul_log_ne_top (by norm_num)
-    (RSA.literalListener_apply_ne_top prior _ u {w})
+/-- LU listener (eqs. 12–13): Bayesian inverse over the joint state. -/
+noncomputable def luListener (α : ℝ) : Kernel Utterance (World × LULex) :=
+  (luSpeaker α)†luPrior
 
 /-! ### Marginal-positivity witnesses -/
 
@@ -594,35 +488,12 @@ theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
 
-theorem lu_marg_ss : (luSpeaker ∘ₘ luPrior) {Utterance.ss} ≠ 0 :=
-  comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit))
-    (RSA.speaker_apply_singleton_ne_zero (util_ne_bot (p := ∅) (by decide))
-      (util_ne_top ∅ · wNS))
-
-/-! ### Speaker values on reals -/
-
-private theorem rpow_two (r : ℝ) : r ^ (2 : ℝ) = r ^ 2 := by
-  rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
+/-! ### Evaluation scaffolding -/
 
 private theorem rpow_five (r : ℝ) : r ^ (5 : ℝ) = r ^ 5 := by
   rw [show (5 : ℝ) = ((5 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
 
-private theorem luS_real (s : World × LULex) (u : Utterance) :
-    (luSpeaker s).real {u}
-      = (L0 s.2.toParse u {s.1}).toReal ^ (2 : ℝ)
-        / ∑ u', (L0 s.2.toParse u' {s.1}).toReal ^ (2 : ℝ) := by
-  rw [measureReal_def, luSpeaker, RSA.speaker_apply_singleton]
-  simp_rw [RSA.exp_mul_utility_zero]
-  rw [ENNReal.toReal_div, ENNReal.toReal_sum fun u' _ =>
-    ENNReal.rpow_ne_top_of_nonneg (by norm_num)
-      (show L0 s.2.toParse u' {s.1} ≠ ⊤ from
-        RSA.literalListener_apply_ne_top prior _ u' {s.1})]
-  simp_rw [ENNReal.toReal_rpow]
-
 /-! ### Enumeration scaffolding -/
-
-private theorem univU : (Finset.univ : Finset Utterance)
-    = {.nn, .ns, .na, .sn, .ss, .sa, .an, .as, .aa} := by decide
 
 private theorem univP : (Finset.univ : Finset Parse)
     = {∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
@@ -633,86 +504,10 @@ private theorem univW : (Finset.univ : Finset World)
 
 private theorem univLU : (Finset.univ : Finset LULex) = {.lit, .oi} := by decide
 
-private theorem univLI : (Finset.univ : Finset LIParse) = {.lit, .i, .o, .oi} := by decide
-
-/-! ### Partitions
-
-The per-world softmax partitions, as real rationals: `Z(w) = Σ |ext|⁻²` over
-the model's choice space. -/
-
-/-! ### Per-parse and LI partitions -/
-
-private theorem zP (p : Parse) (w : World) (z : ℝ)
-    (h : (∑ u : Utterance,
-        (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
-         else 0) ^ 2) = z) :
-    (∑ u' : Utterance, (L0 p u' {w}).toReal ^ 2) = z := by
-  simp_rw [L0_toReal]
-  exact h
-
-set_option maxRecDepth 8192 in
-private theorem zVan_wNS : (∑ u' : Utterance, (L0 ∅ u' {wNS}).toReal ^ 2) = 29 / 144 :=
-  zP _ _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zVan_wNA : (∑ u' : Utterance, (L0 ∅ u' {wNA}).toReal ^ 2) = 11 / 72 :=
-  zP _ _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zOI_wNS :
-    (∑ u' : Utterance, (L0 {.outer, .inner} u' {wNS}).toReal ^ 2) = 1 / 3 :=
-  zP _ _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-set_option maxRecDepth 8192 in
-private theorem zOI_wNA :
-    (∑ u' : Utterance, (L0 {.outer, .inner} u' {wNA}).toReal ^ 2) = 1 / 3 :=
-  zP _ _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton])
-
-/-! ### Listener-preference reductions -/
-
-private theorem lu_fst_lt {u : Utterance}
-    (hx : (luSpeaker ∘ₘ luPrior) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ l : LULex, luPrior.real {(w₁, l)} * (luSpeaker (w₁, l)).real {u})
-        < ∑ l : LULex, luPrior.real {(w₂, l)} * (luSpeaker (w₂, l)).real {u}) :
-    (luListener u).fst.real {w₁} < (luListener u).fst.real {w₂} := by
-  rw [luListener, posterior_fst_real_lt_iff luSpeaker luPrior hx]
-  exact h
-
 private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
   rw [luPrior, uniformOn_univ_real_singleton,
     show Fintype.card (World × LULex) = 14 from by decide]
   norm_num
-
-/-! ### Pooled speaker masses
-
-Each finding compares two pooled speaker masses; naming their values keeps
-the findings two-line. -/
-
-private theorem luPool_ss_wNS :
-    (∑ l : LULex, (luSpeaker (wNS, l)).real {Utterance.ss}) = 41 / 87 := by
-  simp_rw [luS_real, rpow_two]
-  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, LULex.toParse]
-  simp_rw [zVan_wNS, zOI_wNS, L0_toReal]
-  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton]
-
-private theorem luPool_ss_wNA :
-    (∑ l : LULex, (luSpeaker (wNA, l)).real {Utterance.ss}) = 2 / 11 := by
-  simp_rw [luS_real, rpow_two]
-  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, LULex.toParse]
-  simp_rw [zVan_wNA, zOI_wNA, L0_toReal]
-  norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
-    Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton]
 
 /-! ### The ten qualitative findings -/
 
@@ -861,13 +656,32 @@ theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
     (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
 
-/-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA (the
-paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
+set_option maxRecDepth 8192 in
+/-- LU keeps wNS above wNA at the paper's illustrative α = 5: the OI
+lexicon's ⟦SS⟧ excludes wNA outright, while at wNS both lexica contribute
+(the paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15).
+Evaluation register. -/
 theorem lu_ss_prefers_wNS :
-    (luListener .ss).fst.real {wNA} < (luListener .ss).fst.real {wNS} :=
-  lu_fst_lt lu_marg_ss (by
-    simp_rw [luPrior_real_singleton, ← Finset.mul_sum, luPool_ss_wNA, luPool_ss_wNS]
-    norm_num)
+    (luListener 5 .ss).fst.real {wNA} < (luListener 5 .ss).fst.real {wNS} := by
+  have hκ : luSpeaker 5 (wNS, LULex.lit) {Utterance.ss} ≠ 0 := by
+    rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
+    exact (luFam .lit).speaker_apply_singleton_ne_zero (by norm_num) (by decide)
+  rw [luListener, posterior_fst_real_lt_iff (luSpeaker 5) luPrior
+      (comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit)) hκ)]
+  simp_rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
+  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, luPrior_real_singleton]
+  simp only [(luFam .lit).speaker_real_singleton (α := 5) (by norm_num),
+    (luFam .oi).speaker_real_singleton (α := 5) (by norm_num)]
+  norm_num +decide [-Multiset.invPowSum_cons, -Multiset.invPowSum_singleton,
+    -Multiset.invPowSum_add, -Multiset.invPowSum_zero,
+    show (luFam .lit).profile wNS = {3, 4, 6} from by decide,
+    show (luFam .lit).profile wNA = {4, 4, 6} from by decide,
+    show (luFam .oi).profile wNS = {3, 3, 3} from by decide,
+    show (luFam .oi).profile wNA = {3, 3, 3} from by decide,
+    Multiset.invPowSum_toReal, Multiset.insert_eq_cons, Multiset.map_cons,
+    Multiset.map_singleton, Multiset.sum_cons, Multiset.sum_singleton, rpow_five, ext,
+    LULex.toParse, univW, Finset.filter_insert, Finset.filter_singleton,
+    Finset.card_insert_of_notMem, Finset.card_singleton]
 
 set_option maxRecDepth 8192 in
 /-- LI derives outer exhaustification for SS at every rationality: wNS over

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -397,6 +397,16 @@ and `jointPosterior` (LI/GI pair choice). -/
 /-- The extension of an utterance under a parse. -/
 def sem (p : Parse) (u : Utterance) : Set World := {w | exhMeaning p u w}
 
+@[simp] theorem mem_sem {p : Parse} {u : Utterance} {w : World} :
+    w ∈ sem p u ↔ exhMeaning p u w := Iff.rfl
+
+instance (p : Parse) (u : Utterance) (w : World) : Decidable (w ∈ sem p u) :=
+  inferInstanceAs (Decidable (exhMeaning p u w))
+
+/-- Set form of Table 1's AA row: ⟦AA⟧ = {wA} under every parse. -/
+theorem sem_aa (p : Parse) : sem p .aa = {wA} :=
+  Set.ext fun w => table1_aa p w
+
 noncomputable def prior : Measure World := uniformOn Set.univ
 
 instance : IsProbabilityMeasure prior :=
@@ -453,16 +463,25 @@ normalizes per lexicon rather than against the pooled extension — the
 type-level content of the paper's LU-vs-intentions contrast. -/
 
 /-- The vanilla model: utterances read literally. -/
-noncomputable def vanilla : RSA.Speaker World Utterance :=
-  ⟨2, by norm_num, prior, sem ∅⟩
+@[simps] noncomputable def vanilla : RSA.Speaker World Utterance where
+  α := 2
+  α_pos := two_pos
+  prior := prior
+  sem := sem ∅
 
 /-- The GI model: pair choice with all parses available. -/
-noncomputable def gi : RSA.Speaker World (Utterance × Parse) :=
-  ⟨2, by norm_num, prior, fun x => sem x.2 x.1⟩
+@[simps] noncomputable def gi : RSA.Speaker World (Utterance × Parse) where
+  α := 2
+  α_pos := two_pos
+  prior := prior
+  sem x := sem x.2 x.1
 
 /-- The LI model: pair choice over matrix-free parses. -/
-noncomputable def li : RSA.Speaker World (Utterance × LIParse) :=
-  ⟨2, by norm_num, prior, fun x => sem x.2.toParse x.1⟩
+@[simps] noncomputable def li : RSA.Speaker World (Utterance × LIParse) where
+  α := 2
+  α_pos := two_pos
+  prior := prior
+  sem x := sem x.2.toParse x.1
 
 instance : IsProbabilityMeasure vanilla.prior := inferInstanceAs (IsProbabilityMeasure prior)
 instance : IsProbabilityMeasure gi.prior := inferInstanceAs (IsProbabilityMeasure prior)
@@ -538,12 +557,12 @@ private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
 
 theorem vanilla_marg_ss : (vanilla.toKernel ∘ₘ prior) {Utterance.ss} ≠ 0 :=
   comp_apply_singleton_ne_zero _ _ (prior_singleton_ne_zero wNS)
-    (vanilla.toKernel_apply_ne_zero (show exhMeaning ∅ .ss wNS by decide))
+    (vanilla.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
     ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := (∅ : Parse))
-    (prior_singleton_ne_zero w) (gi.toKernel_apply_ne_zero h)
+    (prior_singleton_ne_zero w) (gi.toKernel_apply_singleton_ne_zero h)
 
 theorem gi_marg_ss : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   gi_marg .ss (w := wNS) (by decide)
@@ -554,12 +573,11 @@ theorem gi_marg_as : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.as} �
 theorem li_marg_ss : ((li.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := LIParse.lit)
     (prior_singleton_ne_zero wNS)
-    (li.toKernel_apply_ne_zero (show exhMeaning ∅ .ss wNS by decide))
+    (li.toKernel_apply_singleton_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
-  rw [luPrior, uniformOn_univ, Measure.count_singleton, ne_eq, ENNReal.div_eq_zero_iff]
-  simp
-  exact ENNReal.mul_ne_top (ENNReal.natCast_ne_top _) (ENNReal.natCast_ne_top _)
+  rw [luPrior, uniformOn_univ, Measure.count_singleton]
+  simp [ENNReal.mul_eq_top]
 
 theorem lu_marg_ss : (luSpeaker ∘ₘ luPrior) {Utterance.ss} ≠ 0 :=
   comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit))
@@ -743,34 +761,28 @@ private theorem gi_fst_lt {u : Utterance}
     (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
     (h : (∑ p : Parse, prior.real {w₁} * (gi.toKernel w₁).real {(u, p)})
         < ∑ p : Parse, prior.real {w₂} * (gi.toKernel w₂).real {(u, p)}) :
-    ((gi.jointListener u).fst).real {w₁} < ((gi.jointListener u).fst).real {w₂} := by
-  unfold RSA.Speaker.jointListener
-  rw [jointPosterior_fst_real_lt_iff gi.toKernel gi.prior hx]
-  exact h
+    (gi.jointListener u).fst.real {w₁} < (gi.jointListener u).fst.real {w₂} :=
+  (gi.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
 
 private theorem gi_snd_lt {u : Utterance}
     (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
     (h : (∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₁)})
         < ∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₂)}) :
-    ((gi.jointListener u).snd).real {p₁} < ((gi.jointListener u).snd).real {p₂} := by
-  unfold RSA.Speaker.jointListener
-  rw [jointPosterior_snd_real_lt_iff gi.toKernel gi.prior hx]
-  exact h
+    (gi.jointListener u).snd.real {p₁} < (gi.jointListener u).snd.real {p₂} :=
+  (gi.jointListener_snd_real_lt_iff hx p₁ p₂).mpr h
 
 private theorem li_fst_lt {u : Utterance}
     (hx : ((li.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
     (h : (∑ l : LIParse, prior.real {w₁} * (li.toKernel w₁).real {(u, l)})
         < ∑ l : LIParse, prior.real {w₂} * (li.toKernel w₂).real {(u, l)}) :
-    ((li.jointListener u).fst).real {w₁} < ((li.jointListener u).fst).real {w₂} := by
-  unfold RSA.Speaker.jointListener
-  rw [jointPosterior_fst_real_lt_iff li.toKernel li.prior hx]
-  exact h
+    (li.jointListener u).fst.real {w₁} < (li.jointListener u).fst.real {w₂} :=
+  (li.jointListener_fst_real_lt_iff hx w₁ w₂).mpr h
 
 private theorem lu_fst_lt {u : Utterance}
     (hx : (luSpeaker ∘ₘ luPrior) {u} ≠ 0) {w₁ w₂ : World}
     (h : (∑ l : LULex, luPrior.real {(w₁, l)} * (luSpeaker (w₁, l)).real {u})
         < ∑ l : LULex, luPrior.real {(w₂, l)} * (luSpeaker (w₂, l)).real {u}) :
-    ((luListener u).fst).real {w₁} < ((luListener u).fst).real {w₂} := by
+    (luListener u).fst.real {w₁} < (luListener u).fst.real {w₂} := by
   rw [luListener, posterior_fst_real_lt_iff luSpeaker luPrior hx]
   exact h
 
@@ -778,10 +790,8 @@ private theorem vanilla_lt {u : Utterance} (hx : (vanilla.toKernel ∘ₘ prior)
     {w₁ w₂ : World}
     (h : prior.real {w₁} * (vanilla.toKernel w₁).real {u}
         < prior.real {w₂} * (vanilla.toKernel w₂).real {u}) :
-    (vanilla.listener u).real {w₁} < (vanilla.listener u).real {w₂} := by
-  unfold RSA.Speaker.listener
-  rw [posterior_real_singleton_lt_iff vanilla.toKernel vanilla.prior hx]
-  exact h
+    (vanilla.listener u).real {w₁} < (vanilla.listener u).real {w₂} :=
+  (vanilla.listener_real_singleton_lt_iff hx w₁ w₂).mpr h
 
 private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
   rw [luPrior, uniformOn_univ_real_singleton,
@@ -892,14 +902,14 @@ private theorem luPool_ss_wNA :
 
 /-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
 theorem ss_inner_exh :
-    ((gi.jointListener .ss).fst).real {wNSA} < ((gi.jointListener .ss).fst).real {wNS} :=
+    (gi.jointListener .ss).fst.real {wNSA} < (gi.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
     norm_num)
 
 /-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
 theorem ss_outer_exh :
-    ((gi.jointListener .ss).fst).real {wS} < ((gi.jointListener .ss).fst).real {wNS} :=
+    (gi.jointListener .ss).fst.real {wS} < (gi.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
     norm_num)
@@ -908,14 +918,13 @@ theorem ss_outer_exh :
 wSA under every parse (Table 1's AA row) and true at wA under the bare parse.
 Purely structural — no masses computed. -/
 theorem aa_identifies :
-    ((gi.jointListener .aa).fst).real {wSA} < ((gi.jointListener .aa).fst).real {wA} :=
+    (gi.jointListener .aa).fst.real {wSA} < (gi.jointListener .aa).fst.real {wA} :=
   gi.jointListener_fst_real_lt_of_support
-    (show ∀ p, ¬ exhMeaning p .aa wSA by decide)
-    ⟨∅, show exhMeaning ∅ .aa wA by decide⟩
+    (by simp only [gi_sem, sem_aa]; decide) ⟨∅, by simp only [gi_sem, sem_aa]; decide⟩
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :
-    ((gi.jointListener .as).fst).real {wA} < ((gi.jointListener .as).fst).real {wS} :=
+    (gi.jointListener .as).fst.real {wA} < (gi.jointListener .as).fst.real {wS} :=
   gi_fst_lt gi_marg_as (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_as_wA, giPool_as_wS]
     norm_num)
@@ -925,7 +934,7 @@ set_option maxRecDepth 8192 in
 uniquely identifies wNS (eq. 22). Pair choice drives this: under per-parse
 normalization M would not dominate. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
-    ((gi.jointListener .ss).snd).real {p} < ((gi.jointListener .ss).snd).real {{.matrix}} := by
+    (gi.jointListener .ss).snd.real {p} < (gi.jointListener .ss).snd.real {{.matrix}} := by
   intro p hp
   have hmem : p ∈ ({∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
       {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse) :=
@@ -952,7 +961,7 @@ theorem vanilla_ss_prefers_wNA :
 
 /-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
-    ((gi.jointListener .ss).fst).real {wNA} < ((gi.jointListener .ss).fst).real {wNS} :=
+    (gi.jointListener .ss).fst.real {wNA} < (gi.jointListener .ss).fst.real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNA, giPool_ss_wNS]
     norm_num)
@@ -960,21 +969,21 @@ theorem gi_ss_prefers_wNS :
 /-- LU also keeps wNS above wNA: the OI lexicon's ⟦SS⟧ excludes wNA (the
 paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
 theorem lu_ss_prefers_wNS :
-    ((luListener .ss).fst).real {wNA} < ((luListener .ss).fst).real {wNS} :=
+    (luListener .ss).fst.real {wNA} < (luListener .ss).fst.real {wNS} :=
   lu_fst_lt lu_marg_ss (by
     simp_rw [luPrior_real_singleton, ← Finset.mul_sum, luPool_ss_wNA, luPool_ss_wNS]
     norm_num)
 
 /-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
-    ((li.jointListener .ss).fst).real {wS} < ((li.jointListener .ss).fst).real {wNS} :=
+    (li.jointListener .ss).fst.real {wS} < (li.jointListener .ss).fst.real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wS, liPool_ss_wNS]
     norm_num)
 
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
 theorem li_ss_prefers_wNS :
-    ((li.jointListener .ss).fst).real {wNA} < ((li.jointListener .ss).fst).real {wNS} :=
+    (li.jointListener .ss).fst.real {wNA} < (li.jointListener .ss).fst.real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wNA, liPool_ss_wNS]
     norm_num)

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -29,34 +29,45 @@ reading ⟦SS⟧^M = {wNS} "uniquely singles out this world state" (eq. 22,
 `m_ss_singleton`) and is unavailable to LI and LU (`li_excludes_matrix`,
 `lu_excludes_matrix`) — the paper's explanation of GI's win in its Bayesian
 model comparison (posterior 0.956 vs LI 0.033, LU 0.01, vanilla 0; Table 2).
-LI and LU still derive the embedded enrichments (`li_ss_outer_exh`,
-`li_ss_prefers_wNS`, `lu_ss_prefers_wNS`).
+The M-advantage exists *because* the pooled speaker normalizes over pairs:
+under the per-parse normalization the paper rejects (p. e85), O beats M at
+every rationality (`perParse_ss_o_beats_m`). LI and LU still derive the
+embedded enrichments (`li_ss_outer_exh`, `li_ss_prefers_wNS`,
+`lu_ss_prefers_wNS`).
 
 ## Main results
 
 * `table1_*` — the paper's Table 1, one lemma per row, including NN's
   distinct matrix row (fn. 7) from the `none ~ not all` lexical alternative
   ([levinson-2000]).
-* `ss_m_parse_pref` — GI's parse posterior for SS peaks at M.
+* `ss_m_parse_pref` vs `perParse_ss_o_beats_m` — the architectural headline:
+  pooled (utterance, parse) choice peaks at M (α = 5), per-parse
+  normalization prefers O for every rationality. With
+  `RSA.Scenario.pool_L0` (identical weights), the pair locates GI's win
+  purely in the position of the latent parameter (p. e86).
 * `moi_ss_ne_innocent_exclusion` — the paper's matrix operator (eq. A2) is
   not Fox-style innocent exclusion ([fox-2007]).
 
 ## Implementation notes
 
-Sentential alternatives (A3a) range over a fourth quantifier `notAll` that is
-never an utterance — the paper's grammatical-vs-utterance alternatives
-distinction (its comparison with [gotzner-romoli-2018]'s alternative set
-favors this one by a Bayes factor of ~1,530). Each model is an
-`RSA.Scenario` (LU a `RSA.Scenario.familySpeaker` family) with rationality a
-parameter, and each finding's docstring names its register: support facts
-and `Multiset.Dominates` certificates hold for every rationality `α > 0`;
-genuinely α-dependent findings are evaluated at the paper's illustrative
-α = 5 via `Multiset.invPowSum` profiles. We omit the paper's cost term for
-*none*-initial utterances and fixed error ε = 0.045 (eqs. 25–28);
-`vanilla_ss_prefers_wNA` reverses at the fitted cost. The paper's S2/L2
-layer for LU ([lassiter-goodman-2017], eqs. 14a–14b) is also omitted: our
-L1-only LU keeps wNS over wNA, though the paper's LU-L2 concentrates on
-wNSA (eq. 15).
+One reading family (`readings`) generates every model: vanilla is its
+literal member, GI and LI pool (utterance, parse) pairs into the choice
+space (`RSA.Scenario.pool`, eqs. 18a/21a), and LU — like the rejected
+per-parse architecture — fixes the latent as a speaker argument
+(`RSA.Scenario.familySpeaker`, eq. 11). Sentential alternatives (A3a) range
+over a fourth quantifier `notAll` that is never an utterance — the paper's
+grammatical-vs-utterance alternatives distinction (its comparison with
+[gotzner-romoli-2018]'s alternative set favors this one by a Bayes factor of
+~1,530). Findings come in two registers, both closed by `decide`:
+`Multiset.StrictDominates` certificates — strict stochastic dominance of
+informativity profiles — hold for every rationality `α > 0`, while genuinely
+α-dependent findings are pinned at the paper's illustrative α = 5, where
+comparisons clear to ℕ inequalities via `Multiset.divPowSum`. We omit the
+paper's cost term for *none*-initial utterances and fixed error ε = 0.045
+(eqs. 25–28); `vanilla_ss_prefers_wNA` reverses at the fitted cost. The
+paper's S2/L2 layer for LU ([lassiter-goodman-2017], eqs. 14a–14b) is also
+omitted: our L1-only LU keeps wNS over wNA at every rationality, though the
+paper's LU-L2 concentrates on wNSA (eq. 15).
 -/
 
 namespace FrankeBergen2020
@@ -405,19 +416,10 @@ def ext (p : Parse) (u : Utterance) : Finset World :=
     w ∈ ext p u ↔ exhMeaning p u w := by
   simp [ext]
 
-/-- Extension form of Table 1's AA row: ⟦AA⟧ = {wA} under every parse. -/
-theorem ext_aa : ∀ p : Parse, ext p .aa = {wA} := by decide
-
 noncomputable def prior : Measure World := uniformOn Set.univ
 
 instance : IsProbabilityMeasure prior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
-
-private theorem card_world : Fintype.card World = 7 := by decide
-
-theorem prior_real_singleton (w : World) : prior.real {w} = 7⁻¹ := by
-  rw [prior, uniformOn_univ_real_singleton, card_world]
-  norm_num
 
 theorem prior_singleton_eq (w w' : World) : prior {w} = prior {w'} := by
   simp [prior, uniformOn_univ]
@@ -429,36 +431,33 @@ theorem prior_singleton_ne_zero (w : World) : prior {w} ≠ 0 := by
 /-- Every `(world, parse)` state has a true utterance. -/
 theorem exists_true : ∀ (w : World) (p : Parse), ∃ u, exhMeaning p u w := by decide
 
-/-! ### The models as choice scenarios
+/-! ### The models as combinators over one reading family
 
-Each model is an `RSA.Scenario`: an extension and an observable form per
-choice, with rationality a parameter of the derived kernels — findings
-quantify over `α` where the paper's argument does. Vanilla chooses bare
-utterances read literally (obs = id); GI chooses over all 72 (utterance,
-parse) pairs (eq. 21a), LI over the 36 matrix-free pairs (eq. 18a), both
-heard through `Prod.fst`. LU's per-lexicon speakers form the `luFam` family
-(eq. 11) — the lexicon sits in the state, not the choice, so LU is *not* one
-`Scenario`: the type-level content of the paper's LU-vs-intentions contrast. -/
+Each parse yields a scenario (`readings`); the paper's models are combinators
+applied to this single family. Vanilla (§3.1) is the literal member. GI
+(eq. 21a) and LI (eq. 18a) pool (utterance, parse) pairs into one choice
+space — the speaker *chooses* the parse — while LU (eq. 11) fixes the lexicon
+as a speaker argument (`RSA.Scenario.familySpeaker`). By
+`RSA.Scenario.pool_L0` the weights agree, so the models differ *only* in the
+position of the latent parameter (p. e86); `ss_m_parse_pref` against
+`perParse_ss_o_beats_m` below turns that difference into diverging
+predictions. Rationality is a parameter of the derived kernels, and findings
+quantify over it wherever the paper's argument does. -/
 
-/-- The vanilla scenario (§3.1): utterances read literally. -/
-@[simps] def vanilla : RSA.Scenario World Utterance Utterance where
-  sem := ext ∅
+/-- One scenario per parse: utterances read under it. -/
+@[simps] def readings (p : Parse) : RSA.Scenario World Utterance Utterance where
+  sem := ext p
   obs := id
 
-/-- The GI scenario (eq. 21): pair choice with all parses available. -/
-@[simps] def gi : RSA.Scenario World (Utterance × Parse) Utterance where
-  sem x := ext x.2 x.1
-  obs := Prod.fst
+/-- The vanilla scenario (§3.1): the literal member of the family. -/
+abbrev vanilla : RSA.Scenario World Utterance Utterance := readings ∅
 
-/-- The LI scenario (eq. 18): pair choice over matrix-free parses. -/
-@[simps] def li : RSA.Scenario World (Utterance × LIParse) Utterance where
-  sem x := ext x.2.toParse x.1
-  obs := Prod.fst
+/-- The GI scenario (eq. 21a): pair choice over the full reading family. -/
+def gi : RSA.Scenario World (Utterance × Parse) Utterance := .pool readings
 
-/-- The LU speaker family (eq. 11): one scenario per lexicon. -/
-@[simps] def luFam (l : LULex) : RSA.Scenario World Utterance Utterance where
-  sem := ext l.toParse
-  obs := id
+/-- The LI scenario (eq. 18a): pair choice over the matrix-free parses. -/
+def li : RSA.Scenario World (Utterance × LIParse) Utterance :=
+  .pool fun l => readings l.toParse
 
 instance : vanilla.Expressible := ⟨fun w => (exists_true w ∅).imp fun _ h => mem_ext.mpr h⟩
 instance : gi.Expressible :=
@@ -466,14 +465,18 @@ instance : gi.Expressible :=
 instance : li.Expressible :=
   ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), mem_ext.mpr h⟩⟩
 
+/-! ### Lexical uncertainty: the latent as a speaker argument -/
+
+/-- The LU speaker family (eq. 11): one member of `readings` per lexicon. -/
+def luFam (l : LULex) : RSA.Scenario World Utterance Utterance := readings l.toParse
+
 /-- LU's joint prior: the lexicon is drawn with the world. -/
 noncomputable def luPrior : Measure (World × LULex) := uniformOn Set.univ
 
 instance : IsProbabilityMeasure luPrior :=
   inferInstanceAs (IsProbabilityMeasure (uniformOn _))
 
-/-- The LU speaker (eq. 11): the `luFam` family — the lexicon is an argument
-of the speaker, not a choice. -/
+/-- The LU speaker (eq. 11): the lexicon is an argument, not a choice. -/
 noncomputable def luSpeaker (α : ℝ) : Kernel (World × LULex) Utterance :=
   RSA.Scenario.familySpeaker luFam α
 
@@ -484,25 +487,9 @@ instance (α : ℝ) : IsFiniteKernel (luSpeaker α) :=
 noncomputable def luListener (α : ℝ) : Kernel Utterance (World × LULex) :=
   (luSpeaker α)†luPrior
 
-/-! ### Marginal-positivity witnesses -/
-
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton]
   simp [ENNReal.mul_eq_top]
-
-/-! ### Evaluation scaffolding -/
-
-private theorem rpow_five (r : ℝ) : r ^ (5 : ℝ) = r ^ 5 := by
-  rw [show (5 : ℝ) = ((5 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
-
-/-! ### Enumeration scaffolding -/
-
-private theorem univP : (Finset.univ : Finset Parse)
-    = {∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
-       {.outer, .inner}, {.matrix, .outer, .inner}} := by decide
-
-private theorem univW : (Finset.univ : Finset World)
-    = {wN, wNS, wNA, wNSA, wS, wSA, wA} := by decide
 
 private theorem univLU : (Finset.univ : Finset LULex) = {.lit, .oi} := by decide
 
@@ -511,53 +498,73 @@ private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} =
     show Fintype.card (World × LULex) = 14 from by decide]
   norm_num
 
-/-! ### The ten qualitative findings -/
+/-! ### The rejected architecture: per-parse normalization -/
+
+/-- The architecture the paper rejects as "conceptually highly implausible"
+(p. e85): the full parse family with the parse as a speaker *argument* —
+eq. 11 with an enlarged latent set, rather than eq. 21a's pooled choice. -/
+noncomputable def perParseSpeaker (α : ℝ) : Kernel (World × Parse) Utterance :=
+  RSA.Scenario.familySpeaker readings α
+
+noncomputable def perParsePrior : Measure (World × Parse) := uniformOn Set.univ
+
+instance : IsProbabilityMeasure perParsePrior :=
+  inferInstanceAs (IsProbabilityMeasure (uniformOn _))
+
+instance (α : ℝ) : IsFiniteKernel (perParseSpeaker α) :=
+  inferInstanceAs (IsFiniteKernel (RSA.Scenario.familySpeaker readings α))
+
+private theorem perParsePrior_singleton_ne_zero (s : World × Parse) :
+    perParsePrior {s} ≠ 0 := by
+  rw [perParsePrior, uniformOn_univ, Measure.count_singleton]
+  simp [ENNReal.mul_eq_top]
+
+private theorem perParsePrior_real_singleton (s : World × Parse) :
+    perParsePrior.real {s} = 56⁻¹ := by
+  rw [perParsePrior, uniformOn_univ_real_singleton,
+    show Fintype.card (World × Parse) = 56 from by decide]
+  norm_num
+
+/-! ### The ten findings
+
+Two registers, both closed by `decide`. Certificate findings hold for every
+rationality `α > 0`: a decided `Multiset.StrictDominates` fact — strict
+stochastic dominance of informativity profiles — settles the fiber-by-rest
+odds comparison uniformly. Evaluation findings are genuinely α-dependent
+(their direction degenerates as α → 0) and are pinned at the paper's
+illustrative α = 5, where the comparison clears to a ℕ inequality via
+`Multiset.divPowSum`. -/
+
+private theorem univW : (Finset.univ : Finset World)
+    = {wN, wNS, wNA, wNSA, wS, wSA, wA} := by decide
 
 /-- SS exhaustifies the inner quantifier at the paper's illustrative α = 5:
 hearing SS, the listener prefers wNS to wNSA (eq. 22's regime). Evaluation
 register — the domination certificate provably fails here (wNSA's SS-fiber is
-not termwise matched by wNS's), so profile literals by `decide` plus
-fifth-power arithmetic by `norm_num` decide it. -/
+not stochastically dominated), and the preference degenerates as α → 0. -/
 theorem ss_inner_exh :
-    (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} := by
-  rw [gi.listener_real_lt_iff_invPowSum (o := .ss) (by norm_num) (prior_singleton_eq wNSA wNS)
-      (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩,
-    show gi.fiberProfile .ss wNSA = {3, 3, 3, 3, 4, 4, 6} from by decide,
-    show gi.profile wNS
-      = {1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} from by
-      decide,
-    show gi.fiberProfile .ss wNS = {1, 3, 3, 3, 3, 4, 4, 6} from by decide,
-    show gi.profile wNSA
-      = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 6} from by decide,
-    Multiset.invPowSum_toReal (by norm_num) (by decide),
-    Multiset.invPowSum_toReal (by norm_num) (by decide),
-    Multiset.invPowSum_toReal (by norm_num) (by decide),
-    Multiset.invPowSum_toReal (by norm_num) (by decide)]
-  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
-    Multiset.sum_cons, Multiset.sum_singleton]
-  norm_num [rpow_five]
+    (gi.listener 5 prior .ss).real {wNSA} < (gi.listener 5 prior .ss).real {wNS} :=
+  gi.listener_real_lt_of_divPowSum (k := 5) (D := 12) (by decide) (by decide)
+    (prior_singleton_eq wNSA wNS) (prior_singleton_ne_zero wNS)
+    (by decide) (by decide) (by decide)
 
 set_option maxRecDepth 1024 in
 /-- SS exhaustifies the outer quantifier for every rationality: hearing SS,
-the listener prefers wNS to wS. Certificate register: the fiber-by-rest
-cross-product domination closes by `decide`. -/
+the listener prefers wNS to wS. Certificate register. -/
 theorem ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wS} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
-    (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
+    (prior_singleton_ne_zero wNS) (by decide)
 
+set_option maxRecDepth 1024 in
 /-- AA identifies the unique world where all aliens drank all, for every
-rationality: AA is false at wSA under every parse (`sem_aa`, Table 1's AA row)
-and true at wA under the bare parse. Purely structural — no masses computed. -/
+rationality: AA's readings are all {wA} (Table 1), so wSA's AA-fiber is empty
+and any nonempty product strictly dominates it — the support case of the
+certificate register. -/
 theorem aa_identifies {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .aa).real {wSA} < (gi.listener α prior .aa).real {wA} :=
-  gi.listener_real_lt_of_support hα (prior_singleton_ne_zero wA)
-    (fun c hc => by
-      obtain ⟨u, p⟩ := c
-      obtain rfl : u = .aa := hc
-      simp only [gi_sem, ext_aa]
-      decide)
-    ⟨(.aa, ∅), rfl, by simp only [gi_sem, ext_aa]; decide⟩
+  gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wSA wA)
+    (prior_singleton_ne_zero wA) (by decide)
 
 set_option maxRecDepth 1024 in
 /-- AS exhaustifies the inner quantifier for every rationality: hearing AS,
@@ -565,127 +572,148 @@ the listener prefers wS to wA. Certificate register. -/
 theorem as_inner_exh {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .as).real {wA} < (gi.listener α prior .as).real {wS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wA wS)
-    (prior_singleton_ne_zero wS) ⟨(.as, ∅), rfl, by decide⟩ (by decide)
-
-private theorem giProfile_wN : gi.profile wN
-    = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 4, 4} := by decide
-
-private theorem giProfile_wNS : gi.profile wNS
-    = {1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
-
-private theorem giProfile_wNA : gi.profile wNA
-    = {2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
-
-private theorem giProfile_wNSA : gi.profile wNSA
-    = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 6} := by decide
-
-private theorem giProfile_wS : gi.profile wS
-    = {1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by
-  decide
-
-private theorem giProfile_wSA : gi.profile wSA
-    = {2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6} := by decide
-
-private theorem giProfile_wA : gi.profile wA
-    = {1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 6} := by decide
+    (prior_singleton_ne_zero wS) (by decide)
 
 /-- GI's parse posterior for SS peaks at the matrix-only parse, whose reading
 uniquely identifies wNS, at the paper's illustrative α = 5 (eq. 22's regime).
-Pair choice drives this: under per-parse normalization M would not dominate.
-Evaluation register — genuinely α-dependent: as α → 0 the singleton reading's
-informativity advantage vanishes, so no α-free certificate exists. -/
+Pair choice drives this — see `perParse_ss_o_beats_m` for the contrast.
+Evaluation register: as α → 0 the singleton reading's informativity advantage
+vanishes, so no α-free certificate exists. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
     (gi.choicePosterior 5 prior .ss).real {(.ss, p)}
       < (gi.choicePosterior 5 prior .ss).real {(.ss, {.matrix})} := by
-  intro p hp
-  have hmem : p ∈ ({∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
-      {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse) :=
-    univP ▸ Finset.mem_univ p
-  have ho : ((gi.speaker 5 ∘ₘ prior).map gi.obs) {Utterance.ss} ≠ 0 :=
-    gi.map_obs_comp_ne_zero (c := (.ss, ∅)) (prior_singleton_ne_zero wNS) rfl
-      (gi.speaker_apply_singleton_ne_zero (by norm_num) (by decide))
-  fin_cases hmem <;>
-    first
-      | exact absurd rfl hp
-      | (rw [gi.choicePosterior_real_lt_iff ho rfl rfl]
-         simp_rw [gi.speaker_real_singleton (α := 5) (by norm_num), prior_real_singleton]
-         norm_num +decide [-Multiset.invPowSum_cons, -Multiset.invPowSum_singleton,
-           -Multiset.invPowSum_add, -Multiset.invPowSum_zero,
-           univW, Finset.sum_insert, Finset.sum_singleton,
-           giProfile_wN, giProfile_wNS, giProfile_wNA, giProfile_wNSA, giProfile_wS,
-           giProfile_wSA, giProfile_wA, Multiset.invPowSum_toReal,
-           Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
-           Multiset.sum_cons, Multiset.sum_singleton, rpow_five, ext,
-           Finset.filter_insert, Finset.filter_singleton,
-           Finset.card_insert_of_notMem, Finset.card_singleton])
+  have hnat : ∀ p : Parse, p ≠ {ExhPosition.matrix} →
+      (∑ t : World, if t ∈ gi.sem (.ss, p) then
+          (12 / (gi.sem (.ss, p)).card) ^ 5
+            * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
+        else 0)
+        < ∑ t : World, if t ∈ gi.sem (.ss, ({.matrix} : Parse)) then
+          (12 / (gi.sem (.ss, ({.matrix} : Parse))).card) ^ 5
+            * ∏ t' ∈ Finset.univ.erase t, (gi.profile t').divPowSum 12 5
+        else 0 := by decide
+  exact fun p hp =>
+    gi.choicePosterior_real_lt_of_divPowSum (by decide) (by decide) (by decide)
+      prior_singleton_eq prior_singleton_ne_zero rfl rfl (hnat p hp)
 
-/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — at the
-paper's illustrative α = 5 (eq. 10, cost-free; the direction reverses at the
-fitted cost). Evaluation register. -/
-theorem vanilla_ss_prefers_wNA :
-    (vanilla.listener 5 prior .ss).real {wNS} < (vanilla.listener 5 prior .ss).real {wNA} := by
-  rw [vanilla.listener_real_lt_iff_invPowSum (o := .ss) (by norm_num) (prior_singleton_eq wNS wNA)
-      (prior_singleton_ne_zero wNA) ⟨.ss, rfl, by decide⟩,
-    show vanilla.fiberProfile .ss wNS = {6} from by decide,
-    show vanilla.profile wNA = {4, 4, 6} from by decide,
-    show vanilla.fiberProfile .ss wNA = {6} from by decide,
-    show vanilla.profile wNS = {3, 4, 6} from by decide,
-    Multiset.invPowSum_toReal (by norm_num) (by decide),
-    Multiset.invPowSum_toReal (by norm_num) (by decide),
-    Multiset.invPowSum_toReal (by norm_num) (by decide)]
-  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
-    Multiset.sum_cons, Multiset.sum_singleton]
-  norm_num [rpow_five]
+/-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction — for
+every rationality (cost-free; the direction reverses at the paper's fitted
+cost). Certificate register: {6}·{3,4} = {18,24} strictly dominates
+{6}·{4,4} = {24,24} with a strictly smaller matched entry and no spare. -/
+theorem vanilla_ss_prefers_wNA {α : ℝ} (hα : 0 < α) :
+    (vanilla.listener α prior .ss).real {wNS} < (vanilla.listener α prior .ss).real {wNA} :=
+  vanilla.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNS wNA)
+    (prior_singleton_ne_zero wNA) (by decide)
 
 set_option maxRecDepth 1024 in
 /-- GI corrects vanilla's error for every rationality: hearing SS, the
 listener prefers wNS to wNA. Certificate register: wNS's SS-fiber
 {1,3,3,3,3,4,4,6} strictly dominates wNA's {3,3,6} — the M-pair's singleton
-extension is the spare element — and the cross-product certificate closes the
-partition side by `decide`. -/
+extension is the spare element. -/
 theorem gi_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (gi.listener α prior .ss).real {wNA} < (gi.listener α prior .ss).real {wNS} :=
   gi.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
-    (prior_singleton_ne_zero wNS) ⟨(.ss, ∅), rfl, by decide⟩ (by decide)
+    (prior_singleton_ne_zero wNS) (by decide)
 
-/-- LU keeps wNS above wNA at the paper's illustrative α = 5: the OI
-lexicon's ⟦SS⟧ excludes wNA outright, while at wNS both lexica contribute
-(the paper's full LU-L2 nonetheless concentrates on wNSA, eq. 15).
-Evaluation register. -/
-theorem lu_ss_prefers_wNS :
-    (luListener 5 .ss).fst.real {wNA} < (luListener 5 .ss).fst.real {wNS} := by
-  have hκ : luSpeaker 5 (wNS, LULex.lit) {Utterance.ss} ≠ 0 := by
-    rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
-    exact (luFam .lit).speaker_apply_singleton_ne_zero (by norm_num) (by decide)
-  rw [luListener, posterior_fst_real_lt_iff (luSpeaker 5) luPrior
-      (comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit)) hκ)]
-  simp_rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
-  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, luPrior_real_singleton]
-  simp only [(luFam .lit).speaker_real_singleton (α := 5) (by norm_num),
-    (luFam .oi).speaker_real_singleton (α := 5) (by norm_num)]
-  norm_num +decide [-Multiset.invPowSum_cons, -Multiset.invPowSum_singleton,
-    -Multiset.invPowSum_add, -Multiset.invPowSum_zero,
-    show (luFam .lit).profile wNS = {3, 4, 6} from by decide,
-    show (luFam .lit).profile wNA = {4, 4, 6} from by decide,
-    show (luFam .oi).profile wNS = {3, 3, 3} from by decide,
-    show (luFam .oi).profile wNA = {3, 3, 3} from by decide,
-    Multiset.invPowSum_toReal, Multiset.insert_eq_cons, Multiset.map_cons,
-    Multiset.map_singleton, Multiset.sum_cons, Multiset.sum_singleton, rpow_five, ext,
-    LULex.toParse, univW, Finset.filter_insert, Finset.filter_singleton,
-    Finset.card_insert_of_notMem, Finset.card_singleton]
-
+set_option maxRecDepth 1024 in
 /-- LI derives outer exhaustification for SS at every rationality: wNS over
 wS via the OI parse. Certificate register. -/
 theorem li_ss_outer_exh {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wS} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wS wNS)
-    (prior_singleton_ne_zero wNS) ⟨(.ss, .lit), rfl, by decide⟩ (by decide)
+    (prior_singleton_ne_zero wNS) (by decide)
 
+set_option maxRecDepth 1024 in
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses, at every
 rationality. Certificate register. -/
 theorem li_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
     (li.listener α prior .ss).real {wNA} < (li.listener α prior .ss).real {wNS} :=
   li.listener_real_lt_of_prodMul_strictDominates hα (prior_singleton_eq wNA wNS)
-    (prior_singleton_ne_zero wNS) ⟨(.ss, .lit), rfl, by decide⟩ (by decide)
+    (prior_singleton_ne_zero wNS) (by decide)
+
+/-- LU keeps wNS above wNA for every rationality: the OI lexicon's ⟦SS⟧
+excludes wNA outright, contributing a constant third of the posterior odds at
+wNS, while wNA's literal-lexicon share stays below a third (the paper's full
+LU-L2 nonetheless concentrates on wNSA, eq. 15). -/
+theorem lu_ss_prefers_wNS {α : ℝ} (hα : 0 < α) :
+    (luListener α .ss).fst.real {wNA} < (luListener α .ss).fst.real {wNS} := by
+  have hκ : luSpeaker α (wNS, LULex.lit) {Utterance.ss} ≠ 0 := by
+    rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
+    exact (luFam .lit).speaker_apply_singleton_ne_zero hα.le (by decide)
+  rw [luListener, posterior_fst_real_lt_iff (luSpeaker α) luPrior
+      (comp_apply_singleton_ne_zero _ _ (luPrior_singleton_ne_zero (wNS, .lit)) hκ)]
+  simp_rw [luSpeaker, RSA.Scenario.familySpeaker_apply]
+  norm_num +decide [univLU, Finset.sum_insert, Finset.sum_singleton, luPrior_real_singleton]
+  rw [(luFam .lit).speaker_real_singleton hα, (luFam .oi).speaker_real_singleton hα,
+    (luFam .lit).speaker_real_singleton hα, (luFam .oi).speaker_real_singleton hα,
+    show (luFam .lit).profile wNS = {3, 4, 6} from by decide,
+    show (luFam .lit).profile wNA = {4, 4, 6} from by decide,
+    show (luFam .oi).profile wNS = {3, 3, 3} from by decide,
+    show (luFam .oi).profile wNA = {3, 3, 3} from by decide,
+    Multiset.invPowSum_toReal hα.le (by decide),
+    Multiset.invPowSum_toReal hα.le (by decide),
+    Multiset.invPowSum_toReal hα.le (by decide),
+    show ((luFam LULex.lit).sem Utterance.ss).card = 6 from by decide,
+    show ((luFam LULex.oi).sem Utterance.ss).card = 3 from by decide]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  norm_num +decide
+  have p6 : (0 : ℝ) < (1 / 6 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
+  have h46 : (1 / 6 : ℝ) ^ α < (1 / 4 : ℝ) ^ α :=
+    Real.rpow_lt_rpow (by norm_num) (by norm_num) hα
+  have keyA : (1 / 6 : ℝ) ^ α / ((1 / 4 : ℝ) ^ α + ((1 / 4 : ℝ) ^ α + (1 / 6 : ℝ) ^ α))
+      < 1 / 3 := by
+    rw [div_lt_iff₀ (by positivity)]
+    linarith
+  have keyB : (1 / 3 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 3 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))
+      = 1 / 3 := by
+    rw [div_eq_iff (by positivity)]
+    ring
+  have keyC : (0 : ℝ) < (1 / 6 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 4 : ℝ) ^ α + (1 / 6 : ℝ) ^ α)) :=
+    div_pos p6 (by positivity)
+  linarith
+
+set_option maxRecDepth 1024 in
+/-- The headline divergence, for every rationality: hearing SS, the
+*per-parse-normalized* listener's parse posterior puts more mass on O than on
+M. Renormalizing within each parse erases exactly the informativity advantage
+of the singleton reading ⟦SS⟧^M that the pooled speaker exploits in
+`ss_m_parse_pref`; with `RSA.Scenario.pool_L0` (identical weights), the pair
+locates GI's win purely in the position of the latent parameter
+(pp. e85–e86). -/
+theorem perParse_ss_o_beats_m {α : ℝ} (hα : 0 < α) :
+    (((perParseSpeaker α)†perParsePrior) .ss).snd.real {({.matrix} : Parse)}
+      < (((perParseSpeaker α)†perParsePrior) .ss).snd.real {({.outer} : Parse)} := by
+  have hκ : perParseSpeaker α (wNS, ({.matrix} : Parse)) {Utterance.ss} ≠ 0 := by
+    rw [perParseSpeaker, RSA.Scenario.familySpeaker_apply]
+    exact (readings _).speaker_apply_singleton_ne_zero hα.le (by decide)
+  rw [posterior_snd_real_lt_iff _ _
+      (comp_apply_singleton_ne_zero _ _
+        (perParsePrior_singleton_ne_zero (wNS, {.matrix})) hκ)]
+  simp_rw [perParseSpeaker, RSA.Scenario.familySpeaker_apply]
+  norm_num +decide [univW, Finset.sum_insert, Finset.sum_singleton, perParsePrior_real_singleton]
+  simp only [(readings ({ExhPosition.matrix} : Parse)).speaker_real_singleton hα,
+    (readings ({ExhPosition.outer} : Parse)).speaker_real_singleton hα]
+  norm_num +decide
+  rw [show (readings ({ExhPosition.matrix} : Parse)).profile wNS = {1, 2, 3} from by decide,
+    show (readings ({ExhPosition.outer} : Parse)).profile wNS = {3, 3, 3} from by decide,
+    show (readings ({ExhPosition.outer} : Parse)).profile wNA = {3, 3, 3} from by decide,
+    show (readings ({ExhPosition.outer} : Parse)).profile wNSA = {3, 3, 3} from by decide,
+    show (ext ({ExhPosition.matrix} : Parse) Utterance.ss).card = 1 from by decide,
+    show (ext ({ExhPosition.outer} : Parse) Utterance.ss).card = 3 from by decide,
+    Multiset.invPowSum_toReal hα.le (by decide),
+    Multiset.invPowSum_toReal hα.le (by decide)]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  norm_num
+  have p2 : (0 : ℝ) < (1 / 2 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
+  have p3 : (0 : ℝ) < (1 / 3 : ℝ) ^ α := Real.rpow_pos_of_pos (by norm_num) α
+  have keyM : (1 + ((1 / 2 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))⁻¹ < 1 := by
+    rw [inv_lt_one₀ (by positivity)]
+    linarith
+  have keyO : (1 / 3 : ℝ) ^ α / ((1 / 3 : ℝ) ^ α + ((1 / 3 : ℝ) ^ α + (1 / 3 : ℝ) ^ α))
+      = 1 / 3 := by
+    rw [div_eq_iff (by positivity)]
+    ring
+  linarith
 
 end FrankeBergen2020

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -265,84 +265,65 @@ instance (p : Parse) (u : Utterance) : DecidablePred (exhMeaning p u) := fun _ =
 
 /-! ### Truth-table verification (the paper's Table 1)
 
-Each reading is characterized by a membership predicate on the world's
-alien-type set, rather than transcribed as a truth vector. -/
+One characterization per utterance, total over all eight parses — the paper's
+row-groups appear as the guards. Each reading is a membership predicate on
+the world's alien-type set, not a truth vector. -/
 
-/-- Table 1, SS literal row: true everywhere but wN. -/
-theorem table1_ss_lit : ∀ w, exhMeaning ∅ .ss w ↔ w ≠ wN := by decide
+/-- Table 1, NN: no N-types; matrix parses additionally negate "none drank
+not all" (= {wA}) — the fn. 7 reading from the `none ~ not all` alternative. -/
+theorem table1_nn : ∀ (p : Parse) (w : World),
+    exhMeaning p .nn w ↔ (.none ∉ w ∧ (.matrix ∈ p → w ≠ wA)) := by decide
 
-/-- Table 1, SS inner-EXH row: an S-type exists. -/
-theorem table1_ss_i : ∀ w, exhMeaning {.inner} .ss w ↔ .someNotAll ∈ w := by decide
+/-- Table 1, NS: only wN literally; inner EXH weakens to the S-free worlds,
+whereupon matrix EXH negates the sentence's own now-stronger literal {wN}. -/
+theorem table1_ns : ∀ (p : Parse) (w : World),
+    exhMeaning p .ns w ↔
+      if .inner ∈ p then .someNotAll ∉ w ∧ (.matrix ∈ p → w ≠ wN)
+      else w = wN := by decide
 
-/-- Table 1, SS outer+inner row: an S-type exists but not exclusively. -/
-theorem table1_ss_oi :
-    ∀ w, exhMeaning {.outer, .inner} .ss w ↔ (.someNotAll ∈ w ∧ w ≠ wS) := by decide
+/-- Table 1, NA: no A-types; matrix EXH negates the stronger NS = {wN}. -/
+theorem table1_na : ∀ (p : Parse) (w : World),
+    exhMeaning p .na w ↔ (.all ∉ w ∧ (.matrix ∈ p → w ≠ wN)) := by decide
 
-/-- EXH_MOI(SS) = EXH_OI(SS): matrix EXH is vacuous at MOI. -/
-theorem exh_moi_ss : ∀ w,
-    exhMeaning {.matrix, .outer, .inner} .ss w ↔ exhMeaning {.outer, .inner} .ss w := by
-  decide
+/-- Table 1, SN: an N-type exists; outer or matrix EXH negates AN = {wN}. -/
+theorem table1_sn : ∀ (p : Parse) (w : World),
+    exhMeaning p .sn w ↔
+      (.none ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wN)) := by decide
 
-/-- Table 1, NN matrix-free rows: no N-types. -/
-theorem table1_nn_lit : ∀ p : Parse, .matrix ∉ p →
-    ∀ w, exhMeaning p .nn w ↔ .none ∉ w := by decide
+/-- Table 1, SS: the five row-groups — literal; inner EXH requires an S-type
+(matrix then vacuous); adding outer EXH excludes wS; outer alone keeps mixed
+worlds; matrix alone pins wNS. -/
+theorem table1_ss : ∀ (p : Parse) (w : World),
+    exhMeaning p .ss w ↔
+      if .inner ∈ p then .someNotAll ∈ w ∧ (.outer ∈ p → w ≠ wS)
+      else if .outer ∈ p then .none ∈ w ∧ w ≠ wN
+      else if .matrix ∈ p then w = wNS
+      else w ≠ wN := by decide
 
-/-- Table 1, NN matrix rows: matrix EXH additionally negates "none drank not
-all" (= {wA}) — the fn. 7 reading from the `none ~ not all` alternative. -/
-theorem table1_nn_m : ∀ p : Parse, .matrix ∈ p →
-    ∀ w, exhMeaning p .nn w ↔ (.none ∉ w ∧ w ≠ wA) := by decide
-
-/-- Table 1, NS literal row: only wN. -/
-theorem table1_ns_lit : ∀ w, exhMeaning ∅ .ns w ↔ w = wN := by decide
-
-/-- Table 1, NS inner-EXH row: no S-types — inner EXH weakens NS. -/
-theorem table1_ns_i : ∀ w, exhMeaning {.inner} .ns w ↔ .someNotAll ∉ w := by decide
-
-/-- Table 1, NS matrix+inner row: matrix EXH negates the sentence's own
-now-stronger literal meaning {wN}. -/
-theorem table1_ns_mi :
-    ∀ w, exhMeaning {.matrix, .inner} .ns w ↔ (.someNotAll ∉ w ∧ w ≠ wN) := by decide
+/-- Table 1, SA: an A-type exists; outer or matrix EXH excludes wA. -/
+theorem table1_sa : ∀ (p : Parse) (w : World),
+    exhMeaning p .sa w ↔
+      (.all ∈ w ∧ (.outer ∈ p ∨ .matrix ∈ p → w ≠ wA)) := by decide
 
 /-- Table 1, AN: only wN, under every parse. -/
-theorem table1_an : ∀ p : Parse, ∀ w, exhMeaning p .an w ↔ w = wN := by decide
+theorem table1_an : ∀ (p : Parse) (w : World), exhMeaning p .an w ↔ w = wN := by decide
+
+/-- Table 1, AS: no N-types; inner EXH pins wS; matrix EXH without inner
+negates AA, excluding wA. -/
+theorem table1_as : ∀ (p : Parse) (w : World),
+    exhMeaning p .as w ↔
+      if .inner ∈ p then w = wS
+      else .none ∉ w ∧ (.matrix ∈ p → w ≠ wA) := by decide
 
 /-- Table 1, AA: only wA, under every parse. -/
-theorem table1_aa : ∀ p : Parse, ∀ w, exhMeaning p .aa w ↔ w = wA := by decide
-
-/-- Table 1, SA literal row: an A-type exists. -/
-theorem table1_sa_lit : ∀ w, exhMeaning ∅ .sa w ↔ .all ∈ w := by decide
-
-/-- Table 1, SA outer-EXH row: outer EXH excludes wA. -/
-theorem table1_sa_o : ∀ w, exhMeaning {.outer} .sa w ↔ (.all ∈ w ∧ w ≠ wA) := by decide
-
-/-- Table 1, NA literal row: no A-types. -/
-theorem table1_na_lit : ∀ w, exhMeaning ∅ .na w ↔ .all ∉ w := by decide
-
-/-- Table 1, NA matrix row: matrix EXH negates the stronger NS = {wN}. -/
-theorem table1_na_m : ∀ w, exhMeaning {.matrix} .na w ↔ (.all ∉ w ∧ w ≠ wN) := by decide
-
-/-- Table 1, SN literal row: an N-type exists. -/
-theorem table1_sn_lit : ∀ w, exhMeaning ∅ .sn w ↔ .none ∈ w := by decide
-
-/-- Table 1, SN outer-EXH row: outer EXH negates AN = {wN}. -/
-theorem table1_sn_o : ∀ w, exhMeaning {.outer} .sn w ↔ (.none ∈ w ∧ w ≠ wN) := by decide
-
-/-- Table 1, AS literal row: no N-types. -/
-theorem table1_as_lit : ∀ w, exhMeaning ∅ .as w ↔ .none ∉ w := by decide
-
-/-- Table 1, AS inner-EXH row: inner EXH pins wS. -/
-theorem table1_as_i : ∀ w, exhMeaning {.inner} .as w ↔ w = wS := by decide
-
-/-- Table 1, AS matrix row: matrix EXH without I negates AA, excluding wA. -/
-theorem table1_as_m :
-    ∀ w, exhMeaning {.matrix} .as w ↔ (.none ∉ w ∧ w ≠ wA) := by decide
+theorem table1_aa : ∀ (p : Parse) (w : World), exhMeaning p .aa w ↔ w = wA := by decide
 
 /-- Literal meaning is the empty parse's exhaustified meaning. -/
-theorem literal_eq_exh_none : ∀ u : Utterance, ∀ w,
+theorem literal_eq_exh_none : ∀ (u : Utterance) (w : World),
     literalMeaning u w ↔ exhMeaning ∅ u w := by decide
 
-/-- Table 1, SS matrix row — ⟦SS⟧^M = {wNS}: the reading that "uniquely
-singles out this world state" (eq. 22) and drives GI's win. -/
+/-- ⟦SS⟧^M = {wNS} — the reading that "uniquely singles out this world
+state" (eq. 22) and drives GI's win; the matrix-alone case of `table1_ss`. -/
 theorem m_ss_singleton : ∀ w, exhMeaning {.matrix} .ss w ↔ w = wNS := by decide
 
 /-- The matrix operator (eq. A2) is not Fox-style innocent exclusion

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -443,28 +443,38 @@ theorem L0_toReal (p : Parse) (u : Utterance) (w : World) :
   · exact L0_real_of_mem ‹_›
   · exact RSA.literalListener_real_singleton_of_not_mem prior ‹_›
 
-/-! ### Speakers -/
+/-! ### The models as bundled speakers
 
-/-- Vanilla speaker: informativity softmax over the literal parse. -/
-noncomputable def vanillaSpeaker : Kernel World Utterance :=
-  RSA.speaker 2 (RSA.utility (L0 ∅) fun _ => 0)
+Each model is an `RSA.Speaker` at α = 2 over its own choice space: vanilla
+chooses bare utterances read literally, GI chooses over all 72 (utterance,
+parse) pairs (eq. 21a), LI over the 36 matrix-free pairs (eq. 18a). LU is
+*not* a `Speaker` over the joint (world, lexicon) state: its utility
+normalizes per lexicon rather than against the pooled extension — the
+type-level content of the paper's LU-vs-intentions contrast. -/
 
-/-- The GI literal listener, keyed by (utterance, parse) pairs: a pair means
-its parse's reading. -/
-noncomputable def giL0 : Kernel (Utterance × Parse) World :=
-  RSA.literalListener prior fun x => sem x.2 x.1
+/-- The vanilla model: utterances read literally. -/
+noncomputable def vanilla : RSA.Speaker World Utterance :=
+  ⟨2, by norm_num, prior, sem ∅⟩
 
-/-- The GI speaker (eq. 21a): one softmax over all 72 pairs per world. -/
-noncomputable def giSpeaker : Kernel World (Utterance × Parse) :=
-  RSA.speaker 2 (RSA.utility giL0 fun _ => 0)
+/-- The GI model: pair choice with all parses available. -/
+noncomputable def gi : RSA.Speaker World (Utterance × Parse) :=
+  ⟨2, by norm_num, prior, fun x => sem x.2 x.1⟩
 
-/-- The LI literal listener over the 36 matrix-free pairs. -/
-noncomputable def liL0 : Kernel (Utterance × LIParse) World :=
-  RSA.literalListener prior fun x => sem x.2.toParse x.1
+/-- The LI model: pair choice over matrix-free parses. -/
+noncomputable def li : RSA.Speaker World (Utterance × LIParse) :=
+  ⟨2, by norm_num, prior, fun x => sem x.2.toParse x.1⟩
 
-/-- The LI speaker (eq. 18a). -/
-noncomputable def liSpeaker : Kernel World (Utterance × LIParse) :=
-  RSA.speaker 2 (RSA.utility liL0 fun _ => 0)
+instance : IsProbabilityMeasure vanilla.prior := inferInstanceAs (IsProbabilityMeasure prior)
+instance : IsProbabilityMeasure gi.prior := inferInstanceAs (IsProbabilityMeasure prior)
+instance : IsProbabilityMeasure li.prior := inferInstanceAs (IsProbabilityMeasure prior)
+
+instance : vanilla.Positive := ⟨prior_singleton_ne_zero⟩
+instance : gi.Positive := ⟨prior_singleton_ne_zero⟩
+instance : li.Positive := ⟨prior_singleton_ne_zero⟩
+
+instance : vanilla.Viable := ⟨fun w => exists_true w ∅⟩
+instance : gi.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, ∅), h⟩⟩
+instance : li.Viable := ⟨fun w => (exists_true w ∅).elim fun u h => ⟨(u, .lit), h⟩⟩
 
 /-- LU's joint prior: the lexicon is drawn with the world. -/
 noncomputable def luPrior : Measure (World × LULex) := uniformOn Set.univ
@@ -480,32 +490,17 @@ noncomputable def luSpeaker : Kernel (World × LULex) Utterance :=
 /-! ### Markov structure -/
 
 theorem giL0_toReal (x : Utterance × Parse) (w : World) :
-    (giL0 x {w}).toReal
+    (gi.L0 x {w}).toReal
       = if exhMeaning x.2 x.1 w then ((Finset.univ.filter (exhMeaning x.2 x.1)).card : ℝ)⁻¹
         else 0 :=
   L0_toReal x.2 x.1 w
 
 theorem liL0_toReal (x : Utterance × LIParse) (w : World) :
-    (liL0 x {w}).toReal
+    (li.L0 x {w}).toReal
       = if exhMeaning x.2.toParse x.1 w
           then ((Finset.univ.filter (exhMeaning x.2.toParse x.1)).card : ℝ)⁻¹
         else 0 :=
   L0_toReal x.2.toParse x.1 w
-
-instance : IsMarkovKernel vanillaSpeaker :=
-  RSA.isMarkovKernel_speaker_utility_zero (by norm_num)
-    (fun u w => RSA.literalListener_apply_ne_top prior (sem ∅) u {w})
-    fun w => (exists_true w ∅).imp fun u hu => L0_ne_zero hu
-
-instance : IsMarkovKernel giSpeaker :=
-  RSA.isMarkovKernel_speaker_utility_zero (by norm_num)
-    (fun x w => RSA.literalListener_apply_ne_top prior _ x {w})
-    fun w => (exists_true w ∅).elim fun u hu => ⟨(u, ∅), L0_ne_zero hu⟩
-
-instance : IsMarkovKernel liSpeaker :=
-  RSA.isMarkovKernel_speaker_utility_zero (by norm_num)
-    (fun x w => RSA.literalListener_apply_ne_top prior _ x {w})
-    fun w => (exists_true w ∅).elim fun u hu => ⟨(u, .lit), L0_ne_zero hu⟩
 
 instance : IsMarkovKernel luSpeaker := by
   refine RSA.isMarkovKernel_speaker (fun s u => ?_) fun s => ?_
@@ -516,21 +511,14 @@ instance : IsMarkovKernel luSpeaker := by
     rw [RSA.utility, EReal.coe_zero, sub_zero]
     exact RSA.coe_mul_log_ne_bot (by norm_num) (L0_ne_zero hu)
 
-/-! ### Listeners -/
+/-! ### Listeners
 
-/-- Vanilla listener (eq. 9): the Bayesian inverse of the vanilla speaker. -/
-noncomputable def vanillaListener : Kernel Utterance World := vanillaSpeaker†prior
+Vanilla's pragmatic listener is `vanilla.listener` (eq. 9); the intention
+models' are `gi.jointListener` (eq. 21b) and `li.jointListener` (eq. 18b).
+LU keeps a bespoke inverse over the joint state (eqs. 12–13). -/
 
-/-- LU listener (eqs. 12–13): Bayesian inverse over the joint state. -/
+/-- LU listener: Bayesian inverse over the joint (world, lexicon) state. -/
 noncomputable def luListener : Kernel Utterance (World × LULex) := luSpeaker†luPrior
-
-/-- LI listener (eq. 18b): joint posterior over (world, parse). -/
-noncomputable def liListener : Kernel Utterance (World × LIParse) :=
-  jointPosterior liSpeaker prior
-
-/-- GI listener (eq. 21b). -/
-noncomputable def giListener : Kernel Utterance (World × Parse) :=
-  jointPosterior giSpeaker prior
 
 /-! ### Utility bounds for positivity witnesses -/
 
@@ -548,43 +536,25 @@ private theorem util_ne_top (p : Parse) (u : Utterance) (w : World) :
 
 /-! ### Marginal-positivity witnesses -/
 
-theorem vanilla_marg_ss : (vanillaSpeaker ∘ₘ prior) {Utterance.ss} ≠ 0 :=
+theorem vanilla_marg_ss : (vanilla.toKernel ∘ₘ prior) {Utterance.ss} ≠ 0 :=
   comp_apply_singleton_ne_zero _ _ (prior_singleton_ne_zero wNS)
-    (RSA.speaker_apply_singleton_ne_zero (util_ne_bot (by decide)) (util_ne_top ∅ · wNS))
+    (vanilla.toKernel_apply_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem gi_marg (u : Utterance) {w : World} (h : exhMeaning ∅ u w) :
-    ((giSpeaker ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
+    ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := (∅ : Parse))
-    (prior_singleton_ne_zero w)
-    (RSA.speaker_apply_singleton_ne_zero
-      (show _ ≠ ⊥ by
-        rw [RSA.utility, EReal.coe_zero, sub_zero]
-        exact RSA.coe_mul_log_ne_bot (by norm_num) (L0_ne_zero h))
-      fun x => by
-        rw [RSA.utility, EReal.coe_zero, sub_zero]
-        exact RSA.coe_mul_log_ne_top (by norm_num)
-          (RSA.literalListener_apply_ne_top prior _ x {w}))
+    (prior_singleton_ne_zero w) (gi.toKernel_apply_ne_zero h)
 
-theorem gi_marg_ss : ((giSpeaker ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
+theorem gi_marg_ss : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   gi_marg .ss (w := wNS) (by decide)
 
-theorem gi_marg_aa : ((giSpeaker ∘ₘ prior).map Prod.fst) {Utterance.aa} ≠ 0 :=
-  gi_marg .aa (w := wA) (by decide)
-
-theorem gi_marg_as : ((giSpeaker ∘ₘ prior).map Prod.fst) {Utterance.as} ≠ 0 :=
+theorem gi_marg_as : ((gi.toKernel ∘ₘ prior).map Prod.fst) {Utterance.as} ≠ 0 :=
   gi_marg .as (w := wS) (by decide)
 
-theorem li_marg_ss : ((liSpeaker ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
+theorem li_marg_ss : ((li.toKernel ∘ₘ prior).map Prod.fst) {Utterance.ss} ≠ 0 :=
   map_fst_comp_apply_singleton_ne_zero _ _ (θ := LIParse.lit)
     (prior_singleton_ne_zero wNS)
-    (RSA.speaker_apply_singleton_ne_zero
-      (show _ ≠ ⊥ by
-        rw [RSA.utility, EReal.coe_zero, sub_zero]
-        exact RSA.coe_mul_log_ne_bot (by norm_num) (L0_ne_zero (p := ∅) (by decide)))
-      fun x => by
-        rw [RSA.utility, EReal.coe_zero, sub_zero]
-        exact RSA.coe_mul_log_ne_top (by norm_num)
-          (RSA.literalListener_apply_ne_top prior _ x {wNS}))
+    (li.toKernel_apply_ne_zero (show exhMeaning ∅ .ss wNS by decide))
 
 theorem luPrior_singleton_ne_zero (s : World × LULex) : luPrior {s} ≠ 0 := by
   rw [luPrior, uniformOn_univ, Measure.count_singleton, ne_eq, ENNReal.div_eq_zero_iff]
@@ -602,21 +572,21 @@ private theorem rpow_two (r : ℝ) : r ^ (2 : ℝ) = r ^ 2 := by
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) from by norm_num, Real.rpow_natCast]
 
 private theorem vanillaS_real (w : World) (u : Utterance) :
-    (vanillaSpeaker w).real {u}
+    (vanilla.toKernel w).real {u}
       = (L0 ∅ u {w}).toReal ^ (2 : ℝ) / ∑ u', (L0 ∅ u' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton (by norm_num) (L0 ∅)
+  RSA.speaker_utility_zero_real_singleton vanilla.α_pos.le (L0 ∅)
     (fun u' => RSA.literalListener_apply_ne_top prior _ u' {w}) u
 
 private theorem giS_real (w : World) (x : Utterance × Parse) :
-    (giSpeaker w).real {x}
-      = (giL0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (giL0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton (by norm_num) giL0
+    (gi.toKernel w).real {x}
+      = (gi.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (gi.L0 x' {w}).toReal ^ (2 : ℝ) :=
+  RSA.speaker_utility_zero_real_singleton gi.α_pos.le gi.L0
     (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem liS_real (w : World) (x : Utterance × LIParse) :
-    (liSpeaker w).real {x}
-      = (liL0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (liL0 x' {w}).toReal ^ (2 : ℝ) :=
-  RSA.speaker_utility_zero_real_singleton (by norm_num) liL0
+    (li.toKernel w).real {x}
+      = (li.L0 x {w}).toReal ^ (2 : ℝ) / ∑ x', (li.L0 x' {w}).toReal ^ (2 : ℝ) :=
+  RSA.speaker_utility_zero_real_singleton li.α_pos.le li.L0
     (fun x' => RSA.literalListener_apply_ne_top prior _ x' {w}) x
 
 private theorem luS_real (s : World × LULex) (u : Utterance) :
@@ -656,49 +626,49 @@ private theorem zGI (w : World) (z : ℝ)
     (h : (∑ u : Utterance, ∑ p : Parse,
         (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
          else 0) ^ 2) = z) :
-    (∑ x : Utterance × Parse, (giL0 x {w}).toReal ^ 2) = z := by
+    (∑ x : Utterance × Parse, (gi.L0 x {w}).toReal ^ 2) = z := by
   rw [Fintype.sum_prod_type]
   simp_rw [giL0_toReal]
   exact h
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wN : (∑ x : Utterance × Parse, (giL0 x {wN}).toReal ^ 2) = 307 / 24 :=
+private theorem zGI_wN : (∑ x : Utterance × Parse, (gi.L0 x {wN}).toReal ^ 2) = 307 / 24 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNS : (∑ x : Utterance × Parse, (giL0 x {wNS}).toReal ^ 2) = 23 / 6 :=
+private theorem zGI_wNS : (∑ x : Utterance × Parse, (gi.L0 x {wNS}).toReal ^ 2) = 23 / 6 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNA : (∑ x : Utterance × Parse, (giL0 x {wNA}).toReal ^ 2) = 23 / 9 :=
+private theorem zGI_wNA : (∑ x : Utterance × Parse, (gi.L0 x {wNA}).toReal ^ 2) = 23 / 9 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wNSA : (∑ x : Utterance × Parse, (giL0 x {wNSA}).toReal ^ 2) = 157 / 72 :=
+private theorem zGI_wNSA : (∑ x : Utterance × Parse, (gi.L0 x {wNSA}).toReal ^ 2) = 157 / 72 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wS : (∑ x : Utterance × Parse, (giL0 x {wS}).toReal ^ 2) = 559 / 72 :=
+private theorem zGI_wS : (∑ x : Utterance × Parse, (gi.L0 x {wS}).toReal ^ 2) = 559 / 72 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wSA : (∑ x : Utterance × Parse, (giL0 x {wSA}).toReal ^ 2) = 10 / 3 :=
+private theorem zGI_wSA : (∑ x : Utterance × Parse, (gi.L0 x {wSA}).toReal ^ 2) = 10 / 3 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zGI_wA : (∑ x : Utterance × Parse, (giL0 x {wA}).toReal ^ 2) = 229 / 24 :=
+private theorem zGI_wA : (∑ x : Utterance × Parse, (gi.L0 x {wA}).toReal ^ 2) = 229 / 24 :=
   zGI _ _ (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
@@ -744,25 +714,25 @@ private theorem zLI (w : World) (z : ℝ)
         (if exhMeaning l.toParse u w
           then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
          else 0) ^ 2) = z) :
-    (∑ x : Utterance × LIParse, (liL0 x {w}).toReal ^ 2) = z := by
+    (∑ x : Utterance × LIParse, (li.L0 x {w}).toReal ^ 2) = z := by
   rw [Fintype.sum_prod_type]
   simp_rw [liL0_toReal]
   exact h
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wNS : (∑ x : Utterance × LIParse, (liL0 x {wNS}).toReal ^ 2) = 53 / 48 :=
+private theorem zLI_wNS : (∑ x : Utterance × LIParse, (li.L0 x {wNS}).toReal ^ 2) = 53 / 48 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wNA : (∑ x : Utterance × LIParse, (liL0 x {wNA}).toReal ^ 2) = 19 / 18 :=
+private theorem zLI_wNA : (∑ x : Utterance × LIParse, (li.L0 x {wNA}).toReal ^ 2) = 19 / 18 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
 set_option maxRecDepth 8192 in
-private theorem zLI_wS : (∑ x : Utterance × LIParse, (liL0 x {wS}).toReal ^ 2) = 461 / 144 :=
+private theorem zLI_wS : (∑ x : Utterance × LIParse, (li.L0 x {wS}).toReal ^ 2) = 461 / 144 :=
   zLI _ _ (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
@@ -770,27 +740,30 @@ private theorem zLI_wS : (∑ x : Utterance × LIParse, (liL0 x {wS}).toReal ^ 2
 /-! ### Listener-preference reductions -/
 
 private theorem gi_fst_lt {u : Utterance}
-    (hx : ((giSpeaker ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ p : Parse, prior.real {w₁} * (giSpeaker w₁).real {(u, p)})
-        < ∑ p : Parse, prior.real {w₂} * (giSpeaker w₂).real {(u, p)}) :
-    ((giListener u).fst).real {w₁} < ((giListener u).fst).real {w₂} := by
-  rw [giListener, jointPosterior_fst_real_lt_iff giSpeaker prior hx]
+    (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
+    (h : (∑ p : Parse, prior.real {w₁} * (gi.toKernel w₁).real {(u, p)})
+        < ∑ p : Parse, prior.real {w₂} * (gi.toKernel w₂).real {(u, p)}) :
+    ((gi.jointListener u).fst).real {w₁} < ((gi.jointListener u).fst).real {w₂} := by
+  unfold RSA.Speaker.jointListener
+  rw [jointPosterior_fst_real_lt_iff gi.toKernel gi.prior hx]
   exact h
 
 private theorem gi_snd_lt {u : Utterance}
-    (hx : ((giSpeaker ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
-    (h : (∑ w : World, prior.real {w} * (giSpeaker w).real {(u, p₁)})
-        < ∑ w : World, prior.real {w} * (giSpeaker w).real {(u, p₂)}) :
-    ((giListener u).snd).real {p₁} < ((giListener u).snd).real {p₂} := by
-  rw [giListener, jointPosterior_snd_real_lt_iff giSpeaker prior hx]
+    (hx : ((gi.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {p₁ p₂ : Parse}
+    (h : (∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₁)})
+        < ∑ w : World, prior.real {w} * (gi.toKernel w).real {(u, p₂)}) :
+    ((gi.jointListener u).snd).real {p₁} < ((gi.jointListener u).snd).real {p₂} := by
+  unfold RSA.Speaker.jointListener
+  rw [jointPosterior_snd_real_lt_iff gi.toKernel gi.prior hx]
   exact h
 
 private theorem li_fst_lt {u : Utterance}
-    (hx : ((liSpeaker ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
-    (h : (∑ l : LIParse, prior.real {w₁} * (liSpeaker w₁).real {(u, l)})
-        < ∑ l : LIParse, prior.real {w₂} * (liSpeaker w₂).real {(u, l)}) :
-    ((liListener u).fst).real {w₁} < ((liListener u).fst).real {w₂} := by
-  rw [liListener, jointPosterior_fst_real_lt_iff liSpeaker prior hx]
+    (hx : ((li.toKernel ∘ₘ prior).map Prod.fst) {u} ≠ 0) {w₁ w₂ : World}
+    (h : (∑ l : LIParse, prior.real {w₁} * (li.toKernel w₁).real {(u, l)})
+        < ∑ l : LIParse, prior.real {w₂} * (li.toKernel w₂).real {(u, l)}) :
+    ((li.jointListener u).fst).real {w₁} < ((li.jointListener u).fst).real {w₂} := by
+  unfold RSA.Speaker.jointListener
+  rw [jointPosterior_fst_real_lt_iff li.toKernel li.prior hx]
   exact h
 
 private theorem lu_fst_lt {u : Utterance}
@@ -801,12 +774,13 @@ private theorem lu_fst_lt {u : Utterance}
   rw [luListener, posterior_fst_real_lt_iff luSpeaker luPrior hx]
   exact h
 
-private theorem vanilla_lt {u : Utterance} (hx : (vanillaSpeaker ∘ₘ prior) {u} ≠ 0)
+private theorem vanilla_lt {u : Utterance} (hx : (vanilla.toKernel ∘ₘ prior) {u} ≠ 0)
     {w₁ w₂ : World}
-    (h : prior.real {w₁} * (vanillaSpeaker w₁).real {u}
-        < prior.real {w₂} * (vanillaSpeaker w₂).real {u}) :
-    (vanillaListener u).real {w₁} < (vanillaListener u).real {w₂} := by
-  rw [vanillaListener, posterior_real_singleton_lt_iff vanillaSpeaker prior hx]
+    (h : prior.real {w₁} * (vanilla.toKernel w₁).real {u}
+        < prior.real {w₂} * (vanilla.toKernel w₂).real {u}) :
+    (vanilla.listener u).real {w₁} < (vanilla.listener u).real {w₂} := by
+  unfold RSA.Speaker.listener
+  rw [posterior_real_singleton_lt_iff vanilla.toKernel vanilla.prior hx]
   exact h
 
 private theorem luPrior_real_singleton (s : World × LULex) : luPrior.real {s} = 14⁻¹ := by
@@ -820,77 +794,77 @@ Each finding compares two pooled speaker masses; naming their values keeps
 the findings two-line. -/
 
 private theorem giPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × Parse, (giL0 x {w}).toReal ^ 2) = z)
+    (hz : (∑ x : Utterance × Parse, (gi.L0 x {w}).toReal ^ 2) = z)
     (h : (∑ p : Parse,
         (if exhMeaning p u w then ((Finset.univ.filter (exhMeaning p u)).card : ℝ)⁻¹
          else 0) ^ 2 / z) = v) :
-    (∑ p : Parse, (giSpeaker w).real {(u, p)}) = v := by
+    (∑ p : Parse, (gi.toKernel w).real {(u, p)}) = v := by
   simp_rw [giS_real, rpow_two, hz, giL0_toReal]
   exact h
 
-private theorem giPool_ss_wNS : (∑ p : Parse, (giSpeaker wNS).real {(.ss, p)}) = 5 / 12 :=
+private theorem giPool_ss_wNS : (∑ p : Parse, (gi.toKernel wNS).real {(.ss, p)}) = 5 / 12 :=
   giPool _ _ _ _ zGI_wNS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_ss_wNA : (∑ p : Parse, (giSpeaker wNA).real {(.ss, p)}) = 9 / 92 :=
+private theorem giPool_ss_wNA : (∑ p : Parse, (gi.toKernel wNA).real {(.ss, p)}) = 9 / 92 :=
   giPool _ _ _ _ zGI_wNA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem giPool_ss_wNSA :
-    (∑ p : Parse, (giSpeaker wNSA).real {(.ss, p)}) = 43 / 157 :=
+    (∑ p : Parse, (gi.toKernel wNSA).real {(.ss, p)}) = 43 / 157 :=
   giPool _ _ _ _ zGI_wNSA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_ss_wS : (∑ p : Parse, (giSpeaker wS).real {(.ss, p)}) = 11 / 559 :=
+private theorem giPool_ss_wS : (∑ p : Parse, (gi.toKernel wS).real {(.ss, p)}) = 11 / 559 :=
   giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_as_wS : (∑ p : Parse, (giSpeaker wS).real {(.as, p)}) = 340 / 559 :=
+private theorem giPool_as_wS : (∑ p : Parse, (gi.toKernel wS).real {(.as, p)}) = 340 / 559 :=
   giPool _ _ _ _ zGI_wS (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem giPool_as_wA : (∑ p : Parse, (giSpeaker wA).real {(.as, p)}) = 16 / 687 :=
+private theorem giPool_as_wA : (∑ p : Parse, (gi.toKernel wA).real {(.as, p)}) = 16 / 687 :=
   giPool _ _ _ _ zGI_wA (by norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton])
 
 private theorem liPool (u : Utterance) (w : World) (z v : ℝ)
-    (hz : (∑ x : Utterance × LIParse, (liL0 x {w}).toReal ^ 2) = z)
+    (hz : (∑ x : Utterance × LIParse, (li.L0 x {w}).toReal ^ 2) = z)
     (h : (∑ l : LIParse,
         (if exhMeaning l.toParse u w
           then ((Finset.univ.filter (exhMeaning l.toParse u)).card : ℝ)⁻¹
          else 0) ^ 2 / z) = v) :
-    (∑ l : LIParse, (liSpeaker w).real {(u, l)}) = v := by
+    (∑ l : LIParse, (li.toKernel w).real {(u, l)}) = v := by
   simp_rw [liS_real, rpow_two, hz, liL0_toReal]
   exact h
 
-private theorem liPool_ss_wNS : (∑ l : LIParse, (liSpeaker wNS).real {(.ss, l)}) = 15 / 53 :=
+private theorem liPool_ss_wNS : (∑ l : LIParse, (li.toKernel wNS).real {(.ss, l)}) = 15 / 53 :=
   liPool _ _ _ _ zLI_wNS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem liPool_ss_wNA : (∑ l : LIParse, (liSpeaker wNA).real {(.ss, l)}) = 5 / 38 :=
+private theorem liPool_ss_wNA : (∑ l : LIParse, (li.toKernel wNA).real {(.ss, l)}) = 5 / 38 :=
   liPool _ _ _ _ zLI_wNA (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem liPool_ss_wS : (∑ l : LIParse, (liSpeaker wS).real {(.ss, l)}) = 13 / 461 :=
+private theorem liPool_ss_wS : (∑ l : LIParse, (li.toKernel wS).real {(.ss, l)}) = 13 / 461 :=
   liPool _ _ _ _ zLI_wS (by norm_num +decide [rpow_two, univU, univLI, LIParse.toParse, univW,
     Finset.sum_insert, Finset.sum_singleton, Finset.filter_insert,
     Finset.filter_singleton, Finset.card_insert_of_notMem, Finset.card_singleton])
 
-private theorem vanS_ss_wNS : (vanillaSpeaker wNS).real {Utterance.ss} = 4 / 29 := by
+private theorem vanS_ss_wNS : (vanilla.toKernel wNS).real {Utterance.ss} = 4 / 29 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNS, L0_toReal]
   norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
     Finset.card_insert_of_notMem, Finset.card_singleton]
 
-private theorem vanS_ss_wNA : (vanillaSpeaker wNA).real {Utterance.ss} = 2 / 11 := by
+private theorem vanS_ss_wNA : (vanilla.toKernel wNA).real {Utterance.ss} = 2 / 11 := by
   simp_rw [vanillaS_real, rpow_two, zVan_wNA, L0_toReal]
   norm_num +decide [rpow_two, univU, univP, univW, Finset.sum_insert,
     Finset.sum_singleton, Finset.filter_insert, Finset.filter_singleton,
@@ -918,52 +892,30 @@ private theorem luPool_ss_wNA :
 
 /-- SS exhaustifies the inner quantifier: GI's listener prefers wNS to wNSA. -/
 theorem ss_inner_exh :
-    ((giListener .ss).fst).real {wNSA} < ((giListener .ss).fst).real {wNS} :=
+    ((gi.jointListener .ss).fst).real {wNSA} < ((gi.jointListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNSA, giPool_ss_wNS]
     norm_num)
 
 /-- SS exhaustifies the outer quantifier: GI's listener prefers wNS to wS. -/
 theorem ss_outer_exh :
-    ((giListener .ss).fst).real {wS} < ((giListener .ss).fst).real {wNS} :=
+    ((gi.jointListener .ss).fst).real {wS} < ((gi.jointListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wS, giPool_ss_wNS]
     norm_num)
 
-/-- AA identifies the unique world where all aliens drank all: at wSA the
-utterance is false under every parse, so its pooled mass vanishes; at wA any
-parse gives an applicable pair. Structural — no masses computed. -/
+/-- AA identifies the unique world where all aliens drank all: AA is false at
+wSA under every parse (Table 1's AA row) and true at wA under the bare parse.
+Purely structural — no masses computed. -/
 theorem aa_identifies :
-    ((giListener .aa).fst).real {wSA} < ((giListener .aa).fst).real {wA} :=
-  gi_fst_lt gi_marg_aa <| by
-    have hzero : ∀ p : Parse, (giSpeaker wSA).real {(.aa, p)} = 0 := fun p =>
-      RSA.speaker_real_singleton_eq_zero (by
-        rw [RSA.utility, EReal.coe_zero, sub_zero,
-          show giL0 (.aa, p) {wSA} = 0 from
-            RSA.literalListener_apply_singleton_of_not_mem prior _ fun h =>
-              absurd ((table1_aa p wSA).mp h) (by decide),
-          ENNReal.log_zero]
-        exact EReal.mul_bot_of_pos (by norm_num))
-    calc ∑ p : Parse, prior.real {wSA} * (giSpeaker wSA).real {(.aa, p)}
-        = 0 := by simp [hzero]
-      _ < ∑ p : Parse, prior.real {wA} * (giSpeaker wA).real {(.aa, p)} :=
-          Finset.sum_pos'
-            (fun p _ => mul_nonneg measureReal_nonneg measureReal_nonneg)
-            ⟨∅, Finset.mem_univ _,
-              mul_pos (by rw [prior_real_singleton]; norm_num)
-                (RSA.speaker_real_singleton_pos
-                  (by
-                    rw [RSA.utility, EReal.coe_zero, sub_zero]
-                    exact RSA.coe_mul_log_ne_bot (by norm_num)
-                      (L0_ne_zero (p := ∅) (by decide)))
-                  fun x => by
-                    rw [RSA.utility, EReal.coe_zero, sub_zero]
-                    exact RSA.coe_mul_log_ne_top (by norm_num)
-                      (RSA.literalListener_apply_ne_top prior _ x {wA}))⟩
+    ((gi.jointListener .aa).fst).real {wSA} < ((gi.jointListener .aa).fst).real {wA} :=
+  gi.jointListener_fst_real_lt_of_support
+    (show ∀ p, ¬ exhMeaning p .aa wSA by decide)
+    ⟨∅, show exhMeaning ∅ .aa wA by decide⟩
 
 /-- AS exhaustifies the inner quantifier: GI's listener prefers wS to wA. -/
 theorem as_inner_exh :
-    ((giListener .as).fst).real {wA} < ((giListener .as).fst).real {wS} :=
+    ((gi.jointListener .as).fst).real {wA} < ((gi.jointListener .as).fst).real {wS} :=
   gi_fst_lt gi_marg_as (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_as_wA, giPool_as_wS]
     norm_num)
@@ -973,7 +925,7 @@ set_option maxRecDepth 8192 in
 uniquely identifies wNS (eq. 22). Pair choice drives this: under per-parse
 normalization M would not dominate. -/
 theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
-    ((giListener .ss).snd).real {p} < ((giListener .ss).snd).real {{.matrix}} := by
+    ((gi.jointListener .ss).snd).real {p} < ((gi.jointListener .ss).snd).real {{.matrix}} := by
   intro p hp
   have hmem : p ∈ ({∅, {.matrix}, {.outer}, {.inner}, {.matrix, .outer}, {.matrix, .inner},
       {.outer, .inner}, {.matrix, .outer, .inner}} : Finset Parse) :=
@@ -993,14 +945,14 @@ theorem ss_m_parse_pref : ∀ p : Parse, p ≠ {.matrix} →
 /-- Vanilla RSA hearing SS prefers wNA to wNS — the wrong prediction (the
 cost-free illustration of eq. 10; the direction reverses at the fitted cost). -/
 theorem vanilla_ss_prefers_wNA :
-    (vanillaListener .ss).real {wNS} < (vanillaListener .ss).real {wNA} :=
+    (vanilla.listener .ss).real {wNS} < (vanilla.listener .ss).real {wNA} :=
   vanilla_lt vanilla_marg_ss (by
     simp_rw [prior_real_singleton, vanS_ss_wNS, vanS_ss_wNA]
     norm_num)
 
 /-- GI corrects vanilla's error: SS → wNS, not wNA. -/
 theorem gi_ss_prefers_wNS :
-    ((giListener .ss).fst).real {wNA} < ((giListener .ss).fst).real {wNS} :=
+    ((gi.jointListener .ss).fst).real {wNA} < ((gi.jointListener .ss).fst).real {wNS} :=
   gi_fst_lt gi_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, giPool_ss_wNA, giPool_ss_wNS]
     norm_num)
@@ -1015,14 +967,14 @@ theorem lu_ss_prefers_wNS :
 
 /-- LI derives outer exhaustification for SS: wNS over wS via the OI parse. -/
 theorem li_ss_outer_exh :
-    ((liListener .ss).fst).real {wS} < ((liListener .ss).fst).real {wNS} :=
+    ((li.jointListener .ss).fst).real {wS} < ((li.jointListener .ss).fst).real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wS, liPool_ss_wNS]
     norm_num)
 
 /-- LI also gets the wNS-over-wNA ordering that vanilla misses. -/
 theorem li_ss_prefers_wNS :
-    ((liListener .ss).fst).real {wNA} < ((liListener .ss).fst).real {wNS} :=
+    ((li.jointListener .ss).fst).real {wNA} < ((li.jointListener .ss).fst).real {wNS} :=
   li_fst_lt li_marg_ss (by
     simp_rw [prior_real_singleton, ← Finset.mul_sum, liPool_ss_wNA, liPool_ss_wNS]
     norm_num)

--- a/Linglib/Studies/FrankeBergen2020.lean
+++ b/Linglib/Studies/FrankeBergen2020.lean
@@ -19,8 +19,8 @@ the parse enters the speaker: vanilla (§3.1) has only the literal parse; LU
 of the speaker (eq. 11) and a latent the listener marginalizes
 ([bergen-levy-goodman-2016], [potts-etal-2016]); the LI (§3.3) and GI (§3.4)
 speakers instead *choose* an (utterance, parse) pair (eqs. 18a/21a), over the
-4 matrix-free parses resp. all 8 — one softmax over pairs per world, read by
-`ProbabilityTheory.jointPosterior`.
+4 matrix-free parses resp. all 8 — one softmax over pairs per world, heard
+through the `RSA.Scenario` observation map.
 
 We show that GI corrects the SS interpretation vanilla gets wrong
 (`vanilla_ss_prefers_wNA` vs `gi_ss_prefers_wNS`), and that its parse
@@ -46,15 +46,17 @@ LI and LU still derive the embedded enrichments (`li_ss_outer_exh`,
 Sentential alternatives (A3a) range over a fourth quantifier `notAll` that is
 never an utterance — the paper's grammatical-vs-utterance alternatives
 distinction (its comparison with [gotzner-romoli-2018]'s alternative set
-favors this one by a Bayes factor of ~1,530). We fix α = 2 and omit the
-paper's cost term for *none*-initial utterances and fixed error ε = 0.045
-(eqs. 25–28); each finding except `vanilla_ss_prefers_wNA` is robust to this.
-The paper's S2/L2 layer for LU ([lassiter-goodman-2017], eqs. 14a–14b) is
-also omitted: our L1-only LU keeps wNS over wNA, though the paper's LU-L2
-concentrates on wNSA (eq. 15). The model lives on mathlib's probability API:
-`uniformOn` priors, `ProbabilityTheory.cond` literal listeners, softmax
-kernels, and posterior kernels; predictions are stated on `Measure.real` and
-close by partition-value rewrites plus `norm_num`.
+favors this one by a Bayes factor of ~1,530). Each model is an
+`RSA.Scenario` (LU a `RSA.Scenario.familySpeaker` family) with rationality a
+parameter, and each finding's docstring names its register: support facts
+and `Multiset.Dominates` certificates hold for every rationality `α > 0`;
+genuinely α-dependent findings are evaluated at the paper's illustrative
+α = 5 via `Multiset.invPowSum` profiles. We omit the paper's cost term for
+*none*-initial utterances and fixed error ε = 0.045 (eqs. 25–28);
+`vanilla_ss_prefers_wNA` reverses at the fitted cost. The paper's S2/L2
+layer for LU ([lassiter-goodman-2017], eqs. 14a–14b) is also omitted: our
+L1-only LU keeps wNS over wNA, though the paper's LU-L2 concentrates on
+wNSA (eq. 15).
 -/
 
 namespace FrankeBergen2020


### PR DESCRIPTION
Compression pass on the exemplar (re-landed truth-table commit stranded from #1761 plus the findings layer): Table 1 becomes one total characterization per utterance — all 72 cells, row-groups as guards — replacing 21 sampled row-theorems; a pooled-speaker-mass value layer (`giPool_ss_wNS : … = 5/12` etc.) absorbs the evaluation machinery once, so each finding closes by citing its two masses plus `norm_num`.