### PR TITLE
refactor(Semantics/Tense): thenPresup as Core.Order.distinct category

### DIFF
--- a/Linglib/Semantics/Tense/Perspective.lean
+++ b/Linglib/Semantics/Tense/Perspective.lean
@@ -18,7 +18,12 @@ remains satisfiable (`thenPresup_satisfiable`).
 In the point approximation used throughout, overlap is equality: the PRES
 presupposition *is* `ReichenbachFrame.isPresent` (R = π) and the PAST
 presupposition *is* `ReichenbachFrame.isPast` (R < π), so theorems here are
-stated directly with the frame predicates.
+stated directly with the frame predicates. Tenses and ⌈then⌉ are temporal
+pronouns in one architecture ([partee-1973], `TensePronoun`): each
+presupposes a comparison category (`Finset Ordering`) of its reference
+against π — PAST `Tense.past`, PRES `Tense.present`, and ⌈then⌉
+`Core.Order.distinct`, the complement of `Tense.present`, so the
+⌈then⌉-present clash is disjointness of comparison categories.
 -/
 
 open Time
@@ -30,13 +35,19 @@ open Tense
 /-! ### The ⌈then⌉ presupposition -/
 
 /-- Temporal ⌈then⌉ presupposes that its reference is disjoint from the
-    perspective π — in the point approximation, `thenRef ≠ perspective`
-    ([tsilia-zhao-2026]). This is ⌈then⌉'s own presupposition, separate from
-    the presuppositions of any co-clausal tense; the clash with PRES arises
-    because the temporal assertion ("during then") forces the PRES reference
-    inside the ⌈then⌉ reference. -/
-def thenPresup {Time : Type*} (thenRef perspective : Time) : Prop :=
-  thenRef ≠ perspective
+    perspective π: the `Core.Order.distinct` comparison category, the
+    complement of PRES's `Tense.present` ([tsilia-zhao-2026]). This is
+    ⌈then⌉'s own presupposition, separate from the presuppositions of any
+    co-clausal tense; the clash with PRES arises because the temporal
+    assertion ("during then") forces the PRES reference inside the ⌈then⌉
+    reference. -/
+def thenPresup {Time : Type*} [LinearOrder Time] (thenRef perspective : Time) : Prop :=
+  Core.Order.holds Core.Order.distinct thenRef perspective
+
+@[simp] theorem thenPresup_def {Time : Type*} [LinearOrder Time]
+    (thenRef perspective : Time) :
+    thenPresup thenRef perspective ↔ thenRef ≠ perspective :=
+  Core.Order.holds_distinct thenRef perspective
 
 /-- A ⌈then⌉-type temporal adverb: a lexical item denoting a temporal pronoun
     that carries the `thenPresup` disjointness presupposition (English *then*,
@@ -74,18 +85,19 @@ theorem opPi_eq_embeddedFrame {Time : Type*}
     PRES presupposes R = π (`isPresent`), the temporal assertion requires the
     ⌈then⌉ reference to contain — in the point approximation, equal — R
     ("during then"), and ⌈then⌉ presupposes its reference disjoint from π. -/
-theorem then_present_clash {Time : Type*} (f : ReichenbachFrame Time)
+theorem then_present_clash {Time : Type*} [LinearOrder Time]
+    (f : ReichenbachFrame Time)
     {thenRef : Time} (hPres : f.isPresent) (hDuring : f.referenceTime = thenRef)
     (hThen : thenPresup thenRef f.perspectiveTime) : False :=
-  hThen (hDuring.symm.trans hPres)
+  (thenPresup_def _ _).mp hThen (hDuring.symm.trans hPres)
 
 /-- ⌈then⌉'s presupposition is satisfiable on any timeline with two points.
     This is why ⌈then⌉ is compatible with *deleted* (SOT) tense
     ([tsilia-zhao-2026]): a deleted tense contributes no perspectival
     presupposition, leaving only `thenPresup`, which any reference off the
     perspective witnesses. -/
-theorem thenPresup_satisfiable {Time : Type*} [Nontrivial Time]
-    (perspective : Time) : ∃ thenRef, thenPresup thenRef perspective :=
-  exists_ne perspective
+theorem thenPresup_satisfiable {Time : Type*} [LinearOrder Time] [Nontrivial Time]
+    (perspective : Time) : ∃ thenRef, thenPresup thenRef perspective := by
+  simpa using exists_ne perspective
 
 end Tense.Perspective

--- a/Linglib/Studies/TsiliaZhao2026.lean
+++ b/Linglib/Studies/TsiliaZhao2026.lean
@@ -45,7 +45,7 @@ open Semantics.Context (KContext)
     the shifted PRES (R = π') and a clausemate ⌈then⌉ (reference disjoint
     from π') read the same π' — no reference satisfies both the "during
     then" containment and disjointness. *Nate said Erica is angry (*then)*. -/
-theorem shifted_present_blocks_then {Time : Type*}
+theorem shifted_present_blocks_then {Time : Type*} [LinearOrder Time]
     (f : ReichenbachFrame Time) (attitudeTime : Time)
     (hPres : (opPi f attitudeTime).isPresent) :
     ¬∃ thenRef, (opPi f attitudeTime).referenceTime = thenRef ∧

--- a/Linglib/Studies/Zhao2025.lean
+++ b/Linglib/Studies/Zhao2025.lean
@@ -95,10 +95,12 @@ def thenAdverbs : List ThenAdverb :=
 /-- Root clause ("Mary is feeling sick (*then)"): π = S, so a present-tensed
     clause admits no ⌈then⌉ restriction — no reference satisfies both the
     "during then" containment and ⌈then⌉'s disjointness from π. -/
-theorem then_present_root_clash {Time : Type*} (f : ReichenbachFrame Time)
+theorem then_present_root_clash {Time : Type*} [LinearOrder Time]
+    (f : ReichenbachFrame Time)
     (hSimple : f.isSimpleCase) (hPres : f.isPresent) :
     ¬∃ thenRef, f.referenceTime = thenRef ∧ thenPresup thenRef f.speechTime :=
   λ ⟨_, hDuring, hThen⟩ =>
-    then_present_clash f hPres hDuring (λ hEq => hThen (hEq.trans hSimple))
+    then_present_clash f hPres hDuring
+      ((show f.perspectiveTime = f.speechTime from hSimple).symm ▸ hThen)
 
 end Zhao2025


### PR DESCRIPTION
Grounds ⌈then⌉ in the temporal-pronoun architecture: `thenPresup` is now the `Core.Order.distinct` comparison category (the complement of PRES's `Tense.present`) rather than a bespoke `Ne`, so tenses and ⌈then⌉ presuppose comparison categories in one algebra and the ⌈then⌉-present clash is category disjointness. `@[simp] thenPresup_def` keeps the `≠` shape available to consumers. Follow-up to #1920.