### PR TITLE
docs(Syntax/DependencyGrammar): license headers on the seven substrate files

### DIFF
--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Combinatorics.Digraph.Basic
 import Linglib.Data.UD.Basic

--- a/Linglib/Syntax/DependencyGrammar/Catena.lean
+++ b/Linglib/Syntax/DependencyGrammar/Catena.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.NonProjective
 
 /-!

--- a/Linglib/Syntax/DependencyGrammar/DependencyLength.lean
+++ b/Linglib/Syntax/DependencyGrammar/DependencyLength.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.Basic
 import Mathlib.Data.Nat.Dist
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic

--- a/Linglib/Syntax/DependencyGrammar/EnhancedDependencies.lean
+++ b/Linglib/Syntax/DependencyGrammar/EnhancedDependencies.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.Basic
 
 /-!

--- a/Linglib/Syntax/DependencyGrammar/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/NonProjective.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.Projection
 
 /-!

--- a/Linglib/Syntax/DependencyGrammar/Projection.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projection.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Core.Relation.ReflTransGen
 import Mathlib.Logic.Relation

--- a/Linglib/Syntax/DependencyGrammar/Valency.lean
+++ b/Linglib/Syntax/DependencyGrammar/Valency.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Syntax.Category.Verb.Frame
 


### PR DESCRIPTION
Adds the standard header to the seven files polished in the #1852 re-founding, per the file-by-file convention.