### PR TITLE
refactor(Syntax/DependencyGrammar): catena as SimpleGraph connectivity

### DIFF
--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -1,5 +1,7 @@
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Combinatorics.Digraph.Basic
+import Mathlib.Combinatorics.Digraph.Orientation
+import Mathlib.Combinatorics.SimpleGraph.Basic
 import Linglib.Data.UD.Basic
 import Linglib.Morphology.Word.Basic
 
@@ -19,8 +21,9 @@ artificial root token, following [kuhlmann-nivre-2006].
 * `Graph n` — a dependency graph on `n` words: vertex-labeling `words`,
   arc-labeling `label`, distinguished `root`. `Graph.Adj` is the induced
   adjacency (decidable), `Graph.toDigraph` the projection onto mathlib's
-  `Digraph`, and `Graph.ofArcs` the constructor from CoNLL-U-style arc
-  lists.
+  `Digraph`, `Linked` / `Graph.toSimpleGraph` its symmetrization (mathlib
+  `SimpleGraph`), and `Graph.ofArcs` the constructor from CoNLL-U-style
+  arc lists.
 * `Graph.parents`, `children`, `inDegree` — the local graph API.
 * Well-formedness (`Graph.IsTree`) lives in `Projection.lean`, beside the
   dominance relation it is stated through. Feature-level constraints
@@ -79,6 +82,14 @@ instance : Coe (Graph n) (Digraph (Fin n)) := ⟨toDigraph⟩
 theorem toDigraph_mono {g g' : Graph n} (h : ∀ v w, g.Adj v w → g'.Adj v w) :
     g.toDigraph ≤ g'.toDigraph := h
 
+/-- The graph's undirected view: mathlib's orientation-forgetting
+    `Digraph.toSimpleGraphInclusive` applied to `toDigraph`. Planarity and
+    catena connectivity are stated through it. -/
+def toSimpleGraph : SimpleGraph (Fin n) := g.toDigraph.toSimpleGraphInclusive
+
+instance : DecidableRel g.toSimpleGraph.Adj :=
+  inferInstanceAs (DecidableRel (SimpleGraph.fromRel g.Adj).Adj)
+
 /-- The head positions of `w`. -/
 def parents (w : Fin n) : List (Fin n) :=
   (List.finRange n).filter (g.Adj · w)
@@ -110,5 +121,15 @@ def ofArcs (words : List Word) (root : Fin words.length)
     root }
 
 end Graph
+
+/-- Positions linked by an arc in either direction — the unbundled adjacency
+    of `Graph.toSimpleGraph`, without its `≠` guard. -/
+def Linked {n : ℕ} (g : Graph n) (a b : Fin n) : Prop := g.Adj a b ∨ g.Adj b a
+
+instance {n : ℕ} (g : Graph n) (a b : Fin n) : Decidable (Linked g a b) :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+@[simp] theorem Graph.toSimpleGraph_adj {n : ℕ} (g : Graph n) (v w : Fin n) :
+    g.toSimpleGraph.Adj v w ↔ v ≠ w ∧ Linked g v w := Iff.rfl
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Catena.lean
+++ b/Linglib/Syntax/DependencyGrammar/Catena.lean
@@ -1,39 +1,66 @@
-import Linglib.Syntax.DependencyGrammar.NonProjective
+import Linglib.Syntax.DependencyGrammar.Projection
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Finite
 
 /-!
 # Catenae
 
-[osborne-gross-2012]'s catena — the unit of syntactic analysis larger than
-a word and looser than a constituent: a set of positions connected in the
-tree's undirected view. A constituent is the special case of a full
-dominance cone. Both are decidable, so fixtures close by `decide`; the
-general separation (every non-leaf position forms with a dependent a
-catena that is not a constituent) is ported with the study layer.
+[osborne-gross-2012]'s catena — a word or combination of words connected in
+the dependency tree's undirected view — as mathlib connectivity of the
+subgraph induced on the graph's symmetrization. A constituent — a full
+dominance cone — is a special case (`IsConstituent.isCatena`); the
+separation is witnessed by `decide` on the fixtures in
+`Studies/Osborne2019.lean`.
+
+`connected_induce_cone` is an `[UPSTREAM]` candidate for
+`Mathlib/Combinatorics/Digraph/Orientation.lean`: a vertex's
+`Relation.ReflTransGen`-forward-closure induces a connected subgraph of
+`Digraph.toSimpleGraphInclusive`, for any digraph — nothing in the
+statement or proof is specific to the dependency carrier.
 -/
 
 namespace DependencyGrammar
 
 variable {n : ℕ}
 
