### PR TITLE
refactor(Semantics/Causation): root Causative/Implicative in VerbClass

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -658,7 +658,6 @@ import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Capabilities
 import Linglib.Features.Case.Grammaticalization
 import Linglib.Features.Case.Source
-import Linglib.Features.Causation
 import Linglib.Features.Clusivity
 import Linglib.Features.ContainmentPair
 import Linglib.Features.CoreferenceStatus
@@ -1548,6 +1547,7 @@ import Linglib.Semantics.Causation.SEM.Deterministic
 import Linglib.Semantics.Causation.Strength
 import Linglib.Semantics.Causation.Sufficiency
 import Linglib.Semantics.Causation.Valuation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.Classifier
 import Linglib.Semantics.Composition.Combinator
 import Linglib.Semantics.Composition.Cont

--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -22,7 +22,7 @@ namespace English.Predicates.Verbal
 -- Re-export Features verb-entry vocabulary so downstream files that open this
 -- namespace continue to find it. The `Verb`/`ComplementType`/… types now
 -- live at the root namespace (`Syntax/Category/Verb/Defs`), so they need no re-export.
-export Features (Preferential Attitude Causative Implicative)
+export Features (Preferential Attitude)
 
 open Features
 open ArgumentStructure
@@ -3534,12 +3534,12 @@ theorem lexical_causatives_match_make :
 /-- "manage" → polymorphic `Implicative.manageSem`. -/
 theorem manage_semantics_implicative :
     manage.implicative.map (Implicative.toSemantics M) =
-    some (Causation.Implicative.manageSem M) := rfl
+    some (Implicative.manageSem M) := rfl
 
 /-- "fail" → polymorphic `Implicative.failSem`. -/
 theorem fail_semantics_implicative :
     fail.implicative.map (Implicative.toSemantics M) =
-    some (Causation.Implicative.failSem M) := rfl
+    some (Implicative.failSem M) := rfl
 
 end V2
 

--- a/Linglib/Fragments/Finnish/Predicates.lean
+++ b/Linglib/Fragments/Finnish/Predicates.lean
@@ -178,8 +178,7 @@ theorem finnish_is_active_passive :
 
     The structure extends `FinnishVerb` with implicative fields. -/
 
-open Features (Implicative)
-open Causation.Implicative (Directionality Prerequisite ImplicativeClass)
+open Implicative (Directionality Prerequisite ImplicativeClass)
 
 /-- A Finnish implicative verb entry, extending the base verb with
     implicative classification from [nadathur-2023-implicatives]. -/

--- a/Linglib/Fragments/Ga/Predicates.lean
+++ b/Linglib/Fragments/Ga/Predicates.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Fragments.Ga.Basic
 import Linglib.Syntax.Clause.Complementation
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 
 /-!
 # Gã Complement-Taking Predicates
@@ -29,7 +29,6 @@ See `Fragments/Ga/Basic.lean` for rationale.
 
 namespace Ga
 
-open Features (Implicative)
 
 /-- A Gã complement-taking predicate: form, gloss, the embedded clause
     types it is attested with, the control relation of its `ni`-frame

--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -27,7 +27,6 @@ German preferential attitudes pattern with other Indo-European languages:
 namespace German.Predicates
 
 open ArgumentStructure
-open Features (Causative)
 
 /-- German verb entry: extends Verb with German inflectional paradigm. -/
 structure GermanVerbEntry extends Verb where

--- a/Linglib/Fragments/Japanese/Predicates.lean
+++ b/Linglib/Fragments/Japanese/Predicates.lean
@@ -13,7 +13,6 @@ namespace Japanese.Predicates
 
 open ArgumentStructure
 open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
-open Features (Causative)
 
 /-- Japanese verb entry: extends Verb with Japanese inflectional paradigm. -/
 structure JapaneseVerbEntry extends Verb where

--- a/Linglib/Fragments/Korean/Predicates.lean
+++ b/Linglib/Fragments/Korean/Predicates.lean
@@ -15,7 +15,6 @@ event is not entailed to have actually occurred.
 namespace Korean.Predicates
 
 open ArgumentStructure
-open Features (Causative)
 
 /-- Korean verb entry: extends Verb with Korean inflectional paradigm. -/
 structure KoreanVerbEntry extends Verb where

