### PR TITLE
refactor(Syntax/Control): Shares is exhaustive control, set-builder kernel

### DIFF
--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -242,8 +242,8 @@ def ex42Occupant : Fin 2 → Ex42Item :=
     the dependency — the Movement Theory of Control ([hornstein-1999])
     is refuted on the Gã configuration (§3.6.2): control is
     base-generated. -/
-theorem ga_refutes_movement : ¬ Shares ex42Occupant ex42Dependency :=
-  not_shares_of_mismatch (P := (· = .ameele)) rfl rfl (by decide)
+theorem ga_refutes_movement : ¬ IsExhaustive ex42Occupant ex42Dependency :=
+  not_isExhaustive_of_mismatch (P := (· = .ameele)) rfl rfl (by decide)
 
 /-- The lexical-copy ban is what [landau-2024]'s (72) predicts: the
     ex 42b/64 matrix verb *kai* is an implicative — nonattitude,

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -428,8 +428,8 @@ def ex86Occupant : Fin 2 → Ex86Item :=
 /-- Movement is token identity, and the (86)–(87) occupants differ
     across the dependency — movement is refuted (§6, pp. 26–31): SMPM
     control is base-generated. -/
-theorem smpm_refutes_movement : ¬ Shares ex86Occupant ex86Dependency :=
-  not_shares_of_mismatch (P := (· = .quantifierDP)) rfl rfl (by decide)
+theorem smpm_refutes_movement : ¬ IsExhaustive ex86Occupant ex86Dependency :=
+  not_isExhaustive_of_mismatch (P := (· = .quantifierDP)) rfl rfl (by decide)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 10: Implicational Universal (54)

--- a/Linglib/Syntax/Control/CopyControl.lean
+++ b/Linglib/Syntax/Control/CopyControl.lean
@@ -10,7 +10,7 @@ Authors: Robert Hawkins
 Copy control ([polinsky-potsdam-2006]): the subject of a control clause
 is a phonologically overt copy of its controller. The typology of copy
 types. The movement vs. base-generation opposition is adjudicated by
-occupant-transport refutations (`Control.not_shares_of_mismatch` in
+occupant-transport refutations (`Control.not_isExhaustive_of_mismatch` in
 `Dependency.lean`): movement is token identity, so an embedded
 occupant differing from its controller — a pronoun where a lexical
 copy is predicted (Gã), or a genuine pronoun anteceding an exempt

--- a/Linglib/Syntax/Control/Dependency.lean
+++ b/Linglib/Syntax/Control/Dependency.lean
@@ -19,9 +19,10 @@ reference of the embedded subject, "open as to how the control reading is
 obtained: either structurally or semantically/lexically". A dependency here is
 a relation `SetRel Pos Pos` over argument positions, read
 `antecedent ~[r] dependent`, with a valuation `val : Pos → Ref` assigning
-referents; exhaustive inclusion is the kernel refinement `Control.Shares`, and
-proper inclusion — a partial reading ([landau-2000]) — is strict growth
-`val a < val b` along the dependency.
+referents. Identical inclusion is *exhaustive control* ([landau-2000]):
+related positions are co-valued (`Control.IsExhaustive`); proper inclusion —
+a *partial* reading — is strict growth `val a < val b` along the dependency
+(`exists_lt_of_comp_lt` localizes it to a leg of a composite).
 
 Grammatical dependencies share the fixed format of the configurational matrix:
 [koster-1987]'s five shared properties, as explained by
@@ -33,84 +34,62 @@ refinements `r ⊆ s` in the `SetRel` lattice, uniqueness of the antecedent is
 bound anaphora, and both control mechanisms instantiate the format, so nothing
 here chooses between base-generation and movement.
 
-Composition `○` serves the theories that decompose a control dependency into
-legs (e.g. [landau-2024]'s binding over predication): a composite keeps every
-refinement (`SetRel.comp_subset_comp`) and the sharing (`Shares.comp`) of its
-legs, and a partial reading localizes to a leg (`exists_lt_of_comp_lt`).
-
-What a dependency shares distinguishes the enforcement species —
-[bresnan-1982]'s functional vs. anaphoric control: *functional* control shares
-the occupant assignment itself (structure sharing; movement chains),
-*anaphoric* control only the referent valuation. Occupant sharing is the
-stronger: a shared assignment transports along every map of it (`Shares.map`),
-so every occupant property transports across the dependency
-(`Shares.iff_of_rel`) and one observed mismatch refutes it
-(`not_shares_of_mismatch`) — the refutation engine of the overt-copy
+Which assignment a dependency exhaustively shares distinguishes the
+enforcement species — [bresnan-1982]'s functional vs. anaphoric control:
+*functional* control shares the occupant assignment itself (structure sharing;
+movement chains), *anaphoric* control only the referent valuation. Occupant
+sharing is the stronger: it transports along every map of the assignment
+(`IsExhaustive.map`), so one observed occupant mismatch refutes it
+(`not_isExhaustive_of_mismatch`) — the refutation engine of the overt-copy
 diagnostics ([polinsky-potsdam-2006]).
 
 ## Main definitions
 
-- `SetRel.ker`: the kernel of a function, as a relation (`[UPSTREAM]`)
-- `Control.Shares`: exhaustive argument sharing as kernel refinement
+- `Control.IsExhaustive`: exhaustive control — the dependency refines the
+  kernel of the valuation
 -/
-
-namespace SetRel
-
-variable {α β : Type*} {f : α → β} {a b : α}
-
-/-- `[UPSTREAM]` The kernel of a function, as a relation: `a ~[ker f] b` iff
-    `f a = f b`. -/
-def ker (f : α → β) : SetRel α α := f.graph ○ f.graph.inv
-
-@[simp] theorem mem_ker : a ~[ker f] b ↔ f a = f b := by simp [ker, eq_comm]
-
-instance : (ker f).IsRefl where refl _ := mem_ker.2 rfl
-
-instance : (ker f).IsSymm where symm _ _ h := mem_ker.2 (mem_ker.1 h).symm
-
-instance : (ker f).IsTrans where
-  trans _ _ _ h h' := mem_ker.2 ((mem_ker.1 h).trans (mem_ker.1 h'))
-
-end SetRel
 
 namespace Control
 
 open SetRel
 
