### PR TITLE
refactor(Features/Causation): Bool→Prop predicates, mathlib register

### DIFF
--- a/Linglib/Features/Causation.lean
+++ b/Linglib/Features/Causation.lean
@@ -1,160 +1,115 @@
 /-!
-# Features.Causation
-[talmy-1988] [wolff-2003] [karttunen-1971] [nadathur-2023-implicatives]
+# Causative and implicative verb features
 
-Per-verb-entry feature taxonomies for causal verb classifications:
-the `Causative` enum (force-dynamic mechanism) and the `Implicative`
-enum (Karttunen complement-entailment polarity).
+Per-verb-entry taxonomies for causal verb classification: the force-dynamic
+`Causative` classification and the [karttunen-1971] `Implicative` polarity.
 
-## Provenance
+`Causative`'s five-way `cause`/`make`/`force`/`enable`/`prevent` split extends
+the three-way force-dynamic taxonomy of [wolff-2003] (CAUSE / ENABLE / PREVENT)
+by subdividing CAUSE into counterfactual dependence (`cause`), direct
+sufficient guarantee (`make`), and coercive sufficiency (`force`) —
+distinctions [talmy-1988] discusses without crystallizing as named primitives.
+The `AssertsSufficiency`/`AssertsNecessity` classification follows
+[nadathur-lauer-2020]'s sufficiency/necessity decomposition and is
+characterized against the truth-conditional dispatch in
+`Semantics/Causation/Interpretation.lean` (`Causative.toSemantics`). Rival
+taxonomies carve causatives differently — [comrie-1989]'s
+lexical/morphological/syntactic scale, [shibatani-pardeshi-2002]'s directness
+continuum, [pylkkanen-2008]'s Cause-head theory — and are formalized in the
+studies that consume them.
 
-Bundled together (rather than 2 separate single-enum files) per the
-mathlib idiom of co-locating peer concepts. Moved from
-`Core/Lexical/VerbClass.lean` in the cleanup that dissolved `Core/Lexical/`.
-
-## Framework commitment
-
-Both enums here encode specific theoretical commitments rather than
-neutral substrate:
-
-- **Causative** (`Causative`): the 5-way `cause/make/force/enable/prevent`
-  split is **linglib's extension** of the 3-way force-dynamic taxonomy
-  of [wolff-2003] (CAUSE / ENABLE / PREVENT). The substrate
-  subdivides Wolff's CAUSE category into `{cause, make, force}` to
-  carry the counterfactual-dependence (`cause`) vs direct-sufficient-
-  guarantee (`make`) vs coercive-sufficiency (`force`) distinctions
-  that [talmy-1988] discusses but does not crystallize as named
-  primitives. The `assertsSufficiency`/`assertsNecessity`/`isCoercive`/
-  `isPermissive` derivations match the [nadathur-lauer-2020]
-  sufficiency/necessity decomposition.
-
-  Major non-force-dynamic frameworks for causation:
-  - [comrie-1989] typological scale (lexical / morphological /
-    syntactic causatives, with implications for productivity).
-  - Shibatani 1976 / Shibatani & Pardeshi 2002 directness typology
-    (direct vs indirect causation correlating with morphological vs
-    analytic encoding); not currently in `references.bib`.
-  - [pylkkanen-2008] Voice/Cause-head theory (where the cause
-    head is a separately licensed functional element).
-  None of these carve verbs into exactly the 5 cases here.
-
-  See `Semantics/Causation/Interpretation.lean` for the
-  force-dynamic mapping to truth conditions; alternative analyses live
-  in sibling Theories files.
-
-- **Implicative** (`Implicative`): the binary positive/negative split
-  is the [karttunen-1971] bipartition. Finer-grained alternatives:
-  Karttunen 2012 / Nairn et al. 2006 9-way matrix (`++`/`+-`/`-+`/
-  `--`/`+o`/`o+`/`-o`/`o-`/`oo`) capturing both one-direction and
-  two-direction implications, and update-semantics revisions that
-  treat implicativity as projection through context rather than direct
-  entailment. The substrate fixes 2 cases; richer frameworks need their
-  own enum (planned slot:
-  `Semantics/Implicative/NairnCondoravdiKarttunen.lean`).
-
-UNVERIFIED: Shibatani 1976 / Shibatani & Pardeshi 2002 publication
-details and Karttunen 2012 / Nairn-Condoravdi-Karttunen 2006 9-way
-matrix details cited from memory; verify before adding to
-`references.bib`.
+`Implicative` fixes [karttunen-1971]'s binary positive/negative bipartition;
+the finer nine-way entailment matrix of [nairn-condoravdi-karttunen-2006] and
+[karttunen-2012] is not encoded here. Implicatives differ structurally from
+causatives ([nadathur-2023-implicatives]): causatives predicate causation
+directly, while implicatives assert a prerequisite whose causal link to the
+complement is presupposed. `Semantics/Causation/Implicative.lean` carries that
+account.
 -/
 
 namespace Features
 
