### PR TITLE
refactor(Core/ModelTheory): family satisfaction leaves the modal layer

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -157,6 +157,7 @@ import Linglib.Logic.CylindricAlgebra
 import Linglib.Logic.Duality
 import Linglib.Core.Relation.FactorsThroughOn
 import Linglib.Core.ModelTheory.Binders
+import Linglib.Core.ModelTheory.StructureFamily
 import Linglib.Core.ModelTheory.EhrenfeuchtFraisse
 import Linglib.Core.ModelTheory.EhrenfeuchtFraisseGame
 import Linglib.Core.ModelTheory.FiniteModel

--- a/Linglib/Core/ModelTheory/StructureFamily.lean
+++ b/Linglib/Core/ModelTheory/StructureFamily.lean
@@ -1,0 +1,60 @@
+import Linglib.Core.ModelTheory.Binders
+
+/-!
+# Satisfaction in an indexed family of structures
+
+Classical satisfaction at an index of a structure family
+`interp : W → L.Structure M` — mathlib's `Formula.Realize` with the
+instance selected per index — and the transport of the `Formula.realize_*`
+simp set. `[UPSTREAM]` candidate for `Mathlib/ModelTheory`, which carries
+one structure at a time.
+-/
+
+namespace FirstOrder.Language
+
+variable {L : Language} {W M α : Type*}
+
+/-- Satisfaction at an index of a structure family: mathlib's
+    `Formula.Realize` in the structure the family carries at `w`. -/
+def Formula.RealizeAt (ψ : L.Formula α) (interp : W → L.Structure M)
+    (w : W) (v : α → M) : Prop :=
+  letI := interp w; ψ.Realize v
+
+variable (interp : W → L.Structure M) (w : W) (v : α → M)
+
+@[simp] theorem Formula.realizeAt_not (ψ : L.Formula α) :
+    ψ.not.RealizeAt interp w v ↔ ¬ ψ.RealizeAt interp w v :=
+  letI := interp w
+  Formula.realize_not
+
+@[simp] theorem Formula.realizeAt_inf (ψ₁ ψ₂ : L.Formula α) :
+    (ψ₁ ⊓ ψ₂).RealizeAt interp w v ↔
+      ψ₁.RealizeAt interp w v ∧ ψ₂.RealizeAt interp w v :=
+  letI := interp w
+  Formula.realize_inf
+
+@[simp] theorem Formula.realizeAt_sup (ψ₁ ψ₂ : L.Formula α) :
+    (ψ₁ ⊔ ψ₂).RealizeAt interp w v ↔
+      ψ₁.RealizeAt interp w v ∨ ψ₂.RealizeAt interp w v :=
+  letI := interp w
+  Formula.realize_sup
+
+section Binders
+
+variable [DecidableEq α]
+
+@[simp] theorem Formula.realizeAt_all₁ (x : α) (ψ : L.Formula α) :
+    (Formula.all₁ x ψ).RealizeAt interp w v ↔
+      ∀ d : M, ψ.RealizeAt interp w (Function.update v x d) :=
+  letI := interp w
+  Formula.realize_all₁
+
+@[simp] theorem Formula.realizeAt_ex₁ (x : α) (ψ : L.Formula α) :
+    (Formula.ex₁ x ψ).RealizeAt interp w v ↔
+      ∃ d : M, ψ.RealizeAt interp w (Function.update v x d) :=
+  letI := interp w
+  Formula.realize_ex₁
+
+end Binders
+
+end FirstOrder.Language

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -206,7 +206,7 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
     (hψ : stAtom? k χ = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W}
     {v : Var → M} (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
-    K.RealizeAt w χ v ↔ (letI := K.corrStructure; ψ.Realize val) := by
+    χ.RealizeAt K.interp w v ↔ (letI := K.corrStructure; ψ.Realize val) := by
   let _S := K.corrStructure
   cases χ with
   | falsum => simp [stAtom?] at hψ
@@ -229,7 +229,7 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
       | var s =>
         cases s with
         | inl x =>
-          have hLHS : K.RealizeAt w (.rel (monadicRel P) ts) v ↔
+          have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
               K.pInterp P w (v x) := by
             let _S := K.interp w
             show (K.interp w).RelMap (monadicRel P)
@@ -262,7 +262,7 @@ private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const
         | zero =>
           obtain (e | c) := f
           · exact e.elim
-          have hLHS : K.RealizeAt w (.rel (monadicRel P) ts) v ↔
+          have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
               K.pInterp P w (K.cInterp c w) := by
             let _S := K.interp w
             show (K.interp w).RelMap (monadicRel P)

--- a/Linglib/Logic/Modal/FirstOrder/Kripke.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Kripke.lean
@@ -1,5 +1,5 @@
 import Mathlib.ModelTheory.Semantics
-import Linglib.Core.ModelTheory.Binders
+import Linglib.Core.ModelTheory.StructureFamily
 
 /-!
 # Constant-domain first-order Kripke structures and modal formulas
@@ -14,18 +14,14 @@ quantifiers over embedded classical `L.Formula`s, and
 ## Main declarations
 
 * `KripkeStructure` — accessibility plus a world-indexed family of
-  first-order structures on a constant domain.
-* `KripkeStructure.RealizeAt` — classical satisfaction at a world, with the
-  transported `Formula.realize_*` simp set.
+  first-order structures on a constant domain (classical satisfaction at an
+  index is `Core/ModelTheory/StructureFamily.lean`'s `Formula.RealizeAt`).
 * `ModalFormula`, `ModalFormula.Realize` — modal formulas over embedded
   classical formulas, and Kripke satisfaction; `ModalFormula.dia` is the
   derived `◇ := ¬□¬`.
 
 ## Implementation notes
 
-* Structures are carried as **terms**, not instances — a world-indexed
-  family cannot be instance-based — so interfacing with instance-based
-  mathlib API (`Formula.Realize`) threads `letI := K.interp w`.
 * Accessibility is `Finset`-valued (computability-first, matching the
   team-semantics consumers); generalize to a `Prop`-valued relation when a
   consumer needs infinite branching.
@@ -49,57 +45,6 @@ structure KripkeStructure (L : Language) (W M : Type*) where
   access : W → Finset W
   /-- World-indexed interpretation of the signature. -/
   interp : W → L.Structure M
-
-namespace KripkeStructure
-
-/-- Classical first-order satisfaction at a world — `K, w ⊨_v ψ`, mathlib's
-    `Formula.Realize` in the structure the Kripke structure carries
-    at `w`. -/
-def RealizeAt (K : KripkeStructure L W M) (w : W) (ψ : L.Formula α)
-    (v : α → M) : Prop :=
-  letI := K.interp w; ψ.Realize v
-
-@[simp] theorem realizeAt_not (K : KripkeStructure L W M) (w : W)
-    (ψ : L.Formula α) (v : α → M) :
-    K.RealizeAt w ψ.not v ↔ ¬ K.RealizeAt w ψ v :=
-  letI := K.interp w
-  Formula.realize_not
-
-@[simp] theorem realizeAt_inf (K : KripkeStructure L W M) (w : W)
-    (ψ₁ ψ₂ : L.Formula α) (v : α → M) :
-    K.RealizeAt w (ψ₁ ⊓ ψ₂) v ↔
-      K.RealizeAt w ψ₁ v ∧ K.RealizeAt w ψ₂ v :=
-  letI := K.interp w
-  Formula.realize_inf
-
-@[simp] theorem realizeAt_sup (K : KripkeStructure L W M) (w : W)
-    (ψ₁ ψ₂ : L.Formula α) (v : α → M) :
-    K.RealizeAt w (ψ₁ ⊔ ψ₂) v ↔
-      K.RealizeAt w ψ₁ v ∨ K.RealizeAt w ψ₂ v :=
-  letI := K.interp w
-  Formula.realize_sup
-
-section Binders
-
-variable [DecidableEq α]
-
-@[simp] theorem realizeAt_all₁ (K : KripkeStructure L W M) (w : W) (x : α)
-    (ψ : L.Formula α) (v : α → M) :
-    K.RealizeAt w (Formula.all₁ x ψ) v ↔
-      ∀ d : M, K.RealizeAt w ψ (Function.update v x d) :=
-  letI := K.interp w
-  Formula.realize_all₁
-
-@[simp] theorem realizeAt_ex₁ (K : KripkeStructure L W M) (w : W) (x : α)
-    (ψ : L.Formula α) (v : α → M) :
-    K.RealizeAt w (Formula.ex₁ x ψ) v ↔
-      ∃ d : M, K.RealizeAt w ψ (Function.update v x d) :=
-  letI := K.interp w
-  Formula.realize_ex₁
-
-end Binders
-
-end KripkeStructure
 
 /-- Modal formulas over `L` with named free variables `α`: classical
     `L.Formula`s embedded wholesale via `ofFormula`, closed under the
@@ -134,7 +79,7 @@ variable [DecidableEq α]
     quantifiers update the valuation. -/
 def Realize (K : KripkeStructure L W M) :
     W → ModalFormula L α → (α → M) → Prop
-  | w, .ofFormula ψ, v => K.RealizeAt w ψ v
+  | w, .ofFormula ψ, v => ψ.RealizeAt K.interp w v
   | w, .not φ, v => ¬ Realize K w φ v
   | w, .inf φ ψ, v => Realize K w φ v ∧ Realize K w ψ v
   | w, .sup φ ψ, v => Realize K w φ v ∨ Realize K w ψ v
@@ -146,7 +91,7 @@ variable (K : KripkeStructure L W M) (w : W) (v : α → M)
 
 /-- Embedded classical formulas realize classically — by construction. -/
 @[simp] theorem realize_ofFormula (ψ : L.Formula α) :
-    (ofFormula ψ : ModalFormula L α).Realize K w v ↔ K.RealizeAt w ψ v :=
+    (ofFormula ψ : ModalFormula L α).Realize K w v ↔ ψ.RealizeAt K.interp w v :=
   Iff.rfl
 
 @[simp] theorem realize_not (φ : ModalFormula L α) :

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -58,7 +58,7 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     (hv : ∀ y, i.assign y = some (v y)) (hsupp : support M φ {i}) :
     (letI := M.corrStructure
      (W ⊕ Domain) ⊨ (stClose 0 ψ).toSentence hcl) := by
-  letI := M.corrStructure
+  let _S := M.corrStructure
   have h1 : ψ.Realize
       (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world))) :=
     (support_singleton_iff_st M hτ hψ (fun _ => i.world) hv rfl).mp hsupp
