### PR TITLE
style(Logic/Modal/QBSML): align IsNEFree naming with BSML.Formula.NEFree

### DIFF
--- a/Linglib/Logic/Modal/QBSML/Defs.lean
+++ b/Linglib/Logic/Modal/QBSML/Defs.lean
@@ -24,7 +24,7 @@ by state non-emptiness.
   `State.extendFunctional`: the state extensions `s[x/d]`, `s[x]`, `s[x/h]`.
 * `State.modalLift`: a set of worlds, paired with one assignment.
 * `Formula`: the formula language; `Formula.nec` is the derived `□`;
-  `Formula.IsNEFree` the NE-free fragment.
+  `Formula.NEFree` the NE-free fragment.
 * `Model`, `Model.ofMonadic`: models, as `KripkeStructure`s over
   `Language.monadicWithConstants`.
 * `eval`, `support`, `antiSupport`: bilateral evaluation.
@@ -342,21 +342,21 @@ def Formula.nec (φ : Formula Var Const Pred) : Formula Var Const Pred :=
     fragment QBSML reduces to classical first-order modal logic
     ([aloni-vanormondt-2023] analogue of [anttila-2021]
     Proposition 2.2.16); see `Logic/Modal/QBSML/Properties.lean`. -/
-inductive Formula.IsNEFree : Formula Var Const Pred → Prop
-  | pred (P : Pred) (x : Var) : IsNEFree (.pred P x)
-  | predc (P : Pred) (c : Const) : IsNEFree (.predc P c)
-  | neg {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.neg φ)
+inductive Formula.NEFree : Formula Var Const Pred → Prop
+  | pred (P : Pred) (x : Var) : NEFree (.pred P x)
+  | predc (P : Pred) (c : Const) : NEFree (.predc P c)
+  | neg {φ : Formula Var Const Pred} : NEFree φ → NEFree (.neg φ)
   | conj {φ ψ : Formula Var Const Pred} :
-      IsNEFree φ → IsNEFree ψ → IsNEFree (.conj φ ψ)
+      NEFree φ → NEFree ψ → NEFree (.conj φ ψ)
   | disj {φ ψ : Formula Var Const Pred} :
-      IsNEFree φ → IsNEFree ψ → IsNEFree (.disj φ ψ)
-  | poss {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.poss φ)
-  | exi (x : Var) {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.exi x φ)
-  | univ (x : Var) {φ : Formula Var Const Pred} : IsNEFree φ → IsNEFree (.univ x φ)
+      NEFree φ → NEFree ψ → NEFree (.disj φ ψ)
+  | poss {φ : Formula Var Const Pred} : NEFree φ → NEFree (.poss φ)
+  | exi (x : Var) {φ : Formula Var Const Pred} : NEFree φ → NEFree (.exi x φ)
+  | univ (x : Var) {φ : Formula Var Const Pred} : NEFree φ → NEFree (.univ x φ)
 
 /-- The derived `□φ := ¬◇¬φ` preserves NE-freeness. -/
-theorem Formula.IsNEFree.nec {φ : Formula Var Const Pred}
-    (h : φ.IsNEFree) : φ.nec.IsNEFree :=
+theorem Formula.NEFree.nec {φ : Formula Var Const Pred}
+    (h : φ.NEFree) : φ.nec.NEFree :=
   .neg (.poss (.neg h))
 
 /-! ### Atom substitution -/
@@ -383,12 +383,12 @@ def Formula.mapAtoms
   | .univ x φ => .univ x (φ.mapAtoms fp fc)
 
 /-- An atom substitution with NE-free images preserves NE-freeness. -/
-theorem Formula.IsNEFree.mapAtoms
+theorem Formula.NEFree.mapAtoms
     {fp : Pred → Var → Formula Var Const Pred}
     {fc : Pred → Const → Formula Var Const Pred}
-    (hfp : ∀ P x, (fp P x).IsNEFree) (hfc : ∀ P c, (fc P c).IsNEFree)
-    {φ : Formula Var Const Pred} (h : φ.IsNEFree) :
-    (φ.mapAtoms fp fc).IsNEFree := by
+    (hfp : ∀ P x, (fp P x).NEFree) (hfc : ∀ P c, (fc P c).NEFree)
+    {φ : Formula Var Const Pred} (h : φ.NEFree) :
+    (φ.mapAtoms fp fc).NEFree := by
   induction h with
   | pred P x => exact hfp P x
   | predc P c => exact hfc P c

--- a/Linglib/Logic/Modal/QBSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/QBSML/Enrichment.lean
@@ -132,7 +132,7 @@ theorem antiSupport_conj_ne_iff (M : Model W Domain Const Pred)
     conjunct, then `extendUniversal` / `extendFunctional` to apply the IH
     on the extended state. -/
 private theorem enrichment_strengthens_both (M : Model W Domain Const Pred)
