### PR TITLE
refactor(Syntax/Control): occupant transport replaces derivation table

### DIFF
--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -221,14 +221,29 @@ theorem npi_patterns_with_lda (c : EmbeddedClauseType) :
 /-- Gã forbids embedded lexical-DP copies (exx 42b, 64). -/
 def gaEmbeddedLexicalCopyAvailable : Bool := false
 
-/-- The derivation the lexical-copy observation supports. -/
-def gaControlDerivation : Derivation :=
-  Derivation.supportedBy .embeddedLexicalCopy gaEmbeddedLexicalCopyAvailable
+/-- The occupants of ex 42b's two positions. -/
+inductive Ex42Item where
+  /-- the lexical matrix subject *Ameele* -/
+  | ameele
+  /-- the obligatory embedded proclitic -/
+  | pronoun
+  deriving DecidableEq, Repr
 
-/-- Control is base-generated: movement predicts the lexical-DP copy Gã
-    forbids (§3.6.2). -/
-theorem ga_supports_basegeneration :
-    gaControlDerivation = .baseGeneration := rfl
+/-- Ex 42b's control dependency: matrix controller position `0` to
+    embedded subject position `1`. -/
+def ex42Dependency : SetRel (Fin 2) (Fin 2) := {(0, 1)}
+
+/-- The attested occupants: lexical *Ameele* controls the obligatory
+    proclitic — never a lexical copy (exx 42b, 64). -/
+def ex42Occupant : Fin 2 → Ex42Item :=
+  fun p => if p = 0 then .ameele else .pronoun
+
+/-- Movement is token identity, and ex 42b's occupants differ across
+    the dependency — the Movement Theory of Control ([hornstein-1999])
+    is refuted on the Gã configuration (§3.6.2): control is
+    base-generated. -/
+theorem ga_refutes_movement : ¬ Shares ex42Occupant ex42Dependency :=
+  not_shares_of_mismatch (P := (· = .ameele)) rfl rfl (by decide)
 
 /-- The lexical-copy ban is what [landau-2024]'s (72) predicts: the
     ex 42b/64 matrix verb *kai* is an implicative — nonattitude,

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -404,38 +404,31 @@ theorem smpm_has_exempt_anaphors :
 theorem smpm_no_quantified_exempt :
     Mixtec.SMPM.exemptAnaphorAllowsQuantifiedAntecedent = false := rfl
 
-/-- **The argument against movement** (§6, pp.26–31):
+/-- The occupants of the (86)–(87) configurations. -/
+inductive Ex86Item where
+  /-- the quantified controller ('each dog', 'no boy') -/
+  | quantifierDP
+  /-- the overt controlled clitic anteceding the exempt anaphor -/
+  | pronoun
+  deriving DecidableEq, Repr
 
-    Given: exempt anaphors cannot have quantified antecedents (78).
+/-- The (86)–(87) control dependency: quantified controller position
+    `0` to embedded clitic position `1`. -/
+def ex86Dependency : SetRel (Fin 2) (Fin 2) := {(0, 1)}
 
-    Movement analysis predicts: if the controller is quantified (e.g.,
-    "every dog"), the copy in embedded subject position IS the quantifier.
-    An exempt anaphor in the embedded clause would need to be bound by
-    this quantified copy → predicted UNAVAILABLE.
+/-- The attested occupants: exempt anaphors reject quantified
+    antecedents ((78)), yet they are available in untensed
+    subjunctives with quantified controllers ((86)–(87)) — so the
+    embedded position holds a genuine referential pronoun, not a
+    quantifier copy. -/
+def ex86Occupant : Fin 2 → Ex86Item :=
+  fun p => if p = 0 then .quantifierDP else .pronoun
 
