### PR TITLE
style(Logic/Modal/FirstOrder): Comparative register polish

### DIFF
--- a/Linglib/Core/Order/ComparativeProbability/Defs.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Defs.lean
@@ -34,6 +34,9 @@ variable {α : Type*} [BooleanAlgebra α]
 /-- `Strict r a b` ("`a ≻ b`"): `a` is at least as likely as `b` but not conversely. -/
 def Strict (r : α → α → Prop) (a b : α) : Prop := r a b ∧ ¬ r b a
 
+instance {r : α → α → Prop} [DecidableRel r] : DecidableRel (Strict r) :=
+  fun _ _ => inferInstanceAs (Decidable (_ ∧ _))
+
 /-- `Probably r a` ("`△a`"): `a` is strictly more likely than its complement. -/
 def Probably (r : α → α → Prop) (a : α) : Prop := Strict r a aᶜ
 

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -39,6 +39,13 @@ instance (S : L.Structure E) (R : L.Relations 1) (e : E)
     [h : Decidable (S.RelMap R ![e])] : Decidable (e ∈ S.ext₁ R) :=
   h
 
+/-- Pointwise decidability of atoms across a doubly-indexed structure family —
+the hook that makes `decide` available on finite models; the semantics itself
+is decidability-free. -/
+abbrev DecidableAtoms (interp : I → W → L.Structure E) :=
+  ∀ (i : I) (w : W) (n : ℕ) (r : L.Relations n) (x : Fin n → E),
+    Decidable ((interp i w).RelMap r x)
+
 /-- Comparative-possibility formulas: an embedded classical formula (free
 variables valued by domain elements), booleans, and the comparative ≻
 (`.comp`). Booleans exist at both layers because negation and the derived
@@ -52,6 +59,9 @@ inductive CompFormula (L : Language) (E : Type*) where
 
 namespace CompFormula
 
+open Core.Order (TotalPreorder)
+open ComparativeProbability
+
 /-- Ground unary predication `R(e)`, as an embedded formula. -/
 abbrev matom (R : L.Relations 1) (e : E) : CompFormula L E :=
   .ofFormula (R.formula ![Term.var e])
@@ -61,27 +71,13 @@ def equi (A B : CompFormula L E) : CompFormula L E :=
   .inf (.not (.comp A B)) (.not (.comp B A))
 
 /-- Formulas free of the comparative: the fragment whose truth does not
-consult the ordering (`realize_congr_of_compFree`). -/
+consult the ordering (`CompFree.realize_congr`). -/
 def CompFree : CompFormula L E → Prop
   | .ofFormula _ => True
   | .not A => A.CompFree
   | .inf A B => A.CompFree ∧ B.CompFree
   | .sup A B => A.CompFree ∧ B.CompFree
   | .comp _ _ => False
-
-end CompFormula
-
-/-- Pointwise decidability of atoms across a doubly-indexed structure family —
-the hook that makes `decide` available on finite models; the semantics itself
-is decidability-free. -/
-abbrev DecidableAtoms (interp : I → W → L.Structure E) :=
-  ∀ (i : I) (w : W) (n : ℕ) (r : L.Relations n) (x : Fin n → E),
-    Decidable ((interp i w).RelMap r x)
-
-namespace CompFormula
-
-open Core.Order (TotalPreorder)
-open ComparativeProbability
 
 variable (interp : I → W → L.Structure E)
 

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -71,12 +71,12 @@ def equi (A B : ComparativeFormula L E) : ComparativeFormula L E :=
   .inf (.not (.comp A B)) (.not (.comp B A))
 
 /-- Formulas free of the comparative: the fragment whose truth does not
-consult the ordering (`CompFree.realize_congr`). -/
-def CompFree : ComparativeFormula L E → Prop
+consult the ordering (`ComparativeFree.realize_congr`). -/
+def ComparativeFree : ComparativeFormula L E → Prop
   | .ofFormula _ => True
-  | .not A => A.CompFree
-  | .inf A B => A.CompFree ∧ B.CompFree
-  | .sup A B => A.CompFree ∧ B.CompFree
+  | .not A => A.ComparativeFree
+  | .inf A B => A.ComparativeFree ∧ B.ComparativeFree
+  | .sup A B => A.ComparativeFree ∧ B.ComparativeFree
   | .comp _ _ => False
 
 variable (interp : I → W → L.Structure E)
@@ -138,14 +138,14 @@ theorem realize_comp_iff :
   rw [Formula.realize_rel, hv]
 
 /-- Comparative-free formulas are ordering-invariant. -/
