### PR TITLE
refactor(Semantics/Focus): Set-based Particles; cut dead API

### DIFF
--- a/Linglib/Pragmatics/DecisionTheoretic/Even.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/Even.lean
@@ -1,15 +1,14 @@
 import Linglib.Pragmatics.DecisionTheoretic.Basic
 import Linglib.Pragmatics.DecisionTheoretic.But
-import Linglib.Semantics.Focus.Particles
 
 /-!
 # Decision-Theoretic Semantics: "Even" ([merin-1999-relevance] §5)
-[francescotti-1995] [kay-1990] [merin-1999-relevance]
 
 Merin's DTS account of the scalar particle "even". The felicity of
 "A CONJ even(B)" requires B to be *more* relevant than A, resolving the
-dispute between Anscombre (argumentative value), Kay (contextual entailment),
-and Francescotti (surprise) under a single relevance ordering.
+dispute between Anscombre (argumentative value), [kay-1990] (contextual
+entailment), and [francescotti-1995] (surprise) under a single
+relevance ordering.
 
 ## Key Definitions
 
@@ -79,27 +78,5 @@ theorem but_even_incompatible (ctx : DTSContext W) (a b : Set W)
   linarith
 
 end Predictions
-
--- ============================================================
--- Section 3: Bridge to Focus Particle Semantics
--- ============================================================
-
-/-- DTS Bayes factor ordering as a likelihood ordering for focus particles.
-
-    Higher BF = more informative about the issue = less likely a priori =
-    more surprising. This connects Merin's relevance ordering to the
-    traditional EVEN presupposition framework in `Focus.Particles`.
-
-    [merin-1999-relevance] subsumes [francescotti-1995]'s "surprise" and
-    [kay-1990]'s "informativeness" as special cases of signed relevance.
-
-    Note: `LikelihoodOrder` operates on `World → Bool` functions (the
-    upstream Focus.Particles interface). We embed each Bool predicate
-    into a Prop predicate via `· = true` to apply `bayesFactor`. -/
-def dtsLikelihood {W : Type} [Fintype W] (ctx : DTSContext W) :
-    Focus.Particles.LikelihoodOrder W :=
-  fun a b =>
-    bayesFactor ctx ({w | a w = true} : Set W) >
-      bayesFactor ctx ({w | b w = true} : Set W)
 
 end DTS.Even

--- a/Linglib/Semantics/Focus/Particles.lean
+++ b/Linglib/Semantics/Focus/Particles.lean
@@ -1,135 +1,45 @@
 import Mathlib.Data.Set.Basic
-import Linglib.Semantics.Entailment.NaturalLogic
 
 /-!
 # Focus-sensitive particles: even and only
 
-Traditional truth-conditional semantics for focus-sensitive particles
-(*even*, *only*), with NPI licensing derived from the scalar
-presupposition of *even*.
+Truth-conditional semantics for the focus particles *even* and *only*,
+with propositions as `Set World`. *Even*'s scalar presupposition
+([karttunen-peters-1979]) requires the prejacent to be less likely than
+every focus alternative; *only*'s assertion ([rooth-1992]) excludes
+every alternative; and `LikelihoodMonotone` — a likelihood ordering
+respecting entailment — is the property from which [lahiri-1998]
+derives the distribution of *even one* NPIs (cf. [crnic-2014]).
+[francescotti-1995] weakens the presupposition's universal force to a
+majority threshold — see `Studies/Francescotti1995.lean`.
 
 ## Main definitions
 
-* `FocusStructure α`: alternative-semantics pair of an ordinary value
-  and a list of alternatives.
-* `LikelihoodOrder W`: relation on `W → Bool` predicates expressing
-  context-dependent likelihood.
-* `TraditionalEven`, `TraditionalOnly`: bundled semantics of *even*
-  and *only*.
-* `npiLicensed`: NPI licensing condition keyed on `ContextPolarity`.
-* `LikelihoodMonotone`: monotonicity of a likelihood ordering with
-  respect to entailment.
-
-## References
-
-* [lahiri-1998], [crnic-2014], [karttunen-peters-1979],
-  [francescotti-1995], [rooth-1992].
+* `evenPresup`: the prejacent is less likely than every alternative.
+* `onlyAssertion`: no focus alternative holds.
+* `LikelihoodMonotone`: entailment-monotonicity of a likelihood
+  ordering.
 -/
 
 namespace Focus.Particles
 
