### PR TITLE
refactor(Syntax/Control): neutral dependency core and taxonomy stratum

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2849,6 +2849,7 @@ import Linglib.Syntax.Control.CopyControl
 import Linglib.Syntax.Control.Clause
 import Linglib.Syntax.Control.Dependency
 import Linglib.Syntax.Control.Signature
+import Linglib.Syntax.Control.Taxonomy
 import Linglib.Syntax.Coordination
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Syntax.DependencyGrammar.Coordination

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -7,7 +7,7 @@ import Linglib.Fragments.Ga.Predicates
 import Linglib.Syntax.Minimalist.MinimalPronoun
 import Linglib.Syntax.Control.Tier
 import Linglib.Syntax.Control.Clause
-import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Control.Dependency
 import Linglib.Syntax.Control.Signature
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -22,7 +22,7 @@ consilience bridge to [noonan-2007]'s CTP classification.
 - `Table80Row` with the two availability columns: the six empirical
   contrasts of table (80), a perfect split between the tiers
   (`table80_complementary`); the mechanism rows cite their
-  `Control.IsPredicative` derivations
+  `Control.IsSaturating` derivations
 - `objectControlReading`: psychological → *de se*, communicative →
   *de te* (table (36))
 - `derivedLandauClass` / `derivedControlTier`: predicate classes derived
@@ -49,14 +49,15 @@ inductive Table80Row where
   /-- Implicit control ((90)/(93): predication needs an overt
       external argument) -/
   | implicitControl
-  /-- Control shift (`Control.IsPredicative.eq_of_controlled` blocks
-      it under predication) -/
+  /-- Control shift (`Control.IsSaturating.eq_of_controllers` blocks
+      it under predication: the shifted reading assigns the saturated
+      slot a different controller) -/
   | controlShift
