### PR TITLE
feat(Syntax/Control): T-Agr calculus; derive HasOC and the OC-NC row

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2846,6 +2846,7 @@ import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Syntax.ConstructionGrammar.Licensing
 import Linglib.Syntax.ConstructionGrammar.Resultatives
 import Linglib.Syntax.Control.Basic
+import Linglib.Syntax.Control.Calculus
 import Linglib.Syntax.Control.Clause
 import Linglib.Syntax.Control.CopyControl
 import Linglib.Syntax.Control.Defs

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -41,7 +41,7 @@ open Features (Attitude)
 /-- The six contrast rows of table (80) of [landau-2015]. -/
 inductive Table80Row where
   /-- OC into an inflected complement (the OC-NC generalization (70);
-      `Tier.agrBlocksControl`) -/
+      `inflectedComplement_realizes_ocnc`) -/
   | inflectedComplement
   /-- `[−human]` PRO ((81): the logophoric binder is the
       AUTHOR/ADDRESSEE function, defined only for humans) -/
@@ -79,13 +79,19 @@ theorem table80_complementary (r : Table80Row) :
     availableUnderLogophoric r = !availableUnderPredicative r := by
   cases r <;> rfl
 
-/-- The inflected-complement row is the OC-NC generalization (70). -/
-theorem inflectedComplement_eq_agrBlocks :
-    (availableUnderPredicative .inflectedComplement
-        = !Tier.agrBlocksControl .predicative)
+/-- The inflected-complement row is the OC-NC generalization ((70)),
+    derived from the calculus: `[+Agr]` leaves OC in `[−T]` complements
+    (the predicative tier) and destroys it in `[+T]` complements (the
+    logophoric tier), by the Feature Transmission asymmetry ((60):
+    predication is not contingent on feature matching — Icelandic quirky
+    constructions — while variable binding is, [heim-2008],
+    [kratzer-2009]). Its empirical scope is contested ([ganenkov-2019]). -/
+theorem inflectedComplement_realizes_ocnc :
+    availableUnderPredicative .inflectedComplement
+        = decide (ClauseClass.cSubjunctive.HasOC true)
     ∧ availableUnderLogophoric .inflectedComplement
-        = !Tier.agrBlocksControl .logophoric :=
-  ⟨rfl, rfl⟩
+        = decide (ClauseClass.fSubjunctive.HasOC true) := by
+  exact ⟨by decide, by decide⟩
 
 /-- EC verbs resist impersonal passives ((98) in [landau-2015]): a
     direct consequence of condition (90), since impersonal passives

--- a/Linglib/Syntax/Control/Calculus.lean
+++ b/Linglib/Syntax/Control/Calculus.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+
+/-!
+# The Calculus of Control
+
+[landau-2004]'s calculus, as codified in [landau-2013] ((6)/(178)): each
+clausal head — I and C — carries a `⟨T, Agr⟩` feature specification, and a
+head both of whose features are positive assigns `[+R]`, licensing an
+independent referential subject. Control is the *elsewhere* case. Mutual
+cancellation ([landau-2013] fn. 6): when C is `[+T, +Agr]` as well as I,
+R-assignment cancels and OC re-emerges — the Hebrew subjunctive effect,
+inexpressible on a flat tense scale. `Control.ClauseClass.HasOC` is derived
+from this calculus via `ClauseClass.toSpec` (`Syntax/Control/Tier.lean`).
+
+## Main definitions
+
+- `Control.FeatureSpec`, `Control.Head`, `Control.Spec`
+- `Control.Spec.HasControl`: control as the elsewhere condition
+-/
+
+namespace Control
+
+/-- A `⟨T, Agr⟩` feature specification on a clausal head ([landau-2004];
+    [landau-2013] (6)). -/
+structure FeatureSpec where
+  /-- Semantic tense, `[±T]`. -/
+  tense : Bool
+  /-- Agreement, `[±Agr]`. -/
+  agr : Bool
+  deriving DecidableEq, Repr
+
+/-- A head is R-assigning when both features are positive: it licenses an
+    independent referential subject ([landau-2013] (178)). -/
+def FeatureSpec.RAssigning (h : FeatureSpec) : Prop :=
+  h.tense ∧ h.agr
+
+instance (h : FeatureSpec) : Decidable h.RAssigning :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- The two clausal heads carrying `⟨T, Agr⟩` specifications. -/
+inductive Head where
+  /-- The inflectional head. -/
+  | I
+  /-- The complementizer head. -/
+  | C
+  deriving DecidableEq, Repr
+
+/-- A clause's control-relevant specification: `⟨T, Agr⟩` on each head. -/
+abbrev Spec : Type := Head → FeatureSpec
+
+/-- Control is the elsewhere case ([landau-2013] (178) with fn. 6): an
+    R-assigning I destroys control unless C is R-assigning too — mutual
+    cancellation. -/
+def Spec.HasControl (s : Spec) : Prop :=
+  (s .I).RAssigning → (s .C).RAssigning
+
+instance (s : Spec) : Decidable s.HasControl :=
+  inferInstanceAs (Decidable (_ → _))
+
+/-- Mutual cancellation: a fully specified C restores OC in a fully finite
+    clause — Hebrew subjunctives ([landau-2013] fn. 6). -/
+theorem Spec.hasControl_of_c_rAssigning {s : Spec} (h : (s .C).RAssigning) :
+    s.HasControl :=
+  fun _ => h
+
+end Control