--- ════════════════════════════════════════════════════
--- § 1. Causative (force-dynamic mechanism)
--- ════════════════════════════════════════════════════
+/-! ### Force-dynamic causatives -/
 
-/-- How a causative verb's semantics is built from causal model infrastructure.
-
-    Names a **force-dynamic mechanism**, not a causal-model property.
-    `toSemantics` (in `Semantics/Causation/Interpretation.lean`)
-    maps each variant to its truth-condition function; properties like
-    sufficiency/necessity are derived via theorems.
-
-    - `cause`: Counterfactual dependence — removing cause blocks effect.
-    - `make`: Direct sufficient guarantee — adding cause ensures effect.
-    - `force`: Coercive sufficiency — overcome resistance, no alternatives.
-    - `enable`: Permissive — remove barrier so effect can occur.
-    - `prevent`: Blocking — add barrier so effect cannot occur. -/
+/-- Force-dynamic classification of causative verbs by the causal mechanism
+the verb lexicalizes. `Causative.toSemantics` (in
+`Semantics/Causation/Interpretation.lean`) maps each variant to its truth
+conditions. -/
 inductive Causative where
-  /-- Counterfactual dependence: removing cause → no effect.
-      Semantic function: `causeSem`. -/
+  /-- Counterfactual dependence: removing the cause blocks the effect (*cause*). -/
   | cause
-  /-- Direct sufficient guarantee: adding cause → effect.
-      Semantic function: `causallySufficient`. -/
+  /-- Direct sufficient guarantee: adding the cause ensures the effect (*make*). -/
   | make
-  /-- Coercive sufficiency: overcome resistance, no alternatives.
-      Same truth conditions as `make`; distinguished by `isCoercive`. -/
+  /-- Coercive sufficiency: the causer overcomes the causee's resistance (*force*). -/
   | force
-  /-- Permissive: remove barrier so effect can occur.
-      Same truth conditions as `make`; distinguished by `isPermissive`. -/
+  /-- Permissive: the causer removes a barrier so the effect can occur (*let*). -/
   | enable
-  /-- Blocking: add barrier so effect cannot occur.
-      Semantic function: `preventSem` (dual of `causeSem`). -/
+  /-- Blocking: the causer adds a barrier so the effect cannot occur (*prevent*). -/
   | prevent
   deriving DecidableEq, Repr
 
 namespace Causative
 
-/-- Does this variant assert causal sufficiency ([nadathur-lauer-2020]'s
-    definition (23))?
+/-- The variant asserts causal sufficiency ([nadathur-lauer-2020]): `make`,
+`force`, and `enable` share sufficiency truth conditions
+(`AssertsSufficiency.toSemantics_eq`). -/
+def AssertsSufficiency : Causative → Prop
+  | .make | .force | .enable => True
+  | .cause | .prevent => False
 
-    DERIVED: true for variants whose `toSemantics` maps to `causallySufficient`. -/
-def assertsSufficiency : Causative → Bool
-  | .make | .force | .enable => true
-  | .cause | .prevent => false
+instance : DecidablePred AssertsSufficiency := fun b => by
+  cases b <;> unfold AssertsSufficiency <;> infer_instance
 
-/-- Does this variant assert causal necessity ([nadathur-lauer-2020]'s
-    definition (24))?
+/-- The variant asserts causal necessity ([nadathur-lauer-2020]): only `cause`,
+whose truth conditions are counterfactual dependence
+(`AssertsNecessity.toSemantics_eq`). -/
+def AssertsNecessity : Causative → Prop
+  | .cause => True
+  | _ => False
 
-    DERIVED: true only for `.cause`, whose `toSemantics` maps to `causeSem`. -/
-def assertsNecessity : Causative → Bool
-  | .cause => true
-  | _ => false
+instance : DecidablePred AssertsNecessity := fun b => by
+  cases b <;> unfold AssertsNecessity <;> infer_instance
 