-variable {World Entity : Type*}
+variable {World : Type*}
 
-/-- Alternative-semantics pair: an ordinary value plus a list of
-alternatives. -/
-structure FocusStructure (α : Type*) where
-  /-- The ordinary semantic value. -/
-  ordinary : α
-  /-- The focus alternatives. -/
-  alternatives : List α
+/-- The scalar presupposition of *even* ([karttunen-peters-1979]): the
+prejacent `p` is less likely than every focus alternative, where
+`r p q` reads "`p` is less likely than `q`". -/
+def evenPresup (r : Set World → Set World → Prop) (p : Set World)
+    (alts : List (Set World)) : Prop :=
+  ∀ q ∈ alts, r p q
 
-/-- Context-dependent likelihood ordering on `World → Bool` predicates.
-`lo a b` holds when `a` is less likely (more surprising) than `b`. -/
-def LikelihoodOrder (World : Type*) := (World → Bool) → (World → Bool) → Prop
+/-- The assertion of *only*: no focus alternative holds. The prejacent
+is presupposed separately; the alternative list excludes it. -/
+def onlyAssertion (alts : List (Set World)) : Set World :=
+  {w | ∀ q ∈ alts, w ∉ q}
 
-/-- Traditional EVEN semantics -/
-structure TraditionalEven where
-  /-- The prejacent proposition -/
-  prejacent : (World → Bool)
-  /-- Focus alternatives -/
-  alternatives : List ((World → Bool))
-  /-- Likelihood ordering -/
-  likelihood : LikelihoodOrder World
-
-/-- EVEN asserts the prejacent -/
-def TraditionalEven.assertion (even : TraditionalEven (World := World)) : (World → Bool) :=
-  even.prejacent
-
-/-- EVEN presupposes prejacent is least likely.
-    This is [karttunen-peters-1979]'s universal threshold: the prejacent
-    must be less likely than ALL alternatives. [francescotti-1995] argues
-    this is too strong — see the revised most-threshold in
-    `Studies/Francescotti1995.lean`. -/
-def TraditionalEven.presupposition (even : TraditionalEven (World := World)) : Prop :=
-  ∀ alt ∈ even.alternatives, even.likelihood even.prejacent alt
-
-/-- EVEN is defined (presupposition satisfied) -/
-def TraditionalEven.defined (even : TraditionalEven (World := World)) : Prop :=
-  even.presupposition
-
-/-- Full EVEN meaning: defined and true -/
-def TraditionalEven.trueAt (even : TraditionalEven (World := World)) (w : World) : Prop :=
-  even.defined ∧ even.prejacent w
-
-open NaturalLogic (ContextPolarity)
-
-/-- NPI licensing condition: EVEN presupposition must be satisfiable.
-    Uses `ContextPolarity` from `NaturalLogic`. -/
-def npiLicensed (pol : ContextPolarity) (npiDomain : Set Entity) (regularDomain : Set Entity)
-    (_hWider : regularDomain ⊆ npiDomain) : Prop :=
-  match pol with
-  | .downward =>
-      -- In DE: wider domain → less likely (after negation applies)
-      -- So NPI (wide domain) satisfies EVEN's "least likely" presupposition
-      True
-  | .upward =>
-      -- In UE: wider domain → more likely
-      -- NPI would violate EVEN's presupposition
-      False
-  | .nonMonotonic =>
-      -- Non-monotonic contexts (e.g., "exactly three") don't license NPIs
-      False
-
-/-- NPI licensed in DE contexts -/
-theorem npi_licensed_de (npiDomain regularDomain : Set Entity)
-    (hWider : regularDomain ⊆ npiDomain) :
-    npiLicensed .downward npiDomain regularDomain hWider = True := rfl
-
-/-- NPI unlicensed in UE contexts -/
-theorem npi_unlicensed_ue (npiDomain regularDomain : Set Entity)
-    (hWider : regularDomain ⊆ npiDomain) :
-    npiLicensed .upward npiDomain regularDomain hWider = False := rfl
-
-/-- NPI unlicensed in non-monotonic contexts -/
-theorem npi_unlicensed_nonmon (npiDomain regularDomain : Set Entity)
-    (hWider : regularDomain ⊆ npiDomain) :
-    npiLicensed .nonMonotonic npiDomain regularDomain hWider = False := rfl
-
-/-- Traditional "only" semantics -/
-structure TraditionalOnly where
-  /-- The prejacent (the focused element's contribution) -/
-  prejacent : (World → Bool)
-  /-- The alternatives (what focus evokes) -/
-  alternatives : List ((World → Bool))
-
-/-- "only" presupposes the prejacent -/
-def TraditionalOnly.presupposition (only : TraditionalOnly (World := World)) : (World → Bool) :=
-  only.prejacent
-
-/-- "only" asserts no alternative is true.
-    The alternatives list excludes the prejacent (Roothian focus alternatives
-    minus the focused element's contribution). -/
-def TraditionalOnly.assertion (only : TraditionalOnly (World := World)) : (World → Bool) :=
-  λ w => only.alternatives.all (λ alt => !alt w)
-
-/-- Full "only" meaning -/
-def TraditionalOnly.trueAt (only : TraditionalOnly (World := World)) (w : World) : Prop :=
-  only.prejacent w ∧ only.assertion w
-
-/-- A likelihood ordering is monotone with respect to entailment when a
-stronger proposition (true at fewer worlds) is less likely than a weaker
-one. -/
-def LikelihoodMonotone {W : Type*} (lessLikely : (W → Bool) → (W → Bool) → Prop) : Prop :=
-  ∀ (p q : (W → Bool)), (∀ w, p w = true → q w = true) → lessLikely p q
+/-- A likelihood ordering respects entailment: a stronger proposition
+is at most as likely. -/
+def LikelihoodMonotone (r : Set World → Set World → Prop) : Prop :=
+  ∀ ⦃p q : Set World⦄, p ⊆ q → r p q
 
 end Focus.Particles

--- a/Linglib/Studies/Francescotti1995.lean
+++ b/Linglib/Studies/Francescotti1995.lean
@@ -24,7 +24,7 @@ vagueness of "most".
 
 namespace Francescotti1995
 
-open Focus.Particles (TraditionalEven)
+open Focus.Particles (evenPresup)
 
 /-! ### The three threshold conditions -/
 
@@ -73,11 +73,10 @@ theorem evenPresupWith_universal_iff :
   simp [evenPresupWith, countExceeded, List.countP_eq_length]
 
 /-- The universal threshold coincides with the traditional scalar
-presupposition of *even* (`Focus.Particles.TraditionalEven`). -/
-theorem traditionalEven_presup_iff_universal {W : Type*}
-    (te : TraditionalEven (World := W)) [DecidableRel te.likelihood] :
-    te.presupposition ↔
-      evenPresupWith te.prejacent te.alternatives te.likelihood .universal :=
+presupposition of *even* (`Focus.Particles.evenPresup`). -/
+theorem evenPresup_iff_universal {W : Type*}
+    (r : Set W → Set W → Prop) [DecidableRel r] (p : Set W) (alts : List (Set W)) :
+    evenPresup r p alts ↔ evenPresupWith p alts r .universal :=
   (evenPresupWith_universal_iff ..).symm
 
 /-! ### The two counterexamples (§I, pp. 155–156) -/

--- a/Linglib/Studies/Lahiri1998.lean
+++ b/Linglib/Studies/Lahiri1998.lean
@@ -38,7 +38,7 @@ does not.
 
 namespace Lahiri1998
 
-open Focus.Particles (TraditionalEven LikelihoodOrder LikelihoodMonotone)
+open Focus.Particles (evenPresup LikelihoodMonotone)
 open Entailment (World allWorlds entails pnot)
 open Semantics.Polarity
 
@@ -263,55 +263,30 @@ theorem de_not_reverse :
 end ImplicatureClash
 
 -- ============================================================================
--- §6. End-to-End: TraditionalEven Instances
+-- §6. End-to-End: the EVEN presupposition on the cardinality model
 -- ============================================================================
 
-/-! We build `TraditionalEven` instances for *ek bhii* in UE and DE contexts,
-    connecting the cardinality model to the `Particles.lean` API.
+/-! The cardinality model plugged into the `Focus.Particles` API.
 
-    In UE: `atLeastOne` is the prejacent, `[atLeastTwo, atLeastThree]` are
-    alternatives. The presupposition requires `atLeastOne` to be less likely
-    than each alternative — but since each alternative entails `atLeastOne`,
-    the opposite holds under any monotone likelihood ordering.
+    In UE: `atLeastOne` is the prejacent, `[atLeastTwo, atLeastThree]` the
+    alternatives. `evenPresup` requires `atLeastOne` to be less likely than
+    each alternative — but each alternative entails `atLeastOne`, so the
+    opposite holds under any monotone likelihood ordering.
 
     In DE: `pnot atLeastOne` is the prejacent. The assertion entails each
     negated alternative, so the prejacent IS the least likely. -/
 
-/-- EVEN instance for *ek bhii aayaa ('*Even one came') in UE context. -/
-def ekBhiiEvenUE : TraditionalEven (World := World) :=
-  { prejacent := atLeastOneB
-  , alternatives := [atLeastTwoB, atLeastThreeB]
-  , likelihood := λ _ _ => True }  -- placeholder; clash proved independently
-
-/-- EVEN instance for *ek bhii nahiiN aayaa* ('Not even one came') in DE. -/
-def ekBhiiEvenDE : TraditionalEven (World := World) :=
-  { prejacent := λ w => !atLeastOneB w
-  , alternatives := [λ w => !atLeastTwoB w, λ w => !atLeastThreeB w]
-  , likelihood := λ _ _ => True }  -- placeholder; satisfaction proved independently
-
-/-- In UE, the EVEN presupposition for *ek bhii* is contradicted:
-    every alternative entails the assertion, so under any monotone likelihood
-    ordering the assertion cannot be strictly less likely than its alternatives.
-
-    This is the abstract version of the paper's argument (§7.4, eqs. 68–71). -/
+/-- In UE, the EVEN presupposition for *ek bhii* is contradicted: each
+    alternative entails the assertion, so under any monotone likelihood
+    ordering the assertion cannot be strictly less likely (§7.4,
+    eqs. 68–71). -/
 theorem ekBhii_even_clash_UE
-    (lt : (World → Bool) → (World → Bool) → Prop)
-    (le : (World → Bool) → (World → Bool) → Prop)
+    (lt le : Set World → Set World → Prop)
     (hMono : LikelihoodMonotone le)
-    (hCompat : ∀ (a b : (World → Bool)), lt a b → le b a → False)
-    (alt : (World → Bool))
-    (hAlt : alt = atLeastTwoB ∨ alt = atLeastThreeB)
-    (hEven : lt atLeastOneB alt) :
-    False := by
-  cases hAlt with
-  | inl h =>
-    exact hCompat atLeastOneB alt hEven
-      (hMono alt atLeastOneB
-        (by subst h; intro w; cases w <;> simp [atLeastOneB, atLeastTwoB]))
-  | inr h =>
-    exact hCompat atLeastOneB alt hEven
-      (hMono alt atLeastOneB
-        (by subst h; intro w; cases w <;> simp [atLeastOneB, atLeastThreeB]))
+    (hCompat : ∀ a b, lt a b → le b a → False)
+    (hEven : evenPresup lt atLeastOne [atLeastTwo, atLeastThree]) :
+    False :=
+  hCompat _ _ (hEven atLeastTwo (by simp)) (hMono two_entails_one)
 
 /-- In DE, the EVEN presupposition for *ek bhii nahiiN* is satisfiable:
     the negated assertion entails each negated alternative, so the assertion
@@ -328,21 +303,18 @@ theorem ekBhii_even_ok_DE :
 -- ============================================================================
 
 /-- An EVEN scalar implicature is CONTRADICTED when the assertion is entailed
-    by all alternatives. Under `LikelihoodMonotone`, each alternative is
-    then at most as likely as the assertion, but EVEN requires the assertion
-    to be strictly less likely than each alternative. -/
-theorem even_clash_abstract
-    {W : Type}
-    (lt : (W → Bool) → (W → Bool) → Prop)
-    (le : (W → Bool) → (W → Bool) → Prop)
-    (hMono : ∀ (p q : (W → Bool)), (∀ w, p w = true → q w = true) → le p q)
-    (hCompat : ∀ (a b : (W → Bool)), lt a b → le b a → False)
-    (assertion : (W → Bool))
-    (alt : (W → Bool))
-    (hEntails : ∀ w, alt w = true → assertion w = true)
+    by an alternative. Under `LikelihoodMonotone`, the alternative is then
+    at most as likely as the assertion, but EVEN requires the assertion to
+    be strictly less likely. -/
+theorem even_clash_abstract {W : Type*}
+    (lt le : Set W → Set W → Prop)
+    (hMono : LikelihoodMonotone le)
+    (hCompat : ∀ a b, lt a b → le b a → False)
+    {assertion alt : Set W}
+    (hEntails : alt ⊆ assertion)
     (hEven : lt assertion alt) :
     False :=
-  hCompat assertion alt hEven (hMono alt assertion hEntails)
+  hCompat assertion alt hEven (hMono hEntails)
 
 -- ============================================================================
 -- §8. Hindi NPI Data (§4)

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -222,22 +222,14 @@ theorem direct_only_unsatisfiable :
   simp only [Focus.mem_onlyVia, Set.mem_empty_iff_false, iff_false]
   exact fun hw => hne (hw trivialR (by simp) (Set.mem_univ w))
 
-private def readingB : RWorld → Bool
-  | .readOnly | .readAndGrasp => true
-  | .neither => false
-private def graspingB : RWorld → Bool
-  | .readAndGrasp => true
-  | _ => false
-private def trivialB : RWorld → Bool := fun _ => true
-
-/-- The same over-generation exhibited on `TraditionalOnly` itself:
-    with a lexically carried full alternative list its assertion is
-    everywhere false in this model, and no pragmatic narrowing is
-    possible — the list is fixed in the lexical entry. -/
-theorem traditional_only_unsatisfiable (w : RWorld) :
-    (Focus.Particles.TraditionalOnly.mk
-      readingB [graspingB, trivialB]).assertion w = false := by
-  cases w <;> rfl
+/-- The same over-generation on the lexical semantics of *only*: with
+    the full focus value carried as a lexical alternative list, the
+    assertion is unsatisfiable, and no pragmatic narrowing is possible
+    — the list is fixed in the lexical entry. -/
+theorem lexical_only_unsatisfiable :
+    Focus.Particles.onlyAssertion [grasping, trivialR] = (∅ : Set RWorld) := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  exact fun w hw => hw trivialR (by simp) (Set.mem_univ w)
 
 /-! ### Association with *only*
 


### PR DESCRIPTION
Mathlib treatment of `Focus/Particles.lean`: propositions as `Set World`, unbundled `evenPresup`/`onlyAssertion`/`LikelihoodMonotone` (the surface consumers actually use); deletes dead `FocusStructure`, `npiLicensed` + vacuous rfl theorems, `LikelihoodOrder` alias, `TraditionalEven/Only` bundles, and DTS's unconsumed `dtsLikelihood` bridge.

- Lahiri1998: placeholder-likelihood instances deleted; clash theorems restated over Sets, now consuming `evenPresup` and the §4 entailment lemmas
- Rooth1992: Bool shadow defs deleted; unsatisfiability restated on its own Sets
- Francescotti1995: bridge retargeted (`evenPresup_iff_universal`)