### PR TITLE
refactor(Logic/Modal): rename Modal namespace to ModalLogic

### DIFF
--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -28,7 +28,7 @@ commitment to belief.
 
 namespace Discourse.Commitment.Frame
 
-open Modal (AccessRel AgentAccessRel IsKD45Frame IsK4EuclFrame
+open ModalLogic (AccessRel AgentAccessRel IsKD45Frame IsK4EuclFrame
   IsEuclidean box diamond box_K box_four)
 open Modality.EpistemicLogic (knows)
 

--- a/Linglib/Logic/Modal/BSML/Bisimulation.lean
+++ b/Linglib/Logic/Modal/BSML/Bisimulation.lean
@@ -41,7 +41,7 @@ disj-support).
 
 namespace BSML
 
-open Modal
+open ModalLogic
 
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}

--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -25,7 +25,7 @@ team semantics restricted to singleton teams.
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
@@ -217,7 +217,7 @@ theorem neFree_flat (M : KripkeModel W Atom)
 -- §5: BSML–CML Type Bridge
 -- ============================================================================
 
-open Modal (diamond)
+open ModalLogic (diamond)
 
 /-!
 ### Accessibility Type Bridge
@@ -230,8 +230,8 @@ canonical accessibility-relation type in
 
 /-- Convert BSML accessibility (`Finset`-valued) to a classical Prop-valued
     accessibility relation. -/
-def _root_.Modal.KripkeModel.toAccessRel (M : KripkeModel W Atom) :
-    Modal.AccessRel W :=
+def _root_.ModalLogic.KripkeModel.toAccessRel (M : KripkeModel W Atom) :
+    ModalLogic.AccessRel W :=
   fun w v => v ∈ M.access w
 
 /-- `classicalEval` of ◇φ agrees with `diamond` (Prop-valued possibility),
@@ -241,6 +241,6 @@ theorem classicalEval_agrees_diamond_poss
     (M : KripkeModel W Atom) (φ : Formula Atom) (w : W) :
     classicalEval M (.poss φ) w = true ↔
     diamond M.toAccessRel (fun v => classicalEval M φ v = true) w := by
-  simp only [classicalEval, decide_eq_true_eq, diamond, Modal.KripkeModel.toAccessRel]
+  simp only [classicalEval, decide_eq_true_eq, diamond, ModalLogic.KripkeModel.toAccessRel]
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -39,7 +39,7 @@ standard *classical* modal Hintikka characterisation.
 
 namespace BSML
 
-open Modal
+open ModalLogic
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
+++ b/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
@@ -49,7 +49,7 @@ identification.
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -26,7 +26,7 @@ runs the same recursion over quantified atoms.
   parameter; `support`/`antiSupport` fix the polarity.
 * `Formula.NEFree`, `Formula.Positive` — the `NE`-free and negation-free
   syntactic fragments.
-* `Modal.KripkeModel.IsIndisputable`, `Modal.KripkeModel.IsStateBased` —
+* `ModalLogic.KripkeModel.IsIndisputable`, `ModalLogic.KripkeModel.IsStateBased` —
   the frame conditions governing wide-scope free choice.
 * `consequence`, `equivalent` — support consequence and bilateral
   equivalence.
@@ -51,13 +51,13 @@ atoms flip truth value:
 Encoding both polarities in one `eval` makes the duality a single recursion
 and double-negation elimination a `rfl`: `eval M true (.neg (.neg φ)) t`
 reduces to `eval M true φ t` by two negation clauses. Models are the shared
-`Modal.KripkeModel` carrier; teams are `Finset W`; `eval` is `Prop`-valued
+`ModalLogic.KripkeModel` carrier; teams are `Finset W`; `eval` is `Prop`-valued
 with a `Decidable` instance, so concrete claims close by `decide`.
 -/
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 /-! ### Formulas -/
 
@@ -206,13 +206,13 @@ lemma empty_supports_atom (M : KripkeModel W Atom) (p : Atom) :
 /-- Indisputable accessibility: all worlds in the team see the same
     accessible worlds — the frame condition for wide-scope free choice.
     Defined via `Team.IsIndisputable`, sharing substrate with QBSML. -/
