### PR TITLE
refactor(Pragmatics/DecisionTheoretic): likelihood-ratio grounding

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -297,6 +297,7 @@ import Linglib.Core.Probability.GibbsVariational
 import Linglib.Core.Probability.Gumbel
 import Linglib.Core.Probability.Hypergeometric
 import Linglib.Core.Probability.JointPosterior
+import Linglib.Core.Probability.LikelihoodRatio
 import Linglib.Core.Probability.LogitChoice
 import Linglib.Core.Probability.Marginal
 import Linglib.Core.Probability.PitmanYor

--- a/Linglib/Core/Probability/LikelihoodRatio.lean
+++ b/Linglib/Core/Probability/LikelihoodRatio.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Probability.Independence.Basic
+import Mathlib.MeasureTheory.Measure.Real
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+
+/-!
+# Event-level likelihood ratios of two measures
+
+The likelihood ratio `μ e / ν e` of a pair of measures at an event: the
+Bayes factor of the evidence `e` for the simple binary testing problem
+`(μ, ν)`. Mathlib's `MeasureTheory.llr` is the *pointwise* log-ratio
+`log (μ.rnDeriv ν x).toReal`; this file's ratio is its event-level
+companion — the marginal likelihood ratio a Bayes factor compares, which
+agrees with `exp (llr μ ν x)` at positive-mass atoms of a discrete space
+and is the object Merin-style argumentation semantics needs (evidence is a
+proposition, not a sample point). In the vocabulary of Degenne's
+testing-lower-bounds development (upstreaming into
+`Mathlib.Probability.Decision`), the pair `(μ, ν)` is `twoHypKernel μ ν`;
+this file proves the ratio's algebra without any packaging. `[UPSTREAM]`
+candidates.
+
+## Main results
+
+* `likelihoodRatio_mul_swap`: LR(μ,ν) · LR(ν,μ) = 1 at events of nonzero
+  finite mass under both measures.
+* `log_likelihoodRatio`: the log-ratio is a difference of surprisals.
+* `likelihoodRatio_inter`: under independence in both measures, the ratio
+  is multiplicative over intersections.
+* `max_likelihoodRatio_lt_inter`, `likelihoodRatio_union_lt_max`,
+  `one_lt_likelihoodRatio_union`: for probability measures with both events
+  of ratio above one, intersection beats both events beats union beats one.
+-/
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace ProbabilityTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω]
+
+/-- The likelihood ratio of two measures at an event, in `ℝ≥0∞`: total
+division gives the boundary cases their true values — `ν e = 0 < μ e` is
+infinitely strong evidence for `μ`, and 0/0 = 0. -/
+noncomputable def likelihoodRatio (μ ν : Measure Ω) (e : Set Ω) : ℝ≥0∞ :=
+  μ e / ν e
+
+variable {μ ν : Measure Ω} {a b e : Set Ω}
+
+theorem likelihoodRatio_def (μ ν : Measure Ω) (e : Set Ω) :
+    likelihoodRatio μ ν e = μ e / ν e := rfl
+
+/-- Swapping the hypotheses inverts the ratio: LR(μ,ν) · LR(ν,μ) = 1 at any
+event with nonzero finite mass under both. -/
+theorem likelihoodRatio_mul_swap (hμ0 : μ e ≠ 0) (hμt : μ e ≠ ∞)
+    (hν0 : ν e ≠ 0) (hνt : ν e ≠ ∞) :
+    likelihoodRatio μ ν e * likelihoodRatio ν μ e = 1 := by
+  rw [likelihoodRatio, likelihoodRatio, div_eq_mul_inv, div_eq_mul_inv,
+    mul_mul_mul_comm, mul_comm (μ e) (ν e), mul_mul_mul_comm,
+    ENNReal.mul_inv_cancel hν0 hνt, ENNReal.mul_inv_cancel hμ0 hμt, one_mul]
+
+/-- The log-likelihood ratio is a difference of surprisals:
+log LR(μ,ν)(E) = (−log ν E) − (−log μ E). -/
+theorem log_likelihoodRatio (hμ0 : μ e ≠ 0) (hμt : μ e ≠ ∞)
+    (hν0 : ν e ≠ 0) (hνt : ν e ≠ ∞) :
+    Real.log (likelihoodRatio μ ν e).toReal =
+      (-Real.log (ν e).toReal) - (-Real.log (μ e).toReal) := by
+  rw [likelihoodRatio, ENNReal.toReal_div,
+    Real.log_div (ENNReal.toReal_ne_zero.mpr ⟨hμ0, hμt⟩)
+      (ENNReal.toReal_ne_zero.mpr ⟨hν0, hνt⟩)]
+  ring
+
+/-- Under independence in both measures, the likelihood ratio is
+multiplicative over intersections. -/
+theorem likelihoodRatio_inter (h₁ : IndepSet a b μ) (h₂ : IndepSet a b ν)
+    (hνb0 : ν b ≠ 0) (hνbt : ν b ≠ ∞) :
+    likelihoodRatio μ ν (a ∩ b) = likelihoodRatio μ ν a * likelihoodRatio μ ν b := by
+  rw [likelihoodRatio, likelihoodRatio, likelihoodRatio,
+    h₁.measure_inter_eq_mul, h₂.measure_inter_eq_mul,
+    ENNReal.mul_div_mul_comm (Or.inr hνbt) (Or.inr hνb0)]
+
+section OrderFacts
+
+variable [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+
+/-- Intersection dominates both conjuncts: under independence in both
+measures, if both events have ratio above one then so does their
+intersection, strictly beyond either. -/
+theorem max_likelihoodRatio_lt_inter (h₁ : IndepSet a b μ) (h₂ : IndepSet a b ν)
+    (ha : 1 < likelihoodRatio μ ν a) (hb : 1 < likelihoodRatio μ ν b)
+    (hνa : ν a ≠ 0) (hνb : ν b ≠ 0) :
+    max (likelihoodRatio μ ν a) (likelihoodRatio μ ν b) <
+      likelihoodRatio μ ν (a ∩ b) := by
+  have hFinA : likelihoodRatio μ ν a ≠ ∞ :=
+    (ENNReal.div_lt_top (measure_ne_top μ a) hνa).ne
+  have hFinB : likelihoodRatio μ ν b ≠ ∞ :=
+    (ENNReal.div_lt_top (measure_ne_top μ b) hνb).ne
+  rw [likelihoodRatio_inter h₁ h₂ hνb (measure_ne_top ν b), max_lt_iff]
+  constructor
+  · calc likelihoodRatio μ ν a = likelihoodRatio μ ν a * 1 := (mul_one _).symm
+    _ < likelihoodRatio μ ν a * likelihoodRatio μ ν b :=
+        ENNReal.mul_lt_mul_right (pos_of_gt ha).ne' hFinA hb
+  · calc likelihoodRatio μ ν b = 1 * likelihoodRatio μ ν b := (one_mul _).symm
+    _ < likelihoodRatio μ ν a * likelihoodRatio μ ν b :=
+        ENNReal.mul_lt_mul_left (pos_of_gt hb).ne' hFinB ha
+
+/-- Arithmetic core of the union bounds: with the four masses in position,
+the inclusion-exclusion ratio sits strictly between one and the larger
+single-event ratio. -/
+private lemma max_div_gt_or_div (pAH pBH pAnH pBnH : ℝ)
+    (h1 : 0 < pAnH) (h2 : 0 < pBnH)
+    (h3 : pAnH < pAH) (h4 : pBnH < pBH)
+    (h5 : pAnH < 1) (h6 : pBnH < 1)
+    (_h7 : pAH ≤ 1) (h8 : pBH ≤ 1) :
+    max (pAH / pAnH) (pBH / pBnH) >
+      (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) ∧
+    (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) > 1 := by
+  have hden_pos : pAnH + pBnH - pAnH * pBnH > 0 := by nlinarith
+  refine ⟨?_, ?_⟩
+  · rw [gt_iff_lt, max_def]; split
+    · rename_i hge
+      rw [div_lt_div_iff₀ hden_pos h2]
+      have h_cross := (div_le_div_iff₀ h1 h2).mp hge
+      nlinarith [mul_pos (mul_pos h2 (show (0:ℝ) < pBH by linarith))
+        (show pAH - pAnH > 0 from by linarith)]
+    · rename_i hlt; push Not at hlt
+      rw [div_lt_div_iff₀ hden_pos h1]
+      have h_cross := (div_le_div_iff₀ h2 h1).mp (le_of_lt hlt)
+      nlinarith [mul_pos (mul_pos h1 (show (0:ℝ) < pAH by linarith))
+        (show pBH - pBnH > 0 from by linarith)]
+  · rw [gt_iff_lt, one_lt_div hden_pos]
+    nlinarith
+
+/-- Union bounds under independence in both measures with both ratios above
+one: the union's ratio is strictly below the larger single-event ratio and
+strictly above one. -/
+private theorem likelihoodRatio_union_bounds (hbm : MeasurableSet b)
+    (h₁ : IndepSet a b μ) (h₂ : IndepSet a b ν)
+    (ha : 1 < likelihoodRatio μ ν a) (hb : 1 < likelihoodRatio μ ν b)
+    (hνa : ν a ≠ 0) (hνb : ν b ≠ 0) :
+    likelihoodRatio μ ν (a ∪ b) < max (likelihoodRatio μ ν a) (likelihoodRatio μ ν b) ∧
+    1 < likelihoodRatio μ ν (a ∪ b) := by
+  -- Real shadows of the four masses.
+  set pAH := (μ a).toReal with hpAH
+  set pBH := (μ b).toReal with hpBH
+  set pAnH := (ν a).toReal with hpAnH
+  set pBnH := (ν b).toReal with hpBnH
+  have hAnH_pos : 0 < pAnH := ENNReal.toReal_pos hνa (measure_ne_top ν a)
+  have hBnH_pos : 0 < pBnH := ENNReal.toReal_pos hνb (measure_ne_top ν b)
+  have hAH_gt : pAnH < pAH := by
+    refine (ENNReal.toReal_lt_toReal (measure_ne_top ν a) (measure_ne_top μ a)).mpr ?_
+    have h := (ENNReal.lt_div_iff_mul_lt (Or.inl hνa)
+      (Or.inl (measure_ne_top ν a))).mp ha
+    rwa [one_mul] at h
+  have hBH_gt : pBnH < pBH := by
+    refine (ENNReal.toReal_lt_toReal (measure_ne_top ν b) (measure_ne_top μ b)).mpr ?_
+    have h := (ENNReal.lt_div_iff_mul_lt (Or.inl hνb)
+      (Or.inl (measure_ne_top ν b))).mp hb
+    rwa [one_mul] at h
+  have hAH_le : pAH ≤ 1 := by
+    rw [hpAH, ← ENNReal.toReal_one]
+    exact ENNReal.toReal_mono ENNReal.one_ne_top prob_le_one
+  have hBH_le : pBH ≤ 1 := by
+    rw [hpBH, ← ENNReal.toReal_one]
+    exact ENNReal.toReal_mono ENNReal.one_ne_top prob_le_one
+  have harith := max_div_gt_or_div pAH pBH pAnH pBnH hAnH_pos hBnH_pos hAH_gt hBH_gt
+    (lt_of_lt_of_le hAH_gt hAH_le) (lt_of_lt_of_le hBH_gt hBH_le) hAH_le hBH_le
+  -- Inclusion-exclusion in ℝ, independence-substituted.
+  have hOrM : (μ (a ∪ b)).toReal = pAH + pBH - pAH * pBH := by
+    have h := congrArg ENNReal.toReal (measure_union_add_inter (μ := μ) a hbm)
+    rw [ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _),
+      ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _),
+      h₁.measure_inter_eq_mul, ENNReal.toReal_mul] at h
+    linarith
+  have hOrN : (ν (a ∪ b)).toReal = pAnH + pBnH - pAnH * pBnH := by
+    have h := congrArg ENNReal.toReal (measure_union_add_inter (μ := ν) a hbm)
+    rw [ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _),
+      ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _),
+      h₂.measure_inter_eq_mul, ENNReal.toReal_mul] at h
+    linarith
+  have hOrN_ne : ν (a ∪ b) ≠ 0 := fun h0 =>
+    hνa (measure_mono_null Set.subset_union_left h0)
+  have hFinA : likelihoodRatio μ ν a ≠ ∞ :=
+    (ENNReal.div_lt_top (measure_ne_top μ a) hνa).ne
+  have hFinB : likelihoodRatio μ ν b ≠ ∞ :=
+    (ENNReal.div_lt_top (measure_ne_top μ b) hνb).ne
+  have hFinOr : likelihoodRatio μ ν (a ∪ b) ≠ ∞ :=
+    (ENNReal.div_lt_top (measure_ne_top μ _) hOrN_ne).ne
+  have hLROr : (likelihoodRatio μ ν (a ∪ b)).toReal =
+      (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) := by
+    rw [likelihoodRatio, ENNReal.toReal_div, hOrM, hOrN]
+  constructor
+  · refine (ENNReal.toReal_lt_toReal hFinOr (by simp [hFinA, hFinB])).mp ?_
+    rw [hLROr, ENNReal.toReal_max hFinA hFinB, likelihoodRatio, likelihoodRatio,
+      ENNReal.toReal_div, ENNReal.toReal_div]
+    exact harith.1
+  · refine (ENNReal.toReal_lt_toReal ENNReal.one_ne_top hFinOr).mp ?_
+    rw [hLROr, ENNReal.toReal_one]
+    exact harith.2
+
+/-- Under independence in both measures with both ratios above one, the
+union's ratio is strictly below the larger single-event ratio. -/
+theorem likelihoodRatio_union_lt_max (hbm : MeasurableSet b)
+    (h₁ : IndepSet a b μ) (h₂ : IndepSet a b ν)
+    (ha : 1 < likelihoodRatio μ ν a) (hb : 1 < likelihoodRatio μ ν b)
+    (hνa : ν a ≠ 0) (hνb : ν b ≠ 0) :
+    likelihoodRatio μ ν (a ∪ b) < max (likelihoodRatio μ ν a) (likelihoodRatio μ ν b) :=
+  (likelihoodRatio_union_bounds hbm h₁ h₂ ha hb hνa hνb).1
+
+/-- Under independence in both measures with both ratios above one, the
+union's ratio still exceeds one. -/
+theorem one_lt_likelihoodRatio_union (hbm : MeasurableSet b)
+    (h₁ : IndepSet a b μ) (h₂ : IndepSet a b ν)
+    (ha : 1 < likelihoodRatio μ ν a) (hb : 1 < likelihoodRatio μ ν b)
+    (hνa : ν a ≠ 0) (hνb : ν b ≠ 0) :
+    1 < likelihoodRatio μ ν (a ∪ b) :=
+  (likelihoodRatio_union_bounds hbm h₁ h₂ ha hb hνa hνb).2
+
+end OrderFacts
+
+end ProbabilityTheory

