### PR TITLE
refactor(Syntax/Clause): complement-frame and Deal2026 audit rewrite

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -712,6 +712,7 @@ import Linglib.Features.WordOrder
 import Linglib.Fragments.ASL.Classifiers
 import Linglib.Fragments.ASL.Height
 import Linglib.Fragments.Abkhaz.Evidentiality
+import Linglib.Fragments.Adyghe.Clause
 import Linglib.Fragments.Akan.Definiteness
 import Linglib.Fragments.Akan.Determiners
 import Linglib.Fragments.Akan.Phonology
@@ -732,6 +733,7 @@ import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Basque.Postsyntax
 import Linglib.Fragments.Basque.Pronouns
 import Linglib.Fragments.Basque.WordOrder
+import Linglib.Fragments.Bulgarian.Clause
 import Linglib.Fragments.Burmese.Negation
 import Linglib.Fragments.Buryat.Complementizers
 import Linglib.Fragments.Cantonese.Aspect
@@ -1058,7 +1060,8 @@ import Linglib.Fragments.Mongolian.Case
 import Linglib.Fragments.Mwaghavul.Basic
 import Linglib.Fragments.Navajo.Comparison
 import Linglib.Fragments.Navajo.Relativization
-import Linglib.Fragments.NezPerce.ClausalEmbedding
+import Linglib.Fragments.Ndebele.Clause
+import Linglib.Fragments.NezPerce.Clause
 import Linglib.Fragments.NezPerce.Modals
 import Linglib.Fragments.Niuean.Modals
 import Linglib.Fragments.Norwegian.V2
@@ -1228,6 +1231,7 @@ import Linglib.Fragments.Urdu.CausativeSystem
 import Linglib.Fragments.Uyghur.Complementizers
 import Linglib.Fragments.Wambaya.Reciprocals
 import Linglib.Fragments.Wan.Reciprocals
+import Linglib.Fragments.Washo.Clause
 import Linglib.Fragments.Washo.Modals
 import Linglib.Fragments.Welsh.Adposition
 import Linglib.Fragments.Welsh.Relativization

--- a/Linglib/Data/Complementation/Schema.lean
+++ b/Linglib/Data/Complementation/Schema.lean
@@ -12,14 +12,14 @@ This is substrate: it imports `Features/Complementation.lean` only. Consumers
 (the paper's study file, bridge studies) import the generated module.
 
 ## Main definitions
-* `Datum` — one CTP row: verb, CTP class, attested complement types,
+* `Datum` — one CTP row: verb, CTP class, attested complement codings,
   equi-deletion, negative raising.
 -/
 
 namespace Data.Complementation
 
 /-- One row of [noonan-2007]'s CTP sample: a complement-taking predicate in
-    one language, with its CTP class, the complement types it is attested
+    one language, with its CTP class, the complement codings it is attested
     with, and its equi-deletion / negative-raising behavior.
 
     `verb` is citation provenance, not identity — rows are identified by
@@ -33,7 +33,7 @@ namespace Data.Complementation
 structure Datum where
   verb : String
   ctpClass : CTPClass
-  compTypes : List NoonanCompType
+  codings : List Complement.Coding
   hasEquiDeletion : Bool := false
   hasNegativeRaising : Bool := false
   deriving DecidableEq, Repr

--- a/Linglib/Features/Complementation.lean
+++ b/Linglib/Features/Complementation.lean
@@ -15,7 +15,7 @@ enum for infinitival complements (`ControlType`).
 
 These enums stay in `Features/` because `Data/Complementation/Schema.lean`
 types its rows with them and the Data layer imports Features only. The
-typed complement-frame object and the legacy `ComplementType` view live
+typed complement-frame object and the flat `ComplementType` view live
 in `Syntax/Clause/Frame.lean`; the adapter (`ComplementType.toCoding`)
 in `Syntax/Clause/Complementation.lean`.
 

--- a/Linglib/Features/Complementation.lean
+++ b/Linglib/Features/Complementation.lean
@@ -2,82 +2,32 @@ import Mathlib.Order.Basic
 import Mathlib.Data.Nat.Basic
 
 /-!
-# Complementation — complement selection and control
+# Complementation — Noonan typology and control
 
 [noonan-2007]
 
-Per-entry complementation features: the legacy complement-type enum
-(`ComplementType`, the flat view over the typed `Frame` of
-`Syntax/Clause/Frame.lean`) and, for infinitival complements, its control
-type (`ControlType`).
+The cross-linguistic complementation typology: [noonan-2007]'s six
+morphological complement codings (`Complement.Coding`, in his summary
+table's row order via `rank`) and twelve of his fourteen
+complement-taking-predicate classes (`CTPClass`) with their default
+reality status (`RealityStatus`, `ctpRealityStatus`), plus the control
+enum for infinitival complements (`ControlType`).
 
-The cross-linguistic complementation typology also lives here:
-[noonan-2007]'s six complement-clause types (`NoonanCompType`, linearly
-ordered from most to least finite via `rank`) and twelve
-complement-taking-predicate classes (`CTPClass`) with their default reality
-status (`RealityStatus`, `ctpRealityStatus`). The adapter between the two
-enum inventories (`ComplementType.toNoonan`) lives in
-`Syntax/Clause/Complementation.lean`.
+These enums stay in `Features/` because `Data/Complementation/Schema.lean`
+types its rows with them and the Data layer imports Features only. The
+typed complement-frame object and the legacy `ComplementType` view live
+in `Syntax/Clause/Frame.lean`; the adapter (`ComplementType.toCoding`)
+in `Syntax/Clause/Complementation.lean`.
 
 ## Main declarations
 
-* `ComplementType` — complement frame a predicate selects (English-leaning
-  inventory: NP, double object, clausal, …)
-* `ControlType` — subject/object control vs raising for infinitival complements
-* `NoonanCompType` + `isReduced` + `rank` — [noonan-2007]'s complement-clause
-  types with their finiteness order
+* `Complement.Coding` + `isReduced` + `rank` — [noonan-2007]'s complement
+  types, classified by the morphological coding of the complement clause
 * `CTPClass`, `RealityStatus`, `ctpRealityStatus` — [noonan-2007]'s CTP
   classification and realis/irrealis defaults
+* `ControlType` — subject/object control vs raising for infinitival
+  complements
 -/
-
-/--
-Complement type that the verb selects.
-
-- Finite: "that" clauses ("John knows that Mary left")
-- Infinitival: "to" complements ("John managed to leave")
-- Gerund: "-ing" complements ("John stopped smoking")
-- NP: Direct object ("John kicked the ball")
-- None: Intransitive ("John slept")
--/
-inductive ComplementType where
-  | none            -- Intransitive
-  | np              -- Transitive with NP object
-  | np_np           -- Ditransitive: "give X Y"
-  | np_pp           -- NP + PP: "put X on Y"
-  | finiteClause    -- "that" clause
-  | infinitival     -- "to" VP
-  | gerund          -- "-ing" VP
-  | smallClause     -- "consider X happy"
-  | question        -- Embedded question "wonder who"
-  deriving DecidableEq, Repr
-
-/-- Is this complement type finite (i.e., does it contain a tense head)?
-
-    Finite complements (.finiteClause,.question) have independent tense
-    morphology; non-finite complements (.infinitival,.gerund,.smallClause)
-    do not. -/
-def ComplementType.isFinite : ComplementType → Bool
-  | .finiteClause | .question => true
-  | _ => false
-
-/-- Is this complement type a nominal (DP) argument?
-
-    Nominal complements project DP: the verb selects a noun phrase
-    in object position. Relevant to c-selection in coordination:
-    a verb that only selects nominal complements cannot independently
-    license a CP conjunct ([schwarzer-2026]). -/
-def ComplementType.isNominal : ComplementType → Bool
-  | .np | .np_np | .np_pp => true
-  | _ => false
-
-/-- Is this complement type a clausal (CP) argument?
-
-    Clausal complements project CP or reduced clausal structure.
-    This covers finite clauses (*dass*-clauses), infinitivals,
-    gerunds, small clauses, and embedded questions. -/
-def ComplementType.isClausal : ComplementType → Bool
-  | .finiteClause | .infinitival | .gerund | .smallClause | .question => true
-  | _ => false
 
 /--
 Control type for verbs with infinitival complements.
@@ -91,28 +41,32 @@ inductive ControlType where
 
 /-! ### Noonan complement typology -/
 
-/-- The six major complement types attested cross-linguistically.
-    Ordered roughly from most to least "finite" (Noonan's "balanced" to
-    "deranked"). -/
-inductive NoonanCompType where
+namespace Complement
+
+/-- The six major complement types of [noonan-2007]'s survey, classified
+    by the morphological coding of the complement clause (part of speech
+    of its predicate, subject relation, inflectional range). -/
+inductive Coding where
   | indicative     -- Finite clause with indicative mood marking
   | subjunctive    -- Finite clause with subjunctive/irrealis marking
-  | paratactic     -- Juxtaposed clause, no subordinator
+  | paratactic     -- Juxtaposed fully-inflected clause, no subordinator
   | infinitive     -- Non-finite with "to" or equivalent
   | nominalized    -- Gerund / action nominal
   | participle     -- Participial complement
   deriving DecidableEq, Repr, BEq
 
-/-- Is this complement type "reduced" (non-finite)? -/
-def NoonanCompType.isReduced : NoonanCompType → Bool
+/-- Is this coding non-finite (infinitive, nominalized, participial)? -/
+def Coding.isReduced : Coding → Bool
   | .infinitive  => true
   | .nominalized => true
   | .participle  => true
   | _            => false
 
-/-- [noonan-2007]'s balanced-to-deranked order as a numeric rank
-    (indicative most finite, participle most deranked). -/
-def NoonanCompType.rank : NoonanCompType → Nat
+/-- Position in [noonan-2007]'s summary-table row order (indicative
+    first, participle last). A presentation order, not an inflectional
+    finiteness scale: paratactic complements carry the same inflectional
+    range as indicatives. -/
+def Coding.rank : Coding → Nat
   | .indicative  => 0
   | .subjunctive => 1
   | .paratactic  => 2
@@ -120,16 +74,17 @@ def NoonanCompType.rank : NoonanCompType → Nat
   | .nominalized => 4
   | .participle  => 5
 
-/-- The balanced-to-deranked order: `t ≤ t'` iff `t` is at least as
-    finite as `t'`. -/
-instance : LinearOrder NoonanCompType :=
-  .lift' NoonanCompType.rank fun a b => by
-    cases a <;> cases b <;> simp [NoonanCompType.rank]
+/-- The summary-table row order as a linear order. -/
+instance : LinearOrder Coding :=
+  .lift' Coding.rank fun a b => by
+    cases a <;> cases b <;> simp [Coding.rank]
 
-/-- Noonan's twelve CTP classes, organized by semantic contribution.
+end Complement
 
-    The ordering follows [noonan-2007] Table 2.1 from most to least
-    "assertive":
+/-- Twelve of [noonan-2007]'s fourteen CTP classes (§3.2; predicates of
+    fearing §3.2.6 and conjunctive predicates §3.2.14 are omitted), in
+    the chapter's presentation order with perception hoisted next to the
+    epistemic classes:
     - Utterance/propAttitude/pretence: report/judge propositional content
     - Commentative/knowledge: evaluate/know propositional content
     - Perception: direct experience
@@ -158,13 +113,17 @@ inductive CTPClass where
 
 /-- The fundamental realis/irrealis split that predicts complement type
     selection. Realis CTPs tend toward indicative; irrealis toward
-    subjunctive/infinitive ([noonan-2007] §2.3). -/
+    subjunctive/infinitive ([noonan-2007] §3.1.1). -/
 inductive RealityStatus where
   | realis    -- CTP asserts or presupposes complement truth
   | irrealis  -- CTP does not commit to complement truth
   deriving DecidableEq, Repr
 
-/-- Default reality status of each CTP class ([noonan-2007] Table 2.3). -/
+/-- Default reality status of each CTP class, extending [noonan-2007]'s
+    realis/irrealis mood distinction (§3.1.1) from complement roles to
+    CTP classes. The phasal and perception assignments are extensions:
+    Noonan assigns their complements determined time reference, not a
+    mood value. -/
 def ctpRealityStatus : CTPClass → RealityStatus
   | .utterance    => .realis
   | .propAttitude => .realis

--- a/Linglib/Fragments/Adyghe/Clause.lean
+++ b/Linglib/Fragments/Adyghe/Clause.lean
@@ -1,0 +1,176 @@
+import Linglib.Features.Complementation
+
+/-!
+# Adyghe Clausal Embedding Inventory
+
+[caponigro-polinsky-2011]
+
+Adyghe (Northwest Caucasian, ISO 639-3 `ady`) inventory of
+complement-taking predicates. [caponigro-polinsky-2011]'s central
+descriptive result: Adyghe has no embedded declaratives or embedded
+polar interrogatives — every *tensed* notional complement is a relative
+construction inside a DP ((96) vs (98)), while a smaller class of
+volitional and aspectual predicates takes infinitival/converbal TPs
+(their §8). The construction imposes no presuppositional restriction
+(their §6.5) — pace the relative *fact*-clause characterization they
+cite from Gerasimov & Lander.
+
+Factivity values are textbook consensus for the predicate concepts —
+[caponigro-polinsky-2011] run no per-predicate projection tests; their
+only factivity-relevant claim is the construction-level one above.
+Forms follow the paper's transliteration (ʷ marks labialization, ʼ
+ejectives, ə schwa).
+-/
+
+namespace Adyghe.Clause
+
+/-! ### Predicate schema -/
+
+/-- Status of the high applicative *re-* on a predicate's
+    notional-complement verb ([caponigro-polinsky-2011] §6.3): *re-* is
+    the only applicative confined to relative constructions, occurs
+    outermost in the applicative field, and — always adjacent to the
+    relativizer *ze-* — distinguishes proposition-denoting embeddings
+    from ordinary relatives. -/
+inductive HighApplicative where
+  /-- Every attested notional complement carries *ze-re-*. -/
+  | required
+  /-- Attested with and without *re-*, tracking the polar-question vs
+      constituent-question reading ((99) vs (69)), not free variation. -/
+  | readingConditioned
+  /-- The predicate takes an infinitival/converbal TP, not a relative
+      clause — the volitional/aspectual class of their §8. -/
+  | notApplicable
+  deriving DecidableEq, Repr
+
+/-- Case suffix on the complement DP's right edge: absolutive *-r* vs
+    oblique *-m*, "which depends on the different case assigning
+    properties of the respective main predicate" ((98) vs (99)).
+    Caveat ([caponigro-polinsky-2011] §2.2.3): Adyghe has an extensive
+    middle class taking absolutive subject + oblique object, so this
+    split may reduce to matrix valence. -/
+inductive ComplementCase where
+  | abs
+  | obl
+  deriving DecidableEq, Repr
+
+/-- An Adyghe complement-taking predicate.
+
+    - `ctpClass`: [noonan-2007] category; `none` where unclear.
+    - `factive`: textbook consensus for the predicate concept (see
+      module docstring — not a [caponigro-polinsky-2011] claim).
+    - `highApplicative`, `complementCase`: the morphological
+      observables. -/
+structure AdygheEmbedder where
+  form : String
+  gloss : String
+  ctpClass : Option CTPClass
+  factive : Option Bool
+  highApplicative : HighApplicative
+  complementCase : Option ComplementCase
+  deriving DecidableEq, Repr
+
+/-! ### Relative-strategy predicates
+
+Tensed notional complements: a DP-wrapped relative clause whose verb
+carries *ze-re-*. -/
+
+/-- *gʷəpšəsa* 'think'. The bare finite complement is ungrammatical
+    ((96)); the relative-construction complement is fine ((98)); plain
+    DP objects attested ((102)). [caponigro-polinsky-2011] §6.2. -/
+def gwepshesa : AdygheEmbedder where
+  form := "gʷəpšəsa"; gloss := "think"
+  ctpClass := some .propAttitude
+  factive := some false
+  highApplicative := .required
+  complementCase := some .abs
+
+/-- *qəč'ewəpč'a* 'ask'. Constituent-question complements carry the
+    relativizer without *re-* ((69)); polar complements carry *ze-re-*
+    ((99)); direct embedding of a matrix interrogative is out ((97)).
+    Plain DP objects attested ((103)). [caponigro-polinsky-2011] §§5,
+    6.2. -/
+def chewepcha : AdygheEmbedder where
+  form := "qəč'ewəpč'a"; gloss := "ask"
+  ctpClass := some .utterance
+  factive := some false
+  highApplicative := .readingConditioned
+  complementCase := some .obl
+
+/-- *ŝe* (also *jeŝe*) 'know'. One *ze-re-* complement is ambiguous
+    between declarative and interrogative readings ((101)); the
+    complement is a strong island ((104)–(106)).
+    [caponigro-polinsky-2011] §6.2. -/
+def she : AdygheEmbedder where
+  form := "ŝe"; gloss := "know"
+  ctpClass := some .knowledge
+  factive := some true
+  highApplicative := .required
+  complementCase := some .abs
+
+/-- *gʷərəʔʷe* 'understand'. Its *ze-re-* complement is
+    truth-conditionally equivalent with and without an overt nominal
+    head — *qeba* 'news', *ŝəpqə* 'verity' ((108)–(110)) — the paper's
+    argument for a silent N in the shell. [caponigro-polinsky-2011]
+    §6.3. -/
+def gwereqwe : AdygheEmbedder where
+  form := "gʷərəʔʷe"; gloss := "understand"
+  ctpClass := some .knowledge
+  factive := some true
+  highApplicative := .required
+  complementCase := some .abs
+
+/-- *ʔʷa* 'say', with a *ze-re-* complement in §3.1's footnote example
+    (ii). [caponigro-polinsky-2011]. -/
+def qwa : AdygheEmbedder where
+  form := "ʔʷa"; gloss := "say"
+  ctpClass := some .utterance
+  factive := some false
+  highApplicative := .required
+  complementCase := some .abs
+
+/-! ### Infinitival-strategy predicates
+
+The volitional and aspectual class takes infinitival/converbal TPs, not
+relative clauses ([caponigro-polinsky-2011] §8, citing Polinsky &
+Potsdam). -/
+
+-- UNVERIFIED: transliteration of the form in (54) not yet checked
+-- against the typeset article.
+/-- *raʔežʼa* 'begin' — aspectual, infinitival TP complement
+    (*-new* infinitive, (54); the star on (54) targets the possessive
+    marker, not the complement). [caponigro-polinsky-2011] §2.3, §8. -/
+def raqezha : AdygheEmbedder where
+  form := "raʔežʼa"; gloss := "begin"
+  ctpClass := some .phasal
+  factive := none
+  highApplicative := .notApplicable
+  complementCase := none
+
+/-! ### Inventories -/
+
+/-- The complement-taking predicates with quotable per-predicate data
+    in [caponigro-polinsky-2011]. -/
+def allEmbedders : List AdygheEmbedder :=
+  [gwepshesa, chewepcha, she, gwereqwe, qwa, raqezha]
+
+/-- The predicates whose tensed complements use the relative strategy. -/
+def relativeTakers : List AdygheEmbedder :=
+  allEmbedders.filter (·.highApplicative != .notApplicable)
+
+/-- Drift sentry: the relative-strategy predicates are exactly the five
+    tensed-complement-takers. -/
+theorem relativeTakers_membership :
+    relativeTakers = [gwepshesa, chewepcha, she, gwereqwe, qwa] := by
+  decide
+
+/-- The relative strategy is factivity-blind: it is required both for
+    consensus-factive 'know'/'understand' and consensus-non-factive
+    'think'/'say' ([caponigro-polinsky-2011] §6.5: the construction has
+    no presuppositional restriction). -/
+theorem relative_strategy_factivity_blind :
+    (∃ v ∈ relativeTakers, v.factive = some true) ∧
+    (∃ v ∈ relativeTakers, v.factive = some false) := by
+  refine ⟨?_, ?_⟩ <;> decide
+
+end Adyghe.Clause

