### PR TITLE
refactor(Features/ModalIndefinite): cut dead fields; cleanse MI cluster

### DIFF
--- a/Linglib/Features/ModalIndefinite.lean
+++ b/Linglib/Features/ModalIndefinite.lean
@@ -2,151 +2,95 @@ import Linglib.Semantics.Modality.ModalTypes
 
 /-!
 # Modal Indefinite Types
-[alonso-ovalle-menendez-benito-2010] [alonso-ovalle-royer-2024]
 
-Framework-agnostic types for recording cross-linguistic properties of modal
-indefinites — indefinite determiners/DPs that conventionally encode a modal
-component (e.g., Chuj *yalnhej*, Spanish *algún*, German *irgendein*).
+Framework-agnostic types for recording cross-linguistic properties of
+modal indefinites — indefinites that conventionally encode a modal
+component (Chuj *yalnhej*, Spanish *algún*, German *irgendein*) — along
+[alonso-ovalle-royer-2024]'s dimensions of variation: status (§6.1),
+content (§6.2), and upper-boundedness (within §6.2). Random-choice
+readings are carried by the `.circumstantial` flavor.
 
-Sibling of `Features/IndefiniteType.lean`: that file classifies indefinites
-by Degano & Aloni's variation/constancy types (Haspelmath's NS/SU/SK map);
-this file classifies modal indefinites along [alonso-ovalle-royer-2024]'s
-dimensions of variation (status × content × upper-boundedness).
+Sibling of `Features/IndefiniteType.lean`, which classifies indefinites
+by Degano & Aloni's variation/constancy types.
 
-## Dimensions of Variation
+## Main declarations
 
-[alonso-ovalle-royer-2024] (§6) identifies two sources of variation —
-status (§6.1) and content (§6.2) — with upper-boundedness a further
-axis inside the content discussion:
-
-1. **Status**: Is the modal component at-issue or not-at-issue?
-2. **Content**: Which modal flavors does the component support?
-3. **Upper-boundedness**: Does it impose an upper bound on witnesses
-   in the described situation?
-
+* `ModalIndefiniteEntry` — a lexical entry over the three dimensions.
+* `ModalComponentStatus`, `AnchorConstraint` — the status dimension and
+  the definedness condition on the anchoring function f.
 -/
-
-set_option autoImplicit false
 
 namespace Features.ModalIndefinite
 
 open Semantics.Modality (ModalFlavor)
 
-
--- ════════════════════════════════════════════════════
--- § 1. Modal Component Status
--- ════════════════════════════════════════════════════
+/-! ### Modal component status -/
 
 /-- Whether the modal component of a modal indefinite is at-issue