-def _root_.Modal.KripkeModel.IsIndisputable (M : KripkeModel W Atom) (t : Finset W) : Prop :=
+def _root_.ModalLogic.KripkeModel.IsIndisputable (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsIndisputable M.access t
 
 /-- State-based accessibility: every world in the team has the team itself
     as its accessible worlds. Strictly stronger than indisputability.
     Defined via `Team.IsStateBased`. -/
-def _root_.Modal.KripkeModel.IsStateBased (M : KripkeModel W Atom) (t : Finset W) : Prop :=
+def _root_.ModalLogic.KripkeModel.IsStateBased (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsStateBased M.access t
 
 instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) :=

--- a/Linglib/Logic/Modal/BSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/BSML/Enrichment.lean
@@ -26,7 +26,7 @@ non-empty witnesses — yielding free choice.
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
+++ b/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
@@ -38,7 +38,7 @@ The theorem splits into two halves:
 
 namespace BSML
 
-open Team Modal
+open Team ModalLogic
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
+++ b/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
@@ -48,7 +48,7 @@ exactly the NE-free fragment.
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 open Team
 

--- a/Linglib/Logic/Modal/BSML/Properties.lean
+++ b/Linglib/Logic/Modal/BSML/Properties.lean
@@ -46,7 +46,7 @@ separately and composing them via `Team.isFlat_iff`.
 
 namespace BSML
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 open Team
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -39,7 +39,7 @@ necessity is `box universalR` — see `box_restrict` for why restriction
 strengthens.
 -/
 
-namespace Modal
+namespace ModalLogic
 
 variable {W : Type*}
 
@@ -357,17 +357,11 @@ instance diamond_decidable {W : Type*} [Fintype W]
     Decidable (diamond R p w) :=
   inferInstanceAs (Decidable (∃ v, R w v ∧ p v))
 
-end Modal
-
 /-! ### The lattice of normal modal logics
 
 A normal modal logic is identified with its set of axiom schemas over K;
 the `Finset` lattice (`⊆`, `∪`, `∩`, `⊥ = ∅ = K`) is the lattice of
 normal logics. -/
-
-namespace ModalLogic
-
-open Modal (AccessRel IsSerial IsEuclidean)
 
 /-- Axiom schemas addable to the base logic K. -/
 inductive Axiom where

--- a/Linglib/Logic/Modal/Bisimulation.lean
+++ b/Linglib/Logic/Modal/Bisimulation.lean
@@ -43,7 +43,7 @@ other-side team by `Finset.filter` over the bisim's existential witnesses,
 using `Classical.choice` only inside pure-`Prop` existentials.
 -/
 
-namespace Modal
+namespace ModalLogic
 
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}
@@ -358,4 +358,4 @@ theorem StateBisim.possWitness {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     obtain ⟨_, y, hyY, hby⟩ := Finset.mem_filter.mp hy'
     exact ⟨y, hyY, hby⟩
 
-end Modal
+end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -9,7 +9,7 @@ frame conditions of modal correspondence theory, and the relational
 `box`/`diamond` of Kripke semantics ([kripke-1963]).
 -/
 
-namespace Modal
+namespace ModalLogic
 
 /-! ### Accessibility relations -/
 
@@ -136,4 +136,4 @@ theorem diamond_neg_box (R : AccessRel W) (p : W → Prop) (w : W) :
    fun h => Classical.byContradiction fun hne =>
      h fun v hwv hpv => hne ⟨v, hwv, hpv⟩⟩
 
-end Modal
+end ModalLogic

--- a/Linglib/Logic/Modal/Dependence.lean
+++ b/Linglib/Logic/Modal/Dependence.lean
@@ -115,11 +115,11 @@ infrastructure but differ in atom flavor:
   sibling at `Logic/Modal/Independence.lean`.
 -/
 
-namespace Modal.Dependence
+namespace ModalLogic.Dependence
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 /-! ### Syntax (Definition 1.1) -/
 
@@ -460,7 +460,7 @@ realised in a team, and functional dependence is a property of that set. -/
 
 section Bisimulation
 
-open Modal
+open ModalLogic
 
 variable {W' : Type*} [DecidableEq W'] [Fintype W']
 
@@ -602,4 +602,4 @@ theorem bisim_invariant_eval {M : KripkeModel W Atom} {M' : KripkeModel W' Atom}
 
 end Bisimulation
 
-end Modal.Dependence
+end ModalLogic.Dependence

--- a/Linglib/Logic/Modal/Inclusion.lean
+++ b/Linglib/Logic/Modal/Inclusion.lean
@@ -89,11 +89,11 @@ MIL would lose union closure. We follow the paper in using lax.
   this for the expressive completeness proof.
 -/
 
-namespace Modal.Inclusion
+namespace ModalLogic.Inclusion
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 /-! ### Syntax (AHY 2024 Definition 2.1) -/
 
@@ -366,4 +366,4 @@ theorem soundFor_unionClosed_inter_empty (M : KripkeModel W Atom) :
     show ∅ ∈ definedBy (support M) φ
     exact support_empty M φ
 
-end Modal.Inclusion
+end ModalLogic.Inclusion

--- a/Linglib/Logic/Modal/Inquisitive.lean
+++ b/Linglib/Logic/Modal/Inquisitive.lean
@@ -100,11 +100,11 @@ Per-world `□` semantics naturally fits the `R : W → Finset W` shape.
 * Bisim invariance — Ciardelli & Otto (2020) "Inquisitive bisimulation".
 -/
 
-namespace Modal.Inquisitive
+namespace ModalLogic.Inquisitive
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 /-! ### Syntax (Ciardelli §3 + §8) -/
 
@@ -300,4 +300,4 @@ theorem soundFor_downwardClosed_inter_empty (M : KripkeModel W Atom) :
     show ∅ ∈ definedBy (support M) φ
     exact support_empty M φ
 
-end Modal.Inquisitive
+end ModalLogic.Inquisitive

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -34,7 +34,7 @@ the AAY-2024 extensions BSMLOr/BSMLEmpty, modal dependence logic in
 * `Logic/Modal/Bisimulation.lean` — bounded bisimulation over this carrier.
 -/
 
-namespace Modal
+namespace ModalLogic
 
 /-- A **Kripke model** over world-type `W` and atom-type `Atom`:
     an accessibility relation `access : W → Finset W` (mapping each
@@ -51,4 +51,4 @@ structure KripkeModel (W : Type*) (Atom : Type*) [DecidableEq W] [Fintype W] whe
   /-- Valuation: `val p w` is the truth value of atom `p` at world `w`. -/
   val : Atom → W → Bool
 
-end Modal
+end ModalLogic

--- a/Linglib/Logic/Temporal/Basic.lean
+++ b/Linglib/Logic/Temporal/Basic.lean
@@ -13,7 +13,7 @@ import Linglib.Logic.Modal.Basic
 Basic semantic lemmas for `Temporal` satisfaction: the satisfaction-clause `@[simp]`
 lemmas, the dual operators (`M`/`dia`/`Fut`/`Pst`), the modality hierarchy `box ⊃ N ⊃ A`, and the
 fact that historical necessity `N` and the all-worlds `box` are **S5** modalities. Since `sat`'s
-`G`/`H`/`N`/`box` clauses are `Modal.box` Kripke modalities, the hierarchy and S5 axioms
+`G`/`H`/`N`/`box` clauses are `ModalLogic.box` Kripke modalities, the hierarchy and S5 axioms
 are *derived from modal correspondence theory* (`box_T`/`box_four`/`box_restrict`) rather than
 re-proved — `N` is S5 because `∼ₜ` is an equivalence, `box` because the universal relation is
 ([von-kutschera-1997] A4, A5).
@@ -32,7 +32,7 @@ namespace Temporal.TWFrame
 variable {Time : Type*} {World : Type*} {Atom : Type*} [LinearOrder Time]
   (F : TWFrame Time World) (V : Atom → Time → World → Prop)
 
-open Modal (box_T box_four box_restrict box_isIndicial IsIndicial universalR)
+open ModalLogic (box_T box_four box_restrict box_isIndicial IsIndicial universalR)
 
 /-! ### Satisfaction clauses -/
 
@@ -78,7 +78,7 @@ open Modal (box_T box_four box_restrict box_isIndicial IsIndicial universalR)
 
 /-! ### The modality hierarchy `box ⊃ N ⊃ A` and S5, from modal correspondence
 
-`N` and `box` are `Modal.box` modalities, so the hierarchy and S5 axioms come from modal
+`N` and `box` are `ModalLogic.box` modalities, so the hierarchy and S5 axioms come from modal
 correspondence theory: `box ⊃ N` from `box_restrict` (the universal relation contains `∼ₜ`); the `T`
 axioms from reflexivity (`box_T`); the `4` axioms from transitivity (`box_four`); the `5` axioms from
 euclideanness of `∼ₜ`. -/
@@ -119,10 +119,10 @@ theorem sat_dia_imp_box_dia {a : OForm Atom} {t : Time} {w : World} :
   obtain ⟨w₀, ha⟩ := h
   exact ⟨w₀, ha⟩
 
-/-- Historical necessity `N` is a Kripke (indicial) modality — `Modal.box` over `∼ₜ`,
+/-- Historical necessity `N` is a Kripke (indicial) modality — `ModalLogic.box` over `∼ₜ`,
     [gallin-1975]'s indicial necessity. (`G`/`H` are tense over the time order, not world-PropOps,
     so they fall outside this world-indexed classification.) -/
-theorem N_isIndicial (t : Time) : IsIndicial (Modal.box (F.sim t)) :=
+theorem N_isIndicial (t : Time) : IsIndicial (ModalLogic.box (F.sim t)) :=
   box_isIndicial (F.sim t)
 
 /-! ### The temporal adjunctions `Fut ⊣ H`, `Pst ⊣ G`

--- a/Linglib/Logic/Temporal/Defs.lean
+++ b/Linglib/Logic/Temporal/Defs.lean
@@ -58,9 +58,9 @@ namespace TWFrame
 
 variable {Time : Type u} {World : Type v} {Atom : Type*} [LinearOrder Time]
 
-open Modal (box universalR) in
+open ModalLogic (box universalR) in
 /-- Satisfaction `V_{t,w}(A)` ([von-kutschera-1997]) relative to an atomic valuation `V`.
-    `G`/`H`/`N`/`box` are `Modal.box` Kripke modalities over, respectively, future
+    `G`/`H`/`N`/`box` are `ModalLogic.box` Kripke modalities over, respectively, future
     precedence `<`, past precedence `>`, historical equivalence `sim t`, and the universal
     relation — making the object logic a multimodal Kripke logic by construction. -/
 def sat (F : TWFrame Time World) (V : Atom → Time → World → Prop) :

--- a/Linglib/Logic/Temporal/Soundness.lean
+++ b/Linglib/Logic/Temporal/Soundness.lean
@@ -167,7 +167,7 @@ inductive Provable : OForm Atom → Prop where
 /-! ### Soundness -/
 
 open TWFrame
-open Modal (box_four self_imp_box_flip_diamond)
+open ModalLogic (box_four self_imp_box_flip_diamond)
 
 /-- **Soundness of `TW`** ([von-kutschera-1997]): every `TW`-provable formula is T × W-valid. -/
 theorem soundness {a : OForm Atom} (h : Provable a) : Valid.{u, v} a := by

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -38,7 +38,7 @@ relates RSA speakers to IBR argmax behaviour.
 
 namespace NeoGricean
 
-open Modal (AccessRel box diamond IsSerial)
+open ModalLogic (AccessRel box diamond IsSerial)
 
 variable {W : Type*}
 
@@ -74,7 +74,7 @@ instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] :
 `knows`/`possible` are `box`/`diamond` over the (world-independent)
 epistemic accessibility `accessFrom e`, serial because `e.possible` is
 nonempty. The epistemic square of opposition is
-`Modal.modalSquare (accessFrom e)` with `modalSquare_relations`
+`ModalLogic.modalSquare (accessFrom e)` with `modalSquare_relations`
 discharged by this `IsSerial` instance. -/
 
 /-- Epistemic accessibility: from any world, the speaker's live possibilities. -/
@@ -91,7 +91,7 @@ theorem possible_eq_diamond (e : EpistemicState W) (φ : W → Prop) (w : W) :
     possible e φ = diamond (accessFrom e) φ w := rfl
 
 /-- Epistemic duality: ¬K¬φ ↔ Pφ — the box–diamond duality underlying
-the modal square of opposition (`Modal.modalSquare_relations`). -/
+the modal square of opposition (`ModalLogic.modalSquare_relations`). -/
 theorem duality (e : EpistemicState W) (φ : W → Prop) :
     ¬ knows e (fun w => ¬ φ w) ↔ possible e φ := by
   simp only [knows, possible, not_forall, not_not, exists_prop]

--- a/Linglib/Semantics/Exhaustification/FreeChoice.lean
+++ b/Linglib/Semantics/Exhaustification/FreeChoice.lean
@@ -54,11 +54,11 @@ section FreeChoice
 variable {World : Type*}
 
 /-- Possibility modal `◇p = ∃ w, p w` — the flat S5 possibility
-`Modal.poss`, so the whole free-choice stack shares one modal. -/
-abbrev diamond (p : Set World) : Prop := Modal.poss p
+`ModalLogic.poss`, so the whole free-choice stack shares one modal. -/
+abbrev diamond (p : Set World) : Prop := ModalLogic.poss p
 
-/-- Necessity modal `□p = ∀ w, p w` — the flat S5 necessity `Modal.nec`. -/
-abbrev box (p : Set World) : Prop := Modal.nec p
+/-- Necessity modal `□p = ∀ w, p w` — the flat S5 necessity `ModalLogic.nec`. -/
+abbrev box (p : Set World) : Prop := ModalLogic.nec p
 
 /-- The alternative set for ◇(p ∨ q) consists of {◇p, ◇q, ◇(p ∧ q)}.
 

--- a/Linglib/Semantics/Intensional/Rigidity.lean
+++ b/Linglib/Semantics/Intensional/Rigidity.lean
@@ -355,7 +355,7 @@ The operator-side dual of `IsRigid`: an operator on intensions is
 *extensional at* `w` when its value at `w` depends on its argument only
 through the argument's extension at `w` (local truth-functionality at
 `β = Prop`). Negation and the other pointwise connectives are extensional
