### PR TITLE
refactor(Studies/Angelopoulos2026): wire examples, derive stativity

### DIFF
--- a/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Complementizers.lean
@@ -192,4 +192,16 @@ def thimonoStat : Verb where
   attitude := some (.preferential (.degreeComparison .negative))
   vendlerClass := some .state
 
+/-! ### Occurrence verbs -/
+
+/-- *simvéni* (συμβαίνει) 'happen/occur' — unaccusative achievement,
+    the [angelopoulos-2026] ex. 34 diagnostic. Rejects both *oti*- and
+    *pu*-complements and takes subjunctive *na*-clauses
+    ([angelopoulos-2026] fn. 14). -/
+def simveni : Verb where
+  form := "simvéni"
+  frames := [[.clausal (coding := some .subjunctive)]]
+  vendlerClass := some .achievement
+  unaccusative := true
+
 end Greek.StandardModern.Complementizers

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -25,8 +25,7 @@ derives the argument asymmetry and the P-ban (§3.1 ex. 27–32). The
 (§3.2, adopting [bondarenko-2022]); the stativity restriction from
 aspectual-head selection (§4.1: vState selects both otiP and puP,
 vEvent only otiP). §7.1 extends the adjunct-selection account to
-Uyghur *dep* (= *de* 'say' + converb *-ip*, per Major 2024) — the
-structural parallel of Buryat *gɘ-žɘ*.
+Uyghur *dep* (= *de* 'say' + converb *-ip*, per Major 2024).
 
 §7.3 departs from [bondarenko-2022]'s transparent syntax–semantics
 mapping: bare *oti*-clauses are merged in COMPLEMENT position (the §2
@@ -37,13 +36,17 @@ yields either composition mode.
 
 ## Main declarations
 
-- `bearsN` — the §3.1 [n]-feature datum over the fragment entries
+- `bearsN`, `bearsN_iff_sorted` — the §3.1 [n]-feature datum and its
+  alignment with the content/situation sorts
 - `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`, `factivity_anti_aligned` —
   the attested selection classes (§1–§2.3) and the emotive/cognitive
   factivity split they carry
-- `NounHost`, `ClausePosition`, `licensedIn` — the incorporation
-  mechanism and the derived argument-position asymmetry
-- `selectsClause`, `pu_requires_stative` — the §4.1 stativity locus
+- `NounHost`, `ClausePosition`, `licensedIn`, `licensing_matches_judgments`
+  — the incorporation mechanism, the derived argument-position asymmetry,
+  and its check against the ex. 31–32 judgments
+- `selectsClause`, `AspectualHead.ofVendler`, `pu_complement_verb_stative`
+  — the §4.1 stativity locus and the derived §2.3 verb-level
+  generalization
 - `clauseSort` — *oti* = content, *pu* = situation, consuming
   `Bondarenko2022.NominalSort` (§3.2 ex. 33–34)
 - `bareOtiAttested`, `transparency_conflates_axes` — the §7.3
@@ -58,6 +61,7 @@ namespace Angelopoulos2026
 
 open Greek.StandardModern.Complementizers
 open Bondarenko2022 (NominalSort CompositionPath)
+open Features (VendlerClass)
 
 /-! ### Reversed selection: the [n]-feature (§3.1) -/
 
@@ -90,16 +94,16 @@ def dualVerbs : List (Verb × Verb) :=
   [(thimame, thimameStat), (thimono, thimonoStat)]
 
 /-- The emotive/cognitive factivity split: verb-level and C-level
-factivity are anti-aligned on the sample. The complement-presupposing
-verbs (`Verb.factivePresup`: *kséro*, *katalavéno*, *sinidhitopió*)
-select *oti*, which records no lexical factive presupposition, while
+factivity are anti-aligned on the sample. Among the *oti*-selectors
+exactly the knowledge verbs (*kséro*, *katalavéno*, *sinidhitopió*)
+carry `Verb.factivePresup`, while *oti* records no lexical factivity;
 the *pu*-only emotive factives all escape `factivePresup` (preferential
 rather than veridical-doxastic attitude) yet select lexically factive
 *pu*. Complement factivity thus has two independent sources — verb and
 complementizer — which the Greek data tease apart. -/
 theorem factivity_anti_aligned :
     oti.factive = none ∧ pu.factive = some true ∧
-    (∀ v ∈ [ksero, katalaveno, sinidhitopio], v.factivePresup = true) ∧
+    otiOnlyVerbs.map (·.factivePresup) = [false, false, true, true, true, false] ∧
     (∀ v ∈ puOnlyVerbs, v.factivePresup = false) := by
   decide
 
@@ -112,13 +116,18 @@ inductive NounHost where
   | vLex
   | t
   | p
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, Repr
 
 /-- Whether a host licenses light-noun incorporation. -/
 def NounHost.licenses : NounHost → Prop
   | .vLex => True
   | .t    => False
   | .p    => False
+
+instance : DecidablePred NounHost.licenses
+  | .vLex => isTrue trivial
+  | .t    => isFalse id
+  | .p    => isFalse id
 
 /-- Positions a bare oti/pu-clause can occupy, each with the nearest
 potential incorporation host: internal arguments sit under an
@@ -129,7 +138,7 @@ inductive ClausePosition where
   | derivedSubject
   | externalArgument
   | pComplement
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, Repr
 
 /-- The nearest potential incorporation host from each position. -/
 def ClausePosition.nearestHost : ClausePosition → NounHost
@@ -143,18 +152,30 @@ host licenses light-noun incorporation — the paper's derivation of
 the distribution, not a stipulated table. -/
 def licensedIn (pos : ClausePosition) : Prop := pos.nearestHost.licenses
 
+instance : DecidablePred licensedIn := fun pos =>
+  inferInstanceAs (Decidable pos.nearestHost.licenses)
+
 /-- Internal arguments and derived subjects are licensed (§2.1–2.2). -/
 theorem internal_and_derived_subject_licensed :
     licensedIn .internalArgument ∧ licensedIn .derivedSubject :=
   ⟨trivial, trivial⟩
 
 /-- The external-argument ban (§2.2): T cannot host incorporation. -/
-theorem external_argument_banned : ¬ licensedIn .externalArgument :=
-  fun h => h
+theorem external_argument_banned : ¬ licensedIn .externalArgument := id
 
 /-- Bare clauses are excluded after P (ex. 31c, 32c). -/
-theorem p_complement_banned : ¬ licensedIn .pComplement :=
-  fun h => h
+theorem p_complement_banned : ¬ licensedIn .pComplement := id
+
+/-- The licensing predictions match the ex. 31–32 paradigm judgments:
+bare clauses are fine as internal arguments (31b, 32b) and out after
+P (31c, 32c). -/
+theorem licensing_matches_judgments :
+    ∀ p ∈ [(ClausePosition.internalArgument, Examples.ex_31b),
+           (.internalArgument, Examples.ex_32b),
+           (.pComplement, Examples.ex_31c),
+           (.pComplement, Examples.ex_32c)],
+      licensedIn p.1 ↔ p.2.judgment ≠ .ungrammatical := by
+  decide
 
 /-! ### The stativity locus (§4.1) -/
 
@@ -163,7 +184,14 @@ Borer and Merchant as cited there). -/
 inductive AspectualHead where
   | vState
   | vEvent
