### PR TITLE
refactor(Logic/Modal): Basic cleanse — dissolve Logic struct, derive from box

### DIFF
--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -25,9 +25,9 @@ lattice of normal modal logics as axiom sets over K.
   square, satisfying all six relations under seriality.
 * `PropOp`, `IsIndicial`, `s5Nec`, `poss`/`nec` — the Gallin hierarchy:
   arbitrary operators ⊋ Kripke-definable (`∃ R, N = box R`) ⊋ S5.
-* `Logic.frameConditions` — frame conditions for a normal modal logic,
-  identified with its axiom set over K and ordered by the `Finset`
-  lattice (named logics `Logic.K` … `Logic.KD45`).
+* `ModalLogic.frameConditions` — frame conditions for a normal modal
+  logic, identified with its axiom set over K and ordered by the
+  `Finset` lattice (named logics `ModalLogic.K` … `ModalLogic.KD45`).
 
 ## Connection to Kratzer semantics
 
@@ -357,11 +357,17 @@ instance diamond_decidable {W : Type*} [Fintype W]
     Decidable (diamond R p w) :=
   inferInstanceAs (Decidable (∃ v, R w v ∧ p v))
 
+end Modal
+
 /-! ### The lattice of normal modal logics
 
 A normal modal logic is identified with its set of axiom schemas over K;
 the `Finset` lattice (`⊆`, `∪`, `∩`, `⊥ = ∅ = K`) is the lattice of
 normal logics. -/
+
+namespace ModalLogic
+
+open Modal (AccessRel IsSerial IsEuclidean)
 
 /-- Axiom schemas addable to the base logic K. -/
 inductive Axiom where
@@ -380,7 +386,6 @@ inductive Axiom where
 instance : ToString Axiom where
   toString | .M => "M" | .D => "D" | .B => "B" | .four => "4" | .five => "5"
 
-namespace Logic
 
 /-- The base logic `K`: no additional axioms. -/
 def K : Finset Axiom := ∅
@@ -427,7 +432,7 @@ def frameConditions {W : Type*} (L : Finset Axiom) (R : AccessRel W) : Prop :=
   (.four ∈ L → IsTrans W R) ∧
   (.five ∈ L → IsEuclidean R)
 
-/-- The syntactic-semantic bridge for `S5`: `frameConditions Logic.S5 R`
+/-- The syntactic-semantic bridge for `S5`: `frameConditions ModalLogic.S5 R`
     iff `R` is an S5 frame. -/
 @[simp] theorem frameConditions_S5_iff {W : Type*} (R : AccessRel W) :
     frameConditions S5 R ↔ Std.Refl R ∧ IsEuclidean R := by
@@ -443,6 +448,4 @@ def frameConditions {W : Type*} (L : Finset Axiom) (R : AccessRel W) : Prop :=
     frameConditions KTB R ↔ Std.Refl R ∧ Std.Symm R := by
   simp [frameConditions, KTB]
 
-end Logic
-
-end Modal
+end ModalLogic

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -3,58 +3,55 @@ import Linglib.Logic.Aristotelian.Square
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.Lattice
-import Mathlib.Order.BoundedOrder.Basic
 
 /-!
-# Modal logic: axioms, the lattice of normal logics, and the modal square
+# Modal logic over accessibility relations
 
-[dowty-wall-peters-1981] [kratzer-1981] [kripke-1963]
+Axiom correspondence, normality, and the operator hierarchy for the
+relational `box`/`diamond` of `Defs.lean` ([kripke-1963]): which frame
+conditions validate the T, D, 4, B, and 5 schemas; monotonicity and
+distribution; restriction — [kratzer-1981]'s insight that conversational
+backgrounds strengthen necessity by shrinking accessibility; the modal
+square of opposition ([carnielli-pizzi-2008]); [gallin-1975]'s hierarchy
+of propositional operators, placing Montague's S5 `box`/`diamond`
+([dowty-wall-peters-1981]) as the universal-accessibility case; and the
+lattice of normal modal logics as axiom sets over K.
 
-Builds on the polymorphic Kripke foundation in `Defs.lean`. This file adds:
+## Main declarations
 
-1. **Modal axiom correspondence** (T, D, 4, B, 5): which frame conditions on
-   `R` validate which modal axioms when interpreted via `box`/`diamond`.
-   The K axiom holds for any `R`.
-
-2. **Monotonicity, distribution, restriction**: standard properties of
-   normal modal operators. Restriction (`box_restrict`) is Kratzer's
-   insight that conversational backgrounds *strengthen* necessity.
-
-3. **Decidable instances**: `box R p w`, `diamond R p w` are decidable
-   over finite worlds with decidable accessibility and propositions.
-
-4. **Logic lattice**: `Axiom`, `Logic`, named logics (K, T, D, S4, S5, KD45),
-   lattice instances, `frameConditions` predicate.
-
-5. **Gallin hierarchy** ([gallin-1975]): `PropOp` (general propositional
-   operators), `indicialNec`/`indicialPoss` (Kripke-type), `s5Nec`/`s5Poss`
-   (universal-accessibility = classical IL S5). The architectural anchor
-   showing that classical IL S5 = the universal-accessibility special case
-   of the polymorphic theory, and that non-Kripke operators (tense,
-   progressive) live outside `IsIndicial`.
-
-6. **Modal square of opposition** (`modalSquare`, [carnielli-pizzi-2008]):
-   under seriality the `box`/`diamond` corners satisfy all six Aristotelian
-   relations — `subalternAI` is the D axiom, `contradEI` the box–diamond duality.
+* `box_K` … `box_five` — per-axiom frame correspondences; `box_not_moore`
+  is the Moore-sentence reductio for any KD4 modality ([hintikka-1962]).
+* `modalSquare`, `modalSquare_relations` — the `□`/`◇` Aristotelian
+  square, satisfying all six relations under seriality.
+* `PropOp`, `IsIndicial`, `s5Nec`, `poss`/`nec` — the Gallin hierarchy:
+  arbitrary operators ⊋ Kripke-definable (`∃ R, N = box R`) ⊋ S5.
+* `Logic.frameConditions` — frame conditions for a normal modal logic,
+  identified with its axiom set over K and ordered by the `Finset`
+  lattice (named logics `Logic.K` … `Logic.KD45`).
 
 ## Connection to Kratzer semantics
 
