### PR TITLE
refactor(Syntax/Category/Particle): dissolve SentenceType into cells

### DIFF
--- a/Linglib/Fragments/German/Particles.lean
+++ b/Linglib/Fragments/German/Particles.lean
@@ -124,10 +124,10 @@ def questionParticles : List Particle := [denn, dochWohl]
 the clause-type facet (dass-VL clauses exclude modal particles). -/
 def licensedInClause (p : Particle) : GermanClauseType → Bool
   | .dassVL          => false
-  | .v2Declarative   => decide (p.LicensedIn .declarative)
-  | .v2Interrogative => decide (p.LicensedIn .polarInterrogative)
-  | .vlInterrogative => decide (p.LicensedIn .constituentInterrogative)
-  | .imperative      => decide (p.LicensedIn .imperative)
+  | .v2Declarative   => decide (p.LicensedIn (·.declarative))
+  | .v2Interrogative => decide (p.LicensedIn (·.polarInterrogative))
+  | .vlInterrogative => decide (p.LicensedIn (·.constituentInterrogative))
+  | .imperative      => decide (p.LicensedIn (·.imperative))
 
 /-- Every MP is excluded from dass-VL clauses. -/
 theorem all_excluded_from_dassVL :

--- a/Linglib/Studies/Gutzmann2015.lean
+++ b/Linglib/Studies/Gutzmann2015.lean
@@ -659,11 +659,11 @@ theorem wohl_iff_epis (ct : GermanClauseType) :
 /-- *ja* is restricted to declaratives, matching the clause type with
 deontic + epistemic mood but without the hearer knowledge condition. -/
 theorem ja_declarative_restriction :
-    ja.LicensedIn .declarative ∧ ¬ ja.LicensedIn .polarInterrogative := by decide
+    ja.LicensedIn (·.declarative) ∧ ¬ ja.LicensedIn (·.polarInterrogative) := by decide
 
 /-- *denn* is the interrogative counterpart of *ja*. -/
 theorem denn_interrogative_restriction :
-    ¬ denn.LicensedIn .declarative ∧ denn.LicensedIn .polarInterrogative := by decide
+    ¬ denn.LicensedIn (·.declarative) ∧ denn.LicensedIn (·.polarInterrogative) := by decide
 
 /-- *ja* and *denn* partition clause types: they are never both
 licensed in the same clause type. -/

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -487,7 +487,7 @@ open Semantics.Polarity.Marking (Env)
     questions, not assertions ([seeliger-repp-2018] §5.2). Derived from
     the fragment's distribution facet. -/
 theorem val_creates_questions :
-    ¬ Swedish.QuestionParticles.val.LicensedIn .declarative := by decide
+    ¬ Swedish.QuestionParticles.val.LicensedIn (·.declarative) := by decide
 
 /-- S&R's bias classification of *väl* (formerly fragment fields; a
     particle's bias requirement is the analysis, so it lives here):
@@ -522,7 +522,7 @@ def dochWohlOriginalBias : Option Semantics.Questions.Bias.OriginalBias :=
 /-- *doch wohl* is not usable in assertions — it marks questions.
     Derived from the fragment's distribution facet. -/
 theorem dochWohl_not_assertion :
-    ¬ German.Particles.dochWohl.LicensedIn .declarative := by decide
+    ¬ German.Particles.dochWohl.LicensedIn (·.declarative) := by decide
 
 /-- The derived RQ property behind `dochWohlOriginalBias`: both DQ types
     *doch wohl* can mark have active ("plus") epistemic bias — the
@@ -565,7 +565,7 @@ theorem dochWohl_is_complex :
     In RQs, *doch* has a "conflict" meaning — it signals surprise or
     realization — rather than the "reminding" function of assertive *doch*. -/
 theorem dochWohl_is_question_marker :
-    ¬ German.Particles.dochWohl.LicensedIn .declarative := by decide
+    ¬ German.Particles.dochWohl.LicensedIn (·.declarative) := by decide
 
 /-- German *doch* is formally ambiguous between two distinct roles:
     1. **Polarity-reversal *doch***: pre-utterance correction particle
@@ -586,7 +586,7 @@ theorem doch_dual_role :
     Env.correction ∈ dochPreUtterance.environments ∧
     Env.sentenceInternal ∉ dochPreUtterance.environments ∧
     -- The RQ *doch wohl* is a question marker (not usable in assertions)
