### PR TITLE
refactor(Logic/Modal/FirstOrder): monadicWithConstants via withConstants

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -154,8 +154,10 @@ def stTerm (k : ℕ) :
   | .var (Sum.inl x) => corrIndivVar x
   | .var (Sum.inr i) => i.elim0
   | @Term.func _ _ l f _ => match l, f with
-    | 0, c => Term.func (corrConst c) ![corrWorldVar k]
-    | _ + 1, f => f.elim
+    | 0, Sum.inr c => Term.func (corrConst c) ![corrWorldVar k]
+    | 0, Sum.inl e => e.elim
+    | _ + 1, Sum.inl e => e.elim
+    | _ + 1, Sum.inr e => e.elim
 
 /-- Translate an embedded classical formula when it is a monadic atom
     (`none` otherwise — which never arises from `Formula.toModal?`
@@ -164,10 +166,13 @@ def stAtom? (k : ℕ) :
     (monadicWithConstants Const Pred).Formula Var →
       Option ((correspondence Const Pred).Formula (Var ⊕ ℕ))
   | @BoundedFormula.rel _ _ _ l R ts => match l, R, ts with
-    | 1, P, ts =>
+    | 1, Sum.inl P, ts =>
         some ((corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0)))
-    | 0, r, _ => r.elim
-    | _ + 2, r, _ => r.elim
+    | 1, Sum.inr r, _ => r.elim
+    | 0, Sum.inl r, _ => r.elim
+    | 0, Sum.inr r, _ => r.elim
+    | _ + 2, Sum.inl r, _ => r.elim
+    | _ + 2, Sum.inr r, _ => r.elim
   | _ => none
 
 /-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
@@ -210,9 +215,12 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
   | all χ' => simp [stAtom?] at hψ
   | @rel _ l R ts =>
     match l, R with
-    | 0, r => exact r.elim
-    | (n + 2), r => exact r.elim
-    | 1, (P : Pred) =>
+    | 0, Sum.inl r => exact r.elim
+    | 0, Sum.inr r => exact r.elim
+    | (n + 2), Sum.inl r => exact r.elim
+    | (n + 2), Sum.inr r => exact r.elim
+    | 1, Sum.inr r => exact r.elim
+    | 1, Sum.inl (P : Pred) =>
       rw [show stAtom? k (.rel (monadicRel P) ts) =
           some ((corrRel P).formula₂ (Term.var (Sum.inr k)) (stTerm k (ts 0)))
           from rfl, Option.some.injEq] at hψ
@@ -250,20 +258,22 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
         | inr i => exact i.elim0
       | @func l' f args =>
         cases l' with
-        | succ m => exact f.elim
+        | succ m => obtain (e | e) := f <;> exact e.elim
         | zero =>
+          obtain (e | c) := f
+          · exact e.elim
           have hLHS : K.RealizeAt w (.rel (monadicRel P) ts) v ↔
