### PR TITLE
refactor(Syntax/Clause): Clause is an interface, not a record

### DIFF
--- a/Linglib/Fragments/Buryat/Complementizers.lean
+++ b/Linglib/Fragments/Buryat/Complementizers.lean
@@ -76,8 +76,8 @@ clause-embedding verbs). -/
 (§4.3.1). Richer than the bare `Frame.gerund` cell: it records the
 embedded-subject case. -/
 def nominalizedFrame : Frame :=
-  [.clausal { coding := some .nominalized,
-              embeddedSubject := some (.overt (some .gen)) }]
+  [.clausal (coding := some .nominalized)
+    (embeddedSubject := some (.overt (some .gen)))]
 
 /-- *hanaxa* 'think ~ remember': 'think' with a bare gɘžɘ-CP, 'remember'
 with a nominalized complement (§4.4.3). The `readings` rows carry the

--- a/Linglib/Syntax/Category/Verb/Frame.lean
+++ b/Linglib/Syntax/Category/Verb/Frame.lean
@@ -4,14 +4,14 @@ import Linglib.Syntax.Clause.Basic
 
 A predicate's complement frame as a list of typed
 `Complement.Position`s: nominal, adpositional, or clausal, the clausal
-case carrying its `Clause` description. The flat `ComplementType` enum
-survives as a round-trip view (`ComplementType.toFrame` /
-`Frame.toComplementType`).
+case carrying the axes the predicate selects for. The flat
+`ComplementType` enum survives as a round-trip view
+(`ComplementType.toFrame` / `Frame.toComplementType`).
 
 ## Main definitions
 
 * `Complement.Position` — one complement position; a clausal position
-  carries a `Clause` by construction
+  carries its selectional axes by construction
 * `Frame` + `Frame.np`, `Frame.finiteClause`, … — a frame is a list of
   complement positions; the flat enum cells as smart constructors
 * `ComplementType` + `toFrame` / `Frame.toComplementType` — the flat
@@ -37,28 +37,29 @@ selection relation between verb frames and clause-typers
 namespace Complement
 
 /-- One complement position of a predicate's frame: nominal,
-    adpositional, or clausal with its recorded `Clause` description.
-    Non-clausal positions carry no clausal axes by construction. -/
+    adpositional, or clausal with the axes the predicate selects for —
+    [noonan-2007] coding, clause form, and subject requirement, `none`
+    = unselective. Non-clausal positions carry no clausal axes by
+    construction. -/
 inductive Position where
   | nominal
   | adpositional
-  | clausal (clause : Clause)
+  | clausal (coding : Option Coding := none)
+      (clauseForm : Option Clause.Form := none)
+      (embeddedSubject : Option Clause.EmbeddedSubject := none)
   deriving DecidableEq, Repr
 
 namespace Position
 
-/-- The clausal position's `Clause`, if any. -/
-def clause? : Position → Option Clause
-  | clausal c => some c
+/-- The position's recorded [noonan-2007] coding, if clausal. -/
+def coding? : Position → Option Coding
+  | clausal c _ _ => c
   | _ => none
 
-/-- The position's recorded [noonan-2007] coding, if clausal. -/
-def coding? (p : Position) : Option Coding :=
-  p.clause?.bind (·.coding)
-
 /-- The position's recorded clause form, if clausal. -/
-def clauseForm? (p : Position) : Option Clause.Form :=
-  p.clause?.bind (·.clauseForm)
+def clauseForm? : Position → Option Clause.Form
+  | clausal _ cf _ => cf
+  | _ => none
 
 end Position
 
@@ -97,27 +98,26 @@ def np_pp : Frame := [.nominal, .adpositional]
 
 /-- Finite declarative clause. -/
 def finiteClause : Frame :=
-  [.clausal { coding := some .indicative,
-              clauseForm := some .declarative }]
+  [.clausal (coding := some .indicative) (clauseForm := some .declarative)]
 
 /-- Infinitival clause. The embedded-subject requirement varies by verb
     (equi-deletion, raising, or adposition-marked overt subjects,
     [noonan-2007] §1.3.4), so it lives on the verb's reading, not here. -/