-/-- Does this variant encode coercion (overcoming resistance)?
+/-- The variant encodes coercion: `force` lexicalizes overcoming the causee's
+resistance, distinguishing it from `make` despite shared truth conditions. -/
+def IsCoercive : Causative → Prop
+  | .force => True
+  | _ => False
 
-    Force-dynamic property: `.force` encodes that the causer overcame
-    the causee's resistance. -/
-def isCoercive : Causative → Bool
-  | .force => true
-  | _ => false
+instance : DecidablePred IsCoercive := fun b => by
+  cases b <;> unfold IsCoercive <;> infer_instance
 
-/-- Does this variant encode permissivity (barrier removal)?
+/-- The variant encodes permission: `enable` lexicalizes removing a barrier,
+distinguishing it from `make` despite shared truth conditions. -/
+def IsPermissive : Causative → Prop
+  | .enable => True
+  | _ => False
 
-    Force-dynamic property: `.enable` encodes that the causer removed
-    a barrier, allowing the effect to occur naturally. -/
-def isPermissive : Causative → Bool
-  | .enable => true
-  | _ => false
+instance : DecidablePred IsPermissive := fun b => by
+  cases b <;> unfold IsPermissive <;> infer_instance
 
 end Causative
 
--- ════════════════════════════════════════════════════
--- § 2. Implicative (Karttunen 1971 polarity)
--- ════════════════════════════════════════════════════
+/-! ### Implicative polarity -/
 
-/-- Polarity for implicative verbs.
-
-    Positive implicatives (*manage*, *remember*) entail the complement on success.
-    Negative implicatives (*fail*, *forget*) entail the complement does NOT hold
-    on success.
-
-    Note: `Implicative` and `Causative` are structurally different
-    ([nadathur-2023-implicatives]): causatives directly predicate causation (make/cause →
-    sufficiency/necessity), while implicatives predicate a prerequisite whose
-    causal relationship to the complement is only presupposed. -/
+/-- [karttunen-1971] polarity for implicative verbs: positive implicatives
+entail their complement, negative implicatives entail its negation. -/
 inductive Implicative where
-  | positive   -- manage, remember: success → complement true
-  | negative   -- fail, forget: success → complement NOT true
+  /-- The verb entails its complement (*manage*, *remember*). -/
+  | positive
+  /-- The verb entails the negation of its complement (*fail*, *forget*). -/
+  | negative
   deriving DecidableEq, Repr
 
 namespace Implicative
 
-/-- Whether the verb entails the complement (positive) or its negation (negative). -/
-def entailsComplement : Implicative → Bool
-  | .positive => true
-  | .negative => false
+/-- The polarity entails the complement rather than its negation. -/
+def EntailsComplement : Implicative → Prop
+  | .positive => True
+  | .negative => False
+
+instance : DecidablePred EntailsComplement := fun i => by
+  cases i <;> unfold EntailsComplement <;> infer_instance
 
 end Implicative
 

--- a/Linglib/Features/Causation.lean
+++ b/Linglib/Features/Causation.lean
@@ -1,30 +1,18 @@
 /-!
 # Causative and implicative verb features
 
-Per-verb-entry taxonomies for causal verb classification: the force-dynamic
-`Causative` classification and the [karttunen-1971] `Implicative` polarity.
+This file defines two classifications carried by verb lexical entries:
+`Causative`, the force-dynamic mechanism a causative verb lexicalizes, and
+`Implicative`, the polarity of an implicative verb's complement entailment.
 
-`Causative`'s five-way `cause`/`make`/`force`/`enable`/`prevent` split extends
-the three-way force-dynamic taxonomy of [wolff-2003] (CAUSE / ENABLE / PREVENT)
-by subdividing CAUSE into counterfactual dependence (`cause`), direct
-sufficient guarantee (`make`), and coercive sufficiency (`force`) —
-distinctions [talmy-1988] discusses without crystallizing as named primitives.
-The `AssertsSufficiency`/`AssertsNecessity` classification follows
-[nadathur-lauer-2020]'s sufficiency/necessity decomposition and is
-characterized against the truth-conditional dispatch in
-`Semantics/Causation/Interpretation.lean` (`Causative.toSemantics`). Rival
-taxonomies carve causatives differently — [comrie-1989]'s
-lexical/morphological/syntactic scale, [shibatani-pardeshi-2002]'s directness
-continuum, [pylkkanen-2008]'s Cause-head theory — and are formalized in the
-studies that consume them.
+## References
 
