### PR TITLE
refactor(Core/Logic/Modal/QBSML): one-sided free-choice engines

### DIFF
--- a/Linglib/Core/Logic/FirstOrder/Binders.lean
+++ b/Linglib/Core/Logic/FirstOrder/Binders.lean
@@ -52,7 +52,7 @@ private theorem realize_relabel_update (n : α) (φ : L.Formula α) (v : α → 
   rw [BoundedFormula.realize_relabel]
   refine iff_of_eq (congrArg₂ (BoundedFormula.Realize φ) ?_ ?_)
   · funext k
-    by_cases hk : k = n <;> simp [hk, toBound, Function.update_apply, Fin.snoc]
+    by_cases hk : k = n <;> simp [hk, toBound, Fin.snoc]
   · funext i
     exact i.elim0
 

--- a/Linglib/Core/Logic/Modal/QBSML/FreeChoice.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/FreeChoice.lean
@@ -15,35 +15,36 @@ under modals license both disjuncts:
 |------|-----------|
 | 3   | `[Pa ∨ Pb]⁺ ⊨_epi ◇Pa ∧ ◇Pb` (ignorance, R state-based) |
 | 5   | `card(s)=1 ⇒ M, s ⊨ [∀x(Px ∨ Qx)]⁺ ⇒ M, s ⊨ ∃xPx ∧ ∃xQx` |
-| 6   | `[∀x(Px ∨ Qx)]⁺ ⊨_epi ∃x◇Px ∧ ∃x◇Qx` (distribution°) |
+| 6   | `[∀x(Px ∨ Qx)]⁺ ⊨_epi ∃x◇Px ∧ ∃x◇Qx` (distribution◇) |
 | 7   | `[□(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` (□-free choice) |
 | 8   | `[◇(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` (◇-free choice) |
 | 9   | `[∀x◇(Px ∨ Qx)]⁺ ⊨ ∀x◇Px ∧ ∀x◇Qx` (universal FC; [chemla-2009]) |
 | 10  | `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb` (negation; ignorance disappears) |
 
 plus the quantified □-FC composite `[□∃x(α ∨ β)]⁺ ⊨ ◇∃xα ∧ ◇∃xβ`
-(`boxExiFC_Q`) behind [yan-2023]'s Asher and Heim solutions. Fact 4
+(`boxExiFC`) behind [yan-2023]'s Asher and Heim solutions. Fact 4
 (obviation) is a countermodel claim and lives with the concrete model in
-`Studies/AloniVanOrmondt2023.lean`, which also instantiates the facts here.
+`Studies/AloniVanOrmondt2023.lean`, which instantiates the frame-free facts
+(5, 7–10) there; the epistemic Facts 3 and 6 require a state-based `R` and
+stay substrate-level.
 
 ## Main declarations
 
 * `diamond_split` — the shared core: an enriched split disjunction
   supported on a modal pairing yields a non-empty world-set witness for
   each disjunct.
-* `narrowScopeFC_Q`, `boxFC_Q`, `universalFC_Q` — the free-choice facts.
-* `boxExiFC_Q` — quantified □-FC ([yan-2023] §4.4.3).
-* `ignorance_Q`, `distribution_Q`, `distributionEpi_Q`, `negationStrip_Q`.
+* `narrowScopeFC`, `boxFC`, `universalFC` — the free-choice facts.
+* `boxExiFC` — quantified □-FC ([yan-2023] §4.4.3).
+* `ignorance`, `distribution`, `distributionEpi`, `negationStrip`.
 
-## Proof architecture
+## Implementation notes
 
 1. **Enrichment strengthens** (`enrichment_strengthens_support`,
    `Core/Logic/Modal/QBSML/Enrichment.lean`): the enriched form entails
    the original on the NE-free fragment.
 2. **Diamond split** (`diamond_split`): the split `t₁ ∪ t₂ = modalLift X g`
-   supports the enriched disjuncts on its pieces;
-   `State.modalLift_worldProj_of_subset` recovers each piece from its world
-   projection, which serves as the `Finset W` witness.
+   supports the enriched disjuncts on its pieces; each piece is recovered
+   from its world projection, which serves as the `Finset W` witness.
 3. **NE strips**: `support_enrich_nec_iff` peels the derived `□`'s
    enrichment; `antiSupport_strip_ne` the remaining `NE` conjuncts.
 4. **Witness reconstruction** (`support_exi_of_update_closure`,
@@ -64,55 +65,50 @@ open Core.Logic.Team
 variable {W Var Domain Const Pred : Type*}
 variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
+variable (M : QBSMLModel W Domain Const Pred)
+variable {α β : QBSMLFormula Var Const Pred} {s : Finset (Index W Var Domain)}
 
 /-! ### The diamond split -/
 
+/-- A subset of a modal pairing supporting an enriched formula yields a
+    non-empty world-set witness: project the worlds, pair them back with the
+    same assignment (`State.modalLift_worldProj_of_subset`), and discharge
+    the enrichment (`enrichment_strengthens_support`). One-sided engine of
+    `diamond_split`. -/
+private theorem poss_of_subset_modalLift {X : Finset W}
+    {g : Assignment Var Domain} {t : Finset (Index W Var Domain)}
+    (hα : α.IsNEFree) (ht : t ⊆ State.modalLift X g)
+    (h : support M α.enrich t) :
+    ∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g) :=
+  ⟨State.worldProj t, State.worldProj_subset_of_subset_modalLift ht,
+    State.worldProj_nonempty (enriched_support_implies_nonempty M α t h),
+    (State.modalLift_worldProj_of_subset ht).symm ▸
+      enrichment_strengthens_support M α t hα h⟩
+
 /-- The shared core of the free-choice facts: an enriched split disjunction
     supported on a modal pairing yields a non-empty world-set witness for
-    each disjunct. The split `t₁ ∪ t₂ = modalLift X g` supports the enriched
-    disjuncts on its pieces; `State.modalLift_worldProj_of_subset` recovers
-    each piece from its world projection, which serves as the `Finset W`
-    witness, and `enrichment_strengthens_support` discharges the enrichment
-    to plain support of α, β. -/
-theorem diamond_split (M : QBSMLModel W Domain Const Pred)
-    {α β : QBSMLFormula Var Const Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    {X : Finset W} {g : Assignment Var Domain}
+    each disjunct — `poss_of_subset_modalLift` on each half of the split. -/
+theorem diamond_split {X : Finset W} {g : Assignment Var Domain}
+    (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (hsupp : support M (QBSMLFormula.disj α β).enrich (State.modalLift X g)) :
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g)) ∧
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M β (State.modalLift Y g)) := by
-  obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := hsupp.1
-  constructor
-  · have ht₁_sub : t₁ ⊆ State.modalLift X g :=
-      hunion ▸ Finset.subset_union_left
-    refine ⟨State.worldProj t₁,
-      State.worldProj_subset_of_subset_modalLift ht₁_sub,
-      State.worldProj_nonempty (enriched_support_implies_nonempty M α t₁ h₁),
-      ?_⟩
-    rw [State.modalLift_worldProj_of_subset ht₁_sub]
-    exact enrichment_strengthens_support M α t₁ hα h₁
-  · have ht₂_sub : t₂ ⊆ State.modalLift X g :=
-      hunion ▸ Finset.subset_union_right
-    refine ⟨State.worldProj t₂,
-      State.worldProj_subset_of_subset_modalLift ht₂_sub,
-      State.worldProj_nonempty (enriched_support_implies_nonempty M β t₂ h₂),
-      ?_⟩
-    rw [State.modalLift_worldProj_of_subset ht₂_sub]
-    exact enrichment_strengthens_support M β t₂ hβ h₂
+  obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := hsupp.1
+  exact ⟨poss_of_subset_modalLift M hα (splitsAs_left_subset hsplit) h₁,
+    poss_of_subset_modalLift M hβ (splitsAs_right_subset hsplit) h₂⟩
 
 /-- Per-index form of the core: a state whose every index sees an enriched
     split disjunction supports both diamonds (shared by Facts 8 and 9). -/
