### PR TITLE
refactor(Syntax/Control): inline Relator vocabulary, drop SetRel aliases

### DIFF
--- a/Linglib/Syntax/Control/Dependency.lean
+++ b/Linglib/Syntax/Control/Dependency.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Mathlib.Data.Rel
-import Mathlib.Logic.Relator
 import Mathlib.Order.Basic
 
 /-!
@@ -28,18 +27,16 @@ Grammatical dependencies share the fixed format of the configurational matrix:
 [koster-1987]'s five shared properties, as explained by
 [neeleman-vandekoot-2002] — c-command by the antecedent, obligatoriness,
 uniqueness of the antecedent, nonuniqueness of the dependent, and locality.
-Every clause of the matrix is mathlib vocabulary in the `SetRel` lattice:
-c-command and locality are refinements `r ⊆ s`, uniqueness of the antecedent
-is `SetRel.IsInjective`, obligatoriness is `dependent ⊆ r.cod`. Movement
-chains, bound anaphora, and both control mechanisms instantiate the format, so
-nothing here chooses between base-generation and movement.
+Every clause of the matrix is mathlib vocabulary: c-command and locality are
+refinements `r ⊆ s` in the `SetRel` lattice, uniqueness of the antecedent is
+`Relator.LeftUnique`, obligatoriness is `dependent ⊆ r.cod`. Movement chains,
+bound anaphora, and both control mechanisms instantiate the format, so nothing
+here chooses between base-generation and movement.
 
 Composition `○` serves the theories that decompose a control dependency into
 legs (e.g. [landau-2024]'s binding over predication): a composite keeps every
-refinement (`SetRel.comp_subset_comp`), obligatoriness
-(`cod_comp_of_dom_subset`), both uniqueness properties (`IsFunctional.comp`,
-`IsInjective.comp`), and sharing (`Shares.comp`) of its legs, and a partial
-reading localizes to a leg (`exists_lt_of_comp_lt`).
+refinement (`SetRel.comp_subset_comp`) and the sharing (`Shares.comp`) of its
+legs, and a partial reading localizes to a leg (`exists_lt_of_comp_lt`).
 
 What a dependency shares distinguishes the enforcement species —
 [bresnan-1982]'s functional vs. anaphoric control: *functional* control shares
@@ -51,55 +48,15 @@ so every occupant property transports across the dependency
 (`not_shares_of_mismatch`) — the refutation engine of the overt-copy
 diagnostics ([polinsky-potsdam-2006]).
 
-The `SetRel` declarations are general relation algebra that mathlib currently
-lacks; each is marked `[UPSTREAM]`.
-
 ## Main definitions
 
-- `SetRel.IsFunctional`, `SetRel.IsInjective`, `SetRel.IsBiUnique`
-- `SetRel.ker`: the kernel of a function, as a relation
+- `SetRel.ker`: the kernel of a function, as a relation (`[UPSTREAM]`)
 - `Control.Shares`: exhaustive argument sharing as kernel refinement
 -/
 
 namespace SetRel
 
-variable {α β γ : Type*} {R : SetRel α β} {S : SetRel β γ} {f : α → β} {a b : α}
-
-/-- `[UPSTREAM]` A relation is functional when it relates each left element to
-    at most one right element. -/
-protected abbrev IsFunctional (R : SetRel α β) : Prop :=
-  Relator.RightUnique (· ~[R] ·)
-
-/-- `[UPSTREAM]` A relation is injective when it relates each right element to
-    at most one left element. -/
-protected abbrev IsInjective (R : SetRel α β) : Prop :=
-  Relator.LeftUnique (· ~[R] ·)
-
-/-- `[UPSTREAM]` A relation is bi-unique when it is injective and functional. -/
-protected abbrev IsBiUnique (R : SetRel α β) : Prop :=
-  Relator.BiUnique (· ~[R] ·)
-
-/-- `[UPSTREAM]` Functionality is the relation-algebra inequality
-    `R.inv ○ R ⊆ .id`. -/
-theorem isFunctional_iff_inv_comp_subset_id : R.IsFunctional ↔ R.inv ○ R ⊆ .id where
-  mp h := fun ⟨_, _⟩ ⟨_, hba, hab'⟩ => h hba hab'
-  mpr h := fun _ _ _ hab hab' => mem_id.1 (h ⟨_, mem_inv.2 hab, hab'⟩)
-
-/-- `[UPSTREAM]` Injectivity is the relation-algebra inequality
-    `R ○ R.inv ⊆ .id`. -/
-theorem isInjective_iff_comp_inv_subset_id : R.IsInjective ↔ R ○ R.inv ⊆ .id where
-  mp h := fun ⟨_, _⟩ ⟨_, hab, hba'⟩ => h hab hba'
-  mpr h := fun _ _ _ hab ha'b => mem_id.1 (h ⟨_, hab, mem_inv.2 ha'b⟩)
-
-/-- `[UPSTREAM]` Functional relations compose. -/
-theorem IsFunctional.comp (hR : R.IsFunctional) (hS : S.IsFunctional) :
-    (R ○ S).IsFunctional :=
-  fun _ _ _ ⟨_, hab, hbc⟩ ⟨_, hab', hb'c⟩ => hS (hR hab hab' ▸ hbc) hb'c
-
-/-- `[UPSTREAM]` Injective relations compose. -/
-theorem IsInjective.comp (hR : R.IsInjective) (hS : S.IsInjective) :
-    (R ○ S).IsInjective :=
-  fun _ _ _ ⟨_, hab, hbc⟩ ⟨_, ha'b', hb'c⟩ => hR (hS hbc hb'c ▸ hab) ha'b'
+variable {α β : Type*} {f : α → β} {a b : α}
 
 /-- `[UPSTREAM]` The kernel of a function, as a relation: `a ~[ker f] b` iff
     `f a = f b`. -/