-or not-at-issue.
-
-Diagnostics:
-- **At-issue**: targetable by direct denial ("No, that's not true —
-  you know exactly which book you bought")
-- **Not-at-issue**: targetable by "Hey, wait a minute!" but not by
-  direct denial; projects under negation, questions, modals -/
+    (challengeable by direct denial) or not-at-issue (projects under
+    negation, questions, and modals). -/
 inductive ModalComponentStatus where
-  /-- Modal component is part of assertive content (challengeable
-      by direct denial). Ex: Chuj *yalnhej*, Sp. *uno cualquiera*. -/
+  /-- Part of assertive content. Ex: Chuj *yalnhej*, Sp. *uno cualquiera*. -/
   | atIssue
-  /-- Modal component is not part of assertive content: presupposed,
-      conventionally implicated, or conversationally implicated.
-      Projects or persists under embedding operators.
-      Ex: Sp. *algún* (conversational implicature per [alonso-ovalle-menendez-benito-2010]),
-      Ger. *irgendein* (domain widening per [kratzer-shimoyama-2002]). -/
+  /-- Presupposed or implicated rather than asserted. Ex: Sp. *algún*
+      (conversational implicature per
+      [alonso-ovalle-menendez-benito-2010]), Ger. *irgendein* (domain
+      widening per [kratzer-shimoyama-2002]). -/
   | notAtIssue
   deriving DecidableEq, Repr
 
+/-! ### Anchor constraint -/
 
--- ════════════════════════════════════════════════════
--- § 2. Anchor Constraint
--- ════════════════════════════════════════════════════
-
-/-- Whether the anchoring function f has a definedness condition.
-    [alonso-ovalle-royer-2024] §4.1–4.2.
-
-    Modal indefinites whose modal component is at-issue project their
-    modal domain from an event argument via an anchoring function f.
-    The key lexical distinction is whether f has no definedness condition
-    (accepting any event) or presupposes normative content. Note that
-    f's definedness controls which events CAN anchor the MI; content
-    licensing (whether the event has propositional content) independently
-    determines the resulting modal flavor. -/
+/-- Whether the anchoring function f of an at-issue modal indefinite has
+    a definedness condition ([alonso-ovalle-royer-2024] §4). -/
 inductive AnchorConstraint where
-  /-- f has no definedness condition: defined for any event regardless
-      of content. The anchor constraint does not restrict WHERE f can
-      anchor. For *yalnhej*, f yields an epistemic background from
-      contentful events. French *n'importe quel* and Italian *un
-      qualsiasi* express random choice only; [alonso-ovalle-royer-2024]
-      (§6.2) leaves open whether that follows from an anchor constraint
-      or from a different projection function ("different constraints on
-      the types of anchors … or … different functions projecting modal
-      domains from those anchors"), so their listing here picks no horn.
-      Ex: Chuj *yalnhej*, French *n'importe quel*, Italian *un qualsiasi*. -/
+  /-- f is defined for any event. For *yalnhej*, f yields an epistemic
+      background from contentful events. French *n'importe quel* and
+      Italian *un qualsiasi* express random choice only;
+      [alonso-ovalle-royer-2024] (§6.2) leaves open whether that follows
+      from an anchor constraint or from a different projection function,
+      so their listing here picks no horn. -/
   | unrestricted
-  /-- f presupposes that its event argument has normative content
-      (a decision subevent of a volitional event). A consequence of the
-      analysis: a speech event supplies no normative content, so
-      f(speech event) is undefined → no epistemic. Only yields RC
-      readings (from volitional VP events).
-      Ex: Spanish *uno cualquiera*. -/
+  /-- f presupposes normative content (a decision subevent of a
+      volitional event), so only random-choice readings arise; on this
+      analysis a speech event supplies no normative content, blocking
+      epistemic readings. Ex: Spanish *uno cualquiera*. -/
   | volitionalOnly
   deriving DecidableEq, Repr
 
+/-! ### Modal indefinite entry -/
 
--- ════════════════════════════════════════════════════
--- § 3. Modal Indefinite Entry
--- ════════════════════════════════════════════════════
-
-/-- A cross-linguistic modal indefinite entry parameterized along
-[alonso-ovalle-royer-2024] three dimensions of variation. -/
+/-- A modal indefinite entry over [alonso-ovalle-royer-2024]'s
+    dimensions of variation. -/
 structure ModalIndefiniteEntry where
-  /-- Language name -/
-  language : String
   /-- Surface form -/
   form : String
-  /-- Gloss or translation -/
-  gloss : String
   /-- Dimension 1: Is the modal component at-issue? -/
   status : ModalComponentStatus
   /-- Dimension 2: Which modal flavors are available? -/
   flavors : List ModalFlavor
   /-- Dimension 3: Does it impose an upper bound on witnesses in the
-      described situation? (Distinct from the anti-singleton *domain*
-      constraint of [alonso-ovalle-menendez-benito-2010].) -/
+      described situation? (Distinct from
+      [alonso-ovalle-menendez-benito-2010]'s anti-singleton domain
+      constraint.) -/
   upperBounded : Bool
-  /-- Is the available flavor sensitive to syntactic position? -/
-  positionSensitive : Bool := false
-  /-- Does the item have a plain/unremarkable (non-modal) reading in
-      addition to its modal reading? ([alonso-ovalle-royer-2024], §5) -/
+  /-- Does the item have a plain, non-modal reading in addition to its
+      modal reading? ([alonso-ovalle-royer-2024], §5) -/
   hasUnremarkableReading : Bool := false
-  /-- Can the item appear in predicative position?
-      Correlates with unremarkable readings per [alonso-ovalle-royer-2024]. -/
+  /-- Can the item appear in predicative position? -/
   canBePredicate : Bool := false
-  /-- Anchor constraint on the anchoring function f.
-      Only applicable to at-issue modal indefinites analyzed via
-      event-relative anchoring ([alonso-ovalle-royer-2024]).
-      `none` for items with non-at-issue modal components
-      (e.g., *algún*, *irgendein*) where the mechanism is
-      conversational implicature or domain widening — or for at-issue
-      items fitting neither constructor (Chuj *komon*: never epistemic,
-      yet fine with non-volitional predicates). -/
+  /-- Anchor constraint on the anchoring function f. `none` for
+      not-at-issue items (conversational implicature, domain widening)
+      and for at-issue items fitting neither constructor (Chuj *komon*:
+      never epistemic, yet fine with non-volitional predicates). -/
   anchorConstraint : Option AnchorConstraint := none
-  /-- Whether the item is number-neutral (compatible with singular
-      and plural reference). Chuj *yalnhej* is number-neutral
-      (wh-phrase origin); Spanish *algún* is singular-only. -/
+  /-- Is the item number-neutral? Chuj *yalnhej* is; Spanish *algún* is
+      singular-only. -/
   numberNeutral : Bool := false
-  /-- Source citation -/
-  source : String := ""
   deriving Repr
 
-/-- Whether the entry's modal component supports a given flavor. Generic
-    over `ModalFlavor` rather than cherry-picking named projections. -/
-def ModalIndefiniteEntry.hasFlavor (e : ModalIndefiniteEntry) (f : ModalFlavor) : Prop :=
-  f ∈ e.flavors
-
-instance (e : ModalIndefiniteEntry) (f : ModalFlavor) : Decidable (e.hasFlavor f) :=
-  inferInstanceAs (Decidable (_ ∈ _))
-
+/-- Whether the entry's modal component supports a given flavor. -/
+def ModalIndefiniteEntry.hasFlavor (e : ModalIndefiniteEntry) (f : ModalFlavor) : Bool :=
+  e.flavors.contains f
 
 end Features.ModalIndefinite

--- a/Linglib/Fragments/German/ModalIndefinites.lean
+++ b/Linglib/Fragments/German/ModalIndefinites.lean
@@ -2,41 +2,28 @@ import Linglib.Features.ModalIndefinite
 
 /-!
 # German Modal Indefinite Fragment
-[kratzer-shimoyama-2002]
 
 Lexical entry for German modal indefinite *irgendein*, the prototypical
 domain-widening indefinite ([kratzer-shimoyama-2002]).
-
 -/
-
-set_option autoImplicit false
 
 namespace German.ModalIndefinites
 
 open Features.ModalIndefinite
 
-
--- ════════════════════════════════════════════════════
--- § 1. Lexical Entry
--- ════════════════════════════════════════════════════
-
-/-- *irgendein*: not-at-issue, epistemic + random choice, not upper-bounded.
-    Epistemic in episodic assertions; free choice under deontic modals.
-    Domain widening is the core mechanism
+/-- *irgendein*: not-at-issue, epistemic + random choice, not
+    upper-bounded. Epistemic in episodic assertions; free choice under
+    deontic modals. Domain widening is the core mechanism
     ([kratzer-shimoyama-2002]). -/
 def irgendeinEntry : ModalIndefiniteEntry where
-  language := "German"
   form := "irgendein"
-  gloss := "IRGEND.one"
   status := .notAtIssue
   flavors := [.epistemic, .circumstantial]
   upperBounded := false
   hasUnremarkableReading := true
   canBePredicate := true
-  source := "Kratzer & Shimoyama 2002"
 
 /-- The German modal indefinite paradigm. -/
 def paradigm : List ModalIndefiniteEntry := [irgendeinEntry]
-
 
 end German.ModalIndefinites

--- a/Linglib/Fragments/Italian/ModalIndefinites.lean
+++ b/Linglib/Fragments/Italian/ModalIndefinites.lean
@@ -2,40 +2,28 @@ import Linglib.Features.ModalIndefinite
 
 /-!
 # Italian Modal Indefinite Fragment
-[chierchia-2013]
 
-Lexical entry for Italian modal indefinite *un qualsiasi*.
-
+Lexical entry for Italian modal indefinite *un qualsiasi*
+([chierchia-2013]).
 -/
-
-set_option autoImplicit false
 
 namespace Italian.ModalIndefinites
 
 open Features.ModalIndefinite
 
-
--- ════════════════════════════════════════════════════
--- § 1. Lexical Entry
--- ════════════════════════════════════════════════════
-
 /-- *un qualsiasi*: at-issue, random choice, not upper-bounded.
     Existential FCI; requires a modal licensor
     ([chierchia-2013], §5.3.2). -/
 def unQualsiasiEntry : ModalIndefiniteEntry where
-  language := "Italian"
   form := "un qualsiasi"
-  gloss := "a whichever"
   status := .atIssue
   flavors := [.circumstantial]
   upperBounded := false
   hasUnremarkableReading := false
   canBePredicate := false
   anchorConstraint := some .unrestricted
-  source := "Chierchia 2013"
 
 /-- The Italian modal indefinite paradigm. -/
 def paradigm : List ModalIndefiniteEntry := [unQualsiasiEntry]
-
 
 end Italian.ModalIndefinites

--- a/Linglib/Fragments/Mayan/Chuj/ModalIndefinites.lean
+++ b/Linglib/Fragments/Mayan/Chuj/ModalIndefinites.lean
@@ -18,32 +18,21 @@ is formalized in `Studies/AlonsoOvalleRoyer2024.lean` (`rcAvailable`,
 `predictedMIFlavors`).
 -/
 
-set_option autoImplicit false
-
 namespace Chuj.ModalIndefinites
 
 open Features.ModalIndefinite
 
-
--- ════════════════════════════════════════════════════
--- § 1. Lexical Entries
--- ════════════════════════════════════════════════════
-
 /-- *yalnhej*: number-neutral modal indefinite ([alonso-ovalle-royer-2024],
     §3.1, §4.2). At-issue, epistemic + random choice, not upper-bounded. -/
 def yalnhejEntry : ModalIndefiniteEntry where
-  language := "Chuj (Mayan)"
   form := "yalnhej"
-  gloss := "yalnhej"
   status := .atIssue
   flavors := [.epistemic, .circumstantial]
   upperBounded := false
-  positionSensitive := true
   hasUnremarkableReading := false
   canBePredicate := false
   anchorConstraint := some .unrestricted
   numberNeutral := true
-  source := "Alonso-Ovalle & Royer 2024"
 
 /-- *komon*: modal modifier conveying random-choice (circumstantial)
     modality ([alonso-ovalle-royer-2021]); never epistemic.
@@ -57,32 +46,17 @@ def yalnhejEntry : ModalIndefiniteEntry where
     with non-volitional predicates) — the projection-function variation
     [alonso-ovalle-royer-2024] §6.2 leaves open. -/
 def komonEntry : ModalIndefiniteEntry where
-  language := "Chuj (Mayan)"
   form := "komon"
-  gloss := "komon"
   status := .atIssue
   flavors := [.circumstantial]
   upperBounded := false
   hasUnremarkableReading := true
   canBePredicate := true
   anchorConstraint := none
-  source := "Alonso-Ovalle & Royer 2021"
 
 /-- The Chuj entries. The papers themselves decline to classify *komon*
     as a modal indefinite: [alonso-ovalle-royer-2021] analyzes it as a
     modal *modifier* (vP-, D-, or NP-level), not a determiner. -/
 def paradigm : List ModalIndefiniteEntry := [yalnhejEntry, komonEntry]
-
-
--- ════════════════════════════════════════════════════
--- § 2. Cross-Entry Contrast
--- ════════════════════════════════════════════════════
-
-/-- *yalnhej* and *komon* differ in flavor inventory: *yalnhej* has
-    epistemic + RC, *komon* has RC only. -/
-theorem yalnhej_komon_flavor_difference :
-    yalnhejEntry.hasFlavor .epistemic ∧ ¬ komonEntry.hasFlavor .epistemic := by
-  refine ⟨?_, ?_⟩ <;> decide
-
 
 end Chuj.ModalIndefinites

--- a/Linglib/Fragments/Romance/French/ModalIndefinites.lean
+++ b/Linglib/Fragments/Romance/French/ModalIndefinites.lean
@@ -2,40 +2,28 @@ import Linglib.Features.ModalIndefinite
 
 /-!
 # French Modal Indefinite Fragment
-[jayez-tovena-2006]
 
-Lexical entry for French modal indefinite *n'importe quel*.
-
+Lexical entry for French modal indefinite *n'importe quel*
+([jayez-tovena-2006]).
 -/
-
-set_option autoImplicit false
 
 namespace French.ModalIndefinites
 
 open Features.ModalIndefinite
 
-
--- ════════════════════════════════════════════════════
--- § 1. Lexical Entry
--- ════════════════════════════════════════════════════
-
 /-- *n'importe quel*: at-issue, random choice only, not upper-bounded.
     Literally "no matter which"; conveys indiscriminacy
     ([jayez-tovena-2006]). -/
 def nimporteQuelEntry : ModalIndefiniteEntry where
-  language := "French"
   form := "n'importe quel"
-  gloss := "no matter which"
   status := .atIssue
   flavors := [.circumstantial]
   upperBounded := false
   hasUnremarkableReading := false
   canBePredicate := false
   anchorConstraint := some .unrestricted
-  source := "Jayez & Tovena 2006"
 
 /-- The French modal indefinite paradigm. -/
 def paradigm : List ModalIndefiniteEntry := [nimporteQuelEntry]
-
 
 end French.ModalIndefinites

--- a/Linglib/Fragments/Spanish/ModalIndefinites.lean
+++ b/Linglib/Fragments/Spanish/ModalIndefinites.lean
@@ -2,75 +2,43 @@ import Linglib.Features.ModalIndefinite
 
 /-!
 # Spanish Modal Indefinite Fragment
-[alonso-ovalle-menendez-benito-2010] [alonso-ovalle-menendez-benito-2018]
 
-Lexical entries for Spanish modal indefinites *algún* and *uno cualquiera*.
-
-- *algún*: epistemic modal indefinite with anti-singleton constraint
-  ([alonso-ovalle-menendez-benito-2010]).
-- *uno cualquiera*: random choice modal indefinite with anti-singleton
-  constraint ([alonso-ovalle-menendez-benito-2018]).
-
+Lexical entries for Spanish modal indefinites *algún*
+([alonso-ovalle-menendez-benito-2010]: epistemic, with an
+anti-singleton domain constraint) and *uno cualquiera*
+([alonso-ovalle-menendez-benito-2018]: random choice).
 -/
-
-set_option autoImplicit false
 
 namespace Spanish.ModalIndefinites
 
 open Features.ModalIndefinite
 
-
--- ════════════════════════════════════════════════════
--- § 1. Lexical Entries
--- ════════════════════════════════════════════════════
-
-/-- *algún*: not-at-issue, epistemic only, upper-bounded.
-    The modal component is a conversational implicature derived from
-    the anti-singleton constraint on the domain
+/-- *algún*: not-at-issue, epistemic only, upper-bounded. The modal
+    component is a conversational implicature derived from the
+    anti-singleton constraint on the domain
     ([alonso-ovalle-menendez-benito-2010], §4). -/
 def algúnEntry : ModalIndefiniteEntry where
-  language := "Spanish"
   form := "algún"
-  gloss := "ALGÚN"
   status := .notAtIssue
   flavors := [.epistemic]
   upperBounded := true
   hasUnremarkableReading := false
   canBePredicate := false
-  source := "Alonso-Ovalle & Menéndez-Benito 2010"
 
-/-- *uno cualquiera*: at-issue, random choice only, upper-bounded.
-    The random choice interpretation requires a volitional predicate;
-    with non-volitional predicates only the unremarkable reading
-    is available ([alonso-ovalle-menendez-benito-2018], §1.1). -/
+/-- *uno cualquiera*: at-issue, random choice only, upper-bounded. The
+    random-choice interpretation requires a volitional predicate; with
+    non-volitional predicates only the unremarkable reading is
+    available ([alonso-ovalle-menendez-benito-2018], §1.1). -/
 def unoCualquieraEntry : ModalIndefiniteEntry where
-  language := "Spanish"
   form := "uno cualquiera"
-  gloss := "one whichever"
   status := .atIssue
   flavors := [.circumstantial]
   upperBounded := true
   hasUnremarkableReading := true
   canBePredicate := true
   anchorConstraint := some .volitionalOnly
-  source := "Alonso-Ovalle & Menéndez-Benito 2018"
 
 /-- The Spanish modal indefinite paradigm. -/
 def paradigm : List ModalIndefiniteEntry := [algúnEntry, unoCualquieraEntry]
-
-
--- ════════════════════════════════════════════════════
--- § 2. Cross-Entry Contrast
--- ════════════════════════════════════════════════════
-
-/-- *algún* and *uno cualquiera* share upper-boundedness but differ in
-    status and flavor: *algún* is not-at-issue + epistemic, *uno cualquiera*
-    is at-issue + random choice. -/
-theorem algún_unoCualquiera_contrast :
-    algúnEntry.status ≠ unoCualquieraEntry.status ∧
-    algúnEntry.flavors ≠ unoCualquieraEntry.flavors ∧
-    algúnEntry.upperBounded = unoCualquieraEntry.upperBounded := by
-  refine ⟨by decide, by decide, rfl⟩
-
 
 end Spanish.ModalIndefinites

--- a/Linglib/Studies/AlonsoOvalleMenendezBenito2010.lean
+++ b/Linglib/Studies/AlonsoOvalleMenendezBenito2010.lean
@@ -589,7 +589,7 @@ theorem typology_coverage :
     cell4_antisingleton_nonunique.exemplars.length > 0 ∧
     cell2_predicted.exemplars.length = 0 ∧
     cell3_predicted.exemplars.length = 0 := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> native_decide
+  decide
 
 
 -- ════════════════════════════════════════════════════
@@ -613,8 +613,8 @@ theorem algún_entry_not_at_issue :
     the Modal Variation inference concerns the SPEAKER's beliefs, mediated
     by ASSERT ((20)). The fragment entry records epistemic-only flavor. -/
 theorem algún_entry_epistemic_only :
-    algúnEntry.hasFlavor .epistemic ∧ ¬ algúnEntry.hasFlavor .circumstantial := by
-  refine ⟨?_, ?_⟩ <;> decide
+    algúnEntry.hasFlavor .epistemic = true ∧
+    algúnEntry.hasFlavor .circumstantial = false := ⟨rfl, rfl⟩
 
 
 end AlonsoOvalleMenendezBenito2010

--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -8,59 +8,31 @@ import Linglib.Fragments.Romance.French.ModalIndefinites
 import Linglib.Fragments.Italian.ModalIndefinites
 
 /-!
-# Modal Indefinites: Cross-Linguistic Typology & Event-Relative Anchoring
-[alonso-ovalle-royer-2024] [alonso-ovalle-menendez-benito-2010]
-[alonso-ovalle-menendez-benito-2018] [coon-2019] [hacquard-2006]
-[alonso-ovalle-royer-2021]
-[chierchia-2013] [jayez-tovena-2006] [kratzer-shimoyama-2002]
+# Modal indefinites and semantic variation: lessons from Chuj
 
-Cross-linguistic typology of modal indefinites and bridge theorems connecting
-the event-relative modality theory ([hacquard-2006], formalized in
-`Semantics/Modality/EventRelativity`) to empirical observations.
+[alonso-ovalle-royer-2024]'s account of Chuj *yalnhej*: the modal
+component is at-issue, event-relative
+(`Semantics/Modality/EventRelativity`, after [hacquard-2006]), and its
+flavor is derived from structural position and predicate volitionality
+rather than stipulated lexically. The lexical entries live in the
+`ModalIndefinites` fragments (Chuj, Spanish, German, French, Italian);
+this file holds the paper's denotation, the cross-linguistic typology
+over the pooled entries, the position × volitionality derivation, and
+finite-model witnesses for non-maximality, upper-boundedness, and
+harmonic anchoring.
 
-Lexical entries are defined in Fragment files (single source of truth):
-- `Fragments/Mayan/Chuj/ModalIndefinites.lean`: *yalnhej*, *komon*
-- `Fragments/Spanish/ModalIndefinites.lean`: *algún*, *uno cualquiera*
-- `Fragments/German/ModalIndefinites.lean`: *irgendein*
-- `Fragments/French/ModalIndefinites.lean`: *n'importe quel*
-- `Fragments/Italian/ModalIndefinites.lean`: *un qualsiasi*
+One departure from [hacquard-2006] (§4.1, fn. 17): *yalnhej*'s anchor
+can be left free — bound by the speech-act event rather than the
+closest event binder — which is how external arguments above AspP still
+access the speech event.
 
-## Architecture
+## Main declarations
 
-The key contribution of [alonso-ovalle-royer-2024] is DERIVING the
-position-sensitive flavor distribution of Chuj *yalnhej* from structural
-properties of event binding, rather than stipulating it lexically:
-
-    ChujArgPosition → accessibleBinders → miAnchorFlavor → predictedMIFlavors
-
-1. Syntactic position determines which `EventBinder`s are accessible
-2. Each binder projects a specific MI flavor via `AnchorType.toFlavor`
-3. RC (random choice) additionally requires verb volitionality
-
-## Three Dimensions of Variation (§6)
-
-1. **Status**: at-issue vs not-at-issue
-2. **Content**: which modal flavors
-3. **Upper-boundedness**: anti-singleton inference
-
-## Anchor Constraint (§4)
-
-At-issue modal indefinites are further distinguished by their
-`AnchorConstraint`: whether the anchoring function f has no definedness
-condition (unrestricted — defined for any event) or presupposes normative
-content (volitional-only). The anchor constraint controls where f CAN
-anchor; content licensing independently determines the resulting flavor.
-
-## Anchor Freedom (§4.1, footnote 17)
-
-A-O&R depart from [hacquard-2006] in one key respect: the event
-argument of *yalnhej*'s anchoring function can be "left free" — bound
-by the existential closure of the speech act event rather than by the
-closest event binder. In Hacquard's system, modals are always bound by
-the closest c-commanding event binder; *yalnhej* allows non-local
-binding, which is how external arguments (above AspP) still access the
-speech event despite intervening projections.
-
+* `modalIndefiniteSat`, `upperBoundedSat` — the paper's denotation (59).
+* `allEntries` — the pooled fragment paradigms.
+* `predictedMIFlavors`, `flavor_pattern_derived` — the position ×
+  volitionality pattern, derived from `accessibleBinders` and
+  `rcAvailable`.
 -/
 
 namespace AlonsoOvalleRoyer2024
@@ -74,10 +46,7 @@ open German.ModalIndefinites
 open French.ModalIndefinites
 open Italian.ModalIndefinites
 
-
--- ════════════════════════════════════════════════════════════════
--- Part 0: Modal Indefinite Denotation ([alonso-ovalle-royer-2024], (59))
--- ════════════════════════════════════════════════════════════════
+/-! ### Modal Indefinite Denotation ([alonso-ovalle-royer-2024], (59)) -/
 
 /-- The modal component of a modal indefinite ([alonso-ovalle-royer-2024], (59)):
 
@@ -153,26 +122,17 @@ theorem upperBounded_entails_plain {Event W Entity : Type*}
     modalIndefiniteSat f e allW domain P Q w :=
   h.1
 
+/-! ### The pooled sample -/
 
--- ════════════════════════════════════════════════════════════════
--- Part I: Cross-Linguistic Typology
--- ════════════════════════════════════════════════════════════════
-
-
--- ════════════════════════════════════════════════════
--- § 1. All Entries
--- ════════════════════════════════════════════════════
-
+/-- The pooled cross-linguistic sample: the five fragment paradigms. -/
 def allEntries : List ModalIndefiniteEntry :=
-  [yalnhejEntry, komonEntry, algúnEntry, irgendeinEntry,
-   unoCualquieraEntry, nimporteQuelEntry, unQualsiasiEntry]
+  Chuj.ModalIndefinites.paradigm ++ Spanish.ModalIndefinites.paradigm ++
+  German.ModalIndefinites.paradigm ++ French.ModalIndefinites.paradigm ++
+  Italian.ModalIndefinites.paradigm
 
 theorem allEntries_count : allEntries.length = 7 := rfl
 
-
--- ════════════════════════════════════════════════════
--- § 2. Typological Generalizations (§6)
--- ════════════════════════════════════════════════════
+/-! ### Typological Generalizations (§6) -/
 
 /-- Chuj *yalnhej* and German *irgendein* share the same flavor
 inventory (epistemic + random choice) but differ in status. -/
@@ -200,35 +160,21 @@ epistemic and random choice flavors. This is the core empirical
 contribution of [alonso-ovalle-royer-2024]. -/
 theorem yalnhej_unique_profile :
     (allEntries.filter (λ e =>
-      e.status == .atIssue && decide (e.hasFlavor .epistemic) && decide (e.hasFlavor .circumstantial))).length = 1 := rfl
+      e.status == .atIssue && e.hasFlavor .epistemic &&
+      e.hasFlavor .circumstantial)).length = 1 := rfl
 
