### PR TITLE
fix(Fragments/Mayan/Chuj): correct data vs Coon 2019 and AO&R papers

### DIFF
--- a/Linglib/Features/ModalIndefinite.lean
+++ b/Linglib/Features/ModalIndefinite.lean
@@ -10,16 +10,19 @@ component (e.g., Chuj *yalnhej*, Spanish *algún*, German *irgendein*).
 
 Sibling of `Features/IndefiniteType.lean`: that file classifies indefinites
 by Degano & Aloni's variation/constancy types (Haspelmath's NS/SU/SK map);
-this file classifies modal indefinites by Alonso-Ovalle & Royer's three
-dimensions (status × content × upper-boundedness).
+this file classifies modal indefinites along [alonso-ovalle-royer-2024]'s
+dimensions of variation (status × content × upper-boundedness).
 
-## Three Dimensions of Variation
+## Dimensions of Variation
 
-Following [alonso-ovalle-royer-2024]:
+[alonso-ovalle-royer-2024] (§6) identifies two sources of variation —
+status (§6.1) and content (§6.2) — with upper-boundedness a further
+axis inside the content discussion:
 
 1. **Status**: Is the modal component at-issue or not-at-issue?
 2. **Content**: Which modal flavors does the component support?
-3. **Upper-boundedness**: Does it impose an anti-singleton inference?
+3. **Upper-boundedness**: Does it impose an upper bound on witnesses
+   in the described situation?
 
 -/
 
@@ -49,7 +52,7 @@ inductive ModalComponentStatus where
   /-- Modal component is not part of assertive content: presupposed,
       conventionally implicated, or conversationally implicated.
       Projects or persists under embedding operators.
-      Ex: Sp. *algún* (conv. implicature per [alonso-ovalle-menendez-benito-2010]),
+      Ex: Sp. *algún* (conversational implicature per [alonso-ovalle-menendez-benito-2010]),
       Ger. *irgendein* (domain widening per [kratzer-shimoyama-2002]). -/
   | notAtIssue
   deriving DecidableEq, Repr
@@ -72,20 +75,20 @@ inductive ModalComponentStatus where
 inductive AnchorConstraint where
   /-- f has no definedness condition: defined for any event regardless
       of content. The anchor constraint does not restrict WHERE f can
