### PR TITLE
fix(Studies/Theiler2021): use cell selectors with LicensedIn

### DIFF
--- a/Linglib/Studies/Theiler2021.lean
+++ b/Linglib/Studies/Theiler2021.lean
@@ -52,8 +52,8 @@ def dennBias : Option Semantics.Questions.Bias.ContextualEvidence := none
     *nandao*'s polar-only restriction. Derived from the fragments'
     distribution facets. -/
 theorem denn_wh_unlike_nandao :
-    German.Particles.denn.LicensedIn .constituentInterrogative ∧
-    ¬ Mandarin.QuestionParticles.nandao.LicensedIn .constituentInterrogative := by
+    German.Particles.denn.LicensedIn (·.constituentInterrogative) ∧
+    ¬ Mandarin.QuestionParticles.nandao.LicensedIn (·.constituentInterrogative) := by
   decide
 
 end Theiler2021


### PR DESCRIPTION
Fixes the CI failure on main: #1832 changed `Particle.LicensedIn` to take a cell selector but missed the two call sites in Theiler2021 (`Unknown constant Option.constituentInterrogative`). Repo-wide grep confirms these were the only stale sites.