### PR TITLE
refactor(Logic/Modal/QBSML): drop name stutter; AvO 2023 study cleanse

### DIFF
--- a/Linglib/Logic/Modal/BSML/Scenarios.lean
+++ b/Linglib/Logic/Modal/BSML/Scenarios.lean
@@ -17,7 +17,7 @@ a typo silently compiles to `false` under the
   a third proposition.
 * `QVar` — the shared toy variable type for quantified FC scenarios
   (QBSML); the first-order counterpart of `FCAtom`.
-* `PowerSet2World` — the 2² = 4 truth assignments to two atoms
+* `TwoAtomWorld` — the 2² = 4 truth assignments to two atoms
   ([aloni-2022] Figure 1: `w_∅`, `w_a`, `w_b`, `w_ab`), with the typed
   `holds` truth table.
 
@@ -64,23 +64,23 @@ inductive QVar | x
     - `onlyB`   = `w_b`: only `b`
     - `both`    = `w_ab`: both `a` and `b`
 -/
-inductive PowerSet2World
+inductive TwoAtomWorld
   | nothing
   | onlyA
   | onlyB
   | both
   deriving DecidableEq, Repr
 
-instance : Fintype PowerSet2World where
+instance : Fintype TwoAtomWorld where
   elems := {.nothing, .onlyA, .onlyB, .both}
   complete := by intro x; cases x <;> simp
 
-namespace PowerSet2World
+namespace TwoAtomWorld
 
 /-- Truth-table for the two-atom power set. The third atom (`c`) is
     unsatisfiable in this baseline 4-world model — embedded scenarios
     needing `c` should use a larger world type. -/
-def holds : PowerSet2World → FCAtom → Bool
+def holds : TwoAtomWorld → FCAtom → Bool
   | .both,    .a => true
   | .both,    .b => true
   | .onlyA,   .a => true
@@ -92,8 +92,8 @@ def holds : PowerSet2World → FCAtom → Bool
   | _,        .c => false
 
 /-- Synonym used by Studies that prefer the predicate spelling. -/
-abbrev satisfies : PowerSet2World → FCAtom → Bool := holds
+abbrev satisfies : TwoAtomWorld → FCAtom → Bool := holds
 
-end PowerSet2World
+end TwoAtomWorld
 
 end BSML

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -27,7 +27,7 @@ the AAY-2024 extensions BSMLOr/BSMLEmpty, modal dependence logic in
 
 * `Logic/Modal/BSML/Defs.lean` — `BSMLModel` is an `abbrev` of
   this type.
-* `Logic/Modal/QBSML/Defs.lean` — `QBSMLModel` parameterises
+* `Logic/Modal/QBSML/Defs.lean` — `QBSML.Model` parameterises
   this carrier with an assignment type.
 * `Logic/Modal/Dependence.lean` — modal dependence logic (MDL).
 * `Studies/AloniAnttilaYang2024.lean` — BSMLOr,

--- a/Linglib/Logic/Modal/QBSML/Defs.lean
+++ b/Linglib/Logic/Modal/QBSML/Defs.lean
@@ -27,17 +27,17 @@ the `Team.isFlat_iff` template at the point type
   ([aloni-vanormondt-2023] Definitions 4.5–4.7).
 * `State.modalLift`, `State.worldProj`: pairing accessible worlds with an
   assignment, and the world projection `s↓`.
-* `QBSMLFormula`: the formula language ([aloni-vanormondt-2023]
-  Definition 4.1), with `□` derived as `QBSMLFormula.nec`.
-* `QBSMLFormula.IsNEFree`: the NE-free fragment.
+* `Formula`: the formula language ([aloni-vanormondt-2023]
+  Definition 4.1), with `□` derived as `Formula.nec`.
+* `Formula.IsNEFree`: the NE-free fragment.
 * `monadicLang`, `monadicStructure`: the monadic first-order signature on
   `Const` and `Pred` and its structures, as a mathlib `FirstOrder.Language`.
-* `QBSMLModel` (an abbreviation for `FirstOrder.Language.KripkeStructure`
+* `Model` (an abbreviation for `FirstOrder.Language.KripkeStructure`
   over `monadicLang`), `eval`, `support`, `antiSupport`: bilateral evaluation
   ([aloni-vanormondt-2023] Definition 4.9), with the interpretation carried
   as a world-indexed family of mathlib structures.
 * `isBilateral`: `support`/`antiSupport` form a
-  `Bilateral.IsBilateral` under `QBSMLFormula.neg`.
+  `Bilateral.IsBilateral` under `Formula.neg`.
 * `KripkeStructure.IsStateBased`, `KripkeStructure.IsIndisputable`: frame
   conditions
   via `s↓` ([aloni-vanormondt-2023] Definition 4.10).
@@ -52,7 +52,7 @@ the `Team.isFlat_iff` template at the point type
 * The paper's domain `D` (part of `M = ⟨W, D, R, I⟩`) is a `Domain : Type*`
   parameter, with `[Fintype Domain]` where the universal extension must range
   over all of it. The interpretation `I` is a world-indexed family of mathlib
-  first-order structures: `QBSMLModel` is `FirstOrder.Language.KripkeStructure`
+  first-order structures: `Model` is `FirstOrder.Language.KripkeStructure`
   over the monadic signature, and `KripkeStructure.pInterp` /
   `KripkeStructure.cInterp` read the world-dependent (non-rigid) predicate
   and constant denotations off `Structure.RelMap` / `Structure.funMap`.
@@ -61,7 +61,7 @@ the `Team.isFlat_iff` template at the point type
   operations preserve it.
 * `□` is not primitive: the paper takes `□` primitive and derives `◇`; we
   invert this, so `eval`'s `poss` clauses match the paper's derived
-  `◇`-clauses and `QBSMLFormula.nec` matches its primitive `□`.
+  `◇`-clauses and `Formula.nec` matches its primitive `□`.
 -/
 
 namespace QBSML
@@ -340,55 +340,55 @@ variable {Const Pred : Type*}
     parameterized over variable type `Var`, constant type `Const`, and
     (monadic) predicate type `Pred`. The paper's terms `t := c | x` appear
     as the two atom constructors. `□` is not primitive — see
-    `QBSMLFormula.nec`. -/
-inductive QBSMLFormula (Var : Type*) (Const : Type*) (Pred : Type*) where
+    `Formula.nec`. -/
+inductive Formula (Var : Type*) (Const : Type*) (Pred : Type*) where
   /-- Monadic predicate applied to a variable. -/
-  | pred : Pred → Var → QBSMLFormula Var Const Pred
+  | pred : Pred → Var → Formula Var Const Pred
   /-- Monadic predicate applied to an individual constant. -/
-  | predc : Pred → Const → QBSMLFormula Var Const Pred
+  | predc : Pred → Const → Formula Var Const Pred
   /-- Non-emptiness atom: state is non-empty. -/
-  | ne : QBSMLFormula Var Const Pred
+  | ne : Formula Var Const Pred
   /-- Bilateral negation: swap support/anti-support. -/
-  | neg : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+  | neg : Formula Var Const Pred → Formula Var Const Pred
   /-- Conjunction. -/
-  | conj : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred →
-      QBSMLFormula Var Const Pred
+  | conj : Formula Var Const Pred → Formula Var Const Pred →
+      Formula Var Const Pred
   /-- Split (tensor) disjunction. -/
-  | disj : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred →
-      QBSMLFormula Var Const Pred
+  | disj : Formula Var Const Pred → Formula Var Const Pred →
+      Formula Var Const Pred
   /-- Possibility modal. -/
-  | poss : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+  | poss : Formula Var Const Pred → Formula Var Const Pred
   /-- Existential quantifier. -/
-  | exi : Var → QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+  | exi : Var → Formula Var Const Pred → Formula Var Const Pred
   /-- Universal quantifier. -/
-  | univ : Var → QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+  | univ : Var → Formula Var Const Pred → Formula Var Const Pred
   deriving Repr
 
 /-- Necessity, derived: `□φ := ¬◇¬φ`. [aloni-vanormondt-2023] takes `□`
     primitive and `◇ := ¬□¬` derived; we invert this, so `eval`'s `poss`
     clauses match the paper's derived `◇`-clauses and `nec` matches its
     primitive `□`. -/
-def QBSMLFormula.nec (φ : QBSMLFormula Var Const Pred) : QBSMLFormula Var Const Pred :=
+def Formula.nec (φ : Formula Var Const Pred) : Formula Var Const Pred :=
   .neg (.poss (.neg φ))
 
 /-- The NE-free fragment: formulas not containing the `NE` atom. On this
     fragment QBSML reduces to classical first-order modal logic
     ([aloni-vanormondt-2023] analogue of [anttila-2021]
     Proposition 2.2.16); see `Logic/Modal/QBSML/Properties.lean`. -/
-inductive QBSMLFormula.IsNEFree : QBSMLFormula Var Const Pred → Prop
+inductive Formula.IsNEFree : Formula Var Const Pred → Prop
   | pred (P : Pred) (x : Var) : IsNEFree (.pred P x)
   | predc (P : Pred) (c : Const) : IsNEFree (.predc P c)
-  | neg {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.neg φ)
-  | conj {φ ψ : QBSMLFormula Var Const Pred} :
+  | neg {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.neg φ)
+  | conj {φ ψ : Formula Var Const Pred} :
       IsNEFree φ → IsNEFree ψ → IsNEFree (.conj φ ψ)
-  | disj {φ ψ : QBSMLFormula Var Const Pred} :
+  | disj {φ ψ : Formula Var Const Pred} :
       IsNEFree φ → IsNEFree ψ → IsNEFree (.disj φ ψ)
-  | poss {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.poss φ)
-  | exi (x : Var) {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.exi x φ)
-  | univ (x : Var) {φ : QBSMLFormula Var Const Pred} : IsNEFree φ → IsNEFree (.univ x φ)
+  | poss {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.poss φ)
+  | exi (x : Var) {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.exi x φ)
+  | univ (x : Var) {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.univ x φ)
 
 /-- The derived `□φ := ¬◇¬φ` preserves NE-freeness. -/
-theorem QBSMLFormula.IsNEFree.nec {φ : QBSMLFormula Var Const Pred}
+theorem Formula.IsNEFree.nec {φ : Formula Var Const Pred}
     (h : φ.IsNEFree) : φ.nec.IsNEFree :=
   .neg (.poss (.neg h))
 
@@ -401,10 +401,10 @@ theorem QBSMLFormula.IsNEFree.nec {φ : QBSMLFormula Var Const Pred}
     `Logic/Modal/QBSML/Properties.lean`), so each such operation — e.g.
     [yan-2023]'s reinterpretation function in `Studies/Yan2023.lean` — needs
     only its two atom lemmas. -/
-def QBSMLFormula.mapAtoms
-    (fp : Pred → Var → QBSMLFormula Var Const Pred)
-    (fc : Pred → Const → QBSMLFormula Var Const Pred) :
-    QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+def Formula.mapAtoms
+    (fp : Pred → Var → Formula Var Const Pred)
+    (fc : Pred → Const → Formula Var Const Pred) :
+    Formula Var Const Pred → Formula Var Const Pred
   | .pred P x => fp P x
   | .predc P c => fc P c
   | .ne => .ne
@@ -416,11 +416,11 @@ def QBSMLFormula.mapAtoms
   | .univ x φ => .univ x (φ.mapAtoms fp fc)
 
 /-- An atom substitution with NE-free images preserves NE-freeness. -/
-theorem QBSMLFormula.IsNEFree.mapAtoms
-    {fp : Pred → Var → QBSMLFormula Var Const Pred}
-    {fc : Pred → Const → QBSMLFormula Var Const Pred}
+theorem Formula.IsNEFree.mapAtoms
+    {fp : Pred → Var → Formula Var Const Pred}
+    {fc : Pred → Const → Formula Var Const Pred}
     (hfp : ∀ P x, (fp P x).IsNEFree) (hfc : ∀ P c, (fc P c).IsNEFree)
-    {φ : QBSMLFormula Var Const Pred} (h : φ.IsNEFree) :
+    {φ : Formula Var Const Pred} (h : φ.IsNEFree) :
     (φ.mapAtoms fp fc).IsNEFree := by
   induction h with
   | pred P x => exact hfp P x
@@ -487,7 +487,7 @@ abbrev monadicRel {Const Pred : Type*} (P : Pred) :
     world-indexed interpretation `I`, carried as a family of mathlib
     structures (`FirstOrder.Language.KripkeStructure`) — true by
     construction, not by bridge. -/
-abbrev QBSMLModel (W : Type*) (Domain : Type*) (Const : Type*)
+abbrev Model (W : Type*) (Domain : Type*) (Const : Type*)
     (Pred : Type*) :=
   FirstOrder.Language.KripkeStructure (monadicLang Const Pred) W Domain
 
@@ -497,7 +497,7 @@ abbrev QBSMLModel (W : Type*) (Domain : Type*) (Const : Type*)
     (cf. `Semantics.Composition.Model.pred₁ext`). -/
 def _root_.FirstOrder.Language.KripkeStructure.pInterp
     {W Domain Const Pred : Type*}
-    (M : QBSMLModel W Domain Const Pred) (P : Pred) (w : W) (d : Domain) :
+    (M : Model W Domain Const Pred) (P : Pred) (w : W) (d : Domain) :
     Prop :=
   (M.interp w).RelMap (monadicRel P) (fun _ => d)
 
@@ -506,7 +506,7 @@ def _root_.FirstOrder.Language.KripkeStructure.pInterp
     `Structure.funMap` (cf. `Semantics.Composition.Model.const`). -/
 def _root_.FirstOrder.Language.KripkeStructure.cInterp
     {W Domain Const Pred : Type*}
-    (M : QBSMLModel W Domain Const Pred) (c : Const) (w : W) : Domain :=
+    (M : Model W Domain Const Pred) (c : Const) (w : W) : Domain :=
   (M.interp w).funMap (monadicConst c) default
 
 @[simp] theorem _root_.FirstOrder.Language.KripkeStructure.pInterp_monadicStructure
@@ -536,8 +536,8 @@ variable [Fintype Domain]
     Definition 4.9): `eval M true φ s` is support (`M, s ⊨ φ`),
     `eval M false φ s` anti-support (`M, s ⫤ φ`). Negation flips the
     polarity, making double-negation elimination definitional. -/
-def eval (M : QBSMLModel W Domain Const Pred) :
-    Bool → QBSMLFormula Var Const Pred → Finset (Index W Var Domain) → Prop
+def eval (M : Model W Domain Const Pred) :
+    Bool → Formula Var Const Pred → Finset (Index W Var Domain) → Prop
   | true,  .pred P x, s =>
       ∀ i ∈ s, ∃ d, i.assign x = some d ∧ M.pInterp P i.world d
   | false, .pred P x, s =>
@@ -571,29 +571,29 @@ def eval (M : QBSMLModel W Domain Const Pred) :
   | false, .exi x ψ, s => eval M false ψ (State.extendUniversal s x)
 
 /-- Support: positive evaluation. -/
