### PR TITLE
style(Semantics/Modality): settling via Set lattice; Kernel.directlySettles

### DIFF
--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -31,8 +31,8 @@ this apparatus live in `Studies/Zheng2025.lean`.
   fails, which is what makes the presupposition non-trivial
 - `kernelMust`, `kernelMight`, `kernelCant`: the presuppositional operators
   (Defs 5–6), as `PartialProp`s
-- `kernelMust_eq_simpleNecessity`, `kernelMust_eq_necessity`: the assertion of
-  `kernelMust` is Kratzer necessity over the induced modal base
+- `kernelMust_iff_simpleNecessity`, `kernelMust_iff_necessity`: the assertion
+  of `kernelMust` is Kratzer necessity over the induced modal base
 -/
 
 namespace Modality
@@ -129,7 +129,6 @@ def kernelCant : PartialProp W :=
 
 /-- T axiom: must φ entails φ when B_K is realistic (w ∈ B_K). -/
 theorem must_entails_prejacent (hReal : w ∈ k.base)
-    (_hDef : (kernelMust k φ).presup w)
     (hTrue : (kernelMust k φ).assertion w) :
     φ w :=
   hTrue hReal
@@ -140,32 +139,20 @@ theorem kernel_duality :
   isCompatibleWith_iff_not_followsFrom_not
 
 /-- Empty kernel: nothing is settled, so must is always defined. -/
-theorem empty_kernel_always_defined :
-    (kernelMust ⟨[]⟩ φ).presup w := by
-  show ¬ Kernel.directlySettles _ _
-  simp [Kernel.directlySettles]
-
-/-- Direct evidence infelicity: when K settles φ, must φ is undefined. -/
-theorem direct_evidence_infelicity (hSettled : k.directlySettles φ) :
-    ¬(kernelMust k φ).presup w := by
-  intro h; exact h hSettled
+theorem empty_kernel_always_defined : (kernelMust ⟨[]⟩ φ).presup w :=
+  λ ⟨_, hx, _⟩ => List.not_mem_nil hx
 
 /-! ### Bridge to Kratzer necessity -/
 
 /-- Kernel must assertion ↔ Kratzer simple necessity. -/
-theorem kernelMust_eq_simpleNecessity :
-    (kernelMust k φ).assertion w ↔
-      simpleNecessity k.toModalBase φ w := by
-  show k.followsFrom φ ↔ _
-  simp only [Kernel.followsFrom, Semantics.Modality.Kratzer.followsFrom,
-             simpleNecessity_iff_all, accessibleWorlds, Kernel.toModalBase]
-  rfl
+theorem kernelMust_iff_simpleNecessity :
+    (kernelMust k φ).assertion w ↔ simpleNecessity k.toModalBase φ w :=
+  Iff.rfl
 
 /-- Kernel must assertion ↔ full Kratzer necessity with empty ordering. -/
-theorem kernelMust_eq_necessity :
-    (kernelMust k φ).assertion w ↔
-      necessity k.toModalBase emptyBackground φ w := by
-  rw [kernelMust_eq_simpleNecessity]
-  exact (necessity_empty_iff_simple k.toModalBase _ w).symm
+theorem kernelMust_iff_necessity :
+    (kernelMust k φ).assertion w ↔ necessity k.toModalBase emptyBackground φ w :=
+  (kernelMust_iff_simpleNecessity k φ w).trans
+    (necessity_empty_iff_simple k.toModalBase φ w).symm
 
 end Modality

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -25,7 +25,7 @@ this apparatus live in `Studies/Zheng2025.lean`.
 
 - `Kernel`: direct-information propositions with their modal base `B_K = ⋂K`,
   entailment (`Kernel.followsFrom`), and compatibility (`Kernel.compatibleWith`)
-- `directlySettlesExplicit`: Implementation 1 — some `X ∈ K` entails or
+- `Kernel.directlySettles`: Implementation 1 — some `X ∈ K` entails or
   excludes the prejacent
 - `explicit_implies_entailment`: settling implies entailment; the converse
   fails, which is what makes the presupposition non-trivial
@@ -89,41 +89,41 @@ end Kernel
 
 /-! ### Settling ([von-fintel-gillies-2010] §7.1, Implementation 1) -/
 
-/-- K directly settles P iff some X ∈ K entails P or is incompatible with P
-([von-fintel-gillies-2010] Implementation 1, "Explicit Representation"). -/
-def directlySettlesExplicit : Prop :=
+/-- K directly settles P iff some X ∈ K entails P or is incompatible with P:
+`X ⊆ ⟦φ⟧` or `X ∩ ⟦φ⟧ = ∅` ([von-fintel-gillies-2010] Implementation 1, the
+"Explicit Representation"; the rival partition implementation is
+`VonFintelGillies2010.settlesByPartition`). -/
+def Kernel.directlySettles : Prop :=
   ∃ x ∈ k.props,
-    (∀ w ∈ propExtension x, φ w) ∨ (¬ ∃ w ∈ propExtension x, φ w)
+    propExtension x ⊆ propExtension φ ∨ Disjoint (propExtension x) (propExtension φ)
 
 /-- Settling implies entailment: if K directly settles φ, then B_K ⊆ ⟦φ⟧ or
-    B_K ⊆ ⟦¬φ⟧. If X ∈ K entails φ then B_K ⊆ X ⊆ ⟦φ⟧; if X excludes φ then
-    B_K ⊆ X ⊆ ⟦¬φ⟧. The converse fails (see
-    `VonFintelGillies2010.entailment_settling_gap`). -/
-theorem explicit_implies_entailment (h : directlySettlesExplicit k φ) :
+    B_K ⊆ ⟦¬φ⟧, since B_K ⊆ X for the settling X ∈ K. The converse fails
+    (see `VonFintelGillies2010.entailment_settling_gap`). -/
+theorem explicit_implies_entailment (h : k.directlySettles φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w' => ¬ φ w') := by
-  obtain ⟨x, hx_mem, h_ent | h_exc⟩ := h
-  · exact Or.inl λ w' hw' =>
-      h_ent w' (propIntersection_subset_propExtension hx_mem hw')
-  · exact Or.inr λ w' hw' hφ =>
-      h_exc ⟨w', propIntersection_subset_propExtension hx_mem hw', hφ⟩
+  obtain ⟨x, hx_mem, h_sub | h_disj⟩ := h
+  · exact Or.inl ((propIntersection_subset_propExtension hx_mem).trans h_sub)
+  · exact Or.inr ((propIntersection_subset_propExtension hx_mem).trans
+      h_disj.subset_compl_right)
 
-/-- Settling is monotone: more propositions in K means more is settled. -/
-theorem settling_monotone (p : W → Prop)
-    (hSettled : directlySettlesExplicit k φ) :
-    directlySettlesExplicit ⟨p :: k.props⟩ φ := by
-  obtain ⟨x, hx_mem, hx⟩ := hSettled
-  exact ⟨x, List.mem_cons_of_mem _ hx_mem, hx⟩
+/-- Settling is monotone: a larger kernel settles everything a smaller one
+    does. -/
+theorem Kernel.directlySettles_mono {k' : Kernel W} (hk : k.props ⊆ k'.props)
+    (h : k.directlySettles φ) :
+    k'.directlySettles φ :=
+  h.imp λ _ ⟨hm, hx⟩ => ⟨hk hm, hx⟩
 
 /-! ### Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
 /-- ⟦must φ⟧: presupposes K doesn't settle φ; asserts B_K ⊆ ⟦φ⟧. -/
 def kernelMust : PartialProp W where
-  presup := λ _ => ¬ directlySettlesExplicit k φ
+  presup := λ _ => ¬ k.directlySettles φ
   assertion := λ _ => k.followsFrom φ
 
 /-- ⟦might φ⟧: presupposes K doesn't settle φ; asserts B_K ∩ ⟦φ⟧ ≠ ∅. -/
 def kernelMight : PartialProp W where
-  presup := λ _ => ¬ directlySettlesExplicit k φ
+  presup := λ _ => ¬ k.directlySettles φ
   assertion := λ _ => k.compatibleWith φ
 
 /-- ⟦can't φ⟧ = must(¬φ). -/
