### PR TITLE
refactor(Syntax/CCG): cull dead defs; coord carries its coordinator

### DIFF
--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -53,6 +53,12 @@ def the_cat_eats_pizza : DerivStep :=
   .bapp (.fapp (.lex ⟨"the", Det⟩) (.lex ⟨"cat", N⟩))
         (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
 
+def john_sleeps : DerivStep :=
+  .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩)
+
+def john_sees_mary : DerivStep :=
+  .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
+
 theorem mary_eats_pizza_cat : mary_eats_pizza.cat = some S := rfl
 theorem he_sees_her_cat : he_sees_her.cat = some S := rfl
 theorem the_cat_eats_pizza_cat : the_cat_eats_pizza.cat = some S := rfl
@@ -63,20 +69,42 @@ section Coordination
 
 open Semantics.Montague
 
+/-- Type-raised subject "John": `S/(S\NP)`. -/
+def john_tr : DerivStep := .ftr (.lex ⟨"John", NP⟩) S
+
+/-- "John likes": the type-raised subject composed with the transitive verb — a
+constituent of category `S/NP`. -/
+def john_likes : DerivStep := .fcomp john_tr (.lex ⟨"likes", TV⟩)
+
+def mary_tr : DerivStep := .ftr (.lex ⟨"Mary", NP⟩) S
+def mary_hates : DerivStep := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
+
+/-- "John likes and Mary hates": coordination of two `S/NP` constituents. -/
+def john_likes_and_mary_hates : DerivStep :=
+  .coord English.Coordination.and_ john_likes mary_hates
+
+def john_likes_and_mary_hates_beans : DerivStep :=
+  .fapp john_likes_and_mary_hates (.lex ⟨"beans", NP⟩)
+
 /-- CCG derives "John likes and Mary hates beans" (modeled on the book's
 "Anna married, and I detest, Manny") with category S: "John likes" is a
 constituent `S/NP` via type-raising + composition. -/
 theorem john_likes_and_mary_hates_beans_cat :
     john_likes_and_mary_hates_beans.cat = some S := rfl
 
+/-- The derivation spells out the full surface string, coordinator included. -/
+theorem john_likes_and_mary_hates_beans_yield :
+    john_likes_and_mary_hates_beans.yield
+      = ["John", "likes", "and", "Mary", "hates", "beans"] := rfl
+
 def john_sleeps_and_mary_sleeps : DerivStep :=
-  .coord .j
+  .coord English.Coordination.and_
     (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
     (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩))
 
-#guard john_sleeps.opCount == 1
-#guard john_sleeps_and_mary_sleeps.opCount == 3
-#guard john_likes_and_mary_hates_beans.opCount == 8
+example : john_sleeps.opCount = 1 := rfl
+example : john_sleeps_and_mary_sleeps.opCount = 3 := rfl
+example : john_likes_and_mary_hates_beans.opCount = 6 := rfl
 
 /-- Non-constituent coordination requires more combinatory operations than
 standard coordination. Reading operation count as processing difficulty is
@@ -112,22 +140,22 @@ theorem getMeaning_john_sleeps :
     getMeaning (john_sleeps.interp toySemLexicon) = some True := rfl
 
 theorem getMeaning_john_sees_mary :
-    getMeaning (CCG.john_sees_mary.interp toySemLexicon) = some True := rfl
+    getMeaning (john_sees_mary.interp toySemLexicon) = some True := rfl
 
-#guard (CCG.john_tr.interp toySemLexicon).isSome
+example : (john_tr.interp toySemLexicon).isSome = true := rfl
 
 /-- "John sees Mary" with a type-raised subject: the raised subject
-`CCG.john_tr : S/(S\NP)` uses forward application, and the derivation
+`john_tr : S/(S\NP)` uses forward application, and the derivation
 produces the same truth value as the canonical one. -/
 def john_sees_mary_via_tr : DerivStep :=
