### PR TITLE
refactor(Syntax/Control): Landau signature API, dissolve profiles

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2845,6 +2845,7 @@ import Linglib.Syntax.ConstructionGrammar.Licensing
 import Linglib.Syntax.ConstructionGrammar.Resultatives
 import Linglib.Syntax.Control.Basic
 import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Control.Signature
 import Linglib.Syntax.Coordination
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Syntax.DependencyGrammar.Coordination

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -7,6 +7,7 @@ import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Control.Basic
 import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Control.Signature
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Features.Complementation
@@ -37,15 +38,15 @@ open Minimalist Minimalist.MinimalPronoun Control Ga
 
 /-! ### OC by clause type -/
 
-/-- The OC signature of a Gã clause type, from its noncoreference flag
-    (the derivation `Ostrove2026.smpmOCSignature` also uses). -/
-def gaOCSignature (c : EmbeddedClauseType) : OCSignature :=
+/-- The control signature of a Gã clause type, from its noncoreference
+    flag (the derivation `Ostrove2026.smpmSignature` also uses). -/
+def gaSignature (c : EmbeddedClauseType) : Signature :=
   .ofNoncoreferential (clauseProperties c).noncoreferentialSubject
 
 /-- OC status is read off the complementizer's finiteness. -/
-theorem isOC_eq_not_isFinite (c : EmbeddedClauseType) :
-    (gaOCSignature c).isOC = !(clauseComplementizer c).isFinite := by
-  cases c <;> rfl
+theorem obligatory_iff_not_isFinite (c : EmbeddedClauseType) :
+    (gaSignature c).Obligatory ↔ (clauseComplementizer c).isFinite = false := by
+  cases c <;> decide
 
 /-- A verb has a `ni`-frame exactly when it is a control verb (§§3.4–3.5,
     5.5.1). -/
@@ -55,9 +56,9 @@ theorem control_iff_selects_ni :
 
 /-! ### Table 2: the overt pronoun has the OC signature -/
 
-/-- The eight diagnostic properties of [allotey-2021]'s Table 2
-    ([landau-2013]'s OC diagnostics, §§3.3–3.4). -/
-inductive OCDiagnostic where
+/-- The eight rows of [allotey-2021]'s Table 2 ([landau-2013]'s OC
+    criteria, §§3.3–3.4). -/
+inductive Table2Row where
   /-- Must be c-commanded by its antecedent (exx 45–46) -/
   | cCommandedByAntecedent
   /-- Allows a long-distance antecedent (exx 47–49) -/
@@ -76,29 +77,32 @@ inductive OCDiagnostic where
   | objectControl
   deriving DecidableEq, Repr
 
-/-- The Table 2 column an OC signature predicts over a control-verb
-    inventory: codependency forces a local c-commanding antecedent and
-    excludes long-distance ones; variable binding forces bound-variable,
-    sloppy-only, φ-covarying, *de se* readings ([chierchia-1990]); the
-    two control rows read the inventory. -/
-def predictedColumn (sig : OCSignature) (verbs : List CTP) : OCDiagnostic → Bool
-  | .cCommandedByAntecedent => sig.controllerCodependent
-  | .longDistanceAntecedent => !sig.controllerCodependent
-  | .sloppyOnly             => sig.boundVariable
-  | .boundVariable          => sig.boundVariable
+/-- The Table 2 column predicted by a control signature, a tier, and a
+    control-verb inventory: the antecedence and reading rows are the
+    criteria the signature excludes (`Signature.admits`); *de se* is a
+    tier property, not signature content ([landau-2013] §1.3;
+    [chierchia-1990]); φ-covariance is feature transmission under
+    binding; the two control rows read the inventory. -/
+def predictedColumn (sig : Signature) (tier : Tier) (verbs : List CTP) :
+    Table2Row → Bool
+  | .cCommandedByAntecedent => !sig.admits .nonCCommandingControl
+  | .longDistanceAntecedent => sig.admits .longDistanceControl
+  | .sloppyOnly             => !sig.admits .strictEllipsis
+  | .boundVariable          => !sig.admits .strictUnderOnly
   | .hasPhiFeatures         => sig.boundVariable
-  | .obligatoryDeSe         => sig.boundVariable
+  | .obligatoryDeSe         => tier.obligatoryDeSe
   | .subjectControl         => verbs.any (·.control == .subjectControl)
   | .objectControl          => verbs.any (·.control == .objectControl)
 
 /-- Table 2's observed overt-pronoun column (§§3.3.1–3.3.7, 3.4). -/
