### PR TITLE
style(Logic/Modal): implicit binders and notation for the axiom theorems

### DIFF
--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -130,13 +130,13 @@ def Committed (c : CommitmentState W A) (a b : A) (π : Set W) (w : W) : Prop :=
 theorem believes_four (c : CommitmentState W A) (a : A) (π : Set W) (w : W)
     (h : Believes c a π w) :
     Believes c a (fun v => Believes c a π v) w :=
-  box_four (c.belief a) (fun v => v ∈ π) w h
+  box_four h
 
 /-- Commitment satisfies the 4 axiom. -/
 theorem committed_four (c : CommitmentState W A) (a b : A) (π : Set W) (w : W)
     (h : Committed c a b π w) :
     Committed c a b (fun v => Committed c a b π v) w :=
-  box_four (c.commitment a b) (fun v => v ∈ π) w h
+  box_four h
 
 /-! ### Frame conditions linking belief and commitment -/
 

--- a/Linglib/Logic/Aristotelian/Square.lean
+++ b/Linglib/Logic/Aristotelian/Square.lean
@@ -47,6 +47,24 @@ structure SquareRelations (sq : Square α) where
   /-- I and O are subcontraries. -/
   subcontrIO : Codisjoint sq.I sq.O
 
+/-- The classical square: when the particulars are the complements of the
+    opposite universals (`I = Eᶜ`, `O = Aᶜ`), the contradiction diagonals
+    hold outright and the remaining relations are each equivalent to
+    contrariety, so `Disjoint A E` yields the full square. Under the modern
+    Boolean reading, contrariety is where existential import lives: it
+    fails when the universals hold vacuously (empty subject term; modally,
+    a dead-end world), and the discharging assumption — a non-empty term,
+    seriality — enters through this hypothesis. -/
+theorem SquareRelations.of_disjoint {sq : Square α}
+    (hI : sq.I = sq.Eᶜ) (hO : sq.O = sq.Aᶜ) (h : Disjoint sq.A sq.E) :
+    SquareRelations sq := by
+  refine ⟨?_, ?_, ?_, ?_, h, ?_⟩
+  · rw [hI]; exact le_compl_iff_disjoint_right.mpr h
+  · rw [hO]; exact le_compl_iff_disjoint_right.mpr h.symm
+  · rw [hO]; exact isCompl_compl
+  · rw [hI]; exact isCompl_compl
+  · rw [hI, hO, codisjoint_iff, ← compl_inf, disjoint_iff.mp h.symm, compl_bot]
+
 /-! ### Bridges to the Aristotelian predicates -/
 
 /-- Lift to `IsSubaltern sq.A sq.I` given strictness `sq.A ≠ sq.I`. -/

--- a/Linglib/Logic/Modal/BSML/Bisimulation.lean
+++ b/Linglib/Logic/Modal/BSML/Bisimulation.lean
@@ -43,7 +43,7 @@ namespace BSML
 
 open ModalLogic
 
-variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
+variable {W W' : Type*} [DecidableEq W] [DecidableEq W']
 variable {Atom : Type*}
 
 /-! ### Modal depth -/

--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -25,9 +25,12 @@ team semantics restricted to singleton teams.
 
 namespace BSML
 
-open ModalLogic (KripkeModel)
+open ModalLogic (KripkeModel diamond)
 
-variable {W : Type*} [DecidableEq W] {Atom : Type*}
+variable {W : Type*} {Atom : Type*}
+
+section
+variable [DecidableEq W]
 
 -- ============================================================================
 -- §1: Classical Evaluation
@@ -217,8 +220,6 @@ theorem neFree_flat (M : KripkeModel W Atom)
 -- §5: BSML–CML Type Bridge
 -- ============================================================================
 
-open ModalLogic (diamond)
-
 /-!
 ### Accessibility Type Bridge
 
@@ -233,6 +234,8 @@ canonical accessibility-relation type in
 def _root_.ModalLogic.KripkeModel.toAccessRel (M : KripkeModel W Atom) :
     W → W → Prop :=
   fun w v => v ∈ M.access w
+
+end
 
 /-- `classicalEval` of ◇φ agrees with `diamond` (Prop-valued possibility),
     connecting BSML's classical evaluation to the shared modal logic

--- a/Linglib/Logic/Modal/BSML/Bridge.lean
+++ b/Linglib/Logic/Modal/BSML/Bridge.lean
@@ -27,7 +27,7 @@ namespace BSML
 
 open ModalLogic (KripkeModel)
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 -- ============================================================================
 -- §1: Classical Evaluation

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -41,7 +41,7 @@ namespace BSML
 
 open ModalLogic
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 /-! ### `⊤` and finite conjunction -/
 

--- a/Linglib/Logic/Modal/BSML/Characteristic.lean
+++ b/Linglib/Logic/Modal/BSML/Characteristic.lean
@@ -43,7 +43,7 @@ namespace BSML
 
 open ModalLogic
 
-variable {W : Type*} [DecidableEq W] {Atom : Type*}
+variable {W : Type*} {Atom : Type*}
 
 /-! ### `⊤` and finite conjunction -/
 