+/-! ### Independence of Dimensions -/
 
--- ════════════════════════════════════════════════════
--- § 3. Independence of Dimensions
--- ════════════════════════════════════════════════════
+/-- Status and upper-boundedness are independent: all four cells of the
+    2×2 matrix are attested (*uno cualquiera*, *yalnhej*, *algún*,
+    *irgendein*). -/
+theorem status_ub_independent :
+    (allEntries.any (λ e => e.status == .atIssue && e.upperBounded) &&
+     allEntries.any (λ e => e.status == .atIssue && !e.upperBounded) &&
+     allEntries.any (λ e => e.status == .notAtIssue && e.upperBounded) &&
+     allEntries.any (λ e => e.status == .notAtIssue && !e.upperBounded)) = true := rfl
 
-/-- The three dimensions are logically independent: we find items in
-multiple cells of the 2×2 (status × upper-bounded) matrix. -/
-theorem at_issue_and_ub_exists :
-    allEntries.any (λ e => e.status == .atIssue && e.upperBounded) = true := rfl
-  -- uno cualquiera
-
-theorem at_issue_and_not_ub_exists :
-    allEntries.any (λ e => e.status == .atIssue && !e.upperBounded) = true := rfl
-  -- yalnhej
-
-theorem not_at_issue_and_ub_exists :
-    allEntries.any (λ e => e.status == .notAtIssue && e.upperBounded) = true := rfl
-  -- algún
-
-theorem not_at_issue_and_not_ub_exists :
-    allEntries.any (λ e => e.status == .notAtIssue && !e.upperBounded) = true := rfl
-  -- irgendein
-
-
--- ════════════════════════════════════════════════════
--- § 4. AnchorConstraint Bridge
--- ════════════════════════════════════════════════════
+/-! ### AnchorConstraint Bridge -/
 
 /-- Consistency check: anchored entries are at-issue. Event-relative
 anchoring (`anchorConstraint = some _`) is the paper's mechanism for