--- a/Linglib/Pragmatics/DecisionTheoretic/Also.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/Also.lean
@@ -155,7 +155,7 @@ private lemma presup_implies_bf_one (ctx : Context W)
     rw [cond_apply ctx.topicMeasurable.compl, Set.inter_comm,
       presup_joint ctx.prior ha hp, mul_comm, mul_assoc,
       ENNReal.mul_inv_cancel hNH (measure_ne_top _ _), mul_one]
-  rw [bayesFactor, h1, h2, ENNReal.div_self hA (measure_ne_top _ _)]
+  rw [bayesFactor_def, h1, h2, ENNReal.div_self hA (measure_ne_top _ _)]
 
 /-- **Corollary 15**: "Also" requires non-identity.
 
@@ -179,9 +179,10 @@ theorem also_nonidentity {E : Type*} (ctx : Context W)
 conditionally independent of any other proposition given both H and ¬H. -/
 private lemma presup_implies_cip (ctx : Context W)
     [IsProbabilityMeasure ctx.prior] {a b : Set W} (ha : MeasurableSet a)
-    (hp : presupposedIrrelevant ctx.prior a) : CIP ctx a b := by
+    (hbm : MeasurableSet b)
+    (hp : presupposedIrrelevant ctx.prior a) : CondIndepIssue ctx a b := by
   have hA := presup_ne_zero ctx.prior hp
