### PR TITLE
refactor(Logic/Modal/BSML): Defs register cleanse, Bool→Prop fragments

### DIFF
--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -54,15 +54,14 @@ set_option maxHeartbeats 800000 in
     team members in terms of classical evaluation. -/
 private theorem neFree_flat_eq (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hNE : φ.isNEFree = true) :
+    (hNE : φ.NEFree) :
     (support M φ t ↔ ∀ w ∈ t, classicalEval M φ w = true) ∧
     (antiSupport M φ t ↔ ∀ w ∈ t, classicalEval M φ w = false) := by
   induction φ generalizing t with
   | atom p => exact ⟨Iff.rfl, Iff.rfl⟩
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | neg ψ ih =>
-    have hNE' := by simp [Formula.isNEFree] at hNE; exact hNE
-    have ⟨ih_s, ih_a⟩ := ih t hNE'
+    have ⟨ih_s, ih_a⟩ := ih t hNE
     constructor
     · -- support of ¬ψ = antiSupport of ψ
       simp only [classicalEval, Bool.not_eq_true']
@@ -71,8 +70,8 @@ private theorem neFree_flat_eq (M : KripkeModel W Atom)
       simp only [classicalEval, Bool.not_eq_false']
       exact ih_s
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := hNE.1
+    have hψ₂ := hNE.2
     constructor
     · -- support of ψ₁ ∧ ψ₂ = ∀ w ∈ t, classicalEval (ψ₁ ∧ ψ₂) w
       simp only [classicalEval, Bool.and_eq_true]
@@ -109,8 +108,8 @@ private theorem neFree_flat_eq (M : KripkeModel W Atom)
             | inl h => simp [hce] at h
             | inr h => exact h)
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ := by simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := hNE.1
+    have hψ₂ := hNE.2
     constructor
     · -- support of ψ₁ ∨ ψ₂ (SPLIT) = ∀ w ∈ t, ce ψ₁ w ∨ ce ψ₂ w
       simp only [classicalEval, Bool.or_eq_true]
@@ -145,7 +144,6 @@ private theorem neFree_flat_eq (M : KripkeModel W Atom)
              fun h => ⟨(ih₁ t hψ₁).2.mpr (fun w hw => (h w hw).1),
                        (ih₂ t hψ₂).2.mpr (fun w hw => (h w hw).2)⟩⟩
   | poss ψ ih =>
-    have hNE' := by simp [Formula.isNEFree] at hNE; exact hNE
     constructor
     · -- support of ◇ψ ↔ ∀ w ∈ t, ∃ v ∈ R[w], ce ψ v = true
       simp only [classicalEval]
@@ -154,13 +152,13 @@ private theorem neFree_flat_eq (M : KripkeModel W Atom)
         obtain ⟨s, hs_sub, hs_ne, hs_supp⟩ := h w hw
         obtain ⟨v, hv⟩ := hs_ne
         have hv_acc := hs_sub (Finset.mem_coe.mpr hv)
-        have hv_ce := (ih s hNE').1.mp hs_supp v hv
+        have hv_ce := (ih s hNE).1.mp hs_supp v hv
         exact decide_eq_true ⟨v, hv_acc, hv_ce⟩
       · intro h w hw
         obtain ⟨v, hv_acc, hv_ce⟩ := of_decide_eq_true (h w hw)
         exact ⟨{v}, Finset.singleton_subset_iff.mpr hv_acc,
                ⟨v, Finset.mem_singleton.mpr rfl⟩,
-               (ih {v} hNE').1.mpr (fun u hu => by
+               (ih {v} hNE).1.mpr (fun u hu => by
                  rw [Finset.mem_singleton.mp hu]; exact hv_ce)⟩
     · -- antiSupport of ◇ψ ↔ ∀ w ∈ t, classicalEval ◇ψ w = false
       -- classicalEval ◇ψ w = false means ¬∃ v ∈ R[w], ce ψ v = true
@@ -169,12 +167,12 @@ private theorem neFree_flat_eq (M : KripkeModel W Atom)
       simp only [classicalEval]
       constructor
       · intro h w hw
-        have h_all := (ih (M.access w) hNE').2.mp (h w hw)
+        have h_all := (ih (M.access w) hNE).2.mp (h w hw)
         simp only [decide_eq_false_iff_not, not_exists]
         intro v ⟨hv_acc, hv_ce⟩; rw [h_all v hv_acc] at hv_ce; exact Bool.false_ne_true hv_ce
       · intro h w hw
         simp only [decide_eq_false_iff_not, not_exists] at h
-        exact (ih (M.access w) hNE').2.mpr (fun v hv =>
+        exact (ih (M.access w) hNE).2.mpr (fun v hv =>
           Bool.eq_false_iff.mpr (fun hce => h w hw v ⟨hv, hce⟩))
 
 -- ============================================================================
@@ -189,7 +187,7 @@ Kripke evaluation.
 -/
 theorem classicalCollapse (M : KripkeModel W Atom)
     (φ : Formula Atom) (w : W)
-    (hNE : φ.isNEFree = true) :
+    (hNE : φ.NEFree) :
     support M φ {w} ↔ classicalEval M φ w = true := by
   rw [(neFree_flat_eq M φ {w} hNE).1]
   simp [Finset.mem_singleton]
@@ -198,7 +196,7 @@ theorem classicalCollapse (M : KripkeModel W Atom)
     classical evaluation. -/
 theorem classicalCollapseAnti (M : KripkeModel W Atom)
     (φ : Formula Atom) (w : W)
-    (hNE : φ.isNEFree = true) :
+    (hNE : φ.NEFree) :
     antiSupport M φ {w} ↔ classicalEval M φ w = false := by
   rw [(neFree_flat_eq M φ {w} hNE).2]
   simp [Finset.mem_singleton]
@@ -211,7 +209,7 @@ theorem classicalCollapseAnti (M : KripkeModel W Atom)
     evaluation on all members. -/
 theorem neFree_flat (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hNE : φ.isNEFree = true) :
+    (hNE : φ.NEFree) :
     support M φ t ↔ ∀ w ∈ t, classicalEval M φ w = true :=
   (neFree_flat_eq M φ t hNE).1
 

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -55,9 +55,8 @@ def verum [Inhabited Atom] : Formula Atom :=
     classicalEval M verum w = true := by
   simp [verum, classicalEval, Bool.or_not_self]
 
-@[simp] theorem isNEFree_verum [Inhabited Atom] :
-    (verum : Formula Atom).isNEFree = true := by
-  simp [verum, Formula.isNEFree]
+@[simp] theorem neFree_verum [Inhabited Atom] : (verum : Formula Atom).NEFree :=
+  ⟨trivial, trivial⟩
 
 /-- Finite conjunction of a list of formulas; the empty conjunction is `⊤`. -/
 def bigConj [Inhabited Atom] : List (Formula Atom) → Formula Atom
@@ -72,12 +71,11 @@ theorem classicalEval_bigConj [Inhabited Atom] (M : KripkeModel W Atom) (w : W)
   | cons φ rest ih =>
     simp only [bigConj, classicalEval, Bool.and_eq_true, List.forall_mem_cons, ih]
 
-theorem isNEFree_bigConj [Inhabited Atom] (l : List (Formula Atom))
-    (h : ∀ φ ∈ l, φ.isNEFree = true) : (bigConj l).isNEFree = true := by
+theorem neFree_bigConj [Inhabited Atom] (l : List (Formula Atom))
+    (h : ∀ φ ∈ l, φ.NEFree) : (bigConj l).NEFree := by
   induction l with
-  | nil => simp [bigConj]
+  | nil => exact neFree_verum
   | cons φ rest ih =>
-    simp only [bigConj, Formula.isNEFree, Bool.and_eq_true]
     exact ⟨h φ (List.mem_cons.mpr (Or.inl rfl)),
            ih (fun ψ hψ => h ψ (List.mem_cons.mpr (Or.inr hψ)))⟩
 
@@ -91,12 +89,12 @@ noncomputable def atomicType [Fintype Atom] [Inhabited Atom]
   bigConj ((Finset.univ : Finset Atom).toList.map
     (fun p => if M.val p w then .atom p else .neg (.atom p)))
 
-theorem isNEFree_atomicType [Fintype Atom] [Inhabited Atom]
-    (M : KripkeModel W Atom) (w : W) : (atomicType M w).isNEFree = true := by
-  apply isNEFree_bigConj
+theorem neFree_atomicType [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) (w : W) : (atomicType M w).NEFree := by
+  apply neFree_bigConj
   intro φ hφ
   obtain ⟨p, -, rfl⟩ := List.mem_map.mp hφ
-  cases M.val p w <;> simp [Formula.isNEFree]
+  cases M.val p w <;> simp [Formula.NEFree]
 
 /-- The atomic type of `w` is classically satisfied at `v` exactly when `v` and
     `w` assign every atom the same value. -/

--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -6,43 +6,37 @@ import Linglib.Logic.Bilateral.Defs
 import Linglib.Logic.Modal.Kripke
 
 /-!
-# Bilateral State-based Modal Logic (BSML) — Core Definitions
-[aloni-2022]
+# Bilateral state-based modal logic: core definitions
 
-BSML is a bilateral, state-based modal logic in which formulas are evaluated
-against **teams** (sets of worlds):
-- **Support** (⊨⁺): positive evaluation
-- **Anti-support** (⊨⁻): negative evaluation
-- **Negation**: swaps support and anti-support → DNE is definitional
+Bilateral state-based modal logic (BSML, [aloni-2022]) evaluates formulas
+against **teams** — finite sets of worlds of a Kripke model — with two
+polarities: support (`⊨⁺`) and anti-support (`⊨⁻`). Negation swaps the
+polarities, so double-negation elimination holds definitionally, and the
+non-emptiness atom `NE` (supported exactly by non-empty teams) is the
+ingredient from which the free-choice effects derive. Despite being
+state-based, BSML is a static logic: formulas are evaluated against teams,
+not updated by them ([aloni-2022] p. 22). QBSML ([aloni-vanormondt-2023])
+runs the same recursion over quantified atoms.
 
-Key innovations over classical modal logic:
-- **Split disjunction**: t ⊨⁺ φ ∨ ψ iff ∃t₁,t₂: t₁ ∪ t₂ = t ∧ t₁ ⊨⁺ φ ∧ t₂ ⊨⁺ ψ
-- **Split conjunction (anti-support)**: t ⊨⁻ φ ∧ ψ iff ∃t₁,t₂: t₁ ∪ t₂ = t ∧ t₁ ⊨⁻ φ ∧ t₂ ⊨⁻ ψ
-- **Non-emptiness atom (NE)**: t ⊨⁺ NE iff t ≠ ∅
+## Main declarations
 
-Despite being state-based, BSML is a **static** logic (not dynamic):
-formulas are evaluated against teams, not updated by them
-([aloni-2022] p. 22).
+* `Formula` — atoms, `NE`, `¬`, `∧`, split `∨`, and `◇`; `□` is the
+  abbreviation `Formula.nec` (`□φ := ¬◇¬φ`).
+* `eval` — bilateral evaluation, the two polarities unified by a `Bool`
+  parameter; `support`/`antiSupport` fix the polarity.
+* `Formula.NEFree`, `Formula.Positive` — the `NE`-free and negation-free
+  syntactic fragments.
+* `Modal.KripkeModel.IsIndisputable`, `Modal.KripkeModel.IsStateBased` —
+  the frame conditions governing wide-scope free choice.
+* `consequence`, `equivalent` — support consequence and bilateral
+  equivalence.
+* `supportStar`, `consequenceStar` — the BSML* variant excluding `∅` from
+  intermediate states.
 
-## Atom polymorphism
+## Implementation notes
 
-Both `Formula` and `KripkeModel` are parameterized over an atom type
-`Atom : Type*`. This eliminates the silent typo trap of String-keyed
-valuations and aligns with the predicate-level extension in QBSML
-([aloni-vanormondt-2023]), which generalizes atoms to typed
-predicates with terms.
-
-## Substrate dependencies
-
-The split-disjunction predicate `splitsAs` and the frame-condition
-predicates `IsStateBased` / `IsIndisputable` live in
-`Team` (theory-neutral `Finset` combinatorics) and
-are consumed below. This is the same machinery QBSML reuses via the
-`s↓` projection from `Finset (W × Assignment)` to `Finset W`.
-
-## Bilateral Symmetry
-
-The support and anti-support clauses exhibit a striking duality:
+The support and anti-support clauses are dual — `∧`/`∨` swap, `◇`/`□` swap,
+atoms flip truth value:
 
 | Connective | Support (⊨⁺) | Anti-support (⊨⁻) |
 |-----------|-------------|-------------------|
@@ -54,35 +48,21 @@ The support and anti-support clauses exhibit a striking duality:
 | □φ | ∀w∈s: R[w] ⊨⁺ φ | ∀w∈s: ∃ ne t⊆R[w]: t ⊨⁻ φ |
 | NE | s ≠ ∅ | s = ∅ |
 
-∧/∨ are swapped; ◇/□ are swapped; atoms are dual.
-
-## Implementation
-
-Models are the shared `Modal.KripkeModel` carrier (Definition 1,
-[aloni-2022]); teams are `Finset W` (with `[DecidableEq W] [Fintype W]`).
-Support and anti-support are unified into a single `eval` function
-parameterized by a `Bool` polarity. This makes DNE definitional
-(`eval M true (.neg (.neg φ)) t` reduces to `eval M true φ t` by
-two applications of the negation clause).
-
-`eval` returns `Prop`, with a `Decidable` instance provided for
-computational verification via `#guard decide (...)`.
+Encoding both polarities in one `eval` makes the duality a single recursion
+and double-negation elimination a `rfl`: `eval M true (.neg (.neg φ)) t`
+reduces to `eval M true φ t` by two negation clauses. Models are the shared
+`Modal.KripkeModel` carrier; teams are `Finset W`; `eval` is `Prop`-valued
+with a `Decidable` instance, so concrete claims close by `decide`.
 -/
 
 namespace BSML
 
 open Modal (KripkeModel)
 
--- ============================================================================
--- §1: Formulas (Definition 1)
--- ============================================================================
+/-! ### Formulas -/
 
-/-- BSML formula language (Definition 1 from [aloni-2022]).
-
-    Parameterized over an atom type `Atom : Type*`. The base language is:
-    p | ¬φ | φ∧ψ | φ∨ψ | ◇φ | NE.
-    □ is NOT a primitive — it is defined as an abbreviation:
-    □φ := ¬◇¬φ (see `Formula.nec`). -/
+/-- BSML formulas over an atom type: `p | NE | ¬φ | φ∧ψ | φ∨ψ | ◇φ`.
+    `□` is not primitive — see `Formula.nec`. -/
 inductive Formula (Atom : Type*) where
   /-- Atomic proposition -/
   | atom : Atom → Formula Atom
@@ -100,59 +80,59 @@ inductive Formula (Atom : Type*) where
 
 variable {Atom : Type*}
 
-/-- □φ := ¬◇¬φ — necessity as an abbreviation, not a primitive.
-    The derived support/anti-support conditions are:
-    - s ⊨⁺ □φ iff ∀w∈s, R[w] ⊨⁺ φ
-    - s ⊨⁻ □φ iff ∀w∈s, ∃ ne t⊆R[w], t ⊨⁻ φ
-    These follow from the definitions of ¬, ◇, and ¬ applied to φ. -/
+/-- Necessity as an abbreviation: `Formula.nec φ = ¬◇¬φ`, giving the derived
+    clauses `s ⊨⁺ □φ ↔ ∀ w ∈ s, R[w] ⊨⁺ φ` and
+    `s ⊨⁻ □φ ↔ ∀ w ∈ s, ∃ nonempty t ⊆ R[w], t ⊨⁻ φ`. -/
 def Formula.nec (φ : Formula Atom) : Formula Atom :=
   .neg (.poss (.neg φ))
 
-/-- A formula is NE-free if it does not contain the NE atom.
-    For NE-free formulas, BSML reduces to classical modal logic
-    on singleton teams (Fact 15, [aloni-2022]). -/
-def Formula.isNEFree : Formula Atom → Bool
-  | .atom _ => true
-  | .ne => false
-  | .neg φ => φ.isNEFree
-  | .conj φ ψ => φ.isNEFree && ψ.isNEFree
-  | .disj φ ψ => φ.isNEFree && ψ.isNEFree
-  | .poss φ => φ.isNEFree
+/-! ### Syntactic fragments -/
 
-/-- A formula is positive if it contains no negation. -/
-def Formula.isPositive : Formula Atom → Bool
-  | .atom _ => true
-  | .ne => true
-  | .neg _ => false
-  | .conj φ ψ => φ.isPositive && ψ.isPositive
-  | .disj φ ψ => φ.isPositive && ψ.isPositive
-  | .poss φ => φ.isPositive
+/-- `Formula.NEFree φ` holds when `φ` contains no `NE` atom — the fragment
+    on which BSML collapses to classical modal logic on singleton teams
+    (`BSML/Bridge.lean`). -/
+def Formula.NEFree : Formula Atom → Prop
+  | .atom _ => True
+  | .ne => False
+  | .neg φ => φ.NEFree
+  | .conj φ ψ => φ.NEFree ∧ ψ.NEFree
+  | .disj φ ψ => φ.NEFree ∧ ψ.NEFree
+  | .poss φ => φ.NEFree
 
-/-- A formula is atomic (a single propositional variable). -/
-def Formula.isAtom : Formula Atom → Bool
-  | .atom _ => true
-  | _ => false
+instance instDecidableNEFree : (φ : Formula Atom) → Decidable φ.NEFree
+  | .atom _ => .isTrue trivial
+  | .ne => .isFalse id
+  | .neg φ => instDecidableNEFree φ
+  | .conj φ ψ => @instDecidableAnd _ _ (instDecidableNEFree φ) (instDecidableNEFree ψ)
+  | .disj φ ψ => @instDecidableAnd _ _ (instDecidableNEFree φ) (instDecidableNEFree ψ)
+  | .poss φ => instDecidableNEFree φ
 
-/-- Atoms are NE-free. -/
-theorem Formula.isAtom_implies_isNEFree (φ : Formula Atom)
-    (h : φ.isAtom = true) : φ.isNEFree = true := by
-  cases φ <;> simp_all [isAtom, isNEFree]
+/-- `Formula.Positive φ` holds when `φ` contains no negation. -/
+def Formula.Positive : Formula Atom → Prop
+  | .atom _ => True
+  | .ne => True
+  | .neg _ => False
+  | .conj φ ψ => φ.Positive ∧ ψ.Positive
+  | .disj φ ψ => φ.Positive ∧ ψ.Positive
+  | .poss φ => φ.Positive
 
--- ============================================================================
--- §3: Evaluation (Definition 2)
--- ============================================================================
+instance instDecidablePositive : (φ : Formula Atom) → Decidable φ.Positive
+  | .atom _ => .isTrue trivial
+  | .ne => .isTrue trivial
+  | .neg _ => .isFalse id
+  | .conj φ ψ => @instDecidableAnd _ _ (instDecidablePositive φ) (instDecidablePositive ψ)
+  | .disj φ ψ => @instDecidableAnd _ _ (instDecidablePositive φ) (instDecidablePositive ψ)
+  | .poss φ => instDecidablePositive φ
+
+/-! ### Bilateral evaluation -/
 
 variable {W : Type*} [DecidableEq W] [Fintype W]
 
-/-- Bilateral evaluation with polarity parameter (Definition 2, [aloni-2022]).
-
-    `eval M true φ t` is support (⊨⁺), `eval M false φ t` is anti-support (⊨⁻).
-    Negation flips polarity, making DNE definitional:
-    `eval M true (.neg (.neg φ)) t` = `eval M true φ t` by computation.
-
-    Split disjunction and split conjunction-anti-support clauses use
-    `Team.splitsAs` (= `t₁ ∪ t₂ = t`); the recursion is
-    the same shape QBSML reuses at the `Finset (W × Assignment)` carrier. -/
+/-- Bilateral evaluation with polarity parameter: `eval M true φ t` is
+    support (`⊨⁺`), `eval M false φ t` is anti-support (`⊨⁻`), and negation
+    flips the polarity. The split clauses (disjunction-support,
+    conjunction-anti-support) quantify over `Team.splitsAs` decompositions
+    `t₁ ∪ t₂ = t`. -/
 def eval (M : KripkeModel W Atom) : Bool → Formula Atom → Finset W → Prop
   | true,  .atom p,       t => ∀ w ∈ t, M.val p w = true
   | false, .atom p,       t => ∀ w ∈ t, M.val p w = false
@@ -179,23 +159,19 @@ abbrev support (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Pro
 abbrev antiSupport (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
   eval M false φ t
 
--- ============================================================================
--- §4: Double Negation Elimination (Fact 6)
--- ============================================================================
+/-! ### Double-negation elimination -/
 
-/-- DNE: ¬¬φ has the same support as φ. Definitional with the polarity design. -/
+/-- `¬¬φ` has the same support as `φ`, definitionally. -/
 theorem dne_support (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W) :
     support M (.neg (.neg φ)) t ↔ support M φ t := Iff.rfl
 
-/-- DNE: ¬¬φ has the same anti-support as φ. -/
+/-- `¬¬φ` has the same anti-support as `φ`, definitionally. -/
 theorem dne_antiSupport (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W) :
     antiSupport M (.neg (.neg φ)) t ↔ antiSupport M φ t := Iff.rfl
 
--- ============================================================================
--- §5: Unfolding Lemmas
--- ============================================================================
+/-! ### Unfolding lemmas -/
 
 @[simp] lemma support_neg (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W) :
@@ -206,9 +182,7 @@ theorem dne_antiSupport (M : KripkeModel W Atom)
     antiSupport M (.neg φ) t ↔ support M φ t := Iff.rfl
 
 /-- BSML's `support` and `antiSupport` form a paraconsistent bilateral
-    logic (`Bilateral.IsBilateral`) under `Formula.neg`.
-    Pointwise polarity-flip lemmas (`support_neg` / `antiSupport_neg`,
-    both `Iff.rfl`) lift to function equality via `IsBilateral.of_iff`. -/
+    logic (`Bilateral.IsBilateral`) under `Formula.neg`. -/
 theorem isBilateral (M : KripkeModel W Atom) :
     Bilateral.IsBilateral
       (support M) (antiSupport M) Formula.neg :=
@@ -222,41 +196,34 @@ theorem isBilateral (M : KripkeModel W Atom) :
     (φ ψ : Formula Atom) (t : Finset W) :
     antiSupport M (.disj φ ψ) t ↔ antiSupport M φ t ∧ antiSupport M ψ t := Iff.rfl
 
-/-- Empty team supports all atoms (vacuous truth). -/
+/-- The empty team supports every atom, vacuously. -/
 lemma empty_supports_atom (M : KripkeModel W Atom) (p : Atom) :
-    support M (.atom p) ∅ := by
-  intro w hw; exact absurd hw (by simp)
+    support M (.atom p) ∅ :=
+  fun w hw => absurd hw (Finset.notMem_empty w)
 
--- ============================================================================
--- §6: Frame Properties
--- ============================================================================
+/-! ### Frame conditions -/
 
-/-- Indisputable accessibility: all worlds in team see the same accessible worlds.
-    Required for wide-scope FC (Fact 5, [aloni-2022]).
-
-    Defined via `Team.IsIndisputable` to share substrate
-    with QBSML and any other state-based logic. -/
+/-- Indisputable accessibility: all worlds in the team see the same
+    accessible worlds — the frame condition for wide-scope free choice.
+    Defined via `Team.IsIndisputable`, sharing substrate with QBSML. -/
 def _root_.Modal.KripkeModel.IsIndisputable (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsIndisputable M.access t
 
-/-- State-based accessibility: every world in team has the team itself as
-    accessible worlds. Strictly stronger than indisputability.
-
+/-- State-based accessibility: every world in the team has the team itself
+    as its accessible worlds. Strictly stronger than indisputability.
     Defined via `Team.IsStateBased`. -/
 def _root_.Modal.KripkeModel.IsStateBased (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsStateBased M.access t
 
-instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) := by
-  unfold Modal.KripkeModel.IsIndisputable; infer_instance
+instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) :=
+  inferInstanceAs (Decidable (Team.IsIndisputable M.access t))
 
-instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) := by
-  unfold Modal.KripkeModel.IsStateBased; infer_instance
+instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) :=
+  inferInstanceAs (Decidable (Team.IsStateBased M.access t))
 
--- ============================================================================
--- §7: Semantic Relations
--- ============================================================================
+/-! ### Consequence and equivalence -/
 
-/-- Semantic consequence: φ ⊨ ψ if every team supporting φ also supports ψ. -/
+/-- Semantic consequence: every team supporting `φ` supports `ψ`. -/
 def consequence (φ ψ : Formula Atom) : Prop :=
   ∀ (M : KripkeModel W Atom) (t : Finset W), support M φ t → support M ψ t
 
@@ -265,19 +232,15 @@ def equivalent (φ ψ : Formula Atom) : Prop :=
   ∀ (M : KripkeModel W Atom) (t : Finset W),
     (support M φ t ↔ support M ψ t) ∧ (antiSupport M φ t ↔ antiSupport M ψ t)
 
--- ============================================================================
--- §8: BSML* Consequence (non-empty teams only)
--- ============================================================================
+/-! ### BSML* -/
 
-/-- BSML* support: like standard BSML support but ∅ is excluded from all
-    intermediate states. The only difference from `eval M true` is in
-    disjunction, where both parts of the split must be non-empty.
-    ([aloni-2022] §6.3.1).
+/-- BSML* support ([aloni-2022] §6.3.1): like `support` but `∅` is excluded
+    from intermediate states — in disjunction, both parts of the split must
+    be non-empty (`Team.splitsAsNE`).
 
     NOTE: the negation case `| .neg _, _ => True` is a placeholder. Aloni's
-    actual BSML* uses bilateral polarity mirror BSML's; completing this
-    requires a proper polarity-flipped supportStar definition. Completing
-    bilateral negation for BSML* is tracked as out-of-scope. -/
+    actual BSML* uses bilateral polarity mirroring BSML's; completing this
+    requires a polarity-flipped `supportStar`, tracked as out of scope. -/
 def supportStar (M : KripkeModel W Atom) : Formula Atom → Finset W → Prop
   | .atom p, t => ∀ w ∈ t, M.val p w = true
   | .ne, t => t.Nonempty
@@ -288,15 +251,12 @@ def supportStar (M : KripkeModel W Atom) : Formula Atom → Finset W → Prop
       supportStar M φ t₁ ∧ supportStar M ψ t₂
   | .poss φ, t => ∀ w ∈ t, ∃ s ⊆ M.access w, s.Nonempty ∧ supportStar M φ s
 
-/-- BSML* consequence: consequence using BSML* support (non-empty intermediate
-    states) on non-empty teams. In BSML*, the empty set ∅ is not among the
-    possible states ([aloni-2022] §6.3.1). -/
+/-- BSML* consequence: `supportStar` consequence on non-empty teams — in
+    BSML*, `∅` is not among the possible states. -/
 def consequenceStar (φ ψ : Formula Atom) : Prop :=
   ∀ (M : KripkeModel W Atom) (t : Finset W), t.Nonempty → supportStar M φ t → supportStar M ψ t
 
--- ============================================================================
--- §9: Decidable Instance
--- ============================================================================
+/-! ### Decidability of evaluation -/
 
 /-- Decidability of `eval` by structural recursion on the formula. -/
 def decidableEval (M : KripkeModel W Atom) :

--- a/Linglib/Logic/Modal/BSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/BSML/Enrichment.lean
@@ -159,21 +159,19 @@ theorem antiSupport_poss_weaken (M : KripkeModel W Atom)
 /-- Both directions of Fact 1 (enrichment strengthens), proved by simultaneous
     induction on formula structure. -/
 private theorem enrichment_strengthens_both (M : KripkeModel W Atom)
-    (φ : Formula Atom) (hNE : φ.isNEFree = true) :
+    (φ : Formula Atom) (hNE : φ.NEFree) :
     (∀ t, support M (enrich φ) t → support M φ t) ∧
     (∀ t, antiSupport M (enrich φ) t → antiSupport M φ t) := by
   induction φ with
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | atom p =>
     exact ⟨fun t h => h.1, fun t h => antiSupport_strip_ne M (.atom p) t h⟩
   | neg ψ ih =>
-    have ⟨ih_s, ih_a⟩ := ih (by simp [Formula.isNEFree] at hNE; exact hNE)
+    have ⟨ih_s, ih_a⟩ := ih hNE
     exact ⟨fun t h => ih_a t h.1, fun t h => ih_s t (antiSupport_strip_ne M _ t h)⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := hNE.1
+    have hψ₂ := hNE.2
     have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
     have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
     constructor
@@ -183,10 +181,8 @@ private theorem enrichment_strengthens_both (M : KripkeModel W Atom)
       obtain ⟨s₁, s₂, hunion, h₁, h₂⟩ := h'
       exact ⟨s₁, s₂, hunion, ih₁_a s₁ h₁, ih₂_a s₂ h₂⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have hψ₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have hψ₁ := hNE.1
+    have hψ₂ := hNE.2
     have ⟨ih₁_s, ih₁_a⟩ := ih₁ hψ₁
     have ⟨ih₂_s, ih₂_a⟩ := ih₂ hψ₂
     constructor
@@ -197,7 +193,7 @@ private theorem enrichment_strengthens_both (M : KripkeModel W Atom)
       have h' := antiSupport_strip_ne M (.disj (enrich ψ₁) (enrich ψ₂)) t h
       exact ⟨ih₁_a t h'.1, ih₂_a t h'.2⟩
   | poss ψ ih =>
-    have ⟨ih_s, ih_a⟩ := ih (by simp [Formula.isNEFree] at hNE; exact hNE)
+    have ⟨ih_s, ih_a⟩ := ih hNE
     constructor
     · intro t h w hw
       obtain ⟨s, hs, hne, hsupp⟩ := h.1 w hw
@@ -214,7 +210,7 @@ supports the original α.
 -/
 theorem enrichment_strengthens_support (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hNE : φ.isNEFree = true)
+    (hNE : φ.NEFree)
     (h : support M (enrich φ) t) :
     support M φ t :=
   (enrichment_strengthens_both M φ hNE).1 t h
@@ -222,7 +218,7 @@ theorem enrichment_strengthens_support (M : KripkeModel W Atom)
 /-- Enrichment strengthens (anti-support direction of Fact 1). -/
 theorem enrichment_strengthens_antiSupport (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hNE : φ.isNEFree = true)
+    (hNE : φ.NEFree)
     (h : antiSupport M (enrich φ) t) :
     antiSupport M φ t :=
   (enrichment_strengthens_both M φ hNE).2 t h
@@ -236,7 +232,7 @@ Fact 2 from [aloni-2022]: [α]⁺ ⊨ α ∧ NE for NE-free α.
 -/
 theorem enrichment_entails_conj_ne (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hNE : φ.isNEFree = true)
+    (hNE : φ.NEFree)
     (h : support M (enrich φ) t) :
     support M (.conj φ .ne) t :=
   ⟨enrichment_strengthens_support M φ t hNE h,
@@ -254,14 +250,13 @@ For positive α (no negation): ¬[α]⁺ ≡ ¬α (both support and anti-support
 -/
 theorem enrichment_vacuous_under_negation (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hPos : φ.isPositive = true) :
+    (hPos : φ.Positive) :
     antiSupport M (enrich φ) t ↔ antiSupport M φ t := by
   induction φ generalizing t with
   | atom p => exact antiSupport_conj_ne_iff M (.atom p) t
   | ne => exact Iff.rfl
-  | neg _ => simp [Formula.isPositive] at hPos
+  | neg _ => exact hPos.elim
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    simp only [Formula.isPositive, Bool.and_eq_true] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show (∃ t₁ t₂, t₁ ∪ t₂ = t ∧ antiSupport M (enrich ψ₁) t₁ ∧
@@ -273,7 +268,6 @@ theorem enrichment_vacuous_under_negation (M : KripkeModel W Atom)
     · rintro ⟨t₁, t₂, hu, h₁, h₂⟩
       exact ⟨t₁, t₂, hu, (ih₁ t₁ hPos.1).mpr h₁, (ih₂ t₂ hPos.2).mpr h₂⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    simp only [Formula.isPositive, Bool.and_eq_true] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show antiSupport M (enrich ψ₁) t ∧ antiSupport M (enrich ψ₂) t ↔
@@ -281,7 +275,6 @@ theorem enrichment_vacuous_under_negation (M : KripkeModel W Atom)
     exact ⟨fun ⟨h₁, h₂⟩ => ⟨(ih₁ t hPos.1).mp h₁, (ih₂ t hPos.2).mp h₂⟩,
            fun ⟨h₁, h₂⟩ => ⟨(ih₁ t hPos.1).mpr h₁, (ih₂ t hPos.2).mpr h₂⟩⟩
   | poss ψ ih =>
-    simp only [Formula.isPositive] at hPos
     simp only [enrich]
     rw [antiSupport_conj_ne_iff]
     show (∀ w ∈ t, antiSupport M (enrich ψ) (M.access w)) ↔
@@ -292,7 +285,7 @@ theorem enrichment_vacuous_under_negation (M : KripkeModel W Atom)
 /-- Fact 9, support direction: support M (.neg (enrich φ)) t ↔ support M (.neg φ) t. -/
 theorem enrichment_vacuous_under_negation_support (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hPos : φ.isPositive = true) :
+    (hPos : φ.Positive) :
     support M (.neg (enrich φ)) t ↔ support M (.neg φ) t :=
   enrichment_vacuous_under_negation M φ t hPos
 
@@ -309,11 +302,13 @@ def consequencePlus (φ ψ : Formula Atom) : Prop :=
 -- §11: BSML* ↔ BSML+ for Classical Positive Formulas (Fact 13)
 -- ============================================================================
 
-/-- A formula is classical positive: no NE atom and no negation.
-    These are the formulas for which BSML* and BSML+ consequence coincide
-    ([aloni-2022] Fact 13). -/
-def Formula.isClassicalPositive (φ : Formula Atom) : Bool :=
-  φ.isNEFree && φ.isPositive
+/-- `Formula.ClassicalPositive φ` holds when `φ` has no `NE` and no negation —
+    the fragment on which BSML* and BSML+ consequence coincide. -/
+def Formula.ClassicalPositive (φ : Formula Atom) : Prop :=
+  φ.NEFree ∧ φ.Positive
+
+instance (φ : Formula Atom) : Decidable φ.ClassicalPositive :=
+  inferInstanceAs (Decidable (φ.NEFree ∧ φ.Positive))
 
 /-- For classical positive formulas, enriched support is equivalent to BSML*
     support plus non-emptiness. The key insight is that enrichment adds NE at
@@ -321,21 +316,15 @@ def Formula.isClassicalPositive (φ : Formula Atom) : Bool :=
     intermediate states (including disjunction splits). -/
 private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
     (φ : Formula Atom) (t : Finset W)
-    (hCP : φ.isClassicalPositive = true) :
+    (hCP : φ.ClassicalPositive) :
     support M (enrich φ) t ↔ supportStar M φ t ∧ t.Nonempty := by
   induction φ generalizing t with
-  | ne => simp [Formula.isClassicalPositive, Formula.isNEFree] at hCP
-  | neg _ => simp [Formula.isClassicalPositive, Formula.isPositive] at hCP
+  | ne => exact hCP.1.elim
+  | neg _ => exact hCP.2.elim
   | atom _ => exact Iff.rfl
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isClassicalPositive = true := by
-      simp only [Formula.isClassicalPositive, Formula.isNEFree,
-                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
-      exact ⟨hCP.1.1, hCP.2.1⟩
-    have hψ₂ : ψ₂.isClassicalPositive = true := by
-      simp only [Formula.isClassicalPositive, Formula.isNEFree,
-                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
-      exact ⟨hCP.1.2, hCP.2.2⟩
+    have hψ₁ : ψ₁.ClassicalPositive := ⟨hCP.1.1, hCP.2.1⟩
+    have hψ₂ : ψ₂.ClassicalPositive := ⟨hCP.1.2, hCP.2.2⟩
     simp only [enrich, support, eval, supportStar]
     constructor
     · intro ⟨⟨h₁, h₂⟩, hne⟩
@@ -343,14 +332,8 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
     · intro ⟨⟨h₁, h₂⟩, hne⟩
       exact ⟨⟨(ih₁ t hψ₁).mpr ⟨h₁, hne⟩, (ih₂ t hψ₂).mpr ⟨h₂, hne⟩⟩, hne⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have hψ₁ : ψ₁.isClassicalPositive = true := by
-      simp only [Formula.isClassicalPositive, Formula.isNEFree,
-                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
-      exact ⟨hCP.1.1, hCP.2.1⟩
-    have hψ₂ : ψ₂.isClassicalPositive = true := by
-      simp only [Formula.isClassicalPositive, Formula.isNEFree,
-                  Formula.isPositive, Bool.and_eq_true] at hCP ⊢
-      exact ⟨hCP.1.2, hCP.2.2⟩
+    have hψ₁ : ψ₁.ClassicalPositive := ⟨hCP.1.1, hCP.2.1⟩
+    have hψ₂ : ψ₂.ClassicalPositive := ⟨hCP.1.2, hCP.2.2⟩
     simp only [enrich, support, eval, supportStar]
     constructor
     · intro ⟨⟨t₁, t₂, hu, h₁, h₂⟩, hne⟩
@@ -361,9 +344,7 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
       exact ⟨⟨t₁, t₂, hu, (ih₁ t₁ hψ₁).mpr ⟨hs₁, hne₁⟩,
               (ih₂ t₂ hψ₂).mpr ⟨hs₂, hne₂⟩⟩, hne⟩
   | poss ψ ih =>
-    have hψ : ψ.isClassicalPositive = true := by
-      simp only [Formula.isClassicalPositive, Formula.isNEFree,
-                  Formula.isPositive] at hCP; exact hCP
+    have hψ : ψ.ClassicalPositive := hCP
     simp only [enrich, support, eval, supportStar]
     constructor
     · intro ⟨hposs, hne⟩
@@ -384,7 +365,7 @@ empty state syntactically (via [·]⁺ enrichment) is equivalent to ruling
 it out model-theoretically (via BSML* non-empty restriction).
 -/
 theorem bsmlStar_iff_bsmlPlus (φ ψ : Formula Atom)
-    (hφ : φ.isClassicalPositive = true) (hψ : ψ.isClassicalPositive = true) :
+    (hφ : φ.ClassicalPositive) (hψ : ψ.ClassicalPositive) :
     consequenceStar (W := W) φ ψ ↔ consequencePlus (W := W) φ ψ := by
   constructor
   · intro hStar M t hEnrich

--- a/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
+++ b/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
@@ -94,7 +94,7 @@ is NE-free exactly when `φ` is. -/
 /-- NE-free formulas cannot be both supported and anti-supported on a
     nonempty team. -/
 theorem eq_empty_of_support_antiSupport {φ : Formula Atom}
-    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
+    (hNE : φ.NEFree) (M : KripkeModel W Atom) :
     ∀ s : Finset W, support M φ s → antiSupport M φ s → s = ∅ := by
   induction φ with
   | atom p =>
@@ -103,40 +103,36 @@ theorem eq_empty_of_support_antiSupport {φ : Formula Atom}
     have h1 := hs w hw
     have h2 := ha w hw
     simp [h1] at h2
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | neg ψ ih =>
     intro s hs ha
     exact ih hNE s ha hs
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have h₁ := hNE.1
+    have h₂ := hNE.2
     rintro s ⟨hs₁, hs₂⟩ ⟨t₁, t₂, hsp, ha₁, ha₂⟩
     have hsub₁ : t₁ ⊆ s := hsp ▸ Finset.subset_union_left
     have hsub₂ : t₂ ⊆ s := hsp ▸ Finset.subset_union_right
-    have he₁ := ih₁ h₁ t₁ (isLowerSet_support_of_isNEFree h₁ M hsub₁ hs₁) ha₁
-    have he₂ := ih₂ h₂ t₂ (isLowerSet_support_of_isNEFree h₂ M hsub₂ hs₂) ha₂
+    have he₁ := ih₁ h₁ t₁ (isLowerSet_support_of_neFree h₁ M hsub₁ hs₁) ha₁
+    have he₂ := ih₂ h₂ t₂ (isLowerSet_support_of_neFree h₂ M hsub₂ hs₂) ha₂
     rw [← hsp, he₁, he₂, Finset.union_empty]
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have h₁ := hNE.1
+    have h₂ := hNE.2
     rintro s ⟨t₁, t₂, hsp, hs₁, hs₂⟩ ⟨ha₁, ha₂⟩
     have hsub₁ : t₁ ⊆ s := hsp ▸ Finset.subset_union_left
     have hsub₂ : t₂ ⊆ s := hsp ▸ Finset.subset_union_right
     have he₁ := ih₁ h₁ t₁ hs₁
-      (isLowerSet_support_of_isNEFree (φ := .neg ψ₁) h₁ M hsub₁ ha₁)
+      (isLowerSet_support_of_neFree (φ := .neg ψ₁) h₁ M hsub₁ ha₁)
     have he₂ := ih₂ h₂ t₂ hs₂
-      (isLowerSet_support_of_isNEFree (φ := .neg ψ₂) h₂ M hsub₂ ha₂)
+      (isLowerSet_support_of_neFree (φ := .neg ψ₂) h₂ M hsub₂ ha₂)
     rw [← hsp, he₁, he₂, Finset.union_empty]
   | poss ψ ih =>
     intro s hs ha
     refine Finset.eq_empty_iff_forall_notMem.mpr (fun w hw => ?_)
     obtain ⟨t, hsub, hne, hψ⟩ := hs w hw
     have haψ : antiSupport M ψ t :=
-      isLowerSet_support_of_isNEFree (φ := .neg ψ) hNE M hsub (ha w hw)
+      isLowerSet_support_of_neFree (φ := .neg ψ) hNE M hsub (ha w hw)
     obtain ⟨v, hv⟩ := hne
     have := ih hNE t hψ haψ
     simp [this] at hv
@@ -144,7 +140,7 @@ theorem eq_empty_of_support_antiSupport {φ : Formula Atom}
 /-- **Bilateral determinacy on singletons** for NE-free formulas: every
     singleton team supports or anti-supports. -/
 theorem support_singleton_or_antiSupport_singleton {φ : Formula Atom}
-    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
+    (hNE : φ.NEFree) (M : KripkeModel W Atom) :
     ∀ w : W, support M φ {w} ∨ antiSupport M φ {w} := by
   induction φ with
   | atom p =>
@@ -152,31 +148,27 @@ theorem support_singleton_or_antiSupport_singleton {φ : Formula Atom}
     cases h : M.val p w with
     | true => exact Or.inl (fun v hv => by rw [Finset.mem_singleton] at hv; rw [hv, h])
     | false => exact Or.inr (fun v hv => by rw [Finset.mem_singleton] at hv; rw [hv, h])
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | neg ψ ih => exact fun w => (ih hNE w).symm
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have h₁ := hNE.1
+    have h₂ := hNE.2
     intro w
     rcases ih₁ h₁ w with hs₁ | ha₁
     · rcases ih₂ h₂ w with hs₂ | ha₂
       · exact Or.inl ⟨hs₁, hs₂⟩
       · exact Or.inr ⟨∅, {w}, by simp,
-          support_empty_of_isNEFree (φ := .neg ψ₁) h₁ M, ha₂⟩
+          support_empty_of_neFree (φ := .neg ψ₁) h₁ M, ha₂⟩
     · exact Or.inr ⟨{w}, ∅, by simp, ha₁,
-        support_empty_of_isNEFree (φ := .neg ψ₂) h₂ M⟩
+        support_empty_of_neFree (φ := .neg ψ₂) h₂ M⟩
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
+    have h₁ := hNE.1
+    have h₂ := hNE.2
     intro w
     rcases ih₁ h₁ w with hs₁ | ha₁
-    · exact Or.inl ⟨{w}, ∅, by simp, hs₁, support_empty_of_isNEFree h₂ M⟩
+    · exact Or.inl ⟨{w}, ∅, by simp, hs₁, support_empty_of_neFree h₂ M⟩
     · rcases ih₂ h₂ w with hs₂ | ha₂
-      · exact Or.inl ⟨∅, {w}, by simp, support_empty_of_isNEFree h₁ M, hs₂⟩
+      · exact Or.inl ⟨∅, {w}, by simp, support_empty_of_neFree h₁ M, hs₂⟩
       · exact Or.inr ⟨ha₁, ha₂⟩
   | poss ψ ih =>
     intro w
@@ -188,7 +180,7 @@ theorem support_singleton_or_antiSupport_singleton {φ : Formula Atom}
     · refine Or.inr (fun v hv => ?_)
       rw [Finset.mem_singleton] at hv
       subst hv
-      have hflat := isFlat_support_of_isNEFree (φ := .neg ψ) hNE M
+      have hflat := isFlat_support_of_neFree (φ := .neg ψ) hNE M
       refine (hflat (M.access v)).mpr (fun u hu => ?_)
       rcases ih hNE u with hs | ha
       · exact absurd ⟨{u}, Finset.singleton_subset_iff.mpr hu, by simp, hs⟩ h
@@ -220,11 +212,11 @@ inductive Derives :
   /-- `∧E` (right). -/
   | conjE₂ {Γ φ ψ} : Derives Γ (.conj φ ψ) → Derives Γ ψ
   /-- `¬I`: classical `α`, NE-free undischarged assumptions. -/
-  | negI {Γ α} (p : Atom) : α.isNEFree = true →
-      (∀ γ ∈ Γ, Formula.isNEFree γ = true) →
+  | negI {Γ α} (p : Atom) : α.NEFree →
+      (∀ γ ∈ Γ, Formula.NEFree γ) →
       Derives (insert α Γ) (.bot p) → Derives Γ (.neg α)
   /-- `¬E`: ex falso for the classical fragment. -/
-  | negE {Γ₁ Γ₂ α β} : α.isNEFree = true → β.isNEFree = true →
+  | negE {Γ₁ Γ₂ α β} : α.NEFree → β.NEFree →
       Derives Γ₁ α → Derives Γ₂ (.neg α) → Derives (Γ₁ ∪ Γ₂) β
   /-- `¬¬E` (downward half of the invertible rule). -/
   | dneE {Γ φ} : Derives Γ (.neg (.neg φ)) → Derives Γ φ
@@ -247,7 +239,7 @@ inductive Derives :
   /-- `¬NEE` (upward half). -/
   | negNeI {Γ p} : Derives Γ (.bot p) → Derives Γ (.neg .ne)
   /-- `∨I`: the introduced disjunct must be NE-free. -/
-  | disjI {Γ φ ψ} : ψ.isNEFree = true → Derives Γ φ →
+  | disjI {Γ φ ψ} : ψ.NEFree → Derives Γ φ →
       Derives Γ (.disj φ ψ)
   /-- `∨W`: unconstrained introduction of the premise itself. -/
   | disjW {Γ φ} : Derives Γ φ → Derives Γ (.disj φ φ)
@@ -259,13 +251,13 @@ inductive Derives :
   /-- `∨E`: NE-free subderivation contexts (the `⫶`-freeness condition on
       `χ` is vacuous in the `⫶`-free language). -/
   | disjE {Γ Δ₁ Δ₂ φ ψ χ} :
-      (∀ γ ∈ Δ₁, Formula.isNEFree γ = true) →
-      (∀ γ ∈ Δ₂, Formula.isNEFree γ = true) →
+      (∀ γ ∈ Δ₁, Formula.NEFree γ) →
+      (∀ γ ∈ Δ₂, Formula.NEFree γ) →
       Derives Γ (.disj φ ψ) → Derives (insert φ Δ₁) χ →
       Derives (insert ψ Δ₂) χ → Derives (Γ ∪ Δ₁ ∪ Δ₂) χ
   /-- `∨Mon`: NE-free subderivation context. -/
   | disjMon {Γ Δ φ ψ χ} :
-      (∀ γ ∈ Δ, Formula.isNEFree γ = true) →
+      (∀ γ ∈ Δ, Formula.NEFree γ) →
       Derives Γ (.disj φ ψ) → Derives (insert ψ Δ) χ →
       Derives (Γ ∪ Δ) (.disj φ χ)
   /-- `⊥E`. -/
@@ -307,7 +299,7 @@ inductive Derives :
     shared-core rules): derivable consequence is team-semantic consequence —
     on every model, every team supporting all of `Γ` supports `φ`. The
     `∨`-rule cases run on the closure pillars: NE-free downward closure
-    (`isLowerSet_support_of_isNEFree`) for discharging side-conditioned
+    (`isLowerSet_support_of_neFree`) for discharging side-conditioned
     contexts on sub-teams, and unrestricted union closure
     (`supClosed_support`) for reassembling `∨E`'s conclusion. -/
 theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
@@ -327,7 +319,7 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
   | @negI Γ α p hα hΓNE _ ih =>
     intro s hΓ
     show antiSupport M α s
-    have hflat := isFlat_support_of_isNEFree (φ := .neg α) hα M
+    have hflat := isFlat_support_of_neFree (φ := .neg α) hα M
     refine (hflat s).mpr (fun w hw => ?_)
     rcases support_singleton_or_antiSupport_singleton hα M w with hsup | hanti
     · exfalso
@@ -336,7 +328,7 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
         simp at this
       · rcases hγ with rfl | hγ
         · exact hsup
-        · exact isLowerSet_support_of_isNEFree (hΓNE γ hγ) M
+        · exact isLowerSet_support_of_neFree (hΓNE γ hγ) M
             (Finset.singleton_subset_iff.mpr hw) (hΓ γ hγ)
     · exact hanti
   | @negE Γ₁ Γ₂ α β hα hβ _ _ ih₁ ih₂ =>
@@ -344,7 +336,7 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
     have h1 := ih₁ s (fun γ hγ => hΓ γ (Set.mem_union_left _ hγ))
     have h2 := ih₂ s (fun γ hγ => hΓ γ (Set.mem_union_right _ hγ))
     have hs : s = ∅ := eq_empty_of_support_antiSupport hα M s h1 h2
-    exact hs ▸ support_empty_of_isNEFree hβ M
+    exact hs ▸ support_empty_of_neFree hβ M
   | dneE _ ih => exact ih
   | dneI _ ih => exact ih
   | dmConjE _ ih => exact ih
@@ -357,7 +349,7 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
     exact fun s hΓ => (support_bot_iff M p s).mp (ih s hΓ)
   | disjI hψ _ ih =>
     exact fun s hΓ =>
-      ⟨s, ∅, by simp, ih s hΓ, support_empty_of_isNEFree hψ M⟩
+      ⟨s, ∅, by simp, ih s hΓ, support_empty_of_neFree hψ M⟩
   | disjW _ ih =>
     exact fun s hΓ => ⟨s, s, by simp, ih s hΓ, ih s hΓ⟩
   | disjCom _ ih =>
@@ -379,12 +371,12 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
     have hχ₁ := ih₁ t₁ (fun γ hγ => by
       rcases hγ with rfl | hγ
       · exact hφ
-      · exact isLowerSet_support_of_isNEFree (hΔ₁ γ hγ) M hsub₁
+      · exact isLowerSet_support_of_neFree (hΔ₁ γ hγ) M hsub₁
           (hΓ γ (Set.mem_union_left _ (Set.mem_union_right _ hγ))))
     have hχ₂ := ih₂ t₂ (fun γ hγ => by
       rcases hγ with rfl | hγ
       · exact hψ
-      · exact isLowerSet_support_of_isNEFree (hΔ₂ γ hγ) M hsub₂
+      · exact isLowerSet_support_of_neFree (hΔ₂ γ hγ) M hsub₂
           (hΓ γ (Set.mem_union_right _ hγ)))
     exact hsp ▸ supClosed_support M χ hχ₁ hχ₂
   | @disjMon Γ Δ φ ψ χ hΔ _ _ ihmaj ih =>
@@ -395,7 +387,7 @@ theorem soundness {Γ : Set (Formula Atom)} {φ : Formula Atom}
     have hχ := ih t₂ (fun γ hγ => by
       rcases hγ with rfl | hγ
       · exact hψ
-      · exact isLowerSet_support_of_isNEFree (hΔ γ hγ) M hsub₂
+      · exact isLowerSet_support_of_neFree (hΔ γ hγ) M hsub₂
           (hΓ γ (Set.mem_union_right _ hγ)))
     exact ⟨t₁, t₂, hsp, hφ, hχ⟩
   | @botE Γ p φ _ ih =>

--- a/Linglib/Logic/Modal/BSML/Properties.lean
+++ b/Linglib/Logic/Modal/BSML/Properties.lean
@@ -17,11 +17,11 @@ without global disjunction ⨼) plus the flatness corollary from Anttila
 * `supClosed_support` — every BSML formula has sup-closed support
   (Anttila 2.2.8 part 2; BSML's connective set has no ⨼, so the
   union-closure obstruction is absent).
-* `support_empty_of_isNEFree` — NE-free BSML formulas are supported on
+* `support_empty_of_neFree` — NE-free BSML formulas are supported on
   the empty team (Anttila 2.2.8 part 1).
-* `isLowerSet_support_of_isNEFree` — NE-free BSML formulas are
+* `isLowerSet_support_of_neFree` — NE-free BSML formulas are
   downward-closed (Anttila 2.2.8 part 1).
-* `isFlat_support_of_isNEFree` — NE-free BSML formulas are flat
+* `isFlat_support_of_neFree` — NE-free BSML formulas are flat
   (Anttila 2.2.16 / [aloni-2022] Fact 15), derived via Anttila
   Proposition 2.2.2 from the three properties above.
 
@@ -149,28 +149,22 @@ theorem supClosed_support (M : KripkeModel W Atom) (φ : Formula Atom) :
 /-- Joint empty-team property: NE-free formulas have BOTH support and
     anti-support on the empty team. Used as the engine for the bilateral
     mutual induction needed by the negation case. -/
-private theorem support_and_antiSupport_empty_of_isNEFree
-    (φ : Formula Atom) (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
+private theorem support_and_antiSupport_empty_of_neFree
+    (φ : Formula Atom) (hNE : φ.NEFree) (M : KripkeModel W Atom) :
     support M φ ∅ ∧ antiSupport M φ ∅ := by
   induction φ with
   | atom p =>
     refine ⟨?_, ?_⟩
     · intro w hw; exact absurd hw (by simp)
     · intro w hw; exact absurd hw (by simp)
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | neg ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [Formula.isNEFree] at hNE; exact hNE
-    have ⟨hs, ha⟩ := ih hψ
+    have ⟨hs, ha⟩ := ih hNE
     -- support (¬ψ) ∅ = antiSupport ψ ∅; antiSupport (¬ψ) ∅ = support ψ ∅
     exact ⟨ha, hs⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨hs₁, ha₁⟩ := ih₁ h₁
-    have ⟨hs₂, ha₂⟩ := ih₂ h₂
+    have ⟨hs₁, ha₁⟩ := ih₁ hNE.1
+    have ⟨hs₂, ha₂⟩ := ih₂ hNE.2
     refine ⟨⟨hs₁, hs₂⟩, ?_⟩
     -- antiSupport (φ₁ ∧ φ₂) ∅ = ∃ t₁ t₂ : Finset W, splitsAs ∅ t₁ t₂ ∧ antiSupport φ₁ t₁ ∧ antiSupport φ₂ t₂
     -- Take t₁ = ∅, t₂ = ∅
@@ -178,12 +172,8 @@ private theorem support_and_antiSupport_empty_of_isNEFree
     show ∅ ∪ ∅ = ∅
     simp
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨hs₁, ha₁⟩ := ih₁ h₁
-    have ⟨hs₂, ha₂⟩ := ih₂ h₂
+    have ⟨hs₁, ha₁⟩ := ih₁ hNE.1
+    have ⟨hs₂, ha₂⟩ := ih₂ hNE.2
     refine ⟨?_, ⟨ha₁, ha₂⟩⟩
     -- support (φ₁ ∨ φ₂) ∅ = ∃ t₁ t₂ : Finset W, splitsAs ∅ t₁ t₂ ∧ support φ₁ t₁ ∧ support φ₂ t₂
     refine ⟨∅, ∅, ?_, hs₁, hs₂⟩
@@ -196,17 +186,17 @@ private theorem support_and_antiSupport_empty_of_isNEFree
 
 /-- NE-free BSML formulas are supported on the empty team. The only
     obstruction is NE itself, which fails on ∅ by definition. -/
-theorem support_empty_of_isNEFree {φ : Formula Atom}
-    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) : support M φ ∅ :=
-  (support_and_antiSupport_empty_of_isNEFree φ hNE M).1
+theorem support_empty_of_neFree {φ : Formula Atom}
+    (hNE : φ.NEFree) (M : KripkeModel W Atom) : support M φ ∅ :=
+  (support_and_antiSupport_empty_of_neFree φ hNE M).1
 
 /-! ### Downward closure for NE-free formulas (Anttila 2.2.8 part 1) -/
 
 /-- Joint downward closure: NE-free formulas have BOTH support and
     anti-support downward-closed. The bilateral mutual induction handles
     the negation case (where support flips to antiSupport). -/
-private theorem support_and_antiSupport_downward_of_isNEFree
-    (φ : Formula Atom) (hNE : φ.isNEFree = true)
+private theorem support_and_antiSupport_downward_of_neFree
+    (φ : Formula Atom) (hNE : φ.NEFree)
     (M : KripkeModel W Atom) :
     (∀ s t : Finset W, t ⊆ s → support M φ s → support M φ t) ∧
     (∀ s t : Finset W, t ⊆ s → antiSupport M φ s → antiSupport M φ t) := by
@@ -215,20 +205,14 @@ private theorem support_and_antiSupport_downward_of_isNEFree
     refine ⟨?_, ?_⟩
     · intro s t hsub hsupp w hw; exact hsupp w (hsub hw)
     · intro s t hsub hsupp w hw; exact hsupp w (hsub hw)
-  | ne => simp [Formula.isNEFree] at hNE
+  | ne => exact hNE.elim
   | neg ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [Formula.isNEFree] at hNE; exact hNE
-    have ⟨ihs, iha⟩ := ih hψ
+    have ⟨ihs, iha⟩ := ih hNE
     -- support (¬ψ) = antiSupport ψ; antiSupport (¬ψ) = support ψ
     exact ⟨iha, ihs⟩
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ihs₁, iha₁⟩ := ih₁ h₁
-    have ⟨ihs₂, iha₂⟩ := ih₂ h₂
+    have ⟨ihs₁, iha₁⟩ := ih₁ hNE.1
+    have ⟨ihs₂, iha₂⟩ := ih₂ hNE.2
     refine ⟨?_, ?_⟩
     · -- support: conjunction of two supports survives ⊆
       intro s t hsub ⟨hs₁, hs₂⟩
@@ -246,12 +230,8 @@ private theorem support_and_antiSupport_downward_of_isNEFree
       · exact iha₁ t₁ (t₁ ∩ t) (Finset.inter_subset_left) ha₁
       · exact iha₂ t₂ (t₂ ∩ t) (Finset.inter_subset_left) ha₂
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
-    have h₁ : ψ₁.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.1
-    have h₂ : ψ₂.isNEFree = true := by
-      simp only [Formula.isNEFree, Bool.and_eq_true] at hNE; exact hNE.2
-    have ⟨ihs₁, iha₁⟩ := ih₁ h₁
-    have ⟨ihs₂, iha₂⟩ := ih₂ h₂
+    have ⟨ihs₁, iha₁⟩ := ih₁ hNE.1
+    have ⟨ihs₂, iha₂⟩ := ih₂ hNE.2
     refine ⟨?_, ?_⟩
     · -- support: split into (t₁, t₂); for t ⊆ s, intersect
       intro s t hsub ⟨t₁, t₂, hsplit, hs₁, hs₂⟩
@@ -267,10 +247,7 @@ private theorem support_and_antiSupport_downward_of_isNEFree
     · -- antiSupport: conjunction of two antiSupports survives ⊆
       intro s t hsub ⟨ha₁, ha₂⟩
       exact ⟨iha₁ s t hsub ha₁, iha₂ s t hsub ha₂⟩
-  | poss ψ ih =>
-    have hψ : ψ.isNEFree = true := by
-      simp [Formula.isNEFree] at hNE; exact hNE
-    have ⟨_, _⟩ := ih hψ  -- IHs not used directly; the modal cases hold from per-w structure
+  | poss ψ _ih =>
     refine ⟨?_, ?_⟩
     · -- support (◇ψ) s = ∀ w ∈ s, ∃ subteam ⊆ R[w], nonempty, support ψ subteam.
       -- For t ⊆ s, ∀ w ∈ t, w ∈ s, so the per-w property holds.
@@ -282,11 +259,11 @@ private theorem support_and_antiSupport_downward_of_isNEFree
 
 /-- NE-free BSML formulas are downward-closed: support survives under
     taking subsets of the team. -/
-theorem isLowerSet_support_of_isNEFree {φ : Formula Atom}
-    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
+theorem isLowerSet_support_of_neFree {φ : Formula Atom}
+    (hNE : φ.NEFree) (M : KripkeModel W Atom) :
     IsLowerSet { t : Finset W | support M φ t } :=
   fun _ _ hab hb =>
-    (support_and_antiSupport_downward_of_isNEFree φ hNE M).1 _ _ hab hb
+    (support_and_antiSupport_downward_of_neFree φ hNE M).1 _ _ hab hb
 
 /-! ### Convexity for all formulas (Anttila 2025, Proposition 3.3.1) -/
 
@@ -402,7 +379,7 @@ private theorem support_and_antiSupport_ordConnected
     `Set.OrdConnected`, i.e. `s ⊆ t ⊆ u` with `support M φ s` and
     `support M φ u` forces `support M φ t`.
 
-    Generalizes `isLowerSet_support_of_isNEFree`: for NE-free `φ` the empty-team
+    Generalizes `isLowerSet_support_of_neFree`: for NE-free `φ` the empty-team
     property holds, and `Team.isLowerSet_iff_ordConnected_of_empty`
     recovers downward closure from convexity. Together with `supClosed_support`,
     this is the convex-and-union-closed property for which BSML is expressively
@@ -424,13 +401,13 @@ theorem ordConnected_support (M : KripkeModel W Atom) (φ : Formula Atom) :
     the three closure properties proved above. The same conclusion has a
     direct classical-evaluation-bridge proof in `Bridge.lean` as
     `neFree_flat_eq`. -/
-theorem isFlat_support_of_isNEFree {φ : Formula Atom}
-    (hNE : φ.isNEFree = true) (M : KripkeModel W Atom) :
+theorem isFlat_support_of_neFree {φ : Formula Atom}
+    (hNE : φ.NEFree) (M : KripkeModel W Atom) :
     IsFlat { t : Finset W | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
-    (isLowerSet_support_of_isNEFree hNE M)
+    (isLowerSet_support_of_neFree hNE M)
     (supClosed_support M φ)
-    (support_empty_of_isNEFree hNE M)
+    (support_empty_of_neFree hNE M)
 
 /-! ### Soundness for the closure cell (Definability bridge) -/
 
@@ -465,9 +442,9 @@ open Team in
     exactly what moves a formula off the `flat` cell into the strictly larger
     convex, union-closed cell. -/
 theorem soundFor_flat_neFree (M : KripkeModel W Atom) :
-    definableClassWhere (support M) (fun φ => φ.isNEFree = true) ⊆ flatProperties := by
+    definableClassWhere (support M) Formula.NEFree ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)
-    fun _φ hφ => isFlat_support_of_isNEFree hφ M
+    fun _φ hφ => isFlat_support_of_neFree hφ M
 
 end BSML

--- a/Linglib/Studies/Aloni2022.lean
+++ b/Linglib/Studies/Aloni2022.lean
@@ -161,7 +161,7 @@ theorem aloni2022_fact4_NS_FC
     support deonticModel mayCoffee freeChoiceTeam ∧
     support deonticModel mayTea    freeChoiceTeam :=
   narrowScopeFC deonticModel (.atom .a) (.atom .b) freeChoiceTeam
-    rfl rfl h
+    trivial trivial h
 
 /-- The premise of Fact 4 holds on this model + team. -/
 theorem aloni2022_fact4_premise_supported :
@@ -178,7 +178,7 @@ theorem aloni2022_fact11_dual_prohibition
     support restrictiveModel notMayCoffee prohibitionTeam ∧
     support restrictiveModel notMayTea    prohibitionTeam :=
   dualProhibition restrictiveModel (.atom .a) (.atom .b) prohibitionTeam
-    rfl rfl h
+    trivial trivial h
 
 theorem aloni2022_fact11_premise_supported :
     support restrictiveModel (enrich prohibition) prohibitionTeam := by decide
@@ -197,7 +197,7 @@ theorem aloni2022_fact5_WS_FC
     support deonticModel mayCoffee freeChoiceTeam ∧
     support deonticModel mayTea    freeChoiceTeam :=
   wideScopeFC deonticModel (.atom .a) (.atom .b) freeChoiceTeam
-    rfl rfl deonticModel_indisputable_on_team h
+    trivial trivial deonticModel_indisputable_on_team h
 
 theorem aloni2022_fact5_premise_supported :
     support deonticModel (enrich wideScopeDisj) freeChoiceTeam := by decide
@@ -234,7 +234,7 @@ theorem aloni2022_fact12_double_negation
     support deonticModel mayCoffee freeChoiceTeam ∧
     support deonticModel mayTea    freeChoiceTeam :=
   doubleNegationFC deonticModel (.atom .a) (.atom .b) freeChoiceTeam
-    rfl rfl h
+    trivial trivial h
 
 theorem aloni2022_fact12_premise_supported :
     support deonticModel (enrich doubleNegMayHaveCoffeeOrTea) freeChoiceTeam := by
@@ -252,7 +252,7 @@ theorem aloni2022_fact3_modal_disjunction
     support stateBasedModel mayCoffee freeChoiceTeam ∧
     support stateBasedModel mayTea    freeChoiceTeam :=
   modalDisjunction stateBasedModel (.atom .a) (.atom .b) freeChoiceTeam
-    rfl rfl stateBasedModel_state_based_on_team h
+    trivial trivial stateBasedModel_state_based_on_team h
 
 theorem aloni2022_fact3_premise_supported :
     support stateBasedModel (enrich plainDisj) freeChoiceTeam := by decide

--- a/Linglib/Studies/Aloni2022/FreeChoice.lean
+++ b/Linglib/Studies/Aloni2022/FreeChoice.lean
@@ -36,21 +36,21 @@ variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
 /-! ### Downward closure of atom and NE primitives -/
 
--- `BSML.isFlat_support_of_isNEFree` (in `Properties.lean`) gives
+-- `BSML.isFlat_support_of_neFree` (in `Properties.lean`) gives
 -- true pointwise-iff flatness for all NE-free formulas via the substrate.
 -- The two per-primitive theorems below isolate the *downward closure*
 -- clause that splits atom from NE: atoms have it, NE doesn't, and the FC
 -- arguments below depend only on this restriction, not on full flatness.
 
 /-- Atoms are downward-closed. Per-primitive isolation of the atom case of
-    `BSML.isLowerSet_support_of_isNEFree`. -/
+    `BSML.isLowerSet_support_of_neFree`. -/
 theorem atom_downwardClosed (M : KripkeModel W Atom) (p : Atom) :
     ∀ t t' : Finset W, t' ⊆ t → support M (.atom p) t → support M (.atom p) t' :=
   fun _ _ hSub hSupp w hw => hSupp w (hSub hw)
 
 /-- NE is NOT downward-closed: an inhabited team supports NE but ∅ doesn't.
     This is the obstruction that prevents
-    `isFlat_support_of_isNEFree` from extending to NE-bearing formulas. -/
+    `isFlat_support_of_neFree` from extending to NE-bearing formulas. -/
 theorem ne_not_downwardClosed [Nonempty W] (M : KripkeModel W Atom) :
     ¬(∀ t t' : Finset W, t' ⊆ t → support M .ne t → support M .ne t') := by
   intro hDC
@@ -74,7 +74,7 @@ is a subset of R[w] (via the union), yielding ◇α and ◇β.
 -/
 theorem narrowScopeFC (M : KripkeModel W Atom)
     (α β : Formula Atom) (t : Finset W)
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (enrich (.poss (.disj α β))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
   have hPoss := h.1
@@ -108,7 +108,7 @@ so s_a ⊆ R[w], yielding ◇α at every world. Symmetrically for β.
 -/
 theorem wideScopeFC (M : KripkeModel W Atom)
     (α β : Formula Atom) (t : Finset W)
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (hInd : M.IsIndisputable t)
     (h : support M (enrich (.disj (.poss α) (.poss β))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
@@ -148,7 +148,7 @@ a non-empty subset of R[w], yielding ◇α and ◇β.
 -/
 theorem modalDisjunction (M : KripkeModel W Atom)
     (α β : Formula Atom) (t : Finset W)
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (hSB : M.IsStateBased t)
     (h : support M (enrich (.disj α β)) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
@@ -188,7 +188,7 @@ strips enrichment from the anti-supported disjuncts using Fact 1
 -/
 theorem dualProhibition (M : KripkeModel W Atom)
     (α β : Formula Atom) (t : Finset W)
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (enrich (.neg (.poss (.disj α β)))) t) :
     support M (.neg (.poss α)) t ∧
     support M (.neg (.poss β)) t := by
@@ -218,7 +218,7 @@ swap), and narrow-scope FC (Fact 4) applies.
 -/
 theorem doubleNegationFC (M : KripkeModel W Atom)
     (α β : Formula Atom) (t : Finset W)
-    (hα : α.isNEFree = true) (hβ : β.isNEFree = true)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (enrich (.neg (.neg (.poss (.disj α β))))) t) :
     support M (.poss α) t ∧ support M (.poss β) t := by
   have h_strip := antiSupport_strip_ne M


### PR DESCRIPTION
Register cleanse of `BSML/Defs.lean` plus the Bool→Prop migration it forces on the cluster.

- `Formula.isNEFree`/`isPositive`/`isClassicalPositive : Bool` become `Formula.NEFree`/`Positive`/`ClassicalPositive : Prop` with structural `Decidable` instances; consumer proofs collapse definitionally (`simp only [..., Bool.and_eq_true]` dances → `.1`/`.2`, refutation simps → `.elim`, `rfl` side conditions → `trivial`). Consumer-less `isAtom` and its lemma deleted; `_of_isNEFree` theorem names become `_of_neFree`.
- Module docstring rewritten in mathlib register (citations woven, duality table kept under Implementation notes); `-- ==== §N ====` banners → `/-! ### -/` sections; frame-condition `Decidable` instances golfed to `inferInstanceAs`.
- QBSML's parallel Bool predicates on its own `Formula` are untouched (sibling arc).
