### PR TITLE
refactor(Semantics): dissolve Spatial/ into Events/; two-axis PP split

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1645,7 +1645,9 @@ import Linglib.Semantics.Entailment.StrawsonSoundness
 import Linglib.Semantics.Events.Adjacency
 import Linglib.Semantics.Events.Basic
 import Linglib.Semantics.Events.CEM
+import Linglib.Semantics.Events.Path
 import Linglib.Semantics.Events.Phase
+import Linglib.Semantics.Events.SpatialTrace
 import Linglib.Semantics.Evidential.Basic
 import Linglib.Semantics.Evidential.Defs
 import Linglib.Semantics.Evidential.Epistemicity
@@ -1842,8 +1844,6 @@ import Linglib.Semantics.Reference.PluralityLicensing
 import Linglib.Semantics.Reference.PronounDenotation
 import Linglib.Semantics.Reference.Reciprocals
 import Linglib.Semantics.Reference.ShiftedIndexicals
-import Linglib.Semantics.Spatial.Path
-import Linglib.Semantics.Spatial.Trace
 import Linglib.Semantics.Supervaluation
 import Linglib.Semantics.Tense.Basic
 import Linglib.Semantics.Tense.Compositional

--- a/Linglib/Core/Order/Boundedness.lean
+++ b/Linglib/Core/Order/Boundedness.lean
@@ -121,7 +121,7 @@ def MereoTag.toBoundedness : MereoTag → Boundedness
     instantiate this with different source types but the same target.
 
     Core instances (`Boundedness`, `MereoTag`) live here. Domain-specific
-    instances (`Telicity`, `VendlerClass`, `PathShape`, `BoundaryType`)
+    instances (`Telicity`, `VendlerClass`, `BoundaryType`)
     live in their respective theory/bridge files. -/
 class LicensingPipeline (α : Type*) where
   toBoundedness : α → Boundedness

--- a/Linglib/Fragments/Dutch/Adpositions.lean
+++ b/Linglib/Fragments/Dutch/Adpositions.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Spatial.Path
+import Linglib.Features.Aktionsart
 
 /-!
 # Dutch Adposition Fragment
@@ -24,7 +25,8 @@ core properties (R-pronominalization, complement types).
 
 namespace Dutch.Adpositions
 
-open Spatial (PathShape)
+open Spatial (Path)
+open Features (Telicity)
 
 /-- Complement types attested for Dutch adpositions.
     [broekhuis-corver-2026] §2.1: nominal (default), PP, adjectival,
@@ -61,8 +63,8 @@ structure DutchAdposition where
   locational   : Bool := false
   /-- Has directional reading (path/change of location) -/
   directional  : Bool := false
-  /-- Path shape for directional uses (if any) -/
-  pathShape    : Option PathShape := none
+  /-- Directionality and telicity for directional uses (if any) -/
+  pathType     : Option (Path.Directionality × Telicity) := none
   /-- English gloss -/
   gloss        : String
   deriving DecidableEq, Repr
@@ -79,7 +81,7 @@ def op : DutchAdposition :=
   { form := "op", prePOk := true, postPOk := true
   , intransOk := true
   , locational := true, directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "on/onto/up" }
 
 /-- §2.1 ex. 2a, §2.2 ex. 35a/58a: *in* is preP (locational "in") and postP
@@ -88,7 +90,7 @@ def in_ : DutchAdposition :=
   { form := "in", prePOk := true, postPOk := true
   , intransOk := true
   , locational := true, directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "in/into" }
 
 /-- §2.1 ex. 2b: *naar* is preP only, inherently directional.
@@ -96,7 +98,7 @@ def in_ : DutchAdposition :=
 def naar : DutchAdposition :=
   { form := "naar", prePOk := true, postPOk := false
   , directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "to" }
 
 /-- §2.1 ex. 6–7: *van* indicates starting point of a path.
@@ -107,7 +109,7 @@ def van : DutchAdposition :=
   , circumPart := some "af"
   , complTypes := [.nominal, .pp]
   , directional := true
-  , pathShape := some .source
+  , pathType := some (.source, .telic)
   , gloss := "from/of" }
 
 /-- §2.1 ex. 6–7: *tot* indicates endpoint of a path.
@@ -120,7 +122,7 @@ def tot : DutchAdposition :=
   { form := "tot", prePOk := true, postPOk := false
   , complTypes := [.nominal, .pp, .adjectival]
   , directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "to/until" }
 
 /-- §3 ex. 31a, §2.3 ex. 28b: *achter* = "behind".
@@ -146,7 +148,7 @@ def onder : DutchAdposition :=
   { form := "onder", prePOk := true, postPOk := false
   , circumPart := some "door"
   , locational := true, directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "under" }
 
 /-- §2.2 ex. 24b: *over* = "over/across". Circumposition with *heen*:
