### PR TITLE
feat(Semantics/Spatial): Zwarts 2005 path algebra; Spatial namespace

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2767,6 +2767,7 @@ import Linglib.Studies.Zimmermann2026
 import Linglib.Studies.Zompi2023
 import Linglib.Studies.Zuraw2010
 import Linglib.Studies.ZurawHayes2017
+import Linglib.Studies.Zwarts2005
 import Linglib.Studies.ZwickyPullum1983
 import Linglib.Syntax.Agreement.Controller
 import Linglib.Syntax.Agreement.Paradigm

--- a/Linglib/Fragments/Dutch/Adpositions.lean
+++ b/Linglib/Fragments/Dutch/Adpositions.lean
@@ -24,7 +24,7 @@ core properties (R-pronominalization, complement types).
 
 namespace Dutch.Adpositions
 
-open Semantics.Spatial (PathShape)
+open Spatial (PathShape)
 
 /-- Complement types attested for Dutch adpositions.
     [broekhuis-corver-2026] §2.1: nominal (default), PP, adjectival,

--- a/Linglib/Fragments/Dutch/Adpositions.lean
+++ b/Linglib/Fragments/Dutch/Adpositions.lean
@@ -24,7 +24,7 @@ core properties (R-pronominalization, complement types).
 
 namespace Dutch.Adpositions
 
-open Semantics.Spatial.Path (PathShape)
+open Semantics.Spatial (PathShape)
 
 /-- Complement types attested for Dutch adpositions.
     [broekhuis-corver-2026] §2.1: nominal (default), PP, adjectival,

--- a/Linglib/Semantics/ArgumentStructure/LevinClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinClass.lean
@@ -433,7 +433,7 @@ def isVerbOfCreation : LevinClass → Bool
     lexicalize a bounded path. Manner-of-motion verbs (51.3: run, walk)
     are path-neutral — the path comes from a PP complement.
     [talmy-2000]: verb-framed vs. satellite-framed distinction. -/
-def pathSpec : LevinClass → Option Semantics.Spatial.Path.PathShape
+def pathSpec : LevinClass → Option Semantics.Spatial.PathShape
   | .inherentlyDirectedMotion => some .bounded
   | .leave => some .source
   | .mannerOfMotion => none    -- path from PP

--- a/Linglib/Semantics/ArgumentStructure/LevinClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinClass.lean
@@ -433,7 +433,7 @@ def isVerbOfCreation : LevinClass → Bool
     lexicalize a bounded path. Manner-of-motion verbs (51.3: run, walk)
     are path-neutral — the path comes from a PP complement.
     [talmy-2000]: verb-framed vs. satellite-framed distinction. -/
-def pathSpec : LevinClass → Option Semantics.Spatial.PathShape
+def pathSpec : LevinClass → Option Spatial.PathShape
   | .inherentlyDirectedMotion => some .bounded
   | .leave => some .source
   | .mannerOfMotion => none    -- path from PP

--- a/Linglib/Semantics/Events/Adjacency.lean
+++ b/Linglib/Semantics/Events/Adjacency.lean
@@ -35,8 +35,7 @@ def Event.precedes {Time : Type*} [LinearOrder Time]
   e1.runtime.isBefore e2.runtime
 
 /-- Event adjacency is symmetric. -/
-theorem Event.adjacent_symm {Time : Type*} [LinearOrder Time]
-    (e1 e2 : Event Time) :
-    e1.adjacent e2 ↔ e2.adjacent e1 := by
-  unfold Event.adjacent
-  exact ⟨Or.symm, Or.symm⟩
+theorem Event.adjacent_comm {Time : Type*} [LinearOrder Time]
+    {e1 e2 : Event Time} :
+    e1.adjacent e2 ↔ e2.adjacent e1 :=
+  or_comm

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -1,34 +1,30 @@
 import Linglib.Core.Order.Boundedness
 
 /-!
-# Spatial Path Infrastructure
-[gawron-2009] [talmy-2000] [zwarts-2005] [zwarts-winter-2000]
+# Spatial paths
 
-Framework-agnostic types for spatial paths and their boundedness
-classification. Paths are the spatial analog of temporal intervals
-(`NonemptyInterval`): directed stretches of space between locations.
+Directed trajectories between locations: the spatial analog of temporal
+intervals. [zwarts-2005]'s aspectual generalization — bounded directional PPs
+(*to the store*) create telic VPs, unbounded ones (*towards the store*) atelic
+VPs — enters through the `PathShape` classification and its bridge into scale
+boundedness; the event-side telicity transfer lives in
+`Semantics/Spatial/Trace.lean`.
 
-The key linguistic insight: the boundedness of a directional
-PP determines whether the VP it creates is telic or atelic. Bounded PPs
-("to the store") yield telic VPs; unbounded PPs ("towards the store")
-yield atelic VPs. This parallels the QUA/CUM mereological classification
-from `Semantics/Mereology.lean`.
+## Main declarations
 
