### PR TITLE
refactor(Syntax/CCG): one Grammar object with rule-system gates

### DIFF
--- a/Linglib/Studies/KuhlmannKollerSatta2015.lean
+++ b/Linglib/Studies/KuhlmannKollerSatta2015.lean
@@ -65,12 +65,12 @@ abbrev Scat : Cat Atom := .atom .S
 /-- The grammar `G₁` of Example 2: the six lexical entries, target restriction and
 start at `S`, degree bound 2 — an instance of the modern capacity object
 ([schiffer-maletti-2021]: ε-free, degree at most 2). -/
-def exampleGrammar : Grammar Atom where
-  lexicon := [("a", Acat), ("c", Ccat \ Acat),
-              ("b", (Scat / Ccat) / Bcat), ("b", (Bcat / Ccat) / Bcat),
-              ("b", Scat / Ccat), ("b", Bcat / Ccat)]
-  start := .S
-  degree := 2
+def exampleGrammar : Grammar Atom :=
+  .targetRestricted
+    [("a", Acat), ("c", Ccat \ Acat),
+     ("b", (Scat / Ccat) / Bcat), ("b", (Bcat / Ccat) / Bcat),
+     ("b", Scat / Ccat), ("b", Bcat / Ccat)]
+    .S 2
 
 /-- The cluster category `S/C/…/C` with `n` forward `C`-arguments. -/
 def clusterCat : Nat → Cat Atom
@@ -95,8 +95,8 @@ theorem fc2Chain_derives (j : Nat) :
   | succ j ih =>
       have h : exampleGrammar.Derives ((clusterCat (j + 2)).rslash .dot Bcat)
           (List.replicate (j + 1) "b" ++ ["b"]) :=
