### PR TITLE
refactor(Semantics/Possessive): rename Carrier to Description

### DIFF
--- a/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
+++ b/Linglib/Semantics/Definiteness/DeterminerDenotation.lean
@@ -45,8 +45,8 @@ deictic feature projects: deixis filters the referent but never selects it
   possessor; the GQ-form possessive (`PossW`, narrowing-aware) lives in
   `Semantics/Possessive/GQ.lean`.
 * `interpret_possessive_eq_viaModifier`, `Possessive.denote_isSome_iff_iotaPresupposition`,
-  `Possessive.toCarrier` — the determiner denotation *is* the `Possessive`
-  carrier API: same restrictor (Barker's `viaModifier`), same definedness
+  `Possessive.toDefinite` — the determiner denotation *is* the `Possessive`
+  description API: same restrictor (Barker's `viaModifier`), same definedness
   presupposition, same referent.
 
 ## Implementation notes
@@ -211,18 +211,18 @@ theorem Possessive.denote_realized (p : Possessive)
     Determiner.Inventory.Realizes [.possessive p] (Description.possessive R possessor rel).kind :=
   ⟨.possessive p, List.mem_singleton_self _, trivial⟩
 
-/-! ### Unification with the possessive carrier API
+/-! ### Unification with the possessive description API
 
 The possessive determiner's denotation (`Description.possessive`/`russellIota`)
-and the `Possessive` carrier API are not two analyses — they are the same
+and the `Possessive` description API are not two analyses — they are the same
 construction. The determiner's restrictor *is* Barker's `Possessive.viaModifier`
 (π of the noun predicate and the possession relation); its definedness
-presupposition *is* the carrier's Russellian iota-presupposition; and at a
+presupposition *is* the description's Russellian iota-presupposition; and at a
 context where the presupposition holds, the determiner assembles into a
-`Possessive.Definite` carrier whose `existsUnique_possessee` selects the very
+`Possessive.Definite` whose `existsUnique_possessee` selects the very
 referent the determiner does. -/
 
-section CarrierUnification
+section DescriptionUnification
 
 open _root_.ArgumentStructure.Relational
 
@@ -239,7 +239,7 @@ theorem interpret_possessive_eq_viaModifier :
           (fun y _ => R g gs y) (fun a b _ => rel g gs a b) x PUnit.unit) :=
   rfl
 
-/-- The possessive determiner's definedness presupposition *is* the carrier
+/-- The possessive determiner's definedness presupposition *is* the description
 API's Russellian iota-presupposition (`HasIotaWitness`'s condition). -/
 theorem Possessive.denote_isSome_iff_iotaPresupposition (p : Possessive) :
     ((p.denote R possessor rel).selector (g, gs) PUnit.unit).isSome
@@ -250,9 +250,9 @@ theorem Possessive.denote_isSome_iff_iotaPresupposition (p : Possessive) :
   rw [russellIota_isSome_iff_exists_unique]
 
 /-- At a context where its presupposition holds, the possessive determiner
-assembles into a `Possessive.Definite` carrier (over the trivial situation) whose
+assembles into a `Possessive.Definite` (over the trivial situation) whose
 possessee predicate is the determiner's restrictor. -/
-def Possessive.toCarrier
+def Possessive.toDefinite
     (h : iotaPresupposition
       (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit) :
     Possessive.Definite E PUnit where
@@ -260,16 +260,16 @@ def Possessive.toCarrier
   predicate := fun x _ => R g gs x ∧ rel g gs (possessor g gs) x
   presupposition := fun _ => h
 
-/-- The carrier's unique possessee (`existsUnique_possessee`, inherited from
+/-- The description's unique possessee (`existsUnique_possessee`, inherited from
 `HasIotaWitness`) is the referent the determiner selects — the two encodings
 agree by construction. -/
-theorem Possessive.toCarrier_existsUnique
+theorem Possessive.toDefinite_existsUnique
     (h : iotaPresupposition
       (fun x (_ : PUnit) => R g gs x ∧ rel g gs (possessor g gs) x) PUnit.unit) :
     ∃! y : E, HasPossesseePredicate.possesseePredicate
