### PR TITLE
refactor(Logic/Modal): epistemic logic joins Modal; Montague box is nec

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1694,7 +1694,7 @@ import Linglib.Semantics.Mereology
 import Linglib.Semantics.Modality.ActualityEntailments
 import Linglib.Semantics.Modality.BranchingTime
 import Linglib.Semantics.Modality.Directive
-import Linglib.Semantics.Modality.EpistemicLogic
+import Linglib.Logic.Modal.Epistemic
 import Linglib.Semantics.Modality.EpistemicProbability
 import Linglib.Semantics.Modality.EventRelativity
 import Linglib.Semantics.Modality.Exclusion

--- a/Linglib/Discourse/Commitment/Frame.lean
+++ b/Linglib/Discourse/Commitment/Frame.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Set.Basic
 import Linglib.Logic.Modal.Defs
 import Linglib.Logic.Modal.Basic
-import Linglib.Semantics.Modality.EpistemicLogic
+import Linglib.Logic.Modal.Epistemic
 
 /-!
 # Doxastic / Deontic Commitment Frame
@@ -28,7 +28,7 @@ commitment to belief.
 namespace Discourse.Commitment.Frame
 
 open ModalLogic (IsKD45Frame IsK45Frame IsEuclidean box diamond box_K box_four)
-open Modality.EpistemicLogic (knows)
+open ModalLogic.Epistemic (knows)
 
 /-- Multi-relational Kripke frame: belief (KD45) + commitment (K4 +
     Eucl., not serial) + atomic valuation. -/

--- a/Linglib/Logic/Modal/Epistemic.lean
+++ b/Linglib/Logic/Modal/Epistemic.lean
@@ -35,16 +35,15 @@ Following mathlib style, all operators are `Prop`-valued; computation
 on finite worlds goes through `Decidable` instances + `decide`.
 -/
 
-namespace Modality.EpistemicLogic
+namespace ModalLogic.Epistemic
 
 open ModalLogic
   (box diamond IsSerial IsEuclidean box_T box_D box_four box_B box_five)
 
 /-! ## Individual Knowledge
 
-Agent i knows φ at world w iff φ holds at all worlds accessible to i.
-This re-uses `box` from `RestrictedModality.lean` with agent-indexed
-accessibility relations. -/
+Agent i knows φ at world w iff φ holds at all worlds accessible to i:
+`box` with agent-indexed accessibility relations. -/
 
 /-- Agent i knows φ at world w: Kᵢ(φ)(w) = □ᵢ φ(w). -/
 def knows {W E : Type*} (Rs : E → W → W → Prop) (i : E)
@@ -269,4 +268,4 @@ def s5ToSystemW {W : Type*} (R : W → W → Prop) [hRefl : Std.Refl R] :
     ComparativeProbability.EpistemicSystemW W :=
   ComparativeProbability.dominationLiftSystemW (s5ToWorldOrder R) (fun w => hRefl.refl w)
 
-end Modality.EpistemicLogic
+end ModalLogic.Epistemic

--- a/Linglib/Semantics/Intensional/Algebra.lean
+++ b/Linglib/Semantics/Intensional/Algebra.lean
@@ -220,7 +220,7 @@ theorem entails_nil (q : Denot E W .prop) :
 /-- Single-premise entailment: `p ⊨ q` iff `□(p → q)`. -/
 theorem entails_singleton (p q : Denot E W .prop) :
     entails (E := E) (W := W) [p] q = box (fun i => impl (p i) (q i)) := by
-  simp [entails, trueAt, box, impl]
+  simp [entails, trueAt, box, ModalLogic.nec, impl]
 
 -- ════════════════════════════════════════════════════════════════
 -- § Boolean-Algebra Instances on `Denot E W τ`

--- a/Linglib/Semantics/Intensional/Quantification.lean
+++ b/Linglib/Semantics/Intensional/Quantification.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.Intensional.Defs
+import Linglib.Logic.Modal.Basic
 
 /-!
 # IL Quantification, Modality, and Identity
@@ -152,22 +153,22 @@ theorem identIntens_up {a : Ty} (x y : Denot E W a)
     (`Semantics/Modality/Kratzer/`) restricts quantification
     to accessible worlds via a modal base and ordering source. -/
 def box (p : Denot E W .prop) : Denot E W .t :=
-  ∀ i : W, p i
+  ModalLogic.nec p
 
 /-- Possibility (◇): a proposition is possible iff it is true at
     some index. Dual of `box`. -/
 def diamond (p : Denot E W .prop) : Denot E W .t :=
-  ∃ i : W, p i
+  ModalLogic.poss p
 
 /-- □ and ◇ are duals: `□p ↔ ¬◇¬p`. -/
 theorem box_neg_diamond (p : Denot E W .prop) :
     box (E := E) (W := W) p = neg (diamond (fun i => neg (p i))) := by
-  simp only [box, diamond, neg, not_exists_not]
+  simp only [box, diamond, ModalLogic.nec, ModalLogic.poss, neg, not_exists_not]
 
 /-- `◇p ↔ ¬□¬p`. -/
 theorem diamond_neg_box (p : Denot E W .prop) :
     diamond (E := E) (W := W) p = neg (box (fun i => neg (p i))) := by
-  simp only [diamond, box, neg, not_forall_not]
+  simp only [diamond, box, ModalLogic.nec, ModalLogic.poss, neg, not_forall_not]
 
 /-- **K axiom**: `□(p → q) → (□p → □q)`.
     The fundamental distribution axiom of normal modal logic. -/