-/-! ### Argument sharing -/
+/-! ### Exhaustive sharing -/
 
 variable {Pos Ref : Type*} {val : Pos → Ref} {ante bind pred : SetRel Pos Pos}
   {a b p c : Pos}
 
-/-- A dependency enforces exhaustive argument sharing when related positions
-    are co-valued — the dependency refines the kernel of the valuation. -/
-abbrev Shares (val : Pos → Ref) (ante : SetRel Pos Pos) : Prop :=
-  ante ⊆ .ker val
+/-- Exhaustive control ([landau-2000]): the dependency shares the valuation
+    exhaustively — related positions are co-valued, i.e. the dependency
+    refines the kernel of the valuation. -/
+def IsExhaustive (val : Pos → Ref) (ante : SetRel Pos Pos) : Prop :=
+  ante ⊆ {(a, b) | val a = val b}
 
-/-- Related positions of a sharing dependency are co-valued. -/
-theorem Shares.eq (hs : Shares val ante) (h : a ~[ante] b) : val a = val b :=
-  mem_ker.1 (hs h)
+/-- Related positions of an exhaustive dependency are co-valued. -/
+theorem IsExhaustive.eq (hs : IsExhaustive val ante) (h : a ~[ante] b) :
+    val a = val b :=
+  hs h
 
-/-- A refinement of a sharing dependency shares. -/
-theorem Shares.mono (h : ante ⊆ bind) (hs : Shares val bind) :
-    Shares val ante :=
+/-- A refinement of an exhaustive dependency is exhaustive. -/
+theorem IsExhaustive.mono (h : ante ⊆ bind) (hs : IsExhaustive val bind) :
+    IsExhaustive val ante :=
   h.trans hs
 
-/-- Sharing composes through the mediating position. -/
-theorem Shares.comp (hb : Shares val bind) (hp : Shares val pred) :
-    Shares val (bind ○ pred) :=
-  (comp_subset_comp hb hp).trans comp_subset_self
+/-- Exhaustivity composes through the mediating position. -/
+theorem IsExhaustive.comp (hb : IsExhaustive val bind)
+    (hp : IsExhaustive val pred) : IsExhaustive val (bind ○ pred) := by
+  rintro ⟨a, c⟩ ⟨m, ham, hmc⟩
+  exact (hb.eq ham).trans (hp.eq hmc)
 
-/-- Exhaustive sharing excludes partial readings: no strict growth of the
+/-- Exhaustive control excludes partial readings: no strict growth of the
     referent along the dependency ([landau-2000]). -/
-theorem Shares.not_lt [Preorder Ref] (hs : Shares val ante)
+theorem IsExhaustive.not_lt [Preorder Ref] (hs : IsExhaustive val ante)
     (h : a ~[ante] b) : ¬ val a < val b := by
   simp [hs.eq h]
 
-/-- Under exhaustive sharing, joint antecedents are co-valued — split control
+/-- Under exhaustive control, joint antecedents are co-valued — split control
     needs a non-exhaustive leg. -/
-theorem Shares.eq_of_two (hs : Shares val ante) (ha : a ~[ante] p)
-    (hb : b ~[ante] p) : val a = val b :=
+theorem IsExhaustive.eq_of_two (hs : IsExhaustive val ante)
+    (ha : a ~[ante] p) (hb : b ~[ante] p) : val a = val b :=
   (hs.eq ha).trans (hs.eq hb).symm
 
 /-- A partial reading in a composite localizes to a leg: if referents grow
