### PR TITLE
refactor(Pragmatics/RSA): re-adopt prefixMeaning; drop dead NoisyLex

### DIFF
--- a/Linglib/Pragmatics/RSA/Channel.lean
+++ b/Linglib/Pragmatics/RSA/Channel.lean
@@ -52,9 +52,9 @@ The `noiseChannel` operation is the per-feature primitive consumed by
 reliability parameters, so there is no canonical `NoisySemantics` instance
 per `(U, W)` pair — each study constructs its own bundle:
 
-- Product-of-Experts noisy semantics (`WaldonDegen2021.NoisyLex` in
-  `Studies/WaldonDegen2021.lean`; [degen-etal-2020], [waldon-degen-2021]).
-  PoE prefix product via `RSA.prefixMeaning` (`Sequential.lean`).
+- Multiplicative continuous semantics ([degen-etal-2020],
+  [waldon-degen-2021]): per-word channel values composed by
+  `RSA.prefixMeaning` (`Sequential.lean`); see `Studies/WaldonDegen2021.lean`.
 - Extension-counting Boolean semantics
   (`CohnGordonEtAl2019.IncrementalSemantics` in
   `Studies/CohnGordonEtAl2019.lean`; [cohn-gordon-goodman-potts-2019]).

--- a/Linglib/Pragmatics/RSA/Sequential.lean
+++ b/Linglib/Pragmatics/RSA/Sequential.lean
@@ -1,36 +1,31 @@
 import Mathlib.Algebra.BigOperators.Group.List.Basic
 import Mathlib.Algebra.Order.BigOperators.GroupWithZero.List
-import Mathlib.Algebra.Order.Field.Rat
 
 /-!
-# Sequential RSA: prefix-meaning composition
+# Prefix meaning in sequential RSA
 
-[degen-etal-2020] [waldon-degen-2021]
-
-The Product-of-Experts (PoE) prefix meaning underlying noisy RSA models:
-a per-word lex function `lex : U → W → R` is composed multiplicatively
-over a list of tokens. Consumed by [waldon-degen-2021]'s `NoisyLex`
-bundle (in `Studies/WaldonDegen2021.lean`).
-
-## Generality
-
-`prefixMeaning` is polymorphic over any `[CommMonoid R]`. The default
-arithmetic instance is ℚ for computable studies, but the same operator
-applies over ℝ (proof studies) or PMF-valued semantics (future mathlib-PMF
-migration, see MEMORY.md). Order-related lemmas (`prefixMeaning_nonneg`,
-`_pos`) require the additional structure that ℚ and ℝ both provide.
+Sequential RSA models with continuous semantics interpret a token sequence by
+multiplying per-word lexical values: [degen-etal-2020]'s continuous lexical
+interpretation assigns each word a value in `[0, 1]`, and [waldon-degen-2021]
+scores an utterance as the product of those values over its words.
+`prefixMeaning` is this composition for a per-word lex function
+`lex : U → W → R`, stated over any `CommMonoid R` so that both the ℚ-valued
+chain of [waldon-degen-2021] and the ℚ≥0-valued chain of
+[schlotterbeck-wang-2023] instantiate it. `prefixMeaning_perm` — the composed
+meaning is independent of token order — is the listener-level sanity check of
+[schlotterbeck-wang-2023].
 -/
 
 namespace RSA
 
-variable {U W : Type} {R : Type*}
+variable {U W R : Type*}
 
 section CommMonoid
 
 variable [CommMonoid R]
 
-/-- Prefix-meaning: the per-word lex composed multiplicatively over a list.
-    Generic over any commutative monoid `R`. -/
+/-- Prefix meaning: the per-word lex composed multiplicatively over a list,
+`prefixMeaning lex pfx w = (pfx.map (lex · w)).prod`. -/
 def prefixMeaning (lex : U → W → R) (pfx : List U) (w : W) : R :=
   (pfx.map (lex · w)).prod
 