-  /-- Partial control (`Control.IsPredicative.not_partial` blocks it
+  /-- Partial control (`Control.IsSaturating.not_hasPartial` blocks it
       under predication) -/
   | partialControl
-  /-- Split control (`Control.IsPredicative.eq_of_controllers` blocks
-      it under predication) -/
+  /-- Split control (`Control.IsSaturating.not_hasSplit` blocks it
+      under predication) -/
   | splitControl
   deriving DecidableEq, Repr
 

--- a/Linglib/Studies/Landau2024.lean
+++ b/Linglib/Studies/Landau2024.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Syntax.Control.Tier
-import Linglib.Syntax.Control.Signature
-import Linglib.Syntax.Control.Dependency
+import Linglib.Syntax.Control.Taxonomy
 
 /-!
 # Landau (2024): Control
@@ -168,10 +167,10 @@ theorem korean_realizes_postal (j : Jussive) :
 
 (36)–(37): PC is attested in attitude complements and unavailable
 under implicatives — *\*John managed to gather at 6* (37a). On the
-dual theory this is `Control.IsPredicative.not_partial`: implicative
-complements are predicative, and predication shares the referent
-exhaustively. The (37a) configuration refutes predicative status for
-its hypothetical PC reading, never the other way around. -/
+dual theory this is `Control.IsSaturating.not_hasPartial`: implicative
+complements are predicative, and predication saturates, sharing the
+referent exhaustively. The (37a) configuration refutes saturating
+status for its hypothetical PC reading, never the other way around. -/
 
 /-- The (37a) configuration: matrix controller position `0`, embedded
     subject position `1`. -/
@@ -182,10 +181,10 @@ def ex37Dependency : SetRel (Fin 2) (Fin 2) := {(0, 1)}
 def ex37Val : Fin 2 → ℕ :=
   fun p => if p = 0 then 1 else 2
 
-/-- A partial-control reading is incompatible with a predicative
+/-- A partial-control reading is incompatible with a saturating
     dependency: (37a)'s star, from exhaustive sharing. -/
-theorem manage_excludes_pc : ¬ IsPredicative ex37Val ex37Dependency :=
-  fun h => h.not_partial (a := 0) (b := 1) rfl (by decide)
+theorem manage_excludes_pc : ¬ IsSaturating ex37Val ex37Dependency :=
+  fun h => h.not_hasPartial ⟨0, 1, rfl, by decide⟩
 
 /-! ### NOC: dual licensing by topic and logophoric center
 

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -8,6 +8,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.Mixtec.SMPM.Basic
 import Linglib.Syntax.Control.Tier
 import Linglib.Syntax.Control.CopyControl
+import Linglib.Syntax.Control.Dependency
 import Linglib.Syntax.Control.Signature
 import Linglib.Studies.Allotey2021
 import Linglib.Features.Complementation

--- a/Linglib/Syntax/Control/Dependency.lean
+++ b/Linglib/Syntax/Control/Dependency.lean
@@ -5,129 +5,132 @@ Authors: Robert Hawkins
 -/
 import Mathlib.Data.Rel
 import Mathlib.Logic.Relator
+import Mathlib.Order.Basic
 
 /-!
 # Control Dependencies
 
-The framework-neutral positional stratum of control theory. Control is
-pre-theoretically an antecedence relation between the understood
-subject of a clause-like complement and the matrix argument that
-supplies its interpretation ([mccloskey-2003]; [landau-2013] (74)); a
-dependency here is a bundled relation `SetRel Pos Pos` over argument
-positions, read `antecedent ~[r] dependent`. Grammatical dependencies
-share the fixed format of the configurational matrix ([koster-1987];
-[neeleman-vandekoot-2002]), and every clause of the matrix is mathlib
-vocabulary in the `SetRel` lattice: c-command, locality, and feature
-matching are refinements `r ⊆ s`; uniqueness of the antecedent is
-`SetRel.IsInjective`; obligatoriness is `dependent ⊆ r.cod`; the
-nonuniqueness of dependents that the general format permits is exactly
-what predication forbids (`SetRel.IsFunctional` — saturation consumes
-its one slot). Movement chains, bound anaphora, and both control
-mechanisms instantiate the format, so nothing here chooses between
-base-generation and movement.
+The framework-neutral stratum of control theory. Control is pre-theoretically
+an antecedence relation between the understood subject of a clause-like
+complement and the matrix argument that supplies its interpretation
+([landau-2013] (74)); the one definition in the literature written to be
+neutral between the rival mechanisms is [stiebels-2007] (22): the control
+predicate requires one of its arguments to be (improperly) included in the
+reference of the embedded subject, "open as to how the control reading is
+obtained: either structurally or semantically/lexically". A dependency here is
+a relation `SetRel Pos Pos` over argument positions, read
+`antecedent ~[r] dependent`, with a valuation `val : Pos → Ref` assigning
+referents; exhaustive inclusion is the kernel refinement `Control.Shares`, and
+proper inclusion — a partial reading ([landau-2000]) — is strict growth
+`val a < val b` along the dependency.
 
-Composition `○` carries [landau-2024]'s decomposition of logophoric
-control as binding ∘ predication: the composite keeps every refinement
-(`SetRel.comp_subset_comp`), obligatoriness (`cod_subset_cod_comp`),
-and both uniqueness properties (`IsInjective.comp`,
-`IsFunctional.comp`) of its legs — so control shift and split control
-can enter only through a non-functional binding leg, the perspectival
-*pro* anchoring to AUTHOR, ADDRESSEE, or their sum, never through
-predication.
+Grammatical dependencies share the fixed format of the configurational matrix:
+[koster-1987]'s five shared properties, as explained by
+[neeleman-vandekoot-2002] — c-command by the antecedent, obligatoriness,
+uniqueness of the antecedent, nonuniqueness of the dependent, and locality.
+Every clause of the matrix is mathlib vocabulary in the `SetRel` lattice:
+c-command and locality are refinements `r ⊆ s`, uniqueness of the antecedent
+is `SetRel.IsInjective`, obligatoriness is `dependent ⊆ r.cod`. Movement
+chains, bound anaphora, and both control mechanisms instantiate the format, so
+nothing here chooses between base-generation and movement.
 
-The declarations below are general relation algebra that mathlib's
-`SetRel` currently lacks; each is marked `[UPSTREAM]`.
+Composition `○` serves the theories that decompose a control dependency into
+legs (e.g. [landau-2024]'s binding over predication): a composite keeps every
+refinement (`SetRel.comp_subset_comp`), obligatoriness
+(`cod_comp_of_dom_subset`), both uniqueness properties (`IsFunctional.comp`,
+`IsInjective.comp`), and sharing (`Shares.comp`) of its legs, and a partial
+reading localizes to a leg (`exists_lt_of_comp_lt`).
 
-The `Control` section adds the referential stratum: a valuation
-`val : Pos → Ref` assigns each position its referent, and a dependency
-enforces exhaustive argument sharing (`Control.Shares`) when it refines
-the valuation's kernel. Partial control ([landau-2000]) is strict
-growth `val a < val b` along the dependency — excluded by exhaustive
-sharing (`Shares.not_lt`) and localizable to a leg of a composite
-(`exists_lt_of_comp_lt`), which is [landau-2024]'s claim that partial
-readings enter through the mediating *pro*, never through predication.
-Split control (a dependent's referent joining two antecedents') is
-excluded the same way: exhaustive sharing forces joint antecedents to
-be co-valued (`Shares.eq_of_two`).
+What a dependency shares distinguishes the enforcement species —
+[bresnan-1982]'s functional vs. anaphoric control: *functional* control shares
+the occupant assignment itself (structure sharing; movement chains),
+*anaphoric* control only the referent valuation. Occupant sharing is the
+stronger: a shared assignment transports along every map of it (`Shares.map`),
+so every occupant property transports across the dependency
+(`Shares.iff_of_rel`) and one observed mismatch refutes it
+(`not_shares_of_mismatch`) — the refutation engine of the overt-copy
+diagnostics ([polinsky-potsdam-2006]).
+
+The `SetRel` declarations are general relation algebra that mathlib currently
+lacks; each is marked `[UPSTREAM]`.
+
+## Main definitions
+
+- `SetRel.IsFunctional`, `SetRel.IsInjective`, `SetRel.IsBiUnique`
+- `SetRel.ker`: the kernel of a function, as a relation
+- `Control.Shares`: exhaustive argument sharing as kernel refinement
 -/
 
 namespace SetRel
 
-variable {α β γ : Type*} {R : SetRel α β} {S : SetRel β γ}
+variable {α β γ : Type*} {R : SetRel α β} {S : SetRel β γ} {f : α → β} {a b : α}
 
-/-- `[UPSTREAM]` A relation is functional when it relates each left
-    element to at most one right element. -/
+/-- `[UPSTREAM]` A relation is functional when it relates each left element to
+    at most one right element. -/
 protected abbrev IsFunctional (R : SetRel α β) : Prop :=
-  R.inv ○ R ⊆ .id
+  Relator.RightUnique (· ~[R] ·)
 
-/-- `[UPSTREAM]` A relation is injective when it relates each right
-    element to at most one left element. -/
+/-- `[UPSTREAM]` A relation is injective when it relates each right element to
+    at most one left element. -/
 protected abbrev IsInjective (R : SetRel α β) : Prop :=
-  R ○ R.inv ⊆ .id
+  Relator.LeftUnique (· ~[R] ·)
+
+/-- `[UPSTREAM]` A relation is bi-unique when it is injective and functional. -/
+protected abbrev IsBiUnique (R : SetRel α β) : Prop :=
+  Relator.BiUnique (· ~[R] ·)
+
+/-- `[UPSTREAM]` Functionality is the relation-algebra inequality
+    `R.inv ○ R ⊆ .id`. -/
+theorem isFunctional_iff_inv_comp_subset_id : R.IsFunctional ↔ R.inv ○ R ⊆ .id where
+  mp h := fun ⟨_, _⟩ ⟨_, hba, hab'⟩ => h hba hab'
+  mpr h := fun _ _ _ hab hab' => mem_id.1 (h ⟨_, mem_inv.2 hab, hab'⟩)
+
+/-- `[UPSTREAM]` Injectivity is the relation-algebra inequality
+    `R ○ R.inv ⊆ .id`. -/
+theorem isInjective_iff_comp_inv_subset_id : R.IsInjective ↔ R ○ R.inv ⊆ .id where
+  mp h := fun ⟨_, _⟩ ⟨_, hab, hba'⟩ => h hab hba'
+  mpr h := fun _ _ _ hab ha'b => mem_id.1 (h ⟨_, hab, mem_inv.2 ha'b⟩)
 
 /-- `[UPSTREAM]` Functional relations compose. -/
 theorem IsFunctional.comp (hR : R.IsFunctional) (hS : S.IsFunctional) :