-`Implicative` fixes [karttunen-1971]'s binary positive/negative bipartition;
-the finer nine-way entailment matrix of [nairn-condoravdi-karttunen-2006] and
-[karttunen-2012] is not encoded here. Implicatives differ structurally from
-causatives ([nadathur-2023-implicatives]): causatives predicate causation
-directly, while implicatives assert a prerequisite whose causal link to the
-complement is presupposed. `Semantics/Causation/Implicative.lean` carries that
-account.
+* [Lauri Karttunen, *Implicative Verbs*][karttunen-1971]
+* [Prerna Nadathur and Sven Lauer, *Causal Necessity, Causal Sufficiency, and
+  the Implications of Causative Verbs*][nadathur-lauer-2020]
+* [Leonard Talmy, *Force dynamics in language and cognition*][talmy-1988]
+* [Phillip Wolff, *Direct causation in the linguistic coding and individuation
+  of causal events*][wolff-2003]
 -/
 
 namespace Features
@@ -50,9 +38,8 @@ inductive Causative where
 
 namespace Causative
 
-/-- The variant asserts causal sufficiency ([nadathur-lauer-2020]): `make`,
-`force`, and `enable` share sufficiency truth conditions
-(`AssertsSufficiency.toSemantics_eq`). -/
+/-- The variant asserts causal sufficiency: `make`, `force`, and `enable`
+share sufficiency truth conditions (`AssertsSufficiency.toSemantics_eq`). -/
 def AssertsSufficiency : Causative → Prop
   | .make | .force | .enable => True
   | .cause | .prevent => False
@@ -60,9 +47,8 @@ def AssertsSufficiency : Causative → Prop
 instance : DecidablePred AssertsSufficiency := fun b => by
   cases b <;> unfold AssertsSufficiency <;> infer_instance
 
-/-- The variant asserts causal necessity ([nadathur-lauer-2020]): only `cause`,
-whose truth conditions are counterfactual dependence
-(`AssertsNecessity.toSemantics_eq`). -/
+/-- The variant asserts causal necessity: only `cause`, whose truth conditions
+are counterfactual dependence (`AssertsNecessity.toSemantics_eq`). -/
 def AssertsNecessity : Causative → Prop
   | .cause => True
   | _ => False
@@ -92,8 +78,8 @@ end Causative
 
 /-! ### Implicative polarity -/
 
-/-- [karttunen-1971] polarity for implicative verbs: positive implicatives
-entail their complement, negative implicatives entail its negation. -/
+/-- Polarity for implicative verbs: positive implicatives entail their
+complement, negative implicatives entail its negation. -/
 inductive Implicative where
   /-- The verb entails its complement (*manage*, *remember*). -/
   | positive

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -3384,16 +3384,16 @@ referenced `Causative.toSemantics` over `CausalDynamics`) were removed
 in Phase D-G in favor of the polymorphic V2 versions. -/
 
 /-- "make" asserts sufficiency — derived from its builder. -/
-theorem make_asserts_sufficiency : make.toVerb.assertsSufficiency = true := by decide
+theorem make_asserts_sufficiency : make.toVerb.AssertsSufficiency := by decide
 
 /-- "cause" asserts necessity — derived from its builder. -/
-theorem cause_asserts_necessity : cause.toVerb.assertsNecessity = true := by decide
+theorem cause_asserts_necessity : cause.toVerb.AssertsNecessity := by decide
 
 /-- "make" does NOT assert necessity. -/
-theorem make_not_necessity : make.toVerb.assertsNecessity = false := by decide
+theorem make_not_necessity : ¬ make.toVerb.AssertsNecessity := by decide
 
 /-- "cause" does NOT assert sufficiency. -/
-theorem cause_not_sufficiency : cause.toVerb.assertsSufficiency = false := by decide
+theorem cause_not_sufficiency : ¬ cause.toVerb.AssertsSufficiency := by decide
 
 /-- make-type verbs (make, have, get) share the `.make` builder. -/
 theorem make_type_verbs_share_semantics :
@@ -3402,16 +3402,16 @@ theorem make_type_verbs_share_semantics :
 
 /-- "force" is coercive — derived from its builder. -/
 theorem force_is_coercive :
-    force.causative.map (·.isCoercive) = some true := rfl
+    ∃ c ∈ force.causative, c.IsCoercive := ⟨.force, rfl, trivial⟩
 
 /-- "let" is permissive — derived from its builder. -/
 theorem let_is_permissive :
-    let_.causative.map (·.isPermissive) = some true := rfl
+    ∃ c ∈ let_.causative, c.IsPermissive := ⟨.enable, rfl, trivial⟩
 
 /-- "prevent" asserts neither sufficiency nor necessity —
     it uses the dual `preventSem` (blocking). -/
 theorem prevent_not_sufficiency :
