### PR TITLE
refactor(Features): flat-typed φ-capability accessors, register cleanse

### DIFF
--- a/Linglib/Features/Agreement.lean
+++ b/Linglib/Features/Agreement.lean
@@ -11,7 +11,7 @@ map (`ι : U → Option F`, or a total `g : U → F` — the `fromUD` ingests).
 
 The order-theoretic core is `Flat.compat_iff` (`Core.Order.Flat`); this file
 is the linglib-specific adapter on top of it, shared by the per-feature
-agreement-faithfulness theorems (`HasX.compatible_hasX` in
+agreement-faithfulness theorems (`UD.MorphFeatures.compatible_hasX` in
 `Features/{Person,Number,Gender,Case}/Capabilities.lean`). It is the
 slot-level face of subsumption-based agreement ([shieber-1986];
 [carpenter-1992]).

--- a/Linglib/Features/Case/Capabilities.lean
+++ b/Linglib/Features/Case/Capabilities.lean
@@ -1,71 +1,49 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Flat
 import Linglib.Features.Agreement
 import Linglib.Features.Case.Basic
 
 /-!
-# Case — carrier capabilities
-[blake-1994] [corbett-2006]
+# The case-bearing capability
 
-The typeclass mixin for carriers that bear grammatical case — the case
-analogue of `HasPerson` (`Features/Person/Capabilities.lean`). `caseOf`
-extracts the carrier's analytical case value; carriers that store UD
-realization (`UD.MorphFeatures`) lift through `Case.fromUD`.
-
-`Compatible` is the **case-concord** relation: symmetric, agree-or-wildcard
-slot compatibility (NP-internal agreement in case, e.g. Slavic/Latin
-adjective–noun). It is *not* case **government/assignment** — the asymmetric,
-head-to-dependent relation by which case enters an NP in the first place —
-which lives in `Syntax/Case/Dependent.lean` (Marantz dependent case) and
-`Syntax/Case/Licensing.lean` (Kalin licensing). Unlike person/number/gender,
-case is a *non-canonical* agreement feature ([corbett-2006]): the controller of
-case concord is itself the target of some other case relation; Blake's
-treatment of case assignment and concord ([blake-1994]) is the typological
-anchor.
-
-The carrier is single-valued (`Option Case`), so syncretism (one form
-realizing several cases), case-stacking/Suffixaufnahme, and coordinate case
-resolution are out of scope — a faithful treatment of those would carry a
-`Finset Case` and check nonempty intersection. The present consumer
-(`Studies/WechslerZlatic2000.lean`, concord) treats concord case as
-single-valued, for which this carrier is adequate.
+`HasCase` equips a carrier with the grammatical case it bears;
+`HasCase.Compatible` is the induced case-concord relation, slot compatibility
+in the flat information order: symmetric NP-internal agreement in case, not
+the asymmetric government/assignment by which case enters an NP
+(`Syntax/Case/Dependent.lean`, `Syntax/Case/Licensing.lean`). Case is a
+non-canonical agreement feature ([corbett-2006]); [blake-1994]'s treatment of
+assignment and concord is the typological anchor. The carrier is
+single-valued, so syncretism, case-stacking, and coordinate case resolution
+are out of scope.
 -/
 
-set_option autoImplicit false
-
-/-- A carrier of grammatical case. `none` = the carrier does not mark
-    case. -/
+/-- A carrier of grammatical case. `⊥` = the carrier does not mark case. -/
 class HasCase (α : Type*) where
-  /-- The analytical case value, if marked. -/
-  caseOf : α → Option Case
+  /-- The case value the carrier bears, if marked. -/
+  caseOf : α → Flat Case
 
 export HasCase (caseOf)
 
 instance : HasCase UD.MorphFeatures :=
   ⟨fun mf => mf.case_.map Case.fromUD⟩
 
-instance : HasCase Case := ⟨some⟩
+instance : HasCase Case := ⟨(↑·)⟩
 
 /-- `Option Case` is the free case-bearer: `some c` bears `c`, `none` is
-    caseless. -/
+caseless. -/
 instance : HasCase (Option Case) := ⟨id⟩
 
-namespace HasCase
+/-- Case compatibility (concord): valued cases coincide, an unvalued carrier
+is a wildcard. -/
+abbrev HasCase.Compatible {α β : Type*} [HasCase α] [HasCase β]
+    (a : α) (b : β) : Prop :=
+  Compat (caseOf a) (caseOf b)
 
-variable {α β : Type*} [HasCase α] [HasCase β]
-
-/-- Two carriers are case-compatible: the slot values are compatible in
-    the flat information order (`Compat`) — if both mark case, the values
-    agree; unmarked carriers are wildcards. The concord-checking
-    relation. -/
-abbrev Compatible (a : α) (b : β) : Prop :=
-  Compat (α := Flat Case) (caseOf a) (caseOf b)
-
-end HasCase
-
-/-- φ-compatibility entails case compatibility: the `HasCase` mixin
-    never diverges from the unification-based agreement engine
-    (`UD.MorphFeatures.compatible`) — the case analogue of
-    `UD.MorphFeatures.compatible_hasPerson`. -/
+/-- φ-compatibility of UD bundles entails case compatibility. -/
 theorem UD.MorphFeatures.compatible_hasCase {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasCase.Compatible f1 f2 :=

--- a/Linglib/Features/Gender/Capabilities.lean
+++ b/Linglib/Features/Gender/Capabilities.lean
@@ -1,62 +1,45 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Flat
 import Linglib.Features.Agreement
 import Linglib.Features.Gender.Basic
 
 /-!
-# HasGender — the gender-bearing capability
-[corbett-1991]
+# The gender-bearing capability
 
-The typeclass mixin for carriers that bear grammatical gender — the gender
-axis of the capability tower over lexical carriers, the analogue of
-`HasNumber` (`Features/Number/Capabilities.lean`) and `HasPerson`
-(`Features/Person/Capabilities.lean`). A consumer (agreement checker,
-resolution, semantics) requires `[HasGender α]` and works over any
-representation: a UD feature bundle, a `Word`, a `Pronoun`.
-
-The accessor is **label-valued** (`Option Gender`, the comparative-concept
-vocabulary), because the mixin is the cross-linguistic interface:
-language-particular fine-grained access goes through the language's
-`Gender.System` carrier, not through this class. It is `Option`-valued
-because underspecification is the typologically normal case: a carrier with
-no gender marking is a wildcard for agreement, and most languages have no
+`HasGender` equips a carrier with the comparative gender label it bears;
+`HasGender.Compatible` is the induced agreement relation, slot compatibility
+in the flat information order. The label vocabulary is the cross-linguistic
+interface; language-particular fine-grained access goes through the language's
+`Gender.System`. `⊥` is the typologically normal case: most languages have no
 gender at all ([corbett-1991]).
-
-Instances live with their carriers (mathlib-style): `UD.MorphFeatures` here
-(its type is upstream of this file); downstream carriers (`Word`, `Pronoun`)
-declare theirs where they are defined.
 -/
 
-set_option autoImplicit false
-
-/-- A carrier that bears grammatical gender. `none` = unmarked or
-    underspecified (a wildcard for agreement, not a default value). -/
+/-- A carrier of grammatical gender. `⊥` = the carrier does not mark
+gender. -/
 class HasGender (α : Type*) where
-  /-- The comparative gender label the carrier bears. -/
-  genderOf : α → Option Gender
+  /-- The comparative gender label the carrier bears, if marked. -/
+  genderOf : α → Flat Gender
 
 export HasGender (genderOf)
 
-/-- A UD morphology bundle bears the label its `gender` tag ingests
-    (`Gender.fromUD`, total on UD genders). -/
+/-- A UD bundle bears the label its `gender` tag ingests (`Gender.fromUD`,
+total on UD genders). -/
 instance : HasGender UD.MorphFeatures :=
   ⟨fun f => f.gender.map Gender.fromUD⟩
 
-namespace HasGender
+instance : HasGender Gender := ⟨(↑·)⟩
 
-variable {α : Type*} {β : Type*} [HasGender α] [HasGender β]
+/-- Gender compatibility: valued genders coincide, an unvalued carrier is a
+wildcard. -/
+abbrev HasGender.Compatible {α β : Type*} [HasGender α] [HasGender β]
+    (a : α) (b : β) : Prop :=
+  Compat (genderOf a) (genderOf b)
 
-/-- Gender compatibility between two (possibly heterogeneous) carriers:
-    the slot values are compatible in the flat information order (`Compat`)
-    — valued genders must coincide; an unvalued carrier is a wildcard.
-    The gender axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
-abbrev Compatible (a : α) (b : β) : Prop :=
-  Compat (α := Flat Gender) (genderOf a) (genderOf b)
-
-end HasGender
-
-/-- φ-compatibility entails gender compatibility: the `HasGender` mixin never
-    diverges from the unification-based agreement engine
-    (`UD.MorphFeatures.compatible`). -/
+/-- φ-compatibility of UD bundles entails gender compatibility. -/
 theorem UD.MorphFeatures.compatible_hasGender {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasGender.Compatible f1 f2 :=

--- a/Linglib/Features/Number/Capabilities.lean
+++ b/Linglib/Features/Number/Capabilities.lean
@@ -1,70 +1,44 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Flat
 import Linglib.Features.Agreement
 import Linglib.Features.Number.Basic
 
 /-!
-# HasNumber — the number-bearing capability
-[corbett-2000]
+# The number-bearing capability
 
-The typeclass mixin for carriers that bear grammatical number — the number
-axis of the capability tower over lexical carriers (cf. `HasPhi` in
-`Features/Phi.lean`, `Bound` in
-`Features/CoreferenceStatus.lean`). A consumer (agreement
-checker, resolution, semantics) requires `[HasNumber α]` and works over any
-representation: a UD feature bundle, a `Word`, a `Pronoun`, an agreement
-paradigm cell.
-
-The accessor is `Option`-valued because underspecification is the
-typologically normal case ([corbett-2000]): a carrier with no number marking
-is a wildcard for agreement, not a default singular.
-
-Instances live with their carriers (mathlib-style): `UD.MorphFeatures` here
-(its type is below this file); `Word` in `Morphology/Word/Basic.lean`; `Pronoun`/
-`PersonalPronoun` in `Syntax/Category/Pronoun/Capabilities.lean`; paradigm `Cell` in
-`Syntax/Agreement/Paradigm.lean`.
-
-Named `HasNumber`, not `Numbered`: the bare name is taken by the carrier
-type itself, the situation where Lean retains the `Has` prefix
-(`HasEquiv`, `HasSubset`, `HasQuotient`), and the scheme scales across the
-φ-inventory (`HasPerson`, `HasGender`) where adjectival forms do not.
-
-The Minimalist probe/goal inventory (`Minimalist.PhiFeature.number`) is the
-other number-bearing route in the library; it carries `UD.Number` and
-relates to this one by `Number.fromUD`.
+`HasNumber` equips a carrier with the grammatical number it bears;
+`HasNumber.Compatible` is the induced agreement relation, slot compatibility
+in the flat information order. Underspecification is the typologically normal
+case ([corbett-2000]): an unmarked carrier (`none`) is a wildcard, not a
+default singular.
 -/
 
-set_option autoImplicit false
-
-/-- A carrier that bears grammatical number. `none` = unmarked or
-    underspecified (a wildcard for agreement, not a default value). -/
+/-- A carrier of grammatical number. `⊥` = the carrier does not mark
+number. -/
 class HasNumber (α : Type*) where
-  /-- The canonical number value the carrier bears. -/
-  numberOf : α → Option Number
+  /-- The number value the carrier bears, if marked. -/
+  numberOf : α → Flat Number
 
 export HasNumber (numberOf)
 
-/-- A UD morphology bundle bears the number its `number` tag ingests
-    (`Number.fromUD`); tags with no analytical equivalent (`Inv`/`Coll`/
-    `Count`) leave the carrier unvalued. -/
+/-- A UD bundle bears the number its `number` tag ingests (`Number.fromUD`);
+`Inv`/`Coll`/`Count` have no analytical value and leave it unmarked. -/
 instance : HasNumber UD.MorphFeatures :=
   ⟨fun f => f.number.bind Number.fromUD⟩
 
-namespace HasNumber
+instance : HasNumber Number := ⟨(↑·)⟩
 
-variable {α : Type*} {β : Type*} [HasNumber α] [HasNumber β]
+/-- Number compatibility: valued numbers coincide, an unvalued carrier is a
+wildcard. -/
+abbrev HasNumber.Compatible {α β : Type*} [HasNumber α] [HasNumber β]
+    (a : α) (b : β) : Prop :=
+  Compat (numberOf a) (numberOf b)
 
-/-- Number compatibility between two (possibly heterogeneous) carriers:
-    the slot values are compatible in the flat information order (`Compat`)
-    — valued numbers must coincide; an unvalued carrier is a wildcard.
-    The number axis of φ-agreement (`UD.MorphFeatures.compatible`). -/
-abbrev Compatible (a : α) (b : β) : Prop :=
-  Compat (α := Flat Number) (numberOf a) (numberOf b)
-
-end HasNumber
-
-/-- φ-compatibility entails number compatibility: the `HasNumber` mixin never
-    diverges from the unification-based agreement engine
-    (`UD.MorphFeatures.compatible`). -/
+/-- φ-compatibility of UD bundles entails number compatibility. -/
 theorem UD.MorphFeatures.compatible_hasNumber {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasNumber.Compatible f1 f2 :=

--- a/Linglib/Features/Person/Capabilities.lean
+++ b/Linglib/Features/Person/Capabilities.lean
@@ -1,51 +1,43 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Flat
 import Linglib.Features.Agreement
 import Linglib.Features.Person.Basic
 
 /-!
-# Person — carrier capabilities
-[cysouw-2009]
+# The person-bearing capability
 
-The typeclass mixin for carriers that bear grammatical person — the
-person analogue of `HasNumber` (`Features/Number/Capabilities.lean`).
-`personOf` extracts the carrier's analytical person value; `Compatible`
-is the agreement-checking relation. Carriers that store UD realization
-(`UD.MorphFeatures`) lift through `Person.fromUD`; carriers that store a
-(UD person, clusivity) pair recover the quadripartition cell
-(`Syntax/Category/Pronoun/Capabilities.lean`).
+`HasPerson` equips a carrier with the grammatical person it bears;
+`HasPerson.Compatible` is the induced agreement relation, slot compatibility
+in the flat information order. Carriers storing UD realization lift through
+`Person.fromUD`; carriers storing a (UD person, clusivity) pair recover the
+quadripartition cell ([cysouw-2009]) in
+`Syntax/Category/Pronoun/Capabilities.lean`.
 -/
 
-set_option autoImplicit false
-
-/-- A carrier of grammatical person. `none` = the carrier does not mark
-    person. -/
+/-- A carrier of grammatical person. `⊥` = the carrier does not mark
+person. -/
 class HasPerson (α : Type*) where
-  /-- The analytical person value, if marked. -/
-  personOf : α → Option Person
+  /-- The person value the carrier bears, if marked. -/
+  personOf : α → Flat Person
 
 export HasPerson (personOf)
 
 instance : HasPerson UD.MorphFeatures :=
   ⟨fun mf => mf.person.map Person.fromUD⟩
 
-instance : HasPerson Person := ⟨some⟩
+instance : HasPerson Person := ⟨(↑·)⟩
 
-namespace HasPerson
+/-- Person compatibility: valued persons coincide, an unvalued carrier is a
+wildcard. -/
+abbrev HasPerson.Compatible {α β : Type*} [HasPerson α] [HasPerson β]
+    (a : α) (b : β) : Prop :=
+  Compat (personOf a) (personOf b)
 
-variable {α β : Type*} [HasPerson α] [HasPerson β]
-
-/-- Two carriers are person-compatible: the slot values are compatible in
-    the flat information order (`Compat`) — if both mark person, the values
-    agree; unmarked carriers are wildcards. -/
-abbrev Compatible (a : α) (b : β) : Prop :=
-  Compat (α := Flat Person) (personOf a) (personOf b)
-
-end HasPerson
-
-/-- φ-compatibility entails person compatibility: the `HasPerson` mixin
-    never diverges from the unification-based agreement engine
-    (`UD.MorphFeatures.compatible`) — the person analogue of
-    `UD.MorphFeatures.compatible_hasNumber`. -/
+/-- φ-compatibility of UD bundles entails person compatibility. -/
 theorem UD.MorphFeatures.compatible_hasPerson {f1 f2 : UD.MorphFeatures}
     (h : f1.compatible f2 = true) :
     HasPerson.Compatible f1 f2 :=


### PR DESCRIPTION
Type the φ-capability accessors (`numberOf`/`personOf`/`genderOf`/`caseOf`) at `Flat X` rather than `Option X` (the `List.maximum : List α → WithBot α` idiom), dropping the `Compat (α := Flat X)` pun; cleanse the four Capabilities files to mathlib register; add the missing `HasNumber Number`/`HasGender Gender` self-instances and fix a stale `PhiFeature` docstring claim.