-      (Possessive.toCarrier R possessor rel g gs h) y PUnit.unit :=
+      (Possessive.toDefinite R possessor rel g gs h) y PUnit.unit :=
   existsUnique_possessee _ PUnit.unit
 
-end CarrierUnification
+end DescriptionUnification
 
 end Semantics.Definiteness

--- a/Linglib/Semantics/Possessive/Basic.lean
+++ b/Linglib/Semantics/Possessive/Basic.lean
@@ -1,13 +1,13 @@
 import Linglib.Semantics.Possessive.Relational
 
 /-!
-# Possessive carriers and capabilities
+# Possessive descriptions and capabilities
 
 The unified `Possessive` namespace for the semantics of possessive
 constructions, built on the general relational-noun substrate
 (`ArgumentStructure.Relational`: `π`, `Ex`, `iotaPresupposition`, …). The
-quantificational layer (`Poss`, `PossW`, narrowing, `carrierGQ`) is in
-`Possessive/GQ.lean`; the determiner that denotes through these carriers is
+quantificational layer (`Poss`, `PossW`, narrowing, `descriptionGQ`) is in
+`Possessive/GQ.lean`; the determiner that denotes through these descriptions is
 `Possessive.denote` (`Semantics/Definiteness/DeterminerDenotation.lean`).
 
 ## Main declarations
@@ -16,14 +16,14 @@ quantificational layer (`Poss`, `PossW`, narrowing, `carrierGQ`) is in
   combines with a noun: with a relational noun's own relation (the argument
   genitive) or with a free relation over a sortal restrictor (the modifier
   genitive, Barker's `π`).
-* `Possessive.Carrier` — a possessor + relation + sortal restrictor; the
-  possessee predicate is *derived* (`viaModifier`), never stored, so a carrier
-  cannot be incoherent.
+* `Possessive.Description` — a possessor + relation + sortal restrictor; the
+  possessee predicate is *derived* (`viaModifier`), never stored, so a
+  description cannot be incoherent.
 * `Possessive.Definite` — a possessive carrying a Russellian uniqueness
   presupposition.
 * `HasPossessor`, `HasPossesseePredicate`, `HasPossessionRelation`,
   `HasIotaWitness` — composable capability mixins (root namespace, `Add`/`Mul`
-  idiom); carriers opt into whichever axes they bear.
+  idiom); description types opt into whichever axes they bear.
 * `possesseeSet`, `existsUnique_possessee` — capability-polymorphic consumers.
 * `Possessive.PossessionRelationType` — the four-way Vikner-Jensen possession
   taxonomy.
