### PR TITLE
refactor(Semantics/Possessive): asNPQ relation Bool → Prop

### DIFF
--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -106,9 +106,9 @@ inductive PossessionRelationType where
 /-- Possessive as a type ⟨1⟩ quantifier (Quantifier):
 `⟦John's⟧ = fun R P ↦ ∃ y, R possessor y ∧ P y`. Not isomorphism-invariant: it
 depends on the identity of the possessor, not just cardinalities. -/
-def asNPQ {E : Type*} (possessor : E) (R : E → E → Bool) :
+def asNPQ {E : Type*} (possessor : E) (R : E → E → Prop) :
     Quantification.Quantifier E :=
-  fun P => ∃ y : E, R possessor y = true ∧ P y
+  fun P => ∃ y : E, R possessor y ∧ P y
 
 end Possessive
 

--- a/Linglib/Semantics/Possessive/GQ.lean
+++ b/Linglib/Semantics/Possessive/GQ.lean
@@ -196,11 +196,10 @@ theorem carrierGQ_existential_import {γ E S : Type*}
     `Possessive.asNPQ`) is `PossW` at a Montagovian individual with
     existential `Q₂` and trivial possessee restrictor — the possessee class is
     folded into `R` by Barker's π shift. -/
-theorem possessiveAsNPQ_iff_possW {E : Type*} (a : E) (R : E → E → Bool)
+theorem possessiveAsNPQ_iff_possW {E : Type*} (a : E) (R : E → E → Prop)
     (P : E → Prop) :
     Possessive.asNPQ a R P ↔
-      PossW (individual a) some_sem (fun x y => R x y = true)
-        (fun _ => True) P := by
+      PossW (individual a) some_sem R (fun _ => True) P := by
   unfold Possessive.asNPQ PossW dom
     individual some_sem
   constructor


### PR DESCRIPTION
Prop-migrate `asNPQ`'s possession relation; `possessiveAsNPQ_iff_possW` no longer wraps `R` in `= true`.