-    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree) :
+    {φ : Formula Var Const Pred} (hNE : φ.NEFree) :
     (∀ s : Finset (Index W Var Domain), support M φ.enrich s → support M φ s) ∧
     (∀ s : Finset (Index W Var Domain),
         antiSupport M φ.enrich s → antiSupport M φ s) := by
@@ -215,7 +215,7 @@ private theorem enrichment_strengthens_both (M : Model W Domain Const Pred)
     supporting the original. -/
 theorem enrichment_strengthens_support (M : Model W Domain Const Pred)
     (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
-    (hNE : φ.IsNEFree)
+    (hNE : φ.NEFree)
     (h : support M φ.enrich s) :
     support M φ s :=
   (enrichment_strengthens_both M hNE).1 s h
@@ -223,7 +223,7 @@ theorem enrichment_strengthens_support (M : Model W Domain Const Pred)
 /-- **Enrichment strengthens (anti-support direction)**. -/
 theorem enrichment_strengthens_antiSupport (M : Model W Domain Const Pred)
     (φ : Formula Var Const Pred) (s : Finset (Index W Var Domain))
-    (hNE : φ.IsNEFree)
+    (hNE : φ.NEFree)
     (h : antiSupport M φ.enrich s) :
     antiSupport M φ s :=
   (enrichment_strengthens_both M hNE).2 s h

--- a/Linglib/Logic/Modal/QBSML/FreeChoice.lean
+++ b/Linglib/Logic/Modal/QBSML/FreeChoice.lean
@@ -77,7 +77,7 @@ variable {α β : Formula Var Const Pred} {s : Finset (Index W Var Domain)}
     `diamond_split`. -/
 private theorem poss_of_subset_modalLift {X : Finset W}
     {g : PartialAssign Var Domain} {t : Finset (Index W Var Domain)}
-    (hα : α.IsNEFree) (ht : t ⊆ State.modalLift X g)
+    (hα : α.NEFree) (ht : t ⊆ State.modalLift X g)
     (h : support M α.enrich t) :
     ∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g) :=
   ⟨State.worldProj t, State.worldProj_subset_of_subset_modalLift ht,
@@ -89,7 +89,7 @@ private theorem poss_of_subset_modalLift {X : Finset W}
     supported on a modal pairing yields a non-empty world-set witness for
     each disjunct — `poss_of_subset_modalLift` on each half of the split. -/
 theorem diamond_split {X : Finset W} {g : PartialAssign Var Domain}
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (hsupp : support M (Formula.disj α β).enrich (State.modalLift X g)) :
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M α (State.modalLift Y g)) ∧
     (∃ Y, Y ⊆ X ∧ Y.Nonempty ∧ support M β (State.modalLift Y g)) := by
@@ -99,7 +99,7 @@ theorem diamond_split {X : Finset W} {g : PartialAssign Var Domain}
 
 /-- Per-index form of the core: a state whose every index sees an enriched
     split disjunction supports both diamonds (shared by Facts 8 and 9). -/
