### PR TITLE
refactor(Syntax/Control): dependency stratum on SetRel

### DIFF
--- a/Linglib/Syntax/Control/Dependency.lean
+++ b/Linglib/Syntax/Control/Dependency.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Mathlib.Data.Rel
 import Mathlib.Logic.Relator
-import Mathlib.Logic.Relation
 
 /-!
 # Control Dependencies
@@ -13,87 +13,108 @@ The framework-neutral positional stratum of control theory. Control is
 pre-theoretically an antecedence relation between the understood
 subject of a clause-like complement and the matrix argument that
 supplies its interpretation ([mccloskey-2003]; [landau-2013] (74)); a
-dependency here is a bare relation `α → α → Prop` over argument
-positions, read `r antecedent dependent`. Grammatical dependencies
+dependency here is a bundled relation `SetRel Pos Pos` over argument
+positions, read `antecedent ~[r] dependent`. Grammatical dependencies
 share the fixed format of the configurational matrix ([koster-1987];
-[neeleman-vandekoot-2002]): c-command by the antecedent,
-obligatoriness, uniqueness of the antecedent, nonuniqueness of the
-dependent, and locality. Movement chains, bound anaphora, and both
-control mechanisms instantiate the format, so nothing here chooses
-between base-generation and movement.
+[neeleman-vandekoot-2002]), and every clause of the matrix is mathlib
+vocabulary in the `SetRel` lattice: c-command, locality, and feature
+matching are refinements `r ⊆ s`; uniqueness of the antecedent is
+`SetRel.IsInjective`; obligatoriness is `dependent ⊆ r.cod`; the
+nonuniqueness of dependents that the general format permits is exactly
+what predication forbids (`SetRel.IsFunctional` — saturation consumes
+its one slot). Movement chains, bound anaphora, and both control
+mechanisms instantiate the format, so nothing here chooses between
+base-generation and movement.
 
-The matrix clauses are mathlib vocabulary, not new definitions:
-uniqueness of the antecedent is `Relator.LeftUnique`; predication
-strengthens the format with `Relator.RightUnique` (saturation consumes
-its one slot — the nonuniqueness of dependents that the general format
-permits is exactly what predication forbids); c-command, locality, and
-feature matching are refinements `r ≤ s` in the lattice of relations.
-Only obligatoriness needs a definition. The composition lemmas carry
-[landau-2024]'s decomposition of logophoric control as binding ∘
-predication (`Relation.Comp`): the composite keeps every refinement
-and both uniqueness properties of its legs, so control shift and split
-control can enter only through a non-functional binding leg, and
-feature transmission percolates through the mediating position.
+Composition `○` carries [landau-2024]'s decomposition of logophoric
+control as binding ∘ predication: the composite keeps every refinement
+(`SetRel.comp_subset_comp`), obligatoriness (`cod_subset_cod_comp`),
+and both uniqueness properties (`IsInjective.comp`,
+`IsFunctional.comp`) of its legs — so control shift and split control
+can enter only through a non-functional binding leg, the perspectival
+*pro* anchoring to AUTHOR, ADDRESSEE, or their sum, never through
+predication.
+
+The declarations below are general relation algebra that mathlib's
+`SetRel` currently lacks; each is marked `[UPSTREAM]`.
 -/
 
-namespace Control
+namespace SetRel
 
-variable {α : Type*} {dependent : α → Prop} {bind pred : α → α → Prop}
+variable {α β γ : Type*} {R : SetRel α β} {S : SetRel β γ}
 
-/-- Obligatoriness clause of the configurational matrix: every
-    dependent takes an antecedent. -/
-def Obligatory (dependent : α → Prop) (r : α → α → Prop) : Prop :=
-  ∀ ⦃b⦄, dependent b → ∃ a, r a b
+/-- `[UPSTREAM]` A relation is functional when it relates each left
+    element to at most one right element. -/
+protected abbrev IsFunctional (R : SetRel α β) : Prop :=
+  R.inv ○ R ⊆ .id
 
