### PR TITLE
refactor(Semantics/Causation): delete singleton Causative predicates

### DIFF
--- a/Linglib/Fragments/English/Predicates/Verbal.lean
+++ b/Linglib/Fragments/English/Predicates/Verbal.lean
@@ -3386,12 +3386,6 @@ in Phase D-G in favor of the polymorphic V2 versions. -/
 /-- "make" asserts sufficiency — derived from its builder. -/
 theorem make_asserts_sufficiency : make.toVerb.AssertsSufficiency := by decide
 
-/-- "cause" asserts necessity — derived from its builder. -/
-theorem cause_asserts_necessity : cause.toVerb.AssertsNecessity := by decide
-
-/-- "make" does NOT assert necessity. -/
-theorem make_not_necessity : ¬ make.toVerb.AssertsNecessity := by decide
-
 /-- "cause" does NOT assert sufficiency. -/
 theorem cause_not_sufficiency : ¬ cause.toVerb.AssertsSufficiency := by decide
 
@@ -3399,14 +3393,6 @@ theorem cause_not_sufficiency : ¬ cause.toVerb.AssertsSufficiency := by decide
 theorem make_type_verbs_share_semantics :
     make.causative = have_caus.causative ∧
     make.causative = get_caus.causative := ⟨rfl, rfl⟩
-
-/-- "force" is coercive — derived from its builder. -/
-theorem force_is_coercive :
-    ∃ c ∈ force.causative, c.IsCoercive := ⟨.force, rfl, trivial⟩
-
-/-- "let" is permissive — derived from its builder. -/
-theorem let_is_permissive :
-    ∃ c ∈ let_.causative, c.IsPermissive := ⟨.enable, rfl, trivial⟩
 
 /-- "prevent" asserts neither sufficiency nor necessity —
     it uses the dual `preventSem` (blocking). -/
@@ -3461,21 +3447,24 @@ sub-namespace (`manage_semantics_implicative`, `fail_semantics_implicative`)
 parameterized by an arbitrary `SEM V α`. The legacy versions were
 removed in Phase D-G. -/
 
-/-- "manage" entails the complement — derived from its builder. -/
-theorem manage_entails_complement_derived :
-    ∃ i ∈ manage.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
+/-- "manage" is a positive implicative: success entails the complement
+    (`Implicative.manageSem`). -/
+theorem manage_positive_implicative :
+    manage.toVerb.implicative = some .positive := rfl
 
-/-- "fail" entails NOT the complement — derived from its builder. -/
-theorem fail_entails_not_complement_derived :
-    ∃ i ∈ fail.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
+/-- "fail" is a negative implicative: success entails the complement's
+    negation (`Implicative.failSem`). -/
+theorem fail_negative_implicative :
+    fail.toVerb.implicative = some .negative := rfl
 
-/-- "remember" entails the complement — derived from its builder. -/
-theorem remember_entails_complement_derived :
-    ∃ i ∈ remember.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
+/-- "remember" is a positive implicative: success entails the complement. -/
+theorem remember_positive_implicative :
+    remember.toVerb.implicative = some .positive := rfl
 
-/-- "forget" entails NOT the complement — derived from its builder. -/
-theorem forget_entails_not_complement_derived :
-    ∃ i ∈ forget.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
+/-- "forget" is a negative implicative: success entails the complement's
+    negation. -/
+theorem forget_negative_implicative :
+    forget.toVerb.implicative = some .negative := rfl
 
 -- ════════════════════════════════════════════════════
 -- § V2 Causative Grounding Theorems (Phase D-D)

--- a/Linglib/Semantics/Causation/Interpretation.lean
+++ b/Linglib/Semantics/Causation/Interpretation.lean
@@ -15,7 +15,7 @@ import Linglib.Semantics.Causation.Prevention
 Maps `Causative` verb classifications to their compositional semantics
 under the **force-dynamic** view ([talmy-1988], [wolff-2003]),
 which collapses `enable`/`force`/`make` into a single sufficiency
-predicate (`makeSem`) distinguished post-hoc by `IsCoercive`/`IsPermissive`.
+predicate (`makeSem`); the three remain distinct lexical classifications.
 
 | Causative | Mechanism | English verbs | N&L property (derived) |
 |-----------|-----------|---------------|----------------------|
