### PR TITLE
feat(Syntax/DependencyGrammar): ground DepGraph in mathlib's Digraph

### DIFF
--- a/Linglib/Studies/ArnoldEtAl2000.lean
+++ b/Linglib/Studies/ArnoldEtAl2000.lean
@@ -107,7 +107,7 @@ namespace ArnoldEtAl2000
 
 
 open Constraints Core.Optimization Features
-open DepGrammar DepGrammar.DependencyLength
+open DependencyGrammar DependencyGrammar.DependencyLength
 
 -- ============================================================================
 -- § 1: Phrases, Orderings, and Candidates

--- a/Linglib/Studies/BarkerPullum1990.lean
+++ b/Linglib/Studies/BarkerPullum1990.lean
@@ -118,22 +118,22 @@ structure DepEdge (α : Type) where
   deriving Repr
 
 /-- Dependency graph = list of edges -/
-structure DepGraph (α : Type) where
+structure Graph (α : Type) where
   edges : List (DepEdge α)
   deriving Repr
 
 /-- Is `a` a dependent of `h`? -/
-def DepGraph.hasDep {α : Type} [DecidableEq α] (g : DepGraph α) (a h : α) : Bool :=
+def Graph.hasDep {α : Type} [DecidableEq α] (g : Graph α) (a h : α) : Bool :=
   g.edges.any (λ e => e.dependent == a && e.head == h)
 
 /-- Get label for dependency -/
-def DepGraph.labelOf {α : Type} [DecidableEq α] (g : DepGraph α) (a h : α) : Option String :=
+def Graph.labelOf {α : Type} [DecidableEq α] (g : Graph α) (a h : α) : Option String :=
   (g.edges.find? (λ e => e.dependent == a && e.head == h)).map (·.label)
 
 /-- **D-command**:
     A d-commands B iff A and B are co-dependents of the same head,
     and A bears the "subj" relation (designated binder). -/
-def dCommand {α : Type} [DecidableEq α] (g : DepGraph α) (a b : α) : Bool :=
+def dCommand {α : Type} [DecidableEq α] (g : Graph α) (a b : α) : Bool :=
   g.edges.any (λ edgeA =>
     edgeA.dependent == a &&
     edgeA.label == "subj" &&
@@ -167,7 +167,7 @@ structure ConfigurationalClause where
   argSt : ArgSt String
 
   -- Dependency graph
-  depGraph : DepGraph String
+  depGraph : Graph String
 
   -- === CONFIGURATIONAL INVARIANTS ===
 

--- a/Linglib/Studies/DeMarneffeNivre2019.lean
+++ b/Linglib/Studies/DeMarneffeNivre2019.lean
@@ -10,8 +10,8 @@ open Morphology (Word)
 Worked English examples illustrating Universal Dependencies' basic vs
 enhanced representations (cf. §4.2 and Figure 9 of
 [de-marneffe-nivre-2019]). The substrate — gap-filling
-(`DepGrammar.LongDistance.fillGap`) and shared-dependent propagation
-(`DepGrammar.Coordination.enhanceSharedDeps`) — lives in the corresponding
+(`DependencyGrammar.LongDistance.fillGap`) and shared-dependent propagation
+(`DependencyGrammar.Coordination.enhanceSharedDeps`) — lives in the corresponding
 substrate files.
 
 ## Examples
@@ -48,28 +48,28 @@ feature-tagged fixtures if richer parallelism theorems are wanted.
 namespace DeMarneffeNivre2019
 
 
-open DepGrammar DepGrammar.LongDistance DepGrammar.Coordination
+open DependencyGrammar DependencyGrammar.LongDistance DependencyGrammar.Coordination
 
 /-! ### Wh-question fixtures -/
 
 /-- "What did John see?" — object wh-question (basic tree).
 Words: what(0) did(1) John(2) see(3). The wh-word attaches as `obj` of
 the main verb. -/
-def exWhatDidJohnSee : DepTree :=
+def exWhatDidJohnSee : Tree :=
   { words := [{ form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX,
               Word.mk' "John" .PROPN, Word.mk' "see" .VERB]
     deps  := [⟨1, 2, .nsubj⟩, ⟨1, 3, .aux⟩, ⟨1, 0, .obj⟩]
     rootIdx := 1 }
 
 /-- "Who saw Mary?" — subject wh-question (no gap needed). -/
-def exWhoSawMary : DepTree :=
+def exWhoSawMary : Tree :=
   { words := [{ form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "saw" .VERB,
               Word.mk' "Mary" .PROPN]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
     rootIdx := 1 }
 
 /-- "Who did John see?" — object wh-question with `who`. -/
-def exWhoDidJohnSee : DepTree :=
+def exWhoDidJohnSee : Tree :=
   { words := [{ form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX,
               Word.mk' "John" .PROPN, Word.mk' "see" .VERB]
     deps  := [⟨1, 2, .nsubj⟩, ⟨1, 3, .aux⟩, ⟨1, 0, .obj⟩]
@@ -80,7 +80,7 @@ def exWhoDidJohnSee : DepTree :=
 /-- "the book that John read" — object relative clause (basic tree). In UD
 the relative clause attaches via `acl` from head noun to RC verb; the gap
 (`book` as `obj` of `read`) is implicit. -/
-def exTheBookThatJohnRead : DepTree :=
+def exTheBookThatJohnRead : Tree :=
   { words := [Word.mk' "the" .DET, Word.mk' "book" .NOUN,
               Word.mk' "that" .SCONJ, Word.mk' "John" .PROPN,
               Word.mk' "read" .VERB]
@@ -89,13 +89,13 @@ def exTheBookThatJohnRead : DepTree :=
 
 /-- Enhanced graph for "the book that John read": `book` is added as `obj`
 of `read`. -/
-def exTheBookThatJohnRead_enhanced : DepGraph :=
+def exTheBookThatJohnRead_enhanced : Graph :=
   fillGap exTheBookThatJohnRead 1 4 .objGap
 
 /-! ### Complement-clause fixtures -/
 
 /-- "John thinks that Mary sleeps" — that-complement (no gap). -/
-def exJohnThinksThatMarySleeps : DepTree :=
+def exJohnThinksThatMarySleeps : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "thinks" .VERB,
               Word.mk' "that" .SCONJ, Word.mk' "Mary" .PROPN,
               Word.mk' "sleeps" .VERB]
@@ -103,14 +103,14 @@ def exJohnThinksThatMarySleeps : DepTree :=
     rootIdx := 1 }
 
 /-- "John thinks Mary sleeps" — bare complement (that-omission, no gap). -/
-def exJohnThinksMarySleeps : DepTree :=
+def exJohnThinksMarySleeps : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "thinks" .VERB,
               Word.mk' "Mary" .PROPN, Word.mk' "sleeps" .VERB]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 3, .ccomp⟩, ⟨3, 2, .nsubj⟩]
     rootIdx := 1 }
 
 /-- "John wonders if Mary sleeps" — if-complement (no gap). -/
-def exJohnWondersIfMarySleeps : DepTree :=
+def exJohnWondersIfMarySleeps : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "wonders" .VERB,
               Word.mk' "if" .SCONJ, Word.mk' "Mary" .PROPN,
               Word.mk' "sleeps" .VERB]
@@ -119,7 +119,7 @@ def exJohnWondersIfMarySleeps : DepTree :=
 
 /-- "John wonders what Mary saw" — embedded wh-question.
 Words: John(0) wonders(1) what(2) Mary(3) saw(4). -/
-def exJohnWondersWhatMarySaw : DepTree :=
+def exJohnWondersWhatMarySaw : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "wonders" .VERB,
               { form :="what", cat := .PRON, features := { pronType := some .Int }},
               Word.mk' "Mary" .PROPN, Word.mk' "saw" .VERB]
@@ -129,14 +129,14 @@ def exJohnWondersWhatMarySaw : DepTree :=
 /-! ### Coordination fixtures -/
 
 /-- "John and Mary sleep" — NP coordination. -/
-def exJohnAndMarySleep : DepTree :=
+def exJohnAndMarySleep : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "and" .CCONJ,
               Word.mk' "Mary" .PROPN, Word.mk' "sleep" .VERB]
     deps  := [⟨3, 0, .nsubj⟩, ⟨0, 2, .conj⟩]
     rootIdx := 3 }
 
 /-- "John sleeps and Mary sleeps" — S coordination. -/
-def exJohnSleepsAndMarySleeps : DepTree :=
+def exJohnSleepsAndMarySleeps : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "sleeps" .VERB,
               Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN,
               Word.mk' "sleeps" .VERB]
@@ -145,7 +145,7 @@ def exJohnSleepsAndMarySleeps : DepTree :=
 
 /-- "John sees and hears Mary" — VP coordination (basic tree). `Mary`
 attaches as `obj` of `sees` only; `hears` is `conj` of `sees`. -/
-def exJohnSeesAndHearsMary : DepTree :=
+def exJohnSeesAndHearsMary : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "sees" .VERB,
               Word.mk' "and" .CCONJ, Word.mk' "hears" .VERB,
               Word.mk' "Mary" .PROPN]
@@ -154,11 +154,11 @@ def exJohnSeesAndHearsMary : DepTree :=
 
 /-- Enhanced graph for "John sees and hears Mary": `Mary` is `obj` of
 *both* `sees` and `hears` (shared-dep propagation). -/
-def exJohnSeesAndHearsMary_enhanced : DepGraph :=
+def exJohnSeesAndHearsMary_enhanced : Graph :=
   enhanceSharedDeps exJohnSeesAndHearsMary
 
 /-- "the happy and smart boy" — adjective coordination. -/
-def exOldAndWiseMan : DepTree :=
+def exOldAndWiseMan : Tree :=
   { words := [Word.mk' "the" .DET, Word.mk' "happy" .ADJ,
               Word.mk' "and" .CCONJ, Word.mk' "smart" .ADJ,
               Word.mk' "boy" .NOUN]
@@ -167,7 +167,7 @@ def exOldAndWiseMan : DepTree :=
 
 /-- "John likes and Mary hates pizza" — Right Node Raising (basic tree).
 `pizza` attaches to `likes` only. -/
-def exRNR : DepTree :=
+def exRNR : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "likes" .VERB,
               Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN,
               Word.mk' "hates" .VERB, Word.mk' "pizza" .NOUN]
@@ -175,7 +175,7 @@ def exRNR : DepTree :=
     rootIdx := 1 }
 
 /-- Enhanced graph for RNR: `pizza` is `obj` of both verbs. -/
-def exRNR_enhanced : DepGraph := enhanceSharedDeps exRNR
+def exRNR_enhanced : Graph := enhanceSharedDeps exRNR
 
 /-! ### Smoke tests -/
 

--- a/Linglib/Studies/FedzechkinaEtAl2017.lean
+++ b/Linglib/Studies/FedzechkinaEtAl2017.lean
@@ -32,7 +32,7 @@ bias for dependency-length-minimizing (= memory-efficient) orders.
 namespace FedzechkinaEtAl2017
 
 
-open DepGrammar DependencyLength Processing.MemorySurprisal
+open DependencyGrammar DependencyLength Processing.MemorySurprisal
 
 -- ============================================================================
 -- Mini-Language Setup
@@ -71,7 +71,7 @@ Dependencies:
 - det: dog(4) ← the(3) length 1
 - obj: chased(5) ← dog(4) length 1
 Total = 8 -/
-def langA_SOV : DepTree :=
+def langA_SOV : Tree :=
   { words := [ Word.mk' "the" .DET, Word.mk' "big" .ADJ, Word.mk' "cat" .NOUN
              , Word.mk' "the" .DET, Word.mk' "dog" .NOUN, Word.mk' "chased" .VERB ]
     deps := [ ⟨2, 0, .det⟩, ⟨2, 1, .amod⟩, ⟨5, 2, .nsubj⟩
@@ -87,7 +87,7 @@ Dependencies:
 - amod: cat(4) ← big(3) length 1
 - obj: chased(5) ← cat(4) length 1
 Total = 9 -/
-def langB_SOV : DepTree :=
+def langB_SOV : Tree :=
   { words := [ Word.mk' "the" .DET, Word.mk' "dog" .NOUN, Word.mk' "the" .DET
              , Word.mk' "big" .ADJ, Word.mk' "cat" .NOUN, Word.mk' "chased" .VERB ]
     deps := [ ⟨1, 0, .det⟩, ⟨5, 1, .nsubj⟩, ⟨4, 2, .det⟩

--- a/Linglib/Studies/FutrellEtAl2020.lean
+++ b/Linglib/Studies/FutrellEtAl2020.lean
@@ -27,7 +27,7 @@ lengths match the printed diagrams.
 namespace FutrellEtAl2020
 
 open Morphology (Word)
-open DepGrammar DepGrammar.DependencyLength
+open DependencyGrammar DependencyGrammar.DependencyLength
 open English.Nouns English.Predicates.Verbal English.Pronouns English.Determiners
   English.FunctionWords English.Auxiliaries
 
@@ -49,7 +49,7 @@ only mildly. -/
 
 /-- Example (3): "I think a woman arrived who you know" — extraposed
     relative clause. -/
-def extraposition : DepTree :=
+def extraposition : Tree :=
   { words := [i.toWord, think.toWordBase, a.toWord, woman.toWordSg, arrive.toWordPast,
               who.toWord, you.toWord, know.toWordBase]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 4, .ccomp⟩, ⟨4, 3, .nsubj⟩, ⟨3, 2, .det⟩,
@@ -57,7 +57,7 @@ def extraposition : DepTree :=
     rootIdx := 1 }
 
 /-- Example (4): "I know what he thinks you did yesterday" — wh-movement. -/
-def whMovement : DepTree :=
+def whMovement : Tree :=
   { words := [i.toWord, know.toWordBase, what.toWord, he.toWord, think.toWord3sg,
               you.toWord, did.toWord, Word.mk' "yesterday" .ADV]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 4, .ccomp⟩, ⟨4, 3, .nsubj⟩, ⟨4, 6, .ccomp⟩,
@@ -80,28 +80,28 @@ long-before-short order does. The paper cites experimental evidence for
 the latter from Japanese, where heavy elements shift leftward. -/
 
 /-- (7a) A [B] [C D] [E F G]: dependents short-to-long after the head. -/
-def shortBeforeLong : DepTree :=
+def shortBeforeLong : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D", tok "E", tok "F", tok "G"]
     deps := [⟨0, 1, .dep⟩, ⟨0, 2, .dep⟩, ⟨2, 3, .dep⟩, ⟨0, 4, .dep⟩,
              ⟨4, 5, .dep⟩, ⟨4, 6, .dep⟩]
     rootIdx := 0 }
 
 /-- (7b) A [B C D] [E F] [G]: dependents long-to-short after the head. -/
-def longBeforeShort : DepTree :=
+def longBeforeShort : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D", tok "E", tok "F", tok "G"]
     deps := [⟨0, 1, .dep⟩, ⟨1, 2, .dep⟩, ⟨1, 3, .dep⟩, ⟨0, 4, .dep⟩,
              ⟨4, 5, .dep⟩, ⟨0, 6, .dep⟩]
     rootIdx := 0 }
 
 /-- (8a) [A B C] [D E] [F] G: the mirror image of (7a), head-final. -/
-def longBeforeShortHF : DepTree :=
+def longBeforeShortHF : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D", tok "E", tok "F", tok "G"]
     deps := [⟨2, 0, .dep⟩, ⟨2, 1, .dep⟩, ⟨4, 3, .dep⟩, ⟨6, 2, .dep⟩,
              ⟨6, 4, .dep⟩, ⟨6, 5, .dep⟩]
     rootIdx := 6 }
 
 /-- (8b) [A] [B C] [D E F] G: the mirror image of (7b), head-final. -/
-def shortBeforeLongHF : DepTree :=
+def shortBeforeLongHF : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D", tok "E", tok "F", tok "G"]
     deps := [⟨2, 1, .dep⟩, ⟨5, 3, .dep⟩, ⟨5, 4, .dep⟩, ⟨6, 0, .dep⟩,
              ⟨6, 2, .dep⟩, ⟨6, 5, .dep⟩]
@@ -134,13 +134,13 @@ exceptions (e.g. prenominal determiners in otherwise head-initial
 Spanish). -/
 
 /-- (9a) chain A → B → C → D linearized consistently: A B C D. -/
-def consistentChain : DepTree :=
+def consistentChain : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D"]
     deps := [⟨0, 1, .dep⟩, ⟨1, 2, .dep⟩, ⟨2, 3, .dep⟩]
     rootIdx := 0 }
 
 /-- (9b) the same chain linearized with mixed head direction: A C D B. -/
-def mixedChain : DepTree :=
+def mixedChain : Tree :=
   { words := [tok "A", tok "C", tok "D", tok "B"]
     deps := [⟨0, 3, .dep⟩, ⟨3, 1, .dep⟩, ⟨1, 2, .dep⟩]
     rootIdx := 0 }
@@ -149,7 +149,7 @@ def mixedChain : DepTree :=
 theorem consistent_chain_shorter :
     totalDepLength consistentChain < totalDepLength mixedChain := by decide
 
-open DepGrammar.HarmonicOrder in
+open DependencyGrammar.HarmonicOrder in
 /-- The consistent chain achieves the substrate's span lower bound; the mixed
     linearization exceeds it. -/
 theorem consistent_chain_achieves_span :
@@ -157,13 +157,13 @@ theorem consistent_chain_achieves_span :
     chainTDL [0, 3, 1, 2] > listSpan [0, 3, 1, 2] := by decide
 
 /-- (10a) A B C D: both dependents (B and C–D) after the head A. -/
-def dependentsSameSide : DepTree :=
+def dependentsSameSide : Tree :=
   { words := [tok "A", tok "B", tok "C", tok "D"]
     deps := [⟨0, 1, .dep⟩, ⟨0, 2, .dep⟩, ⟨2, 3, .dep⟩]
     rootIdx := 0 }
 
 /-- (10b) B A C D: the one-word dependent moved before the head. -/
-def dependentsSplit : DepTree :=
+def dependentsSplit : Tree :=
   { words := [tok "B", tok "A", tok "C", tok "D"]
     deps := [⟨1, 0, .dep⟩, ⟨1, 2, .dep⟩, ⟨2, 3, .dep⟩]
     rootIdx := 1 }
@@ -182,19 +182,19 @@ object, it costs 5 (11 vs. 16) — matching the near-obligatory shift in
 (6c–d). DLM thus derives why heavy NP shift is weight-sensitive. -/
 
 /-- (11a) "John threw out the trash", total dependency length 6. -/
-def lightParticleEarly : DepTree :=
+def lightParticleEarly : Tree :=
   { words := [john.toWordSg, throw.toWordPast, out.toWord, the.toWord, trash.toWordSg]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .compound⟩, ⟨1, 4, .obj⟩, ⟨4, 3, .det⟩]
     rootIdx := 1 }
 
 /-- (11b) "John threw the trash out", total dependency length 7. -/
-def lightParticleLate : DepTree :=
+def lightParticleLate : Tree :=
   { words := [john.toWordSg, throw.toWordPast, the.toWord, trash.toWordSg, out.toWord]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .obj⟩, ⟨3, 2, .det⟩, ⟨1, 4, .compound⟩]
     rootIdx := 1 }
 
 /-- (11c) "John threw out the trash sitting in the kitchen", total 11. -/
-def heavyParticleEarly : DepTree :=
+def heavyParticleEarly : Tree :=
   { words := [john.toWordSg, throw.toWordPast, out.toWord, the.toWord, trash.toWordSg,
               sit.toWordPresPart, in_.toWord, the.toWord, kitchen.toWordSg]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .compound⟩, ⟨1, 4, .obj⟩, ⟨4, 3, .det⟩,
@@ -202,7 +202,7 @@ def heavyParticleEarly : DepTree :=
     rootIdx := 1 }
 
 /-- (11d) "John threw the trash sitting in the kitchen out", total 16. -/
-def heavyParticleLate : DepTree :=
+def heavyParticleLate : Tree :=
   { words := [john.toWordSg, throw.toWordPast, the.toWord, trash.toWordSg,
               sit.toWordPresPart, in_.toWord, the.toWord, kitchen.toWordSg, out.toWord]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .obj⟩, ⟨3, 2, .det⟩, ⟨3, 4, .acl⟩,
@@ -229,21 +229,21 @@ the paper's illustration of the random-order baseline methodology of
 §4–5, whose Monte-Carlo results are not formalized here. -/
 
 /-- (13a) "this story comes from the AP", the attested order, total 6. -/
-def attestedOrder : DepTree :=
+def attestedOrder : Tree :=
   { words := [this_, story.toWordSg, come.toWord3sg, from_.toWord, the.toWord, ap]
     deps := [⟨1, 0, .det⟩, ⟨2, 1, .nsubj⟩, ⟨2, 3, .obl⟩, ⟨3, 5, .obl⟩,
              ⟨5, 4, .det⟩]
     rootIdx := 2 }
 
 /-- (13b) reordering "from AP the this story comes", total 9. -/
-def reorderingB : DepTree :=
+def reorderingB : Tree :=
   { words := [from_.toWord, ap, the.toWord, this_, story.toWordSg, come.toWord3sg]
     deps := [⟨4, 3, .det⟩, ⟨5, 4, .nsubj⟩, ⟨5, 0, .obl⟩, ⟨0, 1, .obl⟩,
              ⟨1, 2, .det⟩]
     rootIdx := 5 }
 
 /-- (13c) reordering "comes AP the from story this", total 11. -/
-def reorderingC : DepTree :=
+def reorderingC : Tree :=
   { words := [come.toWord3sg, ap, the.toWord, from_.toWord, story.toWordSg, this_]
     deps := [⟨4, 5, .det⟩, ⟨0, 4, .nsubj⟩, ⟨0, 3, .obl⟩, ⟨3, 1, .obl⟩,
              ⟨1, 2, .det⟩]

--- a/Linglib/Studies/Gibson2025.lean
+++ b/Linglib/Studies/Gibson2025.lean
@@ -54,7 +54,7 @@ importing this file, so it is not currently wired through.
 namespace Gibson2025
 
 
-open DepGrammar DependencyLength DepGrammar.HarmonicOrder
+open DependencyGrammar DependencyLength DependencyGrammar.HarmonicOrder
 
 -- ============================================================================
 -- §0. Cross-tabulation apparatus (paper-anchored substrate)

--- a/Linglib/Studies/HahnDegenFutrell2021.lean
+++ b/Linglib/Studies/HahnDegenFutrell2021.lean
@@ -425,14 +425,14 @@ the chain: harmonic order → short dependencies → information locality
 /-- The DLM harmonic order prediction holds: consistent head direction
 produces shorter total dependency length (from HarmonicOrder.lean). -/
 theorem harmonic_dlm_holds :
-    DepGrammar.HarmonicOrder.dlmPredictsHarmonicCheaper = true := by native_decide
+    DependencyGrammar.HarmonicOrder.dlmPredictsHarmonicCheaper = true := by native_decide
 
 /-- The full chain: all languages with low entropy (consistent direction,
 short dependencies) are efficient, and the DLM prediction holds.
 This connects the structural argument (HarmonicOrder) to the
 information-theoretic result (memory-surprisal efficiency). -/
 theorem dlm_to_efficiency_chain :
-    DepGrammar.HarmonicOrder.dlmPredictsHarmonicCheaper = true ∧
+    DependencyGrammar.HarmonicOrder.dlmPredictsHarmonicCheaper = true ∧
     (allLanguages.filter (λ l =>
       match l.branchDirEntropy1000 with | some e => e < 300 | none => false
     )).all (·.moreEfficient) = true := by

--- a/Linglib/Studies/Hudson1990.lean
+++ b/Linglib/Studies/Hudson1990.lean
@@ -21,14 +21,14 @@ complementary distribution, and pronominal disjoint reference.
 namespace Hudson1990
 
 
-open DepGrammar.Coreference
-open DepGrammar.Nominal
+open DependencyGrammar.Coreference
+open DependencyGrammar.Nominal
 open Chomsky1981 (reflexiveCoreferenceData pronominalDisjointReferenceData
   complementaryDistributionData reciprocalCoreferenceData)
 
 /-- English binding under dependency grammar (d-command): the framework-neutral
     engine (`Binding.grammaticalForCoreference`) applied with DG's
-    `CommandRelation` instance (in scope via `open DepGrammar.Coreference`) and
+    `CommandRelation` instance (in scope via `open DependencyGrammar.Coreference`) and
     English's binding-class classifier. `Bool`-valued for `capturesPhenomenonData`. -/
 private def grammaticalForCoreference (ws : List Word) : Bool :=
   decide (Binding.grammaticalForCoreference Binding.bindingClassOf ws)

--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -25,9 +25,9 @@ satisfy the corresponding valency frames.
 ```
 Fragment VerbEntry.complementType ← lexical data (sleep=.none, kick=.np, give=.np_np)
     ↓ complementToArgStr
-ArgStr frames (argStrV0/VN/VNN) → DepTree.frames premises
+ArgStr frames (argStrV0/VN/VNN) → Tree.frames premises
     ↓
-DepTree instances ← concrete parse trees
+Tree instances ← concrete parse trees
     ↓
 satisfiesArgStr / checkVerbSubcat ← frame satisfaction + subcat verification
     ↓
@@ -43,7 +43,7 @@ grammaticality contrasts ← predictions for the example sentences
 namespace Osborne2019
 
 
-open DepGrammar WordGrammar Catena
+open DependencyGrammar WordGrammar Catena
 
 -- ============================================================================
 -- §1: Words from the Fragment Lexicon
@@ -128,7 +128,7 @@ def ditransTree :=
     (complementToArgStr English.Predicates.Verbal.give.complementType)
 
 /-- "John kicked the ball" — active transitive (for passive derivation). -/
-def activeTree : DepTree :=
+def activeTree : Tree :=
   { words := [john, kicked, the_, ball]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .obj⟩, ⟨3, 2, .det⟩]
     rootIdx := 1
@@ -137,14 +137,14 @@ def activeTree : DepTree :=
 
 /-- "The ball was kicked" — short passive; the passive analysis derives
     `argStrVPassive` from kick's transitive frame (`passive_frame_matches`). -/
-def passiveTree : DepTree :=
+def passiveTree : Tree :=
   { words := [the_, ball, was_, kicked_pass]
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩]
     rootIdx := 3
     frames := [none, none, none, some argStrVPassive] }
 
 /-- "The ball was kicked by John" — long passive with agent by-phrase. -/
-def longPassiveTree : DepTree :=
+def longPassiveTree : Tree :=
   { words := [the_, ball, was_, kicked_pass, by_, john]
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩,
              ⟨3, 5, .obl⟩, ⟨5, 4, .case_⟩]
@@ -156,7 +156,7 @@ def longPassiveTree : DepTree :=
 -- ============================================================================
 
 /-- "*John sleeps book" — intransitive with spurious object. -/
-def intrans_with_obj : DepTree :=
+def intrans_with_obj : Tree :=
   { words := [john, sleeps, book]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
     rootIdx := 1
@@ -168,7 +168,7 @@ def trans_no_obj :=
   mkSVTree john devours (complementToArgStr English.Predicates.Verbal.devour.complementType)
 
 /-- "*John gives Mary" — ditransitive missing direct object. -/
-def ditrans_no_obj : DepTree :=
+def ditrans_no_obj : Tree :=
   { words := [john, gives, mary]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .iobj⟩]
     rootIdx := 1
@@ -176,7 +176,7 @@ def ditrans_no_obj : DepTree :=
                none] }
 
 /-- "*The ball was kicked the ball" — passive with spurious object. -/
-def passive_with_obj : DepTree :=
+def passive_with_obj : Tree :=
   { words := [the_, ball, was_, kicked_pass, the_, ball]
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩,
              ⟨3, 5, .obj⟩, ⟨5, 4, .det⟩]
@@ -353,7 +353,7 @@ Fragments/English/Predicates/Verbal
     kick.complementType =.np → argStrVN
     give.complementType =.np_np → argStrVNN
         ↓ VerbEntry.toWord3sg / complementToArgStr
-DepTree instances (trees carry Fragment-derived frames)
+Tree instances (trees carry Fragment-derived frames)
         ↓ satisfiesArgStr / checkVerbSubcat
 grammatical ✓ / ungrammatical ✗
         ↓ passiveRule.transform

--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -25,7 +25,7 @@ satisfy the corresponding valency frames.
 ```
 Fragment VerbEntry.complementType ← lexical data (sleep=.none, kick=.np, give=.np_np)
     ↓ complementToArgStr
-ArgStr frames (argStr_V0/VN/VNN) → DepTree.frames premises
+ArgStr frames (argStrV0/VN/VNN) → DepTree.frames premises
     ↓
 DepTree instances ← concrete parse trees
     ↓
@@ -79,7 +79,7 @@ private def lex_kicked : LexEntry :=
   { form := kicked.form
     cat := .VERB
     features := kicked.features
-    argStr := argStr_VN }
+    argStr := argStrVN }
 
 -- ============================================================================
 -- §2: Fragment Grounding Theorems
@@ -88,24 +88,24 @@ private def lex_kicked : LexEntry :=
 
 /-- sleep.complementType =.none → intransitive frame (V0). -/
 theorem sleep_frame_from_fragment :
-    complementToArgStr English.Predicates.Verbal.sleep.complementType = some argStr_V0 := rfl
+    complementToArgStr English.Predicates.Verbal.sleep.complementType = some argStrV0 := rfl
 
 /-- devour.complementType =.np → transitive frame (VN). -/
 theorem devour_frame_from_fragment :
-    complementToArgStr English.Predicates.Verbal.devour.complementType = some argStr_VN := rfl
+    complementToArgStr English.Predicates.Verbal.devour.complementType = some argStrVN := rfl
 
 /-- give.complementType =.np_np → ditransitive frame (VNN). -/
 theorem give_frame_from_fragment :
-    complementToArgStr English.Predicates.Verbal.give.complementType = some argStr_VNN := rfl
+    complementToArgStr English.Predicates.Verbal.give.complementType = some argStrVNN := rfl
 
 /-- kick.complementType =.np → transitive frame (VN, active). -/
 theorem kick_frame_from_fragment :
-    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStr_VN := rfl
+    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStrVN := rfl
 
 /-- The passive frame carried on `passiveTree.frames` is consistent with the
     passive rule: the rule removes the obj slot from kick's transitive frame. -/
 theorem passive_valence_consistent :
-    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStr_VN ∧
+    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStrVN ∧
     passiveRule.applies lex_kicked = true ∧
     (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false :=
   ⟨rfl, rfl, rfl⟩
@@ -136,12 +136,12 @@ def activeTree : DepTree :=
                none, none] }
 
 /-- "The ball was kicked" — short passive; the passive analysis derives
-    `argStr_VPassive` from kick's transitive frame (`passive_frame_matches`). -/
+    `argStrVPassive` from kick's transitive frame (`passive_frame_matches`). -/
 def passiveTree : DepTree :=
   { words := [the_, ball, was_, kicked_pass]
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩]
     rootIdx := 3
-    frames := [none, none, none, some argStr_VPassive] }
+    frames := [none, none, none, some argStrVPassive] }
 
 /-- "The ball was kicked by John" — long passive with agent by-phrase. -/
 def longPassiveTree : DepTree :=
@@ -149,7 +149,7 @@ def longPassiveTree : DepTree :=
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩,
              ⟨3, 5, .obl⟩, ⟨5, 4, .case_⟩]
     rootIdx := 3