-    (R ○ S).IsFunctional := by
-  rintro ⟨c, c'⟩ ⟨a, hca, hac'⟩
-  obtain ⟨b, hab, hbc⟩ := mem_inv.mp hca
-  obtain ⟨b', hab', hb'c'⟩ := hac'
-  obtain rfl : b = b' := mem_id.mp (hR (prodMk_mem_comp (mem_inv.mpr hab) hab'))
-  exact hS (prodMk_mem_comp (mem_inv.mpr hbc) hb'c')
+    (R ○ S).IsFunctional :=
+  fun _ _ _ ⟨_, hab, hbc⟩ ⟨_, hab', hb'c⟩ => hS (hR hab hab' ▸ hbc) hb'c
 
 /-- `[UPSTREAM]` Injective relations compose. -/
 theorem IsInjective.comp (hR : R.IsInjective) (hS : S.IsInjective) :
-    (R ○ S).IsInjective := by
-  rintro ⟨a, a'⟩ ⟨c, hac, hca'⟩
-  obtain ⟨b, hab, hbc⟩ := hac
-  obtain ⟨b', ha'b', hb'c⟩ := mem_inv.mp hca'
-  obtain rfl : b = b' := mem_id.mp (hS (prodMk_mem_comp hbc (mem_inv.mpr hb'c)))
-  exact hR (prodMk_mem_comp hab (mem_inv.mpr ha'b'))
+    (R ○ S).IsInjective :=
+  fun _ _ _ ⟨_, hab, hbc⟩ ⟨_, ha'b', hb'c⟩ => hR (hS hbc hb'c ▸ hab) ha'b'
 