-everywhere; quantifiers over indices (`Modal.box`) are not.
+everywhere; quantifiers over indices (`ModalLogic.box`) are not.
 Kamp-style extensional adjective operators
 (`Semantics/Modification/Classification.lean`) are the
 `α = β = E → Prop` instance of this notion. -/

--- a/Linglib/Semantics/Modality/EpistemicLogic.lean
+++ b/Linglib/Semantics/Modality/EpistemicLogic.lean
@@ -37,7 +37,7 @@ on finite worlds goes through `Decidable` instances + `decide`.
 
 namespace Modality.EpistemicLogic
 
-open Modal
+open ModalLogic
   (AccessRel AgentAccessRel box diamond IsSerial IsEuclidean IsBeliefRefinementOf
    box_T box_D box_four box_B box_five)
 

--- a/Linglib/Semantics/Modality/EventRelativity.lean
+++ b/Linglib/Semantics/Modality/EventRelativity.lean
@@ -608,7 +608,7 @@ theorem doxastic_necessity_eq {Event W E : Type*}
     (holder : Event → E) (e : Event) (p : W → Prop) (w : W) :
     simpleNecessity (doxasticAnchoring R holder e) p w ↔
       ∀ w', R (holder e) w w' → p w' := by
-  simp [simpleNecessity, Modal.box, kratzerR, doxasticAnchoring]
+  simp [simpleNecessity, ModalLogic.box, kratzerR, doxasticAnchoring]
 
 /-- Possibility dually: some doxastic alternative of the holder
 satisfies p. -/