-  deriving DecidableEq, Fintype, Repr
+  deriving DecidableEq, Repr
+
+/-- The aspectual head introducing a verb's internal argument tracks
+the verb's Vendler class through its dynamicity (§4.1). -/
+def AspectualHead.ofVendler (vc : VendlerClass) : AspectualHead :=
+  match vc.dynamicity with
+  | .stative => .vState
+  | .dynamic => .vEvent
 
 /-- §4.1: vState selects both otiP and puP as its complement; vEvent
 selects only otiP. -/
@@ -179,17 +207,28 @@ theorem pu_requires_stative (h : AspectualHead)
   · rfl
   · exact absurd (show pu = oti from hp) (by decide)
 
-/-- The verb-level reflex over the fragment sample: the *pu*-only
-matrix verbs are all stative. -/
+/-- The §2.3 stativity generalization, derived: a verb whose aspectual
+head licenses a *pu*-complement is Vendler-stative. -/
+theorem pu_complement_verb_stative (vc : VendlerClass)
+    (hp : selectsClause (.ofVendler vc) pu) : vc = .state := by
+  cases vc
+  · rfl
+  all_goals exact absurd (show pu = oti from hp) (by decide)
+
+/-- The verb-level reflex over the fragment sample: each *pu*-only
+matrix verb's aspectual head is `vState`. -/
 theorem pu_only_verbs_stative :
-    ∀ v ∈ puOnlyVerbs, v.vendlerClass = some .state := by
+    ∀ v ∈ puOnlyVerbs,
+      v.vendlerClass.map AspectualHead.ofVendler = some .vState := by
   decide
 
 /-- The dual verbs realize the same restriction sense-internally:
-stative *pu*-sense, non-stative *oti*-sense (ex. 19, 22–23). -/
+`vState` for the *pu*-sense, `vEvent` for the *oti*-sense
+(ex. 19, 22–23). -/
 theorem dual_verbs_stative_with_pu :
-    ∀ p ∈ dualVerbs, p.2.vendlerClass = some .state ∧
-      p.1.vendlerClass ≠ some .state := by
+    ∀ p ∈ dualVerbs,
+      p.2.vendlerClass.map AspectualHead.ofVendler = some .vState ∧
+      p.1.vendlerClass.map AspectualHead.ofVendler = some .vEvent := by
   decide
 
 /-! ### Content vs situation (§3.2) -/
@@ -211,8 +250,15 @@ theorem clauseSort_matches_diagnostics :
     clauseSort oti = some .content ∧
     NominalSort.truthEvaluable .content ∧
     clauseSort pu = some .situation ∧
-    NominalSort.occurrenceCompatible .situation :=
-  ⟨by decide, trivial, by decide, trivial⟩
+    NominalSort.occurrenceCompatible .situation := by
+  decide
+
+/-- The [n]-bearers are exactly the sorted complementizers: light-noun
+incorporation presupposes a clause sort for the noun to match
+(§3.1–§3.2); *an* and *na* fall outside both. -/
+theorem bearsN_iff_sorted :
+    ∀ c ∈ complementizers, (bearsN c ↔ (clauseSort c).isSome) := by
+  decide
 
 /-- fn. 17's rebuttal of a reviewer's oti ~ pu allomorphy alternative,
 cross-checked against the rival lexical typology: both this account
@@ -245,31 +291,20 @@ def bareOtiAttested : SynPosition → CompositionPath → Prop
   | .adjunct,    .viaSituation  => True
   | .adjunct,    .viaDPArgument => False
 
-/-- [bondarenko-2022]'s transparent mapping restated on the split
-axes: a bare clause composing via PM must be a syntactic adjunct
-(the composition path is reflected in syntax). -/
-def transparentBare : SynPosition → CompositionPath → Prop
-  | .adjunct, .viaSituation => True
-  | _, _ => False
+/-- Bare clauses never compose via FA from either position: FA requires
+the nominalizing D (§7.3 ex. 57). -/
+theorem bare_never_via_dp : ∀ p, ¬ bareOtiAttested p .viaDPArgument :=
+  fun p => by cases p <;> exact id
 