-  .fapp CCG.john_tr (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
+  .fapp john_tr (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
 
 theorem getMeaning_john_sees_mary_via_tr :
     getMeaning (john_sees_mary_via_tr.interp toySemLexicon) = some True := rfl
 
-#guard (CCG.john_likes.interp toySemLexicon).isSome
-#guard (john_likes_and_mary_hates.interp toySemLexicon).isSome
-#guard (john_likes_and_mary_hates_beans.interp toySemLexicon).isSome
+example : (john_likes.interp toySemLexicon).isSome = true := rfl
+example : (john_likes_and_mary_hates.interp toySemLexicon).isSome = true := rfl
+example : (john_likes_and_mary_hates_beans.interp toySemLexicon).isSome = true := rfl
 
 /-- The predicate "John likes and Mary hates" (category `S/NP`) evaluated
 at an entity. -/
@@ -155,7 +183,7 @@ theorem getMeaning_john_likes_and_mary_hates_beans :
 
 /-- The spelled-out paraphrase "John likes beans and Mary hates beans". -/
 def john_likes_beans_and_mary_hates_beans : DerivStep :=
-  .coord .j
+  .coord English.Coordination.and_
     (.bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"likes", TV⟩) (.lex ⟨"beans", NP⟩)))
     (.bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"hates", TV⟩) (.lex ⟨"beans", NP⟩)))
 
@@ -190,11 +218,11 @@ private def dq : DerivStep := .lex ⟨"q", .atom .S⟩
     `or_` yields `p ∨ q`, and these differ at `p = ⊤`, `q = ⊥`. Flipping a fragment
     coordinator's `role` collapses the inequality, so the `role` marking is not decorative. -/
 theorem coord_role_load_bearing :
-    getMeaning ((DerivStep.coord English.Coordination.and_.role dp dq).interp pqLex) ≠
-    getMeaning ((DerivStep.coord English.Coordination.or_.role dp dq).interp pqLex) := by
-  have hand : getMeaning ((DerivStep.coord English.Coordination.and_.role dp dq).interp pqLex)
+    getMeaning ((DerivStep.coord English.Coordination.and_ dp dq).interp pqLex) ≠
+    getMeaning ((DerivStep.coord English.Coordination.or_ dp dq).interp pqLex) := by
+  have hand : getMeaning ((DerivStep.coord English.Coordination.and_ dp dq).interp pqLex)
       = some (True ∧ False) := rfl
-  have hor : getMeaning ((DerivStep.coord English.Coordination.or_.role dp dq).interp pqLex)
+  have hor : getMeaning ((DerivStep.coord English.Coordination.or_ dp dq).interp pqLex)
       = some (True ∨ False) := rfl
   rw [hand, hor, ne_eq, Option.some.injEq, eq_iff_iff]
   exact fun h => (h.mpr (Or.inl trivial)).2
@@ -537,9 +565,9 @@ def scopeData : List (VerbOrder × BinaryScopeAvailability) :=
 -- Drift sentry: every example in the JSON is either a ch. 7 gapping
 -- stimulus or a §6.8 scope example carrying both annotations; this
 -- fires if a row that is neither is added.
-#guard Examples.all.all λ ex =>
-  (ex.paperFeatures.lookup "phenomenon" == some "gapping") ||
-  ((wordOrderOf ex).isSome && (observedAvailability ex).isSome)
+example : Examples.all.all (λ ex =>
+    (ex.paperFeatures.lookup "phenomenon" == some "gapping") ||
+    ((wordOrderOf ex).isSome && (observedAvailability ex).isSome)) = true := by decide
 
 /-- The CCG prediction matches every §6.8 judgment. -/
 theorem predictedAvailability_eq_observed :
@@ -558,11 +586,8 @@ section TruthConditions
 open CCG
 open Semantics.Montague
 
--- CCG Derivations for Test Sentences
-
-/-- "John sleeps" - backward application -/
-def ccg_john_sleeps : DerivStep :=
-  .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩)
+-- CCG Derivations for Test Sentences ("John sleeps" and "John sees Mary"
+-- are the file-level derivations above)
 
 /-- "Mary sleeps" - backward application -/
 def ccg_mary_sleeps : DerivStep :=
