### PR TITLE
chore(Syntax/DependencyGrammar): prune dead code; honest import edges

### DIFF
--- a/Linglib/Studies/KuhlmannNivre2006.lean
+++ b/Linglib/Studies/KuhlmannNivre2006.lean
@@ -1,5 +1,3 @@
-import Linglib.Syntax.DependencyGrammar.Formal.NonProjective
-
 /-!
 # Kuhlmann & Nivre 2006: Mildly Non-Projective Dependency Structures
 [kuhlmann-nivre-2006]

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -16,47 +16,6 @@ namespace DepGrammar
 
 section DominanceUnderUniqueHeads
 
-/-- In a tree with unique heads, the unique head of a non-root node. -/
-private def uniqueHead (t : DepTree) (x : Nat) : Option Nat :=
-  (t.deps.filter (·.depIdx == x)).head?.map (·.headIdx)
-
-/-- With unique heads and acyclicity, the depth (distance to root) of any
-    node is well-defined and finite. Following the unique head pointer from
-    any node terminates at the root. -/
-private def depth (t : DepTree) (x : Nat) (fuel : Nat) : Nat :=
-  match fuel with
-  | 0 => 0
-  | fuel' + 1 =>
-    if x == t.rootIdx then 0
-    else match t.deps.find? (·.depIdx == x) with
-    | some d => depth t d.headIdx fuel' + 1
-    | none => 0
-
-/-- Adding one unit of fuel increases depth by at most 1. -/
-private theorem depth_fuel_step (t : DepTree) (x : Nat) (k : Nat) :
-    depth t x (k + 1) ≤ depth t x k + 1 := by
-  induction k generalizing x with
-  | zero =>
-    simp only [depth]
-    split <;> (try split) <;> omega
-  | succ k' ih =>
-    -- Unfold depth exactly one level on both sides via `change`
-    show depth t x (k' + 1 + 1) ≤ depth t x (k' + 1) + 1
-    change (if (x == t.rootIdx) = true then 0
-            else match t.deps.find? (·.depIdx == x) with
-            | some d => depth t d.headIdx (k' + 1) + 1
-            | none => 0)
-           ≤
-           (if (x == t.rootIdx) = true then 0
-            else match t.deps.find? (·.depIdx == x) with
-            | some d => depth t d.headIdx k' + 1
-            | none => 0) + 1
-    by_cases hroot : (x == t.rootIdx) = true
-    · simp [hroot]
-    · rw [if_neg hroot, if_neg hroot]
-      cases hfind : t.deps.find? (·.depIdx == x) with
-      | none => simp
-      | some d => exact Nat.add_le_add_right (ih d.headIdx) 1
 
 /-- Extract from `hasUniqueHeads` for a specific node index: root has 0 incoming
     edges, non-root nodes have exactly 1. -/
@@ -79,83 +38,6 @@ private theorem hasUniqueHeads_count (t : DepTree)
   simp only [beq_iff_eq] at h
   exact h
 
-/-- One dominance step: if edge (u, p) and `hasUniqueHeads`, then
-    `depth u ≤ depth p` (with any fuel ≥ 1).
-
-    Under `hasUniqueHeads`, `p ≠ rootIdx` and `find? (·.depIdx == p)` returns
-    an edge with head = u. So `depth p (k+1) = depth u k + 1 ≥ depth u (k+1)`
-    by `depth_fuel_step`. -/
-private theorem depth_le_of_edge (t : DepTree)
-    (hwf : hasUniqueHeads t = true) {u p : Nat}
-    (hp_lt : p < t.words.length)
-    (hedge : parentEdge t.deps u p)
-    (k : Nat) : depth t u (k + 1) ≤ depth t p (k + 1) := by
-  obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
-  have hspec := hasUniqueHeads_count t hwf p hp_lt
-  -- p ≠ rootIdx: root has 0 incoming edges, but d is incoming to p
-  have hp_ne_root : p ≠ t.rootIdx := by
-    intro hp_eq
-    rw [if_pos hp_eq, beq_iff_eq] at hspec
-    have : d ∈ t.deps.filter (·.depIdx == p) :=
-      List.mem_filter.mpr ⟨hd_mem, beq_iff_eq.mpr hd_dep⟩
-    have := List.length_pos_of_mem this
-    omega
-  rw [if_neg hp_ne_root, beq_iff_eq] at hspec
-  -- filter has exactly 1 element; d is it
-  obtain ⟨e, he_eq⟩ := List.length_eq_one_iff.mp hspec
-  have hd_filter : d ∈ t.deps.filter (·.depIdx == p) :=
-    List.mem_filter.mpr ⟨hd_mem, beq_iff_eq.mpr hd_dep⟩
-  rw [he_eq] at hd_filter
-  have hd_eq_e := List.eq_of_mem_singleton hd_filter
-  -- find? returns some edge (since d has matching depIdx)
-  have hfind_some : (t.deps.find? (·.depIdx == p)).isSome = true :=
-    List.find?_isSome.mpr ⟨d, hd_mem, beq_iff_eq.mpr hd_dep⟩
-  obtain ⟨f, hf_find⟩ := Option.isSome_iff_exists.mp hfind_some
-  -- f has depIdx = p and f ∈ t.deps
-  have hf_dep : f.depIdx = p := by
-    have := List.find?_some hf_find; exact beq_iff_eq.mp this
-  have hf_mem : f ∈ t.deps := List.mem_of_find?_eq_some hf_find
-  -- f is in the filter, which is [e], so f = e = d
-  have hf_filter : f ∈ t.deps.filter (·.depIdx == p) :=
-    List.mem_filter.mpr ⟨hf_mem, beq_iff_eq.mpr hf_dep⟩
-  rw [he_eq] at hf_filter
-  have hf_eq_e := List.eq_of_mem_singleton hf_filter
-  -- f.headIdx = u
-  have hf_head : f.headIdx = u := by
-    rw [hf_eq_e, ← hd_eq_e]; exact hd_head
-  -- Unfold depth t p (k+1): since p ≠ rootIdx and find? = some f
-  have hp_ne : ¬((p == t.rootIdx) = true) := by
-    intro h; exact hp_ne_root (beq_iff_eq.mp h)
-  have h_depth_p : depth t p (k + 1) = depth t u k + 1 := by
-    change (if (p == t.rootIdx) = true then 0
-            else match t.deps.find? (·.depIdx == p) with
-            | some d => depth t d.headIdx k + 1
-            | none => 0) = depth t u k + 1
-    simp only [if_neg hp_ne, hf_find, hf_head]
-  rw [h_depth_p]
-  exact depth_fuel_step t u k
-
-/-- If `Dominates v w`, then `depth v ≤ depth w` (non-strict).
-
-    Each dominance step uses `depth_le_of_edge` + `depth_fuel_step`.
-    Non-strict inequality suffices when combined with strict inequality
-    for the proper-ancestor case (see `dominates_antisymm`). -/
-private theorem dominates_depth_le (t : DepTree)
-    (hwf : hasUniqueHeads t = true)
-    (h_wf : ∀ d ∈ t.deps, d.depIdx < t.words.length)
-    {v w : Nat} (h : Dominates t.deps v w) :
-    depth t v t.words.length ≤ depth t w t.words.length := by
-  induction h using Dominates.head_induction_on with
-  | refl => exact Nat.le_refl _
-  | @step v w' hedge _ ih =>
-    obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
-    have hw'_lt : w' < t.words.length := hd_dep ▸ h_wf d hd_mem
-    have hk : t.words.length - 1 + 1 = t.words.length := by omega
-    have h1 : depth t v (t.words.length - 1 + 1) ≤
-              depth t w' (t.words.length - 1 + 1) :=
-      depth_le_of_edge t hwf hw'_lt ⟨d, hd_mem, hd_head, hd_dep⟩ _
-    rw [hk] at h1
-    exact Nat.le_trans h1 ih
 
 -- ============================================================================
 -- Parent-pointer tracing infrastructure for dominates_antisymm
@@ -217,35 +99,6 @@ private theorem follow_no_parent_uh (t : DepTree) (current : Nat)
     · rename_i _ heq; rw [h2] at heq; cases heq
     · rfl
 
-/-- If `follow` returns false with fuel f, it also returns false with fuel f+1.
-    (Cycles detected at depth f persist at depth f+1.) -/
-private theorem follow_false_mono (t : DepTree) (x : Nat) (visited : List Nat)
-    (f : Nat) (h : isAcyclic.follow t x visited f = false) :
-    isAcyclic.follow t x visited (f + 1) = false := by
-  induction f generalizing x visited with
-  | zero => unfold isAcyclic.follow at h; exact absurd h (by decide)
-  | succ f ih =>
-    match hcv : visited.contains x with
-    | true => exact follow_visited_uh t x visited (f + 1) hcv
-    | false =>
-      match hfind : t.deps.find? (fun d => d.depIdx == x) with
-      | none =>
-        have := follow_no_parent_uh t x visited f hcv hfind
-        rw [this] at h; exact absurd h (by decide)
-      | some dep =>
-        rw [follow_step_uh t x visited f hcv dep hfind] at h
-        rw [follow_step_uh t x visited (f + 1) hcv dep hfind]
-        exact ih dep.headIdx (x :: visited) h
-
-/-- Generalized monotonicity: false at fuel f implies false at any fuel f' ≥ f. -/
-private theorem follow_false_mono_gen (t : DepTree) (x : Nat) (visited : List Nat)
-    (f f' : Nat) (hff : f' ≥ f)
-    (h : isAcyclic.follow t x visited f = false) :
-    isAcyclic.follow t x visited f' = false := by
-  obtain ⟨d, rfl⟩ : ∃ d, f' = f + d := ⟨f' - f, by omega⟩
-  induction d with
-  | zero => exact h
-  | succ d ih => exact follow_false_mono t x visited _ (ih (by omega))
 
 /-- If the iterParent chain revisits a node in `visited` after m steps,
     `follow` returns false. -/

--- a/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
@@ -5,9 +5,9 @@ import Linglib.Syntax.DependencyGrammar.Basic
 
 Formalises the core quantity behind [futrell-gibson-2020]'s claim that
 natural languages minimise total dependency length beyond what independent
-constraints predict, together with [behaghel-1909]'s "Oberstes Gesetz"
+constraints predict, together with [behaghel-1932]'s "Oberstes Gesetz"
 threshold predicate. The two short-before-long arithmetic lemmas record the
-*direction* of the DLM savings at the lemma level; the per-paper example trees
+*direction* of [behaghel-1909]'s Law of Growing Members; the per-paper example trees
 and cross-linguistic data sit in `Studies/FutrellEtAl2020.lean`,
 `Studies/ArnoldEtAl2000.lean`, and `Studies/FedzechkinaEtAl2017.lean`.
 
@@ -44,7 +44,7 @@ def totalDepLength (t : DepTree) : Nat :=
 
 /-! ### Behaghel's Oberstes Gesetz -/
 
-/-- [behaghel-1909]'s Oberstes Gesetz: every dependency has length at
+/-- [behaghel-1932]'s Oberstes Gesetz: every dependency has length at
 most `threshold`. -/
 def oberstesGesetz (t : DepTree) (threshold : Nat) : Bool :=
   t.deps.all λ d => depLength d ≤ threshold

--- a/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.DependencyGrammar.Formal.NonProjective
+import Linglib.Syntax.DependencyGrammar.Basic
 
 /-!
 # Dependency Length Minimization
@@ -44,7 +44,7 @@ def totalDepLength (t : DepTree) : Nat :=
 
 /-! ### Behaghel's Oberstes Gesetz -/
 
-/-- [behaghel-1932]'s Oberstes Gesetz: every dependency has length at
+/-- [behaghel-1909]'s Oberstes Gesetz: every dependency has length at
 most `threshold`. -/
 def oberstesGesetz (t : DepTree) (threshold : Nat) : Bool :=
   t.deps.all λ d => depLength d ≤ threshold

--- a/Linglib/Syntax/DependencyGrammar/Formal/HarmonicOrder.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/HarmonicOrder.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.DependencyGrammar.Formal.DependencyLength
+import Linglib.Syntax.DependencyGrammar.Projection
 
 open Morphology (Word)
 

--- a/Linglib/Syntax/DependencyGrammar/Projection.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projection.lean
@@ -261,15 +261,6 @@ private theorem go_mem_of_queue (deps : List Dependency)
       exact ih (sfx ++ _) (y :: visited) fuel'
         (by simp only [List.length_cons] at hfuel; omega)
 
-/-- The output of `projection` is a list with no duplicates.
-    Follows from BFS visiting each node at most once (`go_nodup`), composed
-    with the fact that `insertionSort` preserves the multiset (hence Nodup). -/
-theorem projection_nodup (deps : List Dependency) (root : Nat) :
-    (projection deps root).Nodup := by
-  unfold projection
-  set goResult := projection.go deps [root] [] (deps.length * (deps.length + 1) + 2)
-  have hnodup_go : goResult.Nodup := go_nodup deps [root] [] _ List.nodup_nil
-  exact (List.perm_insertionSort _ goResult).nodup_iff.mpr hnodup_go
 
 /-- If (v, w) is a dependency edge, then w ∈ projection deps v.
     Proof: BFS from v processes v first (adding children to queue),
@@ -563,12 +554,6 @@ theorem interval_mem_between (l : List Nat)
 def Dominates (deps : List Dependency) (v x : Nat) : Prop :=
   Relation.ReflTransGen (parentEdge deps) v x
 
-/-- Unfolding bridge to mathlib's `Relation.ReflTransGen` for ad-hoc access to
-    its lemma corpus (`lift`, `mono`, `closed`, etc.) without manual `unfold`. -/
-theorem Dominates_def {deps : List Dependency} {v x : Nat} :
-    Dominates deps v x ↔ Relation.ReflTransGen (parentEdge deps) v x :=
-  Iff.rfl
-
 /-- Reflexive case: `v` dominates itself. -/
 @[refl]
 theorem Dominates.refl {deps : List Dependency} {v : Nat} : Dominates deps v v :=
@@ -659,27 +644,6 @@ theorem dominates_of_mem_projection {deps : List Dependency} {v x : Nat}
   rcases go_dominates_of_mem deps [v] [] _ x hx_go with habs | ⟨q, hq, hdom⟩
   · exact nomatch habs
   · exact List.mem_singleton.mp hq ▸ hdom
-
-/-- Fuel monotonicity: more fuel never loses BFS results. -/
-private theorem go_mono_fuel (deps : List Dependency)
-    (queue visited : List Nat) (f k : Nat) (x : Nat)
-    (hx : x ∈ projection.go deps queue visited f) :
-    x ∈ projection.go deps queue visited (f + k) := by
-  induction f generalizing queue visited with
-  | zero =>
-    simpa [Nat.zero_add] using go_visited_subset deps queue visited k x hx
-  | succ f' ih =>
-    match queue with
-    | [] =>
-      rw [go_empty_queue] at hx; rw [go_empty_queue]; exact hx
-    | node :: rest =>
-      simp only [projection.go] at hx
-      rw [Nat.add_right_comm]; simp only [projection.go]
-      split at hx <;> split
-      · exact ih rest visited hx
-      · rename_i h1 h2; exact absurd h1 h2
-      · rename_i h1 h2; exact absurd h2 h1
-      · exact ih (rest ++ _) (node :: visited) hx
 
 /-- If predicate `p` implies `q` on all list elements, then `filter p` is no longer than `filter q`. -/
 private theorem filter_length_le_of_imp {α : Type*} (l : List α) (p q : α → Bool)
@@ -844,6 +808,10 @@ theorem dominates_iff_mem_projection (deps : List Dependency) (v x : Nat) :
     Dominates deps v x ↔ x ∈ projection deps v :=
   ⟨mem_projection_of_dominates, dominates_of_mem_projection⟩
 
+/-- Dominance is decidable: decide membership in the BFS projection. -/
+instance (deps : List Dependency) (v x : Nat) : Decidable (Dominates deps v x) :=
+  decidable_of_iff _ (dominates_iff_mem_projection deps v x).symm
+
 end Projection
 
 -- ============================================================================
@@ -891,13 +859,6 @@ theorem foldl_max_zero_iff (ls : List Nat) :
       have : max 0 0 = 0 := by omega
       rw [this]
       exact ih (λ x hx => hall x (List.mem_cons.mpr (Or.inr hx)))
-
-/-- If some element of `ls` is positive, then `List.foldl max 0 ls > 0`. -/
-theorem foldl_max_pos_of_mem_pos (ls : List Nat) (x : Nat)
-    (hx : x ∈ ls) (hpos : x > 0) :
-    ls.foldl max 0 > 0 := by
-  have hge := foldl_max_ge_mem ls 0 x hx
-  omega
 
 /-- `foldl max init ls ≤ bound` when `init ≤ bound` and all elements `≤ bound`. -/
 theorem foldl_max_le_bound (ls : List Nat) (init bound : Nat)

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23149,6 +23149,18 @@
   subfield  = {syntax/word-order},
   role      = {cited},
 }
+
+@book{behaghel-1932,
+  author    = {Behaghel, Otto},
+  year      = {1932},
+  title     = {Deutsche Syntax: Eine geschichtliche Darstellung. Band IV: Wortstellung. Periodenbau},
+  publisher = {Winter},
+  address   = {Heidelberg},
+  subfield  = {syntax/word-order},
+  role      = {cited},
+  validated = {true},
+  sources   = {Syntax/DependencyGrammar/Formal/DependencyLength.lean}
+}
 @book{melcuk-1988,
   author    = {Mel'\v{c}uk, Igor},
   year      = {1988},


### PR DESCRIPTION
First PR from the DepTree API audit (five-agent review; punchlist in progress).

- deletes 147 lines of verified-dead private code in Dominance.lean (the fuel-indexed depth apparatus superseded by the iterParent antisymmetry proof) and four dead declarations in Projection.lean
- adds the `Decidable (Dominates …)` instance the unused bridge `iff` was always for — dominance goals now close by `decide`
- fixes three false import edges (DependencyLength needs only Basic; KuhlmannNivre2006 used nothing it imported; HarmonicOrder now imports Projection directly instead of transitively)
- `[behaghel-1932]` → `[behaghel-1909]` (dangling bib key)