### PR TITLE
refactor(Semantics/Possessive): inline Pred1/Pred2; content-name arity cases

### DIFF
--- a/Linglib/Morphology/DM/CategorizerSemantics.lean
+++ b/Linglib/Morphology/DM/CategorizerSemantics.lean
@@ -49,9 +49,9 @@ open ArgumentStructure.Relational
     denotation ([adamson-2024] §3.1). -/
 inductive NSemanticType where
   /-- Relational: n introduces a relation (body-part-of, part-of, etc.).
-      Result type: ⟨e,⟨e,t⟩⟩ = `Pred2`. -/
+      Result type: ⟨e,⟨e,t⟩⟩. -/
   | relational
-  /-- Sortal: n simply categorizes. Result type: ⟨e,t⟩ = `Pred1`. -/
+  /-- Sortal: n simply categorizes. Result type: ⟨e,t⟩. -/
   | sortal
   /-- Alienator: n existentially closes a relational root.
       Input type: ⟨e,⟨e,t⟩⟩; result type: ⟨e,t⟩. -/
@@ -79,13 +79,13 @@ def catHeadSemanticType (ch : CatHead) (mediatesAPossession : Bool := false)
 
     In π's convention: first arg = possessor, second arg = possessee. -/
 def nBodyPartDenot {E S : Type}
-    (rootPred : Pred1 E S) (bodyPartOf : Pred2 E S) : Pred2 E S :=
+    (rootPred : E → S → Prop) (bodyPartOf : E → E → S → Prop) : E → E → S → Prop :=
   π rootPred bodyPartOf
 
 /-- Denotation of n_{sortal}: the root predicate, unchanged.
 
     [adamson-2024] (37): ⟦nP⟧ = λx. ROOT(x) -/
-def nSortalDenot {E S : Type} (rootPred : Pred1 E S) : Pred1 E S :=
+def nSortalDenot {E S : Type} (rootPred : E → S → Prop) : E → S → Prop :=
   bareSemantics rootPred
 
 /-- Denotation of n_{alienator}: existentially closes the possessor
@@ -97,7 +97,7 @@ def nSortalDenot {E S : Type} (rootPred : Pred1 E S) : Pred1 E S :=
     existentially closed, yielding a one-place property of the
     possessee. -/
 def nAlienatorDenot {E S : Type}
-    (relation : Pred2 E S) (x : E) (s : S) : Prop :=
+    (relation : E → E → S → Prop) (x : E) (s : S) : Prop :=
   ∃ y, relation y x s
 
 -- ============================================================================
@@ -106,7 +106,7 @@ def nAlienatorDenot {E S : Type}
 
 /-- n_{body-part{D}} IS Barker's π: the relationalizer. -/
 theorem nBodyPartDenot_eq_pi {E S : Type}
-    (rootPred : Pred1 E S) (bodyPartOf : Pred2 E S) :
+    (rootPred : E → S → Prop) (bodyPartOf : E → E → S → Prop) :
     nBodyPartDenot rootPred bodyPartOf = π rootPred bodyPartOf := rfl
 
 /-- n_{alienator} is the argument-flipped version of Barker's Ex.
@@ -120,7 +120,7 @@ theorem nBodyPartDenot_eq_pi {E S : Type}
     Both perform existential closure; the difference is which argument
     of the relation represents the possessor vs possessee. -/
 theorem nAlienatorDenot_is_ex_flipped {E S : Type}
-    (R : Pred2 E S) (x : E) (s : S) :
+    (R : E → E → S → Prop) (x : E) (s : S) :
     nAlienatorDenot R x s ↔ Ex (λ a b t => R b a t) x s := by
   simp only [nAlienatorDenot, Ex]
 
@@ -138,14 +138,14 @@ theorem selectsD_iff_relational (ch : CatHead) :
 section TeopExample
 
 variable {E S : Type}
-variable (isSpleen : Pred1 E S)
-variable (bodyPartOf : Pred2 E S)
+variable (isSpleen : E → S → Prop)
+variable (bodyPartOf : E → E → S → Prop)
 
 /-- iPossession: √BINA + n_{body-part{D}} → relational noun.
 
     ⟦bina⟧ = λposs.λx. isSpleen(x) ∧ bodyPartOf(poss, x)
     'spleen of poss' -/
-def teopSpleenIPossessed : Pred2 E S :=
+def teopSpleenIPossessed : E → E → S → Prop :=
   nBodyPartDenot isSpleen bodyPartOf
 
 /-- aPossession: √BINA + n_{alienator} → existentially closed.
