### PR TITLE
refactor(Syntax/Clause): move complementation typology from Features

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -659,7 +659,6 @@ import Linglib.Features.Case.Grammaticalization
 import Linglib.Features.Case.Source
 import Linglib.Features.Causation
 import Linglib.Features.Clusivity
-import Linglib.Features.Complementation
 import Linglib.Features.ContainmentPair
 import Linglib.Features.CoreferenceStatus
 import Linglib.Features.Definiteness
@@ -2822,6 +2821,7 @@ import Linglib.Syntax.Category.Verb.Selection
 import Linglib.Syntax.Category.Verb.Stem
 import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Chaining
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Syntax.Clause.Construction
 import Linglib.Syntax.Comparative
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure

--- a/Linglib/Data/Complementation/Schema.lean
+++ b/Linglib/Data/Complementation/Schema.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Complementation data schema

--- a/Linglib/Fragments/Adyghe/Clause.lean
+++ b/Linglib/Fragments/Adyghe/Clause.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Adyghe Clausal Embedding Inventory

--- a/Linglib/Fragments/Bulgarian/Clause.lean
+++ b/Linglib/Fragments/Bulgarian/Clause.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Bulgarian Clausal Embedding Inventory

--- a/Linglib/Fragments/Cantonese/Predicates.lean
+++ b/Linglib/Fragments/Cantonese/Predicates.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Cantonese Complement-Taking Predicates

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Causation.Interpretation
 import Linglib.Syntax.Category.Verb.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Morphology.Word.Basic
 
 open Morphology (Word)

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Fragments.Ga.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Features.Causation
 
 /-!

--- a/Linglib/Fragments/Ndebele/Clause.lean
+++ b/Linglib/Fragments/Ndebele/Clause.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Ndebele Clausal Embedding Inventory

--- a/Linglib/Fragments/NezPerce/Clause.lean
+++ b/Linglib/Fragments/NezPerce/Clause.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities
 

--- a/Linglib/Fragments/Washo/Clause.lean
+++ b/Linglib/Fragments/Washo/Clause.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Washo Clausal Embedding Inventory

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -13,7 +13,7 @@ import Linglib.Syntax.Control.Diagnostics
 import Linglib.Studies.Landau2013
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Allotey (2021): Overt Pronouns of Infinitival Predicates of Gã

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Syntax.Minimalist.Agree.Basic
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes
 import Linglib.Studies.Bondarenko2022
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -11,7 +11,7 @@ import Linglib.Syntax.Control.Basic
 import Linglib.Syntax.Control.Diagnostics
 import Linglib.Studies.Landau2013
 import Linglib.Studies.Allotey2021
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 
 /-!
 # Ostrove (2026): Obligatorily Overt PRO in San Martín Peras Mixtec

--- a/Linglib/Syntax/Category/Complementizer/Basic.lean
+++ b/Linglib/Syntax/Category/Complementizer/Basic.lean
@@ -1,6 +1,6 @@
 import Linglib.Data.UD.Basic
 import Linglib.Semantics.Mood.Defs
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Morphology.Word.Basic
 
 open Morphology (Word)

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -1,4 +1,4 @@
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Syntax.Category.Verb.Frame
 import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.Presupposition.Basic

--- a/Linglib/Syntax/Clause/Basic.lean
+++ b/Linglib/Syntax/Clause/Basic.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Mood.Defs
-import Linglib.Features.Complementation
+import Linglib.Syntax.Clause.Complementation
 import Linglib.Features.Case.Basic
 
 /-!

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -15,8 +15,8 @@ enum for infinitival complements (`ControlType`).
 
 The typed complement-frame object, the flat `ComplementType` view, and
 the adapter (`ComplementType.toCoding`) live in
-`Syntax/Category/Verb/Frame.lean`; the verb–complementizer
-compatibility relation in `Syntax/Category/Verb/Takes.lean`.
+`Syntax/Category/Verb/Complement/Basic.lean`; the verb–complementizer
+compatibility relation in `Syntax/Category/Verb/Complement/Takes.lean`.
 `Data/Complementation/Schema.lean` types its rows with these enums —
 the one deliberate theory-layer import in `Data/`, carrying descriptive
 typological vocabulary rather than analytical commitments.

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -13,11 +13,13 @@ complement-taking-predicate classes (`CTPClass`) with their default
 reality status (`RealityStatus`, `ctpRealityStatus`), plus the control
 enum for infinitival complements (`ControlType`).
 
-These enums stay in `Features/` because `Data/Complementation/Schema.lean`
-types its rows with them and the Data layer imports Features only. The
-typed complement-frame object and the flat `ComplementType` view live
-in `Syntax/Category/Verb/Frame.lean`; the adapter (`ComplementType.toCoding`)
-in `Syntax/Category/Verb/Selection.lean`.
+The typed complement-frame object, the flat `ComplementType` view, and
+the adapter (`ComplementType.toCoding`) live in
+`Syntax/Category/Verb/Frame.lean`; the verb–complementizer selection
+relation in `Syntax/Category/Verb/Selection.lean`.
+`Data/Complementation/Schema.lean` types its rows with these enums —
+the one deliberate theory-layer import in `Data/`, carrying descriptive
+typological vocabulary rather than analytical commitments.
 
 ## Main declarations
 

--- a/Linglib/Syntax/Clause/Complementation.lean
+++ b/Linglib/Syntax/Clause/Complementation.lean
@@ -15,8 +15,8 @@ enum for infinitival complements (`ControlType`).
 
 The typed complement-frame object, the flat `ComplementType` view, and
 the adapter (`ComplementType.toCoding`) live in
-`Syntax/Category/Verb/Frame.lean`; the verb–complementizer selection
-relation in `Syntax/Category/Verb/Selection.lean`.
+`Syntax/Category/Verb/Frame.lean`; the verb–complementizer
+compatibility relation in `Syntax/Category/Verb/Takes.lean`.
 `Data/Complementation/Schema.lean` types its rows with these enums —
 the one deliberate theory-layer import in `Data/`, carrying descriptive
 typological vocabulary rather than analytical commitments.


### PR DESCRIPTION
Dissolves the `Features/Complementation.lean` junk drawer into the complementation API's home: `Syntax/Clause/Complementation.lean`, beside the `Clause` class its enums serve. 15 importers swapped.

- `Data/Complementation/Schema.lean` now carries the one deliberate theory-layer import in `Data/` (descriptive typological vocabulary, no analytical commitments) — documented in the moved file's docstring.