-    prevent.toVerb.assertsSufficiency = false := by decide
+    ¬ prevent.toVerb.AssertsSufficiency := by decide
 
 /-- "prevent" is an EN trigger — it entails ¬p in w₀ (complement
     falsity), satisfying the FORGET class licensing condition
@@ -3438,11 +3438,11 @@ theorem lexical_causatives_use_make :
 
 /-- Lexical causatives all assert sufficiency — like periphrastic "make". -/
 theorem lexical_causatives_assert_sufficiency :
-    kill.toVerb.assertsSufficiency = true ∧
-    break_.toVerb.assertsSufficiency = true ∧
-    burn.toVerb.assertsSufficiency = true ∧
-    destroy.toVerb.assertsSufficiency = true ∧
-    melt.toVerb.assertsSufficiency = true := by
+    kill.toVerb.AssertsSufficiency ∧
+    break_.toVerb.AssertsSufficiency ∧
+    burn.toVerb.AssertsSufficiency ∧
+    destroy.toVerb.AssertsSufficiency ∧
+    melt.toVerb.AssertsSufficiency := by
   refine ⟨by decide, by decide, by decide,
           by decide, by decide⟩
 
@@ -3463,19 +3463,19 @@ removed in Phase D-G. -/
 
 /-- "manage" entails the complement — derived from its builder. -/
 theorem manage_entails_complement_derived :
-    manage.toVerb.entailsComplement = some true := by decide
+    ∃ i ∈ manage.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
 
 /-- "fail" entails NOT the complement — derived from its builder. -/
 theorem fail_entails_not_complement_derived :
-    fail.toVerb.entailsComplement = some false := by decide
+    ∃ i ∈ fail.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
 
 /-- "remember" entails the complement — derived from its builder. -/
 theorem remember_entails_complement_derived :
-    remember.toVerb.entailsComplement = some true := by decide
+    ∃ i ∈ remember.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
 
 /-- "forget" entails NOT the complement — derived from its builder. -/
 theorem forget_entails_not_complement_derived :
-    forget.toVerb.entailsComplement = some false := by decide
+    ∃ i ∈ forget.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
 
 -- ════════════════════════════════════════════════════
 -- § V2 Causative Grounding Theorems (Phase D-D)

--- a/Linglib/Semantics/Causation/Interpretation.lean
+++ b/Linglib/Semantics/Causation/Interpretation.lean
@@ -15,7 +15,7 @@ import Linglib.Semantics.Causation.Prevention
 Maps `Causative` verb classifications to their compositional semantics
 under the **force-dynamic** view ([talmy-1988], [wolff-2003]),
 which collapses `enable`/`force`/`make` into a single sufficiency
-predicate (`causallySufficient`) distinguished post-hoc by `isCoercive`/`isPermissive`.
+predicate (`makeSem`) distinguished post-hoc by `IsCoercive`/`IsPermissive`.
 
 | Causative | Mechanism | English verbs | N&L property (derived) |
 |-----------|-----------|---------------|----------------------|
@@ -79,6 +79,24 @@ noncomputable def toSemantics {V : Type*} {α : V → Type*}
   | .enable => Causation.Sufficiency.makeSem M
   | .prevent => Causation.Prevention.preventSem M
 
