### PR TITLE
feat(Semantics/Dynamic/DRS): Realize simp API, perm and map transport

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -73,6 +73,9 @@ theorem Condition.mapList_id [DecidableEq V] (cs : List (Condition L V)) :
   | c :: cs => simp only [Condition.mapList, Condition.map_id c, Condition.mapList_id cs]
 end
 
+@[simp] theorem DRS.referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).referents = K.referents.image f := by cases K; rfl
+
 /-! ### Merge algebra -/
 
 namespace DRS

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -62,7 +62,7 @@ mutual
 input-output relation `⟨a, a'⟩` where `a'` differs from `a` at most on the
 universe and verifies every condition. -/
 def DRS.toRel : DRS L V → Update (V → M)
-  | .mk U conds => fun a a' => (∀ x, x ∉ U → a' x = a x) ∧ Condition.holdsAll conds a'
+  | .mk U conds => fun a a' => (∀ x ∉ U, a' x = a x) ∧ Condition.holdsAll conds a'
 /-- The set denotation of a condition ([muskens-1996], SEM1/2): the set of
 embeddings at which it holds. Complex conditions apply the spine connectives
 `neg`/`impl`/`disj` to the box relations of their sub-DRSs. -/
@@ -87,7 +87,7 @@ def DRS.trueRel (K : DRS L V) (a : V → M) : Prop := closure (DRS.toRel K) a
 
 @[simp] theorem DRS.toRel_mk (U : Finset V) (conds : List (Condition L V)) (a a' : V → M) :
     DRS.toRel (.mk U conds) a a' ↔
-      (∀ x, x ∉ U → a' x = a x) ∧ Condition.holdsAll conds a' := Iff.rfl
+      (∀ x ∉ U, a' x = a x) ∧ Condition.holdsAll conds a' := Iff.rfl
 
 @[simp] theorem Condition.holds_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) (a : V → M) :
     (Condition.rel R args).holds a ↔ Structure.RelMap R (fun i => a (args i)) := Iff.rfl
@@ -124,37 +124,37 @@ agrees with the static verifying-embedding semantics — `toRel K a a'` holds if
 the output `a'` extends the input `a` over `K`'s universe and verifies `K`.
 (Both sides are the total-assignment variant; see `DRS/Semantics.lean`.) -/
 theorem DRS.toRel_iff_realize (K : DRS L V) (a a' : V → M) :
-    DRS.toRel K a a' ↔ (∀ x, x ∉ K.referents → a' x = a x) ∧ DRS.Realize a' K := by
+    DRS.toRel K a a' ↔ (∀ x ∉ K.referents, a' x = a x) ∧ K.Realize a' := by
   match K with
   | .mk U conds =>
-    simp only [DRS.toRel, DRS.referents_mk, DRS.Realize]
+    simp only [DRS.toRel, DRS.referents_mk, DRS.realize_mk]
     exact and_congr_right (fun _ => Condition.holdsAll_iff_realizeAll conds a')
 /-- A condition's set denotation agrees with its static `Realize`. -/
 theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
-    Condition.holds c a ↔ Condition.Realize a c := by
+    c.holds a ↔ c.Realize a := by
   match c with
   | .rel R args => exact Iff.rfl
   | .eq u v => exact Iff.rfl
   | .neg K =>
-    simp only [Condition.holds_neg, Condition.Realize]
+    simp only [Condition.holds_neg, Condition.realize_neg]
     exact not_congr (exists_congr (fun a' => DRS.toRel_iff_realize K a a'))
   | .imp ante cons =>
-    simp only [Condition.holds_imp, Condition.Realize]
+    simp only [Condition.holds_imp, Condition.realize_imp]
     refine forall_congr' (fun a' => ?_)
     rw [DRS.toRel_iff_realize ante a a', and_imp]
     refine imp_congr_right (fun _ => imp_congr_right (fun _ => ?_))
     exact exists_congr (fun a'' => DRS.toRel_iff_realize cons a' a'')
   | .dis l r =>
-    simp only [Condition.holds_dis, Condition.Realize, exists_or]
+    simp only [Condition.holds_dis, Condition.realize_dis, exists_or]
     exact or_congr (exists_congr (fun a' => DRS.toRel_iff_realize l a a'))
       (exists_congr (fun a' => DRS.toRel_iff_realize r a a'))
 /-- The list analogue of `Condition.holds_iff_realize`. -/
 theorem Condition.holdsAll_iff_realizeAll (cs : List (Condition L V)) (a : V → M) :
-    Condition.holdsAll cs a ↔ Condition.RealizeAll a cs := by
+    Condition.holdsAll cs a ↔ Condition.RealizeAll cs a := by
   match cs with
   | [] => exact Iff.rfl
   | c :: cs =>
-    simp only [Condition.holdsAll, Condition.RealizeAll]
+    simp only [Condition.holdsAll_cons, Condition.realizeAll_cons]
     exact and_congr (Condition.holds_iff_realize c a) (Condition.holdsAll_iff_realizeAll cs a)
 end
 
@@ -178,8 +178,8 @@ theorem DRS.trueRel_congr [DecidableEq V] (K : DRS L V) (a₁ a₂ : V → M)
   | .mk U conds =>
     simp only [DRS.trueRel_iff, DRS.toRel_mk]
     have key : ∀ (b₁ b₂ : V → M), Set.EqOn b₁ b₂ ↑(DRS.occ (DRS.mk U conds)) →
-        (∃ a', (∀ x, x ∉ U → a' x = b₁ x) ∧ Condition.holdsAll conds a') →
-        (∃ a', (∀ x, x ∉ U → a' x = b₂ x) ∧ Condition.holdsAll conds a') := by
+        (∃ a', (∀ x ∉ U, a' x = b₁ x) ∧ Condition.holdsAll conds a') →
+        (∃ a', (∀ x ∉ U, a' x = b₂ x) ∧ Condition.holdsAll conds a') := by
       rintro b₁ b₂ hb ⟨a', hag, hh⟩
       refine ⟨(Condition.occL conds).piecewise a' b₂, ?_, ?_⟩
       · intro x hx

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Dynamic.DRS.Semantics
-import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Semantics
 
 /-!
 # From DRT to predicate logic: the DRS → first-order reduction
@@ -89,11 +89,11 @@ private theorem elim_comp_splitOn [DecidableEq V] (U : Finset V) (v : V → M)
   by_cases h : x ∈ U <;> simp [h]
 
 private theorem extendOn_agrees [DecidableEq V] (U : Finset V) (v : V → M)
-    (i : {x // x ∈ U} → M) : ∀ x, x ∉ U → extendOn U v i x = v x := by
+    (i : {x // x ∈ U} → M) : ∀ x ∉ U, extendOn U v i x = v x := by
   intro x hx; simp only [extendOn, dif_neg hx]
 
 private theorem extendOn_restrict [DecidableEq V] (U : Finset V) (v v' : V → M)
-    (h : ∀ x, x ∉ U → v' x = v x) : extendOn U v (fun s => v' s.val) = v' := by
+    (h : ∀ x ∉ U, v' x = v x) : extendOn U v (fun s => v' s.val) = v' := by
   funext x
   simp only [extendOn]
   by_cases hx : x ∈ U
@@ -105,7 +105,7 @@ over embeddings extending `v` on `U`. -/
 private theorem exists_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
     (P : (V → M) → Prop) :
     (∃ i : {x // x ∈ U} → M, P (extendOn U v i)) ↔
-      ∃ v', (∀ x, x ∉ U → v' x = v x) ∧ P v' := by
+      ∃ v', (∀ x ∉ U, v' x = v x) ∧ P v' := by
   constructor
   · rintro ⟨i, hi⟩
     exact ⟨extendOn U v i, extendOn_agrees U v i, hi⟩
@@ -117,7 +117,7 @@ private theorem exists_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
 private theorem forall_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
     (P : (V → M) → Prop) :
     (∀ i : {x // x ∈ U} → M, P (extendOn U v i)) ↔
-      ∀ v', (∀ x, x ∉ U → v' x = v x) → P v' := by
+      ∀ v', (∀ x ∉ U, v' x = v x) → P v' := by
   constructor
   · intro hi v' hagree
     have := hi (fun s => v' s.val)
@@ -128,7 +128,7 @@ private theorem forall_extend_iff [DecidableEq V] (U : Finset V) (v : V → M)
 /-- `closeExists` realizes as existential quantification over embeddings that
 extend `v` on `U`. -/
 theorem realize_closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v : V → M) :
-    (closeExists U φ).Realize v ↔ ∃ v', (∀ x, x ∉ U → v' x = v x) ∧ φ.Realize v' := by
+    (closeExists U φ).Realize v ↔ ∃ v', (∀ x ∉ U, v' x = v x) ∧ φ.Realize v' := by
   rw [closeExists, Formula.realize_iExs]
   simp only [Formula.realize_relabel, elim_comp_splitOn]
   exact exists_extend_iff U v (Formula.Realize φ)
@@ -136,7 +136,7 @@ theorem realize_closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v
 /-- `closeForall` realizes as universal quantification over embeddings that extend
 `v` on `U`. -/
 theorem realize_closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v : V → M) :
-    (closeForall U φ).Realize v ↔ ∀ v', (∀ x, x ∉ U → v' x = v x) → φ.Realize v' := by
+    (closeForall U φ).Realize v ↔ ∀ v', (∀ x ∉ U, v' x = v x) → φ.Realize v' := by
   rw [closeForall, Formula.realize_iAlls]
   simp only [Formula.realize_relabel, elim_comp_splitOn]
   exact forall_extend_iff U v (Formula.Realize φ)
@@ -147,46 +147,46 @@ translated formula's `Realize` coincides with the bespoke `DRS.Realize`. As
 `toFormula` existentially closes the universe, the correspondence is with an
 embedding `v'` extending `v` over `K.referents`. -/
 theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
-    (K.toFormula).Realize v ↔ ∃ v', (∀ x, x ∉ K.referents → v' x = v x) ∧ DRS.Realize v' K := by
+    (K.toFormula).Realize v ↔ ∃ v', (∀ x ∉ K.referents, v' x = v x) ∧ K.Realize v' := by
   match K with
   | .mk U conds =>
     rw [DRS.toFormula, realize_closeExists]
-    simp only [DRS.referents_mk, DRS.Realize]
+    simp only [DRS.referents_mk, DRS.realize_mk]
     exact exists_congr fun v' =>
       and_congr_right fun _ => Condition.realize_toFormulaAll conds v'
 /-- The open body of a DRS (its conditions, no universe closure) realizes as
 `DRS.Realize` (used for the antecedent of `⇒`). -/
 theorem DRS.realize_bodyFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
-    (DRS.bodyFormula K).Realize v ↔ DRS.Realize v K := by
+    (DRS.bodyFormula K).Realize v ↔ K.Realize v := by
   match K with
   | .mk _ conds => exact Condition.realize_toFormulaAll conds v
 /-- A single condition's translation realizes as `Condition.Realize`. -/
 theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : V → M) :