-      anchor. Whether the resulting background is epistemic, however,
-      depends on the specific projection function f — not just on
-      anchor definedness or content licensing. For *yalnhej*, f yields
-      an epistemic background from contentful events; for *n'importe
-      quel* and *un qualsiasi*, f always yields a circumstantial/
-      indiscriminacy background regardless of the event's content
-      ([alonso-ovalle-royer-2024], §6.2: "different functions
-      projecting modal domains from those anchors").
+      anchor. For *yalnhej*, f yields an epistemic background from
+      contentful events. French *n'importe quel* and Italian *un
+      qualsiasi* express random choice only; [alonso-ovalle-royer-2024]
+      (§6.2) leaves open whether that follows from an anchor constraint
+      or from a different projection function ("different constraints on
+      the types of anchors … or … different functions projecting modal
+      domains from those anchors"), so their listing here picks no horn.
       Ex: Chuj *yalnhej*, French *n'importe quel*, Italian *un qualsiasi*. -/
   | unrestricted
   /-- f presupposes that its event argument has normative content
-      (a decision subevent of a volitional event). Speech acts lack
-      normative content, so f(speech event) is undefined → no epistemic.
-      Only yields RC readings (from volitional VP events).
+      (a decision subevent of a volitional event). A consequence of the
+      analysis: a speech event supplies no normative content, so
+      f(speech event) is undefined → no epistemic. Only yields RC
+      readings (from volitional VP events).
       Ex: Spanish *uno cualquiera*. -/
   | volitionalOnly
   deriving DecidableEq, Repr
@@ -108,22 +111,26 @@ structure ModalIndefiniteEntry where
   status : ModalComponentStatus
   /-- Dimension 2: Which modal flavors are available? -/
   flavors : List ModalFlavor
-  /-- Dimension 3: Does it impose an upper bound (anti-singleton)? -/
+  /-- Dimension 3: Does it impose an upper bound on witnesses in the
+      described situation? (Distinct from the anti-singleton *domain*
+      constraint of [alonso-ovalle-menendez-benito-2010].) -/
   upperBounded : Bool
   /-- Is the available flavor sensitive to syntactic position? -/
   positionSensitive : Bool := false
   /-- Does the item have a plain/unremarkable (non-modal) reading in
-      addition to its modal reading? (A-[alonso-ovalle-royer-2024], §5) -/
+      addition to its modal reading? ([alonso-ovalle-royer-2024], §5) -/
   hasUnremarkableReading : Bool := false
   /-- Can the item appear in predicative position?
-      Correlates with unremarkable readings per A-[alonso-ovalle-royer-2024]. -/
+      Correlates with unremarkable readings per [alonso-ovalle-royer-2024]. -/
   canBePredicate : Bool := false
   /-- Anchor constraint on the anchoring function f.
       Only applicable to at-issue modal indefinites analyzed via
       event-relative anchoring ([alonso-ovalle-royer-2024]).
       `none` for items with non-at-issue modal components
       (e.g., *algún*, *irgendein*) where the mechanism is
-      conversational implicature or domain widening. -/
+      conversational implicature or domain widening — or for at-issue
+      items fitting neither constructor (Chuj *komon*: never epistemic,
+      yet fine with non-volitional predicates). -/
   anchorConstraint : Option AnchorConstraint := none
   /-- Whether the item is number-neutral (compatible with singular
       and plural reference). Chuj *yalnhej* is number-neutral

--- a/Linglib/Fragments/Mayan/Chuj/ModalIndefinites.lean
+++ b/Linglib/Fragments/Mayan/Chuj/ModalIndefinites.lean
@@ -2,24 +2,20 @@ import Linglib.Features.ModalIndefinite
 
 /-!
 # Chuj Modal Indefinite Fragment
-[alonso-ovalle-royer-2021] [alonso-ovalle-royer-2024]
 
-Lexical entries for Chuj modal indefinites *yalnhej* (singular) and
-*komon* (mass/plural), following [alonso-ovalle-royer-2024].
+Lexical entries for Chuj *yalnhej* ([alonso-ovalle-royer-2024]) and
+*komon* ([alonso-ovalle-royer-2021]).
 
-## Connection to VerbBuilding.lean
-
-The Chuj voice system ([coon-2019], formalized in `VerbBuilding.lean`)
-determines whether a *yalnhej* DP is in external or internal argument
-position, which in turn constrains the available modal flavor:
-
-- vØ (active transitive): agent = external → epistemic only
-- v_ch (passive): theme promoted, agent implicit → both flavors available
-- v_w (agentive intransitive): agent = external → epistemic only
-- v_j (agentless passive): no agent → internal argument → both flavors
-
-This connection is proved in `Studies/AlonsoOvalleRoyer2024.lean`.
-
+The modal flavor a *yalnhej* DP contributes depends on its structural
+position and the predicate's volitionality ([alonso-ovalle-royer-2024],
+§3.4): as an external argument it contributes epistemic modality only;
+as an internal argument (object or passive subject) or adjunct of a
+volitional predicate it contributes either epistemic or random-choice
+modality. Voice morphology ([coon-2019], voice heads in
+`Studies/Coon2019.lean`) bears on this only by fixing where the DP
+sits and whether an agent's decision subevent exists — the derivation
+is formalized in `Studies/AlonsoOvalleRoyer2024.lean` (`rcAvailable`,
+`predictedMIFlavors`).
 -/
 
 set_option autoImplicit false
@@ -33,12 +29,12 @@ open Features.ModalIndefinite
 -- § 1. Lexical Entries
 -- ════════════════════════════════════════════════════
 
-/-- *yalnhej*: singular modal indefinite.
-    At-issue, epistemic + random choice, not upper-bounded. -/
+/-- *yalnhej*: number-neutral modal indefinite ([alonso-ovalle-royer-2024],
+    §3.1, §4.2). At-issue, epistemic + random choice, not upper-bounded. -/
 def yalnhejEntry : ModalIndefiniteEntry where
   language := "Chuj (Mayan)"
   form := "yalnhej"
-  gloss := "MODAL.INDEF.SG"
+  gloss := "yalnhej"
   status := .atIssue
   flavors := [.epistemic, .circumstantial]
   upperBounded := false
@@ -49,21 +45,32 @@ def yalnhejEntry : ModalIndefiniteEntry where
   numberNeutral := true
   source := "Alonso-Ovalle & Royer 2024"
 
-/-- *komon*: mass/plural modal modifier.
-    At-issue, random choice only, not upper-bounded. -/
+/-- *komon*: modal modifier conveying random-choice (circumstantial)
+    modality ([alonso-ovalle-royer-2021]); never epistemic.
+
+    Caveats: `hasUnremarkableReading` holds of NP-*komon* only
+    ([alonso-ovalle-royer-2024], §5); `upperBounded := false` and
+    `numberNeutral := false` are inapplicable rather than substantive —
+    *komon*-DPs are headed by the singular indefinite *jun*, so those
+    dimensions belong to the determiner; `anchorConstraint := none`
+    because *komon* fits neither constructor (never epistemic, yet fine
+    with non-volitional predicates) — the projection-function variation
+    [alonso-ovalle-royer-2024] §6.2 leaves open. -/
 def komonEntry : ModalIndefiniteEntry where
   language := "Chuj (Mayan)"
   form := "komon"
-  gloss := "MODAL.INDEF.MASS"
+  gloss := "komon"
   status := .atIssue
   flavors := [.circumstantial]
   upperBounded := false
   hasUnremarkableReading := true
   canBePredicate := true
-  anchorConstraint := some .unrestricted
+  anchorConstraint := none
   source := "Alonso-Ovalle & Royer 2021"
 
-/-- The Chuj modal indefinite paradigm. -/
+/-- The Chuj entries. The papers themselves decline to classify *komon*
+    as a modal indefinite: [alonso-ovalle-royer-2021] analyzes it as a
+    modal *modifier* (vP-, D-, or NP-level), not a determiner. -/
 def paradigm : List ModalIndefiniteEntry := [yalnhejEntry, komonEntry]
 
 

--- a/Linglib/Fragments/Mayan/Chuj/VerbBuilding.lean
+++ b/Linglib/Fragments/Mayan/Chuj/VerbBuilding.lean
@@ -57,8 +57,9 @@ def rootTV_pc : Classification :=
     denotationType := some (.e ⇒ .s ⇒ .t), licensesTransitiveVoice := true }
 
 /-- √TV root (result): selects theme, entails change-of-state.
