### PR TITLE
refactor(Syntax/CCG): DerivStep → intrinsically typed Derivation

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -16,7 +16,7 @@ grammar (here, via the target restriction modelled in `Syntax/CCG/TargetRestrict
 fires only when the *target* of its primary input category is `S`). For lexicalized CCG
 *without* target restrictions they prove the power is strictly below TAG: such a CCG that
 covers `aⁿbⁿcⁿ` also admits extra permuted strings, so it cannot generate the language
-*exactly*. `Syntax/CCG/Basic`'s `CCG.DerivStep` models a (rule-inventory) fragment of that
+*exactly*. `Syntax/CCG/Basic`'s `CCG.Derivation` models a (rule-inventory) fragment of that
 unrestricted variant, so this construction genuinely needs the restricted model
 `CCG.TargetRestricted`.
 
@@ -66,9 +66,9 @@ abbrev Scat : Cat Atom := .atom .S
 /-! ### The grammar `G₁` of Example 2 -/
 
 /-- `a := A`. -/
-def aLex : Derivation Atom := .lex Acat "a"
+def aLex : TargetRestricted.Derivation Atom := .lex Acat "a"
 /-- `c := C\A`. -/
-def cLex : Derivation Atom := .lex (Ccat \ Acat) "c"
+def cLex : TargetRestricted.Derivation Atom := .lex (Ccat \ Acat) "c"
 
 /-- The cluster category `S/C/…/C` with `n` forward `C`-arguments. -/
 def clusterCat : Nat → Cat Atom
@@ -77,27 +77,27 @@ def clusterCat : Nat → Cat Atom
 
 /-- Chain of degree-2 compositions: `b₁ = S/C/B` composed with `j` copies of
 `B/C/B`, giving `S/Cʲ⁺¹/B` and yield `bʲ⁺¹`. -/
-def fc2Chain : Nat → Derivation Atom
+def fc2Chain : Nat → TargetRestricted.Derivation Atom
   | 0 => .lex ((Scat / Ccat) / Bcat) "b"
   | j + 1 => .fc 2 (fc2Chain j) (.lex ((Bcat / Ccat) / Bcat) "b")
 
 /-- The `b`-cluster derivation for `n ≥ 1`, with category `clusterCat n`, yield `bⁿ`. -/
-def clusterDeriv : Nat → Derivation Atom
+def clusterDeriv : Nat → TargetRestricted.Derivation Atom
   | 0 => .lex Scat "b"            -- unused (the construction starts at n = 1)
   | 1 => .lex (Scat / Ccat) "b"
   | n + 2 => .fc 1 (fc2Chain n) (.lex (Bcat / Ccat) "b")
 
 /-- One peel: crossed-compose with a `c` on the right, then backward-apply an `a` on the
 left — wrapping the yield with `a … c` and removing one `C` argument. -/
-def peelStep (d : Derivation Atom) : Derivation Atom := .bc 0 aLex (.fc 1 d cLex)
+def peelStep (d : TargetRestricted.Derivation Atom) : TargetRestricted.Derivation Atom := .bc 0 aLex (.fc 1 d cLex)
 
 /-- Peel `k` times. -/
-def peel : Nat → Derivation Atom → Derivation Atom
+def peel : Nat → TargetRestricted.Derivation Atom → TargetRestricted.Derivation Atom
   | 0, d => d
   | k + 1, d => peel k (peelStep d)
 
 /-- The full derivation of `aⁿbⁿcⁿ`. -/
-def build (n : Nat) : Derivation Atom := peel n (clusterDeriv n)
+def build (n : Nat) : TargetRestricted.Derivation Atom := peel n (clusterDeriv n)
 
 /-! ### Target invariant -/
 
@@ -115,24 +115,24 @@ theorem fc2Chain_cat (j : Nat) :
   induction j with
   | zero => rfl
   | succ j ih =>
-    simp [fc2Chain, Derivation.cat, ih, Cat.generalizedForwardComp, target_clusterCat, clusterCat]
+    simp [fc2Chain, TargetRestricted.Derivation.cat, ih, Cat.generalizedForwardComp, target_clusterCat, clusterCat]
 
 /-- The cluster derivation has category `clusterCat n` for `n ≥ 1`. -/
 theorem clusterDeriv_cat : ∀ {n : Nat}, 1 ≤ n → (clusterDeriv n).cat .S = some (clusterCat n)
   | 1, _ => rfl
   | n + 2, _ => by
-    simp [clusterDeriv, Derivation.cat, fc2Chain_cat, Cat.generalizedForwardComp, target_clusterCat,
+    simp [clusterDeriv, TargetRestricted.Derivation.cat, fc2Chain_cat, Cat.generalizedForwardComp, target_clusterCat,
       clusterCat]
 
 /-- One peel removes one `C` argument from a cluster. -/
-theorem peelStep_cat {d : Derivation Atom} {k : Nat}
+theorem peelStep_cat {d : TargetRestricted.Derivation Atom} {k : Nat}
     (h : d.cat .S = some (clusterCat (k + 1))) :
     (peelStep d).cat .S = some (clusterCat k) := by
-  simp [peelStep, Derivation.cat, aLex, cLex, h, Cat.generalizedForwardComp, Cat.generalizedBackwardComp, clusterCat,
+  simp [peelStep, TargetRestricted.Derivation.cat, aLex, cLex, h, Cat.generalizedForwardComp, Cat.generalizedBackwardComp, clusterCat,
     target_clusterCat]
 
 /-- Peeling `k` times turns a `clusterCat k` derivation into one of category `S`. -/
-theorem peel_cat : ∀ (k : Nat) (d : Derivation Atom), d.cat .S = some (clusterCat k) →
+theorem peel_cat : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom), d.cat .S = some (clusterCat k) →
     (peel k d).cat .S = some Scat
   | 0, d, h => by simpa [peel, clusterCat] using h
   | k + 1, d, h => by
@@ -154,21 +154,21 @@ private theorem replicate_cons_comm {α : Type*} (k : Nat) (a : α) (X : List α
 theorem fc2Chain_yield (j : Nat) : (fc2Chain j).yield = List.replicate (j + 1) "b" := by
   induction j with
   | zero => rfl
-  | succ j ih => simp [fc2Chain, Derivation.yield, ih, List.replicate_succ']
+  | succ j ih => simp [fc2Chain, TargetRestricted.Derivation.yield, ih, List.replicate_succ']
 
 theorem clusterDeriv_yield : ∀ {n : Nat}, 1 ≤ n →
     (clusterDeriv n).yield = List.replicate n "b"
   | 1, _ => rfl
-  | n + 2, _ => by simp [clusterDeriv, Derivation.yield, fc2Chain_yield, List.replicate_succ']
+  | n + 2, _ => by simp [clusterDeriv, TargetRestricted.Derivation.yield, fc2Chain_yield, List.replicate_succ']
 
-theorem peel_yield : ∀ (k : Nat) (d : Derivation Atom),
+theorem peel_yield : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom),
     (peel k d).yield = List.replicate k "a" ++ d.yield ++ List.replicate k "c"
   | 0, d => by simp [peel]
   | k + 1, d => by
     simp only [peel]
     rw [peel_yield k (peelStep d)]
     have hy : (peelStep d).yield = "a" :: (d.yield ++ ["c"]) := by
-      simp [peelStep, Derivation.yield, aLex, cLex]
+      simp [peelStep, TargetRestricted.Derivation.yield, aLex, cLex]
     rw [hy, List.replicate_succ, List.replicate_succ]
     simp only [List.cons_append, List.append_assoc]
     exact replicate_cons_comm k "a" _
@@ -189,7 +189,7 @@ every string in the non-context-free language is the yield of a well-formed (tar
 restricted) CCG derivation. This is the completeness half of CCG ⊋ CFG; the language
 `anbnc` it covers is not context-free (`AnBnCn.anbnc_not_contextFree`). -/
 theorem ccg_generates_anbnc (w : List String) (hw : w ∈ anbncStrings) :
-    ∃ d : Derivation Atom, d.cat .S = some Scat ∧ d.yield = w := by
+    ∃ d : TargetRestricted.Derivation Atom, d.cat .S = some Scat ∧ d.yield = w := by
   obtain ⟨n, hn, rfl⟩ := hw
   exact ⟨build n, build_cat hn, build_yield hn⟩
 

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -43,25 +43,21 @@ Slash direction encodes word order: `TV = (S\NP)/NP` looks right for the
 object NP first, then the resulting `S\NP` looks left for the subject,
 enforcing SVO. -/
 
-def mary_eats_pizza : DerivStep Atom :=
+def mary_eats_pizza : Derivation Atom S :=
   .bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
 
-def he_sees_her : DerivStep Atom :=
+def he_sees_her : Derivation Atom S :=
   .bapp (.lex ⟨"he", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"her", NP⟩))
 
-def the_cat_eats_pizza : DerivStep Atom :=
+def the_cat_eats_pizza : Derivation Atom S :=
   .bapp (.fapp (.lex ⟨"the", Det⟩) (.lex ⟨"cat", N⟩))
         (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
 
-def john_sleeps : DerivStep Atom :=
+def john_sleeps : Derivation Atom S :=
   .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩)
 
-def john_sees_mary : DerivStep Atom :=
+def john_sees_mary : Derivation Atom S :=
   .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
-
-theorem mary_eats_pizza_cat : mary_eats_pizza.cat = some S := rfl
-theorem he_sees_her_cat : he_sees_her.cat = some S := rfl
-theorem the_cat_eats_pizza_cat : the_cat_eats_pizza.cat = some S := rfl
 
 /-! ### Non-constituent coordination -/
 
@@ -70,34 +66,28 @@ section Coordination
 open Semantics.Montague
 
 /-- Type-raised subject "John": `S/(S\NP)`. -/
-def john_tr : DerivStep Atom := .ftr (.lex ⟨"John", NP⟩) S
+def john_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex ⟨"John", NP⟩) S
 
 /-- "John likes": the type-raised subject composed with the transitive verb — a
 constituent of category `S/NP`. -/
-def john_likes : DerivStep Atom := .fcomp john_tr (.lex ⟨"likes", TV⟩)
+def john_likes : Derivation Atom (S / NP) := .fcomp john_tr (.lex ⟨"likes", TV⟩)
 
-def mary_tr : DerivStep Atom := .ftr (.lex ⟨"Mary", NP⟩) S
-def mary_hates : DerivStep Atom := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
+def mary_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex ⟨"Mary", NP⟩) S
+def mary_hates : Derivation Atom (S / NP) := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
 
 /-- "John likes and Mary hates": coordination of two `S/NP` constituents. -/
-def john_likes_and_mary_hates : DerivStep Atom :=
+def john_likes_and_mary_hates : Derivation Atom (S / NP) :=
   .coord English.Coordination.and_ john_likes mary_hates
 
-def john_likes_and_mary_hates_beans : DerivStep Atom :=
+def john_likes_and_mary_hates_beans : Derivation Atom S :=
   .fapp john_likes_and_mary_hates (.lex ⟨"beans", NP⟩)
-
-/-- CCG derives "John likes and Mary hates beans" (modeled on the book's
-"Anna married, and I detest, Manny") with category S: "John likes" is a
-constituent `S/NP` via type-raising + composition. -/
-theorem john_likes_and_mary_hates_beans_cat :
-    john_likes_and_mary_hates_beans.cat = some S := rfl
 
 /-- The derivation spells out the full surface string, coordinator included. -/
 theorem john_likes_and_mary_hates_beans_yield :
     john_likes_and_mary_hates_beans.yield
       = ["John", "likes", "and", "Mary", "hates", "beans"] := rfl
 
-def john_sleeps_and_mary_sleeps : DerivStep Atom :=
+def john_sleeps_and_mary_sleeps : Derivation Atom S :=
   .coord English.Coordination.and_
     (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
     (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩))
@@ -121,37 +111,33 @@ theorem opCount_simple_lt_standardCoord :
 reuse `sees_sem` as placeholder denotations). -/
 def toySemLexicon : SemLexicon ToyEntity Unit := λ word cat =>
   match word, cat with
-  | "John", .atom .NP => some ⟨NP, ToyEntity.john⟩
-  | "Mary", .atom .NP => some ⟨NP, ToyEntity.mary⟩
-  | "beans", .atom .NP => some ⟨NP, ToyEntity.pizza⟩
-  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ⟨IV, ToyLexicon.sleeps_sem⟩
-  | "laughs", .lslash (.atom .S) (.atom .NP) => some ⟨IV, ToyLexicon.laughs_sem⟩
-  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.sees_sem⟩
-  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.eats_sem⟩
-  | "likes", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.sees_sem⟩
-  | "hates", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.sees_sem⟩
+  | "John", .atom .NP => some ToyEntity.john
+  | "Mary", .atom .NP => some ToyEntity.mary
+  | "beans", .atom .NP => some ToyEntity.pizza
+  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.sleeps_sem
+  | "laughs", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.laughs_sem
+  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
+  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.eats_sem
+  | "likes", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
+  | "hates", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
   | _, _ => none
 
-theorem getMeaning_john_sleeps :
-    getMeaning (john_sleeps.interp toySemLexicon) = some True := rfl
+theorem interp_john_sleeps :
+    john_sleeps.interp toySemLexicon = some True := rfl
 
-theorem getMeaning_john_sees_mary :
-    getMeaning (john_sees_mary.interp toySemLexicon) = some True := rfl
+theorem interp_john_sees_mary :
+    john_sees_mary.interp toySemLexicon = some True := rfl
 
 example : (john_tr.interp toySemLexicon).isSome = true := rfl
 
 /-- "John sees Mary" with a type-raised subject: the raised subject
 `john_tr : S/(S\NP)` uses forward application, and the derivation
 produces the same truth value as the canonical one. -/
-def john_sees_mary_via_tr : DerivStep Atom :=
+def john_sees_mary_via_tr : Derivation Atom S :=
   .fapp john_tr (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
 
-theorem getMeaning_john_sees_mary_via_tr :
-    getMeaning (john_sees_mary_via_tr.interp toySemLexicon) = some True := rfl
+theorem interp_john_sees_mary_via_tr :
+    john_sees_mary_via_tr.interp toySemLexicon = some True := rfl
 
 example : (john_likes.interp toySemLexicon).isSome = true := rfl
 example : (john_likes_and_mary_hates.interp toySemLexicon).isSome = true := rfl
@@ -160,12 +146,11 @@ example : (john_likes_and_mary_hates_beans.interp toySemLexicon).isSome = true :
 /-- The predicate "John likes and Mary hates" (category `S/NP`) evaluated
 at an entity. -/
 def coordMeaningAt (e : ToyEntity) : Option Prop :=
-  (getPredicateMeaning (john_likes_and_mary_hates.interp toySemLexicon)).map (· e)
+  (john_likes_and_mary_hates.interp toySemLexicon).map (· e)
 
 /-- The pointwise conjunction of "John likes" and "Mary hates" at an entity. -/
 def pointwiseConjAt (e : ToyEntity) : Option Prop :=
-  match getPredicateMeaning (john_likes.interp toySemLexicon),
-        getPredicateMeaning (mary_hates.interp toySemLexicon) with
+  match john_likes.interp toySemLexicon, mary_hates.interp toySemLexicon with
   | some m₁, some m₂ => some (m₁ e ∧ m₂ e)
   | _, _ => none
 
@@ -176,13 +161,13 @@ theorem coordMeaningAt_eq_pointwiseConjAt :
 
 /-- The truth conditions of "John likes and Mary hates beans" are the
 conjunction of the two predications (in the toy model, likes = hates = sees). -/
-theorem getMeaning_john_likes_and_mary_hates_beans :
-    getMeaning (john_likes_and_mary_hates_beans.interp toySemLexicon) =
+theorem interp_john_likes_and_mary_hates_beans :
+    john_likes_and_mary_hates_beans.interp toySemLexicon =
       some (ToyLexicon.sees_sem ToyEntity.pizza ToyEntity.john ∧
             ToyLexicon.sees_sem ToyEntity.pizza ToyEntity.mary) := rfl
 
 /-- The spelled-out paraphrase "John likes beans and Mary hates beans". -/
-def john_likes_beans_and_mary_hates_beans : DerivStep Atom :=
+def john_likes_beans_and_mary_hates_beans : Derivation Atom S :=
   .coord English.Coordination.and_
     (.bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"likes", TV⟩) (.lex ⟨"beans", NP⟩)))
     (.bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"hates", TV⟩) (.lex ⟨"beans", NP⟩)))
@@ -191,8 +176,8 @@ def john_likes_beans_and_mary_hates_beans : DerivStep Atom :=
 the same truth conditions — the book's claim that the composed derivation
 yields the same predicate-argument structure as the canonical one. -/
 theorem nonConstituentCoord_eq_spelledOut :
-    getMeaning (john_likes_and_mary_hates_beans.interp toySemLexicon) =
-      getMeaning (john_likes_beans_and_mary_hates_beans.interp toySemLexicon) := rfl
+    john_likes_and_mary_hates_beans.interp toySemLexicon =
+      john_likes_beans_and_mary_hates_beans.interp toySemLexicon := rfl
 
 /-! ### The coordinator's `role` is truth-conditionally load-bearing
 
@@ -205,24 +190,24 @@ gives `p ∨ q` (true). They differ, so the marking's `role` field is load-beari
 theorem depending on it. -/
 
 /-- Minimal lexicon: sentence `p` is true, `q` is false. -/
-private def pqLex : SemLexicon Unit Unit := fun w _ =>
-  match w with
-  | "p" => some ⟨.atom .S, True⟩
-  | "q" => some ⟨.atom .S, False⟩
-  | _ => none
+private def pqLex : SemLexicon Unit Unit := fun w c =>
+  match w, c with
+  | "p", .atom .S => some True
+  | "q", .atom .S => some False
+  | _, _ => none
 
-private def dp : DerivStep Atom := .lex ⟨"p", .atom .S⟩
-private def dq : DerivStep Atom := .lex ⟨"q", .atom .S⟩
+private def dp : Derivation Atom S := .lex ⟨"p", S⟩
+private def dq : Derivation Atom S := .lex ⟨"q", S⟩
 
 /-- The coordinator's `role` flips the truth conditions: English `and_` yields `p ∧ q`,
     `or_` yields `p ∨ q`, and these differ at `p = ⊤`, `q = ⊥`. Flipping a fragment
     coordinator's `role` collapses the inequality, so the `role` marking is not decorative. -/
 theorem coord_role_load_bearing :
-    getMeaning ((DerivStep.coord English.Coordination.and_ dp dq).interp pqLex) ≠
-    getMeaning ((DerivStep.coord English.Coordination.or_ dp dq).interp pqLex) := by
-  have hand : getMeaning ((DerivStep.coord English.Coordination.and_ dp dq).interp pqLex)
+    (Derivation.coord English.Coordination.and_ dp dq).interp pqLex ≠
+    (Derivation.coord English.Coordination.or_ dp dq).interp pqLex := by
+  have hand : (Derivation.coord English.Coordination.and_ dp dq).interp pqLex
       = some (True ∧ False) := rfl
-  have hor : getMeaning ((DerivStep.coord English.Coordination.or_ dp dq).interp pqLex)
+  have hor : (Derivation.coord English.Coordination.or_ dp dq).interp pqLex
       = some (True ∨ False) := rfl
   rw [hand, hor, ne_eq, Option.some.injEq, eq_iff_iff]
   exact fun h => (h.mpr (Or.inl trivial)).2
@@ -488,8 +473,8 @@ Scope tracks word order: in the verb-raising order the cluster forms by
 composition, so a quantified argument combines with a function containing
 the tensed verb and can take scope over it; in the verb-projection-raising
 order it combines with the embedded verb alone. The derivations below are
-category-checked `DerivStep` trees: the verb-raising cluster forms by
-forward crossed composition (`CCG.Cat.forwardCompX`), the
+intrinsically typed `Derivation` trees: the verb-raising cluster forms by
+forward crossed composition (`.fcompx`), the
 verb-projection-raising order by plain application — the composed-cluster
 vs. applied-cluster contrast driving the account. (The toy `Cat` still
 drops the book's features, e.g. the `VP₋SUB` restriction on `>B×`.) -/
@@ -508,27 +493,21 @@ inductive VerbOrder where
 
 /-- Verb-raising order, Dutch (99a): the cluster *probeert te zingen*
 forms by crossed composition before taking the object to its left. -/
-def verbRaisingDeriv : DerivStep Atom :=
+def verbRaisingDeriv : Derivation Atom IV :=
   .bapp (.lex ⟨"veel liederen", NP⟩)
     (.fcompx (.lex ⟨"probeert", IV / IV⟩) (.lex ⟨"te zingen", IV \ NP⟩))
 
 /-- Verb-projection-raising order, Dutch (99b): the matrix verb applies to
 an already-saturated embedded VP, so the quantified object never combines
 with a function containing the tensed verb. -/
-def verbProjectionRaisingDeriv : DerivStep Atom :=
+def verbProjectionRaisingDeriv : Derivation Atom IV :=
   .fapp (.lex ⟨"probeert", IV / IV⟩)
     (.bapp (.lex ⟨"veel liederen", NP⟩) (.lex ⟨"te zingen", IV \ NP⟩))
 
 /-- The CCG derivation shape each verb order forces. -/
-def schematicDeriv : VerbOrder → DerivStep Atom
+def schematicDeriv : VerbOrder → Derivation Atom IV
   | .verbRaising => verbRaisingDeriv
   | .verbProjectionRaising => verbProjectionRaisingDeriv
-
-/-- Both derivations are category-valid and derive the same category. -/
-theorem verbRaisingDeriv_cat : verbRaisingDeriv.cat = some IV := rfl
-
-theorem verbProjectionRaisingDeriv_cat :
-    verbProjectionRaisingDeriv.cat = some IV := rfl
 
 theorem analyzeDerivation_verbRaisingDeriv :
     analyzeDerivation verbRaisingDeriv = .composed := rfl
@@ -590,23 +569,23 @@ open Semantics.Montague
 -- are the file-level derivations above)
 
 /-- "Mary sleeps" - backward application -/
-def ccg_mary_sleeps : DerivStep Atom :=
+def ccg_mary_sleeps : Derivation Atom S :=
   .bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩)
 
 /-- "John laughs" - backward application -/
-def ccg_john_laughs : DerivStep Atom :=
+def ccg_john_laughs : Derivation Atom S :=
   .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"laughs", IV⟩)
 
 /-- "Mary laughs" - backward application -/
-def ccg_mary_laughs : DerivStep Atom :=
+def ccg_mary_laughs : Derivation Atom S :=
   .bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"laughs", IV⟩)
 
 /-- "Mary sees John" - forward then backward application -/
-def ccg_mary_sees_john : DerivStep Atom :=
+def ccg_mary_sees_john : Derivation Atom S :=
   .bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"John", NP⟩))
 
 /-- "John eats pizza" - forward then backward application -/
-def ccg_john_eats_pizza : DerivStep Atom :=
+def ccg_john_eats_pizza : Derivation Atom S :=
   .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
 
 -- Extended Semantic Lexicon (matching the toy model)
@@ -615,25 +594,22 @@ def ccg_john_eats_pizza : DerivStep Atom :=
 def extendedLexicon : SemLexicon ToyEntity Unit := λ word cat =>
   match word, cat with
   -- Proper names
-  | "John", .atom .NP => some ⟨NP, ToyEntity.john⟩
-  | "Mary", .atom .NP => some ⟨NP, ToyEntity.mary⟩
-  | "pizza", .atom .NP => some ⟨NP, ToyEntity.pizza⟩
-  | "book", .atom .NP => some ⟨NP, ToyEntity.book⟩
+  | "John", .atom .NP => some ToyEntity.john
+  | "Mary", .atom .NP => some ToyEntity.mary
+  | "pizza", .atom .NP => some ToyEntity.pizza
+  | "book", .atom .NP => some ToyEntity.book
   -- Intransitive verbs
-  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ⟨IV, ToyLexicon.sleeps_sem⟩
-  | "laughs", .lslash (.atom .S) (.atom .NP) => some ⟨IV, ToyLexicon.laughs_sem⟩
+  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.sleeps_sem
+  | "laughs", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.laughs_sem
   -- Transitive verbs
-  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.sees_sem⟩
-  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.eats_sem⟩
-  | "reads", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) =>
-      some ⟨TV, ToyLexicon.reads_sem⟩
+  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
+  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.eats_sem
+  | "reads", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.reads_sem
   | _, _ => none
 
 /-- Get meaning (as Prop) from CCG derivation -/
-def ccgMeaning (d : DerivStep Atom) : Option Prop :=
-  getMeaning (d.interp extendedLexicon)
+def ccgMeaning (d : Derivation Atom S) : Option Prop :=
+  d.interp extendedLexicon
 
 -- Pipeline Theorems: CCG Derives Correct Truth Conditions
 

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -4,8 +4,8 @@ import Linglib.Syntax.Category.Coordinator
 # Combinatory Categorial Grammar (CCG)
 
 This file defines Combinatory Categorial Grammar (CCG): categories that encode
-argument structure through directional slashes, the combinatory rules that combine
-them, and derivation trees with their categories and surface yields ([steedman-2000]).
+argument structure through directional slashes, the combinatory rule schema that
+combines them, and intrinsically typed derivations ([steedman-2000]).
 
 Categories are stated over an arbitrary type `α` of atomic categories, so a grammar
 needing featured atoms (e.g. [steedman-2000]'s `S₊SUB` and `VP₋SUB` for Dutch) can
@@ -13,23 +13,21 @@ instantiate a richer inventory than the featureless core `CCG.Atom`.
 
 Every binary rule is an instance of one schema, generalized composition of degree `n`:
 degree 0 is application, and at degree ≥ 1 the harmonic and crossed variants differ
-only in the slash directions the schema passes through. The named rules are the
-instances the toy grammar admits; backward crossed composition and the substitution
-rules of [steedman-2000] are not among them. The target-restricted (VW-CCG) rules
-live in `CCG.TargetRestricted`.
+only in the slash directions the schema passes through. `Derivation` is intrinsically
+typed — its constructors are the rule instances the toy grammar admits, so a value of
+`Derivation α c` *is* a derivation of category `c` and "derives `S`" is typechecking.
+The target-restricted (VW-CCG) schema derivations live in `CCG.TargetRestricted`.
 
 ## Main definitions
 
 * `Cat`: categories over an atom type `α` — atoms plus directional slashes.
 * `Cat.generalizedForwardComp`, `Cat.generalizedBackwardComp`: generalized
   composition of degree `n`, the schema every binary rule instantiates.
-* `Cat.forwardApp`, `Cat.backwardApp`, `Cat.forwardComp`, `Cat.backwardComp`,
-  `Cat.forwardCompX`: the toy grammar's rule instances.
 * `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: type-raising.
 * `LexEntry`: a lexical entry, pairing a surface form with its category.
-* `DerivStep`: a derivation tree; `DerivStep.cat` reads off its category,
-  `DerivStep.yield` the surface string it spells out, and `DerivStep.opCount` the
-  number of rule applications.
+* `Derivation`: intrinsically typed derivations, indexed by the category they derive;
+  `Derivation.yield` reads off the surface string a derivation spells out and
+  `Derivation.opCount` the number of rule applications.
 
 ## Notation
 
@@ -108,55 +106,6 @@ def generalizedBackwardComp : Nat → Cat α → Cat α → Option (Cat α)
   | n + 1, .lslash g z, f => (generalizedBackwardComp n g f).map (Cat.lslash · z)
   | _, _, _ => none
 
-/-- Forward application `>`: X/Y Y ⇒ X — degree 0 of `generalizedForwardComp`. -/
-def forwardApp : Cat α → Cat α → Option (Cat α) := generalizedForwardComp 0
-
-/-- Backward application `<`: Y X\Y ⇒ X — degree 0 of `generalizedBackwardComp`. -/
-def backwardApp : Cat α → Cat α → Option (Cat α) := generalizedBackwardComp 0
-
-/-- Forward harmonic composition `>B`: X/Y Y/Z ⇒ X/Z — the degree-1 harmonic instance
-of `generalizedForwardComp` (the toy grammar admits this but not its degree-1 backward crossed
-mirror). -/
-def forwardComp : Cat α → Cat α → Option (Cat α)
-  | f, g@(.rslash _ _) => generalizedForwardComp 1 f g
-  | _, _ => none
-
-/-- Backward harmonic composition `<B`: Y\Z X\Y ⇒ X\Z — the degree-1 harmonic instance
-of `generalizedBackwardComp`. -/
-def backwardComp : Cat α → Cat α → Option (Cat α)
-  | f@(.lslash _ _), g => generalizedBackwardComp 1 f g
-  | _, _ => none
-
-/-- Forward crossed composition `>B×`: X/Y Y\Z ⇒ X\Z — the degree-1 crossed instance
-of `generalizedForwardComp`.
-
-In [steedman-2000] this rule is language-specific and restricted (for Dutch,
-to `Y = VP₋SUB`; ch. 6 appendix) — unrestricted crossed composition licenses
-scrambling. The restriction is expressible over a featured atom type; the toy
-`Atom` inventory carries no features, and the target-restricted schema lives in
-`CCG.TargetRestricted`. -/
-def forwardCompX : Cat α → Cat α → Option (Cat α)
-  | f, g@(.lslash _ _) => generalizedForwardComp 1 f g
-  | _, _ => none
-
-@[simp] theorem forwardApp_rslash (x y : Cat α) : forwardApp (x / y) y = some x := by
-  simp [forwardApp, generalizedForwardComp]
-
-@[simp] theorem backwardApp_lslash (x y : Cat α) : backwardApp y (x \ y) = some x := by
-  simp [backwardApp, generalizedBackwardComp]
-
-@[simp] theorem forwardComp_rslash (x y z : Cat α) :
-    forwardComp (x / y) (y / z) = some (x / z) := by
-  simp [forwardComp, generalizedForwardComp]
-
-@[simp] theorem backwardComp_lslash (x y z : Cat α) :
-    backwardComp (y \ z) (x \ y) = some (x \ z) := by
-  simp [backwardComp, generalizedBackwardComp]
-
-@[simp] theorem forwardCompX_lslash (x y z : Cat α) :
-    forwardCompX (x / y) (y \ z) = some (x \ z) := by
-  simp [forwardCompX, generalizedForwardComp]
-
 end CombinatoryRules
 
 section TypeRaising
@@ -171,13 +120,6 @@ def backwardTypeRaise (x : Cat α) (t : Cat α) : Cat α :=
 
 end TypeRaising
 
-/-- Coordination: X conj X => X. -/
-def coordinate : Cat α → Cat α → Option (Cat α)
-  | x, y => if x = y then some x else none
-
-@[simp] theorem coordinate_self (x : Cat α) : coordinate x x = some x := by
-  simp [coordinate]
-
 end Cat
 
 /-- A CCG lexical entry. -/
@@ -188,58 +130,34 @@ structure LexEntry (α : Type*) where
 
 section Derivations
 
-/-- A derivation step. -/
-inductive DerivStep (α : Type*) where
-  /-- A lexical leaf. -/
-  | lex : LexEntry α → DerivStep α
-  /-- Forward application. -/
-  | fapp : DerivStep α → DerivStep α → DerivStep α
-  /-- Backward application. -/
-  | bapp : DerivStep α → DerivStep α → DerivStep α
-  /-- Forward composition. -/
-  | fcomp : DerivStep α → DerivStep α → DerivStep α
-  /-- Backward composition. -/
-  | bcomp : DerivStep α → DerivStep α → DerivStep α
-  /-- Forward crossed composition. -/
-  | fcompx : DerivStep α → DerivStep α → DerivStep α
-  /-- Forward type-raising to a target category. -/
-  | ftr : DerivStep α → Cat α → DerivStep α
-  /-- Backward type-raising to a target category. -/
-  | btr : DerivStep α → Cat α → DerivStep α
-  /-- Coordination (X c X ⇒ X). Carries the coordinator itself: its `role` fixes the
-      semantic operation (`DerivStep.interp`) and its `form` is spelled out in the yield. -/
-  | coord : Coordinator → DerivStep α → DerivStep α → DerivStep α
-  deriving Repr
-
-/-- Get the category of a derivation. -/
-def DerivStep.cat : DerivStep α → Option (Cat α)
-  | .lex e => some e.cat
-  | .fapp d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.forwardApp c2
-  | .bapp d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.backwardApp c2
-  | .fcomp d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.forwardComp c2
-  | .bcomp d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.backwardComp c2
-  | .fcompx d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.forwardCompX c2
-  | .ftr d t => d.cat.map (·.forwardTypeRaise t)
-  | .btr d t => d.cat.map (·.backwardTypeRaise t)
-  | .coord _ d1 d2 => do
-    let c1 ← d1.cat
-    let c2 ← d2.cat
-    c1.coordinate c2
+/-- A CCG derivation of category `c`, intrinsically typed: each constructor is one of
+the toy grammar's rule instances, so a value of `Derivation α c` *is* a well-formed
+derivation and "derives `c`" is typechecking. Backward crossed composition and the
+substitution rules of [steedman-2000] are not part of this inventory. -/
+inductive Derivation (α : Type*) : Cat α → Type _ where
+  /-- A lexical leaf, at its entry's category. -/
+  | lex (e : LexEntry α) : Derivation α e.cat
+  /-- Forward application `>`: X/Y Y ⇒ X. -/
+  | fapp {x y : Cat α} : Derivation α (x / y) → Derivation α y → Derivation α x
+  /-- Backward application `<`: Y X\Y ⇒ X. -/
+  | bapp {x y : Cat α} : Derivation α y → Derivation α (x \ y) → Derivation α x
+  /-- Forward harmonic composition `>B`: X/Y Y/Z ⇒ X/Z. -/
+  | fcomp {x y z : Cat α} :
+      Derivation α (x / y) → Derivation α (y / z) → Derivation α (x / z)
+  /-- Backward harmonic composition `<B`: Y\Z X\Y ⇒ X\Z. -/
+  | bcomp {x y z : Cat α} :
+      Derivation α (y \ z) → Derivation α (x \ y) → Derivation α (x \ z)
+  /-- Forward crossed composition `>B×`: X/Y Y\Z ⇒ X\Z. -/
+  | fcompx {x y z : Cat α} :
+      Derivation α (x / y) → Derivation α (y \ z) → Derivation α (x \ z)
+  /-- Forward type-raising to target `t`: X ⇒ T/(T\X). -/
+  | ftr {x : Cat α} : Derivation α x → (t : Cat α) → Derivation α (t / (t \ x))
+  /-- Backward type-raising to target `t`: X ⇒ T\(T/X). -/
+  | btr {x : Cat α} : Derivation α x → (t : Cat α) → Derivation α (t \ (t / x))
+  /-- Coordination (X c X ⇒ X); identity of the conjunct categories is enforced by the
+      index. Carries the coordinator itself: its `role` fixes the semantic operation
+      (`Derivation.interp`) and its `form` is spelled out in the yield. -/
+  | coord {x : Cat α} : Coordinator → Derivation α x → Derivation α x → Derivation α x
 
 /-- The surface string a derivation spells out: its leaf forms and coordinators, left
 to right.
@@ -247,35 +165,43 @@ to right.
 Combinatory rules concatenate their daughters and type-raising leaves the string
 untouched, so the yield is independent of the derivation's combinatory structure —
 the property that lets a CCG derivation witness a string language. -/
-def DerivStep.yield : DerivStep α → List String
+def Derivation.yield {c : Cat α} : Derivation α c → List String
   | .lex e => [e.form]
-  | .fapp d1 d2 | .bapp d1 d2 | .fcomp d1 d2 | .bcomp d1 d2 | .fcompx d1 d2 =>
-    d1.yield ++ d2.yield
-  | .ftr d _ | .btr d _ => d.yield
-  | .coord c d1 d2 => d1.yield ++ c.form :: d2.yield
+  | .fapp d1 d2 => d1.yield ++ d2.yield
+  | .bapp d1 d2 => d1.yield ++ d2.yield
+  | .fcomp d1 d2 => d1.yield ++ d2.yield
+  | .bcomp d1 d2 => d1.yield ++ d2.yield
+  | .fcompx d1 d2 => d1.yield ++ d2.yield
+  | .ftr d _ => d.yield
+  | .btr d _ => d.yield
+  | .coord co d1 d2 => d1.yield ++ co.form :: d2.yield
 
 /-- The number of combinatory rule applications in a derivation. -/
-def DerivStep.opCount : DerivStep α → Nat
+def Derivation.opCount {c : Cat α} : Derivation α c → Nat
   | .lex _ => 0
-  | .fapp d1 d2 | .bapp d1 d2 | .fcomp d1 d2 | .bcomp d1 d2 | .fcompx d1 d2
+  | .fapp d1 d2 => 1 + d1.opCount + d2.opCount
+  | .bapp d1 d2 => 1 + d1.opCount + d2.opCount
+  | .fcomp d1 d2 => 1 + d1.opCount + d2.opCount
+  | .bcomp d1 d2 => 1 + d1.opCount + d2.opCount
+  | .fcompx d1 d2 => 1 + d1.opCount + d2.opCount
+  | .ftr d _ => 1 + d.opCount
+  | .btr d _ => 1 + d.opCount
   | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
-  | .ftr d _ | .btr d _ => 1 + d.opCount
 
 end Derivations
 
 section Examples
 
--- "John sees Mary": forward then backward application derives S.
-example :
-    (DerivStep.bapp (.lex ⟨"John", NP⟩)
-      (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))).cat = some S := rfl
+-- "John sees Mary": forward then backward application — deriving `S` is typechecking.
+example : Derivation Atom S :=
+  .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
 
 -- Type-raising a subject: NP ⇒ S/(S\NP).
