### PR TITLE
feat(Syntax/Category/Pronoun): Proform.Agree; wire discourse studies

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1300,6 +1300,7 @@ import Linglib.Morphology.Realization
 import Linglib.Morphology.Root.Basic
 import Linglib.Morphology.Root.Certificates
 import Linglib.Morphology.Root.Consonantal
+import Linglib.Morphology.Word.Agree
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Word.Tree
 import Linglib.Phonology.Autosegmental.AR

--- a/Linglib/Morphology/Word/Agree.lean
+++ b/Linglib/Morphology/Word/Agree.lean
@@ -8,12 +8,10 @@ import Linglib.Morphology.Word.Basic
 /-!
 # φ-agreement between word tokens
 
-The φ-projection (`Word.phi`: person, number, gender) and the agreement
-relation it induces: two tokens agree when their φ-features unify
-(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard.
-A reflexive, symmetric tolerance relation — not transitive
-(`Word.Agree.not_transitive`). The feature-based agreement check binding and
-concord consumers share; `Proform.Agree` is its carrier-generic form.
+`Word.phi` projects a word's person, number, and gender. Two words `Agree` when
+these features unify (`UD.MorphFeatures.compatible`), an unspecified feature
+acting as a wildcard; the relation is reflexive and symmetric but not
+transitive. `Proform.Agree` is its carrier-generic form.
 -/
 
 namespace Morphology
@@ -23,11 +21,9 @@ def Word.phi (w : Word) : UD.MorphFeatures :=
   { person := w.features.person, number := w.features.number,
     gender := w.features.gender }
 
-/-- φ-agreement between two words: their person/number/gender features are
-    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
-    *tolerance* relation on `Word` (not transitive), decided by the shared
-    `UD.MorphFeatures.compatible`. The feature-based agreement check binding
-    and concord consumers share — no surface-form gender lookup. -/
+/-- Two words agree when their φ-features (person, number, gender) are
+    compatible, an unspecified feature acting as a wildcard. This is the
+    feature-based agreement check binding and concord consumers share. -/
 def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
 
 instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
@@ -36,15 +32,14 @@ instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
 @[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
   UD.MorphFeatures.compatible_self w.phi
 
-/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation",
-    as a theorem. -/
+/-- φ-agreement is symmetric. -/
 @[symm] theorem Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) :
     Word.Agree w2 w1 := by
   unfold Word.Agree at h ⊢
   rwa [UD.MorphFeatures.compatible_comm]
 
-/-- φ-agreement is *not* transitive: an unspecified feature is a wildcard, so
-    underspecified *they* agrees with both *she* and *he* while *she ≁ he*. -/
+/-- φ-agreement is not transitive; underspecified *they* agrees with both
+    *she* and *he* while *she* and *he* disagree. -/
 theorem Word.Agree.not_transitive :
     ¬ ∀ w1 w2 w3 : Word, Word.Agree w1 w2 → Word.Agree w2 w3 → Word.Agree w1 w3 := by
   intro h
@@ -55,8 +50,7 @@ theorem Word.Agree.not_transitive :
        (by decide) (by decide))
     (by decide)
 
-/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
-    diverges from the agreement check on `Word`. -/
+/-- φ-agreement entails number compatibility (`HasNumber.Compatible`). -/
 theorem Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
     HasNumber.Compatible w1 w2 :=
   UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h

--- a/Linglib/Morphology/Word/Agree.lean
+++ b/Linglib/Morphology/Word/Agree.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Morphology.Word.Basic
+
+/-!
+# φ-agreement between word tokens
+
+The φ-projection (`Word.phi`: person, number, gender) and the agreement
+relation it induces: two tokens agree when their φ-features unify
+(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard.
+A reflexive, symmetric tolerance relation — not transitive
+(`Word.Agree.not_transitive`). The feature-based agreement check binding and
+concord consumers share; `Proform.Agree` is its carrier-generic form.
+-/
+
+namespace Morphology
+
+/-- The φ-feature subset (person, number, gender) of a word. -/
+def Word.phi (w : Word) : UD.MorphFeatures :=
+  { person := w.features.person, number := w.features.number,
+    gender := w.features.gender }
+
+/-- φ-agreement between two words: their person/number/gender features are
+    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
+    *tolerance* relation on `Word` (not transitive), decided by the shared
+    `UD.MorphFeatures.compatible`. The feature-based agreement check binding
+    and concord consumers share — no surface-form gender lookup. -/
+def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
+
+instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
+  unfold Word.Agree; infer_instance
+
+@[refl] theorem Word.Agree.refl (w : Word) : Word.Agree w w :=
+  UD.MorphFeatures.compatible_self w.phi
+
+/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation",
+    as a theorem. -/
+@[symm] theorem Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) :
+    Word.Agree w2 w1 := by
+  unfold Word.Agree at h ⊢
+  rwa [UD.MorphFeatures.compatible_comm]
+
+/-- φ-agreement is *not* transitive: an unspecified feature is a wildcard, so
+    underspecified *they* agrees with both *she* and *he* while *she ≁ he*. -/
+theorem Word.Agree.not_transitive :
+    ¬ ∀ w1 w2 w3 : Word, Word.Agree w1 w2 → Word.Agree w2 w3 → Word.Agree w1 w3 := by
+  intro h
+  exact absurd
+    (h ⟨"she", .PRON, { person := some .third, number := some .Sing, gender := some .Fem }⟩
+       ⟨"they", .PRON, { person := some .third }⟩
+       ⟨"he", .PRON, { person := some .third, number := some .Sing, gender := some .Masc }⟩
+       (by decide) (by decide))
+    (by decide)
+
+/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
+    diverges from the agreement check on `Word`. -/
+theorem Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
+    HasNumber.Compatible w1 w2 :=
+  UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h
+
+-- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
+-- agrees with an unmarked one (the φ-projection drops it).
+example : Word.Agree ⟨"sich", .PRON, { reflex := true }⟩ ⟨"Kind", .NOUN, {}⟩ := by decide
+
+end Morphology

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -540,8 +540,8 @@ referent: the passages pair same-gender characters, so the prompt pronoun
 coherence prior and the topichood likelihood. The premise is checked against
 the English Fragment entry rather than stipulated. -/
 
