### PR TITLE
refactor(Syntax/DependencyGrammar): split Valency; construct adjacency

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2858,6 +2858,7 @@ import Linglib.Syntax.DependencyGrammar.Formal.VPDivergence
 import Linglib.Syntax.DependencyGrammar.LongDistance
 import Linglib.Syntax.DependencyGrammar.Nominal
 import Linglib.Syntax.DependencyGrammar.Projection
+import Linglib.Syntax.DependencyGrammar.Valency
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.HPSG.Basic
 import Linglib.Syntax.HPSG.Binding

--- a/Linglib/Studies/Osborne2019.lean
+++ b/Linglib/Studies/Osborne2019.lean
@@ -107,12 +107,33 @@ theorem kick_frame_from_fragment :
 theorem passive_valence_consistent :
     complementToArgStr English.Predicates.Verbal.kick.complementType = some argStrVN ∧
     passiveRule.applies lex_kicked = true ∧
-    (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false :=
+    (passiveRule.transform lex_kicked).argStr.any (·.depType == .obj) = false :=
   ⟨rfl, rfl, rfl⟩
 
 -- ============================================================================
 -- §3: Grammatical Trees
 -- ============================================================================
+
+/-- SV fixture: subject → verb. -/
+private def mkSVTree (subj verb : Word) (frame : Option ArgStr := none) : Tree :=
+  { words := [subj, verb]
+    deps := [⟨1, 0, .nsubj⟩]
+    rootIdx := 1
+    frames := [none, frame] }
+
+/-- SVO fixture: subject → verb ← object. -/
+private def mkSVOTree (subj verb obj : Word) (frame : Option ArgStr := none) : Tree :=
+  { words := [subj, verb, obj]
+    deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
+    rootIdx := 1
+    frames := [none, frame, none] }
+
+/-- Ditransitive fixture: subj → verb ← iobj, obj. -/
+private def mkDitransTree (subj verb iobj obj : Word) (frame : Option ArgStr := none) : Tree :=
+  { words := [subj, verb, iobj, obj]
+    deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .iobj⟩, ⟨1, 3, .obj⟩]
+    rootIdx := 1
+    frames := [none, frame, none, none] }
 
 /-- "John sleeps" — intransitive, no object. -/
 def intransTree :=
@@ -236,14 +257,14 @@ theorem passive_applies_to_kicked :
 
 /-- The derived entry removes the obj slot and adds optional obl. -/
 theorem passive_removes_obj_adds_obl :
-    (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false ∧
-    (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obl) = true :=
+    (passiveRule.transform lex_kicked).argStr.any (·.depType == .obj) = false ∧
+    (passiveRule.transform lex_kicked).argStr.any (·.depType == .obl) = true :=
   ⟨rfl, rfl⟩
 
 /-- The passive rule output matches argStrVPassive. -/
 theorem passive_frame_matches :
-    (passiveRule.transform lex_kicked).argStr.slots =
-    argStrVPassive.slots := by native_decide
+    (passiveRule.transform lex_kicked).argStr =
+    argStrVPassive := by native_decide
 
 -- Passive trees validate
 theorem passive_subcat_ok : checkVerbSubcat passiveTree = true := rfl
@@ -308,7 +329,7 @@ theorem valency_derivation_chain :
     checkVerbSubcat activeTree = true ∧
     -- Passive rule applies, removes obj
     passiveRule.applies lex_kicked = true ∧
-    (passiveRule.transform lex_kicked).argStr.slots.any (·.depType == .obj) = false ∧
+    (passiveRule.transform lex_kicked).argStr.any (·.depType == .obj) = false ∧
     -- Passive tree: derived frame ✓, subcat ✓
     satisfiesArgStr passiveTree 3 argStrVPassive = true ∧
     checkVerbSubcat passiveTree = true ∧

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,21 +1,16 @@
 import Mathlib.Data.List.Basic
 import Mathlib.Combinatorics.Digraph.Basic
 import Linglib.Data.UD.Basic
-import Linglib.Syntax.Category.Verb.Frame
 import Linglib.Morphology.Word.Basic
-
-open Morphology (Word)
 
 /-!
 # Dependency grammar substrate
 
 Core data types for dependency grammar: words connected by typed directed
-edges (`Dependency`), trees built over them (`Tree`), and enhanced
-graphs allowing multiple incoming arcs (`Graph`). Argument structures
-(`ArgStr`) record direction and selectional category for each slot.
-
-Dependency relations use `UD.DepRel` from `Core/UD.lean` (Universal
-Dependencies v2). [hudson-2010], [gibson-2025].
+edges (`Dependency`), graphs built over them (`Graph`), and single-headed
+trees (`Tree`). Dependency relations use `UD.DepRel` from
+`Data/UD/Basic.lean` (Universal Dependencies v2). [hudson-2010],
+[gibson-2025].
 
 ## Main declarations
 
@@ -25,12 +20,12 @@ Dependencies v2). [hudson-2010], [gibson-2025].
   `toDigraph` presents the graph as a mathlib `Digraph` with decidable
   adjacency (`ParentEdge` is the adjacency at the edge-list level), and
   `toDigraph_mono` orders basic below enhanced graphs in the `Digraph` lattice.
-* `ArgStr`, `argStrV0/VN/VNN/VPassive` — argument-structure schemas for the
-  standard intransitive / transitive / ditransitive / passive valences.
-* `hasUniqueHeads`, `isAcyclic`, `isWellFormed` — structural well-formedness
-  predicates (`Bool`-valued; see Implementation notes).
-* `mkSVTree`, `mkSVOTree`, `mkDetNVTree`, `mkDitransTree` — small fixture
-  builders used by Studies and Formal/ test data.
+* `hasUniqueHeads`, `isAcyclic`, `Tree.WF` — structural well-formedness.
+* `numberAgreesOn` — number agreement across the edges of one relation.
+
+The valency layer — frame schemas and their satisfaction — lives in
+`Valency.lean`; only the slot data types (`Dir`, `ArgSlot`, `ArgStr`) are
+declared here, because `Tree.frames` carries them.
 
 ## Implementation notes
 
