### PR TITLE
refactor(Discourse/QUD): Strategy as RoseTree, Roberts stack invariant

### DIFF
--- a/Linglib/Core/Data/RoseTree/Basic.lean
+++ b/Linglib/Core/Data/RoseTree/Basic.lean
@@ -116,8 +116,8 @@ end DecidableEq
 /-- A child of a node is strictly smaller than the node, in the auto-generated
 `SizeOf`. This is the measure behind `rec'` and downstream well-founded
 recursions over `RoseTree`. -/
-theorem sizeOf_lt_of_mem {a : α} {cs : List (RoseTree α)} {c : RoseTree α} (hc : c ∈ cs) :
-    sizeOf c < sizeOf (RoseTree.node a cs) := by
+theorem sizeOf_lt_of_mem [SizeOf α] {a : α} {cs : List (RoseTree α)} {c : RoseTree α}
+    (hc : c ∈ cs) : sizeOf c < sizeOf (RoseTree.node a cs) := by
   have := List.sizeOf_lt_of_mem hc
   simp only [RoseTree.node.sizeOf_spec]
   omega
@@ -259,6 +259,24 @@ def numNodes : RoseTree α → ℕ :=
 theorem numNodes_pos (t : RoseTree α) : 0 < numNodes t := by
   cases t with
   | node a cs => rw [numNodes_node]; omega
+
+/-- The node values in preorder: root first, then each child's values
+left to right. -/
+def values : RoseTree α → List α :=
+  fold fun a ls => a :: ls.flatten
+
+@[simp] theorem values_node (a : α) (cs : List (RoseTree α)) :
+    values (node a cs) = a :: (cs.map values).flatten := by
+  simp only [values, fold_node]
+
+theorem length_values (t : RoseTree α) : t.values.length = t.numNodes := by
+  induction t with
+  | node a cs ih =>
+    simp only [values_node, numNodes_node, List.length_cons, List.length_flatten,
+      List.map_map, Function.comp_def]
+    rw [show (cs.map fun c => c.values.length) = cs.map numNodes from
+      List.map_congr_left ih]
+    omega
 
 /-- The number of leaves (childless nodes). A single leaf counts as `1`. -/
 def numLeaves : RoseTree α → ℕ :=

--- a/Linglib/Discourse/Gameboard/Basic.lean
+++ b/Linglib/Discourse/Gameboard/Basic.lean
@@ -197,7 +197,7 @@ theorem downdateQud_restores_nonResolveCond
 
 Ch. 4 defines QUD-downdate in terms of FACTS resolving questions.
 The `Support` typeclass abstracts this. Here we connect it to the
-partition-based `QUD W` from `Discourse/QUD.lean`
+partition-based `QUD W` from `Semantics/Questions/Partition/QUD.lean`
 ([groenendijk-stokhof-1984]):
 
 A `Set W` fact supports a `QUD W` question when the fact determines

--- a/Linglib/Discourse/QUD/AtIssueness.lean
+++ b/Linglib/Discourse/QUD/AtIssueness.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Core.Order.Boundedness
 import Linglib.Core.Order.Rat01
 import Mathlib.Tactic.NormNum

--- a/Linglib/Discourse/QUD/Basic.lean
+++ b/Linglib/Discourse/QUD/Basic.lean
@@ -1,144 +1,169 @@
-import Linglib.Semantics.Questions.Basic
+import Linglib.Core.Data.RoseTree.Basic
 import Linglib.Semantics.Questions.Hamblin
 import Linglib.Semantics.Questions.Entailment
 import Linglib.Semantics.Questions.Resolution
 
 /-!
 # Questions under discussion: stack and strategy
-[roberts-2012]
 
-The inquiry coordinate of the conversational scoreboard: the stack of
-accepted-but-unanswered questions (head is the immediate QUD;
-subquestions push, answers pop), the rose-tree strategy of inquiry
-decomposing a question into subquestions whose joint resolution answers
-the parent, and relevance of a move to the inquiry (`moveRelevant`,
-`moveRelevantToStrategy`).
+The inquiry coordinate of the conversational scoreboard, after
+[roberts-2012]: the stack of accepted-but-unanswered questions
+(`QUDStack`, her definition (10g); the head is the immediate QUD),
+strategies of inquiry as rose trees of questions (`Strategy`, her (12);
+[buring-2003]'s d-trees are the explicit tree-shaped ancestor),
+hereditary strategy completeness (`IsComplete`), and relevance of a
+move's denotation to a set of questions (`Relevant`, built from the
+assertion clause of her Relevance (15)). [ginzburg-2012]'s KoS models
+the same coordinate as a partially ordered set with its own update
+rules; that structure lives with the gameboard in
+`Discourse/Gameboard/`.
+
+## Main definitions
+
+* `Discourse.QUDStack` — the stack, as a `List (Question W)`
+* `Discourse.QUDStack.WellFormed` — Roberts' ordering constraint
+  (10g.iii), relative to a context set
+* `Discourse.Strategy` — strategies of inquiry as `RoseTree (Question W)`
+* `Discourse.Strategy.IsComplete` — at every branching node, the meet of
+  the children's questions entails the parent's
+* `Discourse.Relevant` — some alternative of the move partially answers
+  some question in the set
 
 ## Fidelity notes
 
-`moveRelevant` is existential answerhood relevance: the partial-answer
-clause of [roberts-2012]'s Relevance (15), weaker than her strategy
-clause for interrogative moves. It is the proxy
-[ippolito-kiss-williams-2025] use for their relevance assumption (iii),
-consumed by the discourse *only* definedness condition in their (16).
-That the `subquestions` argument really lists subquestions of the QUD is
-the caller's obligation.
+Roberts' (10g) makes QUD a function from moves to ordered sets of
+accepted, unanswered questions; `QUDStack` models a single value of that
+function, and clause (iii) — each question's complete answers
+contextually entail partial answers to every question below it — is
+`WellFormed`, relative to a context set because entailment in her (9) is
+contextual throughout. She warns against strengthening (iii) to question
+entailment (her bridging-question discourse (13) violates it). Questions
+are retired when answered or determined practically unanswerable, and
+she licenses non-LIFO removal (answering a lower question discharges the
+higher questions in its strategy); `List.tail` is the unconditional LIFO
+special case, and the licensing conditions are the caller's obligation.
+
+Her (12) defines `Strat(q)` derivatively — its substrategies are those
+for the questions accepted while `q` was the immediate QUD — with
+well-formedness left to "rational considerations", and the second
+component an unordered set. The ordered `RoseTree` follows
+[buring-2003]. `IsComplete` is the success criterion her D₀ discussion
+illustrates (complete answers to the subquestions jointly yield a
+complete answer to the parent), not a clause of (12); the converse
+direction (parent entails children-meet) is exactly what (13) rules out.
+
+`Relevant` is existential answerhood relevance: weaker than (15), whose
+guarantee is universal (every complete answer to the move contextually
+entails a partial answer to the QUD), and set-valued where (15) targets
+only `last(QUD)`. The set extension is the proxy
+[ippolito-kiss-williams-2025] use for their relevance assumption,
+consumed by the discourse *only* definedness condition in their (16);
+that the set really holds subquestions of the QUD is the caller's
+obligation.
 -/
 
 namespace Discourse
 
-/-- A QUD stack: ordered list of accepted, unanswered questions
-    (Roberts 2012 Def 10g). -/
-structure QUDStack (W : Type*) where
-  questions : List (Question W)
+/-- A QUD stack ([roberts-2012] definition (10g)): the accepted, unanswered
+questions, most recent first, so the head is the immediate QUD. Accepting a
+question is `List.cons`; retiring one from the top is `List.tail`. -/
+abbrev QUDStack (W : Type*) := List (Question W)
 
 namespace QUDStack
 
 variable {W : Type*}
 
-/-- Empty QUD stack (discourse initial state). -/
-def empty : QUDStack W := ⟨[]⟩
+/-- Roberts' ordering constraint (10g.iii) on a QUD stack, relative to context
+set `C`: for `higher` accepted more recently than `lower`, every complete
+answer to `higher` contextually entails a partial answer to `lower`. -/
+def WellFormed (C : Set W) (s : QUDStack W) : Prop :=
+  s.Pairwise fun higher lower =>
+    ∀ a ∈ Question.alt higher, Question.PartiallyAnswers (C ∩ a) lower
 
-/-- The immediate QUD: the most recently accepted, unanswered question. -/
-def immediateQUD (s : QUDStack W) : Option (Question W) := s.questions.head?
+@[simp] theorem wellFormed_nil (C : Set W) : WellFormed C ([] : QUDStack W) :=
+  List.Pairwise.nil
 