--- a/Linglib/Fragments/Bulgarian/Clause.lean
+++ b/Linglib/Fragments/Bulgarian/Clause.lean
@@ -1,0 +1,261 @@
+import Linglib.Features.Complementation
+
+/-!
+# Bulgarian Clausal Embedding Inventory
+
+[krapova-2010]
+
+Bulgarian (Slavic, ISO 639-3 `bul`) inventory of complement-taking
+predicates around the invariant complementizer *deto*. [krapova-2010]
+§5: *deto*-complements are available exactly to emotive factives that
+also select a *za*-PP — factivity is necessary but not sufficient
+(*văzmuštavam se* 'resent' is factive yet *deto*-excluded, her (58a)) —
+and where available, *deto* "seems to freely alternate" with default
+*če*, partly conditioned by register (colloquial; her fn. 45). The
+*za*-PP selection biconditional and the hidden-relative analysis are
+paper-specific and live study-side; this file carries the two directly
+observed axes. Both predicate lists are open-ended in the paper ("such
+as …", "e.g. …") — the inventories below are the predicates Krapova
+names, not the full classes.
+
+Forms follow the paper's scientific transliteration (*ă* for ъ; several
+citation forms are multiword impersonals with an experiencer clitic,
+e.g. *jad me e*).
+-/
+
+namespace Bulgarian.Clause
+
+/-! ### Predicate schema -/
+
+/-- Whether a predicate's notional complement may be introduced by the
+    invariant complementizer *deto* ([krapova-2010] §5). Two values
+    because only two are attested: *deto* is never obligatory — where
+    possible it alternates with default *če* (which her fn. 46 says
+    "may show up in all complement clauses") — and the alternation is
+    partly register-conditioned (colloquial, fn. 45). -/
+inductive DetoAvailability where
+  /-- *deto* possible, alternating with *če* ((56)–(57)). -/
+  | alternating
+  /-- *če* only ((58)). -/
+  | excluded
+  deriving DecidableEq, Repr
+
+/-- [krapova-2010] §5's two-way factivity split: "true" factives
+    including the emotives ([kiparsky-kiparsky-1970]; Krapova cites the
+    1971 reprint) vs semi-factives ([karttunen-1971]'s term). Class-
+    level assertions — her projection trials ((57)) run on *săžaljavam*
+    and *vinoven săm* only. -/
+inductive Factivity where
+  | trueFactive
+  | semiFactive
+  deriving DecidableEq, Repr
+
+/-- A Bulgarian complement-taking predicate.
+
+    - `ctpClass`: [noonan-2007] category; `none` where unclear.
+    - `factivity`, `deto`: the two observed axes ([krapova-2010] §5). -/
+structure BulgarianEmbedder where
+  form : String
+  gloss : String
+  ctpClass : Option CTPClass
+  factivity : Factivity
+  deto : DetoAvailability
+  deriving DecidableEq, Repr
+
+/-! ### The *deto*-takers — emotive factives ([krapova-2010] §5)
+
+"Predicates of emotive reaction or emotive appraisal"; all
+[noonan-2007]-commentative, all "true" factive. -/
+
+/-- *săžaljavam* 'regret' — the projection-trial predicate ((57a), (57c));
+    the *zadeto* variant is exhibited at [deal-2026] (49). -/
+def sazhaljavam : BulgarianEmbedder where
+  form := "săžaljavam"; gloss := "regret"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *vinoven săm* 'be one's fault' ((57b), under matrix question). -/
+def vinovenSam : BulgarianEmbedder where
+  form := "vinoven săm"; gloss := "be one's fault"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *jad me e* 'be sorry; regret' ((56b)). -/
+def jadMeE : BulgarianEmbedder where
+  form := "jad me e"; gloss := "be sorry; regret"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *radvam se* 'be happy'. -/
+def radvamSe : BulgarianEmbedder where
+  form := "radvam se"; gloss := "be happy"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *nedovolstvam* 'be dissatisfied'. -/
+def nedovolstvam : BulgarianEmbedder where
+  form := "nedovolstvam"; gloss := "be dissatisfied"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *pritesnjavam se* 'worry'. -/
+def pritesnjavamSe : BulgarianEmbedder where
+  form := "pritesnjavam se"; gloss := "worry"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *žal mi e* 'be sorry'. -/
+def zhalMiE : BulgarianEmbedder where
+  form := "žal mi e"; gloss := "be sorry"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *măčno mi e* 'be sad'. -/
+def machnoMiE : BulgarianEmbedder where
+  form := "măčno mi e"; gloss := "be sad"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-- *sram me e* 'feel ashamed'. -/
+def sramMeE : BulgarianEmbedder where
+  form := "sram me e"; gloss := "feel ashamed"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .alternating
+
+/-! ### The *deto*-excluded factives
+
+"True" factives on [kiparsky-kiparsky-1970]'s list that nonetheless
+reject *deto* ([krapova-2010] pp. 1265–1266) — her evidence that
+factivity does not suffice. -/
+
+/-- *văzmuštavam se* 'resent' ((58a)) — the named dissociation witness:
+    emotive and factive, but takes no *za*-PP and no *deto*. -/
+def vazmushtavamSe : BulgarianEmbedder where
+  form := "văzmuštavam se"; gloss := "resent"
+  ctpClass := some .commentative
+  factivity := .trueFactive
+  deto := .excluded
+
+/-- *razbiram* 'comprehend'. -/
+def razbiram : BulgarianEmbedder where
+  form := "razbiram"; gloss := "comprehend"
+  ctpClass := some .knowledge
+  factivity := .trueFactive
+  deto := .excluded
+
+/-- *vzemam previd* 'take into account' (printed *previd*, beside
+    *imam predvid* — transcribed verbatim). -/
+def vzemamPrevid : BulgarianEmbedder where
+  form := "vzemam previd"; gloss := "take into account"
+  ctpClass := none
+  factivity := .trueFactive
+  deto := .excluded
+
+/-- *imam predvid* 'bear in mind'. -/
+def imamPredvid : BulgarianEmbedder where
+  form := "imam predvid"; gloss := "bear in mind"
+  ctpClass := none
+  factivity := .trueFactive
+  deto := .excluded
+
+/-- *prenebregvam* 'ignore'. -/
+def prenebregvam : BulgarianEmbedder where
+  form := "prenebregvam"; gloss := "ignore"
+  ctpClass := none
+  factivity := .trueFactive
+  deto := .excluded
+
+/-- *griža se* 'take care' (on [krapova-2010]'s reading of the
+    [kiparsky-kiparsky-1970] factive list). -/
+def grizhaSe : BulgarianEmbedder where
+  form := "griža se"; gloss := "take care"
+  ctpClass := none
+  factivity := .trueFactive
+  deto := .excluded
+
+/-! ### The *deto*-excluded semi-factives ([krapova-2010] p. 1266) -/
+
+/-- *znaja* 'know'. -/
+def znaja : BulgarianEmbedder where
+  form := "znaja"; gloss := "know"
+  ctpClass := some .knowledge
+  factivity := .semiFactive
+  deto := .excluded
+
+/-- *pomnja* 'remember'. -/
+def pomnja : BulgarianEmbedder where
+  form := "pomnja"; gloss := "remember"
+  ctpClass := some .knowledge
+  factivity := .semiFactive
+  deto := .excluded
+
+/-- *otkrivam* 'find out'. -/
+def otkrivam : BulgarianEmbedder where
+  form := "otkrivam"; gloss := "find out"
+  ctpClass := some .knowledge
+  factivity := .semiFactive
+  deto := .excluded
+
+/-- *viždam* 'see' (the propositional reading). -/
+def vizhdam : BulgarianEmbedder where
+  form := "viždam"; gloss := "see"
+  ctpClass := some .perception
+  factivity := .semiFactive
+  deto := .excluded
+
+/-- *čuvam* 'hear' (the propositional reading). -/
+def chuvam : BulgarianEmbedder where
+  form := "čuvam"; gloss := "hear"
+  ctpClass := some .perception
+  factivity := .semiFactive
+  deto := .excluded
+
+/-- *zabeljazvam* 'notice' (perception/knowledge borderline). -/
+def zabeljazvam : BulgarianEmbedder where
+  form := "zabeljazvam"; gloss := "notice"
+  ctpClass := none
+  factivity := .semiFactive
+  deto := .excluded
+
+/-! ### Inventories -/
+
+/-- The predicates [krapova-2010] names (open-ended lists — see module
+    docstring). -/
+def allEmbedders : List BulgarianEmbedder :=
+  [sazhaljavam, vinovenSam, jadMeE, radvamSe, nedovolstvam,
+   pritesnjavamSe, zhalMiE, machnoMiE, sramMeE,
+   vazmushtavamSe, razbiram, vzemamPrevid, imamPredvid, prenebregvam,
+   grizhaSe, znaja, pomnja, otkrivam, vizhdam, chuvam, zabeljazvam]
+
+/-- The *deto*-takers. -/
+def detoTakers : List BulgarianEmbedder :=
+  allEmbedders.filter (·.deto == .alternating)
+
+/-- Drift sentry: the *deto*-takers are exactly the nine emotive
+    factives Krapova names. -/
+theorem detoTakers_membership :
+    detoTakers = [sazhaljavam, vinovenSam, jadMeE, radvamSe,
+                  nedovolstvam, pritesnjavamSe, zhalMiE, machnoMiE,
+                  sramMeE] := by decide
+
+/-- Every *deto*-taker is a "true" (emotive) factive. -/
+theorem detoTakers_all_trueFactive :
+    detoTakers.all (·.factivity == .trueFactive) = true := by decide
+
+/-- Factivity does not suffice for *deto*: "true" factives with *deto*
+    excluded exist (*văzmuštavam se* and the transitive class) —
+    [krapova-2010]'s dissociation. -/
+theorem factivity_not_sufficient_for_deto :
+    ∃ v ∈ allEmbedders,
+      v.factivity = .trueFactive ∧ v.deto = .excluded := by decide
+
+end Bulgarian.Clause

--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -50,7 +50,7 @@ participle — two axes, two fields. -/
 def aasha : Complementizer where
   form := "-Aːša"
   position := some .postfixed
-  noonanType := some .nominalized
+  coding := some .nominalized
   verbForm := some .Part
   licenser := some .nominal
 
@@ -59,7 +59,7 @@ verbs, also in analytical verb forms and sentential adjuncts (ex. 30). -/
 def zha : Complementizer where
   form := "-žA"
   position := some .postfixed
-  noonanType := some .indicative
+  coding := some .indicative
   verbForm := some .Conv
   licenser := some .verbal
 
@@ -98,9 +98,8 @@ def hanaxa : Verb where
 questions (ex. 3). -/
 def medexe : Verb where
   form := "mɘdɘxɘ"
-  frames := [Frame.finiteClause, Frame.gerund]
+  frames := [Frame.finiteClause, Frame.gerund, Frame.question]
   attitude := some (.doxastic .veridical)
-  takesQuestionBase := true
 
 /-- *xɘlɘxɘ* 'say' — non-factive with bare CPs; nominalized complements
 are existence-entailing (ex. 51; speaker variation per fn. 30). -/

--- a/Linglib/Fragments/English/Complementizers.lean
+++ b/Linglib/Fragments/English/Complementizers.lean
@@ -31,7 +31,7 @@ structure CompEntry extends Complementizer where
 
 def that : CompEntry :=
   { form := "that", position := some .detached,
-    noonanType := some .indicative, clauseForm := some .declarative,
+    coding := some .indicative, clauseForm := some .declarative,
     optional := true }
 
 def if_ : CompEntry :=

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -304,12 +304,11 @@ def know : VerbEntry where
   formPast := "knew"
   formPastPart := "known"
   formPresPart := "knowing"
-  frames := [Frame.finiteClause]
+  frames := [Frame.finiteClause, Frame.question]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
   projectionBehavior := some .hole
-  takesQuestionBase := true
   complementSig := some .mono
   attitude := some (.doxastic .veridical)
 
@@ -340,12 +339,11 @@ def realize : VerbEntry := .mkRegular {
 /-- "discover" — semifactive, weaker projection -/
 def discover : VerbEntry := .mkRegular {
   form := "discover"
-  frames := [Frame.finiteClause]
+  frames := [Frame.finiteClause, Frame.question]
   vendlerClass := some .achievement
   passivizable := false
   presupType := some .softTrigger
   projectionBehavior := some .hole
-  takesQuestionBase := true
   attitude := some (.doxastic .veridical) }
 
 /-- "notice" — semifactive -/
@@ -1522,7 +1520,6 @@ def wonder : VerbEntry := .mkRegular {
   form := "wonder"
   frames := [Frame.question]
   vendlerClass := some .state
-  takesQuestionBase := true
   opaqueContext := true }
 
 /-- "ask" — embeds questions -/
@@ -1530,15 +1527,13 @@ def ask : VerbEntry := .mkRegular {
   form := "ask"
   speechActVerb := true
   frames := [Frame.question]
-  vendlerClass := some .achievement
-  takesQuestionBase := true }
+  vendlerClass := some .achievement }
 
 /-- "investigate" — rogative, embeds interrogatives only -/
 def investigate : VerbEntry := .mkRegular {
   form := "investigate"
   frames := [Frame.question]
   vendlerClass := some .activity
-  takesQuestionBase := true
   levinClass := some .search }
 
 /-- "depend_on" — rogative, embeds interrogatives only ([dayal-2025]: rogativeCP) -/
@@ -1550,17 +1545,15 @@ def depend_on : VerbEntry where
   formPresPart := "depending on"
   frames := [Frame.question]
   vendlerClass := some .state
-  takesQuestionBase := true
 
 /-- "remember" in factive/question-embedding sense. -/
 def remember_rog : VerbEntry := .mkRegular {
   form := "remember"
-  frames := [Frame.finiteClause]
+  frames := [Frame.finiteClause, Frame.question]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
   attitude := some (.doxastic .veridical)
-  takesQuestionBase := true
   senseTag := .rogative }
 
 /-- "forget" in factive/question-embedding sense. -/
@@ -1570,12 +1563,11 @@ def forget_rog : VerbEntry where
   formPast := "forgot"
   formPastPart := "forgotten"
   formPresPart := "forgetting"
-  frames := [Frame.finiteClause]
+  frames := [Frame.finiteClause, Frame.question]
   vendlerClass := some .state
   passivizable := false
   presupType := some .softTrigger
   attitude := some (.doxastic .veridical)
-  takesQuestionBase := true
   senseTag := .rogative
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -24,7 +24,7 @@ namespace Greek.StandardModern.Complementizers
 def oti : Complementizer where
   form := "oti"
   position := some .detached
-  noonanType := some .indicative
+  coding := some .indicative
   clauseForm := some .declarative
 
 /-- *pu* — factive complementizer ([christidis-1982], [roussou-2019]);
@@ -36,7 +36,7 @@ def oti : Complementizer where
 def pu : Complementizer where
   form := "pu"
   position := some .detached
-  noonanType := some .indicative
+  coding := some .indicative
   clauseForm := some .declarative
   factive := some true
 
@@ -47,7 +47,7 @@ def pu : Complementizer where
 def an : Complementizer where
   form := "an"
   position := some .detached
-  noonanType := some .indicative
+  coding := some .indicative
   clauseForm := some .embeddedQuestion
 
 /-- *na* — subjunctive ([grano-2024]); the *na*-selecting mood-choice
@@ -57,7 +57,7 @@ def an : Complementizer where
 def na : Complementizer where
   form := "na"
   position := some .detached
-  noonanType := some .subjunctive
+  coding := some .subjunctive
 
 /-- The complementizer inventory. -/
 def complementizers : List Complementizer := [oti, pu, an, na]

--- a/Linglib/Fragments/Hausa/VerbGrades.lean
+++ b/Linglib/Fragments/Hausa/VerbGrades.lean
@@ -330,8 +330,7 @@ theorem gr7_nonThematic (v : HausaVerb)
 theorem mkVerb_is_canonical (form : String) (g : StemTemplate)
     (lexTones : List TRN := []) :
     (mkVerb form g lexTones).canonical :=
-  ⟨by simp [mkVerb, HausaVerb.canonical, Verb.complementType,
-      toComplementType_toFrame], rfl⟩
+  ⟨by simp [mkVerb, HausaVerb.canonical, Verb.complementType], rfl⟩
 
 /-- **Grades 5 and 6 introduce an external argument.** The two H–H
     grades are both agentive at the `Verb` level. -/

--- a/Linglib/Fragments/Hungarian/Predicates.lean
+++ b/Linglib/Fragments/Hungarian/Predicates.lean
@@ -125,10 +125,9 @@ def tud : HungarianVerbEntry where
   formPresIndef := "tud"
   formPastDef := "tudta"
   formPastIndef := "tudott"
-  frames := [Frame.finiteClause]
+  frames := [Frame.finiteClause, Frame.question]
   presupType := some .softTrigger
   attitude := some (.doxastic .veridical)
-  takesQuestionBase := true
   complementSig := some .mono
 
 /-- *aggaszt* 'worry' — subject-experiencer psych verb taking a subject clause

--- a/Linglib/Fragments/Ndebele/Clause.lean
+++ b/Linglib/Fragments/Ndebele/Clause.lean
@@ -1,0 +1,140 @@
+import Linglib.Features.Complementation
+
+/-!
+# Ndebele Clausal Embedding Inventory
+
+[pietraszko-2019]
+
+Northern Ndebele (Bantu S44, Zimbabwe; ISO 639-3 `nde`) inventory of
+complement-taking predicates. The clause-typer is *ukuthi* — augment
+*u-* (the exponent of D) over the class-15 complementizer root *kuthi*,
+etymologically a nominalization of *thi* 'say' ((8)) — and it wraps
+indicative and subjunctive complements alike in every syntactic context
+[pietraszko-2019] tests (verb complement, clausal subject, preposition
+object, demoted passive subject, adnominal). The augment drops exactly
+where nominal augments drop (negation + in situ, (11)–(12)); the D
+layer itself is obligatory. Since the paper establishes no
+predicate-conditioned variation in the clause-typer, the observables
+here are the complement's mood coding (lexically conditioned, their
+fn. 3) and the clausal argument's syntactic role. No factivity data:
+the paper runs no projection tests, and the *the fact that*
+paraphrases in its translations are an English artifact it flags
+itself (at (20)).
+-/
+
+namespace Ndebele.Clause
+
+/-! ### Language-level constants -/
+
+/-- The clause-typer: augment + class-15 complementizer root. -/
+def clauseTyperForm : String := "ukuthi"
+
+/-- Noun class of the clause-typer (Bantu class number): class 15, per
+    the augment's agreement ((10)), the object marker *ku-* ((7b)), and
+    clausal-subject agreement ((22)). Halpert's Zulu counterpart is
+    glossed class 17. -/
+def clauseTyperClass : Nat := 15
+
+/-! ### Predicate schema -/
+
+/-- Syntactic role of the predicate's attested clausal argument. -/
+inductive ClausalRole where
+  /-- Complement/object of the verb. -/
+  | complement
+  /-- Object of an independent preposition (*nga* 'about', (20b)). -/
+  | prepositionObject
+  /-- Demoted passive subject with oblique *yi-* ((14)). -/
+  | obliquePassiveSubject
+  /-- Clausal subject ((22)). -/
+  | subject
+  deriving DecidableEq, Repr
+
+/-- An Ndebele complement-taking predicate.
+
+    - `ctpClass`: [noonan-2007] category; `none` where the attested
+      frame gives no clear assignment.
+    - `coding`: mood of the *ukuthi*-complement — indicative vs
+      subjunctive, lexically conditioned ([pietraszko-2019] fn. 3:
+      indicative clauses allow only *ukuthi*; *ukuze*, *sengathi* are
+      lexically selected and subjunctive-only).
+    - `clausalRole`: where the clause sits. -/
+structure NdebeleEmbedder where
+  form : String
+  gloss : String
+  ctpClass : Option CTPClass
+  coding : Option Complement.Coding
+  clausalRole : ClausalRole
+  deriving DecidableEq, Repr
+
+/-! ### Predicates -/
+
+/-- *cabanga* 'think'. Indicative *ukuthi*-complement; the augment-drop
+    paradigm predicate ((4), (12a–c)). -/
+def cabanga : NdebeleEmbedder where
+  form := "cabanga"; gloss := "think"
+  ctpClass := some .propAttitude
+  coding := some .indicative
+  clausalRole := .complement
+
+/-- *funa* 'want'. Subjunctive *ukuthi*-complement ((7b)); also plain
+    class-15 nominal objects ((7a)). -/
+def funa : NdebeleEmbedder where
+  form := "funa"; gloss := "want"
+  ctpClass := some .desiderative
+  coding := some .subjunctive
+  clausalRole := .complement
+
+/-- *zwa* 'hear'. Both attested examples are hearsay reports
+    ((18), (26a)), not immediate perception. -/
+def zwa : NdebeleEmbedder where
+  form := "zwa"; gloss := "hear"
+  ctpClass := some .perception
+  coding := some .indicative
+  clausalRole := .complement
+
+/-- *khuluma nga* 'talk about': the clause is the object of the
+    preposition *nga*, with no extra nominal structure —
+    `nga [DP u-kuthi …]`, coalescing to *ngokuthi* ((20b)). -/
+def khulumaNga : NdebeleEmbedder where
+  form := "khuluma nga"; gloss := "talk about"
+  ctpClass := some .utterance
+  coding := some .indicative
+  clausalRole := .prepositionObject
+
+/-- *danisa* 'worry (caus.)', attested only passivized: the clause is a
+    demoted subject with the augment-replacing oblique *yi-*
+    (*yikuthi*, (14)). -/
+def danisa : NdebeleEmbedder where
+  form := "danisa"; gloss := "worry"
+  ctpClass := none
+  coding := some .indicative
+  clausalRole := .obliquePassiveSubject
+
+/-- *bala* 'write', passive impersonal: the *ukuthi*-clause is a
+    subject controlling class-15 agreement ((22)). -/
+def bala : NdebeleEmbedder where
+  form := "bala"; gloss := "write"
+  ctpClass := none
+  coding := some .indicative
+  clausalRole := .subject
+
+/-! ### Inventories -/
+
+/-- The predicates with quotable clausal-argument data in
+    [pietraszko-2019]. -/
+def allEmbedders : List NdebeleEmbedder :=
+  [cabanga, funa, zwa, khulumaNga, danisa, bala]
+
+/-- Drift sentry: *funa* is the only subjunctive-taker in the sample
+    ([pietraszko-2019] fn. 3's lexical conditioning). -/
+theorem subjunctive_takers :
+    allEmbedders.filter (·.coding == some .subjunctive) = [funa] := by
+  decide
+
+/-- Drift sentry: the verb-complement frame is attested for exactly
+    *cabanga*, *funa*, *zwa*. -/
+theorem complement_takers :
+    allEmbedders.filter (·.clausalRole == .complement) =
+      [cabanga, funa, zwa] := by decide
+
+end Ndebele.Clause

--- a/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
+++ b/Linglib/Fragments/NezPerce/ClausalEmbedding.lean
@@ -10,282 +10,221 @@ import Linglib.Features.Number.Capabilities
 Nez Perce (Sahaptian, ISO 639-3 `nez`) inventory of notional-complement-taking
 predicates plus the relative-pronoun paradigm. Theory-light: each predicate
 carries only consensus-typological metadata (CTP class per [noonan-2007],
-factivity status per [tonhauser-beaver-roberts-simons-2013] projection
-diagnostics).
+factivity per [tonhauser-beaver-roberts-simons-2013]-style projection trials,
+[deal-2026] §3/§6) and one morphological observable — the grammaticality
+status of *yox̂ ke* on the complement edge. The analytical RE-vs-simplex split,
+selectional features, and projection-site claims are Deal-specific apparatus
+and live in the co-located `Studies/Deal2026.lean`.
 
-## Scope and provenance
-
-Predicate list and factivity assessments are from [deal-2026] §3 (RE-takers)
-and §6 (simplex-takers); the analytical RE-vs-simplex split is *not* encoded
-here as a Fragment field — it is Deal-specific apparatus and lives in the
-co-located study file `Studies/Deal2026.lean` as a
-Studies-side projection.
-
-Relative-pronoun paradigm is from [deal-2016a] (Table 22 reproduced in
-[deal-2026] (22)). Case and number values reuse `Core.UD` substrate.
-
-## What is here
-
-- `NezPerceEmbedder`: per-verb consensus typology.
-- 11 verbs: 8 typically RE-only (per [deal-2026] §3) + 3 typically simplex-only
-  (per [deal-2026] §6).
-- `RelativePronoun`: the *yox̂/ko* paradigm cells, indexed by `Core.UD.Case`
-  × `Core.UD.Number`.
-- 6 paradigm-cell entries.
-
-## What is NOT here (lives in Studies/Deal2026.lean)
-
-- The RE-vs-simplex strategy field per verb (Deal-specific apparatus).
-- The `[uĀ]` selectional feature per RE-taker (Deal-specific analytical claim).
-- The Tonhauser `ProjectiveClass` projection (consumes
-  `Semantics/Presupposition/ProjectiveContent.lean`).
-- Cross-classification theorems (factivity ⊥ RE-structure).
-- The *ke*-as-φ-probe-on-C analysis (consumes `Minimalist.SatisfactionCond`).
+The relative-pronoun paradigm is from [deal-2016a] as reproduced at
+[deal-2026] (22); case and number values reuse `Core.UD` substrate.
 -/
 
 namespace NezPerce.ClausalEmbedding
 
--- ============================================================================
--- §1. Predicate Schema
--- ============================================================================
+/-! ### Predicate schema -/
+
+/-- Grammaticality status of the *yox̂ ke* morpheme pair on a predicate's
+    notional-complement edge — a morphological observable, recording what
+    the morphology does, not what it means.
+
+    [deal-2026]: obligatory for the RE-takers ((28)); prohibited for
+    *neki* and *hi* ((65)); marginal for *cuukwe* — (66b) is `%`-marked,
+    and consultants "did on rare occasions accept" and once produced it,
+    so *cuukwe* *permits* a bare complement rather than rejecting the
+    marked one. -/
+inductive EdgeRequirement where
+  | obligatory
+  /-- Rarely/marginally accepted (`%`-marked). -/
+  | marginal
+  | prohibited
+  deriving DecidableEq, Repr
 
 /-- A Nez Perce notional-complement-taking predicate.
 
-    Fields are theory-neutral consensus typology and morphological
-    observations:
     - `ctpClass`: [noonan-2007] category. Emotive factives are
       `commentative`; cognitive factives are `knowledge`; *think* is
       `propAttitude`; *say* is `utterance`.
-    - `factive`: per [tonhauser-beaver-roberts-simons-2013] projection
-      diagnostics (entailment-canceling environments). Established for
-      Nez Perce by [deal-2026] §3 (33)–(36).
-    - `requiresYoxKeEdge`: morphological observation per [deal-2026] §3
-      (28). When `true`, the predicate's notional complement obligatorily
-      begins with the morpheme pair *yox̂ ke* (relative-pronoun + Cₐ̄
-      complementizer per Deal's analysis); when `false`, *yox̂ ke* on the
-      complement edge is ungrammatical. This field is *observable* — it
-      records what the morphology does, not what it means. Theory-laden
-      interpretations (selectional features, projection sites) belong in
-      `Studies/Deal2026.lean`.
-
-    A `notionalTransitivity` field would be uniformly `intransitive` for
-    every predicate Deal 2026 reviews (cf. §4 (38)–(39)) and is therefore
-    omitted as carrying no discriminating signal. -/
+    - `factive`: by projection trials in entailment-canceling
+      environments ([deal-2026] §3 (33)–(36), §6 (68)). Deal notes the
+      trials assess only the projection dimension of the
+      [tonhauser-beaver-roberts-simons-2013] taxonomy.
+    - `yoxKeEdge`: the *yox̂ ke* edge observable ([deal-2026] (28), (65),
+      (66)). -/
 structure NezPerceEmbedder where
   form : String
   gloss : String
   ctpClass : CTPClass
   factive : Bool
-  requiresYoxKeEdge : Bool
+  yoxKeEdge : EdgeRequirement
   deriving DecidableEq, Repr
 
--- ============================================================================
--- §2. Predicates from [deal-2026] §3 — RE-only ("relative-embedding")
--- ============================================================================
+/-! ### RE-taking predicates ([deal-2026] §3)
 
-/-! ### Emotive factives (commentative class, per [noonan-2007])
+Emotive factives (commentative per [noonan-2007]) plus one cognitive
+factive; all require *yox̂ ke* on the complement edge ((28)), with
+factivity established by projection trials ((33)–(34)). -/
 
-These predicates require their notional complement to carry the relative-
-pronoun + complementizer pair *yox̂ ke* ([deal-2026] (28)). Their factivity
-is established by Deal's projection-test trials (§3, (33)–(34)). -/
-
-/-- *liloy* 'be happy'. [deal-2026] (27a). -/
+/-- *lilooy* 'be happy'. [deal-2026] (27a). -/
 def liloy : NezPerceEmbedder where
-  form := "liloy"; gloss := "be happy"
+  form := "lilooy"; gloss := "be happy"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-- *etqew* 'be sad'. [deal-2026] (27b). -/
+/-- *'etqew* 'be sad'. [deal-2026] (27b). -/
 def etqew : NezPerceEmbedder where
   form := "'etqew"; gloss := "be sad"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
 /-- *cicwaay* 'be surprised'. [deal-2026] (27c). -/
 def cicwaay : NezPerceEmbedder where
   form := "cicwaay"; gloss := "be surprised"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-- *eey's* 'be joyful'. [deal-2026] (27e). -/
+/-- *'eey's* 'be joyful'. [deal-2026] (27e). -/
 def eeys : NezPerceEmbedder where
   form := "'eey's"; gloss := "be joyful"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-- *q'eese* 'be bothered, unhappy'. [deal-2026] (27e). -/
+/-- *q'eese'* 'be bothered, unhappy'. [deal-2026] (27e). -/
 def qeese : NezPerceEmbedder where
-  form := "q'eese"; gloss := "be bothered"
+  form := "q'eese'"; gloss := "be bothered"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-- *tim'neneki* 'be worried'. [deal-2026] (27e). -/
+/-- *tim'neeneki* 'be worried'. [deal-2026] (27e). -/
 def timneneki : NezPerceEmbedder where
-  form := "tim'neneki"; gloss := "be worried"
+  form := "tim'neeneki"; gloss := "be worried"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-! ### Cognitive factive
-
-*timiipni* 'remember' is classed by Noonan as `knowledge` (cognitive factive)
-but exhibits the same RE morphosyntax as the emotive factives in Nez Perce
-([deal-2026] (27d), §3). The CTP class divergence between Nez Perce
-*timiipni* and English *remember* (which is also `knowledge`) is a Fragment
-fact: whether `knowledge` predicates are RE-takers is a per-language
-property. -/
-
-/-- *timiipni* 'remember'. [deal-2026] (27d). -/
+/-- *timiipni* 'remember'. [deal-2026] (27d). Classed by Noonan as
+    `knowledge` (cognitive factive) but with the same RE morphosyntax as
+    the emotive factives — whether `knowledge` predicates are RE-takers
+    is a per-language property (contrast English *remember*). -/
 def timiipni : NezPerceEmbedder where
   form := "timiipni"; gloss := "remember"
   ctpClass := .knowledge
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
-/-! ### Speech-act particle
-
-*qe'ciyeew'yew* 'thank you' is a non-verbal particle that nonetheless takes
-notional complements with the RE morphosyntax ([deal-2026] (42)). It
-disallows DP complements (42b), reinforcing Deal's argument that REs are not
-DPs. -/
-
-/-- *qe'ciyeew'yew* 'thank you' (particle). [deal-2026] (42). -/
+/-- *qe'ciyeew'yew'* 'thank you' — an unanalyzable particle, not a verb,
+    taking notional complements with RE morphosyntax while disallowing
+    all nominal complements ([deal-2026] §4 (42); fn. 16). Its factivity
+    follows [deal-2026] §7's generalization that all REs are factive (no
+    per-item projection trial is reported). -/
 def qeciyeewyew : NezPerceEmbedder where
-  form := "qe'ciyeew'yew"; gloss := "thank you"
+  form := "qe'ciyeew'yew'"; gloss := "thank you"
   ctpClass := .commentative
   factive := true
-  requiresYoxKeEdge := true
+  yoxKeEdge := .obligatory
 
--- ============================================================================
--- §3. Predicates from [deal-2026] §6 — simplex-only
--- ============================================================================
+/-! ### Simplex-taking predicates ([deal-2026] §6) -/
 
-/-! ### Non-factive cognitive and utterance predicates
-
-These predicates strictly reject the RE morphosyntax — *yox̂ ke* on the
-complement edge is ungrammatical for them ([deal-2026] (20), (47)–(48),
-(65), (69)–(70)). -/
-
-/-- *neki* 'think'. [deal-2026] (47), (65). Non-factive. -/
+/-- *neki* 'think'. [deal-2026] (48), (65a). Non-factive; rejects
+    *yox̂ ke* on the complement edge. -/
 def neki : NezPerceEmbedder where
   form := "neki"; gloss := "think"
   ctpClass := .propAttitude
   factive := false
-  requiresYoxKeEdge := false
+  yoxKeEdge := .prohibited
 
-/-- *hi* 'say, tell'. [deal-2026] (47), (65). Non-factive. -/
+/-- *hi* 'say, tell'. [deal-2026] (47), (65b). Non-factive; rejects
+    *yox̂ ke*. Unlike the RE-takers, *hi* is transitive: it takes an
+    accusative addressee and triggers object agreement ((47a)). -/
 def hi : NezPerceEmbedder where
   form := "hi"; gloss := "say, tell"
   ctpClass := .utterance
   factive := false
-  requiresYoxKeEdge := false
+  yoxKeEdge := .prohibited
 
-/-! ### Factive cognitive predicate
-
-*cuukwe* 'know' is factive ([deal-2026] §6 (68): projection test
-confirms factivity even in conditional antecedent), but typically takes
-*simplex* complements (no *yox̂ ke*) — RE morphosyntax is rare and marginal
-((66b) is `%`-marked). This is Deal 2026's central dissociation:
-factivity ⊥ RE-structure. -/
-
-/-- *cuukwe* 'know'. [deal-2026] (66), (68). Factive but
-    typically simplex-embedding — the `requiresYoxKeEdge = false` field
-    encodes the headline [deal-2026] dissociation: factivity does not
-    force RE morphology in Nez Perce. (66b) shows a marginal `%`-attested
-    RE-marked variant; we record the canonical pattern.  -/
+/-- *cuukwe* 'know'. [deal-2026] (66), (68). Factive (projection
+    survives a conditional antecedent, (68)) but canonically
+    simplex-embedding — the RE-marked variant is only marginally
+    accepted ((66b), `%`-marked). The factive-but-simplex combination is
+    [deal-2026]'s central dissociation: factivity does not force RE
+    morphology. -/
 def cuukwe : NezPerceEmbedder where
   form := "cuukwe"; gloss := "know"
   ctpClass := .knowledge
   factive := true