-    Base-generation analysis predicts: the pronoun in embedded subject
-    position is a genuine pronoun (base-generated), not a copy of the
-    quantifier. An exempt anaphor can take this pronoun as antecedent →
-    predicted AVAILABLE.
-
-    SMPM data (86–87): exempt anaphors ARE available in untensed
-    subjunctives with quantified controllers.
-    - *Tá'iin'iin tsǐnà kìxà [tsìi =rí ndò'ò mí =rí].*
-      'Each dog started to bite its own tail.'
-    - *Kò xíniñu'u ni'iin =rà bálí [kòni =rà táta mí =rà].*
-      'No boy needs to see his own father.'
-
-    This matches the base-generation prediction. -/
-def smpmExemptAvailableWithQuantifiedController : Bool := true
-
-/-- The derivation the exempt-anaphor observation supports
-    (`Derivation.eq_supportedBy_of_predicts`: it is the only one). -/
-def smpmControlDerivation : Derivation :=
-  Derivation.supportedBy .exemptAnaphorWithQuantifiedController
-    smpmExemptAvailableWithQuantifiedController
-
-theorem smpm_supports_basegeneration :
-    smpmControlDerivation = .baseGeneration := rfl
+/-- Movement is token identity, and the (86)–(87) occupants differ
+    across the dependency — movement is refuted (§6, pp. 26–31): SMPM
+    control is base-generated. -/
+theorem smpm_refutes_movement : ¬ Shares ex86Occupant ex86Dependency :=
+  not_shares_of_mismatch (P := (· = .quantifierDP)) rfl rfl (by decide)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10: Implicational Universal (54)

--- a/Linglib/Syntax/Control/CopyControl.lean
+++ b/Linglib/Syntax/Control/CopyControl.lean
@@ -5,23 +5,23 @@ Authors: Robert Hawkins
 -/
 
 /-!
-# Copy Control and Control Derivation
+# Copy Control
 
 Copy control ([polinsky-potsdam-2006]): the subject of a control clause
 is a phonologically overt copy of its controller. The typology of copy
-types and the movement vs. base-generation opposition for deriving
-obligatory control, adjudicated by diagnostics such as exempt anaphora
-([pollard-sag-1992]: exempt anaphors cannot have quantified
-antecedents). Substrate for the overt-PRO studies
+types. The movement vs. base-generation opposition is adjudicated by
+occupant-transport refutations (`Control.not_shares_of_mismatch` in
+`Dependency.lean`): movement is token identity, so an embedded
+occupant differing from its controller — a pronoun where a lexical
+copy is predicted (Gã), or a genuine pronoun anteceding an exempt
+anaphor under a quantified controller ([pollard-sag-1992]; SMPM) —
+refutes it. Substrate for the overt-PRO studies
 (`Studies/Ostrove2026.lean`, `Studies/Allotey2021.lean`).
 
 ## Main definitions
 
 - `Control.CopyControlType`: the four copy-control types, with their
   distinguishing properties as predicates
-- `Control.Derivation`: base-generation vs. movement, with the
-  diagnostic prediction table (`Derivation.predicts`) and the unique
-  derivation an observation supports (`Derivation.supportedBy`)
 -/
 
 namespace Control
@@ -68,57 +68,6 @@ def CopyControlType.copyCanBearFocus : CopyControlType → Bool
   | .obligatoryPronominal => false
   | _                     => true
 
-/-! ### Control derivation -/
 
-/-- The two analyses of obligatory control derivation. -/
-inductive Derivation where
-  /-- Controller base-generated in matrix; PRO base-generated in the
-      embedded clause. Two distinct syntactic positions, linked by
-      variable binding. -/
-  | baseGeneration
-  /-- Controller enters the derivation in embedded subject position and
-      moves to the matrix position ([hornstein-1999]-style Movement
-      Theory of Control). One DP, two copies. -/
-  | movement
-  deriving DecidableEq, Repr
-
-namespace Derivation
-
-/-- Observable diagnostics that separate the two derivations. -/
-inductive Diagnostic where
-  /-- Is an exempt anaphor available with a quantified controller? -/
-  | exemptAnaphorWithQuantifiedController
-  /-- Can the pronounced embedded element be a lexical-DP copy of the
-      controller? -/
-  | embeddedLexicalCopy
-  deriving DecidableEq, Repr
-
-/-- What each derivation predicts for each diagnostic. Under movement
-    the embedded element is a copy of the controller: a quantified
-    controller leaves no pronoun to antecede an exempt anaphor, and a
-    lexical-DP controller should reappear as a lexical-DP copy. Under
-    base-generation the embedded element is an independent pronoun. -/
-def predicts : Derivation → Diagnostic → Bool
-  | .baseGeneration, .exemptAnaphorWithQuantifiedController => true
-  | .baseGeneration, .embeddedLexicalCopy                   => false
-  | .movement,       .exemptAnaphorWithQuantifiedController => false
-  | .movement,       .embeddedLexicalCopy                   => true
-
-/-- The unique derivation consistent with an observed diagnostic value. -/
-def supportedBy (d : Diagnostic) (obs : Bool) : Derivation :=
-  if Derivation.baseGeneration.predicts d = obs then .baseGeneration else .movement
-
-/-- The supported derivation predicts the observation. -/
-@[simp] theorem predicts_supportedBy (d : Diagnostic) (obs : Bool) :
-    (supportedBy d obs).predicts d = obs := by
-  cases d <;> cases obs <;> rfl
-
-/-- Only the supported derivation predicts the observation: every
-    diagnostic discriminates between the two derivations. -/
-theorem eq_supportedBy_of_predicts {dv : Derivation} {d : Diagnostic}
-    {obs : Bool} (h : dv.predicts d = obs) : dv = supportedBy d obs := by
-  cases dv <;> cases d <;> subst h <;> rfl
-
-end Derivation
 
 end Control

--- a/Linglib/Syntax/Control/Dependency.lean
+++ b/Linglib/Syntax/Control/Dependency.lean
@@ -184,4 +184,39 @@ theorem exists_lt_of_comp_lt [PartialOrder Ref]
   · exact Or.inl ⟨a, m, ham, hlt'⟩
   · exact Or.inr ⟨m, c, hmc, heq ▸ hlt⟩
 
+/-! ### Enforcement
+
+The species of sharing enforcement are distinguished by WHAT the
+dependency shares ([landau-2024] §3's road map; [mccloskey-2003]):
+token identity (movement) shares the occupant assignment itself;
+referential dependencies (predication, coordinate binding) share only
+the referent valuation; complex-predicate formation merges grids with
+no dependent position; lexicalist accounts enforce sharing by meaning
+postulate. Token identity is the strongest: a shared assignment
+transports along every map of it (`Shares.map`), so every occupant
+property transports across the dependency (`Shares.iff_of_rel`) — and
+one observed mismatch refutes it (`not_shares_of_mismatch`), the
+engine of the copy-control diagnostics (embedded lexical copies,
+exempt anaphora with quantified controllers). -/
+
+variable {Item : Type*} {occ : Pos → Item}
+
+/-- Sharing an assignment transports along any map of it: token
+    identity yields referential co-valuation for every referent map. -/
+theorem Shares.map (hs : Shares occ ante) (f : Item → Ref) :
+    Shares (f ∘ occ) ante :=
+  fun _ _ hab => congrArg f (hs hab)
+
+/-- Under a shared assignment, every property of the assigned value
+    transports across the dependency: copies are indistinguishable. -/
+theorem Shares.iff_of_rel (hs : Shares occ ante) (h : a ~[ante] b)
+    (P : Item → Prop) : P (occ a) ↔ P (occ b) :=
+  iff_of_eq (congrArg P (hs h))
+
+/-- One observed mismatch refutes a shared assignment — the refutation
+    engine of the copy-control diagnostics. -/
+theorem not_shares_of_mismatch {P : Item → Prop} (h : a ~[ante] b)
+    (hPa : P (occ a)) (hPb : ¬ P (occ b)) : ¬ Shares occ ante :=
+  fun hs => hPb (hs h ▸ hPa)
+
 end Control


### PR DESCRIPTION
PR6 of the ladder: the movement-vs-base-generation adjudication becomes derivation, not stipulation. `Dependency.lean` gains the enforcement section — `Shares.map` (token identity transports along every referent map), `Shares.iff_of_rel` (copies are indistinguishable), and `not_shares_of_mismatch`, the refutation engine: one observed occupant mismatch across the dependency refutes a shared assignment. `Control.Derivation`/`Diagnostic`/`predicts`/`supportedBy` — the stipulated 2×2 table — dissolve out of `CopyControl.lean`. The studies now *model* their refutations: Allotey2021's ex 42b (lexical *Ameele* controlling the obligatory proclitic) and Ostrove2026's (86)–(87) (quantified controller anteceding an exempt-anaphor-licensing pronoun) each build the two-position configuration and derive `¬ Shares occupant dependency` — movement refuted from what token identity *is*, the K5 divergence made concrete.