### PR TITLE
feat(Syntax/CCG): modern API — Baldridge modalities, Rule family, CPP node

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -111,7 +111,7 @@ theorem target_clusterCat (n : Nat) : target (clusterCat n) = Atom.S := by
 
 /-- The degree-2 chain composes to `S/Cʲ⁺¹/B`. -/
 theorem fc2Chain_cat (j : Nat) :
-    (fc2Chain j).cat .S = some ((clusterCat (j + 1)).rslash Bcat) := by
+    (fc2Chain j).cat .S = some ((clusterCat (j + 1)).rslash .dot Bcat) := by
   induction j with
   | zero => rfl
   | succ j ih =>

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -64,21 +64,28 @@ def john_sees_mary : Derivation Atom S :=
 
 section Coordination
 
-open Semantics.Montague
+open Semantics.Montague Combinator
 
-/-- Type-raised subject "John": `S/(S\NP)`. -/
-def john_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex "John" NP) S
+/-- The type-raised subject "John", `S/(S\NP)` — a lexical leaf, since type-raising
+is morpholexical in the modern theory ([steedman-2019]; the book's syntactic `>T`
+yields the same category). -/
+def john_tr : Derivation Atom (S / (S \ NP)) := .lex "John" (S / (S \ NP))
 
 /-- "John likes": the type-raised subject composed with the transitive verb — a
 constituent of category `S/NP`. -/
-def john_likes : Derivation Atom (S / NP) := .fcomp john_tr (.lex "likes" TV)
+def john_likes : Derivation Atom (S / NP) := .fcomp (by decide) john_tr (.lex "likes" TV)
 
-def mary_tr : Derivation Atom (S / (S \ NP)) := .ftr (.lex "Mary" NP) S
-def mary_hates : Derivation Atom (S / NP) := .fcomp mary_tr (.lex "hates" TV)
+def mary_tr : Derivation Atom (S / (S \ NP)) := .lex "Mary" (S / (S \ NP))
+def mary_hates : Derivation Atom (S / NP) := .fcomp (by decide) mary_tr (.lex "hates" TV)
 
-/-- "John likes and Mary hates": coordination of two `S/NP` constituents. -/
+/-- The lexical conjunction category coordinating constituents of category `c`:
+`(X \⋆ X) /⋆ X`, whose `star` slashes confine it to application ([steedman-2019]). -/
+def conj (c : Cat Atom) : Cat Atom := (c \⋆ c) /⋆ c
+
+/-- "John likes and Mary hates": coordination of two `S/NP` constituents via the
+lexical conjunction — "and" is an ordinary leaf, not a rule. -/
 def john_likes_and_mary_hates : Derivation Atom (S / NP) :=
-  .coord English.Coordination.and_ john_likes mary_hates
+  .bapp john_likes (.fapp (.lex "and" (conj (S / NP))) mary_hates)
 
 def john_likes_and_mary_hates_beans : Derivation Atom S :=
   .fapp john_likes_and_mary_hates (.lex "beans" NP)
@@ -89,13 +96,12 @@ theorem john_likes_and_mary_hates_beans_yield :
       = ["John", "likes", "and", "Mary", "hates", "beans"] := rfl
 
 def john_sleeps_and_mary_sleeps : Derivation Atom S :=
-  .coord English.Coordination.and_
-    (.bapp (.lex "John" NP) (.lex "sleeps" IV))
-    (.bapp (.lex "Mary" NP) (.lex "sleeps" IV))
+  .bapp (.bapp (.lex "John" NP) (.lex "sleeps" IV))
+    (.fapp (.lex "and" (conj S)) (.bapp (.lex "Mary" NP) (.lex "sleeps" IV)))
 
 example : john_sleeps.opCount = 1 := rfl
-example : john_sleeps_and_mary_sleeps.opCount = 3 := rfl
-example : john_likes_and_mary_hates_beans.opCount = 6 := rfl
+example : john_sleeps_and_mary_sleeps.opCount = 4 := rfl
+example : john_likes_and_mary_hates_beans.opCount = 5 := rfl
 
 /-- Non-constituent coordination requires more combinatory operations than
 standard coordination. Reading operation count as processing difficulty is
@@ -115,12 +121,28 @@ def toySemLexicon : SemLexicon ToyEntity Unit := λ word cat =>
   | "John", .atom .NP => some ToyEntity.john
   | "Mary", .atom .NP => some ToyEntity.mary
   | "beans", .atom .NP => some ToyEntity.pizza
-  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.sleeps_sem
-  | "laughs", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.laughs_sem
-  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
-  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.eats_sem
-  | "likes", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
-  | "hates", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
+  -- morpholexically raised subjects ([steedman-2019]): `T` applied in the lexicon
+  | "John", .rslash (.atom .S) _ (.lslash (.atom .S) _ (.atom .NP)) =>
+      some (T ToyEntity.john)
+  | "Mary", .rslash (.atom .S) _ (.lslash (.atom .S) _ (.atom .NP)) =>
+      some (T ToyEntity.mary)
+  | "sleeps", .lslash (.atom .S) _ (.atom .NP) => some ToyLexicon.sleeps_sem
+  | "laughs", .lslash (.atom .S) _ (.atom .NP) => some ToyLexicon.laughs_sem
+  | "sees", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.sees_sem
+  | "eats", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.eats_sem
+  | "likes", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.sees_sem
+  | "hates", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.sees_sem
+  -- sentential conjunction, a lexical entry
+  | "and", .rslash (.lslash (.atom .S) _ (.atom .S)) _ (.atom .S) =>
+      some (fun q p => p ∧ q)
+  -- generalized conjunction at `S/NP` ([partee-rooth-1983]), a lexical entry
+  | "and", .rslash (.lslash (.rslash (.atom .S) _ (.atom .NP)) _
+        (.rslash (.atom .S) _ (.atom .NP))) _ (.rslash (.atom .S) _ (.atom .NP)) =>
+      some (fun q p x => p x ∧ q x)
   | _, _ => none
 
 theorem interp_john_sleeps :
@@ -169,9 +191,9 @@ theorem interp_john_likes_and_mary_hates_beans :
 
 /-- The spelled-out paraphrase "John likes beans and Mary hates beans". -/
 def john_likes_beans_and_mary_hates_beans : Derivation Atom S :=
-  .coord English.Coordination.and_
-    (.bapp (.lex "John" NP) (.fapp (.lex "likes" TV) (.lex "beans" NP)))
-    (.bapp (.lex "Mary" NP) (.fapp (.lex "hates" TV) (.lex "beans" NP)))
+  .bapp (.bapp (.lex "John" NP) (.fapp (.lex "likes" TV) (.lex "beans" NP)))
+    (.fapp (.lex "and" (conj S))
+      (.bapp (.lex "Mary" NP) (.fapp (.lex "hates" TV) (.lex "beans" NP))))
 
 /-- The non-constituent coordination and its spelled-out paraphrase receive
 the same truth conditions — the book's claim that the composed derivation
@@ -195,6 +217,14 @@ private def pqLex : SemLexicon Unit Unit := fun w c =>
   match w, c with
   | "p", .atom .S => some True
   | "q", .atom .S => some False
