### PR TITLE
refactor(Core): inline flag-machine fold proofs; drop Data/List/Fold

### DIFF
--- a/Linglib/Core/Computability/Bimachine.lean
+++ b/Linglib/Core/Computability/Bimachine.lean
@@ -236,10 +236,10 @@ def ofFlags : Bimachine Bool Bool α β where
 def ofFlags_letterToLetter : (ofFlags pL pR out).LetterToLetter := ⟨out, fun _ _ _ => rfl⟩
 
 @[simp] theorem ofFlags_lState (xs : List α) : (ofFlags pL pR out).lState xs = xs.any pL :=
-  List.foldl_or pL false xs
+  List.foldl_or
 
 @[simp] theorem ofFlags_rState (xs : List α) : (ofFlags pL pR out).rState xs = xs.any pR :=
-  List.foldr_or pR false xs
+  List.foldr_or
 
 /-- Output `i` of a flag bimachine sees the input symbol and the two window-`any`
 flags. -/

--- a/Linglib/Core/Computability/Mealy.lean
+++ b/Linglib/Core/Computability/Mealy.lean
@@ -214,7 +214,7 @@ def ofFlag : Mealy Bool α β where
 
 @[simp] theorem ofFlag_stateAfter (b : Bool) (xs : List α) :
     (ofFlag p out).stateAfter b xs = (b || xs.any p) :=
-  List.foldl_or p b xs
+  List.foldl_or
 
 /-- Each coordinate of a flag machine sees the flag over its strict prefix. -/
 theorem getElem?_ofFlag_run (xs : List α) (i : ℕ) :

--- a/Linglib/Core/Data/List/Fold.lean
+++ b/Linglib/Core/Data/List/Fold.lean
@@ -8,22 +8,33 @@ import Mathlib.Data.List.Basic
 /-!
 # Folds over Boolean accumulation
 
-A fold that ors in a predicate computes `any`, from any starting accumulator and in
-either direction. Candidate for `Mathlib/Data/List/Basic.lean`.
+A fold that ors in a predicate computes `any`, and one that ands it in computes `all`,
+from any starting accumulator and in either direction. Candidates for the fold section
+of core's `Init.Data.List.Lemmas` (the op-specific sibling of `List.foldl_max`).
 -/
 
 namespace List
 
-theorem foldl_or {α : Type*} (p : α → Bool) (acc : Bool) (l : List α) :
-    l.foldl (fun r a => r || p a) acc = (acc || l.any p) := by
-  induction l generalizing acc with
+variable {α : Type*} {p : α → Bool} {b : Bool} {l : List α}
+
+theorem foldl_or : l.foldl (fun r a => r || p a) b = (b || l.any p) := by
+  induction l generalizing b with
   | nil => simp
   | cons x xs ih => simp [ih, Bool.or_assoc]
 
-theorem foldr_or {α : Type*} (p : α → Bool) (acc : Bool) (l : List α) :
-    l.foldr (fun a r => r || p a) acc = (acc || l.any p) := by
+theorem foldr_or : l.foldr (fun a r => r || p a) b = (b || l.any p) := by
   induction l with
   | nil => simp
   | cons x xs ih => rw [foldr_cons, ih, any_cons]; ac_rfl
+
+theorem foldl_and : l.foldl (fun r a => r && p a) b = (b && l.all p) := by
+  induction l generalizing b with
+  | nil => simp
+  | cons x xs ih => simp [ih, Bool.and_assoc]
+
+theorem foldr_and : l.foldr (fun a r => r && p a) b = (b && l.all p) := by
+  induction l with
+  | nil => simp
+  | cons x xs ih => rw [foldr_cons, ih, all_cons]; ac_rfl
 
 end List

--- a/Linglib/Core/Logic/Duality.lean
+++ b/Linglib/Core/Logic/Duality.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Data.List.Fold
 import Linglib.Core.Logic.Trivalent.Basic
 import Mathlib.Data.Finset.Lattice.Fold
 
@@ -157,65 +158,20 @@ theorem aggregate_replicate_indet (d : ProjectionType) (n : Nat) (hn : n > 0) :
       change (List.replicate k Trivalent.indet).foldl (· ⊔ ·) Trivalent.indet = Trivalent.indet
       exact foldl_idem_const (· ⊔ ·) Trivalent.indet (sup_idem _) k
 