@@ -617,7 +617,7 @@ theorem doxastic_possibility_eq {Event W E : Type*}
     (holder : Event → E) (e : Event) (p : W → Prop) (w : W) :
     simplePossibility (doxasticAnchoring R holder e) p w ↔
       ∃ w', R (holder e) w w' ∧ p w' := by
-  simp [simplePossibility, Modal.diamond, kratzerR, doxasticAnchoring]
+  simp [simplePossibility, ModalLogic.diamond, kratzerR, doxasticAnchoring]
 
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -41,7 +41,7 @@ import Linglib.Logic.Modal.Basic
 
 namespace Modality.Kratzer
 
-open Modal
+open ModalLogic
 
 variable {W : Type*}
 
@@ -236,7 +236,7 @@ theorem empty_base_universal_access (w : W) :
 
 /-- **Modal duality**: `□p ↔ ¬◇¬p`. Since `necessity = box (kratzerBestR f g)`,
     this is the box–diamond duality of the modal square of opposition
-    (`Modal.modalSquare_relations`). -/
+    (`ModalLogic.modalSquare_relations`). -/
 theorem duality (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) :
     necessity f g p w ↔ ¬ possibility f g (fun w' => ¬ p w') w := by
   rw [necessity, possibility, box_neg_diamond]

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -29,7 +29,7 @@ namespace Semantics.Presupposition.BeliefEmbedding
 open Semantics.Presupposition
 open CommonGround
 open Semantics.Presupposition.Context
