### PR TITLE
feat(Fragments/Hindi): Lahiri-verified bhii paradigm; fix koii bhii

### DIFF
--- a/Linglib/Fragments/Hindi/PolarityItems.lean
+++ b/Linglib/Fragments/Hindi/PolarityItems.lean
@@ -2,24 +2,24 @@ import Linglib.Semantics.Polarity.Licensing
 
 /-!
 # Hindi Polarity-Sensitive Items
-[haspelmath-1997]
 
-Hindi indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
-
-Hindi builds polarity items from the general indefinite *koii* + particles:
-- **koii nahiiN**: koii + negation → NPI (nobody)
-- **koii bhii**: koii + bhii (even/also) → FCI (anyone at all)
+Hindi builds NPIs from weak indefinites plus the particle *bhii* 'even'
+([lahiri-1998] (1), p. 58): *koii bhii* 'anyone', *ek bhii* 'even one',
+*kuch bhii* 'anything', *zaraa bhii* 'even a little', *kabhii bhii*
+'ever'. All are dual NPI/FC items — strength-licensed in DE contexts,
+free-choice in generics and possibility modals but not necessity modals
+([lahiri-1998] §5) — and the cardinality-alternative items (*ek bhii*,
+*zaraa bhii*) resist imperatives (§5.4). *koii nahiiN* is the
+indefinite + negation route. Attested contexts follow [lahiri-1998]
+§4–5; cf. [haspelmath-1997] on the *koii* series.
 -/
 
 namespace Hindi.PolarityItems
 
 open Semantics.Polarity
 
-/-! ### NPI -/
-
-/-- *koii nahiiN* — Negative indefinite.
-    koii + negation: 'koii nahiiN aayaa' (nobody came). -/
+/-- *koii nahiiN* — negative indefinite, koii + negation:
+'koii nahiiN aayaa' (nobody came). -/
 def koiiNahiin : Item :=
   { form := "koii nahiiN"
   , licensor := some .weak
@@ -29,24 +29,84 @@ def koiiNahiin : Item :=
   , morphology := .indefPlusNeg
   , alternativeType := .contextualProperty }
 
-/-! ### FCI -/
-
-/-- *koii bhii* — Free choice item.
-    koii + bhii (even/also): 'koii bhii yah kar saktaa hai'
-    (anyone can do this). [lahiri-1998] -/
+/-- *koii bhii* 'anyone' — dual NPI/FCI with contextual-property
+alternatives ([lahiri-1998] (6), (10)–(12), (29), (31b), (32), (34) for
+the DE uses; (35), (36b), (39b) for free choice; necessity modals are
+out, (36d)). -/
 def koiiBhii : Item :=
   { form := "koii bhii"
+  , licensor := some .weak
   , freeChoice := true
   , baseForce := .existential
-  , licensingContexts := [.modalPossibility, .modalNecessity, .imperative, .generic]
+  , licensingContexts :=
+      [.negation, .conditionalAntecedent, .universalRestrictor, .adversative,
+       .denyVerb, .beforeClause, .question, .generic, .modalPossibility,
+       .imperative]
   , morphology := .indefPlusEven
   , alternativeType := .contextualProperty }
 
-/-! ### Verification -/
+/-- *ek bhii* 'even one' — dual NPI/FCI with cardinality alternatives;
+degraded in imperatives ([lahiri-1998] (7), (10d), (11a), (29a), (29f),
+(34b), (35d), (36a); imperative (40b)). -/
+def ekBhii : Item :=
+  { form := "ek bhii"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts :=
+      [.negation, .conditionalAntecedent, .universalRestrictor, .adversative,
+       .denyVerb, .question, .generic, .modalPossibility]
+  , morphology := .indefPlusEven
+  , alternativeType := .cardinality }
+
+/-- *kuch bhii* 'anything, any (mass)' ([lahiri-1998] (8), (10f), (34c),
+(35c), (39a)). -/
+def kuchBhii : Item :=
+  { form := "kuch bhii"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts :=
+      [.negation, .conditionalAntecedent, .question, .generic, .imperative]
+  , morphology := .indefPlusEven
+  , alternativeType := .contextualProperty }
+
+/-- *zaraa bhii* 'even a little' — measure (cardinality) alternatives;
+degraded in imperatives ([lahiri-1998] (9), (10e), §4.5, (34d), (35e);
+imperative (40a)). -/
+def zaraaBhii : Item :=
+  { form := "zaraa bhii"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts :=
+      [.negation, .conditionalAntecedent, .adversative, .question, .generic]
+  , morphology := .indefPlusEven
+  , alternativeType := .cardinality }
+
+/-- *kabhii bhii* 'ever, anytime' ([lahiri-1998] (36c)). -/
+def kabhiiBhii : Item :=
+  { form := "kabhii bhii"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts := [.modalPossibility]
+  , morphology := .indefPlusEven
+  , alternativeType := .contextualProperty }
+
+/-- The *bhii*-compound entries. -/
+def bhiiItems : List Item := [koiiBhii, ekBhii, kuchBhii, zaraaBhii, kabhiiBhii]
 
 /-- Every attested context of every entry is predicted licensed. -/
 theorem hindi_licensing_sound :