-        .fc 2 ih (.lex (c := (Bcat / Ccat) / Bcat) (by decide)) (by decide)
-          (by simp [target_clusterCat, exampleGrammar]) rfl
+        .fc 2 ih (.lex (c := (Bcat / Ccat) / Bcat) (by decide))
+          ⟨by decide, by simp [target_clusterCat]⟩ rfl
       simpa [List.replicate_succ'] using h
 
 /-- The `b`-cluster: `G₁` derives `bⁿ` at category `clusterCat n`, for `n ≥ 1`. -/
@@ -106,8 +106,8 @@ theorem cluster_derives : ∀ {n : Nat}, 1 ≤ n →
   | n + 2, _ => by
       have h : exampleGrammar.Derives (clusterCat (n + 2))
           (List.replicate (n + 1) "b" ++ ["b"]) :=
-        .fc 1 (fc2Chain_derives n) (.lex (c := Bcat / Ccat) (by decide)) (by decide)
-          (by simp [target_clusterCat, exampleGrammar]) rfl
+        .fc 1 (fc2Chain_derives n) (.lex (c := Bcat / Ccat) (by decide))
+          ⟨by decide, by simp [target_clusterCat]⟩ rfl
       simpa [List.replicate_succ'] using h
 
 private theorem replicate_cons_comm {α : Type*} (k : Nat) (a : α) (X : List α) :
@@ -126,9 +126,9 @@ theorem peel_derives : ∀ (k : Nat) {w : List String},
   | k + 1, w, h => by
       have hstep : exampleGrammar.Derives (clusterCat k) ("a" :: (w ++ ["c"])) :=
         .bc 0 (.lex (c := Acat) (by decide))
-          (.fc 1 h (.lex (c := Ccat \ Acat) (by decide)) (by decide)
-            (by simp [target_clusterCat, exampleGrammar]) rfl)
-          (by decide) (by simp [target_clusterCat, exampleGrammar]) rfl
+          (.fc 1 h (.lex (c := Ccat \ Acat) (by decide))
+            ⟨by decide, by simp [target_clusterCat]⟩ rfl)
+          ⟨by decide, by simp [target_clusterCat]⟩ rfl
       have hrec := peel_derives k hstep
       simpa [List.replicate_succ, List.cons_append, List.append_assoc,
         replicate_cons_comm] using hrec

--- a/Linglib/Studies/Steedman2000.lean
+++ b/Linglib/Studies/Steedman2000.lean
@@ -508,13 +508,13 @@ def InfHeadSub : Cat Atom := (VP \ NP) / VP
 
 /-- The Dutch fragment as a target-restricted grammar: the lexical entries the
 derivations below draw on, target and start `S`, degree bound 2. -/
-def dutchGrammar : Grammar Atom where
-  lexicon := [("Jan", NP), ("Piet", NP), ("Marie", NP),
-              ("zag", PercV), ("zag", PercVSub),
-              ("helpen", ControlVR), ("helpen", InfHeadSub),
-              ("zwemmen", VP), ("zwemmen", InfSubj)]
-  start := .S
-  degree := 2
+def dutchGrammar : Grammar Atom :=
+  .targetRestricted
+    [("Jan", NP), ("Piet", NP), ("Marie", NP),
+     ("zag", PercV), ("zag", PercVSub),
+     ("helpen", ControlVR), ("helpen", InfHeadSub),
+     ("zwemmen", VP), ("zwemmen", InfSubj)]
+    .S 2
 
 /-! ### Lexical entries, as derivability facts -/
 
@@ -539,8 +539,8 @@ cluster, so the derived strings do **not** match Dutch surface order. -/
 theorem verb_cluster_derives :
     dutchGrammar.Derives (((S \ NP) / NP) / NP) ["zag", "helpen", "zwemmen"] :=
   .fc 2 zag_vr_derives
-    (.fc 1 helpen_vr_derives zwemmen_vr_derives (by decide) (by decide) rfl)
-    (by decide) (by decide) rfl
+    (.fc 1 helpen_vr_derives zwemmen_vr_derives ⟨by decide, rfl⟩ rfl)
+    ⟨by decide, rfl⟩ rfl
 
 /-- The 2-verb verb-raising derivation derives `S` — at the string
 "Jan zag zwemmen Piet", which is **not** Dutch ("Jan Piet zag zwemmen"): the
@@ -549,9 +549,9 @@ surface-faithful derivations below get both. -/
 theorem jan_zag_zwemmen_piet_derives :
     dutchGrammar.Derives S ["Jan", "zag", "zwemmen", "Piet"] :=
   .bc 0 jan_derives
-    (.fc 0 (.fc 1 zag_vr_derives zwemmen_vr_derives (by decide) (by decide) rfl)
-      piet_derives (by decide) (by decide) rfl)
-    (by decide) (by decide) rfl
+    (.fc 0 (.fc 1 zag_vr_derives zwemmen_vr_derives ⟨by decide, rfl⟩ rfl)
+      piet_derives ⟨by decide, rfl⟩ rfl)
+    ⟨by decide, rfl⟩ rfl
 
 /-! ### Surface-faithful derivations (leftward argument categories)
 
@@ -565,8 +565,8 @@ predicate. -/
 theorem crossed_cluster_derives :
     dutchGrammar.Derives (((S \ NP) \ NP) \ NP) ["zag", "helpen", "zwemmen"] :=
   .fc 1 zag_sub_derives
-    (.fc 0 helpen_sub_derives zwemmen_bare_derives (by decide) (by decide) rfl)
-    (by decide) (by decide) rfl
+    (.fc 0 helpen_sub_derives zwemmen_bare_derives ⟨by decide, rfl⟩ rfl)
+    ⟨by decide, rfl⟩ rfl
 
 /-- "(dat) Jan Piet zag zwemmen": `zag` applies to bare `zwemmen` and the NPs attach
 leftward — the 2-verb cluster needs no composition, and the string is the attested
@@ -575,9 +575,9 @@ theorem two_np_sub_derives :
     dutchGrammar.Derives S ["Jan", "Piet", "zag", "zwemmen"] :=
   .bc 0 jan_derives
     (.bc 0 piet_derives
-      (.fc 0 zag_sub_derives zwemmen_bare_derives (by decide) (by decide) rfl)
-      (by decide) (by decide) rfl)
-    (by decide) (by decide) rfl
+      (.fc 0 zag_sub_derives zwemmen_bare_derives ⟨by decide, rfl⟩ rfl)
+      ⟨by decide, rfl⟩ rfl)
+    ⟨by decide, rfl⟩ rfl
 
 /-- "(dat) Jan Piet Marie zag helpen zwemmen": the three NPs attach leftward to the
 crossed cluster — Marie to `helpen`'s slot, Piet to `zag`'s object slot, Jan as
@@ -587,9 +587,9 @@ theorem three_np_sub_derives :
     dutchGrammar.Derives S ["Jan", "Piet", "Marie", "zag", "helpen", "zwemmen"] :=
   .bc 0 jan_derives
     (.bc 0 piet_derives
-      (.bc 0 marie_derives crossed_cluster_derives (by decide) (by decide) rfl)
-      (by decide) (by decide) rfl)
-    (by decide) (by decide) rfl
+      (.bc 0 marie_derives crossed_cluster_derives ⟨by decide, rfl⟩ rfl)
+      ⟨by decide, rfl⟩ rfl)
+    ⟨by decide, rfl⟩ rfl
 
 /-! ### Binding annotations -/
 

--- a/Linglib/Syntax/CCG/Grammar.lean
+++ b/Linglib/Syntax/CCG/Grammar.lean
@@ -4,11 +4,14 @@ import Mathlib.Data.Set.Defs
 /-!
 # CCG grammars and their languages
 