@@ -157,7 +159,7 @@ def over : DutchAdposition :=
   , circumPart := some "heen"
   , intransOk := true
   , locational := true, directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "over/across" }
 
 /-- §2.2 ex. 25: *tussen* = "between". Circumposition with *in*:
@@ -192,7 +194,7 @@ def uit : DutchAdposition :=
   { form := "uit", prePOk := true, postPOk := false
   , intransOk := true
   , directional := true
-  , pathShape := some .source
+  , pathType := some (.source, .telic)
   , gloss := "out of" }
 
 /-- §2.3 ex. 28c: *om* = "around".
@@ -277,7 +279,7 @@ def af : DutchAdposition :=
   { form := "af", prePOk := false, postPOk := false
   , intransOk := true
   , directional := true
-  , pathShape := some .source
+  , pathType := some (.source, .telic)
   , gloss := "off/down" }
 
 /-- *heen* = directional particle. Primarily circumP second element
@@ -286,7 +288,7 @@ def heen : DutchAdposition :=
   { form := "heen", prePOk := false, postPOk := false
   , intransOk := true
   , directional := true
-  , pathShape := some .bounded
+  , pathType := some (.goal, .telic)
   , gloss := "thither (directional)" }
 
 -- ════════════════════════════════════════════════════
@@ -316,9 +318,9 @@ theorem complex_Ps_no_rPron :
 theorem circumP_parts_not_preP :
     af.prePOk = false ∧ heen.prePOk = false := ⟨rfl, rfl⟩
 
-/-- All adpositions with directional readings have a PathShape. -/
-theorem directional_has_pathShape :
-    ∀ a ∈ dutchAdpositions, a.directional → a.pathShape.isSome := by decide
+/-- All adpositions with directional readings carry directionality and telicity. -/
+theorem directional_has_pathType :
+    ∀ a ∈ dutchAdpositions, a.directional → a.pathType.isSome := by decide
 
 /-- PostP-capable adpositions have both locational and directional readings.
     §2.2 ex. 21: preP *op* = locational, postP *op* = directional. -/

--- a/Linglib/Fragments/Dutch/Adpositions.lean
+++ b/Linglib/Fragments/Dutch/Adpositions.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Spatial.Path
+import Linglib.Semantics.Events.Path
 import Linglib.Features.Aktionsart
 
 /-!

--- a/Linglib/Semantics/ArgumentStructure/LevinClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinClass.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.ArgumentStructure.RoleList
-import Linglib.Semantics.Spatial.Path
+import Linglib.Semantics.Events.Path
 import Linglib.Features.Aktionsart
 
 /-!

--- a/Linglib/Semantics/ArgumentStructure/LevinClass.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinClass.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Semantics.Spatial.Path
+import Linglib.Features.Aktionsart
 
 /-!
 # Verb classes: the [levin-1993] taxonomy
@@ -433,9 +434,9 @@ def isVerbOfCreation : LevinClass → Bool
     lexicalize a bounded path. Manner-of-motion verbs (51.3: run, walk)
     are path-neutral — the path comes from a PP complement.
     [talmy-2000]: verb-framed vs. satellite-framed distinction. -/
-def pathSpec : LevinClass → Option Spatial.PathShape
-  | .inherentlyDirectedMotion => some .bounded
-  | .leave => some .source
+def pathSpec : LevinClass → Option (Spatial.Path.Directionality × Features.Telicity)
+  | .inherentlyDirectedMotion => some (.goal, .telic)
+  | .leave => some (.source, .telic)
   | .mannerOfMotion => none    -- path from PP
   | .vehicleMotion => none     -- path from PP/context
   | .chase => none             -- path from complement

--- a/Linglib/Semantics/Events/Path.lean
+++ b/Linglib/Semantics/Events/Path.lean
@@ -140,7 +140,7 @@ theorem subpath_iff_infix {p q : Path Loc} :
 
 /-- The subpath order, as a **scoped** instance: path sets are also studied
     under a rival total lattice sum ([krifka-1998]'s part structures,
-    hypothesized as `SemilatticeSup (Path Loc)` in `Spatial/Trace.lean`).
+    hypothesized as `SemilatticeSup (Path Loc)` in `Events/SpatialTrace.lean`).
     Activate with `open scoped Spatial.Path`. -/
 scoped instance instSubpathOrder : PartialOrder (Path Loc) where
   le := Subpath