@@ -575,10 +600,6 @@ def ccg_john_laughs : DerivStep :=
 /-- "Mary laughs" - backward application -/
 def ccg_mary_laughs : DerivStep :=
   .bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"laughs", IV⟩)
-
-/-- "John sees Mary" - forward then backward application -/
-def ccg_john_sees_mary : DerivStep :=
-  .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
 
 /-- "Mary sees John" - forward then backward application -/
 def ccg_mary_sees_john : DerivStep :=
@@ -618,7 +639,7 @@ def ccgMeaning (d : DerivStep) : Option Prop :=
 
 /-- CCG correctly predicts "John sleeps" is true -/
 theorem ccg_predicts_john_sleeps :
-    ccgMeaning ccg_john_sleeps = some True := rfl
+    ccgMeaning john_sleeps = some True := rfl
 
 /-- CCG correctly predicts "Mary sleeps" is false -/
 theorem ccg_predicts_mary_sleeps :
@@ -634,7 +655,7 @@ theorem ccg_predicts_mary_laughs :
 
 /-- CCG correctly predicts "John sees Mary" is true -/
 theorem ccg_predicts_john_sees_mary :
-    ccgMeaning ccg_john_sees_mary = some True := rfl
+    ccgMeaning john_sees_mary = some True := rfl
 
 /-- CCG correctly predicts "Mary sees John" is true -/
 theorem ccg_predicts_mary_sees_john :

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -4,12 +4,17 @@ import Linglib.Syntax.Category.Coordinator
 # Combinatory Categorial Grammar (CCG)
 
 A lexicalized grammar in which categories encode argument structure and a small fixed
