### PR TITLE
feat(Semantics/ArgumentStructure): graduate salience classes

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1473,6 +1473,7 @@ import Linglib.Semantics.ArgumentStructure.ParticipantType
 import Linglib.Semantics.ArgumentStructure.PersistenceLevel
 import Linglib.Semantics.ArgumentStructure.Projection
 import Linglib.Semantics.ArgumentStructure.RoleList
+import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Semantics.ArgumentStructure.Thematic.Basic
 import Linglib.Semantics.ArgumentStructure.Thematic.Defs
 import Linglib.Semantics.ArgumentStructure.Thematic.Mereology

--- a/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/SalienceClass.lean
@@ -1,0 +1,89 @@
+import Linglib.Semantics.Verb.Root.Signature
+import Linglib.Semantics.Verb.Root.Arity
+
+/-!
+# Salience classes
+
+[lucy-1994]'s classification of verbal roots by required transitiviser —
+"salience" is his term for the default semantic values in a root that
+influence overt case marking, which is why the classifier lives in the
+argument-realization layer. Stated over the (kind signature × arity)
+coordinates: agent salient (intransitive manner roots), agent-patient
+salient (root transitives), patient salient (intransitive change-of-state
+roots). The positional diagnostic (`IsPositional`) is deliberately
+separate and arity-free — positional roots cross-cut the transitiviser
+classes rather than forming a fourth case.
+
+Originates with [lucy-1994] (Yucatec `=t`, `=∅`, `=s`); the Yucatec
+instantiation with attested derivations is `Studies/Lucy1994.lean`, and
+`Studies/Coon2019.lean` consumes the annotation-level hom
+(`Classification.salienceClass` in `Verb/Root/Classification.lean`) for
+the Chuj root classes.
+
+## Main declarations
+
+* `SalienceClass`
+* `IsAgentSalient`, `IsPatientSalient`, `IsPositional`
+* `SalienceClass.ofKinds` — the pair-level classifier
+* `SalienceClass.ofKinds_close` — closure invariance on cause-free
+  signatures
+-/
+
+namespace ArgumentStructure
+
+open Verb
+
+/-- Lucy's "three large predicate root classes", named for the
+    argument(s) the underived root makes salient. Positional roots are
+    deliberately not a case: they fall outside the transitiviser cut
+    (`IsPositional`). -/
+inductive SalienceClass where
+  | agent
+  | agentPatient
+  | patient
+  deriving DecidableEq, Repr
+
+variable (s : Root.Kinds) (ar : Root.Arity)
+
+/-- Agent salient: intransitive manner-of-action root ("actions or
+    activities that some entity undertakes"). -/
+abbrev IsAgentSalient : Prop :=
+  ar = .noTheme ∧ .manner ∈ s ∧ .result ∉ s
+
+/-- Patient salient: intransitive change-of-state root ("state changes
+    that some entity undergoes more or less spontaneously"). -/
+abbrev IsPatientSalient : Prop :=
+  ar = .noTheme ∧ .manner ∉ s ∧ .result ∈ s
+
+/-- Positional: pure stative configurational signature. Deliberately
+    arity-free — a positional root may also zero-derive a transitive
+    ([lucy-1994]'s *čin* 'bend'), so the positional class cross-cuts
+    the transitiviser cut. -/
+abbrev IsPositional : Prop := s = {.state}
+
+/-- The transitiviser cut. Agent-patient salience is root transitivity
+    (`selectsTheme`), not a feature configuration; the two intransitive
+    classes split by signature; intransitive signatures with neither
+    manner nor result — pure statives included — are outside the cut. -/
+def SalienceClass.ofKinds : Option SalienceClass :=
+  if ar = .selectsTheme then some .agentPatient
+  else if IsAgentSalient s ar then some .agent
+  else if IsPatientSalient s ar then some .patient
+  else none
+
+/-- Collocational closure does not move the transitiviser cut on
+    cause-free signatures: the only available closure edge is
+    result→state, which no arm of the classifier consults. -/
+theorem SalienceClass.ofKinds_close (h : LexKind.cause ∉ s) :
+    ofKinds s.close ar = ofKinds s ar := by
+  revert s ar; decide
+
+/-- The cause-free hypothesis of `ofKinds_close` is necessary: a lone
+    `cause` atom is outside the cut at base but patient salient after
+    closure. -/
+theorem SalienceClass.ofKinds_close_cause :
+    ofKinds {.cause} .noTheme = none ∧
+    ofKinds (Root.Kinds.close {.cause}) .noTheme = some .patient := by
+  decide
+
+end ArgumentStructure

--- a/Linglib/Semantics/Verb/Root/Classification.lean
+++ b/Linglib/Semantics/Verb/Root/Classification.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Verb.Root.Arity
+import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Semantics.ArgumentStructure.LevinTheory
 
 /-!
@@ -72,6 +73,13 @@ def ChangeType.entailsChange : ChangeType → Bool
 def ChangeType.allowsRestitutiveAgain : ChangeType → Bool
   | .propertyConcept => true
   | .result => false
+
+/-- The change-entailment type of a kind signature: a root entails change
+    iff its signature carries `result` ([beavers-etal-2021]). The
+    projection is manner-blind — see `Classification.salienceClass_ofKinds`
+    for what survives it. -/
+def ChangeType.ofKinds (s : Root.Kinds) : ChangeType :=
+  if LexKind.result ∈ s then .result else .propertyConcept
 
 /-- The semantic denotation domain of a root ([coon-2019] (3); extended by
     [hanink-koontz-garboden-2025]).
@@ -215,5 +223,30 @@ theorem change_does_not_determine_arity :
 theorem theme_persistence (r : Classification) (h : r.arity = .selectsTheme) :
     r.arity.hasInternalArg = true := by
   simp [h, Arity.hasInternalArg]
+
+/-! ### Salience through the annotation coordinates -/
+
+/-- The salience class determined by the annotation coordinates
+    (arity × change type). Partial where the coordinates underdetermine
+    the class: `ChangeType` is manner-blind, so a `noTheme`
+    property-concept annotation cannot distinguish an agent-salient
+    manner root from an unclassified stative. -/
+def Classification.salienceClass (c : Classification) : Option SalienceClass :=
+  match c.arity, c.changeType with
+  | .selectsTheme, _ => some .agentPatient
+  | .noTheme, .result => some .patient
+  | .noTheme, .propertyConcept => none
+
+/-- On manner-free signatures the annotation-level classifier agrees with
+    the signature-level one (`SalienceClass.ofKinds`) — the agree-by-theorem
+    link between the stipulated and derived coordinates. The hypothesis is
+    necessary: a manner root maps to `.propertyConcept` under
+    `ChangeType.ofKinds`, where the annotation coordinates return `none`
+    but the signature classifier sees agent salience. -/
+theorem Classification.salienceClass_ofKinds :
+    ∀ (s : Root.Kinds) (ar : Arity), LexKind.manner ∉ s →
+      ({ arity := ar, changeType := .ofKinds s } : Classification).salienceClass =
+        SalienceClass.ofKinds s ar := by
+  decide
 
 end Verb.Root

--- a/Linglib/Semantics/Verb/RootContent.lean
+++ b/Linglib/Semantics/Verb/RootContent.lean
@@ -75,11 +75,11 @@ cannot. -/
 /-- The change-entailment type of a root, derived from its kind signature: a
     root entails change iff its signature carries `result` ([beavers-etal-2021]). -/
 def Verb.Root.changeType (r : Verb.Root) : Verb.Root.ChangeType :=
-  if LexKind.result ∈ r.kinds then .result else .propertyConcept
+  ChangeType.ofKinds r.kinds
 
 theorem Verb.Root.changeType_eq_result_iff (r : Verb.Root) :
     r.changeType = .result ↔ r.HasResult := by
-  unfold Verb.Root.changeType Verb.Root.HasResult
+  unfold Verb.Root.changeType Verb.Root.HasResult ChangeType.ofKinds
   by_cases h : LexKind.result ∈ r.kinds <;> simp [h]
 
 /-- `changeType` is blind to outcomes: same entailments ⇒ same `changeType`,

--- a/Linglib/Studies/Bohnemeyer2004.lean
+++ b/Linglib/Studies/Bohnemeyer2004.lean
@@ -496,7 +496,7 @@ of these classes. -/
     outside the predicate-root cut, and `positional` roots form Lucy's
     separate cross-cutting class (completive *-lah*) — the two stem
     classes share only the anomalous incompletive *-tal*. -/
-def salienceClassOf : VerbStemClass → Option Lucy1994.SalienceClass
+def salienceClassOf : VerbStemClass → Option ArgumentStructure.SalienceClass
   | .active => some .agent
   | .inactive => some .patient
   | .transitiveActive => some .agentPatient

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -554,4 +554,20 @@ theorem w_verbalization_cross_class :
     isActivity (buildDecomposition v_w activityLower) = true :=
   ⟨rfl, rfl, by decide, by decide⟩
 
+/-! ### Root classes in the salience coordinates -/
+
+/-- Chuj root classes through the annotation-level salience hom
+    (`Classification.salienceClass`): both √TV rows occupy the
+    agent-patient salient cell — the same `selectsTheme` coordinates
+    that [lucy-1994]'s Yucatec `=∅` class instantiates — while the
+    three intransitive classes are underdetermined by the manner-blind
+    annotation coordinates. -/
+theorem salience_of_root_classes :
+    rootTV_res.salienceClass = some .agentPatient ∧
+    rootTV_pc.salienceClass = some .agentPatient ∧
+    (toFragmentRoot .itv).salienceClass = none ∧
+    (toFragmentRoot .pos).salienceClass = none ∧
+    (toFragmentRoot .nom).salienceClass = none :=
+  ⟨rfl, rfl, rfl, rfl, rfl⟩
+
 end Coon2019

--- a/Linglib/Studies/Lucy1994.lean
+++ b/Linglib/Studies/Lucy1994.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Verb.Root.Closure
 import Linglib.Semantics.Verb.Root.Arity
+import Linglib.Semantics.ArgumentStructure.SalienceClass
 import Linglib.Morphology.Exponence.Select
 
 /-!
@@ -52,66 +53,16 @@ in a root or stem that influence an overt case marking" (p. 628). Root
 name strings follow Lucy's orthography. The `=t` class is inflated by
 denominal and loanword verbalization (p. 629), so `=t` applicability is a
 weaker signal of manner entailments than `=∅` or `=s` are of theirs.
+
+The salience classes and the pair-level classifier
+(`ArgumentStructure.SalienceClass.ofKinds`) are substrate
+(`Semantics/ArgumentStructure/SalienceClass.lean`); this file supplies the
+Yucatec roots, diagnostic operators, and attested derivations.
 -/
 
 namespace Lucy1994
 
-open Verb Morphology
-
-/-! ### Salience classes -/
-
-/-- Lucy's "three large predicate root classes" (p. 630), named for the
-    argument(s) the underived root makes salient. Positional roots are
-    deliberately not a case: they fall outside the transitiviser cut
-    (`IsPositional`). -/
-inductive SalienceClass where
-  | agent
-  | agentPatient
-  | patient
-  deriving DecidableEq, Repr
-
-variable (s : Root.Kinds) (ar : Root.Arity)
-
-/-- Agent salient: intransitive manner-of-action root — "actions or
-    activities that some entity undertakes" (pp. 628–629); takes `=t`. -/
-abbrev IsAgentSalient : Prop :=
-  ar = .noTheme ∧ .manner ∈ s ∧ .result ∉ s
-
-/-- Patient salient: intransitive change-of-state root — "state changes
-    that some entity undergoes more or less spontaneously" (p. 629);
-    takes `=s`. -/
-abbrev IsPatientSalient : Prop :=
-  ar = .noTheme ∧ .manner ∉ s ∧ .result ∈ s
-
-/-- Positional: pure stative configurational signature; takes the
-    positional derivation. Deliberately arity-free — *čin* 'bend' is
-    positional *and* zero-derives a transitive (ex. (6)), so the
-    positional class cross-cuts the transitiviser cut. -/
-abbrev IsPositional : Prop := s = {.state}
-
-/-- The transitiviser cut. Agent-patient salience is root transitivity
-    (`selectsTheme`), not a feature configuration; the two intransitive
-    classes split by signature; intransitive signatures with neither
-    manner nor result — pure statives included — are outside the cut. -/
-def classOf : Option SalienceClass :=
-  if ar = .selectsTheme then some .agentPatient
-  else if IsAgentSalient s ar then some .agent
-  else if IsPatientSalient s ar then some .patient
-  else none
-
-/-- Collocational closure does not move the transitiviser cut on
-    cause-free signatures: the only available closure edge is
-    result→state, which no arm of `classOf` consults. -/
-theorem classOf_close (h : LexKind.cause ∉ s) :
-    classOf s.close ar = classOf s ar := by
-  revert s ar; decide
-
-/-- The cause-free hypothesis is necessary: a lone `cause` atom is
-    outside the cut at base but patient salient after closure. -/
-theorem classOf_close_ne_of_cause :
-    classOf {.cause} .noTheme = none ∧
-    classOf (Root.Kinds.close {.cause}) .noTheme = some .patient := by
-  decide
+open Verb ArgumentStructure Morphology
 
 /-! ### Agent-salient roots (p. 629, ex. (1a)) -/
 
@@ -365,7 +316,7 @@ theorem predicted_matches_attested :
 
 /-- A root's predicted salience class. -/
 def predictedClass (r : Root) : Option SalienceClass :=
-  classOf r.kinds (arity r)
+  SalienceClass.ofKinds r.kinds (arity r)
 
 /-- The transitiviser each salience class requires. -/
 def exponentOf : SalienceClass → String
@@ -384,7 +335,7 @@ theorem predictedExponents_eq (r : Root) :
   simp only [predictedExponents, predictedClass, Exponence.applicable,
     applies_iff, inventory, affectiveT, zeroDeriv, causativeS,
     positionalLah, List.filter_cons, List.filter_nil, decide_eq_true_eq,
-    classOf]
+    SalienceClass.ofKinds]
   generalize r.kinds = s
   generalize arity r = a
   revert s a
@@ -439,7 +390,7 @@ theorem positional_crosscuts_transitiviser_classes :
 /-- For cause-free roots — every root in this sample — collocational
     closure does not change the predicted class. -/
 theorem predictedClass_closure_invariant (r : Root) (h : ¬ r.HasCause) :
-    classOf r.closedKinds (arity r) = predictedClass r :=
-  classOf_close r.kinds (arity r) h
+    SalienceClass.ofKinds r.closedKinds (arity r) = predictedClass r :=
+  SalienceClass.ofKinds_close r.kinds (arity r) h
 
 end Lucy1994

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5177,7 +5177,7 @@
   subfield  = {semantics/lexical},
   role      = {formalized},
   validated = {true},
-  sources   = {Studies/Lucy1994.lean;Studies/Bohnemeyer2004.lean;Fragments/Mayan/Yukatek/VerbClasses.lean}
+  sources   = {Semantics/ArgumentStructure/SalienceClass.lean;Studies/Lucy1994.lean;Studies/Bohnemeyer2004.lean;Studies/Coon2019.lean;Fragments/Mayan/Yukatek/VerbClasses.lean}
 }% REF: Smith, C. S. (1978). Jespersen's "move and change" class and causative verbs in English.
 @phdthesis{hafeez-2025,
   author    = {Hafeez, Saima},


### PR DESCRIPTION
Graduates [lucy-1994]'s salience classifier from the study into `Semantics/ArgumentStructure/SalienceClass.lean` (pair-level `SalienceClass.ofKinds` over kind signature × arity, cross-cutting positional diagnostic) — realization-facing classifiers live in ArgumentStructure per the `Template.ofKinds` precedent; root ontology stays in `Verb/Root/`.

- `Classification.salienceClass` annotation-level hom + `ChangeType.ofKinds` π, linked by a compatibility theorem (manner-free hypothesis, necessity noted); `RootContent.changeType` now routes through the π.
- Consumers: Lucy1994 (Yucatec instantiation), Bohnemeyer2004, and a new Coon2019 section — Chuj √TV occupies the same `selectsTheme` cell as Yucatec `=∅`; the intransitive classes are underdetermined by the manner-blind annotation coordinates.