### PR TITLE
refactor(Semantics/Dynamic/DRS): demutualize map; add map_map functor law

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1603,6 +1603,7 @@ import Linglib.Semantics.Dynamic.Category
 import Linglib.Semantics.Dynamic.Collapse
 import Linglib.Semantics.Dynamic.DPL
 import Linglib.Semantics.Dynamic.DRS.Basic
+import Linglib.Semantics.Dynamic.DRS.Box
 import Linglib.Semantics.Dynamic.DRS.Category
 import Linglib.Semantics.Dynamic.DRS.Defs
 import Linglib.Semantics.Dynamic.DRS.Dynamics

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -1,15 +1,14 @@
 import Linglib.Semantics.Dynamic.DRS.Defs
-import Mathlib.Data.Finset.Image
 
 /-!
 # Structural operations on DRSs
 
 This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
 functorial renaming of discourse referents (`DRS.map`), the merge algebra,
-embedding functions (`Embedding`) with the extension relation `f [K] g`
-(`Box.Extends`), and the referent predicates `varFinset`, `freeVarFinset` and
-`IsProper`, `ReuseFreeAt`, and `Accessible`. Renaming along a bijection is
-[kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
+transport of the extension relation along renaming, and the referent
+predicates `varFinset`, `freeVarFinset` and `IsProper`, `ReuseFreeAt`, and
+`Accessible`. Renaming along a bijection is [kamp-reyle-1993]'s *alphabetic
+variant* (the prose preceding Def. 1.4.8).
 -/
 
 open FirstOrder
@@ -18,67 +17,7 @@ namespace DRT
 
 universe u v w x
 
-variable {L : Language.{u, v}} {V : Type w} {W : Type x} {C D E M X : Type*}
-
-/-- An *embedding function* is a function that maps discourse referents to
-individuals in a model — here total (deviation note in `DRS/Verification.lean`).
-Only the model's domain `M` appears; its interpretation of the relation
-symbols enters with verification (`f.Verifies K`, `DRS/Verification.lean`). -/
-abbrev Embedding (V : Type w) (M : Type*) := V → M
-
-/-! ## Boxes -/
-
-namespace Box
-
-variable [DecidableEq W] {f : V → W} {g : C → D} {K : Box V C}
-
-/-! ### Functorial action -/
-
-/-- `K.map f g` applies `f` to the universe and `g` to each condition. -/
-def map (f : V → W) (g : C → D) (K : Box V C) : Box W D :=
-  ⟨K.referents.image f, K.conditions.map g⟩
-
-/-- Well-founded recursions may traverse sub-boxes with `Box.map`: preprocessing
-re-marks the condition list, exposing `· ∈ K.conditions` to termination proofs. -/
-@[wf_preprocess] theorem map_wfParam :
-    map f g (wfParam K) = ⟨K.referents.image f, (wfParam K.conditions).map g⟩ := by
-  simp [wfParam, map]
-
-@[simp] theorem referents_map : (K.map f g).referents = K.referents.image f := rfl
-
-@[simp] theorem conditions_map : (K.map f g).conditions = K.conditions.map g := rfl
-
-@[simp] theorem map_id [DecidableEq V] : K.map id id = K := by
-  simp [map]
-
-@[simp] theorem map_id' [DecidableEq V] : K.map id (fun c => c) = K := map_id
-
-@[congr] theorem map_congr {f' : V → W} {g' : C → D} {K' : Box V C} (hf : f = f')
-    (hg : ∀ c ∈ K.conditions, g c = g' c) (hK : K = K') : K.map f g = K'.map f' g' := by
-  subst hK; subst hf
-  simp [map, List.map_congr_left hg]
-
-theorem map_map [DecidableEq X] {f' : W → X} {g' : D → E} :
-    (K.map f g).map f' g' = K.map (f' ∘ f) (g' ∘ g) := by
-  simp [map, Finset.image_image, List.map_map]
-
-theorem map_eq_self [DecidableEq V] {g : C → C} {K : Box V C}
-    (h : ∀ c ∈ K.conditions, g c = c) : K.map id g = K :=
-  (map_congr rfl h rfl).trans map_id'
-
-theorem map_map_of_forall [DecidableEq X] (f : V → W) (f' : W → X) {g' : D → E}
-    {g'' : C → E} (h : ∀ c ∈ K.conditions, g' (g c) = g'' c) :
-    (K.map f g).map f' g' = K.map (f' ∘ f) g'' :=
-  map_map.trans (map_congr rfl h rfl)
-
-/-! ### The extension relation -/
-
-/-- `K.Extends f g` (written `f [K] g`) if the output embedding `g` differs
-from the input `f` at most on `K`'s universe — the total-assignment rendering
-of "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
-def Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
-
-end Box
+variable {L : Language.{u, v}} {V : Type w} {W : Type x} {M X : Type*}
 
 /-! ## Conditions -/
 

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -7,8 +7,8 @@ import Mathlib.Data.Finset.Image
 This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
 functorial renaming of discourse referents (`DRS.map`), the merge algebra,
 embedding functions (`Embedding`) with the extension relation `f [K] g`
-(`Box.Extends`), and the referent predicates `occ`, `fv` and `IsProper`,
-`ReuseFreeAt`, and `Accessible`. Renaming along a bijection is
+(`Box.Extends`), and the referent predicates `varFinset`, `freeVarFinset` and
+`IsProper`, `ReuseFreeAt`, and `Accessible`. Renaming along a bijection is
 [kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
 -/
 
@@ -20,11 +20,19 @@ universe u v w x
 
 variable {L : Language.{u, v}} {V : Type w} {W : Type x} {C D E M X : Type*}
 
-/-! ### Functorial renaming -/
+/-- An *embedding function* is a function that maps discourse referents to
+individuals in a model — here total (deviation note in `DRS/Verification.lean`).
+Only the model's domain `M` appears; its interpretation of the relation
+symbols enters with verification (`f.Verifies K`, `DRS/Verification.lean`). -/
+abbrev Embedding (V : Type w) (M : Type*) := V → M
+
+/-! ## Boxes -/
 
 namespace Box
 
 variable [DecidableEq W] {f : V → W} {g : C → D} {K : Box V C}
+
+/-! ### Functorial action -/
 
 /-- `K.map f g` applies `f` to the universe and `g` to each condition. -/
 def map (f : V → W) (g : C → D) (K : Box V C) : Box W D :=
@@ -63,9 +71,20 @@ theorem map_map_of_forall [DecidableEq X] (f : V → W) (f' : W → X) {g' : D �
     (K.map f g).map f' g' = K.map (f' ∘ f) g'' :=
   map_map.trans (map_congr rfl h rfl)
 
+/-! ### The extension relation -/
+
+/-- `K.Extends f g` (written `f [K] g`) if the output embedding `g` differs
+from the input `f` at most on `K`'s universe — the total-assignment rendering
+of "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
+def Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
+
 end Box
 
+/-! ## Conditions -/
+
 namespace Condition
+
+/-! ### Renaming -/
 
 /-- Rename discourse referents along `f` throughout a condition. -/
 def map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
@@ -94,133 +113,42 @@ theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W)
   | imp a c iha ihc => simp [map, Box.map_map_of_forall f g iha, Box.map_map_of_forall f g ihc]
   | dis l r ihl ihr => simp [map, Box.map_map_of_forall f g ihl, Box.map_map_of_forall f g ihr]
 
-end Condition
-
-namespace DRS
-
-/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
-def map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
-  Box.map f (Condition.map f)
-
-@[simp] theorem referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).referents = K.referents.image f := rfl
-
-@[simp] theorem conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).conditions = K.conditions.map (Condition.map f) := rfl
-
-/-- Renaming a DRS along the identity is the identity. -/
-@[simp] theorem map_id [DecidableEq V] (K : DRS L V) : map id K = K := by
-  simp [map]
-
-/-- Renaming a DRS along a composite is the composite of the renamings. -/
-theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
-    map g (map f K) = map (g ∘ f) K := by
-  simp [map, Box.map_map, Condition.map_map g f]
-
-/-! ### Merge algebra -/
-
 variable [DecidableEq V]
-
-@[simp] theorem empty_merge (K : DRS L V) : (empty : DRS L V).merge K = K := by
-  cases K with
-  | mk r c => simp [merge, empty]
-
-@[simp] theorem merge_empty (K : DRS L V) : K.merge (empty : DRS L V) = K := by
-  cases K with
-  | mk r c => simp [merge, empty]
-
-theorem merge_assoc (K₁ K₂ K₃ : DRS L V) :
-    (K₁.merge K₂).merge K₃ = K₁.merge (K₂.merge K₃) := by
-  cases K₁; cases K₂; cases K₃
-  simp only [merge, referents_mk, conditions_mk]
-  rw [Finset.union_assoc, List.append_assoc]
-
-end DRS
-
-/-! ### Embeddings and the extension relation -/
-
-/-- An *embedding function* is a function that maps discourse referents to
-individuals in a model — here total (deviation note in `DRS/Verification.lean`).
-Only the model's domain `M` appears; its interpretation of the relation
-symbols enters with verification (`f.Verifies K`, `DRS/Verification.lean`). -/
-abbrev Embedding (V : Type w) (M : Type*) := V → M
-
-/-- `K.Extends f g` (written `f [K] g`) if the output embedding `g` differs
-from the input `f` at most on `K`'s universe — the total-assignment rendering
-of "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
-def Box.Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
-
-namespace DRS
-
-/-- Extension along a renamed DRS is extension of the precompositions. -/
-theorem extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
-    (K.map e).Extends f g ↔ K.Extends (f ∘ e) (g ∘ e) := by
-  simp only [Box.Extends, referents_map, Function.comp_apply]
-  refine ⟨fun h x hx => h (e x) (by simpa using hx), fun h y hy => ?_⟩
-  have hx : e.symm y ∉ K.referents := fun hm =>
-    hy (by simpa using Finset.mem_image_of_mem e hm)
-  simpa using h (e.symm y) hx
-
-/-- The extensions of `f` at `K.map e` are the extensions of `f ∘ e` at `K`,
-via precomposition. -/
-theorem exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
-    (P : Embedding V M → Prop) :
-    (∃ g, (K.map e).Extends f g ∧ P (g ∘ e)) ↔ ∃ g, K.Extends (f ∘ e) g ∧ P g := by
-  simp only [extends_map]
-  refine ⟨fun ⟨g, hg, hp⟩ => ⟨g ∘ e, hg, hp⟩, fun ⟨g, hg, hp⟩ => ⟨g ∘ e.symm, ?_⟩⟩
-  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
-  exact key.symm ▸ ⟨hg, hp⟩
-
-/-- The `∀` analogue of `DRS.exists_extends_map`. -/
-theorem forall_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
-    (P : Embedding V M → Prop) :
-    (∀ g, (K.map e).Extends f g → P (g ∘ e)) ↔ ∀ g, K.Extends (f ∘ e) g → P g := by
-  simp only [extends_map]
-  refine ⟨fun H g hg => ?_, fun H g hg => H (g ∘ e) hg⟩
-  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
-  exact key ▸ H (g ∘ e.symm) (key.symm ▸ hg)
-
-end DRS
 
 /-! ### Occurring referents -/
 
-section Occ
-variable [DecidableEq V]
-
-namespace Condition
-
 /-- Occurring referents (free or bound) in a condition, as a `Finset` — the DRS
-analogue of mathlib's `Term.varFinset`. Membership `x ∈ occ c` is decidable, so
-downstream consumers get decidable occurrence for free. -/
-def occ : Condition L V → Finset V
+analogue of mathlib's `Term.varFinset`. Membership `x ∈ varFinset c` is
+decidable, so downstream consumers get decidable occurrence for free. -/
+def varFinset : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => K.referents ∪ (K.conditions.map occ).foldr (· ∪ ·) ∅
-  | .imp a c => (a.referents ∪ (a.conditions.map occ).foldr (· ∪ ·) ∅) ∪
-      (c.referents ∪ (c.conditions.map occ).foldr (· ∪ ·) ∅)
-  | .dis l r => (l.referents ∪ (l.conditions.map occ).foldr (· ∪ ·) ∅) ∪
-      (r.referents ∪ (r.conditions.map occ).foldr (· ∪ ·) ∅)
+  | .neg K => K.referents ∪ (K.conditions.map varFinset).foldr (· ∪ ·) ∅
+  | .imp a c => (a.referents ∪ (a.conditions.map varFinset).foldr (· ∪ ·) ∅) ∪
+      (c.referents ∪ (c.conditions.map varFinset).foldr (· ∪ ·) ∅)
+  | .dis l r => (l.referents ∪ (l.conditions.map varFinset).foldr (· ∪ ·) ∅) ∪
+      (r.referents ∪ (r.conditions.map varFinset).foldr (· ∪ ·) ∅)
 
 /-- Occurring referents in a list of conditions. -/
-def occL (cs : List (Condition L V)) : Finset V := (cs.map occ).foldr (· ∪ ·) ∅
+def varFinsetL (cs : List (Condition L V)) : Finset V := (cs.map varFinset).foldr (· ∪ ·) ∅
 
-@[simp] theorem occL_nil : occL ([] : List (Condition L V)) = ∅ := rfl
-@[simp] theorem occL_cons (c : Condition L V) (cs : List (Condition L V)) :
-    occL (c :: cs) = c.occ ∪ occL cs := rfl
-@[simp] theorem occ_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (rel R args).occ = Finset.image args Finset.univ := by simp only [occ]
-@[simp] theorem occ_eq (u v : V) :
-    (eq u v : Condition L V).occ = {u, v} := by simp only [occ]
+@[simp] theorem varFinsetL_nil : varFinsetL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem varFinsetL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    varFinsetL (c :: cs) = c.varFinset ∪ varFinsetL cs := rfl
+@[simp] theorem varFinset_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (rel R args).varFinset = Finset.image args Finset.univ := by simp only [varFinset]
+@[simp] theorem varFinset_eq (u v : V) :
+    (eq u v : Condition L V).varFinset = {u, v} := by simp only [varFinset]
 
-@[simp] theorem occL_append (cs ds : List (Condition L V)) :
-    occL (cs ++ ds) = occL cs ∪ occL ds := by
+@[simp] theorem varFinsetL_append (cs ds : List (Condition L V)) :
+    varFinsetL (cs ++ ds) = varFinsetL cs ∪ varFinsetL ds := by
   induction cs with
   | nil => simp
   | cons c cs ih => simp [ih, Finset.union_assoc]
 
 /-- A condition's occurring referents are among its list's. -/
-theorem occ_subset_occL {c : Condition L V} {cs : List (Condition L V)}
-    (hc : c ∈ cs) : c.occ ⊆ occL cs := by
+theorem varFinset_subset_varFinsetL {c : Condition L V} {cs : List (Condition L V)}
+    (hc : c ∈ cs) : c.varFinset ⊆ varFinsetL cs := by
   induction cs with
   | nil => cases hc
   | cons d ds ih =>
@@ -228,160 +156,44 @@ theorem occ_subset_occL {c : Condition L V} {cs : List (Condition L V)}
     · exact h ▸ Finset.subset_union_left
     · exact (ih h).trans Finset.subset_union_right
 
-end Condition
-
-namespace DRS
-
-/-- Occurring referents in a DRS (its universe and those of its conditions). -/
-def occ (K : DRS L V) : Finset V := K.referents ∪ Condition.occL K.conditions
-
-@[simp] theorem occ_mk (U : Finset V) (conds : List (Condition L V)) :
-    occ ⟨U, conds⟩ = U ∪ Condition.occL conds := rfl
-
-/-- A DRS's conditions' occurring referents are among the DRS's. -/
-theorem occL_subset_occ (K : DRS L V) : Condition.occL K.conditions ⊆ K.occ :=
-  Finset.subset_union_right
-
-end DRS
-
-@[simp] theorem Condition.occ_neg (K : DRS L V) : (Condition.neg K).occ = K.occ := by
-  simp only [Condition.occ]; rfl
-@[simp] theorem Condition.occ_imp (a c : DRS L V) :
-    (Condition.imp a c).occ = a.occ ∪ c.occ := by simp only [Condition.occ]; rfl
-@[simp] theorem Condition.occ_dis (l r : DRS L V) :
-    (Condition.dis l r).occ = l.occ ∪ r.occ := by simp only [Condition.occ]; rfl
-
-end Occ
-
-/-! ### Free discourse referents and properness -/
-
-section Fv
-variable [DecidableEq V]
-
-namespace Condition
+/-! ### Free discourse referents -/
 
 /-- The free discourse referents of a condition. -/
-def fv : Condition L V → Finset V
+def freeVarFinset : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => (K.conditions.map fv).foldr (· ∪ ·) ∅ \ K.referents
-  | .imp a c => ((a.conditions.map fv).foldr (· ∪ ·) ∅ \ a.referents) ∪
-      (((c.conditions.map fv).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
-  | .dis l r => ((l.conditions.map fv).foldr (· ∪ ·) ∅ \ l.referents) ∪
-      ((r.conditions.map fv).foldr (· ∪ ·) ∅ \ r.referents)
+  | .neg K => (K.conditions.map freeVarFinset).foldr (· ∪ ·) ∅ \ K.referents
+  | .imp a c => ((a.conditions.map freeVarFinset).foldr (· ∪ ·) ∅ \ a.referents) ∪
+      (((c.conditions.map freeVarFinset).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
+  | .dis l r => ((l.conditions.map freeVarFinset).foldr (· ∪ ·) ∅ \ l.referents) ∪
+      ((r.conditions.map freeVarFinset).foldr (· ∪ ·) ∅ \ r.referents)
 
 /-- Free referents of a list of conditions. -/
-def fvL (cs : List (Condition L V)) : Finset V := (cs.map fv).foldr (· ∪ ·) ∅
+def freeVarFinsetL (cs : List (Condition L V)) : Finset V :=
+  (cs.map freeVarFinset).foldr (· ∪ ·) ∅
 
-@[simp] theorem fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (rel R args).fv = Finset.image args Finset.univ := by simp only [fv]
-@[simp] theorem fv_eq (u v : V) :
-    (eq u v : Condition L V).fv = {u, v} := by simp only [fv]
-@[simp] theorem fvL_nil : fvL ([] : List (Condition L V)) = ∅ := rfl
-@[simp] theorem fvL_cons (c : Condition L V) (cs : List (Condition L V)) :
-    fvL (c :: cs) = c.fv ∪ fvL cs := rfl
+@[simp] theorem freeVarFinset_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (rel R args).freeVarFinset = Finset.image args Finset.univ := by simp only [freeVarFinset]
+@[simp] theorem freeVarFinset_eq (u v : V) :
+    (eq u v : Condition L V).freeVarFinset = {u, v} := by simp only [freeVarFinset]
+@[simp] theorem freeVarFinsetL_nil : freeVarFinsetL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem freeVarFinsetL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    freeVarFinsetL (c :: cs) = c.freeVarFinset ∪ freeVarFinsetL cs := rfl
 
-@[simp] theorem fvL_append (cs ds : List (Condition L V)) :
-    fvL (cs ++ ds) = fvL cs ∪ fvL ds := by
+@[simp] theorem freeVarFinsetL_append (cs ds : List (Condition L V)) :
+    freeVarFinsetL (cs ++ ds) = freeVarFinsetL cs ∪ freeVarFinsetL ds := by
   induction cs with
   | nil => simp
   | cons c cs ih => simp [ih, Finset.union_assoc]
 
-private theorem fvL_subset_occL_of_forall {cs : List (Condition L V)}
-    (h : ∀ c ∈ cs, c.fv ⊆ c.occ) : fvL cs ⊆ occL cs := by
+private theorem freeVarFinsetL_subset_varFinsetL_of_forall {cs : List (Condition L V)}
+    (h : ∀ c ∈ cs, c.freeVarFinset ⊆ c.varFinset) : freeVarFinsetL cs ⊆ varFinsetL cs := by
   induction cs with
   | nil => simp
   | cons c cs ih =>
-    simp only [fvL_cons, occL_cons]
+    simp only [freeVarFinsetL_cons, varFinsetL_cons]
     exact Finset.union_subset_union (h c (by simp))
       (ih fun d hd => h d (List.mem_cons_of_mem c hd))
-
-end Condition
-
-namespace DRS
-
-/-- The free discourse referents of a DRS: referents occurring in its
-conditions and not bound by its universe or by an ancestor reachable "left
-and up" (the antecedent of a `⇒` threads its referents into the consequent).
-`K.fv ⊆ b` says every referent of `K` is bound in context `b`. -/
-def fv (K : DRS L V) : Finset V := Condition.fvL K.conditions \ K.referents
-
-@[simp] theorem fv_mk (U : Finset V) (conds : List (Condition L V)) :
-    fv ⟨U, conds⟩ = Condition.fvL conds \ U := rfl
-
-/-- The characteristic form of the referential presupposition: a box's free
-referents are supplied by `X` iff its conditions' are supplied by the grown
-base. -/
-theorem fv_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
-    fv ⟨U, conds⟩ ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
-  rw [fv_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
-
-private theorem fv_subset_occ_of_forall {K : DRS L V}
-    (h : ∀ c ∈ K.conditions, c.fv ⊆ c.occ) : K.fv ⊆ K.occ :=
-  Finset.sdiff_subset.trans ((Condition.fvL_subset_occL_of_forall h).trans
-    Finset.subset_union_right)
-
-end DRS
-
-@[simp] theorem Condition.fv_neg (K : DRS L V) : (Condition.neg K).fv = K.fv := by
-  simp only [Condition.fv]; rfl
-@[simp] theorem Condition.fv_imp (a c : DRS L V) :
-    (Condition.imp a c).fv = a.fv ∪ (c.fv \ a.referents) := by simp only [Condition.fv]; rfl
-@[simp] theorem Condition.fv_dis (l r : DRS L V) :
-    (Condition.dis l r).fv = l.fv ∪ r.fv := by simp only [Condition.fv]; rfl
-
-/-- Free referents of a condition occur. -/
-theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
-  induction c with
-  | rel R args => simp
-  | eq u v => simp
-  | neg K ih => simpa using DRS.fv_subset_occ_of_forall ih
-  | imp a c iha ihc =>
-    simp only [Condition.fv_imp, Condition.occ_imp]
-    exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall iha)
-      (Finset.sdiff_subset.trans (DRS.fv_subset_occ_of_forall ihc))
-  | dis l r ihl ihr =>
-    simp only [Condition.fv_dis, Condition.occ_dis]
-    exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall ihl)
-      (DRS.fv_subset_occ_of_forall ihr)
-
-/-- Free referents occur. -/
-theorem DRS.fv_subset_occ (K : DRS L V) : K.fv ⊆ K.occ :=
-  DRS.fv_subset_occ_of_forall fun c _ => Condition.fv_subset_occ c
-
-/-- The list analogue of `Condition.fv_subset_occ`. -/
-theorem Condition.fvL_subset_occL (cs : List (Condition L V)) :
-    Condition.fvL cs ⊆ Condition.occL cs :=
-  Condition.fvL_subset_occL_of_forall fun c _ => Condition.fv_subset_occ c
-
-namespace DRS
-
-/-- Merging preserves boundedness: the merge's free referents are supplied by
-`X` when the context's are and the increment's are supplied by the grown base. -/
-theorem fv_merge_subset {X : Finset V} {K₁ K₂ : DRS L V} (h₁ : K₁.fv ⊆ X)
-    (h₂ : K₂.fv ⊆ X ∪ K₁.referents) : (K₁.merge K₂).fv ⊆ X := by
-  obtain ⟨U₁, c₁⟩ := K₁
-  obtain ⟨U₂, c₂⟩ := K₂
-  rw [referents_mk] at h₂
-  rw [fv_subset_iff] at h₁ h₂
-  rw [merge, referents_mk, conditions_mk, fv_subset_iff,
-    Condition.fvL_append, ← Finset.union_assoc]
-  exact Finset.union_subset (h₁.trans Finset.subset_union_left) h₂
-
-/-- A DRS is *proper* iff it has no free discourse referent
-(Def. 1.4.2–1.4.3). -/
-def IsProper (K : DRS L V) : Prop := K.fv = ∅
-
-/-- Merging preserves properness when the increment's free referents are
-supplied by the context DRS's universe. -/
-theorem isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
-    (h₂ : K₂.fv ⊆ K₁.referents) : (K₁.merge K₂).IsProper :=
-  Finset.subset_empty.mp (fv_merge_subset (Finset.subset_empty.mpr h₁)
-    (h₂.trans Finset.subset_union_right))
-
-end DRS
-
-end Fv
 
 /-! ### Reuse-freeness
 
@@ -391,11 +203,6 @@ verification threads the base (the antecedent of a `⇒` feeds its referents
 into the consequent). This is the hypothesis under which the total
 agree-off-universe semantics and the persistence semantics coincide
 (`DRS.trueRel_iff_toRelAt` in `DRS/Indexed.lean`). -/
-
-section ReuseFree
-variable [DecidableEq V]
-
-namespace Condition
 
 /-- A condition is reuse-free at ambient declarations `X`: each sub-box
 universe is fresh for the declarations in scope, threaded the way verification
@@ -438,38 +245,7 @@ def ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
     ReuseFreeAllAt X (c :: cs) ↔ ReuseFreeAt X c ∧ ReuseFreeAllAt X cs := by
   simp only [ReuseFreeAllAt, List.forall_mem_cons]
 
-end Condition
-
-namespace DRS
-
-/-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
-and its conditions are reuse-free at the grown set. -/
-def ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
-  Disjoint X K.referents ∧ Condition.ReuseFreeAllAt (X ∪ K.referents) K.conditions
-
-@[simp] theorem reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
-    ReuseFreeAt X (.mk U conds) ↔
-      Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds := Iff.rfl
-
-end DRS
-
-@[simp] theorem Condition.reuseFreeAt_neg (X : Finset V) (K : DRS L V) :
-    Condition.ReuseFreeAt X (.neg K) ↔ DRS.ReuseFreeAt X K := by
-  simp only [Condition.ReuseFreeAt]; rfl
-
-@[simp] theorem Condition.reuseFreeAt_imp (X : Finset V) (a c : DRS L V) :
-    Condition.ReuseFreeAt X (.imp a c) ↔
-      DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c := by
-  simp only [Condition.ReuseFreeAt]; rfl
-
-@[simp] theorem Condition.reuseFreeAt_dis (X : Finset V) (l r : DRS L V) :
-    Condition.ReuseFreeAt X (.dis l r) ↔
-      DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := by
-  simp only [Condition.ReuseFreeAt]; rfl
-
-end ReuseFree
-
-/-! ### Accessibility (decidable, host-relative)
+/-! ### Accessibility threading
 
 Accessibility (Def. 1.4.11) is intrinsically *relative to a
 host DRS*: "`u` accessible at box `B`" means `u` lies in the universe of `B` or of
@@ -477,11 +253,6 @@ a box on the path from the host down to `B`. A host-free `∃ D, WeakSubordinate
 ∧ u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent
 can always be manufactured. So accessibility is computed *top-down*, threading the
 in-scope referents (the same threading as `DRS.Bound`), which is also decidable. -/
-
-section Accessibility
-variable [DecidableEq V]
-
-namespace Condition
 
 /-- Accessibility threading through a condition. -/
 def accScope (s : Finset V) : Condition L V → V → Option (Finset V)
@@ -513,7 +284,149 @@ def accScopeL (s : Finset V) (cs : List (Condition L V)) (x : V) : Option (Finse
 
 end Condition
 
+/-! ## DRSs -/
+
 namespace DRS
+
+/-! ### Renaming -/
+
+/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
+def map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
+  Box.map f (Condition.map f)
+
+@[simp] theorem referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).referents = K.referents.image f := rfl
+
+@[simp] theorem conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).conditions = K.conditions.map (Condition.map f) := rfl
+
+/-- Renaming a DRS along the identity is the identity. -/
+@[simp] theorem map_id [DecidableEq V] (K : DRS L V) : map id K = K := by
+  simp [map]
+
+/-- Renaming a DRS along a composite is the composite of the renamings. -/
+theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
+    map g (map f K) = map (g ∘ f) K := by
+  simp [map, Box.map_map, Condition.map_map g f]
+
+/-- Extension along a renamed DRS is extension of the precompositions. -/
+theorem extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
+    (K.map e).Extends f g ↔ K.Extends (f ∘ e) (g ∘ e) := by
+  simp only [Box.Extends, referents_map, Function.comp_apply]
+  refine ⟨fun h x hx => h (e x) (by simpa using hx), fun h y hy => ?_⟩
+  have hx : e.symm y ∉ K.referents := fun hm =>
+    hy (by simpa using Finset.mem_image_of_mem e hm)
+  simpa using h (e.symm y) hx
+
+/-- The extensions of `f` at `K.map e` are the extensions of `f ∘ e` at `K`,
+via precomposition. -/
+theorem exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
+    (P : Embedding V M → Prop) :
+    (∃ g, (K.map e).Extends f g ∧ P (g ∘ e)) ↔ ∃ g, K.Extends (f ∘ e) g ∧ P g := by
+  simp only [extends_map]
+  refine ⟨fun ⟨g, hg, hp⟩ => ⟨g ∘ e, hg, hp⟩, fun ⟨g, hg, hp⟩ => ⟨g ∘ e.symm, ?_⟩⟩
+  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
+  exact key.symm ▸ ⟨hg, hp⟩
+
+/-- The `∀` analogue of `DRS.exists_extends_map`. -/
+theorem forall_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
+    (P : Embedding V M → Prop) :
+    (∀ g, (K.map e).Extends f g → P (g ∘ e)) ↔ ∀ g, K.Extends (f ∘ e) g → P g := by
+  simp only [extends_map]
+  refine ⟨fun H g hg => ?_, fun H g hg => H (g ∘ e) hg⟩
+  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
+  exact key ▸ H (g ∘ e.symm) (key.symm ▸ hg)
+
+variable [DecidableEq V]
+
+/-! ### Merge algebra -/
+
+@[simp] theorem empty_merge (K : DRS L V) : (empty : DRS L V).merge K = K := by
+  cases K with
+  | mk r c => simp [merge, empty]
+
+@[simp] theorem merge_empty (K : DRS L V) : K.merge (empty : DRS L V) = K := by
+  cases K with
+  | mk r c => simp [merge, empty]
+
+theorem merge_assoc (K₁ K₂ K₃ : DRS L V) :
+    (K₁.merge K₂).merge K₃ = K₁.merge (K₂.merge K₃) := by
+  cases K₁; cases K₂; cases K₃
+  simp only [merge, referents_mk, conditions_mk]
+  rw [Finset.union_assoc, List.append_assoc]
+
+/-! ### Occurring and free referents -/
+
+/-- Occurring referents in a DRS (its universe and those of its conditions). -/
+def varFinset (K : DRS L V) : Finset V := K.referents ∪ Condition.varFinsetL K.conditions
+
+@[simp] theorem varFinset_mk (U : Finset V) (conds : List (Condition L V)) :
+    varFinset ⟨U, conds⟩ = U ∪ Condition.varFinsetL conds := rfl
+
+/-- A DRS's conditions' occurring referents are among the DRS's. -/
+theorem varFinsetL_subset_varFinset (K : DRS L V) :
+    Condition.varFinsetL K.conditions ⊆ K.varFinset :=
+  Finset.subset_union_right
+
+/-- The free discourse referents of a DRS: referents occurring in its
+conditions and not bound by its universe or by an ancestor reachable "left
+and up" (the antecedent of a `⇒` threads its referents into the consequent).
+`K.freeVarFinset ⊆ b` says every referent of `K` is bound in context `b`. -/
+def freeVarFinset (K : DRS L V) : Finset V :=
+  Condition.freeVarFinsetL K.conditions \ K.referents
+
+@[simp] theorem freeVarFinset_mk (U : Finset V) (conds : List (Condition L V)) :
+    freeVarFinset ⟨U, conds⟩ = Condition.freeVarFinsetL conds \ U := rfl
+
+/-- The characteristic form of the referential presupposition: a box's free
+referents are supplied by `X` iff its conditions' are supplied by the grown
+base. -/
+theorem freeVarFinset_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
+    freeVarFinset ⟨U, conds⟩ ⊆ X ↔ Condition.freeVarFinsetL conds ⊆ X ∪ U := by
+  rw [freeVarFinset_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
+
+private theorem freeVarFinset_subset_varFinset_of_forall {K : DRS L V}
+    (h : ∀ c ∈ K.conditions, c.freeVarFinset ⊆ c.varFinset) :
+    K.freeVarFinset ⊆ K.varFinset :=
+  Finset.sdiff_subset.trans
+    ((Condition.freeVarFinsetL_subset_varFinsetL_of_forall h).trans Finset.subset_union_right)
+
+/-- Merging preserves boundedness: the merge's free referents are supplied by
+`X` when the context's are and the increment's are supplied by the grown base. -/
+theorem freeVarFinset_merge_subset {X : Finset V} {K₁ K₂ : DRS L V}
+    (h₁ : K₁.freeVarFinset ⊆ X) (h₂ : K₂.freeVarFinset ⊆ X ∪ K₁.referents) :
+    (K₁.merge K₂).freeVarFinset ⊆ X := by
+  obtain ⟨U₁, c₁⟩ := K₁
+  obtain ⟨U₂, c₂⟩ := K₂
+  rw [referents_mk] at h₂
+  rw [freeVarFinset_subset_iff] at h₁ h₂
+  rw [merge, referents_mk, conditions_mk, freeVarFinset_subset_iff,
+    Condition.freeVarFinsetL_append, ← Finset.union_assoc]
+  exact Finset.union_subset (h₁.trans Finset.subset_union_left) h₂
+
+/-- A DRS is *proper* iff it has no free discourse referent
+(Def. 1.4.2–1.4.3). -/
+def IsProper (K : DRS L V) : Prop := K.freeVarFinset = ∅
+
+/-- Merging preserves properness when the increment's free referents are
+supplied by the context DRS's universe. -/
+theorem isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
+    (h₂ : K₂.freeVarFinset ⊆ K₁.referents) : (K₁.merge K₂).IsProper :=
+  Finset.subset_empty.mp (freeVarFinset_merge_subset (Finset.subset_empty.mpr h₁)
+    (h₂.trans Finset.subset_union_right))
+
+/-! ### Reuse-freeness -/
+
+/-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
+and its conditions are reuse-free at the grown set. -/
+def ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
+  Disjoint X K.referents ∧ Condition.ReuseFreeAllAt (X ∪ K.referents) K.conditions
+
+@[simp] theorem reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
+    ReuseFreeAt X (.mk U conds) ↔
+      Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds := Iff.rfl
+
+/-! ### Accessibility -/
 
 /-- Descend `K`, accumulating in-scope referents `s` ("left and up"); on reaching
 the box introducing `x`, return that box's in-scope set `s ∪ U`. The `⇒`-consequent
@@ -536,6 +449,76 @@ instance (T : DRS L V) (u v : V) : Decidable (Accessible T u v) :=
 
 end DRS
 
+/-! ## Sub-box characterizations
+
+The per-constructor forms of the condition-level predicates, phrased through
+the corresponding DRS-level notion of the sub-boxes, and the subset relations
+tying free to occurring referents. -/
+
+variable [DecidableEq V]
+
+@[simp] theorem Condition.varFinset_neg (K : DRS L V) :
+    (Condition.neg K).varFinset = K.varFinset := by
+  simp only [Condition.varFinset]; rfl
+@[simp] theorem Condition.varFinset_imp (a c : DRS L V) :
+    (Condition.imp a c).varFinset = a.varFinset ∪ c.varFinset := by
+  simp only [Condition.varFinset]; rfl
+@[simp] theorem Condition.varFinset_dis (l r : DRS L V) :
+    (Condition.dis l r).varFinset = l.varFinset ∪ r.varFinset := by
+  simp only [Condition.varFinset]; rfl
+
+@[simp] theorem Condition.freeVarFinset_neg (K : DRS L V) :
+    (Condition.neg K).freeVarFinset = K.freeVarFinset := by
+  simp only [Condition.freeVarFinset]; rfl
+@[simp] theorem Condition.freeVarFinset_imp (a c : DRS L V) :
+    (Condition.imp a c).freeVarFinset
+      = a.freeVarFinset ∪ (c.freeVarFinset \ a.referents) := by
+  simp only [Condition.freeVarFinset]; rfl
+@[simp] theorem Condition.freeVarFinset_dis (l r : DRS L V) :
+    (Condition.dis l r).freeVarFinset = l.freeVarFinset ∪ r.freeVarFinset := by
+  simp only [Condition.freeVarFinset]; rfl
+
+/-- Free referents of a condition occur. -/
+theorem Condition.freeVarFinset_subset_varFinset (c : Condition L V) :
+    c.freeVarFinset ⊆ c.varFinset := by
+  induction c with
+  | rel R args => simp
+  | eq u v => simp
+  | neg K ih => simpa using DRS.freeVarFinset_subset_varFinset_of_forall ih
+  | imp a c iha ihc =>
+    simp only [Condition.freeVarFinset_imp, Condition.varFinset_imp]
+    exact Finset.union_subset_union (DRS.freeVarFinset_subset_varFinset_of_forall iha)
+      (Finset.sdiff_subset.trans (DRS.freeVarFinset_subset_varFinset_of_forall ihc))
+  | dis l r ihl ihr =>
+    simp only [Condition.freeVarFinset_dis, Condition.varFinset_dis]
+    exact Finset.union_subset_union (DRS.freeVarFinset_subset_varFinset_of_forall ihl)
+      (DRS.freeVarFinset_subset_varFinset_of_forall ihr)
+
+/-- Free referents occur. -/
+theorem DRS.freeVarFinset_subset_varFinset (K : DRS L V) : K.freeVarFinset ⊆ K.varFinset :=
+  DRS.freeVarFinset_subset_varFinset_of_forall fun c _ =>
+    Condition.freeVarFinset_subset_varFinset c
+
+/-- The list analogue of `Condition.freeVarFinset_subset_varFinset`. -/
+theorem Condition.freeVarFinsetL_subset_varFinsetL (cs : List (Condition L V)) :
+    Condition.freeVarFinsetL cs ⊆ Condition.varFinsetL cs :=
+  Condition.freeVarFinsetL_subset_varFinsetL_of_forall fun c _ =>
+    Condition.freeVarFinset_subset_varFinset c
+
+@[simp] theorem Condition.reuseFreeAt_neg (X : Finset V) (K : DRS L V) :
+    Condition.ReuseFreeAt X (.neg K) ↔ DRS.ReuseFreeAt X K := by
+  simp only [Condition.ReuseFreeAt]; rfl
+
+@[simp] theorem Condition.reuseFreeAt_imp (X : Finset V) (a c : DRS L V) :
+    Condition.ReuseFreeAt X (.imp a c) ↔
+      DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c := by
+  simp only [Condition.ReuseFreeAt]; rfl
+
+@[simp] theorem Condition.reuseFreeAt_dis (X : Finset V) (l r : DRS L V) :
+    Condition.ReuseFreeAt X (.dis l r) ↔
+      DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := by
+  simp only [Condition.ReuseFreeAt]; rfl
+
 theorem Condition.accScope_neg (s : Finset V) (K : DRS L V) (x : V) :
     Condition.accScope s (.neg K) x = DRS.accScope s K x := by
   simp only [Condition.accScope]; rfl
@@ -549,17 +532,5 @@ theorem Condition.accScope_dis (s : Finset V) (l r : DRS L V) (x : V) :
     Condition.accScope s (.dis l r) x =
       (DRS.accScope s l x).orElse fun _ => DRS.accScope s r x := by
   simp only [Condition.accScope]; rfl
-
-end Accessibility
-
-open FirstOrder in
-/-- Non-vacuity guard: in `[1 | ¬[2 | ]]`, `1` is accessible from `2` but `2` is
-not accessible from `1` — the subordination asymmetry, now decidable (contrast the
-old host-free `Accessible`, which was provable for *all* referents). -/
-example :
-    DRS.Accessible (L := Language.empty) (.mk {1} [.neg (.mk {2} [])]) 2 1 ∧
-      ¬ DRS.Accessible (L := Language.empty) (.mk {1} [.neg (.mk {2} [])]) 1 2 := by
-  simp [DRS.Accessible, DRS.accessibleFrom, DRS.accScope, Condition.accScopeL,
-    Condition.accScope_neg]
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -215,34 +215,55 @@ end Extends
 section Occ
 variable [DecidableEq V]
 
-mutual
 /-- Occurring referents (free or bound) in a condition, as a `Finset` — the DRS
 analogue of mathlib's `Term.varFinset`. Membership `x ∈ occ c` is decidable, so
 downstream consumers get decidable occurrence for free. -/
 def Condition.occ : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => DRS.occ K
-  | .imp a c => DRS.occ a ∪ DRS.occ c
-  | .dis l r => DRS.occ l ∪ DRS.occ r
-/-- Occurring referents in a DRS (its universe and those of its conditions). -/
-def DRS.occ : DRS L V → Finset V
-  | .mk U conds => U ∪ Condition.occL conds
+  | .neg K => K.referents ∪ (K.conditions.map Condition.occ).foldr (· ∪ ·) ∅
+  | .imp a c => (a.referents ∪ (a.conditions.map Condition.occ).foldr (· ∪ ·) ∅) ∪
+      (c.referents ∪ (c.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
+  | .dis l r => (l.referents ∪ (l.conditions.map Condition.occ).foldr (· ∪ ·) ∅) ∪
+      (r.referents ∪ (r.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
 /-- Occurring referents in a list of conditions. -/
-def Condition.occL : List (Condition L V) → Finset V
-  | [] => ∅
-  | c :: cs => Condition.occ c ∪ Condition.occL cs
-end
+def Condition.occL (cs : List (Condition L V)) : Finset V :=
+  (cs.map Condition.occ).foldr (· ∪ ·) ∅
+
+/-- Occurring referents in a DRS (its universe and those of its conditions). -/
+def DRS.occ (K : DRS L V) : Finset V := K.referents ∪ Condition.occL K.conditions
+
+@[simp] theorem Condition.occL_nil : Condition.occL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem Condition.occL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    Condition.occL (c :: cs) = c.occ ∪ Condition.occL cs := rfl
+@[simp] theorem DRS.occ_mk (U : Finset V) (conds : List (Condition L V)) :
+    DRS.occ ⟨U, conds⟩ = U ∪ Condition.occL conds := rfl
+@[simp] theorem Condition.occ_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (Condition.rel R args).occ = Finset.image args Finset.univ := by
+  simp only [Condition.occ]
+@[simp] theorem Condition.occ_eq (u v : V) :
+    (Condition.eq u v : Condition L V).occ = {u, v} := by simp only [Condition.occ]
+@[simp] theorem Condition.occ_neg (K : DRS L V) : (Condition.neg K).occ = K.occ := by
+  simp only [Condition.occ]; rfl
+@[simp] theorem Condition.occ_imp (a c : DRS L V) :
+    (Condition.imp a c).occ = a.occ ∪ c.occ := by simp only [Condition.occ]; rfl
+@[simp] theorem Condition.occ_dis (l r : DRS L V) :
+    (Condition.dis l r).occ = l.occ ∪ r.occ := by simp only [Condition.occ]; rfl
 
 @[simp] theorem Condition.occL_append (cs ds : List (Condition L V)) :
     Condition.occL (cs ++ ds) = Condition.occL cs ∪ Condition.occL ds := by
   induction cs with
-  | nil => simp [Condition.occL]
-  | cons c cs ih => simp [Condition.occL, ih, Finset.union_assoc]
+  | nil => simp
+  | cons c cs ih => simp [ih, Finset.union_assoc]
 
 /-- A DRS's conditions' occurring referents are among the DRS's. -/
-theorem DRS.occL_subset_occ (K : DRS L V) : Condition.occL K.conditions ⊆ K.occ := by
-  cases K; exact Finset.subset_union_right
+theorem DRS.occL_subset_occ (K : DRS L V) : Condition.occL K.conditions ⊆ K.occ :=
+  Finset.subset_union_right
 
 /-- A condition's occurring referents are among its list's. -/
 theorem Condition.occ_subset_occL {c : Condition L V} {cs : List (Condition L V)}
@@ -261,38 +282,42 @@ end Occ
 section Fv
 variable [DecidableEq V]
 
-mutual
-/-- The free discourse referents of a DRS: referents occurring in its
-conditions and not bound by its universe or by an ancestor reachable "left
-and up" (the antecedent of a `⇒` threads its referents into the consequent).
-`K.fv ⊆ b` says every referent of `K` is bound in context `b`. -/
-def DRS.fv : DRS L V → Finset V
-  | .mk U conds => Condition.fvL conds \ U
 /-- The free discourse referents of a condition. -/
 def Condition.fv : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => DRS.fv K
-  | .imp a c => DRS.fv a ∪ (DRS.fv c \ a.referents)
-  | .dis l r => DRS.fv l ∪ DRS.fv r
-/-- Free referents of a list of conditions. A `List` helper — the
-higher-order form fails the nested-inductive structural-recursion checker. -/
-def Condition.fvL : List (Condition L V) → Finset V
-  | [] => ∅
-  | c :: cs => Condition.fv c ∪ Condition.fvL cs
-end
+  | .neg K => (K.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ K.referents
+  | .imp a c => ((a.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ a.referents) ∪
+      (((c.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
+  | .dis l r => ((l.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ l.referents) ∪
+      ((r.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ r.referents)
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- Free referents of a list of conditions. -/
+def Condition.fvL (cs : List (Condition L V)) : Finset V :=
+  (cs.map Condition.fv).foldr (· ∪ ·) ∅
+
+/-- The free discourse referents of a DRS: referents occurring in its
+conditions and not bound by its universe or by an ancestor reachable "left
+and up" (the antecedent of a `⇒` threads its referents into the consequent).
+`K.fv ⊆ b` says every referent of `K` is bound in context `b`. -/
+def DRS.fv (K : DRS L V) : Finset V := Condition.fvL K.conditions \ K.referents
 
 @[simp] theorem DRS.fv_mk (U : Finset V) (conds : List (Condition L V)) :
     DRS.fv ⟨U, conds⟩ = Condition.fvL conds \ U := rfl
 @[simp] theorem Condition.fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (Condition.rel R args).fv = Finset.image args Finset.univ := rfl
+    (Condition.rel R args).fv = Finset.image args Finset.univ := by simp only [Condition.fv]
 @[simp] theorem Condition.fv_eq (u v : V) :
-    (Condition.eq u v : Condition L V).fv = {u, v} := rfl
-@[simp] theorem Condition.fv_neg (K : DRS L V) : (Condition.neg K).fv = K.fv := rfl
+    (Condition.eq u v : Condition L V).fv = {u, v} := by simp only [Condition.fv]
+@[simp] theorem Condition.fv_neg (K : DRS L V) : (Condition.neg K).fv = K.fv := by
+  simp only [Condition.fv]; rfl
 @[simp] theorem Condition.fv_imp (a c : DRS L V) :
-    (Condition.imp a c).fv = a.fv ∪ (c.fv \ a.referents) := rfl
+    (Condition.imp a c).fv = a.fv ∪ (c.fv \ a.referents) := by simp only [Condition.fv]; rfl
 @[simp] theorem Condition.fv_dis (l r : DRS L V) :
-    (Condition.dis l r).fv = l.fv ∪ r.fv := rfl
+    (Condition.dis l r).fv = l.fv ∪ r.fv := by simp only [Condition.fv]; rfl
 @[simp] theorem Condition.fvL_nil : Condition.fvL ([] : List (Condition L V)) = ∅ := rfl
 @[simp] theorem Condition.fvL_cons (c : Condition L V) (cs : List (Condition L V)) :
     Condition.fvL (c :: cs) = c.fv ∪ Condition.fvL cs := rfl
@@ -304,37 +329,53 @@ theorem DRS.fv_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
     DRS.fv ⟨U, conds⟩ ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
   rw [DRS.fv_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
 
-mutual
-/-- Free referents occur. -/
-theorem DRS.fv_subset_occ (K : DRS L V) : K.fv ⊆ K.occ := by
-  match K with
-  | .mk U conds =>
-    simp only [DRS.fv_mk, DRS.occ]
-    exact (Finset.sdiff_subset).trans (Condition.fvL_subset_occL conds) |>.trans
-      Finset.subset_union_right
+private theorem Condition.fvL_subset_occL_of_forall {cs : List (Condition L V)}
+    (h : ∀ c ∈ cs, c.fv ⊆ c.occ) : Condition.fvL cs ⊆ Condition.occL cs := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih =>
+    simp only [Condition.fvL_cons, Condition.occL_cons]
+    exact Finset.union_subset_union (h c (by simp))
+      (ih fun d hd => h d (List.mem_cons_of_mem c hd))
+
+private theorem DRS.fv_subset_occ_of_forall {K : DRS L V}
+    (h : ∀ c ∈ K.conditions, c.fv ⊆ c.occ) : K.fv ⊆ K.occ :=
+  Finset.sdiff_subset.trans ((Condition.fvL_subset_occL_of_forall h).trans
+    Finset.subset_union_right)
+
 /-- Free referents of a condition occur. -/
 theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
   match c with
-  | .rel R args => simp [Condition.occ]
-  | .eq u v => simp [Condition.occ]
-  | .neg K => simpa [Condition.occ] using DRS.fv_subset_occ K
+  | .rel R args => simp
+  | .eq u v => simp
+  | .neg K =>
+    have ih : ∀ d ∈ K.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+    simpa using DRS.fv_subset_occ_of_forall ih
   | .imp a c =>
-    simp only [Condition.fv_imp, Condition.occ]
-    exact Finset.union_subset_union (DRS.fv_subset_occ a)
-      ((Finset.sdiff_subset).trans (DRS.fv_subset_occ c))
+    have iha : ∀ d ∈ a.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+    have ihc : ∀ d ∈ c.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+    simp only [Condition.fv_imp, Condition.occ_imp]
+    exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall iha)
+      (Finset.sdiff_subset.trans (DRS.fv_subset_occ_of_forall ihc))
   | .dis l r =>
-    simp only [Condition.fv_dis, Condition.occ]
-    exact Finset.union_subset_union (DRS.fv_subset_occ l) (DRS.fv_subset_occ r)
+    have ihl : ∀ d ∈ l.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+    have ihr : ∀ d ∈ r.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+    simp only [Condition.fv_dis, Condition.occ_dis]
+    exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall ihl)
+      (DRS.fv_subset_occ_of_forall ihr)
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- Free referents occur. -/
+theorem DRS.fv_subset_occ (K : DRS L V) : K.fv ⊆ K.occ :=
+  DRS.fv_subset_occ_of_forall fun c _ => Condition.fv_subset_occ c
+
 /-- The list analogue of `Condition.fv_subset_occ`. -/
 theorem Condition.fvL_subset_occL (cs : List (Condition L V)) :
-    Condition.fvL cs ⊆ Condition.occL cs := by
-  match cs with
-  | [] => simp
-  | c :: cs =>
-    simp only [Condition.fvL_cons, Condition.occL]
-    exact Finset.union_subset_union (Condition.fv_subset_occ c)
-      (Condition.fvL_subset_occL cs)
-end
+    Condition.fvL cs ⊆ Condition.occL cs :=
+  Condition.fvL_subset_occL_of_forall fun c _ => Condition.fv_subset_occ c
 
 @[simp] theorem Condition.fvL_append (cs ds : List (Condition L V)) :
     Condition.fvL (cs ++ ds) = Condition.fvL cs ∪ Condition.fvL ds := by
@@ -379,52 +420,74 @@ agree-off-universe semantics and the persistence semantics coincide
 section ReuseFree
 variable [DecidableEq V]
 
-mutual
-/-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
-and its conditions are reuse-free at the grown set. -/
-def DRS.ReuseFreeAt (X : Finset V) : DRS L V → Prop
-  | .mk U conds => Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds
-/-- A condition is reuse-free at ambient declarations `X`. -/
+/-- A condition is reuse-free at ambient declarations `X`: each sub-box
+universe is fresh for the declarations in scope, threaded the way verification
+threads the base (the antecedent of a `⇒` feeds its referents into the
+consequent). -/
 def Condition.ReuseFreeAt (X : Finset V) : Condition L V → Prop
   | .rel _ _ => True
   | .eq _ _ => True
-  | .neg K => DRS.ReuseFreeAt X K
-  | .imp a c => DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c
-  | .dis l r => DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r
+  | .neg K => Disjoint X K.referents ∧
+      ∀ c ∈ K.conditions, Condition.ReuseFreeAt (X ∪ K.referents) c
+  | .imp a c =>
+      (Disjoint X a.referents ∧
+        ∀ d ∈ a.conditions, Condition.ReuseFreeAt (X ∪ a.referents) d) ∧
+      (Disjoint (X ∪ a.referents) c.referents ∧
+        ∀ d ∈ c.conditions, Condition.ReuseFreeAt (X ∪ a.referents ∪ c.referents) d)
+  | .dis l r =>
+      (Disjoint X l.referents ∧
+        ∀ d ∈ l.conditions, Condition.ReuseFreeAt (X ∪ l.referents) d) ∧
+      (Disjoint X r.referents ∧
+        ∀ d ∈ r.conditions, Condition.ReuseFreeAt (X ∪ r.referents) d)
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
 /-- Reuse-freeness for a list of conditions. -/
-def Condition.ReuseFreeAllAt (X : Finset V) : List (Condition L V) → Prop
-  | [] => True
-  | c :: cs => Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs
-end
+def Condition.ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
+  ∀ c ∈ cs, Condition.ReuseFreeAt X c
+
+/-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
+and its conditions are reuse-free at the grown set. -/
+def DRS.ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
+  Disjoint X K.referents ∧ Condition.ReuseFreeAllAt (X ∪ K.referents) K.conditions
 
 @[simp] theorem DRS.reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
     DRS.ReuseFreeAt X (.mk U conds) ↔
       Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds := Iff.rfl
 
 @[simp] theorem Condition.reuseFreeAt_rel (X : Finset V) {n : ℕ} (R : L.Relations n)
-    (args : Fin n → V) : Condition.ReuseFreeAt X (.rel R args) := trivial
+    (args : Fin n → V) : Condition.ReuseFreeAt X (.rel R args) := by
+  simp only [Condition.ReuseFreeAt]
 
 @[simp] theorem Condition.reuseFreeAt_eq (X : Finset V) (u v : V) :
-    Condition.ReuseFreeAt X (.eq u v : Condition L V) := trivial
+    Condition.ReuseFreeAt X (.eq u v : Condition L V) := by
+  simp only [Condition.ReuseFreeAt]
 
 @[simp] theorem Condition.reuseFreeAt_neg (X : Finset V) (K : DRS L V) :
-    Condition.ReuseFreeAt X (.neg K) ↔ DRS.ReuseFreeAt X K := Iff.rfl
+    Condition.ReuseFreeAt X (.neg K) ↔ DRS.ReuseFreeAt X K := by
+  simp only [Condition.ReuseFreeAt]; rfl
 
 @[simp] theorem Condition.reuseFreeAt_imp (X : Finset V) (a c : DRS L V) :
     Condition.ReuseFreeAt X (.imp a c) ↔
-      DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c := Iff.rfl
+      DRS.ReuseFreeAt X a ∧ DRS.ReuseFreeAt (X ∪ a.referents) c := by
+  simp only [Condition.ReuseFreeAt]; rfl
 
 @[simp] theorem Condition.reuseFreeAt_dis (X : Finset V) (l r : DRS L V) :
     Condition.ReuseFreeAt X (.dis l r) ↔
-      DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := Iff.rfl
+      DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := by
+  simp only [Condition.ReuseFreeAt]; rfl
 
 @[simp] theorem Condition.reuseFreeAllAt_nil (X : Finset V) :
-    Condition.ReuseFreeAllAt X ([] : List (Condition L V)) := trivial
+    Condition.ReuseFreeAllAt X ([] : List (Condition L V)) := by
+  simp [Condition.ReuseFreeAllAt]
 
 @[simp] theorem Condition.reuseFreeAllAt_cons (X : Finset V) (c : Condition L V)
     (cs : List (Condition L V)) :
     Condition.ReuseFreeAllAt X (c :: cs) ↔
-      Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs := Iff.rfl
+      Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs := by
+  simp only [Condition.ReuseFreeAllAt, List.forall_mem_cons]
 
 end ReuseFree
 
@@ -440,33 +503,59 @@ in-scope referents (the same threading as `DRS.Bound`), which is also decidable.
 section Accessibility
 variable [DecidableEq V]
 
-mutual
-/-- Descend `T`, accumulating in-scope referents `s` ("left and up"); on reaching
-the box introducing `x`, return that box's in-scope set `s ∪ U`. The `⇒`-consequent
-additionally sees the antecedent's universe. -/
-def DRS.accScope (s : Finset V) : DRS L V → V → Option (Finset V)
-  | .mk U conds, x => if x ∈ U then some (s ∪ U) else Condition.accScopeL (s ∪ U) conds x
 /-- Accessibility threading through a condition. -/
 def Condition.accScope (s : Finset V) : Condition L V → V → Option (Finset V)
   | .rel _ _, _ => none
   | .eq _ _, _ => none
-  | .neg K, x => DRS.accScope s K x
+  | .neg K, x =>
+      if x ∈ K.referents then some (s ∪ K.referents)
+      else (K.conditions.map fun c => Condition.accScope (s ∪ K.referents) c x).foldr
+        (fun r acc => r.orElse fun _ => acc) none
   | .imp a c, x =>
-      match DRS.accScope s a x with
-      | some r => some r
-      | none => DRS.accScope (s ∪ a.referents) c x
+      (if x ∈ a.referents then some (s ∪ a.referents)
+       else (a.conditions.map fun d => Condition.accScope (s ∪ a.referents) d x).foldr
+         (fun r acc => r.orElse fun _ => acc) none).orElse fun _ =>
+      if x ∈ c.referents then some (s ∪ a.referents ∪ c.referents)
+      else (c.conditions.map fun d =>
+          Condition.accScope (s ∪ a.referents ∪ c.referents) d x).foldr
+        (fun r acc => r.orElse fun _ => acc) none
   | .dis l r, x =>
-      match DRS.accScope s l x with
-      | some r => some r
-      | none => DRS.accScope s r x
-/-- Accessibility threading through a list of conditions (mutual helper). -/
-def Condition.accScopeL (s : Finset V) : List (Condition L V) → V → Option (Finset V)
-  | [], _ => none
-  | c :: cs, x =>
-      match Condition.accScope s c x with
-      | some r => some r
-      | none => Condition.accScopeL s cs x
-end
+      (if x ∈ l.referents then some (s ∪ l.referents)
+       else (l.conditions.map fun d => Condition.accScope (s ∪ l.referents) d x).foldr
+         (fun r acc => r.orElse fun _ => acc) none).orElse fun _ =>
+      if x ∈ r.referents then some (s ∪ r.referents)
+      else (r.conditions.map fun d => Condition.accScope (s ∪ r.referents) d x).foldr
+        (fun r acc => r.orElse fun _ => acc) none
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- Accessibility threading through a list of conditions: the first hit wins. -/
+def Condition.accScopeL (s : Finset V) (cs : List (Condition L V)) (x : V) :
+    Option (Finset V) :=
+  (cs.map fun c => Condition.accScope s c x).foldr (fun r acc => r.orElse fun _ => acc) none
+
+/-- Descend `K`, accumulating in-scope referents `s` ("left and up"); on reaching
+the box introducing `x`, return that box's in-scope set `s ∪ U`. The `⇒`-consequent
+additionally sees the antecedent's universe. -/
+def DRS.accScope (s : Finset V) (K : DRS L V) (x : V) : Option (Finset V) :=
+  if x ∈ K.referents then some (s ∪ K.referents)
+  else Condition.accScopeL (s ∪ K.referents) K.conditions x
+
+theorem Condition.accScope_neg (s : Finset V) (K : DRS L V) (x : V) :
+    Condition.accScope s (.neg K) x = DRS.accScope s K x := by
+  simp only [Condition.accScope]; rfl
+
+theorem Condition.accScope_imp (s : Finset V) (a c : DRS L V) (x : V) :
+    Condition.accScope s (.imp a c) x =
+      (DRS.accScope s a x).orElse fun _ => DRS.accScope (s ∪ a.referents) c x := by
+  simp only [Condition.accScope]; rfl
+
+theorem Condition.accScope_dis (s : Finset V) (l r : DRS L V) (x : V) :
+    Condition.accScope s (.dis l r) x =
+      (DRS.accScope s l x).orElse fun _ => DRS.accScope s r x := by
+  simp only [Condition.accScope]; rfl
 
 /-- The referents accessible from `u`'s introduction in `T`, as a decidable
 `Finset`; `∅` if `u` is not introduced in `T`. (Def. 1.4.11 defines
@@ -488,6 +577,8 @@ not accessible from `1` — the subordination asymmetry, now decidable (contrast
 old host-free `Accessible`, which was provable for *all* referents). -/
 example :
     DRS.Accessible (L := Language.empty) (.mk {1} [.neg (.mk {2} [])]) 2 1 ∧
-      ¬ DRS.Accessible (L := Language.empty) (.mk {1} [.neg (.mk {2} [])]) 1 2 := by decide
+      ¬ DRS.Accessible (L := Language.empty) (.mk {1} [.neg (.mk {2} [])]) 1 2 := by
+  simp [DRS.Accessible, DRS.accessibleFrom, DRS.accScope, Condition.accScopeL,
+    Condition.accScope_neg]
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -18,29 +18,56 @@ namespace DRT
 
 universe u v w x
 
-variable {L : Language.{u, v}} {V : Type w} {W : Type x}
+variable {L : Language.{u, v}} {V : Type w} {W : Type x} {C D E X : Type*}
 
 /-! ### Functorial renaming -/
+
+namespace Box
+
+variable [DecidableEq W] {f : V → W} {g : C → D} {K : Box V C}
+
+/-- `K.map f g` applies `f` to the universe and `g` to each condition. -/
+def map (f : V → W) (g : C → D) (K : Box V C) : Box W D :=
+  ⟨K.referents.image f, K.conditions.map g⟩
+
+/-- Well-founded recursions may traverse sub-boxes with `Box.map`: preprocessing
+re-marks the condition list, exposing `· ∈ K.conditions` to termination proofs. -/
+@[wf_preprocess] theorem map_wfParam :
+    map f g (wfParam K) = ⟨K.referents.image f, (wfParam K.conditions).map g⟩ := by
+  simp [wfParam, map]
+
+@[simp] theorem referents_map : (K.map f g).referents = K.referents.image f := rfl
+
+@[simp] theorem conditions_map : (K.map f g).conditions = K.conditions.map g := rfl
+
+@[simp] theorem map_id [DecidableEq V] : K.map id id = K := by
+  simp [map]
+
+theorem map_congr {g' : C → D} (h : ∀ c ∈ K.conditions, g c = g' c) :
+    K.map f g = K.map f g' := by
+  simp [map, List.map_congr_left h]
+
+theorem map_map [DecidableEq X] {f' : W → X} {g' : D → E} :
+    (K.map f g).map f' g' = K.map (f' ∘ f) (g' ∘ g) := by
+  simp [map, Finset.image_image, List.map_map]
+
+end Box
 
 /-- Rename discourse referents along `f` throughout a condition. -/
 def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
   | .rel R args => .rel R (fun i => f (args i))
   | .eq a b => .eq (f a) (f b)
-  | .neg K => .neg ⟨K.referents.image f, K.conditions.map (Condition.map f)⟩
-  | .imp a c =>
-      .imp ⟨a.referents.image f, a.conditions.map (Condition.map f)⟩
-        ⟨c.referents.image f, c.conditions.map (Condition.map f)⟩
-  | .dis l r =>
-      .dis ⟨l.referents.image f, l.conditions.map (Condition.map f)⟩
-        ⟨r.referents.image f, r.conditions.map (Condition.map f)⟩
+  | .neg K => .neg (K.map f (Condition.map f))
+  | .imp a c => .imp (a.map f (Condition.map f)) (c.map f (Condition.map f))
+  | .dis l r => .dis (l.map f (Condition.map f)) (r.map f (Condition.map f))
 decreasing_by all_goals
   have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
   simp_wf
   omega
 
 /-- Rename discourse referents along `f : V → W` throughout a DRS. -/
-def DRS.map [DecidableEq W] (f : V → W) (K : DRS L V) : DRS L W :=
-  ⟨K.referents.image f, K.conditions.map (Condition.map f)⟩
+def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
+  Box.map f (Condition.map f)
 
 @[simp] theorem DRS.referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
     (K.map f).referents = K.referents.image f := rfl
@@ -53,18 +80,16 @@ def DRS.map [DecidableEq W] (f : V → W) (K : DRS L V) : DRS L W :=
   | .rel R args => by simp only [Condition.map, id_eq]
   | .eq a b => by simp only [Condition.map, id_eq]
   | .neg K => by
-    have ih : ∀ d ∈ K.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Finset.image_id, List.map_congr_left ih, List.map_id']
+    have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Box.map_congr ih, Box.map_id]
   | .imp a c => by
-    have iha : ∀ d ∈ a.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
-    have ihc : ∀ d ∈ c.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Finset.image_id, List.map_congr_left iha,
-      List.map_congr_left ihc, List.map_id']
+    have iha : ∀ d ∈ a.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+    have ihc : ∀ d ∈ c.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Box.map_congr iha, Box.map_congr ihc, Box.map_id]
   | .dis l r => by
-    have ihl : ∀ d ∈ l.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
-    have ihr : ∀ d ∈ r.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Finset.image_id, List.map_congr_left ihl,
-      List.map_congr_left ihr, List.map_id']
+    have ihl : ∀ d ∈ l.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+    have ihr : ∀ d ∈ r.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Box.map_congr ihl, Box.map_congr ihr, Box.map_id]
 decreasing_by all_goals
   have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
   simp_wf
@@ -72,11 +97,8 @@ decreasing_by all_goals
 
 /-- Renaming a DRS along the identity is the identity. -/
 @[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
-  obtain ⟨U, conds⟩ := K
-  have ih : ∀ d ∈ conds, Condition.map id d = d := fun d _ => Condition.map_id d
-  simp only [DRS.map, Finset.image_id, List.map_congr_left ih, List.map_id']
-
-variable {X : Type*}
+  have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+  simp only [DRS.map, Box.map_congr ih, Box.map_id]
 
 /-- Renaming a condition along a composite is the composite of the renamings. -/
 theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) :
@@ -87,7 +109,7 @@ theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V �
     have ih : ∀ d ∈ K.conditions,
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
       fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left ih]
+    simp only [Condition.map, Box.map_map, Box.map_congr ih]
   | .imp a c => by
     have iha : ∀ d ∈ a.conditions,
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
@@ -95,8 +117,7 @@ theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V �
     have ihc : ∀ d ∈ c.conditions,
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
       fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left iha,
-      List.map_congr_left ihc]
+    simp only [Condition.map, Box.map_map, Box.map_congr iha, Box.map_congr ihc]
   | .dis l r => by
     have ihl : ∀ d ∈ l.conditions,
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
@@ -104,8 +125,7 @@ theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V �
     have ihr : ∀ d ∈ r.conditions,
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
       fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left ihl,
-      List.map_congr_left ihr]
+    simp only [Condition.map, Box.map_map, Box.map_congr ihl, Box.map_congr ihr]
 decreasing_by all_goals
   have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
   simp_wf
@@ -117,7 +137,7 @@ theorem DRS.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) 
   have ih : ∀ d ∈ K.conditions,
       (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
     fun d _ => Condition.map_map g f d
-  simp only [DRS.map, Finset.image_image, List.map_map, List.map_congr_left ih]
+  simp only [DRS.map, Box.map_map, Box.map_congr ih]
 
 /-! ### Merge algebra -/
 
@@ -154,7 +174,7 @@ abbrev Embedding (V : Type w) (M : Type*) := V → M
 
 section Extends
 
-variable {M : Type*} {C : Type x}
+variable {M : Type*}
 
 /-- `K.Extends f g` (written `f [K] g`): the output embedding `g` differs from
 the input `f` at most on `K`'s universe — the total-assignment rendering of

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -60,10 +60,6 @@ def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L 
   | .neg K => .neg (K.map f (Condition.map f))
   | .imp a c => .imp (a.map f (Condition.map f)) (c.map f (Condition.map f))
   | .dis l r => .dis (l.map f (Condition.map f)) (r.map f (Condition.map f))
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Rename discourse referents along `f : V → W` throughout a DRS. -/
 def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
@@ -90,10 +86,6 @@ def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
     have ihl : ∀ d ∈ l.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
     have ihr : ∀ d ∈ r.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
     simp only [Condition.map, Box.map_congr ihl, Box.map_congr ihr, Box.map_id]
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Renaming a DRS along the identity is the identity. -/
 @[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
@@ -126,10 +118,6 @@ theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V �
         (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
       fun d _ => Condition.map_map g f d
     simp only [Condition.map, Box.map_map, Box.map_congr ihl, Box.map_congr ihr]
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Renaming a DRS along a composite is the composite of the renamings. -/
 theorem DRS.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
@@ -237,10 +225,6 @@ def Condition.occ : Condition L V → Finset V
       (c.referents ∪ (c.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
   | .dis l r => (l.referents ∪ (l.conditions.map Condition.occ).foldr (· ∪ ·) ∅) ∪
       (r.referents ∪ (r.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Occurring referents in a list of conditions. -/
 def Condition.occL (cs : List (Condition L V)) : Finset V :=
@@ -302,10 +286,6 @@ def Condition.fv : Condition L V → Finset V
       (((c.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
   | .dis l r => ((l.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ l.referents) ∪
       ((r.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ r.referents)
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Free referents of a list of conditions. -/
 def Condition.fvL (cs : List (Condition L V)) : Finset V :=
@@ -374,10 +354,6 @@ theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
     simp only [Condition.fv_dis, Condition.occ_dis]
     exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall ihl)
       (DRS.fv_subset_occ_of_forall ihr)
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Free referents occur. -/
 theorem DRS.fv_subset_occ (K : DRS L V) : K.fv ⊆ K.occ :=
@@ -450,10 +426,6 @@ def Condition.ReuseFreeAt (X : Finset V) : Condition L V → Prop
         ∀ d ∈ l.conditions, Condition.ReuseFreeAt (X ∪ l.referents) d) ∧
       (Disjoint X r.referents ∧
         ∀ d ∈ r.conditions, Condition.ReuseFreeAt (X ∪ r.referents) d)
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Reuse-freeness for a list of conditions. -/
 def Condition.ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
@@ -537,10 +509,6 @@ def Condition.accScope (s : Finset V) : Condition L V → V → Option (Finset V
       if x ∈ r.referents then some (s ∪ r.referents)
       else (r.conditions.map fun d => Condition.accScope (s ∪ r.referents) d x).foldr
         (fun r acc => r.orElse fun _ => acc) none
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Accessibility threading through a list of conditions: the first hit wins. -/
 def Condition.accScopeL (s : Finset V) (cs : List (Condition L V)) (x : V) :

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -18,7 +18,7 @@ namespace DRT
 
 universe u v w x
 
-variable {L : Language.{u, v}} {V : Type w} {W : Type x} {C D E X : Type*}
+variable {L : Language.{u, v}} {V : Type w} {W : Type x} {C D E M X : Type*}
 
 /-! ### Functorial renaming -/
 
@@ -139,23 +139,15 @@ end DRS
 
 /-! ### Embeddings and the extension relation -/
 
-/-- An *embedding function*: an assignment of discourse referents to
-individuals in a given model, in the total-assignment rendering (deviation
-note in `DRS/Verification.lean`). `M` is the model's domain of individuals;
-the model itself — `M` together with an interpretation of the relation
-symbols — is the `L.Structure M` instance that verification
-(`Embedding.Verifies`) requires, so embeddings and the extension relation
-need no model theory, while `f.Verifies K` only exists in a given model. -/
+/-- An *embedding function* is a function that maps discourse referents to
+individuals in a model — here total (deviation note in `DRS/Verification.lean`).
+Only the model's domain `M` appears; its interpretation of the relation
+symbols enters with verification (`f.Verifies K`, `DRS/Verification.lean`). -/
 abbrev Embedding (V : Type w) (M : Type*) := V → M
 
-section Extends
-
-variable {M : Type*}
-
-/-- `K.Extends f g` (written `f [K] g`): the output embedding `g` differs from
-the input `f` at most on `K`'s universe — the total-assignment rendering of
-"`f ⊆ g` and `Dom g = Dom f ∪ U_K`". Stated for any box, since only the
-universe is read. -/
+/-- `K.Extends f g` (written `f [K] g`) if the output embedding `g` differs
+from the input `f` at most on `K`'s universe — the total-assignment rendering
+of "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
 def Box.Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
 
 namespace DRS
@@ -164,13 +156,10 @@ namespace DRS
 theorem extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
     (K.map e).Extends f g ↔ K.Extends (f ∘ e) (g ∘ e) := by
   simp only [Box.Extends, referents_map, Function.comp_apply]
-  constructor
-  · intro h x hx
-    exact h (e x) (by simpa using hx)
-  · intro h y hy
-    have hx : e.symm y ∉ K.referents := fun hm =>
-      hy (by simpa using Finset.mem_image_of_mem e hm)
-    simpa using h (e.symm y) hx
+  refine ⟨fun h x hx => h (e x) (by simpa using hx), fun h y hy => ?_⟩
+  have hx : e.symm y ∉ K.referents := fun hm =>
+    hy (by simpa using Finset.mem_image_of_mem e hm)
+  simpa using h (e.symm y) hx
 
 /-- The extensions of `f` at `K.map e` are the extensions of `f ∘ e` at `K`,
 via precomposition. -/
@@ -178,28 +167,20 @@ theorem exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embe
     (P : Embedding V M → Prop) :
     (∃ g, (K.map e).Extends f g ∧ P (g ∘ e)) ↔ ∃ g, K.Extends (f ∘ e) g ∧ P g := by
   simp only [extends_map]
-  constructor
-  · rintro ⟨g, hg, hp⟩
-    exact ⟨g ∘ e, hg, hp⟩
-  · rintro ⟨g, hg, hp⟩
-    have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
-    exact ⟨g ∘ e.symm, key.symm ▸ hg, key.symm ▸ hp⟩
+  refine ⟨fun ⟨g, hg, hp⟩ => ⟨g ∘ e, hg, hp⟩, fun ⟨g, hg, hp⟩ => ⟨g ∘ e.symm, ?_⟩⟩
+  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
+  exact key.symm ▸ ⟨hg, hp⟩
 
 /-- The `∀` analogue of `DRS.exists_extends_map`. -/
 theorem forall_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
     (P : Embedding V M → Prop) :
     (∀ g, (K.map e).Extends f g → P (g ∘ e)) ↔ ∀ g, K.Extends (f ∘ e) g → P g := by
   simp only [extends_map]
-  constructor
-  · intro H g hg
-    have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
-    exact key ▸ H (g ∘ e.symm) (key.symm ▸ hg)
-  · intro H g hg
-    exact H (g ∘ e) hg
+  refine ⟨fun H g hg => ?_, fun H g hg => H (g ∘ e) hg⟩
+  have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
+  exact key ▸ H (g ∘ e.symm) (key.symm ▸ hg)
 
 end DRS
-
-end Extends
 
 /-! ### Occurring referents -/
 

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -53,79 +53,82 @@ theorem map_map [DecidableEq X] {f' : W → X} {g' : D → E} :
 
 end Box
 
+namespace Condition
+
 /-- Rename discourse referents along `f` throughout a condition. -/
-def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
+def map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
   | .rel R args => .rel R (fun i => f (args i))
   | .eq a b => .eq (f a) (f b)
-  | .neg K => .neg (K.map f (Condition.map f))
-  | .imp a c => .imp (a.map f (Condition.map f)) (c.map f (Condition.map f))
-  | .dis l r => .dis (l.map f (Condition.map f)) (r.map f (Condition.map f))
-
-/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
-def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
-  Box.map f (Condition.map f)
-
-@[simp] theorem DRS.referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).referents = K.referents.image f := rfl
-
-@[simp] theorem DRS.conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).conditions = K.conditions.map (Condition.map f) := rfl
+  | .neg K => .neg (K.map f (map f))
+  | .imp a c => .imp (a.map f (map f)) (c.map f (map f))
+  | .dis l r => .dis (l.map f (map f)) (r.map f (map f))
 
 /-- Renaming a condition along the identity is the identity. -/
-@[simp] theorem Condition.map_id [DecidableEq V] : ∀ c : Condition L V, Condition.map id c = c
-  | .rel R args => by simp only [Condition.map, id_eq]
-  | .eq a b => by simp only [Condition.map, id_eq]
+@[simp] theorem map_id [DecidableEq V] : ∀ c : Condition L V, map id c = c
+  | .rel R args => by simp only [map, id_eq]
+  | .eq a b => by simp only [map, id_eq]
   | .neg K => by
-    have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Box.map_congr ih, Box.map_id]
+    have ih : ∀ d ∈ K.conditions, map id d = id d := fun d _ => map_id d
+    simp only [map, Box.map_congr ih, Box.map_id]
   | .imp a c => by
-    have iha : ∀ d ∈ a.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-    have ihc : ∀ d ∈ c.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Box.map_congr iha, Box.map_congr ihc, Box.map_id]
+    have iha : ∀ d ∈ a.conditions, map id d = id d := fun d _ => map_id d
+    have ihc : ∀ d ∈ c.conditions, map id d = id d := fun d _ => map_id d
+    simp only [map, Box.map_congr iha, Box.map_congr ihc, Box.map_id]
   | .dis l r => by
-    have ihl : ∀ d ∈ l.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-    have ihr : ∀ d ∈ r.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-    simp only [Condition.map, Box.map_congr ihl, Box.map_congr ihr, Box.map_id]
-
-/-- Renaming a DRS along the identity is the identity. -/
-@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
-  have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-  simp only [DRS.map, Box.map_congr ih, Box.map_id]
+    have ihl : ∀ d ∈ l.conditions, map id d = id d := fun d _ => map_id d
+    have ihr : ∀ d ∈ r.conditions, map id d = id d := fun d _ => map_id d
+    simp only [map, Box.map_congr ihl, Box.map_congr ihr, Box.map_id]
 
 /-- Renaming a condition along a composite is the composite of the renamings. -/
-theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) :
-    ∀ c : Condition L V, Condition.map g (Condition.map f c) = Condition.map (g ∘ f) c
-  | .rel R args => by simp only [Condition.map]; rfl
-  | .eq a b => by simp only [Condition.map]; rfl
+theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) :
+    ∀ c : Condition L V, map g (map f c) = map (g ∘ f) c
+  | .rel R args => by simp only [map]; rfl
+  | .eq a b => by simp only [map]; rfl
   | .neg K => by
-    have ih : ∀ d ∈ K.conditions,
-        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-      fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Box.map_map, Box.map_congr ih]
+    have ih : ∀ d ∈ K.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
+      fun d _ => map_map g f d
+    simp only [map, Box.map_map, Box.map_congr ih]
   | .imp a c => by
-    have iha : ∀ d ∈ a.conditions,
-        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-      fun d _ => Condition.map_map g f d
-    have ihc : ∀ d ∈ c.conditions,
-        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-      fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Box.map_map, Box.map_congr iha, Box.map_congr ihc]
+    have iha : ∀ d ∈ a.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
+      fun d _ => map_map g f d
+    have ihc : ∀ d ∈ c.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
+      fun d _ => map_map g f d
+    simp only [map, Box.map_map, Box.map_congr iha, Box.map_congr ihc]
   | .dis l r => by
-    have ihl : ∀ d ∈ l.conditions,
-        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-      fun d _ => Condition.map_map g f d
-    have ihr : ∀ d ∈ r.conditions,
-        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-      fun d _ => Condition.map_map g f d
-    simp only [Condition.map, Box.map_map, Box.map_congr ihl, Box.map_congr ihr]
+    have ihl : ∀ d ∈ l.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
+      fun d _ => map_map g f d
+    have ihr : ∀ d ∈ r.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
+      fun d _ => map_map g f d
+    simp only [map, Box.map_map, Box.map_congr ihl, Box.map_congr ihr]
+
+end Condition
+
+namespace DRS
+
+/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
+def map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
+  Box.map f (Condition.map f)
+
+@[simp] theorem referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).referents = K.referents.image f := rfl
+
+@[simp] theorem conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
+    (K.map f).conditions = K.conditions.map (Condition.map f) := rfl
+
+/-- Renaming a DRS along the identity is the identity. -/
+@[simp] theorem map_id [DecidableEq V] (K : DRS L V) : map id K = K := by
+  have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
+  simp only [map, Box.map_congr ih, Box.map_id]
 
 /-- Renaming a DRS along a composite is the composite of the renamings. -/
-theorem DRS.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
-    DRS.map g (DRS.map f K) = DRS.map (g ∘ f) K := by
+theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
+    map g (map f K) = map (g ∘ f) K := by
   have ih : ∀ d ∈ K.conditions,
       (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
     fun d _ => Condition.map_map g f d
-  simp only [DRS.map, Box.map_map, Box.map_congr ih]
+  simp only [map, Box.map_map, Box.map_congr ih]
+
+end DRS
 
 /-! ### Merge algebra -/
 
@@ -170,10 +173,12 @@ the input `f` at most on `K`'s universe — the total-assignment rendering of
 universe is read. -/
 def Box.Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
 
+namespace DRS
+
 /-- Extension along a renamed DRS is extension of the precompositions. -/
-theorem DRS.extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
+theorem extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embedding W M) :
     (K.map e).Extends f g ↔ K.Extends (f ∘ e) (g ∘ e) := by
-  simp only [Box.Extends, DRS.referents_map, Function.comp_apply]
+  simp only [Box.Extends, referents_map, Function.comp_apply]
   constructor
   · intro h x hx
     exact h (e x) (by simpa using hx)
@@ -184,10 +189,10 @@ theorem DRS.extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f g : Embed
 
 /-- The extensions of `f` at `K.map e` are the extensions of `f ∘ e` at `K`,
 via precomposition. -/
-theorem DRS.exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
+theorem exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
     (P : Embedding V M → Prop) :
     (∃ g, (K.map e).Extends f g ∧ P (g ∘ e)) ↔ ∃ g, K.Extends (f ∘ e) g ∧ P g := by
-  simp only [DRS.extends_map]
+  simp only [extends_map]
   constructor
   · rintro ⟨g, hg, hp⟩
     exact ⟨g ∘ e, hg, hp⟩
@@ -196,16 +201,18 @@ theorem DRS.exists_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : 
     exact ⟨g ∘ e.symm, key.symm ▸ hg, key.symm ▸ hp⟩
 
 /-- The `∀` analogue of `DRS.exists_extends_map`. -/
-theorem DRS.forall_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
+theorem forall_extends_map [DecidableEq W] (e : V ≃ W) (K : DRS L V) (f : Embedding W M)
     (P : Embedding V M → Prop) :
     (∀ g, (K.map e).Extends f g → P (g ∘ e)) ↔ ∀ g, K.Extends (f ∘ e) g → P g := by
-  simp only [DRS.extends_map]
+  simp only [extends_map]
   constructor
   · intro H g hg
     have key : (g ∘ e.symm) ∘ e = g := by funext x; simp
     exact key ▸ H (g ∘ e.symm) (key.symm ▸ hg)
   · intro H g hg
     exact H (g ∘ e) hg
+
+end DRS
 
 end Extends
 
@@ -214,61 +221,69 @@ end Extends
 section Occ
 variable [DecidableEq V]
 
+namespace Condition
+
 /-- Occurring referents (free or bound) in a condition, as a `Finset` — the DRS
 analogue of mathlib's `Term.varFinset`. Membership `x ∈ occ c` is decidable, so
 downstream consumers get decidable occurrence for free. -/
-def Condition.occ : Condition L V → Finset V
+def occ : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => K.referents ∪ (K.conditions.map Condition.occ).foldr (· ∪ ·) ∅
-  | .imp a c => (a.referents ∪ (a.conditions.map Condition.occ).foldr (· ∪ ·) ∅) ∪
-      (c.referents ∪ (c.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
-  | .dis l r => (l.referents ∪ (l.conditions.map Condition.occ).foldr (· ∪ ·) ∅) ∪
-      (r.referents ∪ (r.conditions.map Condition.occ).foldr (· ∪ ·) ∅)
+  | .neg K => K.referents ∪ (K.conditions.map occ).foldr (· ∪ ·) ∅
+  | .imp a c => (a.referents ∪ (a.conditions.map occ).foldr (· ∪ ·) ∅) ∪
+      (c.referents ∪ (c.conditions.map occ).foldr (· ∪ ·) ∅)
+  | .dis l r => (l.referents ∪ (l.conditions.map occ).foldr (· ∪ ·) ∅) ∪
+      (r.referents ∪ (r.conditions.map occ).foldr (· ∪ ·) ∅)
 
 /-- Occurring referents in a list of conditions. -/
-def Condition.occL (cs : List (Condition L V)) : Finset V :=
-  (cs.map Condition.occ).foldr (· ∪ ·) ∅
+def occL (cs : List (Condition L V)) : Finset V := (cs.map occ).foldr (· ∪ ·) ∅
 
-/-- Occurring referents in a DRS (its universe and those of its conditions). -/
-def DRS.occ (K : DRS L V) : Finset V := K.referents ∪ Condition.occL K.conditions
+@[simp] theorem occL_nil : occL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem occL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    occL (c :: cs) = c.occ ∪ occL cs := rfl
+@[simp] theorem occ_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (rel R args).occ = Finset.image args Finset.univ := by simp only [occ]
+@[simp] theorem occ_eq (u v : V) :
+    (eq u v : Condition L V).occ = {u, v} := by simp only [occ]
 
-@[simp] theorem Condition.occL_nil : Condition.occL ([] : List (Condition L V)) = ∅ := rfl
-@[simp] theorem Condition.occL_cons (c : Condition L V) (cs : List (Condition L V)) :
-    Condition.occL (c :: cs) = c.occ ∪ Condition.occL cs := rfl
-@[simp] theorem DRS.occ_mk (U : Finset V) (conds : List (Condition L V)) :
-    DRS.occ ⟨U, conds⟩ = U ∪ Condition.occL conds := rfl
-@[simp] theorem Condition.occ_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (Condition.rel R args).occ = Finset.image args Finset.univ := by
-  simp only [Condition.occ]
-@[simp] theorem Condition.occ_eq (u v : V) :
-    (Condition.eq u v : Condition L V).occ = {u, v} := by simp only [Condition.occ]
-@[simp] theorem Condition.occ_neg (K : DRS L V) : (Condition.neg K).occ = K.occ := by
-  simp only [Condition.occ]; rfl
-@[simp] theorem Condition.occ_imp (a c : DRS L V) :
-    (Condition.imp a c).occ = a.occ ∪ c.occ := by simp only [Condition.occ]; rfl
-@[simp] theorem Condition.occ_dis (l r : DRS L V) :
-    (Condition.dis l r).occ = l.occ ∪ r.occ := by simp only [Condition.occ]; rfl
-
-@[simp] theorem Condition.occL_append (cs ds : List (Condition L V)) :
-    Condition.occL (cs ++ ds) = Condition.occL cs ∪ Condition.occL ds := by
+@[simp] theorem occL_append (cs ds : List (Condition L V)) :
+    occL (cs ++ ds) = occL cs ∪ occL ds := by
   induction cs with
   | nil => simp
   | cons c cs ih => simp [ih, Finset.union_assoc]
 
-/-- A DRS's conditions' occurring referents are among the DRS's. -/
-theorem DRS.occL_subset_occ (K : DRS L V) : Condition.occL K.conditions ⊆ K.occ :=
-  Finset.subset_union_right
-
 /-- A condition's occurring referents are among its list's. -/
-theorem Condition.occ_subset_occL {c : Condition L V} {cs : List (Condition L V)}
-    (hc : c ∈ cs) : c.occ ⊆ Condition.occL cs := by
+theorem occ_subset_occL {c : Condition L V} {cs : List (Condition L V)}
+    (hc : c ∈ cs) : c.occ ⊆ occL cs := by
   induction cs with
   | nil => cases hc
   | cons d ds ih =>
     rcases List.mem_cons.mp hc with h | h
     · exact h ▸ Finset.subset_union_left
     · exact (ih h).trans Finset.subset_union_right
+
+end Condition
+
+namespace DRS
+
+/-- Occurring referents in a DRS (its universe and those of its conditions). -/
+def occ (K : DRS L V) : Finset V := K.referents ∪ Condition.occL K.conditions
+
+@[simp] theorem occ_mk (U : Finset V) (conds : List (Condition L V)) :
+    occ ⟨U, conds⟩ = U ∪ Condition.occL conds := rfl
+
+/-- A DRS's conditions' occurring referents are among the DRS's. -/
+theorem occL_subset_occ (K : DRS L V) : Condition.occL K.conditions ⊆ K.occ :=
+  Finset.subset_union_right
+
+end DRS
+
+@[simp] theorem Condition.occ_neg (K : DRS L V) : (Condition.neg K).occ = K.occ := by
+  simp only [Condition.occ]; rfl
+@[simp] theorem Condition.occ_imp (a c : DRS L V) :
+    (Condition.imp a c).occ = a.occ ∪ c.occ := by simp only [Condition.occ]; rfl
+@[simp] theorem Condition.occ_dis (l r : DRS L V) :
+    (Condition.dis l r).occ = l.occ ∪ r.occ := by simp only [Condition.occ]; rfl
 
 end Occ
 
@@ -277,62 +292,77 @@ end Occ
 section Fv
 variable [DecidableEq V]
 
+namespace Condition
+
 /-- The free discourse referents of a condition. -/
-def Condition.fv : Condition L V → Finset V
+def fv : Condition L V → Finset V
   | .rel _ args => Finset.image args Finset.univ
   | .eq u v => {u, v}
-  | .neg K => (K.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ K.referents
-  | .imp a c => ((a.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ a.referents) ∪
-      (((c.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
-  | .dis l r => ((l.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ l.referents) ∪
-      ((r.conditions.map Condition.fv).foldr (· ∪ ·) ∅ \ r.referents)
+  | .neg K => (K.conditions.map fv).foldr (· ∪ ·) ∅ \ K.referents
+  | .imp a c => ((a.conditions.map fv).foldr (· ∪ ·) ∅ \ a.referents) ∪
+      (((c.conditions.map fv).foldr (· ∪ ·) ∅ \ c.referents) \ a.referents)
+  | .dis l r => ((l.conditions.map fv).foldr (· ∪ ·) ∅ \ l.referents) ∪
+      ((r.conditions.map fv).foldr (· ∪ ·) ∅ \ r.referents)
 
 /-- Free referents of a list of conditions. -/
-def Condition.fvL (cs : List (Condition L V)) : Finset V :=
-  (cs.map Condition.fv).foldr (· ∪ ·) ∅
+def fvL (cs : List (Condition L V)) : Finset V := (cs.map fv).foldr (· ∪ ·) ∅
+
+@[simp] theorem fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
+    (rel R args).fv = Finset.image args Finset.univ := by simp only [fv]
+@[simp] theorem fv_eq (u v : V) :
+    (eq u v : Condition L V).fv = {u, v} := by simp only [fv]
+@[simp] theorem fvL_nil : fvL ([] : List (Condition L V)) = ∅ := rfl
+@[simp] theorem fvL_cons (c : Condition L V) (cs : List (Condition L V)) :
+    fvL (c :: cs) = c.fv ∪ fvL cs := rfl
+
+@[simp] theorem fvL_append (cs ds : List (Condition L V)) :
+    fvL (cs ++ ds) = fvL cs ∪ fvL ds := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih => simp [ih, Finset.union_assoc]
+
+private theorem fvL_subset_occL_of_forall {cs : List (Condition L V)}
+    (h : ∀ c ∈ cs, c.fv ⊆ c.occ) : fvL cs ⊆ occL cs := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih =>
+    simp only [fvL_cons, occL_cons]
+    exact Finset.union_subset_union (h c (by simp))
+      (ih fun d hd => h d (List.mem_cons_of_mem c hd))
+
+end Condition
+
+namespace DRS
 
 /-- The free discourse referents of a DRS: referents occurring in its
 conditions and not bound by its universe or by an ancestor reachable "left
 and up" (the antecedent of a `⇒` threads its referents into the consequent).
 `K.fv ⊆ b` says every referent of `K` is bound in context `b`. -/
-def DRS.fv (K : DRS L V) : Finset V := Condition.fvL K.conditions \ K.referents
+def fv (K : DRS L V) : Finset V := Condition.fvL K.conditions \ K.referents
 
-@[simp] theorem DRS.fv_mk (U : Finset V) (conds : List (Condition L V)) :
-    DRS.fv ⟨U, conds⟩ = Condition.fvL conds \ U := rfl
-@[simp] theorem Condition.fv_rel {n : ℕ} (R : L.Relations n) (args : Fin n → V) :
-    (Condition.rel R args).fv = Finset.image args Finset.univ := by simp only [Condition.fv]
-@[simp] theorem Condition.fv_eq (u v : V) :
-    (Condition.eq u v : Condition L V).fv = {u, v} := by simp only [Condition.fv]
+@[simp] theorem fv_mk (U : Finset V) (conds : List (Condition L V)) :
+    fv ⟨U, conds⟩ = Condition.fvL conds \ U := rfl
+
+/-- The characteristic form of the referential presupposition: a box's free
+referents are supplied by `X` iff its conditions' are supplied by the grown
+base. -/
+theorem fv_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
+    fv ⟨U, conds⟩ ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
+  rw [fv_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
+
+private theorem fv_subset_occ_of_forall {K : DRS L V}
+    (h : ∀ c ∈ K.conditions, c.fv ⊆ c.occ) : K.fv ⊆ K.occ :=
+  Finset.sdiff_subset.trans ((Condition.fvL_subset_occL_of_forall h).trans
+    Finset.subset_union_right)
+
+end DRS
+
 @[simp] theorem Condition.fv_neg (K : DRS L V) : (Condition.neg K).fv = K.fv := by
   simp only [Condition.fv]; rfl
 @[simp] theorem Condition.fv_imp (a c : DRS L V) :
     (Condition.imp a c).fv = a.fv ∪ (c.fv \ a.referents) := by simp only [Condition.fv]; rfl
 @[simp] theorem Condition.fv_dis (l r : DRS L V) :
     (Condition.dis l r).fv = l.fv ∪ r.fv := by simp only [Condition.fv]; rfl
-@[simp] theorem Condition.fvL_nil : Condition.fvL ([] : List (Condition L V)) = ∅ := rfl
-@[simp] theorem Condition.fvL_cons (c : Condition L V) (cs : List (Condition L V)) :
-    Condition.fvL (c :: cs) = c.fv ∪ Condition.fvL cs := rfl
-
-/-- The characteristic form of the referential presupposition: a box's free
-referents are supplied by `X` iff its conditions' are supplied by the grown
-base. -/
-theorem DRS.fv_subset_iff {U X : Finset V} {conds : List (Condition L V)} :
-    DRS.fv ⟨U, conds⟩ ⊆ X ↔ Condition.fvL conds ⊆ X ∪ U := by
-  rw [DRS.fv_mk, sdiff_le_iff, sup_comm, Finset.sup_eq_union]
-
-private theorem Condition.fvL_subset_occL_of_forall {cs : List (Condition L V)}
-    (h : ∀ c ∈ cs, c.fv ⊆ c.occ) : Condition.fvL cs ⊆ Condition.occL cs := by
-  induction cs with
-  | nil => simp
-  | cons c cs ih =>
-    simp only [Condition.fvL_cons, Condition.occL_cons]
-    exact Finset.union_subset_union (h c (by simp))
-      (ih fun d hd => h d (List.mem_cons_of_mem c hd))
-
-private theorem DRS.fv_subset_occ_of_forall {K : DRS L V}
-    (h : ∀ c ∈ K.conditions, c.fv ⊆ c.occ) : K.fv ⊆ K.occ :=
-  Finset.sdiff_subset.trans ((Condition.fvL_subset_occL_of_forall h).trans
-    Finset.subset_union_right)
 
 /-- Free referents of a condition occur. -/
 theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
@@ -364,34 +394,32 @@ theorem Condition.fvL_subset_occL (cs : List (Condition L V)) :
     Condition.fvL cs ⊆ Condition.occL cs :=
   Condition.fvL_subset_occL_of_forall fun c _ => Condition.fv_subset_occ c
 
-@[simp] theorem Condition.fvL_append (cs ds : List (Condition L V)) :
-    Condition.fvL (cs ++ ds) = Condition.fvL cs ∪ Condition.fvL ds := by
-  induction cs with
-  | nil => simp
-  | cons c cs ih => simp [ih, Finset.union_assoc]
+namespace DRS
 
 /-- Merging preserves boundedness: the merge's free referents are supplied by
 `X` when the context's are and the increment's are supplied by the grown base. -/
-theorem DRS.fv_merge_subset {X : Finset V} {K₁ K₂ : DRS L V} (h₁ : K₁.fv ⊆ X)
+theorem fv_merge_subset {X : Finset V} {K₁ K₂ : DRS L V} (h₁ : K₁.fv ⊆ X)
     (h₂ : K₂.fv ⊆ X ∪ K₁.referents) : (K₁.merge K₂).fv ⊆ X := by
   obtain ⟨U₁, c₁⟩ := K₁
   obtain ⟨U₂, c₂⟩ := K₂
-  rw [DRS.referents_mk] at h₂
-  rw [DRS.fv_subset_iff] at h₁ h₂
-  rw [DRS.merge, DRS.referents_mk, DRS.conditions_mk, DRS.fv_subset_iff,
+  rw [referents_mk] at h₂
+  rw [fv_subset_iff] at h₁ h₂
+  rw [merge, referents_mk, conditions_mk, fv_subset_iff,
     Condition.fvL_append, ← Finset.union_assoc]
   exact Finset.union_subset (h₁.trans Finset.subset_union_left) h₂
 
 /-- A DRS is *proper* iff it has no free discourse referent
 (Def. 1.4.2–1.4.3). -/
-def DRS.IsProper (K : DRS L V) : Prop := K.fv = ∅
+def IsProper (K : DRS L V) : Prop := K.fv = ∅
 
 /-- Merging preserves properness when the increment's free referents are
 supplied by the context DRS's universe. -/
-theorem DRS.isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
+theorem isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
     (h₂ : K₂.fv ⊆ K₁.referents) : (K₁.merge K₂).IsProper :=
-  Finset.subset_empty.mp (DRS.fv_merge_subset (Finset.subset_empty.mpr h₁)
+  Finset.subset_empty.mp (fv_merge_subset (Finset.subset_empty.mpr h₁)
     (h₂.trans Finset.subset_union_right))
+
+end DRS
 
 end Fv
 
@@ -407,46 +435,63 @@ agree-off-universe semantics and the persistence semantics coincide
 section ReuseFree
 variable [DecidableEq V]
 
+namespace Condition
+
 /-- A condition is reuse-free at ambient declarations `X`: each sub-box
 universe is fresh for the declarations in scope, threaded the way verification
 threads the base (the antecedent of a `⇒` feeds its referents into the
 consequent). -/
-def Condition.ReuseFreeAt (X : Finset V) : Condition L V → Prop
+def ReuseFreeAt (X : Finset V) : Condition L V → Prop
   | .rel _ _ => True
   | .eq _ _ => True
   | .neg K => Disjoint X K.referents ∧
-      ∀ c ∈ K.conditions, Condition.ReuseFreeAt (X ∪ K.referents) c
+      ∀ c ∈ K.conditions, ReuseFreeAt (X ∪ K.referents) c
   | .imp a c =>
       (Disjoint X a.referents ∧
-        ∀ d ∈ a.conditions, Condition.ReuseFreeAt (X ∪ a.referents) d) ∧
+        ∀ d ∈ a.conditions, ReuseFreeAt (X ∪ a.referents) d) ∧
       (Disjoint (X ∪ a.referents) c.referents ∧
-        ∀ d ∈ c.conditions, Condition.ReuseFreeAt (X ∪ a.referents ∪ c.referents) d)
+        ∀ d ∈ c.conditions, ReuseFreeAt (X ∪ a.referents ∪ c.referents) d)
   | .dis l r =>
       (Disjoint X l.referents ∧
-        ∀ d ∈ l.conditions, Condition.ReuseFreeAt (X ∪ l.referents) d) ∧
+        ∀ d ∈ l.conditions, ReuseFreeAt (X ∪ l.referents) d) ∧
       (Disjoint X r.referents ∧
-        ∀ d ∈ r.conditions, Condition.ReuseFreeAt (X ∪ r.referents) d)
+        ∀ d ∈ r.conditions, ReuseFreeAt (X ∪ r.referents) d)
 
 /-- Reuse-freeness for a list of conditions. -/
-def Condition.ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
-  ∀ c ∈ cs, Condition.ReuseFreeAt X c
+def ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
+  ∀ c ∈ cs, ReuseFreeAt X c
+
+@[simp] theorem reuseFreeAt_rel (X : Finset V) {n : ℕ} (R : L.Relations n)
+    (args : Fin n → V) : ReuseFreeAt X (.rel R args) := by
+  simp only [ReuseFreeAt]
+
+@[simp] theorem reuseFreeAt_eq (X : Finset V) (u v : V) :
+    ReuseFreeAt X (.eq u v : Condition L V) := by
+  simp only [ReuseFreeAt]
+
+@[simp] theorem reuseFreeAllAt_nil (X : Finset V) :
+    ReuseFreeAllAt X ([] : List (Condition L V)) := by
+  simp [ReuseFreeAllAt]
+
+@[simp] theorem reuseFreeAllAt_cons (X : Finset V) (c : Condition L V)
+    (cs : List (Condition L V)) :
+    ReuseFreeAllAt X (c :: cs) ↔ ReuseFreeAt X c ∧ ReuseFreeAllAt X cs := by
+  simp only [ReuseFreeAllAt, List.forall_mem_cons]
+
+end Condition
+
+namespace DRS
 
 /-- A DRS is *reuse-free* at ambient declarations `X`: its universe avoids `X`
 and its conditions are reuse-free at the grown set. -/
-def DRS.ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
+def ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
   Disjoint X K.referents ∧ Condition.ReuseFreeAllAt (X ∪ K.referents) K.conditions
 
-@[simp] theorem DRS.reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
-    DRS.ReuseFreeAt X (.mk U conds) ↔
+@[simp] theorem reuseFreeAt_mk (X U : Finset V) (conds : List (Condition L V)) :
+    ReuseFreeAt X (.mk U conds) ↔
       Disjoint X U ∧ Condition.ReuseFreeAllAt (X ∪ U) conds := Iff.rfl
 
-@[simp] theorem Condition.reuseFreeAt_rel (X : Finset V) {n : ℕ} (R : L.Relations n)
-    (args : Fin n → V) : Condition.ReuseFreeAt X (.rel R args) := by
-  simp only [Condition.ReuseFreeAt]
-
-@[simp] theorem Condition.reuseFreeAt_eq (X : Finset V) (u v : V) :
-    Condition.ReuseFreeAt X (.eq u v : Condition L V) := by
-  simp only [Condition.ReuseFreeAt]
+end DRS
 
 @[simp] theorem Condition.reuseFreeAt_neg (X : Finset V) (K : DRS L V) :
     Condition.ReuseFreeAt X (.neg K) ↔ DRS.ReuseFreeAt X K := by
@@ -462,16 +507,6 @@ def DRS.ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
       DRS.ReuseFreeAt X l ∧ DRS.ReuseFreeAt X r := by
   simp only [Condition.ReuseFreeAt]; rfl
 
-@[simp] theorem Condition.reuseFreeAllAt_nil (X : Finset V) :
-    Condition.ReuseFreeAllAt X ([] : List (Condition L V)) := by
-  simp [Condition.ReuseFreeAllAt]
-
-@[simp] theorem Condition.reuseFreeAllAt_cons (X : Finset V) (c : Condition L V)
-    (cs : List (Condition L V)) :
-    Condition.ReuseFreeAllAt X (c :: cs) ↔
-      Condition.ReuseFreeAt X c ∧ Condition.ReuseFreeAllAt X cs := by
-  simp only [Condition.ReuseFreeAllAt, List.forall_mem_cons]
-
 end ReuseFree
 
 /-! ### Accessibility (decidable, host-relative)
@@ -486,41 +521,60 @@ in-scope referents (the same threading as `DRS.Bound`), which is also decidable.
 section Accessibility
 variable [DecidableEq V]
 
+namespace Condition
+
 /-- Accessibility threading through a condition. -/
-def Condition.accScope (s : Finset V) : Condition L V → V → Option (Finset V)
+def accScope (s : Finset V) : Condition L V → V → Option (Finset V)
   | .rel _ _, _ => none
   | .eq _ _, _ => none
   | .neg K, x =>
       if x ∈ K.referents then some (s ∪ K.referents)
-      else (K.conditions.map fun c => Condition.accScope (s ∪ K.referents) c x).foldr
+      else (K.conditions.map fun c => accScope (s ∪ K.referents) c x).foldr
         (fun r acc => r.orElse fun _ => acc) none
   | .imp a c, x =>
       (if x ∈ a.referents then some (s ∪ a.referents)
-       else (a.conditions.map fun d => Condition.accScope (s ∪ a.referents) d x).foldr
+       else (a.conditions.map fun d => accScope (s ∪ a.referents) d x).foldr
          (fun r acc => r.orElse fun _ => acc) none).orElse fun _ =>
       if x ∈ c.referents then some (s ∪ a.referents ∪ c.referents)
       else (c.conditions.map fun d =>
-          Condition.accScope (s ∪ a.referents ∪ c.referents) d x).foldr
+          accScope (s ∪ a.referents ∪ c.referents) d x).foldr
         (fun r acc => r.orElse fun _ => acc) none
   | .dis l r, x =>
       (if x ∈ l.referents then some (s ∪ l.referents)
-       else (l.conditions.map fun d => Condition.accScope (s ∪ l.referents) d x).foldr
+       else (l.conditions.map fun d => accScope (s ∪ l.referents) d x).foldr
          (fun r acc => r.orElse fun _ => acc) none).orElse fun _ =>
       if x ∈ r.referents then some (s ∪ r.referents)
-      else (r.conditions.map fun d => Condition.accScope (s ∪ r.referents) d x).foldr
+      else (r.conditions.map fun d => accScope (s ∪ r.referents) d x).foldr
         (fun r acc => r.orElse fun _ => acc) none
 
 /-- Accessibility threading through a list of conditions: the first hit wins. -/
-def Condition.accScopeL (s : Finset V) (cs : List (Condition L V)) (x : V) :
-    Option (Finset V) :=
-  (cs.map fun c => Condition.accScope s c x).foldr (fun r acc => r.orElse fun _ => acc) none
+def accScopeL (s : Finset V) (cs : List (Condition L V)) (x : V) : Option (Finset V) :=
+  (cs.map fun c => accScope s c x).foldr (fun r acc => r.orElse fun _ => acc) none
+
+end Condition
+
+namespace DRS
 
 /-- Descend `K`, accumulating in-scope referents `s` ("left and up"); on reaching
 the box introducing `x`, return that box's in-scope set `s ∪ U`. The `⇒`-consequent
 additionally sees the antecedent's universe. -/
-def DRS.accScope (s : Finset V) (K : DRS L V) (x : V) : Option (Finset V) :=
+def accScope (s : Finset V) (K : DRS L V) (x : V) : Option (Finset V) :=
   if x ∈ K.referents then some (s ∪ K.referents)
   else Condition.accScopeL (s ∪ K.referents) K.conditions x
+
+/-- The referents accessible from `u`'s introduction in `T`, as a decidable
+`Finset`; `∅` if `u` is not introduced in `T`. (Def. 1.4.11 defines
+accessibility of a referent from a *condition*; this is the derived
+referent-to-referent relation of the surrounding prose.) -/
+def accessibleFrom (T : DRS L V) (u : V) : Finset V := (accScope ∅ T u).getD ∅
+
+/-- `v` is accessible from `u`'s position in `T`. Decidable (Finset membership). -/
+def Accessible (T : DRS L V) (u v : V) : Prop := v ∈ accessibleFrom T u
+
+instance (T : DRS L V) (u v : V) : Decidable (Accessible T u v) :=
+  inferInstanceAs (Decidable (v ∈ _))
+
+end DRS
 
 theorem Condition.accScope_neg (s : Finset V) (K : DRS L V) (x : V) :
     Condition.accScope s (.neg K) x = DRS.accScope s K x := by
@@ -535,18 +589,6 @@ theorem Condition.accScope_dis (s : Finset V) (l r : DRS L V) (x : V) :
     Condition.accScope s (.dis l r) x =
       (DRS.accScope s l x).orElse fun _ => DRS.accScope s r x := by
   simp only [Condition.accScope]; rfl
-
-/-- The referents accessible from `u`'s introduction in `T`, as a decidable
-`Finset`; `∅` if `u` is not introduced in `T`. (Def. 1.4.11 defines
-accessibility of a referent from a *condition*; this is the derived
-referent-to-referent relation of the surrounding prose.) -/
-def DRS.accessibleFrom (T : DRS L V) (u : V) : Finset V := (DRS.accScope ∅ T u).getD ∅
-
-/-- `v` is accessible from `u`'s position in `T`. Decidable (Finset membership). -/
-def DRS.Accessible (T : DRS L V) (u v : V) : Prop := v ∈ DRS.accessibleFrom T u
-
-instance (T : DRS L V) (u v : V) : Decidable (DRS.Accessible T u v) :=
-  inferInstanceAs (Decidable (v ∈ _))
 
 end Accessibility
 

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -43,13 +43,25 @@ re-marks the condition list, exposing `· ∈ K.conditions` to termination proof
 @[simp] theorem map_id [DecidableEq V] : K.map id id = K := by
   simp [map]
 
-theorem map_congr {g' : C → D} (h : ∀ c ∈ K.conditions, g c = g' c) :
-    K.map f g = K.map f g' := by
-  simp [map, List.map_congr_left h]
+@[simp] theorem map_id' [DecidableEq V] : K.map id (fun c => c) = K := map_id
+
+@[congr] theorem map_congr {f' : V → W} {g' : C → D} {K' : Box V C} (hf : f = f')
+    (hg : ∀ c ∈ K.conditions, g c = g' c) (hK : K = K') : K.map f g = K'.map f' g' := by
+  subst hK; subst hf
+  simp [map, List.map_congr_left hg]
 
 theorem map_map [DecidableEq X] {f' : W → X} {g' : D → E} :
     (K.map f g).map f' g' = K.map (f' ∘ f) (g' ∘ g) := by
   simp [map, Finset.image_image, List.map_map]
+
+theorem map_eq_self [DecidableEq V] {g : C → C} {K : Box V C}
+    (h : ∀ c ∈ K.conditions, g c = c) : K.map id g = K :=
+  (map_congr rfl h rfl).trans map_id'
+
+theorem map_map_of_forall [DecidableEq X] (f : V → W) (f' : W → X) {g' : D → E}
+    {g'' : C → E} (h : ∀ c ∈ K.conditions, g' (g c) = g'' c) :
+    (K.map f g).map f' g' = K.map (f' ∘ f) g'' :=
+  map_map.trans (map_congr rfl h rfl)
 
 end Box
 
@@ -64,42 +76,25 @@ def map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
   | .dis l r => .dis (l.map f (map f)) (r.map f (map f))
 
 /-- Renaming a condition along the identity is the identity. -/
-@[simp] theorem map_id [DecidableEq V] : ∀ c : Condition L V, map id c = c
-  | .rel R args => by simp only [map, id_eq]
-  | .eq a b => by simp only [map, id_eq]
-  | .neg K => by
-    have ih : ∀ d ∈ K.conditions, map id d = id d := fun d _ => map_id d
-    simp only [map, Box.map_congr ih, Box.map_id]
-  | .imp a c => by
-    have iha : ∀ d ∈ a.conditions, map id d = id d := fun d _ => map_id d
-    have ihc : ∀ d ∈ c.conditions, map id d = id d := fun d _ => map_id d
-    simp only [map, Box.map_congr iha, Box.map_congr ihc, Box.map_id]
-  | .dis l r => by
-    have ihl : ∀ d ∈ l.conditions, map id d = id d := fun d _ => map_id d
-    have ihr : ∀ d ∈ r.conditions, map id d = id d := fun d _ => map_id d
-    simp only [map, Box.map_congr ihl, Box.map_congr ihr, Box.map_id]
+@[simp] theorem map_id [DecidableEq V] (c : Condition L V) : map id c = c := by
+  induction c with
+  | rel R args => simp [map]
+  | eq u v => simp [map]
+  | neg K ih => simp [map, Box.map_eq_self ih]
+  | imp a c iha ihc => simp [map, Box.map_eq_self iha, Box.map_eq_self ihc]
+  | dis l r ihl ihr => simp [map, Box.map_eq_self ihl, Box.map_eq_self ihr]
 
 /-- Renaming a condition along a composite is the composite of the renamings. -/
-theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) :
-    ∀ c : Condition L V, map g (map f c) = map (g ∘ f) c
-  | .rel R args => by simp only [map]; rfl
-  | .eq a b => by simp only [map]; rfl
-  | .neg K => by
-    have ih : ∀ d ∈ K.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
-      fun d _ => map_map g f d
-    simp only [map, Box.map_map, Box.map_congr ih]
-  | .imp a c => by
-    have iha : ∀ d ∈ a.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
-      fun d _ => map_map g f d
-    have ihc : ∀ d ∈ c.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
-      fun d _ => map_map g f d
-    simp only [map, Box.map_map, Box.map_congr iha, Box.map_congr ihc]
-  | .dis l r => by
-    have ihl : ∀ d ∈ l.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
-      fun d _ => map_map g f d
-    have ihr : ∀ d ∈ r.conditions, (map g ∘ map f) d = map (g ∘ f) d :=
-      fun d _ => map_map g f d
-    simp only [map, Box.map_map, Box.map_congr ihl, Box.map_congr ihr]
+theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W)
+    (c : Condition L V) : map g (map f c) = map (g ∘ f) c := by
+  induction c with
+  | rel R args => simp [map]
+  | eq u v => simp [map]
+  | neg K ih => simp [map, Box.map_map_of_forall f g ih]
+  | imp a c iha ihc =>
+    simp [map, Box.map_map_of_forall f g iha, Box.map_map_of_forall f g ihc]
+  | dis l r ihl ihr =>
+    simp [map, Box.map_map_of_forall f g ihl, Box.map_map_of_forall f g ihr]
 
 end Condition
 
@@ -117,16 +112,12 @@ def map [DecidableEq W] (f : V → W) : DRS L V → DRS L W :=
 
 /-- Renaming a DRS along the identity is the identity. -/
 @[simp] theorem map_id [DecidableEq V] (K : DRS L V) : map id K = K := by
-  have ih : ∀ d ∈ K.conditions, Condition.map id d = id d := fun d _ => Condition.map_id d
-  simp only [map, Box.map_congr ih, Box.map_id]
+  simp [map]
 
 /-- Renaming a DRS along a composite is the composite of the renamings. -/
 theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
     map g (map f K) = map (g ∘ f) K := by
-  have ih : ∀ d ∈ K.conditions,
-      (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
-    fun d _ => Condition.map_map g f d
-  simp only [map, Box.map_map, Box.map_congr ih]
+  simp [map, Box.map_map, Condition.map_map g f]
 
 end DRS
 

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -2,23 +2,14 @@ import Linglib.Semantics.Dynamic.DRS.Defs
 import Mathlib.Data.Finset.Image
 
 /-!
-# DRS structural API: functorial renaming and merge algebra
+# Structural operations on DRSs
 
-Structural operations and lemmas over the faithful `DRS` core (`DRS/Defs.lean`):
-
-* `DRS.map` / `Condition.map` — functorial renaming of discourse referents along
-  `f : V → W`. When `f` is a bijection this is [kamp-reyle-1993]'s *alphabetic
-  variant* (the prose preceding Def. 1.4.8); `map_id` makes "renaming to the
-  identity is the identity" a free corollary, and `Embedding.verifies_map`
-  (`DRS/Verification.lean`) shows variants have the same semantics.
-* `merge` algebra — identity (`empty`) and associativity.
-* `Embedding` and `Box.Extends` — embedding functions and K&R's extension
-  relation `f [K] g` between them.
-* `DRS.fv` / `DRS.IsProper` — free discourse referents (as a `Finset`) and
-  properness (`fv K = ∅`, Def. 1.4.2–1.4.3).
-* `Condition.occ` / `DRS.occ` — occurring referents, as a decidable `Finset`.
-* `DRS.accessibleFrom` / `DRS.Accessible` — decidable, host-relative
-  accessibility (Def. 1.4.11).
+This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
+functorial renaming of discourse referents (`DRS.map`), the merge algebra,
+embedding functions (`Embedding`) with the extension relation `f [K] g`
+(`Box.Extends`), and the referent predicates `occ`, `fv` and `IsProper`,
+`ReuseFreeAt`, and `Accessible`. Renaming along a bijection is
+[kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
 -/
 
 open FirstOrder
@@ -165,7 +156,7 @@ section Extends
 
 variable {M : Type*} {C : Type x}
 
-/-- `K.Extends f g` (K&R's `f [K] g`): the output embedding `g` differs from
+/-- `K.Extends f g` (written `f [K] g`): the output embedding `g` differs from
 the input `f` at most on `K`'s universe — the total-assignment rendering of
 "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". Stated for any box, since only the
 universe is read. -/

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -91,10 +91,8 @@ theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W)
   | rel R args => simp [map]
   | eq u v => simp [map]
   | neg K ih => simp [map, Box.map_map_of_forall f g ih]
-  | imp a c iha ihc =>
-    simp [map, Box.map_map_of_forall f g iha, Box.map_map_of_forall f g ihc]
-  | dis l r ihl ihr =>
-    simp [map, Box.map_map_of_forall f g ihl, Box.map_map_of_forall f g ihr]
+  | imp a c iha ihc => simp [map, Box.map_map_of_forall f g iha, Box.map_map_of_forall f g ihc]
+  | dis l r ihl ihr => simp [map, Box.map_map_of_forall f g ihl, Box.map_map_of_forall f g ihr]
 
 end Condition
 
@@ -119,11 +117,7 @@ theorem map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K :
     map g (map f K) = map (g ∘ f) K := by
   simp [map, Box.map_map, Condition.map_map g f]
 
-end DRS
-
 /-! ### Merge algebra -/
-
-namespace DRS
 
 variable [DecidableEq V]
 
@@ -357,21 +351,15 @@ end DRS
 
 /-- Free referents of a condition occur. -/
 theorem Condition.fv_subset_occ (c : Condition L V) : c.fv ⊆ c.occ := by
-  match c with
-  | .rel R args => simp
-  | .eq u v => simp
-  | .neg K =>
-    have ih : ∀ d ∈ K.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
-    simpa using DRS.fv_subset_occ_of_forall ih
-  | .imp a c =>
-    have iha : ∀ d ∈ a.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
-    have ihc : ∀ d ∈ c.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+  induction c with
+  | rel R args => simp
+  | eq u v => simp
+  | neg K ih => simpa using DRS.fv_subset_occ_of_forall ih
+  | imp a c iha ihc =>
     simp only [Condition.fv_imp, Condition.occ_imp]
     exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall iha)
       (Finset.sdiff_subset.trans (DRS.fv_subset_occ_of_forall ihc))
-  | .dis l r =>
-    have ihl : ∀ d ∈ l.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
-    have ihr : ∀ d ∈ r.conditions, d.fv ⊆ d.occ := fun d _ => Condition.fv_subset_occ d
+  | dis l r ihl ihr =>
     simp only [Condition.fv_dis, Condition.occ_dis]
     exact Finset.union_subset_union (DRS.fv_subset_occ_of_forall ihl)
       (DRS.fv_subset_occ_of_forall ihr)

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -31,58 +31,102 @@ variable {L : Language.{u, v}} {V : Type w} {W : Type x}
 
 /-! ### Functorial renaming -/
 
-mutual
-/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
-def DRS.map [DecidableEq W] (f : V → W) : DRS L V → DRS L W
-  | .mk refs conds => .mk (refs.image f) (Condition.mapList f conds)
 /-- Rename discourse referents along `f` throughout a condition. -/
 def Condition.map [DecidableEq W] (f : V → W) : Condition L V → Condition L W
   | .rel R args => .rel R (fun i => f (args i))
   | .eq a b => .eq (f a) (f b)
-  | .neg K => .neg (DRS.map f K)
-  | .imp a c => .imp (DRS.map f a) (DRS.map f c)
-  | .dis l r => .dis (DRS.map f l) (DRS.map f r)
-/-- Rename along `f` throughout a list of conditions. A `List` helper (not
-`conds.map (Condition.map f)`) because the higher-order form fails the
-nested-inductive structural-recursion checker. -/
-def Condition.mapList [DecidableEq W] (f : V → W) : List (Condition L V) → List (Condition L W)
-  | [] => []
-  | c :: cs => Condition.map f c :: Condition.mapList f cs
-end
+  | .neg K => .neg ⟨K.referents.image f, K.conditions.map (Condition.map f)⟩
+  | .imp a c =>
+      .imp ⟨a.referents.image f, a.conditions.map (Condition.map f)⟩
+        ⟨c.referents.image f, c.conditions.map (Condition.map f)⟩
+  | .dis l r =>
+      .dis ⟨l.referents.image f, l.conditions.map (Condition.map f)⟩
+        ⟨r.referents.image f, r.conditions.map (Condition.map f)⟩
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
 
-mutual
-/-- Renaming along the identity is the identity. -/
-@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
-  match K with
-  | .mk refs conds => simp only [DRS.map, Condition.mapList_id, Finset.image_id]
-/-- Renaming a condition along the identity is the identity. -/
-@[simp] theorem Condition.map_id [DecidableEq V] (c : Condition L V) :
-    Condition.map id c = c := by
-  match c with
-  | .rel R args => simp only [Condition.map, id_eq]
-  | .eq a b => simp only [Condition.map, id_eq]
-  | .neg K => simp only [Condition.map, DRS.map_id K]
-  | .imp a c => simp only [Condition.map, DRS.map_id a, DRS.map_id c]
-  | .dis l r => simp only [Condition.map, DRS.map_id l, DRS.map_id r]
-theorem Condition.mapList_id [DecidableEq V] (cs : List (Condition L V)) :
-    Condition.mapList id cs = cs := by
-  match cs with
-  | [] => rfl
-  | c :: cs => simp only [Condition.mapList, Condition.map_id c, Condition.mapList_id cs]
-end
+/-- Rename discourse referents along `f : V → W` throughout a DRS. -/
+def DRS.map [DecidableEq W] (f : V → W) (K : DRS L V) : DRS L W :=
+  ⟨K.referents.image f, K.conditions.map (Condition.map f)⟩
 
 @[simp] theorem DRS.referents_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).referents = K.referents.image f := by cases K; rfl
+    (K.map f).referents = K.referents.image f := rfl
 
 @[simp] theorem DRS.conditions_map [DecidableEq W] (f : V → W) (K : DRS L V) :
-    (K.map f).conditions = Condition.mapList f K.conditions := by cases K; rfl
+    (K.map f).conditions = K.conditions.map (Condition.map f) := rfl
 
-/-- `mapList` is `List.map` (definable only after the mutual block). -/
-theorem Condition.mapList_eq_map [DecidableEq W] (f : V → W) (cs : List (Condition L V)) :
-    Condition.mapList f cs = cs.map (Condition.map f) := by
-  induction cs with
-  | nil => rfl
-  | cons c cs ih => simp only [Condition.mapList, List.map_cons, ih]
+/-- Renaming a condition along the identity is the identity. -/
+@[simp] theorem Condition.map_id [DecidableEq V] : ∀ c : Condition L V, Condition.map id c = c
+  | .rel R args => by simp only [Condition.map, id_eq]
+  | .eq a b => by simp only [Condition.map, id_eq]
+  | .neg K => by
+    have ih : ∀ d ∈ K.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Finset.image_id, List.map_congr_left ih, List.map_id']
+  | .imp a c => by
+    have iha : ∀ d ∈ a.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
+    have ihc : ∀ d ∈ c.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Finset.image_id, List.map_congr_left iha,
+      List.map_congr_left ihc, List.map_id']
+  | .dis l r => by
+    have ihl : ∀ d ∈ l.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
+    have ihr : ∀ d ∈ r.conditions, Condition.map id d = d := fun d _ => Condition.map_id d
+    simp only [Condition.map, Finset.image_id, List.map_congr_left ihl,
+      List.map_congr_left ihr, List.map_id']
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- Renaming a DRS along the identity is the identity. -/
+@[simp] theorem DRS.map_id [DecidableEq V] (K : DRS L V) : DRS.map id K = K := by
+  obtain ⟨U, conds⟩ := K
+  have ih : ∀ d ∈ conds, Condition.map id d = d := fun d _ => Condition.map_id d
+  simp only [DRS.map, Finset.image_id, List.map_congr_left ih, List.map_id']
+
+variable {X : Type*}
+
+/-- Renaming a condition along a composite is the composite of the renamings. -/
+theorem Condition.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) :
+    ∀ c : Condition L V, Condition.map g (Condition.map f c) = Condition.map (g ∘ f) c
+  | .rel R args => by simp only [Condition.map]; rfl
+  | .eq a b => by simp only [Condition.map]; rfl
+  | .neg K => by
+    have ih : ∀ d ∈ K.conditions,
+        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+      fun d _ => Condition.map_map g f d
+    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left ih]
+  | .imp a c => by
+    have iha : ∀ d ∈ a.conditions,
+        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+      fun d _ => Condition.map_map g f d
+    have ihc : ∀ d ∈ c.conditions,
+        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+      fun d _ => Condition.map_map g f d
+    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left iha,
+      List.map_congr_left ihc]
+  | .dis l r => by
+    have ihl : ∀ d ∈ l.conditions,
+        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+      fun d _ => Condition.map_map g f d
+    have ihr : ∀ d ∈ r.conditions,
+        (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+      fun d _ => Condition.map_map g f d
+    simp only [Condition.map, Finset.image_image, List.map_map, List.map_congr_left ihl,
+      List.map_congr_left ihr]
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- Renaming a DRS along a composite is the composite of the renamings. -/
+theorem DRS.map_map [DecidableEq W] [DecidableEq X] (g : W → X) (f : V → W) (K : DRS L V) :
+    DRS.map g (DRS.map f K) = DRS.map (g ∘ f) K := by
+  have ih : ∀ d ∈ K.conditions,
+      (Condition.map g ∘ Condition.map f) d = Condition.map (g ∘ f) d :=
+    fun d _ => Condition.map_map g f d
+  simp only [DRS.map, Finset.image_image, List.map_map, List.map_congr_left ih]
 
 /-! ### Merge algebra -/
 

--- a/Linglib/Semantics/Dynamic/DRS/Box.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Box.lean
@@ -1,0 +1,104 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Image
+
+/-!
+# The DRT box
+
+The generic two-compartment shell of DRT: a *box* pairs a universe of
+discourse referents with a list of conditions, generic over the condition
+type `C`. DRT variants re-instantiate the shell at their own condition types
+(`DRS L V := Box V (Condition L V)` in `DRS/Defs.lean`; Layered DRT's LDRSs).
+Everything here is condition-agnostic: the functorial action `Box.map`, the
+extension relation `Box.Extends` between embedding functions, and the
+`sizeOf`/termination infrastructure for recursions that descend through the
+nested condition list.
+-/
+
+namespace DRT
+
+universe w x
+
+variable {V : Type w} {C : Type x} {W D E M : Type*}
+
+/-- A DRT *box*, generic over the condition type `C`; `DRS` instantiates `C`
+at `Condition L V`. -/
+@[ext] structure Box (V : Type w) (C : Type x) where
+  /-- The universe `U`: the discourse referents the box introduces. -/
+  referents : Finset V
+  /-- The box's conditions. -/
+  conditions : List C
+
+/-- An *embedding function* is a function that maps discourse referents to
+individuals in a model — here total (deviation note in `DRS/Verification.lean`).
+Only the model's domain `M` appears; its interpretation of the relation
+symbols enters with verification (`f.Verifies K`, `DRS/Verification.lean`). -/
+abbrev Embedding (V : Type w) (M : Type*) := V → M
+
+namespace Box
+
+/-- A condition of a box is smaller than the box — the recursion measure for
+definitions descending through the nested condition list. -/
+theorem sizeOf_lt_of_mem_conditions [SizeOf C] {K : Box V C} {c : C}
+    (h : c ∈ K.conditions) : sizeOf c < sizeOf K := by
+  obtain ⟨U, conds⟩ := K
+  have : sizeOf c < sizeOf conds := List.sizeOf_lt_of_mem h
+  simp only [Box.mk.sizeOf_spec]
+  omega
+
+-- Registers the `Box`-through-`List` nesting step with the default termination
+-- tactic: recursions descending into a box's conditions need no `decreasing_by`.
+macro_rules
+  | `(tactic| decreasing_trivial) =>
+    `(tactic| have := DRT.Box.sizeOf_lt_of_mem_conditions (by assumption); omega)
+
+/-! ### Functorial action -/
+
+variable [DecidableEq W] {f : V → W} {g : C → D} {K : Box V C}
+
+/-- `K.map f g` applies `f` to the universe and `g` to each condition. -/
+def map (f : V → W) (g : C → D) (K : Box V C) : Box W D :=
+  ⟨K.referents.image f, K.conditions.map g⟩
+
+/-- Well-founded recursions may traverse sub-boxes with `Box.map`: preprocessing
+re-marks the condition list, exposing `· ∈ K.conditions` to termination proofs. -/
+@[wf_preprocess] theorem map_wfParam :
+    map f g (wfParam K) = ⟨K.referents.image f, (wfParam K.conditions).map g⟩ := by
+  simp [wfParam, map]
+
+@[simp] theorem referents_map : (K.map f g).referents = K.referents.image f := rfl
+
+@[simp] theorem conditions_map : (K.map f g).conditions = K.conditions.map g := rfl
+
+@[simp] theorem map_id [DecidableEq V] : K.map id id = K := by
+  simp [map]
+
+@[simp] theorem map_id' [DecidableEq V] : K.map id (fun c => c) = K := map_id
+
+@[congr] theorem map_congr {f' : V → W} {g' : C → D} {K' : Box V C} (hf : f = f')
+    (hg : ∀ c ∈ K.conditions, g c = g' c) (hK : K = K') : K.map f g = K'.map f' g' := by
+  subst hK; subst hf
+  simp [map, List.map_congr_left hg]
+
+theorem map_map {X : Type*} [DecidableEq X] {f' : W → X} {g' : D → E} :
+    (K.map f g).map f' g' = K.map (f' ∘ f) (g' ∘ g) := by
+  simp [map, Finset.image_image, List.map_map]
+
+theorem map_eq_self [DecidableEq V] {g : C → C} {K : Box V C}
+    (h : ∀ c ∈ K.conditions, g c = c) : K.map id g = K :=
+  (map_congr rfl h rfl).trans map_id'
+
+theorem map_map_of_forall {X : Type*} [DecidableEq X] (f : V → W) (f' : W → X) {g' : D → E}
+    {g'' : C → E} (h : ∀ c ∈ K.conditions, g' (g c) = g'' c) :
+    (K.map f g).map f' g' = K.map (f' ∘ f) g'' :=
+  map_map.trans (map_congr rfl h rfl)
+
+/-! ### The extension relation -/
+
+/-- `K.Extends f g` (written `f [K] g`) if the output embedding `g` differs
+from the input `f` at most on `K`'s universe — the total-assignment rendering
+of "`f ⊆ g` and `Dom g = Dom f ∪ U_K`". -/
+def Extends (K : Box V C) (f g : Embedding V M) : Prop := ∀ x ∉ K.referents, g x = f x
+
+end Box
+
+end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Box.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Box.lean
@@ -4,14 +4,12 @@ import Mathlib.Data.Finset.Image
 /-!
 # The DRT box
 
-The generic two-compartment shell of DRT: a *box* pairs a universe of
-discourse referents with a list of conditions, generic over the condition
-type `C`. DRT variants re-instantiate the shell at their own condition types
-(`DRS L V := Box V (Condition L V)` in `DRS/Defs.lean`; Layered DRT's LDRSs).
-Everything here is condition-agnostic: the functorial action `Box.map`, the
-extension relation `Box.Extends` between embedding functions, and the
-`sizeOf`/termination infrastructure for recursions that descend through the
-nested condition list.
+In discourse representation theory, a box contains two pieces of information:
+a universe of discourse referents, and a set of conditions recording what has
+been established about them. Boxes can be nested, and different theories
+instantiate conditions in different ways
+([venhuizen-bos-hendriks-brouwer-2018]; [liu-2021]). This file develops basic
+results about boxes, including renaming, extension, and recursions.
 -/
 
 namespace DRT

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -70,9 +70,9 @@ whose occurring referents are visible, and whose fresh introductions grow
   drs : DRS L V
   /-- The referential presupposition: free referents are supplied by the
   context. -/
-  presup : drs.fv ⊆ X.base
+  presup : drs.freeVarFinset ⊆ X.base
   /-- Visibility: every occurring referent is contextual or introduced. -/
-  occ_le : Condition.occL drs.conditions ⊆ X.base ∪ drs.referents
+  varFinsetL_le : Condition.varFinsetL drs.conditions ⊆ X.base ∪ drs.referents
   /-- Introductions are fresh for the context. -/
   fresh : Disjoint X.base drs.referents
   /-- The context grows by the introduced referents. -/
@@ -81,17 +81,17 @@ whose occurring referents are visible, and whose fresh introductions grow
 instance : Category (Ctx L V) where
   Hom := Hom
   id X :=
-    ⟨DRS.empty, by simp [DRS.empty], by simp [DRS.empty, Condition.occL],
+    ⟨DRS.empty, by simp [DRS.empty], by simp [DRS.empty, Condition.varFinsetL],
       by simp [DRS.empty], by simp [DRS.empty]⟩
   comp {X Y Z} u v :=
     { drs := u.drs.merge v.drs
-      presup := DRS.fv_merge_subset u.presup (by rw [u.target]; exact v.presup)
-      occ_le := by
-        rw [DRS.conditions_merge, Condition.occL_append, DRS.referents_merge,
+      presup := DRS.freeVarFinset_merge_subset u.presup (by rw [u.target]; exact v.presup)
+      varFinsetL_le := by
+        rw [DRS.conditions_merge, Condition.varFinsetL_append, DRS.referents_merge,
           ← Finset.union_assoc]
         exact Finset.union_subset
-          (u.occ_le.trans Finset.subset_union_left)
-          (by rw [u.target]; exact v.occ_le)
+          (u.varFinsetL_le.trans Finset.subset_union_left)
+          (by rw [u.target]; exact v.varFinsetL_le)
       fresh := by
         rw [DRS.referents_merge, Finset.disjoint_union_right]
         refine ⟨u.fresh, ?_⟩
@@ -123,11 +123,11 @@ def sem (W M : Type*) [L.Structure M] [Nonempty M] :
     exact DRS.transition_empty W X.base (by simp [DRS.empty]) (by simp [DRS.empty])
   map_comp {X Y Z} u v := by
     apply DynamicSemantics.Ctx.Hom.ext
-    have hocc : Condition.occL u.drs.conditions ⊆ Y.base := by
-      rw [← u.target]; exact u.occ_le
-    have hfresh : Disjoint v.drs.referents (Condition.occL u.drs.conditions) :=
+    have hocc : Condition.varFinsetL u.drs.conditions ⊆ Y.base := by
+      rw [← u.target]; exact u.varFinsetL_le
+    have hfresh : Disjoint v.drs.referents (Condition.varFinsetL u.drs.conditions) :=
       v.fresh.symm.mono_right hocc
-    have hv : v.drs.fv ⊆ X.base ∪ u.drs.referents := by
+    have hv : v.drs.freeVarFinset ⊆ X.base ∪ u.drs.referents := by
       rw [u.target]; exact v.presup
     show ((u ≫ v).drs.transition W X.base (u ≫ v).presup).copy rfl
         (Finset.coe_inj.mpr (u ≫ v).target) =

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -20,9 +20,8 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
 
 "Box" and "DRS" name the same object in the literature — the two-compartment
 diagram, [muskens-1996]'s linear `[u₁ … uₙ | γ₁ … γₘ]` — in diagrammatic vs.
-official register. `Box` (`DRS/Box.lean`) is the generic shell that DRT
-variants re-instantiate at their condition types (Layered DRT's LDRSs), and
-`DRS` its instantiation at `Condition L V`.
+official register. `Box` (`DRS/Box.lean`) is the generic container; `DRS` is
+its instantiation at `Condition L V`.
 
 ## Main declarations
 

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -1,4 +1,4 @@
-import Mathlib.Data.Finset.Basic
+import Linglib.Semantics.Dynamic.DRS.Box
 import Mathlib.Logic.Relation
 import Mathlib.ModelTheory.Basic
 
@@ -20,9 +20,9 @@ complex condition is `neg`; `imp` and `dis` are its Chapter 2 extension
 
 "Box" and "DRS" name the same object in the literature — the two-compartment
 diagram, [muskens-1996]'s linear `[u₁ … uₙ | γ₁ … γₘ]` — in diagrammatic vs.
-official register. Here `Box` is the generic shell that DRT variants
-re-instantiate at their condition types (Layered DRT's LDRSs), and `DRS` its
-instantiation at `Condition L V`.
+official register. `Box` (`DRS/Box.lean`) is the generic shell that DRT
+variants re-instantiate at their condition types (Layered DRT's LDRSs), and
+`DRS` its instantiation at `Condition L V`.
 
 ## Main declarations
 
@@ -60,14 +60,6 @@ universe u v w x
 
 variable {L : Language.{u, v}} {V : Type w}
 
-/-- A DRT *box*, generic over the condition type `C`; `DRS` instantiates `C`
-at `Condition L V`. -/
-@[ext] structure Box (V : Type w) (C : Type x) where
-  /-- The universe `U`: the discourse referents the box introduces. -/
-  referents : Finset V
-  /-- The box's conditions. -/
-  conditions : List C
-
 /-- A DRS-condition: atomic (`rel`, `eq`) or complex — `neg` per Def. 1.4.1,
 `imp`/`dis` per its Chapter 2 extension. Sub-DRSs occur only inside complex
 conditions. -/
@@ -96,21 +88,6 @@ namespace DRS
 
 @[simp] theorem conditions_mk (u : Finset V) (c : List (Condition L V)) :
     (Box.mk u c).conditions = c := rfl
-
-/-- A condition of a DRS is smaller than the DRS — the recursion measure for
-definitions descending through the nested `List (Condition L V)`. -/
-theorem sizeOf_lt_of_mem_conditions {K : DRS L V} {c : Condition L V}
-    (h : c ∈ K.conditions) : sizeOf c < sizeOf K := by
-  obtain ⟨U, conds⟩ := K
-  have : sizeOf c < sizeOf conds := List.sizeOf_lt_of_mem h
-  simp only [Box.mk.sizeOf_spec]
-  omega
-
--- Registers the `Box`-through-`List` nesting step with the default termination
--- tactic: recursions descending into a box's conditions need no `decreasing_by`.
-macro_rules
-  | `(tactic| decreasing_trivial) =>
-    `(tactic| have := DRS.sizeOf_lt_of_mem_conditions (by assumption); omega)
 
 /-- The empty DRS `⟨∅, []⟩`. -/
 def empty : DRS L V := .mk ∅ []

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -106,6 +106,12 @@ theorem sizeOf_lt_of_mem_conditions {K : DRS L V} {c : Condition L V}
   simp only [Box.mk.sizeOf_spec]
   omega
 
+-- Registers the `Box`-through-`List` nesting step with the default termination
+-- tactic: recursions descending into a box's conditions need no `decreasing_by`.
+macro_rules
+  | `(tactic| decreasing_trivial) =>
+    `(tactic| have := DRS.sizeOf_lt_of_mem_conditions (by assumption); omega)
+
 /-- The empty DRS `⟨∅, []⟩`. -/
 def empty : DRS L V := .mk ∅ []
 

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -132,6 +132,25 @@ def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
 
 end DRS
 
+/-- Induction on conditions, descending into sub-boxes: to prove `motive c` for
+every condition, handle each constructor given the motive for every condition
+of its sub-boxes. -/
+@[induction_eliminator] theorem Condition.induction {motive : Condition L V → Prop}
+    (rel : ∀ {n : ℕ} (R : L.Relations n) (args : Fin n → V), motive (.rel R args))
+    (eq : ∀ u v, motive (.eq u v))
+    (neg : ∀ K, (∀ c ∈ K.conditions, motive c) → motive (.neg K))
+    (imp : ∀ a c, (∀ d ∈ a.conditions, motive d) → (∀ d ∈ c.conditions, motive d) →
+      motive (.imp a c))
+    (dis : ∀ l r, (∀ d ∈ l.conditions, motive d) → (∀ d ∈ r.conditions, motive d) →
+      motive (.dis l r)) : ∀ c, motive c
+  | .rel R args => rel R args
+  | .eq u v => eq u v
+  | .neg K => neg K fun c _ => Condition.induction rel eq neg imp dis c
+  | .imp a c => imp a c (fun d _ => Condition.induction rel eq neg imp dis d)
+      (fun d _ => Condition.induction rel eq neg imp dis d)
+  | .dis l r => dis l r (fun d _ => Condition.induction rel eq neg imp dis d)
+      (fun d _ => Condition.induction rel eq neg imp dis d)
+
 /-! ### Subordination -/
 
 /-- One-step subordination: `DirectlySubordinate K' K` says `K'` is *directly

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -99,7 +99,7 @@ theorem DRS.trueRel_iff_realize_toFormula [DecidableEq V] (K : DRS L V) (a : V �
 /-- **Coincidence**: truth reads the input embedding only at the occurring
 referents. -/
 theorem DRS.trueRel_congr [DecidableEq V] {K : DRS L V} {a₁ a₂ : V → M}
-    (h : Set.EqOn a₁ a₂ ↑(DRS.occ K)) : DRS.trueRel K a₁ ↔ DRS.trueRel K a₂ :=
+    (h : Set.EqOn a₁ a₂ ↑(DRS.varFinset K)) : DRS.trueRel K a₁ ↔ DRS.trueRel K a₂ :=
   Embedding.exists_extends_verifies_congr h
 
 /-- Renaming along a bijection transports dynamic truth: alphabetic variants
@@ -116,7 +116,7 @@ for `K₁`'s conditions, the merge `K₁ ⊕ K₂` denotes the spine sequencing
 (relational composition) of the two box relations — `‖K₁ ⊕ K₂‖ = seq ‖K₁‖ ‖K₂‖`.
 This is what gives `merge` its dynamic meaning. -/
 theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
-    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+    (hfresh : Disjoint K₂.referents (Condition.varFinsetL K₁.conditions)) :
     (DRS.toRel (K₁.merge K₂) : Update (V → M)) = seq (DRS.toRel K₁) (DRS.toRel K₂) := by
   obtain ⟨U₁, conds₁⟩ := K₁
   obtain ⟨U₂, conds₂⟩ := K₂
@@ -138,7 +138,7 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
     · intro c hc
       refine (Embedding.verifiesCondition_congr c fun x hx => ?_).mpr (hh₁ c hc)
       exact Finset.piecewise_eq_of_notMem _ _ _
-        (fun hU => hfresh hU (Condition.occ_subset_occL hc (Finset.mem_coe.mp hx)))
+        (fun hU => hfresh hU (Condition.varFinset_subset_varFinsetL hc (Finset.mem_coe.mp hx)))
     · intro x hx
       exact (Finset.piecewise_eq_of_notMem _ _ _ hx).symm
     · exact hh₂
@@ -149,6 +149,6 @@ theorem DRS.toRel_merge [DecidableEq V] (K₁ K₂ : DRS L V)
       rw [hag2 x hx.2, hag1 x hx.1]
     · intro c hc
       refine (Embedding.verifiesCondition_congr c fun x hx => ?_).mpr (hh1 c hc)
-      exact hag2 x fun hU => hfresh hU (Condition.occ_subset_occL hc (Finset.mem_coe.mp hx))
+      exact hag2 x fun hU => hfresh hU (Condition.varFinset_subset_varFinsetL hc (Finset.mem_coe.mp hx))
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -346,7 +346,7 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
   | .eq u v => exact Iff.rfl
   | .neg K =>
     obtain ⟨U, conds⟩ := K
-    simp only [Condition.occ, DRS.occ] at hocc
+    simp only [Condition.occ_neg, DRS.occ_mk] at hocc
     rw [Condition.fv_neg] at hfv
     obtain ⟨hΔU, hΔc⟩ := Finset.disjoint_union_right.mp hocc
     have hfvc : Condition.fvL conds ⊆ X ∪ U := DRS.fv_subset_iff.mp hfv
@@ -359,7 +359,7 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
   | .imp a c' =>
     obtain ⟨Ua, ca⟩ := a
     obtain ⟨Uc, cc⟩ := c'
-    simp only [Condition.occ, DRS.occ] at hocc
+    simp only [Condition.occ_imp, DRS.occ_mk] at hocc
     obtain ⟨ha, hc⟩ := Finset.disjoint_union_right.mp hocc
     obtain ⟨hΔUa, hΔca⟩ := Finset.disjoint_union_right.mp ha
     obtain ⟨hΔUc, hΔcc⟩ := Finset.disjoint_union_right.mp hc
@@ -397,7 +397,7 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
   | .dis l r =>
     obtain ⟨Ul, cl⟩ := l
     obtain ⟨Ur, cr⟩ := r
-    simp only [Condition.occ, DRS.occ] at hocc
+    simp only [Condition.occ_dis, DRS.occ_mk] at hocc
     obtain ⟨hl, hr⟩ := Finset.disjoint_union_right.mp hocc
     obtain ⟨hΔUl, hΔcl⟩ := Finset.disjoint_union_right.mp hl
     obtain ⟨hΔUr, hΔcr⟩ := Finset.disjoint_union_right.mp hr

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -17,7 +17,7 @@ freely reassigns re-declared referents ([muskens-1996]'s fn. 4 divergence).
 Persistence is what makes the indexed semantics well-typed: `toRelAt X K` is
 read only at `X` (`toRelAt_congr_left` — one line, no witness surgery) and
 written only at `X ∪ U` (`toRelAt_congr_right`, given the *referential
-presupposition* `K.fv ⊆ X`), so a well-formed DRS denotes a spine
+presupposition* `K.freeVarFinset ⊆ X`), so a well-formed DRS denotes a spine
 `Transition X (X ∪ U)` (`DRS.transition`), and a proper DRS expresses an
 information state by acting on `⊥` (`DRS.state`, Def. 22).
 
@@ -113,7 +113,7 @@ end
 
 The indexed clauses only mention the input through the agreement conjunct, so
 read-support is one line — the flat semantics' piecewise witness surgery
-disappears. Write-support needs the referential presupposition `fv ⊆ X`
+disappears. Write-support needs the referential presupposition `freeVarFinset ⊆ X`
 only at the atomic clauses. -/
 
 /-- `toRelAt X K` reads its input only at `X`. -/
@@ -126,7 +126,7 @@ theorem DRS.toRelAt_congr_left (X : Finset V) (K : DRS L V) {f f' g : V → M}
 /-- A condition with free referents in `X` depends on the assignment only at
 `X`. -/
 theorem Condition.holdsAt_congr {X : Finset V} (c : Condition L V)
-    (hfv : c.fv ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
+    (hfv : c.freeVarFinset ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
     Condition.holdsAt X c g ↔ Condition.holdsAt X c g' := by
   match c with
   | .rel R args =>
@@ -137,8 +137,8 @@ theorem Condition.holdsAt_congr {X : Finset V} (c : Condition L V)
     rw [this]
   | .eq u v =>
     simp only [Condition.holdsAt_eq]
-    rw [hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.fv_eq]))),
-      hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.fv_eq])))]
+    rw [hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.freeVarFinset_eq]))),
+      hgg' (Finset.mem_coe.mpr (hfv (by simp [Condition.freeVarFinset_eq])))]
   | .neg K =>
     simp only [Condition.holdsAt_neg]
     exact not_congr (exists_congr fun k => DRS.toRelAt_congr_left X K hgg')
@@ -153,18 +153,18 @@ theorem Condition.holdsAt_congr {X : Finset V} (c : Condition L V)
 
 /-- The list analogue of `Condition.holdsAt_congr`. -/
 theorem Condition.holdsAllAt_congr {X : Finset V} (cs : List (Condition L V))
-    (hfv : Condition.fvL cs ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
+    (hfv : Condition.freeVarFinsetL cs ⊆ X) {g g' : V → M} (hgg' : Set.EqOn g g' ↑X) :
     Condition.holdsAllAt X cs g ↔ Condition.holdsAllAt X cs g' := by
   induction cs with
   | nil => exact Iff.rfl
   | cons c cs ih =>
-    rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinsetL_cons, Finset.union_subset_iff] at hfv
     simp only [Condition.holdsAllAt_cons]
     exact and_congr (Condition.holdsAt_congr c hfv.1 hgg') (ih hfv.2)
 
 /-- `toRelAt X K` writes its output only at `X ∪ U`, given the referential
-presupposition `K.fv ⊆ X`. -/
-theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
+presupposition `K.freeVarFinset ⊆ X`. -/
+theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.freeVarFinset ⊆ X)
     {f g g' : V → M} (hgg' : Set.EqOn g g' ↑(X ∪ K.referents)) :
     DRS.toRelAt X K f g ↔ DRS.toRelAt X K f g' := by
   obtain ⟨U, conds⟩ := K
@@ -173,19 +173,19 @@ theorem DRS.toRelAt_congr_right {X : Finset V} (K : DRS L V) (hfv : K.fv ⊆ X)
   simp only [DRS.toRelAt_mk]
   exact and_congr
     ⟨fun he => hX.symm.trans he, fun he => hX.trans he⟩
-    (Condition.holdsAllAt_congr conds (DRS.fv_subset_iff.mp hfv) hgg')
+    (Condition.holdsAllAt_congr conds (DRS.freeVarFinset_subset_iff.mp hfv) hgg')
 
 /-! ### A DRS as a spine transition -/
 
 /-- A well-formed DRS denotes a transition from its context base to the
-base grown by its universe — `K.fv ⊆ X` is the *referential presupposition*
+base grown by its universe — `K.freeVarFinset ⊆ X` is the *referential presupposition*
 (Def. 27(i)). -/
 theorem DRS.readsAt_toRelAt {W : Type*} (X : Finset V) (K : DRS L V) :
     Transition.ReadsAt (W := W) ↑X fun _ => DRS.toRelAt (M := M) X K :=
   fun _ _ _ _ h => DRS.toRelAt_congr_left X K h
 
 theorem DRS.writesAt_toRelAt {W : Type*} {X : Finset V} (K : DRS L V)
-    (hK : K.fv ⊆ X) :
+    (hK : K.freeVarFinset ⊆ X) :
     Transition.WritesAt (W := W) ↑(X ∪ K.referents)
       fun _ => DRS.toRelAt (M := M) X K :=
   fun _ _ _ _ h => DRS.toRelAt_congr_right K hK h
@@ -195,7 +195,7 @@ at `X`, write at `X ∪ U`. The referential presupposition documents
 Def. 24's domain condition; the congruence lemmas above are the bridge's
 support hypotheses. -/
 def DRS.transition (W : Type*) (K : DRS L V) (X : Finset V)
-    (_hK : K.fv ⊆ X) :
+    (_hK : K.freeVarFinset ⊆ X) :
     Transition W M (↑X : Set V) (↑(X ∪ K.referents) : Set V) :=
   Transition.ofTotal (Finset.coe_subset.mpr Finset.subset_union_left)
     fun _ => DRS.toRelAt X K
@@ -205,7 +205,7 @@ source: interpretation sends DRT's unit to the semantic unit. Nonempty
 entities are needed — under extension-typing an empty domain separates
 the empty box from the identity. -/
 theorem DRS.transition_empty [Nonempty M] (W : Type*) (X : Finset V)
-    (h : (DRS.empty : DRS L V).fv ⊆ X)
+    (h : (DRS.empty : DRS L V).freeVarFinset ⊆ X)
     (he : X ∪ (DRS.empty : DRS L V).referents = X) :
     (DRS.empty.transition (M := M) W X h).copy rfl (Finset.coe_inj.mpr he) =
       Transition.id (↑X : Set V) := by
@@ -225,7 +225,7 @@ theorem DRS.transition_empty [Nonempty M] (W : Type*) (X : Finset V)
 
 /-- Established referents persist along a DRS transition. -/
 theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
-    (hK : K.fv ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by
+    (hK : K.freeVarFinset ⊆ X) : (K.transition (M := M) W X hK).IsExtension := by
   rintro w e e' ⟨f, g, rfl, rfl, hrel⟩
   obtain ⟨U, conds⟩ := K
   funext v
@@ -234,7 +234,7 @@ theorem DRS.transition_isExtension (W : Type*) (K : DRS L V) (X : Finset V)
 /-- Repackaging a DRS transition along an equality of context bases is the
 transition at the new base. -/
 theorem DRS.transition_copy (W : Type*) {X X' : Finset V} (K : DRS L V)
-    (hX : X = X') (hK : K.fv ⊆ X) (hK' : K.fv ⊆ X') :
+    (hX : X = X') (hK : K.freeVarFinset ⊆ X) (hK' : K.freeVarFinset ⊆ X') :
     (K.transition (M := M) W X hK).copy (Finset.coe_inj.mpr hX) (by rw [hX]) =
       K.transition W X' hK' := by
   subst hX; rfl
@@ -292,7 +292,7 @@ base referents needs no exclusion: persistence makes it inert. -/
 fresh `Δ` yields an output at the grown base, agreeing with the original on
 the working base. -/
 private theorem DRS.toRelAt_adjust {X Δ U : Finset V} {conds : List (Condition L V)}
-    (hΔU : Disjoint Δ U) (hfvc : Condition.fvL conds ⊆ X ∪ U)
+    (hΔU : Disjoint Δ U) (hfvc : Condition.freeVarFinsetL conds ⊆ X ∪ U)
     (hIH : ∀ k : V → M, Condition.holdsAllAt ((X ∪ U) ∪ Δ) conds k ↔
       Condition.holdsAllAt (X ∪ U) conds k)
     {g k : V → M} (hk : DRS.toRelAt X (.mk U conds) g k) :
@@ -339,17 +339,17 @@ mutual
 /-- **Base invariance**: a fresh base extension is invisible to a well-formed
 condition. -/
 theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
-    (hocc : Disjoint Δ c.occ) (hfv : c.fv ⊆ X) (g : V → M) :
+    (hocc : Disjoint Δ c.varFinset) (hfv : c.freeVarFinset ⊆ X) (g : V → M) :
     Condition.holdsAt (X ∪ Δ) c g ↔ Condition.holdsAt X c g := by
   match c with
   | .rel R args => exact Iff.rfl
   | .eq u v => exact Iff.rfl
   | .neg K =>
     obtain ⟨U, conds⟩ := K
-    simp only [Condition.occ_neg, DRS.occ_mk] at hocc
-    rw [Condition.fv_neg] at hfv
+    simp only [Condition.varFinset_neg, DRS.varFinset_mk] at hocc
+    rw [Condition.freeVarFinset_neg] at hfv
     obtain ⟨hΔU, hΔc⟩ := Finset.disjoint_union_right.mp hocc
-    have hfvc : Condition.fvL conds ⊆ X ∪ U := DRS.fv_subset_iff.mp hfv
+    have hfvc : Condition.freeVarFinsetL conds ⊆ X ∪ U := DRS.freeVarFinset_subset_iff.mp hfv
     have hIH : ∀ k : V → M, Condition.holdsAllAt ((X ∪ U) ∪ Δ) conds k ↔
         Condition.holdsAllAt (X ∪ U) conds k :=
       fun k => Condition.holdsAllAt_union_fresh conds hΔc hfvc k
@@ -359,21 +359,21 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
   | .imp a c' =>
     obtain ⟨Ua, ca⟩ := a
     obtain ⟨Uc, cc⟩ := c'
-    simp only [Condition.occ_imp, DRS.occ_mk] at hocc
+    simp only [Condition.varFinset_imp, DRS.varFinset_mk] at hocc
     obtain ⟨ha, hc⟩ := Finset.disjoint_union_right.mp hocc
     obtain ⟨hΔUa, hΔca⟩ := Finset.disjoint_union_right.mp ha
     obtain ⟨hΔUc, hΔcc⟩ := Finset.disjoint_union_right.mp hc
-    rw [Condition.fv_imp, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinset_imp, Finset.union_subset_iff] at hfv
     obtain ⟨hfva, hfvc'⟩ := hfv
-    have hfvca : Condition.fvL ca ⊆ X ∪ Ua := DRS.fv_subset_iff.mp hfva
-    have hfvcc : Condition.fvL cc ⊆ (X ∪ Ua) ∪ Uc := by
+    have hfvca : Condition.freeVarFinsetL ca ⊆ X ∪ Ua := DRS.freeVarFinset_subset_iff.mp hfva
+    have hfvcc : Condition.freeVarFinsetL cc ⊆ (X ∪ Ua) ∪ Uc := by
       intro x hx
       by_cases hxUc : x ∈ Uc
       · exact Finset.mem_union_right _ hxUc
       · by_cases hxUa : x ∈ Ua
         · exact Finset.mem_union_left _ (Finset.mem_union_right _ hxUa)
         · refine Finset.mem_union_left _ (Finset.mem_union_left _ (hfvc' ?_))
-          rw [DRS.fv_mk, DRS.referents_mk, Finset.mem_sdiff, Finset.mem_sdiff]
+          rw [DRS.freeVarFinset_mk, DRS.referents_mk, Finset.mem_sdiff, Finset.mem_sdiff]
           exact ⟨⟨hx, hxUc⟩, hxUa⟩
     have hIHa : ∀ k : V → M, Condition.holdsAllAt ((X ∪ Ua) ∪ Δ) ca k ↔
         Condition.holdsAllAt (X ∪ Ua) ca k :=
@@ -397,14 +397,14 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
   | .dis l r =>
     obtain ⟨Ul, cl⟩ := l
     obtain ⟨Ur, cr⟩ := r
-    simp only [Condition.occ_dis, DRS.occ_mk] at hocc
+    simp only [Condition.varFinset_dis, DRS.varFinset_mk] at hocc
     obtain ⟨hl, hr⟩ := Finset.disjoint_union_right.mp hocc
     obtain ⟨hΔUl, hΔcl⟩ := Finset.disjoint_union_right.mp hl
     obtain ⟨hΔUr, hΔcr⟩ := Finset.disjoint_union_right.mp hr
-    rw [Condition.fv_dis, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinset_dis, Finset.union_subset_iff] at hfv
     obtain ⟨hfvl, hfvr⟩ := hfv
-    have hfvcl : Condition.fvL cl ⊆ X ∪ Ul := DRS.fv_subset_iff.mp hfvl
-    have hfvcr : Condition.fvL cr ⊆ X ∪ Ur := DRS.fv_subset_iff.mp hfvr
+    have hfvcl : Condition.freeVarFinsetL cl ⊆ X ∪ Ul := DRS.freeVarFinset_subset_iff.mp hfvl
+    have hfvcr : Condition.freeVarFinsetL cr ⊆ X ∪ Ur := DRS.freeVarFinset_subset_iff.mp hfvr
     have hIHl : ∀ k : V → M, Condition.holdsAllAt ((X ∪ Ul) ∪ Δ) cl k ↔
         Condition.holdsAllAt (X ∪ Ul) cl k :=
       fun k => Condition.holdsAllAt_union_fresh cl hΔcl hfvcl k
@@ -421,15 +421,15 @@ theorem Condition.holdsAt_union_fresh {X Δ : Finset V} (c : Condition L V)
       · exact ⟨_, Or.inr (DRS.toRelAt_adjust hΔUr hfvcr hIHr hk).1⟩
 /-- The list analogue of `Condition.holdsAt_union_fresh`. -/
 theorem Condition.holdsAllAt_union_fresh {X Δ : Finset V}
-    (cs : List (Condition L V)) (hocc : Disjoint Δ (Condition.occL cs))
-    (hfv : Condition.fvL cs ⊆ X) (g : V → M) :
+    (cs : List (Condition L V)) (hocc : Disjoint Δ (Condition.varFinsetL cs))
+    (hfv : Condition.freeVarFinsetL cs ⊆ X) (g : V → M) :
     Condition.holdsAllAt (X ∪ Δ) cs g ↔ Condition.holdsAllAt X cs g := by
   match cs with
   | [] => exact Iff.rfl
   | c :: cs =>
-    simp only [Condition.occL] at hocc
+    simp only [Condition.varFinsetL] at hocc
     obtain ⟨hc, hcs⟩ := Finset.disjoint_union_right.mp hocc
-    rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinsetL_cons, Finset.union_subset_iff] at hfv
     simp only [Condition.holdsAllAt_cons]
     exact and_congr (Condition.holdsAt_union_fresh c hc hfv.1 g)
       (Condition.holdsAllAt_union_fresh cs hcs hfv.2 g)
@@ -442,14 +442,14 @@ only that `K₂`'s universe not occur in `K₁`'s conditions (no *capture*);
 re-declaration of context or `K₁`-universe referents is allowed — persistence
 makes it inert. Contrast the flat lemma (`DRS.toRel_merge`), whose freshness
 hypothesis also had to forbid re-declaration. -/
-theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv ⊆ X)
-    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.freeVarFinset ⊆ X)
+    (hfresh : Disjoint K₂.referents (Condition.varFinsetL K₁.conditions)) :
     (DRS.toRelAt X (K₁.merge K₂) : (V → M) → (V → M) → Prop) =
       DynamicSemantics.Update.seq (DRS.toRelAt X K₁)
         (DRS.toRelAt (X ∪ K₁.referents) K₂) := by
   obtain ⟨U₁, c₁⟩ := K₁
   obtain ⟨U₂, c₂⟩ := K₂
-  have hfvc₁ := DRS.fv_subset_iff.mp h₁
+  have hfvc₁ := DRS.freeVarFinset_subset_iff.mp h₁
   funext f g
   apply propext
   simp only [DRS.merge, DRS.toRelAt_mk,
@@ -467,10 +467,10 @@ theorem DRS.toRelAt_merge {X : Finset V} (K₁ K₂ : DRS L V) (h₁ : K₁.fv �
 /-- **Transition-level Merging Lemma**: sequencing the transitions is the
 merge's transition, repackaged along associativity of the grown bases. -/
 theorem DRS.transition_merge (W : Type*) {X : Finset V} (K₁ K₂ : DRS L V)
-    (h₁ : K₁.fv ⊆ X) (h₂ : K₂.fv ⊆ X ∪ K₁.referents)
-    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+    (h₁ : K₁.freeVarFinset ⊆ X) (h₂ : K₂.freeVarFinset ⊆ X ∪ K₁.referents)
+    (hfresh : Disjoint K₂.referents (Condition.varFinsetL K₁.conditions)) :
     (K₁.transition (M := M) W X h₁).comp (K₂.transition W (X ∪ K₁.referents) h₂) =
-      ((K₁.merge K₂).transition W X (DRS.fv_merge_subset h₁ h₂)).copy rfl
+      ((K₁.merge K₂).transition W X (DRS.freeVarFinset_merge_subset h₁ h₂)).copy rfl
         (by rw [DRS.referents_merge, ← Finset.union_assoc]) := by
   unfold DRS.transition
   rw [Transition.ofTotal_comp (DRS.readsAt_toRelAt (X ∪ K₁.referents) K₂),
@@ -483,8 +483,8 @@ DRS's transition to the state a proper context DRS expresses yields the
 state of the merge — an instance of `Transition.apply_comp` through the
 transition-level Merging Lemma. -/
 theorem DRS.state_merge (W : Type*) (K₁ K₂ : DRS L V) (h₁ : K₁.IsProper)
-    (h₂ : K₂.fv ⊆ K₁.referents)
-    (hfresh : Disjoint K₂.referents (Condition.occL K₁.conditions)) :
+    (h₂ : K₂.freeVarFinset ⊆ K₁.referents)
+    (hfresh : Disjoint K₂.referents (Condition.varFinsetL K₁.conditions)) :
     (K₂.transition (M := M) W K₁.referents h₂).applyState (K₁.state W h₁) =
       (K₁.merge K₂).state W (DRS.isProper_merge h₁ h₂) := by
   simp only [DRS.state]
@@ -519,7 +519,7 @@ private theorem DRS.toRelAt_of_toRel' {X U : Finset V} {conds : List (Condition 
 /-- Indexed-to-flat on a bounded box: repair the output off the grown base with
 the input's values. -/
 private theorem DRS.toRel_of_toRelAt' {X U : Finset V} {conds : List (Condition L V)}
-    (hfvc : Condition.fvL conds ⊆ X ∪ U)
+    (hfvc : Condition.freeVarFinsetL conds ⊆ X ∪ U)
     (hIH : ∀ k : V → M, (∀ c ∈ conds, Embedding.VerifiesCondition k c) ↔
       Condition.holdsAllAt (X ∪ U) conds k)
     {g g' : V → M} (h : DRS.toRelAt X (.mk U conds) g g') :
@@ -543,7 +543,7 @@ mutual
 /-- On a reuse-free condition with free referents in the base, the flat set
 denotation and the indexed one coincide. -/
 theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
-    (hrf : Condition.ReuseFreeAt X c) (hfv : c.fv ⊆ X) (g : V → M) :
+    (hrf : Condition.ReuseFreeAt X c) (hfv : c.freeVarFinset ⊆ X) (g : V → M) :
     Embedding.VerifiesCondition g c ↔ Condition.holdsAt X c g := by
   match c with
   | .rel R args => simp only [Embedding.verifies_rel, Condition.holdsAt_rel]
@@ -551,8 +551,8 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
   | .neg K =>
     obtain ⟨U, conds⟩ := K
     simp only [Condition.reuseFreeAt_neg, DRS.reuseFreeAt_mk] at hrf
-    rw [Condition.fv_neg] at hfv
-    have hfvc := DRS.fv_subset_iff.mp hfv
+    rw [Condition.freeVarFinset_neg] at hfv
+    have hfvc := DRS.freeVarFinset_subset_iff.mp hfv
     have hIH : ∀ k : V → M, (∀ c ∈ conds, Embedding.VerifiesCondition k c) ↔
         Condition.holdsAllAt (X ∪ U) conds k :=
       fun k => Condition.verifiesAll_iff_holdsAllAt conds hrf.2 hfvc k
@@ -564,17 +564,17 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
     obtain ⟨Uc, cc⟩ := c'
     simp only [Condition.reuseFreeAt_imp, DRS.reuseFreeAt_mk] at hrf
     obtain ⟨⟨hXUa, hrfa⟩, hXUc, hrfc⟩ := hrf
-    rw [Condition.fv_imp, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinset_imp, Finset.union_subset_iff] at hfv
     obtain ⟨hfva, hfvc'⟩ := hfv
-    have hfvca : Condition.fvL ca ⊆ X ∪ Ua := DRS.fv_subset_iff.mp hfva
-    have hfvcc : Condition.fvL cc ⊆ (X ∪ Ua) ∪ Uc := by
+    have hfvca : Condition.freeVarFinsetL ca ⊆ X ∪ Ua := DRS.freeVarFinset_subset_iff.mp hfva
+    have hfvcc : Condition.freeVarFinsetL cc ⊆ (X ∪ Ua) ∪ Uc := by
       intro x hx
       by_cases hxUc : x ∈ Uc
       · exact Finset.mem_union_right _ hxUc
       · by_cases hxUa : x ∈ Ua
         · exact Finset.mem_union_left _ (Finset.mem_union_right _ hxUa)
         · refine Finset.mem_union_left _ (Finset.mem_union_left _ (hfvc' ?_))
-          rw [DRS.fv_mk, DRS.referents_mk, Finset.mem_sdiff, Finset.mem_sdiff]
+          rw [DRS.freeVarFinset_mk, DRS.referents_mk, Finset.mem_sdiff, Finset.mem_sdiff]
           exact ⟨⟨hx, hxUc⟩, hxUa⟩
     have hIHa : ∀ k : V → M, (∀ c ∈ ca, Embedding.VerifiesCondition k c) ↔
         Condition.holdsAllAt (X ∪ Ua) ca k :=
@@ -597,9 +597,9 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
     obtain ⟨Ur, cr⟩ := r
     simp only [Condition.reuseFreeAt_dis, DRS.reuseFreeAt_mk] at hrf
     obtain ⟨⟨hXUl, hrfl⟩, hXUr, hrfr⟩ := hrf
-    rw [Condition.fv_dis, Finset.union_subset_iff] at hfv
-    have hfvcl : Condition.fvL cl ⊆ X ∪ Ul := DRS.fv_subset_iff.mp hfv.1
-    have hfvcr : Condition.fvL cr ⊆ X ∪ Ur := DRS.fv_subset_iff.mp hfv.2
+    rw [Condition.freeVarFinset_dis, Finset.union_subset_iff] at hfv
+    have hfvcl : Condition.freeVarFinsetL cl ⊆ X ∪ Ul := DRS.freeVarFinset_subset_iff.mp hfv.1
+    have hfvcr : Condition.freeVarFinsetL cr ⊆ X ∪ Ur := DRS.freeVarFinset_subset_iff.mp hfv.2
     have hIHl : ∀ k : V → M, (∀ c ∈ cl, Embedding.VerifiesCondition k c) ↔
         Condition.holdsAllAt (X ∪ Ul) cl k :=
       fun k => Condition.verifiesAll_iff_holdsAllAt cl hrfl hfvcl k
@@ -616,13 +616,13 @@ theorem Condition.verifies_iff_holdsAt {X : Finset V} (c : Condition L V)
       · exact Or.inr ⟨_, (DRS.toRel_of_toRelAt' hfvcr hIHr hk).1⟩
 /-- The list analogue of `Condition.verifies_iff_holdsAt`. -/
 theorem Condition.verifiesAll_iff_holdsAllAt {X : Finset V} (cs : List (Condition L V))
-    (hrf : Condition.ReuseFreeAllAt X cs) (hfv : Condition.fvL cs ⊆ X) (g : V → M) :
+    (hrf : Condition.ReuseFreeAllAt X cs) (hfv : Condition.freeVarFinsetL cs ⊆ X) (g : V → M) :
     (∀ c ∈ cs, Embedding.VerifiesCondition g c) ↔ Condition.holdsAllAt X cs g := by
   match cs with
   | [] => simp
   | c :: cs =>
     simp only [Condition.reuseFreeAllAt_cons] at hrf
-    rw [Condition.fvL_cons, Finset.union_subset_iff] at hfv
+    rw [Condition.freeVarFinsetL_cons, Finset.union_subset_iff] at hfv
     simp only [List.forall_mem_cons, Condition.holdsAllAt_cons]
     exact and_congr (Condition.verifies_iff_holdsAt c hrf.1 hfv.1 g)
       (Condition.verifiesAll_iff_holdsAllAt cs hrf.2 hfv.2 g)
@@ -630,28 +630,28 @@ end
 
 /-- Flat-to-indexed: on a reuse-free DRS every flat output is a indexed output. -/
 theorem DRS.toRelAt_of_toRel {X : Finset V} {K : DRS L V} (hrf : DRS.ReuseFreeAt X K)
-    (hfv : K.fv ⊆ X) {g g' : V → M} (h : DRS.toRel K g g') : DRS.toRelAt X K g g' := by
+    (hfv : K.freeVarFinset ⊆ X) {g g' : V → M} (h : DRS.toRel K g g') : DRS.toRelAt X K g g' := by
   obtain ⟨U, conds⟩ := K
   simp only [DRS.reuseFreeAt_mk] at hrf
   exact DRS.toRelAt_of_toRel' hrf.1
-    (fun k => Condition.verifiesAll_iff_holdsAllAt conds hrf.2 (DRS.fv_subset_iff.mp hfv) k) h
+    (fun k => Condition.verifiesAll_iff_holdsAllAt conds hrf.2 (DRS.freeVarFinset_subset_iff.mp hfv) k) h
 
 /-- Indexed-to-flat: on a reuse-free DRS a indexed output repairs, off the grown
 base, into a flat output. -/
 theorem DRS.toRel_of_toRelAt {X : Finset V} {K : DRS L V} (hrf : DRS.ReuseFreeAt X K)
-    (hfv : K.fv ⊆ X) {g g' : V → M} (h : DRS.toRelAt X K g g') :
+    (hfv : K.freeVarFinset ⊆ X) {g g' : V → M} (h : DRS.toRelAt X K g g') :
     ∃ g'', DRS.toRel K g g'' ∧ Set.EqOn g'' g' ↑(X ∪ K.referents) := by
   obtain ⟨U, conds⟩ := K
   simp only [DRS.reuseFreeAt_mk] at hrf
-  exact ⟨_, DRS.toRel_of_toRelAt' (DRS.fv_subset_iff.mp hfv)
-    (fun k => Condition.verifiesAll_iff_holdsAllAt conds hrf.2 (DRS.fv_subset_iff.mp hfv) k) h⟩
+  exact ⟨_, DRS.toRel_of_toRelAt' (DRS.freeVarFinset_subset_iff.mp hfv)
+    (fun k => Condition.verifiesAll_iff_holdsAllAt conds hrf.2 (DRS.freeVarFinset_subset_iff.mp hfv) k) h⟩
 
 /-- **Truth-level reconciliation** (Muskens's fn. 4): on a reuse-free
 DRS the flat total-assignment semantics and the indexed persistence semantics
 have the same truth conditions. Reuse-freeness is needed — a re-declaring
 witness separates the two (`Studies/Muskens1996.lean`). -/
 theorem DRS.trueRel_iff_toRelAt {X : Finset V} {K : DRS L V} (hrf : DRS.ReuseFreeAt X K)
-    (hfv : K.fv ⊆ X) (g : V → M) :
+    (hfv : K.freeVarFinset ⊆ X) (g : V → M) :
     DRS.trueRel K g ↔ ∃ g', DRS.toRelAt X K g g' := by
   rw [DRS.trueRel_iff]
   exact ⟨fun ⟨g', h⟩ => ⟨g', DRS.toRelAt_of_toRel hrf hfv h⟩,

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -61,10 +61,6 @@ noncomputable def Condition.toFormula [DecidableEq V] : Condition L V → L.Form
   | .dis l r =>
       closeExists l.referents ((l.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤) ⊔
         closeExists r.referents ((r.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤)
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- The conjunction of a list of translated conditions. -/
 noncomputable def Condition.toFormulaAll [DecidableEq V] (cs : List (Condition L V)) :
@@ -226,10 +222,6 @@ theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : Emb
       fun d _ w => Condition.realize_toFormula d w
     rw [Condition.toFormula_dis, Formula.realize_sup, Embedding.verifies_dis,
       DRS.realize_toFormula_of_forall ihl, DRS.realize_toFormula_of_forall ihr]
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- A list of conditions' conjoined translation realizes as the conjunction of
 their realizations. -/

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -47,31 +47,58 @@ noncomputable def closeExists [DecidableEq V] (U : Finset V) (φ : L.Formula V) 
 noncomputable def closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) : L.Formula V :=
   (φ.relabel (splitOn U)).iAlls {x // x ∈ U}
 
-mutual
-/-- Translate a DRS to a first-order formula: existentially close the universe
-over the conjunction of the (translated) conditions (§1.5). -/
-noncomputable def DRS.toFormula [DecidableEq V] : DRS L V → L.Formula V
-  | .mk U conds => closeExists U (Condition.toFormulaAll conds)
-/-- The conjunction of a DRS's conditions, *without* closing its universe (used
-as the antecedent body of a `⇒`). A mutual sibling — the composite
-`Condition.toFormulaAll ∘ conditions` fails the nested-inductive
-structural-recursion checker. -/
-noncomputable def DRS.bodyFormula [DecidableEq V] : DRS L V → L.Formula V
-  | .mk _ conds => Condition.toFormulaAll conds
-/-- Translate a single DRS-condition to a formula. -/
+/-- Translate a single DRS-condition to a formula: each sub-box's universe is
+existentially closed over the conjunction of its translated conditions; the
+antecedent of a `⇒` is universally closed instead (§1.5). -/
 noncomputable def Condition.toFormula [DecidableEq V] : Condition L V → L.Formula V
   | .rel R args => Relations.formula R (fun i => Term.var (args i))
   | .eq a b => Term.equal (Term.var a) (Term.var b)
-  | .neg K => (DRS.toFormula K).not
-  | .imp a c => closeForall a.referents ((DRS.bodyFormula a).imp (DRS.toFormula c))
-  | .dis l r => DRS.toFormula l ⊔ DRS.toFormula r
-/-- The conjunction of a list of (translated) conditions. A `List` helper — the
-higher-order `(cs.map Condition.toFormula).foldr (· ⊓ ·) ⊤` form fails the
-nested-inductive structural-recursion checker. -/
-noncomputable def Condition.toFormulaAll [DecidableEq V] : List (Condition L V) → L.Formula V
-  | [] => ⊤
-  | c :: cs => Condition.toFormula c ⊓ Condition.toFormulaAll cs
-end
+  | .neg K =>
+      (closeExists K.referents ((K.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤)).not
+  | .imp a c => closeForall a.referents
+      (((a.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤).imp
+        (closeExists c.referents ((c.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤)))
+  | .dis l r =>
+      closeExists l.referents ((l.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤) ⊔
+        closeExists r.referents ((r.conditions.map Condition.toFormula).foldr (· ⊓ ·) ⊤)
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
+/-- The conjunction of a list of translated conditions. -/
+noncomputable def Condition.toFormulaAll [DecidableEq V] (cs : List (Condition L V)) :
+    L.Formula V := (cs.map Condition.toFormula).foldr (· ⊓ ·) ⊤
+
+/-- The conjunction of a DRS's conditions, *without* closing its universe (the
+antecedent body of a `⇒`). -/
+noncomputable def DRS.bodyFormula [DecidableEq V] (K : DRS L V) : L.Formula V :=
+  Condition.toFormulaAll K.conditions
+
+/-- Translate a DRS to a first-order formula: existentially close the universe
+over the conjunction of the (translated) conditions (§1.5). -/
+noncomputable def DRS.toFormula [DecidableEq V] (K : DRS L V) : L.Formula V :=
+  closeExists K.referents (Condition.toFormulaAll K.conditions)
+
+theorem Condition.toFormulaAll_nil [DecidableEq V] :
+    Condition.toFormulaAll ([] : List (Condition L V)) = ⊤ := rfl
+
+theorem Condition.toFormulaAll_cons [DecidableEq V] (c : Condition L V)
+    (cs : List (Condition L V)) :
+    Condition.toFormulaAll (c :: cs) = Condition.toFormula c ⊓ Condition.toFormulaAll cs := rfl
+
+theorem Condition.toFormula_neg [DecidableEq V] (K : DRS L V) :
+    Condition.toFormula (.neg K) = (DRS.toFormula K).not := by
+  simp only [Condition.toFormula]; rfl
+
+theorem Condition.toFormula_imp [DecidableEq V] (a c : DRS L V) :
+    Condition.toFormula (.imp a c) =
+      closeForall a.referents ((DRS.bodyFormula a).imp (DRS.toFormula c)) := by
+  simp only [Condition.toFormula]; rfl
+
+theorem Condition.toFormula_dis [DecidableEq V] (l r : DRS L V) :
+    Condition.toFormula (.dis l r) = DRS.toFormula l ⊔ DRS.toFormula r := by
+  simp only [Condition.toFormula]; rfl
 
 variable {M : Type x} [L.Structure M]
 
@@ -140,25 +167,31 @@ theorem realize_closeForall [DecidableEq V] (U : Finset V) (φ : L.Formula V) (v
   simp only [Formula.realize_relabel, elim_comp_splitOn]
   exact forall_extend_iff U v (Formula.Realize φ)
 
-mutual
-/-- **DRT ⊆ FOL** (§1.5): the
-translated formula's `Realize` coincides with the bespoke `Embedding.Verifies`. As
-`toFormula` existentially closes the universe, the correspondence is with an
-embedding `v'` extending `v` over `K.referents`. -/
-theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : Embedding V M) :
-    (K.toFormula).Realize v ↔ ∃ v', K.Extends v v' ∧ v'.Verifies K := by
-  match K with
-  | .mk U conds =>
-    rw [DRS.toFormula, realize_closeExists]
-    simp only [Embedding.verifies_mk, Box.Extends]
-    exact exists_congr fun v' =>
-      and_congr_right fun _ => Condition.realize_toFormulaAll conds v'
-/-- The open body of a DRS (its conditions, no universe closure) realizes as
-`Verifies` of the DRS (used for the antecedent of `⇒`). -/
-theorem DRS.realize_bodyFormula [DecidableEq V] (K : DRS L V) (v : Embedding V M) :
-    (DRS.bodyFormula K).Realize v ↔ v.Verifies K := by
-  match K with
-  | .mk _ conds => exact Condition.realize_toFormulaAll conds v
+private theorem Condition.realize_toFormulaAll_of_forall [DecidableEq V]
+    {cs : List (Condition L V)} {v : Embedding V M}
+    (ih : ∀ c ∈ cs, (Condition.toFormula c).Realize v ↔ v.VerifiesCondition c) :
+    (Condition.toFormulaAll cs).Realize v ↔ ∀ c ∈ cs, v.VerifiesCondition c := by
+  induction cs with
+  | nil => simp [Condition.toFormulaAll_nil, Formula.realize_top]
+  | cons c cs ihl =>
+    rw [Condition.toFormulaAll_cons, Formula.realize_inf, List.forall_mem_cons]
+    exact and_congr (ih c (by simp)) (ihl fun d hd => ih d (List.mem_cons_of_mem c hd))
+
+private theorem DRS.realize_bodyFormula_of_forall [DecidableEq V] {K : DRS L V}
+    {v : Embedding V M}
+    (ih : ∀ c ∈ K.conditions, (Condition.toFormula c).Realize v ↔ v.VerifiesCondition c) :
+    (DRS.bodyFormula K).Realize v ↔ v.Verifies K :=
+  Condition.realize_toFormulaAll_of_forall ih
+
+private theorem DRS.realize_toFormula_of_forall [DecidableEq V] {K : DRS L V}
+    {v : Embedding V M}
+    (ih : ∀ c ∈ K.conditions, ∀ w : Embedding V M,
+      (Condition.toFormula c).Realize w ↔ w.VerifiesCondition c) :
+    (DRS.toFormula K).Realize v ↔ ∃ v', K.Extends v v' ∧ v'.Verifies K := by
+  simp only [DRS.toFormula, realize_closeExists, Box.Extends, Embedding.Verifies]
+  exact exists_congr fun v' => and_congr_right fun _ =>
+    Condition.realize_toFormulaAll_of_forall fun c hc => ih c hc v'
+
 /-- A single condition's translation realizes as `VerifiesCondition`. -/
 theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : Embedding V M) :
     (Condition.toFormula c).Realize v ↔ v.VerifiesCondition c := by
@@ -168,27 +201,55 @@ theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : Emb
       BoundedFormula.realize_rel, Term.realize_var]
   | .eq a b => simp [Condition.toFormula, Formula.realize_equal]
   | .neg K =>
-    simp only [Condition.toFormula, Embedding.verifies_neg, Formula.realize_not]
-    rw [DRS.realize_toFormula K v]
-  | .imp a c =>
-    simp only [Condition.toFormula, Embedding.verifies_imp]
-    rw [realize_closeForall]
-    simp only [Formula.realize_imp]
-    refine forall_congr' (fun v' => imp_congr_right (fun _ => ?_))
-    rw [DRS.realize_bodyFormula a v', DRS.realize_toFormula c v']
+    have ih : ∀ d ∈ K.conditions, ∀ w : Embedding V M,
+        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
+      fun d _ w => Condition.realize_toFormula d w
+    rw [Condition.toFormula_neg, Formula.realize_not, DRS.realize_toFormula_of_forall ih,
+      Embedding.verifies_neg]
+  | .imp a c' =>
+    have iha : ∀ d ∈ a.conditions, ∀ w : Embedding V M,
+        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
+      fun d _ w => Condition.realize_toFormula d w
+    have ihc : ∀ d ∈ c'.conditions, ∀ w : Embedding V M,
+        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
+      fun d _ w => Condition.realize_toFormula d w
+    rw [Condition.toFormula_imp, Embedding.verifies_imp, realize_closeForall]
+    refine forall_congr' fun v' => imp_congr_right fun _ => ?_
+    rw [Formula.realize_imp, DRS.realize_bodyFormula_of_forall fun d hd => iha d hd v',
+      DRS.realize_toFormula_of_forall ihc]
   | .dis l r =>
-    simp only [Condition.toFormula, Embedding.verifies_dis, Formula.realize_sup]
-    rw [DRS.realize_toFormula l v, DRS.realize_toFormula r v]
+    have ihl : ∀ d ∈ l.conditions, ∀ w : Embedding V M,
+        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
+      fun d _ w => Condition.realize_toFormula d w
+    have ihr : ∀ d ∈ r.conditions, ∀ w : Embedding V M,
+        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
+      fun d _ w => Condition.realize_toFormula d w
+    rw [Condition.toFormula_dis, Formula.realize_sup, Embedding.verifies_dis,
+      DRS.realize_toFormula_of_forall ihl, DRS.realize_toFormula_of_forall ihr]
+decreasing_by all_goals
+  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
+  simp_wf
+  omega
+
 /-- A list of conditions' conjoined translation realizes as the conjunction of
 their realizations. -/
 theorem Condition.realize_toFormulaAll [DecidableEq V] (cs : List (Condition L V))
     (v : Embedding V M) :
-    (Condition.toFormulaAll cs).Realize v ↔ ∀ c ∈ cs, v.VerifiesCondition c := by
-  match cs with
-  | [] => simp [Condition.toFormulaAll, Formula.realize_top]
-  | c :: cs =>
-    rw [Condition.toFormulaAll, Formula.realize_inf, Condition.realize_toFormula c v,
-      Condition.realize_toFormulaAll cs v, List.forall_mem_cons]
-end
+    (Condition.toFormulaAll cs).Realize v ↔ ∀ c ∈ cs, v.VerifiesCondition c :=
+  Condition.realize_toFormulaAll_of_forall fun c _ => Condition.realize_toFormula c v
+
+/-- The open body of a DRS (its conditions, no universe closure) realizes as
+`Verifies` of the DRS (used for the antecedent of `⇒`). -/
+theorem DRS.realize_bodyFormula [DecidableEq V] (K : DRS L V) (v : Embedding V M) :
+    (DRS.bodyFormula K).Realize v ↔ v.Verifies K :=
+  DRS.realize_bodyFormula_of_forall fun c _ => Condition.realize_toFormula c v
+
+/-- **DRT ⊆ FOL** (§1.5): the
+translated formula's `Realize` coincides with the bespoke `Embedding.Verifies`. As
+`toFormula` existentially closes the universe, the correspondence is with an
+embedding `v'` extending `v` over `K.referents`. -/
+theorem DRS.realize_toFormula [DecidableEq V] (K : DRS L V) (v : Embedding V M) :
+    (K.toFormula).Realize v ↔ ∃ v', K.Extends v v' ∧ v'.Verifies K :=
+  DRS.realize_toFormula_of_forall fun c _ w => Condition.realize_toFormula c w
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -191,35 +191,20 @@ private theorem DRS.realize_toFormula_of_forall [DecidableEq V] {K : DRS L V}
 /-- A single condition's translation realizes as `VerifiesCondition`. -/
 theorem Condition.realize_toFormula [DecidableEq V] (c : Condition L V) (v : Embedding V M) :
     (Condition.toFormula c).Realize v ↔ v.VerifiesCondition c := by
-  match c with
-  | .rel R args =>
+  induction c generalizing v with
+  | rel R args =>
     simp [Condition.toFormula, Relations.formula, Formula.Realize,
       BoundedFormula.realize_rel, Term.realize_var]
-  | .eq a b => simp [Condition.toFormula, Formula.realize_equal]
-  | .neg K =>
-    have ih : ∀ d ∈ K.conditions, ∀ w : Embedding V M,
-        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
-      fun d _ w => Condition.realize_toFormula d w
+  | eq a b => simp [Condition.toFormula, Formula.realize_equal]
+  | neg K ih =>
     rw [Condition.toFormula_neg, Formula.realize_not, DRS.realize_toFormula_of_forall ih,
       Embedding.verifies_neg]
-  | .imp a c' =>
-    have iha : ∀ d ∈ a.conditions, ∀ w : Embedding V M,
-        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
-      fun d _ w => Condition.realize_toFormula d w
-    have ihc : ∀ d ∈ c'.conditions, ∀ w : Embedding V M,
-        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
-      fun d _ w => Condition.realize_toFormula d w
+  | imp a c iha ihc =>
     rw [Condition.toFormula_imp, Embedding.verifies_imp, realize_closeForall]
     refine forall_congr' fun v' => imp_congr_right fun _ => ?_
     rw [Formula.realize_imp, DRS.realize_bodyFormula_of_forall fun d hd => iha d hd v',
       DRS.realize_toFormula_of_forall ihc]
-  | .dis l r =>
-    have ihl : ∀ d ∈ l.conditions, ∀ w : Embedding V M,
-        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
-      fun d _ w => Condition.realize_toFormula d w
-    have ihr : ∀ d ∈ r.conditions, ∀ w : Embedding V M,
-        (Condition.toFormula d).Realize w ↔ w.VerifiesCondition d :=
-      fun d _ w => Condition.realize_toFormula d w
+  | dis l r ihl ihr =>
     rw [Condition.toFormula_dis, Formula.realize_sup, Embedding.verifies_dis,
       DRS.realize_toFormula_of_forall ihl, DRS.realize_toFormula_of_forall ihr]
 

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -140,7 +140,7 @@ private theorem verifies_map_all (e : V ≃ W) (K : DRS L V) (g : Embedding W M)
     (ih : ∀ c ∈ K.conditions, ∀ u : Embedding W M,
       u.VerifiesCondition (c.map e) ↔ VerifiesCondition (u ∘ e) c) :
     g.Verifies (K.map e) ↔ Verifies (g ∘ e) K := by
-  simp only [Verifies, DRS.conditions_map, Condition.mapList_eq_map, List.forall_mem_map]
+  simp only [Verifies, DRS.conditions_map, List.forall_mem_map]
   exact forall_congr' fun c => imp_congr_right fun hc => ih c hc g
 
 /-- "Some extension of `f` verifies `K`" transported along renaming, given the

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -71,11 +71,6 @@ def VerifiesCondition : Embedding V M → Condition L V → Prop
   | f, .dis l r =>
       (∃ g, l.Extends f g ∧ ∀ c ∈ l.conditions, g.VerifiesCondition c) ∨
       (∃ g, r.Extends f g ∧ ∀ c ∈ r.conditions, g.VerifiesCondition c)
-termination_by _ c => sizeOf c
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- `f.Verifies K`: the embedding `f` *verifies* the DRS `K` — `f` verifies
 every condition of `K` (Def. 1.4.4). -/
@@ -176,11 +171,6 @@ theorem verifies_map_condition (e : V ≃ W) : ∀ (f : Embedding W M) (c : Cond
     exact or_congr
       (exists_extends_verifies_map_aux e l f fun d _ u => verifies_map_condition e u d)
       (exists_extends_verifies_map_aux e r f fun d _ u => verifies_map_condition e u d)
-termination_by _ c => sizeOf c
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Renaming along a bijection transports verification: `f` verifies `K.map e`
 iff `f ∘ e` verifies `K` — alphabetic variants have the same semantics. -/
@@ -290,11 +280,6 @@ theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding
         fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,
        exists_extends_verifies_congr_aux r hr.symm
         fun d _ g₁ g₂ hg => verifiesCondition_congr d hg⟩
-termination_by c => sizeOf c
-decreasing_by all_goals
-  have := DRS.sizeOf_lt_of_mem_conditions (by assumption)
-  simp_wf
-  omega
 
 /-- Verification reads the embedding only at the DRS's occurring referents. -/
 theorem verifies_congr {K : DRS L V} {f₁ f₂ : Embedding V M}

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -195,29 +195,29 @@ variable [DecidableEq V]
 /-- "Some extension of `f₁` verifies `K`" survives changing `f₁` at
 non-occurring referents, given coincidence for each condition of `K`. -/
 private theorem exists_extends_verifies_congr_aux (K : DRS L V) {f₁ f₂ : Embedding V M}
-    (h : Set.EqOn f₁ f₂ ↑K.occ)
+    (h : Set.EqOn f₁ f₂ ↑K.varFinset)
     (ih : ∀ c ∈ K.conditions, ∀ {g₁ g₂ : Embedding V M},
-      Set.EqOn g₁ g₂ ↑(Condition.occ c) → (g₁.VerifiesCondition c ↔ g₂.VerifiesCondition c)) :
+      Set.EqOn g₁ g₂ ↑(Condition.varFinset c) → (g₁.VerifiesCondition c ↔ g₂.VerifiesCondition c)) :
     (∃ g, K.Extends f₁ g ∧ g.Verifies K) → ∃ g, K.Extends f₂ g ∧ g.Verifies K := by
   obtain ⟨U, conds⟩ := K
   rintro ⟨g, hag, hh⟩
-  refine ⟨(Condition.occL conds).piecewise g f₂, ?_, ?_⟩
+  refine ⟨(Condition.varFinsetL conds).piecewise g f₂, ?_, ?_⟩
   · intro x hx
-    by_cases hxc : x ∈ Condition.occL conds
+    by_cases hxc : x ∈ Condition.varFinsetL conds
     · rw [Finset.piecewise_eq_of_mem _ _ _ hxc, hag x hx]
       refine h ?_
-      simp only [DRS.occ, Finset.coe_union]
+      simp only [DRS.varFinset, Finset.coe_union]
       exact Or.inr (Finset.mem_coe.mpr hxc)
     · rw [Finset.piecewise_eq_of_notMem _ _ _ hxc]
   · intro c hc
     refine (ih c hc (g₂ := g) fun x hx => ?_).mpr (hh c hc)
     exact Finset.piecewise_eq_of_mem _ _ _
-      (Condition.occ_subset_occL hc (Finset.mem_coe.mp hx))
+      (Condition.varFinset_subset_varFinsetL hc (Finset.mem_coe.mp hx))
 
 /-- Verification of a condition reads the embedding only at its occurring
 referents. -/
 theorem verifiesCondition_congr (c : Condition L V) {f₁ f₂ : Embedding V M}
-    (h : Set.EqOn f₁ f₂ ↑(Condition.occ c)) :
+    (h : Set.EqOn f₁ f₂ ↑(Condition.varFinset c)) :
     f₁.VerifiesCondition c ↔ f₂.VerifiesCondition c := by
   induction c generalizing f₁ f₂ with
   | rel R args =>
@@ -226,47 +226,47 @@ theorem verifiesCondition_congr (c : Condition L V) {f₁ f₂ : Embedding V M}
       funext fun i => h (by simp)]
   | eq a b =>
     simp only [verifies_eq]
-    rw [h (show a ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp),
-      h (show b ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp)]
+    rw [h (show a ∈ ↑(Condition.varFinset (.eq a b : Condition L V)) by simp),
+      h (show b ∈ ↑(Condition.varFinset (.eq a b : Condition L V)) by simp)]
   | neg K ih =>
     simp only [verifies_neg]
-    rw [Condition.occ_neg] at h
+    rw [Condition.varFinset_neg] at h
     exact not_congr ⟨exists_extends_verifies_congr_aux K h ih,
       exists_extends_verifies_congr_aux K h.symm ih⟩
   | imp a c iha ihc =>
     simp only [verifies_imp]
-    rw [Condition.occ_imp] at h
+    rw [Condition.varFinset_imp] at h
     have key : ∀ b₁ b₂ : Embedding V M,
-        Set.EqOn b₁ b₂ ↑(DRS.occ a ∪ DRS.occ c) →
+        Set.EqOn b₁ b₂ ↑(DRS.varFinset a ∪ DRS.varFinset c) →
         (∀ g, a.Extends b₁ g → g.Verifies a →
           ∃ h', c.Extends g h' ∧ h'.Verifies c) →
         ∀ g, a.Extends b₂ g → g.Verifies a →
           ∃ h', c.Extends g h' ∧ h'.Verifies c := by
       rintro b₁ b₂ hb hL g hag hv
-      have hpg : Set.EqOn ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) g ↑(DRS.occ a) :=
+      have hpg : Set.EqOn ((DRS.varFinset a ∪ DRS.varFinset c).piecewise g b₁) g ↑(DRS.varFinset a) :=
         fun x hx =>
           Finset.piecewise_eq_of_mem _ _ _ (Finset.mem_union_left _ (Finset.mem_coe.mp hx))
-      have hExt : a.Extends b₁ ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) := by
+      have hExt : a.Extends b₁ ((DRS.varFinset a ∪ DRS.varFinset c).piecewise g b₁) := by
         intro x hx