-    ¬ dochWohl.LicensedIn .declarative := ⟨rfl, by decide, by decide, by decide⟩
+    ¬ dochWohl.LicensedIn (·.declarative) := ⟨rfl, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Romero-bridge applied to the Swedish/German data

--- a/Linglib/Syntax/Category/Particle/Basic.lean
+++ b/Linglib/Syntax/Category/Particle/Basic.lean
@@ -8,15 +8,17 @@ open Morphology (Word)
 
 This file defines `Particle`, the lexical core for uninflectable
 function words ([zwicky-1985-clitics]): form, position, and optional
-three-valued distribution facets over `Clause.SentenceType` and
-`Clause.EmbeddingContext`. Facets record distributional felicity, not
-licensing mechanism (analytical, study-side); a `none` cell means the
-source records nothing, not exclusion.
+three-valued distribution facets over the [sadock-zwicky-1985]
+sentence-type cells and `Clause.EmbeddingContext`. Facets record
+distributional felicity, not licensing mechanism (analytical,
+study-side); a `none` cell means the source records nothing, not
+exclusion. The cells are record fields, not a taxonomy: force is
+`Mood.Illocutionary`, and the interrogative subtypes are the question
+constructions of `Semantics/Questions` — a lookup is keyed by field
+projection (`p.LicensedIn (·.declarative)`).
 
 ## Main declarations
 
-* `Clause.SentenceType` — the [sadock-zwicky-1985] sentence-type
-  cells the distribution facets are recorded over
 * `Particle`, `Particle.Position`
 * `ParticleStatus`, `ClauseDistribution`, `EmbedDistribution`
 * `Particle.LicensedIn`, `Particle.LicensedInEmbed` — derived,
@@ -26,38 +28,7 @@ source records nothing, not exclusion.
 
 set_option autoImplicit false
 
-namespace Clause
-
-/-- A [sadock-zwicky-1985] sentence-type cell, with interrogatives
-    subtyped — the function-side vocabulary distributional sources
-    record over. A clause *object* does not determine a cell
-    (`Clause.force?` is the object-side query); a language's formal
-    clause types pair with these via their force maps (the
-    Sadock–Zwicky form-function pairings, e.g.
-    `Fragments/German/Particles`). -/
-inductive SentenceType where
-  | declarative
-  | polarInterrogative
-  /-- Alternative question ("Is it A or B?"). -/
-  | alternativeInterrogative
-  /-- Constituent (wh-) question. -/
-  | constituentInterrogative
-  | imperative
-  | exclamative
-  deriving DecidableEq, Repr
-
-/-- The illocutionary force of a sentence type — the coarse
-    [sadock-zwicky-1985] cut, collapsing the interrogative subtypes. -/
-def SentenceType.force : SentenceType → Mood.Illocutionary
-  | .declarative => .declarative
-  | .polarInterrogative | .alternativeInterrogative
-  | .constituentInterrogative => .interrogative
-  | .imperative => .imperative
-  | .exclamative => .exclamative
-
-end Clause
-
-open Clause (SentenceType EmbeddingContext)
+open Clause (EmbeddingContext)
 
 /-- Where a particle sits relative to its host domain — the
 [zwicky-1985-clitics] positional diagnostic. -/
@@ -84,9 +55,14 @@ inductive ParticleStatus where
   | excluded
   deriving DecidableEq, Repr
 
-/-- Per-clause-context distribution record. Each cell is `Option`-valued:
-`none` means the anchoring source records nothing for that context —
-distinct from `some .excluded`, which is a positive claim. -/
+/-- Per-clause-context distribution record over the
+[sadock-zwicky-1985] sentence-type cells (interrogatives subtyped:
+polar, alternative, constituent — the `Semantics/Questions`
+constructions). Each cell is `Option`-valued: `none` means the
+anchoring source records nothing for that context — distinct from
+`some .excluded`, which is a positive claim. Cells are addressed by
+field projection; there is no index enum (force is
+`Mood.Illocutionary`, not a parallel type here). -/
 structure ClauseDistribution where
   declarative : Option ParticleStatus := none
   polarInterrogative : Option ParticleStatus := none
