### PR TITLE
refactor(Logic/Modal): register pass — refinement class is le, doc fixes

### DIFF
--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -33,12 +33,10 @@ def diamond (p : W → Prop) (w : W) : Prop :=
 
 /-! ### Duality -/
 
-/-- Push negation through `box`: `¬□p ↔ ◇¬p`. -/
 @[simp] theorem not_box (p : W → Prop) (w : W) :
     ¬ □[R] p w ↔ ◇[R] (fun v => ¬ p v) w := by
   simp [box, diamond, not_forall]
 
-/-- Push negation through `diamond`: `¬◇p ↔ □¬p`. -/
 @[simp] theorem not_diamond (p : W → Prop) (w : W) :
     ¬ ◇[R] p w ↔ □[R] (fun v => ¬ p v) w := by
   simp [box, diamond, not_and]

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -12,11 +12,7 @@ of Kripke semantics ([kripke-1963]).
 
 namespace ModalLogic
 
-/-! ### Frame conditions
-
-Reflexivity, symmetry, and transitivity are `Std.Refl R`, `Std.Symm R`,
-`IsTrans W R` from Lean core + mathlib. Seriality and Euclideanness are
-modal-logic-specific and defined here. -/
+/-! ### Frame conditions -/
 
 /-- Seriality: every world accesses at least one world.
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -1,4 +1,5 @@
 import Mathlib.Logic.Basic
+import Mathlib.Logic.Relator
 import Mathlib.Order.Defs.Unbundled
 import Mathlib.Order.PropInstances
 
@@ -14,19 +15,16 @@ namespace ModalLogic
 
 /-! ### Frame conditions -/
 
-/-- A relation is **serial** if every world accesses at least one world. -/
+/-- `R` is **serial** if every world accesses at least one world. -/
 class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
-  serial : ∀ w, ∃ v, R w v
+  serial : Relator.LeftTotal R
 
-/-- A relation is **euclidean** if from any pair of `R`-successors of `w`,
-    each is an `R`-successor of the other. -/
+/-- `R` is **Euclidean** if from any pair of `R`-successors of `w`, each is
+    an `R`-successor of the other. -/
 class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
 
-/-! ### Frame implications and instances
-
-The universal relation is `⊤ : W → W → Prop` and the empty relation `⊥`,
-via the pointwise lattice on relations. -/
+/-! ### Frame implications and instances -/
 
 variable {W : Type*}
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -14,15 +14,12 @@ namespace ModalLogic
 
 /-! ### Frame conditions -/
 
-/-- Seriality: every world accesses at least one world.
-
-    Identical as a `Prop` to `Mathlib.Logic.Relator.LeftTotal R`, but
-    packaged as a class with the modal-logic-canonical name. -/
+/-- A relation is **serial** if every world accesses at least one world. -/
 class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
   serial : ∀ w, ∃ v, R w v
 
-/-- Euclideanness: from any pair of `R`-successors of `w`, each is an
-    `R`-successor of the other. No mathlib analogue (modal-specific). -/
+/-- A relation is **euclidean** if from any pair of `R`-successors of `w`,
+    each is an `R`-successor of the other. -/
 class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -28,10 +28,9 @@ class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
 
 variable {W : Type*}
 
+-- Seriality, symmetry, and transitivity of `⊤` follow from the two
+-- instances below via the derivations that follow.
 instance : Std.Refl (⊤ : W → W → Prop) := ⟨fun _ => trivial⟩
