### PR TITLE
refactor(Logic/Modal/BSML): BSMLFormula → Formula, drop BSMLModel

### DIFF
--- a/Linglib/Logic/Bilateral/Defs.lean
+++ b/Linglib/Logic/Bilateral/Defs.lean
@@ -84,7 +84,7 @@ structure IsBilateral
     original values. This does NOT imply `negate (negate φ) = φ`
     syntactically; it implies the *interpretations agree*. Consumers
     where `negate (negate φ) = φ` syntactically (e.g., BSML's
-    `BSMLFormula.neg`) can derive the syntactic involution separately. -/
+    `BSML.Formula.neg`) can derive the syntactic involution separately. -/
 theorem IsBilateral.positive_negate_negate
     {positive negative : Form → Result} {negate : Form → Form}
     (h : IsBilateral positive negative negate) (φ : Form) :

--- a/Linglib/Logic/Modal/BSML/Bisimulation.lean
+++ b/Linglib/Logic/Modal/BSML/Bisimulation.lean
@@ -7,14 +7,14 @@ import Linglib.Logic.Modal.Bisimulation
 The carrier-level bisimulation substrate (`WorldBisim`, `StateBisim`, and
 the Lemma 3.7 transport lemmas of [aloni-anttila-yang-2024]) lives in
 `Logic/Modal/Bisimulation.lean`, shared across the modal team logics. This
-file specialises it to BSML: the modal-depth measure on `BSMLFormula` and
+file specialises it to BSML: the modal-depth measure on `Formula` and
 the invariance result (Theorem 3.8) for BSML's bilateral evaluation, which
 the [anttila-2025] expressive-completeness development consumes in
 `BSML/ExpressiveCompleteness.lean`.
 
 ## Main declarations
 
-* `BSMLFormula.modalDepth` — modal depth (page 9): atoms/NE are 0,
+* `Formula.modalDepth` — modal depth (page 9): atoms/NE are 0,
   `conj`/`disj` take max, `poss` increments.
 * `bisim_invariant_eval` — Theorem 3.8 for BSML: `k`-bisimilar states agree
   on `eval` for all formulas of modal depth `≤ k`, for both polarities.
@@ -48,10 +48,10 @@ variable {Atom : Type*}
 
 /-! ### Modal depth -/
 
-/-- Modal depth of a `BSMLFormula` (page 9 of [aloni-anttila-yang-2024]).
+/-- Modal depth of a `Formula` (page 9 of [aloni-anttila-yang-2024]).
     Atoms and `NE` are 0; `neg` preserves depth; `conj` and `disj` take
     the max; `poss` increments. -/
-def BSMLFormula.modalDepth : BSMLFormula Atom → ℕ
+def Formula.modalDepth : Formula Atom → ℕ
   | .atom _ => 0
   | .ne => 0
   | .neg ψ => ψ.modalDepth
@@ -62,7 +62,7 @@ def BSMLFormula.modalDepth : BSMLFormula Atom → ℕ
 /-! ### Theorem 3.8: bisimulation invariance for BSML -/
 
 /-- **Theorem 3.8** of [aloni-anttila-yang-2024] specialised to BSML:
-    if `s ⇌_k s'` and `φ : BSMLFormula Atom` has modal depth `≤ k`, then
+    if `s ⇌_k s'` and `φ : Formula Atom` has modal depth `≤ k`, then
     `eval M b φ s ↔ eval M' b φ s'` for both polarities.
 
     Proved by structural induction on `φ`, with both polarities handled
@@ -71,8 +71,8 @@ def BSMLFormula.modalDepth : BSMLFormula Atom → ℕ
     `WorldBisim.accessStateBisim`; conjunction and disjunction use
     Lemma 3.7(ii) for the split-existential clauses (conj-antiSupport
     and disj-support). -/
-theorem bisim_invariant_eval {M : BSMLModel W Atom} {M' : BSMLModel W' Atom}
-    (φ : BSMLFormula Atom) {k : ℕ} (hd : φ.modalDepth ≤ k)
+theorem bisim_invariant_eval {M : KripkeModel W Atom} {M' : KripkeModel W' Atom}
+    (φ : Formula Atom) {k : ℕ} (hd : φ.modalDepth ≤ k)
     {s : Finset W} {s' : Finset W'} (hbisim : StateBisim k M s M' s')
     (b : Bool) : eval M b φ s ↔ eval M' b φ s' := by
   induction φ generalizing k s s' b with

--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -25,6 +25,8 @@ team semantics restricted to singleton teams.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
 -- ============================================================================
@@ -34,7 +36,7 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 /-- Classical (Kripke) evaluation of a BSML formula at a single world.
     ∨ is pointwise, ◇ is existential, □ is universal — no team splitting.
     NE evaluates to true (singletons are non-empty). -/