-/-- `s` is a **catena**: nonempty and connected under `Linked` within `s`.
-    ([osborne-gross-2012]) -/
+/-- `s` is a **catena** if the subgraph induced on `s` is connected. -/
 def IsCatena (g : Graph n) (s : Finset (Fin n)) : Prop :=
-  s.Nonempty ∧ ∀ v ∈ s, ∀ w ∈ s,
-    Relation.ReflTransGen (λ a b => Linked g a b ∧ a ∈ s ∧ b ∈ s) v w
+  (g.toSimpleGraph.induce ↑s).Connected
 
 /-- `s` is a **constituent**: exactly the dominance cone of some position. -/
 def IsConstituent (g : Graph n) (s : Finset (Fin n)) : Prop :=
   ∃ v, ∀ w, w ∈ s ↔ Dominates g v w
 
-instance (g : Graph n) (s : Finset (Fin n)) (v w : Fin n) :
-    Decidable (Relation.ReflTransGen (λ a b => Linked g a b ∧ a ∈ s ∧ b ∈ s) v w) :=
-  Relation.ReflTransGen.decidable_of_finite (List.finRange n)
-    (λ _ b _ => List.mem_finRange b) v w
-
 instance (g : Graph n) (s : Finset (Fin n)) : Decidable (IsCatena g s) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+  inferInstanceAs (Decidable (SimpleGraph.Connected _))
 
 instance (g : Graph n) (s : Finset (Fin n)) : Decidable (IsConstituent g s) :=
   inferInstanceAs (Decidable (∃ _, _))
+
+/-- Every single word is a catena. -/
+theorem singleton_isCatena (g : Graph n) (v : Fin n) : IsCatena g {v} := by
+  rw [IsCatena, Finset.coe_singleton]
+  exact .of_subsingleton
+
+/-- The dominance cone of a position induces a connected subgraph of the
+    undirected view: each dominated position is reached along its own
+    dominance path, which never leaves the cone. -/
+theorem connected_induce_cone (g : Graph n) (v : Fin n) :
+    (g.toSimpleGraph.induce {x | Dominates g v x}).Connected := by
+  refine (SimpleGraph.connected_iff_exists_forall_reachable _).mpr ⟨⟨v, .refl⟩, ?_⟩
+  rintro ⟨w, hw⟩
+  induction hw with
+  | refl => exact .rfl
+  | @tail b c hb hbc ih =>
+    rcases eq_or_ne b c with rfl | hne
+    · exact ih
+    · exact ih.trans (SimpleGraph.Adj.reachable ⟨hne, Or.inl hbc⟩)
+
+/-- Every constituent is a catena: a constituent is the dominance cone of
+    some position, and cones induce connected subgraphs. -/
+theorem IsConstituent.isCatena {g : Graph n} {s : Finset (Fin n)}
+    (h : IsConstituent g s) : IsCatena g s := by
+  obtain ⟨v, hv⟩ := h
+  rw [IsCatena, show (↑s : Set (Fin n)) = {x | Dominates g v x} from Set.ext hv]
+  exact connected_induce_cone g v
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/NonProjective.lean
+++ b/Linglib/Syntax/DependencyGrammar/NonProjective.lean
@@ -30,13 +30,6 @@ section Defs
 
 variable {n : ℕ}
 
-/-- Positions linked by an arc in either direction — the undirected view
-    under which planarity is stated. -/
-def Linked (g : Graph n) (a b : Fin n) : Prop := g.Adj a b ∨ g.Adj b a
-
-instance (g : Graph n) (a b : Fin n) : Decidable (Linked g a b) :=
-  inferInstanceAs (Decidable (_ ∨ _))
-
 /-- **Planarity**: no two links cross — spans, taken left-to-right, never
     strictly interleave. ([melcuk-1988]'s constraint; [kuhlmann-nivre-2006]
     §3.) -/


### PR DESCRIPTION
Grounds the DG undirected view in mathlib (`Graph.toSimpleGraph := g.toDigraph.toSimpleGraphInclusive`; `Linked` relocates to Basic beside it), redefines `IsCatena` as induced-subgraph connectivity with all decidability inferred from mathlib, and adds `singleton_isCatena` plus `IsConstituent.isCatena` via the `[UPSTREAM]`-candidate `connected_induce_cone`.