### PR TITLE
style(Syntax/Clause): clean up Chaining.lean; rename bundle to System

### DIFF
--- a/Linglib/Studies/SarvasyAikhenvald2025.lean
+++ b/Linglib/Studies/SarvasyAikhenvald2025.lean
@@ -64,7 +64,7 @@ open Clause.Chaining
     DS-SEQ, DS-SIM). Medial verbs are maximally reduced (bare stem +
     SR suffix). The final verb alone carries tense, agreement, and full mood.
     Non-canonical stand-alone medial clauses are attested. -/
-def nungon : ClauseChainingParams where
+def nungon : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .ssDsTemporal
   srTarget            := some .subjectOnly
@@ -83,7 +83,7 @@ def nungon : ClauseChainingParams where
   medialCanStandAlone := true
 
 /-- Manambu (Ndu family, East Sepik; [aikhenvald-2008], 2025 Ch. 6). -/
-def manambu : ClauseChainingParams where
+def manambu : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .ssDs
   srTarget            := some .subjectOnly
@@ -102,7 +102,7 @@ def manambu : ClauseChainingParams where
   medialCanStandAlone := true
 
 /-- Ku Waru (Trans-New Guinea, Chimbu-Wahgi; [merlan-rumsey-1991]). -/
-def kuWaru : ClauseChainingParams where
+def kuWaru : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .ssDs
   srTarget            := some .subjectOnly
@@ -121,7 +121,7 @@ def kuWaru : ClauseChainingParams where
   medialCanStandAlone := false
 
 /-- Korean (Koreanic; [sohn-1999]). -/
-def korean : ClauseChainingParams where
+def korean : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .none
   srTarget            := none
@@ -142,7 +142,7 @@ def korean : ClauseChainingParams where
   medialCanStandAlone := true
 
 /-- Turkish (Turkic; [goksel-kerslake-2005]). -/
-def turkish : ClauseChainingParams where
+def turkish : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .none
   srTarget            := none
@@ -162,7 +162,7 @@ def turkish : ClauseChainingParams where
   medialCanStandAlone := false
 
 /-- Korowai (Trans-New Guinea, Greater Awyu; [de-vries-2025] Ch. 5). -/
-def korowai : ClauseChainingParams where
+def korowai : Clause.Chaining.System where
   direction           := .medialFinal
   srSystem            := .multiTrack
   srTarget            := some .topicBased
@@ -181,7 +181,7 @@ def korowai : ClauseChainingParams where
   medialCanStandAlone := false
 
 /-- All language data entries. -/
-def allLanguages : List ClauseChainingParams :=
+def allLanguages : List Clause.Chaining.System :=
   [nungon, manambu, kuWaru, korean, turkish, korowai]
 
 theorem nungon_has_sr : nungon.hasSR = true := rfl

--- a/Linglib/Syntax/Clause/Chaining.lean
+++ b/Linglib/Syntax/Clause/Chaining.lean
@@ -1,62 +1,45 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.WordOrder
 
-/-! # Clause Chaining Typology [sarvasy-aikhenvald-2025] [foley-r-d-van-valin-1984] [longacre-2007]
+/-!
+# Clause chaining
 
-Cross-linguistic typology of clause chaining: multi-clause constructions in which
-one or more **medial** (dependent, morphologically reduced) clauses combine with
-a single **final** (independent, fully inflected) clause. The final verb supplies
-tense, mood, and often agreement for the entire chain.
+[sarvasy-aikhenvald-2025]
 
-Clause chaining is typologically distinct from both coordination (syntactically
-equal independent clauses) and subordination (embedded dependent clauses).
-Following [foley-r-d-van-valin-1984] and [longacre-2007], chained medial clauses
-are **dependent but not embedded** — what Role & Reference Grammar calls
-"cosubordination."
+Typology of clause chaining: multi-clause constructions in which one or
+more **medial** clauses (dependent, morphologically reduced) combine
+with a single **final** clause (independent, fully inflected) that
+supplies tense, mood, and often agreement for the whole chain. Chaining
+is the prototypical *cosubordinate* combining scheme
+(`Clause.CombiningScheme`): the medial clause is dependent but not
+embedded ([foley-r-d-van-valin-1984]; [longacre-2007]). Anchors:
+[sarvasy-aikhenvald-2025] and [de-vries-2025], with per-language
+bundles and generalizations in `Studies/SarvasyAikhenvald2025.lean`.
 
-## Core structural asymmetry
-[chomsky-1981] [dryer-1992] [givon-1983] [sarvasy-2015]
+## Main definitions
 