+/-- Sufficiency-asserting variants share `makeSem` truth conditions: the
+`AssertsSufficiency` classification tracks the force-dynamic dispatch. -/
+theorem AssertsSufficiency.toSemantics_eq {V : Type*} {α : V → Type*}
+    [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α v)]
+    (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
+    {b : Causative} (h : b.AssertsSufficiency) :
+    b.toSemantics M = Causation.Sufficiency.makeSem M := by
+  cases b <;> first | rfl | exact (h : False).elim
+
+/-- The necessity-asserting variant has `causeSem` truth conditions: the
+`AssertsNecessity` classification tracks the force-dynamic dispatch. -/
+theorem AssertsNecessity.toSemantics_eq {V : Type*} {α : V → Type*}
+    [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α v)]
+    (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
+    {b : Causative} (h : b.AssertsNecessity) :
+    b.toSemantics M = Causation.Necessity.causeSem M := by
+  cases b <;> first | rfl | exact (h : False).elim
+
 end Features.Causative
 
 /-! ### Derivation theorems (substrate-independent) -/
@@ -90,13 +108,11 @@ open Features
 
 /-- `make` and `force` are distinguished by coercion despite sharing truth conditions. -/
 theorem make_force_distinguished_by_coercion :
-    Causative.make.isCoercive = false ∧
-    Causative.force.isCoercive = true := ⟨rfl, rfl⟩
+    ¬ Causative.make.IsCoercive ∧ Causative.force.IsCoercive := ⟨id, trivial⟩
 
 /-- `make` and `enable` are distinguished by permissivity despite sharing truth conditions. -/
 theorem make_enable_distinguished_by_permissivity :
-    Causative.make.isPermissive = false ∧
-    Causative.enable.isPermissive = true := ⟨rfl, rfl⟩
+    ¬ Causative.make.IsPermissive ∧ Causative.enable.IsPermissive := ⟨id, trivial⟩
 
 /-! ### Bridge to CC-Selection -/
 
@@ -107,9 +123,9 @@ but connected: each variant has a canonical selection mode. -/
 
 /-- Sufficiency variants have completion selection mode. -/
 theorem sufficiency_selects_completion (b : Causative)
-    (h : b.assertsSufficiency = true) :
+    (h : b.AssertsSufficiency) :
     b.selectionMode = .completionOfSufficientSet := by
-  cases b <;> simp_all [Causative.assertsSufficiency, Causative.selectionMode]
+  cases b <;> first | rfl | exact (h : False).elim
 
 /-- Necessity variant has member selection mode. -/
 theorem necessity_selects_member :

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -173,11 +173,11 @@ theorem dependence_analogous_cause :
 
 /-- P-CAUSE's analogous builder asserts sufficiency. -/
 theorem production_asserts_sufficiency :
-    CausationType.production.analogousBuilder.assertsSufficiency = true := rfl
+    CausationType.production.analogousBuilder.AssertsSufficiency := trivial
 
 /-- D-CAUSE's analogous builder asserts necessity. -/
 theorem dependence_asserts_necessity :
-    CausationType.dependence.analogousBuilder.assertsNecessity = true := rfl
+    CausationType.dependence.analogousBuilder.AssertsNecessity := trivial
 
 /-! ## Bridge to Resultatives
 

--- a/Linglib/Semantics/Causation/Resultatives.lean
+++ b/Linglib/Semantics/Causation/Resultatives.lean
@@ -92,12 +92,12 @@ def deriveCausativeBuilder (rel : SubeventRelation) (desc : SubeventDesc) :
 
 /-- `.make` is the unique builder asserting neutral sufficiency. -/
 theorem make_unique_neutral_sufficiency (b : Causative)
-    (hs : b.assertsSufficiency = true)
-    (hc : b.isCoercive = false)
-    (hp : b.isPermissive = false) :
+    (hs : b.AssertsSufficiency)
+    (hc : ¬ b.IsCoercive)
+    (hp : ¬ b.IsPermissive) :
     b = .make := by
-  cases b <;> simp_all [Causative.assertsSufficiency,
-    Causative.isCoercive, Causative.isPermissive]
+  cases b <;> simp_all [Causative.AssertsSufficiency,
+    Causative.IsCoercive, Causative.IsPermissive]
 
 /-- MEANS + CAUSE derives `.make`. -/
 theorem means_cause_derives_make (desc : SubeventDesc)
@@ -130,10 +130,10 @@ theorem non_means_no_builder (desc : SubeventDesc) :
 /-- When `deriveCausativeBuilder` succeeds, the result asserts sufficiency. -/
 theorem derived_asserts_sufficiency (rel : SubeventRelation) (desc : SubeventDesc)
     (b : Causative) (h : deriveCausativeBuilder rel desc = some b) :
-    b.assertsSufficiency = true := by
+    b.AssertsSufficiency := by
   unfold deriveCausativeBuilder at h
   split at h
-  · simp only [Option.some.injEq] at h; subst h; rfl
+  · simp only [Option.some.injEq] at h; subst h; trivial
   · simp at h
 
 /-- The resultative Causative, derived from MEANS + CAUSE. -/

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -264,12 +264,12 @@ structure InitiativeCausativeLink (Entity Time : Type*) [LinearOrder Time]
     volitional causee, which is precisely the initiative pattern
     where the initiator overrides the causee's will. -/
 theorem force_lexicalizes_coercive_initiative :
-    Causative.force.isCoercive = true := rfl
+    Causative.force.IsCoercive := trivial
 
 /-- The make builder asserts sufficiency — the initiator's action
     is sufficient for the causee to act. -/
 theorem make_lexicalizes_sufficient_initiative :
-    Causative.make.assertsSufficiency = true := rfl
+    Causative.make.AssertsSufficiency := trivial
 
 -- ════════════════════════════════════════════════════
 -- § 7. Stative Do-Verbs (Challenge to agent_selects_action)

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1080,7 +1080,7 @@ open Features (Causative Implicative)
     builder's polarity, not stipulated.
     [nadathur-2023]: negative implicatives entail complement falsity. -/
 theorem forget_grounded_in_implicativity :
-    Implicative.negative.entailsComplement = false := rfl
+    ¬ Implicative.negative.EntailsComplement := id
 
 /-- STOP/PREVENT are causative preventatives: "X prevented Y" entails
     that Y did NOT occur (¬p in w₀). The negative entailment comes from
@@ -1088,7 +1088,7 @@ theorem forget_grounded_in_implicativity :
     [nadathur-lauer-2020]: prevent = effect blocked with preventer,
     would have occurred without it. -/
 theorem prevent_is_causative_builder :
-    (Causative.prevent).assertsSufficiency = false := rfl
+    ¬ Causative.prevent.AssertsSufficiency := id
 
 /-- The FORGET class is unified by real-world negative entailment:
     all subclasses entail ¬p in w₀ (or worlds close to w₀), but

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -195,13 +195,13 @@ theorem believe_not_implicative :
 -- ── Derived entailment predictions ──
 
 theorem manage_entails :
-    manage.toVerb.entailsComplement = some true := by native_decide
+    ∃ i ∈ manage.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
 
 theorem fail_entails_not :
-    fail.toVerb.entailsComplement = some false := by native_decide
+    ∃ i ∈ fail.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
 
 theorem hope_no_complement_entailment :
-    hope.toVerb.entailsComplement = none := rfl
+    hope.toVerb.implicative = none := rfl
 
 -- ── Raising vs control ──
 
@@ -253,10 +253,10 @@ theorem force_has_causative :
     force.toVerb.causative = some .force := rfl
 
 theorem force_asserts_sufficiency :
-    Causative.force.assertsSufficiency = true := rfl
+    Causative.force.AssertsSufficiency := trivial
 
 theorem force_no_necessity :
-    Causative.force.assertsNecessity = false := rfl
+    ¬ Causative.force.AssertsNecessity := id
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6. KarttunenClass → Entailment Predictions

--- a/Linglib/Studies/NadathurLauer2020.lean
+++ b/Linglib/Studies/NadathurLauer2020.lean
@@ -773,8 +773,8 @@ theorem cause_karttunen_class :
     scenario: `makeSem` holds while `causeSem` fails). -/
 theorem cause_make_same_cell_different_mechanism :
     karttunenOfCausative .cause = karttunenOfCausative .make ∧