-def overtPronoun (d : OCDiagnostic) : Bool :=
+def overtPronoun (d : Table2Row) : Bool :=
   d != .longDistanceAntecedent
 
-/-- The observed column is what the `ni`-clause OC signature predicts
-    over the attested inventory (§3.7). -/
+/-- The observed column is what the `ni`-clause signature predicts over
+    the attested inventory, on the logophoric tier of the attitude
+    verbs the *de se* test uses (ex 53 'expect'). -/
 theorem overt_pronoun_matches_pro :
-    overtPronoun = predictedColumn (gaOCSignature .irrealisNi) gaCTPs := by
+    overtPronoun = predictedColumn (gaSignature .irrealisNi) .logophoric gaCTPs := by
   funext d; cases d <;> decide
 
 /-! ### The irrealis marker across complement frames
@@ -163,8 +167,8 @@ theorem ga_no_fSubjunctive (c : EmbeddedClauseType) :
     the one position that reads Agr, and has no φ-agreement anyway
     (§4.4, exx 79–81; §6.1). -/
 theorem landau_predicts_control (c : EmbeddedClauseType) (agr : Bool) :
-    (gaOCSignature c).isOC = (gaToLandau c).hasOCWithAgr agr := by
-  cases c <;> cases agr <;> rfl
+    (gaSignature c).Obligatory ↔ (gaToLandau c).hasOCWithAgr agr = true := by
+  cases c <;> cases agr <;> decide
 
 /-! ### Long-Distance Agree and CP strength
 
@@ -191,9 +195,9 @@ theorem ldaReaches_eq_not_isFinite (c : Complementizer) :
   cases c <;> rfl
 
 /-- The probe reaches the embedded subject in exactly the OC clause types. -/
-theorem ldaReaches_eq_isOC (c : EmbeddedClauseType) :
-    ldaReaches (clauseComplementizer c) = (gaOCSignature c).isOC := by
-  cases c <;> rfl
+theorem ldaReaches_iff_obligatory (c : EmbeddedClauseType) :
+    ldaReaches (clauseComplementizer c) = true ↔ (gaSignature c).Obligatory := by
+  cases c <;> decide
 
 /-- `ni` projects no focus field; the finite complementizers do
     (exx 107–108). -/

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -8,6 +8,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.Mixtec.SMPM.Basic
 import Linglib.Syntax.Control.Basic
 import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Control.Signature
 import Linglib.Studies.Allotey2021
 import Linglib.Features.Complementation
 
@@ -98,10 +99,10 @@ theorem finite_no_restructuring :
 -- § 2: OC Diagnostics (§4)
 -- ════════════════════════════════════════════════════════════════
 
-/-- OC signature for each SMPM clause type, derived from
+/-- The control signature of each SMPM clause type, from
     `clauseProperties.noncoreferentialSubject` via
-    `OCSignature.ofNoncoreferential` — the same derivation
-    `Allotey2021.gaOCSignature` uses for Gã.
+    `Signature.ofNoncoreferential` — the same derivation
+    `Allotey2021.gaSignature` uses for Gã.
 
     Untensed subjunctives show the full OC signature (§4):
     - Sloppy-only under VPE (33)
@@ -112,17 +113,17 @@ theorem finite_no_restructuring :
     these properties: they allow strict readings under VPE (30, 32),
     nonexhaustive binding (tensed subj., fn. 16), and non-local
     antecedents (43, 45). -/
-def smpmOCSignature (c : EmbeddedClauseType) : OCSignature :=
+def smpmSignature (c : EmbeddedClauseType) : Signature :=
   .ofNoncoreferential (clauseProperties c).noncoreferentialSubject
 
 theorem untensed_is_OC :
-    (smpmOCSignature .untensedSubjunctive).isOC = true := rfl
+    (smpmSignature .untensedSubjunctive).Obligatory := by decide
 
 theorem tensed_not_OC :
-    (smpmOCSignature .tensedSubjunctive).isOC = false := rfl
+    ¬(smpmSignature .tensedSubjunctive).Obligatory := by decide
 
 theorem finite_not_OC :