-    frames := [none, none, none, some argStr_VPassive, none, none] }
+    frames := [none, none, none, some argStrVPassive, none, none] }
 
 -- ============================================================================
 -- §4: Ungrammatical Trees
@@ -181,7 +181,7 @@ def passive_with_obj : DepTree :=
     deps := [⟨1, 0, .det⟩, ⟨3, 1, .nsubj⟩, ⟨3, 2, .auxPass⟩,
              ⟨3, 5, .obj⟩, ⟨5, 4, .det⟩]
     rootIdx := 3
-    frames := [none, none, none, some argStr_VPassive, none, none] }
+    frames := [none, none, none, some argStrVPassive, none, none] }
 
 -- ============================================================================
 -- LEVEL 1: Valency Frame Satisfaction
@@ -190,25 +190,25 @@ def passive_with_obj : DepTree :=
 
 /-- Intransitive tree satisfies intransitive frame (V0). -/
 theorem intrans_satisfies_V0 :
-    satisfiesArgStr intransTree 1 argStr_V0 = true := rfl
+    satisfiesArgStr intransTree 1 argStrV0 = true := rfl
 
 /-- Transitive tree satisfies transitive frame (VN). -/
 theorem trans_satisfies_VN :
-    satisfiesArgStr transTree 1 argStr_VN = true := rfl
+    satisfiesArgStr transTree 1 argStrVN = true := rfl
 
 /-- Ditransitive tree satisfies ditransitive frame (VNN). -/
 theorem ditrans_satisfies_VNN :
-    satisfiesArgStr ditransTree 1 argStr_VNN = true := rfl
+    satisfiesArgStr ditransTree 1 argStrVNN = true := rfl
 
 -- Cross-frame mismatches: wrong frame → fails
 
 /-- Intransitive tree does NOT satisfy transitive frame (missing obj). -/
 theorem intrans_not_VN :
-    satisfiesArgStr intransTree 1 argStr_VN = false := rfl
+    satisfiesArgStr intransTree 1 argStrVN = false := rfl
 
 /-- Transitive-minus-object tree does NOT satisfy transitive frame. -/
 theorem trans_noobj_not_VN :
-    satisfiesArgStr trans_no_obj 1 argStr_VN = false := rfl
+    satisfiesArgStr trans_no_obj 1 argStrVN = false := rfl
 
 -- ============================================================================
 -- LEVEL 2: Subcategorization Verification
@@ -240,10 +240,10 @@ theorem passive_removes_obj_adds_obl :
     (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obl) = true :=
   ⟨rfl, rfl⟩
 
-/-- The passive rule output matches argStr_VPassive. -/
+/-- The passive rule output matches argStrVPassive. -/
 theorem passive_frame_matches :
     (passiveRule.transform lex_kicked).argStr.slots =
-    argStr_VPassive.slots := by native_decide
+    argStrVPassive.slots := by native_decide
 
 -- Passive trees validate
 theorem passive_subcat_ok : checkVerbSubcat passiveTree = true := rfl
@@ -252,10 +252,10 @@ theorem passive_obj_subcat_fail : checkVerbSubcat passive_with_obj = false := rf
 
 -- Passive frame satisfaction
 theorem passive_satisfies_VPassive :
-    satisfiesArgStr passiveTree 3 argStr_VPassive = true := rfl
+    satisfiesArgStr passiveTree 3 argStrVPassive = true := rfl
 
 theorem long_passive_satisfies_VPassive :
-    satisfiesArgStr longPassiveTree 3 argStr_VPassive = true := rfl
+    satisfiesArgStr longPassiveTree 3 argStrVPassive = true := rfl
 
 -- ============================================================================
 -- LEVEL 4: Catena vs Constituent Analysis
@@ -293,24 +293,24 @@ theorem ditrans_verb_obj_catena_not_constituent :
 /-- **Full valency derivation chain**: from Fragment lexicon through DG
     theory to grammaticality predictions.
 
-    1. Fragment kick.complementType =.np → transitive frame (argStr_VN)
-    2. Active tree satisfies transitive frame (argStr_VN) ✓
+    1. Fragment kick.complementType =.np → transitive frame (argStrVN)
+    2. Active tree satisfies transitive frame (argStrVN) ✓
     3. checkVerbSubcat validates the active tree ✓
     4. Passive rule applies and removes obj slot ✓
-    5. Passive tree satisfies derived frame (argStr_VPassive) ✓
+    5. Passive tree satisfies derived frame (argStrVPassive) ✓
     6. checkVerbSubcat validates the passive tree ✓
     7. Passive + spurious obj correctly rejected ✗ -/
 theorem valency_derivation_chain :
     -- Fragment grounding
-    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStr_VN ∧
+    complementToArgStr English.Predicates.Verbal.kick.complementType = some argStrVN ∧
     -- Active: frame ✓, subcat ✓