-def infinitival : Frame := [.clausal { coding := some .infinitive }]
+def infinitival : Frame := [.clausal (coding := some .infinitive)]
 
 /-- Gerund / nominalized clause. -/
-def gerund : Frame := [.clausal { coding := some .nominalized }]
+def gerund : Frame := [.clausal (coding := some .nominalized)]
 
 /-- Small clause (*consider X happy*; causative *make X leave*). Outside
     [noonan-2007]'s coding inventory, which classifies complements by
-    the part of speech of their predicate, so the clause records
+    the part of speech of their predicate, so the position records
     nothing. -/
-def smallClause : Frame := [.clausal {}]
+def smallClause : Frame := [.clausal]
 
 /-- Embedded question. Interrogativity is a clause-form distinction
     orthogonal to [noonan-2007] coding, so `coding` stays `none`. -/
 def question : Frame :=
-  [.clausal { clauseForm := some .embeddedQuestion }]
+  [.clausal (clauseForm := some .embeddedQuestion)]
 
 end Frame
 

--- a/Linglib/Syntax/Category/Verb/Selection.lean
+++ b/Linglib/Syntax/Category/Verb/Selection.lean
@@ -6,45 +6,57 @@ import Linglib.Syntax.Category.Complementizer.Basic
 
 The hom between the `Verb` and `Complementizer` entry APIs: which
 clause-typers can head a predicate's complements. The core relation is
-axis-wise compatibility between a `Clause` description's recorded axes
-and a clause-typer's — [noonan-2007]'s coding axis and the clause-form
+axis-wise compatibility between a clausal position's recorded axes and
+a clause-typer's — [noonan-2007]'s coding axis and the clause-form
 axis — with no conflicting axis and at least one positively agreeing
-one. Position-, frame- and verb-level relations are derived lifts, all
-decidable.
+one. Frame- and verb-level relations are derived lifts, all decidable.
+`Complement.Position.SatisfiedBy` is the object-side counterpart: the
+recorded axes checked against any `Clause` carrier.
 
 ## Main definitions
 
-- `Clause.TypedBy` — the axis-matching core
-- `Complement.Position.TypedBy`, `Frame.RealizedBy`, `Verb.realizes` —
-  the derived lifts
+- `Complement.Position.TypedBy` — the axis-matching core
+- `Complement.Position.SatisfiedBy` — satisfaction by a `Clause` object
+- `Frame.RealizedBy`, `Verb.realizes` — the derived lifts
 - `Verb.typers` — the typers of a verb within an inventory
 
 Consistency checks against Fragment data live in Studies
 (e.g. `Bondarenko2022.hanaxa_frames_realized`).
 -/
 
-/-- Clause-typer `z` types clause `c`: no axis both sides record
-    conflicts, and at least one recorded axis agrees (matching needs
-    positive evidence — a typer recording nothing types nothing). -/
-def Clause.TypedBy (c : Clause) (z : Complementizer) : Prop :=
-  (c.coding = none ∨ z.coding = none ∨ c.coding = z.coding) ∧
-    (c.clauseForm = none ∨ z.clauseForm = none ∨
-      c.clauseForm = z.clauseForm) ∧
-    ((c.coding ≠ none ∧ c.coding = z.coding) ∨
-      (c.clauseForm ≠ none ∧ c.clauseForm = z.clauseForm))
-
-instance (c : Clause) (z : Complementizer) : Decidable (c.TypedBy z) :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- A clausal position is typed by `z` iff its clause is. -/
+/-- Clause-typer `z` types the clausal position: no axis both sides
+    record conflicts, and at least one recorded axis agrees (matching
+    needs positive evidence — a typer recording nothing types nothing).
+    Non-clausal positions are typed by nothing. -/
 def Complement.Position.TypedBy : Complement.Position →
     Complementizer → Prop
