### PR TITLE
feat(Syntax/Category/Pronoun): CandidateAntecedent consumers

### DIFF
--- a/Linglib/Fragments/Romance/Clitics.lean
+++ b/Linglib/Fragments/Romance/Clitics.lean
@@ -26,8 +26,8 @@ Romanian contrasts reflexive accusative *se* with reflexive dative *își*,
 so a Romanian instantiation must split the REFL cell (or make the
 projection person-sensitive) rather than reuse this `toCase`.
 
-The clitic is its own bespoke struct — capabilities (`HasPhi`, `Bound`,
-`HasPerson`, `HasNumber`, `HasCase`) abstract over it without merging it
+The clitic is its own bespoke struct — capabilities (`HasPhi`, `Proform`,
+`Bound`, `HasPerson`, `HasNumber`, `HasCase`) abstract over it without merging it
 into `Pronoun` (the `FunLike`-over-many-hom-types pattern). Deficiency is
 deliberately *not* a capability: it is per-series (a whole clitic paradigm
 is `.clitic`), modelled by the per-language `cliticStrength` and the
@@ -72,6 +72,9 @@ instance : HasCase CliticEntry := ⟨fun c => c.case_.toCase⟩
 /-- A clitic's φ-features (person/number). -/
 instance : HasPhi CliticEntry :=
   ⟨fun c => { person := some c.person, number := some c.number }⟩
+
+/-- An object clitic's domain is the nominal tokens. -/
+instance : Proform CliticEntry := ⟨fun _ w => Binding.isNominalCat w.cat = true⟩
 
 /-- Binding class from the clitic's paradigm cell: a reflexive clitic is a
     Principle-A anaphor; an accusative/dative object clitic is a

--- a/Linglib/Studies/KehlerRohde2013.lean
+++ b/Linglib/Studies/KehlerRohde2013.lean
@@ -32,9 +32,10 @@ experiments with transfer-of-possession and implicit-causality verbs.
   expectancy hypothesis the substrate's `predictedForm` encodes.
 * `cb_topichood_dissociation_under_voice`: Centering's backward-looking center is
   voice-blind where `topichood` is voice-sensitive.
-* `she_ambiguous_over_stimuli`: the φ-design premise — the prompt pronoun
-  (the English Fragment entry) φ-agrees with both same-gender characters, so
-  the φ-filter cannot resolve the reference the Bayesian model competes over.
+* `she_ambiguous_over_stimuli`: the φ-design premise — both same-gender
+  characters are candidate antecedents (`Proform.CandidateAntecedent`) of the
+  prompt pronoun, so the φ-filter cannot resolve the reference the Bayesian
+  model competes over.
 
 ## Implementation notes
 
@@ -552,17 +553,17 @@ def brittany : Word :=
 def masculineFoil : Word :=
   ⟨"Bill", .PROPN, { person := some .third, number := some .Sing, gender := some .Masc }⟩
 
-/-- The prompt *She* (the English Fragment entry) is φ-compatible with both
-    characters, so gender cannot resolve the reference. -/
+/-- Both characters are candidate antecedents for the prompt *She* (the
+    English Fragment entry), so the φ-filter cannot resolve the reference. -/
 theorem she_ambiguous_over_stimuli :
-    HasPhi.Agree English.Pronouns.she amanda ∧
-      HasPhi.Agree English.Pronouns.she brittany := by decide
+    Proform.CandidateAntecedent English.Pronouns.she amanda ∧
+      Proform.CandidateAntecedent English.Pronouns.she brittany := by decide
 
-/-- Against a mixed-gender pair the φ-filter resolves *she* by itself; the
+/-- Against a mixed-gender pair the candidate set is a singleton; the
     same-gender design is what forces the Bayesian competition. -/
 theorem she_resolved_against_masculine :
-    HasPhi.Agree English.Pronouns.she amanda ∧
-      ¬ HasPhi.Agree English.Pronouns.she masculineFoil := by decide
+    Proform.CandidateAntecedent English.Pronouns.she amanda ∧
+      ¬ Proform.CandidateAntecedent English.Pronouns.she masculineFoil := by decide
 
 section CenteringBridge
 

--- a/Linglib/Studies/RosaArnold2017.lean
+++ b/Linglib/Studies/RosaArnold2017.lean
@@ -110,12 +110,12 @@ def brendan : Morphology.Word :=
 theorem lisa_brendan_context :
     GenderContext.ofReferents lisa brendan = .differentGender := by decide
 