-The medial/final asymmetry is the defining property. Medial verbs carry a
-**reduced** morphological paradigm: some TAM categories are absent or restricted,
-while the final verb is fully inflected. The final verb's TAM values scope over
-the entire chain. This creates a characteristic "head-final scope" pattern where
-interpretive parameters flow rightward (in medial-final chains) from the final
-verb to all preceding medial clauses.
-
-## Switch-reference
-
-Many clause-chaining languages mark **switch-reference** (SR) on medial verbs:
-morphology tracking whether the subject of the next clause is the same as (SS)
-or different from (DS) the current clause's subject. SR is orthogonal to binding
-theory: binding constrains intra-clausal coreference via syntactic
-configuration, while SR tracks inter-clausal participant continuity via verbal
-morphology. Some languages (Greater Awyu) track topical participants rather than
-syntactic subjects, revealing SR as discourse-pragmatic rather than purely
-syntactic.
-
-## Typological parameters
-
-The formalization captures five parameter dimensions:
-
-| Dimension | Types | Examples |
-|-----------|-------|----------|
-| Chain direction | medial-final, initial-medial | most SOV langs, some V-initial |
-| SR system | none, SS/DS, SS/DS+temporal, multi-track | Korean, Nungon, Korowai |
-| Medial morphology | per-category retention (full/restricted/absent) | 5 TAM dimensions |
-| Interclausal semantics | 9 relation types marked on medial verbs | sequential, simultaneous,... |
-| Bridging constructions | recapitulative, summary | tail-head linkage, generic verb |
-
+* `Clause.CombiningScheme` (+ `Embedded`, `Dependent`) — the
+  [scancarelli-2003] combination schemes
+* `ClauseStatus`, `ChainDirection` — medial/final and chain order
+* `CategoryRetention`, `MedialMorphProfile` — the medial verb's
+  per-category finiteness profile
+* `SRSystem`, `SRTarget`, `SRMarkedness` — switch-reference
+* `InterclauseRelation` — marked interclausal semantic relations
+* `BridgingType` — discourse bridging across chain boundaries
+* `ClauseChainingParams` — the per-language bundle Fragments
+  instantiate
 -/
 
 namespace Clause
 
+/-! ### Combining schemes -/
+
 /-- How a clause combines with its neighbors into a larger structure
     ([scancarelli-2003]): relatively independent conjuncts, dependence
     on a main clause, chained cosubordination (dependent but not
-    embedded, [foley-r-d-van-valin-1984] — the scheme this file's
-    typology covers), or serialization with the relationship left
-    unmarked. Languages differ in which schemes they use at all. -/
+    embedded, [foley-r-d-van-valin-1984]), or serialization with the
+    relationship left unmarked. Languages differ in which schemes they
+    use at all. -/
 inductive CombiningScheme where
   | coordinate
   | subordinate
@@ -64,431 +47,286 @@ inductive CombiningScheme where
   | serial
   deriving DecidableEq, Repr
 
-end Clause
+namespace CombiningScheme
 
-namespace Clause.Chaining
+/-- The dependent clause is embedded as a syntactic constituent of the
+    other. -/
+def Embedded (s : CombiningScheme) : Prop := s = subordinate
 
--- ============================================================================
--- § Clause status
--- ============================================================================
+instance : DecidablePred Embedded := fun _ =>
+  inferInstanceAs (Decidable (_ = _))
 
-/-- Structural status of a clause within a chain.
+/-- The dependent clause is morphologically reduced (cannot stand
+    alone). -/
+def Dependent (s : CombiningScheme) : Prop :=
+  s = subordinate ∨ s = cosubordinate
 
-    The medial/final asymmetry is the defining property of clause chaining:
-    medial verbs have reduced morphology and depend on the final verb for
-    full TAM interpretation. -/
+instance : DecidablePred Dependent := fun _ =>
+  inferInstanceAs (Decidable (_ ∨ _))
+
+end CombiningScheme
+
+namespace Chaining
+
+/-- Clause chaining is cosubordination — dependent but not embedded
+    ([foley-r-d-van-valin-1984]). -/
+def scheme : CombiningScheme := .cosubordinate
+
+/-! ### Clause status and chain direction -/
+
+/-- Structural status of a clause within a chain. -/
 inductive ClauseStatus where
-  /-- Dependent clause with reduced morphology. Typically carries converbal
-      or participial marking (UD `VerbForm.Conv`). May encode SR and
-      interclausal semantic relations but lacks full tense/agreement. -/
+  /-- Dependent clause with reduced morphology. Typically carries
+      converbal or participial marking (UD `VerbForm.Conv`); may encode
+      switch-reference and interclausal relations but lacks full
+      tense/agreement. -/
   | medial
-  /-- Independent clause with full inflection. Supplies tense, mood, and
-      often agreement for the entire chain. Exactly one per chain. -/
+  /-- Independent clause with full inflection. Supplies tense, mood,
+      and often agreement for the entire chain; exactly one per
+      chain. -/
   | final
   deriving DecidableEq, Repr, Inhabited
 
--- ============================================================================
--- § Chain directionality
--- ============================================================================
-
-/-- Linear order of medial and final clauses.
-
-    Medial-final order is overwhelmingly dominant, correlating strongly with
-    verb-final (SOV/SOV-flexible) word order. Initial-medial order is rare,
-    attested in some verb-initial languages. The correlation follows from the
-    head-direction generalization: the final verb is the "head"
-    of the chain, and its position mirrors the language's general head direction.
-
-    [sarvasy-aikhenvald-2025] §1.2. -/
+/-- Linear order of medial and final clauses
+    ([sarvasy-aikhenvald-2025] §1.2). -/
 inductive ChainDirection where