-/-- Accept a new question: push onto the stack. -/
-def push (s : QUDStack W) (q : Question W) : QUDStack W := ⟨q :: s.questions⟩
+@[simp] theorem wellFormed_singleton (C : Set W) (q : Question W) :
+    WellFormed C [q] :=
+  List.pairwise_singleton ..
 
-/-- Answer the immediate QUD: pop from the stack. -/
-def pop (s : QUDStack W) : QUDStack W := ⟨s.questions.tail⟩
+/-- Accepting `q` preserves well-formedness iff `q`'s complete answers
+contextually partially answer every question already on the stack. -/
+theorem wellFormed_cons {C : Set W} {q : Question W} {s : QUDStack W} :
+    WellFormed C (q :: s) ↔
+      (∀ lower ∈ s, ∀ a ∈ Question.alt q,
+        Question.PartiallyAnswers (C ∩ a) lower) ∧ WellFormed C s :=
+  List.pairwise_cons
 
-/-- Current depth of the QUD stack. -/
-def depth (s : QUDStack W) : Nat := s.questions.length
+/-- Retiring the immediate QUD preserves well-formedness. -/
+theorem WellFormed.tail {C : Set W} {s : QUDStack W} (h : WellFormed C s) :
+    WellFormed C s.tail :=
+  List.Pairwise.tail h
 
 end QUDStack
 
-open Question
-
-/-- A strategy of inquiry as a rose tree: each node a question, children
-    subquestions whose joint resolution answers the parent (Roberts Def 12). -/
-inductive Strategy (W : Type*) where
-  | leaf : Question W → Strategy W
-  | branch : Question W → List (Strategy W) → Strategy W
+/-- A strategy of inquiry as a rose tree of questions ([roberts-2012]
+definition (12), [buring-2003]'s d-trees): each node a question, its children
+the subquestions pursued to answer it. -/
+abbrev Strategy (W : Type*) := RoseTree (Question W)
 
 namespace Strategy
 
 variable {W : Type*}
 
-/-- The question at the root of this (sub)strategy. -/
-def question : Strategy W → Question W
-  | .leaf q | .branch q _ => q
+/-- A strategy is **complete** when at every branching node the meet of the
+children's questions entails the parent's question: jointly resolving the
+subquestions resolves the parent. Terminal nodes are trivially complete. -/
+inductive IsComplete : Strategy W → Prop
+  | node {q : Question W} {cs : List (Strategy W)}
+      (complete : cs ≠ [] →
+        ((cs.map RoseTree.value : Multiset (Question W))).inf.Entails q)
+      (children : ∀ c ∈ cs, IsComplete c) : IsComplete (.node q cs)
 
-/-- Immediate substrategies (empty for leaves). -/
-def substrategies : Strategy W → List (Strategy W)
-  | .leaf _ => []
-  | .branch _ ss => ss
+theorem IsComplete.leaf (q : Question W) : IsComplete (.leaf q : Strategy W) :=
+  .node (fun h => absurd rfl h) nofun
 
-/-- All questions in the strategy (root + all descendants). -/
-def allQuestions : Strategy W → List (Question W)
-  | .leaf q => [q]
-  | .branch q ss => q :: ss.flatMap allQuestions
+/-- Binary branching: a two-child node is complete when the meet of the
+children's questions entails the parent's and both children are complete. -/
+theorem IsComplete.node_pair {q : Question W} {s t : Strategy W}
+    (h : (s.value ⊓ t.value).Entails q)
+    (hs : s.IsComplete) (ht : t.IsComplete) :
+    IsComplete (.node q [s, t]) := by
+  refine .node (fun _ => ?_) ?_
+  · simpa using h
+  · rintro c hc
+    rcases List.mem_cons.mp hc with rfl | hc
+    · exact hs
+    · rcases List.mem_cons.mp hc with rfl | hc
+      · exact ht
+      · exact absurd hc (List.not_mem_nil)
 
-/-- Leaf questions only (terminal nodes of the strategy). -/
-def leaves : Strategy W → List (Question W)
-  | .leaf q => [q]
-  | .branch _ ss => ss.flatMap leaves
-
-/-- A strategy is complete at a single level: the meet of children's
-    questions entails the parent. Recurse on substrategies for full-tree
-    verification. -/
-def isComplete : Strategy W → Prop
-  | .leaf _ => True
-  | .branch q children =>
-    let combined := (children.map (·.question)).foldl (· ⊓ ·) ⊤
-    combined.Entails q
+@[simp] theorem isComplete_node_iff {q : Question W} {cs : List (Strategy W)} :
+    IsComplete (.node q cs) ↔
+      (cs ≠ [] →
+        ((cs.map RoseTree.value : Multiset (Question W))).inf.Entails q) ∧
+        ∀ c ∈ cs, IsComplete c :=
+  ⟨fun h => by cases h with | node h₁ h₂ => exact ⟨h₁, h₂⟩,
+    fun ⟨h₁, h₂⟩ => .node h₁ h₂⟩
 
 end Strategy
 
 variable {W : Type*}
 
-/-- A move is relevant if one of its alternatives partially answers the
-QUD or one of the subquestions. -/
-def moveRelevant (den qud : Question W) (subquestions : List (Question W)) : Prop :=
-  ∃ a ∈ Question.alt den,
-    Question.PartiallyAnswers a qud ∨
-      ∃ q ∈ subquestions, Question.PartiallyAnswers a q
+/-- A move with denotation `den` is **relevant** to the questions in `qs` when
+some alternative of `den` partially answers some question in `qs` — the
+assertion clause of [roberts-2012]'s Relevance (15), existentially weakened
+and extended to a question set (see the fidelity notes). -/
+def Relevant (den : Question W) (qs : Set (Question W)) : Prop :=
+  ∃ a ∈ Question.alt den, ∃ q ∈ qs, Question.PartiallyAnswers a q
 
-/-- A discourse move is relevant to a strategy if some alternative of
-    `den` partially answers some question in the strategy. -/
-def moveRelevantToStrategy (den : Question W) (strat : Strategy W) : Prop :=
-  ∃ a ∈ Question.alt den, ∃ q ∈ strat.allQuestions, Question.PartiallyAnswers a q
-
-/-- A move is relevant if one of its alternatives partially answers the
-QUD directly, with no subquestions. -/
-theorem moveRelevant_of_partiallyAnswers
-    {den qud : Question W} {a : Set W} (ha : a ∈ Question.alt den)
-    (h : Question.PartiallyAnswers a qud) :
-    moveRelevant den qud [] :=
-  ⟨a, ha, Or.inl h⟩
-
-/-- Strategy relevance is `moveRelevant` against the root question and
-the descendant questions. -/
-theorem moveRelevantToStrategy_iff_moveRelevant
-    (den : Question W) (strat : Strategy W) :
-    moveRelevantToStrategy den strat ↔
-      moveRelevant den strat.question
-        (strat.substrategies.flatMap Strategy.allQuestions) := by
-  cases strat <;>
-    simp [moveRelevantToStrategy, moveRelevant, Strategy.allQuestions,
-      Strategy.question, Strategy.substrategies]
-
-/-- Polar reduction of `moveRelevant` to partial answerhood of `p` and
-`pᶜ`. -/
-theorem moveRelevant_polar_iff {p : Set W} {qud : Question W}
-    {subquestions : List (Question W)}
+/-- Polar reduction of `Relevant` to partial answerhood of `p` and `pᶜ`. -/
+theorem relevant_polar_iff {p : Set W} {qs : Set (Question W)}
     (hne : p ≠ ∅) (hnu : p ≠ Set.univ) :
-    moveRelevant (Question.polar p) qud subquestions ↔
-      (Question.PartiallyAnswers p qud ∨
-        ∃ Q ∈ subquestions, Question.PartiallyAnswers p Q) ∨
-      (Question.PartiallyAnswers pᶜ qud ∨
-        ∃ Q ∈ subquestions, Question.PartiallyAnswers pᶜ Q) := by
-  simp only [moveRelevant, Question.alt_polar_of_nontrivial hne hnu,
+    Relevant (Question.polar p) qs ↔
+      (∃ q ∈ qs, Question.PartiallyAnswers p q) ∨
+        ∃ q ∈ qs, Question.PartiallyAnswers pᶜ q := by
+  simp only [Relevant, Question.alt_polar_of_nontrivial hne hnu,
     Set.mem_insert_iff, Set.mem_singleton_iff, exists_eq_or_imp,
     exists_eq_left]
 

--- a/Linglib/Semantics/Degree/Granularity.lean
+++ b/Linglib/Semantics/Degree/Granularity.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.Finset.Max
 import Linglib.Core.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Order.Group.Defs
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Semantics.Questions.Partition.Lattice
 
 /-!

--- a/Linglib/Semantics/Questions/Partition/Basic.lean
+++ b/Linglib/Semantics/Questions/Partition/Basic.lean
@@ -21,6 +21,7 @@ classes of any equivalence relation.
 - `fromSetoid r` — the issue whose alternatives are the cells of `r`.
 - `IsPartition P` — `Setoid.IsPartition (alt P)`.
 - `toSetoid h` — the equivalence relation of a partition issue.
+- `QUD.toQuestion q` — the issue whose alternatives are a QUD's cells.
 - `toQUD h` — bridge to the legacy Bool-based `QUD W`.
 
 ## Main theorems
@@ -217,7 +218,16 @@ theorem toSetoid_rel_iff {P : Question W} (h : P.IsPartition) (w v : W) :
     (toSetoid h) w v ↔ ∃ p ∈ alt P, w ∈ p ∧ v ∈ p := by
   rw [Setoid.rel_iff_exists_classes, classes_toSetoid h]
 
-/-! ### `toQUD` — bridge to the legacy Bool-based QUD -/
+/-! ### Bridges to the Bool-based QUD -/
+
+/-- The issue raised by a `QUD`: its alternatives are exactly the QUD's
+    equivalence classes. The bridge is one-way: not every `Question`
+    arises from a `QUD` (mention-some, intermediate-exhaustive, and
+    conditional-question alternatives are non-disjoint or non-exhaustive
+    and so are not the cells of any equivalence relation —
+    [theiler-etal-2018]). -/
+def _root_.QUD.toQuestion (q : QUD W) : Question W :=
+  fromSetoid q.toSetoid
 
 /-- Bridge to legacy Bool-based `QUD W`: two worlds get the same
     answer iff they share an alternative cell. `noncomputable` —

--- a/Linglib/Semantics/Questions/Support.lean
+++ b/Linglib/Semantics/Questions/Support.lean
@@ -41,7 +41,7 @@ canonical one).
 ## Specialisations
 
 * `Question.PartiallyAnswers` (`Resolution.lean`) and
-  `Discourse.moveRelevant` (`Discourse/QUD/Basic.lean`) — Roberts
+  `Discourse.Relevant` (`Discourse/QUD/Basic.lean`) — Roberts
   QUD-relevance over `Question W`. Specific notions, not a typeclass.
 * `Question.Resolves` / `Question.MentionAll` (`Resolution.lean`) over
   `Set W → Question W`. Each is a candidate `Support` instance for the

--- a/Linglib/Studies/DeoThomas2025.lean
+++ b/Linglib/Studies/DeoThomas2025.lean
@@ -339,8 +339,8 @@ At the partition level, "finer" is `QUD.refines` (every fine cell ⊆ some coars
 cell), equivalently `q.toSetoid ≤ q'.toSetoid` in mathlib's `Setoid` lattice.
 At the issue level, "wider" is `Question.widerThan` ([deo-thomas-2025]
 (32): same `info`, no coarse answer ⊊ fine answer, some fine answer ⊊ coarse
-answer). The bridge: `toIssue := Question.fromSetoid ∘ QUD.toSetoid`
-preserves this relationship.
+answer). The bridge `QUD.toQuestion` (in
+`Semantics/Questions/Partition/Basic.lean`) preserves this relationship.
 
 The proof is an order-theoretic one-liner over `Setoid`: every alternative
 of `Question.fromSetoid r` is either `∅` or an equivalence class of `r`
