### PR TITLE
feat(Semantics): eventuality sorts in Ty; type-driven root annotation

### DIFF
--- a/Linglib/Fragments/Chuj/VerbBuilding.lean
+++ b/Linglib/Fragments/Chuj/VerbBuilding.lean
@@ -30,14 +30,14 @@ Consequences for the nature of roots."
 
 ## Modeling Notes
 
-**Valency captures complement projection, not semantic type.**
-Coon's semantic types (3) group {√TV, √ITV} together as ⟨e, ⟨s,t⟩⟩ — both
-compose with an entity argument per [davis-1997]. But syntactically, only
-√TV projects a complement DP that persists across voice alternations; √ITV's
-entity argument becomes the subject. Root valency `{.internal}` captures
-the syntactic complement projection, giving {√TV} vs {√ITV, √POS, √NOM}.
-This matches the -aj diagnostic: -aj marks implicit arguments, and only √TV
-stems show -aj (the theme can be implicit), not √ITV.
+**√TV and √ITV share type and valency; transitive-Voice licensing
+separates them.** Coon's semantic types (3) group {√TV, √ITV} together as
+⟨e,⟨s,t⟩⟩ — both compose with an internal entity argument per
+[davis-1997], and √ITV roots are unaccusative (§3.3), so both carry
+valency `{.internal}`. What only √TV has is compatibility with the
+transitive-forming v ~ Voice⁰ head that merges an agent
+(`licensesTransitiveVoice`) — the source of which Coon expressly declines
+to formalize. The -aj diagnostic tracks this: only √TV stems show -aj.
 
 -/
 
@@ -54,60 +54,64 @@ open Verb Verb.Root
     Examples: mak' "hit", tek' "kick". -/
 def rootTV_pc : Classification :=
   { valency := {.internal}, changeType := .propertyConcept,
-    denotationType := some .indivStatePred }
+    denotationType := some (.e ⇒ .s ⇒ .t), licensesTransitiveVoice := true }
 
 /-- √TV root (result): selects theme, entails change-of-state.
     Semantic type ⟨e, ⟨s,t⟩⟩ ([coon-2019], (3)).
     Examples: jatz' "hit (breaking)", tzak' "wrap". -/
 def rootTV_res : Classification :=
   { valency := {.internal}, changeType := .result,
-    denotationType := some .indivStatePred }
+    denotationType := some (.e ⇒ .s ⇒ .t), licensesTransitiveVoice := true }
 
-/-- √ITV root: semantic type ⟨e, ⟨s,t⟩⟩ (same as √TV per [davis-1997]),
-    but does NOT project a complement — the entity argument becomes the
-    subject. The class is morphologically defined: roots that appear
-    with null v/Voice⁰ in intransitive stems (p. 40).
+/-- √ITV root: semantic type ⟨e,⟨s,t⟩⟩, same as √TV per [davis-1997],
+    and unaccusative — it combines with an internal argument (§3.3), so
+    its valency is `{.internal}` like √TV's. What it lacks is
+    compatibility with the transitive-forming v/Voice⁰ head. The class is
+    morphologically defined: roots that appear with null v/Voice⁰ in
+    intransitive stems (p. 40).
     Examples: way "sleep", ok' "cry", jaw "arrive", b'at "go". -/
 def rootITV : Classification :=
-  { valency := ∅, changeType := .propertyConcept,
-    denotationType := some .indivStatePred }
+  { valency := {.internal}, changeType := .propertyConcept,
+    denotationType := some (.e ⇒ .s ⇒ .t) }
 
 /-- √POS root: positional/stative. Semantic type ⟨e, ⟨s,d⟩⟩ — a
     measure function, not a truth-value predicate.
     Examples: chot "sit", kot "on all fours", watz "lie face down". -/
 def rootPOS : Classification :=
   { valency := ∅, changeType := .propertyConcept,
-    denotationType := some .measureFn }
+    denotationType := some (.e ⇒ .s ⇒ .d) }
 
 /-- √NOM root: nominal base. Semantic type ⟨e,t⟩ — entity predicate
     with no event argument ([coon-2019], (3)).
     Examples: a' "water", ixim "corn", chanhal "dance". -/
 def rootNOM : Classification :=
   { valency := ∅, changeType := .propertyConcept,
-    denotationType := some .entityPred }
+    denotationType := some (.e ⇒ .t) }
 
 -- ============================================================================
 -- § 2: Four-Way Root Classification ([coon-2019], (3))
 -- ============================================================================
 
-/-- Coon's four root classes are recovered as (valency × denotationType)
-    pairs. √TV = `{.internal}` + indivStatePred, √ITV = `∅` + indivStatePred,
-    √POS = `∅` + measureFn, √NOM = `∅` + entityPred. -/
+/-- Coon's four root classes in their coordinates: √TV and √ITV share
+    type ⟨e,⟨s,t⟩⟩ and internal-argument valency, split by
+    transitive-Voice licensing; √POS is the measure-function type
+    ⟨e,⟨s,d⟩⟩ and √NOM the entity predicate ⟨e,t⟩. -/
 theorem four_way_classification :
-    rootTV_res.valency = {.internal} ∧
-    rootTV_res.denotationType = some .indivStatePred ∧
-    rootITV.valency = ∅ ∧
-    rootITV.denotationType = some .indivStatePred ∧
+    rootTV_res.licensesTransitiveVoice = true ∧
+    rootTV_res.denotationType = some (.e ⇒ .s ⇒ .t) ∧
+    rootITV.licensesTransitiveVoice = false ∧
+    rootITV.denotationType = some (.e ⇒ .s ⇒ .t) ∧
     rootPOS.valency = ∅ ∧