-    Causative.cause.assertsNecessity ≠ Causative.make.assertsNecessity := by
-  exact ⟨rfl, by decide⟩
+    Causative.cause.AssertsNecessity ∧ ¬ Causative.make.AssertsNecessity :=
+  ⟨rfl, trivial, id⟩
 
 end KarttunenCells
 

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -114,9 +114,14 @@ def Verb.isCausative (v : Verb) : Bool :=
 
 /-- Does this causative verb assert sufficiency (like "make")?
 
-    DERIVED: delegates to `Causative.assertsSufficiency`. -/
-def Verb.assertsSufficiency (v : Verb) : Bool :=
-  v.causative.map (·.assertsSufficiency) |>.getD false
+    DERIVED: delegates to `Causative.AssertsSufficiency`. -/
+def Verb.AssertsSufficiency (v : Verb) : Prop :=
+  match v.causative with
+  | some c => c.AssertsSufficiency
+  | none => False
+
+instance : DecidablePred Verb.AssertsSufficiency := fun v => by
+  unfold Verb.AssertsSufficiency; split <;> infer_instance
 
 /-- Lexicalist prediction of the external argument's theta role
     ([levin-1993], [rappaport-hovav-levin-1998]), based solely
@@ -173,17 +178,14 @@ def Verb.isENTrigger (v : Verb) : Bool :=
 
 /-- Does this causative verb assert necessity (like "cause")?
 
-    DERIVED: delegates to `Causative.assertsNecessity`. -/
-def Verb.assertsNecessity (v : Verb) : Bool :=
-  v.causative.map (·.assertsNecessity) |>.getD false
+    DERIVED: delegates to `Causative.AssertsNecessity`. -/
+def Verb.AssertsNecessity (v : Verb) : Prop :=
+  match v.causative with
+  | some c => c.AssertsNecessity
+  | none => False
 
