### PR TITLE
refactor(Logic/Modal/FirstOrder): ModalFormula in the BoundedFormula basis

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -161,7 +161,8 @@ import Linglib.Core.ModelTheory.StructureFamily
 import Linglib.Core.ModelTheory.EhrenfeuchtFraisse
 import Linglib.Core.ModelTheory.EhrenfeuchtFraisseGame
 import Linglib.Core.ModelTheory.FiniteModel
-import Linglib.Logic.Modal.FirstOrder.Kripke
+import Linglib.Logic.Modal.FirstOrder.Semantics
+import Linglib.Logic.Modal.FirstOrder.Syntax
 import Linglib.Logic.Modal.FirstOrder.Monadic
 import Linglib.Logic.Modal.FirstOrder.Correspondence
 import Linglib.Core.ModelTheory.Lindstrom

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -149,159 +149,74 @@ variable [DecidableEq Var]
 /-- Translate a monadic term: variables stay, constants become their unary
     function applied to the current world variable. -/
 def stTerm (k : ℕ) :
-    (monadicWithConstants Const Pred).Term (Var ⊕ Fin 0) →
+    (monadicWithConstants Const Pred).Term Var →
       (correspondence Const Pred).Term (Var ⊕ ℕ)
-  | .var (Sum.inl x) => corrIndivVar x
-  | .var (Sum.inr i) => i.elim0
+  | .var x => corrIndivVar x
   | @Term.func _ _ l f _ => match l, f with
     | 0, Sum.inr c => Term.func (corrConst c) ![corrWorldVar k]
     | 0, Sum.inl e => e.elim
     | _ + 1, Sum.inl e => e.elim
     | _ + 1, Sum.inr e => e.elim
 
-/-- Translate an embedded classical formula when it is a monadic atom
-    (`none` otherwise — which never arises from `Formula.toModal?`
-    images, whose embedded formulas are exactly the atoms). -/
-def stAtom? (k : ℕ) :
-    (monadicWithConstants Const Pred).Formula Var →
-      Option ((correspondence Const Pred).Formula (Var ⊕ ℕ))
-  | @BoundedFormula.rel _ _ _ l R ts => match l, R, ts with
+/-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
+    current world is the free variable `Sum.inr k`; `box` relativizes a
+    fresh world variable `Sum.inr (k + 1)` along accessibility; quantifiers
+    relativize to the individual sort. Total — `ModalFormula` atoms are
+    atomic. -/
+def ModalFormula.st (k : ℕ) :
+    ModalFormula (monadicWithConstants Const Pred) Var →
+      (correspondence Const Pred).Formula (Var ⊕ ℕ)
+  | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
+  | @ModalFormula.rel _ _ l R ts => match l, R, ts with
     | 1, Sum.inl P, ts =>
-        some ((corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0)))
+        (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0))
     | 1, Sum.inr r, _ => r.elim
     | 0, Sum.inl r, _ => r.elim
     | 0, Sum.inr r, _ => r.elim
     | _ + 2, Sum.inl r, _ => r.elim
     | _ + 2, Sum.inr r, _ => r.elim
-  | _ => none
-
-/-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
-    current world is the free variable `Sum.inr k`; `box` relativizes a
-    fresh world variable `Sum.inr (k + 1)` along accessibility; quantifiers
-    relativize to the individual sort. -/
-def ModalFormula.st? (k : ℕ) :
-    ModalFormula (monadicWithConstants Const Pred) Var →
-      Option ((correspondence Const Pred).Formula (Var ⊕ ℕ))
-  | .ofFormula χ => stAtom? k χ
-  | .not φ => (φ.st? k).map (·.not)
-  | .inf φ ψ => (φ.st? k).bind fun a => (ψ.st? k).map (a ⊓ ·)
-  | .sup φ ψ => (φ.st? k).bind fun a => (ψ.st? k).map (a ⊔ ·)
-  | .box φ => (φ.st? (k + 1)).map fun a =>
-      Formula.all₁ (Sum.inr (k + 1))
-        ((corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1))).imp a)
-  | .all x φ => (φ.st? k).map fun a =>
-      Formula.all₁ (Sum.inl x)
-        ((corrIndiv.formula₁ (corrIndivVar x)).imp a)
-  | .ex x φ => (φ.st? k).map fun a =>
-      Formula.ex₁ (Sum.inl x)
-        (corrIndiv.formula₁ (corrIndivVar x) ⊓ a)
+  | .falsum => ⊥
+  | .imp φ ψ => (φ.st k).imp (ψ.st k)
+  | .box φ => Formula.all₁ (Sum.inr (k + 1))
+      ((corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1))).imp
+        (φ.st (k + 1)))
+  | .all x φ => Formula.all₁ (Sum.inl x)
+      ((corrIndiv.formula₁ (corrIndivVar x)).imp (φ.st k))
 
 /-! ### Satisfaction preservation -/
 
 omit [DecidableEq Var] in
