### PR TITLE
refactor(Syntax/Control): derive tier phenomenology from predication

### DIFF
--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -581,18 +581,13 @@ def chierchiaToLandauTier : ChierchiaControlClass → Control.Tier
 
 /-- The CP/no-CP distinction aligns with the predicative/logophoric
     distinction: CP-bearing classes are predicative, CP-lacking classes
-    are logophoric. -/
+    are logophoric. Chierchia's CP is thereby the semantic reflex of
+    Landau's condition (90): the entailment needs a specific overt
+    argument to serve as controller, which is what predication
+    demands. -/
 theorem cp_iff_predicative (c : ChierchiaControlClass) :
     c.hasCP = true ↔ chierchiaToLandauTier c = .predicative := by
   cases c <;> simp [ChierchiaControlClass.hasCP, chierchiaToLandauTier]
-
-/-- Predicative control requires a syntactic controller (Landau's
-    condition (90)), which is the syntactic reflex of Chierchia's CP:
-    the entailment needs a specific argument to serve as controller. -/
-theorem cp_requires_syntactic_controller (c : ChierchiaControlClass)
-    (h : c.hasCP = true) :
-    (chierchiaToLandauTier c).requiresSyntacticController = true := by
-  cases c <;> first | rfl | simp [ChierchiaControlClass.hasCP] at h
 
 -- ── Per-verb cross-system consistency ──
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -19,8 +19,10 @@ consilience bridge to [noonan-2007]'s CTP classification.
 
 ## Main results
 
-- `ttcContrasts` + `ttcContrasts_consistent`: the six empirical
-  contrasts of table (80), each derived from `Control.Tier` properties
+- `Table80Row` with the two availability columns: the six empirical
+  contrasts of table (80), a perfect split between the tiers
+  (`table80_complementary`); the mechanism rows cite their
+  `Control.IsPredicative` derivations
 - `objectControlReading`: psychological → *de se*, communicative →
   *de te* (table (36))
 - `derivedLandauClass` / `derivedControlTier`: predicate classes derived
@@ -36,49 +38,61 @@ open Features (Attitude)
 
 /-! ### Table (80): empirical contrasts -/
 
-/-- One row of the empirical contrast table (80) of [landau-2015]:
-    a property available under exactly one control tier. -/
-structure TTCContrast where
-  name : String
-  /-- Available under predicative control? -/
-  predicative : Bool
-  /-- Available under logophoric control? -/
-  logophoric : Bool
-  deriving DecidableEq, Repr, Inhabited
+/-- The six contrast rows of table (80) of [landau-2015]. -/
+inductive Table80Row where
+  /-- OC into an inflected complement (the OC-NC generalization (70);
+      `Tier.agrBlocksControl`) -/
+  | inflectedComplement
+  /-- `[−human]` PRO ((81): the logophoric binder is the
+      AUTHOR/ADDRESSEE function, defined only for humans) -/
+  | nonhumanPRO
+  /-- Implicit control ((90)/(93): predication needs an overt
+      external argument) -/
+  | implicitControl
+  /-- Control shift (`Control.IsPredicative.eq_of_controlled` blocks
+      it under predication) -/
+  | controlShift
+  /-- Partial control (`Control.IsPredicative.not_partial` blocks it
+      under predication) -/
+  | partialControl
+  /-- Split control (`Control.IsPredicative.eq_of_controllers` blocks
+      it under predication) -/
+  | splitControl
+  deriving DecidableEq, Repr
 
-/-- The six contrasts from table (80), encoded as data. -/
-def ttcContrasts : List TTCContrast :=
-  [ ⟨"inflected complement", true,  false⟩
-  , ⟨"[−human] PRO",         true,  false⟩
-  , ⟨"implicit control",     false, true⟩
-  , ⟨"control shift",        false, true⟩
-  , ⟨"partial control",      false, true⟩
-  , ⟨"split control",        false, true⟩ ]
+/-- Table (80)'s predicative column. -/
+def availableUnderPredicative : Table80Row → Bool
+  | .inflectedComplement => true
+  | .nonhumanPRO         => true
+  | _                    => false
 