@@ -83,16 +83,7 @@ theorem AssertsSufficiency.toSemantics_eq {V : Type*} {α : V → Type*}
     (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
     {b : Causative} (h : b.AssertsSufficiency) :
     b.toSemantics M = Causation.Sufficiency.makeSem M := by
-  cases b <;> first | rfl | exact (h : False).elim
-
-/-- The necessity-asserting variant has `causeSem` truth conditions: the
-`AssertsNecessity` classification tracks the force-dynamic dispatch. -/
-theorem AssertsNecessity.toSemantics_eq {V : Type*} {α : V → Type*}
-    [Fintype V] [DecidableEq V] [DecidableValuation α] [∀ v, Fintype (α v)]
-    (M : SEM V α) [CausalGraph.IsDAG M.graph] [SEM.IsDeterministic M]
-    {b : Causative} (h : b.AssertsNecessity) :
-    b.toSemantics M = Causation.Necessity.causeSem M := by
-  cases b <;> first | rfl | exact (h : False).elim
+  rcases h with rfl | rfl | rfl <;> rfl
 
 end Causative
 
@@ -102,14 +93,6 @@ namespace Causation.Interpretation
 
 open ArgumentStructure
 open Features
-
-/-- `make` and `force` are distinguished by coercion despite sharing truth conditions. -/
-theorem make_force_distinguished_by_coercion :
-    ¬ Causative.make.IsCoercive ∧ Causative.force.IsCoercive := ⟨id, trivial⟩
-
-/-- `make` and `enable` are distinguished by permissivity despite sharing truth conditions. -/
-theorem make_enable_distinguished_by_permissivity :
-    ¬ Causative.make.IsPermissive ∧ Causative.enable.IsPermissive := ⟨id, trivial⟩
 
 /-! ### Bridge to CC-Selection -/
 
@@ -122,7 +105,7 @@ but connected: each variant has a canonical selection mode. -/
 theorem sufficiency_selects_completion (b : Causative)
     (h : b.AssertsSufficiency) :
     b.selectionMode = .completionOfSufficientSet := by
-  cases b <;> first | rfl | exact (h : False).elim
+  rcases h with rfl | rfl | rfl <;> rfl
 
 /-- Necessity variant has member selection mode. -/
 theorem necessity_selects_member :

--- a/Linglib/Semantics/Causation/ProductionDependence.lean
+++ b/Linglib/Semantics/Causation/ProductionDependence.lean
@@ -170,14 +170,6 @@ theorem production_analogous_make :
 theorem dependence_analogous_cause :
     CausationType.dependence.analogousBuilder = .cause := rfl
 
-/-- P-CAUSE's analogous builder asserts sufficiency. -/
-theorem production_asserts_sufficiency :
-    CausationType.production.analogousBuilder.AssertsSufficiency := trivial
-
-/-- D-CAUSE's analogous builder asserts necessity. -/
-theorem dependence_asserts_necessity :
-    CausationType.dependence.analogousBuilder.AssertsNecessity := trivial
-
 /-! ## Bridge to Resultatives
 
 Thick causative manner verbs (break-class) are compatible with strong

--- a/Linglib/Semantics/Causation/Resultatives.lean
+++ b/Linglib/Semantics/Causation/Resultatives.lean
@@ -89,14 +89,14 @@ def deriveCausativeBuilder (rel : SubeventRelation) (desc : SubeventDesc) :
   | .means, true => some .make
   | _, _ => none
 
-/-- `.make` is the unique builder asserting neutral sufficiency. -/
+/-- `.make` is the unique builder asserting neutral (non-coercive,
+    non-permissive) sufficiency. -/
 theorem make_unique_neutral_sufficiency (b : Causative)
     (hs : b.AssertsSufficiency)
-    (hc : ¬ b.IsCoercive)
-    (hp : ¬ b.IsPermissive) :
+    (hc : b ≠ .force)
+    (hp : b ≠ .enable) :
     b = .make := by
-  cases b <;> simp_all [Causative.AssertsSufficiency,
-    Causative.IsCoercive, Causative.IsPermissive]
+  rcases hs with rfl | rfl | rfl <;> simp_all
 
 /-- MEANS + CAUSE derives `.make`. -/
 theorem means_cause_derives_make (desc : SubeventDesc)
@@ -132,7 +132,7 @@ theorem derived_asserts_sufficiency (rel : SubeventRelation) (desc : SubeventDes
     b.AssertsSufficiency := by
   unfold deriveCausativeBuilder at h
   split at h
-  · simp only [Option.some.injEq] at h; subst h; trivial
+  · simp only [Option.some.injEq] at h; subst h; exact .inl rfl
   · simp at h
 
 /-- The resultative Causative, derived from MEANS + CAUSE. -/

--- a/Linglib/Semantics/Causation/VerbClass.lean
+++ b/Linglib/Semantics/Causation/VerbClass.lean
@@ -38,39 +38,11 @@ namespace Causative
 
 /-- The variant asserts causal sufficiency: `make`, `force`, and `enable`
 share sufficiency truth conditions (`AssertsSufficiency.toSemantics_eq`). -/
-def AssertsSufficiency : Causative → Prop
-  | .make | .force | .enable => True
-  | .cause | .prevent => False
+def AssertsSufficiency (b : Causative) : Prop :=
+  b = make ∨ b = force ∨ b = enable
 
 instance : DecidablePred AssertsSufficiency := fun b => by
-  cases b <;> unfold AssertsSufficiency <;> infer_instance
-
-/-- The variant asserts causal necessity: only `cause`, whose truth conditions
-are counterfactual dependence (`AssertsNecessity.toSemantics_eq`). -/
-def AssertsNecessity : Causative → Prop
-  | .cause => True
-  | _ => False
-
-instance : DecidablePred AssertsNecessity := fun b => by
-  cases b <;> unfold AssertsNecessity <;> infer_instance
-
-/-- The variant encodes coercion: `force` lexicalizes overcoming the causee's
-resistance, distinguishing it from `make` despite shared truth conditions. -/
-def IsCoercive : Causative → Prop
-  | .force => True
-  | _ => False
-
-instance : DecidablePred IsCoercive := fun b => by
-  cases b <;> unfold IsCoercive <;> infer_instance
-
-/-- The variant encodes permission: `enable` lexicalizes removing a barrier,
-distinguishing it from `make` despite shared truth conditions. -/
-def IsPermissive : Causative → Prop
-  | .enable => True
-  | _ => False
-
-instance : DecidablePred IsPermissive := fun b => by
-  cases b <;> unfold IsPermissive <;> infer_instance
+  unfold AssertsSufficiency; infer_instance
 
 end Causative
 
@@ -84,15 +56,3 @@ inductive Implicative where
   /-- The verb entails the negation of its complement (*fail*, *forget*). -/
   | negative
   deriving DecidableEq, Repr
-
-namespace Implicative
-
-/-- The polarity entails the complement rather than its negation. -/
-def EntailsComplement : Implicative → Prop
-  | .positive => True
-  | .negative => False
-
-instance : DecidablePred EntailsComplement := fun i => by
-  cases i <;> unfold EntailsComplement <;> infer_instance
-
-end Implicative

--- a/Linglib/Studies/Cruse1973.lean
+++ b/Linglib/Studies/Cruse1973.lean
@@ -259,16 +259,10 @@ structure InitiativeCausativeLink (Entity Time : Type*) [LinearOrder Time]
     -- The causee is the one with agentive_ (doing the action)
     profile.hasAgentive causee e
 
-/-- The force builder is coercive — it lexicalizes coercion of a
-    volitional causee, which is precisely the initiative pattern
-    where the initiator overrides the causee's will. -/
-theorem force_lexicalizes_coercive_initiative :
-    Causative.force.IsCoercive := trivial
-
 /-- The make builder asserts sufficiency — the initiator's action
     is sufficient for the causee to act. -/
 theorem make_lexicalizes_sufficient_initiative :
-    Causative.make.AssertsSufficiency := trivial
+    Causative.make.AssertsSufficiency := .inl rfl
 
 -- ════════════════════════════════════════════════════
 -- § 7. Stative Do-Verbs (Challenge to agent_selects_action)

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -1074,20 +1074,13 @@ Each mechanism independently entails ¬p in the real world, unifying
 the class despite its heterogeneity. -/
 
 
-/-- FORGET is a negative implicative: "X forgot to do Y" entails that
-    Y did NOT happen (¬p in w₀). This is DERIVED from the implicative
-    builder's polarity, not stipulated.
-    [nadathur-2023]: negative implicatives entail complement falsity. -/
-theorem forget_grounded_in_implicativity :
-    ¬ Implicative.negative.EntailsComplement := id
-
 /-- STOP/PREVENT are causative preventatives: "X prevented Y" entails
     that Y did NOT occur (¬p in w₀). The negative entailment comes from
     the causal blocking semantics of `preventSem`.
     [nadathur-lauer-2020]: prevent = effect blocked with preventer,
     would have occurred without it. -/
 theorem prevent_is_causative_builder :
-    ¬ Causative.prevent.AssertsSufficiency := id
+    ¬ Causative.prevent.AssertsSufficiency := by decide
 
 /-- The FORGET class is unified by real-world negative entailment:
     all subclasses entail ¬p in w₀ (or worlds close to w₀), but

--- a/Linglib/Studies/Karttunen1971.lean
+++ b/Linglib/Studies/Karttunen1971.lean
@@ -194,10 +194,10 @@ theorem believe_not_implicative :
 -- ── Derived entailment predictions ──
 
 theorem manage_entails :
-    ∃ i ∈ manage.toVerb.implicative, i.EntailsComplement := ⟨.positive, rfl, trivial⟩
+    manage.toVerb.implicative = some .positive := rfl
 
 theorem fail_entails_not :
-    ∃ i ∈ fail.toVerb.implicative, ¬ i.EntailsComplement := ⟨.negative, rfl, id⟩
+    fail.toVerb.implicative = some .negative := rfl
 
 theorem hope_no_complement_entailment :
     hope.toVerb.implicative = none := rfl
@@ -252,10 +252,7 @@ theorem force_has_causative :
     force.toVerb.causative = some .force := rfl
 
 theorem force_asserts_sufficiency :
-    Causative.force.AssertsSufficiency := trivial
-
-theorem force_no_necessity :
-    ¬ Causative.force.AssertsNecessity := id
+    Causative.force.AssertsSufficiency := .inr (.inl rfl)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6. KarttunenClass → Entailment Predictions

--- a/Linglib/Studies/NadathurLauer2020.lean
+++ b/Linglib/Studies/NadathurLauer2020.lean
@@ -772,8 +772,7 @@ theorem cause_karttunen_class :
     scenario: `makeSem` holds while `causeSem` fails). -/
 theorem cause_make_same_cell_different_mechanism :
     karttunenOfCausative .cause = karttunenOfCausative .make ∧
-    Causative.cause.AssertsNecessity ∧ ¬ Causative.make.AssertsNecessity :=
-  ⟨rfl, trivial, id⟩
+    Causative.cause ≠ .make := ⟨rfl, by decide⟩
 
 end KarttunenCells
 

--- a/Linglib/Syntax/Category/Verb/Basic.lean
+++ b/Linglib/Syntax/Category/Verb/Basic.lean
@@ -176,16 +176,6 @@ def Verb.isENTrigger (v : Verb) : Bool :=
   -- STOP/PREVENT: causative prevent verbs
   (v.causative == some .prevent)
 
-/-- Does this causative verb assert necessity (like "cause")?
-
-    DERIVED: delegates to `Causative.AssertsNecessity`. -/
-def Verb.AssertsNecessity (v : Verb) : Prop :=
-  match v.causative with
-  | some c => c.AssertsNecessity
-  | none => False
-
-instance : DecidablePred Verb.AssertsNecessity := fun v => by
-  unfold Verb.AssertsNecessity; split <;> infer_instance
 
 /-- Is this verb a preferential attitude predicate? -/
 def Verb.isPreferentialAttitude (v : Verb) : Bool :=


### PR DESCRIPTION
Deletes the Eq-alias predicates `AssertsNecessity` (↔ `= .cause`), `IsCoercive` (↔ `= .force`), `IsPermissive` (↔ `= .enable`), and `Implicative.EntailsComplement` (↔ `= .positive`) — consumers state the classification equality directly, and the stipulation-restatement theorems they enabled are cut. `AssertsSufficiency` (the one genuine class) is redefined as the disjunction `b = make ∨ b = force ∨ b = enable`; the vacuous `AssertsNecessity.toSemantics_eq` goes with them.