@@ -192,13 +193,13 @@ theorem necessitation (p : Denot E W .prop)
 theorem box_conj (p q : Denot E W .prop) :
     box (E := E) (W := W) (fun i => conj (p i) (q i)) =
     conj (box p) (box q) := by
-  simp only [box, conj, forall_and]
+  simp only [box, ModalLogic.nec, conj, forall_and]
 
 /-- ◇ distributes over ∨. -/
 theorem diamond_disj (p q : Denot E W .prop) :
     diamond (E := E) (W := W) (fun i => disj (p i) (q i)) =
     disj (diamond p) (diamond q) := by
-  simp only [diamond, disj, exists_or]
+  simp only [diamond, ModalLogic.poss, disj, exists_or]
 
 /-- `□p → ◇p` (seriality — holds vacuously when Index is inhabited). -/
 theorem box_implies_diamond [Inhabited W]
@@ -230,7 +231,7 @@ theorem box_or_box_neg_of_up (p : Denot E W .t) :
     that `up` followed by `box` is equivalent to the original proposition. -/
 theorem box_up_iff [Inhabited W] (p : Denot E W .t) :
     box (E := E) (W := W) (up p) = p := by
-  simp only [box, up]
+  simp only [box, ModalLogic.nec, up]
   exact propext ⟨fun h => h default, fun h _ => h⟩
 
 /-- `□` applied to the intension of `p` is `p` evaluated at every index.

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Presupposition.Context
-import Linglib.Semantics.Modality.EpistemicLogic
+import Linglib.Logic.Modal.Epistemic
 
 /-!
 # Belief Embedding and Local Contexts

--- a/Linglib/Studies/FaginHalpern1994.lean
+++ b/Linglib/Studies/FaginHalpern1994.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Modality.EpistemicLogic
+import Linglib.Logic.Modal.Epistemic
 import Linglib.Semantics.Modality.EpistemicProbability
 import Mathlib.Data.Fintype.Basic
 
@@ -57,7 +57,7 @@ namespace FaginHalpern1994
 
 open ModalLogic
   (box IsEuclidean)
-open Modality.EpistemicLogic (knows everyoneKnows)
+open ModalLogic.Epistemic (knows everyoneKnows)
 open Modality.EpistemicProbability (WorldCredence nestedThreshold)
 
 -- ============================================================================
@@ -359,7 +359,7 @@ theorem everyoneKnows_implies_everyoneProbOne {W E : Type*} [Fintype W]
   intro i hi
   simp only [nestedThreshold, decide_eq_true_eq]
   linarith [knows_implies_prob_one kp hCONS hNorm i φ w
-    (Modality.EpistemicLogic.everyoneKnows_implies_knows
+    (ModalLogic.Epistemic.everyoneKnows_implies_knows
       kp.accessRel group _ w i hi h)]
 
 -- ============================================================================

--- a/Linglib/Studies/Hintikka1962.lean
+++ b/Linglib/Studies/Hintikka1962.lean
@@ -17,7 +17,7 @@ namespace Hintikka1962
 
 open Discourse.Commitment.Frame
 open ModalLogic (box box_four IsSerial)
-open Modality.EpistemicLogic (knows)
+open ModalLogic.Epistemic (knows)
 
 variable {W A : Type*}
 

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -119,7 +119,7 @@ intentional states (not unified here).
    principled fix is to refactor `demonstratum` to a relation
    `C → E → Prop`.
 2. `inCG : Prop → Prop` (here taken as hypothesis) should connect to
-   `commonBelief` in `Semantics/Modality/EpistemicLogic.lean`
+   `commonBelief` in `Logic/Modal/Epistemic.lean`
    once a `CommonGround.toAgentAccess` bridge exists.
 3. `SpeakerIntention.intendedRef` parallel-stipulates with
    `Donnellan.DefiniteDescription.intendedRef`; not unified.

--- a/Linglib/Studies/VanDerLeer2026.lean
+++ b/Linglib/Studies/VanDerLeer2026.lean
@@ -64,7 +64,7 @@ def MutuallyCommitted (C : CommitmentSpace W A) (π : Set W) : Prop :=
     `EpistemicLogic.commonBelief` on the state's belief relation. -/
 def CommonlyBelieved (c : CommitmentState W A) (group : List A)
     (π : Set W) (bound : ℕ) (w : W) : Prop :=
-  Modality.EpistemicLogic.commonBelief c.belief group
+  ModalLogic.Epistemic.commonBelief c.belief group
     (fun v => v ∈ π) bound w
 
 end CommitmentSpace

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -5025,7 +5025,7 @@
   subfield  = {semantics/compositional},
   role      = {formalized},
   validated = {true},
-  sources   = {Semantics/Modality/EpistemicLogic.lean;Semantics/Modality/EpistemicProbability.lean;Studies/FaginHalpern1994.lean}
+  sources   = {Logic/Modal/Epistemic.lean;Semantics/Modality/EpistemicProbability.lean;Studies/FaginHalpern1994.lean}
 }
 @article{kamp-partee-1995,
   author    = {Kamp, Hans and Partee, Barbara H.},


### PR DESCRIPTION
Moves Halpern multi-agent epistemic logic from Semantics/Modality/ to Logic/Modal/Epistemic.lean (namespace ModalLogic.Epistemic, replacing the stale Modality.EpistemicLogic umbrella prefix), and grounds Intensional.Quantification's Montague S5 box/diamond on ModalLogic.nec/poss per layered grounding.