### PR TITLE
style(Semantics/Dynamic/DRS): cite-once docstrings; ReuseFreeAllAt

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -3,14 +3,14 @@ import Mathlib.Data.Finset.Image
 
 /-!
 # DRS structural API: functorial renaming and merge algebra
-[kamp-reyle-1993]
 
 Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
 
 * `DRS.map` / `Condition.map` — functorial renaming of discourse referents along
-  `f : V → W`. When `f` is a bijection this is Kamp & Reyle's *alphabetic
+  `f : V → W`. When `f` is a bijection this is [kamp-reyle-1993]'s *alphabetic
   variant* (the prose preceding Def. 1.4.8); `map_id` makes "renaming to the
-  identity is the identity" a free corollary.
+  identity is the identity" a free corollary, and `DRS.realize_map`
+  (`DRS/Semantics.lean`) shows variants have the same semantics.
 * `merge` algebra — identity (`empty`) and associativity.
 * `DRS.fv` / `DRS.IsProper` — free discourse referents (as a `Finset`) and
   properness (`fv K = ∅`, Def. 1.4.2–1.4.3).
@@ -229,7 +229,7 @@ theorem DRS.fv_merge_subset {X : Finset V} {K₁ K₂ : DRS L V} (h₁ : K₁.fv
   exact Finset.union_subset (h₁.trans Finset.subset_union_left) h₂
 
 /-- A DRS is *proper* iff it has no free discourse referent
-([kamp-reyle-1993], Def. 1.4.2–1.4.3). -/
+(Def. 1.4.2–1.4.3). -/
 def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
 
 /-- Merging preserves properness when the increment's free referents are
@@ -257,7 +257,7 @@ mutual
 /-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
 and its conditions are reuse-free at the grown set. -/
 def DRS.ReuseFreeAt (X : Finset V) : DRS L V → Prop
-  | .mk U conds => Disjoint X U ∧ Condition.ReuseFreeAtL (X ∪ U) conds
+  | .mk U conds => Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds
 /-- A condition is reuse-free at ambient declarations `X`. -/
 def Condition.ReuseFreeAt (X : Finset V) : Condition L V → Prop
   | .rel _ _ => True
@@ -266,14 +266,14 @@ def Condition.ReuseFreeAt (X : Finset V) : Condition L V → Prop
   | .imp a c => DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c
   | .dis l r => DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r
 /-- Reuse-freeness for a list of conditions. -/
-def Condition.ReuseFreeAtL (X : Finset V) : List (Condition L V) → Prop
+def Condition.ReuseFreeAllAt (X : Finset V) : List (Condition L V) → Prop
   | [] => True
-  | c :: cs => Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAtL X cs
+  | c :: cs => Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs
 end
 
 @[simp] theorem DRS.reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
     DRS.ReuseFreeAt X (.mk U conds) ↔
-      Disjoint X U ∧ Condition.ReuseFreeAtL (X ∪ U) conds := Iff.rfl
+      Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds := Iff.rfl
 
 @[simp] theorem Condition.reuseFreeAt_rel (X : Finset V) {n : ℕ} (R : L.Relations n)
     (args : Fin n → V) : Condition.ReuseFreeAt X (.rel R args) := trivial
@@ -292,19 +292,19 @@ end
     Condition.ReuseFreeAt X (.dis l r) ↔
       DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := Iff.rfl
 
-@[simp] theorem Condition.reuseFreeAtL_nil (X : Finset V) :
-    Condition.ReuseFreeAtL X ([] : List (Condition L V)) := trivial
+@[simp] theorem Condition.reuseFreeAllAt_nil (X : Finset V) :
+    Condition.ReuseFreeAllAt X ([] : List (Condition L V)) := trivial
 
-@[simp] theorem Condition.reuseFreeAtL_cons (X : Finset V) (c : Condition L V)
+@[simp] theorem Condition.reuseFreeAllAt_cons (X : Finset V) (c : Condition L V)
     (cs : List (Condition L V)) :
-    Condition.ReuseFreeAtL X (c :: cs) ↔
-      Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAtL X cs := Iff.rfl
+    Condition.ReuseFreeAllAt X (c :: cs) ↔
+      Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs := Iff.rfl
 
 end ReuseFree
 
 /-! ### Accessibility (decidable, host-relative)
 
-Accessibility ([kamp-reyle-1993], Def. 1.4.11) is intrinsically *relative to a
+Accessibility (Def. 1.4.11) is intrinsically *relative to a
 host DRS*: "`u` accessible at box `B`" means `u` lies in the universe of `B` or of
 a box on the path from the host down to `B`. A host-free `∃ D, WeakSubordinate K D
 ∧ u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent
@@ -343,8 +343,8 @@ def Condition.accScopeL (s : Finset V) : List (Condition L V) → V → Option (
 end
 
 /-- The referents accessible from `u`'s introduction in `T`, as a decidable
-`Finset`; `∅` if `u` is not introduced in `T`. ([kamp-reyle-1993] Def. 1.4.11
-defines accessibility of a referent from a *condition*; this is the derived
+`Finset`; `∅` if `u` is not introduced in `T`. (Def. 1.4.11 defines
+accessibility of a referent from a *condition*; this is the derived
 referent-to-referent relation of the surrounding prose.) -/
 def DRS.accessibleFrom (T : DRS L V) (u : V) : Finset V := (DRS.accScope ∅ T u).getD ∅
 

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -4,12 +4,11 @@ import Mathlib.ModelTheory.Basic
 
 /-!
 # Discourse Representation Structures (faithful, model-theoretic core)
-[kamp-reyle-1993]
 
 A faithful Lean model of the canonical DRS data type, built on mathlib's
 `FirstOrder.Language` so its semantics can be given model-theoretically (via
-`FirstOrder.Language.Structure` / `Realize`), exactly as Kamp & Reyle define it
-(verifying embeddings into a model, Def. 1.4.4–1.4.5).
+`FirstOrder.Language.Structure` / `Realize`), exactly as [kamp-reyle-1993]
+define it (verifying embeddings into a model, Def. 1.4.4–1.4.5).
 
 A DRS is a pair `⟨referents, conditions⟩` (Def. 1.4.1): `referents` is the
 *universe* `U` — a finite set of discourse referents — and `conditions` a
@@ -23,7 +22,8 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
 
 * `DRS L V`, `Condition L V` — the mutual data type over a language `L` (relation
   signature) and discourse-referent type `V`.
-* `DRS.merge` — the `⊕` operation (set-union referents, concatenate conditions).
+* `DRS.merge` — the `⊕` operation (set-union referents, concatenate
+  conditions); [muskens-1996]'s compositional operation.
 * `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — immediate
   subordination (Def. 1.4.10(i), extended to `⇒`/`∨` in Ch. 2) and its
   `Relation.TransGen` / `ReflTransGen` closures (Def. 1.4.10(ii)). Accessibility
@@ -35,8 +35,9 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
   `universe` is a Lean keyword and `univ` collides with `Finset.univ`.
 * The recursive `conditions` field is a `List`: Lean forbids nesting an inductive
   through `Finset`/`Multiset`. Set semantics are imposed by the interpretation.
-* The namespace is transitional `DRT` while the legacy `_root_.DRS` is migrated
-  out; it promotes to the root namespace once the legacy type is retired.
+* `DRT` is the owning namespace (mathlib's `FirstOrder.Language` pattern):
+  `DRS`, `Condition`, and `Ctx` are DRT's objects, keeping generic names
+  owner-relative rather than claiming them at the root.
 -/
 
 open FirstOrder
@@ -49,13 +50,13 @@ variable {L : Language.{u, v}} {V : Type w}
 
 mutual
 /-- A discourse representation structure: the pair `⟨referents, conditions⟩`
-([kamp-reyle-1993], Def. 1.4.1). `referents` is the universe `U` (a finite
-set of discourse referents); `conditions` the DRS-conditions. -/
+(Def. 1.4.1). `referents` is the universe `U` (a finite set of discourse
+referents); `conditions` the DRS-conditions. -/
 inductive DRS (L : Language.{u, v}) (V : Type w) where
   | mk (referents : Finset V) (conditions : List (Condition L V))
-/-- A DRS-condition ([kamp-reyle-1993]): atomic (`rel`, `eq`) or complex —
-`neg` per Def. 1.4.1, `imp`/`dis` per its Chapter 2 extension. Sub-DRSs occur
-only inside complex conditions. -/
+/-- A DRS-condition: atomic (`rel`, `eq`) or complex — `neg` per Def. 1.4.1,
+`imp`/`dis` per its Chapter 2 extension. Sub-DRSs occur only inside complex
+conditions. -/
 inductive Condition (L : Language.{u, v}) (V : Type w) where
   /-- Atomic condition: `n`-ary relation symbol `R` applied to referents `args`. -/
   | rel {n : ℕ} (R : L.Relations n) (args : Fin n → V)
@@ -89,9 +90,9 @@ def conditions : DRS L V → List (Condition L V)
 def empty : DRS L V := .mk ∅ []
 
 /-- Merge `⊕`: set-union the referents, concatenate the conditions. The binary
-DRS merge is [muskens-1996]'s compositional operation — Kamp & Reyle
-themselves combine DRSs incrementally via the construction algorithm, not a
-symmetric binary `⊕`. An operation, not a syntactic constructor. -/
+DRS merge is Muskens's compositional operation — Kamp & Reyle themselves
+combine DRSs incrementally via the construction algorithm, not a symmetric
+binary `⊕`. An operation, not a syntactic constructor. -/
 def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
   .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
 
@@ -106,8 +107,7 @@ end DRS
 /-! ### Subordination and accessibility -/
 
 /-- One-step subordination ("`K'` is *directly subordinate* to `K`"). The `neg`
-case is [kamp-reyle-1993] Def. 1.4.10(i); the `⇒`/`∨` cases are its Chapter 2
-extension:
+case is Def. 1.4.10(i); the `⇒`/`∨` cases are its Chapter 2 extension:
 
 * the body of a `¬` is subordinate to the containing DRS;
 * the antecedent of a `⇒` is subordinate to the containing DRS;
@@ -122,14 +122,14 @@ inductive DirectlySubordinate : DRS L V → DRS L V → Prop where
   | disR {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
 
 /-- `K₁ < K₂`: subordinate — transitive closure of `DirectlySubordinate`
-([kamp-reyle-1993], Def. 1.4.10(ii)). Anchors Def. 1.4.10(ii) only:
+(Def. 1.4.10(ii)). Anchors Def. 1.4.10(ii) only:
 accessibility (`accessibleFrom`, `DRS/Basic.lean`) does not build on this
 closure. -/
 abbrev Subordinate : DRS L V → DRS L V → Prop :=
   Relation.TransGen DirectlySubordinate
 
 /-- `K₁ ≤ K₂`: weakly subordinate — reflexive-transitive closure
-([kamp-reyle-1993]; the `≤` of Def. 1.4.10). Anchors Def. 1.4.10(ii) only:
+(the `≤` of Def. 1.4.10). Anchors Def. 1.4.10(ii) only:
 accessibility does not build on this closure. -/
 abbrev WeakSubordinate : DRS L V → DRS L V → Prop :=
   Relation.ReflTransGen DirectlySubordinate

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -4,9 +4,8 @@ import Linglib.Semantics.Dynamic.Update
 
 /-!
 # Relational (dynamic) semantics of DRSs, and its equivalence with verifying embeddings
-[muskens-1996]
 
-Muskens's reformulation of DRT. Conditions denote *sets* of embeddings (SEM1/2);
+[muskens-1996]'s reformulation of DRT. Conditions denote *sets* of embeddings (SEM1/2);
 boxes denote *binary relations* between embeddings (SEM3, input → output, the
 format of [groenendijk-stokhof-1991]); a box is true under an input embedding
 `a` iff some output `a'` is related to it (p. 148). This is the dynamic / CCP
@@ -58,14 +57,14 @@ variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 /-! ### The relational denotation -/
 
 mutual
-/-- The relational (dynamic) denotation of a DRS ([muskens-1996], SEM3): the
-input-output relation `⟨a, a'⟩` where `a'` differs from `a` at most on the
-universe and verifies every condition. -/
+/-- The relational (dynamic) denotation of a DRS (SEM3): the input-output
+relation `⟨a, a'⟩` where `a'` differs from `a` at most on the universe and
+verifies every condition. -/
 def DRS.toRel : DRS L V → Update (V → M)
   | .mk U conds => fun a a' => (∀ x ∉ U, a' x = a x) ∧ Condition.holdsAll conds a'
-/-- The set denotation of a condition ([muskens-1996], SEM1/2): the set of
-embeddings at which it holds. Complex conditions apply the spine connectives
-`neg`/`impl`/`disj` to the box relations of their sub-DRSs. -/
+/-- The set denotation of a condition (SEM1/2): the set of embeddings at which
+it holds. Complex conditions apply the spine connectives `neg`/`impl`/`disj`
+to the box relations of their sub-DRSs. -/
 def Condition.holds : Condition L V → (V → M) → Prop
   | .rel R args => fun a => Structure.RelMap R (fun i => a (args i))
   | .eq u v => fun a => a u = a v
@@ -80,7 +79,7 @@ def Condition.holdsAll : List (Condition L V) → (V → M) → Prop
 end
 
 /-- A DRS is *true* under an input embedding `a` iff some output embedding is
-related to it ([muskens-1996], p. 148) — the spine's anaphoric `closure`. -/
+related to it (p. 148) — the spine's anaphoric `closure`. -/
 def DRS.trueRel (K : DRS L V) (a : V → M) : Prop := closure (DRS.toRel K) a
 
 /-! ### Structural simp API -/
@@ -119,7 +118,7 @@ theorem DRS.trueRel_iff (K : DRS L V) (a : V → M) :
 /-! ### Equivalence with the verifying-embedding semantics -/
 
 mutual
-/-- **SEM3 ≡ verification semantics** ([muskens-1996]): the relational denotation
+/-- **SEM3 ≡ verification semantics**: the relational denotation
 agrees with the static verifying-embedding semantics — `toRel K a a'` holds iff
 the output `a'` extends the input `a` over `K`'s universe and verifies `K`.
 (Both sides are the total-assignment variant; see `DRS/Semantics.lean`.) -/
@@ -159,8 +158,7 @@ theorem Condition.holdsAll_iff_realizeAll (cs : List (Condition L V)) (a : V →
 end
 
 /-- The dynamic truth of a DRS equals its first-order translation's `Realize`
-([muskens-1996]; [kamp-reyle-1993] §1.5) — the third edge of the
-`Realize`/`toFormula`/`toRel` triangle. -/
+— the third edge of the `Realize`/`toFormula`/`toRel` triangle. -/
 theorem DRS.trueRel_iff_realize_toFormula [DecidableEq V] (K : DRS L V) (a : V → M) :
     DRS.trueRel K a ↔ (K.toFormula).Realize a := by
   rw [DRS.trueRel_iff, DRS.realize_toFormula K a]
@@ -282,7 +280,7 @@ end
   | nil => simp [Condition.holdsAll]
   | cons c cs ih => simp only [List.cons_append, Condition.holdsAll, ih, and_assoc]
 
-/-- **Merging Lemma** ([muskens-1996], §II.2): when `K₂`'s universe is fresh
+/-- **Merging Lemma** (§II.2): when `K₂`'s universe is fresh
 for `K₁`'s conditions, the merge `K₁ ⊕ K₂` denotes the spine sequencing
 (relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = seq ‖K₁‖ ‖K₂‖`.
 This is what gives `merge` its dynamic meaning. -/

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -4,15 +4,15 @@ import Linglib.Semantics.Dynamic.Transition
 
 /-!
 # Indexed relational semantics of DRSs
-[kamp-vangenabith-reyle-2011] (Defs. 19, 22, 24), [kamp-reyle-1993]
 
 The base-threaded verification semantics: `toRelAt X K f g` holds when the
 output `g` agrees with the input `f` *on the context base* `X` and verifies
 `K`'s conditions, sub-boxes entered at the grown base. This is the
-total-assignment rendering of K&R's partial-embedding semantics
-(Def. 19): values at established referents *persist* — contrast the flat
-`DRS.toRel` (`DRS/Dynamics.lean`), whose agree-off-universe clause freely
-reassigns re-declared referents (Muskens's fn. 4 divergence).
+total-assignment rendering of [kamp-vangenabith-reyle-2011]'s
+partial-embedding semantics (Defs. 19, 22, 24): values at established
+referents *persist*, as in [kamp-reyle-1993]'s original embeddings — contrast
+the flat `DRS.toRel` (`DRS/Dynamics.lean`), whose agree-off-universe clause
+freely reassigns re-declared referents ([muskens-1996]'s fn. 4 divergence).
 
 Persistence is what makes the indexed semantics well-typed: `toRelAt X K` is
 read only at `X` (`toRelAt_congr_left` — one line, no witness surgery) and
@@ -52,8 +52,8 @@ variable [DecidableEq V]
 /-! ### The base-threaded semantics -/
 
 mutual
-/-- Base-threaded relational semantics ([kamp-vangenabith-reyle-2011],
-Def. 19 in total-assignment form): the output agrees with the input *on the
+/-- Base-threaded relational semantics (Def. 19 in total-assignment
+form): the output agrees with the input *on the
 base* — established referents persist — and verifies the conditions, with
 sub-boxes entered at the grown base. -/
 def DRS.toRelAt (X : Finset V) : DRS L V → (V → M) → (V → M) → Prop
@@ -179,7 +179,7 @@ theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
 
 /-- A well-formed DRS denotes a transition from its context base to the
 base grown by its universe — `K.fv ⊆ X` is the *referential presupposition*
-([kamp-vangenabith-reyle-2011], Def. 27(i)). -/
+(Def. 27(i)). -/
 theorem DRS.readsAt_toRelAt {W : Type*} (X : Finset V) (K : DRS L V) :
     Transition.ReadsAt (W := W) ↑X fun _ => DRS.toRelAt (M := M) X K :=
   fun _ _ _ _ h => DRS.toRelAt_congr_left X K h
@@ -239,8 +239,8 @@ theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
       K.transition W X' hK' := by
   subst hX; rfl
 
-/-- The information state a proper DRS expresses
-([kamp-vangenabith-reyle-2011], Def. 22): act on the initial state. -/
+/-- The information state a proper DRS expresses (Def. 22): act on the
+initial state. -/
 def DRS.state (W : Type*) (K : DRS L V) (hK : K.IsProper) : State W V M :=
   (K.transition W ∅ (Finset.subset_empty.mpr hK)).applyState ⊥
 
@@ -479,7 +479,7 @@ theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
   exact Transition.ofTotal_congr _ _
     (funext fun _ => (DRS.toRelAt_merge K₁ K₂ h₁ hfresh).symm)
 
-/-- **Action equation** ([kamp-vangenabith-reyle-2011], p. 159): applying a
+/-- **Action equation** (p. 159): applying a
 DRS's transition to the state a proper context DRS expresses yields the
 state of the merge — an instance of `Transition.apply_comp` through the
 transition-level Merging Lemma. -/
@@ -503,7 +503,7 @@ agree-off-universe semantics (`DRS.toRel`, `DRS/Dynamics.lean`) and the indexed
 persistence semantics coincide at truth level: every flat output is a indexed
 output, and a indexed output repairs, off the grown base, into a flat one.
 Reuse-freeness is needed — on a DRS that re-declares a referent the two
-diverge ([muskens-1996], fn. 4; witness in `Studies/Muskens1996.lean`). -/
+diverge (Muskens's fn. 4; witness in `Studies/Muskens1996.lean`). -/
 
 /-- Flat-to-indexed on a reuse-free box: agreement off the universe restricts
 to agreement on a disjoint base. -/
@@ -615,12 +615,12 @@ theorem Condition.holds_iff_holdsAt {X : Finset V} (c : Condition L V)
       · exact ⟨_, Or.inr (DRS.toRel_of_toRelAt' hfvcr hIHr hk).1⟩
 /-- The list analogue of `Condition.holds_iff_holdsAt`. -/
 theorem Condition.holdsAll_iff_holdsAllAt {X : Finset V} (cs : List (Condition L V))
-    (hrf : Condition.ReuseFreeAtL X cs) (hfv : Condition.fvL cs ⊆ X) (g : V → M) :
+    (hrf : Condition.ReuseFreeAllAt X cs) (hfv : Condition.fvL cs ⊆ X) (g : V → M) :
     Condition.holdsAll cs g ↔ Condition.holdsAllAt X cs g := by
   match cs with
   | [] => exact Iff.rfl
   | c :: cs =>
-    simp only [Condition.reuseFreeAtL_cons] at hrf
+    simp only [Condition.reuseFreeAllAt_cons] at hrf
     rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
     exact and_congr (Condition.holds_iff_holdsAt c hrf.1 hfv.1 g)
       (Condition.holdsAll_iff_holdsAllAt cs hrf.2 hfv.2 g)
@@ -644,7 +644,7 @@ theorem DRS.toRel_of_toRelAt {X : Finset V} {K : DRS L V} (hrf : DRS.ReuseFreeAt
   exact ⟨_, DRS.toRel_of_toRelAt' (DRS.fv_subset_iff.mp hfv)
     (fun k => Condition.holdsAll_iff_holdsAllAt conds hrf.2 (DRS.fv_subset_iff.mp hfv) k) h⟩
 
-/-- **Truth-level reconciliation** ([muskens-1996], fn. 4): on a reuse-free
+/-- **Truth-level reconciliation** (Muskens's fn. 4): on a reuse-free
 DRS the flat total-assignment semantics and the indexed persistence semantics
 have the same truth conditions. Reuse-freeness is needed — a re-declaring
 witness separates the two (`Studies/Muskens1996.lean`). -/

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -3,14 +3,13 @@ import Mathlib.ModelTheory.Semantics
 
 /-!
 # From DRT to predicate logic: the DRS → first-order reduction
-[kamp-reyle-1993] (§1.5), [muskens-1996]
 
 The bespoke DRS box language is *equivalent to ordinary first-order
 logic*. We translate each DRS into a mathlib
-`FirstOrder.Language.Formula` and prove its `Realize` coincides with the bespoke
-`DRS.Realize` — Kamp & Reyle's §1.5 ("From DRT to Predicate Logic") and Muskens's
-"DRSs are already present in classical logic", now a Lean theorem
-(`DRS.realize_toFormula`) rather than an assertion.
+`FirstOrder.Language.Formula` and prove its `Realize` coincides with the
+bespoke `DRS.Realize` — [kamp-reyle-1993]'s §1.5 ("From DRT to Predicate
+Logic") and [muskens-1996]'s "DRSs are already present in classical logic",
+now a Lean theorem (`DRS.realize_toFormula`) rather than an assertion.
 
 The universe of a (sub-)DRS is *existentially closed* (`closeExists`, via
 mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
@@ -50,7 +49,7 @@ noncomputable def closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) 
 
 mutual
 /-- Translate a DRS to a first-order formula: existentially close the universe
-over the conjunction of the (translated) conditions ([kamp-reyle-1993] §1.5). -/
+over the conjunction of the (translated) conditions (§1.5). -/
 noncomputable def DRS.toFormula [DecidableEq V] : DRS L V → L.Formula V
   | .mk U conds => closeExists U (Condition.toFormulaAll conds)
 /-- The conjunction of a DRS's conditions, *without* closing its universe (used
@@ -142,7 +141,7 @@ theorem realize_closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v
   exact forall_extend_iff U v (Formula.Realize φ)
 
 mutual
-/-- **DRT ⊆ FOL** ([kamp-reyle-1993] §1.5; [muskens-1996]): the
+/-- **DRT ⊆ FOL** (§1.5): the
 translated formula's `Realize` coincides with the bespoke `DRS.Realize`. As
 `toFormula` existentially closes the universe, the correspondence is with an
 embedding `v'` extending `v` over `K.referents`. -/


### PR DESCRIPTION
Sibling cleanse from the #1882 audit.

- module docstrings: no bare `[key]` blocks under titles (keys woven into prose); decl docstrings drop scattered cites, keeping plain Def/§ anchors
- `ReuseFreeAtL` → `ReuseFreeAllAt` (the `holdsAllAt` pattern; the `L` suffix is the Finset family)
- Defs.lean: retire the stale "transitional DRT namespace" note — the legacy `_root_.DRS` is gone, and `DRT` stays as the owning namespace (`Condition`/`Ctx` should not claim root)