### PR TITLE
refactor(Logic/Modal/FirstOrder): KripkeModel is ModalStructure

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -16,7 +16,7 @@ preservation.
 ## Main declarations
 
 * `Language.correspondence` — the target signature;
-  `KripkeModel.corrStructure` — the `W ⊕ M` encoding of a Kripke
+  `ModalStructure.corrStructure` — the `W ⊕ M` encoding of a Kripke
   structure as one mathlib structure.
 * `ModalFormula.st?` — the standard translation, with the current world as
   the free variable `Sum.inr k` and box introducing the fresh world
@@ -95,8 +95,8 @@ abbrev corrWorldVar (k : ℕ) :
 /-- The `W ⊕ M` encoding of a Kripke model over the monadic signature
     as a single mathlib structure: worlds and individuals share the carrier,
     sorted by `corrIndiv`; relational guards make all off-sort atoms false. -/
-@[reducible] def KripkeModel.corrStructure
-    (K : KripkeModel (monadicWithConstants Const Pred) W M) :
+@[reducible] def ModalStructure.corrStructure
+    (K : ModalStructure (monadicWithConstants Const Pred) W M) :
     (correspondence Const Pred).Structure (W ⊕ M) where
   funMap := fun {n} f => match n, f with
     | 1, c => fun z => match z 0 with
@@ -114,26 +114,26 @@ abbrev corrWorldVar (k : ℕ) :
     | _ + 3, r => r.elim
 
 @[simp] theorem corrStructure_relMap_rel
-    (K : KripkeModel (monadicWithConstants Const Pred) W M)
+    (K : ModalStructure (monadicWithConstants Const Pred) W M)
     (P : Pred) (z : Fin 2 → W ⊕ M) :
     (K.corrStructure).RelMap (corrRel P) z ↔
       ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.predInterp P w d :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_acc (K : KripkeModel (monadicWithConstants Const Pred) W M)
+@[simp] theorem corrStructure_relMap_acc (K : ModalStructure (monadicWithConstants Const Pred) W M)
     (z : Fin 2 → W ⊕ M) :
     (K.corrStructure).RelMap (corrAcc (Const := Const)) z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
 @[simp] theorem corrStructure_relMap_indiv
-    (K : KripkeModel (monadicWithConstants Const Pred) W M)
+    (K : ModalStructure (monadicWithConstants Const Pred) W M)
     (z : Fin 1 → W ⊕ M) :
     (K.corrStructure).RelMap (corrIndiv (Const := Const)) z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
-theorem corrStructure_funMap_inl (K : KripkeModel (monadicWithConstants Const Pred) W M)
+theorem corrStructure_funMap_inl (K : ModalStructure (monadicWithConstants Const Pred) W M)
     (c : Const) (w : W) (z : Fin 1 → W ⊕ M) (hz : z 0 = Sum.inl w) :
     (K.corrStructure).funMap (corrConst (Pred := Pred) c) z =
       Sum.inr (K.constInterp c w) := by
@@ -189,7 +189,7 @@ omit [DecidableEq Var] in
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
     realization, via the world pinned at index `k`. -/
 private theorem realize_stTerm
-    (K : KripkeModel (monadicWithConstants Const Pred) W M)
+    (K : ModalStructure (monadicWithConstants Const Pred) W M)
     {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w)
@@ -241,7 +241,7 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
     `k + 1` leaves the pinned index untouched. -/
-theorem realize_st (K : KripkeModel (monadicWithConstants Const Pred) W M)
+theorem realize_st (K : ModalStructure (monadicWithConstants Const Pred) W M)
     {φ : ModalFormula (monadicWithConstants Const Pred) Var} {k : ℕ}
     {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
@@ -356,7 +356,7 @@ def stClose (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)) :
 
 /-- Over `corrStructure`, the guarded witness of `stClose` is exactly a
     world. -/
-theorem realize_stClose (K : KripkeModel (monadicWithConstants Const Pred) W M)
+theorem realize_stClose (K : ModalStructure (monadicWithConstants Const Pred) W M)
     (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ))
     (val : Var ⊕ ℕ → W ⊕ M) :
     (letI := K.corrStructure; (stClose k ψ).Realize val) ↔

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -20,21 +20,21 @@ variable {Const Pred Domain W : Type*}
 
 /-- The predicate denotation at a world, read off a Kripke model's
     world-indexed family via `Structure.RelMap`. -/