-private theorem possFC_on (hα : α.IsNEFree) (hβ : β.IsNEFree)
+private theorem possFC_on (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (.poss (Formula.disj α β).enrich) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   refine ⟨fun i hi => ?_, fun i hi => ?_⟩
@@ -119,7 +119,7 @@ private theorem possFC_on (hα : α.IsNEFree) (hβ : β.IsNEFree)
 
     Projects the diamond clause of the enrichment and applies the per-index
     core `possFC_on` at `s`. -/
-theorem narrowScopeFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem narrowScopeFC (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (Formula.enrich (.poss (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s :=
   possFC_on M hα hβ h.1
@@ -132,7 +132,7 @@ theorem narrowScopeFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
     The enriched premise evaluates the enriched diamond at the universal
     extension `s[x]`, so the conclusion is `possFC_on` at `s[x]` — the same
     per-index argument as Fact 8, one extension up. -/
-theorem universalFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem universalFC {x : Var} (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (Formula.enrich (.univ x (.poss (.disj α β)))) s) :
     support M (.univ x (.poss α)) s ∧ support M (.univ x (.poss β)) s :=
   possFC_on M hα hβ h.1.1
@@ -147,7 +147,7 @@ theorem universalFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
     `support_enrich_nec_iff` puts the enriched disjunction on each index's
     full accessible lift `R(wᵢ)[gᵢ]`, and `diamond_split` produces the
     witnesses. -/
-theorem boxFC (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem boxFC (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (Formula.enrich (Formula.nec (.disj α β))) s) :
     support M (.poss α) s ∧ support M (.poss β) s := by
   rw [support_enrich_nec_iff] at h
@@ -206,7 +206,7 @@ private theorem poss_exi_of_subset_extendFunctional
     each index's full accessible lift's functional extension; each
     non-empty half yields a `◇∃x`-witness by
     `poss_exi_of_subset_extendFunctional`. -/
-theorem boxExiFC {x : Var} (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem boxExiFC {x : Var} (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M
       (Formula.enrich (Formula.nec (.exi x (.disj α β)))) s) :
     support M (.poss (.exi x α)) s ∧ support M (.poss (.exi x β)) s := by
@@ -279,7 +279,7 @@ theorem ignorance {P Q : Pred} {c₁ c₂ : Const} (hSB : M.IsStateBased s)
     Negation cancels ignorance (paper §5.5): the `Nonempty` hypothesis is
     discharged by the three NE-strips, leaving classical anti-support on
     each disjunct. -/
-theorem negationStrip (hα : α.IsNEFree) (hβ : β.IsNEFree)
+theorem negationStrip (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (Formula.enrich (.neg (.disj α β))) s) :
     support M (.neg α) s ∧ support M (.neg β) s := by
   have hDisj : antiSupport M (.disj α.enrich β.enrich) s :=
@@ -322,7 +322,7 @@ private theorem exi_of_subset_extendUniversal_singleton
     a singleton, every part extends the *same* index, so each part is the
     image of a functional extension witnessing the existential. -/
 theorem distribution {x : Var} {i : Index W Var Domain}
-    (hα : α.IsNEFree) (hβ : β.IsNEFree)
+    (hα : α.NEFree) (hβ : β.NEFree)
     (h : support M (Formula.enrich (.univ x (.disj α β))) {i}) :
     support M (.exi x α) {i} ∧ support M (.exi x β) {i} := by
   obtain ⟨t₁, t₂, hsplit, h₁, h₂⟩ := h.1.1

--- a/Linglib/Logic/Modal/QBSML/Properties.lean
+++ b/Linglib/Logic/Modal/QBSML/Properties.lean
@@ -17,9 +17,9 @@ empty-team support, hence flat support, via the same
 
 ## Main declarations
 
-* `support_empty_of_isNEFree`, `isLowerSet_support_of_isNEFree`,
-  `supClosed_support_of_isNEFree` — the three closure properties.
-* `isFlat_support_of_isNEFree` — flatness of the NE-free fragment
+* `support_empty_of_neFree`, `isLowerSet_support_of_neFree`,
+  `supClosed_support_of_neFree` — the three closure properties.
+* `isFlat_support_of_neFree` — flatness of the NE-free fragment
   ([anttila-2021] Proposition 2.2.16, QBSML specialisation).
 * `soundFor_flat_neFree` — the NE-free fragment is sound for the flat cell
   of `Team/Definability.lean`.
@@ -31,7 +31,7 @@ empty-team support, hence flat support, via the same
   Proposition 4.1: the NE-free fragment (modals included) translates into
   `ModalFormula` over `Logic/Modal/FirstOrder/Kripke.lean`, and support is
   Kripke satisfaction at every index; the translation is total on exactly
-  the NE-free fragment (`exists_toModal?_of_isNEFree`).
+  the NE-free fragment (`exists_toModal?_of_neFree`).
 * `eval_mapAtoms_iff` — atom-substitution congruence: an atom map with
   bilaterally equivalent images is *salva veritate*.
 * `support_disj_inl`, `support_nec_iff`, `support_nec_mono`,
@@ -65,8 +65,8 @@ variable [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain]
     the negation case (where support flips to antiSupport). All quantifier
     cases use `State.extendUniversal_empty` and
     `State.extendFunctional_empty`. -/
-private theorem support_and_antiSupport_empty_of_isNEFree
-    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree)
+private theorem support_and_antiSupport_empty_of_neFree
+    {φ : Formula Var Const Pred} (hNE : φ.NEFree)
     (M : Model W Domain Const Pred) :
     support M φ (∅ : Finset (Index W Var Domain)) ∧
     antiSupport M φ (∅ : Finset (Index W Var Domain)) := by
@@ -112,10 +112,10 @@ private theorem support_and_antiSupport_empty_of_isNEFree
       exact ih.2
 
 /-- NE-free QBSML formulas are supported on the empty team. -/
-theorem support_empty_of_isNEFree {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
+theorem support_empty_of_neFree {φ : Formula Var Const Pred}
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred) :
     support M φ ∅ :=
-  (support_and_antiSupport_empty_of_isNEFree hNE M).1
+  (support_and_antiSupport_empty_of_neFree hNE M).1
 
 /-! ### Joint downward + sup closure for NE-free formulas -/
 
@@ -126,8 +126,8 @@ theorem support_empty_of_isNEFree {φ : Formula Var Const Pred}
     needs the IH's downward closure for the subformula to weaken
     `t.extendFunctional x h_t` to `(t \ s).extendFunctional x h_t`, so all
     four properties have to live inside one induction. -/
-private theorem support_and_antiSupport_dc_uc_of_isNEFree
-    {φ : Formula Var Const Pred} (hNE : φ.IsNEFree)
+private theorem support_and_antiSupport_dc_uc_of_neFree
+    {φ : Formula Var Const Pred} (hNE : φ.NEFree)
     (M : Model W Domain Const Pred) :
     -- (1) DC support
     (∀ s t : Finset (Index W Var Domain), t ⊆ s → support M φ s → support M φ t) ∧
@@ -346,11 +346,11 @@ private theorem support_and_antiSupport_dc_uc_of_isNEFree
 
 /-- NE-free QBSML formulas are downward-closed ([anttila-2021]
     Proposition 2.2.8 part 1, extended to first-order). -/
-theorem isLowerSet_support_of_isNEFree {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
+theorem isLowerSet_support_of_neFree {φ : Formula Var Const Pred}
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred) :
     IsLowerSet { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ _ hab hb =>
-    (support_and_antiSupport_dc_uc_of_isNEFree hNE M).1 _ _ hab hb
+    (support_and_antiSupport_dc_uc_of_neFree hNE M).1 _ _ hab hb
 
 /-- NE-free QBSML formulas have sup-closed support.
 
@@ -358,11 +358,11 @@ theorem isLowerSet_support_of_isNEFree {φ : Formula Var Const Pred}
     QBSML's `exi` UC case needs downward closure of the subformula as IH
     (see the module docstring), so the QBSML version narrows to NE-free.
     The downstream flat corollary consumes NE-free anyway. -/
-theorem supClosed_support_of_isNEFree {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
+theorem supClosed_support_of_neFree {φ : Formula Var Const Pred}
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred) :
     SupClosed { t : Finset (Index W Var Domain) | support M φ t } :=
   fun _ ha _ hb =>
-    (support_and_antiSupport_dc_uc_of_isNEFree hNE M).2.1 _ _ ha hb
+    (support_and_antiSupport_dc_uc_of_neFree hNE M).2.1 _ _ ha hb
 
 /-! ### Flatness corollary -/
 
@@ -370,13 +370,13 @@ theorem supClosed_support_of_isNEFree {φ : Formula Var Const Pred}
     QBSML formulas are flat. Derived from [anttila-2021] Proposition 2.2.2
     (`Team.isFlat_iff`) applied to the three closure properties
     above. -/
-theorem isFlat_support_of_isNEFree {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred) :
+theorem isFlat_support_of_neFree {φ : Formula Var Const Pred}
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred) :
     IsFlat { t : Finset (Index W Var Domain) | support M φ t } :=
   isFlat_of_isLowerSet_supClosed_empty
-    (isLowerSet_support_of_isNEFree hNE M)
-    (supClosed_support_of_isNEFree hNE M)
-    (support_empty_of_isNEFree hNE M)
+    (isLowerSet_support_of_neFree hNE M)
+    (supClosed_support_of_neFree hNE M)
+    (support_empty_of_neFree hNE M)
 
 /-! ### Soundness for the flat cell (Definability bridge) -/
 
@@ -394,10 +394,10 @@ theorem isFlat_support_of_isNEFree {φ : Formula Var Const Pred}
     union-closed cell. -/
 theorem soundFor_flat_neFree (M : Model W Domain Const Pred) :
     definableClassWhere (support M)
-      (fun φ : Formula Var Const Pred => φ.IsNEFree) ⊆ flatProperties := by
+      (fun φ : Formula Var Const Pred => φ.NEFree) ⊆ flatProperties := by
   unfold flatProperties
   exact definableClassWhere_subset (C := IsFlat)
-    fun _φ hφ => isFlat_support_of_isNEFree hφ M
+    fun _φ hφ => isFlat_support_of_neFree hφ M
 
 /-! ### Fact 1: classical validities
 
@@ -453,15 +453,15 @@ end Fact1
 /-- Flat (NE-free) support is pointwise: a team supports `φ` iff each of its
     singletons does (`Team.IsFlat` unfolded at the support set). -/
 theorem support_iff_forall_singleton {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred)
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     support M φ s ↔ ∀ i ∈ s, support M φ {i} :=
-  isFlat_support_of_isNEFree hNE M s
+  isFlat_support_of_neFree hNE M s
 
 /-- Anti-support of an NE-free formula is likewise pointwise: flatness of the
     bilateral negation. -/
 theorem antiSupport_iff_forall_singleton {φ : Formula Var Const Pred}
-    (hNE : φ.IsNEFree) (M : Model W Domain Const Pred)
+    (hNE : φ.NEFree) (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) :
     antiSupport M φ s ↔ ∀ i ∈ s, antiSupport M φ {i} :=
   support_iff_forall_singleton (.neg hNE) M s
@@ -562,10 +562,10 @@ theorem eval_mapAtoms_iff (M : Model W Domain Const Pred)
 /-- Disjunction introduction: `α ⊨ α ∨ β` for NE-free `β` (the right
     disjunct is supported by the empty half of the split). -/
 theorem support_disj_inl (M : Model W Domain Const Pred)
-    {α β : Formula Var Const Pred} (hβ : β.IsNEFree)
+    {α β : Formula Var Const Pred} (hβ : β.NEFree)
     {s : Finset (Index W Var Domain)} (h : support M α s) :
     support M (.disj α β) s :=
-  ⟨s, ∅, splitsAs_self_empty s, h, support_empty_of_isNEFree hβ M⟩
+  ⟨s, ∅, splitsAs_self_empty s, h, support_empty_of_neFree hβ M⟩
 
 /-- Support of the derived `□` is pointwise support at the full accessible
     lift — definitional, by the `neg`/`poss` clauses of `eval`. -/
@@ -672,9 +672,9 @@ def Formula.toFormula? :
 
 omit [DecidableEq W] [Fintype Var] in
 /-- Translatable formulas are NE-free. -/
-theorem isNEFree_of_toFormula? :
+theorem neFree_of_toFormula? :
     ∀ {φ : Formula Var Const Pred} {ψ : (Language.monadicWithConstants Const Pred).Formula Var},
-      φ.toFormula? = some ψ → φ.IsNEFree := by
+      φ.toFormula? = some ψ → φ.NEFree := by
   intro φ
   induction φ with
   | pred P x => exact fun _ => .pred P x
@@ -838,11 +838,11 @@ private theorem support_and_antiSupport_singleton_realizeAt
           · rintro (h | h)
             · exact ⟨{i}, ∅, Team.splitsAs_self_empty _,
                 ih₁a.mpr h,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toFormula? hφ₂) M).2⟩
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toFormula? hφ₂) M).2⟩
             · exact ⟨∅, {i}, Team.splitsAs_empty_self _,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toFormula? hφ₁) M).2,
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toFormula? hφ₁) M).2,
                 ih₂a.mpr h⟩
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ i v hv
@@ -873,11 +873,11 @@ private theorem support_and_antiSupport_singleton_realizeAt
           · rintro (h | h)
             · exact ⟨{i}, ∅, Team.splitsAs_self_empty _,
                 ih₁s.mpr h,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toFormula? hφ₂) M).1⟩
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toFormula? hφ₂) M).1⟩
             · exact ⟨∅, {i}, Team.splitsAs_empty_self _,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toFormula? hφ₁) M).1,
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toFormula? hφ₁) M).1,
                 ih₂s.mpr h⟩
         · rw [KripkeStructure.realizeAt_sup, not_or]
           exact and_congr ih₁a ih₂a
