### PR TITLE
refactor(Syntax): lawful Proform stand-in; HasPhi → Features/Phi

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -693,6 +693,7 @@ import Linglib.Features.Number.Resolve
 import Linglib.Features.Person.Basic
 import Linglib.Features.Person.Capabilities
 import Linglib.Features.Person.Decomposition
+import Linglib.Features.Phi
 import Linglib.Features.Person.Interp
 import Linglib.Features.Person.PersonCaseConstraint
 import Linglib.Features.Person.Resolve

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -7,8 +7,8 @@ import Linglib.Features.Number.Basic
 [corbett-2000]
 
 The typeclass mixin for carriers that bear grammatical number — the number
-axis of the capability tower over lexical carriers (cf. `Proform` in
-`Syntax/Category/Pronoun/Capabilities.lean`, `Bound` in
+axis of the capability tower over lexical carriers (cf. `HasPhi` in
+`Features/Phi.lean`, `Bound` in
 `Features/CoreferenceStatus.lean`). A consumer (agreement
 checker, resolution, semantics) requires `[HasNumber α]` and works over any
 representation: a UD feature bundle, a `Word`, a `Pronoun`, an agreement

--- a/Linglib/Features/Phi.lean
+++ b/Linglib/Features/Phi.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Data.UD.Basic
+
+/-!
+# The φ-bundle capability
+
+`HasPhi` equips a carrier with its agreement φ-features (person, number,
+gender) as a UD bundle; `HasPhi.Agree` is the induced agreement relation.
+The per-axis analytical capabilities are `HasPerson`/`HasNumber`/`HasGender`;
+`HasPhi` is their UD-realization face, the bundle φ-agreement
+(`UD.MorphFeatures.compatible`) consumes.
+-/
+
+/-- A φ-bearer is an expression that exposes person, number, and gender for
+agreement, as a UD feature bundle. -/
+class HasPhi (α : Type*) where
+  /-- The agreement φ-features (person/number/gender). -/
+  phi : α → UD.MorphFeatures
+
+export HasPhi (phi)
+
+/-- A φ-bundle bears itself. -/
+instance : HasPhi UD.MorphFeatures := ⟨id⟩
+
+/-- Two φ-bearers agree when their features unify
+(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard. -/
+def HasPhi.Agree {α β : Type*} [HasPhi α] [HasPhi β] (a : α) (b : β) : Prop :=
+  (phi a).compatible (phi b)
+
+instance {α β : Type*} [HasPhi α] [HasPhi β] (a : α) (b : β) :
+    Decidable (HasPhi.Agree a b) := by
+  unfold HasPhi.Agree; infer_instance

--- a/Linglib/Fragments/Italian/Pronouns.lean
+++ b/Linglib/Fragments/Italian/Pronouns.lean
@@ -91,7 +91,7 @@ def allPronouns : List PersonalPronoun :=
 
 open Romance.Clitics (CliticEntry CliticCase)
 
-/-! Schema and capability instances (`Proform`/`Bound`/`HasPerson`/
+/-! Schema and capability instances (`HasPhi`/`Bound`/`HasPerson`/
 `HasNumber`/`HasCase`) are the shared Romance clitic schema
 (`Fragments/Romance/Clitics.lean`). -/
 

--- a/Linglib/Fragments/Romance/Clitics.lean
+++ b/Linglib/Fragments/Romance/Clitics.lean
@@ -26,7 +26,7 @@ Romanian contrasts reflexive accusative *se* with reflexive dative *își*,
 so a Romanian instantiation must split the REFL cell (or make the
 projection person-sensitive) rather than reuse this `toCase`.
 
-The clitic is its own bespoke struct — capabilities (`Proform`, `Bound`,
+The clitic is its own bespoke struct — capabilities (`HasPhi`, `Bound`,
 `HasPerson`, `HasNumber`, `HasCase`) abstract over it without merging it
 into `Pronoun` (the `FunLike`-over-many-hom-types pattern). Deficiency is
 deliberately *not* a capability: it is per-series (a whole clitic paradigm
@@ -69,9 +69,9 @@ instance : HasPerson CliticEntry := ⟨fun c => some (Person.fromUD c.person)⟩
     reflexives, neutralizing the contrast, bear `none`. -/
 instance : HasCase CliticEntry := ⟨fun c => c.case_.toCase⟩
 
-/-- A clitic's surface form + φ-features (person/number). -/
-instance : Proform CliticEntry :=
-  ⟨CliticEntry.form, fun c => { person := some c.person, number := some c.number }⟩
+/-- A clitic's φ-features (person/number). -/
+instance : HasPhi CliticEntry :=
+  ⟨fun c => { person := some c.person, number := some c.number }⟩
 
 /-- Binding class from the clitic's paradigm cell: a reflexive clitic is a
     Principle-A anaphor; an accusative/dative object clitic is a

--- a/Linglib/Fragments/Turkish/Anaphors.lean
+++ b/Linglib/Fragments/Turkish/Anaphors.lean
@@ -66,7 +66,7 @@ structure TurkishAnaphor where
 /-! ### Anaphors as `Bound` carriers
 
 The anaphor's binding class is *derived* from its `anaphorType`, and `Anaphoric` records that the
-whole carrier is Principle-A. (`Proform` is not instanced: the struct carries no surface form —
+whole carrier is Principle-A. (`HasPhi` is not instanced: the struct carries no φ-features —
 the forms *birbirleri*/*kendi* live in the entry names, a pre-existing data gap.) -/
 
 /-- Binding class from the anaphor type: reciprocal → reciprocal, reflexive → reflexive. -/

--- a/Linglib/Morphology/Word/Agree.lean
+++ b/Linglib/Morphology/Word/Agree.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Features.Phi
 import Linglib.Morphology.Word.Basic
 
 /-!
@@ -11,7 +12,7 @@ import Linglib.Morphology.Word.Basic
 `Word.phi` projects a word's person, number, and gender. Two words `Agree` when
 these features unify (`UD.MorphFeatures.compatible`), an unspecified feature
 acting as a wildcard; the relation is reflexive and symmetric but not
-transitive. `Proform.Agree` is its carrier-generic form.
+transitive. `HasPhi.Agree` is its generic form.
 -/
 
 namespace Morphology
@@ -21,10 +22,15 @@ def Word.phi (w : Word) : UD.MorphFeatures :=
   { person := w.features.person, number := w.features.number,
     gender := w.features.gender }
 
+instance : HasPhi Word := ⟨Word.phi⟩
+
 /-- Two words agree when their φ-features (person, number, gender) are
     compatible, an unspecified feature acting as a wildcard. This is the
     feature-based agreement check binding and concord consumers share. -/
 def Word.Agree (w1 w2 : Word) : Prop := w1.phi.compatible w2.phi
+
+/-- On word tokens, generic agreement is `Word.Agree`. -/
+theorem Word.hasPhi_agree (w1 w2 : Word) : HasPhi.Agree w1 w2 ↔ w1.Agree w2 := Iff.rfl
 
 instance (w1 w2 : Word) : Decidable (Word.Agree w1 w2) := by
   unfold Word.Agree; infer_instance

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -555,14 +555,14 @@ def masculineFoil : Word :=
 /-- The prompt *She* (the English Fragment entry) is φ-compatible with both
     characters, so gender cannot resolve the reference. -/
 theorem she_ambiguous_over_stimuli :
-    Proform.Agree English.Pronouns.she amanda ∧
-      Proform.Agree English.Pronouns.she brittany := by decide
+    HasPhi.Agree English.Pronouns.she amanda ∧
+      HasPhi.Agree English.Pronouns.she brittany := by decide
 
 /-- Against a mixed-gender pair the φ-filter resolves *she* by itself; the
     same-gender design is what forces the Bayesian competition. -/
 theorem she_resolved_against_masculine :
-    Proform.Agree English.Pronouns.she amanda ∧
-      ¬ Proform.Agree English.Pronouns.she masculineFoil := by decide
+    HasPhi.Agree English.Pronouns.she amanda ∧
+      ¬ HasPhi.Agree English.Pronouns.she masculineFoil := by decide
 
 section CenteringBridge
 

--- a/Linglib/Studies/PatelGroszGrosz2017.lean
+++ b/Linglib/Studies/PatelGroszGrosz2017.lean
@@ -168,7 +168,7 @@ The PER series is the **weak** article (uniqueness); the marked DEM series the *
 (familiarity, `der_er_can_diverge` above) — article-strength is *per-series*, not a per-element slot
 (like deficiency, unlike the demonstrative's deixis). The load-bearing parallel to the demonstrative
 grounding (`Studies/Hanink2021`): there `deixis` filled `Description.demonstrative`'s slot; here the
-`Proform.phi` **gender** supplies the restrictor's presupposition. -/
+`HasPhi.phi` **gender** supplies the restrictor's presupposition. -/
 
 open Semantics.Presupposition.PhiFeatures (femSem)
 

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -114,8 +114,8 @@ theorem lisa_brendan_context :
     Lisa and excludes Brendan, so a pronoun is unambiguous — the condition
     under which pronoun rates rise. -/
 theorem differentGender_phi_resolves :
-    Proform.Agree English.Pronouns.she lisa ∧
-      ¬ Proform.Agree English.Pronouns.she brendan := by decide
+    HasPhi.Agree English.Pronouns.she lisa ∧
+      ¬ HasPhi.Agree English.Pronouns.she brendan := by decide
 
 /-- [kehler-rohde-2013]'s same-gender pair is a `sameGender` context under the
     same derivation — the two studies' design premises are one φ-fact. -/

--- a/Linglib/Syntax/Category/Adjective/Basic.lean
+++ b/Linglib/Syntax/Category/Adjective/Basic.lean
@@ -26,7 +26,7 @@ This file deliberately does not depend on the Degree/Kennedy semantics.
 * Dixon `PCClass` view (`ScalarDimension.pcClass`) — waits on wiring to
   `Verb.Root.PCClass` (in `Semantics/ArgumentStructure/Root/Classification.lean`).
 * The `Modifier`/`Gradable` capability classes — built at the second-carrier trigger
-  (an `Adverb`/degree-word struct), exactly as `Pronoun` deferred `Proform`.
+  (an `Adverb`/degree-word struct), exactly as `Pronoun` defers its deictic axis.
 
 This is the adjectival realization of a property concept; when a verb- or
 noun-strategy fragment lands, factor a `PropertyConcept` superclass.

--- a/Linglib/Syntax/Category/Particle/Capabilities.lean
+++ b/Linglib/Syntax/Category/Particle/Capabilities.lean
@@ -5,7 +5,7 @@ import Linglib.Syntax.Category.Particle.Basic
 
 This file defines `Distributed α Ctx`: a carrier `α` with a recorded
 three-valued distribution over licensing contexts `Ctx`, the
-`Proform`-style capability behind `Particle`'s embedding facet
+`HasPhi`-style capability behind `Particle`'s embedding facet
 (instance for `Clause.EmbeddingContext`; `Studies/Stankova2026` adds a
 negation-position axis). The clause-type facet is projection-keyed
 (`ClauseDistribution` fields), so it has no context type to

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -24,8 +24,8 @@ exactly the axes it touches.
 ## Main declarations
 
 * `Proform` — a pro-form stands in for members of a form-class, its domain
-  ([bloomfield-1933]); standing in requires φ-agreement (`HasPhi.Agree`, from
-  `Features/Phi.lean`).
+  ([bloomfield-1933]); `Proform.StandsInFor` is derived — domain membership
+  plus φ-agreement (`HasPhi.Agree`, from `Features/Phi.lean`).
 * `Bound`, `HasNumber`, `HasPerson`, `HasCase`, `HasGender` instances for the
   pronoun carriers.
 * `bindingClassOf_toWord`, `numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
@@ -59,28 +59,33 @@ theorem HasPhi.agree_toWord {β : Type*} [HasPhi β] (p : Pronoun) (b : β) :
     HasPhi.Agree p b ↔ HasPhi.Agree p.toWord b := Iff.rfl
 
 /-- A pro-form is an expression that stands in for members of a form-class —
-its *domain* ([bloomfield-1933]) — under φ-agreement. -/
-class Proform (α : Type*) [HasPhi α] where
-  /-- `a` can substitute for the token `w`. -/
-  StandsInFor : α → Word → Prop
-  /-- Standing in requires φ-agreement. -/
-  agree_of_standsInFor : ∀ a w, StandsInFor a w → HasPhi.Agree a w
+its *domain* ([bloomfield-1933]). -/
+class Proform (α : Type*) where
+  /-- `w` is in the form-class `a` replaces. -/
+  Domain : α → Word → Prop
 
-/-- A pronoun's domain is the nominal tokens; it stands in for those it
-φ-agrees with. -/
-instance : Proform Pronoun where
-  StandsInFor p w := Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w
-  agree_of_standsInFor _ _ h := h.2
+/-- A pro-form stands in for the domain members it φ-agrees with. -/
+def Proform.StandsInFor {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word) : Prop :=
+  Proform.Domain a w ∧ HasPhi.Agree a w
 
-instance : Proform PersonalPronoun where
-  StandsInFor p w := Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w
-  agree_of_standsInFor _ _ h := h.2
+/-- Standing in requires φ-agreement. -/
+theorem Proform.agree_of_standsInFor {α : Type*} [Proform α] [HasPhi α] {a : α}
+    {w : Word} (h : StandsInFor a w) : HasPhi.Agree a w := h.2
 
-instance (p : Pronoun) (w : Word) : Decidable (Proform.StandsInFor p w) :=
-  inferInstanceAs (Decidable (Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w))
+/-- A pronoun's domain is the nominal tokens. -/
+instance : Proform Pronoun := ⟨fun _ w => Binding.isNominalCat w.cat = true⟩
 
-instance (p : PersonalPronoun) (w : Word) : Decidable (Proform.StandsInFor p w) :=
-  inferInstanceAs (Decidable (Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w))
+instance : Proform PersonalPronoun := ⟨fun _ w => Binding.isNominalCat w.cat = true⟩
+
+instance (p : Pronoun) (w : Word) : Decidable (Proform.Domain p w) :=
+  inferInstanceAs (Decidable (_ = true))
+
+instance (p : PersonalPronoun) (w : Word) : Decidable (Proform.Domain p w) :=
+  inferInstanceAs (Decidable (_ = true))
+
+instance {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word)
+    [Decidable (Proform.Domain a w)] : Decidable (Proform.StandsInFor a w) := by
+  unfold Proform.StandsInFor; infer_instance
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Data.UD.Basic
+import Linglib.Features.Phi
 import Linglib.Features.Case.Capabilities
 import Linglib.Features.Gender.Capabilities
 import Linglib.Features.Number.Capabilities
@@ -22,8 +23,9 @@ exactly the axes it touches.
 
 ## Main declarations
 
-* `Proform` — the base capability: a surface `form` and agreement `phi`-features.
-* `Proform.Agree` — carrier-generic φ-agreement; `Word.Agree` is the `Word` case.
+* `Proform` — a pro-form stands in for members of a form-class, its domain
+  ([bloomfield-1933]); standing in requires φ-agreement (`HasPhi.Agree`, from
+  `Features/Phi.lean`).
 * `Bound`, `HasNumber`, `HasPerson`, `HasCase`, `HasGender` instances for the
   pronoun carriers.
 * `bindingClassOf_toWord`, `numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
@@ -39,43 +41,46 @@ Three axes are fields, not classes: deficiency (`Pronoun.strength`, per-series
 [cardinaletti-starke-1999]), lexical kind (`Pronoun.pronType`, UD morphology),
 and register/referential person (`PersonalPronoun` fields, borne by one
 carrier).
+
+`Proform.StandsInFor` is token-level: whether a stand-in site is a bare
+element or hosts deleted structure ([hankamer-sag-1976]; [baltin-2012]) is a
+theory question for study files.
 -/
 
 open Morphology (Word)
 
-/-! ### The spine: `Proform` -/
+/-! ### φ instances and the pro-form -/
 
-/-- A pro-form is an expression that can substitute for another expression,
-bearing a surface `form` and agreement `phi`-features. -/
-class Proform (α : Type*) where
-  /-- Surface form (romanization or orthographic). -/
-  form : α → String
-  /-- Agreement φ-features (person/number/gender). -/
-  phi : α → UD.MorphFeatures
-
-instance : Proform Word := ⟨Word.form, Word.phi⟩
-instance : Proform Pronoun := ⟨Pronoun.form, fun p => p.toWord.phi⟩
-instance : Proform PersonalPronoun :=
-  ⟨fun p => p.toPronoun.form, fun p => p.toPronoun.toWord.phi⟩
-
-/-! ### φ-agreement over carriers -/
-
-/-- Two pro-forms agree when their `phi`-features unify
-(`UD.MorphFeatures.compatible`), an unspecified feature acting as a wildcard.
-This is the carrier-generic form of `Word.Agree`. -/
-def Proform.Agree {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) : Prop :=
-  (Proform.phi a).compatible (Proform.phi b)
-
-instance {α β : Type*} [Proform α] [Proform β] (a : α) (b : β) :
-    Decidable (Proform.Agree a b) := by
-  unfold Proform.Agree; infer_instance
-
-/-- On word tokens, carrier-generic agreement is `Word.Agree`. -/
-theorem Proform.agree_word (w1 w2 : Word) : Proform.Agree w1 w2 ↔ w1.Agree w2 := Iff.rfl
+instance : HasPhi Pronoun := ⟨fun p => p.toWord.phi⟩
+instance : HasPhi PersonalPronoun := ⟨fun p => p.toPronoun.toWord.phi⟩
 
 /-- A pronoun agrees exactly as its projected word does. -/
-theorem Proform.agree_toWord {β : Type*} [Proform β] (p : Pronoun) (b : β) :
-    Proform.Agree p b ↔ Proform.Agree p.toWord b := Iff.rfl
+theorem HasPhi.agree_toWord {β : Type*} [HasPhi β] (p : Pronoun) (b : β) :
+    HasPhi.Agree p b ↔ HasPhi.Agree p.toWord b := Iff.rfl
+
+/-- A pro-form is an expression that stands in for members of a form-class —
+its *domain* ([bloomfield-1933]) — under φ-agreement. -/
+class Proform (α : Type*) [HasPhi α] where
+  /-- `a` can substitute for the token `w`. -/
+  StandsInFor : α → Word → Prop
+  /-- Standing in requires φ-agreement. -/
+  agree_of_standsInFor : ∀ a w, StandsInFor a w → HasPhi.Agree a w
+
+/-- A pronoun's domain is the nominal tokens; it stands in for those it
+φ-agrees with. -/
+instance : Proform Pronoun where
+  StandsInFor p w := Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w
+  agree_of_standsInFor _ _ h := h.2
+
+instance : Proform PersonalPronoun where
+  StandsInFor p w := Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w
+  agree_of_standsInFor _ _ h := h.2
+
+instance (p : Pronoun) (w : Word) : Decidable (Proform.StandsInFor p w) :=
+  inferInstanceAs (Decidable (Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w))
+
+instance (p : PersonalPronoun) (w : Word) : Decidable (Proform.StandsInFor p w) :=
+  inferInstanceAs (Decidable (Binding.isNominalCat w.cat = true ∧ HasPhi.Agree p w))
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -23,8 +23,8 @@ exactly the axes it touches.
 
 ## Main declarations
 
-* `Proform` — a pro-form stands in for members of a form-class, its domain
-  ([bloomfield-1933]); `Proform.StandsInFor` is derived — domain membership
+* `Proform` — a pro-form substitutes for members of a form-class, its domain
+  ([bloomfield-1933]); `Proform.SubstitutesFor` is derived — domain membership
   plus φ-agreement (`HasPhi.Agree`, from `Features/Phi.lean`).
 * `Bound`, `HasNumber`, `HasPerson`, `HasCase`, `HasGender` instances for the
   pronoun carriers.
@@ -42,7 +42,7 @@ Three axes are fields, not classes: deficiency (`Pronoun.strength`, per-series
 and register/referential person (`PersonalPronoun` fields, borne by one
 carrier).
 
-`Proform.StandsInFor` is token-level: whether a stand-in site is a bare
+`Proform.SubstitutesFor` is token-level: whether a substitution site is a bare
 element or hosts deleted structure ([hankamer-sag-1976]; [baltin-2012]) is a
 theory question for study files.
 -/
@@ -58,19 +58,19 @@ instance : HasPhi PersonalPronoun := ⟨fun p => p.toPronoun.toWord.phi⟩
 theorem HasPhi.agree_toWord {β : Type*} [HasPhi β] (p : Pronoun) (b : β) :
     HasPhi.Agree p b ↔ HasPhi.Agree p.toWord b := Iff.rfl
 
-/-- A pro-form is an expression that stands in for members of a form-class —
+/-- A pro-form is an expression that substitutes for members of a form-class —
 its *domain* ([bloomfield-1933]). -/
 class Proform (α : Type*) where
   /-- `w` is in the form-class `a` replaces. -/
   Domain : α → Word → Prop
 
-/-- A pro-form stands in for the domain members it φ-agrees with. -/
-def Proform.StandsInFor {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word) : Prop :=
+/-- A pro-form substitutes for the domain members it φ-agrees with. -/
+def Proform.SubstitutesFor {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word) : Prop :=
   Proform.Domain a w ∧ HasPhi.Agree a w
 
-/-- Standing in requires φ-agreement. -/
-theorem Proform.agree_of_standsInFor {α : Type*} [Proform α] [HasPhi α] {a : α}
-    {w : Word} (h : StandsInFor a w) : HasPhi.Agree a w := h.2
+/-- Substitution requires φ-agreement. -/
+theorem Proform.agree_of_substitutesFor {α : Type*} [Proform α] [HasPhi α] {a : α}
+    {w : Word} (h : SubstitutesFor a w) : HasPhi.Agree a w := h.2
 
 /-- A pronoun's domain is the nominal tokens. -/
 instance : Proform Pronoun := ⟨fun _ w => Binding.isNominalCat w.cat = true⟩
@@ -84,8 +84,8 @@ instance (p : PersonalPronoun) (w : Word) : Decidable (Proform.Domain p w) :=
   inferInstanceAs (Decidable (_ = true))
 
 instance {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word)
-    [Decidable (Proform.Domain a w)] : Decidable (Proform.StandsInFor a w) := by
-  unfold Proform.StandsInFor; infer_instance
+    [Decidable (Proform.Domain a w)] : Decidable (Proform.SubstitutesFor a w) := by
+  unfold Proform.SubstitutesFor; infer_instance
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 

--- a/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
+++ b/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
@@ -27,7 +27,7 @@ assignment keeps them apart by construction.
 
 * `DemonstrativePronoun` — the deictic demonstrative pronoun (`extends Pronoun` + `deixis`).
 * `instance : Demonstrative DemonstrativePronoun` — its deictic-contrast capability.
-* `Proform` / `Bound` instances routing it through the Pronoun API.
+* `HasPhi` / `Bound` instances routing it through the Pronoun API.
 -/
 
 set_option autoImplicit false
@@ -43,9 +43,8 @@ structure DemonstrativePronoun extends Pronoun where
   deixis : Features.Deixis.Feature
   deriving Repr, DecidableEq
 
-/-- A demonstrative pronoun is a `Proform` (form + φ via its `Pronoun` core). -/
-instance : Proform DemonstrativePronoun :=
-  ⟨fun d => d.toPronoun.form, fun d => d.toPronoun.toWord.phi⟩
+/-- A demonstrative pronoun bears φ via its `Pronoun` core. -/
+instance : HasPhi DemonstrativePronoun := ⟨fun d => d.toPronoun.toWord.phi⟩
 
 /-- Its binding class is the `Pronoun` core's, defaulting an undeclared shell to `.pronoun`. -/
 instance : Bound DemonstrativePronoun :=

--- a/Linglib/Syntax/Category/Pronoun/Indefinite.lean
+++ b/Linglib/Syntax/Category/Pronoun/Indefinite.lean
@@ -26,7 +26,7 @@ bridge, syncretism) are typological and live in `Typology/Indefinite.lean`.
 
 * `Indefinite.IndefinitePronoun` — the lexical object (`extends Pronoun`).
 * `instance : Indefinite Indefinite.IndefinitePronoun` — the pronoun carrier of the series.
-* `Proform` / `Bound` instances routing the object through the Pronoun API.
+* `HasPhi` / `Bound` instances routing the object through the Pronoun API.
 -/
 
 set_option autoImplicit false
@@ -79,9 +79,8 @@ end Indefinite
 
 /-! ### Capability instances -/
 
-/-- The indefinite pronoun is a `Proform` (form + φ via its `Pronoun` core). -/
-instance : Proform Indefinite.IndefinitePronoun :=
-  ⟨fun e => e.toPronoun.form, fun e => e.toPronoun.toWord.phi⟩
+/-- An indefinite pronoun bears φ via its `Pronoun` core. -/
+instance : HasPhi Indefinite.IndefinitePronoun := ⟨fun e => e.toPronoun.toWord.phi⟩
 
 /-- An indefinite pronoun is a Principle-B pronominal (its `Pronoun` core's class,
     defaulting an undeclared φ-shell to `.pronoun`). -/

--- a/Linglib/Syntax/Category/Pronoun/Logophoric.lean
+++ b/Linglib/Syntax/Category/Pronoun/Logophoric.lean
@@ -31,7 +31,7 @@ concrete by carrying both axes on one object (`zibun_anaphor_yet_pivot_oriented`
 
 * `LogophoricPronoun` — the lexical object (`extends Pronoun` + `requiredRole`).
 * `instance : Logophoric LogophoricPronoun` — the pronoun carrier of the series.
-* `Proform` / `Bound` instances routing the object through the Pronoun API.
+* `HasPhi` / `Bound` instances routing the object through the Pronoun API.
 * `ye`, `zibun` — worked [sells-1987] entries; licensing derived from the hierarchy.
 -/
 
@@ -49,9 +49,8 @@ structure LogophoricPronoun extends Pronoun where
   requiredRole : LogophoricRole
   deriving Repr, DecidableEq
 
-/-- A logophoric pronoun is a `Proform` (form + φ via its `Pronoun` core). -/
-instance : Proform LogophoricPronoun :=
-  ⟨fun p => p.toPronoun.form, fun p => p.toPronoun.toWord.phi⟩
+/-- A logophoric pronoun bears φ via its `Pronoun` core. -/
+instance : HasPhi LogophoricPronoun := ⟨fun p => p.toPronoun.toWord.phi⟩
 
 /-- Its binding class is the `Pronoun` core's, defaulting an undeclared shell to `.pronoun` —
     independent of its logophoric orientation. -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -24736,6 +24736,19 @@
   validated = {true},
   role      = {cited},
   sources   = {Studies/Landau2026.lean}
+}% REF: Baltin, M. (2012). Deletion versus pro-forms: an overly simple dichotomy? Natural Language & Linguistic Theory 30, 381-423.
+@article{baltin-2012,
+  author    = {Baltin, Mark},
+  year      = {2012},
+  title     = {Deletion versus Pro-Forms: An Overly Simple Dichotomy?},
+  journal   = {Natural Language \& Linguistic Theory},
+  volume    = {30},
+  pages     = {381--423},
+  doi       = {10.1007/s11049-011-9157-x},
+  subfield  = {syntax},
+  validated = {true},
+  role      = {cited},
+  sources   = {Syntax/Category/Pronoun/Capabilities.lean}
 }% REF: Chomsky, N. (1982). Some Concepts and Consequences of the Theory of Government and Binding.
 @book{chomsky-1982,
   author    = {Chomsky, Noam},


### PR DESCRIPTION
`Proform Word` claimed every token is a pro-form. The φ side splits out as `HasPhi` (`Features/Phi.lean`, the φ-inventory scheme's bundle class); `Proform` carries only its one datum — the `Domain` form-class a pro-form takes antecedents from (the notion originates with [bloomfield-1933]) — and `Proform.CandidateAntecedent` is derived: domain membership plus φ-agreement, in the pronoun-resolution literature's own vocabulary, with the agreement law a theorem rather than a field.

- `HasPhi Word` + `Word.hasPhi_agree` live in `Morphology/Word/Agree.lean`; the pronoun-family carriers instance `HasPhi`; the discourse studies use `HasPhi.Agree`.
- The deletion-vs-pro-form structure question stays study-level ([hankamer-sag-1976]; [baltin-2012] — new bib entry, DOI verified against the publisher PDF).