-abbrev support (M : QBSMLModel W Domain Const Pred) (φ : QBSMLFormula Var Const Pred)
+abbrev support (M : Model W Domain Const Pred) (φ : Formula Var Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   eval M true φ s
 
 /-- Anti-support: negative evaluation. -/
-abbrev antiSupport (M : QBSMLModel W Domain Const Pred) (φ : QBSMLFormula Var Const Pred)
+abbrev antiSupport (M : Model W Domain Const Pred) (φ : Formula Var Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   eval M false φ s
 
-@[simp] lemma support_neg (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
+@[simp] lemma support_neg (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain)) :
     support M (.neg φ) s ↔ antiSupport M φ s := Iff.rfl
 
-@[simp] lemma antiSupport_neg (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
+@[simp] lemma antiSupport_neg (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain)) :
     antiSupport M (.neg φ) s ↔ support M φ s := Iff.rfl
 
 /-- `support` and `antiSupport` form a paraconsistent bilateral logic
-    (`Bilateral.IsBilateral`) under `QBSMLFormula.neg`, like
+    (`Bilateral.IsBilateral`) under `Formula.neg`, like
     BSML's `isBilateral` at the point type `Index W Var Domain`. -/
-theorem isBilateral (M : QBSMLModel W Domain Const Pred) :
-    Bilateral.IsBilateral (Form := QBSMLFormula Var Const Pred)
-      (support M) (antiSupport M) QBSMLFormula.neg :=
+theorem isBilateral (M : Model W Domain Const Pred) :
+    Bilateral.IsBilateral (Form := Formula Var Const Pred)
+      (support M) (antiSupport M) Formula.neg :=
   Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
 
 end Evaluation
@@ -609,22 +609,22 @@ variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
     `Team.IsStateBased` applied to `State.worldProj s`, sharing
     BSML's frame-condition substrate. -/
 def _root_.FirstOrder.Language.KripkeStructure.IsStateBased
-    (M : QBSMLModel W Domain Const Pred)
+    (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsStateBased M.access (State.worldProj s)
 
 /-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
     accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
 def _root_.FirstOrder.Language.KripkeStructure.IsIndisputable
-    (M : QBSMLModel W Domain Const Pred)
+    (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsIndisputable M.access (State.worldProj s)
 
-instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
+instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
   unfold FirstOrder.Language.KripkeStructure.IsStateBased; infer_instance
 
-instance [Fintype W] (M : QBSMLModel W Domain Const Pred)
+instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
   unfold FirstOrder.Language.KripkeStructure.IsIndisputable; infer_instance
 

--- a/Linglib/Logic/Modal/QBSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/QBSML/Enrichment.lean
@@ -29,7 +29,7 @@ behaviour-under-negation pattern — the QBSML free-choice facts of
 
 ## Main declarations
 
-* `QBSMLFormula.enrich` — the enrichment function `[·]⁺`.
+* `Formula.enrich` — the enrichment function `[·]⁺`.
 * `enriched_support_implies_nonempty` — a state supporting an enriched
   formula is non-empty (the `NE` conjunct guards every clause).
 * `antiSupport_strip_ne`, `antiSupport_conj_ne_iff` — anti-support of
@@ -43,10 +43,10 @@ behaviour-under-negation pattern — the QBSML free-choice facts of
 
 ## Implementation notes
 
-`enrich` is total on `QBSMLFormula` for definitional convenience, but `[·]⁺`
+`enrich` is total on `Formula` for definitional convenience, but `[·]⁺`
 is defined only on the NE-free fragment in both papers, so the `.ne` case is
 a filler convention. The construction is structurally identical to BSML's
-`Logic/Modal/BSML/Enrichment.lean` but operates on `QBSMLFormula Var Const Pred`
+`Logic/Modal/BSML/Enrichment.lean` but operates on `Formula Var Const Pred`
 (quantifiers, predicate atoms) rather than `BSMLFormula Atom`. The two are
 kept parallel rather than unified: a shared "team-semantic formula language
 with an `NE` constructor" abstraction awaits a third instance, per the family
@@ -61,7 +61,7 @@ variable {Var Const Pred : Type*}
 
 /-- Pragmatic enrichment `[·]⁺` for QBSML formulas ([aloni-vanormondt-2023]
     Definition 4.13). Recursively conjoins `NE` to every clause. -/
-def QBSMLFormula.enrich : QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred
+def Formula.enrich : Formula Var Const Pred → Formula Var Const Pred
   | .pred P x   => .conj (.pred P x) .ne
   | .predc P c  => .conj (.predc P c) .ne
   | .ne         => .ne  -- totality filler; enrichment is defined only on the NE-free fragment
@@ -81,8 +81,8 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
 /-- A QBSML state supporting an enriched formula must be non-empty. The NE
     conjunct guards every clause of `enrich φ`, forcing the witnessing state
     to satisfy `Nonempty`. -/
-theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
+theorem enriched_support_implies_nonempty (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : support M φ.enrich s) : s.Nonempty := by
   cases φ with
   | ne => exact h
@@ -95,8 +95,8 @@ theorem enriched_support_implies_nonempty (M : QBSMLModel W Domain Const Pred)
     `t₁ = s`. The QBSML analogue of `BSML/Enrichment`'s `antiSupport_strip_ne`;
     the workhorse of the free-choice derivations in
     `Studies/AloniVanOrmondt2023.lean`. -/
-theorem antiSupport_strip_ne (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
+theorem antiSupport_strip_ne (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : antiSupport M (.conj φ .ne) s) :
     antiSupport M φ s := by
   obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h
@@ -107,15 +107,15 @@ theorem antiSupport_strip_ne (M : QBSMLModel W Domain Const Pred)
 
 /-- Anti-support of `φ` implies anti-support of `φ ∧ NE` via the trivial
     split `(s, ∅)`. The reverse direction of `antiSupport_strip_ne`. -/
-theorem antiSupport_conj_ne_of_antiSupport (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
+theorem antiSupport_conj_ne_of_antiSupport (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
     (h : antiSupport M φ s) :
     antiSupport M (.conj φ .ne) s :=
   ⟨s, ∅, Team.splitsAs_self_empty s, h, rfl⟩
 
 /-- Anti-support of `φ ∧ NE` ↔ anti-support of `φ`. -/
-theorem antiSupport_conj_ne_iff (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
+theorem antiSupport_conj_ne_iff (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain)) :
     antiSupport M (.conj φ .ne) s ↔ antiSupport M φ s :=
   ⟨antiSupport_strip_ne M φ s, antiSupport_conj_ne_of_antiSupport M φ s⟩
 
@@ -131,8 +131,8 @@ theorem antiSupport_conj_ne_iff (M : QBSMLModel W Domain Const Pred)
     All quantifier cases use `antiSupport_strip_ne` to peel the `NE`
     conjunct, then `extendUniversal` / `extendFunctional` to apply the IH
     on the extended state. -/
-private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree) :
+private theorem enrichment_strengthens_both (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree) :
     (∀ s : Finset (Index W Var Domain), support M φ.enrich s → support M φ s) ∧
     (∀ s : Finset (Index W Var Domain),
         antiSupport M φ.enrich s → antiSupport M φ s) := by
@@ -213,16 +213,16 @@ private theorem enrichment_strengthens_both (M : QBSMLModel W Domain Const Pred)
 /-- **Enrichment strengthens (support direction)** — [aloni-2022] Fact 1
     extended to QBSML. For NE-free `φ`, supporting the enriched form implies
     supporting the original. -/
-theorem enrichment_strengthens_support (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
+theorem enrichment_strengthens_support (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
     (hNE : φ.IsNEFree)
     (h : support M φ.enrich s) :
     support M φ s :=
   (enrichment_strengthens_both M hNE).1 s h
 
 /-- **Enrichment strengthens (anti-support direction)**. -/
-theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain))
+theorem enrichment_strengthens_antiSupport (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
     (hNE : φ.IsNEFree)
     (h : antiSupport M φ.enrich s) :
     antiSupport M φ s :=
@@ -235,14 +235,14 @@ theorem enrichment_strengthens_antiSupport (M : QBSMLModel W Domain Const Pred)
     peel `[□φ]⁺ = [¬◇¬φ]⁺` down to `[φ]⁺` at each `R(wᵢ)[gᵢ]`, packaged
     once for the `□`-free-choice derivations
     (`Logic/Modal/QBSML/FreeChoice.lean`). -/
-theorem support_enrich_nec_iff (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
+theorem support_enrich_nec_iff (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain)) :
     support M φ.nec.enrich s ↔
       (∀ i ∈ s, support M φ.enrich
         (State.modalLift (M.access i.world) i.assign)) ∧ s.Nonempty := by
   constructor
   · intro h
-    have h' : antiSupport M (.poss (QBSMLFormula.neg φ).enrich) s :=
+    have h' : antiSupport M (.poss (Formula.neg φ).enrich) s :=
       antiSupport_strip_ne M _ s h.1
     exact ⟨fun i hi => antiSupport_strip_ne M _ _ (h' i hi), h.2⟩
   · intro h

--- a/Linglib/Logic/Modal/QBSML/FreeChoice.lean
+++ b/Linglib/Logic/Modal/QBSML/FreeChoice.lean
@@ -65,8 +65,8 @@ open Team
 variable {W Var Domain Const Pred : Type*}
 variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
-variable (M : QBSMLModel W Domain Const Pred)
-variable {α β : QBSMLFormula Var Const Pred} {s : Finset (Index W Var Domain)}
+variable (M : Model W Domain Const Pred)
+variable {α β : Formula Var Const Pred} {s : Finset (Index W Var Domain)}
 
 /-! ### The diamond split -/
 
@@ -90,7 +90,7 @@ private theorem poss_of_subset_modalLift {X : Finset W}
     each disjunct — `poss_of_subset_modalLift` on each half of the split. -/
 theorem diamond_split {X : Finset W} {g : Assignment Var Domain}
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (hsupp : support M (QBSMLFormula.disj α β).enrich (State.modalLift X g)) :
+    (hsupp : support M (Formula.disj α β).enrich (State.modalLift X g)) :
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g)) ∧
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M β (State.modalLift Y g)) := by
   obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := hsupp.1
@@ -100,7 +100,7 @@ theorem diamond_split {X : Finset W} {g : Assignment Var Domain}
 /-- Per-index form of the core: a state whose every index sees an enriched
     split disjunction supports both diamonds (shared by Facts 8 and 9). -/
 private theorem possFC_on (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (.poss (QBSMLFormula.disj α β).enrich) s) :
+    (h : support M (.poss (Formula.disj α β).enrich) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   refine ⟨fun i hi => ?_, fun i hi => ?_⟩
   · obtain ⟨X, hX, -, hsupp⟩ := h i hi
@@ -120,7 +120,7 @@ private theorem possFC_on (hα : α.IsNEFree) (hβ : β.IsNEFree)
     Projects the diamond clause of the enrichment and applies the per-index
     core `possFC_on` at `s`. -/
 theorem narrowScopeFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (QBSMLFormula.enrich (.poss (.disj α β))) s) :
+    (h : support M (Formula.enrich (.poss (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s :=
   possFC_on M hα hβ h.1
 
@@ -133,7 +133,7 @@ theorem narrowScopeFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
     extension `s[x]`, so the conclusion is `possFC_on` at `s[x]` — the same
     per-index argument as Fact 8, one extension up. -/
 theorem universalFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (QBSMLFormula.enrich (.univ x (.poss (.disj α β)))) s) :
+    (h : support M (Formula.enrich (.univ x (.poss (.disj α β)))) s) :
     support M (.univ x (.poss α)) s ∧ support M (.univ x (.poss β)) s :=
   possFC_on M hα hβ h.1.1
 
@@ -141,14 +141,14 @@ theorem universalFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
 
     `[□(α ∨ β)]⁺ ⊨ ◇α ∧ ◇β` for NE-free `α`, `β`.
 
-    `□` is derived (`QBSMLFormula.nec`), so the enrichment here is the
+    `□` is derived (`Formula.nec`), so the enrichment here is the
     negation-clause enrichment of `¬◇¬(α ∨ β)` rather than the paper's
     primitive `[□φ]⁺ = □[φ]⁺ ∧ NE` — but the fact holds all the same:
     `support_enrich_nec_iff` puts the enriched disjunction on each index's
     full accessible lift `R(wᵢ)[gᵢ]`, and `diamond_split` produces the
     witnesses. -/
 theorem boxFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (QBSMLFormula.enrich (QBSMLFormula.nec (.disj α β))) s) :
+    (h : support M (Formula.enrich (Formula.nec (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   rw [support_enrich_nec_iff] at h
   exact ⟨fun i hi => (diamond_split M hα hβ (h.1 i hi)).1,
@@ -166,7 +166,7 @@ solutions invoke (its §4.4.3; see `Studies/Yan2023.lean`). -/
     `support_exi_of_update_closure`. The quantified analogue of
     `poss_of_subset_modalLift`. -/
 private theorem poss_exi_of_subset_extendFunctional
-    {γ : QBSMLFormula Var Const Pred} {X₀ : Finset W}
+    {γ : Formula Var Const Pred} {X₀ : Finset W}
     {g : Assignment Var Domain} {x : Var}
     {hf : Index W Var Domain → Finset Domain}
     {t : Finset (Index W Var Domain)}
@@ -208,7 +208,7 @@ private theorem poss_exi_of_subset_extendFunctional
     `poss_exi_of_subset_extendFunctional`. -/
 theorem boxExiFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     (h : support M
-      (QBSMLFormula.enrich (QBSMLFormula.nec (.exi x (.disj α β)))) s) :
+      (Formula.enrich (Formula.nec (.exi x (.disj α β)))) s) :
     support M (.poss (.exi x α)) s ∧ support M (.poss (.exi x β)) s := by
   rw [support_enrich_nec_iff] at h
   refine ⟨fun i hi => ?_, fun i hi => ?_⟩
@@ -256,7 +256,7 @@ private theorem poss_predc_of_stateBased {P : Pred} {c : Const}
     (the transplanted indices carry the wrong assignments). -/
 theorem ignorance {P Q : Pred} {c₁ c₂ : Const} (hSB : M.IsStateBased s)
     (h : support M
-      (QBSMLFormula.enrich (.disj (.predc P c₁) (.predc Q c₂))) s) :
+      (Formula.enrich (.disj (.predc P c₁) (.predc Q c₂))) s) :
     support M (.poss (.predc P c₁)) s ∧
     support M (.poss (.predc Q c₂)) s := by
   obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1
@@ -280,7 +280,7 @@ theorem ignorance {P Q : Pred} {c₁ c₂ : Const} (hSB : M.IsStateBased s)
     discharged by the three NE-strips, leaving classical anti-support on
     each disjunct. -/
 theorem negationStrip (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (QBSMLFormula.enrich (.neg (.disj α β))) s) :
+    (h : support M (Formula.enrich (.neg (.disj α β))) s) :
     support M (.neg α) s ∧ support M (.neg β) s := by
   have hDisj : antiSupport M (.disj α.enrich β.enrich) s :=
     antiSupport_strip_ne M (.disj α.enrich β.enrich) s h.1
@@ -293,7 +293,7 @@ theorem negationStrip (hα : α.IsNEFree) (hβ : β.IsNEFree)
     that supports `γ` yields an existential witness on the singleton, by
     `support_exi_of_update_closure`. The engine of Fact 5. -/
 private theorem exi_of_subset_extendUniversal_singleton
-    {γ : QBSMLFormula Var Const Pred}
+    {γ : Formula Var Const Pred}
     {i : Index W Var Domain} {x : Var} {t : Finset (Index W Var Domain)}
     (htsub : t ⊆ State.extendUniversal {i} x) (htne : t.Nonempty)
     (hsupp : support M γ t) :
@@ -323,7 +323,7 @@ private theorem exi_of_subset_extendUniversal_singleton
     image of a functional extension witnessing the existential. -/
 theorem distribution {x : Var} {i : Index W Var Domain}
     (hα : α.IsNEFree) (hβ : β.IsNEFree)
-    (h : support M (QBSMLFormula.enrich (.univ x (.disj α β))) {i}) :
+    (h : support M (Formula.enrich (.univ x (.disj α β))) {i}) :
     support M (.exi x α) {i} ∧ support M (.exi x β) {i} := by
   obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1.1
   exact ⟨exi_of_subset_extendUniversal_singleton M
@@ -389,7 +389,7 @@ private theorem exi_poss_atom_of_subset_extendUniversal
     route through flatness). -/
 theorem distributionEpi {P Q : Pred} {x : Var} (hSB : M.IsStateBased s)
     (h : support M
-      (QBSMLFormula.enrich (.univ x (.disj (.pred P x) (.pred Q x)))) s) :
+      (Formula.enrich (.univ x (.disj (.pred P x) (.pred Q x)))) s) :
     support M (.exi x (.poss (.pred P x))) s ∧
     support M (.exi x (.poss (.pred Q x))) s := by
   obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1.1

--- a/Linglib/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Logic/Modal/QBSML/Properties.lean
@@ -23,11 +23,11 @@ empty-team support, hence flat support, via the same
   ([anttila-2021] Proposition 2.2.16, QBSML specialisation).
 * `soundFor_flat_neFree` — the NE-free fragment is sound for the flat cell
   of `Team/Definability.lean`.
-* `QBSMLFormula.toFormula?`,
+* `Formula.toFormula?`,
   `support_iff_forall_realizeAt` — the modal-free case of
   [aloni-vanormondt-2023] Proposition 4.1: support of a translatable formula
   is mathlib `Formula.Realize` at every index.
-* `QBSMLFormula.toModal?`, `support_iff_forall_realize` — the **full**
+* `Formula.toModal?`, `support_iff_forall_realize` — the **full**
   Proposition 4.1: the NE-free fragment (modals included) translates into
   `ModalFormula` over `Logic/FirstOrder/Kripke.lean`, and support is
   Kripke satisfaction at every index; the translation is total on exactly
@@ -66,8 +66,8 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
     cases use `State.extendUniversal_empty` and
     `State.extendFunctional_empty`. -/
 private theorem support_and_antiSupport_empty_of_isNEFree
-    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree)
-    (M : QBSMLModel W Domain Const Pred) :
+    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree)
+    (M : Model W Domain Const Pred) :
     support M φ (∅ : Finset (Index W Var Domain)) ∧
     antiSupport M φ (∅ : Finset (Index W Var Domain)) := by
   induction hNE with
@@ -112,8 +112,8 @@ private theorem support_and_antiSupport_empty_of_isNEFree
       exact ih.2
 
 /-- NE-free QBSML formulas are supported on the empty team. -/
-theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
+theorem support_empty_of_isNEFree {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
     support M φ ∅ :=
   (support_and_antiSupport_empty_of_isNEFree hNE M).1
 
@@ -127,8 +127,8 @@ theorem support_empty_of_isNEFree {φ : QBSMLFormula Var Const Pred}
     `t.extendFunctional x h_t` to `(t \ s).extendFunctional x h_t`, so all
     four properties have to live inside one induction. -/
 private theorem support_and_antiSupport_dc_uc_of_isNEFree
-    {φ : QBSMLFormula Var Const Pred} (hNE : φ.IsNEFree)
-    (M : QBSMLModel W Domain Const Pred) :
+    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree)
+    (M : Model W Domain Const Pred) :
     -- (1) DC support
     (∀ s t : Finset (Index W Var Domain), t ⊆ s → support M φ s → support M φ t) ∧
     -- (2) UC support
@@ -346,8 +346,8 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
 
 /-- NE-free QBSML formulas are downward-closed ([anttila-2021]
     Proposition 2.2.8 part 1, extended to first-order). -/
-theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
+theorem isLowerSet_support_of_isNEFree {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
     IsLowerSet { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ _ hab hb =>
     (support_and_antiSupport_dc_uc_of_isNEFree hNE M).1 _ _ hab hb
@@ -358,8 +358,8 @@ theorem isLowerSet_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
     QBSML's `exi` UC case needs downward closure of the subformula as IH
     (see the module docstring), so the QBSML version narrows to NE-free.
     The downstream flat corollary consumes NE-free anyway. -/
-theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
+theorem supClosed_support_of_isNEFree {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
     SupClosed { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ ha _ hb =>
     (support_and_antiSupport_dc_uc_of_isNEFree hNE M).2.1 _ _ ha hb
@@ -370,8 +370,8 @@ theorem supClosed_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
     QBSML formulas are flat. Derived from [anttila-2021] Proposition 2.2.2
     (`Team.isFlat_iff`) applied to the three closure properties
     above. -/
-theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred) :
+theorem isFlat_support_of_isNEFree {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
     IsFlat { t : Finset (Index W Var Domain) | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
     (isLowerSet_support_of_isNEFree hNE M)
@@ -392,9 +392,9 @@ theorem isFlat_support_of_isNEFree {φ : QBSMLFormula Var Const Pred}
     docstring), which NE breaks. So QBSML has no unconditional all-formula
     cell — unlike BSML, whose NE-bearing formulas still land in the convex,
     union-closed cell. -/
-theorem soundFor_flat_neFree (M : QBSMLModel W Domain Const Pred) :
+theorem soundFor_flat_neFree (M : Model W Domain Const Pred) :
     definableClassWhere (support M)
-      (fun φ : QBSMLFormula Var Const Pred => φ.IsNEFree) ⊆ flatProperties := by
+      (fun φ : Formula Var Const Pred => φ.IsNEFree) ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)
     fun _φ hφ => isFlat_support_of_isNEFree hφ M
@@ -409,7 +409,7 @@ arranged in De Morgan pairs — so each is `Iff.rfl`. -/
 
 section Fact1
 
-variable (M : QBSMLModel W Domain Const Pred) (φ ψ : QBSMLFormula Var Const Pred)
+variable (M : Model W Domain Const Pred) (φ ψ : Formula Var Const Pred)
   (x : Var) (s : Finset (Index W Var Domain))
 
 /-- Double negation elimination ([aloni-vanormondt-2023] Fact 1). -/
@@ -433,7 +433,7 @@ theorem support_neg_nec :
 
 /-- Modal duality: `¬◇φ ≡ □¬φ` ([aloni-vanormondt-2023] Fact 1). -/
 theorem support_neg_poss :
-    support M (.neg (.poss φ)) s ↔ support M (QBSMLFormula.neg φ).nec s :=
+    support M (.neg (.poss φ)) s ↔ support M (Formula.neg φ).nec s :=
   Iff.rfl
 
 /-- Quantifier duality: `¬∀xφ ≡ ∃x¬φ` ([aloni-vanormondt-2023] Fact 1). -/
@@ -452,16 +452,16 @@ end Fact1
 
 /-- Flat (NE-free) support is pointwise: a team supports `φ` iff each of its
     singletons does (`Team.IsFlat` unfolded at the support set). -/
-theorem support_iff_forall_singleton {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred)
+theorem support_iff_forall_singleton {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     support M φ s ↔ ∀ i ∈ s, support M φ {i} :=
   isFlat_support_of_isNEFree hNE M s
 
 /-- Anti-support of an NE-free formula is likewise pointwise: flatness of the
     bilateral negation. -/
-theorem antiSupport_iff_forall_singleton {φ : QBSMLFormula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : QBSMLModel W Domain Const Pred)
+theorem antiSupport_iff_forall_singleton {φ : Formula Var Const Pred}
+    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     antiSupport M φ s ↔ ∀ i ∈ s, antiSupport M φ {i} :=
   support_iff_forall_singleton (.neg hNE) M s
@@ -474,16 +474,16 @@ theorem antiSupport_iff_forall_singleton {φ : QBSMLFormula Var Const Pred}
     the same states. Atom-rewriting operations (e.g. [yan-2023]'s
     reinterpretation function, `Studies/Yan2023.lean`) get truth-conditional
     harmlessness for the price of their two atom lemmas. -/
-theorem eval_mapAtoms_iff (M : QBSMLModel W Domain Const Pred)
-    {fp : Pred → Var → QBSMLFormula Var Const Pred}
-    {fc : Pred → Const → QBSMLFormula Var Const Pred}
+theorem eval_mapAtoms_iff (M : Model W Domain Const Pred)
+    {fp : Pred → Var → Formula Var Const Pred}
+    {fc : Pred → Const → Formula Var Const Pred}
     (hfp : ∀ (P : Pred) (x : Var) (b : Bool)
       (s : Finset (Index W Var Domain)),
       eval M b (fp P x) s ↔ eval M b (.pred P x) s)
     (hfc : ∀ (P : Pred) (c : Const) (b : Bool)
       (s : Finset (Index W Var Domain)),
       eval M b (fc P c) s ↔ eval M b (.predc P c) s)
-    (φ : QBSMLFormula Var Const Pred) :
+    (φ : Formula Var Const Pred) :
     ∀ (b : Bool) (s : Finset (Index W Var Domain)),
       eval M b (φ.mapAtoms fp fc) s ↔ eval M b φ s := by
   induction φ with
@@ -561,16 +561,16 @@ theorem eval_mapAtoms_iff (M : QBSMLModel W Domain Const Pred)
 
 /-- Disjunction introduction: `α ⊨ α ∨ β` for NE-free `β` (the right
     disjunct is supported by the empty half of the split). -/
-theorem support_disj_inl (M : QBSMLModel W Domain Const Pred)
-    {α β : QBSMLFormula Var Const Pred} (hβ : β.IsNEFree)
+theorem support_disj_inl (M : Model W Domain Const Pred)
+    {α β : Formula Var Const Pred} (hβ : β.IsNEFree)
     {s : Finset (Index W Var Domain)} (h : support M α s) :
     support M (.disj α β) s :=
   ⟨s, ∅, splitsAs_self_empty s, h, support_empty_of_isNEFree hβ M⟩
 
 /-- Support of the derived `□` is pointwise support at the full accessible
     lift — definitional, by the `neg`/`poss` clauses of `eval`. -/
-@[simp] theorem support_nec_iff (M : QBSMLModel W Domain Const Pred)
-    (φ : QBSMLFormula Var Const Pred) (s : Finset (Index W Var Domain)) :
+@[simp] theorem support_nec_iff (M : Model W Domain Const Pred)
+    (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain)) :
     support M φ.nec s ↔
       ∀ i ∈ s, support M φ
         (State.modalLift (M.access i.world) i.assign) :=
@@ -578,8 +578,8 @@ theorem support_disj_inl (M : QBSMLModel W Domain Const Pred)
 
 /-- `□` is monotone: a state-wise entailment between prejacents lifts to
     their necessitations. -/
-theorem support_nec_mono (M : QBSMLModel W Domain Const Pred)
-    {α β : QBSMLFormula Var Const Pred}
+theorem support_nec_mono (M : Model W Domain Const Pred)
+    {α β : Formula Var Const Pred}
     (h : ∀ t : Finset (Index W Var Domain), support M α t → support M β t)
     {s : Finset (Index W Var Domain)} (hα : support M α.nec s) :
     support M β.nec s :=
@@ -593,8 +593,8 @@ theorem support_nec_mono (M : QBSMLModel W Domain Const Pred)
     (`State.extendFunctional_filter_of_update_mem`). The shared
     existential-witness step of the free-choice facts
     (`Logic/Modal/QBSML/FreeChoice.lean`). -/
-theorem support_exi_of_update_closure (M : QBSMLModel W Domain Const Pred)
-    {γ : QBSMLFormula Var Const Pred} {x : Var}
+theorem support_exi_of_update_closure (M : Model W Domain Const Pred)
+    {γ : Formula Var Const Pred} {x : Var}
     {s t : Finset (Index W Var Domain)}
     (hpar : ∀ j ∈ t, ∃ i ∈ s, ∃ d, i.update x d = j)
     (hcov : ∀ i ∈ s, ∃ d, i.update x d ∈ t)
@@ -611,7 +611,7 @@ theorem support_exi_of_update_closure (M : QBSMLModel W Domain Const Pred)
 
 [aloni-vanormondt-2023] Proposition 4.1 reduces the NE-free fragment to
 classical quantified modal logic. The modal-free part of that reduction is
-stated against mathlib first-order satisfaction: `QBSMLFormula.toFormula?`
+stated against mathlib first-order satisfaction: `Formula.toFormula?`
 translates the fragment into `(monadicLang Const Pred).Formula Var` — quantifiers
 via the computable named binders `Formula.all₁` / `Formula.ex₁` of
 `Core/ModelTheory/Binders.lean` — support at a singleton state is
@@ -625,7 +625,7 @@ open FirstOrder Language
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
 @[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁
-    (M : QBSMLModel W Domain Const Pred)
+    (M : Model W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     M.RealizeAt w ((monadicRel P).formula₁ (Term.var x)) v ↔
       M.pInterp P w (v x) := by
@@ -639,7 +639,7 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
 @[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁_const
-    (M : QBSMLModel W Domain Const Pred) (P : Pred) (c : Const) (w : W)
+    (M : Model W Domain Const Pred) (P : Pred) (c : Const) (w : W)
     (v : Var → Domain) :
     M.RealizeAt w
       ((monadicRel P).formula₁ (Constants.term (monadicConst c))) v ↔
@@ -659,8 +659,8 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
     formulas over the monadic signature: quantifiers via the computable named
     binders `Formula.all₁` / `Formula.ex₁` (`none` on `NE` and modal
     formulas). -/
-def QBSMLFormula.toFormula? :
-    QBSMLFormula Var Const Pred → Option ((monadicLang Const Pred).Formula Var)
+def Formula.toFormula? :
+    Formula Var Const Pred → Option ((monadicLang Const Pred).Formula Var)
   | .pred P x => some ((monadicRel P).formula₁ (Term.var x))
   | .predc P c => some ((monadicRel P).formula₁ (Constants.term (monadicConst c)))
   | .neg φ => φ.toFormula?.map (·.not)
@@ -673,7 +673,7 @@ def QBSMLFormula.toFormula? :
 omit [DecidableEq W] [Fintype Var] in
 /-- Translatable formulas are NE-free. -/
 theorem isNEFree_of_toFormula? :
-    ∀ {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
+    ∀ {φ : Formula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
       φ.toFormula? = some ψ → φ.IsNEFree := by
   intro φ
   induction φ with
@@ -682,36 +682,36 @@ theorem isNEFree_of_toFormula? :
   | neg φ ih =>
     intro ψ hψ
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α => exact .neg (ih hφ)
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ
     cases hφ₁ : φ₁.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ₁] at hψ
+    | none => simp [Formula.toFormula?, hφ₁] at hψ
     | some α =>
       cases hφ₂ : φ₂.toFormula? with
-      | none => simp [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+      | none => simp [Formula.toFormula?, hφ₁, hφ₂] at hψ
       | some β => exact .conj (ih₁ hφ₁) (ih₂ hφ₂)
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ
     cases hφ₁ : φ₁.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ₁] at hψ
+    | none => simp [Formula.toFormula?, hφ₁] at hψ
     | some α =>
       cases hφ₂ : φ₂.toFormula? with
-      | none => simp [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+      | none => simp [Formula.toFormula?, hφ₁, hφ₂] at hψ
       | some β => exact .disj (ih₁ hφ₁) (ih₂ hφ₂)
   | exi x φ ih =>
     intro ψ hψ
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α => exact .exi x (ih hφ)
   | univ x φ ih =>
     intro ψ hψ
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α => exact .univ x (ih hφ)
-  | ne => intro ψ hψ; simp [QBSMLFormula.toFormula?] at hψ
-  | poss _ _ => intro ψ hψ; simp [QBSMLFormula.toFormula?] at hψ
+  | ne => intro ψ hψ; simp [Formula.toFormula?] at hψ
+  | poss _ _ => intro ψ hψ; simp [Formula.toFormula?] at hψ
 
 omit [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
 /-- Updating an index's assignment refines the matching valuation update. -/
@@ -734,8 +734,8 @@ private lemma update_refines {i : Index W Var Domain} {v : Var → Domain}
     pointwise via flatness and apply the IH at the updated index and
     valuation. -/
 private theorem support_and_antiSupport_singleton_realizeAt
-    (M : QBSMLModel W Domain Const Pred) :
-    ∀ {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
+    (M : Model W Domain Const Pred) :
+    ∀ {φ : Formula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var},
       φ.toFormula? = some ψ →
       ∀ {i : Index W Var Domain} {v : Var → Domain},
         (∀ y, i.assign y = some (v y)) →
@@ -745,7 +745,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
   induction φ with
   | pred P x =>
     intro ψ hψ i v hv
-    rw [show (QBSMLFormula.pred P x).toFormula? =
+    rw [show (Formula.pred P x).toFormula? =
         some ((monadicRel P).formula₁ (Term.var x)) from rfl,
       Option.some.injEq] at hψ
     subst hψ
@@ -772,7 +772,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         exact ⟨v x, hv x, h⟩
   | predc P c =>
     intro ψ hψ i v hv
-    rw [show (QBSMLFormula.predc P c).toFormula? =
+    rw [show (Formula.predc P c).toFormula? =
         some ((monadicRel P).formula₁ (Constants.term (monadicConst c)))
         from rfl,
       Option.some.injEq] at hψ
@@ -796,9 +796,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
   | neg φ ih =>
     intro ψ hψ i v hv
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α =>
-      simp only [QBSMLFormula.toFormula?, hφ] at hψ
+      simp only [Formula.toFormula?, hφ] at hψ
       rw [Option.map_some, Option.some.injEq] at hψ
       subst hψ
       obtain ⟨ihs, iha⟩ := ih hφ hv
@@ -810,12 +810,12 @@ private theorem support_and_antiSupport_singleton_realizeAt
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ i v hv
     cases hφ₁ : φ₁.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ₁] at hψ
+    | none => simp [Formula.toFormula?, hφ₁] at hψ
     | some α =>
       cases hφ₂ : φ₂.toFormula? with
-      | none => simp [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+      | none => simp [Formula.toFormula?, hφ₁, hφ₂] at hψ
       | some β =>
-        simp only [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+        simp only [Formula.toFormula?, hφ₁, hφ₂] at hψ
         rw [Option.bind_some, Option.map_some, Option.some.injEq] at hψ
         subst hψ
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
@@ -847,12 +847,12 @@ private theorem support_and_antiSupport_singleton_realizeAt
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ i v hv
     cases hφ₁ : φ₁.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ₁] at hψ
+    | none => simp [Formula.toFormula?, hφ₁] at hψ
     | some α =>
       cases hφ₂ : φ₂.toFormula? with
-      | none => simp [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+      | none => simp [Formula.toFormula?, hφ₁, hφ₂] at hψ
       | some β =>
-        simp only [QBSMLFormula.toFormula?, hφ₁, hφ₂] at hψ
+        simp only [Formula.toFormula?, hφ₁, hφ₂] at hψ
         rw [Option.bind_some, Option.map_some, Option.some.injEq] at hψ
         subst hψ
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
@@ -884,9 +884,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
   | exi x φ ih =>
     intro ψ hψ i v hv
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α =>
-      simp only [QBSMLFormula.toFormula?, hφ] at hψ
+      simp only [Formula.toFormula?, hφ] at hψ
       rw [Option.map_some, Option.some.injEq] at hψ
       subst hψ
       have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
@@ -926,9 +926,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
   | univ x φ ih =>
     intro ψ hψ i v hv
     cases hφ : φ.toFormula? with
-    | none => simp [QBSMLFormula.toFormula?, hφ] at hψ
+    | none => simp [Formula.toFormula?, hφ] at hψ
     | some α =>
-      simp only [QBSMLFormula.toFormula?, hφ] at hψ
+      simp only [Formula.toFormula?, hφ] at hψ
       rw [Option.map_some, Option.some.injEq] at hψ
       subst hψ
       have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
@@ -965,15 +965,15 @@ private theorem support_and_antiSupport_singleton_realizeAt
           subst hd'
           subst hupd
           exact ((ih hφ (update_refines hv x d')).2).mpr hd
-  | ne => intro ψ hψ; simp [QBSMLFormula.toFormula?] at hψ
-  | poss _ _ => intro ψ hψ; simp [QBSMLFormula.toFormula?] at hψ
+  | ne => intro ψ hψ; simp [Formula.toFormula?] at hψ
+  | poss _ _ => intro ψ hψ; simp [Formula.toFormula?] at hψ
 
 /-- **[aloni-vanormondt-2023] Proposition 4.1, singleton case** (modal-free
     fragment): support of a translatable formula at a singleton state is
     classical first-order satisfaction at that index's world, for any total
     valuation the index's partial assignment refines. -/
-theorem support_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
+theorem support_singleton_iff_realizeAt (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
     support M φ {i} ↔ M.RealizeAt i.world ψ v :=
@@ -981,8 +981,8 @@ theorem support_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
 
 /-- Anti-support of a translatable formula at a singleton state is the
     classical falsity of its translation. -/
-theorem antiSupport_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
+theorem antiSupport_singleton_iff_realizeAt (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
     antiSupport M φ {i} ↔ ¬ M.RealizeAt i.world ψ v :=
@@ -992,8 +992,8 @@ theorem antiSupport_singleton_iff_realizeAt (M : QBSMLModel W Domain Const Pred)
     translatable formula is supported by a state iff it is classically
     satisfied at every index — `M, s ⊨ φ(x̄)` iff `M, w ⊨_g φ(x̄)` for all
     `⟨w, g⟩ ∈ s`, with the right-hand side mathlib's `Formula.Realize`. -/
-theorem support_iff_forall_realizeAt (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
+theorem support_iff_forall_realizeAt (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred} {ψ : (monadicLang Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) (s : Finset (Index W Var Domain))
     (v : Index W Var Domain → Var → Domain)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
@@ -1004,7 +1004,7 @@ theorem support_iff_forall_realizeAt (M : QBSMLModel W Domain Const Pred)
 
 /-! ### Classicality II: the full modal bridge
 
-The complete [aloni-vanormondt-2023] Proposition 4.1: `QBSMLFormula.toModal?`
+The complete [aloni-vanormondt-2023] Proposition 4.1: `Formula.toModal?`
 translates the **whole NE-free fragment** — modals included — into
 `ModalFormula` over the monadic signature
 (`Logic/FirstOrder/Kripke.lean`), and support is Kripke satisfaction at
@@ -1013,8 +1013,8 @@ every index. The translation is total on exactly the NE-free fragment. -/
 /-- Translate QBSML into modal formulas over the monadic signature: atoms
     embed as classical formulas, `◇` becomes the derived `ModalFormula.dia`,
     quantifiers become named binders; only `NE` returns `none`. -/
-def QBSMLFormula.toModal? :
-    QBSMLFormula Var Const Pred →
+def Formula.toModal? :
+    Formula Var Const Pred →
       Option (ModalFormula (monadicLang Const Pred) Var)
   | .pred P x => some (.ofFormula ((monadicRel P).formula₁ (Term.var x)))
   | .predc P c =>
@@ -1033,7 +1033,7 @@ def QBSMLFormula.toModal? :
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- Modally translatable formulas are NE-free. -/
 theorem isNEFree_of_toModal? :
-    ∀ {φ : QBSMLFormula Var Const Pred}
+    ∀ {φ : Formula Var Const Pred}
       {τ : ModalFormula (monadicLang Const Pred) Var},
       φ.toModal? = some τ → φ.IsNEFree := by
   intro φ
@@ -1043,47 +1043,47 @@ theorem isNEFree_of_toModal? :
   | neg φ ih =>
     intro τ hτ
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α => exact .neg (ih hφ)
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro τ hτ
     cases hφ₁ : φ₁.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | none => simp [Formula.toModal?, hφ₁] at hτ
     | some α =>
       cases hφ₂ : φ₂.toModal? with
-      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | none => simp [Formula.toModal?, hφ₁, hφ₂] at hτ
       | some β => exact .conj (ih₁ hφ₁) (ih₂ hφ₂)
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro τ hτ
     cases hφ₁ : φ₁.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | none => simp [Formula.toModal?, hφ₁] at hτ
     | some α =>
       cases hφ₂ : φ₂.toModal? with
-      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | none => simp [Formula.toModal?, hφ₁, hφ₂] at hτ
       | some β => exact .disj (ih₁ hφ₁) (ih₂ hφ₂)
   | poss φ ih =>
     intro τ hτ
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α => exact .poss (ih hφ)
   | exi x φ ih =>
     intro τ hτ
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α => exact .exi x (ih hφ)
   | univ x φ ih =>
     intro τ hτ
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α => exact .univ x (ih hφ)
-  | ne => intro τ hτ; simp [QBSMLFormula.toModal?] at hτ
+  | ne => intro τ hτ; simp [Formula.toModal?] at hτ
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- The modal translation is total on the NE-free fragment: together with
     `isNEFree_of_toModal?`, the translatable and NE-free fragments
     coincide. -/
 theorem exists_toModal?_of_isNEFree :
-    ∀ {φ : QBSMLFormula Var Const Pred}, φ.IsNEFree →
+    ∀ {φ : Formula Var Const Pred}, φ.IsNEFree →
       ∃ τ, φ.toModal? = some τ := by
   intro φ h
   induction h with
@@ -1091,24 +1091,24 @@ theorem exists_toModal?_of_isNEFree :
   | predc P c => exact ⟨_, rfl⟩
   | neg _ ih =>
     obtain ⟨τ, hτ⟩ := ih
-    exact ⟨.not τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+    exact ⟨.not τ, by simp [Formula.toModal?, hτ]⟩
   | conj _ _ ih₁ ih₂ =>
     obtain ⟨τ₁, hτ₁⟩ := ih₁
     obtain ⟨τ₂, hτ₂⟩ := ih₂
-    exact ⟨.inf τ₁ τ₂, by simp [QBSMLFormula.toModal?, hτ₁, hτ₂]⟩
+    exact ⟨.inf τ₁ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
   | disj _ _ ih₁ ih₂ =>
     obtain ⟨τ₁, hτ₁⟩ := ih₁
     obtain ⟨τ₂, hτ₂⟩ := ih₂
-    exact ⟨.sup τ₁ τ₂, by simp [QBSMLFormula.toModal?, hτ₁, hτ₂]⟩
+    exact ⟨.sup τ₁ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
   | poss _ ih =>
     obtain ⟨τ, hτ⟩ := ih
-    exact ⟨τ.dia, by simp [QBSMLFormula.toModal?, hτ]⟩
+    exact ⟨τ.dia, by simp [Formula.toModal?, hτ]⟩
   | @exi x _ _ ih =>
     obtain ⟨τ, hτ⟩ := ih
-    exact ⟨.ex x τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+    exact ⟨.ex x τ, by simp [Formula.toModal?, hτ]⟩
   | @univ x _ _ ih =>
     obtain ⟨τ, hτ⟩ := ih
-    exact ⟨.all x τ, by simp [QBSMLFormula.toModal?, hτ]⟩
+    exact ⟨.all x τ, by simp [Formula.toModal?, hτ]⟩
 
 /-- Joint singleton bridge for the **full** NE-free fragment: support of a
     modally translatable formula at `{i}` is Kripke satisfaction at
@@ -1116,8 +1116,8 @@ theorem exists_toModal?_of_isNEFree :
     accessible lift pointwise via flatness: a nonempty witnessing subteam
     collapses to a single accessible world. -/
 private theorem support_and_antiSupport_singleton_realize
-    (M : QBSMLModel W Domain Const Pred) :
-    ∀ {φ : QBSMLFormula Var Const Pred}
+    (M : Model W Domain Const Pred) :
+    ∀ {φ : Formula Var Const Pred}
       {τ : ModalFormula (monadicLang Const Pred) Var},
       φ.toModal? = some τ →
       ∀ {i : Index W Var Domain} {v : Var → Domain},
@@ -1128,7 +1128,7 @@ private theorem support_and_antiSupport_singleton_realize
   induction φ with
   | pred P x =>
     intro τ hτ i v hv
-    rw [show (QBSMLFormula.pred P x).toModal? =
+    rw [show (Formula.pred P x).toModal? =
         some (.ofFormula ((monadicRel P).formula₁ (Term.var x))) from rfl,
       Option.some.injEq] at hτ
     subst hτ
@@ -1155,7 +1155,7 @@ private theorem support_and_antiSupport_singleton_realize
         exact ⟨v x, hv x, h⟩
   | predc P c =>
     intro τ hτ i v hv
-    rw [show (QBSMLFormula.predc P c).toModal? =
+    rw [show (Formula.predc P c).toModal? =
         some (.ofFormula ((monadicRel P).formula₁
           (Constants.term (monadicConst c)))) from rfl,
       Option.some.injEq] at hτ
@@ -1179,9 +1179,9 @@ private theorem support_and_antiSupport_singleton_realize
   | neg φ ih =>
     intro τ hτ i v hv
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α =>
-      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
       obtain ⟨ihs, iha⟩ := ih hφ hv
@@ -1193,12 +1193,12 @@ private theorem support_and_antiSupport_singleton_realize
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro τ hτ i v hv
     cases hφ₁ : φ₁.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | none => simp [Formula.toModal?, hφ₁] at hτ
     | some α =>
       cases hφ₂ : φ₂.toModal? with
-      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | none => simp [Formula.toModal?, hφ₁, hφ₂] at hτ
       | some β =>
-        simp only [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+        simp only [Formula.toModal?, hφ₁, hφ₂] at hτ
         rw [Option.bind_some, Option.map_some, Option.some.injEq] at hτ
         subst hτ
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
@@ -1231,12 +1231,12 @@ private theorem support_and_antiSupport_singleton_realize
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro τ hτ i v hv
     cases hφ₁ : φ₁.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ₁] at hτ
+    | none => simp [Formula.toModal?, hφ₁] at hτ
     | some α =>
       cases hφ₂ : φ₂.toModal? with
-      | none => simp [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+      | none => simp [Formula.toModal?, hφ₁, hφ₂] at hτ
       | some β =>
-        simp only [QBSMLFormula.toModal?, hφ₁, hφ₂] at hτ
+        simp only [Formula.toModal?, hφ₁, hφ₂] at hτ
         rw [Option.bind_some, Option.map_some, Option.some.injEq] at hτ
         subst hτ
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
@@ -1269,9 +1269,9 @@ private theorem support_and_antiSupport_singleton_realize
   | poss φ ih =>
     intro τ hτ i v hv
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α =>
-      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
       have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
@@ -1312,9 +1312,9 @@ private theorem support_and_antiSupport_singleton_realize
   | exi x φ ih =>
     intro τ hτ i v hv
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α =>
-      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
       have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
@@ -1354,9 +1354,9 @@ private theorem support_and_antiSupport_singleton_realize
   | univ x φ ih =>
     intro τ hτ i v hv
     cases hφ : φ.toModal? with
-    | none => simp [QBSMLFormula.toModal?, hφ] at hτ
+    | none => simp [Formula.toModal?, hφ] at hτ
     | some α =>
-      simp only [QBSMLFormula.toModal?, hφ] at hτ
+      simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
       have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
@@ -1393,13 +1393,13 @@ private theorem support_and_antiSupport_singleton_realize
           subst hd'
           subst hupd
           exact ((ih hφ (update_refines hv x d')).2).mpr hd
-  | ne => intro τ hτ; simp [QBSMLFormula.toModal?] at hτ
+  | ne => intro τ hτ; simp [Formula.toModal?] at hτ
 
 /-- **[aloni-vanormondt-2023] Proposition 4.1, singleton case** (full
     NE-free fragment): support of a modally translatable formula at a
     singleton state is Kripke satisfaction at that index's world. -/
-theorem support_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+theorem support_singleton_iff_realize (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var}
     (hτ : φ.toModal? = some τ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
@@ -1408,8 +1408,8 @@ theorem support_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
 
 /-- Anti-support of a modally translatable formula at a singleton state is
     classical modal falsity. -/
-theorem antiSupport_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+theorem antiSupport_singleton_iff_realize (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var}
     (hτ : φ.toModal? = some τ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
@@ -1421,8 +1421,8 @@ theorem antiSupport_singleton_iff_realize (M : QBSMLModel W Domain Const Pred)
     classically satisfied at every index — `M, s ⊨ φ(x̄)` iff
     `M, w ⊨_g φ(x̄)` for all `⟨w, g⟩ ∈ s`, the right-hand side Kripke
     satisfaction over mathlib structures. -/
-theorem support_iff_forall_realize (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+theorem support_iff_forall_realize (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var}
     (hτ : φ.toModal? = some τ) (s : Finset (Index W Var Domain))
     (v : Index W Var Domain → Var → Domain)

--- a/Linglib/Logic/Modal/QBSML/StandardTranslation.lean
+++ b/Linglib/Logic/Modal/QBSML/StandardTranslation.lean
@@ -155,7 +155,7 @@ def stTerm (k : ℕ) :
     | _ + 1, f => f.elim
 
 /-- Translate an embedded classical formula when it is a monadic atom
-    (`none` otherwise — which never arises from `QBSMLFormula.toModal?`
+    (`none` otherwise — which never arises from `Formula.toModal?`
     images, whose embedded formulas are exactly the atoms). -/
 def stAtom? (k : ℕ) :
     (monadicLang Const Pred).Formula Var →
@@ -541,8 +541,8 @@ variable [DecidableEq W] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
     of the standard translation over `stStructure` — the link along which
     classical model theory (compactness, Löwenheim–Skolem) transfers to the
     NE-free fragment. -/
-theorem support_singleton_iff_st (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+theorem support_singleton_iff_st (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var} {k : ℕ}
     {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)}
     (hτ : φ.toModal? = some τ) (hψ : τ.st? k = some ψ)
@@ -556,8 +556,8 @@ theorem support_singleton_iff_st (M : QBSMLModel W Domain Const Pred)
 
 /-- Support at a singleton state forces the closed standard translation,
     as a sentence of `stStructure`. -/
-theorem models_toSentence_of_support (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+theorem models_toSentence_of_support (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var}
     {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)}
     (hτ : φ.toModal? = some τ) (hψ : τ.st? 0 = some ψ)
@@ -583,8 +583,8 @@ theorem models_toSentence_of_support (M : QBSMLModel W Domain Const Pred)
 /-- Conversely, the closed standard translation as a sentence of
     `stStructure` yields support at some singleton state. -/
 theorem exists_support_of_models_toSentence [Nonempty Domain]
-    (M : QBSMLModel W Domain Const Pred)
-    {φ : QBSMLFormula Var Const Pred}
+    (M : Model W Domain Const Pred)
+    {φ : Formula Var Const Pred}
     {τ : ModalFormula (monadicLang Const Pred) Var}
     {ψ : (stLang Const Pred).Formula (Var ⊕ ℕ)}
     (hτ : φ.toModal? = some τ) (hψ : τ.st? 0 = some ψ)
@@ -634,7 +634,7 @@ open FirstOrder Language
     entailment-compactness in team logics. -/
 theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
     {Const : Type u} {Pred : Type v} {ι : Type*}
-    {φs : ι → QBSMLFormula Var Const Pred}
+    {φs : ι → Formula Var Const Pred}
     {τs : ι → ModalFormula (monadicLang Const Pred) Var}
     {ψs : ι → (stLang Const Pred).Formula (Var ⊕ ℕ)}
     (hτ : ∀ i, (φs i).toModal? = some (τs i))
@@ -642,7 +642,7 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
     (hcl : ∀ i, (stClose 0 (ψs i)).freeVarFinset = ∅)
     (hfin : ∀ s : Finset ι, ∃ (W Domain : Type max u v)
       (_ : DecidableEq W) (_ : DecidableEq Domain) (_ : Fintype Domain)
-      (M : QBSMLModel W Domain Const Pred) (i : Index W Var Domain)
+      (M : Model W Domain Const Pred) (i : Index W Var Domain)
       (v : Var → Domain), (∀ y, i.assign y = some (v y)) ∧
         ∀ j ∈ s, support M (φs j) {i}) :
     Theory.IsSatisfiable

--- a/Linglib/Studies/Aloni2022.lean
+++ b/Linglib/Studies/Aloni2022.lean
@@ -28,10 +28,10 @@ The universal results live in `Studies/Aloni2022/FreeChoice.lean`:
 
 This file uses **typed atoms** `FCAtom.{a, b}` (from `BSML.Atoms`)
 rather than String identifiers. The valuation routes directly through
-`PowerSet2World.holds`, eliminating the silent typo trap of the earlier
+`TwoAtomWorld.holds`, eliminating the silent typo trap of the earlier
 String-based pattern (`match p with | "coffee" => ... | _ => false`).
 
-Worlds are `PowerSet2World` (`nothing`/`onlyA`/`onlyB`/`both`), matching
+Worlds are `TwoAtomWorld` (`nothing`/`onlyA`/`onlyB`/`both`), matching
 Aloni 2022 Figure 1's `w_∅`/`w_a`/`w_b`/`w_ab`. We label `FCAtom.a` as
 "coffee" and `FCAtom.b` as "tea" in prose only — the formal types are
 the typed atoms throughout.
@@ -40,7 +40,7 @@ the typed atoms throughout.
 namespace Aloni2022
 
 open BSML
-open BSML (FCAtom PowerSet2World)
+open BSML (FCAtom TwoAtomWorld)
 
 -- ============================================================================
 -- §1 Teams
@@ -49,12 +49,12 @@ open BSML (FCAtom PowerSet2World)
 /-- The free-choice team: {`both`, `onlyA`, `onlyB`} = {w_ab, w_a, w_b}.
     Excludes `nothing` (= w_∅), the world that would supply a zero-witness
     substate for the disjunction enrichment. -/
-def freeChoiceTeam : Finset PowerSet2World :=
+def freeChoiceTeam : Finset TwoAtomWorld :=
   {.both, .onlyA, .onlyB}
 
 /-- The prohibition team: just `nothing` (= w_∅). With `restrictiveModel`,
     R[nothing] = {nothing} so the prohibition `¬◇(a ∨ b)` is supported. -/
-def prohibitionTeam : Finset PowerSet2World :=
+def prohibitionTeam : Finset TwoAtomWorld :=
   {.nothing}
 
 -- ============================================================================
@@ -67,14 +67,14 @@ def prohibitionTeam : Finset PowerSet2World :=
 
     Valuation: `val a w = w.holds a` — direct routing through the typed
     atom. No String fallthrough, no silent typos. -/
-def deonticModel : BSMLModel PowerSet2World FCAtom where
+def deonticModel : BSMLModel TwoAtomWorld FCAtom where
   access := λ _ => Finset.univ
   val := λ p w => w.holds p
 
 /-- Restrictive deontic model: from `nothing`, only `nothing` is accessible;
     from any other world, all worlds. Used for Dual Prohibition on the
     prohibition team `{nothing}`. -/
-def restrictiveModel : BSMLModel PowerSet2World FCAtom where
+def restrictiveModel : BSMLModel TwoAtomWorld FCAtom where
   access := λ w =>
     match w with
     | .nothing => {.nothing}
@@ -83,7 +83,7 @@ def restrictiveModel : BSMLModel PowerSet2World FCAtom where
 
 /-- State-based deontic model: R[w] = freeChoiceTeam for every world. Strictly
     stronger than indisputability; required for Modal Disjunction (Fact 3). -/
-def stateBasedModel : BSMLModel PowerSet2World FCAtom where
+def stateBasedModel : BSMLModel TwoAtomWorld FCAtom where
   access := λ _ => freeChoiceTeam
   val := λ p w => w.holds p
 
@@ -93,7 +93,7 @@ def stateBasedModel : BSMLModel PowerSet2World FCAtom where
     incidental: WS FC's conclusion may fail on this model even when its
     enriched premise is supported. (Aloni 2022 Figure 5(b) shape — non-indisputable R.
     Figure 5(a) shows the dual case where R is indisputable but enrichment fails.) -/
-def looseDeonticModel : BSMLModel PowerSet2World FCAtom where
+def looseDeonticModel : BSMLModel TwoAtomWorld FCAtom where
   access := λ w =>
     match w with
     | .both    => {.both, .onlyA}

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -3,53 +3,47 @@ import Linglib.Logic.Modal.QBSML.StandardTranslation
 import Linglib.Logic.Modal.BSML.Scenarios
 
 /-!
-# [aloni-vanormondt-2023]: QBSML applied to modified numerals + split disjunction
+# [aloni-vanormondt-2023]: modified numerals and split disjunction
 
-[aloni-vanormondt-2023] [aloni-2022]
+Aloni & van Ormondt 2023 introduce QBSML, the first-order extension of
+[aloni-2022]'s BSML, and analyse modified numerals as split disjunctions
+(`at least n φ ↦ n ∨ more`, `at most n φ ↦ n ∨ less`), so that the
+neglect-zero enrichment `[·]⁺` derives their ignorance, obviation,
+distribution, free-choice and negation profile (paper §5). The universal
+facts (3, 5–10) are substrate theorems in
+`Logic/Modal/QBSML/FreeChoice.lean`; this file instantiates them at a
+concrete model and proves the paper's one countermodel claim.
 
-Aloni & van Ormondt 2023 introduces QBSML, the first-order extension of
-Aloni 2022's BSML, and applies it to a battery of inferences arising from
-modified numerals analysed as disjunctions:
-  `at least n φ ↦ n ∨ more`,  `at most n φ ↦ n ∨ less`.
+## Main declarations
 
-The framework's central facts (paper §5):
+* `univAccessModel` — universal-access model over `BSML.PowerSet2World`:
+  indisputable on every state (`univAccessModel_indisputable`) and state-based
+  exactly on states with full world projection
+  (`univAccessModel_stateBased_of_full`).
+* `fact3_ignorance` … `fact10_negation` — the paper's §5 facts at
+  `univAccessModel`, one-line instances of the substrate theorems; the epistemic
+  Facts 3 and 6 hold on full-world-projection states.
+* `fig14Model`, `fact4_obviation` — **Fact 4 (obviation)**:
+  `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, by the paper's Fig. 14 countermodel;
+  `R` is state-based on the countermodel state (`fig14_stateBased`), the
+  epistemic reading Fact 4 assumes.
+* `univPxOrQx_classical`, `possPxOrQx_classical`, `univPxOrQx_sentence` —
+  [aloni-vanormondt-2023] Proposition 4.1 at `univAccessModel`: support of NE-free
+  formulas is classical realization (mathlib `Formula.Realize`) resp. Kripke
+  satisfaction, the translations computed by `rfl`, and the standard
+  translation of `∀x(Px ∨ Qx)` a genuine sentence.
 
-| Fact | Statement |
-|------|-----------|
-| 3   | `[Pa ∨ Pb]⁺ ⊨_epi ◇Pa ∧ ◇Pb` (ignorance, R state-based) |
-| 4   | `[∀xPx ∨ Qx]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)` (obviation; counterexample on paper Fig. 14) |
-| 5   | `card(s)=1 ⇒ M, s ⊨ [∀x(Px ∨ Qx)]⁺ ⇒ M, s ⊨ ∃xPx ∧ ∃xQx` (distribution under full information) |
-| 6   | `[∀x(Px ∨ Qx)]⁺ ⊨_epi ∃x◇Px ∧ ∃x◇Qx` (distribution° on epistemic models) |
-| 7   | `[□(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` (□-free choice) |
-| 8   | `[◇(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` (◇-free choice; ≡ Aloni 2022 NS FC at first-order) |
-| 9   | `[∀x◇(Px ∨ Qx)]⁺ ⊨ ∀x◇Px ∧ ∀x◇Qx` (universal FC; [chemla-2009]) |
-| 10  | `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb` (negation behaviour; ignorance disappears) |
+## Implementation notes
 
-Facts 3 and 5–10 are universal substrate theorems in
-`Logic/Modal/QBSML/FreeChoice.lean` (framework substrate with multiple
-paper-anchored consumers — this file and `Studies/Yan2023.lean`); this file
-instantiates the unconditional ones at a concrete model (`avoModel`).
-Fact 4 is the paper's Fig. 14 countermodel, proved here. Facts 1–2 and
-Proposition 4.1 live in `Logic/Modal/QBSML/{Enrichment,Properties}.lean`
-(the modal-free Proposition 4.1 against mathlib `Formula.Realize` is
-instantiated here at `avoModel`, the translation discharged by `rfl`).
-Fact 3 needs the individual constants of [aloni-vanormondt-2023]
-Definition 4.1 — `QBSMLFormula.predc` atoms, interpreted world-relatively
-via `QBSMLModel.cInterp`.
-
-## What is deferred
-
-- **`Decidable` instance for `QBSML.eval`**: well-defined, but of limited
-  use — the split-disjunction clauses quantify over pairs of subteams of
-  the index space (`2^12 × 2^12` already at this file's model sizes), so
-  kernel `decide` is infeasible for the interesting claims; the Fact 4
-  countermodel is therefore proved by hand.
-
-## Atoms and worlds
-
-The concrete model reuses `BSML.{FCAtom, PowerSet2World}`
-from the existing FreeChoice substrate, ensuring AvO 2023 + Aloni 2022 both
-target the same world space.
+`QBSML.eval` admits a `Decidable` instance in principle, but the
+split-disjunction clause quantifies over pairs of subteams (`2^12 × 2^12`
+at this file's model sizes), so kernel `decide` is infeasible for
+whole-formula claims; the Fact 4 countermodel is proved by hand, with
+`decide` confined to finite side conditions. Fact 3 is stated with the
+individual constants of the paper's Definition 4.1 (`QBSMLFormula.predc`
+atoms, world-relative `KripkeStructure.cInterp`). Atoms and worlds come
+from `Logic/Modal/BSML/Scenarios.lean`, so this file and
+`Studies/Aloni2022.lean` target the same world space.
 -/
 
 namespace AloniVanOrmondt2023
@@ -66,15 +60,11 @@ open BSML (FCAtom PowerSet2World QVar)
     over a 2-element domain, `Pa ∨ Qa` and `Pa ∨ Pb` are equally non-trivial
     instantiations of split disjunction. -/
 inductive QPred | P | Q
-  deriving DecidableEq, Repr
-
-instance : Fintype QPred where
-  elems := {.P, .Q}
-  complete := by intro p; cases p <;> simp
+  deriving DecidableEq, Repr, Fintype
 
 /-! ### The concrete model -/
 
-/-- Universal-access deontic-style model on `PowerSet2World`.
+/-- Universal-access model on `PowerSet2World`.
 
     The interpretation is the `monadicStructure` of the valuation
     `V w P d := w.holds d`: both predicates hold of `d` at `w` iff `w`
@@ -84,9 +74,11 @@ instance : Fintype QPred where
     further; this minimal model suffices for the substrate-instantiation
     tests below.
 
-    Universal access (`access _ = univ`) means R is indisputable on every
-    state but **not** state-based — same shape as `Aloni2022.deonticModel`. -/
-def avoModel : QBSMLModel PowerSet2World FCAtom FCAtom QPred where
+    Universal access (`access _ = univ`) makes `R` indisputable on every
+    state (`univAccessModel_indisputable`) and state-based exactly on states with
+    full world projection (`univAccessModel_stateBased_of_full`) — same shape as
+    `Aloni2022.deonticModel`. -/
+def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom QPred where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
@@ -124,7 +116,7 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
 
 /-! ### Fact 10 (negation): `[¬(Pa ∨ Pb)]⁺ ⊨ ¬Pa ∧ ¬Pb` -/
 
-/-- **Fact 10 (Negation behaviour)** at `avoModel`:
+/-- **Fact 10 (Negation behaviour)** at `univAccessModel`:
 
     Enriched negation `[¬(Px ∨ Qx)]⁺` entails the conjunction of negated
     disjuncts `¬Px ∧ ¬Qx`. One-line invocation of the substrate's
@@ -133,13 +125,13 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
     theorem, model + NE-free witnesses applied. -/
 theorem fact10_negation
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support avoModel negPxOrQx.enrich s) :
-    support avoModel (.neg Px) s ∧ support avoModel (.neg Qx) s :=
-  negationStrip avoModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel negPxOrQx.enrich s) :
+    support univAccessModel (.neg Px) s ∧ support univAccessModel (.neg Qx) s :=
+  negationStrip univAccessModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Facts 7 and 8 (free choice): `[□/◇(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` -/
 
-/-- **Fact 8 (Narrow-Scope free choice / ◇-FC)** at `avoModel`:
+/-- **Fact 8 (Narrow-Scope free choice / ◇-FC)** at `univAccessModel`:
 
     Enriched possibility-disjunction `[◇(Px ∨ Qx)]⁺` entails `◇Px ∧ ◇Qx`.
     One-line invocation of `narrowScopeFC`. The first-order analogue of
@@ -147,74 +139,74 @@ theorem fact10_negation
     monadic predicate language. -/
 theorem fact8_narrowScopeFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support avoModel possPxOrQx.enrich s) :
-    support avoModel (.poss Px) s ∧ support avoModel (.poss Qx) s :=
-  narrowScopeFC avoModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel possPxOrQx.enrich s) :
+    support univAccessModel (.poss Px) s ∧ support univAccessModel (.poss Qx) s :=
+  narrowScopeFC univAccessModel Px_isNEFree Qx_isNEFree h
 
-/-- **Fact 7 (□-free choice)** at `avoModel`: `[□(Px ∨ Qx)]⁺` entails
+/-- **Fact 7 (□-free choice)** at `univAccessModel`: `[□(Px ∨ Qx)]⁺` entails
     `◇Px ∧ ◇Qx`, with the derived `□`. One-line invocation of `boxFC`. -/
 theorem fact7_boxFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support avoModel necPxOrQx.enrich s) :
-    support avoModel (.poss Px) s ∧ support avoModel (.poss Qx) s :=
-  boxFC avoModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel necPxOrQx.enrich s) :
+    support univAccessModel (.poss Px) s ∧ support univAccessModel (.poss Qx) s :=
+  boxFC univAccessModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Facts 9 and 5 (universal FC and distribution) -/
 
-/-- **Fact 9 (Universal free choice)** at `avoModel`:
+/-- **Fact 9 (Universal free choice)** at `univAccessModel`:
 
     `[∀x◇(Px ∨ Qx)]⁺` entails `∀x◇Px ∧ ∀x◇Qx`. One-line invocation of
     `universalFC` — the [chemla-2009]-attested pattern. -/
 theorem fact9_universalFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support avoModel univPossPxOrQx.enrich s) :
-    support avoModel (.univ .x (.poss Px)) s ∧
-    support avoModel (.univ .x (.poss Qx)) s :=
-  universalFC avoModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel univPossPxOrQx.enrich s) :
+    support univAccessModel (.univ .x (.poss Px)) s ∧
+    support univAccessModel (.univ .x (.poss Qx)) s :=
+  universalFC univAccessModel Px_isNEFree Qx_isNEFree h
 
-/-- **Fact 5 (Distribution at maximal information)** at `avoModel`: on any
+/-- **Fact 5 (Distribution at maximal information)** at `univAccessModel`: on any
     singleton state, `[∀x(Px ∨ Qx)]⁺` entails `∃xPx ∧ ∃xQx`. One-line
     invocation of `distribution`. -/
 theorem fact5_distribution
     (i : Index PowerSet2World QVar FCAtom)
-    (h : support avoModel univPxOrQx.enrich {i}) :
-    support avoModel (.exi .x Px) {i} ∧ support avoModel (.exi .x Qx) {i} :=
-  distribution avoModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel univPxOrQx.enrich {i}) :
+    support univAccessModel (.exi .x Px) {i} ∧ support univAccessModel (.exi .x Qx) {i} :=
+  distribution univAccessModel Px_isNEFree Qx_isNEFree h
 
 /-! ### Proposition 4.1 at the concrete model -/
 
 /-- The (unenriched) universal premise `∀x(Px ∨ Qx)` translates into mathlib
     first-order syntax, and its support is classical `Formula.Realize` at
     every index — [aloni-vanormondt-2023] Proposition 4.1 instantiated at
-    `avoModel`. The translation hypothesis is discharged by `rfl`: the
+    `univAccessModel`. The translation hypothesis is discharged by `rfl`: the
     compiler computes. -/
 theorem univPxOrQx_classical
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
-    support avoModel univPxOrQx s ↔
-      ∀ i ∈ s, avoModel.RealizeAt i.world
+    support univAccessModel univPxOrQx s ↔
+      ∀ i ∈ s, univAccessModel.RealizeAt i.world
         (Formula.all₁ QVar.x
           ((monadicRel QPred.P).formula₁ (Term.var QVar.x) ⊔
             (monadicRel QPred.Q).formula₁ (Term.var QVar.x))) (v i) :=
-  support_iff_forall_realizeAt avoModel rfl s v hv
+  support_iff_forall_realizeAt univAccessModel rfl s v hv
 
 /-- The narrow-scope FC premise `◇(Px ∨ Qx)` translates into the modal layer
     over the monadic signature, and its support is Kripke satisfaction at
     every index — the **full** [aloni-vanormondt-2023] Proposition 4.1
-    (modals included) at `avoModel`, the translation discharged by `rfl`. -/
+    (modals included) at `univAccessModel`, the translation discharged by `rfl`. -/
 theorem possPxOrQx_classical
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
-    support avoModel possPxOrQx s ↔
+    support univAccessModel possPxOrQx s ↔
       ∀ i ∈ s,
         (ModalFormula.dia
           (.sup (.ofFormula ((monadicRel QPred.P).formula₁ (Term.var QVar.x)))
             (.ofFormula
               ((monadicRel QPred.Q).formula₁ (Term.var QVar.x))))).Realize
-          avoModel i.world (v i) :=
-  support_iff_forall_realize avoModel rfl s v hv
+          univAccessModel i.world (v i) :=
+  support_iff_forall_realize univAccessModel rfl s v hv
 
 /-- The closed standard translation of `∀x(Px ∨ Qx)`: quantifiers
     relativized to the individual sort, predicates world-relativized to the
@@ -233,49 +225,96 @@ theorem stUnivPxOrQx_closed :
     (stClose 0 stUnivPxOrQx).freeVarFinset = ∅ := by decide
 
 /-- Support of `∀x(Px ∨ Qx)` at a singleton forces its sort-guarded closed
-    standard translation as a **sentence** of `avoModel.stStructure` — the
+    standard translation as a **sentence** of `univAccessModel.stStructure` — the
     compactness-ready form, with every translation step (`toModal?`, `st?`,
     the free-variable check) computed by the compiler. -/
 theorem univPxOrQx_sentence
     (i : Index PowerSet2World QVar FCAtom) (v : QVar → FCAtom)
     (hv : ∀ y, i.assign y = some (v y))
-    (h : support avoModel univPxOrQx {i}) :
-    letI := avoModel.stStructure
+    (h : support univAccessModel univPxOrQx {i}) :
+    letI := univAccessModel.stStructure
     (PowerSet2World ⊕ FCAtom) ⊨
       (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed :=
-  models_toSentence_of_support avoModel rfl rfl stUnivPxOrQx_closed hv h
+  models_toSentence_of_support univAccessModel rfl rfl stUnivPxOrQx_closed hv h
 
 /-- Conversely, the sentence yields support at some singleton — sentencehood
     of the translation makes `∀x(Px ∨ Qx)`'s support assignment- and
     state-independent. -/
 theorem support_of_stUnivPxOrQx_sentence
-    (h : letI := avoModel.stStructure
+    (h : letI := univAccessModel.stStructure
          (PowerSet2World ⊕ FCAtom) ⊨
            (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed) :
     ∃ (i : Index PowerSet2World QVar FCAtom) (v : QVar → FCAtom),
-      (∀ y, i.assign y = some (v y)) ∧ support avoModel univPxOrQx {i} :=
+      (∀ y, i.assign y = some (v y)) ∧ support univAccessModel univPxOrQx {i} :=
   haveI : Nonempty FCAtom := ⟨.a⟩
-  exists_support_of_models_toSentence avoModel rfl rfl stUnivPxOrQx_closed h
+  exists_support_of_models_toSentence univAccessModel rfl rfl stUnivPxOrQx_closed h
 
-/-! ### Frame condition: avoModel is indisputable on every state -/
+/-! ### Frame conditions -/
 
-/-- `avoModel`'s universal accessibility makes R indisputable on every state
+/-- `univAccessModel`'s universal accessibility makes R indisputable on every state
     (every world sees the same `Finset.univ`). Mirrors
     `Aloni2022.deonticModel_indisputable_on_team` for the QBSML carrier.
 
     Indisputability vs state-basedness (paper §4.1.1, Definition 4.10):
     - Indisputable: all worlds in s↓ see the same accessible set (R constant).
-    - State-based: every w ∈ s↓ sees exactly s↓ (R(w) = s↓).
-
-    State-basedness is strictly stronger and is the precondition for the
-    epistemic facts: Fact 3 (`ignorance`) and Fact 6 (`distributionEpi`),
-    which therefore stay substrate-level (universal access is not
-    state-based). Facts 7, 8 and 10 need no frame condition at all — they
-    hold on every model. -/
-theorem avoModel_indisputable
+    - State-based: every w ∈ s↓ sees exactly s↓ (R(w) = s↓). -/
+theorem univAccessModel_indisputable
     (s : Finset (Index PowerSet2World QVar FCAtom)) :
-    avoModel.IsIndisputable s := by
-  intro _ _ _ _; rfl
+    univAccessModel.IsIndisputable s :=
+  fun _ _ _ _ => rfl
+
+/-- State-basedness is strictly stronger than indisputability; universal
+    access delivers it exactly on states whose world projection exhausts
+    `PowerSet2World`. The precondition for the epistemic Facts 3 and 6. -/
+theorem univAccessModel_stateBased_of_full
+    {s : Finset (Index PowerSet2World QVar FCAtom)}
+    (hfull : State.worldProj s = Finset.univ) :
+    univAccessModel.IsStateBased s :=
+  fun _ _ => hfull.symm
+
+/-- A state with full world projection: every world, paired with the empty
+    assignment. Witnesses that the epistemic hypothesis of `fact3_ignorance`
+    and `fact6_distributionEpi` is satisfiable. -/
+def fullState : Finset (Index PowerSet2World QVar FCAtom) :=
+  Finset.univ.image (fun w => (w, fun _ => none))
+
+example : State.worldProj fullState = Finset.univ := by decide
+
+example : univAccessModel.IsStateBased fullState := by decide
+
+/-- On a proper-projection state, universal access is *not* state-based:
+    the frame conditions genuinely separate. -/
+example :
+    ¬ univAccessModel.IsStateBased
+      ({(PowerSet2World.both, fun _ => none)} :
+        Finset (Index PowerSet2World QVar FCAtom)) := by
+  decide
+
+/-! ### Facts 3 and 6 (ignorance and distribution◇): the epistemic facts -/
+
+/-- **Fact 3 (ignorance)** at `univAccessModel`, on states of full world
+    projection (where `univAccessModel_stateBased_of_full` applies): the enriched
+    disjunction of constant atoms `[Pa ∨ Qb]⁺` entails `◇Pa ∧ ◇Qb`.
+    One-line invocation of `ignorance`. -/
+theorem fact3_ignorance
+    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (hfull : State.worldProj s = Finset.univ)
+    (h : support univAccessModel
+      (QBSMLFormula.enrich (.disj (.predc .P .a) (.predc .Q .b))) s) :
+    support univAccessModel (.poss (.predc .P .a)) s ∧
+    support univAccessModel (.poss (.predc .Q .b)) s :=
+  ignorance univAccessModel (univAccessModel_stateBased_of_full hfull) h
+
+/-- **Fact 6 (distribution◇)** at `univAccessModel`, on states of full world
+    projection: `[∀x(Px ∨ Qx)]⁺` entails `∃x◇Px ∧ ∃x◇Qx`. One-line
+    invocation of `distributionEpi`. -/
+theorem fact6_distributionEpi
+    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (hfull : State.worldProj s = Finset.univ)
+    (h : support univAccessModel univPxOrQx.enrich s) :
+    support univAccessModel (.exi .x (.poss Px)) s ∧
+    support univAccessModel (.exi .x (.poss Qx)) s :=
+  distributionEpi univAccessModel (univAccessModel_stateBased_of_full hfull) h
 
 /-! ### Fact 4 (obviation): the Fig. 14 countermodel
 
@@ -291,15 +330,11 @@ where `P` holds of `b`. -/
     supporting neither disjunct, breaking the premise — the paper notes the
     split works "because the domain contains two objects".) -/
 inductive Fig14Atom | a | b
-  deriving DecidableEq, Repr
-
-instance : Fintype Fig14Atom where
-  elems := {.a, .b}
-  complete := by intro d; cases d <;> simp
+  deriving DecidableEq, Repr, Fintype
 
 /-- Fig. 14 valuation: `P` holds exactly of `a`, and `Q` exactly of `b`,
     wherever the world carries the corresponding atom — so `P` and `Q` have
-    *divergent* extensions, unlike `avoModel`'s. -/
+    *divergent* extensions, unlike `univAccessModel`'s. -/
 def fig14V (w : PowerSet2World) : QPred → Fig14Atom → Prop
   | .P, d => d = .a ∧ w.holds .a
   | .Q, d => d = .b ∧ w.holds .b
@@ -316,6 +351,12 @@ def fig14Index : Index PowerSet2World QVar Fig14Atom :=
 /-- The Fig. 14 state: the single-index state of the counterexample. -/
 def fig14State : Finset (Index PowerSet2World QVar Fig14Atom) := {fig14Index}
 
+/-- The Fig. 14 accessibility is state-based on the countermodel state —
+    the epistemic reading Fact 4 assumes ("we assume again that ◇ is an
+    epistemic modal"). Obviation is thus not an artifact of dropping the
+    frame condition behind ignorance. -/
+theorem fig14_stateBased : fig14Model.IsStateBased fig14State := by decide
+
 /-- The Fig. 14 state supports the enriched premise `[∀x(Px ∨ Qx)]⁺`: its
     universal extension splits into the `x/a` half supporting `[Px]⁺` and
     the `x/b` half supporting `[Qx]⁺` (paper Fig. 15). -/
@@ -330,12 +371,10 @@ theorem fig14_premise : support fig14Model univPxOrQx.enrich fig14State := by
       = State.extendUniversal fig14State QVar.x
     decide
   · intro j hj
-    rw [Finset.mem_singleton] at hj
-    subst hj
+    obtain rfl := Finset.mem_singleton.mp hj
     exact ⟨.a, rfl, rfl, rfl⟩
   · intro j hj
-    rw [Finset.mem_singleton] at hj
-    subst hj
+    obtain rfl := Finset.mem_singleton.mp hj
     exact ⟨.b, rfl, rfl, rfl⟩
   · decide
 
@@ -347,20 +386,11 @@ theorem fig14_conclusion_fails :
       fig14State := by
   intro h
   obtain ⟨X, hX, hne, hsupp⟩ := h.1 (fig14Index.update .x .b) (by decide)
-  have hX' : X ⊆ ({PowerSet2World.both} : Finset PowerSet2World) := hX
-  have hXeq : X = {PowerSet2World.both} := by
-    rcases Finset.subset_singleton_iff.mp hX' with h0 | h0
-    · obtain ⟨y, hy⟩ := hne
-      rw [h0] at hy
-      exact absurd hy (Finset.notMem_empty y)
-    · exact h0
-  subst hXeq
+  obtain rfl : X = {PowerSet2World.both} := hne.subset_singleton_iff.mp hX
   obtain ⟨d, hd, hP⟩ := hsupp
     (PowerSet2World.both, (fig14Index.update .x .b).assign)
     (State.mem_modalLift.mpr ⟨Finset.mem_singleton_self _, rfl⟩)
-  rw [show (fig14Index.update QVar.x Fig14Atom.b).assign QVar.x
-      = some Fig14Atom.b from rfl, Option.some.injEq] at hd
-  subst hd
+  obtain rfl := Option.some.inj hd
   exact Fig14Atom.noConfusion hP.1
 
 /-- **Fact 4 (obviation)** of [aloni-vanormondt-2023]: the universal

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -30,11 +30,13 @@ concrete model and proves the paper's one countermodel claim.
 split-disjunction clause quantifies over pairs of subteams (`2^12 × 2^12`
 at this file's model sizes), so kernel `decide` is infeasible for
 whole-formula claims; the Fact 4 countermodel is proved by hand, with
-`decide` confined to finite side conditions. Fact 3 is stated with the
-individual constants of the paper's Definition 4.1 (`QBSMLFormula.predc`
-atoms, world-relative `KripkeStructure.cInterp`). Atoms and worlds come
-from `Logic/Modal/BSML/Scenarios.lean`, so this file and
-`Studies/Aloni2022.lean` target the same world space.
+`decide` confined to finite side conditions. The propositional facts (3, 7,
+8, 10) are stated with the individual constants of the paper's
+Definition 4.1 (`QBSMLFormula.predc` atoms, world-relative
+`KripkeStructure.cInterp`), the quantified facts with variable atoms — both
+as in the paper. Atoms and worlds come from
+`Logic/Modal/BSML/Scenarios.lean`, so this file and `Studies/Aloni2022.lean`
+target the same world space.
 -/
 
 namespace AloniVanOrmondt2023
@@ -45,12 +47,11 @@ open BSML (FCAtom PowerSet2World QVar)
 
 /-! ### Predicates and variables -/
 
-/-- Two unary predicates `P` and `Q`: provides the non-degenerate disjunction
-    `Pa ∨ Qa` matching the paper's `Pa ∨ Pb` schema (where the `a, b` are
-    domain elements rather than predicate-instances). With monadic predicates
-    over a 2-element domain, `Pa ∨ Qa` and `Pa ∨ Pb` are equally non-trivial
-    instantiations of split disjunction. -/
-inductive QPred | P | Q
+/-- The paper's two predicate symbols. The quantified facts use both, in
+    the paper's schema `∀x(Px ∨ Qx)`; the propositional facts use `P` alone,
+    applied to two individual constants (`Pa ∨ Pb`). `univAccessModel`
+    interprets both by the same valuation; `fig14V` separates them. -/
+inductive Pred | P | Q
   deriving DecidableEq, Repr, Fintype
 
 /-! ### The concrete model -/
@@ -69,39 +70,38 @@ inductive QPred | P | Q
     state (`univAccessModel_indisputable`) and state-based exactly on states with
     full world projection (`univAccessModel_stateBased_of_full`) — same shape as
     `Aloni2022.deonticModel`. -/
-def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom QPred where
+def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom Pred where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
-/-! ### Formulas -/
+/-! ### Formulas
 
-/-- The atomic formula `Px`. -/
-def Px {Const : Type*} : QBSMLFormula QVar Const QPred := .pred .P .x
+Constant atoms `Pa`, `Pb` build the propositional schemas of Facts 3, 7, 8
+and 10; variable atoms `Px`, `Qx` build the quantified schemas of Facts 4–6
+and 9 — both exactly as in the paper. -/
 
-/-- The atomic formula `Qx`. -/
-def Qx {Const : Type*} : QBSMLFormula QVar Const QPred := .pred .Q .x
+/-- The constant atom `Pa`. -/
+def Pa : QBSMLFormula QVar FCAtom Pred := .predc .P .a
 
-/-- Disjunction `Px ∨ Qx` — paper's `Pa ∨ Pb`-shape with two distinct
-    predicate-instances. -/
-def PxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .disj Px Qx
+/-- The constant atom `Pb`. -/
+def Pb : QBSMLFormula QVar FCAtom Pred := .predc .P .b
 
-/-- The negation premise `¬(Px ∨ Qx)` corresponding to the paper's
-    `¬(Pa ∨ Pb)` schema. -/
-def negPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .neg PxOrQx
+/-- The variable atom `Px`. -/
+def Px {Const : Type*} : QBSMLFormula QVar Const Pred := .pred .P .x
 
-/-- The narrow-scope FC premise `◇(Px ∨ Qx)` corresponding to the paper's
-    `◇(Pa ∨ Pb)` schema. -/
-def possPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .poss PxOrQx
-
-/-- The □-FC premise `□(Px ∨ Qx)` (paper's Fact 7 schema; `□` derived). -/
-def necPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := PxOrQx.nec
+/-- The variable atom `Qx`. -/
+def Qx {Const : Type*} : QBSMLFormula QVar Const Pred := .pred .Q .x
 
 /-- The universal-FC premise `∀x◇(Px ∨ Qx)` (paper's Fact 9 schema). -/
-def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .univ .x possPxOrQx
+def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const Pred :=
+  .univ .x (.poss (.disj Px Qx))
 
 /-- The distribution premise `∀x(Px ∨ Qx)` (paper's Facts 4–6 schema). -/
-def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const QPred := .univ .x PxOrQx
+def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const Pred :=
+  .univ .x (.disj Px Qx)
 
+theorem Pa_isNEFree : Pa.IsNEFree := .predc _ _
+theorem Pb_isNEFree : Pb.IsNEFree := .predc _ _
 theorem Px_isNEFree {Const : Type*} : (Px (Const := Const)).IsNEFree := .pred _ _
 theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ _
 
@@ -109,38 +109,36 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
 
 /-- **Fact 10 (Negation behaviour)** at `univAccessModel`:
 
-    Enriched negation `[¬(Px ∨ Qx)]⁺` entails the conjunction of negated
-    disjuncts `¬Px ∧ ¬Qx`. One-line invocation of the substrate's
-    `negationStrip` (`Logic/Modal/QBSML/FreeChoice.lean`).
-    Mirrors `Aloni2022.aloni2022_fact11_dual_prohibition` style — substrate
-    theorem, model + NE-free witnesses applied. -/
+    `[¬(Pa ∨ Pb)]⁺` entails `¬Pa ∧ ¬Pb`. One-line invocation of the
+    substrate's `negationStrip`. Mirrors
+    `Aloni2022.aloni2022_fact11_dual_prohibition`. -/
 theorem fact10_negation
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support univAccessModel negPxOrQx.enrich s) :
-    support univAccessModel (.neg Px) s ∧ support univAccessModel (.neg Qx) s :=
-  negationStrip univAccessModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel (QBSMLFormula.enrich (.neg (.disj Pa Pb))) s) :
+    support univAccessModel (.neg Pa) s ∧ support univAccessModel (.neg Pb) s :=
+  negationStrip univAccessModel Pa_isNEFree Pb_isNEFree h
 
 /-! ### Facts 7 and 8 (free choice): `[□/◇(Pa ∨ Pb)]⁺ ⊨ ◇Pa ∧ ◇Pb` -/
 
 /-- **Fact 8 (Narrow-Scope free choice / ◇-FC)** at `univAccessModel`:
 
-    Enriched possibility-disjunction `[◇(Px ∨ Qx)]⁺` entails `◇Px ∧ ◇Qx`.
-    One-line invocation of `narrowScopeFC`. The first-order analogue of
-    `Aloni2022.aloni2022_fact4_NS_FC` — same template, lifted to QBSML's
-    monadic predicate language. -/
+    `[◇(Pa ∨ Pb)]⁺` entails `◇Pa ∧ ◇Pb`. One-line invocation of
+    `narrowScopeFC`; the first-order analogue of
+    `Aloni2022.aloni2022_fact4_NS_FC`. -/
 theorem fact8_narrowScopeFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support univAccessModel possPxOrQx.enrich s) :
-    support univAccessModel (.poss Px) s ∧ support univAccessModel (.poss Qx) s :=
-  narrowScopeFC univAccessModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel (QBSMLFormula.enrich (.poss (.disj Pa Pb))) s) :
+    support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
+  narrowScopeFC univAccessModel Pa_isNEFree Pb_isNEFree h
 
-/-- **Fact 7 (□-free choice)** at `univAccessModel`: `[□(Px ∨ Qx)]⁺` entails
-    `◇Px ∧ ◇Qx`, with the derived `□`. One-line invocation of `boxFC`. -/
+/-- **Fact 7 (□-free choice)** at `univAccessModel`: `[□(Pa ∨ Pb)]⁺` entails
+    `◇Pa ∧ ◇Pb`, with the derived `□`. One-line invocation of `boxFC`. -/
 theorem fact7_boxFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support univAccessModel necPxOrQx.enrich s) :
-    support univAccessModel (.poss Px) s ∧ support univAccessModel (.poss Qx) s :=
-  boxFC univAccessModel Px_isNEFree Qx_isNEFree h
+    (h : support univAccessModel
+      (QBSMLFormula.enrich (QBSMLFormula.nec (.disj Pa Pb))) s) :
+    support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
+  boxFC univAccessModel Pa_isNEFree Pb_isNEFree h
 
 /-! ### Facts 9 and 5 (universal FC and distribution) -/
 
@@ -178,8 +176,8 @@ theorem univPxOrQx_classical
     support univAccessModel univPxOrQx s ↔
       ∀ i ∈ s, univAccessModel.RealizeAt i.world
         (Formula.all₁ QVar.x
-          ((monadicRel QPred.P).formula₁ (Term.var QVar.x) ⊔
-            (monadicRel QPred.Q).formula₁ (Term.var QVar.x))) (v i) :=
+          ((monadicRel Pred.P).formula₁ (Term.var QVar.x) ⊔
+            (monadicRel Pred.Q).formula₁ (Term.var QVar.x))) (v i) :=
   support_iff_forall_realizeAt univAccessModel rfl s v hv
 
 /-- The narrow-scope FC premise `◇(Px ∨ Qx)` translates into the modal layer
@@ -190,24 +188,24 @@ theorem possPxOrQx_classical
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
-    support univAccessModel possPxOrQx s ↔
+    support univAccessModel (.poss (.disj Px Qx)) s ↔
       ∀ i ∈ s,
         (ModalFormula.dia
-          (.sup (.ofFormula ((monadicRel QPred.P).formula₁ (Term.var QVar.x)))
+          (.sup (.ofFormula ((monadicRel Pred.P).formula₁ (Term.var QVar.x)))
             (.ofFormula
-              ((monadicRel QPred.Q).formula₁ (Term.var QVar.x))))).Realize
+              ((monadicRel Pred.Q).formula₁ (Term.var QVar.x))))).Realize
           univAccessModel i.world (v i) :=
   support_iff_forall_realize univAccessModel rfl s v hv
 
 /-- The closed standard translation of `∀x(Px ∨ Qx)`: quantifiers
     relativized to the individual sort, predicates world-relativized to the
     current-world variable `Sum.inr 0`. -/
-def stUnivPxOrQx : (stLang FCAtom QPred).Formula (QVar ⊕ ℕ) :=
+def stUnivPxOrQx : (stLang FCAtom Pred).Formula (QVar ⊕ ℕ) :=
   Formula.all₁ (Sum.inl QVar.x)
     ((stIndiv.formula₁ (Term.var (Sum.inl QVar.x))).imp
-      ((stRel QPred.P).formula₂ (Term.var (Sum.inr 0))
+      ((stRel Pred.P).formula₂ (Term.var (Sum.inr 0))
           (Term.var (Sum.inl QVar.x)) ⊔
-        (stRel QPred.Q).formula₂ (Term.var (Sum.inr 0))
+        (stRel Pred.Q).formula₂ (Term.var (Sum.inr 0))
           (Term.var (Sum.inl QVar.x))))
 
 /-- The closure is a genuine sentence: the compiler computes the
@@ -284,16 +282,14 @@ example :
 /-! ### Facts 3 and 6 (ignorance and distribution◇): the epistemic facts -/
 
 /-- **Fact 3 (ignorance)** at `univAccessModel`, on states of full world
-    projection (where `univAccessModel_stateBased_of_full` applies): the enriched
-    disjunction of constant atoms `[Pa ∨ Qb]⁺` entails `◇Pa ∧ ◇Qb`.
-    One-line invocation of `ignorance`. -/
+    projection (where `univAccessModel_stateBased_of_full` applies):
+    `[Pa ∨ Pb]⁺` entails `◇Pa ∧ ◇Pb`. One-line invocation of `ignorance`. -/
 theorem fact3_ignorance
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (hfull : State.worldProj s = Finset.univ)
-    (h : support univAccessModel
-      (QBSMLFormula.enrich (.disj (.predc .P .a) (.predc .Q .b))) s) :
-    support univAccessModel (.poss (.predc .P .a)) s ∧
-    support univAccessModel (.poss (.predc .Q .b)) s :=
+    (h : support univAccessModel (QBSMLFormula.enrich (.disj Pa Pb)) s) :
+    support univAccessModel (.poss Pa) s ∧
+    support univAccessModel (.poss Pb) s :=
   ignorance univAccessModel (univAccessModel_stateBased_of_full hfull) h
 
 /-- **Fact 6 (distribution◇)** at `univAccessModel`, on states of full world
@@ -326,12 +322,12 @@ inductive Fig14Atom | a | b
 /-- Fig. 14 valuation: `P` holds exactly of `a`, and `Q` exactly of `b`,
     wherever the world carries the corresponding atom — so `P` and `Q` have
     *divergent* extensions, unlike `univAccessModel`'s. -/
-def fig14V (w : PowerSet2World) : QPred → Fig14Atom → Prop
+def fig14V (w : PowerSet2World) : Pred → Fig14Atom → Prop
   | .P, d => d = .a ∧ w.holds .a
   | .Q, d => d = .b ∧ w.holds .b
 
 /-- The Fig. 14 model: reflexive-only access at the `both` world. -/
-def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom QPred where
+def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Pred where
   access := λ _ => {PowerSet2World.both}
   interp := λ w => monadicStructure id (fig14V w)
 
@@ -353,7 +349,7 @@ theorem fig14_stateBased : fig14Model.IsStateBased fig14State := by decide
     the `x/b` half supporting `[Qx]⁺` (paper Fig. 15). -/
 theorem fig14_premise : support fig14Model univPxOrQx.enrich fig14State := by
   refine ⟨?_, Finset.singleton_nonempty _⟩
-  show support fig14Model PxOrQx.enrich
+  show support fig14Model (QBSMLFormula.disj Px Qx).enrich
     (State.extendUniversal fig14State QVar.x)
   refine ⟨⟨{fig14Index.update .x .a}, {fig14Index.update .x .b},
     ?_, ⟨?_, Finset.singleton_nonempty _⟩, ⟨?_, Finset.singleton_nonempty _⟩⟩,
@@ -389,7 +385,7 @@ theorem fig14_conclusion_fails :
     `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, witnessed by the Fig. 14
     countermodel. -/
 theorem fact4_obviation :
-    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom QPred)
+    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Pred)
       (s : Finset (Index PowerSet2World QVar Fig14Atom)),
       support M univPxOrQx.enrich s ∧
       ¬ support M (.univ .x (.conj (.poss Px) (.poss Qx))) s :=

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -32,7 +32,7 @@ at this file's model sizes), so kernel `decide` is infeasible for
 whole-formula claims; the Fact 4 countermodel is proved by hand, with
 `decide` confined to finite side conditions. The propositional facts (3, 7,
 8, 10) are stated with the individual constants of the paper's
-Definition 4.1 (`QBSMLFormula.predc` atoms, world-relative
+Definition 4.1 (`Formula.predc` atoms, world-relative
 `KripkeStructure.cInterp`), the quantified facts with variable atoms — both
 as in the paper. Atoms and worlds come from
 `Logic/Modal/BSML/Scenarios.lean`, so this file and `Studies/Aloni2022.lean`
@@ -66,7 +66,7 @@ inductive Predicate | P | Q
     state (`univAccessModel_indisputable`) and state-based exactly on states with
     full world projection (`univAccessModel_stateBased_of_full`) — same shape as
     `Aloni2022.deonticModel`. -/
-def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom Predicate where
+def univAccessModel : Model PowerSet2World FCAtom FCAtom Predicate where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
@@ -77,23 +77,23 @@ and 10; variable atoms `Px`, `Qx` build the quantified schemas of Facts 4–6
 and 9 — both exactly as in the paper. -/
 
 /-- The constant atom `Pa`. -/
-def Pa : QBSMLFormula QVar FCAtom Predicate := .predc .P .a
+def Pa : Formula QVar FCAtom Predicate := .predc .P .a
 
 /-- The constant atom `Pb`. -/
-def Pb : QBSMLFormula QVar FCAtom Predicate := .predc .P .b
+def Pb : Formula QVar FCAtom Predicate := .predc .P .b
 
 /-- The variable atom `Px`. -/
-def Px {Const : Type*} : QBSMLFormula QVar Const Predicate := .pred .P .x
+def Px {Const : Type*} : Formula QVar Const Predicate := .pred .P .x
 
 /-- The variable atom `Qx`. -/
-def Qx {Const : Type*} : QBSMLFormula QVar Const Predicate := .pred .Q .x
+def Qx {Const : Type*} : Formula QVar Const Predicate := .pred .Q .x
 
 /-- The universal-FC premise `∀x◇(Px ∨ Qx)` (paper's Fact 9 schema). -/
-def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const Predicate :=
+def univPossPxOrQx {Const : Type*} : Formula QVar Const Predicate :=
   .univ .x (.poss (.disj Px Qx))
 
 /-- The distribution premise `∀x(Px ∨ Qx)` (paper's Facts 4–6 schema). -/
-def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const Predicate :=
+def univPxOrQx {Const : Type*} : Formula QVar Const Predicate :=
   .univ .x (.disj Px Qx)
 
 theorem Pa_isNEFree : Pa.IsNEFree := .predc _ _
@@ -110,7 +110,7 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
     `Aloni2022.aloni2022_fact11_dual_prohibition`. -/
 theorem fact10_negation
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support univAccessModel (QBSMLFormula.enrich (.neg (.disj Pa Pb))) s) :
+    (h : support univAccessModel (Formula.enrich (.neg (.disj Pa Pb))) s) :
     support univAccessModel (.neg Pa) s ∧ support univAccessModel (.neg Pb) s :=
   negationStrip univAccessModel Pa_isNEFree Pb_isNEFree h
 
@@ -123,7 +123,7 @@ theorem fact10_negation
     `Aloni2022.aloni2022_fact4_NS_FC`. -/
 theorem fact8_narrowScopeFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
-    (h : support univAccessModel (QBSMLFormula.enrich (.poss (.disj Pa Pb))) s) :
+    (h : support univAccessModel (Formula.enrich (.poss (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
   narrowScopeFC univAccessModel Pa_isNEFree Pb_isNEFree h
 
@@ -132,7 +132,7 @@ theorem fact8_narrowScopeFC
 theorem fact7_boxFC
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (h : support univAccessModel
-      (QBSMLFormula.enrich (QBSMLFormula.nec (.disj Pa Pb))) s) :
+      (Formula.enrich (Formula.nec (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
   boxFC univAccessModel Pa_isNEFree Pb_isNEFree h
 
@@ -283,7 +283,7 @@ example :
 theorem fact3_ignorance
     (s : Finset (Index PowerSet2World QVar FCAtom))
     (hfull : State.worldProj s = Finset.univ)
-    (h : support univAccessModel (QBSMLFormula.enrich (.disj Pa Pb)) s) :
+    (h : support univAccessModel (Formula.enrich (.disj Pa Pb)) s) :
     support univAccessModel (.poss Pa) s ∧
     support univAccessModel (.poss Pb) s :=
   ignorance univAccessModel (univAccessModel_stateBased_of_full hfull) h
@@ -323,7 +323,7 @@ def fig14V (w : PowerSet2World) : Predicate → Fig14Atom → Prop
   | .Q, d => d = .b ∧ w.holds .b
 
 /-- The Fig. 14 model: reflexive-only access at the `both` world. -/
-def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Predicate where
+def fig14Model : Model PowerSet2World Fig14Atom Fig14Atom Predicate where
   access := λ _ => {PowerSet2World.both}
   interp := λ w => monadicStructure id (fig14V w)
 
@@ -345,7 +345,7 @@ theorem fig14_stateBased : fig14Model.IsStateBased fig14State := by decide
     the `x/b` half supporting `[Qx]⁺` (paper Fig. 15). -/
 theorem fig14_premise : support fig14Model univPxOrQx.enrich fig14State := by
   refine ⟨?_, Finset.singleton_nonempty _⟩
-  show support fig14Model (QBSMLFormula.disj Px Qx).enrich
+  show support fig14Model (Formula.disj Px Qx).enrich
     (State.extendUniversal fig14State QVar.x)
   refine ⟨⟨{fig14Index.update .x .a}, {fig14Index.update .x .b},
     ?_, ⟨?_, Finset.singleton_nonempty _⟩, ⟨?_, Finset.singleton_nonempty _⟩⟩,
@@ -381,7 +381,7 @@ theorem fig14_conclusion_fails :
     `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, witnessed by the Fig. 14
     countermodel. -/
 theorem fact4_obviation :
-    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Predicate)
+    ∃ (M : Model PowerSet2World Fig14Atom Fig14Atom Predicate)
       (s : Finset (Index PowerSet2World QVar Fig14Atom)),
       support M univPxOrQx.enrich s ∧
       ¬ support M (.univ .x (.conj (.poss Px) (.poss Qx))) s :=

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -16,22 +16,13 @@ concrete model and proves the paper's one countermodel claim.
 
 ## Main declarations
 
-* `univAccessModel` — universal-access model over `BSML.PowerSet2World`:
-  indisputable on every state (`univAccessModel_indisputable`) and state-based
-  exactly on states with full world projection
-  (`univAccessModel_stateBased_of_full`).
-* `fact3_ignorance` … `fact10_negation` — the paper's §5 facts at
-  `univAccessModel`, one-line instances of the substrate theorems; the epistemic
-  Facts 3 and 6 hold on full-world-projection states.
-* `fig14Model`, `fact4_obviation` — **Fact 4 (obviation)**:
-  `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, by the paper's Fig. 14 countermodel;
-  `R` is state-based on the countermodel state (`fig14_stateBased`), the
-  epistemic reading Fact 4 assumes.
-* `univPxOrQx_classical`, `possPxOrQx_classical`, `univPxOrQx_sentence` —
-  [aloni-vanormondt-2023] Proposition 4.1 at `univAccessModel`: support of NE-free
-  formulas is classical realization (mathlib `Formula.Realize`) resp. Kripke
-  satisfaction, the translations computed by `rfl`, and the standard
-  translation of `∀x(Px ∨ Qx)` a genuine sentence.
+* `univAccessModel` — universal-access model over `BSML.PowerSet2World`.
+* `fact3_ignorance` … `fact10_negation` — the paper's §5 facts, as
+  instances of the substrate theorems.
+* `fact4_obviation` — `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, by the paper's
+  Fig. 14 countermodel.
+* `univPxOrQx_classical`, `univPxOrQx_sentence` — Proposition 4.1 at the
+  concrete model, the translations computed by `rfl`.
 
 ## Implementation notes
 

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -52,20 +52,9 @@ inductive Predicate | P | Q
 
 /-! ### The concrete model -/
 
-/-- Universal-access model on `PowerSet2World`.
-
-    The interpretation is the `monadicStructure` of the valuation
-    `V w P d := w.holds d`: both predicates hold of `d` at `w` iff `w`
-    models the atom `d`. The disjunction `Px ∨ Qx` is non-degenerate at the
-    *formula* level even though at this model the two interpretations
-    coincide. A model with divergent P and Q extensions would discriminate
-    further; this minimal model suffices for the substrate-instantiation
-    tests below.
-
-    Universal access (`access _ = univ`) makes `R` indisputable on every
-    state (`univAccessModel_indisputable`) and state-based exactly on states with
-    full world projection (`univAccessModel_stateBased_of_full`) — same shape as
-    `Aloni2022.deonticModel`. -/
+/-- Universal-access model on `PowerSet2World`: every world is accessible,
+    and both predicates hold of `d` at `w` iff `w` models the atom `d`.
+    Cf. `Aloni2022.deonticModel`. -/
 def univAccessModel : Model PowerSet2World FCAtom FCAtom Predicate where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -47,11 +47,7 @@ open BSML (FCAtom PowerSet2World QVar)
 
 /-! ### Predicates and variables -/
 
-/-- The paper's two predicate symbols. The quantified facts use both, in
-    the paper's schema `∀x(Px ∨ Qx)`; the propositional facts use `P` alone,
-    applied to two individual constants (`Pa ∨ Pb`). `univAccessModel`
-    interprets both by the same valuation; `fig14V` separates them. -/
-inductive Pred | P | Q
+inductive Predicate | P | Q
   deriving DecidableEq, Repr, Fintype
 
 /-! ### The concrete model -/
@@ -70,7 +66,7 @@ inductive Pred | P | Q
     state (`univAccessModel_indisputable`) and state-based exactly on states with
     full world projection (`univAccessModel_stateBased_of_full`) — same shape as
     `Aloni2022.deonticModel`. -/
-def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom Pred where
+def univAccessModel : QBSMLModel PowerSet2World FCAtom FCAtom Predicate where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
@@ -81,23 +77,23 @@ and 10; variable atoms `Px`, `Qx` build the quantified schemas of Facts 4–6
 and 9 — both exactly as in the paper. -/
 
 /-- The constant atom `Pa`. -/
-def Pa : QBSMLFormula QVar FCAtom Pred := .predc .P .a
+def Pa : QBSMLFormula QVar FCAtom Predicate := .predc .P .a
 
 /-- The constant atom `Pb`. -/
-def Pb : QBSMLFormula QVar FCAtom Pred := .predc .P .b
+def Pb : QBSMLFormula QVar FCAtom Predicate := .predc .P .b
 
 /-- The variable atom `Px`. -/
-def Px {Const : Type*} : QBSMLFormula QVar Const Pred := .pred .P .x
+def Px {Const : Type*} : QBSMLFormula QVar Const Predicate := .pred .P .x
 
 /-- The variable atom `Qx`. -/
-def Qx {Const : Type*} : QBSMLFormula QVar Const Pred := .pred .Q .x
+def Qx {Const : Type*} : QBSMLFormula QVar Const Predicate := .pred .Q .x
 
 /-- The universal-FC premise `∀x◇(Px ∨ Qx)` (paper's Fact 9 schema). -/
-def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const Pred :=
+def univPossPxOrQx {Const : Type*} : QBSMLFormula QVar Const Predicate :=
   .univ .x (.poss (.disj Px Qx))
 
 /-- The distribution premise `∀x(Px ∨ Qx)` (paper's Facts 4–6 schema). -/
-def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const Pred :=
+def univPxOrQx {Const : Type*} : QBSMLFormula QVar Const Predicate :=
   .univ .x (.disj Px Qx)
 
 theorem Pa_isNEFree : Pa.IsNEFree := .predc _ _
@@ -176,8 +172,8 @@ theorem univPxOrQx_classical
     support univAccessModel univPxOrQx s ↔
       ∀ i ∈ s, univAccessModel.RealizeAt i.world
         (Formula.all₁ QVar.x
-          ((monadicRel Pred.P).formula₁ (Term.var QVar.x) ⊔
-            (monadicRel Pred.Q).formula₁ (Term.var QVar.x))) (v i) :=
+          ((monadicRel Predicate.P).formula₁ (Term.var QVar.x) ⊔
+            (monadicRel Predicate.Q).formula₁ (Term.var QVar.x))) (v i) :=
   support_iff_forall_realizeAt univAccessModel rfl s v hv
 
 /-- The narrow-scope FC premise `◇(Px ∨ Qx)` translates into the modal layer
@@ -191,21 +187,21 @@ theorem possPxOrQx_classical
     support univAccessModel (.poss (.disj Px Qx)) s ↔
       ∀ i ∈ s,
         (ModalFormula.dia
-          (.sup (.ofFormula ((monadicRel Pred.P).formula₁ (Term.var QVar.x)))
+          (.sup (.ofFormula ((monadicRel Predicate.P).formula₁ (Term.var QVar.x)))
             (.ofFormula
-              ((monadicRel Pred.Q).formula₁ (Term.var QVar.x))))).Realize
+              ((monadicRel Predicate.Q).formula₁ (Term.var QVar.x))))).Realize
           univAccessModel i.world (v i) :=
   support_iff_forall_realize univAccessModel rfl s v hv
 
 /-- The closed standard translation of `∀x(Px ∨ Qx)`: quantifiers
     relativized to the individual sort, predicates world-relativized to the
     current-world variable `Sum.inr 0`. -/
-def stUnivPxOrQx : (stLang FCAtom Pred).Formula (QVar ⊕ ℕ) :=
+def stUnivPxOrQx : (stLang FCAtom Predicate).Formula (QVar ⊕ ℕ) :=
   Formula.all₁ (Sum.inl QVar.x)
     ((stIndiv.formula₁ (Term.var (Sum.inl QVar.x))).imp
-      ((stRel Pred.P).formula₂ (Term.var (Sum.inr 0))
+      ((stRel Predicate.P).formula₂ (Term.var (Sum.inr 0))
           (Term.var (Sum.inl QVar.x)) ⊔
-        (stRel Pred.Q).formula₂ (Term.var (Sum.inr 0))
+        (stRel Predicate.Q).formula₂ (Term.var (Sum.inr 0))
           (Term.var (Sum.inl QVar.x))))
 
 /-- The closure is a genuine sentence: the compiler computes the
@@ -322,12 +318,12 @@ inductive Fig14Atom | a | b
 /-- Fig. 14 valuation: `P` holds exactly of `a`, and `Q` exactly of `b`,
     wherever the world carries the corresponding atom — so `P` and `Q` have
     *divergent* extensions, unlike `univAccessModel`'s. -/
-def fig14V (w : PowerSet2World) : Pred → Fig14Atom → Prop
+def fig14V (w : PowerSet2World) : Predicate → Fig14Atom → Prop
   | .P, d => d = .a ∧ w.holds .a
   | .Q, d => d = .b ∧ w.holds .b
 
 /-- The Fig. 14 model: reflexive-only access at the `both` world. -/
-def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Pred where
+def fig14Model : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Predicate where
   access := λ _ => {PowerSet2World.both}
   interp := λ w => monadicStructure id (fig14V w)
 
@@ -385,7 +381,7 @@ theorem fig14_conclusion_fails :
     `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, witnessed by the Fig. 14
     countermodel. -/
 theorem fact4_obviation :
-    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Pred)
+    ∃ (M : QBSMLModel PowerSet2World Fig14Atom Fig14Atom Predicate)
       (s : Finset (Index PowerSet2World QVar Fig14Atom)),
       support M univPxOrQx.enrich s ∧
       ¬ support M (.univ .x (.conj (.poss Px) (.poss Qx))) s :=

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -16,7 +16,7 @@ concrete model and proves the paper's one countermodel claim.
 
 ## Main declarations
 
-* `univAccessModel` — universal-access model over `BSML.PowerSet2World`.
+* `univAccessModel` — universal-access model over `BSML.TwoAtomWorld`.
 * `fact3_ignorance` … `fact10_negation` — the paper's §5 facts, as
   instances of the substrate theorems.
 * `fact4_obviation` — `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, by the paper's
@@ -43,7 +43,7 @@ namespace AloniVanOrmondt2023
 
 open QBSML
 open FirstOrder Language
-open BSML (FCAtom PowerSet2World QVar)
+open BSML (FCAtom TwoAtomWorld QVar)
 
 /-! ### Predicates and variables -/
 
@@ -52,10 +52,10 @@ inductive Predicate | P | Q
 
 /-! ### The concrete model -/
 
-/-- Universal-access model on `PowerSet2World`: every world is accessible,
+/-- Universal-access model on `TwoAtomWorld`: every world is accessible,
     and both predicates hold of `d` at `w` iff `w` models the atom `d`.
     Cf. `Aloni2022.deonticModel`. -/
-def univAccessModel : Model PowerSet2World FCAtom FCAtom Predicate where
+def univAccessModel : Model TwoAtomWorld FCAtom FCAtom Predicate where
   access := λ _ => Finset.univ
   interp := λ w => monadicStructure id (λ _ d => w.holds d)
 
@@ -98,7 +98,7 @@ theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ 
     substrate's `negationStrip`. Mirrors
     `Aloni2022.aloni2022_fact11_dual_prohibition`. -/
 theorem fact10_negation
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (h : support univAccessModel (Formula.enrich (.neg (.disj Pa Pb))) s) :
     support univAccessModel (.neg Pa) s ∧ support univAccessModel (.neg Pb) s :=
   negationStrip univAccessModel Pa_isNEFree Pb_isNEFree h
@@ -111,7 +111,7 @@ theorem fact10_negation
     `narrowScopeFC`; the first-order analogue of
     `Aloni2022.aloni2022_fact4_NS_FC`. -/
 theorem fact8_narrowScopeFC
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (h : support univAccessModel (Formula.enrich (.poss (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
   narrowScopeFC univAccessModel Pa_isNEFree Pb_isNEFree h
@@ -119,7 +119,7 @@ theorem fact8_narrowScopeFC
 /-- **Fact 7 (□-free choice)** at `univAccessModel`: `[□(Pa ∨ Pb)]⁺` entails
     `◇Pa ∧ ◇Pb`, with the derived `□`. One-line invocation of `boxFC`. -/
 theorem fact7_boxFC
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (h : support univAccessModel
       (Formula.enrich (Formula.nec (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
@@ -132,7 +132,7 @@ theorem fact7_boxFC
     `[∀x◇(Px ∨ Qx)]⁺` entails `∀x◇Px ∧ ∀x◇Qx`. One-line invocation of
     `universalFC` — the [chemla-2009]-attested pattern. -/
 theorem fact9_universalFC
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (h : support univAccessModel univPossPxOrQx.enrich s) :
     support univAccessModel (.univ .x (.poss Px)) s ∧
     support univAccessModel (.univ .x (.poss Qx)) s :=
@@ -142,7 +142,7 @@ theorem fact9_universalFC
     singleton state, `[∀x(Px ∨ Qx)]⁺` entails `∃xPx ∧ ∃xQx`. One-line
     invocation of `distribution`. -/
 theorem fact5_distribution
-    (i : Index PowerSet2World QVar FCAtom)
+    (i : Index TwoAtomWorld QVar FCAtom)
     (h : support univAccessModel univPxOrQx.enrich {i}) :
     support univAccessModel (.exi .x Px) {i} ∧ support univAccessModel (.exi .x Qx) {i} :=
   distribution univAccessModel Px_isNEFree Qx_isNEFree h
@@ -155,8 +155,8 @@ theorem fact5_distribution
     `univAccessModel`. The translation hypothesis is discharged by `rfl`: the
     compiler computes. -/
 theorem univPxOrQx_classical
-    (s : Finset (Index PowerSet2World QVar FCAtom))
-    (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
+    (v : Index TwoAtomWorld QVar FCAtom → QVar → FCAtom)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support univAccessModel univPxOrQx s ↔
       ∀ i ∈ s, univAccessModel.RealizeAt i.world
@@ -170,8 +170,8 @@ theorem univPxOrQx_classical
     every index — the **full** [aloni-vanormondt-2023] Proposition 4.1
     (modals included) at `univAccessModel`, the translation discharged by `rfl`. -/
 theorem possPxOrQx_classical
-    (s : Finset (Index PowerSet2World QVar FCAtom))
-    (v : Index PowerSet2World QVar FCAtom → QVar → FCAtom)
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
+    (v : Index TwoAtomWorld QVar FCAtom → QVar → FCAtom)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support univAccessModel (.poss (.disj Px Qx)) s ↔
       ∀ i ∈ s,
@@ -203,11 +203,11 @@ theorem stUnivPxOrQx_closed :
     compactness-ready form, with every translation step (`toModal?`, `st?`,
     the free-variable check) computed by the compiler. -/
 theorem univPxOrQx_sentence
-    (i : Index PowerSet2World QVar FCAtom) (v : QVar → FCAtom)
+    (i : Index TwoAtomWorld QVar FCAtom) (v : QVar → FCAtom)
     (hv : ∀ y, i.assign y = some (v y))
     (h : support univAccessModel univPxOrQx {i}) :
     letI := univAccessModel.stStructure
-    (PowerSet2World ⊕ FCAtom) ⊨
+    (TwoAtomWorld ⊕ FCAtom) ⊨
       (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed :=
   models_toSentence_of_support univAccessModel rfl rfl stUnivPxOrQx_closed hv h
 
@@ -216,9 +216,9 @@ theorem univPxOrQx_sentence
     state-independent. -/
 theorem support_of_stUnivPxOrQx_sentence
     (h : letI := univAccessModel.stStructure
-         (PowerSet2World ⊕ FCAtom) ⊨
+         (TwoAtomWorld ⊕ FCAtom) ⊨
            (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed) :
-    ∃ (i : Index PowerSet2World QVar FCAtom) (v : QVar → FCAtom),
+    ∃ (i : Index TwoAtomWorld QVar FCAtom) (v : QVar → FCAtom),
       (∀ y, i.assign y = some (v y)) ∧ support univAccessModel univPxOrQx {i} :=
   haveI : Nonempty FCAtom := ⟨.a⟩
   exists_support_of_models_toSentence univAccessModel rfl rfl stUnivPxOrQx_closed h
@@ -233,15 +233,15 @@ theorem support_of_stUnivPxOrQx_sentence
     - Indisputable: all worlds in s↓ see the same accessible set (R constant).
     - State-based: every w ∈ s↓ sees exactly s↓ (R(w) = s↓). -/
 theorem univAccessModel_indisputable
-    (s : Finset (Index PowerSet2World QVar FCAtom)) :
+    (s : Finset (Index TwoAtomWorld QVar FCAtom)) :
     univAccessModel.IsIndisputable s :=
   fun _ _ _ _ => rfl
 
 /-- State-basedness is strictly stronger than indisputability; universal
     access delivers it exactly on states whose world projection exhausts
-    `PowerSet2World`. The precondition for the epistemic Facts 3 and 6. -/
+    `TwoAtomWorld`. The precondition for the epistemic Facts 3 and 6. -/
 theorem univAccessModel_stateBased_of_full
-    {s : Finset (Index PowerSet2World QVar FCAtom)}
+    {s : Finset (Index TwoAtomWorld QVar FCAtom)}
     (hfull : State.worldProj s = Finset.univ) :
     univAccessModel.IsStateBased s :=
   fun _ _ => hfull.symm
@@ -249,7 +249,7 @@ theorem univAccessModel_stateBased_of_full
 /-- A state with full world projection: every world, paired with the empty
     assignment. Witnesses that the epistemic hypothesis of `fact3_ignorance`
     and `fact6_distributionEpi` is satisfiable. -/
-def fullState : Finset (Index PowerSet2World QVar FCAtom) :=
+def fullState : Finset (Index TwoAtomWorld QVar FCAtom) :=
   Finset.univ.image (fun w => (w, fun _ => none))
 
 example : State.worldProj fullState = Finset.univ := by decide
@@ -260,8 +260,8 @@ example : univAccessModel.IsStateBased fullState := by decide
     the frame conditions genuinely separate. -/
 example :
     ¬ univAccessModel.IsStateBased
-      ({(PowerSet2World.both, fun _ => none)} :
-        Finset (Index PowerSet2World QVar FCAtom)) := by
+      ({(TwoAtomWorld.both, fun _ => none)} :
+        Finset (Index TwoAtomWorld QVar FCAtom)) := by
   decide
 
 /-! ### Facts 3 and 6 (ignorance and distribution◇): the epistemic facts -/
@@ -270,7 +270,7 @@ example :
     projection (where `univAccessModel_stateBased_of_full` applies):
     `[Pa ∨ Pb]⁺` entails `◇Pa ∧ ◇Pb`. One-line invocation of `ignorance`. -/
 theorem fact3_ignorance
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (hfull : State.worldProj s = Finset.univ)
     (h : support univAccessModel (Formula.enrich (.disj Pa Pb)) s) :
     support univAccessModel (.poss Pa) s ∧
@@ -281,7 +281,7 @@ theorem fact3_ignorance
     projection: `[∀x(Px ∨ Qx)]⁺` entails `∃x◇Px ∧ ∃x◇Qx`. One-line
     invocation of `distributionEpi`. -/
 theorem fact6_distributionEpi
-    (s : Finset (Index PowerSet2World QVar FCAtom))
+    (s : Finset (Index TwoAtomWorld QVar FCAtom))
     (hfull : State.worldProj s = Finset.univ)
     (h : support univAccessModel univPxOrQx.enrich s) :
     support univAccessModel (.exi .x (.poss Px)) s ∧
@@ -307,21 +307,21 @@ inductive Fig14Atom | a | b
 /-- Fig. 14 valuation: `P` holds exactly of `a`, and `Q` exactly of `b`,
     wherever the world carries the corresponding atom — so `P` and `Q` have
     *divergent* extensions, unlike `univAccessModel`'s. -/
-def fig14V (w : PowerSet2World) : Predicate → Fig14Atom → Prop
+def fig14V (w : TwoAtomWorld) : Predicate → Fig14Atom → Prop
   | .P, d => d = .a ∧ w.holds .a
   | .Q, d => d = .b ∧ w.holds .b
 
 /-- The Fig. 14 model: reflexive-only access at the `both` world. -/
-def fig14Model : Model PowerSet2World Fig14Atom Fig14Atom Predicate where
-  access := λ _ => {PowerSet2World.both}
+def fig14Model : Model TwoAtomWorld Fig14Atom Fig14Atom Predicate where
+  access := λ _ => {TwoAtomWorld.both}
   interp := λ w => monadicStructure id (fig14V w)
 
 /-- The Fig. 14 index: the `both` world with the empty assignment. -/
-def fig14Index : Index PowerSet2World QVar Fig14Atom :=
-  (PowerSet2World.both, fun _ => none)
+def fig14Index : Index TwoAtomWorld QVar Fig14Atom :=
+  (TwoAtomWorld.both, fun _ => none)
 
 /-- The Fig. 14 state: the single-index state of the counterexample. -/
-def fig14State : Finset (Index PowerSet2World QVar Fig14Atom) := {fig14Index}
+def fig14State : Finset (Index TwoAtomWorld QVar Fig14Atom) := {fig14Index}
 
 /-- The Fig. 14 accessibility is state-based on the countermodel state —
     the epistemic reading Fact 4 assumes ("we assume again that ◇ is an
@@ -358,9 +358,9 @@ theorem fig14_conclusion_fails :
       fig14State := by
   intro h
   obtain ⟨X, hX, hne, hsupp⟩ := h.1 (fig14Index.update .x .b) (by decide)
-  obtain rfl : X = {PowerSet2World.both} := hne.subset_singleton_iff.mp hX
+  obtain rfl : X = {TwoAtomWorld.both} := hne.subset_singleton_iff.mp hX
   obtain ⟨d, hd, hP⟩ := hsupp
-    (PowerSet2World.both, (fig14Index.update .x .b).assign)
+    (TwoAtomWorld.both, (fig14Index.update .x .b).assign)
     (State.mem_modalLift.mpr ⟨Finset.mem_singleton_self _, rfl⟩)
   obtain rfl := Option.some.inj hd
   exact Fig14Atom.noConfusion hP.1
@@ -370,8 +370,8 @@ theorem fig14_conclusion_fails :
     `[∀x(Px ∨ Qx)]⁺ ⊭ ∀x(◇Px ∧ ◇Qx)`, witnessed by the Fig. 14
     countermodel. -/
 theorem fact4_obviation :
-    ∃ (M : Model PowerSet2World Fig14Atom Fig14Atom Predicate)
-      (s : Finset (Index PowerSet2World QVar Fig14Atom)),
+    ∃ (M : Model TwoAtomWorld Fig14Atom Fig14Atom Predicate)
+      (s : Finset (Index TwoAtomWorld QVar Fig14Atom)),
       support M univPxOrQx.enrich s ∧
       ¬ support M (.univ .x (.conj (.poss Px) (.poss Qx))) s :=
   ⟨fig14Model, fig14State, fig14_premise, fig14_conclusion_fails⟩

--- a/Linglib/Studies/Yan2023.lean
+++ b/Linglib/Studies/Yan2023.lean
@@ -35,7 +35,7 @@ deferred to the dissertation's Chapter 5).
 ## Main declarations
 
 * `reinterpret` — Yan's reinterpretation function `∥·∥_P` (Definition 32),
-  an instance of `QBSMLFormula.mapAtoms`.
+  an instance of `Formula.mapAtoms`.
 * `reinterpret_isNEFree`, `eval_reinterpret_iff` — reinterpretation stays
   NE-free and is bilaterally equivalent to the original (substitution
   *salva veritate*; the classical equivalence of `Qx` and
@@ -68,7 +68,7 @@ variable {Var Const Pred : Type*}
 /-- **Reinterpretation** `∥·∥_P` ([yan-2023] Definition 32): rewrite each
     atom `Q t` whose predicate has `P` as a (contextually salient)
     sub-predicate as the disjunction `(P t ∧ Q t) ∨ (¬P t ∧ Q t)`, and
-    commute with every connective (`QBSMLFormula.mapAtoms`).
+    commute with every connective (`Formula.mapAtoms`).
 
     `sub P Q` plays the paper's side condition `P ⊂ Q`. That condition is
     *denotational* there (the denotation of `P` a proper subset of `Q`'s),
@@ -84,12 +84,12 @@ variable {Var Const Pred : Type*}
     The paper's language `L_D` (its Definition 24) has primitive `□`,
     derived `◇`, and no `∀`, so Definition 32 has no `◇`/`∀` clauses: the
     `.poss` clause here recovers its derived-`◇` behaviour definitionally,
-    and `.univ` extends the function to the full `QBSMLFormula` language.
+    and `.univ` extends the function to the full `Formula` language.
     The `.ne` clause is a totality filler — the paper defines `∥·∥` on the
     NE-free fragment only. -/
 def reinterpret (sub : Pred → Pred → Prop) [DecidableRel sub] (P : Pred) :
-    QBSMLFormula Var Const Pred → QBSMLFormula Var Const Pred :=
-  QBSMLFormula.mapAtoms
+    Formula Var Const Pred → Formula Var Const Pred :=
+  Formula.mapAtoms
     (fun Q x =>
       if sub P Q then
         .disj (.conj (.pred P x) (.pred Q x))
@@ -106,7 +106,7 @@ variable (sub : Pred → Pred → Prop) [DecidableRel sub] (P : Pred)
 /-- Equation lemma: reinterpretation at a variable atom. Not `@[simp]` —
     unfolding is opt-in. -/
 theorem reinterpret_pred (Q : Pred) (x : Var) :
-    reinterpret sub P (.pred Q x : QBSMLFormula Var Const Pred) =
+    reinterpret sub P (.pred Q x : Formula Var Const Pred) =
       if sub P Q then
         .disj (.conj (.pred P x) (.pred Q x))
               (.conj (.neg (.pred P x)) (.pred Q x))
@@ -115,7 +115,7 @@ theorem reinterpret_pred (Q : Pred) (x : Var) :
 
 /-- Equation lemma: reinterpretation at a constant atom. -/
 theorem reinterpret_predc (Q : Pred) (c : Const) :
-    reinterpret sub P (.predc Q c : QBSMLFormula Var Const Pred) =
+    reinterpret sub P (.predc Q c : Formula Var Const Pred) =
       if sub P Q then
         .disj (.conj (.predc P c) (.predc Q c))
               (.conj (.neg (.predc P c)) (.predc Q c))
@@ -123,17 +123,17 @@ theorem reinterpret_predc (Q : Pred) (c : Const) :
   rfl
 
 /-- Reinterpretation preserves NE-freeness. -/
-theorem reinterpret_isNEFree {φ : QBSMLFormula Var Const Pred}
+theorem reinterpret_isNEFree {φ : Formula Var Const Pred}
     (h : φ.IsNEFree) : (reinterpret sub P φ).IsNEFree :=
   h.mapAtoms
     (fun Q x => by
-      show QBSMLFormula.IsNEFree (if sub P Q then _ else _)
+      show Formula.IsNEFree (if sub P Q then _ else _)
       split
       · exact .disj (.conj (.pred _ _) (.pred _ _))
           (.conj (.neg (.pred _ _)) (.pred _ _))
       · exact .pred _ _)
     (fun Q c => by
-      show QBSMLFormula.IsNEFree (if sub P Q then _ else _)
+      show Formula.IsNEFree (if sub P Q then _ else _)
       split
       · exact .disj (.conj (.predc _ _) (.predc _ _))
           (.conj (.neg (.predc _ _)) (.predc _ _))
@@ -154,14 +154,14 @@ section SalvaVeritate
 variable {W Var Domain Const Pred : Type*}
 variable [DecidableEq W]
 variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
-variable (M : QBSMLModel W Domain Const Pred)
+variable (M : Model W Domain Const Pred)
 
 private theorem eval_iff_of_atom_pred (P Q : Pred) (x : Var) (b : Bool)
     (s : Finset (Index W Var Domain)) :
-    eval M b (QBSMLFormula.disj
+    eval M b (Formula.disj
         (.conj (.pred P x) (.pred Q x))
         (.conj (.neg (.pred P x)) (.pred Q x))) s ↔
-      eval M b (QBSMLFormula.pred Q x) s := by
+      eval M b (Formula.pred Q x) s := by
   classical
   cases b with
   | true =>
@@ -208,10 +208,10 @@ private theorem eval_iff_of_atom_pred (P Q : Pred) (x : Var) (b : Bool)
 
 private theorem eval_iff_of_atom_predc (P Q : Pred) (c : Const) (b : Bool)
     (s : Finset (Index W Var Domain)) :
-    eval M b (QBSMLFormula.disj
+    eval M b (Formula.disj
         (.conj (.predc P c) (.predc Q c))
         (.conj (.neg (.predc P c)) (.predc Q c))) s ↔
-      eval M b (QBSMLFormula.predc Q c) s := by
+      eval M b (Formula.predc Q c) s := by
   classical
   cases b with
   | true =>
@@ -255,7 +255,7 @@ private theorem eval_iff_of_atom_predc (P Q : Pred) (c : Const) (b : Bool)
     not truth); `eval_mapAtoms_iff` reduces it to the two atom
     equivalences. -/
 theorem eval_reinterpret_iff (sub : Pred → Pred → Prop) [DecidableRel sub]
-    (P : Pred) (φ : QBSMLFormula Var Const Pred) (b : Bool)
+    (P : Pred) (φ : Formula Var Const Pred) (b : Bool)
     (s : Finset (Index W Var Domain)) :
     eval M b (reinterpret sub P φ) s ↔ eval M b φ s :=
   eval_mapAtoms_iff M
@@ -273,14 +273,14 @@ theorem eval_reinterpret_iff (sub : Pred → Pred → Prop) [DecidableRel sub]
 
 /-- Support is invariant under reinterpretation. -/
 theorem support_reinterpret_iff (sub : Pred → Pred → Prop) [DecidableRel sub]
-    (P : Pred) (φ : QBSMLFormula Var Const Pred)
+    (P : Pred) (φ : Formula Var Const Pred)
     (s : Finset (Index W Var Domain)) :
     support M (reinterpret sub P φ) s ↔ support M φ s :=
   eval_reinterpret_iff M sub P φ true s
 
 /-- Anti-support is invariant under reinterpretation. -/
 theorem antiSupport_reinterpret_iff (sub : Pred → Pred → Prop)
-    [DecidableRel sub] (P : Pred) (φ : QBSMLFormula Var Const Pred)
+    [DecidableRel sub] (P : Pred) (φ : Formula Var Const Pred)
     (s : Finset (Index W Var Domain)) :
     antiSupport M (reinterpret sub P φ) s ↔ antiSupport M φ s :=
   eval_reinterpret_iff M sub P φ false s
@@ -305,17 +305,17 @@ inductive RossPred | send | burn
   deriving DecidableEq, Repr
 
 /-- `SEND a`: the letter is sent (constant atom; `a` is the letter). -/
-def sendL : QBSMLFormula QVar Unit RossPred := .predc .send ()
+def sendL : Formula QVar Unit RossPred := .predc .send ()
 
 /-- `BURN a`: the letter is burnt. -/
-def burnL : QBSMLFormula QVar Unit RossPred := .predc .burn ()
+def burnL : Formula QVar Unit RossPred := .predc .burn ()
 
 theorem sendL_isNEFree : sendL.IsNEFree := .predc _ _
 theorem burnL_isNEFree : burnL.IsNEFree := .predc _ _
 
 /-- John's bouletic state: a single desire-world where the letter is sent
     and not burnt, reflexively accessible. -/
-def rossModel : QBSMLModel Unit Unit Unit RossPred where
+def rossModel : Model Unit Unit Unit RossPred where
   access _ := {()}
   interp _ := monadicStructure (fun _ => ()) (fun P _ => P = RossPred.send)
 
@@ -337,14 +337,14 @@ theorem ross_monotone {s : Finset (Index Unit QVar Unit)}
     enriched disjunctive want, both "it is ok to send" and the paradoxical
     "it is ok to burn". Direct instance of `boxFC`. -/
 theorem ross_fc {s : Finset (Index Unit QVar Unit)}
-    (h : support rossModel (QBSMLFormula.enrich (sendL.disj burnL).nec) s) :
+    (h : support rossModel (Formula.enrich (sendL.disj burnL).nec) s) :
     support rossModel (.poss sendL) s ∧ support rossModel (.poss burnL) s :=
   boxFC rossModel sendL_isNEFree burnL_isNEFree h
 
 /-- The premise is assertable: John's desire state supports the enriched
     `[□SEND a]⁺`. -/
 theorem ross_premise :
-    support rossModel (QBSMLFormula.enrich sendL.nec) rossState := by
+    support rossModel (Formula.enrich sendL.nec) rossState := by
   rw [support_enrich_nec_iff]
   refine ⟨fun i _ => ⟨fun j _ => rfl, ?_⟩, Finset.singleton_nonempty _⟩
   exact ⟨((), i.assign),
@@ -357,7 +357,7 @@ theorem ross_premise :
     the discourse never grants. -/
 theorem ross_blocked :
     ¬ support rossModel
-      (QBSMLFormula.enrich (sendL.disj burnL).nec) rossState := by
+      (Formula.enrich (sendL.disj burnL).nec) rossState := by
   intro h
   obtain ⟨-, hburn⟩ := ross_fc h
   obtain ⟨X, hX, ⟨w, hw⟩, hsupp⟩ :=
@@ -400,12 +400,12 @@ instance : DecidableRel subFree := fun a b =>
   | .trip, .trip => .isFalse id
 
 /-- `Fx ∧ Tx`: a free trip. -/
-def freeTrip : QBSMLFormula QVar Unit AsherPred :=
+def freeTrip : Formula QVar Unit AsherPred :=
   .conj (.pred .free .x) (.pred .trip .x)
 
 /-- `¬Fx ∧ Tx`: a non-free trip — the unwanted disjunct reinterpretation
     introduces. -/
-def nonFreeTrip : QBSMLFormula QVar Unit AsherPred :=
+def nonFreeTrip : Formula QVar Unit AsherPred :=
   .conj (.neg (.pred .free .x)) (.pred .trip .x)
 
 theorem freeTrip_isNEFree : freeTrip.IsNEFree := .conj (.pred _ _) (.pred _ _)
@@ -413,18 +413,18 @@ theorem nonFreeTrip_isNEFree : nonFreeTrip.IsNEFree :=
   .conj (.neg (.pred _ _)) (.pred _ _)
 
 /-- The premise `□∃x(Fx ∧ Tx)`: Nicholas wants a free trip. -/
-def asherPremise : QBSMLFormula QVar Unit AsherPred :=
-  (QBSMLFormula.exi .x freeTrip).nec
+def asherPremise : Formula QVar Unit AsherPred :=
+  (Formula.exi .x freeTrip).nec
 
 /-- The conclusion `□∃xTx`: Nicholas wants a trip. -/
-def asherConcl : QBSMLFormula QVar Unit AsherPred :=
-  (QBSMLFormula.exi QVar.x (.pred .trip .x)).nec
+def asherConcl : Formula QVar Unit AsherPred :=
+  (Formula.exi QVar.x (.pred .trip .x)).nec
 
 /-- Reinterpreting TRIP by FREE in the conclusion yields exactly the
     disjunctive want `□∃x((F ∧ T)x ∨ (¬F ∧ T)x)` — definitional. -/
 theorem reinterpret_asherConcl :
     reinterpret subFree .free asherConcl =
-      (QBSMLFormula.exi QVar.x (.disj freeTrip nonFreeTrip)).nec := rfl
+      (Formula.exi QVar.x (.disj freeTrip nonFreeTrip)).nec := rfl
 
 section AsherGeneric
 
@@ -433,7 +433,7 @@ variable {W Domain : Type*} [DecidableEq W] [DecidableEq Domain]
 
 /-- **Semantic validity of the monotonic step**: `□∃x(Fx ∧ Tx) ⊨ □∃xTx`
     (conjunction elimination under `∃` under `□`), for any model. -/
-theorem asher_monotone (M : QBSMLModel W Domain Unit AsherPred)
+theorem asher_monotone (M : Model W Domain Unit AsherPred)
     {s : Finset (Index W QVar Domain)}
     (h : support M asherPremise s) : support M asherConcl s :=
   support_nec_mono M
@@ -446,10 +446,10 @@ theorem asher_monotone (M : QBSMLModel W Domain Unit AsherPred)
     quantified □-FC, both "ok with a free trip" and "ok with a non-free
     trip" — the latter being what makes the monotonic conclusion sound
     wrong. -/
-theorem asher_fc (M : QBSMLModel W Domain Unit AsherPred)
+theorem asher_fc (M : Model W Domain Unit AsherPred)
     {s : Finset (Index W QVar Domain)}
     (h : support M
-      (QBSMLFormula.enrich (reinterpret subFree .free asherConcl)) s) :
+      (Formula.enrich (reinterpret subFree .free asherConcl)) s) :
     support M (.poss (.exi QVar.x freeTrip)) s ∧
     support M (.poss (.exi QVar.x nonFreeTrip)) s := by
   rw [reinterpret_asherConcl] at h
@@ -462,7 +462,7 @@ end AsherGeneric
     desire-world `true` every trip is free; the non-desire world `false`
     has a non-free trip; only the desire-world is bouletically
     accessible. -/
-def asherModel : QBSMLModel Bool Unit Unit AsherPred where
+def asherModel : Model Bool Unit Unit AsherPred where
   access _ := {true}
   interp w := monadicStructure (fun _ => ())
     (fun P _ => P = .trip ∨ w = true)
@@ -489,9 +489,9 @@ theorem asherModel_free_ssubset_trip :
 /-- The premise is assertable: the desire state supports
     `[□∃x(Fx ∧ Tx)]⁺`. -/
 theorem asher_premise :
-    support asherModel (QBSMLFormula.enrich asherPremise) asherState := by
+    support asherModel (Formula.enrich asherPremise) asherState := by
   show support asherModel
-    (QBSMLFormula.enrich (QBSMLFormula.exi QVar.x freeTrip).nec) asherState
+    (Formula.enrich (Formula.exi QVar.x freeTrip).nec) asherState
   rw [support_enrich_nec_iff]
   refine ⟨fun i _ => ?_, Finset.singleton_nonempty _⟩
   have hLne : (State.modalLift {true} i.assign :
@@ -521,7 +521,7 @@ theorem asher_premise :
     is licensed only by a premise the discourse never grants. -/
 theorem asher_blocked :
     ¬ support asherModel
-      (QBSMLFormula.enrich (reinterpret subFree .free asherConcl))
+      (Formula.enrich (reinterpret subFree .free asherConcl))
       asherState := by
   intro h
   obtain ⟨-, hnf⟩ := asher_fc asherModel h
@@ -549,9 +549,9 @@ theorem asher_blocked :
     form — the two classically equivalent formulas (`eval_reinterpret_iff`)
     come apart under `[·]⁺`, which is the paper's whole point. -/
 theorem asher_concl_enriched :
-    support asherModel (QBSMLFormula.enrich asherConcl) asherState := by
+    support asherModel (Formula.enrich asherConcl) asherState := by
   show support asherModel
-    (QBSMLFormula.enrich (QBSMLFormula.exi QVar.x (.pred .trip .x)).nec)
+    (Formula.enrich (Formula.exi QVar.x (.pred .trip .x)).nec)
     asherState
   rw [support_enrich_nec_iff]
   refine ⟨fun i _ => ?_, Finset.singleton_nonempty _⟩
@@ -601,25 +601,25 @@ instance : DecidableRel subTuesday := fun a b =>
   | .teach, .teach => .isFalse id
 
 /-- `TUEx ∧ TEACHx`: a Tuesday teaching. -/
-def tuesdayTeach : QBSMLFormula QVar Unit HeimPred :=
+def tuesdayTeach : Formula QVar Unit HeimPred :=
   .conj (.pred .tuesday .x) (.pred .teach .x)
 
 /-- `¬TUEx ∧ TEACHx`: a non-Tuesday teaching. -/
-def nonTuesdayTeach : QBSMLFormula QVar Unit HeimPred :=
+def nonTuesdayTeach : Formula QVar Unit HeimPred :=
   .conj (.neg (.pred .tuesday .x)) (.pred .teach .x)
 
 /-- The conclusion `□∃x TEACHx`: I want to teach next semester. -/
-def heimConcl : QBSMLFormula QVar Unit HeimPred :=
-  (QBSMLFormula.exi QVar.x (.pred .teach .x)).nec
+def heimConcl : Formula QVar Unit HeimPred :=
+  (Formula.exi QVar.x (.pred .teach .x)).nec
 
 /-- **The unwarranted inference** ([yan-2023] §4.4.3, "Reinterpretation of
     TEACH"): the enriched reinterpreted conclusion `[□∃x∥TEACHx∥_TUE]⁺`
     licenses "ok to teach on a non-Tuesday" by quantified □-FC. -/
 theorem heim_fc {W Domain : Type*} [DecidableEq W] [DecidableEq Domain]
-    [Fintype Domain] (M : QBSMLModel W Domain Unit HeimPred)
+    [Fintype Domain] (M : Model W Domain Unit HeimPred)
     {s : Finset (Index W QVar Domain)}
     (h : support M
-      (QBSMLFormula.enrich (reinterpret subTuesday .tuesday heimConcl)) s) :
+      (Formula.enrich (reinterpret subTuesday .tuesday heimConcl)) s) :
     support M (.poss (.exi QVar.x tuesdayTeach)) s ∧
     support M (.poss (.exi QVar.x nonTuesdayTeach)) s :=
   boxExiFC M


### PR DESCRIPTION
Deep cleanse of the AvO 2023 study plus the substrate rename it surfaced.

- `QBSML.QBSMLFormula`/`QBSML.QBSMLModel` → `QBSML.Formula`/`QBSML.Model` (namespace stutter; mathlib `Language.Formula` pattern).
- Study: fixes a false frame-condition claim — universal access **is** state-based on full-world-projection states (`univAccessModel_stateBased_of_full`); adds `fact3_ignorance` + `fact6_distributionEpi` (first consumers of the substrate's `ignorance`/`distributionEpi`), with decide-checked non-vacuity and separation examples; `fig14_stateBased` shows the Fact 4 countermodel meets the paper's epistemic assumption.
- Facts 3/7/8/10 restated in the paper's literal `Pa ∨ Pb` shapes (constant atoms); `avoModel` → `univAccessModel`, `QPred` → `Predicate`; module docstring to mathlib register; golf (`deriving Fintype`, `Nonempty.subset_singleton_iff`, term proofs).