### PR TITLE
refactor(Syntax/CCG): dissolve LexEntry; headers over empty sections

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -66,9 +66,9 @@ abbrev Scat : Cat Atom := .atom .S
 /-! ### The grammar `G₁` of Example 2 -/
 
 /-- `a := A`. -/
-def aLex : TargetRestricted.Derivation Atom := .lex Acat "a"
+def aLex : TargetRestricted.Derivation Atom := .lex "a" Acat
 /-- `c := C\A`. -/
-def cLex : TargetRestricted.Derivation Atom := .lex (Ccat \ Acat) "c"
+def cLex : TargetRestricted.Derivation Atom := .lex "c" (Ccat \ Acat)
 
 /-- The cluster category `S/C/…/C` with `n` forward `C`-arguments. -/
 def clusterCat : Nat → Cat Atom
@@ -78,14 +78,14 @@ def clusterCat : Nat → Cat Atom
 /-- Chain of degree-2 compositions: `b₁ = S/C/B` composed with `j` copies of
 `B/C/B`, giving `S/Cʲ⁺¹/B` and yield `bʲ⁺¹`. -/
 def fc2Chain : Nat → TargetRestricted.Derivation Atom
-  | 0 => .lex ((Scat / Ccat) / Bcat) "b"
-  | j + 1 => .fc 2 (fc2Chain j) (.lex ((Bcat / Ccat) / Bcat) "b")
+  | 0 => .lex "b" ((Scat / Ccat) / Bcat)
+  | j + 1 => .fc 2 (fc2Chain j) (.lex "b" ((Bcat / Ccat) / Bcat))
 
 /-- The `b`-cluster derivation for `n ≥ 1`, with category `clusterCat n`, yield `bⁿ`. -/
 def clusterDeriv : Nat → TargetRestricted.Derivation Atom
-  | 0 => .lex Scat "b"            -- unused (the construction starts at n = 1)
-  | 1 => .lex (Scat / Ccat) "b"
-  | n + 2 => .fc 1 (fc2Chain n) (.lex (Bcat / Ccat) "b")
+  | 0 => .lex "b" Scat            -- unused (the construction starts at n = 1)
+  | 1 => .lex "b" (Scat / Ccat)
+  | n + 2 => .fc 1 (fc2Chain n) (.lex "b" (Bcat / Ccat))
 
 /-- One peel: crossed-compose with a `c` on the right, then backward-apply an `a` on the
 left — wrapping the yield with `a … c` and removing one `C` argument. -/

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -44,20 +44,20 @@ object NP first, then the resulting `S\NP` looks left for the subject,
 enforcing SVO. -/
 
 def mary_eats_pizza : Derivation Atom S :=
-  .bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
+  .bapp (.lex "Mary" NP) (.fapp (.lex "eats" TV) (.lex "pizza" NP))
 
 def he_sees_her : Derivation Atom S :=
-  .bapp (.lex ⟨"he", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"her", NP⟩))
+  .bapp (.lex "he" NP) (.fapp (.lex "sees" TV) (.lex "her" NP))
 
 def the_cat_eats_pizza : Derivation Atom S :=
-  .bapp (.fapp (.lex ⟨"the", Det⟩) (.lex ⟨"cat", N⟩))
-        (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
+  .bapp (.fapp (.lex "the" Det) (.lex "cat" N))
+        (.fapp (.lex "eats" TV) (.lex "pizza" NP))
 
 def john_sleeps : Derivation Atom S :=
-  .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩)
+  .bapp (.lex "John" NP) (.lex "sleeps" IV)
 
 def john_sees_mary : Derivation Atom S :=
-  .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
+  .bapp (.lex "John" NP) (.fapp (.lex "sees" TV) (.lex "Mary" NP))
 
 /-! ### Non-constituent coordination -/
 
@@ -66,21 +66,21 @@ section Coordination
 open Semantics.Montague
 
 /-- Type-raised subject "John": `S/(S\NP)`. -/
-def john_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex ⟨"John", NP⟩) S
+def john_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex "John" NP) S
 
 /-- "John likes": the type-raised subject composed with the transitive verb — a
 constituent of category `S/NP`. -/