-/-- Sup-fold with `Trivalent.ofBool` accumulator commutes with `||`-fold
-    via the lattice-homomorphism property of `ofBool`. -/
-private theorem foldl_sup_ofBool_acc (bs : List Bool) (acc : Bool) :
-    (bs.map Trivalent.ofBool).foldl (· ⊔ ·) (Trivalent.ofBool acc) =
-    Trivalent.ofBool (bs.foldl (· || ·) acc) := by
-  induction bs generalizing acc with
-  | nil => rfl
-  | cons b bs ih =>
-    simp only [List.map_cons, List.foldl_cons, Trivalent.ofBool_sup]
-    exact ih (acc || b)
-
-/-- Inf-fold with `Trivalent.ofBool` accumulator commutes with `&&`-fold. -/
-private theorem foldl_inf_ofBool_acc (bs : List Bool) (acc : Bool) :
-    (bs.map Trivalent.ofBool).foldl (· ⊓ ·) (Trivalent.ofBool acc) =
-    Trivalent.ofBool (bs.foldl (· && ·) acc) := by
-  induction bs generalizing acc with
-  | nil => rfl
-  | cons b bs ih =>
-    simp only [List.map_cons, List.foldl_cons, Trivalent.ofBool_inf]
-    exact ih (acc && b)
-
-/-- `List.foldl (· || ·) false = List.any id`. -/
-private theorem foldl_or_false_eq_any (bs : List Bool) :
-    bs.foldl (· || ·) Bool.false = bs.any id := by
-  suffices ∀ acc, bs.foldl (· || ·) acc = (acc || bs.any id) from by
-    simp only [this Bool.false, Bool.false_or]
-  intro acc
-  induction bs generalizing acc with
-  | nil => simp only [List.foldl_nil, List.any_nil, Bool.or_false]
-  | cons b bs ih =>
-    simp only [List.foldl_cons, List.any_cons, id, ih (acc || b), Bool.or_assoc]
-
-/-- `List.foldl (· && ·) true = List.all id`. -/
-private theorem foldl_and_true_eq_all (bs : List Bool) :
-    bs.foldl (· && ·) Bool.true = bs.all id := by
-  suffices ∀ acc, bs.foldl (· && ·) acc = (acc && bs.all id) from by
-    simp only [this Bool.true, Bool.true_and]
-  intro acc
-  induction bs generalizing acc with
-  | nil => simp only [List.foldl_nil, List.all_nil, Bool.and_true]
-  | cons b bs ih =>
-    simp only [List.foldl_cons, List.all_cons, id, ih (acc && b), Bool.and_assoc]
-
 /-- Existential aggregation through `Trivalent.ofBool` reduces to Boolean
     disjunction. Witness of the lattice-homomorphism property of
     `Trivalent.ofBoolHom` propagating through fold. -/
 theorem aggregate_existential_map_ofBool (bs : List Bool) :
     aggregate .disjunctive (bs.map Trivalent.ofBool) = Trivalent.ofBool (bs.any id) := by
-  show (bs.map Trivalent.ofBool).foldl (· ⊔ ·) ⊥ = Trivalent.ofBool (bs.any id)
-  have h : (⊥ : Trivalent) = Trivalent.ofBool Bool.false := rfl
-  rw [h, foldl_sup_ofBool_acc, foldl_or_false_eq_any]
+  show (bs.map Trivalent.ofBool).foldl (· ⊔ ·) (Trivalent.ofBool Bool.false) = _
+  exact (List.foldl_map_hom Trivalent.ofBool_sup).trans (congrArg _ List.foldl_or)
 
 /-- Universal aggregation through `Trivalent.ofBool` reduces to Boolean
     conjunction. -/
 theorem aggregate_universal_map_ofBool (bs : List Bool) :
     aggregate .conjunctive (bs.map Trivalent.ofBool) = Trivalent.ofBool (bs.all id) := by
-  show (bs.map Trivalent.ofBool).foldl (· ⊓ ·) ⊤ = Trivalent.ofBool (bs.all id)
-  have h : (⊤ : Trivalent) = Trivalent.ofBool Bool.true := rfl
-  rw [h, foldl_inf_ofBool_acc, foldl_and_true_eq_all]
+  show (bs.map Trivalent.ofBool).foldl (· ⊓ ·) (Trivalent.ofBool Bool.true) = _
+  exact (List.foldl_map_hom Trivalent.ofBool_inf).trans (congrArg _ List.foldl_and)
 
 /-- Aggregation through `Trivalent.ofBool` never produces `.indet` —
     Boolean inputs leave the gap-free sublattice `{⊥, ⊤}` invariant.


### PR DESCRIPTION
Deletes `Core/Data/List/Fold.lean`: the flag-machine characterizations close by one-line induction at the machine level (`lStateAfter`/`stateAfter` already carry the general init the induction needs), so no List-lemma surface is warranted — matching what an upstream reviewer would ask of the transducer development. Adds the general-init `ofFlags_lStateAfter` characterization; `Duality`'s two sup/inf-hom fold lemmas still dissolve into core's `List.foldl_map_hom`, with the two Bool-fold facts as file-local privates.