-    Semantic type ⟨e, ⟨s,t⟩⟩ ([coon-2019], (3)).
-    Examples: jatz' "hit (breaking)", tzak' "wrap". -/
+    Semantic type ⟨e, ⟨s,t⟩⟩ ([coon-2019], (3)). The PC/result
+    subdivision of √TV is [beavers-etal-2021]'s axis (after
+    [dixon-1982]); [coon-2019] does not subdivide √TV. -/
 def rootTV_res : Classification :=
   { valency := {.internal}, changeType := .result,
     denotationType := some (.e ⇒ .s ⇒ .t), licensesTransitiveVoice := true }
@@ -69,21 +70,25 @@ def rootTV_res : Classification :=
     compatibility with the transitive-forming v/Voice⁰ head. The class is
     morphologically defined: roots that appear with null v/Voice⁰ in
     intransitive stems (p. 40).
+    `changeType := .propertyConcept` is a placeholder: [coon-2019]
+    (p. 60) includes change-of-state verbs like *k'ib'* "grow" and
+    *cham* "die" in √ITV, so the class is not uniform on this axis.
     Examples: way "sleep", ok' "cry", jaw "arrive", b'at "go". -/
 def rootITV : Classification :=
   { valency := {.internal}, changeType := .propertyConcept,
     denotationType := some (.e ⇒ .s ⇒ .t) }
 
 /-- √POS root: positional/stative. Semantic type ⟨e, ⟨s,d⟩⟩ — a