-example : (DerivStep.ftr (.lex ⟨"John", NP⟩) S).cat = some (S / (S \ NP)) := rfl
+example : Derivation Atom (S / (S \ NP)) := .ftr (.lex ⟨"John", NP⟩) S
 
 -- The yield spells out the surface string, coordinator included.
 example :
-    (DerivStep.coord { form := "and", gloss := "and", role := .j, kind := .free }
+    (Derivation.coord { form := "and", gloss := "and", role := .j, kind := .free }
       (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
       (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"laughs", IV⟩))).yield
       = ["John", "sleeps", "and", "Mary", "laughs"] := rfl

--- a/Linglib/Syntax/CCG/CrossSerial.lean
+++ b/Linglib/Syntax/CCG/CrossSerial.lean
@@ -82,23 +82,23 @@ def dutchLexicon : List (LexEntry Atom) := [
 
 /-! ### Lexical entries -/
 
-def jan_lex : Derivation Atom := .lex NP "Jan"
-def piet_lex : Derivation Atom := .lex NP "Piet"
-def marie_lex : Derivation Atom := .lex NP "Marie"
-def zag_lex : Derivation Atom := .lex PercV "zag"
+def jan_lex : TargetRestricted.Derivation Atom := .lex NP "Jan"
+def piet_lex : TargetRestricted.Derivation Atom := .lex NP "Piet"
+def marie_lex : TargetRestricted.Derivation Atom := .lex NP "Marie"
+def zag_lex : TargetRestricted.Derivation Atom := .lex PercV "zag"
 /-- `zwemmen` in its verb-raising category `(S\NP)/NP`. -/
-def zwemmen_vr : Derivation Atom := .lex InfSubj "zwemmen"
+def zwemmen_vr : TargetRestricted.Derivation Atom := .lex InfSubj "zwemmen"
 /-- `helpen` in its verb-raising category `((S\NP)/NP)/(S\NP)`. -/
-def helpen_vr : Derivation Atom := .lex ControlVR "helpen"
+def helpen_vr : TargetRestricted.Derivation Atom := .lex ControlVR "helpen"
 
 /-! ### Derivation: "Jan Piet zag zwemmen" (2 NPs, 2 Vs) -/
 
 /-- `zag >B zwemmen`: `(S\NP)/(S\NP) ∘ (S\NP)/NP = (S\NP)/NP`. -/
-def zag_comp_zwemmen : Derivation Atom := .fc 1 zag_lex zwemmen_vr
+def zag_comp_zwemmen : TargetRestricted.Derivation Atom := .fc 1 zag_lex zwemmen_vr
 /-- `(zag zwemmen) Piet`: `(S\NP)/NP NP = S\NP`. -/
-def zag_zwemmen_piet : Derivation Atom := .fc 0 zag_comp_zwemmen piet_lex
+def zag_zwemmen_piet : TargetRestricted.Derivation Atom := .fc 0 zag_comp_zwemmen piet_lex
 /-- `Jan (zag zwemmen Piet)`: `NP S\NP = S`. -/
-def jan_zag_zwemmen_piet : Derivation Atom := .bc 0 jan_lex zag_zwemmen_piet
+def jan_zag_zwemmen_piet : TargetRestricted.Derivation Atom := .bc 0 jan_lex zag_zwemmen_piet
 
 /-! ### Derivation: "Jan Piet Marie zag helpen zwemmen" (3 NPs, 3 Vs)
 
@@ -107,15 +107,15 @@ The cross-serial bindings are Jan→zag, Piet→helpen, Marie→zwemmen. `helpen
 Piet's and Marie's slots through the cluster into `((S\NP)/NP)/NP`. -/
 
 /-- `helpen >B zwemmen`: `((S\NP)/NP)/(S\NP) ∘ (S\NP)/NP = ((S\NP)/NP)/NP`. -/
-def helpen_comp_zwemmen : Derivation Atom := .fc 1 helpen_vr zwemmen_vr
+def helpen_comp_zwemmen : TargetRestricted.Derivation Atom := .fc 1 helpen_vr zwemmen_vr
 /-- `zag >B² (helpen zwemmen)`: `(S\NP)/(S\NP) ∘² ((S\NP)/NP)/NP = ((S\NP)/NP)/NP`. -/
-def zag_comp2_helpen_zwemmen : Derivation Atom := .fc 2 zag_lex helpen_comp_zwemmen
+def zag_comp2_helpen_zwemmen : TargetRestricted.Derivation Atom := .fc 2 zag_lex helpen_comp_zwemmen
 /-- verb cluster + Marie: `((S\NP)/NP)/NP NP = (S\NP)/NP`. -/
-def verbs_marie : Derivation Atom := .fc 0 zag_comp2_helpen_zwemmen marie_lex
+def verbs_marie : TargetRestricted.Derivation Atom := .fc 0 zag_comp2_helpen_zwemmen marie_lex
 /-- + Piet: `(S\NP)/NP NP = S\NP`. -/
-def verbs_marie_piet : Derivation Atom := .fc 0 verbs_marie piet_lex
+def verbs_marie_piet : TargetRestricted.Derivation Atom := .fc 0 verbs_marie piet_lex
 /-- + Jan: `NP S\NP = S`. -/
-def jan_piet_marie_zag_helpen_zwemmen_deriv : Derivation Atom := .bc 0 jan_lex verbs_marie_piet
+def jan_piet_marie_zag_helpen_zwemmen_deriv : TargetRestricted.Derivation Atom := .bc 0 jan_lex verbs_marie_piet
 
 /-! ### Verification -/
 
@@ -149,13 +149,13 @@ composes the cluster by forward **crossed** composition, so the
 NPs precede the whole cluster and the yield is the attested
 "Jan Piet (Marie) zag (helpen) zwemmen". -/
 
-def zag_sub : Derivation Atom := .lex PercVSub "zag"
-def helpen_sub : Derivation Atom := .lex InfHeadSub "helpen"
-def zwemmen_bare : Derivation Atom := .lex VP "zwemmen"
+def zag_sub : TargetRestricted.Derivation Atom := .lex PercVSub "zag"
+def helpen_sub : TargetRestricted.Derivation Atom := .lex InfHeadSub "helpen"
+def zwemmen_bare : TargetRestricted.Derivation Atom := .lex VP "zwemmen"
 
 /-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the
 NPs attach leftward — the 2-verb cluster needs no composition. -/
-def jan_piet_zag_zwemmen_sub : Derivation Atom :=
+def jan_piet_zag_zwemmen_sub : TargetRestricted.Derivation Atom :=
   .bc 0 jan_lex (.bc 0 piet_lex (.fc 0 zag_sub zwemmen_bare))
 
 /-- "(dat) Jan Piet Marie zag helpen zwemmen": `helpen zwemmen : VP\NP`
@@ -164,7 +164,7 @@ forms by application, `zag >B× (helpen zwemmen)` crosses the rightward
 attach leftward — Marie to `helpen`'s slot, Piet to `zag`'s object slot,
 Jan as subject: the cross-serial binding falls out of the category
 threading. -/
-def jan_piet_marie_zag_helpen_zwemmen_sub : Derivation Atom :=
+def jan_piet_marie_zag_helpen_zwemmen_sub : TargetRestricted.Derivation Atom :=
   .bc 0 jan_lex (.bc 0 piet_lex (.bc 0 marie_lex
     (.fc 1 zag_sub (.fc 0 helpen_sub zwemmen_bare))))
 
@@ -176,7 +176,7 @@ theorem three_np_sub_derives_S :
 
 /-- The crossed cluster is a leftward-seeking 3-place predicate. -/
 theorem crossed_cluster_cat :
-    (Derivation.fc 1 zag_sub (.fc 0 helpen_sub zwemmen_bare)).cat .S
+    (TargetRestricted.Derivation.fc 1 zag_sub (.fc 0 helpen_sub zwemmen_bare)).cat .S
       = some (((S \ NP) \ NP) \ NP) := by decide
 
 /-- The surface-faithful derivations spell out the attested word order

--- a/Linglib/Syntax/CCG/GenerativeCapacity.lean
+++ b/Linglib/Syntax/CCG/GenerativeCapacity.lean
@@ -27,11 +27,11 @@ target restrictions* they prove the generative power is strictly *below TAG*. Th
 point is about generating a language *exactly*: without target restrictions a CCG that
 covers `aⁿbⁿcⁿ` also admits extra permuted strings, so it does not generate the language
 `aⁿbⁿcⁿ` itself — it is the target restriction that filters these out. This subsystem's
-`CCG.DerivStep` models the unrestricted, universal-rule variant (no rule restrictions), so
+`CCG.Derivation` models the unrestricted, universal-rule variant (no rule restrictions), so
 it is the wrong model for the exact-language construction.
 
 A fully-proven construction of a target-restricted CCG that generates aⁿbⁿcⁿ
-is therefore *not* expressible over `DerivStep`; it lives in
+is therefore *not* expressible over `Derivation`; it lives in
 `Studies/KuhlmannKollerSatta2015` (`ccg_generates_anbnc`), which models the target
 restriction explicitly. The concrete Dutch derivations in `CCG.CrossSerial` are 2- and
 3-verb instances — surface-faithful via crossed composition (see

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -7,29 +7,33 @@ import Linglib.Semantics.Composition.Combinator
 /-!
 # CCG Syntax-Semantics Interface
 
-Syntactic categories directly encode semantic types and the combinatory rules
-correspond to function application and composition ([steedman-2000]), so a
-derivation's meaning is read off compositionally from its structure.
+This file defines the compositional interpretation of CCG derivations. Categories
+encode semantic types (`catToTy`), and because `Derivation` is intrinsically typed,
+`Derivation.interp` needs no run-time category checks and no casts: application is
+function application, composition is the `B` combinator, type-raising is the `T`
+combinator, and coordination is generalized conjunction ([partee-rooth-1983],
+[steedman-2000]). A lexicon is well-typed by construction — it returns meanings at
+the queried category — so soundness of the interface is a typing fact rather than a
+theorem.
 
 ## Main definitions
 
-- `catToTy` — maps CCG categories to semantic types
-- `SemLexEntry`, `SemLexicon` — lexical entries with semantics
-- `DerivStep.interp` — computes a meaning from a derivation compositionally:
-  application is function application, composition is the `B` combinator,
-  type-raising is the `T` combinator, coordination is generalized
-  conjunction ([partee-rooth-1983])
+* `catToTy`: maps CCG categories to semantic types.
+* `SemLexicon`: a semantic lexicon — for each word and category, optionally a meaning
+  at that category.
+* `Derivation.interp`: the meaning of a derivation of category `c`, at type
+  `catToTy c`; `none` only when a word is missing from the lexicon or a coordination
+  is at a non-conjoinable type.
 
 ## Main statements
 
-- `DerivStep.cat_of_interp` — soundness: over a well-typed lexicon, a derivation's
-  meaning is assigned at exactly the category `DerivStep.cat` derives.
-- `DerivStep.interp_fcomp_assoc`, `interp_fapp_fcomp` (and backward mirrors) —
-  spurious ambiguity: reassociating a composition-application chain cannot change a
-  constituent's interpretation.
+* `Derivation.interp_fcomp_assoc`, `Derivation.interp_fapp_fcomp` (and backward
+  mirrors): spurious ambiguity — reassociating a composition-application chain cannot
+  change a constituent's interpretation ([steedman-2000]; the matching-entry tests of
+  [karttunen-1989] and [pareschi-steedman-1987] exploit exactly this invariance).
 
-Worked toy-fragment derivations and the non-constituent-coordination
-semantics theorems live in `Studies/Steedman2000.lean`.
+Worked toy-fragment derivations and the non-constituent-coordination semantics
+theorems live in `Studies/Steedman2000.lean`.
 -/
 
 namespace CCG
@@ -48,17 +52,6 @@ def catToTy : Cat Atom → Ty
   | .atom .PP => .e ⇒ .t   -- PPs are modifiers (simplified)
   | .rslash x y => catToTy y ⇒ catToTy x
   | .lslash x y => catToTy y ⇒ catToTy x
-
-/-- A CCG lexical entry with semantics -/
-structure SemLexEntry (E W : Type) where
-  form : String
-  cat : Cat Atom
-  sem : Denot E W (catToTy cat)
-
-/-! ### Type preservation
-
-CCG combinatory rules preserve semantic well-typedness: if the syntactic
-combination succeeds, the semantic combination is well-typed. -/
 
 /-- Forward application preserves semantic typing:
     if X/Y combines with Y to give X, then (σ→τ) applied to σ gives τ. -/
@@ -80,459 +73,105 @@ theorem iv_type_is_property :
 
 /-! ### Derivation interpretation -/
 
-/-- A semantic interpretation: category paired with its meaning -/
-structure Interp (E W : Type) where
-  cat : Cat Atom
-  meaning : Denot E W (catToTy cat)
+/-- Semantic lexicon: for each word and queried category, optionally a meaning at that
+category — well-typed by construction. -/
+def SemLexicon (E W : Type) := String → (c : Cat Atom) → Option (Denot E W (catToTy c))
 
-/-- Semantic lexicon: maps words to interpretations -/
-def SemLexicon (E W : Type) := String → Cat Atom → Option (Interp E W)
-
-/--
-Interpret a CCG derivation, computing its meaning from the lexicon.
-
-Every combinatory rule corresponds to a semantic operation: application is
-function application, composition is the `B` combinator, type-raising is the
-`T` combinator, and coordination is generalized conjunction (restricted to
-conjoinable types). Returns `none` if the derivation is ill-formed or uses
-unknown words.
--/
-def DerivStep.interp {E W : Type} (d : DerivStep Atom) (lex : SemLexicon E W)
-    : Option (Interp E W) :=
-  match d with
-  | .lex entry => lex entry.form entry.cat
-
-  | .fapp d1 d2 => do
-      -- Forward application: X/Y Y → X
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      match c1, m1 with
-      | .rslash x y, m1 =>
-          if h : c2 = y then
-            let m2' : Denot E W (catToTy y) := h ▸ m2
-            some ⟨x, m1 m2'⟩
-          else none
-      | _, _ => none
-
-  | .bapp d1 d2 => do
-      -- Backward application: Y X\Y → X
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      match c2, m2 with
-      | .lslash x y, m2 =>
-          if h : c1 = y then
-            let m1' : Denot E W (catToTy y) := h ▸ m1
-            some ⟨x, m2 m1'⟩
-          else none
-      | _, _ => none
-
-  | .fcomp d1 d2 => do
-      -- Forward composition: X/Y + Y/Z → X/Z, semantically B (f ∘ g)
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      match c1, m1 with
-      | .rslash x y1, m1 =>
-          match c2, m2 with
-          | .rslash y2 z, m2 =>
-              if h : y1 = y2 then
-                let m2' : Denot E W (catToTy z ⇒ catToTy y1) :=
-                  h ▸ m2
-                some ⟨x / z, B m1 m2'⟩
-              else none
-          | _, _ => none
-      | _, _ => none
-
-  | .bcomp d1 d2 => do
-      -- Backward composition: Y\Z + X\Y → X\Z, semantically B (f ∘ g)
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      match c1, m1 with
-      | .lslash y1 z, m1 =>
-          match c2, m2 with
-          | .lslash x y2, m2 =>
-              if h : y1 = y2 then
-                let m1' : Denot E W (catToTy z ⇒ catToTy y2) :=
-                  h ▸ m1
-                some ⟨x \ z, B m2 m1'⟩
-              else none
-          | _, _ => none
-      | _, _ => none
-
-  | .fcompx d1 d2 => do
-      -- Forward crossed composition: X/Y + Y\Z → X\Z, semantically B (f ∘ g)
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      match c1, m1 with
-      | .rslash x y1, m1 =>
-          match c2, m2 with
-          | .lslash y2 z, m2 =>
-              if h : y1 = y2 then
-                let m2' : Denot E W (catToTy z ⇒ catToTy y1) :=
-                  h ▸ m2
-                some ⟨x \ z, B m1 m2'⟩
-              else none
-          | _, _ => none
-      | _, _ => none
-
-  | .ftr d t => do
-      -- Forward type-raising: X → T/(T\X), semantically T (λf. f x)
-      let ⟨x, m⟩ ← d.interp lex
-      some ⟨x.forwardTypeRaise t, T m⟩
-
-  | .btr d t => do
-      -- Backward type-raising: X → T\(T/X), semantically T (λf. f x)
-      let ⟨x, m⟩ ← d.interp lex
-      some ⟨x.backwardTypeRaise t, T m⟩
-
-  | .coord c d1 d2 => do
-      -- Coordination: X c X → X, via the Coordinator API — the meaning is `Coordinator.op`
-      -- of the coordinator's own `role` (runtime form `engineOp`; = generalized conjunction
-      -- [partee-rooth-1983] at `.j`), restricted to conjoinable types. The `role` is read off
-      -- the coordinator the derivation carries, so *which* coordinator is used is
-      -- truth-conditionally load-bearing.
-      let ⟨c1, m1⟩ ← d1.interp lex
-      let ⟨c2, m2⟩ ← d2.interp lex
-      if h : c1 = c2 then
-        let ty := catToTy c1
-        if ty.isConjoinable then
-          let m2' : Denot E W (catToTy c1) := h ▸ m2
-          some ⟨c1, Coordinator.engineOp c.role ty E W m1 m2'⟩
-        else none
+/-- Interpret a derivation compositionally: application is function application,
+composition is the `B` combinator, type-raising is the `T` combinator, and
+coordination is `Coordinator.engineOp` of the carried coordinator's `role`
+(generalized conjunction [partee-rooth-1983] at `.j`), restricted to conjoinable
+types. The category bookkeeping is carried by `Derivation`'s index, so no run-time
+category checks (and no casts) are needed; the result is `none` only when a word is
+missing from the lexicon or a coordination is at a non-conjoinable type. -/
+def Derivation.interp {E W : Type} (lex : SemLexicon E W) :
+    {c : Cat Atom} → Derivation Atom c → Option (Denot E W (catToTy c))
+  | _, .lex e => lex e.form e.cat
+  | _, .fapp d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      some (m1 m2)
+  | _, .bapp d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      some (m2 m1)
+  | _, .fcomp d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      some (B m1 m2)
+  | _, .bcomp d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      some (B m2 m1)
+  | _, .fcompx d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      some (B m1 m2)
+  | _, .ftr d _ => do
+      let m ← d.interp lex
+      some (T m)
+  | _, .btr d _ => do
+      let m ← d.interp lex
+      some (T m)
+  | x, .coord co d1 d2 => do
+      let m1 ← d1.interp lex
+      let m2 ← d2.interp lex
+      if (catToTy x).isConjoinable then
+        some (Coordinator.engineOp co.role (catToTy x) E W m1 m2)
       else none
-
-/-! ### Soundness: interpretation refines category assignment -/
-
-/-- A semantic lexicon is *well-typed* when every interpretation it returns is at the
-queried category. -/
-def SemLexicon.WellTyped {E W : Type} (lex : SemLexicon E W) : Prop :=
-  ∀ w c i, lex w c = some i → i.cat = c
-
-/-- Soundness of the interface: over a well-typed lexicon, `DerivStep.interp` and
-`DerivStep.cat` agree — a derivation that receives a meaning receives it at exactly the
-category the syntax derives. -/
-theorem DerivStep.cat_of_interp {E W : Type} {lex : SemLexicon E W}
-    (hlex : lex.WellTyped) {d : DerivStep Atom} :
-    ∀ {i : Interp E W}, d.interp lex = some i → d.cat = some i.cat := by
-  induction d with
-  | lex e =>
-    intro i h
-    simp only [DerivStep.interp] at h
-    simp [DerivStep.cat, hlex _ _ _ h]
-  | fapp d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    rcases c1 with _ | ⟨x, y⟩ | ⟨x, y⟩ <;>
-      try (change (none : Option (Interp E W)) = some i at h; simp at h)
-    change (if h' : c2 = y then
-        some (⟨x, m1 (h' ▸ m2)⟩ : Interp E W) else none) = some i at h
-    by_cases hc : c2 = y
-    · rw [dif_pos hc] at h
-      injection h with h; subst h; subst hc
-      show (d1.fapp d2).cat = some x
-      simp [DerivStep.cat, ih1 h1, ih2 h2]
-    · rw [dif_neg hc] at h
-      simp at h
-  | bapp d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    rcases c2 with _ | ⟨x, y⟩ | ⟨x, y⟩ <;>
-      try (change (none : Option (Interp E W)) = some i at h; simp at h)
-    change (if h' : c1 = y then
-        some (⟨x, m2 (h' ▸ m1)⟩ : Interp E W) else none) = some i at h
-    by_cases hc : c1 = y
-    · rw [dif_pos hc] at h
-      injection h with h; subst h; subst hc
-      show (d1.bapp d2).cat = some x
-      simp [DerivStep.cat, ih1 h1, ih2 h2]
-    · rw [dif_neg hc] at h
-      simp at h
-  | fcomp d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    rcases c1 with _ | ⟨x, y⟩ | ⟨x, y⟩ <;> rcases c2 with _ | ⟨y', z⟩ | ⟨y', z⟩ <;>
-      try (change (none : Option (Interp E W)) = some i at h; simp at h)
-    change (if h' : y = y' then
-        some (⟨x / z, B m1 (h' ▸ m2)⟩ : Interp E W) else none) = some i at h
-    by_cases hc : y = y'
-    · rw [dif_pos hc] at h
-      injection h with h; subst h; subst hc
-      show (d1.fcomp d2).cat = some (x / z)
-      simp [DerivStep.cat, ih1 h1, ih2 h2]
-    · rw [dif_neg hc] at h
-      simp at h
-  | bcomp d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    rcases c1 with _ | ⟨y, z⟩ | ⟨y, z⟩ <;> rcases c2 with _ | ⟨x, y'⟩ | ⟨x, y'⟩ <;>
-      try (change (none : Option (Interp E W)) = some i at h; simp at h)
-    change (if h' : y = y' then
-        some (⟨x \ z, B m2 (h' ▸ m1)⟩ : Interp E W) else none) = some i at h
-    by_cases hc : y = y'
-    · rw [dif_pos hc] at h
-      injection h with h; subst h; subst hc
-      show (d1.bcomp d2).cat = some (x \ z)
-      simp [DerivStep.cat, ih1 h1, ih2 h2]
-    · rw [dif_neg hc] at h
-      simp at h
-  | fcompx d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    rcases c1 with _ | ⟨x, y⟩ | ⟨x, y⟩ <;> rcases c2 with _ | ⟨y', z⟩ | ⟨y', z⟩ <;>
-      try (change (none : Option (Interp E W)) = some i at h; simp at h)
-    change (if h' : y = y' then
-        some (⟨x \ z, B m1 (h' ▸ m2)⟩ : Interp E W) else none) = some i at h
-    by_cases hc : y = y'
-    · rw [dif_pos hc] at h
-      injection h with h; subst h; subst hc
-      show (d1.fcompx d2).cat = some (x \ z)
-      simp [DerivStep.cat, ih1 h1, ih2 h2]
-    · rw [dif_neg hc] at h
-      simp at h
-  | ftr d t ih =>
-    intro i h
-    rcases h1 : d.interp lex with _ | ⟨x, m⟩
-    · simp [DerivStep.interp, h1] at h
-    simp only [DerivStep.interp, h1] at h
-    injection h with h; subst h
-    simp [DerivStep.cat, ih h1]
-  | btr d t ih =>
-    intro i h
-    rcases h1 : d.interp lex with _ | ⟨x, m⟩
-    · simp [DerivStep.interp, h1] at h
-    simp only [DerivStep.interp, h1] at h
-    injection h with h; subst h
-    simp [DerivStep.cat, ih h1]
-  | coord c d1 d2 ih1 ih2 =>
-    intro i h
-    rcases h1 : d1.interp lex with _ | ⟨c1, m1⟩
-    · simp [DerivStep.interp, h1] at h
-    rcases h2 : d2.interp lex with _ | ⟨c2, m2⟩
-    · simp [DerivStep.interp, h1, h2] at h
-    simp only [DerivStep.interp] at h
-    rw [h1, h2] at h
-    change (if h' : c1 = c2 then
-        (if (catToTy c1).isConjoinable then
-          some (⟨c1, Coordinator.engineOp c.role (catToTy c1) E W m1 (h' ▸ m2)⟩ : Interp E W)
-        else none) else none) = some i at h
-    by_cases hc : c1 = c2
-    · rw [dif_pos hc] at h
-      by_cases hconj : (catToTy c1).isConjoinable
-      · rw [if_pos hconj] at h
-        injection h with h; subst h; subst hc
-        show (DerivStep.coord c d1 d2).cat = some c1
-        simp [DerivStep.cat, ih1 h1, ih2 h2]
-      · rw [if_neg hconj] at h
-        simp at h
-    · rw [dif_neg hc] at h
-      simp at h
 
 /-! ### Spurious ambiguity
 
 Composition is semantically associative, so left- and right-branching derivations of
-the same composition-application chain receive the same interpretation — category and
-meaning alike, with no assumption on the lexicon. This is the local source of CCG's
-"spurious ambiguity" ([steedman-2000]; the matching-entry tests of [karttunen-1989]
-and [pareschi-steedman-1987] exploit exactly this invariance): a chart parser may keep
+the same composition-application chain receive the same interpretation — with no
+assumption on the lexicon. This is the local source of CCG's "spurious ambiguity"
+([steedman-2000]; the matching-entry tests of [karttunen-1989] and
+[pareschi-steedman-1987] exploit exactly this invariance): a chart parser may keep
 one derivation per equivalence class, because reassociating `fcomp`/`fapp` (or
 `bcomp`/`bapp`) nodes cannot change what a constituent means. -/
 
-set_option maxHeartbeats 800000 in
 /-- Reassociating a forward-composition chain preserves interpretation: `B` is
 semantically associative. -/
-theorem DerivStep.interp_fcomp_assoc {E W : Type} (lex : SemLexicon E W)
-    (d₁ d₂ d₃ : DerivStep Atom) :
-    (DerivStep.fcomp (.fcomp d₁ d₂) d₃).interp lex
-      = (DerivStep.fcomp d₁ (.fcomp d₂ d₃)).interp lex := by
-  simp only [DerivStep.interp]
-  rcases d₁.interp lex with _ | ⟨c₁, m₁⟩
-  · rfl
-  rcases d₂.interp lex with _ | ⟨c₂, m₂⟩
-  · rfl
-  rcases d₃.interp lex with _ | ⟨c₃, m₃⟩
-  · rcases c₁ with _ | ⟨x, y⟩ | ⟨x, y⟩
-    · rfl
-    · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-      · rfl
-      · by_cases h : y = y' <;> simp [h]
-      · rfl
-    · rfl
-  rcases c₁ with _ | ⟨x, y⟩ | ⟨x, y⟩
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · rcases c₃ with _ | ⟨z', w⟩ | ⟨z', w⟩
-      · rfl
-      · by_cases h : z = z' <;> simp [h]
-      · rfl
-    · rfl
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · rcases c₃ with _ | ⟨z', w⟩ | ⟨z', w⟩
-      · by_cases h : y = y' <;> simp [h]
-      · by_cases hy : y = y' <;> by_cases hz : z = z'
-        · subst hy; subst hz; simp
-          rfl
-        · simp [hy, hz]
-        · simp [hy, hz]
-        · simp [hy, hz]
-      · by_cases h : y = y' <;> simp [h]
-    · rfl
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · rcases c₃ with _ | ⟨z', w⟩ | ⟨z', w⟩
-      · rfl
-      · by_cases h : z = z' <;> simp [h]
-      · rfl
-    · rfl
+theorem Derivation.interp_fcomp_assoc {E W : Type} (lex : SemLexicon E W)
+    {x y z w : Cat Atom} (d₁ : Derivation Atom (x / y)) (d₂ : Derivation Atom (y / z))
+    (d₃ : Derivation Atom (z / w)) :
+    (Derivation.fcomp (.fcomp d₁ d₂) d₃).interp lex
+      = (Derivation.fcomp d₁ (.fcomp d₂ d₃)).interp lex := by
+  simp only [Derivation.interp]
+  rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
+    rcases d₃.interp lex with _ | m₃ <;> rfl
 
 /-- Composing before applying is the same as applying twice: `B f g x = f (g x)`,
 lifted to derivations. -/
-theorem DerivStep.interp_fapp_fcomp {E W : Type} (lex : SemLexicon E W)
-    (d₁ d₂ d₃ : DerivStep Atom) :
-    (DerivStep.fapp (.fcomp d₁ d₂) d₃).interp lex
-      = (DerivStep.fapp d₁ (.fapp d₂ d₃)).interp lex := by
-  simp only [DerivStep.interp]
-  rcases d₁.interp lex with _ | ⟨c₁, m₁⟩
-  · rfl
-  rcases d₂.interp lex with _ | ⟨c₂, m₂⟩
-  · rfl
-  rcases d₃.interp lex with _ | ⟨c₃, m₃⟩
-  · rcases c₁ with _ | ⟨x, y⟩ | ⟨x, y⟩
-    · rfl
-    · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-      · rfl
-      · by_cases h : y = y' <;> simp [h]
-      · rfl
-    · rfl
-  rcases c₁ with _ | ⟨x, y⟩ | ⟨x, y⟩
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · by_cases h : c₃ = z <;> simp [h]
-    · rfl
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · by_cases hy : y = y' <;> by_cases hz : c₃ = z
-      · subst hy; subst hz; simp
-      · simp [hy, hz, eq_comm]
-      · simp [hy, hz, eq_comm]
-      · simp [hy, hz, eq_comm]
-    · rfl
-  · rcases c₂ with _ | ⟨y', z⟩ | ⟨y', z⟩
-    · rfl
-    · by_cases h : c₃ = z <;> simp [h]
-    · rfl
+theorem Derivation.interp_fapp_fcomp {E W : Type} (lex : SemLexicon E W)
+    {x y z : Cat Atom} (d₁ : Derivation Atom (x / y)) (d₂ : Derivation Atom (y / z))
+    (d₃ : Derivation Atom z) :
+    (Derivation.fapp (.fcomp d₁ d₂) d₃).interp lex
+      = (Derivation.fapp d₁ (.fapp d₂ d₃)).interp lex := by
+  simp only [Derivation.interp]
+  rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
+    rcases d₃.interp lex with _ | m₃ <;> rfl
 
-set_option maxHeartbeats 800000 in
 /-- Reassociating a backward-composition chain preserves interpretation — the mirror
 of `interp_fcomp_assoc`. -/
-theorem DerivStep.interp_bcomp_assoc {E W : Type} (lex : SemLexicon E W)
-    (d₁ d₂ d₃ : DerivStep Atom) :
-    (DerivStep.bcomp (.bcomp d₁ d₂) d₃).interp lex
-      = (DerivStep.bcomp d₁ (.bcomp d₂ d₃)).interp lex := by
-  simp only [DerivStep.interp]
-  rcases d₁.interp lex with _ | ⟨c₁, m₁⟩
-  · rfl
-  rcases d₂.interp lex with _ | ⟨c₂, m₂⟩
-  · rfl
-  rcases d₃.interp lex with _ | ⟨c₃, m₃⟩
-  · rcases c₁ with _ | ⟨a, b⟩ | ⟨a, b⟩
-    · rfl
-    · rfl
-    · rcases c₂ with _ | ⟨c, e⟩ | ⟨c, e⟩
-      · rfl
-      · rfl
-      · by_cases h : a = e <;> simp [h]
-  rcases c₁ with _ | ⟨a, b⟩ | ⟨a, b⟩
-  · rcases c₂ with _ | ⟨c, e⟩ | ⟨c, e⟩
-    · rfl
-    · rfl
-    · rcases c₃ with _ | ⟨v, w⟩ | ⟨v, w⟩
-      · rfl
-      · rfl
-      · by_cases h : c = w <;> simp [h]
-  · rcases c₂ with _ | ⟨c, e⟩ | ⟨c, e⟩
-    · rfl
-    · rfl
-    · rcases c₃ with _ | ⟨v, w⟩ | ⟨v, w⟩
-      · rfl
-      · rfl
-      · by_cases h : c = w <;> simp [h]
-  · rcases c₂ with _ | ⟨c, e⟩ | ⟨c, e⟩
-    · rfl
-    · rfl
-    · rcases c₃ with _ | ⟨v, w⟩ | ⟨v, w⟩
-      · by_cases h : a = e <;> simp [h]
-      · by_cases h : a = e <;> simp [h]
-      · by_cases h₁ : a = e <;> by_cases h₂ : c = w
-        · subst h₁; subst h₂; simp
-          rfl
-        · simp [h₁, h₂]
-        · simp [h₁, h₂]
-        · simp [h₁, h₂]
+theorem Derivation.interp_bcomp_assoc {E W : Type} (lex : SemLexicon E W)
+    {x y z w : Cat Atom} (d₁ : Derivation Atom (y \ z)) (d₂ : Derivation Atom (x \ y))
+    (d₃ : Derivation Atom (w \ x)) :
+    (Derivation.bcomp (.bcomp d₁ d₂) d₃).interp lex
+      = (Derivation.bcomp d₁ (.bcomp d₂ d₃)).interp lex := by
+  simp only [Derivation.interp]
+  rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
+    rcases d₃.interp lex with _ | m₃ <;> rfl
 
 /-- Applying twice is the same as backward-composing first — the mirror of
 `interp_fapp_fcomp`. -/
-theorem DerivStep.interp_bapp_bcomp {E W : Type} (lex : SemLexicon E W)
-    (d₁ d₂ d₃ : DerivStep Atom) :
-    (DerivStep.bapp (.bapp d₁ d₂) d₃).interp lex
-      = (DerivStep.bapp d₁ (.bcomp d₂ d₃)).interp lex := by
-  simp only [DerivStep.interp]
-  rcases d₁.interp lex with _ | ⟨c₁, m₁⟩
-  · rfl
-  rcases d₂.interp lex with _ | ⟨c₂, m₂⟩
-  · rfl
-  rcases d₃.interp lex with _ | ⟨c₃, m₃⟩
-  · rcases c₂ with _ | ⟨x, y⟩ | ⟨x, y⟩
-    · rfl
-    · rfl
-    · by_cases h : c₁ = y <;> simp [h]
-  rcases c₂ with _ | ⟨x, y⟩ | ⟨x, y⟩
-  · rfl
-  · rfl
-  · rcases c₃ with _ | ⟨v, w⟩ | ⟨v, w⟩
-    · by_cases h : c₁ = y <;> simp [h]
-    · by_cases h : c₁ = y <;> simp [h]
-    · by_cases h₁ : c₁ = y <;> by_cases h₂ : x = w
-      · subst h₁; subst h₂; simp
-      · simp [h₁, h₂]
-      · simp [h₁, h₂]
-      · simp [h₁, h₂]
-
-/-- Extract a sentence meaning (category S) from an interpretation result. -/
-def getMeaning {E W : Type} (result : Option (Interp E W)) : Option Prop :=
-  match result with
-  | some ⟨.atom .S, m⟩ => some m
-  | _ => none
-
-/-- Extract a predicate meaning (category S/NP) from an interpretation result. -/
-def getPredicateMeaning {E W : Type} (result : Option (Interp E W))
-    : Option (E → Prop) :=
-  match result with
-  | some ⟨.rslash (.atom .S) (.atom .NP), m⟩ => some m
-  | _ => none
+theorem Derivation.interp_bapp_bcomp {E W : Type} (lex : SemLexicon E W)
+    {x y w : Cat Atom} (d₁ : Derivation Atom y) (d₂ : Derivation Atom (x \ y))
+    (d₃ : Derivation Atom (w \ x)) :
+    (Derivation.bapp (.bapp d₁ d₂) d₃).interp lex
+      = (Derivation.bapp d₁ (.bcomp d₂ d₃)).interp lex := by
+  simp only [Derivation.interp]
+  rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
+    rcases d₃.interp lex with _ | m₃ <;> rfl
 
 end CCG

--- a/Linglib/Syntax/CCG/Scope.lean
+++ b/Linglib/Syntax/CCG/Scope.lean
@@ -18,13 +18,6 @@ namespace CCG.Scope
 open CCG
 open ScopeTheory
 
-/-- A scope-taking element in a CCG derivation. -/
-structure ScopeTaker where
-  id : String
-  surfacePosition : Nat
-  cat : Cat Atom
-  deriving Repr
-
 /-- Derivation type for scope analysis. -/
 inductive DerivationType where
   | directApp    -- Standard application: surface scope only
@@ -32,29 +25,23 @@ inductive DerivationType where
   | composed     -- Composition: enables scope inversion
   deriving DecidableEq, Repr
 
-/-- Analyze derivation to determine its type. -/
-def analyzeDerivation {α : Type*} : DerivStep α → DerivationType
-  | .lex _ => .directApp
-  | .fapp d1 d2 =>
-    match analyzeDerivation d1, analyzeDerivation d2 with
-    | .typeRaised, _ | _, .typeRaised => .typeRaised
-    | .composed, _ | _, .composed => .composed
-    | _, _ => .directApp
-  | .bapp d1 d2 =>
-    match analyzeDerivation d1, analyzeDerivation d2 with
-    | .typeRaised, _ | _, .typeRaised => .typeRaised
-    | .composed, _ | _, .composed => .composed
-    | _, _ => .directApp
-  | .fcomp _ _ => .composed
-  | .bcomp _ _ => .composed
-  | .fcompx _ _ => .composed
-  | .ftr _ _ => .typeRaised
-  | .btr _ _ => .typeRaised
-  | .coord _ d1 d2 =>
-    match analyzeDerivation d1, analyzeDerivation d2 with
-    | .typeRaised, _ | _, .typeRaised => .typeRaised
-    | .composed, _ | _, .composed => .composed
-    | _, _ => .directApp
+/-- Combine daughters' derivation types: type-raising dominates, then composition. -/
+def DerivationType.join : DerivationType → DerivationType → DerivationType
+  | .typeRaised, _ | _, .typeRaised => .typeRaised
+  | .composed, _ | _, .composed => .composed
+  | _, _ => .directApp
+
+/-- Analyze a derivation to determine its type. -/
+def analyzeDerivation {α : Type*} : {c : Cat α} → Derivation α c → DerivationType
+  | _, .lex _ => .directApp
+  | _, .fapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
+  | _, .bapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
+  | _, .fcomp _ _ => .composed
+  | _, .bcomp _ _ => .composed
+  | _, .fcompx _ _ => .composed
+  | _, .ftr _ _ => .typeRaised
+  | _, .btr _ _ => .typeRaised
+  | _, .coord _ d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
 
 /-- Determine scope availability from derivation type. -/
 def derivationTypeToAvailability : DerivationType → BinaryScopeAvailability
@@ -62,28 +49,17 @@ def derivationTypeToAvailability : DerivationType → BinaryScopeAvailability
   | .typeRaised => .ambiguous
   | .composed => .ambiguous
 
-/-- A CCG derivation annotated with scope-taker information. -/
-structure ScopedDerivation where
-  deriv : DerivStep Atom
-  scopeTakers : List ScopeTaker
-  hasTwoOrMore : scopeTakers.length ≥ 2 := by decide
-  deriving Repr
-
-def ScopedDerivation.availability (sd : ScopedDerivation) : BinaryScopeAvailability :=
-  derivationTypeToAvailability (analyzeDerivation sd.deriv)
-
-def ScopedDerivation.toAvailableScopes (sd : ScopedDerivation) : AvailableScopes :=
-  let ids := sd.scopeTakers.map (·.id)
-  sd.availability.toAvailableScopes (ids.head!) (ids.tail.head!)
-
 -- Examples
 
-def everyHorse_surface : DerivStep Atom :=
+/-- Surface-scope derivation: subject and predicate combine by plain application. -/
+def everyHorse_surface : Derivation Atom S :=
   .bapp (.lex ⟨"every horse", NP⟩) (.lex ⟨"didn't jump", IV⟩)
 
-def everyHorse_inverse : DerivStep Atom :=
-  let everyHorse_tr := DerivStep.ftr (.lex ⟨"every horse", NP⟩) S
-  .fcomp everyHorse_tr (.lex ⟨"didn't jump", IV⟩)
+/-- Inverse-capable derivation: the type-raised subject composes with the negated
+auxiliary before the verb applies. -/
+def everyHorse_inverse : Derivation Atom S :=
+  .fapp (.fcomp (.ftr (.lex ⟨"every horse", NP⟩) S)
+    (.lex ⟨"didn't", (S \ NP) / (S \ NP)⟩)) (.lex ⟨"jump", IV⟩)
 
 example : analyzeDerivation everyHorse_surface = .directApp := rfl
 example : analyzeDerivation everyHorse_inverse = .composed := rfl

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -21,7 +21,7 @@ than a separate rule class.
 
 This substrate makes the CCG≡TAG weak-equivalence — and constructions of CCGs for
 non-context-free languages — expressible. It is distinct from the unrestricted,
-universal-rule CCG of `Syntax/CCG/Basic` (`CCG.DerivStep`), which
+universal-rule CCG of `Syntax/CCG/Basic` (`CCG.Derivation`), which
 [kuhlmann-koller-satta-2015] show is strictly weaker than TAG.
 
 ## Main definitions


### PR DESCRIPTION
The derivation type was misnamed (its values are whole derivations, not steps) and extrinsically typed — the source of every dependent-proof fight in #1944. `Derivation (α) : Cat α → Type` is now indexed by the category it derives, the parsing-as-deduction reading the field itself advertises.

- **"derives S" is typechecking**: `john_sleeps : Derivation Atom S` *is* the theorem; all `.cat = some S` study theorems dissolve into type signatures, and `DerivStep.cat` is gone
- **`interp` has no category checks and no casts**; `SemLexicon` returns meanings at the queried category, so `cat_of_interp` + `SemLexicon.WellTyped` (#1944) are deleted as true-by-construction, and the four spurious-ambiguity theorems reprove by `rcases <;> rfl` — no `maxHeartbeats`
- **intrinsic typing caught a live bug**: `Scope.everyHorse_inverse` was an ill-formed derivation (its `cat` was silently `none` — `fcomp` applied to a non-function secondary); rebuilt as a real composed derivation through the negated auxiliary
- `Interp`/`SemLexEntry`/`getMeaning`/`getPredicateMeaning` wrappers deleted; the now-consumerless named rule functions and their simp lemmas fold away (the schema `generalizedForwardComp`/`generalizedBackwardComp` remains, consumed by `TargetRestricted`)
- `TargetRestricted.Derivation` deliberately stays extrinsic: the capacity object needs raw candidate trees (target gate, future soundness induction); `CrossSerial`/`KKS` qualify it explicitly