-def john_likes : Derivation Atom (S / NP) := .fcomp john_tr (.lex ⟨"likes", TV⟩)
+def john_likes : Derivation Atom (S / NP) := .fcomp john_tr (.lex "likes" TV)
 
-def mary_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex ⟨"Mary", NP⟩) S
-def mary_hates : Derivation Atom (S / NP) := .fcomp mary_tr (.lex ⟨"hates", TV⟩)
+def mary_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex "Mary" NP) S
+def mary_hates : Derivation Atom (S / NP) := .fcomp mary_tr (.lex "hates" TV)
 
 /-- "John likes and Mary hates": coordination of two `S/NP` constituents. -/
 def john_likes_and_mary_hates : Derivation Atom (S / NP) :=
   .coord English.Coordination.and_ john_likes mary_hates
 
 def john_likes_and_mary_hates_beans : Derivation Atom S :=
-  .fapp john_likes_and_mary_hates (.lex ⟨"beans", NP⟩)
+  .fapp john_likes_and_mary_hates (.lex "beans" NP)
 
 /-- The derivation spells out the full surface string, coordinator included. -/
 theorem john_likes_and_mary_hates_beans_yield :
@@ -89,8 +89,8 @@ theorem john_likes_and_mary_hates_beans_yield :
 
 def john_sleeps_and_mary_sleeps : Derivation Atom S :=
   .coord English.Coordination.and_
-    (.bapp (.lex ⟨"John", NP⟩) (.lex ⟨"sleeps", IV⟩))
-    (.bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩))
+    (.bapp (.lex "John" NP) (.lex "sleeps" IV))
+    (.bapp (.lex "Mary" NP) (.lex "sleeps" IV))
 
 example : john_sleeps.opCount = 1 := rfl
 example : john_sleeps_and_mary_sleeps.opCount = 3 := rfl
@@ -134,7 +134,7 @@ example : (john_tr.interp toySemLexicon).isSome = true := rfl
 `john_tr : S/(S\NP)` uses forward application, and the derivation
 produces the same truth value as the canonical one. -/
 def john_sees_mary_via_tr : Derivation Atom S :=
-  .fapp john_tr (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"Mary", NP⟩))
+  .fapp john_tr (.fapp (.lex "sees" TV) (.lex "Mary" NP))
 
 theorem interp_john_sees_mary_via_tr :
     john_sees_mary_via_tr.interp toySemLexicon = some True := rfl
@@ -169,8 +169,8 @@ theorem interp_john_likes_and_mary_hates_beans :
 /-- The spelled-out paraphrase "John likes beans and Mary hates beans". -/
 def john_likes_beans_and_mary_hates_beans : Derivation Atom S :=
   .coord English.Coordination.and_
-    (.bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"likes", TV⟩) (.lex ⟨"beans", NP⟩)))
-    (.bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"hates", TV⟩) (.lex ⟨"beans", NP⟩)))
+    (.bapp (.lex "John" NP) (.fapp (.lex "likes" TV) (.lex "beans" NP)))
+    (.bapp (.lex "Mary" NP) (.fapp (.lex "hates" TV) (.lex "beans" NP)))
 
 /-- The non-constituent coordination and its spelled-out paraphrase receive
 the same truth conditions — the book's claim that the composed derivation
@@ -196,8 +196,8 @@ private def pqLex : SemLexicon Unit Unit := fun w c =>
   | "q", .atom .S => some False
   | _, _ => none
 
-private def dp : Derivation Atom S := .lex ⟨"p", S⟩
-private def dq : Derivation Atom S := .lex ⟨"q", S⟩
+private def dp : Derivation Atom S := .lex "p" S
+private def dq : Derivation Atom S := .lex "q" S
 
 /-- The coordinator's `role` flips the truth conditions: English `and_` yields `p ∧ q`,
     `or_` yields `p ∨ q`, and these differ at `p = ⊤`, `q = ⊥`. Flipping a fragment
@@ -494,15 +494,15 @@ inductive VerbOrder where
 /-- Verb-raising order, Dutch (99a): the cluster *probeert te zingen*
 forms by crossed composition before taking the object to its left. -/
 def verbRaisingDeriv : Derivation Atom IV :=