-/-- In a `differentGender` pair *she* (the English Fragment entry) picks out
-    Lisa and excludes Brendan, so a pronoun is unambiguous — the condition
+/-- In a `differentGender` pair *she* (the English Fragment entry) has Lisa as
+    its sole candidate antecedent, so a pronoun is unambiguous — the condition
     under which pronoun rates rise. -/
 theorem differentGender_phi_resolves :
-    HasPhi.Agree English.Pronouns.she lisa ∧
-      ¬ HasPhi.Agree English.Pronouns.she brendan := by decide
+    Proform.CandidateAntecedent English.Pronouns.she lisa ∧
+      ¬ Proform.CandidateAntecedent English.Pronouns.she brendan := by decide
 
 /-- [kehler-rohde-2013]'s same-gender pair is a `sameGender` context under the
     same derivation — the two studies' design premises are one φ-fact. -/

--- a/Linglib/Syntax/Category/Pronoun/Capabilities.lean
+++ b/Linglib/Syntax/Category/Pronoun/Capabilities.lean
@@ -23,9 +23,9 @@ exactly the axes it touches.
 
 ## Main declarations
 
-* `Proform` — a pro-form substitutes for members of a form-class, its domain
-  ([bloomfield-1933]); `Proform.SubstitutesFor` is derived — domain membership
-  plus φ-agreement (`HasPhi.Agree`, from `Features/Phi.lean`).
+* `Proform` — a pro-form takes its antecedents from a fixed form-class, its
+  domain ([bloomfield-1933]); `Proform.CandidateAntecedent` is derived — domain
+  membership plus φ-agreement (`HasPhi.Agree`, from `Features/Phi.lean`).
 * `Bound`, `HasNumber`, `HasPerson`, `HasCase`, `HasGender` instances for the
   pronoun carriers.
 * `bindingClassOf_toWord`, `numberOf_toWord`, `personOf_toWord`, `caseOf_toWord`,
