### PR TITLE
refactor(Syntax/CCG): HasComp/HasTypeRaise predicates over enum analyzer

### DIFF
--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -27,7 +27,7 @@ CCG predictions from [steedman-2000], one section per phenomenon:
   categories and forward crossed composition.
 - **Verb clusters and quantifier scope** (§6.8): verb-raising orders are
   scope-ambiguous, verb-projection-raising orders surface-only; predictions
-  are computed via `CCG.analyzeDerivation` and checked against the
+  are read off the derivations' structure (`Derivation.HasComp`) and checked against the
   §6.8 judgments in `Linglib.Data.Examples.Steedman2000` ([bayer-1996],
   [kayne-1998], [haegeman-van-riemsdijk-1986], [haegeman-1992] are
   credited per example in the JSON).
@@ -483,15 +483,6 @@ section Quantification
 
 open ScopeTheory Data.Examples
 
-/-- Scope availability from derivation type — the account's linking hypothesis: both
-non-application types map to `.ambiguous`. This is the bare derivation–scope link,
-which [steedman-2000] notes overgenerates as stated (§4.4 refines it). -/
-def derivationTypeToAvailability : DerivationType → BinaryScopeAvailability
-  | .directApp => .surfaceOnly
-  | .typeRaised => .ambiguous
-  | .composed => .ambiguous
-
-
 /-- Word order in a West Germanic verb cluster ([steedman-2000] §6.8). -/
 inductive VerbOrder where
   /-- Object precedes the whole verb cluster: NP … V_emb V_matrix. -/
@@ -518,16 +509,19 @@ def schematicDeriv : VerbOrder → Derivation Atom IV
   | .verbRaising => verbRaisingDeriv
   | .verbProjectionRaising => verbProjectionRaisingDeriv
 
-theorem analyzeDerivation_verbRaisingDeriv :
-    analyzeDerivation verbRaisingDeriv = .composed := rfl
+theorem verbRaisingDeriv_hasComp : verbRaisingDeriv.HasComp := by decide
 
-theorem analyzeDerivation_verbProjectionRaisingDeriv :
-    analyzeDerivation verbProjectionRaisingDeriv = .directApp := rfl
+theorem verbProjectionRaisingDeriv_applicationOnly :
+    ¬verbProjectionRaisingDeriv.HasComp ∧ ¬verbProjectionRaisingDeriv.HasTypeRaise := by
+  decide
 
-/-- Scope availability as CCG predicts it: analyze the derivation the
-word order forces and read availability off its derivation type. -/
+/-- Scope availability as CCG predicts it — the account's linking hypothesis: a
+cluster built with composition or type-raising is scope-ambiguous, an
+application-only cluster surface-only. [steedman-2000] notes this overgenerates as
+stated (§4.4 refines it). -/
 def predictedAvailability (vo : VerbOrder) : BinaryScopeAvailability :=
