### PR TITLE
refactor(Semantics/Attitudes): dissolve Doxastic AccessRel alias family

### DIFF
--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -16,7 +16,6 @@ commitment to belief.
 
 ## Main definitions
 
-* `PairAccessRel W A` — pair-indexed deontic accessibility.
 * `CommitmentState W A` — frame: belief + commitment + valuation +
   bundled per-agent KD45 and per-pair K4-Euclidean frame conditions.
 * `Believes`, `Committed` — modal operators.
@@ -31,19 +30,15 @@ namespace Discourse.Commitment.Frame
 open ModalLogic (IsKD45Frame IsK45Frame IsEuclidean box diamond box_K box_four)
 open Modality.EpistemicLogic (knows)
 
-/-- Pair-indexed deontic accessibility: `commitment a b w v` means at
-    `w`, the world `v` is among those satisfying everything `a` is
-    committed-towards-`b` to. Genuinely ternary; no analogue in
-    linglib's unary-belief substrate. -/
-abbrev PairAccessRel (W A : Type*) := A → A → W → W → Prop
-
 /-- Multi-relational Kripke frame: belief (KD45) + commitment (K4 +
     Eucl., not serial) + atomic valuation. -/
 structure CommitmentState (W : Type*) (A : Type*) where
   /-- Per-agent doxastic accessibility. -/
   belief : A → W → W → Prop
-  /-- Pair-indexed deontic accessibility. -/
-  commitment : PairAccessRel W A
+  /-- Pair-indexed deontic accessibility: `commitment a b w v` means at `w`,
+      the world `v` is among those satisfying everything `a` is
+      committed-towards-`b` to. -/
+  commitment : A → A → W → W → Prop
   /-- Atomic-proposition valuation. -/
   interp : String → Set W
   /-- Belief is KD45 (serial + transitive + euclidean) per agent. -/

--- a/Linglib/Semantics/Attitudes/ContextQuantification.lean
+++ b/Linglib/Semantics/Attitudes/ContextQuantification.lean
@@ -35,7 +35,7 @@ cannot capture.
 namespace Semantics.Attitudes.ContextQuantification
 
 open Semantics.Context
-open Semantics.Attitudes.Doxastic (AccessRel boxAt)
+open Semantics.Attitudes.Doxastic (boxAt)
 
 variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
 
@@ -55,7 +55,7 @@ variable {W : Type*} {E : Type*} {P : Type*} {T : Type*}
     sees the whole shifted tower, it can resolve both origin-reading and
     local-reading indexicals; the special case where `φ` consults only the
     innermost (shifted) context is `ctxBox` below. -/