-    measure function, not a truth-value predicate.
-    Examples: chot "sit", kot "on all fours", watz "lie face down". -/
+    measure function, not a truth-value predicate ([coon-2019]
+    following [henderson-2017]).
+    Examples: chot "crouched", kot "on four legs", tel "lying down". -/
 def rootPOS : Classification :=
   { valency := ∅, changeType := .propertyConcept,
     denotationType := some (.e ⇒ .s ⇒ .d) }
 
 /-- √NOM root: nominal base. Semantic type ⟨e,t⟩ — entity predicate
     with no event argument ([coon-2019], (3)).
-    Examples: a' "water", ixim "corn", chanhal "dance". -/
+    Examples: pat "house", ixim "corn", chanhal "dance". -/
 def rootNOM : Classification :=
   { valency := ∅, changeType := .propertyConcept,
     denotationType := some (.e ⇒ .t) }
@@ -150,10 +155,13 @@ theorem rootToClass_correct :
     rootToClass rootNOM    = .nom := by decide
 
 -- ============================================================================
--- § 4: Voice Suffixes (ex. (78), pp. 75–76)
+-- § 4: Voice Suffixes (ex. (78), p. 76)
 -- ============================================================================
 
-/-- The four voice suffixes in Chuj (ex. (78), pp. 75–76). -/
+/-- The four voice suffixes in Chuj (ex. (78), p. 76). -ch and -w are
+    [coon-2019]'s decomposed morphemes: the attested stems are *-chaj*
+    and *-waj*, analyzed as -ch and -w plus -aj (table (58), p. 66;
+    §4.2). -/
 inductive ChujVoiceSuffix where
   | null  -- Ø: active transitive
   | ch    -- -ch: passive with implicit agent
@@ -205,13 +213,13 @@ def ChujVoiceSuffix.hasAgent : ChujVoiceSuffix → Bool
     Based on the distributional facts in §§2–5:
     - √TV: all four voices (Ø, -ch, -j, -w) — ex. (78)
     - √ITV: null v only (§2.1, p. 40)
-    - √POS: -w only (§2.4, p. 43)
+    - √POS: -w only (§3.1, (20)/(22), p. 47)
     - √NOM: -w only (§3.1, p. 46) -/
 def isGrammatical (rc : CRootClass) (vs : ChujVoiceSuffix) : Bool :=
   match rc, vs with
   | .tv,  _     => true   -- √TV combines with all four
   | .itv, .null => true   -- √ITV takes null v (§2.1)
-  | .pos, .w    => true   -- √POS takes -w (§2.4)
+  | .pos, .w    => true   -- √POS takes -w ((20)/(22), p. 47)
   | .nom, .w    => true   -- √NOM takes -w (§3.1)
   | _,    _     => false
 
@@ -225,15 +233,18 @@ def formsBareTransitive (rc : CRootClass) : Bool :=
 -- § 7: -aj Distribution (§4.2, ex. (78))
 -- ============================================================================
 
-/-- Whether -aj (existential closure) appears on a √TV stem in each
-    voice form (ex. (78), pp. 75–76; §4.2, p. 72).
+/-! -aj marks the presence of an implicit argument on a √TV stem
+(ex. (78), p. 76; §4.2, p. 72) — [coon-2019] (p. 73) proposes it is
+an overt reflex of Existential Closure ([diesing-1992]):
+- Ø: no implicit arg → no -aj
+- -ch: implicit external arg → -aj on stem (§4.1.1, p. 68)
+- -j: no external arg at all → no -aj
+- -w (absolutive): implicit internal arg → -aj (ex. (55c), p. 65)
+- -w (incorporation): overt bare NP internal arg → no -aj (ex. (54a), p. 64) -/
 
-    -aj marks the presence of an implicit argument:
-    - Ø: no implicit arg → no -aj
-    - -ch: implicit external arg → -aj on stem (§4.1.1, p. 68)
-    - -j: no external arg at all → no -aj
-    - -w (absolutive): implicit internal arg → -aj (ex. (55c), p. 65)
-    - -w (incorporation): overt bare NP internal arg → no -aj (ex. (54a), p. 64) -/
+/-- The two antipassive (-w) subtypes: absolutive (implicit theme,
+    ex. (55b–c), p. 65) vs incorporation (overt bare-NP theme,
+    ex. (54a), p. 64). -/
 inductive AntipassiveType where
   | absolutive      -- theme is implicit (suppressed)
   | incorporation   -- theme is overt bare NP (incorporated)