--- a/Linglib/Semantics/Events/SpatialTrace.lean
+++ b/Linglib/Semantics/Events/SpatialTrace.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Events.CEM
-import Linglib.Semantics.Spatial.Path
+import Linglib.Semantics.Events.Path
 
 /-!
 # Spatial trace function σ

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -9,9 +9,9 @@ spatial analog of temporal intervals, carrying [zwarts-2005]'s Appendix A path
 algebra in discrete form: partial concatenation (defined only head-to-tail),
 the subpath order, and endpoint-sharing adjacency ([krifka-1998]). Zwarts's
 own paths are continuous constant-speed curves `[0,1] → ℝ³` — mathlib's
-topological `_root_.Path`, whose `trans` reparametrizes, so his algebra would
-need the arc-length quotient there; he notes the constructive
-sequence-of-places route is equally compatible with the algebra, and it keeps
+topological `_root_.Path`, whose `trans` reparametrizes, so the algebra would
+need the arc-length quotient there; the paper endorses the constructive
+sequence-of-places route as equally compatible with the algebra, and it keeps
 every operation computable.
 
 ## Main declarations
@@ -34,10 +34,8 @@ every operation computable.
 
 namespace Spatial
 
-/-- Spatial path: a directed trajectory through its visited locations, as a
-    start plus later stops ([zwarts-2005]: directed stretches of space with a
-    source and a goal). Parallels `NonemptyInterval` for the temporal
-    domain. -/
+/-- A directed trajectory through space, as the finite sequence of visited
+    locations. The spatial analog of a temporal `NonemptyInterval`. -/
 structure Path (Loc : Type*) where
   /-- The starting location p(0). -/
   source : Loc
@@ -73,9 +71,8 @@ private theorem getLastD_append {α : Type*} (l₁ l₂ : List α) (d : α) :
 
 /-! ### Concatenation and subpaths -/
 
-/-- (67) of [zwarts-2005]: `r` is the concatenation `p + q`. Partial —
-    defined only when `p` ends where `q` starts. Associative, neither
-    commutative nor idempotent. -/
+/-- `r` is the concatenation `p + q`, defined only when `p` ends where `q`
+    starts. Associative, neither commutative nor idempotent. -/
 def IsConcat (p q r : Path Loc) : Prop :=
   p.goal = q.source ∧ r = ⟨p.source, p.steps ++ q.steps⟩
 
@@ -94,18 +91,16 @@ theorem IsConcat.points_eq {p q r : Path Loc} (h : IsConcat p q r) :
     r.points = p.points ++ q.steps := by
   rw [h.2]; simp [points]
 
-/-- Constant paths concatenate with themselves to themselves: they are the
-    identity elements of concatenation. -/
+/-- A constant path concatenates with itself to itself. -/
 theorem isConcat_const (l : Loc) : IsConcat (const l) (const l) (const l) :=
   ⟨rfl, rfl⟩
 
-/-- (68) of [zwarts-2005]: `p` is a subpath of `q` iff `r + p + r′ = q` for
-    some `r`, `r′`. -/
+/-- `p` is a subpath of `q` if concatenating some `r`, `r′` around `p`
+    yields `q`. -/
 def Subpath (p q : Path Loc) : Prop :=
   ∃ r r' m, IsConcat r p m ∧ IsConcat m r' q
 
-/-- The working characterization: subpath-hood is infix-hood of point
-    sequences. -/
+/-- Subpath-hood is infix-hood of point sequences. -/
 theorem subpath_iff_infix {p q : Path Loc} :
     Subpath p q ↔ p.points <:+: q.points := by
   constructor
@@ -142,10 +137,10 @@ theorem subpath_iff_infix {p q : Path Loc} :
       · cases q
         simp_all [points, List.append_assoc]
 
-/-- The subpath order as an order instance — **scoped**, because path sets
-    are also studied under a rival total lattice sum ([krifka-1998]'s part
-    structures, hypothesized as `SemilatticeSup (Path Loc)` in
-    `Spatial/Trace.lean`); activate with `open scoped Spatial.Path`. -/
+/-- The subpath order, as a **scoped** instance: path sets are also studied
+    under a rival total lattice sum ([krifka-1998]'s part structures,
+    hypothesized as `SemilatticeSup (Path Loc)` in `Spatial/Trace.lean`).
+    Activate with `open scoped Spatial.Path`. -/
 scoped instance instSubpathOrder : PartialOrder (Path Loc) where
   le := Subpath
   le_refl p := subpath_iff_infix.mpr (List.infix_refl _)
@@ -154,16 +149,15 @@ scoped instance instSubpathOrder : PartialOrder (Path Loc) where
   le_antisymm _ _ hab hba := points_injective
     (List.infix_antisymm (subpath_iff_infix.mp hab) (subpath_iff_infix.mp hba))
 