-theorem possFC_on (M : QBSMLModel W Domain Const Pred)
-    {α β : QBSMLFormula Var Const Pred} (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    {t : Finset (Index W Var Domain)}
-    (h : support M (.poss (QBSMLFormula.disj α β).enrich) t) :
-    support M (.poss α) t ∧ support M (.poss β) t := by
+private theorem possFC_on (hα : α.IsNEFree) (hβ : β.IsNEFree)
+    (h : support M (.poss (QBSMLFormula.disj α β).enrich) s) :
+    support M (.poss α) s ∧ support M (.poss β) s := by
   refine ⟨fun i hi => ?_, fun i hi => ?_⟩
-  · obtain ⟨X, hX, _, hsupp⟩ := h i hi
-    obtain ⟨⟨Y, hYX, hYne, hY⟩, -⟩ := diamond_split M hα hβ hsupp
-    exact ⟨Y, hYX.trans hX, hYne, hY⟩
-  · obtain ⟨X, hX, _, hsupp⟩ := h i hi
-    obtain ⟨-, ⟨Y, hYX, hYne, hY⟩⟩ := diamond_split M hα hβ hsupp
-    exact ⟨Y, hYX.trans hX, hYne, hY⟩
+  · obtain ⟨X, hX, -, hsupp⟩ := h i hi
+    exact (diamond_split M hα hβ hsupp).1.imp
+      fun Y ⟨hYX, hYne, hY⟩ => ⟨hYX.trans hX, hYne, hY⟩
+  · obtain ⟨X, hX, -, hsupp⟩ := h i hi
+    exact (diamond_split M hα hβ hsupp).2.imp
+      fun Y ⟨hYX, hYne, hY⟩ => ⟨hYX.trans hX, hYne, hY⟩
 
 /-! ### Free choice (Facts 7, 8 and 9) -/
 
@@ -123,9 +119,7 @@ theorem possFC_on (M : QBSMLModel W Domain Const Pred)
 
     Projects the diamond clause of the enrichment and applies the per-index
     core `possFC_on` at `s`. -/
-theorem narrowScopeFC_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem narrowScopeFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.poss (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s :=
   possFC_on M hα hβ h.1
@@ -138,9 +132,7 @@ theorem narrowScopeFC_Q (M : QBSMLModel W Domain Const Pred)
     The enriched premise evaluates the enriched diamond at the universal
     extension `s[x]`, so the conclusion is `possFC_on` at `s[x]` — the same
     per-index argument as Fact 8, one extension up. -/
-theorem universalFC_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (x : Var) (s : Finset (Index W Var Domain))
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem universalFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.univ x (.poss (.disj α β)))) s) :
     support M (.univ x (.poss α)) s ∧ support M (.univ x (.poss β)) s :=
   possFC_on M hα hβ h.1.1