-    (smpmOCSignature .finiteEmbedded).isOC = false := rfl
+    ¬(smpmSignature .finiteEmbedded).Obligatory := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3: Wurmbrand Bridge (partial — subjunctives only)
@@ -151,15 +152,12 @@ def wurmbrandHasOC : InfinitivalTenseClass → Bool
   | .futureIrrealis => false
   | .propositional  => false
 
-/-- For the two Wurmbrand classes that have SMPM correspondents,
-    the mapping correctly predicts control properties. -/
-theorem wurmbrand_predicts_control_futureIrrealis :
-    (wurmbrandToSubjunctive .futureIrrealis).map (smpmOCSignature · |>.isOC)
-    = some (wurmbrandHasOC .futureIrrealis) := rfl
-
-theorem wurmbrand_predicts_control_restructuring :
-    (wurmbrandToSubjunctive .restructuring).map (smpmOCSignature · |>.isOC)
-    = some (wurmbrandHasOC .restructuring) := rfl
+/-- For the Wurmbrand classes with SMPM correspondents, the mapping
+    correctly predicts control properties. -/
+theorem wurmbrand_predicts_control (w : InfinitivalTenseClass) :
+    ∀ c ∈ wurmbrandToSubjunctive w,
+      ((smpmSignature c).Obligatory ↔ wurmbrandHasOC w = true) := by
+  cases w <;> decide
 
 /-- Propositional infinitives have no SMPM correspondent —
     SMPM finite embedded clauses are genuinely finite, not infinitival. -/
@@ -220,8 +218,9 @@ def smpmLandauAgr : Control.ClauseClass → Bool
     - F-subjunctive [+Agr]: logophoric OC blocked by Agr → no OC ✓
     - Finite [+Agr]: no control tier → no OC ✓ -/
 theorem landau_predicts_control (c : Control.ClauseClass) :
-    (smpmOCSignature (landauToSMPM c)).isOC = c.hasOCWithAgr (smpmLandauAgr c) := by
-  cases c <;> rfl
+    (smpmSignature (landauToSMPM c)).Obligatory ↔
+      c.hasOCWithAgr (smpmLandauAgr c) = true := by
+  cases c <;> decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5: Minimal Pronoun Inventories (§7)
@@ -369,20 +368,19 @@ theorem smpm_boundvar_syncretic :
     - Scope-sensitive pronominal (Italian, Hungarian): focus-triggered -/
 def smpmCopyControlType : CopyControlType := .obligatoryPronominal
 
-theorem smpm_shows_oc :
-    (copyControlProfile smpmCopyControlType).showsOC = true := rfl
+theorem smpm_shows_oc : smpmCopyControlType.showsOC = true := rfl
 
 theorem smpm_not_attitude_only :
-    (copyControlProfile smpmCopyControlType).attitudeOnly = false := rfl
+    smpmCopyControlType.attitudeOnly = false := rfl
 
 theorem smpm_no_scope_operator :
-    (copyControlProfile smpmCopyControlType).requiresScopeOperator = false := rfl
+    smpmCopyControlType.requiresScopeOperator = false := rfl
 
 /-- Controlled subjects in SMPM cannot bear focus — they must be
     clitic pronouns, and clitics cannot bear focus (65, 67). This
     distinguishes SMPM from scope-sensitive pronominal copy control. -/
 theorem smpm_copy_cannot_bear_focus :
-    (copyControlProfile smpmCopyControlType).copyCanBearFocus = false := rfl
+    smpmCopyControlType.copyCanBearFocus = false := rfl
 
 /-- The clitic requirement, derived from the fragment and routed through the
     Cardinaletti–Starke deficiency order: the required controlled-subject
@@ -397,20 +395,14 @@ theorem smpm_controlled_must_be_clitic :
 -- § 9: Exempt Anaphor Argument (§6)
 -- ════════════════════════════════════════════════════════════════
 
-/-- SMPM exempt anaphor profile, derived from fragment data.
-
-    Exempt anaphors (reflexive forms used as possessors, outside
-    Condition A domain) ARE available in SMPM (74) but CANNOT have
-    quantified antecedents (75, 78). -/
-def smpmExemptProfile : ExemptAnaphorProfile where
-  hasExemptAnaphors := Mixtec.SMPM.exemptAnaphorsAsPossessors
-  allowsQuantifiedAntecedent := Mixtec.SMPM.exemptAnaphorAllowsQuantifiedAntecedent
-
+/-- Exempt anaphors (reflexive forms used as possessors, outside the
+    Condition A domain) are available in SMPM (74). -/
 theorem smpm_has_exempt_anaphors :