-/-- Constant paths are least: `const p.source ≤ p`. -/
+/-- Constant paths are least in the subpath order. -/
 theorem const_source_le (p : Path Loc) : const p.source ≤ p :=
   subpath_iff_infix.mpr ⟨[], p.steps, rfl⟩
 
 /-! ### Adjacency -/
 
-/-- Two paths are spatially adjacent (`∞_H` in [krifka-1998]'s notation)
-    if they share an endpoint: one's goal is the other's source.
-    Instantiates K98's abstract adjacency primitive for concrete paths;
-    the spatial half of the movement relations in `Studies/Krifka1998.lean`. -/
+/-- Two paths are adjacent if one's goal is the other's source —
+    [krifka-1998]'s spatial adjacency `∞_H`, the spatial half of the
+    movement relations in `Studies/Krifka1998.lean`. -/
 def adjacent (p1 p2 : Path Loc) : Prop :=
   p1.goal = p2.source ∨ p2.goal = p1.source
 

--- a/Linglib/Semantics/Spatial/Path.lean
+++ b/Linglib/Semantics/Spatial/Path.lean
@@ -28,8 +28,9 @@ every operation computable.
   (`open scoped Spatial.Path`).
 * `Path.adjacent`: endpoint-sharing spatial adjacency ([krifka-1998]), the
   spatial half of the movement relations in `Studies/Krifka1998.lean`.
-* `PathShape`: [zwarts-2005]'s boundedness classification of directional PPs,
-  with `PathShape.toBoundedness` into `Core.Order.Boundedness`.
+* `Path.Directionality`: the source/goal/route trichotomy of directional
+  prepositions ([zwarts-2005]); paired with `Features.Telicity` at use sites
+  — the paper's two independent classificatory axes.
 -/
 
 namespace Spatial
@@ -177,39 +178,22 @@ theorem IsConcat.adjacent {p q r : Path Loc} (h : IsConcat p q r) :
     p.adjacent q :=
   Or.inl h.1
 
-end Path
+/-! ### Directionality -/
 
-/-! ### Path shape -/
-
-/-- Directional PP boundedness classification.
-    [zwarts-2005]: the boundedness of a directional PP determines
-    whether the VP it creates is telic or atelic.
-
-    - `bounded`: goal-oriented ("to the store", "into the room")
-    - `unbounded`: direction-oriented ("towards the store", "along the road")
-    - `source`: origin-oriented ("from the store", "out of the room")
-
-    This classifies the *set of paths* denoted by a PP, not individual
-    paths, by closure under path concatenation: "towards X" denotes a
-    cumulative set (concatenating two towards-X paths gives another),
-    while "to X" strictly read denotes a set with no concatenable pairs
-    at all. [zwarts-2005] shows bounded PPs are *not* quantized — a to-X
-    path has proper to-X subpaths — so boundedness is non-cumulativity,
-    not `Mereology.QUA`; see `Studies/Zwarts2005.lean`. -/
-inductive PathShape where
-  | bounded
-  | unbounded
+/-- The source/goal/route trichotomy of directional prepositions
+    ([zwarts-2005]): source prepositions (*from*, *out of*) locate the
+    starting point p(0), goal prepositions (*to*, *into*) the endpoint
+    p(1), route prepositions (*over*, *through*, *via*) an interior point.
+    Independent of prepositional aspect — *to* is goal-directed telic,
+    *towards* goal-directed atelic — so consumers pair it with
+    `Features.Telicity`; the aspect axis is grounded in
+    `Studies/Zwarts2005.lean`. -/
+inductive Directionality where
   | source
+  | goal
+  | route
   deriving DecidableEq, Repr
 
-/-- Path shape to scale boundedness: bounded/source paths correspond
-    to closed scales, unbounded paths to open scales. -/
-def PathShape.toBoundedness : PathShape → Core.Order.Boundedness
-  | .bounded => .closed
-  | .source => .closed
-  | .unbounded => .open_
-
-instance : Core.Order.LicensingPipeline PathShape where
-  toBoundedness := PathShape.toBoundedness
+end Path
 
 end Spatial

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -1,6 +1,5 @@
 import Linglib.Semantics.Events.CEM
 import Linglib.Semantics.Spatial.Path
-import Linglib.Features.Aktionsart
 
 /-!
 # Spatial trace function σ
@@ -20,11 +19,8 @@ homomorphism (`Mereology.IsSumHom`) and injectivity — are stated at use sites.
   *to the store* denotes a QUA set of paths ([zwarts-2005]).
 * `Trace.unbounded_path_atelic`: CUM path predicates pull back through a
   sum-homomorphic σ — *walk towards the store* is atelic.
-* `Trace.pathShapeToTelicity`: the `PathShape → Telicity` bridge, agreeing
-  with scale boundedness (`Trace.telicity_boundedness_agree`).
 -/
 
-open Features
 open Mereology
 
 namespace Spatial
@@ -63,23 +59,6 @@ theorem bounded_path_telic [hσ : IsSumHom st.σ]
 theorem unbounded_path_atelic [hσ : IsSumHom st.σ] (hP : CUM P) :
     CUM (P ∘ st.σ) :=
   cum_pullback hσ hP
-
-/-! ### PathShape → Telicity bridge -/
-
-/-- Bounded and source paths yield telic VPs; unbounded paths atelic ones —
-    [zwarts-2005]'s boundedness-telicity generalization at the `PathShape`
-    level, the spatial analog of `Features.VendlerClass.telicity`. -/
-def pathShapeToTelicity : PathShape → Telicity
-  | .bounded => .telic
-  | .source => .telic
-  | .unbounded => .atelic
-
-/-- The telicity bridge agrees with the scale-boundedness bridge
-    (`PathShape.toBoundedness`): a path shape is telic iff its boundedness
-    is licensed (closed scale). -/
-theorem telicity_boundedness_agree (s : PathShape) :
-    (pathShapeToTelicity s = .telic) ↔ s.toBoundedness.IsLicensed := by
-  cases s <;> decide
 
 end Trace
 

--- a/Linglib/Semantics/Spatial/Trace.lean
+++ b/Linglib/Semantics/Spatial/Trace.lean
@@ -29,11 +29,12 @@ open Mereology
 
 namespace Spatial
 
-/-- Spatial trace: `σ e` is the path traversed in event `e` ([zwarts-2005],
-    [gawron-2009]), parallel to the temporal trace τ (`Event.runtime`).
-    Structural assumptions on σ are stated as mixins at use sites, per
-    `Semantics/Events/CEM.lean`: `[Mereology.IsSumHom st.σ]` for sum
-    preservation, `Function.Injective st.σ` where QUA pullback needs it. -/
+/-- The spatial trace σ assigns each event the path it traverses
+    ([zwarts-2005], [gawron-2009]), parallel to the temporal trace τ
+    (`Event.runtime`). Structural assumptions on σ are stated as mixins at
+    use sites, per `Semantics/Events/CEM.lean`: `[Mereology.IsSumHom st.σ]`
+    for sum preservation, `Function.Injective st.σ` where QUA pullback
+    needs it. -/
 class Trace (Loc Time : Type*) [LinearOrder Time] where
   /-- The path traversed in an event. -/
   σ : Event Time → Path Loc
@@ -46,19 +47,19 @@ variable {Loc Time : Type*} [LinearOrder Time] [Event.Mereology Time]
   [ClassicalMereology (Event Time)] [SemilatticeSup (Path Loc)]
   [st : Trace Loc Time] {P : Path Loc → Prop}
 
-/-- Bounded path predicate → telic VP: QUA pulls back through an injective
-    sum-homomorphic σ — [krifka-1998]'s quantization route to telicity,
-    stated for path predicates. [zwarts-2005] argues bounded PPs are not in
+/-- QUA path predicates pull back through an injective sum-homomorphic σ to
+    QUA (telic) VP predicates — [krifka-1998]'s quantization route to
+    telicity, stated for paths. [zwarts-2005] argues bounded PPs are not in
     fact quantized (bounded = non-cumulative instead; see
-    `Studies/Zwarts2005.lean`), so this theorem records the Krifka-style
-    analysis, applicable when a path predicate is QUA. -/
+    `Studies/Zwarts2005.lean`), so this records the Krifka-style analysis,
+    applicable when a path predicate is QUA. -/
 theorem bounded_path_telic [hσ : IsSumHom st.σ]
     (hinj : Function.Injective st.σ) (hP : QUA P) : QUA (P ∘ st.σ) :=
   qua_of_injective_sumHom hσ hinj hP
 