@@ -147,11 +147,11 @@ theorem kernel_duality :
 /-- Empty kernel: nothing is settled, so must is always defined. -/
 theorem empty_kernel_always_defined :
     (kernelMust ⟨[]⟩ φ).presup w := by
-  show ¬ directlySettlesExplicit _ _
-  simp [directlySettlesExplicit]
+  show ¬ Kernel.directlySettles _ _
+  simp [Kernel.directlySettles]
 
 /-- Direct evidence infelicity: when K settles φ, must φ is undefined. -/
-theorem direct_evidence_infelicity (hSettled : directlySettlesExplicit k φ) :
+theorem direct_evidence_infelicity (hSettled : k.directlySettles φ) :
     ¬(kernelMust k φ).presup w := by
   intro h; exact h hSettled
 

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -89,10 +89,7 @@ end Kernel
 
 /-! ### Settling ([von-fintel-gillies-2010] §7.1, Implementation 1) -/
 
-/-- K directly settles P iff some X ∈ K entails P or is incompatible with P:
-`X ⊆ ⟦φ⟧` or `X ∩ ⟦φ⟧ = ∅` ([von-fintel-gillies-2010] Implementation 1, the
-"Explicit Representation"; the rival partition implementation is
-`VonFintelGillies2010.settlesByPartition`). -/
+/-- K directly settles P iff some X ∈ K entails P or is incompatible with P. -/
 def Kernel.directlySettles : Prop :=
   ∃ x ∈ k.props,
     propExtension x ⊆ propExtension φ ∨ Disjoint (propExtension x) (propExtension φ)

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -104,8 +104,6 @@ theorem explicit_implies_entailment (h : k.directlySettles φ) :
   · exact Or.inr ((propIntersection_subset_propExtension hx_mem).trans
       h_disj.subset_compl_right)
 
-/-- Settling is monotone: a larger kernel settles everything a smaller one
-    does. -/
 theorem Kernel.directlySettles_mono {k' : Kernel W} (hk : k.props ⊆ k'.props)
     (h : k.directlySettles φ) :
     k'.directlySettles φ :=

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -45,8 +45,8 @@ variable {W : Type*}
 
 /-! ### Kernel structure ([von-fintel-gillies-2010] Def 4) -/
 
-/-- A kernel ([von-fintel-gillies-2010] Def 4): the set of direct-information
-    propositions `K`, determining the modal base `B_K = ⋂K` (`Kernel.base`). -/
+/-- A *kernel* is a set of direct-information propositions, determining the
+    modal base `B_K = ⋂K` ([von-fintel-gillies-2010] Def 4). -/
 structure Kernel (W : Type*) where
   /-- The direct-information propositions K. -/
   props : List (W → Prop)
@@ -55,27 +55,27 @@ variable (k : Kernel W) (φ : W → Prop) (w : W)
 
 namespace Kernel
 
-/-- The modal base determined by the kernel: B_K = ⋂K (Def 4(ii)). -/
+/-- The modal base `B_K = ⋂K` determined by the kernel. -/
 def base : Set W :=
   propIntersection k.props
 
-/-- Convert to a context-independent modal base. -/
+/-- The kernel as a context-independent modal base. -/
 def toModalBase : ModalBase W :=
   λ _ => k.props
 
-/-- Consistency: B_K ≠ ∅. -/
+/-- `K` is consistent iff `B_K ≠ ∅`. -/
 def isConsistent : Prop :=
   Semantics.Modality.Kratzer.isConsistent k.props
 
-/-- φ follows from K iff B_K ⊆ ⟦φ⟧. -/
+/-- `φ` follows from `K` iff `B_K ⊆ ⟦φ⟧`. -/
 def followsFrom : Prop :=
   Semantics.Modality.Kratzer.followsFrom φ k.props
 
-/-- φ is compatible with K iff B_K ∩ ⟦φ⟧ ≠ ∅. -/
+/-- `φ` is compatible with `K` iff `B_K ∩ ⟦φ⟧ ≠ ∅`. -/
 def compatibleWith : Prop :=
   isCompatibleWith φ k.props
 
-/-- Induce an `EpistemicFlavor` for Kratzer modal evaluation. -/
+/-- The `EpistemicFlavor` with the kernel's modal base and empty ordering. -/
 def toEpistemicFlavor : EpistemicFlavor W where
   evidence := k.toModalBase
   ordering := emptyBackground
@@ -94,9 +94,8 @@ def Kernel.directlySettles : Prop :=
   ∃ x ∈ k.props,
     propExtension x ⊆ propExtension φ ∨ Disjoint (propExtension x) (propExtension φ)
 
-/-- Settling implies entailment: if K directly settles φ, then B_K ⊆ ⟦φ⟧ or
-    B_K ⊆ ⟦¬φ⟧, since B_K ⊆ X for the settling X ∈ K. The converse fails
-    (see `VonFintelGillies2010.entailment_settling_gap`). -/
+/-- If `K` directly settles `φ` then `B_K ⊆ ⟦φ⟧` or `B_K ⊆ ⟦¬φ⟧`; the
+    converse fails (see `VonFintelGillies2010.entailment_settling_gap`). -/
 theorem explicit_implies_entailment (h : k.directlySettles φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w' => ¬ φ w') := by
   obtain ⟨x, hx_mem, h_sub | h_disj⟩ := h
@@ -111,45 +110,49 @@ theorem Kernel.directlySettles_mono {k' : Kernel W} (hk : k.props ⊆ k'.props)
 
 /-! ### Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
-/-- ⟦must φ⟧: presupposes K doesn't settle φ; asserts B_K ⊆ ⟦φ⟧. -/
+/-- `⟦must φ⟧` presupposes that `K` does not directly settle `φ` and asserts
+    `B_K ⊆ ⟦φ⟧`. -/
 def kernelMust : PartialProp W where
   presup := λ _ => ¬ k.directlySettles φ
   assertion := λ _ => k.followsFrom φ
 
-/-- ⟦might φ⟧: presupposes K doesn't settle φ; asserts B_K ∩ ⟦φ⟧ ≠ ∅. -/
+/-- `⟦might φ⟧` presupposes that `K` does not directly settle `φ` and asserts
+    `B_K ∩ ⟦φ⟧ ≠ ∅`. -/
 def kernelMight : PartialProp W where
   presup := λ _ => ¬ k.directlySettles φ
   assertion := λ _ => k.compatibleWith φ
 
-/-- ⟦can't φ⟧ = must(¬φ). -/
+/-- `⟦can't φ⟧` is `⟦must ¬φ⟧`. -/
 def kernelCant : PartialProp W :=
   kernelMust k (λ w' => ¬ φ w')
 
 /-! ### Core properties -/
 
-/-- T axiom: must φ entails φ when B_K is realistic (w ∈ B_K). -/
+/-- Must `φ` entails `φ` when `B_K` is realistic (the T axiom). -/
 theorem must_entails_prejacent (hReal : w ∈ k.base)
     (hTrue : (kernelMust k φ).assertion w) :
     φ w :=
   hTrue hReal
 
-/-- Duality: might φ ↔ ¬(must ¬φ) in assertion content. -/
+/-- Might `φ` and `¬must ¬φ` have the same assertion content. -/
 theorem kernel_duality :
     (kernelMight k φ).assertion w ↔ ¬(kernelMust k (λ w' => ¬ φ w')).assertion w :=
   isCompatibleWith_iff_not_followsFrom_not
 
-/-- Empty kernel: nothing is settled, so must is always defined. -/
+/-- The empty kernel settles nothing, so must is always defined. -/
 theorem empty_kernel_always_defined : (kernelMust ⟨[]⟩ φ).presup w :=
   λ ⟨_, hx, _⟩ => List.not_mem_nil hx
 
 /-! ### Bridge to Kratzer necessity -/
 
