### PR TITLE
feat(Data/Examples): Zheng2025 nandao rows; reground study data

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2952,3 +2952,4 @@ import Linglib.Data.Examples.Istratkova2004
 import Linglib.Data.Examples.Jablonska2004
 import Linglib.Data.Examples.GoldbergJackendoff2004
 import Linglib.Data.Examples.Coon2019
+import Linglib.Data.Examples.Zheng2025

--- a/Linglib/Data/Examples/Zheng2025.json
+++ b/Linglib/Data/Examples/Zheng2025.json
@@ -1,0 +1,170 @@
+[
+  {
+    "id": "zheng2025_ex1",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(1)"},
+    "language": "mand1415",
+    "primaryText": "Nandao ta fafeng-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["ta", "he"], ["fafeng-le", "go.crazy-PERF"], ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is he crazy?",
+    "context": "A and B are talking about a colleague, Lee, who is going to work on Sunday. B does not think people usually go to work on Sunday.",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "true"],
+      ["unexpected_evidence", "true"]
+    ],
+    "comment": "Rhetorical use: the evidence (Lee working Sunday) contradicts B's norm that people don't work Sundays."
+  },
+  {
+    "id": "zheng2025_ex2",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(2)"},
+    "language": "mand1415",
+    "primaryText": "Nandao waimian xiayu-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["waimian", "outside"], ["xiayu-le", "fall.rain-PERF"],
+      ["ma", "Y/N-Q"]
+    ],
+    "translation": "It is not the case that it is raining outside, right?",
+    "context": "A sits in a windowless room working. A believes it is not raining. At 10, B enters the room with a dripping raincoat.",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "true"],
+      ["unexpected_evidence", "true"]
+    ],
+    "comment": "Biased-question use: the evidence contradicts A's prior belief."
+  },
+  {
+    "id": "zheng2025_ex3",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(3)"},
+    "language": "mand1415",
+    "primaryText": "Nandao waimian xiayu-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["waimian", "outside"], ["xiayu-le", "fall.rain-PERF"],
+      ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is it raining outside?",
+    "context": "A sits in a windowless room working. A has no expectation about the weather. At 10, B enters the room with a dripping raincoat.",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "false"],
+      ["unexpected_evidence", "true"]
+    ],
+    "comment": "Pure-inquiry use, the paper's novel datum: felicitous with no prior belief about the prejacent."
+  },
+  {
+    "id": "zheng2025_ex4b",
+    "source": {"bibkey": "xu-2018", "paperLabel": "p. 449"},
+    "reportedIn": {"bibkey": "zheng-2025", "paperLabel": "(4b)"},
+    "language": "mand1415",
+    "primaryText": "Nandao wuli you ren?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["wuli", "room.in"], ["you", "exist"], ["ren", "person"]
+    ],
+    "translation": "It is not the case there are people in the room, right?",
+    "context": "The speaker believes there is no one in the room, and there is no contextual evidence (such as the light being on) that someone is in.",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["evidential_bias", "false"],
+      ["epistemic_bias", "true"],
+      ["unexpected_evidence", "false"]
+    ],
+    "comment": "Xu's context supplies only the negative belief; Zheng observes that without contextual evidence the question is still infelicitous, so epistemic bias is not sufficient."
+  },
+  {
+    "id": "zheng2025_ex5_ctx1",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(5) ctx 1"},
+    "language": "mand1415",
+    "primaryText": "Nandao waimian xiayu-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["waimian", "outside"], ["xiayu-le", "fall.rain-PERF"],
+      ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is it raining outside?",
+    "context": "A sits in a windowless room with no prior beliefs about the weather. At 10, B enters the room with a dripping raincoat.",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "false"],
+      ["unexpected_evidence", "true"]
+    ],
+    "comment": "Evidence without belief: positive evidential bias is sufficient."
+  },
+  {
+    "id": "zheng2025_ex5_ctx2",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(5) ctx 2"},
+    "language": "mand1415",
+    "primaryText": "Nandao waimian xiayu-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["waimian", "outside"], ["xiayu-le", "fall.rain-PERF"],
+      ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is it raining outside?",
+    "context": "A sits in a windowless room with no prior beliefs about the weather. At 10, B enters the room normally, without a raincoat.",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["evidential_bias", "false"],
+      ["epistemic_bias", "false"],
+      ["unexpected_evidence", "false"]
+    ],
+    "comment": "No evidence and no belief: infelicitous."
+  },
+  {
+    "id": "zheng2025_ex5_ctx3",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(5) ctx 3"},
+    "language": "mand1415",
+    "primaryText": "Nandao waimian xiayu-le ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["waimian", "outside"], ["xiayu-le", "fall.rain-PERF"],
+      ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is it raining outside?",
+    "context": "A thinks it will not rain today. At 10, B enters the room normally, without a raincoat.",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["evidential_bias", "false"],
+      ["epistemic_bias", "true"],
+      ["unexpected_evidence", "false"]
+    ],
+    "comment": "Belief without evidence: negative epistemic bias alone does not license nandao."
+  },
+  {
+    "id": "zheng2025_ex6_ctx1",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(6) ctx 1"},
+    "language": "mand1415",
+    "primaryText": "Nandao ta hen.mang ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["ta", "he"], ["hen.mang", "very.busy"], ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is he busy?",
+    "context": "A says Lee is planning to work on weekends too. B does not think that people, including Lee, usually go to work on Sunday.",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "true"],
+      ["unexpected_evidence", "true"]
+    ],
+    "comment": "Unexpected evidence: Lee working Sunday deviates from B's expectation."
+  },
+  {
+    "id": "zheng2025_ex6_ctx2",
+    "source": {"bibkey": "zheng-2025", "paperLabel": "(6) ctx 2"},
+    "language": "mand1415",
+    "primaryText": "Nandao ta hen.mang ma?",
+    "glossedTokens": [
+      ["nandao", "nandao"], ["ta", "he"], ["hen.mang", "very.busy"], ["ma", "Y/N-Q"]
+    ],
+    "translation": "Is he busy?",
+    "context": "A says Lee is planning to work on weekends too. B knows Lee usually goes to work on Sunday.",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["evidential_bias", "true"],
+      ["epistemic_bias", "false"],
+      ["unexpected_evidence", "false"]
+    ],
+    "comment": "Expected evidence: the same evidence is unremarkable given B's knowledge, so nandao is infelicitous."
+  }
+]