-This file defines CCG grammars and their string languages, in the formalism of
-[vijay-shanker-weir-1994] and [weir-joshi-1988] ("VW-CCG" in
-[kuhlmann-koller-satta-2015]'s terminology), where combinatory rules are restricted
-per grammar rather than by the lexicalized slash modalities of the modern rule
-theory (`Syntax/CCG/Derivation`). The restriction modelled is the one
+This file defines CCG grammars and their string languages. A grammar is a finite
+lexicon, a start atom, and its *rule system*, given as permission gates on the
+generalized composition schema; the formalisms of the literature are choices of
+gate. `Grammar.targetRestricted` is VW-CCG ([vijay-shanker-weir-1994],
+[weir-joshi-1988]), where the grammar owns a degree bound and a target restriction;
+`Grammar.multimodal` is the radically lexicalized modern formalism
+([baldridge-2002], [steedman-2019]), whose rule system is universal — a grammar is
+nothing but its lexicon and start symbol. The restriction modelled is the one
 [kuhlmann-koller-satta-2015]'s generative-capacity results turn on, a *target
 restriction*: a rule fires only when the target of its primary input category (the
 leftmost atom, after stripping all arguments) is a distinguished atom `s`.
@@ -34,8 +37,9 @@ languages in `Studies/KuhlmannKollerSatta2015`.
 
 ## Main definitions
 
-* `CCG.Grammar`: the capacity object — a finite lexicon, the distinguished atom
-  (target restriction and start symbol), and a bound on composition degree.
+* `CCG.Grammar`: a lexicon, a start atom, and rule-permission gates.
+* `CCG.Grammar.targetRestricted`, `CCG.Grammar.multimodal`: the two rule systems of
+  the literature, as gate choices.
 * `CCG.Grammar.Derives`: the derivability relation — `G.Derives c w` says the
   grammar derives token string `w` at category `c`; `Grammar.language` is the set of
   strings derived at the distinguished atom.
@@ -54,36 +58,77 @@ variable {α : Type*}
 
 /-! ### Grammars and their languages -/
 
-/-- A target-restricted CCG grammar: a finite lexicon, a distinguished atom serving as
-both the target restriction and the start symbol (the [kuhlmann-koller-satta-2015]
-simplification of per-rule restrictions), and a bound on composition degree
-(`degree = 2` in [schiffer-maletti-2021]'s normal form). -/
+/-- A CCG grammar: a finite lexicon, a distinguished start atom, and the grammar's
+rule system, given as permission gates — `allowsFwd n a b` says forward composition
+of degree `n` may combine primary `a` with secondary `b` (mirrored by `allowsBwd`).
+The formalisms of the literature are choices of gate: `Grammar.targetRestricted`
+(VW-CCG) and `Grammar.multimodal` (the universal modality-controlled rules). -/
 structure Grammar (α : Type*) where
   /-- Lexical entries, pairing a token with a category. -/
   lexicon : List (String × Cat α)
-  /-- The distinguished atom: rules fire only at this target, and the language
-  collects derivations of this category. -/
+  /-- The distinguished atom: the language collects derivations of this category. -/
   start : α
-  /-- The bound on composition degree. -/
-  degree : Nat
+  /-- May forward composition of degree `n` combine primary `a` with secondary `b`? -/
+  allowsFwd : Nat → Cat α → Cat α → Prop
+  /-- May backward composition of degree `n` combine secondary `a` with primary `b`? -/
+  allowsBwd : Nat → Cat α → Cat α → Prop
+
+/-- A target-restricted (VW-CCG) grammar ([vijay-shanker-weir-1994],
+[kuhlmann-koller-satta-2015]): rules up to a degree bound, gated on the primary
+input's target (`degree = 2` in [schiffer-maletti-2021]'s normal form). -/
+def Grammar.targetRestricted (lexicon : List (String × Cat α)) (start : α)
+    (degree : Nat) : Grammar α where
+  lexicon := lexicon
+  start := start
+  allowsFwd := fun n a _ => n ≤ degree ∧ Cat.target a = start
+  allowsBwd := fun n _ b => n ≤ degree ∧ Cat.target b = start
+
+/-- The universal rule system of multimodal CCG ([baldridge-2002], [steedman-2019]):
+degree at most 2, harmonic and crossing composition gated by the primary slash's
+modality, uniform secondary spines. -/
+def Multimodal.allowsFwd : Nat → Cat α → Cat α → Prop
+  | 0, _, _ => True
+  | 1, .rslash _ m _, .rslash _ _ _ => m ≤ Modality.diamond
+  | 1, .rslash _ m _, .lslash _ _ _ => m ≤ Modality.cross
+  | 2, .rslash _ m _, .rslash (.rslash _ _ _) _ _ => m ≤ Modality.diamond
+  | 2, .rslash _ m _, .lslash (.lslash _ _ _) _ _ => m ≤ Modality.cross
+  | _, _, _ => False
+
+/-- The mirror of `Multimodal.allowsFwd`. -/
+def Multimodal.allowsBwd : Nat → Cat α → Cat α → Prop
+  | 0, _, _ => True
+  | 1, .lslash _ _ _, .lslash _ m _ => m ≤ Modality.diamond
+  | 1, .rslash _ _ _, .lslash _ m _ => m ≤ Modality.cross
+  | 2, .lslash (.lslash _ _ _) _ _, .lslash _ m _ => m ≤ Modality.diamond
+  | 2, .rslash (.rslash _ _ _) _ _, .lslash _ m _ => m ≤ Modality.cross
+  | _, _, _ => False
+
+/-- A multimodal grammar: the radically lexicalized formalism of [steedman-2019],
+where a grammar is nothing but a lexicon and a start symbol — its rule system is the
+universal modality-controlled one. Strictly less expressive than the
+target-restricted grammars ([kuhlmann-koller-satta-2015]). -/
+def Grammar.multimodal (lexicon : List (String × Cat α)) (start : α) : Grammar α where
+  lexicon := lexicon
+  start := start
+  allowsFwd := Multimodal.allowsFwd
+  allowsBwd := Multimodal.allowsBwd
 
 /-- `G.Derives c w`: the grammar derives token string `w` at category `c` — a lexical
-entry, or a target-gated generalized composition of two adjacent derivations, within
-the grammar's degree bound. Capacity arguments proceed by induction on this
-relation. -/
+entry, or a generalized composition of two adjacent derivations permitted by the
+grammar's gates. Capacity arguments proceed by induction on this relation. -/
 inductive Grammar.Derives [DecidableEq α] (G : Grammar α) :
     Cat α → List String → Prop where
   /-- A lexical entry derives its token. -/
   | lex {w : String} {c : Cat α} : (w, c) ∈ G.lexicon → G.Derives c [w]
-  /-- Forward composition of degree `n` (`>Bⁿ`; degree 0 is application), gated on the
-  primary (left) target. -/
+  /-- Forward composition of degree `n` (`>Bⁿ`; degree 0 is application), if the
+  grammar's gate permits it. -/
   | fc (n : Nat) {a b c : Cat α} {u v : List String} :
-      G.Derives a u → G.Derives b v → n ≤ G.degree → Cat.target a = G.start →
+      G.Derives a u → G.Derives b v → G.allowsFwd n a b →
       Cat.generalizedForwardComp n a b = some c → G.Derives c (u ++ v)
-  /-- Backward composition of degree `n` (`<Bⁿ`; degree 0 is application), gated on the
-  primary (right) target. -/
+  /-- Backward composition of degree `n` (`<Bⁿ`; degree 0 is application), if the
+  grammar's gate permits it. -/
   | bc (n : Nat) {a b c : Cat α} {u v : List String} :
-      G.Derives a u → G.Derives b v → n ≤ G.degree → Cat.target b = G.start →
+      G.Derives a u → G.Derives b v → G.allowsBwd n a b →
       Cat.generalizedBackwardComp n a b = some c → G.Derives c (u ++ v)
 
 /-- The string language of a grammar: the token strings derived at the distinguished


### PR DESCRIPTION
Unifies the two formalisms onto one object, following the literature's own abstraction: a grammar is a lexicon, a start atom, and its *rule system*, given as permission gates on the generalized composition schema (`allowsFwd`/`allowsBwd : Nat → Cat α → Cat α → Prop`). The formalisms become gate choices:

- `Grammar.targetRestricted lexicon start degree` — VW-CCG ([vijay-shanker-weir-1994]): degree bound + target restriction (the former `Grammar` fields, now one constructor among others)
- `Grammar.multimodal lexicon start` — the radically lexicalized modern formalism ([baldridge-2002], [steedman-2019]): the universal degree-≤2, modality-gated, uniform-spine rule system, so a grammar is nothing but its lexicon and start symbol — the chapter's radical-lexicalization thesis as a definition
- `Derives` gates on the grammar's own permissions; the KKS expressive-power separation (multimodal strictly below target-restricted) is now a stateable contrast of gate choices over one relation, and the bridge between multimodal `Derives` and `CCG.Derivation` trees (the proof-relevant calculus `interp` consumes) is expressible future work
- KKS's `exampleGrammar` and the study's `dutchGrammar` become `.targetRestricted …` applications; gate proofs are anonymous-constructor pairs