-        by_cases hxS : x ∈ DRS.occ a ∪ DRS.occ c
+        by_cases hxS : x ∈ DRS.varFinset a ∪ DRS.varFinset c
         · rw [Finset.piecewise_eq_of_mem _ _ _ hxS, hag x hx]
           exact (hb (Finset.mem_coe.mpr hxS)).symm
         · rw [Finset.piecewise_eq_of_notMem _ _ _ hxS]
-      have hVer : Verifies ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) a := fun d hd =>
+      have hVer : Verifies ((DRS.varFinset a ∪ DRS.varFinset c).piecewise g b₁) a := fun d hd =>
         (iha d hd (hpg.mono (Finset.coe_subset.mpr
-          ((Condition.occ_subset_occL hd).trans (DRS.occL_subset_occ a))))).mpr (hv d hd)
+          ((Condition.varFinset_subset_varFinsetL hd).trans (DRS.varFinsetL_subset_varFinset a))))).mpr (hv d hd)
       obtain ⟨h', hch', hvh'⟩ := hL _ hExt hVer
-      have hpc : Set.EqOn ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) g ↑(DRS.occ c) :=
+      have hpc : Set.EqOn ((DRS.varFinset a ∪ DRS.varFinset c).piecewise g b₁) g ↑(DRS.varFinset c) :=
         fun x hx =>
           Finset.piecewise_eq_of_mem _ _ _ (Finset.mem_union_right _ (Finset.mem_coe.mp hx))
       exact exists_extends_verifies_congr_aux c hpc ihc ⟨h', hch', hvh'⟩
     exact ⟨key f₁ f₂ h, key f₂ f₁ h.symm⟩
   | dis l r ihl ihr =>
     simp only [verifies_dis]
