### PR TITLE
refactor(Semantics/Dynamic/DRS): demutualize Realize via Extends

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -76,6 +76,16 @@ end
 @[simp] theorem DRS.referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
     (K.map f).referents = K.referents.image f := by cases K; rfl
 
+@[simp] theorem DRS.conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).conditions = Condition.mapList f K.conditions := by cases K; rfl
+
+/-- `mapList` is `List.map` (definable only after the mutual block). -/
+theorem Condition.mapList_eq_map [DecidableEq W] (f : V → W) (cs : List (Condition L V)) :
+    Condition.mapList f cs = cs.map (Condition.map f) := by
+  induction cs with
+  | nil => rfl
+  | cons c cs ih => simp only [Condition.mapList, List.map_cons, ih]
+
 /-! ### Merge algebra -/
 
 namespace DRS

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -123,17 +123,17 @@ agrees with the static verifying-embedding semantics — `toRel K a a'` holds if
 the output `a'` extends the input `a` over `K`'s universe and verifies `K`.
 (Both sides are the total-assignment variant; see `DRS/Verification.lean`.) -/
 theorem DRS.toRel_iff_realize (K : DRS L V) (a a' : V → M) :
-    DRS.toRel K a a' ↔ (∀ x ∉ K.referents, a' x = a x) ∧ K.Realize a' := by
+    DRS.toRel K a a' ↔ K.Extends a a' ∧ K.Realize a' := by
   match K with
   | .mk U conds =>
-    simp only [DRS.toRel, DRS.referents_mk, DRS.realize_mk]
+    simp only [DRS.toRel, DRS.referents_mk, DRS.realize_mk, DRS.Extends]
     exact and_congr_right (fun _ => Condition.holdsAll_iff_realizeAll conds a')
 /-- A condition's set denotation agrees with its static `Realize`. -/
 theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
     c.holds a ↔ c.Realize a := by
   match c with
-  | .rel R args => exact Iff.rfl
-  | .eq u v => exact Iff.rfl
+  | .rel R args => simp only [Condition.holds_rel, Condition.realize_rel]
+  | .eq u v => simp only [Condition.holds_eq, Condition.realize_eq]
   | .neg K =>
     simp only [Condition.holds_neg, Condition.realize_neg]
     exact not_congr (exists_congr (fun a' => DRS.toRel_iff_realize K a a'))
@@ -149,11 +149,11 @@ theorem Condition.holds_iff_realize (c : Condition L V) (a : V → M) :
       (exists_congr (fun a' => DRS.toRel_iff_realize r a a'))
 /-- The list analogue of `Condition.holds_iff_realize`. -/
 theorem Condition.holdsAll_iff_realizeAll (cs : List (Condition L V)) (a : V → M) :
-    Condition.holdsAll cs a ↔ Condition.RealizeAll cs a := by
+    Condition.holdsAll cs a ↔ ∀ c ∈ cs, c.Realize a := by
   match cs with
-  | [] => exact Iff.rfl
+  | [] => simp
   | c :: cs =>
-    simp only [Condition.holdsAll_cons, Condition.realizeAll_cons]
+    simp only [Condition.holdsAll_cons, List.forall_mem_cons]
     exact and_congr (Condition.holds_iff_realize c a) (Condition.holdsAll_iff_realizeAll cs a)
 end
 

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -146,11 +146,11 @@ translated formula's `Realize` coincides with the bespoke `DRS.Realize`. As
 `toFormula` existentially closes the universe, the correspondence is with an
 embedding `v'` extending `v` over `K.referents`. -/
 theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : V → M) :
-    (K.toFormula).Realize v ↔ ∃ v', (∀ x ∉ K.referents, v' x = v x) ∧ K.Realize v' := by
+    (K.toFormula).Realize v ↔ ∃ v', K.Extends v v' ∧ K.Realize v' := by
   match K with
   | .mk U conds =>
     rw [DRS.toFormula, realize_closeExists]
