### PR TITLE
refactor(Syntax/CCG): derivability as an inductive relation

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -25,23 +25,23 @@ parameterized over its atoms, so the construction needs no proxy inventory.
 
 ## Main definitions
 
-- `build` — the `n`-indexed `CCG.TargetRestricted.Derivation` of `aⁿbⁿcⁿ` (cluster of degree-2
-  compositions, peeled to `S` by crossed-composition with `c` and backward-application
-  with `a`).
+- `exampleGrammar` — the grammar `G₁` of Example 2: six lexical entries, target
+  restriction and start at `S`, degree bound 2.
 
 ## Main statements
 
-- `build_cat` — `(build n).cat = some S` for `n ≥ 1`.
-- `build_yield` — `(build n).yield = aⁿbⁿcⁿ`.
-- `ccg_generates_anbnc` — every `aⁿbⁿcⁿ` string is generated.
+- `cluster_derives` — the `b`-cluster: `G₁` derives `bⁿ` at category `S/Cⁿ`.
+- `peel_derives` — peeling: each `C` argument is discharged by crossed-composing a
+  `c` and backward-applying an `a`, wrapping the string as `a … c`.
+- `ccg_generates_anbnc` — `anbncStrings ⊆ exampleGrammar.language`.
 
 ## Implementation notes
 
 These are the *completeness* direction (`anbncStrings ⊆ exampleGrammar.language`).
-The converse *soundness* (`exampleGrammar.language ⊆ anbncStrings`, an all-derivations
-induction) is stateable over `TargetRestricted.Grammar` but not formalised here; with
-it, relabelling `{"a","b","c"} → ThreeSymbol` and `AnBnCn.anbnc_not_contextFree` would
-establish that the grammar's language is itself non-context-free.
+The converse *soundness* (`exampleGrammar.language ⊆ anbncStrings`, an induction on
+`Grammar.Derives`) is stateable but not formalised here; with it, relabelling
+`{"a","b","c"} → ThreeSymbol` and `AnBnCn.anbnc_not_contextFree` would establish that
+the grammar's language is itself non-context-free.
 -/
 
 namespace KuhlmannKollerSatta2015
@@ -63,17 +63,10 @@ abbrev Bcat : Cat Atom := .atom .B
 abbrev Ccat : Cat Atom := .atom .C
 abbrev Scat : Cat Atom := .atom .S
 
-/-! ### The grammar `G₁` of Example 2 -/
-
-/-- `a := A`. -/
-def aLex : TargetRestricted.Derivation Atom := .lex "a" Acat
-/-- `c := C\A`. -/
-def cLex : TargetRestricted.Derivation Atom := .lex "c" (Ccat \ Acat)
-
 /-- The grammar `G₁` of Example 2: the six lexical entries, target restriction and
 start at `S`, degree bound 2 — an instance of the modern capacity object
 ([schiffer-maletti-2021]: ε-free, degree at most 2). -/
-def exampleGrammar : TargetRestricted.Grammar Atom where
+def exampleGrammar : Grammar Atom where
   lexicon := [("a", Acat), ("c", Ccat \ Acat),
               ("b", (Scat / Ccat) / Bcat), ("b", (Bcat / Ccat) / Bcat),
               ("b", Scat / Ccat), ("b", Bcat / Ccat)]
@@ -85,75 +78,38 @@ def clusterCat : Nat → Cat Atom
   | 0 => Scat
   | n + 1 => (clusterCat n) / Ccat
 
-/-- Chain of degree-2 compositions: `b₁ = S/C/B` composed with `j` copies of
-`B/C/B`, giving `S/Cʲ⁺¹/B` and yield `bʲ⁺¹`. -/
-def fc2Chain : Nat → TargetRestricted.Derivation Atom
-  | 0 => .lex "b" ((Scat / Ccat) / Bcat)
-  | j + 1 => .fc 2 (fc2Chain j) (.lex "b" ((Bcat / Ccat) / Bcat))
-
-/-- The `b`-cluster derivation for `n ≥ 1`, with category `clusterCat n`, yield `bⁿ`. -/
-def clusterDeriv : Nat → TargetRestricted.Derivation Atom
-  | 0 => .lex "b" Scat            -- unused (the construction starts at n = 1)
-  | 1 => .lex "b" (Scat / Ccat)
-  | n + 2 => .fc 1 (fc2Chain n) (.lex "b" (Bcat / Ccat))
-
-/-- One peel: crossed-compose with a `c` on the right, then backward-apply an `a` on the
-left — wrapping the yield with `a … c` and removing one `C` argument. -/
-def peelStep (d : TargetRestricted.Derivation Atom) : TargetRestricted.Derivation Atom := .bc 0 aLex (.fc 1 d cLex)
-
-/-- Peel `k` times. -/
-def peel : Nat → TargetRestricted.Derivation Atom → TargetRestricted.Derivation Atom
-  | 0, d => d
-  | k + 1, d => peel k (peelStep d)
-
-/-- The full derivation of `aⁿbⁿcⁿ`. -/
-def build (n : Nat) : TargetRestricted.Derivation Atom := peel n (clusterDeriv n)
-
-/-! ### Target invariant -/
-
 /-- The cluster category always has target `S`. -/
 theorem target_clusterCat (n : Nat) : target (clusterCat n) = Atom.S := by
   induction n with
   | zero => rfl
   | succ n ih => simpa [clusterCat] using ih
 
