### PR TITLE
refactor(Logic/Modal): re-anchor Lemma 3.7(i), drop unused accessImage

### DIFF
--- a/Linglib/Logic/Modal/BSML/Bisimulation.lean
+++ b/Linglib/Logic/Modal/BSML/Bisimulation.lean
@@ -4,13 +4,13 @@ import Linglib.Logic.Modal.Bisimulation
 /-!
 # Bisimulation invariance for BSML
 
-[aloni-anttila-yang-2024] [anttila-2025]
-
 The carrier-level bisimulation substrate (`WorldBisim`, `StateBisim`, and
-the Lemma 3.7 transport lemmas) lives in `Logic/Modal/Bisimulation.lean`,
-shared across the modal team logics. This file specialises it to BSML: the
-modal-depth measure on `BSMLFormula` and the headline invariance result
-(Theorem 3.8) for BSML's bilateral evaluation.
+the Lemma 3.7 transport lemmas of [aloni-anttila-yang-2024]) lives in
+`Logic/Modal/Bisimulation.lean`, shared across the modal team logics. This
+file specialises it to BSML: the modal-depth measure on `BSMLFormula` and
+the invariance result (Theorem 3.8) for BSML's bilateral evaluation, which
+the [anttila-2025] expressive-completeness development consumes in
+`BSML/ExpressiveCompleteness.lean`.
 
 ## Main declarations
 
@@ -23,32 +23,25 @@ modal-depth measure on `BSMLFormula` and the headline invariance result
 
 The bisim-invariance proof inducts on the formula, handling both polarities
 (`eval M b φ s`) jointly at each step. The negation case flips polarity
-without changing depth; the modal case uses `StateBisim.accessImage`
-(Lemma 3.7(i)) to recurse at depth `k`; conjunction and disjunction use
-`StateBisim.splitPreserve` (Lemma 3.7(ii)) for the split-existential clauses
-(conj-antiSupport and disj-support).
+without changing depth; the modal case recurses at depth `k` through
+`WorldBisim.accessStateBisim` (the singleton form of Lemma 3.7(i)), with
+`StateBisim.exists_image_subset` transporting the `poss`-support witness
+sub-team; conjunction and disjunction use `StateBisim.splitPreserve`
+(Lemma 3.7(ii)) for the split-existential clauses (conj-antiSupport and
+disj-support).
 
 ## Todo
 
 * Hennessy-Milner direction (Theorem 3.3): `k`-equivalence implies
   `k`-bisimilarity, via Hintikka formulas. Requires a finite atom set
   hypothesis (`[Fintype Atom]`) for the characteristic-formula construction.
-  Deferred — Theorem 3.8 alone is enough for the expressive-completeness side
-  of [aloni-anttila-yang-2024] §3.
-* Bisim invariance for `BSMLOr.eval` and `BSMLEmpty.eval`. Same shape with one
-  new case each (`gdisj` is structurally like `support_conj` at the team
-  level; `empt` reduces to support of the inner formula or `s = ∅`, both
-  bisim-preserved).
+  Deferred — Theorem 3.8 alone is enough for the soundness half of the
+  expressive-completeness theorem in `BSML/ExpressiveCompleteness.lean`.
 -/
 
 namespace BSML
 
 open Modal
-
--- Re-export the carrier-level bisimulation names under the BSML namespace so
--- consumers that historically opened `BSML (StateBisim …)`
--- continue to resolve after the lift to `Modal`.
-export Modal (WorldBisim StateBisim)
 
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}
@@ -74,18 +67,16 @@ def BSMLFormula.modalDepth : BSMLFormula Atom → ℕ
 
     Proved by structural induction on `φ`, with both polarities handled
     jointly at each step. The `neg` case flips polarity without changing