--- a/Linglib/Fragments/Romance/French/Predicates.lean
+++ b/Linglib/Fragments/Romance/French/Predicates.lean
@@ -17,7 +17,6 @@ despite being separate words.
 namespace French.Predicates
 
 open ArgumentStructure
-open Features (Causative)
 open ArgumentStructure
 open ArgumentStructure (experiencerProfile)
 

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -13,7 +13,6 @@ namespace Turkish.Predicates
 
 open ArgumentStructure
 open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
-open Features (Causative)
 
 /-- Turkish verb entry: extends Verb with Turkish inflectional paradigm. -/
 structure TurkishVerbEntry extends Verb where

--- a/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
+++ b/Linglib/Semantics/ArgumentStructure/LevinTheory.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.ArgumentStructure.Root.Kinds

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -44,7 +44,7 @@ import Linglib.Semantics.Causation.SEM.Bool
 import Linglib.Semantics.Causation.SEM.Counterfactual
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -45,7 +45,7 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Set.Basic
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.Attitudes.CDistributivity

--- a/Linglib/Semantics/Causation/Implicative.lean
+++ b/Linglib/Semantics/Causation/Implicative.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.Causation.SEM.Counterfactual
@@ -39,9 +39,8 @@ were deleted in Phase D-H. The polymorphic V2 versions
 dispatch) are promoted to canonical here.
 -/
 
-namespace Causation.Implicative
+namespace Implicative
 
-open Features (Implicative)
 open Features
 open Causation (SEM CausalGraph Valuation DecidableValuation)
 
@@ -100,7 +99,7 @@ noncomputable instance {V : Type*} {α : V → Type*}
     TODO: this is denial of the sufficiency presupposition, which is what
     the Dreyfus infelicity judgments test, but it is NOT Proposal 32's
     semantics for negative implicative *assertions* (assert ¬A(x) with
-    both presuppositions intact); the `Features.Implicative.toSemantics`
+    both presuppositions intact); the `Implicative.toSemantics`
     `.negative` dispatch below inherits the same caveat. -/
 abbrev failSem {V : Type*} {α : V → Type*}
     [Fintype V] [DecidableEq V] [DecidableValuation α]
@@ -346,17 +345,15 @@ theorem specific_vs_bleached :
     (ImplicativeClass.manage.prerequisite.bind (some ·.isSpecific)) = some false := by
   exact ⟨rfl, rfl⟩
 
-end Causation.Implicative
+end Implicative
 
-/-! ### `Features.Implicative.toSemantics` dispatch (V2 polymorphic) -/
+/-! ### `Implicative.toSemantics` dispatch (V2 polymorphic) -/
 
-/-! Lives here rather than in `Features/Causation.lean` because the
+/-! Lives here rather than in `Semantics/Causation/VerbClass.lean` because the
 dispatch needs `Causation.SEM` + the `Implicative.manageSem`/`failSem`
-machinery defined above; `Features/Causation.lean` is kept import-free.
-Standard mathlib pattern: methods on a type may live in a sibling
-file via `namespace TypeName` block when import weight matters. -/
+machinery defined above; `VerbClass.lean` is kept import-free. -/
 
-namespace Features.Implicative
+namespace Implicative
 
 open Causation (SEM CausalGraph Valuation DecidableValuation)
 
@@ -366,7 +363,7 @@ noncomputable def toSemantics {V : Type*} {α : V → Type*}
     [Fintype V] [DecidableEq V] [DecidableValuation α]
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M] :
     Implicative → Valuation α → ∀ p : V, α p → ∀ c : V, α c → Prop
-  | .positive => Causation.Implicative.manageSem M
-  | .negative => Causation.Implicative.failSem M
+  | .positive => Implicative.manageSem M
+  | .negative => Implicative.failSem M
 
-end Features.Implicative
+end Implicative

--- a/Linglib/Semantics/Causation/Interpretation.lean
+++ b/Linglib/Semantics/Causation/Interpretation.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.Causation.CCSelection
@@ -41,17 +41,14 @@ mapping exists; both dispatches coexist as named functions and the
 disagreement is theorem-provable.
 -/
 
-/-! ### Methods on `Features.Causative` -/
+/-! ### Methods on `Causative` -/
 
-/-! Methods on `Features.Causative` that depend on heavy semantic
+/-! Methods on `Causative` that depend on heavy semantic
 machinery (`Causation.SEM`, `CausalGraph`, the `Necessity`/
 `Sufficiency`/`Prevention` modules) live here rather than in
