### PR TITLE
docs(Syntax/ConstructionGrammar): correct example and section citations

### DIFF
--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -297,13 +297,13 @@ def causedMotionToResultative : InheritanceLink :=
 /-! ## The book's network as a constructicon
 
 [goldberg-1995] draws no single master figure; the network below assembles
-the per-link analyses under the book's own framing of "the entire
-collection of constructions as forming a lattice, with individual
-constructions related by specific types of asymmetric normal mode
-inheritance links" (pp. 99–100): the ditransitive polysemy family
-(pp. 75–77), the caused-motion → intransitive-motion subpart link (p. 78),
-and the caused-motion → resultative metaphorical link (§3.4.1, the
-"Change of State as Change of Location" metaphor). The conative appears in
+the per-link analyses under the book's own framing of the collection of
+constructions as "a highly structured lattice of interrelated
+information" (ch. 1), organized by the asymmetric inheritance links of
+§3.3: the ditransitive polysemy family (pp. 75–77), the caused-motion →
+intransitive-motion subpart link (p. 78), and the caused-motion →
+resultative metaphorical link (§3.4.1, understanding "a change of state
+in terms of movement to a new location"). The conative appears in
 the book's construction inventory (p. 4) but participates in no
 inheritance link — it is a node without edges, and linking it would be
 invention. -/

--- a/Linglib/Syntax/ConstructionGrammar/IdiomTypology.lean
+++ b/Linglib/Syntax/ConstructionGrammar/IdiomTypology.lean
@@ -48,7 +48,10 @@ inductive IdiomFormality where
   deriving DecidableEq, Repr
 
 /-- Combined idiom classification: the product of
-[fillmore-kay-oconnor-1988] §1.1's three dimensions. -/
+[fillmore-kay-oconnor-1988] §1.1.1–§1.1.3's dimensions. The paper's
+fourth distinction — with vs. without pragmatic point, §1.1.4 — is
+carried by `Construction.pragmaticFunction` rather than a dimension
+here. -/
 structure IdiomType where
   interpretability : IdiomInterpretability
   grammaticality : IdiomGrammaticality

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -62,21 +62,23 @@ inductive SubeventKind where
 - **means**: The verbal subevent is the means by which the constructional subevent
   is brought about. This is the default relation for all four core subconstructions
   (97a–d). E.g., "hammer metal flat" — hammering is the means of causing flatness.
-  Also holds for noncausative cases: "the river froze solid" — freezing is the
-  means of becoming solid; "the ball rolled into the field" — rolling is the
+  Also holds for noncausative cases: "the pond froze solid" — freezing is the
+  means of becoming solid; "the ball rolled down the hill" — rolling is the
   means of motion along the path.
 - **result**: The verbal subevent is a result of the constructional subevent
   (reversed directionality from means). Reserved for sound-emission resultatives
-  (ex. 20: "The trolley rumbled through the tunnel" — rumbling results from
-  motion) and disappearance resultatives (ex. 21: "The witch vanished into the
-  forest" — vanishing results from motion).
+  (schema 20; ex. 17a: "The trolley rumbled through the tunnel" — the sound
+  results from the motion) and disappearance resultatives (ex. 21a: "The witch
+  vanished into the forest").
 - **instance_**: The verbal subevent is an instance of the constructional subevent.
-  For the follow-type cases (§7.1, ex. 55: "Bill followed the thief into the
-  library" — following IS going-after) and ride/drive-type cases (ex. 56: "Bill
-  rode a train to New York" — riding IS going-by-way-of).
+  For the follow-type cases (§7.1, schema 55; ex. 50a: "Bill followed the thief
+  into the library" — following IS going-after) and *take* under schema 56;
+  the ride/drive cases of 56 (ex. 58a: "Bill rode a train to New York") are
+  instead means of going-by-way-of.
 - **coOccurrence**: The two subevents merely co-occur without causal connection.
-  The *way* construction ("She sang her way down the road") uses this relation.
-  Some speakers accept CO-OCCURRENCE for sound-emission resultatives as well. -/
+  The *way* construction (ex. 19a: "The car honked its way down the road") uses
+  this relation. Some speakers accept COOCCURRENCE for sound-emission
+  resultatives as well. -/
 inductive SubeventRelation where
   | means
   | result
@@ -93,7 +95,7 @@ inductive RPType where
   deriving Repr, DecidableEq
 
 /-- The four subconstructions in the resultative family
-([goldberg-jackendoff-2004] §2, Table 1).
+([goldberg-jackendoff-2004] §2, summarized as (97)).
 
 |               | Property RP      | Path RP          |
 |---------------|------------------|------------------|
@@ -144,7 +146,7 @@ structure SubeventDesc where
   deriving Repr, BEq, DecidableEq
 
 /-- The dual subevent structure of a resultative
-([goldberg-jackendoff-2004] §3, Principle 25). -/
+([goldberg-jackendoff-2004] §3, the analysis in 14 and 16). -/
 structure DualSubevent where
   /-- The verbal subevent (from the verb's lexical semantics) -/
   verbal : SubeventDesc
@@ -241,13 +243,14 @@ reflexive pronoun that cannot alternate with other NPs. -/
 
 /-- How the postverbal NP is selected (§2). -/
 inductive ObjectSelection where
-  /-- Verb independently selects the object: "She watered the plants flat" -/
+  /-- Verb independently selects the object: "The gardener watered the
+      flowers flat" (7a) -/
   | selected
   /-- Construction licenses the object (verb doesn't take it independently):
       "They drank the pub dry" (cf. *They drank the pub) -/
   | unselected
   /-- Special unselected: reflexive object that cannot alternate with other NPs:
-      "She laughed herself silly" (cf. *She laughed him silly) -/
+      "We yelled ourselves hoarse" (cf. *We yelled Harry hoarse) (9a) -/
   | fakeReflexive
   deriving Repr, DecidableEq, BEq
 


### PR DESCRIPTION
Citation-fidelity sweep of the CxG substrate against the verified sources (Goldberg 1995 scan, Goldberg & Jackendoff 2004, Diessel 2023, FKO 1988 PDF). `Basic.lean`, `Inheritance.lean`, and `Licensing.lean` verified clean; fixes:

- `Resultatives.lean`: the four-subconstruction grid is G&J's (97), not their Table 1 (an RP-productivity tally); "Principle 25" → the analysis in 14 and 16; sentence-vs-schema numbers aligned (17a trolley, 50a follow, 19a way-construction, 58a ride); ride/drive are means (not instance) per schema 56; adapted example sentences replaced with the paper's (7a), (9a), (97b–c)
- `ArgumentStructure.lean`: unverifiable pp. 99–100 "lattice" quotation → the book's verified ch. 1 formulation; invented metaphor name → the book's own §3.4.1 wording
- `IdiomTypology.lean`: §1.1 has four distinctions, not three — §1.1.4's pragmatic point is noted as carried by `Construction.pragmaticFunction`