-theorem CompFree.realize_congr :
-    ∀ {φ : ComparativeFormula L E}, φ.CompFree →
+theorem ComparativeFree.realize_congr :
+    ∀ {φ : ComparativeFormula L E}, φ.ComparativeFree →
       ∀ {le le' : I → I → Prop} {i : I} {w : W},
       Realize interp φ le i w ↔ Realize interp φ le' i w
   | .ofFormula _, _ => Iff.rfl
-  | .not A, h => not_congr (CompFree.realize_congr (show A.CompFree from h))
-  | .inf _ _, h => and_congr (CompFree.realize_congr h.1) (CompFree.realize_congr h.2)
-  | .sup _ _, h => or_congr (CompFree.realize_congr h.1) (CompFree.realize_congr h.2)
+  | .not A, h => not_congr (ComparativeFree.realize_congr (show A.ComparativeFree from h))
+  | .inf _ _, h => and_congr (ComparativeFree.realize_congr h.1) (ComparativeFree.realize_congr h.2)
+  | .sup _ _, h => or_congr (ComparativeFree.realize_congr h.1) (ComparativeFree.realize_congr h.2)
   | .comp _ _, h => h.elim
 
 /-- ≻ is the *strict l-lifting* of the ordering ([holliday-icard-2013];

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -82,10 +82,10 @@ def ComparativeFree : ComparativeFormula L E → Prop
 variable (interp : I → W → L.Structure E)
 
 /-- The strict (asymmetric) part of a raw ordering relation. -/
-private def strictPart (le : I → I → Prop) (b a : I) : Prop :=
+def strictPart (le : I → I → Prop) (b a : I) : Prop :=
   le b a ∧ ¬ le a b
 
-private instance {le : I → I → Prop} [DecidableRel le] :
+instance {le : I → I → Prop} [DecidableRel le] :
     DecidableRel (strictPart le) :=
   fun _ _ => inferInstanceAs (Decidable (_ ∧ _))
 

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -5,17 +5,21 @@ import Linglib.Core.Order.ComparativeProbability.Systems
 /-!
 # Comparative possibility over a first-order base
 
-[lewis-1973]'s comparative possibility as a formula language: classical
-first-order formulas embedded wholesale (the `ModalFormula.ofFormula`
-pattern), boolean connectives, and a binary comparative `A ≻ B` (`.comp`)
-evaluated at an index of an ordered family of structures — some
-(A∧¬B)-index in the cone strictly dominates every (B∧¬A)-index.
-`realize_comp_iff_strict_dominationLift` identifies ≻ with the strict
-l-lifting of [holliday-icard-2013] §5 — Lewis's lift, which is also the lift
-of [kratzer-1991]'s ordering semantics, with complete logic WJR
-([halpern-2003]); comparing *difference sets* follows [kratzer-2012]'s revised
-lifting. [rudolph-kocurek-2024] instantiates the language with
-interpretations as indices.
+This file defines `CompFormula`, Lewis's comparative-possibility language
+over an embedded classical first-order layer, and its truth relation
+`Realize` at an index of an ordered family of structures: `A ≻ B` holds
+when some (A ∧ ¬B)-index in the cone strictly dominates every
+(B ∧ ¬A)-index. `realize_comp_iff_strict_dominationLift` identifies ≻
+with the strict domination lift of the ordering — Lewis's lift, which is
+also the lift of Kratzer's ordering semantics.
+
+## References
+
+* [lewis-1973] — comparative possibility
+* [holliday-icard-2013] — the lift taxonomy; ≻ as the strict l-lifting
+* [kratzer-1991] — ordering semantics; [kratzer-2012] — difference sets
+* [halpern-2003] — the complete logic WJR
+* [rudolph-kocurek-2024] — interpretations as indices
 -/
 
 namespace FirstOrder.Language
@@ -24,16 +28,15 @@ namespace FirstOrder.Language
 term. -/
 def Structure.ext₁ {L : Language} {E : Type*} (S : L.Structure E)
     (R : L.Relations 1) : Set E :=
-  {e | @Structure.RelMap L E S 1 R ![e]}
+  {e | S.RelMap R ![e]}
 
 @[simp] theorem Structure.mem_ext₁ {L : Language} {E : Type*}
     {S : L.Structure E} {R : L.Relations 1} {e : E} :
-    e ∈ S.ext₁ R ↔ @Structure.RelMap L E S 1 R ![e] :=
+    e ∈ S.ext₁ R ↔ S.RelMap R ![e] :=
   Iff.rfl
 
 instance {L : Language} {E : Type*} (S : L.Structure E) (R : L.Relations 1)
-    (e : E) [h : Decidable (@Structure.RelMap L E S 1 R ![e])] :
-    Decidable (e ∈ S.ext₁ R) :=
+    (e : E) [h : Decidable (S.RelMap R ![e])] : Decidable (e ∈ S.ext₁ R) :=
   h
 
 /-- Comparative-possibility formulas: an embedded classical formula (free
@@ -76,7 +79,7 @@ is decidability-free. -/
 abbrev DecidableAtoms {L : Language} {I W E : Type*}
     (interp : I → W → L.Structure E) :=
   ∀ (i : I) (w : W) (n : ℕ) (r : L.Relations n) (x : Fin n → E),
-    Decidable (@Structure.RelMap L E (interp i w) n r x)
+    Decidable ((interp i w).RelMap r x)
 
 namespace CompFormula
 
@@ -91,7 +94,7 @@ comparative: some (A∧¬B)-index in the ≤-cone strictly dominates every
 (B∧¬A)-index. -/
 def Realize (φ : CompFormula L E) (le : I → I → Prop) (i : I) (w : W) : Prop :=
   match φ with
-  | .ofFormula ψ => @Formula.Realize _ _ (interp i w) _ ψ id
+  | .ofFormula ψ => letI := interp i w; ψ.Realize id
   | .not A => ¬ Realize A le i w
   | .inf A B => Realize A le i w ∧ Realize B le i w
   | .sup A B => Realize A le i w ∨ Realize B le i w
@@ -126,8 +129,8 @@ instance instDec [Fintype I] [Fintype E] [DecidableEq E]
         le (fun b a => le b a ∧ ¬ le a b)
         (fun j => Realize interp A le j w) (fun j => Realize interp B le j w) i))
 
-variable (A B : CompFormula L E) (le : I → I → Prop) (ord : TotalPreorder I)
-  (i : I) (w : W)
+variable {interp} {A B : CompFormula L E} {le : I → I → Prop}
+  {ord : TotalPreorder I} {i : I} {w : W}
 
 /-- The comparative clause over a total preorder — definitional; the rewriting
 interface, with the domination conjunction packaged as `ord.lt`. -/
@@ -141,33 +144,23 @@ theorem realize_comp_iff :
 
 /-- Realization of a ground unary atom. -/
 @[simp] theorem realize_matom (R : L.Relations 1) (e : E) :
-    Realize interp (.matom R e) le i w ↔
-      @Structure.RelMap L E (interp i w) 1 R ![e] := by
-  letI := interp i w
+    Realize interp (.matom R e) le i w ↔ (interp i w).RelMap R ![e] := by
+  let _S : L.Structure E := interp i w
   show @Formula.Realize L E (interp i w) E (R.formula ![Term.var e]) id ↔ _
   have hv : (fun j => ((![Term.var e] : Fin 1 → L.Term E) j).realize (M := E) id)
-      = ![e] := by
-    funext j
-    have hj : j = 0 := Subsingleton.elim _ _
-    subst hj
-    simp
+      = ![e] := funext fun j => by rw [Subsingleton.elim j 0]; simp
   rw [Formula.realize_rel, hv]
 
 /-- Comparative-free formulas are ordering-invariant. -/
-theorem realize_congr_of_compFree :
-    ∀ (φ : CompFormula L E), φ.CompFree →
-      ∀ (le le' : I → I → Prop) (i : I) (w : W),
-      (Realize interp φ le i w ↔ Realize interp φ le' i w)
-  | .ofFormula _, _, _, _, _, _ => Iff.rfl
-  | .not A, h, le, le', i, w =>
-      not_congr (realize_congr_of_compFree A h le le' i w)
-  | .inf A B, h, le, le', i, w =>
-      and_congr (realize_congr_of_compFree A h.1 le le' i w)
-        (realize_congr_of_compFree B h.2 le le' i w)
-  | .sup A B, h, le, le', i, w =>
-      or_congr (realize_congr_of_compFree A h.1 le le' i w)
-        (realize_congr_of_compFree B h.2 le le' i w)
-  | .comp _ _, h, _, _, _, _ => h.elim
+theorem CompFree.realize_congr :
+    ∀ {φ : CompFormula L E}, φ.CompFree →
+      ∀ {le le' : I → I → Prop} {i : I} {w : W},
+      Realize interp φ le i w ↔ Realize interp φ le' i w
+  | .ofFormula _, _ => Iff.rfl
+  | .not A, h => not_congr (CompFree.realize_congr (show A.CompFree from h))
+  | .inf _ _, h => and_congr (CompFree.realize_congr h.1) (CompFree.realize_congr h.2)
+  | .sup _ _, h => or_congr (CompFree.realize_congr h.1) (CompFree.realize_congr h.2)
+  | .comp _ _, h => h.elim
 
 /-- ≻ is the *strict l-lifting* of the ordering ([holliday-icard-2013];
 Lewis's lifting) applied to the cone at the evaluation index: comparative
@@ -182,16 +175,15 @@ theorem realize_comp_iff_strict_dominationLift :
       {x | ord.le x i ∧ Realize interp B ord.le x w ∧
         ¬ Realize interp A ord.le x w} :=
   coneStrictLift_iff_strict_dominationLift
-    (fun a b => ord.le_total b a) (fun _ _ => Iff.rfl) _ _ i
+    (fun a b => ord.le_total b a) (fun _ _ => Iff.rfl) _ _ _
 
 /-- ≻ is irreflexive — a witness would make A both true and false. -/
-theorem not_realize_comp_self : ¬ Realize interp (.comp A A) le i w := by
-  rintro ⟨_, _, hA, hnA, _⟩
-  exact hnA hA
+theorem not_realize_comp_self : ¬ Realize interp (.comp A A) le i w :=
+  fun ⟨_, _, hA, hnA, _⟩ => hnA hA
 
 /-- ≈ is reflexive. -/
 theorem realize_equi_self : Realize interp (A.equi A) le i w :=
-  ⟨not_realize_comp_self interp A le i w, not_realize_comp_self interp A le i w⟩
+  ⟨not_realize_comp_self, not_realize_comp_self⟩
 
 /-- ≈ is symmetric. -/
 theorem realize_equi_comm :

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -24,19 +24,19 @@ also the lift of Kratzer's ordering semantics.
 
 namespace FirstOrder.Language
 
+variable {L : Language} {I W E : Type*}
+
 /-- The extension of a unary relation symbol in a structure carried as a
 term. -/
-def Structure.ext₁ {L : Language} {E : Type*} (S : L.Structure E)
-    (R : L.Relations 1) : Set E :=
+def Structure.ext₁ (S : L.Structure E) (R : L.Relations 1) : Set E :=
   {e | S.RelMap R ![e]}
 
-@[simp] theorem Structure.mem_ext₁ {L : Language} {E : Type*}
-    {S : L.Structure E} {R : L.Relations 1} {e : E} :
-    e ∈ S.ext₁ R ↔ S.RelMap R ![e] :=
+@[simp] theorem Structure.mem_ext₁ {S : L.Structure E} {R : L.Relations 1}
+    {e : E} : e ∈ S.ext₁ R ↔ S.RelMap R ![e] :=
   Iff.rfl
 
-instance {L : Language} {E : Type*} (S : L.Structure E) (R : L.Relations 1)
-    (e : E) [h : Decidable (S.RelMap R ![e])] : Decidable (e ∈ S.ext₁ R) :=
+instance (S : L.Structure E) (R : L.Relations 1) (e : E)
+    [h : Decidable (S.RelMap R ![e])] : Decidable (e ∈ S.ext₁ R) :=
   h
 
 /-- Comparative-possibility formulas: an embedded classical formula (free
@@ -51,8 +51,6 @@ inductive CompFormula (L : Language) (E : Type*) where
   | comp : CompFormula L E → CompFormula L E → CompFormula L E
 
 namespace CompFormula
-
-variable {L : Language} {E : Type*}
 
 /-- Ground unary predication `R(e)`, as an embedded formula. -/
 abbrev matom (R : L.Relations 1) (e : E) : CompFormula L E :=
@@ -76,8 +74,7 @@ end CompFormula
 /-- Pointwise decidability of atoms across a doubly-indexed structure family —
 the hook that makes `decide` available on finite models; the semantics itself
 is decidability-free. -/
-abbrev DecidableAtoms {L : Language} {I W E : Type*}
-    (interp : I → W → L.Structure E) :=
+abbrev DecidableAtoms (interp : I → W → L.Structure E) :=
   ∀ (i : I) (w : W) (n : ℕ) (r : L.Relations n) (x : Fin n → E),
     Decidable ((interp i w).RelMap r x)
 
@@ -86,7 +83,7 @@ namespace CompFormula
 open Core.Order (TotalPreorder)
 open ComparativeProbability
 
-variable {L : Language} {I W E : Type*} (interp : I → W → L.Structure E)
+variable (interp : I → W → L.Structure E)
 
 /-- Truth at an index of an ordered structure family, relative to a raw
 ordering relation `le` (restricted orderings need not be total). The

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -81,13 +81,7 @@ def ComparativeFree : ComparativeFormula L E → Prop
 
 variable (interp : I → W → L.Structure E)
 
-/-- The strict (asymmetric) part of a raw ordering relation. -/
-def strictPart (le : I → I → Prop) (b a : I) : Prop :=
-  le b a ∧ ¬ le a b
-
-instance {le : I → I → Prop} [DecidableRel le] :
-    DecidableRel (strictPart le) :=
-  fun _ _ => inferInstanceAs (Decidable (_ ∧ _))
+/-! ### Realization -/
 
 /-- Truth at an index of an ordered structure family, relative to a raw
 ordering relation `le` (restricted orderings need not be total). The
@@ -99,7 +93,7 @@ def Realize : ComparativeFormula L E → (I → I → Prop) → I → W → Prop
   | .inf A B, le, i, w => Realize A le i w ∧ Realize B le i w
   | .sup A B, le, i, w => Realize A le i w ∨ Realize B le i w
   | .comp A B, le, i, w =>
-      coneStrictLift le (strictPart le) (Realize A le · w) (Realize B le · w) i
+      coneStrictLift le (Strict le) (Realize A le · w) (Realize B le · w) i
 
 instance instDec [Fintype I] [Fintype E] [DecidableEq E]
     [hA : DecidableAtoms interp] (le : I → I → Prop) [DecidableRel le] :
@@ -112,7 +106,7 @@ instance instDec [Fintype I] [Fintype E] [DecidableEq E]
   | .comp A B, i, w =>
       haveI : DecidablePred (Realize interp A le · w) := fun j => instDec le A j w
       haveI : DecidablePred (Realize interp B le · w) := fun j => instDec le B j w
-      inferInstanceAs (Decidable (coneStrictLift le (strictPart le)
+      inferInstanceAs (Decidable (coneStrictLift le (Strict le)
         (Realize interp A le · w) (Realize interp B le · w) i))
 
 variable {interp} {A B : ComparativeFormula L E} {le : I → I → Prop}
@@ -148,20 +142,23 @@ theorem ComparativeFree.realize_congr :
   | .sup _ _, h => or_congr (ComparativeFree.realize_congr h.1) (ComparativeFree.realize_congr h.2)
   | .comp _ _, h => h.elim
 
+/-! ### The domination-lift identification -/
+
 /-- ≻ is the *strict l-lifting* of the ordering ([holliday-icard-2013];
 Lewis's lifting) applied to the cone at the evaluation index: comparative
 possibility, with the ∃∀ clause as the strict Smyth order via
 `strict_dominationLift_iff`. -/
 theorem realize_comp_iff_strict_dominationLift :
     Realize interp (.comp A B) ord.le i w ↔
-    Strict
-      (dominationLift (fun a b => ord.le b a))
+    Strict (dominationLift (flip ord.le))
       {x | ord.le x i ∧ Realize interp A ord.le x w ∧
         ¬ Realize interp B ord.le x w}
       {x | ord.le x i ∧ Realize interp B ord.le x w ∧
         ¬ Realize interp A ord.le x w} :=
   coneStrictLift_iff_strict_dominationLift
     (fun a b => ord.le_total b a) (fun _ _ => Iff.rfl) _ _ _
+
+/-! ### Basic properties of ≻ and ≈ -/
 
 /-- ≻ is irreflexive — a witness would make A both true and false. -/
 theorem not_realize_comp_self : ¬ Realize interp (.comp A A) le i w :=

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -5,7 +5,7 @@ import Linglib.Core.Order.ComparativeProbability.Systems
 /-!
 # Comparative possibility over a first-order base
 
-This file defines `CompFormula`, Lewis's comparative-possibility language
+This file defines `ComparativeFormula`, Lewis's comparative-possibility language
 over an embedded classical first-order layer, and its truth relation
 `Realize` at an index of an ordered family of structures: `A ≻ B` holds
 when some (A ∧ ¬B)-index in the cone strictly dominates every
@@ -50,29 +50,29 @@ abbrev DecidableAtoms (interp : I → W → L.Structure E) :=
 variables valued by domain elements), booleans, and the comparative ≻
 (`.comp`). Booleans exist at both layers because negation and the derived
 `equi` must scope over ≻. -/
-inductive CompFormula (L : Language) (E : Type*) where
-  | ofFormula : L.Formula E → CompFormula L E
-  | not : CompFormula L E → CompFormula L E
-  | inf : CompFormula L E → CompFormula L E → CompFormula L E
-  | sup : CompFormula L E → CompFormula L E → CompFormula L E
-  | comp : CompFormula L E → CompFormula L E → CompFormula L E
+inductive ComparativeFormula (L : Language) (E : Type*) where
+  | ofFormula : L.Formula E → ComparativeFormula L E
+  | not : ComparativeFormula L E → ComparativeFormula L E
+  | inf : ComparativeFormula L E → ComparativeFormula L E → ComparativeFormula L E
+  | sup : ComparativeFormula L E → ComparativeFormula L E → ComparativeFormula L E
+  | comp : ComparativeFormula L E → ComparativeFormula L E → ComparativeFormula L E
 
-namespace CompFormula
+namespace ComparativeFormula
 
 open Core.Order (TotalPreorder)
 open ComparativeProbability
 
 /-- Ground unary predication `R(e)`, as an embedded formula. -/
-abbrev matom (R : L.Relations 1) (e : E) : CompFormula L E :=
+abbrev matom (R : L.Relations 1) (e : E) : ComparativeFormula L E :=
   .ofFormula (R.formula ![Term.var e])
 
 /-- Equipossibility: `A ≈ B := ¬(A ≻ B) ∧ ¬(B ≻ A)`. -/
-def equi (A B : CompFormula L E) : CompFormula L E :=
+def equi (A B : ComparativeFormula L E) : ComparativeFormula L E :=
   .inf (.not (.comp A B)) (.not (.comp B A))
 
 /-- Formulas free of the comparative: the fragment whose truth does not
 consult the ordering (`CompFree.realize_congr`). -/
-def CompFree : CompFormula L E → Prop
+def CompFree : ComparativeFormula L E → Prop
   | .ofFormula _ => True
   | .not A => A.CompFree
   | .inf A B => A.CompFree ∧ B.CompFree
@@ -81,48 +81,41 @@ def CompFree : CompFormula L E → Prop
 
 variable (interp : I → W → L.Structure E)
 
+/-- The strict (asymmetric) part of a raw ordering relation. -/
+private def strictPart (le : I → I → Prop) (b a : I) : Prop :=
+  le b a ∧ ¬ le a b
+
+private instance {le : I → I → Prop} [DecidableRel le] :
+    DecidableRel (strictPart le) :=
+  fun _ _ => inferInstanceAs (Decidable (_ ∧ _))
+
 /-- Truth at an index of an ordered structure family, relative to a raw
 ordering relation `le` (restricted orderings need not be total). The
 comparative: some (A∧¬B)-index in the ≤-cone strictly dominates every
 (B∧¬A)-index. -/
-def Realize (φ : CompFormula L E) (le : I → I → Prop) (i : I) (w : W) : Prop :=
-  match φ with
-  | .ofFormula ψ => letI := interp i w; ψ.Realize id
-  | .not A => ¬ Realize A le i w
-  | .inf A B => Realize A le i w ∧ Realize B le i w
-  | .sup A B => Realize A le i w ∨ Realize B le i w
-  | .comp A B =>
-      coneStrictLift le (fun b a => le b a ∧ ¬ le a b)
-        (fun j => Realize A le j w) (fun j => Realize B le j w) i
+def Realize : ComparativeFormula L E → (I → I → Prop) → I → W → Prop
+  | .ofFormula ψ, _, i, w => letI := interp i w; ψ.Realize id
+  | .not A, le, i, w => ¬ Realize A le i w
+  | .inf A B, le, i, w => Realize A le i w ∧ Realize B le i w
+  | .sup A B, le, i, w => Realize A le i w ∨ Realize B le i w
+  | .comp A B, le, i, w =>
+      coneStrictLift le (strictPart le) (Realize A le · w) (Realize B le · w) i
 
 instance instDec [Fintype I] [Fintype E] [DecidableEq E]
-    [hA : DecidableAtoms interp]
-    (φ : CompFormula L E) (le : I → I → Prop) [DecidableRel le] (i : I) (w : W) :
-    Decidable (Realize interp φ le i w) :=
-  match φ with
-  | .ofFormula ψ =>
+    [hA : DecidableAtoms interp] (le : I → I → Prop) [DecidableRel le] :
+    ∀ (φ : ComparativeFormula L E) (i : I) (w : W), Decidable (Realize interp φ le i w)
+  | .ofFormula ψ, i, w =>
       @Formula.decRealize L E (interp i w) _ _ (fun n r x => hA i w n r x) E ψ id
-  | .not A =>
-      haveI := instDec A le i w
-      inferInstanceAs (Decidable (¬ Realize interp A le i w))
-  | .inf A B =>
-      haveI := instDec A le i w
-      haveI := instDec B le i w
-      inferInstanceAs (Decidable (Realize interp A le i w ∧ Realize interp B le i w))
-  | .sup A B =>
-      haveI := instDec A le i w
-      haveI := instDec B le i w
-      inferInstanceAs (Decidable (Realize interp A le i w ∨ Realize interp B le i w))
-  | .comp A B =>
-      haveI : DecidablePred (fun j => Realize interp A le j w) :=
-        fun j => instDec A le j w
-      haveI : DecidablePred (fun j => Realize interp B le j w) :=
-        fun j => instDec B le j w
-      inferInstanceAs (Decidable (coneStrictLift
-        le (fun b a => le b a ∧ ¬ le a b)
-        (fun j => Realize interp A le j w) (fun j => Realize interp B le j w) i))
+  | .not A, i, w => @instDecidableNot _ (instDec le A i w)
+  | .inf A B, i, w => @instDecidableAnd _ _ (instDec le A i w) (instDec le B i w)
+  | .sup A B, i, w => @instDecidableOr _ _ (instDec le A i w) (instDec le B i w)
+  | .comp A B, i, w =>
+      haveI : DecidablePred (Realize interp A le · w) := fun j => instDec le A j w
+      haveI : DecidablePred (Realize interp B le · w) := fun j => instDec le B j w
+      inferInstanceAs (Decidable (coneStrictLift le (strictPart le)
+        (Realize interp A le · w) (Realize interp B le · w) i))
 
-variable {interp} {A B : CompFormula L E} {le : I → I → Prop}
+variable {interp} {A B : ComparativeFormula L E} {le : I → I → Prop}
   {ord : TotalPreorder I} {i : I} {w : W}
 
 /-- The comparative clause over a total preorder — definitional; the rewriting
@@ -146,7 +139,7 @@ theorem realize_comp_iff :
 
 /-- Comparative-free formulas are ordering-invariant. -/
 theorem CompFree.realize_congr :
-    ∀ {φ : CompFormula L E}, φ.CompFree →
+    ∀ {φ : ComparativeFormula L E}, φ.CompFree →
       ∀ {le le' : I → I → Prop} {i : I} {w : W},
       Realize interp φ le i w ↔ Realize interp φ le' i w
   | .ofFormula _, _ => Iff.rfl
@@ -183,6 +176,6 @@ theorem realize_equi_comm :
     Realize interp (A.equi B) le i w ↔ Realize interp (B.equi A) le i w :=
   and_comm
 
-end CompFormula
+end ComparativeFormula
 
 end FirstOrder.Language

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -418,9 +418,9 @@ theorem evalMCond_iff_entails (hB : B.CompFree) :
       {x | CompFormula.Realize interp B ord.le x w} := by
   constructor
   · rintro h x ⟨hx1, hx2⟩
-    exact (CompFormula.realize_congr_of_compFree interp B hB _ _ x w).mp (h x hx1 hx2)
+    exact hB.realize_congr.mp (h x hx1 hx2)
   · intro h x hx hAx
-    exact (CompFormula.realize_congr_of_compFree interp B hB _ _ x w).mpr (h ⟨hx, hAx⟩)
+    exact hB.realize_congr.mpr (h ⟨hx, hAx⟩)
 
 end MCond
 

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -411,7 +411,7 @@ MC-free — the metalinguistic conditional is Stalnakerian entailment
 (`ContextSet.entails`) of the consequent by the ranked antecedent-cone. The
 antecedent may contain ≻ freely: it is always evaluated at the full ordering,
 and an MC-free consequent never consults the restricted one. -/
-theorem evalMCond_iff_entails (hB : B.CompFree) :
+theorem evalMCond_iff_entails (hB : B.ComparativeFree) :
     EvalMCond interp A B ord i w ↔
     CommonGround.ContextSet.entails
       {x | ord.le x i ∧ ComparativeFormula.Realize interp A ord.le x w}

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -23,15 +23,15 @@ The formalization is model-theoretic throughout: an interpretation — the
 paper's "function from expressions to intensions" — is a world-indexed family
 of first-order structures, and the language with its basic semantics IS the
 substrate's comparative-possibility logic
-(`Logic/Modal/FirstOrder/Comparative`): `L.CompFormula E` evaluated by
-`CompFormula.Realize`, with ≻ the strict l-lifting. This file adds only what
+(`Logic/Modal/FirstOrder/Comparative`): `L.ComparativeFormula E` evaluated by
+`ComparativeFormula.Realize`, with ≻ the strict l-lifting. This file adds only what
 is RK-specific: acceptance and the common ground, degree modifiers and the
 conditional, the revised semantics, the delineation bridge, and the degree
 theory.
 
 ## Main definitions
 
-* `SemanticOrdering`, `Eval`, `EvalRevised` — the substrate's `CompFormula`
+* `SemanticOrdering`, `Eval`, `EvalRevised` — the substrate's `ComparativeFormula`
   language with the paper's basic (§4.2) and revised (supplement §B)
   semantics.
 * `AssertoricContent`, `MetalinguisticCG` — acceptance and the common ground:
@@ -84,23 +84,23 @@ variable {L : Language} {I W E : Type*} (interp : I → W → L.Structure E)
 
 section Semantics
 
-/-- Truth at an index ⟨≤, i, w⟩: `CompFormula.Realize` at the ordering's
+/-- Truth at an index ⟨≤, i, w⟩: `ComparativeFormula.Realize` at the ordering's
 `le`. -/
-abbrev Eval (φ : L.CompFormula E) (ord : SemanticOrdering I) (i : I) (w : W) :
+abbrev Eval (φ : L.ComparativeFormula E) (ord : SemanticOrdering I) (i : I) (w : W) :
     Prop :=
-  CompFormula.Realize interp φ ord.le i w
+  ComparativeFormula.Realize interp φ ord.le i w
 
 /-! ### Assertoric Content -/
 
 /-- Assertoric content (§3.3): truth at all ≤-maximal interpretations —
 `TotalPreorder.AcceptedAt`. Acceptance-preservation is nonclassical
 (`mc_disj_not_accepted`). -/
-def AssertoricContent [Fintype I] (φ : L.CompFormula E)
+def AssertoricContent [Fintype I] (φ : L.ComparativeFormula E)
     (ord : SemanticOrdering I) (w : W) : Prop :=
   ord.AcceptedAt (fun i => Eval interp φ ord i w)
 
 instance [Fintype I] [Fintype E] [DecidableEq E] [DecidableAtoms interp]
-    (φ : L.CompFormula E) (ord : SemanticOrdering I) [DecidableRel ord.le] (w : W) :
+    (φ : L.ComparativeFormula E) (ord : SemanticOrdering I) [DecidableRel ord.le] (w : W) :
     Decidable (AssertoricContent interp φ ord w) := by
   unfold AssertoricContent; infer_instance
 
@@ -147,7 +147,7 @@ theorem not_farBelow_total {I : Type*} {ord : SemanticOrdering I}
 
 section Modifiers
 
-variable [Fintype I] (φ ψ : L.CompFormula E) (ord : SemanticOrdering I)
+variable [Fintype I] (φ ψ : L.ComparativeFormula E) (ord : SemanticOrdering I)
   (below : I → I → Prop) (d : DistanceFunction I ord) (i : I) (w : W)
 
 /-- The paper's comparative template — the substrate's `coneStrictLift` at the
@@ -198,7 +198,7 @@ end Modifiers
 
 section ModifierGroundings
 
-variable (φ ψ : L.CompFormula E) (ord : SemanticOrdering I)
+variable (φ ψ : L.ComparativeFormula E) (ord : SemanticOrdering I)
   (d : DistanceFunction I ord) (i : I) (w : W)
 
 /-- **Grounding**: ≫ is the strict l-lifting under the *coarser* total
@@ -285,8 +285,8 @@ theorem eval_mc_iff_delineation_of_noReversal (i : I) (a b : E)
     Eval interp (.comp (.matom R a) (.matom R b)) ord i w ↔
     Degree.Delineation.comparativeSem
       (interpretationDelineation interp ord R w i) a b := by
-  rw [Eval, CompFormula.realize_comp_iff, delineation_comparativeSem_iff]
-  simp only [CompFormula.realize_matom, ← Structure.mem_ext₁]
+  rw [Eval, ComparativeFormula.realize_comp_iff, delineation_comparativeSem_iff]
+  simp only [ComparativeFormula.realize_matom, ← Structure.mem_ext₁]
   constructor
   · rintro ⟨i', h_le, h_A, h_B, -⟩
     exact ⟨i', h_le, h_A, h_B⟩
@@ -312,7 +312,7 @@ basic semantics fails ME transitivity; the revision strengthens the MC: the
 Properties ([kocurek-2024-supplement] §B): all basic entailment patterns
 (Fact 3 a–n) are preserved (Fact 5); ME transitivity is validated (Fact 6);
 interdefinable with the basic semantics (Fact 7). -/
-def EvalRevised (φ : L.CompFormula E) (ord : SemanticOrdering I) (i : I) (w : W) : Prop :=
+def EvalRevised (φ : L.ComparativeFormula E) (ord : SemanticOrdering I) (i : I) (w : W) : Prop :=
   match φ with
   | .ofFormula ψ => @Formula.Realize _ _ (interp i w) _ ψ id
   | .not A => ¬ EvalRevised A ord i w
@@ -326,7 +326,7 @@ def EvalRevised (φ : L.CompFormula E) (ord : SemanticOrdering I) (i : I) (w : W
 
 instance EvalRevised.instDec [Fintype I] [Fintype E] [DecidableEq E]
     [hA : DecidableAtoms interp]
-    (φ : L.CompFormula E) (ord : SemanticOrdering I) [DecidableRel ord.le]
+    (φ : L.ComparativeFormula E) (ord : SemanticOrdering I) [DecidableRel ord.le]
     (i : I) (w : W) :
     Decidable (EvalRevised interp φ ord i w) :=
   match φ with
@@ -355,7 +355,7 @@ instance EvalRevised.instDec [Fintype I] [Fintype E] [DecidableEq E]
         ((∀ i'', ord.le i'' i → EvalRevised interp B ord i'' w → ord.lt i'' i') ∨
          (∀ i'', ord.le i'' i → ¬ EvalRevised interp A ord i'' w → ord.lt i'' i'))))
 
-variable (A B : L.CompFormula E) (ord : SemanticOrdering I) (i : I) (w : W)
+variable (A B : L.ComparativeFormula E) (ord : SemanticOrdering I) (i : I) (w : W)
 
 /-- Characterization of the revised MC case — definitional. -/
 theorem evalRevised_mc_iff :
@@ -372,14 +372,14 @@ end Revised
 
 section MCond
 
-variable [Fintype I] (A B : L.CompFormula E)
+variable [Fintype I] (A B : L.ComparativeFormula E)
 
 /-- Restrict an ordering relation to A-interpretations (§6.3): drops non-A
 interpretations, so the result satisfies reflexivity (at A-interpretations)
 and transitivity but not totality — hence the consequent of a conditional is
 evaluated via `EvalGen` rather than `Eval`. -/
 def restrictLE (le : I → I → Prop) (w : W) : I → I → Prop :=
-  fun i j => le i j ∧ CompFormula.Realize interp A le i w ∧ CompFormula.Realize interp A le j w
+  fun i j => le i j ∧ ComparativeFormula.Realize interp A le i w ∧ ComparativeFormula.Realize interp A le j w
 
 instance [Fintype E] [DecidableEq E] [DecidableAtoms interp]
     (le : I → I → Prop) [DecidableRel le] (w : W) :
@@ -396,8 +396,8 @@ interpretation-strict implication.
 Key properties: C1 (conditionals entail weak comparatives), M1
 (⊨ A → (A ≻ ¬A), see `mcond_m1`), failure of modus tollens for acceptance. -/
 def EvalMCond : Prop :=
-  ∀ i', ord.le i' i → CompFormula.Realize interp A ord.le i' w →
-    CompFormula.Realize interp B (restrictLE interp A ord.le w) i' w
+  ∀ i', ord.le i' i → ComparativeFormula.Realize interp A ord.le i' w →
+    ComparativeFormula.Realize interp B (restrictLE interp A ord.le w) i' w
 
 instance [Fintype E] [DecidableEq E] [DecidableAtoms interp]
     [DecidableRel ord.le] :
@@ -414,8 +414,8 @@ and an MC-free consequent never consults the restricted one. -/
 theorem evalMCond_iff_entails (hB : B.CompFree) :
     EvalMCond interp A B ord i w ↔
     CommonGround.ContextSet.entails
-      {x | ord.le x i ∧ CompFormula.Realize interp A ord.le x w}
-      {x | CompFormula.Realize interp B ord.le x w} := by
+      {x | ord.le x i ∧ ComparativeFormula.Realize interp A ord.le x w}
+      {x | ComparativeFormula.Realize interp B ord.le x w} := by
   constructor
   · rintro h x ⟨hx1, hx2⟩
     exact hB.realize_congr.mp (h x hx1 hx2)
@@ -456,12 +456,12 @@ variable {L : Language} {E : Type*} [Fintype I] [Fintype E] [DecidableEq E]
 
 /-- The proposition a formula expresses over the enriched index: the
 ordering-world pairs at which its assertoric content holds. -/
-def assertoricProp (φ : L.CompFormula E) : Set (OrderingWorldPair I W) :=
+def assertoricProp (φ : L.ComparativeFormula E) : Set (OrderingWorldPair I W) :=
   {pair | AssertoricContent interp φ pair.ord pair.world}
 
 /-- Assertion is the substrate's `ContextSet.update` with the assertoric
 proposition — not a new operation. -/
-def updateAssertoric (cg : MetalinguisticCG I W) (φ : L.CompFormula E) :
+def updateAssertoric (cg : MetalinguisticCG I W) (φ : L.ComparativeFormula E) :
     MetalinguisticCG I W :=
   ContextSet.update cg (assertoricProp interp φ)
 
@@ -469,13 +469,13 @@ omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
 /-- Stalnaker's law at the enriched type: assertion restricts the common
 ground (inherited from `ContextSet.update_restricts`). -/
 theorem updateAssertoric_restricts (cg : MetalinguisticCG I W)
-    (φ : L.CompFormula E) : updateAssertoric interp cg φ ⊆ cg :=
+    (φ : L.ComparativeFormula E) : updateAssertoric interp cg φ ⊆ cg :=
   ContextSet.update_restricts _ _
 
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
 /-- Assertion order is irrelevant (inherited from `ContextSet.update_comm`). -/
 theorem updateAssertoric_comm (cg : MetalinguisticCG I W)
-    (φ ψ : L.CompFormula E) :
+    (φ ψ : L.ComparativeFormula E) :
     updateAssertoric interp (updateAssertoric interp cg φ) ψ =
       updateAssertoric interp (updateAssertoric interp cg ψ) φ :=
   ContextSet.update_comm _ _ _
@@ -483,7 +483,7 @@ theorem updateAssertoric_comm (cg : MetalinguisticCG I W)
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
 /-- Reassertion is idempotent (inherited from `ContextSet.update_idem`). -/
 theorem updateAssertoric_idem (cg : MetalinguisticCG I W)
-    (φ : L.CompFormula E) :
+    (φ : L.ComparativeFormula E) :
     updateAssertoric interp (updateAssertoric interp cg φ) φ =
       updateAssertoric interp cg φ :=
   ContextSet.update_idem _ _
@@ -494,7 +494,7 @@ context set too: the enriched update is Stalnaker-conservative. (That the
 update does NOT factor through the projection — interpretive commitments do
 real work — is the paper's expressivist thesis.) -/
 theorem toContextSet_updateAssertoric_subset (cg : MetalinguisticCG I W)
-    (φ : L.CompFormula E) :
+    (φ : L.ComparativeFormula E) :
     toContextSet (updateAssertoric interp cg φ) ⊆ toContextSet cg :=
   Set.image_mono (updateAssertoric_restricts interp cg φ)
 
@@ -520,12 +520,12 @@ def field : Finset I :=
 open Classical in
 /-- The denotation of a formula: the set of interpretations in I_i
 where the formula is true (under the revised semantics). -/
-def denotation (φ : L.CompFormula E) (w : W) : Finset I :=
+def denotation (φ : L.ComparativeFormula E) (w : W) : Finset I :=
   (field ord i).filter (fun j => EvalRevised interp φ ord j w)
 
 omit [DecidableEq I] in
 open Classical in
-theorem denotation_subset_field (φ : L.CompFormula E) (w : W) :
+theorem denotation_subset_field (φ : L.ComparativeFormula E) (w : W) :
     denotation interp ord i φ w ⊆ field ord i :=
   Finset.filter_subset _ _
 
@@ -1599,7 +1599,7 @@ private theorem mem_field_iff {I : Type*} [Fintype I] [DecidableEq I]
 private theorem mem_denotation_iff {L : Language} {I W E : Type*}
     [Fintype I] [DecidableEq I]
     {interp : I → W → L.Structure E}
-    {φ : L.CompFormula E}
+    {φ : L.ComparativeFormula E}
     {ord : SemanticOrdering I} {i j : I} {w : W} :
     j ∈ denotation interp ord i φ w ↔
     ord.le j i ∧ EvalRevised interp φ ord j w := by
@@ -1611,10 +1611,10 @@ variable {L : Language} {I W E : Type*} [Fintype I] [DecidableEq I]
   (interp : I → W → L.Structure E) (ord : SemanticOrdering I) (i : I)
 
 /-- The metalinguistic degree of a formula's denotation. -/
-def formulaDeg (φ : L.CompFormula E) (w : W) : MetaDegree I ord i :=
+def formulaDeg (φ : L.ComparativeFormula E) (w : W) : MetaDegree I ord i :=
   deg ord i (denotation interp ord i φ w) (denotation_subset_field interp ord i φ w)
 
-variable (A B : L.CompFormula E) (w : W)
+variable (A B : L.ComparativeFormula E) (w : W)
 
 /-- Fact 10: revised MC holds iff denotation of A ⊐ denotation of B. -/
 theorem mc_iff_degree_gt :
@@ -1811,7 +1811,7 @@ metalinguistic comparative IS the degree substrate's binary comparative
 function `formulaDeg`. Metagradability thereby instantiates the degree
 substrate's central object — a measure `μ : E → D` into a bounded linear
 scale — with `E` the formulas and `D` the `MetaDegree` scale. -/
-theorem mc_iff_comparativeSem (A B : L.CompFormula E) (w : W) :
+theorem mc_iff_comparativeSem (A B : L.ComparativeFormula E) (w : W) :
     EvalRevised interp (.comp A B) ord i w ↔
     Degree.comparativeSem (fun φ => formulaDeg interp ord i φ w) A B .positive := by
   rw [mc_iff_degree_gt]
@@ -1839,13 +1839,13 @@ inductive Entity | ann
 abbrev PredLang := Language.monadic Pred
 
 /-- "Ann is a linguist" -/
-abbrev La : PredLang.CompFormula Entity := .matom Pred.linguist .ann
+abbrev La : PredLang.ComparativeFormula Entity := .matom Pred.linguist .ann
 
 /-- "Ann is a philosopher" -/
-abbrev Pa : PredLang.CompFormula Entity := .matom Pred.philosopher .ann
+abbrev Pa : PredLang.ComparativeFormula Entity := .matom Pred.philosopher .ann
 
 /-- "Ann is more a linguist than a philosopher" -/
-abbrev La_mc_Pa : PredLang.CompFormula Entity := .comp La Pa
+abbrev La_mc_Pa : PredLang.ComparativeFormula Entity := .comp La Pa
 
 /-! ### Model 1: Three interpretations (linear order) -/
 
@@ -1939,7 +1939,7 @@ theorem obs5_me_neg_consistent :
     Eval interp₂ (La.equi (.not La)) tiedOrd .j0 .w0 := by decide
 
 /-- ¬La -/
-abbrev NLa : PredLang.CompFormula Entity := .not La
+abbrev NLa : PredLang.ComparativeFormula Entity := .not La
 
 /-! ### Assertoric Content and Acceptance-Preservation -/
 
@@ -2062,10 +2062,10 @@ linear order `ord₃` from Model 1. -/
 instance : DecidableAtoms interpNR := fun _ _ => monadicStructure.decRelMap _
 
 /-- "Ann is tall" -/
-abbrev Ta : (Language.monadic Pred1).CompFormula Entity2 := .matom Pred1.tall .ann
+abbrev Ta : (Language.monadic Pred1).ComparativeFormula Entity2 := .matom Pred1.tall .ann
 
 /-- "Ben is tall" -/
-abbrev Tb : (Language.monadic Pred1).CompFormula Entity2 := .matom Pred1.tall .ben
+abbrev Tb : (Language.monadic Pred1).ComparativeFormula Entity2 := .matom Pred1.tall .ben
 
 /-- No Reversal holds for `tall`: the extensions are monotonically nested,
 so Ben never outruns Ann. -/
@@ -2196,13 +2196,13 @@ instance : DecidableRel ord₄.le := fun _ _ =>
   inferInstanceAs (Decidable (_ = true))
 
 /-- "Ann is a linguist" (3-predicate model) -/
-abbrev La₄ : (Language.monadic Pred3).CompFormula Entity := .matom Pred3.linguist .ann
+abbrev La₄ : (Language.monadic Pred3).ComparativeFormula Entity := .matom Pred3.linguist .ann
 
 /-- "Ann is a philosopher" (3-predicate model) -/
-abbrev Pa₄ : (Language.monadic Pred3).CompFormula Entity := .matom Pred3.philosopher .ann
+abbrev Pa₄ : (Language.monadic Pred3).ComparativeFormula Entity := .matom Pred3.philosopher .ann
 
 /-- "Ann is a psychologist" -/
-abbrev Ca₄ : (Language.monadic Pred3).CompFormula Entity := .matom Pred3.psychologist .ann
+abbrev Ca₄ : (Language.monadic Pred3).ComparativeFormula Entity := .matom Pred3.psychologist .ann
 
 /-! #### Basic semantics: transitivity fails -/
 


### PR DESCRIPTION
Register pass on Comparative.lean: RelMap dot-notation replaces @-applications, goal-inferable theorem binders implicit, the ordering-invariance lemma dot-named CompFree.realize_congr, module docstring citations pulled into References.