@@ -159,7 +159,7 @@ def teopSpleenAPossessed (x : E) (s : S) : Prop :=
 
     ⟦house⟧ = λx. isHouse(x)
     No possessor slot available. -/
-def teopHouseSortal (isHouse : Pred1 E S) : Pred1 E S :=
+def teopHouseSortal (isHouse : E → S → Prop) : E → S → Prop :=
   nSortalDenot isHouse
 
 /-- With a specific possessor, the iPossessed body part reduces to a
@@ -170,7 +170,7 @@ theorem ipossessed_with_possessor (john : E) (x : E) (s : S) :
 
 /-- The sortal noun has no relatum slot — it cannot directly take a
     possessor without π. -/
-theorem sortal_is_pred1 (isHouse : Pred1 E S) :
+theorem sortal_is_pred1 (isHouse : E → S → Prop) :
     teopHouseSortal isHouse = isHouse := rfl
 
 /-- Key insight: the SAME root (√BINA) yields different semantic types
@@ -217,15 +217,15 @@ is secondary (determined by whether aPossession is mediated). -/
     n_{sortal}. Since the alienator n is plain (no gender feature), the
     noun is feminine (unmarked). -/
 theorem alienator_retraction {E S : Type}
-    (P : Pred1 E S) (R : Pred2 E S) (x : E) (s : S) :
+    (P : E → S → Prop) (R : E → E → S → Prop) (x : E) (s : S) :
     nAlienatorDenot (π P R) x s ↔ ∃ y, P x s ∧ R y x s := by
   simp only [nAlienatorDenot, π]
 
 /-- NominalInterpType from Barker 2011 corresponds to NSemanticType. -/
 def NSemanticType.toBarker : NSemanticType → NominalInterpType
-  | .relational => .pred2
-  | .sortal     => .pred1
-  | .alienator  => .pred1  -- alienator yields Pred1 (after closure)
+  | .relational => .relational
+  | .sortal     => .sortal
+  | .alienator  => .sortal  -- alienator yields a one-place predicate (after closure)
 
 /-- Only relational nouns (n with {D}) can directly take a possessor.
     Sortal and alienated nouns cannot — they need Barker's π first. -/

--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -39,16 +39,16 @@ variable {E S : Type*}
 
 /-- Applying a possessor to a lexically relational noun — the *argument*
 genitive: `⟦John's teacher⟧ = λy. teacher(John)(y)`. -/
-def viaArgument (possessor : E) (nounRel : Pred2 E S) : Pred1 E S :=
+def viaArgument (possessor : E) (nounRel : E → E → S → Prop) : E → S → Prop :=
   fun y s => nounRel possessor y s
 
 /-- Applying a possessor to a sortal noun via Barker's `π` — the *modifier*
 genitive with a free relation `R`: `⟦John's team⟧ = λy. team(y) ∧ R(John)(y)`. -/