-  requiresYoxKeEdge := false
+  yoxKeEdge := .marginal
 
--- ============================================================================
--- §4. Inventories
--- ============================================================================
+/-! ### Inventories -/
 
 /-- All embedders surveyed in [deal-2026]: 8 RE-canonical + 3
-    simplex-canonical. This is the source-of-truth list; the partitions
-    `reCanonical` / `simplexCanonical` are derived views on it via the
-    Fragment-level observable `requiresYoxKeEdge`. -/
+    simplex-canonical. Source-of-truth list; `reCanonical` and
+    `simplexCanonical` are derived views via the `yoxKeEdge` observable. -/
 def allEmbedders : List NezPerceEmbedder :=
   [liloy, etqew, cicwaay, eeys, qeese, timneneki, timiipni, qeciyeewyew,
    neki, hi, cuukwe]
 
-/-- The RE-canonical predicates: those whose notional complement
-    obligatorily begins with the *yox̂ ke* morpheme pair. Defined as a
-    derived view on the Fragment-level observable `requiresYoxKeEdge`
-    rather than as a hand-curated list, so that adding/removing the
-    edge-marking field on any predicate automatically updates this list. -/
+/-- The RE-canonical predicates: *yox̂ ke* obligatory on the complement
+    edge. -/
 def reCanonical : List NezPerceEmbedder :=
-  allEmbedders.filter (·.requiresYoxKeEdge)
+  allEmbedders.filter (·.yoxKeEdge == .obligatory)
 
-/-- The simplex-canonical predicates: those whose notional complement
-    is incompatible with *yox̂ ke* on the edge. -/
+/-- The simplex-canonical predicates: those permitting a bare complement
+    (*yox̂ ke* prohibited or merely marginal) — [deal-2026] §6's
+    "conservative generalization". -/
 def simplexCanonical : List NezPerceEmbedder :=
-  allEmbedders.filter (! ·.requiresYoxKeEdge)
+  allEmbedders.filter (·.yoxKeEdge != .obligatory)
 
 /-- Drift sentry: `reCanonical` contains exactly the eight predicates
-    [deal-2026] §3 (27a–e), (27d), (42) lists. A `decide` failure here
-    means either a verb's `requiresYoxKeEdge` field has been edited
-    incorrectly, or a verb has been added/removed from `allEmbedders`. -/
+    [deal-2026] lists at (27a–e), (27d), (42). -/
 theorem reCanonical_membership :
     reCanonical = [liloy, etqew, cicwaay, eeys, qeese, timneneki,
                    timiipni, qeciyeewyew] := by decide
 
-/-- Drift sentry: `simplexCanonical` contains exactly *neki*, *hi*, *cuukwe*. -/
+/-- Drift sentry: `simplexCanonical` contains exactly *neki*, *hi*,
+    *cuukwe*. -/
 theorem simplexCanonical_membership :
     simplexCanonical = [neki, hi, cuukwe] := by decide
 