@@ -238,6 +238,8 @@ theorem classicalEval_charFormula_iff_bisim [Fintype Atom] [Inhabited Atom]
            (ih u u').mpr hb⟩
 
 /-! ### Team support of the auxiliary connectives -/
+
+variable [DecidableEq W]
 
 theorem support_verum [Inhabited Atom] (M : KripkeModel W Atom) (t : Finset W) :
     support M (verum (Atom := Atom)) t := by

--- a/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
+++ b/Linglib/Logic/Modal/BSML/ClassicalValidities.lean
@@ -51,7 +51,7 @@ namespace BSML
 
 open ModalLogic (KripkeModel)
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 /-! ### Box-diamond duality -/
 

--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -215,10 +215,12 @@ def _root_.ModalLogic.KripkeModel.IsIndisputable (M : KripkeModel W Atom) (t : F
 def _root_.ModalLogic.KripkeModel.IsStateBased (M : KripkeModel W Atom) (t : Finset W) : Prop :=
   Team.IsStateBased M.access t
 
-instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsIndisputable t) :=
+instance [Fintype W] (M : KripkeModel W Atom) (t : Finset W) :
+    Decidable (M.IsIndisputable t) :=
   inferInstanceAs (Decidable (Team.IsIndisputable M.access t))
 
-instance (M : KripkeModel W Atom) (t : Finset W) : Decidable (M.IsStateBased t) :=
+instance [Fintype W] (M : KripkeModel W Atom) (t : Finset W) :
+    Decidable (M.IsStateBased t) :=
   inferInstanceAs (Decidable (Team.IsStateBased M.access t))
 
 /-! ### Consequence and equivalence -/
@@ -283,7 +285,7 @@ def consequenceStar (φ ψ : Formula Atom) : Prop :=
 /-! ### Decidability of evaluation -/
 
 /-- Decidability of `eval` by structural recursion on the formula. -/
-def decidableEval (M : KripkeModel W Atom) :
+def decidableEval [Fintype W] (M : KripkeModel W Atom) :
     (pol : Bool) → (φ : Formula Atom) → (t : Finset W) → Decidable (eval M pol φ t)
   | true,  .atom _, t => by unfold eval; infer_instance
   | false, .atom _, t => by unfold eval; infer_instance
@@ -347,7 +349,7 @@ def decidableEval (M : KripkeModel W Atom) :
         (fun w _ => eval M false ψ (M.access w))
         (fun w _ => decidableEval M false ψ (M.access w))
 
-instance instDecidableEval (M : KripkeModel W Atom) (pol : Bool) (φ : Formula Atom)
+instance instDecidableEval [Fintype W] (M : KripkeModel W Atom) (pol : Bool) (φ : Formula Atom)
     (t : Finset W) : Decidable (eval M pol φ t) := decidableEval M pol φ t
 
 end BSML

--- a/Linglib/Logic/Modal/BSML/Defs.lean
+++ b/Linglib/Logic/Modal/BSML/Defs.lean
@@ -126,7 +126,7 @@ instance instDecidablePositive : (φ : Formula Atom) → Decidable φ.Positive
 
 /-! ### Bilateral evaluation -/
 
-variable {W : Type*} [DecidableEq W] [Fintype W]
+variable {W : Type*} [DecidableEq W]
 
 /-- Bilateral evaluation with polarity parameter: `eval M true φ t` is
     support (`⊨⁺`), `eval M false φ t` is anti-support (`⊨⁻`), and negation

--- a/Linglib/Logic/Modal/BSML/Enrichment.lean
+++ b/Linglib/Logic/Modal/BSML/Enrichment.lean
@@ -28,7 +28,7 @@ namespace BSML
 
 open ModalLogic (KripkeModel)
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 -- ============================================================================
 -- §1: Pragmatic Enrichment (Definition 6)

--- a/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
+++ b/Linglib/Logic/Modal/BSML/ExpressiveCompleteness.lean
@@ -41,7 +41,7 @@ namespace BSML
 
 open Team ModalLogic
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 /-! ### Bounded-bisimulation closure (the third soundness pillar) -/
 
@@ -97,7 +97,7 @@ theorem expressiveSoundness (M : KripkeModel W Atom) :
     which yields a team `s₀ ∈ P` whose classes `t` covers, and `s₀ ∪ (U`
     restricted to `t`'s classes`)` lies in `P` by convexity between `s₀`
     and `U` and is bisimilar to `t` — so `t ∈ P` by bisimulation closure. -/
-theorem expressiveCompleteness_converse [Fintype Atom] [Inhabited Atom]
+theorem expressiveCompleteness_converse [Fintype W] [Fintype Atom] [Inhabited Atom]
     (M : KripkeModel W Atom) :
     convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M ⊆
       definableClass (support M) := by
@@ -188,7 +188,7 @@ theorem expressiveCompleteness_converse [Fintype Atom] [Inhabited Atom]
 /-- **BSML is expressively complete** for the convex, union-closed,
     bounded-bisimulation-closed team properties ([anttila-2025] Ch 3, in
     within-model finite-atom form). -/
-theorem expressivelyComplete [Fintype Atom] [Inhabited Atom]
+theorem expressivelyComplete [Fintype W] [Fintype Atom] [Inhabited Atom]
     (M : KripkeModel W Atom) :
     ExpressivelyCompleteFor (support M)
       (convexProperties ∩ unionClosedProperties ∩ bisimClosedProperties M) :=

--- a/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
+++ b/Linglib/Logic/Modal/BSML/NaturalDeduction.lean
@@ -52,7 +52,7 @@ open ModalLogic (KripkeModel)
 
 open Team
 
-variable {Atom : Type*} {W : Type*} [DecidableEq W] [Fintype W]
+variable {Atom : Type*} {W : Type*} [DecidableEq W]
 
 /-! ### Contradictions -/
 

--- a/Linglib/Logic/Modal/BSML/Properties.lean
+++ b/Linglib/Logic/Modal/BSML/Properties.lean
@@ -50,7 +50,7 @@ open ModalLogic (KripkeModel)
 
 open Team
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 /-! ### Sup-closure (Anttila 2.2.8 part 2) -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -64,19 +64,15 @@ theorem diamond_box_gc : GaloisConnection ◇[R] □[flip R] :=
     ⟨fun h v hp w hwv => h w ⟨v, hwv, hp⟩,
      fun h w => fun ⟨v, hwv, hp⟩ => h v hp w hwv⟩
 
-/-- `box R` is monotone. -/
 theorem box_mono : Monotone □[R] :=
   (diamond_box_gc (flip R)).monotone_u
 
-/-- `diamond R` is monotone. -/
 theorem diamond_mono : Monotone ◇[R] :=
   (diamond_box_gc R).monotone_l
 
-/-- `□` distributes over `⊓`. -/
 theorem box_inf : □[R] (p ⊓ q) = □[R] p ⊓ □[R] q :=
   (diamond_box_gc (flip R)).u_inf
 
-/-- `◇` distributes over `⊔`. -/
 theorem diamond_sup : ◇[R] (p ⊔ q) = ◇[R] p ⊔ ◇[R] q :=
   (diamond_box_gc R).l_sup
 
@@ -103,141 +99,56 @@ theorem diamond_restrict {R₁ R₂ : W → W → Prop} (h : R₂ ≤ R₁) (p :
     ◇[R₂] p ≤ ◇[R₁] p :=
   fun _ hd => let ⟨v, hwv, hpv⟩ := hd; ⟨v, h _ _ hwv, hpv⟩
 
-/-! ### Bundled frame classes
-
-Named frame classes for the logics of `ModalLogic.frameConditions`; the
-per-logic correspondence theorems (`frameConditions_S5_iff`, …) live with
-the lattice below. -/
+/-! ### Bundled frame classes -/
 
 /-- S5 frame: reflexive + euclidean (implies symmetric + transitive). -/
-class IsS5Frame {W : Type*} (R : W → W → Prop) : Prop extends Std.Refl R, IsEuclidean R
+class IsS5Frame : Prop extends Std.Refl R, IsEuclidean R
 
 /-- KD45 frame for textbook belief: serial + transitive + euclidean. -/
-class IsKD45Frame {W : Type*} (R : W → W → Prop) : Prop
-  extends IsSerial R, IsTrans W R, IsEuclidean R
+class IsKD45Frame : Prop extends IsSerial R, IsTrans W R, IsEuclidean R
 
 /-- K45 frame: transitive + euclidean, NOT serial. The frame condition
     for commitment in [stalnaker-1984]-style discourse models, where
     commitment violations (no accessible compliance world) must be
     expressible. -/
-class IsK45Frame {W : Type*} (R : W → W → Prop) : Prop
-  extends IsTrans W R, IsEuclidean R
+class IsK45Frame : Prop extends IsTrans W R, IsEuclidean R
 
 /-- KTB frame: reflexive + symmetric. The natural setting for tolerance
     semantics ([cobreros-etal-2012]) where each predicate's
     similarity relation is reflexive and symmetric but possibly
     non-transitive. -/
-class IsKTBFrame {W : Type*} (R : W → W → Prop) : Prop
-  extends Std.Refl R, Std.Symm R
+class IsKTBFrame : Prop extends Std.Refl R, Std.Symm R
 
 /-! ### The Gallin hierarchy
 
-Propositional operators form a three-level hierarchy: **general**
-(`PropOp` — arbitrary properties of propositions, varying by world),
-**indicial** (Kripke-definable: `N = box R` for some accessibility `R`),
-and **S5** (the indicial case with `R = ⊤`). Non-indicial
-operators (tense, present progressive) live outside `IsIndicial`;
-`Logic/Temporal/Basic.lean` consumes this boundary. -/
+Operators `(W → Prop) → W → Prop` form a three-level hierarchy
+([gallin-1975]): arbitrary operators, the **indicial** (Kripke-definable)
+ones — `box R` for some accessibility relation — and S5, the indicial
+case `R = ⊤`. Tense and other non-Kripke operators live outside
+`IsIndicial`. -/
 
-/-- A propositional operator: any function from propositions to propositions,
-    parametrized by world — Gallin's most general level.
-
-    Examples: necessity (`box R`), possibility (`diamond R`),
-    past tense (`∃ v, v < w ∧ p v`), present progressive, habituals. -/
-abbrev PropOp (W : Type*) := (W → Prop) → W → Prop
-
-/-- A propositional operator `N` is **monotone** if `p ≤ q` pointwise implies
-    `N p ≤ N q` pointwise. Every normal (K-)operator is monotone. -/
-def PropOp.Monotone {W : Type*} (N : PropOp W) : Prop :=
-  ∀ ⦃p q : W → Prop⦄, (∀ v, p v → q v) → ∀ w, N p w → N q w
-
-/-- A propositional operator distributes over conjunction (one direction of
-    the K axiom: `□(p ∧ q) → □p ∧ □q`). -/
-def PropOp.DistribConj {W : Type*} (N : PropOp W) : Prop :=
-  ∀ (p q : W → Prop) (w : W), N (fun v => p v ∧ q v) w → N p w ∧ N q w
-
-/-- A propositional operator is **indicial** (Kripke-definable) if it is
-    `box R` for some accessibility relation `R`. The non-indicial case is
-    where tense and other non-Kripke operators live. -/
-def IsIndicial {W : Type*} (N : PropOp W) : Prop :=
+/-- An operator on world-propositions is **indicial** (Kripke-definable)
+    if it is `box R` for some accessibility relation `R`. -/
+def IsIndicial (N : (W → Prop) → W → Prop) : Prop :=
   ∃ R : W → W → Prop, N = box R
 
 /-- Every `box R` is indicial. -/
-theorem box_isIndicial (R : W → W → Prop) : IsIndicial (box R) :=
-  ⟨R, rfl⟩
-
-/-- Every indicial operator is monotone (every Kripke operator is a
-    K-operator). -/
-theorem monotone_box (R : W → W → Prop) : PropOp.Monotone (box R) :=
-  fun _ _ h w hb => box_mono R h w hb
-
-/-- Every indicial operator distributes over conjunction. -/
-theorem distribConj_box (R : W → W → Prop) : PropOp.DistribConj (box R) :=
-  fun p q w h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩
-
-/-- S5 necessity as a `PropOp`: `p` holds at all worlds. -/
-def s5Nec {W : Type*} : PropOp W :=
-  fun p _ => ∀ w, p w
-
-/-- S5 possibility as a `PropOp`: `p` holds at some world. -/
-def s5Poss {W : Type*} : PropOp W :=
-  fun p _ => ∃ w, p w
-
-/-- **S5 = box over the universal relation**: the S5 necessity operator is
-    the indicial operator with universal accessibility — S5 sits at the top
-    of the indicial hierarchy. -/
-theorem s5Nec_eq_box_top : s5Nec (W := W) = box ⊤ := by
-  ext p w
-  exact ⟨fun h v _ => h v, fun h v => h v trivial⟩
-
-/-- S5 necessity is indicial. -/
-theorem s5Nec_isIndicial : IsIndicial (s5Nec (W := W)) :=
-  ⟨⊤, s5Nec_eq_box_top⟩
-
-/-- S5 necessity is the weakest indicial operator: for any `R`,
-    `s5Nec p w → box R p w`. Fewer accessible worlds means a stronger
-    necessity — Kratzer restriction at the `PropOp` level (`box_restrict`). -/
-theorem s5Nec_weakest (R : W → W → Prop) (p : W → Prop) (w : W)
-    (h : s5Nec p w) : box R p w :=
-  fun v _ => h v
-
-/-- The empty relation gives the strongest (vacuously true) necessity. -/
-theorem box_bot (p : W → Prop) (w : W) : box (⊥ : W → W → Prop) p w :=
-  fun _ hv => False.elim hv
+theorem box_isIndicial : IsIndicial □[R] := ⟨R, rfl⟩
 
 /-! ### Flat S5 operators
 
-`poss`/`nec` are the genuinely flat existential/universal modals (`∃ w` / `∀ w`),
-the world-collapsed projection of `s5Poss`/`s5Nec`, whose evaluation world is
-vestigial. These are the canonical flat modals consumed by the implicature
-calculus (`Exhaustification.FreeChoice`) and free-choice scope theory, which do
-not track an evaluation world; `s5Poss_apply`/`s5Nec_apply` connect them back to
-the `PropOp` hierarchy. -/
+`poss`/`nec` are the flat existential/universal modals (`∃ w` / `∀ w`) —
+the S5 operators `□[⊤]`/`◇[⊤]` with their vestigial evaluation world
+dropped. -/
 
-/-- Flat S5 possibility: `◇p = ∃ w, p w` (no evaluation world). -/
+/-- Flat S5 possibility: `poss p` iff `p` holds at some world. -/
 def poss (p : W → Prop) : Prop := ∃ w, p w
 
-/-- Flat S5 necessity: `□p = ∀ w, p w` (no evaluation world). -/
+/-- Flat S5 necessity: `nec p` iff `p` holds at every world. -/
 def nec (p : W → Prop) : Prop := ∀ w, p w
 
-@[simp] theorem s5Poss_apply (p : W → Prop) (w : W) : s5Poss p w = poss p := rfl
-@[simp] theorem s5Nec_apply (p : W → Prop) (w : W) : s5Nec p w = nec p := rfl
-
-/-- ◇ distributes over ∨ (flat): `◇(p ∨ q) = ◇p ∨ ◇q`. -/
-theorem poss_or (p q : W → Prop) : poss (fun w => p w ∨ q w) = (poss p ∨ poss q) :=
-  propext exists_or
-
-/-- □ distributes over ∧ (flat): `□(p ∧ q) = □p ∧ □q`. -/
-theorem nec_and (p q : W → Prop) : nec (fun w => p w ∧ q w) = (nec p ∧ nec q) :=
-  propext forall_and
-
-/-- ◇ is monotone. -/
-theorem poss_mono {p q : W → Prop} (h : ∀ w, p w → q w) : poss p → poss q :=
-  fun ⟨w, hw⟩ => ⟨w, h w hw⟩
-
-/-- □ is monotone. -/
-theorem nec_mono {p q : W → Prop} (h : ∀ w, p w → q w) : nec p → nec q :=
-  fun hn w => h w (hn w)
+theorem nec_mono : Monotone (nec (W := W)) :=
+  fun _ q h hn w => h w (hn w)
 
 /-! ### Decidability over finite worlds -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -47,18 +47,10 @@ def modalSquare (R : W → W → Prop) (p : W → Prop) : Aristotelian.Square (W
   O := (□[R] p)ᶜ
 
 /-- Over a serial relation the modal square satisfies all six Aristotelian
-    relations; the `A`-to-`I` subalternation is the D axiom (`box_D`). -/
+    relations. -/
 theorem modalSquare_relations (R : W → W → Prop) [IsSerial R] (p : W → Prop) :
-    Aristotelian.SquareRelations (modalSquare R p) where
-  subalternAI := fun _ => box_D
-  subalternEO := le_compl_iff_disjoint_right.mpr box_disjoint_compl.symm
-  contradAO := isCompl_compl
-  contradEI := by
-    show IsCompl (□[R] pᶜ) (◇[R] p)
-    rw [← compl_box_compl]; exact isCompl_compl
-  contraryAE := box_disjoint_compl
-  subcontrIO := Pi.codisjoint_iff.mpr fun w => Prop.codisjoint_iff.mpr
-    (or_iff_not_imp_right.mpr fun h => box_D (not_not.mp h))
+    Aristotelian.SquareRelations (modalSquare R p) :=
+  .of_disjoint (compl_box_compl R p).symm rfl box_disjoint_compl
 
 /-! ### Monotonicity and distribution -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -16,86 +16,49 @@ operators, placing Montague's S5 `box`/`diamond`
 ([dowty-wall-peters-1981]) as the universal-accessibility case; and the
 lattice of normal modal logics as axiom sets over K.
 
-## Main declarations
-
-* `modalSquare`, `modalSquare_relations` — the `□`/`◇` Aristotelian
-  square, satisfying all six relations under seriality.
-* `PropOp`, `IsIndicial`, `s5Nec`, `poss`/`nec` — the Gallin hierarchy:
-  arbitrary operators ⊋ Kripke-definable (`∃ R, N = box R`) ⊋ S5.
-* `ModalLogic.frameConditions` — frame conditions for a normal modal
-  logic, identified with its axiom set over K and ordered by the
-  `Finset` lattice (named logics `ModalLogic.K` … `ModalLogic.KD45`);
-  `frameConditions_iff_valid` is the correspondence theorem: the
-  conditions hold iff every schema of the logic is valid.
-
-## Connection to Kratzer semantics
-
-Kratzer's conversational backgrounds derive accessibility from a modal
-base: `R_f(w, w') ≡ w' ∈ ⋂f(w)`, with the ordering source further
-restricting to best worlds. Simple Kratzer necessity is `box R_f`, full
-Kratzer necessity is `box` of the best-world restriction, and S5
-necessity is `box ⊤` — see `box_restrict` for why restriction
-strengthens.
 -/
 
 namespace ModalLogic
 
 variable {W : Type*}
 
-/-! ### Modal square of opposition
+/-! ### Modal square of opposition -/
 
-The `□`/`◇` pair forms an Aristotelian square (`A = □p`, `E = □¬p`,
-`I = ◇p`, `O = ¬□p`). Under seriality — the D axiom (`box_D`) — it
-satisfies all six relations of the square of opposition, so every serial
-modality (epistemic, deontic, temporal, doxastic) inherits the square. -/
+variable {R : W → W → Prop} {p : W → Prop}
 
-/-- Under seriality, `□p` and `□¬p` are incompatible: no world satisfies both. -/
-theorem box_disjoint_compl (R : W → W → Prop) [hS : IsSerial R] (p : W → Prop) :
-    Disjoint (box R p) (box R pᶜ) := by
-  rw [Pi.disjoint_iff]
-  intro w
-  rw [disjoint_iff_inf_le]
-  rintro ⟨hp, hnp⟩
-  obtain ⟨v, hwv⟩ := hS.serial w
-  exact hnp v hwv (hp v hwv)
+/-- Over a serial relation, `□p` and `□¬p` are incompatible. -/
+theorem box_disjoint_compl [hS : IsSerial R] : Disjoint (□[R] p) (□[R] pᶜ) :=
+  Pi.disjoint_iff.mpr fun w => Prop.disjoint_iff.mpr fun ⟨hp, hnp⟩ =>
+    let ⟨v, hwv⟩ := hS.serial w
+    hnp v hwv (hp v hwv)
 
-/-- Box–diamond duality as an equation of predicates: `◇p = ¬□¬p`. -/
-theorem diamond_eq_compl_box_compl (R : W → W → Prop) (p : W → Prop) :
-    diamond R p = (box R pᶜ)ᶜ := by
+/-- Box–diamond duality as an equation of predicates: `¬□¬p = ◇p`. -/
+theorem compl_box_compl (R : W → W → Prop) (p : W → Prop) :
+    (□[R] pᶜ)ᶜ = ◇[R] p := by
   funext w
-  apply propext
-  constructor
-  · rintro ⟨v, hv, hpv⟩ hbox
-    exact hbox v hv hpv
-  · intro h
-    by_contra hne
-    exact h (fun v hv hpv => hne ⟨v, hv, hpv⟩)
+  simp [not_box]
 
-/-- The **modal square of opposition** over an accessibility relation `R`:
-    `A = □p`, `E = □¬p`, `I = ◇p`, `O = ¬□p`. -/
+/-- The **modal square of opposition** over `R`: `A = □p`, `E = □¬p`,
+    `I = ◇p`, `O = ¬□p`. -/
 def modalSquare (R : W → W → Prop) (p : W → Prop) : Aristotelian.Square (W → Prop) where
-  A := box R p
-  E := box R pᶜ
-  I := diamond R p
-  O := (box R p)ᶜ
+  A := □[R] p
+  E := □[R] pᶜ
+  I := ◇[R] p
+  O := (□[R] p)ᶜ
 
-/-- The modal square satisfies all six Aristotelian relations whenever `R` is
-**serial**. `subalternAI` is exactly the D axiom (`box_D` : `□p → ◇p`); the two
-contradiction diagonals combine `isCompl_compl` with box–diamond duality; and
-contrariety/subcontrariety reduce to `box_disjoint_compl`. -/
+/-- Over a serial relation the modal square satisfies all six Aristotelian
+    relations; the `A`-to-`I` subalternation is the D axiom (`box_D`). -/
 theorem modalSquare_relations (R : W → W → Prop) [IsSerial R] (p : W → Prop) :
     Aristotelian.SquareRelations (modalSquare R p) where
-  subalternAI := by rw [Pi.le_def]; exact fun _ => box_D
-  subalternEO := le_compl_iff_disjoint_right.mpr (box_disjoint_compl R p).symm
+  subalternAI := fun _ => box_D
+  subalternEO := le_compl_iff_disjoint_right.mpr box_disjoint_compl.symm
   contradAO := isCompl_compl
   contradEI := by
-    show IsCompl (box R pᶜ) (diamond R p)
-    rw [diamond_eq_compl_box_compl]; exact isCompl_compl
-  contraryAE := box_disjoint_compl R p
-  subcontrIO := by
-    show Codisjoint (diamond R p) ((box R p)ᶜ)
-    rw [diamond_eq_compl_box_compl, codisjoint_iff, ← compl_inf,
-        disjoint_iff.mp (box_disjoint_compl R p).symm, compl_bot]
+    show IsCompl (□[R] pᶜ) (◇[R] p)
+    rw [← compl_box_compl]; exact isCompl_compl
+  contraryAE := box_disjoint_compl
+  subcontrIO := Pi.codisjoint_iff.mpr fun w => Prop.codisjoint_iff.mpr
+    (or_iff_not_imp_right.mpr fun h => box_D (not_not.mp h))
 
 /-! ### Monotonicity and distribution -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -97,22 +97,17 @@ theorem diamond_restrict (p : W → Prop) : Monotone fun R : W → W → Prop =>
 
 /-! ### Bundled frame classes -/
 
-/-- S5 frame: reflexive + euclidean (implies symmetric + transitive). -/
+/-- `R` is an **S5 frame** if it is reflexive and Euclidean. -/
 class IsS5Frame : Prop extends Std.Refl R, IsEuclidean R
 
-/-- KD45 frame for textbook belief: serial + transitive + euclidean. -/
+/-- `R` is a **KD45 frame** — the doxastic frame — if it is serial,
+    transitive, and Euclidean. -/
 class IsKD45Frame : Prop extends IsSerial R, IsTrans W R, IsEuclidean R
 
-/-- K45 frame: transitive + euclidean, NOT serial. The frame condition
-    for commitment in [stalnaker-1984]-style discourse models, where
-    commitment violations (no accessible compliance world) must be
-    expressible. -/
+/-- `R` is a **K45 frame** if it is transitive and Euclidean. -/
 class IsK45Frame : Prop extends IsTrans W R, IsEuclidean R
 
-/-- KTB frame: reflexive + symmetric. The natural setting for tolerance
-    semantics ([cobreros-etal-2012]) where each predicate's
-    similarity relation is reflexive and symmetric but possibly
-    non-transitive. -/
+/-- `R` is a **KTB frame** if it is reflexive and symmetric. -/
 class IsKTBFrame : Prop extends Std.Refl R, Std.Symm R
 
 /-! ### The Gallin hierarchy
@@ -128,7 +123,6 @@ case `R = ⊤`. Tense and other non-Kripke operators live outside
 def IsIndicial (N : (W → Prop) → W → Prop) : Prop :=
   ∃ R : W → W → Prop, N = box R
 
-/-- Every `box R` is indicial. -/
 theorem box_isIndicial : IsIndicial □[R] := ⟨R, rfl⟩
 
 /-! ### Flat S5 operators
@@ -144,18 +138,16 @@ def poss (p : W → Prop) : Prop := ∃ w, p w
 def nec (p : W → Prop) : Prop := ∀ w, p w
 
 theorem nec_mono : Monotone (nec (W := W)) :=
-  fun _ q h hn w => h w (hn w)
+  fun _ _ h hn w => h w (hn w)
 
 /-! ### Decidability over finite worlds -/
 
-instance box_decidable {W : Type*} [Fintype W]
-    (R : W → W → Prop) (p : W → Prop) (w : W)
+instance [Fintype W] (R : W → W → Prop) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (box R p w) :=
   inferInstanceAs (Decidable (∀ v, R w v → p v))
 
-instance diamond_decidable {W : Type*} [Fintype W]
-    (R : W → W → Prop) (p : W → Prop) (w : W)
+instance [Fintype W] (R : W → W → Prop) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (diamond R p w) :=
   inferInstanceAs (Decidable (∃ v, R w v ∧ p v))

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -9,12 +9,19 @@ import Mathlib.Order.Lattice
 
 This file proves the order theory of `box` and `diamond`: the Galois
 connection `◇[R] ⊣ □[flip R]` and the normality laws it yields,
-antitonicity in the relation ([kratzer-1981]'s conversational backgrounds
-strengthen necessity by shrinking accessibility), and the modal square of
-opposition ([carnielli-pizzi-2008]). It also defines the bundled frame
-classes `IsS5Frame`, `IsKD45Frame`, `IsK45Frame`, `IsKTBFrame`, and
-[gallin-1975]'s indicial operators, with Montague's S5 `box`/`diamond`
-([dowty-wall-peters-1981]) as the universal-accessibility case `R = ⊤`.
+antitonicity in the relation (conversational backgrounds strengthen
+necessity by shrinking accessibility), and the modal square of
+opposition. It also defines the bundled frame classes `IsS5Frame`,
+`IsKD45Frame`, `IsK45Frame`, `IsKTBFrame`, and the indicial operators,
+with Montague's S5 `box`/`diamond` as the universal-accessibility case
+`R = ⊤`.
+
+## References
+
+* [kratzer-1981] — necessity strengthened by restricting accessibility
+* [carnielli-pizzi-2008] — the modal square of opposition
+* [gallin-1975] — the indicial operator hierarchy
+* [dowty-wall-peters-1981] — Montague's S5 operators
 
 -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -43,68 +43,42 @@ strengthens.
 
 namespace ModalLogic
 
-variable {W : Type*}
+variable {W : Type*} {R : W → W → Prop} {p q : W → Prop} {w : W}
 
 /-! ### Axiom correspondence -/
 
-/-- `box R p w` unfolds to `∀ v, R w v → p v`. -/
-theorem box_eq_forall (R : W → W → Prop) (p : W → Prop) (w : W) :
-    box R p w = (∀ v, R w v → p v) := rfl
-
-/-- `diamond R p w` unfolds to `∃ v, R w v ∧ p v`. -/
-theorem diamond_eq_exists (R : W → W → Prop) (p : W → Prop) (w : W) :
-    diamond R p w = (∃ v, R w v ∧ p v) := rfl
-
-/-- **K axiom**: `□_R(p → q) → (□_R p → □_R q)`.
-    Holds for any accessibility relation. -/
-theorem box_K (R : W → W → Prop) (p q : W → Prop) (w : W)
-    (hpq : box R (fun v => p v → q v) w)
-    (hp : box R p w) : box R q w :=
+/-- **K**: `□(p → q) → □p → □q`, over any relation. -/
+theorem box_K (hpq : □[R] (fun v => p v → q v) w) (hp : □[R] p w) : □[R] q w :=
   fun v hwv => hpq v hwv (hp v hwv)
 
-/-- **T axiom**: reflexive `R` gives `□_R p w → p w`.
-    What is necessary is actual. -/
-theorem box_T (R : W → W → Prop) [Std.Refl R] (p : W → Prop) (w : W)
-    (h : box R p w) : p w :=
+/-- **T**: over a reflexive relation, `□p → p`. -/
+theorem box_T [Std.Refl R] (h : □[R] p w) : p w :=
   h w (Std.Refl.refl w)
 
-/-- **D axiom**: serial `R` gives `□_R p w → ◇_R p w`.
-    What is necessary is possible. -/
-theorem box_D (R : W → W → Prop) [hS : IsSerial R] (p : W → Prop) (w : W)
-    (h : box R p w) : diamond R p w :=
+/-- **D**: over a serial relation, `□p → ◇p`. -/
+theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
   let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
 
-/-- **4 axiom**: transitive `R` gives `□_R p → □_R □_R p`.
-    Positive introspection. -/
-theorem box_four (R : W → W → Prop) [IsTrans W R] (p : W → Prop) (w : W)
-    (h : box R p w) : box R (box R p) w :=
+/-- **4**: over a transitive relation, `□p → □□p`. -/
+theorem box_four [IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
   fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
 
-/-- **B axiom**: symmetric `R` gives `p w → □_R ◇_R p w`.
-    What is actual is necessarily possible. -/
-theorem box_B (R : W → W → Prop) [Std.Symm R] (p : W → Prop) (w : W)
-    (h : p w) : box R (diamond R p) w :=
+/-- **B**: over a symmetric relation, `p → □◇p`. -/
+theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
   fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
 
-/-- **5 axiom**: euclidean `R` gives `◇_R p w → □_R ◇_R p w`.
-    Positive possibility introspection. -/
-theorem box_five (R : W → W → Prop) [hE : IsEuclidean R] (p : W → Prop) (w : W)
-    (h : diamond R p w) : box R (diamond R p) w :=
+/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
+theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
   let ⟨u, hwu, hpu⟩ := h
   fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
 
-/-- **Moore reductio for KD4**: no world satisfies `□_R (p ∧ ¬□_R p)` when
-    `R` is serial and transitive. The content `p ∧ ¬□_R p` is itself
-    satisfiable; what fails is *boxing* it. Specialise to belief,
-    knowledge, or any other KD4 modality. -/
-theorem box_not_moore (R : W → W → Prop) [hS : IsSerial R] [IsTrans W R]
-    (p : W → Prop) (w : W) :
-    ¬ box R (fun v => p v ∧ ¬ box R p v) w := by
-  intro h
-  have hbp : box R p w := fun v hwv => (h v hwv).1
-  have hbbp : box R (box R p) w := box_four R p w hbp
-  obtain ⟨v, hv⟩ := hS.serial w
-  exact (h v hv).2 (hbbp v hv)
+/-- **Moore reductio for KD4**: no world satisfies `□(p ∧ ¬□p)` over a
+    serial transitive relation — the content is satisfiable; boxing it
+    is not. -/
+theorem box_not_moore [hS : IsSerial R] [IsTrans W R] :
+    ¬ □[R] (fun v => p v ∧ ¬ □[R] p v) w := fun h =>
+  have ⟨v, hv⟩ := hS.serial w
+  (h v hv).2 (box_four (fun u hu => (h u hu).1) v hv)
 
 /-! ### Modal square of opposition
 
@@ -149,7 +123,7 @@ contradiction diagonals combine `isCompl_compl` with box–diamond duality; and
 contrariety/subcontrariety reduce to `box_disjoint_compl`. -/
 theorem modalSquare_relations (R : W → W → Prop) [IsSerial R] (p : W → Prop) :
     Aristotelian.SquareRelations (modalSquare R p) where
-  subalternAI := by rw [Pi.le_def]; exact fun w => box_D R p w
+  subalternAI := by rw [Pi.le_def]; exact fun _ => box_D
   subalternEO := le_compl_iff_disjoint_right.mpr (box_disjoint_compl R p).symm
   contradAO := isCompl_compl
   contradEI := by
@@ -449,27 +423,27 @@ def Axiom.Valid {W : Type*} : Axiom → (W → W → Prop) → Prop
 theorem Axiom.valid_M_iff {W : Type*} {R : W → W → Prop} :
     (Axiom.M).Valid R ↔ Std.Refl R :=
   ⟨fun h => ⟨fun w => h (R w) w (fun _ hv => hv)⟩,
-   fun hR => haveI := hR; fun p w => box_T R p w⟩
+   fun hR => haveI := hR; fun _ _ => box_T⟩
 
 /-- **Correspondence for D**: `□p → ◇p` is valid over `R` iff `R` is serial. -/
 theorem Axiom.valid_D_iff {W : Type*} {R : W → W → Prop} :
     (Axiom.D).Valid R ↔ IsSerial R :=
   ⟨fun h => ⟨fun w => let ⟨v, hv, _⟩ := h (fun _ => True) w (fun _ _ => trivial); ⟨v, hv⟩⟩,
-   fun hR => haveI := hR; fun p w => box_D R p w⟩
+   fun hR => haveI := hR; fun _ _ => box_D⟩
 
 /-- **Correspondence for B**: `p → □◇p` is valid over `R` iff `R` is
     symmetric. -/
 theorem Axiom.valid_B_iff {W : Type*} {R : W → W → Prop} :
     (Axiom.B).Valid R ↔ Std.Symm R :=
   ⟨fun h => ⟨fun w v hwv => match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
-   fun hR => haveI := hR; fun p w => box_B R p w⟩
+   fun hR => haveI := hR; fun _ _ => box_B⟩
 
 /-- **Correspondence for 4**: `□p → □□p` is valid over `R` iff `R` is
     transitive. -/
 theorem Axiom.valid_four_iff {W : Type*} {R : W → W → Prop} :
     (Axiom.four).Valid R ↔ IsTrans W R :=
   ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
-   fun hR => haveI := hR; fun p w => box_four R p w⟩
+   fun hR => haveI := hR; fun _ _ => box_four⟩
 
 /-- **Correspondence for 5**: `◇p → □◇p` is valid over `R` iff `R` is
     euclidean. -/
@@ -477,7 +451,7 @@ theorem Axiom.valid_five_iff {W : Type*} {R : W → W → Prop} :
     (Axiom.five).Valid R ↔ IsEuclidean R :=
   ⟨fun h => ⟨fun w v u hwv hwu =>
      match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
-   fun hR => haveI := hR; fun p w => box_five R p w⟩
+   fun hR => haveI := hR; fun _ _ => box_five⟩
 
 /-- **The correspondence theorem**: `R` satisfies the frame conditions of `L`
     iff every axiom schema of `L` is valid over `R`. Left to right is

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -7,20 +7,17 @@ import Mathlib.Order.Lattice
 /-!
 # Modal logic over accessibility relations
 
-Axiom correspondence, normality, and the operator hierarchy for the
-relational `box`/`diamond` of `Defs.lean` ([kripke-1963]): which frame
-conditions validate the T, D, 4, B, and 5 schemas; monotonicity and
-distribution; restriction — [kratzer-1981]'s insight that conversational
-backgrounds strengthen necessity by shrinking accessibility; the modal
-square of opposition ([carnielli-pizzi-2008]); [gallin-1975]'s hierarchy
-of propositional operators, placing Montague's S5 `box`/`diamond`
+Normality and the operator hierarchy for the relational `box`/`diamond`
+of `Defs.lean`: monotonicity and distribution; restriction —
+[kratzer-1981]'s insight that conversational backgrounds strengthen
+necessity by shrinking accessibility; the modal square of opposition
+([carnielli-pizzi-2008]); [gallin-1975]'s hierarchy of propositional
+operators, placing Montague's S5 `box`/`diamond`
 ([dowty-wall-peters-1981]) as the universal-accessibility case; and the
 lattice of normal modal logics as axiom sets over K.
 
 ## Main declarations
 
-* `box_K` … `box_five` — per-axiom frame correspondences; `box_not_moore`
-  is the Moore-sentence reductio for any KD4 modality ([hintikka-1962]).
 * `modalSquare`, `modalSquare_relations` — the `□`/`◇` Aristotelian
   square, satisfying all six relations under seriality.
 * `PropOp`, `IsIndicial`, `s5Nec`, `poss`/`nec` — the Gallin hierarchy:
@@ -43,42 +40,7 @@ strengthens.
 
 namespace ModalLogic
 
-variable {W : Type*} {R : W → W → Prop} {p q : W → Prop} {w : W}
-
-/-! ### Axiom correspondence -/
-
-/-- **K**: `□(p → q) → □p → □q`, over any relation. -/
-theorem box_K (hpq : □[R] (fun v => p v → q v) w) (hp : □[R] p w) : □[R] q w :=
-  fun v hwv => hpq v hwv (hp v hwv)
-
-/-- **T**: over a reflexive relation, `□p → p`. -/
-theorem box_T [Std.Refl R] (h : □[R] p w) : p w :=
-  h w (Std.Refl.refl w)
-
-/-- **D**: over a serial relation, `□p → ◇p`. -/
-theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
-  let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
-
-/-- **4**: over a transitive relation, `□p → □□p`. -/
-theorem box_four [IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
-  fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
-
-/-- **B**: over a symmetric relation, `p → □◇p`. -/
-theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
-  fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
-
-/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
-theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
-  let ⟨u, hwu, hpu⟩ := h
-  fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
-
-/-- **Moore reductio for KD4**: no world satisfies `□(p ∧ ¬□p)` over a
-    serial transitive relation — the content is satisfiable; boxing it
-    is not. -/
-theorem box_not_moore [hS : IsSerial R] [IsTrans W R] :
-    ¬ □[R] (fun v => p v ∧ ¬ □[R] p v) w := fun h =>
-  have ⟨v, hv⟩ := hS.serial w
-  (h v hv).2 (box_four (fun u hu => (h u hu).1) v hv)
+variable {W : Type*}
 
 /-! ### Modal square of opposition
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -2,6 +2,7 @@ import Linglib.Logic.Modal.Defs
 import Linglib.Logic.Aristotelian.Square
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Order.GaloisConnection.Basic
 import Mathlib.Order.Lattice
 
 /-!
@@ -52,60 +53,55 @@ theorem modalSquare_relations (R : W → W → Prop) [IsSerial R] (p : W → Pro
     Aristotelian.SquareRelations (modalSquare R p) :=
   .of_disjoint (compl_box_compl R p).symm rfl box_disjoint_compl
 
-/-! ### Monotonicity and distribution -/
+/-! ### The Galois connection and normality -/
 
-/-- `box R` is monotone: if `p ≤ q` pointwise, then `□_R p ≤ □_R q`. -/
-theorem box_mono (R : W → W → Prop) {p q : W → Prop}
-    (h : ∀ v, p v → q v) (w : W)
-    (hb : box R p w) : box R q w :=
-  fun v hwv => h v (hb v hwv)
+variable (R) {q : W → Prop}
+
+/-- `◇` along `R` is left adjoint to `□` along the converse relation —
+    the characteristic adjunction of relational modality. -/
+theorem diamond_box_gc : GaloisConnection ◇[R] □[flip R] :=
+  fun _ _ =>
+    ⟨fun h v hp w hwv => h w ⟨v, hwv, hp⟩,
+     fun h w => fun ⟨v, hwv, hp⟩ => h v hp w hwv⟩
+
+/-- `box R` is monotone. -/
+theorem box_mono : Monotone □[R] :=
+  (diamond_box_gc (flip R)).monotone_u
 
 /-- `diamond R` is monotone. -/
-theorem diamond_mono (R : W → W → Prop) {p q : W → Prop}
-    (h : ∀ v, p v → q v) (w : W)
-    (hd : diamond R p w) : diamond R q w :=
-  let ⟨v, hwv, hpv⟩ := hd; ⟨v, hwv, h v hpv⟩
+theorem diamond_mono : Monotone ◇[R] :=
+  (diamond_box_gc R).monotone_l
 
-/-- `□_R` distributes over `∧`. -/
-theorem box_conj (R : W → W → Prop) (p q : W → Prop) (w : W) :
-    box R (fun v => p v ∧ q v) w ↔ box R p w ∧ box R q w :=
-  ⟨fun h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩,
-   fun ⟨hp, hq⟩ v hwv => ⟨hp v hwv, hq v hwv⟩⟩
+/-- `□` distributes over `⊓`. -/
+theorem box_inf : □[R] (p ⊓ q) = □[R] p ⊓ □[R] q :=
+  (diamond_box_gc (flip R)).u_inf
 
-/-- `◇_R` distributes over `∨`. -/
-theorem diamond_disj (R : W → W → Prop) (p q : W → Prop) (w : W) :
-    diamond R (fun v => p v ∨ q v) w ↔ diamond R p w ∨ diamond R q w :=
-  ⟨fun ⟨v, hwv, h⟩ => h.elim (fun hp => .inl ⟨v, hwv, hp⟩) (fun hq => .inr ⟨v, hwv, hq⟩),
-   fun h => h.elim (fun ⟨v, hwv, hp⟩ => ⟨v, hwv, .inl hp⟩)
-                   (fun ⟨v, hwv, hq⟩ => ⟨v, hwv, .inr hq⟩)⟩
+/-- `◇` distributes over `⊔`. -/
+theorem diamond_sup : ◇[R] (p ⊔ q) = ◇[R] p ⊔ ◇[R] q :=
+  (diamond_box_gc R).l_sup
 
-/-- Necessitation: if `p` holds at every world, then `□_R p` holds everywhere. -/
-theorem box_necessitation (R : W → W → Prop) (p : W → Prop)
-    (h : ∀ v, p v) (w : W) : box R p w :=
-  fun v _ => h v
+/-- Necessitation: `□⊤ = ⊤`. -/
+theorem box_top : □[R] ⊤ = ⊤ :=
+  (diamond_box_gc (flip R)).u_top
+
+/-- **Conversion** (Prior's tense axiom `A ⊃ G P A`): the unit of the
+    adjunction — over any relation, `p ≤ □_{flip R} ◇_R p`. -/
+theorem self_imp_box_flip_diamond (p : W → Prop) : p ≤ □[flip R] (◇[R] p) :=
+  (diamond_box_gc R).le_u_l p
 
 /-! ### Accessibility restriction -/
 
-/-- Restricting accessibility strengthens necessity:
-    if `R₂ ⊆ R₁`, then `□_{R₁} p → □_{R₂} p`. -/
-theorem box_restrict {R₁ R₂ : W → W → Prop}
-    (h : ∀ w v, R₂ w v → R₁ w v) (p : W → Prop) (w : W)
-    (hb : box R₁ p w) : box R₂ p w :=
-  fun v hwv => hb v (h w v hwv)
+/-- Restricting accessibility strengthens necessity: `box` is antitone
+    in the relation. -/
+theorem box_restrict {R₁ R₂ : W → W → Prop} (h : R₂ ≤ R₁) (p : W → Prop) :
+    □[R₁] p ≤ □[R₂] p :=
+  fun _ hb v hwv => hb v (h _ _ hwv)
 
-/-- Restricting accessibility weakens possibility:
-    if `R₂ ⊆ R₁`, then `◇_{R₂} p → ◇_{R₁} p`. -/
-theorem diamond_restrict {R₁ R₂ : W → W → Prop}
-    (h : ∀ w v, R₂ w v → R₁ w v) (p : W → Prop) (w : W)
-    (hd : diamond R₂ p w) : diamond R₁ p w :=
-  let ⟨v, hwv, hpv⟩ := hd; ⟨v, h w v hwv, hpv⟩
-
-/-- **Conversion** (Prior's tense axiom `A ⊃ G P A` / `A ⊃ H F A`): for `R` and its converse
-    `flip R`, `p w → □_{flip R} ◇_R p w`. The correspondence fact that two modalities over a
-    relation and its converse are temporally adjoint (holds for *any* `R`). -/
-theorem self_imp_box_flip_diamond (R : W → W → Prop) (p : W → Prop) (w : W)
-    (h : p w) : box (flip R) (diamond R p) w :=
-  fun _ hv => ⟨w, hv, h⟩
+/-- Restricting accessibility weakens possibility: `diamond` is monotone
+    in the relation. -/
+theorem diamond_restrict {R₁ R₂ : W → W → Prop} (h : R₂ ≤ R₁) (p : W → Prop) :
+    ◇[R₂] p ≤ ◇[R₁] p :=
+  fun _ hd => let ⟨v, hwv, hpv⟩ := hd; ⟨v, h _ _ hwv, hpv⟩
 
 /-! ### Bundled frame classes
 
@@ -177,7 +173,7 @@ theorem monotone_box (R : W → W → Prop) : PropOp.Monotone (box R) :=
 
 /-- Every indicial operator distributes over conjunction. -/
 theorem distribConj_box (R : W → W → Prop) : PropOp.DistribConj (box R) :=
-  fun p q w h => (box_conj R p q w).mp h
+  fun p q w h => ⟨fun v hwv => (h v hwv).1, fun v hwv => (h v hwv).2⟩
 
 /-- S5 necessity as a `PropOp`: `p` holds at all worlds. -/
 def s5Nec {W : Type*} : PropOp W :=

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -1,6 +1,5 @@
 import Linglib.Logic.Modal.Defs
 import Linglib.Logic.Aristotelian.Square
-import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.GaloisConnection.Basic
 import Mathlib.Order.Lattice
@@ -14,8 +13,7 @@ of `Defs.lean`: monotonicity and distribution; restriction —
 necessity by shrinking accessibility; the modal square of opposition
 ([carnielli-pizzi-2008]); [gallin-1975]'s hierarchy of propositional
 operators, placing Montague's S5 `box`/`diamond`
-([dowty-wall-peters-1981]) as the universal-accessibility case; and the
-lattice of normal modal logics as axiom sets over K.
+([dowty-wall-peters-1981]) as the universal-accessibility case.
 
 -/
 
@@ -151,116 +149,5 @@ instance [Fintype W] (R : W → W → Prop) (p : W → Prop) (w : W)
     [∀ v, Decidable (R w v)] [DecidablePred p] :
     Decidable (diamond R p w) :=
   inferInstanceAs (Decidable (∃ v, R w v ∧ p v))
-
-/-! ### The lattice of normal modal logics
-
-A normal modal logic is identified with its set of axiom schemas over K;
-the `Finset` lattice (`⊆`, `∪`, `∩`, `⊥ = ∅ = K`) is the lattice of
-normal logics. The named logics below follow the textbook scheme — the
-name lists the axioms added to `K` — plus the historical names `T`,
-`S4`, `S5`. -/
-
-/-- Axiom schemas addable to the base logic K. -/
-inductive Axiom where
-  /-- `□p → p` (T; von Wright's M). -/
-  | M
-  /-- `□p → ◇p`. -/
-  | D
-  /-- `p → □◇p`. -/
-  | B
-  /-- `□p → □□p`. -/
-  | four
-  /-- `◇p → □◇p`. -/
-  | five
-  deriving DecidableEq, Repr, Inhabited
-
-def K : Finset Axiom := ∅
-def T : Finset Axiom := {.M}
-def D : Finset Axiom := {.D}
-def KB : Finset Axiom := {.B}
-def K4 : Finset Axiom := {.four}
-def K5 : Finset Axiom := {.five}
-def S4 : Finset Axiom := {.M, .four}
-def S5 : Finset Axiom := {.M, .five}
-def KTB : Finset Axiom := {.M, .B}
-def KD45 : Finset Axiom := {.D, .four, .five}
-def K45 : Finset Axiom := {.four, .five}
-
-/-- The frame condition of an axiom schema. -/
-def Axiom.FrameCondition : Axiom → (W → W → Prop) → Prop
-  | .M => Std.Refl
-  | .D => IsSerial
-  | .B => Std.Symm
-  | .four => IsTrans W
-  | .five => IsEuclidean
-
-/-- Validity of an axiom schema over an accessibility relation. -/
-def Axiom.Valid : Axiom → (W → W → Prop) → Prop
-  | .M, R => ∀ p, □[R] p ≤ p
-  | .D, R => ∀ p, □[R] p ≤ ◇[R] p
-  | .B, R => ∀ p, p ≤ □[R] (◇[R] p)
-  | .four, R => ∀ p, □[R] p ≤ □[R] (□[R] p)
-  | .five, R => ∀ p, ◇[R] p ≤ □[R] (◇[R] p)
-
-/-- **Correspondence, per axiom**: a schema is valid over `R` iff `R`
-    satisfies its frame condition. -/
-theorem Axiom.valid_iff {R : W → W → Prop} :
-    ∀ a : Axiom, a.Valid R ↔ a.FrameCondition R
-  | .M => ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩,
-           fun hR => haveI : Std.Refl R := hR; fun _ _ h => box_T h⟩
-  | .D => ⟨fun h => ⟨fun w =>
-             let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
-           fun hR => haveI : IsSerial R := hR; fun _ _ h => box_D h⟩
-  | .B => ⟨fun h => ⟨fun w v hwv =>
-             match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
-           fun hR => haveI : Std.Symm R := hR; fun _ _ h => box_B h⟩
-  | .four => ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
-              fun hR => haveI : IsTrans W R := hR; fun _ _ h => box_four h⟩
-  | .five => ⟨fun h => ⟨fun w v u hwv hwu =>
-               match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
-              fun hR => haveI : IsEuclidean R := hR; fun _ _ h => box_five h⟩
-
-/-- Frame conditions of a logic: every axiom schema present imposes its
-    condition on `R`. -/
-def frameConditions (L : Finset Axiom) (R : W → W → Prop) : Prop :=
-  ∀ a ∈ L, a.FrameCondition R
-
-/-- **The correspondence theorem**: `R` satisfies the frame conditions of
-    `L` iff every axiom schema of `L` is valid over `R`. -/
-theorem frameConditions_iff_valid {L : Finset Axiom} {R : W → W → Prop} :
-    frameConditions L R ↔ ∀ a ∈ L, a.Valid R :=
-  forall₂_congr fun a _ => (Axiom.valid_iff a).symm
-
-/-- The syntactic-semantic bridge for `S5`. -/
-@[simp] theorem frameConditions_S5_iff (R : W → W → Prop) :
-    frameConditions S5 R ↔ IsS5Frame R := by
-  simp only [frameConditions, S5, Axiom.FrameCondition, Finset.mem_insert,
-    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
-  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
-         fun h => ⟨h.toRefl, h.toIsEuclidean⟩⟩
-
-/-- The syntactic-semantic bridge for `KD45`. -/
-@[simp] theorem frameConditions_KD45_iff (R : W → W → Prop) :
-    frameConditions KD45 R ↔ IsKD45Frame R := by
-  simp only [frameConditions, KD45, Axiom.FrameCondition, Finset.mem_insert,
-    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
-  exact ⟨fun ⟨h1, h2, h3⟩ => haveI := h1; haveI := h2; haveI := h3; ⟨⟩,
-         fun h => ⟨h.toIsSerial, h.toIsTrans, h.toIsEuclidean⟩⟩
-
-/-- The syntactic-semantic bridge for `K45`. -/
-@[simp] theorem frameConditions_K45_iff (R : W → W → Prop) :
-    frameConditions K45 R ↔ IsK45Frame R := by
-  simp only [frameConditions, K45, Axiom.FrameCondition, Finset.mem_insert,
-    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
-  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
-         fun h => ⟨h.toIsTrans, h.toIsEuclidean⟩⟩
-
-/-- The syntactic-semantic bridge for `KTB`. -/
-@[simp] theorem frameConditions_KTB_iff (R : W → W → Prop) :
-    frameConditions KTB R ↔ IsKTBFrame R := by
-  simp only [frameConditions, KTB, Axiom.FrameCondition, Finset.mem_insert,
-    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
-  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
-         fun h => ⟨h.toRefl, h.toSymm⟩⟩
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -156,7 +156,9 @@ instance [Fintype W] (R : W → W → Prop) (p : W → Prop) (w : W)
 
 A normal modal logic is identified with its set of axiom schemas over K;
 the `Finset` lattice (`⊆`, `∪`, `∩`, `⊥ = ∅ = K`) is the lattice of
-normal logics. -/
+normal logics. The named logics below follow the textbook scheme — the
+name lists the axioms added to `K` — plus the historical names `T`,
+`S4`, `S5`. -/
 
 /-- Axiom schemas addable to the base logic K. -/
 inductive Axiom where
@@ -172,37 +174,16 @@ inductive Axiom where
   | five
   deriving DecidableEq, Repr, Inhabited
 
-/-- The base logic `K`: no additional axioms. -/
 def K : Finset Axiom := ∅
-
-/-- `T = K + M`. -/
 def T : Finset Axiom := {.M}
-
-/-- `D = K + D`. -/
 def D : Finset Axiom := {.D}
-
-/-- `KB = K + B`. -/
 def KB : Finset Axiom := {.B}
-
-/-- `K4 = K + 4`. -/
 def K4 : Finset Axiom := {.four}
-
-/-- `K5 = K + 5`. -/
 def K5 : Finset Axiom := {.five}
-
-/-- `S4 = K + M + 4`. -/
 def S4 : Finset Axiom := {.M, .four}
-
-/-- `S5 = K + M + 5`. -/
 def S5 : Finset Axiom := {.M, .five}
-
-/-- `KTB = K + M + B`. -/
 def KTB : Finset Axiom := {.M, .B}
-
-/-- `KD45 = K + D + 4 + 5` (the doxastic logic). -/
 def KD45 : Finset Axiom := {.D, .four, .five}
-
-/-- `K45 = K + 4 + 5`. -/
 def K45 : Finset Axiom := {.four, .five}
 
 /-- The frame condition of an axiom schema. -/

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -87,17 +87,13 @@ theorem self_imp_box_flip_diamond (p : W → Prop) : p ≤ □[flip R] (◇[R] p
 
 /-! ### Accessibility restriction -/
 
-/-- Restricting accessibility strengthens necessity: `box` is antitone
-    in the relation. -/
-theorem box_restrict {R₁ R₂ : W → W → Prop} (h : R₂ ≤ R₁) (p : W → Prop) :
-    □[R₁] p ≤ □[R₂] p :=
-  fun _ hb v hwv => hb v (h _ _ hwv)
+/-- Restricting accessibility strengthens necessity. -/
+theorem box_restrict (p : W → Prop) : Antitone fun R : W → W → Prop => □[R] p :=
+  fun _ _ h _ hb v hwv => hb v (h _ _ hwv)
 
-/-- Restricting accessibility weakens possibility: `diamond` is monotone
-    in the relation. -/
-theorem diamond_restrict {R₁ R₂ : W → W → Prop} (h : R₂ ≤ R₁) (p : W → Prop) :
-    ◇[R₂] p ≤ ◇[R₁] p :=
-  fun _ hd => let ⟨v, hwv, hpv⟩ := hd; ⟨v, h _ _ hwv, hpv⟩
+/-- Restricting accessibility weakens possibility. -/
+theorem diamond_restrict (p : W → Prop) : Monotone fun R : W → W → Prop => ◇[R] p :=
+  fun _ _ h _ hd => let ⟨v, hwv, hpv⟩ := hd; ⟨v, h _ _ hwv, hpv⟩
 
 /-! ### Bundled frame classes -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -7,13 +7,14 @@ import Mathlib.Order.Lattice
 /-!
 # Modal logic over accessibility relations
 
-Normality and the operator hierarchy for the relational `box`/`diamond`
-of `Defs.lean`: monotonicity and distribution; restriction —
-[kratzer-1981]'s insight that conversational backgrounds strengthen
-necessity by shrinking accessibility; the modal square of opposition
-([carnielli-pizzi-2008]); [gallin-1975]'s hierarchy of propositional
-operators, placing Montague's S5 `box`/`diamond`
-([dowty-wall-peters-1981]) as the universal-accessibility case.
+This file proves the order theory of `box` and `diamond`: the Galois
+connection `◇[R] ⊣ □[flip R]` and the normality laws it yields,
+antitonicity in the relation ([kratzer-1981]'s conversational backgrounds
+strengthen necessity by shrinking accessibility), and the modal square of
+opposition ([carnielli-pizzi-2008]). It also defines the bundled frame
+classes `IsS5Frame`, `IsKD45Frame`, `IsK45Frame`, `IsKTBFrame`, and
+[gallin-1975]'s indicial operators, with Montague's S5 `box`/`diamond`
+([dowty-wall-peters-1981]) as the universal-accessibility case `R = ⊤`.
 
 -/
 

--- a/Linglib/Logic/Modal/Basic.lean
+++ b/Linglib/Logic/Modal/Basic.lean
@@ -172,10 +172,6 @@ inductive Axiom where
   | five
   deriving DecidableEq, Repr, Inhabited
 
-instance : ToString Axiom where
-  toString | .M => "M" | .D => "D" | .B => "B" | .four => "4" | .five => "5"
-
-
 /-- The base logic `K`: no additional axioms. -/
 def K : Finset Axiom := ∅
 
@@ -209,116 +205,81 @@ def KD45 : Finset Axiom := {.D, .four, .five}
 /-- `K45 = K + 4 + 5`. -/
 def K45 : Finset Axiom := {.four, .five}
 
-/-- `K` is the bottom of the lattice of normal logics. -/
-theorem K_bot : K = ⊥ := rfl
+/-- The frame condition of an axiom schema. -/
+def Axiom.FrameCondition : Axiom → (W → W → Prop) → Prop
+  | .M => Std.Refl
+  | .D => IsSerial
+  | .B => Std.Symm
+  | .four => IsTrans W
+  | .five => IsEuclidean
 
-/-- Frame conditions required by a logic: for each axiom schema present,
-    the corresponding condition on `R`. -/
-def frameConditions {W : Type*} (L : Finset Axiom) (R : W → W → Prop) : Prop :=
-  (.M ∈ L → Std.Refl R) ∧
-  (.D ∈ L → IsSerial R) ∧
-  (.B ∈ L → Std.Symm R) ∧
-  (.four ∈ L → IsTrans W R) ∧
-  (.five ∈ L → IsEuclidean R)
+/-- Validity of an axiom schema over an accessibility relation. -/
+def Axiom.Valid : Axiom → (W → W → Prop) → Prop
+  | .M, R => ∀ p, □[R] p ≤ p
+  | .D, R => ∀ p, □[R] p ≤ ◇[R] p
+  | .B, R => ∀ p, p ≤ □[R] (◇[R] p)
+  | .four, R => ∀ p, □[R] p ≤ □[R] (□[R] p)
+  | .five, R => ∀ p, ◇[R] p ≤ □[R] (◇[R] p)
 
-/-- Validity of an axiom schema over an accessibility relation: the schema
-    holds for all propositions at all worlds. -/
-def Axiom.Valid {W : Type*} : Axiom → (W → W → Prop) → Prop
-  | .M, R => ∀ (p : W → Prop) (w : W), box R p w → p w
-  | .D, R => ∀ (p : W → Prop) (w : W), box R p w → diamond R p w
-  | .B, R => ∀ (p : W → Prop) (w : W), p w → box R (diamond R p) w
-  | .four, R => ∀ (p : W → Prop) (w : W), box R p w → box R (box R p) w
-  | .five, R => ∀ (p : W → Prop) (w : W), diamond R p w → box R (diamond R p) w
+/-- **Correspondence, per axiom**: a schema is valid over `R` iff `R`
+    satisfies its frame condition. -/
+theorem Axiom.valid_iff {R : W → W → Prop} :
+    ∀ a : Axiom, a.Valid R ↔ a.FrameCondition R
+  | .M => ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩,
+           fun hR => haveI : Std.Refl R := hR; fun _ _ h => box_T h⟩
+  | .D => ⟨fun h => ⟨fun w =>
+             let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
+           fun hR => haveI : IsSerial R := hR; fun _ _ h => box_D h⟩
+  | .B => ⟨fun h => ⟨fun w v hwv =>
+             match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
+           fun hR => haveI : Std.Symm R := hR; fun _ _ h => box_B h⟩
+  | .four => ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
+              fun hR => haveI : IsTrans W R := hR; fun _ _ h => box_four h⟩
+  | .five => ⟨fun h => ⟨fun w v u hwv hwu =>
+               match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
+              fun hR => haveI : IsEuclidean R := hR; fun _ _ h => box_five h⟩
 
-/-- **Correspondence for M (= T)**: `□p → p` is valid over `R` iff `R` is
-    reflexive. -/
-theorem Axiom.valid_M_iff {W : Type*} {R : W → W → Prop} :
-    (Axiom.M).Valid R ↔ Std.Refl R :=
-  ⟨fun h => ⟨fun w => h (R w) w (fun _ hv => hv)⟩,
-   fun hR => haveI := hR; fun _ _ => box_T⟩
+/-- Frame conditions of a logic: every axiom schema present imposes its
+    condition on `R`. -/
+def frameConditions (L : Finset Axiom) (R : W → W → Prop) : Prop :=
+  ∀ a ∈ L, a.FrameCondition R
 
-/-- **Correspondence for D**: `□p → ◇p` is valid over `R` iff `R` is serial. -/
-theorem Axiom.valid_D_iff {W : Type*} {R : W → W → Prop} :
-    (Axiom.D).Valid R ↔ IsSerial R :=
-  ⟨fun h => ⟨fun w => let ⟨v, hv, _⟩ := h (fun _ => True) w (fun _ _ => trivial); ⟨v, hv⟩⟩,
-   fun hR => haveI := hR; fun _ _ => box_D⟩
+/-- **The correspondence theorem**: `R` satisfies the frame conditions of
+    `L` iff every axiom schema of `L` is valid over `R`. -/
+theorem frameConditions_iff_valid {L : Finset Axiom} {R : W → W → Prop} :
+    frameConditions L R ↔ ∀ a ∈ L, a.Valid R :=
+  forall₂_congr fun a _ => (Axiom.valid_iff a).symm
 
-/-- **Correspondence for B**: `p → □◇p` is valid over `R` iff `R` is
-    symmetric. -/
-theorem Axiom.valid_B_iff {W : Type*} {R : W → W → Prop} :
-    (Axiom.B).Valid R ↔ Std.Symm R :=
-  ⟨fun h => ⟨fun w v hwv => match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
-   fun hR => haveI := hR; fun _ _ => box_B⟩
-
-/-- **Correspondence for 4**: `□p → □□p` is valid over `R` iff `R` is
-    transitive. -/
-theorem Axiom.valid_four_iff {W : Type*} {R : W → W → Prop} :
-    (Axiom.four).Valid R ↔ IsTrans W R :=
-  ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
-   fun hR => haveI := hR; fun _ _ => box_four⟩
-
-/-- **Correspondence for 5**: `◇p → □◇p` is valid over `R` iff `R` is
-    euclidean. -/
-theorem Axiom.valid_five_iff {W : Type*} {R : W → W → Prop} :
-    (Axiom.five).Valid R ↔ IsEuclidean R :=
-  ⟨fun h => ⟨fun w v u hwv hwu =>
-     match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
-   fun hR => haveI := hR; fun _ _ => box_five⟩
-
-/-- **The correspondence theorem**: `R` satisfies the frame conditions of `L`
-    iff every axiom schema of `L` is valid over `R`. Left to right is
-    soundness (`box_T` … `box_five`); the converse holds because each schema
-    elementarily defines its frame condition (`Axiom.valid_M_iff`, …). -/
-theorem frameConditions_iff_valid {W : Type*} {L : Finset Axiom}
-    {R : W → W → Prop} :
-    frameConditions L R ↔ ∀ a ∈ L, a.Valid R := by
-  constructor
-  · intro h a ha
-    cases a with
-    | M => exact Axiom.valid_M_iff.mpr (h.1 ha)
-    | D => exact Axiom.valid_D_iff.mpr (h.2.1 ha)
-    | B => exact Axiom.valid_B_iff.mpr (h.2.2.1 ha)
-    | four => exact Axiom.valid_four_iff.mpr (h.2.2.2.1 ha)
-    | five => exact Axiom.valid_five_iff.mpr (h.2.2.2.2 ha)
-  · intro h
-    exact ⟨fun hm => Axiom.valid_M_iff.mp (h _ hm),
-           fun hm => Axiom.valid_D_iff.mp (h _ hm),
-           fun hm => Axiom.valid_B_iff.mp (h _ hm),
-           fun hm => Axiom.valid_four_iff.mp (h _ hm),
-           fun hm => Axiom.valid_five_iff.mp (h _ hm)⟩
-
-/-- The syntactic-semantic bridge for `S5`: `frameConditions ModalLogic.S5 R`
-    iff `R` is an S5 frame. -/
-@[simp] theorem frameConditions_S5_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions S5 R ↔ IsS5Frame R :=
-  ⟨fun h => haveI := h.1 (by decide); haveI := h.2.2.2.2 (by decide); ⟨⟩,
-   fun h => ⟨fun _ => h.toRefl, fun hm => absurd hm (by decide),
-             fun hm => absurd hm (by decide), fun hm => absurd hm (by decide),
-             fun _ => h.toIsEuclidean⟩⟩
+/-- The syntactic-semantic bridge for `S5`. -/
+@[simp] theorem frameConditions_S5_iff (R : W → W → Prop) :
+    frameConditions S5 R ↔ IsS5Frame R := by
+  simp only [frameConditions, S5, Axiom.FrameCondition, Finset.mem_insert,
+    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
+  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
+         fun h => ⟨h.toRefl, h.toIsEuclidean⟩⟩
 
 /-- The syntactic-semantic bridge for `KD45`. -/
-@[simp] theorem frameConditions_KD45_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions KD45 R ↔ IsKD45Frame R :=
-  ⟨fun h => haveI := h.2.1 (by decide); haveI := h.2.2.2.1 (by decide);
-     haveI := h.2.2.2.2 (by decide); ⟨⟩,
-   fun h => ⟨fun hm => absurd hm (by decide), fun _ => h.toIsSerial,
-             fun hm => absurd hm (by decide), fun _ => h.toIsTrans,
-             fun _ => h.toIsEuclidean⟩⟩
+@[simp] theorem frameConditions_KD45_iff (R : W → W → Prop) :
+    frameConditions KD45 R ↔ IsKD45Frame R := by
+  simp only [frameConditions, KD45, Axiom.FrameCondition, Finset.mem_insert,
+    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
+  exact ⟨fun ⟨h1, h2, h3⟩ => haveI := h1; haveI := h2; haveI := h3; ⟨⟩,
+         fun h => ⟨h.toIsSerial, h.toIsTrans, h.toIsEuclidean⟩⟩
 
 /-- The syntactic-semantic bridge for `K45`. -/
-@[simp] theorem frameConditions_K45_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions K45 R ↔ IsK45Frame R :=
-  ⟨fun h => haveI := h.2.2.2.1 (by decide); haveI := h.2.2.2.2 (by decide); ⟨⟩,
-   fun h => ⟨fun hm => absurd hm (by decide), fun hm => absurd hm (by decide),
-             fun hm => absurd hm (by decide), fun _ => h.toIsTrans,
-             fun _ => h.toIsEuclidean⟩⟩
+@[simp] theorem frameConditions_K45_iff (R : W → W → Prop) :
+    frameConditions K45 R ↔ IsK45Frame R := by
+  simp only [frameConditions, K45, Axiom.FrameCondition, Finset.mem_insert,
+    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
+  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
+         fun h => ⟨h.toIsTrans, h.toIsEuclidean⟩⟩
 
 /-- The syntactic-semantic bridge for `KTB`. -/
-@[simp] theorem frameConditions_KTB_iff {W : Type*} (R : W → W → Prop) :
-    frameConditions KTB R ↔ IsKTBFrame R :=
-  ⟨fun h => haveI := h.1 (by decide); haveI := h.2.2.1 (by decide); ⟨⟩,
-   fun h => ⟨fun _ => h.toRefl, fun hm => absurd hm (by decide),
-             fun _ => h.toSymm, fun hm => absurd hm (by decide),
-             fun hm => absurd hm (by decide)⟩⟩
+@[simp] theorem frameConditions_KTB_iff (R : W → W → Prop) :
+    frameConditions KTB R ↔ IsKTBFrame R := by
+  simp only [frameConditions, KTB, Axiom.FrameCondition, Finset.mem_insert,
+    Finset.mem_singleton, forall_eq_or_imp, forall_eq]
+  exact ⟨fun ⟨h1, h2⟩ => haveI := h1; haveI := h2; ⟨⟩,
+         fun h => ⟨h.toRefl, h.toSymm⟩⟩
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Bisimulation.lean
+++ b/Linglib/Logic/Modal/Bisimulation.lean
@@ -4,49 +4,31 @@ import Linglib.Logic.Team.Algebra
 /-!
 # Bisimulation for modal team logics
 
-[aloni-anttila-yang-2024] [anttila-2025] [vaananen-2008]
-
-Bisimulation is the canonical equivalence relation on Kripke models that
-abstracts away from the choice of world-carrier and identifies models no
-modal formula can distinguish. This file provides the **carrier-level**
-bisimulation substrate shared by every team-semantic modal logic in
-`Logic/Modal/`: bounded-depth world bisimulation (Definition 3.1 of
-[aloni-anttila-yang-2024]), state bisimulation lifted to teams
-(Definition 3.6), and the structural lemmas (Lemma 3.7) that each logic's
-*invariance theorem* (BSML Theorem 3.8, the MDL analogue, …) consumes.
-
-Nothing here mentions a `Formula` type or an `eval` relation — everything
-is stated over the bare `KripkeModel` carrier (`access` + `val`). Each
-logic states its own `bisim_invariant_eval` against its own evaluation,
-recursing through these carrier lemmas at the modal step.
+This file defines bounded-depth world bisimulation between pointed
+`KripkeModel`s and its lift to teams, and proves the transport lemmas
+(image unions, team splits, witness teams) that each team-semantic
+logic's invariance theorem consumes at its modal and split cases.
+Nothing here mentions a formula type: each logic states its own
+`bisim_invariant_eval` against its own evaluation, recursing through
+these carrier lemmas.
 
 ## Main declarations
 
-* `WorldBisim k M w M' w'` — bounded `k`-bisimulation between pointed worlds.
-* `StateBisim k M s M' s'` — state bisimulation lifting it to teams.
-* `WorldBisim.refl` / `.symm` / `.mono_succ` / `.mono_le` and the `StateBisim`
-  analogues — the equivalence-relation and depth-monotonicity properties.
-* `WorldBisim.val_eq`, `WorldBisim.accessStateBisim` — valuation and
-  accessibility-image transfer.
-* `StateBisim.eq_empty_iff`, `StateBisim.nonempty_iff` — emptiness transfer.
-* `StateBisim.biUnionAccess` — Lemma 3.7(i): image-union preservation.
-* `StateBisim.splitPreserve` — Lemma 3.7(ii): team-split preservation.
-* `StateBisim.exists_image_subset` — sub-team transport (BSML's per-world ◇).
-* `StateBisim.possWitness` — single-witness team transport (MDL's ◇-support).
+* `WorldBisim k M w M' w'`: bounded `k`-bisimulation between pointed worlds.
+* `StateBisim k M s M' s'`: its lift to teams, by back/forth partnership.
+* `StateBisim.biUnionAccess`, `StateBisim.splitPreserve`,
+  `StateBisim.possWitness`: the transport lemmas.
 
-## Implementation notes
+## References
 
-`WorldBisim` recurses on `k`: base case is atom invariance, inductive case
-adds back/forth on accessibility. The split- and witness-transport lemmas
-(`splitPreserve`, `exists_image_subset`, `possWitness`) construct the
-other-side team by `Finset.filter` over the bisim's existential witnesses,
-using `Classical.choice` only inside pure-`Prop` existentials.
+* [aloni-anttila-yang-2024] — Definitions 3.1 and 3.6, Lemma 3.7
+* [vaananen-2008] — modal dependence logic, the (T8)/(T9) modal clauses
+* [anttila-2025] — nonemptiness in team semantics
 -/
 
 namespace ModalLogic
 
-variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
-variable {Atom : Type*}
+variable {W W' Atom : Type*}
 
 /-! ### World bisimulation -/
 
@@ -134,29 +116,17 @@ theorem StateBisim.refl (k : ℕ) (M : KripkeModel W Atom) (s : Finset W) :
 
 theorem StateBisim.symm {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     {M' : KripkeModel W' Atom} {s' : Finset W'} :
-    StateBisim k M s M' s' → StateBisim k M' s' M s := by
-  intro h
-  obtain ⟨hforth, hback⟩ := h
-  refine ⟨?_, ?_⟩
-  · intro w' hw'
-    obtain ⟨w, hw, hbisim⟩ := hback w' hw'
-    exact ⟨w, hw, hbisim.symm⟩
-  · intro w hw
-    obtain ⟨w', hw', hbisim⟩ := hforth w hw
-    exact ⟨w', hw', hbisim.symm⟩
+    StateBisim k M s M' s' → StateBisim k M' s' M s :=
+  fun ⟨hforth, hback⟩ =>
+    ⟨fun w' hw' => let ⟨w, hw, hb⟩ := hback w' hw'; ⟨w, hw, hb.symm⟩,
+     fun w hw => let ⟨w', hw', hb⟩ := hforth w hw; ⟨w', hw', hb.symm⟩⟩
 
 theorem StateBisim.mono_succ {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     {M' : KripkeModel W' Atom} {s' : Finset W'} :
-    StateBisim (k + 1) M s M' s' → StateBisim k M s M' s' := by
-  intro h
-  obtain ⟨hforth, hback⟩ := h
-  refine ⟨?_, ?_⟩
-  · intro w hw
-    obtain ⟨w', hw', hbisim⟩ := hforth w hw
-    exact ⟨w', hw', hbisim.mono_succ⟩
-  · intro w' hw'
-    obtain ⟨w, hw, hbisim⟩ := hback w' hw'
-    exact ⟨w, hw, hbisim.mono_succ⟩
+    StateBisim (k + 1) M s M' s' → StateBisim k M s M' s' :=
+  fun ⟨hforth, hback⟩ =>
+    ⟨fun w hw => let ⟨w', hw', hb⟩ := hforth w hw; ⟨w', hw', hb.mono_succ⟩,
+     fun w' hw' => let ⟨w, hw, hb⟩ := hback w' hw'; ⟨w, hw, hb.mono_succ⟩⟩
 
 theorem StateBisim.mono_le {m n : ℕ} (hmn : m ≤ n)
     {M : KripkeModel W Atom} {s : Finset W} {M' : KripkeModel W' Atom}
@@ -178,47 +148,28 @@ theorem WorldBisim.val_eq {k : ℕ} {M : KripkeModel W Atom} {w : W}
   | _ + 1, ⟨h, _, _⟩ => h p
 
 /-- World bisim at depth `k+1` yields state bisim of the accessibility
-    images at depth `k` — the singleton form of Lemma 3.7(i), used by each
-    logic's modal case. -/
+    images at depth `k` — the singleton form of Lemma 3.7(i). -/
 theorem WorldBisim.accessStateBisim {k : ℕ} {M : KripkeModel W Atom} {w : W}
     {M' : KripkeModel W' Atom} {w' : W'}
     (h : WorldBisim (k + 1) M w M' w') :
     StateBisim k M (M.access w) M' (M'.access w') :=
   ⟨fun v hv => h.2.1 v hv, fun v' hv' => h.2.2 v' hv'⟩
 
-/-- State bisim preserves emptiness: `s = ∅ ↔ s' = ∅`. The back/forth
-    conditions force any worlds on one side to have partners on the
-    other, so emptiness is mutually determined. -/
-theorem StateBisim.eq_empty_iff {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
-    {M' : KripkeModel W' Atom} {s' : Finset W'}
-    (h : StateBisim k M s M' s') : s = ∅ ↔ s' = ∅ := by
-  refine ⟨?_, ?_⟩
-  · intro hs
-    apply Finset.eq_empty_of_forall_notMem
-    intro w' hw'
-    obtain ⟨w, hw, _⟩ := h.2 w' hw'
-    exact absurd hw (hs ▸ Finset.notMem_empty w)
-  · intro hs'
-    apply Finset.eq_empty_of_forall_notMem
-    intro w hw
-    obtain ⟨w', hw', _⟩ := h.1 w hw
-    exact absurd hw' (hs' ▸ Finset.notMem_empty w')
-
 /-- State bisim preserves nonemptiness. -/
 theorem StateBisim.nonempty_iff {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     {M' : KripkeModel W' Atom} {s' : Finset W'}
-    (h : StateBisim k M s M' s') : s.Nonempty ↔ s'.Nonempty := by
-  refine ⟨?_, ?_⟩
-  · rintro ⟨w, hw⟩
-    obtain ⟨w', hw', _⟩ := h.1 w hw
-    exact ⟨w', hw'⟩
-  · rintro ⟨w', hw'⟩
-    obtain ⟨w, hw, _⟩ := h.2 w' hw'
-    exact ⟨w, hw⟩
+    (h : StateBisim k M s M' s') : s.Nonempty ↔ s'.Nonempty :=
+  ⟨fun ⟨w, hw⟩ => let ⟨w', hw', _⟩ := h.1 w hw; ⟨w', hw'⟩,
+   fun ⟨w', hw'⟩ => let ⟨w, hw, _⟩ := h.2 w' hw'; ⟨w, hw⟩⟩
 
-/-- Given `s ⇌_k s'` and a sub-team `t ⊆ s`, there exists a corresponding
-    sub-team `t' ⊆ s'` such that `t ⇌_k t'`. Non-emptiness transfers.
-    Used by the per-world `poss`-support case of BSML's invariance proof. -/
+/-- State bisim preserves emptiness. -/
+theorem StateBisim.eq_empty_iff {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
+    {M' : KripkeModel W' Atom} {s' : Finset W'}
+    (h : StateBisim k M s M' s') : s = ∅ ↔ s' = ∅ := by
+  simp only [← Finset.not_nonempty_iff_eq_empty, h.nonempty_iff]
+
+/-- Given `s ⇌_k s'` and a sub-team `t ⊆ s`, there is a sub-team
+    `t' ⊆ s'` with `t ⇌_k t'`; non-emptiness transfers. -/
 theorem StateBisim.exists_image_subset {k : ℕ} {M : KripkeModel W Atom}
     {s t : Finset W} {M' : KripkeModel W' Atom} {s' : Finset W'}
     (h : StateBisim k M s M' s') (hsub : t ⊆ s) :
@@ -241,11 +192,10 @@ theorem StateBisim.exists_image_subset {k : ℕ} {M : KripkeModel W Atom}
 
 /-! ### Lemma 3.7: state bisimulation preserves modal step and team splits -/
 
-/-- Lemma 3.7(i) of [aloni-anttila-yang-2024]: state bisim at depth `k+1`
-    yields state bisim of the **unions of accessibility images** at depth
-    `k`: `s.biUnion R ⇌_k s'.biUnion R'`. Also the transport principle for
-    the MDL anti-`◇` clause ([vaananen-2008] (T9)), which evaluates the
-    inner formula on this union. -/
+variable [DecidableEq W] [DecidableEq W']
+
+/-- Lemma 3.7(i): state bisim at depth `k+1` yields state bisim of the
+    unions of accessibility images at depth `k`. -/
 theorem StateBisim.biUnionAccess {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     {M' : KripkeModel W' Atom} {s' : Finset W'}
     (h : StateBisim (k + 1) M s M' s') :
@@ -264,13 +214,9 @@ theorem StateBisim.biUnionAccess {k : ℕ} {M : KripkeModel W Atom} {s : Finset 
     obtain ⟨v, hv, hbv⟩ := hbw.accessStateBisim.2 v' hvw'
     exact ⟨v, Finset.mem_biUnion.mpr ⟨w, hw, hv⟩, hbv⟩
 
-/-- Lemma 3.7(ii) of [aloni-anttila-yang-2024]: state bisim preserves
-    binary team splits. Given `s = t ∪ u` and `s ⇌_k s'`, there exist
-    `t', u' ⊆ s'` with `s' = t' ∪ u'`, `t ⇌_k t'`, and `u ⇌_k u'`.
-
-    Constructed via classical choice over the bisim's existential
-    witnesses: `t'` collects all of `s'`'s witnesses for `t`, and `u'`
-    likewise for `u`. -/
+/-- Lemma 3.7(ii): state bisim preserves binary team splits. Given
+    `s = t ∪ u` and `s ⇌_k s'`, there are `t'`, `u'` with `s' = t' ∪ u'`,
+    `t ⇌_k t'`, and `u ⇌_k u'`. -/
 theorem StateBisim.splitPreserve {k : ℕ} {M : KripkeModel W Atom}
     {s t u : Finset W} {M' : KripkeModel W' Atom} {s' : Finset W'}
     (h : StateBisim k M s M' s') (hsplit : Team.splitsAs s t u)
@@ -312,19 +258,12 @@ theorem StateBisim.splitPreserve {k : ℕ} {M : KripkeModel W Atom}
       obtain ⟨_, w, hw, hbisim⟩ := Finset.mem_filter.mp hw'
       exact ⟨w, hw, hbisim⟩
 
-/-! ### Single-witness modal step (Väänänen-style ◇)
+/-! ### Single-witness modal step (Väänänen-style ◇) -/
 
-The MDL `◇`-support clause uses a single witness team reached by every
-world, rather than BSML's per-world sub-witness; this lemma is its
-transport principle. The anti-`◇` side is `StateBisim.biUnionAccess`. -/
-
-/-- **Single-witness team transport.** Given `s ⇌_{k+1} s'` and a witness team
-    `Y ⊆ s.biUnion R` that every world in `s` reaches (`∀ w ∈ s, ∃ y ∈ Y ∩
-    R[w]`), there is a corresponding `Y' ⊆ s'.biUnion R'` that every world in
-    `s'` reaches, with `Y ⇌_k Y'`. This is the Lemma 3.7 analogue for the MDL
-    `◇`-support clause ([vaananen-2008] (T8)). The `Y ⊆ s.biUnion R`
-    hypothesis is supplied by the caller via downward closure (shrinking a raw
-    witness to its reachable part). -/
+/-- Single-witness team transport: given `s ⇌_{k+1} s'` and a witness team
+    `Y` inside the image union that every world in `s` reaches, there is a
+    `Y'` that every world in `s'` reaches, with `Y ⇌_k Y'` — the Lemma 3.7
+    analogue for the single-witness `◇`-support clause. -/
 theorem StateBisim.possWitness {k : ℕ} {M : KripkeModel W Atom} {s : Finset W}
     {M' : KripkeModel W' Atom} {s' : Finset W'}
     (h : StateBisim (k + 1) M s M' s') {Y : Finset W}

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -6,12 +6,16 @@ import Mathlib.Order.PropInstances
 /-!
 # Modal operators and frame conditions
 
-This file defines the relational `box`/`diamond` of Kripke semantics
-([kripke-1963]), the frame conditions of modal correspondence theory for
-accessibility relations `W → W → Prop`, and the per-axiom correspondences
-(K, T, D, 4, B, 5) connecting them (frame definability,
-[blackburn-derijke-venema-2001] Chapter 3); the `Set`-valued mathlib counterparts
-of the operators are `Rel.core` and `Rel.preimage`.
+This file defines the relational `box`/`diamond` of Kripke semantics,
+the frame conditions of modal correspondence theory for accessibility
+relations `W → W → Prop`, and the per-axiom correspondences (K, T, D, 4,
+B, 5) connecting them; the `Set`-valued mathlib counterparts of the
+operators are `Rel.core` and `Rel.preimage`.
+
+## References
+
+* [kripke-1963] — relational semantics
+* [blackburn-derijke-venema-2001] — Chapter 3, frame definability
 -/
 
 namespace ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -107,4 +107,32 @@ theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
   let ⟨u, hwu, hpu⟩ := h
   fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
 
+/-- **Correspondence for T**: `□p ≤ p` for all `p` iff `R` is reflexive. -/
+theorem box_T_iff : (∀ p : W → Prop, □[R] p ≤ p) ↔ Std.Refl R :=
+  ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩,
+   fun hR => haveI := hR; fun _ _ h => box_T h⟩
+
+/-- **Correspondence for D**: `□p ≤ ◇p` for all `p` iff `R` is serial. -/
+theorem box_D_iff : (∀ p : W → Prop, □[R] p ≤ ◇[R] p) ↔ IsSerial R :=
+  ⟨fun h => ⟨fun w =>
+     let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
+   fun hR => haveI := hR; fun _ _ h => box_D h⟩
+
+/-- **Correspondence for B**: `p ≤ □◇p` for all `p` iff `R` is symmetric. -/
+theorem box_B_iff : (∀ p : W → Prop, p ≤ □[R] (◇[R] p)) ↔ Std.Symm R :=
+  ⟨fun h => ⟨fun w v hwv =>
+     match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
+   fun hR => haveI := hR; fun _ _ h => box_B h⟩
+
+/-- **Correspondence for 4**: `□p ≤ □□p` for all `p` iff `R` is transitive. -/
+theorem box_four_iff : (∀ p : W → Prop, □[R] p ≤ □[R] (□[R] p)) ↔ IsTrans W R :=
+  ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
+   fun hR => haveI := hR; fun _ _ h => box_four h⟩
+
+/-- **Correspondence for 5**: `◇p ≤ □◇p` for all `p` iff `R` is Euclidean. -/
+theorem box_five_iff : (∀ p : W → Prop, ◇[R] p ≤ □[R] (◇[R] p)) ↔ IsEuclidean R :=
+  ⟨fun h => ⟨fun w v u hwv hwu =>
+     match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
+   fun hR => haveI := hR; fun _ _ h => box_five h⟩
+
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -7,9 +7,10 @@ import Mathlib.Order.PropInstances
 # Modal operators and frame conditions
 
 This file defines the relational `box`/`diamond` of Kripke semantics
-([kripke-1963]) and the frame conditions of modal correspondence theory
-for accessibility relations `W → W → Prop`; the `Set`-valued mathlib
-counterparts of the operators are `Rel.core` and `Rel.preimage`.
+([kripke-1963]), the frame conditions of modal correspondence theory for
+accessibility relations `W → W → Prop`, and the per-axiom correspondences
+(K, T, D, 4, B, 5) connecting them; the `Set`-valued mathlib counterparts
+of the operators are `Rel.core` and `Rel.preimage`.
 -/
 
 namespace ModalLogic
@@ -75,5 +76,42 @@ instance [hR : Std.Refl R] [hE : IsEuclidean R] : IsTrans W R where
 /-- Symmetric + transitive implies euclidean. -/
 instance [hS : Std.Symm R] [hT : IsTrans W R] : IsEuclidean R where
   eucl w v u hwv hwu := hT.trans v w u (hS.symm w v hwv) hwu
+
+variable {p q : W → Prop} {w : W}
+
+/-! ### Axiom correspondence -/
+
+/-- **K**: `□(p → q) → □p → □q`, over any relation. -/
+theorem box_K (hpq : □[R] (fun v => p v → q v) w) (hp : □[R] p w) : □[R] q w :=
+  fun v hwv => hpq v hwv (hp v hwv)
+
+/-- **T**: over a reflexive relation, `□p → p`. -/
+theorem box_T [Std.Refl R] (h : □[R] p w) : p w :=
+  h w (Std.Refl.refl w)
+
+/-- **D**: over a serial relation, `□p → ◇p`. -/
+theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
+  let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
+
+/-- **4**: over a transitive relation, `□p → □□p`. -/
+theorem box_four [IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
+  fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
+
+/-- **B**: over a symmetric relation, `p → □◇p`. -/
+theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
+  fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
+
+/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
+theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
+  let ⟨u, hwu, hpu⟩ := h
+  fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
+
+/-- **Moore reductio for KD4**: no world satisfies `□(p ∧ ¬□p)` over a
+    serial transitive relation — the content is satisfiable; boxing it
+    is not. -/
+theorem box_not_moore [hS : IsSerial R] [IsTrans W R] :
+    ¬ □[R] (fun v => p v ∧ ¬ □[R] p v) w := fun h =>
+  have ⟨v, hv⟩ := hS.serial w
+  (h v hv).2 (box_four (fun u hu => (h u hu).1) v hv)
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -90,53 +90,53 @@ variable {p q : W → Prop} {w : W}
 theorem box_K (hpq : □[R] (fun v => p v → q v) w) (hp : □[R] p w) : □[R] q w :=
   fun v hwv => hpq v hwv (hp v hwv)
 
-/-- **T**: over a reflexive relation, `□p → p`. -/
-theorem box_T [Std.Refl R] (h : □[R] p w) : p w :=
-  h w (Std.Refl.refl w)
-
-/-- **D**: over a serial relation, `□p → ◇p`. -/
-theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
-  let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
-
-/-- **4**: over a transitive relation, `□p → □□p`. -/
-theorem box_four [IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
-  fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
-
-/-- **B**: over a symmetric relation, `p → □◇p`. -/
-theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
-  fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
-
-/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
-theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
-  let ⟨u, hwu, hpu⟩ := h
-  fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
-
-/-- **Correspondence for T**: `□p ≤ p` for all `p` iff `R` is reflexive. -/
+/-- **T** defines reflexivity: `□p ≤ p` for all `p` iff `R` is reflexive. -/
 theorem box_T_iff : (∀ p : W → Prop, □[R] p ≤ p) ↔ Std.Refl R :=
   ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩,
-   fun hR => haveI := hR; fun _ _ h => box_T h⟩
+   fun hR _ w h => h w (hR.refl w)⟩
 
-/-- **Correspondence for D**: `□p ≤ ◇p` for all `p` iff `R` is serial. -/
+/-- **T**: over a reflexive relation, `□p → p`. -/
+theorem box_T [hR : Std.Refl R] (h : □[R] p w) : p w :=
+  box_T_iff.mpr hR _ _ h
+
+/-- **D** defines seriality: `□p ≤ ◇p` for all `p` iff `R` is serial. -/
 theorem box_D_iff : (∀ p : W → Prop, □[R] p ≤ ◇[R] p) ↔ IsSerial R :=
   ⟨fun h => ⟨fun w =>
      let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
-   fun hR => haveI := hR; fun _ _ h => box_D h⟩
+   fun hS _ w h => let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩⟩
 
-/-- **Correspondence for B**: `p ≤ □◇p` for all `p` iff `R` is symmetric. -/
+/-- **D**: over a serial relation, `□p → ◇p`. -/
+theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
+  box_D_iff.mpr hS _ _ h
+
+/-- **B** defines symmetry: `p ≤ □◇p` for all `p` iff `R` is symmetric. -/
 theorem box_B_iff : (∀ p : W → Prop, p ≤ □[R] (◇[R] p)) ↔ Std.Symm R :=
   ⟨fun h => ⟨fun w v hwv =>
      match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
-   fun hR => haveI := hR; fun _ _ h => box_B h⟩
+   fun hS _ w h v hwv => ⟨w, hS.symm w v hwv, h⟩⟩
 
-/-- **Correspondence for 4**: `□p ≤ □□p` for all `p` iff `R` is transitive. -/
+/-- **B**: over a symmetric relation, `p → □◇p`. -/
+theorem box_B [hS : Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
+  box_B_iff.mpr hS _ _ h
+
+/-- **4** defines transitivity: `□p ≤ □□p` for all `p` iff `R` is transitive. -/
 theorem box_four_iff : (∀ p : W → Prop, □[R] p ≤ □[R] (□[R] p)) ↔ IsTrans W R :=
   ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
-   fun hR => haveI := hR; fun _ _ h => box_four h⟩
+   fun hT _ w h v hwv u hvu => h u (hT.trans w v u hwv hvu)⟩
 
-/-- **Correspondence for 5**: `◇p ≤ □◇p` for all `p` iff `R` is Euclidean. -/
+/-- **4**: over a transitive relation, `□p → □□p`. -/
+theorem box_four [hT : IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
+  box_four_iff.mpr hT _ _ h
+
+/-- **5** defines the Euclidean property: `◇p ≤ □◇p` for all `p` iff `R` is
+    Euclidean. -/
 theorem box_five_iff : (∀ p : W → Prop, ◇[R] p ≤ □[R] (◇[R] p)) ↔ IsEuclidean R :=
   ⟨fun h => ⟨fun w v u hwv hwu =>
      match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
-   fun hR => haveI := hR; fun _ _ h => box_five h⟩
+   fun hE _ w h v hwv => let ⟨u, hwu, hpu⟩ := h; ⟨u, hE.eucl w v u hwv hwu, hpu⟩⟩
+
+/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
+theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
+  box_five_iff.mpr hE _ _ h
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -9,7 +9,8 @@ import Mathlib.Order.PropInstances
 This file defines the relational `box`/`diamond` of Kripke semantics
 ([kripke-1963]), the frame conditions of modal correspondence theory for
 accessibility relations `W → W → Prop`, and the per-axiom correspondences
-(K, T, D, 4, B, 5) connecting them; the `Set`-valued mathlib counterparts
+(K, T, D, 4, B, 5) connecting them (frame definability,
+[blackburn-derijke-venema-2001] Chapter 3); the `Set`-valued mathlib counterparts
 of the operators are `Rel.core` and `Rel.preimage`.
 -/
 
@@ -105,13 +106,5 @@ theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
 theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
   let ⟨u, hwu, hpu⟩ := h
   fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
-
-/-- **Moore reductio for KD4**: no world satisfies `□(p ∧ ¬□p)` over a
-    serial transitive relation — the content is satisfiable; boxing it
-    is not. -/
-theorem box_not_moore [hS : IsSerial R] [IsTrans W R] :
-    ¬ □[R] (fun v => p v ∧ ¬ □[R] p v) w := fun h =>
-  have ⟨v, hv⟩ := hS.serial w
-  (h v hv).2 (box_four (fun u hu => (h u hu).1) v hv)
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -115,30 +115,29 @@ Each axiom, read as an inequality between operators on `W → Prop`,
 characterizes its frame condition. -/
 
 /-- **T** defines reflexivity. -/
-theorem box_T_iff : box R ≤ id ↔ Std.Refl R :=
-  ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩, fun hR _ w h => h w (hR.refl w)⟩
+theorem box_T_iff : box R ≤ id ↔ Std.Refl R where
+  mp h := ⟨fun w => h (R w) w fun _ hv => hv⟩
+  mpr hR _ w h := h w (hR.refl w)
 
 /-- **D** defines seriality. -/
-theorem box_D_iff : box R ≤ diamond R ↔ IsSerial R :=
-  ⟨fun h => ⟨fun w =>
-     let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
-   fun hS _ w h => let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩⟩
+theorem box_D_iff : box R ≤ diamond R ↔ IsSerial R where
+  mp h := ⟨fun w => let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩
+  mpr hS _ w h := let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
 
 /-- **B** defines symmetry. -/
-theorem box_B_iff : id ≤ box R ∘ diamond R ↔ Std.Symm R :=
-  ⟨fun h => ⟨fun w v hwv =>
-     match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
-   fun hS _ w h v hwv => ⟨w, hS.symm w v hwv, h⟩⟩
+theorem box_B_iff : id ≤ box R ∘ diamond R ↔ Std.Symm R where
+  mp h := ⟨fun w v hwv => match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩
+  mpr hS _ w h v hwv := ⟨w, hS.symm w v hwv, h⟩
 
 /-- **4** defines transitivity. -/
-theorem box_four_iff : box R ≤ box R ∘ box R ↔ IsTrans W R :=
-  ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
-   fun hT _ w h v hwv u hvu => h u (hT.trans w v u hwv hvu)⟩
+theorem box_four_iff : box R ≤ box R ∘ box R ↔ IsTrans W R where
+  mp h := ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩
+  mpr hT _ w h v hwv u hvu := h u (hT.trans w v u hwv hvu)
 
 /-- **5** defines the Euclidean property. -/
-theorem box_five_iff : diamond R ≤ box R ∘ diamond R ↔ IsEuclidean R :=
-  ⟨fun h => ⟨fun w v u hwv hwu =>
-     match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
-   fun hE _ w h v hwv => let ⟨u, hwu, hpu⟩ := h; ⟨u, hE.eucl w v u hwv hwu, hpu⟩⟩
+theorem box_five_iff : diamond R ≤ box R ∘ diamond R ↔ IsEuclidean R where
+  mp h := ⟨fun w v u hwv hwu =>
+    match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩
+  mpr hE _ w h v hwv := let ⟨u, hwu, hpu⟩ := h; ⟨u, hE.eucl w v u hwv hwu, hpu⟩
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Defs.lean
+++ b/Linglib/Logic/Modal/Defs.lean
@@ -8,8 +8,8 @@ import Mathlib.Order.PropInstances
 
 This file defines the relational `box`/`diamond` of Kripke semantics,
 the frame conditions of modal correspondence theory for accessibility
-relations `W → W → Prop`, and the per-axiom correspondences (K, T, D, 4,
-B, 5) connecting them; the `Set`-valued mathlib counterparts of the
+relations `W → W → Prop`, and the per-axiom correspondences (K, T, D, B,
+4, 5) connecting them; the `Set`-valued mathlib counterparts of the
 operators are `Rel.core` and `Rel.preimage`.
 
 ## References
@@ -62,8 +62,6 @@ class IsEuclidean : Prop where
 
 variable {R}
 
--- Seriality, symmetry, and transitivity of `⊤` follow from the two
--- instances below via the derivations that follow.
 instance : Std.Refl (⊤ : W → W → Prop) := ⟨fun _ => trivial⟩
 instance : IsEuclidean (⊤ : W → W → Prop) := ⟨fun _ _ _ _ _ => trivial⟩
 
@@ -90,53 +88,57 @@ variable {p q : W → Prop} {w : W}
 theorem box_K (hpq : □[R] (fun v => p v → q v) w) (hp : □[R] p w) : □[R] q w :=
   fun v hwv => hpq v hwv (hp v hwv)
 
-/-- **T** defines reflexivity: `□p ≤ p` for all `p` iff `R` is reflexive. -/
-theorem box_T_iff : (∀ p : W → Prop, □[R] p ≤ p) ↔ Std.Refl R :=
-  ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩,
-   fun hR _ w h => h w (hR.refl w)⟩
-
 /-- **T**: over a reflexive relation, `□p → p`. -/
-theorem box_T [hR : Std.Refl R] (h : □[R] p w) : p w :=
-  box_T_iff.mpr hR _ _ h
+theorem box_T [Std.Refl R] (h : □[R] p w) : p w :=
+  h w (Std.Refl.refl w)
 
-/-- **D** defines seriality: `□p ≤ ◇p` for all `p` iff `R` is serial. -/
-theorem box_D_iff : (∀ p : W → Prop, □[R] p ≤ ◇[R] p) ↔ IsSerial R :=
+/-- **D**: over a serial relation, `□p → ◇p`. -/
+theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
+  let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩
+
+/-- **B**: over a symmetric relation, `p → □◇p`. -/
+theorem box_B [Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
+  fun v hwv => ⟨w, Std.Symm.symm w v hwv, h⟩
+
+/-- **4**: over a transitive relation, `□p → □□p`. -/
+theorem box_four [IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
+  fun v hwv u hvu => h u (IsTrans.trans w v u hwv hvu)
+
+/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
+theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
+  let ⟨u, hwu, hpu⟩ := h
+  fun v hwv => ⟨u, hE.eucl w v u hwv hwu, hpu⟩
+
+/-! ### Frame definability
+
+Each axiom, read as an inequality between operators on `W → Prop`,
+characterizes its frame condition. -/
+
+/-- **T** defines reflexivity. -/
+theorem box_T_iff : box R ≤ id ↔ Std.Refl R :=
+  ⟨fun h => ⟨fun w => h (R w) w fun _ hv => hv⟩, fun hR _ w h => h w (hR.refl w)⟩
+
+/-- **D** defines seriality. -/
+theorem box_D_iff : box R ≤ diamond R ↔ IsSerial R :=
   ⟨fun h => ⟨fun w =>
      let ⟨v, hv, _⟩ := h (fun _ => True) w fun _ _ => trivial; ⟨v, hv⟩⟩,
    fun hS _ w h => let ⟨v, hwv⟩ := hS.serial w; ⟨v, hwv, h v hwv⟩⟩
 
-/-- **D**: over a serial relation, `□p → ◇p`. -/
-theorem box_D [hS : IsSerial R] (h : □[R] p w) : ◇[R] p w :=
-  box_D_iff.mpr hS _ _ h
-
-/-- **B** defines symmetry: `p ≤ □◇p` for all `p` iff `R` is symmetric. -/
-theorem box_B_iff : (∀ p : W → Prop, p ≤ □[R] (◇[R] p)) ↔ Std.Symm R :=
+/-- **B** defines symmetry. -/
+theorem box_B_iff : id ≤ box R ∘ diamond R ↔ Std.Symm R :=
   ⟨fun h => ⟨fun w v hwv =>
      match h (· = w) w rfl v hwv with | ⟨_, hvw, rfl⟩ => hvw⟩,
    fun hS _ w h v hwv => ⟨w, hS.symm w v hwv, h⟩⟩
 
-/-- **B**: over a symmetric relation, `p → □◇p`. -/
-theorem box_B [hS : Std.Symm R] (h : p w) : □[R] (◇[R] p) w :=
-  box_B_iff.mpr hS _ _ h
-
-/-- **4** defines transitivity: `□p ≤ □□p` for all `p` iff `R` is transitive. -/
-theorem box_four_iff : (∀ p : W → Prop, □[R] p ≤ □[R] (□[R] p)) ↔ IsTrans W R :=
+/-- **4** defines transitivity. -/
+theorem box_four_iff : box R ≤ box R ∘ box R ↔ IsTrans W R :=
   ⟨fun h => ⟨fun w v u hwv hvu => h (R w) w (fun _ hv => hv) v hwv u hvu⟩,
    fun hT _ w h v hwv u hvu => h u (hT.trans w v u hwv hvu)⟩
 
-/-- **4**: over a transitive relation, `□p → □□p`. -/
-theorem box_four [hT : IsTrans W R] (h : □[R] p w) : □[R] (□[R] p) w :=
-  box_four_iff.mpr hT _ _ h
-
-/-- **5** defines the Euclidean property: `◇p ≤ □◇p` for all `p` iff `R` is
-    Euclidean. -/
-theorem box_five_iff : (∀ p : W → Prop, ◇[R] p ≤ □[R] (◇[R] p)) ↔ IsEuclidean R :=
+/-- **5** defines the Euclidean property. -/
+theorem box_five_iff : diamond R ≤ box R ∘ diamond R ↔ IsEuclidean R :=
   ⟨fun h => ⟨fun w v u hwv hwu =>
      match h (· = u) w ⟨u, hwu, rfl⟩ v hwv with | ⟨_, hvu, rfl⟩ => hvu⟩,
    fun hE _ w h v hwv => let ⟨u, hwu, hpu⟩ := h; ⟨u, hE.eucl w v u hwv hwu, hpu⟩⟩
-
-/-- **5**: over a Euclidean relation, `◇p → □◇p`. -/
-theorem box_five [hE : IsEuclidean R] (h : ◇[R] p w) : □[R] (◇[R] p) w :=
-  box_five_iff.mpr hE _ _ h
 
 end ModalLogic

--- a/Linglib/Logic/Modal/Dependence.lean
+++ b/Linglib/Logic/Modal/Dependence.lean
@@ -117,7 +117,7 @@ infrastructure but differ in atom flavor:
 
 namespace ModalLogic.Dependence
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 open ModalLogic (KripkeModel)
 
@@ -462,7 +462,7 @@ section Bisimulation
 
 open ModalLogic
 
-variable {W' : Type*} [DecidableEq W'] [Fintype W']
+variable {W' : Type*} [DecidableEq W']
 
 /-- **Bisimulation invariance for MDL** (the [aloni-anttila-yang-2024]
     Theorem 3.8 analogue for [vaananen-2008]'s modal dependence logic):

--- a/Linglib/Logic/Modal/Inclusion.lean
+++ b/Linglib/Logic/Modal/Inclusion.lean
@@ -91,7 +91,7 @@ MIL would lose union closure. We follow the paper in using lax.
 
 namespace ModalLogic.Inclusion
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 open ModalLogic (KripkeModel)
 

--- a/Linglib/Logic/Modal/Inquisitive.lean
+++ b/Linglib/Logic/Modal/Inquisitive.lean
@@ -102,7 +102,7 @@ Per-world `□` semantics naturally fits the `R : W → Finset W` shape.
 
 namespace ModalLogic.Inquisitive
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} {Atom : Type*}
 
 open ModalLogic (KripkeModel)
 
@@ -241,8 +241,8 @@ theorem support_empty (M : KripkeModel W Atom) (φ : Formula Atom) :
     each support `p \\/ q` (the first supports `p`, the second supports
     `q`), but `{w₁, w₂}` supports neither. This is the canonical
     inquisitive UC-failure pattern. -/
-theorem not_supClosed_inqDisj_of_witness {p q : Atom} {w₁ w₂ : W}
-    {M : KripkeModel W Atom}
+theorem not_supClosed_inqDisj_of_witness [DecidableEq W] {p q : Atom}
+    {w₁ w₂ : W} {M : KripkeModel W Atom}
     (hp₁ : M.val p w₁ = true) (hq₁ : M.val q w₁ = false)
     (hp₂ : M.val p w₂ = false) (hq₂ : M.val q w₂ = true) :
     ¬ SupClosed { s : Finset W | support M (.inqDisj (.atom p) (.atom q)) s } := by

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -2,50 +2,23 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 
 /-!
-# Kripke models for modal logic
+# Kripke models
 
-[vaananen-2008]
+This file defines `KripkeModel`, the finite Kripke carrier — successor
+`Finset`s and a `Bool` valuation — that the team-semantic modal logics
+(BSML, QBSML, modal dependence and inclusion logic, InqML) evaluate on.
+It is the decidable specialization of the relational primitives of
+`Defs.lean`.
 
-A **Kripke model** for modal logic over a finite world-type `W` and an
-atom-type `Atom`: an accessibility relation `R : W → Finset W` together
-with a Boolean valuation `V : Atom → W → Bool`. This is the standard
-Kripke structure used as the carrier for classical modal logic and
-its team-semantic extensions (BSML, MDL, modal inclusion logic, etc.).
+## References
 
-The `Finset` form of accessibility (rather than `Set` or a binary
-relation) reflects the decidable / finite-witness use case shared by
-the modal team-semantic logics — all current consumers (BSML, QBSML,
-the AAY-2024 extensions BSMLOr/BSMLEmpty, modal dependence logic in
-`Logic/Modal/Dependence.lean`) consume this finite form.
-
-## Main declarations
-
-* `KripkeModel W Atom` — the carrier structure: accessibility (`access`)
-  + valuation (`val`).
-
-## Consumers
-
-* `Logic/Modal/BSML/Defs.lean` — BSML's bilateral `eval` reads
-  this carrier directly.
-* `Logic/Modal/QBSML/Defs.lean` — `QBSML.Model` parameterises
-  this carrier with an assignment type.
-* `Logic/Modal/Dependence.lean` — modal dependence logic (MDL).
-* `Studies/AloniAnttilaYang2024.lean` — BSMLOr, BSMLEmpty.
-* `Logic/Modal/Bisimulation.lean` — bounded bisimulation over this carrier.
+* [vaananen-2008] — modal dependence logic and team semantics
 -/
 
 namespace ModalLogic
 
-/-- A **Kripke model** over world-type `W` and atom-type `Atom`:
-    an accessibility relation `access : W → Finset W` (mapping each
-    world to its set of successors) together with a Boolean valuation
-    `val : Atom → W → Bool` (mapping each atom to its truth value at
-    each world).
-
-    The universe of worlds is given by `[Fintype W]` — use `Finset.univ`
-    for the full set. Decidable equality on `W` is required so that
-    accessibility images are well-behaved as `Finset`s. -/
-structure KripkeModel (W : Type*) (Atom : Type*) [DecidableEq W] [Fintype W] where
+/-- A **Kripke model** over worlds `W` and atoms `Atom`. -/
+structure KripkeModel (W : Type*) (Atom : Type*) where
   /-- Accessibility: `access w` is the set of worlds accessible from `w`. -/
   access : W → Finset W
   /-- Valuation: `val p w` is the truth value of atom `p` at world `w`. -/

--- a/Linglib/Logic/Modal/Kripke.lean
+++ b/Linglib/Logic/Modal/Kripke.lean
@@ -1,5 +1,4 @@
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Defs
 
 /-!
 # Kripke models

--- a/Linglib/Logic/Temporal/Basic.lean
+++ b/Linglib/Logic/Temporal/Basic.lean
@@ -85,7 +85,7 @@ euclideanness of `∼ₜ`. -/
 
 theorem sat_box_imp_N {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.box a) t w → F.sat V (.N a) t w :=
-  fun h => box_restrict (fun _ _ _ => trivial) _ _ h
+  fun h => box_restrict _ (fun _ _ _ => trivial) _ h
 
 theorem sat_N_imp_self {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.N a) t w → F.sat V a t w := by

--- a/Linglib/Logic/Temporal/Basic.lean
+++ b/Linglib/Logic/Temporal/Basic.lean
@@ -90,20 +90,20 @@ theorem sat_box_imp_N {a : OForm Atom} {t : Time} {w : World} :
 theorem sat_N_imp_self {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.N a) t w → F.sat V a t w := by
   haveI : Std.Refl (F.sim t) := ⟨(F.sim_equiv t).refl⟩
-  exact fun h => box_T (F.sim t) _ _ h
+  exact fun h => box_T h
 
 theorem sat_box_imp_self {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.box a) t w → F.sat V a t w :=
-  fun h => box_T ⊤ _ _ h
+  fun h => box_T h
 
 theorem sat_N_imp_N_N {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.N a) t w → F.sat V (.N (.N a)) t w := by
   haveI : IsTrans World (F.sim t) := ⟨fun _ _ _ => (F.sim_equiv t).trans⟩
-  exact fun h => box_four (F.sim t) _ _ h
+  exact fun h => box_four h
 
 theorem sat_box_imp_box_box {a : OForm Atom} {t : Time} {w : World} :
     F.sat V (.box a) t w → F.sat V (.box (.box a)) t w :=
-  fun h => box_four ⊤ _ _ h
+  fun h => box_four h
 
 theorem sat_M_imp_N_M {a : OForm Atom} {t : Time} {w : World} :
     F.sat V a.M t w → F.sat V a.M.N t w := by

--- a/Linglib/Logic/Temporal/Soundness.lean
+++ b/Linglib/Logic/Temporal/Soundness.lean
@@ -193,7 +193,7 @@ theorem soundness {a : OForm Atom} (h : Provable a) : Valid.{u, v} a := by
       simp only [sat_imp, sat_G, sat_Pst]
       exact fun ha => self_imp_box_flip_diamond (· > ·) (fun t' => F.sat V _ t' w) t ha
   | a2 _ =>
-      simp only [sat_imp]; exact fun h => box_four (· < ·) _ _ h
+      simp only [sat_imp]; exact fun h => box_four h
   | a3a _ | a3b _ =>
       simp only [sat_imp, sat_G, sat_H, sat_or, sat_Fut, sat_Pst]
       rintro ⟨t₀, _, ha⟩ t' _

--- a/Linglib/Semantics/Modality/EpistemicLogic.lean
+++ b/Linglib/Semantics/Modality/EpistemicLogic.lean
@@ -202,7 +202,7 @@ theorem believes_consistent {W E : Type*}
     {Rs : E → W → W → Prop} (i : E) [IsSerial (Rs i)]
     (φ : W → Prop) (w : W) (h : believes Rs i φ w) :
     diamond (Rs i) φ w :=
-  box_D (Rs i) φ w h
+  box_D h
 
 /-- Positive introspection: Bᵢ(φ) → Bᵢ(Bᵢ(φ)) (the 4 axiom).
     Follows from transitivity of the belief accessibility relation. -/
@@ -210,7 +210,7 @@ theorem believes_positive_introspection {W E : Type*}
     {Rs : E → W → W → Prop} (i : E) [IsTrans W (Rs i)]
     (φ : W → Prop) (w : W) (h : believes Rs i φ w) :
     believes Rs i (believes Rs i φ) w :=
-  box_four (Rs i) φ w h
+  box_four h
 
 /-- Negative introspection: ◇Bφ → □◇Bφ (the 5 axiom).
     Follows from Euclideanness of the belief accessibility relation. -/
@@ -218,7 +218,7 @@ theorem believes_negative_introspection {W E : Type*}
     {Rs : E → W → W → Prop} (i : E) [IsEuclidean (Rs i)]
     (φ : W → Prop) (w : W) (h : diamond (Rs i) φ w) :
     box (Rs i) (diamond (Rs i) φ) w :=
-  box_five (Rs i) φ w h
+  box_five h
 
 /-- Belief is not veridical: there exist frames where Bᵢ(φ) ∧ ¬φ.
     Unlike knowledge (which requires reflexivity), belief frames are

--- a/Linglib/Semantics/Modality/Kratzer/Operators.lean
+++ b/Linglib/Semantics/Modality/Kratzer/Operators.lean
@@ -246,7 +246,7 @@ theorem K_axiom (f : ModalBase W) (g : OrderingSource W) (p q : W → Prop) (w :
     (hImpl : necessity f g (fun w' => p w' → q w') w)
     (hP : necessity f g p w) :
     necessity f g q w :=
-  box_K (kratzerBestR f g) p q w hImpl hP
+  box_K hImpl hP
 
 /-- Totally realistic base: simple T holds for full necessity. -/
 theorem totally_realistic_gives_T (f : ModalBase W) (g : OrderingSource W)

--- a/Linglib/Studies/Aloni2022/FreeChoice.lean
+++ b/Linglib/Studies/Aloni2022/FreeChoice.lean
@@ -32,7 +32,7 @@ namespace Aloni2022
 open BSML
 open ModalLogic (KripkeModel)
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [DecidableEq W] {Atom : Type*}
 
 /-! ### Downward closure of atom and NE primitives -/
 
@@ -51,7 +51,7 @@ theorem atom_downwardClosed (M : KripkeModel W Atom) (p : Atom) :
 /-- NE is NOT downward-closed: an inhabited team supports NE but ∅ doesn't.
     This is the obstruction that prevents
     `isFlat_support_of_neFree` from extending to NE-bearing formulas. -/
-theorem ne_not_downwardClosed [Nonempty W] (M : KripkeModel W Atom) :
+theorem ne_not_downwardClosed [Fintype W] [Nonempty W] (M : KripkeModel W Atom) :
     ¬(∀ t t' : Finset W, t' ⊆ t → support M .ne t → support M .ne t') := by
   intro hDC
   have hFull : (Finset.univ : Finset W).Nonempty := Finset.univ_nonempty

--- a/Linglib/Studies/AloniAnttilaYang2024.lean
+++ b/Linglib/Studies/AloniAnttilaYang2024.lean
@@ -95,7 +95,7 @@ BSMLEmpty omits `⨼`, union closure is preserved.
 
 namespace AloniAnttilaYang2024
 
-variable {W W' : Type*} [DecidableEq W] [Fintype W] [DecidableEq W'] [Fintype W']
+variable {W W' : Type*} [DecidableEq W] [DecidableEq W']
 variable {Atom : Type*}
 
 open ModalLogic (KripkeModel StateBisim WorldBisim)

--- a/Linglib/Studies/Ciardelli2022.lean
+++ b/Linglib/Studies/Ciardelli2022.lean
@@ -32,9 +32,8 @@ namespace Question
 open ModalLogic (KripkeModel)
 open ModalLogic.Inquisitive
 
-variable {W : Type*} [DecidableEq W] [Fintype W] {Atom : Type*}
+variable {W : Type*} [Fintype W] {Atom : Type*}
 
-omit [DecidableEq W] in
 /-- The image of a lower family of teams under the `Finset W → Set W`
     coercion is again lower (`Fintype W`: every state is the coercion of
     its `toFinset`). The reusable bridge any downward-closed team logic

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -310,7 +310,7 @@ theorem tolerantAt_eq_diamond (M : TModel D Pred) (P : Pred) (a : D) :
     `~_P`. This is the **T axiom** instantiated. -/
 theorem StrictAt.imp_classical (M : TModel D Pred) (P : Pred) (a : D)
     (hs : StrictAt M P a) : M.interp P a :=
-  box_T (M.simAccess P) _ a hs
+  box_T hs
 
 /-- **Classical ⟹ tolerant** at the atomic level: `a` itself
     witnesses the existential by reflexivity of `~_P`. -/

--- a/Linglib/Studies/CobrerosEtAl2012.lean
+++ b/Linglib/Studies/CobrerosEtAl2012.lean
@@ -112,10 +112,9 @@ extension of `P`:
 
 The s ⊆ c ⊆ t hierarchy is the **T axiom** instantiated at `box`
 (`ModalLogic.box_T`); the t/s duality is the standard
-modal de Morgan `box R ¬p ↔ ¬diamond R p`. T-models satisfy
-`frameConditions ModalLogic.KTB` by construction (Definition 4 of
-[cobreros-etal-2012]); see `TModel.satisfies_KTB` for the explicit
-witness. The Brouwersche axiom B / symmetric-frame correspondence is
+modal de Morgan `box R ¬p ↔ ¬diamond R p`. T-models are KTB frames by
+construction (Definition 4 of [cobreros-etal-2012]): each `~_P`
+carries an `IsKTBFrame` instance. The Brouwersche axiom B / symmetric-frame correspondence is
 a standard Sahlqvist result; for systematic treatment see
 [blackburn-derijke-venema-2001] §3.5–3.6 and the model-theoretic
 overview [goranko-otto-2007]. The non-equivalence-relation
@@ -188,7 +187,6 @@ namespace Semantics.Supervaluation.TCS
 
 open ModalLogic
   (IsKTBFrame IsSerial box diamond box_T)
-open ModalLogic (KTB frameConditions)
 open Consequence (MixedConsequence SatImplies IsSelfDual
   premise_monotone conclusion_monotone mixed_monotone)
 open Semantics.Supervaluation (SpecSpace superTrue
@@ -233,21 +231,12 @@ variable {D Pred : Type*}
 
 /-- The similarity relation as a Kripke accessibility relation — the frame
     associated with each predicate. By construction this frame is
-    reflexive + symmetric, i.e., a **KTB frame** (`ModalLogic.KTB`). -/
+    reflexive + symmetric, i.e., a **KTB frame** (`ModalLogic.IsKTBFrame`). -/
 @[reducible] def simAccess (M : TModel D Pred) (P : Pred) : D → D → Prop := M.sim P
 
 /-- Per-`(M, P)` KTB-frame instance: lets typeclass search reach
     `Std.Refl` and `Std.Symm` on `M.sim P` from any call site. -/
 instance (M : TModel D Pred) (P : Pred) : IsKTBFrame (M.sim P) := M.sim_ktb P
-
-/-- **T-models are KTB frames by construction**: every per-predicate
-    similarity relation `~_P` satisfies the frame conditions for the
-    normal modal logic `KTB = K + T + B` (reflexive + symmetric Kripke
-    frame), via the `IsKTBFrame` instance and the syntactic-semantic
-    bridge `frameConditions_KTB_iff`. -/
-theorem satisfies_KTB (M : TModel D Pred) (P : Pred) :
-    frameConditions KTB (M.simAccess P) :=
-  (ModalLogic.frameConditions_KTB_iff _).mpr inferInstance
 
 end TModel
 

--- a/Linglib/Studies/Hintikka1962.lean
+++ b/Linglib/Studies/Hintikka1962.lean
@@ -8,19 +8,27 @@ import Linglib.Discourse.Commitment.Frame
 "p but I do not believe that p" is not self-contradictory — there are
 worlds where `p` holds while the speaker fails to believe `p`. But its
 would-be-believed form `B_a (p ∧ ¬ B_a p)` is *indefensible* in any KD4
-doxastic model: a 1-line specialisation of
-`ModalLogic.box_not_moore` to the agent-indexed belief
-accessibility of `CommitmentState`. The knowledge analogue specialises
-the same substrate lemma to epistemic accessibility.
+doxastic model: the `box_not_moore` reductio below, specialised to the
+agent-indexed belief accessibility of `CommitmentState`. The knowledge
+analogue specialises the same reductio to epistemic accessibility.
 -/
 
 namespace Hintikka1962
 
 open Discourse.Commitment.Frame
-open ModalLogic (box_not_moore IsSerial)
+open ModalLogic (box box_four IsSerial)
 open Modality.EpistemicLogic (knows)
 
 variable {W A : Type*}
+
+/-- **Moore reductio for KD4** ([hintikka-1962] Ch. 4): no world satisfies
+    `□(p ∧ ¬□p)` over a serial transitive relation — the content is
+    satisfiable; boxing it is not. -/
+theorem box_not_moore {R : W → W → Prop} {p : W → Prop} {w : W}
+    [hS : IsSerial R] [IsTrans W R] :
+    ¬ box R (fun v => p v ∧ ¬ box R p v) w := fun h =>
+  have ⟨v, hv⟩ := hS.serial w
+  (h v hv).2 (box_four (fun u hu => (h u hu).1) v hv)
 
 /-- The Moore content for speaker `s` and proposition `p`: worlds where
     `p` holds and `s` does not believe `p`. -/

--- a/Linglib/Studies/Hintikka1962.lean
+++ b/Linglib/Studies/Hintikka1962.lean
@@ -39,7 +39,7 @@ def DoxasticallyIndefensible (c : CommitmentState W A) (a : A) (P : Set W) : Pro
 theorem mooreContent_doxasticallyIndefensible
     (c : CommitmentState W A) (a : A) (p : Set W) :
     DoxasticallyIndefensible c a (mooreContent c a p) :=
-  fun w => box_not_moore (c.belief a) (fun v => v ∈ p) w
+  fun _ => box_not_moore
 
 /-- A two-world KD4 frame: every world treats only `false` as belief-
     accessible. Used as a witness for `true_mem_mooreContent`. -/
@@ -69,7 +69,7 @@ theorem knowledge_unknowable
     [IsSerial (Rs i)] [IsTrans W (Rs i)]
     (p : W → Prop) (w : W) :
     ¬ knows Rs i (fun v => p v ∧ ¬ knows Rs i p v) w :=
-  box_not_moore (Rs i) p w
+  box_not_moore
 
 /-- **Performatory corollary** (state-theoretic restatement of Hintikka
     §4.10): under sincerity, no commitment state hosts a self-commitment

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -43,7 +43,6 @@ namespace KeshetAbney2024.PIP.Bridges
 open KeshetAbney2024.PIP
 open DynamicSemantics.ICDRT (IVar Assignment Entity Context)
 open ModalLogic (box diamond)
-open ModalLogic (frameConditions)
 
 
 -- ============================================================
@@ -235,48 +234,7 @@ theorem properPlural_implies_plural {α : Type*} {a b : α}
 
 
 -- ============================================================
--- § 4. Modal Logic Classification
--- ============================================================
-
-/-!
-### Modal Logic: PIP's must needs the T axiom
-
-PIP's must allows anaphora because of a **realistic modal base**
-([kratzer-1991]): the evaluation world w* is accessible from
-itself (`R w* w*`). This is exactly the T axiom (`□p → p`,
-frame condition: reflexivity).
-
-The `must_truth_agrees_box` and `must_realistic_of_refl`
-theorems in `Connectives.lean` already prove this correspondence.
-This section classifies PIP's modal operators in the lattice of
-normal modal logics from `Intensional`.
--/
-
-/-!
-PIP's anaphora-enabling modality needs the **T axiom** (reflexivity): a
-realistic modal base guarantees the description holds at the evaluation
-world. The content of that claim is carried by `reflexive_satisfies_T`
-below (reflexivity ⟹ T's frame condition) together with
-`Connectives.must_realistic_of_refl` (which consumes `Std.Refl R` to
-derive `p g w₀`). A bare `K ≤ T` lemma would be vacuous — `K = ⊥` — so
-it is intentionally omitted.
--/
-
-/--
-A reflexive accessibility relation satisfies ModalLogic.T's frame condition.
-
-Stated for the Prop-valued `Std.Refl`/`frameConditions` API in
-`Intensional` — the same accessibility type PIP's modal
-operators now use directly.
--/
-theorem reflexive_satisfies_T {W : Type*}
-    (R : W → W → Prop) [hRefl : Std.Refl R] :
-    frameConditions ModalLogic.T R :=
-  fun a ha => by obtain rfl := Finset.mem_singleton.mp ha; exact hRefl
-
-
--- ============================================================
--- § 5. Kratzer Correspondence
+-- § 4. Kratzer Correspondence
 -- ============================================================
 
 /-!
@@ -321,7 +279,7 @@ theorem mustBase_agrees_box {W D : Type*}
 
 
 -- ============================================================
--- § 6. Static↔Dynamic Agreement
+-- § 5. Static↔Dynamic Agreement
 -- ============================================================
 
 /-!

--- a/Linglib/Studies/KeshetAbney2024/Bridges.lean
+++ b/Linglib/Studies/KeshetAbney2024/Bridges.lean
@@ -272,8 +272,7 @@ operators now use directly.
 theorem reflexive_satisfies_T {W : Type*}
     (R : W → W → Prop) [hRefl : Std.Refl R] :
     frameConditions ModalLogic.T R :=
-  ⟨fun _ => hRefl, fun h => absurd h (by decide), fun h => absurd h (by decide),
-   fun h => absurd h (by decide), fun h => absurd h (by decide)⟩
+  fun a ha => by obtain rfl := Finset.mem_singleton.mp ha; exact hRefl
 
 
 -- ============================================================

--- a/Linglib/Studies/KeshetAbney2024/Connectives.lean
+++ b/Linglib/Studies/KeshetAbney2024/Connectives.lean
@@ -341,7 +341,7 @@ theorem must_realistic_of_refl [Fintype W]
     (hd : (g, w₀) ∈ d.info)
     (hmust : (g, w₀) ∈ (must R (Finset.univ : Finset W).toList (atom p) d).info) :
     p g w₀ :=
-  box_T R (p g) w₀ ((must_truth_agrees_box R p d g w₀ hd).mp hmust)
+  box_T ((must_truth_agrees_box R p d g w₀ hd).mp hmust)
 
 /--
 Pointwise realistic base: if `R w₀ w₀` and must holds at w₀,

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7987,6 +7987,18 @@
   role      = {cited},
   sources   = {Semantics/Attitudes/RationalAttitude.lean;Semantics/Lexical/LevinClass.lean;Semantics/Causation/Progressive.lean;Semantics/Lexical/EventStructure.lean;Semantics/Aspect/SubintervalProperty.lean;Features/Aktionsart.lean}
 }
+@book{blackburn-derijke-venema-2001,
+  author    = {Blackburn, Patrick and de Rijke, Maarten and Venema, Yde},
+  year      = {2001},
+  title     = {Modal Logic},
+  series    = {Cambridge Tracts in Theoretical Computer Science},
+  publisher = {Cambridge University Press},
+  doi       = {10.1017/CBO9781107050884},
+  subfield  = {semantics/modality},
+  validated = {true},
+  role      = {cited},
+  sources   = {Logic/Modal/Defs.lean}
+}
 @book{dowty-wall-peters-1981,
   author    = {Dowty, David R. and Wall, Robert E. and Peters, Stanley},
   year      = {1981},


### PR DESCRIPTION
Elegance pass over `Basic.lean`, section by section, continuing the Defs work.

- Axiom theorems: implicit binders, `□[R]`/`◇[R]` notation, moved to `Defs.lean`; `box_not_moore` demoted to `Studies/Hintikka1962.lean`; verified against Blackburn–de Rijke–Venema Ch 3, `[blackburn-derijke-venema-2001]` added and cited.
- Modal square: relations collapse to one line via the new `Aristotelian.SquareRelations.of_disjoint` (complemented square: everything ≡ contrariety, the existential-import locus).
- Normality reorganized around `diamond_box_gc : GaloisConnection ◇[R] □[flip R]` — monotonicity, `box_inf`/`diamond_sup`, `box_top`, and Prior's conversion (the unit) are one-line projections; restriction lemmas as `≤`-in-the-relation.
- Gallin section cut to its consumed surface: `PropOp`/`PropOp.Monotone`/`DistribConj` and the whole `s5Nec`/`s5Poss` tier were consumer-free duplicates of mathlib's `Monotone` and of `box_mono`/`box_inf`/`box ⊤`; what remains is `IsIndicial`/`box_isIndicial` (the Temporal boundary) and the flat `poss`/`nec` with `nec_mono : Monotone nec`. Frame classes draw from the `variable` line; self-evident docstrings dropped.

`Defs.lean` + `Basic.lean` are now 110 + 336 lines.
