### PR TITLE
refactor(Core/ModelTheory): direct monadic signature; world-relative I(w)

### DIFF
--- a/Linglib/Core/ModelTheory/FiniteModel.lean
+++ b/Linglib/Core/ModelTheory/FiniteModel.lean
@@ -11,9 +11,8 @@ models:
   with `monadicStructure` building its structures from a `Sym → E → Prop`
   table.
 * `Language.monadicWithConstants Const Pred` — the monadic signature with
-  individual constants adjoined (`(monadic Pred)[[Const]]`), with
-  `monadicWithConstantsStructure` building its structures from a constant
-  interpretation and a predicate valuation.
+  individual constants, with `monadicWithConstantsStructure` building its
+  structures from a constant interpretation and a predicate valuation.
 * `BoundedFormula.decRealize` — decidable realization over a finite structure
   with decidable atoms, by structural recursion on the formula. Mathlib has no
   such instance; with it, `decide` kernel-checks `Formula.Realize` facts on
@@ -59,30 +58,40 @@ instance {Sym E : Type*} (holds : Sym → E → Prop)
     Decidable (@Structure.RelMap _ _ (monadicStructure holds) n r v) :=
   monadicStructure.decRelMap holds n r v
 
-/-- The monadic signature with constants:
-    `(Language.monadic Pred)[[Const]]`. -/
-abbrev monadicWithConstants (Const : Type*) (Pred : Type*) : Language :=
-  (monadic Pred)[[Const]]
+/-- The monadic signature with individual constants: constant symbols
+    `Const` and unary relation symbols `Pred`, defined directly
+    (mathlib precedent: `Language.graph`; `withConstants` is the
+    elementary-diagram device, not a signature constructor). -/
+def monadicWithConstants (Const : Type*) (Pred : Type*) : Language where
+  Functions := fun n => match n with
+    | 0 => Const
+    | _ => PEmpty
+  Relations := fun n => match n with
+    | 1 => Pred
+    | _ => PEmpty
 
 variable {Const Pred Domain : Type*}
 
-/-- A constant as a symbol of the signature (mathlib's `Language.con`). -/
+/-- A constant as a symbol of the signature. -/
 abbrev monadicConst (c : Const) :
-    (monadicWithConstants Const Pred).Constants := Sum.inr c
+    (monadicWithConstants Const Pred).Constants := c
 
 /-- A predicate as a relation symbol of the signature. -/
 abbrev monadicRel (P : Pred) :
-    (monadicWithConstants Const Pred).Relations 1 := Sum.inl P
+    (monadicWithConstants Const Pred).Relations 1 := P
 
 /-- The `monadicWithConstants` structure a constant interpretation and a
-    predicate valuation induce: `monadicStructure` on the relations side,
-    `constantsOn.structure` on the constants side. -/
+    predicate valuation induce. -/
 @[reducible] def monadicWithConstantsStructure (κ : Const → Domain)
     (V : Pred → Domain → Prop) :
-    (monadicWithConstants Const Pred).Structure Domain :=
-  letI := monadicStructure V
-  letI := constantsOn.structure κ
-  inferInstance
+    (monadicWithConstants Const Pred).Structure Domain where
+  funMap := fun {n} f => match n, f with
+    | 0, c => fun _ => κ c
+    | _ + 1, f => f.elim
+  RelMap := fun {n} r => match n, r with
+    | 1, P => fun v => V P (v 0)
+    | 0, r => r.elim
+    | _ + 2, r => r.elim
 
 @[simp] theorem monadicWithConstantsStructure_relMap (κ : Const → Domain)
     (V : Pred → Domain → Prop) (P : Pred) (v : Fin 1 → Domain) :

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -153,10 +153,8 @@ def stTerm (k : ℕ) :
       (correspondence Const Pred).Term (Var ⊕ ℕ)
   | .var x => corrIndivVar x
   | @Term.func _ _ l f _ => match l, f with
-    | 0, Sum.inr c => Term.func (corrConst c) ![corrWorldVar k]
-    | 0, Sum.inl e => e.elim
-    | _ + 1, Sum.inl e => e.elim
-    | _ + 1, Sum.inr e => e.elim
+    | 0, c => Term.func (corrConst c) ![corrWorldVar k]
+    | _ + 1, f => f.elim
 
 /-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
     current world is the free variable `Sum.inr k`; `box` relativizes a
@@ -168,13 +166,9 @@ def ModalFormula.st (k : ℕ) :
       (correspondence Const Pred).Formula (Var ⊕ ℕ)
   | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
   | @ModalFormula.rel _ _ l R ts => match l, R, ts with
-    | 1, Sum.inl P, ts =>
-        (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0))
-    | 1, Sum.inr r, _ => r.elim
-    | 0, Sum.inl r, _ => r.elim
-    | 0, Sum.inr r, _ => r.elim
-    | _ + 2, Sum.inl r, _ => r.elim
-    | _ + 2, Sum.inr r, _ => r.elim
+    | 1, P, ts => (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0))
+    | 0, r, _ => r.elim
+    | _ + 2, r, _ => r.elim
   | .falsum => ⊥
   | .imp φ ψ => (φ.st k).imp (ψ.st k)
   | .box φ => Formula.all₁ (Sum.inr (k + 1))