-def classicalEval (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (w : W) : Bool :=
+def classicalEval (M : KripkeModel W Atom) (φ : Formula Atom) (w : W) : Bool :=
   match φ with
   | .atom p => M.val p w
   | .ne => true
@@ -50,16 +52,16 @@ def classicalEval (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (w : W) : Bool 
 set_option maxHeartbeats 800000 in
 /-- For NE-free formulas, support and anti-support decompose pointwise over
     team members in terms of classical evaluation. -/
-private theorem neFree_flat_eq (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+private theorem neFree_flat_eq (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hNE : φ.isNEFree = true) :
     (support M φ t ↔ ∀ w ∈ t, classicalEval M φ w = true) ∧
     (antiSupport M φ t ↔ ∀ w ∈ t, classicalEval M φ w = false) := by
   induction φ generalizing t with
   | atom p => exact ⟨Iff.rfl, Iff.rfl⟩
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | neg ψ ih =>
-    have hNE' := by simp [BSMLFormula.isNEFree] at hNE; exact hNE
+    have hNE' := by simp [Formula.isNEFree] at hNE; exact hNE
     have ⟨ih_s, ih_a⟩ := ih t hNE'
     constructor
     · -- support of ¬ψ = antiSupport of ψ
@@ -69,8 +71,8 @@ private theorem neFree_flat_eq (M : BSMLModel W Atom)
       simp only [classicalEval, Bool.not_eq_false']
       exact ih_s
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ := by simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ := by simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+    have hψ₂ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     constructor
     · -- support of ψ₁ ∧ ψ₂ = ∀ w ∈ t, classicalEval (ψ₁ ∧ ψ₂) w
       simp only [classicalEval, Bool.and_eq_true]
@@ -107,8 +109,8 @@ private theorem neFree_flat_eq (M : BSMLModel W Atom)
             | inl h => simp [hce] at h
             | inr h => exact h)
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ := by simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ := by simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+    have hψ₂ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     constructor
     · -- support of ψ₁ ∨ ψ₂ (SPLIT) = ∀ w ∈ t, ce ψ₁ w ∨ ce ψ₂ w
       simp only [classicalEval, Bool.or_eq_true]
@@ -143,7 +145,7 @@ private theorem neFree_flat_eq (M : BSMLModel W Atom)
              fun h => ⟨(ih₁ t hψ₁).2.mpr (fun w hw => (h w hw).1),
                        (ih₂ t hψ₂).2.mpr (fun w hw => (h w hw).2)⟩⟩
   | poss ψ ih =>
-    have hNE' := by simp [BSMLFormula.isNEFree] at hNE; exact hNE
+    have hNE' := by simp [Formula.isNEFree] at hNE; exact hNE
     constructor
     · -- support of ◇ψ ↔ ∀ w ∈ t, ∃ v ∈ R[w], ce ψ v = true
       simp only [classicalEval]
@@ -185,8 +187,8 @@ Classical Collapse (Fact 15 from [aloni-2022]).
 For NE-free formulas, BSML support on a singleton team equals classical
 Kripke evaluation.
 -/
-theorem classicalCollapse (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (w : W)
+theorem classicalCollapse (M : KripkeModel W Atom)
+    (φ : Formula Atom) (w : W)
     (hNE : φ.isNEFree = true) :
     support M φ {w} ↔ classicalEval M φ w = true := by
   rw [(neFree_flat_eq M φ {w} hNE).1]
@@ -194,8 +196,8 @@ theorem classicalCollapse (M : BSMLModel W Atom)
 
 /-- Anti-support collapse: singleton anti-support equals negation of
     classical evaluation. -/
-theorem classicalCollapseAnti (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (w : W)
+theorem classicalCollapseAnti (M : KripkeModel W Atom)
+    (φ : Formula Atom) (w : W)
     (hNE : φ.isNEFree = true) :
     antiSupport M φ {w} ↔ classicalEval M φ w = false := by
   rw [(neFree_flat_eq M φ {w} hNE).2]
@@ -207,8 +209,8 @@ theorem classicalCollapseAnti (M : BSMLModel W Atom)
 
 /-- NE-free formulas have flat support: team support = pointwise classical
     evaluation on all members. -/
-theorem neFree_flat (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem neFree_flat (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hNE : φ.isNEFree = true) :
     support M φ t ↔ ∀ w ∈ t, classicalEval M φ w = true :=
   (neFree_flat_eq M φ t hNE).1
@@ -222,7 +224,7 @@ open Modal (diamond)
 /-!
 ### Accessibility Type Bridge
 
-`BSMLModel.access : W → Finset W` can be converted to a Prop-valued
+`KripkeModel.access : W → Finset W` can be converted to a Prop-valued
 `AccessRel W = W → W → Prop` via `fun w v => v ∈ M.access w`, which is the
 canonical accessibility-relation type in
 `Intensional`.
@@ -230,7 +232,7 @@ canonical accessibility-relation type in
 
 /-- Convert BSML accessibility (`Finset`-valued) to a classical Prop-valued
     accessibility relation. -/
-def BSMLModel.toAccessRel (M : BSMLModel W Atom) :
+def _root_.Modal.KripkeModel.toAccessRel (M : KripkeModel W Atom) :
     Modal.AccessRel W :=
   fun w v => v ∈ M.access w
 
@@ -238,9 +240,9 @@ def BSMLModel.toAccessRel (M : BSMLModel W Atom) :
     connecting BSML's classical evaluation to the shared modal logic
     infrastructure from `Intensional`. -/
 theorem classicalEval_agrees_diamond_poss
-    (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (w : W) :
+    (M : KripkeModel W Atom) (φ : Formula Atom) (w : W) :
     classicalEval M (.poss φ) w = true ↔
     diamond M.toAccessRel (fun v => classicalEval M φ v = true) w := by
-  simp only [classicalEval, decide_eq_true_eq, diamond, BSMLModel.toAccessRel]
+  simp only [classicalEval, decide_eq_true_eq, diamond, Modal.KripkeModel.toAccessRel]
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -48,36 +48,36 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 /-- `⊤` as an NE-free BSML formula: `p ∨ ¬p` for the default atom. Classically
     evaluates to `true` at every world; supported by every team. Requires an
     atom (`[Inhabited Atom]`): BSML has no atom-free closed `⊤`. -/
-def verum [Inhabited Atom] : BSMLFormula Atom :=
+def verum [Inhabited Atom] : Formula Atom :=
   .disj (.atom default) (.neg (.atom default))
 
-@[simp] theorem classicalEval_verum [Inhabited Atom] (M : BSMLModel W Atom) (w : W) :
+@[simp] theorem classicalEval_verum [Inhabited Atom] (M : KripkeModel W Atom) (w : W) :
     classicalEval M verum w = true := by
   simp [verum, classicalEval, Bool.or_not_self]
 
 @[simp] theorem isNEFree_verum [Inhabited Atom] :
-    (verum : BSMLFormula Atom).isNEFree = true := by
-  simp [verum, BSMLFormula.isNEFree]
+    (verum : Formula Atom).isNEFree = true := by
+  simp [verum, Formula.isNEFree]
 
 /-- Finite conjunction of a list of formulas; the empty conjunction is `⊤`. -/
-def bigConj [Inhabited Atom] : List (BSMLFormula Atom) → BSMLFormula Atom
+def bigConj [Inhabited Atom] : List (Formula Atom) → Formula Atom
   | [] => verum
   | φ :: rest => .conj φ (bigConj rest)
 
-theorem classicalEval_bigConj [Inhabited Atom] (M : BSMLModel W Atom) (w : W)
-    (l : List (BSMLFormula Atom)) :
+theorem classicalEval_bigConj [Inhabited Atom] (M : KripkeModel W Atom) (w : W)
+    (l : List (Formula Atom)) :
     classicalEval M (bigConj l) w = true ↔ ∀ φ ∈ l, classicalEval M φ w = true := by
   induction l with
   | nil => simp [bigConj]
   | cons φ rest ih =>
     simp only [bigConj, classicalEval, Bool.and_eq_true, List.forall_mem_cons, ih]
 
-theorem isNEFree_bigConj [Inhabited Atom] (l : List (BSMLFormula Atom))
+theorem isNEFree_bigConj [Inhabited Atom] (l : List (Formula Atom))
     (h : ∀ φ ∈ l, φ.isNEFree = true) : (bigConj l).isNEFree = true := by
   induction l with
   | nil => simp [bigConj]
   | cons φ rest ih =>
-    simp only [bigConj, BSMLFormula.isNEFree, Bool.and_eq_true]
+    simp only [bigConj, Formula.isNEFree, Bool.and_eq_true]
     exact ⟨h φ (List.mem_cons.mpr (Or.inl rfl)),
            ih (fun ψ hψ => h ψ (List.mem_cons.mpr (Or.inr hψ)))⟩
 
@@ -87,21 +87,21 @@ theorem isNEFree_bigConj [Inhabited Atom] (l : List (BSMLFormula Atom))
     `p` (when `w ⊨ p`) or `¬p` (when `w ⊭ p`). The depth-0 characteristic
     formula. -/
 noncomputable def atomicType [Fintype Atom] [Inhabited Atom]
-    (M : BSMLModel W Atom) (w : W) : BSMLFormula Atom :=
+    (M : KripkeModel W Atom) (w : W) : Formula Atom :=
   bigConj ((Finset.univ : Finset Atom).toList.map
     (fun p => if M.val p w then .atom p else .neg (.atom p)))
 
 theorem isNEFree_atomicType [Fintype Atom] [Inhabited Atom]
-    (M : BSMLModel W Atom) (w : W) : (atomicType M w).isNEFree = true := by
+    (M : KripkeModel W Atom) (w : W) : (atomicType M w).isNEFree = true := by
   apply isNEFree_bigConj
   intro φ hφ
   obtain ⟨p, -, rfl⟩ := List.mem_map.mp hφ
-  cases M.val p w <;> simp [BSMLFormula.isNEFree]
+  cases M.val p w <;> simp [Formula.isNEFree]
 
 /-- The atomic type of `w` is classically satisfied at `v` exactly when `v` and
     `w` assign every atom the same value. -/
 theorem classicalEval_atomicType [Fintype Atom] [Inhabited Atom]
-    (M : BSMLModel W Atom) (w v : W) :
+    (M : KripkeModel W Atom) (w v : W) :
     classicalEval M (atomicType M w) v = true ↔ ∀ p : Atom, M.val p v = M.val p w := by
   rw [atomicType, classicalEval_bigConj]
   constructor
@@ -121,7 +121,7 @@ theorem classicalEval_atomicType [Fintype Atom] [Inhabited Atom]
     `v` iff `v` and `w` are 0-bisimilar. The base case of the characteristic-
     formula characterisation. -/
 theorem classicalEval_atomicType_iff_bisim0 [Fintype Atom] [Inhabited Atom]
-    (M : BSMLModel W Atom) (w v : W) :
+    (M : KripkeModel W Atom) (w v : W) :
     classicalEval M (atomicType M w) v = true ↔ WorldBisim 0 M w M v := by
   rw [classicalEval_atomicType]
   constructor

--- a/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
+++ b/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
@@ -20,7 +20,7 @@ proves the key equivalences and the replacement-failure counterexample.
   support of `φ` cannot share any world. Proved by structural induction.
 * `negation_incompatibility`: if `s` supports `¬φ` and `t` supports `φ`, then
   `s` and `t` are disjoint as finsets.
-* `replacement_failure_counterexample`: a concrete `BSMLModel` witnessing
+* `replacement_failure_counterexample`: a concrete `KripkeModel` witnessing
   `φ ≡ ψ ⇏ ¬φ ≡ ¬ψ`. The pair is `p ∧ ¬p` versus `¬NE`, both supported only
   by `∅`; their negations diverge there.
 
@@ -49,66 +49,68 @@ identification.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
 /-! ### Box-diamond duality -/
 
 /-- Box-diamond duality (support): definitionally equal since `□ := ¬◇¬`. -/
-theorem box_diamond_duality_support (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem box_diamond_duality_support (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     support M φ.nec t ↔ support M (.neg (.poss (.neg φ))) t := Iff.rfl
 
 /-- Box-diamond duality (anti-support): definitionally equal. -/
-theorem box_diamond_duality_antiSupport (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem box_diamond_duality_antiSupport (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     antiSupport M φ.nec t ↔ antiSupport M (.neg (.poss (.neg φ))) t := Iff.rfl
 
 /-! ### De Morgan laws -/
 
 /-- De Morgan for conjunction (support): `¬(φ ∧ ψ) ≡ ¬φ ∨ ¬ψ`.
     Both sides reduce to the same SPLIT existential. -/
-theorem deMorgan_conj_support (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+theorem deMorgan_conj_support (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     support M (.neg (.conj φ ψ)) t ↔
     support M (.disj (.neg φ) (.neg ψ)) t := Iff.rfl
 
 /-- De Morgan for conjunction (anti-support). -/
-theorem deMorgan_conj_antiSupport (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+theorem deMorgan_conj_antiSupport (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg (.conj φ ψ)) t ↔
     antiSupport M (.disj (.neg φ) (.neg ψ)) t := Iff.rfl
 
 /-- De Morgan for disjunction (support): `¬(φ ∨ ψ) ≡ ¬φ ∧ ¬ψ`. -/
-theorem deMorgan_disj_support (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+theorem deMorgan_disj_support (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     support M (.neg (.disj φ ψ)) t ↔
     support M (.conj (.neg φ) (.neg ψ)) t := Iff.rfl
 
 /-- De Morgan for disjunction (anti-support). -/
-theorem deMorgan_disj_antiSupport (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+theorem deMorgan_disj_antiSupport (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg (.disj φ ψ)) t ↔
     antiSupport M (.conj (.neg φ) (.neg ψ)) t := Iff.rfl
 
 /-! ### Bilateral equivalence statements -/
 
 /-- DNE is a full bilateral equivalence. -/
-theorem dne_equivalent (φ : BSMLFormula Atom) :
+theorem dne_equivalent (φ : Formula Atom) :
     equivalent (W := W) (.neg (.neg φ)) φ :=
   fun _ _ => ⟨Iff.rfl, Iff.rfl⟩
 
 /-- Box-diamond duality is a full bilateral equivalence. -/
-theorem box_diamond_equivalent (φ : BSMLFormula Atom) :
+theorem box_diamond_equivalent (φ : Formula Atom) :
     equivalent (W := W) φ.nec (.neg (.poss (.neg φ))) :=
   fun _ _ => ⟨Iff.rfl, Iff.rfl⟩
 
 /-- De Morgan for conjunction is a full bilateral equivalence. -/
-theorem deMorgan_conj_equivalent (φ ψ : BSMLFormula Atom) :
+theorem deMorgan_conj_equivalent (φ ψ : Formula Atom) :
     equivalent (W := W) (.neg (.conj φ ψ)) (.disj (.neg φ) (.neg ψ)) :=
   fun _ _ => ⟨Iff.rfl, Iff.rfl⟩
 
 /-- De Morgan for disjunction is a full bilateral equivalence. -/
-theorem deMorgan_disj_equivalent (φ ψ : BSMLFormula Atom) :
+theorem deMorgan_disj_equivalent (φ ψ : Formula Atom) :
     equivalent (W := W) (.neg (.disj φ ψ)) (.conj (.neg φ) (.neg ψ)) :=
   fun _ _ => ⟨Iff.rfl, Iff.rfl⟩
 
@@ -117,7 +119,7 @@ theorem deMorgan_disj_equivalent (φ ψ : BSMLFormula Atom) :
 /-- Pointwise form of the disjointness fact, with explicit team variables so
     the inductive hypothesis can apply across arbitrary `s`, `t`. -/
 private theorem notMem_of_antiSupport_of_support
-    (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
+    (M : KripkeModel W Atom) (φ : Formula Atom) :
     ∀ (s t : Finset W), antiSupport M φ s → support M φ t →
       ∀ w, w ∈ s → w ∉ t := by
   induction φ with
@@ -151,8 +153,8 @@ private theorem notMem_of_antiSupport_of_support
 
 /-- Anti-support and support of the same `φ` are disjoint teams: if `s`
     anti-supports `φ` and `t` supports `φ`, no world lies in both. -/
-theorem disjoint_support_antiSupport (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) {s t : Finset W}
+theorem disjoint_support_antiSupport (M : KripkeModel W Atom)
+    (φ : Formula Atom) {s t : Finset W}
     (hs : antiSupport M φ s) (ht : support M φ t) : Disjoint s t :=
   Finset.disjoint_left.mpr (notMem_of_antiSupport_of_support M φ s t hs ht)
 
@@ -160,8 +162,8 @@ theorem disjoint_support_antiSupport (M : BSMLModel W Atom)
     then `s` and `t` are disjoint as finsets.
 
     One-directional only — the converse fails in BSML; see [aloni-2022]. -/
-theorem negation_incompatibility (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) {s t : Finset W}
+theorem negation_incompatibility (M : KripkeModel W Atom)
+    (φ : Formula Atom) {s t : Finset W}
     (hs : support M (.neg φ) s) (ht : support M φ t) : Disjoint s t :=
   disjoint_support_antiSupport M φ hs ht
 
@@ -175,7 +177,7 @@ theorem negation_incompatibility (M : BSMLModel W Atom)
     trivial split `∅ ∪ ∅`, while `¬¬NE = NE` requires a non-empty team. -/
 theorem replacement_failure_counterexample :
     ∃ (W : Type) (_ : DecidableEq W) (_ : Fintype W)
-      (M : BSMLModel W String) (t : Finset W),
+      (M : KripkeModel W String) (t : Finset W),
       (support M (.conj (.atom "p") (.neg (.atom "p"))) t ↔
        support M (.neg .ne) t) ∧
       ¬(support M (.neg (.conj (.atom "p") (.neg (.atom "p")))) t ↔

--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -26,7 +26,7 @@ formulas are evaluated against teams, not updated by them
 
 ## Atom polymorphism
 
-Both `BSMLFormula` and `BSMLModel` are parameterized over an atom type
+Both `Formula` and `KripkeModel` are parameterized over an atom type
 `Atom : Type*`. This eliminates the silent typo trap of String-keyed
 valuations and aligns with the predicate-level extension in QBSML
 ([aloni-vanormondt-2023]), which generalizes atoms to typed
@@ -58,7 +58,8 @@ The support and anti-support clauses exhibit a striking duality:
 
 ## Implementation
 
-Teams are `Finset W` (with `[DecidableEq W] [Fintype W]`).
+Models are the shared `Modal.KripkeModel` carrier (Definition 1,
+[aloni-2022]); teams are `Finset W` (with `[DecidableEq W] [Fintype W]`).
 Support and anti-support are unified into a single `eval` function
 parameterized by a `Bool` polarity. This makes DNE definitional
 (`eval M true (.neg (.neg φ)) t` reduces to `eval M true φ t` by
@@ -70,6 +71,8 @@ computational verification via `#guard decide (...)`.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 -- ============================================================================
 -- §1: Formulas (Definition 1)
 -- ============================================================================
@@ -79,20 +82,20 @@ namespace BSML
     Parameterized over an atom type `Atom : Type*`. The base language is:
     p | ¬φ | φ∧ψ | φ∨ψ | ◇φ | NE.
     □ is NOT a primitive — it is defined as an abbreviation:
-    □φ := ¬◇¬φ (see `BSMLFormula.nec`). -/
-inductive BSMLFormula (Atom : Type*) where
+    □φ := ¬◇¬φ (see `Formula.nec`). -/
+inductive Formula (Atom : Type*) where
   /-- Atomic proposition -/
-  | atom : Atom → BSMLFormula Atom
+  | atom : Atom → Formula Atom
   /-- Non-emptiness atom: team is non-empty -/
-  | ne : BSMLFormula Atom
+  | ne : Formula Atom
   /-- Negation: swap support/anti-support -/
-  | neg : BSMLFormula Atom → BSMLFormula Atom
+  | neg : Formula Atom → Formula Atom
   /-- Conjunction -/
-  | conj : BSMLFormula Atom → BSMLFormula Atom → BSMLFormula Atom
+  | conj : Formula Atom → Formula Atom → Formula Atom
   /-- Split disjunction -/
-  | disj : BSMLFormula Atom → BSMLFormula Atom → BSMLFormula Atom
+  | disj : Formula Atom → Formula Atom → Formula Atom
   /-- Possibility modal -/
-  | poss : BSMLFormula Atom → BSMLFormula Atom
+  | poss : Formula Atom → Formula Atom
   deriving Repr
 
 variable {Atom : Type*}
@@ -102,13 +105,13 @@ variable {Atom : Type*}
     - s ⊨⁺ □φ iff ∀w∈s, R[w] ⊨⁺ φ
     - s ⊨⁻ □φ iff ∀w∈s, ∃ ne t⊆R[w], t ⊨⁻ φ
     These follow from the definitions of ¬, ◇, and ¬ applied to φ. -/
-def BSMLFormula.nec (φ : BSMLFormula Atom) : BSMLFormula Atom :=
+def Formula.nec (φ : Formula Atom) : Formula Atom :=
   .neg (.poss (.neg φ))
 
 /-- A formula is NE-free if it does not contain the NE atom.
     For NE-free formulas, BSML reduces to classical modal logic
     on singleton teams (Fact 15, [aloni-2022]). -/
-def BSMLFormula.isNEFree : BSMLFormula Atom → Bool
+def Formula.isNEFree : Formula Atom → Bool
   | .atom _ => true
   | .ne => false
   | .neg φ => φ.isNEFree
@@ -117,7 +120,7 @@ def BSMLFormula.isNEFree : BSMLFormula Atom → Bool
   | .poss φ => φ.isNEFree
 
 /-- A formula is positive if it contains no negation. -/
-def BSMLFormula.isPositive : BSMLFormula Atom → Bool
+def Formula.isPositive : Formula Atom → Bool
   | .atom _ => true
   | .ne => true
   | .neg _ => false
@@ -126,25 +129,14 @@ def BSMLFormula.isPositive : BSMLFormula Atom → Bool
   | .poss φ => φ.isPositive
 
 /-- A formula is atomic (a single propositional variable). -/
-def BSMLFormula.isAtom : BSMLFormula Atom → Bool
+def Formula.isAtom : Formula Atom → Bool
   | .atom _ => true
   | _ => false
 
 /-- Atoms are NE-free. -/
-theorem BSMLFormula.isAtom_implies_isNEFree (φ : BSMLFormula Atom)
+theorem Formula.isAtom_implies_isNEFree (φ : Formula Atom)
     (h : φ.isAtom = true) : φ.isNEFree = true := by
   cases φ <;> simp_all [isAtom, isNEFree]
-
--- ============================================================================
--- §2: Models
--- ============================================================================
-
-/-- A BSML model (Definition 1, [aloni-2022]): accessibility and
-    valuation over a finite type of worlds. Aliased to the generic
-    `Modal.KripkeModel`; the carrier structure is identical,
-    `BSMLModel` is just the name BSML literature uses. -/
-abbrev BSMLModel (W : Type*) (Atom : Type*) [DecidableEq W] [Fintype W] :=
-  Modal.KripkeModel W Atom
 
 -- ============================================================================
 -- §3: Evaluation (Definition 2)
@@ -161,7 +153,7 @@ variable {W : Type*} [DecidableEq W] [Fintype W]
     Split disjunction and split conjunction-anti-support clauses use
     `Team.splitsAs` (= `t₁ ∪ t₂ = t`); the recursion is
     the same shape QBSML reuses at the `Finset (W × Assignment)` carrier. -/
-def eval (M : BSMLModel W Atom) : Bool → BSMLFormula Atom → Finset W → Prop
+def eval (M : KripkeModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | true,  .atom p,       t => ∀ w ∈ t, M.val p w = true
   | false, .atom p,       t => ∀ w ∈ t, M.val p w = false
   | true,  .ne,           t => t.Nonempty
@@ -180,11 +172,11 @@ def eval (M : BSMLModel W Atom) : Bool → BSMLFormula Atom → Finset W → Pro
   | false, .poss ψ,       t => ∀ w ∈ t, eval M false ψ (M.access w)
 
 /-- Support: positive evaluation. -/
-abbrev support (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (t : Finset W) : Prop :=
+abbrev support (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M true φ t
 
 /-- Anti-support: negative evaluation. -/
-abbrev antiSupport (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (t : Finset W) : Prop :=
+abbrev antiSupport (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M false φ t
 
 -- ============================================================================
@@ -192,46 +184,46 @@ abbrev antiSupport (M : BSMLModel W Atom) (φ : BSMLFormula Atom) (t : Finset W)
 -- ============================================================================
 
 /-- DNE: ¬¬φ has the same support as φ. Definitional with the polarity design. -/
-theorem dne_support (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem dne_support (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     support M (.neg (.neg φ)) t ↔ support M φ t := Iff.rfl
 
 /-- DNE: ¬¬φ has the same anti-support as φ. -/
-theorem dne_antiSupport (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem dne_antiSupport (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg (.neg φ)) t ↔ antiSupport M φ t := Iff.rfl
 
 -- ============================================================================
 -- §5: Unfolding Lemmas
 -- ============================================================================
 
-@[simp] lemma support_neg (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+@[simp] lemma support_neg (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     support M (.neg φ) t ↔ antiSupport M φ t := Iff.rfl
 
-@[simp] lemma antiSupport_neg (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_neg (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg φ) t ↔ support M φ t := Iff.rfl
 
 /-- BSML's `support` and `antiSupport` form a paraconsistent bilateral
-    logic (`Bilateral.IsBilateral`) under `BSMLFormula.neg`.
+    logic (`Bilateral.IsBilateral`) under `Formula.neg`.
     Pointwise polarity-flip lemmas (`support_neg` / `antiSupport_neg`,
     both `Iff.rfl`) lift to function equality via `IsBilateral.of_iff`. -/
-theorem isBilateral (M : BSMLModel W Atom) :
+theorem isBilateral (M : KripkeModel W Atom) :
     Bilateral.IsBilateral
-      (support M) (antiSupport M) BSMLFormula.neg :=
+      (support M) (antiSupport M) Formula.neg :=
   Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
 
-@[simp] lemma support_conj (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+@[simp] lemma support_conj (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     support M (.conj φ ψ) t ↔ support M φ t ∧ support M ψ t := Iff.rfl
 
-@[simp] lemma antiSupport_disj (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_disj (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.disj φ ψ) t ↔ antiSupport M φ t ∧ antiSupport M ψ t := Iff.rfl
 
 /-- Empty team supports all atoms (vacuous truth). -/
-lemma empty_supports_atom (M : BSMLModel W Atom) (p : Atom) :
+lemma empty_supports_atom (M : KripkeModel W Atom) (p : Atom) :
     support M (.atom p) ∅ := by
   intro w hw; exact absurd hw (by simp)
 
@@ -244,33 +236,33 @@ lemma empty_supports_atom (M : BSMLModel W Atom) (p : Atom) :
 
     Defined via `Team.IsIndisputable` to share substrate
     with QBSML and any other state-based logic. -/
-def BSMLModel.IsIndisputable (M : BSMLModel W Atom) (t : Finset W) : Prop :=
+def _root_.Modal.KripkeModel.IsIndisputable (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsIndisputable M.access t
 
 /-- State-based accessibility: every world in team has the team itself as
     accessible worlds. Strictly stronger than indisputability.
 
     Defined via `Team.IsStateBased`. -/
-def BSMLModel.IsStateBased (M : BSMLModel W Atom) (t : Finset W) : Prop :=
+def _root_.Modal.KripkeModel.IsStateBased (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsStateBased M.access t
 
-instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) := by
-  unfold BSMLModel.IsIndisputable; infer_instance
+instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) := by
+  unfold Modal.KripkeModel.IsIndisputable; infer_instance
 
-instance (M : BSMLModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) := by
-  unfold BSMLModel.IsStateBased; infer_instance
+instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) := by
+  unfold Modal.KripkeModel.IsStateBased; infer_instance
 
 -- ============================================================================
 -- §7: Semantic Relations
 -- ============================================================================
 
 /-- Semantic consequence: φ ⊨ ψ if every team supporting φ also supports ψ. -/
-def consequence (φ ψ : BSMLFormula Atom) : Prop :=
-  ∀ (M : BSMLModel W Atom) (t : Finset W), support M φ t → support M ψ t
+def consequence (φ ψ : Formula Atom) : Prop :=
+  ∀ (M : KripkeModel W Atom) (t : Finset W), support M φ t → support M ψ t
 
 /-- Semantic equivalence: same support and anti-support conditions. -/
-def equivalent (φ ψ : BSMLFormula Atom) : Prop :=
-  ∀ (M : BSMLModel W Atom) (t : Finset W),
+def equivalent (φ ψ : Formula Atom) : Prop :=
+  ∀ (M : KripkeModel W Atom) (t : Finset W),
     (support M φ t ↔ support M ψ t) ∧ (antiSupport M φ t ↔ antiSupport M ψ t)
 
 -- ============================================================================
@@ -286,7 +278,7 @@ def equivalent (φ ψ : BSMLFormula Atom) : Prop :=
     actual BSML* uses bilateral polarity mirror BSML's; completing this
     requires a proper polarity-flipped supportStar definition. Completing
     bilateral negation for BSML* is tracked as out-of-scope. -/
-def supportStar (M : BSMLModel W Atom) : BSMLFormula Atom → Finset W → Prop
+def supportStar (M : KripkeModel W Atom) : Formula Atom → Finset W → Prop
   | .atom p, t => ∀ w ∈ t, M.val p w = true
   | .ne, t => t.Nonempty
   | .neg _, _ => True
@@ -299,16 +291,16 @@ def supportStar (M : BSMLModel W Atom) : BSMLFormula Atom → Finset W → Prop
 /-- BSML* consequence: consequence using BSML* support (non-empty intermediate
     states) on non-empty teams. In BSML*, the empty set ∅ is not among the
     possible states ([aloni-2022] §6.3.1). -/
-def consequenceStar (φ ψ : BSMLFormula Atom) : Prop :=
-  ∀ (M : BSMLModel W Atom) (t : Finset W), t.Nonempty → supportStar M φ t → supportStar M ψ t
+def consequenceStar (φ ψ : Formula Atom) : Prop :=
+  ∀ (M : KripkeModel W Atom) (t : Finset W), t.Nonempty → supportStar M φ t → supportStar M ψ t
 
 -- ============================================================================
 -- §9: Decidable Instance
 -- ============================================================================
 
 /-- Decidability of `eval` by structural recursion on the formula. -/
-def decidableEval (M : BSMLModel W Atom) :
-    (pol : Bool) → (φ : BSMLFormula Atom) → (t : Finset W) → Decidable (eval M pol φ t)
+def decidableEval (M : KripkeModel W Atom) :
+    (pol : Bool) → (φ : Formula Atom) → (t : Finset W) → Decidable (eval M pol φ t)
   | true,  .atom _, t => by unfold eval; infer_instance
   | false, .atom _, t => by unfold eval; infer_instance
   | true,  .ne,     t => by unfold eval; infer_instance
@@ -371,7 +363,7 @@ def decidableEval (M : BSMLModel W Atom) :
         (fun w _ => eval M false ψ (M.access w))
         (fun w _ => decidableEval M false ψ (M.access w))
 
-instance instDecidableEval (M : BSMLModel W Atom) (pol : Bool) (φ : BSMLFormula Atom)
+instance instDecidableEval (M : KripkeModel W Atom) (pol : Bool) (φ : Formula Atom)
     (t : Finset W) : Decidable (eval M pol φ t) := decidableEval M pol φ t
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/BSML/Enrichment.lean
@@ -26,6 +26,8 @@ non-empty witnesses — yielding free choice.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
 -- ============================================================================
@@ -44,7 +46,7 @@ Recursively adds non-emptiness constraints at every level:
 - `[◇φ]⁺ = ◇[φ]⁺ ∧ NE`
 - `[□φ]⁺ = □[φ]⁺ ∧ NE`
 -/
-def enrich : BSMLFormula Atom → BSMLFormula Atom
+def enrich : Formula Atom → Formula Atom
   | .atom p => .conj (.atom p) .ne
   | .ne => .ne
   | .neg φ => .conj (.neg (enrich φ)) .ne
@@ -56,16 +58,16 @@ def enrich : BSMLFormula Atom → BSMLFormula Atom
 -- §2: Structure Lemmas
 -- ============================================================================
 
-theorem enrich_neg_structure (φ : BSMLFormula Atom) :
+theorem enrich_neg_structure (φ : Formula Atom) :
     enrich (.neg φ) = .conj (.neg (enrich φ)) .ne := rfl
 
-theorem enrich_conj_structure (φ ψ : BSMLFormula Atom) :
+theorem enrich_conj_structure (φ ψ : Formula Atom) :
     enrich (.conj φ ψ) = .conj (.conj (enrich φ) (enrich ψ)) .ne := rfl
 
-theorem enrich_disj_structure (φ ψ : BSMLFormula Atom) :
+theorem enrich_disj_structure (φ ψ : Formula Atom) :
     enrich (.disj φ ψ) = .conj (.disj (enrich φ) (enrich ψ)) .ne := rfl
 
-theorem enrich_poss_structure (φ : BSMLFormula Atom) :
+theorem enrich_poss_structure (φ : Formula Atom) :
     enrich (.poss φ) = .conj (.poss (enrich φ)) .ne := rfl
 
 -- ============================================================================
@@ -73,8 +75,8 @@ theorem enrich_poss_structure (φ : BSMLFormula Atom) :
 -- ============================================================================
 
 /-- If an enriched formula is supported, the team is non-empty. -/
-theorem enriched_support_implies_nonempty (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enriched_support_implies_nonempty (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (h : support M (enrich φ) t) : t.Nonempty := by
   cases φ with
   | ne => exact h
@@ -86,16 +88,16 @@ theorem enriched_support_implies_nonempty (M : BSMLModel W Atom)
 
 /-- If disjunction is supported, there exists a split where both parts
     support their disjuncts. -/
-theorem split_exists (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W)
+theorem split_exists (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W)
     (h : support M (.disj φ ψ) t) :
     ∃ t₁ t₂ : Finset W, support M φ t₁ ∧ support M ψ t₂ := by
   obtain ⟨t₁, t₂, _, h₁, h₂⟩ := h
   exact ⟨t₁, t₂, h₁, h₂⟩
 
 /-- Enriched disjunction forces both parts of split to be non-empty. -/
-theorem enriched_split_forces_both_nonempty (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W)
+theorem enriched_split_forces_both_nonempty (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W)
     (h : support M (.disj (enrich φ) (enrich ψ)) t) :
     ∃ t₁ t₂ : Finset W,
       t₁.Nonempty ∧ t₂.Nonempty ∧
@@ -113,8 +115,8 @@ theorem enriched_split_forces_both_nonempty (M : BSMLModel W Atom)
 /-- Anti-support of (φ ∧ NE) implies anti-support of φ.
     From the SPLIT, one part anti-supports φ and the other (anti-supporting NE)
     is empty, so the first part is the whole team. -/
-theorem antiSupport_strip_ne (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem antiSupport_strip_ne (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (h : antiSupport M (.conj φ .ne) t) :
     antiSupport M φ t := by
   obtain ⟨t₁, t₂, hunion, h₁, h₂⟩ := h
@@ -125,15 +127,15 @@ theorem antiSupport_strip_ne (M : BSMLModel W Atom)
 
 /-- Anti-support of φ implies anti-support of (φ ∧ NE).
     Use the trivial split (t, ∅). -/
-theorem antiSupport_conj_ne_of_antiSupport (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem antiSupport_conj_ne_of_antiSupport (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (h : antiSupport M φ t) :
     antiSupport M (.conj φ .ne) t :=
   ⟨t, ∅, by simp, h, rfl⟩
 
 /-- Anti-support of (φ ∧ NE) ↔ anti-support of φ. -/
-theorem antiSupport_conj_ne_iff (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem antiSupport_conj_ne_iff (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.conj φ .ne) t ↔ antiSupport M φ t :=
   ⟨antiSupport_strip_ne M φ t, antiSupport_conj_ne_of_antiSupport M φ t⟩
 
@@ -143,8 +145,8 @@ theorem antiSupport_conj_ne_iff (M : BSMLModel W Atom)
 
 /-- Anti-support monotonicity for ◇: if antiSupport of φ implies antiSupport of ψ
     for all teams, then ◇φ anti-support implies ◇ψ anti-support. -/
-theorem antiSupport_poss_weaken (M : BSMLModel W Atom)
-    (φ ψ : BSMLFormula Atom) (t : Finset W)
+theorem antiSupport_poss_weaken (M : KripkeModel W Atom)
+    (φ ψ : Formula Atom) (t : Finset W)
     (hmono : ∀ t' : Finset W, antiSupport M φ t' → antiSupport M ψ t')
     (h : antiSupport M (.poss φ) t) :
     antiSupport M (.poss ψ) t :=
@@ -156,22 +158,22 @@ theorem antiSupport_poss_weaken (M : BSMLModel W Atom)
 
 /-- Both directions of Fact 1 (enrichment strengthens), proved by simultaneous
     induction on formula structure. -/
-private theorem enrichment_strengthens_both (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (hNE : φ.isNEFree = true) :
+private theorem enrichment_strengthens_both (M : KripkeModel W Atom)
+    (φ : Formula Atom) (hNE : φ.isNEFree = true) :
     (∀ t, support M (enrich φ) t → support M φ t) ∧
     (∀ t, antiSupport M (enrich φ) t → antiSupport M φ t) := by
   induction φ with
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | atom p =>
     exact ⟨fun t h => h.1, fun t h => antiSupport_strip_ne M (.atom p) t h⟩
   | neg ψ ih =>
-    have ⟨ih_s, ih_a⟩ := ih (by simp [BSMLFormula.isNEFree] at hNE; exact hNE)
+    have ⟨ih_s, ih_a⟩ := ih (by simp [Formula.isNEFree] at hNE; exact hNE)
     exact ⟨fun t h => ih_a t h.1, fun t h => ih_s t (antiSupport_strip_ne M _ t h)⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
     have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
     constructor
@@ -182,9 +184,9 @@ private theorem enrichment_strengthens_both (M : BSMLModel W Atom)
       exact ⟨s₁, s₂, hunion, ih₁_a s₁ h₁, ih₂_a s₂ h₂⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
     have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
     constructor
@@ -195,7 +197,7 @@ private theorem enrichment_strengthens_both (M : BSMLModel W Atom)
       have h' := antiSupport_strip_ne M (.disj (enrich ψ₁) (enrich ψ₂)) t h
       exact ⟨ih₁_a t h'.1, ih₂_a t h'.2⟩
   | poss ψ ih =>
-    have ⟨ih_s, ih_a⟩ := ih (by simp [BSMLFormula.isNEFree] at hNE; exact hNE)
+    have ⟨ih_s, ih_a⟩ := ih (by simp [Formula.isNEFree] at hNE; exact hNE)
     constructor
     · intro t h w hw
       obtain ⟨s, hs, hne, hsupp⟩ := h.1 w hw
@@ -210,16 +212,16 @@ Enrichment strengthens: [α]⁺ ⊨ α (Fact 1 from [aloni-2022]).
 For NE-free α, if a team supports the enriched formula [α]⁺, it also
 supports the original α.
 -/
-theorem enrichment_strengthens_support (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enrichment_strengthens_support (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hNE : φ.isNEFree = true)
     (h : support M (enrich φ) t) :
     support M φ t :=
   (enrichment_strengthens_both M φ hNE).1 t h
 
 /-- Enrichment strengthens (anti-support direction of Fact 1). -/
-theorem enrichment_strengthens_antiSupport (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enrichment_strengthens_antiSupport (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hNE : φ.isNEFree = true)
     (h : antiSupport M (enrich φ) t) :
     antiSupport M φ t :=
@@ -232,8 +234,8 @@ theorem enrichment_strengthens_antiSupport (M : BSMLModel W Atom)
 /--
 Fact 2 from [aloni-2022]: [α]⁺ ⊨ α ∧ NE for NE-free α.
 -/
-theorem enrichment_entails_conj_ne (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enrichment_entails_conj_ne (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hNE : φ.isNEFree = true)
     (h : support M (enrich φ) t) :
     support M (.conj φ .ne) t :=
@@ -250,16 +252,16 @@ Pragmatic enrichment is vacuous under single negation for positive formulas
 
 For positive α (no negation): ¬[α]⁺ ≡ ¬α (both support and anti-support).
 -/
-theorem enrichment_vacuous_under_negation (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enrichment_vacuous_under_negation (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hPos : φ.isPositive = true) :
     antiSupport M (enrich φ) t ↔ antiSupport M φ t := by
   induction φ generalizing t with
   | atom p => exact antiSupport_conj_ne_iff M (.atom p) t
   | ne => exact Iff.rfl
-  | neg _ => simp [BSMLFormula.isPositive] at hPos
+  | neg _ => simp [Formula.isPositive] at hPos
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    simp only [BSMLFormula.isPositive, Bool.and_eq_true] at hPos
+    simp only [Formula.isPositive, Bool.and_eq_true] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show (∃ t₁ t₂, t₁ ∪ t₂ = t ∧ antiSupport M (enrich ψ₁) t₁ ∧
@@ -271,7 +273,7 @@ theorem enrichment_vacuous_under_negation (M : BSMLModel W Atom)
     · rintro ⟨t₁, t₂, hu, h₁, h₂⟩
       exact ⟨t₁, t₂, hu, (ih₁ t₁ hPos.1).mpr h₁, (ih₂ t₂ hPos.2).mpr h₂⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    simp only [BSMLFormula.isPositive, Bool.and_eq_true] at hPos
+    simp only [Formula.isPositive, Bool.and_eq_true] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show antiSupport M (enrich ψ₁) t ∧ antiSupport M (enrich ψ₂) t ↔
@@ -279,7 +281,7 @@ theorem enrichment_vacuous_under_negation (M : BSMLModel W Atom)
     exact ⟨fun ⟨h₁, h₂⟩ => ⟨(ih₁ t hPos.1).mp h₁, (ih₂ t hPos.2).mp h₂⟩,
            fun ⟨h₁, h₂⟩ => ⟨(ih₁ t hPos.1).mpr h₁, (ih₂ t hPos.2).mpr h₂⟩⟩
   | poss ψ ih =>
-    simp only [BSMLFormula.isPositive] at hPos
+    simp only [Formula.isPositive] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show (∀ w ∈ t, antiSupport M (enrich ψ) (M.access w)) ↔
@@ -288,8 +290,8 @@ theorem enrichment_vacuous_under_negation (M : BSMLModel W Atom)
            fun h w hw => (ih _ hPos).mpr (h w hw)⟩
 
 /-- Fact 9, support direction: support M (.neg (enrich φ)) t ↔ support M (.neg φ) t. -/
-theorem enrichment_vacuous_under_negation_support (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+theorem enrichment_vacuous_under_negation_support (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hPos : φ.isPositive = true) :
     support M (.neg (enrich φ)) t ↔ support M (.neg φ) t :=
   enrichment_vacuous_under_negation M φ t hPos
@@ -300,8 +302,8 @@ theorem enrichment_vacuous_under_negation_support (M : BSMLModel W Atom)
 
 /-- BSML+ consequence: consequence between enriched formulas.
     α ⊨_{BSML+} β iff [α]⁺ ⊨_{BSML} [β]⁺ ([aloni-2022] §6.3.1). -/
-def consequencePlus (φ ψ : BSMLFormula Atom) : Prop :=
-  ∀ (M : BSMLModel W Atom) (t : Finset W), support M (enrich φ) t → support M (enrich ψ) t
+def consequencePlus (φ ψ : Formula Atom) : Prop :=
+  ∀ (M : KripkeModel W Atom) (t : Finset W), support M (enrich φ) t → support M (enrich ψ) t
 
 -- ============================================================================
 -- §11: BSML* ↔ BSML+ for Classical Positive Formulas (Fact 13)
@@ -310,29 +312,29 @@ def consequencePlus (φ ψ : BSMLFormula Atom) : Prop :=
 /-- A formula is classical positive: no NE atom and no negation.
     These are the formulas for which BSML* and BSML+ consequence coincide
     ([aloni-2022] Fact 13). -/
-def BSMLFormula.isClassicalPositive (φ : BSMLFormula Atom) : Bool :=
+def Formula.isClassicalPositive (φ : Formula Atom) : Bool :=
   φ.isNEFree && φ.isPositive
 
 /-- For classical positive formulas, enriched support is equivalent to BSML*
     support plus non-emptiness. The key insight is that enrichment adds NE at
     every level, which exactly matches BSML*'s exclusion of ∅ from all
     intermediate states (including disjunction splits). -/
-private theorem enriched_iff_star_nonempty (M : BSMLModel W Atom)
-    (φ : BSMLFormula Atom) (t : Finset W)
+private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W)
     (hCP : φ.isClassicalPositive = true) :
     support M (enrich φ) t ↔ supportStar M φ t ∧ t.Nonempty := by
   induction φ generalizing t with
-  | ne => simp [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree] at hCP
-  | neg _ => simp [BSMLFormula.isClassicalPositive, BSMLFormula.isPositive] at hCP
+  | ne => simp [Formula.isClassicalPositive, Formula.isNEFree] at hCP
+  | neg _ => simp [Formula.isClassicalPositive, Formula.isPositive] at hCP
   | atom _ => exact Iff.rfl
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.isClassicalPositive = true := by
-      simp only [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree,
-                  BSMLFormula.isPositive, Bool.and_eq_true] at hCP ⊢
+      simp only [Formula.isClassicalPositive, Formula.isNEFree,
+                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
       exact ⟨hCP.1.1, hCP.2.1⟩
     have hψ₂ : ψ₂.isClassicalPositive = true := by
-      simp only [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree,
-                  BSMLFormula.isPositive, Bool.and_eq_true] at hCP ⊢
+      simp only [Formula.isClassicalPositive, Formula.isNEFree,
+                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
       exact ⟨hCP.1.2, hCP.2.2⟩
     simp only [enrich, support, eval, supportStar]
     constructor
@@ -342,12 +344,12 @@ private theorem enriched_iff_star_nonempty (M : BSMLModel W Atom)
       exact ⟨⟨(ih₁ t hψ₁).mpr ⟨h₁, hne⟩, (ih₂ t hψ₂).mpr ⟨h₂, hne⟩⟩, hne⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.isClassicalPositive = true := by
-      simp only [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree,
-                  BSMLFormula.isPositive, Bool.and_eq_true] at hCP ⊢
+      simp only [Formula.isClassicalPositive, Formula.isNEFree,
+                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
       exact ⟨hCP.1.1, hCP.2.1⟩
     have hψ₂ : ψ₂.isClassicalPositive = true := by
-      simp only [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree,
-                  BSMLFormula.isPositive, Bool.and_eq_true] at hCP ⊢
+      simp only [Formula.isClassicalPositive, Formula.isNEFree,
+                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
       exact ⟨hCP.1.2, hCP.2.2⟩
     simp only [enrich, support, eval, supportStar]
     constructor
@@ -360,8 +362,8 @@ private theorem enriched_iff_star_nonempty (M : BSMLModel W Atom)
               (ih₂ t₂ hψ₂).mpr ⟨hs₂, hne₂⟩⟩, hne⟩
   | poss ψ ih =>
     have hψ : ψ.isClassicalPositive = true := by
-      simp only [BSMLFormula.isClassicalPositive, BSMLFormula.isNEFree,
-                  BSMLFormula.isPositive] at hCP; exact hCP
+      simp only [Formula.isClassicalPositive, Formula.isNEFree,
+                  Formula.isPositive] at hCP; exact hCP
     simp only [enrich, support, eval, supportStar]
     constructor
     · intro ⟨hposs, hne⟩
@@ -381,7 +383,7 @@ If we restrict to positive formulas without NE or ¬, then ruling out the
 empty state syntactically (via [·]⁺ enrichment) is equivalent to ruling
 it out model-theoretically (via BSML* non-empty restriction).
 -/
-theorem bsmlStar_iff_bsmlPlus (φ ψ : BSMLFormula Atom)
+theorem bsmlStar_iff_bsmlPlus (φ ψ : Formula Atom)
     (hφ : φ.isClassicalPositive = true) (hψ : ψ.isClassicalPositive = true) :
     consequenceStar (W := W) φ ψ ↔ consequencePlus (W := W) φ ψ := by
   constructor
@@ -409,7 +411,7 @@ support p ∧ NE (the NE conjunct fails).
 -/
 theorem enrichment_not_vacuous_under_double_negation :
     ∃ (W : Type) (_ : DecidableEq W) (_ : Fintype W)
-      (M : BSMLModel W String) (t : Finset W),
+      (M : KripkeModel W String) (t : Finset W),
       -- ¬¬p holds on ∅ (by DNE, = vacuous support of p)
       support M (.neg (.neg (.atom "p"))) t ∧
       -- but ¬¬[p]⁺ fails on ∅ (= p ∧ NE requires non-emptiness)

--- a/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
+++ b/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
@@ -48,24 +48,24 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
     `k` it is closed under `k`-bisimulation of teams within `M`. This is the
     closure invariant — alongside convexity and union closure — that
     characterises BSML-definability ([anttila-2025] Ch 3). -/
-def BisimClosed (M : BSMLModel W Atom) (P : TeamProperty W) : Prop :=
+def BisimClosed (M : KripkeModel W Atom) (P : TeamProperty W) : Prop :=
   ∃ k : ℕ, ∀ s s' : Finset W, StateBisim k M s M s' → (s ∈ P ↔ s' ∈ P)
 
 /-- The class of bounded-bisimulation-closed team properties of `M`. -/
-def bisimClosedProperties (M : BSMLModel W Atom) : Set (TeamProperty W) :=
+def bisimClosedProperties (M : KripkeModel W Atom) : Set (TeamProperty W) :=
   { P | BisimClosed M P }
 
 /-- **BSML support is bounded-bisimulation invariant within a model**: if
     `s ⇌_k s'` and `k ≥ φ.modalDepth`, then `s` and `s'` agree on `φ`. Immediate
     from Theorem 3.8 (`bisim_invariant_eval`) at `M' := M`. -/
-theorem bisimInvariant_support (M : BSMLModel W Atom) (φ : BSMLFormula Atom)
+theorem bisimInvariant_support (M : KripkeModel W Atom) (φ : Formula Atom)
     {k : ℕ} (hd : φ.modalDepth ≤ k) {s s' : Finset W}
     (h : StateBisim k M s M s') : support M φ s ↔ support M φ s' :=
   bisim_invariant_eval φ hd h true
 
 /-- Every BSML-definable team property is bounded-bisimulation-closed, with
     witnessing depth the formula's modal depth. -/
-theorem bisimClosed_definedBy (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
+theorem bisimClosed_definedBy (M : KripkeModel W Atom) (φ : Formula Atom) :
     BisimClosed M (definedBy (support M) φ) :=
   ⟨φ.modalDepth, fun _ _ h => bisimInvariant_support M φ le_rfl h⟩
 
@@ -74,7 +74,7 @@ theorem bisimClosed_definedBy (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
 /-- **Soundness half** ([anttila-2025] Ch 3): every BSML-definable team
     property is convex, union-closed, and bounded-bisimulation-closed. Assembles
     `ordConnected_support`, `supClosed_support`, and `bisimClosed_definedBy`. -/
-theorem expressiveSoundness (M : BSMLModel W Atom) :
+theorem expressiveSoundness (M : KripkeModel W Atom) :
     definableClass (support M) ⊆
       convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M := by
   intro P hP
@@ -96,7 +96,7 @@ theorem expressiveSoundness (M : BSMLModel W Atom) :
     with `NE` (the convex + union-closed normal form — the converse of
     Proposition 3.3.1). This is the within-model specialisation of Anttila's
     cross-model theorem. -/
-theorem expressiveCompleteness_converse (M : BSMLModel W Atom) :
+theorem expressiveCompleteness_converse (M : KripkeModel W Atom) :
     convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M ⊆
       definableClass (support M) := by
   sorry
@@ -104,7 +104,7 @@ theorem expressiveCompleteness_converse (M : BSMLModel W Atom) :
 /-- **BSML is expressively complete** for the convex, union-closed,
     bounded-bisimulation-closed team properties ([anttila-2025] Ch 3).
     Inherits the `sorry` of `expressiveCompleteness_converse`. -/
-theorem expressivelyComplete (M : BSMLModel W Atom) :
+theorem expressivelyComplete (M : KripkeModel W Atom) :
     ExpressivelyCompleteFor (support M)
       (convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M) :=
   Set.Subset.antisymm (expressiveSoundness M) (expressiveCompleteness_converse M)

--- a/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
+++ b/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
@@ -20,7 +20,7 @@ exactly the NE-free fragment.
 
 ## Main declarations
 
-* `BSMLFormula.bot`, `BSMLFormula.botbot` — the weak contradiction `p ∧ ¬p`
+* `Formula.bot`, `Formula.botbot` — the weak contradiction `p ∧ ¬p`
   ([aloni-2022]'s definition; the paper takes `⊥` as primitive only to
   simplify exposition) and the strong contradiction `⊥ ∧ NE`.
 * `support_bot_iff` — `⊥` is supported exactly by the empty team.
@@ -35,7 +35,7 @@ exactly the NE-free fragment.
 
 ## Implementation notes
 
-* `BSMLFormula` has no `⊥` primitive (and `eval`'s shape is load-bearing
+* `Formula` has no `⊥` primitive (and `eval`'s shape is load-bearing
   downstream), so rules mentioning `⊥` are parameterized by a witness atom
   `p`; `support_bot_iff` shows support is `p`-independent.
 * The three `⊥NETrs` substitution rules completing the full BSML system
@@ -48,6 +48,8 @@ exactly the NE-free fragment.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 open Team
 
 variable {Atom : Type*} {W : Type*} [DecidableEq W] [Fintype W]
@@ -56,15 +58,15 @@ variable {Atom : Type*} {W : Type*} [DecidableEq W] [Fintype W]
 
 /-- The weak contradiction `⊥ := p ∧ ¬p` ([aloni-2022]; supported exactly by
     the empty team, for every choice of `p` — `support_bot_iff`). -/
-def BSMLFormula.bot (p : Atom) : BSMLFormula Atom :=
+def Formula.bot (p : Atom) : Formula Atom :=
   .conj (.atom p) (.neg (.atom p))
 
 /-- The strong contradiction `⊥⊥ := ⊥ ∧ NE` (supported by no team). -/
-def BSMLFormula.botbot (p : Atom) : BSMLFormula Atom :=
+def Formula.botbot (p : Atom) : Formula Atom :=
   .conj (.bot p) .ne
 
-theorem support_bot_iff (M : BSMLModel W Atom) (p : Atom) (s : Finset W) :
-    support M (BSMLFormula.bot p) s ↔ s = ∅ := by
+theorem support_bot_iff (M : KripkeModel W Atom) (p : Atom) (s : Finset W) :
+    support M (Formula.bot p) s ↔ s = ∅ := by
   constructor
   · rintro ⟨hpos, hneg⟩
     refine Finset.eq_empty_iff_forall_notMem.mpr (fun w hw => ?_)
@@ -74,8 +76,8 @@ theorem support_bot_iff (M : BSMLModel W Atom) (p : Atom) (s : Finset W) :
   · rintro rfl
     exact ⟨fun w hw => absurd hw (by simp), fun w hw => absurd hw (by simp)⟩
 
-theorem not_support_botbot (M : BSMLModel W Atom) (p : Atom) (s : Finset W) :
-    ¬ support M (BSMLFormula.botbot p) s := by
+theorem not_support_botbot (M : KripkeModel W Atom) (p : Atom) (s : Finset W) :
+    ¬ support M (Formula.botbot p) s := by
   rintro ⟨hbot, hne⟩
   have hs : s = ∅ := (support_bot_iff M p s).mp hbot
   subst hs
@@ -91,8 +93,8 @@ is NE-free exactly when `φ` is. -/
 
 /-- NE-free formulas cannot be both supported and anti-supported on a
     nonempty team. -/
-theorem eq_empty_of_support_antiSupport {φ : BSMLFormula Atom}
-    (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) :
+theorem eq_empty_of_support_antiSupport {φ : Formula Atom}
+    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
     ∀ s : Finset W, support M φ s → antiSupport M φ s → s = ∅ := by
   induction φ with
   | atom p =>
@@ -101,15 +103,15 @@ theorem eq_empty_of_support_antiSupport {φ : BSMLFormula Atom}
     have h1 := hs w hw
     have h2 := ha w hw
     simp [h1] at h2
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | neg ψ ih =>
     intro s hs ha
     exact ih hNE s ha hs
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     rintro s ⟨hs₁, hs₂⟩ ⟨t₁, t₂, hsp, ha₁, ha₂⟩
     have hsub₁ : t₁ ⊆ s := hsp ▸ Finset.subset_union_left
     have hsub₂ : t₂ ⊆ s := hsp ▸ Finset.subset_union_right
@@ -118,9 +120,9 @@ theorem eq_empty_of_support_antiSupport {φ : BSMLFormula Atom}
     rw [← hsp, he₁, he₂, Finset.union_empty]
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     rintro s ⟨t₁, t₂, hsp, hs₁, hs₂⟩ ⟨ha₁, ha₂⟩
     have hsub₁ : t₁ ⊆ s := hsp ▸ Finset.subset_union_left
     have hsub₂ : t₂ ⊆ s := hsp ▸ Finset.subset_union_right
@@ -141,8 +143,8 @@ theorem eq_empty_of_support_antiSupport {φ : BSMLFormula Atom}
 
 /-- **Bilateral determinacy on singletons** for NE-free formulas: every
     singleton team supports or anti-supports. -/
-theorem support_singleton_or_antiSupport_singleton {φ : BSMLFormula Atom}
-    (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) :
+theorem support_singleton_or_antiSupport_singleton {φ : Formula Atom}
+    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
     ∀ w : W, support M φ {w} ∨ antiSupport M φ {w} := by
   induction φ with
   | atom p =>
@@ -150,13 +152,13 @@ theorem support_singleton_or_antiSupport_singleton {φ : BSMLFormula Atom}
     cases h : M.val p w with
     | true => exact Or.inl (fun v hv => by rw [Finset.mem_singleton] at hv; rw [hv, h])
     | false => exact Or.inr (fun v hv => by rw [Finset.mem_singleton] at hv; rw [hv, h])
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | neg ψ ih => exact fun w => (ih hNE w).symm
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     intro w
     rcases ih₁ h₁ w with hs₁ | ha₁
     · rcases ih₂ h₂ w with hs₂ | ha₂
@@ -167,9 +169,9 @@ theorem support_singleton_or_antiSupport_singleton {φ : BSMLFormula Atom}
         support_empty_of_isNEFree (φ := .neg ψ₂) h₂ M⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     intro w
     rcases ih₁ h₁ w with hs₁ | ha₁
     · exact Or.inl ⟨{w}, ∅, by simp, hs₁, support_empty_of_isNEFree h₂ M⟩
@@ -203,9 +205,9 @@ theorem support_singleton_or_antiSupport_singleton {φ : BSMLFormula Atom}
     (`weaken` is the formal counterpart of the paper's "derivable *from
     formulas in* Φ"), so NE-freeness side conditions on subderivation
     contexts match the paper's conditions on undischarged assumptions.
-    Rules mentioning `⊥` carry a witness atom `p` (`BSMLFormula.bot`). -/
+    Rules mentioning `⊥` carry a witness atom `p` (`Formula.bot`). -/
 inductive Derives :
-    Set (BSMLFormula Atom) → BSMLFormula Atom → Prop where
+    Set (Formula Atom) → Formula Atom → Prop where
   /-- Assumption. -/
   | hyp (φ) : Derives {φ} φ
   /-- Weakening (the paper's subset-closure of `Φ ⊢ ψ`). -/
@@ -219,7 +221,7 @@ inductive Derives :
   | conjE₂ {Γ φ ψ} : Derives Γ (.conj φ ψ) → Derives Γ ψ
   /-- `¬I`: classical `α`, NE-free undischarged assumptions. -/
   | negI {Γ α} (p : Atom) : α.isNEFree = true →
-      (∀ γ ∈ Γ, BSMLFormula.isNEFree γ = true) →
+      (∀ γ ∈ Γ, Formula.isNEFree γ = true) →
       Derives (insert α Γ) (.bot p) → Derives Γ (.neg α)
   /-- `¬E`: ex falso for the classical fragment. -/
   | negE {Γ₁ Γ₂ α β} : α.isNEFree = true → β.isNEFree = true →
@@ -257,13 +259,13 @@ inductive Derives :
   /-- `∨E`: NE-free subderivation contexts (the `⫶`-freeness condition on
       `χ` is vacuous in the `⫶`-free language). -/
   | disjE {Γ Δ₁ Δ₂ φ ψ χ} :
-      (∀ γ ∈ Δ₁, BSMLFormula.isNEFree γ = true) →
-      (∀ γ ∈ Δ₂, BSMLFormula.isNEFree γ = true) →
+      (∀ γ ∈ Δ₁, Formula.isNEFree γ = true) →
+      (∀ γ ∈ Δ₂, Formula.isNEFree γ = true) →
       Derives Γ (.disj φ ψ) → Derives (insert φ Δ₁) χ →
       Derives (insert ψ Δ₂) χ → Derives (Γ ∪ Δ₁ ∪ Δ₂) χ
   /-- `∨Mon`: NE-free subderivation context. -/
   | disjMon {Γ Δ φ ψ χ} :
-      (∀ γ ∈ Δ, BSMLFormula.isNEFree γ = true) →
+      (∀ γ ∈ Δ, Formula.isNEFree γ = true) →
       Derives Γ (.disj φ ψ) → Derives (insert ψ Δ) χ →
       Derives (Γ ∪ Δ) (.disj φ χ)
   /-- `⊥E`. -/
@@ -276,14 +278,14 @@ inductive Derives :
       Derives Γ (.poss ψ)
   /-- `□Mon` (finitary): the subderivation's undischarged assumptions are
       among the boxed premises. -/
-  | necMon {Γ ψ} (φs : List (BSMLFormula Atom)) :
-      Derives {δ | δ ∈ φs} ψ → (∀ δ ∈ φs, Derives Γ (BSMLFormula.nec δ)) →
-      Derives Γ (BSMLFormula.nec ψ)
+  | necMon {Γ ψ} (φs : List (Formula Atom)) :
+      Derives {δ | δ ∈ φs} ψ → (∀ δ ∈ φs, Derives Γ (Formula.nec δ)) →
+      Derives Γ (Formula.nec ψ)
   /-- `Inter◇□` (downward half). -/
   | interE {Γ φ} : Derives Γ (.neg (.poss φ)) →
-      Derives Γ (BSMLFormula.nec (.neg φ))
+      Derives Γ (Formula.nec (.neg φ))
   /-- `Inter◇□` (upward half). -/
-  | interI {Γ φ} : Derives Γ (BSMLFormula.nec (.neg φ)) →
+  | interI {Γ φ} : Derives Γ (Formula.nec (.neg φ)) →
       Derives Γ (.neg (.poss φ))
   /-- `◇Sep` (FC-entailment for pragmatically enriched formulas). -/
   | possSep {Γ φ ψ} : Derives Γ (.poss (.disj φ (.conj ψ .ne))) →
@@ -292,12 +294,12 @@ inductive Derives :
   | possJoin {Γ₁ Γ₂ φ ψ} : Derives Γ₁ (.poss φ) → Derives Γ₂ (.poss ψ) →
       Derives (Γ₁ ∪ Γ₂) (.poss (.disj φ ψ))
   /-- `□Inst`: `□` implies `◇` when accessible worlds exist. -/
-  | necInst {Γ φ} : Derives Γ (BSMLFormula.nec (.conj φ .ne)) →
+  | necInst {Γ φ} : Derives Γ (Formula.nec (.conj φ .ne)) →
       Derives Γ (.poss φ)
   /-- `□◇Join`. -/
-  | necPossJoin {Γ₁ Γ₂ φ ψ} : Derives Γ₁ (BSMLFormula.nec φ) →
+  | necPossJoin {Γ₁ Γ₂ φ ψ} : Derives Γ₁ (Formula.nec φ) →
       Derives Γ₂ (.poss ψ) →
-      Derives (Γ₁ ∪ Γ₂) (BSMLFormula.nec (.disj φ ψ))
+      Derives (Γ₁ ∪ Γ₂) (Formula.nec (.disj φ ψ))
 
 /-! ### Soundness -/
 
@@ -308,8 +310,8 @@ inductive Derives :
     (`isLowerSet_support_of_isNEFree`) for discharging side-conditioned
     contexts on sub-teams, and unrestricted union closure
     (`supClosed_support`) for reassembling `∨E`'s conclusion. -/
-theorem soundness {Γ : Set (BSMLFormula Atom)} {φ : BSMLFormula Atom}
-    (h : Derives Γ φ) (M : BSMLModel W Atom) :
+theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
+    (h : Derives Γ φ) (M : KripkeModel W Atom) :
     ∀ s : Finset W, (∀ γ ∈ Γ, support M γ s) → support M φ s := by
   induction h with
   | hyp φ =>
@@ -446,8 +448,8 @@ theorem soundness {Γ : Set (BSMLFormula Atom)} {φ : BSMLFormula Atom}
     the disjuncts, and one `◇Sep` extracts each conjunct-possibility — the
     proof-theoretic counterpart of [aloni-2022]'s FC-entailment, here for the
     right disjunct. `soundness` transports it to team-semantic consequence. -/
-example (φ ψ : BSMLFormula Atom) :
-    Derives {BSMLFormula.poss (.disj φ (.conj ψ .ne))} (.poss ψ) :=
+example (φ ψ : Formula Atom) :
+    Derives {Formula.poss (.disj φ (.conj ψ .ne))} (.poss ψ) :=
   .possSep (.hyp _)
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/Properties.lean
+++ b/Linglib/Logic/Modal/BSML/Properties.lean
@@ -46,6 +46,8 @@ separately and composing them via `Team.isFlat_iff`.
 
 namespace BSML
 
+open Modal (KripkeModel)
+
 open Team
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
@@ -56,7 +58,7 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
     disj-support cases need mutual induction on partitions; the neg case
     needs the polarity flip. -/
 private theorem support_and_antiSupport_unionClosed
-    (φ : BSMLFormula Atom) (M : BSMLModel W Atom) :
+    (φ : Formula Atom) (M : KripkeModel W Atom) :
     (∀ s t : Finset W, support M φ s → support M φ t → support M φ (s ∪ t)) ∧
     (∀ s t : Finset W, antiSupport M φ s → antiSupport M φ t → antiSupport M φ (s ∪ t)) := by
   induction φ with
@@ -138,7 +140,7 @@ private theorem support_and_antiSupport_unionClosed
 /-- BSML support is sup-closed (Anttila Proposition 2.2.8 part 2). BSML's
     connective set lacks the global disjunction ⨼, so the union-closure
     obstruction is absent and all formulas satisfy the property. -/
-theorem supClosed_support (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
+theorem supClosed_support (M : KripkeModel W Atom) (φ : Formula Atom) :
     SupClosed { t : Finset W | support M φ t } :=
   fun _ ha _ hb => (support_and_antiSupport_unionClosed φ M).1 _ _ ha hb
 
@@ -148,25 +150,25 @@ theorem supClosed_support (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
     anti-support on the empty team. Used as the engine for the bilateral
     mutual induction needed by the negation case. -/
 private theorem support_and_antiSupport_empty_of_isNEFree
-    (φ : BSMLFormula Atom) (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) :
+    (φ : Formula Atom) (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
     support M φ ∅ ∧ antiSupport M φ ∅ := by
   induction φ with
   | atom p =>
     refine ⟨?_, ?_⟩
     · intro w hw; exact absurd hw (by simp)
     · intro w hw; exact absurd hw (by simp)
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | neg ψ ih =>
     have hψ : ψ.isNEFree = true := by
-      simp [BSMLFormula.isNEFree] at hNE; exact hNE
+      simp [Formula.isNEFree] at hNE; exact hNE
     have ⟨hs, ha⟩ := ih hψ
     -- support (¬ψ) ∅ = antiSupport ψ ∅; antiSupport (¬ψ) ∅ = support ψ ∅
     exact ⟨ha, hs⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨hs₁, ha₁⟩ := ih₁ h₁
     have ⟨hs₂, ha₂⟩ := ih₂ h₂
     refine ⟨⟨hs₁, hs₂⟩, ?_⟩
@@ -177,9 +179,9 @@ private theorem support_and_antiSupport_empty_of_isNEFree
     simp
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨hs₁, ha₁⟩ := ih₁ h₁
     have ⟨hs₂, ha₂⟩ := ih₂ h₂
     refine ⟨?_, ⟨ha₁, ha₂⟩⟩
@@ -194,8 +196,8 @@ private theorem support_and_antiSupport_empty_of_isNEFree
 
 /-- NE-free BSML formulas are supported on the empty team. The only
     obstruction is NE itself, which fails on ∅ by definition. -/
-theorem support_empty_of_isNEFree {φ : BSMLFormula Atom}
-    (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) : support M φ ∅ :=
+theorem support_empty_of_isNEFree {φ : Formula Atom}
+    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) : support M φ ∅ :=
   (support_and_antiSupport_empty_of_isNEFree φ hNE M).1
 
 /-! ### Downward closure for NE-free formulas (Anttila 2.2.8 part 1) -/
@@ -204,8 +206,8 @@ theorem support_empty_of_isNEFree {φ : BSMLFormula Atom}
     anti-support downward-closed. The bilateral mutual induction handles
     the negation case (where support flips to antiSupport). -/
 private theorem support_and_antiSupport_downward_of_isNEFree
-    (φ : BSMLFormula Atom) (hNE : φ.isNEFree = true)
-    (M : BSMLModel W Atom) :
+    (φ : Formula Atom) (hNE : φ.isNEFree = true)
+    (M : KripkeModel W Atom) :
     (∀ s t : Finset W, t ⊆ s → support M φ s → support M φ t) ∧
     (∀ s t : Finset W, t ⊆ s → antiSupport M φ s → antiSupport M φ t) := by
   induction φ with
@@ -213,18 +215,18 @@ private theorem support_and_antiSupport_downward_of_isNEFree
     refine ⟨?_, ?_⟩
     · intro s t hsub hsupp w hw; exact hsupp w (hsub hw)
     · intro s t hsub hsupp w hw; exact hsupp w (hsub hw)
-  | ne => simp [BSMLFormula.isNEFree] at hNE
+  | ne => simp [Formula.isNEFree] at hNE
   | neg ψ ih =>
     have hψ : ψ.isNEFree = true := by
-      simp [BSMLFormula.isNEFree] at hNE; exact hNE
+      simp [Formula.isNEFree] at hNE; exact hNE
     have ⟨ihs, iha⟩ := ih hψ
     -- support (¬ψ) = antiSupport ψ; antiSupport (¬ψ) = support ψ
     exact ⟨iha, ihs⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨ihs₁, iha₁⟩ := ih₁ h₁
     have ⟨ihs₂, iha₂⟩ := ih₂ h₂
     refine ⟨?_, ?_⟩
@@ -245,9 +247,9 @@ private theorem support_and_antiSupport_downward_of_isNEFree
       · exact iha₂ t₂ (t₂ ∩ t) (Finset.inter_subset_left) ha₂
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have h₁ : ψ₁.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
     have h₂ : ψ₂.isNEFree = true := by
-      simp only [BSMLFormula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
     have ⟨ihs₁, iha₁⟩ := ih₁ h₁
     have ⟨ihs₂, iha₂⟩ := ih₂ h₂
     refine ⟨?_, ?_⟩
@@ -267,7 +269,7 @@ private theorem support_and_antiSupport_downward_of_isNEFree
       exact ⟨iha₁ s t hsub ha₁, iha₂ s t hsub ha₂⟩
   | poss ψ ih =>
     have hψ : ψ.isNEFree = true := by
-      simp [BSMLFormula.isNEFree] at hNE; exact hNE
+      simp [Formula.isNEFree] at hNE; exact hNE
     have ⟨_, _⟩ := ih hψ  -- IHs not used directly; the modal cases hold from per-w structure
     refine ⟨?_, ?_⟩
     · -- support (◇ψ) s = ∀ w ∈ s, ∃ subteam ⊆ R[w], nonempty, support ψ subteam.
@@ -280,8 +282,8 @@ private theorem support_and_antiSupport_downward_of_isNEFree
 
 /-- NE-free BSML formulas are downward-closed: support survives under
     taking subsets of the team. -/
-theorem isLowerSet_support_of_isNEFree {φ : BSMLFormula Atom}
-    (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) :
+theorem isLowerSet_support_of_isNEFree {φ : Formula Atom}
+    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
     IsLowerSet { t : Finset W | support M φ t } :=
   fun _ _ hab hb =>
     (support_and_antiSupport_downward_of_isNEFree φ hNE M).1 _ _ hab hb
@@ -299,7 +301,7 @@ theorem isLowerSet_support_of_isNEFree {φ : BSMLFormula Atom}
     single endpoint: the upper (downward-closed-style) for atom, poss and the
     negative polarities; the lower for `ne` (nonemptiness is upward closed). -/
 private theorem support_and_antiSupport_ordConnected
-    (φ : BSMLFormula Atom) (M : BSMLModel W Atom) :
+    (φ : Formula Atom) (M : KripkeModel W Atom) :
     (∀ s t u : Finset W, s ⊆ t → t ⊆ u →
       support M φ s → support M φ u → support M φ t) ∧
     (∀ s t u : Finset W, s ⊆ t → t ⊆ u →
@@ -405,7 +407,7 @@ private theorem support_and_antiSupport_ordConnected
     recovers downward closure from convexity. Together with `supClosed_support`,
     this is the convex-and-union-closed property for which BSML is expressively
     complete ([anttila-2025]). -/
-theorem ordConnected_support (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
+theorem ordConnected_support (M : KripkeModel W Atom) (φ : Formula Atom) :
     Set.OrdConnected { t : Finset W | support M φ t } := by
   refine ⟨?_⟩
   intro s hs u hu t ht
@@ -422,8 +424,8 @@ theorem ordConnected_support (M : BSMLModel W Atom) (φ : BSMLFormula Atom) :
     the three closure properties proved above. The same conclusion has a
     direct classical-evaluation-bridge proof in `Bridge.lean` as
     `neFree_flat_eq`. -/
-theorem isFlat_support_of_isNEFree {φ : BSMLFormula Atom}
-    (hNE : φ.isNEFree = true) (M : BSMLModel W Atom) :
+theorem isFlat_support_of_isNEFree {φ : Formula Atom}
+    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
     IsFlat { t : Finset W | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
     (isLowerSet_support_of_isNEFree hNE M)
@@ -441,7 +443,7 @@ open Team in
     Composes `ordConnected_support` and `supClosed_support` through the
     `Team/Definability.lean` bridge. The converse (every such property is
     BSML-definable) is the open half. -/
-theorem soundFor_convex_inter_unionClosed (M : BSMLModel W Atom) :
+theorem soundFor_convex_inter_unionClosed (M : KripkeModel W Atom) :
     SoundFor (support M) (convexProperties ∩ unionClosedProperties) := by
   unfold SoundFor
   apply Set.subset_inter
@@ -462,7 +464,7 @@ open Team in
     flat properties. Companion to `soundFor_convex_inter_unionClosed`: NE is
     exactly what moves a formula off the `flat` cell into the strictly larger
     convex, union-closed cell. -/
-theorem soundFor_flat_neFree (M : BSMLModel W Atom) :
+theorem soundFor_flat_neFree (M : KripkeModel W Atom) :
     definableClassWhere (support M) (fun φ => φ.isNEFree = true) ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)

--- a/Linglib/Logic/Modal/BSML/Scenarios.lean
+++ b/Linglib/Logic/Modal/BSML/Scenarios.lean
@@ -21,10 +21,10 @@ a typo silently compiles to `false` under the
   ([aloni-2022] Figure 1: `w_∅`, `w_a`, `w_b`, `w_ab`), with the typed
   `holds` truth table.
 
-Studies instantiate `BSMLModel`'s String-keyed `val` field by
+Studies instantiate `KripkeModel`'s String-keyed `val` field by
 pattern-matching on the canonical names via `FCAtom.toName`. Eliminating
-the String layer entirely (making `BSMLModel.val : FCAtom → α → Bool`)
-would require parameterizing `BSMLFormula` and `BSMLModel` over the atom
+the String layer entirely (making `KripkeModel.val : FCAtom → α → Bool`)
+would require parameterizing `Formula` and `KripkeModel` over the atom
 type — a substrate-wide refactor deferred to a separate effort.
 -/
 
@@ -44,7 +44,7 @@ instance : Fintype FCAtom where
   elems := {.a, .b, .c}
   complete := by intro x; cases x <;> simp
 
-/-- Canonical String name of an atom. Used at `BSMLModel.val` boundaries
+/-- Canonical String name of an atom. Used at `KripkeModel.val` boundaries
     where the substrate's `val : String → α → Bool` field forces String. -/
 def FCAtom.toName : FCAtom → String
   | .a => "a"

--- a/Linglib/Logic/Modal/Dependence.lean
+++ b/Linglib/Logic/Modal/Dependence.lean
@@ -88,9 +88,8 @@ under Lemma 4.2 part 1) rather than the literal `X ⊆ Y ∪ Z` from
 (T6); under downward closure they are equivalent.
 
 The `KripkeModel` carrier from `Logic/Modal/Kripke.lean` is the
-shared substrate; BSML, QBSML, and the AAY-2024 extensions
-(BSMLOr/BSMLEmpty) alias `BSMLModel := KripkeModel` for literature
-compatibility.
+shared substrate consumed by BSML, QBSML, and the AAY-2024
+extensions (BSMLOr/BSMLEmpty) alike.
 
 ## Sibling logics in `Logic/Modal/`
 

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -25,13 +25,12 @@ the AAY-2024 extensions BSMLOr/BSMLEmpty, modal dependence logic in
 
 ## Consumers
 
-* `Logic/Modal/BSML/Defs.lean` — `BSMLModel` is an `abbrev` of
-  this type.
+* `Logic/Modal/BSML/Defs.lean` — BSML's bilateral `eval` reads
+  this carrier directly.
 * `Logic/Modal/QBSML/Defs.lean` — `QBSML.Model` parameterises
   this carrier with an assignment type.
 * `Logic/Modal/Dependence.lean` — modal dependence logic (MDL).
-* `Studies/AloniAnttilaYang2024.lean` — BSMLOr,
-  BSMLEmpty (via `BSMLModel` alias).
+* `Studies/AloniAnttilaYang2024.lean` — BSMLOr, BSMLEmpty.
 * `Logic/Modal/Bisimulation.lean` — bounded bisimulation over this carrier.
 -/
 

--- a/Linglib/Logic/Modal/QBSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/QBSML/Enrichment.lean
@@ -47,7 +47,7 @@ behaviour-under-negation pattern — the QBSML free-choice facts of
 is defined only on the NE-free fragment in both papers, so the `.ne` case is
 a filler convention. The construction is structurally identical to BSML's
 `Logic/Modal/BSML/Enrichment.lean` but operates on `Formula Var Const Pred`
-(quantifiers, predicate atoms) rather than `BSMLFormula Atom`. The two are
+(quantifiers, predicate atoms) rather than `BSML.Formula Atom`. The two are
 kept parallel rather than unified: a shared "team-semantic formula language
 with an `NE` constructor" abstraction awaits a third instance, per the family
 roadmap in `Logic/Team/Algebra.lean`.

--- a/Linglib/Studies/Aloni2022.lean
+++ b/Linglib/Studies/Aloni2022.lean
@@ -40,6 +40,7 @@ the typed atoms throughout.
 namespace Aloni2022
 
 open BSML
+open Modal (KripkeModel)
 open BSML (FCAtom TwoAtomWorld)
 
 -- ============================================================================
@@ -67,14 +68,14 @@ def prohibitionTeam : Finset TwoAtomWorld :=
 
     Valuation: `val a w = w.holds a` — direct routing through the typed
     atom. No String fallthrough, no silent typos. -/
-def deonticModel : BSMLModel TwoAtomWorld FCAtom where
+def deonticModel : KripkeModel TwoAtomWorld FCAtom where
   access := λ _ => Finset.univ
   val := λ p w => w.holds p
 
 /-- Restrictive deontic model: from `nothing`, only `nothing` is accessible;
     from any other world, all worlds. Used for Dual Prohibition on the
     prohibition team `{nothing}`. -/
-def restrictiveModel : BSMLModel TwoAtomWorld FCAtom where
+def restrictiveModel : KripkeModel TwoAtomWorld FCAtom where
   access := λ w =>
     match w with
     | .nothing => {.nothing}
@@ -83,7 +84,7 @@ def restrictiveModel : BSMLModel TwoAtomWorld FCAtom where
 
 /-- State-based deontic model: R[w] = freeChoiceTeam for every world. Strictly
     stronger than indisputability; required for Modal Disjunction (Fact 3). -/
-def stateBasedModel : BSMLModel TwoAtomWorld FCAtom where
+def stateBasedModel : KripkeModel TwoAtomWorld FCAtom where
   access := λ _ => freeChoiceTeam
   val := λ p w => w.holds p
 
@@ -93,7 +94,7 @@ def stateBasedModel : BSMLModel TwoAtomWorld FCAtom where
     incidental: WS FC's conclusion may fail on this model even when its
     enriched premise is supported. (Aloni 2022 Figure 5(b) shape — non-indisputable R.
     Figure 5(a) shows the dual case where R is indisputable but enrichment fails.) -/
-def looseDeonticModel : BSMLModel TwoAtomWorld FCAtom where
+def looseDeonticModel : KripkeModel TwoAtomWorld FCAtom where
   access := λ w =>
     match w with
     | .both    => {.both, .onlyA}
@@ -107,29 +108,29 @@ def looseDeonticModel : BSMLModel TwoAtomWorld FCAtom where
 -- ============================================================================
 
 /-- ◇(a ∨ b) — narrow-scope premise (Fact 4). -/
-def mayHaveCoffeeOrTea : BSMLFormula FCAtom :=
+def mayHaveCoffeeOrTea : Formula FCAtom :=
   .poss (.disj (.atom .a) (.atom .b))
 
-def mayCoffee : BSMLFormula FCAtom := .poss (.atom .a)
-def mayTea    : BSMLFormula FCAtom := .poss (.atom .b)
+def mayCoffee : Formula FCAtom := .poss (.atom .a)
+def mayTea    : Formula FCAtom := .poss (.atom .b)
 
 /-- ¬◇(a ∨ b) — Dual Prohibition premise (Fact 11). -/
-def prohibition : BSMLFormula FCAtom :=
+def prohibition : Formula FCAtom :=
   .neg (.poss (.disj (.atom .a) (.atom .b)))
 
-def notMayCoffee : BSMLFormula FCAtom := .neg (.poss (.atom .a))
-def notMayTea    : BSMLFormula FCAtom := .neg (.poss (.atom .b))
+def notMayCoffee : Formula FCAtom := .neg (.poss (.atom .a))
+def notMayTea    : Formula FCAtom := .neg (.poss (.atom .b))
 
 /-- ◇a ∨ ◇b — wide-scope disjunction premise (Fact 5). -/
-def wideScopeDisj : BSMLFormula FCAtom :=
+def wideScopeDisj : Formula FCAtom :=
   .disj (.poss (.atom .a)) (.poss (.atom .b))
 
 /-- ¬¬◇(a ∨ b) — double-negation premise (Fact 12). -/
-def doubleNegMayHaveCoffeeOrTea : BSMLFormula FCAtom :=
+def doubleNegMayHaveCoffeeOrTea : Formula FCAtom :=
   .neg (.neg (.poss (.disj (.atom .a) (.atom .b))))
 
 /-- a ∨ b — plain disjunction (Modal Disjunction premise, Fact 3). -/
-def plainDisj : BSMLFormula FCAtom :=
+def plainDisj : Formula FCAtom :=
   .disj (.atom .a) (.atom .b)
 
 -- ============================================================================

--- a/Linglib/Studies/Aloni2022/FreeChoice.lean
+++ b/Linglib/Studies/Aloni2022/FreeChoice.lean
@@ -30,6 +30,7 @@ Free choice is DERIVED from three independent principles:
 namespace Aloni2022
 
 open BSML
+open Modal (KripkeModel)
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
@@ -43,14 +44,14 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
 /-- Atoms are downward-closed. Per-primitive isolation of the atom case of
     `BSML.isLowerSet_support_of_isNEFree`. -/
-theorem atom_downwardClosed (M : BSMLModel W Atom) (p : Atom) :
+theorem atom_downwardClosed (M : KripkeModel W Atom) (p : Atom) :
     ∀ t t' : Finset W, t' ⊆ t → support M (.atom p) t → support M (.atom p) t' :=
   fun _ _ hSub hSupp w hw => hSupp w (hSub hw)
 
 /-- NE is NOT downward-closed: an inhabited team supports NE but ∅ doesn't.
     This is the obstruction that prevents
     `isFlat_support_of_isNEFree` from extending to NE-bearing formulas. -/
-theorem ne_not_downwardClosed [Nonempty W] (M : BSMLModel W Atom) :
+theorem ne_not_downwardClosed [Nonempty W] (M : KripkeModel W Atom) :
     ¬(∀ t t' : Finset W, t' ⊆ t → support M .ne t → support M .ne t') := by
   intro hDC
   have hFull : (Finset.univ : Finset W).Nonempty := Finset.univ_nonempty
@@ -71,8 +72,8 @@ two non-empty parts (by enrichment + NE). Each part supports its
 respective disjunct (by `enrichment_strengthens_support`), and each
 is a subset of R[w] (via the union), yielding ◇α and ◇β.
 -/
-theorem narrowScopeFC (M : BSMLModel W Atom)
-    (α β : BSMLFormula Atom) (t : Finset W)
+theorem narrowScopeFC (M : KripkeModel W Atom)
+    (α β : Formula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
     (h : support M (enrich (.poss (.disj α β))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
@@ -105,8 +106,8 @@ The disjunction splits t = t₁ ∪ t₂. From t₁ pick w₁ — it has a subte
 s_a ⊆ R[w₁] supporting α. By indisputability R[w] = R[w₁] for all w ∈ t,
 so s_a ⊆ R[w], yielding ◇α at every world. Symmetrically for β.
 -/
-theorem wideScopeFC (M : BSMLModel W Atom)
-    (α β : BSMLFormula Atom) (t : Finset W)
+theorem wideScopeFC (M : KripkeModel W Atom)
+    (α β : Formula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
     (hInd : M.IsIndisputable t)
     (h : support M (enrich (.disj (.poss α) (.poss β))) t) :
@@ -145,8 +146,8 @@ The proof: enriched disjunction splits into two **non-empty** substates
 (by enrichment + NE). By state-basedness R[w] = t, so each substate is
 a non-empty subset of R[w], yielding ◇α and ◇β.
 -/
-theorem modalDisjunction (M : BSMLModel W Atom)
-    (α β : BSMLFormula Atom) (t : Finset W)
+theorem modalDisjunction (M : KripkeModel W Atom)
+    (α β : Formula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
     (hSB : M.IsStateBased t)
     (h : support M (enrich (.disj α β)) t) :
@@ -185,8 +186,8 @@ of the disjunction entails prohibition of each disjunct. The proof
 strips enrichment from the anti-supported disjuncts using Fact 1
 (`enrichment_strengthens_antiSupport`).
 -/
-theorem dualProhibition (M : BSMLModel W Atom)
-    (α β : BSMLFormula Atom) (t : Finset W)
+theorem dualProhibition (M : KripkeModel W Atom)
+    (α β : Formula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
     (h : support M (enrich (.neg (.poss (.disj α β)))) t) :
     support M (.neg (.poss α)) t ∧
@@ -215,8 +216,8 @@ Under double negation, FC effects re-emerge. Stripping the enrichment
 around ¬ reveals `support M (enrich (◇(α∨β))) t` (by bilateral negation
 swap), and narrow-scope FC (Fact 4) applies.
 -/
-theorem doubleNegationFC (M : BSMLModel W Atom)
-    (α β : BSMLFormula Atom) (t : Finset W)
+theorem doubleNegationFC (M : KripkeModel W Atom)
+    (α β : Formula Atom) (t : Finset W)
     (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
     (h : support M (enrich (.neg (.neg (.poss (.disj α β))))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
@@ -242,7 +243,7 @@ Counterexample: single world w where a=true, b=false, R[w]={w}, team={w}.
 - [◇¬a]⁺ fails: the only accessible subteam {w} has a(w)=true,
   so no non-empty subteam anti-supports a
 -/
-private def negFCModel : BSMLModel Unit String where
+private def negFCModel : KripkeModel Unit String where
   access := fun _ => Finset.univ
   val := fun p _ => match p with
     | "a" => true
@@ -250,10 +251,10 @@ private def negFCModel : BSMLModel Unit String where
 
 private def negFCTeam : Finset Unit := Finset.univ
 
-private def negFC_poss_premise : BSMLFormula String :=
+private def negFC_poss_premise : Formula String :=
   .poss (.neg (.conj (.atom "a") (.atom "b")))
 
-private def negFC_poss_conclusion : BSMLFormula String :=
+private def negFC_poss_conclusion : Formula String :=
   .poss (.neg (.atom "a"))
 
 /-- ◇¬(a ∧ b): enriched premise IS supported on the counterexample team. -/
@@ -275,11 +276,11 @@ theorem negativeFC_poss_fails_bsmlPlus :
   intro h
   exact negFC_poss_conclusion_fails (h negFCModel negFCTeam negFC_poss_premise_holds)
 
-private def negFC_nec_premise : BSMLFormula String :=
-  .neg (BSMLFormula.nec (.conj (.atom "a") (.atom "b")))
+private def negFC_nec_premise : Formula String :=
+  .neg (Formula.nec (.conj (.atom "a") (.atom "b")))
 
-private def negFC_nec_conclusion : BSMLFormula String :=
-  .neg (BSMLFormula.nec (.atom "a"))
+private def negFC_nec_conclusion : Formula String :=
+  .neg (Formula.nec (.atom "a"))
 
 /-- ¬□(a ∧ b): enriched premise IS supported on the counterexample team. -/
 theorem negFC_nec_premise_holds :
@@ -295,8 +296,8 @@ theorem negFC_nec_conclusion_fails :
     Negative FC with necessity also fails under pragmatic enrichment. -/
 theorem negativeFC_nec_fails_bsmlPlus :
     ¬consequencePlus (W := Unit) (Atom := String)
-      (.neg (BSMLFormula.nec (.conj (.atom "a") (.atom "b"))))
-      (.neg (BSMLFormula.nec (.atom "a"))) := by
+      (.neg (Formula.nec (.conj (.atom "a") (.atom "b"))))
+      (.neg (Formula.nec (.atom "a"))) := by
   intro h
   exact negFC_nec_conclusion_fails (h negFCModel negFCTeam negFC_nec_premise_holds)
 

--- a/Linglib/Studies/AloniAnttilaYang2024.lean
+++ b/Linglib/Studies/AloniAnttilaYang2024.lean
@@ -18,8 +18,8 @@ Formalisation of two extensions of BSML introduced in
 * `BSMLEmpty` — BSML extended with the **emptiness operator** `⊘`
   (Definition 2.1).
 
-Both extend BSML's `BSMLModel` (worlds + accessibility + valuation) and
-inherit the bilateral support/anti-support semantics. The new connectives
+Both share BSML's `KripkeModel` carrier (worlds + accessibility +
+valuation) and inherit the bilateral support/anti-support semantics. The new connectives
 are characterised by Fact 2.7 in the paper:
 
 | Logic     | Has `NE` | Has `⨼` | Downward-closed     | Union-closed   |
@@ -48,15 +48,15 @@ insight: each extension occupies a different cell of the
 * `BSMLEmpty.supClosed_support` — union-closure of BSML⊘ formulas
   (Fact 2.7; the second-consumer evidence that BSML's substrate
   generalises).
-* `BSMLOr.ofBSML` / `BSMLEmpty.ofBSML` — embedding `BSMLFormula` into each
+* `BSMLOr.ofBSML` / `BSMLEmpty.ofBSML` — embedding `BSML.Formula` into each
   extension, preserving semantics (`eval_ofBSML` theorems).
 
 ## Implementation notes
 
 The paper's BSML includes `⊥` (weak contradiction) as a primitive, whereas
-linglib's `BSMLFormula` (Aloni 2022) does not (the original defines
+linglib's `BSML.Formula` (Aloni 2022) does not (the original defines
 `⊥ := p ∧ ¬p`). The extension formula types here include `⊥` to match
-[aloni-anttila-yang-2024]; the embedding `BSMLFormula → Formula`
+[aloni-anttila-yang-2024]; the embedding `BSML.Formula → Formula`
 therefore has no preimage for `⊥`.
 
 `BSMLOr`'s global disjunction `⨼` is the team-semantic *inquisitive
@@ -98,8 +98,7 @@ namespace AloniAnttilaYang2024
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}
 
-open BSML (BSMLModel BSMLFormula)
-open Modal (StateBisim WorldBisim)
+open Modal (KripkeModel StateBisim WorldBisim)
 
 /-! ### BSMLOr — BSML with global disjunction `⨼` -/
 
@@ -131,7 +130,7 @@ inductive Formula (Atom : Type*) where
 /-- Bilateral evaluation for BSMLOr (Definition 2.3 of
     [aloni-anttila-yang-2024]). `eval M true φ t` is support;
     `eval M false φ t` is anti-support. Negation flips polarity. -/
-def eval (M : BSMLModel W Atom) : Bool → Formula Atom → Finset W → Prop
+def eval (M : KripkeModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | true,  .atom p,        t => ∀ w ∈ t, M.val p w = true
   | false, .atom p,        t => ∀ w ∈ t, M.val p w = false
   | true,  .bot,           t => t = ∅
@@ -154,40 +153,40 @@ def eval (M : BSMLModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | false, .poss ψ,        t => ∀ w ∈ t, eval M false ψ (M.access w)
 
 /-- Support: positive evaluation. -/
-abbrev support (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+abbrev support (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M true φ t
 
 /-- Anti-support: negative evaluation. -/
-abbrev antiSupport (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+abbrev antiSupport (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M false φ t
 
-@[simp] lemma support_neg (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_neg (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     support M (.neg φ) t ↔ antiSupport M φ t := Iff.rfl
 
-@[simp] lemma antiSupport_neg (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_neg (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg φ) t ↔ support M φ t := Iff.rfl
 
-@[simp] lemma support_bot (M : BSMLModel W Atom) (t : Finset W) :
+@[simp] lemma support_bot (M : KripkeModel W Atom) (t : Finset W) :
     support M (.bot : Formula Atom) t ↔ t = ∅ := Iff.rfl
 
-@[simp] lemma support_ne (M : BSMLModel W Atom) (t : Finset W) :
+@[simp] lemma support_ne (M : KripkeModel W Atom) (t : Finset W) :
     support M (.ne : Formula Atom) t ↔ t.Nonempty := Iff.rfl
 
-@[simp] lemma support_conj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_conj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     support M (.conj φ ψ) t ↔ support M φ t ∧ support M ψ t := Iff.rfl
 
-@[simp] lemma antiSupport_disj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_disj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.disj φ ψ) t ↔ antiSupport M φ t ∧ antiSupport M ψ t := Iff.rfl
 
-@[simp] lemma support_gdisj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_gdisj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     support M (.gdisj φ ψ) t ↔ support M φ t ∨ support M ψ t := Iff.rfl
 
-@[simp] lemma antiSupport_gdisj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_gdisj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.gdisj φ ψ) t ↔ antiSupport M φ t ∧ antiSupport M ψ t := Iff.rfl
 
 /-- `BSMLOr`'s `support`/`antiSupport` form a paraconsistent bilateral
     logic under `Formula.neg`. -/
-theorem isBilateral (M : BSMLModel W Atom) :
+theorem isBilateral (M : KripkeModel W Atom) :
     Bilateral.IsBilateral
       (support M) (antiSupport M) Formula.neg :=
   Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
@@ -212,7 +211,7 @@ def Formula.modalDepth : Formula Atom → ℕ
     `eval M b φ s ↔ eval M' b φ s'` for both polarities. -/
 theorem bisim_invariant_eval (φ : Formula Atom) :
     ∀ {k : ℕ}, φ.modalDepth ≤ k →
-    ∀ {M : BSMLModel W Atom} {M' : BSMLModel W' Atom}
+    ∀ {M : KripkeModel W Atom} {M' : KripkeModel W' Atom}
       {s : Finset W} {s' : Finset W'},
     StateBisim k M s M' s' →
     ∀ b : Bool, eval M b φ s ↔ eval M' b φ s' := by
@@ -377,7 +376,7 @@ inductive Formula (Atom : Type*) where
 
 /-- Bilateral evaluation for BSMLEmpty. The `empt` clause is:
     `support .empt φ s ↔ support φ s ∨ s = ∅` (Definition 2.3). -/
-def eval (M : BSMLModel W Atom) : Bool → Formula Atom → Finset W → Prop
+def eval (M : KripkeModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | true,  .atom p,        t => ∀ w ∈ t, M.val p w = true
   | false, .atom p,        t => ∀ w ∈ t, M.val p w = false
   | true,  .bot,           t => t = ∅
@@ -399,37 +398,37 @@ def eval (M : BSMLModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | true,  .poss ψ,        t => ∀ w ∈ t, ∃ s ⊆ M.access w, s.Nonempty ∧ eval M true ψ s
   | false, .poss ψ,        t => ∀ w ∈ t, eval M false ψ (M.access w)
 
-abbrev support (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+abbrev support (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M true φ t
 
-abbrev antiSupport (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+abbrev antiSupport (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M false φ t
 
-@[simp] lemma support_neg (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_neg (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     support M (.neg φ) t ↔ antiSupport M φ t := Iff.rfl
 
-@[simp] lemma antiSupport_neg (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_neg (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg φ) t ↔ support M φ t := Iff.rfl
 
-@[simp] lemma support_bot (M : BSMLModel W Atom) (t : Finset W) :
+@[simp] lemma support_bot (M : KripkeModel W Atom) (t : Finset W) :
     support M (.bot : Formula Atom) t ↔ t = ∅ := Iff.rfl
 
-@[simp] lemma support_ne (M : BSMLModel W Atom) (t : Finset W) :
+@[simp] lemma support_ne (M : KripkeModel W Atom) (t : Finset W) :
     support M (.ne : Formula Atom) t ↔ t.Nonempty := Iff.rfl
 
-@[simp] lemma support_conj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_conj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     support M (.conj φ ψ) t ↔ support M φ t ∧ support M ψ t := Iff.rfl
 
-@[simp] lemma antiSupport_disj (M : BSMLModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_disj (M : KripkeModel W Atom) (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.disj φ ψ) t ↔ antiSupport M φ t ∧ antiSupport M ψ t := Iff.rfl
 
-@[simp] lemma support_empt (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma support_empt (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     support M (.empt φ) t ↔ support M φ t ∨ t = ∅ := Iff.rfl
 
-@[simp] lemma antiSupport_empt (M : BSMLModel W Atom) (φ : Formula Atom) (t : Finset W) :
+@[simp] lemma antiSupport_empt (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.empt φ) t ↔ antiSupport M φ t := Iff.rfl
 
-theorem isBilateral (M : BSMLModel W Atom) :
+theorem isBilateral (M : KripkeModel W Atom) :
     Bilateral.IsBilateral
       (support M) (antiSupport M) Formula.neg :=
   Bilateral.IsBilateral.of_iff (support_neg M) (antiSupport_neg M)
@@ -443,7 +442,7 @@ theorem isBilateral (M : BSMLModel W Atom) :
     preserved by binary union because the `s = ∅` case forces both
     sub-teams empty, and the `support φ` case uses the IH. -/
 private theorem support_and_antiSupport_supClosed
-    (φ : Formula Atom) (M : BSMLModel W Atom) :
+    (φ : Formula Atom) (M : KripkeModel W Atom) :
     (∀ s t : Finset W, support M φ s → support M φ t → support M φ (s ∪ t)) ∧
     (∀ s t : Finset W, antiSupport M φ s → antiSupport M φ t →
                        antiSupport M φ (s ∪ t)) := by
@@ -534,7 +533,7 @@ private theorem support_and_antiSupport_supClosed
     sup-closed support. Direct evidence that the team-semantics substrate
     generalises from BSML to BSML⊘ without changes — the substrate's
     payoff at a second logic. -/
-theorem supClosed_support (M : BSMLModel W Atom) (φ : Formula Atom) :
+theorem supClosed_support (M : KripkeModel W Atom) (φ : Formula Atom) :
     SupClosed { t : Finset W | support M φ t } :=
   fun _ ha _ hb => (support_and_antiSupport_supClosed φ M).1 _ _ ha hb
 
@@ -558,7 +557,7 @@ def Formula.modalDepth : Formula Atom → ℕ
     `eval M b φ s ↔ eval M' b φ s'` for both polarities. -/
 theorem bisim_invariant_eval (φ : Formula Atom) :
     ∀ {k : ℕ}, φ.modalDepth ≤ k →
-    ∀ {M : BSMLModel W Atom} {M' : BSMLModel W' Atom}
+    ∀ {M : KripkeModel W Atom} {M' : KripkeModel W' Atom}
       {s : Finset W} {s' : Finset W'},
     StateBisim k M s M' s' →
     ∀ b : Bool, eval M b φ s ↔ eval M' b φ s' := by
@@ -698,10 +697,10 @@ theorem bisim_invariant_eval (φ : Formula Atom) :
 
 end BSMLEmpty
 
-/-! ### Embeddings: BSMLFormula ↪ extension formulas -/
+/-! ### Embeddings: BSML.Formula ↪ extension formulas -/
 
 /-- Embed a BSML formula into BSMLOr by inclusion of constructors. -/
-def BSMLOr.ofBSML : BSMLFormula Atom → BSMLOr.Formula Atom
+def BSMLOr.ofBSML : BSML.Formula Atom → BSMLOr.Formula Atom
   | .atom p     => .atom p
   | .ne         => .ne
   | .neg ψ      => .neg (ofBSML ψ)
@@ -710,7 +709,7 @@ def BSMLOr.ofBSML : BSMLFormula Atom → BSMLOr.Formula Atom
   | .poss ψ     => .poss (ofBSML ψ)
 
 /-- Embed a BSML formula into BSMLEmpty. -/
-def BSMLEmpty.ofBSML : BSMLFormula Atom → BSMLEmpty.Formula Atom
+def BSMLEmpty.ofBSML : BSML.Formula Atom → BSMLEmpty.Formula Atom
   | .atom p     => .atom p
   | .ne         => .ne
   | .neg ψ      => .neg (ofBSML ψ)
@@ -718,10 +717,10 @@ def BSMLEmpty.ofBSML : BSMLFormula Atom → BSMLEmpty.Formula Atom
   | .disj ψ₁ ψ₂ => .disj (ofBSML ψ₁) (ofBSML ψ₂)
   | .poss ψ     => .poss (ofBSML ψ)
 
-/-- The embedding `BSMLFormula → BSMLOr.Formula` preserves bilateral
+/-- The embedding `BSML.Formula → BSMLOr.Formula` preserves bilateral
     evaluation: BSMLOr is a faithful extension of BSML. -/
-theorem BSMLOr.eval_ofBSML (M : BSMLModel W Atom) (b : Bool)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem BSMLOr.eval_ofBSML (M : KripkeModel W Atom) (b : Bool)
+    (φ : BSML.Formula Atom) (t : Finset W) :
     BSMLOr.eval M b (BSMLOr.ofBSML φ) t ↔ BSML.eval M b φ t := by
   induction φ generalizing b t with
   | atom p => cases b <;> rfl
@@ -762,10 +761,10 @@ theorem BSMLOr.eval_ofBSML (M : BSMLModel W Atom) (b : Bool)
         obtain ⟨s, hsub, hne, hsupp⟩ := h w hw
         exact ⟨s, hsub, hne, (ih true s).mpr hsupp⟩
 
-/-- The embedding `BSMLFormula → BSMLEmpty.Formula` preserves bilateral
+/-- The embedding `BSML.Formula → BSMLEmpty.Formula` preserves bilateral
     evaluation. -/
-theorem BSMLEmpty.eval_ofBSML (M : BSMLModel W Atom) (b : Bool)
-    (φ : BSMLFormula Atom) (t : Finset W) :
+theorem BSMLEmpty.eval_ofBSML (M : KripkeModel W Atom) (b : Bool)
+    (φ : BSML.Formula Atom) (t : Finset W) :
     BSMLEmpty.eval M b (BSMLEmpty.ofBSML φ) t ↔ BSML.eval M b φ t := by
   induction φ generalizing b t with
   | atom p => cases b <;> rfl

--- a/Linglib/Studies/Booth2022.lean
+++ b/Linglib/Studies/Booth2022.lean
@@ -501,7 +501,7 @@ dual `.neg` form where it differs). Each proof discharges the
 
 These are the building blocks for proving compactness of any specific
 `BilatInqProp` formula. (The fully general statement for arbitrary
-formulas requires an inductive `BSMLFormula` type with an interpretation
+formulas requires an inductive `BSML.Formula` type with an interpretation
 function; that's deferred.) -/
 
 /-- Compactness equation for `atom V`'s positive interpretation.


### PR DESCRIPTION
Dissolves the BSML naming stutter flagged in the #1969 audit: `BSML.BSMLFormula` → `BSML.Formula` (the pattern `BSMLOr.Formula`/`BSMLEmpty.Formula` already use), and the law-free `BSMLModel := Modal.KripkeModel` abbrev is dissolved — consumers read the carrier directly.

- Dot-notation defs formerly on the alias (`IsIndisputable`, `IsStateBased`, `toAccessRel`) re-home as `_root_.Modal.KripkeModel.*`, following the QBSML `KripkeStructure.*` precedent; study call sites unchanged.
- Mechanical rename otherwise (18 files); stale alias prose in `Kripke.lean`/`Dependence.lean` docstrings updated.