@@ -155,17 +147,12 @@ theorem universalFC_Q (M : QBSMLModel W Domain Const Pred)
     `support_enrich_nec_iff` puts the enriched disjunction on each index's
     full accessible lift `R(wᵢ)[gᵢ]`, and `diamond_split` produces the
     witnesses. -/
-theorem boxFC_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem boxFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (QBSMLFormula.nec (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   rw [support_enrich_nec_iff] at h
-  refine ⟨fun i hi => ?_, fun i hi => ?_⟩
-  · obtain ⟨⟨Y, hYX, hYne, hY⟩, -⟩ := diamond_split M hα hβ (h.1 i hi)
-    exact ⟨Y, hYX, hYne, hY⟩
-  · obtain ⟨-, ⟨Y, hYX, hYne, hY⟩⟩ := diamond_split M hα hβ (h.1 i hi)
-    exact ⟨Y, hYX, hYne, hY⟩
+  exact ⟨fun i hi => (diamond_split M hα hβ (h.1 i hi)).1,
+    fun i hi => (diamond_split M hα hβ (h.1 i hi)).2⟩
 
 /-! ### Quantified □-free choice
 
@@ -177,9 +164,8 @@ solutions invoke (its §4.4.3; see `Studies/Yan2023.lean`). -/
     supports `γ` yields a `◇∃xγ`-witness: project `t`'s worlds, pair them
     back with the original assignment, and reconstruct `t` via
     `support_exi_of_update_closure`. The quantified analogue of
-    `diamond_split`'s witness recovery. -/
+    `poss_of_subset_modalLift`. -/
 private theorem poss_exi_of_subset_extendFunctional
-    (M : QBSMLModel W Domain Const Pred)
     {γ : QBSMLFormula Var Const Pred} {X₀ : Finset W}
     {g : Assignment Var Domain} {x : Var}
     {hf : Index W Var Domain → Finset Domain}
@@ -220,23 +206,20 @@ private theorem poss_exi_of_subset_extendFunctional
     each index's full accessible lift's functional extension; each
     non-empty half yields a `◇∃x`-witness by
     `poss_exi_of_subset_extendFunctional`. -/
-theorem boxExiFC_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (x : Var)
-    (s : Finset (Index W Var Domain))
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem boxExiFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M
       (QBSMLFormula.enrich (QBSMLFormula.nec (.exi x (.disj α β)))) s) :
     support M (.poss (.exi x α)) s ∧ support M (.poss (.exi x β)) s := by
   rw [support_enrich_nec_iff] at h
   refine ⟨fun i hi => ?_, fun i hi => ?_⟩
   · obtain ⟨hf, -, hD⟩ := (h.1 i hi).1
-    obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := hD.1
+    obtain ⟨t₁, t₂, hsplit, h₁, -⟩ := hD.1
     exact poss_exi_of_subset_extendFunctional M
       (splitsAs_left_subset hsplit)
       (enriched_support_implies_nonempty M α t₁ h₁)
       (enrichment_strengthens_support M α t₁ hα h₁)
   · obtain ⟨hf, -, hD⟩ := (h.1 i hi).1
-    obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := hD.1
+    obtain ⟨t₁, t₂, hsplit, -, h₂⟩ := hD.1
     exact poss_exi_of_subset_extendFunctional M
       (splitsAs_right_subset hsplit)
       (enriched_support_implies_nonempty M β t₂ h₂)
@@ -244,46 +227,43 @@ theorem boxExiFC_Q (M : QBSMLModel W Domain Const Pred)
 
 /-! ### Ignorance (Fact 3) -/
 
+/-- A non-empty substate supporting a constant atom yields the diamond on
+    the whole state when `R` is state-based: transplant the substate's
+    worlds to every index. Sound only because constant atoms are
+    *assignment-invariant*. One-sided engine of `ignorance`. -/
+private theorem poss_predc_of_stateBased {P : Pred} {c : Const}
+    {t : Finset (Index W Var Domain)} (hSB : M.IsStateBased s) (hts : t ⊆ s)
+    (htne : t.Nonempty) (h : support M (.predc P c) t) :
+    support M (.poss (.predc P c)) s := by
+  intro i hi
+  refine ⟨State.worldProj t, ?_, State.worldProj_nonempty htne, ?_⟩
+  · rw [hSB i.world (State.mem_worldProj.mpr ⟨i, hi, rfl⟩)]
+    exact State.worldProj_mono hts
+  · intro k hk
+    obtain ⟨hkw, -⟩ := State.mem_modalLift.mp hk
+    obtain ⟨j, hj, hjw⟩ := State.mem_worldProj.mp hkw
+    rw [← hjw]
+    exact h j hj
+
 /-- **Fact 3 (ignorance)** of [aloni-vanormondt-2023]: on epistemic models
     (state-based `R`),
 
     `[Pc₁ ∨ Qc₂]⁺ ⊨_epi ◇Pc₁ ∧ ◇Qc₂`.
 
-    Stated for constant atoms, as in the paper's `Pa ∨ Pb`: the proof
-    transplants each split-half's worlds to every index via state-basedness,
-    which is sound only because constant atoms are *assignment-invariant* —
+    Stated for constant atoms, as in the paper's `Pa ∨ Pb`: the transplant
+    argument of `poss_predc_of_stateBased` needs assignment-invariance —
     with a free variable in place of the constant the statement is false
     (the transplanted indices carry the wrong assignments). -/
-theorem ignorance_Q (M : QBSMLModel W Domain Const Pred)
-    (P Q : Pred) (c₁ c₂ : Const) (s : Finset (Index W Var Domain))
-    (hSB : M.IsStateBased s)
+theorem ignorance {P Q : Pred} {c₁ c₂ : Const} (hSB : M.IsStateBased s)
     (h : support M
       (QBSMLFormula.enrich (.disj (.predc P c₁) (.predc Q c₂))) s) :
     support M (.poss (.predc P c₁)) s ∧
     support M (.poss (.predc Q c₂)) s := by
-  have hSB' : ∀ w ∈ State.worldProj s, M.access w = State.worldProj s := hSB
-  obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1
-  have ht₁s : t₁ ⊆ s := hunion ▸ Finset.subset_union_left
-  have ht₂s : t₂ ⊆ s := hunion ▸ Finset.subset_union_right
-  constructor
-  · intro i hi
-    refine ⟨State.worldProj t₁, ?_, State.worldProj_nonempty h₁.2, ?_⟩
-    · rw [hSB' i.world (State.mem_worldProj.mpr ⟨i, hi, rfl⟩)]
-      exact State.worldProj_mono ht₁s
-    · intro k hk
-      obtain ⟨hkw, -⟩ := State.mem_modalLift.mp hk
-      obtain ⟨j, hj, hjw⟩ := State.mem_worldProj.mp hkw
-      rw [← hjw]
-      exact h₁.1 j hj
-  · intro i hi
-    refine ⟨State.worldProj t₂, ?_, State.worldProj_nonempty h₂.2, ?_⟩
-    · rw [hSB' i.world (State.mem_worldProj.mpr ⟨i, hi, rfl⟩)]
-      exact State.worldProj_mono ht₂s
-    · intro k hk
-      obtain ⟨hkw, -⟩ := State.mem_modalLift.mp hk
-      obtain ⟨j, hj, hjw⟩ := State.mem_worldProj.mp hkw
-      rw [← hjw]
-      exact h₂.1 j hj
+  obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1
+  exact ⟨poss_predc_of_stateBased M hSB (splitsAs_left_subset hsplit)
+      h₁.2 h₁.1,
+    poss_predc_of_stateBased M hSB (splitsAs_right_subset hsplit)
+      h₂.2 h₂.1⟩
 
 /-! ### Negation behaviour (Fact 10) -/
 
@@ -299,19 +279,13 @@ theorem ignorance_Q (M : QBSMLModel W Domain Const Pred)
     Negation cancels ignorance (paper §5.5): the `Nonempty` hypothesis is
     discharged by the three NE-strips, leaving classical anti-support on
     each disjunct. -/
-theorem negationStrip_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem negationStrip (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.neg (.disj α β))) s) :
     support M (.neg α) s ∧ support M (.neg β) s := by
-  -- Outer: enrich (¬(α ∨ β)) = (¬enrich (α ∨ β)) ∧ NE; project outer NE.
-  have hNeg : antiSupport M (QBSMLFormula.enrich (.disj α β)) s := h.1
-  -- enrich (α ∨ β) = (enrich α ∨ enrich β) ∧ NE; strip NE.
   have hDisj : antiSupport M (.disj α.enrich β.enrich) s :=
-    antiSupport_strip_ne M (.disj α.enrich β.enrich) s hNeg
-  -- antiSupport-disj is conj of antiSupports.
+    antiSupport_strip_ne M (.disj α.enrich β.enrich) s h.1
   exact ⟨enrichment_strengthens_antiSupport M α s hα hDisj.1,
-         enrichment_strengthens_antiSupport M β s hβ hDisj.2⟩
+    enrichment_strengthens_antiSupport M β s hβ hDisj.2⟩
 
 /-! ### Distribution (Facts 5 and 6) -/
 
@@ -319,7 +293,7 @@ theorem negationStrip_Q (M : QBSMLModel W Domain Const Pred)
     that supports `γ` yields an existential witness on the singleton, by
     `support_exi_of_update_closure`. The engine of Fact 5. -/
 private theorem exi_of_subset_extendUniversal_singleton
-    (M : QBSMLModel W Domain Const Pred) {γ : QBSMLFormula Var Const Pred}
+    {γ : QBSMLFormula Var Const Pred}
     {i : Index W Var Domain} {x : Var} {t : Finset (Index W Var Domain)}
     (htsub : t ⊆ State.extendUniversal {i} x) (htne : t.Nonempty)
     (hsupp : support M γ t) :
@@ -347,18 +321,17 @@ private theorem exi_of_subset_extendUniversal_singleton
     non-empty parts supporting the enriched disjuncts; because the state is
     a singleton, every part extends the *same* index, so each part is the
     image of a functional extension witnessing the existential. -/
-theorem distribution_Q (M : QBSMLModel W Domain Const Pred)
-    (α β : QBSMLFormula Var Const Pred) (x : Var) (i : Index W Var Domain)
+theorem distribution {x : Var} {i : Index W Var Domain}
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M (QBSMLFormula.enrich (.univ x (.disj α β))) {i}) :
     support M (.exi x α) {i} ∧ support M (.exi x β) {i} := by