@@ -295,7 +306,7 @@ def byPhraseOK (vs : ChujVoiceSuffix) : Bool :=
     privileged position. Instead, Voice controls whether an external
     argument is overt, implicit, or absent. Each voice form is built
     independently from root + v/Voice⁰: passive is not derived from
-    active. Non-pivot system; Voice controls EA status (Coon 2019). -/
+    active. -/
 namespace VoiceSystem
 
 def voices : List Voice.VoiceEntry :=
@@ -359,7 +370,8 @@ def ok'   : ChujRoot := ⟨"ok'",   "cry", rootITV⟩
 -- √POS roots (Table (5), p. 39)
 def chot  : ChujRoot := ⟨"chot",  "crouched", rootPOS⟩
 def jenh  : ChujRoot := ⟨"jenh",  "outstretched", rootPOS⟩
-def lich' : ChujRoot := ⟨"lich'", "leaning", rootPOS⟩
+def chek' : ChujRoot := ⟨"chek'", "leaning", rootPOS⟩
+def lich' : ChujRoot := ⟨"lich'", "extended", rootPOS⟩
 def b'ul  : ChujRoot := ⟨"b'ul",  "gathered", rootPOS⟩
 
 -- √POS roots from Table (20), p. 47
@@ -387,7 +399,7 @@ def itvRoots : List ChujRoot :=
 
 /-- All √POS roots from Table (5). -/
 def posRoots : List ChujRoot :=
