### PR TITLE
feat(Syntax/CCG): Grammar and language — the modern capacity object

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -37,11 +37,11 @@ parameterized over its atoms, so the construction needs no proxy inventory.
 
 ## Implementation notes
 
-These are the *completeness* direction (every target string is generated). The converse
-*soundness* (the target-restricted rules generate *only* count-matched strings) is an
-all-derivations induction not formalised here; with it, relabelling
-`{"a","b","c"} → ThreeSymbol` and `AnBnCn.anbnc_not_contextFree` would establish that the
-grammar's language is itself non-context-free.
+These are the *completeness* direction (`anbncStrings ⊆ exampleGrammar.language`).
+The converse *soundness* (`exampleGrammar.language ⊆ anbncStrings`, an all-derivations
+induction) is stateable over `TargetRestricted.Grammar` but not formalised here; with
+it, relabelling `{"a","b","c"} → ThreeSymbol` and `AnBnCn.anbnc_not_contextFree` would
+establish that the grammar's language is itself non-context-free.
 -/
 
 namespace KuhlmannKollerSatta2015
@@ -69,6 +69,16 @@ abbrev Scat : Cat Atom := .atom .S
 def aLex : TargetRestricted.Derivation Atom := .lex "a" Acat
 /-- `c := C\A`. -/
 def cLex : TargetRestricted.Derivation Atom := .lex "c" (Ccat \ Acat)
+
+/-- The grammar `G₁` of Example 2: the six lexical entries, target restriction and
+start at `S`, degree bound 2 — an instance of the modern capacity object
+([schiffer-maletti-2021]: ε-free, degree at most 2). -/
+def exampleGrammar : TargetRestricted.Grammar Atom where
+  lexicon := [("a", Acat), ("c", Ccat \ Acat),
+              ("b", (Scat / Ccat) / Bcat), ("b", (Bcat / Ccat) / Bcat),
+              ("b", Scat / Ccat), ("b", Bcat / Ccat)]
+  start := .S
+  degree := 2
 
 /-- The cluster category `S/C/…/C` with `n` forward `C`-arguments. -/
 def clusterCat : Nat → Cat Atom
@@ -178,19 +188,42 @@ theorem build_yield {n : Nat} (hn : 1 ≤ n) :
     (build n).yield = List.replicate n "a" ++ List.replicate n "b" ++ List.replicate n "c" := by
   simp [build, peel_yield, clusterDeriv_yield hn, List.append_assoc]
 
+/-! ### Well-formedness over the grammar -/
+
+theorem fc2Chain_wf (j : Nat) : (fc2Chain j).WellFormed exampleGrammar := by
+  induction j with
+  | zero => decide
+  | succ j ih => exact ⟨by decide, ih, by decide⟩
+
+theorem clusterDeriv_wf : ∀ {n : Nat}, 1 ≤ n →
+    (clusterDeriv n).WellFormed exampleGrammar
+  | 1, _ => by decide
+  | n + 2, _ => ⟨by decide, fc2Chain_wf n, by decide⟩
+
+theorem peelStep_wf {d : TargetRestricted.Derivation Atom}
+    (h : d.WellFormed exampleGrammar) : (peelStep d).WellFormed exampleGrammar :=
+  ⟨by decide, by decide, by decide, h, by decide⟩
+
+theorem peel_wf : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom),
+    d.WellFormed exampleGrammar → (peel k d).WellFormed exampleGrammar
+  | 0, _, h => h
+  | k + 1, d, h => peel_wf k (peelStep d) (peelStep_wf h)
+
+theorem build_wf {n : Nat} (hn : 1 ≤ n) : (build n).WellFormed exampleGrammar :=
+  peel_wf n (clusterDeriv n) (clusterDeriv_wf hn)
+
 /-! ### Generative-capacity result -/
 
 /-- The string language `aⁿbⁿcⁿ` (`n ≥ 1`) over `{"a","b","c"}`. -/
 def anbncStrings : Set (List String) :=
   {w | ∃ n, 1 ≤ n ∧ w = List.replicate n "a" ++ List.replicate n "b" ++ List.replicate n "c"}
 