-  obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1.1
+  obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1.1
   exact ⟨exi_of_subset_extendUniversal_singleton M
-      (hunion ▸ Finset.subset_union_left)
+      (splitsAs_left_subset hsplit)
       (enriched_support_implies_nonempty M α t₁ h₁)
       (enrichment_strengthens_support M α t₁ hα h₁),
     exi_of_subset_extendUniversal_singleton M
-      (hunion ▸ Finset.subset_union_right)
+      (splitsAs_right_subset hsplit)
       (enriched_support_implies_nonempty M β t₂ h₂)
       (enrichment_strengthens_support M β t₂ hβ h₂)⟩
 
@@ -369,14 +342,11 @@ theorem distribution_Q (M : QBSMLModel W Domain Const Pred)
     `i₀.world` in every index's accessible set, so the singleton
     `{i₀.world}` witnesses each diamond. The engine of Fact 6. -/
 private theorem exi_poss_atom_of_subset_extendUniversal
-    (M : QBSMLModel W Domain Const Pred) {P : Pred} {x : Var}
-    {s t : Finset (Index W Var Domain)}
+    {P : Pred} {x : Var} {t : Finset (Index W Var Domain)}
     (hSB : M.IsStateBased s)
     (htsub : t ⊆ State.extendUniversal s x) (htne : t.Nonempty)
     (hsupp : support M (.pred P x) t) :
     support M (.exi x (.poss (.pred P x))) s := by