-  .bapp (.lex ⟨"veel liederen", NP⟩)
-    (.fcompx (.lex ⟨"probeert", IV / IV⟩) (.lex ⟨"te zingen", IV \ NP⟩))
+  .bapp (.lex "veel liederen" NP)
+    (.fcompx (.lex "probeert" (IV / IV)) (.lex "te zingen" (IV \ NP)))
 
 /-- Verb-projection-raising order, Dutch (99b): the matrix verb applies to
 an already-saturated embedded VP, so the quantified object never combines
 with a function containing the tensed verb. -/
 def verbProjectionRaisingDeriv : Derivation Atom IV :=
-  .fapp (.lex ⟨"probeert", IV / IV⟩)
-    (.bapp (.lex ⟨"veel liederen", NP⟩) (.lex ⟨"te zingen", IV \ NP⟩))
+  .fapp (.lex "probeert" (IV / IV))
+    (.bapp (.lex "veel liederen" NP) (.lex "te zingen" (IV \ NP)))
 
 /-- The CCG derivation shape each verb order forces. -/
 def schematicDeriv : VerbOrder → Derivation Atom IV
@@ -570,23 +570,23 @@ open Semantics.Montague
 
 /-- "Mary sleeps" - backward application -/
 def ccg_mary_sleeps : Derivation Atom S :=
-  .bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"sleeps", IV⟩)
+  .bapp (.lex "Mary" NP) (.lex "sleeps" IV)
 
 /-- "John laughs" - backward application -/
 def ccg_john_laughs : Derivation Atom S :=
-  .bapp (.lex ⟨"John", NP⟩) (.lex ⟨"laughs", IV⟩)
+  .bapp (.lex "John" NP) (.lex "laughs" IV)
 
 /-- "Mary laughs" - backward application -/
 def ccg_mary_laughs : Derivation Atom S :=
-  .bapp (.lex ⟨"Mary", NP⟩) (.lex ⟨"laughs", IV⟩)
+  .bapp (.lex "Mary" NP) (.lex "laughs" IV)
 
 /-- "Mary sees John" - forward then backward application -/
 def ccg_mary_sees_john : Derivation Atom S :=
-  .bapp (.lex ⟨"Mary", NP⟩) (.fapp (.lex ⟨"sees", TV⟩) (.lex ⟨"John", NP⟩))
+  .bapp (.lex "Mary" NP) (.fapp (.lex "sees" TV) (.lex "John" NP))
 
 /-- "John eats pizza" - forward then backward application -/
 def ccg_john_eats_pizza : Derivation Atom S :=