-/-- Partition: every embedder is either RE-canonical or simplex-canonical
-    (no third category in [deal-2026]'s survey). -/
+/-- Partition: every embedder is either RE-canonical or
+    simplex-canonical (no third category in [deal-2026]'s survey). -/
 theorem allEmbedders_partitioned :
     allEmbedders = reCanonical ++ simplexCanonical := by decide
 
--- ============================================================================
--- §5. Factivity Generalisations (consensus, observation-level)
--- ============================================================================
+/-! ### Factivity generalisations (observation-level) -/
 
-/-- All RE-canonical predicates are factive. [deal-2026] §3. -/
+/-- All RE-canonical predicates are factive. [deal-2026] §3, §7. -/
 theorem reCanonical_all_factive :
     reCanonical.all (·.factive) = true := by decide
 
-/-- The factive simplex-canonical predicates: exactly *cuukwe* 'know'.
-    Drift sentry rather than aggregate count — pins which verb is the
-    factive simplex-taker. -/
+/-- The factive simplex-canonical predicates: exactly *cuukwe* 'know'. -/
 theorem factive_simplex_membership :
     simplexCanonical.filter (·.factive) = [cuukwe] := by decide
 
-/-- The non-factive simplex-canonical predicates: exactly *neki* 'think'
-    and *hi* 'say/tell'. -/
+/-- The non-factive simplex-canonical predicates: exactly *neki* and
+    *hi*. -/
 theorem nonfactive_simplex_membership :
     simplexCanonical.filter (! ·.factive) = [neki, hi] := by decide
 
-/-- Crucially: factivity does NOT predict RE-canonical status.
-    *cuukwe* 'know' is factive but simplex-canonical — establishing that
-    factivity is necessary but not sufficient for RE morphosyntax in
-    Nez Perce. (Deal 2026's central dissociation.) -/
+/-- Factivity does not predict RE-canonical status: *cuukwe* 'know' is
+    factive but simplex-canonical ([deal-2026]'s central dissociation —
+    in Nez Perce factivity is necessary but not sufficient for RE
+    morphosyntax). -/
 theorem cuukwe_factive_but_simplex :
     cuukwe.factive = true ∧ cuukwe ∈ simplexCanonical := by
   refine ⟨rfl, ?_⟩
   decide
 
--- ============================================================================
--- §6. Relative Pronoun Paradigm
--- ============================================================================
+/-! ### Relative-pronoun paradigm
 
-/-! ### *yox̂/ko* paradigm — [deal-2016a], reproduced as
-[deal-2026] Table (22).
+The *yox̂/ko* paradigm from [deal-2016a], reproduced at [deal-2026] (22).
+Cells are indexed by `Core.UD.Case` (Nom/Erg/Acc) × `Core.UD.Number`. -/
 
-Cells are indexed by `Core.UD.Case` (Nom/Erg/Acc) × `Core.UD.Number`
-(Sing/Plur) — reusing the universally-shared UD substrate rather than
-inventing local enums. -/
-
-/-- A relative-pronoun cell from [deal-2026] Table (22). -/
+/-- A relative-pronoun cell from [deal-2026] (22). -/
 structure RelativePronoun where
   case : UD.Case
   number : UD.Number
@@ -302,20 +241,19 @@ def rp_erg_pl : RelativePronoun := ⟨.Erg, .Plur, ["konmam"]⟩
 def rp_acc_sg : RelativePronoun := ⟨.Acc, .Sing, ["konya"]⟩
 def rp_acc_pl : RelativePronoun := ⟨.Acc, .Plur, ["konmana", "yox̂mene"]⟩
 
-/-- The full [deal-2016a] paradigm: three cases × two numbers,
-    six cells total. -/
+/-- The full paradigm: three cases × two numbers, six cells. -/
 def relativePronounParadigm : List RelativePronoun :=
   [rp_nom_sg, rp_nom_pl, rp_erg_sg, rp_erg_pl, rp_acc_sg, rp_acc_pl]
 
-/-- Drift sentry: the paradigm covers exactly the Nom × Sing/Plur,
-    Erg × Sing/Plur, Acc × Sing/Plur cells. A failure here means a cell
-    has been added, removed, or its (case, number) pair edited. -/
+/-- Drift sentry: the paradigm covers exactly the Nom/Erg/Acc ×
+    Sing/Plur cells. -/
 theorem paradigm_membership :
     (relativePronounParadigm.map (λ p => (p.case, p.number))) =
       [(.Nom, .Sing), (.Nom, .Plur), (.Erg, .Sing), (.Erg, .Plur),
        (.Acc, .Sing), (.Acc, .Plur)] := by decide
 
-/-- The accusative-plural cell shows idiolectal variation: two attested forms. -/
+/-- The accusative-plural cell shows idiolectal variation: two attested
+    forms. -/
 theorem acc_pl_variants : rp_acc_pl.forms = ["konmana", "yox̂mene"] := rfl
 
 end NezPerce.ClausalEmbedding

--- a/Linglib/Fragments/NezPerce/Clause.lean
+++ b/Linglib/Fragments/NezPerce/Clause.lean
@@ -12,7 +12,7 @@ predicates plus the relative-pronoun paradigm. Theory-light: each predicate
 carries only consensus-typological metadata (CTP class per [noonan-2007],
 factivity per [tonhauser-beaver-roberts-simons-2013]-style projection trials,
 [deal-2026] §3/§6) and one morphological observable — the grammaticality
-status of *yox̂ ke* on the complement edge. The analytical RE-vs-simplex split,
+status of *yox̂ ke* on the complement edge. The analytical relative-vs-simplex split,
 selectional features, and projection-site claims are Deal-specific apparatus
 and live in the co-located `Studies/Deal2026.lean`.
 
@@ -20,7 +20,7 @@ The relative-pronoun paradigm is from [deal-2016a] as reproduced at
 [deal-2026] (22); case and number values reuse `Core.UD` substrate.
 -/
 
-namespace NezPerce.ClausalEmbedding
+namespace NezPerce.Clause
 
 /-! ### Predicate schema -/
 
@@ -28,7 +28,7 @@ namespace NezPerce.ClausalEmbedding
     notional-complement edge — a morphological observable, recording what
     the morphology does, not what it means.
 
-    [deal-2026]: obligatory for the RE-takers ((28)); prohibited for
+    [deal-2026]: obligatory for the relative-embedding takers ((28)); prohibited for
     *neki* and *hi* ((65)); marginal for *cuukwe* — (66b) is `%`-marked,
     and consultants "did on rare occasions accept" and once produced it,
     so *cuukwe* *permits* a bare complement rather than rejecting the
@@ -59,7 +59,7 @@ structure NezPerceEmbedder where
   yoxKeEdge : EdgeRequirement
   deriving DecidableEq, Repr
 
-/-! ### RE-taking predicates ([deal-2026] §3)
+/-! ### Relative-embedding predicates ([deal-2026] §3)
 
 Emotive factives (commentative per [noonan-2007]) plus one cognitive
 factive; all require *yox̂ ke* on the complement edge ((28)), with
@@ -108,8 +108,8 @@ def timneneki : NezPerceEmbedder where
   yoxKeEdge := .obligatory
 
 /-- *timiipni* 'remember'. [deal-2026] (27d). Classed by Noonan as
-    `knowledge` (cognitive factive) but with the same RE morphosyntax as
-    the emotive factives — whether `knowledge` predicates are RE-takers
+    `knowledge` (cognitive factive) but with the same relative-embedding morphosyntax as
+    the emotive factives — whether `knowledge` predicates are relative-embedding takers
     is a per-language property (contrast English *remember*). -/
 def timiipni : NezPerceEmbedder where
   form := "timiipni"; gloss := "remember"
@@ -118,9 +118,9 @@ def timiipni : NezPerceEmbedder where
   yoxKeEdge := .obligatory
 
 /-- *qe'ciyeew'yew'* 'thank you' — an unanalyzable particle, not a verb,
-    taking notional complements with RE morphosyntax while disallowing
+    taking notional complements with relative-embedding morphosyntax while disallowing
     all nominal complements ([deal-2026] §4 (42); fn. 16). Its factivity
-    follows [deal-2026] §7's generalization that all REs are factive (no
+    follows [deal-2026] §7's generalization that all relative embeddings are factive (no
     per-item projection trial is reported). -/
 def qeciyeewyew : NezPerceEmbedder where
   form := "qe'ciyeew'yew'"; gloss := "thank you"
@@ -139,7 +139,7 @@ def neki : NezPerceEmbedder where
   yoxKeEdge := .prohibited
 
 /-- *hi* 'say, tell'. [deal-2026] (47), (65b). Non-factive; rejects
-    *yox̂ ke*. Unlike the RE-takers, *hi* is transitive: it takes an
+    *yox̂ ke*. Unlike the relative-embedding takers, *hi* is transitive: it takes an
     accusative addressee and triggers object agreement ((47a)). -/
 def hi : NezPerceEmbedder where
   form := "hi"; gloss := "say, tell"
@@ -149,9 +149,9 @@ def hi : NezPerceEmbedder where
 
 /-- *cuukwe* 'know'. [deal-2026] (66), (68). Factive (projection
     survives a conditional antecedent, (68)) but canonically
-    simplex-embedding — the RE-marked variant is only marginally
+    simplex-embedding — the relative-marked variant is only marginally
     accepted ((66b), `%`-marked). The factive-but-simplex combination is
-    [deal-2026]'s central dissociation: factivity does not force RE
+    [deal-2026]'s central dissociation: factivity does not force relative-embedding
     morphology. -/
 def cuukwe : NezPerceEmbedder where
   form := "cuukwe"; gloss := "know"
@@ -161,16 +161,16 @@ def cuukwe : NezPerceEmbedder where
 
 /-! ### Inventories -/
 
-/-- All embedders surveyed in [deal-2026]: 8 RE-canonical + 3
-    simplex-canonical. Source-of-truth list; `reCanonical` and
+/-- All embedders surveyed in [deal-2026]: 8 relative-canonical + 3
+    simplex-canonical. Source-of-truth list; `relativeCanonical` and
     `simplexCanonical` are derived views via the `yoxKeEdge` observable. -/
 def allEmbedders : List NezPerceEmbedder :=
   [liloy, etqew, cicwaay, eeys, qeese, timneneki, timiipni, qeciyeewyew,
    neki, hi, cuukwe]
 
-/-- The RE-canonical predicates: *yox̂ ke* obligatory on the complement
+/-- The relative-canonical predicates: *yox̂ ke* obligatory on the complement
     edge. -/
-def reCanonical : List NezPerceEmbedder :=
+def relativeCanonical : List NezPerceEmbedder :=
   allEmbedders.filter (·.yoxKeEdge == .obligatory)
 
 /-- The simplex-canonical predicates: those permitting a bare complement
@@ -179,10 +179,10 @@ def reCanonical : List NezPerceEmbedder :=
 def simplexCanonical : List NezPerceEmbedder :=
   allEmbedders.filter (·.yoxKeEdge != .obligatory)
 
-/-- Drift sentry: `reCanonical` contains exactly the eight predicates
+/-- Drift sentry: `relativeCanonical` contains exactly the eight predicates
     [deal-2026] lists at (27a–e), (27d), (42). -/
-theorem reCanonical_membership :
-    reCanonical = [liloy, etqew, cicwaay, eeys, qeese, timneneki,
+theorem relativeCanonical_membership :
+    relativeCanonical = [liloy, etqew, cicwaay, eeys, qeese, timneneki,
                    timiipni, qeciyeewyew] := by decide
 
 /-- Drift sentry: `simplexCanonical` contains exactly *neki*, *hi*,
@@ -190,16 +190,16 @@ theorem reCanonical_membership :
 theorem simplexCanonical_membership :
     simplexCanonical = [neki, hi, cuukwe] := by decide
 
-/-- Partition: every embedder is either RE-canonical or
+/-- Partition: every embedder is either relative-canonical or
     simplex-canonical (no third category in [deal-2026]'s survey). -/
 theorem allEmbedders_partitioned :
-    allEmbedders = reCanonical ++ simplexCanonical := by decide
+    allEmbedders = relativeCanonical ++ simplexCanonical := by decide
 
 /-! ### Factivity generalisations (observation-level) -/
 
-/-- All RE-canonical predicates are factive. [deal-2026] §3, §7. -/
-theorem reCanonical_all_factive :
-    reCanonical.all (·.factive) = true := by decide
+/-- All relative-canonical predicates are factive. [deal-2026] §3, §7. -/
+theorem relativeCanonical_all_factive :
+    relativeCanonical.all (·.factive) = true := by decide
 
 /-- The factive simplex-canonical predicates: exactly *cuukwe* 'know'. -/
 theorem factive_simplex_membership :
@@ -210,9 +210,9 @@ theorem factive_simplex_membership :
 theorem nonfactive_simplex_membership :
     simplexCanonical.filter (! ·.factive) = [neki, hi] := by decide
 
-/-- Factivity does not predict RE-canonical status: *cuukwe* 'know' is
+/-- Factivity does not predict relative-canonical status: *cuukwe* 'know' is
     factive but simplex-canonical ([deal-2026]'s central dissociation —
-    in Nez Perce factivity is necessary but not sufficient for RE
+    in Nez Perce factivity is necessary but not sufficient for relative-embedding
     morphosyntax). -/
 theorem cuukwe_factive_but_simplex :
     cuukwe.factive = true ∧ cuukwe ∈ simplexCanonical := by
@@ -256,4 +256,4 @@ theorem paradigm_membership :
     forms. -/
 theorem acc_pl_variants : rp_acc_pl.forms = ["konmana", "yox̂mene"] := rfl
 
-end NezPerce.ClausalEmbedding
+end NezPerce.Clause

--- a/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
+++ b/Linglib/Fragments/Tigrinya/ClausePrefixes.lean
@@ -73,7 +73,7 @@ def zi : ClausePrefixEntry where
 def ki : ClausePrefixEntry where
   form := "kɨ-"
   position := some .praefixed
-  noonanType := some .subjunctive
+  coding := some .subjunctive
   agrees := some true
   gloss := "SBJV"
   clauseType := .subjunctive
@@ -83,7 +83,7 @@ def ki : ClausePrefixEntry where
 def kemzi : ClausePrefixEntry where
   form := "kəmzi-"
   position := some .praefixed
-  noonanType := some .indicative
+  coding := some .indicative
   agrees := some false
   factive := some true
   gloss := "COMP.FACT"

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -61,7 +61,6 @@ def merakEt : TurkishVerbEntry where
   frames := [Frame.question]
   passivizable := false
   opaqueContext := true
-  takesQuestionBase := true
 
 /-- "endişelen-" — worry (Class 1: non-C-distributive). -/
 def endiselen : TurkishVerbEntry where

--- a/Linglib/Fragments/Uyghur/Complementizers.lean
+++ b/Linglib/Fragments/Uyghur/Complementizers.lean
@@ -61,7 +61,7 @@ subjects (his 49a) and factive complements (his 61a). -/
 def lik : Complementizer where
   form := "-lik"
   position := some .postfixed
-  noonanType := some .nominalized
+  coding := some .nominalized
 
 /-- The clause-linking morphemes at issue in [major-2024]: the two
 pieces of the say-complex plus the rival argument strategy's typer.

--- a/Linglib/Fragments/Washo/Clause.lean
+++ b/Linglib/Fragments/Washo/Clause.lean
@@ -1,0 +1,171 @@
+import Linglib.Features.Complementation
+
+/-!
+# Washo Clausal Embedding Inventory
+
+[bochnak-hanink-2021]
+
+Washo (Hokan/isolate, ISO 639-3 `was`) inventory of complement-taking
+predicates. Theory-light: each predicate carries its
+[noonan-2007] CTP class where clear, [bochnak-hanink-2021]'s
+*presuppositional* classification ((5); their §5.3.2 argues factivity is
+*not* lexically specified — complements of 'remember'/'know' can be
+false, (86)–(87) — so this field deliberately is not named `factive`),
+and one morphological observable — the shape of the complement edge.
+
+Forms follow the paper's orthography (after [jacobsen-1964]): `:` marks
+vowel length, ʔ ɨ ŋ are IPA, stress is acute. 'know' and 'remember'
+belong to a small inherently-negative class — the positive reading
+requires the negative suffix *-e:s*, and 'remember' is simply negated
+'forget' (their fn. 7).
+-/
+
+namespace Washo.Clause
+
+/-! ### Predicate schema -/
+
+/-- Morphological shape of a predicate's notional-complement edge
+    ([bochnak-hanink-2021] Table 1). The two morphemes co-vary without
+    exception in their data, so one two-valued observable is faithful;
+    there is no marginal cell. The *-gi ~ -ge* alternation is case
+    (nominative vs accusative, their fn. 6) conditioned by the
+    nominalization's matrix function — attitude complements are all
+    accusative *-ge*. -/
+inductive ComplementEdge where
+  /-- Clausal nominalization: nominalizer *-gi ~ -ge* over independent
+      mood *-i*. -/
+  | nominalized
+  /-- Bare clause: dependent mood *-aʔ*, never nominalized. -/
+  | bare
+  deriving DecidableEq, Repr
+
+/-- A Washo complement-taking predicate.
+
+    - `ctpClass`: [noonan-2007] category; `none` where the assignment
+      is unclear ('dream').
+    - `presuppositional`: [bochnak-hanink-2021] (5) — "the embedded
+      clause refers to familiar content" — their descriptive
+      classification, deliberately not `factive` (§5.3.2).
+    - `edge`: the complement-edge observable (Table 1). -/
+structure WashoEmbedder where
+  form : String
+  gloss : String
+  ctpClass : Option CTPClass
+  presuppositional : Bool
+  edge : ComplementEdge
+  deriving DecidableEq, Repr
+
+/-! ### Presuppositional predicates — nominalized complements
+
+[bochnak-hanink-2021] (5b), §2: complements are always nominalized with
+*-gi ~ -ge* and occur with the independent mood suffix *-i*. -/
+
+/-- *hamup'ay* 'forget'. [bochnak-hanink-2021] (1), (9), (31), (33). -/
+def hamupay : WashoEmbedder where
+  form := "hamup'ay"; gloss := "forget"
+  ctpClass := some .knowledge
+  presuppositional := true
+  edge := .nominalized
+
+/-- *hamup'ay-e:s* 'remember' — negated 'forget' (inherently-negative
+    class, fn. 7). [bochnak-hanink-2021] (8), (86). -/
+def hamupayEs : WashoEmbedder where
+  form := "hamup'ay-e:s"; gloss := "remember"
+  ctpClass := some .knowledge
+  presuppositional := true
+  edge := .nominalized
+
+/-- *ašaš-e:s* 'know' — negated 'not know' (inherently-negative class).
+    [bochnak-hanink-2021] (6), (32), (87). -/
+def ashashEs : WashoEmbedder where
+  form := "ašaš-e:s"; gloss := "know"
+  ctpClass := some .knowledge
+  presuppositional := true
+  edge := .nominalized
+
+/-- *i:gi* 'see'. Attested with a propositional complement ('I saw that
+    it rained', (10)) and with plain DP objects ((89)).
+    [bochnak-hanink-2021] (10), (20), (88). -/
+def iigi : WashoEmbedder where
+  form := "i:gi"; gloss := "see"
+  ctpClass := some .perception
+  presuppositional := true
+  edge := .nominalized
+
+/-- *damal* 'hear'. Attested only on the event-perception reading ('I
+    heard it raining', (11); 'I heard the man singing', (84b)).
+    [bochnak-hanink-2021] (11), (84). -/
+def damal : WashoEmbedder where
+  form := "damal"; gloss := "hear"
+  ctpClass := some .perception
+  presuppositional := true
+  edge := .nominalized
+
+/-! ### Non-presuppositional predicates — bare complements
+
+[bochnak-hanink-2021] (5a), §2: complements "surface with the
+'dependent' mood marker -aʔ" and "are never nominalized". -/
+
+/-- *hamu* 'think'. [bochnak-hanink-2021] (2), (13), (41), (42). -/
+def hamu : WashoEmbedder where
+  form := "hamu"; gloss := "think"
+  ctpClass := some .propAttitude
+  presuppositional := false
+  edge := .bare
+
+/-- *i:d* 'say'. [bochnak-hanink-2021] (14), (37), (50). -/
+def iid : WashoEmbedder where
+  form := "i:d"; gloss := "say"
+  ctpClass := some .utterance
+  presuppositional := false
+  edge := .bare
+
+/-- *mɨtgi:bɨl-e:s* 'believe' — negated 'disbelieve' (inherently-
+    negative class, fn. 7). [bochnak-hanink-2021] (16). -/
+def metgiibilEs : WashoEmbedder where
+  form := "mɨtgi:bɨl-e:s"; gloss := "believe"
+  ctpClass := some .propAttitude
+  presuppositional := false
+  edge := .bare
+
+/-- *gum-suʔuʔuš* 'dream' (reflexive *gum-*). Its 'that'-complement is
+    always bare ((15), (52), (54)); the nominalized complement of the
+    non-reflexive form is an internally headed relative, not a notional
+    complement ((55)). No clear [noonan-2007] class.
+    [bochnak-hanink-2021] §3.2.2. -/
+def gumsuus : WashoEmbedder where
+  form := "gum-suʔuʔuš"; gloss := "dream"
+  ctpClass := none
+  presuppositional := false
+  edge := .bare
+
+/-! ### Inventories -/
+
+/-- The complement-taking predicates with quotable per-predicate data in
+    [bochnak-hanink-2021]. -/
+def allEmbedders : List WashoEmbedder :=
+  [hamupay, hamupayEs, ashashEs, iigi, damal,
+   hamu, iid, metgiibilEs, gumsuus]
+
+/-- The predicates taking nominalized complements. -/
+def nominalizedTakers : List WashoEmbedder :=
+  allEmbedders.filter (·.edge == .nominalized)
+
+/-- The predicates taking bare complements. -/
+def bareTakers : List WashoEmbedder :=
+  allEmbedders.filter (·.edge == .bare)
+
+/-- Drift sentry: the nominalized-takers are exactly the five
+    presuppositional predicates. -/
+theorem nominalizedTakers_membership :
+    nominalizedTakers = [hamupay, hamupayEs, ashashEs, iigi, damal] := by
+  decide
+
+/-- [bochnak-hanink-2021] Table 1's correlation, stated exceptionless in
+    both directions: a predicate takes nominalized complements iff it is
+    presuppositional. -/
+theorem presuppositional_iff_nominalized :
+    ∀ v ∈ allEmbedders,
+      (v.presuppositional = true ↔ v.edge = .nominalized) := by decide
+
+end Washo.Clause

--- a/Linglib/Semantics/Composition/TypeShifting.lean
+++ b/Linglib/Semantics/Composition/TypeShifting.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Intensional.Defs
 import Linglib.Semantics.Quantification.Quantifier
 import Linglib.Semantics.Intensional.Conjunction
 import Linglib.Semantics.Modification.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Frame
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Data.Finset.Lattice.Fold
 

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -357,7 +357,7 @@ theorem ga_has_reflexive :
 
 /-- Gã complements in [noonan-2007]'s typology; `.infinitive` is §5.6's
     own term for the bare-root `ni`-complement. -/
-def gaToNoonan : EmbeddedClauseType → NoonanCompType
+def gaToNoonan : EmbeddedClauseType → Complement.Coding
   | .finiteAke  => .indicative
   | .finiteKeji => .indicative
   | .irrealisNi => .infinitive

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -493,10 +493,7 @@ and the say-root *gɘ* realizes neither. -/
 theorem hanaxa_frames_realized :
     hanaxa.realizes zha ∧
     hanaxa.realizes aasha ∧
-    ¬ hanaxa.realizes ge :=
-  ⟨⟨Frame.finiteClause, .head _, _, .head _, .indicative, rfl, rfl⟩,
-    ⟨nominalizedFrame, .tail _ (.head _), _, .head _, .nominalized, rfl, rfl⟩,
-    fun ⟨_, _, _, _, _, _, h⟩ => nomatch h⟩
+    ¬ hanaxa.realizes ge := by decide
 
 /-- *hanaxa* think~remember (§4.4.3): the attitude flips with the frame —
     nonveridical/opaque on the bare CP, veridical on the nominalized

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -1,21 +1,25 @@
-import Linglib.Fragments.NezPerce.ClausalEmbedding
+import Linglib.Fragments.Adyghe.Clause
+import Linglib.Fragments.Bulgarian.Clause
+import Linglib.Fragments.Ndebele.Clause
+import Linglib.Fragments.NezPerce.Clause
+import Linglib.Fragments.Washo.Clause
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 
 /-! # Deal (2026): Clausal complementation as relativization, revisited
 
 [deal-2026] argues that the relative-like notional complement clauses of
-Nez Perce ("relative embeddings", REs) are CPs containing an
+Nez Perce ("relative embeddings") are CPs containing an
 Ā-dependency launched above TP — not DPs or PPs. Clausal complementation
 is therefore not uniformly relativization ([kayne-2008], [kayne-2014],
-[arsenijevic-2009]), and factivity, RE-syntax, and nominalization
+[arsenijevic-2009]), and factivity, relative-embedding syntax, and nominalization
 dissociate cross-linguistically ((79)–(81)), though within Nez Perce all
-REs are factive. Formalized here: the (79) typology as extended clause
+relative embeddings are factive. Formalized here: the (79) typology as extended clause
 spines (`Minimalist.ClauseSpine`), with shell superstructure, bare-CP
 status, nominal-shell status, and the selected category all *derived*
 from each row's spine; the per-predicate embedding strategy derived from
 the Fragment's *yox̂ ke* edge observable; the factivity dissociations;
 and the case-inflection half of the *yox̂*-is-D diagnostic. Deal's
-c-selection point — RE-takers and simplex-takers alike select a CP, the
+c-selection point — relative-embedding takers and simplex-takers alike select a CP, the
 contrast being CP-internal — awaits LI-level Nez Perce entries
 (`Minimalist.SimpleLI` selection stacks).
 
@@ -27,7 +31,7 @@ contrast being CP-internal — awaits LI-level Nez Perce entries
   agreement is overt. Needs value-sensitive satisfaction and
   ordered-goal probing — `Minimalist.SatisfactionCond` matches feature
   types only.
-* §6 shift/tense: REs block indexical shift and take matrix-matching
+* §6 shift/tense: relative embeddings block indexical shift and take matrix-matching
   tense as temporal de re; simplex embeddings allow shift and relative
   tense. Rests on [deal-2025]'s clause-type semantics (world-set vs
   perspectival-tuple denotations), not yet implemented.
@@ -35,7 +39,7 @@ contrast being CP-internal — awaits LI-level Nez Perce entries
 
 namespace Deal2026
 
-open NezPerce.ClausalEmbedding
+open NezPerce.Clause
 open Minimalist (Cat ClauseSpine catFeatures)
 
 /-! ### Embedding strategy from the *yox̂ ke* edge
@@ -43,28 +47,28 @@ open Minimalist (Cat ClauseSpine catFeatures)
 The Fragment carries the morphological observable (`yoxKeEdge`); Deal's
 analytical classification is derived from it: obligatory *yox̂ ke* on
 the complement edge ↔ a syntactic Ā-dependency above TP inside the
-embedded CP. Both classes c-select a CP — the RE-vs-simplex contrast is
+embedded CP. Both classes c-select a CP — the relative-vs-simplex contrast is
 internal to the selected clause, not a c-selectional difference. -/
 
 /-- The two embedding strategies [deal-2026] distinguishes. -/
 inductive EmbeddingStrategy where
-  | re       -- relative embedding (yox̂ + ke + Ā-dep above TP)
+  | relative -- relative embedding (yox̂ + ke + Ā-dep above TP)
   | simplex  -- bare CP, no Ā-dep
   deriving DecidableEq, Repr
 
 /-- Deal's per-predicate embedding-strategy classification, derived from
     the Fragment observable. -/
 def nezPerceEmbedStrategy (v : NezPerceEmbedder) : EmbeddingStrategy :=
-  if v.yoxKeEdge = .obligatory then .re else .simplex
+  if v.yoxKeEdge = .obligatory then .relative else .simplex
 
-/-- A predicate is RE-canonical in Deal's analysis iff its complement
+/-- A predicate is relative-canonical in Deal's analysis iff its complement
     obligatorily carries the *yox̂ ke* edge morphology. -/
 theorem strategy_iff_yoxKe (v : NezPerceEmbedder) :
-    nezPerceEmbedStrategy v = .re ↔ v.yoxKeEdge = .obligatory := by
+    nezPerceEmbedStrategy v = .relative ↔ v.yoxKeEdge = .obligatory := by
   simp [nezPerceEmbedStrategy]
 
-theorem reCanonical_strategy :
-    ∀ v ∈ reCanonical, nezPerceEmbedStrategy v = .re := by decide
+theorem relativeCanonical_strategy :
+    ∀ v ∈ relativeCanonical, nezPerceEmbedStrategy v = .relative := by decide
 
 theorem simplexCanonical_strategy :
     ∀ v ∈ simplexCanonical, nezPerceEmbedStrategy v = .simplex := by decide
@@ -114,8 +118,8 @@ def nezPerceCell (construction : String) (v : NezPerceEmbedder) :
     ShellTypologyCell :=
   ⟨"Nez Perce", construction, ClauseSpine.cP, v.yoxKeEdge == .obligatory⟩
 
-/-- The Nez Perce RE row ([deal-2026] §3, §5). -/
-def nezPerceRE : ShellTypologyCell := nezPerceCell "RE" liloy
+/-- The Nez Perce relative-embedding row ([deal-2026] §3, §5). -/
+def nezPerceRelative : ShellTypologyCell := nezPerceCell "relative embedding" liloy
 
 /-- The Nez Perce simplex row ([deal-2026] §6). -/
 def nezPerceSimplex : ShellTypologyCell := nezPerceCell "simplex" neki
@@ -125,12 +129,16 @@ def nezPerceSimplex : ShellTypologyCell := nezPerceCell "simplex" neki
 def englishThink : ShellTypologyCell :=
   ⟨"English", "think-complement", ClauseSpine.cP, false⟩
 
-/-- The Adyghe RE row from [caponigro-polinsky-2011], exhibited at
-    [deal-2026] §4 (43): V D N CP with internal Ā. Deal cites Caponigro
-    & Polinsky as theoretical kin on the high origin of the operator
-    while diverging on the external shell. -/
-def adygheRE : ShellTypologyCell :=
-  ⟨"Adyghe", "RE", ClauseSpine.cP.extend [.N, .D], true⟩
+/-- The Adyghe relative-embedding row from [caponigro-polinsky-2011],
+    exhibited at [deal-2026] §4 (43): V D N CP with internal Ā. The
+    Ā-flag is derived from the Fragment observable — 'think' requires
+    the relativizer + high-applicative *ze-re-* on its tensed
+    complement. Deal cites Caponigro & Polinsky as theoretical kin on
+    the high origin of the operator while diverging on the external
+    shell. -/
+def adygheRelative : ShellTypologyCell :=
+  ⟨"Adyghe", "relative embedding", ClauseSpine.cP.extend [.N, .D],
+    Adyghe.Clause.gwepshesa.highApplicative == .required⟩
 
 /-- The English N-complementation row of (79)'s V D N CP / no-Ā cell
     (*the fact that S*) — the DP shell with an N co-argument envisioned
@@ -138,20 +146,34 @@ def adygheRE : ShellTypologyCell :=
 def englishNComplementation : ShellTypologyCell :=
   ⟨"English", "N-complementation", ClauseSpine.cP.extend [.N, .D], false⟩
 
-/-- The Bulgarian RE row from [krapova-2010], exhibited at
-    [deal-2026] §4 (49): V P D CP with internal Ā. -/
-def bulgarianRE : ShellTypologyCell :=
-  ⟨"Bulgarian", "RE", ClauseSpine.cP.extend [.D, .P], true⟩
+/-- The Bulgarian relative-embedding row from [krapova-2010], exhibited
+    at [deal-2026] §4 (49): V P D CP (*za* over demonstrative *tova*
+    over the *deto*-CP; both heads can be null) with internal Ā. The
+    Ā-flag is derived from the Fragment observable — *săžaljavam*
+    'regret' takes the *deto*-complement Krapova analyzes as a hidden
+    relative. -/
+def bulgarianRelative : ShellTypologyCell :=
+  ⟨"Bulgarian", "relative embedding", ClauseSpine.cP.extend [.D, .P],
+    Bulgarian.Clause.sazhaljavam.deto == .alternating⟩
 
-/-- The Ndebele row from [pietraszko-2019], exhibited at [deal-2026]
-    §7 (78): V P D CP with no Ā-dependency. -/
+/-- The Ndebele row, exhibited at [deal-2026] §7 (78): V P D CP with no
+    Ā-dependency. [pietraszko-2019]'s general claim is a *direct* DP
+    shell over the CP (class-15 augment = D over *kuthi*); the P here
+    is the independent preposition *nga* 'about' of the (78) exhibit
+    (her (20b), *khuluma nga*), so this row records the attested
+    P-over-DP combination, not the language's only shape. -/
 def ndebeleEmbedding : ShellTypologyCell :=
   ⟨"Ndebele", "embedding", ClauseSpine.cP.extend [.D, .P], false⟩
 
 /-- The Washo factive row from [bochnak-hanink-2021],
     [hanink-bochnak-2017]: V D CP, no Ā — not a row of (79);
     [deal-2026] fn. 33 notes the structure as "defended in the
-    literature" for Washo, with no known RE instance. -/
+    literature" for Washo, with no known relative-embedding instance.
+    The D is silent, with the nominalizer *-gi ~ -ge* spelling out a
+    separate idx head, and no intervening N ('fact'-nouns are
+    unattested in the language); the Fragment observable
+    (`Washo.Clause.hamupay.edge = .nominalized`) records the
+    nominalization this cell rests on. -/
 def washoFactive : ShellTypologyCell :=
   ⟨"Washo", "factive", ClauseSpine.cP.extend [.D], false⟩
 
@@ -159,8 +181,8 @@ def washoFactive : ShellTypologyCell :=
     filled, with V CP / no-Ā doubly witnessed — plus the Washo V D CP
     structure from footnote 33. -/
 def shellTypology : List ShellTypologyCell := [
-  nezPerceRE, nezPerceSimplex, englishThink, adygheRE,
-  englishNComplementation, bulgarianRE, ndebeleEmbedding, washoFactive
+  nezPerceRelative, nezPerceSimplex, englishThink, adygheRelative,
+  englishNComplementation, bulgarianRelative, ndebeleEmbedding, washoFactive
 ]
 
 /-- Not every row of (79) carries an internal Ā-dependency: the
@@ -170,14 +192,14 @@ def shellTypology : List ShellTypologyCell := [
 theorem not_all_rows_abar :
     ¬ ∀ c ∈ shellTypology, c.hasInternalAbar = true := by decide
 
-/-- Bare CPs occur with and without an internal Ā-dependency: REs are
+/-- Bare CPs occur with and without an internal Ā-dependency: relative embeddings are
     real, and not all complementation is relativization. -/
 theorem bareCP_abar_dissociates :
     (∃ c ∈ shellTypology, c.IsBareCP ∧ c.hasInternalAbar = true) ∧
     (∃ c ∈ shellTypology, c.IsBareCP ∧ c.hasInternalAbar = false) := by
   refine ⟨?_, ?_⟩ <;> decide
 
-/-- REs vary in nominal superstructure: some carry their Ā-dependency
+/-- relative embeddings vary in nominal superstructure: some carry their Ā-dependency
     inside a nominal shell (Adyghe V D N CP, Bulgarian V P D CP). -/
 theorem shelled_RE_attested :
     ∃ c ∈ shellTypology, c.HasNominalShell ∧
@@ -199,22 +221,25 @@ theorem selected_category_varies :
       c₁.spine.highestHead = .C ∧ c₂.spine.highestHead = .D ∧
       c₃.spine.highestHead = .P := by decide
 
-/-! ### Factivity and RE-syntax vary independently
+/-! ### Factivity and relative-embedding syntax vary independently
 
-[deal-2026] (80): factivity and RE-syntax dissociate — cross-
-linguistically the axes vary "independently to at least some extent",
-while within Nez Perce the entailment holds one way only (all REs are
-factive, `reCanonical_all_factive`; not all factives are REs). The
-fourth cell (non-factive + Ā) is Adyghe: Deal reports from
-[caponigro-polinsky-2011] p. 115 that Adyghe uses the RE strategy for
-all notional complementation regardless of factivity, so RE syntax does
-not ensure factivity. -/
+[deal-2026] (80): factivity and relative-embedding syntax dissociate —
+cross-linguistically the axes vary "independently to at least some
+extent", while within Nez Perce the entailment holds one way only (all
+relative embeddings are factive, `relativeCanonical_all_factive`; not
+all factives are relative embeddings). The fourth cell (non-factive +
+Ā) is Adyghe, where the relative strategy is required for all *tensed*
+notional complementation regardless of factivity
+([caponigro-polinsky-2011] §6.5, as Deal reports) — now witnessed from
+Fragment data (`nonfactive_relative_attested`). Bulgarian dissociates
+in the same direction as Nez Perce:
+`Bulgarian.Clause.factivity_not_sufficient_for_deto`. -/
 
 /-- Factivity does not coincide with the embedding strategy across the
     Fragment inventory. -/
 theorem factivity_not_strategy :
     ¬ ∀ v ∈ allEmbedders,
-      (v.factive = true ↔ nezPerceEmbedStrategy v = .re) := by decide
+      (v.factive = true ↔ nezPerceEmbedStrategy v = .relative) := by decide
 
 /-- The dissociating witness: a factive simplex-taker (*cuukwe*
     'know'). -/
@@ -222,18 +247,27 @@ theorem factive_simplex_attested :
     ∃ v ∈ allEmbedders,
       v.factive = true ∧ nezPerceEmbedStrategy v = .simplex := by decide
 
-/-- The co-occurring cell: a factive RE-taker (*lilooy* 'be happy'). -/
-theorem factive_re_attested :
+/-- The co-occurring cell: a factive relative-embedding taker
+    (*lilooy* 'be happy'). -/
+theorem factive_relative_attested :
     ∃ v ∈ allEmbedders,
-      v.factive = true ∧ nezPerceEmbedStrategy v = .re := by decide
+      v.factive = true ∧ nezPerceEmbedStrategy v = .relative := by decide
 
-/-! ### Projection does not distinguish RE from simplex
+/-- The fourth cell of (80) — non-factive + Ā — witnessed from Fragment
+    data: Adyghe 'think' is consensus-non-factive and requires *ze-re-*
+    on its tensed complement ([caponigro-polinsky-2011] (96) vs
+    (98)). -/
+theorem nonfactive_relative_attested :
+    ∃ v ∈ Adyghe.Clause.relativeTakers, v.factive = some false := by
+  decide
+
+/-! ### Projection does not distinguish relative from simplex
 
 Deal's factivity trials assess projection only — "in claiming that RE
 verbs are factive, what I claim is that their complement clause content
 is projective" (§3), in the [tonhauser-beaver-roberts-simons-2013]
 sense. On that dimension *cuukwe* and *lilooy* are indistinguishable;
-the RE-vs-simplex split lives at the embedding-strategy layer. -/
+the relative-vs-simplex split lives at the embedding-strategy layer. -/
 
 /-- The projection dimension does not distinguish *cuukwe* from
     *lilooy*: both are factive. -/

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -13,9 +13,20 @@ REs are factive. Formalized here: the CP-external shell inventory and
 the (79) shell typology; the per-predicate embedding strategy derived
 from the Fragment's *yox̂ ke* edge observable; the factivity
 dissociations; and the case-inflection half of the *yox̂*-is-D
-diagnostic. The *ke*-agreement analysis ([deal-2015a-nels]
-interaction–satisfaction) and the §6 shift/tense semantics
-([deal-2025]) await substrate — see the closing section.
+diagnostic.
+
+## TODO
+
+* *ke*-agreement ([deal-2026] §2, after [deal-2015a-nels]): the φ-probe
+  on C interacts with all φ-features, probing from the subject downward
+  until [addr] (second person) satisfies it; 1st/2nd but not 3rd person
+  agreement is overt. Needs value-sensitive satisfaction and
+  ordered-goal probing — `Minimalist.SatisfactionCond` matches feature
+  types only.
+* §6 shift/tense: REs block indexical shift and take matrix-matching
+  tense as temporal de re; simplex embeddings allow shift and relative
+  tense. Rests on [deal-2025]'s clause-type semantics (world-set vs
+  perspectival-tuple denotations), not yet implemented.
 -/
 
 namespace Deal2026
@@ -282,20 +293,5 @@ theorem strategy_cuukwe_ne_liloy :
 theorem paradigm_case_discriminates :
     ∀ p ∈ relativePronounParadigm, ∀ q ∈ relativePronounParadigm,
       p.case ≠ q.case → ∀ f ∈ p.forms, f ∉ q.forms := by decide
-
-/-! ### Awaiting substrate
-
-Two of the paper's core arguments are stated here only as deferrals.
-The *ke*-agreement analysis ([deal-2026] §2, following
-[deal-2015a-nels]): *ke*'s φ-probe interacts with all φ-features,
-probing from the subject downward until the feature [addr] (second
-person) is encountered, with 1st/2nd — but not 3rd — person agreement
-overt. Expressing this needs value-sensitive satisfaction (the current
-`Minimalist.SatisfactionCond` matches feature *types* only) and
-ordered-goal sequential probing. The §6 contrasts — REs block indexical
-shift and take matrix-matching tense as temporal de re, simplex
-embeddings allow shift and relative tense — rest on [deal-2025]'s
-semantics for the two clause types (world-set vs perspectival-tuple
-denotations), which linglib does not yet implement. -/
 
 end Deal2026

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -9,11 +9,15 @@ Nez Perce ("relative embeddings", REs) are CPs containing an
 is therefore not uniformly relativization ([kayne-2008], [kayne-2014],
 [arsenijevic-2009]), and factivity, RE-syntax, and nominalization
 dissociate cross-linguistically ((79)–(81)), though within Nez Perce all
-REs are factive. Formalized here: the CP-external shell inventory and
-the (79) shell typology; the per-predicate embedding strategy derived
-from the Fragment's *yox̂ ke* edge observable; the factivity
-dissociations; and the case-inflection half of the *yox̂*-is-D
-diagnostic.
+REs are factive. Formalized here: the (79) typology as extended clause
+spines (`Minimalist.ClauseSpine`), with shell superstructure, bare-CP
+status, nominal-shell status, and the selected category all *derived*
+from each row's spine; the per-predicate embedding strategy derived from
+the Fragment's *yox̂ ke* edge observable; the factivity dissociations;
+and the case-inflection half of the *yox̂*-is-D diagnostic. Deal's
+c-selection point — RE-takers and simplex-takers alike select a CP, the
+contrast being CP-internal — awaits LI-level Nez Perce entries
+(`Minimalist.SimpleLI` selection stacks).
 
 ## TODO
 
@@ -32,157 +36,15 @@ diagnostic.
 namespace Deal2026
 
 open NezPerce.ClausalEmbedding
-open Minimalist (Cat ClauseSpine)
-
-/-! ### CP-external shells
-
-The external-syntax axis of [deal-2026]'s (79): what wraps the embedded
-CP, innermost first. -/
-
-/-- A wrapping head above the embedded CP: [deal-2026]'s survey exhibits
-    D, N, and P shells ((79) and fn. 33). -/
-inductive Shell where
-  /-- D shell. -/
-  | d
-  /-- N shell (between D and CP). -/
-  | n
-  /-- P shell. -/
-  | p
-  deriving DecidableEq, Repr
-
-/-- The external wrapping above a CP, innermost first: `[]` = bare CP,
-`[.n, .d]` = D over N over CP, `[.d, .p]` = P over D over CP. -/
-abbrev ShellInventory := List Shell
-
-namespace ShellInventory
-
-/-- The bare-CP row of (79) (Nez Perce; English *think*). -/
-def bareCP : ShellInventory := []
-
-/-- V D CP: not a row of (79) — [deal-2026] fn. 33 notes the structure
-    as "defended in the literature" for Washo ([bochnak-hanink-2021]),
-    with no known RE instance. -/
-def dCP : ShellInventory := [.d]
-
-/-- The V D N CP row of (79) (Adyghe, [caponigro-polinsky-2011];
-    English N complementation, [hankamer-mikkelsen-2021]). -/
-def dnCP : ShellInventory := [.n, .d]
-
-/-- The V P D CP row of (79) (Bulgarian, [krapova-2010]; Ndebele,
-    [pietraszko-2019]). -/
-def pdCP : ShellInventory := [.d, .p]
-
-end ShellInventory
-
-open ShellInventory
-
-/-! ### Notional-complement shapes -/
-
-/-- The full Deal-2026 description of a notional complement clause:
-    internal spine + external shell + presence of an internal
-    Ā-dependency. Bundled here rather than in substrate to keep the
-    per-axis substrate primitive (`ClauseSpine`) reusable for non-Deal
-    accounts; the shell axis is Deal-specific and lives above. -/
-structure NotionalComplementShape where
-  /-- Internal spine of the embedded clause (typically `ClauseSpine.cP`). -/
-  internal : ClauseSpine
-  /-- External wrapping shells from C outward (`bareCP / dCP / dnCP / pdCP`). -/
-  external : ShellInventory
-  /-- Whether the embedded CP contains an internal Ā-dependency. -/
-  hasInternalAbar : Bool
-  deriving Repr
-
-/-- The Nez Perce shape of a given embedder, derived from the Fragment's
-    edge observable: a bare CP whose internal Ā-dependency is Deal's
-    interpretation of obligatory *yox̂ ke* edge morphology. -/
-def nezPerceShape (v : NezPerceEmbedder) : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, bareCP, v.yoxKeEdge == .obligatory⟩
-
-/-- The Nez Perce RE shape ([deal-2026] §3, §5). -/
-def nezPerceREShape : NotionalComplementShape := nezPerceShape liloy
-
-/-- The Nez Perce simplex shape ([deal-2026] §6). -/
-def nezPerceSimplexShape : NotionalComplementShape := nezPerceShape neki
-
-/-- The Adyghe RE shape from [caponigro-polinsky-2011], exhibited at
-    [deal-2026] §4 (43): V D N CP with internal Ā. Deal cites Caponigro
-    & Polinsky as theoretical kin on the high origin of the operator
-    while diverging on the external shell. -/
-def adygheREShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, dnCP, true⟩
-
-/-- The Bulgarian RE shape from [krapova-2010], exhibited at
-    [deal-2026] §4 (49): V P D CP with internal Ā. -/
-def bulgarianREShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, pdCP, true⟩
-
-/-- The Ndebele simplex shape from [pietraszko-2019], exhibited at
-    [deal-2026] §7 (78): V P D CP with no Ā-dependency. -/
-def ndebeleShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, pdCP, false⟩
-
-/-- The Washo factive shape from [bochnak-hanink-2021],
-    [hanink-bochnak-2017]: V D CP, no Ā ([deal-2026] fn. 33). -/
-def washoShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, dCP, false⟩
-
-/-- The English N-complementation shape of (79)'s V D N CP / no-Ā cell
-    (*the fact that S*) — the DP shell with an N co-argument envisioned
-    by [hankamer-mikkelsen-2021], as Deal notes in §7. -/
-def englishNComplementationShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, dnCP, false⟩
-
-/-! ### The cross-linguistic shell typology -/
-
-/-- An entry in [deal-2026]'s (79): a language × construction with its
-    NotionalComplementShape. -/
-structure ShellTypologyCell where
-  language : String
-  construction : String
-  shape : NotionalComplementShape
-  deriving Repr
-
-/-- The rows of [deal-2026]'s (79) — all six cells of the 3×2 table are
-    filled, with V CP / no-Ā doubly witnessed — plus the Washo V D CP
-    structure from footnote 33 per [bochnak-hanink-2021]. -/
-def shellTypology : List ShellTypologyCell := [
-  ⟨"Nez Perce", "RE",                nezPerceREShape⟩,
-  ⟨"Nez Perce", "simplex",           nezPerceSimplexShape⟩,
-  ⟨"English",   "think-complement",  nezPerceSimplexShape⟩,  -- bareCP, no Ā
-  ⟨"Adyghe",    "RE",                adygheREShape⟩,
-  ⟨"English",   "N-complementation", englishNComplementationShape⟩,
-  ⟨"Bulgarian", "RE",                bulgarianREShape⟩,
-  ⟨"Ndebele",   "embedding",         ndebeleShape⟩,
-  ⟨"Washo",     "factive",           washoShape⟩
-]
-
-/-- Not every row of (79) carries an internal Ā-dependency: the
-    universalist position that all clausal complementation is
-    relativization ([kayne-2008], [arsenijevic-2009]) fails on the no-Ā
-    rows (Nez Perce simplex, English *think*, Ndebele, Washo). -/
-theorem not_all_rows_abar :
-    ¬ ∀ c ∈ shellTypology, c.shape.hasInternalAbar = true := by decide
-
-/-- Bare CPs occur with and without an internal Ā-dependency: REs are
-    real, and not all complementation is relativization. -/
-theorem bareCP_abar_dissociates :
-    (∃ c ∈ shellTypology,
-      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = true) ∧
-    (∃ c ∈ shellTypology,
-      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) := by
-  refine ⟨?_, ?_⟩ <;> decide
-
-/-- REs vary in nominal superstructure: some carry their Ā-dependency
-    inside a D shell (Adyghe V D N CP, Bulgarian V P D CP). -/
-theorem shelled_RE_attested :
-    ∃ c ∈ shellTypology, Shell.d ∈ c.shape.external ∧
-      c.shape.hasInternalAbar = true := by decide
+open Minimalist (Cat ClauseSpine catFeatures)
 
 /-! ### Embedding strategy from the *yox̂ ke* edge
 
 The Fragment carries the morphological observable (`yoxKeEdge`); Deal's
-analytical commitments — the RE-vs-simplex classification and the
-selectional profile — are derived from it. -/
+analytical classification is derived from it: obligatory *yox̂ ke* on
+the complement edge ↔ a syntactic Ā-dependency above TP inside the
+embedded CP. Both classes c-select a CP — the RE-vs-simplex contrast is
+internal to the selected clause, not a c-selectional difference. -/
 
 /-- The two embedding strategies [deal-2026] distinguishes. -/
 inductive EmbeddingStrategy where
@@ -191,8 +53,7 @@ inductive EmbeddingStrategy where
   deriving DecidableEq, Repr
 
 /-- Deal's per-predicate embedding-strategy classification, derived from
-    the Fragment observable: obligatory *yox̂ ke* on the complement edge
-    ↔ syntactic Ā-dependency above TP. -/
+    the Fragment observable. -/
 def nezPerceEmbedStrategy (v : NezPerceEmbedder) : EmbeddingStrategy :=
   if v.yoxKeEdge = .obligatory then .re else .simplex
 
@@ -208,34 +69,135 @@ theorem reCanonical_strategy :
 theorem simplexCanonical_strategy :
     ∀ v ∈ simplexCanonical, nezPerceEmbedStrategy v = .simplex := by decide
 
-/-- Deal's selectional commitment for a Nez Perce embedder: the verb
-    c-selects a CP and (for RE-takers) requires that CP to contain an
-    internal Ā-dependency. This is not standard c-selection: c-selection
-    sees only the outer category, which is uniformly `.C`; the
-    RE-vs-simplex distinction is in the internal structure of the
-    selected CP — whether its head bears the [+Ā] feature triggering
-    operator movement above TP. -/
-structure DealSelectionalProfile where
-  /-- Outer category the verb c-selects for (always `.C` for embedders). -/
-  outerCat : Cat
-  /-- Whether the selected CP must contain an internal Ā-dependency. -/
-  requiresInternalAbar : Bool
-  deriving DecidableEq, Repr
+/-! ### The cross-linguistic shell typology
 
-/-- Deal's selectional analysis, derived from the Fragment observable. -/
-def dealSelectionalProfile (v : NezPerceEmbedder) : DealSelectionalProfile :=
-  { outerCat := .C, requiresInternalAbar := v.yoxKeEdge == .obligatory }
+[deal-2026]'s (79) describes each notional complement by its extended
+spine — the projected heads from V upward, *including* any nominal or
+adpositional superstructure over C. The shell vocabulary is derived:
+the shells are `spine.above .C`, bare-CP-hood is `highestHead = .C`, a
+nominal shell is a [+N] head above C ([chomsky-1970] features via
+`catFeatures`), and the category the matrix predicate selects is the
+spine's highest head. The internal-Ā axis remains a recorded datum
+(probe-bearing structure is not yet represented). -/
 
-/-- The selected CP requires an internal Ā-dependency iff *yox̂ ke* is
-    obligatory on the edge. -/
-theorem requiresInternalAbar_iff_yoxKe (v : NezPerceEmbedder) :
-    (dealSelectionalProfile v).requiresInternalAbar =
-      (v.yoxKeEdge == .obligatory) := rfl
+/-- A row of [deal-2026]'s (79): a language × construction with its
+    extended spine and internal-Ā status. -/
+structure ShellTypologyCell where
+  language : String
+  construction : String
+  /-- Projected heads of the notional complement, V up through any
+      CP-external shells. -/
+  spine : ClauseSpine
+  /-- Whether the embedded CP contains an internal Ā-dependency. -/
+  hasInternalAbar : Bool
+  deriving Repr
 
-/-- Every Nez Perce embedder uniformly c-selects `.C`: the RE-vs-simplex
-    contrast is not a c-selectional difference. -/
-theorem all_embedders_select_C (v : NezPerceEmbedder) :
-    (dealSelectionalProfile v).outerCat = .C := rfl
+/-- Nothing projects above C ((79)'s V CP row). -/
+def ShellTypologyCell.IsBareCP (c : ShellTypologyCell) : Prop :=
+  c.spine.highestHead = .C
+
+instance (c : ShellTypologyCell) : Decidable c.IsBareCP :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- The clause complex is wrapped in a nominal projection: some head
+    above C is [+N]. -/
+def ShellTypologyCell.HasNominalShell (c : ShellTypologyCell) : Prop :=
+  ∃ h ∈ c.spine.above .C, (catFeatures h).plusN = true
+
+instance (c : ShellTypologyCell) : Decidable c.HasNominalShell :=
+  inferInstanceAs (Decidable (∃ h ∈ c.spine.above .C, _))
+
+/-- A Nez Perce row, derived from the Fragment's edge observable: a bare
+    finite CP whose internal Ā-dependency is Deal's interpretation of
+    obligatory *yox̂ ke* edge morphology. -/
+def nezPerceCell (construction : String) (v : NezPerceEmbedder) :
+    ShellTypologyCell :=
+  ⟨"Nez Perce", construction, ClauseSpine.cP, v.yoxKeEdge == .obligatory⟩
+
+/-- The Nez Perce RE row ([deal-2026] §3, §5). -/
+def nezPerceRE : ShellTypologyCell := nezPerceCell "RE" liloy
+
+/-- The Nez Perce simplex row ([deal-2026] §6). -/
+def nezPerceSimplex : ShellTypologyCell := nezPerceCell "simplex" neki
+
+/-- English simplex V complementation (*think*): bare CP, no Ā
+    ((79)'s V CP row). -/
+def englishThink : ShellTypologyCell :=
+  ⟨"English", "think-complement", ClauseSpine.cP, false⟩
+
+/-- The Adyghe RE row from [caponigro-polinsky-2011], exhibited at
+    [deal-2026] §4 (43): V D N CP with internal Ā. Deal cites Caponigro
+    & Polinsky as theoretical kin on the high origin of the operator
+    while diverging on the external shell. -/
+def adygheRE : ShellTypologyCell :=
+  ⟨"Adyghe", "RE", ClauseSpine.cP.extend [.N, .D], true⟩
+
+/-- The English N-complementation row of (79)'s V D N CP / no-Ā cell
+    (*the fact that S*) — the DP shell with an N co-argument envisioned
+    by [hankamer-mikkelsen-2021], as Deal notes in §7. -/
+def englishNComplementation : ShellTypologyCell :=
+  ⟨"English", "N-complementation", ClauseSpine.cP.extend [.N, .D], false⟩
+
+/-- The Bulgarian RE row from [krapova-2010], exhibited at
+    [deal-2026] §4 (49): V P D CP with internal Ā. -/
+def bulgarianRE : ShellTypologyCell :=
+  ⟨"Bulgarian", "RE", ClauseSpine.cP.extend [.D, .P], true⟩
+
+/-- The Ndebele row from [pietraszko-2019], exhibited at [deal-2026]
+    §7 (78): V P D CP with no Ā-dependency. -/
+def ndebeleEmbedding : ShellTypologyCell :=
+  ⟨"Ndebele", "embedding", ClauseSpine.cP.extend [.D, .P], false⟩
+
+/-- The Washo factive row from [bochnak-hanink-2021],
+    [hanink-bochnak-2017]: V D CP, no Ā — not a row of (79);
+    [deal-2026] fn. 33 notes the structure as "defended in the
+    literature" for Washo, with no known RE instance. -/
+def washoFactive : ShellTypologyCell :=
+  ⟨"Washo", "factive", ClauseSpine.cP.extend [.D], false⟩
+
+/-- The rows of [deal-2026]'s (79) — all six cells of the 3×2 table are
+    filled, with V CP / no-Ā doubly witnessed — plus the Washo V D CP
+    structure from footnote 33. -/
+def shellTypology : List ShellTypologyCell := [
+  nezPerceRE, nezPerceSimplex, englishThink, adygheRE,
+  englishNComplementation, bulgarianRE, ndebeleEmbedding, washoFactive
+]
+
+/-- Not every row of (79) carries an internal Ā-dependency: the
+    universalist position that all clausal complementation is
+    relativization ([kayne-2008], [arsenijevic-2009]) fails on the no-Ā
+    rows (Nez Perce simplex, English *think*, Ndebele, Washo). -/
+theorem not_all_rows_abar :
+    ¬ ∀ c ∈ shellTypology, c.hasInternalAbar = true := by decide
+
+/-- Bare CPs occur with and without an internal Ā-dependency: REs are
+    real, and not all complementation is relativization. -/
+theorem bareCP_abar_dissociates :
+    (∃ c ∈ shellTypology, c.IsBareCP ∧ c.hasInternalAbar = true) ∧
+    (∃ c ∈ shellTypology, c.IsBareCP ∧ c.hasInternalAbar = false) := by
+  refine ⟨?_, ?_⟩ <;> decide
+
+/-- REs vary in nominal superstructure: some carry their Ā-dependency
+    inside a nominal shell (Adyghe V D N CP, Bulgarian V P D CP). -/
+theorem shelled_RE_attested :
+    ∃ c ∈ shellTypology, c.HasNominalShell ∧
+      c.hasInternalAbar = true := by decide
+
+/-- Every row's spine extends the same finite-CP core: the rows differ
+    only above C. -/
+theorem shared_cP_core :
+    ∀ c ∈ shellTypology,
+      ClauseSpine.cP.projectedHeads <+: c.spine.projectedHeads := by decide
+
+/-- The category the matrix predicate selects — the spine's highest
+    head — nonetheless varies across the rows: C, D, and P are all
+    attested. With `shared_cP_core`, this derives [deal-2026] §7's
+    moral: the internal syntax of a clause does not predict its
+    external syntax. -/
+theorem selected_category_varies :
+    ∃ c₁ ∈ shellTypology, ∃ c₂ ∈ shellTypology, ∃ c₃ ∈ shellTypology,
+      c₁.spine.highestHead = .C ∧ c₂.spine.highestHead = .D ∧
+      c₃.spine.highestHead = .P := by decide
 
 /-! ### Factivity and RE-syntax vary independently
 
@@ -248,24 +210,22 @@ fourth cell (non-factive + Ā) is Adyghe: Deal reports from
 all notional complementation regardless of factivity, so RE syntax does
 not ensure factivity. -/
 
-/-- Factivity does not coincide with RE-syntax across the Fragment
-    inventory. -/
-theorem factivity_not_abar :
+/-- Factivity does not coincide with the embedding strategy across the
+    Fragment inventory. -/
+theorem factivity_not_strategy :
     ¬ ∀ v ∈ allEmbedders,
-      v.factive = (nezPerceShape v).hasInternalAbar := by decide
+      (v.factive = true ↔ nezPerceEmbedStrategy v = .re) := by decide
 
-/-- The dissociating witness: a factive predicate whose shape carries no
-    internal Ā-dependency (*cuukwe* 'know'). -/
+/-- The dissociating witness: a factive simplex-taker (*cuukwe*
+    'know'). -/
 theorem factive_simplex_attested :
     ∃ v ∈ allEmbedders,
-      v.factive = true ∧ (nezPerceShape v).hasInternalAbar = false := by
-  decide
+      v.factive = true ∧ nezPerceEmbedStrategy v = .simplex := by decide
 
 /-- The co-occurring cell: a factive RE-taker (*lilooy* 'be happy'). -/
 theorem factive_re_attested :
     ∃ v ∈ allEmbedders,
-      v.factive = true ∧ (nezPerceShape v).hasInternalAbar = true := by
-  decide
+      v.factive = true ∧ nezPerceEmbedStrategy v = .re := by decide
 
 /-! ### Projection does not distinguish RE from simplex
 

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -1,98 +1,32 @@
 import Linglib.Fragments.NezPerce.ClausalEmbedding
-import Linglib.Syntax.Clause.Complementation
-import Linglib.Syntax.Minimalist.Probe.Satisfaction
-import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
-import Linglib.Semantics.Presupposition.ProjectiveContent
 
 /-! # Deal (2026): Clausal complementation as relativization, revisited
 
-[deal-2026]
-
-## Paper's central claims
-
-In Nez Perce, some but not all notional complement clauses show the
-characteristic morphology of relativization. [deal-2026] argues that the
-relative-like notional complement clauses ("relative embeddings", REs) are
-*CPs* — not DPs/PPs — containing an internal Ā-dependency from a *high
-functional projection above TP*. Three primary conclusions:
-
-1. Not all clausal complementation is relativization (refuting [kayne-2008],
-   [kayne-2014], [arsenijevic-2009]).
-2. Relative-like notional complement clauses vary across languages in nominal
-   superstructure ([deal-2026] (79): V CP / V D N CP / V P D CP) and in
-   factive inferences ((80)–(81)).
-3. Factivity, RE-syntax, and nominalization are *three orthogonal axes* — no
-   one entails another.
-
-## What this file contributes
-
-- The CP-external shell inventory (`Shell`, `ShellInventory`, the named
-  rows) and the bundled `NotionalComplementShape` analytical record
-  (Deal-specific apparatus per CLAUDE.md "paper-specific apparatus stays
-  in Studies").
-- The (79) sample: V CP / V D N CP / V P D CP rows for six languages.
-- The `nezPerceEmbedStrategy` projection: derives RE-vs-simplex from
-  Fragment-level Noonan/factivity data plus the Deal-analytical Ā-dep
-  presence flag.
-- *ke*-agreement as `Minimalist.SatisfactionCond.disjunctive`
-  ([deal-2015a-nels], [deal-2024] framework; bridge to
-  `Syntax/Minimalist/Agree.lean` §14).
-- Cross-classification theorems: factivity ⊥ RE-structure; factivity ⊥
-  nominalization.
-- Cross-framework comparison notes (HPSG modifier-only RC; Cacchioli 2025
-  Tigrinya in-system counterargument).
-
-## What this file does NOT contribute
-
-- §6 indexical-shift / sequence-of-tense formal predictions: deferred pending
-  a Kaplanian-context-shifting substrate (`[deal-2020]` book is the
-  reference theory). Existing `deal-2020` bib entry but no implementation
-  module.
-- A full HPSG-side bridge theorem: documented as silent divergence;
-  formalisation requires updating `HPSG/RelativeClauses.lean` to
-  parameterise its currently-hardcoded `MOD NP` analysis.
-- A `commentative`-emitting fix to `deriveCTPClass` in
-  `Studies/Noonan2007.lean`: blocked on
-  VerbEntry schema (regret and know have identical features in
-  `Fragments/English/Predicates/Verbal.lean`).
-
-## Disagreements documented but not formalised
-
-[kayne-2008], [kayne-2014], [arsenijevic-2009]: universalist
-position (all complementation = relativization). Deal 2026 §7 refutes by
-exhibiting bare-CP cells with no internal Ā-dependency.
-
-[decuba-2017]: opposing position — complement clauses are *never*
-relatives. Compatible with Deal 2026 for English simplex; incompatible
-with Deal for Adyghe/Bulgarian/Nez Perce REs.
-
-[hanink-bochnak-2017], [bochnak-hanink-2021]: Washo factive
-complementation as nominalization (V D CP). Deal 2026 §7 accepts this for
-Washo but refutes the universal extension to all factives — Nez Perce REs
-are factive without nominal superstructure.
-
-[moulton-2015]: CPs are predicates (type ⟨e, t⟩), not propositions
-(type t), composing with attitude verbs via predicate modification. This
-analysis is *orthogonal* to Deal 2026's typology — it concerns the semantic
-type of the embedded CP, not its external syntactic shell. The two analyses
-intersect on `barePropositionalCP` cells (Moulton's CP-predicate semantics
-applies most directly there) but Deal's `nominalization` cells (V D N CP,
-V P D CP) shift composition into the nominal layer where Moulton's
-predicate-modification mechanism may not directly apply.
+[deal-2026] argues that the relative-like notional complement clauses of
+Nez Perce ("relative embeddings", REs) are CPs containing an
+Ā-dependency launched above TP — not DPs or PPs. Clausal complementation
+is therefore not uniformly relativization ([kayne-2008], [kayne-2014],
+[arsenijevic-2009]), and factivity, RE-syntax, and nominalization
+dissociate cross-linguistically ((79)–(81)), though within Nez Perce all
+REs are factive. Formalized here: the CP-external shell inventory and
+the (79) shell typology; the per-predicate embedding strategy derived
+from the Fragment's *yox̂ ke* edge observable; the factivity
+dissociations; and the case-inflection half of the *yox̂*-is-D
+diagnostic. The *ke*-agreement analysis ([deal-2015a-nels]
+interaction–satisfaction) and the §6 shift/tense semantics
+([deal-2025]) await substrate — see the closing section.
 -/
 
 namespace Deal2026
 
 open NezPerce.ClausalEmbedding
-open Clause.Complementation
-open Semantics.Presupposition.ProjectiveContent (ProjectiveClass)
-open Minimalist (Cat SatisfactionCond AbarDep keineĀProbe ClauseSpine
-  hasValuedFeature FeatureBundle FeatureVal GramFeature ābar_is_Ā)
+open Minimalist (Cat ClauseSpine)
 
--- ============================================================================
--- §0. CP-external shell inventory — the shell axis of (79)
--- ============================================================================
+/-! ### CP-external shells
+
+The external-syntax axis of [deal-2026]'s (79): what wraps the embedded
+CP, innermost first. -/
 
 /-- A wrapping head above the embedded CP: [deal-2026]'s survey exhibits
     D, N, and P shells ((79) and fn. 33). -/
@@ -127,30 +61,17 @@ def dnCP : ShellInventory := [.n, .d]
     [pietraszko-2019]). -/
 def pdCP : ShellInventory := [.d, .p]
 
-/-- The clause complex is wrapped in a nominal projection: its shell
-    contains D (all rows Deal exhibits except `bareCP`). -/
-def hasNominalShell (inv : ShellInventory) : Prop := Shell.d ∈ inv
-
-instance : DecidablePred hasNominalShell :=
-  λ inv => inferInstanceAs (Decidable (Shell.d ∈ inv))
-
 end ShellInventory
 
 open ShellInventory
 
--- ============================================================================
--- §1. NotionalComplementShape — Deal-specific bundling
--- ============================================================================
+/-! ### Notional-complement shapes -/
 
-/-- The full Deal-2026 description of a notional complement clause: internal
-    spine + external shell + presence of internal Ā-dependency. Bundled here
-    rather than in substrate to keep the per-axis substrate primitives
-    (`ClauseSpine`, `AbarDep`) reusable for non-Deal accounts; the shell
-    axis is Deal-specific and lives in this file (§0).
-
-    The axes are independent in [deal-2026]'s (79): all six cells of its
-    3×2 cross-classification (CP-superstructure × ±Ā) are filled, and
-    fn. 33 adds the V D CP shell as a seventh defended structure. -/
+/-- The full Deal-2026 description of a notional complement clause:
+    internal spine + external shell + presence of an internal
+    Ā-dependency. Bundled here rather than in substrate to keep the
+    per-axis substrate primitive (`ClauseSpine`) reusable for non-Deal
+    accounts; the shell axis is Deal-specific and lives above. -/
 structure NotionalComplementShape where
   /-- Internal spine of the embedded clause (typically `ClauseSpine.cP`). -/
   internal : ClauseSpine
@@ -160,15 +81,22 @@ structure NotionalComplementShape where
   hasInternalAbar : Bool
   deriving Repr
 
-/-- The two Nez Perce shapes from [deal-2026] §3 vs §6. -/
-def nezPerceREShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, bareCP, true⟩
+/-- The Nez Perce shape of a given embedder, derived from the Fragment's
+    edge observable: a bare CP whose internal Ā-dependency is Deal's
+    interpretation of obligatory *yox̂ ke* edge morphology. -/
+def nezPerceShape (v : NezPerceEmbedder) : NotionalComplementShape :=
+  ⟨ClauseSpine.cP, bareCP, v.yoxKeEdge == .obligatory⟩
 
-def nezPerceSimplexShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, bareCP, false⟩
+/-- The Nez Perce RE shape ([deal-2026] §3, §5). -/
+def nezPerceREShape : NotionalComplementShape := nezPerceShape liloy
+
+/-- The Nez Perce simplex shape ([deal-2026] §6). -/
+def nezPerceSimplexShape : NotionalComplementShape := nezPerceShape neki
 
 /-- The Adyghe RE shape from [caponigro-polinsky-2011], exhibited at
-    [deal-2026] §4 (43): V D N CP with internal Ā. -/
+    [deal-2026] §4 (43): V D N CP with internal Ā. Deal cites Caponigro
+    & Polinsky as theoretical kin on the high origin of the operator
+    while diverging on the external shell. -/
 def adygheREShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, dnCP, true⟩
 
@@ -183,11 +111,7 @@ def ndebeleShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, pdCP, false⟩
 
 /-- The Washo factive shape from [bochnak-hanink-2021],
-    [hanink-bochnak-2017]: V D CP (D wraps CP, no intervening N).
-    [deal-2026] footnote 33 explicitly notes this structure as
-    "defended in the literature ... for Washo (Bochnak & Hanink 2021)"
-    but absent from (79) because no example language combines V D CP
-    with an internal Ā-dependency. We include the no-Ā version. -/
+    [hanink-bochnak-2017]: V D CP, no Ā ([deal-2026] fn. 33). -/
 def washoShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, dCP, false⟩
 
@@ -197,9 +121,7 @@ def washoShape : NotionalComplementShape :=
 def englishNComplementationShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, dnCP, false⟩
 
--- ============================================================================
--- §2. The (79) table — cross-linguistic sample
--- ============================================================================
+/-! ### The cross-linguistic shell typology -/
 
 /-- An entry in [deal-2026]'s (79): a language × construction with its
     NotionalComplementShape. -/
@@ -223,151 +145,33 @@ def shellTypology : List ShellTypologyCell := [
   ⟨"Washo",     "factive",           washoShape⟩
 ]
 
-/-- Drift sentry: `shellTypology` covers exactly the seven
-    (language, construction) pairs of (79) plus the Washo structure from
-    footnote 33. -/
-theorem shellTypology_membership :
-    shellTypology.map (λ c => (c.language, c.construction)) =
-      [("Nez Perce", "RE"), ("Nez Perce", "simplex"),
-       ("English",   "think-complement"),
-       ("Adyghe",    "RE"), ("English", "N-complementation"),
-       ("Bulgarian", "RE"),
-       ("Ndebele",   "embedding"), ("Washo", "factive")] := by decide
-
-/-- The Kayne-Arsenij\'evi\'c universalist hypothesis — that all clausal
-    complementation is relativization — stated on the Ā-axis: not every
-    row of (79) carries an internal Ā-dependency. (The retired surface-enum
-    version undercounted — Adyghe/Bulgarian REs DO relativize, inside a
-    nominal shell, and are not counterexamples; the counterexamples are the
-    no-Ā cells: Nez Perce simplex, English *think*, Ndebele, Washo.) -/
-theorem kayne_universalism_refuted :
+/-- Not every row of (79) carries an internal Ā-dependency: the
+    universalist position that all clausal complementation is
+    relativization ([kayne-2008], [arsenijevic-2009]) fails on the no-Ā
+    rows (Nez Perce simplex, English *think*, Ndebele, Washo). -/
+theorem not_all_rows_abar :
     ¬ ∀ c ∈ shellTypology, c.shape.hasInternalAbar = true := by decide
 
-/-- Deal 2026's positive contribution, on the two axes: bare CP + Ā attested
-    (REs are real); bare CP without Ā attested (not all complementation is
-    relativization); a nominal shell attested (consistent with prior
-    nominalization analyses for some languages). -/
-theorem shellTypology_axes_attested :
+/-- Bare CPs occur with and without an internal Ā-dependency: REs are
+    real, and not all complementation is relativization. -/
+theorem bareCP_abar_dissociates :
     (∃ c ∈ shellTypology,
       c.shape.external = bareCP ∧ c.shape.hasInternalAbar = true) ∧
     (∃ c ∈ shellTypology,
-      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) ∧
-    (∃ c ∈ shellTypology, hasNominalShell c.shape.external) := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) := by
+  refine ⟨?_, ?_⟩ <;> decide
 
-/-- The combination the surface enum could not express — claim 2: REs
-    vary in nominal superstructure (Adyghe V D N CP, Bulgarian V P D CP
-    carry Ā inside a nominal shell). -/
-theorem shelled_REs_attested :
-    ∃ c ∈ shellTypology, hasNominalShell c.shape.external ∧
+/-- REs vary in nominal superstructure: some carry their Ā-dependency
+    inside a D shell (Adyghe V D N CP, Bulgarian V P D CP). -/
+theorem shelled_RE_attested :
+    ∃ c ∈ shellTypology, Shell.d ∈ c.shape.external ∧
       c.shape.hasInternalAbar = true := by decide
 
--- ============================================================================
--- §2.5. Greek extension (cross-reference to [angelopoulos-2026])
--- ============================================================================
---
--- Deal's (79) doesn't include Greek. [angelopoulos-2026]
--- (NLLT 44:26) argues that Greek *pu*-complement clauses are bare CPs
--- (no nominalization shell) where the [n]-feature on C is checked by a
--- light noun in Spec,CP that incorporates into the matrix v_State head.
--- Critically, *pu* additionally surfaces as an adjunct, relative
--- pronoun, and interrogative pronoun *where* — uses where the
--- stativity restriction (paper §2.3) vanishes. The adjunct case is the
--- one Angelopoulos uses to refute the [bochnak-hanink-2021]
--- "selection limited to argument clauses" thesis: a *pu*-adjunct
--- selects its host (per [bruening-2013], [hewett-2023],
--- [hunter-2015], [neeleman-philip-tanaka-vandekoot-2023])
--- and so selection is bidirectional, not restricted to argument
--- positions. The refutation theorem itself lives in
--- `Studies/Angelopoulos2026.lean`
--- (`angelopoulos_refutes_selection_argument_only`); this file just
--- exposes the Greek *pu*-complement shape as a bare-CP no-Ā entry
--- to make the typology connection explicit.
+/-! ### Embedding strategy from the *yox̂ ke* edge
 
-/-- Greek *pu*-complement shape per [angelopoulos-2026]: bare CP
-    with no internal Ā-dependency and no nominal shell (Greek lacks
-    a silent situation noun, so *pu* cannot nominalize per paper §5).
-    The categorial [n]-feature on C is checked structurally (light
-    noun in Spec) rather than by a nominal shell — witnessing that
-    the (factive, bare-CP) combination is attested. -/
-def greekPuComplementShape : NotionalComplementShape :=
-  ⟨ClauseSpine.cP, bareCP, false⟩
-
--- ============================================================================
--- §3. Cross-Classification: factivity ⊥ RE-structure
--- ============================================================================
-
-/-! ### Headline orthogonality ([deal-2026] (80)–(81))
-
-The central typological discovery: factivity does not predict RE-structure
-in either direction.
-
-* Factive + RE-structure: Nez Perce REs (e.g. *liloy* 'be happy').
-* Factive + simplex: Nez Perce *cuukwe* 'know'.
-* Non-factive + RE-structure: Adyghe REs (per [caponigro-polinsky-2011]).
-* Non-factive + simplex: Nez Perce *neki/hi*; English *think*. -/
-
-/-- All four cells are attested: factivity neither necessitates nor precludes
-    RE-syntax. The `factive` flag is per [deal-2026] §3 projection-test
-    diagnoses. The Adyghe non-factive RE judgement is attributed to
-    [caponigro-polinsky-2011] via [deal-2026] §7 (80). -/
-theorem factivity_perp_re_structure :
-    -- Factive + RE: Nez Perce REs (e.g. liloy)
-    liloy.factive = true ∧ nezPerceREShape.hasInternalAbar = true ∧
-    -- Factive + simplex: Nez Perce cuukwe 'know'
-    cuukwe.factive = true ∧ nezPerceSimplexShape.hasInternalAbar = false ∧
-    -- Non-factive + simplex: Nez Perce neki 'think'
-    neki.factive = false ∧ nezPerceSimplexShape.hasInternalAbar = false := by
-  refine ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-! ### The fourth cell (non-factive + RE)
-
-Documented by [deal-2026] §7 ((80)) as instantiated by Adyghe per
-[caponigro-polinsky-2011]. Absent a formalised Adyghe Fragment, this is
-recorded as an unproven Lean claim: in linglib Adyghe is not yet present at
-Fragment level.
-
-TODO(adyghe-fragment): once `Fragments/Adyghe/ClausalEmbedding.lean` lands,
-replace this prose with a theorem `adyghe_re_nonfactive`. -/
-
--- ============================================================================
--- §4. Cross-Classification: factivity ⊥ nominalization
--- ============================================================================
-
-/-! ### [deal-2026] (81)
-
-* Factive + nominalization: Washo *forget* (per [hanink-bochnak-2017]).
-* Factive + no nominalization: Nez Perce REs (the headline Deal-2026 finding,
-  refuting the [hanink-bochnak-2017] universal extension).
-* Non-factive + nominalization: Turkish *düşün-* 'think' (per [deal-2026]
-  §7 citing Özyıldız 2017).
-* Non-factive + no nominalization: Washo, Nez Perce 'think'. -/
-
-/-- Nez Perce REs are factive without external nominal shell
-    (`bareCP = []` wraps nothing by construction). -/
-theorem nezPerce_re_factive_no_nominalization :
-    liloy.factive = true ∧
-    nezPerceREShape.external = bareCP := by
-  refine ⟨rfl, rfl⟩
-
--- ============================================================================
--- §5. Embedding-strategy projection from Fragment data
--- ============================================================================
-
-/-! ### Observable-driven derivation (Pattern B architecture)
-
-The Fragment carries a single morphological observable
-(`requiresYoxKeEdge : Bool`) per [deal-2026] §3 (28). Deal's two
-analytical commitments — the embedding-strategy classification and the
-selectional-feature stack — are *derived* from this observable, not
-stipulated alongside it. The derivation is the theory; the observable
-is the data.
-
-This pattern lets alternative theories provide alternative derivation
-functions over the same Fragment observable, making cross-theory
-divergence theorems expressible (currently only Deal's derivation is
-supplied; an Adyghe-style or Krapova-style derivation would be a
-straightforward sibling Studies file). -/
+The Fragment carries the morphological observable (`yoxKeEdge`); Deal's
+analytical commitments — the RE-vs-simplex classification and the
+selectional profile — are derived from it. -/
 
 /-- The two embedding strategies [deal-2026] distinguishes. -/
 inductive EmbeddingStrategy where
@@ -375,339 +179,123 @@ inductive EmbeddingStrategy where
   | simplex  -- bare CP, no Ā-dep
   deriving DecidableEq, Repr
 
-/-- Deal 2026's per-verb embedding-strategy classification, *derived* from
-    the Fragment-level observable `requiresYoxKeEdge`. The interpretation
-    is Deal's: morphological obligation of *yox̂ ke* on the complement
-    edge ↔ syntactic Ā-dependency above TP. The bi-conditional is
-    `strategy_iff_yoxKe` below — was previously trivially `rfl` over a
-    list-membership check, now expresses the genuine theory commitment. -/
+/-- Deal's per-predicate embedding-strategy classification, derived from
+    the Fragment observable: obligatory *yox̂ ke* on the complement edge
+    ↔ syntactic Ā-dependency above TP. -/
 def nezPerceEmbedStrategy (v : NezPerceEmbedder) : EmbeddingStrategy :=
-  if v.requiresYoxKeEdge then .re else .simplex
+  if v.yoxKeEdge = .obligatory then .re else .simplex
+
+/-- A predicate is RE-canonical in Deal's analysis iff its complement
+    obligatorily carries the *yox̂ ke* edge morphology. -/
+theorem strategy_iff_yoxKe (v : NezPerceEmbedder) :
+    nezPerceEmbedStrategy v = .re ↔ v.yoxKeEdge = .obligatory := by
+  simp [nezPerceEmbedStrategy]
+
+theorem reCanonical_strategy :
+    ∀ v ∈ reCanonical, nezPerceEmbedStrategy v = .re := by decide
+
+theorem simplexCanonical_strategy :
+    ∀ v ∈ simplexCanonical, nezPerceEmbedStrategy v = .simplex := by decide
 
 /-- Deal's selectional commitment for a Nez Perce embedder: the verb
-    c-selects a CP, and (for RE-takers) requires that CP to contain an
-    internal Ā-dependency above TP.
-
-    Note that Deal's analysis is *not* standard c-selection: c-selection
-    only sees the *outer* category of the complement, and both RE-takers
-    and simplex-takers c-select uniformly for `.C` (a CP). The RE-vs-simplex
-    distinction is in the *internal* structure of the selected CP —
-    whether its head bears the [+Ā] feature triggering operator movement
-    above TP. We separate the two by storing both the c-selectional
-    outer category and a Boolean flag for the internal-Ā requirement. -/
+    c-selects a CP and (for RE-takers) requires that CP to contain an
+    internal Ā-dependency. This is not standard c-selection: c-selection
+    sees only the outer category, which is uniformly `.C`; the
+    RE-vs-simplex distinction is in the internal structure of the
+    selected CP — whether its head bears the [+Ā] feature triggering
+    operator movement above TP. -/
 structure DealSelectionalProfile where
   /-- Outer category the verb c-selects for (always `.C` for embedders). -/
   outerCat : Cat
-  /-- Whether the selected CP must contain an internal Ā-dependency.
-      Maps to Deal's [+Ā] feature on the C head of the embedded clause. -/
+  /-- Whether the selected CP must contain an internal Ā-dependency. -/
   requiresInternalAbar : Bool
   deriving DecidableEq, Repr
 
-/-- Deal 2026's selectional analysis: derived entirely from the Fragment
-    observable `requiresYoxKeEdge`. The verb uniformly c-selects for a CP;
-    only the internal-Ā requirement varies between RE-takers and
-    simplex-takers. -/
+/-- Deal's selectional analysis, derived from the Fragment observable. -/
 def dealSelectionalProfile (v : NezPerceEmbedder) : DealSelectionalProfile :=
-  { outerCat := .C, requiresInternalAbar := v.requiresYoxKeEdge }
+  { outerCat := .C, requiresInternalAbar := v.yoxKeEdge == .obligatory }
 
-/-- The headline derivation theorem: a Nez Perce embedder is RE-canonical
-    in Deal's analysis iff its complement obligatorily carries the
-    *yox̂ ke* edge morphology. Replaces what was previously a trivial
-    `rfl` over membership in a hand-curated list. -/
-theorem strategy_iff_yoxKe (v : NezPerceEmbedder) :
-    nezPerceEmbedStrategy v = .re ↔ v.requiresYoxKeEdge = true := by
-  unfold nezPerceEmbedStrategy
-  cases v.requiresYoxKeEdge <;> simp
-
-/-- Deal's selectional analysis: an embedder selects for a CP with internal
-    Ā-dependency iff it requires *yox̂ ke* edge marking. -/
+/-- The selected CP requires an internal Ā-dependency iff *yox̂ ke* is
+    obligatory on the edge. -/
 theorem requiresInternalAbar_iff_yoxKe (v : NezPerceEmbedder) :
-    (dealSelectionalProfile v).requiresInternalAbar = v.requiresYoxKeEdge := rfl
+    (dealSelectionalProfile v).requiresInternalAbar =
+      (v.yoxKeEdge == .obligatory) := rfl
 
-/-- Every Nez Perce embedder uniformly c-selects for `.C`. The RE-vs-simplex
-    contrast is *not* a c-selectional difference — it lives in the internal
-    structure of the selected CP. -/
+/-- Every Nez Perce embedder uniformly c-selects `.C`: the RE-vs-simplex
+    contrast is not a c-selectional difference. -/
 theorem all_embedders_select_C (v : NezPerceEmbedder) :
     (dealSelectionalProfile v).outerCat = .C := rfl
 
-/-- Per-verb sanity checks (decidable lookup of the observable). -/
-theorem liloy_strategy : nezPerceEmbedStrategy liloy = .re := by decide
-theorem timiipni_strategy : nezPerceEmbedStrategy timiipni = .re := by decide
-theorem qeciyeewyew_strategy : nezPerceEmbedStrategy qeciyeewyew = .re := by decide
-theorem neki_strategy : nezPerceEmbedStrategy neki = .simplex := by decide
-theorem hi_strategy : nezPerceEmbedStrategy hi = .simplex := by decide
-theorem cuukwe_strategy : nezPerceEmbedStrategy cuukwe = .simplex := by decide
+/-! ### Factivity and RE-syntax vary independently
 
-/-- Per-verb selectional sanity. *liloy* selects a CP requiring internal Ā;
-    *neki* selects a bare CP. -/
-theorem liloy_selProfile :
-    dealSelectionalProfile liloy = { outerCat := .C, requiresInternalAbar := true } := rfl
-theorem neki_selProfile :
-    dealSelectionalProfile neki = { outerCat := .C, requiresInternalAbar := false } := rfl
+[deal-2026] (80): factivity and RE-syntax dissociate — cross-
+linguistically the axes vary "independently to at least some extent",
+while within Nez Perce the entailment holds one way only (all REs are
+factive, `reCanonical_all_factive`; not all factives are REs). The
+fourth cell (non-factive + Ā) is Adyghe: Deal reports from
+[caponigro-polinsky-2011] p. 115 that Adyghe uses the RE strategy for
+all notional complementation regardless of factivity, so RE syntax does
+not ensure factivity. -/
 
-/-- Every RE-canonical embedder gets `EmbeddingStrategy.re` (now follows
-    from the Fragment observable, not from list-membership). -/
-theorem reCanonical_strategy :
-    ∀ v ∈ reCanonical, nezPerceEmbedStrategy v = .re := by
-  intro v hv
-  rw [strategy_iff_yoxKe]
-  -- v ∈ reCanonical = v ∈ allEmbedders.filter (·.requiresYoxKeEdge)
-  -- so v.requiresYoxKeEdge = true
-  unfold reCanonical at hv
-  exact (List.mem_filter.mp hv).2
+/-- Factivity does not coincide with RE-syntax across the Fragment
+    inventory. -/
+theorem factivity_not_abar :
+    ¬ ∀ v ∈ allEmbedders,
+      v.factive = (nezPerceShape v).hasInternalAbar := by decide
 
--- ============================================================================
--- §5b. Tonhauser projective-content classification
--- ============================================================================
-
-/-! ### Bridge to [tonhauser-beaver-roberts-simons-2013] taxonomy
-
-The Tonhauser et al. classes are formalised in
-`Semantics/Presupposition/ProjectiveContent.lean` (`ProjectiveClass.classA`–
-`classD`). Factive predicates project as Class C (SCF=no, OLE=yes — the same
-class as English *know*). The Class C trigger `know_complement` is one of
-the listed examples (see `ProjectiveTrigger.know_complement`).
-
-Non-factive predicates introduce no projective content and so map to `none`. -/
-
-/-- Project a Nez Perce embedder onto the Tonhauser projective-content
-    taxonomy. Factive predicates map to Class C (the *know*-class);
-    non-factives have no projective content. -/
-def derivedProjectiveClass (v : NezPerceEmbedder) : Option ProjectiveClass :=
-  if v.factive then some .classC else none
-
-/-- All RE-canonical predicates project as Tonhauser Class C. This bridges
-    Deal's empirical Nez Perce data to the typed
-    [tonhauser-beaver-roberts-simons-2013] taxonomy. -/
-theorem reCanonical_projects_classC :
-    reCanonical.all (λ v => derivedProjectiveClass v = some .classC) = true := by
+/-- The dissociating witness: a factive predicate whose shape carries no
+    internal Ā-dependency (*cuukwe* 'know'). -/
+theorem factive_simplex_attested :
+    ∃ v ∈ allEmbedders,
+      v.factive = true ∧ (nezPerceShape v).hasInternalAbar = false := by
   decide
 
-/-- *cuukwe* 'know' projects as Class C — same projective class as
-    Deal-RE-canonical predicates, despite *cuukwe* being simplex-canonical.
-    Confirms factivity ⊥ RE-structure at the Tonhauser-substrate level. -/
-theorem cuukwe_projects_classC :
-    derivedProjectiveClass cuukwe = some .classC := by decide
+/-- The co-occurring cell: a factive RE-taker (*lilooy* 'be happy'). -/
+theorem factive_re_attested :
+    ∃ v ∈ allEmbedders,
+      v.factive = true ∧ (nezPerceShape v).hasInternalAbar = true := by
+  decide
 
-/-- *neki* 'think' has no projective content (non-factive). -/
-theorem neki_no_projection :
-    derivedProjectiveClass neki = none := by decide
+/-! ### Projection does not distinguish RE from simplex
 
--- ============================================================================
--- §5c. Cross-substrate bridges: Strategy ↔ Surface ↔ Tonhauser
--- ============================================================================
+Deal's factivity trials assess projection only — "in claiming that RE
+verbs are factive, what I claim is that their complement clause content
+is projective" (§3), in the [tonhauser-beaver-roberts-simons-2013]
+sense. On that dimension *cuukwe* and *lilooy* are indistinguishable;
+the RE-vs-simplex split lives at the embedding-strategy layer. -/
 
-/-! ### Bridges between four substrate layers
+/-- The projection dimension does not distinguish *cuukwe* from
+    *lilooy*: both are factive. -/
+theorem projective_cuukwe_eq_liloy : cuukwe.factive = liloy.factive := rfl
 
-The Studies file integrates four independent substrate layers:
-- Fragment: per-verb consensus typology (CTPClass, factive)
-- Tonhauser projective content: ProjectiveClass (Semantics/Presupposition/)
-- Deal-internal: EmbeddingStrategy + NotionalComplementShape
-- Shell/Ā axes: `ShellInventory` + `hasNominalShell` (§0 above)
-
-The bridge theorems below derive load-bearing predictions across these
-layers rather than stipulating them. -/
-
-/-- The analytical shape associated with each embedding strategy.
-    `re` predicates select `nezPerceREShape`; `simplex` predicates select
-    `nezPerceSimplexShape`. -/
-def EmbeddingStrategy.shape : EmbeddingStrategy → NotionalComplementShape
-  | .re => nezPerceREShape
-  | .simplex => nezPerceSimplexShape
-
-/-- Strategy-shape correspondence on the Ā-axis: the shape an embedder's
-    strategy selects carries an internal Ā-dependency exactly when the
-    Fragment observable holds. -/
-theorem strategy_shape_abar (v : NezPerceEmbedder) :
-    (nezPerceEmbedStrategy v).shape.hasInternalAbar = v.requiresYoxKeEdge := by
-  unfold nezPerceEmbedStrategy
-  cases v.requiresYoxKeEdge <;> rfl
-
-/-- All three RE rows of (79) (Nez Perce, Adyghe, Bulgarian) carry an
-    internal Ā-dependency. The shared `hasInternalAbar = true` is the
-    universal property of REs that survives Deal's typological dissolution. -/
-theorem all_REs_have_internal_abar :
-    nezPerceREShape.hasInternalAbar = true ∧
-    adygheREShape.hasInternalAbar = true ∧
-    bulgarianREShape.hasInternalAbar = true := by
-  refine ⟨rfl, rfl, rfl⟩
-
-/-- All three no-Ā simplex/embedding shapes (Nez Perce simplex, English
-    *think*, Ndebele, Washo factive) lack internal Ā. -/
-theorem all_simplex_lack_internal_abar :
-    nezPerceSimplexShape.hasInternalAbar = false ∧
-    ndebeleShape.hasInternalAbar = false ∧
-    washoShape.hasInternalAbar = false := by
-  refine ⟨rfl, rfl, rfl⟩
-
-/-- The four-cell cross-classification of (80)–(81) is exhaustively
-    populated: every combination of (factive, hasInternalAbar) is attested
-    by at least one (verb, shape) pair. The fourth cell (non-factive + Ā)
-    is documented from [caponigro-polinsky-2011]'s Adyghe REs as
-    cited by Deal — Adyghe REs combine `adygheREShape` (hasInternalAbar=true)
-    with predicates that are not factive in Caponigro & Polinsky's analysis
-    ([deal-2026] §7, (80); supporting prose p. 52). -/
-theorem cross_classification_populated :
-    -- Factive + Ā: liloy + nezPerceREShape
-    (liloy.factive = true ∧ nezPerceREShape.hasInternalAbar = true) ∧
-    -- Factive + no Ā: cuukwe + nezPerceSimplexShape (Nez Perce 'know')
-    (cuukwe.factive = true ∧ nezPerceSimplexShape.hasInternalAbar = false) ∧
-    -- Non-factive + Ā: documented for Adyghe REs (per Caponigro-Polinsky 2011)
-    (adygheREShape.hasInternalAbar = true) ∧
-    -- Non-factive + no Ā: neki + nezPerceSimplexShape ('think')
-    (neki.factive = false ∧ nezPerceSimplexShape.hasInternalAbar = false) := by
-  refine ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, rfl, ⟨rfl, rfl⟩⟩
-
--- ============================================================================
--- §5d. Discrimination at the Tonhauser layer
--- ============================================================================
-
-/-! ### What Tonhauser substrate alone CANNOT see
-
-The headline cross-classification's *fourth* cell (factive + simplex,
-Nez Perce *cuukwe*) and *first* cell (factive + RE, Nez Perce *liloy*)
-both project to Tonhauser Class C. The Tonhauser substrate alone cannot
-distinguish them — the distinction lives at the `EmbeddingStrategy` /
-`NotionalComplementShape` layer, not at the projective-content layer.
-
-This is informative: it shows that Deal's typology is *strictly finer-
-grained* than Tonhauser's, and motivates the need for substrate at the
-Probe / ClauseSpine layer (where the Ā-dep distinction is visible). -/
-
-/-- Tonhauser projective class does not distinguish *cuukwe* from *liloy*. -/
-theorem tonhauser_fails_to_distinguish_cuukwe_liloy :
-    derivedProjectiveClass cuukwe = derivedProjectiveClass liloy := by decide
-
-/-- But the embedding-strategy projection DOES distinguish them. -/
-theorem strategy_distinguishes_cuukwe_liloy :
+/-- The embedding-strategy layer does distinguish them. -/
+theorem strategy_cuukwe_ne_liloy :
     nezPerceEmbedStrategy cuukwe ≠ nezPerceEmbedStrategy liloy := by decide
 
--- ============================================================================
--- §6. ke-agreement via SatisfactionCond
--- ============================================================================
+/-! ### The D-inflection diagnostic -/
 
-/-! ### *ke* as a φ-probe on C ([deal-2015a-nels])
+/-- The relative pronoun *yox̂/ko* inflects for case: cells with distinct
+    cases share no forms. This is the case-inflection half of
+    [deal-2026] §2's diagnostic ((21)) that *yox̂/ko* is a D while
+    invariant *ke* is a C — the D half of the *yox̂ ke* edge whose
+    obligatoriness `yoxKeEdge` records. -/
+theorem paradigm_case_discriminates :
+    ∀ p ∈ relativePronounParadigm, ∀ q ∈ relativePronounParadigm,
+      p.case ≠ q.case → ∀ f ∈ p.forms, f ∉ q.forms := by decide
 
-[deal-2026] §2 argues *ke* is a C-head with a φ-probe rather than a
-relative pronoun. The argument: *ke*'s φ-features track the embedded
-*subject* (sometimes plus object), starting from the highest argument and
-proceeding down — exactly the [deal-2015a-nels] interaction-satisfaction
-algorithm probing into c-command domain.
+/-! ### Awaiting substrate
 
-The C-probe is satisfied either by feature-match (yielding overt person
-agreement) or by encountering the TP boundary (yielding null surface
-agreement). We model this with [deal-2024]'s `SatisfactionCond.disjunctive`.
-
-Caveat: the existing `Agree.lean` `featuresMatch` uses `sameType` matching
-(see `Agree.lean:234`), which collapses 1st/2nd/3rd person into a single
-"person feature type." A finer-grained `valueMatch` substrate would be
-needed to formalise Deal's 1st vs 3rd person split. The disjunctive shape
-here is faithful to the framework but currently distinguishes only
-"person-feature-present" vs "no-feature-encountered-T." -/
-
-
-/-- *ke*'s satisfaction condition: matched by any φ-feature (collapsed by
-    `sameType` regardless of person value), or by encountering the TP head. -/
-def keSatisfaction : SatisfactionCond :=
-  .disjunctive
-    [ .featureMatch (.phi (.person .third))
-    , .headEncounter .T ]
-
-/-- *ke* is satisfied by a subject bearing person features (any person, due to
-    `sameType` matching in Agree.lean). -/
-theorem ke_satisfied_by_phi :
-    keSatisfaction.isSatisfied
-      (.ofGramFeatures [.valued (.phi (.person .first))])
-      none = true := by decide
-
-/-- *ke* is satisfied by encountering the TP boundary even with no φ-features
-    on the goal — the disjunctive escape that yields null surface agreement. -/
-theorem ke_satisfied_by_head_encounter :
-    keSatisfaction.isSatisfied ⊥ (some .T) = true := by decide
-
-/-- The head-encounter satisfaction copies no features (default null surface
-    agreement when subject lacks φ). -/
-theorem ke_head_encounter_no_copy :
-    keSatisfaction.copiedFeatures ⊥ (some .T) = false := by decide
-
--- ============================================================================
--- §7. Internal-Ā-dependency profile
--- ============================================================================
-
-/-! ### REs contain a high Ā-dependency ([deal-2026] §5)
-
-Deal §5 argues the relative operator originates *above TP* — a high
-functional projection — based on absence of low-position cyclic effects
-and the always-nominative form of the relative pronoun. We attach the
-existing `keineĀDep` (Ā-probe on C, fValue 6) as the substrate witness;
-the alternative `low` analysis (Aboh's Gungbe lexical-Ā) is documented
-but not formalised. -/
-
-/-- A Nez Perce RE's internal Ā-dependency is — in Probe-substrate terms —
-    `Minimalist.keineĀDep` (the substrate witness defined in `Probe.lean §4b`).
-    Deal's "high functional projection above TP" claim falls out of
-    `Minimalist.keineĀDep_isHigh` without re-stipulation here. -/
-abbrev reInternalAbar : AbarDep := Minimalist.keineĀDep
-
-/-- The Nez Perce RE Ā-dependency is "high" in Deal's sense: above TP.
-    Inherited directly from the substrate theorem, no re-proof. -/
-theorem reInternalAbar_isHigh : reInternalAbar.isHigh = true :=
-  Minimalist.keineĀDep_isHigh
-
--- ============================================================================
--- §8. Cross-framework comparison
--- ============================================================================
-
-/-! ### Silent divergence with HPSG
-
-`Syntax/HPSG/RelativeClauses.lean:87-93` hard-codes RC =
-modifier (`isMod = true`, theorem `relClause_is_modifier`). [deal-2026]'s
-analysis of Nez Perce REs as *complement* CPs (not modifier RCs) sits
-incompatibly with this Minimalist-only framing: HPSG would either need to
-recognise REs as a third structural type (not modifier, not bare
-complementation), or accept that the RE-vs-RC distinction is a
-Minimalist-internal one with no HPSG analogue. The bridge theorem
-`HPSG.isMod ↔ ¬ Minimalist.cp_complementation_via_re` is filed as future
-work — promoted from "implicit assumption" to a substrate question.
-
-### Healthy convergence with Cacchioli 2025
-
-`Studies/Cacchioli2025.lean` independently
-establishes that Tigrinya distinguishes *kemzi* (factive complementizer)
-from *zi* (relativizer/general subordinator) without syncretism. This is a
-language-internal counterargument to the universalist
-"complementation = relativization" claim, parallel to [deal-2026]'s
-Nez Perce-internal contrast between simplex (no *yox̂ ke*) and RE (with
-*yox̂ ke*) embeddings. The two papers reinforce each other across distinct
-language families.
-
-### Convergence with Caponigro & Polinsky 2011
-
-[caponigro-polinsky-2011]'s Adyghe analysis shares Deal's "high Ā
-origin" claim while diverging on the V D N CP shell shape. Deal 2026 §5
-explicitly cites Caponigro & Polinsky as theoretical kin. -/
-
--- ============================================================================
--- §9. Indexical shift and SoT (deferred)
--- ============================================================================
-
-/-! ### §6 indexical shift / SoT formalisation deferred
-
-[deal-2026] §6 establishes that REs block shifty pronouns and require
-matching tense (vs. simplex embeddings where shift and relative-tense are
-both available). The semantic substrate for these claims is
-[deal-2020]'s `A Theory of Indexical Shift` book; that substrate is
-not yet implemented in linglib (no `Semantics/IndexicalShift/`
-directory exists; existing `Semantics/Reference/{ShiftedIndexicals,
-Monsters,Kaplan}.lean` cover Kaplanian framing but not Deal's Σ-monsters
-specifically).
-
-Until the substrate lands, the §6 contrasts can only be documented in
-prose. Decide-checking a `shiftedReading? : Sentence → Bool = false`
-predicate would be the "encoding conclusions as definitions" anti-pattern.
-
-Future work: import `deal-2020` substrate (when implemented) and prove
-`re_blocks_shift : ∀ p ∈ reCanonical, p.allowsShift = false` against actual
-indexical-shift semantics. -/
+Two of the paper's core arguments are stated here only as deferrals.
+The *ke*-agreement analysis ([deal-2026] §2, following
+[deal-2015a-nels]): *ke*'s φ-probe interacts with all φ-features,
+probing from the subject downward until the feature [addr] (second
+person) is encountered, with 1st/2nd — but not 3rd — person agreement
+overt. Expressing this needs value-sensitive satisfaction (the current
+`Minimalist.SatisfactionCond` matches feature *types* only) and
+ordered-goal sequential probing. The §6 contrasts — REs block indexical
+shift and take matrix-matching tense as temporal de re, simplex
+embeddings allow shift and relative tense — rest on [deal-2025]'s
+semantics for the two clause types (world-set vs perspectival-tuple
+denotations), which linglib does not yet implement. -/
 
 end Deal2026

--- a/Linglib/Studies/Deal2026.lean
+++ b/Linglib/Studies/Deal2026.lean
@@ -20,16 +20,18 @@ functional projection above TP*. Three primary conclusions:
 1. Not all clausal complementation is relativization (refuting [kayne-2008],
    [kayne-2014], [arsenijevic-2009]).
 2. Relative-like notional complement clauses vary across languages in nominal
-   superstructure ([deal-2026] Table 79: V CP / V D N CP / V P D CP) and in
-   factive inferences (Tables 80–81).
+   superstructure ([deal-2026] (79): V CP / V D N CP / V P D CP) and in
+   factive inferences ((80)–(81)).
 3. Factivity, RE-syntax, and nominalization are *three orthogonal axes* — no
    one entails another.
 
 ## What this file contributes
 
-- The bundled `NotionalComplementShape` analytical record (Deal-specific
-  apparatus per CLAUDE.md "paper-specific apparatus stays in Studies").
-- Table 79 sample: V CP / V D N CP / V P D CP cells for five languages.
+- The CP-external shell inventory (`Shell`, `ShellInventory`, the named
+  rows) and the bundled `NotionalComplementShape` analytical record
+  (Deal-specific apparatus per CLAUDE.md "paper-specific apparatus stays
+  in Studies").
+- The (79) sample: V CP / V D N CP / V P D CP rows for six languages.
 - The `nezPerceEmbedStrategy` projection: derives RE-vs-simplex from
   Fragment-level Noonan/factivity data plus the Deal-analytical Ā-dep
   presence flag.
@@ -84,10 +86,57 @@ namespace Deal2026
 
 open NezPerce.ClausalEmbedding
 open Clause.Complementation
-open Slot.ShellInventory
 open Semantics.Presupposition.ProjectiveContent (ProjectiveClass)
 open Minimalist (Cat SatisfactionCond AbarDep keineĀProbe ClauseSpine
   hasValuedFeature FeatureBundle FeatureVal GramFeature ābar_is_Ā)
+
+-- ============================================================================
+-- §0. CP-external shell inventory — the shell axis of (79)
+-- ============================================================================
+
+/-- A wrapping head above the embedded CP: [deal-2026]'s survey exhibits
+    D, N, and P shells ((79) and fn. 33). -/
+inductive Shell where
+  /-- D shell. -/
+  | d
+  /-- N shell (between D and CP). -/
+  | n
+  /-- P shell. -/
+  | p
+  deriving DecidableEq, Repr
+
+/-- The external wrapping above a CP, innermost first: `[]` = bare CP,
+`[.n, .d]` = D over N over CP, `[.d, .p]` = P over D over CP. -/
+abbrev ShellInventory := List Shell
+
+namespace ShellInventory
+
+/-- The bare-CP row of (79) (Nez Perce; English *think*). -/
+def bareCP : ShellInventory := []
+
+/-- V D CP: not a row of (79) — [deal-2026] fn. 33 notes the structure
+    as "defended in the literature" for Washo ([bochnak-hanink-2021]),
+    with no known RE instance. -/
+def dCP : ShellInventory := [.d]
+
+/-- The V D N CP row of (79) (Adyghe, [caponigro-polinsky-2011];
+    English N complementation, [hankamer-mikkelsen-2021]). -/
+def dnCP : ShellInventory := [.n, .d]
+
+/-- The V P D CP row of (79) (Bulgarian, [krapova-2010]; Ndebele,
+    [pietraszko-2019]). -/
+def pdCP : ShellInventory := [.d, .p]
+
+/-- The clause complex is wrapped in a nominal projection: its shell
+    contains D (all rows Deal exhibits except `bareCP`). -/
+def hasNominalShell (inv : ShellInventory) : Prop := Shell.d ∈ inv
+
+instance : DecidablePred hasNominalShell :=
+  λ inv => inferInstanceAs (Decidable (Shell.d ∈ inv))
+
+end ShellInventory
+
+open ShellInventory
 
 -- ============================================================================
 -- §1. NotionalComplementShape — Deal-specific bundling
@@ -95,17 +144,18 @@ open Minimalist (Cat SatisfactionCond AbarDep keineĀProbe ClauseSpine
 
 /-- The full Deal-2026 description of a notional complement clause: internal
     spine + external shell + presence of internal Ā-dependency. Bundled here
-    rather than in substrate to keep the per-axis primitives reusable
-    (`ClauseSpine`, `Slot.ShellInventory`, `AbarDep`) for non-Deal accounts.
+    rather than in substrate to keep the per-axis substrate primitives
+    (`ClauseSpine`, `AbarDep`) reusable for non-Deal accounts; the shell
+    axis is Deal-specific and lives in this file (§0).
 
-    The three axes are independent in [deal-2026] Table 79: each cell
-    in the 4×2 cross-classification (CP-superstructure × ±Ā) is filled or
-    explicitly noted as predicted-but-unattested. -/
+    The axes are independent in [deal-2026]'s (79): all six cells of its
+    3×2 cross-classification (CP-superstructure × ±Ā) are filled, and
+    fn. 33 adds the V D CP shell as a seventh defended structure. -/
 structure NotionalComplementShape where
   /-- Internal spine of the embedded clause (typically `ClauseSpine.cP`). -/
   internal : ClauseSpine
   /-- External wrapping shells from C outward (`bareCP / dCP / dnCP / pdCP`). -/
-  external : Slot.ShellInventory
+  external : ShellInventory
   /-- Whether the embedded CP contains an internal Ā-dependency. -/
   hasInternalAbar : Bool
   deriving Repr
@@ -134,77 +184,89 @@ def ndebeleShape : NotionalComplementShape :=
 
 /-- The Washo factive shape from [bochnak-hanink-2021],
     [hanink-bochnak-2017]: V D CP (D wraps CP, no intervening N).
-    [deal-2026] footnote 33 explicitly notes this cell as attested
-    "for example, for Washo (Bochnak & Hanink 2021)" but absent from
-    the main Table 79 because no example language combines V D CP with
-    an internal Ā-dependency. We include the no-Ā version. -/
+    [deal-2026] footnote 33 explicitly notes this structure as
+    "defended in the literature ... for Washo (Bochnak & Hanink 2021)"
+    but absent from (79) because no example language combines V D CP
+    with an internal Ā-dependency. We include the no-Ā version. -/
 def washoShape : NotionalComplementShape :=
   ⟨ClauseSpine.cP, dCP, false⟩
 
+/-- The English N-complementation shape of (79)'s V D N CP / no-Ā cell
+    (*the fact that S*) — the DP shell with an N co-argument envisioned
+    by [hankamer-mikkelsen-2021], as Deal notes in §7. -/
+def englishNComplementationShape : NotionalComplementShape :=
+  ⟨ClauseSpine.cP, dnCP, false⟩
+
 -- ============================================================================
--- §2. Table 79 — Cross-Linguistic Sample
+-- §2. The (79) table — cross-linguistic sample
 -- ============================================================================
 
-/-- An entry in [deal-2026] Table 79: a language × construction with its
+/-- An entry in [deal-2026]'s (79): a language × construction with its
     NotionalComplementShape. -/
-structure Table79Cell where
+structure ShellTypologyCell where
   language : String
   construction : String
   shape : NotionalComplementShape
   deriving Repr
 
-/-- The seven attested Table-79 cells (Deal 2026 main Table 79 + Washo cell
-    from footnote 33 per [bochnak-hanink-2021]). -/
-def table79 : List Table79Cell := [
+/-- The rows of [deal-2026]'s (79) — all six cells of the 3×2 table are
+    filled, with V CP / no-Ā doubly witnessed — plus the Washo V D CP
+    structure from footnote 33 per [bochnak-hanink-2021]. -/
+def shellTypology : List ShellTypologyCell := [
   ⟨"Nez Perce", "RE",                nezPerceREShape⟩,
   ⟨"Nez Perce", "simplex",           nezPerceSimplexShape⟩,
   ⟨"English",   "think-complement",  nezPerceSimplexShape⟩,  -- bareCP, no Ā
   ⟨"Adyghe",    "RE",                adygheREShape⟩,
+  ⟨"English",   "N-complementation", englishNComplementationShape⟩,
   ⟨"Bulgarian", "RE",                bulgarianREShape⟩,
   ⟨"Ndebele",   "embedding",         ndebeleShape⟩,
   ⟨"Washo",     "factive",           washoShape⟩
 ]
 
-/-- Drift sentry: `table79` covers exactly the seven (language, construction)
-    pairs Deal lists in §7 main Table 79 plus the Washo cell from footnote 33. -/
-theorem table79_membership :
-    table79.map (λ c => (c.language, c.construction)) =
+/-- Drift sentry: `shellTypology` covers exactly the seven
+    (language, construction) pairs of (79) plus the Washo structure from
+    footnote 33. -/
+theorem shellTypology_membership :
+    shellTypology.map (λ c => (c.language, c.construction)) =
       [("Nez Perce", "RE"), ("Nez Perce", "simplex"),
        ("English",   "think-complement"),
-       ("Adyghe",    "RE"), ("Bulgarian", "RE"),
+       ("Adyghe",    "RE"), ("English", "N-complementation"),
+       ("Bulgarian", "RE"),
        ("Ndebele",   "embedding"), ("Washo", "factive")] := by decide
 
 /-- The Kayne-Arsenij\'evi\'c universalist hypothesis — that all clausal
     complementation is relativization — stated on the Ā-axis: not every
-    Table 79 cell carries an internal Ā-dependency. (The retired surface-enum
+    row of (79) carries an internal Ā-dependency. (The retired surface-enum
     version undercounted — Adyghe/Bulgarian REs DO relativize, inside a
     nominal shell, and are not counterexamples; the counterexamples are the
     no-Ā cells: Nez Perce simplex, English *think*, Ndebele, Washo.) -/
 theorem kayne_universalism_refuted :
-    ¬ ∀ c ∈ table79, c.shape.hasInternalAbar = true := by decide
+    ¬ ∀ c ∈ shellTypology, c.shape.hasInternalAbar = true := by decide
 
 /-- Deal 2026's positive contribution, on the two axes: bare CP + Ā attested
     (REs are real); bare CP without Ā attested (not all complementation is
     relativization); a nominal shell attested (consistent with prior
     nominalization analyses for some languages). -/
-theorem table79_axes_attested :
-    (∃ c ∈ table79, c.shape.external = bareCP ∧ c.shape.hasInternalAbar = true) ∧
-    (∃ c ∈ table79, c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) ∧
-    (∃ c ∈ table79, hasNominalShell c.shape.external) := by
+theorem shellTypology_axes_attested :
+    (∃ c ∈ shellTypology,
+      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = true) ∧
+    (∃ c ∈ shellTypology,
+      c.shape.external = bareCP ∧ c.shape.hasInternalAbar = false) ∧
+    (∃ c ∈ shellTypology, hasNominalShell c.shape.external) := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
 /-- The combination the surface enum could not express — claim 2: REs
     vary in nominal superstructure (Adyghe V D N CP, Bulgarian V P D CP
     carry Ā inside a nominal shell). -/
 theorem shelled_REs_attested :
-    ∃ c ∈ table79, hasNominalShell c.shape.external ∧
+    ∃ c ∈ shellTypology, hasNominalShell c.shape.external ∧
       c.shape.hasInternalAbar = true := by decide
 
 -- ============================================================================
 -- §2.5. Greek extension (cross-reference to [angelopoulos-2026])
 -- ============================================================================
 --
--- Deal's main Table 79 doesn't include Greek. [angelopoulos-2026]
+-- Deal's (79) doesn't include Greek. [angelopoulos-2026]
 -- (NLLT 44:26) argues that Greek *pu*-complement clauses are bare CPs
 -- (no nominalization shell) where the [n]-feature on C is checked by a
 -- light noun in Spec,CP that incorporates into the matrix v_State head.
@@ -235,7 +297,7 @@ def greekPuComplementShape : NotionalComplementShape :=
 -- §3. Cross-Classification: factivity ⊥ RE-structure
 -- ============================================================================
 
-/-! ### Headline orthogonality (Deal 2026 Tables 80–81)
+/-! ### Headline orthogonality ([deal-2026] (80)–(81))
 
 The central typological discovery: factivity does not predict RE-structure
 in either direction.
@@ -248,7 +310,7 @@ in either direction.
 /-- All four cells are attested: factivity neither necessitates nor precludes
     RE-syntax. The `factive` flag is per [deal-2026] §3 projection-test
     diagnoses. The Adyghe non-factive RE judgement is attributed to
-    [caponigro-polinsky-2011] via [deal-2026] §7 Table 80. -/
+    [caponigro-polinsky-2011] via [deal-2026] §7 (80). -/
 theorem factivity_perp_re_structure :
     -- Factive + RE: Nez Perce REs (e.g. liloy)
     liloy.factive = true ∧ nezPerceREShape.hasInternalAbar = true ∧
@@ -260,7 +322,7 @@ theorem factivity_perp_re_structure :
 
 /-! ### The fourth cell (non-factive + RE)
 
-Documented by [deal-2026] §7 (Table 80) as instantiated by Adyghe per
+Documented by [deal-2026] §7 ((80)) as instantiated by Adyghe per
 [caponigro-polinsky-2011]. Absent a formalised Adyghe Fragment, this is
 recorded as an unproven Lean claim: in linglib Adyghe is not yet present at
 Fragment level.
@@ -272,7 +334,7 @@ replace this prose with a theorem `adyghe_re_nonfactive`. -/
 -- §4. Cross-Classification: factivity ⊥ nominalization
 -- ============================================================================
 
-/-! ### Deal 2026 Table 81
+/-! ### [deal-2026] (81)
 
 * Factive + nominalization: Washo *forget* (per [hanink-bochnak-2017]).
 * Factive + no nominalization: Nez Perce REs (the headline Deal-2026 finding,
@@ -281,16 +343,12 @@ replace this prose with a theorem `adyghe_re_nonfactive`. -/
   §7 citing Özyıldız 2017).
 * Non-factive + no nominalization: Washo, Nez Perce 'think'. -/
 
-/-- Nez Perce REs are factive without external nominal shell. -/
+/-- Nez Perce REs are factive without external nominal shell
+    (`bareCP = []` wraps nothing by construction). -/
 theorem nezPerce_re_factive_no_nominalization :
     liloy.factive = true ∧
     nezPerceREShape.external = bareCP := by
   refine ⟨rfl, rfl⟩
-
-/-- The bare-CP shell contains neither D nor N. -/
-theorem bareCP_no_d_no_n :
-    Slot.Shell.d ∉ bareCP ∧ Slot.Shell.n ∉ bareCP := by
-  refine ⟨?_, ?_⟩ <;> decide
 
 -- ============================================================================
 -- §5. Embedding-strategy projection from Fragment data
@@ -445,7 +503,7 @@ The Studies file integrates four independent substrate layers:
 - Fragment: per-verb consensus typology (CTPClass, factive)
 - Tonhauser projective content: ProjectiveClass (Semantics/Presupposition/)
 - Deal-internal: EmbeddingStrategy + NotionalComplementShape
-- Shell/Ā axes: `Slot.ShellInventory` + `hasNominalShell` (Syntax/Clause/Frame.lean)
+- Shell/Ā axes: `ShellInventory` + `hasNominalShell` (§0 above)
 
 The bridge theorems below derive load-bearing predictions across these
 layers rather than stipulating them. -/
@@ -465,7 +523,7 @@ theorem strategy_shape_abar (v : NezPerceEmbedder) :
   unfold nezPerceEmbedStrategy
   cases v.requiresYoxKeEdge <;> rfl
 
-/-- All three Table-79 RE cells (Nez Perce, Adyghe, Bulgarian) carry an
+/-- All three RE rows of (79) (Nez Perce, Adyghe, Bulgarian) carry an
     internal Ā-dependency. The shared `hasInternalAbar = true` is the
     universal property of REs that survives Deal's typological dissolution. -/
 theorem all_REs_have_internal_abar :
@@ -474,7 +532,7 @@ theorem all_REs_have_internal_abar :
     bulgarianREShape.hasInternalAbar = true := by
   refine ⟨rfl, rfl, rfl⟩
 
-/-- All three Table-79 simplex/embedding cells (Nez Perce simplex, English
+/-- All three no-Ā simplex/embedding shapes (Nez Perce simplex, English
     *think*, Ndebele, Washo factive) lack internal Ā. -/
 theorem all_simplex_lack_internal_abar :
     nezPerceSimplexShape.hasInternalAbar = false ∧
@@ -482,13 +540,13 @@ theorem all_simplex_lack_internal_abar :
     washoShape.hasInternalAbar = false := by
   refine ⟨rfl, rfl, rfl⟩
 
-/-- The four-cell cross-classification of Tables 80–81 is exhaustively
+/-- The four-cell cross-classification of (80)–(81) is exhaustively
     populated: every combination of (factive, hasInternalAbar) is attested
     by at least one (verb, shape) pair. The fourth cell (non-factive + Ā)
     is documented from [caponigro-polinsky-2011]'s Adyghe REs as
     cited by Deal — Adyghe REs combine `adygheREShape` (hasInternalAbar=true)
     with predicates that are not factive in Caponigro & Polinsky's analysis
-    (Deal §7 p. 53). -/
+    ([deal-2026] §7, (80); supporting prose p. 52). -/
 theorem cross_classification_populated :
     -- Factive + Ā: liloy + nezPerceREShape
     (liloy.factive = true ∧ nezPerceREShape.hasInternalAbar = true) ∧

--- a/Linglib/Studies/LiuYip2026.lean
+++ b/Linglib/Studies/LiuYip2026.lean
@@ -472,7 +472,7 @@ have Studies-level Chinese formalizations they currently lack):
     proposition = CP, situation = TP, event = vP. Replaces the retired
     projection onto the deleted surface enum, which forced
     situation/event onto an Ā-dependency cell the ICH does not claim.
-    ([deal-2026]'s shell/Ā axes live in `Syntax/Clause/Complementation`;
+    ([deal-2026]'s shell/Ā axes live in `Studies/Deal2026.lean`;
     the ICH makes no claim on either axis, so no bridge is stated.) -/
 def ComplementClass.size : ComplementClass → ComplementSize
   | .proposition => .cP

--- a/Linglib/Studies/Major2024.lean
+++ b/Linglib/Studies/Major2024.lean
@@ -15,7 +15,7 @@ subjects (his 49b) and "are never internal arguments" (§3.2). The
 paper's methodological point — "taking the morphology at face value
 (i.e. dep is 'say' + CNV)" (§1) — is rendered literally here:
 `mergeMode` reads a morpheme's merge behavior off its recorded
-morphology (`verbForm`, `noonanType`), and the ban is derived, not
+morphology (`verbForm`, `coding`), and the ban is derived, not
 stipulated per position. The Washo parallel is [bochnak-hanink-2021]'s
 modifier analysis of non-factive embedding, which Major extends with
 the verb 'say' inside the linker.
@@ -117,11 +117,11 @@ instance (m : MergeMode) (pos : ClausePosition) : Decidable (m.admits pos) :=
 /-- The merge mode of a clause-forming morpheme, read off its recorded
 morphology — the paper's "morphology at face value" (§1): a converbial
 suffix (`verbForm = .Conv`) builds adjuncts; a nominalizing
-clause-typer (`noonanType = .nominalized`) builds arguments. `none`
+clause-typer (`coding = .nominalized`) builds arguments. `none`
 for morphemes heading no clause of their own. -/
 def mergeMode (c : Complementizer) : Option MergeMode :=
   if c.verbForm = some .Conv then some .converbAdjunction
-  else if c.noonanType = some .nominalized then some .nominalArgument
+  else if c.coding = some .nominalized then some .nominalArgument
   else none
 
 /-- A clause headed by `c` is licensed in `pos` iff `c`'s merge mode

--- a/Linglib/Studies/Noonan2007.lean
+++ b/Linglib/Studies/Noonan2007.lean
@@ -35,8 +35,8 @@ Five bridges connecting CTPClass to existing infrastructure:
 1. CTPClass ↔ VerbEntry (Verbal.lean) — derive CTP class from verb features
 2. CTPClass ↔ SelectionClass (LeftPeriphery.lean) — map CTP to question embedding
 3. CTPClass ↔ Selector (Mood/Defs.lean) — map CTP to mood selection
-4. ComplementType ↔ NoonanCompType — via the substrate adapter
-   `ComplementType.toNoonan` (`Syntax/Clause/Complementation.lean`)
+4. ComplementType ↔ Complement.Coding — via the substrate adapter
+   `ComplementType.toCoding` (`Syntax/Clause/Complementation.lean`)
 5. VerbEntry → Selector — derive mood selection from verb features
 
 -/
@@ -60,7 +60,7 @@ open Mood
 theorem equi_requires_reduced :
     ∀ d ∈ all,
       d.hasEquiDeletion = true →
-      d.compTypes.any NoonanCompType.isReduced = true := by decide
+      d.codings.any Complement.Coding.isReduced = true := by decide
 
 -- ============================================================================
 -- G3: Negative raising data (fills a gap in linglib)
@@ -84,7 +84,7 @@ theorem knowledge_no_negative_raising :
 /-- Does some row of this language's list attest an indicative complement
     for CTP class `cls`? -/
 def hasIndicativeFor (rows : List Datum) (cls : CTPClass) : Bool :=
-  rows.any fun d => d.ctpClass == cls && d.compTypes.any (· == .indicative)
+  rows.any fun d => d.ctpClass == cls && d.codings.any (· == .indicative)
 
 /-- [noonan-2007] §2.4: any sampled language using indicative with
     desideratives also uses it with propositional attitudes.
@@ -350,21 +350,22 @@ theorem irrealis_not_indicative :
   cases c <;> simp_all [ctpRealityStatus, ctpToSelector]
 
 -- ============================================================================
--- D. Bridge 4: English ComplementType ↔ NoonanCompType
+-- D. Bridge 4: English ComplementType ↔ Complement.Coding
 -- ============================================================================
 
 /-! ## D1. Map linglib's English-specific complement types to Noonan's
 typological categories
 
-The adapter itself is substrate: `ComplementType.toNoonan` in
-`Syntax/Clause/Complementation.lean`. The clausal-coverage check stays here. -/
+The adapter itself is substrate: `ComplementType.toCoding` in
+`Syntax/Clause/Complementation.lean`. The coverage check stays here:
+the coded clausal cells map to Noonan types; small clauses and embedded
+questions are outside his coding inventory (`toCoding` is `none`). -/
 
-/-- Every English verb that takes a clausal complement maps to a Noonan type. -/
+/-- The clausal complements Noonan's inventory covers all map to a coding. -/
 theorem clausal_complements_have_noonan_type :
-    ComplementType.toNoonan .finiteClause ≠ none ∧
-    ComplementType.toNoonan .infinitival ≠ none ∧
-    ComplementType.toNoonan .gerund ≠ none ∧
-    ComplementType.toNoonan .smallClause ≠ none := by decide
+    ComplementType.toCoding .finiteClause ≠ none ∧
+    ComplementType.toCoding .infinitival ≠ none ∧
+    ComplementType.toCoding .gerund ≠ none := by decide
 
 -- ============================================================================
 -- E. Gap fix: VerbEntry → Selector (derived function)

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -491,7 +491,7 @@ theorem buli_satisfies_universal :
 
     All three are "balanced" in Noonan's terms — SMPM lacks
     morphologically nonfinite predicates entirely. -/
-def smpmToNoonan : EmbeddedClauseType → NoonanCompType
+def smpmToNoonan : EmbeddedClauseType → Complement.Coding
   | .finiteEmbedded      => .indicative
   | .tensedSubjunctive   => .subjunctive
   | .untensedSubjunctive => .subjunctive

--- a/Linglib/Syntax/Category/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Category/Complementizer/Basic.lean
@@ -89,8 +89,8 @@ structure Complementizer where
   script : Option String := none
   /-- Morphological attachment. -/
   position : Option Morphology.FormativePosition := none
-  /-- [noonan-2007] type of the clause this morpheme types. -/
-  noonanType : Option NoonanCompType := none
+  /-- [noonan-2007] coding of the clause this morpheme types. -/
+  coding : Option Complement.Coding := none
   /-- Surface clause form typed. -/
   clauseForm : Option Features.ClauseForm := none
   /-- Verb form derived on the host (UD). -/

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -32,7 +32,7 @@ into facet structures under the `Verb` namespace — `Verb.ArgStructure`,
 language fragments extend `Verb` with their own inflectional paradigms.
 Complement selection is a list of typed `Frame`s
 (`Syntax/Clause/Frame.lean`); frame-conditioned
-attitude/opacity/control lives on `Verb.Reading` rows; the legacy flat
+attitude/opacity/control lives on `Verb.Reading` rows; the flat
 readers (`v.complementType`, `v.controlType`, …) are derived accessors
 over `frames`/`readings`.
 
@@ -163,7 +163,7 @@ namespace Verb
     proto-role entailments, voice, and implicit arguments. -/
 structure ArgStructure where
   /-- Complement frames, citation frame first. `[]` for intransitives.
-      The legacy `ComplementType` cells are the `Frame.np`,
+      The flat `ComplementType` cells are the `Frame.np`,
       `Frame.finiteClause`, … smart constructors
       (`Syntax/Clause/Frame.lean`). -/
   frames : List Frame
@@ -315,15 +315,15 @@ end
 
 /-! ### Frame accessors
 
-Flat readers over `Verb.frames`/`Verb.readings`, preserving the legacy
+Flat readers over `Verb.frames`/`Verb.readings`, preserving the flat
 enum-based call syntax: the citation frame's complement/control type and
 the alternate frame's, when present. -/
 
-/-- The citation (first) frame's legacy `ComplementType` cell. -/
+/-- The citation (first) frame's flat `ComplementType` cell. -/
 def Verb.complementType (v : Verb) : ComplementType :=
   (v.frames.head?.bind Frame.toComplementType).getD .none
 
-/-- The alternate (second) frame's legacy `ComplementType` cell. A second
+/-- The alternate (second) frame's flat `ComplementType` cell. A second
     frame richer than any enum cell reads as `none` — Buryat *hanaxa*'s
     genitive-subject nominalized frame has `altComplementType = none`
     despite a recorded second frame. -/

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -264,8 +264,6 @@ structure Attitude where
   /-- Frame-conditioned readings ([bondarenko-2022] §4.4.3): per-frame
       attitude/opacity overrides and control, keyed to `frames` entries. -/
   readings : List Reading := []
-  /-- For non-preferential question-embedding verbs (know, wonder, ask) -/
-  takesQuestionBase : Bool := false
   /-- Entailment signature of the complement position.
       Classifies this verb's monotonicity w.r.t. its clausal complement.
       `.mono` = upward monotone: the report is closed under entailment of
@@ -325,7 +323,10 @@ the alternate frame's, when present. -/
 def Verb.complementType (v : Verb) : ComplementType :=
   (v.frames.head?.bind Frame.toComplementType).getD .none
 
-/-- The alternate (second) frame's legacy `ComplementType` cell. -/
+/-- The alternate (second) frame's legacy `ComplementType` cell. A second
+    frame richer than any enum cell reads as `none` — Buryat *hanaxa*'s
+    genitive-subject nominalized frame has `altComplementType = none`
+    despite a recorded second frame. -/
 def Verb.altComplementType (v : Verb) : Option ComplementType :=
   v.frames[1]?.bind Frame.toComplementType
 
@@ -350,9 +351,18 @@ def Verb.readingsWF (v : Verb) : Prop :=
   ∀ r ∈ v.readings, r.frame ∈ v.frames
 
 /-- All [noonan-2007] codings across the verb's frames. -/
-def Verb.codings (v : Verb) : List NoonanCompType :=
+def Verb.codings (v : Verb) : List Complement.Coding :=
   v.frames.flatMap Frame.codings
 
 /-- Some frame of the verb records clause form `cf`. -/
 def Verb.takesClauseForm (v : Verb) (cf : Features.ClauseForm) : Prop :=
   ∃ fr ∈ v.frames, fr.hasClauseForm cf
+
+instance (v : Verb) (cf : Features.ClauseForm) :
+    Decidable (v.takesClauseForm cf) :=
+  inferInstanceAs (Decidable (∃ fr ∈ v.frames, _))
+
+/-- The verb records an embedded-question frame (responsives and
+    rogatives: know, wonder, ask). Derived from `frames`. -/
+def Verb.takesQuestionBase (v : Verb) : Bool :=
+  decide (v.takesClauseForm .embeddedQuestion)

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -4,26 +4,26 @@ import Linglib.Syntax.Category.Complementizer.Basic
 /-!
 # Clause complementation: selection
 
-[deal-2026] [noonan-2007]
+[noonan-2007]
 
 The [noonan-2007]-anchored selection relation between verb frames and
 clause-typers.
 
 ## Main definitions
 
-- `ComplementType.toNoonan`, `Verb.compTypes`, `Verb.realizes` — the
-  selection relation
+- `ComplementType.toCoding`, `Verb.realizes` — the selection relation
+- `ComplementType.codings_toFrame` — the enum view and the typed frames
+  record the same coding
 
 ## Implementation notes
 
-The typed complement-frame object (`Slot`, `Frame`) and [deal-2026]'s CP
-external-shell inventory (`Slot.Shell`, `Slot.ShellInventory`, the named
-witnesses) live in `Syntax/Clause/Frame.lean`; [noonan-2007]'s enums
-(`NoonanCompType`, `CTPClass`, `RealityStatus`) in
-`Features/Complementation.lean`; the generated CTP sample rows in
-`Data/Complementation/`. Placement of individual languages in Table 79
-cells consumes Fragment data and lives in `Studies/Deal2026.lean`;
-consistency checks on the selection relation live in Studies
+The typed complement-frame object (`Slot`, `Frame`) lives in
+`Syntax/Clause/Frame.lean`; [noonan-2007]'s enums (`Complement.Coding`,
+`CTPClass`, `RealityStatus`) in `Features/Complementation.lean`; the
+generated CTP sample rows in `Data/Complementation/`. [deal-2026]'s
+CP-external shell inventory and the language placements of its (79)
+table live in `Studies/Deal2026.lean`; consistency checks on the
+selection relation live in Studies
 (e.g. `Bondarenko2022.hanaxa_frames_realized`).
 -/
 
@@ -34,28 +34,32 @@ namespace Clause.Complementation
 The [noonan-2007]-anchored relation between a verb's complement frames
 and a language's clause-typing morphemes. -/
 
-/-- The [noonan-2007] category of a complement frame; `none` for
-non-clausal frames. -/
-def _root_.ComplementType.toNoonan : ComplementType → Option NoonanCompType
+/-- The [noonan-2007] coding of a complement frame: `none` for
+non-clausal frames, for small clauses (outside the coding inventory),
+and for embedded questions (interrogativity is a clause-form axis, not
+a coding). -/
+def _root_.ComplementType.toCoding : ComplementType → Option Complement.Coding
   | .finiteClause => some .indicative
   | .infinitival => some .infinitive
   | .gerund => some .nominalized
-  | .smallClause => some .paratactic
+  | .smallClause => none
   | .none => none
   | .np => none
   | .np_np => none
   | .np_pp => none
-  | .question => some .indicative
+  | .question => none
 
-/-- The legacy `ComplementType` cells of a verb's frame inventory
-    (frames richer than any cell are dropped). -/
-def _root_.Verb.compTypes (v : Verb) : List ComplementType :=
-  v.frames.filterMap Frame.toComplementType
+/-- The enum view and the typed frames record the same coding: a cell's
+    frame carries exactly the codings `toCoding` assigns it. -/
+theorem _root_.ComplementType.codings_toFrame (ct : ComplementType) :
+    ct.toFrame.codings = ct.toCoding.toList := by cases ct <;> rfl
 
-/-- Some frame of `v` is realized by clause-typer `c`: a slot's
-    [noonan-2007] coding matches the typer's. The `∃ t` guard keeps
-    coding-less slots from matching type-less typers (`none`/`none`). -/
+/-- Some frame of `v` is realized by clause-typer `c`: a recorded
+    [noonan-2007] coding of `v`'s frames matches the typer's. -/
 def _root_.Verb.realizes (v : Verb) (c : Complementizer) : Prop :=
-  ∃ fr ∈ v.frames, ∃ s ∈ fr, ∃ t, s.coding = some t ∧ c.noonanType = some t
+  ∃ t ∈ v.codings, c.coding = some t
+
+instance (v : Verb) (c : Complementizer) : Decidable (v.realizes c) :=
+  inferInstanceAs (Decidable (∃ t ∈ v.codings, _))
 
 end Clause.Complementation

--- a/Linglib/Syntax/Clause/Frame.lean
+++ b/Linglib/Syntax/Clause/Frame.lean
@@ -8,7 +8,7 @@ A predicate's complement frame as a list of typed `Complement.Position`s,
 factoring the flat `ComplementType` enum cells into their axes:
 syntactic category, clause form, [noonan-2007] coding, and
 embedded-subject requirement (genitive subjects of nominalized clauses,
-[noonan-2007] §1.3.5, [bondarenko-2022]). The legacy enum survives as a
+[noonan-2007] §1.3.5, [bondarenko-2022]). The flat enum survives as a
 round-trip view (`ComplementType.toFrame` / `Frame.toComplementType`).
 
 ## Main declarations
@@ -17,9 +17,9 @@ round-trip view (`ComplementType.toFrame` / `Frame.toComplementType`).
   `Complement.EmbeddedSubject` axes — one complement position: category
   plus optional clausal axes
 * `Frame` + `Frame.np`, `Frame.finiteClause`, … — a frame is a list of
-  complement positions; the legacy enum cells as smart constructors
-* `ComplementType` + `toFrame` / `Frame.toComplementType` — the legacy
-  flat enum and its round-trip view
+  complement positions; the flat enum cells as smart constructors
+* `ComplementType` + `toFrame` / `Frame.toComplementType` — the flat
+  enum and its round-trip view
 
 ## Implementation notes
 
@@ -98,7 +98,7 @@ instance (fr : Frame) (cf : Features.ClauseForm) :
     Decidable (fr.hasClauseForm cf) :=
   inferInstanceAs (Decidable (∃ s ∈ fr, _))
 
-/-! ### Smart constructors — the legacy `ComplementType` cells -/
+/-! ### Smart constructors — the flat `ComplementType` cells -/
 
 /-- Transitive: one nominal position. -/
 def np : Frame := [{ cat := .nominal }]
@@ -134,7 +134,7 @@ def question : Frame :=
 
 end Frame
 
-/-! ### The legacy enum view -/
+/-! ### The flat enum view -/
 
 /--
 Complement type that the verb selects — the flat view over the typed
@@ -186,7 +186,7 @@ def ComplementType.isClausal : ComplementType → Bool
   | .finiteClause | .infinitival | .gerund | .smallClause | .question => true
   | _ => false
 
-/-- The `Frame` cell of a legacy `ComplementType` (`.none` ↦ `[]`). -/
+/-- The `Frame` cell of a flat `ComplementType` (`.none` ↦ `[]`). -/
 def ComplementType.toFrame : ComplementType → Frame
   | .none => []
   | .np => Frame.np
@@ -198,7 +198,7 @@ def ComplementType.toFrame : ComplementType → Frame
   | .smallClause => Frame.smallClause
   | .question => Frame.question
 
-/-- Partial inverse of `ComplementType.toFrame`: the legacy enum cell a
+/-- Partial inverse of `ComplementType.toFrame`: the flat enum cell a
     frame instantiates, `none` on frames richer than any cell. -/
 def Frame.toComplementType (fr : Frame) : Option ComplementType :=
   [ComplementType.none, .np, .np_np, .np_pp, .finiteClause, .infinitival,

--- a/Linglib/Syntax/Clause/Frame.lean
+++ b/Linglib/Syntax/Clause/Frame.lean
@@ -2,207 +2,111 @@ import Linglib.Features.Complementation
 import Linglib.Features.ClauseForm
 import Linglib.Features.Case.Basic
 
-/-! # Complement frames — typed slots
+/-! # Complement frames — typed complement positions
 
-A verb's complement frame as a list of typed `Slot`s, factoring the flat
-`ComplementType` enum cells into their axes: syntactic category, case
-marking, CP-external shell ([deal-2026]), clause form, [noonan-2007]
-coding, and embedded-subject requirement (genitive subjects of
-nominalized clauses, [bondarenko-2022]). The legacy enum survives as a
+A predicate's complement frame as a list of typed `Complement.Position`s,
+factoring the flat `ComplementType` enum cells into their axes:
+syntactic category, clause form, [noonan-2007] coding, and
+embedded-subject requirement (genitive subjects of nominalized clauses,
+[noonan-2007] §1.3.5, [bondarenko-2022]). The legacy enum survives as a
 round-trip view (`ComplementType.toFrame` / `Frame.toComplementType`).
 
 ## Main declarations
 
-* `Slot.Shell`, `Slot.ShellInventory` (+ `isAttested`, `hasNominalShell`,
-  the named cells) — CP-external wrapping shells ([deal-2026] Table 79)
-* `Slot`, `Slot.WellFormed` — one complement position: category plus
-  optional clausal axes
+* `Complement.Position`, with its `Complement.Cat` and
+  `Complement.EmbeddedSubject` axes — one complement position: category
+  plus optional clausal axes
 * `Frame` + `Frame.np`, `Frame.finiteClause`, … — a frame is a list of
-  slots; the legacy enum cells as smart constructors
+  complement positions; the legacy enum cells as smart constructors
+* `ComplementType` + `toFrame` / `Frame.toComplementType` — the legacy
+  flat enum and its round-trip view
 
 ## Implementation notes
 
-Frame-conditioned readings (attitude, opacity, control) are not slot
-data — they live on `Verb.Reading` (`Syntax/Category/Verb/Defs.lean`), keyed
-to the verb's frames. The [noonan-2007] selection relation between verb
-frames and clause-typers (`Verb.realizes`) lives in
-`Syntax/Clause/Complementation.lean`. This file never imports
-`Semantics/`.
+Complement-taking is cross-categorial ([noonan-2007]'s CTPs include
+adjectives and nouns), so the position record lives in the `Complement`
+namespace beside `Complement.Coding`, not under `Verb`;
+`Adposition.Complement` is the P-specific counterpart of
+`Complement.Cat`. Frame-conditioned readings (attitude, opacity,
+control) are not per-position data — they live on `Verb.Reading`
+(`Syntax/Category/Verb/Defs.lean`), keyed to the verb's frames. The
+[noonan-2007] selection relation between verb frames and clause-typers
+(`Verb.realizes`) lives in `Syntax/Clause/Complementation.lean`.
+[deal-2026]'s CP-external shell inventory lives with its consumer in
+`Studies/Deal2026.lean`.
 -/
 
-namespace Slot
+namespace Complement
 
-/-! ### CP-external wrapping shells
+/-! ### Complement-position axes -/
 
-`ComplementSize` and `ClauseSpine` (Syntax/Minimalist/) record *internal*
-clause height; `Slot.Shell` records what wraps the CP *externally*.
-[deal-2026] Table 79 cross-classifies the two axes. -/
-
-/-- A wrapping head above a CP: [deal-2026] Table 79 attests D, N, and P;
-`c` is the base case, so the bare-CP inventory is `[.c]`. -/
-inductive Shell where
-  /-- The CP itself (always present). -/
-  | c
-  /-- D shell. -/
-  | d
-  /-- N shell (between D and CP). -/
-  | n
-  /-- P shell. -/
-  | p
-  deriving DecidableEq, Repr
-
-/-- An ordered shell list, innermost first: `[.c, .d]` = D wraps CP,
-`[.c, .n, .d]` = D wraps N wraps CP. -/
-abbrev ShellInventory := List Shell
-
-namespace ShellInventory
-
-/-- The shell inventory is a [deal-2026] Table 79 cell. -/
-def isAttested : ShellInventory → Bool
-  | [.c] => true
-  | [.c, .d] => true
-  | [.c, .n, .d] => true
-  | [.c, .d, .p] => true
-  | _ => false
-
-/-- The bare-CP cell (Nez Perce; English *think*). -/
-def bareCP : ShellInventory := [.c]
-
-/-- The V D CP cell (Washo, [bochnak-hanink-2021]). -/
-def dCP : ShellInventory := [.c, .d]
-
-/-- The V D N CP cell (Adyghe, [caponigro-polinsky-2011]). -/
-def dnCP : ShellInventory := [.c, .n, .d]
-
-/-- The V P D CP cell (Bulgarian, [krapova-2010]; Ndebele,
-[pietraszko-2019]). -/
-def pdCP : ShellInventory := [.c, .d, .p]
-
-/-- The four named witnesses are all attested. -/
-theorem named_shells_attested :
-    isAttested bareCP = true ∧
-    isAttested dCP = true ∧
-    isAttested dnCP = true ∧
-    isAttested pdCP = true :=
-  ⟨rfl, rfl, rfl, rfl⟩
-
-/-- P-shelling co-occurs with D-shelling. -/
-theorem pdCP_contains_p_and_d : Shell.p ∈ pdCP ∧ Shell.d ∈ pdCP := by
-  decide
-
-/-- N appears only inside a D shell. -/
-theorem dnCP_contains_n_and_d : Shell.n ∈ dnCP ∧ Shell.d ∈ dnCP := by
-  decide
-
-/-- Every named shell contains C. -/
-theorem named_shells_contain_c :
-    Shell.c ∈ bareCP ∧ Shell.c ∈ dCP ∧
-    Shell.c ∈ dnCP ∧ Shell.c ∈ pdCP := by
-  decide
-
-/-- `V P CP` (P with no D shell) is not a Table 79 cell. -/
-theorem pCP_not_attested : isAttested [.c, .p] = false := rfl
-
-/-- `V N CP` (N with no D shell) is not a Table 79 cell. -/
-theorem nCP_not_attested : isAttested [.c, .n] = false := rfl
-
-/-- The clause complex is wrapped in a nominal projection: its shell
-    contains D (Washo `dCP`, Adyghe `dnCP`, Bulgarian/Ndebele `pdCP`;
-    `bareCP` is not). On [deal-2026]'s attested cells this coincides
-    with `≠ bareCP` (`pCP`/`nCP` are unattested); D-membership is the
-    definitional content, not the complement of a special case. -/
-def hasNominalShell (inv : ShellInventory) : Prop := Shell.d ∈ inv
-
-instance : DecidablePred hasNominalShell :=
-  λ inv => inferInstanceAs (Decidable (Shell.d ∈ inv))
-
-end ShellInventory
-
-/-! ### Complement-frame axes -/
-
-/-- Syntactic category of a complement slot. -/
+/-- Syntactic category of a complement position. -/
 inductive Cat where
   | nominal
   | adpositional
   | clausal
   deriving DecidableEq, Repr
 
-/-- Embedded-subject requirement of a clausal slot: obligatorily null
-    (control/raising infinitives) or overt, optionally with a fixed
-    case (genitive subjects of nominalized clauses, [bondarenko-2022]). -/
+/-- Embedded-subject requirement of a clausal complement: obligatorily
+    null (as in control complements) or overt, optionally with a fixed
+    case. Genitive marking on the subject is [noonan-2007]'s criterion
+    for the nominalization coding (§1.3.5); [bondarenko-2022] ch. 4 is
+    the modern instance (Buryat genitive subjects of nominalized
+    clauses). -/
 inductive EmbeddedSubject where
   | obligatorilyNull
   | overt (subjCase : Option Case)
   deriving DecidableEq, Repr
 
-end Slot
-
 /-! ### The frame object -/
 
-/-- One complement position of a verb's frame: its category plus, for
-    clausal slots, the recorded clausal axes. On non-clausal slots the
-    clausal axes are `none` (`Slot.WellFormed`); on clausal slots `none`
-    means unrecorded. Frame-conditioned readings and control are not
-    slot data — they live on `Verb.Reading`. -/
-structure Slot where
-  cat : Slot.Cat
-  /-- Case marking on the slot (case-marked nominalized clauses, NPs). -/
-  marking : Option Case := none
-  /-- CP-external wrapping shell ([deal-2026] Table 79). -/
-  shell : Option Slot.ShellInventory := none
+/-- One complement position of a predicate's frame: its category plus,
+    for clausal complements, the recorded clausal axes. On clausal
+    complements `none` means unrecorded; non-clausal complements leave
+    the clausal axes at their `none` defaults. Frame-conditioned
+    readings and control are not per-position data — they live on
+    `Verb.Reading`. -/
+structure Position where
+  /-- Syntactic category of the complement. -/
+  cat : Cat
   /-- Clause form (declarative vs embedded question). -/
   clauseForm : Option Features.ClauseForm := none
   /-- [noonan-2007] coding of the complement clause. -/
-  coding : Option NoonanCompType := none
+  coding : Option Coding := none
   /-- Embedded-subject requirement. -/
-  embeddedSubject : Option Slot.EmbeddedSubject := none
+  embeddedSubject : Option EmbeddedSubject := none
   deriving DecidableEq, Repr
 
-/-- Clausal axes are reserved for clausal slots. -/
-def Slot.WellFormed (s : Slot) : Prop :=
-  s.cat = .clausal ∨
-    (s.shell = none ∧ s.clauseForm = none ∧ s.coding = none ∧
-      s.embeddedSubject = none)
+end Complement
 
-instance : DecidablePred Slot.WellFormed := fun s => by
-  unfold Slot.WellFormed; infer_instance
-
-/-- The slot is clausal. -/
-def Slot.isClausal (s : Slot) : Prop := s.cat = .clausal
-
-/-- A complement frame: the verb's selected complement positions in
-    order. Intransitive = `[]`; double object = two slots. -/
-abbrev Frame := List Slot
+/-- A complement frame: the predicate's selected complement positions in
+    order. Intransitive = `[]`; double object = two positions. The
+    external argument is not a frame position — it lives on
+    `Verb.voiceType`. -/
+abbrev Frame := List Complement.Position
 
 namespace Frame
 
-/-- The [noonan-2007] codings recorded across the frame's slots. -/
-def codings (fr : Frame) : List NoonanCompType := fr.filterMap (·.coding)
+/-- The [noonan-2007] codings recorded across the frame's positions. -/
+def codings (fr : Frame) : List Complement.Coding := fr.filterMap (·.coding)
 
-/-- Some slot of the frame records clause form `cf`. -/
+/-- Some position of the frame records clause form `cf`. -/
 def hasClauseForm (fr : Frame) (cf : Features.ClauseForm) : Prop :=
   ∃ s ∈ fr, s.clauseForm = some cf
 
 instance (fr : Frame) (cf : Features.ClauseForm) :
-    Decidable (fr.hasClauseForm cf) := by
-  unfold hasClauseForm; infer_instance
-
-/-- Some slot of the frame records [noonan-2007] coding `t`. -/
-def hasCoding (fr : Frame) (t : NoonanCompType) : Prop :=
-  ∃ s ∈ fr, s.coding = some t
-
-instance (fr : Frame) (t : NoonanCompType) : Decidable (fr.hasCoding t) := by
-  unfold hasCoding; infer_instance
+    Decidable (fr.hasClauseForm cf) :=
+  inferInstanceAs (Decidable (∃ s ∈ fr, _))
 
 /-! ### Smart constructors — the legacy `ComplementType` cells -/
 
-/-- Transitive: one nominal slot. -/
+/-- Transitive: one nominal position. -/
 def np : Frame := [{ cat := .nominal }]
 
-/-- Double object: two nominal slots. -/
+/-- Double object: two nominal positions. -/
 def np_np : Frame := [{ cat := .nominal }, { cat := .nominal }]
 
-/-- NP + PP: a nominal plus an adpositional slot. -/
+/-- NP + PP: a nominal plus an adpositional position. -/
 def np_pp : Frame := [{ cat := .nominal }, { cat := .adpositional }]
 
 /-- Finite declarative clause. -/
@@ -210,24 +114,77 @@ def finiteClause : Frame :=
   [{ cat := .clausal, coding := some .indicative,
      clauseForm := some .declarative }]
 
-/-- Infinitival clause: obligatorily null embedded subject. -/
-def infinitival : Frame :=
-  [{ cat := .clausal, coding := some .infinitive,
-     embeddedSubject := some .obligatorilyNull }]
+/-- Infinitival clause. The embedded-subject requirement varies by verb
+    (equi-deletion, raising, or adposition-marked overt subjects,
+    [noonan-2007] §1.3.4), so it lives on the verb's reading, not here. -/
+def infinitival : Frame := [{ cat := .clausal, coding := some .infinitive }]
 
 /-- Gerund / nominalized clause. -/
 def gerund : Frame := [{ cat := .clausal, coding := some .nominalized }]
 
-/-- Small clause (paratactic coding). -/
-def smallClause : Frame := [{ cat := .clausal, coding := some .paratactic }]
+/-- Small clause (*consider X happy*; causative *make X leave*). Outside
+    [noonan-2007]'s coding inventory, which classifies complements by
+    the part of speech of their predicate, so `coding` stays `none`. -/
+def smallClause : Frame := [{ cat := .clausal }]
 
-/-- Embedded question. -/
+/-- Embedded question. Interrogativity is a clause-form distinction
+    orthogonal to [noonan-2007] coding, so `coding` stays `none`. -/
 def question : Frame :=
   [{ cat := .clausal, clauseForm := some .embeddedQuestion }]
 
 end Frame
 
 /-! ### The legacy enum view -/
+
+/--
+Complement type that the verb selects — the flat view over the typed
+`Frame`.
+
+- Finite: "that" clauses ("John knows that Mary left")
+- Infinitival: "to" complements ("John managed to leave")
+- Gerund: "-ing" complements ("John stopped smoking")
+- NP: Direct object ("John kicked the ball")
+- None: Intransitive ("John slept")
+-/
+inductive ComplementType where
+  | none            -- Intransitive
+  | np              -- Transitive with NP object
+  | np_np           -- Ditransitive: "give X Y"
+  | np_pp           -- NP + PP: "put X on Y"
+  | finiteClause    -- "that" clause
+  | infinitival     -- "to" VP
+  | gerund          -- "-ing" VP
+  | smallClause     -- "consider X happy"
+  | question        -- Embedded question "wonder who"
+  deriving DecidableEq, Repr
+
+/-- Is this complement type finite (i.e., does it contain a tense head)?
+
+    Finite complements (.finiteClause,.question) have independent tense
+    morphology; non-finite complements (.infinitival,.gerund,.smallClause)
+    do not. -/
+def ComplementType.isFinite : ComplementType → Bool
+  | .finiteClause | .question => true
+  | _ => false
+
+/-- Is this complement type a nominal (DP) argument?
+
+    Nominal complements project DP: the verb selects a noun phrase
+    in object position. Relevant to c-selection in coordination:
+    a verb that only selects nominal complements cannot independently
+    license a CP conjunct ([schwarzer-2026]). -/
+def ComplementType.isNominal : ComplementType → Bool
+  | .np | .np_np | .np_pp => true
+  | _ => false
+
+/-- Is this complement type a clausal (CP) argument?
+
+    Clausal complements project CP or reduced clausal structure.
+    This covers finite clauses (*dass*-clauses), infinitivals,
+    gerunds, small clauses, and embedded questions. -/
+def ComplementType.isClausal : ComplementType → Bool
+  | .finiteClause | .infinitival | .gerund | .smallClause | .question => true
+  | _ => false
 
 /-- The `Frame` cell of a legacy `ComplementType` (`.none` ↦ `[]`). -/
 def ComplementType.toFrame : ComplementType → Frame
@@ -248,5 +205,13 @@ def Frame.toComplementType (fr : Frame) : Option ComplementType :=
     .gerund, .smallClause, .question].find? (·.toFrame == fr)
 
 /-- The enum view round-trips over the smart-constructor cells. -/
+@[simp]
 theorem toComplementType_toFrame (ct : ComplementType) :
     ct.toFrame.toComplementType = some ct := by cases ct <;> rfl
+
+theorem ComplementType.toFrame_injective :
+    Function.Injective ComplementType.toFrame := by
+  intro a b h
+  have ha := toComplementType_toFrame a
+  rw [h, toComplementType_toFrame b] at ha
+  exact (Option.some.inj ha).symm

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.List.Basic
 import Linglib.Data.UD.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Frame
 import Linglib.Morphology.Word.Basic
 
 open Morphology (Word)

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
@@ -60,6 +60,17 @@ def ClauseSpine.lowestHead (spine : ClauseSpine) : Cat :=
 def ClauseSpine.size (spine : ClauseSpine) : Nat :=
   spine.projectedHeads.length
 
+/-- Extend a spine upward with further projected heads — e.g. the
+    nominal or adpositional superstructure over an embedded CP
+    ([deal-2026]'s shelled notional complements). -/
+def ClauseSpine.extend (spine : ClauseSpine) (heads : List Cat) : ClauseSpine :=
+  ⟨spine.projectedHeads ++ heads, by simp [spine.nonempty]⟩
+
+/-- The heads projected strictly above the last occurrence of `c`:
+    `above .C` is the CP-external superstructure (`[]` for a bare CP). -/
+def ClauseSpine.above (spine : ClauseSpine) (c : Cat) : List Cat :=
+  (spine.projectedHeads.reverse.takeWhile (· != c)).reverse
+
 -- ============================================================================
 -- § 3: Named Spines
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Probe/Profile.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Profile.lean
@@ -199,9 +199,11 @@ def keineĀDep : AbarDep := ⟨keineĀProbe, ābar_is_Ā⟩
 /-- The wh-licensing probe is also an `AbarDep` (sits on C, fValue 6). -/
 def keineWhDep : AbarDep := ⟨keineWhLicensing, wh_is_Ā⟩
 
-/-- An Ā-dependency originates "above TP" iff its probe head's fValue exceeds
-    that of T. This is [deal-2026] §5's "high functional projection"
-    structural diagnostic. -/
+/-- The dependency's *probe head* sits above T (fValue above T's). Every
+    Ā-probe in this file satisfies it (Ā-probes sit on C). NOTE: this is
+    a property of the probe site, not of the moved element's origin —
+    [deal-2026] §5's claim that the Nez Perce RE operator *originates*
+    above TP concerns the chain foot, which `AbarDep` does not record. -/
 def AbarDep.isHigh (a : AbarDep) : Bool :=
   fValue a.val.probeHead > fValue .T
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -38108,3 +38108,13 @@
   role      = {formalized},
   sources   = {Studies/BeckOdaSugisaki2004.lean}
 }
+
+@phdthesis{jacobsen-1964,
+  author    = {Jacobsen, William H., Jr.},
+  year      = {1964},
+  title     = {A grammar of the Washo language},
+  school    = {University of California, Berkeley},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Fragments/Washo/Clause.lean}
+}


### PR DESCRIPTION
Deep audits of `Syntax/Clause/Frame.lean` and `Studies/Deal2026.lean` against the Deal 2026 and Noonan 2007 primary sources.
- citation fixes: Deal's "Table 79" is example (79) and V D CP is its fn. 33, not a cell; `smallClause` is not Noonan-paratactic and questions carry no Noonan coding; infinitival subjects are not obligatorily null; Noonan section/table cites corrected; missing English N-complementation row added
- Complement API: `NoonanCompType` → `Complement.Coding`, `Slot` → `Complement.Position`, `Complementizer.noonanType` → `coding`; `ComplementType` moves beside `Frame`; `takesQuestionBase` derived from frames; `Verb.realizes` via `Verb.codings`, decidable; shell inventory demoted to the Deal study; dead API deleted
- Deal2026 full-paper rewrite: Nez Perce shapes derived from the fragment's three-valued `yoxKeEdge` observable (read-back theorem bundles → falsifiable inventory-level dissociations); unfaithful `keSatisfaction` and mis-glossed `isHigh` removed (honest deferrals name the missing substrate: value-sensitive ordered probing, chain feet); §6 deferral re-aimed at [deal-2025]; fragment example swaps and form spellings fixed
- fragment arc: \`Fragments/{Adyghe,Bulgarian,Ndebele,Washo}/Clause.lean\` built from the four primary sources (PDF-verified forms); NezPerce fragment renamed to \`Clause.lean\` with a three-valued edge observable; "RE" spelled out as relative embedding; Deal2026 rows derived from fragment observables, with the (80) fourth cell now a theorem (\`nonfactive_relative_attested\`, Adyghe *ze-re-*)