-  /-- Medial clauses precede the final clause. By far the most common pattern,
-      strongly correlated with verb-final (OV) word order.
-      E.g., Nungon, Turkish, Korean, Japanese, Manambu, Ku Waru. -/
+  /-- Medial clauses precede the final clause — by far the most common,
+      strongly correlated with verb-final word order (Nungon, Turkish,
+      Korean, Manambu, Ku Waru). -/
   | medialFinal
-  /-- An initial independent clause precedes medial dependent clauses. Rare;
-      attested in some verb-initial and SVO languages (e.g., Barai, some
-      Papuan languages with initial-verb tendencies). -/
+  /-- An initial independent clause precedes medial dependent clauses —
+      rare, attested in some verb-initial languages (Barai). -/
   | initialMedial
   deriving DecidableEq, Repr, Inhabited
 
-/-- Predicted head direction for a given chain direction.
-
-    Medial-final chains place the "head" (final verb, which determines TAM
-    for the chain) at the right edge — consistent with head-final languages.
-    Initial-medial chains place it at the left edge — consistent with
-    head-initial languages. -/
+/-- Predicted head direction: the final verb determines the chain's TAM
+    and patterns as its head, so chain direction mirrors the language's
+    head direction ([dryer-1992]-style correlation;
+    [sarvasy-aikhenvald-2025] §1.2). -/
 def ChainDirection.predictedHeadDirection : ChainDirection → HeadDirection
-  | .medialFinal  => .headFinal
+  | .medialFinal => .headFinal
   | .initialMedial => .headInitial
 
--- ============================================================================
--- § Morphological reduction on medial verbs
--- ============================================================================
+/-! ### Medial-verb morphology -/
 
-/-- How much of a morphological category a medial verb retains relative to
-    independent (final) verbs.
-
-    Medial verbs are characteristically "partially finite": they may retain some
-    TAM distinctions while lacking others. This three-way scale captures the
-    cross-linguistic variation. The ordering is full > restricted > absent.
-
-    [sarvasy-aikhenvald-2025] §§1.3-1.5; [de-vries-2025] §2. -/
+/-- How much of a morphological category a medial verb retains relative
+    to independent verbs — the three-point scale `absent < restricted <
+    full` ([sarvasy-aikhenvald-2025] §§1.3–1.5; [de-vries-2025] §2). -/
 inductive CategoryRetention where
-  /-- Full paradigm: medial verbs mark this category with the same range of
-      values as independent verbs. E.g., Turkish converbs retain aspect. -/
-  | full
-  /-- Reduced paradigm: medial verbs distinguish fewer values than independent
-      verbs. E.g., only realis/irrealis (binary mood), not the full mood
-      paradigm; or only perfective/imperfective, not all aspect values. -/
-  | restricted
-  /-- Category unmarked: medial verbs carry no morphology for this category.
-      Its value is inherited from the final verb's specification (scope).
-      E.g., Nungon medial verbs lack tense entirely. -/
+  /-- Unmarked on medial verbs; the value is inherited from the final
+      verb (Nungon medial verbs lack tense entirely). -/
   | absent
+  /-- Fewer values than independent verbs (e.g. binary realis/irrealis
+      rather than a full mood paradigm). -/
+  | restricted
+  /-- The same range of values as independent verbs (Turkish converbs
+      retain aspect). -/
+  | full
   deriving DecidableEq, Repr, Inhabited
 
-instance : LE CategoryRetention where
-  le a b := match a, b with
-    | .absent, _ => True
-    | .restricted, .restricted | .restricted, .full => True
-    | .full, .full => True
-    | _, _ => False
+/-- Position on the retention scale. -/
+def CategoryRetention.rank : CategoryRetention → Nat
+  | .absent => 0
+  | .restricted => 1
+  | .full => 2
 
-instance : DecidableRel (α := CategoryRetention) (· ≤ ·) := λ a b =>
-  match a, b with
-  | .absent, _ => isTrue trivial
-  | .restricted, .restricted | .restricted, .full => isTrue trivial
-  | .full, .full => isTrue trivial
-  | .full, .absent | .full, .restricted | .restricted, .absent =>
-    isFalse (λ h => nomatch h)
+/-- The retention scale as a linear order: `absent < restricted <
+    full`. -/
+instance : LinearOrder CategoryRetention :=
+  .lift' CategoryRetention.rank fun a b => by
+    cases a <;> cases b <;> simp [CategoryRetention.rank]
 
-/-- Absent ≤ everything: the bottom of the retention scale. -/
-theorem absent_le (r : CategoryRetention) : .absent ≤ r := trivial
+/-- `absent` is the bottom of the retention scale. -/
+theorem CategoryRetention.absent_le (r : CategoryRetention) :
+    absent ≤ r := by cases r <;> decide
 