-  | .clausal c, z => c.TypedBy z
+  | .clausal coding form _, z =>
+      (coding = none ∨ z.coding = none ∨ coding = z.coding) ∧
+        (form = none ∨ z.clauseForm = none ∨ form = z.clauseForm) ∧
+        ((coding ≠ none ∧ coding = z.coding) ∨
+          (form ≠ none ∧ form = z.clauseForm))
   | _, _ => False
 
 instance : (p : Complement.Position) → (z : Complementizer) →
     Decidable (p.TypedBy z)
-  | .clausal c, z => inferInstanceAs (Decidable (c.TypedBy z))
+  | .clausal _ _ _, _ => inferInstanceAs (Decidable (_ ∧ _))
+  | .nominal, _ => inferInstanceAs (Decidable False)
+  | .adpositional, _ => inferInstanceAs (Decidable False)
+
+/-- A `Clause` object satisfies the clausal position: every axis the
+    position records, the object determines and agrees on. A position
+    recording nothing is satisfied by every clause object; non-clausal
+    positions by none. -/
+def Complement.Position.SatisfiedBy {C : Type*} [Clause C] :
+    Complement.Position → C → Prop
+  | .clausal coding form _, c =>
+      (coding = none ∨ Clause.coding? c = coding) ∧
+        (form = none ∨ Clause.form? c = form)
+  | _, _ => False
+
+instance {C : Type*} [Clause C] : (p : Complement.Position) → (c : C) →
+    Decidable (p.SatisfiedBy c)
+  | .clausal _ _ _, _ => inferInstanceAs (Decidable (_ ∧ _))
   | .nominal, _ => inferInstanceAs (Decidable False)
   | .adpositional, _ => inferInstanceAs (Decidable False)
 
@@ -65,4 +77,4 @@ instance (v : Verb) (c : Complementizer) : Decidable (v.realizes c) :=
 /-- The typers of `v` within a language's complementizer inventory. -/
 def Verb.typers (v : Verb) (inv : List Complementizer) :
     List Complementizer :=
-  inv.filter (fun c => decide (v.realizes c))
+  inv.filter (λ c => decide (v.realizes c))

--- a/Linglib/Syntax/Clause/Basic.lean
+++ b/Linglib/Syntax/Clause/Basic.lean
@@ -1,27 +1,41 @@
-import Linglib.Syntax.Clause.Construction
+import Linglib.Syntax.Clause.Size
 import Linglib.Syntax.Clause.Form
 import Linglib.Features.Complementation
 import Linglib.Features.Case.Basic
 
 /-!
-# The clause object
+# The clause interface
 
-A clause is a predication: at minimum a predicate and an explicit or
-implied subject, expressing a proposition. `Clause` records the axes
-sources record about one — the construction it instantiates
-(`Clause.Construction`), its surface form (`Clause.Form`), its
-[noonan-2007] coding (`Complement.Coding`), and its subject requirement
-(`Clause.EmbeddedSubject`). A `none` field is unrecorded, not a claim —
-the record-what-sources-record convention of the Fragment layer, where
-these values originate. The first consumer is the clausal case of
-`Complement.Position` (`Syntax/Category/Verb/Frame.lean`), so a
-complement frame's clausal position carries a `Clause` by construction.
+A clause is a predication — at minimum a predicate and an explicit or
+implied subject, expressing a proposition. What a clause *is*
+concretely is framework-relative (a Minimalist extended projection, an
+HPSG sign, a dependency subtree), so `Clause` is the interface those
+carriers instantiate: a clause object answers the theory-neutral
+queries — its grade on the `Clause.Size` scale and the selectional
+axes ([noonan-2007] coding, `Clause.Form`) — and consumers reason
+through the queries rather than importing a framework.
+`Minimalist.ClauseSpine` is the first instance
+(`Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean`).
 
 ## Main definitions
 