-  [chot, jenh, lich', b'ul]
+  [chot, jenh, chek', lich', b'ul]
 
 /-- All √NOM roots from Table (5). -/
 def nomRoots : List ChujRoot :=
@@ -397,11 +409,12 @@ def nomRoots : List ChujRoot :=
 -- § 11: Verification
 -- ============================================================================
 
--- Root classification
-theorem tvRoots_selectTheme :
+-- Root classification. Both √TV and √ITV select a theme (p. 61);
+-- what distinguishes them is transitive-Voice licensing.
+theorem tvRoots_licenseTransitiveVoice :
     tvRoots.all (·.root.licensesTransitiveVoice) = true := by decide
 
-theorem itvRoots_noTheme :
+theorem itvRoots_noTransitiveVoice :
     itvRoots.all (fun v => !v.root.licensesTransitiveVoice) = true := by decide
 
 theorem posRoots_measureFn :

--- a/Linglib/Semantics/Modality/EventRelativity.lean
+++ b/Linglib/Semantics/Modality/EventRelativity.lean
@@ -153,13 +153,13 @@ theorem duality {Event W : Type*} (f : AnchoringFn Event W) (e : Event)
 
 
 -- ════════════════════════════════════════════════════
--- §§ 3–7. Modal Indefinites (extracted to ModalIndefinites.lean)
+-- §§ 3–7. Modal Indefinites (live in the study file)
 -- ════════════════════════════════════════════════════
 
-/-! The modal indefinite denotation (A-[alonso-ovalle-royer-2024]), upper-boundedness,
-non-maximality, and harmonic interpretation types have been extracted to
-`Semantics/Modality/ModalIndefinites.lean`. That file imports
-this one for `AnchoringFn` and `possibility`. -/
+/-! The modal indefinite denotation ([alonso-ovalle-royer-2024]), upper-boundedness,
+non-maximality, and harmonic interpretation types live in
+`Studies/AlonsoOvalleRoyer2024.lean`, which imports this file for
+`AnchoringFn` and `possibility`. -/
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -76,10 +76,10 @@ open Italian.ModalIndefinites
 
 
 -- ════════════════════════════════════════════════════════════════
--- Part 0: Modal Indefinite Denotation (A-[alonso-ovalle-royer-2024], (59))
+-- Part 0: Modal Indefinite Denotation ([alonso-ovalle-royer-2024], (59))
 -- ════════════════════════════════════════════════════════════════
 
-/-- The modal component of a modal indefinite (A-[alonso-ovalle-royer-2024], (59)):
+/-- The modal component of a modal indefinite ([alonso-ovalle-royer-2024], (59)):
 
     `∀y[P(y)(w) → ◇_{f(e₁)}(Q(y)(w'))]`
 
@@ -100,7 +100,7 @@ instance {Event W Entity : Type*}
     Decidable (modalComponent f e allW domain P Q w) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
-/-- Full modal indefinite denotation (A-[alonso-ovalle-royer-2024], (59)):
+/-- Full modal indefinite denotation ([alonso-ovalle-royer-2024], (59)):
 
     `⟦MI⟧^{f,e₁} = λP.λQ.λw. ∃x[P(x)(w) ∧ Q(x)(w)] ∧ ∀y[P(y)(w) → ◇_{f(e₁)}(Q(y)(w'))]`
 
@@ -127,7 +127,9 @@ instance {Event W Entity : Type*}
 
     `⟦MI_UB⟧ = ⟦MI⟧ ∧ ¬∀x[P(x)(w) → Q(x)(w)]`
 
-The anti-singleton inference of *algún*. Items like *yalnhej* lack this
+The witness upper bound of *algún* (§4.2 — distinct from the
+anti-singleton *domain* constraint of
+[alonso-ovalle-menendez-benito-2010]). Items like *yalnhej* lack this
 condition and are compatible with all P being Q. -/
 def upperBoundedSat {Event W Entity : Type*}
     (f : AnchoringFn Event W) (e : Event) (allW : List W)
@@ -189,7 +191,7 @@ theorem not_at_issue_items :
     [algúnEntry, irgendeinEntry].all (·.status == .notAtIssue) = true := rfl
 
 /-- Upper-bounded items are a proper subset: only *algún* and
-*uno cualquiera* impose anti-singleton inferences. -/
+*uno cualquiera* impose witness upper bounds. -/
 theorem upper_bounded_items :
     (allEntries.filter (·.upperBounded)).length = 2 := rfl
 
@@ -228,16 +230,18 @@ theorem not_at_issue_and_not_ub_exists :
 -- § 4. AnchorConstraint Bridge
 -- ════════════════════════════════════════════════════
 
-/-- Consistency check: at-issue status aligns with anchor constraint
-across all entries. At-issue items use event-relative anchoring
-(`anchorConstraint = some _`); not-at-issue items use different
-mechanisms (conversational implicature for *algún*, domain widening
-for *irgendein*) and have `anchorConstraint = none`. This is true
-by construction of the entries — verifying we encoded the paper's
-§4 classification correctly. -/
-theorem at_issue_iff_anchored :
+/-- Consistency check: anchored entries are at-issue. Event-relative
+anchoring (`anchorConstraint = some _`) is the paper's mechanism for
+at-issue modal components; not-at-issue items use different mechanisms
+(conversational implicature for *algún*, domain widening for
+*irgendein*) and have `anchorConstraint = none`. The converse fails:
+*komon* is at-issue but fits neither anchor constructor (never
+epistemic, yet fine with non-volitional predicates) — the
+projection-function variation §6.2 leaves open. True by construction
+of the entries. -/
+theorem anchored_entries_at_issue :
     allEntries.all (λ e =>
-      (e.status == .atIssue) == e.anchorConstraint.isSome) = true := rfl
+      !e.anchorConstraint.isSome || e.status == .atIssue) = true := rfl
 
 /-- Volitional-only anchor constraint correlates with lacking epistemic:
 *uno cualquiera*'s f requires normative content, blocking speech
@@ -341,16 +345,17 @@ def predictedMIFlavors (pos : ChujArgPosition) (volitional : Bool) : List ModalF
 
 
 -- ════════════════════════════════════════════════════
--- § 7. Table 5 Verification
+-- § 7. Flavor Pattern Verification
 -- ════════════════════════════════════════════════════
 