-    smpmExemptProfile.hasExemptAnaphors = true := rfl
+    Mixtec.SMPM.exemptAnaphorsAsPossessors = true := rfl
 
+/-- SMPM exempt anaphors cannot have quantified antecedents (75, 78). -/
 theorem smpm_no_quantified_exempt :
-    smpmExemptProfile.allowsQuantifiedAntecedent = false := rfl
+    Mixtec.SMPM.exemptAnaphorAllowsQuantifiedAntecedent = false := rfl
 
 /-- **The argument against movement** (§6, pp.26–31):
 
@@ -550,8 +542,7 @@ theorem propAttitude_is_realis :
     proclitic showing the full OC signature ([allotey-2021]). -/
 def gaCopyControlType : CopyControlType := .obligatoryPronominal
 
-theorem ga_shows_oc :
-    (copyControlProfile gaCopyControlType).showsOC = true := rfl
+theorem ga_shows_oc : gaCopyControlType.showsOC = true := rfl
 
 /-- Gã and SMPM occupy the same copy-control cell. -/
 theorem ga_same_copy_type_as_smpm :

--- a/Linglib/Syntax/Control/Basic.lean
+++ b/Linglib/Syntax/Control/Basic.lean
@@ -26,8 +26,8 @@ for the paper-anchored control studies (`Studies/Landau2015.lean`,
 - `Control.PredicateClass`: the eight predicate classes, mapped to tiers
 - `Control.ClauseClass`: the finiteness scale (C-subjunctive,
   F-subjunctive, finite) with the Agr-sensitive `hasOCWithAgr`
-- `Control.ftAsymmetry`, `Control.agrBlocksControl`: the Feature
-  Transmission asymmetry and the OC-NC generalization derived from it
+- `Control.agrBlocksControl`: the OC-NC generalization, from the
+  Feature Transmission asymmetry
 -/
 
 namespace Control
@@ -138,39 +138,16 @@ def PredicateClass.tier : PredicateClass → Tier
   | .implicative | .aspectual | .modal | .evaluative => .predicative
   | .factive | .propositional | .desiderative | .interrogative => .logophoric
 
-/-! ### The Feature Transmission asymmetry and the OC-NC generalization -/
-
-/-- The Feature Transmission asymmetry ([landau-2015] (60)): predication
-    is not contingent on feature matching between subject and predicate
-    (60a), while variable binding is contingent on feature matching
-    between binder and pronominal variable (60b). Independently
-    motivated: predication tolerates φ-mismatches (Icelandic quirky
-    constructions), variable binding requires φ-agreement ([heim-2008],
-    [kratzer-2009]). -/
-structure FeatureTransmissionAsymmetry where
-  /-- (60a): Predication does NOT require feature matching. -/
-  predicationContingentOnFeatureMatch : Bool
-  /-- (60b): Variable binding DOES require feature matching. -/
-  variableBindingContingentOnFeatureMatch : Bool
-
-/-- The empirically motivated Feature Transmission asymmetry. -/
-def ftAsymmetry : FeatureTransmissionAsymmetry where
-  predicationContingentOnFeatureMatch := false
-  variableBindingContingentOnFeatureMatch := true
+/-! ### The OC-NC generalization -/
 
 /-- The OC-NC generalization ([landau-2015] (70)): `[+Agr]` blocks
-    logophoric control but not predicative control — derived from the
-    Feature Transmission asymmetry, not stipulated: predication is not
-    contingent on feature matching (60a), variable binding is (60b). -/
+    logophoric but not predicative control, by the Feature Transmission
+    asymmetry ((60): predication is not contingent on feature matching —
+    Icelandic quirky constructions — while variable binding is,
+    [heim-2008], [kratzer-2009]). -/
 def agrBlocksControl : Tier → Bool
-  | .predicative => ftAsymmetry.predicationContingentOnFeatureMatch
-  | .logophoric  => ftAsymmetry.variableBindingContingentOnFeatureMatch
-
-/-- Predicative control survives in inflected complements. -/
-theorem predicative_survives_agr : agrBlocksControl .predicative = false := rfl
-
-/-- Logophoric control is blocked by inflected complements. -/
-theorem logophoric_blocked_by_agr : agrBlocksControl .logophoric = true := rfl
+  | .predicative => false
+  | .logophoric  => true
 
 /-! ### Clause classes -/
 

--- a/Linglib/Syntax/Control/CopyControl.lean
+++ b/Linglib/Syntax/Control/CopyControl.lean
@@ -1,23 +1,27 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
 /-!
 # Copy Control and Control Derivation
 
 Copy control ([polinsky-potsdam-2006]): the subject of a control clause
 is a phonologically overt copy of its controller. The typology of copy
-types, the movement vs. base-generation opposition for deriving
-obligatory control, and the exempt-anaphor apparatus
-([pollard-sag-1992]) that adjudicates between them.
-
-Substrate for the overt-PRO studies (`Studies/Ostrove2026.lean`,
-`Studies/Allotey2021.lean`).
+types and the movement vs. base-generation opposition for deriving
+obligatory control, adjudicated by diagnostics such as exempt anaphora
+([pollard-sag-1992]: exempt anaphors cannot have quantified
+antecedents). Substrate for the overt-PRO studies
+(`Studies/Ostrove2026.lean`, `Studies/Allotey2021.lean`).
 
 ## Main definitions
 
-- `Control.CopyControlType` / `Control.copyControlProfile`: the four
-  copy-control types and their distinguishing properties
+- `Control.CopyControlType`: the four copy-control types, with their
+  distinguishing properties as predicates
 - `Control.Derivation`: base-generation vs. movement, with the
   diagnostic prediction table (`Derivation.predicts`) and the unique
   derivation an observation supports (`Derivation.supportedBy`)
-- `Control.ExemptAnaphorProfile`: per-language exempt-anaphor facts
 -/
 
 namespace Control
@@ -43,37 +47,26 @@ inductive CopyControlType where
   | obligatoryPronominal
   deriving DecidableEq, Repr
 
-/-- Properties distinguishing copy control types. -/
-structure CopyControlProfile where
-  controlType : CopyControlType
-  /-- Does the copy show the full OC signature (bound variable, exhaustive)? -/
-  showsOC : Bool
-  /-- Is the copy restricted to attitude report contexts? -/
-  attitudeOnly : Bool
-  /-- Does the copy require a scope-taking operator (focus, only)? -/
-  requiresScopeOperator : Bool
-  /-- Can the copy bear focus? -/
-  copyCanBearFocus : Bool
-  deriving DecidableEq, Repr
+/-- The copy shows the full OC signature (bound variable, exhaustive). -/
+def CopyControlType.showsOC : CopyControlType → Bool
+  | .obligatoryPronominal => true
+  | _                     => false
 
-/-- Profile for each copy control type. -/
-def copyControlProfile : CopyControlType → CopyControlProfile
-  | .fullCopy                 => ⟨.fullCopy,                 false, false, false, true⟩
-  | .logophoricPronominal     => ⟨.logophoricPronominal,     false, true,  false, true⟩
-  | .scopeSensitivePronominal => ⟨.scopeSensitivePronominal, false, false, true,  true⟩
-  | .obligatoryPronominal     => ⟨.obligatoryPronominal,     true,  false, false, false⟩
+/-- The copy is restricted to attitude-report contexts. -/
+def CopyControlType.attitudeOnly : CopyControlType → Bool
+  | .logophoricPronominal => true
+  | _                     => false
 
-/-! ### Exempt anaphors -/
+/-- The copy requires a scope-taking operator (focus, *only*). -/
+def CopyControlType.requiresScopeOperator : CopyControlType → Bool
+  | .scopeSensitivePronominal => true
+  | _                         => false
 
-/-- Exempt anaphors ([pollard-sag-1992]): reflexive forms used outside
-    their canonical binding (Condition A) domain. Key constraint: exempt
-    anaphors cannot have quantified antecedents. -/
-structure ExemptAnaphorProfile where
-  /-- Exempt anaphors available in this language -/
-  hasExemptAnaphors : Bool
-  /-- Can exempt anaphors have quantified antecedents? -/
-  allowsQuantifiedAntecedent : Bool
-  deriving DecidableEq, Repr
+/-- The copy can bear focus — obligatory pronominals, being the only
+    copy type showing true OC, cannot. -/
+def CopyControlType.copyCanBearFocus : CopyControlType → Bool
+  | .obligatoryPronominal => false
+  | _                     => true
 
 /-! ### Control derivation -/
 

--- a/Linglib/Syntax/Control/Signature.lean
+++ b/Linglib/Syntax/Control/Signature.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
+/-!
+# The Control Signature
+
+[landau-2013]'s OC signature ((74), §1.3): in a control construction,
+(a) the controller(s) must be co-dependent(s) of the clause, and (b)
+the controlled element (or part of it) must be interpreted as a bound
+variable. Constructions displaying both clauses are obligatory control;
+the mirror image — neither clause — is the NOC signature (§7.1). The
+familiar OC criteria are *derived*: co-dependence excludes arbitrary,
+long-distance, and non-c-commanding control and forces sloppy ellipsis
+readings; variable binding excludes strict readings under
+*only*-binding (`Signature.admits`).
+
+Deliberately absent, per §1.3: obligatory *de se* is NOT criterial for
+OC — it is a lexical property of attitude-implicating verbs
+(`Control.Tier.obligatoryDeSe`). Per §1.4, obligatory *nullness* of the
+controlled element is not criterial either — whether a language spells
+the controlled subject out is a vocabulary fact
+(`Minimalist.MinimalPronoun.MinPronInventory.controlForm`), independent
+of the signature; overt-PRO languages (Gã, SMPM) turn on exactly this
+separation.
+-/
+
+namespace Control
+
+/-- [landau-2013]'s control signature ((74)): is the controller a
+    co-dependent of the controlled clause, and is the controlled
+    element read as a bound variable? The co-dependence clause admits
+    implicit, split, and (via "part of it") partial control. -/
+structure Signature where
+  /-- (74a): the controller(s) must be co-dependent(s) of the clause. -/
+  controllerCodependent : Bool
+  /-- (74b): the controlled element is interpreted as a bound variable. -/
+  boundVariable : Bool
+  deriving DecidableEq, Repr
+
+namespace Signature
+
+variable {s : Signature}
+
+/-- Obligatory control: both clauses of the signature hold. -/
+def Obligatory (s : Signature) : Prop :=
+  s.controllerCodependent ∧ s.boundVariable
+
+instance : Decidable s.Obligatory :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Non-obligatory control, the signature's mirror image (§7.1):
+    neither clause holds. -/
+def NonObligatory (s : Signature) : Prop :=
+  ¬s.controllerCodependent ∧ ¬s.boundVariable
+
+instance : Decidable s.NonObligatory :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- The signature determined by whether a clause type licenses
+    noncoreferential subjects: free reference fails both clauses,
+    obligatory coreference forces both. -/
+def ofNoncoreferential (noncoreferential : Bool) : Signature :=
+  ⟨!noncoreferential, !noncoreferential⟩
+
+@[simp] theorem obligatory_ofNoncoreferential {b : Bool} :
+    (ofNoncoreferential b).Obligatory ↔ b = false := by
+  cases b <;> simp [ofNoncoreferential, Obligatory]
+
+/-- The configurations and readings whose availability separates OC
+    from NOC ([landau-2013] §1.3): each is excluded by a clause of the
+    signature and available under the NOC signature (§7.1). -/
+inductive Criterion where
+  /-- Arbitrary control ((75a)) -/
+  | arbitraryControl
+  /-- A long-distance controller ((75b)) -/
+  | longDistanceControl
+  /-- A non-c-commanding controller ((75c)) -/
+  | nonCCommandingControl
+  /-- A strict reading under ellipsis ((76)) -/
+  | strictEllipsis
+  /-- A strict (non-bound-variable) reading under *only*-binding
+      ((78)–(79)) -/
+  | strictUnderOnly
+  deriving DecidableEq, Repr
+
+/-- Which criterial configurations a signature admits: co-dependence
+    (74a) excludes the three antecedence configurations and strict
+    ellipsis readings; variable binding (74b) excludes strict
+    *only*-readings. -/
+def admits (s : Signature) : Criterion → Bool
+  | .strictUnderOnly => !s.boundVariable
+  | _                => !s.controllerCodependent
+
+/-- A signature is the OC signature iff it admits nothing criterial. -/
+theorem obligatory_iff_admits_none :
+    s.Obligatory ↔ ∀ cr, s.admits cr = false := by
+  constructor
+  · rintro ⟨hc, hb⟩ cr
+    cases cr <;> simp_all [admits]
+  · intro h
+    exact ⟨by simpa [admits] using h .arbitraryControl,
+           by simpa [admits] using h .strictUnderOnly⟩
+
+/-- A signature is the NOC signature iff it admits everything
+    criterial. -/
+theorem nonObligatory_iff_admits_all :
+    s.NonObligatory ↔ ∀ cr, s.admits cr = true := by
+  constructor
+  · rintro ⟨hc, hb⟩ cr
+    cases cr <;> simp_all [admits]
+  · intro h
+    exact ⟨by simpa [admits] using h .arbitraryControl,
+           by simpa [admits] using h .strictUnderOnly⟩
+
+end Signature
+
+end Control

--- a/Linglib/Syntax/Minimalist/MinimalPronoun.lean
+++ b/Linglib/Syntax/Minimalist/MinimalPronoun.lean
@@ -20,7 +20,6 @@ item inventory.
 - `VocabItem`: A context-sensitive realization rule (D[uφ] → Form / context)
 - `MinPronInventory`: A language's vocabulary item inventory + elsewhere default
 - `PronForm`: Standard surface form categories (null, pronoun, reflexive)
-- `OCSignature`: [landau-2013]'s Obligatory Control diagnostic package
 
 ## Core Claims
 
@@ -163,48 +162,6 @@ theorem MinPronInventory.controlForm_eq_null_of_overtPROUniversal
     {inv : MinPronInventory PronForm} (h : inv.OvertPROUniversal true) :
     inv.controlForm = .null :=
   Decidable.byContradiction fun hne => Bool.noConfusion (h hne)
-
-/-! ### Obligatory Control Signature -/
-
-/-- [landau-2013]'s Obligatory Control signature (simplified).
-
-    A clause S exhibits OC iff its subject satisfies two core conditions:
-    (a) the controller(s) must be codependent(s) of S
-    (b) PRO (or part of it) must be interpreted as a bound variable
-
-    Partial control is a subspecies of OC per [landau-2013] — "PRO (or part
-    of it)" explicitly accommodates it. -/
-structure OCSignature where
-  /-- (a): Controller must be argument of the matrix predicate -/
-  controllerCodependent : Bool
-  /-- (b): Embedded subject interpreted as bound variable -/
-  boundVariable : Bool
-  deriving DecidableEq, Repr
-
-/-- The full OC signature: both core diagnostics positive. -/
-def ocFull : OCSignature where
-  controllerCodependent := true
-  boundVariable := true
-
-/-- No OC: neither core diagnostic holds. -/
-def ocNone : OCSignature where
-  controllerCodependent := false
-  boundVariable := false
-
-/-- Does a clause type show obligatory control? -/
-def OCSignature.isOC (sig : OCSignature) : Bool :=
-  sig.controllerCodependent && sig.boundVariable
-
-/-- OC signature determined by whether a clause type licenses
-    noncoreferential embedded subjects: free reference means no OC;
-    obligatory coreference forces the full [landau-2013] signature.
-    The shared derivation behind the per-language OC tables of
-    [ostrove-2026] (SMPM) and [allotey-2021] (Gã). -/
-def OCSignature.ofNoncoreferential (noncoreferential : Bool) : OCSignature :=
-  if noncoreferential then ocNone else ocFull
-
-@[simp] theorem OCSignature.ofNoncoreferential_isOC (b : Bool) :
-    (ofNoncoreferential b).isOC = !b := by cases b <;> rfl
 
 /-! ### Cross-Linguistic BVA Syncretism -/
 


### PR DESCRIPTION
New `Control/Signature.lean` ([landau-2013] §§1.3–1.4, 7.1): `Signature` moves out of MinimalPronoun (fixing the OC-prefix stutter), `Obligatory`/`NonObligatory` Props replace `isOC`/`ocFull`/`ocNone`, and the OC criteria become derived — `Criterion` + `Signature.admits`, with OC ⟺ nothing criterial admitted and the §7.1 NOC mirror.

- Fidelity fix: *de se* is no longer derived from the signature (Landau explicitly rejects that; it is a tier property) — `Allotey2021.predictedColumn` routes it through `Tier.obligatoryDeSe`.
- Dissolves `FeatureTransmissionAsymmetry` (one-instance wrapper), `CopyControlProfile` (self-indexed row → four predicates on `CopyControlType`), and `ExemptAnaphorProfile`; both overt-PRO studies rewired to the Prop register.