-open Modal (AgentAccessRel IsBeliefRefinementOf)
+open ModalLogic (AgentAccessRel IsBeliefRefinementOf)
 
 variable {W : Type*} {Agent : Type*}
 
@@ -37,7 +37,7 @@ variable {W : Type*} {Agent : Type*}
 /--
 An agent's belief state at a world: the doxastically accessible worlds,
 viewed as a context set. Doxastic accessibility is the agent-indexed
-accessibility relation `Modal.AgentAccessRel` ([hintikka-1962]):
+accessibility relation `ModalLogic.AgentAccessRel` ([hintikka-1962]):
 `Dox agent w w'` means `w'` is compatible with what `agent` believes at `w`.
 -/
 def beliefState (Dox : AgentAccessRel W Agent) (agent : Agent) (w : W) : ContextSet W :=
@@ -190,7 +190,7 @@ theorem stop_ole_attribution :
 ### Refinement Between Knowledge and Belief Embeddings
 [hintikka-1962]
 
-Doxastic accessibility is `Modal.AgentAccessRel` directly, so
+Doxastic accessibility is `ModalLogic.AgentAccessRel` directly, so
 belief local contexts compose with the epistemic-logic frame conditions:
 when belief pointwise refines knowledge (`IsBeliefRefinementOf`), filtering
 under knowledge embedding implies filtering under belief embedding.

--- a/Linglib/Semantics/Quantification/ChoiceFunction.lean
+++ b/Linglib/Semantics/Quantification/ChoiceFunction.lean
@@ -219,7 +219,7 @@ collapse — narrow readings under the modal remain available — and the
 individual skolem index carrying [owusu-2022]'s functional readings is
 beyond this fragment. -/
 
-open Modal
+open ModalLogic
 
 /-- Apply a skolemized CF at `s` to an intensional restrictor, evaluating
 both at the same index — [owusu-2022]'s f_s(P(s)) (entry (67), modulo

--- a/Linglib/Studies/Aloni2022.lean
+++ b/Linglib/Studies/Aloni2022.lean
@@ -40,7 +40,7 @@ the typed atoms throughout.
 namespace Aloni2022
 
 open BSML
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 open BSML (FCAtom TwoAtomWorld)
 
 -- ============================================================================

--- a/Linglib/Studies/Aloni2022/FreeChoice.lean
+++ b/Linglib/Studies/Aloni2022/FreeChoice.lean
@@ -30,7 +30,7 @@ Free choice is DERIVED from three independent principles:
 namespace Aloni2022
 
 open BSML
-open Modal (KripkeModel)
+open ModalLogic (KripkeModel)
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Studies/AloniAnttilaYang2024.lean
+++ b/Linglib/Studies/AloniAnttilaYang2024.lean
@@ -98,7 +98,7 @@ namespace AloniAnttilaYang2024
 variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
 variable {Atom : Type*}
 
-open Modal (KripkeModel StateBisim WorldBisim)
+open ModalLogic (KripkeModel StateBisim WorldBisim)
 
 /-! ### BSMLOr — BSML with global disjunction `⨼` -/
 

--- a/Linglib/Studies/Booth2022.lean
+++ b/Linglib/Studies/Booth2022.lean
@@ -165,7 +165,7 @@ def conj (φ ψ : BilatInqProp W) : BilatInqProp W where
 /-! ### §3 Necessity and possibility (Booth Def 14)
 
 `R : W → Set W` is the relevant-worlds accessibility relation
