### PR TITLE
refactor(Logic/Modal): frame classes join the lattice; bridges to iffs

### DIFF
--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -28,7 +28,7 @@ commitment to belief.
 
 namespace Discourse.Commitment.Frame
 
-open ModalLogic (IsKD45Frame IsK4EuclFrame IsEuclidean box diamond box_K box_four)
+open ModalLogic (IsKD45Frame IsK45Frame IsEuclidean box diamond box_K box_four)
 open Modality.EpistemicLogic (knows)
 
 /-- Pair-indexed deontic accessibility: `commitment a b w v` means at
@@ -50,7 +50,7 @@ structure CommitmentState (W : Type*) (A : Type*) where
   belief_kd45 : ∀ a, IsKD45Frame (belief a)
   /-- Commitment is K4-Euclidean (no seriality — violations are
       expressible) per pair. -/
-  commitment_k4eucl : ∀ a b, IsK4EuclFrame (commitment a b)
+  commitment_k4eucl : ∀ a b, IsK45Frame (commitment a b)
 
 namespace CommitmentState
 variable {W : Type*} {A : Type*}
@@ -58,7 +58,7 @@ variable {W : Type*} {A : Type*}
 instance (c : CommitmentState W A) (a : A) : IsKD45Frame (c.belief a) :=
   c.belief_kd45 a
 
-instance (c : CommitmentState W A) (a b : A) : IsK4EuclFrame (c.commitment a b) :=
+instance (c : CommitmentState W A) (a b : A) : IsK45Frame (c.commitment a b) :=
   c.commitment_k4eucl a b
 
 /-- The trivial state: every world doxastically/commitmentally

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -214,6 +214,33 @@ theorem self_imp_box_flip_diamond (R : W → W → Prop) (p : W → Prop) (w : W
     (h : p w) : box (flip R) (diamond R p) w :=
   fun _ hv => ⟨w, hv, h⟩
 
+/-! ### Bundled frame classes
+
+Named frame classes for the logics of `ModalLogic.frameConditions`; the
+per-logic correspondence theorems (`frameConditions_S5_iff`, …) live with
+the lattice below. -/
+
+/-- S5 frame: reflexive + euclidean (implies symmetric + transitive). -/
+class IsS5Frame {W : Type*} (R : W → W → Prop) : Prop extends Std.Refl R, IsEuclidean R
+
+/-- KD45 frame for textbook belief: serial + transitive + euclidean. -/
+class IsKD45Frame {W : Type*} (R : W → W → Prop) : Prop
+  extends IsSerial R, IsTrans W R, IsEuclidean R
+
+/-- K45 frame: transitive + euclidean, NOT serial. The frame condition
+    for commitment in [stalnaker-1984]-style discourse models, where
+    commitment violations (no accessible compliance world) must be
+    expressible. -/
+class IsK45Frame {W : Type*} (R : W → W → Prop) : Prop
+  extends IsTrans W R, IsEuclidean R
+
+/-- KTB frame: reflexive + symmetric. The natural setting for tolerance
+    semantics ([cobreros-etal-2012]) where each predicate's
+    similarity relation is reflexive and symmetric but possibly
+    non-transitive. -/
+class IsKTBFrame {W : Type*} (R : W → W → Prop) : Prop
+  extends Std.Refl R, Std.Symm R
+
 /-! ### S5 and KD45 frames -/
 
 /-- With reflexive + euclidean accessibility (= S5 frame conditions),
@@ -428,17 +455,35 @@ def frameConditions {W : Type*} (L : Finset Axiom) (R : W → W → Prop) : Prop
 /-- The syntactic-semantic bridge for `S5`: `frameConditions ModalLogic.S5 R`
     iff `R` is an S5 frame. -/
 @[simp] theorem frameConditions_S5_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions S5 R ↔ Std.Refl R ∧ IsEuclidean R := by
-  simp [frameConditions, S5]
+    frameConditions S5 R ↔ IsS5Frame R :=
+  ⟨fun h => haveI := h.1 (by decide); haveI := h.2.2.2.2 (by decide); ⟨⟩,
+   fun h => ⟨fun _ => h.toRefl, fun hm => absurd hm (by decide),
+             fun hm => absurd hm (by decide), fun hm => absurd hm (by decide),
+             fun _ => h.toIsEuclidean⟩⟩
 
 /-- The syntactic-semantic bridge for `KD45`. -/
 @[simp] theorem frameConditions_KD45_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions KD45 R ↔ IsSerial R ∧ IsTrans W R ∧ IsEuclidean R := by
-  simp [frameConditions, KD45]
+    frameConditions KD45 R ↔ IsKD45Frame R :=
+  ⟨fun h => haveI := h.2.1 (by decide); haveI := h.2.2.2.1 (by decide);
+     haveI := h.2.2.2.2 (by decide); ⟨⟩,
+   fun h => ⟨fun hm => absurd hm (by decide), fun _ => h.toIsSerial,
+             fun hm => absurd hm (by decide), fun _ => h.toIsTrans,
+             fun _ => h.toIsEuclidean⟩⟩
+
+/-- The syntactic-semantic bridge for `K45`. -/
+@[simp] theorem frameConditions_K45_iff {W : Type*} (R : W → W → Prop) :
+    frameConditions K45 R ↔ IsK45Frame R :=
+  ⟨fun h => haveI := h.2.2.2.1 (by decide); haveI := h.2.2.2.2 (by decide); ⟨⟩,
+   fun h => ⟨fun hm => absurd hm (by decide), fun hm => absurd hm (by decide),
+             fun hm => absurd hm (by decide), fun _ => h.toIsTrans,
+             fun _ => h.toIsEuclidean⟩⟩
 
 /-- The syntactic-semantic bridge for `KTB`. -/
 @[simp] theorem frameConditions_KTB_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions KTB R ↔ Std.Refl R ∧ Std.Symm R := by
-  simp [frameConditions, KTB]
+    frameConditions KTB R ↔ IsKTBFrame R :=
+  ⟨fun h => haveI := h.1 (by decide); haveI := h.2.2.1 (by decide); ⟨⟩,
+   fun h => ⟨fun _ => h.toRefl, fun hm => absurd hm (by decide),
+             fun _ => h.toSymm, fun hm => absurd hm (by decide),
+             fun hm => absurd hm (by decide)⟩⟩
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -30,29 +30,6 @@ class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
 class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
 
-/-! ### Bundled frame classes -/
-
-/-- S5 frame: reflexive + euclidean (implies symmetric + transitive). -/
-class IsS5Frame {W : Type*} (R : W → W → Prop) : Prop extends Std.Refl R, IsEuclidean R
-
-/-- KD45 frame for textbook belief: serial + transitive + euclidean. -/
-class IsKD45Frame {W : Type*} (R : W → W → Prop) : Prop
-  extends IsSerial R, IsTrans W R, IsEuclidean R
-
-/-- K4-Eucl frame: transitive + euclidean, NOT serial. The frame condition
-    for commitment in [stalnaker-1984]-style discourse models, where
-    commitment violations (no accessible compliance world) must be
-    expressible. -/
-class IsK4EuclFrame {W : Type*} (R : W → W → Prop) : Prop
-  extends IsTrans W R, IsEuclidean R
-
-/-- KTB frame: reflexive + symmetric. The natural setting for tolerance
-    semantics ([cobreros-etal-2012]) where each predicate's
-    similarity relation is reflexive and symmetric but possibly
-    non-transitive. -/
-class IsKTBFrame {W : Type*} (R : W → W → Prop) : Prop
-  extends Std.Refl R, Std.Symm R
-
 /-- `Rb` is a *belief refinement* of `Rk`: every belief-accessible world is
     knowledge-accessible. The pure subset condition; whether `Rk` is S5
     and `Rb` is KD45 is asserted by separate instance declarations. -/

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -243,16 +243,11 @@ instance (M : TModel D Pred) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
 /-- **T-models are KTB frames by construction**: every per-predicate
     similarity relation `~_P` satisfies the frame conditions for the
     normal modal logic `KTB = K + T + B` (reflexive + symmetric Kripke
-    frame). The four flag-fields beyond `.M` and `.B` are vacuously
-    satisfied because `ModalLogic.KTB` doesn't require D, 4, or 5. -/
+    frame), via the `IsKTBFrame` instance and the syntactic-semantic
+    bridge `frameConditions_KTB_iff`. -/
 theorem satisfies_KTB (M : TModel D Pred) (P : Pred) :