-    rootPOS.denotationType = some .measureFn ∧
+    rootPOS.denotationType = some (.e ⇒ .s ⇒ .d) ∧
     rootNOM.valency = ∅ ∧
-    rootNOM.denotationType = some .entityPred := by
+    rootNOM.denotationType = some (.e ⇒ .t) := by
   exact ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
-/-- The four root classes are pairwise distinguishable: no two share
-    both valency and denotationType. -/
+/-- The four root classes are pairwise distinguishable: √TV and √ITV by
+    transitive-Voice licensing, the intransitive classes by semantic
+    type. -/
 theorem root_classes_pairwise_distinct :
-    (rootTV_res.valency ≠ rootITV.valency) ∧
+    (rootTV_res.licensesTransitiveVoice ≠ rootITV.licensesTransitiveVoice) ∧
     (rootITV.denotationType ≠ rootPOS.denotationType) ∧
     (rootITV.denotationType ≠ rootNOM.denotationType) ∧
     (rootPOS.denotationType ≠ rootNOM.denotationType) := by
@@ -128,12 +132,13 @@ inductive CRootClass where
   deriving DecidableEq, Repr
 
 /-- Map an abstract Classification to the distributional CRootClass.
-    The bridge is determined by (valency × denotationType). -/
+    The bridge is determined by (transitive-Voice licensing × semantic
+    type). -/
 def rootToClass (r : Classification) : CRootClass :=
-  if .internal ∈ r.valency then .tv
+  if r.licensesTransitiveVoice then .tv
   else match r.denotationType with
-  | some .indivStatePred => .itv
-  | some .measureFn => .pos
+  | some (.fn .e (.fn .s .t)) => .itv
+  | some (.fn .e (.fn .s .d)) => .pos
   | _ => .nom
 
 /-- The bridge is correct for each abstract root definition. -/
@@ -394,16 +399,16 @@ def nomRoots : List ChujRoot :=
 
 -- Root classification
 theorem tvRoots_selectTheme :
-    tvRoots.all (fun v => decide (.internal ∈ v.root.valency)) = true := by decide
+    tvRoots.all (·.root.licensesTransitiveVoice) = true := by decide
 
 theorem itvRoots_noTheme :
-    itvRoots.all (fun v => decide (v.root.valency = ∅)) = true := by decide
+    itvRoots.all (fun v => !v.root.licensesTransitiveVoice) = true := by decide
 
 theorem posRoots_measureFn :
-    posRoots.all (·.root.denotationType == some .measureFn) = true := by decide
+    posRoots.all (·.root.denotationType == some (.e ⇒ .s ⇒ .d)) = true := by decide
 
 theorem nomRoots_entityPred :
-    nomRoots.all (·.root.denotationType == some .entityPred) = true := by decide
+    nomRoots.all (·.root.denotationType == some (.e ⇒ .t)) = true := by decide
 
 -- Root↔CRootClass bridge
 theorem tvRoots_bridge :

