### PR TITLE
docs(Syntax/ConstructionGrammar): reinstate verified Goldberg 1995 quotes

### DIFF
--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -297,13 +297,14 @@ def causedMotionToResultative : InheritanceLink :=
 /-! ## The book's network as a constructicon
 
 [goldberg-1995] draws no single master figure; the network below assembles
-the per-link analyses under the book's own framing of the collection of
-constructions as "a highly structured lattice of interrelated
-information" (ch. 1), organized by the asymmetric inheritance links of
-§3.3: the ditransitive polysemy family (pp. 75–77), the caused-motion →
-intransitive-motion subpart link (p. 78), and the caused-motion →
-resultative metaphorical link (§3.4.1, understanding "a change of state
-in terms of movement to a new location"). The conative appears in
+the per-link analyses under the book's own framing of "the entire
+collection of constructions as forming a lattice, with individual
+constructions related by specific types of asymmetric normal mode
+inheritance links" (§3.7, p. 99): the ditransitive polysemy family
+(pp. 75–77), the caused-motion → intransitive-motion subpart link (p. 78),
+and the caused-motion → resultative metaphorical link (§3.4.1, the
+"Change of State as Change of Location" metaphor, p. 99). The conative
+appears in
 the book's construction inventory (p. 4) but participates in no
 inheritance link — it is a node without edges, and linking it would be
 invention. -/


### PR DESCRIPTION
Follow-up to #1817: the full Goldberg 1995 scan (Zotero's fulltext cache truncates at ~100 pages; the PDF itself is complete) confirms the two `ArgumentStructure.lean` formulations #1817 replaced were verbatim-correct — the §3.7 lattice quotation (p. 99) and the named "Change of State as Change of Location" metaphor (p. 99). Reinstated with exact page anchors. The ch. 7 caused-motion pp. 152–179 cite is also now text-verified.