### PR TITLE
refactor(Syntax/Category/Pronoun): cleanse Capabilities; add gender axis

### DIFF
--- a/Linglib/Features/Gender/Capabilities.lean
+++ b/Linglib/Features/Gender/Capabilities.lean
@@ -34,6 +34,8 @@ class HasGender (α : Type*) where
   /-- The comparative gender label the carrier bears. -/
   genderOf : α → Option Gender
 
+export HasGender (genderOf)
+
 /-- A UD morphology bundle bears the label its `gender` tag ingests
     (`Gender.fromUD`, total on UD genders). -/
 instance : HasGender UD.MorphFeatures :=

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -7,8 +7,9 @@ import Linglib.Features.Number.Basic
 [corbett-2000]
 
 The typeclass mixin for carriers that bear grammatical number — the number
-axis of the capability tower over lexical carriers (cf. `Proform`/`Bound`/
-`Clusive` in `Syntax/Category/Pronoun/Capabilities.lean`). A consumer (agreement
+axis of the capability tower over lexical carriers (cf. `Proform` in
+`Syntax/Category/Pronoun/Capabilities.lean`, `Bound` in
+`Features/CoreferenceStatus.lean`). A consumer (agreement
 checker, resolution, semantics) requires `[HasNumber α]` and works over any
 representation: a UD feature bundle, a `Word`, a `Pronoun`, an agreement
 paradigm cell.
@@ -18,7 +19,7 @@ typologically normal case ([corbett-2000]): a carrier with no number marking
 is a wildcard for agreement, not a default singular.
 
 Instances live with their carriers (mathlib-style): `UD.MorphFeatures` here
-(its type is below this file); `Word` in `Morphology/Word.lean`; `Pronoun`/
+(its type is below this file); `Word` in `Morphology/Word/Basic.lean`; `Pronoun`/
 `PersonalPronoun` in `Syntax/Category/Pronoun/Capabilities.lean`; paradigm `Cell` in
 `Syntax/Agreement/Paradigm.lean`.
 
@@ -39,6 +40,8 @@ set_option autoImplicit false
 class HasNumber (α : Type*) where
   /-- The canonical number value the carrier bears. -/
   numberOf : α → Option Number
+
+export HasNumber (numberOf)
 
 /-- A UD morphology bundle bears the number its `number` tag ingests
     (`Number.fromUD`); tags with no analytical equivalent (`Inv`/`Coll`/

--- a/Linglib/Morphology/Word/Basic.lean
+++ b/Linglib/Morphology/Word/Basic.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Data.UD.Basic
 import Linglib.Features.Case.Capabilities
+import Linglib.Features.Gender.Capabilities
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person.Capabilities
 
@@ -41,6 +42,8 @@ instance : HasNumber Word := ⟨fun w => w.features.number.bind Number.fromUD⟩
 instance : HasPerson Word := ⟨fun w => w.features.person.map Person.fromUD⟩
 
 instance : HasCase Word := ⟨fun w => w.features.case_.map Case.fromUD⟩
+
+instance : HasGender Word := ⟨fun w => w.features.gender.map Gender.fromUD⟩
 
 
 /-- Words compare by form and category, ignoring features, so homographs

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -1,17 +1,17 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Data.UD.Basic
 import Linglib.Features.Case.Capabilities
+import Linglib.Features.Gender.Capabilities
 import Linglib.Features.Number.Capabilities
 import Linglib.Features.Person.Capabilities
 import Linglib.Features.CoreferenceStatus
-import Linglib.Features.Register
-import Linglib.Features.Prominence
-import Linglib.Features.Clusivity
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Category.Pronoun.Basic
 import Linglib.Morphology.Word.Basic
-
-open Morphology (Word)
-
 
 /-!
 # Pronoun capabilities — a mixin tower over pronoun carriers
@@ -35,14 +35,18 @@ object (`Word`), or a future theory representation; each supplies its own instan
 * `bindingClassOf_toWord` — the faithfulness certificate: the binding engine's canonical
   morphology source (`Binding.bindingClassOf`) agrees with the `Bound` mixin on every
   projected pro-form, so the surface engine and the carrier capability never diverge.
-* `Deictic` — orthogonal data-mixin (register / referential person).
+* `HasNumber`/`HasPerson`/`HasCase`/`HasGender` instances for the pronoun carriers, each
+  with a faithfulness theorem (`numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
+  `genderOf_toWord`) locating exactly what `toWord`'s UD realization preserves or loses.
 
 ## Implementation notes
 
 Capabilities live near their domain (mathlib-style: `ContinuousMul` is in `Topology`, not
 `Algebra`). The word-class-neutral `Indefinite` capability (`[Indefinite α]`, Haspelmath
 function-coverage) therefore lives in `Features/Indefinite.lean`, and the binding axis `Bound`
-lives in `Features/CoreferenceStatus.lean` — neither is pronoun-specific. Two further axes are deferred, each for a principled reason. *Deficiency*
+lives in `Features/CoreferenceStatus.lean` — neither is pronoun-specific.
+
+Three further axes are deferred, each for a principled reason. *Deficiency*
 ([cardinaletti-starke-1999] `Pronoun.Strength`) is *per-series*, not per-element: every carrier's
 strength is carrier-uniform (Italian clitics are all `.clitic`; the Mixtec clitic/nonclitic *fields*
 have fixed strengths), so an `α → Strength` accessor would be constant on every carrier — a
@@ -50,10 +54,13 @@ per-*type* fact, not a per-element capability. It is served by the `Pronoun.stre
 (series-level, `none` when not homogeneous) and the `Strength` linear order, not by a class.
 The finer *lexical-kind* axis (personal vs relative vs interrogative vs
 demonstrative) is `Pronoun.pronType` — real UD morphology on the carrier (no invented enum),
-threaded onto the projected word by `toWord`.
+threaded onto the projected word by `toWord`. The *deictic* axis (register, referential
+person) is borne by one carrier only, which carries it as fields
+(`PersonalPronoun.register`/`referentialPerson`); a class over those accessors earns its
+keep when a second carrier bears the axis.
 -/
 
-set_option autoImplicit false
+open Morphology (Word)
 
 /-! ### The spine: `Proform` -/
 
@@ -89,44 +96,24 @@ theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpre
     (hr : p.pronType = some .Rcp → p.bindingClass = some .reciprocal) :
     Binding.bindingClassOf p.toWord = Bound.source p := by
   show Binding.bindingClassOf p.toWord = some (p.bindingClass.getD .pronoun)
-  rcases hb : p.bindingClass with _ | c
-  · rcases hp : p.pronType with _ | pt
-    · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]
-    · cases pt
-      case Rcp => exact absurd ((hr hp).symm.trans hb) (by simp)
-      all_goals (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
-  · cases c with
-    | reflexive =>
-      rcases hp : p.pronType with _ | pt
-      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide
-      · cases pt <;> (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
-    | reciprocal =>
-      rcases hp : p.pronType with _ | pt
-      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide
-      · cases pt <;> (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
-    | pronoun =>
-      rcases hp : p.pronType with _ | pt
-      · simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]
-        try decide
-      · cases pt
-        case Rcp => exact absurd ((hr hp).symm.trans hb) (by simp)
-        all_goals (simp [Binding.bindingClassOf, Pronoun.toWord, hb, hp]; try decide)
-    | rExpression => exact absurd hb h
+  rcases hb : p.bindingClass with _ | (_ | _ | _ | _) <;>
+      rcases hp : p.pronType with _ | pt <;> (try cases pt) <;>
+    simp_all +decide [Binding.bindingClassOf, Pronoun.toWord]
 
 /-! ### The number axis: `HasNumber` instances and faithfulness -/
 
 /-- A pronoun bears its analytical number directly — the carrier field is
 root-`Number`-typed. -/
 instance : HasNumber Pronoun := ⟨fun p => p.number⟩
-instance : HasNumber PersonalPronoun := ⟨fun p => HasNumber.numberOf p.toPronoun⟩
+
+instance : HasNumber PersonalPronoun := ⟨fun p => numberOf p.toPronoun⟩
 
 /-- Projecting a pronoun to a `Word` realizes its number through UD: the
 round-trip is identity exactly on UD-expressible values — the
 minimal/augmented values are lost to realization (`Number.toUD` is
 partial), the number analogue of `personOf_toWord`'s coarsening. -/
 theorem numberOf_toWord (p : Pronoun) :
-    HasNumber.numberOf p.toWord =
-      p.number.bind fun n => n.toUD.bind Number.fromUD := by
+    numberOf p.toWord = p.number.bind fun n => n.toUD.bind Number.fromUD := by
   show (p.number.bind Number.toUD).bind Number.fromUD = _
   cases p.number <;> rfl
 
@@ -137,20 +124,15 @@ root-`Person`-typed, clusivity included (Tagalog *kami* =
 `firstExclusive`). -/
 instance : HasPerson Pronoun := ⟨fun p => p.person⟩
 
-instance : HasPerson PersonalPronoun :=
-  ⟨fun p => HasPerson.personOf p.toPronoun⟩
+instance : HasPerson PersonalPronoun := ⟨fun p => personOf p.toPronoun⟩
 
 /-- Projecting a pronoun to a `Word` coarsens its person: `Word` carries
 UD realization, which has no clusivity — the mixin makes the loss
 explicit rather than silent. -/
 theorem personOf_toWord (p : Pronoun) :
-    HasPerson.personOf p.toWord =
-      (HasPerson.personOf p).map Person.coarsen := by
-  show (p.person.map Person.toUD).map Person.fromUD =
-    p.person.map Person.coarsen
-  cases p.person with
-  | none => rfl
-  | some per => exact congrArg some (Person.fromUD_toUD per)
+    personOf p.toWord = (personOf p).map Person.coarsen := by
+  show (p.person.map Person.toUD).map Person.fromUD = p.person.map Person.coarsen
+  simp [Option.map_map, Function.comp_def, Person.fromUD_toUD]
 
 /-! ### The case axis: `HasCase` instances and faithfulness -/
 
@@ -158,29 +140,30 @@ theorem personOf_toWord (p : Pronoun) :
 root-`Case`-typed. -/
 instance : HasCase Pronoun := ⟨fun p => p.case_⟩
 
-instance : HasCase PersonalPronoun := ⟨fun p => HasCase.caseOf p.toPronoun⟩
+instance : HasCase PersonalPronoun := ⟨fun p => caseOf p.toPronoun⟩
 
 /-- Projecting a pronoun to a `Word` realizes its case through UD
 losslessly: `Case.toUD` is currently a bijection, so — unlike person
 (clusivity lost) and number (minimal/augmented lost) — the round-trip is
 the identity. This is the theorem that degrades when an analytical
 refinement splits a UD cell (`Case.fromUD_toUD`). -/
-theorem caseOf_toWord (p : Pronoun) :
-    HasCase.caseOf p.toWord = HasCase.caseOf p := by
+theorem caseOf_toWord (p : Pronoun) : caseOf p.toWord = caseOf p := by
   show (p.case_.map Case.toUD).map Case.fromUD = p.case_
-  cases p.case_ with
-  | none => rfl
-  | some c => exact congrArg some (Case.fromUD_toUD c)
+  simp [Option.map_map, Function.comp_def, Case.fromUD_toUD]
 
-/-! ### Orthogonal data-mixin: `Deictic` -/
+/-! ### The gender axis: `HasGender` instances and faithfulness -/
 
-/-- A deictic carrier exposes register and — when it diverges from agreement person — referential
-person, the features specific to personal/referential pronouns ([adamson-zompi-2025]). -/
-class Deictic (α : Type*) [Proform α] where
-  /-- Register level (T/V, honorific tiers). -/
-  register : α → Features.Register.Level
-  /-- Referential person when it diverges from formal/agreement person; `none` otherwise. -/
-  referentialPerson : α → Option Person
+/-- A pronoun bears its analytical gender directly — the carrier field is
+root-`Gender`-typed. -/
+instance : HasGender Pronoun := ⟨fun p => p.gender⟩
 
-instance : Deictic PersonalPronoun :=
-  ⟨PersonalPronoun.register, PersonalPronoun.referentialPerson⟩
+instance : HasGender PersonalPronoun := ⟨fun p => genderOf p.toPronoun⟩
+
+/-- Projecting a pronoun to a `Word` realizes its gender through UD: the
+round-trip is identity exactly on UD-expressible values — the animacy-based
+labels are lost to realization (`Gender.toUD` is partial), the gender
+analogue of `numberOf_toWord`. -/
+theorem genderOf_toWord (p : Pronoun) :
+    genderOf p.toWord = p.gender.bind fun g => g.toUD.map Gender.fromUD := by
+  show (p.gender.bind Gender.toUD).map Gender.fromUD = _
+  cases p.gender <;> rfl


### PR DESCRIPTION
Deep-audit cleanse of `Syntax/Category/Pronoun/Capabilities.lean`: delete the zero-consumer `Deictic` class (its `[Proform α]` binder was unused by its fields; documented as the third deferred axis), add the missing gender axis (`HasGender` instances for `Pronoun`/`PersonalPronoun`/`Word` + `genderOf_toWord`), golf `bindingClassOf_toWord` 27 → 3 lines (`simp_all +decide`), and trim unused imports.

- Riders: `export HasNumber (numberOf)` / `export HasGender (genderOf)` harmonizing with `HasPerson`/`HasCase`; stale doc pointers fixed in `Features/Number/Capabilities.lean`.