-/-- Satisfaction preservation for embedded atoms. -/
-private theorem realize_stAtom? (K : KripkeModel (monadicWithConstants Const Pred) W M)
-    {k : ℕ} {χ : (monadicWithConstants Const Pred).Formula Var}
-    {ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)}
-    (hψ : stAtom? k χ = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W}
-    {v : Var → M} (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
-    (hw : val (Sum.inr k) = Sum.inl w) :
-    χ.RealizeAt K.interp w v ↔ (letI := K.corrStructure; ψ.Realize val) := by
+/-- Translated terms realize to the individual sort: `stTerm` commutes with
+    realization, via the world pinned at index `k`. -/
+private theorem realize_stTerm
+    (K : KripkeModel (monadicWithConstants Const Pred) W M)
+    {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
+    (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
+    (hw : val (Sum.inr k) = Sum.inl w)
+    (t : (monadicWithConstants Const Pred).Term Var) :
+    (letI := K.corrStructure; (stTerm k t).realize val) =
+      Sum.inr (letI := K.interp w; t.realize v) := by
   let _S := K.corrStructure
-  cases χ with
-  | falsum => simp [stAtom?] at hψ
-  | equal t₁ t₂ => simp [stAtom?] at hψ
-  | imp χ₁ χ₂ => simp [stAtom?] at hψ
-  | all χ' => simp [stAtom?] at hψ
-  | @rel _ l R ts =>
-    match l, R with
-    | 0, Sum.inl r => exact r.elim
-    | 0, Sum.inr r => exact r.elim
-    | (n + 2), Sum.inl r => exact r.elim
-    | (n + 2), Sum.inr r => exact r.elim
-    | 1, Sum.inr r => exact r.elim
-    | 1, Sum.inl (P : Pred) =>
-      rw [show stAtom? k (.rel (monadicRel P) ts) =
-          some ((corrRel P).formula₂ (Term.var (Sum.inr k)) (stTerm k (ts 0)))
-          from rfl, Option.some.injEq] at hψ
-      subst hψ
-      cases hts : ts 0 with
-      | var s =>
-        cases s with
-        | inl x =>
-          have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
-              K.predInterp P w (v x) := by
-            let _S := K.interp w
-            show (K.interp w).RelMap (monadicRel P)
-                (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
-              ↔ _
-            have hfun : (fun i : Fin 1 => (ts i).realize
-                (Sum.elim v (default : Fin 0 → M))) = fun _ => v x := by
-              funext i
-              rw [Subsingleton.elim i 0, hts]
-              rfl
-            rw [hfun]
-            exact Iff.rfl
-          rw [hLHS, Formula.realize_rel₂,
-            show (stTerm k (.var (Sum.inl x)) :
-                (correspondence Const Pred).Term (Var ⊕ ℕ)) =
-              Term.var (Sum.inl x) from rfl,
-            corrStructure_relMap_rel]
-          simp only [Term.realize_var, hw, hind]
-          constructor
-          · intro h
-            exact ⟨w, v x, rfl, rfl, h⟩
-          · rintro ⟨w', d, hw', hd, h⟩
-            obtain rfl : w = w' := Sum.inl.inj hw'
-            obtain rfl : v x = d := Sum.inr.inj hd
-            exact h
-        | inr i => exact i.elim0
-      | @func l' f args =>
-        cases l' with
-        | succ m => obtain (e | e) := f <;> exact e.elim
-        | zero =>
-          obtain (e | c) := f
-          · exact e.elim
-          have hLHS : Formula.RealizeAt (.rel (monadicRel P) ts) K.interp w v ↔
-              K.predInterp P w (K.constInterp c w) := by
-            let _S := K.interp w
-            show (K.interp w).RelMap (monadicRel P)
-                (fun i => (ts i).realize (Sum.elim v (default : Fin 0 → M)))
-              ↔ _
-            have hfun : (fun i : Fin 1 => (ts i).realize
-                (Sum.elim v (default : Fin 0 → M))) =
-                fun _ => K.constInterp c w := by
-              funext i
-              rw [Subsingleton.elim i 0, hts]
-              show (K.interp w).funMap (monadicConst c)
-                  (fun j => (args j).realize (Sum.elim v default)) = _
-              have hargs : (fun j : Fin 0 => (args j).realize
-                  (Sum.elim v (default : Fin 0 → M))) = default :=
-                funext fun j => j.elim0
-              rw [hargs]
-              rfl
-            rw [hfun]
-            exact Iff.rfl
-          rw [hLHS, Formula.realize_rel₂,
-            show (stTerm k (.func (monadicConst c) args) :
-                (correspondence Const Pred).Term (Var ⊕ ℕ)) =
-              Term.func (corrConst c) ![Term.var (Sum.inr k)] from rfl,
-            corrStructure_relMap_rel]
-          have hcv : (Term.func (corrConst c)
-              ![Term.var (Sum.inr k)] :
-              (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val
-              = Sum.inr (K.constInterp c w) :=
-            corrStructure_funMap_inl K c w _ hw
-          constructor
-          · intro h
-            exact ⟨w, K.constInterp c w, hw, hcv, h⟩
-          · rintro ⟨w', d, hw', hd, h⟩
-            have hww : val (Sum.inr k) = Sum.inl w' := hw'
-            obtain rfl : w = w' := Sum.inl.inj (hw.symm.trans hww)
-            have hdd : Sum.inr (K.constInterp c w) = Sum.inr d :=
-              hcv.symm.trans hd
-            obtain rfl : K.constInterp c w = d := Sum.inr.inj hdd
-            exact h
+  cases t with
+  | var x => exact hind x
+  | @func l f args =>
+    match l, f with
+    | 0, Sum.inl e => exact e.elim
+    | _ + 1, Sum.inl e => exact e.elim
+    | _ + 1, Sum.inr e => exact e.elim
+    | 0, Sum.inr c =>
+      let _I := K.interp w
+      rw [show stTerm k (.func (Sum.inr c) args) =
+          Term.func (corrConst c) ![corrWorldVar k] from rfl,
+        show (Term.func (corrConst c) ![corrWorldVar k] :
+            (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val =
+          (K.corrStructure).funMap (corrConst c)
+            fun i => (![corrWorldVar k] i).realize val from rfl,
+        corrStructure_funMap_inl K c w _ (by simpa using hw)]
+      refine congrArg Sum.inr ?_
+      show (K.interp w).funMap (monadicConst c) default = _
+      show _ = (K.interp w).funMap (monadicConst c) fun i => (args i).realize v
+      exact congrArg _ (funext fun i => i.elim0)
 
 /-- An individual-sorted update of an individual-sorted valuation. -/
 private theorem sorted_update {val : Var ⊕ ℕ → W ⊕ M} {v : Var → M}
@@ -326,36 +241,34 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
     `k + 1` leaves the pinned index untouched. -/
-theorem realize_st? (K : KripkeModel (monadicWithConstants Const Pred) W M)
+theorem realize_st (K : KripkeModel (monadicWithConstants Const Pred) W M)
     {φ : ModalFormula (monadicWithConstants Const Pred) Var} {k : ℕ}
-    {ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)}
-    (hψ : φ.st? k = some ψ) {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
+    {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
-    φ.Realize K w v ↔ (letI := K.corrStructure; ψ.Realize val) := by
-  induction φ generalizing k ψ val w v with
-  | ofFormula χ => exact realize_stAtom? K hψ hind hw
-  | not φ ih =>
-    obtain ⟨a, hφ, rfl⟩ := Option.map_eq_some_iff.mp hψ
+    φ.Realize K w v ↔ (letI := K.corrStructure; (φ.st k).Realize val) := by
+  induction φ generalizing k val w v with
+  | equal t₁ t₂ =>
     let _S := K.corrStructure
-    rw [ModalFormula.realize_not, Formula.realize_not]
-    exact not_congr (ih hφ hind hw)
-  | inf φ₁ φ₂ ih₁ ih₂ =>
-    obtain ⟨a, hφ₁, hb⟩ := Option.bind_eq_some_iff.mp hψ
-    obtain ⟨b, hφ₂, rfl⟩ := Option.map_eq_some_iff.mp hb
+    rw [show (ModalFormula.equal t₁ t₂).st k =
+        Term.equal (stTerm k t₁) (stTerm k t₂) from rfl]
+    rw [ModalFormula.realize_equal, Formula.realize_equal,
+      realize_stTerm K hind hw, realize_stTerm K hind hw]
+    exact ⟨congrArg _, Sum.inr.inj⟩
+  | falsum => exact Iff.rfl
+  | imp φ ψ ih₁ ih₂ =>
     let _S := K.corrStructure
-    rw [ModalFormula.realize_inf, Formula.realize_inf]
-    exact and_congr (ih₁ hφ₁ hind hw) (ih₂ hφ₂ hind hw)
-  | sup φ₁ φ₂ ih₁ ih₂ =>
-    obtain ⟨a, hφ₁, hb⟩ := Option.bind_eq_some_iff.mp hψ
-    obtain ⟨b, hφ₂, rfl⟩ := Option.map_eq_some_iff.mp hb
-    let _S := K.corrStructure
-    rw [ModalFormula.realize_sup, Formula.realize_sup]
-    exact or_congr (ih₁ hφ₁ hind hw) (ih₂ hφ₂ hind hw)
+    rw [ModalFormula.realize_imp,
+      show (ModalFormula.imp φ ψ).st k = (φ.st k).imp (ψ.st k) from rfl,
+      Formula.realize_imp]
+    exact imp_congr (ih₁ hind hw) (ih₂ hind hw)
   | box φ ih =>
-    obtain ⟨a, hφ, rfl⟩ := Option.map_eq_some_iff.mp hψ
     let _S := K.corrStructure
-    rw [ModalFormula.realize_box, Formula.realize_all₁]
+    rw [ModalFormula.realize_box,
+      show (ModalFormula.box φ).st k = Formula.all₁ (Sum.inr (k + 1))
+        ((corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1))).imp
+          (φ.st (k + 1))) from rfl,
+      Formula.realize_all₁]
     constructor
     · intro h z
       rw [Formula.realize_imp, Formula.realize_rel₂]
@@ -365,7 +278,7 @@ theorem realize_st? (K : KripkeModel (monadicWithConstants Const Pred) W M)
       rintro ⟨w₁, w₂, hw₁, hw₂, hmem⟩
       obtain rfl : w = w₁ := Sum.inl.inj hw₁
       subst hw₂
-      refine (ih hφ ?_ ?_).mp (h w₂ hmem)
+      refine (ih ?_ ?_).mp (h w₂ hmem)
       · intro x
         rw [Function.update_of_ne (by simp), hind]
       · rw [Function.update_self]
@@ -375,14 +288,16 @@ theorem realize_st? (K : KripkeModel (monadicWithConstants Const Pred) W M)
       simp only [Term.realize_var, Function.update_of_ne
         (by simp : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr (k + 1)),
         Function.update_self, hw] at hz
-      refine (ih hφ ?_ ?_).mpr (hz ⟨w, w', rfl, rfl, hw'⟩)
+      refine (ih ?_ ?_).mpr (hz ⟨w, w', rfl, rfl, hw'⟩)
       · intro x
         rw [Function.update_of_ne (by simp), hind]
       · rw [Function.update_self]
   | all x φ ih =>
-    obtain ⟨a, hφ, rfl⟩ := Option.map_eq_some_iff.mp hψ
     let _S := K.corrStructure
-    rw [ModalFormula.realize_all, Formula.realize_all₁]
+    rw [ModalFormula.realize_all,
+      show (ModalFormula.all x φ).st k = Formula.all₁ (Sum.inl x)
+        ((corrIndiv.formula₁ (corrIndivVar x)).imp (φ.st k)) from rfl,
+      Formula.realize_all₁]
     constructor
     · intro h z
       rw [Formula.realize_imp, Formula.realize_rel₁]
@@ -392,35 +307,41 @@ theorem realize_st? (K : KripkeModel (monadicWithConstants Const Pred) W M)
         simpa [corrStructure_relMap_indiv] using hsort
       rw [Function.update_self] at hd
       subst hd
-      exact (ih hφ (sorted_update hind x d) (pinned_update hw x _)).mp (h d)
+      exact (ih (sorted_update hind x d) (pinned_update hw x _)).mp (h d)
     · intro h d
       have hz := h (Sum.inr d)
       rw [Formula.realize_imp, Formula.realize_rel₁] at hz
-      refine (ih hφ (sorted_update hind x d) (pinned_update hw x _)).mpr
+      refine (ih (sorted_update hind x d) (pinned_update hw x _)).mpr
         (hz ⟨d, ?_⟩)
       show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
       rw [Function.update_self]
-  | ex x φ ih =>
-    obtain ⟨a, hφ, rfl⟩ := Option.map_eq_some_iff.mp hψ
-    let _S := K.corrStructure
-    rw [ModalFormula.realize_ex, Formula.realize_ex₁]
-    constructor
-    · rintro ⟨d, hd⟩
-      refine ⟨Sum.inr d, ?_⟩
-      rw [Formula.realize_inf, Formula.realize_rel₁]
-      refine ⟨⟨d, ?_⟩,
-        (ih hφ (sorted_update hind x d) (pinned_update hw x _)).mp hd⟩
-      show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
-      rw [Function.update_self]
-    · rintro ⟨z, hz⟩
-      rw [Formula.realize_inf, Formula.realize_rel₁] at hz
-      obtain ⟨hsort, hreal⟩ := hz
-      obtain ⟨d, hd⟩ : ∃ d : M,
-          Function.update val (Sum.inl x) z (Sum.inl x) = Sum.inr d := by
-        simpa [corrStructure_relMap_indiv] using hsort
-      rw [Function.update_self] at hd
-      subst hd
-      exact ⟨d, (ih hφ (sorted_update hind x d) (pinned_update hw x _)).mpr hreal⟩
+  | @rel l R ts =>
+    match l, R with
+    | 0, Sum.inl r => exact r.elim
+    | 0, Sum.inr r => exact r.elim
+    | (n + 2), Sum.inl r => exact r.elim
+    | (n + 2), Sum.inr r => exact r.elim
+    | 1, Sum.inr r => exact r.elim
+    | 1, Sum.inl (P : Pred) =>
+      let _S := K.corrStructure
+      rw [show (ModalFormula.rel (Sum.inl P : (monadicWithConstants Const
+            Pred).Relations 1) ts).st k =
+          (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0)) from rfl,
+        Formula.realize_rel₂, corrStructure_relMap_rel,
+        ModalFormula.realize_rel,
+        show (fun i => letI := K.interp w; ((ts i).realize v)) =
+          fun _ => (letI := K.interp w; (ts 0).realize v) from
+          funext fun i => by rw [Subsingleton.elim i 0] ]
+      constructor
+      · intro h
+        exact ⟨w, (letI := K.interp w; (ts 0).realize v), by simpa using hw,
+          realize_stTerm K hind hw (ts 0), h⟩
+      · rintro ⟨w', d, hw', hd, h⟩
+        obtain rfl : w = w' := Sum.inl.inj ((by simpa using hw : (corrWorldVar
+          (Const := Const) (Pred := Pred) k).realize val = Sum.inl w).symm.trans hw')
+        obtain rfl : (letI := K.interp w; (ts 0).realize v) = d :=
+          Sum.inr.inj ((realize_stTerm K hind hw (ts 0)).symm.trans hd)
+        exact h
 
 /-! ### Sort-guarded sentence closure -/
 

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.ModelTheory.FiniteModel
-import Linglib.Logic.Modal.FirstOrder.Kripke
+import Linglib.Logic.Modal.FirstOrder.Semantics
 
 /-!
 # World-relative denotations over the monadic signature
@@ -30,5 +30,25 @@ def KripkeModel.constInterp
     (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
     (c : Const) (w : W) : Domain :=
   (K.interp w).funMap (monadicConst c) default
+
+/-- Realization of a monadic atom: the predicate denotation at the world,
+    of the term's value. -/
+@[simp] theorem ModalFormula.realize_monadicRel {α : Type*} [DecidableEq α]
+    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+    (w : W) (v : α → Domain) (P : Pred)
+    (t : (monadicWithConstants Const Pred).Term α) :
+    ((monadicRel P).modalFormula₁ t).Realize K w v ↔
+      K.predInterp P w (letI := K.interp w; t.realize v) := by
+  rw [Relations.modalFormula₁, ModalFormula.realize_rel]
+  exact iff_of_eq (congrArg _ (funext fun i => by rw [Subsingleton.elim i 0, Matrix.cons_val_zero]))
+
+/-- A constant term's value at a world is its `constInterp` denotation. -/
+theorem realize_monadicConst {α : Type*}
+    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+    (w : W) (v : α → Domain) (c : Const) :
+    (letI := K.interp w;
+      (Constants.term (monadicConst (Pred := Pred) c)).realize v) =
+      K.constInterp c w :=
+  congrArg _ (funext fun i => i.elim0)
 
 end FirstOrder.Language

--- a/Linglib/Logic/Modal/FirstOrder/Semantics.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Semantics.lean
@@ -1,24 +1,24 @@
 import Mathlib.ModelTheory.Semantics
 import Linglib.Core.ModelTheory.StructureFamily
+import Linglib.Logic.Modal.FirstOrder.Syntax
 
 /-!
-# Constant-domain first-order Kripke models and modal formulas
+# Constant-domain Kripke semantics
 
 `[UPSTREAM]` candidates for `Mathlib/ModelTheory`, which is classical: one
 structure, no accessibility. A `KripkeModel L W M` is a `W`-indexed
 family of `L`-structures on a constant domain `M` together with
-`Finset`-valued accessibility; `ModalFormula L α` layers `□` and named
-quantifiers over embedded classical `L.Formula`s, and
-`ModalFormula.Realize` is Kripke satisfaction `K, w ⊨_v φ`.
+`Finset`-valued accessibility; `ModalFormula L α` is the quantified modal
+language in `BoundedFormula`'s basis, and `ModalFormula.Realize` is
+Kripke satisfaction `K, w ⊨_v φ`.
 
 ## Main declarations
 
 * `KripkeModel` — accessibility plus a world-indexed family of
   first-order structures on a constant domain (classical satisfaction at an
   index is `Core/ModelTheory/StructureFamily.lean`'s `Formula.RealizeAt`).
-* `ModalFormula`, `ModalFormula.Realize` — modal formulas over embedded
-  classical formulas, and Kripke satisfaction; `ModalFormula.dia` is the
-  derived `◇ := ¬□¬`.
+* `ModalFormula.Realize` — Kripke satisfaction for the modal language of
+  `Syntax.lean`, with the `realize_*` simp set and the Barcan laws.
 
 ## Implementation notes
 
@@ -28,9 +28,7 @@ quantifiers over embedded classical `L.Formula`s, and
 * `ModalFormula` quantifiers bind **named** variables with
   `Function.update` semantics (the `Formula.all₁` / `ex₁` convention of
   `Core/ModelTheory/Binders.lean`), not de Bruijn indices: the modal
-  layer's consumers carry named variables, and the embedding of classical
-  formulas via `ofFormula` makes satisfaction commute by construction
-  (`ModalFormula.realize_ofFormula` is `Iff.rfl`).
+  layer's consumers carry named variables.
 -/
 
 namespace FirstOrder.Language
@@ -46,86 +44,76 @@ structure KripkeModel (L : Language) (W M : Type*) where
   /-- World-indexed interpretation of the signature. -/
   interp : W → L.Structure M
 
-/-- Modal formulas over `L` with named free variables `α`: classical
-    `L.Formula`s embedded wholesale via `ofFormula`, closed under the
-    connectives, `□`, and named quantifiers (`◇` is derived —
-    `ModalFormula.dia`). -/
-inductive ModalFormula (L : Language) (α : Type*) where
-  /-- An embedded classical (modal-free) formula. -/
-  | ofFormula : L.Formula α → ModalFormula L α
-  /-- Negation. -/
-  | not : ModalFormula L α → ModalFormula L α
-  /-- Conjunction. -/
-  | inf : ModalFormula L α → ModalFormula L α → ModalFormula L α
-  /-- Disjunction. -/
-  | sup : ModalFormula L α → ModalFormula L α → ModalFormula L α
-  /-- Necessity. -/
-  | box : ModalFormula L α → ModalFormula L α
-  /-- Universal quantification of a named variable. -/
-  | all : α → ModalFormula L α → ModalFormula L α
-  /-- Existential quantification of a named variable. -/
-  | ex : α → ModalFormula L α → ModalFormula L α
-
 namespace ModalFormula
-
-/-- Possibility, derived: `◇φ := ¬□¬φ`. -/
-def dia (φ : ModalFormula L α) : ModalFormula L α :=
-  .not (.box (.not φ))
 
 variable [DecidableEq α]
 
-/-- Kripke satisfaction `K, w ⊨_v φ`: classical formulas evaluate at the
-    world's structure, `□` quantifies over accessible worlds, and named
+/-- Kripke satisfaction `K, w ⊨_v φ`: atoms evaluate at the world's
+    structure, `□` quantifies over accessible worlds, and named
     quantifiers update the valuation. -/
 def Realize (K : KripkeModel L W M) :
     W → ModalFormula L α → (α → M) → Prop
-  | w, .ofFormula ψ, v => ψ.RealizeAt K.interp w v
-  | w, .not φ, v => ¬ Realize K w φ v
-  | w, .inf φ ψ, v => Realize K w φ v ∧ Realize K w ψ v
-  | w, .sup φ ψ, v => Realize K w φ v ∨ Realize K w ψ v
+  | w, .equal t₁ t₂, v => letI := K.interp w; t₁.realize v = t₂.realize v
+  | w, .rel R ts, v =>
+      letI := K.interp w; Structure.RelMap R fun i => (ts i).realize v
+  | _, .falsum, _ => False
+  | w, .imp φ ψ, v => Realize K w φ v → Realize K w ψ v
   | w, .box φ, v => ∀ w' ∈ K.access w, Realize K w' φ v
   | w, .all x φ, v => ∀ d : M, Realize K w φ (Function.update v x d)
-  | w, .ex x φ, v => ∃ d : M, Realize K w φ (Function.update v x d)
 
 variable (K : KripkeModel L W M) (w : W) (v : α → M)
 
-/-- Embedded classical formulas realize classically — by construction. -/
-@[simp] theorem realize_ofFormula (ψ : L.Formula α) :
-    (ofFormula ψ : ModalFormula L α).Realize K w v ↔ ψ.RealizeAt K.interp w v :=
+@[simp] theorem realize_equal (t₁ t₂ : L.Term α) :
+    (equal t₁ t₂).Realize K w v ↔
+      (letI := K.interp w; t₁.realize v = t₂.realize v) :=
+  Iff.rfl
+
+@[simp] theorem realize_rel {n : ℕ} (R : L.Relations n) (ts : Fin n → L.Term α) :
+    (rel R ts).Realize K w v ↔
+      (letI := K.interp w; Structure.RelMap R fun i => (ts i).realize v) :=
+  Iff.rfl
+
+@[simp] theorem realize_bot :
+    (⊥ : ModalFormula L α).Realize K w v ↔ False :=
+  Iff.rfl
+
+@[simp] theorem realize_imp (φ ψ : ModalFormula L α) :
+    (imp φ ψ).Realize K w v ↔ (φ.Realize K w v → ψ.Realize K w v) :=
   Iff.rfl
 
 @[simp] theorem realize_not (φ : ModalFormula L α) :
     (ModalFormula.not φ).Realize K w v ↔ ¬ φ.Realize K w v :=
   Iff.rfl
 
+@[simp] theorem realize_top :
+    (⊤ : ModalFormula L α).Realize K w v ↔ True := by
+  simp [Top.top]
+
 @[simp] theorem realize_inf (φ ψ : ModalFormula L α) :
-    (ModalFormula.inf φ ψ).Realize K w v ↔
-      φ.Realize K w v ∧ ψ.Realize K w v :=
-  Iff.rfl
+    (φ ⊓ ψ).Realize K w v ↔ φ.Realize K w v ∧ ψ.Realize K w v := by
+  simp [Min.min]
 
 @[simp] theorem realize_sup (φ ψ : ModalFormula L α) :
-    (ModalFormula.sup φ ψ).Realize K w v ↔
-      φ.Realize K w v ∨ ψ.Realize K w v :=
-  Iff.rfl
+    (φ ⊔ ψ).Realize K w v ↔ φ.Realize K w v ∨ ψ.Realize K w v := by
+  simp [Max.max, imp_iff_not_or]
 
 @[simp] theorem realize_box (φ : ModalFormula L α) :
-    (ModalFormula.box φ).Realize K w v ↔
-      ∀ w' ∈ K.access w, φ.Realize K w' v :=
+    (box φ).Realize K w v ↔ ∀ w' ∈ K.access w, φ.Realize K w' v :=
   Iff.rfl
 
 @[simp] theorem realize_all (x : α) (φ : ModalFormula L α) :
-    (ModalFormula.all x φ).Realize K w v ↔
+    (all x φ).Realize K w v ↔
       ∀ d : M, φ.Realize K w (Function.update v x d) :=
   Iff.rfl
 
 @[simp] theorem realize_ex (x : α) (φ : ModalFormula L α) :
     (ModalFormula.ex x φ).Realize K w v ↔
-      ∃ d : M, φ.Realize K w (Function.update v x d) :=
-  Iff.rfl
+      ∃ d : M, φ.Realize K w (Function.update v x d) := by
+  simp [ModalFormula.ex, not_forall]
 
 @[simp] theorem realize_dia (φ : ModalFormula L α) :
     (dia φ).Realize K w v ↔ ∃ w' ∈ K.access w, φ.Realize K w' v := by
-  simp only [dia, realize_not, realize_box, not_forall, not_not, exists_prop]
+  simp [dia, not_forall]
 
 /-! ### The Barcan laws
 

--- a/Linglib/Logic/Modal/FirstOrder/Syntax.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Syntax.lean
@@ -1,0 +1,72 @@
+import Mathlib.ModelTheory.Syntax
+
+/-!
+# The quantified modal language
+
+`ModalFormula L α`: modal formulas over `L` with named free variables `α`,
+in mathlib's `BoundedFormula` basis — atomic `equal`/`rel`, `falsum`,
+`imp` — plus `□` and named universal quantification, with `∼`, `⊤`, `⊓`,
+`⊔`, `ex`, and `dia` derived exactly as for `BoundedFormula`.
+`[UPSTREAM]` candidate for `Mathlib/ModelTheory`.
+-/
+
+namespace FirstOrder.Language
+
+variable {L : Language} {α : Type*}
+
+/-- Modal formulas over `L` with named free variables `α`: mathlib's
+    `BoundedFormula` basis — atomic `equal`/`rel`, `falsum`, `imp` — plus
+    `□` and named quantification; `∼`, `⊤`, `⊓`, `⊔`, `ex`, and `dia` are
+    derived exactly as for `BoundedFormula`. -/
+inductive ModalFormula (L : Language) (α : Type*) where
+  /-- The proposition that two terms are equal. -/
+  | equal (t₁ t₂ : L.Term α) : ModalFormula L α
+  /-- A relation symbol applied to terms. -/
+  | rel {n : ℕ} (R : L.Relations n) (ts : Fin n → L.Term α) : ModalFormula L α
+  /-- The contradiction. -/
+  | falsum : ModalFormula L α
+  /-- Implication. -/
+  | imp (φ ψ : ModalFormula L α) : ModalFormula L α
+  /-- Necessity. -/
+  | box (φ : ModalFormula L α) : ModalFormula L α
+  /-- Universal quantification of a named variable. -/
+  | all (x : α) (φ : ModalFormula L α) : ModalFormula L α
+
+namespace ModalFormula
+
+instance : Inhabited (ModalFormula L α) := ⟨falsum⟩
+
+instance : Bot (ModalFormula L α) := ⟨falsum⟩
+
+/-- The negation of a modal formula. -/
+@[match_pattern]
+protected def not (φ : ModalFormula L α) : ModalFormula L α := φ.imp ⊥
+
+instance : Top (ModalFormula L α) := ⟨ModalFormula.not ⊥⟩
+
+instance : Min (ModalFormula L α) := ⟨fun φ ψ => (φ.imp ψ.not).not⟩
+
+instance : Max (ModalFormula L α) := ⟨fun φ ψ => φ.not.imp ψ⟩
+
+/-- Existential quantification of a named variable, derived: `∃x := ∼∀x∼`. -/
+@[match_pattern]
+protected def ex (x : α) (φ : ModalFormula L α) : ModalFormula L α :=
+  (all x φ.not).not
+
+/-- Possibility, derived: `◇φ := ∼□∼φ` — to `box` what `ex` is to `all`. -/
+@[match_pattern]
+def dia (φ : ModalFormula L α) : ModalFormula L α := (box φ.not).not
+
+end ModalFormula
+
+/-- Applies a relation symbol to terms as a modal formula. -/
+abbrev Relations.modalFormula {n : ℕ} (R : L.Relations n)
+    (ts : Fin n → L.Term α) : ModalFormula L α :=
+  ModalFormula.rel R ts
+
+/-- Applies a unary relation symbol to a term as a modal formula. -/
+abbrev Relations.modalFormula₁ (R : L.Relations 1) (t : L.Term α) :
+    ModalFormula L α :=
+  ModalFormula.rel R ![t]
+
+end FirstOrder.Language

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -36,35 +36,33 @@ variable [DecidableEq Domain] [Fintype Domain]
 theorem support_singleton_iff_st (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var} {k : ℕ}
-    {ψ : (Language.correspondence Const Pred).Formula (Var ⊕ ℕ)}
-    (hτ : φ.toModal? = some τ) (hψ : τ.st? k = some ψ)
+    (hτ : φ.toModal? = some τ)
     {i : Index W Var Domain} {v : Var → Domain} (u : ℕ → W)
     (hv : ∀ y, i.assign y = some (v y)) (hu : u k = i.world) :
     support M φ {i} ↔
       (letI := M.corrStructure
-       ψ.Realize (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u))) :=
+       (τ.st k).Realize (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u))) :=
   (support_singleton_iff_realize M hτ hv).trans
-    (realize_st? M hψ (fun _ => rfl) (by rw [Sum.elim_inr, Function.comp_apply, hu]))
+    (realize_st M (fun _ => rfl) (by rw [Sum.elim_inr, Function.comp_apply, hu]))
 
 /-- Support at a singleton state forces the closed standard translation,
     as a sentence of `corrStructure`. -/
 theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var}
-    {ψ : (Language.correspondence Const Pred).Formula (Var ⊕ ℕ)}
-    (hτ : φ.toModal? = some τ) (hψ : τ.st? 0 = some ψ)
-    (hcl : (stClose 0 ψ).freeVarFinset = ∅)
+    (hτ : φ.toModal? = some τ)
+    (hcl : (stClose 0 (τ.st 0)).freeVarFinset = ∅)
     {i : Index W Var Domain} {v : Var → Domain}
     (hv : ∀ y, i.assign y = some (v y)) (hsupp : support M φ {i}) :
     (letI := M.corrStructure
-     (W ⊕ Domain) ⊨ (stClose 0 ψ).toSentence hcl) := by
+     (W ⊕ Domain) ⊨ (stClose 0 (τ.st 0)).toSentence hcl) := by
   let _S := M.corrStructure
-  have h1 : ψ.Realize
+  have h1 : (τ.st 0).Realize
       (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world))) :=