@@ -349,21 +349,10 @@ the q'-class of `w₀` by refinement, with `v₀` witnessing strict containment.
 This replaces a 100-line Bool/List proof that managed indices into
 `worlds : List W` and case-split on `properlyContains`. -/
 
-/-- A `QUD` partitions a meaning space via an equivalence relation; via
-    `QUD.toSetoid` and `Question.fromSetoid`, every QUD induces an
-    inquisitive content whose alternatives are exactly the QUD's
-    equivalence classes. The bridge is one-way: not every `Question`
-    arises from a `QUD` (mention-some, intermediate-exhaustive, and
-    conditional-question alternatives are non-disjoint or non-exhaustive
-    and so are not representable as the cells of any equivalence
-    relation — [theiler-etal-2018]). -/
-def toIssue {W : Type*} (q : QUD W) : Question W :=
-  Question.fromSetoid q.toSetoid
-
 /-- Strict partition refinement implies issue width.
 
     If `q` (strictly) refines `q'` (`q` is the finer partition), then
-    `toIssue q` is wider than `toIssue q'` as `Question`s.
+    `QUD.toQuestion q` is wider than `QUD.toQuestion q'` as `Question`s.
 
     The strictness witnesses `w₀, v₀ : W` share a coarse cell
     (`q'.r w₀ v₀`) but not a fine cell