@@ -113,24 +70,6 @@ instance : (ker f).IsSymm where symm _ _ h := mem_ker.2 (mem_ker.1 h).symm
 
 instance : (ker f).IsTrans where
   trans _ _ _ h h' := mem_ker.2 ((mem_ker.1 h).trans (mem_ker.1 h'))
-
-/-- `[UPSTREAM]` The codomain of a composite is the image of the first leg's
-    codomain under the second leg. -/
-theorem cod_comp : (R ○ S).cod = S.image R.cod := by aesop
-
-/-- `[UPSTREAM]` The domain of a composite is the preimage of the second leg's
-    domain under the first leg. -/
-theorem dom_comp : (R ○ S).dom = R.preimage S.dom := by aesop
-
-/-- `[UPSTREAM]` The composite's codomain is the second leg's when the second
-    leg's domain is covered by the first leg's codomain. -/
-theorem cod_comp_of_dom_subset (h : S.dom ⊆ R.cod) : (R ○ S).cod = S.cod := by
-  rw [cod_comp, image_eq_cod_of_dom_subset h]
-
-/-- `[UPSTREAM]` The composite's domain is the first leg's when the first
-    leg's codomain is covered by the second leg's domain. -/
-theorem dom_comp_of_cod_subset (h : R.cod ⊆ S.dom) : (R ○ S).dom = R.dom := by
-  rw [dom_comp, preimage_eq_dom_of_cod_subset h]
 
 end SetRel
 

--- a/Linglib/Syntax/Control/Taxonomy.lean
+++ b/Linglib/Syntax/Control/Taxonomy.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Syntax.Control.Dependency
+import Mathlib.Logic.Relator
 
 /-!
 # The Descriptive Taxonomy of Control
@@ -20,9 +21,9 @@ lives at the controller-choice stratum.
 `Mechanism` names what a dependency shares — the framework-neutral cut behind
 the movement vs. base-generation and functional vs. anaphoric
 ([bresnan-1982]) oppositions. `IsSaturating` is the profile of a dependency
-enforced by saturation (predication, structure sharing): bi-unique and
-exhaustive, with the phenomenology — no partial reading, no split
-antecedents — as theorems.
+enforced by saturation (predication, structure sharing): bi-unique
+(`Relator.BiUnique`) and exhaustive, with the phenomenology — no partial
+reading, no split antecedents — as theorems.
 
 ## Main definitions
 
@@ -48,9 +49,10 @@ abbrev IsExhaustive (val : Pos → Ref) (d : SetRel Pos Pos) : Prop :=
 def HasPartial [Preorder Ref] (val : Pos → Ref) (d : SetRel Pos Pos) : Prop :=
   ∃ a b, a ~[d] b ∧ val a < val b
 
-/-- Split control: some dependent has two distinct controllers. -/
+/-- Split control: some dependent has two distinct controllers — the
+    dependency is not left-unique. -/
 abbrev HasSplit (d : SetRel Pos Pos) : Prop :=
-  ¬ d.IsInjective
+  ¬ Relator.LeftUnique (· ~[d] ·)
 
 /-- An exhaustive dependency admits no partial reading. -/
 theorem IsExhaustive.not_hasPartial [Preorder Ref] (h : IsExhaustive val d) :
@@ -81,7 +83,7 @@ inductive Mechanism where
     controller saturates a single slot, and the referent is shared
     exhaustively. -/
 structure IsSaturating (val : Pos → Ref) (d : SetRel Pos Pos) : Prop where
-  biUnique : d.IsBiUnique
+  biUnique : Relator.BiUnique (· ~[d] ·)
   exhaustive : IsExhaustive val d
 
 /-- A saturating dependency admits no partial reading. -/


### PR DESCRIPTION
Uses mathlib's `Relator.LeftUnique`/`BiUnique` directly instead of the `SetRel.IsFunctional`/`IsInjective`/`IsBiUnique` aliases, and drops the zero-consumer satellite lemmas (`.comp` pair, relation-algebra iff forms, dom/cod composite equations). The `[UPSTREAM]` surface shrinks to the one declaration with real content and a consumer: `SetRel.ker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)