@@ -889,7 +889,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       simp only [Formula.toFormula?, hφ] at hψ
       rw [Option.map_some, Option.some.injEq] at hψ
       subst hψ
-      have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
+      have hNE : φ.NEFree := neFree_of_toFormula? hφ
       constructor
       · rw [KripkeStructure.realizeAt_ex₁]
         constructor
@@ -931,7 +931,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       simp only [Formula.toFormula?, hφ] at hψ
       rw [Option.map_some, Option.some.injEq] at hψ
       subst hψ
-      have hNE : φ.IsNEFree := isNEFree_of_toFormula? hφ
+      have hNE : φ.NEFree := neFree_of_toFormula? hφ
       constructor
       · rw [KripkeStructure.realizeAt_all₁]
         show support M φ (State.extendUniversal {i} x) ↔ _
@@ -998,7 +998,7 @@ theorem support_iff_forall_realizeAt (M : Model W Domain Const Pred)
     (v : Index W Var Domain → Var → Domain)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support M φ s ↔ ∀ i ∈ s, M.RealizeAt i.world ψ (v i) := by
-  rw [support_iff_forall_singleton (isNEFree_of_toFormula? hψ)]
+  rw [support_iff_forall_singleton (neFree_of_toFormula? hψ)]
   exact forall₂_congr fun i hi =>
     support_singleton_iff_realizeAt M hψ (hv i hi)
 
