### PR TITLE
refactor(Logic/Modal): dissolve AccessRel aliases; universalR, emptyR → ⊤, ⊥

### DIFF
--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -28,21 +28,20 @@ commitment to belief.
 
 namespace Discourse.Commitment.Frame
 
-open ModalLogic (AccessRel AgentAccessRel IsKD45Frame IsK4EuclFrame
-  IsEuclidean box diamond box_K box_four)
+open ModalLogic (IsKD45Frame IsK4EuclFrame IsEuclidean box diamond box_K box_four)
 open Modality.EpistemicLogic (knows)
 
 /-- Pair-indexed deontic accessibility: `commitment a b w v` means at
     `w`, the world `v` is among those satisfying everything `a` is
     committed-towards-`b` to. Genuinely ternary; no analogue in
     linglib's unary-belief substrate. -/
-abbrev PairAccessRel (W A : Type*) := A → A → AccessRel W
+abbrev PairAccessRel (W A : Type*) := A → A → W → W → Prop
 
 /-- Multi-relational Kripke frame: belief (KD45) + commitment (K4 +
     Eucl., not serial) + atomic valuation. -/
 structure CommitmentState (W : Type*) (A : Type*) where
   /-- Per-agent doxastic accessibility. -/
-  belief : AgentAccessRel W A
+  belief : A → W → W → Prop
   /-- Pair-indexed deontic accessibility. -/
   commitment : PairAccessRel W A
   /-- Atomic-proposition valuation. -/

--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -223,7 +223,7 @@ open ModalLogic (diamond)
 ### Accessibility Type Bridge
 
 `KripkeModel.access : W → Finset W` can be converted to a Prop-valued
-`AccessRel W = W → W → Prop` via `fun w v => v ∈ M.access w`, which is the
+`W → W → Prop` via `fun w v => v ∈ M.access w`, which is the
 canonical accessibility-relation type in
 `Intensional`.
 -/
@@ -231,7 +231,7 @@ canonical accessibility-relation type in
 /-- Convert BSML accessibility (`Finset`-valued) to a classical Prop-valued
     accessibility relation. -/
 def _root_.ModalLogic.KripkeModel.toAccessRel (M : KripkeModel W Atom) :
-    ModalLogic.AccessRel W :=
+    W → W → Prop :=
   fun w v => v ∈ M.access w
 
 /-- `classicalEval` of ◇φ agrees with `diamond` (Prop-valued possibility),

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -35,7 +35,7 @@ Kratzer's conversational backgrounds derive accessibility from a modal
 base: `R_f(w, w') ≡ w' ∈ ⋂f(w)`, with the ordering source further
 restricting to best worlds. Simple Kratzer necessity is `box R_f`, full
 Kratzer necessity is `box` of the best-world restriction, and S5
-necessity is `box universalR` — see `box_restrict` for why restriction
+necessity is `box ⊤` — see `box_restrict` for why restriction
 strengthens.
 -/
 
@@ -46,47 +46,47 @@ variable {W : Type*}
 /-! ### Axiom correspondence -/
 
 /-- `box R p w` unfolds to `∀ v, R w v → p v`. -/
-theorem box_eq_forall (R : AccessRel W) (p : W → Prop) (w : W) :
+theorem box_eq_forall (R : W → W → Prop) (p : W → Prop) (w : W) :
     box R p w = (∀ v, R w v → p v) := rfl
 
 /-- `diamond R p w` unfolds to `∃ v, R w v ∧ p v`. -/
-theorem diamond_eq_exists (R : AccessRel W) (p : W → Prop) (w : W) :
+theorem diamond_eq_exists (R : W → W → Prop) (p : W → Prop) (w : W) :
     diamond R p w = (∃ v, R w v ∧ p v) := rfl
 
 /-- **K axiom**: `□_R(p → q) → (□_R p → □_R q)`.
     Holds for any accessibility relation. -/
-theorem box_K (R : AccessRel W) (p q : W → Prop) (w : W)
+theorem box_K (R : W → W → Prop) (p q : W → Prop) (w : W)
     (hpq : box R (fun v => p v → q v) w)
     (hp : box R p w) : box R q w :=
   fun v hwv => hpq v hwv (hp v hwv)
 
 /-- **T axiom**: reflexive `R` gives `□_R p w → p w`.
     What is necessary is actual. -/
-theorem box_T (R : AccessRel W) [Std.Refl R] (p : W → Prop) (w : W)
+theorem box_T (R : W → W → Prop) [Std.Refl R] (p : W → Prop) (w : W)
     (h : box R p w) : p w :=
   h w (Std.Refl.refl w)
 
 /-- **D axiom**: serial `R` gives `□_R p w → ◇_R p w`.
     What is necessary is possible. -/
-theorem box_D (R : AccessRel W) [hS : IsSerial R] (p : W → Prop) (w : W)
+theorem box_D (R : W → W → Prop) [hS : IsSerial R] (p : W → Prop) (w : W)
     (h : box R p w) : diamond R p w :=
   let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
 
 /-- **4 axiom**: transitive `R` gives `□_R p → □_R □_R p`.
     Positive introspection. -/
-theorem box_four (R : AccessRel W) [IsTrans W R] (p : W → Prop) (w : W)
+theorem box_four (R : W → W → Prop) [IsTrans W R] (p : W → Prop) (w : W)
     (h : box R p w) : box R (box R p) w :=
   fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
 
 /-- **B axiom**: symmetric `R` gives `p w → □_R ◇_R p w`.
     What is actual is necessarily possible. -/
-theorem box_B (R : AccessRel W) [Std.Symm R] (p : W → Prop) (w : W)
+theorem box_B (R : W → W → Prop) [Std.Symm R] (p : W → Prop) (w : W)
     (h : p w) : box R (diamond R p) w :=
   fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
 
 /-- **5 axiom**: euclidean `R` gives `◇_R p w → □_R ◇_R p w`.
     Positive possibility introspection. -/
-theorem box_five (R : AccessRel W) [hE : IsEuclidean R] (p : W → Prop) (w : W)
+theorem box_five (R : W → W → Prop) [hE : IsEuclidean R] (p : W → Prop) (w : W)
     (h : diamond R p w) : box R (diamond R p) w :=
   let ⟨u, hwu, hpu⟩ := h
   fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
@@ -95,7 +95,7 @@ theorem box_five (R : AccessRel W) [hE : IsEuclidean R] (p : W → Prop) (w : W)
     `R` is serial and transitive. The content `p ∧ ¬□_R p` is itself
     satisfiable; what fails is *boxing* it. Specialise to belief,
     knowledge, or any other KD4 modality. -/
-theorem box_not_moore (R : AccessRel W) [hS : IsSerial R] [IsTrans W R]
+theorem box_not_moore (R : W → W → Prop) [hS : IsSerial R] [IsTrans W R]
     (p : W → Prop) (w : W) :
     ¬ box R (fun v => p v ∧ ¬ box R p v) w := by
   intro h
@@ -112,7 +112,7 @@ satisfies all six relations of the square of opposition, so every serial
 modality (epistemic, deontic, temporal, doxastic) inherits the square. -/
 
 /-- Under seriality, `□p` and `□¬p` are incompatible: no world satisfies both. -/
-theorem box_disjoint_compl (R : AccessRel W) [hS : IsSerial R] (p : W → Prop) :
+theorem box_disjoint_compl (R : W → W → Prop) [hS : IsSerial R] (p : W → Prop) :
     Disjoint (box R p) (box R pᶜ) := by
   rw [Pi.disjoint_iff]
   intro w
@@ -122,7 +122,7 @@ theorem box_disjoint_compl (R : AccessRel W) [hS : IsSerial R] (p : W → Prop) 
   exact hnp v hwv (hp v hwv)
 
 /-- Box–diamond duality as an equation of predicates: `◇p = ¬□¬p`. -/
-theorem diamond_eq_compl_box_compl (R : AccessRel W) (p : W → Prop) :
+theorem diamond_eq_compl_box_compl (R : W → W → Prop) (p : W → Prop) :
     diamond R p = (box R pᶜ)ᶜ := by
   funext w
   apply propext
@@ -135,7 +135,7 @@ theorem diamond_eq_compl_box_compl (R : AccessRel W) (p : W → Prop) :
 
 /-- The **modal square of opposition** over an accessibility relation `R`:
     `A = □p`, `E = □¬p`, `I = ◇p`, `O = ¬□p`. -/
-def modalSquare (R : AccessRel W) (p : W → Prop) : Aristotelian.Square (W → Prop) where
+def modalSquare (R : W → W → Prop) (p : W → Prop) : Aristotelian.Square (W → Prop) where
   A := box R p
   E := box R pᶜ
   I := diamond R p
