### PR TITLE
fix(Studies/FutrellEtAl2020): reground on the paper's real Table 2

### DIFF
--- a/Linglib/Studies/FutrellEtAl2020.lean
+++ b/Linglib/Studies/FutrellEtAl2020.lean
@@ -15,7 +15,9 @@ Values are scaled integers — permille for the head-final proportion, ×100
 for dependency lengths (mirroring the table's two decimal places) — so
 that downstream list computations kernel-`decide`. UD language codes are
 linglib annotation for cross-study joins (`Studies/LevshinaEtAl2023`);
-they are not part of the table.
+they are not printed in the table, but match the language keys of the
+paper's analysis pipeline, the CLIQS codebase its footnote cites
+(<https://github.com/langprocgroup/cliqs/>, `typology3.csv`).
 -/
 
 namespace FutrellEtAl2020

--- a/Linglib/Studies/FutrellEtAl2020.lean
+++ b/Linglib/Studies/FutrellEtAl2020.lean
@@ -1,334 +1,137 @@
 /-!
-# [futrell-gibson-2020]: Crosslinguistic Dependency Length Data
-[futrell-gibson-2020] [zaslavsky-hu-levy-2020]
+# Crosslinguistic Dependency Length Data
+[futrell-gibson-2020]
 
-Empirical data from Table 2 of [futrell-gibson-2020] "Dependency
-locality as an explanatory principle for word order", Language 96(2):371–412.
+Table 2 of [futrell-gibson-2020] ("Dependency locality as an explanatory
+principle for word order", *Language* 96(2):371–412): for each of the 46
+languages measured over Universal Dependencies 2.1 corpora, the proportion
+of head-final dependencies and the mean dependency length per word at
+sentence lengths 10, 15, and 20. The paper reads the table together with
+its scatterplots: more head-final languages have longer dependencies, and
+the languages with especially long dependencies are predominantly
+head-final ones such as Japanese, Korean, and Turkish.
 
-53 languages from Universal Dependencies corpora, measuring:
-- Proportion of head-final dependencies
-- Mean dependency length at sentence lengths 10, 15, 20
-
-All values are scaled integers to avoid Float (permille for proportions,
-× 100 for dependency lengths).
-
-## Key Empirical Finding
-
-Head-final languages (Japanese, Korean, Turkish, Hindi) systematically have
-higher mean dependency lengths than head-initial languages (Arabic, Indonesian,
-Romanian), controlling for sentence length. This is predicted by DLM theory:
-head-final order with right-branching structures creates longer dependencies.
-
+Values are scaled integers — permille for the head-final proportion, ×100
+for dependency lengths (mirroring the table's two decimal places) — so
+that downstream list computations kernel-`decide`. UD language codes are
+linglib annotation for cross-study joins (`Studies/LevshinaEtAl2023`);
+they are not part of the table.
 -/
 
 namespace FutrellEtAl2020
 
--- ============================================================================
--- Data Structure
--- ============================================================================
-
-/-- Crosslinguistic dependency length data for a single language.
-
-Values are scaled integers:
-- `propHeadFinal`: × 1000 (permille), e.g., 890 = 89.0% head-final
-- `depLengthAt10/15/20`: × 100, e.g., 245 = 2.45 mean dep length -/
-structure LanguageDLM where
-  name : String
+/-- One row of Table 2: head-final proportion and mean per-word dependency
+lengths for one UD 2.1 language. -/
+structure DepLengthRow where
+  /-- Language name as printed in the table (e.g. "Norwegian (B)"). -/
+  language : String
+  /-- UD language code (linglib annotation, not part of the table). -/
   isoCode : String
-  family : String
-  propHeadFinal : Nat    -- × 1000
-  depLengthAt10 : Nat    -- × 100
-  depLengthAt15 : Nat    -- × 100
-  depLengthAt20 : Nat    -- × 100
+  /-- Proportion of head-final dependencies, permille (881 = 0.881). -/
+  propHeadFinal1000 : Nat
+  /-- Mean dependency length per word at sentence length 10, ×100. -/
+  depLengthAt10_100 : Nat
+  /-- Mean dependency length per word at sentence length 15, ×100. -/
+  depLengthAt15_100 : Nat
+  /-- Mean dependency length per word at sentence length 20, ×100. -/
+  depLengthAt20_100 : Nat
   deriving Repr, DecidableEq
 
--- ============================================================================
--- Classification
--- ============================================================================
+/-- Table 2, in the paper's row order (descending head-final proportion). -/
+def table2 : List DepLengthRow := [
+  { language := "Korean", isoCode := "ko", propHeadFinal1000 := 881,
+    depLengthAt10_100 := 201, depLengthAt15_100 := 249, depLengthAt20_100 := 284 },
+  { language := "Japanese", isoCode := "ja", propHeadFinal1000 := 809,
+    depLengthAt10_100 := 170, depLengthAt15_100 := 198, depLengthAt20_100 := 226 },
+  { language := "Turkish", isoCode := "tr", propHeadFinal1000 := 778,
+    depLengthAt10_100 := 199, depLengthAt15_100 := 236, depLengthAt20_100 := 261 },
+  { language := "Hindi", isoCode := "hi", propHeadFinal1000 := 763,
+    depLengthAt10_100 := 188, depLengthAt15_100 := 226, depLengthAt20_100 := 257 },
+  { language := "Urdu", isoCode := "ur", propHeadFinal1000 := 745,
+    depLengthAt10_100 := 186, depLengthAt15_100 := 227, depLengthAt20_100 := 249 },
+  { language := "Hungarian", isoCode := "hu", propHeadFinal1000 := 726,
+    depLengthAt10_100 := 178, depLengthAt15_100 := 213, depLengthAt20_100 := 240 },
+  { language := "Mandarin", isoCode := "zh", propHeadFinal1000 := 661,
+    depLengthAt10_100 := 203, depLengthAt15_100 := 251, depLengthAt20_100 := 298 },
+  { language := "Basque", isoCode := "eu", propHeadFinal1000 := 587,
+    depLengthAt10_100 := 177, depLengthAt15_100 := 210, depLengthAt20_100 := 229 },
+  { language := "Ancient Greek", isoCode := "grc", propHeadFinal1000 := 566,
+    depLengthAt10_100 := 234, depLengthAt15_100 := 274, depLengthAt20_100 := 308 },
+  { language := "Latin", isoCode := "la", propHeadFinal1000 := 547,
+    depLengthAt10_100 := 227, depLengthAt15_100 := 272, depLengthAt20_100 := 299 },
+  { language := "Northern Sami", isoCode := "sme", propHeadFinal1000 := 542,
+    depLengthAt10_100 := 185, depLengthAt15_100 := 220, depLengthAt20_100 := 262 },
+  { language := "Dutch", isoCode := "nl", propHeadFinal1000 := 533,
+    depLengthAt10_100 := 207, depLengthAt15_100 := 248, depLengthAt20_100 := 274 },
+  { language := "Afrikaans", isoCode := "af", propHeadFinal1000 := 524,
+    depLengthAt10_100 := 216, depLengthAt15_100 := 248, depLengthAt20_100 := 278 },
+  { language := "Finnish", isoCode := "fi", propHeadFinal1000 := 521,
+    depLengthAt10_100 := 167, depLengthAt15_100 := 192, depLengthAt20_100 := 216 },
+  { language := "Latvian", isoCode := "lv", propHeadFinal1000 := 513,
+    depLengthAt10_100 := 171, depLengthAt15_100 := 193, depLengthAt20_100 := 216 },
+  { language := "Estonian", isoCode := "et", propHeadFinal1000 := 508,
+    depLengthAt10_100 := 184, depLengthAt15_100 := 213, depLengthAt20_100 := 232 },
+  { language := "German", isoCode := "de", propHeadFinal1000 := 500,
+    depLengthAt10_100 := 204, depLengthAt15_100 := 245, depLengthAt20_100 := 281 },
+  { language := "Modern Greek", isoCode := "el", propHeadFinal1000 := 472,
+    depLengthAt10_100 := 159, depLengthAt15_100 := 186, depLengthAt20_100 := 202 },
+  { language := "English", isoCode := "en", propHeadFinal1000 := 460,
+    depLengthAt10_100 := 167, depLengthAt15_100 := 193, depLengthAt20_100 := 210 },
+  { language := "Danish", isoCode := "da", propHeadFinal1000 := 420,
+    depLengthAt10_100 := 172, depLengthAt15_100 := 201, depLengthAt20_100 := 213 },
+  { language := "Swedish", isoCode := "sv", propHeadFinal1000 := 420,
+    depLengthAt10_100 := 166, depLengthAt15_100 := 193, depLengthAt20_100 := 213 },
+  { language := "Slovenian", isoCode := "sl", propHeadFinal1000 := 419,
+    depLengthAt10_100 := 173, depLengthAt15_100 := 195, depLengthAt20_100 := 219 },
+  { language := "Slovak", isoCode := "sk", propHeadFinal1000 := 412,
+    depLengthAt10_100 := 165, depLengthAt15_100 := 185, depLengthAt20_100 := 210 },
+  { language := "Norwegian (B)", isoCode := "nb", propHeadFinal1000 := 401,
+    depLengthAt10_100 := 163, depLengthAt15_100 := 190, depLengthAt20_100 := 208 },
+  { language := "Persian", isoCode := "fa", propHeadFinal1000 := 401,
+    depLengthAt10_100 := 226, depLengthAt15_100 := 265, depLengthAt20_100 := 288 },
+  { language := "Norwegian (N)", isoCode := "nn", propHeadFinal1000 := 390,
+    depLengthAt10_100 := 163, depLengthAt15_100 := 192, depLengthAt20_100 := 206 },
+  { language := "Czech", isoCode := "cs", propHeadFinal1000 := 389,
+    depLengthAt10_100 := 169, depLengthAt15_100 := 194, depLengthAt20_100 := 213 },
+  { language := "Italian", isoCode := "it", propHeadFinal1000 := 384,
+    depLengthAt10_100 := 150, depLengthAt15_100 := 180, depLengthAt20_100 := 188 },
+  { language := "Croatian", isoCode := "hr", propHeadFinal1000 := 380,
+    depLengthAt10_100 := 168, depLengthAt15_100 := 189, depLengthAt20_100 := 206 },
+  { language := "French", isoCode := "fr", propHeadFinal1000 := 374,
+    depLengthAt10_100 := 151, depLengthAt15_100 := 175, depLengthAt20_100 := 189 },
+  { language := "Portuguese", isoCode := "pt", propHeadFinal1000 := 373,
+    depLengthAt10_100 := 155, depLengthAt15_100 := 181, depLengthAt20_100 := 200 },
+  { language := "Bulgarian", isoCode := "bg", propHeadFinal1000 := 372,
+    depLengthAt10_100 := 156, depLengthAt15_100 := 181, depLengthAt20_100 := 197 },
+  { language := "Gothic", isoCode := "got", propHeadFinal1000 := 372,
+    depLengthAt10_100 := 197, depLengthAt15_100 := 234, depLengthAt20_100 := 275 },
+  { language := "Catalan", isoCode := "ca", propHeadFinal1000 := 371,
+    depLengthAt10_100 := 155, depLengthAt15_100 := 178, depLengthAt20_100 := 194 },
+  { language := "Ukrainian", isoCode := "uk", propHeadFinal1000 := 368,
+    depLengthAt10_100 := 161, depLengthAt15_100 := 189, depLengthAt20_100 := 206 },
+  { language := "Galician", isoCode := "gl", propHeadFinal1000 := 365,
+    depLengthAt10_100 := 150, depLengthAt15_100 := 220, depLengthAt20_100 := 210 },
+  { language := "Russian", isoCode := "ru", propHeadFinal1000 := 358,
+    depLengthAt10_100 := 156, depLengthAt15_100 := 181, depLengthAt20_100 := 207 },
+  { language := "Serbian", isoCode := "sr", propHeadFinal1000 := 349,
+    depLengthAt10_100 := 160, depLengthAt15_100 := 182, depLengthAt20_100 := 200 },
+  { language := "Church Slavonic", isoCode := "cu", propHeadFinal1000 := 341,
+    depLengthAt10_100 := 200, depLengthAt15_100 := 241, depLengthAt20_100 := 272 },
+  { language := "Vietnamese", isoCode := "vi", propHeadFinal1000 := 339,
+    depLengthAt10_100 := 165, depLengthAt15_100 := 195, depLengthAt20_100 := 212 },
+  { language := "Spanish", isoCode := "es", propHeadFinal1000 := 332,
+    depLengthAt10_100 := 145, depLengthAt15_100 := 171, depLengthAt20_100 := 186 },
+  { language := "Polish", isoCode := "pl", propHeadFinal1000 := 325,
+    depLengthAt10_100 := 156, depLengthAt15_100 := 180, depLengthAt20_100 := 205 },
+  { language := "Hebrew", isoCode := "he", propHeadFinal1000 := 314,
+    depLengthAt10_100 := 154, depLengthAt15_100 := 181, depLengthAt20_100 := 195 },
+  { language := "Romanian", isoCode := "ro", propHeadFinal1000 := 301,
+    depLengthAt10_100 := 160, depLengthAt15_100 := 179, depLengthAt20_100 := 195 },
+  { language := "Indonesian", isoCode := "id", propHeadFinal1000 := 244,
+    depLengthAt10_100 := 148, depLengthAt15_100 := 175, depLengthAt20_100 := 194 },
+  { language := "Arabic", isoCode := "ar", propHeadFinal1000 := 103,
+    depLengthAt10_100 := 140, depLengthAt15_100 := 168, depLengthAt20_100 := 193 } ]
 
-/-- A language is predominantly head-final if > 50% of deps are head-final. -/
-def LanguageDLM.isHeadFinal (l : LanguageDLM) : Bool := l.propHeadFinal > 500
-
-/-- A language is predominantly head-initial if ≤ 50% of deps are head-final. -/
-def LanguageDLM.isHeadInitial (l : LanguageDLM) : Bool := l.propHeadFinal ≤ 500
-
--- ============================================================================
--- Language Data ([futrell-gibson-2020], Table 2, representative subset)
--- ============================================================================
--- Values are approximate from the paper's figures and supplementary materials.
--- Dep lengths are mean dependency lengths at sentence lengths 10, 15, 20.
-
-/-- Arabic (afro-asiatic, head-initial, VSO/SVO) -/
-def arabic : LanguageDLM :=
-  { name := "Arabic", isoCode := "ar", family := "Afro-Asiatic"
-    propHeadFinal := 210, depLengthAt10 := 215, depLengthAt15 := 240, depLengthAt20 := 260 }
-
-/-- Basque (isolate, head-final, SOV) -/
-def basque : LanguageDLM :=
-  { name := "Basque", isoCode := "eu", family := "Isolate"
-    propHeadFinal := 720, depLengthAt10 := 255, depLengthAt15 := 295, depLengthAt20 := 320 }
-
-/-- Bulgarian (Indo-European, head-initial, SVO) -/
-def bulgarian : LanguageDLM :=
-  { name := "Bulgarian", isoCode := "bg", family := "Indo-European"
-    propHeadFinal := 350, depLengthAt10 := 225, depLengthAt15 := 255, depLengthAt20 := 280 }
-
-/-- Chinese (Sino-Tibetan, mixed) -/
-def chinese : LanguageDLM :=
-  { name := "Chinese", isoCode := "zh", family := "Sino-Tibetan"
-    propHeadFinal := 510, depLengthAt10 := 235, depLengthAt15 := 270, depLengthAt20 := 295 }
-
-/-- Czech (Indo-European, head-initial, SVO) -/
-def czech : LanguageDLM :=
-  { name := "Czech", isoCode := "cs", family := "Indo-European"
-    propHeadFinal := 410, depLengthAt10 := 230, depLengthAt15 := 265, depLengthAt20 := 290 }
-
-/-- Danish (Indo-European, head-initial, SVO) -/
-def danish : LanguageDLM :=
-  { name := "Danish", isoCode := "da", family := "Indo-European"
-    propHeadFinal := 370, depLengthAt10 := 220, depLengthAt15 := 250, depLengthAt20 := 275 }
-
-/-- Dutch (Indo-European, mixed V2) -/
-def dutch : LanguageDLM :=
-  { name := "Dutch", isoCode := "nl", family := "Indo-European"
-    propHeadFinal := 480, depLengthAt10 := 240, depLengthAt15 := 275, depLengthAt20 := 305 }
-
-/-- English (Indo-European, head-initial, SVO) -/
-def english : LanguageDLM :=
-  { name := "English", isoCode := "en", family := "Indo-European"
-    propHeadFinal := 320, depLengthAt10 := 220, depLengthAt15 := 250, depLengthAt20 := 270 }
-
-/-- Estonian (Uralic, mixed) -/
-def estonian : LanguageDLM :=
-  { name := "Estonian", isoCode := "et", family := "Uralic"
-    propHeadFinal := 490, depLengthAt10 := 235, depLengthAt15 := 270, depLengthAt20 := 295 }
-
-/-- Finnish (Uralic, head-final, SVO) -/
-def finnish : LanguageDLM :=
-  { name := "Finnish", isoCode := "fi", family := "Uralic"
-    propHeadFinal := 530, depLengthAt10 := 240, depLengthAt15 := 275, depLengthAt20 := 300 }
-
-/-- French (Indo-European, head-initial, SVO) -/
-def french : LanguageDLM :=
-  { name := "French", isoCode := "fr", family := "Indo-European"
-    propHeadFinal := 290, depLengthAt10 := 215, depLengthAt15 := 245, depLengthAt20 := 265 }
-
-/-- German (Indo-European, mixed V2/SOV) -/
-def german : LanguageDLM :=
-  { name := "German", isoCode := "de", family := "Indo-European"
-    propHeadFinal := 480, depLengthAt10 := 240, depLengthAt15 := 280, depLengthAt20 := 310 }
-
-/-- Greek (Indo-European, head-initial, SVO) -/
-def greek : LanguageDLM :=
-  { name := "Greek", isoCode := "el", family := "Indo-European"
-    propHeadFinal := 350, depLengthAt10 := 225, depLengthAt15 := 255, depLengthAt20 := 280 }
-
-/-- Hebrew (Afro-Asiatic, head-initial, SVO) -/
-def hebrew : LanguageDLM :=
-  { name := "Hebrew", isoCode := "he", family := "Afro-Asiatic"
-    propHeadFinal := 270, depLengthAt10 := 220, depLengthAt15 := 250, depLengthAt20 := 275 }
-
-/-- Hindi (Indo-European, head-final, SOV) -/
-def hindi : LanguageDLM :=
-  { name := "Hindi", isoCode := "hi", family := "Indo-European"
-    propHeadFinal := 780, depLengthAt10 := 260, depLengthAt15 := 310, depLengthAt20 := 345 }
-
-/-- Hungarian (Uralic, head-final) -/
-def hungarian : LanguageDLM :=
-  { name := "Hungarian", isoCode := "hu", family := "Uralic"
-    propHeadFinal := 580, depLengthAt10 := 245, depLengthAt15 := 280, depLengthAt20 := 310 }
-
-/-- Indonesian (Austronesian, head-initial, SVO) -/
-def indonesian : LanguageDLM :=
-  { name := "Indonesian", isoCode := "id", family := "Austronesian"
-    propHeadFinal := 250, depLengthAt10 := 210, depLengthAt15 := 235, depLengthAt20 := 255 }
-
-/-- Italian (Indo-European, head-initial, SVO) -/
-def italian : LanguageDLM :=
-  { name := "Italian", isoCode := "it", family := "Indo-European"
-    propHeadFinal := 300, depLengthAt10 := 220, depLengthAt15 := 250, depLengthAt20 := 270 }
-
-/-- Japanese (Japonic, head-final, SOV) -/
-def japanese : LanguageDLM :=
-  { name := "Japanese", isoCode := "ja", family := "Japonic"
-    propHeadFinal := 890, depLengthAt10 := 275, depLengthAt15 := 330, depLengthAt20 := 370 }
-
-/-- Korean (Koreanic, head-final, SOV) -/
-def korean : LanguageDLM :=
-  { name := "Korean", isoCode := "ko", family := "Koreanic"
-    propHeadFinal := 870, depLengthAt10 := 270, depLengthAt15 := 325, depLengthAt20 := 365 }
-
-/-- Latin (Indo-European, head-final, SOV) -/
-def latin : LanguageDLM :=
-  { name := "Latin", isoCode := "la", family := "Indo-European"
-    propHeadFinal := 600, depLengthAt10 := 250, depLengthAt15 := 290, depLengthAt20 := 320 }
-
-/-- Norwegian (Indo-European, head-initial, SVO) -/
-def norwegian : LanguageDLM :=
-  { name := "Norwegian", isoCode := "no", family := "Indo-European"
-    propHeadFinal := 360, depLengthAt10 := 220, depLengthAt15 := 250, depLengthAt20 := 275 }
-
-/-- Persian (Indo-European, head-final, SOV) -/
-def persian : LanguageDLM :=
-  { name := "Persian", isoCode := "fa", family := "Indo-European"
-    propHeadFinal := 650, depLengthAt10 := 250, depLengthAt15 := 285, depLengthAt20 := 315 }
-
-/-- Polish (Indo-European, head-initial, SVO) -/
-def polish : LanguageDLM :=
-  { name := "Polish", isoCode := "pl", family := "Indo-European"
-    propHeadFinal := 420, depLengthAt10 := 230, depLengthAt15 := 265, depLengthAt20 := 290 }
-
-/-- Portuguese (Indo-European, head-initial, SVO) -/
-def portuguese : LanguageDLM :=
-  { name := "Portuguese", isoCode := "pt", family := "Indo-European"
-    propHeadFinal := 280, depLengthAt10 := 215, depLengthAt15 := 245, depLengthAt20 := 265 }
-
-/-- Romanian (Indo-European, head-initial, SVO) -/
-def romanian : LanguageDLM :=
-  { name := "Romanian", isoCode := "ro", family := "Indo-European"
-    propHeadFinal := 290, depLengthAt10 := 215, depLengthAt15 := 240, depLengthAt20 := 260 }
-
-/-- Russian (Indo-European, mixed) -/
-def russian : LanguageDLM :=
-  { name := "Russian", isoCode := "ru", family := "Indo-European"
-    propHeadFinal := 430, depLengthAt10 := 235, depLengthAt15 := 270, depLengthAt20 := 300 }
-
-/-- Spanish (Indo-European, head-initial, SVO) -/
-def spanish : LanguageDLM :=
-  { name := "Spanish", isoCode := "es", family := "Indo-European"
-    propHeadFinal := 280, depLengthAt10 := 215, depLengthAt15 := 245, depLengthAt20 := 265 }
-
-/-- Swedish (Indo-European, head-initial, SVO) -/
-def swedish : LanguageDLM :=
-  { name := "Swedish", isoCode := "sv", family := "Indo-European"
-    propHeadFinal := 370, depLengthAt10 := 225, depLengthAt15 := 255, depLengthAt20 := 280 }
-
-/-- Tamil (Dravidian, head-final, SOV) -/
-def tamil : LanguageDLM :=
-  { name := "Tamil", isoCode := "ta", family := "Dravidian"
-    propHeadFinal := 830, depLengthAt10 := 265, depLengthAt15 := 320, depLengthAt20 := 355 }
-
-/-- Turkish (Turkic, head-final, SOV) -/
-def turkish : LanguageDLM :=
-  { name := "Turkish", isoCode := "tr", family := "Turkic"
-    propHeadFinal := 810, depLengthAt10 := 260, depLengthAt15 := 310, depLengthAt20 := 350 }
-
-/-- Urdu (Indo-European, head-final, SOV) -/
-def urdu : LanguageDLM :=
-  { name := "Urdu", isoCode := "ur", family := "Indo-European"
-    propHeadFinal := 770, depLengthAt10 := 258, depLengthAt15 := 305, depLengthAt20 := 340 }
-
-/-- Vietnamese (Austroasiatic, head-initial, SVO) -/
-def vietnamese : LanguageDLM :=
-  { name := "Vietnamese", isoCode := "vi", family := "Austroasiatic"
-    propHeadFinal := 260, depLengthAt10 := 212, depLengthAt15 := 238, depLengthAt20 := 258 }
-
--- ============================================================================
--- Language Lists
--- ============================================================================
-
-/-- Representative subset of 32 languages from Table 2. -/
-def languages : List LanguageDLM :=
-  [ arabic, basque, bulgarian, chinese, czech, danish, dutch, english
-  , estonian, finnish, french, german, greek, hebrew, hindi, hungarian
-  , indonesian, italian, japanese, korean, latin, norwegian, persian
-  , polish, portuguese, romanian, russian, spanish, swedish, tamil
-  , turkish, urdu, vietnamese ]
-
-/-- Head-final languages in the dataset. -/
-def headFinalLanguages : List LanguageDLM :=
-  languages.filter (·.isHeadFinal)
-
-/-- Head-initial languages in the dataset. -/
-def headInitialLanguages : List LanguageDLM :=
-  languages.filter (·.isHeadInitial)
-
--- ============================================================================
--- Per-Datum Classification Verification
--- ============================================================================
-
-/-- Japanese is classified as head-final. -/
-example : japanese.isHeadFinal = true := by native_decide
-
-/-- Korean is classified as head-final. -/
-example : korean.isHeadFinal = true := by native_decide
-
-/-- Turkish is classified as head-final. -/
-example : turkish.isHeadFinal = true := by native_decide
-
-/-- Hindi is classified as head-final. -/
-example : hindi.isHeadFinal = true := by native_decide
-
-/-- Tamil is classified as head-final. -/
-example : tamil.isHeadFinal = true := by native_decide
-
-/-- English is classified as head-initial. -/
-example : english.isHeadInitial = true := by native_decide
-
-/-- Arabic is classified as head-initial. -/
-example : arabic.isHeadInitial = true := by native_decide
-
-/-- Indonesian is classified as head-initial. -/
-example : indonesian.isHeadInitial = true := by native_decide
-
-/-- French is classified as head-initial. -/
-example : french.isHeadInitial = true := by native_decide
-
-/-- Romanian is classified as head-initial. -/
-example : romanian.isHeadInitial = true := by native_decide
-
--- ============================================================================
--- Empirical Generalizations
--- ============================================================================
-
-/-- Mean dep length at length 10 for head-final subset. -/
-def meanDepLengthHF10 : Nat :=
-  let hf := headFinalLanguages
-  if hf.isEmpty then 0
-  else hf.foldl (λ acc l => acc + l.depLengthAt10) 0 / hf.length
-
-/-- Mean dep length at length 10 for head-initial subset. -/
-def meanDepLengthHI10 : Nat :=
-  let hi := headInitialLanguages
-  if hi.isEmpty then 0
-  else hi.foldl (λ acc l => acc + l.depLengthAt10) 0 / hi.length
-
-/-- Head-final languages have higher mean dep length at sentence length 10.
-
-This is the core empirical finding: head-final languages systematically
-exhibit longer dependencies, consistent with DLM theory's prediction that
-consistently head-final order creates longer dependencies when combined
-with right-branching structure. -/
-theorem headFinal_higher_depLength_10 :
-    meanDepLengthHF10 > meanDepLengthHI10 := by native_decide
-
-/-- Same pattern at sentence length 20. -/
-def meanDepLengthHF20 : Nat :=
-  let hf := headFinalLanguages
-  if hf.isEmpty then 0
-  else hf.foldl (λ acc l => acc + l.depLengthAt20) 0 / hf.length
-
-def meanDepLengthHI20 : Nat :=
-  let hi := headInitialLanguages
-  if hi.isEmpty then 0
-  else hi.foldl (λ acc l => acc + l.depLengthAt20) 0 / hi.length
-
-theorem headFinal_higher_depLength_20 :
-    meanDepLengthHF20 > meanDepLengthHI20 := by native_decide
-
-/-- Japanese has the highest dep length at length 20 among all languages. -/
-theorem japanese_highest_depLength_20 :
-    languages.all (·.depLengthAt20 ≤ japanese.depLengthAt20) = true := by native_decide
-
-/-- Indonesian has the lowest dep length at length 10 among all languages. -/
-theorem indonesian_lowest_depLength_10 :
-    languages.all (·.depLengthAt10 ≥ indonesian.depLengthAt10) = true := by native_decide
-
-/-- The head-finality gap increases with sentence length:
-the difference in mean dep length between head-final and head-initial languages
-is larger at length 20 than at length 10. -/
-theorem headFinality_gap_increases :
-    meanDepLengthHF20 - meanDepLengthHI20 > meanDepLengthHF10 - meanDepLengthHI10 := by
-  native_decide
+example : table2.length = 46 := rfl
 
 end FutrellEtAl2020

--- a/Linglib/Studies/HahnDegenFutrell2021.lean
+++ b/Linglib/Studies/HahnDegenFutrell2021.lean
@@ -1,5 +1,4 @@
 import Linglib.Processing.Memory.SurprisalTradeoff
-import Linglib.Studies.FutrellEtAl2020
 import Linglib.Syntax.DependencyGrammar.Formal.HarmonicOrder
 import Linglib.Data.WALS.Languages
 
@@ -351,40 +350,6 @@ theorem slovak_lowest_g :
 the real language beats every sampled baseline grammar). -/
 theorem most_efficient_fully_optimized :
     (efficientLanguages.filter (·.gMean1000 = 1000)).length = 42 := by native_decide
-
--- ============================================================================
--- Crosslinguistic Bridge to [futrell-gibson-2020]
--- ============================================================================
-
-open FutrellEtAl2020
-
-/-- ISO codes appearing in [futrell-gibson-2020]'s 32-language dataset. -/
-def futrellIsoCodes : List String :=
-  FutrellEtAl2020.languages.map (·.isoCode)
-
-/-- ISO codes appearing in this study's 54-language dataset. -/
-def hahnIsoCodes : List String :=
-  allLanguages.map (·.isoCode)
-
-/-- Languages in both datasets (by ISO code). -/
-def sharedIsoCodes : List String :=
-  futrellIsoCodes.filter (hahnIsoCodes.contains ·)
-
-/-- At least 20 languages appear in both datasets. -/
-theorem many_shared_languages :
-    sharedIsoCodes.length ≥ 20 := by native_decide
-
-/-- All but one shared language (Polish) are efficient in this study. -/
-theorem shared_languages_mostly_efficient :
-    (sharedIsoCodes.filter (λ iso =>
-      (allLanguages.filter (·.isoCode == iso)).all (·.moreEfficient)
-    )).length ≥ sharedIsoCodes.length - 1 := by native_decide
-
-/-- Polish is the only shared language that is an exception. -/
-theorem polish_only_shared_exception :
-    (sharedIsoCodes.filter (λ iso =>
-      (allLanguages.filter (·.isoCode == iso)).any (! ·.moreEfficient)
-    )) = ["pl"] := by native_decide
 
 -- ============================================================================
 -- Entropy–Optimization Correlation (Figure 13)

--- a/Linglib/Studies/LevshinaEtAl2023.lean
+++ b/Linglib/Studies/LevshinaEtAl2023.lean
@@ -293,16 +293,15 @@ theorem high_so_entropy_implies_high_branch_entropy :
 
 -- Bridge 3: Head-final proportion ↔ SO proportion (FutrellEtAl2020.lean)
 
-private def futrellLanguages := FutrellEtAl2020.languages
-
-/-- Languages with high propHeadFinal (> 700) in Futrell have high
-    soProportion (> 700) in Levshina: head-final ≈ SOV ≈ high SO proportion. -/
+/-- Languages with a high head-final proportion (> 700‰) in
+    [futrell-gibson-2020]'s Table 2 have high soProportion (> 700) in
+    Levshina: head-final ≈ SOV ≈ high SO proportion. -/
 theorem head_final_correlates_with_so :
     let shared := allProfiles.filter (λ p =>
-      futrellLanguages.any (·.isoCode == p.isoCode))
+      FutrellEtAl2020.table2.any (·.isoCode == p.isoCode))
     let highHF := shared.filter (λ p =>
-      match futrellLanguages.find? (·.isoCode == p.isoCode) with
-      | some f => f.propHeadFinal > 700
+      match FutrellEtAl2020.table2.find? (·.isoCode == p.isoCode) with
+      | some f => f.propHeadFinal1000 > 700
       | none => false)
     highHF.all (·.soProportion1000 > 700) = true := by decide
 


### PR DESCRIPTION
The file's 32-language table was fabricated ("values are approximate from the paper's figures") — e.g. Japanese DL@10 was 2.75 vs the paper's 1.70, and `japanese_highest_depLength_20` is false of the real data. Replaced with the actual 46-row Table 2 (verified against the PDF), Bool→scaled-Nat schema kept kernel-decidable.

- cuts the fabrication-dependent corpus-count theorems here and the HahnDegenFutrell2021 bridge section (its claims, e.g. "Polish is the only shared exception", were artifacts of the fake roster)
- LevshinaEtAl2023's head-final ↔ SO-proportion bridge re-proves against the real data with kernel `decide`