-/-- Unbounded path predicate → atelic VP: CUM pulls back through a
-    sum-homomorphic σ. *Walk towards the store* is atelic because *towards
-    the store* denotes a CUM set of paths ([zwarts-2005]). -/
+/-- CUM path predicates pull back through a sum-homomorphic σ to CUM
+    (atelic) VP predicates: *walk towards the store* is atelic because
+    *towards the store* denotes a cumulative set of paths ([zwarts-2005]). -/
 theorem unbounded_path_atelic [hσ : IsSumHom st.σ] (hP : CUM P) :
     CUM (P ∘ st.σ) :=
   cum_pullback hσ hP

--- a/Linglib/Studies/BroekhuisCorver2026.lean
+++ b/Linglib/Studies/BroekhuisCorver2026.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Properties
 import Linglib.Syntax.Category.Adposition.Order
 import Linglib.Studies.Dendikken1995ParticleVerbs
 import Linglib.Semantics.ArgumentStructure.AuxiliarySelection
-import Linglib.Semantics.Spatial.Path
+import Linglib.Semantics.Events.Path
 
 /-!
 # Broekhuis & Corver (2026): Adpositions in Dutch

--- a/Linglib/Studies/BroekhuisCorver2026.lean
+++ b/Linglib/Studies/BroekhuisCorver2026.lean
@@ -3,7 +3,7 @@ import Linglib.Syntax.Minimalist.ExtendedProjection.Properties
 import Linglib.Syntax.Category.Adposition.Order
 import Linglib.Studies.Dendikken1995ParticleVerbs
 import Linglib.Semantics.ArgumentStructure.AuxiliarySelection
