### PR TITLE
feat(Studies/ViknerJensen2002): audit cleanse; genitive clitic

### DIFF
--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -88,7 +88,7 @@ structure Definite (E S : Type*) where
 /-! ### Vikner-Jensen possession taxonomy -/
 
 /-- Four-way lexical taxonomy of possession relations from
-[vikner-jensen-2002] §3.1.2, reproduced in Fig 6.1 of [barker-2011]. The
+[vikner-jensen-2002] §3.1.2 (their Table 1), reproduced in [barker-2011]. The
 separate "pragmatic" interpretation is not lexical and is not one of these. -/
 inductive PossessionRelationType where
   /-- Inherent relation: lexically argument-structural (the teacher's class). -/

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -3,38 +3,12 @@ import Linglib.Semantics.Possessive.Basic
 /-!
 # Vikner & Jensen 2002: A semantic analysis of the English genitive
 
-Paper-anchored consumer of the relational/possessive substrate for
-[vikner-jensen-2002]. V&J give the prenominal genitive a single syntactic type
-(it always combines with a *relational* noun); a non-relational head noun is
-coerced to relational, with the genitive relation *derived* from the noun's
-Pustejovsky qualia rather than stipulated.
-
-* **Four lexical relation types** (§3.1.2): inherent, part-whole, agentive,
-  control. These *are* the project's `PossessionRelationType` — V&J is the
-  source of that taxonomy (cited in `Semantics/Possessive/Basic.lean`), and
-  this study is its first consumer.
-* **Qualia derivation** (§3.2.3): the relation type follows from lexical
-  structure — inherent from relationality, part-whole from the constitutive
-  quale, agentive from the agentive quale; control is always available. So the
-  three-way ambiguity of *the girl's picture* is derived, not listed.
-* **The denotation** (§3.2.3, (20)–(21)): the genitive is the possessor plus a
-  narrow-scope definite — the unique entity standing in the resolved relation to
-  the possessor. The relation combines with the noun via Barker's `π`
-  (`viaArgument` for a relational noun, `viaModifier` for a coerced
-  sortal noun); uniqueness is `iotaPresupposition`, and a worked entry feeds the
-  `Possessive.Definite` carrier's `existsUnique_possessee`.
-
-## Main statements
-
-* `control_always`, `picture_three_ways`, `nose_partWhole`, … — the
-  qualia-derivation predictions (decide-checked).
-* `girlsTeacher_existsUnique` — V&J's inherent genitive as a carrier-API
-  definite (unique referent via `existsUnique_possessee`).
-* `girlsCar_eq_sortal` — V&J's coerced (control) genitive as `viaModifier`.
-
-## References
-
-* [vikner-jensen-2002]: A semantic analysis of the English genitive.
+[vikner-jensen-2002]'s uniform argument-only analysis of the English prenominal
+genitive: the genitive always combines with a *relational* noun — a
+non-relational head is coerced via Barker's `π`, the relation type supplied by
+the noun's qualia (`availableRelations`). The genitive itself is a narrow-scope
+definite: the worked examples prove `iotaPresupposition` and feed the
+`Possessive.Definite` carrier's `existsUnique_possessee`.
 -/
 
 namespace ViknerJensen2002
@@ -42,79 +16,72 @@ namespace ViknerJensen2002
 open ArgumentStructure.Relational
 open Possessive
 
-/-! ### Qualia structure (Pustejovsky, as used by V&J §3.2.1) -/
+/-! ### Qualia structure (Pustejovsky, as used by Vikner & Jensen) -/
 
-/-- The relation-bearing qualia V&J read off a head noun. The telic and formal
-qualia do not contribute a genitive relation type in V&J's four-way taxonomy, so
-they are omitted. -/
+/-- The relation-bearing lexical structure Vikner & Jensen read off a head
+noun. Their lexical entries also carry telic and formal qualia, but those
+license no genitive relation type, so they are omitted. -/
 structure NounQualia where
   /-- Inherently relational (e.g. *sister*, *teacher*) — bears its own relatum. -/
-  isRelational : Bool
+  isRelational : Prop
   /-- Bears a constitutive quale (*nose*: part-of a body). -/
-  hasConstitutive : Bool
+  hasConstitutive : Prop
   /-- Bears an agentive quale (*poem*: composed by someone). -/
-  hasAgentive : Bool
-  deriving DecidableEq, Repr
+  hasAgentive : Prop
 
-/-! ### Deriving the relation type from qualia (V&J §3.2.3) -/
+/-! ### Deriving the relation type from qualia -/
 
-/-- V&J's central thesis: the genitive's relation type is *derived* from the head
-noun's lexical structure, not stipulated. A noun licenses the inherent relation
-iff it is relational, the part-whole relation iff it bears a constitutive quale,
-the agentive relation iff it bears an agentive quale; the control relation is
-always available (the default, independent of qualia, §3.1.2). The codomain is
-the project's `PossessionRelationType` — V&J is the source of that taxonomy. -/
-def availableRelations (q : NounQualia) : List PossessionRelationType :=
-  (if q.isRelational then [PossessionRelationType.inherent] else []) ++
-  (if q.hasConstitutive then [PossessionRelationType.partWhole] else []) ++
-  (if q.hasAgentive then [PossessionRelationType.agentive] else []) ++
-  [PossessionRelationType.control]
+/-- Vikner & Jensen's central thesis: the genitive's relation type is *derived*
+from the head noun's lexical structure, not stipulated. A noun licenses the
+inherent relation iff it is relational, the part-whole relation iff it bears a
+constitutive quale, the agentive relation iff it bears an agentive quale; the
+control relation is always available, ownership being only one special case of
+control. Selectional restrictions on the possessor slot (control wants an
+animate possessor, a quale constrains its own arguments) are idealized away. -/
+def availableRelations (q : NounQualia) : Set PossessionRelationType :=
+  {r | r = .inherent ∧ q.isRelational ∨ r = .partWhole ∧ q.hasConstitutive ∨
+    r = .agentive ∧ q.hasAgentive ∨ r = .control}
 
-/-- Control is available whatever the noun's qualia (V&J §3.1.2: it is always
-available, ownership being only one special case of control). -/
+/-- Control is available whatever the noun's qualia. -/
 theorem control_always (q : NounQualia) :
