### PR TITLE
refactor(Semantics/Modality): root Modality namespace; lift kernel binders

### DIFF
--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -23,7 +23,7 @@ this apparatus live in `Studies/Zheng2025.lean`.
 
 ## Main declarations
 
-- `Kernel`: a set of direct-information propositions, with `Kernel.base` (B_K),
+- `Kernel`: direct-information propositions with their modal base `B_K = ⋂K`,
   entailment (`Kernel.followsFrom`), and compatibility (`Kernel.compatibleWith`)
 - `directlySettlesExplicit`: Implementation 1 — some `X ∈ K` entails or
   excludes the prejacent
@@ -35,7 +35,7 @@ this apparatus live in `Studies/Zheng2025.lean`.
   `kernelMust` is Kratzer necessity over the induced modal base
 -/
 
-namespace Semantics.Modality
+namespace Modality
 
 open Semantics.Modality.Kratzer
 open Semantics.Presupposition
@@ -45,42 +45,44 @@ variable {W : Type*}
 
 /-! ### Kernel structure ([von-fintel-gillies-2010] Def 4) -/
 
-/-- A kernel: a set of direct-information propositions with B_K = ⋂K. -/
+/-- A kernel ([von-fintel-gillies-2010] Def 4): the set of direct-information
+    propositions `K`, determining the modal base `B_K = ⋂K` (`Kernel.base`). -/
 structure Kernel (W : Type*) where
-  props : List ((W → Prop))
+  /-- The direct-information propositions K. -/
+  props : List (W → Prop)
+
+variable (k : Kernel W) (φ : W → Prop) (w : W)
 
 namespace Kernel
 
-/-- B_K = ⋂K. -/
-def base (k : Kernel W) : Set W :=
+/-- The modal base determined by the kernel: B_K = ⋂K (Def 4(ii)). -/
+def base : Set W :=
   propIntersection k.props
 
 /-- Convert to a context-independent modal base. -/
-def toModalBase (k : Kernel W) : ModalBase W :=
+def toModalBase : ModalBase W :=
   λ _ => k.props
 
 /-- Consistency: B_K ≠ ∅. -/
-def isConsistent (k : Kernel W) : Prop :=
-  Kratzer.isConsistent k.props
+def isConsistent : Prop :=
+  Semantics.Modality.Kratzer.isConsistent k.props
 
 /-- φ follows from K iff B_K ⊆ ⟦φ⟧. -/
-def followsFrom (k : Kernel W) (φ : (W → Prop)) : Prop :=
-  Kratzer.followsFrom φ k.props
+def followsFrom : Prop :=
+  Semantics.Modality.Kratzer.followsFrom φ k.props
 
 /-- φ is compatible with K iff B_K ∩ ⟦φ⟧ ≠ ∅. -/
-def compatibleWith (k : Kernel W) (φ : (W → Prop)) : Prop :=
+def compatibleWith : Prop :=
   isCompatibleWith φ k.props
 
 /-- Induce an `EpistemicFlavor` for Kratzer modal evaluation. -/
-def toEpistemicFlavor (k : Kernel W) : EpistemicFlavor W where
+def toEpistemicFlavor : EpistemicFlavor W where
   evidence := k.toModalBase
   ordering := emptyBackground
 
-theorem followsFrom_iff (k : Kernel W) (φ : (W → Prop)) :
-    k.followsFrom φ ↔ ∀ w ∈ k.base, φ w := Iff.rfl
+theorem followsFrom_iff : k.followsFrom φ ↔ ∀ w ∈ k.base, φ w := Iff.rfl
 
-theorem compatibleWith_iff (k : Kernel W) (φ : (W → Prop)) :
-    k.compatibleWith φ ↔ ∃ w ∈ k.base, φ w :=
+theorem compatibleWith_iff : k.compatibleWith φ ↔ ∃ w ∈ k.base, φ w :=
   isCompatibleWith_iff_exists
 
 end Kernel
@@ -89,7 +91,7 @@ end Kernel
 
 /-- K directly settles P iff some X ∈ K entails P or is incompatible with P
 ([von-fintel-gillies-2010] Implementation 1, "Explicit Representation"). -/