-/-- Morphological profile of medial verbs along five TAM dimensions.
-
-    Each dimension records how much of the category's paradigm is retained on
-    medial verbs. A fully reduced medial verb (all `.absent`) is a bare converb;
-    a fully retained profile (all `.full`) approaches an independent verb.
-
-    This structure is effectively a 5-dimensional finiteness vector. The
-    traditional binary finite/non-finite distinction is a coarsening that
-    collapses all five dimensions into one bit. -/
+/-- Morphological profile of medial verbs along five TAM dimensions —
+    a per-category finiteness vector, of which the binary
+    finite/non-finite cut is a coarsening. -/
 structure MedialMorphProfile where
-  /-- Tense marking. Absent in many Papuan languages (Nungon, Ku Waru);
-      restricted in some (Manambu: only yesterday/today/remote); full in
-      some Turkic and Caucasian languages. -/
-  tense     : CategoryRetention
-  /-- Subject agreement. Often absent on medial verbs (agreement inherited
-      from final verb when SS); sometimes restricted to person only. -/
+  /-- Tense (absent in Nungon and Ku Waru; restricted in Manambu; full
+      in some Turkic and Caucasian languages). -/
+  tense : CategoryRetention
+  /-- Subject agreement (often inherited from the final verb under
+      same-subject marking). -/
   agreement : CategoryRetention
-  /-- Mood distinctions. Typically restricted to a binary realis/irrealis
-      split when present at all. Full mood paradigms on medial verbs are
-      rare cross-linguistically. -/
-  mood      : CategoryRetention
-  /-- Independent negation. Whether medial clauses can be independently
-      negated. Some languages restrict negation to the final clause only
-      (polarity scopes over chain); others allow medial negation. -/
-  polarity  : CategoryRetention
-  /-- Aspectual distinctions. Some languages retain perfective/imperfective
-      on medial verbs to distinguish completed vs. ongoing subevents. -/
-  aspect    : CategoryRetention
+  /-- Mood (typically at most a binary realis/irrealis split). -/
+  mood : CategoryRetention
+  /-- Independent negation of the medial clause (some languages
+      restrict negation to the final clause, so polarity scopes over
+      the chain). -/
+  polarity : CategoryRetention
+  /-- Aspect (some languages retain perfective/imperfective to
+      distinguish completed vs ongoing subevents). -/
+  aspect : CategoryRetention
   deriving Repr, DecidableEq
 
-/-- Whether this profile represents maximal reduction (all categories absent). -/
-def MedialMorphProfile.isMaximallyReduced (p : MedialMorphProfile) : Bool :=
-  p.tense == .absent && p.agreement == .absent && p.mood == .absent &&
-  p.polarity == .absent && p.aspect == .absent
+namespace MedialMorphProfile
 
-/-- Whether this profile represents no reduction (all categories full). -/
-def MedialMorphProfile.isFullyRetained (p : MedialMorphProfile) : Bool :=
-  p.tense == .full && p.agreement == .full && p.mood == .full &&
-  p.polarity == .full && p.aspect == .full
+variable (p : MedialMorphProfile)
 
-/-- Expected UD VerbForm for a medial verb given its morphological profile.
+/-- Every category is absent: a bare converb. -/
+def MaximallyReduced : Prop :=
+  p.tense = .absent ∧ p.agreement = .absent ∧ p.mood = .absent ∧
+    p.polarity = .absent ∧ p.aspect = .absent
 
-    Maximally or partially reduced medial verbs map to `VerbForm.Conv` (converb).
-    Fully retained medial verbs approach `VerbForm.Fin`, though they still differ
-    from independent verbs in lacking illocutionary force. -/
-def MedialMorphProfile.udVerbForm (p : MedialMorphProfile) : UD.VerbForm :=
-  if p.isFullyRetained then .Fin else .Conv
+instance : DecidablePred MaximallyReduced := fun _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
 
--- ============================================================================
--- § Switch-reference
--- ============================================================================
+/-- Every category is full: the profile of an independent verb (though
+    a medial verb still lacks illocutionary force). -/
+def FullyRetained : Prop :=
+  p.tense = .full ∧ p.agreement = .full ∧ p.mood = .full ∧
+    p.polarity = .full ∧ p.aspect = .full
 
-/-- Type of switch-reference system.
+instance : DecidablePred FullyRetained := fun _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
 
-    SR is a morphological system on medial verbs that tracks referential
-    continuity across clause boundaries. It is orthogonal to binding theory:
-    binding constrains coreference within a clause via syntactic configuration
-    (c-command); SR tracks coreference between clauses via verbal morphology.
+/-- Expected UD verb form for a medial verb with this profile: converb
+    unless fully retained. -/
+def udVerbForm : UD.VerbForm :=
+  if p.FullyRetained then .Fin else .Conv
 