-/-- The two characters of the running example ("Amanda amazed Brittany"), as
-    φ-bearing tokens: both third-person singular feminine. -/
+/-- The two characters of the running example ("Amanda amazed Brittany"), both
+    third-person singular feminine. -/
 def amanda : Word :=
   ⟨"Amanda", .PROPN, { person := some .third, number := some .Sing, gender := some .Fem }⟩
 
@@ -553,13 +553,12 @@ def masculineFoil : Word :=
   ⟨"Bill", .PROPN, { person := some .third, number := some .Sing, gender := some .Masc }⟩
 
 /-- The prompt *She* (the English Fragment entry) is φ-compatible with both
-    characters: gender cannot resolve the reference, so interpretation is left
-    to the coherence prior and topichood likelihood. -/
+    characters, so gender cannot resolve the reference. -/
 theorem she_ambiguous_over_stimuli :
     Proform.Agree English.Pronouns.she amanda ∧
       Proform.Agree English.Pronouns.she brittany := by decide
 
-/-- Against a mixed-gender pair the φ-filter resolves *she* by itself: the
+/-- Against a mixed-gender pair the φ-filter resolves *she* by itself; the
     same-gender design is what forces the Bayesian competition. -/
 theorem she_resolved_against_masculine :
     Proform.Agree English.Pronouns.she amanda ∧

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -5,6 +5,8 @@ import Linglib.Data.UD.Basic
 import Linglib.Discourse.Centering.Pronominalization
 import Linglib.Discourse.Centering.Instances.GrammaticalRole
 import Linglib.Discourse.Accessibility
+import Linglib.Fragments.English.Pronouns
+import Linglib.Syntax.Category.Pronoun.Capabilities
 
 /-!
 # Pronoun interpretation: coherence vs. centering [kehler-rohde-2013]
@@ -30,6 +32,9 @@ experiments with transfer-of-possession and implicit-causality verbs.
   expectancy hypothesis the substrate's `predictedForm` encodes.
 * `cb_topichood_dissociation_under_voice`: Centering's backward-looking center is
   voice-blind where `topichood` is voice-sensitive.
+* `she_ambiguous_over_stimuli`: the φ-design premise — the prompt pronoun
+  (the English Fragment entry) φ-agrees with both same-gender characters, so
+  the φ-filter cannot resolve the reference the Bayesian model competes over.
 
 ## Implementation notes
 
@@ -47,6 +52,7 @@ namespace KehlerRohde2013
 
 open Discourse.Coherence
 open UD (Voice)
+open Morphology (Word)
 
 /-! ### Experimental design -/
 
@@ -526,28 +532,56 @@ yet `topichood` distinguishes them (passive subject `.strong`, active subject
 `.default_`). The voice-induced pronominalization gradient (87% vs. 62%) lives in
 the topichood signal, not the CB signal. -/
 
+/-! ### The φ-design premise
+
+The Bayesian competition presupposes that morphology underdetermines the
+referent: the passages pair same-gender characters, so the prompt pronoun
+φ-agrees with both candidates and `P(referent | pronoun)` must come from the
+coherence prior and the topichood likelihood. The premise is checked against
+the English Fragment entry rather than stipulated. -/
+
+/-- The two characters of the running example ("Amanda amazed Brittany"), as
+    φ-bearing tokens: both third-person singular feminine. -/
+def amanda : Word :=
+  ⟨"Amanda", .PROPN, { person := some .third, number := some .Sing, gender := some .Fem }⟩
+
+def brittany : Word :=
+  ⟨"Brittany", .PROPN, { person := some .third, number := some .Sing, gender := some .Fem }⟩
+
+/-- A masculine token (a counterfactual foil, not a K&R stimulus). -/
+def masculineFoil : Word :=
+  ⟨"Bill", .PROPN, { person := some .third, number := some .Sing, gender := some .Masc }⟩
+
+/-- The prompt *She* (the English Fragment entry) is φ-compatible with both
+    characters: gender cannot resolve the reference, so interpretation is left
+    to the coherence prior and topichood likelihood. -/
+theorem she_ambiguous_over_stimuli :
+    Proform.Agree English.Pronouns.she amanda ∧
+      Proform.Agree English.Pronouns.she brittany := by decide
+
+/-- Against a mixed-gender pair the φ-filter resolves *she* by itself: the
+    same-gender design is what forces the Bayesian competition. -/
+theorem she_resolved_against_masculine :
+    Proform.Agree English.Pronouns.she amanda ∧
+      ¬ Proform.Agree English.Pronouns.she masculineFoil := by decide
+
 section CenteringBridge
 
 open Discourse.Centering
 