-  constructor
+  refine (condIndepIssue_iff _ ha hbm).mpr ⟨?_, ?_⟩
   · rcases eq_or_ne (ctx.prior ctx.topic) 0 with h0 | h0
     · simp [ProbabilityTheory.cond, Measure.restrict_eq_zero.mpr h0]
     · rw [cond_apply ctx.topicMeasurable, cond_apply ctx.topicMeasurable,
@@ -219,10 +220,11 @@ If A is presupposed, then BF(A∧B) = BF(A)·BF(B) with no independence
 assumption: inertness supplies the factorization. -/
 theorem presuppositional_independence_additivity (ctx : Context W)
     [IsProbabilityMeasure ctx.prior] {a b : Set W} (ha : MeasurableSet a)
+    (hbm : MeasurableSet b)
     (hp : presupposedIrrelevant ctx.prior a)
     (hNotH' : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
     bayesFactor ctx (a ∩ b) = bayesFactor ctx a * bayesFactor ctx b :=
-  bayes_factor_multiplicative_under_cip ctx a b (presup_implies_cip ctx ha hp) hNotH'
+  (presup_implies_cip ctx ha hbm hp).bayesFactor_inter hNotH'
 
 /-! **Prediction 4** (not formalized): "Also" removes causal implicature.
 

--- a/Linglib/Pragmatics/DecisionTheoretic/Basic.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/Basic.lean
@@ -1,8 +1,10 @@
 import Linglib.Core.Probability.ConditionalProbability
+import Linglib.Core.Probability.LikelihoodRatio
 import Linglib.Semantics.Questions.Hamblin
 import Mathlib.MeasureTheory.Measure.Count
 import Mathlib.MeasureTheory.Measure.Real
 import Mathlib.Probability.Kernel.Basic
+import Mathlib.Probability.Decision.Risk.Countable
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 /-!
@@ -13,34 +15,39 @@ Core definitions for Merin's Decision-Theoretic Semantics (DTS). Meaning is
 explicated through *signed relevance* — the Bayes factor P(E∣H)/P(E∣¬H) —
 relative to a dichotomic issue {H, ¬H}.
 
-The probability substrate is mathlib's: a context carries a
-`MeasureTheory.Measure`, conditioning is `ProbabilityTheory.cond` (`μ[|s]`),
-and the Bayes factor lives in `ℝ≥0∞`, where total division gives the edge
-cases their true values — P(E∣¬H) = 0 < P(E∣H) is *infinitely* strong
-evidence, and 0/0 is the vacuous 0.
+A context is a binary statistical model in the sense of mathlib's
+statistical decision theory (`Mathlib.Probability.Decision`): each side of
+the issue generates data from the prior conditioned on it
+(`Context.conditional`), the pair packages as a kernel out of `Bool`
+(`Context.hypothesisKernel`, the shape of Degenne's `twoHypKernel`), and
+`bayesFactor` is `ProbabilityTheory.likelihoodRatio` of the two
+conditionals. The substance of the Bayes-factor algebra lives at the
+two-measure level in `Core.Probability.LikelihoodRatio`; this file adds the
+issue vocabulary and the facts that genuinely concern the joint prior.
 
 ## Key Definitions
 
 - `Context` — a dichotomic issue (`topic : Set W`, with its measurability
-  witness) plus a prior measure. Following mathlib's `Filter.principal`
-  pattern, the polar interrogative is not given a separate wrapper type: the
-  `topic` is stored directly, and the inquisitive view is recovered as
-  `Context.toCoreIssue ctx = Question.polar {w | ctx.topic w}` at
-  consumption sites that need the general inquisitive-content lattice.
-- `bayesFactor` — P(E∣H) / P(E∣¬H) in `ℝ≥0∞`
+  witness) plus a prior measure; `Context.Nondegenerate` marks a live issue
+- `bayesFactor` — the likelihood ratio of the induced testing problem
 - `posRelevant` / `negRelevant` / `irrelevant` — ordinal relevance predicates
 - `hContrary` — A and B have opposite relevance signs
-- `CIP` — Conditional Independence Presumption
+- `CondIndepIssue` — Merin's Conditional Independence Presumption, as
+  mathlib `IndepSet` under both conditionals
 
 ## Main Results
 
 - **Corollary 3** (`sign_reversal`): BF_H(E) · BF_{¬H}(E) = 1
-- **Fact 2** (`log_bayesFactor`): relevance is the differential of conditional
-  informativeness, log BF_H(E) = inf(E, ¬H) − inf(E, H)
-- **Fact 5** (`bayes_factor_multiplicative_under_cip`): Under CIP,
-  BF(A∧B) = BF(A) · BF(B)
-- **Theorem 6b** (`xor_not_necessarily_positive`): Counterexample showing
-  XOR of two positively relevant propositions can be negatively relevant
+- **Fact 2** (`log_bayesFactor`): relevance is the differential of
+  conditional informativeness
+- **Fact 5** (`CondIndepIssue.bayesFactor_inter`): under issue-conditional
+  independence, BF(A∧B) = BF(A) · BF(B); **Theorem 6a** splits into
+  `CondIndepIssue.max_bayesFactor_lt_inter`, `.bayesFactor_union_lt_max`,
+  and `.one_lt_bayesFactor_union`
+- **Theorem 6b** (`xor_not_necessarily_positive`): XOR of two positively
+  relevant propositions can be negatively relevant
+- `avgRisk_hypothesisKernel`: the average risk of an estimator against the
+  induced problem, in its finite two-point form
 -/
 
 open MeasureTheory ProbabilityTheory
@@ -114,15 +121,89 @@ theorem Context.toCoreIssue_isInquisitive_iff (ctx : Context W) :
       {w | ctx.topic w} ≠ ∅ ∧ {w | ctx.topic w} ≠ Set.univ :=
   Question.isInquisitive_polar_iff _
 
+/-! ### The induced binary testing problem
+
+A context is a binary statistical model: the parameter space is `Bool`,
+and each side of the issue generates data from the prior conditioned on
+it. `Context.conditional` is the model's family of data-generating
+distributions and `Context.hypothesisKernel` packages it as the kernel of
+the testing problem (the shape of Degenne's `twoHypKernel μ ν`). -/
+
+/-- The data-generating distribution of each side of the issue: the prior
+conditioned on H (at `true`) or on ¬H (at `false`). -/
+noncomputable def Context.conditional (ctx : Context W) : Bool → Measure W
+  | true => ctx.prior[|ctx.topic]
+  | false => ctx.prior[|ctx.topicᶜ]
+
+@[simp] theorem Context.conditional_true (ctx : Context W) :
+    ctx.conditional true = ctx.prior[|ctx.topic] := rfl
+
+@[simp] theorem Context.conditional_false (ctx : Context W) :
+    ctx.conditional false = ctx.prior[|ctx.topicᶜ] := rfl
+
+/-- Swapping the issue reindexes the conditionals along negation. -/
+theorem Context.conditional_swapIssue (ctx : Context W) (θ : Bool) :
+    (swapIssue ctx).conditional θ = ctx.conditional (!θ) := by
+  cases θ <;> simp [Context.conditional, swapIssue, compl_compl]
+
+/-- The data-generating kernel of the induced binary testing problem. -/
+noncomputable def Context.hypothesisKernel (ctx : Context W) : Kernel Bool W :=
+  .ofFunOfCountable ctx.conditional
+
+/-- The parameter prior of the induced binary testing problem: the issue
+splits the prior's total mass. -/
+noncomputable def Context.hypothesisPrior (ctx : Context W) : Measure Bool :=
+  ctx.prior ctx.topic • Measure.dirac true + ctx.prior ctx.topicᶜ • Measure.dirac false
+
+@[simp] theorem Context.hypothesisKernel_apply (ctx : Context W) (θ : Bool) :
+    ctx.hypothesisKernel θ = ctx.conditional θ := rfl
+
+@[simp] theorem Context.hypothesisPrior_true (ctx : Context W) :
+    ctx.hypothesisPrior {true} = ctx.prior ctx.topic := by
+  simp [Context.hypothesisPrior, Measure.dirac_apply' _ (MeasurableSet.singleton _)]
+
+@[simp] theorem Context.hypothesisPrior_false (ctx : Context W) :
+    ctx.hypothesisPrior {false} = ctx.prior ctx.topicᶜ := by
+  simp [Context.hypothesisPrior, Measure.dirac_apply' _ (MeasurableSet.singleton _)]
+
+/-- A live issue: both sides carry mass. Merin's dichotomic issue {H, ¬H}
+presupposes a genuine question, so the degenerate cases are excluded at the
+level of the object rather than per theorem. -/
+class Context.Nondegenerate (ctx : Context W) : Prop where
+  topic_ne_zero : ctx.prior ctx.topic ≠ 0
+  compl_ne_zero : ctx.prior ctx.topicᶜ ≠ 0
+
+instance (ctx : Context W) [h : ctx.Nondegenerate] : (swapIssue ctx).Nondegenerate :=
+  ⟨h.compl_ne_zero, by simpa [swapIssue, compl_compl] using h.topic_ne_zero⟩
+
+/-- Each side's conditional is a genuine probability measure over a live
+issue. -/
+theorem Context.isProbabilityMeasure_conditional (ctx : Context W)
+    [IsFiniteMeasure ctx.prior] [ctx.Nondegenerate] (θ : Bool) :
+    IsProbabilityMeasure (ctx.conditional θ) := by
+  cases θ
+  · exact cond_isProbabilityMeasure Context.Nondegenerate.compl_ne_zero
+  · exact cond_isProbabilityMeasure Context.Nondegenerate.topic_ne_zero
+
+instance (ctx : Context W) (θ : Bool) :
+    IsZeroOrProbabilityMeasure (ctx.conditional θ) := by
+  cases θ <;> · rw [Context.conditional]; infer_instance
+
 /-! ### Bayes factor and relevance -/
 
-/-- Bayes factor: P(E∣H) / P(E∣¬H), in `ℝ≥0∞`.
-
-The pre-log ratio that determines relevance sign and magnitude. Total
-division gives the boundary cases their true values: P(E∣¬H) = 0 with
-P(E∣H) > 0 is `∞` (infinitely strong evidence for H), and 0/0 = 0. -/
+/-- Bayes factor: P(E∣H) / P(E∣¬H), in `ℝ≥0∞` — the likelihood ratio of the
+induced binary testing problem. Total division gives the boundary cases
+their true values: P(E∣¬H) = 0 with P(E∣H) > 0 is `∞` (infinitely strong
+evidence for H), and 0/0 = 0. -/
 noncomputable def bayesFactor (ctx : Context W) (e : Set W) : ℝ≥0∞ :=
-  ctx.prior[|ctx.topic] e / ctx.prior[|ctx.topicᶜ] e
+  likelihoodRatio (ctx.conditional true) (ctx.conditional false) e
+
+theorem bayesFactor_def (ctx : Context W) (e : Set W) :
+    bayesFactor ctx e = ctx.prior[|ctx.topic] e / ctx.prior[|ctx.topicᶜ] e := rfl
+
+/-- `bayesFactor` is the likelihood ratio of the induced testing problem. -/
+theorem bayesFactor_eq_hypothesisKernel_div (ctx : Context W) (e : Set W) :
+    bayesFactor ctx e = ctx.hypothesisKernel true e / ctx.hypothesisKernel false e := rfl
 
 /-- E is positively relevant to H: BF > 1 (E confirms H). -/
 def posRelevant (ctx : Context W) (e : Set W) : Prop :=
@@ -147,7 +228,7 @@ reduced. -/
 theorem bayesFactor_swapIssue (ctx : Context W) (e : Set W) :
     bayesFactor (swapIssue ctx) e =
       ctx.prior[|ctx.topicᶜ] e / ctx.prior[|ctx.topic] e := by
-  simp [bayesFactor, swapIssue, compl_compl]
+  simp [bayesFactor, likelihoodRatio, swapIssue, compl_compl]
 
 /-! ### Cross-product characterizations
 
@@ -158,16 +239,19 @@ transfer done once, edge cases included; the particle files consume these. -/
 the H-side mass of E outweighs its ¬H-side mass after weighting each by the
 opposite cell of the issue. -/
 theorem posRelevant_iff_real_cross (ctx : Context W) [IsFiniteMeasure ctx.prior]
-    {e : Set W} (hH : ctx.prior ctx.topic ≠ 0) (hNH : ctx.prior ctx.topicᶜ ≠ 0) :
+    [ctx.Nondegenerate] {e : Set W} :
     posRelevant ctx e ↔
       (ctx.prior (ctx.topicᶜ ∩ e)).toReal * (ctx.prior ctx.topic).toReal <
       (ctx.prior (ctx.topic ∩ e)).toReal * (ctx.prior ctx.topicᶜ).toReal := by
+  have hH := Context.Nondegenerate.topic_ne_zero (ctx := ctx)
+  have hNH := Context.Nondegenerate.compl_ne_zero (ctx := ctx)
   have hHm := ctx.topicMeasurable
   have hpH : 0 < (ctx.prior ctx.topic).toReal :=
     ENNReal.toReal_pos hH (measure_ne_top _ _)
   have hpNH : 0 < (ctx.prior ctx.topicᶜ).toReal :=
     ENNReal.toReal_pos hNH (measure_ne_top _ _)
-  simp only [posRelevant, bayesFactor]
+  simp only [posRelevant, bayesFactor, likelihoodRatio, Context.conditional_true,
+    Context.conditional_false]
   rcases eq_or_ne (ctx.prior[|ctx.topicᶜ] e) 0 with hz | hz
   · have hzm : ctx.prior (ctx.topicᶜ ∩ e) = 0 :=
       (mul_eq_zero.mp ((cond_apply hHm.compl ctx.prior e).symm.trans hz)).resolve_left
@@ -203,17 +287,19 @@ theorem posRelevant_iff_real_cross (ctx : Context W) [IsFiniteMeasure ctx.prior]
 proposition E (one of nonzero mass; a null E is vacuously negatively
 relevant but has a degenerate cross-product). -/
 theorem negRelevant_iff_real_cross (ctx : Context W) [IsFiniteMeasure ctx.prior]
-    {e : Set W} (he : ctx.prior e ≠ 0)
-    (hH : ctx.prior ctx.topic ≠ 0) (hNH : ctx.prior ctx.topicᶜ ≠ 0) :
+    [ctx.Nondegenerate] {e : Set W} (he : ctx.prior e ≠ 0) :
     negRelevant ctx e ↔
       (ctx.prior (ctx.topic ∩ e)).toReal * (ctx.prior ctx.topicᶜ).toReal <
       (ctx.prior (ctx.topicᶜ ∩ e)).toReal * (ctx.prior ctx.topic).toReal := by
+  have hH := Context.Nondegenerate.topic_ne_zero (ctx := ctx)
+  have hNH := Context.Nondegenerate.compl_ne_zero (ctx := ctx)
   have hHm := ctx.topicMeasurable
   have hpH : 0 < (ctx.prior ctx.topic).toReal :=
     ENNReal.toReal_pos hH (measure_ne_top _ _)
   have hpNH : 0 < (ctx.prior ctx.topicᶜ).toReal :=
     ENNReal.toReal_pos hNH (measure_ne_top _ _)
-  simp only [negRelevant, bayesFactor]
+  simp only [negRelevant, bayesFactor, likelihoodRatio, Context.conditional_true,
+    Context.conditional_false]
   rcases eq_or_ne (ctx.prior[|ctx.topicᶜ] e) 0 with hz | hz
   · have hzm : ctx.prior (ctx.topicᶜ ∩ e) = 0 :=
       (mul_eq_zero.mp ((cond_apply hHm.compl ctx.prior e).symm.trans hz)).resolve_left
@@ -240,38 +326,28 @@ theorem negRelevant_iff_real_cross (ctx : Context W) [IsFiniteMeasure ctx.prior]
       cond_real_apply _ hHm.compl e, cond_real_apply _ hHm e,
       div_lt_div_iff₀ hpH hpNH]
 
-/-! ### The induced binary testing problem
+/-! ### Issue-conditional independence -/
 
-A context induces a binary hypothesis-testing problem in the sense of
-mathlib's statistical decision theory (`Mathlib.Probability.Decision`): the
-parameter space is `Bool`, each side of the issue generates data from the
-prior conditioned on it, and the parameter prior splits the total mass by
-the issue. `bayesFactor` is the likelihood ratio of this problem, and
-Merin's expected-utility apparatus is its Bayes-risk theory. -/
+/-- Merin's Conditional Independence Presumption (Def. 6): A and B are
+independent under the prior conditioned on each side of the issue —
+mathlib's `IndepSet` at both conditionals. -/
+def CondIndepIssue (ctx : Context W) (a b : Set W) : Prop :=
+  ∀ θ, IndepSet a b (ctx.conditional θ)
 
-/-- The data-generating kernel of the induced binary testing problem. -/
-noncomputable def Context.hypothesisKernel (ctx : Context W) : Kernel Bool W :=
-  .ofFunOfCountable fun h => if h then ctx.prior[|ctx.topic] else ctx.prior[|ctx.topicᶜ]
-
-/-- The parameter prior of the induced binary testing problem. -/
-noncomputable def Context.hypothesisPrior (ctx : Context W) : Measure Bool :=
-  ctx.prior ctx.topic • Measure.dirac true + ctx.prior ctx.topicᶜ • Measure.dirac false
-
-/-- `bayesFactor` is the likelihood ratio of the induced testing problem. -/
-theorem bayesFactor_eq_hypothesisKernel_div (ctx : Context W) (e : Set W) :
-    bayesFactor ctx e = ctx.hypothesisKernel true e / ctx.hypothesisKernel false e := rfl
-
-/-! ### Conditional Independence Presumption (CIP) -/
-
-/-- Conditional Independence Presumption (CIP, Merin's Def. 6): A and B are
-conditionally independent given both H and ¬H.
-
-P(A∧B∣H) = P(A∣H)·P(B∣H) and P(A∧B∣¬H) = P(A∣¬H)·P(B∣¬H). -/
-def CIP (ctx : Context W) (a b : Set W) : Prop :=
-  ctx.prior[|ctx.topic] (a ∩ b) =
-    ctx.prior[|ctx.topic] a * ctx.prior[|ctx.topic] b ∧
-  ctx.prior[|ctx.topicᶜ] (a ∩ b) =
-    ctx.prior[|ctx.topicᶜ] a * ctx.prior[|ctx.topicᶜ] b
+/-- The product-equation characterization of issue-conditional
+independence: P(A∧B∣H) = P(A∣H)·P(B∣H) and likewise given ¬H. -/
+theorem condIndepIssue_iff (ctx : Context W) {a b : Set W}
+    (ham : MeasurableSet a) (hbm : MeasurableSet b) :
+    CondIndepIssue ctx a b ↔
+      (ctx.prior[|ctx.topic] (a ∩ b) =
+        ctx.prior[|ctx.topic] a * ctx.prior[|ctx.topic] b ∧
+      ctx.prior[|ctx.topicᶜ] (a ∩ b) =
+        ctx.prior[|ctx.topicᶜ] a * ctx.prior[|ctx.topicᶜ] b) := by
+  refine ⟨fun h => ⟨(h true).measure_inter_eq_mul, (h false).measure_inter_eq_mul⟩,
+    fun h θ => ?_⟩
+  cases θ
+  · exact (indepSet_iff_measure_inter_eq_mul ham hbm _).mpr h.2
+  · exact (indepSet_iff_measure_inter_eq_mul ham hbm _).mpr h.1
 
 /-! ### Sign reversal -/
 
@@ -285,7 +361,7 @@ theorem sign_reversal_qual (ctx : Context W) [IsFiniteMeasure ctx.prior]
     (hENotH : ctx.prior[|ctx.topicᶜ] e ≠ 0) :
     posRelevant ctx e ↔ negRelevant (swapIssue ctx) e := by
   unfold posRelevant negRelevant
-  rw [bayesFactor_swapIssue, bayesFactor,
+  rw [bayesFactor_swapIssue, bayesFactor_def,
     ENNReal.lt_div_iff_mul_lt (Or.inl hENotH)
       (Or.inl (cond_apply_ne_top _ ctx.topicMeasurable.compl e)), one_mul,
     ENNReal.div_lt_iff (Or.inl hEH)
@@ -299,12 +375,9 @@ theorem sign_reversal (ctx : Context W) [IsFiniteMeasure ctx.prior]
     (hEH : ctx.prior[|ctx.topic] e ≠ 0)
     (hENotH : ctx.prior[|ctx.topicᶜ] e ≠ 0) :
     bayesFactor ctx e * bayesFactor (swapIssue ctx) e = 1 := by
-  set x := ctx.prior[|ctx.topic] e with hx
-  set y := ctx.prior[|ctx.topicᶜ] e with hy
-  rw [bayesFactor_swapIssue, bayesFactor, ← hx, ← hy, div_eq_mul_inv, div_eq_mul_inv,
-    mul_mul_mul_comm, mul_comm x y, mul_mul_mul_comm,
-    ENNReal.mul_inv_cancel hENotH (hy ▸ cond_apply_ne_top _ ctx.topicMeasurable.compl e),
-    ENNReal.mul_inv_cancel hEH (hx ▸ cond_apply_ne_top _ ctx.topicMeasurable e), one_mul]
+  rw [bayesFactor_swapIssue]
+  exact likelihoodRatio_mul_swap hEH (cond_apply_ne_top _ ctx.topicMeasurable e)
+    hENotH (cond_apply_ne_top _ ctx.topicMeasurable.compl e)
 
 /-- **Fact 2**: relevance is the differential of conditional
 informativeness — log BF_H(E) = inf(E, ¬H) − inf(E, H), where
@@ -315,228 +388,132 @@ theorem log_bayesFactor (ctx : Context W) [IsFiniteMeasure ctx.prior]
     (hENotH : ctx.prior[|ctx.topicᶜ] e ≠ 0) :
     Real.log (bayesFactor ctx e).toReal =
       (-Real.log (ctx.prior[|ctx.topicᶜ] e).toReal) -
-      (-Real.log (ctx.prior[|ctx.topic] e).toReal) := by
-  rw [bayesFactor, ENNReal.toReal_div,
-    Real.log_div (ENNReal.toReal_ne_zero.mpr
-        ⟨hEH, cond_apply_ne_top _ ctx.topicMeasurable e⟩)
-      (ENNReal.toReal_ne_zero.mpr
-        ⟨hENotH, cond_apply_ne_top _ ctx.topicMeasurable.compl e⟩)]
-  ring
+      (-Real.log (ctx.prior[|ctx.topic] e).toReal) :=
+  log_likelihoodRatio hEH (cond_apply_ne_top _ ctx.topicMeasurable e)
+    hENotH (cond_apply_ne_top _ ctx.topicMeasurable.compl e)
 
-/-! ### CIP consequences -/
+/-! ### Consequences of issue-conditional independence -/
 
-/-- **Fact 5**: Under CIP, the Bayes factor is multiplicative over
-conjunction: BF(A∧B) = BF(A) · BF(B) when A and B are conditionally
-independent given both H and ¬H. -/
-theorem bayes_factor_multiplicative_under_cip (ctx : Context W)
-    [IsFiniteMeasure ctx.prior] (a b : Set W)
-    (hcip : CIP ctx a b)
+/-- **Fact 5**: Under issue-conditional independence, the Bayes factor is
+multiplicative over conjunction: BF(A∧B) = BF(A) · BF(B). -/
+theorem CondIndepIssue.bayesFactor_inter {ctx : Context W}
+    [IsFiniteMeasure ctx.prior] {a b : Set W}
+    (h : CondIndepIssue ctx a b)
     (hNotH' : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
-    bayesFactor ctx (a ∩ b) = bayesFactor ctx a * bayesFactor ctx b := by
-  obtain ⟨hcipH, hcipNH⟩ := hcip
-  rw [bayesFactor, bayesFactor, bayesFactor, hcipH, hcipNH,
-    ENNReal.mul_div_mul_comm
-      (Or.inr (cond_apply_ne_top _ ctx.topicMeasurable.compl b))
-      (Or.inr hNotH')]
+    bayesFactor ctx (a ∩ b) = bayesFactor ctx a * bayesFactor ctx b :=
+  likelihoodRatio_inter (h true) (h false) hNotH'
+    (cond_apply_ne_top _ ctx.topicMeasurable.compl b)
 
-/-- **Theorem 6a** (part 1): Under CIP with both A, B positively relevant,
-conjunction dominates both conjuncts: BF(A∧B) > max(BF(A), BF(B)). -/
-theorem conjunction_dominates_conjuncts (ctx : Context W)
-    [IsFiniteMeasure ctx.prior] (a b : Set W)
-    (hcip : CIP ctx a b)
+/-- **Theorem 6a** (conjunction): under issue-conditional independence with
+both A, B positively relevant, conjunction dominates both conjuncts. -/
+theorem CondIndepIssue.max_bayesFactor_lt_inter {ctx : Context W}
+    [IsFiniteMeasure ctx.prior] [ctx.Nondegenerate] {a b : Set W}
+    (h : CondIndepIssue ctx a b)
     (hPosA : posRelevant ctx a) (hPosB : posRelevant ctx b)
-    (hNotH' : ctx.prior[|ctx.topicᶜ] b ≠ 0)
-    (hFinA : bayesFactor ctx a ≠ ∞) (hFinB : bayesFactor ctx b ≠ ∞) :
+    (hNa : ctx.prior[|ctx.topicᶜ] a ≠ 0) (hNb : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
     max (bayesFactor ctx a) (bayesFactor ctx b) < bayesFactor ctx (a ∩ b) := by
-  rw [bayes_factor_multiplicative_under_cip ctx a b hcip hNotH', max_lt_iff]
-  constructor
-  · calc bayesFactor ctx a = bayesFactor ctx a * 1 := (mul_one _).symm
-    _ < bayesFactor ctx a * bayesFactor ctx b :=
-        ENNReal.mul_lt_mul_right (pos_of_gt hPosA).ne' hFinA hPosB
-  · calc bayesFactor ctx b = 1 * bayesFactor ctx b := (one_mul _).symm
-    _ < bayesFactor ctx a * bayesFactor ctx b :=
-        ENNReal.mul_lt_mul_left (pos_of_gt hPosB).ne' hFinB hPosA
+  have := ctx.isProbabilityMeasure_conditional true
+  have := ctx.isProbabilityMeasure_conditional false
+  exact max_likelihoodRatio_lt_inter (h true) (h false) hPosA hPosB hNa hNb
 
-/-- Arithmetic core for the Theorem 6a disjunction ordering: given four
-conditional probabilities satisfying the CIP-derived relationships,
-max(pAH/pAnH, pBH/pBnH) exceeds the inclusion-exclusion ratio, which itself
-exceeds 1. -/
-private lemma max_div_gt_or_div (pAH pBH pAnH pBnH : ℝ)
-    (h1 : 0 < pAnH) (h2 : 0 < pBnH)
-    (h3 : pAnH < pAH) (h4 : pBnH < pBH)
-    (h5 : pAnH < 1) (h6 : pBnH < 1)
-    (_h7 : pAH ≤ 1) (h8 : pBH ≤ 1) :
-    max (pAH / pAnH) (pBH / pBnH) >
-      (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) ∧
-    (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) > 1 := by
-  have hden_pos : pAnH + pBnH - pAnH * pBnH > 0 := by nlinarith
-  refine ⟨?_, ?_⟩
-  · rw [gt_iff_lt, max_def]; split
-    · rename_i hge
-      rw [div_lt_div_iff₀ hden_pos h2]
-      have h_cross := (div_le_div_iff₀ h1 h2).mp hge
-      nlinarith [mul_pos (mul_pos h2 (show (0:ℝ) < pBH by linarith))
-        (show pAH - pAnH > 0 from by linarith)]
-    · rename_i hlt; push Not at hlt
-      rw [div_lt_div_iff₀ hden_pos h1]
-      have h_cross := (div_le_div_iff₀ h2 h1).mp (le_of_lt hlt)
-      nlinarith [mul_pos (mul_pos h1 (show (0:ℝ) < pAH by linarith))
-        (show pBH - pBnH > 0 from by linarith)]
-  · rw [gt_iff_lt, one_lt_div hden_pos]
-    nlinarith
-
-/-- **Theorem 6a** (full): Under CIP with both A, B positively relevant,
-BF(A∧B) > max(BF(A), BF(B)) > BF(A∨B) > 1.
-
-The disjunction ordering rests on inclusion-exclusion for the conditional
-measures: P(A∨B∣X) + P(A∧B∣X) = P(A∣X) + P(B∣X). -/
-theorem conjunction_dominates_disjunction (ctx : Context W)
-    [IsFiniteMeasure ctx.prior] (a b : Set W) (hbm : MeasurableSet b)
-    (hcip : CIP ctx a b)
+/-- **Theorem 6a** (disjunction, upper): under issue-conditional
+independence with both A, B positively relevant, the disjunction is
+dominated by the stronger disjunct. -/
+theorem CondIndepIssue.bayesFactor_union_lt_max {ctx : Context W}
+    [IsFiniteMeasure ctx.prior] [ctx.Nondegenerate] {a b : Set W}
+    (hbm : MeasurableSet b) (h : CondIndepIssue ctx a b)
     (hPosA : posRelevant ctx a) (hPosB : posRelevant ctx b)
-    (hNotH : ctx.prior[|ctx.topicᶜ] a ≠ 0)
-    (hNotH' : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
-    max (bayesFactor ctx a) (bayesFactor ctx b) < bayesFactor ctx (a ∩ b) ∧
-    bayesFactor ctx (a ∪ b) < max (bayesFactor ctx a) (bayesFactor ctx b) ∧
+    (hNa : ctx.prior[|ctx.topicᶜ] a ≠ 0) (hNb : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
+    bayesFactor ctx (a ∪ b) < max (bayesFactor ctx a) (bayesFactor ctx b) := by
+  have := ctx.isProbabilityMeasure_conditional true
+  have := ctx.isProbabilityMeasure_conditional false
+  exact likelihoodRatio_union_lt_max hbm (h true) (h false) hPosA hPosB hNa hNb
+
+/-- **Theorem 6a** (disjunction, lower): under issue-conditional
+independence with both A, B positively relevant, the disjunction is still
+positively relevant. -/
+theorem CondIndepIssue.one_lt_bayesFactor_union {ctx : Context W}
+    [IsFiniteMeasure ctx.prior] [ctx.Nondegenerate] {a b : Set W}
+    (hbm : MeasurableSet b) (h : CondIndepIssue ctx a b)
+    (hPosA : posRelevant ctx a) (hPosB : posRelevant ctx b)
+    (hNa : ctx.prior[|ctx.topicᶜ] a ≠ 0) (hNb : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
     1 < bayesFactor ctx (a ∪ b) := by
-  have hTfin : ∀ e, ctx.prior[|ctx.topic] e ≠ ∞ :=
-    cond_apply_ne_top ctx.prior ctx.topicMeasurable
-  have hNfin : ∀ e, ctx.prior[|ctx.topicᶜ] e ≠ ∞ :=
-    cond_apply_ne_top ctx.prior ctx.topicMeasurable.compl
-  have hFinA : bayesFactor ctx a ≠ ∞ := (ENNReal.div_lt_top (hTfin a) hNotH).ne
-  have hFinB : bayesFactor ctx b ≠ ∞ := (ENNReal.div_lt_top (hTfin b) hNotH').ne
-  refine ⟨conjunction_dominates_conjuncts ctx a b hcip hPosA hPosB hNotH' hFinA hFinB,
-    ?_, ?_⟩ <;>
-  · -- Real shadows of the four conditional probabilities.
-    set pAH := (ctx.prior[|ctx.topic] a).toReal with hpAH
-    set pBH := (ctx.prior[|ctx.topic] b).toReal with hpBH
-    set pAnH := (ctx.prior[|ctx.topicᶜ] a).toReal with hpAnH
-    set pBnH := (ctx.prior[|ctx.topicᶜ] b).toReal with hpBnH
-    have hAnH_pos : 0 < pAnH := ENNReal.toReal_pos hNotH (hNfin a)
-    have hBnH_pos : 0 < pBnH := ENNReal.toReal_pos hNotH' (hNfin b)
-    have hAH_gt : pAnH < pAH := by
-      refine (ENNReal.toReal_lt_toReal (hNfin a) (hTfin a)).mpr ?_
-      have h := (ENNReal.lt_div_iff_mul_lt (Or.inl hNotH) (Or.inl (hNfin a))).mp hPosA
-      rwa [one_mul] at h
-    have hBH_gt : pBnH < pBH := by
-      refine (ENNReal.toReal_lt_toReal (hNfin b) (hTfin b)).mpr ?_
-      have h := (ENNReal.lt_div_iff_mul_lt (Or.inl hNotH') (Or.inl (hNfin b))).mp hPosB
-      rwa [one_mul] at h
-    have hAH_le : pAH ≤ 1 := by
-      rw [hpAH, ← ENNReal.toReal_one]
-      exact ENNReal.toReal_mono ENNReal.one_ne_top
-        (cond_apply_le_one ctx.prior ctx.topicMeasurable a)
-    have hBH_le : pBH ≤ 1 := by
-      rw [hpBH, ← ENNReal.toReal_one]
-      exact ENNReal.toReal_mono ENNReal.one_ne_top
-        (cond_apply_le_one ctx.prior ctx.topicMeasurable b)
-    have harith := max_div_gt_or_div pAH pBH pAnH pBnH hAnH_pos hBnH_pos hAH_gt hBH_gt
-      (lt_of_lt_of_le hAH_gt hAH_le) (lt_of_lt_of_le hBH_gt hBH_le) hAH_le hBH_le
-    -- Inclusion-exclusion under both conditionals, CIP-substituted, in ℝ.
-    have hOrH : (ctx.prior[|ctx.topic] (a ∪ b)).toReal = pAH + pBH - pAH * pBH := by
-      have h := congrArg ENNReal.toReal (measure_union_add_inter (μ := ctx.prior[|ctx.topic]) a hbm)
-      rw [ENNReal.toReal_add (hTfin _) (hTfin _), ENNReal.toReal_add (hTfin _) (hTfin _),
-        hcip.1, ENNReal.toReal_mul] at h
-      linarith
-    have hOrNH : (ctx.prior[|ctx.topicᶜ] (a ∪ b)).toReal = pAnH + pBnH - pAnH * pBnH := by
-      have h := congrArg ENNReal.toReal
-        (measure_union_add_inter (μ := ctx.prior[|ctx.topicᶜ]) a hbm)
-      rw [ENNReal.toReal_add (hNfin _) (hNfin _), ENNReal.toReal_add (hNfin _) (hNfin _),
-        hcip.2, ENNReal.toReal_mul] at h
-      linarith
-    have hOrNH_ne : ctx.prior[|ctx.topicᶜ] (a ∪ b) ≠ 0 := fun h0 =>
-      hNotH (measure_mono_null Set.subset_union_left h0)
-    have hFinOr : bayesFactor ctx (a ∪ b) ≠ ∞ := (ENNReal.div_lt_top (hTfin _) hOrNH_ne).ne
-    have hBFOr : (bayesFactor ctx (a ∪ b)).toReal =
-        (pAH + pBH - pAH * pBH) / (pAnH + pBnH - pAnH * pBnH) := by
-      rw [bayesFactor, ENNReal.toReal_div, hOrH, hOrNH]
-    first
-    | -- BF(A∨B) < max(BF(A), BF(B))
-      refine (ENNReal.toReal_lt_toReal hFinOr (by simp [hFinA, hFinB])).mp ?_
-      rw [hBFOr, ENNReal.toReal_max hFinA hFinB, bayesFactor, bayesFactor,
-        ENNReal.toReal_div, ENNReal.toReal_div]
-      exact harith.1
-    | -- 1 < BF(A∨B)
-      refine (ENNReal.toReal_lt_toReal ENNReal.one_ne_top hFinOr).mp ?_
-      rw [hBFOr, ENNReal.toReal_one]
-      exact harith.2
+  have := ctx.isProbabilityMeasure_conditional true
+  have := ctx.isProbabilityMeasure_conditional false
+  exact one_lt_likelihoodRatio_union hbm (h true) (h false) hPosA hPosB hNa hNb
 
 /-! ### The Bayesian bridge -/
 
-/-- Probabilistic support implies DTS positive relevance for binary issues.
-The Bayes-theorem bridge: P(E∣H) > P(E) ⟹ BF_H(E) > 1.
-
-The edge case P(E ∩ ¬H) = 0 needs no special treatment: the Bayes factor is
-then genuinely infinite.
+/-- Probabilistic support implies positive relevance over a live issue: the
+Bayes-theorem bridge P(E∣H) > P(E) ⟹ BF_H(E) > 1. The edge case
+P(E ∩ ¬H) = 0 needs no special treatment: the factor is then genuinely
+infinite.
 
 Promoted from the IKW2025 Part II "Bayesian-to-DTS bridge" in 0.230.502 —
 pure DTS-internal content (no IKW dependency), belongs in DTS Core. -/
-theorem probSupports_implies_posRelevant_binary
-    (μ : Measure W) [IsProbabilityMeasure μ] {topic : Set W}
-    (htopic : MeasurableSet topic) (evidence : Set W)
-    (hH_pos : μ topic ≠ 0) (hNH_pos : μ topicᶜ ≠ 0)
-    (hSupp : μ evidence < μ[|topic] evidence) :
-    posRelevant ⟨topic, htopic, μ⟩ evidence := by
-  have hpart : μ (evidence ∩ topic) + μ (evidence ∩ topicᶜ) = μ evidence := by
-    simpa [Set.sdiff_eq] using measure_inter_add_sdiff evidence htopic
-  have hEH : μ[|topic] evidence = (μ topic)⁻¹ * μ (topic ∩ evidence) :=
-    cond_apply htopic μ evidence
-  unfold posRelevant bayesFactor
-  rcases eq_or_ne (μ[|topicᶜ] evidence) 0 with hz | hz
+theorem posRelevant_of_lt_cond (ctx : Context W) [IsProbabilityMeasure ctx.prior]
+    [ctx.Nondegenerate] (e : Set W)
+    (hSupp : ctx.prior e < ctx.prior[|ctx.topic] e) :
+    posRelevant ctx e := by
+  set μ := ctx.prior
+  set topic := ctx.topic
+  have htopic : MeasurableSet topic := ctx.topicMeasurable
+  have hH_pos : μ topic ≠ 0 := Context.Nondegenerate.topic_ne_zero
+  have hNH_pos : μ topicᶜ ≠ 0 := Context.Nondegenerate.compl_ne_zero
+  have hpart : μ (e ∩ topic) + μ (e ∩ topicᶜ) = μ e := by
+    simpa [Set.sdiff_eq] using measure_inter_add_sdiff e htopic
+  have hEH : μ[|topic] e = (μ topic)⁻¹ * μ (topic ∩ e) :=
+    cond_apply htopic μ e
+  show 1 < ctx.prior[|ctx.topic] e / ctx.prior[|ctx.topicᶜ] e
+  rcases eq_or_ne (μ[|topicᶜ] e) 0 with hz | hz
   · -- P(E∣¬H) = 0: the factor is ∞ once P(E∣H) > 0.
-    have hnum : μ[|topic] evidence ≠ 0 := by
+    have hnum : μ[|topic] e ≠ 0 := by
       intro h0
       rw [h0] at hSupp
       exact absurd hSupp (by simp)
-    rw [hz, ENNReal.div_zero hnum]
+    rw [show ctx.prior[|ctx.topicᶜ] e = 0 from hz, ENNReal.div_zero hnum]
     exact ENNReal.one_lt_top
   · -- Main case: cross-multiply in ℝ.
-    have hENH : μ[|topicᶜ] evidence = (μ topicᶜ)⁻¹ * μ (topicᶜ ∩ evidence) :=
-      cond_apply htopic.compl μ evidence
+    have hENH : μ[|topicᶜ] e = (μ topicᶜ)⁻¹ * μ (topicᶜ ∩ e) :=
+      cond_apply htopic.compl μ e
     rw [ENNReal.lt_div_iff_mul_lt (Or.inl hz)
-      (Or.inl (cond_apply_ne_top μ htopic.compl evidence)), one_mul]
-    -- Convert to real arithmetic.
+      (Or.inl (cond_apply_ne_top μ htopic.compl e)), one_mul]
     have hHfin := measure_ne_top μ topic
     have hNHfin := measure_ne_top μ topicᶜ
     have hsum1 : μ topic + μ topicᶜ = 1 := prob_add_prob_compl htopic
     set pH := (μ topic).toReal with hpH
     set pNH := (μ topicᶜ).toReal with hpNH
-    set pEH := (μ (topic ∩ evidence)).toReal with hpEH
-    set pENH := (μ (topicᶜ ∩ evidence)).toReal with hpENH
+    set pEH := (μ (topic ∩ e)).toReal with hpEH
+    set pENH := (μ (topicᶜ ∩ e)).toReal with hpENH
     have hpH_pos : 0 < pH := ENNReal.toReal_pos hH_pos hHfin
     have hpNH_pos : 0 < pNH := ENNReal.toReal_pos hNH_pos hNHfin
     have hpEH_nonneg : 0 ≤ pEH := ENNReal.toReal_nonneg
     have hpENH_nonneg : 0 ≤ pENH := ENNReal.toReal_nonneg
     have hsum1' : pH + pNH = 1 := by
       rw [hpH, hpNH, ← ENNReal.toReal_add hHfin hNHfin, hsum1, ENNReal.toReal_one]
-    have hpartR : pEH + pENH = (μ evidence).toReal := by
+    have hpartR : pEH + pENH = (μ e).toReal := by
       rw [hpEH, hpENH, ← ENNReal.toReal_add (measure_ne_top _ _) (measure_ne_top _ _)]
       congr 1
       simpa [Set.inter_comm] using hpart
-    have hSuppR : (μ evidence).toReal < pEH / pH := by
-      have := ENNReal.toReal_lt_toReal (measure_ne_top μ evidence)
-        (cond_apply_ne_top μ htopic evidence) |>.mpr hSupp
+    have hSuppR : (μ e).toReal < pEH / pH := by
+      have := ENNReal.toReal_lt_toReal (measure_ne_top μ e)
+        (cond_apply_ne_top μ htopic e) |>.mpr hSupp
       rwa [hEH, ENNReal.toReal_mul, ENNReal.toReal_inv, inv_mul_eq_div] at this
     refine ENNReal.toReal_lt_toReal
-      (cond_apply_ne_top μ htopic.compl evidence)
-      (cond_apply_ne_top μ htopic evidence) |>.mp ?_
+      (cond_apply_ne_top μ htopic.compl e)
+      (cond_apply_ne_top μ htopic e) |>.mp ?_
     rw [hEH, hENH, ENNReal.toReal_mul, ENNReal.toReal_mul, ENNReal.toReal_inv,
       ENNReal.toReal_inv, inv_mul_eq_div, inv_mul_eq_div, div_lt_div_iff₀ hpNH_pos hpH_pos]
     nlinarith [hSuppR, hsum1', hpartR, mul_pos hpH_pos hpNH_pos,
       (lt_div_iff₀ hpH_pos).mp hSuppR]
 
-/-- Negative relevance (DTS) implies non-support (probabilistic).
-
-Contrapositive of `probSupports_implies_posRelevant_binary`. Promoted from
-IKW2025 Part II in 0.230.502. -/
-theorem negRelevant_implies_not_probSupports
-    (μ : Measure W) [IsProbabilityMeasure μ] {topic : Set W}
-    (htopic : MeasurableSet topic) (evidence : Set W)
-    (hH_pos : μ topic ≠ 0) (hNH_pos : μ topicᶜ ≠ 0)
-    (hNeg : negRelevant ⟨topic, htopic, μ⟩ evidence) :
-    ¬ μ evidence < μ[|topic] evidence := fun hSupp =>
-  absurd (probSupports_implies_posRelevant_binary μ htopic evidence
-    hH_pos hNH_pos hSupp) (lt_asymm hNeg)
+/-- Negative relevance implies non-support: the contrapositive of
+`posRelevant_of_lt_cond`. Promoted from IKW2025 Part II in 0.230.502. -/
+theorem not_lt_cond_of_negRelevant (ctx : Context W) [IsProbabilityMeasure ctx.prior]
+    [ctx.Nondegenerate] (e : Set W)
+    (hNeg : negRelevant ctx e) :
+    ¬ ctx.prior e < ctx.prior[|ctx.topic] e := fun hSupp =>
+  absurd (posRelevant_of_lt_cond ctx e hSupp) (lt_asymm hNeg)
 
 /-! ### Exclusive disjunction -/
 
@@ -552,7 +529,8 @@ theorem xor_not_necessarily_positive :
   refine ⟨⟨(↑({World4.w0} : Finset World4) : Set World4), .of_discrete, .count⟩,
     ↑({World4.w0, World4.w1} : Finset World4), ↑({World4.w0, World4.w2} : Finset World4),
     ?_, ?_, ?_⟩ <;>
-    simp only [posRelevant, bayesFactor, cond_apply MeasurableSet.of_discrete,
+    simp only [posRelevant, bayesFactor, likelihoodRatio, Context.conditional_true,
+      Context.conditional_false, cond_apply MeasurableSet.of_discrete,
       ← Finset.coe_compl, ← Finset.coe_inter, ← Finset.coe_symmDiff,
       Measure.count_apply_finset]
   · rw [show ({World4.w0} : Finset World4).card = 1 by decide,
@@ -570,5 +548,19 @@ theorem xor_not_necessarily_positive :
   · rw [show ({World4.w0} ∩ ({World4.w0, World4.w1} ∆ {World4.w0, World4.w2}) :
         Finset World4).card = 0 by decide]
     simp
+
+/-! ### Risk of the induced problem -/
+
+/-- The average risk of an estimator against the induced testing problem,
+in its finite two-point form: the loss on each side of the issue weighted
+by that side's prior mass (the countable-space register of
+`Mathlib.Probability.Decision.Risk.Countable`). -/
+theorem avgRisk_hypothesisKernel {𝓨 : Type*} [MeasurableSpace 𝓨] (ctx : Context W)
+    (ℓ : Bool → 𝓨 → ℝ≥0∞) (κ : Kernel W 𝓨) :
+    avgRisk ℓ ctx.hypothesisKernel κ ctx.hypothesisPrior =
+      (∫⁻ y, ℓ true y ∂((κ ∘ₖ ctx.hypothesisKernel) true)) * ctx.prior ctx.topic +
+      (∫⁻ y, ℓ false y ∂((κ ∘ₖ ctx.hypothesisKernel) false)) * ctx.prior ctx.topicᶜ := by
+  rw [avgRisk_fintype]
+  simp
 
 end DTS

--- a/Linglib/Pragmatics/DecisionTheoretic/But.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/But.lean
@@ -85,19 +85,23 @@ CIP turns the total-probability decompositions of P(A∧B), P(A), and P(B)
 into a factorized cross-product whose factors contrariness makes jointly
 positive. -/
 theorem cip_contrariness_implies_unexpectedness (ctx : Context W)
-    [IsProbabilityMeasure ctx.prior] {a b : Set W} (ham : MeasurableSet a)
-    (hcip : CIP ctx a b) (hcontr : hContrary ctx a b)
-    (ha0 : ctx.prior a ≠ 0) (hb0 : ctx.prior b ≠ 0)
-    (hH : ctx.prior ctx.topic ≠ 0) (hNH : ctx.prior ctx.topicᶜ ≠ 0) :
+    [IsProbabilityMeasure ctx.prior] [ctx.Nondegenerate] {a b : Set W}
+    (ham : MeasurableSet a)
+    (hcip : CondIndepIssue ctx a b) (hcontr : hContrary ctx a b)
+    (ha0 : ctx.prior a ≠ 0) (hb0 : ctx.prior b ≠ 0) :
     ctx.prior[|a] b < ctx.prior b := by
+  have hH : ctx.prior ctx.topic ≠ 0 := Context.Nondegenerate.topic_ne_zero
+  have hNH : ctx.prior ctx.topicᶜ ≠ 0 := Context.Nondegenerate.compl_ne_zero
   set μ := ctx.prior
   set H := ctx.topic
   have hHm : MeasurableSet H := ctx.topicMeasurable
   -- Raw real forms of the CIP equations (before the shadows fold them).
-  have hcipH' := congrArg ENNReal.toReal hcip.1
+  have hcipH' := congrArg ENNReal.toReal
+    (show μ[|H] (a ∩ b) = μ[|H] a * μ[|H] b from (hcip true).measure_inter_eq_mul)
   rw [ENNReal.toReal_mul, cond_real_apply μ hHm, cond_real_apply μ hHm,
     cond_real_apply μ hHm] at hcipH'
-  have hcipNH' := congrArg ENNReal.toReal hcip.2
+  have hcipNH' := congrArg ENNReal.toReal
+    (show μ[|Hᶜ] (a ∩ b) = μ[|Hᶜ] a * μ[|Hᶜ] b from (hcip false).measure_inter_eq_mul)
   rw [ENNReal.toReal_mul, cond_real_apply μ hHm.compl, cond_real_apply μ hHm.compl,
     cond_real_apply μ hHm.compl] at hcipNH'
   -- ℝ shadows, conditioning-set first.
@@ -135,11 +139,11 @@ theorem cip_contrariness_implies_unexpectedness (ctx : Context W)
   -- Contrariness gives the sign of the factorized cross-product.
   have hSign : 0 < (pnH * aH - pH * anH) * (pH * bnH - pnH * bH) := by
     rcases hcontr with ⟨hposA, hnegB⟩ | ⟨hnegA, hposB⟩
-    · have hA := (posRelevant_iff_real_cross ctx hH hNH).mp hposA
-      have hB := (negRelevant_iff_real_cross ctx hb0 hH hNH).mp hnegB
+    · have hA := (posRelevant_iff_real_cross ctx).mp hposA
+      have hB := (negRelevant_iff_real_cross ctx hb0).mp hnegB
       nlinarith
-    · have hA := (negRelevant_iff_real_cross ctx ha0 hH hNH).mp hnegA
-      have hB := (posRelevant_iff_real_cross ctx hH hNH).mp hposB
+    · have hA := (negRelevant_iff_real_cross ctx ha0).mp hnegA
+      have hB := (posRelevant_iff_real_cross ctx).mp hposB
       nlinarith
   have hFact := cross_product_factorization aH anH bH bnH pH pnH hNormHP
   -- From CIP: P(A∧B)·pH·pnH = aH·bH·pnH + anH·bnH·pH.
@@ -159,14 +163,15 @@ theorem cip_contrariness_implies_unexpectedness (ctx : Context W)
   rw [cond_real_apply μ ham b, div_lt_iff₀ (ENNReal.toReal_pos ha0 (measure_ne_top μ a))]
   linarith [hKey, mul_comm (μ a).toReal (μ b).toReal]
 
-/-- **Theorem 9**: When H = B, CIP holds automatically for any A.
+/-- **Theorem 9**: When H = B, issue-conditional independence holds
+automatically for any A.
 
 P(A∧B∣B) = P(A∣B)·P(B∣B) because B∧(A∧B) = B∧A and P(B∣B) = 1, and
 P(A∧B∣¬B) = P(A∣¬B)·P(B∣¬B) because both sides vanish on ¬B. -/
-theorem topic_eq_b_satisfies_cip (μ : Measure W) [IsFiniteMeasure μ]
-    (a b : Set W) (hbm : MeasurableSet b) :
-    CIP (defaultButCtx μ b hbm) a b := by
-  constructor
+theorem condIndepIssue_defaultButCtx (μ : Measure W) [IsFiniteMeasure μ]
+    (a b : Set W) (ham : MeasurableSet a) (hbm : MeasurableSet b) :
+    CondIndepIssue (defaultButCtx μ b hbm) a b := by
+  refine (condIndepIssue_iff _ ham hbm).mpr ⟨?_, ?_⟩
   · show μ[|b] (a ∩ b) = μ[|b] a * μ[|b] b
     rcases eq_or_ne (μ b) 0 with h0 | h0
     · simp [ProbabilityTheory.cond, Measure.restrict_eq_zero.mpr h0]
@@ -192,7 +197,8 @@ theorem default_but_properties (μ : Measure W) [IsProbabilityMeasure μ]
     (hNegA : negRelevant (defaultButCtx μ b hbm) a)
     (ha0 : μ a ≠ 0) (hB : μ b ≠ 0) (hNB : μ bᶜ ≠ 0) :
     μ[|a] b < μ b := by
-  have hcross := (negRelevant_iff_real_cross (defaultButCtx μ b hbm) ha0 hB hNB).mp hNegA
+  haveI : (defaultButCtx μ b hbm).Nondegenerate := ⟨hB, hNB⟩
+  have hcross := (negRelevant_iff_real_cross (defaultButCtx μ b hbm) ha0).mp hNegA
   set pB := (μ b).toReal with hpB_def
   set pnB := (μ bᶜ).toReal with hpnB_def
   set xa := (μ (b ∩ a)).toReal with hxa_def
@@ -224,7 +230,7 @@ theorem harris_universal {E : Type*} (μ : Measure W) [IsFiniteMeasure μ]
     (_hnnir : NNIR E μ Q) :
     ¬ butFelicitous (defaultButCtx μ (Q b) hQb) (Q a) (Q b) := by
   rintro ⟨_, hNeg, _⟩
-  simp only [negRelevant, bayesFactor] at hNeg
+  simp only [negRelevant, bayesFactor_def] at hNeg
   rw [cond_eq_one_of_subset μ hQb subset_rfl hb,
     show μ[|(Q b)ᶜ] (Q b) = 0 from by
       rw [cond_apply hQb.compl, Set.compl_inter_self, measure_empty, mul_zero],

--- a/Linglib/Pragmatics/DecisionTheoretic/ScalarImplicature.lean
+++ b/Linglib/Pragmatics/DecisionTheoretic/ScalarImplicature.lean
@@ -91,7 +91,7 @@ theorem not_if_not_indeed_disjunct :
   · rw [Set.union_eq_self_of_subset_right hsub] at this
     exact lt_irrefl _ this
   · -- BF({w0, w1}) = 3 > 1
-    simp only [posRelevant, bayesFactor, cond_apply MeasurableSet.of_discrete,
+    simp only [posRelevant, bayesFactor_def, cond_apply MeasurableSet.of_discrete,
       ← Finset.coe_compl, ← Finset.coe_inter, Measure.count_apply_finset]
     rw [show ({World4.w0} : Finset World4).card = 1 by decide,
       show ({World4.w0} ∩ {World4.w0, World4.w1} : Finset World4).card = 1 by decide,
@@ -100,7 +100,7 @@ theorem not_if_not_indeed_disjunct :
     simp only [Nat.cast_one, Nat.cast_ofNat, inv_one]
     norm_num
   · -- BF({w0}) = ∞ > 1: the issue itself is infinitely relevant
-    simp only [posRelevant, bayesFactor, cond_apply MeasurableSet.of_discrete,
+    simp only [posRelevant, bayesFactor_def, cond_apply MeasurableSet.of_discrete,
       ← Finset.coe_compl, ← Finset.coe_inter, Measure.count_apply_finset]
     rw [show ({World4.w0} : Finset World4).card = 1 by decide,
       show ({World4.w0} ∩ {World4.w0} : Finset World4).card = 1 by decide,
@@ -114,15 +114,15 @@ conjunction dominates both conjuncts and disjunction.
 This is the core of Merin's scalar implicature account: "A and B" is
 strictly more relevant than "A or B", explaining why "or" implicates ¬∧. -/
 theorem if_not_indeed_conjunction (ctx : Context W) [IsFiniteMeasure ctx.prior]
-    (a b : Set W) (hbm : MeasurableSet b)
-    (hcip : CIP ctx a b)
+    [ctx.Nondegenerate] (a b : Set W) (hbm : MeasurableSet b)
+    (hcip : CondIndepIssue ctx a b)
     (hPosA : posRelevant ctx a) (hPosB : posRelevant ctx b)
     (hNotH : ctx.prior[|ctx.topicᶜ] a ≠ 0)
     (hNotH' : ctx.prior[|ctx.topicᶜ] b ≠ 0) :
     bayesFactor ctx a < bayesFactor ctx (a ∩ b) ∧
     bayesFactor ctx (a ∪ b) < bayesFactor ctx (a ∩ b) := by
-  have hFull := conjunction_dominates_disjunction ctx a b hbm hcip hPosA hPosB
-    hNotH hNotH'
-  exact ⟨lt_of_le_of_lt (le_max_left _ _) hFull.1, hFull.2.1.trans hFull.1⟩
+  have hInter := hcip.max_bayesFactor_lt_inter hPosA hPosB hNotH hNotH'
+  have hUnion := hcip.bayesFactor_union_lt_max hbm hPosA hPosB hNotH hNotH'
+  exact ⟨lt_of_le_of_lt (le_max_left _ _) hInter, hUnion.trans hInter⟩
 
 end DTS.ScalarImplicature

--- a/Linglib/Studies/BarnettEtAl2022.lean
+++ b/Linglib/Studies/BarnettEtAl2022.lean
@@ -241,7 +241,7 @@ private lemma shows_s3_eq : shows .s3 =
 factor 3/2): in [cummins-franke-2021]'s terms it has positive argumentative
 strength toward the goal. -/
 theorem s4_posRelevant : DTS.posRelevant stickContext (shows .s4) := by
-  simp only [DTS.posRelevant, DTS.bayesFactor, stickContext,
+  simp only [DTS.posRelevant, DTS.bayesFactor_def, stickContext,
     ProbabilityTheory.cond_apply MeasurableSet.of_discrete, topic_eq, shows_s4_eq,
     ← Finset.coe_compl, ← Finset.coe_inter, MeasureTheory.Measure.count_apply_finset]
   rw [show ({StickWorld.w145, StickWorld.w235, StickWorld.w245, StickWorld.w345} :
@@ -259,7 +259,7 @@ theorem s4_posRelevant : DTS.posRelevant stickContext (shows .s4) := by
 
 /-- Showing stick 3 is not positively relevant to "longer" (Bayes factor 3/4). -/
 theorem s3_not_posRelevant : ¬ DTS.posRelevant stickContext (shows .s3) := by
-  simp only [DTS.posRelevant, DTS.bayesFactor, stickContext,
+  simp only [DTS.posRelevant, DTS.bayesFactor_def, stickContext,
     ProbabilityTheory.cond_apply MeasurableSet.of_discrete, topic_eq, shows_s3_eq,
     ← Finset.coe_compl, ← Finset.coe_inter, MeasureTheory.Measure.count_apply_finset]
   rw [show ({StickWorld.w145, StickWorld.w235, StickWorld.w245, StickWorld.w345} :

--- a/Linglib/Studies/CumminsFranke2021.lean
+++ b/Linglib/Studies/CumminsFranke2021.lean
@@ -74,7 +74,7 @@ theorem bayesFactor_lt_of_goal_entails (ctx : DTS.Context W) [IsFiniteMeasure ct
       Set.ext fun w => ⟨fun h => ⟨h.1.1, h.2⟩, fun h => ⟨⟨h.1, hsub h.2⟩, h.2⟩⟩] at hsplit
     rw [← hsplit]
     exact ENNReal.lt_add_right (measure_ne_top _ _) hgap
-  rw [bayesFactor, bayesFactor,
+  rw [bayesFactor_def, bayesFactor_def,
     cond_eq_one_of_subset _ hHm (hent.trans hsub) hG,
     cond_eq_one_of_subset _ hHm hent hG,
     cond_apply hHm.compl, cond_apply hHm.compl, one_div, one_div,
@@ -116,7 +116,7 @@ private lemma cond_count_ne {s e : Set Band} [DecidablePred (· ∈ s)] [Decidab
 /-- §5.1: the Bayes factor of *more than 100* toward success is 1 / (1/6) = 6 (the paper's
 log 6 ≈ 0.78). -/
 theorem bayesFactor_moreThan100 : bayesFactor successContext (moreThan 100) = 6 := by
-  rw [bayesFactor]
+  rw [bayesFactor_def]
   refine ENNReal.eq_of_toReal
     ((ENNReal.div_lt_top (cond_apply_ne_top _ MeasurableSet.of_discrete _)
       (cond_count_ne (by decide))).ne) (by finiteness) ?_
@@ -135,7 +135,7 @@ theorem bayesFactor_moreThan100 : bayesFactor successContext (moreThan 100) = 6 
 prints log 11 (see `bayesFactor_moreThan100_toward110`); the ordering against
 `bayesFactor_moreThan100` is the same. -/
 theorem bayesFactor_moreThan110 : bayesFactor successContext (moreThan 110) = 12 := by
-  rw [bayesFactor]
+  rw [bayesFactor_def]
   refine ENNReal.eq_of_toReal
     ((ENNReal.div_lt_top (cond_apply_ne_top _ MeasurableSet.of_discrete _)
       (cond_count_ne (by decide))).ne) (by finiteness) ?_
@@ -155,7 +155,7 @@ toward the goal *more than 110* ("the probability that *more than 100* is true g
 *more than 110* is false equals 1/11"). -/
 theorem bayesFactor_moreThan100_toward110 :
     bayesFactor ⟨moreThan 110, .of_discrete, .count⟩ (moreThan 100) = 11 := by
-  rw [bayesFactor]
+  rw [bayesFactor_def]
   refine ENNReal.eq_of_toReal
     ((ENNReal.div_lt_top (cond_apply_ne_top _ MeasurableSet.of_discrete _)
       (cond_count_ne (by decide))).ne) (by finiteness) ?_
@@ -278,7 +278,7 @@ private lemma assertable_bayesFactor_eval (n cap : ℕ) :
   have hcompl : (moreThan 120 ×ˢ (Set.univ : Set Interpretation))ᶜ =
       (moreThan 120)ᶜ ×ˢ (Set.univ : Set Interpretation) := by
     ext p; simp [Set.mem_prod]
-  rw [bayesFactor, assertabilityContext, assertable]
+  rw [bayesFactor_def, assertabilityContext, assertable]
   simp only
   rw [hcompl, cond_prod_byInterpretation _ _ MeasurableSet.of_discrete .of_discrete,
     cond_prod_byInterpretation _ _ MeasurableSet.of_discrete .of_discrete,


### PR DESCRIPTION
Grounds DTS one level deeper in mathlib's decision theory. New `Core/Probability/LikelihoodRatio.lean` (`ProbabilityTheory` namespace, [UPSTREAM] register): the event-level likelihood ratio `μ e / ν e` of a two-measure testing problem, with sign reversal, the surprisal-difference log identity, multiplicativity under `IndepSet` in both measures, and the full Theorem-6a order family — the DTS layer keeps only the issue vocabulary and the joint-prior facts.

- `DTS.Context.conditional : Bool → Measure W` is the model's data-generating family; `hypothesisKernel` is now `Kernel.ofFunOfCountable conditional` (the shape of Degenne's `twoHypKernel`), and `bayesFactor := likelihoodRatio` of the conditionals, by definition.
- `Context.Nondegenerate` mixin (a live issue) replaces the per-theorem `μ topic ≠ 0` / `μ topicᶜ ≠ 0` hypothesis noise; `CIP` is now `CondIndepIssue` = mathlib `IndepSet` at both conditionals (product equations recovered by `condIndepIssue_iff`); Theorem 6a splits into `CondIndepIssue.max_bayesFactor_lt_inter` / `.bayesFactor_union_lt_max` / `.one_lt_bayesFactor_union`, and the Bayesian bridge renames to `posRelevant_of_lt_cond`.
- `avgRisk_hypothesisKernel` evaluates the induced problem's average risk in the finite two-point form of `Mathlib.Probability.Decision.Risk.Countable` — the seed of the Phase-2 restatement of the Van Rooy / Blackwell layer against `bayesRisk`.