-/-- Kernel must assertion ↔ Kratzer simple necessity. -/
+/-- The assertion of kernel must is Kratzer simple necessity over the induced
+    modal base. -/
 theorem kernelMust_iff_simpleNecessity :
     (kernelMust k φ).assertion w ↔ simpleNecessity k.toModalBase φ w :=
   Iff.rfl
 
-/-- Kernel must assertion ↔ full Kratzer necessity with empty ordering. -/
+/-- The assertion of kernel must is Kratzer necessity with the empty ordering
+    source. -/
 theorem kernelMust_iff_necessity :
     (kernelMust k φ).assertion w ↔ necessity k.toModalBase emptyBackground φ w :=
   (kernelMust_iff_simpleNecessity k φ w).trans

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -183,7 +183,7 @@ theorem raincoat_downstream : downstreamEvidence raincoatFrame := by
 /-- The raincoat kernel doesn't settle isRaining — the third conjunct of
     [zheng-2025]'s nandao-felicity theorem. -/
 theorem raincoat_not_settled :
-    ¬ directlySettlesExplicit raincoatK isRaining :=
+    ¬ raincoatK.directlySettles isRaining :=
   raincoat_nandao_felicitous.2.2
 
 /-- **Downstream implies must-defined**: in the raincoat scenario, downstream
@@ -210,16 +210,15 @@ theorem tense_modal_evidential_parallel :
   exact (by decide : ¬ isRaining World.sprinkler) (hAll hw1)
 
 private theorem isRaining_settles_isRaining :
-    directlySettlesExplicit (⟨[isRaining]⟩ : Kernel World) isRaining := by
-  refine ⟨isRaining, by simp, Or.inl ?_⟩
-  intro w hw; exact hw
+    (⟨[isRaining]⟩ : Kernel World).directlySettles isRaining :=
+  ⟨isRaining, by simp, Or.inl subset_rfl⟩
 
 /-- **Direct evidence blocks both**: when evidence is direct, the kernel
     settles the prejacent → `kernelMust` is undefined and downstream is
     trivially satisfied (T = A). Speaker uses bare assertion, not `must`. -/
 theorem direct_evidence_blocks_both :
     let directK : Kernel World := ⟨[isRaining]⟩