-    PossessionRelationType.control ∈ availableRelations q := by
-  simp [availableRelations]
+    PossessionRelationType.control ∈ availableRelations q :=
+  .inr <| .inr <| .inr rfl
 
-/-! ### Lexical entries (V&J (9), §3.1.2) -/
+/-! ### Lexical entries -/
 
 /-- *sister* — inherently relational. -/
-def sister : NounQualia := ⟨true, false, false⟩
+def sister : NounQualia := ⟨True, False, False⟩
 /-- *nose* — constitutive quale (part-of a body). -/
-def nose : NounQualia := ⟨false, true, false⟩
+def nose : NounQualia := ⟨False, True, False⟩
 /-- *poem* — agentive quale (composed). -/
-def poem : NounQualia := ⟨false, false, true⟩
-/-- *car* — agentive quale (constructed); the salient reading is control. -/
-def car : NounQualia := ⟨false, false, true⟩
+def poem : NounQualia := ⟨False, False, True⟩
 /-- *picture* — relational (*picture of*) and agentive (*picture made by*). -/
-def picture : NounQualia := ⟨true, false, true⟩
+def picture : NounQualia := ⟨True, False, True⟩
 
 /-- *the girl's sister*: inherent relation, plus the ever-present control. -/
 theorem sister_inherent :
-    availableRelations sister = [.inherent, .control] := by decide
+    availableRelations sister = {.inherent, .control} := by
+  ext r; simp [availableRelations, sister]
 
 /-- *the girl's nose*: part-whole, via the constitutive quale (no inherent or
 agentive reading). -/
 theorem nose_partWhole :
-    availableRelations nose = [.partWhole, .control] := by decide
+    availableRelations nose = {.partWhole, .control} := by
+  ext r; simp [availableRelations, nose]
 
 /-- *the girl's poem*: agentive, via the agentive quale. -/
 theorem poem_agentive :
-    availableRelations poem = [.agentive, .control] := by decide
+    availableRelations poem = {.agentive, .control} := by
+  ext r; simp [availableRelations, poem]
 
-/-- *the girl's picture* is three ways ambiguous (V&J §3.1.2): inherent
-(*picture of the girl*), agentive (*picture the girl made*), and control
-(*picture at her disposal*) — but **not** part-whole. -/
+/-- *the girl's picture* is three ways ambiguous: inherent (*picture of the
+girl*), agentive (*picture the girl made*), and control (*picture at her
+disposal*) — but **not** part-whole. -/
 theorem picture_three_ways :
-    availableRelations picture = [.inherent, .agentive, .control] := by decide
+    availableRelations picture = {.inherent, .agentive, .control} := by
+  ext r; simp [availableRelations, picture]
 
-/-- The qualia derivation distinguishes the readings: *picture* is three-way
-ambiguous, *nose* only two-way. -/
-theorem picture_more_ambiguous_than_nose :
-    (availableRelations picture).length = 3 ∧ (availableRelations nose).length = 2 := by
-  decide
-
-/-! ### The denotation: possessor + narrow-scope definite (V&J §3.2.3)
+/-! ### The denotation: possessor + narrow-scope definite
 
 Model over `Fin 4` (girl `0`, her teacher `1`, her car `2`, an unrelated `3`),
 single situation. The genitive picks the unique entity standing in the resolved