@@ -95,15 +71,6 @@ structure ClauseDistribution where
   imperative : Option ParticleStatus := none
   exclamative : Option ParticleStatus := none
   deriving DecidableEq, Repr
-
-/-- Recorded status in context `c`, if any. -/
-def ClauseDistribution.status? (d : ClauseDistribution) : Clause.SentenceType → Option ParticleStatus
-  | .declarative => d.declarative
-  | .polarInterrogative => d.polarInterrogative
-  | .alternativeInterrogative => d.alternativeInterrogative
-  | .constituentInterrogative => d.constituentInterrogative
-  | .imperative => d.imperative
-  | .exclamative => d.exclamative
 
 /-- Per-embedding-context distribution record ([bhatt-dayal-2020]
 axis). Same `Option`-valued honesty convention as `ClauseDistribution`. -/
@@ -141,18 +108,21 @@ structure Particle where
 namespace Particle
 
 
-/-- Recorded clause-type distribution status in context `c`, if any. -/
-def status? (p : Particle) (c : Clause.SentenceType) : Option ParticleStatus :=
-  p.distribution.bind (·.status? c)
+/-- Recorded clause-type distribution status in the cell picked out by
+projection `c` (e.g. `(·.declarative)`), if any. -/
+def status? (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
+    Option ParticleStatus :=
+  p.distribution.bind c
 
 /-- The particle is positively recorded as available (obligatorily or
-optionally) in context `c`. -/
-def LicensedIn (p : Particle) (c : Clause.SentenceType) : Prop :=
+optionally) in the cell picked out by projection `c`. -/
+def LicensedIn (p : Particle) (c : ClauseDistribution → Option ParticleStatus) : Prop :=
   match p.status? c with
   | some .obligatory | some .optional => True
   | _ => False
 
-instance (p : Particle) (c : Clause.SentenceType) : Decidable (p.LicensedIn c) := by
+instance (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
+    Decidable (p.LicensedIn c) := by
   unfold LicensedIn; exact match p.status? c with
     | some .obligatory => .isTrue trivial
     | some .optional => .isTrue trivial

--- a/Linglib/Syntax/Category/Particle/Capabilities.lean
+++ b/Linglib/Syntax/Category/Particle/Capabilities.lean
@@ -5,8 +5,11 @@ import Linglib.Syntax.Category.Particle.Basic
 
 This file defines `Distributed α Ctx`: a carrier `α` with a recorded
 three-valued distribution over licensing contexts `Ctx`, the
-`Proform`-style capability behind `Particle`'s two facets (instances
-for `Clause.SentenceType` and `Clause.EmbeddingContext`).
+`Proform`-style capability behind `Particle`'s embedding facet
+(instance for `Clause.EmbeddingContext`; `Studies/Stankova2026` adds a
+negation-position axis). The clause-type facet is projection-keyed
+(`ClauseDistribution` fields), so it has no context type to
+instantiate.
 
 There is deliberately no universal clause carrier: a theory whose
 clause representation `C` classifies into these cells obtains
@@ -16,7 +19,7 @@ stored facets finite and decidable.
 
 set_option autoImplicit false
 
-open Clause (SentenceType EmbeddingContext)
+open Clause (EmbeddingContext)
 
 /-- A carrier `α` with a recorded three-valued distribution over
 licensing contexts `Ctx`. `none` = the source records nothing
@@ -43,7 +46,5 @@ instance (a : α) (c : Ctx) : Decidable (LicensedIn a c) := by
     | none => .isFalse nofun
 
 end Distributed
-
-instance : Distributed Particle Clause.SentenceType := ⟨Particle.status?⟩
 
 instance : Distributed Particle Clause.EmbeddingContext := ⟨Particle.embedStatus?⟩


### PR DESCRIPTION
`Clause.SentenceType` deleted rather than kept as an index enum: force is already `Mood.Illocutionary` and the interrogative subtypes are already `Semantics/Questions` constructions, so the enum was a duplicate taxonomy. Distribution cells stay as `ClauseDistribution` record fields with lookups keyed by field projection (`p.LicensedIn (·.declarative)`); the one-carrier `Distributed` instance for it and the echo-rfl theorems go (class stays — Stankova2026 instantiates a third axis).