### PR TITLE
refactor(Core/ModelTheory): monadic signature descends; predInterp names

### DIFF
--- a/Linglib/Core/ModelTheory/FiniteModel.lean
+++ b/Linglib/Core/ModelTheory/FiniteModel.lean
@@ -10,6 +10,10 @@ models:
   symbols are `Sym` (mathlib precedent: `Language.graph`, one binary symbol),
   with `monadicStructure` building its structures from a `Sym → E → Prop`
   table.
+* `Language.monadicWithConstants Const Pred` — the monadic signature with
+  individual constants adjoined (`(monadic Pred)[[Const]]`), with
+  `monadicWithConstantsStructure` building its structures from a constant
+  interpretation and a predicate valuation.
 * `BoundedFormula.decRealize` — decidable realization over a finite structure
   with decidable atoms, by structural recursion on the formula. Mathlib has no
   such instance; with it, `decide` kernel-checks `Formula.Realize` facts on
@@ -54,6 +58,42 @@ instance {Sym E : Type*} (holds : Sym → E → Prop)
     (r : (monadic Sym).Relations n) (v : Fin n → E) :
     Decidable (@Structure.RelMap _ _ (monadicStructure holds) n r v) :=
   monadicStructure.decRelMap holds n r v
+
+/-- The monadic signature with constants:
+    `(Language.monadic Pred)[[Const]]`. -/
+abbrev monadicWithConstants (Const : Type*) (Pred : Type*) : Language :=
+  (monadic Pred)[[Const]]
+
+variable {Const Pred Domain : Type*}
+
+/-- A constant as a symbol of the signature (mathlib's `Language.con`). -/
+abbrev monadicConst (c : Const) :
+    (monadicWithConstants Const Pred).Constants := Sum.inr c
+
+/-- A predicate as a relation symbol of the signature. -/
+abbrev monadicRel (P : Pred) :
+    (monadicWithConstants Const Pred).Relations 1 := Sum.inl P
+
+/-- The `monadicWithConstants` structure a constant interpretation and a
+    predicate valuation induce: `monadicStructure` on the relations side,
+    `constantsOn.structure` on the constants side. -/
+@[reducible] def monadicWithConstantsStructure (κ : Const → Domain)
+    (V : Pred → Domain → Prop) :
+    (monadicWithConstants Const Pred).Structure Domain :=
+  letI := monadicStructure V
+  letI := constantsOn.structure κ
+  inferInstance
+
+@[simp] theorem monadicWithConstantsStructure_relMap (κ : Const → Domain)
+    (V : Pred → Domain → Prop) (P : Pred) (v : Fin 1 → Domain) :
+    (monadicWithConstantsStructure κ V).RelMap (monadicRel P) v ↔ V P (v 0) :=
+  Iff.rfl
+
+@[simp] theorem monadicWithConstantsStructure_funMap (κ : Const → Domain)
+    (V : Pred → Domain → Prop) (c : Const) (v : Fin 0 → Domain) :
+    (monadicWithConstantsStructure κ V).funMap
+      (monadicConst (Pred := Pred) c) v = κ c :=
+  rfl
 
 /-- Decidable realization on a finite structure with decidable atoms:
 structural recursion on the formula. `decide` kernel-reduces through it. -/

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -100,14 +100,14 @@ abbrev corrWorldVar (k : ℕ) :
     (correspondence Const Pred).Structure (W ⊕ M) where
   funMap := fun {n} f => match n, f with
     | 1, c => fun z => match z 0 with
-      | Sum.inl w => Sum.inr (K.cInterp c w)
+      | Sum.inl w => Sum.inr (K.constInterp c w)
       | Sum.inr d => Sum.inr d
     | 0, f => f.elim
     | _ + 2, f => f.elim
   RelMap := fun {n} r => match n, r with
     | 1, _ => fun z => ∃ d : M, z 0 = Sum.inr d
     | 2, Sum.inl P => fun z =>
-        ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.pInterp P w d
+        ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.predInterp P w d
     | 2, Sum.inr _ => fun z =>
         ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
     | 0, r => r.elim
@@ -117,7 +117,7 @@ abbrev corrWorldVar (k : ℕ) :
     (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (P : Pred) (z : Fin 2 → W ⊕ M) :
     (K.corrStructure).RelMap (corrRel P) z ↔
-      ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.pInterp P w d :=
+      ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.predInterp P w d :=
   Iff.rfl
 
 @[simp] theorem corrStructure_relMap_acc (K : KripkeModel (monadicWithConstants Const Pred) W M)
@@ -136,9 +136,9 @@ abbrev corrWorldVar (k : ℕ) :
 theorem corrStructure_funMap_inl (K : KripkeModel (monadicWithConstants Const Pred) W M)
     (c : Const) (w : W) (z : Fin 1 → W ⊕ M) (hz : z 0 = Sum.inl w) :
     (K.corrStructure).funMap (corrConst (Pred := Pred) c) z =
-      Sum.inr (K.cInterp c w) := by
+      Sum.inr (K.constInterp c w) := by
   show (match z 0 with
-    | Sum.inl w' => Sum.inr (K.cInterp c w')
+    | Sum.inl w' => Sum.inr (K.constInterp c w')
     | Sum.inr d => Sum.inr d) = _
   rw [hz]
 