-/-- Two referents in the toy KR2013 example: Amanda (subject across voice
-    manipulations) and Brittany (object/by-phrase). -/
-def amanda : Nat := 1
-def brittany : Nat := 2
-
 /-- Prior "Amanda V'd Brittany": Amanda SUBJ, Brittany OBJ. Under Kameyama's role
     ranking the forward-looking centers are `[Amanda, Brittany]` with Amanda Cp. -/
-def prevAmandaActive : Utterance Nat GrammaticalRole :=
+def prevAmandaActive : Utterance Word GrammaticalRole :=
   { realizations := [⟨amanda, .subject, false⟩, ⟨brittany, .object, false⟩] }
 
 /-- Active continuation "She V'd her" — Amanda still SUBJ, both pronouns. -/
-def curActive : Utterance Nat GrammaticalRole :=
+def curActive : Utterance Word GrammaticalRole :=
   { realizations := [⟨amanda, .subject, true⟩, ⟨brittany, .object, true⟩] }
 
 /-- Passive continuation "Amanda was V'd by Brittany" — Amanda promoted to SUBJ by
     the marked passive; Brittany now in the by-phrase (`OTHER`). The proposition is
     identical; only the construction differs. -/
-def curPassive : Utterance Nat GrammaticalRole :=
+def curPassive : Utterance Word GrammaticalRole :=
   { realizations := [⟨amanda, .subject, true⟩, ⟨brittany, .other, false⟩] }
 
 /-- Cp of the prior utterance is Amanda (SUBJ outranks OBJ). -/

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -2,6 +2,8 @@ import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Discourse.Coherence
 import Linglib.Discourse.Accessibility
 import Linglib.Fragments.English.Predicates.Verbal
+import Linglib.Fragments.English.Pronouns
+import Linglib.Morphology.Word.Agree
 import Linglib.Studies.ArnoldEtAl2000
 import Linglib.Studies.KehlerRohde2013
 
@@ -87,6 +89,39 @@ inductive GenderContext where
   | sameGender       -- both characters same gender (pronoun ambiguous)
   | differentGender  -- different gender (pronoun unambiguous)
   deriving DecidableEq, Repr
+
+/-- The gender context of a referent pair, derived from the tokens' φ-features:
+    for the fully-φ-specified character tokens of the stimuli, `sameGender` ⟺
+    the tokens φ-agree (`Word.Agree`) — exactly the pairs a third-singular
+    gendered pronoun cannot discriminate. -/
+def GenderContext.ofReferents (w1 w2 : Morphology.Word) : GenderContext :=
+  if w1.Agree w2 then .sameGender else .differentGender
+
+/-- The running example's characters ("Lisa gave the pie to Brendan"), as
+    φ-bearing tokens. -/
+def lisa : Morphology.Word :=
+  ⟨"Lisa", .PROPN, { person := some .third, number := some .Sing, gender := some .Fem }⟩
+
+def brendan : Morphology.Word :=
+  ⟨"Brendan", .PROPN, { person := some .third, number := some .Sing, gender := some .Masc }⟩
+
+/-- The running example is a `differentGender` item, derived from the tokens'
+    φ-features rather than stipulated. -/
+theorem lisa_brendan_context :
+    GenderContext.ofReferents lisa brendan = .differentGender := by decide
+
+/-- What `differentGender` buys the speaker: *she* (the English Fragment entry)
+    picks out Lisa and excludes Brendan, so a pronoun is unambiguous — the
+    condition under which pronoun rates rise. -/
+theorem differentGender_phi_resolves :
+    Proform.Agree English.Pronouns.she lisa ∧
+      ¬ Proform.Agree English.Pronouns.she brendan := by decide
+
+/-- [kehler-rohde-2013]'s same-gender pair is a `sameGender` context under the
+    same derivation — the two studies' design premises are one φ-fact. -/
+theorem kr_stimuli_sameGender :
+    GenderContext.ofReferents KehlerRohde2013.amanda KehlerRohde2013.brittany =
+      .sameGender := by decide
 
 /-- Experimental paradigm. -/
 inductive Paradigm where

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -90,10 +90,10 @@ inductive GenderContext where
   | differentGender  -- different gender (pronoun unambiguous)
   deriving DecidableEq, Repr
 
-/-- The gender context of a referent pair, derived from the tokens' φ-features:
-    for the fully-φ-specified character tokens of the stimuli, `sameGender` ⟺
-    the tokens φ-agree (`Word.Agree`) — exactly the pairs a third-singular
-    gendered pronoun cannot discriminate. -/
+/-- The gender context of a referent pair. For the fully-φ-specified stimulus
+    tokens, a pair is `sameGender` exactly when the tokens φ-agree
+    (`Word.Agree`) — the pairs a third-singular gendered pronoun cannot
+    discriminate. -/
 def GenderContext.ofReferents (w1 w2 : Morphology.Word) : GenderContext :=
   if w1.Agree w2 then .sameGender else .differentGender
 