-def KripkeModel.predInterp
-    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+def ModalStructure.predInterp
+    (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (P : Pred) (w : W) (d : Domain) : Prop :=
   (K.interp w).RelMap (monadicRel P) (fun _ => d)
 
 /-- The constant denotation at a world, read off `Structure.funMap`. -/
-def KripkeModel.constInterp
-    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+def ModalStructure.constInterp
+    (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (c : Const) (w : W) : Domain :=
   (K.interp w).funMap (monadicConst c) default
 
 /-- Realization of a monadic atom: the predicate denotation at the world,
     of the term's value. -/
 @[simp] theorem ModalFormula.realize_monadicRel {α : Type*} [DecidableEq α]
-    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+    (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (w : W) (v : α → Domain) (P : Pred)
     (t : (monadicWithConstants Const Pred).Term α) :
     ((monadicRel P).modalFormula₁ t).Realize K w v ↔
@@ -44,7 +44,7 @@ def KripkeModel.constInterp
 
 /-- A constant term's value at a world is its `constInterp` denotation. -/
 theorem realize_monadicConst {α : Type*}
-    (K : KripkeModel (monadicWithConstants Const Pred) W Domain)
+    (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (w : W) (v : α → Domain) (c : Const) :
     (letI := K.interp w;
       (Constants.term (monadicConst (Pred := Pred) c)).realize v) =

--- a/Linglib/Logic/Modal/FirstOrder/Semantics.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Semantics.lean
@@ -6,15 +6,15 @@ import Linglib.Logic.Modal.FirstOrder.Syntax
 # Constant-domain Kripke semantics
 
 `[UPSTREAM]` candidates for `Mathlib/ModelTheory`, which is classical: one
-structure, no accessibility. A `KripkeModel L W M` is a `W`-indexed
-family of `L`-structures on a constant domain `M` together with
-`Finset`-valued accessibility; `ModalFormula L α` is the quantified modal
+structure, no accessibility. A `ModalStructure L W M` — the modal analogue
+of `L.Structure` — is a `W`-indexed family of `L`-structures on a constant
+domain `M` together with `Finset`-valued accessibility; `ModalFormula L α` is the quantified modal
 language in `BoundedFormula`'s basis, and `ModalFormula.Realize` is
 Kripke satisfaction `K, w ⊨_v φ`.
 
 ## Main declarations
 
-* `KripkeModel` — accessibility plus a world-indexed family of
+* `ModalStructure` — accessibility plus a world-indexed family of
   first-order structures on a constant domain (classical satisfaction at an
   index is `Core/ModelTheory/StructureFamily.lean`'s `Formula.RealizeAt`).
 * `ModalFormula.Realize` — Kripke satisfaction for the modal language of
@@ -35,10 +35,10 @@ namespace FirstOrder.Language
 
 variable {L : Language} {W M α : Type*}
 
-/-- A constant-domain first-order Kripke model: `Finset`-valued
-    accessibility plus a `W`-indexed family of `L`-structures on the
-    domain `M`. -/
-structure KripkeModel (L : Language) (W M : Type*) where
+/-- A structure for the quantified modal language — the model object of
+    constant-domain Kripke semantics: `Finset`-valued accessibility plus a
+    `W`-indexed family of `L`-structures on the domain `M`. -/
+structure ModalStructure (L : Language) (W M : Type*) where
   /-- Accessibility relation (per-world set of accessible worlds). -/
   access : W → Finset W
   /-- World-indexed interpretation of the signature. -/
@@ -51,7 +51,7 @@ variable [DecidableEq α]
 /-- Kripke satisfaction `K, w ⊨_v φ`: atoms evaluate at the world's
     structure, `□` quantifies over accessible worlds, and named
     quantifiers update the valuation. -/
-def Realize (K : KripkeModel L W M) :
+def Realize (K : ModalStructure L W M) :
     W → ModalFormula L α → (α → M) → Prop
   | w, .equal t₁ t₂, v => letI := K.interp w; t₁.realize v = t₂.realize v
   | w, .rel R ts, v =>
@@ -61,7 +61,7 @@ def Realize (K : KripkeModel L W M) :
   | w, .box φ, v => ∀ w' ∈ K.access w, Realize K w' φ v
   | w, .all x φ, v => ∀ d : M, Realize K w φ (Function.update v x d)
 
-variable (K : KripkeModel L W M) (w : W) (v : α → M)
+variable (K : ModalStructure L W M) (w : W) (v : α → M)
 
 @[simp] theorem realize_equal (t₁ t₂ : L.Term α) :
     (equal t₁ t₂).Realize K w v ↔

--- a/Linglib/Logic/Team/QBSML/Defs.lean
+++ b/Linglib/Logic/Team/QBSML/Defs.lean
@@ -25,10 +25,10 @@ by state non-emptiness.
 * `State.modalLift`: a set of worlds, paired with one assignment.
 * `Formula`: the formula language; `Formula.nec` is the derived `□`;
   `Formula.NEFree` the NE-free fragment.
-* `Model`, `Model.ofMonadic`: models, as `KripkeModel`s over
+* `Model`, `Model.ofMonadic`: models, as `ModalStructure`s over
   `Language.monadicWithConstants`.
 * `eval`, `support`, `antiSupport`: bilateral evaluation.
-* `KripkeModel.IsStateBased`, `KripkeModel.IsIndisputable`: frame
+* `ModalStructure.IsStateBased`, `ModalStructure.IsIndisputable`: frame
   conditions via `s↓`.
 
 ## Implementation notes
@@ -405,11 +405,11 @@ theorem Formula.NEFree.mapAtoms
     `M = ⟨W, D, R, I⟩`) **is** a constant-domain first-order Kripke
     structure over the monadic signature with constants: accessibility `R`
     plus the world-indexed interpretation `I`, carried as a family of
-    mathlib structures (`FirstOrder.Language.KripkeModel`) — true by
+    mathlib structures (`FirstOrder.Language.ModalStructure`) — true by
     construction, not by bridge. -/
 abbrev Model (W : Type*) (Domain : Type*) (Const : Type*)
     (Pred : Type*) :=
-  FirstOrder.Language.KripkeModel
+  FirstOrder.Language.ModalStructure
     (Language.monadicWithConstants Const Pred) W Domain
 
 /-- The QBSML model with accessibility `access`, constant interpretation
@@ -514,25 +514,25 @@ variable [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain]
     ([aloni-vanormondt-2023] Definition 4.10). Defined via
     `Team.IsStateBased` applied to `State.worldProj s`, sharing
     BSML's frame-condition substrate. -/
-def _root_.FirstOrder.Language.KripkeModel.IsStateBased
+def _root_.FirstOrder.Language.ModalStructure.IsStateBased
     (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsStateBased M.access (State.worldProj s)
 
 /-- `R` is indisputable on `(M, s)`: all worlds in `s↓` see the same
     accessible set ([aloni-vanormondt-2023] Definition 4.10). -/
-def _root_.FirstOrder.Language.KripkeModel.IsIndisputable
+def _root_.FirstOrder.Language.ModalStructure.IsIndisputable
     (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Prop :=
   Team.IsIndisputable M.access (State.worldProj s)
 
 instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsStateBased s) := by
-  unfold FirstOrder.Language.KripkeModel.IsStateBased; infer_instance
+  unfold FirstOrder.Language.ModalStructure.IsStateBased; infer_instance
 
 instance [Fintype W] (M : Model W Domain Const Pred)
     (s : Finset (Index W Var Domain)) : Decidable (M.IsIndisputable s) := by
-  unfold FirstOrder.Language.KripkeModel.IsIndisputable; infer_instance
+  unfold FirstOrder.Language.ModalStructure.IsIndisputable; infer_instance
 
 end FrameConditions
 

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -624,7 +624,7 @@ bridge: their right-hand side is classical *modal* logic, which mathlib's
 open FirstOrder Language
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem _root_.FirstOrder.Language.KripkeModel.realizeAt_rel₁
+@[simp] theorem _root_.FirstOrder.Language.ModalStructure.realizeAt_rel₁
     (M : Model W Domain Const Pred)
     (P : Pred) (x : Var) (w : W) (v : Var → Domain) :
     ((monadicRel P).formula₁ (Term.var x)).RealizeAt M.interp w v ↔
@@ -638,7 +638,7 @@ omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Finty
   exact Iff.rfl
 
 omit [DecidableEq W] [DecidableEq Var] [Fintype Var] [DecidableEq Domain] [Fintype Domain] in
-@[simp] theorem _root_.FirstOrder.Language.KripkeModel.realizeAt_rel₁_const
+@[simp] theorem _root_.FirstOrder.Language.ModalStructure.realizeAt_rel₁_const
     (M : Model W Domain Const Pred) (P : Pred) (c : Const) (w : W)
     (v : Var → Domain) :
     ((monadicRel P).formula₁
@@ -749,7 +749,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         some ((monadicRel P).formula₁ (Term.var x)) from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [KripkeModel.realizeAt_rel₁]
+    rw [ModalStructure.realizeAt_rel₁]
     constructor
     · constructor
       · intro h
@@ -777,7 +777,7 @@ private theorem support_and_antiSupport_singleton_realizeAt
         from rfl,
       Option.some.injEq] at hψ
     subst hψ
-    rw [KripkeModel.realizeAt_rel₁_const]
+    rw [ModalStructure.realizeAt_rel₁_const]
     constructor
     · constructor
       · intro h

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -33,7 +33,7 @@ whole-formula claims; the Fact 4 countermodel is proved by hand, with
 `decide` confined to finite side conditions. The propositional facts (3, 7,
 8, 10) are stated with the individual constants of the paper's
 Definition 4.1 (`Formula.predc` atoms, world-relative
-`KripkeModel.constInterp`), the quantified facts with variable atoms — both
+`ModalStructure.constInterp`), the quantified facts with variable atoms — both
 as in the paper. Atoms and worlds come from
 `Logic/Team/BSML/Scenarios.lean`, so this file and `Studies/Aloni2022.lean`
 target the same world space.


### PR DESCRIPTION
Neutral, register-correct name for the first-order carrier: it is the interpreting object for ModalFormula — a structure in ModelTheory's sense (Model there means Theory.Model), completing the parallel Formula : Structure :: ModalFormula : ModalStructure. BdRV themselves avoid the eponym; Kripke stays in the prose. The propositional ModalLogic.KripkeModel is untouched.