-Kratzer's conversational backgrounds derive accessibility from a modal base:
-`R_f(w, w') ≡ w' ∈ ⋂f(w)`. The ordering source further restricts to "best"
-worlds. In IL terms:
-
-- Simple Kratzer necessity = `box R_f` (no ordering source)
-- Full Kratzer necessity = `box R_{f,g}` where `R_{f,g}` restricts to best worlds
-- S5 necessity = `box universalR`
+Kratzer's conversational backgrounds derive accessibility from a modal
+base: `R_f(w, w') ≡ w' ∈ ⋂f(w)`, with the ordering source further
+restricting to best worlds. Simple Kratzer necessity is `box R_f`, full
+Kratzer necessity is `box` of the best-world restriction, and S5
+necessity is `box universalR` — see `box_restrict` for why restriction
+strengthens.
 -/
 
 namespace Modal
 
 variable {W : Type*}
 
--- ════════════════════════════════════════════════════════════════════════
--- § 1. Modal Axiom Correspondence
--- ════════════════════════════════════════════════════════════════════════
+/-! ### Axiom correspondence -/
+
+/-- `box R p w` unfolds to `∀ v, R w v → p v`. -/
+theorem box_eq_forall (R : AccessRel W) (p : W → Prop) (w : W) :
+    box R p w = (∀ v, R w v → p v) := rfl
+
+/-- `diamond R p w` unfolds to `∃ v, R w v ∧ p v`. -/
+theorem diamond_eq_exists (R : AccessRel W) (p : W → Prop) (w : W) :
+    diamond R p w = (∃ v, R w v ∧ p v) := rfl
 
 /-- **K axiom**: `□_R(p → q) → (□_R p → □_R q)`.
     Holds for any accessibility relation. -/
@@ -96,8 +93,8 @@ theorem box_five (R : AccessRel W) [hE : IsEuclidean R] (p : W → Prop) (w : W)
 
 /-- **Moore reductio for KD4**: no world satisfies `□_R (p ∧ ¬□_R p)` when
     `R` is serial and transitive. The content `p ∧ ¬□_R p` is itself
-    satisfiable; what fails is *boxing* it. Specialise to belief
-    ([hintikka-1962]), knowledge, or any other KD4 modality. -/
+    satisfiable; what fails is *boxing* it. Specialise to belief,
+    knowledge, or any other KD4 modality. -/
 theorem box_not_moore (R : AccessRel W) [hS : IsSerial R] [IsTrans W R]
     (p : W → Prop) (w : W) :
     ¬ box R (fun v => p v ∧ ¬ box R p v) w := by
@@ -109,10 +106,10 @@ theorem box_not_moore (R : AccessRel W) [hS : IsSerial R] [IsTrans W R]
 
 /-! ### Modal square of opposition
 
-[carnielli-pizzi-2008]. The `□`/`◇` pair forms an Aristotelian square
-(`A = □p`, `E = □¬p`, `I = ◇p`, `O = ¬□p`). Under seriality — the modal D axiom
-(`box_D`) — it satisfies all six relations of the square of opposition, so every
-serial modality (epistemic, deontic, temporal, doxastic) inherits the square. -/
+The `□`/`◇` pair forms an Aristotelian square (`A = □p`, `E = □¬p`,
+`I = ◇p`, `O = ¬□p`). Under seriality — the D axiom (`box_D`) — it
+satisfies all six relations of the square of opposition, so every serial
+modality (epistemic, deontic, temporal, doxastic) inherits the square. -/
 
 /-- Under seriality, `□p` and `□¬p` are incompatible: no world satisfies both. -/
 theorem box_disjoint_compl (R : AccessRel W) [hS : IsSerial R] (p : W → Prop) :
@@ -136,8 +133,8 @@ theorem diamond_eq_compl_box_compl (R : AccessRel W) (p : W → Prop) :
     by_contra hne
     exact h (fun v hv hpv => hne ⟨v, hv, hpv⟩)
 
-/-- The **modal square of opposition** over an accessibility relation `R`
-([carnielli-pizzi-2008]): `A = □p`, `E = □¬p`, `I = ◇p`, `O = ¬□p`. -/
+/-- The **modal square of opposition** over an accessibility relation `R`:
+    `A = □p`, `E = □¬p`, `I = ◇p`, `O = ¬□p`. -/
 def modalSquare (R : AccessRel W) (p : W → Prop) : Aristotelian.Square (W → Prop) where
   A := box R p
   E := box R pᶜ
@@ -162,9 +159,7 @@ theorem modalSquare_relations (R : AccessRel W) [IsSerial R] (p : W → Prop) :
     rw [diamond_eq_compl_box_compl, codisjoint_iff, ← compl_inf,
         disjoint_iff.mp (box_disjoint_compl R p).symm, compl_bot]
 
--- ════════════════════════════════════════════════════════════════════════
--- § 2. Monotonicity
--- ════════════════════════════════════════════════════════════════════════
+/-! ### Monotonicity and distribution -/
 
 /-- `box R` is monotone: if `p ≤ q` pointwise, then `□_R p ≤ □_R q`. -/
 theorem box_mono (R : AccessRel W) {p q : W → Prop}