-def directlySettlesExplicit (k : Kernel W) (φ : (W → Prop)) : Prop :=
+def directlySettlesExplicit : Prop :=
   ∃ x ∈ k.props,
     (∀ w ∈ propExtension x, φ w) ∨ (¬ ∃ w ∈ propExtension x, φ w)
 
@@ -97,17 +99,16 @@ def directlySettlesExplicit (k : Kernel W) (φ : (W → Prop)) : Prop :=
     B_K ⊆ ⟦¬φ⟧. If X ∈ K entails φ then B_K ⊆ X ⊆ ⟦φ⟧; if X excludes φ then
     B_K ⊆ X ⊆ ⟦¬φ⟧. The converse fails (see
     `VonFintelGillies2010.entailment_settling_gap`). -/
-theorem explicit_implies_entailment (k : Kernel W) (φ : (W → Prop))
-    (h : directlySettlesExplicit k φ) :
-    k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
+theorem explicit_implies_entailment (h : directlySettlesExplicit k φ) :
+    k.followsFrom φ ∨ k.followsFrom (λ w' => ¬ φ w') := by
   obtain ⟨x, hx_mem, h_ent | h_exc⟩ := h
-  · exact Or.inl λ w hw =>
-      h_ent w (propIntersection_subset_propExtension hx_mem hw)
-  · exact Or.inr λ w hw hφ =>
-      h_exc ⟨w, propIntersection_subset_propExtension hx_mem hw, hφ⟩
+  · exact Or.inl λ w' hw' =>
+      h_ent w' (propIntersection_subset_propExtension hx_mem hw')
+  · exact Or.inr λ w' hw' hφ =>
+      h_exc ⟨w', propIntersection_subset_propExtension hx_mem hw', hφ⟩
 
 /-- Settling is monotone: more propositions in K means more is settled. -/
-theorem settling_monotone (k : Kernel W) (p : (W → Prop)) (φ : (W → Prop))
+theorem settling_monotone (p : W → Prop)
     (hSettled : directlySettlesExplicit k φ) :
     directlySettlesExplicit ⟨p :: k.props⟩ φ := by
   obtain ⟨x, hx_mem, hx⟩ := hSettled
@@ -116,62 +117,60 @@ theorem settling_monotone (k : Kernel W) (p : (W → Prop)) (φ : (W → Prop))
 /-! ### Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
 /-- ⟦must φ⟧: presupposes K doesn't settle φ; asserts B_K ⊆ ⟦φ⟧. -/
