### PR TITLE
refactor(Logic/Modal/FirstOrder): KripkeStructure is KripkeModel

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -16,7 +16,7 @@ preservation.
 ## Main declarations
 
 * `Language.correspondence` — the target signature;
-  `KripkeStructure.corrStructure` — the `W ⊕ M` encoding of a Kripke
+  `KripkeModel.corrStructure` — the `W ⊕ M` encoding of a Kripke
   structure as one mathlib structure.
 * `ModalFormula.st?` — the standard translation, with the current world as
   the free variable `Sum.inr k` and box introducing the fresh world
@@ -92,11 +92,11 @@ abbrev corrIndivVar (x : Var) :
 abbrev corrWorldVar (k : ℕ) :
     (correspondence Const Pred).Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
-/-- The `W ⊕ M` encoding of a Kripke structure over the monadic signature
+/-- The `W ⊕ M` encoding of a Kripke model over the monadic signature
     as a single mathlib structure: worlds and individuals share the carrier,
     sorted by `corrIndiv`; relational guards make all off-sort atoms false. -/
-@[reducible] def KripkeStructure.corrStructure
-    (K : KripkeStructure (monadicWithConstants Const Pred) W M) :
+@[reducible] def KripkeModel.corrStructure
+    (K : KripkeModel (monadicWithConstants Const Pred) W M) :
     (correspondence Const Pred).Structure (W ⊕ M) where
   funMap := fun {n} f => match n, f with
     | 1, c => fun z => match z 0 with
@@ -114,26 +114,26 @@ abbrev corrWorldVar (k : ℕ) :
     | _ + 3, r => r.elim
 
 @[simp] theorem corrStructure_relMap_rel
