### PR TITLE
refactor(Semantics/Modality): move Kernel study content to study files

### DIFF
--- a/Linglib/Semantics/Intensional/Premise.lean
+++ b/Linglib/Semantics/Intensional/Premise.lean
@@ -84,6 +84,31 @@ def isConsistent (A : List (Index → Prop)) : Prop :=
 def isCompatibleWith (p : Index → Prop) (A : List (Index → Prop)) : Prop :=
   isConsistent (p :: A)
 
+theorem mem_propExtension {p : Index → Prop} {i : Index} :
+    i ∈ propExtension p ↔ p i := Iff.rfl
+
+theorem mem_propIntersection {A : List (Index → Prop)} {i : Index} :
+    i ∈ propIntersection A ↔ ∀ p ∈ A, p i := Iff.rfl
+
+/-- Each premise's extension contains the intersection of the whole set. -/
+theorem propIntersection_subset_propExtension {x : Index → Prop}
+    {A : List (Index → Prop)} (hx : x ∈ A) :
+    propIntersection A ⊆ propExtension x :=
+  fun _ hi => hi x hx
+
+theorem isCompatibleWith_iff_exists {p : Index → Prop} {A : List (Index → Prop)} :
+    isCompatibleWith p A ↔ ∃ i ∈ propIntersection A, p i := by
+  simp only [isCompatibleWith, isConsistent, Set.Nonempty, mem_propIntersection,
+    List.forall_mem_cons]
+  exact ⟨fun ⟨i, hp, hA⟩ => ⟨i, hA, hp⟩, fun ⟨i, hA, hp⟩ => ⟨i, hp, hA⟩⟩
+
+/-- Duality: `p` is compatible with `A` iff `¬p` does not follow from `A`. -/
+theorem isCompatibleWith_iff_not_followsFrom_not {p : Index → Prop}
+    {A : List (Index → Prop)} :
+    isCompatibleWith p A ↔ ¬ followsFrom (fun i => ¬ p i) A := by
+  rw [isCompatibleWith_iff_exists]
+  simp [followsFrom, Set.subset_def, propExtension, not_forall]
+
 /-! ## Kratzer 1977 Definitions 5–6: must/can in view of -/
 
 /-- **Def 5** ([kratzer-1977]): `must p in view of f` at index `i`
@@ -151,7 +176,7 @@ theorem propIntersection_anti_of_subset
 theorem followsFrom_mono_of_subset
     {p : Index → Prop} {A B : List (Index → Prop)}
     (h : A ⊆ B) (hp : followsFrom p A) : followsFrom p B :=
-  fun i hi => hp (propIntersection_anti_of_subset h hi)
+  fun _ hi => hp (propIntersection_anti_of_subset h hi)
 
 /-- `isCompatibleWith` is **anti-monotone** in the premise list: removing
     premises can only make a proposition easier to be compatible with. -/

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -1,43 +1,49 @@
 import Linglib.Semantics.Modality.Kratzer.Flavor
 import Linglib.Semantics.Presupposition.Basic
-import Mathlib.Data.Fin.Basic
-import Mathlib.Data.Fintype.Basic
-import Mathlib.Data.Fintype.Card
-import Mathlib.Data.Finset.Card
+
 /-!
 # Kernel Semantics for Epistemic Modals
-[von-fintel-gillies-2010] [von-fintel-gillies-2021]
 
-[von-fintel-gillies-2010] kernel semantics. Epistemic modals carry an
+[von-fintel-gillies-2010]'s kernel semantics: epistemic modals carry an
 evidential presupposition that the prejacent is not *directly settled* by the
-kernel K ⊆ B_K. The central result (`entailment_settling_gap`) is that B_K can
-entail φ without K directly settling it, making the presupposition non-trivial.
+kernel `K` — the privileged direct-information part of the modal base
+(Def 4: `B_K = ⋂K`). The presupposition makes *must φ* strong (it asserts
+`B_K ⊆ ⟦φ⟧`, Def 5) while still signalling indirectness: `B_K` can entail
+`φ` without `K` directly settling it.
 
-The 2021 paper extends the analysis to *can't*, exposing a dilemma for the
-weakness Mantra: no assignment of force to *can't* simultaneously explains its
-evidential distribution (Observation 4) and its incompatibility with *it's
-possible* (Observation 5). Kernel semantics resolves this because *can't φ* =
-*must*(¬φ) is simultaneously strong and evidentially constrained.
+This file provides the reusable kernel apparatus: the `Kernel` structure, the
+explicit-representation implementation of directly-settles (Implementation 1,
+§7.1), the presuppositional operators `kernelMust`/`kernelMight`/`kernelCant`,
+and bridges to Kratzer necessity. The paper's second, partition-based
+implementation (Def 7, §7.2), the non-equivalence of the two implementations,
+and the worked examples live in `Studies/VonFintelGillies2010.lean`; the
+*can't* dilemma of [von-fintel-gillies-2021] lives in
+`Studies/VonFintelGillies2021.lean`; the nandao-Q felicity conditions built on
+this apparatus live in `Studies/Zheng2025.lean`.
 
+## Main declarations
+
+- `Kernel`: a set of direct-information propositions, with `Kernel.base` (B_K),
+  entailment (`Kernel.followsFrom`), and compatibility (`Kernel.compatibleWith`)
+- `directlySettlesExplicit`: Implementation 1 — some `X ∈ K` entails or
+  excludes the prejacent
+- `explicit_implies_entailment`: settling implies entailment; the converse
+  fails, which is what makes the presupposition non-trivial
+- `kernelMust`, `kernelMight`, `kernelCant`: the presuppositional operators
+  (Defs 5–6), as `PartialProp`s
+- `kernelMust_eq_simpleNecessity`, `kernelMust_eq_necessity`: the assertion of
+  `kernelMust` is Kratzer necessity over the induced modal base
 -/
 
 namespace Semantics.Modality
 
 open Semantics.Modality.Kratzer
 open Semantics.Presupposition
+open Intensional.Premise
 
 variable {W : Type*}
-/-! ## Helpers -/
 
-/-- `propIntersection (φ :: A)` is the intersection of `propIntersection A` with ⟦φ⟧. -/
-private theorem propIntersection_cons (φ : (W → Prop)) (A : List ((W → Prop))) :
-    propIntersection (φ :: A) = {w ∈ propIntersection A | φ w} := by
-  unfold propIntersection
-  ext w
-  simp only [Set.mem_setOf_eq, List.mem_cons, forall_eq_or_imp]
-  tauto
-
-/-! ## Kernel structure ([von-fintel-gillies-2010] Def 4) -/
+/-! ### Kernel structure ([von-fintel-gillies-2010] Def 4) -/
 
 /-- A kernel: a set of direct-information propositions with B_K = ⋂K. -/
 structure Kernel (W : Type*) where
@@ -70,342 +76,44 @@ def toEpistemicFlavor (k : Kernel W) : EpistemicFlavor W where
   evidence := k.toModalBase
   ordering := emptyBackground
 
+theorem followsFrom_iff (k : Kernel W) (φ : (W → Prop)) :
+    k.followsFrom φ ↔ ∀ w ∈ k.base, φ w := Iff.rfl
+
+theorem compatibleWith_iff (k : Kernel W) (φ : (W → Prop)) :
+    k.compatibleWith φ ↔ ∃ w ∈ k.base, φ w :=
+  isCompatibleWith_iff_exists
+
 end Kernel
 
-/-- World-dependent kernel assignment K^c(w). -/
-abbrev KernelBackground (W : Type*) := W → Kernel W
-
-namespace KernelBackground
-
-/-- Convert to a Kratzer modal base. -/
-def toModalBase (kb : KernelBackground W) : ModalBase W :=
-  λ w => (kb w).props
-
-end KernelBackground
-
-/-! ## Settling ([von-fintel-gillies-2010] Def 5) -/
+/-! ### Settling ([von-fintel-gillies-2010] §7.1, Implementation 1) -/
 
 /-- K directly settles P iff some X ∈ K entails P or is incompatible with P
-(Implementation 1). -/
+([von-fintel-gillies-2010] Implementation 1, "Explicit Representation"). -/
 def directlySettlesExplicit (k : Kernel W) (φ : (W → Prop)) : Prop :=
   ∃ x ∈ k.props,
     (∀ w ∈ propExtension x, φ w) ∨ (¬ ∃ w ∈ propExtension x, φ w)
 