@@ -42,52 +37,11 @@ def prefixMeaning (lex : U → W → R) (pfx : List U) (w : W) : R :=
     prefixMeaning lex (u :: pfx) w = lex u w * prefixMeaning lex pfx w := by
   simp [prefixMeaning]
 
-theorem prefixMeaning_append (lex : U → W → R) (pfx₁ pfx₂ : List U) (w : W) :
-    prefixMeaning lex (pfx₁ ++ pfx₂) w =
-      prefixMeaning lex pfx₁ w * prefixMeaning lex pfx₂ w := by
-  simp [prefixMeaning, List.prod_append]
-
-theorem prefixMeaning_singleton (lex : U → W → R) (u : U) (w : W) :
-    prefixMeaning lex [u] w = lex u w := by
-  simp [prefixMeaning]
-
-/-- **Order-independence of prefix-meaning.** Any permutation of the prefix
-    yields the same product — the headline structural fact behind the noisy
-    sequential RSA "swap" theorems. -/
+/-- Any permutation of the prefix yields the same meaning. -/
 theorem prefixMeaning_perm {lex : U → W → R} {pfx pfx' : List U}
     (h : pfx.Perm pfx') (w : W) :
     prefixMeaning lex pfx w = prefixMeaning lex pfx' w :=
   (h.map _).prod_eq
-
-/-- Two-element swap — canonical instance of `prefixMeaning_perm`. -/
-theorem prefixMeaning_swap (lex : U → W → R) (a b : U) (w : W) :
-    prefixMeaning lex [a, b] w = prefixMeaning lex [b, a] w :=
-  prefixMeaning_perm (List.Perm.swap b a []) w
-
-/-- Swap the first two elements of a prefix (any tail). Generalized
-    head-swap for n-element prefixes. -/
-theorem prefixMeaning_swap_head (lex : U → W → R) (a b : U) (rest : List U)
-    (w : W) :
-    prefixMeaning lex (a :: b :: rest) w =
-    prefixMeaning lex (b :: a :: rest) w :=
-  prefixMeaning_perm (List.Perm.swap b a rest) w
-
-/-- **Foldl-prod bridge.** `prefixMeaning` agrees with the imperative
-    `foldl (· * lex ·)` form, generalized over any starting accumulator.
-    Polymorphic version of the W&D study-file helper. -/
-theorem foldl_mul_lex_eq_acc_mul_prefixMeaning (lex : U → W → R)
-    (w : W) : ∀ (acc : R) (pfx : List U),
-      pfx.foldl (fun a u => a * lex u w) acc = acc * prefixMeaning lex pfx w
-  | acc, [] => by simp
-  | acc, u :: us => by
-    simp only [List.foldl, prefixMeaning_cons]
-    rw [foldl_mul_lex_eq_acc_mul_prefixMeaning lex w (acc * lex u w) us, mul_assoc]
-
-/-- The PoE prefix product, expressed as a `foldl` from the unit
-    accumulator. The form W&D and S&W's original code used. -/
-theorem prefixMeaning_eq_foldl_mul (lex : U → W → R) (pfx : List U) (w : W) :
-    prefixMeaning lex pfx w = pfx.foldl (fun a u => a * lex u w) 1 := by
-  rw [foldl_mul_lex_eq_acc_mul_prefixMeaning lex w 1 pfx, one_mul]
 
 end CommMonoid
 
@@ -97,17 +51,8 @@ variable [CommMonoidWithZero R] [PartialOrder R] [ZeroLEOneClass R]
 
 theorem prefixMeaning_nonneg [PosMulMono R] {lex : U → W → R}
     (h : ∀ u w, 0 ≤ lex u w) (pfx : List U) (w : W) :
-    0 ≤ prefixMeaning lex pfx w := by
-  induction pfx with
-  | nil => exact zero_le_one
-  | cons u us ih => rw [prefixMeaning_cons]; exact mul_nonneg (h u w) ih
-
-theorem prefixMeaning_pos [PosMulStrictMono R] [NeZero (1 : R)]
-    {lex : U → W → R} (h : ∀ u w, 0 < lex u w) (pfx : List U) (w : W) :
-    0 < prefixMeaning lex pfx w := by
-  induction pfx with
-  | nil => exact zero_lt_one
-  | cons u us ih => rw [prefixMeaning_cons]; exact mul_pos (h u w) ih
+    0 ≤ prefixMeaning lex pfx w :=
+  List.prod_nonneg (List.forall_mem_map.2 fun u _ => h u w)
 
 end Order
 

--- a/Linglib/Studies/DegenEtAl2020.lean
+++ b/Linglib/Studies/DegenEtAl2020.lean
@@ -12,8 +12,8 @@ Standard RSA with a Boolean semantics predicts no preference for overmodified
 referring expressions — if "small" already identifies the target, adding "blue"
 is literally uninformative. Yet speakers routinely overmodify, more with color
 than with size. [degen-etal-2020] resolve this by relaxing the semantics to a
-**continuous** meaning `φ(u, o) ∈ [0,1]` (a Product-of-Experts over noisy feature
-channels): redundant modifiers then carry real information, and the color/size
+**continuous** meaning `φ(u, o) ∈ [0,1]` (per-word noise channels multiplied over
+the utterance): redundant modifiers then carry real information, and the color/size
 *asymmetry* follows from color channels being less noisy than size channels.
 
 The model is the mathlib-`PMF` RSA pipeline (`RSA.L0OfMeaning` / `RSA.S1Belief`,
@@ -80,8 +80,8 @@ private theorem sumW (f : World → ℝ≥0∞) :
   rw [tsum_fintype, show (Finset.univ : Finset World) = {.bigBlue, .bigRed, .smallBlue} from rfl,
     Finset.sum_insert (by decide), Finset.sum_insert (by decide), Finset.sum_singleton, add_assoc]
 
-/-- Continuous meaning `φ(u, o) ∈ ℝ≥0∞` via a Product of Experts: a single
-    adjective is its noise channel, a pair the product of its two channels. -/
+/-- Continuous meaning `φ(u, o) ∈ ℝ≥0∞`: a single adjective is its noise
+    channel, a pair the product of its two channels. -/
 noncomputable def φ : Utterance → World → ℝ≥0∞
   | .big, .bigBlue => .ofReal sM | .big, .bigRed => .ofReal sM | .big, .smallBlue => .ofReal sm
   | .small, .bigBlue => .ofReal sm | .small, .bigRed => .ofReal sm | .small, .smallBlue => .ofReal sM
@@ -121,7 +121,7 @@ theorem L0_small_target : L0 .small target = ENNReal.ofReal (2/3) := by
       ← div_eq_mul_inv, ← ENNReal.ofReal_div_of_pos (by norm_num)]
   congr 1; norm_num
 
-/-- L0(target | "small blue") = 99/124 — the redundant colour sharpens via PoE. -/
+/-- L0(target | "small blue") = 99/124 — the redundant colour sharpens the channel product. -/
 theorem L0_smallBlue_target : L0 .smallBlue target = ENNReal.ofReal (99/124) := by
   rw [L0, L0OfMeaning_apply, sumW]
   simp only [φ, noiseR.1, noiseR.2.1, noiseR.2.2.1, noiseR.2.2.2]

--- a/Linglib/Studies/SchlotterbeckWang2023.lean
+++ b/Linglib/Studies/SchlotterbeckWang2023.lean
@@ -1,5 +1,6 @@
 import Linglib.Core.Probability.Scores
 import Linglib.Pragmatics.RSA.Channel
+import Linglib.Pragmatics.RSA.Sequential
 
 /-!
 # [schlotterbeck-wang-2023] — incremental RSA for adjective ordering
@@ -8,8 +9,8 @@ import Linglib.Pragmatics.RSA.Channel
 Schlotterbeck, F. & Wang, H. (2023). An incremental RSA model for adjective
 ordering preferences in referential visual context. *SCiL* 6, 121–132.
 
-**Scope.** This file formalizes the *symmetric-PoE sanity-check slice* of
-the paper, not its main asymmetric model: the order-independence of the
+**Scope.** This file formalizes the *symmetric-semantics sanity-check slice*
+of the paper, not its main asymmetric model: the order-independence of the
 incremental listener under symmetric per-class semantics, plus
 discrimination-driven ordering preferences at the speaker level as
 chain-rule trajectory products (per-step normalized; the paper's `S1^inc`
@@ -21,8 +22,8 @@ reported simulations, matching the exponent-free chain here.
 
 ## Main results
 
-* `meaning_perm`: the PoE prefix meaning is order-independent, for every
-  lexicon — the paper's listener-level sanity check.
+* Order-independence of the prefix meaning — the paper's listener-level
+  sanity check — is the substrate lemma `RSA.prefixMeaning_perm`.
 * `size_first_when_size_discriminates` / `color_first_when_color_reliable`:
   the trajectory preference tracks discriminatory power (Scene A) and
   flips to the more reliable dimension under equal discrimination
@@ -37,7 +38,7 @@ reported simulations, matching the exponent-free chain here.
 The chain is exact ℚ≥0: `lex` is the Bernoulli-channel form of
 [degen-etal-2020]'s continuous semantics (reliability if the word truly
 applies, the complementary noise floor otherwise), prefix meanings are
-`List` products, `l0Score`/`s1Score` normalize via `PMF.normalizeScores`,
+`RSA.prefixMeaning` products, `l0Score`/`s1Score` normalize via `PMF.normalizeScores`,
 and the PMF speaker is `PMF.ofScores`. Trajectories are `Fin`-indexed
 products of speaker values, so ordering predictions close by
 `PMF.prod_ofScores_lt` with one kernel certificate each.
@@ -46,6 +47,8 @@ products of speaker values, so ordering predictions close by
 open scoped ENNReal NNRat
 
 namespace SchlotterbeckWang2023
+
+open RSA
 
 /-- Referents in the reference game. -/
 inductive Referent where
@@ -84,16 +87,6 @@ complementary noise floor otherwise — the Bernoulli-channel form of
 def lex (sRel cRel : ℚ≥0) (w : Word) (r : Referent) : ℚ≥0 :=
   if wordApplies w r then rel sRel cRel w else 1 - rel sRel cRel w
 
-/-- PoE prefix meaning: the product of per-word noisy meanings. -/
-def meaning (lex : Word → Referent → ℚ≥0) (us : List Word) (r : Referent) : ℚ≥0 :=
-  (us.map (lex · r)).prod
-
-/-- The listener-level sanity check: the PoE prefix meaning is
-order-independent, for every lexicon and reliability setting. -/
-theorem meaning_perm (lex : Word → Referent → ℚ≥0) {us vs : List Word}
-    (h : us.Perm vs) (r : Referent) : meaning lex us r = meaning lex vs r :=
-  (h.map (lex · r)).prod_eq
-
 /-! ### Scenes -/
 
 /-- Scene A: size discriminates. Objects {big-blue, small-blue,
@@ -122,7 +115,7 @@ def lexB : Word → Referent → ℚ≥0 := lex (80/100) (95/100)
 /-- Literal listener over scene referents at each prefix extension. -/
 def l0Score (lex : Word → Referent → ℚ≥0) (scene : Referent → Bool)
     (ctx : List Word) (u : Word) : Referent → ℚ≥0 :=
-  PMF.normalizeScores fun r => if scene r then meaning lex (ctx ++ [u]) r else 0
+  PMF.normalizeScores fun r => if scene r then prefixMeaning lex (ctx ++ [u]) r else 0
 
 /-- Word-level speaker (β = 1, no cost): renormalized literal posteriors. -/
 def s1Score (lex : Word → Referent → ℚ≥0) (scene : Referent → Bool)
@@ -195,7 +188,7 @@ theorem blue_more_informative_B :
 Scene A members. -/
 theorem both_orderings_identify_target_A (r : Referent)
     (hr : sceneA r = true) (hne : r ≠ target) :
-    meaning lexA [.big, .blue] r < meaning lexA [.big, .blue] target := by
+    prefixMeaning lexA [.big, .blue] r < prefixMeaning lexA [.big, .blue] target := by
   cases r
   · exact absurd rfl hne
   all_goals first | exact absurd hr (by decide) | decide +kernel
@@ -204,7 +197,7 @@ theorem both_orderings_identify_target_A (r : Referent)
 Scene B members. -/
 theorem both_orderings_identify_target_B (r : Referent)
     (hr : sceneB r = true) (hne : r ≠ target) :
-    meaning lexB [.big, .blue] r < meaning lexB [.big, .blue] target := by
+    prefixMeaning lexB [.big, .blue] r < prefixMeaning lexB [.big, .blue] target := by
   cases r
   · exact absurd rfl hne
   all_goals first | exact absurd hr (by decide) | decide +kernel

--- a/Linglib/Studies/WaldonDegen2021.lean
+++ b/Linglib/Studies/WaldonDegen2021.lean
@@ -56,9 +56,9 @@ different (language × scene) configurations of the same chain.
   `RSA.Channel`. See `lexContinuous_as_noiseChannel`.
 - **Incremental RSA**: Extends [cohn-gordon-goodman-potts-2019] with
   continuous semantics and cross-linguistic word order variation.
-- **PoE bundle**: `noisyLex` packages `lexContinuousQ` as a
-  `NoisyLex` (Product-of-Experts) bundle; the multiplicative prefix
-  meaning delegates to `RSA.prefixMeaning` (from `Sequential`).
+- **Sequential substrate**: `uttContinuousQ` is defined via
+  `RSA.prefixMeaning` (`Sequential.lean`), sharing the multiplicative
+  composition with [schlotterbeck-wang-2023] by construction.
 -/
 
 namespace WaldonDegen2021
@@ -110,9 +110,20 @@ def semanticValueQ : Word → ℚ
 def lexContinuousQ (r : Referent) (w : Word) : ℚ :=
   if wordApplies w r then semanticValueQ w else 1 - semanticValueQ w
 
-/-- Continuous utterance meaning ⟦u⟧^C(r) = ∏_{w ∈ u} L^C(r, w). -/
+/-- Continuous utterance meaning ⟦u⟧^C(r) = ∏_{w ∈ u} L^C(r, w), the
+    `RSA.prefixMeaning` of the continuous lexicon. -/
 def uttContinuousQ (r : Referent) (u : List Word) : ℚ :=
-  u.foldl (fun acc w => acc * lexContinuousQ r w) 1
+  prefixMeaning (fun w r' => lexContinuousQ r' w) u r
+
+private theorem lexContinuousQ_nonneg (r : Referent) (w : Word) :
+    0 ≤ lexContinuousQ r w := by
+  cases w <;> cases r <;>
+    (unfold lexContinuousQ; simp only [wordApplies, semanticValueQ];
+     split_ifs <;> norm_num)
+
+private theorem uttContinuousQ_nonneg (r : Referent) (u : List Word) :
+    0 ≤ uttContinuousQ r u :=
+  prefixMeaning_nonneg (fun w r' => lexContinuousQ_nonneg r' w) u r
 
 /-! ### Utterances (Scene-Filtered) -/
 
@@ -166,7 +177,7 @@ def continuousMeaningQ (utts : List (List Word)) (scene : Referent → Bool)
     (pfx : List Word) (r : Referent) : ℚ :=
   let exts := (sceneFilter utts scene).filter (pfx.isPrefixOf)
   if exts.isEmpty then 0
-  else exts.foldl (fun acc u => acc + uttContinuousQ r u) 0 / exts.length
+  else (exts.map (uttContinuousQ r)).sum / exts.length
 
 private theorem continuousMeaningQ_nonneg (utts : List (List Word))
     (scene : Referent → Bool) (pfx : List Word) (r : Referent) :
@@ -175,28 +186,11 @@ private theorem continuousMeaningQ_nonneg (utts : List (List Word))
   simp only
   split
   · exact le_refl _
-  · apply div_nonneg
-    · suffices ∀ (l : List (List Word)) (init : ℚ), 0 ≤ init →
-          0 ≤ l.foldl (fun acc u => acc + uttContinuousQ r u) init by
-        exact this _ 0 (le_refl _)
-      intro l; induction l with
-      | nil => intro init h; exact h
-      | cons u us ih =>
-        intro init hinit; simp only [List.foldl]
-        apply ih
-        apply add_nonneg hinit
-        unfold uttContinuousQ
-        suffices ∀ (l : List Word) (init : ℚ), 0 ≤ init →
-            0 ≤ l.foldl (fun acc w => acc * lexContinuousQ r w) init by
-          exact this _ 1 one_pos.le
-        intro l2; induction l2 with
-        | nil => intro init h; exact h
-        | cons w ws ih2 =>
-          intro init hinit; simp only [List.foldl]
-          exact ih2 _ (mul_nonneg hinit (by
-            cases r <;> cases w <;>
-              simp [lexContinuousQ, wordApplies, semanticValueQ] <;> norm_num))
-    · exact Nat.cast_nonneg _
+  · exact div_nonneg
+      (List.sum_nonneg fun x hx => by
+        obtain ⟨u, -, rfl⟩ := List.mem_map.1 hx
+        exact uttContinuousQ_nonneg r u)
+      (Nat.cast_nonneg _)
 
 /-! ### Scenes -/
 
@@ -612,64 +606,7 @@ theorem semantic_values_positive :
     ∀ w : Word, semanticValueQ w > 0 := by
   intro w; cases w <;> norm_num [semanticValueQ]
 
-/-! ### `NoisyLex` bundle
-
-A `NoisyLex U W` packages the per-(token, world) lex function underlying
-Product-of-Experts noisy semantics ([degen-etal-2020], [waldon-degen-2021]).
-`prefixMeaning` composes `lex` multiplicatively over a prefix, delegating to
-the polymorphic `RSA.prefixMeaning` from `Sequential.lean`. -/
-
-/-- Bundle of noisy lexical semantics: a per-(token, world) ℚ-valued score
-    that is non-negative everywhere. The `lex` field is the "Product of
-    Experts" per-word factor underlying [degen-etal-2020] and
-    [waldon-degen-2021]. -/
-structure NoisyLex (U W : Type) where
-  /-- Per-(token, world) noisy meaning value. -/
-  lex : U → W → ℚ
-  /-- Noisy meaning is non-negative. -/
-  lex_nonneg : ∀ u w, 0 ≤ lex u w
-
-namespace NoisyLex
-
-variable {U W : Type}
-
-/-- The PoE prefix meaning derived from the lex function — multiplicative
-    composition over a list of tokens. Delegates to `RSA.prefixMeaning`. -/
-def prefixMeaning (s : NoisyLex U W) (pfx : List U) (w : W) : ℚ :=
-  RSA.prefixMeaning s.lex pfx w
-
-theorem prefixMeaning_nonneg (s : NoisyLex U W) (pfx : List U) (w : W) :
-    0 ≤ s.prefixMeaning pfx w :=
-  RSA.prefixMeaning_nonneg s.lex_nonneg pfx w
-
-theorem prefixMeaning_perm (s : NoisyLex U W) {pfx pfx' : List U}
-    (h : pfx.Perm pfx') (w : W) :
-    s.prefixMeaning pfx w = s.prefixMeaning pfx' w :=
-  RSA.prefixMeaning_perm h w
-
-/-- Standard noisy-lex construction: pick a "true" reliability `r⁺` and
-    a noise floor `r⁻` (typically `1 - r⁺`), and let `lex u w = r⁺` when
-    `applies u w` and `r⁻` otherwise. Bernoulli-channel form:
-    `lex = RSA.Noise.noiseChannel r⁺ r⁻ (applies? 1 0)`. -/
-def ofChannel (applies : U → W → Bool) (rPlus rMinus : ℚ)
-    (h0 : 0 ≤ rMinus) (h1 : rMinus ≤ rPlus) : NoisyLex U W where
-  lex u w := if applies u w then rPlus else rMinus
-  lex_nonneg u w := by
-    by_cases h : applies u w
-    · simp [h]; linarith
-    · simp [h, h0]
-
-/-- The `ofChannel` lex agrees with `RSA.Noise.noiseChannel`. -/
-theorem ofChannel_lex_eq_noiseChannel (applies : U → W → Bool)
-    (rPlus rMinus : ℚ) (h0 : 0 ≤ rMinus) (h1 : rMinus ≤ rPlus) (u : U) (w : W) :
-    (ofChannel applies rPlus rMinus h0 h1).lex u w =
-      RSA.Noise.noiseChannel rPlus rMinus (if applies u w then 1 else 0) := by
-  simp only [ofChannel, RSA.Noise.noiseChannel]
-  by_cases h : applies u w <;> simp [h]
-
-end NoisyLex
-
-/-! ### Noise Theory Connection + Substrate Bridge -/
+/-! ### Noise Theory Connection -/
 
 /-- `lexContinuousQ` is an instance of the `noiseChannel` from
     `RSA.Channel`. The continuous lexical semantics L^C(r, i) is exactly
@@ -684,26 +621,6 @@ theorem lexContinuous_as_noiseChannel (r : Referent) (w : Word) :
       (if wordApplies w r then 1 else 0 : ℚ) := by
   simp only [lexContinuousQ, RSA.Noise.noiseChannel]
   split <;> ring
-
-/-- `lexContinuousQ` packaged as a `NoisyLex` bundle: `lex` and reliability
-    parameters, with the PoE prefix-product machinery
-    (`RSA.prefixMeaning` and friends) reused as-is. -/
-def noisyLex : NoisyLex Word Referent where
-  lex w r := lexContinuousQ r w
-  lex_nonneg w r := by
-    cases w <;> cases r <;>
-      (unfold lexContinuousQ; simp only [wordApplies, semanticValueQ];
-       split_ifs <;> norm_num)
-
-/-- `uttContinuousQ` is the `NoisyLex.prefixMeaning` of the bundled lex
-    (modulo argument order). Uses the polymorphic
-    `RSA.prefixMeaning_eq_foldl_mul` from `Sequential.lean` — no
-    study-local foldl helper needed. -/
-theorem uttContinuousQ_eq_prefixMeaning (r : Referent) (u : List Word) :
-    uttContinuousQ r u = noisyLex.prefixMeaning u r := by
-  unfold uttContinuousQ NoisyLex.prefixMeaning
-  rw [RSA.prefixMeaning_eq_foldl_mul]
-  rfl
 
 /-! ### Prediction 4: Overall Cross-Linguistic Redundancy -/
 


### PR DESCRIPTION
Deep-audit follow-up for `Pragmatics/RSA/Sequential.lean`: the operator had one real consumer, and even that one only decoratively.

- `SchlotterbeckWang2023.meaning` restipulated the operator verbatim; it and `WaldonDegen2021.uttContinuousQ` are now defined via `RSA.prefixMeaning`, and W&D's dead `NoisyLex` bundle + bridge theorem are deleted (nothing downstream consumed them).
- Sequential's order lemmas now derive from `List.prod_nonneg` (same typeclasses) instead of re-proving them; zero-consumer lemmas (`swap`, `swap_head`, `append`, `singleton`, `pos`) and the foldl helper are cut; `Type` → `Type*`; dead ℚ import dropped.
- "Product-of-Experts (PoE)" labeling removed where attributed to Degen et al. 2020 / Waldon & Degen 2021 / Schlotterbeck & Wang 2023 — the term appears in none of the three papers (PDF-verified); docstrings now use the papers' own vocabulary.