-    (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+    (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (P : Pred) (z : Fin 2 → W ⊕ M) :
     (K.corrStructure).RelMap (corrRel P) z ↔
       ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.pInterp P w d :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_acc (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+@[simp] theorem corrStructure_relMap_acc (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (z : Fin 2 → W ⊕ M) :
     (K.corrStructure).RelMap (corrAcc (Const := Const)) z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
 @[simp] theorem corrStructure_relMap_indiv
-    (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+    (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (z : Fin 1 → W ⊕ M) :
     (K.corrStructure).RelMap (corrIndiv (Const := Const)) z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
-theorem corrStructure_funMap_inl (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+theorem corrStructure_funMap_inl (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (c : Const) (w : W) (z : Fin 1 → W ⊕ M) (hz : z 0 = Sum.inl w) :
     (K.corrStructure).funMap (corrConst (Pred := Pred) c) z =
       Sum.inr (K.cInterp c w) := by
@@ -200,7 +200,7 @@ def ModalFormula.st? (k : ℕ) :
 
 omit [DecidableEq Var] in
 /-- Satisfaction preservation for embedded atoms. -/
-private theorem realize_stAtom? (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+private theorem realize_stAtom? (K : KripkeModel (monadicWithConstants Const Pred) W M)
     {k : ℕ} {χ : (monadicWithConstants Const Pred).Formula Var}
     {ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)}
     (hψ : stAtom? k χ = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W}
@@ -326,7 +326,7 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
     `k + 1` leaves the pinned index untouched. -/
-theorem realize_st? (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+theorem realize_st? (K : KripkeModel (monadicWithConstants Const Pred) W M)
     {φ : ModalFormula (monadicWithConstants Const Pred) Var} {k : ℕ}
     {ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)}
     (hψ : φ.st? k = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
@@ -435,7 +435,7 @@ def stClose (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)) :
 
 /-- Over `corrStructure`, the guarded witness of `stClose` is exactly a
     world. -/
-theorem realize_stClose (K : KripkeStructure (monadicWithConstants Const Pred) W M)
+theorem realize_stClose (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ))
     (val : Var ⊕ ℕ → W ⊕ M) :
     (letI := K.corrStructure; (stClose k ψ).Realize val) ↔

--- a/Linglib/Logic/Modal/FirstOrder/Kripke.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Kripke.lean
@@ -2,10 +2,10 @@ import Mathlib.ModelTheory.Semantics
 import Linglib.Core.ModelTheory.StructureFamily
 
 /-!
-# Constant-domain first-order Kripke structures and modal formulas
+# Constant-domain first-order Kripke models and modal formulas
 
 `[UPSTREAM]` candidates for `Mathlib/ModelTheory`, which is classical: one
-structure, no accessibility. A `KripkeStructure L W M` is a `W`-indexed
+structure, no accessibility. A `KripkeModel L W M` is a `W`-indexed
 family of `L`-structures on a constant domain `M` together with
 `Finset`-valued accessibility; `ModalFormula L α` layers `□` and named
 quantifiers over embedded classical `L.Formula`s, and
@@ -13,7 +13,7 @@ quantifiers over embedded classical `L.Formula`s, and
 
 ## Main declarations
 
-* `KripkeStructure` — accessibility plus a world-indexed family of
+* `KripkeModel` — accessibility plus a world-indexed family of
   first-order structures on a constant domain (classical satisfaction at an
   index is `Core/ModelTheory/StructureFamily.lean`'s `Formula.RealizeAt`).
 * `ModalFormula`, `ModalFormula.Realize` — modal formulas over embedded
@@ -37,10 +37,10 @@ namespace FirstOrder.Language
 
 variable {L : Language} {W M α : Type*}
 
-/-- A constant-domain first-order Kripke structure — the Kripke analogue
-    of mathlib's `L.Structure`: `Finset`-valued accessibility plus a
-    `W`-indexed family of `L`-structures on the domain `M`. -/
-structure KripkeStructure (L : Language) (W M : Type*) where
+/-- A constant-domain first-order Kripke model: `Finset`-valued
+    accessibility plus a `W`-indexed family of `L`-structures on the
+    domain `M`. -/
+structure KripkeModel (L : Language) (W M : Type*) where
   /-- Accessibility relation (per-world set of accessible worlds). -/
   access : W → Finset W
   /-- World-indexed interpretation of the signature. -/
@@ -77,7 +77,7 @@ variable [DecidableEq α]
 /-- Kripke satisfaction `K, w ⊨_v φ`: classical formulas evaluate at the
     world's structure, `□` quantifies over accessible worlds, and named
     quantifiers update the valuation. -/
-def Realize (K : KripkeStructure L W M) :
+def Realize (K : KripkeModel L W M) :
     W → ModalFormula L α → (α → M) → Prop
   | w, .ofFormula ψ, v => ψ.RealizeAt K.interp w v
   | w, .not φ, v => ¬ Realize K w φ v
@@ -87,7 +87,7 @@ def Realize (K : KripkeStructure L W M) :
   | w, .all x φ, v => ∀ d : M, Realize K w φ (Function.update v x d)
   | w, .ex x φ, v => ∃ d : M, Realize K w φ (Function.update v x d)
 
-variable (K : KripkeStructure L W M) (w : W) (v : α → M)
+variable (K : KripkeModel L W M) (w : W) (v : α → M)
 
 /-- Embedded classical formulas realize classically — by construction. -/
 @[simp] theorem realize_ofFormula (ψ : L.Formula α) :

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -20,8 +20,8 @@ the constants side.
 * `monadicWithConstantsStructure` — its structure from a constant
   interpretation and a predicate valuation (cf. mathlib's
   `orderStructure`).
-* `KripkeStructure.pInterp`, `KripkeStructure.cInterp` — world-relative
-  predicate and constant denotations of a Kripke structure over the
+* `KripkeModel.pInterp`, `KripkeModel.cInterp` — world-relative
+  predicate and constant denotations of a Kripke model over the
   signature.
 -/
 
@@ -67,20 +67,20 @@ abbrev monadicRel (P : Pred) :
 
 variable {W : Type*}
 
-/-- The predicate denotation at a world, read off a Kripke structure's
+/-- The predicate denotation at a world, read off a Kripke model's
     world-indexed family via `Structure.RelMap` — the world-relativized
     `I(w)(Pⁿ)` of [aloni-vanormondt-2023] Definition 4.2, specialised to
     monadic `P`. -/
-def KripkeStructure.pInterp
-    (K : KripkeStructure (monadicWithConstants Const Pred) W Domain)
+def KripkeModel.pInterp
+    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
     (P : Pred) (w : W) (d : Domain) : Prop :=
   (K.interp w).RelMap (monadicRel P) (fun _ => d)
 
 /-- The constant denotation at a world — the world-relative `I(w)(c)` of
     [aloni-vanormondt-2023] Definitions 4.2 and 4.8, read off
     `Structure.funMap`. -/
-def KripkeStructure.cInterp
-    (K : KripkeStructure (monadicWithConstants Const Pred) W Domain)
+def KripkeModel.cInterp
+    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
     (c : Const) (w : W) : Domain :=
   (K.interp w).funMap (monadicConst c) default
 

--- a/Linglib/Logic/Team/QBSML/Defs.lean
+++ b/Linglib/Logic/Team/QBSML/Defs.lean
@@ -25,10 +25,10 @@ by state non-emptiness.
 * `State.modalLift`: a set of worlds, paired with one assignment.
 * `Formula`: the formula language; `Formula.nec` is the derived `□`;
   `Formula.NEFree` the NE-free fragment.
-* `Model`, `Model.ofMonadic`: models, as `KripkeStructure`s over
+* `Model`, `Model.ofMonadic`: models, as `KripkeModel`s over
   `Language.monadicWithConstants`.
 * `eval`, `support`, `antiSupport`: bilateral evaluation.
-* `KripkeStructure.IsStateBased`, `KripkeStructure.IsIndisputable`: frame
+* `KripkeModel.IsStateBased`, `KripkeModel.IsIndisputable`: frame
   conditions via `s↓`.
 
 ## Implementation notes
@@ -405,11 +405,11 @@ theorem Formula.NEFree.mapAtoms
     `M = ⟨W, D, R, I⟩`) **is** a constant-domain first-order Kripke
     structure over the monadic signature with constants: accessibility `R`
     plus the world-indexed interpretation `I`, carried as a family of
-    mathlib structures (`FirstOrder.Language.KripkeStructure`) — true by
+    mathlib structures (`FirstOrder.Language.KripkeModel`) — true by
     construction, not by bridge. -/
 abbrev Model (W : Type*) (Domain : Type*) (Const : Type*)
     (Pred : Type*) :=
-  FirstOrder.Language.KripkeStructure
+  FirstOrder.Language.KripkeModel
     (Language.monadicWithConstants Const Pred) W Domain
 
 /-- The QBSML model with accessibility `access`, constant interpretation
@@ -514,25 +514,25 @@ variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
     ([aloni-vanormondt-2023] Definition 4.10). Defined via
     `Team.IsStateBased` applied to `State.worldProj s`, sharing
     BSML's frame-condition substrate. -/
-def _root_.FirstOrder.Language.KripkeStructure.IsStateBased
+def _root_.FirstOrder.Language.KripkeModel.IsStateBased
     (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsStateBased M.access (State.worldProj s)
 
 /-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
     accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
-def _root_.FirstOrder.Language.KripkeStructure.IsIndisputable
+def _root_.FirstOrder.Language.KripkeModel.IsIndisputable
     (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsIndisputable M.access (State.worldProj s)
 
 instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
-  unfold FirstOrder.Language.KripkeStructure.IsStateBased; infer_instance
+  unfold FirstOrder.Language.KripkeModel.IsStateBased; infer_instance
 
 instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
-  unfold FirstOrder.Language.KripkeStructure.IsIndisputable; infer_instance
+  unfold FirstOrder.Language.KripkeModel.IsIndisputable; infer_instance
 
 end FrameConditions
 

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -624,7 +624,7 @@ bridge: their right-hand side is classical *modal* logic, which mathlib's
 open FirstOrder Language
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁
+@[simp] theorem _root_.FirstOrder.Language.KripkeModel.realizeAt_rel₁
     (M : Model W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     ((monadicRel P).formula₁ (Term.var x)).RealizeAt M.interp w v ↔
@@ -638,7 +638,7 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
   exact Iff.rfl
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem _root_.FirstOrder.Language.KripkeStructure.realizeAt_rel₁_const
+@[simp] theorem _root_.FirstOrder.Language.KripkeModel.realizeAt_rel₁_const
     (M : Model W Domain Const Pred) (P : Pred) (c : Const) (w : W)
     (v : Var → Domain) :
     ((monadicRel P).formula₁
@@ -749,7 +749,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         some ((monadicRel P).formula₁ (Term.var x)) from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [KripkeStructure.realizeAt_rel₁]
+    rw [KripkeModel.realizeAt_rel₁]
     constructor
     · constructor
       · intro h
@@ -777,7 +777,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [KripkeStructure.realizeAt_rel₁_const]
+    rw [KripkeModel.realizeAt_rel₁_const]
     constructor
     · constructor
       · intro h
@@ -1132,7 +1132,7 @@ private theorem support_and_antiSupport_singleton_realize
         some (.ofFormula ((monadicRel P).formula₁ (Term.var x))) from rfl,
       Option.some.injEq] at hτ
     subst hτ
-    rw [ModalFormula.realize_ofFormula, KripkeStructure.realizeAt_rel₁]
+    rw [ModalFormula.realize_ofFormula, KripkeModel.realizeAt_rel₁]
     constructor
     · constructor
       · intro h
@@ -1160,7 +1160,7 @@ private theorem support_and_antiSupport_singleton_realize
           (Constants.term (monadicConst c)))) from rfl,
       Option.some.injEq] at hτ
     subst hτ
-    rw [ModalFormula.realize_ofFormula, KripkeStructure.realizeAt_rel₁_const]
+    rw [ModalFormula.realize_ofFormula, KripkeModel.realizeAt_rel₁_const]
     constructor
     · constructor
       · intro h

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -33,7 +33,7 @@ whole-formula claims; the Fact 4 countermodel is proved by hand, with
 `decide` confined to finite side conditions. The propositional facts (3, 7,
 8, 10) are stated with the individual constants of the paper's
 Definition 4.1 (`Formula.predc` atoms, world-relative
-`KripkeStructure.cInterp`), the quantified facts with variable atoms — both
+`KripkeModel.cInterp`), the quantified facts with variable atoms — both
 as in the paper. Atoms and worlds come from
 `Logic/Team/BSML/Scenarios.lean`, so this file and `Studies/Aloni2022.lean`
 target the same world space.


### PR DESCRIPTION
Renames the constant-domain first-order carrier to KripkeModel: BdRV say frame/model (never "Kripke structure"), the program vocabulary is already Model (QBSML.Model), and owner-relative naming sanctions the coexistence with ModalLogic.KripkeModel — no file opens both namespaces.