@@ -145,7 +145,7 @@ def modalSquare (R : AccessRel W) (p : W → Prop) : Aristotelian.Square (W → 
 **serial**. `subalternAI` is exactly the D axiom (`box_D` : `□p → ◇p`); the two
 contradiction diagonals combine `isCompl_compl` with box–diamond duality; and
 contrariety/subcontrariety reduce to `box_disjoint_compl`. -/
-theorem modalSquare_relations (R : AccessRel W) [IsSerial R] (p : W → Prop) :
+theorem modalSquare_relations (R : W → W → Prop) [IsSerial R] (p : W → Prop) :
     Aristotelian.SquareRelations (modalSquare R p) where
   subalternAI := by rw [Pi.le_def]; exact fun w => box_D R p w
   subalternEO := le_compl_iff_disjoint_right.mpr (box_disjoint_compl R p).symm
@@ -162,32 +162,32 @@ theorem modalSquare_relations (R : AccessRel W) [IsSerial R] (p : W → Prop) :
 /-! ### Monotonicity and distribution -/
 
 /-- `box R` is monotone: if `p ≤ q` pointwise, then `□_R p ≤ □_R q`. -/
-theorem box_mono (R : AccessRel W) {p q : W → Prop}
+theorem box_mono (R : W → W → Prop) {p q : W → Prop}
     (h : ∀ v, p v → q v) (w : W)
     (hb : box R p w) : box R q w :=
   fun v hwv => h v (hb v hwv)
 
 /-- `diamond R` is monotone. -/
-theorem diamond_mono (R : AccessRel W) {p q : W → Prop}
+theorem diamond_mono (R : W → W → Prop) {p q : W → Prop}
     (h : ∀ v, p v → q v) (w : W)
     (hd : diamond R p w) : diamond R q w :=
   let ⟨v, hwv, hpv⟩ := hd; ⟨v, hwv, h v hpv⟩
 
 /-- `□_R` distributes over `∧`. -/
-theorem box_conj (R : AccessRel W) (p q : W → Prop) (w : W) :
+theorem box_conj (R : W → W → Prop) (p q : W → Prop) (w : W) :
     box R (fun v => p v ∧ q v) w ↔ box R p w ∧ box R q w :=
   ⟨fun h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩,
    fun ⟨hp, hq⟩ v hwv => ⟨hp v hwv, hq v hwv⟩⟩
 
 /-- `◇_R` distributes over `∨`. -/
-theorem diamond_disj (R : AccessRel W) (p q : W → Prop) (w : W) :
+theorem diamond_disj (R : W → W → Prop) (p q : W → Prop) (w : W) :
     diamond R (fun v => p v ∨ q v) w ↔ diamond R p w ∨ diamond R q w :=
   ⟨fun ⟨v, hwv, h⟩ => h.elim (fun hp => .inl ⟨v, hwv, hp⟩) (fun hq => .inr ⟨v, hwv, hq⟩),
    fun h => h.elim (fun ⟨v, hwv, hp⟩ => ⟨v, hwv, .inl hp⟩)
                    (fun ⟨v, hwv, hq⟩ => ⟨v, hwv, .inr hq⟩)⟩
 
 /-- Necessitation: if `p` holds at every world, then `□_R p` holds everywhere. -/
-theorem box_necessitation (R : AccessRel W) (p : W → Prop)
+theorem box_necessitation (R : W → W → Prop) (p : W → Prop)
     (h : ∀ v, p v) (w : W) : box R p w :=
   fun v _ => h v
 
@@ -195,14 +195,14 @@ theorem box_necessitation (R : AccessRel W) (p : W → Prop)
 
 /-- Restricting accessibility strengthens necessity:
     if `R₂ ⊆ R₁`, then `□_{R₁} p → □_{R₂} p`. -/
-theorem box_restrict {R₁ R₂ : AccessRel W}
+theorem box_restrict {R₁ R₂ : W → W → Prop}
     (h : ∀ w v, R₂ w v → R₁ w v) (p : W → Prop) (w : W)
     (hb : box R₁ p w) : box R₂ p w :=
   fun v hwv => hb v (h w v hwv)
 
 /-- Restricting accessibility weakens possibility:
     if `R₂ ⊆ R₁`, then `◇_{R₂} p → ◇_{R₁} p`. -/
-theorem diamond_restrict {R₁ R₂ : AccessRel W}
+theorem diamond_restrict {R₁ R₂ : W → W → Prop}
     (h : ∀ w v, R₂ w v → R₁ w v) (p : W → Prop) (w : W)
     (hd : diamond R₂ p w) : diamond R₁ p w :=
   let ⟨v, hwv, hpv⟩ := hd; ⟨v, h w v hwv, hpv⟩
@@ -210,7 +210,7 @@ theorem diamond_restrict {R₁ R₂ : AccessRel W}
 /-- **Conversion** (Prior's tense axiom `A ⊃ G P A` / `A ⊃ H F A`): for `R` and its converse
     `flip R`, `p w → □_{flip R} ◇_R p w`. The correspondence fact that two modalities over a
     relation and its converse are temporally adjoint (holds for *any* `R`). -/
-theorem self_imp_box_flip_diamond (R : AccessRel W) (p : W → Prop) (w : W)
+theorem self_imp_box_flip_diamond (R : W → W → Prop) (p : W → Prop) (w : W)
     (h : p w) : box (flip R) (diamond R p) w :=
   fun _ hv => ⟨w, hv, h⟩
 
@@ -218,7 +218,7 @@ theorem self_imp_box_flip_diamond (R : AccessRel W) (p : W → Prop) (w : W)
 
 /-- With reflexive + euclidean accessibility (= S5 frame conditions),
     `box` validates all of T, D, 4, B, 5. -/
-theorem S5_frame_all_axioms (R : AccessRel W) [Std.Refl R] [IsEuclidean R] :
+theorem S5_frame_all_axioms (R : W → W → Prop) [Std.Refl R] [IsEuclidean R] :
     (∀ p w, box R p w → p w) ∧                          -- T
     (∀ p w, box R p w → diamond R p w) ∧               -- D
     (∀ p w, box R p w → box R (box R p) w) ∧          -- 4
@@ -227,7 +227,7 @@ theorem S5_frame_all_axioms (R : AccessRel W) [Std.Refl R] [IsEuclidean R] :
   ⟨box_T R, box_D R, box_four R, box_B R, box_five R⟩
 
 /-- KD45 frame conditions validate all three KD45 axioms (D, 4, 5). -/
-theorem KD45_frame_all_axioms (R : AccessRel W) [IsKD45Frame R] :
+theorem KD45_frame_all_axioms (R : W → W → Prop) [IsKD45Frame R] :
     (∀ p w, box R p w → diamond R p w) ∧               -- D
     (∀ p w, box R p w → box R (box R p) w) ∧          -- 4
     (∀ p w, diamond R p w → box R (diamond R p) w) := -- 5
@@ -238,7 +238,7 @@ theorem KD45_frame_all_axioms (R : AccessRel W) [IsKD45Frame R] :
 Propositional operators form a three-level hierarchy: **general**
 (`PropOp` — arbitrary properties of propositions, varying by world),
 **indicial** (Kripke-definable: `N = box R` for some accessibility `R`),
-and **S5** (the indicial case with `R = universalR`). Non-indicial
+and **S5** (the indicial case with `R = ⊤`). Non-indicial
 operators (tense, present progressive) live outside `IsIndicial`;
 `Logic/Temporal/Basic.lean` consumes this boundary. -/
 
@@ -263,19 +263,19 @@ def PropOp.DistribConj {W : Type*} (N : PropOp W) : Prop :=
     `box R` for some accessibility relation `R`. The non-indicial case is
     where tense and other non-Kripke operators live. -/
 def IsIndicial {W : Type*} (N : PropOp W) : Prop :=
-  ∃ R : AccessRel W, N = box R
+  ∃ R : W → W → Prop, N = box R
 
 /-- Every `box R` is indicial. -/
-theorem box_isIndicial (R : AccessRel W) : IsIndicial (box R) :=
+theorem box_isIndicial (R : W → W → Prop) : IsIndicial (box R) :=
   ⟨R, rfl⟩
 
 /-- Every indicial operator is monotone (every Kripke operator is a
     K-operator). -/
-theorem monotone_box (R : AccessRel W) : PropOp.Monotone (box R) :=
+theorem monotone_box (R : W → W → Prop) : PropOp.Monotone (box R) :=
   fun _ _ h w hb => box_mono R h w hb
 
 /-- Every indicial operator distributes over conjunction. -/
-theorem distribConj_box (R : AccessRel W) : PropOp.DistribConj (box R) :=
+theorem distribConj_box (R : W → W → Prop) : PropOp.DistribConj (box R) :=
   fun p q w h => (box_conj R p q w).mp h
 
 /-- S5 necessity as a `PropOp`: `p` holds at all worlds. -/
@@ -286,28 +286,27 @@ def s5Nec {W : Type*} : PropOp W :=
 def s5Poss {W : Type*} : PropOp W :=
   fun p _ => ∃ w, p w
 
-/-- **S5 = box over universal accessibility**: the S5 necessity operator is
+/-- **S5 = box over the universal relation**: the S5 necessity operator is
     the indicial operator with universal accessibility — S5 sits at the top
     of the indicial hierarchy. -/
-theorem s5Nec_eq_box_universalR :
-    s5Nec (W := W) = box universalR := by
+theorem s5Nec_eq_box_top : s5Nec (W := W) = box ⊤ := by
   ext p w
-  simp only [s5Nec, box, universalR, forall_true_left]
+  exact ⟨fun h v _ => h v, fun h v => h v trivial⟩
 
 /-- S5 necessity is indicial. -/
 theorem s5Nec_isIndicial : IsIndicial (s5Nec (W := W)) :=
-  ⟨universalR, s5Nec_eq_box_universalR⟩
+  ⟨⊤, s5Nec_eq_box_top⟩
 
 /-- S5 necessity is the weakest indicial operator: for any `R`,
     `s5Nec p w → box R p w`. Fewer accessible worlds means a stronger
     necessity — Kratzer restriction at the `PropOp` level (`box_restrict`). -/
-theorem s5Nec_weakest (R : AccessRel W) (p : W → Prop) (w : W)
+theorem s5Nec_weakest (R : W → W → Prop) (p : W → Prop) (w : W)
     (h : s5Nec p w) : box R p w :=
   fun v _ => h v
 
-/-- Empty accessibility gives the strongest (vacuously true) necessity. -/
-theorem box_emptyR (p : W → Prop) (w : W) : box (emptyR (W := W)) p w :=
-  fun _ hv => hv.elim
+/-- The empty relation gives the strongest (vacuously true) necessity. -/
+theorem box_bot (p : W → Prop) (w : W) : box (⊥ : W → W → Prop) p w :=
+  fun _ hv => False.elim hv
 
 /-! ### Flat S5 operators
 
@@ -346,13 +345,13 @@ theorem nec_mono {p q : W → Prop} (h : ∀ w, p w → q w) : nec p → nec q :
 /-! ### Decidability over finite worlds -/
 
 instance box_decidable {W : Type*} [Fintype W]
-    (R : AccessRel W) (p : W → Prop) (w : W)
+    (R : W → W → Prop) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (box R p w) :=
   inferInstanceAs (Decidable (∀ v, R w v → p v))
 
 instance diamond_decidable {W : Type*} [Fintype W]
-    (R : AccessRel W) (p : W → Prop) (w : W)
+    (R : W → W → Prop) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (diamond R p w) :=
   inferInstanceAs (Decidable (∃ v, R w v ∧ p v))
@@ -419,7 +418,7 @@ theorem K_bot : K = ⊥ := rfl
 
 /-- Frame conditions required by a logic: for each axiom schema present,
     the corresponding condition on `R`. -/
-def frameConditions {W : Type*} (L : Finset Axiom) (R : AccessRel W) : Prop :=
+def frameConditions {W : Type*} (L : Finset Axiom) (R : W → W → Prop) : Prop :=
   (.M ∈ L → Std.Refl R) ∧
   (.D ∈ L → IsSerial R) ∧
   (.B ∈ L → Std.Symm R) ∧
@@ -428,17 +427,17 @@ def frameConditions {W : Type*} (L : Finset Axiom) (R : AccessRel W) : Prop :=
 
 /-- The syntactic-semantic bridge for `S5`: `frameConditions ModalLogic.S5 R`
     iff `R` is an S5 frame. -/
-@[simp] theorem frameConditions_S5_iff {W : Type*} (R : AccessRel W) :
+@[simp] theorem frameConditions_S5_iff {W : Type*} (R : W → W → Prop) :
     frameConditions S5 R ↔ Std.Refl R ∧ IsEuclidean R := by
   simp [frameConditions, S5]
 
 /-- The syntactic-semantic bridge for `KD45`. -/
-@[simp] theorem frameConditions_KD45_iff {W : Type*} (R : AccessRel W) :
+@[simp] theorem frameConditions_KD45_iff {W : Type*} (R : W → W → Prop) :
     frameConditions KD45 R ↔ IsSerial R ∧ IsTrans W R ∧ IsEuclidean R := by
   simp [frameConditions, KD45]
 
 /-- The syntactic-semantic bridge for `KTB`. -/
-@[simp] theorem frameConditions_KTB_iff {W : Type*} (R : AccessRel W) :
+@[simp] theorem frameConditions_KTB_iff {W : Type*} (R : W → W → Prop) :
     frameConditions KTB R ↔ Std.Refl R ∧ Std.Symm R := by
   simp [frameConditions, KTB]
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -1,31 +1,16 @@
 import Mathlib.Logic.Basic
 import Mathlib.Order.Defs.Unbundled
+import Mathlib.Order.PropInstances
 
 /-!
-# Accessibility relations and modal operators
+# Frame conditions and modal operators
 
-This file defines accessibility relations over an arbitrary world type, the
-frame conditions of modal correspondence theory, and the relational
-`box`/`diamond` of Kripke semantics ([kripke-1963]).
+This file defines the frame conditions of modal correspondence theory for
+accessibility relations `W → W → Prop`, and the relational `box`/`diamond`
+of Kripke semantics ([kripke-1963]).
 -/
 
 namespace ModalLogic
-
-/-! ### Accessibility relations -/
-
-/-- An accessibility relation on worlds. `R w v` means world `v` is
-    accessible from world `w`. -/
-abbrev AccessRel (W : Type*) := W → W → Prop
-
-/-- Agent-indexed accessibility relation: each agent has their own
-    accessibility relation over worlds. -/
-abbrev AgentAccessRel (W E : Type*) := E → AccessRel W
-
-/-- Universal accessibility: every world is accessible from every world. -/
-def universalR {W : Type*} : AccessRel W := fun _ _ => True
-
-/-- Empty accessibility: no world is accessible from any world. -/
-def emptyR {W : Type*} : AccessRel W := fun _ _ => False
 
 /-! ### Frame conditions -/
 
@@ -37,71 +22,72 @@ def emptyR {W : Type*} : AccessRel W := fun _ _ => False
 
     Identical as a `Prop` to `Mathlib.Logic.Relator.LeftTotal R`, but
     packaged as a class with the modal-logic-canonical name. -/
-class IsSerial {W : Type*} (R : AccessRel W) : Prop where
+class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
   serial : ∀ w, ∃ v, R w v
 
 /-- Euclideanness: from any pair of `R`-successors of `w`, each is an
     `R`-successor of the other. No mathlib analogue (modal-specific). -/
-class IsEuclidean {W : Type*} (R : AccessRel W) : Prop where
+class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
 
 /-! ### Bundled frame classes -/
 
 /-- S5 frame: reflexive + euclidean (implies symmetric + transitive). -/
-class IsS5Frame {W : Type*} (R : AccessRel W) : Prop extends Std.Refl R, IsEuclidean R
+class IsS5Frame {W : Type*} (R : W → W → Prop) : Prop extends Std.Refl R, IsEuclidean R
 
 /-- KD45 frame for textbook belief: serial + transitive + euclidean. -/
-class IsKD45Frame {W : Type*} (R : AccessRel W) : Prop
+class IsKD45Frame {W : Type*} (R : W → W → Prop) : Prop
   extends IsSerial R, IsTrans W R, IsEuclidean R
 
 /-- K4-Eucl frame: transitive + euclidean, NOT serial. The frame condition
     for commitment in [stalnaker-1984]-style discourse models, where
     commitment violations (no accessible compliance world) must be
     expressible. -/
-class IsK4EuclFrame {W : Type*} (R : AccessRel W) : Prop
+class IsK4EuclFrame {W : Type*} (R : W → W → Prop) : Prop
   extends IsTrans W R, IsEuclidean R
 
 /-- KTB frame: reflexive + symmetric. The natural setting for tolerance
     semantics ([cobreros-etal-2012]) where each predicate's
     similarity relation is reflexive and symmetric but possibly
     non-transitive. -/
-class IsKTBFrame {W : Type*} (R : AccessRel W) : Prop
+class IsKTBFrame {W : Type*} (R : W → W → Prop) : Prop
   extends Std.Refl R, Std.Symm R
 
 /-- `Rb` is a *belief refinement* of `Rk`: every belief-accessible world is
     knowledge-accessible. The pure subset condition; whether `Rk` is S5
     and `Rb` is KD45 is asserted by separate instance declarations. -/
-class IsBeliefRefinementOf {W : Type*} (Rk Rb : AccessRel W) : Prop where
+class IsBeliefRefinementOf {W : Type*} (Rk Rb : W → W → Prop) : Prop where
   sub : ∀ w v, Rb w v → Rk w v
 
-/-! ### Frame implications and instances -/
+/-! ### Frame implications and instances
+
+The universal relation is `⊤ : W → W → Prop` and the empty relation `⊥`,
+via the pointwise lattice on relations. -/
 
 variable {W : Type*}
 
-instance universalR_isRefl : Std.Refl (universalR (W := W)) := ⟨fun _ => trivial⟩
-instance universalR_isSerial : IsSerial (universalR (W := W)) := ⟨fun w => ⟨w, trivial⟩⟩
-instance universalR_isTrans : IsTrans W (universalR (W := W)) :=
-  ⟨fun _ _ _ _ _ => trivial⟩
-instance universalR_isSymm : Std.Symm (universalR (W := W)) := ⟨fun _ _ _ => trivial⟩
-instance universalR_isEuclidean : IsEuclidean (universalR (W := W)) :=
-  ⟨fun _ _ _ _ _ => trivial⟩
+instance : Std.Refl (⊤ : W → W → Prop) := ⟨fun _ => trivial⟩
+instance : IsSerial (⊤ : W → W → Prop) := ⟨fun w => ⟨w, trivial⟩⟩
+instance : IsTrans W (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
+instance : Std.Symm (⊤ : W → W → Prop) := ⟨fun _ _ _ => trivial⟩
+instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
 /-- Reflexive relations are serial. -/
-instance (priority := 100) Std.Refl.toIsSerial {R : AccessRel W} [h : Std.Refl R] :
+instance (priority := 100) Std.Refl.toIsSerial {R : W → W → Prop} [h : Std.Refl R] :
     IsSerial R := ⟨fun w => ⟨w, h.refl w⟩⟩
 
 /-- Reflexive + Euclidean implies symmetric. -/
-instance (priority := 100) {R : AccessRel W} [hR : Std.Refl R] [hE : IsEuclidean R] :
+instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEuclidean R] :
     Std.Symm R :=
   ⟨fun w v hwv => hE.eucl w v w hwv (hR.refl w)⟩
 
 /-- Reflexive + Euclidean implies transitive. -/
-instance (priority := 100) {R : AccessRel W} [hR : Std.Refl R] [hE : IsEuclidean R] :
+instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEuclidean R] :
     IsTrans W R :=
   ⟨fun w v u hwv hvu => hE.eucl v w u (Std.Symm.symm w v hwv) hvu⟩
 
 /-- Symmetric + transitive implies euclidean. -/
-instance (priority := 100) {R : AccessRel W} [hS : Std.Symm R] [hT : IsTrans W R] :
+instance (priority := 100) {R : W → W → Prop} [hS : Std.Symm R] [hT : IsTrans W R] :
     IsEuclidean R :=
   ⟨fun w v u hwv hwu => hT.trans v w u (hS.symm w v hwv) hwu⟩
 
@@ -113,24 +99,24 @@ instance (priority := 100) {R : AccessRel W} [hS : Std.Symm R] [hT : IsTrans W R
     `⟦□_R φ⟧^w = 1` iff `⟦φ⟧^v = 1` for all `v` with `R(w,v)` — the Kripke
     generalization of the S5 necessity of [dowty-wall-peters-1981]'s IL,
     whose `Intensional.box` is the universal-accessibility special case. -/
-def box (R : AccessRel W) (p : W → Prop) (w : W) : Prop :=
+def box (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
   ∀ v, R w v → p v
 
 /-- Restricted possibility: `◇_R p` at world `w` holds iff `p v` for some
     `v` accessible from `w`. Dual of `box`. -/
-def diamond (R : AccessRel W) (p : W → Prop) (w : W) : Prop :=
+def diamond (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
   ∃ v, R w v ∧ p v
 
 /-! ### Duality -/
 
 /-- Restricted modal duality: `□_R p ↔ ¬◇_R ¬p`. -/
-theorem box_neg_diamond (R : AccessRel W) (p : W → Prop) (w : W) :
+theorem box_neg_diamond (R : W → W → Prop) (p : W → Prop) (w : W) :
     box R p w ↔ ¬ diamond R (fun v => ¬ p v) w :=
   ⟨fun hb ⟨v, hwv, hnp⟩ => hnp (hb v hwv),
    fun h v hwv => Classical.byContradiction fun hnp => h ⟨v, hwv, hnp⟩⟩
 
 /-- Dual form: `◇_R p ↔ ¬□_R ¬p`. -/
-theorem diamond_neg_box (R : AccessRel W) (p : W → Prop) (w : W) :
+theorem diamond_neg_box (R : W → W → Prop) (p : W → Prop) (w : W) :
     diamond R p w ↔ ¬ box R (fun v => ¬ p v) w :=
   ⟨fun ⟨v, hwv, hpv⟩ h => h v hwv hpv,
    fun h => Classical.byContradiction fun hne =>

--- a/Linglib/Logic/Temporal/Basic.lean
+++ b/Linglib/Logic/Temporal/Basic.lean
@@ -32,7 +32,7 @@ namespace Temporal.TWFrame
 variable {Time : Type*} {World : Type*} {Atom : Type*} [LinearOrder Time]
   (F : TWFrame Time World) (V : Atom → Time → World → Prop)
 
-open ModalLogic (box_T box_four box_restrict box_isIndicial IsIndicial universalR)
+open ModalLogic (box_T box_four box_restrict box_isIndicial IsIndicial)
 
 /-! ### Satisfaction clauses -/
 
@@ -94,7 +94,7 @@ theorem sat_N_imp_self {a : OForm Atom} {t : Time} {w : World} :
 
 theorem sat_box_imp_self {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.box a) t w → F.sat V a t w :=
-  fun h => box_T universalR _ _ h
+  fun h => box_T ⊤ _ _ h
 
 theorem sat_N_imp_N_N {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.N a) t w → F.sat V (.N (.N a)) t w := by
@@ -103,7 +103,7 @@ theorem sat_N_imp_N_N {a : OForm Atom} {t : Time} {w : World} :
 
 theorem sat_box_imp_box_box {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.box a) t w → F.sat V (.box (.box a)) t w :=
-  fun h => box_four universalR _ _ h
+  fun h => box_four ⊤ _ _ h
 
 theorem sat_M_imp_N_M {a : OForm Atom} {t : Time} {w : World} :
     F.sat V a.M t w → F.sat V a.M.N t w := by

--- a/Linglib/Logic/Temporal/Defs.lean
+++ b/Linglib/Logic/Temporal/Defs.lean
@@ -58,7 +58,7 @@ namespace TWFrame
 
 variable {Time : Type u} {World : Type v} {Atom : Type*} [LinearOrder Time]
 
-open ModalLogic (box universalR) in
+open ModalLogic (box) in
 /-- Satisfaction `V_{t,w}(A)` ([von-kutschera-1997]) relative to an atomic valuation `V`.
     `G`/`H`/`N`/`box` are `ModalLogic.box` Kripke modalities over, respectively, future
     precedence `<`, past precedence `>`, historical equivalence `sim t`, and the universal
@@ -71,7 +71,7 @@ def sat (F : TWFrame Time World) (V : Atom → Time → World → Prop) :
   | .G a,     t, w => box (· < ·) (fun t' => F.sat V a t' w) t
   | .H a,     t, w => box (· > ·) (fun t' => F.sat V a t' w) t
   | .N a,     t, w => box (F.sim t) (fun w' => F.sat V a t w') w
-  | .box a,   t, w => box universalR (fun w' => F.sat V a t w') w
+  | .box a,   t, w => box ⊤ (fun w' => F.sat V a t w') w
 
 /-- Local entailment in a model: `a` entails `b` iff `b` holds wherever `a` does. -/
 def entails (F : TWFrame Time World) (V : Atom → Time → World → Prop) (a b : OForm Atom) : Prop :=

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -38,7 +38,7 @@ relates RSA speakers to IBR argmax behaviour.
 
 namespace NeoGricean
 
-open ModalLogic (AccessRel box diamond IsSerial)
+open ModalLogic (box diamond IsSerial)
 
 variable {W : Type*}
 
@@ -78,7 +78,7 @@ nonempty. The epistemic square of opposition is
 discharged by this `IsSerial` instance. -/
 
 /-- Epistemic accessibility: from any world, the speaker's live possibilities. -/
-def accessFrom (e : EpistemicState W) : AccessRel W := fun _ w' => w' ∈ e.possible
+def accessFrom (e : EpistemicState W) : W → W → Prop := fun _ w' => w' ∈ e.possible
 
 instance (e : EpistemicState W) : IsSerial (accessFrom e) := ⟨fun _ => e.nonempty⟩
 

--- a/Linglib/Semantics/Modality/EpistemicLogic.lean
+++ b/Linglib/Semantics/Modality/EpistemicLogic.lean
@@ -38,8 +38,7 @@ on finite worlds goes through `Decidable` instances + `decide`.
 namespace Modality.EpistemicLogic
 
 open ModalLogic
-  (AccessRel AgentAccessRel box diamond IsSerial IsEuclidean IsBeliefRefinementOf
-   box_T box_D box_four box_B box_five)
+  (box diamond IsSerial IsEuclidean IsBeliefRefinementOf box_T box_D box_four box_B box_five)
 
 /-! ## Individual Knowledge
 
@@ -48,7 +47,7 @@ This re-uses `box` from `RestrictedModality.lean` with agent-indexed
 accessibility relations. -/
 
 /-- Agent i knows φ at world w: Kᵢ(φ)(w) = □ᵢ φ(w). -/
-def knows {W E : Type*} (Rs : AgentAccessRel W E) (i : E)
+def knows {W E : Type*} (Rs : E → W → W → Prop) (i : E)
     (φ : W → Prop) (w : W) : Prop :=
   box (Rs i) φ w
 
@@ -58,13 +57,13 @@ E_G(φ) holds at w iff every agent in group G knows φ at w.
 E_G(φ) = ∧ᵢ∈G Kᵢ(φ). -/
 
 /-- Everyone in group G knows φ at w. -/
-def everyoneKnows {W E : Type*} (Rs : AgentAccessRel W E)
+def everyoneKnows {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (w : W) : Prop :=
   ∀ i ∈ group, knows Rs i φ w
 
 /-- Everyone knows implies each individual knows. -/
 theorem everyoneKnows_implies_knows {W E : Type*}
-    (Rs : AgentAccessRel W E) (group : List E) (φ : W → Prop) (w : W)
+    (Rs : E → W → W → Prop) (group : List E) (φ : W → Prop) (w : W)
     (i : E) (hi : i ∈ group)
     (h : everyoneKnows Rs group φ w) :
     knows Rs i φ w :=
@@ -80,7 +79,7 @@ there are finitely many truth assignments, the iteration reaches a
 fixed point within a finite number of steps. -/
 
 /-- Iterate "everyone knows" n times: E^n_G(φ). -/
-def everyoneKnowsIter {W E : Type*} (Rs : AgentAccessRel W E)
+def everyoneKnowsIter {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) : ℕ → (W → Prop)
   | .zero => φ
   | .succ n => everyoneKnows Rs group (everyoneKnowsIter Rs group φ n)
@@ -91,13 +90,13 @@ def everyoneKnowsIter {W E : Type*} (Rs : AgentAccessRel W E)
     For finite W with |W| = k, the fixed point is reached within
     2^k iterations (since each iteration can only shrink the set
     of satisfying worlds). -/
-def commonKnowledge {W E : Type*} (Rs : AgentAccessRel W E)
+def commonKnowledge {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (bound : ℕ) (w : W) : Prop :=
   ∀ n, n ≤ bound → everyoneKnowsIter Rs group φ n w
 
 /-- Common knowledge implies everyone knows (at depth 1). -/
 theorem commonKnowledge_implies_everyoneKnows {W E : Type*}
-    (Rs : AgentAccessRel W E) (group : List E) (φ : W → Prop)
+    (Rs : E → W → W → Prop) (group : List E) (φ : W → Prop)
     (bound : ℕ) (w : W) (hbound : 1 ≤ bound)
     (h : commonKnowledge Rs group φ bound w) :
     everyoneKnows Rs group φ w :=
@@ -105,7 +104,7 @@ theorem commonKnowledge_implies_everyoneKnows {W E : Type*}
 
 /-- Common knowledge implies the proposition itself (depth 0). -/
 theorem commonKnowledge_implies_prop {W E : Type*}
-    (Rs : AgentAccessRel W E) (group : List E) (φ : W → Prop)
+    (Rs : E → W → W → Prop) (group : List E) (φ : W → Prop)
     (bound : ℕ) (w : W)
     (h : commonKnowledge Rs group φ bound w) :
     φ w :=
@@ -123,12 +122,12 @@ than common knowledge in the opposite direction:
 D_G(φ) → Kᵢ(φ) for each i, but C_G(φ) → E_G(φ) → Kᵢ(φ). -/
 
 /-- Intersection of accessibility relations for a group. -/
-def groupAccessRel {W E : Type*} (Rs : AgentAccessRel W E)
-    (group : List E) : AccessRel W :=
+def groupAccessRel {W E : Type*} (Rs : E → W → W → Prop)
+    (group : List E) : W → W → Prop :=
   fun w v => ∀ i ∈ group, Rs i w v
 
 /-- Distributed knowledge: D_G(φ)(w) = □_{∩R} φ(w). -/
-def distributedKnowledge {W E : Type*} (Rs : AgentAccessRel W E)
+def distributedKnowledge {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (w : W) : Prop :=
   box (groupAccessRel Rs group) φ w
 
@@ -137,7 +136,7 @@ def distributedKnowledge {W E : Type*} (Rs : AgentAccessRel W E)
     group-accessible world is also i-accessible. Therefore if φ holds
     at all i-accessible worlds, it holds at all group-accessible worlds. -/
 theorem knows_implies_distributedKnowledge {W E : Type*}
-    (Rs : AgentAccessRel W E) (group : List E) (φ : W → Prop) (w : W)
+    (Rs : E → W → W → Prop) (group : List E) (φ : W → Prop) (w : W)
     (i : E) (hi : i ∈ group)
     (h : knows Rs i φ w) :
     distributedKnowledge Rs group φ w := by
@@ -163,28 +162,28 @@ accessible worlds), knowledge is harder to achieve than belief. -/
     Same evaluation as knows, but the accessibility relation
     satisfies KD45 (serial + transitive + Euclidean) rather than
     S5 (reflexive + Euclidean). -/
-def believes {W E : Type*} (Rs : AgentAccessRel W E) (i : E)
+def believes {W E : Type*} (Rs : E → W → W → Prop) (i : E)
     (φ : W → Prop) (w : W) : Prop :=
   box (Rs i) φ w
 
 /-- Everyone in group G believes φ at w. -/
-def everyoneBelieves {W E : Type*} (Rs : AgentAccessRel W E)
+def everyoneBelieves {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (w : W) : Prop :=
   ∀ i ∈ group, believes Rs i φ w
 
 /-- Iterate "everyone believes" n times: EB^n_G(φ). -/
-def everyoneBeliefIter {W E : Type*} (Rs : AgentAccessRel W E)
+def everyoneBeliefIter {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) : ℕ → (W → Prop)
   | .zero => φ
   | .succ n => everyoneBelieves Rs group (everyoneBeliefIter Rs group φ n)
 
 /-- Common belief: CB_G(φ)(w) iff EB^n_G(φ)(w) for all n up to bound. -/
-def commonBelief {W E : Type*} (Rs : AgentAccessRel W E)
+def commonBelief {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (bound : ℕ) (w : W) : Prop :=
   ∀ n, n ≤ bound → everyoneBeliefIter Rs group φ n w
 
 /-- Distributed belief: DB_G(φ)(w) = □_{∩R_B} φ(w). -/
-def distributedBelief {W E : Type*} (Rs : AgentAccessRel W E)
+def distributedBelief {W E : Type*} (Rs : E → W → W → Prop)
     (group : List E) (φ : W → Prop) (w : W) : Prop :=
   box (groupAccessRel Rs group) φ w
 
@@ -194,14 +193,14 @@ def distributedBelief {W E : Type*} (Rs : AgentAccessRel W E)
     pointwise refinement; whether `Rk` is S5 and `Rb` is KD45 is
     a separate stipulation (cf. Hintikka 1962). -/
 theorem knows_implies_believes {W E : Type*}
-    (Rk Rb : AgentAccessRel W E) (i : E) [hRef : IsBeliefRefinementOf (Rk i) (Rb i)]
+    (Rk Rb : E → W → W → Prop) (i : E) [hRef : IsBeliefRefinementOf (Rk i) (Rb i)]
     (φ : W → Prop) (w : W) (h : knows Rk i φ w) :
     believes Rb i φ w := fun v hv => h v (hRef.sub w v hv)
 
 /-- Belief is consistent: Bᵢ(φ) → ◇ᵢφ (the D axiom).
     Follows from seriality of the belief accessibility relation. -/
 theorem believes_consistent {W E : Type*}
-    {Rs : AgentAccessRel W E} (i : E) [IsSerial (Rs i)]
+    {Rs : E → W → W → Prop} (i : E) [IsSerial (Rs i)]
     (φ : W → Prop) (w : W) (h : believes Rs i φ w) :
     diamond (Rs i) φ w :=
   box_D (Rs i) φ w h
@@ -209,7 +208,7 @@ theorem believes_consistent {W E : Type*}
 /-- Positive introspection: Bᵢ(φ) → Bᵢ(Bᵢ(φ)) (the 4 axiom).
     Follows from transitivity of the belief accessibility relation. -/
 theorem believes_positive_introspection {W E : Type*}
-    {Rs : AgentAccessRel W E} (i : E) [IsTrans W (Rs i)]
+    {Rs : E → W → W → Prop} (i : E) [IsTrans W (Rs i)]
     (φ : W → Prop) (w : W) (h : believes Rs i φ w) :
     believes Rs i (believes Rs i φ) w :=
   box_four (Rs i) φ w h
@@ -217,7 +216,7 @@ theorem believes_positive_introspection {W E : Type*}
 /-- Negative introspection: ◇Bφ → □◇Bφ (the 5 axiom).
     Follows from Euclideanness of the belief accessibility relation. -/
 theorem believes_negative_introspection {W E : Type*}
-    {Rs : AgentAccessRel W E} (i : E) [IsEuclidean (Rs i)]
+    {Rs : E → W → W → Prop} (i : E) [IsEuclidean (Rs i)]
     (φ : W → Prop) (w : W) (h : diamond (Rs i) φ w) :
     box (Rs i) (diamond (Rs i) φ) w :=
   box_five (Rs i) φ w h
@@ -227,7 +226,7 @@ theorem believes_negative_introspection {W E : Type*}
     serial but not reflexive, so an agent can believe φ at a world
     where φ is false. -/
 theorem believes_not_veridical :
-    ∃ (W : Type) (E : Type) (Rs : AgentAccessRel W E)
+    ∃ (W : Type) (E : Type) (Rs : E → W → W → Prop)
       (i : E) (φ : W → Prop) (w : W),
       believes Rs i φ w ∧ ¬ φ w := by
   -- W = Bool, single agent: Rs () w v ↔ v = true; φ = (· = true); w = false.
@@ -245,7 +244,7 @@ are common knowledge among the discourse participants. -/
 /-- A common ground is grounded in common knowledge when its context
     set equals the intersection of what is commonly known. -/
 def _root_.CommonGround.groundedIn {W E : Type*}
-    (cg : CommonGround W) (Rs : AgentAccessRel W E) (group : List E)
+    (cg : CommonGround W) (Rs : E → W → W → Prop) (group : List E)
     (bound : ℕ) : Prop :=
   ∀ w, cg.contextSet w ↔
     ∀ p ∈ cg.propositions, commonKnowledge Rs group p bound w
@@ -260,14 +259,14 @@ representation theorems in `EpistemicScale/`). -/
 
 /-- An S5 accessibility relation induces a world ordering for
     `dominationLift`: w ≥ v iff w is accessible from v. -/
-def s5ToWorldOrder {W : Type*} (R : AccessRel W) (w v : W) : Prop :=
+def s5ToWorldOrder {W : Type*} (R : W → W → Prop) (w v : W) : Prop :=
   R v w
 
 /-- An S5 frame yields an `EpistemicSystemW` via l-lifting.
 
     The reflexivity of R gives reflexivity of the world ordering;
     `dominationLiftSystemW` does the rest. -/
-def s5ToSystemW {W : Type*} (R : AccessRel W) [hRefl : Std.Refl R] :
+def s5ToSystemW {W : Type*} (R : W → W → Prop) [hRefl : Std.Refl R] :
     ComparativeProbability.EpistemicSystemW W :=
   ComparativeProbability.dominationLiftSystemW (s5ToWorldOrder R) (fun w => hRefl.refl w)
 

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -51,14 +51,14 @@ variable {W : Type*}
 
     `kratzerR f w w'` iff `w'` satisfies all propositions in `f(w)`,
     i.e., `w' ∈ ⋂f(w)` in Kratzer's notation. -/
-def kratzerR (f : ModalBase W) : AccessRel W :=
+def kratzerR (f : ModalBase W) : W → W → Prop :=
   fun w w' => ∀ p ∈ f w, p w'
 
 /-- Accessibility restricted to best worlds (modal base + ordering source).
 
     `kratzerBestR f g w w'` iff `w'` is among the best accessible worlds
     from `w` — accessible via `f` and maximal under the `g(w)`-ordering. -/
-def kratzerBestR (f : ModalBase W) (g : OrderingSource W) : AccessRel W :=
+def kratzerBestR (f : ModalBase W) (g : OrderingSource W) : W → W → Prop :=
   fun w w' => w' ∈ bestWorlds f g w
 
 /-- With the empty ordering source, best-world accessibility reduces to base

--- a/Linglib/Semantics/Modality/ModalTypes.lean
+++ b/Linglib/Semantics/Modality/ModalTypes.lean
@@ -21,7 +21,7 @@ force-flavor pairs) but conceptually independent.
 - **Here** (`Modality`): `ModalForce`, `ModalFlavor`, `ForceFlavor`,
   `ModalItem`, `ConcordType`, `ModalDecomposition` — linguistic classification
   of modal meanings.
-- **There** (`Intensional`): `AccessRel`, `kripkeEval`, frame conditions
+- **There** (`Intensional`): accessibility relations, `kripkeEval`, frame conditions
   (`IsReflexive`, `IsSerial`, `IsTransitive`, `IsSymmetric`, `IsEuclidean`),
   correspondence theorems,
   the lattice of normal modal logics — mathematical semantics.

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -29,7 +29,7 @@ namespace Semantics.Presupposition.BeliefEmbedding
 open Semantics.Presupposition
 open CommonGround
 open Semantics.Presupposition.Context
-open ModalLogic (AgentAccessRel IsBeliefRefinementOf)
+open ModalLogic (IsBeliefRefinementOf)
 
 variable {W : Type*} {Agent : Type*}
 
@@ -37,17 +37,17 @@ variable {W : Type*} {Agent : Type*}
 /--
 An agent's belief state at a world: the doxastically accessible worlds,
 viewed as a context set. Doxastic accessibility is the agent-indexed
-accessibility relation `ModalLogic.AgentAccessRel` ([hintikka-1962]):
+agent-indexed accessibility relation `E → W → W → Prop` ([hintikka-1962]):
 `Dox agent w w'` means `w'` is compatible with what `agent` believes at `w`.
 -/
-def beliefState (Dox : AgentAccessRel W Agent) (agent : Agent) (w : W) : ContextSet W :=
+def beliefState (Dox : Agent → W → W → Prop) (agent : Agent) (w : W) : ContextSet W :=
   Dox agent w
 
 /--
 An agent believes a proposition at a world iff the proposition holds at all
 doxastically accessible worlds.
 -/
-def believes (Dox : AgentAccessRel W Agent) (agent : Agent) (p : W → Prop) (w : W) : Prop :=
+def believes (Dox : Agent → W → W → Prop) (agent : Agent) (p : W → Prop) (w : W) : Prop :=
   ∀ w', Dox agent w w' → p w'
 
 
@@ -66,7 +66,7 @@ structure BeliefLocalCtx (W : Type*) (Agent : Type*) where
   /-- The global context set -/
   globalCtx : ContextSet W
   /-- The doxastic accessibility relation -/
-  dox : AgentAccessRel W Agent
+  dox : Agent → W → W → Prop
   /-- The attitude holder -/
   agent : Agent
 
@@ -112,7 +112,7 @@ inductive SmokingAgent where
 /--
 John's belief state at each world.
 -/
-def smokingDox : AgentAccessRel SmokingWorld SmokingAgent
+def smokingDox : SmokingAgent → SmokingWorld → SmokingWorld → Prop
   -- At world where Mary used to smoke and John believes it:
   -- John's beliefs are consistent with Mary having smoked
   | .john, .maryUsedToSmoke_johnBelieves_maryQuit =>
@@ -190,7 +190,7 @@ theorem stop_ole_attribution :
 ### Refinement Between Knowledge and Belief Embeddings
 [hintikka-1962]
 
-Doxastic accessibility is `ModalLogic.AgentAccessRel` directly, so
+Doxastic accessibility is `E → W → W → Prop` directly, so
 belief local contexts compose with the epistemic-logic frame conditions:
 when belief pointwise refines knowledge (`IsBeliefRefinementOf`), filtering
 under knowledge embedding implies filtering under belief embedding.
@@ -201,7 +201,7 @@ section Refinement
 variable {W E : Type*}
 
 /-- Build a `BeliefLocalCtx` from an agent-indexed accessibility relation. -/
-def localCtxOf (Rs : AgentAccessRel W E) (ctx : ContextSet W) (i : E) :
+def localCtxOf (Rs : E → W → W → Prop) (ctx : ContextSet W) (i : E) :
     BeliefLocalCtx W E :=
   { globalCtx := ctx
   , dox := Rs
@@ -209,7 +209,7 @@ def localCtxOf (Rs : AgentAccessRel W E) (ctx : ContextSet W) (i : E) :
 
 /-- Belief-accessible worlds are a subset of knowledge-accessible worlds
     when belief refines knowledge pointwise. -/
-theorem localCtx_sub_of_refinement (Rk Rb : AgentAccessRel W E)
+theorem localCtx_sub_of_refinement (Rk Rb : E → W → W → Prop)
     (ctx : ContextSet W) (i : E) [hRef : IsBeliefRefinementOf (Rk i) (Rb i)]
     (w_star : W) :
     ∀ w, (localCtxOf Rb ctx i).atWorld w_star w →
@@ -220,7 +220,7 @@ theorem localCtx_sub_of_refinement (Rk Rb : AgentAccessRel W E)
 /-- If a presupposition is filtered under knowledge embedding, it is also
     filtered under any belief embedding that refines knowledge. -/
 theorem knowledge_filtered_implies_belief_filtered
-    (Rk Rb : AgentAccessRel W E) (ctx : ContextSet W) (i : E)
+    (Rk Rb : E → W → W → Prop) (ctx : ContextSet W) (i : E)
     [IsBeliefRefinementOf (Rk i) (Rb i)] (p : PartialProp W) (w_star : W) :
     ContextSet.entails ((localCtxOf Rk ctx i).atWorld w_star) p.presup →
     ContextSet.entails ((localCtxOf Rb ctx i).atWorld w_star) p.presup := by

--- a/Linglib/Semantics/Quantification/ChoiceFunction.lean
+++ b/Linglib/Semantics/Quantification/ChoiceFunction.lean
@@ -269,20 +269,20 @@ theorem bound_free_collapse {S E : Type*} {O : (S → Prop) → S → Prop}
 the bound and free construals — two situations, a restrictor whose
 extension varies, a CF tracking its index. -/
 theorem bound_free_diverge_box :
-    ∃ (S E : Type) (R : AccessRel S) (f : SkolemCF S E)
+    ∃ (S E : Type) (R : S → S → Prop) (f : SkolemCF S E)
       (P : Intensional.Intension S (E → Prop)) (VP : E → S → Prop) (s₀ : S),
       box R (fun s => VP (f.applyIntensionAt .bound s s₀ P) s) s₀ ∧
       ¬ box R (fun s => VP (f.applyIntensionAt .free s s₀ P) s) s₀ := by
-  refine ⟨Bool, Bool, universalR, fun s _ => s, fun s x => x = s,
+  refine ⟨Bool, Bool, ⊤, fun s _ => s, fun s x => x = s,
     fun x s => x = s, false, fun v _ => rfl, fun h => ?_⟩
   exact Bool.noConfusion (h true trivial)
 
 /-- `box` is not extensional: the operator side of the dichotomy is
 genuine. -/
 theorem box_not_extensionalAt :
-    ∃ (S : Type) (R : AccessRel S) (s₀ : S),
+    ∃ (S : Type) (R : S → S → Prop) (s₀ : S),
       ¬ Intensional.IsExtensionalAt (box R) s₀ := by
-  refine ⟨Bool, universalR, false,
+  refine ⟨Bool, ⊤, false,
     Intensional.not_isExtensionalAt_iff_exists_witness.mpr ?_⟩
   refine ⟨fun s => s = s, fun s => false = s, rfl, fun h => ?_⟩
   exact Bool.noConfusion ((iff_of_eq h).mp (fun v _ => rfl) true trivial)

--- a/Linglib/Studies/Booth2022.lean
+++ b/Linglib/Studies/Booth2022.lean
@@ -165,7 +165,7 @@ def conj (φ ψ : BilatInqProp W) : BilatInqProp W where
 /-! ### §3 Necessity and possibility (Booth Def 14)
 
 `R : W → Set W` is the relevant-worlds accessibility relation
-(equivalent in expressive power to `ModalLogic.AccessRel W
+(equivalent in expressive power to `W → W → Prop
 = W → W → Prop`; Booth uses the curried `W → Set W` form throughout
 his Def 14, which we mirror). -/
 

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -187,7 +187,7 @@ is addressed in §8–§9 below.
 namespace Semantics.Supervaluation.TCS
 
 open ModalLogic
-  (AccessRel IsKTBFrame IsSerial box diamond box_T)
+  (IsKTBFrame IsSerial box diamond box_T)
 open ModalLogic (KTB frameConditions)
 open Consequence (MixedConsequence SatImplies IsSelfDual
   premise_monotone conclusion_monotone mixed_monotone)
@@ -231,10 +231,10 @@ namespace TModel
 
 variable {D Pred : Type*}
 
-/-- The similarity relation as an `AccessRel` — the Kripke frame
+/-- The similarity relation as a Kripke accessibility relation — the frame
     associated with each predicate. By construction this frame is
     reflexive + symmetric, i.e., a **KTB frame** (`ModalLogic.KTB`). -/
-@[reducible] def simAccess (M : TModel D Pred) (P : Pred) : AccessRel D := M.sim P
+@[reducible] def simAccess (M : TModel D Pred) (P : Pred) : D → D → Prop := M.sim P
 
 /-- Per-`(M, P)` KTB-frame instance: lets typeclass search reach
     `Std.Refl` and `Std.Symm` on `M.sim P` from any call site. -/

--- a/Linglib/Studies/Cooper2023/Ch6.lean
+++ b/Linglib/Studies/Cooper2023/Ch6.lean
@@ -25,7 +25,7 @@ single-paper Cooper-textbook replication: only `ChatzikyriakidisEtAl2025`
 
 **Bridges**:
   - ModalTypeSystem ↔ ModalSystem (Bool ↔ Prop)
-  - ModalSystem ↔ AccessRel (Kripke accessibility)
+  - ModalSystem ↔ Kripke accessibility relations
   - know = believe + veridicality (abstract doxastic bridge)
   - Topos → induced necessity/possibility (abstract Kratzer bridge)
 

--- a/Linglib/Studies/Coppock2018.lean
+++ b/Linglib/Studies/Coppock2018.lean
@@ -74,7 +74,7 @@ via the paper's translation: radically counterstance-contingent = strongly discr
 namespace Coppock2018
 
 open Trivalent (Prop3)
-open ModalLogic (AccessRel box)
+open ModalLogic (box)
 open Semantics.Presupposition (PartialProp)
 
 variable {W Ω : Type*}
@@ -275,25 +275,25 @@ a proposition is for it to hold throughout one's accessible outlooks — the Kri
 
 /-- An agent with accessibility `R` **accepts** `p` at `o`: `p` holds at every accessible
 outlook. -/
-def Accepts (R : AccessRel Ω) (p : Prop3 Ω) : Ω → Prop := box R (p · = .true)
+def Accepts (R : Ω → Ω → Prop) (p : Prop3 Ω) : Ω → Prop := box R (p · = .true)
 
 /-- An agent with accessibility `R` **rejects** `p` at `o`: `p` fails at every accessible
 outlook. Rejection is stronger than non-acceptance. -/
-def Rejects (R : AccessRel Ω) (p : Prop3 Ω) : Ω → Prop := box R (p · = .false)
+def Rejects (R : Ω → Ω → Prop) (p : Prop3 Ω) : Ω → Prop := box R (p · = .false)
 
 /-- Two agents **disagree** about `p` at `o` when one accepts it and the other rejects it. -/
-def DisagreeAt (R₁ R₂ : AccessRel Ω) (p : Prop3 Ω) (o : Ω) : Prop :=
+def DisagreeAt (R₁ R₂ : Ω → Ω → Prop) (p : Prop3 Ω) (o : Ω) : Prop :=
     Accepts R₁ p o ∧ Rejects R₂ p o
 
 /-- An agent is **opinionated** about `p` at `o` when they accept or reject it; lack of
 opinionatedness — both live possibilities — is the state *tycka*-reports deny without
 contradiction ([coppock-2018] (38)). -/
-def Opinionated (R : AccessRel Ω) (p : Prop3 Ω) (o : Ω) : Prop :=
+def Opinionated (R : Ω → Ω → Prop) (p : Prop3 Ω) (o : Ω) : Prop :=
     Accepts R p o ∨ Rejects R p o
 
 section Decidability
 
-variable [Fintype Ω] (R : AccessRel Ω) [DecidableRel R] (p : Prop3 Ω) (o : Ω)
+variable [Fintype Ω] (R : Ω → Ω → Prop) [DecidableRel R] (p : Prop3 Ω) (o : Ω)
 
 instance : Decidable (Accepts R p o) :=
   inferInstanceAs (Decidable (∀ o', R o o' → p o' = .true))
@@ -301,7 +301,7 @@ instance : Decidable (Accepts R p o) :=
 instance : Decidable (Rejects R p o) :=
   inferInstanceAs (Decidable (∀ o', R o o' → p o' = .false))
 
-instance (R₂ : AccessRel Ω) [DecidableRel R₂] : Decidable (DisagreeAt R R₂ p o) :=
+instance (R₂ : Ω → Ω → Prop) [DecidableRel R₂] : Decidable (DisagreeAt R R₂ p o) :=
   inferInstanceAs (Decidable (Accepts R p o ∧ Rejects R₂ p o))
 
 instance : Decidable (Opinionated R p o) :=
@@ -346,14 +346,14 @@ non-linguist world. -/
 example : ¬ StronglyDiscretionary3 chiliWorld sexyLinguist := by decide
 
 /-- John's doxastic state: only tasty-outlooks accessible. -/
-abbrev johnR : AccessRel ChiliOutlook := λ _ o' => o'.1 = true
+abbrev johnR : ChiliOutlook → ChiliOutlook → Prop := λ _ o' => o'.1 = true
 
 /-- Mary's doxastic state: only non-tasty-outlooks accessible. -/
-abbrev maryR : AccessRel ChiliOutlook := λ _ o' => o'.1 = false
+abbrev maryR : ChiliOutlook → ChiliOutlook → Prop := λ _ o' => o'.1 = false
 
-/-- An unopinionated agent: every outlook accessible (`ModalLogic.universalR`,
+/-- An unopinionated agent: every outlook accessible (`⊤`,
 inlined for decidability). -/
-abbrev openR : AccessRel ChiliOutlook := λ _ _ => True
+abbrev openR : ChiliOutlook → ChiliOutlook → Prop := λ _ _ => True
 
 /-- **The chili dialogue is a genuine disagreement**: at every outlook, John accepts *tasty*
 and Mary rejects it. -/
@@ -386,29 +386,29 @@ partiality); the presupposition is outlook-independent because discretionariness
 property of `p` against `C`. -/
 
 /-- *think*: bare doxastic acceptance, no presupposition. -/
-def think (R : AccessRel Ω) (p : Prop3 Ω) : PartialProp Ω :=
+def think (R : Ω → Ω → Prop) (p : Prop3 Ω) : PartialProp Ω :=
   ⟨λ _ => True, Accepts R p⟩
 
 /-- *tycka* 'think[opinion]': doxastic acceptance, presupposing that the complement is
 strongly discretionary relative to the information state `C`. -/
-def tycka (R : AccessRel Ω) (p : Prop3 Ω) : PartialProp Ω :=
+def tycka (R : Ω → Ω → Prop) (p : Prop3 Ω) : PartialProp Ω :=
   ⟨λ _ => StronglyDiscretionaryIn ρ C p, Accepts R p⟩
 
 /-- *think* and *tycka* assert the same thing — the verbs differ only in *tycka*'s
 discretionariness presupposition. -/
-theorem think_tycka_same_assertion (R : AccessRel Ω) (p : Prop3 Ω) :
+theorem think_tycka_same_assertion (R : Ω → Ω → Prop) (p : Prop3 Ω) :
     (think R p).assertion = (tycka ρ C R p).assertion := rfl
 
 /-- *tycka*'s subjectivity requirement projects through negation (via `PartialProp.neg`):
 *"#I don't think[opinion] it's Tuesday"* is as bad as the unnegated version. -/
-theorem tycka_presup_survives_neg (R : AccessRel Ω) (p : Prop3 Ω) :
+theorem tycka_presup_survives_neg (R : Ω → Ω → Prop) (p : Prop3 Ω) :
     (PartialProp.neg (tycka ρ C R p)).presup = (tycka ρ C R p).presup := rfl
 
 /-- An objective complement is presupposition failure for *tycka*, given that the state
 leaves some world's refinements open in a way `p` actually cuts — the
 *"#I think[opinion] it's Tuesday / that she's a doctor"* effect. -/
 theorem tycka_undefined_of_objectiveIn {p : Prop3 Ω} (hobj : ObjectiveIn ρ C p)
-    {w : W} (hw : (ρ ⁻¹' {w} ∩ C).Nonempty) (R : AccessRel Ω) (o : Ω) :
+    {w : W} (hw : (ρ ⁻¹' {w} ∩ C).Nonempty) (R : Ω → Ω → Prop) (o : Ω) :
     ¬ (tycka ρ C R p).presup o :=
   λ h =>
     let ⟨o₁, ho₁, o₂, ho₂, hw₁, hw₂, ht, hf⟩ := h w hw

--- a/Linglib/Studies/FaginHalpern1994.lean
+++ b/Linglib/Studies/FaginHalpern1994.lean
@@ -56,7 +56,7 @@ set_option autoImplicit false
 namespace FaginHalpern1994
 
 open ModalLogic
-  (AgentAccessRel AccessRel box IsEuclidean)
+  (box IsEuclidean)
 open Modality.EpistemicLogic (knows everyoneKnows)
 open Modality.EpistemicProbability (WorldCredence nestedThreshold)
 
@@ -75,7 +75,7 @@ open Modality.EpistemicProbability (WorldCredence nestedThreshold)
     Structural conditions (CONS, UNIF, etc.) are separate predicates. -/
 structure KripkeKP (W E : Type*) where
   /-- Agent-indexed accessibility relation (information partition) -/
-  accessRel : AgentAccessRel W E
+  accessRel : E → W → W → Prop
   /-- World-dependent agent credence (probability spaces) -/
   worldCredence : WorldCredence E W
 
@@ -317,7 +317,7 @@ theorem probCKIter_monotone {W E : Type*}
     coincide whenever w' is accessible from w. This is the key property
     that makes S5 relations equivalence relations: accessibility classes
     are either identical or disjoint. -/
-private theorem s5_access_eq {W : Type*} {R : AccessRel W}
+private theorem s5_access_eq {W : Type*} {R : W → W → Prop}
     [Std.Refl R] [IsEuclidean R]
     {w w' : W} (hAcc : R w w') :
     ∀ v, R w v ↔ R w' v := by

--- a/Linglib/Studies/Heim1992Projection.lean
+++ b/Linglib/Studies/Heim1992Projection.lean
@@ -38,8 +38,7 @@ namespace Heim1992
 
 open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
-open ModalLogic (IsSerial IsEuclidean IsS5Frame IsKD45Frame
-  IsBeliefRefinementOf)
+open ModalLogic (IsSerial IsEuclidean IsS5Frame IsKD45Frame IsBeliefRefinementOf)
 open Semantics.Presupposition.Context (presupSatisfied)
 open Semantics.Presupposition.BeliefEmbedding
 

--- a/Linglib/Studies/Hintikka1962.lean
+++ b/Linglib/Studies/Hintikka1962.lean
@@ -17,7 +17,7 @@ the same substrate lemma to epistemic accessibility.
 namespace Hintikka1962
 
 open Discourse.Commitment.Frame
-open ModalLogic (box_not_moore AgentAccessRel IsSerial)
+open ModalLogic (box_not_moore IsSerial)
 open Modality.EpistemicLogic (knows)
 
 variable {W A : Type*}
@@ -65,7 +65,7 @@ theorem true_mem_mooreContent :
     "p but I don't know whether p" is unknowable. Direct corollary of
     `box_not_moore` for `knows`. -/
 theorem knowledge_unknowable
-    {E : Type*} (Rs : AgentAccessRel W E) (i : E)
+    {E : Type*} (Rs : E → W → W → Prop) (i : E)
     [IsSerial (Rs i)] [IsTrans W (Rs i)]
     (p : W → Prop) (w : W) :
     ¬ knows Rs i (fun v => p v ∧ ¬ knows Rs i p v) w :=

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -125,7 +125,6 @@ namespace KeshetAbney2024
 
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context idUp)
-open ModalLogic (AccessRel)
 
 
 -- ============================================================
@@ -155,7 +154,7 @@ def αWolf : FLabel := ⟨0⟩
 def vWolf : IVar := ⟨0⟩
 
 /-- Epistemic accessibility from actual world. -/
-def sAccess : AccessRel SWorld
+def sAccess : SWorld → SWorld → Prop
   | .actual, .wolfIn => True
   | .actual, .noWolf => True
   | _, _ => False
@@ -619,7 +618,7 @@ def ibWorlds : List IBWorld := [.actual, .burgerW]
 def αBurger : FLabel := ⟨10⟩
 def vBurger : IVar := ⟨10⟩
 
-def ibAccess : AccessRel IBWorld
+def ibAccess : IBWorld → IBWorld → Prop
   | .actual, .actual => True
   | .actual, .burgerW => True
   | _, _ => False
@@ -700,7 +699,7 @@ def αAnimal : FLabel := ⟨11⟩
 def vAnimal : IVar := ⟨11⟩
 
 /-- Realistic epistemic: actual accessible from itself. -/
-def iaAccess : AccessRel IAWorld
+def iaAccess : IAWorld → IAWorld → Prop
   | .actual, .actual => True
   | .actual, .shedW => True
   | _, _ => False
@@ -781,7 +780,7 @@ def αMA : FLabel := ⟨12⟩
 def vMA : IVar := ⟨12⟩
 
 /-- Realistic epistemic: actual accessible from itself, plus two alternatives. -/
-def maAccess : AccessRel MAWorld
+def maAccess : MAWorld → MAWorld → Prop
   | .actual, _ => True
   | _, _ => False
 
@@ -864,7 +863,7 @@ def αWinner : FLabel := ⟨20⟩
 def vWinner : IVar := ⟨20⟩
 
 /-- Epistemic: speaker considers all outcomes possible. -/
-def pcAccess : AccessRel PCWorld
+def pcAccess : PCWorld → PCWorld → Prop
   | .actual, _ => True
   | _, _ => False
 
@@ -1316,12 +1315,12 @@ def αWitch : FLabel := ⟨40⟩
 def vWitch : IVar := ⟨40⟩
 
 /-- Hob's doxastic accessibility: Hob believes from actual to hobBelief. -/
-def hobAccess : AccessRel HNWorld
+def hobAccess : HNWorld → HNWorld → Prop
   | .actual, .hobBelief => True
   | _, _ => False
 
 /-- Nob's bouletic accessibility: Nob wonders from actual to nobWonder. -/
-def nobAccess : AccessRel HNWorld
+def nobAccess : HNWorld → HNWorld → Prop
   | .actual, .nobWonder => True
   | _, _ => False
 

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -42,7 +42,7 @@ namespace KeshetAbney2024.PIP.Bridges
 
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context)
-open ModalLogic (AccessRel box diamond)
+open ModalLogic (box diamond)
 open ModalLogic (frameConditions)
 
 
@@ -265,12 +265,12 @@ it is intentionally omitted.
 /--
 A reflexive accessibility relation satisfies ModalLogic.T's frame condition.
 
-Stated for the Prop-valued `AccessRel`/`Std.Refl`/`frameConditions` API in
+Stated for the Prop-valued `Std.Refl`/`frameConditions` API in
 `Intensional` — the same accessibility type PIP's modal
 operators now use directly.
 -/
 theorem reflexive_satisfies_T {W : Type*}
-    (R : ModalLogic.AccessRel W) [hRefl : Std.Refl R] :
+    (R : W → W → Prop) [hRefl : Std.Refl R] :
     frameConditions ModalLogic.T R :=
   ⟨fun _ => hRefl, fun h => absurd h (by decide), fun h => absurd h (by decide),
    fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
@@ -300,13 +300,13 @@ The formal connection is established via `Intensional.box`:
 
 Direct import of `Semantics/Modality/Kratzer/` is not possible
 because Kratzer's implementation is monomorphic over `World4`. The
-correspondence is structural (via `AccessRel` ≅ `ModalBase`) rather
+correspondence is structural (via accessibility ≅ `ModalBase`) rather
 than definitional.
 -/
 
 /--
 Full Kratzer bridge: PIP's three-argument `mustBase` agrees with
-`box` when the modal base comes from an `AccessRel` and the restriction
+`box` when the modal base comes from an accessibility relation and the restriction
 is tautological.
 
 The composition: `mustBase (accessRelToBase R w) ⊤ {w' | φ.truth w'}` ↔
@@ -314,7 +314,7 @@ The composition: `mustBase (accessRelToBase R w) ⊤ {w' | φ.truth w'}` ↔
 "the body holds at every R-accessible world from w".
 -/
 theorem mustBase_agrees_box {W D : Type*}
-    (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+    (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     mustBase (accessRelToBase R w) Set.univ { w' | φ.truth w' } ↔
     box R φ.truth w := by
   simp only [mustBase, accessRelToBase, Set.inter_univ, Set.subset_def,

--- a/Linglib/Studies/KeshetAbney2024/Composition.lean
+++ b/Linglib/Studies/KeshetAbney2024/Composition.lean
@@ -26,7 +26,7 @@ type and connected to it via bridge theorems.
 
 namespace KeshetAbney2024.PIP
 
-open ModalLogic (AccessRel box diamond)
+open ModalLogic (box diamond)
 
 
 -- ============================================================
@@ -192,7 +192,7 @@ Three-argument necessity: the modal base β restricted by W₁ is
 included in W₂. When W₁ = ⊤, reduces to β ⊆ W₂.
 
 The modal base β corresponds to `accessRelToBase R w` for an
-`AccessRel W` from `Intensional`. `PIP.Connectives.must`
+`W → W → Prop` from `Intensional`. `PIP.Connectives.must`
 provides the dynamic implementation; `must_truth_iff_mustBase` below
 bridges the static `PIPExprF.must` to this set-based formulation.
 Cf. `Modality.Kratzer.simpleNecessity` for the
@@ -237,13 +237,13 @@ theorem modal_duality (β W₁ W₂ : Set W) :
   exact gq_duality (β ∩ W₁) W₂
 
 /-- Convert an accessibility relation to a modal base at world w. -/
-def accessRelToBase (R : AccessRel W) (w : W) : Set W :=
+def accessRelToBase (R : W → W → Prop) (w : W) : Set W :=
   { w' | R w w' }
 
 /-- `PIPExprF.must R φ` truth agrees with three-argument `mustBase`.
     Direct, since `must` truth is `box` and `mustBase` is set inclusion. -/
 theorem must_truth_iff_mustBase {D : Type*}
-    (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+    (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     (PIPExprF.must R φ).truth w ↔
     mustBase (accessRelToBase R w) Set.univ { w' | φ.truth w' } := by
   simp only [mustBase, accessRelToBase, Set.inter_univ, Set.subset_def, Set.mem_setOf_eq,
@@ -251,7 +251,7 @@ theorem must_truth_iff_mustBase {D : Type*}
 
 /-- `PIPExprF.might R φ` truth agrees with three-argument `mightBase`. -/
 theorem might_truth_iff_mightBase {D : Type*}
-    (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+    (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     (PIPExprF.might R φ).truth w ↔
     mightBase (accessRelToBase R w) Set.univ { w' | φ.truth w' } := by
   simp only [mightBase, accessRelToBase, Set.inter_univ, Set.Nonempty,

--- a/Linglib/Studies/KeshetAbney2024/Connectives.lean
+++ b/Linglib/Studies/KeshetAbney2024/Connectives.lean
@@ -24,7 +24,7 @@ PIP's modals are generalized quantifiers over worlds (paper Section 2.5):
 - MIGHT^β_w(W₁, W₂) ≜ SOME(β_w ∩ W₁, W₂)
 - MUST^β_w(W₁, W₂) ≜ EVERY(β_w ∩ W₁, W₂)
 
-Our encoding parameterizes by an accessibility relation (`KeshetAbney2024.PIP.AccessRel`,
+Our encoding parameterizes by an accessibility relation (`W → W → Prop`,
 equivalent to a Kratzer modal base β) and quantifies over accessible worlds.
 The grounding theorem `must_truth_agrees_box` proves that PIP's `must`
 produces the same truth conditions as `Intensional.box`.
@@ -35,7 +35,7 @@ namespace KeshetAbney2024.PIP
 
 open DynamicSemantics
 open DynamicSemantics.ICDRT
-open ModalLogic (AccessRel box diamond box_T)
+open ModalLogic (box diamond box_T)
 
 variable {W E : Type*}
 
@@ -165,16 +165,16 @@ would produce no accessible-world pairs for universal modals to check,
 making must/would vacuously satisfied and losing the modal subordination
 mechanism.
 -/
-def modalExpand (c : ICDRT.Context W E) (access : AccessRel W) : ICDRT.Context W E :=
+def modalExpand (c : ICDRT.Context W E) (access : W → W → Prop) : ICDRT.Context W E :=
   c ∪ { gw | ∃ w₀, (gw.1, w₀) ∈ c ∧ access w₀ gw.2 }
 
 /-- Modal expansion includes all original pairs. -/
-theorem modalExpand_superset (c : ICDRT.Context W E) (access : AccessRel W) :
+theorem modalExpand_superset (c : ICDRT.Context W E) (access : W → W → Prop) :
     c ⊆ modalExpand c access := by
   intro x hx; left; exact hx
 
 /-- Modal expansion adds accessible-world pairs. -/
-theorem modalExpand_adds_accessible (c : ICDRT.Context W E) (access : AccessRel W)
+theorem modalExpand_adds_accessible (c : ICDRT.Context W E) (access : W → W → Prop)
     (g : ICDRT.Assignment W E) (w₀ w₁ : W)
     (hc : (g, w₀) ∈ c) (hacc : access w₀ w₁) :
     (g, w₁) ∈ modalExpand c access := by
@@ -199,7 +199,7 @@ subordination work: "A wolf might come in" introduces the wolf (local)
 under the modal's world quantification (external). The wolf's descriptive
 content (via the label) is accessible in subsequent discourse.
 -/
-def must (access : AccessRel W) (allWorlds : List W)
+def must (access : W → W → Prop) (allWorlds : List W)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
     let bodyResult := body { d with info := modalExpand d.info access }
@@ -218,7 +218,7 @@ Modal possibility (might): existential quantification over accessible worlds.
 Like `must`, the body is evaluated on an expanded context (via `modalExpand`)
 and the world variable is external.
 -/
-def might (access : AccessRel W) (allWorlds : List W)
+def might (access : W → W → Prop) (allWorlds : List W)
     (body : PUpdate W E) : PUpdate W E :=
   λ d =>
     let bodyResult := body { d with info := modalExpand d.info access }
@@ -235,7 +235,7 @@ In the paper's modal subordination analysis, "It would eat you first" is
 analyzed as MUST with the same accessibility relation from "might" in the
 preceding sentence. So `would` = `must` with the inherited modal base.
 -/
-def would (access : AccessRel W) (allWorlds : List W)
+def would (access : W → W → Prop) (allWorlds : List W)
     (body : PUpdate W E) : PUpdate W E :=
   must access allWorlds body
 
@@ -265,12 +265,12 @@ Labels survive modal operators.
 Labels registered inside a modal scope propagate to the outer
 discourse state. This is what enables modal subordination.
 -/
-theorem labels_survive_must (access : AccessRel W) (allWorlds : List W)
+theorem labels_survive_must (access : W → W → Prop) (allWorlds : List W)
     (body : PUpdate W E) (desc : Description W E)
     (h : (body { d with info := modalExpand d.info access }).labels.lookup α = some desc) :
     (must access allWorlds body d).labels.lookup α = some desc := h
 
-theorem labels_survive_might (access : AccessRel W) (allWorlds : List W)
+theorem labels_survive_might (access : W → W → Prop) (allWorlds : List W)
     (body : PUpdate W E) (desc : Description W E)
     (h : (body { d with info := modalExpand d.info access }).labels.lookup α = some desc) :
     (might access allWorlds body d).labels.lookup α = some desc := h
@@ -289,10 +289,10 @@ Specifically: a pair (g, w₀) survives `must R allWorlds (atom p)` iff
 `box R (p g) w₀` — the body predicate holds at all R-accessible worlds.
 This connects PIP's discourse-update modals to the standard Kripke semantics
 used throughout `Semantics/Modality/`. Since accessibility is now the
-project-canonical Prop-valued `AccessRel`, the identity is direct — no lift.
+project-canonical Prop-valued `W → W → Prop`, the identity is direct — no lift.
 -/
 theorem must_truth_agrees_box [Fintype W]
-    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (R : W → W → Prop) (p : ICDRT.Assignment W E → W → Prop)
     (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info) :
     ((g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) ↔
@@ -312,7 +312,7 @@ theorem must_truth_agrees_box [Fintype W]
 PIP's `might` agrees with `diamond`.
 -/
 theorem might_truth_agrees_diamond [Fintype W]
-    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (R : W → W → Prop) (p : ICDRT.Assignment W E → W → Prop)
     (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info) :
     ((g, w₀) ∈ (might R (Finset.univ : Finset W).toList (atom p) d).info) ↔
@@ -335,7 +335,7 @@ modal base guarantees the description holds at the evaluation world — from
 `ModalLogic.box_T`.
 -/
 theorem must_realistic_of_refl [Fintype W]
-    (R : AccessRel W) [Std.Refl R]
+    (R : W → W → Prop) [Std.Refl R]
     (p : ICDRT.Assignment W E → W → Prop)
     (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hd : (g, w₀) ∈ d.info)
@@ -352,7 +352,7 @@ This is the version that applies to non-globally-reflexive relations
 [kratzer-1991]'s realistic modal base without requiring global reflexivity.
 -/
 theorem must_realistic_at [Fintype W]
-    (R : AccessRel W) (p : ICDRT.Assignment W E → W → Prop)
+    (R : W → W → Prop) (p : ICDRT.Assignment W E → W → Prop)
     (d : Discourse W E) (g : ICDRT.Assignment W E) (w₀ : W)
     (hRefl_at : R w₀ w₀)
     (hmust : (g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) :

--- a/Linglib/Studies/KeshetAbney2024/Expr.lean
+++ b/Linglib/Studies/KeshetAbney2024/Expr.lean
@@ -41,7 +41,7 @@ all `X ≡ φ` definitions regardless of their structural position.
 
 namespace KeshetAbney2024.PIP
 
-open ModalLogic (AccessRel box diamond)
+open ModalLogic (box diamond)
 
 /-- A finite domain of individuals for PIP quantifier evaluation. -/
 class FiniteDomain (D : Type*) where
@@ -87,10 +87,10 @@ inductive PIPExprF (W : Type*) (D : Type*) where
   | labelDef (label : FLabel) (φ : PIPExprF W D)
   /-- Modal necessity: □_R φ (MUST).
       Universal quantification over R-accessible worlds. -/
-  | must (R : AccessRel W) (φ : PIPExprF W D)
+  | must (R : W → W → Prop) (φ : PIPExprF W D)
   /-- Modal possibility: ◇_R φ (MIGHT).
       Existential quantification over R-accessible worlds. -/
-  | might (R : AccessRel W) (φ : PIPExprF W D)
+  | might (R : W → W → Prop) (φ : PIPExprF W D)
 
 
 -- ============================================================
@@ -233,7 +233,7 @@ theorem felicitousF_exists (body : D → PIPExprF W D) (w : W) :
     (∀ d, (body d).felicitous w) := rfl
 
 /-- Modal necessity felicity is universal over accessible worlds. -/
-theorem felicitousF_must (R : AccessRel W) (φ : PIPExprF W D)
+theorem felicitousF_must (R : W → W → Prop) (φ : PIPExprF W D)
     (w : W) :
     (PIPExprF.must R φ).felicitous w =
     box R φ.felicitous w := rfl

--- a/Linglib/Studies/KeshetAbney2024/Felicity.lean
+++ b/Linglib/Studies/KeshetAbney2024/Felicity.lean
@@ -57,7 +57,7 @@ world and assignment consistent with γ.
 
 namespace KeshetAbney2024.PIP.Felicity
 
-open ModalLogic (AccessRel box diamond)
+open ModalLogic (box diamond)
 
 variable {W : Type*}
 
@@ -309,19 +309,19 @@ theorem existsF_forallF_felicity_agree (body : D → PIPExprF W D) (w : W) :
 
 /-- F(□_R φ) iff φ is felicitous at every R-accessible world.
     Holds by definition (`must` felicity is `box`). -/
-theorem mustF_felicitous_iff (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+theorem mustF_felicitous_iff (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     (PIPExprF.must R φ).felicitous w ↔ ∀ w', R w w' → φ.felicitous w' :=
   Iff.rfl
 
 /-- F(◇_R φ) iff φ is felicitous at every R-accessible world.
     Truth is existential for ◇ but felicity is universal for both. -/
-theorem mightF_felicitous_iff (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+theorem mightF_felicitous_iff (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     (PIPExprF.might R φ).felicitous w ↔ ∀ w', R w w' → φ.felicitous w' :=
   Iff.rfl
 
 /-- □ and ◇ have identical felicity clauses — both project universally.
     The asymmetry between must and might is in truth, not felicity. -/
-theorem mustF_mightF_felicity_agree (R : AccessRel W) (φ : PIPExprF W D) (w : W) :
+theorem mustF_mightF_felicity_agree (R : W → W → Prop) (φ : PIPExprF W D) (w : W) :
     (PIPExprF.must R φ).felicitous w =
     (PIPExprF.might R φ).felicitous w := rfl
 
@@ -367,7 +367,7 @@ No `Nonempty` hypothesis needed: ψ varies with w', so this is a
 direct instance of `∀x, (P x ∧ Q x) ↔ (∀x, P x) ∧ (∀x, Q x)`.
 -/
 theorem mustF_presup_factored
-    (R : AccessRel W) (φ : PIPExprF W D) (ψ : W → Prop) (w : W) :
+    (R : W → W → Prop) (φ : PIPExprF W D) (ψ : W → Prop) (w : W) :
     (PIPExprF.must R (PIPExprF.presup φ ψ)).felicitous w ↔
     (∀ w', R w w' → φ.felicitous w') ∧
     (∀ w', R w w' → ψ w') := by
@@ -377,7 +377,7 @@ theorem mustF_presup_factored
 
 /-- Factored projection through ◇ — identical structure to □. -/
 theorem mightF_presup_factored
-    (R : AccessRel W) (φ : PIPExprF W D) (ψ : W → Prop) (w : W) :
+    (R : W → W → Prop) (φ : PIPExprF W D) (ψ : W → Prop) (w : W) :
     (PIPExprF.might R (PIPExprF.presup φ ψ)).felicitous w ↔
     (∀ w', R w w' → φ.felicitous w') ∧
     (∀ w', R w w' → ψ w') := by
@@ -407,7 +407,7 @@ theorem forallF_presup_projection
 
 /-- Presupposition extraction through □ at an accessible world. -/
 theorem mustF_presup_at_accessible
-    (R : AccessRel W) (φ : PIPExprF W D) (ψ : W → Prop) (w w' : W)
+    (R : W → W → Prop) (φ : PIPExprF W D) (ψ : W → Prop) (w w' : W)
     (hR : R w w')
     (hF : (PIPExprF.must R (PIPExprF.presup φ ψ)).felicitous w) :
     ψ w' :=
@@ -415,7 +415,7 @@ theorem mustF_presup_at_accessible
 
 /-- Presupposition extraction through ◇ at an accessible world. -/
 theorem mightF_presup_at_accessible
-    (R : AccessRel W) (φ : PIPExprF W D) (ψ : W → Prop) (w w' : W)
+    (R : W → W → Prop) (φ : PIPExprF W D) (ψ : W → Prop) (w w' : W)
     (hR : R w w')
     (hF : (PIPExprF.might R (PIPExprF.presup φ ψ)).felicitous w) :
     ψ w' :=

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -68,7 +68,7 @@ The §3 prima-facie challenge is formalized abstractly:
 hypothesis on the conception. Substantive Ney soundness — that the
 resolution holds under a *realistic* CommonGround operator derived from
 `commonBelief` ([stalnaker-2002]) — requires a `CommonGround.toAgentAccess :
-CommonGround W → AgentAccessRel W E` bridge in `Discourse/CommonGround.lean`
+CommonGround W → E → W → W → Prop` bridge in `Discourse/CommonGround.lean`
 that does not yet exist. Until that bridge lands, the resolution
 theorems are witnessed by toy operators (a degenerate `inCG := · = True`
 that distinguishes intersection-CommonGround-transparency from union-CommonGround-transparency

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -53,7 +53,6 @@ needs QUD/information-structure machinery).
 namespace TonhauserEtAl2013
 
 open CommonGround
-open ModalLogic (AgentAccessRel)
 open Semantics.Presupposition
 open Semantics.Presupposition.Context
 open Semantics.Presupposition.BeliefEmbedding
@@ -106,7 +105,7 @@ structure SCF_Allows (W : Type*) where
 OLE=yes means: under belief embedding, the local context is the attitude
 holder's belief state. The projective content is attributed to the holder.
 -/
-def OLE_Obligatory (Dox : AgentAccessRel W Agent)
+def OLE_Obligatory (Dox : Agent → W → W → Prop)
     (content : Set W) : Prop :=
   ∀ (c : ContextSet W) (agent : Agent) (w_star : W),
     c w_star →
@@ -124,7 +123,7 @@ but NOT in the attitude holder's beliefs. The content is "speaker-anchored"
 
 Class B triggers (expressives) and Class D triggers exhibit this behavior.
 -/
-def OLE_NotObligatory (Dox : AgentAccessRel W Agent)
+def OLE_NotObligatory (Dox : Agent → W → W → Prop)
     (content : Set W) : Prop :=
   ∃ (c : ContextSet W) (agent : Agent) (w_star : W),
     c w_star ∧

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -188,7 +188,7 @@ open CommonGround (ContextSet)
 
 /-- Local Bool-valued accessibility used by Wang2025 for `List.all` evaluation
 of the speaker-K operator. The Prop-valued canonical version lives in
-`ModalLogic.AccessRel`; lift via
+`W → W → Prop`; lift via
 `fun a b => R a b = true` to bridge. -/
 abbrev BAccessRel (W : Type*) := W → W → Bool
 open Pragmatics.Expressives (TwoDimProp)

--- a/Linglib/Studies/ZwickyPullum1983.lean
+++ b/Linglib/Studies/ZwickyPullum1983.lean
@@ -400,7 +400,7 @@ an accessibility relation under which the two scope readings diverge. -/
 section ScopeBridge
 
 open Modality (ModalForce)
-open ModalLogic (AccessRel box diamond)
+open ModalLogic (box diamond)
 
 abbrev World := Fin 4
 
@@ -452,7 +452,7 @@ every other world sees only itself.
 This suffices to separate ¬◇P from ◇¬P and ¬□P from □¬P at w0:
 when P holds at w1 and fails at w2, both accessible worlds disagree,
 so ◇P and ◇¬P are both true while ¬◇P is false. -/
-private def kripkeR : AccessRel World := fun w v =>
+private def kripkeR : World → World → Prop := fun w v =>
   match w with
   | 0 => v = (1 : World) ∨ v = (2 : World)
   | 1 => v = (1 : World)
@@ -485,7 +485,7 @@ There exists a Kripke accessibility relation where ¬◇P ≠ ◇¬P: when w0
 accesses worlds where P differs, ◇P and ◇¬P are both true, so
 ¬◇P = false but ◇¬P = true. -/
 theorem neg_over_poss_ne_poss_over_neg :
-    ∃ (R : AccessRel World),
+    ∃ (R : World → World → Prop),
     ¬(∀ (p : World → Prop) (w : World),
       ¬ diamond R p w ↔ diamond R (fun w' => ¬ p w') w) := by
   refine ⟨kripkeR, ?_⟩
@@ -499,7 +499,7 @@ There exists a Kripke accessibility relation where ¬□P ≠ □¬P: failing
 to be necessary (¬□P = true when P fails at w2) is weaker than being
 necessarily false (□¬P = false when P holds at w1). -/
 theorem neg_over_nec_ne_nec_over_neg :
-    ∃ (R : AccessRel World),
+    ∃ (R : World → World → Prop),
     ¬(∀ (p : World → Prop) (w : World),
       ¬ box R p w ↔ box R (fun w' => ¬ p w') w) := by
   refine ⟨kripkeR, ?_⟩


### PR DESCRIPTION
Completes the mathlib-vocabulary pass on the modal substrate: the law-free `AccessRel`/`AgentAccessRel` abbrevs dissolve onto `W → W → Prop` / `E → W → W → Prop` inline (mathlib never aliases relation types), and `universalR`/`emptyR` become `⊤`/`⊥` via the pointwise lattice on relations — mathlib's canonical spellings, definitionally identical. Frame instances now sit on `(⊤ : W → W → Prop)`; `s5Nec_eq_box_top`, `box_bot` replace the `-R`-named theorems.

`Semantics.Attitudes.Doxastic.AccessRel` (the two-parameter alias) and its `BAgentAccessRel`/`PairAccessRel` descendants are a separate follow-up.