-    (support_singleton_iff_st M hτ hψ (fun _ => i.world) hv rfl).mp hsupp
+    (support_singleton_iff_st M hτ (fun _ => i.world) hv rfl).mp hsupp
   refine (Formula.realize_toSentence _ hcl
     (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world)))).mpr ?_
-  refine (realize_stClose M 0 ψ _).mpr ⟨i.world, ?_⟩
+  refine (realize_stClose M 0 (τ.st 0) _).mpr ⟨i.world, ?_⟩
   rw [show Function.update
       (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world)))
       (Sum.inr 0) (Sum.inl i.world)
@@ -78,25 +76,24 @@ theorem exists_support_of_models_toSentence [Nonempty Domain]
     (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var}
-    {ψ : (Language.correspondence Const Pred).Formula (Var ⊕ ℕ)}
-    (hτ : φ.toModal? = some τ) (hψ : τ.st? 0 = some ψ)
-    (hcl : (stClose 0 ψ).freeVarFinset = ∅)
+    (hτ : φ.toModal? = some τ)
+    (hcl : (stClose 0 (τ.st 0)).freeVarFinset = ∅)
     (h : letI := M.corrStructure
-         (W ⊕ Domain) ⊨ (stClose 0 ψ).toSentence hcl) :
+         (W ⊕ Domain) ⊨ (stClose 0 (τ.st 0)).toSentence hcl) :
     ∃ (i : Index W Var Domain) (v : Var → Domain),
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
   let _S := M.corrStructure
   obtain ⟨d₀⟩ := ‹Nonempty Domain›