-def kernelMust (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
+def kernelMust : PartialProp W where
   presup := λ _ => ¬ directlySettlesExplicit k φ
   assertion := λ _ => k.followsFrom φ
 
 /-- ⟦might φ⟧: presupposes K doesn't settle φ; asserts B_K ∩ ⟦φ⟧ ≠ ∅. -/
-def kernelMight (k : Kernel W) (φ : (W → Prop)) : PartialProp W where
+def kernelMight : PartialProp W where
   presup := λ _ => ¬ directlySettlesExplicit k φ
   assertion := λ _ => k.compatibleWith φ
 
 /-- ⟦can't φ⟧ = must(¬φ). -/
-def kernelCant (k : Kernel W) (φ : (W → Prop)) : PartialProp W :=
-  kernelMust k (λ w => ¬ φ w)
+def kernelCant : PartialProp W :=
+  kernelMust k (λ w' => ¬ φ w')
 
 /-! ### Core properties -/
 
 /-- T axiom: must φ entails φ when B_K is realistic (w ∈ B_K). -/
-theorem must_entails_prejacent (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hReal : w ∈ k.base)
+theorem must_entails_prejacent (hReal : w ∈ k.base)
     (_hDef : (kernelMust k φ).presup w)
     (hTrue : (kernelMust k φ).assertion w) :
     φ w :=
   hTrue hReal
 
 /-- Duality: might φ ↔ ¬(must ¬φ) in assertion content. -/
-theorem kernel_duality (k : Kernel W) (φ : (W → Prop)) (w : W) :
+theorem kernel_duality :
     (kernelMight k φ).assertion w ↔ ¬(kernelMust k (λ w' => ¬ φ w')).assertion w :=
   isCompatibleWith_iff_not_followsFrom_not
 
 /-- Empty kernel: nothing is settled, so must is always defined. -/
-theorem empty_kernel_always_defined (φ : (W → Prop)) (w : W) :
+theorem empty_kernel_always_defined :
     (kernelMust ⟨[]⟩ φ).presup w := by
   show ¬ directlySettlesExplicit _ _
   simp [directlySettlesExplicit]
 
 /-- Direct evidence infelicity: when K settles φ, must φ is undefined. -/
-theorem direct_evidence_infelicity (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hSettled : directlySettlesExplicit k φ) :
+theorem direct_evidence_infelicity (hSettled : directlySettlesExplicit k φ) :
     ¬(kernelMust k φ).presup w := by
   intro h; exact h hSettled
 
 /-! ### Bridge to Kratzer necessity -/
 
 /-- Kernel must assertion ↔ Kratzer simple necessity. -/
-theorem kernelMust_eq_simpleNecessity (k : Kernel W) (φ : (W → Prop)) (w : W) :
+theorem kernelMust_eq_simpleNecessity :
     (kernelMust k φ).assertion w ↔
       simpleNecessity k.toModalBase φ w := by
   show k.followsFrom φ ↔ _
-  simp only [Kernel.followsFrom, Kratzer.followsFrom,
+  simp only [Kernel.followsFrom, Semantics.Modality.Kratzer.followsFrom,
              simpleNecessity_iff_all, accessibleWorlds, Kernel.toModalBase]
   rfl
 
 /-- Kernel must assertion ↔ full Kratzer necessity with empty ordering. -/
-theorem kernelMust_eq_necessity (k : Kernel W) (φ : (W → Prop)) (w : W) :
+theorem kernelMust_eq_necessity :
     (kernelMust k φ).assertion w ↔
       necessity k.toModalBase emptyBackground φ w := by
   rw [kernelMust_eq_simpleNecessity]
   exact (necessity_empty_iff_simple k.toModalBase _ w).symm
 
-end Semantics.Modality
+end Modality

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -161,7 +161,7 @@ tense side is the nonfuture downstream constraint (T ≤ A). The
 witnesses both at once: the raincoat evidence is causally downstream of the
 rain, and the kernel `{wearingRaincoat}` does not settle `isRaining`. -/
 
-open Semantics.Modality
+open Modality
 open Intensional.Premise (propIntersection)
 open Zheng2025 (World wearingRaincoat isRaining raincoatK
   raincoat_nandao_felicitous)

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -151,7 +151,7 @@ Mastermind scenario (Pascal asking Mordecai *Must there be two reds?*):
 `P` = red-only, `Q` = blue, so `redOrBlue = P ∪ Q` and `notRed = W \ P`.
 `B_K = {w1}` entails *blue* without either kernel proposition settling it. -/
 
-open Semantics.Modality
+open Modality
 open Intensional.Premise
 
 /-- Four worlds: w0 = red, w1 = blue, w2 = green, w3 = unknown. -/
@@ -229,7 +229,7 @@ theorem mastermind_redOrBlue_settled :
 This gap makes the evidential presupposition non-trivial: must φ can be
 simultaneously defined and true. -/
 theorem entailment_settling_gap :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
+    ∃ (k : Kernel World) (φ : World → Prop),
       k.followsFrom φ ∧ ¬ directlySettlesExplicit k φ :=
   ⟨mastermindK, blue, mastermind_blue_follows, mastermind_blue_unsettled⟩
 
@@ -254,21 +254,21 @@ theorem indirectness_neq_weakness :
         rcases List.mem_singleton.mp hp with rfl; decide
     exact (by decide : ¬ blue World.w0) (h hw0)
 
-variable {W : Type*}
+variable {W : Type*} (k : Kernel W)
 
 /-- **Modus ponens with must** ([von-fintel-gillies-2010] Argument 4.3.1): the
 argument form "if φ, must ψ; φ; ∴ ψ" is valid under realistic B_K. -/
-theorem modus_ponens_with_must (k : Kernel W) (φ ψ : (W → Prop)) (w : W)
+theorem modus_ponens_with_must (φ ψ : W → Prop) (w : W)
     (hReal : w ∈ k.base)
     (_hDef : (kernelMust k ψ).presup w)
     (hCond : φ w → (kernelMust k ψ).assertion w)
     (hPhi : φ w) :
     ψ w :=
-  hCond hPhi hReal
+  Modality.must_entails_prejacent k ψ w hReal _hDef (hCond hPhi)
 
 /-- **Must-perhaps contradiction** ([von-fintel-gillies-2010] Argument 4.3.2):
 must φ ∧ might ¬φ is contradictory. When B_K ⊆ ⟦φ⟧, B_K ∩ ⟦¬φ⟧ = ∅. -/
-theorem must_perhaps_contradiction (k : Kernel W) (φ : (W → Prop)) (w : W)
+theorem must_perhaps_contradiction (φ : W → Prop) (w : W)
     (_hDef : (kernelMust k φ).presup w)
     (hMust : (kernelMust k φ).assertion w) :
     ¬(kernelMight k (λ w' => ¬ φ w')).assertion w := by
@@ -288,7 +288,7 @@ K directly settles P iff P is an issue in S_K. -/
 /-- The subject matter S_K determined by a kernel ([von-fintel-gillies-2010]
     Implementation 2(i)): worlds are equivalent iff they agree on every
     proposition in K. -/
-def subjectMatter (k : Kernel W) : Setoid W where
+def subjectMatter : Setoid W where
   r w v := ∀ p ∈ k.props, (p w ↔ p v)
   iseqv := ⟨λ _ _ _ => Iff.rfl, λ h p hp => (h p hp).symm,
     λ h h' p hp => (h p hp).trans (h' p hp)⟩
@@ -301,14 +301,14 @@ def IsIssue (s : Setoid W) (φ : W → Prop) : Prop :=
 
 /-- K settles P by partition ([von-fintel-gillies-2010] Implementation 2(ii)):
     P is an issue in S_K. -/
-def settlesByPartition (k : Kernel W) (φ : W → Prop) : Prop :=
+def settlesByPartition (φ : W → Prop) : Prop :=
   IsIssue (subjectMatter k) φ
 
 /-- Partition settling implies entailment: all worlds in B_K agree on every
     X ∈ K, so they are S_K-equivalent; if φ is an issue in S_K, B_K is
     φ-uniform. Both implementations therefore imply entailment (cf.
     `explicit_implies_entailment`); the converse fails for both. -/
-theorem partition_implies_entailment (k : Kernel W) (φ : (W → Prop))
+theorem partition_implies_entailment (φ : W → Prop)
     (h : settlesByPartition k φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
   rcases Set.eq_empty_or_nonempty k.base with hEmpty | ⟨w₀, hw₀⟩
@@ -343,7 +343,7 @@ private theorem not_settles_redOrBlue :
 /-- Counterexample (Impl 1 ↛ Impl 2): `K = {red}` settles `redOrBlue`
     explicitly (red ⊆ redOrBlue), but not by partition. -/
 theorem explicit_not_implies_partition :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
+    ∃ (k : Kernel World) (φ : World → Prop),
       directlySettlesExplicit k φ ∧ ¬ settlesByPartition k φ :=
   ⟨⟨[red]⟩, redOrBlue,
     ⟨red, by simp, Or.inl λ _ hw => Or.inl hw⟩, not_settles_redOrBlue⟩
@@ -353,7 +353,7 @@ theorem explicit_not_implies_partition :
     which jointly determine `blue` — but no single kernel proposition
     entails or excludes it. -/
 theorem partition_not_implies_explicit :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
+    ∃ (k : Kernel World) (φ : World → Prop),
       settlesByPartition k φ ∧ ¬ directlySettlesExplicit k φ := by
   refine ⟨mastermindK, blue, λ w v h => ?_, mastermind_blue_unsettled⟩
   have h1 := h redOrBlue (by simp [mastermindK])
@@ -365,7 +365,7 @@ theorem partition_not_implies_explicit :
     `redOrBlue` (B_K = {w0} ⊆ ⟦redOrBlue⟧) but does not settle it by
     partition. -/
 theorem entailment_not_implies_partition :
-    ∃ (k : Kernel World) (φ : (World → Prop)),
+    ∃ (k : Kernel World) (φ : World → Prop),
       k.followsFrom φ ∧ ¬ settlesByPartition k φ :=
   ⟨⟨[red]⟩, redOrBlue,
     λ w hw => Or.inl (mem_propIntersection.mp hw red (by simp)),

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -50,17 +50,16 @@ Kernel semantics resolves this: *can't φ* = *must*(¬φ) by definition
 (`kernelCant`), so Observation 4's evidential parallelism holds by
 construction, while the strong assertion B_K ⊆ ⟦¬φ⟧ delivers Observation 5. -/
 
-open Semantics.Modality
+open Modality
 open Intensional.Premise
 open VonFintelGillies2010 (World mastermindK redOrBlue notRed blue red notBlue
   mastermind_base)
 
-variable {W : Type*}
+variable {W : Type*} (k : Kernel W) (φ : W → Prop) (w : W)
 
 /-- **Can't–might exclusion** ([von-fintel-gillies-2021] Obs 5): when can't φ
 holds (B_K ⊆ ⟦¬φ⟧), might φ is false (B_K ∩ ⟦φ⟧ = ∅). -/
-theorem cant_might_exclusion (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hCant : (kernelCant k φ).assertion w) :
+theorem cant_might_exclusion (hCant : (kernelCant k φ).assertion w) :
     ¬(kernelMight k φ).assertion w := by
   intro hc
   obtain ⟨w', hw', hφ⟩ := (Kernel.compatibleWith_iff _ _).mp hc
@@ -68,8 +67,7 @@ theorem cant_might_exclusion (k : Kernel W) (φ : (W → Prop)) (w : W)
 
 /-- **Can't entails negation** ([von-fintel-gillies-2021] via S2): when B_K is
 realistic and can't φ is defined and true, ¬φ(w). -/
-theorem cant_entails_negation (k : Kernel W) (φ : (W → Prop)) (w : W)
-    (hReal : w ∈ k.base)
+theorem cant_entails_negation (hReal : w ∈ k.base)
     (_hDef : (kernelCant k φ).presup w)
     (hTrue : (kernelCant k φ).assertion w) :
     ¬ φ w :=

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -38,7 +38,7 @@ and the prejacent is not directly settled in K.
 
 namespace Zheng2025
 
-open Semantics.Modality (Kernel directlySettlesExplicit)
+open Modality (Kernel directlySettlesExplicit)
 open Intensional.Premise
 
 /-! ### Empirical data -/
@@ -199,23 +199,28 @@ otherwise). -/
 def evidenceRaises (p φ : W → Prop) : Prop :=
   {w | p w ∧ φ w}.ncard * Nat.card W > {w | φ w}.ncard * {w | p w}.ncard
 
+section
+variable (k : Kernel W)
+
 /-- Some proposition in K raises the probability of φ
 ([zheng-2025] condition (11i)). -/
-def evidenceSupports (k : Kernel W) (φ : W → Prop) : Prop :=
+def evidenceSupports (φ : W → Prop) : Prop :=
   ∃ p ∈ k.props, evidenceRaises p φ
 
 /-- The evidence in K is unexpected given the prior information state U
 ([zheng-2025] condition (11ii)): B_K ∩ ⋂U = ∅. U collects what leads to the
 information state prior to encountering the evidence — beliefs, norms,
 desires — distinct from the kernel's direct evidence. -/
-def unexpected (k : Kernel W) (u : List ((W → Prop))) : Prop :=
+def unexpected (u : List (W → Prop)) : Prop :=
   k.base ∩ propIntersection u = ∅
 
 /-- **Nandao-Q felicity** ([zheng-2025] condition (11), final version for
 polar questions): (i) some evidence in K raises P(φ), (ii) the evidence is
 unexpected given the prior state U, (iii) φ is not directly settled in K. -/
-def nandaoFelicitous (k : Kernel W) (u : List ((W → Prop))) (φ : W → Prop) : Prop :=
+def nandaoFelicitous (u : List (W → Prop)) (φ : W → Prop) : Prop :=
   evidenceSupports k φ ∧ unexpected k u ∧ ¬ directlySettlesExplicit k φ
+
+end
 
 /-! ### The dripping-raincoat scenario ([zheng-2025] exx. 2–3, 5)
 
@@ -241,7 +246,7 @@ abbrev isRaining : World → Prop := (· = .rain)
 def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
 
 /-- The prior information state: A expects dry weather. -/
-def dryU : List ((World → Prop)) := [expectDry]
+def dryU : List (World → Prop) := [expectDry]
 
 /-- "Nandao waimian xiayu-le ma?" is felicitous with a dripping raincoat:
 P(rain|coat) = 1/2 > P(rain) = 1/4; B_K ∩ ⋂U = ∅; rain unsettled by K. -/
@@ -306,8 +311,8 @@ def nandaoOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
 /-- `nandaoFelicitous` entails `evidenceSupports`, connecting the felicity
 predicate to `nandaoContextualEvidence` and the empirical generalization
 `evidential_bias_necessary`. -/
-theorem kernel_requires_evidence (k : Kernel World) (u : List ((World → Prop)))
-    (φ : (World → Prop)) (h : nandaoFelicitous k u φ) :
+theorem kernel_requires_evidence (k : Kernel World) (u : List (World → Prop))
+    (φ : World → Prop) (h : nandaoFelicitous k u φ) :
     evidenceSupports k φ :=
   h.1
 
@@ -372,19 +377,19 @@ failure (a non-trivial two-cell polar) blocks felicity regardless of
 witness `p` is supplied externally; for the noncomputable choice from a
 `SingletonQuestion` use `SingletonQuestion.witness`. -/
 def nandaoFullFelicity (Q : Question World) (k : Kernel World)
-    (u : List ((World → Prop))) (p : Set World) : Prop :=
+    (u : List (World → Prop)) (p : Set World) : Prop :=
   alt Q = {p} ∧ nandaoFelicitous k u p
 
 /-- Integrated felicity entails the singleton presupposition. -/
 theorem nandaoFullFelicity_isSingleton {Q : Question World} {k : Kernel World}
-    {u : List ((World → Prop))} {p : Set World}
+    {u : List (World → Prop)} {p : Set World}
     (h : nandaoFullFelicity Q k u p) :
     Question.IsSingleton Q :=
   ⟨p, h.1⟩
 
 /-- Integrated felicity entails the kernel-bias check on the witness. -/
 theorem nandaoFullFelicity_kernel {Q : Question World} {k : Kernel World}
-    {u : List ((World → Prop))} {p : Set World}
+    {u : List (World → Prop)} {p : Set World}
     (h : nandaoFullFelicity Q k u p) :
     nandaoFelicitous k u p :=
   h.2
@@ -394,7 +399,7 @@ integrated-felicity witness: no kernel and prior state can rescue it, because
 the singleton requirement `alt Q = {p}` already fails. -/
 theorem nandao_polar_no_witness {p₀ : Set World}
     (hne : p₀ ≠ ∅) (hnu : p₀ ≠ Set.univ)
-    (k : Kernel World) (u : List ((World → Prop))) :
+    (k : Kernel World) (u : List (World → Prop)) :
     ¬ ∃ p : Set World, nandaoFullFelicity (polar p₀) k u p := by
   rintro ⟨p, hfull, _⟩
   exact not_isSingleton_polar_of_nontrivial hne hnu ⟨p, hfull⟩
@@ -402,7 +407,7 @@ theorem nandao_polar_no_witness {p₀ : Set World}
 /-- On a one-cell sister `ofSet p`, integrated felicity is exactly the
 kernel-bias check on `p`: the singleton component holds by `alt_ofSet`. -/
 theorem nandaoFullFelicity_declarative_iff {p : Set World}
-    (k : Kernel World) (u : List ((World → Prop))) :
+    (k : Kernel World) (u : List (World → Prop)) :
     nandaoFullFelicity (Question.ofSet p) k u p ↔
       nandaoFelicitous k u p := by
   unfold nandaoFullFelicity


### PR DESCRIPTION
Re-lands the follow-up commit stranded on the #1843 branch after its squash-merge: `Kernel.lean` moves to the root `Modality` namespace (Kratzer files unchanged, rename candidates when next touched), recurring `(k : Kernel W) (φ : W → Prop) (w : W)` binders lift to `variable` blocks here and in the studies' generic sections, and consumers switch to `open Modality`.