-`Features/Causation.lean`, which is kept import-free per the
-"Features/ stays lightweight" convention. The `namespace
-Features.Causative` block below is the standard mathlib pattern for
-distributing methods on a type across files based on import weight. -/
+`Semantics/Causation/VerbClass.lean`, which is kept import-free. -/
 
-namespace Features.Causative
+namespace Causative
 
 open Causation.CCSelection
 open Causation (SEM CausalGraph Valuation DecidableValuation)
@@ -97,7 +94,7 @@ theorem AssertsNecessity.toSemantics_eq {V : Type*} {α : V → Type*}
     b.toSemantics M = Causation.Necessity.causeSem M := by
   cases b <;> first | rfl | exact (h : False).elim
 
-end Features.Causative
+end Causative
 
 /-! ### Derivation theorems (substrate-independent) -/
 

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -37,7 +37,6 @@ namespace Causation.ProductionDependence
 
 open Intensional (WorldTimeIndex)
 
-open Features (Causative)
 open Features
 
 /-! ## Causation Type

--- a/Linglib/Semantics/Causation/Resultatives.lean
+++ b/Linglib/Semantics/Causation/Resultatives.lean
@@ -44,7 +44,6 @@ open ConstructionGrammar.Resultatives
 open Features
 open ArgumentStructure
 open Features.ChangeOfState
-open Features (Causative)
 open Causation.ProductionDependence
 open Causation.CCSelection
 

--- a/Linglib/Semantics/Causation/VerbClass.lean
+++ b/Linglib/Semantics/Causation/VerbClass.lean
@@ -15,8 +15,6 @@ This file defines two classifications carried by verb lexical entries:
   of causal events*][wolff-2003]
 -/
 
-namespace Features
-
 /-! ### Force-dynamic causatives -/
 
 /-- Force-dynamic classification of causative verbs by the causal mechanism
@@ -98,5 +96,3 @@ instance : DecidablePred EntailsComplement := fun i => by
   cases i <;> unfold EntailsComplement <;> infer_instance
 
 end Implicative
-
-end Features

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -45,7 +45,6 @@ namespace Cruse1973
 
 open ArgumentStructure
 open Causation.CoerciveImplication
-open Features (Causative)
 open Features
 open ArgumentStructure
 open Features

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1073,7 +1073,6 @@ close to w₀), but they derive from distinct semantic mechanisms:
 Each mechanism independently entails ¬p in the real world, unifying
 the class despite its heterogeneity. -/
 
-open Features (Causative Implicative)
 
 /-- FORGET is a negative implicative: "X forgot to do Y" entails that
     Y did NOT happen (¬p in w₀). This is DERIVED from the implicative

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -50,8 +50,7 @@ Key differences from the modern analysis:
 
 namespace Karttunen1971
 
-open Causation.Implicative
-open Features (Causative)
+open Implicative
 open English.Predicates.Verbal
 open English.Predicates.Copular (beAble)
 open ArgumentStructure

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -9,7 +9,7 @@ import Linglib.Studies.HofmeisterSag2010
 import Linglib.Studies.Sag2010
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Fragments.English.Predicates.Verbal

--- a/Linglib/Studies/MajidBosterBowerman2008.lean
+++ b/Linglib/Studies/MajidBosterBowerman2008.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Semantics.ArgumentStructure.EventStructure

--- a/Linglib/Studies/Nadathur2023.lean
+++ b/Linglib/Studies/Nadathur2023.lean
@@ -8,7 +8,7 @@ The Dreyfus scenario of [nadathur-2023-implicatives] (§6.1.1, Figure 3;
 introduced in [nadathur-2019] ch. 3 as "the modified Dreyfus scenario",
 adapted from [baglini-francez-2016]): an eight-vertex structural causal
 model discriminating where two-way *dare* is felicitous. The felicity
-theorems are stated through `Causation.Implicative.manageSem` /
+theorems are stated through `Implicative.manageSem` /
 `failSem` — the substrate formalization of this paper's prerequisite
 account (Proposal 32) — so they instantiate the same sufficiency predicate
 the rest of the codebase attributes to implicative verbs.
@@ -43,7 +43,7 @@ fn. 21); `manageSem` currently takes a single prerequisite vertex.
 namespace Nadathur2023
 
 open Causation Causation.Mechanism Causation.SEM