@@ -123,14 +90,12 @@ relation to the possessor. -/
 /-- The (inherent) teacher relation: `0`'s teacher is `1`. -/
 def teacherRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 1
 
-/-- *the girl's teacher* (inherent, V&J (21)): the possessee predicate is the
-relation applied to the possessor (`viaArgument`), and there is a unique
-satisfier — V&J's narrow-scope definite, here as `iotaPresupposition`. -/
+/-- *the girl's teacher* (inherent): the possessee predicate is the relational
+noun's own relation applied to the possessor (`viaArgument`), and there is a
+unique satisfier — the narrow-scope definite, here as `iotaPresupposition`. -/
 theorem girlsTeacher_unique (s : Unit) :
-    iotaPresupposition (viaArgument (E := Fin 4) 0 teacherRel) s := by
-  refine ⟨1, ⟨rfl, rfl⟩, ?_⟩
-  rintro y ⟨-, hy⟩
-  exact hy
+    iotaPresupposition (viaArgument (E := Fin 4) 0 teacherRel) s :=
+  ⟨1, ⟨rfl, rfl⟩, fun _ hy => hy.2⟩
 
 /-- *the girl's teacher* as a `Possessive.Definite` carrier: its unique referent
 is delivered by the carrier API's `existsUnique_possessee`, no bespoke proof. -/
@@ -149,13 +114,12 @@ def controlRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 2
 /-- *car* as a sortal noun predicate. -/
 def carPred : Pred1 (Fin 4) Unit := fun y _ => y = 2
 
-/-- *the girl's car* (coerced, control): the sortal noun is shifted to a relation
-via Barker's `π` (`viaModifier`), and the result selects the controlled car.
-This is V&J's coercion of a non-relational head noun. -/
-theorem girlsCar_eq_sortal (y : Fin 4) :
-    viaModifier (E := Fin 4) 0 carPred controlRel y () ↔ y = 2 := by
-  constructor
-  · rintro ⟨hcar, -, -⟩; exact hcar
-  · rintro rfl; exact ⟨rfl, rfl, rfl⟩
+/-- *the girl's car* (coerced, control): the sortal noun is first shifted to a
+relation by Barker's `π` with the control relation, then combines exactly like
+a relational noun (`viaArgument`) — the uniform argument-only analysis. The
+result again carries the definite's unique witness. -/
+theorem girlsCar_unique (s : Unit) :
+    iotaPresupposition (viaArgument (E := Fin 4) 0 (π carPred controlRel)) s :=
+  ⟨2, ⟨rfl, rfl, rfl⟩, fun _ hy => hy.1⟩
 
 end ViknerJensen2002

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -6,9 +6,10 @@ import Linglib.Semantics.Possessive.Basic
 [vikner-jensen-2002]'s uniform argument-only analysis of the English prenominal
 genitive: the genitive always combines with a *relational* noun — a
 non-relational head is coerced via Barker's `π`, the relation type supplied by
-the noun's qualia (`availableRelations`). The genitive itself is a narrow-scope
-definite: the worked examples prove `iotaPresupposition` and feed the
-`Possessive.Definite` carrier's `existsUnique_possessee`.
+the noun's qualia (`availableRelations`, §3.1.2). The genitive clitic itself
+(`clitic`, their (16)) embeds a narrow-scope definite: the worked examples
+prove `iotaPresupposition` and feed the `Possessive.Definite` carrier's
+`existsUnique_possessee`.
 -/
 
 namespace ViknerJensen2002
@@ -18,9 +19,8 @@ open Possessive
 
 /-! ### Qualia structure (Pustejovsky, as used by Vikner & Jensen) -/
 
-/-- The relation-bearing lexical structure Vikner & Jensen read off a head
-noun. Their lexical entries also carry telic and formal qualia, but those
-license no genitive relation type, so they are omitted. -/
+/-- The relation-bearing lexical structure of a head noun. Telic and formal
+qualia license no genitive relation type and are omitted. -/
 structure NounQualia where
   /-- Inherently relational (e.g. *sister*, *teacher*) — bears its own relatum. -/
   isRelational : Prop
@@ -31,13 +31,10 @@ structure NounQualia where
 
 /-! ### Deriving the relation type from qualia -/
 