-    [sarvasy-aikhenvald-2025] §§1.4-1.5; [de-vries-2025] §§3-4;
-    [sarvasy-aikhenvald-2025] §3. -/
+end MedialMorphProfile
+
+/-! ### Switch-reference -/
+
+/-- Type of switch-reference system: morphology on medial verbs
+    tracking referential continuity across clause boundaries —
+    orthogonal to binding theory, which constrains intra-clausal
+    coreference configurationally ([sarvasy-aikhenvald-2025] §§1.4–1.5,
+    §3; [de-vries-2025] §§3–4). -/
 inductive SRSystem where
-  /-- No SR morphology. The language may still have clause chaining (e.g.,
-      Korean, Turkish, Japanese) but does not grammatically mark whether
-      subjects corefer across clause boundaries. -/
+  /-- No SR morphology; the language may still chain (Korean, Turkish,
+      Japanese). -/
   | none
-  /-- Binary SS/DS distinction. Medial verbs carry morphology indicating
-      same-subject (SS) or different-subject (DS) relative to the next
-      clause. The canonical and most widespread SR system.
-      E.g., Nungon, Ku Waru, many Papuan and Amerindian languages. -/
+  /-- Binary same-subject vs different-subject marking — the canonical
+      system (Nungon, Ku Waru, many Papuan and Amerindian languages). -/
   | ssDs
-  /-- SS/DS plus temporal relation encoding. Medial verb morphology
-      simultaneously signals referential continuity and temporal relation
-      (sequential vs. simultaneous). SS-sequential, SS-simultaneous,
-      DS-sequential, DS-simultaneous are distinct forms.
-      E.g., Nungon, Amele, many Trans-New Guinea languages. -/
+  /-- SS/DS fused with temporal relation: SS-sequential,
+      SS-simultaneous, DS-sequential, DS-simultaneous as distinct forms
+      (Nungon, Amele, many Trans-New Guinea languages). -/
   | ssDsTemporal
-  /-- Multi-track SR. Tracks continuity of more than one argument: e.g.,
-      subject and object, or subject and possessor. Rare.
-      E.g., Panoan languages (subject+object tracking). -/
+  /-- Tracks more than one argument (e.g. subject and object) — rare
+      (Panoan). -/
   | multiTrack
   deriving DecidableEq, Repr, Inhabited
 
-/-- What participant role(s) SR tracks.
-
-    Canonical SR tracks syntactic subjects. Some systems track topical
-    participants (pragmatic, not syntactic) or multiple arguments. -/
+/-- What the SR system tracks. -/
 inductive SRTarget where
-  /-- Track syntactic subject only. The canonical and most widespread pattern.
-      E.g., Nungon, Ku Waru, most Papuan and Amerindian languages. -/
+  /-- Syntactic subject only — the canonical pattern. -/
   | subjectOnly
-  /-- Track both subject and object. Rare.
-      E.g., some Panoan languages. -/
+  /-- Subject and object — rare (some Panoan languages). -/
   | subjectAndObject
-  /-- Track the topical participant, which may not be the syntactic subject.
-      The tracked referent is determined by discourse prominence rather than
-      grammatical function.
-      E.g., Greater Awyu languages ([de-vries-2025] §4.4). -/
+  /-- The topical participant, determined by discourse prominence
+      rather than grammatical function (Greater Awyu,
+      [de-vries-2025] §4.4). -/
   | topicBased
   deriving DecidableEq, Repr, Inhabited
 
-/-- SR marking asymmetry.
-
-    Cross-linguistically, SS forms tend to be morphologically simpler (shorter,
-    less marked) than DS forms. This asymmetry reflects the discourse-pragmatic
-    default: subject continuity is the unmarked expectation in connected
-    discourse. -/
+/-- Markedness asymmetry between the SS and DS forms. Subject
+    continuity is the discourse default, so SS is usually the unmarked
+    member. -/
 inductive SRMarkedness where
-  /-- SS is the morphologically unmarked member (shorter, zero, or suffix-only).
-      DS carries overt marking. The cross-linguistically dominant pattern. -/
+  /-- SS shorter, zero, or suffix-only; DS overtly marked — the
+      dominant pattern. -/
   | ssUnmarked
-  /-- DS is the morphologically unmarked member. Rare. -/
+  /-- DS unmarked — rare. -/
   | dsUnmarked
-  /-- SS and DS are both overtly marked with comparable morphological weight. -/
+  /-- Both overtly marked with comparable weight. -/
   | symmetric
   deriving DecidableEq, Repr, Inhabited
 
--- ============================================================================
--- § Interclausal semantic relations
--- ============================================================================
+/-! ### Interclausal relations and bridging -/
 
-/-- Semantic relation between a medial clause and the next clause in the chain.
-
-    These relations may be encoded on the medial verb (via dedicated morphology
-    or converbal suffixes), inferred from context, or signaled by the SR system
-    (e.g., SS-sequential vs. SS-simultaneous as distinct forms).
-
-    [sarvasy-aikhenvald-2025] §1.4; [longacre-2007]. -/
+/-- Semantic relation between a medial clause and the next clause,
+    encoded on the medial verb, inferred, or signaled by the SR system
+    ([sarvasy-aikhenvald-2025] §1.4; [longacre-2007]). -/
 inductive InterclauseRelation where
