### PR TITLE
feat(Logic/Modal/BSML): Hintikka formulas; expressive completeness proved

### DIFF
--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -237,6 +237,55 @@ theorem classicalEval_charFormula_iff_bisim [Fintype Atom] [Inhabited Atom]
           ⟨charFormula M k u, List.mem_map.mpr ⟨u, Finset.mem_toList.mpr hu, rfl⟩,
            (ih u u').mpr hb⟩
 
+/-! ### Team support of the auxiliary connectives -/
+
+theorem support_verum [Inhabited Atom] (M : KripkeModel W Atom) (t : Finset W) :
+    support M (verum (Atom := Atom)) t := by
+  refine ⟨t.filter (fun w => M.val default w = true),
+          t.filter (fun w => M.val default w = false), ?_, ?_, ?_⟩
+  · show t.filter _ ∪ t.filter _ = t
+    ext w
+    simp only [Finset.mem_union, Finset.mem_filter]
+    constructor
+    · rintro (⟨h, -⟩ | ⟨h, -⟩) <;> exact h
+    · intro hw
+      cases hb : M.val default w
+      · exact Or.inr ⟨hw, rfl⟩
+      · exact Or.inl ⟨hw, rfl⟩
+  · exact fun w hw => (Finset.mem_filter.mp hw).2
+  · exact fun w hw => (Finset.mem_filter.mp hw).2
+
+theorem support_bigConj_iff [Inhabited Atom] (M : KripkeModel W Atom)
+    (l : List (Formula Atom)) (t : Finset W) :
+    support M (bigConj l) t ↔ ∀ φ ∈ l, support M φ t := by
+  induction l with
+  | nil => simpa [bigConj] using support_verum M t
+  | cons φ rest ih =>
+    simp only [bigConj, support_conj, ih, List.forall_mem_cons]
+
+/-- Team support of a flat disjunction of characteristic formulas: every
+    world of the team is `k`-bisimilar to some representative in `S`. -/
+theorem support_charDisj_iff [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) (k : ℕ) (S : Finset W) (t : Finset W) :
+    support M (bigDisj (S.toList.map (charFormula M k))) t ↔
+      ∀ v ∈ t, ∃ w ∈ S, WorldBisim k M w M v := by
+  have hNE : (bigDisj (S.toList.map (charFormula M k))).NEFree := by
+    refine neFree_bigDisj _ (fun φ hφ => ?_)
+    obtain ⟨w, -, rfl⟩ := List.mem_map.mp hφ
+    exact neFree_charFormula M k w
+  rw [neFree_flat M _ t hNE]
+  constructor
+  · intro h v hv
+    obtain ⟨φ, hφ, hval⟩ := (classicalEval_bigDisj M v _).mp (h v hv)
+    obtain ⟨w, hw, rfl⟩ := List.mem_map.mp hφ
+    exact ⟨w, Finset.mem_toList.mp hw,
+      (classicalEval_charFormula_iff_bisim M k w v).mp hval⟩
+  · intro h v hv
+    obtain ⟨w, hw, hb⟩ := h v hv
+    exact (classicalEval_bigDisj M v _).mpr
+      ⟨charFormula M k w, List.mem_map.mpr ⟨w, Finset.mem_toList.mpr hw, rfl⟩,
+       (classicalEval_charFormula_iff_bisim M k w v).mpr hb⟩
+
 /-- On singleton teams, support of the characteristic formula is exactly
     `k`-bisimilarity — the team-semantic face of the characterisation, via
     the NE-free classical collapse. -/

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -24,17 +24,19 @@ standard *classical* modal Hintikka characterisation.
 * `verum`, `bigConj` — `⊤` (as `p ∨ ¬p`) and finite conjunction, both NE-free.
 * `atomicType M w` — the depth-0 Hintikka formula: the conjunction of atomic
   literals true at `w`.
-* `classicalEval_atomicType_iff_bisim0` — `{v}` (classically) satisfies `w`'s
-  atomic type iff `v` and `w` are 0-bisimilar (`WorldBisim 0`).
+* `charFormula M k w` — the depth-`k` Hintikka formula: atomic type, `◇` of
+  each successor type, and `□` of the successor-type disjunction.
+* `classicalEval_charFormula_iff_bisim` — the characterisation: `v`
+  classically satisfies `χ_w^k` iff `w` and `v` are `k`-bisimilar.
+* `support_charFormula_singleton_iff_bisim` — the team-semantic face:
+  singleton support of `χ_w^k` is `k`-bisimilarity.
 
 ## Todo
 
-* Depth-`k+1` Hintikka formula (atomic type ∧ `◇` each successor type ∧ `□`
-  disjunction of successor types) and the characterisation
-  `classicalEval (charFormula k w) v = true ↔ WorldBisim k M w M v` by induction
-  on `k`. Then lift to team support via `Bridge.neFree_flat_eq` (currently
-  `private`; expose it) for the Hennessy-Milner theorem, feeding the normal form
-  that discharges `expressiveCompleteness_converse`.
+* Team characteristic formulas (`θ_s^k = ⋁_{w ∈ s} (χ_w^k ∧ NE)`,
+  Definition 3.10 of [aloni-anttila-yang-2024]) and the convex,
+  union-closed normal form that discharges
+  `expressiveCompleteness_converse`.
 -/
 
 namespace BSML
@@ -125,5 +127,123 @@ theorem classicalEval_atomicType_iff_bisim0 [Fintype Atom] [Inhabited Atom]
   constructor
   · intro h p; exact (h p).symm
   · intro h p; exact (h p).symm
+
+/-! ### `⊥` and finite disjunction -/
+
+/-- `⊥` as an NE-free BSML formula: `p ∧ ¬p` for the default atom. Classically
+    false at every world. -/
+def falsum [Inhabited Atom] : Formula Atom :=
+  .conj (.atom default) (.neg (.atom default))
+
+@[simp] theorem classicalEval_falsum [Inhabited Atom] (M : KripkeModel W Atom) (w : W) :
+    classicalEval M falsum w = false := by
+  simp [falsum, classicalEval]
+
+@[simp] theorem neFree_falsum [Inhabited Atom] : (falsum : Formula Atom).NEFree :=
+  ⟨trivial, trivial⟩
+
+/-- Finite disjunction of a list of formulas; the empty disjunction is `⊥`. -/
+def bigDisj [Inhabited Atom] : List (Formula Atom) → Formula Atom
+  | [] => falsum
+  | φ :: rest => .disj φ (bigDisj rest)
+
+theorem classicalEval_bigDisj [Inhabited Atom] (M : KripkeModel W Atom) (w : W)
+    (l : List (Formula Atom)) :
+    classicalEval M (bigDisj l) w = true ↔ ∃ φ ∈ l, classicalEval M φ w = true := by
+  induction l with
+  | nil => simp [bigDisj]
+  | cons φ rest ih => simp [bigDisj, classicalEval, ih]
+
+theorem neFree_bigDisj [Inhabited Atom] (l : List (Formula Atom))
+    (h : ∀ φ ∈ l, φ.NEFree) : (bigDisj l).NEFree := by
+  induction l with
+  | nil => exact neFree_falsum
+  | cons φ rest ih =>
+    exact ⟨h φ (List.mem_cons.mpr (Or.inl rfl)),
+           ih (fun ψ hψ => h ψ (List.mem_cons.mpr (Or.inr hψ)))⟩
+
+/-! ### Modal clauses of classical evaluation -/
+
+theorem classicalEval_poss_iff (M : KripkeModel W Atom) (ψ : Formula Atom) (w : W) :
+    classicalEval M (.poss ψ) w = true ↔ ∃ v ∈ M.access w, classicalEval M ψ v = true := by
+  simp [classicalEval]
+
+theorem classicalEval_nec_iff (M : KripkeModel W Atom) (ψ : Formula Atom) (w : W) :
+    classicalEval M (Formula.nec ψ) w = true ↔ ∀ v ∈ M.access w, classicalEval M ψ v = true := by
+  simp [Formula.nec, classicalEval]
+
+/-! ### Characteristic formulas -/
+
+/-- The depth-`k` characteristic (Hintikka) formula of `w`: at depth `0` the
+    atomic type; at depth `k + 1` the atomic type, conjoined with `◇χ_v^k`
+    for each `R`-successor `v` and with `□` of the disjunction of the
+    successor types. -/
+noncomputable def charFormula [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) : ℕ → W → Formula Atom
+  | 0, w => atomicType M w
+  | k + 1, w =>
+      .conj (atomicType M w)
+        (.conj
+          (bigConj ((M.access w).toList.map fun v => .poss (charFormula M k v)))
+          (Formula.nec (bigDisj ((M.access w).toList.map fun v => charFormula M k v))))
+
+theorem neFree_charFormula [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) (k : ℕ) (w : W) : (charFormula M k w).NEFree := by
+  induction k generalizing w with
+  | zero => exact neFree_atomicType M w
+  | succ k ih =>
+    refine ⟨neFree_atomicType M w, ?_, ?_⟩
+    · refine neFree_bigConj _ (fun φ hφ => ?_)
+      obtain ⟨v, -, rfl⟩ := List.mem_map.mp hφ
+      exact ih v
+    · refine neFree_bigDisj _ (fun φ hφ => ?_)
+      obtain ⟨v, -, rfl⟩ := List.mem_map.mp hφ
+      exact ih v
+
+/-- **Depth-`k` characterisation** (the Hintikka half of Theorem 3.3 of
+    [aloni-anttila-yang-2024]): `w`'s depth-`k` characteristic formula is
+    classically satisfied at `v` iff `w` and `v` are `k`-bisimilar. -/
+theorem classicalEval_charFormula_iff_bisim [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) (k : ℕ) (w v : W) :
+    classicalEval M (charFormula M k w) v = true ↔ WorldBisim k M w M v := by
+  induction k generalizing w v with
+  | zero => exact classicalEval_atomicType_iff_bisim0 M w v
+  | succ k ih =>
+    constructor
+    · intro h
+      simp only [charFormula, classicalEval, Bool.and_eq_true] at h
+      obtain ⟨hA, hB, hC⟩ := h
+      refine ⟨fun p => ((classicalEval_atomicType M w v).mp hA p).symm, ?_, ?_⟩
+      · intro u hu
+        have hposs := (classicalEval_bigConj M v _).mp hB (.poss (charFormula M k u))
+          (List.mem_map.mpr ⟨u, Finset.mem_toList.mpr hu, rfl⟩)
+        obtain ⟨u', hu', hchar⟩ := (classicalEval_poss_iff M _ v).mp hposs
+        exact ⟨u', hu', (ih u u').mp hchar⟩
+      · intro u' hu'
+        have hd := (classicalEval_nec_iff M _ v).mp hC u' hu'
+        obtain ⟨φ, hφ, hval⟩ := (classicalEval_bigDisj M u' _).mp hd
+        obtain ⟨u, hu, rfl⟩ := List.mem_map.mp hφ
+        exact ⟨u, Finset.mem_toList.mp hu, (ih u u').mp hval⟩
+    · intro hbisim
+      simp only [charFormula, classicalEval, Bool.and_eq_true]
+      refine ⟨(classicalEval_atomicType M w v).mpr (fun p => (hbisim.1 p).symm), ?_, ?_⟩
+      · refine (classicalEval_bigConj M v _).mpr (fun φ hφ => ?_)
+        obtain ⟨u, hu, rfl⟩ := List.mem_map.mp hφ
+        obtain ⟨u', hu', hb⟩ := hbisim.2.1 u (Finset.mem_toList.mp hu)
+        exact (classicalEval_poss_iff M _ v).mpr ⟨u', hu', (ih u u').mpr hb⟩
+      · refine (classicalEval_nec_iff M _ v).mpr (fun u' hu' => ?_)
+        obtain ⟨u, hu, hb⟩ := hbisim.2.2 u' hu'
+        exact (classicalEval_bigDisj M u' _).mpr
+          ⟨charFormula M k u, List.mem_map.mpr ⟨u, Finset.mem_toList.mpr hu, rfl⟩,
+           (ih u u').mpr hb⟩
+
+/-- On singleton teams, support of the characteristic formula is exactly
+    `k`-bisimilarity — the team-semantic face of the characterisation, via
+    the NE-free classical collapse. -/
+theorem support_charFormula_singleton_iff_bisim [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) (k : ℕ) (w v : W) :
+    support M (charFormula M k w) {v} ↔ WorldBisim k M w M v :=
+  (classicalCollapse M _ v (neFree_charFormula M k w)).trans
+    (classicalEval_charFormula_iff_bisim M k w v)
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
+++ b/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
@@ -1,5 +1,5 @@
 import Linglib.Logic.Modal.BSML.Properties
-import Linglib.Logic.Modal.BSML.Bisimulation
+import Linglib.Logic.Modal.BSML.Characteristic
 
 /-!
 # Expressive completeness for BSML
@@ -20,10 +20,11 @@ The theorem splits into two halves:
   `ordConnected_support` (convexity, Proposition 3.3.1), `supClosed_support`
   (union closure), and `bisimClosed_definedBy` (Theorem 3.8 / bisimulation
   invariance, `BSML/Bisimulation.lean`).
-* **Completeness** (`cell ⊆ ⟦BSML⟧`) — the hard converse: every property in the
-  cell is BSML-definable. Stated here as `expressiveCompleteness_converse` with
-  a `sorry`; it is the within-model specialisation of [anttila-2025] Ch 3
-  and requires the characteristic-formula machinery (see the TODO there).
+* **Completeness** (`cell ⊆ ⟦BSML⟧`) — the converse: every property in the
+  cell is BSML-definable, proved for finite atom types via the
+  characteristic-formula machinery of `BSML/Characteristic.lean` (the
+  within-model, finite-atom specialisation of [anttila-2025] Ch 3, whose
+  cross-model theorem indexes bisimulation by finite atom sets).
 
 ## Main declarations
 
@@ -32,8 +33,8 @@ The theorem splits into two halves:
 * `bisimInvariant_support` — Theorem 3.8 specialised to one model.
 * `bisimClosed_definedBy` — every BSML-definable property is bisim-closed.
 * `expressiveSoundness` — `⟦BSML⟧ ⊆` the convex/union-closed/bisim-closed cell.
-* `expressiveCompleteness_converse` — the open converse (`sorry`).
-* `expressivelyComplete` — the headline equality (inherits the converse `sorry`).
+* `expressiveCompleteness_converse` — the converse.
+* `expressivelyComplete` — the headline equality.
 -/
 
 namespace BSML
@@ -83,28 +84,112 @@ theorem expressiveSoundness (M : KripkeModel W Atom) :
   exact ⟨⟨ordConnected_support M φ, supClosed_support M φ⟩, bisimClosed_definedBy M φ⟩
 
 /-- **Completeness half** ([anttila-2025] Ch 3 — the hard direction, the
-    BSML expressive-power problem left open by [aloni-anttila-yang-2024]
-    and solved via Knudstorp's convexity machinery): every convex, union-closed,
+    BSML expressive-power problem left open by [aloni-anttila-yang-2024] —
+    in its within-model, finite-atom form): every convex, union-closed,
     bounded-bisimulation-closed team property is BSML-definable.
 
-    TODO: prove via characteristic formulas. The prerequisite is the
-    Hennessy-Milner direction (Theorem 3.3, deferred in `BSML/Bisimulation.lean`):
-    for `[Fintype Atom]`, build NE-free Hintikka formulas `χ_w^k` satisfying
-    `{v} ⊨ χ_w^k ↔ WorldBisim k M w M v`, lift them to characteristic formulas
-    for teams, then assemble `P` as a split disjunction over the
-    inclusion-minimal teams of `P` of their characteristic formulas conjoined
-    with `NE` (the convex + union-closed normal form — the converse of
-    Proposition 3.3.1). This is the within-model specialisation of Anttila's
-    cross-model theorem. -/
-theorem expressiveCompleteness_converse (M : KripkeModel W Atom) :
+    The defining formula conjoins an upper bound — the flat disjunction
+    `δ_U` of the characteristic formulas of the union `U` of all teams of
+    `P` — with, for every set `T` of worlds whose bisimilarity classes meet
+    every team of `P`, the hitting disjunct `(δ_T ∧ NE) ∨ δ_U`. A
+    supporting team `t` lies under `U` and meets every such transversal;
+    the worlds not bisimilar into `t` therefore fail to be a transversal,
+    which yields a team `s₀ ∈ P` whose classes `t` covers, and `s₀ ∪ (U`
+    restricted to `t`'s classes`)` lies in `P` by convexity between `s₀`
+    and `U` and is bisimilar to `t` — so `t ∈ P` by bisimulation closure. -/
+theorem expressiveCompleteness_converse [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) :
     convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M ⊆
       definableClass (support M) := by
-  sorry
+  classical
+  rintro P ⟨⟨hconv, hsup⟩, hbc⟩
+  obtain ⟨k, hbisim⟩ := hbc
+  have hconv' : Set.OrdConnected P := hconv
+  have hsup' : SupClosed P := hsup
+  rw [mem_definableClass]
+  rcases Set.eq_empty_or_nonempty P with rfl | hP
+  · refine ⟨.conj falsum .ne, ?_⟩
+    ext t
+    constructor
+    · exact fun h => h.elim
+    · rintro ⟨⟨h1, h2⟩, w, hw⟩
+      exact absurd ((h1 w hw).symm.trans (h2 w hw)) (by decide)
+  · set PF : Finset (Finset W) := P.toFinset with hPF
+    have hPFne : PF.Nonempty := Set.toFinset_nonempty.mpr hP
+    set U : Finset W := PF.sup id with hUdef
+    have hUP : U ∈ P :=
+      hsup'.finsetSup_mem hPFne (fun s hs => Set.mem_toFinset.mp hs)
+    have hsubU : ∀ s ∈ P, s ⊆ U :=
+      fun s hs => Finset.le_sup (f := id) (Set.mem_toFinset.mpr hs)
+    set 𝒯 : Finset (Finset W) := Finset.univ.filter
+      (fun T => ∀ s ∈ PF, ∃ v ∈ s, ∃ w ∈ T, WorldBisim k M w M v) with h𝒯
+    set δ : Finset W → Formula Atom :=
+      fun S => bigDisj (S.toList.map (charFormula M k)) with hδdef
+    refine ⟨.conj (δ U)
+      (bigConj (𝒯.toList.map (fun T => .disj (.conj (δ T) .ne) (δ U)))), ?_⟩
+    ext t
+    constructor
+    · intro htP
+      refine ⟨(support_charDisj_iff M k U t).mpr
+        (fun v hv => ⟨v, hsubU t htP hv, WorldBisim.refl k M v⟩), ?_⟩
+      refine (support_bigConj_iff M _ t).mpr (fun ψ hψ => ?_)
+      obtain ⟨T, hT, rfl⟩ := List.mem_map.mp hψ
+      have hTtrans := (Finset.mem_filter.mp (Finset.mem_toList.mp hT)).2
+      obtain ⟨v, hvt, w, hwT, hb⟩ := hTtrans t (Set.mem_toFinset.mpr htP)
+      refine ⟨{v}, t, ?_, ⟨?_, Finset.singleton_nonempty v⟩, ?_⟩
+      · show {v} ∪ t = t
+        exact Finset.union_eq_right.mpr (Finset.singleton_subset_iff.mpr hvt)
+      · refine (support_charDisj_iff M k T {v}).mpr (fun x hx => ?_)
+        obtain rfl := Finset.mem_singleton.mp hx
+        exact ⟨w, hwT, hb⟩
+      · exact (support_charDisj_iff M k U t).mpr
+          (fun x hx => ⟨x, hsubU t htP hx, WorldBisim.refl k M x⟩)
+    · rintro ⟨hupper, hhits⟩
+      have hcov : ∀ v ∈ t, ∃ w ∈ U, WorldBisim k M w M v :=
+        (support_charDisj_iff M k U t).mp hupper
+      set T₀ : Finset W := Finset.univ.filter
+        (fun w => ¬ ∃ v ∈ t, WorldBisim k M w M v) with hT₀def
+      have hT₀notin : T₀ ∉ 𝒯 := by
+        intro hmem
+        have hhit := (support_bigConj_iff M _ t).mp hhits _
+          (List.mem_map.mpr ⟨T₀, Finset.mem_toList.mpr hmem, rfl⟩)
+        obtain ⟨t₁, t₂, hsplit, ⟨hδ₁, hne₁⟩, -⟩ := hhit
+        obtain ⟨x, hx⟩ := hne₁
+        obtain ⟨w, hwT₀, hb⟩ := (support_charDisj_iff M k T₀ t₁).mp hδ₁ x hx
+        exact (Finset.mem_filter.mp hwT₀).2
+          ⟨x, Team.splitsAs_left_subset hsplit hx, hb⟩
+      have hs₀ : ∃ s₀ ∈ PF, ∀ w ∈ s₀, ∃ v ∈ t, WorldBisim k M w M v := by
+        by_contra hno
+        refine hT₀notin (Finset.mem_filter.mpr ⟨Finset.mem_univ _, fun s hs => ?_⟩)
+        by_contra hall
+        refine hno ⟨s, hs, fun w hw => ?_⟩
+        by_contra hwnc
+        exact hall ⟨w, hw, w,
+          Finset.mem_filter.mpr ⟨Finset.mem_univ _, hwnc⟩, WorldBisim.refl k M w⟩
+      obtain ⟨s₀, hs₀PF, hs₀cov⟩ := hs₀
+      have hs₀P : s₀ ∈ P := Set.mem_toFinset.mp hs₀PF
+      set t'' : Finset W :=
+        s₀ ∪ U.filter (fun w => ∃ v ∈ t, WorldBisim k M w M v) with ht''def
+      have hbis : StateBisim k M t'' M t := by
+        constructor
+        · intro w hw
+          rcases Finset.mem_union.mp hw with hw₀ | hwU
+          · exact hs₀cov w hw₀
+          · exact (Finset.mem_filter.mp hwU).2
+        · intro v hv
+          obtain ⟨w, hwU, hb⟩ := hcov v hv
+          exact ⟨w, Finset.mem_union_right _ (Finset.mem_filter.mpr ⟨hwU, v, hv, hb⟩), hb⟩
+      have ht''P : t'' ∈ P :=
+        hconv'.out hs₀P hUP (Set.mem_Icc.mpr
+          ⟨Finset.subset_union_left,
+           Finset.union_subset (hsubU s₀ hs₀P) (Finset.filter_subset _ _)⟩)
+      exact (hbisim t'' t hbis).mp ht''P
 
 /-- **BSML is expressively complete** for the convex, union-closed,
-    bounded-bisimulation-closed team properties ([anttila-2025] Ch 3).
-    Inherits the `sorry` of `expressiveCompleteness_converse`. -/
-theorem expressivelyComplete (M : KripkeModel W Atom) :
+    bounded-bisimulation-closed team properties ([anttila-2025] Ch 3, in
+    within-model finite-atom form). -/
+theorem expressivelyComplete [Fintype Atom] [Inhabited Atom]
+    (M : KripkeModel W Atom) :
     ExpressivelyCompleteFor (support M)
       (convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M) :=
   Set.Subset.antisymm (expressiveSoundness M) (expressiveCompleteness_converse M)


### PR DESCRIPTION
Builds the Hintikka machinery and uses it to discharge the library's `expressiveCompleteness_converse` sorry, making `Logic/Modal/` sorry-free.

- `charFormula M k w` (depth-`k` Hintikka formula: atomic type ∧ `◇` of each successor type ∧ `□` of the successor-type disjunction) with the two-directional characterisation `classicalEval_charFormula_iff_bisim : … ↔ WorldBisim k M w M v`, plus the singleton-support lift and supporting `falsum`/`bigDisj`/team-support API.
- `expressiveCompleteness_converse`: every convex, union-closed, bounded-bisimulation-closed team property is BSML-definable (within-model finite-atom form of Anttila 2025 Ch 3 — the cross-model theorem indexes bisimulation by finite atom sets, so `[Fintype Atom]` is the honest hypothesis). The defining formula is `δ_U ∧ ⋀_{T ∈ 𝒯} ((δ_T ∧ NE) ∨ δ_U)` over flat characteristic disjunctions, with `U` the union of `P`'s teams and `𝒯` the transversal world-sets; a supporting team's uncovered-worlds set fails transversality, yielding `s₀ ∈ P` covered by `t`, and `s₀ ∪ (U ∩ cover t)` closes via convexity + bisim-closure.
- `expressivelyComplete` — the headline theorem — is now fully proved.
