### PR TITLE
feat(Syntax/DependencyGrammar): dependency trees are RootedTrees

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -263,6 +263,7 @@ import Linglib.Core.Order.SetPreimage
 import Linglib.Core.Order.SignVectors
 import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Core.Order.StrictBounds
+import Linglib.Core.Order.SuccPred.Tree
 import Linglib.Core.Order.TotalPreorder
 import Linglib.Core.Order.Tree
 import Linglib.Core.Order.TreePath

--- a/Linglib/Core/Order/SuccPred/Tree.lean
+++ b/Linglib/Core/Order/SuccPred/Tree.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Order.SuccPred.Archimedean
+import Mathlib.Order.BoundedOrder.Basic
+import Mathlib.Data.Nat.Find
+
+/-!
+# Meets in bounded pred-archimedean orders
+
+`[UPSTREAM]` candidate for `Mathlib/Order/SuccPred/Tree.lean`: in a
+partial order with a bottom, predecessors, and archimedean descent —
+the unbundled data of a rooted tree — binary meets exist: `a ⊓ b` is
+the first `pred`-iterate of `a` that lies below `b`. `RootedTree`
+currently asks for `SemilatticeInf` as a field; on orders with
+decidable `≤` it is derivable.
+-/
+
+namespace IsPredArchimedean
+
+variable {α : Type*} [PartialOrder α] [PredOrder α] [IsPredArchimedean α]
+  [OrderBot α]
+
+/-- Some `pred`-iterate of `a` lies below `b`: descend all the way
+    to `⊥`. -/
+theorem exists_pred_iterate_le (a b : α) : ∃ i, Order.pred^[i] a ≤ b :=
+  ((bot_le (a := a)).exists_pred_iterate).imp λ _ h => (le_of_eq h).trans bot_le
+
+/-- Binary meets from archimedean descent: `a ⊓ b` is the first
+    `pred`-iterate of `a` below `b`. Not an instance: a type may
+    already carry a `SemilatticeInf` that this construction need not
+    match definitionally. -/
+@[reducible] def semilatticeInf [DecidableRel ((· ≤ ·) : α → α → Prop)] :
+    SemilatticeInf α where
+  inf a b := Order.pred^[Nat.find (exists_pred_iterate_le a b)] a
+  inf_le_left a b := Order.pred_iterate_le _ _
+  inf_le_right a b := Nat.find_spec (exists_pred_iterate_le a b)
+  le_inf c a b hca hcb := by
+    obtain ⟨j, hj⟩ := hca.exists_pred_iterate
+    have hfind : Nat.find (exists_pred_iterate_le a b) ≤ j :=
+      Nat.find_min' _ (hj ▸ hcb)
+    calc c = Order.pred^[j] a := hj.symm
+      _ = Order.pred^[j - Nat.find (exists_pred_iterate_le a b)]
+            (Order.pred^[Nat.find (exists_pred_iterate_le a b)] a) := by
+          rw [← Function.iterate_add_apply, Nat.sub_add_cancel hfind]
+      _ ≤ _ := Order.pred_iterate_le _ _
+
+end IsPredArchimedean

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -9,6 +9,8 @@ import Mathlib.Logic.Relation
 import Mathlib.Data.Fintype.Card
 import Mathlib.Order.SuccPred.Basic
 import Mathlib.Order.SuccPred.Archimedean
+import Mathlib.Order.SuccPred.Tree
+import Linglib.Core.Order.SuccPred.Tree
 
 /-!
 # Dominance
@@ -29,11 +31,11 @@ theory of dominance on trees ([kuhlmann-nivre-2006] §2).
 * `Dominates.antisymm`, `Dominates.to_head`, `Dominates.comparable` —
   on trees dominance is a partial order under which the dominators of
   any position form a chain.
-* `Graph.headOf`, `DominanceOrder` — the head function, and `Fin n`
-  re-ordered by dominance: with `[Fact g.IsTree]` a `PartialOrder` +
-  `OrderBot` + `PredOrder` + `IsPredArchimedean` (root as `⊥`, head as
-  `Order.pred`), the order-theoretic reading of a rooted dependency
-  tree (cf. mathlib's `RootedTree`).
+* `Graph.headOf`, `DominanceOrder`, `Graph.toRootedTree` — the head
+  function; `Fin n` re-ordered by dominance, with `[Fact g.IsTree]` a
+  `PartialOrder` + `OrderBot` + `PredOrder` + `IsPredArchimedean` +
+  `SemilatticeInf` (root as `⊥`, head as `Order.pred`, lowest common
+  governor as `⊓`); and the bundling as mathlib's `RootedTree`.
 
 ## Implementation notes
 
@@ -234,6 +236,10 @@ instance [Fact g.IsTree] : PredOrder (DominanceOrder g) where
       Dominates.to_head (Fact.out : g.IsTree) h.le h.ne
         ((Fact.out : g.IsTree).adj_headOf hw)
 
+instance [Fact g.IsTree] :
+    DecidableRel ((· ≤ ·) : DominanceOrder g → DominanceOrder g → Prop) :=
+  λ v w => inferInstanceAs (Decidable (Dominates g v w))
+
 instance [Fact g.IsTree] : IsPredArchimedean (DominanceOrder g) where
   exists_pred_iterate_of_le {a b} h := by
     have h' : Relation.ReflTransGen g.Adj a b := h
@@ -246,7 +252,18 @@ instance [Fact g.IsTree] : IsPredArchimedean (DominanceOrder g) where
       rw [Function.iterate_succ_apply]
       exact (show Order.pred d = c from (Fact.out : g.IsTree).headOf_eq hcd) ▸ hk
 
+/-- Lowest common governor as the meet: the first head-iterate of one
+    argument that dominates the other. -/
+instance [Fact g.IsTree] : SemilatticeInf (DominanceOrder g) :=
+  IsPredArchimedean.semilatticeInf
+
 end DominanceOrder
+
+/-- A well-formed dependency graph, as mathlib's rooted tree: positions
+    ordered by dominance, the root as `⊥`, the head as `Order.pred`,
+    and the lowest common governor as `⊓`. -/
+def Graph.toRootedTree (g : Graph n) [Fact g.IsTree] : RootedTree :=
+  { α := DominanceOrder g }
 
 end Dominance
 


### PR DESCRIPTION
Closes the order-theoretic story: `Core/Order/SuccPred/Tree.lean` (`[UPSTREAM]` candidate) derives `SemilatticeInf` for bounded pred-archimedean orders with decidable `≤` — `a ⊓ b` is the first `pred`-iterate of `a` below `b`, which mathlib's `RootedTree` currently asks for as data. `DominanceOrder g` inherits it (lowest common governor as `⊓`), and `Graph.toRootedTree` bundles a well-formed dependency graph as mathlib's `RootedTree`.