-/-- Table 5 DERIVED from structural position + volitionality + EventBinder.
-The full five-cell pattern of [alonso-ovalle-royer-2024] falls
-out from three orthogonal components:
+/-- The position × volitionality flavor pattern DERIVED from structural
+position + volitionality + EventBinder. The full pattern of
+[alonso-ovalle-royer-2024] (§3.4) falls out from three orthogonal
+components:
 (1) `accessibleBinders` (structural position)
 (2) `miAnchorFlavor` (EventBinder → ModalFlavor, from EventRelativity)
 (3) `rcAvailable` (volitionality constraint) -/
-theorem table5_derived :
+theorem flavor_pattern_derived :
     -- External arg: epistemic only (no VP event access → no RC)
     predictedMIFlavors .external true = [.epistemic] ∧
     predictedMIFlavors .external false = [.epistemic] ∧
@@ -467,8 +472,8 @@ theorem argPosition_parallels_modalPosition :
 /-- *Yalnhej* is not upper-bounded: compatible with partial-domain
 scenarios where not all P are Q. This distinguishes it from maximal
 free relatives (*whatever*), which require all domain members to
-satisfy the scope. The EventRelativity worked example demonstrates
-this concretely with `yalnhej_nonmaximal_ab` (ModalIndefinites.lean). -/
+satisfy the scope. The book-scenario worked example demonstrates
+this concretely with `yalnhej_nonmaximal_ab` (§14 below). -/
 theorem yalnhej_nonmaximal :
     yalnhejEntry.upperBounded = false := rfl
 
@@ -502,11 +507,11 @@ theorem rc_only_items :
 -- § 10. Upper-Boundedness (§3.2.4, §6.2)
 -- ════════════════════════════════════════════════════
 
-/-- Upper-bounded modal indefinites impose an anti-singleton inference. -/
+/-- Upper-bounded modal indefinites impose a witness upper bound. -/
 theorem upper_bounded_group :
     [algúnEntry, unoCualquieraEntry].all (·.upperBounded) = true := rfl
 
-/-- Non-upper-bounded modal indefinites: no anti-singleton. -/
+/-- Non-upper-bounded modal indefinites: no witness upper bound. -/
 theorem not_upper_bounded_group :
     [yalnhejEntry, irgendeinEntry, nimporteQuelEntry, unQualsiasiEntry].all
       (·.upperBounded == false) = true := rfl
@@ -525,9 +530,9 @@ theorem predicativity_correlates_unremarkable :
       e.canBePredicate == e.hasUnremarkableReading) = true := rfl
 
 /-- Number-neutral items lack upper-boundedness. (Footnote 18 of
-[alonso-ovalle-royer-2024], p.32, attributed to Louise McNally:
-wh-phrase origin → number neutrality → incompatible with anti-singleton
-inference, since anti-singleton presupposes a singleton alternative.) -/
+[alonso-ovalle-royer-2024], p. 32, crediting Louise McNally (p.c.):
+the lack of an upper bound for *yalnhej* DPs may be tied to their
+being semantically number neutral.) -/
 theorem numberNeutral_implies_not_ub :
     (allEntries.filter (·.numberNeutral)).all (!·.upperBounded) = true := rfl
 
@@ -587,8 +592,8 @@ theorem harmonic_neq_nonharmonic :
 -- ════════════════════════════════════════════════════════════════
 
 /-! Concrete model-theoretic witnesses for the typological claims of
