### PR TITLE
docs(Syntax/Control): trim module docstrings to register; fix bib sources

### DIFF
--- a/Linglib/Syntax/Control/Defs.lean
+++ b/Linglib/Syntax/Control/Defs.lean
@@ -10,40 +10,20 @@ import Mathlib.Logic.Relator
 /-!
 # Control: Basic Definitions
 
-The framework-neutral vocabulary of control theory. Control is
-pre-theoretically an antecedence relation between the understood subject of a
-clause-like complement and the matrix argument that supplies its
-interpretation ([landau-2013] (74)); the one definition in the literature
-written to be neutral between the rival mechanisms is [stiebels-2007] (22):
-the control predicate requires one of its arguments to be (improperly)
-included in the reference of the embedded subject, "open as to how the
-control reading is obtained: either structurally or semantically/lexically".
-A dependency here is a relation `SetRel Pos Pos` over argument positions,
-read `antecedent ~[r] dependent`, with a valuation `val : Pos → Ref`
-assigning referents. Identical inclusion is *exhaustive control*
-([landau-2000]): related positions are co-valued (`IsExhaustive`); proper
-inclusion is a *partial* reading (`IsPartial`), and joint antecedence is
-*split* control (`IsSplit`). Control *shift* — the antecedent varying across
-readings of one construction — is deliberately not a property of a single
-dependency: a dependency encodes one reading, so shift lives at the
-controller-choice stratum.
-
-Grammatical dependencies share the fixed format of the configurational
-matrix: [koster-1987]'s five shared properties, as explained by
-[neeleman-vandekoot-2002] — c-command by the antecedent, obligatoriness,
-uniqueness of the antecedent, nonuniqueness of the dependent, and locality.
-Every clause of the matrix is mathlib vocabulary: c-command and locality are
-refinements `r ⊆ s` in the `SetRel` lattice, uniqueness of the antecedent is
-`Relator.LeftUnique`, obligatoriness is `dependent ⊆ r.cod`. Movement chains,
-bound anaphora, and both control mechanisms instantiate the format, so
-nothing here chooses between base-generation and movement.
-
-`Mechanism` names what a dependency shares — the framework-neutral cut behind
-the movement vs. base-generation and functional vs. anaphoric
-([bresnan-1982]) oppositions. `IsSaturating` is the profile of a dependency
-enforced by saturation (predication, structure sharing): bi-unique
-(`Relator.BiUnique`) and exhaustive. The lemmas — composition, the
-phenomenology of saturation, the occupant-mismatch refutation engine — are in
+The framework-neutral vocabulary of control. A dependency is a relation
+`SetRel Pos Pos` over argument positions, read `antecedent ~[r] dependent`,
+with a valuation `val : Pos → Ref` assigning referents — [stiebels-2007]'s
+mechanism-neutral definition of control as referential inclusion, "open as to
+how the control reading is obtained". Reading types follow [landau-2000]:
+exhaustive (`IsExhaustive`), partial (`IsPartial`), and split (`IsSplit`);
+control *shift* varies the antecedent across readings of one construction, so
+it is not a property of a single dependency. `Mechanism` names what a
+dependency shares ([bresnan-1982]'s functional vs. anaphoric cut), and
+`IsSaturating` is the bi-unique, exhaustive profile of saturation
+(predication, structure sharing). Grammatical dependencies share
+[koster-1987]'s configurational-matrix format ([neeleman-vandekoot-2002]),
+whose clauses are mathlib vocabulary: refinement `r ⊆ s`,
+`Relator.LeftUnique`, `dependent ⊆ r.cod`. Lemmas are in
 `Syntax/Control/Basic.lean`.
 
 ## Main definitions

--- a/Linglib/Syntax/Control/Diagnostics.lean
+++ b/Linglib/Syntax/Control/Diagnostics.lean
@@ -11,24 +11,15 @@ import Mathlib.Tactic.DeriveFintype
 # Control Diagnostics and Profiles
 
 The observable diagnostic battery of control — the antecedence and reading
-tests every framework's account of a construction is answerable to: arbitrary
-reference, long-distance antecedence, non-c-commanding antecedence,
-strict-vs-sloppy under ellipsis, and strict-vs-bound-variable under *only*.
-The battery is shared field vocabulary; what varies by theory is which
-configurations admit which diagnostics (e.g. [landau-2013] (75)–(79) derives
-the five from the two clauses of its OC signature; [hornstein-1999] from chain
-locality).
-
-A `Profile ι` records which of an analysis's licensing clauses hold of a
-construction, over an arbitrary clause index `ι`. An `Excludes ι` instance
-says which clause's failure admits each diagnostic — part of what makes a
-clause index the index it is, so it is a typeclass, unlike rival *analyses*,
-which are values. From it, `Profile.admits` computes the admitted diagnostics
-as a preimage, and the characterizations follow from mathlib `Set` lemmas:
-`admits` is antitone, obligatory control is the empty fiber, non-obligatory
-control the full one, and — when every clause is witnessed by some diagnostic
-(`Excludes.surjective`) — the battery encodes the profile faithfully
-(`Profile.admits_injective`).
+tests every framework's account is answerable to. A `Profile ι` records which
+of an analysis's licensing clauses hold of a construction, over an arbitrary
+clause index `ι`; an `Excludes ι` instance says which clause's failure admits
+each diagnostic, and `Profile.admits` computes the admitted diagnostics as a
+preimage: `admits` is antitone, obligatory control is the empty fiber,
+non-obligatory control the full one, and the battery encodes the profile
+faithfully (`Profile.admits_injective`). Which configurations admit which
+diagnostics varies by theory — [landau-2013] (75)–(79) derives the five from
+the two clauses of its OC signature (`Studies/Landau2013.lean`).
 
 ## Main definitions
 

--- a/Linglib/Syntax/Control/Head.lean
+++ b/Linglib/Syntax/Control/Head.lean
@@ -13,9 +13,9 @@ head both of whose features are positive assigns `[+R]`, licensing an
 independent referential subject. Control is the *elsewhere* case. Mutual
 cancellation ([landau-2013] fn. 6): when C is `[+T, +Agr]` as well as I,
 R-assignment cancels and OC re-emerges — the Hebrew subjunctive effect,
-inexpressible on a flat tense scale. [landau-2004]'s scale of finiteness (`ClauseClass`) abbreviates
-clauses so specified, and `ClauseClass.HasOC` is derived from the
-calculus via `ClauseClass.toClause`.
+inexpressible on a flat tense scale. [landau-2004]'s scale of finiteness
+(`ClauseClass`) abbreviates clauses so specified, and `ClauseClass.HasOC` is
+derived from the calculus via `ClauseClass.toClause`.
 
 ## Main definitions
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -17207,7 +17207,7 @@
   pages     = {69--96},
   subfield  = {syntax},
   role      = {cited},
-  sources   = {Syntax/Control/CopyControl.lean}
+  sources   = {Syntax/Control/Diagnostics.lean;Studies/Allotey2021.lean}
 }
 @article{pollock-1989,
   author    = {Pollock, Jean-Yves},


### PR DESCRIPTION
Cuts the Defs/Diagnostics module docstrings from literature-synthesis length to the mathlib Defs register (per-declaration docstrings keep their citations), rewraps a long line in Head.lean, and fixes hornstein-1999's stale bib sources field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)