-  have h0 : (stClose 0 ψ).Realize
+  have h0 : (stClose 0 (τ.st 0)).Realize
       (fun _ => (Sum.inr d₀ : W ⊕ Domain)) :=
     (Formula.realize_toSentence _ hcl _).mp h
-  obtain ⟨w, hw⟩ := (realize_stClose M 0 ψ _).mp h0
+  obtain ⟨w, hw⟩ := (realize_stClose M 0 (τ.st 0) _).mp h0
   have hsorted : ∀ x : Var, Function.update
       (fun _ : Var ⊕ ℕ => (Sum.inr d₀ : W ⊕ Domain)) (Sum.inr 0)
       (Sum.inl w) (Sum.inl x) = Sum.inr d₀ := fun x => by
     rw [Function.update_of_ne (by simp)]
   have hmodal : τ.Realize M w (fun _ => d₀) :=
-    (realize_st? M hψ hsorted (Function.update_self _ _ _)).mpr hw
+    (realize_st M hsorted (Function.update_self _ _ _)).mpr hw
   exact ⟨⟨w, fun _ => some d₀⟩, fun _ => d₀, fun _ => rfl,
     (support_singleton_iff_realize M hτ fun _ => rfl).mpr hmodal⟩
 
@@ -120,17 +117,15 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
     {Const : Type u} {Pred : Type v} {ι : Type*}
     {φs : ι → Formula Var Const Pred}
     {τs : ι → ModalFormula (Language.monadicWithConstants Const Pred) Var}