-  | sequential    -- medial event precedes next event (iconic temporal order)
-  | simultaneous  -- medial event overlaps temporally with next event
-  | causal        -- medial event is reason/cause for next event
-  | conditional   -- medial event is condition for next event
-  | concessive    -- medial event holds despite next event (although/even though)
-  | manner        -- medial event specifies how next event occurs
-  | contrastive   -- medial and next events contrast (but/whereas)
-  | additive      -- medial event added to next without temporal/causal import
-  | purpose       -- medial event is purpose of next event (in order to)
+  | sequential    -- medial event precedes next event (iconic order)
+  | simultaneous  -- medial event overlaps the next event
+  | causal        -- medial event is reason for the next event
+  | conditional   -- medial event is condition for the next event
+  | concessive    -- medial event holds despite the next event
+  | manner        -- medial event specifies how the next event occurs
+  | contrastive   -- the events contrast
+  | additive      -- added without temporal or causal import
+  | purpose       -- medial event is the purpose of the next event
   deriving DecidableEq, Repr, Inhabited
 
-/-- Whether a relation involves temporal ordering. -/
-def InterclauseRelation.IsTemporal (r : InterclauseRelation) : Prop :=
+/-- The temporal relations — exactly the ones SR morphology can encode
+    without additional marking (`SRSystem.ssDsTemporal`). -/
+def InterclauseRelation.Temporal (r : InterclauseRelation) : Prop :=
   r = .sequential ∨ r = .simultaneous
 
-instance : DecidablePred InterclauseRelation.IsTemporal :=
+instance : DecidablePred InterclauseRelation.Temporal :=
   fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
-/-- Whether a relation can be encoded purely via SR morphology
-    (without a separate connective or adverbial suffix).
-    In many Papuan languages, SR forms directly encode sequential vs.
-    simultaneous, while other relations require additional marking. -/
-def InterclauseRelation.encodableViaSR : InterclauseRelation → Bool
-  | .sequential   => true
-  | .simultaneous => true
-  | _             => false
-
--- ============================================================================
--- § Bridging constructions
--- ============================================================================
-
-/-- Discourse-level bridging constructions that span clause chain boundaries.
-
-    These are characteristic of oral narrative in clause-chaining languages
-    and serve to structure discourse into episodes.
-
-    [sarvasy-aikhenvald-2025] §1.6; [sarvasy-aikhenvald-2025] §3.3. -/
+/-- Discourse bridging constructions spanning chain boundaries,
+    characteristic of oral narrative ([sarvasy-aikhenvald-2025] §1.6,
+    §3.3). -/
 inductive BridgingType where
-  /-- Recapitulative (tail-head) linkage: the first medial clause of a new chain
-      repeats (wholly or in reduced form) the final clause of the preceding chain.
-      Creates cohesion across chain boundaries in oral narrative.
-      E.g., Nungon, Ku Waru, many Trans-New Guinea languages. -/
+  /-- Recapitulative (tail-head) linkage: the first medial clause of a
+      new chain repeats the final clause of the preceding one (Nungon,
+      Ku Waru). -/
   | recapitulative
-  /-- Summary linkage: a generic verb form (typically 'do' or 'say') summarizes
-      the entire preceding episode before the next chain begins.
-      E.g., Ku Waru *ab-*, Manambu *a-yk-*. -/
+  /-- Summary linkage: a generic verb ('do', 'say') summarizes the
+      preceding episode (Ku Waru, Manambu). -/
   | summary
   deriving DecidableEq, Repr, Inhabited
 
--- ============================================================================
--- § Clause-linking strategy (shared vocabulary)
--- ============================================================================
+/-! ### The per-language bundle -/
 