@@ -248,7 +194,7 @@ theorem anchored_entries_at_issue :
 event anchoring (speech acts lack normative content). -/
 theorem volitional_blocks_epistemic :
     unoCualquieraEntry.anchorConstraint = some .volitionalOnly ∧
-    ¬ unoCualquieraEntry.hasFlavor .epistemic := ⟨rfl, by decide⟩
+    unoCualquieraEntry.hasFlavor .epistemic = false := ⟨rfl, rfl⟩
 
 /-- Unrestricted anchor constraint is necessary but not sufficient for
 epistemic: *yalnhej* gets epistemic because f is defined for the
@@ -257,21 +203,15 @@ yet only have circumstantial (their lexical semantics restricts to
 indiscriminacy/FC readings). -/
 theorem unrestricted_with_epistemic :
     yalnhejEntry.anchorConstraint = some .unrestricted ∧
-    yalnhejEntry.hasFlavor .epistemic := ⟨rfl, by decide⟩
+    yalnhejEntry.hasFlavor .epistemic = true := ⟨rfl, rfl⟩
 
 theorem unrestricted_without_epistemic :
     nimporteQuelEntry.anchorConstraint = some .unrestricted ∧
-    ¬ nimporteQuelEntry.hasFlavor .epistemic := ⟨rfl, by decide⟩
+    nimporteQuelEntry.hasFlavor .epistemic = false := ⟨rfl, rfl⟩
 