-def viaModifier (possessor : E) (nounPred : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+def viaModifier (possessor : E) (nounPred : E → S → Prop) (R : E → E → S → Prop) : E → S → Prop :=
   fun y s => π nounPred R possessor y s
 
 /-- The argument genitive is the modifier genitive over a trivial restrictor. -/
-theorem viaArgument_eq_viaModifier_top (possessor : E) (R : Pred2 E S) :
+theorem viaArgument_eq_viaModifier_top (possessor : E) (R : E → E → S → Prop) :
     viaArgument possessor R = viaModifier possessor (fun _ _ => True) R := by
   funext y s; simp [viaArgument, viaModifier, π]
 
@@ -62,15 +62,15 @@ structure Carrier (E S : Type*) where
   /-- The possessor entity. -/
   possessor : E
   /-- The possession relation. -/
-  relation : Pred2 E S
+  relation : E → E → S → Prop
   /-- The sortal restrictor (the noun predicate). -/
-  restrictor : Pred1 E S
+  restrictor : E → S → Prop
 
 namespace Carrier
 
 /-- The derived possessee predicate: the restrictor conjoined with the relation
 applied to the possessor. -/
-def possesseePred (c : Carrier E S) : Pred1 E S :=
+def possesseePred (c : Carrier E S) : E → S → Prop :=
   viaModifier c.possessor c.restrictor c.relation
 
 end Carrier
@@ -81,7 +81,7 @@ structure Definite (E S : Type*) where
   /-- The possessor entity. -/
   possessor : E
   /-- The possessee predicate (a definite description's restrictor). -/
-  predicate : Pred1 E S
+  predicate : E → S → Prop
   /-- The possessee predicate has a unique witness at every situation. -/
   presupposition : ∀ s : S, iotaPresupposition predicate s
 
@@ -129,17 +129,17 @@ class HasPossessor (α : Type*) (E : outParam Type*) where
   /-- Project the bundled possessor entity. -/
   possessor : α → E
 
-/-- A carrier whose values bundle a possessee predicate `Pred1 E S`. -/
+/-- A carrier whose values bundle a possessee predicate `E → S → Prop`. -/
 class HasPossesseePredicate (α : Type*) (E S : outParam Type*) where
   /-- Project the bundled possessee predicate. -/
-  possesseePredicate : α → Pred1 E S
+  possesseePredicate : α → E → S → Prop
 
-/-- A carrier whose values bundle a possession relation `Pred2 E S`. Distinct
+/-- A carrier whose values bundle a possession relation `E → E → S → Prop`. Distinct
 from `HasPossesseePredicate`: a relational noun's R is the noun denotation
 itself, while a sortal-with-π construction carries R separately. -/
 class HasPossessionRelation (α : Type*) (E S : outParam Type*) where
   /-- Project the bundled possession relation. -/
-  possessionRelation : α → Pred2 E S
+  possessionRelation : α → E → E → S → Prop
 
 /-- Prop class: a possessive carrier whose possessee predicate has a unique
 witness at every situation. Definite possessives bear this; existential and
@@ -174,7 +174,7 @@ variable {α E S : Type*}
 /-- The possessee set determined by any carrier bundling a possessor and a
 possession relation: the entities standing in the relation to the possessor. -/
 def possesseeSet [HasPossessor α E] [HasPossessionRelation α E S] (a : α) :
-    Pred1 E S :=
+    E → S → Prop :=
   fun y s => HasPossessionRelation.possessionRelation a (HasPossessor.possessor a) y s
 
 /-- Any carrier bearing a Russellian iota-witness denotes a unique possessee at

--- a/Linglib/Semantics/Possessive/Relational.lean
+++ b/Linglib/Semantics/Possessive/Relational.lean
@@ -49,12 +49,6 @@ namespace ArgumentStructure.Relational
 
 /-! ### Predicates and arity -/
 
-/-- One-place predicate over entities and states. -/
-abbrev Pred1 (E S : Type*) := E → S → Prop
-
-/-- Two-place predicate over entities and states. -/
-abbrev Pred2 (E S : Type*) := E → E → S → Prop
-
 /-! ### Type shifters -/
 
 section TypeShifters
@@ -62,18 +56,18 @@ section TypeShifters
 variable {E S : Type*}
 
 /-- Barker's relationalizer: `π P R x y s ↔ P y s ∧ R x y s`. -/
-def π (P : Pred1 E S) (R : Pred2 E S) : Pred2 E S :=
+def π (P : E → S → Prop) (R : E → E → S → Prop) : E → E → S → Prop :=
   λ x y s => P y s ∧ R x y s
 
 /-- Existential closure of a relation in its second argument:
 `Ex R x s ↔ ∃ y, R x y s`. -/
-def Ex (R : Pred2 E S) : Pred1 E S :=
+def Ex (R : E → E → S → Prop) : E → S → Prop :=
   λ x s => ∃ y, R x y s
 
 /-- `Ex (π P R) z s` is witnessed whenever some `y` satisfies both `P y s`
 and `R z y s`. -/
 theorem ex_pi_retraction [Nonempty E]
-    (P : Pred1 E S) (R : Pred2 E S) (y z : E) (s : S)
+    (P : E → S → Prop) (R : E → E → S → Prop) (y z : E) (s : S)
     (hP : P y s) (hR : R z y s) :
     Ex (π P R) z s :=
   ⟨y, hP, hR⟩
@@ -90,15 +84,15 @@ variable {E S : Type*}
 `ExistsUnique` (the body unfolds to `∃ x, P x s ∧ ∀ y, P y s → y = x`), so the
 full `ExistsUnique.*` API is available; the name records the linguistic role —
 the presupposition a definite description carries. -/
-abbrev iotaPresupposition (P : Pred1 E S) (s : S) : Prop := ∃! x, P x s
+abbrev iotaPresupposition (P : E → S → Prop) (s : S) : Prop := ∃! x, P x s
 
 /-- Demonstrative-headed nominal: `π` applied to a sortal noun with the
 demonstrative supplying the relatum. -/
-def naSemantics (nounPred : Pred1 E S) (R : Pred2 E S) (relatum : E) : Pred1 E S :=
+def naSemantics (nounPred : E → S → Prop) (R : E → E → S → Prop) (relatum : E) : E → S → Prop :=
   π nounPred R relatum
 
 /-- Bare nominal: identity on the predicate (no relatum slot). -/
-def bareSemantics (nounPred : Pred1 E S) : Pred1 E S :=
+def bareSemantics (nounPred : E → S → Prop) : E → S → Prop :=
   nounPred
 
 end Definites
@@ -128,26 +122,26 @@ instance : DecidablePred CanFillRelatum := λ s => by
 
 /-- Interpretation type of a nominal: with or without a relatum slot. -/
 inductive NominalInterpType where
-  /-- `Pred1`: no relatum slot (sortal, no `π`). -/
-  | pred1
-  /-- `Pred2`: relatum slot (relational or `π`-shifted). -/
-  | pred2
+  /-- No relatum slot (one-place; no `π`). -/
+  | sortal
+  /-- Relatum slot (two-place: lexically relational or `π`-shifted). -/
+  | relational
   deriving DecidableEq, Repr
 
 namespace NominalInterpType
 
 /-- Whether the interpretation type has a relatum slot. -/
 def hasRelatumSlot : NominalInterpType → Prop
-  | .pred1 => False
-  | .pred2 => True
+  | .sortal => False
+  | .relational => True
 
 instance : DecidablePred hasRelatumSlot := λ t => by
   cases t <;> unfold hasRelatumSlot <;> infer_instance
 
 /-- Whether the interpretation type can take a possessor argument. -/
 def canTakePossessor : NominalInterpType → Prop
-  | .pred1 => False
-  | .pred2 => True
+  | .sortal => False
+  | .relational => True
 
 instance : DecidablePred canTakePossessor := λ t => by
   cases t <;> unfold canTakePossessor <;> infer_instance

--- a/Linglib/Studies/AhnZhu2025.lean
+++ b/Linglib/Studies/AhnZhu2025.lean
@@ -72,14 +72,14 @@ variable {E S : Type*}
 /-- Felicity of a **bare** definite (eq. 44a): the uniqueness presupposition of
 the noun alone. *bare P* denotes the unique `x` with `P x` in `s` — situational
 uniqueness (Schwarz-weak / [jenks-2018]'s ι). -/
-def bareDefiniteFelicitous (P : Pred1 E S) (s : S) : Prop :=
+def bareDefiniteFelicitous (P : E → S → Prop) (s : S) : Prop :=
   iotaPresupposition (bareSemantics P) s
 
 /-- Felicity of a **na** definite (eq. 48): the uniqueness presupposition of the
 relationalized predicate `π P R`. *na P* (with index `z`) denotes the unique `x`
 with `P x ∧ R z x` in `s`. The `ι` is the definiteness; the `π` is what *na*
 adds. -/
-def naDefiniteFelicitous (P : Pred1 E S) (R : Pred2 E S) (z : E) (s : S) : Prop :=
+def naDefiniteFelicitous (P : E → S → Prop) (R : E → E → S → Prop) (z : E) (s : S) : Prop :=
   iotaPresupposition (naSemantics P R z) s
 
 /-! ### The relationalizer restores uniqueness -/
@@ -93,7 +93,7 @@ This is [ahn-zhu-2025]'s bridging asymmetry *derived* from the denotations: the
 gap between bare and *na* is `π` restoring the `ι` presupposition, not a
 stipulation. -/
 theorem na_restores_uniqueness
-    (P : Pred1 E S) (R : Pred2 E S) (z : E) (s : S)
+    (P : E → S → Prop) (R : E → E → S → Prop) (z : E) (s : S)
     (hAmbiguous : ∃ a b, a ≠ b ∧ P a s ∧ P b s)
     (hDisambiguated : ∃! x, P x s ∧ R z x s) :
     ¬ bareDefiniteFelicitous P s ∧ naDefiniteFelicitous P R z s := by
@@ -104,12 +104,12 @@ theorem na_restores_uniqueness
   · obtain ⟨x, hx, huniq⟩ := hDisambiguated
     exact ⟨x, hx, huniq⟩
 
-/-- A lexically **relational** noun (a `Pred2`) supplies its own relatum: with the
+/-- A lexically **relational** noun (a two-place predicate) supplies its own relatum: with the
 antecedent `z` filling the internal argument (eq. 57–58: covert possessor /
 Mandarin argument-drop), the bare definite's uniqueness presupposition can be met
 without *na*. This is why bare relational bridging is licensed. -/
 theorem relational_bare_felicitous
-    (Rel : Pred2 E S) (z : E) (s : S)
+    (Rel : E → E → S → Prop) (z : E) (s : S)
     (hUnique : ∃! x, Rel z x s) :
     bareDefiniteFelicitous (fun x => Rel z x) s := by
   obtain ⟨x, hx, huniq⟩ := hUnique
@@ -166,7 +166,7 @@ The two accounts thus assign opposite status to the bare relational-bridging for
 Ahn & Zhu predict it licensed; Jenks predicts it blocked. Both halves below are
 derived from each account's own machinery. -/
 theorem diverges_from_jenks_on_bare_relational
-    (Rel : Pred2 E S) (z : E) (s : S) (hUnique : ∃! x, Rel z x s) :
+    (Rel : E → E → S → Prop) (z : E) (s : S) (hUnique : ∃! x, Rel z x s) :
     -- Ahn & Zhu: bare relational definite is felicitous (no *na* needed)
     bareDefiniteFelicitous (fun x => Rel z x) s ∧
     -- Jenks: Index! strictly prefers the indexed *na* form when an antecedent exists

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -66,7 +66,7 @@ namespace HaninkKoontzGarboden2025
 open Verb Verb.Root
 open KoontzGarboden2009.Monotonicity
 open Morphology.DM (Categorizer)
-open ArgumentStructure.Relational (π Pred1 Pred2)
+open ArgumentStructure.Relational (π)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Morphological Classes and Semantic Types
@@ -143,14 +143,14 @@ variable {Entity State : Type}
     something satisfying P. Quantification over the possessum y is
     modeled via `List.any` over a finite entity domain. -/
 def vHave (entities : List Entity)
-    (P : Pred1 Entity State) (R : Pred2 Entity State)
+    (P : Entity → State → Prop) (R : Entity → Entity → State → Prop)
     (x : Entity) (s : State) : Prop :=
   ∃ y ∈ entities, P y s ∧ R x y s
 
 /-- v_have is Barker's π composed with existential closure:
     `vHave entities P R x s ↔ ∃y ∈ entities, (π P R) x y s` -/
 theorem vHave_is_ex_pi (entities : List Entity)
-    (P : Pred1 Entity State) (R : Pred2 Entity State)
+    (P : Entity → State → Prop) (R : Entity → Entity → State → Prop)
     (x : Entity) (s : State) :
     vHave entities P R x s ↔ ∃ y ∈ entities, (π P R) x y s := by
   simp only [vHave, π]

--- a/Linglib/Studies/Heine1997.lean
+++ b/Linglib/Studies/Heine1997.lean
@@ -44,12 +44,12 @@ Cambridge Studies in Linguistics 83. Cambridge University Press, 1997.
 - `Grammaticalization.GramStage`: the verbal cline
 - `ArgumentStructure.Relational`: π operator and
   arity tracking — connects to which schemas have possessor-as-subject
-  (Action, Companion = transitive/Pred2) vs possessee-as-subject (rest)
+  (Action, Companion = transitive/relational) vs possessee-as-subject (rest)
 -/
 
 open Possession
 open Grammaticalization
-open ArgumentStructure.Relational (Pred1 Pred2 NominalInterpType)
+open ArgumentStructure.Relational (NominalInterpType)
 
 namespace Heine1997
 
@@ -319,45 +319,45 @@ theorem location_not_permanent :
 
     Possessor-as-subject schemas (Action, Companion) produce transitive
     constructions: the possessive verb takes two core arguments (possessor
-    and possessee), corresponding to [barker-2011]'s Pred2.
+    and possessee), corresponding to [barker-2011]'s two-place relational type.
 
     Possessee-as-subject schemas produce intransitive/existential
     constructions: the possessee is the sole core argument, and the
-    possessor is an oblique adjunct. The possessive predicate is Pred1,
+    possessor is an oblique adjunct. The possessive predicate is one-place,
     with the possessor introduced by Ex closure or case marking. -/
 def schemaArity : Source → NominalInterpType
-  | .action    => .pred2  -- X takes Y: two core arguments
-  | .companion => .pred2  -- X is with Y: two core arguments
-  | _          => .pred1  -- Y exists/is-at/...: one core argument + oblique
+  | .action    => .relational  -- X takes Y: two core arguments
+  | .companion => .relational  -- X is with Y: two core arguments
+  | _          => .sortal  -- Y exists/is-at/...: one core argument + oblique
 
-/-- Possessor-as-subject correlates exactly with Pred2 (transitive). -/
-theorem possessor_subject_iff_pred2 :
+/-- Possessor-as-subject correlates exactly with the relational interpretation (transitive). -/
+theorem possessor_subject_iff_relational :
     ∀ s : Source,
-      schemaSubject s = .possessor ↔ schemaArity s = .pred2 := by
+      schemaSubject s = .possessor ↔ schemaArity s = .relational := by
   intro s; cases s <;> simp [schemaSubject, schemaArity]
 
-/-- Pred2 schemas are exactly the basic-structure schemas where the
+/-- Relational schemas are exactly the basic-structure schemas where the
     possessor is a core argument (not grafted on). Companion is the
-    exception: extended structure but still Pred2, because the comitative
+    exception: extended structure but still relational, because the comitative
     complement is reanalyzed as a core argument. -/
-theorem pred2_action_companion_only :
+theorem relational_action_companion_only :
     ∀ s : Source,
-      schemaArity s = .pred2 ↔ (s = .action ∨ s = .companion) := by
+      schemaArity s = .relational ↔ (s = .action ∨ s = .companion) := by
   intro s; cases s <;> simp [schemaArity]
 
-/-- The Pred1 schemas (Location, Genitive, Goal, Source, Topic, Equation)
+/-- The sortal schemas (Location, Genitive, Goal, Source, Topic, Equation)
     express possession via an existential predicate + oblique possessor.
     This matches Barker's ExProp closure: the possessor is introduced
     by existential quantification over a relation, not as a direct argument
     of the predicate.
 
     Structural consequence: in these schemas, the possessor does NOT
-    fill a relatum slot directly (as it would in Pred2). Instead, it is
+    fill a relatum slot directly (as it would with a relational noun). Instead, it is
     introduced via case morphology (locative, dative, genitive, etc.) —
     the morphological reflex of the oblique adjunct position. -/
-theorem pred1_possessee_subject :
+theorem sortal_possessee_subject :
     ∀ s : Source,
-      schemaArity s = .pred1 → schemaSubject s = .possessee := by
+      schemaArity s = .sortal → schemaSubject s = .possessee := by
   intro s h; cases s <;> simp [schemaArity] at h <;> simp [schemaSubject]
 
 /-- The Action Schema's grammaticalization path:
@@ -388,25 +388,25 @@ def predictionsFor (s : Source) : SchemaPrediction :=
     possessorIsSubject := schemaSubject s == .possessor
     arity := schemaArity s }
 
-/-- Location Schema predictions: have-only, possessee-as-subject, Pred1. -/
+/-- Location Schema predictions: have-only, possessee-as-subject, sortal. -/
 theorem location_predictions :
     let p := predictionsFor .location
     p.yieldsHave = true ∧ p.yieldsBelong = false ∧
-    p.possessorIsSubject = false ∧ p.arity = .pred1 := by
+    p.possessorIsSubject = false ∧ p.arity = .sortal := by
   exact ⟨rfl, rfl, rfl, rfl⟩
 
-/-- Companion Schema predictions: have-only, possessor-as-subject, Pred2. -/
+/-- Companion Schema predictions: have-only, possessor-as-subject, relational. -/
 theorem companion_predictions :
     let p := predictionsFor .companion
     p.yieldsHave = true ∧ p.yieldsBelong = false ∧
-    p.possessorIsSubject = true ∧ p.arity = .pred2 := by
+    p.possessorIsSubject = true ∧ p.arity = .relational := by
   exact ⟨rfl, rfl, rfl, rfl⟩
 
-/-- Genitive Schema predictions: have-only, possessee-as-subject, Pred1. -/
+/-- Genitive Schema predictions: have-only, possessee-as-subject, sortal. -/
 theorem genitive_predictions :
     let p := predictionsFor .genitive
     p.yieldsHave = true ∧ p.yieldsBelong = false ∧
-    p.possessorIsSubject = false ∧ p.arity = .pred1 := by
+    p.possessorIsSubject = false ∧ p.arity = .sortal := by
   exact ⟨rfl, rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -490,7 +490,7 @@ section Finnish
 open Finnish.Possession
 
 /-- Finnish's Location Schema matches Heine's predictions:
-    have-construction (not belong), possessee as subject, Pred1 arity. -/
+    have-construction (not belong), possessee as subject, sortal arity. -/
 theorem finnish_matches_heine_predictions :
     let p := predictionsFor sourceSchema
     p.yieldsHave = true ∧ p.yieldsBelong = false ∧
@@ -548,11 +548,11 @@ section Swahili
 open Swahili.Possession
 
 /-- Swahili's Companion Schema matches Heine's predictions:
-    have-construction (not belong), possessor as subject, Pred2. -/
+    have-construction (not belong), possessor as subject, relational. -/
 theorem swahili_companion_matches_heine :
     let p := predictionsFor sourceSchema
     p.yieldsHave = true ∧ p.yieldsBelong = false ∧
-    p.possessorIsSubject = true ∧ p.arity = .pred2 := by
+    p.possessorIsSubject = true ∧ p.arity = .relational := by
   exact ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Swahili is at Stage III: the `-na` marker is no longer decomposable

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -250,26 +250,26 @@ theorem isHaveVerbLanguage_iff_copulaVI (v : Head) :
 open ArgumentStructure.Relational in
 
 /-- The relational HAVE reading requires the complement DP to have a
-    Pred2 interpretation (either lexically relational or via π-shift).
-    This is exactly `NominalInterpType.pred2` from [barker-2011].
+    two-place interpretation (either lexically relational or via π-shift).
+    This is exactly `NominalInterpType.relational` from [barker-2011].
 
     [myler-2016]: "The meanings [of HAVE] are a syntactic natural
     class: all introduced by heads inside DP." For relational HAVE, the
-    DP must supply a possessor slot — which is what Pred2 provides.
+    DP must supply a possessor slot — which is what a relational denotation provides.
 
     The bridge: relational HAVE ↔ possessedDP complement ↔
-    `NominalInterpType.pred2` (has relatum slot for possessor). -/
+    `NominalInterpType.relational` (has relatum slot for possessor). -/
 theorem relational_have_requires_pred2 :
-    NominalInterpType.pred2.hasRelatumSlot ∧
-    NominalInterpType.pred2.canTakePossessor := ⟨trivial, trivial⟩
+    NominalInterpType.relational.hasRelatumSlot ∧
+    NominalInterpType.relational.canTakePossessor := ⟨trivial, trivial⟩
 
 open ArgumentStructure.Relational in
 
-/-- Bare sortals (Pred1, no π) cannot appear in relational HAVE:
+/-- Bare sortals (one-place, no π) cannot appear in relational HAVE:
     "I have a cloud" requires a contextually supplied relation (π).
     Without π, the DP has no possessor slot, so no possessive reading. -/
 theorem bare_sortal_blocks_relational :
-    ¬ NominalInterpType.pred1.canTakePossessor := id
+    ¬ NominalInterpType.sortal.canTakePossessor := id
 
 -- ─── Bridge to NominalStructure (Possession Type) ───
 

--- a/Linglib/Studies/ParteeBorschev2001.lean
+++ b/Linglib/Studies/ParteeBorschev2001.lean
@@ -144,7 +144,7 @@ standalone. -/
 
 variable {E S : Type*}
 
-theorem predicateForm_eq_viaArgument (possessor : E) (R : Pred2 E S) :
+theorem predicateForm_eq_viaArgument (possessor : E) (R : E → E → S → Prop) :
     (fun x s => R possessor x s) = Possessive.viaArgument possessor R :=
   rfl
 

--- a/Linglib/Studies/ParteeBorschev2003.lean
+++ b/Linglib/Studies/ParteeBorschev2003.lean
@@ -54,7 +54,7 @@ J&V, with the construction for P&B — but the result is identical. -/
 /-- **Convergence** (P&B §4.3): J&V's coerce-then-argument equals P&B's modifier
 genitive. The "two theories of genitives" are, on the coerced-sortal case, a
 single denotation reached two ways. -/
-theorem vj_coerce_eq_pb_modifier (possessor : E) (P : Pred1 E S) (R : Pred2 E S) :
+theorem vj_coerce_eq_pb_modifier (possessor : E) (P : E → S → Prop) (R : E → E → S → Prop) :
     viaArgument possessor (π P R) = viaModifier possessor P R :=
   rfl
 
@@ -66,8 +66,8 @@ elliptical argument NP, so English needs the modifier genitive — a problem for
 the uniform argument-only approach. -/
 
 /-- The predicate genitive *John's* is the possessee predicate `λx[R possessor x]`
-= `viaArgument possessor R`, a genuine ⟨e,t⟩ predicate (here `Pred1`). -/
-theorem predicateGenitive_eq (possessor : E) (R : Pred2 E S) :
+= `viaArgument possessor R`, a genuine ⟨e,t⟩ predicate. -/
+theorem predicateGenitive_eq (possessor : E) (R : E → E → S → Prop) :
     (fun x s => R possessor x s) = viaArgument possessor R :=
   rfl
 
@@ -81,14 +81,14 @@ alone; J&V's coercion can introduce `R` at the noun-shift, deriving both. -/
 
 /-- Reading A: the free relation is outside `former`'s scope — *a former mansion
 that is now Mary's*. The only reading P&B's split derives. -/
-def readingA (former : Pred1 E S → Pred1 E S) (possessor : E)
-    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+def readingA (former : (E → S → Prop) → E → S → Prop) (possessor : E)
+    (noun : E → S → Prop) (R : E → E → S → Prop) : E → S → Prop :=
   viaModifier possessor (former noun) R
 
 /-- Reading B: the free relation is inside `formerRel`'s scope — *something that
 was formerly Mary's mansion*. Available on J&V's coercion. -/
-def readingB (formerRel : Pred2 E S → Pred2 E S) (possessor : E)
-    (noun : Pred1 E S) (R : Pred2 E S) : Pred1 E S :=
+def readingB (formerRel : (E → E → S → Prop) → E → E → S → Prop) (possessor : E)
+    (noun : E → S → Prop) (R : E → E → S → Prop) : E → S → Prop :=
   viaArgument possessor (formerRel (π noun R))
 
 namespace FormerMansion
@@ -99,13 +99,13 @@ abbrev Ent := Fin 2
 abbrev Tm := Bool
 
 /-- The building `0` is a mansion at every time. -/
-def mansion : Pred1 Ent Tm := fun x _ => x = 0
+def mansion : Ent → Tm → Prop := fun x _ => x = 0
 /-- Mary (`1`) owned the building (`0`) only in the past. -/
-def owns : Pred2 Ent Tm := fun o x t => o = 1 ∧ x = 0 ∧ t = false
+def owns : Ent → Ent → Tm → Prop := fun o x t => o = 1 ∧ x = 0 ∧ t = false
 /-- *former* P: was P in the past, no longer P now. -/
-def former (P : Pred1 Ent Tm) : Pred1 Ent Tm := fun x t => P x false ∧ ¬ P x t
+def former (P : Ent → Tm → Prop) : Ent → Tm → Prop := fun x t => P x false ∧ ¬ P x t
 /-- *former* on a relation: held in the past, no longer. -/
-def formerRel (Rel : Pred2 Ent Tm) : Pred2 Ent Tm :=
+def formerRel (Rel : Ent → Ent → Tm → Prop) : Ent → Ent → Tm → Prop :=
   fun o x t => Rel o x false ∧ ¬ Rel o x t
 
 /-- **Divergence**: the locus of the free relation is detectable under *former*.

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -94,7 +94,7 @@ single situation. The genitive picks the unique entity standing in the resolved
 relation to the possessor. -/
 
 /-- The (inherent) teacher relation: `0`'s teacher is `1`. -/
-def teacherRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 1
+def teacherRel : Fin 4 → Fin 4 → Unit → Prop := fun x y _ => x = 0 ∧ y = 1
 
 /-- *the girl's teacher* (inherent): the relational noun's own relation applied
 to the possessor (`viaArgument`) has a unique satisfier. -/
@@ -127,10 +127,10 @@ theorem girlsTeacher_existsUnique (s : Unit) :
   existsUnique_possessee theGirlsTeacher s
 
 /-- The control relation: the girl `0` controls the car `2`. -/
-def controlRel : Pred2 (Fin 4) Unit := fun x y _ => x = 0 ∧ y = 2
+def controlRel : Fin 4 → Fin 4 → Unit → Prop := fun x y _ => x = 0 ∧ y = 2
 
 /-- *car* as a sortal noun predicate. -/
-def carPred : Pred1 (Fin 4) Unit := fun y _ => y = 2
+def carPred : Fin 4 → Unit → Prop := fun y _ => y = 2
 
 /-- *the girl's car* (coerced, control): the sortal noun is `π`-shifted with
 the control relation, then combines exactly like a relational noun


### PR DESCRIPTION
Delete the `Pred1`/`Pred2` abbreviations (predicate types this general are used everywhere — write `E → S → Prop` / `E → E → S → Prop` inline); rename `NominalInterpType.pred1/pred2` to `.sortal`/`.relational` and update Heine1997 theorem names and prose accordingly.