--- a/Linglib/Semantics/Intensional/Conjunction.lean
+++ b/Linglib/Semantics/Intensional/Conjunction.lean
@@ -32,6 +32,8 @@ def genConj (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ → Denot E W
   | .t => λ x y => x ∧ y
   | .e => λ x _ => x
   | .d => λ x _ => x
+  | .v => λ x _ => x
+  | .s => λ x _ => x
   | .fn _ τ' => λ f g => λ x => genConj τ' E W (f x) (g x)
   | .intens a => λ f g => λ i => genConj a E W (f i) (g i)
 
@@ -41,6 +43,8 @@ def genDisj (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ → Denot E W
   | .t => λ x y => x ∨ y
   | .e => λ x _ => x
   | .d => λ x _ => x
+  | .v => λ x _ => x
+  | .s => λ x _ => x
   | .fn _ τ' => λ f g => λ x => genDisj τ' E W (f x) (g x)
   | .intens a => λ f g => λ i => genDisj a E W (f i) (g i)
 
@@ -51,6 +55,8 @@ def genNeg (τ : Ty) (E W : Type) : Denot E W τ → Denot E W τ :=
   | .t => λ p => ¬p
   | .e => λ x => x
   | .d => λ x => x
+  | .v => λ x => x
+  | .s => λ x => x
   | .fn _ τ' => λ f => λ x => genNeg τ' E W (f x)
   | .intens a => λ f => λ i => genNeg a E W (f i)
 

--- a/Linglib/Semantics/Intensional/Defs.lean
+++ b/Linglib/Semantics/Intensional/Defs.lean
@@ -31,7 +31,16 @@ namespace Intensional
 - `intens a` — intensions ⟨s,a⟩ (functions from indices to a-extensions)
 
 The old `Ty.s` base type is replaced by the `intens` constructor:
-intensionality is a type-forming operation, not a separate domain. -/
+intensionality is a type-forming operation, not a separate domain.
+
+The core `e`, `t`, `⟨a,b⟩`, `⟨s,a⟩` grammar is [dowty-wall-peters-1981]
+Ch. 6 (equivalently [heim-kratzer-1998]'s (5) plus intensions); the
+degree and eventuality sorts are the standard extensions of degree and
+neo-Davidsonian event semantics. Following [yu-ausensi-smith-2023]'s
+convention, `v` is the sort of events and `s` the sort of states — so
+⟨e,⟨s,t⟩⟩ is an individual/state relation (a stative or property-concept
+root) and ⟨e,⟨v,t⟩⟩ an individual/event relation (a change-of-state
+root). -/
 inductive Ty where
   | e : Ty
   | t : Ty
@@ -39,11 +48,47 @@ inductive Ty where
       ([heim-2001], [wellwood-2015]). Denoted by ℚ, the repo's exact
       degree carrier. -/
   | d : Ty
+  /-- Events (type `v`): the neo-Davidsonian event sort ([davidson-1967],
+      [parsons-1990]). -/
+  | v : Ty
+  /-- States (type `s`): the state sort, distinguished from events per
+      [yu-ausensi-smith-2023]'s convention (`v` events, `s` states);
+      not the Montagovian index sort, which is `intens`. -/
+  | s : Ty
   | fn : Ty → Ty → Ty
   | intens : Ty → Ty
   deriving Repr, DecidableEq
 
 infixr:25 " ⇒ " => Ty.fn
+
+/-! ### Functional application at type level -/
+
+/-- Type-level functional application ([heim-kratzer-1998]'s Functional
+    Application, on types): a function type applied to a matching argument
+    type yields the value type; anything else is a type mismatch (`none`).
+    Composition failures are computed, not stipulated. -/
+def Ty.apply : Ty → Ty → Option Ty
+  | .fn a b, a' => if a = a' then some b else none
+  | _, _ => none
+
+theorem Ty.apply_eq_some_iff {f x c : Ty} :
+    f.apply x = some c ↔ f = (x ⇒ c) := by
+  constructor
+  · intro h
+    cases f with
+    | fn a b =>
+      simp only [Ty.apply] at h
+      split at h
+      · next hax => subst hax; cases h; rfl
+      · exact absurd h (by simp)
+    | e => exact absurd h (by simp [Ty.apply])
+    | t => exact absurd h (by simp [Ty.apply])
+    | d => exact absurd h (by simp [Ty.apply])
+    | v => exact absurd h (by simp [Ty.apply])
+    | s => exact absurd h (by simp [Ty.apply])
+    | intens a => exact absurd h (by simp [Ty.apply])
+  · rintro rfl
+    simp [Ty.apply]
 
 /-- Standard type abbreviations. -/
 abbrev Ty.et : Ty := .e ⇒ .t
@@ -61,6 +106,8 @@ def Ty.isConjoinable : Ty → Bool
   | .t => true
   | .e => false
   | .d => false
+  | .v => false
+  | .s => false
   | .fn _ τ => τ.isConjoinable
   | .intens a => a.isConjoinable
 
@@ -78,13 +125,30 @@ def Ty.isConjoinable : Ty → Bool
     D_e = E
     D_t = Prop
     D_⟨a,b⟩ = D_a → D_b
-    D_⟨s,a⟩ = W → D_a -/
+    D_⟨s,a⟩ = W → D_a
+
+    The eventuality sorts `v` and `s` denote in the empty domain: the
+    extensional DWP fragment carries no eventuality domain, and nothing
+    here constructs event-typed denotations. Event-semantic
+    interpretation is the extension point — a carrier-parametric
+    variant of `Denot` supplying event and state domains — and lands
+    with the first study that composes event-typed denotations. -/
 def Denot (E W : Type) : Ty → Type
   | .e => E
   | .t => Prop
   | .d => ℚ
+  | .v => Empty
+  | .s => Empty
   | .fn a b => Denot E W a → Denot E W b
   | .intens a => W → Denot E W a
+
+/-- Soundness of type-level application: when `apply` succeeds, the
+    denotation domain of the function type is exactly the function space
+    from the argument's domain to the value's. -/
+theorem Denot.apply_sound {E W : Type} {f x c : Ty}
+    (h : f.apply x = some c) :
+    Denot E W f = (Denot E W x → Denot E W c) := by
+  rw [Ty.apply_eq_some_iff] at h; subst h; rfl
 
 -- ════════════════════════════════════════════════════════════════
 -- § Up and Down (DWP Rules B.14–B.15)

--- a/Linglib/Semantics/Verb/Root/Classification.lean
+++ b/Linglib/Semantics/Verb/Root/Classification.lean
@@ -1,15 +1,17 @@
 import Linglib.Semantics.Verb.Root.Kinds
 import Linglib.Semantics.ArgumentStructure.Valency
 import Linglib.Semantics.ArgumentStructure.SalienceClass
+import Linglib.Semantics.Intensional.Defs
 
 /-!
-# Root classification: change type, denotation type, and the annotation record
+# Root classification: change type, semantic type, and the annotation record
 
 The cross-linguistic classification dimensions a change-of-state verb root
 is typed by: whether it lexically entails change (`ChangeType`), its
-semantic denotation domain (`DenotationType`), Dixon's property-concept
-categories (`PCClass`), and the `Classification` annotation record over
-(valency × change type × denotation type) for annotation-first fragments.
+semantic type (an `Intensional.Ty` — [coon-2019] (3) types Chuj roots
+⟨e,⟨s,t⟩⟩, ⟨e,⟨s,d⟩⟩, ⟨e,t⟩), Dixon's property-concept categories
+(`PCClass`), and the `Classification` annotation record for
+annotation-first fragments.
 
 ## Anchoring and provenance
 
@@ -22,15 +24,16 @@ categories (`PCClass`), and the `Classification` annotation record over
   verb inventory. The reading that result roots *lexically entail*
   change is the Beavers et al. account, contested by the
   Distributed-Morphology camp; the split itself is theory-neutral.
-* `DenotationType` — the four denotation domains of [coon-2019] (3),
-  extended by [hanink-koontz-garboden-2025].
+* denotation types — actual semantic types (`Intensional.Ty`), not a
+  bespoke enum: [coon-2019] (3)'s four Chuj domains and
+  [hanink-koontz-garboden-2025]'s three Wáshiw PC classes are finite
+  inventories the anchoring studies state over concrete `Ty` values.
 * `PCClass` — [dixon-1982]'s seven categories.
 
 ## Main definitions
 
 * `ChangeType`, `ChangeType.ofKinds` — the axis and its projection from
   kind signatures
-* `DenotationType`, `DenotationType.hasIndivArg`
 * `Classification` — the annotation record
 * `Classification.salienceClass` — the annotation-level salience hom
 
@@ -85,36 +88,6 @@ def ChangeType.allowsRestitutiveAgain : ChangeType → Bool
 def ChangeType.ofKinds (s : Root.Kinds) : ChangeType :=
   if LexKind.result ∈ s then .result else .propertyConcept
 
-/-- The semantic denotation domain of a root ([coon-2019] (3); extended by
-    [hanink-koontz-garboden-2025]). -/
-inductive DenotationType where
-  /-- ⟨e,⟨s,t⟩⟩: individual/state relation (√TV and √ITV in [coon-2019]
-      (3); PC Class 1/3 roots per [hanink-koontz-garboden-2025]). -/
-  | indivStatePred
-  /-- ⟨s,t⟩: predicate of states, no individual argument (PC Class 2). -/
-  | statePred
-  /-- ⟨e,⟨s,d⟩⟩: entity → state → degree (√POS, per [coon-2019] (3);
-      [henderson-2019]'s published analysis types positional-root measure
-      functions ⟨e,d⟩ — the state argument is Coon's). -/
-  | measureFn
-  /-- ⟨e,t⟩: entity predicate with no eventuality argument (√NOM). -/
-  | entityPred
-  deriving DecidableEq, Repr
-
-/-- Whether a root denotation type includes an individual argument.
-
-    Types with an individual argument (⟨e, …⟩) compose directly with v_become
-    (which requires ⟨e,⟨s,t⟩⟩). A bare state predicate (⟨s,t⟩) cannot, and is
-    predicated of individuals via possession instead — the *-iʔ* possessive
-    verbalizer of [hanink-koontz-garboden-2025] (their analysis of the *ʔil-*
-    prefix, §5.2), following [francez-koontz-garboden-2017]'s possessive
-    analysis of property concepts. -/
-def DenotationType.hasIndivArg : DenotationType → Bool
-  | .indivStatePred => true   -- ⟨e,⟨s,t⟩⟩
-  | .statePred      => false  -- ⟨s,t⟩
-  | .measureFn      => true   -- ⟨e,⟨s,d⟩⟩
-  | .entityPred     => true   -- ⟨e,t⟩
-
 /-- Property concept root subclasses ([dixon-1982]; [beavers-etal-2021]
     ex. 5). [beavers-etal-2021] exclude human propensity from their sample
     (fn. 5 to ex. 5): many of its verbal forms are stative, and their study
@@ -137,25 +110,27 @@ inductive PCClass where
   deriving DecidableEq, Repr
 
 /-- Annotation record for roots with no atom decomposition: stipulated
-    coordinates over valency × change type × denotation type, the
-    annotation-first counterpart of the derived projections off
-    `Root.kinds`. The stipulated and derived coordinates agree only by
-    theorem (`salienceClass_ofKinds`), never by construction.
-
-    [coon-2019]'s √TV vs √ITV distinction is *not* recovered by these
-    coordinates: her §3.3 gives both classes type ⟨e,⟨s,t⟩⟩, with √ITV
-    unaccusative, and separates them by compatibility with the
-    external-argument-introducing v ~ Voice head — a coordinate she
-    declines to formalize and this record does not yet carry. -/
+    coordinates over valency × change type × semantic type ×
+    transitive-Voice licensing, the annotation-first counterpart of the
+    derived projections off `Root.kinds`. The stipulated and derived
+    coordinates agree only by theorem (`salienceClass_ofKinds`), never by
+    construction. -/
 structure Classification where
   /-- The core-argument positions the root introduces ([coon-2019]:
       at most the internal argument — `Valency.IsRootValency`). -/
   valency : Valency
   /-- Does this root lexically entail prior change? -/
   changeType : ChangeType
-  /-- Semantic denotation domain ([coon-2019] (3)). Optional — not all roots
-      have been annotated. -/
-  denotationType : Option DenotationType := none
+  /-- The root's semantic type ([coon-2019] (3)). Optional — not all
+      roots have been annotated. -/
+  denotationType : Option Intensional.Ty := none
+  /-- Whether the root may combine with the transitive-forming v ~ Voice⁰
+      head that merges an agent — the coordinate separating [coon-2019]'s
+      √TV from her unaccusative √ITV (§3.3), which share both semantic
+      type and internal-argument valency. Coon expressly declines to
+      formalize its source ("I do not take a particular stance on the
+      source of this distinction"). -/
+  licensesTransitiveVoice : Bool := false
   deriving DecidableEq, Repr
 
 /-- Does this root lexically entail prior change? -/
@@ -165,13 +140,16 @@ def Classification.entailsChange (r : Classification) : Bool := r.changeType.ent
 
 variable (s : Root.Kinds) (v : Valency)
 
-/-- The salience class determined by the annotation coordinates
-    (valency × change type). Partial where the coordinates underdetermine
-    the class: `ChangeType` is manner-blind, so an internal-argument-free
-    property-concept annotation cannot distinguish an agent-salient
-    manner root from an unclassified stative. -/
+/-- The salience class determined by the annotation coordinates.
+    Agent-patient salience is transitive-Voice licensing — [lucy-1994]'s
+    `=∅` roots form transitive stems bare — not internal-argument
+    introduction, which unaccusatives also have ([coon-2019] §3.3).
+    Partial where the coordinates underdetermine the class: `ChangeType`
+    is manner-blind, so a non-transitivizing property-concept annotation
+    cannot distinguish an agent-salient manner root from an unclassified
+    stative. -/
 def Classification.salienceClass (c : Classification) : Option SalienceClass :=
-  if .internal ∈ c.valency then some .agentPatient
+  if c.licensesTransitiveVoice then some .agentPatient
   else match c.changeType with
     | .result => some .patient
     | .propertyConcept => none
@@ -183,8 +161,9 @@ def Classification.salienceClass (c : Classification) : Option SalienceClass :=
     `ChangeType.ofKinds`, where the annotation coordinates return `none`
     but the signature classifier sees agent salience. -/
 theorem Classification.salienceClass_ofKinds (h : LexKind.manner ∉ s) :
-    ({ valency := v, changeType := .ofKinds s } : Classification).salienceClass =
-      SalienceClass.ofKinds s v := by
+    ({ valency := v, changeType := .ofKinds s,
+       licensesTransitiveVoice := decide (.internal ∈ v) } :
+      Classification).salienceClass = SalienceClass.ofKinds s v := by
   revert s v; decide
 
 end Verb.Root

--- a/Linglib/Studies/BeaversEtAl2021.lean
+++ b/Linglib/Studies/BeaversEtAl2021.lean
@@ -828,15 +828,17 @@ theorem chuj_tv_pc_is_pc_root :
     verbalMarkedness rootTV_pc.changeType = .marked := by
   exact ⟨rfl, rfl, rfl⟩
 
-/-- The Chuj fragment witnesses the full orthogonality theorem:
-    all four cells of the (valency × changeType) matrix are inhabited. -/
+/-- The Chuj fragment witnesses cells of the (valency × changeType)
+    matrix: theme-taking roots with and without change entailment, and
+    valency-free property-concept roots (√POS — √ITV is unaccusative and
+    theme-taking per [coon-2019] §3.3). -/
 theorem chuj_witnesses_orthogonality :
-    -- selectsTheme + result (√TV result)
+    -- internal + result (√TV result)
     rootTV_res.valency = {.internal} ∧ rootTV_res.changeType = .result ∧
-    -- selectsTheme + PC (√TV PC)
+    -- internal + PC (√TV PC, √ITV)
     rootTV_pc.valency = {.internal} ∧ rootTV_pc.changeType = .propertyConcept ∧
-    -- noTheme + PC (√ITV, √POS, √NOM)
-    rootITV.valency = ∅ ∧ rootITV.changeType = .propertyConcept :=
+    -- no core positions + PC (√POS, √NOM)
+    rootPOS.valency = ∅ ∧ rootPOS.changeType = .propertyConcept :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Per-root class verification: each Chuj root's change entailment matches

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -32,14 +32,16 @@ Connect the fragment's theory-neutral types (`CRootClass`, `ChujVoiceSuffix`,
 
 ### Chuj fragment bridge (§§10–15)
 
-1. **Root class ↔ Root valency**: `CRootClass` maps to `Classification`
-   values. √TV = valency `{.internal}`, others = `∅`.
+1. **Root class ↔ Root coordinates**: `CRootClass` maps to
+   `Classification` values. √TV and √ITV share type ⟨e,⟨s,t⟩⟩ and
+   internal-argument valency; transitive-Voice licensing separates them.
 2. **Voice suffix ↔ Head**: theta assignment, D feature, phase head.
 3. **Paradigm predictions**: `isGrammatical` matches data attestation.
 4. **-aj predictions**: `hasImplicitExternal` / `triggersAj` match -aj
    distribution.
 5. **Agent diagnostics**: `assignsTheta` matches agent adverb / by-phrase.
-6. **Division of labor**: `formsBareTransitive` aligns with valency.
+6. **Division of labor**: `formsBareTransitive` aligns with
+   transitive-Voice licensing.
 
 ### Root typology bridge
 
@@ -323,9 +325,9 @@ theorem minimalist_division_of_labor :
     -- Same result root: Ø gives causative, -j gives inchoative
     isCausative (buildDecomposition vØ resultLower) = true ∧
     isInchoative (buildDecomposition v_j resultLower) = true ∧
-    -- √TV has theme, √ITV does not — root determines internal arg
-    rootTV_res.valency = {.internal} ∧
-    rootITV.valency = ∅ := ⟨by decide, by decide, rfl, rfl⟩
+    -- √TV licenses transitive Voice, √ITV does not (both take a theme)
+    rootTV_res.licensesTransitiveVoice = true ∧
+    rootITV.licensesTransitiveVoice = false := ⟨by decide, by decide, rfl, rfl⟩
 
 /-- The causative alternation in Chuj is determined by Voice, not by the root
     (instantiation of `voice_determines_causativity_go_be` for Chuj heads).
@@ -345,8 +347,8 @@ theorem chuj_causative_alternation_result :
     This connects theory-neutral distributional classes to the
     theoretically analyzed Classification structure.
     √TV maps to `rootTV_res` as a representative — the choice between
-    `rootTV_res` and `rootTV_pc` is arbitrary for valency (both are
-    `{.internal}`); only changeType differs. -/
+    `rootTV_res` and `rootTV_pc` is arbitrary for the class coordinates
+    (both license transitive Voice); only changeType differs. -/
 def toFragmentRoot : CRootClass → Classification
   | .tv  => rootTV_res
   | .itv => rootITV
@@ -358,15 +360,18 @@ def toFragmentRoot : CRootClass → Classification
     bare transitive stems (§2.2). -/
 theorem root_class_valency_alignment :
     (toFragmentRoot .tv).valency = {.internal} ∧
-    (toFragmentRoot .itv).valency = ∅ ∧
+    -- √ITV roots are unaccusative: they combine with an internal
+    -- argument, like √TV (§3.3) — cham 'die' is Coon's own example
+    (toFragmentRoot .itv).valency = {.internal} ∧
     (toFragmentRoot .pos).valency = ∅ ∧
     (toFragmentRoot .nom).valency = ∅ := ⟨rfl, rfl, rfl, rfl⟩
 
-/-- The data's `formsBareTransitive` matches the fragment's valency.
-    Only roots that introduce their theme can form bare transitive stems. -/
-theorem bare_transitive_iff_theme (rc : CRootClass) :
+/-- The data's `formsBareTransitive` matches transitive-Voice licensing —
+    not internal-argument valency, which unaccusative √ITV shares with
+    √TV (§3.3). -/
+theorem bare_transitive_iff_voice (rc : CRootClass) :
     formsBareTransitive rc = true ↔
-      .internal ∈ (toFragmentRoot rc).valency := by
+      (toFragmentRoot rc).licensesTransitiveVoice = true := by
   cases rc <;> decide
 
 -- ════════════════════════════════════════════════════
@@ -495,10 +500,10 @@ theorem event_decomposition_matches_data :
 theorem division_of_labor_matches_data :
     -- Root determines internal: √TV always selects theme
     formsBareTransitive .tv = true ∧
-    rootTV_res.valency = {.internal} ∧
-    -- Root determines internal: √ITV never selects theme
+    rootTV_res.licensesTransitiveVoice = true ∧
+    -- √ITV takes a theme but cannot license transitive Voice
     formsBareTransitive .itv = false ∧
-    rootITV.valency = ∅ ∧
+    rootITV.licensesTransitiveVoice = false ∧
     -- Voice determines external: same root, different agent status
     ChujVoiceSuffix.extArgStatus .null = .overt_erg ∧
     ChujVoiceSuffix.extArgStatus .ch = .implicit ∧
@@ -528,19 +533,20 @@ theorem theme_persists_all_voices :
     √TV/√ITV = indivStatePred ⟨e,⟨s,t⟩⟩, √POS = measureFn ⟨e,⟨s,d⟩⟩,
     √NOM = entityPred ⟨e,t⟩. -/
 theorem denotation_type_alignment :
-    (toFragmentRoot .tv).denotationType = some .indivStatePred ∧
-    (toFragmentRoot .itv).denotationType = some .indivStatePred ∧
-    (toFragmentRoot .pos).denotationType = some .measureFn ∧
-    (toFragmentRoot .nom).denotationType = some .entityPred := ⟨rfl, rfl, rfl, rfl⟩
+    (toFragmentRoot .tv).denotationType = some (.e ⇒ .s ⇒ .t) ∧
+    (toFragmentRoot .itv).denotationType = some (.e ⇒ .s ⇒ .t) ∧
+    (toFragmentRoot .pos).denotationType = some (.e ⇒ .s ⇒ .d) ∧
+    (toFragmentRoot .nom).denotationType = some (.e ⇒ .t) := ⟨rfl, rfl, rfl, rfl⟩
 
-/-- √TV and √ITV share semantic type (event predicate) but differ in valency.
-    This is the formal content of the observation that both compose with
-    an entity argument per [davis-1997], but only √TV projects a syntactic
-    complement. -/
-theorem tv_itv_same_type_different_valency :
+/-- √TV and √ITV share both semantic type and internal-argument valency
+    ([davis-1997]; §3.3) — what separates them is transitive-Voice
+    licensing alone, whose source Coon expressly declines to formalize. -/
+theorem tv_itv_same_type_different_voice :
     (toFragmentRoot .tv).denotationType = (toFragmentRoot .itv).denotationType ∧
-    (toFragmentRoot .tv).valency ≠ (toFragmentRoot .itv).valency := by
-  exact ⟨rfl, by decide⟩
+    (toFragmentRoot .tv).valency = (toFragmentRoot .itv).valency ∧
+    (toFragmentRoot .tv).licensesTransitiveVoice ≠
+      (toFragmentRoot .itv).licensesTransitiveVoice := by
+  exact ⟨rfl, rfl, by decide⟩
 
 /-- The -w suffix cross-class generalization: -w verbalizes √POS and √NOM
     roots (data: both take -w), and the fragment predicts different event
@@ -559,7 +565,7 @@ theorem w_verbalization_cross_class :
 
 /-- Chuj root classes through the annotation-level salience hom
     (`Classification.salienceClass`): both √TV rows occupy the
-    agent-patient salient cell — the same `{.internal}` valency
+    agent-patient salient cell — the same root-transitivity coordinate
     that [lucy-1994]'s Yucatec `=∅` class instantiates — while the
     three intransitive classes are underdetermined by the manner-blind
     annotation coordinates. -/

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -17,11 +17,11 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
 
 - **Individual/state relations** (Class 1, Class 3): `λx_e λs_v[P(x)(s)]`
   These relate an individual to a state (e.g., √IHUK' 'dry': λx λs[dry(x)(s)]).
-  Type: `⟨e, ⟨v, t⟩⟩` = `DenotationType.indivStatePred`.
+  Type: `⟨e,⟨s,t⟩⟩` (`Intensional.Ty`: `.e ⇒ .s ⇒ .t`).
 
 - **Quality predicates** (Class 2): `λs_v[P(s)]`
   These are predicates of states with no individual argument
-  (e.g., √I:YEL 'big': λs[big(s)]). Type: `⟨v, t⟩` = `DenotationType.statePred`.
+  (e.g., √I:YEL 'big': λs[big(s)]). Type: `⟨s,t⟩` (`.s ⇒ .t`).
 
 ## Three morphological classes
 
@@ -43,10 +43,10 @@ Property concept (PC) roots in Wá·šiw come in two semantic types:
    Converts individual/state relations (Class 3) to quality-type predicates,
    which then feed into -iʔ.
 
-3. **Type mismatch prediction**: v_become requires `⟨e, ⟨v, t⟩⟩` as input.
-   Class 2 roots are `⟨v, t⟩` (`hasIndivArg = false`), so they CANNOT
+3. **Type mismatch prediction**: v_become requires `⟨e,⟨s,t⟩⟩` as input.
+   Class 2 roots are `⟨s,t⟩` (no individual argument), so they CANNOT
    appear as finals in resultative bipartite verb constructions.
-   Class 1 and 3 roots CAN (`hasIndivArg = true`).
+   Class 1 and 3 roots CAN (their type takes an individual first).
 
 ## Connections
 
@@ -79,28 +79,33 @@ inductive MorphClass where
   | class3  -- ʔil- + reduplication + root + -iʔ (kaykay 'tall', ši:šip 'straight')
   deriving DecidableEq, Repr
 
-/-- The `DenotationType` of roots in each morphological class.
+/-- The semantic type of roots in each morphological class.
 
     Derived from the paper's analysis (§§4–5):
-    - Class 1/3: individual/state relations ⟨e, ⟨v, t⟩⟩
+    - Class 1/3: individual/state relations ⟨e,⟨s,t⟩⟩
     - Class 2: quality predicates ⟨v, t⟩ -/
-def MorphClass.denotationType : MorphClass → DenotationType
-  | .class1 => .indivStatePred
-  | .class2 => .statePred
-  | .class3 => .indivStatePred
+def MorphClass.denotationType : MorphClass → Intensional.Ty
+  | .class1 => .e ⇒ .s ⇒ .t
+  | .class2 => .s ⇒ .t
+  | .class3 => .e ⇒ .s ⇒ .t
 
 -- ════════════════════════════════════════════════════
--- § 2. Bipartite Verb Composability (derived from DenotationType)
+-- § 2. Bipartite Verb Composability (derived from the semantic type)
 -- ════════════════════════════════════════════════════
 
-/-- v_become requires an individual/state relation ⟨e, ⟨v, t⟩⟩.
+/-- Whether a semantic type takes an individual argument first — computed
+    from the type's structure (an `.e ⇒ _` arrow head), not stipulated
+    per class. -/
+def tyHasIndivArg : Intensional.Ty → Bool
+  | .fn .e _ => true
+  | _ => false
+
+/-- v_become requires an individual/state relation ⟨e,⟨s,t⟩⟩.
     A root can serve as a bipartite verb "final" (result component) iff
-    its denotation type has an individual argument.
-
-    This is DERIVED from `DenotationType.hasIndivArg`, not stipulated
-    per morphological class. -/
+    its semantic type takes an individual argument — derived from the
+    type structure. -/
 def MorphClass.canBeResultFinal (mc : MorphClass) : Bool :=
-  mc.denotationType.hasIndivArg
+  tyHasIndivArg mc.denotationType
 
 /-- Class 1 roots can appear as bipartite verb finals (e.g., √IHUK' 'dry'
     in resultative 'dry by wiping'). -/
@@ -113,8 +118,8 @@ theorem class3_can_be_final :
     MorphClass.class3.canBeResultFinal = true := rfl
 
 /-- Class 2 roots CANNOT appear as bipartite verb finals — type mismatch
-    with v_become because `statePred.hasIndivArg = false`.
-    ([hanink-koontz-garboden-2025] §5.1) -/
+    with v_become because ⟨s,t⟩ has no individual argument
+    (their analysis of the *ʔil-* prefix, §5.2). -/
 theorem class2_cannot_be_final :
     MorphClass.class2.canBeResultFinal = false := rfl
 
@@ -157,7 +162,7 @@ theorem vHave_is_ex_pi (entities : List Entity)
 /-- The ∇ operator (ʔil-): type-shifts an individual/state relation to
     a quality predicate ([hanink-koontz-garboden-2025] (57)).
 
-    `⟦ʔil-⟧ = λP_⟨e,⟨v,t⟩⟩ λs_v[∇P(s)]`
+    `⟦ʔil-⟧ = λP_⟨e,⟨v,t⟩⟩ λs_v[∇P(s)]` (the paper's own sort labels)
 
     Takes a relation P between individuals and states, and returns the
     set of states that underly P's range — i.e., states s such that
@@ -168,7 +173,7 @@ def nabla [BEq Entity] (entities : List Entity)
 
 /-- ∇ produces a quality-type predicate: its output depends only on the
     state, with the individual argument existentially closed.
-    This matches `DenotationType.statePred` (⟨v,t⟩). -/
+    This matches the Class 2 type ⟨s,t⟩. -/
 theorem nabla_closes_indiv_arg [BEq Entity] (entities : List Entity)
     (P : Entity → State → Bool) (s₁ s₂ : State)
     (h : ∀ x, P x s₁ = P x s₂) :
@@ -204,10 +209,10 @@ theorem only_class1_zero_categorizes (mc : MorphClass) :
 
 /-- Quality-type roots (those without an individual argument) always
     require possessive morphology. This is the paper's central claim:
-    the type mismatch between ⟨v,t⟩ and predication of individuals
+    the type mismatch between ⟨s,t⟩ and predication of individuals
     FORCES v_have. -/
 theorem no_indiv_arg_forces_vhave :
-    MorphClass.class2.denotationType.hasIndivArg = false ∧
+    tyHasIndivArg MorphClass.class2.denotationType = false ∧
     MorphClass.class2.requiresVHave = true := ⟨rfl, rfl⟩
 
 /-- ʔil- always co-occurs with -iʔ: Class 3 has both. ∇ type-shifts
@@ -379,19 +384,20 @@ theorem class_distribution :
 -- § 10. Bridge Theorems
 -- ════════════════════════════════════════════════════
 
-/-- `statePred` is the only `DenotationType` without an individual
-    argument — it is the type that forces possessive morphology. -/
+/-- ⟨s,t⟩ is the only class type without an individual argument — it is
+    the type that forces possessive morphology. -/
 theorem statePred_unique_no_indiv :
-    ∀ dt : DenotationType, dt.hasIndivArg = false ↔ dt = .statePred := by
-  intro dt; cases dt <;> decide
+    ∀ mc : MorphClass, tyHasIndivArg mc.denotationType = false ↔
+      mc.denotationType = (.s ⇒ .t) := by
+  intro mc; cases mc <;> decide
 
-/-- Class 1 and Class 3 share denotation type (both `indivStatePred`). -/
+/-- Class 1 and Class 3 share denotation type (both ⟨e,⟨s,t⟩⟩). -/
 theorem class1_class3_same_denotation :
     MorphClass.class1.denotationType = MorphClass.class3.denotationType := rfl
 
 /-- Class 2 is the only class with `statePred` denotation type. -/
 theorem class2_unique_statePred (mc : MorphClass) :
-    mc.denotationType = .statePred ↔ mc = .class2 := by
+    mc.denotationType = (.s ⇒ .t) ↔ mc = .class2 := by
   cases mc <;> decide
 
 /-- The three key predictions form a single biconditional over
@@ -403,7 +409,7 @@ theorem class2_unique_statePred (mc : MorphClass) :
     despite having indivStatePred, because ∇ converts it to quality-type
     before -iʔ applies.) -/
 theorem class2_characterization (mc : MorphClass) :
-    mc.denotationType = .statePred ↔
+    mc.denotationType = (.s ⇒ .t) ↔
     (mc.canBeResultFinal = false ∧ mc = .class2) := by
   cases mc <;> decide
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -20001,6 +20001,20 @@
   validated = {true},
   sources   = {Semantics/Verb/Root/Classification.lean}
 }
+% REF: Yu, J., Ausensi, J. & Smith, R. W. (2023). States and changes-of-state in the semantics of result roots.
+@article{yu-ausensi-smith-2023,
+  author    = {Yu, Jianrong and Ausensi, Josep and Smith, Ryan Walter},
+  year      = {2023},
+  title     = {States and changes-of-state in the semantics of result roots},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {41},
+  pages     = {1589--1628},
+  doi       = {10.1007/s11049-023-09570-9},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  validated = {true},
+  sources   = {Semantics/Intensional/Defs.lean}
+}
 @book{beavers-koontz-garboden-2020,
   author    = {Beavers, John and Koontz-Garboden, Andrew},
   year      = {2020},


### PR DESCRIPTION
Grounds root denotation types in the actual type grammar, per the Classification audits.

- `Intensional.Ty` gains the eventuality sorts `v` (events) and `s` (states) under [yu-ausensi-smith-2023]'s convention (new bib entry, DOI verified), plus type-level Functional Application `Ty.apply` ([heim-kratzer-1998]) with `apply_eq_some_iff` and `Denot.apply_sound` — composition failures are computed, not stipulated. The extensional `Denot` interprets the new sorts in the empty domain, with carrier-parametric event interpretation documented as the extension point.
- `DenotationType` is deleted: `Classification.denotationType : Option Intensional.Ty`, and Coon's / Hanink-KG's finite type inventories are stated paper-side over concrete `Ty` values (all sort letters now match the sources: ⟨e,⟨s,t⟩⟩ ~ ⟨s,t⟩ ~ ⟨e,⟨s,d⟩⟩ ~ ⟨e,t⟩). HKG's individual-argument test is computed from the type's arrow structure.
- The √ITV correction ([coon-2019] §3.3): √ITV roots are unaccusative and theme-taking — `rootITV.valency = {.internal}`, same type and valency as √TV. The discriminator is the new `licensesTransitiveVoice` coordinate (Coon's hedge quoted); `salienceClass` and `formsBareTransitive` re-key off it, and `tv_itv_same_type_different_voice` states Coon's actual claim.