@@ -106,13 +106,13 @@ def brendan : Morphology.Word :=
   ⟨"Brendan", .PROPN, { person := some .third, number := some .Sing, gender := some .Masc }⟩
 
 /-- The running example is a `differentGender` item, derived from the tokens'
-    φ-features rather than stipulated. -/
+    φ-features. -/
 theorem lisa_brendan_context :
     GenderContext.ofReferents lisa brendan = .differentGender := by decide
 
-/-- What `differentGender` buys the speaker: *she* (the English Fragment entry)
-    picks out Lisa and excludes Brendan, so a pronoun is unambiguous — the
-    condition under which pronoun rates rise. -/
+/-- In a `differentGender` pair *she* (the English Fragment entry) picks out
+    Lisa and excludes Brendan, so a pronoun is unambiguous — the condition
+    under which pronoun rates rise. -/
 theorem differentGender_phi_resolves :
     Proform.Agree English.Pronouns.she lisa ∧
       ¬ Proform.Agree English.Pronouns.she brendan := by decide

--- a/Linglib/Syntax/Binding/Basic.lean
+++ b/Linglib/Syntax/Binding/Basic.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Features.CoreferenceStatus
-import Linglib.Morphology.Word.Basic
+import Linglib.Morphology.Word.Agree
 
 open Morphology (Word)
 
@@ -10,13 +10,11 @@ open Morphology (Word)
 
 A framework-neutral binding engine. The binding principles (A/B/C) and the
 coreference-status computation are stated **once**, parameterized by a
-`CommandRelation` — the structural-prominence order they range over. The three
-syntactic frameworks formalized in linglib supply that relation and inherit the
-principles unchanged:
-
-* Minimalism — c-command (tree geometry)
-* HPSG — ARG-ST outranking (obliqueness)
-* Dependency grammar — d-command (dependency subgraph)
+`CommandRelation` — the structural-prominence order they range over. A
+syntactic framework supplies that relation and inherits the principles
+unchanged; the candidate notions are Minimalist c-command (tree geometry — the
+instance in `Studies/Chomsky1981.lean`), HPSG ARG-ST outranking (obliqueness),
+and dependency-grammar d-command (dependency subgraph).
 
 [barker-pullum-1990] give the general notion of which c-command,
 m-command, and the rest are instances; the linglib frameworks' command notions
@@ -45,53 +43,6 @@ passed explicitly rather than baked in, so the engine imports no Fragment.
 A language (English, …) supplies the classifier; a framework supplies the
 command relation; a study combines them.
 -/
-
-/-- The φ-feature subset (person, number, gender) of a word. -/
-def Morphology.Word.phi (w : Word) : UD.MorphFeatures :=
-  { person := w.features.person, number := w.features.number,
-    gender := w.features.gender }
-
-/-- φ-agreement between two words: their person/number/gender features are
-    compatible (an unspecified feature is a wildcard). A reflexive, symmetric
-    *tolerance* relation on `Word` (not transitive), decided by the shared
-    `UD.MorphFeatures.compatible`. The feature-based agreement check binding
-    and concord consumers share — no surface-form gender lookup. -/
-def Morphology.Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
-
-instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
-  unfold Morphology.Word.Agree; infer_instance
-
-@[refl] theorem Morphology.Word.Agree.refl (w : Word) : Word.Agree w w :=
-  UD.MorphFeatures.compatible_self w.phi
-
-/-- φ-agreement is symmetric — the docstring's "symmetric tolerance relation",
-    as a theorem. -/
-@[symm] theorem Morphology.Word.Agree.symm {w1 w2 : Word} (h : Word.Agree w1 w2) :
-    Word.Agree w2 w1 := by
-  unfold Morphology.Word.Agree at h ⊢
-  rwa [UD.MorphFeatures.compatible_comm]
-
-/-- φ-agreement is *not* transitive: an unspecified feature is a wildcard, so
-    underspecified *they* agrees with both *she* and *he* while *she ≁ he*. -/
-theorem Morphology.Word.Agree.not_transitive :
-    ¬ ∀ w1 w2 w3 : Word, Word.Agree w1 w2 → Word.Agree w2 w3 → Word.Agree w1 w3 := by
-  intro h
-  exact absurd
-    (h ⟨"she", .PRON, { person := some .third, number := some .Sing, gender := some .Fem }⟩
-       ⟨"they", .PRON, { person := some .third }⟩
-       ⟨"he", .PRON, { person := some .third, number := some .Sing, gender := some .Masc }⟩
-       (by decide) (by decide))
-    (by decide)
-
-/-- φ-agreement entails number compatibility: the `HasNumber` mixin never
-    diverges from the agreement check on `Word`. -/
-theorem Morphology.Word.Agree.hasNumber_compatible {w1 w2 : Word} (h : w1.Agree w2) :
-    HasNumber.Compatible w1 w2 :=
-  UD.MorphFeatures.compatible_hasNumber (f1 := w1.phi) (f2 := w2.phi) h
-
--- `reflex` is deliberately not an agreement feature: a reflexive-marked token still
--- agrees with an unmarked one (the φ-projection drops it).
-example : Word.Agree ⟨"sich", .PRON, { reflex := true }⟩ ⟨"Kind", .NOUN, {}⟩ := by decide
 
 namespace Binding
 

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -11,7 +11,7 @@ import Linglib.Features.Person.Capabilities
 import Linglib.Features.CoreferenceStatus
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Category.Pronoun.Basic
-import Linglib.Morphology.Word.Basic
+import Linglib.Morphology.Word.Agree
 
 /-!
 # Pronoun capabilities — a mixin tower over pronoun carriers