-/-- Does success of this implicative verb entail the complement?
-
-    DERIVED: delegates to `Implicative.entailsComplement`.
-    Returns `some true` for positive implicatives (*manage*, *remember*),
-    `some false` for negative (*fail*, *forget*), `none` for non-implicatives. -/
-def Verb.entailsComplement (v : Verb) : Option Bool :=
-  v.implicative.map (·.entailsComplement)
+instance : DecidablePred Verb.AssertsNecessity := fun v => by
+  unfold Verb.AssertsNecessity; split <;> infer_instance
 
 /-- Is this verb a preferential attitude predicate? -/
 def Verb.isPreferentialAttitude (v : Verb) : Bool :=

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10236,6 +10236,47 @@
   validated = {true},
   sources   = {Semantics/Attitudes/Factivity.lean;Semantics/Causation/Implicative.lean;Fragments/English/Predicates/Verbal.lean;Studies/Karttunen1971.lean}
 }
+@inproceedings{karttunen-2012,
+  author    = {Karttunen, Lauri},
+  year      = {2012},
+  title     = {Simple and Phrasal Implicatives},
+  booktitle = {*{SEM} 2012: The First Joint Conference on Lexical and Computational Semantics},
+  pages     = {124--131},
+  address   = {Montr{\'e}al, Canada},
+  publisher = {Association for Computational Linguistics},
+  url       = {https://aclanthology.org/S12-1020/},
+  subfield  = {semantics/causation},
+  role      = {cited},
+  validated = {true},
+  sources   = {Features/Causation.lean}
+}
+@inproceedings{nairn-condoravdi-karttunen-2006,
+  author    = {Nairn, Rowan and Condoravdi, Cleo and Karttunen, Lauri},
+  year      = {2006},
+  title     = {Computing Relative Polarity for Textual Inference},
+  booktitle = {Proceedings of the Fifth International Workshop on Inference in Computational Semantics ({ICoS}-5)},
+  url       = {https://aclanthology.org/W06-3907/},
+  subfield  = {semantics/causation},
+  role      = {cited},
+  validated = {true},
+  sources   = {Features/Causation.lean}
+}
+@incollection{shibatani-pardeshi-2002,
+  author    = {Shibatani, Masayoshi and Pardeshi, Prashant},
+  year      = {2002},
+  title     = {The Causative Continuum},
+  booktitle = {The Grammar of Causation and Interpersonal Manipulation},
+  editor    = {Shibatani, Masayoshi},
+  series    = {Typological Studies in Language},
+  volume    = {48},
+  pages     = {85--126},
+  publisher = {John Benjamins},
+  doi       = {10.1075/tsl.48.07shi},
+  subfield  = {semantics/causation},
+  role      = {cited},
+  validated = {true},
+  sources   = {Features/Causation.lean}
+}
 @phdthesis{tay-2024,
   author    = {Tay, Wenkai},
   year      = {2024},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10248,7 +10248,6 @@
   subfield  = {semantics/causation},
   role      = {cited},
   validated = {true},
-  sources   = {Features/Causation.lean}
 }
 @inproceedings{nairn-condoravdi-karttunen-2006,
   author    = {Nairn, Rowan and Condoravdi, Cleo and Karttunen, Lauri},
@@ -10259,7 +10258,6 @@
   subfield  = {semantics/causation},
   role      = {cited},
   validated = {true},
-  sources   = {Features/Causation.lean}
 }
 @incollection{shibatani-pardeshi-2002,
   author    = {Shibatani, Masayoshi and Pardeshi, Prashant},
@@ -10275,7 +10273,6 @@
   subfield  = {semantics/causation},
   role      = {cited},
   validated = {true},
-  sources   = {Features/Causation.lean}
 }
 @phdthesis{tay-2024,
   author    = {Tay, Wenkai},


### PR DESCRIPTION
Deep audit of `Features/Causation.lean`: the five classification predicates become `Prop` with `DecidablePred` instances, and the module docstring moves to mathlib register with the UNVERIFIED citation block resolved (Shibatani–Pardeshi 2002, Nairn–Condoravdi–Karttunen 2006, Karttunen 2012 verified and added to the bib).

- new `AssertsSufficiency.toSemantics_eq` / `AssertsNecessity.toSemantics_eq` characterize the classification against the force-dynamic dispatch
- `Verb.entailsComplement : Option Bool` dissolved into `∃ i ∈ v.implicative, …` statements; the two `native_decide`s in Karttunen1971 become term proofs