@@ -39,29 +34,40 @@ Dependencies v2). [hudson-2010], [gibson-2025].
   inherit, and migrating it is a separate refactor.
 -/
 
+open Morphology (Word)
+
 namespace DependencyGrammar
 
 
 section ArgumentStructure
 
-/-- Direction of a dependent relative to head. -/
+/-- Direction of a dependent relative to its head. -/
 inductive Dir where
-  | left   -- dependent precedes head
-  | right  -- dependent follows head
-  deriving Repr, DecidableEq, Inhabited
+  /-- The dependent precedes the head. -/
+  | left
+  /-- The dependent follows the head. -/
+  | right
+  deriving Repr, DecidableEq
 
-/-- A single argument slot in an argument structure. -/
+/-- Whether a dependent at position `dep` sits on side `dir` of the head at
+    position `head`. -/
+def Dir.admits : Dir → Nat → Nat → Bool
+  | .left, head, dep => dep < head
+  | .right, head, dep => head < dep
+
+/-- A single argument slot in an argument structure: which relation fills it,
+    on which side of the head, and whether it must be filled. -/
 structure ArgSlot where
+  /-- The UD relation of the filler. -/
   depType : UD.DepRel
+  /-- Which side of the head the filler sits. -/
   dir : Dir
+  /-- Whether the slot must be filled. -/
   required : Bool := true
-  cat : Option UD.UPOS := none
   deriving Repr, DecidableEq
 
-/-- Argument structure: what dependents a word requires/allows. -/
-structure ArgStr where
-  slots : List ArgSlot
-  deriving Repr, DecidableEq
+/-- Argument structure: the dependent slots a word requires or allows. -/
+abbrev ArgStr := List ArgSlot
 
 end ArgumentStructure
 
@@ -91,12 +97,27 @@ structure Graph where
   rootIdx : Nat
   deriving Repr
 