@@ -230,7 +230,7 @@ private theorem realize_stAtom? (K : KripkeModel (monadicWithConstants Const Pre
         cases s with
         | inl x =>
           have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
-              K.pInterp P w (v x) := by
+              K.predInterp P w (v x) := by
             let _S := K.interp w
             show (K.interp w).RelMap (monadicRel P)
                 (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
@@ -263,14 +263,14 @@ private theorem realize_stAtom? (K : KripkeModel (monadicWithConstants Const Pre
           obtain (e | c) := f
           · exact e.elim
           have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
-              K.pInterp P w (K.cInterp c w) := by
+              K.predInterp P w (K.constInterp c w) := by
             let _S := K.interp w
             show (K.interp w).RelMap (monadicRel P)
                 (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
               ↔ _
             have hfun : (fun i : Fin 1 => (ts i).realize
                 (Sum.elim v (default : Fin 0 → M))) =
-                fun _ => K.cInterp c w := by
+                fun _ => K.constInterp c w := by
               funext i
               rw [Subsingleton.elim i 0, hts]
               show (K.interp w).funMap (monadicConst c)
@@ -290,17 +290,17 @@ private theorem realize_stAtom? (K : KripkeModel (monadicWithConstants Const Pre
           have hcv : (Term.func (corrConst c)
               ![Term.var (Sum.inr k)] :
               (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val
-              = Sum.inr (K.cInterp c w) :=
+              = Sum.inr (K.constInterp c w) :=
             corrStructure_funMap_inl K c w _ hw
           constructor
           · intro h
-            exact ⟨w, K.cInterp c w, hw, hcv, h⟩
+            exact ⟨w, K.constInterp c w, hw, hcv, h⟩
           · rintro ⟨w', d, hw', hd, h⟩
             have hww : val (Sum.inr k) = Sum.inl w' := hw'
             obtain rfl : w = w' := Sum.inl.inj (hw.symm.trans hww)
-            have hdd : Sum.inr (K.cInterp c w) = Sum.inr d :=
+            have hdd : Sum.inr (K.constInterp c w) = Sum.inr d :=
               hcv.symm.trans hd
-            obtain rfl : K.cInterp c w = d := Sum.inr.inj hdd
+            obtain rfl : K.constInterp c w = d := Sum.inr.inj hdd
             exact h
 
 /-- An individual-sorted update of an individual-sorted valuation. -/

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -2,84 +2,31 @@ import Linglib.Core.ModelTheory.FiniteModel
 import Linglib.Logic.Modal.FirstOrder.Kripke
 
 /-!
-# The monadic signature with individual constants
+# World-relative denotations over the monadic signature
 
-`Language.monadicWithConstants Const Pred` is the relations-only monadic
-language `Language.monadic Pred` (`Core/ModelTheory/FiniteModel.lean`) with
-constants adjoined by mathlib's `withConstants` — one individual constant
-per `Const`, one unary relation symbol per `Pred`: the object-language
-signature of monadic quantified modal logic ([aloni-vanormondt-2023]
-Definition 4.1, terms `t := c | x`). Structures compose from
-`monadicStructure` on the relations side and `constantsOn.structure` on
-the constants side.
+The predicate and constant denotations a first-order Kripke model over
+`Language.monadicWithConstants Const Pred` assigns at each world — the
+world-relativized `I(w)(P)` and `I(w)(c)` of monadic quantified modal
+logic, read off the world's structure.
 
-## Main definitions
+## References
 
-* `Language.monadicWithConstants` — the signature, as
-  `(Language.monadic Pred)[[Const]]`.
-* `monadicWithConstantsStructure` — its structure from a constant
-  interpretation and a predicate valuation (cf. mathlib's
-  `orderStructure`).
-* `KripkeModel.pInterp`, `KripkeModel.cInterp` — world-relative
-  predicate and constant denotations of a Kripke model over the
-  signature.
+* [aloni-vanormondt-2023] — Definitions 4.2 and 4.8
 -/
-
-universe u v
 
 namespace FirstOrder.Language
 
-/-- The monadic signature with constants:
-    `(Language.monadic Pred)[[Const]]`. -/
-abbrev monadicWithConstants (Const : Type u) (Pred : Type v) : Language :=
-  (monadic Pred)[[Const]]
-
-variable {Const Pred Domain : Type*}
-
-/-- A constant as a symbol of the signature (mathlib's `Language.con`). -/
-abbrev monadicConst (c : Const) :
-    (monadicWithConstants Const Pred).Constants := Sum.inr c
-
-/-- A predicate as a relation symbol of the signature. -/
-abbrev monadicRel (P : Pred) :
-    (monadicWithConstants Const Pred).Relations 1 := Sum.inl P
-
-/-- The `monadicWithConstants` structure a constant interpretation and a
-    predicate valuation induce: `monadicStructure` on the relations side,
-    `constantsOn.structure` on the constants side. -/
-@[reducible] def monadicWithConstantsStructure (κ : Const → Domain)
-    (V : Pred → Domain → Prop) :
-    (monadicWithConstants Const Pred).Structure Domain :=
-  letI := monadicStructure V
-  letI := constantsOn.structure κ
-  inferInstance
-
-@[simp] theorem monadicWithConstantsStructure_relMap (κ : Const → Domain)
-    (V : Pred → Domain → Prop) (P : Pred) (v : Fin 1 → Domain) :
-    (monadicWithConstantsStructure κ V).RelMap (monadicRel P) v ↔ V P (v 0) :=
-  Iff.rfl
-
-@[simp] theorem monadicWithConstantsStructure_funMap (κ : Const → Domain)
-    (V : Pred → Domain → Prop) (c : Const) (v : Fin 0 → Domain) :
-    (monadicWithConstantsStructure κ V).funMap
-      (monadicConst (Pred := Pred) c) v = κ c :=
-  rfl
-
-variable {W : Type*}
+variable {Const Pred Domain W : Type*}
 
 /-- The predicate denotation at a world, read off a Kripke model's
-    world-indexed family via `Structure.RelMap` — the world-relativized
-    `I(w)(Pⁿ)` of [aloni-vanormondt-2023] Definition 4.2, specialised to
-    monadic `P`. -/
-def KripkeModel.pInterp
+    world-indexed family via `Structure.RelMap`. -/
+def KripkeModel.predInterp
     (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
     (P : Pred) (w : W) (d : Domain) : Prop :=
   (K.interp w).RelMap (monadicRel P) (fun _ => d)
 
-/-- The constant denotation at a world — the world-relative `I(w)(c)` of
-    [aloni-vanormondt-2023] Definitions 4.2 and 4.8, read off
-    `Structure.funMap`. -/
-def KripkeModel.cInterp
+/-- The constant denotation at a world, read off `Structure.funMap`. -/
+def KripkeModel.constInterp
     (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
     (c : Const) (w : W) : Domain :=
   (K.interp w).funMap (monadicConst c) default

--- a/Linglib/Logic/Team/QBSML/Defs.lean
+++ b/Linglib/Logic/Team/QBSML/Defs.lean
@@ -419,16 +419,16 @@ def Model.ofMonadic {W Domain Const Pred : Type*} (access : W → Finset W)
     Model W Domain Const Pred :=
   ⟨access, fun w => Language.monadicWithConstantsStructure (κ w) (V w)⟩
 
-@[simp] theorem pInterp_ofMonadic {W Domain Const Pred : Type*}
+@[simp] theorem predInterp_ofMonadic {W Domain Const Pred : Type*}
     (access : W → Finset W) (κ : W → Const → Domain)
     (V : W → Pred → Domain → Prop) (P : Pred) (w : W) (d : Domain) :
-    (Model.ofMonadic access κ V).pInterp P w d ↔ V w P d :=
+    (Model.ofMonadic access κ V).predInterp P w d ↔ V w P d :=
   Iff.rfl
 
-@[simp] theorem cInterp_ofMonadic {W Domain Const Pred : Type*}
+@[simp] theorem constInterp_ofMonadic {W Domain Const Pred : Type*}
     (access : W → Finset W) (κ : W → Const → Domain)
     (V : W → Pred → Domain → Prop) (c : Const) (w : W) :
-    (Model.ofMonadic access κ V).cInterp c w = κ w c :=
+    (Model.ofMonadic access κ V).constInterp c w = κ w c :=
   rfl
 
 /-! ### Bilateral evaluation -/
@@ -445,13 +445,13 @@ variable [Fintype Domain]
 def eval (M : Model W Domain Const Pred) :
     Bool → Formula Var Const Pred → Finset (Index W Var Domain) → Prop
   | true,  .pred P x, s =>
-      ∀ i ∈ s, ∃ d, i.assign x = some d ∧ M.pInterp P i.world d
+      ∀ i ∈ s, ∃ d, i.assign x = some d ∧ M.predInterp P i.world d
   | false, .pred P x, s =>
-      ∀ i ∈ s, ∃ d, i.assign x = some d ∧ ¬ M.pInterp P i.world d
+      ∀ i ∈ s, ∃ d, i.assign x = some d ∧ ¬ M.predInterp P i.world d
   | true,  .predc P c, s =>
-      ∀ i ∈ s, M.pInterp P i.world (M.cInterp c i.world)
+      ∀ i ∈ s, M.predInterp P i.world (M.constInterp c i.world)
   | false, .predc P c, s =>
-      ∀ i ∈ s, ¬ M.pInterp P i.world (M.cInterp c i.world)
+      ∀ i ∈ s, ¬ M.predInterp P i.world (M.constInterp c i.world)
   | true,  .ne, s => s.Nonempty
   | false, .ne, s => s = ∅
   | true,  .neg ψ, s => eval M false ψ s

--- a/Linglib/Logic/Team/QBSML/FreeChoice.lean
+++ b/Linglib/Logic/Team/QBSML/FreeChoice.lean
@@ -355,7 +355,7 @@ private theorem exi_poss_atom_of_subset_extendUniversal
     Option.some.injEq] at hassign
   rw [← hassign] at hmem
   rw [Index.world_update] at hmem
-  -- hmem : d ∈ M.pInterp P i₀.world
+  -- hmem : d ∈ M.predInterp P i₀.world
   refine ⟨fun _ => {d}, fun j _ => Finset.singleton_nonempty d, ?_⟩
   intro j hj
   obtain ⟨i, his, d'', hd'', hupd'⟩ := State.mem_extendFunctional.mp hj

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -628,7 +628,7 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
     (M : Model W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     ((monadicRel P).formula₁ (Term.var x)).RealizeAt M.interp w v ↔
-      M.pInterp P w (v x) := by
+      M.predInterp P w (v x) := by
   let _S := M.interp w
   show ((monadicRel P).formula₁ (Term.var x)).Realize v ↔ _
   have hfun : (![v x] : Fin 1 → Domain) = fun _ => v x := by
@@ -643,12 +643,12 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
     (v : Var → Domain) :
     ((monadicRel P).formula₁
       (Constants.term (monadicConst c))).RealizeAt M.interp w v ↔
-      M.pInterp P w (M.cInterp c w) := by
+      M.predInterp P w (M.constInterp c w) := by
   let _S := M.interp w
   show ((monadicRel P).formula₁ (Constants.term (monadicConst c))).Realize v
     ↔ _
   have hfun : (![(Constants.term (monadicConst (Pred := Pred) c)).realize v] :
-      Fin 1 → Domain) = fun _ => M.cInterp c w := by
+      Fin 1 → Domain) = fun _ => M.constInterp c w := by
     funext j
     rw [Matrix.cons_val_fin_one]
     exact Term.realize_constants

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -33,7 +33,7 @@ whole-formula claims; the Fact 4 countermodel is proved by hand, with
 `decide` confined to finite side conditions. The propositional facts (3, 7,
 8, 10) are stated with the individual constants of the paper's
 Definition 4.1 (`Formula.predc` atoms, world-relative
-`KripkeModel.cInterp`), the quantified facts with variable atoms — both
+`KripkeModel.constInterp`), the quantified facts with variable atoms — both
 as in the paper. Atoms and worlds come from
 `Logic/Team/BSML/Scenarios.lean`, so this file and `Studies/Aloni2022.lean`
 target the same world space.

--- a/Linglib/Studies/Yan2023.lean
+++ b/Linglib/Studies/Yan2023.lean
@@ -174,9 +174,9 @@ private theorem eval_iff_of_atom_pred (P Q : Pred) (x : Var) (b : Bool)
       · exact hQ₂ i h
     · intro hQ
       refine ⟨s.filter (fun i => ∀ d, i.assign x = some d →
-          M.pInterp P i.world d),
+          M.predInterp P i.world d),
         s.filter (fun i => ¬ ∀ d, i.assign x = some d →
-          M.pInterp P i.world d),
+          M.predInterp P i.world d),
         Finset.filter_union_filter_not_eq _ s, ⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
       · intro i hi
         obtain ⟨his, hcond⟩ := Finset.mem_filter.mp hi
@@ -223,8 +223,8 @@ private theorem eval_iff_of_atom_predc (P Q : Pred) (c : Const) (b : Bool)
       · exact hQ₁ i h
       · exact hQ₂ i h
     · intro hQ
-      refine ⟨s.filter (fun i => M.pInterp P i.world (M.cInterp c i.world)),
-        s.filter (fun i => ¬ M.pInterp P i.world (M.cInterp c i.world)),
+      refine ⟨s.filter (fun i => M.predInterp P i.world (M.constInterp c i.world)),
+        s.filter (fun i => ¬ M.predInterp P i.world (M.constInterp c i.world)),
         Finset.filter_union_filter_not_eq _ s, ⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
       · exact fun i hi => (Finset.mem_filter.mp hi).2
       · exact fun i hi => hQ i (Finset.mem_of_mem_filter i hi)
@@ -474,9 +474,9 @@ def asherState : Finset (Index Bool QVar Unit) := {(true, fun _ => none)}
     necessarily so, since blocking requires no accessible non-free trip;
     see `reinterpret`.) -/
 theorem asherModel_free_ssubset_trip :
-    (∀ w d, asherModel.pInterp .free w d → asherModel.pInterp .trip w d) ∧
-    ∃ w d, asherModel.pInterp .trip w d ∧
-      ¬ asherModel.pInterp .free w d :=
+    (∀ w d, asherModel.predInterp .free w d → asherModel.predInterp .trip w d) ∧
+    ∃ w d, asherModel.predInterp .trip w d ∧
+      ¬ asherModel.predInterp .free w d :=
   ⟨fun _ _ _ => Or.inl rfl,
    false, (), Or.inl rfl, fun h => by
      rcases h with h | h
@@ -503,7 +503,7 @@ theorem asher_premise :
         ⟨j, hj, (), Finset.mem_singleton_self _, rfl⟩⟩
   have hpt : ∀ P : AsherPred, ∀ j ∈ State.extendFunctional
       (State.modalLift {true} i.assign) QVar.x (fun _ => ({()} : Finset Unit)),
-      ∃ d, j.assign QVar.x = some d ∧ asherModel.pInterp P j.world d := by
+      ∃ d, j.assign QVar.x = some d ∧ asherModel.predInterp P j.world d := by
     intro P j hj
     obtain ⟨i', hi', d, -, rfl⟩ := State.mem_extendFunctional.mp hj
     exact ⟨d, by simp,


### PR DESCRIPTION
monadicWithConstants and its structure builder join their siblings monadic/monadicStructure in Core/ModelTheory/FiniteModel.lean (no modal content); Monadic.lean keeps only the world-relative denotations, renamed pInterp/cInterp → predInterp/constInterp.