@@ -384,7 +373,7 @@ theorem refinement_implies_wider {W : Type*}
     (w₀ v₀ : W)
     (hCoarse : q'.r w₀ v₀)
     (hFine : ¬ q.r w₀ v₀) :
-    (toIssue q).widerThan (toIssue q') := by
+    (QUD.toQuestion q).widerThan (QUD.toQuestion q') := by
   -- Refinement reads as `q.toSetoid ≤ q'.toSetoid` in mathlib's lattice
   have hle : ∀ {x y : W}, q.toSetoid x y → q'.toSetoid x y :=
     fun {x y} hxy => QUD.r_of_sameAnswer (hRefines x y (QUD.sameAnswer_of_r hxy))
@@ -399,7 +388,7 @@ theorem refinement_implies_wider {W : Type*}
     Question.class_mem_alt_fromSetoid _ hC₂_class
   refine ⟨?_, ?_, ?_⟩
   -- (a) Same info: both reduce to Set.univ
-  · simp only [toIssue, Question.info_fromSetoid]
+  · simp only [QUD.toQuestion, Question.info_fromSetoid]
   -- (b) No q'-alternative properly contained in any q-alternative
   · intro p₂ hp₂ p₁ hp₁ hssub
     rcases Question.alt_fromSetoid_subset_classes _ hp₂ with hp₂_empty | hp₂_class
@@ -475,7 +464,7 @@ theorem finer_granularity_implies_wider (n ε₁ ε₂ : Nat)
     (w₀ v₀ : Fin n)
     (hCoarse : (granQUD n ε₂).r w₀ v₀)
     (hFine : ¬ (granQUD n ε₁).r w₀ v₀) :
-    (toIssue (granQUD n ε₁)).widerThan (toIssue (granQUD n ε₂)) :=
+    (QUD.toQuestion (granQUD n ε₁)).widerThan (QUD.toQuestion (granQUD n ε₂)) :=
   refinement_implies_wider _ _
     (finer_granularity_refines n ε₁ ε₂ hdvd)
     w₀ v₀ hCoarse hFine
@@ -517,7 +506,7 @@ theorem fig1_strict_refinement :
     Witnessed by worlds 0 and 2: they share a coarse cell (0/4 = 2/4 = 0)
     but not a fine cell (0/2 = 0 ≠ 2/2 = 1). -/
 theorem fig1_finer_is_wider :
-    (toIssue fineQ).widerThan (toIssue coarseQ) := by
+    (QUD.toQuestion fineQ).widerThan (QUD.toQuestion coarseQ) := by
   rw [coarseQ_is_granQUD, fineQ_is_granQUD]
   exact finer_granularity_implies_wider 8 2 4 ⟨2, rfl⟩
     0 2

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -3,7 +3,6 @@ import Linglib.Features.Definiteness
 import Linglib.Semantics.Definiteness.Maximality
 import Linglib.Semantics.Intensional.Rigidity
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Semantics.Definiteness.Basic
 import Linglib.Semantics.Reference.Donnellan
 import Linglib.Fragments.English.Determiners

--- a/Linglib/Studies/IppolitoKissWilliams2025.lean
+++ b/Linglib/Studies/IppolitoKissWilliams2025.lean
@@ -107,7 +107,7 @@ answer whose existence the definedness condition requires.
 namespace IppolitoKissWilliams2025
 
 open Question Semantics.Questions.Probabilistic
-open Discourse (moveRelevant moveRelevant_polar_iff)
+open Discourse (Relevant relevant_polar_iff)
 open IppolitoKissWilliams2022
 
 /-! ### Discourse context -/
@@ -131,7 +131,7 @@ structure Context (W : Type*) where
   /-- Subquestions of the QUD established by the discourse context.
       [roberts-2012] (subquestion strategy); IKW §5.1: provided
       by the context, not computed. -/
-  subquestions : List (Question W)
+  subquestions : Set (Question W)
 
 /-! ### Sentence -/
 
@@ -167,8 +167,8 @@ def atIssueContent (d : Sentence W) : Set W :=
     2. `S'` is structurally relevant to the QUD;
     3. `S` supports some answer α ∈ QUD via `Supports`. -/
 def isDefined (d : Sentence W) (ctx : Context W) : Prop :=
-  moveRelevant d.sDen ctx.qud ctx.subquestions ∧
-  moveRelevant d.s'Den ctx.qud ctx.subquestions ∧
+  Relevant d.sDen (insert ctx.qud ctx.subquestions) ∧
+  Relevant d.s'Den (insert ctx.qud ctx.subquestions) ∧
   ∃ α ∈ alt ctx.qud, Supports ctx.dox d.sDen α ctx.prior
 
 /-- CI content of discourse *only*. [ippolito-kiss-williams-2025]
@@ -531,8 +531,8 @@ noncomputable def coreCtx : Context World where
   prior := prior
   dox := doxBE
   partialAnswers := []
-  subquestions := [Question.polar beautiful, Question.polar expensive,
-                   Question.polar renovated]
+  subquestions := {Question.polar beautiful, Question.polar expensive,
+                   Question.polar renovated}
 
 /-- Context for clause-type examples: S = "beautiful", S' =
     interrogative. Speaker believes S but doesn't know the answer to
@@ -543,8 +543,8 @@ noncomputable def clauseTypeCtx : Context World where
   prior := prior
   dox := doxB
   partialAnswers := []
-  subquestions := [Question.polar beautiful, Question.polar expensive,
-                   Question.polar renovated]
+  subquestions := {Question.polar beautiful, Question.polar expensive,
+                   Question.polar renovated}
 
 /-! ### § 5: Sentences -/
 
@@ -567,7 +567,7 @@ predictions on a concrete 8-world model with uniform prior. The PMF
 arithmetic reduces to four base probabilities (`beautiful`, `expensive`,
 their intersections with `buy`/`buyᶜ`) computed via
 `PMF.probOfSet_apply` + `Fin.sum_univ_eight`. The doxastic `⊆` checks
-and the `moveRelevant` reductions (via `moveRelevant_polar_iff`) are
+and the `Relevant` reductions (via `relevant_polar_iff`) are
 pure Set arithmetic discharged by `decide`.
 -/
 
@@ -864,23 +864,18 @@ private lemma sBeautiful_not_supports_buy_compl_doxBE :
     explicit subquestion list, and `S` supports `buy` from `doxBE`. -/
 theorem core_isDefined : declSentence.isDefined coreCtx := by
   refine ⟨?_, ?_, ?_⟩
-  · -- moveRelevant sBeautiful coreCtx.qud coreCtx.subquestions
-    -- via the `polar beautiful` subquestion in coreCtx.subquestions
+  · -- Relevant sBeautiful, via the `polar beautiful` subquestion
     rw [show declSentence.sDen = Question.polar beautiful from rfl,
-        moveRelevant_polar_iff beautiful_ne_empty beautiful_ne_univ]
-    refine Or.inl (Or.inr ?_)
-    refine ⟨Question.polar beautiful, ?_, ?_⟩
-    · show Question.polar beautiful ∈ coreCtx.subquestions
-      simp [coreCtx]
+        relevant_polar_iff beautiful_ne_empty beautiful_ne_univ]
+    refine Or.inl ⟨Question.polar beautiful, ?_, ?_⟩
+    · exact Set.mem_insert_of_mem _ (by simp [coreCtx])
     · rw [partiallyAnswers_polar_iff beautiful_ne_empty beautiful_ne_univ]
       exact Or.inl Set.Subset.rfl
-  · -- moveRelevant s'Expensive coreCtx.qud coreCtx.subquestions
+  · -- Relevant s'Expensive, via the `polar expensive` subquestion
     rw [show declSentence.s'Den = Question.polar expensive from rfl,
-        moveRelevant_polar_iff expensive_ne_empty expensive_ne_univ]
-    refine Or.inl (Or.inr ?_)
-    refine ⟨Question.polar expensive, ?_, ?_⟩
-    · show Question.polar expensive ∈ coreCtx.subquestions
-      simp [coreCtx]
+        relevant_polar_iff expensive_ne_empty expensive_ne_univ]
+    refine Or.inl ⟨Question.polar expensive, ?_, ?_⟩
+    · exact Set.mem_insert_of_mem _ (by simp [coreCtx])
     · rw [partiallyAnswers_polar_iff expensive_ne_empty expensive_ne_univ]
       exact Or.inl Set.Subset.rfl
   · -- ∃ α ∈ alt qud, Supports doxBE sBeautiful α prior
@@ -989,22 +984,18 @@ private lemma doxB_not_subset_renovated_compl : ¬ doxB ⊆ renovatedᶜ := by
     the relevance of `s'RenovatedQ`. -/
 theorem polarQ_isDefined : polarQSentence.isDefined clauseTypeCtx := by
   refine ⟨?_, ?_, ?_⟩
-  · -- moveRelevant sBeautiful via polar beautiful subquestion
+  · -- Relevant sBeautiful, via the `polar beautiful` subquestion
     rw [show polarQSentence.sDen = Question.polar beautiful from rfl,
-        moveRelevant_polar_iff beautiful_ne_empty beautiful_ne_univ]
-    refine Or.inl (Or.inr ?_)
-    refine ⟨Question.polar beautiful, ?_, ?_⟩
-    · show Question.polar beautiful ∈ clauseTypeCtx.subquestions
-      simp [clauseTypeCtx]
+        relevant_polar_iff beautiful_ne_empty beautiful_ne_univ]
+    refine Or.inl ⟨Question.polar beautiful, ?_, ?_⟩
+    · exact Set.mem_insert_of_mem _ (by simp [clauseTypeCtx])
     · rw [partiallyAnswers_polar_iff beautiful_ne_empty beautiful_ne_univ]
       exact Or.inl Set.Subset.rfl
-  · -- moveRelevant s'RenovatedQ via polar renovated subquestion
+  · -- Relevant s'RenovatedQ, via the `polar renovated` subquestion
     rw [show polarQSentence.s'Den = Question.polar renovated from rfl,
-        moveRelevant_polar_iff renovated_ne_empty renovated_ne_univ]
-    refine Or.inl (Or.inr ?_)
-    refine ⟨Question.polar renovated, ?_, ?_⟩
-    · show Question.polar renovated ∈ clauseTypeCtx.subquestions
-      simp [clauseTypeCtx]
+        relevant_polar_iff renovated_ne_empty renovated_ne_univ]
+    refine Or.inl ⟨Question.polar renovated, ?_, ?_⟩
+    · exact Set.mem_insert_of_mem _ (by simp [clauseTypeCtx])
     · rw [partiallyAnswers_polar_iff renovated_ne_empty renovated_ne_univ]
       exact Or.inl Set.Subset.rfl
   · refine ⟨buy, ?_, sBeautiful_supports_buy_doxB⟩

--- a/Linglib/Studies/Jenks2018.lean
+++ b/Linglib/Studies/Jenks2018.lean
@@ -345,7 +345,7 @@ Two empirical points the paper makes (p. 524-526):
   *ne* (continuing topic + alternative-set).
 
 The substrate has `Roberts2012` QUD machinery in
-`Discourse/QUDStack.lean`. A faithful formalization of paper §5.3
+`Discourse/QUD/Basic.lean`. A faithful formalization of paper §5.3
 would need a topic predicate over `Description` configurations
 co-occurring with QUD-stack state — substrate the linglib has but
 that this study file does not yet plug into.

--- a/Linglib/Studies/KatzirSingh2015.lean
+++ b/Linglib/Studies/KatzirSingh2015.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Studies.Magri2009
 import Linglib.Semantics.Questions.Partition.Constructors
 

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Semantics.Focus.Marking
 import Linglib.Features.Givenness
 import Linglib.Semantics.Focus.ExtractionClash

--- a/Linglib/Studies/RitchieSchiller2024.lean
+++ b/Linglib/Studies/RitchieSchiller2024.lean
@@ -4,7 +4,6 @@ import Linglib.Pragmatics.BToM
 import Linglib.Pragmatics.RSA.Canonical
 import Linglib.Discourse.CommonGround
 import Linglib.Semantics.Questions.Partition.QUD
-import Linglib.Discourse.QUD.Basic
 import Linglib.Features.Subjectivity
 
 /-!

--- a/Linglib/Studies/Roberts2012.lean
+++ b/Linglib/Studies/Roberts2012.lean
@@ -17,34 +17,33 @@ formal theory of pragmatics" (Semantics & Pragmatics 5(6): 1–69).
 
 1. **QUD stack** — discourse state is an ordered stack of accepted, unanswered
    questions (`QUDStack`), not a single QUD.
-2. **Strategy of inquiry** — recursive question decomposition (`Strategy`):
-   answering all subquestions answers the parent.
+2. **Strategy of inquiry** — questions decomposed into subquestions
+   (`Strategy`), with completeness (`Strategy.IsComplete`) capturing her
+   observation that jointly answering D₀'s subquestions answers the parent.
 3. **Negative partial answerhood** — a proposition partially answers a question
    by ruling out an alternative, not just confirming one (`PartiallyAnswers`).
 4. **Q-A congruence** — the focus alternatives of an answer equal the QUD
    alternatives (grounded by the Rooth–Hamblin type identity).
 