@@ -1032,10 +1032,10 @@ def Formula.toModal? :
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- Modally translatable formulas are NE-free. -/
-theorem isNEFree_of_toModal? :
+theorem neFree_of_toModal? :
     ∀ {φ : Formula Var Const Pred}
       {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var},
-      φ.toModal? = some τ → φ.IsNEFree := by
+      φ.toModal? = some τ → φ.NEFree := by
   intro φ
   induction φ with
   | pred P x => exact fun _ => .pred P x
@@ -1080,10 +1080,10 @@ theorem isNEFree_of_toModal? :
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] in
 /-- The modal translation is total on the NE-free fragment: together with
-    `isNEFree_of_toModal?`, the translatable and NE-free fragments
+    `neFree_of_toModal?`, the translatable and NE-free fragments
     coincide. -/
-theorem exists_toModal?_of_isNEFree :
-    ∀ {φ : Formula Var Const Pred}, φ.IsNEFree →
+theorem exists_toModal?_of_neFree :
+    ∀ {φ : Formula Var Const Pred}, φ.NEFree →
       ∃ τ, φ.toModal? = some τ := by
   intro φ h
   induction h with
@@ -1222,11 +1222,11 @@ private theorem support_and_antiSupport_singleton_realize
           · rintro (h | h)
             · exact ⟨{i}, ∅, Team.splitsAs_self_empty _,
                 ih₁a.mpr h,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toModal? hφ₂) M).2⟩
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toModal? hφ₂) M).2⟩
             · exact ⟨∅, {i}, Team.splitsAs_empty_self _,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toModal? hφ₁) M).2,
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toModal? hφ₁) M).2,
                 ih₂a.mpr h⟩
   | disj φ₁ φ₂ ih₁ ih₂ =>
     intro τ hτ i v hv