-/-- A composite dependency is obligatory when its inner leg is and its
-    mediating positions all have binders. -/
-theorem Obligatory.comp (hp : Obligatory dependent pred)
-    (hb : ∀ m, ∃ a, bind a m) :
-    Obligatory dependent (Relation.Comp bind pred) := by
-  intro c hc
-  obtain ⟨m, hm⟩ := hp hc
-  obtain ⟨a, ha⟩ := hb m
-  exact ⟨a, m, ha, hm⟩
+/-- `[UPSTREAM]` A relation is injective when it relates each right
+    element to at most one left element. -/
+protected abbrev IsInjective (R : SetRel α β) : Prop :=
+  R ○ R.inv ⊆ .id
 
-/-- Unique antecedents compose: if the dependent picks a unique
-    mediator and the mediator a unique binder, the composite dependent
-    picks a unique antecedent. -/
-theorem leftUnique_comp (hb : Relator.LeftUnique bind)
-    (hp : Relator.LeftUnique pred) :
-    Relator.LeftUnique (Relation.Comp bind pred) := by
-  rintro a a' c ⟨m, hbm, hmc⟩ ⟨m', hbm', hmc'⟩
-  obtain rfl := hp hmc hmc'
-  exact hb hbm hbm'
+/-- `[UPSTREAM]` Functional relations compose. -/
+theorem IsFunctional.comp (hR : R.IsFunctional) (hS : S.IsFunctional) :
+    (R ○ S).IsFunctional := by
+  rintro ⟨c, c'⟩ ⟨a, hca, hac'⟩
+  obtain ⟨b, hab, hbc⟩ := mem_inv.mp hca
+  obtain ⟨b', hab', hb'c'⟩ := hac'
+  obtain rfl : b = b' := mem_id.mp (hR (prodMk_mem_comp (mem_inv.mpr hab) hab'))
+  exact hS (prodMk_mem_comp (mem_inv.mpr hbc) hb'c')
 
-/-- Bi-uniqueness survives composition: an antecedent reaches a unique
-    dependent when both legs are functional. Contrapositively, control
-    shift and split control ([landau-2024] §5.1) can arise only through
-    a binding leg that is not right-unique — the perspectival *pro*
-    anchoring to AUTHOR, ADDRESSEE, or their sum — never through
-    predication, which saturates a single slot. -/
-theorem rightUnique_comp (hb : Relator.RightUnique bind)
-    (hp : Relator.RightUnique pred) :
-    Relator.RightUnique (Relation.Comp bind pred) := by
-  rintro a c c' ⟨m, hbm, hmc⟩ ⟨m', hbm', hmc'⟩
-  obtain rfl := hb hbm hbm'
-  exact hp hmc hmc'
+/-- `[UPSTREAM]` Injective relations compose. -/
+theorem IsInjective.comp (hR : R.IsInjective) (hS : S.IsInjective) :
+    (R ○ S).IsInjective := by
+  rintro ⟨a, a'⟩ ⟨c, hac, hca'⟩
+  obtain ⟨b, hab, hbc⟩ := hac
+  obtain ⟨b', ha'b', hb'c⟩ := mem_inv.mp hca'
+  obtain rfl : b = b' := mem_id.mp (hS (prodMk_mem_comp hbc (mem_inv.mpr hb'c)))
+  exact hR (prodMk_mem_comp hab (mem_inv.mpr ha'b'))
 