-## D₀ Worked Example (Roberts §1.2)
+## D₀ Worked Example
 
-The Big Question: "What did each person eat?"
-
-- 4 Boolean dimensions: Hannah-beans, Hannah-tofu, Roger-beans, Roger-tofu
-- 16 possible worlds
-- 7 questions forming a strategy tree
+Roberts' worked discourse D₀, on a model with two individuals (Hilary,
+Robin) and two foods (bagels, tofu): 4 Boolean dimensions, 16 possible
+worlds, 7 questions forming a strategy tree.
 
 ```
-         q₁ (What did everyone eat?)
+         q₁ (Who ate what?)
         /                            \
-    q_a (What did Hannah eat?)    q_b (What did Roger eat?)
+    q_a (What did Hilary eat?)    q_b (What did Robin eat?)
     /        \                    /        \
-q_ai (H beans?) q_aii (H tofu?) q_bi (R beans?) q_bii (R tofu?)
+q_ai (H bagels?) q_aii (H tofu?) q_bi (R bagels?) q_bii (R tofu?)
 ```
 
 ## Representation
 
 This file uses `Question` (Set-based, with `Question.Entails` from
 `Entailment.lean`, `Question.PartiallyAnswers` from `Resolution.lean`, and
-`Discourse.moveRelevant`, all reduced to decidable `Set` inclusions via
+`Discourse.Relevant`, all reduced to decidable `Set` inclusions via
 the `_polar_iff` lemmas). Non-polar issues are built via
 `Question.ofList` and `⊓`; entailment for these goes through the lattice
 route (`entails_of_le'`). Set-based partitions live in
@@ -55,7 +54,7 @@ route (`entails_of_le'`). Set-based partitions live in
 namespace Roberts2012
 
 open Question
-open Discourse (QUDStack Strategy moveRelevant moveRelevantToStrategy)
+open Discourse (QUDStack Strategy Relevant)
 
 -- `decide` on `Set`-subset goals from the `_polar_iff` reductions.
 attribute [local instance] Set.decidableSubsetOfFintype
@@ -66,10 +65,10 @@ attribute [local instance] Set.decidableSubsetOfFintype
 
 /-- A world in the D₀ scenario: 4 independent Boolean facts. -/
 structure D0World where
-  hb : Bool   -- Hannah ate beans
-  ht : Bool   -- Hannah ate tofu
-  rb : Bool   -- Roger ate beans
-  rt : Bool   -- Roger ate tofu
+  hb : Bool   -- Hilary ate bagels
+  ht : Bool   -- Hilary ate tofu
+  rb : Bool   -- Robin ate bagels
+  rt : Bool   -- Robin ate tofu
   deriving DecidableEq, BEq, Repr
 
 /-- Finite enumeration of D0World via the canonical equivalence with
@@ -87,75 +86,75 @@ theorem card_D0World : Fintype.card D0World = 16 := by decide
 -- § Atomic Propositions (as Sets)
 -- ════════════════════════════════════════════════════
 
-/-- Hannah ate the beans. -/
-def hannahBeans : Set D0World := {w | w.hb = true}
-/-- Hannah ate the tofu. -/
-def hannahTofu : Set D0World := {w | w.ht = true}
-/-- Roger ate the beans. -/
-def rogerBeans : Set D0World := {w | w.rb = true}
-/-- Roger ate the tofu. -/
-def rogerTofu : Set D0World := {w | w.rt = true}
+/-- Hilary ate the bagels. -/
+def hilaryBagels : Set D0World := {w | w.hb = true}
+/-- Hilary ate the tofu. -/
+def hilaryTofu : Set D0World := {w | w.ht = true}
+/-- Robin ate the bagels. -/
+def robinBagels : Set D0World := {w | w.rb = true}
+/-- Robin ate the tofu. -/
+def robinTofu : Set D0World := {w | w.rt = true}
 
-instance : DecidablePred (· ∈ hannahBeans) :=
+instance : DecidablePred (· ∈ hilaryBagels) :=
   fun w => show Decidable (w.hb = true) from inferInstance
-instance : DecidablePred (· ∈ (hannahBeansᶜ : Set D0World)) :=
-  fun w => show Decidable (¬ w ∈ hannahBeans) from inferInstance
-instance : DecidablePred (· ∈ hannahTofu) :=
+instance : DecidablePred (· ∈ (hilaryBagelsᶜ : Set D0World)) :=
+  fun w => show Decidable (¬ w ∈ hilaryBagels) from inferInstance
+instance : DecidablePred (· ∈ hilaryTofu) :=
   fun w => show Decidable (w.ht = true) from inferInstance
-instance : DecidablePred (· ∈ (hannahTofuᶜ : Set D0World)) :=
-  fun w => show Decidable (¬ w ∈ hannahTofu) from inferInstance
-instance : DecidablePred (· ∈ rogerBeans) :=
+instance : DecidablePred (· ∈ (hilaryTofuᶜ : Set D0World)) :=
+  fun w => show Decidable (¬ w ∈ hilaryTofu) from inferInstance
+instance : DecidablePred (· ∈ robinBagels) :=
   fun w => show Decidable (w.rb = true) from inferInstance
-instance : DecidablePred (· ∈ (rogerBeansᶜ : Set D0World)) :=
-  fun w => show Decidable (¬ w ∈ rogerBeans) from inferInstance
-instance : DecidablePred (· ∈ rogerTofu) :=
+instance : DecidablePred (· ∈ (robinBagelsᶜ : Set D0World)) :=
+  fun w => show Decidable (¬ w ∈ robinBagels) from inferInstance
+instance : DecidablePred (· ∈ robinTofu) :=
   fun w => show Decidable (w.rt = true) from inferInstance
-instance : DecidablePred (· ∈ (rogerTofuᶜ : Set D0World)) :=
-  fun w => show Decidable (¬ w ∈ rogerTofu) from inferInstance
+instance : DecidablePred (· ∈ (robinTofuᶜ : Set D0World)) :=
+  fun w => show Decidable (¬ w ∈ robinTofu) from inferInstance
 
 /-! ### Nontriviality lemmas (manual, one per atomic proposition) -/
 
-theorem hb_ne_empty : hannahBeans ≠ (∅ : Set D0World) := by
+theorem hb_ne_empty : hilaryBagels ≠ (∅ : Set D0World) := by
   intro h
-  have hmem : (⟨true, false, false, false⟩ : D0World) ∈ hannahBeans := rfl
+  have hmem : (⟨true, false, false, false⟩ : D0World) ∈ hilaryBagels := rfl
   rw [h] at hmem; exact hmem.elim
 
-theorem hb_ne_univ : hannahBeans ≠ Set.univ := by
+theorem hb_ne_univ : hilaryBagels ≠ Set.univ := by
   intro h
-  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ hannahBeans :=
+  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ hilaryBagels :=
     h.symm ▸ Set.mem_univ _
   exact Bool.false_ne_true hmem
 
-theorem ht_ne_empty : hannahTofu ≠ (∅ : Set D0World) := by
+theorem ht_ne_empty : hilaryTofu ≠ (∅ : Set D0World) := by
   intro h
-  have hmem : (⟨false, true, false, false⟩ : D0World) ∈ hannahTofu := rfl
+  have hmem : (⟨false, true, false, false⟩ : D0World) ∈ hilaryTofu := rfl
   rw [h] at hmem; exact hmem.elim
 
-theorem ht_ne_univ : hannahTofu ≠ Set.univ := by
+theorem ht_ne_univ : hilaryTofu ≠ Set.univ := by
   intro h
-  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ hannahTofu :=
+  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ hilaryTofu :=
     h.symm ▸ Set.mem_univ _
   exact Bool.false_ne_true hmem
 
-theorem rb_ne_empty : rogerBeans ≠ (∅ : Set D0World) := by
+theorem rb_ne_empty : robinBagels ≠ (∅ : Set D0World) := by
   intro h
-  have hmem : (⟨false, false, true, false⟩ : D0World) ∈ rogerBeans := rfl
+  have hmem : (⟨false, false, true, false⟩ : D0World) ∈ robinBagels := rfl
   rw [h] at hmem; exact hmem.elim
 
-theorem rb_ne_univ : rogerBeans ≠ Set.univ := by
+theorem rb_ne_univ : robinBagels ≠ Set.univ := by
   intro h
-  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ rogerBeans :=
+  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ robinBagels :=
     h.symm ▸ Set.mem_univ _
   exact Bool.false_ne_true hmem
 
-theorem rt_ne_empty : rogerTofu ≠ (∅ : Set D0World) := by
+theorem rt_ne_empty : robinTofu ≠ (∅ : Set D0World) := by
   intro h