+  -- the coordinators' meanings are `Coordinator.op` of the English fragment's roles,
+  -- instantiated at `Prop` — the marking's `role` selects the Boolean operation
+  | "and", .rslash (.lslash (.atom .S) _ (.atom .S)) _ (.atom .S) =>
+      some (show Prop → Prop → Prop from
+        fun q p => Coordinator.op English.Coordination.and_.role p q)
+  | "or", .rslash (.lslash (.atom .S) _ (.atom .S)) _ (.atom .S) =>
+      some (show Prop → Prop → Prop from
+        fun q p => Coordinator.op English.Coordination.or_.role p q)
   | _, _ => none
 
 private def dp : Derivation Atom S := .lex "p" S
@@ -204,11 +234,11 @@ private def dq : Derivation Atom S := .lex "q" S
     `or_` yields `p ∨ q`, and these differ at `p = ⊤`, `q = ⊥`. Flipping a fragment
     coordinator's `role` collapses the inequality, so the `role` marking is not decorative. -/
 theorem coord_role_load_bearing :
-    (Derivation.coord English.Coordination.and_ dp dq).interp pqLex ≠
-    (Derivation.coord English.Coordination.or_ dp dq).interp pqLex := by
-  have hand : (Derivation.coord English.Coordination.and_ dp dq).interp pqLex
+    (Derivation.bapp dp (.fapp (.lex "and" (conj S)) dq)).interp pqLex ≠
+    (Derivation.bapp dp (.fapp (.lex "or" (conj S)) dq)).interp pqLex := by
+  have hand : (Derivation.bapp dp (.fapp (.lex "and" (conj S)) dq)).interp pqLex
       = some (True ∧ False) := rfl
-  have hor : (Derivation.coord English.Coordination.or_ dp dq).interp pqLex
+  have hor : (Derivation.bapp dp (.fapp (.lex "or" (conj S)) dq)).interp pqLex
       = some (True ∨ False) := rfl
   rw [hand, hor, ne_eq, Option.some.injEq, eq_iff_iff]
   exact fun h => (h.mpr (Or.inl trivial)).2
@@ -232,7 +262,8 @@ backward type-raising both remnants and backward-composing them yields
 `S\((S/NP)/NP)` — a leftward-looking function over VSO-style transitive verbs, which
 is why forward gapping leaves the verb to the left. Deriving it is typechecking. -/
 def gappedConjunct : Derivation Atom (S \ ((S / NP) / NP)) :=
-  .bcomp (.btr (.lex "Warren" NP) (S / NP)) (.btr (.lex "potatoes" NP) S)
+  .bcomp (by decide) (.lex "Warren" ((S / NP) \ ((S / NP) / NP)))
+    (.lex "potatoes" (S \ (S / NP)))
 
 theorem gappedConjunct_yield : gappedConjunct.yield = ["Warren", "potatoes"] := rfl
 
@@ -240,7 +271,8 @@ theorem gappedConjunct_yield : gappedConjunct.yield = ["Warren", "potatoes"] := 
 type-raising and forward composition yield `S/((S\NP)\NP)`, a rightward-looking
 function over SOV transitive verbs — the verb must follow. -/
 def backwardGappedConjunct : Derivation Atom (S / ((S \ NP) \ NP)) :=
-  .fcomp (.ftr (.lex "Ken-ga" NP) S) (.ftr (.lex "Naomi-o" NP) (S \ NP))
+  .fcomp (by decide) (.lex "Ken-ga" (S / (S \ NP)))
+    (.lex "Naomi-o" ((S \ NP) / ((S \ NP) \ NP)))
 
 theorem backwardGappedConjunct_yield :
     backwardGappedConjunct.yield = ["Ken-ga", "Naomi-o"] := rfl
@@ -248,7 +280,7 @@ theorem backwardGappedConjunct_yield :
 /-- Stripping ("Dexter ran away, and Warren (too)") is the single-remnant case: one
 backward-raised subject, `S\(S/NP)`. -/
 def strippedConjunct : Derivation Atom (S \ (S / NP)) :=
-  .btr (.lex "Warren" NP) S
+  .lex "Warren" (S \ (S / NP))
 
 /-- Basic word order of a transitive clause (S = subject, V = verb,
 O = object). -/
@@ -666,7 +698,7 @@ inductive VerbOrder where
 forms by crossed composition before taking the object to its left. -/
 def verbRaisingDeriv : Derivation Atom IV :=
   .bapp (.lex "veel liederen" NP)
-    (.fcompx (.lex "probeert" (IV / IV)) (.lex "te zingen" (IV \ NP)))
+    (.fcompx (by decide) (.lex "probeert" (IV / IV)) (.lex "te zingen" (IV \ NP)))
 
 /-- Verb-projection-raising order, Dutch (99b): the matrix verb applies to
 an already-saturated embedded VP, so the quantified object never combines
@@ -683,16 +715,14 @@ def schematicDeriv : VerbOrder → Derivation Atom IV
 theorem verbRaisingDeriv_hasComp : verbRaisingDeriv.HasComp := by decide
 
 theorem verbProjectionRaisingDeriv_applicationOnly :
-    ¬verbProjectionRaisingDeriv.HasComp ∧ ¬verbProjectionRaisingDeriv.HasTypeRaise := by
-  decide
+    ¬verbProjectionRaisingDeriv.HasComp := by decide
 
 /-- Scope availability as CCG predicts it — the account's linking hypothesis: a
 cluster built with composition or type-raising is scope-ambiguous, an
 application-only cluster surface-only. [steedman-2000] notes this overgenerates as
 stated (§4.4 refines it). -/
 def predictedAvailability (vo : VerbOrder) : BinaryScopeAvailability :=
-  if (schematicDeriv vo).HasComp ∨ (schematicDeriv vo).HasTypeRaise then .ambiguous
-  else .surfaceOnly
+  if (schematicDeriv vo).HasComp then .ambiguous else .surfaceOnly
 
 /-- Read the §6.8 word-order classification off an example's
 `paperFeatures`. -/
@@ -751,7 +781,7 @@ def annaMannyAccents : AccentAssignment := fun w =>
 
 /-- "ANNA married": the composed theme constituent, category `S/NP`. -/
 def anna_married : Derivation Atom (S / NP) :=
-  .fcomp (.ftr (.lex "Anna" NP) S) (.lex "married" TV)
+  .fcomp (by decide) (.lex "Anna" (S / (S \ NP))) (.lex "married" TV)
 
 /-- The theme constituent projects `θ`: the theme accent on "Anna" unifies with
 unaccented "married". -/
@@ -826,12 +856,15 @@ def extendedLexicon : SemLexicon ToyEntity Unit := λ word cat =>
   | "pizza", .atom .NP => some ToyEntity.pizza
   | "book", .atom .NP => some ToyEntity.book
   -- Intransitive verbs
-  | "sleeps", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.sleeps_sem
-  | "laughs", .lslash (.atom .S) (.atom .NP) => some ToyLexicon.laughs_sem
+  | "sleeps", .lslash (.atom .S) _ (.atom .NP) => some ToyLexicon.sleeps_sem
+  | "laughs", .lslash (.atom .S) _ (.atom .NP) => some ToyLexicon.laughs_sem
   -- Transitive verbs
-  | "sees", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.sees_sem
-  | "eats", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.eats_sem
-  | "reads", .rslash (.lslash (.atom .S) (.atom .NP)) (.atom .NP) => some ToyLexicon.reads_sem
+  | "sees", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.sees_sem
+  | "eats", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.eats_sem
+  | "reads", .rslash (.lslash (.atom .S) _ (.atom .NP)) _ (.atom .NP) =>
+      some ToyLexicon.reads_sem
   | _, _ => none
 
 /-- Get meaning (as Prop) from CCG derivation -/