-    depth; the `poss` case uses Lemma 3.7(i) to recurse at depth `k`;
-    conjunction and disjunction use Lemma 3.7(ii) for the split-existential
-    clauses (conj-antiSupport and disj-support). -/
-theorem bisim_invariant_eval (φ : BSMLFormula Atom) :
-    ∀ {k : ℕ}, φ.modalDepth ≤ k →
-    ∀ {M : BSMLModel W Atom} {M' : BSMLModel W' Atom}
-      {s : Finset W} {s' : Finset W'},
-    StateBisim k M s M' s' →
-    ∀ b : Bool, eval M b φ s ↔ eval M' b φ s' := by
-  induction φ with
+    depth; the `poss` case recurses at depth `k` through
+    `WorldBisim.accessStateBisim`; conjunction and disjunction use
+    Lemma 3.7(ii) for the split-existential clauses (conj-antiSupport
+    and disj-support). -/
+theorem bisim_invariant_eval {M : BSMLModel W Atom} {M' : BSMLModel W' Atom}
+    (φ : BSMLFormula Atom) {k : ℕ} (hd : φ.modalDepth ≤ k)
+    {s : Finset W} {s' : Finset W'} (hbisim : StateBisim k M s M' s')
+    (b : Bool) : eval M b φ s ↔ eval M' b φ s' := by
+  induction φ generalizing k s s' b with
   | atom p =>
-    intro k _ M M' s s' hbisim b
     -- For both polarities: each side of the iff uses the bisim partner's
     -- valuation, related by `WorldBisim.val_eq`.
     cases b <;>
@@ -97,23 +88,18 @@ theorem bisim_invariant_eval (φ : BSMLFormula Atom) :
         obtain ⟨w', hw', hbw⟩ := hbisim.1 w hw
         rw [hbw.val_eq]; exact h w' hw'
   | ne =>
-    intro k _ M M' s s' hbisim b
     cases b
     · exact hbisim.eq_empty_iff
     · exact hbisim.nonempty_iff
   | neg ψ ih =>
-    intro k hd M M' s s' hbisim b
     cases b
     · -- antiSupport (neg ψ) = support ψ
       exact ih hd hbisim true
     · -- support (neg ψ) = antiSupport ψ
       exact ih hd hbisim false
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    intro k hd M M' s s' hbisim b
-    have hd₁ : ψ₁.modalDepth ≤ k :=
-      le_trans (le_max_left _ _) hd
-    have hd₂ : ψ₂.modalDepth ≤ k :=
-      le_trans (le_max_right _ _) hd
+    have hd₁ : ψ₁.modalDepth ≤ k := (le_max_left _ _).trans hd
+    have hd₂ : ψ₂.modalDepth ≤ k := (le_max_right _ _).trans hd
     cases b
     · -- antiSupport (conj ψ₁ ψ₂): ∃ t u, splitsAs ∧ antiSupport ψ₁ t ∧ antiSupport ψ₂ u
       constructor
@@ -139,11 +125,8 @@ theorem bisim_invariant_eval (φ : BSMLFormula Atom) :
       · rintro ⟨h₁, h₂⟩
         exact ⟨(ih₁ hd₁ hbisim true).mpr h₁, (ih₂ hd₂ hbisim true).mpr h₂⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    intro k hd M M' s s' hbisim b
-    have hd₁ : ψ₁.modalDepth ≤ k :=
-      le_trans (le_max_left _ _) hd
-    have hd₂ : ψ₂.modalDepth ≤ k :=
-      le_trans (le_max_right _ _) hd
+    have hd₁ : ψ₁.modalDepth ≤ k := (le_max_left _ _).trans hd
+    have hd₂ : ψ₂.modalDepth ≤ k := (le_max_right _ _).trans hd
     cases b
     · -- antiSupport (disj ψ₁ ψ₂) = antiSupport ψ₁ ∧ antiSupport ψ₂
       constructor
@@ -169,42 +152,38 @@ theorem bisim_invariant_eval (φ : BSMLFormula Atom) :
         · exact (ih₁ hd₁ hbt.symm true).mpr h₁
         · exact (ih₂ hd₂ hbu.symm true).mpr h₂
   | poss ψ ih =>