--- a/Linglib/Data/Examples/Zheng2025.lean
+++ b/Linglib/Data/Examples/Zheng2025.lean
@@ -1,0 +1,180 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Zheng2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Zheng2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Zheng2025.Examples`.
+-/
+
+namespace Zheng2025.Examples
+
+open Data.Examples
+
+def ex1 : LinguisticExample :=
+  { id := "zheng2025_ex1"
+    source := ⟨"zheng-2025", "(1)"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao ta fafeng-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("ta", "he"), ("fafeng-le", "go.crazy-PERF"), ("ma", "Y/N-Q")]
+    translation := "Is he crazy?"
+    context := "A and B are talking about a colleague, Lee, who is going to work on Sunday. B does not think people usually go to work on Sunday."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "true"), ("unexpected_evidence", "true")]
+    comment := "Rhetorical use: the evidence (Lee working Sunday) contradicts B's norm that people don't work Sundays."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex2 : LinguisticExample :=
+  { id := "zheng2025_ex2"
+    source := ⟨"zheng-2025", "(2)"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao waimian xiayu-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("waimian", "outside"), ("xiayu-le", "fall.rain-PERF"), ("ma", "Y/N-Q")]
+    translation := "It is not the case that it is raining outside, right?"
+    context := "A sits in a windowless room working. A believes it is not raining. At 10, B enters the room with a dripping raincoat."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "true"), ("unexpected_evidence", "true")]
+    comment := "Biased-question use: the evidence contradicts A's prior belief."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex3 : LinguisticExample :=
+  { id := "zheng2025_ex3"
+    source := ⟨"zheng-2025", "(3)"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao waimian xiayu-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("waimian", "outside"), ("xiayu-le", "fall.rain-PERF"), ("ma", "Y/N-Q")]
+    translation := "Is it raining outside?"
+    context := "A sits in a windowless room working. A has no expectation about the weather. At 10, B enters the room with a dripping raincoat."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "false"), ("unexpected_evidence", "true")]
+    comment := "Pure-inquiry use, the paper's novel datum: felicitous with no prior belief about the prejacent."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex4b : LinguisticExample :=
+  { id := "zheng2025_ex4b"
+    source := ⟨"xu-2018", "p. 449"⟩
+    reportedIn := some ⟨"zheng-2025", "(4b)"⟩
+    language := "mand1415"
+    primaryText := "Nandao wuli you ren?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("wuli", "room.in"), ("you", "exist"), ("ren", "person")]
+    translation := "It is not the case there are people in the room, right?"
+    context := "The speaker believes there is no one in the room, and there is no contextual evidence (such as the light being on) that someone is in."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "false"), ("epistemic_bias", "true"), ("unexpected_evidence", "false")]
+    comment := "Xu's context supplies only the negative belief; Zheng observes that without contextual evidence the question is still infelicitous, so epistemic bias is not sufficient."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex5_ctx1 : LinguisticExample :=
+  { id := "zheng2025_ex5_ctx1"
+    source := ⟨"zheng-2025", "(5) ctx 1"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao waimian xiayu-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("waimian", "outside"), ("xiayu-le", "fall.rain-PERF"), ("ma", "Y/N-Q")]
+    translation := "Is it raining outside?"
+    context := "A sits in a windowless room with no prior beliefs about the weather. At 10, B enters the room with a dripping raincoat."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "false"), ("unexpected_evidence", "true")]
+    comment := "Evidence without belief: positive evidential bias is sufficient."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex5_ctx2 : LinguisticExample :=
+  { id := "zheng2025_ex5_ctx2"
+    source := ⟨"zheng-2025", "(5) ctx 2"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao waimian xiayu-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("waimian", "outside"), ("xiayu-le", "fall.rain-PERF"), ("ma", "Y/N-Q")]
+    translation := "Is it raining outside?"
+    context := "A sits in a windowless room with no prior beliefs about the weather. At 10, B enters the room normally, without a raincoat."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "false"), ("epistemic_bias", "false"), ("unexpected_evidence", "false")]
+    comment := "No evidence and no belief: infelicitous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex5_ctx3 : LinguisticExample :=
+  { id := "zheng2025_ex5_ctx3"
+    source := ⟨"zheng-2025", "(5) ctx 3"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao waimian xiayu-le ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("waimian", "outside"), ("xiayu-le", "fall.rain-PERF"), ("ma", "Y/N-Q")]
+    translation := "Is it raining outside?"
+    context := "A thinks it will not rain today. At 10, B enters the room normally, without a raincoat."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "false"), ("epistemic_bias", "true"), ("unexpected_evidence", "false")]
+    comment := "Belief without evidence: negative epistemic bias alone does not license nandao."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6_ctx1 : LinguisticExample :=
+  { id := "zheng2025_ex6_ctx1"
+    source := ⟨"zheng-2025", "(6) ctx 1"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao ta hen.mang ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("ta", "he"), ("hen.mang", "very.busy"), ("ma", "Y/N-Q")]
+    translation := "Is he busy?"
+    context := "A says Lee is planning to work on weekends too. B does not think that people, including Lee, usually go to work on Sunday."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "true"), ("unexpected_evidence", "true")]
+    comment := "Unexpected evidence: Lee working Sunday deviates from B's expectation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex6_ctx2 : LinguisticExample :=
+  { id := "zheng2025_ex6_ctx2"
+    source := ⟨"zheng-2025", "(6) ctx 2"⟩
+    reportedIn := none
+    language := "mand1415"
+    primaryText := "Nandao ta hen.mang ma?"
+    discourseSegments := []
+    glossedTokens := [("nandao", "nandao"), ("ta", "he"), ("hen.mang", "very.busy"), ("ma", "Y/N-Q")]
+    translation := "Is he busy?"
+    context := "A says Lee is planning to work on weekends too. B knows Lee usually goes to work on Sunday."
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("evidential_bias", "true"), ("epistemic_bias", "false"), ("unexpected_evidence", "false")]
+    comment := "Expected evidence: the same evidence is unremarkable given B's knowledge, so nandao is infelicitous."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex1, ex2, ex3, ex4b, ex5_ctx1, ex5_ctx2, ex5_ctx3, ex6_ctx1, ex6_ctx2]
+
+end Zheng2025.Examples

--- a/Linglib/Semantics/Intensional/Premise.lean
+++ b/Linglib/Semantics/Intensional/Premise.lean
@@ -108,6 +108,13 @@ theorem propIntersection_singleton (p : Index → Prop) :
     propIntersection [p] = propExtension p := by
   rw [propIntersection_cons, propIntersection_nil, Set.inter_univ]
 
+theorem propExtension_subset_iff {p q : Index → Prop} :
+    propExtension p ⊆ propExtension q ↔ ∀ i, p i → q i := Iff.rfl
+
+theorem disjoint_propExtension_iff {p q : Index → Prop} :
+    Disjoint (propExtension p) (propExtension q) ↔ ∀ i, p i → ¬ q i :=
+  Set.disjoint_left
+
 theorem isCompatibleWith_iff_exists {p : Index → Prop} {A : List (Index → Prop)} :
     isCompatibleWith p A ↔ ∃ i ∈ propIntersection A, p i := by
   simp only [isCompatibleWith, isConsistent, Set.Nonempty, mem_propIntersection,

--- a/Linglib/Semantics/Intensional/Premise.lean
+++ b/Linglib/Semantics/Intensional/Premise.lean
@@ -97,7 +97,7 @@ theorem propIntersection_subset_propExtension {x : Index → Prop}
   fun _ hi => hi x hx
 
 theorem propIntersection_nil : propIntersection ([] : List (Index → Prop)) = Set.univ :=
-  Set.eq_univ_of_forall fun _ p hp => absurd hp (List.not_mem_nil)
+  Set.eq_univ_of_forall fun _ _ hp => absurd hp List.not_mem_nil
 
 theorem propIntersection_cons (p : Index → Prop) (A : List (Index → Prop)) :
     propIntersection (p :: A) = propExtension p ∩ propIntersection A := by

--- a/Linglib/Semantics/Intensional/Premise.lean
+++ b/Linglib/Semantics/Intensional/Premise.lean
@@ -96,6 +96,18 @@ theorem propIntersection_subset_propExtension {x : Index → Prop}
     propIntersection A ⊆ propExtension x :=
   fun _ hi => hi x hx
 
+theorem propIntersection_nil : propIntersection ([] : List (Index → Prop)) = Set.univ :=
+  Set.eq_univ_of_forall fun _ p hp => absurd hp (List.not_mem_nil)
+
+theorem propIntersection_cons (p : Index → Prop) (A : List (Index → Prop)) :
+    propIntersection (p :: A) = propExtension p ∩ propIntersection A := by
+  ext i
+  simp [mem_propIntersection, mem_propExtension, List.forall_mem_cons]
+
+theorem propIntersection_singleton (p : Index → Prop) :
+    propIntersection [p] = propExtension p := by
+  rw [propIntersection_cons, propIntersection_nil, Set.inter_univ]
+
 theorem isCompatibleWith_iff_exists {p : Index → Prop} {A : List (Index → Prop)} :
     isCompatibleWith p A ↔ ∃ i ∈ propIntersection A, p i := by
   simp only [isCompatibleWith, isConsistent, Set.Nonempty, mem_propIntersection,

--- a/Linglib/Semantics/Intensional/Premise.lean
+++ b/Linglib/Semantics/Intensional/Premise.lean
@@ -102,7 +102,7 @@ theorem propIntersection_nil : propIntersection ([] : List (Index → Prop)) = S
 theorem propIntersection_cons (p : Index → Prop) (A : List (Index → Prop)) :
     propIntersection (p :: A) = propExtension p ∩ propIntersection A := by
   ext i
-  simp [mem_propIntersection, mem_propExtension, List.forall_mem_cons]
+  simp [mem_propIntersection, mem_propExtension]
 
 theorem propIntersection_singleton (p : Index → Prop) :
     propIntersection [p] = propExtension p := by

--- a/Linglib/Semantics/Modality/Kernel.lean
+++ b/Linglib/Semantics/Modality/Kernel.lean
@@ -108,6 +108,18 @@ theorem Kernel.directlySettles_mono {k' : Kernel W} (hk : k.props ⊆ k'.props)
     k'.directlySettles φ :=
   h.imp λ _ ⟨hm, hx⟩ => ⟨hk hm, hx⟩
 
+@[simp]
+theorem Kernel.base_singleton (p : W → Prop) :
+    (⟨[p]⟩ : Kernel W).base = propExtension p :=
+  propIntersection_singleton p
+
+@[simp]
+theorem Kernel.directlySettles_singleton (p : W → Prop) :
+    (⟨[p]⟩ : Kernel W).directlySettles φ ↔
+      propExtension p ⊆ propExtension φ ∨
+        Disjoint (propExtension p) (propExtension φ) := by
+  simp [Kernel.directlySettles]
+
 /-! ### Modal operators ([von-fintel-gillies-2010] Defs 5–6) -/
 
 /-- `⟦must φ⟧` presupposes that `K` does not directly settle `φ` and asserts

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -103,29 +103,29 @@ avoid rationals. [zheng-2025]'s condition (11i) writes P(φ|p) ≫ P(φ); we
 sharpen "significantly raises" to strict raising and fix the uniform measure
 on `W`. Meaningful for finite `W` (`Set.ncard` and `Nat.card` are junk
 otherwise). -/
-def evidenceRaises (p φ : W → Prop) : Prop :=
-  {w | p w ∧ φ w}.ncard * Nat.card W > {w | φ w}.ncard * {w | p w}.ncard
+def evidenceRaises (p φ : Set W) : Prop :=
+  (p ∩ φ).ncard * Nat.card W > φ.ncard * p.ncard
 
 section
-variable (k : Kernel W)
+variable (k : Kernel W) (u : List (W → Prop)) (φ : W → Prop)
 
 /-- Some proposition in K raises the probability of φ
 ([zheng-2025] condition (11i)). -/
-def evidenceSupports (φ : W → Prop) : Prop :=
+def evidenceSupports : Prop :=
   ∃ p ∈ k.props, evidenceRaises p φ
 
 /-- The evidence in K is unexpected given the prior information state U
-([zheng-2025] condition (11ii)): B_K ∩ ⋂U = ∅. U collects what leads to the
-information state prior to encountering the evidence — beliefs, norms,
-desires — distinct from the kernel's direct evidence. -/
-def unexpected (u : List (W → Prop)) : Prop :=
-  k.base ∩ propIntersection u = ∅
+([zheng-2025] condition (11ii)): B_K is disjoint from ⋂U. U collects what
+leads to the information state prior to encountering the evidence — beliefs,
+norms, desires — distinct from the kernel's direct evidence. -/
+def unexpected : Prop :=
+  Disjoint k.base (propIntersection u)
 
 /-- Nandao `φ`? is felicitous iff some evidence in `K` raises P(φ), the
 evidence is unexpected given the prior state `U`, and `φ` is not directly
 settled in `K` ([zheng-2025] condition (11), final version for polar
 questions). -/
-def nandaoFelicitous (u : List (W → Prop)) (φ : W → Prop) : Prop :=
+def nandaoFelicitous : Prop :=
   evidenceSupports k φ ∧ unexpected k u ∧ ¬ k.directlySettles φ
 
 end
@@ -161,18 +161,19 @@ P(rain|coat) = 1/2 > P(rain) = 1/4; B_K ∩ ⋂U = ∅; rain unsettled by K. -/
 theorem raincoat_nandao_felicitous :
     nandaoFelicitous raincoatK dryU isRaining := by
   refine ⟨⟨wearingRaincoat, by simp [raincoatK], ?_⟩, ?_, ?_⟩
-  · -- |coat ∧ rain| ⬝ |W| > |rain| ⬝ |coat|: 1 ⬝ 4 > 1 ⬝ 2.
+  · -- |coat ∩ rain| ⬝ |W| > |rain| ⬝ |coat|: 1 ⬝ 4 > 1 ⬝ 2.
+    show {w | wearingRaincoat w ∧ isRaining w}.ncard * Nat.card World >
+      {w | isRaining w}.ncard * {w | wearingRaincoat w}.ncard
     have hpφ : {w | wearingRaincoat w ∧ isRaining w} = {World.rain} := by
       ext w; cases w <;> simp [wearingRaincoat, isRaining]
     have hφ : {w | isRaining w} = {World.rain} := by
       ext w; cases w <;> simp [isRaining]
     have hp : {w | wearingRaincoat w} = {World.rain, World.sprinkler} := by
       ext w; cases w <;> simp [wearingRaincoat]
-    unfold evidenceRaises
     rw [hpφ, hφ, hp, Set.ncard_singleton, Set.ncard_pair (by decide),
       Nat.card_eq_fintype_card]
     decide
-  · refine Set.eq_empty_iff_forall_notMem.mpr λ w ⟨hK, hU⟩ => ?_
+  · refine Set.disjoint_left.mpr λ w hK hU => ?_
     have h1 : wearingRaincoat w := mem_propIntersection.mp hK _ (by simp [raincoatK])
     have h2 : expectDry w := mem_propIntersection.mp hU _ (by simp [dryU])
     revert h1 h2
@@ -197,11 +198,11 @@ expectation of wet coats makes the evidence unremarkable). -/
 theorem expected_evidence_infelicitous :
     ¬ nandaoFelicitous raincoatK [wearingRaincoat] isRaining := by
   rintro ⟨_, hInc, _⟩
-  have hmem : World.rain ∈ raincoatK.base ∩ propIntersection [wearingRaincoat] :=
-    ⟨mem_propIntersection.mpr (by simp [raincoatK, wearingRaincoat]),
-     mem_propIntersection.mpr (by simp [wearingRaincoat])⟩
-  rw [unexpected] at hInc
-  exact absurd (hInc ▸ hmem) (Set.notMem_empty _)
+  have h1 : World.rain ∈ raincoatK.base :=
+    mem_propIntersection.mpr (by simp [raincoatK, wearingRaincoat])
+  have h2 : World.rain ∈ propIntersection [wearingRaincoat] :=
+    mem_propIntersection.mpr (by simp [wearingRaincoat])
+  exact Set.disjoint_left.mp hInc h1 h2
 
 /-! ### Bias classification -/
 

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -1,4 +1,5 @@
 import Linglib.Data.UD.Basic
+import Linglib.Data.Examples.Zheng2025
 import Linglib.Fragments.Mandarin.QuestionParticles
 import Linglib.Semantics.Modality.Kernel
 import Linglib.Features.QParticleLayer
@@ -20,9 +21,9 @@ and the prejacent is not directly settled in K.
 
 ## Main declarations
 
-- `NandaoDatum`, `allData`: the felicity data of exx. 1–6, with the
-  generalizations `evidential_bias_necessary`, `epistemic_bias_not_necessary`,
-  `epistemic_bias_not_sufficient`, `unexpectedness_necessary`
+- `evidential_bias_necessary`, `epistemic_bias_not_necessary`,
+  `epistemic_bias_not_sufficient`, `unexpectedness_necessary`: the felicity
+  generalizations over the example rows of `Data.Examples.Zheng2025`
 - `nandaoFelicitous`: condition (11) — evidence raises P(φ), the kernel is
   unexpected given the prior state, φ unsettled
 - `raincoat_nandao_felicitous`: the dripping-raincoat scenario (exx. 2–3)
@@ -41,143 +42,49 @@ namespace Zheng2025
 open Modality (Kernel)
 open Intensional.Premise
 
-/-! ### Empirical data -/
+/-! ### Empirical data
 
-/-- A nandao-Q felicity datum. -/
-structure NandaoDatum where
-  /-- Example number from [zheng-2025] -/
-  exampleNum : String
-  /-- Context description -/
-  context : String
-  /-- The nandao-Q sentence (pinyin) -/
-  sentence : String
-  /-- Is there positive evidential bias (contextual evidence for p)? -/
-  evidentialBias : Bool
-  /-- Is there negative epistemic bias (prior belief against p)? -/
-  epistemicBias : Bool
-  /-- Is the evidence unexpected? -/
-  unexpectedEvidence : Bool
-  /-- Is the nandao-Q felicitous? -/
-  felicitous : Bool
-  deriving Repr, DecidableEq
+The example rows of exx. 1–6 live in `Data/Examples/Zheng2025.json`; the
+adapters below read each row's felicity and bias profile off the generated
+`Data.Examples.Zheng2025` module. -/
 
-/-- Ex. 1, rhetorical use: Lee working on Sunday (evidence) contradicts B's
-norm that people don't work Sundays. -/
-def rhetoricalUse : NandaoDatum where
-  exampleNum := "1"
-  context := "Lee plans to work on Sunday; B thinks people don't work Sundays"
-  sentence := "Nandao ta fafeng-le ma? (Is he crazy?)"
-  evidentialBias := true
-  epistemicBias := true
-  unexpectedEvidence := true
-  felicitous := true
+open Data.Examples
 
-/-- Ex. 2, biased question: A believes not-raining; B enters with a dripping
-raincoat. -/
-def biasedUse : NandaoDatum where
-  exampleNum := "2"
-  context := "A believes not-raining; B enters with dripping raincoat"
-  sentence := "Nandao waimian xiayu-le ma? (Is it raining outside?)"
-  evidentialBias := true
-  epistemicBias := true
-  unexpectedEvidence := true
-  felicitous := true
+/-- The row records positive evidential bias (contextual evidence for p). -/
+def evidentialBias (row : LinguisticExample) : Bool :=
+  row.feature? "evidential_bias" == some "true"
 
-/-- Ex. 3, pure inquiry (novel): same evidence as ex. 2 but A has no prior
-belief about the weather. Nandao is still felicitous. -/
-def pureInquiry : NandaoDatum where
-  exampleNum := "3"
-  context := "A has no weather expectation; B enters with dripping raincoat"
-  sentence := "Nandao waimian xiayu-le ma? (Is it raining outside?)"
-  evidentialBias := true
-  epistemicBias := false
-  unexpectedEvidence := true
-  felicitous := true
+/-- The row records negative epistemic bias (prior belief against p). -/
+def epistemicBias (row : LinguisticExample) : Bool :=
+  row.feature? "epistemic_bias" == some "true"
 
-/-- Ex. 4a: epistemic bias without evidence — infelicitous. -/
-def epistemicOnly : NandaoDatum where
-  exampleNum := "4a"
-  context := "Speaker believes room is empty; no contextual evidence"
-  sentence := "Nandao wuli you ren? (Are there people in the room?)"
-  evidentialBias := false
-  epistemicBias := true
-  unexpectedEvidence := false
-  felicitous := false
+/-- The row records evidence unexpected to the speaker. -/
+def unexpectedEvidence (row : LinguisticExample) : Bool :=
+  row.feature? "unexpected_evidence" == some "true"
 
-/-- Ex. 5 ctx 1: evidence, no belief — felicitous. -/
-def evidenceNoBelief : NandaoDatum where
-  exampleNum := "5.1"
-  context := "No prior beliefs; B enters with dripping raincoat"
-  sentence := "Nandao waimian xiayu-le ma? (Is it raining outside?)"
-  evidentialBias := true
-  epistemicBias := false
-  unexpectedEvidence := true
-  felicitous := true
-
-/-- Ex. 5 ctx 2: no evidence, no belief — infelicitous. -/
-def noEvidenceNoBelief : NandaoDatum where
-  exampleNum := "5.2"
-  context := "No prior beliefs; B enters normally (no raincoat)"
-  sentence := "Nandao waimian xiayu-le ma? (Is it raining outside?)"
-  evidentialBias := false
-  epistemicBias := false
-  unexpectedEvidence := false
-  felicitous := false
-
-/-- Ex. 5 ctx 3: epistemic bias, no evidence — infelicitous. -/
-def beliefNoEvidence : NandaoDatum where
-  exampleNum := "5.3"
-  context := "A thinks it won't rain; B enters normally (no raincoat)"
-  sentence := "Nandao waimian xiayu-le ma? (Is it raining outside?)"
-  evidentialBias := false
-  epistemicBias := true
-  unexpectedEvidence := false
-  felicitous := false
-
-/-- Ex. 6 ctx 1: unexpected evidence — felicitous. -/
-def workSundayUnexpected : NandaoDatum where
-  exampleNum := "6.1"
-  context := "B doesn't think people work Sundays; A says Lee is working Sunday"
-  sentence := "Nandao ta hen.mang ma? (Is he busy?)"
-  evidentialBias := true
-  epistemicBias := true
-  unexpectedEvidence := true
-  felicitous := true
-
-/-- Ex. 6 ctx 2: expected evidence — infelicitous. -/
-def workSundayExpected : NandaoDatum where
-  exampleNum := "6.2"
-  context := "B knows Lee usually works Sundays; A says Lee is working Sunday"
-  sentence := "Nandao ta hen.mang ma? (Is he busy?)"
-  evidentialBias := true
-  epistemicBias := false
-  unexpectedEvidence := false
-  felicitous := false
-
-/-- The pooled felicity data of exx. 1–6. -/
-def allData : List NandaoDatum :=
-  [ rhetoricalUse, biasedUse, pureInquiry,
-    epistemicOnly,
-    evidenceNoBelief, noEvidenceNoBelief, beliefNoEvidence,
-    workSundayUnexpected, workSundayExpected ]
+/-- The row's nandao-Q is felicitous. -/
+def felicitous (row : LinguisticExample) : Bool :=
+  row.judgment == .acceptable
 
 /-- All felicitous nandao-Qs have evidential bias (Generalization 1). -/
 theorem evidential_bias_necessary :
-    (allData.filter (·.felicitous)).all (·.evidentialBias) = true := by decide
+    (Examples.all.filter felicitous).all evidentialBias = true := by decide
 
 /-- Some felicitous nandao-Qs lack epistemic bias — the pure inquiry use
 (Generalization 2). -/
 theorem epistemic_bias_not_necessary :
-    (allData.filter (λ d => d.felicitous && !d.epistemicBias)).length > 0 := by decide
+    (Examples.all.filter (λ d => felicitous d && !epistemicBias d)).length > 0 := by
+  decide
 
 /-- Some infelicitous nandao-Qs have epistemic bias, so epistemic bias is not
 sufficient (Generalization 3). -/
 theorem epistemic_bias_not_sufficient :
-    (allData.filter (λ d => d.epistemicBias && !d.felicitous)).length > 0 := by decide
+    (Examples.all.filter (λ d => epistemicBias d && !felicitous d)).length > 0 := by
+  decide
 
 /-- All felicitous nandao-Qs have unexpected evidence (Generalization 4). -/
 theorem unexpectedness_necessary :
-    (allData.filter (·.felicitous)).all (·.unexpectedEvidence) = true := by decide
+    (Examples.all.filter felicitous).all unexpectedEvidence = true := by decide
 
 /-! ### Kernel-theoretic felicity conditions
 
@@ -418,7 +325,7 @@ theorem nandaoFullFelicity_declarative_iff {p : Set World}
 /-- In the dripping-raincoat scenario with sister `declarative isRaining`,
 both layers of nandao felicity hold simultaneously; reduces to
 `raincoat_nandao_felicitous` via `nandaoFullFelicity_declarative_iff`. The
-datum `biasedUse` records the same scenario ([zheng-2025] ex. 2) as
+row `Examples.ex2` records the same scenario ([zheng-2025] ex. 2) as
 empirical data. -/
 theorem biasedUse_integrated_felicity :
     nandaoFullFelicity (Question.ofSet isRaining) raincoatK dryU

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -101,6 +101,14 @@ measure on a finite `W`: P(φ|p) > P(φ). -/
 def evidenceRaises (p φ : Set W) : Prop :=
   (p ∩ φ).ncard * Nat.card W > φ.ncard * p.ncard
 
+instance (p φ : W → Prop) [Fintype W] [DecidablePred p] [DecidablePred φ] :
+    Decidable (evidenceRaises p φ) :=
+  decidable_of_iff
+    ((Finset.univ.filter λ w => p w ∧ φ w).card * Fintype.card W >
+      (Finset.univ.filter φ).card * (Finset.univ.filter p).card) <| by
+    show _ ↔ {w | p w ∧ φ w}.ncard * Nat.card W > {w | φ w}.ncard * {w | p w}.ncard
+    simp [Set.ncard_eq_toFinset_card', Set.toFinset_setOf, Nat.card_eq_fintype_card]
+
 section
 variable (k : Kernel W) (u : List (W → Prop)) (φ : W → Prop)
 
@@ -152,24 +160,17 @@ def dryU : List (World → Prop) := [expectDry]
 context (exx. 2–3). -/
 theorem raincoat_nandao_felicitous :
     nandaoFelicitous raincoatK dryU isRaining := by
-  refine ⟨⟨wearingRaincoat, by simp [raincoatK], ?_⟩, ?_, ?_⟩
-  · -- P(rain|coat) = 1/2 > P(rain) = 1/4: cross-multiplied, 1 ⬝ 4 > 1 ⬝ 2.
-    show {w | wearingRaincoat w ∧ isRaining w}.ncard * Nat.card World >
-      {w | isRaining w}.ncard * {w | wearingRaincoat w}.ncard
-    simp only [Set.ncard_eq_toFinset_card', Nat.card_eq_fintype_card]
-    decide
-  · refine Set.disjoint_left.mpr λ w hK hU => ?_
-    have h1 : wearingRaincoat w := mem_propIntersection.mp hK _ (by simp [raincoatK])
-    have h2 : expectDry w := mem_propIntersection.mp hU _ (by simp [dryU])
-    revert h1 h2
-    cases w <;> decide
-  · rintro ⟨x, hx, hxor⟩
-    rcases List.mem_singleton.mp (by simpa [raincoatK] using hx) with rfl
-    rcases hxor with h_sub | h_disj
-    · exact (show ¬ isRaining .sprinkler from by decide)
-        (h_sub (show wearingRaincoat .sprinkler from by decide))
-    · exact Set.disjoint_left.mp h_disj (show wearingRaincoat .rain from by decide)
-        (show isRaining .rain from by decide)
+  refine ⟨⟨wearingRaincoat, List.mem_singleton_self _, by decide⟩, ?_, ?_⟩
+  · simp only [unexpected, raincoatK, dryU, Kernel.base_singleton,
+      propIntersection_singleton]
+    exact Set.disjoint_left.mpr λ w (h1 : wearingRaincoat w) (h2 : expectDry w) => by
+      revert h1 h2; cases w <;> decide
+  · simp only [raincoatK, Kernel.directlySettles_singleton]
+    rintro (h_sub | h_disj)
+    · exact (by decide : ¬ isRaining .sprinkler)
+        (h_sub (by decide : wearingRaincoat .sprinkler))
+    · exact Set.disjoint_left.mp h_disj (by decide : wearingRaincoat .rain)
+        (by decide : isRaining .rain)
 
 /-- Without evidence, nandao is infelicitous (ex. 5 ctx 2). -/
 theorem no_evidence_nandao_infelicitous :

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -10,11 +10,10 @@ import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Zheng (2025): Nandao-Q Felicity
-[zheng-2025]
 
 Mandarin *nandao*-question felicity: positive evidential bias is necessary,
 while negative epistemic bias is neither necessary nor sufficient. The
-felicity conditions (Zheng's condition (11)) are built on
+felicity conditions ([zheng-2025] condition (11)) are built on
 [von-fintel-gillies-2010]'s kernel: some evidence in the kernel K raises the
 probability of the prejacent, K conflicts with the prior information state U,
 and the prejacent is not directly settled in K.
@@ -91,10 +90,9 @@ theorem unexpectedness_necessary :
 A nandao question is felicitous when some evidence in the kernel raises the
 probability of the prejacent, the kernel conflicts with the prior information
 state `U` — the beliefs, norms, and desires in place before encountering the
-evidence — and the prejacent is not directly settled ([zheng-2025]
-condition (11); its "significantly raises" (≫) is sharpened to strict
-raising). The last conjunct is the presupposition of
-[von-fintel-gillies-2010]'s `kernelMust`. -/
+evidence — and the prejacent is not directly settled (condition (11); its
+"significantly raises" (≫) is sharpened to strict raising). The last
+conjunct is the presupposition of [von-fintel-gillies-2010]'s `kernelMust`. -/
 
 variable {W : Type*}
 
@@ -107,25 +105,24 @@ section
 variable (k : Kernel W) (u : List (W → Prop)) (φ : W → Prop)
 
 /-- Some proposition in K raises the probability of φ
-([zheng-2025] condition (11i)). -/
+(condition (11i)). -/
 def evidenceSupports : Prop :=
   ∃ p ∈ k.props, evidenceRaises p φ
 
 /-- The evidence in K is unexpected given the prior information state U
-([zheng-2025] condition (11ii)). -/
+(condition (11ii)). -/
 def unexpected : Prop :=
   Disjoint k.base (propIntersection u)
 
 /-- Nandao `φ`? is felicitous iff some evidence in `K` raises P(φ), the
 evidence is unexpected given the prior state `U`, and `φ` is not directly
-settled in `K` ([zheng-2025] condition (11), final version for polar
-questions). -/
+settled in `K` (condition (11), final version for polar questions). -/
 def nandaoFelicitous : Prop :=
   evidenceSupports k φ ∧ unexpected k u ∧ ¬ k.directlySettles φ
 
 end
 
-/-! ### The dripping-raincoat scenario ([zheng-2025] exx. 2–3, 5)
+/-! ### The dripping-raincoat scenario (exx. 2–3, 5)
 
 K = {wearingRaincoat}: direct evidence that someone entered with a wet coat.
 U = {expectDry}: prior expectation of no rain (doxastic or normative). -/
@@ -151,22 +148,15 @@ def raincoatK : Kernel World := ⟨[wearingRaincoat]⟩
 /-- The prior information state in which A expects dry weather. -/
 def dryU : List (World → Prop) := [expectDry]
 
-/-- "Nandao waimian xiayu-le ma?" is felicitous with a dripping raincoat:
-P(rain|coat) = 1/2 > P(rain) = 1/4; B_K ∩ ⋂U = ∅; rain unsettled by K. -/
+/-- "Nandao waimian xiayu-le ma?" is felicitous in the dripping-raincoat
+context (exx. 2–3). -/
 theorem raincoat_nandao_felicitous :
     nandaoFelicitous raincoatK dryU isRaining := by
   refine ⟨⟨wearingRaincoat, by simp [raincoatK], ?_⟩, ?_, ?_⟩
-  · -- |coat ∩ rain| ⬝ |W| > |rain| ⬝ |coat|: 1 ⬝ 4 > 1 ⬝ 2.
+  · -- P(rain|coat) = 1/2 > P(rain) = 1/4: cross-multiplied, 1 ⬝ 4 > 1 ⬝ 2.
     show {w | wearingRaincoat w ∧ isRaining w}.ncard * Nat.card World >
       {w | isRaining w}.ncard * {w | wearingRaincoat w}.ncard
-    have hpφ : {w | wearingRaincoat w ∧ isRaining w} = {World.rain} := by
-      ext w; cases w <;> simp [wearingRaincoat, isRaining]
-    have hφ : {w | isRaining w} = {World.rain} := by
-      ext w; cases w <;> simp [isRaining]
-    have hp : {w | wearingRaincoat w} = {World.rain, World.sprinkler} := by
-      ext w; cases w <;> simp [wearingRaincoat]
-    rw [hpφ, hφ, hp, Set.ncard_singleton, Set.ncard_pair (by decide),
-      Nat.card_eq_fintype_card]
+    simp only [Set.ncard_eq_toFinset_card', Nat.card_eq_fintype_card]
     decide
   · refine Set.disjoint_left.mpr λ w hK hU => ?_
     have h1 : wearingRaincoat w := mem_propIntersection.mp hK _ (by simp [raincoatK])
@@ -181,14 +171,14 @@ theorem raincoat_nandao_felicitous :
     · exact Set.disjoint_left.mp h_disj (show wearingRaincoat .rain from by decide)
         (show isRaining .rain from by decide)
 
-/-- Without evidence, nandao is infelicitous ([zheng-2025] ex. 5 ctx 2). -/
+/-- Without evidence, nandao is infelicitous (ex. 5 ctx 2). -/
 theorem no_evidence_nandao_infelicitous :
     ¬ nandaoFelicitous ⟨[]⟩ dryU isRaining := by
   rintro ⟨⟨x, hx, _⟩, _, _⟩
   exact List.not_mem_nil hx
 
 /-- When evidence is expected (K compatible with U), nandao is infelicitous
-([zheng-2025] ex. 6 ctx 2, transposed to the raincoat scenario: a prior
+(ex. 6 ctx 2, transposed to the raincoat scenario: a prior
 expectation of wet coats makes the evidence unremarkable). -/
 theorem expected_evidence_infelicitous :
     ¬ nandaoFelicitous raincoatK [wearingRaincoat] isRaining := by
@@ -321,7 +311,7 @@ theorem nandaoFullFelicity_declarative_iff {p : Set World}
 /-- In the dripping-raincoat scenario with sister `declarative isRaining`,
 both layers of nandao felicity hold simultaneously; reduces to
 `raincoat_nandao_felicitous` via `nandaoFullFelicity_declarative_iff`. The
-row `Examples.ex2` records the same scenario ([zheng-2025] ex. 2) as
+row `Examples.ex2` records the same scenario (ex. 2) as
 empirical data. -/
 theorem biasedUse_integrated_felicity :
     nandaoFullFelicity (Question.ofSet isRaining) raincoatK dryU

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -92,14 +92,14 @@ A nandao question is felicitous when some evidence in the kernel raises the
 probability of the prejacent, the kernel conflicts with the prior information
 state `U` — the beliefs, norms, and desires in place before encountering the
 evidence — and the prejacent is not directly settled ([zheng-2025]
-condition (11)). The last conjunct is the presupposition of
+condition (11); its "significantly raises" (≫) is sharpened to strict
+raising). The last conjunct is the presupposition of
 [von-fintel-gillies-2010]'s `kernelMust`. -/
 
 variable {W : Type*}
 
 /-- Evidence `p` raises the probability of `φ` under the uniform counting
-measure on a finite `W`: P(φ|p) > P(φ). [zheng-2025]'s condition (11i) writes
-P(φ|p) ≫ P(φ); we sharpen "significantly raises" to strict raising. -/
+measure on a finite `W`: P(φ|p) > P(φ). -/
 def evidenceRaises (p φ : Set W) : Prop :=
   (p ∩ φ).ncard * Nat.card W > φ.ncard * p.ncard
 

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -161,16 +161,15 @@ context (exx. 2–3). -/
 theorem raincoat_nandao_felicitous :
     nandaoFelicitous raincoatK dryU isRaining := by
   refine ⟨⟨wearingRaincoat, List.mem_singleton_self _, by decide⟩, ?_, ?_⟩
-  · simp only [unexpected, raincoatK, dryU, Kernel.base_singleton,
-      propIntersection_singleton]
-    exact Set.disjoint_left.mpr λ w (h1 : wearingRaincoat w) (h2 : expectDry w) => by
-      revert h1 h2; cases w <;> decide
-  · simp only [raincoatK, Kernel.directlySettles_singleton]
-    rintro (h_sub | h_disj)
-    · exact (by decide : ¬ isRaining .sprinkler)
-        (h_sub (by decide : wearingRaincoat .sprinkler))
-    · exact Set.disjoint_left.mp h_disj (by decide : wearingRaincoat .rain)
-        (by decide : isRaining .rain)
+  · -- No coat-world is an expected world.
+    simp only [unexpected, raincoatK, dryU, Kernel.base_singleton,
+      propIntersection_singleton, disjoint_propExtension_iff]
+    decide
+  · -- The coat neither entails rain (the sprinkler world) nor excludes it
+    -- (the rain world).
+    simp only [raincoatK, Kernel.directlySettles_singleton,
+      propExtension_subset_iff, disjoint_propExtension_iff]
+    decide
 
 /-- Without evidence, nandao is infelicitous (ex. 5 ctx 2). -/
 theorem no_evidence_nandao_infelicitous :

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -88,21 +88,18 @@ theorem unexpectedness_necessary :
 
 /-! ### Kernel-theoretic felicity conditions
 
-Zheng's condition (11), the final felicity condition for nandao on polar
-questions, built on [von-fintel-gillies-2010]'s kernel: (i) some evidence
-`p ∈ K` raises the probability of the prejacent φ; (ii) the kernel conflicts
-with the prior information state U — the evidence is unexpected; (iii) φ is
-not directly settled in K. Condition (iii) is the presupposition of
+A nandao question is felicitous when some evidence in the kernel raises the
+probability of the prejacent, the kernel conflicts with the prior information
+state `U` — the beliefs, norms, and desires in place before encountering the
+evidence — and the prejacent is not directly settled ([zheng-2025]
+condition (11)). The last conjunct is the presupposition of
 [von-fintel-gillies-2010]'s `kernelMust`. -/
 
 variable {W : Type*}
 
-/-- Evidence `p` raises the probability of `φ` under the uniform (counting)
-measure: P(φ|p) > P(φ), stated by cross-multiplication over cardinalities to
-avoid rationals. [zheng-2025]'s condition (11i) writes P(φ|p) ≫ P(φ); we
-sharpen "significantly raises" to strict raising and fix the uniform measure
-on `W`. Meaningful for finite `W` (`Set.ncard` and `Nat.card` are junk
-otherwise). -/
+/-- Evidence `p` raises the probability of `φ` under the uniform counting
+measure on a finite `W`: P(φ|p) > P(φ). [zheng-2025]'s condition (11i) writes
+P(φ|p) ≫ P(φ); we sharpen "significantly raises" to strict raising. -/
 def evidenceRaises (p φ : Set W) : Prop :=
   (p ∩ φ).ncard * Nat.card W > φ.ncard * p.ncard
 
@@ -115,9 +112,7 @@ def evidenceSupports : Prop :=
   ∃ p ∈ k.props, evidenceRaises p φ
 
 /-- The evidence in K is unexpected given the prior information state U
-([zheng-2025] condition (11ii)): B_K is disjoint from ⋂U. U collects what
-leads to the information state prior to encountering the evidence — beliefs,
-norms, desires — distinct from the kernel's direct evidence. -/
+([zheng-2025] condition (11ii)). -/
 def unexpected : Prop :=
   Disjoint k.base (propIntersection u)
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -13256,6 +13256,20 @@
   role      = {cited},
   sources   = {Studies/BhattDayal2020.lean}
 }
+@inproceedings{xu-2018,
+  author    = {Xu, Beibei},
+  year      = {2018},
+  title     = {Dedicated Bias Word \emph{nandao} as an Illocutionary Modifier},
+  booktitle = {Proceedings of the 35th West Coast Conference on Formal Linguistics (WCCFL 35)},
+  editor    = {Bennett, Wm. G. and Hracs, Lindsay and Storoshenko, Dennis Ryan},
+  pages     = {448--457},
+  publisher = {Cascadilla Proceedings Project},
+  address   = {Somerville, MA},
+  url       = {http://www.lingref.com/cpp/wccfl/35/paper3418.pdf},
+  subfield  = {semantics/questions},
+  role      = {cited},
+  sources   = {Data/Examples/Zheng2025.json}
+}
 @phdthesis{xu-2017,
   author    = {Xu, Beibei},
   year      = {2017},


### PR DESCRIPTION
Moves the hand-typed `NandaoDatum` table out of `Studies/Zheng2025.lean` into `Data/Examples/Zheng2025.json` per the Data/ grounding doctrine: 9 rows for exx. 1–6 with IGT glosses, the paper's translations, and the bias profile as `paperFeatures` (felicity carried by `judgment`, not duplicated). The study's four generalization theorems now quantify over the generated `Examples.all` via `feature?` adapters.

- Provenance fixes: the room example is (4b), not 4a as the old table had it, and it is sourced to Xu 2018 p. 449 (`source: xu-2018`, `reportedIn: zheng-2025`) with a new verified bib entry (WCCFL 35, Cascadilla, pp. 448–457).
- Generator output (`Data/Examples/Zheng2025.lean`, `Linglib.lean` sync) included; `--check` green.