-instance : IsSerial (⊤ : W → W → Prop) := ⟨fun w => ⟨w, trivial⟩⟩
-instance : IsTrans W (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
-instance : Std.Symm (⊤ : W → W → Prop) := ⟨fun _ _ _ => trivial⟩
 instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
 -- The derived instances get lowered priority: the Refl+Euclidean and
@@ -39,23 +38,24 @@ instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial�
 -- should always be preferred.
 
 /-- Reflexive relations are serial. -/
-instance (priority := 100) {R : W → W → Prop} [h : Std.Refl R] :
-    IsSerial R := ⟨fun w => ⟨w, h.refl w⟩⟩
+instance (priority := 100) {R : W → W → Prop} [Std.Refl R] : IsSerial R where
+  serial w := ⟨w, Std.Refl.refl w⟩
 
 /-- Reflexive + Euclidean implies symmetric. -/
-instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEuclidean R] :
-    Std.Symm R :=
-  ⟨fun w v hwv => hE.eucl w v w hwv (hR.refl w)⟩
+instance (priority := 100) {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
+    Std.Symm R where
+  symm w v hwv := IsEuclidean.eucl w v w hwv (Std.Refl.refl w)
 
 /-- Reflexive + Euclidean implies transitive. -/
-instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEuclidean R] :
-    IsTrans W R :=
-  ⟨fun w v u hwv hvu => hE.eucl v w u (hE.eucl w v w hwv (hR.refl w)) hvu⟩
+instance (priority := 100) {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
+    IsTrans W R where
+  trans w v u hwv hvu :=
+    IsEuclidean.eucl v w u (IsEuclidean.eucl w v w hwv (Std.Refl.refl w)) hvu
 
 /-- Symmetric + transitive implies euclidean. -/
-instance (priority := 100) {R : W → W → Prop} [hS : Std.Symm R] [hT : IsTrans W R] :
-    IsEuclidean R :=
-  ⟨fun w v u hwv hwu => hT.trans v w u (hS.symm w v hwv) hwu⟩
+instance (priority := 100) {R : W → W → Prop} [Std.Symm R] [IsTrans W R] :
+    IsEuclidean R where
+  eucl w v u hwv hwu := IsTrans.trans v w u (Std.Symm.symm w v hwv) hwu
 
 /-! ### Box and diamond -/
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -12,11 +12,11 @@ of Kripke semantics ([kripke-1963]).
 
 namespace ModalLogic
 
-/-! ### Frame conditions -/
+/-! ### Frame conditions
 
-/-! Reflexivity, symmetry, and transitivity are `Std.Refl R`,
-    `Std.Symm R`, `IsTrans W R` from Lean core + mathlib. Seriality
-    and Euclideanness are modal-logic-specific and defined here. -/
+Reflexivity, symmetry, and transitivity are `Std.Refl R`, `Std.Symm R`,
+`IsTrans W R` from Lean core + mathlib. Seriality and Euclideanness are
+modal-logic-specific and defined here. -/
 
 /-- Seriality: every world accesses at least one world.
 
@@ -29,12 +29,6 @@ class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
     `R`-successor of the other. No mathlib analogue (modal-specific). -/
 class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
-
-/-- `Rb` is a *belief refinement* of `Rk`: every belief-accessible world is
-    knowledge-accessible. The pure subset condition; whether `Rk` is S5
-    and `Rb` is KD45 is asserted by separate instance declarations. -/
-class IsBeliefRefinementOf {W : Type*} (Rk Rb : W → W → Prop) : Prop where
-  sub : ∀ w v, Rb w v → Rk w v
 
 /-! ### Frame implications and instances
 
@@ -49,8 +43,12 @@ instance : IsTrans W (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 instance : Std.Symm (⊤ : W → W → Prop) := ⟨fun _ _ _ => trivial⟩
 instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
+-- The derived instances get lowered priority: the Refl+Euclidean and
+-- Symm+Trans derivations are mutually productive, and direct instances
+-- should always be preferred.
+
 /-- Reflexive relations are serial. -/
-instance (priority := 100) Std.Refl.toIsSerial {R : W → W → Prop} [h : Std.Refl R] :
+instance (priority := 100) {R : W → W → Prop} [h : Std.Refl R] :
     IsSerial R := ⟨fun w => ⟨w, h.refl w⟩⟩
 
 /-- Reflexive + Euclidean implies symmetric. -/
@@ -61,7 +59,7 @@ instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEucl
 /-- Reflexive + Euclidean implies transitive. -/
 instance (priority := 100) {R : W → W → Prop} [hR : Std.Refl R] [hE : IsEuclidean R] :
     IsTrans W R :=
-  ⟨fun w v u hwv hvu => hE.eucl v w u (Std.Symm.symm w v hwv) hvu⟩
+  ⟨fun w v u hwv hvu => hE.eucl v w u (hE.eucl w v w hwv (hR.refl w)) hvu⟩
 
 /-- Symmetric + transitive implies euclidean. -/
 instance (priority := 100) {R : W → W → Prop} [hS : Std.Symm R] [hT : IsTrans W R] :
@@ -75,12 +73,14 @@ instance (priority := 100) {R : W → W → Prop} [hS : Std.Symm R] [hT : IsTran
 
     `⟦□_R φ⟧^w = 1` iff `⟦φ⟧^v = 1` for all `v` with `R(w,v)` — the Kripke
     generalization of the S5 necessity of [dowty-wall-peters-1981]'s IL,
-    whose `Intensional.box` is the universal-accessibility special case. -/
+    whose `Intensional.box` is the universal-accessibility special case.
+    The `Set`-valued mathlib counterpart is `Rel.core`. -/
 def box (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
   ∀ v, R w v → p v
 
 /-- Restricted possibility: `◇_R p` at world `w` holds iff `p v` for some
-    `v` accessible from `w`. Dual of `box`. -/
+    `v` accessible from `w`. Dual of `box`; the `Set`-valued mathlib
+    counterpart is `Rel.preimage`. -/
 def diamond (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
   ∃ v, R w v ∧ p v
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -26,7 +26,7 @@ class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
 
 /-! ### Frame implications and instances -/
 
-variable {W : Type*}
+variable {W : Type*} {R : W → W → Prop}
 
 -- Seriality, symmetry, and transitivity of `⊤` follow from the two
 -- instances below via the derivations that follow.
@@ -34,26 +34,23 @@ instance : Std.Refl (⊤ : W → W → Prop) := ⟨fun _ => trivial⟩
 instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
 /-- Reflexive relations are serial. -/
-instance {R : W → W → Prop} [Std.Refl R] : IsSerial R where
-  serial w := ⟨w, Std.Refl.refl w⟩
+instance [hR : Std.Refl R] : IsSerial R where serial w := ⟨w, hR.refl w⟩
 
 /-- Reflexive + Euclidean implies symmetric. -/
-instance {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
-    Std.Symm R where
-  symm w v hwv := IsEuclidean.eucl w v w hwv (Std.Refl.refl w)
+instance [hR : Std.Refl R] [hE : IsEuclidean R] : Std.Symm R where
+  symm w v hwv := hE.eucl w v w hwv (hR.refl w)
 
 /-- Reflexive + Euclidean implies transitive. -/
-instance {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
-    IsTrans W R where
-  trans w v u hwv hvu :=
-    IsEuclidean.eucl v w u (IsEuclidean.eucl w v w hwv (Std.Refl.refl w)) hvu
+instance [hR : Std.Refl R] [hE : IsEuclidean R] : IsTrans W R where
+  trans w v u hwv hvu := hE.eucl v w u (hE.eucl w v w hwv (hR.refl w)) hvu
 
 /-- Symmetric + transitive implies euclidean. -/
-instance {R : W → W → Prop} [Std.Symm R] [IsTrans W R] :
-    IsEuclidean R where
-  eucl w v u hwv hwu := IsTrans.trans v w u (Std.Symm.symm w v hwv) hwu
+instance [hS : Std.Symm R] [hT : IsTrans W R] : IsEuclidean R where
+  eucl w v u hwv hwu := hT.trans v w u (hS.symm w v hwv) hwu
 
 /-! ### Box and diamond -/
+
+variable (R)
 
 /-- Restricted necessity: `□_R p` at world `w` holds iff `p v` for all
     `v` accessible from `w`.
@@ -62,25 +59,25 @@ instance {R : W → W → Prop} [Std.Symm R] [IsTrans W R] :
     generalization of the S5 necessity of [dowty-wall-peters-1981]'s IL,
     whose `Intensional.box` is the universal-accessibility special case.
     The `Set`-valued mathlib counterpart is `Rel.core`. -/
-def box (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
+def box (p : W → Prop) (w : W) : Prop :=
   ∀ v, R w v → p v
 
 /-- Restricted possibility: `◇_R p` at world `w` holds iff `p v` for some
     `v` accessible from `w`. Dual of `box`; the `Set`-valued mathlib
     counterpart is `Rel.preimage`. -/
-def diamond (R : W → W → Prop) (p : W → Prop) (w : W) : Prop :=
+def diamond (p : W → Prop) (w : W) : Prop :=
   ∃ v, R w v ∧ p v
 
 /-! ### Duality -/
 
 /-- Restricted modal duality: `□_R p ↔ ¬◇_R ¬p`. -/
-theorem box_neg_diamond (R : W → W → Prop) (p : W → Prop) (w : W) :
+theorem box_neg_diamond (p : W → Prop) (w : W) :
     box R p w ↔ ¬ diamond R (fun v => ¬ p v) w :=
   ⟨fun hb ⟨v, hwv, hnp⟩ => hnp (hb v hwv),
    fun h v hwv => Classical.byContradiction fun hnp => h ⟨v, hwv, hnp⟩⟩
 
 /-- Dual form: `◇_R p ↔ ¬□_R ¬p`. -/
-theorem diamond_neg_box (R : W → W → Prop) (p : W → Prop) (w : W) :
+theorem diamond_neg_box (p : W → Prop) (w : W) :
     diamond R p w ↔ ¬ box R (fun v => ¬ p v) w :=
   ⟨fun ⟨v, hwv, hpv⟩ h => h v hwv hpv,
    fun h => Classical.byContradiction fun hne =>

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -33,27 +33,23 @@ variable {W : Type*}
 instance : Std.Refl (⊤ : W → W → Prop) := ⟨fun _ => trivial⟩
 instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
--- The derived instances get lowered priority: the Refl+Euclidean and
--- Symm+Trans derivations are mutually productive, and direct instances
--- should always be preferred.
-
 /-- Reflexive relations are serial. -/
-instance (priority := 100) {R : W → W → Prop} [Std.Refl R] : IsSerial R where
+instance {R : W → W → Prop} [Std.Refl R] : IsSerial R where
   serial w := ⟨w, Std.Refl.refl w⟩
 
 /-- Reflexive + Euclidean implies symmetric. -/
-instance (priority := 100) {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
+instance {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
     Std.Symm R where
   symm w v hwv := IsEuclidean.eucl w v w hwv (Std.Refl.refl w)
 
 /-- Reflexive + Euclidean implies transitive. -/
-instance (priority := 100) {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
+instance {R : W → W → Prop} [Std.Refl R] [IsEuclidean R] :
     IsTrans W R where
   trans w v u hwv hvu :=
     IsEuclidean.eucl v w u (IsEuclidean.eucl w v w hwv (Std.Refl.refl w)) hvu
 
 /-- Symmetric + transitive implies euclidean. -/
-instance (priority := 100) {R : W → W → Prop} [Std.Symm R] [IsTrans W R] :
+instance {R : W → W → Prop} [Std.Symm R] [IsTrans W R] :
     IsEuclidean R where
   eucl w v u hwv hwu := IsTrans.trans v w u (Std.Symm.symm w v hwv) hwu
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -8,7 +8,8 @@ import Mathlib.Order.PropInstances
 
 This file defines the frame conditions of modal correspondence theory for
 accessibility relations `W → W → Prop`, and the relational `box`/`diamond`
-of Kripke semantics ([kripke-1963]).
+of Kripke semantics ([kripke-1963]); their `Set`-valued mathlib
+counterparts are `Rel.core` and `Rel.preimage`.
 -/
 
 namespace ModalLogic
@@ -52,19 +53,13 @@ instance [hS : Std.Symm R] [hT : IsTrans W R] : IsEuclidean R where
 
 variable (R)
 
-/-- Restricted necessity: `□_R p` at world `w` holds iff `p v` for all
-    `v` accessible from `w`.
-
-    `⟦□_R φ⟧^w = 1` iff `⟦φ⟧^v = 1` for all `v` with `R(w,v)` — the Kripke
-    generalization of the S5 necessity of [dowty-wall-peters-1981]'s IL,
-    whose `Intensional.box` is the universal-accessibility special case.
-    The `Set`-valued mathlib counterpart is `Rel.core`. -/
+/-- Restricted necessity: `box R p w` holds iff `p v` for all `v`
+    accessible from `w`. -/
 def box (p : W → Prop) (w : W) : Prop :=
   ∀ v, R w v → p v
 
-/-- Restricted possibility: `◇_R p` at world `w` holds iff `p v` for some
-    `v` accessible from `w`. Dual of `box`; the `Set`-valued mathlib
-    counterpart is `Rel.preimage`. -/
+/-- Restricted possibility: `diamond R p w` holds iff `p v` for some `v`
+    accessible from `w`. Dual of `box`. -/
 def diamond (p : W → Prop) (w : W) : Prop :=
   ∃ v, R w v ∧ p v
 

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -4,30 +4,59 @@ import Mathlib.Order.Defs.Unbundled
 import Mathlib.Order.PropInstances
 
 /-!
-# Frame conditions and modal operators
+# Modal operators and frame conditions
 
-This file defines the frame conditions of modal correspondence theory for
-accessibility relations `W → W → Prop`, and the relational `box`/`diamond`
-of Kripke semantics ([kripke-1963]); their `Set`-valued mathlib
-counterparts are `Rel.core` and `Rel.preimage`.
+This file defines the relational `box`/`diamond` of Kripke semantics
+([kripke-1963]) and the frame conditions of modal correspondence theory
+for accessibility relations `W → W → Prop`; the `Set`-valued mathlib
+counterparts of the operators are `Rel.core` and `Rel.preimage`.
 -/
 
 namespace ModalLogic
 
+variable {W : Type*} (R : W → W → Prop)
+
+/-! ### Box and diamond -/
+
+/-- Restricted necessity: `box R p w` holds iff `p v` for all `v`
+    accessible from `w`. -/
+def box (p : W → Prop) (w : W) : Prop :=
+  ∀ v, R w v → p v
+
+/-- Restricted possibility: `diamond R p w` holds iff `p v` for some `v`
+    accessible from `w`. Dual of `box`. -/
+def diamond (p : W → Prop) (w : W) : Prop :=
+  ∃ v, R w v ∧ p v
+
+@[inherit_doc] scoped notation:max "□[" R "]" => box R
+@[inherit_doc] scoped notation:max "◇[" R "]" => diamond R
+
+/-! ### Duality -/
+
+/-- Push negation through `box`: `¬□p ↔ ◇¬p`. -/
+@[simp] theorem not_box (p : W → Prop) (w : W) :
+    ¬ □[R] p w ↔ ◇[R] (fun v => ¬ p v) w := by
+  simp [box, diamond, not_forall]
+
+/-- Push negation through `diamond`: `¬◇p ↔ □¬p`. -/
+@[simp] theorem not_diamond (p : W → Prop) (w : W) :
+    ¬ ◇[R] p w ↔ □[R] (fun v => ¬ p v) w := by
+  simp [box, diamond, not_and]
+
 /-! ### Frame conditions -/
 
 /-- `R` is **serial** if every world accesses at least one world. -/
-class IsSerial {W : Type*} (R : W → W → Prop) : Prop where
+class IsSerial : Prop where
   serial : Relator.LeftTotal R
 
 /-- `R` is **Euclidean** if from any pair of `R`-successors of `w`, each is
     an `R`-successor of the other. -/
-class IsEuclidean {W : Type*} (R : W → W → Prop) : Prop where
+class IsEuclidean : Prop where
   eucl : ∀ w v u, R w v → R w u → R v u
 
 /-! ### Frame implications and instances -/
 
-variable {W : Type*} {R : W → W → Prop}
+variable {R}
 
 -- Seriality, symmetry, and transitivity of `⊤` follow from the two
 -- instances below via the derivations that follow.
@@ -48,34 +77,5 @@ instance [hR : Std.Refl R] [hE : IsEuclidean R] : IsTrans W R where
 /-- Symmetric + transitive implies euclidean. -/
 instance [hS : Std.Symm R] [hT : IsTrans W R] : IsEuclidean R where
   eucl w v u hwv hwu := hT.trans v w u (hS.symm w v hwv) hwu
-
-/-! ### Box and diamond -/
-
-variable (R)
-
-/-- Restricted necessity: `box R p w` holds iff `p v` for all `v`
-    accessible from `w`. -/
-def box (p : W → Prop) (w : W) : Prop :=
-  ∀ v, R w v → p v
-
-/-- Restricted possibility: `diamond R p w` holds iff `p v` for some `v`
-    accessible from `w`. Dual of `box`. -/
-def diamond (p : W → Prop) (w : W) : Prop :=
-  ∃ v, R w v ∧ p v
-
-/-! ### Duality -/
-
-/-- Restricted modal duality: `□_R p ↔ ¬◇_R ¬p`. -/
-theorem box_neg_diamond (p : W → Prop) (w : W) :
-    box R p w ↔ ¬ diamond R (fun v => ¬ p v) w :=
-  ⟨fun hb ⟨v, hwv, hnp⟩ => hnp (hb v hwv),
-   fun h v hwv => Classical.byContradiction fun hnp => h ⟨v, hwv, hnp⟩⟩
-
-/-- Dual form: `◇_R p ↔ ¬□_R ¬p`. -/
-theorem diamond_neg_box (p : W → Prop) (w : W) :
-    diamond R p w ↔ ¬ box R (fun v => ¬ p v) w :=
-  ⟨fun ⟨v, hwv, hpv⟩ h => h v hwv hpv,
-   fun h => Classical.byContradiction fun hne =>
-     h fun v hwv hpv => hne ⟨v, hwv, hpv⟩⟩
 
 end ModalLogic

--- a/Linglib/Semantics/Modality/EpistemicLogic.lean
+++ b/Linglib/Semantics/Modality/EpistemicLogic.lean
@@ -38,7 +38,7 @@ on finite worlds goes through `Decidable` instances + `decide`.
 namespace Modality.EpistemicLogic
 
 open ModalLogic
-  (box diamond IsSerial IsEuclidean IsBeliefRefinementOf box_T box_D box_four box_B box_five)
+  (box diamond IsSerial IsEuclidean box_T box_D box_four box_B box_five)
 
 /-! ## Individual Knowledge
 
@@ -188,14 +188,13 @@ def distributedBelief {W E : Type*} (Rs : E → W → W → Prop)
   box (groupAccessRel Rs group) φ w
 
 /-- Knowledge implies belief: Kᵢ(φ) → Bᵢ(φ), given that every
-    belief-accessible world is knowledge-accessible. The
-    `[IsBeliefRefinementOf (Rk i) (Rb i)]` constraint encodes the
-    pointwise refinement; whether `Rk` is S5 and `Rb` is KD45 is
+    belief-accessible world is knowledge-accessible (`Rb i ≤ Rk i` in the
+    pointwise order on relations); whether `Rk` is S5 and `Rb` is KD45 is
     a separate stipulation (cf. Hintikka 1962). -/
 theorem knows_implies_believes {W E : Type*}
-    (Rk Rb : E → W → W → Prop) (i : E) [hRef : IsBeliefRefinementOf (Rk i) (Rb i)]
+    (Rk Rb : E → W → W → Prop) (i : E) (hsub : Rb i ≤ Rk i)
     (φ : W → Prop) (w : W) (h : knows Rk i φ w) :
-    believes Rb i φ w := fun v hv => h v (hRef.sub w v hv)
+    believes Rb i φ w := fun v hv => h v (hsub w v hv)
 
 /-- Belief is consistent: Bᵢ(φ) → ◇ᵢφ (the D axiom).
     Follows from seriality of the belief accessibility relation. -/

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -235,11 +235,11 @@ theorem empty_base_universal_access (w : W) :
 /-! ### Modal axioms (from `RestrictedModality`) -/
 
 /-- **Modal duality**: `□p ↔ ¬◇¬p`. Since `necessity = box (kratzerBestR f g)`,
-    this is the box–diamond duality of the modal square of opposition
-    (`ModalLogic.modalSquare_relations`). -/
+    this is the box–diamond duality (`ModalLogic.not_diamond`). -/
 theorem duality (f : ModalBase W) (g : OrderingSource W) (p : W → Prop) (w : W) :
     necessity f g p w ↔ ¬ possibility f g (fun w' => ¬ p w') w := by
-  rw [necessity, possibility, box_neg_diamond]
+  rw [necessity, possibility, ModalLogic.not_diamond]
+  simp [ModalLogic.box]
 
 /-- **K (Distribution)**: `□(p → q) → □p → □q`. -/
 theorem K_axiom (f : ModalBase W) (g : OrderingSource W) (p q : W → Prop) (w : W)

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -29,7 +29,6 @@ namespace Semantics.Presupposition.BeliefEmbedding
 open Semantics.Presupposition
 open CommonGround
 open Semantics.Presupposition.Context
-open ModalLogic (IsBeliefRefinementOf)
 
 variable {W : Type*} {Agent : Type*}
 
@@ -192,7 +191,7 @@ theorem stop_ole_attribution :
 
 Doxastic accessibility is `E → W → W → Prop` directly, so
 belief local contexts compose with the epistemic-logic frame conditions:
-when belief pointwise refines knowledge (`IsBeliefRefinementOf`), filtering
+when belief pointwise refines knowledge (`Rb i ≤ Rk i`), filtering
 under knowledge embedding implies filtering under belief embedding.
 -/
 
@@ -210,22 +209,22 @@ def localCtxOf (Rs : E → W → W → Prop) (ctx : ContextSet W) (i : E) :
 /-- Belief-accessible worlds are a subset of knowledge-accessible worlds
     when belief refines knowledge pointwise. -/
 theorem localCtx_sub_of_refinement (Rk Rb : E → W → W → Prop)
-    (ctx : ContextSet W) (i : E) [hRef : IsBeliefRefinementOf (Rk i) (Rb i)]
+    (ctx : ContextSet W) (i : E) (hsub : Rb i ≤ Rk i)
     (w_star : W) :
     ∀ w, (localCtxOf Rb ctx i).atWorld w_star w →
          (localCtxOf Rk ctx i).atWorld w_star w := by
   intro w ⟨hctx, hbel⟩
-  exact ⟨hctx, hRef.sub w_star w hbel⟩
+  exact ⟨hctx, hsub w_star w hbel⟩
 
 /-- If a presupposition is filtered under knowledge embedding, it is also
     filtered under any belief embedding that refines knowledge. -/
 theorem knowledge_filtered_implies_belief_filtered
     (Rk Rb : E → W → W → Prop) (ctx : ContextSet W) (i : E)
-    [IsBeliefRefinementOf (Rk i) (Rb i)] (p : PartialProp W) (w_star : W) :
+    (hsub : Rb i ≤ Rk i) (p : PartialProp W) (w_star : W) :
     ContextSet.entails ((localCtxOf Rk ctx i).atWorld w_star) p.presup →
     ContextSet.entails ((localCtxOf Rb ctx i).atWorld w_star) p.presup := by
   intro h_know w h_bel
-  exact h_know (localCtx_sub_of_refinement Rk Rb ctx i w_star w h_bel)
+  exact h_know (localCtx_sub_of_refinement Rk Rb ctx i hsub w_star w h_bel)
 
 end Refinement
 

--- a/Linglib/Studies/Heim1992Projection.lean
+++ b/Linglib/Studies/Heim1992Projection.lean
@@ -38,7 +38,7 @@ namespace Heim1992
 
 open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
-open ModalLogic (IsSerial IsEuclidean IsS5Frame IsKD45Frame IsBeliefRefinementOf)
+open ModalLogic (IsSerial IsEuclidean IsS5Frame IsKD45Frame)
 open Semantics.Presupposition.Context (presupSatisfied)
 open Semantics.Presupposition.BeliefEmbedding
 
@@ -124,9 +124,9 @@ instance : IsS5Frame (agentKnowsR .john) where
 /-- John's belief is KD45. -/
 instance : IsKD45Frame (agentBelievesR .john) where
 
-/-- Belief refines knowledge for John: R_B ⊆ R_K. -/
-instance : IsBeliefRefinementOf (agentKnowsR .john) (agentBelievesR .john) :=
-  ⟨fun _ _ _ => trivial⟩
+/-- Belief refines knowledge for John: `R_B ≤ R_K`. -/
+theorem agentBelieves_le_knows : agentBelievesR .john ≤ agentKnowsR .john :=
+  fun _ _ _ => trivial
 
 /-! ## Presupposition -/
 


### PR DESCRIPTION
Register and API pass on `Modal/Defs.lean`, following an architecture check against mathlib, plus consumer-driven refinements.

- `IsBeliefRefinementOf` deleted (it was the pointwise `Rb ≤ Rk`); `IsSerial.serial` is now `Relator.LeftTotal R` (the `IsWellFounded.wf` pattern); three redundant `⊤`-instances deleted (derivable from `Refl` + `Euclidean` via the file's own implication chain); instance priorities dropped (Lean 4 tabled resolution handles the cyclic derivations; Prop-class selection is proof-irrelevant).
- Scoped `□[R]`/`◇[R]` notation (mathlib `~[R]` style, partially-applied so ordinary application gives `□[R] p w`); duality restated in push-negation normal form as `@[simp] not_box`/`not_diamond` with one-line simp proofs, replacing the hand-rolled classical terms (sole consumer's textbook `duality` now derives in two lines); operators lead the file, title corrected to "Modal operators and frame conditions" (the file no longer defines accessibility relations).
- Docstrings are definition-form one-liners; section headers bare; `variable`-lifted binders with the `(R)`/`{R}` flip.

Checked, not changed: `Std.Refl R`/`IsTrans W R` mixed arity is mathlib's current register (`IsRefl` deprecated in favor of `Std.Refl`, 2026-01-08).