-    satisfiesArgStr activeTree 1 argStr_VN = true ∧
+    satisfiesArgStr activeTree 1 argStrVN = true ∧
     checkVerbSubcat activeTree = true ∧
     -- Passive rule applies, removes obj
     passiveRule.applies lex_kicked = true ∧
     (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false ∧
     -- Passive tree: derived frame ✓, subcat ✓
-    satisfiesArgStr passiveTree 3 argStr_VPassive = true ∧
+    satisfiesArgStr passiveTree 3 argStrVPassive = true ∧
     checkVerbSubcat passiveTree = true ∧
     -- Passive with obj: correctly rejected
     checkVerbSubcat passive_with_obj = false :=
@@ -324,9 +324,9 @@ theorem valency_derivation_chain :
 
     | Grammatical          | Ungrammatical         | Frame      |
     |---------------------|-----------------------|------------|
-    | "John sleeps"       | "*John sleeps book"   | argStr_V0  |
-    | "John devours pizza"| "*John devours"       | argStr_VN  |
-    | "John gives Mary …" | "*John gives Mary"    | argStr_VNN | -/
+    | "John sleeps"       | "*John sleeps book"   | argStrV0  |
+    | "John devours pizza"| "*John devours"       | argStrVN  |
+    | "John gives Mary …" | "*John gives Mary"    | argStrVNN | -/
 theorem subcategorization_contrasts :
     checkVerbSubcat intransTree = true ∧
     checkVerbSubcat intrans_with_obj = false ∧
@@ -348,16 +348,16 @@ theorem passive_contrasts :
 
 ```
 Fragments/English/Predicates/Verbal
-    sleep.complementType =.none → argStr_V0
-    devour.complementType =.np → argStr_VN
-    kick.complementType =.np → argStr_VN
-    give.complementType =.np_np → argStr_VNN
+    sleep.complementType =.none → argStrV0
+    devour.complementType =.np → argStrVN
+    kick.complementType =.np → argStrVN
+    give.complementType =.np_np → argStrVNN
         ↓ VerbEntry.toWord3sg / complementToArgStr
 DepTree instances (trees carry Fragment-derived frames)
         ↓ satisfiesArgStr / checkVerbSubcat
 grammatical ✓ / ungrammatical ✗
         ↓ passiveRule.transform
-obj removed → argStr_VPassive surface frame
+obj removed → argStrVPassive surface frame
 ```
 
 Each level is independently verifiable by `rfl` or `native_decide`.

--- a/Linglib/Studies/Osborne2019Control.lean
+++ b/Linglib/Studies/Osborne2019Control.lean
@@ -44,9 +44,9 @@ Datum.hasEquiDeletion ← matches [noonan-2007]'s observations
 
 -/
 
-namespace DepGrammar.ControlBridge
+namespace DependencyGrammar.ControlBridge
 
-open DepGrammar DepGrammar.EnhancedDependencies
+open DependencyGrammar DependencyGrammar.EnhancedDependencies
 
 -- ============================================================================
 -- §1: Words from the Fragment Lexicon
@@ -92,13 +92,13 @@ theorem seem_is_raising :
 -- john(0) manages(1) to(2) sleep(3)
 
 /-- Basic tree: John is nsubj of manages only. -/
-def subjControlBasic : DepTree :=
+def subjControlBasic : Tree :=
   { words := [john, manages, to_, sleep_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩]
     rootIdx := 1 }
 
 /-- Enhanced graph: John is also nsubj of sleep (shared dependent). -/
-def subjControlEnhanced : DepGraph :=
+def subjControlEnhanced : Graph :=
   { words := [john, manages, to_, sleep_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩,
              ⟨3, 0, .nsubj⟩]  -- ← ENHANCED: sleep ← John
@@ -108,13 +108,13 @@ def subjControlEnhanced : DepGraph :=
 -- john(0) persuaded(1) mary(2) to(3) run(4)
 
 /-- Basic tree: Mary is obj of persuaded only. -/
-def objControlBasic : DepTree :=
+def objControlBasic : Tree :=
   { words := [john, persuaded, mary, to_, run_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩, ⟨1, 4, .xcomp⟩, ⟨4, 3, .mark⟩]
     rootIdx := 1 }
 
 /-- Enhanced graph: Mary is also nsubj of run (shared dependent). -/
-def objControlEnhanced : DepGraph :=
+def objControlEnhanced : Graph :=
   { words := [john, persuaded, mary, to_, run_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩, ⟨1, 4, .xcomp⟩, ⟨4, 3, .mark⟩,
              ⟨4, 2, .nsubj⟩]  -- ← ENHANCED: run ← Mary
@@ -125,13 +125,13 @@ def objControlEnhanced : DepGraph :=
 -- Same tree structure as subject control — the difference is semantic (theta roles)
 
 /-- Basic tree: John is nsubj of seems only. -/
-def raisingBasic : DepTree :=
+def raisingBasic : Tree :=
   { words := [john, seems, to_, sleep_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩]
     rootIdx := 1 }
 
 /-- Enhanced graph: John is also nsubj of sleep. -/
-def raisingEnhanced : DepGraph :=
+def raisingEnhanced : Graph :=
   { words := [john, seems, to_, sleep_]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩,
              ⟨3, 0, .nsubj⟩]  -- ← ENHANCED: sleep ← John
@@ -328,4 +328,4 @@ theorem object_control_derivation_chain :
     english_persuade.hasEquiDeletion = true :=
   ⟨rfl, by native_decide, by native_decide, by native_decide, by native_decide, rfl⟩
 
-end DepGrammar.ControlBridge
+end DependencyGrammar.ControlBridge

--- a/Linglib/Studies/Osborne2019Ellipsis.lean
+++ b/Linglib/Studies/Osborne2019Ellipsis.lean
@@ -14,13 +14,13 @@ not a constituent.
 
 ## Bridges
 
-- `DepGrammar.Ellipsis.EllipsisType` → `Steedman2000.EllipsisType`
-- `DepGrammar.Ellipsis.gappingTree` / `gappingElided` → catena-not-constituent proof
+- `DependencyGrammar.Ellipsis.EllipsisType` → `Steedman2000.EllipsisType`
+- `DependencyGrammar.Ellipsis.gappingTree` / `gappingElided` → catena-not-constituent proof
 -/
 
-namespace DepGrammar.Ellipsis
+namespace DependencyGrammar.Ellipsis
 
-open DepGrammar Catena
+open DependencyGrammar Catena
 
 /-- Map DG ellipsis types to `Steedman2000.EllipsisType`.
     Not all DG types have Steedman equivalents (pseudogapping/fragmentAnswer don't). -/
@@ -46,4 +46,4 @@ theorem gapping_always_catena_not_constituent :
     isConstituent gappingTree.deps 3 gappingElided = false := by
   constructor <;> native_decide
 
-end DepGrammar.Ellipsis
+end DependencyGrammar.Ellipsis

--- a/Linglib/Studies/OsborneGross2012/Data.lean
+++ b/Linglib/Studies/OsborneGross2012/Data.lean
@@ -33,7 +33,7 @@ The paper demonstrates catenae across five construction types:
 namespace OsborneGross2012
 
 
-open DepGrammar
+open DependencyGrammar
 
 -- ============================================================================
 -- §1: Construction Type Classification
@@ -57,7 +57,7 @@ inductive ConstructionType where
     Words: spill(0) the(1) beans(2)
     Deps: spill(0) → beans(2:obj), beans(2) → the(1:det)
     Construction nodes: {0, 2} -/
-def spillTheBeans : DepTree :=
+def spillTheBeans : Tree :=
   { words := [Word.mk' "spill" .VERB, Word.mk' "the" .DET, Word.mk' "beans" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -67,7 +67,7 @@ def spillTheBeans : DepTree :=
     Words: give(0) the(1) sack(2)
     Deps: give(0) → sack(2:obj), sack(2) → the(1:det)
     Construction nodes: {0, 2} -/
-def giveTheSack : DepTree :=
+def giveTheSack : Tree :=
   { words := [Word.mk' "give" .VERB, Word.mk' "the" .DET, Word.mk' "sack" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -77,7 +77,7 @@ def giveTheSack : DepTree :=
     Words: kick(0) the(1) bucket(2)
     Deps: kick(0) → bucket(2:obj), bucket(2) → the(1:det)
     Construction nodes: {0, 2} -/
-def kickTheBucket : DepTree :=
+def kickTheBucket : Tree :=
   { words := [Word.mk' "kick" .VERB, Word.mk' "the" .DET, Word.mk' "bucket" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -89,7 +89,7 @@ def kickTheBucket : DepTree :=
     Words: pull(0) some(1) strings(2)
     Deps: pull(0) → strings(2:obj), strings(2) → some(1:det)
     Construction nodes: {0, 2} -/
-def pullSomeStrings : DepTree :=
+def pullSomeStrings : Tree :=
   { words := [Word.mk' "pull" .VERB, Word.mk' "some" .DET, Word.mk' "strings" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -106,7 +106,7 @@ def pullSomeStrings : DepTree :=
     Words: take(0) a(1) bath(2)
     Deps: take(0) → bath(2:obj), bath(2) → a(1:det)
     Construction nodes: {0, 2} -/
-def takeABath : DepTree :=
+def takeABath : Tree :=
   { words := [Word.mk' "take" .VERB, Word.mk' "a" .DET, Word.mk' "bath" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -116,7 +116,7 @@ def takeABath : DepTree :=
     Words: have(0) a(1) look(2)
     Deps: have(0) → look(2:obj), look(2) → a(1:det)
     Construction nodes: {0, 2} -/
-def haveALook : DepTree :=
+def haveALook : Tree :=
   { words := [Word.mk' "have" .VERB, Word.mk' "a" .DET, Word.mk' "look" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -126,7 +126,7 @@ def haveALook : DepTree :=
     Words: give(0) a(1) yell(2)
     Deps: give(0) → yell(2:obj), yell(2) → a(1:det)
     Construction nodes: {0, 2} -/
-def giveAYell : DepTree :=
+def giveAYell : Tree :=
   { words := [Word.mk' "give" .VERB, Word.mk' "a" .DET, Word.mk' "yell" .NOUN]
     deps := [⟨0, 2, .obj⟩, ⟨2, 1, .det⟩]
     rootIdx := 0 }
@@ -144,7 +144,7 @@ def giveAYell : DepTree :=
     Words: he(0) will(1) have(2) helped(3)
     Deps: will(1) → he(0:nsubj), will(1) → have(2:dep), have(2) → helped(3:dep)
     Construction nodes: {1, 2, 3} -/
-def heWillHaveHelped : DepTree :=
+def heWillHaveHelped : Tree :=
   { words := [Word.mk' "he" .PRON, Word.mk' "will" .AUX,
               Word.mk' "have" .AUX, Word.mk' "helped" .VERB]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .dep⟩, ⟨2, 3, .dep⟩]
@@ -161,7 +161,7 @@ def heWillHaveHelped : DepTree :=
           have(2) → been(3:dep), been(3) → doing(4:dep),
           doing(4) → it(5:obj)
     Construction nodes: {1, 2, 3, 4} -/
-def sheWillHaveBeenDoingIt : DepTree :=
+def sheWillHaveBeenDoingIt : Tree :=
   { words := [Word.mk' "she" .PRON, Word.mk' "will" .AUX,
               Word.mk' "have" .AUX, Word.mk' "been" .AUX,
               Word.mk' "doing" .VERB, Word.mk' "it" .PRON]
@@ -183,7 +183,7 @@ def sheWillHaveBeenDoingIt : DepTree :=
     Words: beans(0) she(1) spilled(2)
     Deps: spilled(2) → beans(0:obj), spilled(2) → she(1:nsubj)
     Construction nodes: {0, 2} -/
-def beansSheSpilled : DepTree :=
+def beansSheSpilled : Tree :=
   { words := [Word.mk' "beans" .NOUN, Word.mk' "she" .PRON,
               Word.mk' "spilled" .VERB]
     deps := [⟨2, 0, .obj⟩, ⟨2, 1, .nsubj⟩]
@@ -206,7 +206,7 @@ def beansSheSpilled : DepTree :=
           get(7) → you(6:nsubj), get(7) → fatter(5:xcomp), fatter(5) → the(4:det)
     Protasis nodes: {0, 1, 2, 3}
     Apodosis nodes: {4, 5, 6, 7} -/
-def theMoreTheFatter : DepTree :=
+def theMoreTheFatter : Tree :=
   { words := [Word.mk' "the" .DET, Word.mk' "more" .ADV,
               Word.mk' "you" .PRON, Word.mk' "eat" .VERB,
               Word.mk' "the" .DET, Word.mk' "fatter" .ADJ,
@@ -227,8 +227,8 @@ catenae. `CatenalCx` instances span the specificity spectrum, and
 [fillmore-kay-oconnor-1988]'s idiom typology classifies the catena-verified
 constructions. -/
 
-open DepGrammar DepGrammar.Catena ConstructionGrammar
-open DepGrammar.CatenalConstruction
+open DependencyGrammar DependencyGrammar.Catena ConstructionGrammar
+open DependencyGrammar.CatenalConstruction
 
 -- ============================================================================
 -- §1: Per-Datum Catena Verification — Idioms

--- a/Linglib/Studies/OsborneLi2023.lean
+++ b/Linglib/Studies/OsborneLi2023.lean
@@ -37,7 +37,7 @@ project's 5-level enum.
 ## Main definitions
 
 * `isConjunctValent` / `isFullValent` — the paper's predicate-valent
-  type distinction, operationalised over `DepTree` via
+  type distinction, operationalised over `Tree` via
   `UD.DepRel.isValencyArg` from `Core/UD.lean`.
 * `crdcPredictedJudgment` — the `Judgment` the CRDC assigns to a
   candidate co-valuation; `.questionable` exactly when CRDC fires,
@@ -50,7 +50,7 @@ project's 5-level enum.
   of the predicate. This is a deliberate simplification of the paper's
   catena-based notion (paper §4); the example set does not exercise the
   distinction.
-* `getConjuncts` is reused from `DepGrammar.Coordination` rather than
+* `getConjuncts` is reused from `DependencyGrammar.Coordination` rather than
   reinventing coord-structure traversal. UD's basic-tree convention
   makes the first conjunct the head of the coordinate structure; the
   remaining conjuncts attach via `.conj`.
@@ -95,7 +95,7 @@ output to `Judgment`. Both are out of scope for this study file.
   dependency contrast — is theoretical commentary without formal
   content here yet.
 * Bool→Prop migration of `isConjunctValent` / `isFullValent` should
-  happen as part of a unified `DepGrammar/*` sweep, not piecemeal.
+  happen as part of a unified `DependencyGrammar/*` sweep, not piecemeal.
 * Cross-framework CRDC-vs-Conditions-A/B/C bake-off blocked on
   parser/coordination work (see Cross-framework relationship).
 -/
@@ -103,8 +103,8 @@ output to `Judgment`. Both are out of scope for this study file.
 namespace OsborneLi2023
 
 
-open DepGrammar
-open DepGrammar.Coordination
+open DependencyGrammar
+open DependencyGrammar.Coordination
 open Data.Examples (LinguisticExample)
 open Features (Judgment)
 
@@ -116,7 +116,7 @@ open Features (Judgment)
     `predIdx` to some coord-head `c`, and `valentIdx` is in
     `allConjuncts c` (the first conjunct, which heads the structure
     in UD, plus the remaining conjuncts attached via `.conj`). -/
-def isConjunctValent (t : DepTree) (predIdx valentIdx : Nat) : Bool :=
+def isConjunctValent (t : Tree) (predIdx valentIdx : Nat) : Bool :=
   t.deps.any λ d =>
     d.headIdx == predIdx && d.depType.isValencyArg
       && hasConjuncts t d.depIdx
@@ -128,7 +128,7 @@ def isConjunctValent (t : DepTree) (predIdx valentIdx : Nat) : Bool :=
     valent thereof if it is complete, that is, it is *not* a conjunct
     valent." Operationalised as "direct valency-eligible dependent of
     `predIdx` AND not a conjunct valent." -/
-def isFullValent (t : DepTree) (predIdx valentIdx : Nat) : Bool :=
+def isFullValent (t : Tree) (predIdx valentIdx : Nat) : Bool :=
   (t.deps.any λ d =>
       d.headIdx == predIdx && d.depType.isValencyArg
         && d.depIdx == valentIdx)
@@ -144,7 +144,7 @@ def isFullValent (t : DepTree) (predIdx valentIdx : Nat) : Bool :=
     Otherwise returns `.acceptable` — CRDC is silent, and other binding
     principles (Conditions A/B/C) may still apply. -/
 def crdcPredictedJudgment
-    (t : DepTree) (predIdx anaIdx anteIdx : Nat) : Judgment :=
+    (t : Tree) (predIdx anaIdx anteIdx : Nat) : Judgment :=
   if isFullValent t predIdx anaIdx && isConjunctValent t predIdx anteIdx then
     .questionable
   else
@@ -152,7 +152,7 @@ def crdcPredictedJudgment
 
 /-! ### CRDC-prediction theorems
 
-Each theorem builds a `DepTree` matching one of the example sentences
+Each theorem builds a `Tree` matching one of the example sentences
 and checks that `crdcPredictedJudgment` returns the contribution the
 CRDC is responsible for. For data points whose sentence-level judgment
 is set by a different principle (e.g. ex9b by Condition B, ex5a
@@ -162,7 +162,7 @@ CRDC's contribution from other determinants of acceptability. -/
 
 /-- Tree for "Max and Lucie talked about him."
     `Max(0) and(1) Lucie(2) talked(3) about(4) him(5)`. -/
-def ex2a_tree : DepTree :=
+def ex2a_tree : Tree :=
   { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="and", cat := .CCONJ, features := {}}
              , { form :="Lucie", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
              , { form :="about", cat := .ADP, features := {}}, { form :="him", cat := .PRON, features := {}} ]
@@ -174,7 +174,7 @@ theorem ex2a_predicts_questionable :
     crdcPredictedJudgment ex2a_tree 3 5 0 = .questionable := by decide
 
 /-- Tree for "Max talked about himself." — non-coordinate baseline. -/
-def ex9a_tree : DepTree :=
+def ex9a_tree : Tree :=
   { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
              , { form :="about", cat := .ADP, features := {}}, { form :="himself", cat := .PRON, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 3, .obl⟩, ⟨3, 2, .case_⟩ ]
@@ -187,7 +187,7 @@ theorem ex9a_predicts_acceptable :
     context. The sentence-level `.questionable` reading comes from
     Condition B, not the CRDC; here we record only that the CRDC is
     silent. -/
-def ex9b_tree : DepTree :=
+def ex9b_tree : Tree :=
   { words := [ { form :="Max", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
              , { form :="about", cat := .ADP, features := {}}, { form :="him", cat := .PRON, features := {}} ]
     deps  := [ ⟨1, 0, .nsubj⟩, ⟨1, 3, .obl⟩, ⟨3, 2, .case_⟩ ]
@@ -200,7 +200,7 @@ theorem ex9b_crdc_silent :
     *object*. `himself` heads the coord, so it is a conjunct valent;
     `John` is a full valent. CRDC's permitted direction (conjunct
     anaphor of full antecedent). -/
-def ex24a_tree : DepTree :=
+def ex24a_tree : Tree :=
   { words := [ { form :="John", cat := .PROPN, features := {}}, { form :="talked", cat := .VERB, features := {}}
              , { form :="about", cat := .ADP, features := {}}, { form :="himself", cat := .PRON, features := {}}
              , { form :="and", cat := .CCONJ, features := {}}, { form :="his", cat := .PRON, features := {}}
@@ -217,7 +217,7 @@ theorem ex24a_predicts_acceptable :
     Sentence-level judgment is stronger (`.ungrammatical`) due to
     `both...and` strengthening; the CRDC alone predicts
     `.questionable`. -/
-def ex5a_tree : DepTree :=
+def ex5a_tree : Tree :=
   { words := [ { form :="Both", cat := .CCONJ, features := {}}, { form :="John", cat := .PROPN, features := {}}
              , { form :="and", cat := .CCONJ, features := {}}, { form :="Mary", cat := .PROPN, features := {}}
              , { form :="love", cat := .VERB, features := {}}, { form :="him", cat := .PRON, features := {}} ]
@@ -233,7 +233,7 @@ theorem ex5a_predicts_questionable :
     subject (full valent), `him` is a conjunct of the embedded subject
     coord. Permitted direction; the CRDC is silent on `him↔John`
     co-valuation because `him` is a conjunct valent (not a full valent). -/
-def ex28d_tree : DepTree :=
+def ex28d_tree : Tree :=
   { words := [ { form :="John", cat := .PROPN, features := {}}, { form :="expected", cat := .VERB, features := {}}
              , { form :="Mary", cat := .PROPN, features := {}}, { form :="and", cat := .CCONJ, features := {}}
              , { form :="him", cat := .PRON, features := {}}, { form :="to", cat := .PART, features := {}}

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.List.Basic
+import Mathlib.Combinatorics.Digraph.Basic
 import Linglib.Data.UD.Basic
 import Linglib.Syntax.Category.Verb.Frame
 import Linglib.Morphology.Word.Basic
@@ -18,7 +19,12 @@ Dependencies v2). [hudson-2010], [gibson-2025].
 
 ## Main declarations
 
-* `Dependency`, `DepTree`, `DepGraph` — the basic graph-shaped data.
+* `Dependency`, `DepGraph`, `DepTree` — the basic graph-shaped data;
+  `DepTree extends DepGraph` with argument-structure frames.
+* `DepGraph.parentsOf`, `children`, `inDegree`, `toDigraph` — the graph API;
+  `toDigraph` presents the graph as a mathlib `Digraph` with decidable
+  adjacency (`ParentEdge` is the adjacency at the edge-list level), and
+  `toDigraph_mono` orders basic below enhanced graphs in the `Digraph` lattice.
 * `ArgStr`, `argStrV0/VN/VNN/VPassive` — argument-structure schemas for the
   standard intransitive / transitive / ditransitive / passive valences.
 * `hasUniqueHeads`, `isAcyclic`, `isWellFormed` — structural well-formedness
@@ -63,23 +69,77 @@ end ArgumentStructure
 
 section DependenciesAndTrees
 
-/-- A dependency: directed edge from head to dependent.
-    Uses UD.DepRel for the relation label. -/
+/-- A dependency: directed edge from head to dependent. -/
 structure Dependency where
+  /-- Index of the head word in the sentence's `words` list. -/
   headIdx : Nat
+  /-- Index of the dependent word in the sentence's `words` list. -/
   depIdx : Nat
+  /-- The UD v2 relation label; length metrics ignore it. -/
   depType : UD.DepRel
   deriving Repr, DecidableEq
 
-/-- A dependency tree for a sentence. `frames` carries the DG-specific lexical
-    argument-structure premises, aligned with `words` (missing/short = no frame):
-    the frame is framework apparatus (like HPSG's ARG-ST), so it lives on DG's
-    tree, not on the shared `Word` token. Frames come from the lexical carrier at
-    tree construction (`complementToArgStr` applied to a verb's `complementType`). -/
-structure DepTree where
+/-- A dependency graph for a sentence: tokens in surface order plus directed
+    head → dependent edges. A word may carry several incoming arcs, as in the
+    UD *enhanced* representation; the single-headed case is `DepTree`. -/
+structure DepGraph where
+  /-- The sentence's tokens, in surface order. -/
   words : List Word
+  /-- Directed head → dependent edges. -/
   deps : List Dependency
+  /-- Index into `words` of the sentence root. -/
   rootIdx : Nat
+  deriving Repr
+
+/-- The head → dependent adjacency of an edge list: there is an edge `(v → w)`
+    in `deps`. The atomic relation whose reflexive-transitive closure is
+    `Dominates`; sites that need "v is a head with dependent w" should use
+    this rather than re-spelling the existential. -/
+def ParentEdge (deps : List Dependency) (v w : Nat) : Prop :=
+  ∃ d ∈ deps, d.headIdx = v ∧ d.depIdx = w
+
+namespace DepGraph
+
+/-- The edges into position `i`. -/
+def parentsOf (g : DepGraph) (i : Nat) : List Dependency :=
+  g.deps.filter (·.depIdx == i)
+
+/-- The dependent positions of the word at position `i`. -/
+def children (g : DepGraph) (i : Nat) : List Nat :=
+  g.deps.filter (·.headIdx == i) |>.map (·.depIdx)
+
+/-- The number of incoming edges at position `i`. -/
+def inDegree (g : DepGraph) (i : Nat) : Nat :=
+  (g.parentsOf i).length
+
+/-- The graph as a mathlib `Digraph` on word positions. Built with
+    `Digraph.mk'`, so adjacency is decidable and digraph-level goals close by
+    `decide`. -/
+def toDigraph (g : DepGraph) : Digraph Nat :=
+  Digraph.mk' λ v w => g.deps.any λ d => d.headIdx == v && d.depIdx == w
+
+@[simp] theorem toDigraph_adj (g : DepGraph) (v w : Nat) :
+    g.toDigraph.Adj v w ↔ ParentEdge g.deps v w := by
+  simp [toDigraph, ParentEdge]
+
+/-- More edges, larger digraph: a graph's digraph is a subgraph of any
+    enhancement of it (in the `Digraph` lattice order). -/
+theorem toDigraph_mono {g g' : DepGraph} (h : ∀ d ∈ g.deps, d ∈ g'.deps) :
+    g.toDigraph ≤ g'.toDigraph := λ v w hvw => by
+  obtain ⟨d, hd, hh, hdep⟩ := (g.toDigraph_adj v w).mp hvw
+  exact (g'.toDigraph_adj v w).mpr ⟨d, h d hd, hh, hdep⟩
+
+end DepGraph
+
+/-- A dependency tree: a `DepGraph` meant to be single-headed (`hasUniqueHeads`
+    checks it), plus DG-specific lexical argument-structure premises. `frames`
+    is aligned with `words` (missing/short = no frame): the frame is framework
+    apparatus (like HPSG's ARG-ST), so it lives on DG's tree, not on the shared
+    `Word` token; frames come from the lexical carrier at tree construction
+    (`complementToArgStr` applied to a verb's `complementType`). -/
+structure DepTree extends DepGraph where
+  /-- Argument-structure premises aligned with `words`; short or missing list
+      means "no frame at this position" (see `DepTree.frame`). -/
   frames : List (Option ArgStr) := []
   deriving Repr
 
@@ -87,39 +147,27 @@ structure DepTree where
 def DepTree.frame (t : DepTree) (i : Nat) : Option ArgStr :=
   (t.frames[i]?).getD none
 
-/-- An enhanced dependency graph: like DepTree but allows multiple heads per word.
-    Relaxes the unique-heads constraint. -/
-structure DepGraph where
-  words : List Word
-  deps : List Dependency
-  rootIdx : Nat
-  deriving Repr
-
-/-- Every DepTree is trivially a DepGraph. -/
-def DepTree.toGraph (t : DepTree) : DepGraph :=
-  { words := t.words, deps := t.deps, rootIdx := t.rootIdx }
-
 end DependenciesAndTrees
 
 section StandardArgStr
 
 /-- Intransitive verb: subject to the left -/
-def argStr_V0 : ArgStr :=
+def argStrV0 : ArgStr :=
   { slots := [⟨.nsubj, .left, true, some .DET⟩] }
 
 /-- Transitive verb: subject left, object right -/
-def argStr_VN : ArgStr :=
+def argStrVN : ArgStr :=
   { slots := [⟨.nsubj, .left, true, some .DET⟩,
               ⟨.obj, .right, true, some .DET⟩] }
 
 /-- Ditransitive verb: subject left, indirect object right, object right -/
-def argStr_VNN : ArgStr :=
+def argStrVNN : ArgStr :=
   { slots := [⟨.nsubj, .left, true, some .DET⟩,
               ⟨.iobj, .right, true, some .DET⟩,
               ⟨.obj, .right, true, some .DET⟩] }
 
 /-- Passive transitive: subject left (was patient), optional by-phrase right -/
-def argStr_VPassive : ArgStr :=
+def argStrVPassive : ArgStr :=
   { slots := [⟨.nsubj, .left, true, some .DET⟩,
               ⟨.obl, .right, false, some .ADP⟩] }  -- by-phrase is optional
 
@@ -127,9 +175,9 @@ def argStr_VPassive : ArgStr :=
     Returns `none` for frames without a standard schema: clause-embedding
     types take xcomp/ccomp, not obj, and `.np_pp` has no fixture here. -/
 def complementToArgStr : ComplementType → Option ArgStr
-  | .none => some argStr_V0
-  | .np => some argStr_VN
-  | .np_np => some argStr_VNN
+  | .none => some argStrV0
+  | .np => some argStrVN
+  | .np_np => some argStrVNN
   | _ => Option.none
 
 end StandardArgStr
@@ -138,11 +186,8 @@ section WellFormedness
 
 /-- Check if every word except root has exactly one head. -/
 def hasUniqueHeads (t : DepTree) : Bool :=
-  let n := t.words.length
-  let inCounts := List.range n |>.map λ i =>
-    t.deps.filter (·.depIdx == i) |>.length
-  (List.range inCounts.length).zip inCounts |>.all λ (i, count) =>
-    if i == t.rootIdx then count == 0 else count == 1
+  (List.range t.words.length).all λ i =>
+    t.toDepGraph.inDegree i == (if i == t.rootIdx then 0 else 1)
 
 /-- Check for cycles: no word is its own ancestor. -/
 def isAcyclic (t : DepTree) : Bool :=

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -10,8 +10,8 @@ open Morphology (Word)
 # Dependency grammar substrate
 
 Core data types for dependency grammar: words connected by typed directed
-edges (`Dependency`), trees built over them (`DepTree`), and enhanced
-graphs allowing multiple incoming arcs (`DepGraph`). Argument structures
+edges (`Dependency`), trees built over them (`Tree`), and enhanced
+graphs allowing multiple incoming arcs (`Graph`). Argument structures
 (`ArgStr`) record direction and selectional category for each slot.
 
 Dependency relations use `UD.DepRel` from `Core/UD.lean` (Universal
@@ -19,9 +19,9 @@ Dependencies v2). [hudson-2010], [gibson-2025].
 
 ## Main declarations
 
-* `Dependency`, `DepGraph`, `DepTree` — the basic graph-shaped data;
-  `DepTree extends DepGraph` with argument-structure frames.
-* `DepGraph.parentsOf`, `children`, `inDegree`, `toDigraph` — the graph API;
+* `Dependency`, `Graph`, `Tree` — the basic graph-shaped data;
+  `Tree extends Graph` with argument-structure frames.
+* `Graph.parentsOf`, `children`, `inDegree`, `toDigraph` — the graph API;
   `toDigraph` presents the graph as a mathlib `Digraph` with decidable
   adjacency (`ParentEdge` is the adjacency at the edge-list level), and
   `toDigraph_mono` orders basic below enhanced graphs in the `Digraph` lattice.
@@ -39,7 +39,7 @@ Dependencies v2). [hudson-2010], [gibson-2025].
   inherit, and migrating it is a separate refactor.
 -/
 
-namespace DepGrammar
+namespace DependencyGrammar
 
 
 section ArgumentStructure
@@ -81,8 +81,8 @@ structure Dependency where
 
 /-- A dependency graph for a sentence: tokens in surface order plus directed
     head → dependent edges. A word may carry several incoming arcs, as in the
-    UD *enhanced* representation; the single-headed case is `DepTree`. -/
-structure DepGraph where
+    UD *enhanced* representation; the single-headed case is `Tree`. -/
+structure Graph where
   /-- The sentence's tokens, in surface order. -/
   words : List Word
   /-- Directed head → dependent edges. -/
@@ -98,53 +98,55 @@ structure DepGraph where
 def ParentEdge (deps : List Dependency) (v w : Nat) : Prop :=
   ∃ d ∈ deps, d.headIdx = v ∧ d.depIdx = w
 
-namespace DepGraph
+namespace Graph
 
 /-- The edges into position `i`. -/
-def parentsOf (g : DepGraph) (i : Nat) : List Dependency :=
+def parentsOf (g : Graph) (i : Nat) : List Dependency :=
   g.deps.filter (·.depIdx == i)
 
 /-- The dependent positions of the word at position `i`. -/
-def children (g : DepGraph) (i : Nat) : List Nat :=
+def children (g : Graph) (i : Nat) : List Nat :=
   g.deps.filter (·.headIdx == i) |>.map (·.depIdx)
 
 /-- The number of incoming edges at position `i`. -/
-def inDegree (g : DepGraph) (i : Nat) : Nat :=
+def inDegree (g : Graph) (i : Nat) : Nat :=
   (g.parentsOf i).length
 
 /-- The graph as a mathlib `Digraph` on word positions. Built with
     `Digraph.mk'`, so adjacency is decidable and digraph-level goals close by
     `decide`. -/
-def toDigraph (g : DepGraph) : Digraph Nat :=
+def toDigraph (g : Graph) : Digraph Nat :=
   Digraph.mk' λ v w => g.deps.any λ d => d.headIdx == v && d.depIdx == w
 
-@[simp] theorem toDigraph_adj (g : DepGraph) (v w : Nat) :
+@[simp] theorem toDigraph_adj (g : Graph) (v w : Nat) :
     g.toDigraph.Adj v w ↔ ParentEdge g.deps v w := by
   simp [toDigraph, ParentEdge]
 
 /-- More edges, larger digraph: a graph's digraph is a subgraph of any
     enhancement of it (in the `Digraph` lattice order). -/
-theorem toDigraph_mono {g g' : DepGraph} (h : ∀ d ∈ g.deps, d ∈ g'.deps) :
+theorem toDigraph_mono {g g' : Graph} (h : ∀ d ∈ g.deps, d ∈ g'.deps) :
     g.toDigraph ≤ g'.toDigraph := λ v w hvw => by
   obtain ⟨d, hd, hh, hdep⟩ := (g.toDigraph_adj v w).mp hvw
   exact (g'.toDigraph_adj v w).mpr ⟨d, h d hd, hh, hdep⟩
 
-end DepGraph
+instance : Coe Graph (Digraph Nat) := ⟨toDigraph⟩
 
-/-- A dependency tree: a `DepGraph` meant to be single-headed (`hasUniqueHeads`
+end Graph
+
+/-- A dependency tree: a `Graph` meant to be single-headed (`hasUniqueHeads`
     checks it), plus DG-specific lexical argument-structure premises. `frames`
     is aligned with `words` (missing/short = no frame): the frame is framework
     apparatus (like HPSG's ARG-ST), so it lives on DG's tree, not on the shared
     `Word` token; frames come from the lexical carrier at tree construction
     (`complementToArgStr` applied to a verb's `complementType`). -/
-structure DepTree extends DepGraph where
+structure Tree extends Graph where
   /-- Argument-structure premises aligned with `words`; short or missing list
-      means "no frame at this position" (see `DepTree.frame`). -/
+      means "no frame at this position" (see `Tree.frame`). -/
   frames : List (Option ArgStr) := []
   deriving Repr
 
 /-- The argument-structure frame at position `i`, if one was supplied. -/
-def DepTree.frame (t : DepTree) (i : Nat) : Option ArgStr :=
+def Tree.frame (t : Tree) (i : Nat) : Option ArgStr :=
   (t.frames[i]?).getD none
 
 end DependenciesAndTrees
@@ -185,12 +187,12 @@ end StandardArgStr
 section WellFormedness
 
 /-- Check if every word except root has exactly one head. -/
-def hasUniqueHeads (t : DepTree) : Bool :=
+def hasUniqueHeads (t : Tree) : Bool :=
   (List.range t.words.length).all λ i =>
-    t.toDepGraph.inDegree i == (if i == t.rootIdx then 0 else 1)
+    t.toGraph.inDegree i == (if i == t.rootIdx then 0 else 1)
 
 /-- Check for cycles: no word is its own ancestor. -/
-def isAcyclic (t : DepTree) : Bool :=
+def isAcyclic (t : Tree) : Bool :=
   let n := t.words.length
   List.range n |>.all λ start =>
     let rec follow (current : Nat) (visited : List Nat) (fuel : Nat) : Bool :=
@@ -206,7 +208,7 @@ def isAcyclic (t : DepTree) : Bool :=
 
 /-- Bundled well-formedness: unique heads + valid index bounds.
     Collects the three hypotheses that most dominance/planarity theorems need. -/
-structure DepTree.WF (t : DepTree) : Prop where
+structure Tree.WF (t : Tree) : Prop where
   uniqueHeads : hasUniqueHeads t = true
   depIdx_lt : ∀ d ∈ t.deps, d.depIdx < t.words.length
   headIdx_lt : ∀ d ∈ t.deps, d.headIdx < t.words.length
@@ -216,7 +218,7 @@ end WellFormedness
 section AgreementChecking
 
 /-- Check subject-verb number agreement. -/
-def checkSubjVerbAgr (t : DepTree) : Bool :=
+def checkSubjVerbAgr (t : Tree) : Bool :=
   t.deps.all λ d =>
     if d.depType == .nsubj then
       match t.words[d.depIdx]?, t.words[d.headIdx]? with
@@ -228,7 +230,7 @@ def checkSubjVerbAgr (t : DepTree) : Bool :=
     else true
 
 /-- Check determiner-noun number agreement. -/
-def checkDetNounAgr (t : DepTree) : Bool :=
+def checkDetNounAgr (t : Tree) : Bool :=
   t.deps.all λ d =>
     if d.depType == .det then
       match t.words[d.depIdx]?, t.words[d.headIdx]? with
@@ -244,7 +246,7 @@ end AgreementChecking
 section ArgStrSatisfaction
 
 /-- Check if a dependency tree satisfies an argument structure -/
-def satisfiesArgStr (t : DepTree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
+def satisfiesArgStr (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
   argStr.slots.all λ slot =>
     if slot.required then
       -- Required slot: must have a matching dependency
@@ -270,7 +272,7 @@ def coreArgRels : List UD.DepRel := [.nsubj, .obj, .iobj]
 /-- Every core-argument dependent of `headIdx` is licensed by a slot of
     `argStr` — the closed-world half of frame checking (`satisfiesArgStr`
     only checks that required slots are filled). -/
-def coreArgsLicensed (t : DepTree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
+def coreArgsLicensed (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
   t.deps.all λ d =>
     if d.headIdx == headIdx && coreArgRels.contains d.depType then
       argStr.slots.any (·.depType == d.depType)
@@ -279,7 +281,7 @@ def coreArgsLicensed (t : DepTree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
 /-- Check each verb's dependents against its lexical frame: required slots
     filled in the right direction (`satisfiesArgStr`) and no unlicensed core
     arguments (`coreArgsLicensed`). Verbs without a frame are skipped. -/
-def checkVerbSubcat (t : DepTree) : Bool :=
+def checkVerbSubcat (t : Tree) : Bool :=
   List.range t.words.length |>.all λ i =>
     match t.words[i]? with
     | some w =>
@@ -295,28 +297,28 @@ end ArgStrSatisfaction
 section TreeConstructionHelpers
 
 /-- Create a simple SV tree: subject -> verb. -/
-def mkSVTree (subj verb : Word) (frame : Option ArgStr := none) : DepTree :=
+def mkSVTree (subj verb : Word) (frame : Option ArgStr := none) : Tree :=
   { words := [subj, verb]
     deps := [⟨1, 0, .nsubj⟩]
     rootIdx := 1
     frames := [none, frame] }
 
 /-- Create a simple SVO tree: subject -> verb <- object. -/
-def mkSVOTree (subj verb obj : Word) (frame : Option ArgStr := none) : DepTree :=
+def mkSVOTree (subj verb obj : Word) (frame : Option ArgStr := none) : Tree :=
   { words := [subj, verb, obj]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
     rootIdx := 1
     frames := [none, frame, none] }
 
 /-- Create Det-N-V tree: det -> noun -> verb. -/
-def mkDetNVTree (det noun verb : Word) (frame : Option ArgStr := none) : DepTree :=
+def mkDetNVTree (det noun verb : Word) (frame : Option ArgStr := none) : Tree :=
   { words := [det, noun, verb]
     deps := [⟨1, 0, .det⟩, ⟨2, 1, .nsubj⟩]
     rootIdx := 2
     frames := [none, none, frame] }
 
 /-- Create a ditransitive tree: subj -> verb <- iobj <- obj. -/
-def mkDitransTree (subj verb iobj obj : Word) (frame : Option ArgStr := none) : DepTree :=
+def mkDitransTree (subj verb iobj obj : Word) (frame : Option ArgStr := none) : Tree :=
   { words := [subj, verb, iobj, obj]
     deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .iobj⟩, ⟨1, 3, .obj⟩]
     rootIdx := 1
@@ -324,4 +326,4 @@ def mkDitransTree (subj verb iobj obj : Word) (frame : Option ArgStr := none) : 
 
 end TreeConstructionHelpers
 
-end DepGrammar
+end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Coordination.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coordination.lean
@@ -25,13 +25,13 @@ complex-symbol grammar), see [gazdar-1981].
 * `checkCatMatch` — verifies that every `conj` edge connects words of
   matching UPOS categories.
 * `checkArgStrMatch` — for verbal `conj` edges, verifies matching valence.
-* `enhanceSharedDeps` — produce a `DepGraph` from a basic `DepTree` by
+* `enhanceSharedDeps` — produce a `Graph` from a basic `Tree` by
   propagating shared `obj` / `nsubj` / `iobj` edges from the first
   conjunct's head to each subsequent conjunct.
 
 ## Implementation notes
 
-* The `Bool`-valued predicates follow `DepGrammar`'s substrate convention;
+* The `Bool`-valued predicates follow `DependencyGrammar`'s substrate convention;
   migrating to `Prop` + `Decidable` is a substrate-wide refactor not done
   here.
 * Paper-replication fixtures and worked theorems for `enhanceSharedDeps`
@@ -39,39 +39,39 @@ complex-symbol grammar), see [gazdar-1981].
   consumers (`Formal/EnhancedDependencies.lean`,
   `Formal/CoordinationParallelism.lean`) define their own local minimal
   fixtures.
-* `checkArgStrMatch` is a coarse heuristic over `DepTree.frames`. Real
+* `checkArgStrMatch` is a coarse heuristic over `Tree.frames`. Real
   coordination-parallelism judgements (gapping, ATB extraction) live in
   `Formal/CoordinationParallelism.lean`.
 -/
 
-namespace DepGrammar.Coordination
+namespace DependencyGrammar.Coordination
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Coordinate structure -/
 
 /-- Conjuncts of a head: words linked by `conj` edges from `headIdx`.
 In UD basic-tree convention these are the second-and-later conjuncts;
 the first conjunct *is* `headIdx`. -/
-def getConjuncts (t : DepTree) (headIdx : Nat) : List Nat :=
+def getConjuncts (t : Tree) (headIdx : Nat) : List Nat :=
   t.deps.filter (λ d => d.headIdx == headIdx && d.depType == .conj)
     |>.map (·.depIdx)
 
 /-- Word `i` heads a coordinate structure iff it has at least one outgoing
 `conj` edge. -/
-def hasConjuncts (t : DepTree) (i : Nat) : Bool :=
+def hasConjuncts (t : Tree) (i : Nat) : Bool :=
   ¬ (getConjuncts t i).isEmpty
 
 /-- All conjuncts of a coordinate structure headed at `headIdx`: `headIdx`
 itself (first conjunct, which heads the structure in UD basic-tree
 convention) plus the words linked via `conj`. -/
-def allConjuncts (t : DepTree) (headIdx : Nat) : List Nat :=
+def allConjuncts (t : Tree) (headIdx : Nat) : List Nat :=
   headIdx :: getConjuncts t headIdx
 
 /-! ### Parallelism heuristics -/
 
 /-- Every `conj` edge connects words of matching UPOS categories. -/
-def checkCatMatch (t : DepTree) : Bool :=
+def checkCatMatch (t : Tree) : Bool :=
   t.deps.all λ d =>
     if d.depType == .conj then
       match t.words[d.headIdx]?, t.words[d.depIdx]? with
@@ -82,7 +82,7 @@ def checkCatMatch (t : DepTree) : Bool :=
 /-- For verbal `conj` edges, conjuncts have matching frames. Coarse
 heuristic — does not handle clausal coordination (`ccomp` / `xcomp`) or
 finer subcategorization. -/
-def checkArgStrMatch (t : DepTree) : Bool :=
+def checkArgStrMatch (t : Tree) : Bool :=
   t.deps.all λ d =>
     if d.depType == .conj then
       match t.words[d.headIdx]?, t.words[d.depIdx]? with
@@ -98,9 +98,9 @@ def checkArgStrMatch (t : DepTree) : Bool :=
 /-- Enhance a basic tree by propagating shared dependents from the first
 conjunct to all subsequent conjuncts. For each `conj` edge head→dep,
 propagates the head's `obj` / `nsubj` / `iobj` edges to `dep`. Returns a
-`DepGraph` (words may have multiple incoming edges). Cf.
+`Graph` (words may have multiple incoming edges). Cf.
 [de-marneffe-nivre-2019] Figure 9 for the relative-clause analogue. -/
-def enhanceSharedDeps (t : DepTree) : DepGraph :=
+def enhanceSharedDeps (t : Tree) : Graph :=
   let conjEdges := t.deps.filter (·.depType == .conj)
   let enhancedDeps := conjEdges.foldl (λ acc conjEdge =>
     let sharedDeps := t.deps.filter λ d =>
@@ -113,4 +113,4 @@ def enhanceSharedDeps (t : DepTree) : DepGraph :=
     deps  := t.deps ++ enhancedDeps
     rootIdx := t.rootIdx }
 
-end DepGrammar.Coordination
+end DependencyGrammar.Coordination

--- a/Linglib/Syntax/DependencyGrammar/Coreference.lean
+++ b/Linglib/Syntax/DependencyGrammar/Coreference.lean
@@ -17,13 +17,13 @@ language-neutral — it imports no Fragment.
 
 ## Main definitions
 
-- `toDepTree`, `dCommands`, `subjectDCommandsObject`, `sameLocalDomain` — the
+- `toTree`, `dCommands`, `subjectDCommandsObject`, `sameLocalDomain` — the
   d-command relation and its locality restriction, over a `Binding.SimpleClause`.
 - `instance : CommandRelation` — the dependency-grammar instance of the abstract
   command relation (d-command); the engine supplies Principles A/B/C over it.
 -/
 
-namespace DepGrammar.Coreference
+namespace DependencyGrammar.Coreference
 
 open Binding (SimpleClause Pos CommandRelation)
 
@@ -31,7 +31,7 @@ open Binding (SimpleClause Pos CommandRelation)
 
 /-- Build a dependency tree from a clause. Indices: 0 = subject, 1 = verb
     (root), 2 = object (if present); subject ←nsubj— verb, object ←obj— verb. -/
-def toDepTree (clause : SimpleClause) : DepTree :=
+def toTree (clause : SimpleClause) : Tree :=
   let words := match clause.object with
     | none => [clause.subject, clause.verb]
     | some obj => [clause.subject, clause.verb, obj]
@@ -43,7 +43,7 @@ def toDepTree (clause : SimpleClause) : DepTree :=
 
 /-- D-command: the word at `i` d-commands the word at `j` if both are dependents
     of the same head and `i` bears the subject relation (nsubj). -/
-def dCommands (tree : DepTree) (i j : Nat) : Bool :=
+def dCommands (tree : Tree) (i j : Nat) : Bool :=
   tree.deps.any fun di =>
     di.depIdx == i && di.depType == .nsubj &&
     tree.deps.any fun dj => dj.depIdx == j && di.headIdx == dj.headIdx
@@ -52,14 +52,14 @@ def dCommands (tree : DepTree) (i j : Nat) : Bool :=
 def subjectDCommandsObject (clause : SimpleClause) : Bool :=
   match clause.object with
   | none => false
-  | some _ => dCommands (toDepTree clause) 0 2
+  | some _ => dCommands (toTree clause) 0 2
 
 /-- Both positions are dependents of the same head (the verb) — one domain. -/
 def sameLocalDomain (clause : SimpleClause) : Bool :=
   match clause.object with
   | none => true
   | some _ =>
-    let tree := toDepTree clause
+    let tree := toTree clause
     (tree.deps.any fun d => d.depIdx == 0 && d.headIdx == tree.rootIdx) &&
     (tree.deps.any fun d => d.depIdx == 2 && d.headIdx == tree.rootIdx)
 
@@ -89,4 +89,4 @@ instance : CommandRelation where
   commandsDec := fun c i j => inferInstance
   sameDomainDec := fun c i j => inferInstance
 
-end DepGrammar.Coreference
+end DependencyGrammar.Coreference

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -25,18 +25,9 @@ private theorem hasUniqueHeads_count (t : DepTree)
       (t.deps.filter (·.depIdx == c)).length == 0
     else
       (t.deps.filter (·.depIdx == c)).length == 1) = true := by
-  unfold hasUniqueHeads at hwf
-  have hmem : (c, (t.deps.filter (·.depIdx == c)).length) ∈
-    (List.range (List.map (λ i => (List.filter (·.depIdx == i) t.deps).length)
-      (List.range t.words.length)).length).zip
-      (List.map (λ i => (List.filter (·.depIdx == i) t.deps).length)
-        (List.range t.words.length)) := by
-    rw [List.mem_iff_getElem]
-    simp only [List.length_zip, List.length_range, List.length_map]
-    exact ⟨c, by omega, by simp [List.getElem_zip, List.getElem_range, List.getElem_map]⟩
-  have h := (List.all_eq_true.mp hwf) _ hmem
-  simp only [beq_iff_eq] at h
-  exact h
+  have h := List.all_eq_true.mp hwf c (List.mem_range.mpr hc)
+  simp only [DepGraph.inDegree, DepGraph.parentsOf] at h
+  by_cases hcr : c = t.rootIdx <;> simp_all
 
 
 -- ============================================================================
@@ -186,7 +177,7 @@ private theorem parentOf_eq_find_uh (t : DepTree) (x : Nat) {dep : Dependency}
 /-- Under unique heads, if edge(v, c) exists, then `parentOf c = v`. -/
 theorem parentOf_of_edge_uh (t : DepTree)
     (hwf : t.WF)
-    {v c : Nat} (hedge : parentEdge t.deps v c) :
+    {v c : Nat} (hedge : ParentEdge t.deps v c) :
     parentOf_uh t c = v := by
   obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
   have hfind_some : (t.deps.find? (fun d => d.depIdx == c)).isSome = true :=

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -8,7 +8,7 @@ These results require `hasUniqueHeads` and/or `isAcyclic` from Basic.lean
 and the Dominates inductive + projection bridge theorems from Projection.lean.
 -/
 
-namespace DepGrammar
+namespace DependencyGrammar
 
 -- ============================================================================
 -- Dominance Properties Under Unique Heads
@@ -19,14 +19,14 @@ section DominanceUnderUniqueHeads
 
 /-- Extract from `hasUniqueHeads` for a specific node index: root has 0 incoming
     edges, non-root nodes have exactly 1. -/
-private theorem hasUniqueHeads_count (t : DepTree)
+private theorem hasUniqueHeads_count (t : Tree)
     (hwf : hasUniqueHeads t = true) (c : Nat) (hc : c < t.words.length) :
     (if c = t.rootIdx then
       (t.deps.filter (·.depIdx == c)).length == 0
     else
       (t.deps.filter (·.depIdx == c)).length == 1) = true := by
   have h := List.all_eq_true.mp hwf c (List.mem_range.mpr hc)
-  simp only [DepGraph.inDegree, DepGraph.parentsOf] at h
+  simp only [Graph.inDegree, Graph.parentsOf] at h
   by_cases hcr : c = t.rootIdx <;> simp_all
 
 
@@ -35,24 +35,24 @@ private theorem hasUniqueHeads_count (t : DepTree)
 -- ============================================================================
 
 /-- The unique parent of node x (follows `find?` on depIdx). Returns x if no parent. -/
-def parentOf_uh (t : DepTree) (x : Nat) : Nat :=
+def parentOf_uh (t : Tree) (x : Nat) : Nat :=
   match t.deps.find? (fun d => d.depIdx == x) with
   | some d => d.headIdx
   | none => x
 
 /-- Iterate parentOf k times. -/
-def iterParent_uh (t : DepTree) (x : Nat) : Nat → Nat
+def iterParent_uh (t : Tree) (x : Nat) : Nat → Nat
   | 0 => x
   | k + 1 => parentOf_uh t (iterParent_uh t x k)
 
-private theorem iterParent_add_uh (t : DepTree) (x : Nat) (a b : Nat) :
+private theorem iterParent_add_uh (t : Tree) (x : Nat) (a b : Nat) :
     iterParent_uh t x (a + b) = iterParent_uh t (iterParent_uh t x a) b := by
   induction b generalizing x a with
   | zero => simp [iterParent_uh]
   | succ b ih => simp only [iterParent_uh]; congr 1; exact ih x a
 
 /-- `follow` returns false when current node is already visited. -/
-private theorem follow_visited_uh (t : DepTree) (current : Nat)
+private theorem follow_visited_uh (t : Tree) (current : Nat)
     (visited : List Nat) (fuel : Nat)
     (h : visited.contains current = true) :
     isAcyclic.follow t current visited (fuel + 1) = false := by
@@ -62,7 +62,7 @@ private theorem follow_visited_uh (t : DepTree) (current : Nat)
   · rename_i h2; exact absurd h h2
 
 /-- `follow` steps through the unique parent edge. -/
-private theorem follow_step_uh (t : DepTree) (current : Nat)
+private theorem follow_step_uh (t : Tree) (current : Nat)
     (visited : List Nat) (fuel : Nat)
     (h1 : visited.contains current = false) (dep : Dependency)
     (h2 : t.deps.find? (fun d => d.depIdx == current) = some dep) :
@@ -78,7 +78,7 @@ private theorem follow_step_uh (t : DepTree) (current : Nat)
     · rename_i _ heq; rw [h2] at heq; cases heq
 
 /-- `follow` returns true when no parent edge exists. -/
-private theorem follow_no_parent_uh (t : DepTree) (current : Nat)
+private theorem follow_no_parent_uh (t : Tree) (current : Nat)
     (visited : List Nat) (fuel : Nat)
     (h1 : visited.contains current = false)
     (h2 : t.deps.find? (fun d => d.depIdx == current) = none) :
@@ -93,7 +93,7 @@ private theorem follow_no_parent_uh (t : DepTree) (current : Nat)
 
 /-- If the iterParent chain revisits a node in `visited` after m steps,
     `follow` returns false. -/
-private theorem follow_false_of_chain_revisit (t : DepTree)
+private theorem follow_false_of_chain_revisit (t : Tree)
     (current : Nat) (visited : List Nat)
     (m fuel : Nat) (hfuel : fuel ≥ m + 1)
     (hparents : ∀ i, i < m →
@@ -134,7 +134,7 @@ private theorem follow_false_of_chain_revisit (t : DepTree)
 
 /-- If the iterParent chain cycles back to start after m+1 steps,
     `follow` from start with empty visited returns false. -/
-private theorem follow_false_of_cycle (t : DepTree)
+private theorem follow_false_of_cycle (t : Tree)
     (start : Nat) (m fuel : Nat) (hfuel : fuel ≥ m + 2)
     (hparents : ∀ i, i ≤ m →
       ∃ dep, t.deps.find? (fun d => d.depIdx == iterParent_uh t start i) = some dep ∧
@@ -162,20 +162,20 @@ private theorem follow_false_of_cycle (t : DepTree)
       exact List.elem_eq_true_of_mem List.mem_cons_self
 
 /-- Extract from `isAcyclic`: `follow v [] (n+1) = true` for v < n. -/
-private theorem isAcyclic_follow_uh (t : DepTree) (hacyc : isAcyclic t = true)
+private theorem isAcyclic_follow_uh (t : Tree) (hacyc : isAcyclic t = true)
     (v : Nat) (hv : v < t.words.length) :
     isAcyclic.follow t v [] (t.words.length + 1) = true := by
   unfold isAcyclic at hacyc
   exact List.all_eq_true.mp hacyc v (List.mem_range.mpr hv)
 
 /-- `parentOf_uh` equals the headIdx from `find?`. -/
-private theorem parentOf_eq_find_uh (t : DepTree) (x : Nat) {dep : Dependency}
+private theorem parentOf_eq_find_uh (t : Tree) (x : Nat) {dep : Dependency}
     (hfind : t.deps.find? (fun d => d.depIdx == x) = some dep) :
     parentOf_uh t x = dep.headIdx := by
   simp [parentOf_uh, hfind]
 
 /-- Under unique heads, if edge(v, c) exists, then `parentOf c = v`. -/
-theorem parentOf_of_edge_uh (t : DepTree)
+theorem parentOf_of_edge_uh (t : Tree)
     (hwf : t.WF)
     {v c : Nat} (hedge : ParentEdge t.deps v c) :
     parentOf_uh t c = v := by
@@ -210,7 +210,7 @@ theorem parentOf_of_edge_uh (t : DepTree)
 
 /-- Under unique heads, `Dominates v w` with v ≠ w implies the iterParent chain
     from w reaches v, with valid parent edges at each step. -/
-theorem dominates_iterParent_uh (t : DepTree)
+theorem dominates_iterParent_uh (t : Tree)
     (hwf : t.WF)
     {v w : Nat} (hdom : Dominates t.deps v w) (hne : v ≠ w) :
     ∃ k : Nat, k > 0 ∧ iterParent_uh t w k = v ∧
@@ -256,7 +256,7 @@ theorem dominates_iterParent_uh (t : DepTree)
             rw [hiter]; exact (parentOf_eq_find_uh t c hf_find).symm⟩
 
 /-- If `Dominates v w` with v ≠ w, then w is a depIdx in some edge, hence < n. -/
-private theorem dominates_depIdx_lt (t : DepTree)
+private theorem dominates_depIdx_lt (t : Tree)
     (h_dep_wf : ∀ d ∈ t.deps, d.depIdx < t.words.length)
     {v w : Nat} (hdom : Dominates t.deps v w) (hne : v ≠ w) :
     w < t.words.length := by
@@ -272,7 +272,7 @@ private theorem dominates_depIdx_lt (t : DepTree)
     · exact ih hcx
 
 /-- Each node in the iterParent chain (with valid parent edges) is a depIdx < n. -/
-private theorem iterParent_chain_lt (t : DepTree)
+private theorem iterParent_chain_lt (t : Tree)
     (h_dep_wf : ∀ d ∈ t.deps, d.depIdx < t.words.length)
     (start : Nat) (k : Nat) (i : Nat) (hi : i < k)
     (hchain : ∀ j, j < k →
@@ -344,7 +344,7 @@ private theorem ofFn_nodup_of_injective {α : Type*} [DecidableEq α] {n : Nat}
     of length `j - i ≤ n`, detectable by `follow_false_of_cycle` with fuel
     `n + 1 ≥ j - i + 1`. But `isAcyclic = true`, contradiction.
     Then `nodup_bound` gives `n + 1 ≤ n`, contradiction. -/
-theorem iterParent_chain_bound (t : DepTree)
+theorem iterParent_chain_bound (t : Tree)
     (hacyc : isAcyclic t = true)
     (h_dep_wf : ∀ d ∈ t.deps, d.depIdx < t.words.length)
     (start : Nat) (k : Nat)
@@ -432,7 +432,7 @@ theorem iterParent_chain_bound (t : DepTree)
     from both `Dominates` derivations, combine into a cycle, and show
     `isAcyclic.follow` detects it (returning `false`), contradicting
     `isAcyclic = true`. -/
-theorem dominates_antisymm (t : DepTree)
+theorem dominates_antisymm (t : Tree)
     (hwf : t.WF) (hacyc : isAcyclic t = true)
     (v w : Nat) (hvw : Dominates t.deps v w) (hwv : Dominates t.deps w v) :
     v = w := by
@@ -499,4 +499,4 @@ theorem dominates_to_parent {deps : List Dependency} {v c a : Nat}
 
 end DominanceUnderUniqueHeads
 
-end DepGrammar
+end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Formal/Catena.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Catena.lean
@@ -36,9 +36,9 @@ every catena is a constituent.
 
 -/
 
-namespace DepGrammar.Catena
+namespace DependencyGrammar.Catena
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Computable BFS over dependency edges -/
 
@@ -434,4 +434,4 @@ theorem singleton_isCatena (deps : List Dependency) (v : Nat) :
   exact List.elem_eq_true_of_mem
     (mem_go_of_mem_visited _ _ _ _ _ v List.mem_cons_self)
 
-end DepGrammar.Catena
+end DependencyGrammar.Catena

--- a/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
@@ -24,10 +24,10 @@ live in `Studies/OsborneGross2012/Data.lean`; their catena fields are
 discharged by `decide` over the concrete tree.
 -/
 
-namespace DepGrammar.CatenalConstruction
+namespace DependencyGrammar.CatenalConstruction
 
 
-open DepGrammar Catena ConstructionGrammar
+open DependencyGrammar Catena ConstructionGrammar
 
 /-! ### Core bridge type -/
 
@@ -51,7 +51,7 @@ structure CatenalCx where
   /-- CxG description of the construction. -/
   construction : Construction
   /-- A dependency tree instantiating the construction. -/
-  tree : DepTree
+  tree : Tree
   /-- Node indices that carry the construction. -/
   nodes : List Nat
   /-- The construction nodes form a catena. -/
@@ -132,4 +132,4 @@ theorem constituent_implies_catena (deps : List Dependency) (n : Nat)
         (h_n2p start List.mem_cons_self) (h_n2p x hx))
     exact List.elem_eq_true_of_mem (bfsReachable_complete deps _ start x hbidir)
 
-end DepGrammar.CatenalConstruction
+end DependencyGrammar.CatenalConstruction

--- a/Linglib/Syntax/DependencyGrammar/Formal/CoordinationParallelism.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/CoordinationParallelism.lean
@@ -15,11 +15,11 @@ from requiring symmetric (ATB) extraction.
 ## Main declarations
 
 * `SharingType` — typology of shared material (forward / backward / symmetric / none).
-* `parallelConjuncts`, `sharedDepTypes` — predicates over a `DepTree`
+* `parallelConjuncts`, `sharedDepTypes` — predicates over a `Tree`
   detecting core-argument parallelism and the shared-dep typeset between
   two conjunct heads.
 * `isATBExtraction`, `cscViolation` — Bool predicates over an enhanced
-  `DepGraph` detecting across-the-board extraction and CSC violations.
+  `Graph` detecting across-the-board extraction and CSC violations.
 * `forwardSharing`, `rnrBasic`, `gappingPreEllipsis`, `atbExtraction` —
   worked example trees from Osborne 2019.
 
@@ -36,10 +36,10 @@ from requiring symmetric (ATB) extraction.
   have been dropped.
 -/
 
-namespace DepGrammar.CoordinationParallelism
+namespace DependencyGrammar.CoordinationParallelism
 
 
-open DepGrammar Catena
+open DependencyGrammar Catena
 
 /-! ### Sharing typology -/
 
@@ -60,7 +60,7 @@ inductive SharingType where
 /-- Two conjuncts are parallel when they take the same set of core
     argument relations (nsubj, obj, iobj), ignoring coordination markers
     (conj, cc) and function-word relations that don't affect parallelism. -/
-def parallelConjuncts (t : DepTree) (c1 c2 : Nat) : Bool :=
+def parallelConjuncts (t : Tree) (c1 c2 : Nat) : Bool :=
   let isCoreArg (r : UD.DepRel) := r == .nsubj || r == .obj || r == .iobj
   let rels1 := t.deps.filter (λ d => d.headIdx == c1 && isCoreArg d.depType)
     |>.map (·.depType) |>.insertionSort (·.toString ≤ ·.toString) |>.eraseDups
@@ -69,7 +69,7 @@ def parallelConjuncts (t : DepTree) (c1 c2 : Nat) : Bool :=
   rels1.length == rels2.length && rels1.all rels2.contains
 
 /-- The dependency types that appear under both `c1` and `c2`. -/
-def sharedDepTypes (t : DepTree) (c1 c2 : Nat) : List UD.DepRel :=
+def sharedDepTypes (t : Tree) (c1 c2 : Nat) : List UD.DepRel :=
   let rels1 := t.deps.filter (·.headIdx == c1) |>.map (·.depType)
   let rels2 := t.deps.filter (·.headIdx == c2) |>.map (·.depType)
   rels1.filter rels2.contains |>.eraseDups
@@ -78,7 +78,7 @@ def sharedDepTypes (t : DepTree) (c1 c2 : Nat) : List UD.DepRel :=
 
 /-- Forward sharing: "John eats and drinks beer", with `John(0)` the shared
     subject of both verbs. -/
-def forwardSharing : DepTree :=
+def forwardSharing : Tree :=
   { words := [ Word.mk' "John" .PROPN, Word.mk' "eats" .VERB
              , Word.mk' "and" .CCONJ, Word.mk' "drinks" .VERB
              , Word.mk' "beer" .NOUN ]
@@ -87,13 +87,13 @@ def forwardSharing : DepTree :=
     rootIdx := 1 }
 
 /-- Enhanced graph for `forwardSharing`: `John` is `nsubj` of both verbs. -/
-def forwardSharingEnhanced : DepGraph :=
+def forwardSharingEnhanced : Graph :=
   Coordination.enhanceSharedDeps forwardSharing
 
 /-- Right-node-raising: "John likes and Mary hates pizza". The basic tree
     attaches `pizza` to `likes(1)` only; `enhanceSharedDeps` propagates
     it as `obj` of `hates(4)` too. -/
-def rnrBasic : DepTree :=
+def rnrBasic : Tree :=
   { words := [ Word.mk' "John" .PROPN, Word.mk' "likes" .VERB
              , Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN
              , Word.mk' "hates" .VERB, Word.mk' "pizza" .NOUN ]
@@ -101,11 +101,11 @@ def rnrBasic : DepTree :=
     rootIdx := 1 }
 
 /-- Enhanced graph for `rnrBasic`. -/
-def rnrEnhanced : DepGraph := Coordination.enhanceSharedDeps rnrBasic
+def rnrEnhanced : Graph := Coordination.enhanceSharedDeps rnrBasic
 
 /-- Pre-gapping tree for "Fred eats beans and Jim eats rice", with the
     second `eats` still overt; downstream gapping treatments elide it. -/
-def gappingPreEllipsis : DepTree :=
+def gappingPreEllipsis : Tree :=
   { words := [ Word.mk' "Fred" .PROPN, Word.mk' "eats" .VERB
              , Word.mk' "beans" .NOUN, Word.mk' "and" .CCONJ
              , Word.mk' "eats" .VERB, Word.mk' "Jim" .PROPN
@@ -116,7 +116,7 @@ def gappingPreEllipsis : DepTree :=
 
 /-- ATB extraction: "What did John buy and Mary sell?", symmetric
     extraction of `what` from both conjuncts. -/
-def atbExtraction : DepTree :=
+def atbExtraction : Tree :=
   { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "John" .PROPN, Word.mk' "buy" .VERB
              , Word.mk' "and" .CCONJ, Word.mk' "Mary" .PROPN
@@ -126,7 +126,7 @@ def atbExtraction : DepTree :=
     rootIdx := 3 }
 
 /-- Enhanced ATB graph: `what` is `obj` of both `buy` and `sell`. -/
-def atbExtractionEnhanced : DepGraph :=
+def atbExtractionEnhanced : Graph :=
   Coordination.enhanceSharedDeps atbExtraction
 
 /-! ### Shared material forms catenae -/
@@ -153,7 +153,7 @@ theorem gapping_conjuncts_parallel :
     both have `nsubj` and `obj` after shared-dep propagation. -/
 theorem atb_conjuncts_parallel_enhanced :
     let enhanced := atbExtractionEnhanced
-    let t : DepTree := { words := enhanced.words, deps := enhanced.deps,
+    let t : Tree := { words := enhanced.words, deps := enhanced.deps,
                          rootIdx := enhanced.rootIdx }
     parallelConjuncts t 3 6 = true := by decide
 
@@ -161,7 +161,7 @@ theorem atb_conjuncts_parallel_enhanced :
 
 /-- Extraction is across-the-board when the filler is a dependent of
     every conjunct in the enhanced graph. -/
-def isATBExtraction (enhanced : DepGraph) (fillerIdx : Nat)
+def isATBExtraction (enhanced : Graph) (fillerIdx : Nat)
     (conjuncts : List Nat) : Bool :=
   conjuncts.all λ c =>
     enhanced.deps.any λ d =>
@@ -169,7 +169,7 @@ def isATBExtraction (enhanced : DepGraph) (fillerIdx : Nat)
 
 /-- Extraction violates the CSC when the filler is extracted from some
     but not all conjuncts. -/
-def cscViolation (enhanced : DepGraph) (fillerIdx : Nat)
+def cscViolation (enhanced : Graph) (fillerIdx : Nat)
     (conjuncts : List Nat) : Bool :=
   let someHave := conjuncts.any λ c =>
     enhanced.deps.any (λ d => d.headIdx == c && d.depIdx == fillerIdx)
@@ -183,4 +183,4 @@ theorem atb_extraction_isATB :
 theorem atb_no_cscViolation :
     cscViolation atbExtractionEnhanced 0 [3, 6] = false := by decide
 
-end DepGrammar.CoordinationParallelism
+end DependencyGrammar.CoordinationParallelism

--- a/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/DependencyLength.lean
@@ -25,12 +25,12 @@ and cross-linguistic data sit in `Studies/FutrellEtAl2020.lean`,
 
 `depLength` is `max - min` rather than absolute value to stay in `Nat`. The
 consumers (`Studies/FutrellEtAl2020`, `HarmonicOrder`, `EnhancedDependencies`)
-open `DepGrammar.DependencyLength` to pick up `depLength`/`totalDepLength`.
+open `DependencyGrammar.DependencyLength` to pick up `depLength`/`totalDepLength`.
 -/
 
-namespace DepGrammar.DependencyLength
+namespace DependencyGrammar.DependencyLength
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Core quantities -/
 
@@ -39,14 +39,14 @@ def depLength (d : Dependency) : Nat :=
   max d.headIdx d.depIdx - min d.headIdx d.depIdx
 
 /-- Total dependency length of a tree: the quantity minimised by DLM. -/
-def totalDepLength (t : DepTree) : Nat :=
+def totalDepLength (t : Tree) : Nat :=
   t.deps.foldl (λ acc d => acc + depLength d) 0
 
 /-! ### Behaghel's Oberstes Gesetz -/
 
 /-- [behaghel-1932]'s Oberstes Gesetz: every dependency has length at
 most `threshold`. -/
-def oberstesGesetz (t : DepTree) (threshold : Nat) : Bool :=
+def oberstesGesetz (t : Tree) (threshold : Nat) : Bool :=
   t.deps.all λ d => depLength d ≤ threshold
 
 /-! ### Short-before-long -/
@@ -87,4 +87,4 @@ theorem self_loop_length (i : Nat) :
 theorem empty_tree_dep_length :
     totalDepLength { words := [], deps := [], rootIdx := 0 } = 0 := rfl
 
-end DepGrammar.DependencyLength
+end DependencyGrammar.DependencyLength

--- a/Linglib/Syntax/DependencyGrammar/Formal/Discontinuity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Discontinuity.lean
@@ -40,10 +40,10 @@ phrase-structure grammar with a single tree-level predicate.
   `decide` proofs reduce; see `Syntax/DependencyGrammar/Projection.lean`.
 -/
 
-namespace DepGrammar.Discontinuity
+namespace DependencyGrammar.Discontinuity
 
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Discontinuity classification -/
 
@@ -84,7 +84,7 @@ def isContiguous (nodes : List Nat) : Bool :=
 /-- A **risen catena** ([osborne-2019], Ch 7 §7.10) is a catena whose
     string yield is not contiguous — connected in the dependency tree but
     separated in linear order by intervening material. -/
-def isRisenCatena (t : DepTree) (nodes : List Nat) : Bool :=
+def isRisenCatena (t : Tree) (nodes : List Nat) : Bool :=
   Catena.isCatena t.deps nodes && !isContiguous nodes
 
 /-- Classify a dependency as rising or lowering by whether the dependent
@@ -96,7 +96,7 @@ def classifyDisplacement (d : Dependency) : DisplacementDir :=
 
 /-- **Wh-fronting**: "What did you eat?". The catena `{what(0), eat(3)}` is
     risen — connected via `obj` but `did(1), you(2)` intervene. -/
-def whFrontingTree : DepTree :=
+def whFrontingTree : Tree :=
   { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "you" .PRON, Word.mk' "eat" .VERB ]
     deps := [⟨3, 2, .nsubj⟩, ⟨3, 0, .obj⟩, ⟨3, 1, .aux⟩]
@@ -108,7 +108,7 @@ def whFrontingArc : Dependency := ⟨3, 0, .obj⟩
 /-- **Topicalization**: "Those ideas I do accept". The catena
     `{ideas(1), accept(4)}` is risen — connected via `obj` but `I(2), do(3)`
     intervene. -/
-def topicalizationTree : DepTree :=
+def topicalizationTree : Tree :=
   { words := [ Word.mk' "those" .DET, Word.mk' "ideas" .NOUN
              , Word.mk' "I" .PRON, Word.mk' "do" .AUX
              , Word.mk' "accept" .VERB ]
@@ -121,7 +121,7 @@ def topicalizationArc : Dependency := ⟨4, 1, .obj⟩
 
 /-- **Scrambling** (German): "dass uns Maria etwas gebacken hat". The catena
     `{uns(1), gebacken(4)}` is risen — `uns` is scrambled past the subject. -/
-def scramblingTree : DepTree :=
+def scramblingTree : Tree :=
   { words := [ Word.mk' "dass" .SCONJ, Word.mk' "uns" .PRON
              , Word.mk' "Maria" .PROPN, Word.mk' "etwas" .PRON
              , Word.mk' "gebacken" .VERB, Word.mk' "hat" .AUX ]
@@ -131,7 +131,7 @@ def scramblingTree : DepTree :=
 
 /-- **Extraposition**: "The idea arose to try again". The catena
     `{idea(1), try(4)}` is risen — `arose(2), to(3)` intervene. Lowering. -/
-def extrapositionTree : DepTree :=
+def extrapositionTree : Tree :=
   { words := [ Word.mk' "the" .DET, Word.mk' "idea" .NOUN
              , Word.mk' "arose" .VERB, Word.mk' "to" .PART
              , Word.mk' "try" .VERB, Word.mk' "again" .ADV ]
@@ -144,7 +144,7 @@ def extrapositionArc : Dependency := ⟨1, 4, .acl⟩
 
 /-- **Right dislocation**: "He's nice, that boy". The catena
     `{nice(2), boy(4)}` is risen — `that(3)` intervenes. -/
-def rightDislocationTree : DepTree :=
+def rightDislocationTree : Tree :=
   { words := [ Word.mk' "he" .PRON, Word.mk' "is" .AUX
              , Word.mk' "nice" .ADJ, Word.mk' "that" .DET
              , Word.mk' "boy" .NOUN ]
@@ -182,4 +182,4 @@ theorem topicalization_is_rising :
 theorem extraposition_is_lowering :
     classifyDisplacement extrapositionArc = .lowering := by decide
 
-end DepGrammar.Discontinuity
+end DependencyGrammar.Discontinuity

--- a/Linglib/Syntax/DependencyGrammar/Formal/Ellipsis.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Ellipsis.lean
@@ -32,10 +32,10 @@ VP ellipsis already removes a non-projection set of words.
   substrate-wide `Bool` convention; statements are `... = true` / `= false`.
 -/
 
-namespace DepGrammar.Ellipsis
+namespace DependencyGrammar.Ellipsis
 
 
-open DepGrammar Catena
+open DependencyGrammar Catena
 
 /-! ### Ellipsis type taxonomy -/
 
@@ -53,7 +53,7 @@ inductive EllipsisType where
 
 /-- DG tree for the pre-ellipsis second clause of "Fred eats beans and Jim
     eats rice": `eats(0)` heads `Jim(1)` (nsubj) and `rice(2)` (obj). -/
-def gappingTree : DepTree :=
+def gappingTree : Tree :=
   { words := [Word.mk' "eats" .VERB, Word.mk' "Jim" .PROPN, Word.mk' "rice" .NOUN]
     deps := [⟨0, 1, .nsubj⟩, ⟨0, 2, .obj⟩]
     rootIdx := 0 }
@@ -71,4 +71,4 @@ theorem gapping_elided_is_catena :
 theorem gapping_elided_not_constituent :
     isConstituent gappingTree.deps 3 gappingElided = false := by decide
 
-end DepGrammar.Ellipsis
+end DependencyGrammar.Ellipsis

--- a/Linglib/Syntax/DependencyGrammar/Formal/EnhancedDependencies.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/EnhancedDependencies.lean
@@ -91,7 +91,7 @@ def controlBasicTree : DepTree :=
     rootIdx := 1 }
 
 def controlEnhancedGraph : DepGraph :=
-  { controlBasicTree.toGraph with
+  { controlBasicTree.toDepGraph with
     deps := controlBasicTree.deps ++ [⟨3, 0, .nsubj⟩] }
 
 /-! ### Relative-clause fixture: "the book that John read" -/
@@ -104,8 +104,21 @@ def relClauseBasicTree : DepTree :=
     rootIdx := 1 }
 
 def relClauseEnhancedGraph : DepGraph :=
-  { relClauseBasicTree.toGraph with
+  { relClauseBasicTree.toDepGraph with
     deps := relClauseBasicTree.deps ++ [⟨4, 1, .obj⟩] }
+
+/-! ### Enhancement is subgraph extension
+
+Enhancement only adds arcs, so each basic tree sits below its enhanced graph
+in the `Digraph` lattice — the order `DepGraph.toDigraph_mono` transports. -/
+
+theorem controlBasic_le_enhanced :
+    controlBasicTree.toDepGraph.toDigraph ≤ controlEnhancedGraph.toDigraph :=
+  DepGraph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
+
+theorem relClauseBasic_le_enhanced :
+    relClauseBasicTree.toDepGraph.toDigraph ≤ relClauseEnhancedGraph.toDigraph :=
+  DepGraph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
 
 /-! ### Basic tree loses information -/
 

--- a/Linglib/Syntax/DependencyGrammar/Formal/EnhancedDependencies.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/EnhancedDependencies.lean
@@ -32,10 +32,10 @@ the coordination enhanced graph; the control and relative-clause graphs
 are stipulated.
 -/
 
-namespace DepGrammar.EnhancedDependencies
+namespace DependencyGrammar.EnhancedDependencies
 
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Enhancement classification -/
 
@@ -50,7 +50,7 @@ inductive EnhancementType where
 /-- A word has an *unrepresented argument* in the basic tree if it appears
 as a dependent in the enhanced graph under some head to which the basic
 tree has no edge. -/
-def hasUnrepresentedArg (basic : DepTree) (enhanced : DepGraph)
+def hasUnrepresentedArg (basic : Tree) (enhanced : Graph)
     (wordIdx : Nat) : Bool :=
   enhanced.deps.any λ d =>
     d.depIdx == wordIdx &&
@@ -72,53 +72,53 @@ def classifyEnhancement (basicDeps : List Dependency)
 
 /-! ### Coordination fixture: "John sees and hears Mary" -/
 
-def coordBasicTree : DepTree :=
+def coordBasicTree : Tree :=
   { words := [Word.mk' "John" .PROPN, Word.mk' "sees" .VERB,
               Word.mk' "and" .CCONJ, Word.mk' "hears" .VERB,
               Word.mk' "Mary" .PROPN]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 2, .cc⟩, ⟨1, 3, .conj⟩, ⟨1, 4, .obj⟩]
     rootIdx := 1 }
 
-def coordEnhancedGraph : DepGraph :=
+def coordEnhancedGraph : Graph :=
   Coordination.enhanceSharedDeps coordBasicTree
 
 /-! ### Control fixture: "Students forgot to come" -/
 
-def controlBasicTree : DepTree :=
+def controlBasicTree : Tree :=
   { words := [Word.mk' "students" .NOUN, Word.mk' "forgot" .VERB,
               Word.mk' "to" .PART, Word.mk' "come" .VERB]
     deps  := [⟨1, 0, .nsubj⟩, ⟨1, 3, .xcomp⟩, ⟨3, 2, .mark⟩]
     rootIdx := 1 }
 
-def controlEnhancedGraph : DepGraph :=
-  { controlBasicTree.toDepGraph with
+def controlEnhancedGraph : Graph :=
+  { controlBasicTree.toGraph with
     deps := controlBasicTree.deps ++ [⟨3, 0, .nsubj⟩] }
 
 /-! ### Relative-clause fixture: "the book that John read" -/
 
-def relClauseBasicTree : DepTree :=
+def relClauseBasicTree : Tree :=
   { words := [Word.mk' "the" .DET, Word.mk' "book" .NOUN,
               Word.mk' "that" .SCONJ, Word.mk' "John" .PROPN,
               Word.mk' "read" .VERB]
     deps  := [⟨1, 0, .det⟩, ⟨1, 4, .acl⟩, ⟨4, 2, .mark⟩, ⟨4, 3, .nsubj⟩]
     rootIdx := 1 }
 
-def relClauseEnhancedGraph : DepGraph :=
-  { relClauseBasicTree.toDepGraph with
+def relClauseEnhancedGraph : Graph :=
+  { relClauseBasicTree.toGraph with
     deps := relClauseBasicTree.deps ++ [⟨4, 1, .obj⟩] }
 
 /-! ### Enhancement is subgraph extension
 
 Enhancement only adds arcs, so each basic tree sits below its enhanced graph
-in the `Digraph` lattice — the order `DepGraph.toDigraph_mono` transports. -/
+in the `Digraph` lattice — the order `Graph.toDigraph_mono` transports. -/
 
 theorem controlBasic_le_enhanced :
-    controlBasicTree.toDepGraph.toDigraph ≤ controlEnhancedGraph.toDigraph :=
-  DepGraph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
+    controlBasicTree.toGraph.toDigraph ≤ controlEnhancedGraph.toDigraph :=
+  Graph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
 
 theorem relClauseBasic_le_enhanced :
-    relClauseBasicTree.toDepGraph.toDigraph ≤ relClauseEnhancedGraph.toDigraph :=
-  DepGraph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
+    relClauseBasicTree.toGraph.toDigraph ≤ relClauseEnhancedGraph.toDigraph :=
+  Graph.toDigraph_mono λ _ hd => List.mem_append_left _ hd
 
 /-! ### Basic tree loses information -/
 
@@ -178,4 +178,4 @@ theorem control_enhancement_classified :
     classifyEnhancement controlBasicTree.deps ⟨3, 0, .nsubj⟩ = some .controlSubject := by
   decide
 
-end DepGrammar.EnhancedDependencies
+end DependencyGrammar.EnhancedDependencies

--- a/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Government.lean
@@ -21,7 +21,7 @@ share an `xcomp` slot but require different forms (`infinitive` vs.
 * `GovRequirement` — one head-cat / dep-rel / feature / required-value
   4-tuple, with five English instances from [osborne-2019].
 * `checkGovernment` — Bool checker that verifies every dependency in a
-  `DepTree` honours every requirement that applies to it.
+  `Tree` honours every requirement that applies to it.
 * `withHim_govOk` / `withHe_govFail` etc. — small fixtures exercising
   the checker on accusative-vs-nominative preposition complements and
   infinitive-vs-gerund verb complements.
@@ -38,10 +38,10 @@ share an `xcomp` slot but require different forms (`infinitive` vs.
   paper-anchored Studies file, not the substrate.
 -/
 
-namespace DepGrammar.Government
+namespace DependencyGrammar.Government
 
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Government dimensions and values -/
 
@@ -131,7 +131,7 @@ def matchGovFeature (w : Word) (feat : GovernedFeature) (reqVal : GovernedValue)
 
 /-- A dependency tree satisfies its government requirements when every
     matching head-cat / dep-rel pair carries the required value. -/
-def checkGovernment (t : DepTree) (govReqs : List GovRequirement) : Bool :=
+def checkGovernment (t : Tree) (govReqs : List GovRequirement) : Bool :=
   t.deps.all λ d =>
     govReqs.all λ req =>
       if d.depType = req.depRel then
@@ -147,7 +147,7 @@ def checkGovernment (t : DepTree) (govReqs : List GovRequirement) : Bool :=
 
 /-- "She wants to go": `wants(1)` heads `she(0)` (nsubj) and `go(3)`
     (xcomp); `go(3)` heads `to(2)` (mark). -/
-def exSheWantsToGo : DepTree :=
+def exSheWantsToGo : Tree :=
   { words := [ { form :="she", cat := .PRON, features := { case_ := some .Nom }}
              , { form :="wants", cat := .VERB}
              , { form :="to", cat := .PART, features := {}}
@@ -157,7 +157,7 @@ def exSheWantsToGo : DepTree :=
 
 /-- "She enjoys swimming": `enjoys(1)` heads `she(0)` (nsubj) and
     `swimming(2)` (xcomp). -/
-def exSheEnjoysSwimming : DepTree :=
+def exSheEnjoysSwimming : Tree :=
   { words := [ { form :="she", cat := .PRON, features := { case_ := some .Nom }}
              , { form :="enjoys", cat := .VERB}
              , { form :="swimming", cat := .VERB, features := { verbForm := some .Part }} ]
@@ -165,14 +165,14 @@ def exSheEnjoysSwimming : DepTree :=
     rootIdx := 1 }
 
 /-- "with him": preposition governs accusative — well-formed. -/
-def exWithHim : DepTree :=
+def exWithHim : Tree :=
   { words := [ { form :="with", cat := .ADP, features := {}}
              , { form :="him", cat := .PRON, features := { case_ := some .Acc }} ]
     deps := [⟨0, 1, .obj⟩]
     rootIdx := 0 }
 
 /-- "with he": preposition government violation (nominative for accusative). -/
-def exWithHe : DepTree :=
+def exWithHe : Tree :=
   { words := [ { form :="with", cat := .ADP, features := {}}
              , { form :="he", cat := .PRON, features := { case_ := some .Nom }} ]
     deps := [⟨0, 1, .obj⟩]
@@ -182,7 +182,7 @@ def exWithHe : DepTree :=
     *marked* case other than the required accusative (here dative) violates
     government. The earlier checker fell through to `true` for any case outside
     {nom, acc, gen}, so a dative object spuriously satisfied `govPrepAcc`. -/
-def exPrepDatObj : DepTree :=
+def exPrepDatObj : Tree :=
   { words := [ { form :="with", cat := .ADP, features := {}}
              , { form :="X", cat := .PRON, features := { case_ := some .Dat }} ]
     deps := [⟨0, 1, .obj⟩]
@@ -205,4 +205,4 @@ theorem wantsToGo_govOk :
 theorem enjoysSwimming_govOk :
     checkGovernment exSheEnjoysSwimming [govVerbGerund] = true := by decide
 
-end DepGrammar.Government
+end DependencyGrammar.Government

--- a/Linglib/Syntax/DependencyGrammar/Formal/HarmonicOrder.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/HarmonicOrder.lean
@@ -39,10 +39,10 @@ intervene.
   via `foldl max`/`foldl min` rather than mathlib's `List.maximum?`.
 -/
 
-namespace DepGrammar.HarmonicOrder
+namespace DependencyGrammar.HarmonicOrder
 
 
-open DepGrammar DependencyLength
+open DependencyGrammar DependencyLength
 
 /-! ### Chain total dependency length
 
@@ -230,12 +230,12 @@ between head `h` and dependent `d` is bounded below by `1` plus the number
 of `d`'s subtree members that fall between `h` and `d` in linear order. -/
 
 /-- All transitive descendants of `idx`, excluding `idx` itself. -/
-def subtreeMembers (t : DepTree) (idx : Nat) : List Nat :=
+def subtreeMembers (t : Tree) (idx : Nat) : List Nat :=
   (projection t.deps idx).filter (· != idx)
 
 /-- Number of nodes from `subtreeMembers t depPos` that fall strictly between
 `headPos` and `depPos` in linear order. -/
-def interveningSubtreeNodes (t : DepTree) (headPos depPos : Nat) : Nat :=
+def interveningSubtreeNodes (t : Tree) (headPos depPos : Nat) : Nat :=
   let lo := min headPos depPos
   let hi := max headPos depPos
   let members := subtreeMembers t depPos
@@ -245,7 +245,7 @@ def interveningSubtreeNodes (t : DepTree) (headPos depPos : Nat) : Nat :=
 nodes of the dependent. Strict equality holds when `d`'s subtree is the sole
 occupant of `(h, d)` — the harmonic-order scenario in `### Harmonic vs
 disharmonic trees`. -/
-theorem dep_length_ge_one_plus_intervening (t : DepTree) (d : Dependency)
+theorem dep_length_ge_one_plus_intervening (t : Tree) (d : Dependency)
     (hd : d ∈ t.deps)
     (hne : d.headIdx ≠ d.depIdx) :
     depLength d ≥ 1 + interveningSubtreeNodes t d.headIdx d.depIdx := by
@@ -275,7 +275,7 @@ direction. This is the formal basis for [gibson-2025]'s exception for
 single-word adjectives, demonstratives, intensifiers, and negation markers. -/
 
 /-- A node is a leaf if it has no dependents. -/
-def isLeaf (t : DepTree) (idx : Nat) : Bool :=
+def isLeaf (t : Tree) (idx : Nat) : Bool :=
   t.deps.all (·.headIdx != idx)
 
 private theorem projection_of_leaf (deps : List Dependency) (root : Nat)
@@ -293,7 +293,7 @@ private theorem projection_of_leaf (deps : List Dependency) (root : Nat)
     exact ih h.2
 
 /-- A leaf has no subtree members. -/
-theorem leaf_no_subtree_members (t : DepTree) (idx : Nat)
+theorem leaf_no_subtree_members (t : Tree) (idx : Nat)
     (h : isLeaf t idx = true) :
     subtreeMembers t idx = [] := by
   unfold subtreeMembers
@@ -301,7 +301,7 @@ theorem leaf_no_subtree_members (t : DepTree) (idx : Nat)
   simp [List.filter, bne]
 
 /-- A leaf contributes zero intervening nodes for any head position. -/
-theorem leaf_no_intervening (t : DepTree) (headPos depPos : Nat)
+theorem leaf_no_intervening (t : Tree) (headPos depPos : Nat)
     (h : isLeaf t depPos = true) :
     interveningSubtreeNodes t headPos depPos = 0 := by
   unfold interveningSubtreeNodes
@@ -321,7 +321,7 @@ complement, embedded three levels deep. Head-initial (`HI`) and head-final
 (`HF`) consistent orders share the same TDL; mixed orders inflate it. -/
 
 /-- Consistent head-initial (HI) tree: V₁ S₁ V₂ S₂ V₃ O₃. -/
-def harmonicHI : DepTree :=
+def harmonicHI : Tree :=
   { words := [ Word.mk' "thinks" .VERB, Word.mk' "John" .PROPN
              , Word.mk' "knows" .VERB, Word.mk' "Mary" .PROPN
              , Word.mk' "likes" .VERB, Word.mk' "cats" .NOUN ]
@@ -334,7 +334,7 @@ def harmonicHI : DepTree :=
     rootIdx := 0 }
 
 /-- Consistent head-final (HF) tree: O₃ V₃ S₂ V₂ S₁ V₁ — mirror of `harmonicHI`. -/
-def harmonicHF : DepTree :=
+def harmonicHF : Tree :=
   { words := [ Word.mk' "cats" .NOUN, Word.mk' "likes" .VERB
              , Word.mk' "Mary" .PROPN, Word.mk' "knows" .VERB
              , Word.mk' "John" .PROPN, Word.mk' "thinks" .VERB ]
@@ -347,7 +347,7 @@ def harmonicHF : DepTree :=
     rootIdx := 5 }
 
 /-- Disharmonic HF tree: head-initial main clause, head-final embedding. -/
-def disharmonicHF : DepTree :=
+def disharmonicHF : Tree :=
   { words := [ Word.mk' "thinks" .VERB, Word.mk' "John" .PROPN
              , Word.mk' "Mary" .PROPN, Word.mk' "cats" .NOUN
              , Word.mk' "likes" .VERB, Word.mk' "knows" .VERB ]
@@ -360,7 +360,7 @@ def disharmonicHF : DepTree :=
     rootIdx := 0 }
 
 /-- Disharmonic FH tree: head-final main clause, head-initial embedding. -/
-def disharmonicFH : DepTree :=
+def disharmonicFH : Tree :=
   { words := [ Word.mk' "John" .PROPN, Word.mk' "knows" .VERB
              , Word.mk' "Mary" .PROPN, Word.mk' "likes" .VERB
              , Word.mk' "cats" .NOUN, Word.mk' "thinks" .VERB ]
@@ -386,4 +386,4 @@ def dlmPredictsHarmonicCheaper : Bool :=
   totalDepLength harmonicHI < totalDepLength disharmonicHF &&
   totalDepLength harmonicHF < totalDepLength disharmonicFH
 
-end DepGrammar.HarmonicOrder
+end DependencyGrammar.HarmonicOrder

--- a/Linglib/Syntax/DependencyGrammar/Formal/HeadCriteria.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/HeadCriteria.lean
@@ -28,9 +28,9 @@ been dropped. A future revision should derive each criterion structurally
 from `Dependency` and the surrounding tree.
 -/
 
-namespace DepGrammar.HeadCriteria
+namespace DependencyGrammar.HeadCriteria
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Classification of UD relations -/
 
@@ -79,4 +79,4 @@ theorem coreArgument_mostCriteria :
     expectedCriteriaCount .coreArgument > expectedCriteriaCount .functionWord := by
   decide
 
-end DepGrammar.HeadCriteria
+end DependencyGrammar.HeadCriteria

--- a/Linglib/Syntax/DependencyGrammar/Formal/Islands.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/Islands.lean
@@ -34,10 +34,10 @@ extraction that produces a risen catena with non-contiguous yield.
   `OsborneIslandType` becomes a refinement mapping onto it.
 -/
 
-namespace DepGrammar.Islands
+namespace DependencyGrammar.Islands
 
 
-open DepGrammar Catena Discontinuity
+open DependencyGrammar Catena Discontinuity
 
 /-! ### Extended island taxonomy -/
 
@@ -68,7 +68,7 @@ Each tree models a sentence where extraction from an island creates a risen
 catena whose rising catena violates the corresponding island constraint. -/
 
 /-- DG tree for the left-branch island *"Whose do you like house?". -/
-def islandLeftBranch : DepTree :=
+def islandLeftBranch : Tree :=
   { words := [ { form :="whose", cat := .DET, features := { pronType := some .Int }}, Word.mk' "do" .AUX
              , Word.mk' "you" .PRON, Word.mk' "like" .VERB
              , Word.mk' "house" .NOUN ]
@@ -78,7 +78,7 @@ def islandLeftBranch : DepTree :=
 
 /-- DG tree for the subject island *"Which car did the driver of ignore the light?"
 ([osborne-2019], §9.7, ex. 48). -/
-def islandSubject : DepTree :=
+def islandSubject : Tree :=
   { words := [ { form :="which", cat := .DET, features := { pronType := some .Int }}, Word.mk' "car" .NOUN
              , Word.mk' "did" .AUX, Word.mk' "the" .DET
              , Word.mk' "driver" .NOUN, Word.mk' "of" .ADP
@@ -92,7 +92,7 @@ def islandSubject : DepTree :=
 
 /-- DG tree for the adjunct island *"What do they argue before cleaning?"
 ([osborne-2019], §9.8, ex. 50b/59, simplified). -/
-def islandAdjunct : DepTree :=
+def islandAdjunct : Tree :=
   { words := [ { form :="what", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "do" .AUX
              , Word.mk' "they" .PRON, Word.mk' "argue" .VERB
              , Word.mk' "before" .SCONJ, Word.mk' "cleaning" .VERB ]
@@ -102,7 +102,7 @@ def islandAdjunct : DepTree :=
 
 /-- DG tree for the wh-island *"Which judge might they inquire surprised?"
 ([osborne-2019], §9.9, ex. 61b', simplified). -/
-def islandWhIsland : DepTree :=
+def islandWhIsland : Tree :=
   { words := [ { form :="which", cat := .DET, features := { pronType := some .Int }}, Word.mk' "judge" .NOUN
              , Word.mk' "might" .AUX, Word.mk' "they" .PRON
              , Word.mk' "inquire" .VERB, Word.mk' "surprised" .VERB ]
@@ -113,7 +113,7 @@ def islandWhIsland : DepTree :=
 
 /-- DG tree for the specified-NP island ??"Who did you find those pictures of?"
 ([osborne-2019], §9.6, ex. 36b). -/
-def islandSpecifiedNP : DepTree :=
+def islandSpecifiedNP : Tree :=
   { words := [ { form :="who", cat := .PRON, features := { pronType := some .Int }}, Word.mk' "did" .AUX
              , Word.mk' "you" .PRON, Word.mk' "find" .VERB
              , Word.mk' "those" .DET, Word.mk' "pictures" .NOUN
@@ -164,4 +164,4 @@ theorem whIsland_extraction_risen :
 theorem specifiedNP_extraction_risen :
     isRisenCatena islandSpecifiedNP [0, 6] = true := by decide
 
-end DepGrammar.Islands
+end DependencyGrammar.Islands

--- a/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
@@ -286,38 +286,12 @@ private theorem projective_interval {t : DepTree} (hproj : isProjective t = true
 /-- Under `hasUniqueHeads`, all incoming edges of an in-range non-root node
     share the same head. -/
 private theorem unique_parent_of_hasUniqueHeads {t : DepTree}
-    (hwf : t.WF) {c : Nat} (hc : c < t.words.length)
+    (hwf : t.WF) {c : Nat} (_ : c < t.words.length)
     {e₁ e₂ : Dependency} (he₁ : e₁ ∈ t.deps) (he₂ : e₂ ∈ t.deps)
     (hd₁ : e₁.depIdx = c) (hd₂ : e₂.depIdx = c) :
     e₁.headIdx = e₂.headIdx := by
-  have hf₁ : e₁ ∈ t.deps.filter (·.depIdx == c) :=
-    List.mem_filter.mpr ⟨he₁, beq_iff_eq.mpr hd₁⟩
-  have hf₂ : e₂ ∈ t.deps.filter (·.depIdx == c) :=
-    List.mem_filter.mpr ⟨he₂, beq_iff_eq.mpr hd₂⟩
-  have hspec : (if c = t.rootIdx then
-      (t.deps.filter (·.depIdx == c)).length == 0
-    else (t.deps.filter (·.depIdx == c)).length == 1) = true := by
-    have hwf' := hwf.uniqueHeads
-    unfold hasUniqueHeads at hwf'
-    have hmem : (c, (t.deps.filter (·.depIdx == c)).length) ∈
-        (List.range ((List.range t.words.length |>.map fun i =>
-          (t.deps.filter (·.depIdx == i)).length).length)).zip
-          (List.range t.words.length |>.map fun i =>
-            (t.deps.filter (·.depIdx == i)).length) := by
-      rw [List.mem_iff_getElem]
-      simp only [List.length_zip, List.length_range, List.length_map]
-      exact ⟨c, by omega, by simp [List.getElem_zip, List.getElem_range, List.getElem_map]⟩
-    have h := (List.all_eq_true.mp hwf') _ hmem
-    simp only [beq_iff_eq] at h
-    exact h
-  have hroot : c ≠ t.rootIdx := by
-    intro heq
-    rw [if_pos heq, beq_iff_eq] at hspec
-    exact absurd hspec (by have := List.length_pos_of_mem hf₁; omega)
-  rw [if_neg hroot, beq_iff_eq] at hspec
-  obtain ⟨x, hx⟩ := List.length_eq_one_iff.mp hspec
-  rw [hx] at hf₁ hf₂
-  rw [List.eq_of_mem_singleton hf₁, List.eq_of_mem_singleton hf₂]
+  rw [← parentOf_of_edge_uh t hwf ⟨e₁, he₁, rfl, hd₁⟩,
+      ← parentOf_of_edge_uh t hwf ⟨e₂, he₂, rfl, hd₂⟩]
 
 /-- **Projective ⊂ planar** for well-formed trees.
     ([kuhlmann-nivre-2006], §3.5) -/

--- a/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
@@ -19,7 +19,7 @@ language data.
 
 * `depsCross`, `linked`, `disjoint`, `projectionsInterleave` — arc-crossing
   primitives.
-* `DepTree.isPlanar`, `DepTree.isWellNested` — the two restrictiveness
+* `Tree.isPlanar`, `Tree.isWellNested` — the two restrictiveness
   classes between projective and unrestricted.
 * `projective_iff_gapDegree_zero`, `projective_iff_blockDegree_one`,
   `blockDegree_eq_gapDegree_succ` — equivalences in the hierarchy.
@@ -46,7 +46,7 @@ language data.
   `LongDistance.lean` Todo articulates this), not as a thin subtype here.
 -/
 
-namespace DepGrammar
+namespace DependencyGrammar
 
 
 /-! ### Arc-crossing detection -/
@@ -64,11 +64,11 @@ def depsCross (d1 d2 : Dependency) : Bool :=
       (min2 <= min1 && max1 <= max2))
 
 /-- All non-projective (crossing) dependencies in a tree. -/
-def nonProjectiveDeps (t : DepTree) : List Dependency :=
+def nonProjectiveDeps (t : Tree) : List Dependency :=
   t.deps.filter λ d1 => t.deps.any λ d2 => depsCross d1 d2
 
 /-- Whether a tree has any non-projective dependencies. -/
-def hasFillerGap (t : DepTree) : Bool :=
+def hasFillerGap (t : Tree) : Bool :=
   (nonProjectiveDeps t).length > 0
 
 /-! ### Planarity ([kuhlmann-nivre-2006], Definition 4) -/
@@ -81,7 +81,7 @@ def linked (deps : List Dependency) (a b : Nat) : Bool :=
 /-- A dependency tree is **planar** iff its edges can be drawn above the
     sentence without crossing: no nodes `a < b < c < d` with `linked a c`
     and `linked b d`. ([kuhlmann-nivre-2006], Definition 4) -/
-def DepTree.isPlanar (t : DepTree) : Bool :=
+def Tree.isPlanar (t : Tree) : Bool :=
   let deps := t.deps
   let n := t.words.length
   !(List.range n |>.any λ a =>
@@ -111,7 +111,7 @@ private theorem disjoint_symm {deps : List Dependency} {u v : Nat}
 
 /-- A dependency tree is **well-nested** if no two disjoint nodes have
     interleaving projections. ([kuhlmann-nivre-2006], Definition 8) -/
-def DepTree.isWellNested (t : DepTree) : Bool :=
+def Tree.isWellNested (t : Tree) : Bool :=
   let deps := t.deps
   let n := t.words.length
   !(List.range n |>.any λ u =>
@@ -126,14 +126,14 @@ the canonical pair witnessing that mild non-projectivity (well-nested,
 gap degree 1) covers attested data. -/
 
 /-- Minimal crossing tree: arcs `0 → 2` and `1 → 3` cross. -/
-def nonProjectiveTree : DepTree :=
+def nonProjectiveTree : Tree :=
   { words := [ { form :="A", cat := .NOUN, features := {}}, { form :="B", cat := .VERB, features := {}}, { form :="C", cat := .NOUN, features := {}}, { form :="D", cat := .VERB, features := {}} ]
     deps := [ ⟨0, 2, .obj⟩, ⟨1, 3, .obj⟩ ]
     rootIdx := 0 }
 
 /-- Dutch cross-serial: "dat Jan Piet Marie zag helpen lezen".
     Dependencies `zag→Jan`, `helpen→Piet`, `lezen→Marie` cross. -/
-def dutchCrossSerial : DepTree :=
+def dutchCrossSerial : Tree :=
   { words := [ Word.mk' "dat" .SCONJ, Word.mk' "Jan" .PROPN
              , Word.mk' "Piet" .PROPN, Word.mk' "Marie" .PROPN
              , Word.mk' "zag" .VERB, Word.mk' "helpen" .VERB
@@ -144,7 +144,7 @@ def dutchCrossSerial : DepTree :=
 
 /-- German nested: "dass Jan Piet Marie lesen helfen sah". Same dependencies
     as `dutchCrossSerial` but verbs in reverse order → projective. -/
-def germanNested : DepTree :=
+def germanNested : Tree :=
   { words := [ Word.mk' "dass" .SCONJ, Word.mk' "Jan" .PROPN
              , Word.mk' "Piet" .PROPN, Word.mk' "Marie" .PROPN
              , Word.mk' "lesen" .VERB, Word.mk' "helfen" .VERB
@@ -160,30 +160,30 @@ example : hasFillerGap nonProjectiveTree = true := by decide
 example : isProjective dutchCrossSerial = false := by decide
 example : isProjective germanNested = true := by decide
 
-example : DepTree.gapDegree germanNested = 0 := by decide
-example : DepTree.blockDegree germanNested = 1 := by decide
-example : DepTree.gapDegree dutchCrossSerial = 1 := by decide
-example : DepTree.blockDegree dutchCrossSerial = 2 := by decide
-example : DepTree.gapDegree nonProjectiveTree = 1 := by decide
-example : DepTree.blockDegree nonProjectiveTree = 2 := by decide
+example : Tree.gapDegree germanNested = 0 := by decide
+example : Tree.blockDegree germanNested = 1 := by decide
+example : Tree.gapDegree dutchCrossSerial = 1 := by decide
+example : Tree.blockDegree dutchCrossSerial = 2 := by decide
+example : Tree.gapDegree nonProjectiveTree = 1 := by decide
+example : Tree.blockDegree nonProjectiveTree = 2 := by decide
 
-example : DepTree.isPlanar germanNested = true := by decide
-example : DepTree.isPlanar dutchCrossSerial = false := by decide
-example : DepTree.isPlanar nonProjectiveTree = false := by decide
+example : Tree.isPlanar germanNested = true := by decide
+example : Tree.isPlanar dutchCrossSerial = false := by decide
+example : Tree.isPlanar nonProjectiveTree = false := by decide
 
-example : DepTree.isWellNested germanNested = true := by decide
+example : Tree.isWellNested germanNested = true := by decide
 /-- Dutch cross-serial: well-nested despite being non-projective. -/
-example : DepTree.isWellNested dutchCrossSerial = true := by decide
-example : DepTree.isWellNested nonProjectiveTree = false := by decide
+example : Tree.isWellNested dutchCrossSerial = true := by decide
+example : Tree.isWellNested nonProjectiveTree = false := by decide
 
 /-! ### Hierarchy theorems -/
 
 /-- **Projective ⟺ gap degree 0**: a tree is projective iff no node's
     projection has any gaps.
     ([kuhlmann-nivre-2006], Definition 3 + Definition 7) -/
-theorem projective_iff_gapDegree_zero (t : DepTree) :
+theorem projective_iff_gapDegree_zero (t : Tree) :
     isProjective t = true ↔ t.gapDegree = 0 := by
-  unfold isProjective DepTree.gapDegree
+  unfold isProjective Tree.gapDegree
   constructor
   · intro hall
     rw [foldl_max_zero_iff]
@@ -207,11 +207,11 @@ theorem projective_iff_gapDegree_zero (t : DepTree) :
     exact List.eq_nil_of_length_eq_zero this
 
 /-- **Projective ⟺ block-degree 1** for non-empty trees. -/
-theorem projective_iff_blockDegree_one (t : DepTree)
+theorem projective_iff_blockDegree_one (t : Tree)
     (hne_tree : t.words.length > 0) :
     isProjective t = true ↔ t.blockDegree = 1 := by
   rw [projective_iff_gapDegree_zero]
-  unfold DepTree.gapDegree DepTree.blockDegree
+  unfold Tree.gapDegree Tree.blockDegree
   constructor
   · intro hgap
     have hall_gap : ∀ x ∈ (List.range t.words.length).map (gapDegreeAt t.deps), x = 0 :=
@@ -277,7 +277,7 @@ private theorem linked_exists {deps : List Dependency} {a c : Nat}
   · exact ⟨e, he_mem, Or.inr ⟨h1, h2⟩⟩
 
 /-- From `isProjective = true`, every in-range projection is an interval. -/
-private theorem projective_interval {t : DepTree} (hproj : isProjective t = true)
+private theorem projective_interval {t : Tree} (hproj : isProjective t = true)
     (i : Nat) (hi : i < t.words.length) :
     isInterval (projection t.deps i) = true := by
   simp only [isProjective, List.all_eq_true, List.mem_range, decide_eq_true_eq] at hproj
@@ -285,7 +285,7 @@ private theorem projective_interval {t : DepTree} (hproj : isProjective t = true
 
 /-- Under `hasUniqueHeads`, all incoming edges of an in-range non-root node
     share the same head. -/
-private theorem unique_parent_of_hasUniqueHeads {t : DepTree}
+private theorem unique_parent_of_hasUniqueHeads {t : Tree}
     (hwf : t.WF) {c : Nat} (_ : c < t.words.length)
     {e₁ e₂ : Dependency} (he₁ : e₁ ∈ t.deps) (he₂ : e₂ ∈ t.deps)
     (hd₁ : e₁.depIdx = c) (hd₂ : e₂.depIdx = c) :
@@ -295,11 +295,11 @@ private theorem unique_parent_of_hasUniqueHeads {t : DepTree}
 
 /-- **Projective ⊂ planar** for well-formed trees.
     ([kuhlmann-nivre-2006], §3.5) -/
-theorem projective_implies_planar (t : DepTree)
+theorem projective_implies_planar (t : Tree)
     (hwf : t.WF) (hacyc : isAcyclic t = true)
     (hproj : isProjective t = true) : t.isPlanar = true := by
   by_contra h_np
-  simp only [DepTree.isPlanar] at h_np
+  simp only [Tree.isPlanar] at h_np
   simp at h_np
   obtain ⟨a, ha_lt, b, hb_lt, c, hc_lt, d, hd_lt,
           hab, hbc, hcd, hlink_ac, hlink_bd⟩ := h_np
@@ -377,7 +377,7 @@ exit/entry steps — feeds the core `interleaving_not_planar` lemma. -/
 
 /-- Under unique heads, any two ancestors of the same node are comparable
     under dominance. -/
-private theorem dominates_comparable (t : DepTree)
+private theorem dominates_comparable (t : Tree)
     (hwf : t.WF)
     {u v x : Nat} (hux : Dominates t.deps u x) (hvx : Dominates t.deps v x) :
     Dominates t.deps u v ∨ Dominates t.deps v u := by
@@ -397,7 +397,7 @@ private theorem dominates_comparable (t : DepTree)
     · exact Or.inr (Dominates.step hedge hwu)
 
 /-- Disjoint nodes have disjoint projections. -/
-private theorem projection_disjoint_of_disjoint (t : DepTree)
+private theorem projection_disjoint_of_disjoint (t : Tree)
     (hwf : t.WF)
     {u v : Nat} (hdisj : disjoint t.deps u v = true)
     {x : Nat} (hxu : x ∈ projection t.deps u) (hxv : x ∈ projection t.deps v) :
@@ -478,7 +478,7 @@ private theorem exists_spanning_edge {deps : List Dependency}
     exact exists_spanning_edge_up (dominates_of_mem_projection hb) hu' hb_ge
 
 /-- Crossing edges witness non-planarity. -/
-private theorem crossing_edges_not_planar (t : DepTree)
+private theorem crossing_edges_not_planar (t : Tree)
     (h_head_wf : ∀ d ∈ t.deps, d.headIdx < t.words.length)
     (h_dep_wf : ∀ d ∈ t.deps, d.depIdx < t.words.length)
     {a b c d : Nat} (hab : a < b) (hbc : b < c) (hcd : c < d)
@@ -500,7 +500,7 @@ private theorem crossing_edges_not_planar (t : DepTree)
   | false => rfl
   | true =>
     exfalso
-    simp only [DepTree.isPlanar, Bool.not_eq_true'] at hp
+    simp only [Tree.isPlanar, Bool.not_eq_true'] at hp
     have hwitness : (List.range t.words.length |>.any λ a' =>
       List.range t.words.length |>.any λ b' =>
         List.range t.words.length |>.any λ c' =>
@@ -561,7 +561,7 @@ private theorem linked_symm_val {deps : List Dependency} {a b : Nat}
   exact ⟨d, hd_mem, hd.symm⟩
 
 /-- Every element of the `iterParent` chain from `w` to `u` belongs to `π(u)`. -/
-private theorem iterParent_chain_mem_projection (t : DepTree)
+private theorem iterParent_chain_mem_projection (t : Tree)
     {u w : Nat} {k : Nat} (hiter : iterParent_uh t w k = u)
     (hchain : ∀ i, i < k → ∃ dep,
       t.deps.find? (fun d => d.depIdx == iterParent_uh t w i) = some dep ∧
@@ -588,7 +588,7 @@ private theorem iterParent_chain_mem_projection (t : DepTree)
       hprev ⟨dep, hdep_mem, h_shift ▸ hdep_head, hdep_dep⟩
 
 /-- Consecutive elements of the `iterParent` chain are linked. -/
-private theorem iterParent_chain_linked {t : DepTree}
+private theorem iterParent_chain_linked {t : Tree}
     {w : Nat} {k : Nat}
     (hchain : ∀ i, i < k → ∃ dep,
       t.deps.find? (fun d => d.depIdx == iterParent_uh t w i) = some dep ∧
@@ -606,7 +606,7 @@ private theorem iterParent_chain_linked {t : DepTree}
 
 /-- Walking out of an interval `(lo, hi)` along a parent chain forces a
     boundary-crossing edge, which crosses the disjoint `linked lo hi`. -/
-private theorem escape_gives_crossing (t : DepTree)
+private theorem escape_gives_crossing (t : Tree)
     (hwf : t.WF)
     {u v : Nat} (hdisj : disjoint t.deps u v = true)
     {lo hi : Nat} (hlo_hi : lo < hi)
@@ -678,7 +678,7 @@ private theorem escape_gives_crossing (t : DepTree)
       hj_in.1 hj_in.2 hj1_out' (iterParent_chain_linked hchain_k j hj_lt)
 
 /-- Interleaving projections of disjoint subtrees witness non-planarity. -/
-private theorem interleaving_not_planar (t : DepTree)
+private theorem interleaving_not_planar (t : Tree)
     (hwf : t.WF)
     {u v : Nat} (hdisj : disjoint t.deps u v = true)
     {l₁ l₂ r₁ r₂ : Nat}
@@ -741,13 +741,13 @@ private theorem interleaving_not_planar (t : DepTree)
 
 /-- **Planar ⊂ well-nested** for well-formed trees.
     ([kuhlmann-nivre-2006], Theorem 1) -/
-theorem planar_implies_wellNested (t : DepTree)
+theorem planar_implies_wellNested (t : Tree)
     (hwf : t.WF)
     (hplanar : t.isPlanar = true) : t.isWellNested = true := by
   by_contra h_nwn
   have h_false : t.isWellNested = false := by
     cases h : t.isWellNested with | true => exact absurd h h_nwn | false => rfl
-  simp only [DepTree.isWellNested, Bool.not_eq_true'] at h_false
+  simp only [Tree.isWellNested, Bool.not_eq_true'] at h_false
   have h_any : (List.range t.words.length |>.any fun u =>
     List.range t.words.length |>.any fun v =>
       u != v && disjoint t.deps u v &&
@@ -780,11 +780,11 @@ theorem planar_implies_wellNested (t : DepTree)
 
 /-- Non-projective ⇒ gap degree ≥ 1. Contrapositive of
     `projective_iff_gapDegree_zero`. -/
-theorem nonProjective_implies_gapDeg_ge1 (t : DepTree)
+theorem nonProjective_implies_gapDeg_ge1 (t : Tree)
     (h : isProjective t = false) : t.gapDegree ≥ 1 := by
   by_contra hlt
   have hzero : t.gapDegree = 0 := by omega
   have := (projective_iff_gapDegree_zero t).mpr hzero
   simp [this] at h
 
-end DepGrammar
+end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Formal/VPDivergence.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/VPDivergence.lean
@@ -87,7 +87,7 @@ forms a singleton catena that fails to be a constituent. -/
     catena but `projection deps v ≠ [v]` (the projection contains `w`). -/
 theorem exists_catena_not_constituent
     (deps : List Dependency) (v w : Nat) (hvw : v ≠ w)
-    (hedge : parentEdge deps v w) :
+    (hedge : ParentEdge deps v w) :
     isCatena deps [v] = true ∧ ¬ projection deps v = [v] := by
   refine ⟨singleton_isCatena deps v, ?_⟩
   intro heq

--- a/Linglib/Syntax/DependencyGrammar/Formal/VPDivergence.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/VPDivergence.lean
@@ -39,23 +39,23 @@ files; this module formalizes only the structural DG-side claim.
   rather than a hand-rolled `inductive PSTree`.
 -/
 
-namespace DepGrammar.VPDivergence
+namespace DependencyGrammar.VPDivergence
 
 
-open DepGrammar DepGrammar.Catena
+open DependencyGrammar DependencyGrammar.Catena
 
 /-! ### Example trees from [osborne-2019] -/
 
 /-- DG tree for "Bill plays chess" (Ch. 2, ex. 24):
     `plays(0)` heads `Bill(1)` (nsubj) and `chess(2)` (obj). -/
-def billPlaysChess : DepTree :=
+def billPlaysChess : Tree :=
   { words := [Word.mk' "plays" .VERB, Word.mk' "Bill" .PROPN, Word.mk' "chess" .NOUN]
     deps := [⟨0, 1, .nsubj⟩, ⟨0, 2, .obj⟩]
     rootIdx := 0 }
 
 /-- DG tree for "She reads everything" (Ch. 2, ex. 12): same shape as
     "Bill plays chess", confirming the divergence is structural. -/
-def sheReadsEverything : DepTree :=
+def sheReadsEverything : Tree :=
   { words := [Word.mk' "reads" .VERB, Word.mk' "She" .PRON, Word.mk' "everything" .PRON]
     deps := [⟨0, 1, .nsubj⟩, ⟨0, 2, .obj⟩]
     rootIdx := 0 }
@@ -96,4 +96,4 @@ theorem exists_catena_not_constituent
   simp at hw
   exact hvw hw.symm
 
-end DepGrammar.VPDivergence
+end DependencyGrammar.VPDivergence

--- a/Linglib/Syntax/DependencyGrammar/LongDistance.lean
+++ b/Linglib/Syntax/DependencyGrammar/LongDistance.lean
@@ -14,8 +14,8 @@ from the gap-host word to the filler.
 * `GapType` — the four core UD argument positions a missing element may fill
   (subject, object, indirect object, oblique).
 * `gapToDepRel` — the UD `DepRel` corresponding to a `GapType`.
-* `fillGap` — enhanced-edge construction: produce a `DepGraph` from a basic
-  `DepTree` by appending an edge that records gap-filling.
+* `fillGap` — enhanced-edge construction: produce a `Graph` from a basic
+  `Tree` by appending an edge that records gap-filling.
 * `extractionLabel` — recover the gap-type label at a node by diffing the basic
   tree against the enhanced graph.
 * `checkNoIslandViolation` — coarse modifier/conjunct heuristic over a list of
@@ -25,7 +25,7 @@ from the gap-host word to the filler.
 
 ## Implementation notes
 
-* The `Bool`-valued predicates follow `DepGrammar.isWellFormed`'s substrate
+* The `Bool`-valued predicates follow `DependencyGrammar.isWellFormed`'s substrate
   convention; converting them to `Prop` + `Decidable` is a substrate-wide
   refactor not done here.
 * `hasGapInModifierOrConjunct` is deliberately coarse: it flags any gap whose
@@ -45,9 +45,9 @@ from the gap-host word to the filler.
   labels all specialise a shared interface.
 -/
 
-namespace DepGrammar.LongDistance
+namespace DependencyGrammar.LongDistance
 
-open DepGrammar
+open DependencyGrammar
 
 /-! ### Gap types and the UD relation map -/
 
@@ -71,8 +71,8 @@ inductive GapType where
 
 /-- Add a single enhanced edge to `t`: the filler becomes a dependent of the
 gap host with the UD relation corresponding to `gapType`. -/
-def fillGap (t : DepTree) (fillerIdx gapHostIdx : Nat) (gapType : GapType) :
-    DepGraph :=
+def fillGap (t : Tree) (fillerIdx gapHostIdx : Nat) (gapType : GapType) :
+    Graph :=
   { words := t.words
     deps  := t.deps ++ [⟨gapHostIdx, fillerIdx, gapToDepRel gapType⟩]
     rootIdx := t.rootIdx }
@@ -80,7 +80,7 @@ def fillGap (t : DepTree) (fillerIdx gapHostIdx : Nat) (gapType : GapType) :
 /-- Recover the gap-type label at `nodeIdx` by diffing `basic` against
 `enhanced`: returns the first enhanced-only argument-shaped edge's `GapType`,
 or `none`. -/
-def extractionLabel (basic : DepTree) (enhanced : DepGraph) (nodeIdx : Nat) :
+def extractionLabel (basic : Tree) (enhanced : Graph) (nodeIdx : Nat) :
     Option GapType :=
   let enhancedOnly := enhanced.deps.filter λ d =>
     d.depIdx == nodeIdx &&
@@ -99,12 +99,12 @@ def extractionLabel (basic : DepTree) (enhanced : DepGraph) (nodeIdx : Nat) :
 
 /-- Coarse check: does the word at `gapIdx` head an `nmod` or `conj` relation.
 This does *not* recognise any of the four classical Ross-1967 islands. -/
-def hasGapInModifierOrConjunct (t : DepTree) (gapIdx : Nat) : Bool :=
+def hasGapInModifierOrConjunct (t : Tree) (gapIdx : Nat) : Bool :=
   t.deps.any λ d =>
     (d.depType == .nmod || d.depType == .conj) && d.depIdx == gapIdx
 
 /-- No gap is reported inside the coarse modifier/conjunct heuristic. -/
-def checkNoIslandViolation (t : DepTree) (gaps : List (Nat × Nat × GapType)) :
+def checkNoIslandViolation (t : Tree) (gaps : List (Nat × Nat × GapType)) :
     Bool :=
   gaps.all λ (_, gapHostIdx, _) => !hasGapInModifierOrConjunct t gapHostIdx
 
@@ -112,7 +112,7 @@ def checkNoIslandViolation (t : DepTree) (gaps : List (Nat × Nat × GapType)) :
 tree-level checks (minus `checkVerbSubcat`, since LD trees inherently have
 argument gaps), the coarse island heuristic, and filler-licensing (wh-word,
 leftward topicalization, or relative-clause head). -/
-def isLDWellFormed (t : DepTree) (gaps : List (Nat × Nat × GapType)) : Bool :=
+def isLDWellFormed (t : Tree) (gaps : List (Nat × Nat × GapType)) : Bool :=
   hasUniqueHeads t &&
   isAcyclic t &&
   isProjective t &&
@@ -126,4 +126,4 @@ def isLDWellFormed (t : DepTree) (gaps : List (Nat × Nat × GapType)) : Bool :=
         t.deps.any λ d => d.headIdx == fillerIdx && d.depType == .acl
     | none => false
 
-end DepGrammar.LongDistance
+end DependencyGrammar.LongDistance

--- a/Linglib/Syntax/DependencyGrammar/Nominal.lean
+++ b/Linglib/Syntax/DependencyGrammar/Nominal.lean
@@ -24,7 +24,7 @@ so no per-language lexicon classifier is needed.
   Slated for relocation to `Studies/Hudson1990.lean` (auditor finding 2026-06-01).
 -/
 
-namespace DepGrammar.Nominal
+namespace DependencyGrammar.Nominal
 
 
 export Features (BindingClass)
@@ -47,4 +47,4 @@ abbrev her := English.Pronouns.her.toWord
 abbrev them := English.Pronouns.them.toWord
 abbrev eachOther := English.Pronouns.eachOther.toWord
 
-end DepGrammar.Nominal
+end DependencyGrammar.Nominal

--- a/Linglib/Syntax/DependencyGrammar/Projection.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projection.lean
@@ -22,13 +22,6 @@ namespace DepGrammar
 
 section Projection
 
-/-- Parent edge predicate: there is a head→dep dependency `(v → w)` in `deps`.
-    The atomic relation whose reflexive-transitive closure is `Dominates`
-    (defined below). Sites that need to express "v is a head with dep w"
-    should use this rather than re-spelling the existential. -/
-def parentEdge (deps : List Dependency) (v w : Nat) : Prop :=
-  ∃ d ∈ deps, d.headIdx = v ∧ d.depIdx = w
-
 /-- **Projection** π(i): the yield of node i — all nodes it transitively
     dominates, including itself — sorted in ascending order.
 
@@ -266,7 +259,7 @@ private theorem go_mem_of_queue (deps : List Dependency)
     Proof: BFS from v processes v first (adding children to queue),
     w is a child of v (by the edge), so w enters the queue and is processed. -/
 theorem child_mem_projection (deps : List Dependency) (v w : Nat)
-    (hedge : parentEdge deps v w) :
+    (hedge : ParentEdge deps v w) :
     w ∈ projection deps v := by
   unfold projection
   set goResult := projection.go deps [v] [] (deps.length * (deps.length + 1) + 2)
@@ -550,9 +543,9 @@ theorem interval_mem_between (l : List Nat)
 
 /-- Prop-level dominance: `Dominates deps v x` iff `v` transitively dominates `x`
     via dependency edges (head → dep). Defined as the reflexive-transitive
-    closure of `parentEdge`. -/
+    closure of `ParentEdge`. -/
 def Dominates (deps : List Dependency) (v x : Nat) : Prop :=
-  Relation.ReflTransGen (parentEdge deps) v x
+  Relation.ReflTransGen (ParentEdge deps) v x
 
 /-- Reflexive case: `v` dominates itself. -/
 @[refl]
@@ -561,7 +554,7 @@ theorem Dominates.refl {deps : List Dependency} {v : Nat} : Dominates deps v v :
 
 /-- Head-style step: edge `(v → w)` plus dominance from `w` gives dominance from `v`. -/
 theorem Dominates.step {deps : List Dependency} {v w x : Nat}
-    (hedge : parentEdge deps v w) (h : Dominates deps w x) : Dominates deps v x :=
+    (hedge : ParentEdge deps v w) (h : Dominates deps w x) : Dominates deps v x :=
   Relation.ReflTransGen.head hedge h
 
 /-- Dominance is transitive. -/
@@ -572,13 +565,13 @@ theorem Dominates.trans {deps : List Dependency} {u v w : Nat}
 
 /-- If there is a direct edge `(v, w)`, then `v` dominates `w`. -/
 theorem Dominates.edge {deps : List Dependency} {v w : Nat}
-    (h : parentEdge deps v w) : Dominates deps v w :=
+    (h : ParentEdge deps v w) : Dominates deps v w :=
   Relation.ReflTransGen.single h
 
 /-- Head-style induction principle for `Dominates`: prove a property of
     `Dominates deps v x` (target `x` fixed) by handling the reflexive case
     `motive x Dominates.refl` and the head-step case
-    `parentEdge v w → Dominates w x → motive w → motive v`.
+    `ParentEdge v w → Dominates w x → motive w → motive v`.
 
     Case binders are named `refl` and `step` to mirror the prior inductive's
     constructor names. The `v` and `w` arguments of `step` are implicit
@@ -588,7 +581,7 @@ theorem Dominates.head_induction_on {deps : List Dependency} {x : Nat}
     {motive : (v : Nat) → Dominates deps v x → Prop} {v : Nat}
     (h : Dominates deps v x)
     (refl : motive x Dominates.refl)
-    (step : ∀ {v w : Nat} (hedge : parentEdge deps v w)
+    (step : ∀ {v w : Nat} (hedge : ParentEdge deps v w)
               (h_tail : Dominates deps w x), motive w h_tail →
               motive v (Dominates.step hedge h_tail)) :
     motive v h := by
@@ -628,7 +621,7 @@ private theorem go_dominates_of_mem (deps : List Dependency)
           rcases List.mem_append.mp hq with hr | hc
           · exact Or.inr ⟨q, List.mem_cons.mpr (Or.inr hr), hdom⟩
           · -- q ∈ children: edge (node, q)
-            have hq_child : parentEdge deps node q := by
+            have hq_child : ParentEdge deps node q := by
               obtain ⟨d, hd_filter, hd_dep⟩ := List.mem_map.mp hc
               obtain ⟨hd_mem, hd_head⟩ := List.mem_filter.mp hd_filter
               exact ⟨d, hd_mem, beq_iff_eq.mp hd_head, hd_dep⟩
@@ -770,7 +763,7 @@ private theorem go_children_complete (deps : List Dependency)
     `(w, c)` is a dependency edge, then `c ∈ projection deps r`. -/
 theorem projection_closed_under_children (deps : List Dependency) (r w c : Nat)
     (hw : w ∈ projection deps r)
-    (hedge : parentEdge deps w c) :
+    (hedge : ParentEdge deps w c) :
     c ∈ projection deps r := by
   unfold projection at hw ⊢
   rw [List.mem_insertionSort] at hw ⊢

--- a/Linglib/Syntax/DependencyGrammar/Projection.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projection.lean
@@ -14,7 +14,7 @@ depend on projection infrastructure.
 References: [kuhlmann-nivre-2006], [kuhlmann-2013].
 -/
 
-namespace DepGrammar
+namespace DependencyGrammar
 
 -- ============================================================================
 -- Projection: the foundational primitive for non-projectivity theory
@@ -88,7 +88,7 @@ def gapDegreeAt (deps : List Dependency) (root : Nat) : Nat :=
 /-- **Gap degree** of a tree: max gap degree over all nodes.
     ([kuhlmann-nivre-2006], Definition 7)
     Gap degree 0 ⟺ projective. -/
-def DepTree.gapDegree (t : DepTree) : Nat :=
+def Tree.gapDegree (t : Tree) : Nat :=
   List.range t.words.length |>.map (gapDegreeAt t.deps) |>.foldl max 0
 
 /-- **Block-degree** of a node: number of blocks in its projection.
@@ -100,7 +100,7 @@ def blockDegreeAt (deps : List Dependency) (root : Nat) : Nat :=
     Block-degree 1 ⟺ projective.
     Bounded block-degree + well-nestedness ⟺ polynomial parsing
     ([kuhlmann-2013], Lemma 10). -/
-def DepTree.blockDegree (t : DepTree) : Nat :=
+def Tree.blockDegree (t : Tree) : Nat :=
   List.range t.words.length |>.map (blockDegreeAt t.deps) |>.foldl max 0
 
 -- ============================================================================
@@ -891,12 +891,12 @@ end FoldlMax
     Equivalent to: no two dependency arcs cross.
     Equivalent to: gap degree = 0.
     Equivalent to: block-degree = 1. -/
-def isProjective (t : DepTree) : Bool :=
+def isProjective (t : Tree) : Bool :=
   List.range t.words.length |>.all λ i =>
     isInterval (projection t.deps i)
 
 /-- A dependency tree is well-formed if it satisfies all constraints. -/
-def isWellFormed (t : DepTree) : Bool :=
+def isWellFormed (t : Tree) : Bool :=
   hasUniqueHeads t &&
   isAcyclic t &&
   isProjective t &&
@@ -904,4 +904,4 @@ def isWellFormed (t : DepTree) : Bool :=
   checkDetNounAgr t &&
   checkVerbSubcat t
 
-end DepGrammar
+end DependencyGrammar

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -19,7 +19,7 @@ formalised here.
 
 namespace WordGrammar
 
-open DepGrammar (ArgStr ArgSlot Dir)
+open DependencyGrammar (ArgStr ArgSlot Dir)
 
 -- ============================================================================
 -- Lexical Entries with Argument Structures

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -38,7 +38,7 @@ structure LexEntry where
 
 -- ============================================================================
 -- Auxiliary Argument Structures (DG-specific, used with LexEntry/lexical rules)
--- Standard frames (argStr_V0, argStr_VN, argStr_VNN, argStr_VPassive) and
+-- Standard frames (argStrV0, argStrVN, argStrVNN, argStrVPassive) and
 -- satisfiesArgStr are in Core/Basic.lean.
 -- ============================================================================
 

--- a/Linglib/Syntax/WordGrammar/Network.lean
+++ b/Linglib/Syntax/WordGrammar/Network.lean
@@ -159,7 +159,7 @@ def englishAuxNet : WGNetwork := {
 -- ============================================================================
 
 /-- A transitive verb inherits nsubj/left from `verb` and adds obj/right
-locally — the network-derived argStr matches the manual `argStr_VN`
+locally — the network-derived argStr matches the manual `argStrVN`
 (modulo optional fields that default). -/
 theorem network_transitive_slot0 :
     resolveSlot englishAuxNet "transitive" 0 =
@@ -181,7 +181,7 @@ theorem network_aux_slot0 :
       some { depType := .nsubj, dir := .left } := by decide
 
 /-- The network-derived arg structure for a transitive verb has the same
-slots as the manually defined `argStr_VN`. -/
+slots as the manually defined `argStrVN`. -/
 theorem network_argStr_matches_manual :
     (resolveArgStr englishAuxNet "transitive").slots =
       [{ depType := .nsubj, dir := .left },

--- a/Linglib/Syntax/WordGrammar/Network.lean
+++ b/Linglib/Syntax/WordGrammar/Network.lean
@@ -33,7 +33,7 @@ namespace WordGrammar
 open Features
 open Clause (EmbeddingContext)
 open WordGrammar.Inheritance
-open DepGrammar (Dir ArgStr ArgSlot DepTree satisfiesArgStr)
+open DependencyGrammar (Dir ArgStr ArgSlot Tree satisfiesArgStr)
 
 -- ============================================================================
 -- Node and Relation Types
@@ -242,7 +242,7 @@ def wordClassFor (f : Mood.Illocutionary) (e : EmbeddingContext) : String :=
 for the clause context, resolve its argument structure from the network,
 and check the tree satisfies it. This is the end-to-end chain:
 `force × context → wordClass → network → argStr → satisfiesArgStr`. -/
-def wgLicenses (net : WGNetwork) (t : DepTree) (auxIdx : Nat)
+def wgLicenses (net : WGNetwork) (t : Tree) (auxIdx : Nat)
     (f : Mood.Illocutionary) (e : EmbeddingContext) : Bool :=
   satisfiesArgStr t auxIdx (resolveArgStr net (wordClassFor f e))
 


### PR DESCRIPTION
Second PR from the DepTree API audit: the Digraph grounding keystone.

- `DepTree extends DepGraph` (they shared three fields as unrelated structures; the hand-written `toGraph` copy is now the generated projection), with field docstrings throughout
- `DepGraph.toDigraph` via `Digraph.mk'` (decidable adjacency for free) with the `@[simp]` spec `toDigraph_adj ↔ ParentEdge`; `ParentEdge` moves to `Basic` as the canonical adjacency (renamed from `parentEdge` per mathlib Prop-relation casing)
- basic-below-enhanced as `≤` in the `Digraph` lattice (`toDigraph_mono`, applied to both EnhancedDependencies fixtures)
- named graph API `parentsOf`/`children`/`inDegree`; `hasUniqueHeads` de-zipped through `inDegree`, collapsing an 18-line index-gymnastics lemma to three lines and replacing NonProjective's 35-line private duplicate with a two-line derivation from `parentOf_of_edge_uh`
- `argStr_V0/VN/VNN/VPassive` → `argStrV0/…` (the module docstring already advertised the correct names)