-    {ψs : ι → (Language.correspondence Const Pred).Formula (Var ⊕ ℕ)}
     (hτ : ∀ i, (φs i).toModal? = some (τs i))
-    (hψ : ∀ i, (τs i).st? 0 = some (ψs i))
-    (hcl : ∀ i, (stClose 0 (ψs i)).freeVarFinset = ∅)
+    (hcl : ∀ i, (stClose 0 ((τs i).st 0)).freeVarFinset = ∅)
     (hfin : ∀ s : Finset ι, ∃ (W Domain : Type max u v)
       (_ : DecidableEq W) (_ : DecidableEq Domain) (_ : Fintype Domain)
       (M : Model W Domain Const Pred) (i : Index W Var Domain)
       (v : Var → Domain), (∀ y, i.assign y = some (v y)) ∧
         ∀ j ∈ s, support M (φs j) {i}) :
     Theory.IsSatisfiable
-      (Set.range fun i => (stClose 0 (ψs i)).toSentence (hcl i)) := by
+      (Set.range fun i => (stClose 0 ((τs i).st 0)).toSentence (hcl i)) := by
   rw [Theory.isSatisfiable_iff_isFinitelySatisfiable]
   intro T₀ hT₀
   classical
@@ -141,9 +136,9 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
   have : (W ⊕ Domain) ⊨ (T₀ : (Language.correspondence Const Pred).Theory) := by
     refine ⟨fun σ hσ => ?_⟩
     obtain ⟨x, rfl⟩ : ∃ x : T₀,