-/-! ### Category of the construction (completeness, part 1) -/
+/-! ### The construction, as `Derives` inductions -/
 
-/-- The degree-2 chain composes to `S/Cʲ⁺¹/B`. -/
-theorem fc2Chain_cat (j : Nat) :
-    (fc2Chain j).cat .S = some ((clusterCat (j + 1)).rslash .dot Bcat) := by
+/-- Chain of degree-2 compositions: `b₁ = S/C/B` composed with `j` copies of
+`B/C/B` derives `bʲ⁺¹` at `S/Cʲ⁺¹/B`. -/
+theorem fc2Chain_derives (j : Nat) :
+    exampleGrammar.Derives ((clusterCat (j + 1)).rslash .dot Bcat)
+      (List.replicate (j + 1) "b") := by
   induction j with
-  | zero => rfl
+  | zero => exact .lex (by decide)
   | succ j ih =>
-    simp [fc2Chain, TargetRestricted.Derivation.cat, ih, Cat.generalizedForwardComp, target_clusterCat, clusterCat]
+      have h : exampleGrammar.Derives ((clusterCat (j + 2)).rslash .dot Bcat)
+          (List.replicate (j + 1) "b" ++ ["b"]) :=
+        .fc 2 ih (.lex (c := (Bcat / Ccat) / Bcat) (by decide)) (by decide)
+          (by simp [target_clusterCat, exampleGrammar]) rfl
+      simpa [List.replicate_succ'] using h
 
-/-- The cluster derivation has category `clusterCat n` for `n ≥ 1`. -/
-theorem clusterDeriv_cat : ∀ {n : Nat}, 1 ≤ n → (clusterDeriv n).cat .S = some (clusterCat n)
-  | 1, _ => rfl
+/-- The `b`-cluster: `G₁` derives `bⁿ` at category `clusterCat n`, for `n ≥ 1`. -/
+theorem cluster_derives : ∀ {n : Nat}, 1 ≤ n →
+    exampleGrammar.Derives (clusterCat n) (List.replicate n "b")
+  | 1, _ => .lex (by decide)
   | n + 2, _ => by
-    simp [clusterDeriv, TargetRestricted.Derivation.cat, fc2Chain_cat, Cat.generalizedForwardComp, target_clusterCat,
-      clusterCat]
-
-/-- One peel removes one `C` argument from a cluster. -/
-theorem peelStep_cat {d : TargetRestricted.Derivation Atom} {k : Nat}
-    (h : d.cat .S = some (clusterCat (k + 1))) :
-    (peelStep d).cat .S = some (clusterCat k) := by
-  simp [peelStep, TargetRestricted.Derivation.cat, aLex, cLex, h, Cat.generalizedForwardComp, Cat.generalizedBackwardComp, clusterCat,
-    target_clusterCat]
-
-/-- Peeling `k` times turns a `clusterCat k` derivation into one of category `S`. -/
-theorem peel_cat : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom), d.cat .S = some (clusterCat k) →
-    (peel k d).cat .S = some Scat
-  | 0, d, h => by simpa [peel, clusterCat] using h
-  | k + 1, d, h => by
-    simp only [peel]
-    exact peel_cat k (peelStep d) (peelStep_cat h)
-
-/-- **Completeness, category part.** The construction derives `S` for every `n ≥ 1`. -/
-theorem build_cat {n : Nat} (hn : 1 ≤ n) : (build n).cat .S = some Scat :=
-  peel_cat n (clusterDeriv n) (clusterDeriv_cat hn)
-
-/-! ### Yield of the construction (completeness, part 2) -/
+      have h : exampleGrammar.Derives (clusterCat (n + 2))
+          (List.replicate (n + 1) "b" ++ ["b"]) :=
+        .fc 1 (fc2Chain_derives n) (.lex (c := Bcat / Ccat) (by decide)) (by decide)
+          (by simp [target_clusterCat, exampleGrammar]) rfl
+      simpa [List.replicate_succ'] using h
 
 private theorem replicate_cons_comm {α : Type*} (k : Nat) (a : α) (X : List α) :
     List.replicate k a ++ (a :: X) = a :: (List.replicate k a ++ X) := by
@@ -161,56 +117,22 @@ private theorem replicate_cons_comm {α : Type*} (k : Nat) (a : α) (X : List α
   | zero => rfl
   | succ k ih => simp [List.replicate_succ, List.cons_append, ih]
 
-theorem fc2Chain_yield (j : Nat) : (fc2Chain j).yield = List.replicate (j + 1) "b" := by
-  induction j with
-  | zero => rfl
-  | succ j ih => simp [fc2Chain, TargetRestricted.Derivation.yield, ih, List.replicate_succ']
-
-theorem clusterDeriv_yield : ∀ {n : Nat}, 1 ≤ n →
-    (clusterDeriv n).yield = List.replicate n "b"
-  | 1, _ => rfl
-  | n + 2, _ => by simp [clusterDeriv, TargetRestricted.Derivation.yield, fc2Chain_yield, List.replicate_succ']
-
-theorem peel_yield : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom),
-    (peel k d).yield = List.replicate k "a" ++ d.yield ++ List.replicate k "c"
-  | 0, d => by simp [peel]
-  | k + 1, d => by
-    simp only [peel]
-    rw [peel_yield k (peelStep d)]
-    have hy : (peelStep d).yield = "a" :: (d.yield ++ ["c"]) := by
-      simp [peelStep, TargetRestricted.Derivation.yield, aLex, cLex]
-    rw [hy, List.replicate_succ, List.replicate_succ]
-    simp only [List.cons_append, List.append_assoc]
-    exact replicate_cons_comm k "a" _
-
-/-- **Completeness, yield part.** The construction spells out `aⁿbⁿcⁿ`. -/
-theorem build_yield {n : Nat} (hn : 1 ≤ n) :
-    (build n).yield = List.replicate n "a" ++ List.replicate n "b" ++ List.replicate n "c" := by
-  simp [build, peel_yield, clusterDeriv_yield hn, List.append_assoc]
-
-/-! ### Well-formedness over the grammar -/
-
-theorem fc2Chain_wf (j : Nat) : (fc2Chain j).WellFormed exampleGrammar := by
-  induction j with
-  | zero => decide
-  | succ j ih => exact ⟨by decide, ih, by decide⟩
-
-theorem clusterDeriv_wf : ∀ {n : Nat}, 1 ≤ n →
-    (clusterDeriv n).WellFormed exampleGrammar
-  | 1, _ => by decide
-  | n + 2, _ => ⟨by decide, fc2Chain_wf n, by decide⟩
-
-theorem peelStep_wf {d : TargetRestricted.Derivation Atom}
-    (h : d.WellFormed exampleGrammar) : (peelStep d).WellFormed exampleGrammar :=
-  ⟨by decide, by decide, by decide, h, by decide⟩
-
-theorem peel_wf : ∀ (k : Nat) (d : TargetRestricted.Derivation Atom),
-    d.WellFormed exampleGrammar → (peel k d).WellFormed exampleGrammar
-  | 0, _, h => h
-  | k + 1, d, h => peel_wf k (peelStep d) (peelStep_wf h)
-
-theorem build_wf {n : Nat} (hn : 1 ≤ n) : (build n).WellFormed exampleGrammar :=
-  peel_wf n (clusterDeriv n) (clusterDeriv_wf hn)
+/-- Peeling: from a derivation of `w` at `clusterCat k`, crossed-composing a `c` and
+backward-applying an `a` `k` times derives `aᵏ w cᵏ` at `S`. -/
+theorem peel_derives : ∀ (k : Nat) {w : List String},
+    exampleGrammar.Derives (clusterCat k) w →
+    exampleGrammar.Derives Scat
+      (List.replicate k "a" ++ w ++ List.replicate k "c")
+  | 0, w, h => by simpa [clusterCat] using h
+  | k + 1, w, h => by
+      have hstep : exampleGrammar.Derives (clusterCat k) ("a" :: (w ++ ["c"])) :=
+        .bc 0 (.lex (c := Acat) (by decide))
+          (.fc 1 h (.lex (c := Ccat \ Acat) (by decide)) (by decide)
+            (by simp [target_clusterCat, exampleGrammar]) rfl)
+          (by decide) (by simp [target_clusterCat, exampleGrammar]) rfl
+      have hrec := peel_derives k hstep
+      simpa [List.replicate_succ, List.cons_append, List.append_assoc,
+        replicate_cons_comm] using hrec
 
 /-! ### Generative-capacity result -/
 
@@ -224,6 +146,6 @@ completeness half of CCG ⊋ CFG; the language `anbnc` it covers is not context-
 (`AnBnCn.anbnc_not_contextFree`). -/
 theorem ccg_generates_anbnc : anbncStrings ⊆ exampleGrammar.language := by
   rintro w ⟨n, hn, rfl⟩
-  exact ⟨build n, build_wf hn, build_cat hn, build_yield hn⟩
+  exact peel_derives n (cluster_derives hn)
 
 end KuhlmannKollerSatta2015

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -461,15 +461,14 @@ end Gapping
 
 /-! ### Cross-serial dependencies
 
-Dutch verb clusters ([bresnan-etal-1982]) with cross-serial NP-verb bindings, in the
-target-restricted model (every step has primary target `S`, so each is a valid rule
-instance of `CCG.TargetRestricted`). Two constructions are given. The *verb-raising*
-derivations (rightward `/NP` slots, harmonic `B`/`B²`) encode the cross-serial binding
-pattern but their yield does **not** match Dutch surface order (see
-`jan_zag_zwemmen_piet_yield`). The *surface-faithful* derivations (leftward `\NP`
+Dutch verb clusters ([bresnan-etal-1982]) with cross-serial NP-verb bindings, over a
+target-restricted grammar (`dutchGrammar`: every rule fires at primary target `S`).
+Two constructions are given as `Derives` facts — the relation carries category and
+string at once. The *verb-raising* derivations (rightward `/NP` slots, harmonic
+`B`/`B²`) encode the cross-serial binding pattern at a non-Dutch string (see
+`jan_zag_zwemmen_piet_derives`); the *surface-faithful* derivations (leftward `\NP`
 slots, forward crossed composition, following the book's own Dutch fragment — ch. 6;
-appendix summary) get both the binding and the attested word order, so the yield
-matches "Jan Piet (Marie) zag (helpen) zwemmen". -/
+appendix summary) derive the attested "Jan Piet (Marie) zag (helpen) zwemmen". -/
 
 section CrossSerial
 
@@ -480,9 +479,6 @@ open Features (VerbClusterBinding)
 
 /-- Verb phrase (infinitival). -/
 def VP : Cat Atom := S \ NP
-
-/-- Control verb: takes VP, gives VP (e.g. "helpen" in 2-verb clusters). -/
-def ControlV : Cat Atom := VP / VP
 
 /-- Perception verb: `(S\NP)/(S\NP)` (e.g. "zag" = saw). -/
 def PercV : Cat Atom := (S \ NP) / VP
@@ -510,146 +506,122 @@ def PercVSub : Cat Atom := ((S \ NP) \ NP) / VP
 `zien := (VP\NP)/VP₋SUB`). -/
 def InfHeadSub : Cat Atom := (VP \ NP) / VP
 
-/-! ### Lexical entries -/
+/-- The Dutch fragment as a target-restricted grammar: the lexical entries the
+derivations below draw on, target and start `S`, degree bound 2. -/
+def dutchGrammar : TargetRestricted.Grammar Atom where
+  lexicon := [("Jan", NP), ("Piet", NP), ("Marie", NP),
+              ("zag", PercV), ("zag", PercVSub),
+              ("helpen", ControlVR), ("helpen", InfHeadSub),
+              ("zwemmen", VP), ("zwemmen", InfSubj)]
+  start := .S
+  degree := 2
 
-def jan_lex : TargetRestricted.Derivation Atom := .lex "Jan" NP
-def piet_lex : TargetRestricted.Derivation Atom := .lex "Piet" NP
-def marie_lex : TargetRestricted.Derivation Atom := .lex "Marie" NP
-def zag_lex : TargetRestricted.Derivation Atom := .lex "zag" PercV
-/-- `zwemmen` in its verb-raising category `(S\NP)/NP`. -/
-def zwemmen_vr : TargetRestricted.Derivation Atom := .lex "zwemmen" InfSubj
-/-- `helpen` in its verb-raising category `((S\NP)/NP)/(S\NP)`. -/
-def helpen_vr : TargetRestricted.Derivation Atom := .lex "helpen" ControlVR
+/-! ### Lexical entries, as derivability facts -/
 
-/-! ### Derivation: "Jan Piet zag zwemmen" (2 NPs, 2 Vs) -/
+theorem jan_derives : dutchGrammar.Derives NP ["Jan"] := .lex (by decide)
+theorem piet_derives : dutchGrammar.Derives NP ["Piet"] := .lex (by decide)
+theorem marie_derives : dutchGrammar.Derives NP ["Marie"] := .lex (by decide)
+theorem zag_vr_derives : dutchGrammar.Derives PercV ["zag"] := .lex (by decide)
+theorem zwemmen_vr_derives : dutchGrammar.Derives InfSubj ["zwemmen"] := .lex (by decide)
+theorem helpen_vr_derives : dutchGrammar.Derives ControlVR ["helpen"] := .lex (by decide)
+theorem zag_sub_derives : dutchGrammar.Derives PercVSub ["zag"] := .lex (by decide)
+theorem helpen_sub_derives : dutchGrammar.Derives InfHeadSub ["helpen"] := .lex (by decide)
+theorem zwemmen_bare_derives : dutchGrammar.Derives VP ["zwemmen"] := .lex (by decide)
 
-/-- `zag >B zwemmen`: `(S\NP)/(S\NP) ∘ (S\NP)/NP = (S\NP)/NP`. -/
-def zag_comp_zwemmen : TargetRestricted.Derivation Atom := .fc 1 zag_lex zwemmen_vr
-/-- `(zag zwemmen) Piet`: `(S\NP)/NP NP = S\NP`. -/
-def zag_zwemmen_piet : TargetRestricted.Derivation Atom := .fc 0 zag_comp_zwemmen piet_lex
-/-- `Jan (zag zwemmen Piet)`: `NP S\NP = S`. -/
-def jan_zag_zwemmen_piet : TargetRestricted.Derivation Atom := .bc 0 jan_lex zag_zwemmen_piet
+/-! ### Verb-raising derivations
 
-/-! ### Derivation: "Jan Piet Marie zag helpen zwemmen" (3 NPs, 3 Vs)
+`B`/`B²` thread the raised argument slots through the cluster — the cross-serial
+*binding* pattern — but the rightward `/NP` slots spell the arguments out after the
+cluster, so the derived strings do **not** match Dutch surface order. -/
 
-The cross-serial bindings are Jan→zag, Piet→helpen, Marie→zwemmen. `helpen_vr` passes an
-`/NP` slot (for Piet) through while taking its VP complement, so `B`/`B²` thread both
-Piet's and Marie's slots through the cluster into `((S\NP)/NP)/NP`. -/
+/-- `zag >B² (helpen >B zwemmen)`: the cluster is a 3-place predicate
+`((S\NP)/NP)/NP` wanting Jan (`\NP`), Piet (`/NP`) and Marie (`/NP`). -/
+theorem verb_cluster_derives :
+    dutchGrammar.Derives (((S \ NP) / NP) / NP) ["zag", "helpen", "zwemmen"] :=
+  .fc 2 zag_vr_derives
+    (.fc 1 helpen_vr_derives zwemmen_vr_derives (by decide) (by decide) rfl)
+    (by decide) (by decide) rfl
 
-/-- `helpen >B zwemmen`: `((S\NP)/NP)/(S\NP) ∘ (S\NP)/NP = ((S\NP)/NP)/NP`. -/
-def helpen_comp_zwemmen : TargetRestricted.Derivation Atom := .fc 1 helpen_vr zwemmen_vr
-/-- `zag >B² (helpen zwemmen)`: `(S\NP)/(S\NP) ∘² ((S\NP)/NP)/NP = ((S\NP)/NP)/NP`. -/
-def zag_comp2_helpen_zwemmen : TargetRestricted.Derivation Atom := .fc 2 zag_lex helpen_comp_zwemmen
-/-- verb cluster + Marie: `((S\NP)/NP)/NP NP = (S\NP)/NP`. -/
-def verbs_marie : TargetRestricted.Derivation Atom := .fc 0 zag_comp2_helpen_zwemmen marie_lex
-/-- + Piet: `(S\NP)/NP NP = S\NP`. -/
-def verbs_marie_piet : TargetRestricted.Derivation Atom := .fc 0 verbs_marie piet_lex
-/-- + Jan: `NP S\NP = S`. -/
-def jan_piet_marie_zag_helpen_zwemmen_deriv : TargetRestricted.Derivation Atom := .bc 0 jan_lex verbs_marie_piet
-
-/-! ### Verification -/
-
-/-- The 2-NP cross-serial derivation yields category `S` (under the target restriction). -/
-theorem two_np_derives_S : jan_zag_zwemmen_piet.cat .S = some S := by decide
-
-/-- The 3-NP cross-serial derivation yields category `S`, threading three argument slots
-through the verb cluster via `B` and `B²`. -/
-theorem three_np_derives_S :
-    jan_piet_marie_zag_helpen_zwemmen_deriv.cat .S = some S := by decide
-
-/-- The verb cluster composes into `((S\NP)/NP)/NP` — a 3-place predicate wanting Jan
-(`\NP`), Piet (`/NP`) and Marie (`/NP`). -/
-theorem verb_cluster_cat :
-    zag_comp2_helpen_zwemmen.cat .S = some (((S \ NP) / NP) / NP) := by decide
-
-/-- The 2-verb derivation's surface yield.
-
-    **This does not match Dutch surface order** ("Jan Piet zag zwemmen"): the verb-cluster
-    category `(S\NP)/NP` looks rightward for its arguments, so the derivation tree spells
-    out "Jan zag zwemmen Piet". The categories here capture the cross-serial *binding*
-    pattern but not the *linear order*; the surface-faithful derivations below get both. -/
-theorem jan_zag_zwemmen_piet_yield :
-    jan_zag_zwemmen_piet.yield = ["Jan", "zag", "zwemmen", "Piet"] := by decide
+/-- The 2-verb verb-raising derivation derives `S` — at the string
+"Jan zag zwemmen Piet", which is **not** Dutch ("Jan Piet zag zwemmen"): the
+verb-raising categories capture the binding but not the linear order. The
+surface-faithful derivations below get both. -/
+theorem jan_zag_zwemmen_piet_derives :
+    dutchGrammar.Derives S ["Jan", "zag", "zwemmen", "Piet"] :=
+  .bc 0 jan_derives
+    (.fc 0 (.fc 1 zag_vr_derives zwemmen_vr_derives (by decide) (by decide) rfl)
+      piet_derives (by decide) (by decide) rfl)
+    (by decide) (by decide) rfl
 
 /-! ### Surface-faithful derivations (leftward argument categories)
 
-[steedman-2000]'s own analysis (ch. 6; appendix summary of the Dutch
-fragment) gives subordinate-clause cluster verbs *leftward* NP slots and
-composes the cluster by forward **crossed** composition, so the
-NPs precede the whole cluster and the yield is the attested
-"Jan Piet (Marie) zag (helpen) zwemmen". -/
+[steedman-2000]'s own analysis (ch. 6; appendix summary of the Dutch fragment) gives
+subordinate-clause cluster verbs *leftward* NP slots and composes the cluster by
+forward **crossed** composition, so the NPs precede the whole cluster and the derived
+strings are the attested "Jan Piet (Marie) zag (helpen) zwemmen". -/
 
-def zag_sub : TargetRestricted.Derivation Atom := .lex "zag" PercVSub
-def helpen_sub : TargetRestricted.Derivation Atom := .lex "helpen" InfHeadSub
-def zwemmen_bare : TargetRestricted.Derivation Atom := .lex "zwemmen" VP
+/-- The crossed cluster `zag >B× (helpen zwemmen)` is a leftward-seeking 3-place
+predicate. -/
+theorem crossed_cluster_derives :
+    dutchGrammar.Derives (((S \ NP) \ NP) \ NP) ["zag", "helpen", "zwemmen"] :=
+  .fc 1 zag_sub_derives
+    (.fc 0 helpen_sub_derives zwemmen_bare_derives (by decide) (by decide) rfl)
+    (by decide) (by decide) rfl
 
-/-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the
-NPs attach leftward — the 2-verb cluster needs no composition. -/
-def jan_piet_zag_zwemmen_sub : TargetRestricted.Derivation Atom :=
-  .bc 0 jan_lex (.bc 0 piet_lex (.fc 0 zag_sub zwemmen_bare))
+/-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the NPs attach
+leftward — the 2-verb cluster needs no composition, and the string is the attested
+order (contrast `jan_zag_zwemmen_piet_derives`). -/
+theorem two_np_sub_derives :
+    dutchGrammar.Derives S ["Jan", "Piet", "zag", "zwemmen"] :=
+  .bc 0 jan_derives
+    (.bc 0 piet_derives
+      (.fc 0 zag_sub_derives zwemmen_bare_derives (by decide) (by decide) rfl)
+      (by decide) (by decide) rfl)
+    (by decide) (by decide) rfl
 
-/-- "(dat) Jan Piet Marie zag helpen zwemmen": `helpen zwemmen : VP\NP`
-forms by application, `zag >B× (helpen zwemmen)` crosses the rightward
-`/VP` into a leftward-seeking cluster `((S\NP)\NP)\NP`, and the three NPs
-attach leftward — Marie to `helpen`'s slot, Piet to `zag`'s object slot,
-Jan as subject: the cross-serial binding falls out of the category
-threading. -/
-def jan_piet_marie_zag_helpen_zwemmen_sub : TargetRestricted.Derivation Atom :=
-  .bc 0 jan_lex (.bc 0 piet_lex (.bc 0 marie_lex
-    (.fc 1 zag_sub (.fc 0 helpen_sub zwemmen_bare))))
+/-- "(dat) Jan Piet Marie zag helpen zwemmen": the three NPs attach leftward to the
+crossed cluster — Marie to `helpen`'s slot, Piet to `zag`'s object slot, Jan as
+subject: the cross-serial binding falls out of the category threading, in the
+attested word order. -/
+theorem three_np_sub_derives :
+    dutchGrammar.Derives S ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"] :=
+  .bc 0 jan_derives
+    (.bc 0 piet_derives
+      (.bc 0 marie_derives crossed_cluster_derives (by decide) (by decide) rfl)
+      (by decide) (by decide) rfl)
+    (by decide) (by decide) rfl
 
-theorem two_np_sub_derives_S :
-    jan_piet_zag_zwemmen_sub.cat .S = some S := by decide
+/-! ### Binding annotations -/
 
-theorem three_np_sub_derives_S :
-    jan_piet_marie_zag_helpen_zwemmen_sub.cat .S = some S := by decide
-
-/-- The crossed cluster is a leftward-seeking 3-place predicate. -/
-theorem crossed_cluster_cat :
-    (TargetRestricted.Derivation.fc 1 zag_sub (.fc 0 helpen_sub zwemmen_bare)).cat .S
-      = some (((S \ NP) \ NP) \ NP) := by decide
-
-/-- The surface-faithful derivations spell out the attested word order
-(contrast `jan_zag_zwemmen_piet_yield`). -/
-theorem two_np_sub_yield :
-    jan_piet_zag_zwemmen_sub.yield = ["Jan", "Piet", "zag", "zwemmen"] := by
-  decide
-
-theorem three_np_sub_yield :
-    jan_piet_marie_zag_helpen_zwemmen_sub.yield
-      = ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"] := by decide
-
-/-- A CCG derivation annotated with which NP binds to which verb.
-TODO: compute `binding` from `deriv`'s composition structure instead of
-annotating it by hand. -/
+/-- A derived Dutch string annotated with which NP binds to which verb; carrying the
+derivability fact ties the words to the grammar. TODO: compute `binding` from a
+derivation's composition structure instead of annotating it by hand. -/
 structure AnnotatedDerivation where
   /-- Number of NP-verb pairs -/
   n : Nat
-  deriv : CCG.TargetRestricted.Derivation Atom
   /-- Surface words -/
   words : List String
   /-- The NP-verb binding permutation -/
-  binding : VerbClusterBinding n
-  deriving Repr
+  binding : Features.VerbClusterBinding n
+  /-- The grammar derives the words at `S`. -/
+  derives : dutchGrammar.Derives S words
 
 /-- "Jan Piet zag zwemmen" with cross-serial bindings: Jan is the subject
 of "zag", Piet the argument bound into the cluster. -/
 def dutch_jan_piet_zag_zwemmen : AnnotatedDerivation :=
   { n := 2
-  , deriv := jan_piet_zag_zwemmen_sub
   , words := ["Jan", "Piet", "zag", "zwemmen"]
   , binding := VerbClusterBinding.identity 2
+  , derives := two_np_sub_derives
   }
 
-/-- "Jan Piet Marie zag helpen zwemmen": `zag >B× (helpen zwemmen)` makes
-the cluster a leftward-seeking 3-place predicate; Marie binds `helpen`'s
-slot, Piet `zag`'s object slot, Jan the subject — the cross-serial
-binding pattern, in the attested word order. -/
+/-- "Jan Piet Marie zag helpen zwemmen", the cross-serial binding pattern in the
+attested word order. -/
 def dutch_jan_piet_marie_zag_helpen_zwemmen : AnnotatedDerivation :=
   { n := 3
-  , deriv := jan_piet_marie_zag_helpen_zwemmen_sub
   , words := ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"]
   , binding := VerbClusterBinding.identity 3
+  , derives := three_np_sub_derives
   }
 
 /-- The annotated binding agrees with the empirical datum. -/
@@ -658,15 +630,6 @@ theorem dutch_jan_piet_zag_zwemmen_binding :
 
 theorem dutch_jan_piet_marie_zag_helpen_zwemmen_binding :
     dutch_jan_piet_marie_zag_helpen_zwemmen.binding = dutch_3np_3v.binding := rfl
-
-/-- The derivations spell out exactly the annotated surface words. -/
-theorem dutch_jan_piet_zag_zwemmen_yield :
-    dutch_jan_piet_zag_zwemmen.deriv.yield = dutch_jan_piet_zag_zwemmen.words := by
-  decide
-
-theorem dutch_jan_piet_marie_zag_helpen_zwemmen_yield :
-    dutch_jan_piet_marie_zag_helpen_zwemmen.deriv.yield
-      = dutch_jan_piet_marie_zag_helpen_zwemmen.words := by decide
 
 end CrossSerial
 

--- a/Linglib/Syntax/CCG/TargetRestricted.lean
+++ b/Linglib/Syntax/CCG/TargetRestricted.lean
@@ -35,18 +35,18 @@ languages in `Studies/KuhlmannKollerSatta2015`.
 ## Main definitions
 
 * `CCG.TargetRestricted.target`: the target of a category — its leftmost atom.
-* `CCG.TargetRestricted.Derivation`: a raw derivation tree whose nodes record degree
-  and direction; `Derivation.cat s` reads off its category under the target
-  restriction to `s`, and `Derivation.yield` its surface string.
 * `CCG.TargetRestricted.Grammar`: the capacity object — a finite lexicon, the
-  distinguished atom, and a degree bound; `Derivation.WellFormed` checks a candidate
-  tree against a grammar and `Grammar.language` is the set of yields it derives.
+  distinguished atom, and a bound on composition degree.
+* `CCG.TargetRestricted.Grammar.Derives`: the derivability relation — `G.Derives c w`
+  says the grammar derives token string `w` at category `c`; `Grammar.language` is
+  the set of strings derived at the distinguished atom.
 
 ## Implementation notes
 
-`Derivation` is deliberately extrinsic, in contrast to the intrinsically typed
-`CCG.Derivation`: the generative-capacity results quantify over candidate trees, so
-well-formedness is the proposition `d.cat s = some c` rather than a typing fact.
+Derivability is an inductive `Prop`, mathlib's form for grammar formalisms
+(`ContextFreeGrammar.Derives`), in contrast to the intrinsically typed
+`CCG.Derivation` of the interpreted theory: capacity arguments quantify over all
+derivations, and induction on `Derives` is exactly that quantification.
 -/
 
 namespace CCG.TargetRestricted
@@ -69,37 +69,6 @@ def target : Cat α → α
 @[simp] theorem target_lslash (x y : Cat α) (m : Modality) :
     target (Cat.lslash x m y) = target x := rfl
 
-/-- A raw derivation tree over the degree-`n` composition schema: nodes record degree
-and direction only; well-formedness under a target restriction is read off by
-`Derivation.cat`. -/
-inductive Derivation (α : Type*) where
-  /-- A lexical leaf: a surface form at a category. -/
-  | lex : String → Cat α → Derivation α
-  /-- Forward composition of degree `n` (`>Bⁿ`; degree 0 is application). -/
-  | fc : Nat → Derivation α → Derivation α → Derivation α
-  /-- Backward composition of degree `n` (`<Bⁿ`; degree 0 is application). -/
-  | bc : Nat → Derivation α → Derivation α → Derivation α
-  deriving Repr
-
-/-- The category derived under the target restriction to `s`: each rule fires only when
-the target of its primary (functor) input is `s` (`none` otherwise, or if the schema
-does not apply). -/
-def Derivation.cat [DecidableEq α] (s : α) : Derivation α → Option (Cat α)
-  | .lex _ c => some c
-  | .fc n l r => do
-    let a ← l.cat s
-    let b ← r.cat s
-    if target a = s then Cat.generalizedForwardComp n a b else none
-  | .bc n l r => do
-    let a ← l.cat s
-    let b ← r.cat s
-    if target b = s then Cat.generalizedBackwardComp n a b else none
-
-/-- Surface string: leaf forms left to right. -/
-def Derivation.yield : Derivation α → List String
-  | .lex w _ => [w]
-  | .fc _ l r | .bc _ l r => l.yield ++ r.yield
-
 /-! ### Grammars and their languages -/
 
 /-- A target-restricted CCG grammar: a finite lexicon, a distinguished atom serving as
@@ -115,30 +84,29 @@ structure Grammar (α : Type*) where
   /-- The bound on composition degree. -/
   degree : Nat
 
-/-- The derivation draws its leaves from the grammar's lexicon and respects its
-degree bound. Together with `Derivation.cat G.start`, this is derivational
-well-formedness over `G`. -/
-def Derivation.WellFormed (G : Grammar α) : Derivation α → Prop
-  | .lex w c => (w, c) ∈ G.lexicon
-  | .fc n l r => n ≤ G.degree ∧ l.WellFormed G ∧ r.WellFormed G
-  | .bc n l r => n ≤ G.degree ∧ l.WellFormed G ∧ r.WellFormed G
+/-- `G.Derives c w`: the grammar derives token string `w` at category `c` — a lexical
+entry, or a target-gated generalized composition of two adjacent derivations, within
+the grammar's degree bound. Capacity arguments proceed by induction on this
+relation. -/
+inductive Grammar.Derives [DecidableEq α] (G : Grammar α) :
+    Cat α → List String → Prop where
+  /-- A lexical entry derives its token. -/
+  | lex {w : String} {c : Cat α} : (w, c) ∈ G.lexicon → G.Derives c [w]
+  /-- Forward composition of degree `n` (`>Bⁿ`; degree 0 is application), gated on the
+  primary (left) target. -/
+  | fc (n : Nat) {a b c : Cat α} {u v : List String} :
+      G.Derives a u → G.Derives b v → n ≤ G.degree → target a = G.start →
+      Cat.generalizedForwardComp n a b = some c → G.Derives c (u ++ v)
+  /-- Backward composition of degree `n` (`<Bⁿ`; degree 0 is application), gated on the
+  primary (right) target. -/
+  | bc (n : Nat) {a b c : Cat α} {u v : List String} :
+      G.Derives a u → G.Derives b v → n ≤ G.degree → target b = G.start →
+      Cat.generalizedBackwardComp n a b = some c → G.Derives c (u ++ v)
 
-instance Derivation.WellFormed.decidable [DecidableEq α] (G : Grammar α) :
-    ∀ d : Derivation α, Decidable (d.WellFormed G)
-  | .lex w c => inferInstanceAs (Decidable ((w, c) ∈ G.lexicon))
-  | .fc _ l r =>
-      @instDecidableAnd _ _ inferInstance
-        (@instDecidableAnd _ _ (decidable G l) (decidable G r))
-  | .bc _ l r =>
-      @instDecidableAnd _ _ inferInstance
-        (@instDecidableAnd _ _ (decidable G l) (decidable G r))
-
-/-- The string language of a grammar: the yields of well-formed derivations of the
-distinguished atom. Yields are token lists, so empty-string lexical entries are
-inexpressible — the ε-freeness of [schiffer-maletti-2021]'s normal form holds by
-construction. -/
+/-- The string language of a grammar: the token strings derived at the distinguished
+atom. Strings are token lists, so empty-string lexical entries are inexpressible —
+the ε-freeness of [schiffer-maletti-2021]'s normal form holds by construction. -/
 def Grammar.language [DecidableEq α] (G : Grammar α) : Set (List String) :=
-  { w | ∃ d : Derivation α,
-      d.WellFormed G ∧ d.cat G.start = some (.atom G.start) ∧ d.yield = w }
+  { w | G.Derives (.atom G.start) w }
 
 end CCG.TargetRestricted


### PR DESCRIPTION
Replaces `TargetRestricted`'s derivation-tree encoding with mathlib's form for grammar formalisms (`ContextFreeGrammar.Derives`): `Grammar.Derives : Cat α → List String → Prop` — a lexical entry, or a target-gated generalized composition within the degree bound — with `language` as its set at the distinguished atom. The extrinsic `Derivation` type, its `Option`-valued `cat`, `yield`, and the separate `WellFormed` pass were three pieces of what this one relation says; induction on `Derives` *is* the all-derivations induction the pending KKS soundness needs.

- KKS: the three parallel induction families (category, yield, well-formedness) merge into single `Derives` inductions (`fc2Chain_derives`, `cluster_derives`, `peel_derives`), and completeness stays `anbncStrings ⊆ exampleGrammar.language`
- Steedman2000's cross-serial section runs over an explicit `dutchGrammar` (the fragment's nine entries — the lexicon is finally load-bearing): lexical entries become derivability facts, each derivation+category+yield theorem triple becomes one `Derives` statement carrying category and string at once, and `AnnotatedDerivation` ties words to the grammar intrinsically via a `derives` field
- elaboration notes for the record: constructor fields ordered derivations-first so side-condition holes are pinned; secondary-leaf categories pinned by ascribed leaf facts