--- a/Linglib/Syntax/Control/Tier.lean
+++ b/Linglib/Syntax/Control/Tier.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Syntax.Control.Calculus
 
 /-!
 # Control Theory: Tiers, Predicate Classes, Clause Classes
@@ -29,13 +30,6 @@ for the paper-anchored control studies (`Studies/Landau2015.lean`,
 - `Control.ClauseClass`: the `[±T]` scale positions, with the
   Agr-sensitive `ClauseClass.HasOC` and its characterization
   `ClauseClass.hasOC_iff`
-
-## TODO
-
-Replace the three-cell scale with Landau's ⟨T, Agr⟩ specification on
-each of the two clausal heads (the calculus of control): the `finite`
-cell oversimplifies — mutual cancellation predicts OC in certain
-`[+T,+Agr]` complements (Hebrew subjunctives).
 -/
 
 namespace Control
@@ -65,15 +59,6 @@ inductive Tier where
 def Tier.isAttitude : Tier → Bool
   | .predicative => false
   | .logophoric  => true
-
-/-- The OC-NC generalization ([landau-2015] (70)): `[+Agr]` blocks
-    logophoric but not predicative control, by the Feature Transmission
-    asymmetry ((60): predication is not contingent on feature matching —
-    Icelandic quirky constructions — while variable binding is,
-    [heim-2008], [kratzer-2009]). Its empirical scope is contested
-    ([ganenkov-2019]). -/
-def Tier.agrBlocksControl (t : Tier) : Bool :=
-  t.isAttitude
 
 /-! ### Predicate classification -/
 
@@ -127,8 +112,8 @@ inductive ClauseClass where
   | cSubjunctive
   /-- `[+T]` complement; logophoric control -/
   | fSubjunctive
-  /-- Fully finite; no control (a simplification — see the module
-      TODO) -/
+  /-- Fully finite: `[+T, +Agr]` on I. No control unless C is fully
+      specified too (mutual cancellation, `Spec.hasControl_of_c_rAssigning`) -/
   | finite
   deriving DecidableEq, Repr
 
@@ -148,15 +133,21 @@ def ClauseClass.tier : ClauseClass → Option Tier
   | .fSubjunctive => some .logophoric
   | .finite       => none
 
-/-- OC is realized in a clause class iff it has a control tier that
-    `[+Agr]` does not block. -/
-def ClauseClass.HasOC (c : ClauseClass) (agr : Bool) : Prop :=
-  match c.tier with
-  | none   => False
-  | some t => agr → ¬t.agrBlocksControl
+/-- The `⟨T, Agr⟩` specification a scale position abbreviates, at a given
+    Agr value: `[±T]` on I per the position, C unspecified. The scale cannot
+    express a fully specified C — mutual cancellation needs the calculus
+    directly. -/
+def ClauseClass.toSpec (c : ClauseClass) (agr : Bool) : Spec
+  | .I => ⟨c ≠ .cSubjunctive, if c = .finite then true else agr⟩
+  | .C => ⟨false, false⟩
 
-instance (c : ClauseClass) (agr : Bool) : Decidable (c.HasOC agr) := by
-  cases c <;> unfold ClauseClass.HasOC <;> simp only [ClauseClass.tier] <;> infer_instance
+/-- OC is realized in a clause class iff the calculus leaves control at its
+    specification: the elsewhere condition on `toSpec`. -/
+def ClauseClass.HasOC (c : ClauseClass) (agr : Bool) : Prop :=
+  (c.toSpec agr).HasControl
+
+instance (c : ClauseClass) (agr : Bool) : Decidable (c.HasOC agr) :=
+  inferInstanceAs (Decidable (Spec.HasControl _))
 
 /-- OC obtains exactly on C-subjunctives (any Agr) and `[−Agr]`
     F-subjunctives. -/


### PR DESCRIPTION
Lands the ⟨T, Agr⟩-per-head calculus (`Calculus.lean`: `FeatureSpec`, `Head`, `Spec`, R-assignment, control as the elsewhere condition with mutual cancellation per Landau 2013 fn. 6 — Hebrew finite OC now expressible). `ClauseClass.HasOC` becomes a derived notion via `ClauseClass.toSpec`; the tactic-built `Decidable` instance and the `agrBlocksControl` alias are deleted, and Landau2015's OC-NC table row is now a theorem derived from the calculus instead of an alias unfold. Resolves the module's standing TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)