-        (stClose 0 (ψs (f x))).toSentence (hcl (f x)) = σ :=
+        (stClose 0 ((τs (f x)).st 0)).toSentence (hcl (f x)) = σ :=
       ⟨⟨σ, hσ⟩, hf ⟨σ, hσ⟩⟩
-    exact models_toSentence_of_support M (hτ (f x)) (hψ (f x)) (hcl (f x))
+    exact models_toSentence_of_support M (hτ (f x)) (hcl (f x))
       hv (hs (f x) (Finset.mem_image_of_mem f (Finset.mem_univ x)))
   exact Theory.Model.isSatisfiable (W ⊕ Domain)
 

--- a/Linglib/Logic/Team/QBSML/Defs.lean
+++ b/Linglib/Logic/Team/QBSML/Defs.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Finset.Union
 import Mathlib.Data.Fintype.Basic
 import Linglib.Logic.Assignment
-import Linglib.Logic.Modal.FirstOrder.Kripke
+import Linglib.Logic.Modal.FirstOrder.Semantics
 import Linglib.Logic.Modal.FirstOrder.Monadic
 import Linglib.Logic.Team.Algebra
 import Linglib.Logic.Bilateral.Defs

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -29,7 +29,7 @@ empty-team support, hence flat support, via the same
   is mathlib `Formula.Realize` at every index.
 * `Formula.toModal?`, `support_iff_forall_realize` — the **full**
   Proposition 4.1: the NE-free fragment (modals included) translates into