-  have hmem : (⟨false, false, false, true⟩ : D0World) ∈ rogerTofu := rfl
+  have hmem : (⟨false, false, false, true⟩ : D0World) ∈ robinTofu := rfl
   rw [h] at hmem; exact hmem.elim
 
-theorem rt_ne_univ : rogerTofu ≠ Set.univ := by
+theorem rt_ne_univ : robinTofu ≠ Set.univ := by
   intro h
-  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ rogerTofu :=
+  have hmem : (⟨false, false, false, false⟩ : D0World) ∈ robinTofu :=
     h.symm ▸ Set.mem_univ _
   exact Bool.false_ne_true hmem
 
@@ -163,24 +162,24 @@ theorem rt_ne_univ : rogerTofu ≠ Set.univ := by
 -- § Polar Questions (via `Question.polar`)
 -- ════════════════════════════════════════════════════
 
-/-- "Did Hannah eat the beans?" -/
-abbrev q_ai : Question D0World := Question.polar hannahBeans
+/-- "Did Hilary eat the bagels?" -/
+abbrev q_ai : Question D0World := Question.polar hilaryBagels
 
-/-- "Did Hannah eat the tofu?" -/
-abbrev q_aii : Question D0World := Question.polar hannahTofu
+/-- "Did Hilary eat the tofu?" -/
+abbrev q_aii : Question D0World := Question.polar hilaryTofu
 
-/-- "Did Roger eat the beans?" -/
-abbrev q_bi : Question D0World := Question.polar rogerBeans
+/-- "Did Robin eat the bagels?" -/
+abbrev q_bi : Question D0World := Question.polar robinBagels
 
-/-- "Did Roger eat the tofu?" -/
-abbrev q_bii : Question D0World := Question.polar rogerTofu
+/-- "Did Robin eat the tofu?" -/
+abbrev q_bii : Question D0World := Question.polar robinTofu
 
 -- ════════════════════════════════════════════════════
 -- § Wh-Questions (via `Question.ofList`)
 -- ════════════════════════════════════════════════════
 
-/-- "What did Hannah eat?" — partition into 4 cells by ⟨hb, ht⟩.
-    Beans-only, tofu-only, both, neither. -/
+/-- "What did Hilary eat?" — partition into 4 cells by ⟨hb, ht⟩.
+    Bagels-only, tofu-only, both, neither. -/
 def q_a : Question D0World := Question.ofList [
   {w | w.hb = true ∧ w.ht = false},
   {w | w.hb = false ∧ w.ht = true},
@@ -188,7 +187,7 @@ def q_a : Question D0World := Question.ofList [
   {w | w.hb = false ∧ w.ht = false}
 ]
 
-/-- "What did Roger eat?" — partition by ⟨rb, rt⟩. -/
+/-- "What did Robin eat?" — partition by ⟨rb, rt⟩. -/
 def q_b : Question D0World := Question.ofList [
   {w | w.rb = true ∧ w.rt = false},
   {w | w.rb = false ∧ w.rt = true},
@@ -196,9 +195,11 @@ def q_b : Question D0World := Question.ofList [
   {w | w.rb = false ∧ w.rt = false}
 ]
 
-/-- "What did everyone eat?" — the Big Question, the lattice meet of
-    `q_a` and `q_b` (knowing what everyone ate = knowing what Hannah ate
-    AND what Roger ate). -/
+/-- "Who ate what?" — D₀'s move 1, rendered as the lattice meet of `q_a`
+    and `q_b`. Roberts observes `Ans(a) ∩ Ans(b) = Ans(1)` for the
+    independently given question (her (11c)); here the identification is
+    definitional, so the root obligation of `strat_1_complete` is
+    reflexivity rather than a substantive fact about D₀. -/
 def q_1 : Question D0World := q_a ⊓ q_b
 
 -- ════════════════════════════════════════════════════
@@ -207,13 +208,13 @@ def q_1 : Question D0World := q_a ⊓ q_b
 --  and relevance theorems below.)
 -- ════════════════════════════════════════════════════
 
-/-- Hannah-beans-only cell, the canonical witness in `alt q_a`. -/
+/-- Hilary-bagels-only cell, the canonical witness in `alt q_a`. -/
 private abbrev qa_c1 : Set D0World := {w | w.hb = true ∧ w.ht = false}
 
-/-- Hannah-neither cell — used to construct atomic singletons of `alt q_1`. -/
+/-- Hilary-neither cell — used to construct atomic singletons of `alt q_1`. -/
 private abbrev qa_c4 : Set D0World := {w | w.hb = false ∧ w.ht = false}
 
-/-- Roger-neither cell — paired with `qa_c4` to give the singleton
+/-- Robin-neither cell — paired with `qa_c4` to give the singleton
     `{⟨false, false, false, false⟩}`. -/
 private abbrev qb_c4 : Set D0World := {w | w.rb = false ∧ w.rt = false}
 
@@ -320,8 +321,8 @@ private theorem singleton_w_zero_in_alt_q1 :
 theorem qai_entails_qai : q_ai.Entails q_ai :=
   Entails.refl _
 
-/-- `q_ai` does NOT entail `q_bi`: knowing whether Hannah ate beans tells
-    you nothing about whether Roger ate beans (orthogonal polar questions). -/
+/-- `q_ai` does NOT entail `q_bi`: knowing whether Hilary ate bagels tells
+    you nothing about whether Robin ate bagels (orthogonal polar questions). -/
 theorem qai_not_entails_qbi : ¬ q_ai.Entails q_bi := by
   rw [entails_polar_polar_iff hb_ne_empty hb_ne_univ
         rb_ne_empty rb_ne_univ]
@@ -330,17 +331,17 @@ theorem qai_not_entails_qbi : ¬ q_ai.Entails q_bi := by
 -- Wh→polar entailments now decide via `ofList_le_polar_of_classified`
 -- (each cell of the wh-partition lies in `p` or `pᶜ` of the polar
 -- question) composed with `entails_of_le'` (lattice → Roberts).
--- The Big-Question entailments use `inf_le_left`/`inf_le_right`.
+-- The move-1 entailments use `inf_le_left`/`inf_le_right`.
 
-/-- The Big Question entails "What did Hannah eat?" -/
+/-- "Who ate what?" entails "What did Hilary eat?" -/
 theorem q1_entails_qa : q_1.Entails q_a :=
   entails_of_le' inf_le_left
 
-/-- The Big Question entails "What did Roger eat?" -/
+/-- "Who ate what?" entails "What did Robin eat?" -/
 theorem q1_entails_qb : q_1.Entails q_b :=
   entails_of_le' inf_le_right
 
-/-- "What did Hannah eat?" entails "Did Hannah eat the beans?" -/
+/-- "What did Hilary eat?" entails "Did Hilary eat the bagels?" -/
 theorem qa_entails_qai : q_a.Entails q_ai := by
   apply entails_of_le'
   apply ofList_le_polar_of_classified
@@ -352,7 +353,7 @@ theorem qa_entails_qai : q_a.Entails q_ai := by
   · exact Or.inl (fun w hw => hw.1)
   · exact Or.inr (fun w hw hwhb => Bool.false_ne_true (hw.1.symm.trans hwhb))
 
-/-- "What did Hannah eat?" entails "Did Hannah eat the tofu?" -/
+/-- "What did Hilary eat?" entails "Did Hilary eat the tofu?" -/
 theorem qa_entails_qaii : q_a.Entails q_aii := by
   apply entails_of_le'
   apply ofList_le_polar_of_classified
@@ -364,7 +365,7 @@ theorem qa_entails_qaii : q_a.Entails q_aii := by
   · exact Or.inl (fun w hw => hw.2)
   · exact Or.inr (fun w hw hwht => Bool.false_ne_true (hw.2.symm.trans hwht))
 
-/-- "What did Roger eat?" entails "Did Roger eat the beans?" -/
+/-- "What did Robin eat?" entails "Did Robin eat the bagels?" -/
 theorem qb_entails_qbi : q_b.Entails q_bi := by
   apply entails_of_le'
   apply ofList_le_polar_of_classified
@@ -376,7 +377,7 @@ theorem qb_entails_qbi : q_b.Entails q_bi := by
   · exact Or.inl (fun w hw => hw.1)
   · exact Or.inr (fun w hw hwrb => Bool.false_ne_true (hw.1.symm.trans hwrb))
 
-/-- "What did Roger eat?" entails "Did Roger eat the tofu?" -/
+/-- "What did Robin eat?" entails "Did Robin eat the tofu?" -/
 theorem qb_entails_qbii : q_b.Entails q_bii := by
   apply entails_of_le'
   apply ofList_le_polar_of_classified
@@ -390,7 +391,7 @@ theorem qb_entails_qbii : q_b.Entails q_bii := by
 
 -- Entailment is asymmetric: subquestions do NOT entail their parents.
 
-/-- q_a does NOT entail q_1. The witness `qa_c1 ∈ alt q_a` (Hannah-beans-only)
+/-- q_a does NOT entail q_1. The witness `qa_c1 ∈ alt q_a` (Hilary-bagels-only)
     contains worlds with all four (rb, rt) combinations; no single q_b cell
     contains them all, so no `alt q_1` (which lies in some q_b cell) can
     extend `qa_c1`. -/
@@ -415,16 +416,16 @@ theorem qa_not_entails_q1 : ¬ q_a.Entails q_1 := by
   · exact Bool.false_ne_true (hqc hw1q).2
   · exact Bool.false_ne_true (hqc hw1q).1.symm
 
-/-- q_ai does NOT entail q_a. The witness `hannahBeans ∈ alt q_ai` contains
+/-- q_ai does NOT entail q_a. The witness `hilaryBagels ∈ alt q_ai` contains
     worlds with both `ht = true` and `ht = false`; no q_a cell (each fixing
-    `ht`) can extend `hannahBeans`. -/
+    `ht`) can extend `hilaryBagels`. -/
 theorem qai_not_entails_qa : ¬ q_ai.Entails q_a := by
   intro h