-import Linglib.Semantics.Spatial.Trace
+import Linglib.Semantics.Spatial.Path
 
 /-!
 # Broekhuis & Corver (2026): Adpositions in Dutch
@@ -37,8 +37,7 @@ not whether F is overt. See `MovedConstituent`.
 
 - `Dutch.Adpositions`: lexical inventory
 - `Minimalist.Formal.ExtendedProjection`: Place/Path in EP
-- `Spatial.PathShape`: bounded/unbounded/source classification
-- `Spatial.Trace`: PathShape → telicity
+- `Spatial.Path.Directionality` × `Telicity`: the two-axis PP classification
 - `AuxiliarySelection` auxiliary selection: Dutch *zijn*/*hebben* split
 - `Dendikken1995`: particles as P heads
 - `Data.WALS.Features.F85A`: cross-linguistic adposition order
@@ -48,7 +47,7 @@ namespace BroekhuisCorver2026
 
 open Dutch.Adpositions
 open Minimalist
-open Spatial (PathShape)
+open Spatial (Path)
 
 -- ════════════════════════════════════════════════════
 -- § 1. PP-internal structure and surface orders
@@ -182,41 +181,38 @@ theorem place_path_family :
     catFamily .Path = .adpositional := place_path_adpositional
 
 -- ════════════════════════════════════════════════════
--- § 5. End-to-end: PathShape → telicity → auxiliary
+-- § 5. End-to-end: path shape → telicity → auxiliary
 -- ════════════════════════════════════════════════════
 
 /-! [broekhuis-corver-2026] §2.2 ex. 22: directional *de heuvel op*
     takes *zijn* (be), locational *op de heuvel* takes *hebben* (have).
-    This connects through `PathShape → telicity → unaccusativity →
+    This connects through `directionality × telicity → unaccusativity →
     auxiliary selection`. -/
 
-open Spatial.Trace (pathShapeToTelicity)
 open ArgumentStructure.AuxiliarySelection
 
-/-- All directional adpositions in the inventory carry a PathShape. -/
-theorem directional_adpositions_have_pathShape :
-    ∀ a ∈ dutchAdpositions, a.directional → a.pathShape.isSome :=
-  directional_has_pathShape
+/-- All directional adpositions in the inventory carry directionality and telicity. -/
+theorem directional_adpositions_have_pathType :
+    ∀ a ∈ dutchAdpositions, a.directional → a.pathType.isSome :=
+  directional_has_pathType
 
 /-- PostP-capable adpositions are directional (and locational). -/
 theorem postP_implies_directional :
     ∀ a ∈ dutchAdpositions, a.postPOk → a.directional :=
   fun a ha hpost => (postP_has_both_readings a ha hpost).2
 
-/-- PostP-capable adpositions have a PathShape. -/
-theorem postP_has_pathShape :
-    ∀ a ∈ dutchAdpositions, a.postPOk → a.pathShape.isSome := by
+/-- PostP-capable adpositions carry directionality and telicity. -/
+theorem postP_has_pathType :
+    ∀ a ∈ dutchAdpositions, a.postPOk → a.pathType.isSome := by
   intro a ha hpost
-  exact directional_has_pathShape a ha (postP_implies_directional a ha hpost)
+  exact directional_has_pathType a ha (postP_implies_directional a ha hpost)
 
-/-- End-to-end chain for *op*: directional → bounded path → telic.
+/-- End-to-end chain for *op*: directional → goal-oriented bounded path → telic.
     [broekhuis-corver-2026] §2.2 ex. 22: *De fietser is de heuvel
     op gereden* "The cyclist rode onto the hill" — *zijn* (be) because
-    directional postP *op* denotes a bounded path, which is telic. -/
+    directional postP *op* denotes a goal-oriented bounded path. -/
 theorem op_bounded_telic :
-    op.pathShape = some .bounded ∧
-    pathShapeToTelicity .bounded = .telic :=
-  ⟨rfl, rfl⟩
+    op.pathType = some (.goal, .telic) := rfl
 
 /-- End-to-end: telic → unaccusative → *zijn* (be) in Dutch.
     Dutch has a split auxiliary system ([sorace-2000]); unaccusative
@@ -225,11 +221,11 @@ theorem op_bounded_telic :
 theorem telic_unaccusative_zijn :
     canonicalSelection .unaccusative = .be := rfl
 
-/-- *op* (bounded) vs *van* (source): distinct PathShapes but both telic.
-    Goal-oriented and origin-oriented directionality both yield telic VPs. -/
+/-- *op* (goal) vs *van* (source): distinct directionalities, both telic —
+    the two axes are independent, and source directionality yields telic
+    VPs just as goal directionality does. -/
 theorem op_van_both_telic :
-    pathShapeToTelicity .bounded = .telic ∧
-    pathShapeToTelicity .source = .telic :=
+    op.pathType = some (.goal, .telic) ∧ van.pathType = some (.source, .telic) :=
   ⟨rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -33,7 +33,7 @@ This file inlines the §4 movement-relation predicates (formerly in
 * `telic_licenses_inX` / `durative_atelic_licenses_forX` — §3 for/in diagnostics.
 * `walked_from_to_telic_propositional` / `walked_towards_atelic_propositional` —
   σ-pullback backing the *walked from X to Y* / *walked towards X* analyses.
-* `pathShapeToTelicity_matches_motionData` — the substrate reproduces the §4.5
+* `pathType_telicity_matches_motionData` — the substrate reproduces the §4.5
   path-shape → telicity judgments of the `Data.Examples.Krifka1998` motion rows.
 
 ## TODO
@@ -281,19 +281,20 @@ end SpatialTracePullback
 section MotionData
 
 open Data.Examples (LinguisticExample)
-open Spatial (PathShape)
-open Spatial.Trace (pathShapeToTelicity)
+open Spatial (Path)
 
 /-- A motion VP datum: the path shape K98 assigns and the telicity it predicts. -/
 structure MotionDatum where
-  pathShape : PathShape
+  pathType : Path.Directionality × Telicity
   expectedTelicity : Telicity
   deriving DecidableEq, Repr
 
-private def parsePathShape : String → Option PathShape
-  | "bounded" => some .bounded
-  | "source" => some .source
-  | "unbounded" => some .unbounded
+-- The JSON rows label the K98-era single axis; the *towards* rows
+-- ("unbounded") are goal-directed per [zwarts-2005]'s (12b).
+private def parsePathType : String → Option (Path.Directionality × Telicity)
+  | "bounded" => some (.goal, .telic)
+  | "source" => some (.source, .telic)
+  | "unbounded" => some (.goal, .atelic)
   | _ => none
 
 private def parseTelicity : String → Option Telicity
@@ -303,17 +304,18 @@ private def parseTelicity : String → Option Telicity
 
 /-- Lift a `Data.Examples.Krifka1998` row to a `MotionDatum` via its paper features. -/
 def fromExample (e : LinguisticExample) : Option MotionDatum := do
-  let ps ← parsePathShape (← e.paperFeatures.lookup "pathShape")
+  let ps ← parsePathType (← e.paperFeatures.lookup "pathShape")
   let tel ← parseTelicity (← e.paperFeatures.lookup "expectedTelicity")
-  some { pathShape := ps, expectedTelicity := tel }
+  some { pathType := ps, expectedTelicity := tel }
 
 /-- The K98 §4.5 motion VP data, lifted from the JSON example rows. -/
 def motionData : List MotionDatum :=
   Examples.all.filterMap fromExample
 
-/-- `pathShapeToTelicity` reproduces the paper's telicity for every motion VP. -/
-theorem pathShapeToTelicity_matches_motionData :
-    ∀ d ∈ motionData, pathShapeToTelicity d.pathShape = d.expectedTelicity := by
+/-- The aspect axis of the path type reproduces the paper's telicity for
+    every motion VP. -/
+theorem pathType_telicity_matches_motionData :
+    ∀ d ∈ motionData, d.pathType.2 = d.expectedTelicity := by
   decide
 
 end MotionData

--- a/Linglib/Studies/Krifka1998.lean
+++ b/Linglib/Studies/Krifka1998.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.Aspect.Cumulativity
 import Linglib.Semantics.Events.Adjacency
-import Linglib.Semantics.Spatial.Trace
+import Linglib.Semantics.Events.SpatialTrace
 import Linglib.Features.Aktionsart
 import Linglib.Data.Examples.Krifka1998
 import Mathlib.Data.Finset.Basic
@@ -13,7 +13,7 @@ paper's deepest results: CUM/QUA propagation, telicity by initial/final parts,
 and the path-bounded movement-relation analysis.
 
 The substrate predicates (MO, MSO, MSE, SINC, INC, CumTheta — K98 §3.2) live
-in `Semantics/Events/`; the σ-trace pullback in `Semantics/Spatial/Trace.lean`.
+in `Semantics/Events/`; the σ-trace pullback in `Semantics/Events/SpatialTrace.lean`.
 This file inlines the §4 movement-relation predicates (formerly in
 `Semantics/Events/MovementRelations.lean`).
 

--- a/Linglib/Studies/Zwarts2005.lean
+++ b/Linglib/Studies/Zwarts2005.lean
@@ -25,8 +25,8 @@ built on it.
 * `weakTo_cumulative` vs `toPP_bounded` — the §4.1.1 argument: the weak
   goal-PP denotation is cumulative (wrong aspect), the strict one bounded.
 * `fromPP_bounded` — source PPs are bounded like goal PPs: no aspectual
-  source/goal asymmetry (12a), grounding `Spatial.Trace.pathShapeToTelicity`
-  mapping `.source` to `.telic`.
+  source/goal asymmetry (12a), grounding the telic marking of
+  source-directionality PPs (`Spatial.Path.Directionality`).
 * `towardsPP_concat_closed`, `awayFromPP_concat_closed`,
   `towardsPP_cumulative` — the comparative definitions (45)/(48) are
   cumulative, grounding `.unbounded ↦ .atelic`.
@@ -154,8 +154,8 @@ theorem toPP_bounded (x : Loc) : Bounded Path.IsConcat (toPP x) :=
   bounded_of_no_pairs (toPP_no_pairs x)
 
 /-- Strict source PPs are bounded, exactly like goal PPs — there is no
-    aspectual source/goal asymmetry (12a). Grounds
-    `Spatial.Trace.pathShapeToTelicity` sending `.source` to `.telic`. -/
+    aspectual source/goal asymmetry (12a). Grounds the telic marking of
+    source-directionality PPs (`Spatial.Path.Directionality`). -/
 theorem fromPP_bounded (x : Loc) : Bounded Path.IsConcat (fromPP x) := by
   rintro ⟨⟨p, hp, q, hq, r, hr⟩, -⟩
   exact hp.2 (hr.1.trans hq.1)
@@ -163,8 +163,8 @@ theorem fromPP_bounded (x : Loc) : Bounded Path.IsConcat (fromPP x) := by
 /-! ### Towards and away from (§4.1.3)
 
 The comparative definitions over a distance measure `d` to the reference
-object: cumulative, hence unbounded — grounding
-`Spatial.Trace.pathShapeToTelicity` sending `.unbounded` to `.atelic`. -/
+object: cumulative, hence unbounded — grounding the atelic marking of the
+comparative prepositions in the fragments' directionality × telicity data. -/
 
 /-- (45): *towards x* — the path ends nearer to the reference object than it
     starts, measured by `d`. -/

--- a/Linglib/Studies/Zwarts2005.lean
+++ b/Linglib/Studies/Zwarts2005.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Spatial.Trace
+import Linglib.Semantics.Events.SpatialTrace
 
 /-!
 # [zwarts-2005] *Prepositional Aspect and the Algebra of Paths*
@@ -8,7 +8,7 @@ Directional-PP denotations are sets of paths; what distinguishes telic PPs
 **partial** concatenation operation: atelic PPs are cumulative, telic PPs are
 not (21). The paper's Appendix A path algebra — `Spatial.Path` with
 `Path.IsConcat` (67) and the subpath order (68) — lives in
-`Semantics/Spatial/Path.lean`; this file formalizes the aspectual system
+`Semantics/Events/Path.lean`; this file formalizes the aspectual system
 built on it.
 
 ## Main definitions


### PR DESCRIPTION
Spatial API arc, third round (register sweep recovered from the #1913 automerge race, PathShape split, directory dissolution):

- `Semantics/Spatial/` dissolved into `Semantics/Events/` as too thin for a top-level cut (Diachronic/Sociolinguistics precedent): `Events/Path.lean` + `Events/SpatialTrace.lean`. The `Spatial` **namespace is kept** (namespace ≠ path), so re-minting the directory later is a pure file move.
- `PathShape` conflated [zwarts-2005]'s two independent axes ((12): no aspectual source/goal asymmetry). Replaced by `Path.Directionality` (source/goal/route) × `Features.Telicity` as a plain product; `pathShapeToTelicity` becomes the second projection and dies, as do the `PathShape` licensing shims (the `Telicity` instance covers). *Over* is the one route preposition in the Dutch data; Krifka's "unbounded" motion rows are goal-directed atelic.
- Declaration-docstring register sweep (no label-colon openers, no field restatement).