-/-- Vikner & Jensen's central thesis: the genitive's relation type is *derived*
-from the head noun's lexical structure, not stipulated. A noun licenses the
-inherent relation iff it is relational, the part-whole relation iff it bears a
-constitutive quale, the agentive relation iff it bears an agentive quale; the
-control relation is always available, ownership being only one special case of
-control. Selectional restrictions on the possessor slot (control wants an
-animate possessor, a quale constrains its own arguments) are idealized away. -/
+/-- The genitive relation types a head noun licenses: inherent iff it is
+relational, part-whole iff it bears a constitutive quale, agentive iff it bears
+an agentive quale, and control unconditionally. Possessor-side selectional
+restrictions are left out, as in the paper's own derivations. -/
 def availableRelations (q : NounQualia) : Set PossessionRelationType :=
   {r | r = .inherent ∧ q.isRelational ∨ r = .partWhole ∧ q.hasConstitutive ∨
     r = .agentive ∧ q.hasAgentive ∨ r = .control}
@@ -76,10 +73,19 @@ theorem poem_agentive :
 
 /-- *the girl's picture* is three ways ambiguous: inherent (*picture of the
 girl*), agentive (*picture the girl made*), and control (*picture at her
-disposal*) — but **not** part-whole. -/
+disposal*) — but not part-whole. -/
 theorem picture_three_ways :
     availableRelations picture = {.inherent, .agentive, .control} := by
   ext r; simp [availableRelations, picture]
+
+/-! ### The genitive clitic -/
+
+/-- The genitive clitic: from the possessor quantifier and the genitive
+relation to the head NP's quantifier, with an implicit definite — the unique
+relatum — scoping under the possessor quantifier. -/
+def clitic {E : Type*} (Q : Quantification.Quantifier E) (R : E → E → Prop) :
+    Quantification.Quantifier E :=
+  fun P => Q fun u => ∃ x, (∀ y, R u y ↔ y = x) ∧ P x
 
 /-! ### The denotation: possessor + narrow-scope definite
 
@@ -90,12 +96,24 @@ relation to the possessor. -/
 /-- The (inherent) teacher relation: `0`'s teacher is `1`. -/
 def teacherRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 1
 
-/-- *the girl's teacher* (inherent): the possessee predicate is the relational
-noun's own relation applied to the possessor (`viaArgument`), and there is a
-unique satisfier — the narrow-scope definite, here as `iotaPresupposition`. -/
+/-- *the girl's teacher* (inherent): the relational noun's own relation applied
+to the possessor (`viaArgument`) has a unique satisfier. -/
 theorem girlsTeacher_unique (s : Unit) :
     iotaPresupposition (viaArgument (E := Fin 4) 0 teacherRel) s :=
   ⟨1, ⟨rfl, rfl⟩, fun _ hy => hy.2⟩
+
+/-- *a girl* as an indefinite possessor quantifier. -/
+def aGirl : Quantification.Quantifier (Fin 4) := fun P => ∃ z, z = 0 ∧ P z
+
+/-- *a girl's teacher* holds of `P` iff some girl has a unique teacher who is
+`P` — in this model, iff `P 1`. -/
+theorem aGirlsTeacher (P : Fin 4 → Prop) :
+    clitic aGirl (fun u y => teacherRel u y ()) P ↔ P 1 := by
+  simp only [clitic, aGirl, teacherRel]
+  constructor
+  · rintro ⟨z, rfl, x, hx, hP⟩
+    rwa [← (hx 1).mp ⟨rfl, rfl⟩] at hP
+  · exact fun hP => ⟨0, rfl, 1, fun y => by simp, hP⟩
 
 /-- *the girl's teacher* as a `Possessive.Definite` carrier: its unique referent
 is delivered by the carrier API's `existsUnique_possessee`, no bespoke proof. -/
@@ -114,10 +132,9 @@ def controlRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 2
 /-- *car* as a sortal noun predicate. -/
 def carPred : Pred1 (Fin 4) Unit := fun y _ => y = 2
 
-/-- *the girl's car* (coerced, control): the sortal noun is first shifted to a
-relation by Barker's `π` with the control relation, then combines exactly like
-a relational noun (`viaArgument`) — the uniform argument-only analysis. The
-result again carries the definite's unique witness. -/
+/-- *the girl's car* (coerced, control): the sortal noun is `π`-shifted with
+the control relation, then combines exactly like a relational noun
+(`viaArgument`). The result again carries the definite's unique witness. -/
 theorem girlsCar_unique (s : Unit) :
     iotaPresupposition (viaArgument (E := Fin 4) 0 (π carPred controlRel)) s :=
   ⟨2, ⟨rfl, rfl, rfl⟩, fun _ hy => hy.1⟩


### PR DESCRIPTION
Deep audit against the paper (primary source verified). Prop-valued qualia, Set-valued `availableRelations`, coerced genitive restated through `viaArgument`-of-`π` (the paper's argument-only architecture); dead `car` entry and length-comparison theorem cut. Adds the genitive clitic (their (16)) with a worked model derivation. Substrate: `PossessionRelationType` docstring now cites V&J's own Table 1.