### PR TITLE
refactor(Semantics/Spatial): unbundle Trace σ per CEM mixin doctrine

### DIFF
--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -76,6 +76,9 @@ def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
   | .source => .closed
   | .unbounded => .open_
 
+instance : Core.Order.LicensingPipeline PathShape where
+  toBoundedness := PathShape.toBoundedness
+
 /-- Bounded paths are licensed (closed scale → admits degree modification).
     [zwarts-2005]: "to the store" creates a telic VP because the path
     set is bounded, corresponding to a closed scale. -/

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -3,147 +3,81 @@ import Linglib.Semantics.Spatial.Path
 import Linglib.Features.Aktionsart
 
 /-!
-# Spatial Trace Function σ
-[gawron-2009] [krifka-1998] [talmy-2000] [zwarts-2005] [zwarts-winter-2000]
+# Spatial trace function σ
 
-The spatial dimension of event structure: σ maps events to their spatial
-trajectories (paths). This parallels τ (the temporal trace, `Event.runtime`)
-and the thematic-role dimension θ as Krifka/Zwarts trace functions — each a
-`Mereology.IsSumHom` into a different domain (intervals, paths, entities).
+The spatial trace σ maps events to the paths they traverse ([zwarts-2005],
+[gawron-2009]): the spatial member of [krifka-1998]'s family of trace
+dimensions, alongside the temporal trace τ (`Event.runtime`) and the thematic
+dimension θ. Following the mixin convention of `Semantics/Events/CEM.lean`,
+`Trace` carries only the function σ; its structural assumptions — sum
+homomorphism (`Mereology.IsSumHom`) and injectivity — are stated at use sites.
 
-## Three-Dimension Picture
+## Main declarations
 
-```
-Temporal: Events →τ Intervals →dur ℚ (temporal dimension)
-Spatial: Events →σ Paths →dist ℚ (spatial dimension)
-Object: Events →θ Entities →μ ℚ (object dimension)
-```
-
-All three use the same QUA/CUM pullback mechanism via `MereoDim`.
-
-## Key Results
-
-- **Bounded path → telic VP** (§4): QUA path predicates pull back through σ
-  to yield QUA (telic) VP predicates. "Walk to the store" is telic because
-  "to the store" denotes a QUA set of paths (no proper subpath of a
-  to-the-store path is also to-the-store).
-
-- **Unbounded path → atelic VP** (§4): CUM path predicates pull back through σ
-  to yield CUM (atelic) VP predicates. "Walk towards the store" is atelic
-  because "towards the store" denotes a CUM set of paths.
+* `Trace`: the spatial trace σ of an event theory.
+* `Trace.bounded_path_telic`: QUA path predicates pull back through an
+  injective sum-homomorphic σ — *walk to the store* is telic because
+  *to the store* denotes a QUA set of paths ([zwarts-2005]).
+* `Trace.unbounded_path_atelic`: CUM path predicates pull back through a
+  sum-homomorphic σ — *walk towards the store* is atelic.
+* `Trace.pathShapeToTelicity`: the `PathShape → Telicity` bridge, agreeing
+  with scale boundedness (`Trace.telicity_boundedness_agree`).
 -/
 
-open Semantics.Events.CEM
 open Semantics.Spatial.Path
 open Features
-open _root_.Mereology
-
-/-! ### Trace Class -/
+open Mereology
 
 namespace Semantics.Spatial
 
