### PR TITLE
style(Studies/AlonsoOvalleRoyer2024): lift variables; inline modalComponent

### DIFF
--- a/Linglib/Studies/AlonsoOvalleRoyer2024.lean
+++ b/Linglib/Studies/AlonsoOvalleRoyer2024.lean
@@ -46,81 +46,43 @@ open German.ModalIndefinites
 open French.ModalIndefinites
 open Italian.ModalIndefinites
 
-/-! ### Modal Indefinite Denotation ([alonso-ovalle-royer-2024], (59)) -/
+/-! ### The modal indefinite denotation ((59)) -/
 
-/-- The modal component of a modal indefinite ([alonso-ovalle-royer-2024], (59)):
+section Denotation
 
-    `∀y[P(y)(w) → ◇_{f(e₁)}(Q(y)(w'))]`
+variable {Event W Entity : Type*} (f : AnchoringFn Event W) (e : Event) (allW : List W)
+  (domain : List Entity) (P Q : Entity → W → Prop) (w : W)
 
-For every individual y satisfying restrictor P in the actual world, there
-exists an accessible world w' (via anchoring function f applied to event e₁)
-where y satisfies scope predicate Q. The "modal variation" inference:
-every domain member is a possible witness. -/
-def modalComponent {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop)
-    (w : W) : Prop :=
-  ∀ y ∈ domain, P y w → possibility f e allW (λ w' => Q y w') w
-
-instance {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop)
-    [∀ y, DecidablePred (P y)] [∀ y, DecidablePred (Q y)] (w : W) :
-    Decidable (modalComponent f e allW domain P Q w) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, _))
-
-/-- Full modal indefinite denotation ([alonso-ovalle-royer-2024], (59)):
+/-- The modal indefinite denotation (59):
 
     `⟦MI⟧^{f,e₁} = λP.λQ.λw. ∃x[P(x)(w) ∧ Q(x)(w)] ∧ ∀y[P(y)(w) → ◇_{f(e₁)}(Q(y)(w'))]`
 
-Existential component: some individual satisfies both restrictor and scope.
-Universal modal component: every restrictor individual is a possible
-scope-satisfier in some accessible world (the free choice / modal variation
-effect). -/
-def modalIndefiniteSat {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop) (w : W) : Prop :=
+Some domain member satisfies restrictor and scope, and every restrictor
+member is a possible scope-satisfier — the modal-variation effect. -/
+def modalIndefiniteSat : Prop :=
   (∃ x ∈ domain, P x w ∧ Q x w) ∧
-    modalComponent f e allW domain P Q w
+    ∀ y ∈ domain, P y w → possibility f e allW (λ w' => Q y w') w
 
-instance {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop)
-    [∀ y, DecidablePred (P y)] [∀ y, DecidablePred (Q y)] (w : W) :
+instance [∀ y, DecidablePred (P y)] [∀ y, DecidablePred (Q y)] :
     Decidable (modalIndefiniteSat f e allW domain P Q w) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-- An upper-bounded modal indefinite additionally requires that NOT every
-    P is Q in the actual world — the speaker does not know/intend for all
-    domain members to satisfy Q.
-
-    `⟦MI_UB⟧ = ⟦MI⟧ ∧ ¬∀x[P(x)(w) → Q(x)(w)]`
-
-The witness upper bound of *algún* (§4.2 — distinct from the
+/-- The upper-bounded denotation: additionally, not every P is Q in the
+actual world — *algún*'s witness upper bound (§4.2; distinct from the
 anti-singleton *domain* constraint of
-[alonso-ovalle-menendez-benito-2010]). Items like *yalnhej* lack this
-condition and are compatible with all P being Q. -/
-def upperBoundedSat {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop) (w : W) : Prop :=
-  modalIndefiniteSat f e allW domain P Q w ∧
-    ¬ (∀ x ∈ domain, P x w → Q x w)
+[alonso-ovalle-menendez-benito-2010]). -/
+def upperBoundedSat : Prop :=
+  modalIndefiniteSat f e allW domain P Q w ∧ ¬ ∀ x ∈ domain, P x w → Q x w
 
-instance {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop)
-    [∀ y, DecidablePred (P y)] [∀ y, DecidablePred (Q y)] (w : W) :
+instance [∀ y, DecidablePred (P y)] [∀ y, DecidablePred (Q y)] :
     Decidable (upperBoundedSat f e allW domain P Q w) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-- Upper-boundedness strengthens the modal indefinite: if the UB version
-    holds, the plain MI version holds. -/
-theorem upperBounded_entails_plain {Event W Entity : Type*}
-    (f : AnchoringFn Event W) (e : Event) (allW : List W)
-    (domain : List Entity) (P Q : Entity → W → Prop) (w : W)
-    (h : upperBoundedSat f e allW domain P Q w) :
-    modalIndefiniteSat f e allW domain P Q w :=
-  h.1
+/-- Upper-boundedness strengthens the plain denotation. -/
+theorem upperBounded_entails_plain (h : upperBoundedSat f e allW domain P Q w) :
+    modalIndefiniteSat f e allW domain P Q w := h.1
+
+end Denotation
 
 /-! ### The pooled sample -/
 


### PR DESCRIPTION
Follow-up elegance pass on the Part 0 denotation, per review: the seven-parameter tuple lifts into a sectioned `variable` block (every signature collapses to one line), and `modalComponent` — whose only consumer was `modalIndefiniteSat` — is inlined, deleting a def and an instance. The deeper clunk (`allW : List W` enumeration-threading) is inherited from `EventRelativity`'s list-based `possibility` and is queued as a substrate arc.