-/-- The `ttcContrasts` data agrees with the derived `Control.Tier`
-    properties, row by row. -/
-theorem ttcContrasts_consistent :
-    ((!Tier.agrBlocksControl .predicative) = (ttcContrasts[0]!.predicative))
-    ∧ ((!Tier.agrBlocksControl .logophoric) = (ttcContrasts[0]!.logophoric))
-    ∧ (Tier.allowsNonhumanPRO .predicative = ttcContrasts[1]!.predicative)
-    ∧ (Tier.allowsNonhumanPRO .logophoric = ttcContrasts[1]!.logophoric)
-    ∧ (Tier.allowsImplicitControl .predicative = ttcContrasts[2]!.predicative)
-    ∧ (Tier.allowsImplicitControl .logophoric = ttcContrasts[2]!.logophoric)
-    ∧ (Tier.allowsControlShift .predicative = ttcContrasts[3]!.predicative)
-    ∧ (Tier.allowsControlShift .logophoric = ttcContrasts[3]!.logophoric)
-    ∧ (Tier.allowsPartialControl .predicative = ttcContrasts[4]!.predicative)
-    ∧ (Tier.allowsPartialControl .logophoric = ttcContrasts[4]!.logophoric)
-    ∧ (Tier.allowsSplitControl .predicative = ttcContrasts[5]!.predicative)
-    ∧ (Tier.allowsSplitControl .logophoric = ttcContrasts[5]!.logophoric) := by
-  exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-- Table (80)'s logophoric column. -/
+def availableUnderLogophoric : Table80Row → Bool
+  | .inflectedComplement => false
+  | .nonhumanPRO         => false
+  | _                    => true
+
+/-- Table (80) is a perfect split: every contrast is available under
+    exactly one tier. -/
+theorem table80_complementary (r : Table80Row) :
+    availableUnderLogophoric r = !availableUnderPredicative r := by
+  cases r <;> rfl
+
+/-- The inflected-complement row is the OC-NC generalization (70). -/
+theorem inflectedComplement_eq_agrBlocks :
+    (availableUnderPredicative .inflectedComplement
+        = !Tier.agrBlocksControl .predicative)
+    ∧ availableUnderLogophoric .inflectedComplement
+        = !Tier.agrBlocksControl .logophoric :=
+  ⟨rfl, rfl⟩
 
 /-- EC verbs resist impersonal passives ((98) in [landau-2015]): a
     direct consequence of condition (90), since impersonal passives
-    suppress the external argument that predicative control needs.
-    Cross-linguistic evidence: Hebrew, German, Dutch, Russian. -/
+    suppress the external argument that predicative control needs —
+    the implicit-control row of table (80). Cross-linguistic evidence:
+    Hebrew, German, Dutch, Russian. -/
 theorem ec_resists_impersonal_passives :
-    Tier.requiresSyntacticController .predicative = true
-    ∧ Tier.requiresSyntacticController .logophoric = false := ⟨rfl, rfl⟩
+    availableUnderPredicative .implicitControl = false := rfl
 
 /-! ### De se / de te in object control (table (36)) -/
 

--- a/Linglib/Syntax/Control/Basic.lean
+++ b/Linglib/Syntax/Control/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 
+import Linglib.Syntax.Control.Dependency
+
 /-!
 # Control Theory: Tiers, Predicate Classes, Clause Classes
 