-def sayM (R : AccessRel W E) (holder : E)
+def sayM (R : E → W → W → Prop) (holder : E)
     (φ : ContextTower (KContext W E P T) → W → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) : Prop :=
   ∀ w' ∈ worlds, R holder w w' → φ (t.push (attitudeShift holder w')) w'
@@ -111,7 +111,7 @@ def ctxFromShift (t : ContextTower (KContext W E P T)) (holder : E) (w' : W) :
     unfold to the same term. The ONLY difference between them is whether
     the meaning function can see the tower. -/
 theorem sayM_reduces_to_box
-    (R : AccessRel W E) (holder : E) (p : W → Prop)
+    (R : E → W → W → Prop) (holder : E) (p : W → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
     sayM R holder (fun _ w' => p w') t w worlds
     = boxAt R holder w worlds p := rfl
@@ -129,12 +129,12 @@ theorem sayM_reduces_to_box
     contexts ⟨holder, w', t, p⟩, not just worlds w'. Defined as `sayM` with
     `φ` factored through `.innermost` (which equals `ctxFromShift`), so the
     reduction and Fixity results below are specializations of `sayM`'s. -/
-def ctxBox (R : AccessRel W E) (holder : E)
+def ctxBox (R : E → W → W → Prop) (holder : E)
     (φ : KContext W E P T → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) : Prop :=
   sayM R holder (fun tw _ => φ tw.innermost) t w worlds
 
-instance ctxBox_decidable (R : AccessRel W E) [∀ a w w', Decidable (R a w w')]
+instance ctxBox_decidable (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (holder : E) (φ : KContext W E P T → Prop) [DecidablePred φ]
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
     Decidable (ctxBox R holder φ t w worlds) :=
@@ -149,7 +149,7 @@ instance ctxBox_decidable (R : AccessRel W E) [∀ a w w', Decidable (R a w w')]
     perspective-dependent expressions, nothing that reads from the
     context beyond the world. -/
 theorem ctxBox_world_only
-    (R : AccessRel W E) (holder : E) (p : W → Prop)
+    (R : E → W → W → Prop) (holder : E) (p : W → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
     ctxBox R holder (fun c => p c.world) t w worlds
     = boxAt R holder w worlds p := by
@@ -233,7 +233,7 @@ theorem fixity_world_only (p : W → Prop) :
 
     This is because `ctxBox` with world-only meaning reduces to
     `boxAt` (by `ctxBox_world_only`), which is tower-independent. -/
-theorem ctxBox_fixity (R : AccessRel W E) (holder : E)
+theorem ctxBox_fixity (R : E → W → W → Prop) (holder : E)
     (p : W → Prop)
     (t₁ t₂ : ContextTower (KContext W E P T))
     (w : W) (worlds : List W) :

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -59,20 +59,11 @@ export Features (Veridicality)
 -- Accessibility Relations
 
 /--
-Doxastic accessibility relation type (Prop-valued, mathlib convention).
-
-`R agent evalWorld accessibleWorld` holds iff accessibleWorld is compatible
-with what agent believes/knows in evalWorld. For computational evaluation
-add `[DecidableRel (R agent)]` instances at use sites.
--/
-abbrev AccessRel (W E : Type*) := E → W → W → Prop
-
-/--
 Universal modal: holds at w iff p holds at all accessible worlds.
 
 ⟦□p⟧(w) = ∀w' ∈ worlds. R(agent, w, w') → p(w')
 -/
-def boxAt {W E : Type*} (R : AccessRel W E) (agent : E) (w : W)
+def boxAt {W E : Type*} (R : E → W → W → Prop) (agent : E) (w : W)
     (worlds : List W) (p : W → Prop) : Prop :=
   ∀ w' ∈ worlds, R agent w w' → p w'
 
@@ -81,16 +72,16 @@ Existential modal: holds at w iff p holds at some accessible world.
 
 ⟦◇p⟧(w) = ∃w' ∈ worlds. R(agent, w, w') ∧ p(w')
 -/
-def diaAt {W E : Type*} (R : AccessRel W E) (agent : E) (w : W)
+def diaAt {W E : Type*} (R : E → W → W → Prop) (agent : E) (w : W)
     (worlds : List W) (p : W → Prop) : Prop :=
   ∃ w' ∈ worlds, R agent w w' ∧ p w'
 
-instance boxAt_decidable {W E : Type*} (R : AccessRel W E) [∀ a w w', Decidable (R a w w')]
+instance boxAt_decidable {W E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
     Decidable (boxAt R agent w worlds p) :=
   inferInstanceAs (Decidable (∀ w' ∈ worlds, _))
 
-instance diaAt_decidable {W E : Type*} (R : AccessRel W E) [∀ a w w', Decidable (R a w w')]
+instance diaAt_decidable {W E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
     Decidable (diaAt R agent w worlds p) :=
   inferInstanceAs (Decidable (∃ w' ∈ worlds, _))
@@ -465,7 +456,7 @@ structure DoxasticPredicate (W E : Type*) where
   /-- Name of the predicate -/
   name : String
   /-- Accessibility relation -/
-  access : AccessRel W E
+  access : E → W → W → Prop
   /-- Veridicality (veridical or not) -/
   veridicality : Veridicality
   /-- Does it create an opaque context? (substitution failures) -/
@@ -526,7 +517,7 @@ theorem DoxasticPredicate.toPartialProp_assertion {W E : Type*}
 
 /-- PartialProp for a hypothetical contrafactive verb: presupposes ¬p,
     asserts agent believes p. UNATTESTED — see [glass-2025]. -/
-def contrafactivePartialProp {W E : Type*} (R : AccessRel W E) (agent : E)
+def contrafactivePartialProp {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (p : W → Prop) (worlds : List W) : PartialProp W :=
   { presup := λ w => ¬ p w
   , assertion := λ w => boxAt R agent w worlds p }
@@ -557,7 +548,7 @@ Abstract "believe" predicate template.
 
 Users instantiate with their specific accessibility relation.
 -/
-def believeTemplate {W E : Type*} (R : AccessRel W E) : DoxasticPredicate W E :=
+def believeTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
   { name := "believe"
   , access := R
   , veridicality := .nonVeridical
@@ -569,7 +560,7 @@ Abstract "know" predicate template.
 
 Veridical: knowing p requires p to be true.
 -/
-def knowTemplate {W E : Type*} (R : AccessRel W E) : DoxasticPredicate W E :=
+def knowTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
   { name := "know"
   , access := R
   , veridicality := .veridical
@@ -581,7 +572,7 @@ Abstract "think" predicate template.
 
 Non-veridical, typically less commitment than "believe".
 -/
-def thinkTemplate {W E : Type*} (R : AccessRel W E) : DoxasticPredicate W E :=
+def thinkTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
   { name := "think"
   , access := R
   , veridicality := .nonVeridical

--- a/Linglib/Semantics/Attitudes/NegRaising.lean
+++ b/Linglib/Semantics/Attitudes/NegRaising.lean
@@ -51,7 +51,7 @@ namespace Semantics.Attitudes.NegRaising
 
 open Aristotelian (Square SquareRelations)
 open Semantics.Attitudes.Doxastic
-  (DoxasticPredicate Veridicality boxAt diaAt AccessRel)
+  (DoxasticPredicate Veridicality boxAt diaAt)
 
 /-! ### The doxastic square -/
 
@@ -63,7 +63,7 @@ corners of the doxastic square of opposition:
 - E = Bel(¬p): all doxastic alternatives satisfy ¬p
 - I = ◇p: some doxastic alternative satisfies p
 - O = ¬Bel(p): not all doxastic alternatives satisfy p -/
-def doxasticSquare {W E : Type*} (R : AccessRel W E) (agent : E)
+def doxasticSquare {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) : Square (W → Prop) where
   A := λ w => boxAt R agent w worlds p
   E := λ w => boxAt R agent w worlds (λ w' => ¬ p w')
@@ -71,7 +71,7 @@ def doxasticSquare {W E : Type*} (R : AccessRel W E) (agent : E)
   O := λ w => ¬ boxAt R agent w worlds p
 
 /-- The doxastic square satisfies the A–O contradiction diagonal. -/
-theorem doxasticSquare_contradAO {W E : Type*} (R : AccessRel W E)
+theorem doxasticSquare_contradAO {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W) :
     (doxasticSquare R agent worlds p).A w ↔
     ¬ (doxasticSquare R agent worlds p).O w := by
@@ -81,7 +81,7 @@ theorem doxasticSquare_contradAO {W E : Type*} (R : AccessRel W E)
 
 This requires that `diaAt` is the dual of `boxAt`: ◇p = ¬□¬p.
 We prove this from the definitions. -/
-theorem doxasticSquare_contradEI {W E : Type*} (R : AccessRel W E)
+theorem doxasticSquare_contradEI {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W) :
     (doxasticSquare R agent worlds p).E w ↔
     ¬ (doxasticSquare R agent worlds p).I w := by
@@ -104,31 +104,31 @@ opinionated about *every* prejacent is exactly the decided/subsingleton limit
 validity rather than a defeasible move. -/
 
 /-- Neg-raising: the O→E inference `¬Bel(p) → Bel(¬p)` at a world. -/
-def negRaisesAt {W E : Type*} (R : AccessRel W E) (agent : E)
+def negRaisesAt {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) : Prop :=
   ¬ boxAt R agent w worlds p →
   boxAt R agent w worlds (λ w' => ¬ p w')
 
 /-- The **excluded-middle premise**: the agent is *opinionated* about `p`,
 believing `p` or believing `¬p`. Gajewski's neg-raising presupposition. -/
-def opinionated {W E : Type*} (R : AccessRel W E) (agent : E)
+def opinionated {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) : Prop :=
   boxAt R agent w worlds p ∨ boxAt R agent w worlds (λ w' => ¬ p w')
 
 /-- **The pragmatic mechanism.** Opinionatedness about `p` licenses the O→E
 strengthening — a disjunctive syllogism. Neg-raising is this inference run on the
 (pragmatically presupposed) excluded-middle premise, not a semantic entailment. -/
-theorem negRaisesAt_of_opinionated {W E : Type*} (R : AccessRel W E) (agent : E)
+theorem negRaisesAt_of_opinionated {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) :
     opinionated R agent worlds p w → negRaisesAt R agent worlds p w :=
   fun hem hnot => hem.resolve_left hnot
 
 /-- The accessible-worlds set at `w`; `boxAt … p` is `∀ w' ∈ accessibleSet, p w'`. -/
-def accessibleSet {W E : Type*} (R : AccessRel W E) (agent : E) (worlds : List W)
+def accessibleSet {W E : Type*} (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (w : W) : Set W :=
   {w' | w' ∈ worlds ∧ R agent w w'}
 
-theorem boxAt_iff_forall_accessibleSet {W E : Type*} (R : AccessRel W E) (agent : E)
+theorem boxAt_iff_forall_accessibleSet {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) :
     boxAt R agent w worlds p ↔ ∀ w' ∈ accessibleSet R agent worlds w, p w' := by
   simp only [boxAt, accessibleSet, Set.mem_setOf_eq, and_imp]
@@ -136,7 +136,7 @@ theorem boxAt_iff_forall_accessibleSet {W E : Type*} (R : AccessRel W E) (agent 
 /-- **Validity ⟺ decided state.** The agent is opinionated about *every* prejacent
 (neg-raising then holds as a validity) iff the accessible state is decided — a
 subsingleton — connecting the doxastic layer to the shared `Homogeneity` core. -/
-theorem forall_opinionated_iff_subsingleton {W E : Type*} (R : AccessRel W E)
+theorem forall_opinionated_iff_subsingleton {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (w : W) :
     (∀ p : W → Prop, opinionated R agent worlds p w) ↔
       (accessibleSet R agent worlds w).Subsingleton := by
@@ -171,14 +171,14 @@ theorem negRaising_iff_nonVeridical (v : Veridicality) :
 /-- The standard predicates' neg-raising status is *derived* from their
 veridicality, not stipulated as a flag: believe and think are non-veridical
 (neg-raising available), know is veridical (not). -/
-theorem believe_think_negRaise_know_not {W E : Type*} (R : AccessRel W E) :
+theorem believe_think_negRaise_know_not {W E : Type*} (R : E → W → W → Prop) :
     negRaisingAvailable (Doxastic.believeTemplate R).veridicality = true ∧
     negRaisingAvailable (Doxastic.thinkTemplate R).veridicality = true ∧
     negRaisingAvailable (Doxastic.knowTemplate R).veridicality = false :=
   ⟨rfl, rfl, rfl⟩
 
 /-- The doxastic square for "believe" satisfies the contradiction diagonals. -/
-theorem believe_square_contradictions {W E : Type*} (R : AccessRel W E)
+theorem believe_square_contradictions {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W) :
     ((doxasticSquare R agent worlds p).A w ↔
       ¬ (doxasticSquare R agent worlds p).O w) ∧

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -1127,7 +1127,7 @@ For modalized φ (might p, must p), verifiers are still pow(S ∩ p) —
 modalized complements raise the same issue as unmodalized ones.
 -/
 
-open Semantics.Attitudes.Doxastic (AccessRel diaAt boxAt)
+open Semantics.Attitudes.Doxastic (diaAt boxAt)
 
 /-- An emotive doxastic predicate: hybrid representational + preferential.
 
@@ -1139,7 +1139,7 @@ structure EmotiveDoxasticPredicate (W E : Type*) where
   /-- Name of the predicate -/
   name : String
   /-- Doxastic accessibility relation: DOX(x, w) -/
-  access : AccessRel W E
+  access : E → W → W → Prop
   /-- Preference function: μ(x, p) → degree -/
   μ : PreferenceFunction W E
   /-- Threshold function: θ(C) → degree -/
@@ -1203,13 +1203,13 @@ def EmotiveDoxasticPredicate.holdsAt {W E : Type*}
   V.preferenceAssertion agent p C
 
 /-- Hope: emotive doxastic with positive valence. -/
-def hopeHybrid {W E : Type*} (R : AccessRel W E)
+def hopeHybrid {W E : Type*} (R : E → W → W → Prop)
     (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
     EmotiveDoxasticPredicate W E :=
   { name := "hope", access := R, μ := μ, θ := θ, valence := .positive }
 
 /-- Fear: emotive doxastic with negative valence. -/
-def fearHybrid {W E : Type*} (R : AccessRel W E)
+def fearHybrid {W E : Type*} (R : E → W → W → Prop)
     (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
     EmotiveDoxasticPredicate W E :=
   { name := "fear", access := R, μ := μ, θ := θ, valence := .negative }

--- a/Linglib/Semantics/Attitudes/SituationDependent.lean
+++ b/Linglib/Semantics/Attitudes/SituationDependent.lean
@@ -38,12 +38,8 @@ namespace Semantics.Attitudes.SituationDependent
 
 open Intensional (WorldTimeIndex)
 open Semantics.Attitudes.Doxastic
-  (Veridicality DoxasticPredicate AccessRel boxAt veridicalityHolds)
+  (Veridicality DoxasticPredicate boxAt veridicalityHolds)
 
-/-- Local alias for the agent-indexed accessibility relation
-    used by the situation-dependent operators. Aliased to
-    `Semantics.Attitudes.Doxastic.AccessRel` (Prop-valued, mathlib convention). -/
-abbrev BAgentAccessRel (W E : Type*) := AccessRel W E
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -55,7 +51,7 @@ abbrev BAgentAccessRel (W E : Type*) := AccessRel W E
 
 /-- Situation-dependent accessibility relation: Dox_y(w,t) = {(w',t') |...}.
 
-    Generalizes `BAgentAccessRel W E = E → W → W → Prop` to include
+    Generalizes `E → W → W → Prop = E → W → W → Prop` to include
     temporal coordinates in both the evaluation and accessible situations. -/
 abbrev SitAccessRel (W Time E : Type*) := E → WorldTimeIndex W Time → WorldTimeIndex W Time → Prop
 
@@ -115,7 +111,7 @@ def liftProp {W Time : Type*} (p : W → Prop) : SitProp W Time :=
     `liftAccess R agent s₁ s₂ = R agent s₁.world s₂.world`.
     This gives classic Hintikka behavior where doxastic alternatives
     differ only in world, not time. -/
-def liftAccess {W Time E : Type*} (R : BAgentAccessRel W E) : SitAccessRel W Time E :=
+def liftAccess {W Time E : Type*} (R : E → W → W → Prop) : SitAccessRel W Time E :=
   λ agent s₁ s₂ => R agent s₁.world s₂.world
 
 
@@ -132,7 +128,7 @@ def liftAccess {W Time E : Type*} (R : BAgentAccessRel W E) : SitAccessRel W Tim
     This means code using the old world-only operators produces
     identical results when embedded in the situation framework. -/
 theorem sitBoxAt_lift_eq_boxAt {W Time E : Type*}
-    (R : BAgentAccessRel W E) (agent : E) (s : WorldTimeIndex W Time)
+    (R : E → W → W → Prop) (agent : E) (s : WorldTimeIndex W Time)
     (sits : List (WorldTimeIndex W Time)) (p : W → Prop) :
     sitBoxAt (liftAccess R) agent s sits (liftProp p) ↔
     boxAt R agent s.world (sits.map (·.world)) p := by
@@ -294,11 +290,11 @@ connection between these temporal constraints and SOT readings.
     evaluation situation's time. This gives the "simultaneous"
     reading in sequence of tense. -/
 def temporallyBound {W Time E : Type*}
-    (R : BAgentAccessRel W E) : SitAccessRel W Time E :=
+    (R : E → W → W → Prop) : SitAccessRel W Time E :=
   λ agent s₁ s₂ => R agent s₁.world s₂.world ∧ s₂.time = s₁.time
 
 instance temporallyBound_decidable {W Time E : Type*} [DecidableEq Time]
-    (R : BAgentAccessRel W E) [∀ a w w', Decidable (R a w w')] :
+    (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')] :
     ∀ a s₁ s₂, Decidable (temporallyBound (Time := Time) R a s₁ s₂) := by
   intro a s₁ s₂; unfold temporallyBound; infer_instance
 
@@ -306,12 +302,12 @@ instance temporallyBound_decidable {W Time E : Type*} [DecidableEq Time]
     at or after the evaluation time. This models forward-looking
     attitudes like "expect" or "intend". -/
 def futureOriented {W Time E : Type*} [LE Time]
-    (R : BAgentAccessRel W E) : SitAccessRel W Time E :=
+    (R : E → W → W → Prop) : SitAccessRel W Time E :=
   λ agent s₁ s₂ => R agent s₁.world s₂.world ∧ s₁.time ≤ s₂.time
 
 instance futureOriented_decidable {W Time E : Type*} [LE Time]
     [DecidableRel (α := Time) (· ≤ ·)]
-    (R : BAgentAccessRel W E) [∀ a w w', Decidable (R a w w')] :
+    (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')] :
     ∀ a s₁ s₂, Decidable (futureOriented (Time := Time) R a s₁ s₂) := by
   intro a s₁ s₂; unfold futureOriented; infer_instance
 

--- a/Linglib/Studies/AnandHacquard2013.lean
+++ b/Linglib/Studies/AnandHacquard2013.lean
@@ -207,7 +207,7 @@ theorem must_empty (φ : W → Prop) : mustS ([] : InfoState W) φ := by
 /-- Representational attitude embedding: S' = DOX(x,w).
     The doxastic alternatives form the information state that
     embedded epistemics quantify over. -/
-def representationalS {E : Type*} (R : AccessRel W E) [∀ a w w', Decidable (R a w w')]
+def representationalS {E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) : InfoState W :=
   worlds.filter (fun w' => decide (R agent w w'))
 
@@ -217,7 +217,7 @@ def nonRepresentationalS : InfoState W := []
 
 /-- Representational attitudes yield non-trivial information states
     (when there is at least one accessible world). -/
-theorem representational_nontrivial {E : Type*} (R : AccessRel W E)
+theorem representational_nontrivial {E : Type*} (R : E → W → W → Prop)
     [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W)
     (h : ∃ w' ∈ worlds, R agent w w') :
@@ -241,7 +241,7 @@ theorem nonRepresentational_trivial :
 
 /-- Under a representational attitude, embedded `must p` holds iff
     all doxastic alternatives satisfy p — a non-trivial claim. -/
-theorem believe_must {E : Type*} (R : AccessRel W E)
+theorem believe_must {E : Type*} (R : E → W → W → Prop)
     [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
     mustS (representationalS R agent w worlds) p ↔

--- a/Linglib/Studies/FaginHalpern1994.lean
+++ b/Linglib/Studies/FaginHalpern1994.lean
@@ -15,7 +15,7 @@ probability operators (`EpistemicProbability.lean`) by defining
 
 ## Key contributions
 
-1. **`KripkeKP`**: bundles `BAgentAccessRel` (knowledge) + `WorldCredence`
+1. **`KripkeKP`**: bundles `E → W → W → Prop` (knowledge) + `WorldCredence`
    (probability) into a single structure.
 
 2. **Structural conditions**: CONS, OBJ, UNIF, SDP as predicates on

--- a/Linglib/Studies/Mirrazi2024.lean
+++ b/Linglib/Studies/Mirrazi2024.lean
@@ -60,7 +60,7 @@ descriptive content.
 namespace Mirrazi2024
 
 open Quantification.ChoiceFunction
-open Semantics.Attitudes.Doxastic (AccessRel boxAt)
+open Semantics.Attitudes.Doxastic (boxAt)
 open Semantics.Attitudes.NegRaising (negRaisesAt)
 open Farsi.Determiners (ye candTa doTa PlainIndefiniteEntry)
 
@@ -128,7 +128,7 @@ theorem nonNegRaiser_suffices :
 /-- Structural verification: *think* supports neg-raising via the
     doxastic infrastructure. This connects to the library's `negRaisesAt`
     without claiming neg-raising explains the scope paradox. -/
-theorem think_does_neg_raise {W E : Type*} (R : AccessRel W E)
+theorem think_does_neg_raise {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W)
     (hNeg : ¬ boxAt R agent w worlds p)
     (hExclMiddle : negRaisesAt R agent worlds p w) :
@@ -154,7 +154,7 @@ variable (W : Type*) (E : Type*)
     `R` connects to the doxastic infrastructure in `Attitudes.Doxastic`. -/
 def widePseudoDeDictoTC
     (f : SkolemCF W E)
-    (R : AccessRel W E) (agent : E) (worlds : List W)
+    (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (nounProp : W → E → Prop)
     (vp : E → W → Prop)
     (w₀ : W) : Prop :=
@@ -170,7 +170,7 @@ def widePseudoDeDictoTC
     the individual is fixed across belief worlds. -/
 def wideDeReTC
     (f : SkolemCF W E)
-    (R : AccessRel W E) (agent : E) (worlds : List W)
+    (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (nounProp : W → E → Prop)
     (vp : E → W → Prop)
     (w₀ : W) : Prop :=
@@ -187,7 +187,7 @@ def wideDeReTC
     "pseudo-de dicto" reading reduces to plain de re. -/
 theorem deRe_eq_pseudoDeDicto_when_rigid
     (f : SkolemCF W E)
-    (R : AccessRel W E) (agent : E) (worlds : List W)
+    (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (nounProp : W → E → Prop)
     (vp : E → W → Prop) (w₀ : W)
     (hRigidNP : ∀ w, nounProp w = nounProp w₀)
@@ -224,7 +224,7 @@ end TruthConditions
     (since NEG is syntactically below the operator). -/
 theorem movement_above_neg_forces_deRe
     {W E : Type*} (f : SkolemCF W E)
-    (R : AccessRel W E) (agent : E) (worlds : List W)
+    (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (nounProp : W → E → Prop) (vp : E → W → Prop) (w₀ : W) :
     -- If the CF is "moved" (evaluated at w₀ for both its world and NP args),
     -- the result is de re, not pseudo-de dicto.

--- a/Linglib/Studies/Schlenker2003.lean
+++ b/Linglib/Studies/Schlenker2003.lean
@@ -41,7 +41,7 @@ namespace Schlenker2003
 
 open Semantics.Context
 open Semantics.Attitudes.ContextQuantification
-open Semantics.Attitudes.Doxastic (AccessRel boxAt)
+open Semantics.Attitudes.Doxastic (boxAt)
 open Semantics.Reference.ShiftedIndexicals (amharic_pronI)
 open Semantics.Reference.Kaplan (pronI_access)
 
@@ -66,7 +66,7 @@ def rootT : ContextTower Ctx := ContextTower.root speechCtx
 
 /-- Bob's doxastic accessibility: both worlds are compatible with
     what Bob believes. -/
-def bobBel : AccessRel World Person
+def bobBel : Person → World → World → Prop
   | .bob, _, _ => True
   | .alice, _, w' => w' = .w0
 

--- a/Linglib/Syntax/Minimalist/LeftPeriphery.lean
+++ b/Linglib/Syntax/Minimalist/LeftPeriphery.lean
@@ -258,7 +258,7 @@ open Semantics.Attitudes.Doxastic
     This is PerspP's not-at-issue presupposition ([dayal-2025]: §2.3).
     Uses `diaAt` from Doxastic.lean and `QUD.ans` from
     Semantics/Questions/Partition/Cells.lean. -/
-def possibleIgnorance {W E : Type*} (R : AccessRel W E) (center : E)
+def possibleIgnorance {W E : Type*} (R : E → W → W → Prop) (center : E)
     (Q : QUD W) (w : W) (worlds : List W) : Prop :=
   diaAt R center w worlds (fun w' => QUD.ans Q w w' = false)
 
@@ -272,7 +272,7 @@ structure PerspPResult (W : Type*) where
   presupSatisfied : Prop
 
 /-- Apply PerspP to a question: checks possible-ignorance presupposition. -/
-def applyPerspP {W E : Type*} (R : AccessRel W E) (center : E)
+def applyPerspP {W E : Type*} (R : E → W → W → Prop) (center : E)
     (Q : QUD W) (w : W) (worlds : List W)
     (hamblinQ : Question W) : PerspPResult W :=
   { question := hamblinQ
@@ -289,7 +289,7 @@ in bare (non-negated, non-questioned) contexts.
 /-- box and dia are duals: □p → ¬◇¬p.
     If p holds at all accessible worlds, there is no accessible world where ¬p. -/
 theorem box_excludes_dia_neg {W E : Type*}
-    (R : AccessRel W E) (agent : E) (w : W) (worlds : List W)
+    (R : E → W → W → Prop) (agent : E) (w : W) (worlds : List W)
     (p : W → Prop)
     (hBox : boxAt R agent w worlds p) :
     ¬ diaAt R agent w worlds (fun w' => ¬ p w') := by


### PR DESCRIPTION
Completes the accessibility-alias dissolution begun in #1976 for the agent-indexed family: `Semantics.Attitudes.Doxastic.AccessRel W E`, its re-alias `BAgentAccessRel` (SituationDependent), and `PairAccessRel` (Commitment/Frame) — three layers of law-free aliasing — all dissolve onto `E → W → W → Prop` (pair-indexed: `A → A → W → W → Prop`) inline, per mathlib's no-relation-alias convention. Ten files, mechanical; the `commitment` field keeps its defining gloss in the docstring.