-open Causation.Implicative (manageSem failSem ImplicativeClass Prerequisite)
+open Implicative (manageSem failSem ImplicativeClass Prerequisite)
 
 /-- Dreyfus scenario vertices ([nadathur-2023-implicatives] §6.1.1, Figure 3):
     INT (Dreyfus intends to spy), NRV (he has the nerve), LST (a German is
@@ -107,7 +107,7 @@ def dreyfusBg : Valuation (fun _ : V => Bool) :=
     stated through, and its lexical prerequisite is courage — instantiated
     in the Dreyfus scenario by the NRV vertex. -/
 theorem dare_semantics_via_manageSem :
-    Features.Implicative.toSemantics dreyfusSEM ImplicativeClass.dare.polarity =
+    Implicative.toSemantics dreyfusSEM ImplicativeClass.dare.polarity =
       manageSem dreyfusSEM ∧
     ImplicativeClass.dare.prerequisite = some Prerequisite.courage :=
   ⟨rfl, rfl⟩
@@ -237,7 +237,7 @@ with `Nadathur2023.no_msg_without_nerve`. -/
 
 namespace Karttunen1971
 
-open Causation.Implicative
+open Implicative
 
 /-- Convert `KarttunenClass` to `ImplicativeClass`
     ([nadathur-2023-implicatives]). `aspectGoverned` is always false

--- a/Linglib/Studies/NadathurLauer2020.lean
+++ b/Linglib/Studies/NadathurLauer2020.lean
@@ -724,7 +724,6 @@ here; `necessity_cancellable` above is its kernel-checked witness. -/
 namespace KarttunenCells
 
 open Karttunen1971 (KarttunenClass)
-open Features (Implicative Causative)
 
 /-- Derive the `KarttunenClass` cell from an `Implicative` polarity
     (two-way cell: complement entailment under both polarities). -/

--- a/Linglib/Studies/ShenHuang2026.lean
+++ b/Linglib/Studies/ShenHuang2026.lean
@@ -4,7 +4,7 @@ import Linglib.Syntax.Binding.SpecificityCondition
 import Linglib.Features.Definiteness
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 import Linglib.Fragments.English.Predicates.Verbal

--- a/Linglib/Studies/SpalekMcNally2026.lean
+++ b/Linglib/Studies/SpalekMcNally2026.lean
@@ -2,7 +2,7 @@ import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.Spanish.Predicates
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
 

--- a/Linglib/Syntax/Category/Verb/Defs.lean
+++ b/Linglib/Syntax/Category/Verb/Defs.lean
@@ -4,7 +4,7 @@ import Linglib.Semantics.ArgumentStructure.EntailmentProfile
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Features.Aktionsart
 import Linglib.Features.Attitudes
-import Linglib.Features.Causation
+import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.Entailment.NaturalLogic
 import Linglib.Semantics.Aspect.ChangeOfState

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -10296,7 +10296,7 @@
   role      = {cited},
   doi       = {10.1207/s15516709cog1201_2},
   validated = {true},
-  sources   = {Features/Causation.lean;Semantics/Causation/Interpretation.lean;Semantics/Verb/Root/Profile.lean}
+  sources   = {Semantics/Causation/VerbClass.lean;Semantics/Causation/Interpretation.lean;Semantics/Verb/Root/Profile.lean}
 }% REF: Kratzer, A. (2000). Decomposing make.
 @book{pearl-2000,
   author    = {Pearl, Judea},
@@ -10323,7 +10323,7 @@
   subfield  = {semantics/causation},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Causation/ProductionDependence.lean;Features/Causation.lean;Semantics/Causation/Interpretation.lean}
+  sources   = {Semantics/Causation/ProductionDependence.lean;Semantics/Causation/VerbClass.lean;Semantics/Causation/Interpretation.lean}
 }% REF: Embick, D. (2009). Roots, states, and stative passives. Abstract for Roots workshop, Universität Stuttgart.
 @misc{embick-2009,
   author    = {Embick, David},


### PR DESCRIPTION
Moves `Features/Causation.lean` to its owning research area as `Semantics/Causation/VerbClass.lean`, rooting `Causative` and `Implicative` (no other owner claims the bare names). The formerly mismatched method namespaces (`Causation.Implicative`, `Features.Causative`) unify with the types, so `toSemantics` and friends become genuine dot-notation methods.