-    simp only [DRS.referents_mk, DRS.realize_mk]
+    simp only [DRS.referents_mk, DRS.realize_mk, DRS.Extends]
     exact exists_congr fun v' =>
       and_congr_right fun _ => Condition.realize_toFormulaAll conds v'
 /-- The open body of a DRS (its conditions, no universe closure) realizes as
@@ -179,14 +179,15 @@ theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : V �
   | .dis l r =>
     simp only [Condition.toFormula, Condition.realize_dis, Formula.realize_sup]
     rw [DRS.realize_toFormula l v, DRS.realize_toFormula r v]
-/-- A list of conditions' conjoined translation realizes as `RealizeAll`. -/
+/-- A list of conditions' conjoined translation realizes as the conjunction of
+their realizations. -/
 theorem Condition.realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V)) (v : V → M) :
-    (Condition.toFormulaAll cs).Realize v ↔ Condition.RealizeAll cs v := by
+    (Condition.toFormulaAll cs).Realize v ↔ ∀ c ∈ cs, c.Realize v := by
   match cs with
   | [] => simp [Condition.toFormulaAll, Formula.realize_top]
   | c :: cs =>
-    rw [Condition.toFormulaAll, Condition.realizeAll_cons, Formula.realize_inf,
-      Condition.realize_toFormula c v, Condition.realize_toFormulaAll cs v]
+    rw [Condition.toFormulaAll, Formula.realize_inf, Condition.realize_toFormula c v,
+      Condition.realize_toFormulaAll cs v, List.forall_mem_cons]
 end
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -6,16 +6,16 @@ import Linglib.Semantics.Dynamic.DRS.Basic
 DRS verification via *embeddings* into a mathlib `FirstOrder.Language.Structure`
 — [kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering. An
 embedding is an assignment `v : V → M` of discourse referents to the model
-domain; a sub-DRS is entered by existentially (re)assigning the referents of
-its universe, which is what `∀ x ∉ K.referents, v' x = v x` expresses (`v'`
-extends `v` on `K`'s universe). For `imp`, the consequent witness extends the
-*antecedent* embedding, not the host one — antecedent referents stay visible
-in the consequent, the `⇒` accessibility asymmetry. The atomic and `¬` clauses
-are Def. 1.4.4(ii); the `⇒`/`∨` clauses are the Chapter 2 conditional and
-disjunction semantics. Truth (Def. 1.4.5) is the existential closure of
-verification over the outer universe; it is delivered downstream as
-`DRS.trueRel` (`DRS/Dynamics.lean`) and as the first-order translation's
-realization (`DRS/Reduction.lean`).
+domain; `DRS.Extends K v v'` is K&R's extension relation `v [K] v'` — the
+output `v'` differs from `v` at most on `K`'s universe — and a sub-DRS is
+entered by existentially (re)assigning along it. For `imp`, the consequent
+witness extends the *antecedent* embedding, not the host one — antecedent
+referents stay visible in the consequent, the `⇒` accessibility asymmetry.
+The atomic and `¬` clauses are Def. 1.4.4(ii); the `⇒`/`∨` clauses are the
+Chapter 2 conditional and disjunction semantics. Truth (Def. 1.4.5) is the
+existential closure of verification over the outer universe; it is delivered
+downstream as `DRS.trueRel` (`DRS/Dynamics.lean`) and as the first-order
+translation's realization (`DRS/Reduction.lean`).
 
 **Deviation** ([muskens-1996], fn. 4): K&R's embeddings are *partial* functions
 that sub-DRSs strictly *extend*, so a re-declared referent keeps its value; here
@@ -26,13 +26,22 @@ says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
 
 ## Main declarations
 
-* `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation,
-  reusing mathlib's `Structure.RelMap` for atomic conditions.
+* `DRS.Extends` — K&R's extension relation `v [K] v'`.
+* `DRS.Realize` / `Condition.Realize` — the verifying-embedding relation. A DRS
+  is verified when every condition is (`∀ c ∈ K.conditions`, the `Theory.Model`
+  idiom), so there is no mutual recursion and no list helper.
 * `DRS.realize_perm` — verification reads the condition list as a set, cashing
   the `List`-representation note in `DRS/Defs.lean`.
 * `DRS.realize_map` — renaming along a bijection transports verification:
   alphabetic variants (Def. 1.4.8, via `DRS.map` in `DRS/Basic.lean`) have the
   same semantics.
+
+## Implementation notes
+
+`Condition.Realize` recurses into sub-DRSs through the nested
+`List (Condition L V)` by well-founded recursion on `sizeOf`, so its clause
+characterizations (`realize_neg`, …) are equation-lemma rewrites rather than
+`Iff.rfl`.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -43,84 +52,77 @@ universe u v w x
 
 variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 
-mutual
-/-- `K.Realize v`: the embedding `v` *verifies* `K` — every condition of `K`
-holds under `v`. -/
-def DRS.Realize : DRS L V → (V → M) → Prop
-  | .mk _ conds, v => Condition.RealizeAll conds v
-/-- `c.Realize v`: the embedding `v` verifies the condition `c`; sub-DRSs are
-entered by existentially (re)assigning the referents of their universes. -/
+/-- `K.Extends v v'` (K&R's `v [K] v'`): the output embedding `v'` differs from
+the input `v` at most on `K`'s universe. -/
+def DRS.Extends (K : DRS L V) (v v' : V → M) : Prop := ∀ x ∉ K.referents, v' x = v x
+
+private theorem sizeOf_lt_of_mem_conditions {K : DRS L V} {c : Condition L V}
+    (h : c ∈ K.conditions) : sizeOf c < sizeOf K := by
+  cases K with
+  | mk U conds =>
+    simp only [DRS.conditions_mk] at h
+    have := List.sizeOf_lt_of_mem h
+    simp only [DRS.mk.sizeOf_spec]
+    omega
+
+/-- `c.Realize v`: the embedding `v` *verifies* the condition `c`
+(Def. 1.4.4(ii)); a sub-DRS is entered by existentially (re)assigning along
+its extension relation and verifying each of its conditions. -/
 def Condition.Realize : Condition L V → (V → M) → Prop
   | .rel R args, v => Structure.RelMap R (fun i => v (args i))
   | .eq a b, v => v a = v b
-  | .neg K, v => ¬ ∃ v' : V → M, (∀ x ∉ K.referents, v' x = v x) ∧ DRS.Realize K v'
+  | .neg K, v => ¬ ∃ v', K.Extends v v' ∧ ∀ c ∈ K.conditions, c.Realize v'
   | .imp a c, v =>
-      ∀ v' : V → M, (∀ x ∉ a.referents, v' x = v x) → DRS.Realize a v' →
-        ∃ v'' : V → M, (∀ x ∉ c.referents, v'' x = v' x) ∧ DRS.Realize c v''
+      ∀ v', a.Extends v v' → (∀ d ∈ a.conditions, d.Realize v') →
+        ∃ v'', c.Extends v' v'' ∧ ∀ d ∈ c.conditions, d.Realize v''
   | .dis l r, v =>
-      (∃ v' : V → M, (∀ x ∉ l.referents, v' x = v x) ∧ DRS.Realize l v') ∨
-      (∃ v' : V → M, (∀ x ∉ r.referents, v' x = v x) ∧ DRS.Realize r v')
-/-- Every condition in the list is verified by `v`. A `List` helper — the
-higher-order `List.Forall (·.Realize v)` form fails the nested-inductive
-structural-recursion checker; `realizeAll_iff_forall_mem` is the membership
-characterization. -/
-def Condition.RealizeAll : List (Condition L V) → (V → M) → Prop
-  | [], _ => True
-  | c :: cs, v => Condition.Realize c v ∧ Condition.RealizeAll cs v
-end
+      (∃ v', l.Extends v v' ∧ ∀ c ∈ l.conditions, c.Realize v') ∨
+      (∃ v', r.Extends v v' ∧ ∀ c ∈ r.conditions, c.Realize v')
+decreasing_by all_goals
+  have := sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- `K.Realize v`: the embedding `v` *verifies* `K` — every condition of `K`
+holds under `v` (Def. 1.4.4). -/
+def DRS.Realize (K : DRS L V) (v : V → M) : Prop := ∀ c ∈ K.conditions, c.Realize v
 
 /-! ### Structural simp API -/
 
 variable {v : V → M}
 
 @[simp] theorem DRS.realize_mk (U : Finset V) (conds : List (Condition L V)) :
-    (DRS.mk U conds).Realize v ↔ Condition.RealizeAll conds v := Iff.rfl
+    (DRS.mk U conds).Realize v ↔ ∀ c ∈ conds, c.Realize v := Iff.rfl
 
 @[simp] theorem Condition.realize_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (Condition.rel R args).Realize v ↔ Structure.RelMap R (fun i => v (args i)) := Iff.rfl
+    (Condition.rel R args).Realize v ↔ Structure.RelMap R (fun i => v (args i)) := by
+  simp only [Condition.Realize]
 
 @[simp] theorem Condition.realize_eq (a b : V) :
-    (Condition.eq a b : Condition L V).Realize v ↔ v a = v b := Iff.rfl
+    (Condition.eq a b : Condition L V).Realize v ↔ v a = v b := by
+  simp only [Condition.Realize]
 
 @[simp] theorem Condition.realize_neg (K : DRS L V) :
-    (Condition.neg K).Realize v ↔
-      ¬ ∃ v', (∀ x ∉ K.referents, v' x = v x) ∧ K.Realize v' := Iff.rfl
+    (Condition.neg K).Realize v ↔ ¬ ∃ v', K.Extends v v' ∧ K.Realize v' := by
+  simp only [Condition.Realize, DRS.Realize]
 
 @[simp] theorem Condition.realize_imp (a c : DRS L V) :
     (Condition.imp a c).Realize v ↔
-      ∀ v', (∀ x ∉ a.referents, v' x = v x) → a.Realize v' →
-        ∃ v'', (∀ x ∉ c.referents, v'' x = v' x) ∧ c.Realize v'' := Iff.rfl
+      ∀ v', a.Extends v v' → a.Realize v' →
+        ∃ v'', c.Extends v' v'' ∧ c.Realize v'' := by
+  simp only [Condition.Realize, DRS.Realize]
 
 @[simp] theorem Condition.realize_dis (l r : DRS L V) :
     (Condition.dis l r).Realize v ↔
-      (∃ v', (∀ x ∉ l.referents, v' x = v x) ∧ l.Realize v') ∨
-      (∃ v', (∀ x ∉ r.referents, v' x = v x) ∧ r.Realize v') := Iff.rfl
-
-@[simp] theorem Condition.realizeAll_nil :
-    Condition.RealizeAll ([] : List (Condition L V)) v := trivial
-
-@[simp] theorem Condition.realizeAll_cons (c : Condition L V) (cs : List (Condition L V)) :
-    Condition.RealizeAll (c :: cs) v ↔ c.Realize v ∧ Condition.RealizeAll cs v := Iff.rfl
-
-/-! ### Verification reads the condition list as a set -/
-
-/-- Membership characterization of `RealizeAll`. -/
-theorem Condition.realizeAll_iff_forall_mem {cs : List (Condition L V)} :
-    Condition.RealizeAll cs v ↔ ∀ c ∈ cs, c.Realize v := by
-  induction cs with
-  | nil => simp
-  | cons c cs ih => simp [ih]
-
-/-- Verification of a condition list is invariant under permutation. -/
-theorem Condition.realizeAll_perm {cs ds : List (Condition L V)} (h : cs.Perm ds) :
-    Condition.RealizeAll cs v ↔ Condition.RealizeAll ds v := by
-  simp only [Condition.realizeAll_iff_forall_mem, h.mem_iff]
+      (∃ v', l.Extends v v' ∧ l.Realize v') ∨
+      (∃ v', r.Extends v v' ∧ r.Realize v') := by
+  simp only [Condition.Realize, DRS.Realize]
 
 /-- Verification is invariant under permutation of the conditions — the set
 semantics the `List`-valued `conditions` field promises (`DRS/Defs.lean`). -/
 theorem DRS.realize_perm {U : Finset V} {cs ds : List (Condition L V)} (h : cs.Perm ds) :
-    (DRS.mk U cs).Realize v ↔ (DRS.mk U ds).Realize v :=
-  Condition.realizeAll_perm h
+    (DRS.mk U cs).Realize v ↔ (DRS.mk U ds).Realize v := by
+  simp only [DRS.realize_mk, h.mem_iff]
 
 /-! ### Alphabetic variants -/
 
@@ -158,49 +160,60 @@ private theorem forall_precomp_extend_iff (e : V ≃ W) (U : Finset V) (v : W �
   · intro H v' h
     exact H (v' ∘ e) fun x hx => h (e x) (by simpa using hx)
 
-mutual
+/-- A renamed DRS is verified iff the original is under the precomposed
+embedding, given the transport for each of its conditions. -/
+private theorem realize_map_all (e : V ≃ W) (K : DRS L V) (v' : W → M)
+    (ih : ∀ c ∈ K.conditions, ∀ u : W → M, (c.map e).Realize u ↔ c.Realize (u ∘ e)) :
+    (K.map e).Realize v' ↔ K.Realize (v' ∘ e) := by
+  simp only [DRS.Realize, DRS.conditions_map, Condition.mapList_eq_map, List.forall_mem_map]
+  exact forall_congr' fun c => imp_congr_right fun hc => ih c hc v'
+
+/-- Renaming along a bijection transports verification (the condition form of
+`DRS.realize_map`). -/
+theorem Condition.realize_map (e : V ≃ W) : ∀ (c : Condition L V) (v : W → M),
+    (c.map e).Realize v ↔ c.Realize (v ∘ e)
+  | .rel R args, v => by
+    simp [Condition.map, Function.comp]
+  | .eq a b, v => by
+    simp [Condition.map, Function.comp]
+  | .neg K, v => by
+    have hK := fun v' : W → M =>
+      realize_map_all e K v' (fun d hd u => Condition.realize_map e d u)
+    simp only [Condition.map, Condition.realize_neg, DRS.Extends, DRS.referents_map]
+    exact not_congr ((exists_congr fun v' => and_congr_right fun _ => hK v').trans
+      (exists_precomp_extend_iff e K.referents v K.Realize))
+  | .imp a c, v => by
+    have hA := fun v' : W → M =>
+      realize_map_all e a v' (fun d hd u => Condition.realize_map e d u)
+    have hC := fun v' : W → M =>
+      realize_map_all e c v' (fun d hd u => Condition.realize_map e d u)
+    simp only [Condition.map, Condition.realize_imp, DRS.Extends, DRS.referents_map]
+    refine Iff.trans (forall_congr' fun v' => imp_congr_right fun _ => imp_congr (hA v')
+      ((exists_congr fun v'' => and_congr_right fun _ => hC v'').trans
+        (exists_precomp_extend_iff e c.referents v' c.Realize))) ?_
+    exact forall_precomp_extend_iff e a.referents v
+      (fun u => a.Realize u → ∃ w'', (∀ x ∉ c.referents, w'' x = u x) ∧ c.Realize w'')
+  | .dis l r, v => by
+    have hL := fun v' : W → M =>
+      realize_map_all e l v' (fun d hd u => Condition.realize_map e d u)
+    have hR := fun v' : W → M =>
+      realize_map_all e r v' (fun d hd u => Condition.realize_map e d u)
+    simp only [Condition.map, Condition.realize_dis, DRS.Extends, DRS.referents_map]
+    exact or_congr
+      ((exists_congr fun v' => and_congr_right fun _ => hL v').trans
+        (exists_precomp_extend_iff e l.referents v l.Realize))
+      ((exists_congr fun v' => and_congr_right fun _ => hR v').trans
+        (exists_precomp_extend_iff e r.referents v r.Realize))
+decreasing_by all_goals
+  have := sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
 /-- Renaming along a bijection transports verification: `v` verifies `K.map e`
 iff `v ∘ e` verifies `K` — alphabetic variants have the same semantics. -/
 theorem DRS.realize_map (e : V ≃ W) (K : DRS L V) (v : W → M) :
-    (K.map e).Realize v ↔ K.Realize (v ∘ e) := by
-  match K with
-  | .mk U conds =>
-    simp only [DRS.map, DRS.realize_mk]
-    exact Condition.realizeAll_mapList e conds v
-/-- The condition analogue of `DRS.realize_map`. -/
-theorem Condition.realize_map (e : V ≃ W) (c : Condition L V) (v : W → M) :
-    (c.map e).Realize v ↔ c.Realize (v ∘ e) := by
-  match c with
-  | .rel R args => exact Iff.rfl
-  | .eq a b => exact Iff.rfl
-  | .neg K =>
-    simp only [Condition.map, Condition.realize_neg, DRS.referents_map]
-    exact not_congr ((exists_congr fun v' => and_congr_right fun _ =>
-      DRS.realize_map e K v').trans (exists_precomp_extend_iff e K.referents v K.Realize))
-  | .imp ante cons =>
-    simp only [Condition.map, Condition.realize_imp, DRS.referents_map]
-    refine Iff.trans (forall_congr' fun v' => imp_congr_right fun _ => imp_congr
-      (DRS.realize_map e ante v')
-      ((exists_congr fun v'' => and_congr_right fun _ => DRS.realize_map e cons v'').trans
-        (exists_precomp_extend_iff e cons.referents v' cons.Realize))) ?_
-    exact forall_precomp_extend_iff e ante.referents v
-      (fun u => ante.Realize u → ∃ w'', (∀ x ∉ cons.referents, w'' x = u x) ∧ cons.Realize w'')
-  | .dis l r =>
-    simp only [Condition.map, Condition.realize_dis, DRS.referents_map]
-    exact or_congr
-      ((exists_congr fun v' => and_congr_right fun _ => DRS.realize_map e l v').trans
-        (exists_precomp_extend_iff e l.referents v l.Realize))
-      ((exists_congr fun v' => and_congr_right fun _ => DRS.realize_map e r v').trans
-        (exists_precomp_extend_iff e r.referents v r.Realize))
-/-- The list analogue of `Condition.realize_map`. -/
-theorem Condition.realizeAll_mapList (e : V ≃ W) (cs : List (Condition L V)) (v : W → M) :
-    Condition.RealizeAll (Condition.mapList e cs) v ↔ Condition.RealizeAll cs (v ∘ e) := by
-  match cs with
-  | [] => exact Iff.rfl
-  | c :: cs =>
-    simp only [Condition.mapList, Condition.realizeAll_cons]
-    exact and_congr (Condition.realize_map e c v) (Condition.realizeAll_mapList e cs v)
-end
+    (K.map e).Realize v ↔ K.Realize (v ∘ e) :=
+  realize_map_all e K v (fun c _ u => Condition.realize_map e c u)
 
 end Map
 


### PR DESCRIPTION
`Condition.Realize` becomes a single well-founded definition (no `mutual`, no `RealizeAll` helper): sub-boxes are entered via the named K&R extension relation `DRS.Extends` (`v [K] v'`) and satisfied via `∀ c ∈ K.conditions` (mathlib's `Theory.Model` idiom); `DRS.Realize` is a thin wrapper.

- clause lemmas keep their statements but are equation-lemma rewrites (wf defs don't reduce by `rfl`)
- `toRel_iff_realize` / `realize_toFormula` now read `… ↔ K.Extends _ _ ∧ K.Realize _`
- `realize_map` collapses from a theorem mutual to one wf theorem + a `realize_map_all` helper