-/-- The head → dependent adjacency of an edge list: there is an edge `(v → w)`
-    in `deps`. The atomic relation whose reflexive-transitive closure is
-    `Dominates`; sites that need "v is a head with dependent w" should use
-    this rather than re-spelling the existential. -/
-def ParentEdge (deps : List Dependency) (v w : Nat) : Prop :=
-  ∃ d ∈ deps, d.headIdx = v ∧ d.depIdx = w
+/-- The mathlib `Digraph` on word positions whose edges are the arcs of
+    `deps`, head → dependent. Constructed with `Digraph.mk'`, so adjacency is
+    decidable and digraph-level goals close by `decide`. This is *the*
+    adjacency of the theory: `ParentEdge` is its `Adj`, and `Dominates` its
+    reachability. -/
+def edgeDigraph (deps : List Dependency) : Digraph Nat :=
+  Digraph.mk' λ v w => deps.any λ d => d.headIdx == v && d.depIdx == w
+
+/-- The head → dependent adjacency: `(edgeDigraph deps).Adj`, i.e. there is an
+    edge `(v → w)` in `deps` (see `parentEdge_iff` for the list form). -/
+def ParentEdge (deps : List Dependency) : Nat → Nat → Prop :=
+  (edgeDigraph deps).Adj
+
+/-- Membership characterization of the adjacency. -/
+@[simp] theorem parentEdge_iff {deps : List Dependency} {v w : Nat} :
+    ParentEdge deps v w ↔ ∃ d ∈ deps, d.headIdx = v ∧ d.depIdx = w := by
+  simp [ParentEdge, edgeDigraph]
+
+instance (deps : List Dependency) : DecidableRel (ParentEdge deps) :=
+  inferInstanceAs (DecidableRel
+    (Digraph.mk' λ v w => deps.any λ d => d.headIdx == v && d.depIdx == w).Adj)
 
 namespace Graph
 
@@ -112,22 +133,21 @@ def children (g : Graph) (i : Nat) : List Nat :=
 def inDegree (g : Graph) (i : Nat) : Nat :=
   (g.parentsOf i).length
 
-/-- The graph as a mathlib `Digraph` on word positions. Built with
-    `Digraph.mk'`, so adjacency is decidable and digraph-level goals close by
-    `decide`. -/
+/-- The graph's digraph: `edgeDigraph` on its edge list. -/
 def toDigraph (g : Graph) : Digraph Nat :=
-  Digraph.mk' λ v w => g.deps.any λ d => d.headIdx == v && d.depIdx == w
+  edgeDigraph g.deps
 
 @[simp] theorem toDigraph_adj (g : Graph) (v w : Nat) :
-    g.toDigraph.Adj v w ↔ ParentEdge g.deps v w := by
-  simp [toDigraph, ParentEdge]
+    g.toDigraph.Adj v w ↔ ParentEdge g.deps v w := Iff.rfl
 
 /-- More edges, larger digraph: a graph's digraph is a subgraph of any
     enhancement of it (in the `Digraph` lattice order). -/
-theorem toDigraph_mono {g g' : Graph} (h : ∀ d ∈ g.deps, d ∈ g'.deps) :
+theorem toDigraph_mono {g g' : Graph} (h : g.deps ⊆ g'.deps) :
     g.toDigraph ≤ g'.toDigraph := λ v w hvw => by
-  obtain ⟨d, hd, hh, hdep⟩ := (g.toDigraph_adj v w).mp hvw
-  exact (g'.toDigraph_adj v w).mpr ⟨d, h d hd, hh, hdep⟩
+  obtain ⟨d, hd, hh, hdep⟩ := parentEdge_iff.mp hvw
+  exact parentEdge_iff.mpr ⟨d, h hd, hh, hdep⟩
+
+attribute [coe] toDigraph
 
 instance : Coe Graph (Digraph Nat) := ⟨toDigraph⟩
 
@@ -147,49 +167,16 @@ structure Tree extends Graph where
 
 /-- The argument-structure frame at position `i`, if one was supplied. -/
 def Tree.frame (t : Tree) (i : Nat) : Option ArgStr :=
-  (t.frames[i]?).getD none
+  (t.frames[i]?).join
 
 end DependenciesAndTrees
-
-section StandardArgStr
-
-/-- Intransitive verb: subject to the left -/
-def argStrV0 : ArgStr :=
-  { slots := [⟨.nsubj, .left, true, some .DET⟩] }
-
-/-- Transitive verb: subject left, object right -/
-def argStrVN : ArgStr :=
-  { slots := [⟨.nsubj, .left, true, some .DET⟩,
-              ⟨.obj, .right, true, some .DET⟩] }
-
-/-- Ditransitive verb: subject left, indirect object right, object right -/
-def argStrVNN : ArgStr :=
-  { slots := [⟨.nsubj, .left, true, some .DET⟩,
-              ⟨.iobj, .right, true, some .DET⟩,
-              ⟨.obj, .right, true, some .DET⟩] }
-
-/-- Passive transitive: subject left (was patient), optional by-phrase right -/
-def argStrVPassive : ArgStr :=
-  { slots := [⟨.nsubj, .left, true, some .DET⟩,
-              ⟨.obl, .right, false, some .ADP⟩] }  -- by-phrase is optional
-
-/-- Map a complement type to the corresponding standard DG argument structure.
-    Returns `none` for frames without a standard schema: clause-embedding
-    types take xcomp/ccomp, not obj, and `.np_pp` has no fixture here. -/
-def complementToArgStr : ComplementType → Option ArgStr
-  | .none => some argStrV0
-  | .np => some argStrVN
-  | .np_np => some argStrVNN
-  | _ => Option.none
-
-end StandardArgStr
 
 section WellFormedness
 
 /-- Check if every word except root has exactly one head. -/
 def hasUniqueHeads (t : Tree) : Bool :=
   (List.range t.words.length).all λ i =>
-    t.toGraph.inDegree i == (if i == t.rootIdx then 0 else 1)
+    t.inDegree i == (if i == t.rootIdx then 0 else 1)
 
 /-- Check for cycles: no word is its own ancestor. -/
 def isAcyclic (t : Tree) : Bool :=
@@ -217,113 +204,26 @@ end WellFormedness
 
 section AgreementChecking
 
-/-- Check subject-verb number agreement. -/
-def checkSubjVerbAgr (t : Tree) : Bool :=
+/-- Number agreement across every `rel`-labeled edge. Permissive by default:
+    edges whose endpoints are out of range or unmarked for number pass
+    vacuously, so the check constrains only overtly conflicting marking. -/
+def numberAgreesOn (t : Tree) (rel : UD.DepRel) : Bool :=
   t.deps.all λ d =>
-    if d.depType == .nsubj then
+    if d.depType == rel then
       match t.words[d.depIdx]?, t.words[d.headIdx]? with
-      | some subj, some verb =>
-        match subj.features.number, verb.features.number with
-        | some sn, some vn => sn == vn
+      | some dep, some head =>
+        match dep.features.number, head.features.number with
+        | some dn, some hn => dn == hn
         | _, _ => true
       | _, _ => true
     else true
 
-/-- Check determiner-noun number agreement. -/
-def checkDetNounAgr (t : Tree) : Bool :=
-  t.deps.all λ d =>
-    if d.depType == .det then
-      match t.words[d.depIdx]?, t.words[d.headIdx]? with
-      | some det, some noun =>
-        match det.features.number, noun.features.number with
-        | some dn, some nn => dn == nn
-        | _, _ => true
-      | _, _ => true
-    else true
+/-- Subject-verb number agreement: `numberAgreesOn` at `nsubj`. -/
+def checkSubjVerbAgr (t : Tree) : Bool := numberAgreesOn t .nsubj
+
+/-- Determiner-noun number agreement: `numberAgreesOn` at `det`. -/
+def checkDetNounAgr (t : Tree) : Bool := numberAgreesOn t .det
 
 end AgreementChecking
-
-section ArgStrSatisfaction
-
-/-- Check if a dependency tree satisfies an argument structure -/
-def satisfiesArgStr (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
-  argStr.slots.all λ slot =>
-    if slot.required then
-      -- Required slot: must have a matching dependency
-      t.deps.any λ d =>
-        d.headIdx == headIdx &&
-        d.depType == slot.depType &&
-        -- Check direction
-        (match slot.dir with
-         | .left => d.depIdx < headIdx
-         | .right => d.depIdx > headIdx)
-    else
-      -- Optional slot: if present, must be in correct direction
-      t.deps.all λ d =>
-        if d.headIdx == headIdx && d.depType == slot.depType then
-          match slot.dir with
-          | .left => d.depIdx < headIdx
-          | .right => d.depIdx > headIdx
-        else true
-
-/-- Core argument relations governed by lexical frames. -/
-def coreArgRels : List UD.DepRel := [.nsubj, .obj, .iobj]
-
-/-- Every core-argument dependent of `headIdx` is licensed by a slot of
-    `argStr` — the closed-world half of frame checking (`satisfiesArgStr`
-    only checks that required slots are filled). -/
-def coreArgsLicensed (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
-  t.deps.all λ d =>
-    if d.headIdx == headIdx && coreArgRels.contains d.depType then
-      argStr.slots.any (·.depType == d.depType)
-    else true
-
-/-- Check each verb's dependents against its lexical frame: required slots
-    filled in the right direction (`satisfiesArgStr`) and no unlicensed core
-    arguments (`coreArgsLicensed`). Verbs without a frame are skipped. -/
-def checkVerbSubcat (t : Tree) : Bool :=
-  List.range t.words.length |>.all λ i =>
-    match t.words[i]? with
-    | some w =>
-      if w.cat == UD.UPOS.VERB then
-        match t.frame i with
-        | some a => satisfiesArgStr t i a && coreArgsLicensed t i a
-        | none => true
-      else true
-    | none => true
-
-end ArgStrSatisfaction
-
-section TreeConstructionHelpers
-
-/-- Create a simple SV tree: subject -> verb. -/
-def mkSVTree (subj verb : Word) (frame : Option ArgStr := none) : Tree :=
-  { words := [subj, verb]
-    deps := [⟨1, 0, .nsubj⟩]
-    rootIdx := 1
-    frames := [none, frame] }
-
-/-- Create a simple SVO tree: subject -> verb <- object. -/
-def mkSVOTree (subj verb obj : Word) (frame : Option ArgStr := none) : Tree :=
-  { words := [subj, verb, obj]
-    deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .obj⟩]
-    rootIdx := 1
-    frames := [none, frame, none] }
-
-/-- Create Det-N-V tree: det -> noun -> verb. -/
-def mkDetNVTree (det noun verb : Word) (frame : Option ArgStr := none) : Tree :=
-  { words := [det, noun, verb]
-    deps := [⟨1, 0, .det⟩, ⟨2, 1, .nsubj⟩]
-    rootIdx := 2
-    frames := [none, none, frame] }
-
-/-- Create a ditransitive tree: subj -> verb <- iobj <- obj. -/
-def mkDitransTree (subj verb iobj obj : Word) (frame : Option ArgStr := none) : Tree :=
-  { words := [subj, verb, iobj, obj]
-    deps := [⟨1, 0, .nsubj⟩, ⟨1, 2, .iobj⟩, ⟨1, 3, .obj⟩]
-    rootIdx := 1
-    frames := [none, frame, none, none] }
-
-end TreeConstructionHelpers
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -179,7 +179,7 @@ theorem parentOf_of_edge_uh (t : Tree)
     (hwf : t.WF)
     {v c : Nat} (hedge : ParentEdge t.deps v c) :
     parentOf_uh t c = v := by
-  obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
+  obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedge
   have hfind_some : (t.deps.find? (fun d => d.depIdx == c)).isSome = true :=
     List.find?_isSome.mpr ⟨d, hd_mem, beq_iff_eq.mpr hd_dep⟩
   obtain ⟨f, hf_find⟩ := Option.isSome_iff_exists.mp hfind_some
@@ -231,7 +231,7 @@ theorem dominates_iterParent_uh (t : Tree)
         have hi0 : i = 0 := by omega
         subst hi0
         have hfind_some : (t.deps.find? (fun d => d.depIdx == c)).isSome = true := by
-          obtain ⟨d, hd_mem, _, hd_dep⟩ := hedge
+          obtain ⟨d, hd_mem, _, hd_dep⟩ := parentEdge_iff.mp hedge
           exact List.find?_isSome.mpr ⟨d, hd_mem, beq_iff_eq.mpr hd_dep⟩
         obtain ⟨f, hf_find⟩ := Option.isSome_iff_exists.mp hfind_some
         exact ⟨f, hf_find, (parentOf_eq_find_uh t c hf_find).symm⟩
@@ -248,7 +248,7 @@ theorem dominates_iterParent_uh (t : Tree)
           subst hik
           rw [hiter]
           have hfind_some : (t.deps.find? (fun d => d.depIdx == c)).isSome = true := by
-            obtain ⟨d, hd_mem, _, hd_dep⟩ := hedge
+            obtain ⟨d, hd_mem, _, hd_dep⟩ := parentEdge_iff.mp hedge
             exact List.find?_isSome.mpr ⟨d, hd_mem, beq_iff_eq.mpr hd_dep⟩
           obtain ⟨f, hf_find⟩ := Option.isSome_iff_exists.mp hfind_some
           exact ⟨f, hf_find, by
@@ -267,7 +267,7 @@ private theorem dominates_depIdx_lt (t : Tree)
     intro _
     by_cases hcx : c = w
     · subst hcx
-      obtain ⟨d, hd_mem, _, hd_dep⟩ := hedge
+      obtain ⟨d, hd_mem, _, hd_dep⟩ := parentEdge_iff.mp hedge
       exact hd_dep ▸ h_dep_wf d hd_mem
     · exact ih hcx
 
@@ -490,7 +490,7 @@ theorem dominates_to_parent {deps : List Dependency} {v c a : Nat}
     -- edge(u, w) and Dominates deps w c, need Dominates deps u a
     by_cases hw_eq_c : w = c
     · -- w = c: edge(u, c), so u = a by unique parent
-      obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
+      obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedge
       have hu_eq_a : u = a := by
         rw [← hd_head]; exact hparent d hd_mem (hw_eq_c ▸ hd_dep)
       exact hu_eq_a ▸ Dominates.refl

--- a/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/CatenalConstruction.lean
@@ -87,7 +87,7 @@ private theorem bidir_of_dominates (deps : List Dependency) (root x : Nat)
     have hw_mem := child_mem_projection deps v w hedge
     have hedge' : ∃ d ∈ deps, (d.headIdx = v ∧ d.depIdx = w) ∨
                                 (d.depIdx = v ∧ d.headIdx = w) := by
-      obtain ⟨d, hd, h1, h2⟩ := hedge
+      obtain ⟨d, hd, h1, h2⟩ := parentEdge_iff.mp hedge
       exact ⟨d, hd, Or.inl ⟨h1, h2⟩⟩
     exact .step v w _ hv_mem hw_mem hedge' (bidir_lift hsubset ih)
 

--- a/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/Formal/NonProjective.lean
@@ -290,8 +290,8 @@ private theorem unique_parent_of_hasUniqueHeads {t : Tree}
     {e₁ e₂ : Dependency} (he₁ : e₁ ∈ t.deps) (he₂ : e₂ ∈ t.deps)
     (hd₁ : e₁.depIdx = c) (hd₂ : e₂.depIdx = c) :
     e₁.headIdx = e₂.headIdx := by
-  rw [← parentOf_of_edge_uh t hwf ⟨e₁, he₁, rfl, hd₁⟩,
-      ← parentOf_of_edge_uh t hwf ⟨e₂, he₂, rfl, hd₂⟩]
+  rw [← parentOf_of_edge_uh t hwf (parentEdge_iff.mpr ⟨e₁, he₁, rfl, hd₁⟩),
+      ← parentOf_of_edge_uh t hwf (parentEdge_iff.mpr ⟨e₂, he₂, rfl, hd₂⟩)]
 
 /-- **Projective ⊂ planar** for well-formed trees.
     ([kuhlmann-nivre-2006], §3.5) -/
@@ -312,8 +312,8 @@ theorem projective_implies_planar (t : Tree)
       (unique_parent_of_hasUniqueHeads hwf hnode he_ref_mem hdep hd_ref hdep_node).symm.trans hh_ref
   rcases he₁_dir with ⟨hh₁, hd₁⟩ | ⟨hh₁, hd₁⟩ <;>
   rcases he₂_dir with ⟨hh₂, hd₂⟩ | ⟨hh₂, hd₂⟩
-  · have hc_in_a := child_mem_projection t.deps a c ⟨e₁, he₁_mem, hh₁, hd₁⟩
-    have hd_in_b := child_mem_projection t.deps b d ⟨e₂, he₂_mem, hh₂, hd₂⟩
+  · have hc_in_a := child_mem_projection t.deps a c (parentEdge_iff.mpr ⟨e₁, he₁_mem, hh₁, hd₁⟩)
+    have hd_in_b := child_mem_projection t.deps b d (parentEdge_iff.mpr ⟨e₂, he₂_mem, hh₂, hd₂⟩)
     have hint_a := projective_interval hproj a ha_lt
     have hint_b := projective_interval hproj b hb_lt
     have hb_in_a := interval_mem_between _ (projection_chain' t.deps a) hint_a
@@ -325,8 +325,8 @@ theorem projective_implies_planar (t : Tree)
     have h_c_parent := mk_parent hc_lt e₁ he₁_mem hh₁ hd₁
     have h_b_dom_a := dominates_to_parent h_b_dom_c (Nat.ne_of_lt hbc) h_c_parent
     exact absurd (dominates_antisymm t hwf hacyc a b h_a_dom_b h_b_dom_a) (Nat.ne_of_lt hab)
-  · have hc_in_a := child_mem_projection t.deps a c ⟨e₁, he₁_mem, hh₁, hd₁⟩
-    have hb_in_d := child_mem_projection t.deps d b ⟨e₂, he₂_mem, hh₂, hd₂⟩
+  · have hc_in_a := child_mem_projection t.deps a c (parentEdge_iff.mpr ⟨e₁, he₁_mem, hh₁, hd₁⟩)
+    have hb_in_d := child_mem_projection t.deps d b (parentEdge_iff.mpr ⟨e₂, he₂_mem, hh₂, hd₂⟩)
     have hint_a := projective_interval hproj a ha_lt
     have hint_d := projective_interval hproj d hd_lt
     have hb_in_a := interval_mem_between _ (projection_chain' t.deps a) hint_a
@@ -342,8 +342,8 @@ theorem projective_implies_planar (t : Tree)
     have h_a_dom_d := dominates_to_parent h_a_dom_b (Nat.ne_of_lt hab) h_b_parent
     exact absurd (dominates_antisymm t hwf hacyc a d h_a_dom_d h_d_dom_a)
       (Nat.ne_of_lt (Nat.lt_trans (Nat.lt_trans hab hbc) hcd))
-  · have ha_in_c := child_mem_projection t.deps c a ⟨e₁, he₁_mem, hh₁, hd₁⟩
-    have hd_in_b := child_mem_projection t.deps b d ⟨e₂, he₂_mem, hh₂, hd₂⟩
+  · have ha_in_c := child_mem_projection t.deps c a (parentEdge_iff.mpr ⟨e₁, he₁_mem, hh₁, hd₁⟩)
+    have hd_in_b := child_mem_projection t.deps b d (parentEdge_iff.mpr ⟨e₂, he₂_mem, hh₂, hd₂⟩)
     have hint_c := projective_interval hproj c hc_lt
     have hint_b := projective_interval hproj b hb_lt
     have hb_in_c := interval_mem_between _ (projection_chain' t.deps c) hint_c
@@ -353,8 +353,8 @@ theorem projective_implies_planar (t : Tree)
     have h_c_dom_b := dominates_of_mem_projection hb_in_c
     have h_b_dom_c := dominates_of_mem_projection hc_in_b
     exact absurd (dominates_antisymm t hwf hacyc b c h_b_dom_c h_c_dom_b) (Nat.ne_of_lt hbc)
-  · have ha_in_c := child_mem_projection t.deps c a ⟨e₁, he₁_mem, hh₁, hd₁⟩
-    have hb_in_d := child_mem_projection t.deps d b ⟨e₂, he₂_mem, hh₂, hd₂⟩
+  · have ha_in_c := child_mem_projection t.deps c a (parentEdge_iff.mpr ⟨e₁, he₁_mem, hh₁, hd₁⟩)
+    have hb_in_d := child_mem_projection t.deps d b (parentEdge_iff.mpr ⟨e₂, he₂_mem, hh₂, hd₂⟩)
     have hint_c := projective_interval hproj c hc_lt
     have hint_d := projective_interval hproj d hd_lt
     have hb_in_c := interval_mem_between _ (projection_chain' t.deps c) hint_c
@@ -387,7 +387,7 @@ private theorem dominates_comparable (t : Tree)
     rcases ih with huw | hwu
     · by_cases huw_eq : u = w
       · subst huw_eq; exact Or.inr (Dominates.edge hedge)
-      · obtain ⟨e, he_mem, he_head, he_dep⟩ := hedge
+      · obtain ⟨e, he_mem, he_head, he_dep⟩ := parentEdge_iff.mp hedge
         have hw_lt : w < t.words.length := he_dep ▸ hwf.depIdx_lt e he_mem
         have hparent : ∀ d ∈ t.deps, d.depIdx = w → d.headIdx = v' := by
           intro d hd hd_dep_eq
@@ -423,7 +423,7 @@ private theorem exists_spanning_edge_down {deps : List Dependency}
     intro hroot hx
     have hw_mem := child_mem_projection deps r w hedg
     by_cases hw : w < k
-    · obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedg
+    · obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedg
       refine ⟨w, r, ?_, hw_mem, root_mem_projection deps r, hw, hroot⟩
       simp only [linked, List.any_eq_true, Bool.or_eq_true, Bool.and_eq_true, beq_iff_eq]
       exact ⟨d, hd_mem, Or.inr ⟨hd_head, hd_dep⟩⟩
@@ -451,7 +451,7 @@ private theorem exists_spanning_edge_up {deps : List Dependency}
     intro hroot hx
     have hw_mem := child_mem_projection deps r w hedg
     by_cases hw : k ≤ w
-    · obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedg
+    · obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedg
       refine ⟨r, w, ?_, root_mem_projection deps r, hw_mem, hroot, hw⟩
       simp only [linked, List.any_eq_true, Bool.or_eq_true, Bool.and_eq_true, beq_iff_eq]
       exact ⟨d, hd_mem, Or.inl ⟨hd_head, hd_dep⟩⟩
@@ -585,7 +585,7 @@ private theorem iterParent_chain_mem_projection (t : Tree)
     have h_shift : k - (n + 1) + 1 = k - n := by omega
     exact projection_closed_under_children t.deps u
       (iterParent_uh t w (k - n)) (iterParent_uh t w (k - (n + 1)))
-      hprev ⟨dep, hdep_mem, h_shift ▸ hdep_head, hdep_dep⟩
+      hprev (parentEdge_iff.mpr ⟨dep, hdep_mem, h_shift ▸ hdep_head, hdep_dep⟩)
 
 /-- Consecutive elements of the `iterParent` chain are linked. -/
 private theorem iterParent_chain_linked {t : Tree}

--- a/Linglib/Syntax/DependencyGrammar/LongDistance.lean
+++ b/Linglib/Syntax/DependencyGrammar/LongDistance.lean
@@ -25,7 +25,7 @@ from the gap-host word to the filler.
 
 ## Implementation notes
 
-* The `Bool`-valued predicates follow `DependencyGrammar.isWellFormed`'s substrate
+* The `Bool`-valued predicates follow the substrate-wide
   convention; converting them to `Prop` + `Decidable` is a substrate-wide
   refactor not done here.
 * `hasGapInModifierOrConjunct` is deliberately coarse: it flags any gap whose

--- a/Linglib/Syntax/DependencyGrammar/Projection.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projection.lean
@@ -8,8 +8,8 @@ Projection theory for dependency trees: BFS-based projection computation,
 interval/gap/block analysis, Prop-level Dominance (reflexive-transitive
 closure), and the bridge theorems connecting BFS membership to dominance.
 
-Also contains the `isProjective` / `isWellFormed` predicates, which
-depend on projection infrastructure.
+Also contains the `isProjective` predicate, which
+depends on projection infrastructure.
 
 References: [kuhlmann-nivre-2006], [kuhlmann-2013].
 -/
@@ -277,7 +277,7 @@ theorem child_mem_projection (deps : List Dependency) (v w : Nat)
   simp only [List.nil_append]
   -- Prove w ∈ children
   have hw_children : w ∈ children := by
-    obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
+    obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedge
     exact List.mem_map.mpr ⟨d, List.mem_filter.mpr ⟨hd_mem, by simp [hd_head]⟩, hd_dep⟩
   -- Case split: w = v (trivially in visited) or w ≠ v (use go_mem_of_queue)
   by_cases hvw : w = v
@@ -624,7 +624,7 @@ private theorem go_dominates_of_mem (deps : List Dependency)
             have hq_child : ParentEdge deps node q := by
               obtain ⟨d, hd_filter, hd_dep⟩ := List.mem_map.mp hc
               obtain ⟨hd_mem, hd_head⟩ := List.mem_filter.mp hd_filter
-              exact ⟨d, hd_mem, beq_iff_eq.mp hd_head, hd_dep⟩
+              exact parentEdge_iff.mpr ⟨d, hd_mem, beq_iff_eq.mp hd_head, hd_dep⟩
             exact Or.inr ⟨node, List.mem_cons.mpr (Or.inl rfl),
               Dominates.step hq_child hdom⟩
 
@@ -768,7 +768,7 @@ theorem projection_closed_under_children (deps : List Dependency) (r w c : Nat)
   unfold projection at hw ⊢
   rw [List.mem_insertionSort] at hw ⊢
   have hc_child : c ∈ (deps.filter (fun d => d.headIdx == w)).map (fun d => d.depIdx) := by
-    obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := hedge
+    obtain ⟨d, hd_mem, hd_head, hd_dep⟩ := parentEdge_iff.mp hedge
     exact List.mem_map.mpr ⟨d, List.mem_filter.mpr ⟨hd_mem, by simp [hd_head]⟩, hd_dep⟩
   apply go_children_complete deps [r] [] _ w c hw (fun h => nomatch h) hc_child
   -- bfsPot deps [r] [] = deps.length + 1 (filter is trivially all of deps since visited = [])
@@ -894,14 +894,5 @@ end FoldlMax
 def isProjective (t : Tree) : Bool :=
   List.range t.words.length |>.all λ i =>
     isInterval (projection t.deps i)
-
-/-- A dependency tree is well-formed if it satisfies all constraints. -/
-def isWellFormed (t : Tree) : Bool :=
-  hasUniqueHeads t &&
-  isAcyclic t &&
-  isProjective t &&
-  checkSubjVerbAgr t &&
-  checkDetNounAgr t &&
-  checkVerbSubcat t
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Valency.lean
+++ b/Linglib/Syntax/DependencyGrammar/Valency.lean
@@ -1,0 +1,97 @@
+import Linglib.Syntax.DependencyGrammar.Basic
+import Linglib.Syntax.Category.Verb.Frame
+
+/-!
+# Valency: argument-structure frames over dependency trees
+
+The DG valency layer: standard frame schemas for the basic valences, the
+map from a verb's lexical `ComplementType` into them, and satisfaction of
+a frame by a tree's dependents. [hudson-2010], [osborne-2019].
+
+The slot data types (`Dir`, `ArgSlot`, `ArgStr`) live in `Basic` because
+`Tree.frames` carries them; this file owns everything that *does* something
+with a frame, and with it the only import of the verb lexicon.
+
+## Main declarations
+
+* `argStrV0/VN/VNN/VPassive` — frame schemas for the standard intransitive /
+  transitive / ditransitive / passive valences.
+* `complementToArgStr` — a verb's lexical complement type as a frame.
+* `satisfiesArgStr`, `checkVerbSubcat` — frame satisfaction: every filler on
+  its slot's side of the head, required slots filled, no unlicensed core
+  arguments.
+-/
+
+namespace DependencyGrammar
+
+section StandardArgStr
+
+/-- Intransitive verb: subject to the left. -/
+def argStrV0 : ArgStr := [⟨.nsubj, .left, true⟩]
+
+/-- Transitive verb: subject left, object right. -/
+def argStrVN : ArgStr := [⟨.nsubj, .left, true⟩, ⟨.obj, .right, true⟩]
+
+/-- Ditransitive verb: subject left, indirect object right, object right. -/
+def argStrVNN : ArgStr :=
+  [⟨.nsubj, .left, true⟩, ⟨.iobj, .right, true⟩, ⟨.obj, .right, true⟩]
+
+/-- Passive transitive: subject left (was patient), optional by-phrase right. -/
+def argStrVPassive : ArgStr := [⟨.nsubj, .left, true⟩, ⟨.obl, .right, false⟩]
+
+/-- Map a complement type to the corresponding standard DG argument structure.
+    Returns `none` for frames without a standard schema: clause-embedding
+    types take xcomp/ccomp, not obj, and `.np_pp` has no fixture here. -/
+def complementToArgStr : ComplementType → Option ArgStr
+  | .none => some argStrV0
+  | .np => some argStrVN
+  | .np_np => some argStrVNN
+  | _ => none
+
+end StandardArgStr
+
+section ArgStrSatisfaction
+
+/-- The dependency `d` fills `slot` at head position `headIdx` (relation and
+    head match; direction is checked separately by `Dir.admits`). -/
+def slotMatches (headIdx : Nat) (slot : ArgSlot) (d : Dependency) : Bool :=
+  d.headIdx == headIdx && d.depType == slot.depType
+
+/-- The tree satisfies an argument structure at `headIdx`: every filler of
+    every slot sits on the slot's side of the head, and required slots are
+    filled. -/
+def satisfiesArgStr (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
+  argStr.all λ slot =>
+    (t.deps.filter (slotMatches headIdx slot)).all
+      (λ d => slot.dir.admits headIdx d.depIdx) &&
+    (!slot.required || t.deps.any (slotMatches headIdx slot))
+
+/-- Core argument relations governed by lexical frames. Deliberately the
+    nominal core only — UD's clausal core relations (csubj, ccomp, xcomp)
+    are licensed by clause-embedding frames, which `complementToArgStr`
+    does not schematize. -/
+private def coreArgRels : List UD.DepRel := [.nsubj, .obj, .iobj]
+
+/-- Every core-argument dependent of `headIdx` is licensed by a slot of
+    `argStr` — the closed-world half of frame checking (`satisfiesArgStr`
+    only checks that required slots are filled). -/
+private def coreArgsLicensed (t : Tree) (headIdx : Nat) (argStr : ArgStr) : Bool :=
+  t.deps.all λ d =>
+    if d.headIdx == headIdx && coreArgRels.contains d.depType then
+      argStr.any (·.depType == d.depType)
+    else true
+
+/-- Check each verb's dependents against its lexical frame: required slots
+    filled in the right direction (`satisfiesArgStr`) and no unlicensed core
+    arguments (`coreArgsLicensed`). Verbs without a frame are skipped. -/
+def checkVerbSubcat (t : Tree) : Bool :=
+  t.words.zipIdx.all λ (w, i) =>
+    if w.cat == .VERB then
+      match t.frame i with
+      | some a => satisfiesArgStr t i a && coreArgsLicensed t i a
+      | none => true
+    else true
+
+end ArgStrSatisfaction
+
+end DependencyGrammar

--- a/Linglib/Syntax/WordGrammar/LexicalRules.lean
+++ b/Linglib/Syntax/WordGrammar/LexicalRules.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.DependencyGrammar.Basic
+import Linglib.Syntax.DependencyGrammar.Valency
 
 /-!
 # Lexical Rules for Word Grammar [hudson-2010]
@@ -39,18 +39,14 @@ structure LexEntry where
 -- ============================================================================
 -- Auxiliary Argument Structures (DG-specific, used with LexEntry/lexical rules)
 -- Standard frames (argStrV0, argStrVN, argStrVNN, argStrVPassive) and
--- satisfiesArgStr are in Core/Basic.lean.
+-- satisfiesArgStr are in Syntax/DependencyGrammar/Valency.lean.
 -- ============================================================================
 
 /-- Auxiliary verb (non-inverted): subject left, main verb right -/
-def argStr_Aux : ArgStr :=
-  { slots := [⟨.nsubj, .left, true, some .DET⟩,
-              ⟨.aux, .right, true, some .VERB⟩] }
+def argStrAux : ArgStr := [⟨.nsubj, .left, true⟩, ⟨.aux, .right, true⟩]
 
 /-- Auxiliary verb (inverted): subject right, main verb right -/
-def argStr_AuxInv : ArgStr :=
-  { slots := [⟨.nsubj, .right, true, some .DET⟩,
-              ⟨.aux, .right, true, some .VERB⟩] }
+def argStrAuxInv : ArgStr := [⟨.nsubj, .right, true⟩, ⟨.aux, .right, true⟩]
 
 -- ============================================================================
 -- Lexical Rules
@@ -71,13 +67,12 @@ def auxInversionRule : LexRule :=
     applies := λ e =>
       e.cat == .AUX && !e.inv
     transform := λ e =>
-      let newSlots := e.argStr.slots.map λ slot =>
-        if slot.depType == .nsubj then
-          { slot with dir := .right }  -- subject now goes to the right
-        else slot
       { e with
         inv := true
-        argStr := { slots := newSlots } } }
+        argStr := e.argStr.map λ slot =>
+          if slot.depType == .nsubj then
+            { slot with dir := .right }  -- subject now goes to the right
+          else slot } }
 
 /-- Passive Rule: VN → V+passive
     Object is removed (promoted to subject), by-phrase added as optional -/
@@ -85,13 +80,11 @@ def passiveRule : LexRule :=
   { name := "Passive"
     applies := λ e =>
       e.cat == .VERB && e.features.voice != some .Pass &&
-      e.argStr.slots.any (·.depType == .obj)
+      e.argStr.any (·.depType == .obj)
     transform := λ e =>
-      let newSlots := e.argStr.slots.filter (·.depType != .obj)
-      let withByPhrase := newSlots ++ [⟨.obl, .right, false, some .ADP⟩]
       { e with
         features := { e.features with voice := some .Pass }
-        argStr := { slots := withByPhrase } } }
+        argStr := e.argStr.filter (·.depType != .obj) ++ [⟨.obl, .right, false⟩] } }
 
 -- ============================================================================
 -- Applying Lexical Rules

--- a/Linglib/Syntax/WordGrammar/Network.lean
+++ b/Linglib/Syntax/WordGrammar/Network.lean
@@ -2,7 +2,7 @@ import Linglib.Syntax.WordGrammar.Inheritance.Basic
 import Linglib.Syntax.WordGrammar.Inheritance.Default
 import Linglib.Semantics.Mood.Defs
 import Linglib.Syntax.Clause.Basic
-import Linglib.Syntax.DependencyGrammar.Basic
+import Linglib.Syntax.DependencyGrammar.Valency
 
 open Morphology (Word)
 
@@ -102,7 +102,7 @@ def resolveArgStr (net : WGNetwork) (wc : String)
       match resolveSlot net wc idx with
       | some slot => go (idx + 1) fuel' (slot :: acc)
       | none => acc.reverse
-  { slots := go 0 maxSlots [] }
+  go 0 maxSlots []
 
 -- ============================================================================
 -- Example: English Auxiliary Network
@@ -183,7 +183,7 @@ theorem network_aux_slot0 :
 /-- The network-derived arg structure for a transitive verb has the same
 slots as the manually defined `argStrVN`. -/
 theorem network_argStr_matches_manual :
-    (resolveArgStr englishAuxNet "transitive").slots =
+    resolveArgStr englishAuxNet "transitive" =
       [{ depType := .nsubj, dir := .left },
        { depType := .obj, dir := .right }] := by decide
 
@@ -215,14 +215,14 @@ theorem inverted_aux_inherits_main_verb_slot :
 /-- The full argument structure for the non-inverted auxiliary:
 nsubj/left (inherited from verb) + aux/right (local). -/
 theorem network_aux_argStr :
-    (resolveArgStr englishAuxNet "auxiliary").slots =
+    resolveArgStr englishAuxNet "auxiliary" =
       [{ depType := .nsubj, dir := .left },
        { depType := .aux, dir := .right }] := by decide
 
 /-- The full argument structure for the inverted auxiliary:
 nsubj/right (local override) + aux/right (inherited from auxiliary). -/
 theorem network_inverted_aux_argStr :
-    (resolveArgStr englishAuxNet "inverted_auxiliary").slots =
+    resolveArgStr englishAuxNet "inverted_auxiliary" =
       [{ depType := .nsubj, dir := .right },
        { depType := .aux, dir := .right }] := by decide
 


### PR DESCRIPTION
Third PR from the DepTree API audit: the Basic.lean deep dive.

- extracts the valency micro-theory (frame schemas, `complementToArgStr`, `satisfiesArgStr`, `checkVerbSubcat`) into `Valency.lean`, taking the verb-lexicon import with it — Basic.lean is now the graph carrier only
- `ParentEdge` is no longer an independent stipulation: it IS the adjacency of the `Digraph.mk'`-constructed `edgeDigraph`, with the ∃-form demoted to a `@[simp]` characterization and `DecidableRel` inherited from mathlib
- deletes the dead `ArgSlot.cat` field (write-only, and its only values were wrong), the zero-consumer `isWellFormed`, and `mkDetNVTree`; the three live fixture builders move to their sole consumer (Osborne2019)
- `ArgStr` becomes `abbrev List ArgSlot`; `Dir` gains its interpretation (`Dir.admits`); `satisfiesArgStr` gets uniform filler semantics; the two agreement checkers collapse into parametric `numberAgreesOn`