@@ -178,34 +173,25 @@ theorem diamond_mono (R : AccessRel W) {p q : W → Prop}
     (hd : diamond R p w) : diamond R q w :=
   let ⟨v, hwv, hpv⟩ := hd; ⟨v, hwv, h v hpv⟩
 
--- ════════════════════════════════════════════════════════════════════════
--- § 3. Distribution over Connectives
--- ════════════════════════════════════════════════════════════════════════
-
 /-- `□_R` distributes over `∧`. -/
 theorem box_conj (R : AccessRel W) (p q : W → Prop) (w : W) :
-    box R (fun v => p v ∧ q v) w =
-    (box R p w ∧ box R q w) := by
-  exact propext ⟨fun h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩,
-                  fun ⟨hp, hq⟩ v hwv => ⟨hp v hwv, hq v hwv⟩⟩
+    box R (fun v => p v ∧ q v) w ↔ box R p w ∧ box R q w :=
+  ⟨fun h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩,
+   fun ⟨hp, hq⟩ v hwv => ⟨hp v hwv, hq v hwv⟩⟩
 
 /-- `◇_R` distributes over `∨`. -/
 theorem diamond_disj (R : AccessRel W) (p q : W → Prop) (w : W) :
-    diamond R (fun v => p v ∨ q v) w =
-    (diamond R p w ∨ diamond R q w) := by
-  exact propext ⟨
-    fun ⟨v, hwv, h⟩ => h.elim (fun hp => .inl ⟨v, hwv, hp⟩) (fun hq => .inr ⟨v, hwv, hq⟩),
-    fun h => h.elim (fun ⟨v, hwv, hp⟩ => ⟨v, hwv, .inl hp⟩)
-                     (fun ⟨v, hwv, hq⟩ => ⟨v, hwv, .inr hq⟩)⟩
+    diamond R (fun v => p v ∨ q v) w ↔ diamond R p w ∨ diamond R q w :=
+  ⟨fun ⟨v, hwv, h⟩ => h.elim (fun hp => .inl ⟨v, hwv, hp⟩) (fun hq => .inr ⟨v, hwv, hq⟩),
+   fun h => h.elim (fun ⟨v, hwv, hp⟩ => ⟨v, hwv, .inl hp⟩)
+                   (fun ⟨v, hwv, hq⟩ => ⟨v, hwv, .inr hq⟩)⟩
 
 /-- Necessitation: if `p` holds at every world, then `□_R p` holds everywhere. -/
 theorem box_necessitation (R : AccessRel W) (p : W → Prop)
     (h : ∀ v, p v) (w : W) : box R p w :=
   fun v _ => h v
 