-    (Condition.toFormula c).Realize v ↔ Condition.Realize v c := by
+    (Condition.toFormula c).Realize v ↔ c.Realize v := by
   match c with
   | .rel R args =>
-    simp [Condition.toFormula, Condition.Realize, Relations.formula, Formula.Realize,
+    simp [Condition.toFormula, Relations.formula, Formula.Realize,
       BoundedFormula.realize_rel, Term.realize_var]
-  | .eq a b => simp [Condition.toFormula, Condition.Realize, Formula.realize_equal]
+  | .eq a b => simp [Condition.toFormula, Formula.realize_equal]
   | .neg K =>
-    simp only [Condition.toFormula, Condition.Realize, Formula.realize_not]
+    simp only [Condition.toFormula, Condition.realize_neg, Formula.realize_not]
     rw [DRS.realize_toFormula K v]
   | .imp a c =>
-    simp only [Condition.toFormula, Condition.Realize]
+    simp only [Condition.toFormula, Condition.realize_imp]
     rw [realize_closeForall]
     simp only [Formula.realize_imp]
     refine forall_congr' (fun v' => imp_congr_right (fun _ => ?_))
     rw [DRS.realize_bodyFormula a v', DRS.realize_toFormula c v']
   | .dis l r =>
-    simp only [Condition.toFormula, Condition.Realize, Formula.realize_sup]
+    simp only [Condition.toFormula, Condition.realize_dis, Formula.realize_sup]
     rw [DRS.realize_toFormula l v, DRS.realize_toFormula r v]
 /-- A list of conditions' conjoined translation realizes as `RealizeAll`. -/
 theorem Condition.realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V)) (v : V → M) :