+/-! ### Position-Sensitive Flavor Distribution -/
 
--- ════════════════════════════════════════════════════════════════
--- Part II: Position-Sensitive Flavor Distribution
--- ════════════════════════════════════════════════════════════════
-
-
--- ════════════════════════════════════════════════════
--- § 5. Structural Position and Accessible Binders
--- ════════════════════════════════════════════════════
+/-! ### Structural Position and Accessible Binders -/
 
 /-- Structural position of a DP in the Chuj clause.
     Factored from verb volitionality (an orthogonal property of the
@@ -299,10 +239,7 @@ def accessibleBinders : ChujArgPosition → List EventBinder
   | .internal => [.speechAct, .vpEvent]
   | .adjunct  => [.speechAct, .vpEvent]
 
-
--- ════════════════════════════════════════════════════
--- § 6. MI Flavor Derivation via EventBinder
--- ════════════════════════════════════════════════════
+/-! ### MI Flavor Derivation via EventBinder -/
 
 /-- The MI flavor projected by a given event binder.
 Speech act events project epistemic; VP events project circumstantial.
@@ -343,10 +280,7 @@ def predictedMIFlavors (pos : ChujArgPosition) (volitional : Bool) : List ModalF
   else
     (baseMIFlavors pos).filter (· != .circumstantial)
 
-
--- ════════════════════════════════════════════════════
--- § 7. Flavor Pattern Verification
--- ════════════════════════════════════════════════════
+/-! ### Flavor Pattern Verification -/
 
 /-- The position × volitionality flavor pattern DERIVED from structural
 position + volitionality + EventBinder. The full pattern of
@@ -388,10 +322,7 @@ theorem internal_adjunct_same (v : Bool) :
     predictedMIFlavors .internal v = predictedMIFlavors .adjunct v := by
   cases v <;> rfl
 
-
--- ════════════════════════════════════════════════════
--- § 8. Voice → Position → Binders → Flavors
--- ════════════════════════════════════════════════════
+/-! ### Voice → Position → Binders → Flavors -/
 
 /-! The full derivation chain connecting Chuj clause structure to
 MI flavor predictions:
@@ -459,15 +390,9 @@ theorem argPosition_parallels_modalPosition :
     accessibleBinders .external = [.speechAct] ∧
     accessibleBinders .internal = [.speechAct, .vpEvent] := ⟨rfl, rfl, rfl, rfl⟩
 
+/-! ### Empirical Phenomena -/
 
--- ════════════════════════════════════════════════════════════════
--- Part III: Empirical Phenomena
--- ════════════════════════════════════════════════════════════════
-
-
--- ════════════════════════════════════════════════════
--- § 9. Non-Maximality (§3.2.4)
--- ════════════════════════════════════════════════════
+/-! ### Non-Maximality (§3.2.4) -/
 
 /-- *Yalnhej* is not upper-bounded: compatible with partial-domain
 scenarios where not all P are Q. This distinguishes it from maximal
@@ -477,35 +402,35 @@ this concretely with `yalnhej_nonmaximal_ab` (§14 below). -/
 theorem yalnhej_nonmaximal :
     yalnhejEntry.upperBounded = false := rfl
 
-
--- ════════════════════════════════════════════════════
--- § 9b. Flavor Selectivity (§6.2)
--- ════════════════════════════════════════════════════
+/-! ### Flavor Selectivity (§6.2) -/
 
 /-- Multi-flavor items: can express BOTH epistemic and RC.
 [alonso-ovalle-royer-2024], §6.2: *yalnhej* and *irgendein*
 tolerate more than one modal flavour. -/
 theorem multi_flavor_items :
     (allEntries.filter (λ e =>
-      decide (e.hasFlavor .epistemic) && decide (e.hasFlavor .circumstantial))).length = 2 := rfl
+      e.hasFlavor .epistemic && e.hasFlavor .circumstantial)).length = 2 := rfl
 
 /-- Epistemic-only items: *algún* conveys only speaker ignorance
 (§6.2, example 118). -/
 theorem epistemic_only_items :
     (allEntries.filter (λ e =>
-      decide (e.hasFlavor .epistemic) && !decide (e.hasFlavor .circumstantial))).length = 1 := rfl
+      e.hasFlavor .epistemic && !e.hasFlavor .circumstantial)).length = 1 := rfl
 
 /-- RC-only items: *uno cualquiera*, *n'importe quel*, *un qualsiasi*,
 *komon* convey only random choice / indiscriminacy
 (§6.2, examples 119–121). -/
 theorem rc_only_items :
     (allEntries.filter (λ e =>
-      !decide (e.hasFlavor .epistemic) && decide (e.hasFlavor .circumstantial))).length = 4 := rfl
+      !e.hasFlavor .epistemic && e.hasFlavor .circumstantial)).length = 4 := rfl
 