@@ -85,7 +85,7 @@ theorem exists_support_of_models_toSentence [Nonempty Domain]
          (W ⊕ Domain) ⊨ (stClose 0 ψ).toSentence hcl) :
     ∃ (i : Index W Var Domain) (v : Var → Domain),
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
-  letI := M.corrStructure
+  let _S := M.corrStructure
   obtain ⟨d₀⟩ := ‹Nonempty Domain›
   have h0 : (stClose 0 ψ).Realize
       (fun _ => (Sum.inr d₀ : W ⊕ Domain)) :=
@@ -136,9 +136,9 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
   classical
   choose f hf using fun x : T₀ => hT₀ x.2
   obtain ⟨W, Domain, _, _, _, M, i, v, hv, hs⟩ := hfin (Finset.univ.image f)
-  letI := M.corrStructure
-  haveI : Nonempty (W ⊕ Domain) := ⟨Sum.inl i.world⟩
-  haveI : (W ⊕ Domain) ⊨ (T₀ : (Language.correspondence Const Pred).Theory) := by
+  let _S := M.corrStructure
+  have : Nonempty (W ⊕ Domain) := ⟨Sum.inl i.world⟩
+  have : (W ⊕ Domain) ⊨ (T₀ : (Language.correspondence Const Pred).Theory) := by
     refine ⟨fun σ hσ => ?_⟩
     obtain ⟨x, rfl⟩ : ∃ x : T₀,
         (stClose 0 (ψs (f x))).toSentence (hcl (f x)) = σ :=

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -627,9 +627,9 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
 @[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁
     (M : Model W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
-    M.RealizeAt w ((monadicRel P).formula₁ (Term.var x)) v ↔
+    ((monadicRel P).formula₁ (Term.var x)).RealizeAt M.interp w v ↔
       M.pInterp P w (v x) := by
-  letI := M.interp w
+  let _S := M.interp w
   show ((monadicRel P).formula₁ (Term.var x)).Realize v ↔ _
   have hfun : (![v x] : Fin 1 → Domain) = fun _ => v x := by
     funext j
@@ -641,10 +641,10 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
 @[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁_const
     (M : Model W Domain Const Pred) (P : Pred) (c : Const) (w : W)
     (v : Var → Domain) :
-    M.RealizeAt w
-      ((monadicRel P).formula₁ (Constants.term (monadicConst c))) v ↔
+    ((monadicRel P).formula₁
+      (Constants.term (monadicConst c))).RealizeAt M.interp w v ↔
       M.pInterp P w (M.cInterp c w) := by
-  letI := M.interp w
+  let _S := M.interp w
   show ((monadicRel P).formula₁ (Constants.term (monadicConst c))).Realize v
     ↔ _
   have hfun : (![(Constants.term (monadicConst (Pred := Pred) c)).realize v] :
@@ -739,8 +739,8 @@ private theorem support_and_antiSupport_singleton_realizeAt
       φ.toFormula? = some ψ →
       ∀ {i : Index W Var Domain} {v : Var → Domain},
         (∀ y, i.assign y = some (v y)) →
-        (support M φ {i} ↔ M.RealizeAt i.world ψ v) ∧
-        (antiSupport M φ {i} ↔ ¬ M.RealizeAt i.world ψ v) := by
+        (support M φ {i} ↔ ψ.RealizeAt M.interp i.world v) ∧
+        (antiSupport M φ {i} ↔ ¬ ψ.RealizeAt M.interp i.world v) := by
   intro φ
   induction φ with
   | pred P x =>
@@ -803,9 +803,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       obtain ⟨ihs, iha⟩ := ih hφ hv
       constructor
-      · rw [KripkeStructure.realizeAt_not]
+      · rw [Formula.realizeAt_not]
         exact iha
-      · rw [KripkeStructure.realizeAt_not, not_not]
+      · rw [Formula.realizeAt_not, not_not]
         exact ihs
   | conj φ₁ φ₂ ih₁ ih₂ =>
     intro ψ hψ i v hv
@@ -821,9 +821,9 @@ private theorem support_and_antiSupport_singleton_realizeAt
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
         obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
         constructor
-        · rw [KripkeStructure.realizeAt_inf]
+        · rw [Formula.realizeAt_inf]
           exact and_congr ih₁s ih₂s
-        · rw [KripkeStructure.realizeAt_inf, not_and_or]
+        · rw [Formula.realizeAt_inf, not_and_or]
           constructor
           · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
             have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
@@ -858,7 +858,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         obtain ⟨ih₁s, ih₁a⟩ := ih₁ hφ₁ hv
         obtain ⟨ih₂s, ih₂a⟩ := ih₂ hφ₂ hv
         constructor
-        · rw [KripkeStructure.realizeAt_sup]
+        · rw [Formula.realizeAt_sup]
           constructor
           · rintro ⟨t₁, t₂, hsplit, h₁, h₂⟩
             have hsub₁ : t₁ ⊆ ({i} : Finset (Index W Var Domain)) :=
@@ -879,7 +879,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
                 (support_and_antiSupport_empty_of_neFree
                   (neFree_of_toFormula? hφ₁) M).1,
                 ih₂s.mpr h⟩
-        · rw [KripkeStructure.realizeAt_sup, not_or]
+        · rw [Formula.realizeAt_sup, not_or]
           exact and_congr ih₁a ih₂a
   | exi x φ ih =>
     intro ψ hψ i v hv
@@ -891,7 +891,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       have hNE : φ.NEFree := neFree_of_toFormula? hφ
       constructor
-      · rw [KripkeStructure.realizeAt_ex₁]
+      · rw [Formula.realizeAt_ex₁]
         constructor
         · rintro ⟨h, hne, hsupp⟩
           have hsupp' := (support_iff_forall_singleton hNE M _).mp hsupp
@@ -909,7 +909,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
           subst hd'
           subst hupd
           exact ((ih hφ (update_refines hv x d')).1).mpr hd
-      · rw [KripkeStructure.realizeAt_ex₁, not_exists]
+      · rw [Formula.realizeAt_ex₁, not_exists]
         show antiSupport M φ (State.extendUniversal {i} x) ↔ _
         rw [antiSupport_iff_forall_singleton hNE]
         constructor
@@ -933,7 +933,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
       subst hψ
       have hNE : φ.NEFree := neFree_of_toFormula? hφ
       constructor
-      · rw [KripkeStructure.realizeAt_all₁]
+      · rw [Formula.realizeAt_all₁]
         show support M φ (State.extendUniversal {i} x) ↔ _
         rw [support_iff_forall_singleton hNE]
         constructor
@@ -947,7 +947,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
           subst hi'
           subst hupd
           exact ((ih hφ (update_refines hv x d)).1).mpr (h d)
-      · rw [KripkeStructure.realizeAt_all₁, not_forall]
+      · rw [Formula.realizeAt_all₁, not_forall]
         constructor
         · rintro ⟨h, hne, hanti⟩
           have hanti' := (antiSupport_iff_forall_singleton hNE M _).mp hanti
@@ -976,7 +976,7 @@ theorem support_singleton_iff_realizeAt (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred} {ψ : (Language.monadicWithConstants Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
-    support M φ {i} ↔ M.RealizeAt i.world ψ v :=
+    support M φ {i} ↔ ψ.RealizeAt M.interp i.world v :=
   (support_and_antiSupport_singleton_realizeAt M hψ hv).1
 
 /-- Anti-support of a translatable formula at a singleton state is the
@@ -985,7 +985,7 @@ theorem antiSupport_singleton_iff_realizeAt (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred} {ψ : (Language.monadicWithConstants Const Pred).Formula Var}
     (hψ : φ.toFormula? = some ψ) {i : Index W Var Domain}
     {v : Var → Domain} (hv : ∀ y, i.assign y = some (v y)) :
-    antiSupport M φ {i} ↔ ¬ M.RealizeAt i.world ψ v :=
+    antiSupport M φ {i} ↔ ¬ ψ.RealizeAt M.interp i.world v :=
   (support_and_antiSupport_singleton_realizeAt M hψ hv).2
 
 /-- **[aloni-vanormondt-2023] Proposition 4.1** (modal-free fragment): a
@@ -997,7 +997,7 @@ theorem support_iff_forall_realizeAt (M : Model W Domain Const Pred)
     (hψ : φ.toFormula? = some ψ) (s : Finset (Index W Var Domain))
     (v : Index W Var Domain → Var → Domain)
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
-    support M φ s ↔ ∀ i ∈ s, M.RealizeAt i.world ψ (v i) := by
+    support M φ s ↔ ∀ i ∈ s, ψ.RealizeAt M.interp i.world (v i) := by
   rw [support_iff_forall_singleton (neFree_of_toFormula? hψ)]
   exact forall₂_congr fun i hi =>
     support_singleton_iff_realizeAt M hψ (hv i hi)


### PR DESCRIPTION
Formula.RealizeAt — classical satisfaction at an index of a structure family, with the transported realize_* simp set — moves from Logic/Modal/FirstOrder/Kripke.lean to a new Core/ModelTheory/StructureFamily.lean, generalized over bare families (no accessibility): the modal file keeps only KripkeStructure and ModalFormula. Also clears the letI/haveI lints in the QBSML consumers.