@@ -52,13 +52,14 @@ theorem viaArgument_eq_viaModifier_top (possessor : E) (R : E → E → S → Pr
     viaArgument possessor R = viaModifier possessor (fun _ _ => True) R := by
   funext y s; simp [viaArgument, viaModifier, π]
 
-/-! ### Carriers -/
+/-! ### Possessive descriptions -/
 
-/-- A possessive carrier: a possessor, a possession relation, and a sortal
-restrictor (the noun predicate; `⊤` for a purely relational noun). The possessee
-predicate is *derived* (`viaModifier`), not stored — so a carrier cannot bundle
-a predicate unrelated to its relation. -/
-structure Carrier (E S : Type*) where
+/-- A possessive description ([barker-1995]): a possessor, a possession
+relation, and a sortal restrictor (the noun predicate; `⊤` for a purely
+relational noun). The possessee predicate is *derived* (`viaModifier`), not
+stored — so a description cannot bundle a predicate unrelated to its
+relation. -/
+structure Description (E S : Type*) where
   /-- The possessor entity. -/
   possessor : E
   /-- The possession relation. -/
@@ -66,14 +67,14 @@ structure Carrier (E S : Type*) where
   /-- The sortal restrictor (the noun predicate). -/
   restrictor : E → S → Prop
 
-namespace Carrier
+namespace Description
 
 /-- The derived possessee predicate: the restrictor conjoined with the relation
 applied to the possessor. -/
-def possesseePred (c : Carrier E S) : E → S → Prop :=
-  viaModifier c.possessor c.restrictor c.relation
+def possesseePred (d : Description E S) : E → S → Prop :=
+  viaModifier d.possessor d.restrictor d.relation
 
-end Carrier
+end Description
 
 /-- A definite possessive carrying its Russellian uniqueness presupposition
 ("the boy's cat", "my mother"). -/
@@ -112,36 +113,36 @@ def asNPQ {E : Type*} (possessor : E) (R : E → E → Prop) :
 
 end Possessive
 
-/-! ### Composable carrier capabilities
+/-! ### Composable description capabilities
 
 Cross-cutting capability mixins for the long-run library where 20-30+ possessive
-carriers each implement a subset of the axes. Following the mathlib
+description types each implement a subset of the axes. Following the mathlib
 `Add`/`Mul`/`Inv`/`Neg` idiom: many small composable classes, each one
-operation; carriers opt in to whichever axes they bear.
+operation; description types opt in to whichever axes they bear.
 
-| Carrier | `HasPossessor` | `HasPossesseePredicate` | `HasPossessionRelation` | `HasIotaWitness` |
+| Type | `HasPossessor` | `HasPossesseePredicate` | `HasPossessionRelation` | `HasIotaWitness` |
 |---|---|---|---|---|
-| `Possessive.Carrier E S`  | ✓ | ✓ | ✓ | — |
-| `Possessive.Definite E S` | ✓ | ✓ | — | ✓ | -/
+| `Possessive.Description E S` | ✓ | ✓ | ✓ | — |
+| `Possessive.Definite E S`    | ✓ | ✓ | — | ✓ | -/
 
-/-- A carrier whose values bundle a possessor entity. -/
+/-- A type whose values bundle a possessor entity. -/
 class HasPossessor (α : Type*) (E : outParam Type*) where
   /-- Project the bundled possessor entity. -/
   possessor : α → E
 
-/-- A carrier whose values bundle a possessee predicate `E → S → Prop`. -/
+/-- A type whose values bundle a possessee predicate `E → S → Prop`. -/
 class HasPossesseePredicate (α : Type*) (E S : outParam Type*) where
   /-- Project the bundled possessee predicate. -/
   possesseePredicate : α → E → S → Prop
 
-/-- A carrier whose values bundle a possession relation `E → E → S → Prop`. Distinct
+/-- A type whose values bundle a possession relation `E → E → S → Prop`. Distinct
 from `HasPossesseePredicate`: a relational noun's R is the noun denotation
 itself, while a sortal-with-π construction carries R separately. -/
 class HasPossessionRelation (α : Type*) (E S : outParam Type*) where
   /-- Project the bundled possession relation. -/
   possessionRelation : α → E → E → S → Prop
 
-/-- Prop class: a possessive carrier whose possessee predicate has a unique
+/-- Prop class: a possessive description whose possessee predicate has a unique
 witness at every situation. Definite possessives bear this; existential and
 quantificational ones do not. -/
 class HasIotaWitness (α : Type*) (E S : outParam Type*)
@@ -154,9 +155,9 @@ namespace Possessive
 
 variable {E S : Type*}
 
-instance : HasPossessor (Carrier E S) E := ⟨Carrier.possessor⟩
-instance : HasPossesseePredicate (Carrier E S) E S := ⟨Carrier.possesseePred⟩
-instance : HasPossessionRelation (Carrier E S) E S := ⟨Carrier.relation⟩
+instance : HasPossessor (Description E S) E := ⟨Description.possessor⟩
+instance : HasPossesseePredicate (Description E S) E S := ⟨Description.possesseePred⟩
+instance : HasPossessionRelation (Description E S) E S := ⟨Description.relation⟩
 
 instance : HasPossessor (Definite E S) E := ⟨Definite.possessor⟩
 instance : HasPossesseePredicate (Definite E S) E S := ⟨Definite.predicate⟩
@@ -171,15 +172,15 @@ end Possessive
 
 variable {α E S : Type*}
 
-/-- The possessee set determined by any carrier bundling a possessor and a
+/-- The possessee set determined by any description bundling a possessor and a
 possession relation: the entities standing in the relation to the possessor. -/
 def possesseeSet [HasPossessor α E] [HasPossessionRelation α E S] (a : α) :
     E → S → Prop :=
   fun y s => HasPossessionRelation.possessionRelation a (HasPossessor.possessor a) y s
 
-/-- Any carrier bearing a Russellian iota-witness denotes a unique possessee at
-every situation. Definite possessives inherit `∃!`-reference with no
-carrier-specific reproof. -/
+/-- Any description bearing a Russellian iota-witness denotes a unique possessee
+at every situation. Definite possessives inherit `∃!`-reference with no
+type-specific reproof. -/
 theorem existsUnique_possessee [HasPossesseePredicate α E S] [HasIotaWitness α E S]
     (a : α) (s : S) :
     ∃! y : E, HasPossesseePredicate.possesseePredicate a y s :=

--- a/Linglib/Semantics/Possessive/Denotation.lean
+++ b/Linglib/Semantics/Possessive/Denotation.lean
@@ -22,7 +22,7 @@ relation), inheriting the possessor's intrinsic presupposition. So:
 * `Possessive.theOf R` — the Kleisli arrow: the unique `R`-possessee of a
   possessor, as a `NominalDenot`.
 * `Possessive.applyTo nd R = nd >>= theOf R` — *NP's N*.