-    (Condition.toFormulaAll cs).Realize v ↔ Condition.RealizeAll v cs := by
+    (Condition.toFormulaAll cs).Realize v ↔ Condition.RealizeAll cs v := by
   match cs with
-  | [] => simp [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_top]
+  | [] => simp [Condition.toFormulaAll, Formula.realize_top]
   | c :: cs =>
-    rw [Condition.toFormulaAll, Condition.RealizeAll, Formula.realize_inf,
+    rw [Condition.toFormulaAll, Condition.realizeAll_cons, Formula.realize_inf,
       Condition.realize_toFormula c v, Condition.realize_toFormulaAll cs v]
 end
 

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.DRS.Defs
+import Linglib.Semantics.Dynamic.DRS.Basic
 
 /-!
 # Model-theoretic semantics of DRSs
@@ -30,6 +30,9 @@ says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
   reusing mathlib's `Structure.RelMap` for atomic conditions.
 * `DRS.realize_perm` — verification reads the condition list as a set, cashing
   the `List`-representation note in `DRS/Defs.lean`.
+* `DRS.realize_map` — renaming along a bijection transports verification:
+  alphabetic variants (Def. 1.4.8, via `DRS.map` in `DRS/Basic.lean`) have the
+  same semantics.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -118,5 +121,87 @@ semantics the `List`-valued `conditions` field promises (`DRS/Defs.lean`). -/
 theorem DRS.realize_perm {U : Finset V} {cs ds : List (Condition L V)} (h : cs.Perm ds) :
     (DRS.mk U cs).Realize v ↔ (DRS.mk U ds).Realize v :=
   Condition.realizeAll_perm h
+
+/-! ### Alphabetic variants -/
+
+section Map
+
+variable {W : Type*} [DecidableEq W]
+
+/-- Precomposition with `e` is a bijection between the embeddings extending `v`
+on `U.image e` and those extending `v ∘ e` on `U`. -/
+private theorem exists_precomp_extend_iff (e : V ≃ W) (U : Finset V) (v : W → M)
+    (P : (V → M) → Prop) :
+    (∃ v' : W → M, (∀ y ∉ U.image e, v' y = v y) ∧ P (v' ∘ e)) ↔
+      ∃ w' : V → M, (∀ x ∉ U, w' x = v (e x)) ∧ P w' := by
+  constructor
+  · rintro ⟨v', h, hp⟩
+    exact ⟨v' ∘ e, fun x hx => h (e x) (by simpa using hx), hp⟩
+  · rintro ⟨w', h, hp⟩
+    refine ⟨w' ∘ e.symm, fun y hy => ?_, ?_⟩
+    · have hx : e.symm y ∉ U := fun hmem => hy (by simpa using Finset.mem_image_of_mem e hmem)
+      simpa using h _ hx
+    · have key : (w' ∘ e.symm) ∘ e = w' := by funext x; simp
+      exact key.symm ▸ hp
+
+/-- The `∀` analogue of `exists_precomp_extend_iff`. -/
+private theorem forall_precomp_extend_iff (e : V ≃ W) (U : Finset V) (v : W → M)
+    (P : (V → M) → Prop) :
+    (∀ v' : W → M, (∀ y ∉ U.image e, v' y = v y) → P (v' ∘ e)) ↔
+      ∀ w' : V → M, (∀ x ∉ U, w' x = v (e x)) → P w' := by
+  constructor
+  · intro H w' h
+    have key : (w' ∘ e.symm) ∘ e = w' := by funext x; simp
+    refine key ▸ H (w' ∘ e.symm) fun y hy => ?_
+    have hx : e.symm y ∉ U := fun hmem => hy (by simpa using Finset.mem_image_of_mem e hmem)
+    simpa using h _ hx
+  · intro H v' h
+    exact H (v' ∘ e) fun x hx => h (e x) (by simpa using hx)
+
+mutual
+/-- Renaming along a bijection transports verification: `v` verifies `K.map e`
+iff `v ∘ e` verifies `K` — alphabetic variants have the same semantics. -/
+theorem DRS.realize_map (e : V ≃ W) (K : DRS L V) (v : W → M) :
+    (K.map e).Realize v ↔ K.Realize (v ∘ e) := by
+  match K with
+  | .mk U conds =>
+    simp only [DRS.map, DRS.realize_mk]
+    exact Condition.realizeAll_mapList e conds v
+/-- The condition analogue of `DRS.realize_map`. -/
+theorem Condition.realize_map (e : V ≃ W) (c : Condition L V) (v : W → M) :
+    (c.map e).Realize v ↔ c.Realize (v ∘ e) := by
+  match c with
+  | .rel R args => exact Iff.rfl
+  | .eq a b => exact Iff.rfl
+  | .neg K =>
+    simp only [Condition.map, Condition.realize_neg, DRS.referents_map]
+    exact not_congr ((exists_congr fun v' => and_congr_right fun _ =>
+      DRS.realize_map e K v').trans (exists_precomp_extend_iff e K.referents v K.Realize))
+  | .imp ante cons =>
+    simp only [Condition.map, Condition.realize_imp, DRS.referents_map]
+    refine Iff.trans (forall_congr' fun v' => imp_congr_right fun _ => imp_congr
+      (DRS.realize_map e ante v')
+      ((exists_congr fun v'' => and_congr_right fun _ => DRS.realize_map e cons v'').trans
+        (exists_precomp_extend_iff e cons.referents v' cons.Realize))) ?_
+    exact forall_precomp_extend_iff e ante.referents v
+      (fun u => ante.Realize u → ∃ w'', (∀ x ∉ cons.referents, w'' x = u x) ∧ cons.Realize w'')
+  | .dis l r =>
+    simp only [Condition.map, Condition.realize_dis, DRS.referents_map]
+    exact or_congr
+      ((exists_congr fun v' => and_congr_right fun _ => DRS.realize_map e l v').trans
+        (exists_precomp_extend_iff e l.referents v l.Realize))
+      ((exists_congr fun v' => and_congr_right fun _ => DRS.realize_map e r v').trans
+        (exists_precomp_extend_iff e r.referents v r.Realize))
+/-- The list analogue of `Condition.realize_map`. -/
+theorem Condition.realizeAll_mapList (e : V ≃ W) (cs : List (Condition L V)) (v : W → M) :
+    Condition.RealizeAll (Condition.mapList e cs) v ↔ Condition.RealizeAll cs (v ∘ e) := by
+  match cs with
+  | [] => exact Iff.rfl
+  | c :: cs =>
+    simp only [Condition.mapList, Condition.realizeAll_cons]
+    exact and_congr (Condition.realize_map e c v) (Condition.realizeAll_mapList e cs v)
+end
+
+end Map
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Semantics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Semantics.lean
@@ -1,16 +1,21 @@
 import Linglib.Semantics.Dynamic.DRS.Defs
-import Mathlib.ModelTheory.Semantics
 
 /-!
 # Model-theoretic semantics of DRSs
-[kamp-reyle-1993]
 
-DRS truth via *verifying embeddings* into a mathlib `FirstOrder.Language.Structure`
-— Kamp & Reyle's Def. 1.4.4 in the *total-assignment* rendering. An
+DRS verification via *embeddings* into a mathlib `FirstOrder.Language.Structure`
+— [kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering. An
 embedding is an assignment `v : V → M` of discourse referents to the model
-domain; the discourse referents introduced by a sub-DRS are existentially
-(re)assigned when that sub-DRS is entered, which is what
-`(∀ x ∉ K.referents, v' x = v x)` expresses (`v'` extends `v` on `K`'s universe).
+domain; a sub-DRS is entered by existentially (re)assigning the referents of
+its universe, which is what `∀ x ∉ K.referents, v' x = v x` expresses (`v'`
+extends `v` on `K`'s universe). For `imp`, the consequent witness extends the
+*antecedent* embedding, not the host one — antecedent referents stay visible
+in the consequent, the `⇒` accessibility asymmetry. The atomic and `¬` clauses
+are Def. 1.4.4(ii); the `⇒`/`∨` clauses are the Chapter 2 conditional and
+disjunction semantics. Truth (Def. 1.4.5) is the existential closure of
+verification over the outer universe; it is delivered downstream as
+`DRS.trueRel` (`DRS/Dynamics.lean`) and as the first-order translation's
+realization (`DRS/Reduction.lean`).
 
 **Deviation** ([muskens-1996], fn. 4): K&R's embeddings are *partial* functions
 that sub-DRSs strictly *extend*, so a re-declared referent keeps its value; here
@@ -21,8 +26,10 @@ says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
 
 ## Main declarations
 
-* `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation
-  (Def. 1.4.4), reusing mathlib's `Structure.RelMap` for atomic conditions.
+* `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation,
+  reusing mathlib's `Structure.RelMap` for atomic conditions.
+* `DRS.realize_perm` — verification reads the condition list as a set, cashing
+  the `List`-representation note in `DRS/Defs.lean`.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -34,33 +41,82 @@ universe u v w x
 variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 
 mutual
-/-- `v` *verifies* `K` ([kamp-reyle-1993], Def. 1.4.4): every condition of `K`
-holds under the assignment `v`. -/
-def DRS.Realize (v : V → M) : DRS L V → Prop
-  | .mk _ conds => Condition.RealizeAll v conds
-/-- `v` verifies a condition — Def. 1.4.4(ii) for the atomic and `¬` clauses;
-the `⇒`/`∨` clauses are K&R's Chapter 2 conditional and disjunction semantics.
-A sub-DRS `K` is entered by existentially (re)assigning the referents of its
-universe (`v'` agrees with `v` off `K.referents`). For `imp`, the consequent
-witness `v''` extends the *antecedent* assignment `v'` (not the host `v`):
-antecedent referents are visible in the consequent — the `⇒` accessibility
-asymmetry. -/
-def Condition.Realize (v : V → M) : Condition L V → Prop
-  | .rel R args => Structure.RelMap R (fun i => v (args i))
-  | .eq a b => v a = v b
-  | .neg K => ¬ ∃ v' : V → M, (∀ x, x ∉ K.referents → v' x = v x) ∧ DRS.Realize v' K
-  | .imp a c =>
-      ∀ v' : V → M, (∀ x, x ∉ a.referents → v' x = v x) → DRS.Realize v' a →
-        ∃ v'' : V → M, (∀ x, x ∉ c.referents → v'' x = v' x) ∧ DRS.Realize v'' c
-  | .dis l r =>
-      (∃ v' : V → M, (∀ x, x ∉ l.referents → v' x = v x) ∧ DRS.Realize v' l) ∨
-      (∃ v' : V → M, (∀ x, x ∉ r.referents → v' x = v x) ∧ DRS.Realize v' r)
-/-- Every condition in the list is verified by `v`. A `List` helper (not
-`List.Forall (Condition.Realize v)`) because Lean's structural-recursion checker
-for the nested `List (Condition …)` rejects the higher-order argument. -/
-def Condition.RealizeAll (v : V → M) : List (Condition L V) → Prop
-  | [] => True
-  | c :: cs => Condition.Realize v c ∧ Condition.RealizeAll v cs
+/-- `K.Realize v`: the embedding `v` *verifies* `K` — every condition of `K`
+holds under `v`. -/
+def DRS.Realize : DRS L V → (V → M) → Prop
+  | .mk _ conds, v => Condition.RealizeAll conds v
+/-- `c.Realize v`: the embedding `v` verifies the condition `c`; sub-DRSs are
+entered by existentially (re)assigning the referents of their universes. -/
+def Condition.Realize : Condition L V → (V → M) → Prop
+  | .rel R args, v => Structure.RelMap R (fun i => v (args i))
+  | .eq a b, v => v a = v b
+  | .neg K, v => ¬ ∃ v' : V → M, (∀ x ∉ K.referents, v' x = v x) ∧ DRS.Realize K v'
+  | .imp a c, v =>
+      ∀ v' : V → M, (∀ x ∉ a.referents, v' x = v x) → DRS.Realize a v' →
+        ∃ v'' : V → M, (∀ x ∉ c.referents, v'' x = v' x) ∧ DRS.Realize c v''
+  | .dis l r, v =>
+      (∃ v' : V → M, (∀ x ∉ l.referents, v' x = v x) ∧ DRS.Realize l v') ∨
+      (∃ v' : V → M, (∀ x ∉ r.referents, v' x = v x) ∧ DRS.Realize r v')
+/-- Every condition in the list is verified by `v`. A `List` helper — the
+higher-order `List.Forall (·.Realize v)` form fails the nested-inductive
+structural-recursion checker; `realizeAll_iff_forall_mem` is the membership
+characterization. -/
+def Condition.RealizeAll : List (Condition L V) → (V → M) → Prop
+  | [], _ => True
+  | c :: cs, v => Condition.Realize c v ∧ Condition.RealizeAll cs v
 end
+
+/-! ### Structural simp API -/
+
+variable {v : V → M}
+
+@[simp] theorem DRS.realize_mk (U : Finset V) (conds : List (Condition L V)) :
+    (DRS.mk U conds).Realize v ↔ Condition.RealizeAll conds v := Iff.rfl
+
+@[simp] theorem Condition.realize_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (Condition.rel R args).Realize v ↔ Structure.RelMap R (fun i => v (args i)) := Iff.rfl
+
+@[simp] theorem Condition.realize_eq (a b : V) :
+    (Condition.eq a b : Condition L V).Realize v ↔ v a = v b := Iff.rfl
+
+@[simp] theorem Condition.realize_neg (K : DRS L V) :
+    (Condition.neg K).Realize v ↔
+      ¬ ∃ v', (∀ x ∉ K.referents, v' x = v x) ∧ K.Realize v' := Iff.rfl
+
+@[simp] theorem Condition.realize_imp (a c : DRS L V) :
+    (Condition.imp a c).Realize v ↔
+      ∀ v', (∀ x ∉ a.referents, v' x = v x) → a.Realize v' →
+        ∃ v'', (∀ x ∉ c.referents, v'' x = v' x) ∧ c.Realize v'' := Iff.rfl
+
+@[simp] theorem Condition.realize_dis (l r : DRS L V) :
+    (Condition.dis l r).Realize v ↔
+      (∃ v', (∀ x ∉ l.referents, v' x = v x) ∧ l.Realize v') ∨
+      (∃ v', (∀ x ∉ r.referents, v' x = v x) ∧ r.Realize v') := Iff.rfl
+
+@[simp] theorem Condition.realizeAll_nil :
+    Condition.RealizeAll ([] : List (Condition L V)) v := trivial
+
+@[simp] theorem Condition.realizeAll_cons (c : Condition L V) (cs : List (Condition L V)) :
+    Condition.RealizeAll (c :: cs) v ↔ c.Realize v ∧ Condition.RealizeAll cs v := Iff.rfl
+
+/-! ### Verification reads the condition list as a set -/
+
+/-- Membership characterization of `RealizeAll`. -/
+theorem Condition.realizeAll_iff_forall_mem {cs : List (Condition L V)} :
+    Condition.RealizeAll cs v ↔ ∀ c ∈ cs, c.Realize v := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih => simp [ih]
+
+/-- Verification of a condition list is invariant under permutation. -/
+theorem Condition.realizeAll_perm {cs ds : List (Condition L V)} (h : cs.Perm ds) :
+    Condition.RealizeAll cs v ↔ Condition.RealizeAll ds v := by
+  simp only [Condition.realizeAll_iff_forall_mem, h.mem_iff]
+
+/-- Verification is invariant under permutation of the conditions — the set
+semantics the `List`-valued `conditions` field promises (`DRS/Defs.lean`). -/
+theorem DRS.realize_perm {U : Finset V} {cs ds : List (Condition L V)} (h : cs.Perm ds) :
+    (DRS.mk U cs).Realize v ↔ (DRS.mk U ds).Realize v :=
+  Condition.realizeAll_perm h
 
 end DRT


### PR DESCRIPTION
Deep audit of `DRS/Semantics.lean`, calibrated against `Mathlib/ModelTheory/Semantics.lean`.

- object-first `Realize`/`RealizeAll` (matching `Formula.Realize` and the `holds`/`toRel` siblings), per-constructor `@[simp]` battery, `∀ x ∉ U` binder notation
- `realizeAll_iff_forall_mem` + `realize_perm`: the set semantics `Defs.lean`'s condition-list note promises; `realize_map`: alphabetic variants (Def. 1.4.8) preserve verification
- `Mathlib.ModelTheory.Semantics` import moves to `Reduction.lean`, its actual consumer