-  `ModalFormula` over `Logic/Modal/FirstOrder/Kripke.lean`, and support is
+  `ModalFormula` over `Logic/Modal/FirstOrder/Semantics.lean`, and support is
   Kripke satisfaction at every index; the translation is total on exactly
   the NE-free fragment (`exists_toModal?_of_neFree`).
 * `eval_mapAtoms_iff` — atom-substitution congruence: an atom map with
@@ -1007,7 +1007,7 @@ theorem support_iff_forall_realizeAt (M : Model W Domain Const Pred)
 The complete [aloni-vanormondt-2023] Proposition 4.1: `Formula.toModal?`
 translates the **whole NE-free fragment** — modals included — into
 `ModalFormula` over the monadic signature
-(`Logic/Modal/FirstOrder/Kripke.lean`), and support is Kripke satisfaction at
+(`Logic/Modal/FirstOrder/Semantics.lean`), and support is Kripke satisfaction at
 every index. The translation is total on exactly the NE-free fragment. -/
 
 /-- Translate QBSML into modal formulas over the monadic signature: atoms
@@ -1016,16 +1016,15 @@ every index. The translation is total on exactly the NE-free fragment. -/
 def Formula.toModal? :
     Formula Var Const Pred →
       Option (ModalFormula (Language.monadicWithConstants Const Pred) Var)
-  | .pred P x => some (.ofFormula ((monadicRel P).formula₁ (Term.var x)))
+  | .pred P x => some ((monadicRel P).modalFormula₁ (Term.var x))
   | .predc P c =>
-      some (.ofFormula ((monadicRel P).formula₁
-        (Constants.term (monadicConst c))))
+      some ((monadicRel P).modalFormula₁ (Constants.term (monadicConst c)))
   | .ne => none
   | .neg φ => φ.toModal?.map .not
   | .conj φ ψ =>
-      φ.toModal?.bind fun α => ψ.toModal?.map (ModalFormula.inf α ·)
+      φ.toModal?.bind fun α => ψ.toModal?.map (α ⊓ ·)
   | .disj φ ψ =>
-      φ.toModal?.bind fun α => ψ.toModal?.map (ModalFormula.sup α ·)
+      φ.toModal?.bind fun α => ψ.toModal?.map (α ⊔ ·)
   | .poss φ => φ.toModal?.map ModalFormula.dia
   | .exi x φ => φ.toModal?.map (ModalFormula.ex x ·)
   | .univ x φ => φ.toModal?.map (ModalFormula.all x ·)
