### PR TITLE
docs(Semantics/ArgumentStructure): align RHL 1998 attributions with paper

### DIFF
--- a/Linglib/Semantics/ArgumentStructure/EventStructure.lean
+++ b/Linglib/Semantics/ArgumentStructure/EventStructure.lean
@@ -11,10 +11,12 @@ argument realization) filled by **roots** (idiosyncratic content).
 Templates compose via CAUSE; which sub-predicate determines argument
 realization yields different syntactic frames.
 
-The four templates here are [rappaport-hovav-levin-1998]'s; the
-enriched two-predicate event structure for the wiping-verbs class
-([rappaport-hovav-levin-2024]) is paper-anchored at
-`Studies/RappaportHovavLevin2024.lean`.
+The templates here are [rappaport-hovav-levin-1998]'s, with their two
+accomplishment variants — `[[x ACT⟨MANNER⟩] CAUSE [BECOME [y ⟨STATE⟩]]]`
+and `[x CAUSE [BECOME [y ⟨STATE⟩]]]` — collapsed into one
+`.accomplishment` case. The enriched two-predicate event structure for
+the wiping-verbs class ([rappaport-hovav-levin-2024]) is paper-anchored
+at `Studies/RappaportHovavLevin2024.lean`.
 
 ## Bridges
 
@@ -30,10 +32,11 @@ open Features
 
 /-! ### Event structure templates -/
 
-/-- Canonical event structure templates per [rappaport-hovav-levin-1998]. -/
+/-- Event structure templates per [rappaport-hovav-levin-1998]'s basic
+inventory, with the two accomplishment variants collapsed. -/
 inductive Template where
   | state          -- [x ⟨STATE⟩]
-  | activity       -- [x ACT]
+  | activity       -- [x ACT⟨MANNER⟩]
   | achievement    -- [BECOME [x ⟨STATE⟩]]
   | accomplishment -- [[x ACT] CAUSE [BECOME [y ⟨STATE⟩]]]
   deriving DecidableEq, Repr

--- a/Linglib/Semantics/ArgumentStructure/RoleList.lean
+++ b/Linglib/Semantics/ArgumentStructure/RoleList.lean
@@ -180,7 +180,9 @@ def wipeManner : RoleList where
   objectProfile  := some contactObject
 
 /-- Instrument subclass of the wipe verbs (Levin 10.4.2: *brush, comb, mop,
-    vacuum*; [rappaport-hovav-levin-1998]'s *sweep with a broom*): instrument
+    vacuum*; [rappaport-hovav-levin-1998]'s instrument constants — their
+    canonical realization rule pairs *brush, hammer, saw, shovel* with the
+    activity template): instrument
     lexicalization forces an obligatory volitional agent (V+S+C+M+IE).
     Not in the class map — `LevinClass.roleList .wipe` gives the manner
     subclass default; instrument-sense entries override per verb. -/

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -87,9 +87,10 @@ def causedMotion : ArgStructureConstruction :=
 /-- Resultative construction: [Subj V Obj Pred].
 "X CAUSES Y to BECOME Z" (e.g., "She hammered the metal flat").
 Contributes CoS + causation: manner verbs that lexicalize neither
-acquire both from the construction ([rappaport-hovav-levin-1998];
-[levin-2026] §3). This is what enables the causative alternation
-for verbs like *push* that lack it in isolation. -/
+acquire both — [rappaport-hovav-levin-1998]'s Template Augmentation,
+cast lexically there (their appendix maps it onto the constructional
+approach); [levin-2026] §3. This is what enables the causative
+alternation for verbs like *push* that lack it in isolation. -/
 def resultative : ArgStructureConstruction :=
   { construction :=
       { name := "Resultative"


### PR DESCRIPTION
Verified against the RHL 1998 "Building Verb Meanings" PDF (user-supplied scan, read in full):

- `EventStructure.lean`: the paper's basic inventory has five templates (two accomplishment variants) — the docstrings now state the collapse into one `.accomplishment` instead of claiming the four cases are the paper's
- `RoleList.lean`: "*sweep with a broom*" is not in the paper — replaced with the actual instrument canonical-realization-rule constants (*brush, hammer, saw, shovel*)
- `Syntax/ConstructionGrammar/ArgumentStructure.lean`: the acquisition mechanism is RHL's Template Augmentation, which they cast lexically (their appendix maps it onto the constructional approach) — cite reworded accordingly