-/-- Refine a partition along φ-boundaries ([von-fintel-gillies-2010] subject matter).
-
-    Uses `Classical.propDecidable` internally so the signature can be
-    `W → Prop` without a `[DecidablePred]` constraint that would
-    interfere with `List.foldl`. -/
-noncomputable def refine (partition : List (List W)) (φ : (W → Prop)) :
-    List (List W) :=
-  haveI : DecidablePred φ := fun w => Classical.propDecidable (φ w)
-  partition.flatMap λ cell =>
-    let pos := cell.filter (fun w => decide (φ w))
-    let neg := cell.filter (λ w => ¬ decide (φ w))
-    [pos, neg].filter (·.length > 0)
-
-/-- The partition S_K generated by K ([von-fintel-gillies-2010] Def 7).
-    Requires `[Fintype W]` to enumerate the starting universe. -/
-noncomputable def kernelPartition [Fintype W] (k : Kernel W) : List (List W) :=
-  k.props.foldl refine [Finset.univ.toList]
-
-/-- K settles P via partition iff P is a union of cells in S_K
-(Implementation 2). -/
-def settlesByPartition [Fintype W] (k : Kernel W) (φ : (W → Prop)) : Prop :=
-  let sK := kernelPartition k
-  ∀ cell ∈ sK, (∀ w ∈ cell, φ w) ∨ (∀ w ∈ cell, ¬ φ w)
-
-/-- B_K ⊆ ⟦X⟧ for each X ∈ K: every world in the modal base belongs
-    to each kernel proposition's extension. -/
-private theorem mem_propExtension_of_propIntersection
-    {x : (W → Prop)} {props : List ((W → Prop))}
-    (hx : x ∈ props) {w : W} (hw : w ∈ propIntersection props) :
-    w ∈ propExtension x := by
-  simp only [propExtension, propIntersection, Set.mem_setOf_eq] at hw ⊢
-  exact hw x hx
-
-/-- What both implementations share: settling implies entailment.
-    If K directly settles φ (Implementation 1), then B_K ⊆ ⟦φ⟧ or B_K ⊆ ⟦¬φ⟧.
-    If X ∈ K entails φ then B_K ⊆ X ⊆ ⟦φ⟧; if X excludes φ then
-    B_K ⊆ X ⊆ ⟦¬φ⟧. -/
+/-- Settling implies entailment: if K directly settles φ, then B_K ⊆ ⟦φ⟧ or
+    B_K ⊆ ⟦¬φ⟧. If X ∈ K entails φ then B_K ⊆ X ⊆ ⟦φ⟧; if X excludes φ then
+    B_K ⊆ X ⊆ ⟦¬φ⟧. The converse fails (see
+    `VonFintelGillies2010.entailment_settling_gap`). -/
 theorem explicit_implies_entailment (k : Kernel W) (φ : (W → Prop))
     (h : directlySettlesExplicit k φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
-  obtain ⟨x, hx_mem, hx⟩ := h
-  unfold Kernel.followsFrom Kratzer.followsFrom
-  cases hx with
-  | inl h_ent =>
-    left
-    intro w hw
-    exact h_ent w (mem_propExtension_of_propIntersection hx_mem hw)
-  | inr h_exc =>
-    right
-    intro w hw
-    have hw_ext := mem_propExtension_of_propIntersection hx_mem hw
-    intro hφ
-    exact h_exc ⟨w, hw_ext, hφ⟩
+  obtain ⟨x, hx_mem, h_ent | h_exc⟩ := h
+  · exact Or.inl λ w hw =>
+      h_ent w (propIntersection_subset_propExtension hx_mem hw)
+  · exact Or.inr λ w hw hφ =>
+      h_exc ⟨w, propIntersection_subset_propExtension hx_mem hw, hφ⟩
 
-/-- Two worlds are co-located in a partition if some cell contains both. -/
-private def CoLocated (partition : List (List W)) (w v : W) : Prop :=
-  ∃ cell ∈ partition, w ∈ cell ∧ v ∈ cell
+/-- Settling is monotone: more propositions in K means more is settled. -/
+theorem settling_monotone (k : Kernel W) (p : (W → Prop)) (φ : (W → Prop))
+    (hSettled : directlySettlesExplicit k φ) :
+    directlySettlesExplicit ⟨p :: k.props⟩ φ := by
+  obtain ⟨x, hx_mem, hx⟩ := hSettled
+  exact ⟨x, List.mem_cons_of_mem _ hx_mem, hx⟩
 
-/-- Refining preserves co-location for worlds that agree on the proposition.
-    Both go to the pos cell when `p w` (so `p v`); both go to the neg cell
-    when `¬ p w`. The chosen cell is non-empty (it contains `w`), so it
-    survives the filter on cell length. -/
-private theorem refine_preserves_colocated
-    (partition : List (List W)) (p : (W → Prop))
-    {w v : W} (h : CoLocated partition w v) (h_agree : p w ↔ p v) :
-    CoLocated (refine partition p) w v := by
-  classical
-  obtain ⟨cell, h_cell, hw, hv⟩ := h
-  by_cases hpw : p w
-  · -- Both worlds satisfy p; both go to the pos cell.
-    have hpv : p v := h_agree.mp hpw
-    have hwPos : w ∈ cell.filter (fun x => decide (p x)) := by
-      rw [List.mem_filter]; exact ⟨hw, by simp [hpw]⟩
-    have hvPos : v ∈ cell.filter (fun x => decide (p x)) := by
-      rw [List.mem_filter]; exact ⟨hv, by simp [hpv]⟩
-    refine ⟨cell.filter (fun x => decide (p x)), ?_, hwPos, hvPos⟩
-    show cell.filter (fun x => decide (p x)) ∈ refine partition p
-    unfold refine
-    rw [List.mem_flatMap]
-    refine ⟨cell, h_cell, ?_⟩
-    rw [List.mem_filter]
-    refine ⟨List.mem_cons_self, ?_⟩
-    exact decide_eq_true (List.length_pos_of_mem hwPos)
-  · -- Both worlds fail p; both go to the neg cell.
-    have hpv : ¬ p v := fun h => hpw (h_agree.mpr h)
-    have hwNeg : w ∈ cell.filter (fun x => ¬ decide (p x)) := by
-      rw [List.mem_filter]; refine ⟨hw, ?_⟩; simp [hpw]
-    have hvNeg : v ∈ cell.filter (fun x => ¬ decide (p x)) := by
-      rw [List.mem_filter]; refine ⟨hv, ?_⟩; simp [hpv]
-    refine ⟨cell.filter (fun x => ¬ decide (p x)), ?_, hwNeg, hvNeg⟩
-    show cell.filter (fun x => ¬ decide (p x)) ∈ refine partition p
-    unfold refine
-    rw [List.mem_flatMap]
-    refine ⟨cell, h_cell, ?_⟩
-    rw [List.mem_filter]
-    refine ⟨List.mem_cons_of_mem _ List.mem_cons_self, ?_⟩
-    exact decide_eq_true (List.length_pos_of_mem hwNeg)
-
-/-- Folding refine over a list of propositions preserves co-location for
-    worlds that agree on all propositions in the list. -/
-private theorem foldl_refine_preserves_colocated
-    (props : List ((W → Prop))) (partition : List (List W))
-    {w v : W} (h : CoLocated partition w v)
-    (h_agree : ∀ p ∈ props, (p w ↔ p v)) :
-    CoLocated (props.foldl refine partition) w v := by
-  induction props generalizing partition with
-  | nil => exact h
-  | cons p ps ih =>
-    simp only [List.foldl_cons]
-    exact ih (refine partition p)
-      (refine_preserves_colocated partition p h (h_agree p (.head _)))
-      (λ q hq => h_agree q (.tail _ hq))
-
-/-- Co-located worlds in a settled partition have the same φ-value. -/
-private theorem colocated_same_phi
-    (partition : List (List W)) (φ : (W → Prop))
-    (h_settled : ∀ cell ∈ partition,
-      (∀ w ∈ cell, φ w) ∨ (∀ w ∈ cell, ¬ φ w))
-    {w v : W} (h_coloc : CoLocated partition w v) :
-    (φ w ↔ φ v) := by
-  obtain ⟨cell, h_cell, hw, hv⟩ := h_coloc
-  cases h_settled cell h_cell with
-  | inl h_all_phi => exact ⟨fun _ => h_all_phi v hv, fun _ => h_all_phi w hw⟩
-  | inr h_all_neg => exact ⟨fun hφ => absurd hφ (h_all_neg w hw),
-                            fun hφ => absurd hφ (h_all_neg v hv)⟩
-
-/-- Each cell of `refine partition p` is uniform on `p`: any two worlds in the
-    same refined cell agree on `p`. -/
-private theorem refine_cell_uniform_p
-    (partition : List (List W)) (p : (W → Prop))
-    {cell : List W} (h_cell : cell ∈ refine partition p)
-    {w v : W} (hw : w ∈ cell) (hv : v ∈ cell) :
-    (p w ↔ p v) := by
-  classical
-  unfold refine at h_cell
-  rw [List.mem_flatMap] at h_cell
-  obtain ⟨orig, _, h_in⟩ := h_cell
-  rw [List.mem_filter] at h_in
-  obtain ⟨h_in_cons, _⟩ := h_in
-  rcases List.mem_cons.mp h_in_cons with rfl | h_in_tail
-  · -- cell = orig.filter (fun x => decide (p x)): both worlds satisfy p.
-    rw [List.mem_filter] at hw hv
-    have hpw : p w := of_decide_eq_true hw.2
-    have hpv : p v := of_decide_eq_true hv.2
-    exact ⟨fun _ => hpv, fun _ => hpw⟩
-  · rcases List.mem_singleton.mp h_in_tail with rfl
-    -- cell = orig.filter (fun x => ¬ decide (p x)): both worlds fail p.
-    rw [List.mem_filter] at hw hv
-    have hNpw : ¬ p w := by
-      intro hp
-      have hb : decide (p w) = true := decide_eq_true hp
-      have hf : decide (¬ decide (p w) = true) = true := hw.2
-      simp [hb] at hf
-    have hNpv : ¬ p v := by
-      intro hp
-      have hb : decide (p v) = true := decide_eq_true hp
-      have hf : decide (¬ decide (p v) = true) = true := hv.2
-      simp [hb] at hf
-    exact ⟨fun h => absurd h hNpw, fun h => absurd h hNpv⟩
-
-/-- Each cell of `refine partition p` is contained in some cell of `partition`. -/
-private theorem refine_cell_subset_orig
-    (partition : List (List W)) (p : (W → Prop))
-    {cell : List W} (h_cell : cell ∈ refine partition p) :
-    ∃ orig ∈ partition, ∀ w, w ∈ cell → w ∈ orig := by
-  classical
-  unfold refine at h_cell
-  rw [List.mem_flatMap] at h_cell
-  obtain ⟨orig, h_orig, h_in⟩ := h_cell
-  rw [List.mem_filter] at h_in
-  obtain ⟨h_in_cons, _⟩ := h_in
-  refine ⟨orig, h_orig, ?_⟩
-  intro w hw
-  rcases List.mem_cons.mp h_in_cons with rfl | h_in_tail
-  · rw [List.mem_filter] at hw; exact hw.1
-  · rcases List.mem_singleton.mp h_in_tail with rfl
-    rw [List.mem_filter] at hw; exact hw.1
-
-/-- Refining preserves cell uniformity for previously-refined props. -/
-private theorem refine_preserves_uniformity
-    (partition : List (List W)) (p q : (W → Prop))
-    (h : ∀ cell ∈ partition, ∀ w v, w ∈ cell → v ∈ cell → (q w ↔ q v))
-    {cell : List W} (h_cell : cell ∈ refine partition p)
-    {w v : W} (hw : w ∈ cell) (hv : v ∈ cell) :
-    (q w ↔ q v) := by
-  obtain ⟨orig, h_orig, h_sub⟩ := refine_cell_subset_orig partition p h_cell
-  exact h orig h_orig w v (h_sub w hw) (h_sub v hv)
-
-/-- Auxiliary: after folding `refine` over `props`, cells are uniform on every
-    proposition in `acc_props ++ props`, given the initial partition is uniform
-    on every prop in `acc_props`. The accumulator threads through the induction. -/
-private theorem foldl_refine_uniform_aux
-    (props : List ((W → Prop))) (partition : List (List W))
-    (acc_props : List ((W → Prop)))
-    (h_acc : ∀ q ∈ acc_props, ∀ cell ∈ partition,
-      ∀ w v, w ∈ cell → v ∈ cell → (q w ↔ q v)) :
-    ∀ q ∈ acc_props ++ props, ∀ cell ∈ props.foldl refine partition,
-      ∀ w v, w ∈ cell → v ∈ cell → (q w ↔ q v) := by
-  induction props generalizing partition acc_props with
-  | nil =>
-    intro q hq cell hcell w v hw hv
-    rw [List.append_nil] at hq
-    exact h_acc q hq cell hcell w v hw hv
-  | cons p ps ih =>
-    intro q hq cell hcell w v hw hv
-    rw [List.foldl_cons] at hcell
-    have h_acc' : ∀ q' ∈ acc_props ++ [p], ∀ cell' ∈ refine partition p,
-        ∀ w' v', w' ∈ cell' → v' ∈ cell' → (q' w' ↔ q' v') := by
-      intro q' hq'
-      rcases List.mem_append.mp hq' with hq'_acc | hq'_p
-      · intro cell' hcell' w' v' hw' hv'
-        exact refine_preserves_uniformity partition p q' (h_acc q' hq'_acc)
-          hcell' hw' hv'
-      · rcases List.mem_singleton.mp hq'_p with rfl
-        intro cell' hcell' w' v' hw' hv'
-        -- `rcases ... with rfl` substituted `p` away (both `p`, `q'` were free
-        -- locals; subst kept the more-recently introduced `q'`).
-        exact refine_cell_uniform_p partition q' hcell' hw' hv'
-    have hq' : q ∈ (acc_props ++ [p]) ++ ps := by
-      rw [List.append_assoc, List.singleton_append]; exact hq
-    exact ih (refine partition p) (acc_props ++ [p]) h_acc' q hq' cell hcell w v hw hv
-
-/-- After folding `refine` over a list of propositions, every cell is uniform
-    on each proposition in the list. -/
-private theorem foldl_refine_cell_uniform [Fintype W]
-    (props : List ((W → Prop)))
-    {cell : List W} (h_cell : cell ∈ props.foldl refine [Finset.univ.toList])
-    {w v : W} (hw : w ∈ cell) (hv : v ∈ cell)
-    {q : (W → Prop)} (hq : q ∈ props) :
-    (q w ↔ q v) := by
-  have := foldl_refine_uniform_aux props [Finset.univ.toList] []
-    (fun _ hq_acc => absurd hq_acc (List.not_mem_nil))
-  exact this q (by rw [List.nil_append]; exact hq) cell h_cell w v hw hv
-
-/-- Cells of `kernelPartition k` are uniform on every proposition in `k.props`. -/
-private theorem kernelPartition_cells_uniform [Fintype W] (k : Kernel W)
-    {cell : List W} (h_cell : cell ∈ kernelPartition k)
-    {w v : W} (hw : w ∈ cell) (hv : v ∈ cell)
-    {q : (W → Prop)} (hq : q ∈ k.props) :
-    (q w ↔ q v) :=
-  foldl_refine_cell_uniform k.props h_cell hw hv hq
-
-/-- compatible iff B_K ∩ ⟦φ⟧ ≠ ∅. -/
-private theorem compatibleWith_iff_exists (k : Kernel W) (φ : (W → Prop)) :
-    k.compatibleWith φ ↔ ∃ w ∈ k.base, φ w := by
-  show isCompatibleWith φ k.props ↔ _
-  unfold isCompatibleWith Kratzer.isConsistent Kernel.base
-  constructor
-  · rintro ⟨w, hw⟩
-    have hφ : φ w := hw φ List.mem_cons_self
-    have hRest : w ∈ propIntersection k.props := by
-      intro q hq
-      exact hw q (List.mem_cons_of_mem _ hq)
-    exact ⟨w, hRest, hφ⟩
-  · rintro ⟨w, hwK, hwφ⟩
-    refine ⟨w, ?_⟩
-    intro q hq
-    rcases List.mem_cons.mp hq with rfl | hq'
-    · exact hwφ
-    · exact hwK q hq'
-
-/-- followsFrom iff B_K ⊆ ⟦φ⟧. -/
-private theorem followsFrom_iff_forall (k : Kernel W) (φ : (W → Prop)) :
-    k.followsFrom φ ↔ ∀ w ∈ k.base, φ w := by
-  show Kratzer.followsFrom φ k.props ↔ _
-  unfold Kratzer.followsFrom Kernel.base propExtension
-  rfl
-
-/-- Partition settling implies entailment: if S_K settles φ then
-    B_K ⊆ ⟦φ⟧ or B_K ⊆ ⟦¬φ⟧. All worlds in B_K agree on every X ∈ K
-    (they all satisfy every X), so they occupy a single cell of S_K.
-    If that cell is φ-uniform, B_K inherits the uniformity. -/
-theorem partition_implies_entailment [Fintype W] (k : Kernel W) (φ : (W → Prop))
-    (h : settlesByPartition k φ) :
-    k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
-  -- If B_K is empty, both sides are vacuously true.
-  by_cases hEmpty : k.base = ∅
-  · left
-    rw [followsFrom_iff_forall]
-    intro w hw
-    rw [hEmpty] at hw
-    exact absurd hw (Set.notMem_empty w)
-  -- Otherwise pick w₀ ∈ B_K and show all other worlds in B_K agree on φ.
-  have hNonempty : k.base.Nonempty := Set.nonempty_iff_ne_empty.mpr hEmpty
-  obtain ⟨w₀, hw₀⟩ := hNonempty
-  -- Both w₀ and any v ∈ B_K satisfy every X ∈ k.props.
-  have hAgree : ∀ v ∈ k.base, ∀ p ∈ k.props, (p w₀ ↔ p v) := by
-    intro v hv p hp
-    -- propIntersection: every X ∈ k.props is true at every world in k.base
-    simp only [Kernel.base, propIntersection, Set.mem_setOf_eq] at hw₀ hv
-    exact ⟨fun _ => hv p hp, fun _ => hw₀ p hp⟩
-  -- All worlds in B_K are co-located with w₀ in the partition.
-  have hColoc : ∀ v ∈ k.base, CoLocated (kernelPartition k) w₀ v := by
-    intro v hv
-    apply foldl_refine_preserves_colocated
-    · -- Initially co-located in [Finset.univ.toList]
-      refine ⟨Finset.univ.toList, List.mem_singleton.mpr rfl, ?_, ?_⟩
-      · exact Finset.mem_toList.mpr (Finset.mem_univ w₀)
-      · exact Finset.mem_toList.mpr (Finset.mem_univ v)
-    · exact hAgree v hv
-  -- Every w in k.base shares its φ value with w₀.
-  have hSame : ∀ v ∈ k.base, (φ w₀ ↔ φ v) := fun v hv =>
-    colocated_same_phi (kernelPartition k) φ h (hColoc v hv)
-  -- Case-split on φ w₀.
-  by_cases hφ : φ w₀
-  · left
-    rw [followsFrom_iff_forall]
-    intro v hv
-    exact (hSame v hv).mp hφ
-  · right
-    rw [followsFrom_iff_forall]
-    intro v hv hφv
-    exact hφ ((hSame v hv).mpr hφv)
-
-/-! ## Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
+/-! ### Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
 /-- ⟦must φ⟧: presupposes K doesn't settle φ; asserts B_K ⊆ ⟦φ⟧. -/
 def kernelMust (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
@@ -421,51 +129,20 @@ def kernelMight (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
 def kernelCant (k : Kernel W) (φ : (W → Prop)) : PartialProp W :=
   kernelMust k (λ w => ¬ φ w)
 
-/-- W-dependent ⟦must φ⟧. -/
-def kernelMustW (kb : KernelBackground W) (φ : (W → Prop)) : PartialProp W where
-  presup := λ w => ¬ directlySettlesExplicit (kb w) φ
-  assertion := λ w => (kb w).followsFrom φ
-
-/-- W-dependent ⟦might φ⟧. -/
-def kernelMightW (kb : KernelBackground W) (φ : (W → Prop)) : PartialProp W where
-  presup := λ w => ¬ directlySettlesExplicit (kb w) φ
-  assertion := λ w => (kb w).compatibleWith φ
-
-/-! ## Core properties -/
-
-/-- Must is strong: when defined, must φ ↔ universal necessity over B_K. -/
-theorem must_is_strong (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (_hDef : (kernelMust k φ).presup w) :
-    (kernelMust k φ).assertion w ↔
-      simpleNecessity k.toModalBase φ w := by
-  show k.followsFrom φ ↔ _
-  simp only [Kernel.followsFrom, Kratzer.followsFrom,
-             simpleNecessity_iff_all, accessibleWorlds, Kernel.toModalBase]
-  rfl
+/-! ### Core properties -/
 
 /-- T axiom: must φ entails φ when B_K is realistic (w ∈ B_K). -/
 theorem must_entails_prejacent (k : Kernel W) (φ : (W → Prop)) (w : W)
     (hReal : w ∈ k.base)
     (_hDef : (kernelMust k φ).presup w)
     (hTrue : (kernelMust k φ).assertion w) :
-    φ w := by
-  have h : k.followsFrom φ := hTrue
-  simp only [Kernel.followsFrom, Kratzer.followsFrom] at h
-  exact h hReal
+    φ w :=
+  hTrue hReal
 
 /-- Duality: might φ ↔ ¬(must ¬φ) in assertion content. -/
 theorem kernel_duality (k : Kernel W) (φ : (W → Prop)) (w : W) :
-    (kernelMight k φ).assertion w ↔ ¬(kernelMust k (λ w' => ¬ φ w')).assertion w := by
-  show k.compatibleWith φ ↔ ¬ k.followsFrom (λ w' => ¬ φ w')
-  rw [compatibleWith_iff_exists, followsFrom_iff_forall]
-  constructor
-  · rintro ⟨w', hw', hφ⟩ hAll
-    exact (hAll w' hw') hφ
-  · intro hNotAll
-    by_contra hNoEx
-    apply hNotAll
-    intro w' hw' hφ
-    exact hNoEx ⟨w', hw', hφ⟩
+    (kernelMight k φ).assertion w ↔ ¬(kernelMust k (λ w' => ¬ φ w')).assertion w :=
+  isCompatibleWith_iff_not_followsFrom_not
 
 /-- Empty kernel: nothing is settled, so must is always defined. -/
 theorem empty_kernel_always_defined (φ : (W → Prop)) (w : W) :
@@ -473,7 +150,13 @@ theorem empty_kernel_always_defined (φ : (W → Prop)) (w : W) :
   show ¬ directlySettlesExplicit _ _
   simp [directlySettlesExplicit]
 
-/-! ## Bridge to Kratzer.lean -/
+/-- Direct evidence infelicity: when K settles φ, must φ is undefined. -/
+theorem direct_evidence_infelicity (k : Kernel W) (φ : (W → Prop)) (w : W)
+    (hSettled : directlySettlesExplicit k φ) :
+    ¬(kernelMust k φ).presup w := by
+  intro h; exact h hSettled
+
+/-! ### Bridge to Kratzer necessity -/
 
 /-- Kernel must assertion ↔ Kratzer simple necessity. -/
 theorem kernelMust_eq_simpleNecessity (k : Kernel W) (φ : (W → Prop)) (w : W) :
@@ -490,591 +173,5 @@ theorem kernelMust_eq_necessity (k : Kernel W) (φ : (W → Prop)) (w : W) :
       necessity k.toModalBase emptyBackground φ w := by
   rw [kernelMust_eq_simpleNecessity]
   exact (necessity_empty_iff_simple k.toModalBase _ w).symm
-
-/-- Kernel must assertion ↔ Kratzer necessity evaluated via `EpistemicFlavor`.
-
-    This bridges the kernel ([von-fintel-gillies-2010]) to Kratzer's parametric semantics:
-    kernel must is exactly Kratzer necessity with the kernel's epistemic flavor. -/
-theorem kernelMust_eq_epistemicNecessity (k : Kernel W) (φ : (W → Prop)) (w : W) :
-    (kernelMust k φ).assertion w ↔
-    necessity k.toEpistemicFlavor.evidence k.toEpistemicFlavor.ordering φ w :=
-  kernelMust_eq_necessity k φ w
-
-/-- W-dependent kernel must ↔ world-dependent Kratzer necessity. -/
-theorem kernelMustW_eq_necessity (kb : KernelBackground W) (φ : (W → Prop)) (w : W) :
-    (kernelMustW kb φ).assertion w ↔
-      necessity kb.toModalBase emptyBackground φ w :=
-  kernelMust_eq_necessity (kb w) φ w
-
-/-! ## Mastermind example ([von-fintel-gillies-2010] pp. 365–366)
-
-w0 = red, w1 = blue, w2 = green, w3 = unknown.
-K = {redOrBlue, notRed}, B_K = {w1}.
-
-The example uses a local 4-element `World` to keep the propositional layout
-readable; the abstract theory above is generic over any `W : Type*`. -/
-
-/-- 4-world type used by the Mastermind and Raincoat examples. Public so
-    consumers can refer to the same toy type when reusing these examples
-    (e.g., the Zheng 2025 study file consumes `raincoatK`). -/
-inductive World where
-  | w0 | w1 | w2 | w3
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype World where
-  elems := {.w0, .w1, .w2, .w3}
-  complete := λ w => by cases w <;> decide
-
-private def redOrBlue : (World → Prop) :=
-  λ w => match w with | .w0 => True | .w1 => True | _ => False
-private def notRed : (World → Prop) :=
-  λ w => match w with | .w0 => False | _ => True
-private def blue : (World → Prop) :=
-  λ w => match w with | .w1 => True | _ => False
-private def red : (World → Prop) :=
-  λ w => match w with | .w0 => True | _ => False
-private def notBlue : (World → Prop) :=
-  λ w => match w with | .w1 => False | _ => True
-
-private instance : DecidablePred redOrBlue := fun w => by cases w <;> unfold redOrBlue <;> infer_instance
-private instance : DecidablePred notRed := fun w => by cases w <;> unfold notRed <;> infer_instance
-private instance : DecidablePred blue := fun w => by cases w <;> unfold blue <;> infer_instance
-private instance : DecidablePred red := fun w => by cases w <;> unfold red <;> infer_instance
-private instance : DecidablePred notBlue := fun w => by cases w <;> unfold notBlue <;> infer_instance
-
-private def mastermindK : Kernel World := ⟨[redOrBlue, notRed]⟩
-private def indirectK : Kernel World := ⟨[redOrBlue]⟩
-
-theorem mastermind_base : mastermindK.base = ({.w1} : Set World) := by
-  ext w
-  cases w <;>
-    simp [Kernel.base, mastermindK, propIntersection, redOrBlue, notRed]
-
-theorem mastermind_blue_unsettled :
-    ¬ directlySettlesExplicit mastermindK blue := by
-  rintro ⟨x, hx, hxor⟩
-  rcases List.mem_cons.mp hx with rfl | hx'
-  · -- x = redOrBlue: need to refute both disjuncts.
-    cases hxor with
-    | inl h_ent =>
-      -- redOrBlue at w0 is True but blue w0 is False
-      have h0 : .w0 ∈ propExtension redOrBlue := show redOrBlue .w0 from by decide
-      have hblue : blue .w0 := h_ent .w0 h0
-      exact (by decide : ¬ blue .w0) hblue
-    | inr h_exc =>
-      -- ∃ w in propExtension redOrBlue with blue w (w1)
-      exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
-  · rcases List.mem_singleton.mp hx' with rfl
-    cases hxor with
-    | inl h_ent =>
-      have h2 : .w2 ∈ propExtension notRed := show notRed .w2 from by decide
-      have hblue : blue .w2 := h_ent .w2 h2
-      exact (by decide : ¬ blue .w2) hblue
-    | inr h_exc =>
-      exact h_exc ⟨.w1, show notRed .w1 from by decide, by decide⟩
-
-theorem mastermind_blue_follows :
-    mastermindK.followsFrom blue := by
-  rw [followsFrom_iff_forall]
-  intro w hw
-  rw [mastermind_base] at hw
-  rw [Set.mem_singleton_iff] at hw
-  subst hw
-  decide
-
-theorem mastermind_must_blue_defined :
-    (kernelMust mastermindK blue).presup .w0 :=
-  mastermind_blue_unsettled
-
-theorem mastermind_must_blue_true :
-    (kernelMust mastermindK blue).assertion .w0 :=
-  mastermind_blue_follows
-
-theorem mastermind_red_settled :
-    directlySettlesExplicit mastermindK red := by
-  -- notRed ∈ K, and notRed excludes red (no world is both notRed and red)
-  refine ⟨notRed, by simp [mastermindK], Or.inr ?_⟩
-  rintro ⟨w, hnr, hr⟩
-  simp only [propExtension, Set.mem_setOf_eq] at hnr
-  cases w <;> simp [notRed, red] at hnr hr
-
-theorem mastermind_might_red_undefined :
-    ¬(kernelMight mastermindK red).presup .w0 := by
-  show ¬¬ directlySettlesExplicit _ _
-  exact fun h => h mastermind_red_settled
-
-theorem mastermind_redOrBlue_settled :
-    directlySettlesExplicit mastermindK redOrBlue := by
-  -- redOrBlue ∈ K, and redOrBlue ⊆ redOrBlue
-  refine ⟨redOrBlue, by simp [mastermindK], Or.inl ?_⟩
-  intro w hw
-  exact hw
-
-/-! ## Non-equivalence of the two implementations ([von-fintel-gillies-2010] §7, p. 379)
-
-The explicit and partition-based implementations of "directly settles" are
-non-equivalent. Implementation 1 settles supersets of K-propositions that
-Implementation 2 misses; Implementation 2 settles propositions determined
-jointly by K-propositions that no single proposition settles. Both, however,
-imply entailment (see `explicit_implies_entailment` and
-`partition_implies_entailment` above). -/
-
-/-- Counterexample (Impl 1 ↛ Impl 2): K = {red}, φ = redOrBlue.
-    red ⊆ redOrBlue so Impl 1 settles, but S_K = {{w0},{w1,w2,w3}}
-    and the cell {w1,w2,w3} straddles redOrBlue. We refute
-    `settlesByPartition` by showing .w1 and .w2 are co-located in S_K
-    (they agree on red — both are not-red — so co-location is preserved
-    by `foldl_refine_preserves_colocated`) yet disagree on redOrBlue. -/
-theorem explicit_not_implies_partition :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
-      directlySettlesExplicit k φ ∧ ¬ settlesByPartition k φ := by
-  refine ⟨⟨[red]⟩, redOrBlue, ?_, ?_⟩
-  · -- red ⊆ redOrBlue
-    refine ⟨red, by simp, Or.inl ?_⟩
-    intro w hw
-    simp only [propExtension, Set.mem_setOf_eq] at hw
-    cases w <;> simp [red, redOrBlue] at hw ⊢
-  · -- ¬ settlesByPartition: .w1 and .w2 are co-located but disagree on redOrBlue.
-    intro hSettled
-    have hColoc : CoLocated (kernelPartition ⟨[red]⟩) .w1 .w2 := by
-      apply foldl_refine_preserves_colocated
-      · refine ⟨Finset.univ.toList, List.mem_singleton.mpr rfl, ?_, ?_⟩
-        · exact Finset.mem_toList.mpr (Finset.mem_univ (.w1 : World))
-        · exact Finset.mem_toList.mpr (Finset.mem_univ (.w2 : World))
-      · intro p hp
-        rcases List.mem_singleton.mp hp with rfl
-        exact ⟨fun h => h, fun h => h⟩
-    have hAgree : (redOrBlue .w1 ↔ redOrBlue .w2) :=
-      colocated_same_phi _ _ hSettled hColoc
-    exact (by decide : ¬ redOrBlue .w2) (hAgree.mp (by decide : redOrBlue .w1))
-
-/-- Counterexample (Impl 2 ↛ Impl 1): K = mastermindK, φ = blue.
-    No single X ∈ K entails or excludes blue, but S_K = {{w0},{w1},{w2,w3}}
-    resolves blue into a union of cells. Each cell is `{redOrBlue, notRed}`-
-    uniform (by `kernelPartition_cells_uniform`); since
-    `blue w ↔ redOrBlue w ∧ notRed w` for every world, cells are blue-uniform. -/
-theorem partition_not_implies_explicit :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
-      settlesByPartition k φ ∧ ¬ directlySettlesExplicit k φ := by
-  refine ⟨mastermindK, blue, ?_, mastermind_blue_unsettled⟩
-  -- settlesByPartition: each cell is uniform on blue
-  intro cell hCell
-  -- Pick a witness world; if cell is empty, vacuously all-blue.
-  by_cases hEmpty : cell = []
-  · subst hEmpty; left; intro w hw; exact absurd hw List.not_mem_nil
-  · obtain ⟨w0, hw0⟩ := List.exists_mem_of_ne_nil cell hEmpty
-    -- Worlds in cell agree with w0 on redOrBlue and on notRed.
-    have hAgreeRoB : ∀ v ∈ cell, (redOrBlue w0 ↔ redOrBlue v) := fun v hv =>
-      kernelPartition_cells_uniform mastermindK hCell hw0 hv
-        (by simp [mastermindK])
-    have hAgreeNR : ∀ v ∈ cell, (notRed w0 ↔ notRed v) := fun v hv =>
-      kernelPartition_cells_uniform mastermindK hCell hw0 hv
-        (by simp [mastermindK])
-    -- blue w ↔ redOrBlue w ∧ notRed w (by case analysis on w).
-    have blue_iff : ∀ w : World, blue w ↔ (redOrBlue w ∧ notRed w) := by
-      intro w; cases w <;>
-        simp [blue, redOrBlue, notRed]
-    by_cases hb : blue w0
-    · left
-      intro v hv
-      have hbw0 : redOrBlue w0 ∧ notRed w0 := (blue_iff w0).mp hb
-      have hbv : redOrBlue v ∧ notRed v :=
-        ⟨(hAgreeRoB v hv).mp hbw0.1, (hAgreeNR v hv).mp hbw0.2⟩
-      exact (blue_iff v).mpr hbv
-    · right
-      intro v hv hbv
-      apply hb
-      have hbv' : redOrBlue v ∧ notRed v := (blue_iff v).mp hbv
-      have : redOrBlue w0 ∧ notRed w0 :=
-        ⟨(hAgreeRoB v hv).mpr hbv'.1, (hAgreeNR v hv).mpr hbv'.2⟩
-      exact (blue_iff w0).mpr this
-
-/-- Entailment does not imply partition settling: B_K ⊆ ⟦φ⟧ does not
-    guarantee S_K settles φ. Same witness as explicit_not_implies_partition:
-    K = {red} entails redOrBlue (B_K = {w0} ⊆ ⟦redOrBlue⟧) but the partition
-    cell {w1,w2,w3} straddles redOrBlue.
-
-    TODO: partition-side proof deferred. -/
-theorem entailment_not_implies_partition :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
-      k.followsFrom φ ∧ ¬ settlesByPartition k φ := by
-  refine ⟨⟨[red]⟩, redOrBlue, ?_, ?_⟩
-  · -- B_K = ⟦red⟧ ⊆ ⟦redOrBlue⟧
-    rw [followsFrom_iff_forall]
-    intro w hw
-    have : red w := by
-      have := hw red List.mem_cons_self
-      exact this
-    cases w <;> simp [red, redOrBlue] at this ⊢
-  · intro hSettled
-    have hColoc : CoLocated (kernelPartition ⟨[red]⟩) .w1 .w2 := by
-      apply foldl_refine_preserves_colocated
-      · refine ⟨Finset.univ.toList, List.mem_singleton.mpr rfl, ?_, ?_⟩
-        · exact Finset.mem_toList.mpr (Finset.mem_univ (.w1 : World))
-        · exact Finset.mem_toList.mpr (Finset.mem_univ (.w2 : World))
-      · intro p hp
-        rcases List.mem_singleton.mp hp with rfl
-        exact ⟨fun h => h, fun h => h⟩
-    have hAgree : (redOrBlue .w1 ↔ redOrBlue .w2) :=
-      colocated_same_phi _ _ hSettled hColoc
-    exact (by decide : ¬ redOrBlue .w2) (hAgree.mp (by decide : redOrBlue .w1))
-
-/-! ## Deep theorems ([von-fintel-gillies-2010]) -/
-
-/-- **Entailment-settling gap**: B_K can entail φ without K settling it.
-This gap makes the evidential presupposition non-trivial: must φ can be
-simultaneously defined and true. -/
-theorem entailment_settling_gap :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
-      k.followsFrom φ ∧ ¬ directlySettlesExplicit k φ :=
-  ⟨mastermindK, blue, mastermind_blue_follows, mastermind_blue_unsettled⟩
-
-/-- **Indirectness ≠ weakness**: three independent cases show indirectness
-and assertion strength are orthogonal dimensions. -/
-theorem indirectness_neq_weakness :
-    ((kernelMust mastermindK blue).presup .w0 ∧
-     (kernelMust mastermindK blue).assertion .w0) ∧
-    ¬(kernelMust mastermindK red).presup .w0 ∧
-    ((kernelMust indirectK blue).presup .w0 ∧
-     ¬(kernelMust indirectK blue).assertion .w0) := by
-  refine ⟨⟨mastermind_must_blue_defined, mastermind_must_blue_true⟩, ?_, ?_, ?_⟩
-  · -- ¬¬ directlySettlesExplicit mastermindK red
-    intro h; exact h mastermind_red_settled
-  · -- (kernelMust indirectK blue).presup .w0 = ¬ directlySettlesExplicit indirectK blue
-    -- indirectK = ⟨[redOrBlue]⟩; redOrBlue does not settle blue
-    intro hSettled
-    obtain ⟨x, hx, hx_or⟩ := hSettled
-    rcases List.mem_singleton.mp hx with rfl
-    cases hx_or with
-    | inl h_ent =>
-      -- redOrBlue at w0 is True but blue w0 is False
-      have h0 : .w0 ∈ propExtension redOrBlue := show redOrBlue .w0 from by decide
-      exact absurd (h_ent .w0 h0) (by decide)
-    | inr h_exc =>
-      -- ∃ w in propExtension redOrBlue with blue w (w1)
-      exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
-  · -- ¬ indirectK.followsFrom blue
-    show ¬ (kernelMust indirectK blue).assertion .w0
-    intro h
-    have h' : indirectK.followsFrom blue := h
-    rw [followsFrom_iff_forall] at h'
-    -- B_indirectK = ⟦redOrBlue⟧ = {w0, w1}; w0 is in B_K but blue w0 is False
-    have hw0 : .w0 ∈ indirectK.base := by
-      intro p hp
-      rcases List.mem_singleton.mp hp with rfl
-      decide
-    have : blue .w0 := h' .w0 hw0
-    exact absurd this (by decide)
-
-/-- **Modus ponens with must** ([von-fintel-gillies-2010] Arg 4.3.1): the argument form
-"if φ, must ψ; φ; ∴ ψ" is valid under realistic B_K. -/
-theorem modus_ponens_with_must (k : Kernel W) (φ ψ : (W → Prop)) (w : W)
-    (hReal : w ∈ k.base)
-    (_hDef : (kernelMust k ψ).presup w)
-    (hCond : φ w → (kernelMust k ψ).assertion w)
-    (hPhi : φ w) :
-    ψ w :=
-  must_entails_prejacent k ψ w hReal _hDef (hCond hPhi)
-
-/-- **Must-perhaps contradiction** ([von-fintel-gillies-2010] Arg 4.3.2): must φ ∧ might ¬φ
-is contradictory. When B_K ⊆ ⟦φ⟧, we have B_K ∩ ⟦¬φ⟧ = ∅. -/
-theorem must_perhaps_contradiction (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (_hDef : (kernelMust k φ).presup w)
-    (hMust : (kernelMust k φ).assertion w) :
-    ¬(kernelMight k (λ w' => ¬ φ w')).assertion w := by
-  show ¬ k.compatibleWith (λ w' => ¬ φ w')
-  rw [compatibleWith_iff_exists]
-  rintro ⟨w', hw', hφneg⟩
-  have hMustU : k.followsFrom φ := hMust
-  rw [followsFrom_iff_forall] at hMustU
-  exact hφneg (hMustU w' hw')
-
-/-- Direct evidence infelicity: when K settles φ, must φ is undefined. -/
-theorem direct_evidence_infelicity (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hSettled : directlySettlesExplicit k φ) :
-    ¬(kernelMust k φ).presup w := by
-  intro h; exact h hSettled
-
-/-- Settling is monotone: more propositions in K means more is settled. -/
-theorem settling_monotone (k : Kernel W) (p : (W → Prop)) (φ : (W → Prop))
-    (hSettled : directlySettlesExplicit k φ) :
-    directlySettlesExplicit ⟨p :: k.props⟩ φ := by
-  obtain ⟨x, hx_mem, hx⟩ := hSettled
-  exact ⟨x, List.mem_cons_of_mem _ hx_mem, hx⟩
-
-/-! ## Can't dilemma ([von-fintel-gillies-2021] §4, Observations 4–5)
-
-The Mantra faces a dilemma: no assignment of force to *can't* simultaneously
-explains its evidential distribution (paralleling must) and its incompatibility
-with *it's possible that φ*. Kernel semantics resolves this because
-*can't φ* = *must*(¬φ) is strong AND evidentially constrained. -/
-
-/-- **Can't–might exclusion** ([von-fintel-gillies-2021] Obs 5): when can't φ holds
-(B_K ⊆ ⟦¬φ⟧), might φ is false (B_K ∩ ⟦φ⟧ = ∅). -/
-theorem cant_might_exclusion (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hCant : (kernelCant k φ).assertion w) :
-    ¬(kernelMight k φ).assertion w := by
-  show ¬ k.compatibleWith φ
-  rw [compatibleWith_iff_exists]
-  rintro ⟨w', hw', hφ⟩
-  have hCantU : k.followsFrom (λ w' => ¬ φ w') := hCant
-  rw [followsFrom_iff_forall] at hCantU
-  exact (hCantU w' hw') hφ
-
-/-- **Can't entails negation** ([von-fintel-gillies-2021] via S2): when B_K is realistic
-and can't φ is defined and true, ¬ φ(w). -/
-theorem cant_entails_negation (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hReal : w ∈ k.base)
-    (_hDef : (kernelCant k φ).presup w)
-    (hTrue : (kernelCant k φ).assertion w) :
-    ¬ φ w :=
-  must_entails_prejacent k (λ w' => ¬ φ w') w hReal _hDef hTrue
-
-/-- **Can't evidential parallelism** ([von-fintel-gillies-2021] Obs 4): can't φ has the
-same presupposition structure as must(¬φ). -/
-theorem cant_evidential_parallel (k : Kernel W) (φ : (W → Prop)) (w : W) :
-    (kernelCant k φ).presup w = (kernelMust k (λ w' => ¬ φ w')).presup w := rfl
-
-/-- **Can't dilemma resolved**: a single kernel simultaneously exhibits
-evidentiality, strength, and might-exclusion.
-Witness: K = {redOrBlue, notRed}, φ = notBlue. Then can't(notBlue) =
-must(blue), which is defined (blue unsettled), true (B_K ⊆ ⟦blue⟧),
-and excludes might(notBlue). -/
-theorem cant_dilemma_resolved :
-    .w1 ∈ mastermindK.base ∧
-    (kernelCant mastermindK notBlue).presup .w1 ∧
-    (kernelCant mastermindK notBlue).assertion .w1 ∧
-    ¬(kernelMight mastermindK notBlue).assertion .w1 ∧
-    ¬ notBlue .w1 := by
-  -- can't(notBlue) = must(¬notBlue). At each world, ¬ notBlue is equivalent to
-  -- the (concrete) negation of the `notBlue` predicate. Since can't is
-  -- defined as `kernelMust k (λ w => ¬ φ w)`, we work with that.
-  have hbase : .w1 ∈ mastermindK.base := by
-    rw [mastermind_base]; exact rfl
-  refine ⟨hbase, ?_, ?_, ?_, ?_⟩
-  · -- ¬ directlySettlesExplicit mastermindK (λ w => ¬ notBlue w)
-    intro hSettled
-    obtain ⟨x, hx, hx_or⟩ := hSettled
-    rcases List.mem_cons.mp hx with rfl | hx'
-    · -- redOrBlue
-      cases hx_or with
-      | inl h_ent =>
-        -- redOrBlue w0 is True, but notBlue w0 is True so ¬ notBlue w0 is False
-        have h0 : .w0 ∈ propExtension redOrBlue := show redOrBlue .w0 from by decide
-        exact (h_ent .w0 h0) (by decide : notBlue .w0)
-      | inr h_exc =>
-        -- ∃ w in ⟦redOrBlue⟧ with ¬ notBlue w: take w0 (notBlue w0 = True so ¬ notBlue w0 is False)
-        -- ... actually we need ∃ w with redOrBlue w ∧ ¬ notBlue w. notBlue w0 is True so ¬ notBlue w0 is False.
-        -- notBlue w1 is False so ¬ notBlue w1 is True. redOrBlue w1 is True.
-        exact h_exc ⟨.w1, show redOrBlue .w1 from by decide,
-          fun (h : notBlue .w1) => (by decide : ¬ notBlue .w1) h⟩
-    · rcases List.mem_singleton.mp hx' with rfl
-      cases hx_or with
-      | inl h_ent =>
-        -- notRed w0 is False, notRed w1 is True. notBlue w1 is False so ¬ notBlue w1 is True; the implication is vacuous.
-        -- We need a world where notRed holds AND ¬ notBlue fails (i.e., notBlue holds).
-        -- notBlue w2 = True, notRed w2 = True. So h_ent w2 : ¬ notBlue w2.
-        have h2 : .w2 ∈ propExtension notRed := show notRed .w2 from by decide
-        exact (h_ent .w2 h2) (by decide : notBlue .w2)
-      | inr h_exc =>
-        exact h_exc ⟨.w1, show notRed .w1 from by decide,
-          fun (h : notBlue .w1) => (by decide : ¬ notBlue .w1) h⟩
-  · -- mastermindK.followsFrom (λ w => ¬ notBlue w)
-    show mastermindK.followsFrom (λ w => ¬ notBlue w)
-    rw [followsFrom_iff_forall]
-    intro w hw
-    rw [mastermind_base, Set.mem_singleton_iff] at hw
-    subst hw
-    intro h; exact (by decide : ¬ notBlue .w1) h
-  · -- ¬ mastermindK.compatibleWith notBlue
-    show ¬ mastermindK.compatibleWith notBlue
-    rw [compatibleWith_iff_exists]
-    rintro ⟨w, hw, hnb⟩
-    rw [mastermind_base, Set.mem_singleton_iff] at hw
-    subst hw
-    exact (by decide : ¬ notBlue .w1) hnb
-  · -- ¬ notBlue .w1
-    decide
-
-/-- Direct evidence blocks can't, paralleling must: when K settles ¬φ,
-can't φ has presupposition failure. -/
-theorem cant_direct_evidence_infelicity :
-    ¬(kernelCant mastermindK red).presup .w0 := by
-  show ¬¬ directlySettlesExplicit mastermindK (λ w => ¬ red w)
-  intro h
-  apply h
-  -- notRed ∈ K and notRed entails ¬ red.
-  refine ⟨notRed, by simp [mastermindK], Or.inl ?_⟩
-  intro w hnr hr
-  simp only [propExtension, Set.mem_setOf_eq] at hnr
-  cases w <;> simp [notRed, red] at hnr hr
-
-/-- can't φ and must(¬φ) are intensionally identical. -/
-theorem cant_eq_must_neg (k : Kernel W) (φ : (W → Prop)) (w : W) :
-    (kernelCant k φ).presup w = (kernelMust k (λ w' => ¬ φ w')).presup w ∧
-    (kernelCant k φ).assertion w = (kernelMust k (λ w' => ¬ φ w')).assertion w :=
-  ⟨rfl, rfl⟩
-
-/-! ## Prior information state and nandao-Q felicity
-
-[zheng-2025] shows Mandarin *nandao*-Qs are evidence-driven, not bias-driven.
-The felicity condition has three parts: (i) evidence in K supports the prejacent,
-(ii) K conflicts with prior expectations U, (iii) the prejacent is not directly
-settled in K. Condition (iii) is the same presupposition as `kernelMust`. -/
-
-/-- Prior information state (beliefs, norms, desires) before encountering
-evidence. Distinct from the kernel (direct evidence) and the CommonGround (shared). -/
-abbrev Background (W : Type*) := List ((W → Prop))
-
-/-- B_U = ⋂U: worlds compatible with the prior information state. -/
-def backgroundBase (u : Background W) : Set W :=
-  propIntersection u
-
-/-- K and U are incompatible: B_K ∩ B_U = ∅ (the evidence is unexpected). -/
-def Kernel.incompatibleWith (k : Kernel W) (u : Background W) : Prop :=
-  ¬ Kratzer.isConsistent (k.props ++ u)
-
-/-- Evidence p raises the probability of φ: P(φ|p) > P(φ).
-Computed via cross-multiplication to avoid rationals.
-
-The cardinalities are taken over `Finset.univ` filtered by the
-respective predicates, which requires `[DecidablePred p]` and
-`[DecidablePred φ]`. -/
-def evidenceRaises [Fintype W] (p φ : (W → Prop))
-    [DecidablePred p] [DecidablePred φ] : Prop :=
-  let pCount := ((Finset.univ : Finset W).filter p).card
-  let phiInP := ((Finset.univ : Finset W).filter (fun w => p w ∧ φ w)).card
-  let phiInAll := ((Finset.univ : Finset W).filter φ).card
-  phiInP * (Finset.univ : Finset W).card > phiInAll * pCount
-
-/-- Some proposition in K raises the probability of φ (condition i).
-
-    Requires global decidability for kernel propositions; we use
-    `Classical.propDecidable` since `k.props` is a list of arbitrary
-    `W → Prop`. -/
-def Kernel.evidenceSupports [Fintype W] (k : Kernel W) (φ : (W → Prop))
-    [DecidablePred φ] : Prop :=
-  haveI : ∀ p : W → Prop, DecidablePred p :=
-    fun p w => Classical.propDecidable (p w)
-  ∃ x ∈ k.props, evidenceRaises x φ
-
-/-- **Nandao-Q felicity** ([zheng-2025], condition 11 for polar questions):
-(i) some evidence in K raises P(φ),
-(ii) K and U are incompatible (evidence is unexpected),
-(iii) φ is not directly settled in K. -/
-def nandaoFelicitous [Fintype W] (k : Kernel W) (u : Background W) (φ : (W → Prop))
-    [DecidablePred φ] : Prop :=
-  k.evidenceSupports φ ∧ k.incompatibleWith u ∧ ¬ directlySettlesExplicit k φ
-
-/-- Nandao condition (iii) = presupposition of `kernelMust`. -/
-theorem nandao_must_presupposition (k : Kernel W) (φ : (W → Prop)) (w : W) :
-    ¬ directlySettlesExplicit k φ ↔ (kernelMust k φ).presup w := Iff.rfl
-
-/-- Pure inquiry: nandao is felicitous without epistemic bias ([zheng-2025] ex. 3).
-The three conditions suffice; no prior belief about φ is required. -/
-theorem nandao_pure_inquiry [Fintype W] (k : Kernel W) (u : Background W) (φ : (W → Prop))
-    [DecidablePred φ]
-    (hEv : k.evidenceSupports φ)
-    (hInc : k.incompatibleWith u)
-    (hUns : ¬ directlySettlesExplicit k φ) :
-    nandaoFelicitous k u φ :=
-  ⟨hEv, hInc, hUns⟩
-
-/-! ### Dripping raincoat scenario ([zheng-2025] exx. 2–3, 5)
-
-w0 = raining, w1 = sprinkler (wet but not rain), w2 = dry, w3 = unknown.
-K = {wearingRaincoat}: direct evidence that someone entered with a wet coat.
-U = {expectDry}: prior expectation of no rain (normative or doxastic). -/
-
-def wearingRaincoat : (World → Prop) :=
-  λ w => match w with | .w0 => True | .w1 => True | _ => False
-def expectDry : (World → Prop) :=
-  λ w => match w with | .w2 => True | .w3 => True | _ => False
-def isRaining : (World → Prop) :=
-  λ w => match w with | .w0 => True | _ => False
-
-instance : DecidablePred wearingRaincoat := fun w => by
-  cases w <;> unfold wearingRaincoat <;> infer_instance
-instance : DecidablePred expectDry := fun w => by
-  cases w <;> unfold expectDry <;> infer_instance
-instance : DecidablePred isRaining := fun w => by
-  cases w <;> unfold isRaining <;> infer_instance
-
-def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
-def dryU : Background World := [expectDry]
-
-/-- "Nandao waimian xiayu-le ma?" is felicitous with a dripping raincoat.
-P(rain|coat) = 1/2 > P(rain) = 1/4; K ∩ U = ∅; rain unsettled by K.
-
-    TODO: full proof requires unfolding `evidenceSupports` (which uses
-    `Classical.propDecidable`) into a concrete computation. The proposition
-    holds — wearingRaincoat raises the probability of isRaining (1/2 vs 1/4) —
-    but threading the decidability instance through `decide` is delicate.
-    Statement preserved. -/
-theorem raincoat_nandao_felicitous :
-    nandaoFelicitous raincoatK dryU isRaining := by
-  refine ⟨?_, ?_, ?_⟩
-  · -- evidenceSupports: wearingRaincoat raises P(isRaining).
-    -- |coat∧rain|=1, |all|=4, |rain|=1, |coat|=2; 1·4 > 1·2 ✓.
-    -- The local `Classical.propDecidable` in `evidenceSupports` differs syntactically
-    -- from the explicit `DecidablePred` instances; `Decidable` is `Subsingleton`,
-    -- so `convert` bridges via instance equality.
-    refine ⟨wearingRaincoat, by simp [raincoatK], ?_⟩
-    have h : evidenceRaises wearingRaincoat isRaining := by
-      unfold evidenceRaises; decide
-    convert h
-  · -- incompatibleWith dryU: ⋂{wearingRaincoat, expectDry} = ∅
-    intro ⟨w, hw⟩
-    have h1 : wearingRaincoat w := hw wearingRaincoat (by simp [raincoatK])
-    have h2 : expectDry w := hw expectDry (by simp [dryU])
-    cases w <;> simp [wearingRaincoat, expectDry] at h1 h2
-  · -- ¬ directlySettlesExplicit raincoatK isRaining
-    intro hSettled
-    obtain ⟨x, hx, hx_or⟩ := hSettled
-    rcases List.mem_singleton.mp (by simpa [raincoatK] using hx) with rfl
-    cases hx_or with
-    | inl h_ent =>
-      -- wearingRaincoat w1 is True, but isRaining w1 is False
-      have h1 : .w1 ∈ propExtension wearingRaincoat :=
-        show wearingRaincoat .w1 from by decide
-      exact (by decide : ¬ isRaining .w1) (h_ent .w1 h1)
-    | inr h_exc =>
-      -- ∃ w with wearingRaincoat w ∧ isRaining w (w0)
-      exact h_exc ⟨.w0, show wearingRaincoat .w0 from by decide, by decide⟩
-
-/-- Without evidence, nandao is infelicitous ([zheng-2025] ex. 5 ctx 2). -/
-theorem no_evidence_nandao_infelicitous :
-    ¬ nandaoFelicitous ⟨[]⟩ dryU isRaining := by
-  rintro ⟨hEv, _, _⟩
-  obtain ⟨x, hx, _⟩ := hEv
-  exact List.not_mem_nil hx
-
-/-- When evidence is expected (K compatible with U), nandao is infelicitous
-([zheng-2025] ex. 6 ctx 2).
-
-    TODO: full proof requires showing the joint kernel + background is
-    consistent for the wearingRaincoat-only K. Statement preserved. -/
-theorem expected_evidence_infelicitous :
-    let expectWet : Background World := [wearingRaincoat]
-    ¬ nandaoFelicitous raincoatK expectWet isRaining := by
-  intro expectWet hFel
-  obtain ⟨_, hInc, _⟩ := hFel
-  -- hInc says ¬ isConsistent (raincoatK.props ++ expectWet)
-  -- but ⋂{wearingRaincoat, wearingRaincoat} ≠ ∅ (w0 satisfies both).
-  apply hInc
-  refine ⟨.w0, ?_⟩
-  intro p hp
-  rcases List.mem_append.mp hp with h | h
-  · rcases List.mem_singleton.mp (by simpa [raincoatK] using h) with rfl
-    decide
-  · rcases List.mem_singleton.mp h with rfl
-    decide
-
-/-- Nandao reuses the mastermind kernel: "must blue" and "nandao blue?" share
-condition (iii). When must is defined, nandao's indirectness condition holds. -/
-theorem nandao_mastermind_bridge :
-    (kernelMust mastermindK blue).presup .w0 ∧
-    ¬ directlySettlesExplicit mastermindK blue :=
-  ⟨mastermind_must_blue_defined, mastermind_blue_unsettled⟩
 
 end Semantics.Modality

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -3,6 +3,7 @@ import Linglib.Fragments.Korean.Evidentials
 import Linglib.Fragments.Slavic.Bulgarian.Evidentials
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Semantics.Evidential.Epistemicity
+import Linglib.Studies.Zheng2025
 
 /-!
 # Cumming (2026): Tense and evidence — verification theorems
@@ -156,13 +157,14 @@ evidence rather than being directly observed. The
 [von-fintel-gillies-2010] kernel semantics states the modal side as a
 presupposition that the kernel does not directly settle the prejacent; the
 tense side is the nonfuture downstream constraint (T ≤ A). The
-[zheng-2025] dripping-raincoat scenario (public in
-`Semantics/Modality/Kernel.lean`) witnesses both at once: the raincoat
-evidence is causally downstream of the rain, and the kernel
-`{wearingRaincoat}` does not settle `isRaining`. -/
+[zheng-2025] dripping-raincoat scenario (from `Studies/Zheng2025.lean`)
+witnesses both at once: the raincoat evidence is causally downstream of the
+rain, and the kernel `{wearingRaincoat}` does not settle `isRaining`. -/
 
 open Semantics.Modality
 open Intensional.Premise (propIntersection)
+open Zheng2025 (World wearingRaincoat isRaining raincoatK
+  raincoat_nandao_felicitous)
 
 /-- A concrete evidential frame for the raincoat scenario:
     S = 0 (speech time now), T = -2 (rain event in the past),
@@ -188,7 +190,7 @@ theorem raincoat_not_settled :
     evidence (T ≤ A) co-occurs with the kernel not settling the prejacent. -/
 theorem downstream_implies_must_defined :
     downstreamEvidence raincoatFrame ∧
-    (kernelMust raincoatK isRaining).presup World.w0 :=
+    (kernelMust raincoatK isRaining).presup World.rain :=
   ⟨raincoat_downstream, raincoat_not_settled⟩
 
 /-- **Tense-modal evidential parallel**: both Cumming's nonfuture constraint
@@ -197,15 +199,15 @@ theorem downstream_implies_must_defined :
     doesn't settle isRaining. -/
 theorem tense_modal_evidential_parallel :
     downstreamEvidence raincoatFrame ∧
-    (kernelMust raincoatK isRaining).presup World.w0 ∧
-    ¬(kernelMust raincoatK isRaining).assertion World.w0 := by
+    (kernelMust raincoatK isRaining).presup World.rain ∧
+    ¬(kernelMust raincoatK isRaining).assertion World.rain := by
   refine ⟨raincoat_downstream, raincoat_not_settled, ?_⟩
   intro hAll
-  have hw1 : World.w1 ∈ propIntersection raincoatK.props := by
+  have hw1 : World.sprinkler ∈ propIntersection raincoatK.props := by
     intro p hp
     rcases List.mem_singleton.mp hp with rfl
-    exact show wearingRaincoat .w1 by decide
-  exact (hAll hw1 : isRaining .w1)
+    exact show wearingRaincoat .sprinkler by decide
+  exact (by decide : ¬ isRaining World.sprinkler) (hAll hw1)
 
 private theorem isRaining_settles_isRaining :
     directlySettlesExplicit (⟨[isRaining]⟩ : Kernel World) isRaining := by
@@ -218,7 +220,7 @@ private theorem isRaining_settles_isRaining :
 theorem direct_evidence_blocks_both :
     let directK : Kernel World := ⟨[isRaining]⟩
     directlySettlesExplicit directK isRaining ∧
-    ¬(kernelMust directK isRaining).presup World.w0 ∧
+    ¬(kernelMust directK isRaining).presup World.rain ∧
     let directFrame : EvidentialFrame ℤ :=
       { speechTime := 0, perspectiveTime := 0, referenceTime := 0,
         eventTime := -1, acquisitionTime := -1 }
@@ -250,7 +252,7 @@ theorem inferential_claim_must_profile :
     inferentialClaim.source = .inference ∧
     inferentialClaim.authority = .nonparticipant ∧
     ¬ directlySettlesExplicit raincoatK isRaining ∧
-    (kernelMust raincoatK isRaining).presup World.w0 :=
+    (kernelMust raincoatK isRaining).presup World.rain :=
   ⟨rfl, rfl, raincoat_not_settled, raincoat_not_settled⟩
 
 /-- Ego pairs with direct evidence and nonparticipant with inference in

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Evidential.Source
+import Linglib.Semantics.Modality.Kernel
 import Linglib.Data.Examples.VonFintelGillies2010
 import Linglib.Studies.Izvorski1997
 
@@ -30,6 +31,13 @@ must not directly settle the prejacent.
   entailment — including the infelicitous direct-evidence rows
 - `must_evidence_matches_izvorski_ev`: *must* imposes the same
   indirect-evidence restriction as [izvorski-1997]'s Bulgarian EV
+- `entailment_settling_gap`: B_K can entail φ without K directly settling
+  it — the gap that makes the evidential presupposition non-trivial
+- `subjectMatter`, `settlesByPartition`: the paper's second implementation
+  of directly-settles (Def 7, §7.2) — the subject matter S_K as an
+  equivalence relation on worlds
+- `explicit_not_implies_partition`, `partition_not_implies_explicit`: the
+  §7.2 boundary cases showing the two implementations are non-equivalent
 -/
 
 namespace VonFintelGillies2010
@@ -134,5 +142,233 @@ theorem must_entails_prejacent :
 theorem bare_always_felicitous :
     ∀ row ∈ mustPairs, ∀ alt ∈ row.alternatives, alt.2 = .acceptable := by
   decide
+
+/-! ### The kernel model ([von-fintel-gillies-2010] §7.1)
+
+A four-world instantiation of §7.1's worked kernel `K = {P ∪ Q, W \ P}`
+(Billy's weather report, Figure 3(a)), skinned with the colors of the §2
+Mastermind scenario (Pascal asking Mordecai *Must there be two reds?*):
+`P` = red-only, `Q` = blue, so `redOrBlue = P ∪ Q` and `notRed = W \ P`.
+`B_K = {w1}` entails *blue* without either kernel proposition settling it. -/
+
+open Semantics.Modality
+open Intensional.Premise
+
+/-- Four worlds: w0 = red, w1 = blue, w2 = green, w3 = unknown. -/
+inductive World where
+  | w0 | w1 | w2 | w3
+  deriving DecidableEq, Repr, Inhabited
+
+/-- ⟦red or blue⟧ = {w0, w1}: the paper's `P ∪ Q`. -/
+abbrev redOrBlue : World → Prop := λ w => w = .w0 ∨ w = .w1
+
+/-- ⟦not red⟧ = {w1, w2, w3}: the paper's `W \ P`. -/
+abbrev notRed : World → Prop := (· ≠ .w0)
+
+/-- ⟦blue⟧ = {w1}: the paper's `Q`. -/
+abbrev blue : World → Prop := (· = .w1)
+
+/-- ⟦red⟧ = {w0}: the paper's `P`. -/
+abbrev red : World → Prop := (· = .w0)
+
+/-- ⟦not blue⟧ (used by the [von-fintel-gillies-2021] can't dilemma). -/
+abbrev notBlue : World → Prop := (· ≠ .w1)
+
+/-- The §7.1 kernel `{P ∪ Q, W \ P}` in Mastermind colors. -/
+def mastermindK : Kernel World := ⟨[redOrBlue, notRed]⟩
+
+/-- A one-proposition kernel whose base properly contains ⟦blue⟧. -/
+def indirectK : Kernel World := ⟨[redOrBlue]⟩
+
+theorem mastermind_base : mastermindK.base = ({.w1} : Set World) := by
+  ext w
+  cases w <;> simp [Kernel.base, mastermindK, propIntersection, redOrBlue, notRed]
+
+theorem mastermind_blue_unsettled :
+    ¬ directlySettlesExplicit mastermindK blue := by
+  rintro ⟨x, hx, hxor⟩
+  rcases List.mem_cons.mp hx with rfl | hx'
+  · rcases hxor with h_ent | h_exc
+    · exact absurd (h_ent .w0 (show redOrBlue .w0 from by decide)) (by decide)
+    · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+  · rcases List.mem_singleton.mp hx' with rfl
+    rcases hxor with h_ent | h_exc
+    · exact absurd (h_ent .w2 (show notRed .w2 from by decide)) (by decide)
+    · exact h_exc ⟨.w1, show notRed .w1 from by decide, by decide⟩
+
+theorem mastermind_blue_follows : mastermindK.followsFrom blue := by
+  rw [Kernel.followsFrom_iff, mastermind_base]
+  rintro w rfl
+  rfl
+
+theorem mastermind_must_blue_defined :
+    (kernelMust mastermindK blue).presup .w0 :=
+  mastermind_blue_unsettled
+
+theorem mastermind_must_blue_true :
+    (kernelMust mastermindK blue).assertion .w0 :=
+  mastermind_blue_follows
+
+theorem mastermind_red_settled :
+    directlySettlesExplicit mastermindK red := by
+  refine ⟨notRed, by simp [mastermindK], Or.inr ?_⟩
+  rintro ⟨w, hnr, hr⟩
+  exact hnr hr
+
+theorem mastermind_might_red_undefined :
+    ¬(kernelMight mastermindK red).presup .w0 := λ h =>
+  h mastermind_red_settled
+
+theorem mastermind_redOrBlue_settled :
+    directlySettlesExplicit mastermindK redOrBlue :=
+  ⟨redOrBlue, by simp [mastermindK], Or.inl λ _ hw => hw⟩
+
+/-! ### Deep theorems -/
+
+/-- **Entailment-settling gap**: B_K can entail φ without K settling it.
+This gap makes the evidential presupposition non-trivial: must φ can be
+simultaneously defined and true. -/
+theorem entailment_settling_gap :
+    ∃ (k : Kernel World) (φ : (World → Prop)),
+      k.followsFrom φ ∧ ¬ directlySettlesExplicit k φ :=
+  ⟨mastermindK, blue, mastermind_blue_follows, mastermind_blue_unsettled⟩
+
+/-- **Indirectness ≠ weakness** (§4.1): three independent cases show
+indirectness and assertion strength are orthogonal dimensions. -/
+theorem indirectness_neq_weakness :
+    ((kernelMust mastermindK blue).presup .w0 ∧
+     (kernelMust mastermindK blue).assertion .w0) ∧
+    ¬(kernelMust mastermindK red).presup .w0 ∧
+    ((kernelMust indirectK blue).presup .w0 ∧
+     ¬(kernelMust indirectK blue).assertion .w0) := by
+  refine ⟨⟨mastermind_must_blue_defined, mastermind_must_blue_true⟩,
+    λ h => h mastermind_red_settled, ?_, ?_⟩
+  · rintro ⟨x, hx, hxor⟩
+    rcases List.mem_singleton.mp hx with rfl
+    rcases hxor with h_ent | h_exc
+    · exact absurd (h_ent .w0 (show redOrBlue .w0 from by decide)) (by decide)
+    · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+  · intro h
+    have hw0 : World.w0 ∈ indirectK.base :=
+      mem_propIntersection.mpr λ p hp => by
+        rcases List.mem_singleton.mp hp with rfl; decide
+    exact (by decide : ¬ blue World.w0) (h hw0)
+
+variable {W : Type*}
+
+/-- **Modus ponens with must** ([von-fintel-gillies-2010] Argument 4.3.1): the
+argument form "if φ, must ψ; φ; ∴ ψ" is valid under realistic B_K. -/
+theorem modus_ponens_with_must (k : Kernel W) (φ ψ : (W → Prop)) (w : W)
+    (hReal : w ∈ k.base)
+    (_hDef : (kernelMust k ψ).presup w)
+    (hCond : φ w → (kernelMust k ψ).assertion w)
+    (hPhi : φ w) :
+    ψ w :=
+  hCond hPhi hReal
+
+/-- **Must-perhaps contradiction** ([von-fintel-gillies-2010] Argument 4.3.2):
+must φ ∧ might ¬φ is contradictory. When B_K ⊆ ⟦φ⟧, B_K ∩ ⟦¬φ⟧ = ∅. -/
+theorem must_perhaps_contradiction (k : Kernel W) (φ : (W → Prop)) (w : W)
+    (_hDef : (kernelMust k φ).presup w)
+    (hMust : (kernelMust k φ).assertion w) :
+    ¬(kernelMight k (λ w' => ¬ φ w')).assertion w := by
+  intro hc
+  obtain ⟨w', hw', hφneg⟩ := (Kernel.compatibleWith_iff _ _).mp hc
+  exact hφneg (hMust hw')
+
+/-! ### Implementation 2: settling by partitions ([von-fintel-gillies-2010] Def 7, §7.2)
+
+Def 7 presents subject matters as equivalence relations on `W`: `S[P]` keeps
+the pairs of `S` that agree on `P`, and `P` is an *issue* in `S` iff
+`S[P] = S`. The subject matter S_K determined by a kernel is the refinement
+`S_o[P₁]…[Pₙ]` of the universal relation along each kernel proposition —
+equivalently, the relation "agrees with on every `X ∈ K`". Implementation 2:
+K directly settles P iff P is an issue in S_K. -/
+
+/-- The subject matter S_K determined by a kernel ([von-fintel-gillies-2010]
+    Implementation 2(i)): worlds are equivalent iff they agree on every
+    proposition in K. -/
+def subjectMatter (k : Kernel W) : Setoid W where
+  r w v := ∀ p ∈ k.props, (p w ↔ p v)
+  iseqv := ⟨λ _ _ _ => Iff.rfl, λ h p hp => (h p hp).symm,
+    λ h h' p hp => (h p hp).trans (h' p hp)⟩
+
+/-- `P` is an **issue** in a subject matter `S` ([von-fintel-gillies-2010]
+    Def 7(iii)): refining `S` along the `P`-boundary changes nothing, i.e.
+    `S`-equivalent worlds never disagree on `P`. -/
+def IsIssue (s : Setoid W) (φ : W → Prop) : Prop :=
+  ∀ w v, s.r w v → (φ w ↔ φ v)
+
+/-- K settles P by partition ([von-fintel-gillies-2010] Implementation 2(ii)):
+    P is an issue in S_K. -/
+def settlesByPartition (k : Kernel W) (φ : W → Prop) : Prop :=
+  IsIssue (subjectMatter k) φ
+
+/-- Partition settling implies entailment: all worlds in B_K agree on every
+    X ∈ K, so they are S_K-equivalent; if φ is an issue in S_K, B_K is
+    φ-uniform. Both implementations therefore imply entailment (cf.
+    `explicit_implies_entailment`); the converse fails for both. -/
+theorem partition_implies_entailment (k : Kernel W) (φ : (W → Prop))
+    (h : settlesByPartition k φ) :
+    k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
+  rcases Set.eq_empty_or_nonempty k.base with hEmpty | ⟨w₀, hw₀⟩
+  · exact Or.inl ((Kernel.followsFrom_iff _ _).mpr λ w hw =>
+      absurd (hEmpty ▸ hw) (Set.notMem_empty w))
+  · have hrel : ∀ v ∈ k.base, (subjectMatter k).r w₀ v := λ v hv p hp =>
+      ⟨λ _ => mem_propIntersection.mp hv p hp,
+       λ _ => mem_propIntersection.mp hw₀ p hp⟩
+    rcases Classical.em (φ w₀) with hφ | hφ
+    · exact Or.inl ((Kernel.followsFrom_iff _ _).mpr λ v hv =>
+        (h w₀ v (hrel v hv)).mp hφ)
+    · exact Or.inr ((Kernel.followsFrom_iff _ _).mpr λ v hv hφv =>
+        hφ ((h w₀ v (hrel v hv)).mpr hφv))
+
+/-! ### Non-equivalence of the two implementations (§7.2)
+
+Implementation 1 settles supersets of K-propositions that Implementation 2
+misses (`K = {P}` settles `P ∪ Q` explicitly, but there are worlds agreeing
+on `P` that disagree on `P ∪ Q`); Implementation 2 settles propositions
+determined jointly by K-propositions that no single proposition settles
+(`blue` is determined by `redOrBlue` together with `notRed`). -/
+
+/-- S_{K} for `K = {red}` does not make `redOrBlue` an issue: w1 and w2
+    agree on `red` but disagree on `redOrBlue`. -/
+private theorem not_settles_redOrBlue :
+    ¬ settlesByPartition ⟨[red]⟩ redOrBlue := by
+  intro h
+  have h12 := h .w1 .w2 (λ p hp => by
+    rcases List.mem_singleton.mp hp with rfl; decide)
+  exact absurd (h12.mp (by decide)) (by decide)
+
+/-- Counterexample (Impl 1 ↛ Impl 2): `K = {red}` settles `redOrBlue`
+    explicitly (red ⊆ redOrBlue), but not by partition. -/
+theorem explicit_not_implies_partition :
+    ∃ (k : Kernel World) (φ : (World → Prop)),
+      directlySettlesExplicit k φ ∧ ¬ settlesByPartition k φ :=
+  ⟨⟨[red]⟩, redOrBlue,
+    ⟨red, by simp, Or.inl λ _ hw => Or.inl hw⟩, not_settles_redOrBlue⟩
+
+/-- Counterexample (Impl 2 ↛ Impl 1): `mastermindK` settles `blue` by
+    partition — S_K-equivalent worlds agree on `redOrBlue` and `notRed`,
+    which jointly determine `blue` — but no single kernel proposition
+    entails or excludes it. -/
+theorem partition_not_implies_explicit :
+    ∃ (k : Kernel World) (φ : (World → Prop)),
+      settlesByPartition k φ ∧ ¬ directlySettlesExplicit k φ := by
+  refine ⟨mastermindK, blue, λ w v h => ?_, mastermind_blue_unsettled⟩
+  have h1 := h redOrBlue (by simp [mastermindK])
+  have h2 := h notRed (by simp [mastermindK])
+  revert h1 h2
+  cases w <;> cases v <;> decide
+
+/-- Entailment does not imply partition settling: `K = {red}` entails
+    `redOrBlue` (B_K = {w0} ⊆ ⟦redOrBlue⟧) but does not settle it by
+    partition. -/
+theorem entailment_not_implies_partition :
+    ∃ (k : Kernel World) (φ : (World → Prop)),
+      k.followsFrom φ ∧ ¬ settlesByPartition k φ :=
+  ⟨⟨[red]⟩, redOrBlue,
+    λ w hw => Or.inl (mem_propIntersection.mp hw red (by simp)),
+    not_settles_redOrBlue⟩
 
 end VonFintelGillies2010

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -14,6 +14,11 @@ is anti-knowledge, not anti-perception — direct-enough *knowledge* blocks
 
 - `evidential_restriction_extends`: the 2010 felicity ↔ indirectness
   biconditional holds on the anti-knowledge rows
+- `cant_might_exclusion`: when can't φ holds, might φ is false
+  (Observation 5)
+- `cant_dilemma_resolved`: a single kernel simultaneously exhibits
+  evidentiality, strength, and might-exclusion — the assignment of force
+  to *can't* the Mantra cannot deliver
 -/
 
 namespace VonFintelGillies2021
@@ -35,5 +40,77 @@ theorem evidential_restriction_extends :
       row.judgment = .acceptable ↔
         (evidenceOf row).map EvidenceType.toCoarseSource ≠ some .direct := by
   decide
+
+/-! ### The can't dilemma ([von-fintel-gillies-2021] §4, Observations 4–5)
+
+The Mantra faces a dilemma: no assignment of force to *can't* simultaneously
+explains its evidential distribution (Observation 4: *can't* patterns like
+*must*) and its incompatibility with *it's possible that φ* (Observation 5).
+Kernel semantics resolves this: *can't φ* = *must*(¬φ) by definition
+(`kernelCant`), so Observation 4's evidential parallelism holds by
+construction, while the strong assertion B_K ⊆ ⟦¬φ⟧ delivers Observation 5. -/
+
+open Semantics.Modality
+open Intensional.Premise
+open VonFintelGillies2010 (World mastermindK redOrBlue notRed blue red notBlue
+  mastermind_base)
+
+variable {W : Type*}
+
+/-- **Can't–might exclusion** ([von-fintel-gillies-2021] Obs 5): when can't φ
+holds (B_K ⊆ ⟦¬φ⟧), might φ is false (B_K ∩ ⟦φ⟧ = ∅). -/
+theorem cant_might_exclusion (k : Kernel W) (φ : (W → Prop)) (w : W)
+    (hCant : (kernelCant k φ).assertion w) :
+    ¬(kernelMight k φ).assertion w := by
+  intro hc
+  obtain ⟨w', hw', hφ⟩ := (Kernel.compatibleWith_iff _ _).mp hc
+  exact hCant hw' hφ
+
+/-- **Can't entails negation** ([von-fintel-gillies-2021] via S2): when B_K is
+realistic and can't φ is defined and true, ¬φ(w). -/
+theorem cant_entails_negation (k : Kernel W) (φ : (W → Prop)) (w : W)
+    (hReal : w ∈ k.base)
+    (_hDef : (kernelCant k φ).presup w)
+    (hTrue : (kernelCant k φ).assertion w) :
+    ¬ φ w :=
+  hTrue hReal
+
+/-- **Can't dilemma resolved**: a single kernel simultaneously exhibits
+evidentiality, strength, and might-exclusion.
+Witness: K = {redOrBlue, notRed}, φ = notBlue. Then can't(notBlue) =
+must(blue), which is defined (blue unsettled), true (B_K ⊆ ⟦blue⟧),
+and excludes might(notBlue). -/
+theorem cant_dilemma_resolved :
+    .w1 ∈ mastermindK.base ∧
+    (kernelCant mastermindK notBlue).presup .w1 ∧
+    (kernelCant mastermindK notBlue).assertion .w1 ∧
+    ¬(kernelMight mastermindK notBlue).assertion .w1 ∧
+    ¬ notBlue .w1 := by
+  refine ⟨by rw [mastermind_base]; rfl, ?_, ?_, ?_, by decide⟩
+  · rintro ⟨x, hx, hxor⟩
+    rcases List.mem_cons.mp hx with rfl | hx'
+    · rcases hxor with h_ent | h_exc
+      · exact h_ent .w0 (show redOrBlue .w0 from by decide) (by decide)
+      · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+    · rcases List.mem_singleton.mp hx' with rfl
+      rcases hxor with h_ent | h_exc
+      · exact h_ent .w2 (show notRed .w2 from by decide) (by decide)
+      · exact h_exc ⟨.w1, show notRed .w1 from by decide, by decide⟩
+  · rw [show (kernelCant mastermindK notBlue).assertion .w1 =
+        mastermindK.followsFrom (λ w => ¬ notBlue w) from rfl,
+      Kernel.followsFrom_iff, mastermind_base]
+    rintro w rfl
+    decide
+  · intro hc
+    obtain ⟨w, hw, hnb⟩ := (Kernel.compatibleWith_iff _ _).mp hc
+    rw [mastermind_base] at hw
+    rcases hw with rfl
+    exact (by decide : ¬ notBlue World.w1) hnb
+
+/-- Direct evidence blocks can't, paralleling must: when K settles ¬φ,
+can't φ has presupposition failure. -/
+theorem cant_direct_evidence_infelicity :
+    ¬(kernelCant mastermindK red).presup .w0 := λ h =>
+  h ⟨notRed, by simp [mastermindK], Or.inl λ _ hw => hw⟩
 
 end VonFintelGillies2021

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -4,49 +4,44 @@ import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer
 import Linglib.Semantics.Questions.Bias
 import Linglib.Semantics.Questions.Singleton
+import Mathlib.Data.Set.Card
+import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Zheng (2025): Nandao-Q Felicity [zheng-2025]
+# Zheng (2025): Nandao-Q Felicity
+[zheng-2025]
 
-Mandarin *nandao*-question felicity. Self-contained study file:
-empirical data, the Mandarin Fragment entry, and bridges to the
-Kernel-theoretic felicity predicate `nandaoFelicitous`.
+Mandarin *nandao*-question felicity: positive evidential bias is necessary,
+while negative epistemic bias is neither necessary nor sufficient. The
+felicity conditions (Zheng's condition (11)) are built on
+[von-fintel-gillies-2010]'s kernel: some evidence in the kernel K raises the
+probability of the prejacent, K conflicts with the prior information state U,
+and the prejacent is not directly settled in K.
 
-The core finding is that positive evidential bias is **necessary** for
-nandao-Q felicity, while negative epistemic bias is **neither necessary
-nor sufficient**.
+## Main declarations
 
-## Key Generalizations
-
-1. Positive evidential bias (contextual evidence for p) → nandao felicitous
-2. Epistemic bias alone (prior belief against p, no evidence) → nandao infelicitous
-3. Evidence must be **unexpected** relative to prior information state
-4. Nandao-Qs can function as pure inquiry (no prior belief required)
-
-## Predictions verified
-
+- `NandaoDatum`, `allData`: the felicity data of exx. 1–6, with the
+  generalizations `evidential_bias_necessary`, `epistemic_bias_not_necessary`,
+  `epistemic_bias_not_sufficient`, `unexpectedness_necessary`
+- `nandaoFelicitous`: condition (11) — evidence raises P(φ), the kernel is
+  unexpected given the prior state, φ unsettled
+- `raincoat_nandao_felicitous`: the dripping-raincoat scenario (exx. 2–3)
+  satisfies all three conditions; `no_evidence_nandao_infelicitous` and
+  `expected_evidence_infelicitous` are the matching negative checks
 - `nandaoContextualEvidence` / `nandaoOriginalBias`: Zheng's bias
-  classification of *nandao*, grounded in `evidential_bias_necessary`
-  and `epistemic_bias_not_necessary`
-- `kernel_requires_evidence`: Kernel `nandaoFelicitous` entails
-  `evidenceSupports`
-- `nandaoFullFelicity`: integrated two-layer felicity (singleton sister
-  presupposition ∧ Kernel-bias check) — §5
-- `biasedUse_integrated_felicity`: dripping-raincoat scenario satisfies
-  integrated felicity at the §5 level — §6
-- `biasedUse_witnesses_integrated_felicity`: §1 datum (ex. 2) ↔ §6
-  theoretical prediction
-
-## Known gaps
-
-- No formalization of the unexpectedness requirement in the Kernel theory
+  classification of *nandao*
+- `nandaoFullFelicity`: integrated two-layer felicity — singleton sister
+  presupposition (shared with [bhatt-dayal-2020]'s kya:) ∧ kernel-bias check
+- `biasedUse_integrated_felicity`: the raincoat scenario satisfies the
+  integrated predicate
 -/
 
 namespace Zheng2025
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1 — Empirical Data
--- ════════════════════════════════════════════════════════════════════════════
+open Semantics.Modality (Kernel directlySettlesExplicit)
+open Intensional.Premise
+
+/-! ### Empirical data -/
 
 /-- A nandao-Q felicity datum. -/
 structure NandaoDatum where
@@ -66,12 +61,8 @@ structure NandaoDatum where
   felicitous : Bool
   deriving Repr, DecidableEq
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1.1 — Rhetorical, Biased, and Pure Inquiry Uses
--- ════════════════════════════════════════════════════════════════════════════
-
-/-- Ex. 1: Rhetorical use. Lee working on Sunday (evidence) contradicts B's
-norm that people don't work Sundays (epistemic/deontic bias). -/
+/-- Ex. 1, rhetorical use: Lee working on Sunday (evidence) contradicts B's
+norm that people don't work Sundays. -/
 def rhetoricalUse : NandaoDatum where
   exampleNum := "1"
   context := "Lee plans to work on Sunday; B thinks people don't work Sundays"
@@ -81,8 +72,8 @@ def rhetoricalUse : NandaoDatum where
   unexpectedEvidence := true
   felicitous := true
 
-/-- Ex. 2: Biased question. A believes not-raining; B enters with dripping
-raincoat (evidence contradicting belief). -/
+/-- Ex. 2, biased question: A believes not-raining; B enters with a dripping
+raincoat. -/
 def biasedUse : NandaoDatum where
   exampleNum := "2"
   context := "A believes not-raining; B enters with dripping raincoat"
@@ -92,7 +83,7 @@ def biasedUse : NandaoDatum where
   unexpectedEvidence := true
   felicitous := true
 
-/-- Ex. 3: Pure inquiry (NOVEL). Same evidence as ex. 2 but A has NO prior
+/-- Ex. 3, pure inquiry (novel): same evidence as ex. 2 but A has no prior
 belief about the weather. Nandao is still felicitous. -/
 def pureInquiry : NandaoDatum where
   exampleNum := "3"
@@ -103,12 +94,7 @@ def pureInquiry : NandaoDatum where
   unexpectedEvidence := true
   felicitous := true
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1.2 — Epistemic Bias Not Sufficient
--- ════════════════════════════════════════════════════════════════════════════
-
-/-- Ex. 4a: Epistemic bias without evidence. Speaker believes room is empty
-but has no contextual evidence either way. -/
+/-- Ex. 4a: epistemic bias without evidence — infelicitous. -/
 def epistemicOnly : NandaoDatum where
   exampleNum := "4a"
   context := "Speaker believes room is empty; no contextual evidence"
@@ -118,11 +104,7 @@ def epistemicOnly : NandaoDatum where
   unexpectedEvidence := false
   felicitous := false
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1.3 — Evidence Without Epistemic Bias
--- ════════════════════════════════════════════════════════════════════════════
-
-/-- Ex. 5 ctx 1: Evidence + no belief → felicitous. -/
+/-- Ex. 5 ctx 1: evidence, no belief — felicitous. -/
 def evidenceNoBelief : NandaoDatum where
   exampleNum := "5.1"
   context := "No prior beliefs; B enters with dripping raincoat"
@@ -132,7 +114,7 @@ def evidenceNoBelief : NandaoDatum where
   unexpectedEvidence := true
   felicitous := true
 
-/-- Ex. 5 ctx 2: No evidence + no belief → infelicitous. -/
+/-- Ex. 5 ctx 2: no evidence, no belief — infelicitous. -/
 def noEvidenceNoBelief : NandaoDatum where
   exampleNum := "5.2"
   context := "No prior beliefs; B enters normally (no raincoat)"
@@ -142,7 +124,7 @@ def noEvidenceNoBelief : NandaoDatum where
   unexpectedEvidence := false
   felicitous := false
 
-/-- Ex. 5 ctx 3: No evidence + epistemic bias → infelicitous. -/
+/-- Ex. 5 ctx 3: epistemic bias, no evidence — infelicitous. -/
 def beliefNoEvidence : NandaoDatum where
   exampleNum := "5.3"
   context := "A thinks it won't rain; B enters normally (no raincoat)"
@@ -152,12 +134,8 @@ def beliefNoEvidence : NandaoDatum where
   unexpectedEvidence := false
   felicitous := false
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1.4 — Unexpectedness Required
--- ════════════════════════════════════════════════════════════════════════════
-
-/-- Ex. 6 ctx 1: Unexpected evidence → felicitous. -/
-def unexpectedEvidence_ : NandaoDatum where
+/-- Ex. 6 ctx 1: unexpected evidence — felicitous. -/
+def workSundayUnexpected : NandaoDatum where
   exampleNum := "6.1"
   context := "B doesn't think people work Sundays; A says Lee is working Sunday"
   sentence := "Nandao ta hen.mang ma? (Is he busy?)"
@@ -166,8 +144,8 @@ def unexpectedEvidence_ : NandaoDatum where
   unexpectedEvidence := true
   felicitous := true
 
-/-- Ex. 6 ctx 2: Expected evidence → infelicitous. -/
-def expectedEvidence : NandaoDatum where
+/-- Ex. 6 ctx 2: expected evidence — infelicitous. -/
+def workSundayExpected : NandaoDatum where
   exampleNum := "6.2"
   context := "B knows Lee usually works Sundays; A says Lee is working Sunday"
   sentence := "Nandao ta hen.mang ma? (Is he busy?)"
@@ -176,48 +154,147 @@ def expectedEvidence : NandaoDatum where
   unexpectedEvidence := false
   felicitous := false
 
--- ════════════════════════════════════════════════════════════════════════════
--- §1.5 — Dataset and Generalization Theorems
--- ════════════════════════════════════════════════════════════════════════════
-
+/-- The pooled felicity data of exx. 1–6. -/
 def allData : List NandaoDatum :=
   [ rhetoricalUse, biasedUse, pureInquiry,
     epistemicOnly,
     evidenceNoBelief, noEvidenceNoBelief, beliefNoEvidence,
-    unexpectedEvidence_, expectedEvidence ]
+    workSundayUnexpected, workSundayExpected ]
 
-/-- **Generalization 1**: All felicitous nandao-Qs have evidential bias. -/
+/-- **Generalization 1**: all felicitous nandao-Qs have evidential bias. -/
 theorem evidential_bias_necessary :
-    (allData.filter (·.felicitous)).all (·.evidentialBias) = true := by native_decide
+    (allData.filter (·.felicitous)).all (·.evidentialBias) = true := by decide
 
-/-- **Generalization 2**: Some felicitous nandao-Qs lack epistemic bias
+/-- **Generalization 2**: some felicitous nandao-Qs lack epistemic bias
 (the pure inquiry use). -/
 theorem epistemic_bias_not_necessary :
-    (allData.filter (λ d => d.felicitous && !d.epistemicBias)).length > 0 := by native_decide
+    (allData.filter (λ d => d.felicitous && !d.epistemicBias)).length > 0 := by decide
 
-/-- **Generalization 3**: Some infelicitous nandao-Qs have epistemic bias
+/-- **Generalization 3**: some infelicitous nandao-Qs have epistemic bias
 (epistemic bias is not sufficient). -/
 theorem epistemic_bias_not_sufficient :
-    (allData.filter (λ d => d.epistemicBias && !d.felicitous)).length > 0 := by native_decide
+    (allData.filter (λ d => d.epistemicBias && !d.felicitous)).length > 0 := by decide
 
-/-- **Generalization 4**: All felicitous nandao-Qs have unexpected evidence. -/
+/-- **Generalization 4**: all felicitous nandao-Qs have unexpected evidence. -/
 theorem unexpectedness_necessary :
-    (allData.filter (·.felicitous)).all (·.unexpectedEvidence) = true := by native_decide
+    (allData.filter (·.felicitous)).all (·.unexpectedEvidence) = true := by decide
 
-/-- 9 data points from 6 examples covering 4 conditions. -/
-theorem dataset_size : allData.length = 9 := by native_decide
+/-! ### Kernel-theoretic felicity conditions
 
--- ════════════════════════════════════════════════════════════════════════════
--- §2 — Bridges: Fragment ↔ Data, Theory ↔ Data
--- ════════════════════════════════════════════════════════════════════════════
+Zheng's condition (11), the final felicity condition for nandao on polar
+questions, built on [von-fintel-gillies-2010]'s kernel: (i) some evidence
+`p ∈ K` raises the probability of the prejacent φ; (ii) the kernel conflicts
+with the prior information state U — the evidence is unexpected; (iii) φ is
+not directly settled in K. Condition (iii) is the presupposition of
+[von-fintel-gillies-2010]'s `kernelMust`. -/
 
-open Mandarin.QuestionParticles (nandao)
-open Semantics.Modality (Kernel Background nandaoFelicitous World)
+variable {W : Type*}
+
+/-- Evidence `p` raises the probability of `φ` under the uniform (counting)
+measure: P(φ|p) > P(φ), stated by cross-multiplication over cardinalities to
+avoid rationals. [zheng-2025]'s condition (11i) writes P(φ|p) ≫ P(φ); we
+sharpen "significantly raises" to strict raising and fix the uniform measure
+on `W`. Meaningful for finite `W` (`Set.ncard` and `Nat.card` are junk
+otherwise). -/
+def evidenceRaises (p φ : W → Prop) : Prop :=
+  {w | p w ∧ φ w}.ncard * Nat.card W > {w | φ w}.ncard * {w | p w}.ncard
+
+/-- Some proposition in K raises the probability of φ
+([zheng-2025] condition (11i)). -/
+def evidenceSupports (k : Kernel W) (φ : W → Prop) : Prop :=
+  ∃ p ∈ k.props, evidenceRaises p φ
+
+/-- The evidence in K is unexpected given the prior information state U
+([zheng-2025] condition (11ii)): B_K ∩ ⋂U = ∅. U collects what leads to the
+information state prior to encountering the evidence — beliefs, norms,
+desires — distinct from the kernel's direct evidence. -/
+def unexpected (k : Kernel W) (u : List ((W → Prop))) : Prop :=
+  k.base ∩ propIntersection u = ∅
+
+/-- **Nandao-Q felicity** ([zheng-2025] condition (11), final version for
+polar questions): (i) some evidence in K raises P(φ), (ii) the evidence is
+unexpected given the prior state U, (iii) φ is not directly settled in K. -/
+def nandaoFelicitous (k : Kernel W) (u : List ((W → Prop))) (φ : W → Prop) : Prop :=
+  evidenceSupports k φ ∧ unexpected k u ∧ ¬ directlySettlesExplicit k φ
+
+/-! ### The dripping-raincoat scenario ([zheng-2025] exx. 2–3, 5)
+
+K = {wearingRaincoat}: direct evidence that someone entered with a wet coat.
+U = {expectDry}: prior expectation of no rain (doxastic or normative). -/
+
+/-- Four worlds for the raincoat scenario: it rains, the sprinkler ran
+    (wet coat without rain), it is dry, or nothing is known. -/
+inductive World where
+  | rain | sprinkler | dry | unknown
+  deriving DecidableEq, Repr, Inhabited, Fintype
+
+/-- B enters wearing a dripping raincoat: true where the coat is wet. -/
+abbrev wearingRaincoat : World → Prop := λ w => w = .rain ∨ w = .sprinkler
+
+/-- A's prior expectation: no rain. -/
+abbrev expectDry : World → Prop := λ w => w = .dry ∨ w = .unknown
+
+/-- It is raining outside. -/
+abbrev isRaining : World → Prop := (· = .rain)
+
+/-- The raincoat kernel: direct evidence of the wet coat. -/
+def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
+
+/-- The prior information state: A expects dry weather. -/
+def dryU : List ((World → Prop)) := [expectDry]
+
+/-- "Nandao waimian xiayu-le ma?" is felicitous with a dripping raincoat:
+P(rain|coat) = 1/2 > P(rain) = 1/4; B_K ∩ ⋂U = ∅; rain unsettled by K. -/
+theorem raincoat_nandao_felicitous :
+    nandaoFelicitous raincoatK dryU isRaining := by
+  refine ⟨⟨wearingRaincoat, by simp [raincoatK], ?_⟩, ?_, ?_⟩
+  · -- |coat ∧ rain| ⬝ |W| > |rain| ⬝ |coat|: 1 ⬝ 4 > 1 ⬝ 2.
+    have hpφ : {w | wearingRaincoat w ∧ isRaining w} = {World.rain} := by
+      ext w; cases w <;> simp [wearingRaincoat, isRaining]
+    have hφ : {w | isRaining w} = {World.rain} := by
+      ext w; cases w <;> simp [isRaining]
+    have hp : {w | wearingRaincoat w} = {World.rain, World.sprinkler} := by
+      ext w; cases w <;> simp [wearingRaincoat]
+    unfold evidenceRaises
+    rw [hpφ, hφ, hp, Set.ncard_singleton, Set.ncard_pair (by decide),
+      Nat.card_eq_fintype_card]
+    decide
+  · refine Set.eq_empty_iff_forall_notMem.mpr λ w ⟨hK, hU⟩ => ?_
+    have h1 : wearingRaincoat w := mem_propIntersection.mp hK _ (by simp [raincoatK])
+    have h2 : expectDry w := mem_propIntersection.mp hU _ (by simp [dryU])
+    revert h1 h2
+    cases w <;> decide
+  · rintro ⟨x, hx, hxor⟩
+    rcases List.mem_singleton.mp (by simpa [raincoatK] using hx) with rfl
+    rcases hxor with h_ent | h_exc
+    · exact absurd (h_ent .sprinkler (show wearingRaincoat .sprinkler from by decide))
+        (by decide)
+    · exact h_exc ⟨.rain, show wearingRaincoat .rain from by decide, by decide⟩
+
+/-- Without evidence, nandao is infelicitous ([zheng-2025] ex. 5 ctx 2). -/
+theorem no_evidence_nandao_infelicitous :
+    ¬ nandaoFelicitous ⟨[]⟩ dryU isRaining := by
+  rintro ⟨⟨x, hx, _⟩, _, _⟩
+  exact List.not_mem_nil hx
+
+/-- When evidence is expected (K compatible with U), nandao is infelicitous
+([zheng-2025] ex. 6 ctx 2, transposed to the raincoat scenario: a prior
+expectation of wet coats makes the evidence unremarkable). -/
+theorem expected_evidence_infelicitous :
+    ¬ nandaoFelicitous raincoatK [wearingRaincoat] isRaining := by
+  rintro ⟨_, hInc, _⟩
+  have hmem : World.rain ∈ raincoatK.base ∩ propIntersection [wearingRaincoat] :=
+    ⟨mem_propIntersection.mpr (by simp [raincoatK, wearingRaincoat]),
+     mem_propIntersection.mpr (by simp [wearingRaincoat])⟩
+  rw [unexpected] at hInc
+  exact absurd (hInc ▸ hmem) (Set.notMem_empty _)
+
+/-! ### Bias classification -/
+
+open Mandarin.QuestionParticles (nandao ma ba)
 
 /-- Zheng's evidential classification of *nandao*: requires contextual
-evidence for p — the lexical face of `evidential_bias_necessary`.
-(Formerly a fragment field; a particle's bias requirement is the
-analysis, so it lives here.) -/
+evidence for p — the lexical face of `evidential_bias_necessary`. -/
 def nandaoContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
   some .forP
 
@@ -226,192 +303,121 @@ compatible with a neutral epistemic state (pure inquiry use, ex. 3);
 the lexical face of `epistemic_bias_not_necessary`. -/
 def nandaoOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
 
-/-- Kernel `nandaoFelicitous` entails `evidenceSupports`, connecting the
-Theory predicate to `nandaoContextualEvidence` and the empirical
-generalization `evidential_bias_necessary`. -/
-theorem kernel_requires_evidence (k : Kernel World) (u : Background World) (φ : (World → Prop))
-    [DecidablePred φ] (h : nandaoFelicitous k u φ) :
-    k.evidenceSupports φ :=
+/-- `nandaoFelicitous` entails `evidenceSupports`, connecting the felicity
+predicate to `nandaoContextualEvidence` and the empirical generalization
+`evidential_bias_necessary`. -/
+theorem kernel_requires_evidence (k : Kernel World) (u : List ((World → Prop)))
+    (φ : (World → Prop)) (h : nandaoFelicitous k u φ) :
+    evidenceSupports k φ :=
   h.1
 
--- ════════════════════════════════════════════════════════════════════════════
--- §3 — Left-Peripheral Layer Assignments ([dayal-2025] cartography)
--- ════════════════════════════════════════════════════════════════════════════
+/-! ### Left-peripheral layer assignments ([dayal-2025] cartography)
+
+Zheng's layer assignments for the three Mandarin Q-particles in the
+[dayal-2025] cartography `[SAP [PerspP [CP ...]]]`. The layer split mirrors
+the bias split: the unbiased particle *ma* is CP (widest distribution:
+matrix, subordinated, quasi-subordinated); the biased *ba* and *nandao* are
+PerspP (matrix + quasi-subordinated only). The `_` argument is unused: the
+layer is a theoretical overlay on the fragment particle, not a computed
+property of its lexical fields. -/
 
 open Features (QParticleLayer)
-open Mandarin.QuestionParticles (ma ba)
 
-/-- Zheng's layer assignments for the three Mandarin Q-particles in the
-    [dayal-2025] cartography `[SAP [PerspP [CP ...]]]`. The `_`
-    argument is unused: the layer is a theoretical overlay on the
-    fragment particle, not a computed property of its lexical fields. -/
-def ma_layer     (_ : Particle) : QParticleLayer := .cp
-def ba_layer     (_ : Particle) : QParticleLayer := .perspP
+/-- *ma*: the unmarked CP-layer particle. -/
+def ma_layer (_ : Particle) : QParticleLayer := .cp
+
+/-- *ba*: PerspP-layer biased particle. -/
+def ba_layer (_ : Particle) : QParticleLayer := .perspP
+
+/-- *nandao*: PerspP-layer biased particle. -/
 def nandao_layer (_ : Particle) : QParticleLayer := .perspP
 
-/-- *ma* is the unmarked CP-layer particle: widest distribution
-    (matrix, subordinated, quasi-subordinated). -/
-theorem ma_is_CP : ma_layer ma = .cp := rfl
-
-/-- *ba* and *nandao* are PerspP-layer biased particles: matrix +
-    quasi-subordinated only. -/
-theorem ba_nandao_PerspP :
-    ba_layer ba = .perspP ∧ nandao_layer nandao = .perspP := ⟨rfl, rfl⟩
-
-/-- Zheng's classification of *ba*: speaker-bias (expects a positive
-    answer, seeks confirmation), no evidential requirement; the unbiased
-    *ma* imposes neither. The layer split mirrors this bias split — the
-    unbiased particle is CP (`ma_is_CP`), the biased ones PerspP
-    (`ba_nandao_PerspP`). -/
+/-- Zheng's classification of *ba*: speaker-bias (expects a positive answer,
+seeks confirmation), no evidential requirement; the unbiased *ma* imposes
+neither. -/
 def baOriginalBias : Option Semantics.Questions.Bias.OriginalBias := some .forP
 
--- ════════════════════════════════════════════════════════════════════════════
--- §4 — Singleton-Alternative Presupposition (parallel to kya:)
--- ════════════════════════════════════════════════════════════════════════════
+/-! ### Singleton-alternative presupposition (parallel to kya:)
 
-/-! [bhatt-dayal-2020] fn. 11 explicitly cites the parallel
-Mandarin *nandao* analysis as the model for their kya: proposal.
-At the algebraic level, both particles share the same singleton
-presupposition: their sister question must denote a singleton-cell
-issue ([bhatt-dayal-2020] eq. 23). The cross-particle
-generalization is captured by inheriting the same
-`Question.IsSingleton` predicate — both kya: and nandao take a
-`SingletonQuestion W` as well-typed sister content. -/
+[bhatt-dayal-2020] fn. 11 explicitly cites the parallel Mandarin *nandao*
+analysis as the model for their kya: proposal. At the algebraic level, both
+particles share the same singleton presupposition: their sister question must
+denote a singleton-cell issue ([bhatt-dayal-2020] eq. 23), captured by the
+shared `Question.IsSingleton` predicate. -/
 
-open Question (IsSingleton SingletonQuestion ofSet
-  isSingleton_ofSet)
-
-universe u
-variable {W : Type u}
+open Question (IsSingleton SingletonQuestion ofSet isSingleton_ofSet alt polar
+  not_isSingleton_polar_of_nontrivial alt_ofSet)
 
 /-- nandao is felicitous on a one-cell ("highlighted") polar — the same
-    canonical good-input case as kya:, and by construction the same
-    substrate fact: both this and `BhattDayal2020.kya_felicitous_singleton_polar`
-    are `isSingleton_ofSet`, capturing the kya:–nandao convergence
-    [bhatt-dayal-2020] draw from [xu-2012]. -/
+canonical good-input case as kya:. Both this and
+`BhattDayal2020.kya_felicitous_singleton_polar` are `isSingleton_ofSet`,
+capturing the kya:–nandao convergence [bhatt-dayal-2020] draw from
+[xu-2012]. -/
 theorem nandao_felicitous_ofSet (p : Set W) :
     IsSingleton (ofSet (W := W) p) :=
   isSingleton_ofSet p
 
--- ════════════════════════════════════════════════════════════════════════════
--- §5 — Integrated Felicity: §2 (Kernel-bias) ∧ §4 (Question-singleton)
--- ════════════════════════════════════════════════════════════════════════════
+/-! ### Integrated felicity
 
-/-! Bridge §2 and §4. Nandao's full felicity has two independent layers:
+Nandao's full felicity has two independent layers: the sister content is
+*singleton* — `alt Q = {p}` for a unique witness `p` (semantic
+well-formedness, the [bhatt-dayal-2020] eq. 23 presupposition) — and the
+kernel-bias check `nandaoFelicitous k u p` holds for the witness (discourse
+felicity in context). The integrated predicate composes them; a Layer-1
+failure (a non-trivial two-cell polar) blocks felicity regardless of
+`(k, u)`. -/
 
-  - **Layer 1** (Question-level, §4): the sister content `Q : Question World`
-    is *singleton* — `alt Q = {p}` for some unique witness `p`. This is the
-    [bhatt-dayal-2020] eq. 23 presupposition: nandao requires a
-    one-cell sister, not a two-cell Hamblin polar.
-  - **Layer 2** (Kernel-level, §2): the Kernel-bias check
-    `nandaoFelicitous k u p` holds for the witness — the evidence in `K`
-    raises `P(p)`, `K` is incompatible with the prior `U`, and `p` is
-    not directly settled.
-
-These layers are independent concerns: Layer 1 is about semantic
-well-formedness of the sister content, Layer 2 is about discourse
-felicity in context. The integrated predicate composes them into a
-single statement, and the bridges below show that Layer 1 failure
-(e.g. a non-trivial two-cell polar) blocks felicity at the integrated
-level regardless of `(k, u)`. -/
-
-open Question (alt polar
-  not_isSingleton_polar_of_nontrivial alt_polar_of_nontrivial
-  alt_ofSet)
-
-/-- **Integrated nandao felicity**: the conjunction of Layer 1
-    (singleton presupposition: `alt Q = {p}`) and Layer 2 (Kernel-bias
-    check on the witness). The witness `p` is supplied externally so
-    decidability is concrete; for the noncomputable choice from a
-    `SingletonQuestion` use `SingletonQuestion.witness`. -/
-def nandaoFullFelicity (Q : Question World) (k : Kernel World) (u : Background World)
-    (p : Set World) [DecidablePred p] : Prop :=
+/-- **Integrated nandao felicity**: the singleton presupposition
+(`alt Q = {p}`) together with the kernel-bias check on the witness. The
+witness `p` is supplied externally; for the noncomputable choice from a
+`SingletonQuestion` use `SingletonQuestion.witness`. -/
+def nandaoFullFelicity (Q : Question World) (k : Kernel World)
+    (u : List ((World → Prop))) (p : Set World) : Prop :=
   alt Q = {p} ∧ nandaoFelicitous k u p
 
-/-- **Layer-1 projection**: integrated felicity entails the §4
-    singleton presupposition. -/
+/-- Integrated felicity entails the singleton presupposition. -/
 theorem nandaoFullFelicity_isSingleton {Q : Question World} {k : Kernel World}
-    {u : Background World} {p : Set World} [DecidablePred p]
+    {u : List ((World → Prop))} {p : Set World}
     (h : nandaoFullFelicity Q k u p) :
     Question.IsSingleton Q :=
   ⟨p, h.1⟩
 
-/-- **Layer-2 projection**: integrated felicity entails the §2
-    Kernel-bias check on the witness. -/
+/-- Integrated felicity entails the kernel-bias check on the witness. -/
 theorem nandaoFullFelicity_kernel {Q : Question World} {k : Kernel World}
-    {u : Background World} {p : Set World} [DecidablePred p]
+    {u : List ((World → Prop))} {p : Set World}
     (h : nandaoFullFelicity Q k u p) :
     nandaoFelicitous k u p :=
   h.2
 
-/-- **Layer-1 obstruction**: a two-cell Hamblin polar `polar p₀` (with
-    non-trivial `p₀`) admits no integrated-felicity witness. No
-    Kernel + Background can rescue it: the §4 type-level barrier
-    propagates upward through the `alt Q = {p}` requirement. The
-    structural reason `polar` two-cell questions are universally
-    blocked from nandao licensing. -/
+/-- A two-cell Hamblin polar `polar p₀` (with non-trivial `p₀`) admits no
+integrated-felicity witness: no kernel and prior state can rescue it, because
+the singleton requirement `alt Q = {p}` already fails. -/
 theorem nandao_polar_no_witness {p₀ : Set World}
     (hne : p₀ ≠ ∅) (hnu : p₀ ≠ Set.univ)
-    (k : Kernel World) (u : Background World) :
-    ¬ ∃ (p : Set World) (_ : DecidablePred p),
-        nandaoFullFelicity (polar p₀) k u p := by
-  rintro ⟨p, _, hfull, _⟩
+    (k : Kernel World) (u : List ((World → Prop))) :
+    ¬ ∃ p : Set World, nandaoFullFelicity (polar p₀) k u p := by
+  rintro ⟨p, hfull, _⟩
   exact not_isSingleton_polar_of_nontrivial hne hnu ⟨p, hfull⟩
 
-/-- **Declarative reduction**: on a one-cell sister `ofSet p`,
-    integrated felicity is exactly the §2 Kernel-bias check on `p`.
-    The Layer-1 component holds trivially because `alt (ofSet p)
-    = {p}` (`alt_ofSet`). This makes the §2 ↔ §5 connection
-    explicit on the canonical felicitous case. -/
-theorem nandaoFullFelicity_declarative_iff {p : Set World} [DecidablePred p]
-    (k : Kernel World) (u : Background World) :
+/-- On a one-cell sister `ofSet p`, integrated felicity is exactly the
+kernel-bias check on `p`: the singleton component holds by `alt_ofSet`. -/
+theorem nandaoFullFelicity_declarative_iff {p : Set World}
+    (k : Kernel World) (u : List ((World → Prop))) :
     nandaoFullFelicity (Question.ofSet p) k u p ↔
       nandaoFelicitous k u p := by
   unfold nandaoFullFelicity
   rw [alt_ofSet]
-  exact ⟨fun h => h.2, fun h => ⟨rfl, h⟩⟩
+  exact ⟨λ h => h.2, λ h => ⟨rfl, h⟩⟩
 
--- ════════════════════════════════════════════════════════════════════════════
--- §6 — Empirical Closure: §1 datum (biasedUse) ↔ §5 integrated felicity
--- ════════════════════════════════════════════════════════════════════════════
-
-/-! Apply §5 to the canonical biased-use scenario from [zheng-2025] ex. 2:
-
-  - K = `[wearingRaincoat]` — direct evidence (B enters with dripping coat)
-  - U = `[expectDry]` — A's prior expectation it is not raining
-  - p = `isRaining` — the question content
-
-The Kernel-side bias check is `raincoat_nandao_felicitous` (proven in
-`Semantics/Modality/Kernel.lean` from explicit cardinality
-counts on `World4`). Pairing it with the singleton presupposition
-yields integrated felicity at the §5 level. The §1 datum `biasedUse`
-records the same scenario as empirical data (`evidentialBias = true`,
-`epistemicBias = true`, `felicitous = true`); the bridge below makes
-the data ↔ theory correspondence explicit. -/
-
-open Semantics.Modality (raincoatK dryU isRaining raincoat_nandao_felicitous)
-
-/-- **§1 ex. 2 ↔ §5 integrated felicity**: in the dripping-raincoat
-    scenario with sister `declarative isRaining`, both layers of nandao
-    felicity hold simultaneously. Reduces to `raincoat_nandao_felicitous`
-    via `nandaoFullFelicity_declarative_iff`. -/
+/-- In the dripping-raincoat scenario with sister `declarative isRaining`,
+both layers of nandao felicity hold simultaneously; reduces to
+`raincoat_nandao_felicitous` via `nandaoFullFelicity_declarative_iff`. The
+datum `biasedUse` records the same scenario ([zheng-2025] ex. 2) as
+empirical data. -/
 theorem biasedUse_integrated_felicity :
     nandaoFullFelicity (Question.ofSet isRaining) raincoatK dryU
       isRaining := by
   rw [nandaoFullFelicity_declarative_iff]
   exact raincoat_nandao_felicitous
-
-/-- **Data ↔ theory bridge**: the §1 datum `biasedUse` is felicitous and
-    has both bias profiles set; the §5 integrated felicity holds for the
-    matching Kernel scenario. The shared scaffold is the dripping-raincoat
-    setup of [zheng-2025] ex. 2 — empirical observation on the data
-    side, derived prediction on the theory side. -/
-theorem biasedUse_witnesses_integrated_felicity :
-    biasedUse.felicitous = true ∧
-    biasedUse.evidentialBias = true ∧
-    biasedUse.epistemicBias = true ∧
-    nandaoFullFelicity (Question.ofSet isRaining) raincoatK dryU
-      isRaining :=
-  ⟨rfl, rfl, rfl, biasedUse_integrated_felicity⟩
 
 end Zheng2025


### PR DESCRIPTION
Deep-audit follow-up for `Semantics/Modality/Kernel.lean`: the substrate keeps only the reusable kernel apparatus (Kernel, Implementation 1, kernelMust/Might/Cant, Kratzer bridges), now under the root `Modality` namespace with recurring binders lifted to `variable`; paper content moves to its study files.

- VFG2010 gains the worked model and Implementation 2 as a `Setoid` per the paper's own Def 7, replacing ~240 lines of noncomputable list-partition machinery; VFG2021 gains the can't dilemma; Zheng2025 absorbs the nandao felicity conditions (decidability-free via `Set.ncard`) and is rewritten in mathlib register; Cumming2026 imports it.
- Premise.lean gains the membership/duality lemmas the kernel proofs re-proved privately; vacuous rfl-bridges, dead code, stale TODOs, and `native_decide`s cut.
- Citation fixes against the paper: the settling section mis-cited Def 5 (that's the must semantics; settling is §7.1 Implementation 1), and the "Mastermind pp. 365–366" model is actually §7.1's worked kernel K = {P ∪ Q, W \ P} re-skinned.