-/-- Refinements percolate through composition: if each leg respects a
-    licensing relation (c-command, locality, feature matching — the
-    remaining matrix clauses and [landau-2015]'s (60)), so does the
-    composite through the mediating position. -/
-theorem comp_mono {bind' pred' : α → α → Prop} (hb : bind ≤ bind')
-    (hp : pred ≤ pred') :
-    Relation.Comp bind pred ≤ Relation.Comp bind' pred' := by
-  rintro a c ⟨m, hbm, hmc⟩
-  exact ⟨m, hb _ _ hbm, hp _ _ hmc⟩
+/-- `[UPSTREAM]` Functionality is right-uniqueness of the underlying
+    relation. -/
+theorem isFunctional_iff_rightUnique :
+    R.IsFunctional ↔ Relator.RightUnique (· ~[R] ·) := by
+  constructor
+  · intro h a b b' hab hab'
+    exact mem_id.mp (h (prodMk_mem_comp (mem_inv.mpr hab) hab'))
+  · rintro h ⟨b, b'⟩ ⟨a, hba, hab'⟩
+    exact mem_id.mpr (h (mem_inv.mp hba) hab')
 
-/-- A transitive licensing relation absorbs composition: dependencies
-    whose legs it licenses compose into a dependency it licenses. -/
-theorem comp_le_of_trans {s : α → α → Prop} [IsTrans α s]
-    (hb : bind ≤ s) (hp : pred ≤ s) :
-    Relation.Comp bind pred ≤ s := by
-  rintro a c ⟨m, hbm, hmc⟩
-  exact IsTrans.trans _ _ _ (hb _ _ hbm) (hp _ _ hmc)
+/-- `[UPSTREAM]` Injectivity is left-uniqueness of the underlying
+    relation. -/
+theorem isInjective_iff_leftUnique :
+    R.IsInjective ↔ Relator.LeftUnique (· ~[R] ·) := by
+  constructor
+  · intro h a a' b hab ha'b
+    exact mem_id.mp (h (prodMk_mem_comp hab (mem_inv.mpr ha'b)))
+  · rintro h ⟨a, a'⟩ ⟨b, hab, hba'⟩
+    exact mem_id.mpr (h hab (mem_inv.mp hba'))
 
-end Control
+/-- `[UPSTREAM]` The codomain of a composite is contained in the second
+    leg's codomain. -/
+theorem cod_comp_subset : (R ○ S).cod ⊆ S.cod := by
+  rintro c ⟨a, b, hab, hbc⟩
+  exact ⟨b, hbc⟩
+
+/-- `[UPSTREAM]` The second leg's codomain survives composition when
+    its domain is covered by the first leg's codomain. -/
+theorem cod_subset_cod_comp (h : S.dom ⊆ R.cod) : S.cod ⊆ (R ○ S).cod := by
+  rintro c ⟨b, hbc⟩
+  obtain ⟨a, hab⟩ := h ⟨c, hbc⟩
+  exact ⟨a, b, hab, hbc⟩
+
+/-- `[UPSTREAM]` The domain of a composite is contained in the first
+    leg's domain. -/
+theorem dom_comp_subset : (R ○ S).dom ⊆ R.dom := by
+  rintro a ⟨c, b, hab, hbc⟩
+  exact ⟨b, hab⟩
+
+/-- `[UPSTREAM]` The first leg's domain survives composition when its
+    codomain is covered by the second leg's domain. -/
+theorem dom_subset_dom_comp (h : R.cod ⊆ S.dom) : R.dom ⊆ (R ○ S).dom := by
+  rintro a ⟨b, hab⟩
+  obtain ⟨c, hbc⟩ := h ⟨a, hab⟩
+  exact ⟨c, b, hab, hbc⟩
+
+end SetRel


### PR DESCRIPTION
PR1 of the visioning ladder: `Dependency.lean` moves from pointwise `α → α → Prop` to mathlib's bundled `SetRel` — the register mathlib's own implementation note prescribes for relation operations. The two lemmas that duplicated mathlib on this carrier (`comp_mono`, `comp_le_of_trans`) are deleted; `Obligatory` dissolves into `dependent ⊆ r.cod`; the configurational-matrix dictionary now reads entirely in `SetRel` vocabulary, with the linguistic content in the module docstring and the declarations kept mathlib-clean. All eight declarations are `[UPSTREAM]`-marked verified gaps: `IsFunctional`/`IsInjective` with composition closure and `Relator` bridges, and the four `dom`/`cod`-under-`○` lemmas.