@@ -28,6 +28,8 @@ object (`Word`), or a future theory representation; each supplies its own instan
 ## Main declarations
 
 * `Proform` — the spine: a carrier exposes a surface `form` and agreement `phi`-features.
+* `Proform.Agree` — carrier-generic φ-agreement, the compatibility filter referent
+  resolution and agreement consumers share; `Word.Agree` is its `Word` specialization.
 * `instance Bound Pronoun` / `Bound PersonalPronoun` — the pronoun carriers' binding-axis
   instances. The `Bound` *class* (with `Anaphoric`/`Pronominal`/`Referring` and the
   `Bound.Is*` element predicates) is theory-neutral and lives beside its partial companion
@@ -77,6 +79,28 @@ instance : Proform Word := ⟨Word.form, Word.phi⟩
 instance : Proform Pronoun := ⟨Pronoun.form, fun p => p.toWord.phi⟩
 instance : Proform PersonalPronoun :=
   ⟨fun p => p.toPronoun.form, fun p => p.toPronoun.toWord.phi⟩
+
+/-! ### φ-agreement over carriers -/
+
+/-- φ-agreement between two pro-form carriers: their `phi`-features unify
+(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard —
+the carrier-generic form of `Word.Agree`. The compatibility filter referent
+resolution and agreement consumers share: a pronoun's φ narrows the candidate
+referents to those it agrees with. -/
+def Proform.Agree {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) : Prop :=
+  (Proform.phi a).compatible (Proform.phi b)
+
+instance {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) :
+    Decidable (Proform.Agree a b) := by
+  unfold Proform.Agree; infer_instance
+
+/-- On word tokens, carrier-generic agreement is `Word.Agree`. -/
+theorem Proform.agree_word (w1 w2 : Word) : Proform.Agree w1 w2 ↔ w1.Agree w2 := Iff.rfl
+
+/-- A pronoun agrees exactly as its projected word does — `Proform.phi` on
+`Pronoun` is projection-then-φ by construction. -/
+theorem Proform.agree_toWord {β : Type*} [Proform β] (p : Pronoun) (b : β) :
+    Proform.Agree p b ↔ Proform.Agree p.toWord b := Iff.rfl
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -14,61 +14,39 @@ import Linglib.Syntax.Category.Pronoun.Basic
 import Linglib.Morphology.Word.Agree
 
 /-!
-# Pronoun capabilities — a mixin tower over pronoun carriers
+# Pronoun capabilities
 
-Pronoun *entries* (`Pronoun`, `PersonalPronoun`, `IndefinitePronoun`, …) are bundled `structure`
-values — many per language, like mathlib's `MonoidHom`. This file gives the *capabilities* a
-carrier `α` can have, as typeclass mixins abstracting over the representation — the
-`MonoidHomClass`/`ContinuousMul`-over-`MonoidHom`/`Mul` relationship, applied to pronouns. A
-consumer (binding engine, agreement module, …) then requires exactly the axes it touches:
-`[Proform α]` for form/φ, `[Bound α]` for the Principle A/B/C role, and so on — composed by
-instance parameters with no `extends`-diamond. The carrier may be a record (`Pronoun`), a syntactic
-object (`Word`), or a future theory representation; each supplies its own instances.
+Typeclass mixins for pronoun-like carriers. A carrier may be a lexical record
+(`Pronoun`, `PersonalPronoun`) or a surface token (`Word`); a consumer requires
+exactly the axes it touches.
 
 ## Main declarations
 
-* `Proform` — the spine: a carrier exposes a surface `form` and agreement `phi`-features.
-* `Proform.Agree` — carrier-generic φ-agreement, the compatibility filter referent
-  resolution and agreement consumers share; `Word.Agree` is its `Word` specialization.
-* `instance Bound Pronoun` / `Bound PersonalPronoun` — the pronoun carriers' binding-axis
-  instances. The `Bound` *class* (with `Anaphoric`/`Pronominal`/`Referring` and the
-  `Bound.Is*` element predicates) is theory-neutral and lives beside its partial companion
-  `Features.BindingSource` in `Features/CoreferenceStatus.lean`.
-* `bindingClassOf_toWord` — the faithfulness certificate: the binding engine's canonical
-  morphology source (`Binding.bindingClassOf`) agrees with the `Bound` mixin on every
-  projected pro-form, so the surface engine and the carrier capability never diverge.
-* `HasNumber`/`HasPerson`/`HasCase`/`HasGender` instances for the pronoun carriers, each
-  with a faithfulness theorem (`numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
-  `genderOf_toWord`) locating exactly what `toWord`'s UD realization preserves or loses.
+* `Proform` — the base capability: a surface `form` and agreement `phi`-features.
+* `Proform.Agree` — carrier-generic φ-agreement; `Word.Agree` is the `Word` case.
+* `Bound`, `HasNumber`, `HasPerson`, `HasCase`, `HasGender` instances for the
+  pronoun carriers.
+* `bindingClassOf_toWord`, `numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
+  `genderOf_toWord` — `Pronoun.toWord` commutes with each axis, up to what UD
+  realization can express: clusivity, minimal/augmented number, and animacy-based
+  gender are lost; case and binding class are preserved.
 
 ## Implementation notes
 
-Capabilities live near their domain (mathlib-style: `ContinuousMul` is in `Topology`, not
-`Algebra`). The word-class-neutral `Indefinite` capability (`[Indefinite α]`, Haspelmath
-function-coverage) therefore lives in `Features/Indefinite.lean`, and the binding axis `Bound`
-lives in `Features/CoreferenceStatus.lean` — neither is pronoun-specific.
-
-Three further axes are deferred, each for a principled reason. *Deficiency*
-([cardinaletti-starke-1999] `Pronoun.Strength`) is *per-series*, not per-element: every carrier's
-strength is carrier-uniform (Italian clitics are all `.clitic`; the Mixtec clitic/nonclitic *fields*
-have fixed strengths), so an `α → Strength` accessor would be constant on every carrier — a
-per-*type* fact, not a per-element capability. It is served by the `Pronoun.strength` field
-(series-level, `none` when not homogeneous) and the `Strength` linear order, not by a class.
-The finer *lexical-kind* axis (personal vs relative vs interrogative vs
-demonstrative) is `Pronoun.pronType` — real UD morphology on the carrier (no invented enum),
-threaded onto the projected word by `toWord`. The *deictic* axis (register, referential
-person) is borne by one carrier only, which carries it as fields
-(`PersonalPronoun.register`/`referentialPerson`); a class over those accessors earns its
-keep when a second carrier bears the axis.
+Word-class-neutral capabilities live with their domains: `Indefinite` in
+`Features/Indefinite.lean`, `Bound` in `Features/CoreferenceStatus.lean`.
+Three axes are fields, not classes: deficiency (`Pronoun.strength`, per-series
+[cardinaletti-starke-1999]), lexical kind (`Pronoun.pronType`, UD morphology),
+and register/referential person (`PersonalPronoun` fields, borne by one
+carrier).
 -/
 
 open Morphology (Word)
 
 /-! ### The spine: `Proform` -/
 
-/-- A pronoun-like carrier exposes a surface `form` and agreement `phi`-features — everything true
-of *every* pronoun, the base every other capability builds over (cf. `Mul`/`Semigroup` as the base
-operation class). -/
+/-- A pronoun-like carrier: a surface `form` and agreement `phi`-features — the
+base the other capabilities build over. -/
 class Proform (α : Type*) where
   /-- Surface form (romanization or orthographic). -/
   form : α → String
@@ -84,9 +62,7 @@ instance : Proform PersonalPronoun :=
 
 /-- φ-agreement between two pro-form carriers: their `phi`-features unify
 (`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard —
-the carrier-generic form of `Word.Agree`. The compatibility filter referent
-resolution and agreement consumers share: a pronoun's φ narrows the candidate
-referents to those it agrees with. -/
+the carrier-generic form of `Word.Agree`. -/
 def Proform.Agree {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) : Prop :=
   (Proform.phi a).compatible (Proform.phi b)
 
@@ -109,13 +85,8 @@ theorem Proform.agree_toWord {β : Type*} [Proform β] (p : Pronoun) (b : β) :
 instance : Bound Pronoun := ⟨fun p => p.bindingClass.getD .pronoun⟩
 instance : Bound PersonalPronoun := ⟨fun p => p.toPronoun.bindingClass.getD .pronoun⟩
 
-/-- The canonical morphology source agrees with the mixin: a pro-form's projected word
-classifies (`Binding.bindingClassOf`, reading `Reflex`/`PronType`/category) exactly as the
-carrier's `Bound` class — `Pronoun.toWord` threads the binding morphology faithfully, so the
-surface engine and the capability never diverge. Two coherence premises, both vacuous for
-every actual entry: the pronoun is not lexically declared an R-expression (its surface
-category `.PRON` would win), and it does not *store* `PronType=Rcp` (reciprocal is derived
-by `toWord` from `bindingClass = .reciprocal`, never stored). -/
+/-- A pronoun's projected word classifies (`Binding.bindingClassOf`) exactly as
+its `Bound` class. -/
 theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpression)
     (hr : p.pronType = some .Rcp → p.bindingClass = some .reciprocal) :
     Binding.bindingClassOf p.toWord = Bound.source p := by
@@ -126,16 +97,12 @@ theorem bindingClassOf_toWord (p : Pronoun) (h : p.bindingClass ≠ some .rExpre
 
 /-! ### The number axis: `HasNumber` instances and faithfulness -/
 
-/-- A pronoun bears its analytical number directly — the carrier field is
-root-`Number`-typed. -/
 instance : HasNumber Pronoun := ⟨fun p => p.number⟩
 
 instance : HasNumber PersonalPronoun := ⟨fun p => numberOf p.toPronoun⟩
 
-/-- Projecting a pronoun to a `Word` realizes its number through UD: the
-round-trip is identity exactly on UD-expressible values — the
-minimal/augmented values are lost to realization (`Number.toUD` is
-partial), the number analogue of `personOf_toWord`'s coarsening. -/
+/-- A pronoun's number survives projection to `Word` exactly on UD-expressible
+values: minimal/augmented are lost (`Number.toUD` is partial). -/
 theorem numberOf_toWord (p : Pronoun) :
     numberOf p.toWord = p.number.bind fun n => n.toUD.bind Number.fromUD := by
   show (p.number.bind Number.toUD).bind Number.fromUD = _
@@ -143,16 +110,11 @@ theorem numberOf_toWord (p : Pronoun) :
 
 /-! ### The person axis: `HasPerson` instances and faithfulness -/
 
-/-- A pronoun bears its analytical person directly — the carrier field is
-root-`Person`-typed, clusivity included (Tagalog *kami* =
-`firstExclusive`). -/
 instance : HasPerson Pronoun := ⟨fun p => p.person⟩
 
 instance : HasPerson PersonalPronoun := ⟨fun p => personOf p.toPronoun⟩
 
-/-- Projecting a pronoun to a `Word` coarsens its person: `Word` carries
-UD realization, which has no clusivity — the mixin makes the loss
-explicit rather than silent. -/
+/-- Projection to `Word` coarsens person: UD realization has no clusivity. -/
 theorem personOf_toWord (p : Pronoun) :
     personOf p.toWord = (personOf p).map Person.coarsen := by
   show (p.person.map Person.toUD).map Person.fromUD = p.person.map Person.coarsen
@@ -160,33 +122,23 @@ theorem personOf_toWord (p : Pronoun) :
 
 /-! ### The case axis: `HasCase` instances and faithfulness -/
 
-/-- A pronoun bears its analytical case directly — the carrier field is
-root-`Case`-typed. -/
 instance : HasCase Pronoun := ⟨fun p => p.case_⟩
 
 instance : HasCase PersonalPronoun := ⟨fun p => caseOf p.toPronoun⟩
 
-/-- Projecting a pronoun to a `Word` realizes its case through UD
-losslessly: `Case.toUD` is currently a bijection, so — unlike person
-(clusivity lost) and number (minimal/augmented lost) — the round-trip is
-the identity. This is the theorem that degrades when an analytical
-refinement splits a UD cell (`Case.fromUD_toUD`). -/
+/-- Projection to `Word` preserves case: `Case.toUD` is a bijection. -/
 theorem caseOf_toWord (p : Pronoun) : caseOf p.toWord = caseOf p := by
   show (p.case_.map Case.toUD).map Case.fromUD = p.case_
   simp [Option.map_map, Function.comp_def, Case.fromUD_toUD]
 
 /-! ### The gender axis: `HasGender` instances and faithfulness -/
 
-/-- A pronoun bears its analytical gender directly — the carrier field is
-root-`Gender`-typed. -/
 instance : HasGender Pronoun := ⟨fun p => p.gender⟩
 
 instance : HasGender PersonalPronoun := ⟨fun p => genderOf p.toPronoun⟩
 
-/-- Projecting a pronoun to a `Word` realizes its gender through UD: the
-round-trip is identity exactly on UD-expressible values — the animacy-based
-labels are lost to realization (`Gender.toUD` is partial), the gender
-analogue of `numberOf_toWord`. -/
+/-- A pronoun's gender survives projection to `Word` exactly on UD-expressible
+values: the animacy-based labels are lost (`Gender.toUD` is partial). -/
 theorem genderOf_toWord (p : Pronoun) :
     genderOf p.toWord = p.gender.bind fun g => g.toUD.map Gender.fromUD := by
   show (p.gender.bind Gender.toUD).map Gender.fromUD = _

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -45,8 +45,8 @@ open Morphology (Word)
 
 /-! ### The spine: `Proform` -/
 
-/-- A pro-form carrier is one that bears a surface `form` and agreement
-`phi`-features — the base the other capabilities build over. -/
+/-- A pro-form is an expression that can substitute for another expression,
+bearing a surface `form` and agreement `phi`-features. -/
 class Proform (α : Type*) where
   /-- Surface form (romanization or orthographic). -/
   form : α → String
@@ -60,7 +60,7 @@ instance : Proform PersonalPronoun :=
 
 /-! ### φ-agreement over carriers -/
 
-/-- Two pro-form carriers agree when their `phi`-features unify
+/-- Two pro-forms agree when their `phi`-features unify
 (`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard.
 This is the carrier-generic form of `Word.Agree`. -/
 def Proform.Agree {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) : Prop :=

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -45,8 +45,8 @@ open Morphology (Word)
 
 /-! ### The spine: `Proform` -/
 
-/-- A pronoun-like carrier: a surface `form` and agreement `phi`-features — the
-base the other capabilities build over. -/
+/-- A pro-form carrier is one that bears a surface `form` and agreement
+`phi`-features — the base the other capabilities build over. -/
 class Proform (α : Type*) where
   /-- Surface form (romanization or orthographic). -/
   form : α → String
@@ -60,9 +60,9 @@ instance : Proform PersonalPronoun :=
 
 /-! ### φ-agreement over carriers -/
 
-/-- φ-agreement between two pro-form carriers: their `phi`-features unify
-(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard —
-the carrier-generic form of `Word.Agree`. -/
+/-- Two pro-form carriers agree when their `phi`-features unify
+(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard.
+This is the carrier-generic form of `Word.Agree`. -/
 def Proform.Agree {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) : Prop :=
   (Proform.phi a).compatible (Proform.phi b)
 
@@ -73,15 +73,14 @@ instance {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) :
 /-- On word tokens, carrier-generic agreement is `Word.Agree`. -/
 theorem Proform.agree_word (w1 w2 : Word) : Proform.Agree w1 w2 ↔ w1.Agree w2 := Iff.rfl
 
-/-- A pronoun agrees exactly as its projected word does — `Proform.phi` on
-`Pronoun` is projection-then-φ by construction. -/
+/-- A pronoun agrees exactly as its projected word does. -/
 theorem Proform.agree_toWord {β : Type*} [Proform β] (p : Pronoun) (b : β) :
     Proform.Agree p b ↔ Proform.Agree p.toWord b := Iff.rfl
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 
-/-- A bare `Pronoun`'s declared class, defaulting an undeclared φ-shell to Principle-B `.pronoun`
-([chomsky-1981]'s elsewhere case for a pro-form). -/
+/-- A bare `Pronoun`'s class is its declared `bindingClass`; an undeclared
+φ-shell defaults to Principle-B `.pronoun` ([chomsky-1981]'s elsewhere case). -/
 instance : Bound Pronoun := ⟨fun p => p.bindingClass.getD .pronoun⟩
 instance : Bound PersonalPronoun := ⟨fun p => p.toPronoun.bindingClass.getD .pronoun⟩
 
@@ -102,7 +101,7 @@ instance : HasNumber Pronoun := ⟨fun p => p.number⟩
 instance : HasNumber PersonalPronoun := ⟨fun p => numberOf p.toPronoun⟩
 
 /-- A pronoun's number survives projection to `Word` exactly on UD-expressible
-values: minimal/augmented are lost (`Number.toUD` is partial). -/
+values; the minimal/augmented values are lost, since `Number.toUD` is partial. -/
 theorem numberOf_toWord (p : Pronoun) :
     numberOf p.toWord = p.number.bind fun n => n.toUD.bind Number.fromUD := by
   show (p.number.bind Number.toUD).bind Number.fromUD = _
@@ -114,7 +113,8 @@ instance : HasPerson Pronoun := ⟨fun p => p.person⟩
 
 instance : HasPerson PersonalPronoun := ⟨fun p => personOf p.toPronoun⟩
 
-/-- Projection to `Word` coarsens person: UD realization has no clusivity. -/
+/-- Projection to `Word` coarsens person, since UD realization has no
+clusivity. -/
 theorem personOf_toWord (p : Pronoun) :
     personOf p.toWord = (personOf p).map Person.coarsen := by
   show (p.person.map Person.toUD).map Person.fromUD = p.person.map Person.coarsen
@@ -126,7 +126,7 @@ instance : HasCase Pronoun := ⟨fun p => p.case_⟩
 
 instance : HasCase PersonalPronoun := ⟨fun p => caseOf p.toPronoun⟩
 
-/-- Projection to `Word` preserves case: `Case.toUD` is a bijection. -/
+/-- Projection to `Word` preserves case, since `Case.toUD` is a bijection. -/
 theorem caseOf_toWord (p : Pronoun) : caseOf p.toWord = caseOf p := by
   show (p.case_.map Case.toUD).map Case.fromUD = p.case_
   simp [Option.map_map, Function.comp_def, Case.fromUD_toUD]
@@ -138,7 +138,7 @@ instance : HasGender Pronoun := ⟨fun p => p.gender⟩
 instance : HasGender PersonalPronoun := ⟨fun p => genderOf p.toPronoun⟩
 
 /-- A pronoun's gender survives projection to `Word` exactly on UD-expressible
-values: the animacy-based labels are lost (`Gender.toUD` is partial). -/
+values; the animacy-based labels are lost, since `Gender.toUD` is partial. -/
 theorem genderOf_toWord (p : Pronoun) :
     genderOf p.toWord = p.gender.bind fun g => g.toUD.map Gender.fromUD := by
   show (p.gender.bind Gender.toUD).map Gender.fromUD = _


### PR DESCRIPTION
Carrier-generic φ-agreement (`Proform.Agree`) as the `Proform` spine's first generic consumer, with `Word.phi`/`Word.Agree` relocated from the binding engine to a new `Morphology/Word/Agree.lean`.

- `KehlerRohde2013`: centering toy re-typed to `Word` referents; the same-gender design premise (*she* φ-ambiguous over Amanda/Brittany) checked against the English Fragment entry rather than stipulated.
- `RosaArnold2017`: `GenderContext` derived from referent φ (`ofReferents`); the K&R stimuli classify `sameGender` under the same derivation.
- `Syntax/Binding/Basic` docstring: three-framework claim scoped to the one `CommandRelation` instance that exists.