### PR TITLE
refactor(Syntax/CCG): rule ops into Cat namespace; generalizedComp

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -115,20 +115,20 @@ theorem fc2Chain_cat (j : Nat) :
   induction j with
   | zero => rfl
   | succ j ih =>
-    simp [fc2Chain, Derivation.cat, ih, forwardCompN, target_clusterCat, clusterCat]
+    simp [fc2Chain, Derivation.cat, ih, Cat.generalizedForwardComp, target_clusterCat, clusterCat]
 
 /-- The cluster derivation has category `clusterCat n` for `n ≥ 1`. -/
 theorem clusterDeriv_cat : ∀ {n : Nat}, 1 ≤ n → (clusterDeriv n).cat .S = some (clusterCat n)
   | 1, _ => rfl
   | n + 2, _ => by
-    simp [clusterDeriv, Derivation.cat, fc2Chain_cat, forwardCompN, target_clusterCat,
+    simp [clusterDeriv, Derivation.cat, fc2Chain_cat, Cat.generalizedForwardComp, target_clusterCat,
       clusterCat]
 
 /-- One peel removes one `C` argument from a cluster. -/
 theorem peelStep_cat {d : Derivation Atom} {k : Nat}
     (h : d.cat .S = some (clusterCat (k + 1))) :
     (peelStep d).cat .S = some (clusterCat k) := by
-  simp [peelStep, Derivation.cat, aLex, cLex, h, forwardCompN, backwardCompN, clusterCat,
+  simp [peelStep, Derivation.cat, aLex, cLex, h, Cat.generalizedForwardComp, Cat.generalizedBackwardComp, clusterCat,
     target_clusterCat]
 
 /-- Peeling `k` times turns a `clusterCat k` derivation into one of category `S`. -/

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -489,7 +489,7 @@ composition, so a quantified argument combines with a function containing
 the tensed verb and can take scope over it; in the verb-projection-raising
 order it combines with the embedded verb alone. The derivations below are
 category-checked `DerivStep` trees: the verb-raising cluster forms by
-forward crossed composition (`CCG.forwardCompX`), the
+forward crossed composition (`CCG.Cat.forwardCompX`), the
 verb-projection-raising order by plain application — the composed-cluster
 vs. applied-cluster contrast driving the account. (The toy `Cat` still
 drops the book's features, e.g. the `VP₋SUB` restriction on `>B×`.) -/

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -20,14 +20,14 @@ live in `CCG.TargetRestricted`.
 
 ## Main definitions
 
-* `CCG.Cat`: categories over an atom type `α` — atoms plus directional slashes.
-* `CCG.forwardCompN`, `CCG.backwardCompN`: generalized composition of degree `n`, the
-  schema every binary rule instantiates.
-* `CCG.forwardApp`, `CCG.backwardApp`, `CCG.forwardComp`, `CCG.backwardComp`,
-  `CCG.forwardCompX`: the toy grammar's rule instances.
-* `CCG.forwardTypeRaise`, `CCG.backwardTypeRaise`: type-raising.
-* `CCG.LexEntry`: a lexical entry, pairing a surface form with its category.
-* `CCG.DerivStep`: a derivation tree; `DerivStep.cat` reads off its category,
+* `Cat`: categories over an atom type `α` — atoms plus directional slashes.
+* `Cat.generalizedForwardComp`, `Cat.generalizedBackwardComp`: generalized
+  composition of degree `n`, the schema every binary rule instantiates.
+* `Cat.forwardApp`, `Cat.backwardApp`, `Cat.forwardComp`, `Cat.backwardComp`,
+  `Cat.forwardCompX`: the toy grammar's rule instances.
+* `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: type-raising.
+* `LexEntry`: a lexical entry, pairing a surface form with its category.
+* `DerivStep`: a derivation tree; `DerivStep.cat` reads off its category,
   `DerivStep.yield` the surface string it spells out, and `DerivStep.opCount` the
   number of rule applications.
 
@@ -84,6 +84,8 @@ end Categories
 
 variable {α : Type*} [DecidableEq α]
 
+namespace Cat
+
 section CombinatoryRules
 
 /-- Generalized forward composition `>Bⁿ`, the rule schema of
@@ -92,41 +94,41 @@ the secondary input's last `n` arguments — each keeping its own slash directio
 Principle of Inheritance — and matching the remainder against `Y`. Degree 0 is forward
 application; at degree ≥ 1 the harmonic and crossed instances fall out of the slash
 directions rather than being separate rule classes. -/
-def forwardCompN : Nat → Cat α → Cat α → Option (Cat α)
+def generalizedForwardComp : Nat → Cat α → Cat α → Option (Cat α)
   | 0, .rslash x y, z => if y = z then some x else none
-  | n + 1, f, .rslash g z => (forwardCompN n f g).map (Cat.rslash · z)
-  | n + 1, f, .lslash g z => (forwardCompN n f g).map (Cat.lslash · z)
+  | n + 1, f, .rslash g z => (generalizedForwardComp n f g).map (Cat.rslash · z)
+  | n + 1, f, .lslash g z => (generalizedForwardComp n f g).map (Cat.lslash · z)
   | _, _, _ => none
 
 /-- Generalized backward composition `<Bⁿ`: `Y|Z₁…|Zₙ X\Y ⇒ X|Z₁…|Zₙ`, the mirror of
-`forwardCompN`. Degree 0 is backward application. -/
-def backwardCompN : Nat → Cat α → Cat α → Option (Cat α)
+`generalizedForwardComp`. Degree 0 is backward application. -/
+def generalizedBackwardComp : Nat → Cat α → Cat α → Option (Cat α)
   | 0, z, .lslash x y => if y = z then some x else none
-  | n + 1, .rslash g z, f => (backwardCompN n g f).map (Cat.rslash · z)
-  | n + 1, .lslash g z, f => (backwardCompN n g f).map (Cat.lslash · z)
+  | n + 1, .rslash g z, f => (generalizedBackwardComp n g f).map (Cat.rslash · z)
+  | n + 1, .lslash g z, f => (generalizedBackwardComp n g f).map (Cat.lslash · z)
   | _, _, _ => none
 
-/-- Forward application `>`: X/Y Y ⇒ X — degree 0 of `forwardCompN`. -/
-def forwardApp : Cat α → Cat α → Option (Cat α) := forwardCompN 0
+/-- Forward application `>`: X/Y Y ⇒ X — degree 0 of `generalizedForwardComp`. -/
+def forwardApp : Cat α → Cat α → Option (Cat α) := generalizedForwardComp 0
 
-/-- Backward application `<`: Y X\Y ⇒ X — degree 0 of `backwardCompN`. -/
-def backwardApp : Cat α → Cat α → Option (Cat α) := backwardCompN 0
+/-- Backward application `<`: Y X\Y ⇒ X — degree 0 of `generalizedBackwardComp`. -/
+def backwardApp : Cat α → Cat α → Option (Cat α) := generalizedBackwardComp 0
 
 /-- Forward harmonic composition `>B`: X/Y Y/Z ⇒ X/Z — the degree-1 harmonic instance
-of `forwardCompN` (the toy grammar admits this but not its degree-1 backward crossed
+of `generalizedForwardComp` (the toy grammar admits this but not its degree-1 backward crossed
 mirror). -/
 def forwardComp : Cat α → Cat α → Option (Cat α)
-  | f, g@(.rslash _ _) => forwardCompN 1 f g
+  | f, g@(.rslash _ _) => generalizedForwardComp 1 f g
   | _, _ => none
 
 /-- Backward harmonic composition `<B`: Y\Z X\Y ⇒ X\Z — the degree-1 harmonic instance
-of `backwardCompN`. -/
+of `generalizedBackwardComp`. -/
 def backwardComp : Cat α → Cat α → Option (Cat α)
-  | f@(.lslash _ _), g => backwardCompN 1 f g
+  | f@(.lslash _ _), g => generalizedBackwardComp 1 f g
   | _, _ => none
 
 /-- Forward crossed composition `>B×`: X/Y Y\Z ⇒ X\Z — the degree-1 crossed instance
-of `forwardCompN`.
+of `generalizedForwardComp`.
 
 In [steedman-2000] this rule is language-specific and restricted (for Dutch,
 to `Y = VP₋SUB`; ch. 6 appendix) — unrestricted crossed composition licenses
@@ -134,7 +136,7 @@ scrambling. The restriction is expressible over a featured atom type; the toy
 `Atom` inventory carries no features, and the target-restricted schema lives in
 `CCG.TargetRestricted`. -/
 def forwardCompX : Cat α → Cat α → Option (Cat α)
-  | f, g@(.lslash _ _) => forwardCompN 1 f g
+  | f, g@(.lslash _ _) => generalizedForwardComp 1 f g
   | _, _ => none
 
 end CombinatoryRules
@@ -154,6 +156,8 @@ end TypeRaising
 /-- Coordination: X conj X => X. -/
 def coordinate : Cat α → Cat α → Option (Cat α)
   | x, y => if x = y then some x else none
+
+end Cat
 
 /-- A CCG lexical entry. -/
 structure LexEntry (α : Type*) where
@@ -192,29 +196,29 @@ def DerivStep.cat : DerivStep α → Option (Cat α)
   | .fapp d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    forwardApp c1 c2
+    c1.forwardApp c2
   | .bapp d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    backwardApp c1 c2
+    c1.backwardApp c2
   | .fcomp d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    forwardComp c1 c2
+    c1.forwardComp c2
   | .bcomp d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    backwardComp c1 c2
+    c1.backwardComp c2
   | .fcompx d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    forwardCompX c1 c2
-  | .ftr d t => d.cat.map (forwardTypeRaise · t)
-  | .btr d t => d.cat.map (backwardTypeRaise · t)
+    c1.forwardCompX c2
+  | .ftr d t => d.cat.map (·.forwardTypeRaise t)
+  | .btr d t => d.cat.map (·.backwardTypeRaise t)
   | .coord _ d1 d2 => do
     let c1 ← d1.cat
     let c2 ← d2.cat
-    coordinate c1 c2
+    c1.coordinate c2
 
 /-- The surface string a derivation spells out: its leaf forms and coordinators, left
 to right.

--- a/Linglib/Syntax/CCG/Combinators.lean
+++ b/Linglib/Syntax/CCG/Combinators.lean
@@ -48,11 +48,11 @@ theorem type_raise_is_T {E W : Type} {x t : Cat Atom}
 
 /-- The type of a forward-type-raised category `T/(T\X)`. -/
 theorem ftr_type_is_T (x t : Cat Atom) :
-    catToTy (forwardTypeRaise x t) = ((catToTy x ⇒ catToTy t) ⇒ catToTy t) := rfl
+    catToTy (x.forwardTypeRaise t) = ((catToTy x ⇒ catToTy t) ⇒ catToTy t) := rfl
 
 /-- Backward type-raising has the same type as forward type-raising. -/
 theorem btr_type_is_T (x t : Cat Atom) :
-    catToTy (backwardTypeRaise x t) = ((catToTy x ⇒ catToTy t) ⇒ catToTy t) := rfl
+    catToTy (x.backwardTypeRaise t) = ((catToTy x ⇒ catToTy t) ⇒ catToTy t) := rfl
 
 /-- Forward substitution is `S`: `(X/Y)/Z  Y/Z ⇒ X/Z` with `S f g x = f x (g x)`.
 (The substitution rule is not part of the toy inventory in `Syntax/CCG/Basic`; the

--- a/Linglib/Syntax/CCG/Gapping.lean
+++ b/Linglib/Syntax/CCG/Gapping.lean
@@ -118,7 +118,7 @@ Stripping is gapping with a single remnant.
 
 This is just a type-raised subject coordinating with a decomposed sentence.
 -/
-def strippingCategory : Cat Atom := backwardTypeRaise NP S
+def strippingCategory : Cat Atom := NP.backwardTypeRaise S
 
 theorem stripping_has_correct_category :
     strippingCategory = GappedSubj := rfl

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -169,12 +169,12 @@ def DerivStep.interp {E W : Type} (d : DerivStep Atom) (lex : SemLexicon E W)
   | .ftr d t => do
       -- Forward type-raising: X → T/(T\X), semantically T (λf. f x)
       let ⟨x, m⟩ ← d.interp lex
-      some ⟨forwardTypeRaise x t, T m⟩
+      some ⟨x.forwardTypeRaise t, T m⟩
 
   | .btr d t => do
       -- Backward type-raising: X → T\(T/X), semantically T (λf. f x)
       let ⟨x, m⟩ ← d.interp lex
-      some ⟨backwardTypeRaise x t, T m⟩
+      some ⟨x.backwardTypeRaise t, T m⟩
 
   | .coord c d1 d2 => do
       -- Coordination: X c X → X, via the Coordinator API — the meaning is `Coordinator.op`

--- a/Linglib/Syntax/CCG/Intonation.lean
+++ b/Linglib/Syntax/CCG/Intonation.lean
@@ -291,7 +291,7 @@ def ProsodicDeriv.prosodicCat : ProsodicDeriv → Option ProsodicCat
     prosodicBackwardComp c1 c2
   | .ftr d t => do
     let ⟨x, i⟩ ← d.prosodicCat
-    some ⟨forwardTypeRaise x t, i⟩
+    some ⟨x.forwardTypeRaise t, i⟩
   | .boundary d tc => do
     let c ← d.prosodicCat
     some (applyBoundary c tc)

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -13,8 +13,8 @@ leftmost atom, after stripping all arguments) is a distinguished atom `s`. Their
 equivalence-with-TAG theorem needs it, and without it the power drops strictly below
 TAG.
 
-Rules are the degree-`n` composition schema `CCG.forwardCompN` / `CCG.backwardCompN`
-of `Syntax/CCG/Basic`, gated on the target. A derivation node records only its degree
+Rules are the generalized-composition schema `CCG.Cat.generalizedForwardComp` /
+`CCG.Cat.generalizedBackwardComp` of `Syntax/CCG/Basic`, gated on the target. A derivation node records only its degree
 and direction, per the [vijay-shanker-weir-1994] rule form: degree 0 is application,
 and the harmonic/crossed distinction is a consequence of the slash directions rather
 than a separate rule class.
@@ -69,11 +69,11 @@ def Derivation.cat [DecidableEq α] (s : α) : Derivation α → Option (Cat α)
   | .fc n l r => do
     let a ← l.cat s
     let b ← r.cat s
-    if target a = s then forwardCompN n a b else none
+    if target a = s then Cat.generalizedForwardComp n a b else none
   | .bc n l r => do
     let a ← l.cat s
     let b ← r.cat s
-    if target b = s then backwardCompN n a b else none
+    if target b = s then Cat.generalizedBackwardComp n a b else none
 
 /-- Surface string: leaf forms left to right. -/
 def Derivation.yield : Derivation α → List String


### PR DESCRIPTION
Naming pass on the combinatory rules, calibrated against mathlib (`RegularExpression.deriv`, `DFA.accepts`).

- `forwardCompN`/`backwardCompN` → `generalizedForwardComp`/`generalizedBackwardComp`: the `N` suffix is not a Lean convention and sat one keystroke from the subtly-different bare `forwardComp`; "generalized composition" is the literature's own name for the schema ([kuhlmann-koller-satta-2015], [weir-joshi-1988])
- all rule operations, type-raising, and `coordinate` move from loose `CCG.*` into the owning type's namespace `CCG.Cat.*`, with dot-notation at call sites (`c₁.forwardApp c₂`, `x.forwardTypeRaise t`); toy category constants (`S`, `NP`, `IV`, …) stay at `CCG` level as fragment inventory