-    ∀ e ∈ [koiiNahiin, koiiBhii], ∀ c ∈ e.licensingContexts, c.licenses e := by
+    ∀ e ∈ koiiNahiin :: bhiiItems, ∀ c ∈ e.licensingContexts, c.licenses e := by
   decide
+
+/-- The *bhii*-compounds are uniformly indefinite + *even* dual
+NPI/FC items. -/
+theorem bhii_items_uniform :
+    ∀ e ∈ bhiiItems,
+      e.morphology = .indefPlusEven ∧ e.licensor = some .weak ∧
+        e.freeChoice = true := by decide
 
 end Hindi.PolarityItems

--- a/Linglib/Studies/Lahiri1998.lean
+++ b/Linglib/Studies/Lahiri1998.lean
@@ -28,31 +28,31 @@ open Focus.Particles (evenPresup LikelihoodMonotone)
 open Entailment (World entails pnot)
 open Semantics.Polarity
 
-/-! ### Morphological decomposition (paper p. 58)
+/-! ### Morphological decomposition (paper (1), p. 58)
 
-Every item in the paradigm is a weak indefinite plus *bhii*; the kind
+Every item in the paradigm is a weak indefinite plus *bhii*. The kind
 of alternatives an item activates (cardinality vs contextually salient
-properties, §8) is a lexical property. -/
+properties, §8) is a lexical property, stored on the fragment entries
+in `Hindi.PolarityItems`. (*kahiiN bhii*'s licensed uses in the paper
+are correlatives, §4.4, an environment not modeled here.) -/
 
-/-- A row of the paper's decomposition table: base indefinite, the
-*bhii*-compound, and the alternative type the item activates. -/
+/-- A row of the paper's decomposition table (1): base indefinite and
+the *bhii*-compound, with the paper's glosses. -/
 structure NPIDecomposition where
   base : String
   baseGloss : String
   npiForm : String
   npiGloss : String
-  alternativeType : AlternativeType
   deriving Repr
 
-/-- The paper's decomposition table (p. 58): *ek*/*zaraa* activate
-cardinality (measure) alternatives, the others contextual properties. -/
+/-- The paper's decomposition table ((1), p. 58). -/
 def hindiNPIs : List NPIDecomposition :=
-  [ ⟨"ek", "one", "ek bhii", "any, even one", .cardinality⟩
-  , ⟨"koii", "someone", "koii bhii", "anyone", .contextualProperty⟩
-  , ⟨"kuch", "something (mass)", "kuch bhii", "anything", .contextualProperty⟩
-  , ⟨"zaraa", "a little", "zaraa bhii", "even a little", .cardinality⟩
-  , ⟨"kabhii", "sometime", "kabhii bhii", "ever, anytime", .contextualProperty⟩
-  , ⟨"kahiiN", "somewhere", "kahiiN bhii", "anywhere", .contextualProperty⟩ ]
+  [ ⟨"ek", "one", "ek bhii", "any, even one"⟩
+  , ⟨"koii", "someone", "koii bhii", "anyone, any (count)"⟩
+  , ⟨"kuch", "something, a little", "kuch bhii", "anything, any (mass)"⟩
+  , ⟨"zaraa", "a little", "zaraa bhii", "even a little"⟩
+  , ⟨"kabhii", "sometime", "kabhii bhii", "anytime, ever"⟩
+  , ⟨"kahiiN", "somewhere", "kahiiN bhii", "anywhere"⟩ ]
 
 /-- Morphological uniformity: every NPI form is its base plus *bhii*. -/
 theorem npiForm_eq_base_bhii :