-/-- The three major clause-linking strategies, following [foley-r-d-van-valin-1984].
-
-    This type provides shared vocabulary across the clause-combining phenomenon
-    directories (Coordination, Complementation, FillerGap, ClauseChaining).
-    The key insight: clause chaining is neither coordination nor subordination
-    but a third strategy — dependent but not embedded. -/
-inductive ClauseLinkingStrategy where
-  /-- Coordination: syntactically equal, independent clauses joined by a
-      conjunction or juxtaposition. Neither clause is embedded in the other.
-      E.g., "John sang and Mary danced." -/
-  | coordination
-  /-- Subordination: one clause is embedded within the other as a syntactic
-      constituent (complement, relative clause, adverbial clause). The
-      embedded clause is both dependent and structurally contained.
-      E.g., "I know [that John sang]." -/
-  | subordination
-  /-- Cosubordination: one clause is dependent on the other (reduced morphology,
-      cannot stand alone) but is not embedded as a constituent. The medial clause
-      is structurally adjacent, not contained within the final clause.
-      Clause chaining is the prototypical instantiation.
-      E.g., Nungon: "he having.come, she cooked" (medial + final). -/
-  | cosubordination
-  deriving DecidableEq, Repr, Inhabited
-
-/-- Clause chaining is cosubordination: dependent but not embedded. -/
-def clauseChainingStrategy : ClauseLinkingStrategy := .cosubordination
-
-/-- Whether the dependent clause is embedded as a syntactic constituent. -/
-def ClauseLinkingStrategy.IsEmbedded (s : ClauseLinkingStrategy) : Prop :=
-  s = .subordination
-
-instance : DecidablePred ClauseLinkingStrategy.IsEmbedded :=
-  fun _ => inferInstanceAs (Decidable (_ = _))
-
-/-- Whether the dependent clause is morphologically reduced (non-independent). -/
-def ClauseLinkingStrategy.IsDependentReduced (s : ClauseLinkingStrategy) : Prop :=
-  s = .subordination ∨ s = .cosubordination
-
-instance : DecidablePred ClauseLinkingStrategy.IsDependentReduced :=
-  fun _ => inferInstanceAs (Decidable (_ ∨ _))
-
--- ============================================================================
--- § Language-level parameter bundle
--- ============================================================================
-
-/-- Full clause chaining parameter bundle for a language.
-
-    Captures the five major typological dimensions:
-    1. Chain structure (direction, length, non-canonical possibilities)
-    2. Switch-reference (system type, target, obligatoriness, markedness)
-    3. Medial verb morphology (5-dimensional TAM retention profile)
-    4. Interclausal semantics (which relations are grammatically marked)
-    5. Discourse bridging (recapitulative and/or summary linkage) -/
+/-- Clause-chaining parameters of a language: chain structure,
+    switch-reference, medial morphology, marked relations, and
+    bridging. Fragments instantiate this; generalizations over the
+    bundles live in `Studies/SarvasyAikhenvald2025.lean`. -/
 structure ClauseChainingParams where
   /-- Linear order of medial and final clauses. -/
-  direction           : ChainDirection
-  /-- Type of switch-reference system (if any). -/
-  srSystem            : SRSystem
-  /-- What participant role(s) SR tracks (if SR exists). -/
-  srTarget            : Option SRTarget
+  direction : ChainDirection
+  /-- Type of switch-reference system, if any. -/
+  srSystem : SRSystem
+  /-- What SR tracks, when present. -/
+  srTarget : Option SRTarget
   /-- Whether SR marking is obligatory on every medial verb. -/
-  srObligatory        : Bool
-  /-- Markedness asymmetry in the SR system. -/
-  srMarkedness        : Option SRMarkedness
+  srObligatory : Bool
+  /-- Markedness asymmetry of the SR system, when recorded. -/
+  srMarkedness : Option SRMarkedness
   /-- Morphological profile of medial verbs. -/
-  medialMorph         : MedialMorphProfile
-  /-- Interclausal semantic relations grammatically marked on medial verbs. -/
-  relationsMarked     : List InterclauseRelation
-  /-- Whether recapitulative (tail-head) linkage is attested. -/
-  hasRecapLinkage     : Bool
-  /-- Whether summary linkage is attested. -/
-  hasSummaryLinkage   : Bool
-  /-- Whether medial clauses can occur without a final clause
-      (non-canonical stand-alone medial; [sarvasy-2015]). -/
+  medialMorph : MedialMorphProfile
+  /-- Interclausal relations grammatically marked on medial verbs. -/
+  relationsMarked : List InterclauseRelation
+  /-- Recapitulative (tail-head) linkage attested. -/
+  hasRecapLinkage : Bool
+  /-- Summary linkage attested. -/
+  hasSummaryLinkage : Bool
+  /-- Medial clauses can stand without a final clause — the
+      non-canonical stand-alone medial ([sarvasy-2015]). -/
   medialCanStandAlone : Bool
   deriving Repr, BEq
 
--- ============================================================================
--- § Key functions
--- ============================================================================
+namespace ClauseChainingParams
 
-/-- Whether the language has any SR system. -/
-def ClauseChainingParams.hasSR (p : ClauseChainingParams) : Bool :=
-  p.srSystem != .none
+variable (p : ClauseChainingParams)
 
-/-- Whether tense on medial verbs is inherited from the final verb (scope).
-    This is the case when medial verbs lack tense marking entirely. -/
-def ClauseChainingParams.tenseFromFinalVerb (p : ClauseChainingParams) : Bool :=
-  p.medialMorph.tense == .absent
+/-- The language has an SR system. -/
+def hasSR : Bool := p.srSystem != .none
 
-/-- Whether the chain has any discourse bridging constructions. -/
-def ClauseChainingParams.hasBridging (p : ClauseChainingParams) : Bool :=
-  p.hasRecapLinkage || p.hasSummaryLinkage
+/-- Medial tense is inherited from the final verb (no medial tense
+    marking). -/
+def tenseFromFinalVerb : Bool := p.medialMorph.tense == .absent
 
-/-- Whether temporal relations are encoded via SR morphology (as opposed to
-    requiring separate adverbial marking). -/
-def ClauseChainingParams.temporalViaSR (p : ClauseChainingParams) : Bool :=
-  p.srSystem == .ssDsTemporal
+/-- Some discourse bridging construction is attested. -/
+def hasBridging : Bool := p.hasRecapLinkage || p.hasSummaryLinkage
 
