### PR TITLE
refactor(Semantics/Dynamic/DRS): Box container structure; no mutual types

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -12,7 +12,7 @@ Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
   identity is the identity" a free corollary, and `Embedding.verifies_map`
   (`DRS/Verification.lean`) shows variants have the same semantics.
 * `merge` algebra — identity (`empty`) and associativity.
-* `Embedding` and `DRS.Extends` — embedding functions and K&R's extension
+* `Embedding` and `Box.Extends` — embedding functions and K&R's extension
   relation `f [K] g` between them.
 * `DRS.fv` / `DRS.IsProper` — free discourse referents (as a `Finset`) and
   properness (`fv K = ∅`, Def. 1.4.2–1.4.3).
@@ -54,11 +54,7 @@ mutual
 /-- Renaming along the identity is the identity. -/
 @[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
   match K with
-  | .mk refs conds =>
-      simp only [DRS.map, Condition.mapList_id]
-      congr 1
-      ext x
-      simp
+  | .mk refs conds => simp only [DRS.map, Condition.mapList_id, Finset.image_id]
 /-- Renaming a condition along the identity is the identity. -/
 @[simp] theorem Condition.map_id [DecidableEq V] (c : Condition L V) :
     Condition.map id c = c := by
@@ -123,17 +119,18 @@ abbrev Embedding (V : Type w) (M : Type*) := V → M
 
 section Extends
 
-variable {M : Type*}
+variable {M : Type*} {C : Type x}
 
 /-- `K.Extends f g` (K&R's `f [K] g`): the output embedding `g` differs from
 the input `f` at most on `K`'s universe — the total-assignment rendering of
-"`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
-def DRS.Extends (K : DRS L V) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
+"`f ⊆ g` and `Dom g = Dom f ∪ U_K`". Stated for any box, since only the
+universe is read. -/
+def Box.Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
 
 /-- Extension along a renamed DRS is extension of the precompositions. -/
 theorem DRS.extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
     (K.map e).Extends f g ↔ K.Extends (f ∘ e) (g ∘ e) := by
-  simp only [DRS.Extends, DRS.referents_map, Function.comp_apply]
+  simp only [Box.Extends, DRS.referents_map, Function.comp_apply]
   constructor
   · intro h x hx
     exact h (e x) (by simpa using hx)
@@ -242,7 +239,7 @@ def Condition.fvL : List (Condition L V) → Finset V
 end
 
 @[simp] theorem DRS.fv_mk (U : Finset V) (conds : List (Condition L V)) :
-    (DRS.mk U conds).fv = Condition.fvL conds \ U := rfl
+    DRS.fv ⟨U, conds⟩ = Condition.fvL conds \ U := rfl
 @[simp] theorem Condition.fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
     (Condition.rel R args).fv = Finset.image args Finset.univ := rfl
 @[simp] theorem Condition.fv_eq (u v : V) :
@@ -260,7 +257,7 @@ end
 referents are supplied by `X` iff its conditions' are supplied by the grown
 base. -/
 theorem DRS.fv_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
-    (DRS.mk U conds).fv ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
+    DRS.fv ⟨U, conds⟩ ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
   rw [DRS.fv_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
 
 mutual

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -20,8 +20,9 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
 
 ## Main declarations
 
-* `DRS L V`, `Condition L V` — the mutual data type over a language `L` (relation
-  signature) and discourse-referent type `V`.
+* `Box`, `Condition L V`, `DRS L V` — the data type over a language `L`
+  (relation signature) and discourse-referent type `V`: a DRS is a `Box` of
+  `Condition`s.
 * `DRS.merge` — the `⊕` operation (set-union referents, concatenate
   conditions); [muskens-1996]'s compositional operation.
 * `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — immediate
@@ -33,8 +34,13 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
 
 * `referents` is the textbook "universe `U`"; named for its contents because
   `universe` is a Lean keyword and `univ` collides with `Finset.univ`.
+* No mutual block: `Box` is a parameterized container structure the condition
+  syntax nests through, and `DRS` its instantiation at `Condition L V` — the
+  simultaneous Def. 1.4.1 rendered as nesting, with the structure API
+  (projections, `ext`, eta) for free.
 * The recursive `conditions` field is a `List`: Lean forbids nesting an inductive
-  through `Finset`/`Multiset`. Set semantics are imposed by the interpretation.
+  through `Finset`/`Multiset`. Set semantics are imposed by the interpretation
+  (`Embedding.verifies_perm`, `DRS/Verification.lean`).
 * `DRT` is the owning namespace (mathlib's `FirstOrder.Language` pattern):
   `DRS`, `Condition`, and `Ctx` are DRT's objects, keeping generic names
   owner-relative rather than claiming them at the root.
@@ -44,16 +50,23 @@ open FirstOrder
 
 namespace DRT
 
-universe u v w
+universe u v w x
 
 variable {L : Language.{u, v}} {V : Type w}
 
-mutual
-/-- A discourse representation structure: the pair `⟨referents, conditions⟩`
-(Def. 1.4.1). `referents` is the universe `U` (a finite set of discourse
-referents); `conditions` the DRS-conditions. -/
-inductive DRS (L : Language.{u, v}) (V : Type w) where
-  | mk (referents : Finset V) (conditions : List (Condition L V))
+/-- A DRT *box* over condition type `C`: a universe of discourse referents and
+a list of conditions — the two-compartment diagram the field draws (universe
+above, conditions below; [muskens-1996]'s linear `[u₁ … uₙ | γ₁ … γₘ]`). "Box"
+and "DRS" name the same object in the literature, in diagrammatic vs. official
+register; here `Box` is the generic shell that DRT variants re-instantiate at
+their condition types (`DRS` at `Condition L V`; cf. Layered DRT's LDRSs), and
+the container the condition syntax nests through. -/
+@[ext] structure Box (V : Type w) (C : Type x) where
+  /-- The universe `U`: the discourse referents the box introduces. -/
+  referents : Finset V
+  /-- The box's conditions. -/
+  conditions : List C
+
 /-- A DRS-condition: atomic (`rel`, `eq`) or complex — `neg` per Def. 1.4.1,
 `imp`/`dis` per its Chapter 2 extension. Sub-DRSs occur only inside complex
 conditions. -/
@@ -63,40 +76,37 @@ inductive Condition (L : Language.{u, v}) (V : Type w) where
   /-- Atomic equality condition `u = v`. -/
   | eq (u v : V)
   /-- Complex condition `¬K`. -/
-  | neg (K : DRS L V)
+  | neg (K : Box V (Condition L V))
   /-- Complex condition `K₁ ⇒ K₂` (antecedent ⇒ consequent). -/
-  | imp (ante cons : DRS L V)
+  | imp (ante cons : Box V (Condition L V))
   /-- Complex condition `K₁ ∨ K₂`. -/
-  | dis (left right : DRS L V)
-end
+  | dis (left right : Box V (Condition L V))
+
+/-- A discourse representation structure: a box of DRS-conditions — the pair
+`⟨referents, conditions⟩` (Def. 1.4.1). -/
+abbrev DRS (L : Language.{u, v}) (V : Type w) := Box V (Condition L V)
 
 namespace DRS
 
-/-- The referents (universe `U`) of a DRS — the discourse referents it introduces. -/
-def referents : DRS L V → Finset V
-  | .mk u _ => u
-
-/-- The conditions of a DRS. -/
-def conditions : DRS L V → List (Condition L V)
-  | .mk _ c => c
-
 @[simp] theorem referents_mk (u : Finset V) (c : List (Condition L V)) :
-    (DRS.mk u c).referents = u := rfl
+    (Box.mk u c).referents = u := rfl
 
 @[simp] theorem conditions_mk (u : Finset V) (c : List (Condition L V)) :
-    (DRS.mk u c).conditions = c := rfl
+    (Box.mk u c).conditions = c := rfl
 
 /-- A condition of a DRS is smaller than the DRS — the recursion measure for
 definitions descending through the nested `List (Condition L V)`. -/
 theorem sizeOf_lt_of_mem_conditions {K : DRS L V} {c : Condition L V}
     (h : c ∈ K.conditions) : sizeOf c < sizeOf K := by
   obtain ⟨U, conds⟩ := K
-  have := List.sizeOf_lt_of_mem (by simpa using h)
-  simp only [DRS.mk.sizeOf_spec]
+  have : sizeOf c < sizeOf conds := List.sizeOf_lt_of_mem h
+  simp only [Box.mk.sizeOf_spec]
   omega
 
 /-- The empty DRS `⟨∅, []⟩`. -/
 def empty : DRS L V := .mk ∅ []
+
+instance : Inhabited (DRS L V) := ⟨empty⟩
 
 /-- Merge `⊕`: set-union the referents, concatenate the conditions. The binary
 DRS merge is Muskens's compositional operation — Kamp & Reyle themselves
@@ -113,7 +123,7 @@ def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
 
 end DRS
 
-/-! ### Subordination and accessibility -/
+/-! ### Subordination -/
 
 /-- One-step subordination ("`K'` is *directly subordinate* to `K`"). The `neg`
 case is Def. 1.4.10(i); the `⇒`/`∨` cases are its Chapter 2 extension:
@@ -122,7 +132,10 @@ case is Def. 1.4.10(i); the `⇒`/`∨` cases are its Chapter 2 extension:
 * the antecedent of a `⇒` is subordinate to the containing DRS;
 * the consequent of a `⇒` is subordinate to its *antecedent* (the ⇒ asymmetry:
   antecedent referents are accessible in the consequent, not conversely);
-* each disjunct of a `∨` is subordinate to the containing DRS. -/
+* each disjunct of a `∨` is subordinate to the containing DRS.
+
+A relation on DRS *values*, where the textbook's is on box *occurrences*: on a
+degenerate `imp a a` the consequent edge makes `a` subordinate to itself. -/
 inductive DirectlySubordinate : DRS L V → DRS L V → Prop where
   | neg {D K : DRS L V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
   | impAnte {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -120,10 +120,10 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     (DRS.toRel (K₁.merge K₂) : Update (V → M)) = seq (DRS.toRel K₁) (DRS.toRel K₂) := by
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
-  simp only [DRS.referents_mk, DRS.conditions_mk, Finset.disjoint_left] at hfresh
+  simp only [Finset.disjoint_left] at hfresh
   funext a a'
   apply propext
-  simp only [DRS.toRel, DRS.Extends, DRS.merge, DRS.referents_mk, DRS.conditions_mk,
+  simp only [DRS.toRel, Box.Extends, DRS.merge, DRS.referents_mk,
     Embedding.verifies_mk, List.forall_mem_append, seq, Relation.Comp]
   constructor
   · rintro ⟨hag, hh₁, hh₂⟩

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -381,7 +381,7 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
     have hIHc : ∀ k : V → M, Condition.holdsAllAt (((X ∪ Ua) ∪ Uc) ∪ Δ) cc k ↔
         Condition.holdsAllAt ((X ∪ Ua) ∪ Uc) cc k :=
       fun k => Condition.holdsAllAt_union_fresh cc hΔcc hfvcc k
-    simp only [Condition.holdsAt_imp, DRS.referents_mk]
+    simp only [Condition.holdsAt_imp]
     constructor
     · intro hL g₁ hg₁
       obtain ⟨hadj, heq⟩ := DRS.toRelAt_adjust hΔUa hfvca hIHa hg₁
@@ -450,10 +450,9 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
   obtain ⟨U₁, c₁⟩ := K₁
   obtain ⟨U₂, c₂⟩ := K₂
   have hfvc₁ := DRS.fv_subset_iff.mp h₁
-  simp only [DRS.referents_mk, DRS.conditions_mk] at hfresh
   funext f g
   apply propext
-  simp only [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.toRelAt_mk,
+  simp only [DRS.merge, DRS.toRelAt_mk,
     Condition.holdsAllAt_append, DynamicSemantics.Update.seq, Relation.Comp]
   rw [← Finset.union_assoc]
   constructor
@@ -563,7 +562,7 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
   | .imp a c' =>
     obtain ⟨Ua, ca⟩ := a
     obtain ⟨Uc, cc⟩ := c'
-    simp only [Condition.reuseFreeAt_imp, DRS.reuseFreeAt_mk, DRS.referents_mk] at hrf
+    simp only [Condition.reuseFreeAt_imp, DRS.reuseFreeAt_mk] at hrf
     obtain ⟨⟨hXUa, hrfa⟩, hXUc, hrfc⟩ := hrf
     rw [Condition.fv_imp, Finset.union_subset_iff] at hfv
     obtain ⟨hfva, hfvc'⟩ := hfv
@@ -583,7 +582,7 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
     have hIHc : ∀ k : V → M, (∀ c ∈ cc, Embedding.VerifiesCondition k c) ↔
         Condition.holdsAllAt ((X ∪ Ua) ∪ Uc) cc k :=
       fun k => Condition.verifiesAll_iff_holdsAllAt cc hrfc hfvcc k
-    simp only [Embedding.verifies_imp, Condition.holdsAt_imp, DRS.referents_mk]
+    simp only [Embedding.verifies_imp, Condition.holdsAt_imp]
     constructor
     · intro hL g₁ hg₁
       obtain ⟨hflat, heq⟩ := DRS.toRel_of_toRelAt' hfvca hIHa hg₁

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -150,7 +150,7 @@ theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : Embedding V M) 
   match K with
   | .mk U conds =>
     rw [DRS.toFormula, realize_closeExists]
-    simp only [DRS.referents_mk, Embedding.verifies_mk, DRS.Extends]
+    simp only [Embedding.verifies_mk, Box.Extends]
     exact exists_congr fun v' =>
       and_congr_right fun _ => Condition.realize_toFormulaAll conds v'
 /-- The open body of a DRS (its conditions, no universe closure) realizes as

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Dynamic.DRS.Basic
 [kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering, over a
 mathlib `FirstOrder.Language.Structure`. An *embedding function*
 `f : Embedding V M` assigns discourse referents to individuals in the model;
-`DRS.Extends K f g` is K&R's extension relation `f [K] g` (both in
+`Box.Extends K f g` is K&R's extension relation `f [K] g` (both in
 `DRS/Basic.lean`); `f.Verifies K` says the embedding `f` *verifies* the DRS
 `K` — it verifies every condition of `K` — and `f.VerifiesCondition c` that it
 verifies the DRS-condition `c`. A sub-DRS is entered by existentially

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -83,7 +83,7 @@ def persistence : DRS krLang ℕ :=
 that is a man, walked in, and sat down. -/
 theorem persistence_tc (a : ℕ → M) :
     DRS.trueRel persistence a ↔ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] ∧ rm .satDown ![e] := by
-  simp only [DRS.trueRel_iff, persistence, DRS.toRel_iff, DRS.Extends, DRS.referents_mk,
+  simp only [DRS.trueRel_iff, persistence, DRS.toRel_iff, Box.Extends,
     Embedding.verifies_mk, List.forall_mem_cons, List.not_mem_nil, false_implies,
     implies_true, Embedding.verifies_rel, comp_vecCons, comp_vecEmpty, and_true]
   constructor
@@ -113,8 +113,8 @@ theorem donkey_universal_reading (a : ℕ → M) :
     DRS.trueRel donkey a ↔
     ∀ e₁ e₂ : M, (rm .farmer ![e₁] ∧ rm .donkey ![e₂] ∧ rm .owns ![e₁, e₂]) →
       rm .beats ![e₁, e₂] := by
-  simp only [DRS.trueRel_iff, donkey, donkeyAnte, donkeyCons, DRS.toRel_iff, DRS.Extends,
-    DRS.referents_mk, Embedding.verifies_mk, List.forall_mem_cons, List.not_mem_nil,
+  simp only [DRS.trueRel_iff, donkey, donkeyAnte, donkeyCons, DRS.toRel_iff, Box.Extends,
+    Embedding.verifies_mk, List.forall_mem_cons, List.not_mem_nil,
     false_implies, implies_true, Embedding.verifies_imp, Embedding.verifies_rel,
     comp_vecCons, comp_vecEmpty, and_true]
   constructor
@@ -141,8 +141,8 @@ def negation : DRS krLang ℕ := .mk ∅ [.neg negInner]
 is bound inside the negation and inaccessible to any continuation. -/
 theorem negation_tc (a : ℕ → M) :
     DRS.trueRel negation a ↔ ¬ ∃ e : M, rm .man ![e] ∧ rm .walkedIn ![e] := by
-  simp only [DRS.trueRel_iff, negation, negInner, DRS.toRel_iff, DRS.Extends,
-    DRS.referents_mk, Embedding.verifies_mk, List.forall_mem_cons, List.not_mem_nil,
+  simp only [DRS.trueRel_iff, negation, negInner, DRS.toRel_iff, Box.Extends,
+    Embedding.verifies_mk, List.forall_mem_cons, List.not_mem_nil,
     false_implies, implies_true, Embedding.verifies_neg, Embedding.verifies_rel,
     comp_vecCons, comp_vecEmpty, and_true]
   constructor
@@ -157,13 +157,13 @@ theorem negation_tc (a : ℕ → M) :
 
 /-- The antecedent box is directly subordinate to the donkey DRS. -/
 theorem donkey_antecedent_subordinate : DirectlySubordinate donkeyAnte donkey :=
-  .impAnte (c := donkeyCons) (by simp [donkey, DRS.conditions])
+  .impAnte (c := donkeyCons) (by simp [donkey])
 
 /-- The consequent box is directly subordinate to the *antecedent* — the `⇒`
 asymmetry that makes the antecedent's referents accessible in the consequent. -/
 theorem donkey_consequent_subordinate : DirectlySubordinate donkeyCons donkeyAnte :=
   .impCons (show Condition.imp donkeyAnte donkeyCons ∈ donkey.conditions by
-    simp [donkey, DRS.conditions])
+    simp [donkey])
 
 /-! ### Model evaluation: donkey true in a concrete model
 


### PR DESCRIPTION
The mutual inductive dissolves: `Box V C` is a parameterized container structure (`referents`/`conditions`), `Condition` a single inductive nesting through it, and `DRS L V := Box V (Condition L V)` — Def. 1.4.1's pair with the structure API (`ext`, eta, `mk.injEq`, projections) auto-generated. "Box" is the field's own register for a DRS seen as its two-compartment diagram (Muskens's `[u₁ … uₙ | γ₁ … γₘ]`), and the generic shell is what DRT variants re-instantiate (cf. the hand-rolled `LDRS` in `Studies/VanDerSandtMaier2003.lean`, a future consumer). `Extends` generalizes to `Box.Extends` (only the universe is read); newly redundant projection simp args stripped.