@@ -314,7 +314,7 @@ def npi_adversative_surprise_ek : HindiNPIDatum :=
   { sentence := "mujhe is baat par aaScarya huaa ki ek bhii aadmii tumhaare ghar gayaa"
   , npiItem := "ek bhii", grammatical := true
   , context := some .adversative
-  , notes := "(29a) 'I am surprised that even one person went to your house.'" }
+  , notes := "(29a) 'I am surprised that anyone went to your house.'" }
 
 def npi_adversative_surprise_koii : HindiNPIDatum :=
   { sentence := "mujhe is baat par aaScarya huaa ki koii bhii tumhaare ghar gayaa"
@@ -360,7 +360,7 @@ def npi_question : HindiNPIDatum :=
   { sentence := "tumheN koii bhii kitaab pasand aayii kyaa?"
   , npiItem := "koii bhii", grammatical := true
   , context := some .question
-  , notes := "(34a) 'Did you like any book?' Rhetorical → negative bias" }
+  , notes := "(34a) 'Did you like any book?'" }
 
 -- Subject position (§6): Hindi, unlike English, licenses subject NPIs
 -- under clausemate negation — negation scopes over the subject at LF.
@@ -536,6 +536,20 @@ numerals) while *koii* activates contextually salient properties —
 only the latter yield free-choice readings, and cardinality
 alternatives clash with explicit numerals ((99)–(100)). -/
 
+open Hindi.PolarityItems (koiiBhii koiiNahiin bhiiItems)
+
+/-- §8's contrast is lexical: the fragment's *ek bhii* activates
+cardinality alternatives, *koii bhii* contextual properties. -/
+theorem contrast_is_lexical :
+    Hindi.PolarityItems.ekBhii.alternativeType = .cardinality ∧
+    koiiBhii.alternativeType = .contextualProperty := ⟨rfl, rfl⟩
+
+/-- The imperative asymmetry ((39) vs (40)): the cardinality-alternative
+items are exactly the ones whose attested contexts exclude imperatives. -/
+theorem cardinality_items_resist_imperatives :
+    ∀ i ∈ bhiiItems, i.alternativeType = .cardinality →
+      .imperative ∉ i.licensingContexts := by decide
+
 /-- A minimal *ek bhii* / *koii bhii* pair in the same frame. -/
 structure EkKoiiContrastDatum where
   ekSentence : String
@@ -567,19 +581,21 @@ def generic_contrast : EkKoiiContrastDatum :=
 
 /-! ### Fragment grounding
 
-The fragment entry `Hindi.PolarityItems.koiiBhii` stores the
-distribution this study derives: DE environments for NPI readings,
-generic/modal environments for FC readings. -/
+The fragment entries in `Hindi.PolarityItems` store the distribution
+this study derives: DE environments for NPI readings, generic/modal
+environments for FC readings, necessity modals excluded ((36d)). -/
 
-open Hindi.PolarityItems (koiiBhii koiiNahiin)
-
-/-- The fragment's *koii bhii* matches the analysis: free-choice,
-indefinite + *even* morphology, contextual-property alternatives. -/
+/-- The fragment's *koii bhii* matches the analysis: a dual NPI/FC item
+with indefinite + *even* morphology, licensed under negation ((6b)) and
+in generics ((35a)) but not under necessity modals ((36d)). -/
 theorem koiiBhii_fragment_grounded :
+    koiiBhii.licensor = some .weak ∧
     koiiBhii.freeChoice = true ∧
     koiiBhii.morphology = .indefPlusEven ∧
-    koiiBhii.alternativeType = .contextualProperty :=
-  ⟨rfl, rfl, rfl⟩
+    .negation ∈ koiiBhii.licensingContexts ∧
+    .generic ∈ koiiBhii.licensingContexts ∧
+    .modalNecessity ∉ koiiBhii.licensingContexts := by
+  refine ⟨rfl, rfl, rfl, ?_, ?_, ?_⟩ <;> decide
 
 /-- The fragment's *koii nahiiN* is a strength-licensed NPI with
 indefinite + negation morphology — the non-*bhii* route. -/


### PR DESCRIPTION
Verified against the Lahiri 1998 PDF (every exId in the study checked; all §4–§5 rows verbatim-correct).

- Fragment: adds `ekBhii`/`kuchBhii`/`zaraaBhii`/`kabhiiBhii` Items with paper-attested `licensingContexts`; fixes `koiiBhii` — removes `.modalNecessity` (paper (36d) and §5 intro: possibility "but not of necessity") and adds its NPI half (`licensor .weak` + DE contexts, per (6b) etc.); keystone + `bhii_items_uniform` cover the paradigm
- Study: decomposition table restated as the paper's (1) (p. 58) with exact glosses, `alternativeType` now read from the fragment (`contrast_is_lexical`); new `cardinality_items_resist_imperatives` ((39) vs (40)); (29a) translation corrected to the paper's