@@ -1258,11 +1258,11 @@ private theorem support_and_antiSupport_singleton_realize
           · rintro (h | h)
             · exact ⟨{i}, ∅, Team.splitsAs_self_empty _,
                 ih₁s.mpr h,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toModal? hφ₂) M).1⟩
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toModal? hφ₂) M).1⟩
             · exact ⟨∅, {i}, Team.splitsAs_empty_self _,
-                (support_and_antiSupport_empty_of_isNEFree
-                  (isNEFree_of_toModal? hφ₁) M).1,
+                (support_and_antiSupport_empty_of_neFree
+                  (neFree_of_toModal? hφ₁) M).1,
                 ih₂s.mpr h⟩
         · rw [ModalFormula.realize_sup, not_or]
           exact and_congr ih₁a ih₂a
@@ -1274,7 +1274,7 @@ private theorem support_and_antiSupport_singleton_realize
       simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
-      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      have hNE : φ.NEFree := neFree_of_toModal? hφ
       constructor
       · rw [ModalFormula.realize_dia]
         constructor
@@ -1317,7 +1317,7 @@ private theorem support_and_antiSupport_singleton_realize
       simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
-      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      have hNE : φ.NEFree := neFree_of_toModal? hφ
       constructor
       · rw [ModalFormula.realize_ex]
         constructor
@@ -1359,7 +1359,7 @@ private theorem support_and_antiSupport_singleton_realize
       simp only [Formula.toModal?, hφ] at hτ
       rw [Option.map_some, Option.some.injEq] at hτ
       subst hτ
-      have hNE : φ.IsNEFree := isNEFree_of_toModal? hφ
+      have hNE : φ.NEFree := neFree_of_toModal? hφ
       constructor
       · rw [ModalFormula.realize_all]
         show support M φ (State.extendUniversal {i} x) ↔ _
@@ -1428,7 +1428,7 @@ theorem support_iff_forall_realize (M : Model W Domain Const Pred)
     (v : Index W Var Domain → Var → Domain)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support M φ s ↔ ∀ i ∈ s, τ.Realize M i.world (v i) := by
-  rw [support_iff_forall_singleton (isNEFree_of_toModal? hτ)]
+  rw [support_iff_forall_singleton (neFree_of_toModal? hτ)]
   exact forall₂_congr fun i hi =>
     support_singleton_iff_realize M hτ (hv i hi)
 

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -76,10 +76,10 @@ def univPossPxOrQx {Const : Type*} : Formula QVar Const Predicate :=
 def univPxOrQx {Const : Type*} : Formula QVar Const Predicate :=
   .univ .x (.disj Px Qx)
 
-theorem Pa_isNEFree : Pa.IsNEFree := .predc _ _
-theorem Pb_isNEFree : Pb.IsNEFree := .predc _ _
-theorem Px_isNEFree {Const : Type*} : (Px (Const := Const)).IsNEFree := .pred _ _
-theorem Qx_isNEFree {Const : Type*} : (Qx (Const := Const)).IsNEFree := .pred _ _
+theorem Pa_neFree : Pa.NEFree := .predc _ _
+theorem Pb_neFree : Pb.NEFree := .predc _ _
+theorem Px_neFree {Const : Type*} : (Px (Const := Const)).NEFree := .pred _ _
+theorem Qx_neFree {Const : Type*} : (Qx (Const := Const)).NEFree := .pred _ _
 
 variable {s : Finset (Index TwoAtomWorld QVar FCAtom)}
 variable {i : Index TwoAtomWorld QVar FCAtom}
@@ -205,7 +205,7 @@ theorem fact3_ignorance (hfull : State.worldProj s = Finset.univ)
 /-- **Fact 5** (distribution at maximal information). -/
 theorem fact5_distribution (h : support univAccessModel univPxOrQx.enrich {i}) :
     support univAccessModel (.exi .x Px) {i} ∧ support univAccessModel (.exi .x Qx) {i} :=