-Part I. These instantiate `Semantics/Modality/ModalIndefinites.lean`
-on small finite domains to demonstrate (a) non-maximality, (b) the
+Part I. These instantiate the Part 0 denotations (`modalIndefiniteSat`,
+`upperBoundedSat`) on small finite domains to demonstrate (a) non-maximality, (b) the
 upper-bounded vs. non-upper-bounded contrast, and (c) the harmonic
 vs. non-harmonic anchoring distinction. The toy domains live here
 in the study file (per CLAUDE.md: examples that name a paper's analyses
@@ -667,7 +672,7 @@ theorem yalnhej_not_upper_bounded_abc :
 
 
 -- ════════════════════════════════════════════════════
--- § 14. Non-Maximality (A-[alonso-ovalle-royer-2024], §3.2.4)
+-- § 14. Non-Maximality ([alonso-ovalle-royer-2024], §3.2.4)
 -- ════════════════════════════════════════════════════
 
 /-! Yalnhej is compatible with partial-domain scenarios: the speaker
@@ -709,7 +714,7 @@ theorem yalnhej_three_way_contrast :
 
 
 -- ════════════════════════════════════════════════════
--- § 15. Card Scenario: Harmonic Interpretations (A-[alonso-ovalle-royer-2024], §4.3)
+-- § 15. Card Scenario: Harmonic Interpretations ([alonso-ovalle-royer-2024], §4.3)
 -- ════════════════════════════════════════════════════
 
 /-! When a modal indefinite occurs under an external modal (imperative,

--- a/Linglib/Syntax/Minimalist/Verbal/Voice.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Voice.lean
@@ -127,7 +127,7 @@ structure Head where
   hasD : Bool
   /-- Per-construction override of `flavor.defaultPhasal` — the locus for
       per-paper divergence ([erlewine-sommerlot-2025] Malayic passive,
-      [coon-2019] Chol `v_w`/`v_ch`, [coon-mateo-pedro-preminger-2014]
+      [coon-2019] Chuj `v_w`/`v_ch`, [coon-mateo-pedro-preminger-2014]
       Mam Agent Focus). -/
   phaseOverride : Option Bool := none
   /-- Case-checking ([collins-2005] p. 96 feature dissociation: passive

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7442,11 +7442,23 @@
   title     = {Modal Indefinites and Semantic Variation: Lessons from {C}huj},
   journal   = {Semantics and Pragmatics},
   volume    = {17},
+  number    = {12},
+  pages     = {1--54},
   doi       = {10.3765/sp.17.12},
   subfield  = {semantics/modality},
   validated = {true},
   role      = {formalized},
   sources   = {Studies/AlonsoOvalleRoyer2024.lean}
+}
+@misc{henderson-2017,
+  author    = {Henderson, Robert},
+  year      = {2017},
+  title     = {The Roots of Measurement},
+  howpublished = {Ms., University of Arizona},
+  subfield  = {semantics/lexical},
+  validated = {true},
+  role      = {cited},
+  sources   = {Fragments/Mayan/Chuj/VerbBuilding.lean}
 }
 @misc{stone-1997,
   author    = {Stone, Matthew},
@@ -21072,10 +21084,10 @@
   number    = {4},
   pages     = {483--529},
   doi       = {10.1093/jos/ffab009},
-  subfield  = {morphology},
+  subfield  = {semantics/modality},
   role      = {cited},
   validated = {true},
-  sources   = {Fragments/Chuj/ModalIndefinites.lean}
+  sources   = {Fragments/Mayan/Chuj/ModalIndefinites.lean}
 }% REF: Theiler, N. (2021). Denn as a highlighting-sensitive particle. Linguistics and Philosophy 44, 323–362.
 @article{theiler-2021,
   author    = {Theiler, Nadine},


### PR DESCRIPTION
Content corrections from the Chuj fragment audit, all verified against the PDFs.

- VerbBuilding: Table 5 fixes (*lich'* 'extended', add missing *chek'* 'leaning'), replace four phantom docstring roots with attested ones, page/section citation fixes for (78) and √POS -w, note -ch/-w as Coon's decomposition of -chaj/-waj, rename `tvRoots_selectTheme`/`itvRoots_noTheme` (√ITV does select a theme, p. 61), credit [henderson-2017] for the √POS measure-function type and [diesing-1992] for -aj.
- ModalIndefinites: *yalnhej* is number-neutral, not singular; *komon* is not 'mass/plural'; replace the voice→flavor docstring table with the paper's position × volitionality generalization; `komonEntry.anchorConstraint := none` (fits neither constructor) with the study's `at_issue_iff_anchored` restated as the surviving direction.
- Cluster: `A-[key]` typo sweep, upper bound vs anti-singleton disentangled, `table5_derived` renamed (the paper has no Table 5), phantom `Semantics/Modality/ModalIndefinites.lean` pointers fixed, Voice.lean Chol→Chuj; bib: AO&R 2021 subfield, 2024 number/pages, add henderson-2017.