### PR TITLE
chore(Semantics/Dynamic/DRS): Semantics.lean → Verification.lean

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1608,7 +1608,7 @@ import Linglib.Semantics.Dynamic.DRS.Defs
 import Linglib.Semantics.Dynamic.DRS.Dynamics
 import Linglib.Semantics.Dynamic.DRS.Indexed
 import Linglib.Semantics.Dynamic.DRS.Reduction
-import Linglib.Semantics.Dynamic.DRS.Semantics
+import Linglib.Semantics.Dynamic.DRS.Verification
 import Linglib.Semantics.Dynamic.FileChange
 import Linglib.Semantics.Dynamic.ICDRT.Basic
 import Linglib.Semantics.Dynamic.ICDRT.Defs

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -10,7 +10,7 @@ Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
   `f : V → W`. When `f` is a bijection this is [kamp-reyle-1993]'s *alphabetic
   variant* (the prose preceding Def. 1.4.8); `map_id` makes "renaming to the
   identity is the identity" a free corollary, and `DRS.realize_map`
-  (`DRS/Semantics.lean`) shows variants have the same semantics.
+  (`DRS/Verification.lean`) shows variants have the same semantics.
 * `merge` algebra — identity (`empty`) and associativity.
 * `DRS.fv` / `DRS.IsProper` — free discourse referents (as a `Finset`) and
   properness (`fv K = ∅`, Def. 1.4.2–1.4.3).

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -11,7 +11,7 @@ format of [groenendijk-stokhof-1991]); a box is true under an input embedding
 `a` iff some output `a'` is related to it (p. 148). This is the dynamic / CCP
 face of DRT, dual to the static verifying-embedding semantics `DRS.Realize` —
 the total-assignment rendering of [kamp-reyle-1993]'s verification (see the
-deviation note in `DRS/Semantics.lean`).
+deviation note in `DRS/Verification.lean`).
 
 The two semantics are *defined independently* and proved equivalent — Muskens's
 remark that the relational interpretation "is in fact equivalent" to the
@@ -41,7 +41,7 @@ identification:
 
 Naming: the dynamic face (`toRel`, `holds`, `trueRel`) follows the spine's
 lowerCamel operation names (`neg`, `seq`, `closure`); the static face
-(`DRS.Realize`, `DRS/Semantics.lean`) follows mathlib's `Formula.Realize`.
+(`DRS.Realize`, `DRS/Verification.lean`) follows mathlib's `Formula.Realize`.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -121,7 +121,7 @@ mutual
 /-- **SEM3 ≡ verification semantics**: the relational denotation
 agrees with the static verifying-embedding semantics — `toRel K a a'` holds iff
 the output `a'` extends the input `a` over `K`'s universe and verifies `K`.
-(Both sides are the total-assignment variant; see `DRS/Semantics.lean`.) -/
+(Both sides are the total-assignment variant; see `DRS/Verification.lean`.) -/
 theorem DRS.toRel_iff_realize (K : DRS L V) (a a' : V → M) :
     DRS.toRel K a a' ↔ (∀ x ∉ K.referents, a' x = a x) ∧ K.Realize a' := by
   match K with

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.DRS.Semantics
+import Linglib.Semantics.Dynamic.DRS.Verification
 import Mathlib.ModelTheory.Semantics
 
 /-!

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Dynamic.DRS.Basic
 
 /-!
-# Model-theoretic semantics of DRSs
+# Verifying embeddings for DRSs
 
 DRS verification via *embeddings* into a mathlib `FirstOrder.Language.Structure`
 — [kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering. An


### PR DESCRIPTION
`Verification` is DRT's own name for its satisfaction notion (the field-standard "verifying embeddings" / "f verifies K" vocabulary, cf. the SEP entry) — the `Satisfiability.lean`-style field-term filename, and it disambiguates among the directory's three semantics (`Dynamics`, `Indexed`). Declarations stay `Realize` (the mathlib `Formula.Realize` register, per the naming note in `Dynamics.lean`).