@@ -201,12 +195,10 @@ private theorem realize_stTerm
   | var x => exact hind x
   | @func l f args =>
     match l, f with
-    | 0, Sum.inl e => exact e.elim
-    | _ + 1, Sum.inl e => exact e.elim
-    | _ + 1, Sum.inr e => exact e.elim
-    | 0, Sum.inr c =>
+    | _ + 1, f => exact f.elim
+    | 0, c =>
       let _I := K.interp w
-      rw [show stTerm k (.func (Sum.inr c) args) =
+      rw [show stTerm k (.func c args) =
           Term.func (corrConst c) ![corrWorldVar k] from rfl,
         show (Term.func (corrConst c) ![corrWorldVar k] :
             (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val =
@@ -317,14 +309,11 @@ theorem realize_st (K : ModalStructure (monadicWithConstants Const Pred) W M)
       rw [Function.update_self]
   | @rel l R ts =>
     match l, R with
-    | 0, Sum.inl r => exact r.elim
-    | 0, Sum.inr r => exact r.elim
-    | (n + 2), Sum.inl r => exact r.elim
-    | (n + 2), Sum.inr r => exact r.elim
-    | 1, Sum.inr r => exact r.elim
-    | 1, Sum.inl (P : Pred) =>
+    | 0, r => exact r.elim
+    | (n + 2), r => exact r.elim
+    | 1, (P : Pred) =>
       let _S := K.corrStructure
-      rw [show (ModalFormula.rel (Sum.inl P : (monadicWithConstants Const
+      rw [show (ModalFormula.rel (P : (monadicWithConstants Const
             Pred).Relations 1) ts).st k =
           (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0)) from rfl,
         Formula.realize_rel₂, corrStructure_relMap_rel,

--- a/Linglib/Logic/Modal/FirstOrder/Monadic.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Monadic.lean
@@ -18,18 +18,18 @@ namespace FirstOrder.Language
 
 variable {Const Pred Domain W : Type*}
 
-/-- The predicate denotation at a world, read off a Kripke model's
-    world-indexed family via `Structure.RelMap`. -/
+/-- The predicate denotation at a world: `relInterp`, curried for the
+    monadic signature. -/
 def ModalStructure.predInterp
     (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (P : Pred) (w : W) (d : Domain) : Prop :=
-  (K.interp w).RelMap (monadicRel P) (fun _ => d)
+  K.relInterp (monadicRel P) w (fun _ => d)
 
-/-- The constant denotation at a world, read off `Structure.funMap`. -/
+/-- The constant denotation at a world: `funInterp` at the constant. -/
 def ModalStructure.constInterp
     (K : ModalStructure (monadicWithConstants Const Pred) W Domain)
     (c : Const) (w : W) : Domain :=
-  (K.interp w).funMap (monadicConst c) default
+  K.funInterp (monadicConst c) w default
 
 /-- Realization of a monadic atom: the predicate denotation at the world,
     of the term's value. -/

--- a/Linglib/Logic/Modal/FirstOrder/Semantics.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Semantics.lean
@@ -29,6 +29,11 @@ Kripke satisfaction `K, w ⊨_v φ`.
   `Function.update` semantics (the `Formula.all₁` / `ex₁` convention of
   `Core/ModelTheory/Binders.lean`), not de Bruijn indices: the modal
   layer's consumers carry named variables.
+
+## References
+
+* [fitting-mendelsohn-2023] — constant-domain models, world-relative
+  interpretation, the Barcan formulas
 -/
 
 namespace FirstOrder.Language
@@ -43,6 +48,26 @@ structure ModalStructure (L : Language) (W M : Type*) where
   access : W → Finset W
   /-- World-indexed interpretation of the signature. -/
   interp : W → L.Structure M
+
+namespace ModalStructure
+
+/-! ### World-relative interpretation
+
+The interpretation function `I(w)(·)` of first-order modal semantics
+([fitting-mendelsohn-2023] Definition 8.6.2): what a symbol denotes at a
+world, read off the world's structure. -/
+
+variable (K : ModalStructure L W M)
+
+/-- The relation a relation symbol denotes at a world. -/
+def relInterp {n : ℕ} (R : L.Relations n) (w : W) : (Fin n → M) → Prop :=
+  (K.interp w).RelMap R
+
+/-- The function a function symbol denotes at a world. -/
+def funInterp {n : ℕ} (f : L.Functions n) (w : W) : (Fin n → M) → M :=
+  (K.interp w).funMap f
+
+end ModalStructure
 
 namespace ModalFormula
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7987,11 +7987,27 @@
   role      = {cited},
   sources   = {Semantics/Attitudes/RationalAttitude.lean;Semantics/Lexical/LevinClass.lean;Semantics/Causation/Progressive.lean;Semantics/Lexical/EventStructure.lean;Semantics/Aspect/SubintervalProperty.lean;Features/Aktionsart.lean}
 }
+@book{fitting-mendelsohn-2023,
+  author    = {Fitting, Melvin and Mendelsohn, Richard L.},
+  year      = {2023},
+  title     = {First-Order Modal Logic},
+  edition   = {2},
+  series    = {Synthese Library},
+  number    = {480},
+  publisher = {Springer},
+  doi       = {10.1007/978-3-031-40714-7},
+  subfield  = {semantics/modality},
+  validated = {true},
+  role      = {cited},
+  sources   = {Logic/Modal/FirstOrder/Semantics.lean;Logic/Modal/FirstOrder/Monadic.lean}
+}
+
 @book{blackburn-derijke-venema-2001,
   author    = {Blackburn, Patrick and de Rijke, Maarten and Venema, Yde},
   year      = {2001},
   title     = {Modal Logic},
   series    = {Cambridge Tracts in Theoretical Computer Science},
+  number    = {53},
   publisher = {Cambridge University Press},
   doi       = {10.1017/CBO9781107050884},
   subfield  = {semantics/modality},
@@ -22092,17 +22108,6 @@
   number    = {2--3},
   pages     = {245--253},
   subfield  = {mathematical foundations/rough sets},
-  role      = {cited},
-}
-@book{blackburn-derijke-venema-2001,
-  author    = {Blackburn, Patrick and de Rijke, Maarten and Venema, Yde},
-  year      = {2001},
-  title     = {Modal Logic},
-  series    = {Cambridge Tracts in Theoretical Computer Science},
-  number    = {53},
-  publisher = {Cambridge University Press},
-  doi       = {10.1017/CBO9781107050884},
-  subfield  = {modal logic},
   role      = {cited},
 }
 @incollection{goranko-otto-2007,


### PR DESCRIPTION
monadicWithConstants defined directly (Language.graph precedent) instead of via withConstants, mathlib's elementary-diagram device — the Sum-tagged symbols and their dead elim arms disappear through stTerm/st/realize_st; downstream compiles unchanged through the monadicRel/monadicConst abbrevs. Semantics.lean gains the generic world-relative interpretation relInterp/funInterp (Fitting–Mendelsohn Definition 8.6.2, entry added to the bib with fields verified against the book; duplicate BdRV entry merged), with Monadic's predInterp/constInterp now their monadic specializations.