-  .bapp (.lex ⟨"John", NP⟩) (.fapp (.lex ⟨"eats", TV⟩) (.lex ⟨"pizza", NP⟩))
+  .bapp (.lex "John" NP) (.fapp (.lex "eats" TV) (.lex "pizza" NP))
 
 -- Extended Semantic Lexicon (matching the toy model)
 

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -24,7 +24,6 @@ The target-restricted (VW-CCG) schema derivations live in `CCG.TargetRestricted`
 * `Cat.generalizedForwardComp`, `Cat.generalizedBackwardComp`: generalized
   composition of degree `n`, the schema every binary rule instantiates.
 * `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: type-raising.
-* `LexEntry`: a lexical entry, pairing a surface form with its category.
 * `Derivation`: intrinsically typed derivations, indexed by the category they derive;
   `Derivation.yield` reads off the surface string a derivation spells out and
   `Derivation.opCount` the number of rule applications.
@@ -41,7 +40,7 @@ the Steedman left-to-right reading.
 
 namespace CCG
 
-section Categories
+/-! ### Categories -/
 
 /-- The core atomic categories of the English fragment (`S`, `NP`, `N`, `PP`, as in
 [steedman-2000]), stated without features. -/
@@ -78,13 +77,11 @@ def IV : Cat Atom := S \ NP
 def TV : Cat Atom := (S \ NP) / NP
 def Det : Cat Atom := NP / N
 
-end Categories
-
 variable {α : Type*} [DecidableEq α]
 
 namespace Cat
 
-section CombinatoryRules
+/-! ### The generalized composition schema -/
 
 /-- `generalizedForwardComp n f g` is forward composition of degree `n` (`>Bⁿ`): when
 `f = X/Y` and `g = Y|Z₁…|Zₙ`, the result is `X|Z₁…|Zₙ` with each argument keeping its
@@ -97,16 +94,14 @@ def generalizedForwardComp : Nat → Cat α → Cat α → Option (Cat α)
 
 /-- `generalizedBackwardComp n g f` is backward composition of degree `n` (`<Bⁿ`), the
 mirror of `generalizedForwardComp`: when `g = Y|Z₁…|Zₙ` and `f = X\Y`, the result is
-`X|Z₁…|Zₙ`. -/
+`X|Z₁…|Zₙ`, and `none` otherwise. -/
 def generalizedBackwardComp : Nat → Cat α → Cat α → Option (Cat α)
   | 0, z, .lslash x y => if y = z then some x else none
   | n + 1, .rslash g z, f => (generalizedBackwardComp n g f).map (Cat.rslash · z)
   | n + 1, .lslash g z, f => (generalizedBackwardComp n g f).map (Cat.lslash · z)
   | _, _, _ => none
 
-end CombinatoryRules
-
-section TypeRaising
+/-! ### Type-raising -/
 
 /-- `forwardTypeRaise x t` is `t / (t \ x)` — forward type-raising `>T` of `x` to
 target `t`. -/
@@ -118,25 +113,17 @@ target `t`. -/
 def backwardTypeRaise (x : Cat α) (t : Cat α) : Cat α :=
   t \ (t / x)
 
-end TypeRaising
-
 end Cat
 
-/-- A CCG lexical entry. -/
-structure LexEntry (α : Type*) where
-  form : String
-  cat : Cat α
-  deriving Repr
-
-section Derivations
+/-! ### Derivations -/
 
 /-- A CCG derivation of category `c`, intrinsically typed: each constructor is one of
 the toy grammar's rule instances, so a value of `Derivation α c` *is* a well-formed
 derivation and "derives `c`" is typechecking. Backward crossed composition and the
 substitution rules of [steedman-2000] are not part of this inventory. -/
 inductive Derivation (α : Type*) : Cat α → Type _ where
-  /-- A lexical leaf, at its entry's category. -/
-  | lex (e : LexEntry α) : Derivation α e.cat
+  /-- A lexical leaf: a surface form, at category `c`. -/
+  | lex (form : String) (c : Cat α) : Derivation α c
   /-- Forward application `>`: X/Y Y ⇒ X. -/
   | fapp {x y : Cat α} : Derivation α (x / y) → Derivation α y → Derivation α x
   /-- Backward application `<`: Y X\Y ⇒ X. -/
@@ -166,7 +153,7 @@ Combinatory rules concatenate their daughters and type-raising leaves the string
 untouched, so the yield is independent of the derivation's combinatory structure —
 the property that lets a CCG derivation witness a string language. -/
 def Derivation.yield {c : Cat α} : Derivation α c → List String
-  | .lex e => [e.form]
+  | .lex f _ => [f]
   | .fapp d1 d2 => d1.yield ++ d2.yield
   | .bapp d1 d2 => d1.yield ++ d2.yield
   | .fcomp d1 d2 => d1.yield ++ d2.yield
@@ -178,7 +165,7 @@ def Derivation.yield {c : Cat α} : Derivation α c → List String
 
 /-- The number of combinatory rule applications in a derivation. -/
 def Derivation.opCount {c : Cat α} : Derivation α c → Nat
-  | .lex _ => 0
+  | .lex _ _ => 0
   | .fapp d1 d2 => 1 + d1.opCount + d2.opCount
   | .bapp d1 d2 => 1 + d1.opCount + d2.opCount
   | .fcomp d1 d2 => 1 + d1.opCount + d2.opCount
@@ -187,7 +174,5 @@ def Derivation.opCount {c : Cat α} : Derivation α c → Nat
   | .ftr d _ => 1 + d.opCount
   | .btr d _ => 1 + d.opCount
   | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
-
-end Derivations
 
 end CCG

--- a/Linglib/Syntax/CCG/CrossSerial.lean
+++ b/Linglib/Syntax/CCG/CrossSerial.lean
@@ -70,26 +70,16 @@ def PercVSub : Cat Atom := ((S \ NP) \ NP) / VP
 `zien := (VP\NP)/VP₋SUB`). -/
 def InfHeadSub : Cat Atom := (VP \ NP) / VP
 
-/-- The Dutch lexicon (reference; the derivations below select specific entries). -/
-def dutchLexicon : List (LexEntry Atom) := [
-  ⟨"Jan", NP⟩, ⟨"Piet", NP⟩, ⟨"Marie", NP⟩, ⟨"Karel", NP⟩,
-  ⟨"zag", PercV⟩, ⟨"zag", PercVSub⟩,
-  ⟨"helpen", ControlV⟩, ⟨"laten", ControlV⟩,
-  ⟨"helpen", ControlVR⟩, ⟨"laten", ControlVR⟩,
-  ⟨"helpen", InfHeadSub⟩,
-  ⟨"zwemmen", VP⟩, ⟨"zwemmen", InfSubj⟩
-]
-
 /-! ### Lexical entries -/
 
-def jan_lex : TargetRestricted.Derivation Atom := .lex NP "Jan"
-def piet_lex : TargetRestricted.Derivation Atom := .lex NP "Piet"
-def marie_lex : TargetRestricted.Derivation Atom := .lex NP "Marie"
-def zag_lex : TargetRestricted.Derivation Atom := .lex PercV "zag"
+def jan_lex : TargetRestricted.Derivation Atom := .lex "Jan" NP
+def piet_lex : TargetRestricted.Derivation Atom := .lex "Piet" NP
+def marie_lex : TargetRestricted.Derivation Atom := .lex "Marie" NP
+def zag_lex : TargetRestricted.Derivation Atom := .lex "zag" PercV
 /-- `zwemmen` in its verb-raising category `(S\NP)/NP`. -/
-def zwemmen_vr : TargetRestricted.Derivation Atom := .lex InfSubj "zwemmen"
+def zwemmen_vr : TargetRestricted.Derivation Atom := .lex "zwemmen" InfSubj
 /-- `helpen` in its verb-raising category `((S\NP)/NP)/(S\NP)`. -/
-def helpen_vr : TargetRestricted.Derivation Atom := .lex ControlVR "helpen"
+def helpen_vr : TargetRestricted.Derivation Atom := .lex "helpen" ControlVR
 
 /-! ### Derivation: "Jan Piet zag zwemmen" (2 NPs, 2 Vs) -/
 
@@ -149,9 +139,9 @@ composes the cluster by forward **crossed** composition, so the
 NPs precede the whole cluster and the yield is the attested
 "Jan Piet (Marie) zag (helpen) zwemmen". -/
 
-def zag_sub : TargetRestricted.Derivation Atom := .lex PercVSub "zag"
-def helpen_sub : TargetRestricted.Derivation Atom := .lex InfHeadSub "helpen"
-def zwemmen_bare : TargetRestricted.Derivation Atom := .lex VP "zwemmen"
+def zag_sub : TargetRestricted.Derivation Atom := .lex "zag" PercVSub
+def helpen_sub : TargetRestricted.Derivation Atom := .lex "helpen" InfHeadSub
+def zwemmen_bare : TargetRestricted.Derivation Atom := .lex "zwemmen" VP
 
 /-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the
 NPs attach leftward — the 2-verb cluster needs no composition. -/

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -86,7 +86,7 @@ category checks (and no casts) are needed; the result is `none` only when a word
 missing from the lexicon or a coordination is at a non-conjoinable type. -/
 def Derivation.interp {E W : Type} (lex : SemLexicon E W) :
     {c : Cat Atom} → Derivation Atom c → Option (Denot E W (catToTy c))
-  | _, .lex e => lex e.form e.cat
+  | _, .lex f c => lex f c
   | _, .fapp d1 d2 => do
       let m1 ← d1.interp lex
       let m2 ← d2.interp lex

--- a/Linglib/Syntax/CCG/Scope.lean
+++ b/Linglib/Syntax/CCG/Scope.lean
@@ -33,7 +33,7 @@ def DerivationType.join : DerivationType → DerivationType → DerivationType
 
 /-- Analyze a derivation to determine its type. -/
 def analyzeDerivation {α : Type*} : {c : Cat α} → Derivation α c → DerivationType
-  | _, .lex _ => .directApp
+  | _, .lex _ _ => .directApp
   | _, .fapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
   | _, .bapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
   | _, .fcomp _ _ => .composed
@@ -53,13 +53,13 @@ def derivationTypeToAvailability : DerivationType → BinaryScopeAvailability
 
 /-- Surface-scope derivation: subject and predicate combine by plain application. -/
 def everyHorse_surface : Derivation Atom S :=
-  .bapp (.lex ⟨"every horse", NP⟩) (.lex ⟨"didn't jump", IV⟩)
+  .bapp (.lex "every horse" NP) (.lex "didn't jump" IV)
 
 /-- Inverse-capable derivation: the type-raised subject composes with the negated
 auxiliary before the verb applies. -/
 def everyHorse_inverse : Derivation Atom S :=
-  .fapp (.fcomp (.ftr (.lex ⟨"every horse", NP⟩) S)
-    (.lex ⟨"didn't", (S \ NP) / (S \ NP)⟩)) (.lex ⟨"jump", IV⟩)
+  .fapp (.fcomp (.ftr (.lex "every horse" NP) S)
+    (.lex "didn't" ((S \ NP) / (S \ NP)))) (.lex "jump" IV)
 
 example : analyzeDerivation everyHorse_surface = .directApp := rfl
 example : analyzeDerivation everyHorse_inverse = .composed := rfl

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -53,8 +53,8 @@ def target : Cat α → α
 /-- A derivation under the rule-restricted degree-`n` composition schema: nodes record
 degree and direction only. -/
 inductive Derivation (α : Type*) where
-  /-- A lexical leaf: category and surface form. -/
-  | lex : Cat α → String → Derivation α
+  /-- A lexical leaf: a surface form at a category. -/
+  | lex : String → Cat α → Derivation α
   /-- Forward composition of degree `n` (`>Bⁿ`; degree 0 is application). -/
   | fc : Nat → Derivation α → Derivation α → Derivation α
   /-- Backward composition of degree `n` (`<Bⁿ`; degree 0 is application). -/
@@ -65,7 +65,7 @@ inductive Derivation (α : Type*) where
 the target of its primary (functor) input is `s` (`none` otherwise, or if the schema
 does not apply). -/
 def Derivation.cat [DecidableEq α] (s : α) : Derivation α → Option (Cat α)
-  | .lex c _ => some c
+  | .lex _ c => some c
   | .fc n l r => do
     let a ← l.cat s
     let b ← r.cat s
@@ -77,7 +77,7 @@ def Derivation.cat [DecidableEq α] (s : α) : Derivation α → Option (Cat α)
 
 /-- Surface string: leaf forms left to right. -/
 def Derivation.yield : Derivation α → List String
-  | .lex _ w => [w]
+  | .lex w _ => [w]
   | .fc _ l r | .bc _ l r => l.yield ++ r.yield
 
 end CCG.TargetRestricted


### PR DESCRIPTION
Register cleanups on `Basic.lean` and its cone.

- `LexEntry` dissolved: it was the extrinsic design's carrier (the leaf had to package form+cat so `DerivStep.cat` could read it back); the intrinsic leaf is `lex (form : String) (c : Cat α) : Derivation α c`, which also replaces the projection index `Derivation α e.cat` that caused elaboration postponement, and drops the anonymous-constructor brackets at ~50 call sites. `TargetRestricted.Derivation.lex` aligned to the same form-first order; `CrossSerial.dutchLexicon` cut as unconsumed reference data (the `exampleLexicon` precedent)
- the four organizational `section X`/`end X` pairs scoped nothing (the `variable` block sits outside them; the notation is namespace-scoped) — replaced with mathlib-style `/-! ### … -/` headers
- the backward schema docstring gains the `none`-partiality clause its forward twin has, restoring the pair's parallelism

Constructor binders `{x y z : Cat α}` stay per-constructor: lifting to `variable` would absorb them as fixed inductive parameters (they must vary per node — that's what makes them indices), and per-constructor implicits are mathlib's own idiom for indexed families (`ContextFreeRule.Rewrites.cons`).