-  have halt : hannahBeans ∈ alt q_ai := by
-    rw [show q_ai = Question.polar hannahBeans from rfl,
+  have halt : hilaryBagels ∈ alt q_ai := by
+    rw [show q_ai = Question.polar hilaryBagels from rfl,
         alt_polar_of_nontrivial hb_ne_empty hb_ne_univ]
     left; rfl
-  obtain ⟨q, hq, hsub⟩ := h hannahBeans halt
+  obtain ⟨q, hq, hsub⟩ := h hilaryBagels halt
   have hq_props : q ∈ q_a.props := alt_subset_props _ hq
   have hq' : q ∈ Question.ofList (W := D0World)
       [{w | w.hb = true ∧ w.ht = false}, {w | w.hb = false ∧ w.ht = true},
@@ -455,38 +456,30 @@ theorem qb_sub_q1 : q_b.IsSubquestion q_1 := q1_entails_qb
 -- § Strategy of Inquiry ([roberts-2012] Def. 12)
 -- ════════════════════════════════════════════════════
 
+/-- Substrategy for `q_a`: pursue both polar subquestions about Hilary. -/
+def strat_a : Strategy D0World := .node q_a [.leaf q_ai, .leaf q_aii]
+
+/-- Substrategy for `q_b`: pursue both polar subquestions about Robin. -/
+def strat_b : Strategy D0World := .node q_b [.leaf q_bi, .leaf q_bii]
+
 /-- Roberts' strategy for the D₀ scenario:
-    Answer q_1 by answering q_a and q_b;
+    answer q_1 by answering q_a and q_b;
     answer q_a by answering q_ai and q_aii;
     answer q_b by answering q_bi and q_bii. -/
-def strat_1 : Strategy D0World :=
-  .branch q_1 [
-    .branch q_a [.leaf q_ai, .leaf q_aii],
-    .branch q_b [.leaf q_bi, .leaf q_bii]
-  ]
+def strat_1 : Strategy D0World := .node q_1 [strat_a, strat_b]
 
 /-- The strategy has 7 questions total. -/
-theorem strat_1_count : strat_1.allQuestions.length = 7 := by
-  simp [strat_1, Strategy.allQuestions, List.flatMap]
+theorem strat_1_count : strat_1.numNodes = 7 := by
+  simp [strat_1, strat_a, strat_b]
 
-/-- The root of the strategy is complete: answering "What did Hannah eat?"
-    and "What did Roger eat?" answers "What did everyone eat?" Reduces
-    by `top_inf_eq` to `Entails (q_a ⊓ q_b) q_1` = reflexivity. -/
-theorem strat_1_root_complete : strat_1.isComplete := by
-  show Entails ((⊤ ⊓ q_a) ⊓ q_b) q_1
-  rw [top_inf_eq]
-  exact Entails.refl _
-
-/-- The q_a sub-strategy is complete: pursuing both polar subquestions
-    `q_ai` and `q_aii` resolves the wh-question `q_a` they jointly
+/-- The Hilary substrategy is complete: jointly resolving the polar
+    subquestions `q_ai` and `q_aii` resolves the wh-question `q_a` they
     partition. Closes via `polar_inf_polar_le_ofList_of_corners`: the
-    four corners (Hannah's beans × tofu) are exactly the cells of `q_a`. -/
-theorem strat_1_qa_complete :
-    (Strategy.branch q_a [.leaf q_ai, .leaf q_aii] : Strategy D0World).isComplete := by
-  show Entails ((⊤ ⊓ q_ai) ⊓ q_aii) q_a
-  rw [top_inf_eq]
+    four corners (Hilary's bagels × tofu) are exactly the cells of `q_a`. -/
+theorem strat_a_complete : strat_a.IsComplete := by
+  refine .node_pair ?_ (.leaf _) (.leaf _)
   apply entails_of_le'
-  show Question.polar hannahBeans ⊓ Question.polar hannahTofu ≤ q_a
+  show Question.polar hilaryBagels ⊓ Question.polar hilaryTofu ≤ q_a
   apply Question.polar_inf_polar_le_ofList_of_corners
   · exact ⟨{w | w.hb = true ∧ w.ht = true}, by simp, fun _ hw => hw⟩
   · refine ⟨{w | w.hb = true ∧ w.ht = false}, by simp, fun w hw => ⟨hw.1, ?_⟩⟩
@@ -505,14 +498,11 @@ theorem strat_1_qa_complete :
       · rfl
       · exact (hw.2 h).elim
 
-/-- The q_b sub-strategy is complete (mirror of `strat_1_qa_complete`
-    for Roger). -/
-theorem strat_1_qb_complete :
-    (Strategy.branch q_b [.leaf q_bi, .leaf q_bii] : Strategy D0World).isComplete := by
-  show Entails ((⊤ ⊓ q_bi) ⊓ q_bii) q_b
-  rw [top_inf_eq]
+/-- The Robin substrategy is complete (mirror of `strat_a_complete`). -/
+theorem strat_b_complete : strat_b.IsComplete := by
+  refine .node_pair ?_ (.leaf _) (.leaf _)
   apply entails_of_le'
-  show Question.polar rogerBeans ⊓ Question.polar rogerTofu ≤ q_b
+  show Question.polar robinBagels ⊓ Question.polar robinTofu ≤ q_b
   apply Question.polar_inf_polar_le_ofList_of_corners
   · exact ⟨{w | w.rb = true ∧ w.rt = true}, by simp, fun _ hw => hw⟩
   · refine ⟨{w | w.rb = true ∧ w.rt = false}, by simp, fun w hw => ⟨hw.1, ?_⟩⟩
@@ -531,46 +521,51 @@ theorem strat_1_qb_complete :
       · rfl
       · exact (hw.2 h).elim
 
+/-- The whole D₀ strategy is complete: both substrategies are, and the
+    meet of their root questions is `q_1` by definition (see `q_1`). -/
+theorem strat_1_complete : strat_1.IsComplete :=
+  .node_pair (Entails.refl _) strat_a_complete strat_b_complete
+
 -- ════════════════════════════════════════════════════
 -- § QUD Stack Traces
 -- ════════════════════════════════════════════════════
 
-/-- Initial state: push the Big Question. -/
-def stack_0 : QUDStack D0World := QUDStack.empty.push q_1
+/-- Initial state: accept move 1, "Who ate what?". -/
+def stack_0 : QUDStack D0World := [q_1]
 
-/-- Pursue Hannah's food: push q_a. -/
-def stack_1 : QUDStack D0World := stack_0.push q_a
+/-- Pursue Hilary's food: accept q_a. -/
+def stack_1 : QUDStack D0World := q_a :: stack_0
 
-/-- Pursue Hannah+beans: push q_ai. -/
-def stack_2 : QUDStack D0World := stack_1.push q_ai
+/-- Pursue Hilary+bagels: accept q_ai. -/
+def stack_2 : QUDStack D0World := q_ai :: stack_1
 
-/-- "Hannah ate the beans" answers q_ai: pop. -/
-def stack_3 : QUDStack D0World := stack_2.pop
+/-- "Hilary ate the bagels" answers q_ai: retire it. -/
+def stack_3 : QUDStack D0World := stack_2.tail
 
 /-- Stack depths trace the discourse. -/
 theorem stack_depths :
-    stack_0.depth = 1 ∧ stack_1.depth = 2 ∧
-    stack_2.depth = 3 ∧ stack_3.depth = 2 :=
+    stack_0.length = 1 ∧ stack_1.length = 2 ∧
+    stack_2.length = 3 ∧ stack_3.length = 2 :=
   ⟨rfl, rfl, rfl, rfl⟩
 
-/-- After popping q_ai, the immediate QUD is q_a. -/
-theorem stack_3_qud : stack_3.immediateQUD = some q_a := rfl
+/-- After retiring q_ai, the immediate QUD is q_a. -/
+theorem stack_3_qud : stack_3.head? = some q_a := rfl
 
 -- ════════════════════════════════════════════════════
 -- § Negative Partial Answerhood
 -- ════════════════════════════════════════════════════
 
-/-- "Hannah didn't eat beans" (`hannahBeansᶜ`) negatively partially answers
-    "Did Hannah eat beans?" — it rules out the `hannahBeans` alternative. -/
+/-- "Hilary didn't eat bagels" (`hilaryBagelsᶜ`) negatively partially answers
+    "Did Hilary eat bagels?" — it rules out the `hilaryBagels` alternative. -/
 theorem neg_hb_partially_answers_qai :
-    PartiallyAnswers (hannahBeansᶜ : Set D0World) q_ai := by
+    PartiallyAnswers (hilaryBagelsᶜ : Set D0World) q_ai := by
   rw [partiallyAnswers_polar_iff hb_ne_empty hb_ne_univ]
   decide
 
-/-- "Hannah didn't eat beans" also partially answers "What did Hannah eat?" —
-    it rules out the `qa_c1` (Hannah-beans-only) alternative. -/
+/-- "Hilary didn't eat bagels" also partially answers "What did Hilary eat?" —
+    it rules out the `qa_c1` (Hilary-bagels-only) alternative. -/
 theorem neg_hb_partially_answers_qa :
-    PartiallyAnswers (hannahBeansᶜ : Set D0World) q_a := by
+    PartiallyAnswers (hilaryBagelsᶜ : Set D0World) q_a := by
   refine ⟨qa_c1, qa_c1_in_alt, Or.inr ?_⟩
   intro w hw hw'
   exact hw hw'.1
@@ -579,16 +574,16 @@ theorem neg_hb_partially_answers_qa :
 -- § Positive Partial Answerhood
 -- ════════════════════════════════════════════════════
 
-/-- "Hannah ate beans" positively partially answers q_ai. -/
+/-- "Hilary ate bagels" positively partially answers q_ai. -/
 theorem hb_partially_answers_qai :
-    PartiallyAnswers hannahBeans q_ai := by
+    PartiallyAnswers hilaryBagels q_ai := by
   rw [partiallyAnswers_polar_iff hb_ne_empty hb_ne_univ]
   decide
 
-/-- "Hannah ate beans" partially answers the Big Question — it rules out
+/-- "Hilary ate bagels" partially answers "Who ate what?" — it rules out
     the `{w_zero}` (all-false) alternative. -/
 theorem hb_partially_answers_q1 :
-    PartiallyAnswers hannahBeans q_1 := by
+    PartiallyAnswers hilaryBagels q_1 := by
   refine ⟨{w_zero}, singleton_w_zero_in_alt_q1, Or.inr ?_⟩
   intro w hw hw'
   rw [Set.mem_singleton_iff] at hw'
@@ -599,37 +594,38 @@ theorem hb_partially_answers_q1 :
 -- § Relevance ([roberts-2012] Def. 15)
 -- ════════════════════════════════════════════════════
 
-/-- "Hannah ate beans" as a single-alternative declarative issue. -/
-def hannahBeans_assertion : Question D0World := Question.declarative hannahBeans
+/-- "Hilary ate bagels" as a single-alternative declarative issue. -/
+def hilaryBagels_assertion : Question D0World := Question.declarative hilaryBagels
 
-/-- "Hannah ate beans" is relevant to q_1 (the Big Question). -/
-theorem hannahBeans_relevant_to_q1 :
-    moveRelevant hannahBeans_assertion q_1 [] := by
-  refine ⟨hannahBeans, ?_, Or.inl hb_partially_answers_q1⟩
-  show hannahBeans ∈ alt (Question.declarative hannahBeans)
+/-- "Hilary ate bagels" is relevant to move 1, "Who ate what?". -/
+theorem hilaryBagels_relevant_to_q1 :
+    Relevant hilaryBagels_assertion {q_1} := by
+  refine ⟨hilaryBagels, ?_, q_1, rfl, hb_partially_answers_q1⟩
+  show hilaryBagels ∈ alt (Question.declarative hilaryBagels)
   rw [alt_declarative]
   rfl
 
-/-- q_a is relevant to q_1 as a subquestion: the `qa_c1` alternative
-    rules out the `{w_zero}` alternative of q_1 (since `w_zero ∉ qa_c1`). -/
+/-- The question `q_a` is relevant to `q_1` under the assertion-clause
+    proxy: its Hilary-bagels-only alternative `qa_c1` rules out the
+    `{w_zero}` alternative of `q_1`. (Roberts' own clause for
+    interrogative moves is strategy membership, not partial answerhood.) -/
 theorem qa_relevant_to_q1 :
-    moveRelevant q_a q_1 [] := by
-  refine ⟨qa_c1, qa_c1_in_alt, Or.inl ?_⟩
+    Relevant q_a {q_1} := by
+  refine ⟨qa_c1, qa_c1_in_alt, q_1, rfl, ?_⟩
   refine ⟨{w_zero}, singleton_w_zero_in_alt_q1, Or.inr ?_⟩
   intro w hw hw'
   rw [Set.mem_singleton_iff] at hw'
   subst hw'
   exact Bool.false_ne_true hw.1
 
-/-- "Hannah ate beans" is relevant to the entire D₀ strategy: it partially
+/-- "Hilary ate bagels" is relevant to the entire D₀ strategy: it partially
     answers `q_1` (the strategy's root). -/
-theorem hannahBeans_relevant_to_strategy :
-    moveRelevantToStrategy hannahBeans_assertion strat_1 := by
-  refine ⟨hannahBeans, ?_, q_1, ?_, hb_partially_answers_q1⟩
-  · show hannahBeans ∈ alt (Question.declarative hannahBeans)
+theorem hilaryBagels_relevant_to_strategy :
+    Relevant hilaryBagels_assertion {q | q ∈ strat_1.values} := by
+  refine ⟨hilaryBagels, ?_, q_1, ?_, hb_partially_answers_q1⟩
+  · show hilaryBagels ∈ alt (Question.declarative hilaryBagels)
     rw [alt_declarative]; rfl
-  · -- strat_1 = .branch q_1 [...]; q_1 is the head of allQuestions
-    simp [strat_1, Strategy.allQuestions]
+  · simp [strat_1, strat_a, strat_b]
 
 -- ════════════════════════════════════════════════════
 -- § Q-A Congruence / Focus Type Identity

--- a/Linglib/Studies/Roberts2023.lean
+++ b/Linglib/Studies/Roberts2023.lean
@@ -229,7 +229,7 @@ theorem iflp_roundtrip_imp :
 /-- The scoreboard K = ⟨I, M, ≺, CommonGround, QUD, G⟩. The temporal order ≺
     is implicit in list position of `moves`. `qud` is specialised to
     polar-question content (`W → Prop`); the richer `Discourse.QUDStack`
-    over `Semantics.Questions.Basic.Question W` is consumed by other
+    over `Question W` (`Discourse/QUD/Basic.lean`) is consumed by other
     files. Bridging the two is an open API-coherence item. -/
 structure Scoreboard (W : Type*) where
   numInterlocutors : Nat

--- a/Linglib/Studies/Umbach2004.lean
+++ b/Linglib/Studies/Umbach2004.lean
@@ -2,7 +2,6 @@ import Linglib.Discourse.Coherence
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Semantics.Questions.Resolution
 import Linglib.Semantics.Questions.Partition.Basic
-import Linglib.Discourse.QUD.Basic
 import Linglib.Semantics.Focus.Interpretation
 import Linglib.Pragmatics.DecisionTheoretic.But
 import Linglib.Fragments.English.FunctionWords


### PR DESCRIPTION
Deep audit of `Discourse/QUD/Basic.lean` against the published paper and the RoseTree substrate.

- `Strategy` becomes `abbrev` for `RoseTree (Question W)`, killing the `leaf q` vs `branch q []` double representation whose `isComplete`/`leaves` verdicts disagreed; completeness is now the recursive `Strategy.IsComplete`, and `RoseTree` gains a preorder `values` plus a SizeOf-generic `sizeOf_lt_of_mem`
- `QUDStack` becomes a `List` synonym carrying Roberts' (10g.iii) ordering invariant as `QUDStack.WellFormed` (context-relativized); the two relevance predicates unify into set-valued `Discourse.Relevant`
- Paper fidelity (verified against the S&P PDF): D₀ renamed to Hilary/Robin/bagels, Def-12 misattribution fixed; seven dead importers trimmed; `QUD.toQuestion` promoted from DeoThomas2025 to `Questions/Partition/Basic.lean`