-  derivationTypeToAvailability (analyzeDerivation (schematicDeriv vo))
+  if (schematicDeriv vo).HasComp ∨ (schematicDeriv vo).HasTypeRaise then .ambiguous
+  else .surfaceOnly
 
 /-- Read the §6.8 word-order classification off an example's
 `paperFeatures`. -/

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -26,8 +26,8 @@ The target-restricted (VW-CCG) schema derivations live in `CCG.TargetRestricted`
 * `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: type-raising.
 * `Derivation`: intrinsically typed derivations, indexed by the category they derive;
   `Derivation.yield` reads off the surface string a derivation spells out,
-  `Derivation.opCount` the number of rule applications, and `analyzeDerivation` the
-  strongest rule class used (`DerivationType`).
+  `Derivation.opCount` the number of rule applications, and `Derivation.HasComp` /
+  `Derivation.HasTypeRaise` whether a rule class occurs in the tree.
 
 ## Notation
 
@@ -176,35 +176,52 @@ def Derivation.opCount {c : Cat α} : Derivation α c → Nat
   | .btr d _ => 1 + d.opCount
   | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
 
-/-- The rule classes a derivation can be built from, for structural analysis:
-pure application, or the scope-relevant devices composition and type-raising. -/
-inductive DerivationType where
-  /-- Pure application. -/
-  | directApp
-  /-- At least one type-raising node. -/
-  | typeRaised
-  /-- At least one composition node (and no type-raising). -/
-  | composed
-  deriving DecidableEq, Repr
+/-- The derivation contains a composition node (`fcomp`, `bcomp`, or `fcompx`). -/
+def Derivation.HasComp {c : Cat α} : Derivation α c → Prop
+  | .lex _ _ => False
+  | .fapp d1 d2 => d1.HasComp ∨ d2.HasComp
+  | .bapp d1 d2 => d1.HasComp ∨ d2.HasComp
+  | .fcomp _ _ => True
+  | .bcomp _ _ => True
+  | .fcompx _ _ => True
+  | .ftr d _ => d.HasComp
+  | .btr d _ => d.HasComp
+  | .coord _ d1 d2 => d1.HasComp ∨ d2.HasComp
 
-/-- Combine daughters' derivation types — the maximum under
-`directApp < composed < typeRaised`. -/
-def DerivationType.join : DerivationType → DerivationType → DerivationType
-  | .typeRaised, _ | _, .typeRaised => .typeRaised
-  | .composed, _ | _, .composed => .composed
-  | _, _ => .directApp
+instance Derivation.HasComp.decidable {c : Cat α} :
+    ∀ d : Derivation α c, Decidable d.HasComp
+  | .lex _ _ => isFalse fun h => h
+  | .fapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .bapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .fcomp _ _ => isTrue trivial
+  | .bcomp _ _ => isTrue trivial
+  | .fcompx _ _ => isTrue trivial
+  | .ftr d _ => decidable d
+  | .btr d _ => decidable d
+  | .coord _ d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
 
-/-- The derivation type of a derivation: composition and type-raising nodes dominate
-their subtrees. -/
-def analyzeDerivation {c : Cat α} : Derivation α c → DerivationType
-  | .lex _ _ => .directApp
-  | .fapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
-  | .bapp d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
-  | .fcomp _ _ => .composed
-  | .bcomp _ _ => .composed
-  | .fcompx _ _ => .composed
-  | .ftr _ _ => .typeRaised
-  | .btr _ _ => .typeRaised
-  | .coord _ d1 d2 => (analyzeDerivation d1).join (analyzeDerivation d2)
+/-- The derivation contains a type-raising node (`ftr` or `btr`). -/
+def Derivation.HasTypeRaise {c : Cat α} : Derivation α c → Prop
+  | .lex _ _ => False
+  | .fapp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+  | .bapp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+  | .fcomp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+  | .bcomp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+  | .fcompx d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+  | .ftr _ _ => True
+  | .btr _ _ => True
+  | .coord _ d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
+
+instance Derivation.HasTypeRaise.decidable {c : Cat α} :
+    ∀ d : Derivation α c, Decidable d.HasTypeRaise
+  | .lex _ _ => isFalse fun h => h
+  | .fapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .bapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .fcomp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .bcomp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .fcompx d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .ftr _ _ => isTrue trivial
+  | .btr _ _ => isTrue trivial
+  | .coord _ d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
 
 end CCG


### PR DESCRIPTION
`DerivationType` was a lossy priority-collapse of two independent structural facts: its `composed` case meant "composition *and no type-raising*", the `join` dominance order (type-raising beats composition) was interpretive material smuggled into neutral API, and composition under type-raising was unrecoverable.

- `Basic` now exposes the two facts independently as Prop-valued folds with `Decidable` instances — `Derivation.HasComp` and `Derivation.HasTypeRaise` — replacing `DerivationType`/`join`/`analyzeDerivation`
- the study's `predictedAvailability` states the linking hypothesis directly (ambiguous iff composition or type-raising occurs; the [steedman-2000] §4.4 overgeneration caveat at the definition); `derivationTypeToAvailability` dissolves; the two derivation-type theorems become predicate statements (`verbRaisingDeriv_hasComp`, `verbProjectionRaisingDeriv_applicationOnly`)