-  classical
-  have hSB' : ∀ w ∈ State.worldProj s, M.access w = State.worldProj s := hSB
   obtain ⟨j₀, hj₀⟩ := htne
   obtain ⟨d, i₀, hi₀s, hupd⟩ := State.mem_extendUniversal.mp (htsub hj₀)
   obtain ⟨d', hassign, hmem⟩ := hsupp j₀ hj₀
@@ -397,7 +367,7 @@ private theorem exi_poss_atom_of_subset_extendUniversal
     subst hw
     have hjw : j.world ∈ State.worldProj s :=
       State.mem_worldProj.mpr ⟨i, his, by rw [← hupd', Index.world_update]⟩
-    rw [hSB' j.world hjw]
+    rw [hSB j.world hjw]
     exact State.mem_worldProj.mpr ⟨i₀, hi₀s, rfl⟩
   · intro k hk
     obtain ⟨hkw, hka⟩ := State.mem_modalLift.mp hk
@@ -408,7 +378,7 @@ private theorem exi_poss_atom_of_subset_extendUniversal
     · rw [hkw]
       exact hmem
 
-/-- **Fact 6 (distribution°)** of [aloni-vanormondt-2023]: on epistemic
+/-- **Fact 6 (distribution◇)** of [aloni-vanormondt-2023]: on epistemic
     models (state-based `R`),
 
     `[∀x(Px ∨ Qx)]⁺ ⊨ ∃x◇Px ∧ ∃x◇Qx`.
@@ -417,19 +387,17 @@ private theorem exi_poss_atom_of_subset_extendUniversal
     pointwise at a single transplanted world; the paper notes the result
     "can easily be generalised", which for arbitrary NE-free formulas would
     route through flatness). -/
-theorem distributionEpi_Q (M : QBSMLModel W Domain Const Pred)
-    (P Q : Pred) (x : Var) (s : Finset (Index W Var Domain))
-    (hSB : M.IsStateBased s)
+theorem distributionEpi {P Q : Pred} {x : Var} (hSB : M.IsStateBased s)
     (h : support M
       (QBSMLFormula.enrich (.univ x (.disj (.pred P x) (.pred Q x)))) s) :
     support M (.exi x (.poss (.pred P x))) s ∧
     support M (.exi x (.poss (.pred Q x))) s := by
-  obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h.1.1
+  obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1.1
   exact ⟨exi_poss_atom_of_subset_extendUniversal M hSB
-      (hunion ▸ Finset.subset_union_left)
+      (splitsAs_left_subset hsplit)
       (enriched_support_implies_nonempty M (.pred P x) t₁ h₁) h₁.1,
     exi_poss_atom_of_subset_extendUniversal M hSB
-      (hunion ▸ Finset.subset_union_right)
+      (splitsAs_right_subset hsplit)
       (enriched_support_implies_nonempty M (.pred Q x) t₂ h₂) h₂.1⟩
 
 end Core.Logic.Modal.QBSML

--- a/Linglib/Core/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Core/Logic/Modal/QBSML/Properties.lean
@@ -1030,7 +1030,7 @@ def QBSMLFormula.toModal? :
   | .exi x φ => φ.toModal?.map (ModalFormula.ex x ·)
   | .univ x φ => φ.toModal?.map (ModalFormula.all x ·)
 
-omit [DecidableEq W] [Fintype Var] in
+omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- Modally translatable formulas are NE-free. -/
 theorem isNEFree_of_toModal? :
     ∀ {φ : QBSMLFormula Var Const Pred}
@@ -1078,7 +1078,7 @@ theorem isNEFree_of_toModal? :
     | some α => exact .univ x (ih hφ)
   | ne => intro τ hτ; simp [QBSMLFormula.toModal?] at hτ
 
-omit [DecidableEq W] [Fintype Var] in
+omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- The modal translation is total on the NE-free fragment: together with
     `isNEFree_of_toModal?`, the translatable and NE-free fragments
     coincide. -/

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -128,58 +128,58 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
 
     Enriched negation `[¬(Px ∨ Qx)]⁺` entails the conjunction of negated
     disjuncts `¬Px ∧ ¬Qx`. One-line invocation of the substrate's
-    `negationStrip_Q` (`Core/Logic/Modal/QBSML/FreeChoice.lean`).
+    `negationStrip` (`Core/Logic/Modal/QBSML/FreeChoice.lean`).
     Mirrors `Aloni2022.aloni2022_fact11_dual_prohibition` style — substrate
     theorem, model + NE-free witnesses applied. -/
 theorem fact10_negation
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (h : support avoModel negPxOrQx.enrich s) :
     support avoModel (.neg Px) s ∧ support avoModel (.neg Qx) s :=
-  negationStrip_Q avoModel Px Qx s Px_isNEFree Qx_isNEFree h
+  negationStrip avoModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Facts 7 and 8 (free choice): `[□/◇(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` -/
 
 /-- **Fact 8 (Narrow-Scope free choice / ◇-FC)** at `avoModel`:
 
     Enriched possibility-disjunction `[◇(Px ∨ Qx)]⁺` entails `◇Px ∧ ◇Qx`.
-    One-line invocation of `narrowScopeFC_Q`. The first-order analogue of
+    One-line invocation of `narrowScopeFC`. The first-order analogue of
     `Aloni2022.aloni2022_fact4_NS_FC` — same template, lifted to QBSML's
     monadic predicate language. -/
 theorem fact8_narrowScopeFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (h : support avoModel possPxOrQx.enrich s) :
     support avoModel (.poss Px) s ∧ support avoModel (.poss Qx) s :=
-  narrowScopeFC_Q avoModel Px Qx s Px_isNEFree Qx_isNEFree h
+  narrowScopeFC avoModel Px_isNEFree Qx_isNEFree h
 
 /-- **Fact 7 (□-free choice)** at `avoModel`: `[□(Px ∨ Qx)]⁺` entails
-    `◇Px ∧ ◇Qx`, with the derived `□`. One-line invocation of `boxFC_Q`. -/
+    `◇Px ∧ ◇Qx`, with the derived `□`. One-line invocation of `boxFC`. -/
 theorem fact7_boxFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (h : support avoModel necPxOrQx.enrich s) :
     support avoModel (.poss Px) s ∧ support avoModel (.poss Qx) s :=
-  boxFC_Q avoModel Px Qx s Px_isNEFree Qx_isNEFree h
+  boxFC avoModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Facts 9 and 5 (universal FC and distribution) -/
 
 /-- **Fact 9 (Universal free choice)** at `avoModel`:
 
     `[∀x◇(Px ∨ Qx)]⁺` entails `∀x◇Px ∧ ∀x◇Qx`. One-line invocation of
-    `universalFC_Q` — the [chemla-2009]-attested pattern. -/
+    `universalFC` — the [chemla-2009]-attested pattern. -/
 theorem fact9_universalFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (h : support avoModel univPossPxOrQx.enrich s) :
     support avoModel (.univ .x (.poss Px)) s ∧
     support avoModel (.univ .x (.poss Qx)) s :=
-  universalFC_Q avoModel Px Qx .x s Px_isNEFree Qx_isNEFree h
+  universalFC avoModel Px_isNEFree Qx_isNEFree h
 
 /-- **Fact 5 (Distribution at maximal information)** at `avoModel`: on any
     singleton state, `[∀x(Px ∨ Qx)]⁺` entails `∃xPx ∧ ∃xQx`. One-line
-    invocation of `distribution_Q`. -/
+    invocation of `distribution`. -/
 theorem fact5_distribution
     (i : Index PowerSet2World QVar FCAtom)
     (h : support avoModel univPxOrQx.enrich {i}) :
     support avoModel (.exi .x Px) {i} ∧ support avoModel (.exi .x Qx) {i} :=
-  distribution_Q avoModel Px Qx .x i Px_isNEFree Qx_isNEFree h
+  distribution avoModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Proposition 4.1 at the concrete model -/
 
@@ -268,7 +268,7 @@ theorem support_of_stUnivPxOrQx_sentence
     - State-based: every w ∈ s↓ sees exactly s↓ (R(w) = s↓).
 
     State-basedness is strictly stronger and is the precondition for the
-    epistemic facts: Fact 3 (`ignorance_Q`) and Fact 6 (`distributionEpi_Q`),
+    epistemic facts: Fact 3 (`ignorance`) and Fact 6 (`distributionEpi`),
     which therefore stay substrate-level (universal access is not
     state-based). Facts 7, 8 and 10 need no frame condition at all — they
     hold on every model. -/

--- a/Linglib/Studies/Yan2023.lean
+++ b/Linglib/Studies/Yan2023.lean
@@ -25,8 +25,8 @@ under `[·]⁺`.
 
 This file derives the chapter's account from the QBSML substrate
 (`Core/Logic/Modal/QBSML/FreeChoice.lean`): the □-FC fact it invokes
-(Fact 13) is `boxFC_Q`; the quantified variant needed for Asher and Heim is
-`boxExiFC_Q`; the semantic validity of the monotonic steps is
+(Fact 13) is `boxFC`; the quantified variant needed for Asher and Heim is
+`boxExiFC`; the semantic validity of the monotonic steps is
 `support_disj_inl` / `support_nec_mono`. The verbs *want* / *it is ok* are
 the Hintikka-style `□`/`◇` over a bouletic accessibility relation, exactly
 as in the paper (§4.4.1; the positive semantics of *want* itself is
@@ -335,11 +335,11 @@ theorem ross_monotone {s : Finset (Index Unit QVar Unit)}
 /-- **Pragmatic validity of the FC step** ([yan-2023] (26), instance of
     Fact 13): `[□(SEND a ∨ BURN a)]⁺ ⊨ ◇SEND a ∧ ◇BURN a` — from the
     enriched disjunctive want, both "it is ok to send" and the paradoxical
-    "it is ok to burn". Direct instance of `boxFC_Q`. -/
+    "it is ok to burn". Direct instance of `boxFC`. -/
 theorem ross_fc {s : Finset (Index Unit QVar Unit)}
     (h : support rossModel (QBSMLFormula.enrich (sendL.disj burnL).nec) s) :
     support rossModel (.poss sendL) s ∧ support rossModel (.poss burnL) s :=
-  boxFC_Q rossModel sendL burnL s sendL_isNEFree burnL_isNEFree h
+  boxFC rossModel sendL_isNEFree burnL_isNEFree h
 
 /-- The premise is assertable: John's desire state supports the enriched
     `[□SEND a]⁺`. -/
@@ -453,7 +453,7 @@ theorem asher_fc (M : QBSMLModel W Domain Unit AsherPred)
     support M (.poss (.exi QVar.x freeTrip)) s ∧
     support M (.poss (.exi QVar.x nonFreeTrip)) s := by
   rw [reinterpret_asherConcl] at h
-  exact boxExiFC_Q M freeTrip nonFreeTrip QVar.x s
+  exact boxExiFC M
     freeTrip_isNEFree nonFreeTrip_isNEFree h
 
 end AsherGeneric
@@ -622,7 +622,7 @@ theorem heim_fc {W Domain : Type*} [DecidableEq W] [DecidableEq Domain]
       (QBSMLFormula.enrich (reinterpret subTuesday .tuesday heimConcl)) s) :
     support M (.poss (.exi QVar.x tuesdayTeach)) s ∧
     support M (.poss (.exi QVar.x nonTuesdayTeach)) s :=
-  boxExiFC_Q M tuesdayTeach nonTuesdayTeach QVar.x s
+  boxExiFC M
     (.conj (.pred _ _) (.pred _ _))
     (.conj (.neg (.pred _ _)) (.pred _ _)) h
 


### PR DESCRIPTION
Deep-audit cleanse of `FreeChoice.lean` (paper fidelity verified against Aloni & van Ormondt 2023; all statements, the Fact 10 quote, and attributions check out — findings were style/structure only).

- Duplicated symmetric halves factor through private one-sided engines (`poss_of_subset_modalLift`, `poss_predc_of_stateBased`); `boxFC` collapses to direct `diamond_split` projections; dead `classical` and ascription `have`s dropped; `splitsAs` API used uniformly.
- `M` and statement-determined binders lifted per mathlib convention; namespace-redundant `_Q` suffixes dropped (both consumer studies updated); `possFC_on` now private.
- Rides along: two `omit` linter fixes in `Properties.lean`, unused simp arg in `FirstOrder/Binders.lean`, docstring fixes (paper's Distribution◇ label; accurate instantiation claim).