-* `Clause.EmbeddedSubject` — the subject-requirement axis
-* `Clause` — the predication record
+* `Clause` — the interface: `size`, `coding?`, `form?`
+* `Clause.EmbeddedSubject` — the subject-requirement axis complement
+  frames record (`Syntax/Category/Verb/Frame.lean`)
 -/
+
+/-- Carriers of clause structure. A framework's clause object answers
+    the theory-neutral queries: its `Clause.Size` grade and the
+    selectional axes it determines (`none` = the object does not
+    determine the axis). -/
+class Clause (C : Type*) where
+  /-- The clause's grade on the theory-neutral size scale. -/
+  size : C → Clause.Size
+  /-- The [noonan-2007] coding the object realizes, when its structure
+      determines one. -/
+  coding? : C → Option Complement.Coding := λ _ => none
+  /-- The surface clause form, when the object determines one. -/
+  form? : C → Option Clause.Form := λ _ => none
 
 namespace Clause
 
@@ -37,16 +51,3 @@ inductive EmbeddedSubject where
   deriving DecidableEq, Repr
 
 end Clause
-
-/-- A clause description: the recorded axes of one predication.
-    `none` = unrecorded. -/
-structure Clause where
-  /-- The construction the clause instantiates. -/
-  construction : Option Clause.Construction := none
-  /-- Surface clause form (declarative vs embedded question). -/
-  clauseForm : Option Clause.Form := none
-  /-- [noonan-2007] coding. -/
-  coding : Option Complement.Coding := none
-  /-- Subject requirement. -/
-  embeddedSubject : Option Clause.EmbeddedSubject := none
-  deriving DecidableEq, Repr

--- a/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
+++ b/Linglib/Syntax/Minimalist/ExtendedProjection/ClauseSpine.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
+import Linglib.Syntax.Clause.Basic
 
 /-!
 # Clause Spine: Fine-Grained Clause Size
@@ -131,5 +132,27 @@ def ClauseSpine.forceP : ClauseSpine :=
     `ClauseSpine.tP.fLevel = 2` (T is F2). -/
 def ClauseSpine.fLevel (spine : ClauseSpine) : Nat :=
   fValue spine.highestHead
+
+-- ============================================================================
+-- § 5: The Clause Instance
+-- ============================================================================
+
+/-- A clause spine is a clause carrier: its size is its F-level (the
+    grading `ComplementSize.toClauseSize` already uses), and a spine
+    headed by Nmlz realizes [noonan-2007]'s nominalized coding
+    ([keine-2020]'s nominalizer head). The head inventory determines no
+    other coding (C-headed spines are indicative or subjunctive; the
+    spine does not record finiteness) and no clause form. -/
+instance : Clause ClauseSpine where
+  size := ClauseSpine.fLevel
+  coding? spine :=
+    if spine.highestHead = .Nmlz then some .nominalized else none
+
+@[simp] theorem ClauseSpine.clause_size (spine : ClauseSpine) :
+    Clause.size spine = spine.fLevel := rfl
+
+/-- The nominalized spine realizes the nominalized coding. -/
+theorem ClauseSpine.coding_nmlzP :
+    Clause.coding? ClauseSpine.nmlzP = some .nominalized := rfl
 
 end Minimalist


### PR DESCRIPTION
`Clause` becomes the interface framework clause objects instance (`size` on the `Clause.Size` scale, `coding?`, `force?`), with `Minimalist.ClauseSpine` as first instance (size = F-level, the `toClauseSize` grading; Nmlz-headed spines realize the nominalized coding). The former axis record dissolves into `Complement.Position.clausal`'s optional fields; `TypedBy` re-hosts on the position, and `SatisfiedBy` checks a position's recorded axes against any carrier.
- `Clause.Form` dissolves into its two real axes: `Mood.Illocutionary` force (with `SentenceType.force` as the projection deriving the `Interrogative` fiber) × `Clause.EmbeddingContext`; selection, frames, complementizer entries, MinimalPairs, WordGrammar, and the German clause-type cluster restate over them (`GermanClauseType` drops its index).
- The never-recorded construction axis drops from selection.