### PR TITLE
fix(Syntax/Control): source-verified citation numbers and glosses

### DIFF
--- a/Linglib/Studies/Landau2013.lean
+++ b/Linglib/Studies/Landau2013.lean
@@ -20,12 +20,12 @@ signature admits no criterial configuration, its NOC mirror (§7.1) admits
 all.
 
 Deliberately absent, per §1.3: obligatory *de se* is NOT criterial for OC —
-it is an attitude-tier property. Per §1.4, obligatory *nullness* is not
-criterial either: whether a language spells the controlled subject out is a
-vocabulary fact orthogonal to the signature — the overt-PRO studies
-(`Studies/Ostrove2026.lean`, `Studies/Allotey2021.lean`) turn on exactly this
-separation. The full NOC signature (453) also adds a third, positive clause —
-PRO is `[+human]` — which the book defends as irreducible (§7.5); the
+it is an attitude-tier property. Per §1.4, the lexical-subject diagnostic is
+rejected as an "obligatory nullness criterion" rather than an OC criterion —
+the separation the overt-PRO studies (`Studies/Ostrove2026.lean`,
+`Studies/Allotey2021.lean`) turn on. The full NOC signature (453) also adds a third, positive clause —
+PRO is `[+human]` — which the book (tentatively) defends as irreducible
+(§7.5; retracted by name in [landau-2024]); the
 two-clause mirror covers only the criteria that (74)'s clauses derive.
 -/
 

--- a/Linglib/Studies/Landau2015.lean
+++ b/Linglib/Studies/Landau2015.lean
@@ -301,7 +301,9 @@ theorem promise_desiderative :
     derivedLandauClass promise.toVerb = some .desiderative := rfl
 
 /-- "persuade" (preferential attitude, object control) → desiderative →
-    logophoric, per [landau-2015] table (36). -/
+    logophoric. Table (36) establishes *persuade* as logophoric object
+    control; the desiderative label is this file's derivation from the
+    Fragment's preferential-attitude field ((4)/(5) list no class for it). -/
 theorem persuade_desiderative :
     derivedLandauClass persuade.toVerb = some .desiderative := rfl
 

--- a/Linglib/Studies/Landau2024.lean
+++ b/Linglib/Studies/Landau2024.lean
@@ -210,7 +210,8 @@ NOC by a `[−top, +log]` antecedent (an implicit passive agent), (52b)
 by `[+top, −log]` (an established topic with no mental perspective on
 the event). The `[+human]` character of logophoric antecedents
 follows from mental perspective; topical antecedents are only
-*preferentially* human ((49)–(50), a defeasible empathy default). -/
+*preferentially* human — the (55b) default `[+topic] → [+human]`, with
+(49) the resisting data and (50) the attested overrides. -/
 
 /-- A candidate NOC antecedent's discourse status. -/
 structure Antecedent where
@@ -218,7 +219,7 @@ structure Antecedent where
   logophoricCenter : Bool
   deriving DecidableEq, Repr
 
-/-- (55): a DP may serve as NOC controller iff it is a topic or a
+/-- (55a): a DP may serve as NOC controller iff it is a topic or a
     logophoric center. -/
 def Antecedent.MayControl (a : Antecedent) : Prop :=
   a.topic = true ∨ a.logophoricCenter = true

--- a/Linglib/Syntax/Control/Head.lean
+++ b/Linglib/Syntax/Control/Head.lean
@@ -7,7 +7,7 @@ Authors: Robert Hawkins
 /-!
 # The Calculus of Control
 
-[landau-2004]'s calculus, as codified in [landau-2013] ((6)/(178)): each
+[landau-2004]'s calculus, as codified in [landau-2013] ((137)/(178)): each
 clausal head — I and C — carries a `⟨T, Agr⟩` feature specification, and a
 head both of whose features are positive assigns `[+R]`, licensing an
 independent referential subject. Control is the *elsewhere* case. Mutual
@@ -28,7 +28,7 @@ derived from the calculus via `ClauseClass.toClause`.
 namespace Control
 
 /-- A clausal head as the calculus sees it: its `⟨T, Agr⟩` feature
-    specification ([landau-2004]; [landau-2013] (6)). -/
+    specification ([landau-2004]; [landau-2013] (137)). -/
 structure Head where
   /-- Semantic tense, `[±T]`. -/
   tense : Bool
@@ -37,7 +37,7 @@ structure Head where
   deriving DecidableEq, Repr
 
 /-- A head is R-assigning when both features are positive: it licenses an
-    independent referential subject ([landau-2013] (178)). -/
+    independent referential subject ([landau-2013] (137a)). -/
 def Head.RAssigning (h : Head) : Prop :=
   h.tense ∧ h.agr
 


### PR DESCRIPTION
All ~21 queued Landau 2015/2024 equation numbers verified correct against the books (now in Zotero); this fixes what verification actually found: the calculus in `Head.lean` is Landau 2013's (137)/(137a), not (6)/(178); Landau2024's humanness default is (55b) with (49)/(50) as data, and its licensing condition is (55a); Landau2013 gains the book's own "(tentative)" hedge (the [+human] clause is retracted by name in Landau 2024 — a genuine documented position change, audit W8 resolved) and a tightened §1.4 gloss; Landau2015's *persuade* docstring stops over-claiming table (36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)