-/-- The §7.3 divergence: bare *oti*-clauses occupy complement position
-while composing via PM — attested here, excluded by the transparent
-mapping. Conditional on the paper's premises: the clauses are BARE
-(no covert nominal shell — the analysis rejects Arsenijević's DP
-layer and Faure's case-less-DP treatment, §3.1) and are internal
-ARGUMENTS (clitic doubling, passivization, derived subjects,
-§2.1–2.2). [bondarenko-2022] can deny either premise. -/
-theorem diverges_from_transparent_mapping :
-    bareOtiAttested .complement .viaSituation ∧
-    ¬ transparentBare .complement .viaSituation :=
-  ⟨trivial, fun h => h⟩
-
-/-- Against `Bondarenko2022.transparentSSMapping` directly: Bondarenko
-predicts the (bare, argument) cell empty
-(`Bondarenko2022.bare_argument_predicted_impossible`), identifying
-argument position with the FA path; Greek realizes syntactic
-argumenthood for bare clauses WITHOUT FA — the identification of the
-two axes is what fails. -/
+/-- The §7.3 divergence: [bondarenko-2022] predicts the (bare, argument)
+cell empty (`Bondarenko2022.bare_argument_predicted_impossible`),
+identifying argument position with the FA path; Greek bare *oti*-clauses
+realize syntactic argumenthood while composing via PM — the
+identification of the two axes is what fails. Conditional on the paper's
+premises: the clauses are BARE (no covert nominal shell — the analysis
+rejects Arsenijević's DP layer and Faure's case-less-DP treatment, §3.1)
+and are internal ARGUMENTS (clitic doubling, passivization, derived
+subjects, §2.1–2.2). [bondarenko-2022] can deny either premise. -/
 theorem transparency_conflates_axes :
     ¬ Bondarenko2022.transparentSSMapping .bareArgument ∧
     bareOtiAttested .complement .viaSituation :=

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -2,6 +2,9 @@ import Linglib.Studies.Bondarenko2022
 import Linglib.Studies.Roussou2010
 import Linglib.Fragments.Greek.StandardModern.Complementizers
 import Linglib.Syntax.Category.Verb.Selection
+import Linglib.Syntax.Minimalist.Features
+import Linglib.Semantics.Attitudes.ClauseDenotation.Content
+import Linglib.Semantics.Attitudes.ClauseDenotation.Situation
 import Linglib.Data.Examples.Angelopoulos2026
 
 /-!
@@ -15,8 +18,9 @@ selection: *oti* and *pu* bear an uninterpretable [n]-feature checked
 by a light noun in their specifier (partly adopting [arsenijevic-2009])
 that must incorporate into a lexical verbal head, licit only from
 complement position (§3.1). The *oti* ~ *pu* split follows from the
-content/situation dichotomy (§3.2, adopting [bondarenko-2022]), the
-stativity restriction from aspectual-head selection (§4.1), and §7.3
+content/situation dichotomy (§3.2, adopting [bondarenko-2022]) with
+*pu*'s factivity derived from situation-anchoring, the stativity
+restriction from aspectual-head selection (§4.1), and §7.3
 turns the §2 argumenthood diagnostics against Bondarenko's transparent
 syntax–semantics mapping: bare *oti*-clauses sit in complement position
 while composing via Predicate Modification (the explanans reading,
@@ -29,15 +33,40 @@ namespace Angelopoulos2026
 open Greek.StandardModern.Complementizers
 open Bondarenko2022 (NominalSort CompositionPath)
 open Features (VendlerClass)
+open Minimalist (GramFeature featuresMatch)
+open Semantics.Attitudes.ClauseDenotation.Content
+  (AttitudeVerbCI existsContentClosure)
+open Semantics.Attitudes.ClauseDenotation.Situation
+  (SituationVerb existsSituationClosure)
 
 /-! ### Reversed selection: the light noun (§3.1) -/
 
-/-- *oti* and *pu* select a light noun in their specifier, checking an
-uninterpretable [n]-feature; *na* does not (§3.1). -/
-def selectsLightNoun (c : Complementizer) : Prop := c = oti ∨ c = pu
+/-- The [n] probe: an unvalued categorial-N feature
+([panagiotidis-2015]'s referentiality feature) demanding a nominal
+goal in the specifier. -/
+def nProbe : GramFeature := .unvalued (.catN true)
+
+/-- The light noun's goal feature: valued [n]. -/
+def nGoal : GramFeature := .valued (.catN true)
+
+/-- The §3.1 lexical assignment: *oti* and *pu* carry the [n] probe,
+*an* and *na* none. -/
+def nProbes (c : Complementizer) : List GramFeature :=
+  if c = oti ∨ c = pu then [nProbe] else []
+
+/-- *oti* and *pu* select a light noun in their specifier: their
+feature bundle carries the [n] probe (§3.1). -/
+def selectsLightNoun (c : Complementizer) : Prop := nProbe ∈ nProbes c
 
 instance : DecidablePred selectsLightNoun :=
-  fun _ => inferInstanceAs (Decidable (_ ∨ _))
+  fun _ => inferInstanceAs (Decidable (_ ∈ _))
+
+/-- Merging a light noun in the specifier checks the probe: the goal
+matches it in type and is valued where the probe is not. -/
+theorem lightNoun_checks_nProbe :
+    featuresMatch nProbe nGoal = true ∧
+    nGoal.isValued = true ∧ nProbe.isUnvalued = true := by
+  decide
 
 /-! ### The attested selection classes (§1–§2.3) -/
 
@@ -250,6 +279,38 @@ theorem oti_pu_lexically_distinct :
     clauseSort oti ≠ clauseSort pu ∧
     Roussou2010.profile oti ≠ Roussou2010.profile pu := by
   decide
+
+/-! ### Factivity from situation semantics (§3.2) -/
+
+/-- A situation verb is anchored when it relates agents only to
+situation individuals realized at the evaluation situation. -/
+def Anchored {S X : Type*} (verb : SituationVerb S X) : Prop :=
+  ∀ a xs s, verb a xs s → xs.sit s
+
+/-- An anchored verb's *pu*-report entails its complement — the factive
+presupposition of *pu*-clauses derived from situation semantics
+(§3.2). -/
+theorem pu_report_factive {S X : Type*} {verb : SituationVerb S X}
+    (h : Anchored verb) (a : X) (q : S → Prop) (s : S) :
+    existsSituationClosure verb a q s → q s := by
+  rintro ⟨xs, hv, hq⟩
+  rw [← show xs.sit = q from hq]
+  exact h a xs s hv
+
+/-- Content reports carry no such entailment. -/
+theorem content_report_not_factive :
+    ¬ ∀ (verb : AttitudeVerbCI Bool Unit) (a : Unit) (p : Bool → Prop)
+        (w : Bool), existsContentClosure verb a p w → p w :=
+  fun h => h (fun _ _ _ => True) () (fun _ => False) true
+    ⟨⟨fun _ => False⟩, trivial, rfl⟩
+
+/-- Anchored regret over two situations. -/
+private def toyRegret : SituationVerb Bool Unit := fun _ xs s => xs.sit s
+
+/-- ex. 1b's *pu*-report composed through `existsSituationClosure`. -/
+theorem ex_1b_reading :
+    existsSituationClosure toyRegret () (· = true) true :=
+  ⟨⟨(· = true)⟩, rfl, rfl⟩
 
 /-! ### Against the transparent syntax–semantics mapping (§7.3) -/
 

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -33,9 +33,7 @@ open Features (VendlerClass)
 /-! ### Reversed selection: the light noun (§3.1) -/
 
 /-- *oti* and *pu* select a light noun in their specifier, checking an
-uninterpretable [n]-feature (§3.1); *na* does not (its licensing is
-mood-driven). Paper-specific datum over the fragment entries; the paper
-is neutral on the category of *oti* and *pu* (fn. 3). -/
+uninterpretable [n]-feature; *na* does not (§3.1). -/
 def selectsLightNoun (c : Complementizer) : Prop := c = oti ∨ c = pu
 
 instance : DecidablePred selectsLightNoun :=
@@ -43,39 +41,31 @@ instance : DecidablePred selectsLightNoun :=
 
 /-! ### The attested selection classes (§1–§2.3) -/
 
-/-- Matrix verbs attested with *oti* only (ex. 1a, 3–4, 21): saying,
-belief, knowledge. Study-local lists: the frame axes underdetermine the
-split (`frames_underdetermine_distribution`), and the account derives
-it semantically (§3.2, §4.1) rather than from a verb-level feature. -/
+/-- Matrix verbs attested with *oti* only: saying, belief, knowledge
+(ex. 1a, 3–4, 21). -/
 def otiOnlyVerbs : List Verb :=
   [leo, pistevo, ksero, katalaveno, sinidhitopio, eksigo]
 
-/-- Matrix verbs attested with *pu* only (ex. 1b, 13–14, 20): the
-emotive factives. -/
+/-- Matrix verbs attested with *pu* only: the emotive factives
+(ex. 1b, 13–14, 20). -/
 def puOnlyVerbs : List Verb := [metaniono, areso, xerome]
 
-/-- Verbs attested with both (ex. 19, 22–23), as (eventive *oti*-sense,
-stative *pu*-sense) pairs of sense-tagged fragment entries. -/
+/-- Verbs attested with both, as (eventive *oti*-sense, stative
+*pu*-sense) pairs (ex. 19, 22–23). -/
 def dualVerbs : List (Verb × Verb) :=
   [(thimame, thimameStat), (thimono, thimonoStat)]
 
-/-- The §1 puzzle through the `Verb.realizes` selection hom: every verb
-in the sample types both *oti*- and *pu*-clauses on the coding/force
-axes (both are finite indicative declaratives), while subjunctive *na*
-is already excluded — the *oti* ~ *pu* residue is what the
-content/situation account derives. -/
+/-- Every sample verb's frames admit both *oti* and *pu* and already
+exclude *na*: coding and force underdetermine the split (§1). -/
 theorem frames_underdetermine_distribution :
     ∀ v ∈ otiOnlyVerbs ++ puOnlyVerbs,
       v.realizes oti ∧ v.realizes pu ∧ ¬ v.realizes na := by
   decide
 
-/-- The emotive/cognitive factivity split: verb-level and C-level
-factivity are anti-aligned on the sample. The complement-presupposing
-*oti*-selectors are exactly the knowledge verbs, while *oti* records no
-lexical factivity; no *pu*-only emotive factive presupposes lexically
-(preferential rather than veridical-doxastic attitude), yet *pu* is
-lexically factive. Complement factivity thus has two independent
-sources — verb and complementizer — which the Greek data tease apart. -/
+/-- Verb-level and C-level factivity are anti-aligned: the
+*oti*-selectors that presuppose their complement are exactly the
+knowledge verbs, no *pu*-only emotive factive presupposes, and only
+*pu* is lexically factive. -/
 theorem factivity_anti_aligned :
     oti.factive = none ∧ pu.factive = some true ∧
     otiOnlyVerbs.filter (·.factivePresup) = [ksero, katalaveno, sinidhitopio] ∧
@@ -84,16 +74,16 @@ theorem factivity_anti_aligned :
 
 /-! ### Incorporation licensing and the argument asymmetry (§3.1) -/
 
-/-- Heads adjacent to a clause's light noun. Only a lexical verbal
-head licenses noun incorporation ([hale-keyser-1993]); functional T
-and P do not (§3.1 ex. 29–32). -/
+/-- Heads adjacent to a clause's light noun: a lexical verbal head,
+T, or P (§3.1). -/
 inductive NounHost where
   | vLex
   | t
   | p
   deriving DecidableEq, Repr
 
-/-- Whether a host licenses light-noun incorporation. -/
+/-- Only the lexical verbal head licenses light-noun incorporation
+([hale-keyser-1993]); functional T and P do not. -/
 def NounHost.licenses : NounHost → Prop
   | .vLex => True
   | .t    => False
@@ -104,10 +94,7 @@ instance : DecidablePred NounHost.licenses
   | .t    => isFalse id
   | .p    => isFalse id
 
-/-- Positions a bare oti/pu-clause can occupy, each with the nearest
-potential incorporation host: internal arguments sit under an
-aspectual v; incorporation precedes movement for derived subjects;
-the nearest head above Spec,vP is T; P cannot host (§3.1 ex. 27–32). -/
+/-- Positions a bare oti/pu-clause can occupy (§3.1 ex. 27–32). -/
 inductive ClausePosition where
   | internalArgument
   | derivedSubject
@@ -118,32 +105,32 @@ inductive ClausePosition where
 /-- The nearest potential incorporation host from each position. -/
 def ClausePosition.nearestHost : ClausePosition → NounHost
   | .internalArgument => .vLex
-  | .derivedSubject   => .vLex
-  | .externalArgument => .t
+  | .derivedSubject   => .vLex  -- incorporation precedes movement
+  | .externalArgument => .t     -- nearest head above Spec,vP
   | .pComplement      => .p
 
-/-- A bare oti/pu-clause is licensed in a position iff the nearest
-host licenses light-noun incorporation — the paper's derivation of
-the distribution, not a stipulated table. -/
+/-- A bare oti/pu-clause is licensed in a position iff its nearest
+host licenses light-noun incorporation (§3.1). -/
 def licensedIn (pos : ClausePosition) : Prop := pos.nearestHost.licenses
 
 instance : DecidablePred licensedIn := fun pos =>
   inferInstanceAs (Decidable pos.nearestHost.licenses)
 
-/-- Internal arguments and derived subjects are licensed (§2.1–2.2). -/
+/-- Bare clauses are licensed as internal arguments and derived
+subjects (§2.1–2.2). -/
 theorem internal_and_derived_subject_licensed :
     licensedIn .internalArgument ∧ licensedIn .derivedSubject :=
   ⟨trivial, trivial⟩
 
-/-- The external-argument ban (§2.2): T cannot host incorporation. -/
+/-- Bare clauses are banned from external-argument position: T cannot
+host incorporation (§2.2). -/
 theorem external_argument_banned : ¬ licensedIn .externalArgument := id
 
 /-- Bare clauses are excluded after P (ex. 31c, 32c). -/
 theorem p_complement_banned : ¬ licensedIn .pComplement := id
 
-/-- The licensing predictions match the ex. 31–32 paradigm judgments:
-bare clauses are fine as internal arguments (31b, 32b) and out after
-P (31c, 32c). -/
+/-- The licensing predictions match the ex. 31–32 judgments:
+acceptable as internal arguments, ungrammatical after P. -/
 theorem licensing_matches_judgments :
     ∀ p ∈ [(ClausePosition.internalArgument, Examples.ex_31b),
            (.internalArgument, Examples.ex_32b),
@@ -154,52 +141,48 @@ theorem licensing_matches_judgments :
 
 /-! ### The stativity locus (§4.1) -/
 
-/-- Aspectual heads introducing internal arguments (§4.1, following
-Borer and Merchant as cited there). -/
+/-- Aspectual heads introducing internal arguments (§4.1). -/
 inductive AspectualHead where
   | vState
   | vEvent
   deriving DecidableEq, Repr
 
-/-- The aspectual head introducing a verb's internal argument tracks
-the verb's Vendler class through its dynamicity (§4.1). -/
+/-- The aspectual head determined by a verb's Vendler class: `vState`
+for stative classes, `vEvent` for dynamic ones (§4.1). -/
 def AspectualHead.ofVendler (vc : VendlerClass) : AspectualHead :=
   match vc.dynamicity with
   | .stative => .vState
   | .dynamic => .vEvent
 
-/-- §4.1: vState selects both otiP and puP as its complement; vEvent
-selects only otiP. -/
+/-- vState selects both otiP and puP as its complement; vEvent selects
+only otiP (§4.1). -/
 def selectsClause : AspectualHead → Complementizer → Prop
   | .vState, c => c = oti ∨ c = pu
   | .vEvent, c => c = oti
 
-/-- The stativity restriction (§2.3), derived: a *pu*-complement
-forces the stative aspectual head. -/
+/-- A *pu*-complement forces the stative aspectual head (§2.3). -/
 theorem pu_requires_stative (h : AspectualHead)
     (hp : selectsClause h pu) : h = .vState := by
   cases h
   · rfl
   · exact absurd (show pu = oti from hp) (by decide)
 
-/-- The §2.3 stativity generalization, derived: a verb whose aspectual
-head licenses a *pu*-complement is Vendler-stative. -/
+/-- A verb whose aspectual head licenses a *pu*-complement is
+Vendler-stative (§2.3). -/
 theorem pu_complement_verb_stative (vc : VendlerClass)
     (hp : selectsClause (.ofVendler vc) pu) : vc = .state := by
   cases vc
   · rfl
   all_goals exact absurd (show pu = oti from hp) (by decide)
 
-/-- The verb-level reflex over the fragment sample: each *pu*-only
-matrix verb's aspectual head is `vState`. -/
+/-- Every *pu*-only matrix verb's aspectual head is `vState`. -/
 theorem pu_only_verbs_stative :
     ∀ v ∈ puOnlyVerbs,
       v.vendlerClass.map AspectualHead.ofVendler = some .vState := by
   decide
 
-/-- The dual verbs realize the same restriction sense-internally:
-`vState` for the *pu*-sense, `vEvent` for the *oti*-sense
-(ex. 19, 22–23). -/
+/-- Each dual verb's *pu*-sense takes `vState` and its *oti*-sense
+`vEvent` (ex. 19, 22–23). -/
 theorem dual_verbs_stative_with_pu :
     ∀ p ∈ dualVerbs,
       p.2.vendlerClass.map AspectualHead.ofVendler = some .vState ∧
@@ -209,18 +192,16 @@ theorem dual_verbs_stative_with_pu :
 /-! ### Content vs situation (§3.2) -/
 
 /-- The sort of clause each complementizer introduces — *oti* content,
-*pu* situation — which must match the incorporating noun's sort
-(§3.2). The sorts and their diagnostics ('true'/'mistaken' vs
-'happen', ex. 33–34) are [bondarenko-2022]'s (`Bondarenko2022.NominalSort`,
-§2.2.3); *na* is outside the dichotomy. -/
+*pu* situation, *na* neither — which must match the incorporating
+noun's sort (§3.2). -/
 def clauseSort (c : Complementizer) : Option NominalSort :=
   if c = oti then some .content
   else if c = pu then some .situation
   else none
 
-/-- The assigned sorts pass the §3.2 diagnostics: *oti*'s sort is
-truth-evaluable, *pu*'s occurrence-compatible (ex. 33–34, matching
-[bondarenko-2022] §2.2.3). -/
+/-- The sorts pass the §3.2 diagnostics: *oti*'s is truth-evaluable
+('true'/'mistaken'), *pu*'s occurrence-compatible ('happen')
+(ex. 33–34). -/
 theorem clauseSort_matches_diagnostics :
     clauseSort oti = some .content ∧
     NominalSort.truthEvaluable .content ∧
@@ -228,18 +209,15 @@ theorem clauseSort_matches_diagnostics :
     NominalSort.occurrenceCompatible .situation := by
   decide
 
-/-- The light-noun selectors are exactly the sorted complementizers:
-incorporation presupposes a clause sort for the noun to match
-(§3.1–§3.2); *an* and *na* fall outside both. -/
+/-- The light-noun selectors are exactly the sort-bearing
+complementizers: the noun must match its clause's sort (§3.1–§3.2). -/
 theorem selectsLightNoun_iff_sorted :
     ∀ c ∈ complementizers, (selectsLightNoun c ↔ (clauseSort c).isSome) := by
   decide
 
-/-- fn. 17's rebuttal of a reviewer's oti ~ pu allomorphy alternative,
-cross-checked against the rival lexical typology: both this account
-and [roussou-2010]'s hold the two lexically distinct — content vs
-situation sort here, indefinite vs definite propositional
-quantification there (`Roussou2010.profile`). -/
+/-- *oti* and *pu* are lexically distinct on this account (content vs
+situation) and on [roussou-2010]'s (indefinite vs definite), against
+fn. 17's allomorphy alternative. -/
 theorem oti_pu_lexically_distinct :
     clauseSort oti ≠ clauseSort pu ∧
     Roussou2010.profile oti ≠ Roussou2010.profile pu := by
@@ -247,19 +225,16 @@ theorem oti_pu_lexically_distinct :
 
 /-! ### Against the transparent syntax–semantics mapping (§7.3) -/
 
-/-- Syntactic position of an embedded clause — one of the two axes
-[bondarenko-2022]'s `ClauseStructurePath` conflates. -/
+/-- Syntactic position of an embedded clause: complement or adjunct
+(§7.3). -/
 inductive SynPosition where
   | complement
   | adjunct
   deriving DecidableEq, Repr
 
-/-- The paper's claim for bare *oti*-clauses (§2 diagnostics + §7.3),
-on the composition axis of [bondarenko-2022]'s `CompositionPath` (PM
-with the verb's situation argument = `viaSituation`, FA into a DP slot
-= `viaDPArgument`): complement position composing via PM is attested
-(the explanans reading); FA requires the nominalizing D (§7.3 ex. 57),
-so bare clauses never compose via FA from either position. -/
+/-- The (position, composition-path) pairs attested for bare
+*oti*-clauses: Predicate Modification from either position, Functional
+Application from neither (§2, §7.3). -/
 def bareOtiAttested : SynPosition → CompositionPath → Prop
   | .complement, .viaSituation  => True
   | .complement, .viaDPArgument => False
@@ -271,15 +246,9 @@ the nominalizing D (§7.3 ex. 57). -/
 theorem bare_never_via_dp : ∀ p, ¬ bareOtiAttested p .viaDPArgument :=
   fun p => by cases p <;> exact id
 
-/-- The §7.3 divergence: [bondarenko-2022] predicts the (bare, argument)
-cell empty (`Bondarenko2022.bare_argument_predicted_impossible`),
-identifying argument position with the FA path; Greek bare *oti*-clauses
-realize syntactic argumenthood while composing via PM — the
-identification of the two axes is what fails. Conditional on the paper's
-premises: the clauses are BARE (no covert nominal shell — the analysis
-rejects Arsenijević's DP layer and Faure's case-less-DP treatment, §3.1)
-and are internal ARGUMENTS (clitic doubling, passivization, derived
-subjects, §2.1–2.2). [bondarenko-2022] can deny either premise. -/
+/-- Greek bare *oti*-clauses fill the cell [bondarenko-2022]'s
+transparent mapping predicts empty: syntactic argumenthood without
+Functional Application (§7.3). -/
 theorem transparency_conflates_axes :
     ¬ Bondarenko2022.transparentSSMapping .bareArgument ∧
     bareOtiAttested .complement .viaSituation :=

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -41,28 +41,29 @@ open Semantics.Attitudes.ClauseDenotation.Situation
 
 /-! ### Reversed selection: the light noun (§3.1) -/
 
-/-- The [n] probe: an unvalued categorial-N feature
-([panagiotidis-2015]'s referentiality feature) demanding a nominal
-goal in the specifier. -/
+/-- The uninterpretable [n]-feature *oti* and *pu* bear, checked by
+merging a light noun in their specifier (§3.1: selection as feature
+checking). -/
 def nProbe : GramFeature := .unvalued (.catN true)
 
-/-- The light noun's goal feature: valued [n]. -/
+/-- The light noun's [n]-feature, interpretable and valued on a
+nominal. -/
 def nGoal : GramFeature := .valued (.catN true)
 
-/-- The §3.1 lexical assignment: *oti* and *pu* carry the [n] probe,
+/-- The §3.1 lexical assignment: *oti* and *pu* carry the [n]-feature,
 *an* and *na* none. -/
 def nProbes (c : Complementizer) : List GramFeature :=
   if c = oti ∨ c = pu then [nProbe] else []
 
 /-- *oti* and *pu* select a light noun in their specifier: their
-feature bundle carries the [n] probe (§3.1). -/
+feature bundle carries the [n]-feature (§3.1). -/
 def selectsLightNoun (c : Complementizer) : Prop := nProbe ∈ nProbes c
 
 instance : DecidablePred selectsLightNoun :=
   fun _ => inferInstanceAs (Decidable (_ ∈ _))
 
-/-- Merging a light noun in the specifier checks the probe: the goal
-matches it in type and is valued where the probe is not. -/
+/-- The merged noun's valued [n] checks the complementizer's under
+specifier–head matching. -/
 theorem lightNoun_checks_nProbe :
     featuresMatch nProbe nGoal = true ∧
     nGoal.isValued = true ∧ nProbe.isUnvalued = true := by
@@ -228,26 +229,61 @@ def clauseSort (c : Complementizer) : Option NominalSort :=
   else if c = pu then some .situation
   else none
 
-/-- The sort of the light noun a verb selects: stative senses and
-stative preferential attitudes relate to situations; saying, belief,
-and knowledge to content (§3.2). -/
+/-- A light noun of sort `n` can merge in the complementizer's
+specifier iff its sort is the clause's sort (§3.2). -/
+def mergeableInSpec (n : NominalSort) (c : Complementizer) : Prop :=
+  clauseSort c = some n
+
+instance (n : NominalSort) (c : Complementizer) :
+    Decidable (mergeableInSpec n c) :=
+  inferInstanceAs (Decidable (clauseSort c = some n))
+
+/-- Only the content noun merges in Spec,otiP and only the situation
+noun in Spec,puP (§3.2). -/
+theorem spec_noun_sorted :
+    mergeableInSpec .content oti ∧ ¬ mergeableInSpec .situation oti ∧
+    mergeableInSpec .situation pu ∧ ¬ mergeableInSpec .content pu := by
+  decide
+
+/-- The sort of the light noun a verb verbalizes under incorporation:
+stative senses, stative preferential attitudes, and occurrence verbs
+relate to situations; saying, belief, and knowledge to content
+(§3.2). -/
 def nounSort (v : Verb) : Option NominalSort :=
   if v.senseTag = .stative then some .situation
+  else if v.unaccusative && v.attitude.isNone then some .situation
   else match v.attitude with
     | some (.preferential _) =>
         if v.vendlerClass = some .state then some .situation
         else some .content
     | _ => some .content
 
-/-- The near-complementary distribution follows from sort matching:
-each verb class pairs with exactly the complementizer whose clause
-sort matches its noun sort (§3.2). -/
-theorem distribution_from_sort_matching :
-    (∀ v ∈ otiOnlyVerbs, nounSort v = clauseSort oti) ∧
-    (∀ v ∈ puOnlyVerbs, nounSort v = clauseSort pu) ∧
-    (∀ p ∈ dualVerbs,
-      nounSort p.1 = clauseSort oti ∧ nounSort p.2 = clauseSort pu) := by
+/-- A verb verbalizes the light noun of sort `n` (§3.1–§3.2). -/
+def verbalizes (v : Verb) (n : NominalSort) : Prop := nounSort v = some n
+
+instance (v : Verb) (n : NominalSort) : Decidable (verbalizes v n) :=
+  inferInstanceAs (Decidable (nounSort v = some n))
+
+/-- The near-complementary distribution through the light noun: each
+attested pairing has a noun the verb verbalizes that merges in the
+complementizer's specifier (§3.2). -/
+theorem distribution_via_light_noun :
+    (∀ v ∈ otiOnlyVerbs, ∃ n, verbalizes v n ∧ mergeableInSpec n oti) ∧
+    (∀ v ∈ puOnlyVerbs, ∃ n, verbalizes v n ∧ mergeableInSpec n pu) ∧
+    (∀ p ∈ dualVerbs, (∃ n, verbalizes p.1 n ∧ mergeableInSpec n oti) ∧
+      (∃ n, verbalizes p.2 n ∧ mergeableInSpec n pu)) := by
   decide
+
+/-- *simvéni* 'happen' rejects *oti* by sort mismatch and *pu* by
+eventivity, leaving its subjunctive *na*-frame (fn. 14). -/
+theorem simveni_rejects_both :
+    nounSort simveni = some .situation ∧
+    ¬ mergeableInSpec .situation oti ∧
+    simveni.vendlerClass.map AspectualHead.ofVendler = some .vEvent ∧
+    ¬ selectsClause .vEvent pu ∧
+    simveni.realizes na ∧ ¬ simveni.realizes oti :=
+  ⟨by decide, by decide, by decide,
+    fun h => absurd (show pu = oti from h) (by decide), by decide, by decide⟩
 
 /-- The situation-sorted complementizer is the lexically factive one
 (§3.2). -/

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -1,6 +1,7 @@
 import Linglib.Studies.Bondarenko2022
 import Linglib.Studies.Roussou2010
 import Linglib.Fragments.Greek.StandardModern.Complementizers
+import Linglib.Syntax.Category.Verb.Selection
 import Linglib.Data.Examples.Angelopoulos2026
 
 /-!
@@ -24,8 +25,8 @@ in `Angelopoulos2026.Examples`.
 
 ## Main definitions
 
-* `bearsN`, `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`: the §3.1
-  [n]-feature datum and the attested selection classes
+* `selectsLightNoun`, `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`: the
+  §3.1 light-noun datum and the attested selection classes
 * `NounHost`, `ClausePosition`, `licensedIn`: incorporation licensing
   by position
 * `selectsClause`, `AspectualHead.ofVendler`: the §4.1 stativity locus
@@ -35,13 +36,16 @@ in `Angelopoulos2026.Examples`.
 
 ## Main results
 
+* `frames_underdetermine_distribution`: `Verb.realizes` admits both
+  *oti* and *pu* on the whole sample — the §1 puzzle
 * `factivity_anti_aligned`: verb-level and C-level factivity are
   anti-aligned on the sample
 * `licensing_matches_judgments`: the position asymmetry against the
   ex. 31–32 judgments
 * `pu_complement_verb_stative`: the §2.3 verb-level stativity
   generalization, derived from §4.1 selection
-* `bearsN_iff_sorted`: the [n]-bearers are the sorted complementizers
+* `selectsLightNoun_iff_sorted`: the light-noun selectors are the
+  sorted complementizers
 * `transparency_conflates_axes`: the §7.3 counterclaim against
   `Bondarenko2022.transparentSSMapping`
 -/
@@ -52,24 +56,23 @@ open Greek.StandardModern.Complementizers
 open Bondarenko2022 (NominalSort CompositionPath)
 open Features (VendlerClass)
 
-/-! ### Reversed selection: the [n]-feature (§3.1) -/
+/-! ### Reversed selection: the light noun (§3.1) -/
 
-/-- *oti* and *pu* bear an uninterpretable [n]-feature checked by a
-light noun merged in their specifier (§3.1); *na* does not (its
-licensing is mood-driven). Paper-specific datum projected over the
-fragment entries; the paper is neutral on the category of *oti* and
-*pu* (fn. 3). -/
-def bearsN (c : Complementizer) : Prop := c = oti ∨ c = pu
+/-- *oti* and *pu* select a light noun in their specifier, checking an
+uninterpretable [n]-feature (§3.1); *na* does not (its licensing is
+mood-driven). Paper-specific datum over the fragment entries; the paper
+is neutral on the category of *oti* and *pu* (fn. 3). -/
+def selectsLightNoun (c : Complementizer) : Prop := c = oti ∨ c = pu
 
-instance : DecidablePred bearsN := fun c => by
-  unfold bearsN; infer_instance
+instance : DecidablePred selectsLightNoun :=
+  fun _ => inferInstanceAs (Decidable (_ ∨ _))
 
 /-! ### The attested selection classes (§1–§2.3) -/
 
 /-- Matrix verbs attested with *oti* only (ex. 1a, 3–4, 21): saying,
-belief, knowledge. Study-local lists: the analysis derives selection
-from light-noun incorporation and aspectual-head selection (§3.1,
-§4.1), so no verb-level feature records it. -/
+belief, knowledge. Study-local lists: the frame axes underdetermine the
+split (`frames_underdetermine_distribution`), and the account derives
+it semantically (§3.2, §4.1) rather than from a verb-level feature. -/
 def otiOnlyVerbs : List Verb :=
   [leo, pistevo, ksero, katalaveno, sinidhitopio, eksigo]
 
@@ -82,19 +85,28 @@ stative *pu*-sense) pairs of sense-tagged fragment entries. -/
 def dualVerbs : List (Verb × Verb) :=
   [(thimame, thimameStat), (thimono, thimonoStat)]
 
+/-- The §1 puzzle through the `Verb.realizes` selection hom: every verb
+in the sample types both *oti*- and *pu*-clauses on the coding/force
+axes (both are finite indicative declaratives), while subjunctive *na*
+is already excluded — the *oti* ~ *pu* residue is what the
+content/situation account derives. -/
+theorem frames_underdetermine_distribution :
+    ∀ v ∈ otiOnlyVerbs ++ puOnlyVerbs,
+      v.realizes oti ∧ v.realizes pu ∧ ¬ v.realizes na := by
+  decide
+
 /-- The emotive/cognitive factivity split: verb-level and C-level
-factivity are anti-aligned on the sample. Among the *oti*-selectors
-exactly the knowledge verbs (*kséro*, *katalavéno*, *sinidhitopió*)
-carry `Verb.factivePresup`, while *oti* records no lexical factivity;
-the *pu*-only emotive factives all escape `factivePresup` (preferential
-rather than veridical-doxastic attitude) yet select lexically factive
-*pu*. Complement factivity thus has two independent sources — verb and
-complementizer — which the Greek data tease apart. -/
+factivity are anti-aligned on the sample. The complement-presupposing
+*oti*-selectors are exactly the knowledge verbs, while *oti* records no
+lexical factivity; no *pu*-only emotive factive presupposes lexically
+(preferential rather than veridical-doxastic attitude), yet *pu* is
+lexically factive. Complement factivity thus has two independent
+sources — verb and complementizer — which the Greek data tease apart. -/
 theorem factivity_anti_aligned :
     oti.factive = none ∧ pu.factive = some true ∧
-    otiOnlyVerbs.map (·.factivePresup) = [false, false, true, true, true, false] ∧
-    (∀ v ∈ puOnlyVerbs, v.factivePresup = false) := by
-  decide
+    otiOnlyVerbs.filter (·.factivePresup) = [ksero, katalaveno, sinidhitopio] ∧
+    puOnlyVerbs.filter (·.factivePresup) = [] :=
+  ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ### Incorporation licensing and the argument asymmetry (§3.1) -/
 
@@ -242,11 +254,11 @@ theorem clauseSort_matches_diagnostics :
     NominalSort.occurrenceCompatible .situation := by
   decide
 
-/-- The [n]-bearers are exactly the sorted complementizers: light-noun
+/-- The light-noun selectors are exactly the sorted complementizers:
 incorporation presupposes a clause sort for the noun to match
 (§3.1–§3.2); *an* and *na* fall outside both. -/
-theorem bearsN_iff_sorted :
-    ∀ c ∈ complementizers, (bearsN c ↔ (clauseSort c).isSome) := by
+theorem selectsLightNoun_iff_sorted :
+    ∀ c ∈ complementizers, (selectsLightNoun c ↔ (clauseSort c).isSome) := by
   decide
 
 /-- fn. 17's rebuttal of a reviewer's oti ~ pu allomorphy alternative,

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -199,6 +199,34 @@ def clauseSort (c : Complementizer) : Option NominalSort :=
   else if c = pu then some .situation
   else none
 
+/-- The sort of the light noun a verb selects: stative senses and
+stative preferential attitudes relate to situations; saying, belief,
+and knowledge to content (§3.2). -/
+def nounSort (v : Verb) : Option NominalSort :=
+  if v.senseTag = .stative then some .situation
+  else match v.attitude with
+    | some (.preferential _) =>
+        if v.vendlerClass = some .state then some .situation
+        else some .content
+    | _ => some .content
+
+/-- The near-complementary distribution follows from sort matching:
+each verb class pairs with exactly the complementizer whose clause
+sort matches its noun sort (§3.2). -/
+theorem distribution_from_sort_matching :
+    (∀ v ∈ otiOnlyVerbs, nounSort v = clauseSort oti) ∧
+    (∀ v ∈ puOnlyVerbs, nounSort v = clauseSort pu) ∧
+    (∀ p ∈ dualVerbs,
+      nounSort p.1 = clauseSort oti ∧ nounSort p.2 = clauseSort pu) := by
+  decide
+
+/-- The situation-sorted complementizer is the lexically factive one
+(§3.2). -/
+theorem situation_clause_factive :
+    ∀ c ∈ complementizers,
+      clauseSort c = some .situation → c.factive = some true := by
+  decide
+
 /-- The sorts pass the §3.2 diagnostics: *oti*'s is truth-evaluable
 ('true'/'mistaken'), *pu*'s occurrence-compatible ('happen')
 (ex. 33–34). -/

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -22,32 +22,6 @@ syntax–semantics mapping: bare *oti*-clauses sit in complement position
 while composing via Predicate Modification (the explanans reading,
 [elliott-2020-embedding]). Typed paradigm sentences (ex. 1, 31–34) live
 in `Angelopoulos2026.Examples`.
-
-## Main definitions
-
-* `selectsLightNoun`, `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`: the
-  §3.1 light-noun datum and the attested selection classes
-* `NounHost`, `ClausePosition`, `licensedIn`: incorporation licensing
-  by position
-* `selectsClause`, `AspectualHead.ofVendler`: the §4.1 stativity locus
-* `clauseSort`: *oti* = content, *pu* = situation
-  (`Bondarenko2022.NominalSort`, §3.2)
-* `bareOtiAttested`: the §7.3 (position, composition-path) attestations
-
-## Main results
-
-* `frames_underdetermine_distribution`: `Verb.realizes` admits both
-  *oti* and *pu* on the whole sample — the §1 puzzle
-* `factivity_anti_aligned`: verb-level and C-level factivity are
-  anti-aligned on the sample
-* `licensing_matches_judgments`: the position asymmetry against the
-  ex. 31–32 judgments
-* `pu_complement_verb_stative`: the §2.3 verb-level stativity
-  generalization, derived from §4.1 selection
-* `selectsLightNoun_iff_sorted`: the light-noun selectors are the
-  sorted complementizers
-* `transparency_conflates_axes`: the §7.3 counterclaim against
-  `Bondarenko2022.transparentSSMapping`
 -/
 
 namespace Angelopoulos2026

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -5,56 +5,45 @@ import Linglib.Data.Examples.Angelopoulos2026
 
 /-!
 # Angelopoulos 2026: On clausal complementation, once more
-[angelopoulos-2026]
 
-Greek *oti*- and *pu*-clauses present three puzzles (§1): near-
-complementary distribution after verbs (*oti* with saying/belief, *pu*
-with emotive factives, ex. 1); freedom as internal arguments and
-derived subjects but a ban from external-argument position (§2.2); and
-a novel stativity restriction on complement *pu*-clauses (§2.3).
+[angelopoulos-2026] derives the distribution of Greek *oti*- and
+*pu*-clauses — near-complementary after verbs (ex. 1), free as internal
+arguments and derived subjects yet banned as external arguments (§2.2),
+stativity-restricted as *pu*-complements (§2.3) — from reversed
+selection: *oti* and *pu* bear an uninterpretable [n]-feature checked
+by a light noun in their specifier (partly adopting [arsenijevic-2009])
+that must incorporate into a lexical verbal head, licit only from
+complement position (§3.1). The *oti* ~ *pu* split follows from the
+content/situation dichotomy (§3.2, adopting [bondarenko-2022]), the
+stativity restriction from aspectual-head selection (§4.1), and §7.3
+turns the §2 argumenthood diagnostics against Bondarenko's transparent
+syntax–semantics mapping: bare *oti*-clauses sit in complement position
+while composing via Predicate Modification (the explanans reading,
+[elliott-2020-embedding]). Typed paradigm sentences (ex. 1, 31–34) live
+in `Angelopoulos2026.Examples`.
 
-The analysis reverses selection (§3.1): *oti* and *pu* bear an
-uninterpretable [n]-feature checked by a light noun merged in their
-specifier (partly adopting Arsenijević 2009; the paper is neutral on
-the categorial status of *oti* and *pu* — Cs in [roussou-1994], Ds in
-[roussou-2010] — fn. 3). The noun must
-incorporate into a lexical verbal head — possible from complement
-position, impossible from Spec,vP (nearest head T) or under P — which
-derives the argument asymmetry and the P-ban (§3.1 ex. 27–32). The
-*oti* ~ *pu* distribution follows from the content/situation dichotomy
-(§3.2, adopting [bondarenko-2022]); the stativity restriction from
-aspectual-head selection (§4.1: vState selects both otiP and puP,
-vEvent only otiP). §7.1 extends the adjunct-selection account to
-Uyghur *dep* (= *de* 'say' + converb *-ip*, per Major 2024).
+## Main definitions
 
-§7.3 departs from [bondarenko-2022]'s transparent syntax–semantics
-mapping: bare *oti*-clauses are merged in COMPLEMENT position (the §2
-argumenthood diagnostics: clitic doubling, passivization, derived
-subjects) while composing via Predicate Modification (the explanans
-reading, [elliott-2020-embedding]) — the same syntactic position
-yields either composition mode.
+* `bearsN`, `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`: the §3.1
+  [n]-feature datum and the attested selection classes
+* `NounHost`, `ClausePosition`, `licensedIn`: incorporation licensing
+  by position
+* `selectsClause`, `AspectualHead.ofVendler`: the §4.1 stativity locus
+* `clauseSort`: *oti* = content, *pu* = situation
+  (`Bondarenko2022.NominalSort`, §3.2)
+* `bareOtiAttested`: the §7.3 (position, composition-path) attestations
 
-## Main declarations
+## Main results
 
-- `bearsN`, `bearsN_iff_sorted` — the §3.1 [n]-feature datum and its
-  alignment with the content/situation sorts
-- `otiOnlyVerbs`, `puOnlyVerbs`, `dualVerbs`, `factivity_anti_aligned` —
-  the attested selection classes (§1–§2.3) and the emotive/cognitive
-  factivity split they carry
-- `NounHost`, `ClausePosition`, `licensedIn`, `licensing_matches_judgments`
-  — the incorporation mechanism, the derived argument-position asymmetry,
-  and its check against the ex. 31–32 judgments
-- `selectsClause`, `AspectualHead.ofVendler`, `pu_complement_verb_stative`
-  — the §4.1 stativity locus and the derived §2.3 verb-level
-  generalization
-- `clauseSort` — *oti* = content, *pu* = situation, consuming
-  `Bondarenko2022.NominalSort` (§3.2 ex. 33–34)
-- `bareOtiAttested`, `transparency_conflates_axes` — the §7.3
-  counterclaim against `Bondarenko2022.transparentSSMapping`, stated
-  over `Bondarenko2022.CompositionPath`
-
-Typed paradigm sentences (ex. 1, 31–34) live in `Angelopoulos2026.Examples`,
-generated from `Data/Examples/Angelopoulos2026.json`.
+* `factivity_anti_aligned`: verb-level and C-level factivity are
+  anti-aligned on the sample
+* `licensing_matches_judgments`: the position asymmetry against the
+  ex. 31–32 judgments
+* `pu_complement_verb_stative`: the §2.3 verb-level stativity
+  generalization, derived from §4.1 selection
+* `bearsN_iff_sorted`: the [n]-bearers are the sorted complementizers
+* `transparency_conflates_axes`: the §7.3 counterclaim against
+  `Bondarenko2022.transparentSSMapping`
 -/
 
 namespace Angelopoulos2026

--- a/Linglib/Studies/Bondarenko2022.lean
+++ b/Linglib/Studies/Bondarenko2022.lean
@@ -79,7 +79,7 @@ inductive NominalSort where
   /-- Situation nouns (§2.2): *situation*, *event*, *case*, *circumstance*,
       *state of affairs*. -/
   | situation
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Fintype, Repr
 
 /-! ### Equality vs. subset vs. existential semantics
 


### PR DESCRIPTION
Audit cleanse: consume the generated ex. 31–32 rows (`licensing_matches_judgments`), link the [n]-feature to the sort dichotomy (`bearsN_iff_sorted`), derive the §2.3 verb-level stativity through `AspectualHead.ofVendler`, and cut the locally re-stipulated transparent-mapping table in favor of the cross-file `transparency_conflates_axes`. Also drops the module docstring's Buryat apposition (not in the paper) and the unused `Fintype` derives.