-/-- `[UPSTREAM]` Functionality is right-uniqueness of the underlying
-    relation. -/
-theorem isFunctional_iff_rightUnique :
-    R.IsFunctional ↔ Relator.RightUnique (· ~[R] ·) := by
-  constructor
-  · intro h a b b' hab hab'
-    exact mem_id.mp (h (prodMk_mem_comp (mem_inv.mpr hab) hab'))
-  · rintro h ⟨b, b'⟩ ⟨a, hba, hab'⟩
-    exact mem_id.mpr (h (mem_inv.mp hba) hab')
+/-- `[UPSTREAM]` The kernel of a function, as a relation: `a ~[ker f] b` iff
+    `f a = f b`. -/
+def ker (f : α → β) : SetRel α α := f.graph ○ f.graph.inv
 
-/-- `[UPSTREAM]` Injectivity is left-uniqueness of the underlying
-    relation. -/
-theorem isInjective_iff_leftUnique :
-    R.IsInjective ↔ Relator.LeftUnique (· ~[R] ·) := by
-  constructor
-  · intro h a a' b hab ha'b
-    exact mem_id.mp (h (prodMk_mem_comp hab (mem_inv.mpr ha'b)))
-  · rintro h ⟨a, a'⟩ ⟨b, hab, hba'⟩
-    exact mem_id.mpr (h hab (mem_inv.mp hba'))
+@[simp] theorem mem_ker : a ~[ker f] b ↔ f a = f b := by simp [ker, eq_comm]
 
-/-- `[UPSTREAM]` The codomain of a composite is contained in the second
-    leg's codomain. -/
-theorem cod_comp_subset : (R ○ S).cod ⊆ S.cod := by
-  rintro c ⟨a, b, hab, hbc⟩
-  exact ⟨b, hbc⟩
+instance : (ker f).IsRefl where refl _ := mem_ker.2 rfl
 
-/-- `[UPSTREAM]` The second leg's codomain survives composition when
-    its domain is covered by the first leg's codomain. -/
-theorem cod_subset_cod_comp (h : S.dom ⊆ R.cod) : S.cod ⊆ (R ○ S).cod := by
-  rintro c ⟨b, hbc⟩
-  obtain ⟨a, hab⟩ := h ⟨c, hbc⟩
-  exact ⟨a, b, hab, hbc⟩
+instance : (ker f).IsSymm where symm _ _ h := mem_ker.2 (mem_ker.1 h).symm
 
-/-- `[UPSTREAM]` The domain of a composite is contained in the first
-    leg's domain. -/
-theorem dom_comp_subset : (R ○ S).dom ⊆ R.dom := by
-  rintro a ⟨c, b, hab, hbc⟩
-  exact ⟨b, hab⟩
+instance : (ker f).IsTrans where
+  trans _ _ _ h h' := mem_ker.2 ((mem_ker.1 h).trans (mem_ker.1 h'))
 
-/-- `[UPSTREAM]` The first leg's domain survives composition when its
-    codomain is covered by the second leg's domain. -/
-theorem dom_subset_dom_comp (h : R.cod ⊆ S.dom) : R.dom ⊆ (R ○ S).dom := by
-  rintro a ⟨b, hab⟩
-  obtain ⟨c, hbc⟩ := h ⟨a, hab⟩
-  exact ⟨c, b, hab, hbc⟩
+/-- `[UPSTREAM]` The codomain of a composite is the image of the first leg's
+    codomain under the second leg. -/
+theorem cod_comp : (R ○ S).cod = S.image R.cod := by aesop
+
+/-- `[UPSTREAM]` The domain of a composite is the preimage of the second leg's
+    domain under the first leg. -/
+theorem dom_comp : (R ○ S).dom = R.preimage S.dom := by aesop
+
+/-- `[UPSTREAM]` The composite's codomain is the second leg's when the second
+    leg's domain is covered by the first leg's codomain. -/
+theorem cod_comp_of_dom_subset (h : S.dom ⊆ R.cod) : (R ○ S).cod = S.cod := by
+  rw [cod_comp, image_eq_cod_of_dom_subset h]
+
+/-- `[UPSTREAM]` The composite's domain is the first leg's when the first
+    leg's codomain is covered by the second leg's domain. -/
+theorem dom_comp_of_cod_subset (h : R.cod ⊆ S.dom) : (R ○ S).dom = R.dom := by
+  rw [dom_comp, preimage_eq_dom_of_cod_subset h]
 
 end SetRel
 
@@ -140,40 +143,40 @@ open SetRel
 variable {Pos Ref : Type*} {val : Pos → Ref} {ante bind pred : SetRel Pos Pos}
   {a b p c : Pos}
 
-/-- A dependency enforces exhaustive argument sharing when related
-    positions are co-valued — the dependency refines the kernel of the
-    valuation. -/
-def Shares (val : Pos → Ref) (ante : SetRel Pos Pos) : Prop :=
-  ∀ ⦃a b⦄, a ~[ante] b → val a = val b
+/-- A dependency enforces exhaustive argument sharing when related positions
+    are co-valued — the dependency refines the kernel of the valuation. -/
+abbrev Shares (val : Pos → Ref) (ante : SetRel Pos Pos) : Prop :=
+  ante ⊆ .ker val
+
+/-- Related positions of a sharing dependency are co-valued. -/
+theorem Shares.eq (hs : Shares val ante) (h : a ~[ante] b) : val a = val b :=
+  mem_ker.1 (hs h)
 
 /-- A refinement of a sharing dependency shares. -/
 theorem Shares.mono (h : ante ⊆ bind) (hs : Shares val bind) :
     Shares val ante :=
-  fun _ _ hab => hs (h hab)
+  h.trans hs
 
 /-- Sharing composes through the mediating position. -/
 theorem Shares.comp (hb : Shares val bind) (hp : Shares val pred) :
-    Shares val (bind ○ pred) := by
-  rintro a c ⟨m, ham, hmc⟩
-  exact (hb ham).trans (hp hmc)
+    Shares val (bind ○ pred) :=
+  (comp_subset_comp hb hp).trans comp_subset_self
 
-/-- Exhaustive sharing excludes partial readings: no strict growth of
-    the referent along the dependency ([landau-2000]). -/
+/-- Exhaustive sharing excludes partial readings: no strict growth of the
+    referent along the dependency ([landau-2000]). -/
 theorem Shares.not_lt [Preorder Ref] (hs : Shares val ante)
     (h : a ~[ante] b) : ¬ val a < val b := by
-  simp [hs h]
+  simp [hs.eq h]
 
-/-- Under exhaustive sharing, joint antecedents are co-valued — split
-    control needs a non-exhaustive leg. -/
+/-- Under exhaustive sharing, joint antecedents are co-valued — split control
+    needs a non-exhaustive leg. -/
 theorem Shares.eq_of_two (hs : Shares val ante) (ha : a ~[ante] p)
     (hb : b ~[ante] p) : val a = val b :=
-  (hs ha).trans (hs hb).symm
+  (hs.eq ha).trans (hs.eq hb).symm
 
-/-- A partial reading in a composite localizes to a leg: if referents
-    grow monotonely along the binding link and strictly across the
-    composite, one of the two links already grows strictly. With an
-    exhaustive predication leg this places partial control in the
-    binding leg ([landau-2024] §5.1). -/
+/-- A partial reading in a composite localizes to a leg: if referents grow
+    monotonely along the first leg and strictly across the composite, one of
+    the two legs already grows strictly. -/
 theorem exists_lt_of_comp_lt [PartialOrder Ref]
     (hb : ∀ ⦃x m⦄, x ~[bind] m → val x ≤ val m)
     (h : a ~[bind ○ pred] c) (hlt : val a < val c) :
@@ -186,37 +189,33 @@ theorem exists_lt_of_comp_lt [PartialOrder Ref]
 
 /-! ### Enforcement
 
-The species of sharing enforcement are distinguished by WHAT the
-dependency shares ([landau-2024] §3's road map; [mccloskey-2003]):
-token identity (movement) shares the occupant assignment itself;
-referential dependencies (predication, coordinate binding) share only
-the referent valuation; complex-predicate formation merges grids with
-no dependent position; lexicalist accounts enforce sharing by meaning
-postulate. Token identity is the strongest: a shared assignment
-transports along every map of it (`Shares.map`), so every occupant
-property transports across the dependency (`Shares.iff_of_rel`) — and
-one observed mismatch refutes it (`not_shares_of_mismatch`), the
-engine of the copy-control diagnostics (embedded lexical copies,
-exempt anaphora with quantified controllers). -/
+What a dependency shares distinguishes the enforcement species
+([bresnan-1982]): functional control shares the occupant assignment itself
+(structure sharing — movement chains, LFG control equations), anaphoric
+control only the referent valuation. Occupant sharing is the stronger: a
+shared assignment transports along every map of it (`Shares.map`), so every
+occupant property transports across the dependency (`Shares.iff_of_rel`) —
+and one observed mismatch refutes it (`not_shares_of_mismatch`), the engine
+of the overt-copy diagnostics ([polinsky-potsdam-2006]). -/
 
 variable {Item : Type*} {occ : Pos → Item}
 
-/-- Sharing an assignment transports along any map of it: token
-    identity yields referential co-valuation for every referent map. -/
+/-- Sharing an assignment transports along any map of it: token identity
+    yields referential co-valuation for every referent map. -/
 theorem Shares.map (hs : Shares occ ante) (f : Item → Ref) :
     Shares (f ∘ occ) ante :=
-  fun _ _ hab => congrArg f (hs hab)
+  fun _ h => mem_ker.2 (congrArg f (hs.eq h))
 
-/-- Under a shared assignment, every property of the assigned value
-    transports across the dependency: copies are indistinguishable. -/
+/-- Under a shared assignment, every property of the assigned value transports
+    across the dependency: copies are indistinguishable. -/
 theorem Shares.iff_of_rel (hs : Shares occ ante) (h : a ~[ante] b)
     (P : Item → Prop) : P (occ a) ↔ P (occ b) :=
-  iff_of_eq (congrArg P (hs h))
+  iff_of_eq (congrArg P (hs.eq h))
 
-/-- One observed mismatch refutes a shared assignment — the refutation
-    engine of the copy-control diagnostics. -/
+/-- One observed mismatch refutes a shared assignment — the refutation engine
+    of the copy-control diagnostics. -/
 theorem not_shares_of_mismatch {P : Item → Prop} (h : a ~[ante] b)
     (hPa : P (occ a)) (hPb : ¬ P (occ b)) : ¬ Shares occ ante :=
-  fun hs => hPb (hs h ▸ hPa)
+  fun hs => hPb (hs.eq h ▸ hPa)
 
 end Control

--- a/Linglib/Syntax/Control/Taxonomy.lean
+++ b/Linglib/Syntax/Control/Taxonomy.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.Control.Dependency
+
+/-!
+# The Descriptive Taxonomy of Control
+
+The shared descriptive vocabulary of control — reading types and dependency
+shapes every framework's account is answerable to — as properties of a
+dependency `SetRel Pos Pos` with valuation `val : Pos → Ref`
+(`Syntax/Control/Dependency.lean`): exhaustive vs. partial readings
+([landau-2000]; [pearson-2016]) and split antecedents. Control *shift* — the
+antecedent varying across readings of one construction — is deliberately not a
+property of a single dependency: a dependency encodes one reading, so shift
+lives at the controller-choice stratum.
+
+`Mechanism` names what a dependency shares — the framework-neutral cut behind
+the movement vs. base-generation and functional vs. anaphoric
+([bresnan-1982]) oppositions. `IsSaturating` is the profile of a dependency
+enforced by saturation (predication, structure sharing): bi-unique and
+exhaustive, with the phenomenology — no partial reading, no split
+antecedents — as theorems.
+
+## Main definitions
+
+- `Control.IsExhaustive`, `Control.HasPartial`, `Control.HasSplit`
+- `Control.Mechanism`
+- `Control.IsSaturating`
+-/
+
+namespace Control
+
+open SetRel
+
+variable {Pos Ref : Type*} {val : Pos → Ref} {d : SetRel Pos Pos} {a b p q : Pos}
+
+/-! ### Reading types -/
+
+/-- Exhaustive control: the dependency refines the valuation's kernel. -/
+abbrev IsExhaustive (val : Pos → Ref) (d : SetRel Pos Pos) : Prop :=
+  Shares val d
+
+/-- A partial reading ([landau-2000]): some dependent's referent strictly
+    extends its controller's. -/
+def HasPartial [Preorder Ref] (val : Pos → Ref) (d : SetRel Pos Pos) : Prop :=
+  ∃ a b, a ~[d] b ∧ val a < val b
+
+/-- Split control: some dependent has two distinct controllers. -/
+abbrev HasSplit (d : SetRel Pos Pos) : Prop :=
+  ¬ d.IsInjective
+
+/-- An exhaustive dependency admits no partial reading. -/
+theorem IsExhaustive.not_hasPartial [Preorder Ref] (h : IsExhaustive val d) :
+    ¬ HasPartial val d :=
+  fun ⟨_, _, hab, hlt⟩ => absurd (h.eq hab) hlt.ne
+
+/-! ### Mechanism -/
+
+/-- What a control dependency shares — the framework-neutral cut behind the
+    movement vs. base-generation and functional vs. anaphoric
+    ([bresnan-1982]) oppositions. -/
+inductive Mechanism where
+  /-- Token identity: the occupant assignment itself is shared (movement
+      chains; LFG functional control). -/
+  | occupant
+  /-- Referential co-valuation only (LFG anaphoric control; predication). -/
+  | referent
+  /-- A binding leg composed over a predication leg ([landau-2024]). -/
+  | composite
+  /-- No grammatical dependency (non-obligatory control). -/
+  | free
+  deriving DecidableEq, Repr
+
+/-! ### Saturation -/
+
+/-- The profile of a dependency enforced by saturation (predication,
+    structure sharing): each dependent has a unique controller, each
+    controller saturates a single slot, and the referent is shared
+    exhaustively. -/
+structure IsSaturating (val : Pos → Ref) (d : SetRel Pos Pos) : Prop where
+  biUnique : d.IsBiUnique
+  exhaustive : IsExhaustive val d
+
+/-- A saturating dependency admits no partial reading. -/
+theorem IsSaturating.not_hasPartial [Preorder Ref] (h : IsSaturating val d) :
+    ¬ HasPartial val d :=
+  h.exhaustive.not_hasPartial
+
+/-- A saturating dependency admits no split: joint controllers coincide. -/
+theorem IsSaturating.eq_of_controllers (h : IsSaturating val d)
+    (ha : a ~[d] p) (hb : b ~[d] p) : a = b :=
+  h.biUnique.1 ha hb
+
+/-- A saturating dependency admits no split antecedents. -/
+theorem IsSaturating.not_hasSplit (h : IsSaturating val d) : ¬ HasSplit d :=
+  not_not_intro h.biUnique.1
+
+/-- A saturating controller saturates a single slot: its dependents
+    coincide. -/
+theorem IsSaturating.eq_of_controlled (h : IsSaturating val d)
+    (hp : a ~[d] p) (hq : a ~[d] q) : p = q :=
+  h.biUnique.2 hp hq
+
+end Control

--- a/Linglib/Syntax/Control/Tier.lean
+++ b/Linglib/Syntax/Control/Tier.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 
-import Linglib.Syntax.Control.Dependency
-
 /-!
 # Control Theory: Tiers, Predicate Classes, Clause Classes
 
@@ -24,10 +22,9 @@ for the paper-anchored control studies (`Studies/Landau2015.lean`,
 
 ## Main definitions
 
-- `Control.Tier`: predicative vs. logophoric control
-- `Control.IsPredicative`: the grammatical profile of a
-  predicative-control dependency, with the tier's phenomenology as
-  theorems (exhaustive, no split, no shift)
+- `Control.Tier`: predicative vs. logophoric control; the predicative
+  mechanism's grammatical profile is the framework-neutral
+  `Control.IsSaturating` (`Syntax/Control/Taxonomy.lean`)
 - `Control.PredicateClass`: the eight predicate classes, mapped to tiers
 - `Control.ClauseClass`: the `[±T]` scale positions, with the
   Agr-sensitive `ClauseClass.HasOC` and its characterization
@@ -77,53 +74,6 @@ def Tier.isAttitude : Tier → Bool
     ([ganenkov-2019]). -/
 def Tier.agrBlocksControl (t : Tier) : Bool :=
   t.isAttitude
-
-/-! ### The predicative mechanism
-
-Predication is saturation, so a predicative-control dependency is
-functional, injective, and exhaustively shares the referent; the
-tier's phenomenology follows ([landau-2015]; [landau-2024] §5.1):
-exhaustive control, no split, no shift. Logophoric control composes a
-binding leg over predication and escapes each property exactly when
-the binding leg does (`SetRel.IsInjective.comp`,
-`SetRel.IsFunctional.comp`, `Control.Shares.comp` contrapositives).
-Implicit control ((90)), `[−human]` PRO ((81)), and Agr-blocking
-((60)/(70)) need overtness, animacy, and φ carriers; they are carried
-at the enforcement stratum. -/
-
-section Mechanism
-
-open SetRel
-
-variable {Pos Ref : Type*} {val : Pos → Ref} {d : SetRel Pos Pos}
-  {a b p q : Pos}
-
-/-- The grammatical profile of a predicative-control dependency:
-    predication saturates a unique slot by a unique argument and shares
-    the referent exhaustively. -/
-structure IsPredicative (val : Pos → Ref) (d : SetRel Pos Pos) : Prop where
-  functional : d.IsFunctional
-  injective : d.IsInjective
-  shares : Shares val d
-
-/-- Predicative control is exhaustive: the dependent's referent never
-    strictly extends the controller's (no partial control). -/
-theorem IsPredicative.not_partial [Preorder Ref] (h : IsPredicative val d)
-    (hab : a ~[d] b) : ¬ val a < val b :=
-  h.shares.not_lt hab
-
-/-- Predicative control admits no split: joint controllers coincide. -/
-theorem IsPredicative.eq_of_controllers (h : IsPredicative val d)
-    (ha : a ~[d] p) (hb : b ~[d] p) : a = b :=
-  isInjective_iff_leftUnique.mp h.injective ha hb
-
-/-- Predicative control admits no shift: a controller saturates a
-    single slot. -/
-theorem IsPredicative.eq_of_controlled (h : IsPredicative val d)
-    (hp : a ~[d] p) (hq : a ~[d] q) : p = q :=
-  isFunctional_iff_rightUnique.mp h.functional hp hq
-
-end Mechanism
 
 /-! ### Predicate classification -/
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17673,6 +17673,20 @@
   role      = {formalized},
   validated = {true},
   sources   = {Fragments/Arabic/ModernStandard/Relativization.lean;Fragments/English/Relativization.lean;Fragments/Finnish/Relativization.lean;Fragments/Hebrew/Relativization.lean;Fragments/Korean/Relativization.lean;Fragments/Malagasy/Relativization.lean;Fragments/Swahili/Relativization.lean;Fragments/TobaBatak/Relativization.lean;Fragments/Welsh/Relativization.lean;Studies/KeenanComrie1977.lean;Studies/Comrie1989.lean;Syntax/Extraction.lean}
+}% REF: Bresnan, J. (1982). Control and complementation. LI 13(3):343-434.
+@article{bresnan-1982,
+  author    = {Bresnan, Joan},
+  year      = {1982},
+  title     = {Control and complementation},
+  journal   = {Linguistic Inquiry},
+  volume    = {13},
+  number    = {3},
+  pages     = {343--434},
+  url       = {https://www.jstor.org/stable/4178286},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Control/Dependency.lean;Syntax/Control/Taxonomy.lean}
 }% REF: Ingram, D. (1978). Typology and universals of personal pronouns.
 @incollection{bresnan-etal-1982,
   author    = {Bresnan, Joan and Kaplan, Ronald M. and Peters, Stanley and Zaenen, Annie},
@@ -18411,6 +18425,19 @@
   role      = {cited},
   validated = {true},
   sources   = {Studies/Preminger2014.lean}
+}% REF: Stiebels, B. (2007). Towards a typology of complement control. ZASPiL 47:1-59.
+@article{stiebels-2007,
+  author    = {Stiebels, Barbara},
+  year      = {2007},
+  title     = {Towards a typology of complement control},
+  journal   = {ZAS Papers in Linguistics},
+  volume    = {47},
+  pages     = {1--59},
+  doi       = {10.21248/zaspil.47.2007.344},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/Control/Dependency.lean}
 }% REF: Halpert, C. (2012). Argument licensing and agreement in Zulu. PhD diss., MIT.
 @phdthesis{halpert-2012,
   author    = {Halpert, Claire},


### PR DESCRIPTION
First wave of the consensus-API redesign from the Control audit: `Dependency.lean` restated in mathlib's own `SetRel` idiom (pointwise `IsFunctional`/`IsInjective`/`IsBiUnique` via `Relator`, `SetRel.ker`, `Shares` as kernel refinement, dom/cod composite equations) and re-anchored on the mechanism-neutral definition (Stiebels 2007 (22), Bresnan 1982 functional/anaphoric — both bib entries source-verified); new `Taxonomy.lean` extracts the mechanism stratum (`Mechanism`, `IsExhaustive`/`HasPartial`/`HasSplit`, `IsSaturating` replacing the tier-named `IsPredicative`, with the shift mislabel corrected).

- drops two dead imports (Landau2024 ← Signature, Allotey2021 ← CopyControl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)