-              K.pInterp P w (K.cInterp f w) := by
+              K.pInterp P w (K.cInterp c w) := by
             letI := K.interp w
             show (K.interp w).RelMap (monadicRel P)
                 (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
               ↔ _
             have hfun : (fun i : Fin 1 => (ts i).realize
                 (Sum.elim v (default : Fin 0 → M))) =
-                fun _ => K.cInterp f w := by
+                fun _ => K.cInterp c w := by
               funext i
               rw [Subsingleton.elim i 0, hts]
-              show (K.interp w).funMap f
+              show (K.interp w).funMap (monadicConst c)
                   (fun j => (args j).realize (Sum.elim v default)) = _
               have hargs : (fun j : Fin 0 => (args j).realize
                   (Sum.elim v (default : Fin 0 → M))) = default :=
@@ -273,24 +283,24 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
             rw [hfun]
             exact Iff.rfl
           rw [hLHS, Formula.realize_rel₂,
-            show (stTerm k (.func f args) :
+            show (stTerm k (.func (monadicConst c) args) :
                 (correspondence Const Pred).Term (Var ⊕ ℕ)) =
-              Term.func (corrConst f) ![Term.var (Sum.inr k)] from rfl,
+              Term.func (corrConst c) ![Term.var (Sum.inr k)] from rfl,
             corrStructure_relMap_rel]
-          have hcv : (Term.func (corrConst f)
+          have hcv : (Term.func (corrConst c)
               ![Term.var (Sum.inr k)] :
               (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val
-              = Sum.inr (K.cInterp f w) :=
-            corrStructure_funMap_inl K f w _ hw
+              = Sum.inr (K.cInterp c w) :=
+            corrStructure_funMap_inl K c w _ hw
           constructor
           · intro h
-            exact ⟨w, K.cInterp f w, hw, hcv, h⟩
+            exact ⟨w, K.cInterp c w, hw, hcv, h⟩
           · rintro ⟨w', d, hw', hd, h⟩
             have hww : val (Sum.inr k) = Sum.inl w' := hw'
             obtain rfl : w = w' := Sum.inl.inj (hw.symm.trans hww)
-            have hdd : Sum.inr (K.cInterp f w) = Sum.inr d :=
+            have hdd : Sum.inr (K.cInterp c w) = Sum.inr d :=
               hcv.symm.trans hd
-            obtain rfl : K.cInterp f w = d := Sum.inr.inj hdd
+            obtain rfl : K.cInterp c w = d := Sum.inr.inj hdd
             exact h
 
 /-- An individual-sorted update of an individual-sorted valuation. -/

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -1,24 +1,25 @@
+import Linglib.Core.ModelTheory.FiniteModel
 import Linglib.Logic.Modal.FirstOrder.Kripke
 
 /-!
 # The monadic signature with individual constants
 
-The first-order signature with one individual constant per `Const` and one
-unary relation symbol per `Pred` — the object-language signature of monadic
-quantified modal logic ([aloni-vanormondt-2023] Definition 4.1: terms
-`t := c | x`, monadic relations) — together with its canonical structures
-and the world-relative denotation readers for Kripke structures over it.
+`Language.monadicWithConstants Const Pred` is the relations-only monadic
+language `Language.monadic Pred` (`Core/ModelTheory/FiniteModel.lean`) with
+constants adjoined by mathlib's `withConstants` — one individual constant
+per `Const`, one unary relation symbol per `Pred`: the object-language
+signature of monadic quantified modal logic ([aloni-vanormondt-2023]
+Definition 4.1, terms `t := c | x`). Structures compose from
+`monadicStructure` on the relations side and `constantsOn.structure` on
+the constants side.
 
-Up to definitional shape this signature is `(Language.monadic Pred)[[Const]]`
-(the relations-only `Language.monadic` of `Core/ModelTheory/FiniteModel.lean`
-with constants adjoined via mathlib's `withConstants`); it is kept as a
-direct definition so that interpretation `match` patterns stay structural.
+## Main definitions
 
-## Main declarations
-
-* `Language.monadicWithConstants` — the signature.
+* `Language.monadicWithConstants` — the signature, as
+  `(Language.monadic Pred)[[Const]]`.
 * `monadicWithConstantsStructure` — its structure from a constant
-  interpretation and a predicate valuation (cf. mathlib's `orderStructure`).
+  interpretation and a predicate valuation (cf. mathlib's
+  `orderStructure`).
 * `KripkeStructure.pInterp`, `KripkeStructure.cInterp` — world-relative
   predicate and constant denotations of a Kripke structure over the
   signature.
@@ -28,40 +29,30 @@ universe u v
 
 namespace FirstOrder.Language
 
-/-- The monadic signature with constants: one individual constant per
-    `Const`, one unary relation symbol per `Pred`. -/
-def monadicWithConstants.{u', v'} (Const : Type u') (Pred : Type v') :
-    Language where
-  Functions := fun n => match n with
-    | 0 => Const
-    | _ => PEmpty
-  Relations := fun n => match n with
-    | 1 => Pred
-    | _ => PEmpty
+/-- The monadic signature with constants:
+    `(Language.monadic Pred)[[Const]]`. -/
+abbrev monadicWithConstants (Const : Type u) (Pred : Type v) : Language :=
+  (monadic Pred)[[Const]]
 
 variable {Const Pred Domain : Type*}
 
-/-- A constant as a symbol of the signature (defeq; the parametric analogue
-    of mathlib's per-symbol abbreviations). -/
+/-- A constant as a symbol of the signature (mathlib's `Language.con`). -/
 abbrev monadicConst (c : Const) :
-    (monadicWithConstants Const Pred).Constants := c
+    (monadicWithConstants Const Pred).Constants := Sum.inr c
 
-/-- A predicate as a relation symbol of the signature (defeq). -/
+/-- A predicate as a relation symbol of the signature. -/
 abbrev monadicRel (P : Pred) :
-    (monadicWithConstants Const Pred).Relations 1 := P
+    (monadicWithConstants Const Pred).Relations 1 := Sum.inl P
 
 /-- The `monadicWithConstants` structure a constant interpretation and a
-    predicate valuation induce. -/
+    predicate valuation induce: `monadicStructure` on the relations side,
+    `constantsOn.structure` on the constants side. -/
 @[reducible] def monadicWithConstantsStructure (κ : Const → Domain)
     (V : Pred → Domain → Prop) :
-    (monadicWithConstants Const Pred).Structure Domain where
-  funMap := fun {n} f => match n, f with
-    | 0, c => fun _ => κ c
-    | _ + 1, f => f.elim
-  RelMap := fun {n} r => match n, r with
-    | 1, P => fun v => V P (v 0)
-    | 0, r => r.elim
-    | _ + 2, r => r.elim
+    (monadicWithConstants Const Pred).Structure Domain :=
+  letI := monadicStructure V
+  letI := constantsOn.structure κ
+  inferInstance
 
 @[simp] theorem monadicWithConstantsStructure_relMap (κ : Const → Domain)
     (V : Pred → Domain → Prop) (P : Pred) (v : Fin 1 → Domain) :


### PR DESCRIPTION
Stranded when #1900 automerged: `Language.monadicWithConstants` becomes literally `(Language.monadic Pred)[[Const]]` (Core's relations-only monadic as base, constants adjoined by mathlib's combinator); the structure composes from `monadicStructure` + `constantsOn.structure` via `sumStructure`. Constructor-side abbrevs keep their names as the Sum injections, so only `Correspondence.lean`'s three destruction-site matches change.