### PR TITLE
style(Logic/Modal/FirstOrder): dia is diamond

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Semantics.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Semantics.lean
@@ -112,8 +112,8 @@ variable (K : ModalStructure L W M) (w : W) (v : α → M)
   simp [ModalFormula.ex, not_forall]
 
 @[simp] theorem realize_dia (φ : ModalFormula L α) :
-    (dia φ).Realize K w v ↔ ∃ w' ∈ K.access w, φ.Realize K w' v := by
-  simp [dia, not_forall]
+    (diamond φ).Realize K w v ↔ ∃ w' ∈ K.access w, φ.Realize K w' v := by
+  simp [diamond, not_forall]
 
 /-! ### The Barcan laws
 

--- a/Linglib/Logic/Modal/FirstOrder/Syntax.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Syntax.lean
@@ -6,7 +6,7 @@ import Mathlib.ModelTheory.Syntax
 `ModalFormula L α`: modal formulas over `L` with named free variables `α`,
 in mathlib's `BoundedFormula` basis — atomic `equal`/`rel`, `falsum`,
 `imp` — plus `□` and named universal quantification, with `∼`, `⊤`, `⊓`,
-`⊔`, `ex`, and `dia` derived exactly as for `BoundedFormula`.
+`⊔`, `ex`, and `diamond` derived exactly as for `BoundedFormula`.
 `[UPSTREAM]` candidate for `Mathlib/ModelTheory`.
 -/
 
@@ -16,7 +16,7 @@ variable {L : Language} {α : Type*}
 
 /-- Modal formulas over `L` with named free variables `α`: mathlib's
     `BoundedFormula` basis — atomic `equal`/`rel`, `falsum`, `imp` — plus
-    `□` and named quantification; `∼`, `⊤`, `⊓`, `⊔`, `ex`, and `dia` are
+    `□` and named quantification; `∼`, `⊤`, `⊓`, `⊔`, `ex`, and `diamond` are
     derived exactly as for `BoundedFormula`. -/
 inductive ModalFormula (L : Language) (α : Type*) where
   /-- The proposition that two terms are equal. -/
@@ -55,7 +55,7 @@ protected def ex (x : α) (φ : ModalFormula L α) : ModalFormula L α :=
 
 /-- Possibility, derived: `◇φ := ∼□∼φ` — to `box` what `ex` is to `all`. -/
 @[match_pattern]
-def dia (φ : ModalFormula L α) : ModalFormula L α := (box φ.not).not
+def diamond (φ : ModalFormula L α) : ModalFormula L α := (box φ.not).not
 
 end ModalFormula
 

--- a/Linglib/Logic/Team/QBSML/Properties.lean
+++ b/Linglib/Logic/Team/QBSML/Properties.lean
@@ -1011,7 +1011,7 @@ translates the **whole NE-free fragment** — modals included — into
 every index. The translation is total on exactly the NE-free fragment. -/
 
 /-- Translate QBSML into modal formulas over the monadic signature: atoms
-    embed as classical formulas, `◇` becomes the derived `ModalFormula.dia`,
+    embed as classical formulas, `◇` becomes the derived `ModalFormula.diamond`,
     quantifiers become named binders; only `NE` returns `none`. -/
 def Formula.toModal? :
     Formula Var Const Pred →
@@ -1025,7 +1025,7 @@ def Formula.toModal? :
       φ.toModal?.bind fun α => ψ.toModal?.map (α ⊓ ·)
   | .disj φ ψ =>
       φ.toModal?.bind fun α => ψ.toModal?.map (α ⊔ ·)
-  | .poss φ => φ.toModal?.map ModalFormula.dia
+  | .poss φ => φ.toModal?.map ModalFormula.diamond
   | .exi x φ => φ.toModal?.map (ModalFormula.ex x ·)
   | .univ x φ => φ.toModal?.map (ModalFormula.all x ·)
 
@@ -1101,7 +1101,7 @@ theorem exists_toModal?_of_neFree :
     exact ⟨τ₁ ⊔ τ₂, by simp [Formula.toModal?, hτ₁, hτ₂]⟩
   | poss _ ih =>
     obtain ⟨τ, hτ⟩ := ih
-    exact ⟨τ.dia, by simp [Formula.toModal?, hτ]⟩
+    exact ⟨τ.diamond, by simp [Formula.toModal?, hτ]⟩
   | @exi x _ _ ih =>
     obtain ⟨τ, hτ⟩ := ih
     exact ⟨.ex x τ, by simp [Formula.toModal?, hτ]⟩

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -110,7 +110,7 @@ theorem support_possPxOrQx_iff
     (hv : ∀ i ∈ s, ∀ y, i.assign y = some (v i y)) :
     support univAccessModel (.poss (.disj Px Qx)) s ↔
       ∀ i ∈ s,
-        (ModalFormula.dia
+        (ModalFormula.diamond
           ((monadicRel Predicate.P).modalFormula₁ (Term.var QVar.x) ⊔
             (monadicRel Predicate.Q).modalFormula₁ (Term.var QVar.x))).Realize
           univAccessModel i.world (v i) :=


### PR DESCRIPTION
Spells out the derived possibility operator: dia has no mathlib precedent (mathlib has no modal logic) and the relational side already says ModalLogic.diamond.