-  distribution univAccessModel Px_isNEFree Qx_isNEFree h
+  distribution univAccessModel Px_neFree Qx_neFree h
 
 /-- **Fact 6** (distribution◇), on states of full world projection. -/
 theorem fact6_distributionEpi (hfull : State.worldProj s = Finset.univ)
@@ -218,13 +218,13 @@ theorem fact6_distributionEpi (hfull : State.worldProj s = Finset.univ)
 theorem fact7_boxFC
     (h : support univAccessModel (Formula.enrich (Formula.nec (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
-  boxFC univAccessModel Pa_isNEFree Pb_isNEFree h
+  boxFC univAccessModel Pa_neFree Pb_neFree h
 
 /-- **Fact 8** (◇-free choice); cf. `Aloni2022.aloni2022_fact4_NS_FC`. -/
 theorem fact8_narrowScopeFC
     (h : support univAccessModel (Formula.enrich (.poss (.disj Pa Pb))) s) :
     support univAccessModel (.poss Pa) s ∧ support univAccessModel (.poss Pb) s :=
-  narrowScopeFC univAccessModel Pa_isNEFree Pb_isNEFree h
+  narrowScopeFC univAccessModel Pa_neFree Pb_neFree h
 
 /-- **Fact 9** (universal free choice), attested experimentally by
     [chemla-2009]. -/
@@ -232,14 +232,14 @@ theorem fact9_universalFC
     (h : support univAccessModel univPossPxOrQx.enrich s) :
     support univAccessModel (.univ .x (.poss Px)) s ∧
     support univAccessModel (.univ .x (.poss Qx)) s :=
-  universalFC univAccessModel Px_isNEFree Qx_isNEFree h
+  universalFC univAccessModel Px_neFree Qx_neFree h
 
 /-- **Fact 10** (negation behaviour); cf.
     `Aloni2022.aloni2022_fact11_dual_prohibition`. -/
 theorem fact10_negation
     (h : support univAccessModel (Formula.enrich (.neg (.disj Pa Pb))) s) :
     support univAccessModel (.neg Pa) s ∧ support univAccessModel (.neg Pb) s :=
-  negationStrip univAccessModel Pa_isNEFree Pb_isNEFree h
+  negationStrip univAccessModel Pa_neFree Pb_neFree h
 
 /-! ### Fact 4 (obviation): the Fig. 14 countermodel
 

--- a/Linglib/Studies/Yan2023.lean
+++ b/Linglib/Studies/Yan2023.lean
@@ -36,7 +36,7 @@ deferred to the dissertation's Chapter 5).
 
 * `reinterpret` — Yan's reinterpretation function `∥·∥_P` (Definition 32),
   an instance of `Formula.mapAtoms`.
-* `reinterpret_isNEFree`, `eval_reinterpret_iff` — reinterpretation stays
+* `reinterpret_neFree`, `eval_reinterpret_iff` — reinterpretation stays
   NE-free and is bilaterally equivalent to the original (substitution
   *salva veritate*; the classical equivalence of `Qx` and
   `(Px ∧ Qx) ∨ (¬Px ∧ Qx)` lifted to team semantics).
@@ -123,17 +123,17 @@ theorem reinterpret_predc (Q : Pred) (c : Const) :
   rfl
 
 /-- Reinterpretation preserves NE-freeness. -/
-theorem reinterpret_isNEFree {φ : Formula Var Const Pred}
-    (h : φ.IsNEFree) : (reinterpret sub P φ).IsNEFree :=
+theorem reinterpret_neFree {φ : Formula Var Const Pred}
+    (h : φ.NEFree) : (reinterpret sub P φ).NEFree :=
   h.mapAtoms
     (fun Q x => by
-      show Formula.IsNEFree (if sub P Q then _ else _)
+      show Formula.NEFree (if sub P Q then _ else _)
       split
       · exact .disj (.conj (.pred _ _) (.pred _ _))
           (.conj (.neg (.pred _ _)) (.pred _ _))
       · exact .pred _ _)
     (fun Q c => by
-      show Formula.IsNEFree (if sub P Q then _ else _)
+      show Formula.NEFree (if sub P Q then _ else _)
       split
       · exact .disj (.conj (.predc _ _) (.predc _ _))
           (.conj (.neg (.predc _ _)) (.predc _ _))
@@ -202,9 +202,9 @@ private theorem eval_iff_of_atom_pred (P Q : Pred) (x : Var) (b : Bool)
       · exact hnQ₁ i hit₂
     · intro h
       exact ⟨⟨∅, s, splitsAs_empty_self s,
-          support_empty_of_isNEFree (.neg (.pred P x)) M, h⟩,
+          support_empty_of_neFree (.neg (.pred P x)) M, h⟩,
         ⟨∅, s, splitsAs_empty_self s,
-          support_empty_of_isNEFree (.pred P x) M, h⟩⟩
+          support_empty_of_neFree (.pred P x) M, h⟩⟩
 
 private theorem eval_iff_of_atom_predc (P Q : Pred) (c : Const) (b : Bool)
     (s : Finset (Index W Var Domain)) :
@@ -241,9 +241,9 @@ private theorem eval_iff_of_atom_predc (P Q : Pred) (c : Const) (b : Bool)
       · exact hnQ₁ i hit₂
     · intro h
       exact ⟨⟨∅, s, splitsAs_empty_self s,
-          support_empty_of_isNEFree (.neg (.predc P c)) M, h⟩,
+          support_empty_of_neFree (.neg (.predc P c)) M, h⟩,
         ⟨∅, s, splitsAs_empty_self s,
-          support_empty_of_isNEFree (.predc P c) M, h⟩⟩
+          support_empty_of_neFree (.predc P c) M, h⟩⟩
 
 /-- **Substitution salva veritate** ([yan-2023] §4.3.2): reinterpretation
     is bilaterally equivalent to the original — `∥φ∥_P` and `φ` are
@@ -310,8 +310,8 @@ def sendL : Formula QVar Unit RossPred := .predc .send ()
 /-- `BURN a`: the letter is burnt. -/
 def burnL : Formula QVar Unit RossPred := .predc .burn ()
 
-theorem sendL_isNEFree : sendL.IsNEFree := .predc _ _
-theorem burnL_isNEFree : burnL.IsNEFree := .predc _ _
+theorem sendL_neFree : sendL.NEFree := .predc _ _
+theorem burnL_neFree : burnL.NEFree := .predc _ _
 
 /-- John's bouletic state: a single desire-world where the letter is sent
     and not burnt, reflexively accessible. -/
@@ -329,7 +329,7 @@ theorem ross_monotone {s : Finset (Index Unit QVar Unit)}
     (h : support rossModel sendL.nec s) :
     support rossModel (sendL.disj burnL).nec s :=
   support_nec_mono rossModel
-    (fun _ ht => support_disj_inl rossModel burnL_isNEFree ht) h
+    (fun _ ht => support_disj_inl rossModel burnL_neFree ht) h
 
 /-- **Pragmatic validity of the FC step** ([yan-2023] (26), instance of
     Fact 13): `[□(SEND a ∨ BURN a)]⁺ ⊨ ◇SEND a ∧ ◇BURN a` — from the
@@ -338,7 +338,7 @@ theorem ross_monotone {s : Finset (Index Unit QVar Unit)}
 theorem ross_fc {s : Finset (Index Unit QVar Unit)}
     (h : support rossModel (Formula.enrich (sendL.disj burnL).nec) s) :
     support rossModel (.poss sendL) s ∧ support rossModel (.poss burnL) s :=
-  boxFC rossModel sendL_isNEFree burnL_isNEFree h
+  boxFC rossModel sendL_neFree burnL_neFree h
 
 /-- The premise is assertable: John's desire state supports the enriched
     `[□SEND a]⁺`. -/
@@ -407,8 +407,8 @@ def freeTrip : Formula QVar Unit AsherPred :=
 def nonFreeTrip : Formula QVar Unit AsherPred :=
   .conj (.neg (.pred .free .x)) (.pred .trip .x)
 
-theorem freeTrip_isNEFree : freeTrip.IsNEFree := .conj (.pred _ _) (.pred _ _)
-theorem nonFreeTrip_isNEFree : nonFreeTrip.IsNEFree :=
+theorem freeTrip_neFree : freeTrip.NEFree := .conj (.pred _ _) (.pred _ _)
+theorem nonFreeTrip_neFree : nonFreeTrip.NEFree :=
   .conj (.neg (.pred _ _)) (.pred _ _)
 
 /-- The premise `□∃x(Fx ∧ Tx)`: Nicholas wants a free trip. -/
@@ -453,7 +453,7 @@ theorem asher_fc (M : Model W Domain Unit AsherPred)
     support M (.poss (.exi QVar.x nonFreeTrip)) s := by
   rw [reinterpret_asherConcl] at h
   exact boxExiFC M
-    freeTrip_isNEFree nonFreeTrip_isNEFree h
+    freeTrip_neFree nonFreeTrip_neFree h
 
 end AsherGeneric
 


### PR DESCRIPTION
Renames `QBSML.Formula.IsNEFree` to `NEFree` (and `isNEFree` name parts to `neFree`) so the BSML and QBSML fragments use one spelling — the bare-adjective form matching `Positive`/`ClassicalPositive` and the mathlib `Squarefree` precedent. Mechanical, 6 files.