-    have hl : Set.EqOn f₁ f₂ ↑(DRS.occ l) :=
-      h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_left)
-    have hr : Set.EqOn f₁ f₂ ↑(DRS.occ r) :=
-      h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_right)
+    have hl : Set.EqOn f₁ f₂ ↑(DRS.varFinset l) :=
+      h.mono (by simp only [Condition.varFinset_dis, Finset.coe_union]; exact Set.subset_union_left)
+    have hr : Set.EqOn f₁ f₂ ↑(DRS.varFinset r) :=
+      h.mono (by simp only [Condition.varFinset_dis, Finset.coe_union]; exact Set.subset_union_right)
     exact or_congr
       ⟨exists_extends_verifies_congr_aux l hl ihl,
        exists_extends_verifies_congr_aux l hl.symm ihl⟩
@@ -275,16 +275,16 @@ theorem verifiesCondition_congr (c : Condition L V) {f₁ f₂ : Embedding V M}
 
 /-- Verification reads the embedding only at the DRS's occurring referents. -/
 theorem verifies_congr {K : DRS L V} {f₁ f₂ : Embedding V M}
-    (h : Set.EqOn f₁ f₂ ↑K.occ) : f₁.Verifies K ↔ f₂.Verifies K := by
+    (h : Set.EqOn f₁ f₂ ↑K.varFinset) : f₁.Verifies K ↔ f₂.Verifies K := by
   simp only [verifies_iff]
   exact forall_congr' fun c => imp_congr_right fun hc =>
     verifiesCondition_congr c (h.mono (Finset.coe_subset.mpr
-      ((Condition.occ_subset_occL hc).trans (DRS.occL_subset_occ K))))
+      ((Condition.varFinset_subset_varFinsetL hc).trans (DRS.varFinsetL_subset_varFinset K))))
 
 /-- "Some extension verifies" reads the input embedding only at the occurring
 referents. -/
 theorem exists_extends_verifies_congr {K : DRS L V} {f₁ f₂ : Embedding V M}