--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -1,45 +1,97 @@
 import Linglib.Syntax.Category.Coordinator
+import Mathlib.Order.Bounds.Defs
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Combinatory Categorial Grammar (CCG)
 
-This file defines Combinatory Categorial Grammar (CCG): categories that encode
-argument structure through directional slashes, the combinatory rule schema that
-combines them, and intrinsically typed derivations ([steedman-2000]).
+This file defines Combinatory Categorial Grammar in its modern form
+([steedman-2019]): categories whose directional slashes carry Baldridge modalities
+([baldridge-2002]), the combinatory rules gated by those modalities, and
+intrinsically typed derivations.
 
 Categories are stated over an arbitrary type `α` of atomic categories, so a grammar
-needing featured atoms (e.g. [steedman-2000]'s `S₊SUB` and `VP₋SUB` for Dutch) can
-instantiate a richer inventory than the featureless core `CCG.Atom`.
+needing featured atoms (agreement, case) can instantiate a richer inventory than the
+featureless core `CCG.Atom`. Each slash carries a `Modality` from the Baldridge
+hierarchy — `dot` (unrestricted), `diamond` (order-preserving), `cross` (permuting),
+`star` (application-only) — ordered by restrictiveness: a rule class indexed `m`
+applies to a functor whose slash has modality `s` iff `s ≤ m`. Application is indexed
+`⊤`, harmonic composition `diamond`, crossing composition `cross`; the lexicon
+controls combinatory potential through the modalities it assigns, which is the modern
+replacement for per-grammar rule restrictions (compare `CCG.TargetRestricted`).
 
-Every binary rule is an instance of one schema, generalized composition of degree `n`:
-degree 0 is application, and at degree ≥ 1 the harmonic and crossed variants differ
-only in the slash directions the schema passes through (the Principle of Inheritance). `Derivation` is intrinsically
-typed — its constructors are the rule instances the toy grammar admits, so a value of
-`Derivation α c` *is* a derivation of category `c` and "derives `S`" is typechecking.
-The target-restricted (VW-CCG) schema derivations live in `CCG.TargetRestricted`.
+Following [steedman-2019], type-raising is *morpholexical* — the work of case
+morphemes, not a syntactic rule — so raised categories enter derivations as lexical
+leaves (`Cat.forwardTypeRaise` builds them), and coordination is likewise lexical:
+a conjunction is an ordinary entry of category `(X \⋆ X) /⋆ X` whose `star` slashes
+confine it to application. Composition stops at second order, the chapter's full
+inventory. The substitution rules and the morphemic slash of [steedman-2019] are not
+modeled.
 
 ## Main definitions
 
-* `Cat`: categories over an atom type `α` — atoms plus directional slashes.
-* `Cat.generalizedForwardComp`, `Cat.generalizedBackwardComp`: generalized
-  composition of degree `n`, the schema every binary rule instantiates.
-* `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: type-raising.
-* `Derivation`: intrinsically typed derivations, indexed by the category they derive;
-  `Derivation.yield` reads off the surface string a derivation spells out,
-  `Derivation.opCount` the number of rule applications, and `Derivation.HasComp` /
-  `Derivation.HasTypeRaise` whether composition / type-raising occurs in the tree.
+* `Modality`: the Baldridge slash modalities, a bounded partial order (`dot = ⊥`,
+  `star = ⊤`, `diamond` and `cross` incomparable).
+* `Cat`: categories over an atom type `α` — atoms plus modality-carrying slashes.
+* `Cat.generalizedForwardComp`, `Cat.generalizedBackwardComp`: the degree-`n`
+  composition schema (modality-blind, for `CCG.TargetRestricted`).
+* `Cat.forwardTypeRaise`, `Cat.backwardTypeRaise`: raised categories, for lexicons.
+* `Derivation`: intrinsically typed derivations over the modern rule inventory —
+  application, first- and second-order composition in harmonic and crossing variants,
+  each gated on the primary slash's modality; `Derivation.yield` reads off the
+  surface string, `Derivation.opCount` the number of rule applications, and
+  `Derivation.HasComp` whether composition occurs.
 
 ## Notation
 
-* `X / Y`: the rightward-looking category `Cat.rslash X Y`.
-* `X \ Y`: the leftward-looking category `Cat.lslash X Y`.
+* `X / Y`, `X \ Y`: slashes with the unrestricted modality `dot` (absence of an
+  annotation means unrestricted, as in [steedman-2019]).
+* `X /⋄ Y`, `X \⋄ Y`, `X /× Y`, `X \× Y`, `X /⋆ Y`, `X \⋆ Y`: slashes with the
+  annotated modality.
 
-Both are scoped to the `CCG` namespace. Because `/` overloads Lean's division,
+All are scoped to the `CCG` namespace. Because `/` overloads Lean's division,
 categories are written fully parenthesized (`(S \ NP) / NP`) rather than relying on
 the Steedman left-to-right reading.
 -/
 
 namespace CCG
+
+/-! ### Slash modalities -/
+
+/-- The Baldridge slash modalities ([baldridge-2002], [steedman-2019]), ordered by
+restrictiveness: a rule class indexed `m` applies to a slash of modality `s` iff
+`s ≤ m`. -/
+inductive Modality where
+  /-- Unrestricted (written as an unannotated slash): combines by any rule. -/
+  | dot
+  /-- Order-preserving `⋄`: licenses application and harmonic composition. -/
+  | diamond
+  /-- Permuting `×`: licenses application and crossing composition. -/
+  | cross
+  /-- `⋆`: licenses application only. -/
+  | star
+  deriving DecidableEq, Repr, Fintype
+
+namespace Modality
+
+instance : LE Modality where
+  le a b := a = dot ∨ a = b ∨ b = star
+
+instance : DecidableLE Modality := fun _ _ =>
+  decidable_of_iff (_ = dot ∨ _ = _ ∨ _ = star) Iff.rfl
+
+instance : PartialOrder Modality where
+  le_refl _ := Or.inr (Or.inl rfl)
+  le_trans := by decide
+  le_antisymm := by decide
+
+instance : BoundedOrder Modality where
+  top := star
+  le_top _ := Or.inr (Or.inr rfl)
+  bot := dot
+  bot_le _ := Or.inl rfl
+
+end Modality
 
 /-! ### Categories -/
 
@@ -56,18 +108,25 @@ inductive Atom where
   | PP
   deriving Repr, DecidableEq
 
-/-- CCG categories over a type `α` of atomic categories. -/
+/-- CCG categories over a type `α` of atomic categories: atoms plus directional
+slashes, each carrying a `Modality`. -/
 inductive Cat (α : Type*) where
   /-- An atomic category. -/
   | atom : α → Cat α
-  /-- `X/Y`: looking right for a `Y` to give an `X`. -/
-  | rslash : Cat α → Cat α → Cat α
-  /-- `X\Y`: looking left for a `Y` to give an `X`. -/
-  | lslash : Cat α → Cat α → Cat α
+  /-- `X/ₘY`: looking right for a `Y` to give an `X`, at modality `m`. -/
+  | rslash : Cat α → Modality → Cat α → Cat α
+  /-- `X\ₘY`: looking left for a `Y` to give an `X`, at modality `m`. -/
+  | lslash : Cat α → Modality → Cat α → Cat α
   deriving Repr, DecidableEq
 
-scoped notation:60 X "/" Y => Cat.rslash X Y
-scoped notation:60 X "\\" Y => Cat.lslash X Y
+scoped notation:60 X "/" Y => Cat.rslash X Modality.dot Y
+scoped notation:60 X "\\" Y => Cat.lslash X Modality.dot Y
+scoped notation:60 X "/⋄" Y => Cat.rslash X Modality.diamond Y
+scoped notation:60 X "\\⋄" Y => Cat.lslash X Modality.diamond Y
+scoped notation:60 X "/×" Y => Cat.rslash X Modality.cross Y
+scoped notation:60 X "\\×" Y => Cat.lslash X Modality.cross Y
+scoped notation:60 X "/⋆" Y => Cat.rslash X Modality.star Y
+scoped notation:60 X "\\⋆" Y => Cat.lslash X Modality.star Y
 
 def S : Cat Atom := .atom .S
 def NP : Cat Atom := .atom .NP
@@ -86,142 +145,194 @@ namespace Cat
 
 /-- `generalizedForwardComp n f g` is forward composition of degree `n` (`>Bⁿ`): when
 `f = X/Y` and `g = Y|Z₁…|Zₙ`, the result is `X|Z₁…|Zₙ` with each argument keeping its
-own slash direction, and `none` otherwise. -/
+own slash direction and modality, and `none` otherwise. Modality-blind — the schema
+of `CCG.TargetRestricted`, where rule control is per-grammar rather than lexical. -/
 def generalizedForwardComp : Nat → Cat α → Cat α → Option (Cat α)
-  | 0, .rslash x y, z => if y = z then some x else none
-  | n + 1, f, .rslash g z => (generalizedForwardComp n f g).map (Cat.rslash · z)
-  | n + 1, f, .lslash g z => (generalizedForwardComp n f g).map (Cat.lslash · z)
+  | 0, .rslash x _ y, z => if y = z then some x else none
+  | n + 1, f, .rslash g m z => (generalizedForwardComp n f g).map (Cat.rslash · m z)
+  | n + 1, f, .lslash g m z => (generalizedForwardComp n f g).map (Cat.lslash · m z)
   | _, _, _ => none
 
 /-- `generalizedBackwardComp n g f` is backward composition of degree `n` (`<Bⁿ`), the
 mirror of `generalizedForwardComp`: when `g = Y|Z₁…|Zₙ` and `f = X\Y`, the result is
 `X|Z₁…|Zₙ`, and `none` otherwise. -/
 def generalizedBackwardComp : Nat → Cat α → Cat α → Option (Cat α)
-  | 0, z, .lslash x y => if y = z then some x else none
-  | n + 1, .rslash g z, f => (generalizedBackwardComp n g f).map (Cat.rslash · z)
-  | n + 1, .lslash g z, f => (generalizedBackwardComp n g f).map (Cat.lslash · z)
+  | 0, z, .lslash x _ y => if y = z then some x else none
+  | n + 1, .rslash g m z, f => (generalizedBackwardComp n g f).map (Cat.rslash · m z)
+  | n + 1, .lslash g m z, f => (generalizedBackwardComp n g f).map (Cat.lslash · m z)
   | _, _, _ => none
 
-/-! ### Type-raising -/
+/-! ### Type-raising
 
-/-- `forwardTypeRaise x t` is `t / (t \ x)` — forward type-raising `>T` of `x` to
-target `t`. -/
+Type-raising is morpholexical in [steedman-2019] — the work of case morphemes rather
+than a syntactic rule — so these build the *categories* raised lexical entries carry;
+there is no corresponding `Derivation` constructor. -/
+
+/-- `forwardTypeRaise x t` is `t / (t \ x)` — the forward-raised (`>T`) category of
+`x` at target `t`. -/
 def forwardTypeRaise (x : Cat α) (t : Cat α) : Cat α :=
   t / (t \ x)
 
-/-- `backwardTypeRaise x t` is `t \ (t / x)` — backward type-raising `<T` of `x` to
-target `t`. -/
+/-- `backwardTypeRaise x t` is `t \ (t / x)` — the backward-raised (`<T`) category of
+`x` at target `t`. -/
 def backwardTypeRaise (x : Cat α) (t : Cat α) : Cat α :=
   t \ (t / x)
 
 end Cat
 
-/-! ### Derivations -/
+/-! ### Rules and derivations
 
-/-- A CCG derivation of category `c`, intrinsically typed: each constructor is one of
-the toy grammar's rule instances, so a value of `Derivation α c` *is* a well-formed
-derivation and "derives `c`" is typechecking. Backward crossed composition and the
-substitution rules of [steedman-2000] are not part of this inventory. -/
+The Combinatory Projection Principle ([steedman-2019]): syntactic combinatory rules
+are *binary*, linearly ordered, type-dependent rules applying to string-adjacent
+categories. `Rule` is the modern rule inventory as an indexed family — application,
+first- and second-order composition in harmonic and crossing variants, each gated on
+the primary functor's slash modality — and `Derivation` therefore needs exactly one
+binary `node` constructor. Type-raising and coordination are lexical, so they
+contribute leaves rather than rules; the substitution rules are not modeled. -/
+
+/-- `Rule α l r c`: a binary combinatory rule instance combining a left constituent of
+category `l` with a right constituent of category `r` to give `c`. Harmonic rules
+require the primary slash's modality `≤ diamond`, crossing rules `≤ cross`;
+application admits every modality. -/
+inductive Rule (α : Type*) : Cat α → Cat α → Cat α → Type _ where
+  /-- Forward application `>`: X/Y Y ⇒ X. -/
+  | fapp {x y : Cat α} {m : Modality} : Rule α (.rslash x m y) y x
+  /-- Backward application `<`: Y X\Y ⇒ X. -/
+  | bapp {x y : Cat α} {m : Modality} : Rule α y (.lslash x m y) x
+  /-- Forward harmonic composition `>B`: X/⋄Y Y/Z ⇒ X/Z. -/
+  | fcomp {x y z : Cat α} {m n : Modality} (h : m ≤ Modality.diamond) :
+      Rule α (.rslash x m y) (.rslash y n z) (.rslash x n z)
+  /-- Backward harmonic composition `<B`: Y\Z X\⋄Y ⇒ X\Z. -/
+  | bcomp {x y z : Cat α} {m n : Modality} (h : m ≤ Modality.diamond) :
+      Rule α (.lslash y n z) (.lslash x m y) (.lslash x n z)
+  /-- Forward crossing composition `>B×`: X/×Y Y\Z ⇒ X\Z. -/
+  | fcompx {x y z : Cat α} {m n : Modality} (h : m ≤ Modality.cross) :
+      Rule α (.rslash x m y) (.lslash y n z) (.lslash x n z)
+  /-- Backward crossing composition `<B×`: Y/Z X\×Y ⇒ X/Z. -/
+  | bcompx {x y z : Cat α} {m n : Modality} (h : m ≤ Modality.cross) :
+      Rule α (.rslash y n z) (.lslash x m y) (.rslash x n z)
+  /-- Forward second-order composition `>B²`: X/⋄Y (Y/Z)/W ⇒ (X/Z)/W. -/
+  | fcomp2 {x y z w : Cat α} {m n p : Modality} (h : m ≤ Modality.diamond) :
+      Rule α (.rslash x m y) (.rslash (.rslash y n z) p w) (.rslash (.rslash x n z) p w)
+  /-- Backward second-order composition `<B²`: (Y\Z)\W X\⋄Y ⇒ (X\Z)\W. -/
+  | bcomp2 {x y z w : Cat α} {m n p : Modality} (h : m ≤ Modality.diamond) :
+      Rule α (.lslash (.lslash y n z) p w) (.lslash x m y) (.lslash (.lslash x n z) p w)
+  /-- Forward crossing second-order composition `>B²×`: X/×Y (Y\Z)\W ⇒ (X\Z)\W. -/
+  | fcompx2 {x y z w : Cat α} {m n p : Modality} (h : m ≤ Modality.cross) :
+      Rule α (.rslash x m y) (.lslash (.lslash y n z) p w) (.lslash (.lslash x n z) p w)
+  /-- Backward crossing second-order composition `<B²×`: (Y/Z)/W X\×Y ⇒ (X/Z)/W. -/
+  | bcompx2 {x y z w : Cat α} {m n p : Modality} (h : m ≤ Modality.cross) :
+      Rule α (.rslash (.rslash y n z) p w) (.lslash x m y) (.rslash (.rslash x n z) p w)
+
+/-- The rule is a composition (of any order or direction) rather than an application. -/
+def Rule.IsComp {l r c : Cat α} : Rule α l r c → Prop
+  | .fapp => False
+  | .bapp => False
+  | _ => True
+
+instance {l r c : Cat α} : ∀ ru : Rule α l r c, Decidable ru.IsComp
+  | .fapp => isFalse fun h => h
+  | .bapp => isFalse fun h => h
+  | .fcomp _ => isTrue trivial
+  | .bcomp _ => isTrue trivial
+  | .fcompx _ => isTrue trivial
+  | .bcompx _ => isTrue trivial
+  | .fcomp2 _ => isTrue trivial
+  | .bcomp2 _ => isTrue trivial
+  | .fcompx2 _ => isTrue trivial
+  | .bcompx2 _ => isTrue trivial
+
+/-- A CCG derivation of category `c`, intrinsically typed: a lexical leaf, or a
+binary `Rule` node — the Combinatory Projection Principle's binarity, once. A value
+of `Derivation α c` *is* a well-formed derivation, so "derives `c`" is
+typechecking. -/
 inductive Derivation (α : Type*) : Cat α → Type _ where
   /-- A lexical leaf: a surface form, at category `c`. -/
   | lex (form : String) (c : Cat α) : Derivation α c
-  /-- Forward application `>`: X/Y Y ⇒ X. -/
-  | fapp {x y : Cat α} : Derivation α (x / y) → Derivation α y → Derivation α x
-  /-- Backward application `<`: Y X\Y ⇒ X. -/
-  | bapp {x y : Cat α} : Derivation α y → Derivation α (x \ y) → Derivation α x
-  /-- Forward harmonic composition `>B`: X/Y Y/Z ⇒ X/Z. -/
-  | fcomp {x y z : Cat α} :
-      Derivation α (x / y) → Derivation α (y / z) → Derivation α (x / z)
-  /-- Backward harmonic composition `<B`: Y\Z X\Y ⇒ X\Z. -/
-  | bcomp {x y z : Cat α} :
-      Derivation α (y \ z) → Derivation α (x \ y) → Derivation α (x \ z)
-  /-- Forward crossed composition `>B×`: X/Y Y\Z ⇒ X\Z. -/
-  | fcompx {x y z : Cat α} :
-      Derivation α (x / y) → Derivation α (y \ z) → Derivation α (x \ z)
-  /-- Forward type-raising to target `t`: X ⇒ T/(T\X). -/
-  | ftr {x : Cat α} : Derivation α x → (t : Cat α) → Derivation α (t / (t \ x))
-  /-- Backward type-raising to target `t`: X ⇒ T\(T/X). -/
-  | btr {x : Cat α} : Derivation α x → (t : Cat α) → Derivation α (t \ (t / x))
-  /-- Coordination (X c X ⇒ X); identity of the conjunct categories is enforced by the
-      index. Carries the coordinator itself: its `role` fixes the semantic operation
-      (`Derivation.interp`) and its `form` is spelled out in the yield. -/
-  | coord {x : Cat α} : Coordinator → Derivation α x → Derivation α x → Derivation α x
+  /-- A binary rule application. -/
+  | node {l r c : Cat α} :
+      Rule α l r c → Derivation α l → Derivation α r → Derivation α c
 
-/-- The surface string a derivation spells out: its leaf forms and coordinators, left
-to right.
+namespace Derivation
 
-Combinatory rules concatenate their daughters and type-raising leaves the string
-untouched, so the yield is independent of the derivation's combinatory structure —
-the property that lets a CCG derivation witness a string language. -/
+variable {x y z w : Cat α} {m n p : Modality}
+
+/-- Forward application `>`. -/
+abbrev fapp (d₁ : Derivation α (.rslash x m y)) (d₂ : Derivation α y) :
+    Derivation α x := .node .fapp d₁ d₂
+
+/-- Backward application `<`. -/
+abbrev bapp (d₁ : Derivation α y) (d₂ : Derivation α (.lslash x m y)) :
+    Derivation α x := .node .bapp d₁ d₂
+
+/-- Forward harmonic composition `>B`. -/
+abbrev fcomp (h : m ≤ Modality.diamond) (d₁ : Derivation α (.rslash x m y))
+    (d₂ : Derivation α (.rslash y n z)) : Derivation α (.rslash x n z) :=
+  .node (.fcomp h) d₁ d₂
+
+/-- Backward harmonic composition `<B`. -/
+abbrev bcomp (h : m ≤ Modality.diamond) (d₁ : Derivation α (.lslash y n z))
+    (d₂ : Derivation α (.lslash x m y)) : Derivation α (.lslash x n z) :=
+  .node (.bcomp h) d₁ d₂
+
+/-- Forward crossing composition `>B×`. -/
+abbrev fcompx (h : m ≤ Modality.cross) (d₁ : Derivation α (.rslash x m y))
+    (d₂ : Derivation α (.lslash y n z)) : Derivation α (.lslash x n z) :=
+  .node (.fcompx h) d₁ d₂
+
+/-- Backward crossing composition `<B×`. -/
+abbrev bcompx (h : m ≤ Modality.cross) (d₁ : Derivation α (.rslash y n z))
+    (d₂ : Derivation α (.lslash x m y)) : Derivation α (.rslash x n z) :=
+  .node (.bcompx h) d₁ d₂
+
+/-- Forward second-order composition `>B²`. -/
+abbrev fcomp2 (h : m ≤ Modality.diamond) (d₁ : Derivation α (.rslash x m y))
+    (d₂ : Derivation α (.rslash (.rslash y n z) p w)) :
+    Derivation α (.rslash (.rslash x n z) p w) := .node (.fcomp2 h) d₁ d₂
+
+/-- Backward second-order composition `<B²`. -/
+abbrev bcomp2 (h : m ≤ Modality.diamond)
+    (d₁ : Derivation α (.lslash (.lslash y n z) p w))
+    (d₂ : Derivation α (.lslash x m y)) :
+    Derivation α (.lslash (.lslash x n z) p w) := .node (.bcomp2 h) d₁ d₂
+
+/-- Forward crossing second-order composition `>B²×`. -/
+abbrev fcompx2 (h : m ≤ Modality.cross) (d₁ : Derivation α (.rslash x m y))
+    (d₂ : Derivation α (.lslash (.lslash y n z) p w)) :
+    Derivation α (.lslash (.lslash x n z) p w) := .node (.fcompx2 h) d₁ d₂
+
+/-- Backward crossing second-order composition `<B²×`. -/
+abbrev bcompx2 (h : m ≤ Modality.cross)
+    (d₁ : Derivation α (.rslash (.rslash y n z) p w))
+    (d₂ : Derivation α (.lslash x m y)) :
+    Derivation α (.rslash (.rslash x n z) p w) := .node (.bcompx2 h) d₁ d₂
+
+end Derivation
+
+/-- The surface string a derivation spells out: its leaf forms, left to right.
+
+Rule nodes concatenate their daughters, so the yield is independent of the
+derivation's combinatory structure — the property that lets a CCG derivation witness
+a string language. -/
 def Derivation.yield {c : Cat α} : Derivation α c → List String
   | .lex f _ => [f]
-  | .fapp d1 d2 => d1.yield ++ d2.yield
-  | .bapp d1 d2 => d1.yield ++ d2.yield
-  | .fcomp d1 d2 => d1.yield ++ d2.yield
-  | .bcomp d1 d2 => d1.yield ++ d2.yield
-  | .fcompx d1 d2 => d1.yield ++ d2.yield
-  | .ftr d _ => d.yield
-  | .btr d _ => d.yield
-  | .coord co d1 d2 => d1.yield ++ co.form :: d2.yield
+  | .node _ d₁ d₂ => d₁.yield ++ d₂.yield
 
 /-- The number of combinatory rule applications in a derivation. -/
 def Derivation.opCount {c : Cat α} : Derivation α c → Nat
   | .lex _ _ => 0
-  | .fapp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .bapp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .fcomp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .bcomp d1 d2 => 1 + d1.opCount + d2.opCount
-  | .fcompx d1 d2 => 1 + d1.opCount + d2.opCount
-  | .ftr d _ => 1 + d.opCount
-  | .btr d _ => 1 + d.opCount
-  | .coord _ d1 d2 => 1 + d1.opCount + d2.opCount
+  | .node _ d₁ d₂ => 1 + d₁.opCount + d₂.opCount
 
-/-- The derivation contains a composition node (`fcomp`, `bcomp`, or `fcompx`). -/
+/-- The derivation contains a composition node (of any order or direction). -/
 def Derivation.HasComp {c : Cat α} : Derivation α c → Prop
   | .lex _ _ => False
-  | .fapp d1 d2 => d1.HasComp ∨ d2.HasComp
-  | .bapp d1 d2 => d1.HasComp ∨ d2.HasComp
-  | .fcomp _ _ => True
-  | .bcomp _ _ => True
-  | .fcompx _ _ => True
-  | .ftr d _ => d.HasComp
-  | .btr d _ => d.HasComp
-  | .coord _ d1 d2 => d1.HasComp ∨ d2.HasComp
+  | .node ru d₁ d₂ => ru.IsComp ∨ d₁.HasComp ∨ d₂.HasComp
 
 instance Derivation.HasComp.decidable {c : Cat α} :
     ∀ d : Derivation α c, Decidable d.HasComp
   | .lex _ _ => isFalse fun h => h
-  | .fapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .bapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .fcomp _ _ => isTrue trivial
-  | .bcomp _ _ => isTrue trivial
-  | .fcompx _ _ => isTrue trivial
-  | .ftr d _ => decidable d
-  | .btr d _ => decidable d
-  | .coord _ d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-
-/-- The derivation contains a type-raising node (`ftr` or `btr`). -/
-def Derivation.HasTypeRaise {c : Cat α} : Derivation α c → Prop
-  | .lex _ _ => False
-  | .fapp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-  | .bapp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-  | .fcomp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-  | .bcomp d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-  | .fcompx d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-  | .ftr _ _ => True
-  | .btr _ _ => True
-  | .coord _ d1 d2 => d1.HasTypeRaise ∨ d2.HasTypeRaise
-
-instance Derivation.HasTypeRaise.decidable {c : Cat α} :
-    ∀ d : Derivation α c, Decidable d.HasTypeRaise
-  | .lex _ _ => isFalse fun h => h
-  | .fapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .bapp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .fcomp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .bcomp d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .fcompx d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
-  | .ftr _ _ => isTrue trivial
-  | .btr _ _ => isTrue trivial
-  | .coord _ d1 d2 => @instDecidableOr _ _ (decidable d1) (decidable d2)
+  | .node _ d₁ d₂ =>
+      @instDecidableOr _ _ inferInstance
+        (@instDecidableOr _ _ (decidable d₁) (decidable d₂))
 
 end CCG

--- a/Linglib/Syntax/CCG/Interface.lean
+++ b/Linglib/Syntax/CCG/Interface.lean
@@ -8,13 +8,14 @@ import Linglib.Semantics.Composition.Combinator
 # CCG Syntax-Semantics Interface
 
 This file defines the compositional interpretation of CCG derivations. Categories
-encode semantic types (`catToTy`), and because `Derivation` is intrinsically typed,
+encode semantic types (`catToTy`, which ignores slash modalities — they control
+combinatory potential, not meaning), and because `Derivation` is intrinsically typed,
 `Derivation.interp` needs no run-time category checks and no casts: application is
-function application, composition is the `B` combinator, type-raising is the `T`
-combinator, and coordination is generalized conjunction ([partee-rooth-1983],
-[steedman-2000]). A lexicon is well-typed by construction — it returns meanings at
-the queried category — so soundness of the interface is a typing fact rather than a
-theorem.
+function application and every composition rule is a `B`-combinator composition of
+the daughters' meanings ([steedman-2019]). Type-raising and coordination are lexical,
+so their semantic action (`T`, generalized conjunction) enters through the lexicon.
+A lexicon is well-typed by construction — it returns meanings at the queried
+category — so soundness of the interface is a typing fact rather than a theorem.
 
 ## Main definitions
 
@@ -22,8 +23,7 @@ theorem.
 * `SemLexicon`: a semantic lexicon — for each word and category, optionally a meaning
   at that category.
 * `Derivation.interp`: the meaning of a derivation of category `c`, at type
-  `catToTy c`; `none` only when a word is missing from the lexicon or a coordination
-  is at a non-conjoinable type.
+  `catToTy c`; `none` only when a word is missing from the lexicon.
 
 ## Main statements
 
@@ -44,24 +44,25 @@ open Combinator
 
 /-! ### Type correspondence -/
 
-/-- Map CCG categories to semantic types -/
+/-- Map CCG categories to semantic types. Slash modalities are ignored: they control
+combinatory potential, not meaning. -/
 def catToTy : Cat Atom → Ty
   | .atom .S => .t
   | .atom .NP => .e
   | .atom .N => .e ⇒ .t    -- common nouns are properties
   | .atom .PP => .e ⇒ .t   -- PPs are modifiers (simplified)
-  | .rslash x y => catToTy y ⇒ catToTy x
-  | .lslash x y => catToTy y ⇒ catToTy x
+  | .rslash x _ y => catToTy y ⇒ catToTy x
+  | .lslash x _ y => catToTy y ⇒ catToTy x
 
 /-- Forward application preserves semantic typing:
     if X/Y combines with Y to give X, then (σ→τ) applied to σ gives τ. -/
-theorem forward_app_type_preservation (x y : Cat Atom) :
-    catToTy (x.rslash y) = (catToTy y ⇒ catToTy x) := rfl
+theorem forward_app_type_preservation (x y : Cat Atom) (m : Modality) :
+    catToTy (.rslash x m y) = (catToTy y ⇒ catToTy x) := rfl
 
 /-- Backward application preserves semantic typing:
     if Y combines with X\Y to give X, then (σ→τ) applied to σ gives τ. -/
-theorem backward_app_type_preservation (x y : Cat Atom) :
-    catToTy (x.lslash y) = (catToTy y ⇒ catToTy x) := rfl
+theorem backward_app_type_preservation (x y : Cat Atom) (m : Modality) :
+    catToTy (.lslash x m y) = (catToTy y ⇒ catToTy x) := rfl
 
 /-- Type correspondence for transitive verbs -/
 theorem tv_type_is_relation :
@@ -83,51 +84,35 @@ theorem backward_type_raise_type (x t : Cat Atom) :
 /-! ### Derivation interpretation -/
 
 /-- Semantic lexicon: for each word and queried category, optionally a meaning at that
-category — well-typed by construction. -/
+category — well-typed by construction. Raised and coordinating entries carry their
+semantic action here (`T`, generalized conjunction), per the morpholexical treatment
+of [steedman-2019]. -/
 def SemLexicon (E W : Type) := String → (c : Cat Atom) → Option (Denot E W (catToTy c))
 
-/-- Interpret a derivation compositionally: application is function application,
-composition is the `B` combinator, type-raising is the `T` combinator, and
-coordination is `Coordinator.engineOp` of the carried coordinator's `role`
-(generalized conjunction [partee-rooth-1983] at `.j`), restricted to conjoinable
-types. The category bookkeeping is carried by `Derivation`'s index, so no run-time
-category checks (and no casts) are needed; the result is `none` only when a word is
-missing from the lexicon or a coordination is at a non-conjoinable type. -/
+/-- The semantic action of a rule — the "rule-to-rule relation" of [steedman-2019]:
+application applies, every composition rule is a `B`-combinator composition of the
+daughters\' meanings (second-order rules compose under one argument). -/
+def Rule.sem {E W : Type} : {l r c : Cat Atom} → Rule Atom l r c →
+    Denot E W (catToTy l) → Denot E W (catToTy r) → Denot E W (catToTy c)
+  | _, _, _, .fapp, f, a => f a
+  | _, _, _, .bapp, a, f => f a
+  | _, _, _, .fcomp _, f, g => B f g
+  | _, _, _, .bcomp _, g, f => B f g
+  | _, _, _, .fcompx _, f, g => B f g
+  | _, _, _, .bcompx _, g, f => B f g
+  | _, _, _, .fcomp2 _, f, g => fun w z => f (g w z)
+  | _, _, _, .bcomp2 _, g, f => fun w z => f (g w z)
+  | _, _, _, .fcompx2 _, f, g => fun w z => f (g w z)
+  | _, _, _, .bcompx2 _, g, f => fun w z => f (g w z)
+
+/-- Interpret a derivation compositionally: leaves consult the lexicon and each rule
+node acts by its `Rule.sem`. The category bookkeeping is carried by `Derivation`\'s
+index, so no run-time category checks (and no casts) are needed; the result is `none`
+only when a word is missing from the lexicon. -/
 def Derivation.interp {E W : Type} (lex : SemLexicon E W) :
     {c : Cat Atom} → Derivation Atom c → Option (Denot E W (catToTy c))
   | _, .lex f c => lex f c
-  | _, .fapp d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      some (m1 m2)
-  | _, .bapp d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      some (m2 m1)
-  | _, .fcomp d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      some (B m1 m2)
-  | _, .bcomp d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      some (B m2 m1)
-  | _, .fcompx d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      some (B m1 m2)
-  | _, .ftr d _ => do
-      let m ← d.interp lex
-      some (T m)
-  | _, .btr d _ => do
-      let m ← d.interp lex
-      some (T m)
-  | x, .coord co d1 d2 => do
-      let m1 ← d1.interp lex
-      let m2 ← d2.interp lex
-      if (catToTy x).isConjoinable then
-        some (Coordinator.engineOp co.role (catToTy x) E W m1 m2)
-      else none
+  | _, .node ru d₁ d₂ => do some (ru.sem (← d₁.interp lex) (← d₂.interp lex))
 
 /-! ### Spurious ambiguity
 
@@ -142,10 +127,12 @@ one derivation per equivalence class, because reassociating `fcomp`/`fapp` (or
 /-- Reassociating a forward-composition chain preserves interpretation: `B` is
 semantically associative. -/
 theorem Derivation.interp_fcomp_assoc {E W : Type} (lex : SemLexicon E W)
-    {x y z w : Cat Atom} (d₁ : Derivation Atom (x / y)) (d₂ : Derivation Atom (y / z))
-    (d₃ : Derivation Atom (z / w)) :
-    (Derivation.fcomp (.fcomp d₁ d₂) d₃).interp lex
-      = (Derivation.fcomp d₁ (.fcomp d₂ d₃)).interp lex := by
+    {x y z w : Cat Atom} {m n p : Modality}
+    (hm : m ≤ Modality.diamond) (hn : n ≤ Modality.diamond)
+    (d₁ : Derivation Atom (.rslash x m y)) (d₂ : Derivation Atom (.rslash y n z))
+    (d₃ : Derivation Atom (.rslash z p w)) :
+    (Derivation.fcomp hn (.fcomp hm d₁ d₂) d₃).interp lex
+      = (Derivation.fcomp hm d₁ (.fcomp hn d₂ d₃)).interp lex := by
   simp only [Derivation.interp]
   rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
     rcases d₃.interp lex with _ | m₃ <;> rfl
@@ -153,9 +140,10 @@ theorem Derivation.interp_fcomp_assoc {E W : Type} (lex : SemLexicon E W)
 /-- Composing before applying is the same as applying twice: `B f g x = f (g x)`,
 lifted to derivations. -/
 theorem Derivation.interp_fapp_fcomp {E W : Type} (lex : SemLexicon E W)
-    {x y z : Cat Atom} (d₁ : Derivation Atom (x / y)) (d₂ : Derivation Atom (y / z))
+    {x y z : Cat Atom} {m n : Modality} (hm : m ≤ Modality.diamond)
+    (d₁ : Derivation Atom (.rslash x m y)) (d₂ : Derivation Atom (.rslash y n z))
     (d₃ : Derivation Atom z) :
-    (Derivation.fapp (.fcomp d₁ d₂) d₃).interp lex
+    (Derivation.fapp (.fcomp hm d₁ d₂) d₃).interp lex
       = (Derivation.fapp d₁ (.fapp d₂ d₃)).interp lex := by
   simp only [Derivation.interp]
   rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
@@ -164,10 +152,12 @@ theorem Derivation.interp_fapp_fcomp {E W : Type} (lex : SemLexicon E W)
 /-- Reassociating a backward-composition chain preserves interpretation — the mirror
 of `interp_fcomp_assoc`. -/
 theorem Derivation.interp_bcomp_assoc {E W : Type} (lex : SemLexicon E W)
-    {x y z w : Cat Atom} (d₁ : Derivation Atom (y \ z)) (d₂ : Derivation Atom (x \ y))
-    (d₃ : Derivation Atom (w \ x)) :
-    (Derivation.bcomp (.bcomp d₁ d₂) d₃).interp lex
-      = (Derivation.bcomp d₁ (.bcomp d₂ d₃)).interp lex := by
+    {x y z w : Cat Atom} {m n p : Modality}
+    (hm : m ≤ Modality.diamond) (hn : n ≤ Modality.diamond)
+    (d₁ : Derivation Atom (.lslash y p z)) (d₂ : Derivation Atom (.lslash x n y))
+    (d₃ : Derivation Atom (.lslash w m x)) :
+    (Derivation.bcomp hm (.bcomp hn d₁ d₂) d₃).interp lex
+      = (Derivation.bcomp hn d₁ (.bcomp hm d₂ d₃)).interp lex := by
   simp only [Derivation.interp]
   rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
     rcases d₃.interp lex with _ | m₃ <;> rfl
@@ -175,10 +165,11 @@ theorem Derivation.interp_bcomp_assoc {E W : Type} (lex : SemLexicon E W)
 /-- Applying twice is the same as backward-composing first — the mirror of
 `interp_fapp_fcomp`. -/
 theorem Derivation.interp_bapp_bcomp {E W : Type} (lex : SemLexicon E W)
-    {x y w : Cat Atom} (d₁ : Derivation Atom y) (d₂ : Derivation Atom (x \ y))
-    (d₃ : Derivation Atom (w \ x)) :
+    {x y w : Cat Atom} {m n : Modality} (hm : m ≤ Modality.diamond)
+    (d₁ : Derivation Atom y) (d₂ : Derivation Atom (.lslash x n y))
+    (d₃ : Derivation Atom (.lslash w m x)) :
     (Derivation.bapp (.bapp d₁ d₂) d₃).interp lex
-      = (Derivation.bapp d₁ (.bcomp d₂ d₃)).interp lex := by
+      = (Derivation.bapp d₁ (.bcomp hm d₂ d₃)).interp lex := by
   simp only [Derivation.interp]
   rcases d₁.interp lex with _ | m₁ <;> rcases d₂.interp lex with _ | m₂ <;>
     rcases d₃.interp lex with _ | m₃ <;> rfl

--- a/Linglib/Syntax/CCG/Intonation.lean
+++ b/Linglib/Syntax/CCG/Intonation.lean
@@ -140,32 +140,7 @@ and type-raising preserves. `none` on a theme/rheme clash — the prosodic analo
 def _root_.CCG.Derivation.infoFeature (acc : AccentAssignment) :
     {c : Cat Atom} → Derivation Atom c → Option InfoFeature
   | _, .lex f _ => some (accentInfo (acc f))
-  | _, .fapp d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
-  | _, .bapp d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
-  | _, .fcomp d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
-  | _, .bcomp d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
-  | _, .fcompx d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
-  | _, .ftr d _ => d.infoFeature acc
-  | _, .btr d _ => d.infoFeature acc
-  | _, .coord _ d1 d2 => do
-      let i1 ← d1.infoFeature acc
-      let i2 ← d2.infoFeature acc
-      i1.unify i2
+  | _, .node _ d₁ d₂ => do (← d₁.infoFeature acc).unify (← d₂.infoFeature acc)
 
 /-! ### Tunes and prosodic phrases -/
 

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -41,14 +41,16 @@ variable {α : Type*}
 /-- The target of a category: its leftmost atom (strip all arguments). -/
 def target : Cat α → α
   | .atom a => a
-  | .rslash x _ => target x
-  | .lslash x _ => target x
+  | .rslash x _ _ => target x
+  | .lslash x _ _ => target x
 
 @[simp] theorem target_atom (a : α) : target (Cat.atom a) = a := rfl
 
-@[simp] theorem target_rslash (x y : Cat α) : target (Cat.rslash x y) = target x := rfl
+@[simp] theorem target_rslash (x y : Cat α) (m : Modality) :
+    target (Cat.rslash x m y) = target x := rfl
 
-@[simp] theorem target_lslash (x y : Cat α) : target (Cat.lslash x y) = target x := rfl
+@[simp] theorem target_lslash (x y : Cat α) (m : Modality) :
+    target (Cat.lslash x m y) = target x := rfl
 
 /-- A derivation under the rule-restricted degree-`n` composition schema: nodes record
 degree and direction only. -/

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -16728,6 +16728,30 @@
   role      = {foundational},
   sources   = {Syntax/Minimalist/SyntacticObject/Selection.lean}
 }
+@incollection{steedman-2019,
+  author    = {Steedman, Mark},
+  title     = {Combinatory Categorial Grammar},
+  booktitle = {Current Approaches to Syntax: A Comparative Handbook},
+  editor    = {Kert{\'e}sz, Andr{\'a}s and Moravcsik, Edith A. and R{\'a}kosi, Csilla},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  year      = {2019},
+  pages     = {389--420},
+  doi       = {10.1515/9783110540253-014},
+  subfield  = {syntax/ccg},
+  role      = {formalized},
+  sources   = {Syntax/CCG/Basic.lean},
+}
+
+@phdthesis{baldridge-2002,
+  author    = {Baldridge, Jason},
+  title     = {Lexically Specified Derivational Control in Combinatory Categorial Grammar},
+  school    = {University of Edinburgh},
+  year      = {2002},
+  subfield  = {syntax/ccg},
+  role      = {cited},
+}
+
 @book{steedman-2000,
   author    = {Steedman, Mark},
   year      = {2000},


### PR DESCRIPTION
Re-founds the CCG API on the modern statement of the theory ([steedman-2019], the *Current Approaches to Syntax* chapter; verified against the text), replacing the 2000-era design.

- **slash modalities** ([baldridge-2002]): every slash carries a `Modality` from the Baldridge hierarchy — a bounded partial order (`dot = ⊥` unrestricted, `star = ⊤` application-only, `diamond`/`cross` incomparable) where "rule class `m` applies to slash `s`" is `s ≤ m`. This is the modern replacement for per-grammar rule restrictions; notation `X /⋄ Y`, `X \\⋆ Y`, … with the bare slashes defaulting to unrestricted
- **the CPP as structure**: rules are their own indexed family `Rule α l r c` (application + first- and second-order composition in harmonic and crossing variants, modality-gated — the chapter's full inventory, including the previously missing `<B×` and all four `B²` rules), and `Derivation` has exactly one binary `node` — the Combinatory Projection Principle's binarity stated once. `abbrev` smart constructors keep every existing call site; `yield`/`opCount`/`HasComp` collapse to two arms each
- **type-raising is morpholexical** (§3.4): `ftr`/`btr` constructors deleted; raised categories enter as lexical leaves, and the study's raised subjects move into its lexicons (`T` applied lexically)
- **coordination is lexical** (§5.1): `coord` constructor deleted; "and" is an ordinary leaf at `(X \\⋆ X) /⋆ X` whose `star` slashes confine it to application, with the fragment `Coordinator.role`s still load-bearing through the lexicon (`coord_role_load_bearing` survives)
- `Rule.sem` is the chapter's "rule-to-rule relation": `interp` is two arms, and the four spurious-ambiguity theorems restate with modality hypotheses and reprove by the same `rcases <;> rfl`
- bib: verified `steedman-2019` and `baldridge-2002` entries added, bibliography regenerated