-/-- Expected UD VerbForm for medial verbs in this language. -/
-def ClauseChainingParams.medialVerbForm (p : ClauseChainingParams) : UD.VerbForm :=
-  p.medialMorph.udVerbForm
+/-- Temporal relations are encoded by the SR morphology itself. -/
+def temporalViaSR : Bool := p.srSystem == .ssDsTemporal
 
--- ============================================================================
--- § Invariant theorems
--- ============================================================================
+/-- Expected UD verb form for this language's medial verbs. -/
+def medialVerbForm : UD.VerbForm := p.medialMorph.udVerbForm
 
-/-- Clause chaining is cosubordination: dependent but not embedded. -/
-theorem chaining_not_embedded :
-    ¬ clauseChainingStrategy.IsEmbedded := by decide
+end ClauseChainingParams
 
-/-- Clause chaining involves dependent reduction (unlike coordination). -/
-theorem chaining_is_dependent :
-    clauseChainingStrategy.IsDependentReduced := by decide
+end Chaining
 
-/-- Medial-final chains predict head-final word order. -/
-theorem medialFinal_is_headFinal :
-    ChainDirection.medialFinal.predictedHeadDirection = .headFinal := rfl
-
-/-- Initial-medial chains predict head-initial word order. -/
-theorem initialMedial_is_headInitial :
-    ChainDirection.initialMedial.predictedHeadDirection = .headInitial := rfl
-
-/-- A maximally reduced medial verb maps to UD converb. -/
-theorem maxReduced_is_converb :
-    (MedialMorphProfile.mk .absent .absent .absent .absent .absent).udVerbForm
-    = UD.VerbForm.Conv := rfl
-
-/-- A fully retained medial verb maps to UD finite. -/
-theorem fullRetained_is_finite :
-    (MedialMorphProfile.mk .full .full .full .full .full).udVerbForm
-    = UD.VerbForm.Fin := rfl
-
-/-- Temporal relations (sequential, simultaneous) are encodable via SR. -/
-theorem sequential_encodable_via_sr :
-    InterclauseRelation.sequential.encodableViaSR = true := rfl
-
-theorem simultaneous_encodable_via_sr :
-    InterclauseRelation.simultaneous.encodableViaSR = true := rfl
-
-/-- Non-temporal relations require additional marking beyond SR. -/
-theorem causal_not_sr_only :
-    InterclauseRelation.causal.encodableViaSR = false := rfl
-
-end Clause.Chaining
+end Clause

--- a/Linglib/Syntax/Clause/Chaining.lean
+++ b/Linglib/Syntax/Clause/Chaining.lean
@@ -26,8 +26,8 @@ bundles and generalizations in `Studies/SarvasyAikhenvald2025.lean`.
 * `SRSystem`, `SRTarget`, `SRMarkedness` — switch-reference
 * `InterclauseRelation` — marked interclausal semantic relations
 * `BridgingType` — discourse bridging across chain boundaries
-* `ClauseChainingParams` — the per-language bundle Fragments
-  instantiate
+* `System` — a language's clause-chaining system; per-language
+  instances live in `Studies/SarvasyAikhenvald2025.lean`
 -/
 
 namespace Clause
@@ -277,11 +277,11 @@ inductive BridgingType where
 
 /-! ### The per-language bundle -/
 
-/-- Clause-chaining parameters of a language: chain structure,
+/-- A language's clause-chaining system: chain structure,
     switch-reference, medial morphology, marked relations, and
-    bridging. Fragments instantiate this; generalizations over the
-    bundles live in `Studies/SarvasyAikhenvald2025.lean`. -/
-structure ClauseChainingParams where
+    bridging. Per-language instances and generalizations over them
+    live in `Studies/SarvasyAikhenvald2025.lean`. -/
+structure System where
   /-- Linear order of medial and final clauses. -/
   direction : ChainDirection
   /-- Type of switch-reference system, if any. -/
@@ -305,9 +305,9 @@ structure ClauseChainingParams where
   medialCanStandAlone : Bool
   deriving Repr, BEq
 
-namespace ClauseChainingParams
+namespace System
 
-variable (p : ClauseChainingParams)
+variable (p : System)
 
 /-- The language has an SR system. -/
 def hasSR : Bool := p.srSystem != .none
@@ -325,7 +325,7 @@ def temporalViaSR : Bool := p.srSystem == .ssDsTemporal
 /-- Expected UD verb form for this language's medial verbs. -/
 def medialVerbForm : UD.VerbForm := p.medialMorph.udVerbForm
 
-end ClauseChainingParams
+end System
 
 end Chaining
 


### PR DESCRIPTION
Recovers the Chaining.lean cleanup stranded on #1826's branch after its squash-merge: merges the duplicate scheme enum into `Clause.CombiningScheme`, drops echo theorems and banners, and renames `ClauseChainingParams` → `Clause.Chaining.System`.