@@ -22,21 +24,14 @@ for the paper-anchored control studies (`Studies/Landau2015.lean`,
 
 ## Main definitions
 
-- `Control.Tier`: predicative vs. logophoric control, with the
-  phenomenology derived from `Tier.isAttitude`
+- `Control.Tier`: predicative vs. logophoric control
+- `Control.IsPredicative`: the grammatical profile of a
+  predicative-control dependency, with the tier's phenomenology as
+  theorems (exhaustive, no split, no shift)
 - `Control.PredicateClass`: the eight predicate classes, mapped to tiers
 - `Control.ClauseClass`: the `[±T]` scale positions, with the
   Agr-sensitive `ClauseClass.HasOC` and its characterization
   `ClauseClass.hasOC_iff`
-
-## Implementation notes
-
-Partial control, control shift, implicit control, and split control are
-possible only under logophoric control — one underlying mechanism
-(variable binding of a perspectival coordinate) — so each is
-`Tier.isAttitude` rather than restipulated, and
-`Tier.requiresSyntacticController` and `Tier.allowsNonhumanPRO` are its
-negation.
 
 ## TODO
 
@@ -74,34 +69,6 @@ def Tier.isAttitude : Tier → Bool
   | .predicative => false
   | .logophoric  => true
 
-/-- Condition on syntactic predication ([landau-2015] (90)): the argument
-    predicated of must be syntactically represented, so predicative
-    control requires a syntactically present controller; the logophoric
-    coordinate is bound by a matrix argument that may be implicit. -/
-def Tier.requiresSyntacticController (t : Tier) : Bool :=
-  !t.isAttitude
-
-/-- `[−human]` PRO is compatible with predicative control only
-    ([landau-2015] (81)): the logophoric binder is mapped to the
-    AUTHOR/ADDRESSEE function, which is defined only for humans. -/
-def Tier.allowsNonhumanPRO (t : Tier) : Bool :=
-  !t.isAttitude
-
-/-- Partial control is possible only under logophoric control;
-    predicative control forces exhaustive control. -/
-def Tier.allowsPartialControl : Tier → Bool := Tier.isAttitude
-
-/-- Control shift is possible only under logophoric control:
-    predication is a bi-unique relation. -/
-def Tier.allowsControlShift : Tier → Bool := Tier.isAttitude
-
-/-- Implicit control is possible only under logophoric control
-    (condition (90)). -/
-def Tier.allowsImplicitControl : Tier → Bool := Tier.isAttitude
-
-/-- Split control is possible only under logophoric control. -/
-def Tier.allowsSplitControl : Tier → Bool := Tier.isAttitude
-
 /-- The OC-NC generalization ([landau-2015] (70)): `[+Agr]` blocks
     logophoric but not predicative control, by the Feature Transmission
     asymmetry ((60): predication is not contingent on feature matching —
@@ -110,6 +77,53 @@ def Tier.allowsSplitControl : Tier → Bool := Tier.isAttitude
     ([ganenkov-2019]). -/
 def Tier.agrBlocksControl (t : Tier) : Bool :=
   t.isAttitude
+
+/-! ### The predicative mechanism
+
+Predication is saturation, so a predicative-control dependency is
+functional, injective, and exhaustively shares the referent; the
+tier's phenomenology follows ([landau-2015]; [landau-2024] §5.1):
+exhaustive control, no split, no shift. Logophoric control composes a
+binding leg over predication and escapes each property exactly when
+the binding leg does (`SetRel.IsInjective.comp`,
+`SetRel.IsFunctional.comp`, `Control.Shares.comp` contrapositives).
+Implicit control ((90)), `[−human]` PRO ((81)), and Agr-blocking
+((60)/(70)) need overtness, animacy, and φ carriers; they are carried
+at the enforcement stratum. -/
+
+section Mechanism
+
+open SetRel
+
+variable {Pos Ref : Type*} {val : Pos → Ref} {d : SetRel Pos Pos}
+  {a b p q : Pos}
+
+/-- The grammatical profile of a predicative-control dependency:
+    predication saturates a unique slot by a unique argument and shares
+    the referent exhaustively. -/
+structure IsPredicative (val : Pos → Ref) (d : SetRel Pos Pos) : Prop where
+  functional : d.IsFunctional
+  injective : d.IsInjective
+  shares : Shares val d
+
+/-- Predicative control is exhaustive: the dependent's referent never
+    strictly extends the controller's (no partial control). -/
+theorem IsPredicative.not_partial [Preorder Ref] (h : IsPredicative val d)
+    (hab : a ~[d] b) : ¬ val a < val b :=
+  h.shares.not_lt hab
+
+/-- Predicative control admits no split: joint controllers coincide. -/
+theorem IsPredicative.eq_of_controllers (h : IsPredicative val d)
+    (ha : a ~[d] p) (hb : b ~[d] p) : a = b :=
+  isInjective_iff_leftUnique.mp h.injective ha hb
+
+/-- Predicative control admits no shift: a controller saturates a
+    single slot. -/
+theorem IsPredicative.eq_of_controlled (h : IsPredicative val d)
+    (hp : a ~[d] p) (hq : a ~[d] q) : p = q :=
+  isFunctional_iff_rightUnique.mp h.functional hp hq
+
+end Mechanism
 
 /-! ### Predicate classification -/
 


### PR DESCRIPTION
PR4 of the ladder. The six `Tier.allows*`/`requiresSyntacticController` defs — all definitionally `±isAttitude` — are deleted; in their place, `Control.IsPredicative` (functional + injective + exhaustively sharing, i.e. predication-as-saturation) with the phenomenology as theorems: `not_partial`, `eq_of_controllers` (no split), `eq_of_controlled` (no shift), each one line over the Dependency stratum. `Tier.agrBlocksControl` survives ((70) is load-bearing in `HasOC`; its derivation is the K6/enforcement rung). Landau2015's `TTCContrast` String-table dies: table (80) becomes `Table80Row` with two independent data columns, the perfect-split theorem `table80_complementary`, the (70) row tied to `agrBlocksControl`, and `ec_resists_impersonal_passives` restated over the table; mechanism rows cite their `IsPredicative` derivations. Chierchia1984's `cp_requires_syntactic_controller` folds into `cp_iff_predicative`'s docstring as the (90) reflex. The `Basic.lean` → `Tier.lean` rename is deferred (it would touch files owned by the open #1770).