### PR TITLE
refactor(Core/Order/ComparativeProbability): name the cone difference sets

### DIFF
--- a/Linglib/Core/Order/ComparativeProbability/Systems.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Systems.lean
@@ -387,6 +387,11 @@ instance (le below : W → W → Prop) (P Q : W → Prop) (i : W) [Fintype W]
     Decidable (coneStrictLift le below P Q i) := by
   unfold coneStrictLift; infer_instance
 
+/-- The cone difference set at `i`: `≤`-cone members where `P` holds and `Q`
+fails ([kratzer-2012]'s difference sets, localized to the cone). -/
+def coneDiff (le : W → W → Prop) (P Q : W → Prop) (i : W) : Set W :=
+  {x | le x i ∧ P x ∧ ¬ Q x}
+
 /-- Whenever `below` is the strict form of the total `ge_w`, the
 cone-localized clause is the strict l-lifting on the cone difference sets. -/
 theorem coneStrictLift_iff_strict_dominationLift {le below : W → W → Prop}
@@ -395,9 +400,9 @@ theorem coneStrictLift_iff_strict_dominationLift {le below : W → W → Prop}
     (P Q : W → Prop) (i : W) :
     coneStrictLift le below P Q i ↔
     ComparativeProbability.Strict (dominationLift ge_w)
-      {x | le x i ∧ P x ∧ ¬ Q x} {x | le x i ∧ Q x ∧ ¬ P x} := by
+      (coneDiff le P Q i) (coneDiff le Q P i) := by
   rw [strict_dominationLift_iff_below hTotal hBelow]
-  unfold coneStrictLift
+  unfold coneStrictLift coneDiff
   simp only [Set.mem_setOf_eq, and_imp, and_assoc]
 
 /-- The l-lifting satisfies determination by singletons. -/

--- a/Linglib/Logic/Modal/FirstOrder/Comparative.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Comparative.lean
@@ -151,10 +151,8 @@ possibility, with the ∃∀ clause as the strict Smyth order via
 theorem realize_comp_iff_strict_dominationLift :
     Realize interp (.comp A B) ord.le i w ↔
     Strict (dominationLift (flip ord.le))
-      {x | ord.le x i ∧ Realize interp A ord.le x w ∧
-        ¬ Realize interp B ord.le x w}
-      {x | ord.le x i ∧ Realize interp B ord.le x w ∧
-        ¬ Realize interp A ord.le x w} :=
+      (coneDiff ord.le (Realize interp A ord.le · w) (Realize interp B ord.le · w) i)
+      (coneDiff ord.le (Realize interp B ord.le · w) (Realize interp A ord.le · w) i) :=
   coneStrictLift_iff_strict_dominationLift
     (fun a b => ord.le_total b a) (fun _ _ => Iff.rfl) _ _ _
 


### PR DESCRIPTION
Names the cone-restricted difference sets (`coneDiff`) that `coneStrictLift_iff_strict_dominationLift` and the Comparative keystone both wrote inline, twice each with arguments swapped.