@@ -1095,11 +1094,11 @@ theorem exists_toModal?_of_neFree :
   | conj _ _ ih₁ ih₂ =>
     obtain ⟨τ₁, hτ₁⟩ := ih₁
     obtain ⟨τ₂, hτ₂⟩ := ih₂
-    exact ⟨.inf τ₁ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
+    exact ⟨τ₁ ⊓ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
   | disj _ _ ih₁ ih₂ =>
     obtain ⟨τ₁, hτ₁⟩ := ih₁
     obtain ⟨τ₂, hτ₂⟩ := ih₂
-    exact ⟨.sup τ₁ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
+    exact ⟨τ₁ ⊔ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
   | poss _ ih =>
     obtain ⟨τ, hτ⟩ := ih
     exact ⟨τ.dia, by simp [Formula.toModal?, hτ]⟩
@@ -1129,10 +1128,11 @@ private theorem support_and_antiSupport_singleton_realize
   | pred P x =>
     intro τ hτ i v hv
     rw [show (Formula.pred P x).toModal? =
-        some (.ofFormula ((monadicRel P).formula₁ (Term.var x))) from rfl,
+        some ((monadicRel P).modalFormula₁ (Term.var x)) from rfl,
       Option.some.injEq] at hτ
     subst hτ
-    rw [ModalFormula.realize_ofFormula, KripkeModel.realizeAt_rel₁]
+    let _I := M.interp i.world
+    rw [ModalFormula.realize_monadicRel, Term.realize_var]
     constructor
     · constructor
       · intro h
@@ -1156,11 +1156,11 @@ private theorem support_and_antiSupport_singleton_realize
   | predc P c =>
     intro τ hτ i v hv
     rw [show (Formula.predc P c).toModal? =
-        some (.ofFormula ((monadicRel P).formula₁
-          (Constants.term (monadicConst c)))) from rfl,
+        some ((monadicRel P).modalFormula₁
+          (Constants.term (monadicConst c))) from rfl,
       Option.some.injEq] at hτ
     subst hτ
-    rw [ModalFormula.realize_ofFormula, KripkeModel.realizeAt_rel₁_const]
+    rw [ModalFormula.realize_monadicRel, realize_monadicConst]
     constructor
     · constructor
       · intro h

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -111,22 +111,23 @@ theorem support_possPxOrQx_iff
     support univAccessModel (.poss (.disj Px Qx)) s ↔
       ∀ i ∈ s,
         (ModalFormula.dia
-          (.sup (.ofFormula ((monadicRel Predicate.P).formula₁ (Term.var QVar.x)))
-            (.ofFormula
-              ((monadicRel Predicate.Q).formula₁ (Term.var QVar.x))))).Realize
+          ((monadicRel Predicate.P).modalFormula₁ (Term.var QVar.x) ⊔
+            (monadicRel Predicate.Q).modalFormula₁ (Term.var QVar.x))).Realize
           univAccessModel i.world (v i) :=
   support_iff_forall_realize univAccessModel rfl s v hv
 
-/-- The closed standard translation of `∀x(Px ∨ Qx)`: quantifiers
+/-- The modal image of `∀x(Px ∨ Qx)` under `toModal?`. -/
+def univPxOrQxModal :
+    ModalFormula (Language.monadicWithConstants FCAtom Predicate) QVar :=
+  ModalFormula.all QVar.x
+    ((monadicRel Predicate.P).modalFormula₁ (Term.var QVar.x) ⊔
+      (monadicRel Predicate.Q).modalFormula₁ (Term.var QVar.x))
+
+/-- The standard translation of `∀x(Px ∨ Qx)`, computed by `st`: quantifiers
     relativized to the individual sort, predicates world-relativized to the
     current-world variable `Sum.inr 0`. -/
 def stUnivPxOrQx : (Language.correspondence FCAtom Predicate).Formula (QVar ⊕ ℕ) :=
-  Formula.all₁ (Sum.inl QVar.x)
-    ((corrIndiv.formula₁ (Term.var (Sum.inl QVar.x))).imp
-      ((corrRel Predicate.P).formula₂ (Term.var (Sum.inr 0))
-          (Term.var (Sum.inl QVar.x)) ⊔
-        (corrRel Predicate.Q).formula₂ (Term.var (Sum.inr 0))
-          (Term.var (Sum.inl QVar.x))))
+  univPxOrQxModal.st 0
 
 /-- The closure is a genuine sentence: the compiler computes the
     free-variable finset. -/
@@ -144,15 +145,15 @@ local instance : (Language.correspondence FCAtom Predicate).Structure (TwoAtomWo
 /-- Truth of the standard-translation sentence in `univAccessModel.corrStructure`
     is support of `∀x(Px ∨ Qx)` at some singleton with a total assignment —
     the compactness-ready form of Proposition 4.1, every translation step
-    (`toModal?`, `st?`, the free-variable check) computed by the compiler. -/
+    (`toModal?`, `st`, the free-variable check) computed by the compiler. -/
 theorem models_stUnivPxOrQxSentence_iff :
     (TwoAtomWorld ⊕ FCAtom) ⊨ stUnivPxOrQxSentence ↔
       ∃ (i : Index TwoAtomWorld QVar FCAtom) (v : QVar → FCAtom),
         (∀ y, i.assign y = some (v y)) ∧ support univAccessModel univPxOrQx {i} :=
   haveI : Nonempty FCAtom := ⟨.a⟩
-  ⟨exists_support_of_models_toSentence univAccessModel rfl rfl stUnivPxOrQx_closed,
+  ⟨exists_support_of_models_toSentence univAccessModel (τ := univPxOrQxModal) rfl stUnivPxOrQx_closed,
     fun ⟨_, _, hv, h⟩ =>
-      models_toSentence_of_support univAccessModel rfl rfl stUnivPxOrQx_closed hv h⟩
+      models_toSentence_of_support univAccessModel (τ := univPxOrQxModal) rfl stUnivPxOrQx_closed hv h⟩
 
 /-! ### Frame conditions -/
 


### PR DESCRIPTION
Rebuilds the quantified modal language on mathlib's BoundedFormula scheme: primitives equal/rel/falsum/imp plus box and named all, with not, top, inf, sup, ex, and dia derived exactly as in ModelTheory/Syntax — replacing the ofFormula embedding of whole classical formulas, whose non-atomic atoms were the sole source of the standard translation's partiality. st? becomes total st (Option plumbing deleted end to end, through Compactness); the file splits into Syntax.lean/Semantics.lean on the ModelTheory naming pattern; monadic-atom realize lemmas land in Monadic.lean.