-(equivalent in expressive power to `Modal.AccessRel W
+(equivalent in expressive power to `ModalLogic.AccessRel W
 = W → W → Prop`; Booth uses the curried `W → Set W` form throughout
 his Def 14, which we mirror). -/
 

--- a/Linglib/Studies/Ciardelli2022.lean
+++ b/Linglib/Studies/Ciardelli2022.lean
@@ -29,8 +29,8 @@ the Heyting arrow.
 
 namespace Question
 
-open Modal (KripkeModel)
-open Modal.Inquisitive
+open ModalLogic (KripkeModel)
+open ModalLogic.Inquisitive
 
 variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
 

--- a/Linglib/Studies/CiardelliGuerrini2026.lean
+++ b/Linglib/Studies/CiardelliGuerrini2026.lean
@@ -29,7 +29,7 @@ interpreted, yielding `Δ(A ∘ B)` rather than `ΔA ∘ ΔB`.
 | must A or must B | `□A ∨ □B`     | `□(A ∨ B)`      |
 | may A and may B  | `◇A ∧ ◇B`     | `◇(A ∧ B)`      |
 
-The modal operators `diamond`/`box` are `Modal.poss`/`nec` (the flat
+The modal operators `diamond`/`box` are `ModalLogic.poss`/`nec` (the flat
 S5 modals shared with the whole free-choice stack), so the scope theorems consume
 the substrate's distribution lemmas directly.
 
@@ -69,19 +69,19 @@ theorem scope_equivalence {World : Type*} (A B : Set World) :
 /-! ### Must-or-must: disjunctive obligation (§2)
 
 Under *necessity*, the scope distinction is **not** truth-conditionally vacuous.
-`diamond`/`box` here are `Modal.poss`/`nec`, so these theorems consume
+`diamond`/`box` here are `ModalLogic.poss`/`nec`, so these theorems consume
 the substrate's flat distribution directly. For disjunction the narrow LF
 `□(A ∪ B)` is strictly *weaker* than the wide LF `□A ∨ □B` — exactly C&G's
 must-or-must contrast: "(either) you must A or you must B" on its salient reading
 is a single disjunctive obligation `□(A ∨ B)`, not two obligations. -/
 
 /-- Wide ⟹ narrow: `□A ∨ □B → □(A ∪ B)`. The narrow disjunctive-obligation LF is
-the weaker reading (monotonicity of `Modal.nec`). -/
+the weaker reading (monotonicity of `ModalLogic.nec`). -/
 theorem disjunctive_obligation_narrow_weaker {World : Type*} (A B : Set World) :
     box A ∨ box B → box (A ∪ B) := by
   rintro (h | h)
-  · exact Modal.nec_mono (fun _ ha => Or.inl ha) h
-  · exact Modal.nec_mono (fun _ hb => Or.inr hb) h
+  · exact ModalLogic.nec_mono (fun _ ha => Or.inl ha) h
+  · exact ModalLogic.nec_mono (fun _ hb => Or.inr hb) h
 
 /-- …but **not** conversely: `□(A ∪ B)` does not entail `□A ∨ □B`. A disjunctive
 obligation leaves which disjunct is met open, so neither `□A` nor `□B` follows.

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -111,7 +111,7 @@ extension of `P`:
 - `tolerant P at a` ≡ `diamond (~_P) I(P) a` (Definition 9)
 
 The s ⊆ c ⊆ t hierarchy is the **T axiom** instantiated at `box`
-(`Modal.box_T`); the t/s duality is the standard
+(`ModalLogic.box_T`); the t/s duality is the standard
 modal de Morgan `box R ¬p ↔ ¬diamond R p`. T-models satisfy
 `frameConditions ModalLogic.KTB` by construction (Definition 4 of
 [cobreros-etal-2012]); see `TModel.satisfies_KTB` for the explicit
@@ -186,7 +186,7 @@ is addressed in §8–§9 below.
 
 namespace Semantics.Supervaluation.TCS
 
-open Modal
+open ModalLogic
   (AccessRel IsKTBFrame IsSerial box diamond box_T)
 open ModalLogic (KTB frameConditions)
 open Consequence (MixedConsequence SatImplies IsSelfDual

--- a/Linglib/Studies/Cooper2023/Ch6.lean
+++ b/Linglib/Studies/Cooper2023/Ch6.lean
@@ -1435,7 +1435,7 @@ section TtrKratzerBridge
 
 open Modality.Kratzer (ModalBase OrderingSource bestWorlds
   necessity possibility)
-open Modal (box diamond)
+open ModalLogic (box diamond)
 
 variable {W : Type}
 

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -44,7 +44,7 @@ via the paper's translation: radically counterstance-contingent = strongly discr
   classification, plus the information-state-relativized `ObjectiveIn`/`DiscretionaryIn`/
   `StronglyDiscretionaryIn`.
 * `Accepts`, `Rejects`, `DisagreeAt`, `Opinionated` — doxastic accessibility as a binary
-  relation on outlooks (§5's `R_a`), acceptance as the Kripke box (`Modal.box`).
+  relation on outlooks (§5's `R_a`), acceptance as the Kripke box (`ModalLogic.box`).
 * `AtFault` — the norm of accuracy: asserting what is objectively false at the context world.
 * `think`, `tycka` — the attitude verbs as `PartialProp`s: same assertion (doxastic
   acceptance), differing only in *tycka*'s strong-discretionariness presupposition.
@@ -74,7 +74,7 @@ via the paper's translation: radically counterstance-contingent = strongly discr
 namespace Coppock2018
 
 open Trivalent (Prop3)
-open Modal (AccessRel box)
+open ModalLogic (AccessRel box)
 open Semantics.Presupposition (PartialProp)
 
 variable {W Ω : Type*}
@@ -271,7 +271,7 @@ An agent's accessibility is a binary relation on outlooks ([coppock-2018] §5's 
 doxastic state at `o` is the set of outlooks it reaches (states vary from outlook to
 outlook, since whether an agent holds a belief is itself settled by outlooks). To *accept*
 a proposition is for it to hold throughout one's accessible outlooks — the Kripke box
-(`Modal.box`) over outlooks with the proposition's truth as valuation. -/
+(`ModalLogic.box`) over outlooks with the proposition's truth as valuation. -/
 
 /-- An agent with accessibility `R` **accepts** `p` at `o`: `p` holds at every accessible
 outlook. -/
@@ -351,7 +351,7 @@ abbrev johnR : AccessRel ChiliOutlook := λ _ o' => o'.1 = true
 /-- Mary's doxastic state: only non-tasty-outlooks accessible. -/
 abbrev maryR : AccessRel ChiliOutlook := λ _ o' => o'.1 = false
 
-/-- An unopinionated agent: every outlook accessible (`Modal.universalR`,
+/-- An unopinionated agent: every outlook accessible (`ModalLogic.universalR`,
 inlined for decidability). -/
 abbrev openR : AccessRel ChiliOutlook := λ _ _ => True
 

--- a/Linglib/Studies/FaginHalpern1994.lean
+++ b/Linglib/Studies/FaginHalpern1994.lean
@@ -55,7 +55,7 @@ set_option autoImplicit false
 
 namespace FaginHalpern1994
 
-open Modal
+open ModalLogic
   (AgentAccessRel AccessRel box IsEuclidean)
 open Modality.EpistemicLogic (knows everyoneKnows)
 open Modality.EpistemicProbability (WorldCredence nestedThreshold)

--- a/Linglib/Studies/FuscoSgrizzi2026.lean
+++ b/Linglib/Studies/FuscoSgrizzi2026.lean
@@ -68,7 +68,7 @@ theorem empty_inertia_is_simple (circ : ModalBase W) (prop : W → Prop) (w : W)
     inertialNecessity ⟨circ, emptyBackground⟩ prop w ↔
     simpleNecessity circ prop w := by
   simp only [inertialNecessity, necessity, simpleNecessity,
-             Modal.box]
+             ModalLogic.box]
   constructor
   · intro h j hj
     exact h j ((kratzerBestR_empty circ w j).mpr hj)

--- a/Linglib/Studies/Heim1992Projection.lean
+++ b/Linglib/Studies/Heim1992Projection.lean
@@ -38,7 +38,7 @@ namespace Heim1992
 
 open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
-open Modal (IsSerial IsEuclidean IsS5Frame IsKD45Frame
+open ModalLogic (IsSerial IsEuclidean IsS5Frame IsKD45Frame
   IsBeliefRefinementOf)
 open Semantics.Presupposition.Context (presupSatisfied)
 open Semantics.Presupposition.BeliefEmbedding

--- a/Linglib/Studies/Hintikka1962.lean
+++ b/Linglib/Studies/Hintikka1962.lean
@@ -9,7 +9,7 @@ import Linglib.Discourse.Commitment.Frame
 worlds where `p` holds while the speaker fails to believe `p`. But its
 would-be-believed form `B_a (p ∧ ¬ B_a p)` is *indefensible* in any KD4
 doxastic model: a 1-line specialisation of
-`Modal.box_not_moore` to the agent-indexed belief
+`ModalLogic.box_not_moore` to the agent-indexed belief
 accessibility of `CommitmentState`. The knowledge analogue specialises
 the same substrate lemma to epistemic accessibility.
 -/
@@ -17,7 +17,7 @@ the same substrate lemma to epistemic accessibility.
 namespace Hintikka1962
 
 open Discourse.Commitment.Frame
-open Modal (box_not_moore AgentAccessRel IsSerial)
+open ModalLogic (box_not_moore AgentAccessRel IsSerial)
 open Modality.EpistemicLogic (knows)
 
 variable {W A : Type*}

--- a/Linglib/Studies/Huijsmans2025.lean
+++ b/Linglib/Studies/Huijsmans2025.lean
@@ -38,7 +38,7 @@ EAT analysis (with the same partition reinterpreted) does not.
 The at-issue content is Kratzer strong necessity over the modal base,
 shared across all four lexical entries (modulo modal-base type). It is
 not formalized in this file; consumers wanting full denotations should
-combine `Modal.flavor` with `Modality.Kratzer.necessity`.
+combine `ModalLogic.flavor` with `Modality.Kratzer.necessity`.
 -/
 
 namespace Huijsmans2025

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -125,7 +125,7 @@ namespace KeshetAbney2024
 
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context idUp)
-open Modal (AccessRel)
+open ModalLogic (AccessRel)
 
 
 -- ============================================================

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -42,7 +42,7 @@ namespace KeshetAbney2024.PIP.Bridges
 
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context)
-open Modal (AccessRel box diamond)
+open ModalLogic (AccessRel box diamond)
 open ModalLogic (frameConditions)
 
 
@@ -270,7 +270,7 @@ Stated for the Prop-valued `AccessRel`/`Std.Refl`/`frameConditions` API in
 operators now use directly.
 -/
 theorem reflexive_satisfies_T {W : Type*}
-    (R : Modal.AccessRel W) [hRefl : Std.Refl R] :
+    (R : ModalLogic.AccessRel W) [hRefl : Std.Refl R] :
     frameConditions ModalLogic.T R :=
   ⟨fun _ => hRefl, fun h => absurd h (by decide), fun h => absurd h (by decide),
    fun h => absurd h (by decide), fun h => absurd h (by decide)⟩

--- a/Linglib/Studies/KeshetAbney2024/Composition.lean
+++ b/Linglib/Studies/KeshetAbney2024/Composition.lean
@@ -26,7 +26,7 @@ type and connected to it via bridge theorems.
 
 namespace KeshetAbney2024.PIP
 
-open Modal (AccessRel box diamond)
+open ModalLogic (AccessRel box diamond)
 
 
 -- ============================================================

--- a/Linglib/Studies/KeshetAbney2024/Connectives.lean
+++ b/Linglib/Studies/KeshetAbney2024/Connectives.lean
@@ -35,7 +35,7 @@ namespace KeshetAbney2024.PIP
 
 open DynamicSemantics
 open DynamicSemantics.ICDRT
-open Modal (AccessRel box diamond box_T)
+open ModalLogic (AccessRel box diamond box_T)
 
 variable {W E : Type*}
 
@@ -332,7 +332,7 @@ holds at (g, w₀), then `p g w₀`.
 
 This derives PIP's key insight — must allows anaphora because a realistic
 modal base guarantees the description holds at the evaluation world — from
-`Modal.box_T`.
+`ModalLogic.box_T`.
 -/
 theorem must_realistic_of_refl [Fintype W]
     (R : AccessRel W) [Std.Refl R]

--- a/Linglib/Studies/KeshetAbney2024/Expr.lean
+++ b/Linglib/Studies/KeshetAbney2024/Expr.lean
@@ -41,7 +41,7 @@ all `X ≡ φ` definitions regardless of their structural position.
 
 namespace KeshetAbney2024.PIP
 
-open Modal (AccessRel box diamond)
+open ModalLogic (AccessRel box diamond)
 
 /-- A finite domain of individuals for PIP quantifier evaluation. -/
 class FiniteDomain (D : Type*) where

--- a/Linglib/Studies/KeshetAbney2024/Felicity.lean
+++ b/Linglib/Studies/KeshetAbney2024/Felicity.lean
@@ -57,7 +57,7 @@ world and assignment consistent with γ.
 
 namespace KeshetAbney2024.PIP.Felicity
 
-open Modal (AccessRel box diamond)
+open ModalLogic (AccessRel box diamond)
 
 variable {W : Type*}
 

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -53,7 +53,7 @@ needs QUD/information-structure machinery).
 namespace TonhauserEtAl2013
 
 open CommonGround
-open Modal (AgentAccessRel)
+open ModalLogic (AgentAccessRel)
 open Semantics.Presupposition
 open Semantics.Presupposition.Context
 open Semantics.Presupposition.BeliefEmbedding

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -188,7 +188,7 @@ open CommonGround (ContextSet)
 
 /-- Local Bool-valued accessibility used by Wang2025 for `List.all` evaluation
 of the speaker-K operator. The Prop-valued canonical version lives in
-`Modal.AccessRel`; lift via
+`ModalLogic.AccessRel`; lift via
 `fun a b => R a b = true` to bridge. -/
 abbrev BAccessRel (W : Type*) := W → W → Bool
 open Pragmatics.Expressives (TwoDimProp)

--- a/Linglib/Studies/ZwickyPullum1983.lean
+++ b/Linglib/Studies/ZwickyPullum1983.lean
@@ -400,7 +400,7 @@ an accessibility relation under which the two scope readings diverge. -/
 section ScopeBridge
 
 open Modality (ModalForce)
-open Modal (AccessRel box diamond)
+open ModalLogic (AccessRel box diamond)
 
 abbrev World := Fin 4
 


### PR DESCRIPTION
Renames the `Modal` namespace to `ModalLogic` throughout (51 files, mechanical).

In a linguistics library "modal" is word-class vocabulary — the Fragments layer already has `German.Predicates.Modal` and a dozen `Modals.lean` inventories in exactly that sense — so the Kripke-machinery namespace now carries the discipline name instead: `ModalLogic.box`, `ModalLogic.KripkeModel`, `ModalLogic.StateBisim`, joining the existing `ModalLogic.S5`/`frameConditions`. Directory stays `Logic/Modal/`; `German.Predicates.Modal` and import paths untouched.