--- ════════════════════════════════════════════════════════════════════════
--- § 4. Accessibility Restriction (Kratzer's Insight)
--- ════════════════════════════════════════════════════════════════════════
+/-! ### Accessibility restriction -/
 
 /-- Restricting accessibility strengthens necessity:
     if `R₂ ⊆ R₁`, then `□_{R₁} p → □_{R₂} p`. -/
@@ -214,13 +200,6 @@ theorem box_restrict {R₁ R₂ : AccessRel W}
     (hb : box R₁ p w) : box R₂ p w :=
   fun v hwv => hb v (h w v hwv)
 
-/-- **Conversion** (Prior's tense axiom `A ⊃ G P A` / `A ⊃ H F A`): for `R` and its converse
-    `flip R`, `p w → □_{flip R} ◇_R p w`. The correspondence fact that two modalities over a
-    relation and its converse are temporally adjoint (holds for *any* `R`). -/
-theorem self_imp_box_flip_diamond (R : AccessRel W) (p : W → Prop) (w : W)
-    (h : p w) : box (flip R) (diamond R p) w :=
-  fun _ hv => ⟨w, hv, h⟩
-
 /-- Restricting accessibility weakens possibility:
     if `R₂ ⊆ R₁`, then `◇_{R₂} p → ◇_{R₁} p`. -/
 theorem diamond_restrict {R₁ R₂ : AccessRel W}
@@ -228,9 +207,14 @@ theorem diamond_restrict {R₁ R₂ : AccessRel W}
     (hd : diamond R₂ p w) : diamond R₁ p w :=
   let ⟨v, hwv, hpv⟩ := hd; ⟨v, h w v hwv, hpv⟩
 
--- ════════════════════════════════════════════════════════════════════════
--- § 5. S5 Recovery
--- ════════════════════════════════════════════════════════════════════════
+/-- **Conversion** (Prior's tense axiom `A ⊃ G P A` / `A ⊃ H F A`): for `R` and its converse
+    `flip R`, `p w → □_{flip R} ◇_R p w`. The correspondence fact that two modalities over a
+    relation and its converse are temporally adjoint (holds for *any* `R`). -/
+theorem self_imp_box_flip_diamond (R : AccessRel W) (p : W → Prop) (w : W)
+    (h : p w) : box (flip R) (diamond R p) w :=
+  fun _ hv => ⟨w, hv, h⟩
+
+/-! ### S5 and KD45 frames -/
 
 /-- With reflexive + euclidean accessibility (= S5 frame conditions),
     `box` validates all of T, D, 4, B, 5. -/
@@ -249,100 +233,37 @@ theorem KD45_frame_all_axioms (R : AccessRel W) [IsKD45Frame R] :
     (∀ p w, diamond R p w → box R (diamond R p) w) := -- 5
   ⟨box_D R, box_four R, box_five R⟩
 
-/-- `box R p i` is the infimum of `p v` over worlds `v` accessible from `w`. -/
-theorem box_eq_forall (R : AccessRel W) (p : W → Prop) (w : W) :
-    box R p w = (∀ v, R w v → p v) := rfl
+/-! ### The Gallin hierarchy
 
-/-- `diamond R p w` is the supremum of `p v` over worlds `v` accessible from `w`. -/
-theorem diamond_eq_exists (R : AccessRel W) (p : W → Prop) (w : W) :
-    diamond R p w = (∃ v, R w v ∧ p v) := rfl
-
--- ════════════════════════════════════════════════════════════════════════
--- § 6. Gallin's Hierarchy of Propositional Operators
--- ════════════════════════════════════════════════════════════════════════
-
-/-! ## The Gallin hierarchy ([gallin-1975])
-
-In IL/ML_p, propositional operators form a three-level hierarchy:
-
-1. **General** (`PropOp`): Any `(W → Prop) → W → Prop` — arbitrary
-   properties of propositions, varying by world.
-
-2. **Indicial** (= Kripke-type): Operators definable via an accessibility
-   relation `R`. The necessity variant is `∀ v, R w v → p v` (= `box`);
-   the possibility variant is `∃ v, R w v ∧ p v` (= `diamond`).
-
-3. **S5**: The indicial case with `R = universalR` — IL's `box`/`diamond`.
-
-```
-All PropOps  ⊋  Indicial (Kripke)  ⊋  S5 (IL's □)
-```
-
-**Why this is here even with no current downstream consumer.** These
-theorems are the *architectural anchor* for the design choice that
-restricted modality lives in `Semantics/Intensional/`: they prove that
-classical IL S5 is exactly the universal-accessibility special case of
-the polymorphic theory, and that every `box R` is a normal modal
-operator (monotone, distribConj). Non-indicial PropOps (e.g., tense,
-present progressive) are the formal extension point for tense /
-non-Kripke modal operators that *cannot* be expressed as `box R` for
-any `R`. Removing this section would erase the formal record of why
-the directory layout is what it is.
--/
-
--- ────────────────────────────────────────────────────────────────
--- §6.1 General Propositional Operators
--- ────────────────────────────────────────────────────────────────
+Propositional operators form a three-level hierarchy: **general**
+(`PropOp` — arbitrary properties of propositions, varying by world),
+**indicial** (Kripke-definable: `N = box R` for some accessibility `R`),
+and **S5** (the indicial case with `R = universalR`). Non-indicial
+operators (tense, present progressive) live outside `IsIndicial`;
+`Logic/Temporal/Basic.lean` consumes this boundary. -/
 
 /-- A propositional operator: any function from propositions to propositions,
-    parametrized by world. This is Gallin's most general level —
-    an arbitrary property of propositions varying by index.
+    parametrized by world — Gallin's most general level.
 
     Examples: necessity (`box R`), possibility (`diamond R`),
     past tense (`∃ v, v < w ∧ p v`), present progressive, habituals. -/
 abbrev PropOp (W : Type*) := (W → Prop) → W → Prop
 
 /-- A propositional operator `N` is **monotone** if `p ≤ q` pointwise implies
-    `N p ≤ N q` pointwise. Every K-operator (= normal modal operator) is
-    monotone. -/
+    `N p ≤ N q` pointwise. Every normal (K-)operator is monotone. -/
 def PropOp.Monotone {W : Type*} (N : PropOp W) : Prop :=
-  ∀ {p q : W → Prop}, (∀ v, p v → q v) → ∀ w, N p w → N q w
+  ∀ ⦃p q : W → Prop⦄, (∀ v, p v → q v) → ∀ w, N p w → N q w
 
 /-- A propositional operator distributes over conjunction (one direction of
-    the K axiom: □(p ∧ q) → □p ∧ □q). -/
+    the K axiom: `□(p ∧ q) → □p ∧ □q`). -/
 def PropOp.DistribConj {W : Type*} (N : PropOp W) : Prop :=
   ∀ (p q : W → Prop) (w : W), N (fun v => p v ∧ q v) w → N p w ∧ N q w
 
--- ────────────────────────────────────────────────────────────────
--- §6.2 Indicial (Kripke-type) Operators
--- ────────────────────────────────────────────────────────────────
-
-/-- An indicial necessity operator: the restriction of `PropOp` to
-    operators definable via an accessibility relation.
-    `indicialNec R p w ↔ ∀ v, R w v → p v`.
-
-    This is `box` viewed as a member of the Gallin hierarchy. -/
-def indicialNec {W : Type*} (R : AccessRel W) : PropOp W :=
-  fun p w => ∀ v, R w v → p v
-
-/-- An indicial possibility operator (dual).
-    `indicialPoss R p w ↔ ∃ v, R w v ∧ p v`. -/
-def indicialPoss {W : Type*} (R : AccessRel W) : PropOp W :=
-  fun p w => ∃ v, R w v ∧ p v
-
-/-- `box` IS `indicialNec` — definitional equality. -/
-theorem box_eq_indicialNec (R : AccessRel W) :
-    box R = indicialNec R := rfl
-
-/-- `diamond` IS `indicialPoss` — definitional equality. -/
-theorem diamond_eq_indicialPoss (R : AccessRel W) :
-    diamond R = indicialPoss R := rfl
-
-/-- A propositional operator is **indicial** if there exists an accessibility
-    relation `R` such that `N = indicialNec R`. The non-indicial case is
+/-- A propositional operator is **indicial** (Kripke-definable) if it is
+    `box R` for some accessibility relation `R`. The non-indicial case is
     where tense and other non-Kripke operators live. -/
 def IsIndicial {W : Type*} (N : PropOp W) : Prop :=
-  ∃ R : AccessRel W, N = indicialNec R
+  ∃ R : AccessRel W, N = box R
 
 /-- Every `box R` is indicial. -/
 theorem box_isIndicial (R : AccessRel W) : IsIndicial (box R) :=
@@ -350,18 +271,12 @@ theorem box_isIndicial (R : AccessRel W) : IsIndicial (box R) :=
 
 /-- Every indicial operator is monotone (every Kripke operator is a
     K-operator). -/
-theorem indicial_monotone (R : AccessRel W) :
-    PropOp.Monotone (indicialNec R) :=
-  fun h _ hn v hwv => h v (hn v hwv)
+theorem monotone_box (R : AccessRel W) : PropOp.Monotone (box R) :=
+  fun _ _ h w hb => box_mono R h w hb
 
 /-- Every indicial operator distributes over conjunction. -/
-theorem indicial_distribConj (R : AccessRel W) :
-    PropOp.DistribConj (indicialNec R) :=
-  fun _ _ _ hn => ⟨fun v hwv => (hn v hwv).1, fun v hwv => (hn v hwv).2⟩
-
--- ────────────────────────────────────────────────────────────────
--- §6.3 S5 as the Universal Indicial Operator
--- ────────────────────────────────────────────────────────────────
+theorem distribConj_box (R : AccessRel W) : PropOp.DistribConj (box R) :=
+  fun p q w h => (box_conj R p q w).mp h
 
 /-- S5 necessity as a `PropOp`: `p` holds at all worlds. -/
 def s5Nec {W : Type*} : PropOp W :=
@@ -371,7 +286,30 @@ def s5Nec {W : Type*} : PropOp W :=
 def s5Poss {W : Type*} : PropOp W :=
   fun p _ => ∃ w, p w
 
-/-! #### Flat S5 operators (world-collapsed)
+/-- **S5 = box over universal accessibility**: the S5 necessity operator is
+    the indicial operator with universal accessibility — S5 sits at the top
+    of the indicial hierarchy. -/
+theorem s5Nec_eq_box_universalR :
+    s5Nec (W := W) = box universalR := by
+  ext p w
+  simp only [s5Nec, box, universalR, forall_true_left]
+
+/-- S5 necessity is indicial. -/
+theorem s5Nec_isIndicial : IsIndicial (s5Nec (W := W)) :=
+  ⟨universalR, s5Nec_eq_box_universalR⟩
+
+/-- S5 necessity is the weakest indicial operator: for any `R`,
+    `s5Nec p w → box R p w`. Fewer accessible worlds means a stronger
+    necessity — Kratzer restriction at the `PropOp` level (`box_restrict`). -/
+theorem s5Nec_weakest (R : AccessRel W) (p : W → Prop) (w : W)
+    (h : s5Nec p w) : box R p w :=
+  fun v _ => h v
+
+/-- Empty accessibility gives the strongest (vacuously true) necessity. -/
+theorem box_emptyR (p : W → Prop) (w : W) : box (emptyR (W := W)) p w :=
+  fun _ hv => hv.elim
+
+/-! ### Flat S5 operators
 
 `poss`/`nec` are the genuinely flat existential/universal modals (`∃ w` / `∀ w`),
 the world-collapsed projection of `s5Poss`/`s5Nec`, whose evaluation world is
@@ -405,164 +343,105 @@ theorem poss_mono {p q : W → Prop} (h : ∀ w, p w → q w) : poss p → poss 
 theorem nec_mono {p q : W → Prop} (h : ∀ w, p w → q w) : nec p → nec q :=
   fun hn w => h w (hn w)
 
-/-- **S5 = indicialNec universalR**: the S5 necessity operator is
-    the indicial operator with universal accessibility.
-    The formal statement that S5 sits at the top of the indicial hierarchy. -/
-theorem s5Nec_eq_indicialNec_universalR :
-    s5Nec (W := W) = indicialNec universalR := by
-  ext p w
-  simp only [s5Nec, indicialNec, universalR, forall_true_left]
-
-/-- S5 necessity is indicial. -/
-theorem s5Nec_isIndicial : IsIndicial (s5Nec (W := W)) :=
-  ⟨universalR, s5Nec_eq_indicialNec_universalR⟩
-
-/-- **Restriction order on indicial operators**: if `R₂ ⊆ R₁` then
-    `indicialNec R₁` is weaker than `indicialNec R₂` —
-    fewer accessible worlds means a stronger necessity.
-
-    S5 (R = universal) is the weakest; empty R is the strongest (vacuously true).
-    This is Kratzer's insight that conversational backgrounds *restrict*
-    the modal base, formalized at the PropOp level. -/
-theorem indicialNec_weaker_of_sub {R₁ R₂ : AccessRel W}
-    (h : ∀ w v, R₂ w v → R₁ w v) :
-    ∀ (p : W → Prop) (w : W), indicialNec R₁ p w → indicialNec R₂ p w :=
-  fun _ w hn v hwv => hn v (h w v hwv)
-
-/-- S5 necessity is the weakest indicial operator: for any R,
-    `s5Nec p w → indicialNec R p w`. -/
-theorem s5Nec_weakest (R : AccessRel W) (p : W → Prop) (w : W)
-    (h : s5Nec p w) : indicialNec R p w :=
-  fun v _ => h v
-
-/-- Empty accessibility gives the strongest (vacuously true) indicial operator. -/
-theorem indicialNec_emptyR (p : W → Prop) (w : W) :
-    indicialNec (emptyR (W := W)) p w := by
-  intro v hv; exact absurd hv (by simp [emptyR])
-
 /-! ### Decidability over finite worlds -/
 
-/-- `box R p w` is decidable when worlds enumerate, accessibility is decidable,
-    and the proposition is decidable. -/
 instance box_decidable {W : Type*} [Fintype W]
     (R : AccessRel W) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (box R p w) :=
-  decidable_of_iff (∀ v ∈ (Finset.univ : Finset W), R w v → p v)
-    ⟨fun h v hwv => h v (Finset.mem_univ v) hwv,
-     fun h v _ hwv => h v hwv⟩
+  inferInstanceAs (Decidable (∀ v, R w v → p v))
 
-/-- `diamond R p w` is decidable under the same conditions as `box`. -/
 instance diamond_decidable {W : Type*} [Fintype W]
     (R : AccessRel W) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (diamond R p w) :=
-  decidable_of_iff (∃ v ∈ (Finset.univ : Finset W), R w v ∧ p v)
-    ⟨fun ⟨v, _, hwv, hpv⟩ => ⟨v, hwv, hpv⟩,
-     fun ⟨v, hwv, hpv⟩ => ⟨v, Finset.mem_univ v, hwv, hpv⟩⟩
+  inferInstanceAs (Decidable (∃ v, R w v ∧ p v))
 
--- ════════════════════════════════════════════════════════════════════════
--- § 8. Lattice of Normal Modal Logics
--- ════════════════════════════════════════════════════════════════════════
+/-! ### The lattice of normal modal logics
 
-/-- Axiom schemas addable to K. -/
+A normal modal logic is identified with its set of axiom schemas over K;
+the `Finset` lattice (`⊆`, `∪`, `∩`, `⊥ = ∅ = K`) is the lattice of
+normal logics. -/
+
+/-- Axiom schemas addable to the base logic K. -/
 inductive Axiom where
-  | M     -- □p → p (T)
-  | D     -- □p → ◇p
-  | B     -- p → □◇p
-  | four  -- □p → □□p
-  | five  -- ◇p → □◇p
-  deriving DecidableEq, Repr, Inhabited, Hashable
+  /-- `□p → p` (T; von Wright's M). -/
+  | M
+  /-- `□p → ◇p`. -/
+  | D
+  /-- `p → □◇p`. -/
+  | B
+  /-- `□p → □□p`. -/
+  | four
+  /-- `◇p → □◇p`. -/
+  | five
+  deriving DecidableEq, Repr, Inhabited
 
 instance : ToString Axiom where
   toString | .M => "M" | .D => "D" | .B => "B" | .four => "4" | .five => "5"
 
-/-- A normal modal logic is K plus axiom schemas. -/
-structure Logic where
-  axioms : Finset Axiom
-  deriving DecidableEq
-
 namespace Logic
 
-def K : Logic := ⟨∅⟩
-def T : Logic := ⟨{.M}⟩
-def D : Logic := ⟨{.D}⟩
-def KB : Logic := ⟨{.B}⟩
-def K4 : Logic := ⟨{.four}⟩
-def K5 : Logic := ⟨{.five}⟩
-def S4 : Logic := ⟨{.M, .four}⟩
-def S5 : Logic := ⟨{.M, .five}⟩
-def KTB : Logic := ⟨{.M, .B}⟩
-def KD45 : Logic := ⟨{.D, .four, .five}⟩
-def K45 : Logic := ⟨{.four, .five}⟩
+/-- The base logic `K`: no additional axioms. -/
+def K : Finset Axiom := ∅
 
-/-- L₁ ≤ L₂ means L₁ is weaker (fewer axioms). -/
-instance : LE Logic := ⟨λ L₁ L₂ => L₁.axioms ⊆ L₂.axioms⟩
+/-- `T = K + M`. -/
+def T : Finset Axiom := {.M}
 
-instance : PartialOrder Logic where
-  le_refl := λ _ => Finset.Subset.refl _
-  le_trans := λ _ _ _ h₁ h₂ => Finset.Subset.trans h₁ h₂
-  le_antisymm := λ _ _ h₁ h₂ => by
-    cases_type* Logic
-    simp only [Logic.mk.injEq]
-    exact Finset.Subset.antisymm h₁ h₂
+/-- `D = K + D`. -/
+def D : Finset Axiom := {.D}
 
-instance : Lattice Logic where
-  sup := λ L₁ L₂ => ⟨L₁.axioms ∪ L₂.axioms⟩
-  inf := λ L₁ L₂ => ⟨L₁.axioms ∩ L₂.axioms⟩
-  le_sup_left := λ _ _ => Finset.subset_union_left
-  le_sup_right := λ _ _ => Finset.subset_union_right
-  sup_le := λ _ _ _ h₁ h₂ => Finset.union_subset h₁ h₂
-  inf_le_left := λ _ _ => Finset.inter_subset_left
-  inf_le_right := λ _ _ => Finset.inter_subset_right
-  le_inf := λ _ _ _ h₁ h₂ => Finset.subset_inter h₁ h₂
+/-- `KB = K + B`. -/
+def KB : Finset Axiom := {.B}
 
-def top : Logic := ⟨{.M, .D, .B, .four, .five}⟩
+/-- `K4 = K + 4`. -/
+def K4 : Finset Axiom := {.four}
 
-instance : OrderBot Logic where
-  bot := K
-  bot_le := λ _ => Finset.empty_subset _
+/-- `K5 = K + 5`. -/
+def K5 : Finset Axiom := {.five}
 
-instance : OrderTop Logic where
-  top := top
-  le_top := λ L => by
-    simp only [top, LE.le]
-    intro a _
-    cases a <;> decide
+/-- `S4 = K + M + 4`. -/
+def S4 : Finset Axiom := {.M, .four}
 
-instance : BoundedOrder Logic := BoundedOrder.mk
+/-- `S5 = K + M + 5`. -/
+def S5 : Finset Axiom := {.M, .five}
 
+/-- `KTB = K + M + B`. -/
+def KTB : Finset Axiom := {.M, .B}
+
+/-- `KD45 = K + D + 4 + 5` (the doxastic logic). -/
+def KD45 : Finset Axiom := {.D, .four, .five}
+
+/-- `K45 = K + 4 + 5`. -/
+def K45 : Finset Axiom := {.four, .five}
+
+/-- `K` is the bottom of the lattice of normal logics. -/
 theorem K_bot : K = ⊥ := rfl
-theorem top_all_axioms : top = ⊤ := rfl
 
-def hasAxiom (L : Logic) (a : Axiom) : Bool := a ∈ L.axioms
-
-/-- Frame conditions required by a logic. -/
-def frameConditions {W : Type*} (L : Logic) (R : AccessRel W) : Prop :=
-  (L.hasAxiom .M → Std.Refl R) ∧
-  (L.hasAxiom .D → IsSerial R) ∧
-  (L.hasAxiom .B → Std.Symm R) ∧
-  (L.hasAxiom .four → IsTrans W R) ∧
-  (L.hasAxiom .five → IsEuclidean R)
+/-- Frame conditions required by a logic: for each axiom schema present,
+    the corresponding condition on `R`. -/
+def frameConditions {W : Type*} (L : Finset Axiom) (R : AccessRel W) : Prop :=
+  (.M ∈ L → Std.Refl R) ∧
+  (.D ∈ L → IsSerial R) ∧
+  (.B ∈ L → Std.Symm R) ∧
+  (.four ∈ L → IsTrans W R) ∧
+  (.five ∈ L → IsEuclidean R)
 
 /-- The syntactic-semantic bridge for `S5`: `frameConditions Logic.S5 R`
     iff `R` is an S5 frame. -/
 @[simp] theorem frameConditions_S5_iff {W : Type*} (R : AccessRel W) :
     frameConditions S5 R ↔ Std.Refl R ∧ IsEuclidean R := by
-  unfold frameConditions S5 hasAxiom
-  simp
+  simp [frameConditions, S5]
 
 /-- The syntactic-semantic bridge for `KD45`. -/
 @[simp] theorem frameConditions_KD45_iff {W : Type*} (R : AccessRel W) :
     frameConditions KD45 R ↔ IsSerial R ∧ IsTrans W R ∧ IsEuclidean R := by
-  unfold frameConditions KD45 hasAxiom
-  simp
+  simp [frameConditions, KD45]
 
 /-- The syntactic-semantic bridge for `KTB`. -/
 @[simp] theorem frameConditions_KTB_iff {W : Type*} (R : AccessRel W) :
     frameConditions KTB R ↔ Std.Refl R ∧ Std.Symm R := by
-  unfold frameConditions KTB hasAxiom
-  simp
+  simp [frameConditions, KTB]
 
 end Logic
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -9,7 +9,7 @@ import Mathlib.Order.Defs.Unbundled
 The bare foundation for accessibility-restricted modal logic, parameterised by
 `{W : Type*}` — no Frame, no Entity, no type system: accessibility relations,
 frame conditions, and the relational `box`/`diamond`. The modal-axiom theorems
-(`RestrictedModality.lean`) build on it.
+(`Basic.lean`) build on it.
 
 Montague's S5 `box`/`diamond` in `Intensional.Quantification` is the
 universal-accessibility special case (`box universalR`), but it lives in the
@@ -18,7 +18,7 @@ typed IL layer and is developed independently there.
 `Defs.lean` is the foundation file in mathlib's sense: just the data and the
 relationships among frame conditions. Modal axiom correspondence (K/T/D/4/B/5),
 monotonicity, distribution, restriction, the Logic lattice, and the `PropOp`
-("Gallin") hierarchy live in `RestrictedModality.lean`.
+("Gallin") hierarchy live in `Basic.lean`.
 -/
 
 namespace Modal

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -187,7 +187,8 @@ is addressed in §8–§9 below.
 namespace Semantics.Supervaluation.TCS
 
 open Modal
-  (AccessRel IsKTBFrame IsSerial box diamond box_T Logic)
+  (AccessRel IsKTBFrame IsSerial box diamond box_T)
+open Modal.Logic (KTB frameConditions)
 open Consequence (MixedConsequence SatImplies IsSelfDual
   premise_monotone conclusion_monotone mixed_monotone)
 open Semantics.Supervaluation (SpecSpace superTrue
@@ -245,7 +246,7 @@ instance (M : TModel D Pred) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
     frame). The four flag-fields beyond `.M` and `.B` are vacuously
     satisfied because `Logic.KTB` doesn't require D, 4, or 5. -/
 theorem satisfies_KTB (M : TModel D Pred) (P : Pred) :
-    Logic.KTB.frameConditions (M.simAccess P) := by
+    frameConditions KTB (M.simAccess P) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · intro _; exact inferInstance
   · intro h; exact absurd h (by decide)

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -113,7 +113,7 @@ extension of `P`:
 The s ⊆ c ⊆ t hierarchy is the **T axiom** instantiated at `box`
 (`Modal.box_T`); the t/s duality is the standard
 modal de Morgan `box R ¬p ↔ ¬diamond R p`. T-models satisfy
-`frameConditions Logic.KTB` by construction (Definition 4 of
+`frameConditions ModalLogic.KTB` by construction (Definition 4 of
 [cobreros-etal-2012]); see `TModel.satisfies_KTB` for the explicit
 witness. The Brouwersche axiom B / symmetric-frame correspondence is
 a standard Sahlqvist result; for systematic treatment see
@@ -188,7 +188,7 @@ namespace Semantics.Supervaluation.TCS
 
 open Modal
   (AccessRel IsKTBFrame IsSerial box diamond box_T)
-open Modal.Logic (KTB frameConditions)
+open ModalLogic (KTB frameConditions)
 open Consequence (MixedConsequence SatImplies IsSelfDual
   premise_monotone conclusion_monotone mixed_monotone)
 open Semantics.Supervaluation (SpecSpace superTrue
@@ -233,7 +233,7 @@ variable {D Pred : Type*}
 
 /-- The similarity relation as an `AccessRel` — the Kripke frame
     associated with each predicate. By construction this frame is
-    reflexive + symmetric, i.e., a **KTB frame** (`Modal.Logic.KTB`). -/
+    reflexive + symmetric, i.e., a **KTB frame** (`ModalLogic.KTB`). -/
 @[reducible] def simAccess (M : TModel D Pred) (P : Pred) : AccessRel D := M.sim P
 
 /-- Per-`(M, P)` KTB-frame instance: lets typeclass search reach
@@ -244,7 +244,7 @@ instance (M : TModel D Pred) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
     similarity relation `~_P` satisfies the frame conditions for the
     normal modal logic `KTB = K + T + B` (reflexive + symmetric Kripke
     frame). The four flag-fields beyond `.M` and `.B` are vacuously
-    satisfied because `Logic.KTB` doesn't require D, 4, or 5. -/
+    satisfied because `ModalLogic.KTB` doesn't require D, 4, or 5. -/
 theorem satisfies_KTB (M : TModel D Pred) (P : Pred) :
     frameConditions KTB (M.simAccess P) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -43,7 +43,7 @@ namespace KeshetAbney2024.PIP.Bridges
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context)
 open Modal (AccessRel box diamond)
-open Modal.Logic (frameConditions)
+open ModalLogic (frameConditions)
 
 
 -- ============================================================
@@ -263,7 +263,7 @@ it is intentionally omitted.
 -/
 
 /--
-A reflexive accessibility relation satisfies Logic.T's frame condition.
+A reflexive accessibility relation satisfies ModalLogic.T's frame condition.
 
 Stated for the Prop-valued `AccessRel`/`Std.Refl`/`frameConditions` API in
 `Intensional` — the same accessibility type PIP's modal
@@ -271,7 +271,7 @@ operators now use directly.
 -/
 theorem reflexive_satisfies_T {W : Type*}
     (R : Modal.AccessRel W) [hRefl : Std.Refl R] :
-    frameConditions Modal.Logic.T R :=
+    frameConditions ModalLogic.T R :=
   ⟨fun _ => hRefl, fun h => absurd h (by decide), fun h => absurd h (by decide),
    fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
 

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -271,11 +271,9 @@ operators now use directly.
 -/
 theorem reflexive_satisfies_T {W : Type*}
     (R : Modal.AccessRel W) [hRefl : Std.Refl R] :
-    frameConditions Modal.Logic.T R := by
-  unfold frameConditions Modal.Logic.hasAxiom
-    Modal.Logic.T
-  refine ⟨fun _ => hRefl, fun h => ?_, fun h => ?_, fun h => ?_, fun h => ?_⟩ <;>
-    simp_all [Finset.mem_singleton]
+    frameConditions Modal.Logic.T R :=
+  ⟨fun _ => hRefl, fun h => absurd h (by decide), fun h => absurd h (by decide),
+   fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
 
 
 -- ============================================================

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7987,6 +7987,19 @@
   role      = {cited},
   sources   = {Semantics/Attitudes/RationalAttitude.lean;Semantics/Lexical/LevinClass.lean;Semantics/Causation/Progressive.lean;Semantics/Lexical/EventStructure.lean;Semantics/Aspect/SubintervalProperty.lean;Features/Aktionsart.lean}
 }
+@book{dowty-wall-peters-1981,
+  author    = {Dowty, David R. and Wall, Robert E. and Peters, Stanley},
+  year      = {1981},
+  title     = {Introduction to {M}ontague Semantics},
+  series    = {Studies in Linguistics and Philosophy},
+  publisher = {D. Reidel},
+  doi       = {10.1007/978-94-009-9065-4},
+  isbn      = {9789027711427},
+  subfield  = {semantics/modality},
+  validated = {true},
+  role      = {cited},
+  sources   = {Logic/Modal/Basic.lean}
+}
 @phdthesis{hacquard-2006,
   author    = {Hacquard, Valentine},
   year      = {2006},


### PR DESCRIPTION
Audit fixes for `Logic/Modal/Basic.lean`.

- Deletes the `indicialNec`/`indicialPoss` re-stipulation of `box`/`diamond` and its `rfl` bridges (the stipulate-then-bridge anti-pattern); `IsIndicial` is now `∃ R, N = box R` and the normality facts derive from `box_mono`/`box_conj`. Drops the stale "no current downstream consumer" meta-paragraph (`Temporal/Basic` consumes `IsIndicial`).
- Dissolves the thin `Logic` struct onto `Finset Axiom` — the hand-rolled `PartialOrder`/`Lattice`/`OrderBot`/`OrderTop` block duplicated `Finset`'s instances; Bool `hasAxiom` becomes plain membership. Two-study cascade adapted (proofs get shorter).
- Adds the missing `dowty-wall-peters-1981` bib entry (verified via CrossRef/OpenLibrary; the docstring key previously rendered as dead text); register pass (banners → `/-! ### -/`, keys woven into prose, `↔` over propext equations, `inferInstanceAs` decidability); fixes `Defs.lean`'s stale `RestrictedModality.lean` references.

Follow-up commit per review: the logic-lattice namespace is a top-level `ModalLogic` (`ModalLogic.S5`, `ModalLogic.frameConditions`), not `Modal.Logic`.