### PR TITLE
style(Syntax/CCG): fold observables into Derivation; TargetRestricted docs

### DIFF
--- a/Linglib/Syntax/CCG/Basic.lean
+++ b/Linglib/Syntax/CCG/Basic.lean
@@ -308,32 +308,31 @@ abbrev bcompx2 (h : m ≤ Modality.cross)
     (d₂ : Derivation α (.lslash x m y)) :
     Derivation α (.rslash (.rslash x n z) p w) := .node (.bcompx2 h) d₁ d₂
 
-end Derivation
-
 /-- The surface string a derivation spells out: its leaf forms, left to right.
 
 Rule nodes concatenate their daughters, so the yield is independent of the
 derivation's combinatory structure — the property that lets a CCG derivation witness
 a string language. -/
-def Derivation.yield {c : Cat α} : Derivation α c → List String
+def yield {c : Cat α} : Derivation α c → List String
   | .lex f _ => [f]
   | .node _ d₁ d₂ => d₁.yield ++ d₂.yield
 
 /-- The number of combinatory rule applications in a derivation. -/
-def Derivation.opCount {c : Cat α} : Derivation α c → Nat
+def opCount {c : Cat α} : Derivation α c → Nat
   | .lex _ _ => 0
   | .node _ d₁ d₂ => 1 + d₁.opCount + d₂.opCount
 
 /-- The derivation contains a composition node (of any order or direction). -/
-def Derivation.HasComp {c : Cat α} : Derivation α c → Prop
+def HasComp {c : Cat α} : Derivation α c → Prop
   | .lex _ _ => False
   | .node ru d₁ d₂ => ru.IsComp ∨ d₁.HasComp ∨ d₂.HasComp
 
-instance Derivation.HasComp.decidable {c : Cat α} :
-    ∀ d : Derivation α c, Decidable d.HasComp
+instance HasComp.decidable {c : Cat α} : ∀ d : Derivation α c, Decidable d.HasComp
   | .lex _ _ => isFalse fun h => h
   | .node _ d₁ d₂ =>
       @instDecidableOr _ _ inferInstance
         (@instDecidableOr _ _ (decidable d₁) (decidable d₂))
+
+end Derivation
 
 end CCG

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -5,31 +5,40 @@ import Linglib.Syntax.CCG.Basic
 
 This file defines the target-restricted variant of CCG — the formalism of
 [vijay-shanker-weir-1994] and [weir-joshi-1988], "VW-CCG" in
-[kuhlmann-koller-satta-2015]'s terminology — in which combinatory rules may be
-restricted per grammar. The restriction modelled here is the one
+[kuhlmann-koller-satta-2015]'s terminology — in which combinatory rules are
+restricted per grammar, rather than by the lexicalized slash modalities of the
+modern theory (`Syntax/CCG/Basic`). The restriction modelled is the one
 [kuhlmann-koller-satta-2015]'s generative-capacity results turn on, a *target
 restriction*: a rule fires only when the target of its primary input category (the
-leftmost atom, after stripping all arguments) is a distinguished atom `s`. Their
-equivalence-with-TAG theorem needs it, and without it the power drops strictly below
-TAG.
+leftmost atom, after stripping all arguments) is a distinguished atom `s`.
 
 Rules are the generalized-composition schema `CCG.Cat.generalizedForwardComp` /
-`CCG.Cat.generalizedBackwardComp` of `Syntax/CCG/Basic`, gated on the target. A derivation node records only its degree
-and direction, per the [vijay-shanker-weir-1994] rule form: degree 0 is application,
-and the harmonic/crossed distinction is a consequence of the slash directions rather
-than a separate rule class.
+`CCG.Cat.generalizedBackwardComp`, gated on the target: a derivation node records
+only its degree and direction, per the [vijay-shanker-weir-1994] rule form — degree
+0 is application, and the harmonic/crossed distinction is a consequence of the slash
+directions rather than a separate rule class. The schema is modality-blind (VW-CCG
+predates slash typing); grammars instantiate categories at the unrestricted
+modality.
 
-This substrate makes the CCG≡TAG weak-equivalence — and constructions of CCGs for
-non-context-free languages — expressible. It is distinct from the unrestricted,
-universal-rule CCG of `Syntax/CCG/Basic` (`CCG.Derivation`), which
-[kuhlmann-koller-satta-2015] show is strictly weaker than TAG.
+The two rule-control mechanisms differ in expressive power
+([kuhlmann-koller-satta-2015]): with target restrictions VW-CCG is weakly equivalent
+to TAG, without them it is strictly weaker, and the slash-typing variant is likewise
+slightly less expressive than TAG. This file is the substrate for the equivalence
+side — the constructions of CCGs for non-context-free languages in
+`Studies/KuhlmannKollerSatta2015`.
 
 ## Main definitions
 
 * `CCG.TargetRestricted.target`: the target of a category — its leftmost atom.
-* `CCG.TargetRestricted.Derivation`: a derivation tree whose nodes record degree and
-  direction; `Derivation.cat s` reads off its category under the target restriction
-  to `s`, and `Derivation.yield` its surface string.
+* `CCG.TargetRestricted.Derivation`: a raw derivation tree whose nodes record degree
+  and direction; `Derivation.cat s` reads off its category under the target
+  restriction to `s`, and `Derivation.yield` its surface string.
+
+## Implementation notes
+
+`Derivation` is deliberately extrinsic, in contrast to the intrinsically typed
+`CCG.Derivation`: the generative-capacity results quantify over candidate trees, so
+well-formedness is the proposition `d.cat s = some c` rather than a typing fact.
 -/
 
 namespace CCG.TargetRestricted
@@ -52,8 +61,9 @@ def target : Cat α → α
 @[simp] theorem target_lslash (x y : Cat α) (m : Modality) :
     target (Cat.lslash x m y) = target x := rfl
 
-/-- A derivation under the rule-restricted degree-`n` composition schema: nodes record
-degree and direction only. -/
+/-- A raw derivation tree over the degree-`n` composition schema: nodes record degree
+and direction only; well-formedness under a target restriction is read off by
+`Derivation.cat`. -/
 inductive Derivation (α : Type*) where
   /-- A lexical leaf: a surface form at a category. -/
   | lex : String → Cat α → Derivation α


### PR DESCRIPTION
Two register cleanups.

- `yield`/`opCount`/`HasComp` and the decidability instance move inside the `namespace Derivation` block with bare names, mathlib-style. The `{c : Cat α}` binder stays per-declaration rather than lifting to the `variable` line for a principled reason: these folds recurse at *varying* indices (`d₁ : Derivation α l`), and section variables are fixed across recursive calls.
- `TargetRestricted`'s module docstring was stale post-#1959: it still described `Syntax/CCG/Basic` as "the unrestricted, universal-rule CCG". Rewritten as the two-rule-control-mechanisms contrast (lexical slash modalities vs per-grammar target restrictions) with [kuhlmann-koller-satta-2015]'s expressive-power separation (target-restricted ≡ TAG; without restrictions strictly weaker; the slash-typing variant likewise slightly less expressive), a note that the schema is modality-blind (VW-CCG predates slash typing), and an Implementation notes section recording why this `Derivation` is deliberately extrinsic.