+/-- *Komon* can never express speaker ignorance
+    ([alonso-ovalle-royer-2021]); *yalnhej* can. -/
+theorem komon_never_epistemic :
+    komonEntry.hasFlavor .epistemic = false ∧
+    yalnhejEntry.hasFlavor .epistemic = true := ⟨rfl, rfl⟩
 
--- ════════════════════════════════════════════════════
--- § 10. Upper-Boundedness (§3.2.4, §6.2)
--- ════════════════════════════════════════════════════
+/-! ### Upper-Boundedness (§3.2.4, §6.2) -/
 
 /-- Upper-bounded modal indefinites impose a witness upper bound. -/
 theorem upper_bounded_group :
@@ -516,15 +441,12 @@ theorem not_upper_bounded_group :
     [yalnhejEntry, irgendeinEntry, nimporteQuelEntry, unQualsiasiEntry].all
       (·.upperBounded == false) = true := rfl
 
+/-! ### Unremarkable Readings and Predicativity (§5) -/
 
--- ════════════════════════════════════════════════════
--- § 11. Unremarkable Readings and Predicativity (§5)
--- ════════════════════════════════════════════════════
-
-/-- Predicativity correlates with unremarkable readings across all
-entries. Items that can appear in predicative position also have
-non-modal ("unremarkable") readings. Derived directly from fragment
-entry fields — no intermediate data structures needed. -/
+/-- Predicativity and unremarkable readings coincide across all seven
+entries (§5). True by construction of the entries — the two fields were
+filled from the same diagnostics — so this records the encoding, not an
+independent prediction. -/
 theorem predicativity_correlates_unremarkable :
     allEntries.all (λ e =>
       e.canBePredicate == e.hasUnremarkableReading) = true := rfl