-* `Possessive.Definite.toNominalDenot` — a definite carrier as a `NominalDenot`
+* `Possessive.Definite.toNominalDenot` — a definite description as a `NominalDenot`
   (always-defined selector, from `HasIotaWitness`).
 
 ## Main statements
@@ -76,11 +76,11 @@ theorem applyTo_applyTo (nd : NominalDenot Ctx W E) (R₁ R₂ : E → E → Pro
     applyTo (applyTo nd R₁) R₂ = nd >>= fun p => applyTo (theOf R₁ p) R₂ := by
   simp only [applyTo, NominalDenot.bind_assoc]
 
-/-! ### Definite carriers as nominal denotations -/
+/-! ### Definite descriptions as nominal denotations -/
 
-/-- A definite possessive carrier as a `NominalDenot` over its situations: the
+/-- A definite possessive description as a `NominalDenot` over its situations: the
 selector is `russellIota` of the possessee predicate, always defined because the
-carrier bears the iota-presupposition (`HasIotaWitness`). -/
+description bears the iota-presupposition (`HasIotaWitness`). -/
 noncomputable def Definite.toNominalDenot {S : Type} (d : Possessive.Definite E S) :
     NominalDenot Ctx S E where
   presup := fun _ _ => True

--- a/Linglib/Semantics/Possessive/GQ.lean
+++ b/Linglib/Semantics/Possessive/GQ.lean
@@ -164,28 +164,28 @@ theorem possW_individual_existential_import {Q₂ : GQ α} {R : α → α → Pr
     ∃ b, A b ∧ R a b :=
   h.1
 
-/-! ### Denoting a bundled carrier
+/-! ### Denoting a bundled description
 
-A possessive carrier bundling a possessor and a possession relation (any
-`HasPossessor` + `HasPossessionRelation` instance, e.g. `Possessive.Carrier`)
+A possessive description bundling a possessor and a possession relation (any
+`HasPossessor` + `HasPossessionRelation` instance, e.g. `Possessive.Description`)
 denotes, at a situation, as the `PossW` of its possessor taken whole. Routing
-every carrier through one operator is what makes the API unified: a carrier
+every description through one operator is what makes the API unified: a type
 inherits narrowing and existential import with no bespoke proof. -/
 
-/-- The quantificational denotation of a possessive carrier at a situation `s`:
+/-- The quantificational denotation of a possessive description at a situation `s`:
 its possessor (as an individual NP) and its possession relation (frozen at `s`)
 fed to `PossW`. `Q₂` is the (usually covert) possessee quantifier. -/
-def carrierGQ {γ E S : Type*} [HasPossessor γ E] [HasPossessionRelation γ E S]
+def descriptionGQ {γ E S : Type*} [HasPossessor γ E] [HasPossessionRelation γ E S]
     (a : γ) (Q₂ : GQ E) (s : S) : GQ E :=
   PossW (individual (HasPossessor.possessor a)) Q₂
     (fun x y => HasPossessionRelation.possessionRelation a x y s)
 
-/-- Every carrier inherits existential import: if its denotation holds of
+/-- Every description inherits existential import: if its denotation holds of
 possessee class `A` and scope `B`, the possessor stands in the possession
 relation to some `A`-thing. Free from `possW_individual_existential_import`. -/
-theorem carrierGQ_existential_import {γ E S : Type*}
+theorem descriptionGQ_existential_import {γ E S : Type*}
     [HasPossessor γ E] [HasPossessionRelation γ E S]
-    (a : γ) (Q₂ : GQ E) (s : S) {A B : E → Prop} (h : carrierGQ a Q₂ s A B) :
+    (a : γ) (Q₂ : GQ E) (s : S) {A B : E → Prop} (h : descriptionGQ a Q₂ s A B) :
     ∃ b, A b ∧ HasPossessionRelation.possessionRelation a
       (HasPossessor.possessor a) b s :=
   possW_individual_existential_import h

--- a/Linglib/Semantics/Possessive/Relational.lean
+++ b/Linglib/Semantics/Possessive/Relational.lean
@@ -18,7 +18,7 @@ as separate predicates (`hasRelatumSlot`, `canTakePossessor`) over
 `NominalInterpType` because they describe distinct linguistic facts, even
 though they coincide by construction.
 
-The possessive-specific carriers, capability mixins, and quantificational layer
+The possessive-specific descriptions, capability mixins, and quantificational layer
 live in the unified `Possessive` namespace (`Semantics/Possessive/`), built on
 this substrate.
 

--- a/Linglib/Studies/Barker1995.lean
+++ b/Linglib/Studies/Barker1995.lean
@@ -84,7 +84,7 @@ theorem narrowing_flips_truth_value :
 /-! ### Definiteness and the capability mixins
 
 A definite possessive ("the boy's cat") and a relational possessive ("John's
-sisters"), exercising the possessive-carrier capability mixins
+sisters"), exercising the possessive-description capability mixins
 (`HasIotaWitness`, `HasPossessor`, `HasPossessionRelation`). -/
 
 /-- "the boy's cat": possessor `0` (the boy), with a uniquely-identified cat
@@ -105,7 +105,7 @@ def sibling : Fin 3 → Fin 3 → Prop := fun x y => x = 0 ∧ (y = 1 ∨ y = 2)
 
 /-- "John's sisters": possessor `0` (John), with the sibling relation as the
 possession relation (a relational noun, so the restrictor is trivial). -/
-def johnsSisters : Possessive.Carrier (Fin 3) Unit where
+def johnsSisters : Possessive.Description (Fin 3) Unit where
   possessor := 0
   relation := fun x y _ => sibling x y
   restrictor := fun _ _ => True
@@ -117,27 +117,27 @@ theorem johnsSisters_possesseeSet (y : Fin 3) (s : Unit) :
     possesseeSet johnsSisters y s ↔ sibling 0 y :=
   Iff.rfl
 
-/-! ### Narrowing through a carrier
+/-! ### Narrowing through a description
 
-The same narrowing, now for a type ⟨1⟩ possessor ("planet 2's rings"). A carrier
+The same narrowing, now for a type ⟨1⟩ possessor ("planet 2's rings"). A description
 bundles a single possessor, so narrowing surfaces as existential import: routed
-through the unified `carrierGQ` denotation, *planet 2's rings are icy* is false
+through the unified `descriptionGQ` denotation, *planet 2's rings are icy* is false
 because planet 2 has no ring. Reuses the planets/rings model above. -/
 
 /-- "planet 2's rings": possessor `2`, with `hasRing` as the possession
 relation. -/
-def planet2sRings : Possessive.Carrier (Fin 5) Unit where
+def planet2sRings : Possessive.Description (Fin 5) Unit where
   possessor := 2
   relation := fun x y _ => hasRing x y
   restrictor := fun y _ => isRing y
 
-/-- *Planet 2's rings are icy* is false: via the unified carrier denotation,
-existential import (`carrierGQ_existential_import`) requires planet 2 to possess
+/-- *Planet 2's rings are icy* is false: via the unified description denotation,
+existential import (`descriptionGQ_existential_import`) requires planet 2 to possess
 a ring, but it has none — narrowing at the individual level. -/
 theorem planet2sRings_no_icy_rings :
-    ¬ carrierGQ planet2sRings some_sem () isRing isIcy := by
+    ¬ descriptionGQ planet2sRings some_sem () isRing isIcy := by
   intro h
-  obtain ⟨b, _, hr⟩ := carrierGQ_existential_import planet2sRings some_sem () h
+  obtain ⟨b, _, hr⟩ := descriptionGQ_existential_import planet2sRings some_sem () h
   have hb : hasRing 2 b := hr
   simp only [hasRing] at hb
   rcases hb with ⟨h2, _⟩ | ⟨h2, _⟩ <;> exact absurd h2 (by decide)

--- a/Linglib/Studies/ParteeBorschev2001.lean
+++ b/Linglib/Studies/ParteeBorschev2001.lean
@@ -12,8 +12,8 @@ relation of a relational noun or adjective (an *argument* genitive).
 
 The argument/modifier distinction is **study-local**: it is P&B's analysis of a
 *construction*, contested by [vikner-jensen-2002] (who deny the split is
-grammatical), so it is not a field of the theory-neutral substrate carrier
-(`Possessive.Carrier`). The predicate form itself *is* substrate — the bare
+grammatical), so it is not a field of the theory-neutral substrate description
+(`Possessive.Description`). The predicate form itself *is* substrate — the bare
 ⟨e,t⟩ possessive predicate is `Possessive.viaArgument` (the relation applied to
 the possessor).
 

--- a/Linglib/Studies/ViknerJensen2002.lean
+++ b/Linglib/Studies/ViknerJensen2002.lean
@@ -8,7 +8,7 @@ genitive: the genitive always combines with a *relational* noun — a
 non-relational head is coerced via Barker's `π`, the relation type supplied by
 the noun's qualia (`availableRelations`, §3.1.2). The genitive clitic itself
 (`clitic`, their (16)) embeds a narrow-scope definite: the worked examples
-prove `iotaPresupposition` and feed the `Possessive.Definite` carrier's
+prove `iotaPresupposition` and feed `Possessive.Definite`'s
 `existsUnique_possessee`.
 -/
 
@@ -115,8 +115,8 @@ theorem aGirlsTeacher (P : Fin 4 → Prop) :
     rwa [← (hx 1).mp ⟨rfl, rfl⟩] at hP
   · exact fun hP => ⟨0, rfl, 1, fun y => by simp, hP⟩
 
-/-- *the girl's teacher* as a `Possessive.Definite` carrier: its unique referent
-is delivered by the carrier API's `existsUnique_possessee`, no bespoke proof. -/
+/-- *the girl's teacher* as a `Possessive.Definite`: its unique referent is
+delivered by the capability API's `existsUnique_possessee`, no bespoke proof. -/
 def theGirlsTeacher : Possessive.Definite (Fin 4) Unit where
   possessor := 0
   predicate := viaArgument 0 teacherRel


### PR DESCRIPTION
`Possessive.Carrier` was named for its role in the capability-typeclass plumbing, not its content; mathlib reserves `carrier` for the underlying-set field of bundled substructures. The record is a possessor + relation + restrictor — a possessive description ([barker-1995]). Also `carrierGQ` → `descriptionGQ`, `Possessive.toCarrier` → `toDefinite` (it builds a `Definite`), and prose updated; the model-theoretic sense of "carrier" in GQ.lean is kept.