@@ -128,33 +107,35 @@ theorem exists_lt_of_comp_lt [PartialOrder Ref]
 
 /-! ### Enforcement
 
-What a dependency shares distinguishes the enforcement species
-([bresnan-1982]): functional control shares the occupant assignment itself
-(structure sharing — movement chains, LFG control equations), anaphoric
-control only the referent valuation. Occupant sharing is the stronger: a
-shared assignment transports along every map of it (`Shares.map`), so every
-occupant property transports across the dependency (`Shares.iff_of_rel`) —
-and one observed mismatch refutes it (`not_shares_of_mismatch`), the engine
-of the overt-copy diagnostics ([polinsky-potsdam-2006]). -/
+Which assignment a dependency exhaustively shares distinguishes the
+enforcement species ([bresnan-1982]): functional control shares the occupant
+assignment itself (structure sharing — movement chains, LFG control
+equations), anaphoric control only the referent valuation. Occupant sharing
+is the stronger: a shared assignment transports along every map of it
+(`IsExhaustive.map`), so every occupant property transports across the
+dependency (`IsExhaustive.iff_of_rel`) — and one observed mismatch refutes
+it (`not_isExhaustive_of_mismatch`), the engine of the overt-copy
+diagnostics ([polinsky-potsdam-2006]). -/
 
 variable {Item : Type*} {occ : Pos → Item}
 
 /-- Sharing an assignment transports along any map of it: token identity
     yields referential co-valuation for every referent map. -/
-theorem Shares.map (hs : Shares occ ante) (f : Item → Ref) :
-    Shares (f ∘ occ) ante :=
-  fun _ h => mem_ker.2 (congrArg f (hs.eq h))
+theorem IsExhaustive.map (hs : IsExhaustive occ ante) (f : Item → Ref) :
+    IsExhaustive (f ∘ occ) ante := by
+  rintro ⟨a, b⟩ h
+  exact congrArg f (hs.eq h)
 
 /-- Under a shared assignment, every property of the assigned value transports
     across the dependency: copies are indistinguishable. -/
-theorem Shares.iff_of_rel (hs : Shares occ ante) (h : a ~[ante] b)
+theorem IsExhaustive.iff_of_rel (hs : IsExhaustive occ ante) (h : a ~[ante] b)
     (P : Item → Prop) : P (occ a) ↔ P (occ b) :=
   iff_of_eq (congrArg P (hs.eq h))
 
 /-- One observed mismatch refutes a shared assignment — the refutation engine
     of the copy-control diagnostics. -/
-theorem not_shares_of_mismatch {P : Item → Prop} (h : a ~[ante] b)
-    (hPa : P (occ a)) (hPb : ¬ P (occ b)) : ¬ Shares occ ante :=
+theorem not_isExhaustive_of_mismatch {P : Item → Prop} (h : a ~[ante] b)
+    (hPa : P (occ a)) (hPb : ¬ P (occ b)) : ¬ IsExhaustive occ ante :=
   fun hs => hPb (hs.eq h ▸ hPa)
 
 end Control

--- a/Linglib/Syntax/Control/Taxonomy.lean
+++ b/Linglib/Syntax/Control/Taxonomy.lean
@@ -27,7 +27,7 @@ reading, no split antecedents — as theorems.
 
 ## Main definitions
 
-- `Control.IsExhaustive`, `Control.HasPartial`, `Control.HasSplit`
+- `Control.HasPartial`, `Control.HasSplit`
 - `Control.Mechanism`
 - `Control.IsSaturating`
 -/
@@ -39,10 +39,6 @@ open SetRel
 variable {Pos Ref : Type*} {val : Pos → Ref} {d : SetRel Pos Pos} {a b p q : Pos}
 
 /-! ### Reading types -/
-
-/-- Exhaustive control: the dependency refines the valuation's kernel. -/
-abbrev IsExhaustive (val : Pos → Ref) (d : SetRel Pos Pos) : Prop :=
-  Shares val d
 
 /-- A partial reading ([landau-2000]): some dependent's referent strictly
     extends its controller's. -/


### PR DESCRIPTION
Renames `Shares` to `Control.IsExhaustive` — the linguistics literature's term of art (Landau 2000's exhaustive control = referential identity between controller and controllee, vs. partial = proper inclusion) — and defines the kernel by set-builder (`ante ⊆ {(a, b) | val a = val b}`), `Mathlib/Data/Rel.lean`'s own idiom for a curried relation as a `SetRel`, making membership definitionally the equation. Taxonomy's duplicate `IsExhaustive` alias dissolves; the refutation engine becomes `not_isExhaustive_of_mismatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)