-    directlySettlesExplicit directK isRaining ∧
+    directK.directlySettles isRaining ∧
     ¬(kernelMust directK isRaining).presup World.rain ∧
     let directFrame : EvidentialFrame ℤ :=
       { speechTime := 0, perspectiveTime := 0, referenceTime := 0,
@@ -242,7 +241,7 @@ theorem strong_assertion_settles :
     strongAssertion.source = .direct ∧
     strongAssertion.authority = .ego ∧
     let directK : Kernel World := ⟨[isRaining]⟩
-    directlySettlesExplicit directK isRaining :=
+    directK.directlySettles isRaining :=
   ⟨rfl, rfl, isRaining_settles_isRaining⟩
 
 /-- Inferential claims (nonparticipant + inference) correspond to
@@ -251,7 +250,7 @@ theorem strong_assertion_settles :
 theorem inferential_claim_must_profile :
     inferentialClaim.source = .inference ∧
     inferentialClaim.authority = .nonparticipant ∧
-    ¬ directlySettlesExplicit raincoatK isRaining ∧
+    ¬ raincoatK.directlySettles isRaining ∧
     (kernelMust raincoatK isRaining).presup World.rain :=
   ⟨rfl, rfl, raincoat_not_settled, raincoat_not_settled⟩
 

--- a/Linglib/Studies/Cumming2026.lean
+++ b/Linglib/Studies/Cumming2026.lean
@@ -75,9 +75,8 @@ theorem nfutL_nonfuture : nfutL.IsNonfuture := by decide
 
 /-! ### Master downstream theorem -/
 
-/-- **Generic nonfuture downstream**: any paradigm entry
-    whose EP constraint is nonfuture entails T ≤ A (downstream evidence).
-    Delegates to `EPCondition.nonfuture_implies_downstream`. -/
+/-- Any paradigm entry whose EP constraint is nonfuture entails T ≤ A
+    (downstream evidence). -/
 theorem nonfuture_downstream (p : TAMEEntry) (f : EvidentialFrame ℤ)
     (h_nf : p.IsNonfuture) (h_ep : p.epConstraint f) :
     downstreamEvidence f :=
@@ -133,10 +132,10 @@ theorem future_no_downstream :
 
 /-! ### Korean EP/UP factorization -/
 
-/-- **-te and -ney factorize EP from UP** ([cumming-2026], tables (18)–(19)):
-    the two present-tense evidentials impose the same EP constraint (T = A)
-    but different UP constraints (-te: T < S; -ney: T = S), witnessed in
-    both directions. EP and UP vary independently in the morphology. -/
+/-- The two present-tense evidentials impose the same EP constraint (T = A)
+    but different UP constraints (-te: T < S; -ney: T = S), witnessed in both
+    directions: EP and UP vary independently in the morphology
+    ([cumming-2026], tables (18)–(19)). -/
 theorem korean_te_ney_up_diverge :
     tePresent.ep = neyPresent.ep ∧
     (∃ f : EvidentialFrame ℤ,
@@ -186,17 +185,17 @@ theorem raincoat_not_settled :
     ¬ raincoatK.directlySettles isRaining :=
   raincoat_nandao_felicitous.2.2
 
-/-- **Downstream implies must-defined**: in the raincoat scenario, downstream
-    evidence (T ≤ A) co-occurs with the kernel not settling the prejacent. -/
+/-- In the raincoat scenario, downstream evidence (T ≤ A) co-occurs with the
+    kernel not settling the prejacent. -/
 theorem downstream_implies_must_defined :
     downstreamEvidence raincoatFrame ∧
     (kernelMust raincoatK isRaining).presup World.rain :=
   ⟨raincoat_downstream, raincoat_not_settled⟩
 
-/-- **Tense-modal evidential parallel**: both Cumming's nonfuture constraint
-    and VF&G's `kernelMust` presupposition hold simultaneously for the same
-    scenario. The raincoat evidence is downstream (T ≤ A) AND the kernel
-    doesn't settle isRaining. -/
+/-- Both Cumming's nonfuture constraint and VF&G's `kernelMust`
+    presupposition hold simultaneously for the same scenario: the raincoat
+    evidence is downstream (T ≤ A) and the kernel does not settle
+    `isRaining`. -/
 theorem tense_modal_evidential_parallel :
     downstreamEvidence raincoatFrame ∧
     (kernelMust raincoatK isRaining).presup World.rain ∧
@@ -213,9 +212,9 @@ private theorem isRaining_settles_isRaining :
     (⟨[isRaining]⟩ : Kernel World).directlySettles isRaining :=
   ⟨isRaining, by simp, Or.inl subset_rfl⟩
 
-/-- **Direct evidence blocks both**: when evidence is direct, the kernel
-    settles the prejacent → `kernelMust` is undefined and downstream is
-    trivially satisfied (T = A). Speaker uses bare assertion, not `must`. -/
+/-- When evidence is direct, the kernel settles the prejacent — `kernelMust`
+    is undefined — and downstream is trivially satisfied (T = A); the speaker
+    uses bare assertion, not *must*. -/
 theorem direct_evidence_blocks_both :
     let directK : Kernel World := ⟨[isRaining]⟩
     directK.directlySettles isRaining ∧

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -57,9 +57,9 @@ inductive EvidenceType where
   | elimination
   deriving Repr, DecidableEq, Inhabited
 
-/-- Collapse to the Aikhenvald taxonomy. Elimination reasoning is
-    inference, not direct access: the kernel does not directly settle the
-    prejacent — which is why elimination licenses *must* (VF&G ex. 12). -/
+/-- The collapse onto the Aikhenvald taxonomy. Elimination reasoning is
+    inference, not direct access — which is why elimination licenses *must*
+    (VF&G ex. 12). -/
 def EvidenceType.toCoarseSource : EvidenceType → CoarseSource
   | .direct => .direct
   | .indirect => .inference
@@ -78,8 +78,7 @@ theorem all_evidence_types_nonfuture (e : EvidenceType) :
 
 /-! ### Adapters over the example rows -/
 
-/-- Evidence-type adapter: the row's `evidence` feature as an
-    `EvidenceType`. -/
+/-- The row's `evidence` feature as an `EvidenceType`. -/
 def evidenceOf (row : LinguisticExample) : Option EvidenceType :=
   match row.feature? "evidence" with
   | some "direct" => some .direct
@@ -94,30 +93,28 @@ def mustPairs : List LinguisticExample :=
 
 /-! ### The evidential restriction -/
 
-/-- **Evidential restriction**: a *must*/*can't* sentence is felicitous
-    iff the speaker's evidence source `IsIndirect`. Direct perception
-    (exx. 6, 23) blocks the modal; inference — causal (exx. 7, 21, 24, 26)
-    or by elimination (ex. 12) — licenses it. -/
+/-- A *must* or *can't* sentence is felicitous iff the speaker's evidence
+    source `IsIndirect`: direct perception (exx. 6, 23) blocks the modal;
+    inference — causal (exx. 7, 21, 24, 26) or by elimination (ex. 12) —
+    licenses it. -/
 theorem must_felicitous_iff_indirect :
     ∀ row ∈ mustPairs,
       row.judgment = .acceptable ↔
         ∀ e ∈ evidenceOf row, e.toCoarseSource.IsIndirect := by
   decide
 
-/-- **Can't patterns with must**: the evidential restriction holds
-    uniformly on the negative-modal rows (exx. 21, 23, 24) — *can't*
-    groups with *must*, not with weak modals. -/
+/-- The evidential restriction holds uniformly on the negative-modal rows
+    (exx. 21, 23, 24): *can't* groups with *must*, not with weak modals. -/
 theorem cant_patterns_with_must :
     ∀ row ∈ mustPairs.filter (·.feature? "modal" == some "cant"),
       row.judgment = .acceptable ↔
         ∀ e ∈ evidenceOf row, e.toCoarseSource.IsIndirect :=
   fun row hrow => must_felicitous_iff_indirect row (List.mem_filter.mp hrow).1
 
-/-- ***Must* imposes [izvorski-1997]'s EV restriction**: felicity of the
-    modalized member tracks `CoarseSource.IsIndirect` of the evidence
-    source in VF&G's *must* rows exactly as in Izvorski's Bulgarian EV
-    paradigm — the two epistemic operators presuppose the same coarse
-    indirect-evidence basis. -/
+/-- Felicity of the modalized member tracks `CoarseSource.IsIndirect` in
+    VF&G's *must* rows exactly as in [izvorski-1997]'s Bulgarian EV paradigm:
+    the two epistemic operators presuppose the same coarse indirect-evidence
+    basis. -/
 theorem must_evidence_matches_izvorski_ev :
     (∀ row ∈ mustPairs,
       row.judgment = .acceptable ↔
@@ -127,12 +124,10 @@ theorem must_evidence_matches_izvorski_ev :
 
 /-! ### Must is strong -/
 
-/-- **Must is strong**: every minimal pair records that the modalized
-    sentence entails its prejacent — including the direct-evidence rows
-    where the modal is infelicitous. The restriction is evidential, not a
-    weakening of content. The supporting inference rows (modus ponens is
-    valid, *must φ ∧ perhaps ¬φ* is contradictory, retraction fails) are
-    in the same JSON under `kind = inference`. -/
+/-- Every minimal pair records that the modalized sentence entails its
+    prejacent, including the direct-evidence rows where the modal is
+    infelicitous: the restriction is evidential, not a weakening of
+    content. -/
 theorem must_entails_prejacent :
     ∀ row ∈ mustPairs, row.feature? "must_entails_prejacent" = some "true" := by
   decide
@@ -154,24 +149,24 @@ Mastermind scenario (Pascal asking Mordecai *Must there be two reds?*):
 open Modality
 open Intensional.Premise
 
-/-- Four worlds: w0 = red, w1 = blue, w2 = green, w3 = unknown. -/
+/-- Four worlds, with `w0` red, `w1` blue, `w2` green, and `w3` unknown. -/
 inductive World where
   | w0 | w1 | w2 | w3
   deriving DecidableEq, Repr, Inhabited
 
-/-- ⟦red or blue⟧ = {w0, w1}: the paper's `P ∪ Q`. -/
+/-- `⟦red or blue⟧ = {w0, w1}`, the paper's `P ∪ Q`. -/
 abbrev redOrBlue : World → Prop := λ w => w = .w0 ∨ w = .w1
 
-/-- ⟦not red⟧ = {w1, w2, w3}: the paper's `W \ P`. -/
+/-- `⟦not red⟧ = {w1, w2, w3}`, the paper's `W \ P`. -/
 abbrev notRed : World → Prop := (· ≠ .w0)
 
-/-- ⟦blue⟧ = {w1}: the paper's `Q`. -/
+/-- `⟦blue⟧ = {w1}`, the paper's `Q`. -/
 abbrev blue : World → Prop := (· = .w1)
 
-/-- ⟦red⟧ = {w0}: the paper's `P`. -/
+/-- `⟦red⟧ = {w0}`, the paper's `P`. -/
 abbrev red : World → Prop := (· = .w0)
 
-/-- ⟦not blue⟧ (used by the [von-fintel-gillies-2021] can't dilemma). -/
+/-- `⟦not blue⟧`, used by the [von-fintel-gillies-2021] can't dilemma. -/
 abbrev notBlue : World → Prop := (· ≠ .w1)
 
 /-- The §7.1 kernel `{P ∪ Q, W \ P}` in Mastermind colors. -/
@@ -227,16 +222,15 @@ theorem mastermind_redOrBlue_settled :
 
 /-! ### Deep theorems -/
 
-/-- **Entailment-settling gap**: B_K can entail φ without K settling it.
-This gap makes the evidential presupposition non-trivial: must φ can be
+/-- `B_K` can entail `φ` without `K` directly settling it, so must `φ` can be
 simultaneously defined and true. -/
 theorem entailment_settling_gap :
     ∃ (k : Kernel World) (φ : World → Prop),
       k.followsFrom φ ∧ ¬ k.directlySettles φ :=
   ⟨mastermindK, blue, mastermind_blue_follows, mastermind_blue_unsettled⟩
 
-/-- **Indirectness ≠ weakness** (§4.1): three independent cases show
-indirectness and assertion strength are orthogonal dimensions. -/
+/-- Indirectness and assertion strength are orthogonal dimensions: must can
+be defined and true, undefined, or defined and false (§4.1). -/
 theorem indirectness_neq_weakness :
     ((kernelMust mastermindK blue).presup .w0 ∧
      (kernelMust mastermindK blue).assertion .w0) ∧
@@ -260,8 +254,8 @@ theorem indirectness_neq_weakness :
 
 variable {W : Type*} (k : Kernel W)
 
-/-- **Modus ponens with must** ([von-fintel-gillies-2010] Argument 4.3.1): the
-argument form "if φ, must ψ; φ; ∴ ψ" is valid under realistic B_K. -/
+/-- The argument form "if φ, must ψ; φ; therefore ψ" is valid under realistic
+`B_K` ([von-fintel-gillies-2010] Argument 4.3.1). -/
 theorem modus_ponens_with_must (φ ψ : W → Prop) (w : W)
     (hReal : w ∈ k.base)
     (hCond : φ w → (kernelMust k ψ).assertion w)
@@ -269,8 +263,8 @@ theorem modus_ponens_with_must (φ ψ : W → Prop) (w : W)
     ψ w :=
   Modality.must_entails_prejacent k ψ w hReal (hCond hPhi)
 
-/-- **Must-perhaps contradiction** ([von-fintel-gillies-2010] Argument 4.3.2):
-must φ ∧ might ¬φ is contradictory. When B_K ⊆ ⟦φ⟧, B_K ∩ ⟦¬φ⟧ = ∅. -/
+/-- Must `φ` and might `¬φ` are jointly contradictory
+([von-fintel-gillies-2010] Argument 4.3.2). -/
 theorem must_perhaps_contradiction (φ : W → Prop) (w : W)
     (hMust : (kernelMust k φ).assertion w) :
     ¬(kernelMight k (λ w' => ¬ φ w')).assertion w := by
@@ -287,32 +281,29 @@ the pairs of `S` that agree on `P`, and `P` is an *issue* in `S` iff
 equivalently, the relation "agrees on every `X ∈ K`". Implementation 2:
 K directly settles P iff P is an issue in S_K. -/
 
-/-- The subject matter S_K determined by a kernel: worlds are equivalent iff
-    they agree on every proposition in K. -/
+/-- The subject matter `S_K` of a kernel, relating worlds that agree on every
+    proposition in `K`. -/
 def subjectMatter : Setoid W where
   r w v := ∀ p ∈ k.props, (p w ↔ p v)
   iseqv := ⟨λ _ _ _ => Iff.rfl, λ h p hp => (h p hp).symm,
     λ h h' p hp => (h p hp).trans (h' p hp)⟩
 
-/-- `P` is an **issue** in a subject matter `S`: `S`-equivalent worlds never
+/-- `P` is an *issue* in a subject matter `S`: `S`-equivalent worlds never
     disagree on `P`. -/
 def IsIssue (s : Setoid W) (φ : W → Prop) : Prop :=
   ∀ w v, s.r w v → (φ w ↔ φ v)
 
-/-- K settles P by partition iff P is an issue in S_K. -/
+/-- `K` settles `P` by partition iff `P` is an issue in `S_K`. -/
 def settlesByPartition (φ : W → Prop) : Prop :=
   IsIssue (subjectMatter k) φ
 
-/-- B_K lies in a single cell of the subject matter: worlds in the base
-    satisfy every kernel proposition, so they agree on all of them. -/
+/-- `B_K` lies in a single cell of the subject matter. -/
 theorem subjectMatter_rel_base {v w : W} (hv : v ∈ k.base) (hw : w ∈ k.base) :
     (subjectMatter k).r v w := λ p hp =>
   iff_of_true (mem_propIntersection.mp hv p hp) (mem_propIntersection.mp hw p hp)
 
-/-- Partition settling implies entailment: B_K lies in a single S_K-cell
-    (`subjectMatter_rel_base`), so an issue is uniform on it. Both
-    implementations therefore imply entailment (cf.
-    `explicit_implies_entailment`); the converse fails for both. -/
+/-- If `K` settles `φ` by partition then `B_K ⊆ ⟦φ⟧` or `B_K ⊆ ⟦¬φ⟧`; as
+    with `explicit_implies_entailment`, the converse fails. -/
 theorem partition_implies_entailment (φ : W → Prop)
     (h : settlesByPartition k φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
@@ -330,7 +321,7 @@ on `P` that disagree on `P ∪ Q`); Implementation 2 settles propositions
 determined jointly by K-propositions that no single proposition settles
 (`blue` is determined by `redOrBlue` together with `notRed`). -/
 
-/-- S_{K} for `K = {red}` does not make `redOrBlue` an issue: w1 and w2
+/-- `S_K` for `K = {red}` does not make `redOrBlue` an issue: `w1` and `w2`
     agree on `red` but disagree on `redOrBlue`. -/
 private theorem not_settles_redOrBlue :
     ¬ settlesByPartition ⟨[red]⟩ redOrBlue := by
@@ -339,18 +330,18 @@ private theorem not_settles_redOrBlue :
     rcases List.mem_singleton.mp hp with rfl; decide)
   exact absurd (h12.mp (by decide)) (by decide)
 
-/-- Counterexample (Impl 1 ↛ Impl 2): `K = {red}` settles `redOrBlue`
-    explicitly (red ⊆ redOrBlue), but not by partition. -/
+/-- Explicit settling does not imply partition settling: `K = {red}` settles
+    `redOrBlue` explicitly (`red ⊆ redOrBlue`) but not by partition. -/
 theorem explicit_not_implies_partition :
     ∃ (k : Kernel World) (φ : World → Prop),
       k.directlySettles φ ∧ ¬ settlesByPartition k φ :=
   ⟨⟨[red]⟩, redOrBlue,
     ⟨red, by simp, Or.inl λ _ hw => Or.inl hw⟩, not_settles_redOrBlue⟩
 
-/-- Counterexample (Impl 2 ↛ Impl 1): `mastermindK` settles `blue` by
-    partition — S_K-equivalent worlds agree on `redOrBlue` and `notRed`,
-    which jointly determine `blue` — but no single kernel proposition
-    entails or excludes it. -/
+/-- Partition settling does not imply explicit settling: `mastermindK`
+    settles `blue` by partition — its cells decide `redOrBlue` and `notRed`,
+    which jointly determine `blue` — but no single kernel proposition entails
+    or excludes it. -/
 theorem partition_not_implies_explicit :
     ∃ (k : Kernel World) (φ : World → Prop),
       settlesByPartition k φ ∧ ¬ k.directlySettles φ := by
@@ -361,7 +352,7 @@ theorem partition_not_implies_explicit :
   cases w <;> cases v <;> decide
 
 /-- Entailment does not imply partition settling: `K = {red}` entails
-    `redOrBlue` (B_K = {w0} ⊆ ⟦redOrBlue⟧) but does not settle it by
+    `redOrBlue` (`B_K = {w0} ⊆ ⟦redOrBlue⟧`) but does not settle it by
     partition. -/
 theorem entailment_not_implies_partition :
     ∃ (k : Kernel World) (φ : World → Prop),

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -264,16 +264,14 @@ variable {W : Type*} (k : Kernel W)
 argument form "if φ, must ψ; φ; ∴ ψ" is valid under realistic B_K. -/
 theorem modus_ponens_with_must (φ ψ : W → Prop) (w : W)
     (hReal : w ∈ k.base)
-    (_hDef : (kernelMust k ψ).presup w)
     (hCond : φ w → (kernelMust k ψ).assertion w)
     (hPhi : φ w) :
     ψ w :=
-  Modality.must_entails_prejacent k ψ w hReal _hDef (hCond hPhi)
+  Modality.must_entails_prejacent k ψ w hReal (hCond hPhi)
 
 /-- **Must-perhaps contradiction** ([von-fintel-gillies-2010] Argument 4.3.2):
 must φ ∧ might ¬φ is contradictory. When B_K ⊆ ⟦φ⟧, B_K ∩ ⟦¬φ⟧ = ∅. -/
 theorem must_perhaps_contradiction (φ : W → Prop) (w : W)
-    (_hDef : (kernelMust k φ).presup w)
     (hMust : (kernelMust k φ).assertion w) :
     ¬(kernelMight k (λ w' => ¬ φ w')).assertion w := by
   intro hc

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -284,46 +284,43 @@ Def 7 presents subject matters as equivalence relations on `W`: `S[P]` keeps
 the pairs of `S` that agree on `P`, and `P` is an *issue* in `S` iff
 `S[P] = S`. The subject matter S_K determined by a kernel is the refinement
 `S_o[P₁]…[Pₙ]` of the universal relation along each kernel proposition —
-equivalently, the relation "agrees with on every `X ∈ K`". Implementation 2:
+equivalently, the relation "agrees on every `X ∈ K`". Implementation 2:
 K directly settles P iff P is an issue in S_K. -/
 
-/-- The subject matter S_K determined by a kernel ([von-fintel-gillies-2010]
-    Implementation 2(i)): worlds are equivalent iff they agree on every
-    proposition in K. -/
+/-- The subject matter S_K determined by a kernel: worlds are equivalent iff
+    they agree on every proposition in K. -/
 def subjectMatter : Setoid W where
   r w v := ∀ p ∈ k.props, (p w ↔ p v)
   iseqv := ⟨λ _ _ _ => Iff.rfl, λ h p hp => (h p hp).symm,
     λ h h' p hp => (h p hp).trans (h' p hp)⟩
 
-/-- `P` is an **issue** in a subject matter `S` ([von-fintel-gillies-2010]
-    Def 7(iii)): refining `S` along the `P`-boundary changes nothing, i.e.
-    `S`-equivalent worlds never disagree on `P`. -/
+/-- `P` is an **issue** in a subject matter `S`: `S`-equivalent worlds never
+    disagree on `P`. -/
 def IsIssue (s : Setoid W) (φ : W → Prop) : Prop :=
   ∀ w v, s.r w v → (φ w ↔ φ v)
 
-/-- K settles P by partition ([von-fintel-gillies-2010] Implementation 2(ii)):
-    P is an issue in S_K. -/
+/-- K settles P by partition iff P is an issue in S_K. -/
 def settlesByPartition (φ : W → Prop) : Prop :=
   IsIssue (subjectMatter k) φ
 
-/-- Partition settling implies entailment: all worlds in B_K agree on every
-    X ∈ K, so they are S_K-equivalent; if φ is an issue in S_K, B_K is
-    φ-uniform. Both implementations therefore imply entailment (cf.
+/-- B_K lies in a single cell of the subject matter: worlds in the base
+    satisfy every kernel proposition, so they agree on all of them. -/
+theorem subjectMatter_rel_base {v w : W} (hv : v ∈ k.base) (hw : w ∈ k.base) :
+    (subjectMatter k).r v w := λ p hp =>
+  iff_of_true (mem_propIntersection.mp hv p hp) (mem_propIntersection.mp hw p hp)
+
+/-- Partition settling implies entailment: B_K lies in a single S_K-cell
+    (`subjectMatter_rel_base`), so an issue is uniform on it. Both
+    implementations therefore imply entailment (cf.
     `explicit_implies_entailment`); the converse fails for both. -/
 theorem partition_implies_entailment (φ : W → Prop)
     (h : settlesByPartition k φ) :
     k.followsFrom φ ∨ k.followsFrom (λ w => ¬ φ w) := by
   rcases Set.eq_empty_or_nonempty k.base with hEmpty | ⟨w₀, hw₀⟩
-  · exact Or.inl ((Kernel.followsFrom_iff _ _).mpr λ w hw =>
-      absurd (hEmpty ▸ hw) (Set.notMem_empty w))
-  · have hrel : ∀ v ∈ k.base, (subjectMatter k).r w₀ v := λ v hv p hp =>
-      ⟨λ _ => mem_propIntersection.mp hv p hp,
-       λ _ => mem_propIntersection.mp hw₀ p hp⟩
-    rcases Classical.em (φ w₀) with hφ | hφ
-    · exact Or.inl ((Kernel.followsFrom_iff _ _).mpr λ v hv =>
-        (h w₀ v (hrel v hv)).mp hφ)
-    · exact Or.inr ((Kernel.followsFrom_iff _ _).mpr λ v hv hφv =>
-        hφ ((h w₀ v (hrel v hv)).mpr hφv))
+  · exact Or.inl λ w hw => absurd (hEmpty ▸ hw) (Set.notMem_empty w)
+  · exact (Classical.em (φ w₀)).imp
+      (λ hφ v hv => (h w₀ v (subjectMatter_rel_base k hw₀ hv)).mp hφ)
+      (λ hφ v hv hφv => hφ ((h w₀ v (subjectMatter_rel_base k hw₀ hv)).mpr hφv))
 
 /-! ### Non-equivalence of the two implementations (§7.2)
 

--- a/Linglib/Studies/VonFintelGillies2010.lean
+++ b/Linglib/Studies/VonFintelGillies2010.lean
@@ -185,16 +185,20 @@ theorem mastermind_base : mastermindK.base = ({.w1} : Set World) := by
   cases w <;> simp [Kernel.base, mastermindK, propIntersection, redOrBlue, notRed]
 
 theorem mastermind_blue_unsettled :
-    ¬ directlySettlesExplicit mastermindK blue := by
+    ¬ mastermindK.directlySettles blue := by
   rintro ⟨x, hx, hxor⟩
   rcases List.mem_cons.mp hx with rfl | hx'
-  · rcases hxor with h_ent | h_exc
-    · exact absurd (h_ent .w0 (show redOrBlue .w0 from by decide)) (by decide)
-    · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+  · rcases hxor with h_sub | h_disj
+    · exact (show ¬ blue .w0 from by decide)
+        (h_sub (show redOrBlue .w0 from by decide))
+    · exact Set.disjoint_left.mp h_disj (show redOrBlue .w1 from by decide)
+        (show blue .w1 from by decide)
   · rcases List.mem_singleton.mp hx' with rfl
-    rcases hxor with h_ent | h_exc
-    · exact absurd (h_ent .w2 (show notRed .w2 from by decide)) (by decide)
-    · exact h_exc ⟨.w1, show notRed .w1 from by decide, by decide⟩
+    rcases hxor with h_sub | h_disj
+    · exact (show ¬ blue .w2 from by decide)
+        (h_sub (show notRed .w2 from by decide))
+    · exact Set.disjoint_left.mp h_disj (show notRed .w1 from by decide)
+        (show blue .w1 from by decide)
 
 theorem mastermind_blue_follows : mastermindK.followsFrom blue := by
   rw [Kernel.followsFrom_iff, mastermind_base]
@@ -210,18 +214,16 @@ theorem mastermind_must_blue_true :
   mastermind_blue_follows
 
 theorem mastermind_red_settled :
-    directlySettlesExplicit mastermindK red := by
-  refine ⟨notRed, by simp [mastermindK], Or.inr ?_⟩
-  rintro ⟨w, hnr, hr⟩
-  exact hnr hr
+    mastermindK.directlySettles red :=
+  ⟨notRed, by simp [mastermindK], Or.inr (Set.disjoint_left.mpr λ _ hnr hr => hnr hr)⟩
 
 theorem mastermind_might_red_undefined :
     ¬(kernelMight mastermindK red).presup .w0 := λ h =>
   h mastermind_red_settled
 
 theorem mastermind_redOrBlue_settled :
-    directlySettlesExplicit mastermindK redOrBlue :=
-  ⟨redOrBlue, by simp [mastermindK], Or.inl λ _ hw => hw⟩
+    mastermindK.directlySettles redOrBlue :=
+  ⟨redOrBlue, by simp [mastermindK], Or.inl subset_rfl⟩
 
 /-! ### Deep theorems -/
 
@@ -230,7 +232,7 @@ This gap makes the evidential presupposition non-trivial: must φ can be
 simultaneously defined and true. -/
 theorem entailment_settling_gap :
     ∃ (k : Kernel World) (φ : World → Prop),
-      k.followsFrom φ ∧ ¬ directlySettlesExplicit k φ :=
+      k.followsFrom φ ∧ ¬ k.directlySettles φ :=
   ⟨mastermindK, blue, mastermind_blue_follows, mastermind_blue_unsettled⟩
 
 /-- **Indirectness ≠ weakness** (§4.1): three independent cases show
@@ -245,9 +247,11 @@ theorem indirectness_neq_weakness :
     λ h => h mastermind_red_settled, ?_, ?_⟩
   · rintro ⟨x, hx, hxor⟩
     rcases List.mem_singleton.mp hx with rfl
-    rcases hxor with h_ent | h_exc
-    · exact absurd (h_ent .w0 (show redOrBlue .w0 from by decide)) (by decide)
-    · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+    rcases hxor with h_sub | h_disj
+    · exact (show ¬ blue .w0 from by decide)
+        (h_sub (show redOrBlue .w0 from by decide))
+    · exact Set.disjoint_left.mp h_disj (show redOrBlue .w1 from by decide)
+        (show blue .w1 from by decide)
   · intro h
     have hw0 : World.w0 ∈ indirectK.base :=
       mem_propIntersection.mpr λ p hp => by
@@ -344,7 +348,7 @@ private theorem not_settles_redOrBlue :
     explicitly (red ⊆ redOrBlue), but not by partition. -/
 theorem explicit_not_implies_partition :
     ∃ (k : Kernel World) (φ : World → Prop),
-      directlySettlesExplicit k φ ∧ ¬ settlesByPartition k φ :=
+      k.directlySettles φ ∧ ¬ settlesByPartition k φ :=
   ⟨⟨[red]⟩, redOrBlue,
     ⟨red, by simp, Or.inl λ _ hw => Or.inl hw⟩, not_settles_redOrBlue⟩
 
@@ -354,7 +358,7 @@ theorem explicit_not_implies_partition :
     entails or excludes it. -/
 theorem partition_not_implies_explicit :
     ∃ (k : Kernel World) (φ : World → Prop),
-      settlesByPartition k φ ∧ ¬ directlySettlesExplicit k φ := by
+      settlesByPartition k φ ∧ ¬ k.directlySettles φ := by
   refine ⟨mastermindK, blue, λ w v h => ?_, mastermind_blue_unsettled⟩
   have h1 := h redOrBlue (by simp [mastermindK])
   have h2 := h notRed (by simp [mastermindK])

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -31,10 +31,10 @@ open VonFintelGillies2010 (evidenceOf EvidenceType)
 def mustPairs : List LinguisticExample :=
   Examples.all.filter (·.feature? "kind" == some "must_pair")
 
-/-- **Anti-knowledge**: the evidential restriction extends to rows where
-    "direct" is direct-enough knowledge rather than perception. Phil, who
-    checked everything himself, cannot say *Dinner must be ready* (ex. 24);
-    Meryl, whose information is indirect, can (ex. 25). -/
+/-- The evidential restriction extends to rows where "direct" is
+    direct-enough knowledge rather than perception: Phil, who checked
+    everything himself, cannot say *Dinner must be ready* (ex. 24); Meryl,
+    whose information is indirect, can (ex. 25). -/
 theorem evidential_restriction_extends :
     ∀ row ∈ mustPairs,
       row.judgment = .acceptable ↔
@@ -57,26 +57,24 @@ open VonFintelGillies2010 (World mastermindK redOrBlue notRed blue red notBlue
 
 variable {W : Type*} (k : Kernel W) (φ : W → Prop) (w : W)
 
-/-- **Can't–might exclusion** ([von-fintel-gillies-2021] Obs 5): when can't φ
-holds (B_K ⊆ ⟦¬φ⟧), might φ is false (B_K ∩ ⟦φ⟧ = ∅). -/
+/-- When can't `φ` holds (`B_K ⊆ ⟦¬φ⟧`), might `φ` is false
+([von-fintel-gillies-2021] Observation 5). -/
 theorem cant_might_exclusion (hCant : (kernelCant k φ).assertion w) :
     ¬(kernelMight k φ).assertion w := by
   intro hc
   obtain ⟨w', hw', hφ⟩ := (Kernel.compatibleWith_iff _ _).mp hc
   exact hCant hw' hφ
 
-/-- **Can't entails negation** ([von-fintel-gillies-2021] via S2): when B_K is
-realistic and can't φ holds, ¬φ(w). -/
+/-- When `B_K` is realistic and can't `φ` holds, `¬φ` holds
+([von-fintel-gillies-2021] via S2). -/
 theorem cant_entails_negation (hReal : w ∈ k.base)
     (hTrue : (kernelCant k φ).assertion w) :
     ¬ φ w :=
   hTrue hReal
 
-/-- **Can't dilemma resolved**: a single kernel simultaneously exhibits
-evidentiality, strength, and might-exclusion.
-Witness: K = {redOrBlue, notRed}, φ = notBlue. Then can't(notBlue) =
-must(blue), which is defined (blue unsettled), true (B_K ⊆ ⟦blue⟧),
-and excludes might(notBlue). -/
+/-- A single kernel simultaneously exhibits evidentiality, strength, and
+might-exclusion: over `mastermindK`, can't *notBlue* is defined, true, and
+excludes might *notBlue* — the joint profile the Mantra cannot assign. -/
 theorem cant_dilemma_resolved :
     .w1 ∈ mastermindK.base ∧
     (kernelCant mastermindK notBlue).presup .w1 ∧
@@ -106,8 +104,8 @@ theorem cant_dilemma_resolved :
     rcases hw with rfl
     exact (by decide : ¬ notBlue World.w1) hnb
 
-/-- Direct evidence blocks can't, paralleling must: when K settles ¬φ,
-can't φ has presupposition failure. -/
+/-- Direct evidence blocks can't, paralleling must: when `K` settles `¬φ`,
+can't `φ` has presupposition failure. -/
 theorem cant_direct_evidence_infelicity :
     ¬(kernelCant mastermindK red).presup .w0 := λ h =>
   h ⟨notRed, by simp [mastermindK], Or.inl λ _ hw => hw⟩

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -66,9 +66,8 @@ theorem cant_might_exclusion (hCant : (kernelCant k φ).assertion w) :
   exact hCant hw' hφ
 
 /-- **Can't entails negation** ([von-fintel-gillies-2021] via S2): when B_K is
-realistic and can't φ is defined and true, ¬φ(w). -/
+realistic and can't φ holds, ¬φ(w). -/
 theorem cant_entails_negation (hReal : w ∈ k.base)
-    (_hDef : (kernelCant k φ).presup w)
     (hTrue : (kernelCant k φ).assertion w) :
     ¬ φ w :=
   hTrue hReal

--- a/Linglib/Studies/VonFintelGillies2021.lean
+++ b/Linglib/Studies/VonFintelGillies2021.lean
@@ -87,13 +87,15 @@ theorem cant_dilemma_resolved :
   refine ⟨by rw [mastermind_base]; rfl, ?_, ?_, ?_, by decide⟩
   · rintro ⟨x, hx, hxor⟩
     rcases List.mem_cons.mp hx with rfl | hx'
-    · rcases hxor with h_ent | h_exc
-      · exact h_ent .w0 (show redOrBlue .w0 from by decide) (by decide)
-      · exact h_exc ⟨.w1, show redOrBlue .w1 from by decide, by decide⟩
+    · rcases hxor with h_sub | h_disj
+      · exact h_sub (show redOrBlue .w0 from by decide) (by decide)
+      · exact Set.disjoint_left.mp h_disj (show redOrBlue .w1 from by decide)
+          (show ¬ notBlue .w1 from by decide)
     · rcases List.mem_singleton.mp hx' with rfl
-      rcases hxor with h_ent | h_exc
-      · exact h_ent .w2 (show notRed .w2 from by decide) (by decide)
-      · exact h_exc ⟨.w1, show notRed .w1 from by decide, by decide⟩
+      rcases hxor with h_sub | h_disj
+      · exact h_sub (show notRed .w2 from by decide) (by decide)
+      · exact Set.disjoint_left.mp h_disj (show notRed .w1 from by decide)
+          (show ¬ notBlue .w1 from by decide)
   · rw [show (kernelCant mastermindK notBlue).assertion .w1 =
         mastermindK.followsFrom (λ w => ¬ notBlue w) from rfl,
       Kernel.followsFrom_iff, mastermind_base]

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -161,21 +161,21 @@ def allData : List NandaoDatum :=
     evidenceNoBelief, noEvidenceNoBelief, beliefNoEvidence,
     workSundayUnexpected, workSundayExpected ]
 
-/-- **Generalization 1**: all felicitous nandao-Qs have evidential bias. -/
+/-- All felicitous nandao-Qs have evidential bias (Generalization 1). -/
 theorem evidential_bias_necessary :
     (allData.filter (·.felicitous)).all (·.evidentialBias) = true := by decide
 
-/-- **Generalization 2**: some felicitous nandao-Qs lack epistemic bias
-(the pure inquiry use). -/
+/-- Some felicitous nandao-Qs lack epistemic bias — the pure inquiry use
+(Generalization 2). -/
 theorem epistemic_bias_not_necessary :
     (allData.filter (λ d => d.felicitous && !d.epistemicBias)).length > 0 := by decide
 
-/-- **Generalization 3**: some infelicitous nandao-Qs have epistemic bias
-(epistemic bias is not sufficient). -/
+/-- Some infelicitous nandao-Qs have epistemic bias, so epistemic bias is not
+sufficient (Generalization 3). -/
 theorem epistemic_bias_not_sufficient :
     (allData.filter (λ d => d.epistemicBias && !d.felicitous)).length > 0 := by decide
 
-/-- **Generalization 4**: all felicitous nandao-Qs have unexpected evidence. -/
+/-- All felicitous nandao-Qs have unexpected evidence (Generalization 4). -/
 theorem unexpectedness_necessary :
     (allData.filter (·.felicitous)).all (·.unexpectedEvidence) = true := by decide
 
@@ -214,9 +214,10 @@ desires — distinct from the kernel's direct evidence. -/
 def unexpected (u : List (W → Prop)) : Prop :=
   k.base ∩ propIntersection u = ∅
 
-/-- **Nandao-Q felicity** ([zheng-2025] condition (11), final version for
-polar questions): (i) some evidence in K raises P(φ), (ii) the evidence is
-unexpected given the prior state U, (iii) φ is not directly settled in K. -/
+/-- Nandao `φ`? is felicitous iff some evidence in `K` raises P(φ), the
+evidence is unexpected given the prior state `U`, and `φ` is not directly
+settled in `K` ([zheng-2025] condition (11), final version for polar
+questions). -/
 def nandaoFelicitous (u : List (W → Prop)) (φ : W → Prop) : Prop :=
   evidenceSupports k φ ∧ unexpected k u ∧ ¬ k.directlySettles φ
 
@@ -227,7 +228,7 @@ end
 K = {wearingRaincoat}: direct evidence that someone entered with a wet coat.
 U = {expectDry}: prior expectation of no rain (doxastic or normative). -/
 
-/-- Four worlds for the raincoat scenario: it rains, the sprinkler ran
+/-- Four worlds for the raincoat scenario, where it rains, the sprinkler ran
     (wet coat without rain), it is dry, or nothing is known. -/
 inductive World where
   | rain | sprinkler | dry | unknown
@@ -236,16 +237,16 @@ inductive World where
 /-- B enters wearing a dripping raincoat: true where the coat is wet. -/
 abbrev wearingRaincoat : World → Prop := λ w => w = .rain ∨ w = .sprinkler
 
-/-- A's prior expectation: no rain. -/
+/-- A's prior expectation of no rain. -/
 abbrev expectDry : World → Prop := λ w => w = .dry ∨ w = .unknown
 
 /-- It is raining outside. -/
 abbrev isRaining : World → Prop := (· = .rain)
 
-/-- The raincoat kernel: direct evidence of the wet coat. -/
+/-- The raincoat kernel, carrying the direct evidence of the wet coat. -/
 def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
 
-/-- The prior information state: A expects dry weather. -/
+/-- The prior information state in which A expects dry weather. -/
 def dryU : List (World → Prop) := [expectDry]
 
 /-- "Nandao waimian xiayu-le ma?" is felicitous with a dripping raincoat:
@@ -299,14 +300,14 @@ theorem expected_evidence_infelicitous :
 
 open Mandarin.QuestionParticles (nandao ma ba)
 
-/-- Zheng's evidential classification of *nandao*: requires contextual
-evidence for p — the lexical face of `evidential_bias_necessary`. -/
+/-- *Nandao* requires contextual evidence for p — Zheng's evidential
+classification, the lexical face of `evidential_bias_necessary`. -/
 def nandaoContextualEvidence : Option Semantics.Questions.Bias.ContextualEvidence :=
   some .forP
 
-/-- Zheng's classification: *nandao* does NOT require epistemic bias —
-compatible with a neutral epistemic state (pure inquiry use, ex. 3);
-the lexical face of `epistemic_bias_not_necessary`. -/
+/-- *Nandao* does not require epistemic bias — it is compatible with a
+neutral epistemic state (pure inquiry use, ex. 3); the lexical face of
+`epistemic_bias_not_necessary`. -/
 def nandaoOriginalBias : Option Semantics.Questions.Bias.OriginalBias := none
 
 /-- `nandaoFelicitous` entails `evidenceSupports`, connecting the felicity
@@ -338,9 +339,8 @@ def ba_layer (_ : Particle) : QParticleLayer := .perspP
 /-- *nandao*: PerspP-layer biased particle. -/
 def nandao_layer (_ : Particle) : QParticleLayer := .perspP
 
-/-- Zheng's classification of *ba*: speaker-bias (expects a positive answer,
-seeks confirmation), no evidential requirement; the unbiased *ma* imposes
-neither. -/
+/-- *Ba* carries speaker bias (expects a positive answer, seeks confirmation)
+with no evidential requirement; the unbiased *ma* imposes neither. -/
 def baOriginalBias : Option Semantics.Questions.Bias.OriginalBias := some .forP
 
 /-! ### Singleton-alternative presupposition (parallel to kya:)
@@ -373,10 +373,10 @@ felicity in context). The integrated predicate composes them; a Layer-1
 failure (a non-trivial two-cell polar) blocks felicity regardless of
 `(k, u)`. -/
 
-/-- **Integrated nandao felicity**: the singleton presupposition
-(`alt Q = {p}`) together with the kernel-bias check on the witness. The
-witness `p` is supplied externally; for the noncomputable choice from a
-`SingletonQuestion` use `SingletonQuestion.witness`. -/
+/-- The integrated felicity of nandao conjoins the singleton presupposition
+`alt Q = {p}` with the kernel-bias check on the witness. The witness `p` is
+supplied externally; for the noncomputable choice from a `SingletonQuestion`
+use `SingletonQuestion.witness`. -/
 def nandaoFullFelicity (Q : Question World) (k : Kernel World)
     (u : List (World → Prop)) (p : Set World) : Prop :=
   alt Q = {p} ∧ nandaoFelicitous k u p

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -38,7 +38,7 @@ and the prejacent is not directly settled in K.
 
 namespace Zheng2025
 
-open Modality (Kernel directlySettlesExplicit)
+open Modality (Kernel)
 open Intensional.Premise
 
 /-! ### Empirical data -/
@@ -218,7 +218,7 @@ def unexpected (u : List (W → Prop)) : Prop :=
 polar questions): (i) some evidence in K raises P(φ), (ii) the evidence is
 unexpected given the prior state U, (iii) φ is not directly settled in K. -/
 def nandaoFelicitous (u : List (W → Prop)) (φ : W → Prop) : Prop :=
-  evidenceSupports k φ ∧ unexpected k u ∧ ¬ directlySettlesExplicit k φ
+  evidenceSupports k φ ∧ unexpected k u ∧ ¬ k.directlySettles φ
 
 end
 
@@ -271,10 +271,11 @@ theorem raincoat_nandao_felicitous :
     cases w <;> decide
   · rintro ⟨x, hx, hxor⟩
     rcases List.mem_singleton.mp (by simpa [raincoatK] using hx) with rfl
-    rcases hxor with h_ent | h_exc
-    · exact absurd (h_ent .sprinkler (show wearingRaincoat .sprinkler from by decide))
-        (by decide)
-    · exact h_exc ⟨.rain, show wearingRaincoat .rain from by decide, by decide⟩
+    rcases hxor with h_sub | h_disj
+    · exact (show ¬ isRaining .sprinkler from by decide)
+        (h_sub (show wearingRaincoat .sprinkler from by decide))
+    · exact Set.disjoint_left.mp h_disj (show wearingRaincoat .rain from by decide)
+        (show isRaining .rain from by decide)
 
 /-- Without evidence, nandao is infelicitous ([zheng-2025] ex. 5 ctx 2). -/
 theorem no_evidence_nandao_infelicitous :


### PR DESCRIPTION
Elegance pass on the settling section (re-landed off the merged #1844): the settling predicate is restated in Set-lattice vocabulary — `propExtension x ⊆ propExtension φ ∨ Disjoint (propExtension x) (propExtension φ)`, the paper's literal "X ⊆ P or X ∩ P = ∅" — and renamed `directlySettlesExplicit` → `Kernel.directlySettles` (dot-notation call sites; the Implementation-1 tag moves to the docstring, contrasting with the study's `settlesByPartition`). `explicit_implies_entailment` collapses to two `Subset.trans` chains; `settling_monotone` generalizes from cons to `k.props ⊆ k'.props` as the one-line `Kernel.directlySettles_mono`.