### PR TITLE
feat(Logic/Modal/FirstOrder): Barcan laws for constant domains

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Kripke.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Kripke.lean
@@ -182,6 +182,21 @@ variable (K : KripkeStructure L W M) (w : W) (v : α → M)
     (dia φ).Realize K w v ↔ ∃ w' ∈ K.access w, φ.Realize K w' v := by
   simp only [dia, realize_not, realize_box, not_forall, not_not, exists_prop]
 
+/-! ### The Barcan laws
+
+Constant domains validate the Barcan formula and its converse: `□` and `∀`
+are both world-independent universal quantifiers, so they commute. -/
+
+/-- The Barcan formula `∀x □φ → □ ∀x φ`. -/
+theorem realize_barcan (x : α) (φ : ModalFormula L α) :
+    (all x (box φ)).Realize K w v → (box (all x φ)).Realize K w v :=
+  fun h w' hw' d => h d w' hw'
+
+/-- The converse Barcan formula `□ ∀x φ → ∀x □φ`. -/
+theorem realize_converseBarcan (x : α) (φ : ModalFormula L α) :
+    (box (all x φ)).Realize K w v → (all x (box φ)).Realize K w v :=
+  fun h d w' hw' => h w' hw' d
+
 end ModalFormula
 
 end FirstOrder.Language

--- a/Linglib/Logic/Modal/FirstOrder/Kripke.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Kripke.lean
@@ -37,9 +37,9 @@ namespace FirstOrder.Language
 
 variable {L : Language} {W M α : Type*}
 
-/-- A constant-domain first-order Kripke structure: `Finset`-valued
-    accessibility plus a `W`-indexed family of `L`-structures on the
-    domain `M`. -/
+/-- A constant-domain first-order Kripke structure — the Kripke analogue
+    of mathlib's `L.Structure`: `Finset`-valued accessibility plus a
+    `W`-indexed family of `L`-structures on the domain `M`. -/
 structure KripkeStructure (L : Language) (W M : Type*) where
   /-- Accessibility relation (per-world set of accessible worlds). -/
   access : W → Finset W

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -95,10 +95,11 @@ variable {v : Index TwoAtomWorld QVar FCAtom → QVar → FCAtom}
 theorem support_univPxOrQx_iff
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support univAccessModel univPxOrQx s ↔
-      ∀ i ∈ s, univAccessModel.RealizeAt i.world
+      ∀ i ∈ s,
         (Formula.all₁ QVar.x
           ((monadicRel Predicate.P).formula₁ (Term.var QVar.x) ⊔
-            (monadicRel Predicate.Q).formula₁ (Term.var QVar.x))) (v i) :=
+            (monadicRel Predicate.Q).formula₁
+              (Term.var QVar.x))).RealizeAt univAccessModel.interp i.world (v i) :=
   support_iff_forall_realizeAt univAccessModel rfl s v hv
 
 /-- The narrow-scope FC premise `◇(Px ∨ Qx)` translates into the modal layer


### PR DESCRIPTION
The Barcan formula and its converse, the canonical validities of constant-domain quantified modal logic — box and the objectual quantifier commute. One-line term proofs on ModalFormula.Realize.