-    intro k hd M M' s s' hbisim b
-    -- modalDepth (poss ψ) = ψ.modalDepth + 1, so we need k = succ for accessImage
-    obtain ⟨k, rfl⟩ : ∃ k', k = k' + 1 := by
-      cases k with
-      | zero => exact absurd hd (by simp [BSMLFormula.modalDepth])
-      | succ k => exact ⟨k, rfl⟩
-    have hdψ : ψ.modalDepth ≤ k := by
-      have := hd
-      simp only [BSMLFormula.modalDepth] at this
-      omega
-    cases b
-    · -- antiSupport (poss ψ): ∀ w ∈ s, antiSupport ψ (M.access w).
-      -- For each side, find the bisim-partner world and use IH at the
-      -- accessibility-image state bisim.
-      constructor
-      · intro h w' hw'
-        obtain ⟨w, hw, hbw⟩ := hbisim.2 w' hw'
-        exact (ih hdψ hbw.accessStateBisim false).mp (h w hw)
-      · intro h w hw
-        obtain ⟨w', hw', hbw⟩ := hbisim.1 w hw
-        exact (ih hdψ hbw.accessStateBisim false).mpr (h w' hw')
-    · -- support (poss ψ): ∀ w ∈ s, ∃ t ⊆ R[w], t.Nonempty ∧ support ψ t.
-      -- The witness sub-team `t` of the access image transports across
-      -- models via `exists_image_subset`.
-      constructor
-      · intro h w' hw'
-        obtain ⟨w, hw, hbw⟩ := hbisim.2 w' hw'
-        obtain ⟨t, htsub, htne, htsupp⟩ := h w hw
-        obtain ⟨t', ht'sub, ht'ne, htbisim⟩ :=
-          hbw.accessStateBisim.exists_image_subset htsub
-        exact ⟨t', ht'sub, ht'ne htne, (ih hdψ htbisim true).mp htsupp⟩
-      · intro h w hw
-        obtain ⟨w', hw', hbw⟩ := hbisim.1 w hw
-        obtain ⟨t', ht'sub, ht'ne, ht'supp⟩ := h w' hw'
-        obtain ⟨t, htsub, htne, htbisim⟩ :=
-          hbw.accessStateBisim.symm.exists_image_subset ht'sub
-        exact ⟨t, htsub, htne ht'ne, (ih hdψ htbisim.symm true).mpr ht'supp⟩
+    -- modalDepth (poss ψ) = ψ.modalDepth + 1, so `k` is a successor and the
+    -- recursion through `accessStateBisim` happens one depth down.
+    cases k with
+    | zero => exact absurd hd (Nat.not_succ_le_zero _)
+    | succ k =>
+      have hdψ : ψ.modalDepth ≤ k := Nat.le_of_succ_le_succ hd
+      cases b
+      · -- antiSupport (poss ψ): ∀ w ∈ s, antiSupport ψ (M.access w).
+        -- For each side, find the bisim-partner world and use IH at the
+        -- accessibility-image state bisim.
+        constructor
+        · intro h w' hw'
+          obtain ⟨w, hw, hbw⟩ := hbisim.2 w' hw'
+          exact (ih hdψ hbw.accessStateBisim false).mp (h w hw)
+        · intro h w hw
+          obtain ⟨w', hw', hbw⟩ := hbisim.1 w hw
+          exact (ih hdψ hbw.accessStateBisim false).mpr (h w' hw')
+      · -- support (poss ψ): ∀ w ∈ s, ∃ t ⊆ R[w], t.Nonempty ∧ support ψ t.
+        -- The witness sub-team `t` of the access image transports across
+        -- models via `exists_image_subset`.
+        constructor
+        · intro h w' hw'
+          obtain ⟨w, hw, hbw⟩ := hbisim.2 w' hw'
+          obtain ⟨t, htsub, htne, htsupp⟩ := h w hw
+          obtain ⟨t', ht'sub, ht'ne, htbisim⟩ :=
+            hbw.accessStateBisim.exists_image_subset htsub
+          exact ⟨t', ht'sub, ht'ne htne, (ih hdψ htbisim true).mp htsupp⟩
+        · intro h w hw
+          obtain ⟨w', hw', hbw⟩ := hbisim.1 w hw
+          obtain ⟨t', ht'sub, ht'ne, ht'supp⟩ := h w' hw'
+          obtain ⟨t, htsub, htne, htbisim⟩ :=
+            hbw.accessStateBisim.symm.exists_image_subset ht'sub
+          exact ⟨t, htsub, htne ht'ne, (ih hdψ htbisim.symm true).mpr ht'supp⟩
 
 end BSML