-/-- **The construction generates `aⁿbⁿcⁿ`** ([kuhlmann-koller-satta-2015], Ex. 2):
-every string in the non-context-free language is the yield of a well-formed (target-
-restricted) CCG derivation. This is the completeness half of CCG ⊋ CFG; the language
-`anbnc` it covers is not context-free (`AnBnCn.anbnc_not_contextFree`). -/
-theorem ccg_generates_anbnc (w : List String) (hw : w ∈ anbncStrings) :
-    ∃ d : TargetRestricted.Derivation Atom, d.cat .S = some Scat ∧ d.yield = w := by
-  obtain ⟨n, hn, rfl⟩ := hw
-  exact ⟨build n, build_cat hn, build_yield hn⟩
+/-- **`G₁` generates `aⁿbⁿcⁿ`** ([kuhlmann-koller-satta-2015], Ex. 2): every string
+in the non-context-free language is in the grammar's language. This is the
+completeness half of CCG ⊋ CFG; the language `anbnc` it covers is not context-free
+(`AnBnCn.anbnc_not_contextFree`). -/
+theorem ccg_generates_anbnc : anbncStrings ⊆ exampleGrammar.language := by
+  rintro w ⟨n, hn, rfl⟩
+  exact ⟨build n, build_wf hn, build_cat hn, build_yield hn⟩
 
 end KuhlmannKollerSatta2015

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.CCG.Basic
+import Mathlib.Data.Set.Defs
 
 /-!
 # Target-restricted CCG
@@ -23,9 +24,13 @@ modality.
 The two rule-control mechanisms differ in expressive power
 ([kuhlmann-koller-satta-2015]): with target restrictions VW-CCG is weakly equivalent
 to TAG, without them it is strictly weaker, and the slash-typing variant is likewise
-slightly less expressive than TAG. This file is the substrate for the equivalence
-side — the constructions of CCGs for non-context-free languages in
-`Studies/KuhlmannKollerSatta2015`.
+slightly less expressive than TAG. [schiffer-maletti-2021] upgrade the equivalence to
+*strong* equivalence (the same tree languages, modulo relabeling) for the modern
+capacity object: CCG without empty-string lexicon entries and with rules of degree at
+most 2 — with unbounded degree the formalism is Turing-complete. `Grammar` is that
+object (yields are token lists, so ε-entries are inexpressible by construction), and
+this file is the substrate for the constructions of CCGs for non-context-free
+languages in `Studies/KuhlmannKollerSatta2015`.
 
 ## Main definitions
 
@@ -33,6 +38,9 @@ side — the constructions of CCGs for non-context-free languages in
 * `CCG.TargetRestricted.Derivation`: a raw derivation tree whose nodes record degree
   and direction; `Derivation.cat s` reads off its category under the target
   restriction to `s`, and `Derivation.yield` its surface string.
+* `CCG.TargetRestricted.Grammar`: the capacity object — a finite lexicon, the
+  distinguished atom, and a degree bound; `Derivation.WellFormed` checks a candidate
+  tree against a grammar and `Grammar.language` is the set of yields it derives.
 
 ## Implementation notes
 
@@ -91,5 +99,46 @@ def Derivation.cat [DecidableEq α] (s : α) : Derivation α → Option (Cat α)
 def Derivation.yield : Derivation α → List String
   | .lex w _ => [w]
   | .fc _ l r | .bc _ l r => l.yield ++ r.yield