-    frameConditions KTB (M.simAccess P) := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩
-  · intro _; exact inferInstance
-  · intro h; exact absurd h (by decide)
-  · intro _; exact inferInstance
-  · intro h; exact absurd h (by decide)
-  · intro h; exact absurd h (by decide)
+    frameConditions KTB (M.simAccess P) :=
+  (ModalLogic.frameConditions_KTB_iff _).mpr inferInstance
 
 end TModel
 


### PR DESCRIPTION
Consolidates the two encodings of named modal logics, which were previously unconnected.

- The bundled frame classes (`IsS5Frame`, `IsKD45Frame`, `IsKTBFrame`, and `IsK4EuclFrame` renamed to its standard name `IsK45Frame`) move from `Defs.lean` to `Basic.lean` beside the axiom-set lattice; `Defs.lean` keeps the atomic frame conditions and `box`/`diamond`.
- The `frameConditions_*_iff` bridges now state the actual syntax-semantics correspondence — `frameConditions S5 R ↔ IsS5Frame R` (likewise KD45, K45, KTB) — instead of unfolding to conjunctions, so the two systems are connected by theorem rather than by naming convention.
- `CobrerosEtAl2012.satisfies_KTB` collapses to `(frameConditions_KTB_iff _).mpr inferInstance` — its `IsKTBFrame` instance now does the work once instead of a hand-rolled five-component proof.