@@ -546,10 +468,7 @@ theorem komon_has_unremarkable :
     komonEntry.hasUnremarkableReading = true ∧
     komonEntry.canBePredicate = true := ⟨rfl, rfl⟩
 
-
--- ════════════════════════════════════════════════════
--- § 12. Harmonic Interpretations (§4.3)
--- ════════════════════════════════════════════════════
+/-! ### Harmonic Interpretations (§4.3) -/
 
 /-! Under an external modal (imperative, deontic, attitude verb),
 the MI's anchor can be co-indexed with the modal's event binder,
@@ -586,10 +505,7 @@ theorem harmonic_neq_nonharmonic :
     EventBinder.vpEvent.availableFlavors ≠
     EventBinder.speechAct.availableFlavors := by decide
 
-
--- ════════════════════════════════════════════════════════════════
--- Part IV: Worked Examples — Book and Card Scenarios
--- ════════════════════════════════════════════════════════════════
+/-! ### Worked Examples — Book and Card Scenarios -/
 
 /-! Concrete model-theoretic witnesses for the typological claims of
 Part I. These instantiate the Part 0 denotations (`modalIndefiniteSat`,
@@ -599,9 +515,7 @@ vs. non-harmonic anchoring distinction. The toy domains live here
 in the study file (per CLAUDE.md: examples that name a paper's analyses
 belong with the paper, not in the abstract theory file). -/
 
--- ════════════════════════════════════════════════════
--- § 13. Book Scenario: Non-Maximality and Upper-Boundedness
--- ════════════════════════════════════════════════════
+/-! ### Book Scenario: Non-Maximality and Upper-Boundedness -/
 
 /-- Three books for testing the modal indefinite semantics. -/
 inductive Book where | a | b | c
@@ -666,14 +580,9 @@ theorem yalnhej_book_abc :
 theorem yalnhej_not_upper_bounded_abc :
     modalIndefiniteSat fEPI .speech allBW allBooks isBook isAvailable .abc ∧
     ¬ upperBoundedSat fEPI .speech allBW allBooks isBook isAvailable .abc := by
-  refine ⟨?_, ?_⟩
-  · decide
-  · decide
+  exact ⟨by decide, by decide⟩
 
-
--- ════════════════════════════════════════════════════
--- § 14. Non-Maximality ([alonso-ovalle-royer-2024], §3.2.4)
--- ════════════════════════════════════════════════════
+/-! ### Non-Maximality ([alonso-ovalle-royer-2024], §3.2.4) -/
 
 /-! Yalnhej is compatible with partial-domain scenarios: the speaker
 can felicitously use *yalnhej* even when not all P are Q. This
@@ -710,12 +619,9 @@ theorem yalnhej_three_way_contrast :
     modalIndefiniteSat fEPI .speech allBW allBooks isBook isAvailable .ab ∧
     -- UB fails in abc (all satisfy scope → anti-singleton violated)
     ¬ upperBoundedSat fEPI .speech allBW allBooks isBook isAvailable .abc := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+  refine ⟨by decide, by decide, by decide⟩
 
-
--- ════════════════════════════════════════════════════
--- § 15. Card Scenario: Harmonic Interpretations ([alonso-ovalle-royer-2024], §4.3)
--- ════════════════════════════════════════════════════
+/-! ### Card Scenario: Harmonic Interpretations ([alonso-ovalle-royer-2024], §4.3) -/
 
 /-! When a modal indefinite occurs under an external modal (imperative,
 deontic, attitude verb), the MI's anchoring event can be CO-INDEXED
@@ -811,7 +717,6 @@ theorem harmonic_succeeds :
 theorem harmonic_neq_nonharmonic_witness :
     ¬ modalIndefiniteSat fGrab .local allCW allCards isCard canGrab .only1 ∧
     modalIndefiniteSat fGrab .imperative allCW allCards isCard canGrab .only1 := by
-  refine ⟨?_, ?_⟩ <;> decide
-
+  exact ⟨by decide, by decide⟩
 
 end AlonsoOvalleRoyer2024

--- a/Linglib/Studies/Bubnov2026.lean
+++ b/Linglib/Studies/Bubnov2026.lean
@@ -300,8 +300,8 @@ theorem aadaruu_matches_nonSpecific :
 theorem irgend_compatible_classifications :
     irgendEntry.surfaceDAType = some DAType.epistemic ∧
     irgendeinEntry.status = .notAtIssue ∧
-    irgendeinEntry.hasFlavor Semantics.Modality.ModalFlavor.epistemic := by
-  exact ⟨by decide, rfl, by decide⟩
+    irgendeinEntry.hasFlavor Semantics.Modality.ModalFlavor.epistemic = true := by
+  exact ⟨by decide, rfl, rfl⟩
 
 -- ============================================================================
 -- §8. The broader claim: coexpression ≠ syncretism
@@ -386,9 +386,7 @@ theorem fragment_polarity_disagree_on_some :
     this breaks. Real value: catches drift between the two Fragments. -/
 theorem irgend_irgendein_agree_on_epistemic :
     German.Indefinites.irgendEntry.surfaceDAType = some .epistemic ∧
-    German.ModalIndefinites.irgendeinEntry.flavors.contains .epistemic = true := by
-  refine ⟨?_, ?_⟩
-  · decide
-  · decide
+    German.ModalIndefinites.irgendeinEntry.hasFlavor .epistemic = true := by
+  exact ⟨by decide, rfl⟩
 
 end Bubnov2026


### PR DESCRIPTION
Executes the MI-schema arc of the Chuj audit plus the requested deep cleanse of `Studies/AlonsoOvalleRoyer2024.lean`.

- Schema: delete the four read-free fields (`source` raw-citation strings, `language`, `gloss`, `positionSensitive` — the last stipulated what `position_matters` derives); `hasFlavor` resolved to Bool (the decidable-table idiom), removing every `decide (…)` wrapper.
- Fragments (5 languages): entries slim to schema fields; the two fragment-level contrast theorems move to studies (Chuj's ¬epistemic-komon content lands as `komon_never_epistemic`; Spanish's contrast was already covered in AOMB2010).
- AOR2024 cleanse: `allEntries` now derives from the five fragment paradigms instead of hand-listing seven entries; banners → `/-! ### -/` headers; module docstring to register; four independence any-theorems compressed to one; `predicativity_correlates_unremarkable` hedged as true-by-construction; proof ceremony collapsed.
- AOMB2010: `typology_coverage` off `native_decide` onto kernel `decide`.