### PR TITLE
feat(Logic/Modal/BSML): bilateral BSML* evaluation; negative FC (Fact 14)

### DIFF
--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -30,8 +30,8 @@ runs the same recursion over quantified atoms.
   the frame conditions governing wide-scope free choice.
 * `consequence`, `equivalent` — support consequence and bilateral
   equivalence.
-* `supportStar`, `consequenceStar` — the BSML* variant excluding `∅` from
-  intermediate states.
+* `evalStar`, `consequenceStar` — BSML*, the variant excluding `∅` from
+  the possible states; `supportStar`/`antiSupportStar` fix the polarity.
 
 ## Implementation notes
 
@@ -234,22 +234,46 @@ def equivalent (φ ψ : Formula Atom) : Prop :=
 
 /-! ### BSML* -/
 
-/-- BSML* support ([aloni-2022] §6.3.1): like `support` but `∅` is excluded
-    from intermediate states — in disjunction, both parts of the split must
-    be non-empty (`Team.splitsAsNE`).
+/-- Bilateral evaluation for BSML* ([aloni-2022] §6.3.1): like `eval`, but
+    `∅` is not among the possible states, so the split clauses
+    (disjunction-support, conjunction-anti-support) quantify over
+    `Team.splitsAsNE` decompositions into non-empty parts. The exclusion is
+    imposed wherever states are quantified — the splits here and the outer
+    team in `consequenceStar` — while the atom, `ne`, and modal clauses
+    keep their BSML form. -/
+def evalStar (M : KripkeModel W Atom) : Bool → Formula Atom → Finset W → Prop
+  | true,  .atom p,       t => ∀ w ∈ t, M.val p w = true
+  | false, .atom p,       t => ∀ w ∈ t, M.val p w = false
+  | true,  .ne,           t => t.Nonempty
+  | false, .ne,           t => t = ∅
+  | true,  .neg ψ,        t => evalStar M false ψ t
+  | false, .neg ψ,        t => evalStar M true ψ t
+  | true,  .conj ψ₁ ψ₂,  t => evalStar M true ψ₁ t ∧ evalStar M true ψ₂ t
+  | false, .conj ψ₁ ψ₂,  t => ∃ t₁ t₂ : Finset W,
+                                Team.splitsAsNE t t₁ t₂ ∧
+                                evalStar M false ψ₁ t₁ ∧ evalStar M false ψ₂ t₂
+  | true,  .disj ψ₁ ψ₂,  t => ∃ t₁ t₂ : Finset W,
+                                Team.splitsAsNE t t₁ t₂ ∧
+                                evalStar M true ψ₁ t₁ ∧ evalStar M true ψ₂ t₂
+  | false, .disj ψ₁ ψ₂,  t => evalStar M false ψ₁ t ∧ evalStar M false ψ₂ t
+  | true,  .poss ψ,       t => ∀ w ∈ t, ∃ s ⊆ M.access w, s.Nonempty ∧ evalStar M true ψ s
+  | false, .poss ψ,       t => ∀ w ∈ t, evalStar M false ψ (M.access w)
 