@@ -42,9 +42,9 @@ Three axes are fields, not classes: deficiency (`Pronoun.strength`, per-series
 and register/referential person (`PersonalPronoun` fields, borne by one
 carrier).
 
-`Proform.SubstitutesFor` is token-level: whether a substitution site is a bare
-element or hosts deleted structure ([hankamer-sag-1976]; [baltin-2012]) is a
-theory question for study files.
+`Proform.CandidateAntecedent` is token-level: whether an anaphoric site is a
+bare pro-form or hosts deleted structure ([hankamer-sag-1976]; [baltin-2012])
+is a theory question for study files.
 -/
 
 open Morphology (Word)
@@ -58,19 +58,21 @@ instance : HasPhi PersonalPronoun := ⟨fun p => p.toPronoun.toWord.phi⟩
 theorem HasPhi.agree_toWord {β : Type*} [HasPhi β] (p : Pronoun) (b : β) :
     HasPhi.Agree p b ↔ HasPhi.Agree p.toWord b := Iff.rfl
 
-/-- A pro-form is an expression that substitutes for members of a form-class —
-its *domain* ([bloomfield-1933]). -/
+/-- A pro-form takes its antecedents from a fixed form-class — its *domain*
+(the notion originates with [bloomfield-1933]'s substitutes). -/
 class Proform (α : Type*) where
-  /-- `w` is in the form-class `a` replaces. -/
+  /-- `w` is in the form-class `a` stands for. -/
   Domain : α → Word → Prop
 
-/-- A pro-form substitutes for the domain members it φ-agrees with. -/
-def Proform.SubstitutesFor {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word) : Prop :=
+/-- A candidate antecedent for a pro-form is a domain member that φ-agrees
+with it. -/
+def Proform.CandidateAntecedent {α : Type*} [Proform α] [HasPhi α]
+    (a : α) (w : Word) : Prop :=
   Proform.Domain a w ∧ HasPhi.Agree a w
 
-/-- Substitution requires φ-agreement. -/
-theorem Proform.agree_of_substitutesFor {α : Type*} [Proform α] [HasPhi α] {a : α}
-    {w : Word} (h : SubstitutesFor a w) : HasPhi.Agree a w := h.2
+/-- A candidate antecedent φ-agrees with its pro-form. -/
+theorem Proform.CandidateAntecedent.agree {α : Type*} [Proform α] [HasPhi α] {a : α}
+    {w : Word} (h : CandidateAntecedent a w) : HasPhi.Agree a w := h.2
 
 /-- A pronoun's domain is the nominal tokens. -/
 instance : Proform Pronoun := ⟨fun _ w => Binding.isNominalCat w.cat = true⟩
@@ -84,8 +86,8 @@ instance (p : PersonalPronoun) (w : Word) : Decidable (Proform.Domain p w) :=
   inferInstanceAs (Decidable (_ = true))
 
 instance {α : Type*} [Proform α] [HasPhi α] (a : α) (w : Word)
-    [Decidable (Proform.Domain a w)] : Decidable (Proform.SubstitutesFor a w) := by
-  unfold Proform.SubstitutesFor; infer_instance
+    [Decidable (Proform.Domain a w)] : Decidable (Proform.CandidateAntecedent a w) := by
+  unfold Proform.CandidateAntecedent; infer_instance
 
 /-! ### The pronoun carriers' `Bound` instances, and the faithfulness certificate -/
 

--- a/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
+++ b/Linglib/Syntax/Category/Pronoun/Demonstrative.lean
@@ -27,7 +27,7 @@ assignment keeps them apart by construction.
 
 * `DemonstrativePronoun` — the deictic demonstrative pronoun (`extends Pronoun` + `deixis`).
 * `instance : Demonstrative DemonstrativePronoun` — its deictic-contrast capability.
-* `HasPhi` / `Bound` instances routing it through the Pronoun API.
+* `HasPhi` / `Proform` / `Bound` instances routing it through the Pronoun API.
 -/
 
 set_option autoImplicit false
@@ -45,6 +45,8 @@ structure DemonstrativePronoun extends Pronoun where
 
 /-- A demonstrative pronoun bears φ via its `Pronoun` core. -/
 instance : HasPhi DemonstrativePronoun := ⟨fun d => d.toPronoun.toWord.phi⟩
+
+instance : Proform DemonstrativePronoun := ⟨fun d => Proform.Domain d.toPronoun⟩
 
 /-- Its binding class is the `Pronoun` core's, defaulting an undeclared shell to `.pronoun`. -/
 instance : Bound DemonstrativePronoun :=

--- a/Linglib/Syntax/Category/Pronoun/Indefinite.lean
+++ b/Linglib/Syntax/Category/Pronoun/Indefinite.lean
@@ -26,7 +26,7 @@ bridge, syncretism) are typological and live in `Typology/Indefinite.lean`.
 
 * `Indefinite.IndefinitePronoun` — the lexical object (`extends Pronoun`).
 * `instance : Indefinite Indefinite.IndefinitePronoun` — the pronoun carrier of the series.
-* `HasPhi` / `Bound` instances routing the object through the Pronoun API.
+* `HasPhi` / `Proform` / `Bound` instances routing the object through the Pronoun API.
 -/
 
 set_option autoImplicit false
@@ -81,6 +81,8 @@ end Indefinite
 
 /-- An indefinite pronoun bears φ via its `Pronoun` core. -/
 instance : HasPhi Indefinite.IndefinitePronoun := ⟨fun e => e.toPronoun.toWord.phi⟩
+
+instance : Proform Indefinite.IndefinitePronoun := ⟨fun e => Proform.Domain e.toPronoun⟩
 
 /-- An indefinite pronoun is a Principle-B pronominal (its `Pronoun` core's class,
     defaulting an undeclared φ-shell to `.pronoun`). -/

--- a/Linglib/Syntax/Category/Pronoun/Logophoric.lean
+++ b/Linglib/Syntax/Category/Pronoun/Logophoric.lean
@@ -31,7 +31,7 @@ concrete by carrying both axes on one object (`zibun_anaphor_yet_pivot_oriented`
 
 * `LogophoricPronoun` — the lexical object (`extends Pronoun` + `requiredRole`).
 * `instance : Logophoric LogophoricPronoun` — the pronoun carrier of the series.
-* `HasPhi` / `Bound` instances routing the object through the Pronoun API.
+* `HasPhi` / `Proform` / `Bound` instances routing the object through the Pronoun API.
 * `ye`, `zibun` — worked [sells-1987] entries; licensing derived from the hierarchy.
 -/
 
@@ -51,6 +51,8 @@ structure LogophoricPronoun extends Pronoun where
 
 /-- A logophoric pronoun bears φ via its `Pronoun` core. -/
 instance : HasPhi LogophoricPronoun := ⟨fun p => p.toPronoun.toWord.phi⟩
+
+instance : Proform LogophoricPronoun := ⟨fun p => Proform.Domain p.toPronoun⟩
 
 /-- Its binding class is the `Pronoun` core's, defaulting an undeclared shell to `.pronoun` —
     independent of its logophoric orientation. -/


### PR DESCRIPTION
Renames `Proform.SubstitutesFor` → `Proform.CandidateAntecedent` (the resolution literature's term; the rename commit missed #1907's automerge) and wires its consumers: the KehlerRohde2013/RosaArnold2017 design-premise theorems restate in candidate-antecedent form, and the sibling pro-form carriers (demonstrative, indefinite, logophoric, Romance clitics) get `Proform` instances routed through their `Pronoun` cores.