+
+/-! ### Grammars and their languages -/
+
+/-- A target-restricted CCG grammar: a finite lexicon, a distinguished atom serving as
+both the target restriction and the start symbol (the [kuhlmann-koller-satta-2015]
+simplification of per-rule restrictions), and a bound on composition degree
+(`degree = 2` in [schiffer-maletti-2021]'s normal form). -/
+structure Grammar (α : Type*) where
+  /-- Lexical entries, pairing a token with a category. -/
+  lexicon : List (String × Cat α)
+  /-- The distinguished atom: rules fire only at this target, and the language
+  collects derivations of this category. -/
+  start : α
+  /-- The bound on composition degree. -/
+  degree : Nat
+
+/-- The derivation draws its leaves from the grammar's lexicon and respects its
+degree bound. Together with `Derivation.cat G.start`, this is derivational
+well-formedness over `G`. -/
+def Derivation.WellFormed (G : Grammar α) : Derivation α → Prop
+  | .lex w c => (w, c) ∈ G.lexicon
+  | .fc n l r => n ≤ G.degree ∧ l.WellFormed G ∧ r.WellFormed G
+  | .bc n l r => n ≤ G.degree ∧ l.WellFormed G ∧ r.WellFormed G
+
+instance Derivation.WellFormed.decidable [DecidableEq α] (G : Grammar α) :
+    ∀ d : Derivation α, Decidable (d.WellFormed G)
+  | .lex w c => inferInstanceAs (Decidable ((w, c) ∈ G.lexicon))
+  | .fc _ l r =>
+      @instDecidableAnd _ _ inferInstance
+        (@instDecidableAnd _ _ (decidable G l) (decidable G r))
+  | .bc _ l r =>
+      @instDecidableAnd _ _ inferInstance
+        (@instDecidableAnd _ _ (decidable G l) (decidable G r))
+
+/-- The string language of a grammar: the yields of well-formed derivations of the
+distinguished atom. Yields are token lists, so empty-string lexical entries are
+inexpressible — the ε-freeness of [schiffer-maletti-2021]'s normal form holds by
+construction. -/
+def Grammar.language [DecidableEq α] (G : Grammar α) : Set (List String) :=
+  { w | ∃ d : Derivation α,
+      d.WellFormed G ∧ d.cat G.start = some (.atom G.start) ∧ d.yield = w }
 
 end CCG.TargetRestricted

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -16752,6 +16752,19 @@
   role      = {cited},
 }
 
+@article{schiffer-maletti-2021,
+  author    = {Schiffer, Lena Katharina and Maletti, Andreas},
+  title     = {Strong Equivalence of {TAG} and {CCG}},
+  journal   = {Transactions of the Association for Computational Linguistics},
+  volume    = {9},
+  pages     = {707--720},
+  year      = {2021},
+  doi       = {10.1162/tacl_a_00393},
+  subfield  = {syntax/ccg},
+  role      = {cited},
+  sources   = {Syntax/CCG/TargetRestricted.lean},
+}
+
 @book{steedman-2000,
   author    = {Steedman, Mark},
   year      = {2000},


### PR DESCRIPTION
Gives `TargetRestricted` the piece the capacity theory was missing: the grammar itself. `Grammar` (finite lexicon, distinguished atom, degree bound) is [schiffer-maletti-2021]'s modern object — their strong-equivalence-with-TAG normal form is ε-free with degree ≤ 2, and ε-freeness holds here by construction since yields are token lists. `Derivation.WellFormed` checks a candidate tree against a grammar (decidable), and `Grammar.language` is the set of yields it derives.

- the KKS study's Example-2 construction now runs over an explicit `exampleGrammar` (the six lexical entries, target `S`, degree 2), with well-formedness lemmas mirroring the category/yield inductions, and completeness restated in its honest form: `anbncStrings ⊆ exampleGrammar.language`
- the soundness half (`language ⊆ anbncStrings`) is now *stateable* — recorded in the study's implementation notes as the remaining induction
- `TargetRestricted`'s docstring records the modern capacity picture: strong equivalence at degree ≤ 2, Turing-completeness at unbounded degree ([schiffer-maletti-2021], verified against the arXiv text; bib entry added)