-    NOTE: the negation case `| .neg _, _ => True` is a placeholder. Aloni's
-    actual BSML* uses bilateral polarity mirroring BSML's; completing this
-    requires a polarity-flipped `supportStar`, tracked as out of scope. -/
-def supportStar (M : KripkeModel W Atom) : Formula Atom → Finset W → Prop
-  | .atom p, t => ∀ w ∈ t, M.val p w = true
-  | .ne, t => t.Nonempty
-  | .neg _, _ => True
-  | .conj φ ψ, t => supportStar M φ t ∧ supportStar M ψ t
-  | .disj φ ψ, t => ∃ t₁ t₂ : Finset W,
-      Team.splitsAsNE t t₁ t₂ ∧
-      supportStar M φ t₁ ∧ supportStar M ψ t₂
-  | .poss φ, t => ∀ w ∈ t, ∃ s ⊆ M.access w, s.Nonempty ∧ supportStar M φ s
+/-- BSML* support: positive evaluation with non-empty intermediate states. -/
+abbrev supportStar (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+  evalStar M true φ t
+
+/-- BSML* anti-support. -/
+abbrev antiSupportStar (M : KripkeModel W Atom) (φ : Formula Atom) (t : Finset W) : Prop :=
+  evalStar M false φ t
+
+@[simp] lemma supportStar_neg (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
+    supportStar M (.neg φ) t ↔ antiSupportStar M φ t := Iff.rfl
+
+@[simp] lemma antiSupportStar_neg (M : KripkeModel W Atom)
+    (φ : Formula Atom) (t : Finset W) :
+    antiSupportStar M (.neg φ) t ↔ supportStar M φ t := Iff.rfl
 
 /-- BSML* consequence: `supportStar` consequence on non-empty teams — in
     BSML*, `∅` is not among the possible states. -/

--- a/Linglib/Logic/Modal/BSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/BSML/Enrichment.lean
@@ -325,7 +325,7 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
   | conj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.ClassicalPositive := ⟨hCP.1.1, hCP.2.1⟩
     have hψ₂ : ψ₂.ClassicalPositive := ⟨hCP.1.2, hCP.2.2⟩
-    simp only [enrich, support, eval, supportStar]
+    simp only [enrich, support, eval, supportStar, evalStar]
     constructor
     · intro ⟨⟨h₁, h₂⟩, hne⟩
       exact ⟨⟨((ih₁ t hψ₁).mp h₁).1, ((ih₂ t hψ₂).mp h₂).1⟩, hne⟩
@@ -334,7 +334,7 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
   | disj ψ₁ ψ₂ ih₁ ih₂ =>
     have hψ₁ : ψ₁.ClassicalPositive := ⟨hCP.1.1, hCP.2.1⟩
     have hψ₂ : ψ₂.ClassicalPositive := ⟨hCP.1.2, hCP.2.2⟩
-    simp only [enrich, support, eval, supportStar]
+    simp only [enrich, support, eval, supportStar, evalStar]
     constructor
     · intro ⟨⟨t₁, t₂, hu, h₁, h₂⟩, hne⟩
       have ⟨hs₁, hne₁⟩ := (ih₁ t₁ hψ₁).mp h₁
@@ -345,7 +345,7 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
               (ih₂ t₂ hψ₂).mpr ⟨hs₂, hne₂⟩⟩, hne⟩
   | poss ψ ih =>
     have hψ : ψ.ClassicalPositive := hCP
-    simp only [enrich, support, eval, supportStar]
+    simp only [enrich, support, eval, supportStar, evalStar]
     constructor
     · intro ⟨hposs, hne⟩
       refine ⟨fun w hw => ?_, hne⟩
@@ -355,6 +355,21 @@ private theorem enriched_iff_star_nonempty (M : KripkeModel W Atom)
       refine ⟨fun w hw => ?_, hne⟩
       obtain ⟨s, hs, hne_s, hstar⟩ := hposs w hw
       exact ⟨s, hs, hne_s, (ih s hψ).mpr ⟨hstar, hne_s⟩⟩
+
+/-- **Negative free choice in BSML*** ([aloni-2022] Fact 14):
+    `◇¬(α ∧ β) ⊨ ◇¬α` in the star system. The conjunction anti-support
+    split requires two *non-empty* parts, so an accessible team
+    anti-supporting `α ∧ β` yields a non-empty sub-team anti-supporting
+    `α`. BSML+ does not validate this inference. -/
+theorem negativeFC_star (M : KripkeModel W Atom) (α β : Formula Atom)
+    (t : Finset W) (h : supportStar M (.poss (.neg (.conj α β))) t) :
+    supportStar M (.poss (.neg α)) t := by
+  intro w hw
+  obtain ⟨s, hs, hne, hstar⟩ := h w hw
+  have hstar' : ∃ s₁ s₂ : Finset W, Team.splitsAsNE s s₁ s₂ ∧
+      antiSupportStar M α s₁ ∧ antiSupportStar M β s₂ := hstar
+  obtain ⟨s₁, s₂, ⟨hsplit, hne₁, -⟩, h₁, -⟩ := hstar'
+  exact ⟨s₁, fun x hx => hs (hsplit ▸ Finset.mem_union_left s₂ hx), hne₁, h₁⟩
 
 /--
 For classical positive formulas, BSML* and BSML+ consequence coincide


### PR DESCRIPTION
Replaces `supportStar`'s documented placeholder (`| .neg _, _ => True`) with the faithful bilateral system: Aloni 2022 §6.3.1 defines BSML* as BSML with `∅` removed from the possible states, so `evalStar` mirrors `eval` with polarity-flipping negation and `Team.splitsAsNE` in both split clauses (disjunction-support AND conjunction-anti-support); `supportStar`/`antiSupportStar` fix the polarity and `consequenceStar` is unchanged.

The completed negation unlocks the theorem the stub was blocking: `negativeFC_star` (Fact 14) — `◇¬(α ∧ β) ⊨ ◇¬α` in BSML*, via the non-empty anti-support split. Fact 13 and its proof carry over unchanged.