--- a/Linglib/Logic/Modal/Bisimulation.lean
+++ b/Linglib/Logic/Modal/Bisimulation.lean
@@ -18,9 +18,7 @@ bisimulation substrate shared by every team-semantic modal logic in
 Nothing here mentions a `Formula` type or an `eval` relation — everything
 is stated over the bare `KripkeModel` carrier (`access` + `val`). Each
 logic states its own `bisim_invariant_eval` against its own evaluation,
-recursing through these carrier lemmas at the modal step. This file is the
-genus-level home the per-logic invariance proofs were extracted to once a
-second consumer (MDL) landed; see `Logic/Modal/README.md`.
+recursing through these carrier lemmas at the modal step.
 
 ## Main declarations
 
@@ -31,10 +29,9 @@ second consumer (MDL) landed; see `Logic/Modal/README.md`.
 * `WorldBisim.val_eq`, `WorldBisim.accessStateBisim` — valuation and
   accessibility-image transfer.
 * `StateBisim.eq_empty_iff`, `StateBisim.nonempty_iff` — emptiness transfer.
-* `StateBisim.accessImage` — Lemma 3.7(i): per-world accessibility-image bisim.
+* `StateBisim.biUnionAccess` — Lemma 3.7(i): image-union preservation.
 * `StateBisim.splitPreserve` — Lemma 3.7(ii): team-split preservation.
 * `StateBisim.exists_image_subset` — sub-team transport (BSML's per-world ◇).
-* `StateBisim.biUnionAccess` — union-of-images preservation (MDL's anti-◇).
 * `StateBisim.possWitness` — single-witness team transport (MDL's ◇-support).
 
 ## Implementation notes
@@ -181,7 +178,8 @@ theorem WorldBisim.val_eq {k : ℕ} {M : KripkeModel W Atom} {w : W}
   | _ + 1, ⟨h, _, _⟩ => h p
 
 /-- World bisim at depth `k+1` yields state bisim of the accessibility
-    images at depth `k`. -/
+    images at depth `k` — the singleton form of Lemma 3.7(i), used by each
+    logic's modal case. -/
 theorem WorldBisim.accessStateBisim {k : ℕ} {M : KripkeModel W Atom} {w : W}
     {M' : KripkeModel W' Atom} {w' : W'}
     (h : WorldBisim (k + 1) M w M' w') :
@@ -243,23 +241,28 @@ theorem StateBisim.exists_image_subset {k : ℕ} {M : KripkeModel W Atom}
 
 /-! ### Lemma 3.7: state bisimulation preserves modal step and team splits -/
 
-/-- Lemma 3.7(i) of [aloni-anttila-yang-2024]: at depth `k+1`, state
-    bisim provides for each `w ∈ s` a witness `w' ∈ s'` such that the
-    accessibility images `R[w]` and `R'[w']` are state-bisimilar at
-    depth `k`. -/
-theorem StateBisim.accessImage {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
-    {M' : KripkeModel W' Atom} {s' : Finset W'} {w : W}
-    (h : StateBisim (k + 1) M s M' s') (hw : w ∈ s) :
-    ∃ w' ∈ s', StateBisim k M (M.access w) M' (M'.access w') := by
-  obtain ⟨w', hw', hbisim⟩ := h.1 w hw
-  obtain ⟨_, hforth, hback⟩ := hbisim
-  refine ⟨w', hw', ?_, ?_⟩
+/-- Lemma 3.7(i) of [aloni-anttila-yang-2024]: state bisim at depth `k+1`
+    yields state bisim of the **unions of accessibility images** at depth
+    `k`: `s.biUnion R ⇌_k s'.biUnion R'`. Also the transport principle for
+    the MDL anti-`◇` clause ([vaananen-2008] (T9)), which evaluates the
+    inner formula on this union. -/
+theorem StateBisim.biUnionAccess {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
+    {M' : KripkeModel W' Atom} {s' : Finset W'}
+    (h : StateBisim (k + 1) M s M' s') :
+    StateBisim k M (s.biUnion M.access) M' (s'.biUnion M'.access) := by
+  refine ⟨?_, ?_⟩
   · intro v hv
-    obtain ⟨v', hv', hbv⟩ := hforth v hv
-    exact ⟨v', hv', hbv⟩
+    rw [Finset.mem_biUnion] at hv
+    obtain ⟨w, hw, hvw⟩ := hv
+    obtain ⟨w', hw', hbw⟩ := h.1 w hw
+    obtain ⟨v', hv', hbv⟩ := hbw.accessStateBisim.1 v hvw
+    exact ⟨v', Finset.mem_biUnion.mpr ⟨w', hw', hv'⟩, hbv⟩
   · intro v' hv'
-    obtain ⟨v, hv, hbv⟩ := hback v' hv'
-    exact ⟨v, hv, hbv⟩
+    rw [Finset.mem_biUnion] at hv'
+    obtain ⟨w', hw', hvw'⟩ := hv'
+    obtain ⟨w, hw, hbw⟩ := h.2 w' hw'
+    obtain ⟨v, hv, hbv⟩ := hbw.accessStateBisim.2 v' hvw'
+    exact ⟨v, Finset.mem_biUnion.mpr ⟨w, hw, hv⟩, hbv⟩
 
 /-- Lemma 3.7(ii) of [aloni-anttila-yang-2024]: state bisim preserves
     binary team splits. Given `s = t ∪ u` and `s ⇌_k s'`, there exist
@@ -309,32 +312,11 @@ theorem StateBisim.splitPreserve {k : ℕ} {M : KripkeModel W Atom}
       obtain ⟨_, w, hw, hbisim⟩ := Finset.mem_filter.mp hw'
       exact ⟨w, hw, hbisim⟩
 
-/-! ### Single-relation modal step (Väänänen-style ◇)
+/-! ### Single-witness modal step (Väänänen-style ◇)
 
-The MDL modality uses the union of accessibility images (anti-support) and
-a single witness team (support), rather than BSML's per-world sub-witness.
-These two lemmas are the Lemma 3.7 analogues for that modality. -/
-
-/-- State bisim at depth `k+1` preserves the **union of accessibility images**
-    at depth `k`: `s.biUnion R ⇌_k s'.biUnion R'`. The MDL anti-`◇` clause
-    ([vaananen-2008] (T9)) evaluates the inner formula on this union. -/
-theorem StateBisim.biUnionAccess {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
-    {M' : KripkeModel W' Atom} {s' : Finset W'}
-    (h : StateBisim (k + 1) M s M' s') :
-    StateBisim k M (s.biUnion M.access) M' (s'.biUnion M'.access) := by
-  refine ⟨?_, ?_⟩
-  · intro v hv
-    rw [Finset.mem_biUnion] at hv
-    obtain ⟨w, hw, hvw⟩ := hv
-    obtain ⟨w', hw', hbw⟩ := h.1 w hw
-    obtain ⟨v', hv', hbv⟩ := hbw.accessStateBisim.1 v hvw
-    exact ⟨v', Finset.mem_biUnion.mpr ⟨w', hw', hv'⟩, hbv⟩
-  · intro v' hv'
-    rw [Finset.mem_biUnion] at hv'
-    obtain ⟨w', hw', hvw'⟩ := hv'
-    obtain ⟨w, hw, hbw⟩ := h.2 w' hw'
-    obtain ⟨v, hv, hbv⟩ := hbw.accessStateBisim.2 v' hvw'
-    exact ⟨v, Finset.mem_biUnion.mpr ⟨w, hw, hv⟩, hbv⟩
+The MDL `◇`-support clause uses a single witness team reached by every
+world, rather than BSML's per-world sub-witness; this lemma is its
+transport principle. The anti-`◇` side is `StateBisim.biUnionAccess`. -/
 
 /-- **Single-witness team transport.** Given `s ⇌_{k+1} s'` and a witness team
     `Y ⊆ s.biUnion R` that every world in `s` reaches (`∀ w ∈ s, ∃ y ∈ Y ∩

--- a/Linglib/Logic/Modal/Dependence.lean
+++ b/Linglib/Logic/Modal/Dependence.lean
@@ -105,20 +105,13 @@ infrastructure but differ in atom flavor:
   (Grädel and Väänänen).
 * `Modal/Bilateral.lean` (future, after BSML's eventual Core/
   graduation) — BSML's bilateral negation + NE atom.
-
-The bisimulation substrate currently lives at
-`Logic/Modal/BSML/Bisimulation.lean` for historical reasons; a
-future refactor lifts it to `Logic/Modal/Bisimulation.lean`.
+* `Modal/Bisimulation.lean` — the shared bisimulation substrate.
 
 ## Todo
 
 * [lohmann-vollmer-2013] — adds classical disjunction `⓿` (the
   BSML∨ analogue) and complete satisfiability complexity classification.
   Natural second consumer paper, with a Studies file anchored on it.
-* Bisim invariance for MDL — same shape as BSML/BSMLOr/BSMLEmpty
-  proofs in `BSML/Bisimulation.lean` and `Studies/AloniAnttilaYang2024`,
-  but the modal-case argument differs because MDL's ◇ uses single-
-  witness semantics rather than per-world.
 * Modal independence logic (Grädel and Väänänen's independence atoms) —
   sibling at `Logic/Modal/Independence.lean`.
 -/
@@ -460,9 +453,9 @@ MDL's modality differs from BSML's: anti-`◇` uses the union of accessibility
 images (clause (T9)), and `◇`-support a single witness team (clause (T8)),
 rather than BSML's per-world sub-witnesses. The invariance proof therefore
 recurses through `StateBisim.biUnionAccess` and `StateBisim.possWitness`
-(the carrier-level Lemma 3.7 analogues in `Logic/Modal/Bisimulation.lean`)
-at the modal step, where BSML uses `StateBisim.accessImage` /
-`exists_image_subset`. The dependence-atom case is depth-0 and turns on
+(carrier-level transport lemmas in `Logic/Modal/Bisimulation.lean`)
+at the modal step, where BSML uses `WorldBisim.accessStateBisim` /
+`StateBisim.exists_image_subset`. The dependence-atom case is depth-0 and turns on
 `WorldBisim.val_eq`: state bisim preserves the set of atom-valuation profiles
 realised in a team, and functional dependence is a property of that set. -/
 

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -32,13 +32,7 @@ the AAY-2024 extensions BSMLOr/BSMLEmpty, modal dependence logic in
 * `Logic/Modal/Dependence.lean` — modal dependence logic (MDL).
 * `Studies/AloniAnttilaYang2024.lean` — BSMLOr,
   BSMLEmpty (via `BSMLModel` alias).
-
-## Todo
-
-* Lift bisimulation infrastructure currently at
-  `Logic/Modal/BSML/Bisimulation.lean` to a sibling
-  `Logic/Modal/Bisimulation.lean` once a non-BSML consumer
-  (MDL bisim invariance, modal inclusion logic) lands.
+* `Logic/Modal/Bisimulation.lean` — bounded bisimulation over this carrier.
 -/
 
 namespace Modal

--- a/Linglib/Studies/AloniAnttilaYang2024.lean
+++ b/Linglib/Studies/AloniAnttilaYang2024.lean
@@ -98,7 +98,8 @@ namespace AloniAnttilaYang2024
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}
 
-open BSML (BSMLModel BSMLFormula StateBisim WorldBisim)
+open BSML (BSMLModel BSMLFormula)
+open Modal (StateBisim WorldBisim)
 
 /-! ### BSMLOr — BSML with global disjunction `⨼` -/
 


### PR DESCRIPTION
Audit fixes for `Logic/Modal/BSML/Bisimulation.lean` and its bisim substrate, verified against the published paper.

- `StateBisim.biUnionAccess` is Aloni-Anttila-Yang Lemma 3.7(i) verbatim; the lemma carrying that label, `StateBisim.accessImage`, was unused by any proof and is deleted (docstrings now name `WorldBisim.accessStateBisim`, the singleton form the proofs actually use).
- Stale-Todo sweep: BSMLOr/BSMLEmpty invariance (done in `Studies/AloniAnttilaYang2024`), the already-landed substrate lift (`Kripke.lean`, `Dependence.lean`), and a dangling `README.md` reference; drops the backcompat `export Modal (WorldBisim StateBisim)`.
- `bisim_invariant_eval` gets a flat mathlib-style signature via `induction … generalizing` (call sites unchanged) and defeq golf in the `poss` case.