-/-- Spatial trace: maps events to their spatial trajectories.
-    [zwarts-2005], [gawron-2009]: σ(e) is the path traversed in event e.
-    Parallels the temporal trace τ (`Event.runtime`).
-
-    σ is required to be a sum homomorphism: σ(e₁ ⊕ e₂) = σ(e₁) ⊕ σ(e₂).
-    This ensures CUM pulls back through σ (atelic paths → atelic VPs).
-    For QUA pullback, injectivity must be assumed separately
-    (via `σ_mereoDim`), just as for τ. -/
-class Trace (Loc Time : Type*) [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    [SemilatticeSup (Path Loc)] where
-  /-- Extract the spatial path of an event. -/
+/-- Spatial trace: `σ e` is the path traversed in event `e` ([zwarts-2005],
+    [gawron-2009]), parallel to the temporal trace τ (`Event.runtime`).
+    Structural assumptions on σ are stated as mixins at use sites, per
+    `Semantics/Events/CEM.lean`: `[Mereology.IsSumHom st.σ]` for sum
+    preservation, `Function.Injective st.σ` where QUA pullback needs it. -/
+class Trace (Loc Time : Type*) [LinearOrder Time] where
+  /-- The path traversed in an event. -/
   σ : Event Time → Path Loc
-  /-- σ preserves sums: σ(e₁ ⊕ e₂) = σ(e₁) ⊕ σ(e₂). -/
-  σ_map_sup : ∀ (e₁ e₂ : Event Time), σ (e₁ ⊔ e₂) = σ e₁ ⊔ σ e₂
 
-end Semantics.Spatial
+namespace Trace
 
-namespace Semantics.Spatial.Trace
+/-! ### Telicity transfer through σ -/
 
-/-! ### IsSumHom Instance for σ -/
+variable {Loc Time : Type*} [LinearOrder Time] [Event.Mereology Time]
+  [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
+  [st : Trace Loc Time] {P : Path Loc → Prop}
 
-/-- σ as an `IsSumHom` instance, from `Trace.σ_map_sup`.
-    Enables `cum_pullback` to work automatically for σ. -/
-noncomputable instance instIsSumHomσ (Loc Time : Type*) [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    [SemilatticeSup (Path Loc)] [st : Trace Loc Time] :
-    IsSumHom st.σ :=
-  ⟨fun e₁ e₂ => st.σ_map_sup e₁ e₂⟩
+/-- Bounded path predicate → telic VP: QUA pulls back through an injective
+    sum-homomorphic σ. *Walk to the store* is telic because *to the store*
+    denotes a QUA set of paths ([zwarts-2005]). -/
+theorem bounded_path_telic [hσ : IsSumHom st.σ]
+    (hinj : Function.Injective st.σ) (hP : QUA P) : QUA (P ∘ st.σ) :=
+  qua_of_injective_sumHom hσ hinj hP
 
-/-! ### MereoDim for σ -/
-
-/-- σ with injectivity is a MereoDim: the spatial dimension is a
-    mereological morphism, enabling QUA pullback through spatial paths. -/
-theorem σ_mereoDim {Loc Time : Type*} [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    [SemilatticeSup (Path Loc)] [st : Trace Loc Time]
-    (hinj : Function.Injective st.σ) :
-    MereoDim st.σ :=
-  MereoDim.ofInjSumHom hinj
-
-/-! ### Telicity Transfer Through σ -/
-
-/-- Bounded path predicate → telic VP.
-    "Walk to the store" is telic because "to the store" is QUA
-    (no proper subpath of a to-the-store path is also to-the-store)
-    and QUA pulls back through σ.
-    [zwarts-2005]: bounded PPs yield telic VPs. -/
-theorem bounded_path_telic {Loc Time : Type*} [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    [SemilatticeSup (Path Loc)] [st : Trace Loc Time]
-    (hinj : Function.Injective st.σ)
-    {P : Path Loc → Prop} (hP : QUA P) :
-    QUA (P ∘ st.σ) := by
-  haveI := σ_mereoDim hinj
-  exact qua_pullback_mereoDim hP
-
-/-- Unbounded path predicate → atelic VP.
-    "Walk towards the store" is atelic because "towards the store" is CUM
-    and CUM pulls back through the σ sum homomorphism.
-    [zwarts-2005]: unbounded PPs yield atelic VPs. -/
-theorem unbounded_path_atelic {Loc Time : Type*} [LinearOrder Time]
-    [Event.Mereology Time] [ClassicalMereology (Event Time)]
-    [SemilatticeSup (Path Loc)] [st : Trace Loc Time]
-    {P : Path Loc → Prop} (hP : CUM P) :
+/-- Unbounded path predicate → atelic VP: CUM pulls back through a
+    sum-homomorphic σ. *Walk towards the store* is atelic because *towards
+    the store* denotes a CUM set of paths ([zwarts-2005]). -/
+theorem unbounded_path_atelic [hσ : IsSumHom st.σ] (hP : CUM P) :
     CUM (P ∘ st.σ) :=
-  cum_pullback (instIsSumHomσ Loc Time) hP
+  cum_pullback hσ hP
 
-/-! ### PathShape → Telicity Bridge -/
+/-! ### PathShape → Telicity bridge -/
 
-/-- Map PathShape to Telicity: bounded/source → telic, unbounded → atelic.
-    [zwarts-2005]: the boundedness of a directional PP determines
-    whether the VP it creates is telic or atelic.
-
-    This is the spatial analog of the QUA/CUM ↔ telic/atelic correspondence
-    over `Features.VendlerClass.telicity` (see `Features.telic_classes`). -/
+/-- Bounded and source paths yield telic VPs; unbounded paths atelic ones —
+    [zwarts-2005]'s boundedness-telicity generalization at the `PathShape`
+    level, the spatial analog of `Features.VendlerClass.telicity`. -/
 def pathShapeToTelicity : PathShape → Telicity
   | .bounded => .telic
   | .source => .telic
   | .unbounded => .atelic
 
-/-- Bounded paths are telic. -/
-theorem bounded_telic : pathShapeToTelicity .bounded = .telic := rfl
-
-/-- Source paths are telic. -/
-theorem source_telic : pathShapeToTelicity .source = .telic := rfl
-
-/-- Unbounded paths are atelic. -/
-theorem unbounded_atelic : pathShapeToTelicity .unbounded = .atelic := rfl
-
-/-- PathShape telicity agrees with PathShape boundedness licensing:
-    telic ↔ licensed (closed scale), atelic ↔ blocked (open scale).
-    This connects the spatial classification to the scale-theoretic one. -/
+/-- The telicity bridge agrees with the scale-boundedness bridge
+    (`PathShape.toBoundedness`): a path shape is telic iff its boundedness
+    is licensed (closed scale). -/
 theorem telicity_boundedness_agree (s : PathShape) :
     (pathShapeToTelicity s = .telic) ↔ s.toBoundedness.IsLicensed := by
-  cases s <;> simp [pathShapeToTelicity, PathShape.toBoundedness,
-    Core.Order.Boundedness.IsLicensed]
+  cases s <;> decide
 
-/-- LicensingPipeline instance for PathShape via the `pathShapeToTelicity`
-    bridge. Co-located with the bridge per the convention noted in
-    `Core/Scales/Defs.lean` (instances live with their type). -/
-instance : Core.Order.LicensingPipeline PathShape where
-  toBoundedness p := (pathShapeToTelicity p).toMereoTag.toBoundedness
+end Trace
 
-end Semantics.Spatial.Trace
+end Semantics.Spatial

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -259,7 +259,7 @@ open Semantics.Spatial.Path
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
-variable [st : Trace Loc Time]
+variable [st : Trace Loc Time] [IsSumHom st.σ]
 
 /-- Bounded path (QUA) ↦ telic VP via the σ-pullback (K98 §4.5 *walked from X to Y*). -/
 theorem walked_from_to_telic_propositional


### PR DESCRIPTION
Deep audit of `Semantics/Spatial/Trace.lean`. Completes the #896 EventCEM dissolution for σ: `Trace` now carries only the trace function, with `[IsSumHom st.σ]` stated as a mixin at use sites (matching the τ convention documented in CEM.lean).

- delete the `instIsSumHomσ` conversion shim, unconsumed `σ_mereoDim`, and three unconsumed rfl-unpacking theorems; `bounded_path_telic` now goes directly via `qua_of_injective_sumHom`
- `LicensingPipeline PathShape` instance moves to Path.lean with its type, defined directly via `PathShape.toBoundedness` (agreement with the telicity route stays as `telicity_boundedness_agree`)
- module docstring to mathlib register (Main declarations; drops from-memory §-cites); binder telescope hoisted to one `variable` block