-    (h : Set.EqOn f₁ f₂ ↑K.occ) :
+    (h : Set.EqOn f₁ f₂ ↑K.varFinset) :
     (∃ g, K.Extends f₁ g ∧ g.Verifies K) ↔ ∃ g, K.Extends f₂ g ∧ g.Verifies K :=
   ⟨exists_extends_verifies_congr_aux K h fun c _ => verifiesCondition_congr c,
    exists_extends_verifies_congr_aux K h.symm fun c _ => verifiesCondition_congr c⟩

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Dynamic.DRS.Basic
 [kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering, over a
 mathlib `FirstOrder.Language.Structure`. An *embedding function*
 `f : Embedding V M` assigns discourse referents to individuals in the model;
-`Box.Extends K f g` is K&R's extension relation `f [K] g` (both in
+`Box.Extends K f g` is the extension relation `f [K] g` (both in
 `DRS/Basic.lean`); `f.Verifies K` says the embedding `f` *verifies* the DRS
 `K` — it verifies every condition of `K` — and `f.VerifiesCondition c` that it
 verifies the DRS-condition `c`. A sub-DRS is entered by existentially
@@ -19,12 +19,13 @@ closure of verification over the outer universe; it is delivered downstream
 as `DRS.trueRel` (`DRS/Dynamics.lean`) and as the first-order translation's
 realization (`DRS/Reduction.lean`).
 
-**Deviation** ([muskens-1996], fn. 4): K&R's embeddings are *partial* functions
-that sub-DRSs strictly *extend*, so a re-declared referent keeps its value; here
-embeddings are total and a re-declared referent is freely reassigned. The two
-agree on DRSs that declare each referent once — the construction algorithm never
-re-declares — but diverge on re-declaration: `[ | [x | man x] ⇒ [x | mortal x]]`
-says "every man is mortal" for K&R, "if there is a man there is a mortal" here.
+**Deviation** ([muskens-1996], fn. 4): the book's embeddings are *partial*
+functions that sub-DRSs strictly *extend*, so a re-declared referent keeps its
+value; here embeddings are total and a re-declared referent is freely
+reassigned. The two agree on DRSs that declare each referent once — the
+construction algorithm never re-declares — but diverge on re-declaration:
+`[ | [x | man x] ⇒ [x | mortal x]]` says "every man is mortal" there, "if
+there is a man there is a mortal" here.
 
 ## Main declarations
 

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -151,26 +151,24 @@ private theorem exists_extends_verifies_map_aux (e : V ≃ W) (K : DRS L V) (f :
 
 /-- Renaming along a bijection transports verification (the condition form of
 `verifies_map`). -/
-theorem verifies_map_condition (e : V ≃ W) : ∀ (f : Embedding W M) (c : Condition L V),
-    f.VerifiesCondition (c.map e) ↔ VerifiesCondition (f ∘ e) c
-  | f, .rel R args => by simp [Condition.map, Function.comp]
-  | f, .eq a b => by simp [Condition.map, Function.comp]
-  | f, .neg K => by
+theorem verifies_map_condition (e : V ≃ W) (f : Embedding W M) (c : Condition L V) :
+    f.VerifiesCondition (c.map e) ↔ VerifiesCondition (f ∘ e) c := by
+  induction c generalizing f with
+  | rel R args => simp [Condition.map, Function.comp]
+  | eq a b => simp [Condition.map, Function.comp]
+  | neg K ih =>
     simp only [Condition.map, verifies_neg]
-    exact not_congr
-      (exists_extends_verifies_map_aux e K f fun d _ u => verifies_map_condition e u d)
-  | f, .imp a c => by
+    exact not_congr (exists_extends_verifies_map_aux e K f ih)
+  | imp a c iha ihc =>
     simp only [Condition.map, verifies_imp]
     refine Iff.trans (forall_congr' fun g => imp_congr_right fun _ => imp_congr
-      (verifies_map_all e a g fun d _ u => verifies_map_condition e u d)
-      (exists_extends_verifies_map_aux e c g fun d _ u => verifies_map_condition e u d)) ?_
+      (verifies_map_all e a g iha) (exists_extends_verifies_map_aux e c g ihc)) ?_
     exact DRS.forall_extends_map e a f
       (fun u => Verifies u a → ∃ h', c.Extends u h' ∧ Verifies h' c)
-  | f, .dis l r => by
+  | dis l r ihl ihr =>
     simp only [Condition.map, verifies_dis]
-    exact or_congr
-      (exists_extends_verifies_map_aux e l f fun d _ u => verifies_map_condition e u d)
-      (exists_extends_verifies_map_aux e r f fun d _ u => verifies_map_condition e u d)
+    exact or_congr (exists_extends_verifies_map_aux e l f ihl)
+      (exists_extends_verifies_map_aux e r f ihr)
 
 /-- Renaming along a bijection transports verification: `f` verifies `K.map e`
 iff `f ∘ e` verifies `K` — alphabetic variants have the same semantics. -/
@@ -198,7 +196,7 @@ variable [DecidableEq V]
 non-occurring referents, given coincidence for each condition of `K`. -/
 private theorem exists_extends_verifies_congr_aux (K : DRS L V) {f₁ f₂ : Embedding V M}
     (h : Set.EqOn f₁ f₂ ↑K.occ)
-    (ih : ∀ c ∈ K.conditions, ∀ g₁ g₂ : Embedding V M,
+    (ih : ∀ c ∈ K.conditions, ∀ {g₁ g₂ : Embedding V M},
       Set.EqOn g₁ g₂ ↑(Condition.occ c) → (g₁.VerifiesCondition c ↔ g₂.VerifiesCondition c)) :
     (∃ g, K.Extends f₁ g ∧ g.Verifies K) → ∃ g, K.Extends f₂ g ∧ g.Verifies K := by
   obtain ⟨U, conds⟩ := K
@@ -212,31 +210,30 @@ private theorem exists_extends_verifies_congr_aux (K : DRS L V) {f₁ f₂ : Emb
       exact Or.inr (Finset.mem_coe.mpr hxc)
     · rw [Finset.piecewise_eq_of_notMem _ _ _ hxc]
   · intro c hc
-    refine (ih c hc _ g fun x hx => ?_).mpr (hh c hc)
+    refine (ih c hc (g₂ := g) fun x hx => ?_).mpr (hh c hc)
     exact Finset.piecewise_eq_of_mem _ _ _
       (Condition.occ_subset_occL hc (Finset.mem_coe.mp hx))
 
 /-- Verification of a condition reads the embedding only at its occurring
 referents. -/
-theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding V M},
-    Set.EqOn f₁ f₂ ↑(Condition.occ c) → (f₁.VerifiesCondition c ↔ f₂.VerifiesCondition c)
-  | .rel R args, f₁, f₂, h => by
+theorem verifiesCondition_congr (c : Condition L V) {f₁ f₂ : Embedding V M}
+    (h : Set.EqOn f₁ f₂ ↑(Condition.occ c)) :
+    f₁.VerifiesCondition c ↔ f₂.VerifiesCondition c := by
+  induction c generalizing f₁ f₂ with
+  | rel R args =>
     simp only [verifies_rel]
     rw [show (fun i => f₁ (args i)) = fun i => f₂ (args i) from
       funext fun i => h (by simp)]
-  | .eq a b, f₁, f₂, h => by
+  | eq a b =>
     simp only [verifies_eq]
     rw [h (show a ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp),
       h (show b ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp)]
-  | .neg K, f₁, f₂, h => by
+  | neg K ih =>
     simp only [verifies_neg]
     rw [Condition.occ_neg] at h
-    exact not_congr
-      ⟨exists_extends_verifies_congr_aux K h
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,
-       exists_extends_verifies_congr_aux K h.symm
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg⟩
-  | .imp a c, f₁, f₂, h => by
+    exact not_congr ⟨exists_extends_verifies_congr_aux K h ih,
+      exists_extends_verifies_congr_aux K h.symm ih⟩
+  | imp a c iha ihc =>
     simp only [verifies_imp]
     rw [Condition.occ_imp] at h
     have key : ∀ b₁ b₂ : Embedding V M,
@@ -256,30 +253,25 @@ theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding
           exact (hb (Finset.mem_coe.mpr hxS)).symm
         · rw [Finset.piecewise_eq_of_notMem _ _ _ hxS]
       have hVer : Verifies ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) a := fun d hd =>
-        (verifiesCondition_congr d (hpg.mono (Finset.coe_subset.mpr
+        (iha d hd (hpg.mono (Finset.coe_subset.mpr
           ((Condition.occ_subset_occL hd).trans (DRS.occL_subset_occ a))))).mpr (hv d hd)
       obtain ⟨h', hch', hvh'⟩ := hL _ hExt hVer
       have hpc : Set.EqOn ((DRS.occ a ∪ DRS.occ c).piecewise g b₁) g ↑(DRS.occ c) :=
         fun x hx =>
           Finset.piecewise_eq_of_mem _ _ _ (Finset.mem_union_right _ (Finset.mem_coe.mp hx))
-      exact exists_extends_verifies_congr_aux c hpc
-        (fun d _ g₁ g₂ hg => verifiesCondition_congr d hg) ⟨h', hch', hvh'⟩
+      exact exists_extends_verifies_congr_aux c hpc ihc ⟨h', hch', hvh'⟩
     exact ⟨key f₁ f₂ h, key f₂ f₁ h.symm⟩
-  | .dis l r, f₁, f₂, h => by
+  | dis l r ihl ihr =>
     simp only [verifies_dis]
     have hl : Set.EqOn f₁ f₂ ↑(DRS.occ l) :=
       h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_left)
     have hr : Set.EqOn f₁ f₂ ↑(DRS.occ r) :=
       h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_right)
     exact or_congr
-      ⟨exists_extends_verifies_congr_aux l hl
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,
-       exists_extends_verifies_congr_aux l hl.symm
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg⟩
-      ⟨exists_extends_verifies_congr_aux r hr
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,
-       exists_extends_verifies_congr_aux r hr.symm
-        fun d _ g₁ g₂ hg => verifiesCondition_congr d hg⟩
+      ⟨exists_extends_verifies_congr_aux l hl ihl,
+       exists_extends_verifies_congr_aux l hl.symm ihl⟩
+      ⟨exists_extends_verifies_congr_aux r hr ihr,
+       exists_extends_verifies_congr_aux r hr.symm ihr⟩
 
 /-- Verification reads the embedding only at the DRS's occurring referents. -/
 theorem verifies_congr {K : DRS L V} {f₁ f₂ : Embedding V M}
@@ -294,10 +286,8 @@ referents. -/
 theorem exists_extends_verifies_congr {K : DRS L V} {f₁ f₂ : Embedding V M}
     (h : Set.EqOn f₁ f₂ ↑K.occ) :
     (∃ g, K.Extends f₁ g ∧ g.Verifies K) ↔ ∃ g, K.Extends f₂ g ∧ g.Verifies K :=
-  ⟨exists_extends_verifies_congr_aux K h
-    fun c _ _ _ hg => verifiesCondition_congr c hg,
-   exists_extends_verifies_congr_aux K h.symm
-    fun c _ _ _ hg => verifiesCondition_congr c hg⟩
+  ⟨exists_extends_verifies_congr_aux K h fun c _ => verifiesCondition_congr c,
+   exists_extends_verifies_congr_aux K h.symm fun c _ => verifiesCondition_congr c⟩
 
 end Coincidence
 

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Dynamic.DRS.Basic
 mathlib `FirstOrder.Language.Structure`. An *embedding function*
 `f : Embedding V M` assigns discourse referents to individuals in the model;
 `Box.Extends K f g` is the extension relation `f [K] g` (both in
-`DRS/Basic.lean`); `f.Verifies K` says the embedding `f` *verifies* the DRS
+`DRS/Box.lean`); `f.Verifies K` says the embedding `f` *verifies* the DRS
 `K` — it verifies every condition of `K` — and `f.VerifiesCondition c` that it
 verifies the DRS-condition `c`. A sub-DRS is entered by existentially
 (re)assigning along its extension relation. For `imp`, the consequent witness

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -232,13 +232,14 @@ theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding
   | .rel R args, f₁, f₂, h => by
     simp only [verifies_rel]
     rw [show (fun i => f₁ (args i)) = fun i => f₂ (args i) from
-      funext fun i => h (by simp [Condition.occ])]
+      funext fun i => h (by simp)]
   | .eq a b, f₁, f₂, h => by
     simp only [verifies_eq]
-    rw [h (show a ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp [Condition.occ]),
-      h (show b ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp [Condition.occ])]
+    rw [h (show a ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp),
+      h (show b ∈ ↑(Condition.occ (.eq a b : Condition L V)) by simp)]
   | .neg K, f₁, f₂, h => by
     simp only [verifies_neg]
+    rw [Condition.occ_neg] at h
     exact not_congr
       ⟨exists_extends_verifies_congr_aux K h
         fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,
@@ -246,8 +247,9 @@ theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding
         fun d _ g₁ g₂ hg => verifiesCondition_congr d hg⟩
   | .imp a c, f₁, f₂, h => by
     simp only [verifies_imp]
+    rw [Condition.occ_imp] at h
     have key : ∀ b₁ b₂ : Embedding V M,
-        Set.EqOn b₁ b₂ ↑(Condition.occ (.imp a c)) →
+        Set.EqOn b₁ b₂ ↑(DRS.occ a ∪ DRS.occ c) →
         (∀ g, a.Extends b₁ g → g.Verifies a →
           ∃ h', c.Extends g h' ∧ h'.Verifies c) →
         ∀ g, a.Extends b₂ g → g.Verifies a →
@@ -275,9 +277,9 @@ theorem verifiesCondition_congr : ∀ (c : Condition L V) {f₁ f₂ : Embedding
   | .dis l r, f₁, f₂, h => by
     simp only [verifies_dis]
     have hl : Set.EqOn f₁ f₂ ↑(DRS.occ l) :=
-      h.mono (by simp only [Condition.occ, Finset.coe_union]; exact Set.subset_union_left)
+      h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_left)
     have hr : Set.EqOn f₁ f₂ ↑(DRS.occ r) :=
-      h.mono (by simp only [Condition.occ, Finset.coe_union]; exact Set.subset_union_right)
+      h.mono (by simp only [Condition.occ_dis, Finset.coe_union]; exact Set.subset_union_right)
     exact or_congr
       ⟨exists_extends_verifies_congr_aux l hl
         fun d _ g₁ g₂ hg => verifiesCondition_congr d hg,

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -5,7 +5,7 @@ import Mathlib.Data.Fin.VecNotation
 # Kamp & Reyle (1993): From Discourse to Logic
 [kamp-reyle-1993]
 
-K&R's worked examples, evaluated through the faithful model-theoretic DRS core
+The book's worked examples, evaluated through the faithful model-theoretic DRS core
 (`Semantics/Dynamic/DRS/`). Each truth-condition is a theorem about the substrate
 denotation `DRS.trueRel` (Muskens's relational truth, equivalently `Embedding.Verifies`),
 not a local re-implementation.
@@ -16,7 +16,7 @@ not a local re-implementation.
    discourse referent persists across sentences — `∃ e, man e ∧ walked-in e ∧
    sat-down e` (`persistence_tc`).
 2. **Donkey anaphora**: "If a farmer owns a donkey, he beats it." The `⇒`
-   verification clause (K&R's Chapter 2 conditional semantics) yields the
+   verification clause (the Chapter 2 conditional semantics) yields the
    **universal** reading — `∀ farmer-donkey owning pairs, beats`
    (`donkey_universal_reading`). The antecedent's referents are universally
    bound and remain accessible in the consequent.
@@ -105,7 +105,7 @@ def donkeyCons : DRS krLang ℕ := .mk ∅ [.rel .beats (![1, 2])]
 /-- "If a¹ farmer owns a² donkey, he₁ beats it₂." — `[ | donkeyAnte ⇒ donkeyCons]`. -/
 def donkey : DRS krLang ℕ := .mk ∅ [.imp donkeyAnte donkeyCons]
 
-/-- The donkey universal reading: the `⇒` verification clause (K&R's Chapter 2
+/-- The donkey universal reading: the `⇒` verification clause (the Chapter 2
 conditional semantics) makes the antecedent's existentials universal — every
 owning farmer-donkey pair satisfies `beats`. The empty-universe consequent
 reuses the antecedent's values (the anaphora). -/

--- a/Linglib/Studies/KampVanGenabithReyle2011.lean
+++ b/Linglib/Studies/KampVanGenabithReyle2011.lean
@@ -88,11 +88,11 @@ theorem sentence₁_proper : sentence₁.IsProper := by simp [DRS.IsProper, sent
 
 /-- The referential presupposition: `sentence₂`'s free referent is supplied by
 `sentence₁`'s universe. -/
-theorem sentence₂_bound : sentence₂.fv ⊆ sentence₁.referents := by simp [sentence₂, sentence₁]
+theorem sentence₂_bound : sentence₂.freeVarFinset ⊆ sentence₁.referents := by simp [sentence₂, sentence₁]
 
 /-- No capture: `sentence₂` introduces no referent occurring in `sentence₁`. -/
 theorem sentence₂_fresh :
-    Disjoint sentence₂.referents (Condition.occL sentence₁.conditions) := by simp [sentence₂]
+    Disjoint sentence₂.referents (Condition.varFinsetL sentence₁.conditions) := by simp [sentence₂]
 
 /-- The action equation for the discourse: interpreting sentence two against
 the context sentence one expresses is interpreting their merge from scratch. -/

--- a/Linglib/Studies/Maier2015.lean
+++ b/Linglib/Studies/Maier2015.lean
@@ -53,7 +53,7 @@ presupposition-as-anaphora) to the now-accessible believed event (his
 ## Substrate fit (what the faithful core does and does not provide)
 
 * **Accessibility / occurrence.** `DRS.Accessible`/`DRS.accessibleFrom` and
-  `DRS.occ` (`DRS/Basic.lean`) are decidable, host-relative, and reproduce Maier's
+  `DRS.varFinset` (`DRS/Basic.lean`) are decidable, host-relative, and reproduce Maier's
   parasitic asymmetry — the four theorems below are `decide`d against them.
   (`DRS.Accessible` is the *fixed* notion: an earlier host-free `∃`-over-
   superordinates formulation was vacuous.)
@@ -286,7 +286,7 @@ def sueBound : MentalState := sueMerged.bind 21 20
 /-- Before merge, the believed cheating event does not even occur in the lone
 hope description, so the *stop* presupposition has no antecedent to bind to —
 only (dispreferred) accommodation is available. -/
-theorem believed_event_absent_before_merge : 20 ∉ DRS.occ sueHope.flatten := by
+theorem believed_event_absent_before_merge : 20 ∉ DRS.varFinset sueHope.flatten := by
   simp [sueHope, MentalState.flatten]; decide
 
 /-- After merge, the believed cheating event `e` (20) is accessible from the
@@ -308,7 +308,7 @@ theorem parasitic_asymmetry : ¬ DRS.Accessible sueMerged.flatten 20 21 := by
 it has been identified with the believed event `e` (20), so the presupposition is
 resolved by binding (filtered), not accommodated or projected (Maier's (60)). -/
 theorem presup_resolved_after_binding :
-    21 ∉ DRS.occ sueBound.flatten ∧ 20 ∈ DRS.occ sueBound.flatten := by
+    21 ∉ DRS.varFinset sueBound.flatten ∧ 20 ∈ DRS.varFinset sueBound.flatten := by
   simp [sueBound, sueMerged, sueBelief, sueHope, MentalState.merge, mergeCompartments,
     MentalState.bind, MentalState.flatten, Condition.map]
   decide

--- a/Linglib/Studies/Maier2015.lean
+++ b/Linglib/Studies/Maier2015.lean
@@ -286,22 +286,31 @@ def sueBound : MentalState := sueMerged.bind 21 20
 /-- Before merge, the believed cheating event does not even occur in the lone
 hope description, so the *stop* presupposition has no antecedent to bind to —
 only (dispreferred) accommodation is available. -/
-theorem believed_event_absent_before_merge : 20 ∉ DRS.occ sueHope.flatten := by decide
+theorem believed_event_absent_before_merge : 20 ∉ DRS.occ sueHope.flatten := by
+  simp [sueHope, MentalState.flatten]; decide
 
 /-- After merge, the believed cheating event `e` (20) is accessible from the
 desire-compartment presupposition `e'` (21): binding `e' = e` is licensed. This
 is the filtering, reusing the core's `DRS.Accessible` unchanged. -/
-theorem presup_binds_after_merge : DRS.Accessible sueMerged.flatten 21 20 := by decide
+theorem presup_binds_after_merge : DRS.Accessible sueMerged.flatten 21 20 := by
+  simp [DRS.Accessible, DRS.accessibleFrom, sueMerged, sueBelief, sueHope, MentalState.merge,
+    mergeCompartments, MentalState.flatten, DRS.accScope, Condition.accScopeL,
+    Condition.accScope, Option.orElse]
 
 /-- The dependence is asymmetric (Maier §3.1, fn. 11): the believed event in the
 belief layer does *not* see the desire-compartment referent. Belief can filter
 desire's presupposition, not conversely. -/
-theorem parasitic_asymmetry : ¬ DRS.Accessible sueMerged.flatten 20 21 := by decide
+theorem parasitic_asymmetry : ¬ DRS.Accessible sueMerged.flatten 20 21 := by
+  simp [DRS.Accessible, DRS.accessibleFrom, sueMerged, sueBelief, sueHope, MentalState.merge,
+    mergeCompartments, MentalState.flatten, DRS.accScope]
 
 /-- After binding, the presupposed cheating referent `e'` (21) no longer occurs:
 it has been identified with the believed event `e` (20), so the presupposition is
 resolved by binding (filtered), not accommodated or projected (Maier's (60)). -/
 theorem presup_resolved_after_binding :
-    21 ∉ DRS.occ sueBound.flatten ∧ 20 ∈ DRS.occ sueBound.flatten := by decide
+    21 ∉ DRS.occ sueBound.flatten ∧ 20 ∈ DRS.occ sueBound.flatten := by
+  simp [sueBound, sueMerged, sueBelief, sueHope, MentalState.merge, mergeCompartments,
+    MentalState.bind, MentalState.flatten, Condition.map]
+  decide
 
 end Maier2015

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -14939,6 +14939,32 @@
   role      = {foundational},
   sources   = {Semantics/Dynamic/Core/DynamicTy2.lean;Semantics/Dynamic/Core/Translation.lean}
 }
+
+@phdthesis{liu-2021,
+  author    = {Liu, Jiangming},
+  year      = {2021},
+  title     = {Understanding and Generating Language with Discourse Representation Structures},
+  school    = {University of Edinburgh},
+  subfield  = {semantics/dynamic},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Dynamic/DRS/Box.lean}
+}
+
+@article{venhuizen-bos-hendriks-brouwer-2018,
+  author    = {Venhuizen, Noortje J. and Bos, Johan and Hendriks, Petra and Brouwer, Harm},
+  year      = {2018},
+  title     = {Discourse Semantics with Information Structure},
+  journal   = {Journal of Semantics},
+  volume    = {35},
+  number    = {1},
+  pages     = {127--169},
+  doi       = {10.1093/jos/ffx017},
+  subfield  = {semantics/dynamic},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Dynamic/DRS/Box.lean}
+}
 @inproceedings{bumford-rett-2021,
   author    = {Bumford, Dylan and Rett, Jessica},
   year      = {2021},


### PR DESCRIPTION
With `Condition` a plain nested inductive, the renaming section catches up: `Condition.map` becomes a single wf definition with a direct `List.map` recursive call (the wf-preprocessor threads membership through it), `DRS.map` a non-recursive wrapper, and `mapList`/`mapList_id`/`mapList_eq_map` are deleted with `conditions_map` now stating `List.map` directly. The section header's "functorial" claim is finally cashed both ways: `map_id` joined by the previously missing composition law `map_map` (condition and DRS levels).