-set of combinatory rules (`>`, `<`, `B`, `T`, `S`) derive phrases ([steedman-2000]).
+set of combinatory rules derives phrases ([steedman-2000]): forward and backward
+application (`>`, `<`), harmonic composition (`B`), forward crossed composition (`>B×`),
+type-raising (`T`), and the coordination schema. Backward crossed composition and the
+substitution rules of [steedman-2000] are not part of this toy inventory; the
+rule-restricted (classical) rules live in `CCG.Classical`.
 
 ## Main definitions
 
 - `CCG.Cat` — categories: atoms plus the directional slashes `/` and `\`
-- `CCG.combine` — try every combinatory rule on a pair of categories
+- `CCG.forwardApp`, `backwardApp`, `forwardComp`, `backwardComp`, `forwardCompX` —
+  the combinatory rules as partial operations on categories
 - `CCG.DerivStep` — a derivation tree; `DerivStep.cat` reads off its category and
   `DerivStep.yield` the surface string it spells out
 
@@ -26,17 +31,24 @@ section Categories
 
 /-- Atomic categories. -/
 inductive Atom where
-  | S     -- sentence
-  | NP    -- noun phrase
-  | N     -- common noun
-  | PP    -- prepositional phrase
+  /-- Sentence. -/
+  | S
+  /-- Noun phrase. -/
+  | NP
+  /-- Common noun. -/
+  | N
+  /-- Prepositional phrase. -/
+  | PP
   deriving Repr, DecidableEq
 
 /-- CCG categories. -/
 inductive Cat where
+  /-- An atomic category. -/
   | atom : Atom → Cat
-  | rslash : Cat → Cat → Cat  -- X/Y : looking right for Y to give X
-  | lslash : Cat → Cat → Cat  -- X\Y : looking left for Y to give X
+  /-- `X/Y`: looking right for a `Y` to give an `X`. -/
+  | rslash : Cat → Cat → Cat
+  /-- `X\Y`: looking left for a `Y` to give an `X`. -/
+  | lslash : Cat → Cat → Cat
   deriving Repr, DecidableEq
 
 scoped notation:60 X "/" Y => Cat.rslash X Y
@@ -49,11 +61,7 @@ def PP : Cat := .atom .PP
 
 def IV : Cat := S \ NP
 def TV : Cat := (S \ NP) / NP
-def DTV : Cat := ((S \ NP) / NP) / NP
 def Det : Cat := NP / N
-def Prep : Cat := PP / NP
-def AdjAttr : Cat := N / N
-def AdjPred : Cat := S \ NP
 
 end Categories
 
@@ -61,24 +69,24 @@ section CombinatoryRules
 
 /-- Forward application: X/Y Y => X. -/
 def forwardApp : Cat → Cat → Option Cat
-  | .rslash x y, z => if y == z then some x else none
+  | .rslash x y, z => if y = z then some x else none
   | _, _ => none
 
 /-- Backward application: Y X\Y => X. -/
 def backwardApp : Cat → Cat → Option Cat
-  | z, .lslash x y => if y == z then some x else none
+  | z, .lslash x y => if y = z then some x else none
   | _, _ => none
 
 /-- Forward composition: X/Y Y/Z => X/Z. -/
 def forwardComp : Cat → Cat → Option Cat
   | .rslash x y, .rslash y' z =>
-    if y == y' then some (.rslash x z) else none
+    if y = y' then some (.rslash x z) else none
   | _, _ => none
 
 /-- Backward composition: Y\Z X\Y => X\Z. -/
 def backwardComp : Cat → Cat → Option Cat
   | .lslash y z, .lslash x y' =>
-    if y == y' then some (.lslash x z) else none
+    if y = y' then some (.lslash x z) else none
   | _, _ => none
 
 /-- Forward crossed composition (>B×): X/Y Y\Z => X\Z.
@@ -90,17 +98,8 @@ unrestricted here; the rule-restricted variant lives in
 `CCG.Classical.fcompX1`. -/
 def forwardCompX : Cat → Cat → Option Cat
   | .rslash x y, .lslash y' z =>
-    if y == y' then some (.lslash x z) else none
+    if y = y' then some (.lslash x z) else none
   | _, _ => none
-
-/-- Try to combine two categories using all available rules. -/
-def combine : Cat → Cat → Option Cat
-  | c1, c2 =>
-    forwardApp c1 c2 <|>
-    backwardApp c1 c2 <|>
-    forwardComp c1 c2 <|>
-    backwardComp c1 c2 <|>
-    forwardCompX c1 c2
 
 end CombinatoryRules
 
@@ -114,14 +113,11 @@ def forwardTypeRaise (x : Cat) (t : Cat) : Cat :=
 def backwardTypeRaise (x : Cat) (t : Cat) : Cat :=
   t \ (t / x)
 
-def NPsubj : Cat := forwardTypeRaise NP S
-def NPobj : Cat := backwardTypeRaise NP S
-
 end TypeRaising
 
 /-- Coordination: X conj X => X. -/
 def coordinate : Cat → Cat → Option Cat
-  | x, y => if x == y then some x else none
+  | x, y => if x = y then some x else none
 
 /-- A CCG lexical entry. -/
 structure LexEntry where
@@ -129,34 +125,29 @@ structure LexEntry where
   cat : Cat
   deriving Repr
 
-/-- A CCG lexicon. -/
-def Lexicon := List LexEntry
-
-def exampleLexicon : Lexicon := [
-  ⟨"John", NP⟩, ⟨"Mary", NP⟩,
-  ⟨"the", Det⟩, ⟨"a", Det⟩, ⟨"every", Det⟩,
-  ⟨"cat", N⟩, ⟨"dog", N⟩, ⟨"book", N⟩, ⟨"pizza", N⟩, ⟨"beans", NP⟩,
-  ⟨"sleeps", IV⟩, ⟨"laughs", IV⟩, ⟨"arrives", IV⟩,
-  ⟨"sees", TV⟩, ⟨"eats", TV⟩, ⟨"likes", TV⟩, ⟨"hates", TV⟩, ⟨"reads", TV⟩,
-  ⟨"gives", DTV⟩,
-  ⟨"to", Prep⟩, ⟨"on", Prep⟩,
-  ⟨"big", AdjAttr⟩, ⟨"happy", AdjAttr⟩
-]
-
 section Derivations
 
 /-- A derivation step. -/
 inductive DerivStep where
+  /-- A lexical leaf. -/
   | lex : LexEntry → DerivStep
-  | fapp : DerivStep → DerivStep → DerivStep   -- forward app
-  | bapp : DerivStep → DerivStep → DerivStep   -- backward app
-  | fcomp : DerivStep → DerivStep → DerivStep  -- forward comp
-  | bcomp : DerivStep → DerivStep → DerivStep  -- backward comp
-  | fcompx : DerivStep → DerivStep → DerivStep -- forward crossed comp
-  | ftr : DerivStep → Cat → DerivStep          -- forward type-raise to target
-  | btr : DerivStep → Cat → DerivStep          -- backward type-raise to target
-  | coord : Coordinator.Role → DerivStep → DerivStep → DerivStep
-      -- coordination (X c X ⇒ X); `c` is the coordinator's role (and/or/but/nor)
+  /-- Forward application. -/
+  | fapp : DerivStep → DerivStep → DerivStep
+  /-- Backward application. -/
+  | bapp : DerivStep → DerivStep → DerivStep
+  /-- Forward composition. -/
+  | fcomp : DerivStep → DerivStep → DerivStep
+  /-- Backward composition. -/
+  | bcomp : DerivStep → DerivStep → DerivStep
+  /-- Forward crossed composition. -/
+  | fcompx : DerivStep → DerivStep → DerivStep
+  /-- Forward type-raising to a target category. -/
+  | ftr : DerivStep → Cat → DerivStep
+  /-- Backward type-raising to a target category. -/
+  | btr : DerivStep → Cat → DerivStep
+  /-- Coordination (X c X ⇒ X). Carries the coordinator itself: its `role` fixes the
+      semantic operation (`DerivStep.interp`) and its `form` is spelled out in the yield. -/
+  | coord : Coordinator → DerivStep → DerivStep → DerivStep
   deriving Repr
 
 /-- Get the category of a derivation. -/
@@ -182,123 +173,52 @@ def DerivStep.cat : DerivStep → Option Cat
     let c1 ← d1.cat
     let c2 ← d2.cat
     forwardCompX c1 c2
-  | .ftr d t => do
-    let x ← d.cat
-    some (forwardTypeRaise x t)
-  | .btr d t => do
-    let x ← d.cat
-    some (backwardTypeRaise x t)
+  | .ftr d t => d.cat.map (forwardTypeRaise · t)
+  | .btr d t => d.cat.map (backwardTypeRaise · t)
   | .coord _ d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
     coordinate c1 c2
 
-/-- The surface string a derivation spells out: its leaf forms, left to right.
+/-- The surface string a derivation spells out: its leaf forms and coordinators, left
+to right.
 
 Combinatory rules concatenate their daughters and type-raising leaves the string
 untouched, so the yield is independent of the derivation's combinatory structure —
-the property that lets a CCG derivation witness a string language. (Coordination
-elides the conjunction's surface form in the yield; `DerivStep.coord` carries the
-coordinator's `role`, not its spelled-out word.) -/
+the property that lets a CCG derivation witness a string language. -/
 def DerivStep.yield : DerivStep → List String
   | .lex e => [e.form]
-  | .fapp d1 d2 => d1.yield ++ d2.yield
-  | .bapp d1 d2 => d1.yield ++ d2.yield
-  | .fcomp d1 d2 => d1.yield ++ d2.yield
-  | .bcomp d1 d2 => d1.yield ++ d2.yield
-  | .fcompx d1 d2 => d1.yield ++ d2.yield
-  | .ftr d _ => d.yield
-  | .btr d _ => d.yield
-  | .coord _ d1 d2 => d1.yield ++ d2.yield
+  | .fapp d1 d2 | .bapp d1 d2 | .fcomp d1 d2 | .bcomp d1 d2 | .fcompx d1 d2 =>
+    d1.yield ++ d2.yield
+  | .ftr d _ | .btr d _ => d.yield
+  | .coord c d1 d2 => d1.yield ++ c.form :: d2.yield
+
+/-- The number of combinatory rule applications in a derivation. -/
+def DerivStep.opCount : DerivStep → Nat
+  | .lex _ => 0
+  | .fapp d1 d2 | .bapp d1 d2 | .fcomp d1 d2 | .bcomp d1 d2 | .fcompx d1 d2
+  | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
+  | .ftr d _ | .btr d _ => 1 + d.opCount
 
 end Derivations
 
 section Examples
 
-def john_sleeps : DerivStep :=
-  .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩)
+-- "John sees Mary": forward then backward application derives S.
+example :
+    (DerivStep.bapp (.lex ⟨"John", NP⟩)
+      (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))).cat = some S := rfl
 
-def sees_mary : DerivStep :=
-  .fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩)
+-- Type-raising a subject: NP ⇒ S/(S\NP).
+example : (DerivStep.ftr (.lex ⟨"John", NP⟩) S).cat = some (S / (S \ NP)) := rfl
 
-def john_sees_mary : DerivStep :=
-  .bapp (.lex ⟨"John", NP⟩) sees_mary
-
-def the_cat : DerivStep :=
-  .fapp (.lex ⟨"the", Det⟩) (.lex ⟨"cat", N⟩)
-
-def the_cat_sleeps : DerivStep :=
-  .bapp the_cat (.lex ⟨"sleeps", IV⟩)
-
-def big_cat : DerivStep :=
-  .fapp (.lex ⟨"big", AdjAttr⟩) (.lex ⟨"cat", N⟩)
-
-def the_big_cat : DerivStep :=
-  .fapp (.lex ⟨"the", Det⟩) big_cat
-
-def the_big_cat_sleeps : DerivStep :=
-  .bapp the_big_cat (.lex ⟨"sleeps", IV⟩)
-
-/-- Check if a derivation yields category S. -/
-def derivesS (d : DerivStep) : Bool :=
-  d.cat == some S
-
-/-- Count combinatory operations in a derivation. -/
-def DerivStep.opCount : DerivStep → Nat
-  | .lex _ => 0
-  | .fapp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .bapp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .fcomp d1 d2 => 2 + d1.opCount + d2.opCount   -- composition is "harder"
-  | .bcomp d1 d2 => 2 + d1.opCount + d2.opCount
-  | .fcompx d1 d2 => 2 + d1.opCount + d2.opCount
-  | .ftr d _ => 1 + d.opCount                     -- type-raising has cost
-  | .btr d _ => 1 + d.opCount
-  | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
-
-/-- Depth of derivation tree. -/
-def DerivStep.depth : DerivStep → Nat
-  | .lex _ => 1
-  | .fapp d1 d2 => 1 + max d1.depth d2.depth
-  | .bapp d1 d2 => 1 + max d1.depth d2.depth
-  | .fcomp d1 d2 => 1 + max d1.depth d2.depth
-  | .bcomp d1 d2 => 1 + max d1.depth d2.depth
-  | .fcompx d1 d2 => 1 + max d1.depth d2.depth
-  | .ftr d _ => 1 + d.depth
-  | .btr d _ => 1 + d.depth
-  | .coord _ d1 d2 => 1 + max d1.depth d2.depth
-
-example : derivesS john_sleeps = true := rfl
-example : derivesS john_sees_mary = true := rfl
-example : derivesS the_cat_sleeps = true := rfl
-example : derivesS the_big_cat_sleeps = true := rfl
-
--- The yield reads the surface string off a derivation.
-example : john_sees_mary.yield = ["John", "sees", "Mary"] := rfl
-example : the_big_cat_sleeps.yield = ["the", "big", "cat", "sleeps"] := rfl
+-- The yield spells out the surface string, coordinator included.
+example :
+    (DerivStep.coord { form := "and", gloss := "and", role := .j, kind := .free }
+      (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
+      (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"laughs", IV⟩))).yield
+      = ["John", "sleeps", "and", "Mary", "laughs"] := rfl
 
 end Examples
-
-section NonConstituentCoordination
-
-def john_tr : DerivStep := .ftr (.lex ⟨"John", NP⟩) S
-
-def john_likes : DerivStep := .fcomp john_tr (.lex ⟨"likes", TV⟩)
-
-def mary_tr : DerivStep := .ftr (.lex ⟨"Mary", NP⟩) S
-def mary_hates : DerivStep := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
-
-def john_likes_and_mary_hates : DerivStep := .coord .j john_likes mary_hates
-
-def john_likes_and_mary_hates_beans : DerivStep :=
-  .fapp john_likes_and_mary_hates (.lex ⟨"beans", NP⟩)
-
-example : derivesS john_likes_and_mary_hates_beans = true := rfl
-
--- Non-constituent coordination still spells out the full surface string
--- (the conjunction is elided in the `coord` representation).
-example : john_likes_and_mary_hates_beans.yield
-            = ["John", "likes", "Mary", "hates", "beans"] := rfl
-
-end NonConstituentCoordination
 
 end CCG

--- a/Linglib/Syntax/CCG/Combinators.lean
+++ b/Linglib/Syntax/CCG/Combinators.lean
@@ -54,8 +54,10 @@ theorem ftr_type_is_T (x t : Cat) :
 theorem btr_type_is_T (x t : Cat) :
     catToTy (backwardTypeRaise x t) = ((catToTy x ⇒ catToTy t) ⇒ catToTy t) := rfl
 
-/-- Crossed composition is `S`: `(X/Y)/Z + Y/Z ⇒ X/Z` with `S f g x = f x (g x)`. -/
-theorem crossed_comp_is_S {E W : Type} {x y z : Cat}
+/-- Forward substitution is `S`: `(X/Y)/Z  Y/Z ⇒ X/Z` with `S f g x = f x (g x)`.
+(The substitution rule is not part of the toy inventory in `Syntax/CCG/Basic`; the
+correspondence is stated at the type level.) -/
+theorem substitution_is_S {E W : Type} {x y z : Cat}
     (f_sem : Denot E W (catToTy ((x.rslash y).rslash z)))
     (g_sem : Denot E W (catToTy (y.rslash z))) :
     (λ arg => f_sem arg (g_sem arg)) = Combinator.S f_sem g_sem := rfl

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -176,18 +176,19 @@ def DerivStep.interp {E W : Type} (d : DerivStep) (lex : SemLexicon E W)
       let ⟨x, m⟩ ← d.interp lex
       some ⟨backwardTypeRaise x t, T m⟩
 
-  | .coord role d1 d2 => do
+  | .coord c d1 d2 => do
       -- Coordination: X c X → X, via the Coordinator API — the meaning is `Coordinator.op`
       -- of the coordinator's own `role` (runtime form `engineOp`; = generalized conjunction
       -- [partee-rooth-1983] at `.j`), restricted to conjoinable types. The `role` is read off
-      -- the derivation, so *which* coordinator is used is truth-conditionally load-bearing.
+      -- the coordinator the derivation carries, so *which* coordinator is used is
+      -- truth-conditionally load-bearing.
       let ⟨c1, m1⟩ ← d1.interp lex
       let ⟨c2, m2⟩ ← d2.interp lex
       if h : c1 = c2 then
         let ty := catToTy c1
         if ty.isConjoinable then
           let m2' : Denot E W (catToTy c1) := h ▸ m2
-          some ⟨c1, Coordinator.engineOp role ty E W m1 m2'⟩
+          some ⟨c1, Coordinator.engineOp c.role ty E W m1 m2'⟩
         else none
       else none
 


### PR DESCRIPTION
Audit pass over `Syntax/CCG/Basic.lean`, calibrated against mathlib's `RegularExpressions`/`ContextFreeGrammar`.

- deletes the dead surface (`combine`, `Lexicon`+`exampleLexicon`, `derivesS`, `DerivStep.depth`, unused category shorthands and toy derivations); the paper-specific non-constituent-coordination derivations move to `Studies/Steedman2000`, their only consumer
- `DerivStep.coord` now carries the full `Coordinator`: `yield` spells out its form (the NCC example now yields a real English string) and `interp` reads its `role`
- honest docs and neutral metrics: the module docstring no longer claims an unimplemented substitution rule; the mislabeled `Combinators.crossed_comp_is_S` (its statement is the substitution-rule shape) is renamed `substitution_is_S`; `opCount` is unit-weighted (composition=2 was a stipulated processing hypothesis; the Steedman2000 inequalities survive); BEq guards become propositional `=`