-## Sections
-
-1. Path Type
-2. Path Shape (Boundedness Classification)
-3. PathShape ↔ Scale Boundedness Bridge
-
+* `Path`: a directed trajectory with `source` and `goal` locations
+  ([talmy-2000]'s path component of a motion event).
+* `PathShape`: [zwarts-2005]'s boundedness classification of directional PPs
+  (goal-, direction-, and origin-oriented), with `PathShape.toBoundedness`
+  into `Core.Order.Boundedness`.
+* `Path.adjacent`: endpoint-sharing spatial adjacency ([krifka-1998]), the
+  spatial half of the movement relations in `Studies/Krifka1998.lean`.
 -/
 
-namespace Semantics.Spatial.Path
+namespace Semantics.Spatial
 
--- ════════════════════════════════════════════════════
--- § 1. Path Type
--- ════════════════════════════════════════════════════
+/-! ### Paths -/
 
-set_option linter.dupNamespace false in
 /-- Spatial path: a directed trajectory between locations.
     [zwarts-2005]: paths are directed stretches of space with a
     source (starting point) and goal (endpoint).
@@ -42,9 +38,7 @@ structure Path (Loc : Type*) where
   /-- Ending location of the path. -/
   goal : Loc
 
--- ════════════════════════════════════════════════════
--- § 2. Path Shape (Boundedness Classification)
--- ════════════════════════════════════════════════════
+/-! ### Path shape -/
 
 /-- Directional PP boundedness classification.
     [zwarts-2005]: the boundedness of a directional PP determines
@@ -64,13 +58,8 @@ inductive PathShape where
   | source
   deriving DecidableEq, Repr
 
--- ════════════════════════════════════════════════════
--- § 3. PathShape ↔ Scale Boundedness Bridge
--- ════════════════════════════════════════════════════
-
 /-- Path shape to scale boundedness: bounded/source paths correspond
-    to closed scales, unbounded paths to open scales. Parallel to
-    `quaBoundedness`/`cumBoundedness` in `Core/MereoDim.lean` §1. -/
+    to closed scales, unbounded paths to open scales. -/
 def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
   | .bounded => .closed
   | .source => .closed
@@ -79,51 +68,24 @@ def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
 instance : Core.Order.LicensingPipeline PathShape where
   toBoundedness := PathShape.toBoundedness
 
-/-- Bounded paths are licensed (closed scale → admits degree modification).
-    [zwarts-2005]: "to the store" creates a telic VP because the path
-    set is bounded, corresponding to a closed scale. -/
-theorem bounded_path_licensed :
-    PathShape.bounded.toBoundedness.IsLicensed := trivial
+/-! ### Adjacency -/
 
-/-- Source paths are licensed (closed scale at the origin end). -/
-theorem source_path_licensed :
-    PathShape.source.toBoundedness.IsLicensed := trivial
-
-/-- Unbounded paths are blocked (open scale → no inherent endpoint).
-    [zwarts-2005]: "towards the store" creates an atelic VP because
-    the path set is unbounded, corresponding to an open scale. -/
-theorem unbounded_path_blocked :
-    ¬ PathShape.unbounded.toBoundedness.IsLicensed := id
-
--- ════════════════════════════════════════════════════
--- § 4. Path Adjacency
--- ════════════════════════════════════════════════════
-
-set_option linter.dupNamespace false in
-/-- Two paths are spatially adjacent (`∞_H` in [krifka-1998]'s
-    notation) if they share an endpoint: one's goal is the other's
-    source. The general adjacency primitive ([krifka-1998] §2.3
-    eq. 14) is axiomatized abstractly on a part structure; for the
-    concrete `Path Loc` the share-an-endpoint definition is the
-    intended instance. Used by K98 §4 movement-relation definitions
-    (inlined in `Studies/Krifka1998.lean` Part II)
-    to relate spatial adjacency on paths to temporal adjacency on events. -/
+/-- Two paths are spatially adjacent (`∞_H` in [krifka-1998]'s notation)
+    if they share an endpoint: one's goal is the other's source.
+    Instantiates K98's abstract adjacency primitive for concrete paths;
+    the spatial half of the movement relations in `Studies/Krifka1998.lean`. -/
 def Path.adjacent {Loc : Type*} (p1 p2 : Path Loc) : Prop :=
   p1.goal = p2.source ∨ p2.goal = p1.source
 
-set_option linter.dupNamespace false in
 /-- Path adjacency is symmetric. -/
-theorem Path.adjacent_symm {Loc : Type*} (p1 p2 : Path Loc) :
-    p1.adjacent p2 ↔ p2.adjacent p1 := by
-  unfold Path.adjacent
-  exact ⟨Or.symm, Or.symm⟩
+theorem Path.adjacent_comm {Loc : Type*} {p1 p2 : Path Loc} :
+    p1.adjacent p2 ↔ p2.adjacent p1 :=
+  or_comm
 
-set_option linter.dupNamespace false in
-/-- A path is adjacent to itself when its source equals its goal
-    (degenerate single-point path). Trivial corner case used in the
-    K98 §4.5 SOURCE/GOAL definitions. -/
-theorem Path.adjacent_trivial {Loc : Type*} (p : Path Loc)
-    (h : p.source = p.goal) : p.adjacent p :=
-  Or.inl h.symm
+/-- A path is adjacent to itself iff it is a single-point loop. -/
+@[simp]
+theorem Path.adjacent_self {Loc : Type*} {p : Path Loc} :
+    p.adjacent p ↔ p.goal = p.source :=
+  or_self_iff
 
-end Semantics.Spatial.Path
+end Semantics.Spatial

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -21,7 +21,7 @@ boundedness; the event-side telicity transfer lives in
   spatial half of the movement relations in `Studies/Krifka1998.lean`.
 -/
 
-namespace Semantics.Spatial
+namespace Spatial
 
 /-! ### Paths -/
 
@@ -49,9 +49,12 @@ structure Path (Loc : Type*) where
     - `source`: origin-oriented ("from the store", "out of the room")
 
     This classifies the *set of paths* denoted by a PP, not individual
-    paths. "To X" denotes {p | p.goal = X} — a QUA set (no proper
-    subpath of a to-X path is also to-X). "Towards X" denotes a CUM
-    set (concatenating two towards-X paths gives another). -/
+    paths, by closure under path concatenation: "towards X" denotes a
+    cumulative set (concatenating two towards-X paths gives another),
+    while "to X" strictly read denotes a set with no concatenable pairs
+    at all. [zwarts-2005] shows bounded PPs are *not* quantized — a to-X
+    path has proper to-X subpaths — so boundedness is non-cumulativity,
+    not `Mereology.QUA`; see `Studies/Zwarts2005.lean`. -/
 inductive PathShape where
   | bounded
   | unbounded
@@ -88,4 +91,4 @@ theorem Path.adjacent_self {Loc : Type*} {p : Path Loc} :
     p.adjacent p ↔ p.goal = p.source :=
   or_self_iff
 
-end Semantics.Spatial
+end Spatial

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -1,42 +1,189 @@
 import Linglib.Core.Order.Boundedness
+import Mathlib.Data.List.Infix
 
 /-!
 # Spatial paths
 
-Directed trajectories between locations: the spatial analog of temporal
-intervals. [zwarts-2005]'s aspectual generalization — bounded directional PPs
-(*to the store*) create telic VPs, unbounded ones (*towards the store*) atelic
-VPs — enters through the `PathShape` classification and its bridge into scale
-boundedness; the event-side telicity transfer lives in
-`Semantics/Spatial/Trace.lean`.
+Directed trajectories between locations, as finite location sequences — the
+spatial analog of temporal intervals, carrying [zwarts-2005]'s Appendix A path
+algebra in discrete form: partial concatenation (defined only head-to-tail),
+the subpath order, and endpoint-sharing adjacency ([krifka-1998]). Zwarts's
+own paths are continuous constant-speed curves `[0,1] → ℝ³` — mathlib's
+topological `_root_.Path`, whose `trans` reparametrizes, so his algebra would
+need the arc-length quotient there; he notes the constructive
+sequence-of-places route is equally compatible with the algebra, and it keeps
+every operation computable.
 
 ## Main declarations
 
-* `Path`: a directed trajectory with `source` and `goal` locations
-  ([talmy-2000]'s path component of a motion event).
-* `PathShape`: [zwarts-2005]'s boundedness classification of directional PPs
-  (goal-, direction-, and origin-oriented), with `PathShape.toBoundedness`
-  into `Core.Order.Boundedness`.
+* `Path`: a directed trajectory — `source` plus later `steps`, with endpoint
+  `Path.goal`; `Path.const` is the constant path, the identity of
+  concatenation and least in the subpath order.
+* `Path.IsConcat`: concatenation as in [zwarts-2005]'s (67) — `r` is `p + q`,
+  defined only when `p` ends where `q` starts; associative, neither
+  commutative nor idempotent.
+* `Path.Subpath`: the subpath order of (68) — `p ≤ q` iff `r + p + r′ = q`
+  for some `r`, `r′`; equivalently infix-hood of point sequences
+  (`Path.subpath_iff_infix`), whence a scoped `PartialOrder`
+  (`open scoped Spatial.Path`).
 * `Path.adjacent`: endpoint-sharing spatial adjacency ([krifka-1998]), the
   spatial half of the movement relations in `Studies/Krifka1998.lean`.
+* `PathShape`: [zwarts-2005]'s boundedness classification of directional PPs,
+  with `PathShape.toBoundedness` into `Core.Order.Boundedness`.
 -/
 
 namespace Spatial
 
-/-! ### Paths -/
-
-/-- Spatial path: a directed trajectory between locations.
-    [zwarts-2005]: paths are directed stretches of space with a
-    source (starting point) and goal (endpoint).
-
-    Parallels `NonemptyInterval` for the temporal domain. Unlike
-    intervals, paths have no `valid : source ≤ goal` constraint
-    because spatial locations lack a canonical linear ordering. -/
+/-- Spatial path: a directed trajectory through its visited locations, as a
+    start plus later stops ([zwarts-2005]: directed stretches of space with a
+    source and a goal). Parallels `NonemptyInterval` for the temporal
+    domain. -/
 structure Path (Loc : Type*) where
-  /-- Starting location of the path. -/
+  /-- The starting location p(0). -/
   source : Loc
-  /-- Ending location of the path. -/
-  goal : Loc
+  /-- The later locations, ending at p(1); empty for a constant path. -/
+  steps : List Loc
+  deriving DecidableEq, Repr
+
+namespace Path
+
+variable {Loc : Type*}
+
+/-- The endpoint p(1). -/
+def goal (p : Path Loc) : Loc := p.steps.getLastD p.source
+
+/-- The full point sequence p(0) … p(1). -/
+def points (p : Path Loc) : List Loc := p.source :: p.steps
+
+/-- The constant path at a location. -/
+def const (l : Loc) : Path Loc := ⟨l, []⟩
+
+@[simp] theorem goal_const (l : Loc) : (const l).goal = l := rfl
+
+theorem points_ne_nil (p : Path Loc) : p.points ≠ [] := List.cons_ne_nil _ _
+
+theorem points_injective : Function.Injective (points : Path Loc → List Loc) := by
+  rintro ⟨s, l⟩ ⟨s', l'⟩ h
+  simpa [points] using h
+
+private theorem getLastD_append {α : Type*} (l₁ l₂ : List α) (d : α) :
+    (l₁ ++ l₂).getLastD d = l₂.getLastD (l₁.getLastD d) := by
+  simp only [List.getLastD_eq_getLast?, List.getLast?_append]
+  cases l₂.getLast? <;> simp
+
+/-! ### Concatenation and subpaths -/
+
+/-- (67) of [zwarts-2005]: `r` is the concatenation `p + q`. Partial —
+    defined only when `p` ends where `q` starts. Associative, neither
+    commutative nor idempotent. -/
+def IsConcat (p q r : Path Loc) : Prop :=
+  p.goal = q.source ∧ r = ⟨p.source, p.steps ++ q.steps⟩
+
+theorem IsConcat.source_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.source = p.source := by rw [h.2]
+
+theorem IsConcat.goal_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.goal = q.goal := by
+  obtain ⟨h1, rfl⟩ := h
+  show (p.steps ++ q.steps).getLastD p.source = q.goal
+  rw [getLastD_append]
+  show q.steps.getLastD p.goal = q.goal
+  rw [h1]; rfl
+
+theorem IsConcat.points_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.points = p.points ++ q.steps := by
+  rw [h.2]; simp [points]
+
+/-- Constant paths concatenate with themselves to themselves: they are the
+    identity elements of concatenation. -/
+theorem isConcat_const (l : Loc) : IsConcat (const l) (const l) (const l) :=
+  ⟨rfl, rfl⟩
+
+/-- (68) of [zwarts-2005]: `p` is a subpath of `q` iff `r + p + r′ = q` for
+    some `r`, `r′`. -/
+def Subpath (p q : Path Loc) : Prop :=
+  ∃ r r' m, IsConcat r p m ∧ IsConcat m r' q
+
+/-- The working characterization: subpath-hood is infix-hood of point
+    sequences. -/
+theorem subpath_iff_infix {p q : Path Loc} :
+    Subpath p q ↔ p.points <:+: q.points := by
+  constructor
+  · rintro ⟨r, r', m, hrp, hmq⟩
+    refine ⟨r.points.dropLast, r'.steps, ?_⟩
+    have hgoal : r.points.getLast r.points_ne_nil = p.source := by
+      have : r.points.getLast r.points_ne_nil = r.goal := by
+        cases h : r.steps <;>
+          simp [points, goal, h, List.getLast_cons,
+            List.getLastD_eq_getLast?, List.getLast?_eq_some_getLast]
+      rw [this, hrp.1]
+    calc r.points.dropLast ++ p.points ++ r'.steps
+        = (r.points.dropLast ++ [p.source]) ++ p.steps ++ r'.steps := by
+          simp [points]
+      _ = r.points ++ p.steps ++ r'.steps := by
+          rw [← hgoal, List.dropLast_append_getLast]
+      _ = q.points := by rw [hmq.points_eq, hrp.points_eq]
+  · rintro ⟨A, B, hAB⟩
+    match A with
+    | [] =>
+      obtain ⟨hs, hst⟩ : q.source = p.source ∧ q.steps = p.steps ++ B := by
+        simpa [points, List.cons.injEq] using hAB.symm
+      exact ⟨const p.source, ⟨p.goal, B⟩, p,
+        ⟨rfl, by cases p; rfl⟩, ⟨rfl, by cases q; simp_all [points]⟩⟩
+    | a :: A' =>
+      obtain ⟨hs, hst⟩ : q.source = a ∧ q.steps = A' ++ (p.source :: p.steps) ++ B := by
+        simpa [points, List.cons.injEq, List.append_assoc] using hAB.symm
+      refine ⟨⟨a, A' ++ [p.source]⟩, ⟨p.goal, B⟩,
+        ⟨a, (A' ++ [p.source]) ++ p.steps⟩,
+        ⟨by simp [goal], rfl⟩, ⟨?_, ?_⟩⟩
+      · show ((A' ++ [p.source]) ++ p.steps).getLastD a = p.goal
+        rw [getLastD_append, getLastD_append]
+        rfl
+      · cases q
+        simp_all [points, List.append_assoc]
+
+/-- The subpath order as an order instance — **scoped**, because path sets
+    are also studied under a rival total lattice sum ([krifka-1998]'s part
+    structures, hypothesized as `SemilatticeSup (Path Loc)` in
+    `Spatial/Trace.lean`); activate with `open scoped Spatial.Path`. -/
+scoped instance instSubpathOrder : PartialOrder (Path Loc) where
+  le := Subpath
+  le_refl p := subpath_iff_infix.mpr (List.infix_refl _)
+  le_trans _ _ _ hab hbc := subpath_iff_infix.mpr
+    ((subpath_iff_infix.mp hab).trans (subpath_iff_infix.mp hbc))
+  le_antisymm _ _ hab hba := points_injective
+    (List.infix_antisymm (subpath_iff_infix.mp hab) (subpath_iff_infix.mp hba))
+
+/-- Constant paths are least: `const p.source ≤ p`. -/
+theorem const_source_le (p : Path Loc) : const p.source ≤ p :=
+  subpath_iff_infix.mpr ⟨[], p.steps, rfl⟩
+
+/-! ### Adjacency -/
+
+/-- Two paths are spatially adjacent (`∞_H` in [krifka-1998]'s notation)
+    if they share an endpoint: one's goal is the other's source.
+    Instantiates K98's abstract adjacency primitive for concrete paths;
+    the spatial half of the movement relations in `Studies/Krifka1998.lean`. -/
+def adjacent (p1 p2 : Path Loc) : Prop :=
+  p1.goal = p2.source ∨ p2.goal = p1.source
+
+/-- Path adjacency is symmetric. -/
+theorem adjacent_comm {p1 p2 : Path Loc} :
+    p1.adjacent p2 ↔ p2.adjacent p1 :=
+  or_comm
+
+/-- A path is adjacent to itself iff it is a loop. -/
+@[simp]
+theorem adjacent_self {p : Path Loc} :
+    p.adjacent p ↔ p.goal = p.source :=
+  or_self_iff
+
+/-- Concatenable paths are adjacent. -/
+theorem IsConcat.adjacent {p q r : Path Loc} (h : IsConcat p q r) :
+    p.adjacent q :=
+  Or.inl h.1
+
+end Path
 
 /-! ### Path shape -/
 
@@ -70,25 +217,5 @@ def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
 
 instance : Core.Order.LicensingPipeline PathShape where
   toBoundedness := PathShape.toBoundedness
-
-/-! ### Adjacency -/
-
-/-- Two paths are spatially adjacent (`∞_H` in [krifka-1998]'s notation)
-    if they share an endpoint: one's goal is the other's source.
-    Instantiates K98's abstract adjacency primitive for concrete paths;
-    the spatial half of the movement relations in `Studies/Krifka1998.lean`. -/
-def Path.adjacent {Loc : Type*} (p1 p2 : Path Loc) : Prop :=
-  p1.goal = p2.source ∨ p2.goal = p1.source
-
-/-- Path adjacency is symmetric. -/
-theorem Path.adjacent_comm {Loc : Type*} {p1 p2 : Path Loc} :
-    p1.adjacent p2 ↔ p2.adjacent p1 :=
-  or_comm
-
-/-- A path is adjacent to itself iff it is a single-point loop. -/
-@[simp]
-theorem Path.adjacent_self {Loc : Type*} {p : Path Loc} :
-    p.adjacent p ↔ p.goal = p.source :=
-  or_self_iff
 
 end Spatial

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -24,7 +24,6 @@ homomorphism (`Mereology.IsSumHom`) and injectivity — are stated at use sites.
   with scale boundedness (`Trace.telicity_boundedness_agree`).
 -/
 
-open Semantics.Spatial.Path
 open Features
 open Mereology
 

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -27,7 +27,7 @@ homomorphism (`Mereology.IsSumHom`) and injectivity — are stated at use sites.
 open Features
 open Mereology
 
-namespace Semantics.Spatial
+namespace Spatial
 
 /-- Spatial trace: `σ e` is the path traversed in event `e` ([zwarts-2005],
     [gawron-2009]), parallel to the temporal trace τ (`Event.runtime`).
@@ -47,8 +47,11 @@ variable {Loc Time : Type*} [LinearOrder Time] [Event.Mereology Time]
   [st : Trace Loc Time] {P : Path Loc → Prop}
 
 /-- Bounded path predicate → telic VP: QUA pulls back through an injective
-    sum-homomorphic σ. *Walk to the store* is telic because *to the store*
-    denotes a QUA set of paths ([zwarts-2005]). -/
+    sum-homomorphic σ — [krifka-1998]'s quantization route to telicity,
+    stated for path predicates. [zwarts-2005] argues bounded PPs are not in
+    fact quantized (bounded = non-cumulative instead; see
+    `Studies/Zwarts2005.lean`), so this theorem records the Krifka-style
+    analysis, applicable when a path predicate is QUA. -/
 theorem bounded_path_telic [hσ : IsSumHom st.σ]
     (hinj : Function.Injective st.σ) (hP : QUA P) : QUA (P ∘ st.σ) :=
   qua_of_injective_sumHom hσ hinj hP
@@ -79,4 +82,4 @@ theorem telicity_boundedness_agree (s : PathShape) :
 
 end Trace
 
-end Semantics.Spatial
+end Spatial

--- a/Linglib/Studies/BroekhuisCorver2026.lean
+++ b/Linglib/Studies/BroekhuisCorver2026.lean
@@ -37,8 +37,8 @@ not whether F is overt. See `MovedConstituent`.
 
 - `Dutch.Adpositions`: lexical inventory
 - `Minimalist.Formal.ExtendedProjection`: Place/Path in EP
-- `Semantics.Spatial.PathShape`: bounded/unbounded/source classification
-- `Semantics.Spatial.Trace`: PathShape → telicity
+- `Spatial.PathShape`: bounded/unbounded/source classification
+- `Spatial.Trace`: PathShape → telicity
 - `AuxiliarySelection` auxiliary selection: Dutch *zijn*/*hebben* split
 - `Dendikken1995`: particles as P heads
 - `Data.WALS.Features.F85A`: cross-linguistic adposition order
@@ -48,7 +48,7 @@ namespace BroekhuisCorver2026
 
 open Dutch.Adpositions
 open Minimalist
-open Semantics.Spatial (PathShape)
+open Spatial (PathShape)
 
 -- ════════════════════════════════════════════════════
 -- § 1. PP-internal structure and surface orders
@@ -190,7 +190,7 @@ theorem place_path_family :
     This connects through `PathShape → telicity → unaccusativity →
     auxiliary selection`. -/
 
-open Semantics.Spatial.Trace (pathShapeToTelicity)
+open Spatial.Trace (pathShapeToTelicity)
 open ArgumentStructure.AuxiliarySelection
 
 /-- All directional adpositions in the inventory carry a PathShape. -/

--- a/Linglib/Studies/BroekhuisCorver2026.lean
+++ b/Linglib/Studies/BroekhuisCorver2026.lean
@@ -37,7 +37,7 @@ not whether F is overt. See `MovedConstituent`.
 
 - `Dutch.Adpositions`: lexical inventory
 - `Minimalist.Formal.ExtendedProjection`: Place/Path in EP
-- `Semantics.Spatial.Path.PathShape`: bounded/unbounded/source classification
+- `Semantics.Spatial.PathShape`: bounded/unbounded/source classification
 - `Semantics.Spatial.Trace`: PathShape → telicity
 - `AuxiliarySelection` auxiliary selection: Dutch *zijn*/*hebben* split
 - `Dendikken1995`: particles as P heads
@@ -48,7 +48,7 @@ namespace BroekhuisCorver2026
 
 open Dutch.Adpositions
 open Minimalist
-open Semantics.Spatial.Path (PathShape)
+open Semantics.Spatial (PathShape)
 
 -- ════════════════════════════════════════════════════
 -- § 1. PP-internal structure and surface orders

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -255,7 +255,7 @@ end K98PropositionalSubstrate
 
 section SpatialTracePullback
 
-open Semantics.Spatial.Path
+open Semantics.Spatial
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
@@ -281,7 +281,7 @@ end SpatialTracePullback
 section MotionData
 
 open Data.Examples (LinguisticExample)
-open Semantics.Spatial.Path (PathShape)
+open Semantics.Spatial (PathShape)
 open Semantics.Spatial.Trace (pathShapeToTelicity)
 
 /-- A motion VP datum: the path shape K98 assigns and the telicity it predicts. -/
@@ -339,7 +339,7 @@ end Expansiveness
 
 section MovementInstances
 
-open Semantics.Spatial.Path
+open Semantics.Spatial
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)]

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -53,7 +53,7 @@ open _root_.Mereology
 open ArgumentStructure (IsCumThetaVerb)
 open Semantics.Aspect.Incremental (SINC IsSincVerb)
 open Semantics.Aspect.Cumulativity (VP cum_propagation qua_propagation)
-open Semantics.Spatial (Trace)
+open Spatial (Trace)
 
 variable {α β : Type*}
 
@@ -255,7 +255,7 @@ end K98PropositionalSubstrate
 
 section SpatialTracePullback
 
-open Semantics.Spatial
+open Spatial
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
@@ -281,8 +281,8 @@ end SpatialTracePullback
 section MotionData
 
 open Data.Examples (LinguisticExample)
-open Semantics.Spatial (PathShape)
-open Semantics.Spatial.Trace (pathShapeToTelicity)
+open Spatial (PathShape)
+open Spatial.Trace (pathShapeToTelicity)
 
 /-- A motion VP datum: the path shape K98 assigns and the telicity it predicts. -/
 structure MotionDatum where
@@ -339,7 +339,7 @@ end Expansiveness
 
 section MovementInstances
 
-open Semantics.Spatial
+open Spatial
 
 variable {Loc Time : Type*} [LinearOrder Time]
 variable [Event.Mereology Time] [ClassicalMereology (Event Time)]

--- a/Linglib/Studies/Zwarts2005.lean
+++ b/Linglib/Studies/Zwarts2005.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Spatial.Trace
-import Mathlib.Data.List.Infix
 
 /-!
 # [zwarts-2005] *Prepositional Aspect and the Algebra of Paths*
@@ -7,17 +6,13 @@ import Mathlib.Data.List.Infix
 Directional-PP denotations are sets of paths; what distinguishes telic PPs
 (*to the house*) from atelic PPs (*towards the house*) is closure under the
 **partial** concatenation operation: atelic PPs are cumulative, telic PPs are
-not (21). The paper's Appendix A path algebra ⟨P, +⟩ is formalized here in
-discrete form — paths as location sequences rather than continuous
-constant-speed curves; Zwarts notes (§2) that the axiomatic and constructive
-routes are equally compatible with the algebra.
+not (21). The paper's Appendix A path algebra — `Spatial.Path` with
+`Path.IsConcat` (67) and the subpath order (68) — lives in
+`Semantics/Spatial/Path.lean`; this file formalizes the aspectual system
+built on it.
 
 ## Main definitions
 
-* `Path`, `Path.IsConcat` — the algebra: concatenation (67) is defined only
-  when the first path ends where the second starts; the subpath order (68) is
-  `Subpath`, with `subpath_iff_infix` the working characterization and a
-  `PartialOrder` instance.
 * `Cumulative` (17b, with the existence clause of fn. 7), `Bounded` (21) —
   stated over any ternary concatenation relation, since Appendix A pairs the
   path algebra with an event algebra of the same shape.
@@ -58,141 +53,10 @@ routes are equally compatible with the algebra.
 namespace Zwarts2005
 
 open Mereology (QUA)
+open Spatial
+open scoped Spatial.Path
 
 variable {Loc α : Type*}
-
-/-! ### The path algebra (Appendix A) -/
-
-/-- A path in discrete form: the visited locations, as a start plus later
-    stops. Zwarts's paths are continuous constant-speed curves `[0,1] → ℝ³`;
-    the sequence rendering keeps the algebra — endpoints, partial
-    concatenation, subpaths — while staying computable. -/
-structure Path (Loc : Type*) where
-  /-- The starting location p(0). -/
-  source : Loc
-  /-- The later locations, ending at p(1); empty for a constant path. -/
-  steps : List Loc
-  deriving DecidableEq, Repr
-
-namespace Path
-
-/-- The endpoint p(1). -/
-def goal (p : Path Loc) : Loc := p.steps.getLastD p.source
-
-/-- The full point sequence p(0) … p(1). -/
-def points (p : Path Loc) : List Loc := p.source :: p.steps
-
-/-- The constant path at a location: the identity elements of concatenation
-    and the least elements of the subpath order (Appendix A). -/
-def const (l : Loc) : Path Loc := ⟨l, []⟩
-
-@[simp] theorem goal_const (l : Loc) : (const l).goal = l := rfl
-
-theorem points_ne_nil (p : Path Loc) : p.points ≠ [] := List.cons_ne_nil _ _
-
-theorem points_injective : Function.Injective (points : Path Loc → List Loc) := by
-  rintro ⟨s, l⟩ ⟨s', l'⟩ h
-  simpa [points] using h
-
-private theorem getLastD_append (l₁ l₂ : List α) (d : α) :
-    (l₁ ++ l₂).getLastD d = l₂.getLastD (l₁.getLastD d) := by
-  simp only [List.getLastD_eq_getLast?, List.getLast?_append]
-  cases l₂.getLast? <;> simp
-
-/-- (67): `r` is the concatenation `p + q`. Partial — defined only when `p`
-    ends where `q` starts. Associative, neither commutative nor idempotent
-    (16). -/
-def IsConcat (p q r : Path Loc) : Prop :=
-  p.goal = q.source ∧ r = ⟨p.source, p.steps ++ q.steps⟩
-
-theorem IsConcat.source_eq {p q r : Path Loc} (h : IsConcat p q r) :
-    r.source = p.source := by rw [h.2]
-
-theorem IsConcat.goal_eq {p q r : Path Loc} (h : IsConcat p q r) :
-    r.goal = q.goal := by
-  obtain ⟨h1, rfl⟩ := h
-  show (p.steps ++ q.steps).getLastD p.source = q.goal
-  rw [getLastD_append]
-  show q.steps.getLastD p.goal = q.goal
-  rw [h1]; rfl
-
-theorem IsConcat.points_eq {p q r : Path Loc} (h : IsConcat p q r) :
-    r.points = p.points ++ q.steps := by
-  rw [h.2]; simp [points]
-
-/-- Every pair of constant paths at the same point concatenates to itself. -/
-theorem isConcat_const (l : Loc) : IsConcat (const l) (const l) (const l) :=
-  ⟨rfl, rfl⟩
-
-/-! ### The subpath order (68) -/
-
-/-- (68): `p` is a subpath of `q` iff `r + p + r′ = q` for some `r`, `r′`. -/
-def Subpath (p q : Path Loc) : Prop :=
-  ∃ r r' m, IsConcat r p m ∧ IsConcat m r' q
-
-/-- The working characterization: subpath-hood is infix-hood of point
-    sequences. -/
-theorem subpath_iff_infix {p q : Path Loc} :
-    Subpath p q ↔ p.points <:+: q.points := by
-  constructor
-  · rintro ⟨r, r', m, hrp, hmq⟩
-    refine ⟨r.points.dropLast, r'.steps, ?_⟩
-    have hgoal : r.points.getLast r.points_ne_nil = p.source := by
-      have : r.points.getLast r.points_ne_nil = r.goal := by
-        cases h : r.steps <;>
-          simp [points, goal, h, List.getLast_cons,
-            List.getLastD_eq_getLast?, List.getLast?_eq_some_getLast]
-      rw [this, hrp.1]
-    calc r.points.dropLast ++ p.points ++ r'.steps
-        = (r.points.dropLast ++ [p.source]) ++ p.steps ++ r'.steps := by
-          simp [points]
-      _ = r.points ++ p.steps ++ r'.steps := by
-          rw [← hgoal, List.dropLast_append_getLast]
-      _ = q.points := by rw [hmq.points_eq, hrp.points_eq]
-  · rintro ⟨A, B, hAB⟩
-    match A with
-    | [] =>
-      obtain ⟨hs, hst⟩ : q.source = p.source ∧ q.steps = p.steps ++ B := by
-        simpa [points, List.cons.injEq] using hAB.symm
-      exact ⟨const p.source, ⟨p.goal, B⟩, p,
-        ⟨rfl, by cases p; rfl⟩, ⟨rfl, by cases q; simp_all [points]⟩⟩
-    | a :: A' =>
-      obtain ⟨hs, hst⟩ : q.source = a ∧ q.steps = A' ++ (p.source :: p.steps) ++ B := by
-        simpa [points, List.cons.injEq, List.append_assoc] using hAB.symm
-      refine ⟨⟨a, A' ++ [p.source]⟩, ⟨p.goal, B⟩,
-        ⟨a, (A' ++ [p.source]) ++ p.steps⟩,
-        ⟨by simp [goal], rfl⟩,
-        ⟨?_, ?_⟩⟩
-      · show ((A' ++ [p.source]) ++ p.steps).getLastD a = p.goal
-        rw [getLastD_append, getLastD_append]
-        rfl
-      · cases q
-        simp_all [points, List.append_assoc]
-
-instance : PartialOrder (Path Loc) where
-  le := Subpath
-  le_refl p := subpath_iff_infix.mpr (List.infix_refl _)
-  le_trans _ _ _ hab hbc := subpath_iff_infix.mpr
-    ((subpath_iff_infix.mp hab).trans (subpath_iff_infix.mp hbc))
-  le_antisymm _ _ hab hba := points_injective
-    (List.infix_antisymm (subpath_iff_infix.mp hab) (subpath_iff_infix.mp hba))
-
-/-- Constant paths are least: `const p.source ≤ p`. -/
-theorem const_source_le (p : Path Loc) : const p.source ≤ p :=
-  subpath_iff_infix.mpr ⟨[], p.steps, rfl⟩
-
-/-- Bridge to the endpoint skeleton `Spatial.Path` of the substrate. -/
-def toSpatial (p : Path Loc) : Spatial.Path Loc := ⟨p.source, p.goal⟩
-
-/-- Concatenable paths are adjacent in the substrate's endpoint-sharing
-    sense (`Spatial.Path.adjacent`). -/
-theorem IsConcat.toSpatial_adjacent {p q r : Path Loc} (h : IsConcat p q r) :
-    p.toSpatial.adjacent q.toSpatial :=
-  Or.inl h.1
-
-end Path
-
-open Path
 
 /-! ### Cumulativity and boundedness (17b), (21)
 
@@ -267,7 +131,7 @@ def weakTo (x : Loc) : Set (Path Loc) := {p | p.goal = x}
     *to*/*into*, which is Zwarts's argument for the strict single-phase
     definitions (34)–(35). -/
 theorem weakTo_cumulative (x : Loc) : Cumulative Path.IsConcat (weakTo x) :=
-  ⟨⟨_, goal_const x, _, goal_const x, _, isConcat_const x⟩,
+  ⟨⟨_, Path.goal_const x, _, Path.goal_const x, _, Path.isConcat_const x⟩,
     fun _ _ _ hq _ hr => hr.goal_eq.trans hq⟩
 
 /-- The endpoint content of the strict goal PP (36): the path ends at the
@@ -351,7 +215,7 @@ theorem toPP_not_quantized : ¬ QUA (· ∈ toPP (0 : ℚ)) := by
   have hp : (⟨1, [0]⟩ : Path ℚ) ∈ toPP 0 := ⟨rfl, by norm_num⟩
   have hq : (⟨2, [1, 0]⟩ : Path ℚ) ∈ toPP 0 := ⟨rfl, by norm_num⟩
   have hle : (⟨1, [0]⟩ : Path ℚ) ≤ ⟨2, [1, 0]⟩ :=
-    subpath_iff_infix.mpr ⟨[2], [], rfl⟩
+    Path.subpath_iff_infix.mpr ⟨[2], [], rfl⟩
   exact h hp hq (by simp) hle
 
 /-! ### Plural PPs: the star operator (§4.2.2) -/

--- a/Linglib/Studies/Zwarts2005.lean
+++ b/Linglib/Studies/Zwarts2005.lean
@@ -1,0 +1,422 @@
+import Linglib.Semantics.Spatial.Trace
+import Mathlib.Data.List.Infix
+
+/-!
+# [zwarts-2005] *Prepositional Aspect and the Algebra of Paths*
+
+Directional-PP denotations are sets of paths; what distinguishes telic PPs
+(*to the house*) from atelic PPs (*towards the house*) is closure under the
+**partial** concatenation operation: atelic PPs are cumulative, telic PPs are
+not (21). The paper's Appendix A path algebra ⟨P, +⟩ is formalized here in
+discrete form — paths as location sequences rather than continuous
+constant-speed curves; Zwarts notes (§2) that the axiomatic and constructive
+routes are equally compatible with the algebra.
+
+## Main definitions
+
+* `Path`, `Path.IsConcat` — the algebra: concatenation (67) is defined only
+  when the first path ends where the second starts; the subpath order (68) is
+  `Subpath`, with `subpath_iff_infix` the working characterization and a
+  `PartialOrder` instance.
+* `Cumulative` (17b, with the existence clause of fn. 7), `Bounded` (21) —
+  stated over any ternary concatenation relation, since Appendix A pairs the
+  path algebra with an event algebra of the same shape.
+* `weakTo` (30c), `toPP`/`fromPP` (endpoint content of the strict (36)),
+  `towardsPP` (45), `awayFromPP` (48), `loops`, `Star` (58).
+* `IsTraceHom`, `vpp` (25) — §3.2 aspect transfer from PP to VP.
+
+## Main statements
+
+* `weakTo_cumulative` vs `toPP_bounded` — the §4.1.1 argument: the weak
+  goal-PP denotation is cumulative (wrong aspect), the strict one bounded.
+* `fromPP_bounded` — source PPs are bounded like goal PPs: no aspectual
+  source/goal asymmetry (12a), grounding `Spatial.Trace.pathShapeToTelicity`
+  mapping `.source` to `.telic`.
+* `towardsPP_concat_closed`, `awayFromPP_concat_closed`,
+  `towardsPP_cumulative` — the comparative definitions (45)/(48) are
+  cumulative, grounding `.unbounded ↦ .atelic`.
+* `toPP_not_quantized` — bounded PPs are **not** quantized (23)–(24):
+  a *to x* path has proper *to x* subpaths, so `Mereology.QUA` fails.
+* `quantized_telicK`, `loops_telicK`, `loops_cumulative` — quantization
+  implies Krifka-telicity (22b), but the round-and-round loop set is
+  (22b)-telic yet cumulative, so neither Krifka notion characterizes
+  boundedness (§3.1).
+* `star_cumulative` — the plural closure (58) is cumulative.
+* `vpp_concat_closed`, `vpp_bounded_of_no_pairs`, `toPP_no_pairs` — §3.2:
+  a trace homomorphism transfers PP closure to VP closure, and *walk to the
+  house* is bounded because no two *to the house* traces concatenate.
+
+## TODO
+
+* The full single-phase strict definitions (35)–(36), (39)–(40) and the
+  minimality/grinder operators (63)–(64).
+* Reconciling `Spatial.Trace`'s `IsSumHom` law with this study's trace
+  homomorphism: Zwarts (§3.2) follows Rothstein in using partial event
+  concatenation, not the unrestricted mereological sum.
+-/
+
+namespace Zwarts2005
+
+open Mereology (QUA)
+
+variable {Loc α : Type*}
+
+/-! ### The path algebra (Appendix A) -/
+
+/-- A path in discrete form: the visited locations, as a start plus later
+    stops. Zwarts's paths are continuous constant-speed curves `[0,1] → ℝ³`;
+    the sequence rendering keeps the algebra — endpoints, partial
+    concatenation, subpaths — while staying computable. -/
+structure Path (Loc : Type*) where
+  /-- The starting location p(0). -/
+  source : Loc
+  /-- The later locations, ending at p(1); empty for a constant path. -/
+  steps : List Loc
+  deriving DecidableEq, Repr
+
+namespace Path
+
+/-- The endpoint p(1). -/
+def goal (p : Path Loc) : Loc := p.steps.getLastD p.source
+
+/-- The full point sequence p(0) … p(1). -/
+def points (p : Path Loc) : List Loc := p.source :: p.steps
+
+/-- The constant path at a location: the identity elements of concatenation
+    and the least elements of the subpath order (Appendix A). -/
+def const (l : Loc) : Path Loc := ⟨l, []⟩
+
+@[simp] theorem goal_const (l : Loc) : (const l).goal = l := rfl
+
+theorem points_ne_nil (p : Path Loc) : p.points ≠ [] := List.cons_ne_nil _ _
+
+theorem points_injective : Function.Injective (points : Path Loc → List Loc) := by
+  rintro ⟨s, l⟩ ⟨s', l'⟩ h
+  simpa [points] using h
+
+private theorem getLastD_append (l₁ l₂ : List α) (d : α) :
+    (l₁ ++ l₂).getLastD d = l₂.getLastD (l₁.getLastD d) := by
+  simp only [List.getLastD_eq_getLast?, List.getLast?_append]
+  cases l₂.getLast? <;> simp
+
+/-- (67): `r` is the concatenation `p + q`. Partial — defined only when `p`
+    ends where `q` starts. Associative, neither commutative nor idempotent
+    (16). -/
+def IsConcat (p q r : Path Loc) : Prop :=
+  p.goal = q.source ∧ r = ⟨p.source, p.steps ++ q.steps⟩
+
+theorem IsConcat.source_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.source = p.source := by rw [h.2]
+
+theorem IsConcat.goal_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.goal = q.goal := by
+  obtain ⟨h1, rfl⟩ := h
+  show (p.steps ++ q.steps).getLastD p.source = q.goal
+  rw [getLastD_append]
+  show q.steps.getLastD p.goal = q.goal
+  rw [h1]; rfl
+
+theorem IsConcat.points_eq {p q r : Path Loc} (h : IsConcat p q r) :
+    r.points = p.points ++ q.steps := by
+  rw [h.2]; simp [points]
+
+/-- Every pair of constant paths at the same point concatenates to itself. -/
+theorem isConcat_const (l : Loc) : IsConcat (const l) (const l) (const l) :=
+  ⟨rfl, rfl⟩
+
+/-! ### The subpath order (68) -/
+
+/-- (68): `p` is a subpath of `q` iff `r + p + r′ = q` for some `r`, `r′`. -/
+def Subpath (p q : Path Loc) : Prop :=
+  ∃ r r' m, IsConcat r p m ∧ IsConcat m r' q
+
+/-- The working characterization: subpath-hood is infix-hood of point
+    sequences. -/
+theorem subpath_iff_infix {p q : Path Loc} :
+    Subpath p q ↔ p.points <:+: q.points := by
+  constructor
+  · rintro ⟨r, r', m, hrp, hmq⟩
+    refine ⟨r.points.dropLast, r'.steps, ?_⟩
+    have hgoal : r.points.getLast r.points_ne_nil = p.source := by
+      have : r.points.getLast r.points_ne_nil = r.goal := by
+        cases h : r.steps <;>
+          simp [points, goal, h, List.getLast_cons,
+            List.getLastD_eq_getLast?, List.getLast?_eq_some_getLast]
+      rw [this, hrp.1]
+    calc r.points.dropLast ++ p.points ++ r'.steps
+        = (r.points.dropLast ++ [p.source]) ++ p.steps ++ r'.steps := by
+          simp [points]
+      _ = r.points ++ p.steps ++ r'.steps := by
+          rw [← hgoal, List.dropLast_append_getLast]
+      _ = q.points := by rw [hmq.points_eq, hrp.points_eq]
+  · rintro ⟨A, B, hAB⟩
+    match A with
+    | [] =>
+      obtain ⟨hs, hst⟩ : q.source = p.source ∧ q.steps = p.steps ++ B := by
+        simpa [points, List.cons.injEq] using hAB.symm
+      exact ⟨const p.source, ⟨p.goal, B⟩, p,
+        ⟨rfl, by cases p; rfl⟩, ⟨rfl, by cases q; simp_all [points]⟩⟩
+    | a :: A' =>
+      obtain ⟨hs, hst⟩ : q.source = a ∧ q.steps = A' ++ (p.source :: p.steps) ++ B := by
+        simpa [points, List.cons.injEq, List.append_assoc] using hAB.symm
+      refine ⟨⟨a, A' ++ [p.source]⟩, ⟨p.goal, B⟩,
+        ⟨a, (A' ++ [p.source]) ++ p.steps⟩,
+        ⟨by simp [goal], rfl⟩,
+        ⟨?_, ?_⟩⟩
+      · show ((A' ++ [p.source]) ++ p.steps).getLastD a = p.goal
+        rw [getLastD_append, getLastD_append]
+        rfl
+      · cases q
+        simp_all [points, List.append_assoc]
+
+instance : PartialOrder (Path Loc) where
+  le := Subpath
+  le_refl p := subpath_iff_infix.mpr (List.infix_refl _)
+  le_trans _ _ _ hab hbc := subpath_iff_infix.mpr
+    ((subpath_iff_infix.mp hab).trans (subpath_iff_infix.mp hbc))
+  le_antisymm _ _ hab hba := points_injective
+    (List.infix_antisymm (subpath_iff_infix.mp hab) (subpath_iff_infix.mp hba))
+
+/-- Constant paths are least: `const p.source ≤ p`. -/
+theorem const_source_le (p : Path Loc) : const p.source ≤ p :=
+  subpath_iff_infix.mpr ⟨[], p.steps, rfl⟩
+
+/-- Bridge to the endpoint skeleton `Spatial.Path` of the substrate. -/
+def toSpatial (p : Path Loc) : Spatial.Path Loc := ⟨p.source, p.goal⟩
+
+/-- Concatenable paths are adjacent in the substrate's endpoint-sharing
+    sense (`Spatial.Path.adjacent`). -/
+theorem IsConcat.toSpatial_adjacent {p q r : Path Loc} (h : IsConcat p q r) :
+    p.toSpatial.adjacent q.toSpatial :=
+  Or.inl h.1
+
+end Path
+
+open Path
+
+/-! ### Cumulativity and boundedness (17b), (21)
+
+Stated over an arbitrary ternary concatenation relation: Appendix A pairs the
+path algebra with an event algebra of the same shape, and §3.2 transfers
+closure properties along a homomorphism between the two. -/
+
+/-- (17b): a set is cumulative iff some concatenation exists within it
+    (fn. 7's non-vacuity clause) and it is closed under concatenation. -/
+def Cumulative (C : α → α → α → Prop) (X : Set α) : Prop :=
+  (∃ p ∈ X, ∃ q ∈ X, ∃ r, C p q r) ∧
+    ∀ p ∈ X, ∀ q ∈ X, ∀ r, C p q r → r ∈ X
+
+/-- (21): bounded = non-cumulative. This, not quantization, is what
+    characterizes telic PPs. -/
+def Bounded (C : α → α → α → Prop) (X : Set α) : Prop :=
+  ¬ Cumulative C X
+
+/-- A set with no concatenable pairs at all is bounded. -/
+theorem bounded_of_no_pairs {C : α → α → α → Prop} {X : Set α}
+    (h : ¬ ∃ p ∈ X, ∃ q ∈ X, ∃ r, C p q r) : Bounded C X :=
+  fun hc => h hc.1
+
+/-! ### Quantization and Krifka-telicity are the wrong notions (§3.1)
+
+(22) transplants [krifka-1998]'s quantization and telicity to path sets;
+Zwarts shows neither characterizes boundedness. Quantization is
+`Mereology.QUA` over the subpath order. -/
+
+/-- (22b): Krifka-style telicity for path sets — comparable members share
+    both endpoints. -/
+def TelicK (X : Set (Path Loc)) : Prop :=
+  ∀ p ∈ X, ∀ q ∈ X, p ≤ q → p.source = q.source ∧ p.goal = q.goal
+
+/-- Quantized sets are Krifka-telic (§3.1: "Being quantized implies being
+    telic"). -/
+theorem quantized_telicK {X : Set (Path Loc)} (h : QUA (· ∈ X)) :
+    TelicK X := by
+  intro p hp q hq hle
+  rcases eq_or_ne p q with rfl | hne
+  · exact ⟨rfl, rfl⟩
+  · exact absurd hle (h hp hq hne)
+
+/-- The *round and round the block* set: non-constant loops at a fixed
+    location. -/
+def loops (A : Loc) : Set (Path Loc) :=
+  {p | p.source = A ∧ p.goal = A ∧ p.steps ≠ []}
+
+/-- Loop sets are Krifka-telic: all members share both endpoints. -/
+theorem loops_telicK (A : Loc) : TelicK (loops (Loc := Loc) A) :=
+  fun _ hp _ hq _ => ⟨hp.1.trans hq.1.symm, hp.2.1.trans hq.2.1.symm⟩
+
+/-- Loop sets are cumulative — so Krifka-telicity (22b) does not
+    characterize boundedness (§3.1: *round and round the block* is telic in
+    Krifka's sense but behaves unboundedly). -/
+theorem loops_cumulative (A : Loc) :
+    Cumulative Path.IsConcat (loops (Loc := Loc) A) := by
+  constructor
+  · have h : (⟨A, [A]⟩ : Path Loc) ∈ loops A := ⟨rfl, rfl, by simp⟩
+    exact ⟨_, h, _, h, _, ⟨rfl, rfl⟩⟩
+  · rintro p hp q hq r hr
+    exact ⟨hr.source_eq.trans hp.1, hr.goal_eq.trans hq.2.1,
+      by rw [hr.2]; simp [hq.2.2]⟩
+
+/-! ### Goal and source prepositions (§4.1.1) -/
+
+/-- (30c): the weak goal-PP denotation — paths ending at the reference
+    object. -/
+def weakTo (x : Loc) : Set (Path Loc) := {p | p.goal = x}
+
+/-- The weak definition (30c) is cumulative — the wrong aspect for telic
+    *to*/*into*, which is Zwarts's argument for the strict single-phase
+    definitions (34)–(35). -/
+theorem weakTo_cumulative (x : Loc) : Cumulative Path.IsConcat (weakTo x) :=
+  ⟨⟨_, goal_const x, _, goal_const x, _, isConcat_const x⟩,
+    fun _ _ _ hq _ hr => hr.goal_eq.trans hq⟩
+
+/-- The endpoint content of the strict goal PP (36): the path ends at the
+    reference object and does not start there. -/
+def toPP (x : Loc) : Set (Path Loc) := {p | p.goal = x ∧ p.source ≠ x}
+
+/-- The endpoint content of the strict source PP (36): the path starts at
+    the reference object and does not end there. -/
+def fromPP (x : Loc) : Set (Path Loc) := {p | p.source = x ∧ p.goal ≠ x}
+
+/-- No two *to x* paths concatenate: the first ends at `x`, the second never
+    starts there (§3.1). -/
+theorem toPP_no_pairs (x : Loc) :
+    ¬ ∃ p ∈ toPP x, ∃ q ∈ toPP x, ∃ r, Path.IsConcat p q r := by
+  rintro ⟨p, hp, q, hq, r, hr⟩
+  exact hq.2 (hr.1 ▸ hp.1)
+
+/-- Strict goal PPs are bounded (21): *to the house* is telic. -/
+theorem toPP_bounded (x : Loc) : Bounded Path.IsConcat (toPP x) :=
+  bounded_of_no_pairs (toPP_no_pairs x)
+
+/-- Strict source PPs are bounded, exactly like goal PPs — there is no
+    aspectual source/goal asymmetry (12a). Grounds
+    `Spatial.Trace.pathShapeToTelicity` sending `.source` to `.telic`. -/
+theorem fromPP_bounded (x : Loc) : Bounded Path.IsConcat (fromPP x) := by
+  rintro ⟨⟨p, hp, q, hq, r, hr⟩, -⟩
+  exact hp.2 (hr.1.trans hq.1)
+
+/-! ### Towards and away from (§4.1.3)
+
+The comparative definitions over a distance measure `d` to the reference
+object: cumulative, hence unbounded — grounding
+`Spatial.Trace.pathShapeToTelicity` sending `.unbounded` to `.atelic`. -/
+
+/-- (45): *towards x* — the path ends nearer to the reference object than it
+    starts, measured by `d`. -/
+def towardsPP [Preorder α] (d : Loc → α) : Set (Path Loc) :=
+  {p | d p.goal < d p.source}
+
+/-- (48): *away from x* — the path ends further from the reference object
+    than it starts. -/
+def awayFromPP [Preorder α] (d : Loc → α) : Set (Path Loc) :=
+  {p | d p.source < d p.goal}
+
+/-- (45) is closed under concatenation: distance decreases across each
+    concatenant. -/
+theorem towardsPP_concat_closed [Preorder α] (d : Loc → α) :
+    ∀ p ∈ towardsPP d, ∀ q ∈ towardsPP d, ∀ r, Path.IsConcat p q r →
+      r ∈ towardsPP d := by
+  intro p hp q hq r hr
+  show d r.goal < d r.source
+  rw [hr.goal_eq, hr.source_eq]
+  exact hq.trans_le (hr.1 ▸ hp.le)
+
+/-- (48) is closed under concatenation, mirroring (45). -/
+theorem awayFromPP_concat_closed [Preorder α] (d : Loc → α) :
+    ∀ p ∈ awayFromPP d, ∀ q ∈ awayFromPP d, ∀ r, Path.IsConcat p q r →
+      r ∈ awayFromPP d := by
+  intro p hp q hq r hr
+  show d r.source < d r.goal
+  rw [hr.goal_eq, hr.source_eq]
+  exact hp.trans_le (hr.1 ▸ hq.le)
+
+/-- On the rational line with the reference object at the origin, *towards*
+    is fully cumulative (45): closure plus a concrete concatenable pair. -/
+theorem towardsPP_cumulative :
+    Cumulative Path.IsConcat (towardsPP (abs : ℚ → ℚ)) := by
+  refine ⟨⟨⟨2, [1]⟩, ?_, ⟨1, [0]⟩, ?_, _, ⟨rfl, rfl⟩⟩,
+    towardsPP_concat_closed abs⟩
+  · show |(1 : ℚ)| < |(2 : ℚ)|
+    norm_num
+  · show |(0 : ℚ)| < |(1 : ℚ)|
+    norm_num
+
+/-- Bounded PPs are **not** quantized (23)–(24): a *to x* path has proper
+    subpaths that are also *to x*, so `Mereology.QUA` fails — against the
+    [krifka-1998] characterization of telicity, and against this library's
+    earlier docstring folklore. -/
+theorem toPP_not_quantized : ¬ QUA (· ∈ toPP (0 : ℚ)) := by
+  intro h
+  have hp : (⟨1, [0]⟩ : Path ℚ) ∈ toPP 0 := ⟨rfl, by norm_num⟩
+  have hq : (⟨2, [1, 0]⟩ : Path ℚ) ∈ toPP 0 := ⟨rfl, by norm_num⟩
+  have hle : (⟨1, [0]⟩ : Path ℚ) ≤ ⟨2, [1, 0]⟩ :=
+    subpath_iff_infix.mpr ⟨[2], [], rfl⟩
+  exact h hp hq (by simp) hle
+
+/-! ### Plural PPs: the star operator (§4.2.2) -/
+
+/-- (58): closure of a path set under concatenations — prepositional
+    plurality (*round and round the house*). -/
+inductive Star (X : Set (Path Loc)) : Path Loc → Prop
+  | base {p} (hp : p ∈ X) : Star X p
+  | concat {p q r} (hp : Star X p) (hq : Star X q) (h : Path.IsConcat p q r) :
+      Star X r
+
+/-- (58): the star closure is cumulative, given any concatenable pair to
+    seed it. -/
+theorem star_cumulative {X : Set (Path Loc)}
+    (h : ∃ p ∈ X, ∃ q ∈ X, ∃ r, Path.IsConcat p q r) :
+    Cumulative Path.IsConcat {p | Star X p} := by
+  obtain ⟨p, hp, q, hq, r, hr⟩ := h
+  exact ⟨⟨p, .base hp, q, .base hq, r, hr⟩,
+    fun _ hp' _ hq' _ hr' => .concat hp' hq' hr'⟩
+
+/-! ### Aspect transfer to the VP (§3.2) -/
+
+section Transfer
+
+variable {E : Type*} (C : E → E → E → Prop) (tr : E → Path Loc)
+
+/-- §3.2: the trace function is a homomorphism for concatenation — the trace
+    of a fused event is the concatenation of the traces. Zwarts follows
+    Rothstein's partial event concatenation, not the unrestricted
+    mereological sum. -/
+def IsTraceHom : Prop :=
+  ∀ e e' f, C e e' f → Path.IsConcat (tr e) (tr e') (tr f)
+
+/-- (25): `⟦V PP⟧` — the verb's events whose trace lies in the PP
+    denotation. -/
+def vpp (V : Set E) (X : Set (Path Loc)) : Set E :=
+  {e ∈ V | tr e ∈ X}
+
+/-- §3.2 transfer, positive half: closure of the verb and of the PP
+    denotation transfers to the VP (*walk along the river* is cumulative
+    because *walk* and *along the river* are). -/
+theorem vpp_concat_closed (hhom : IsTraceHom C tr) {V : Set E}
+    {X : Set (Path Loc)}
+    (hV : ∀ e ∈ V, ∀ e' ∈ V, ∀ f, C e e' f → f ∈ V)
+    (hX : ∀ p ∈ X, ∀ q ∈ X, ∀ r, Path.IsConcat p q r → r ∈ X) :
+    ∀ e ∈ vpp tr V X, ∀ e' ∈ vpp tr V X, ∀ f, C e e' f → f ∈ vpp tr V X :=
+  fun e he e' he' f hf =>
+    ⟨hV e he.1 e' he'.1 f hf, hX _ he.2 _ he'.2 _ (hhom e e' f hf)⟩
+
+/-- §3.2 transfer, negative half: if no two PP paths concatenate, no two VP
+    events fuse — *walk to the house* is bounded because *to the house* has
+    no concatenable pairs. -/
+theorem vpp_bounded_of_no_pairs (hhom : IsTraceHom C tr) {V : Set E}
+    {X : Set (Path Loc)}
+    (hX : ¬ ∃ p ∈ X, ∃ q ∈ X, ∃ r, Path.IsConcat p q r) :
+    Bounded C (vpp tr V X) :=
+  bounded_of_no_pairs fun ⟨e, he, e', he', f, hf⟩ =>
+    hX ⟨tr e, he.2, tr e', he'.2, tr f, hhom e e' f hf⟩
+
+/-- *Walk to the house* is bounded (26), (§3.2): instantiates the negative
+    transfer at the strict goal PP. -/
+theorem vpp_toPP_bounded (hhom : IsTraceHom C tr) {V : Set E} (x : Loc) :
+    Bounded C (vpp tr V (toPP x)) :=
+  vpp_bounded_of_no_pairs C tr hhom (toPP_no_pairs x)
+
+end Transfer
+
+end Zwarts2005


### PR DESCRIPTION
Spatial API cleanup arc, PDF-grounded:

- `Path.lean`: bare `Spatial` namespace (no path-mirroring `Semantics.` umbrella, per the Logic-dissolution ruling); carrier upgraded from an endpoint pair to a location sequence, now carrying [zwarts-2005]'s Appendix A algebra — partial concatenation (67), subpath order (68) ≃ points-infix as a **scoped** `PartialOrder` (rival to the Krifka lattice-sum hypothesis in Trace.lean, cf. `Prod.Lex`); unconsumed rfl-unpacking theorems cut, adjacency golfed (`or_comm`, simp `adjacent_self`, mirrored on `Event.adjacent`).
- `Studies/Zwarts2005.lean` (new, PDF-verified): cumulativity (17b) / bounded = non-cumulative (21), weak-vs-strict goal PPs (§4.1.1), `towards`/`away from` (45)/(48), bounded-PPs-not-quantized (23)–(24), round-and-round divergence from Krifka telicity (§3.1), star plurals (58), §3.2 trace-homomorphism aspect transfer. Fixes substrate docstrings that misattributed a QUA story to [zwarts-2005].