### PR TITLE
refactor(Logic/Modal/FirstOrder): the correspondence language of any signature

### DIFF
--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -71,11 +71,9 @@ def correspondence (L : Language) : Language where
 
 variable {L : Language}
 
-abbrev corrFunc {n : ℕ} (f : L.Functions n) :
-    L.correspondence.Functions (n + 1) := f
+abbrev corrFunc {n : ℕ} (f : L.Functions n) : L.correspondence.Functions (n + 1) := f
 
-abbrev corrRel {n : ℕ} (R : L.Relations n) :
-    L.correspondence.Relations (n + 1) := Sum.inl R
+abbrev corrRel {n : ℕ} (R : L.Relations n) : L.correspondence.Relations (n + 1) := Sum.inl R
 
 /-- The individual-sort predicate. -/
 abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
@@ -83,11 +81,9 @@ abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
 /-- The accessibility relation symbol. -/
 abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr PUnit.unit
 
-abbrev corrIndivVar (x : Var) :
-    L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
+abbrev corrIndivVar (x : Var) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
 
-abbrev corrWorldVar (k : ℕ) :
-    L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
+abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
 /-- `K.correspondence` encodes a modal structure as a single mathlib
     structure on `W ⊕ M` — the structure half of `Language.correspondence`:

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -112,6 +112,55 @@ theorem stVal_update_world [DecidableEq Var] (v : Var → M) (u : ℕ → W) (j 
       stVal v (Function.update u j w) := by
   simp only [stVal, Sum.update_elim_inr, Function.comp_update]
 
+/-! ### The translation -/
+
+/-- `stTerm` translates terms: a variable stays put; a function symbol
+    applies its world-relativized form at the current world variable. -/
+def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
+  | .var x => corrIndivVar x
+  | .func f args =>
+      Term.func (corrFunc f) (Fin.cons (corrWorldVar k) fun i => stTerm k (args i))
+
+/-- The standard translation `ST_k` of [blackburn-derijke-venema-2001].
+    The current world is the free variable `Sum.inr k`; atoms
+    world-relativize; `box` relativizes a fresh world variable
+    `Sum.inr (k + 1)` along accessibility; quantifiers relativize to the
+    individual sort. -/
+def ModalFormula.st [DecidableEq Var] (k : ℕ) :
+    ModalFormula L Var → L.correspondence.Formula (Var ⊕ ℕ)
+  | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
+  | .rel R ts =>
+      (corrRel R).formula (Fin.cons (corrWorldVar k) fun i => stTerm k (ts i))
+  | .falsum => ⊥
+  | .imp φ ψ => φ.st k ⟹ ψ.st k
+  | .box φ => Formula.all₁ (Sum.inr (k + 1))
+      (corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1)) ⟹ φ.st (k + 1))
+  | .all x φ => Formula.all₁ (Sum.inl x)
+      (corrIndiv.formula₁ (corrIndivVar x) ⟹ φ.st k)
+
+/-! ### Sort-guarded sentence closure -/
+
+/-- `stClose` closes the current-world variable `Sum.inr k` under a
+    sort-guarded existential, `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is
+    load-bearing on the mixed carrier — a bare `ex₁` could be witnessed by
+    a junk individual-as-world, which satisfies `□⊥` vacuously. -/
+def stClose [DecidableEq Var] (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
+    L.correspondence.Formula (Var ⊕ ℕ) :=
+  Formula.ex₁ (Sum.inr k)
+    ((corrIndiv.formula₁ (corrWorldVar k)).not ⊓ ψ)
+
+/-- Over any correspondence structure on `W ⊕ M` whose individual-sort
+    predicate holds exactly of the second summand — as
+    `ModalStructure.correspondence`'s does definitionally — the guarded
+    witness of `stClose` is exactly a world. -/
+theorem realize_stClose [DecidableEq Var] [L.correspondence.Structure (W ⊕ M)]
+    (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) (val : Var ⊕ ℕ → W ⊕ M)
+    (hind : ∀ z : W ⊕ M,
+      Structure.RelMap (corrIndiv (L := L)) ![z] ↔ ∃ d : M, z = Sum.inr d) :
+    (stClose k ψ).Realize val ↔
+      ∃ w : W, ψ.Realize (Function.update val (Sum.inr k) (Sum.inl w)) := by
+  simp [stClose, Formula.realize_ex₁, hind, Sum.exists]
+
 /-! ### The encoded structure -/
 
 variable [Inhabited M] (K : ModalStructure L W M)
@@ -164,32 +213,6 @@ theorem correspondence_funMap_inl (f : L.Functions n) (w : W) (z : Fin (n + 1) �
     funext fun j => Fin.cases hz hds j
   rfl
 
-/-! ### The translation -/
-
-/-- `stTerm` translates terms: a variable stays put; a function symbol
-    applies its world-relativized form at the current world variable. -/
-def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
-  | .var x => corrIndivVar x
-  | .func f args =>
-      Term.func (corrFunc f) (Fin.cons (corrWorldVar k) fun i => stTerm k (args i))
-
-/-- The standard translation `ST_k` of [blackburn-derijke-venema-2001].
-    The current world is the free variable `Sum.inr k`; atoms
-    world-relativize; `box` relativizes a fresh world variable
-    `Sum.inr (k + 1)` along accessibility; quantifiers relativize to the
-    individual sort. -/
-def ModalFormula.st [DecidableEq Var] (k : ℕ) :
-    ModalFormula L Var → L.correspondence.Formula (Var ⊕ ℕ)
-  | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
-  | .rel R ts =>
-      (corrRel R).formula (Fin.cons (corrWorldVar k) fun i => stTerm k (ts i))
-  | .falsum => ⊥
-  | .imp φ ψ => φ.st k ⟹ ψ.st k
-  | .box φ => Formula.all₁ (Sum.inr (k + 1))
-      (corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1)) ⟹ φ.st (k + 1))
-  | .all x φ => Formula.all₁ (Sum.inl x)
-      (corrIndiv.formula₁ (corrIndivVar x) ⟹ φ.st k)
-
 /-! ### Satisfaction preservation -/
 
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
@@ -230,49 +253,5 @@ theorem realize_st [DecidableEq Var] {φ : ModalFormula L Var} {k : ℕ}
     simp [ModalFormula.st, Formula.realize_all₁, stVal_update_indiv, ← ih]
   | @rel n R ts =>
     simp [ModalFormula.st, realize_stTerm K, ModalStructure.relInterp, ← funext_iff]
-
-/-! ### Sort-guarded sentence closure -/
-
-/-- `stClose` closes the current-world variable `Sum.inr k` under a
-    sort-guarded existential, `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is
-    load-bearing on the mixed carrier — a bare `ex₁` could be witnessed by
-    a junk individual-as-world, which satisfies `□⊥` vacuously. -/
-def stClose [DecidableEq Var] (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
-    L.correspondence.Formula (Var ⊕ ℕ) :=
-  Formula.ex₁ (Sum.inr k)
-    ((corrIndiv.formula₁ (corrWorldVar k)).not ⊓ ψ)
-
-/-- Over `correspondence`, the guarded witness of `stClose` is exactly a
-    world. -/
-theorem realize_stClose [DecidableEq Var] (k : ℕ)
-    (ψ : L.correspondence.Formula (Var ⊕ ℕ)) (val : Var ⊕ ℕ → W ⊕ M) :
-    (letI := K.correspondence; (stClose k ψ).Realize val) ↔
-      ∃ w : W,
-        (letI := K.correspondence
-         ψ.Realize (Function.update val (Sum.inr k) (Sum.inl w))) := by
-  let _S := K.correspondence
-  unfold stClose
-  rw [Formula.realize_ex₁]
-  constructor
-  · rintro ⟨z, hz⟩
-    rw [Formula.realize_inf, Formula.realize_not, Formula.realize_rel₁,
-      correspondence_relMap_indiv] at hz
-    obtain ⟨hguard, hzψ⟩ := hz
-    cases z with
-    | inl w => exact ⟨w, hzψ⟩
-    | inr d =>
-      refine absurd ⟨d, ?_⟩ hguard
-      show Function.update val (Sum.inr k) (Sum.inr d) (Sum.inr k) = _
-      rw [Function.update_self]
-  · rintro ⟨w, hw⟩
-    refine ⟨Sum.inl w, ?_⟩
-    rw [Formula.realize_inf, Formula.realize_not, Formula.realize_rel₁,
-      correspondence_relMap_indiv]
-    refine ⟨?_, hw⟩
-    rintro ⟨d, hd⟩
-    have hd' : Function.update val (Sum.inr k) (Sum.inl w) (Sum.inr k)
-        = Sum.inr d := hd
-    rw [Function.update_self] at hd'
-    exact Sum.inl_ne_inr hd'
 
 end FirstOrder.Language

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -71,11 +71,9 @@ def correspondence (L : Language) : Language where
 
 variable {L : Language}
 
-/-- An `L`-function symbol, world-relativized. -/
 abbrev corrFunc {n : ℕ} (f : L.Functions n) :
     L.correspondence.Functions (n + 1) := f
 
-/-- An `L`-relation symbol, world-relativized. -/
 abbrev corrRel {n : ℕ} (R : L.Relations n) :
     L.correspondence.Relations (n + 1) := Sum.inl R
 
@@ -85,12 +83,9 @@ abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
 /-- The accessibility relation symbol. -/
 abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr PUnit.unit
 
-/-- An individual variable as a sorted term of the correspondence
-    language. -/
 abbrev corrIndivVar (x : Var) :
     L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
 
-/-- A world variable as a sorted term of the correspondence language. -/
 abbrev corrWorldVar (k : ℕ) :
     L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -14,13 +14,13 @@ satisfaction preservation.
 ## Main declarations
 
 * `Language.correspondence` — the correspondence language of `L`;
-  `ModalStructure.corrStructure` — the `W ⊕ M` encoding of a modal
+  `ModalStructure.correspondence` — the `W ⊕ M` encoding of a modal
   structure as one mathlib structure.
 * `ModalFormula.st` — the standard translation, total: the current world is
   the free variable `Sum.inr k`, and `box` introduces the fresh world
   variable `Sum.inr (k + 1)`.
 * `realize_st` — satisfaction preservation: Kripke satisfaction at `w` is
-  first-order realization over `corrStructure` at any sorted valuation
+  first-order realization over `correspondence` at any sorted valuation
   pinning `Sum.inr k` to `w`.
 * `stClose` — sort-guarded existential closure of the current-world
   variable, turning translations into sentence candidates.
@@ -89,18 +89,19 @@ abbrev corrIndivVar (x : Var) :
 abbrev corrWorldVar (k : ℕ) :
     L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
-/-- `corrStructure` encodes a modal structure as a single mathlib
-    structure on `W ⊕ M`: worlds and individuals share the carrier, sorted
-    by `corrIndiv`; relational guards make all off-sort atoms false, and
-    off-sort function arguments default. -/
-@[reducible] def ModalStructure.corrStructure [Inhabited M]
+/-- `K.correspondence` encodes a modal structure as a single mathlib
+    structure on `W ⊕ M` — the structure half of `Language.correspondence`:
+    worlds and individuals share the carrier, sorted by `corrIndiv`;
+    relational guards make all off-sort atoms false, and off-sort function
+    arguments default. -/
+@[reducible] def ModalStructure.correspondence [Inhabited M]
     (K : ModalStructure L W M) :
     L.correspondence.Structure (W ⊕ M) where
   funMap := fun {n} f z => match n, f with
     | 0, f => f.elim
     | _ + 1, f => match z 0 with
       | Sum.inl w =>
-          Sum.inr (K.funInterp f w fun i => (z i.succ).elim (fun _ => default) id)
+          Sum.inr (K.funInterp f w fun i => (z i.succ).getRight?.getD default)
       | Sum.inr d => Sum.inr d
   RelMap := fun {n} r z => match n, r with
     | 0, r => r.elim
@@ -116,34 +117,34 @@ abbrev corrWorldVar (k : ℕ) :
 
 variable [Inhabited M]
 
-@[simp] theorem corrStructure_relMap_rel (K : ModalStructure L W M)
+@[simp] theorem correspondence_relMap_rel (K : ModalStructure L W M)
     {n : ℕ} (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
-    (K.corrStructure).RelMap (corrRel R) z ↔
+    (K.correspondence).RelMap (corrRel R) z ↔
       ∃ (w : W) (ds : Fin n → M),
         z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
           K.relInterp R w ds :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_acc (K : ModalStructure L W M)
+@[simp] theorem correspondence_relMap_acc (K : ModalStructure L W M)
     (z : Fin 2 → W ⊕ M) :
-    (K.corrStructure).RelMap (corrAcc (L := L)) z ↔
+    (K.correspondence).RelMap (corrAcc (L := L)) z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_indiv (K : ModalStructure L W M)
+@[simp] theorem correspondence_relMap_indiv (K : ModalStructure L W M)
     (z : Fin 1 → W ⊕ M) :
-    (K.corrStructure).RelMap (corrIndiv (L := L)) z ↔
+    (K.correspondence).RelMap (corrIndiv (L := L)) z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
-theorem corrStructure_funMap_inl (K : ModalStructure L W M)
+theorem correspondence_funMap_inl (K : ModalStructure L W M)
     {n : ℕ} (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
     (ds : Fin n → M) (hz : z 0 = Sum.inl w)
     (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
-    (K.corrStructure).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
+    (K.correspondence).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
   show (match z 0 with
     | Sum.inl w' =>
-        Sum.inr (K.funInterp f w' fun i => (z i.succ).elim (fun _ => default) id)
+        Sum.inr (K.funInterp f w' fun i => (z i.succ).getRight?.getD default)
     | Sum.inr d => Sum.inr d) = _
   rw [hz]
   exact congrArg Sum.inr (congrArg _ (funext fun i => by rw [hds i]; rfl))
@@ -187,16 +188,16 @@ private theorem realize_stTerm (K : ModalStructure L W M)
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
     ∀ t : L.Term Var,
-      (letI := K.corrStructure; (stTerm k t).realize val) =
+      (letI := K.correspondence; (stTerm k t).realize val) =
         Sum.inr (letI := K.interp w; t.realize v)
   | .var x => hind x
   | .func f args => by
-    let _S := K.corrStructure
+    let _S := K.correspondence
     let _I := K.interp w
     rw [show stTerm k (.func f args) = Term.func (corrFunc f)
         (Fin.cons (corrWorldVar k) fun i => stTerm k (args i)) from rfl,
       Term.realize_func,
-      corrStructure_funMap_inl K f w _
+      correspondence_funMap_inl K f w _
         (fun i => (letI := K.interp w; (args i).realize v))
         (by simpa using hw)
         (fun i => by
@@ -223,7 +224,7 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
   rw [Function.update_of_ne (by simp)]; exact hw
 
 /-- **Satisfaction preservation for the standard translation**: Kripke
-    satisfaction at `w` is first-order realization over `corrStructure`, for
+    satisfaction at `w` is first-order realization over `correspondence`, for
     any valuation that is individual-sorted on `Var` and pins the current
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
@@ -233,20 +234,20 @@ theorem realize_st (K : ModalStructure L W M)
     {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
-    φ.Realize K w v ↔ (letI := K.corrStructure; (φ.st k).Realize val) := by
+    φ.Realize K w v ↔ (letI := K.correspondence; (φ.st k).Realize val) := by
   induction φ generalizing k val w v with
   | equal t₁ t₂ =>
-    let _S := K.corrStructure
+    let _S := K.correspondence
     rw [ModalFormula.st, ModalFormula.realize_equal, Formula.realize_equal,
       realize_stTerm K hind hw, realize_stTerm K hind hw]
     exact ⟨congrArg _, Sum.inr.inj⟩
   | falsum => exact Iff.rfl
   | imp φ ψ ih₁ ih₂ =>
-    let _S := K.corrStructure
+    let _S := K.correspondence
     rw [ModalFormula.realize_imp, ModalFormula.st, Formula.realize_imp]
     exact imp_congr (ih₁ hind hw) (ih₂ hind hw)
   | box φ ih =>
-    let _S := K.corrStructure
+    let _S := K.correspondence
     rw [ModalFormula.realize_box, ModalFormula.st, Formula.realize_all₁]
     constructor
     · intro h z
@@ -272,7 +273,7 @@ theorem realize_st (K : ModalStructure L W M)
         rw [Function.update_of_ne (by simp), hind]
       · rw [Function.update_self]
   | all x φ ih =>
-    let _S := K.corrStructure
+    let _S := K.correspondence
     rw [ModalFormula.realize_all, ModalFormula.st, Formula.realize_all₁]
     constructor
     · intro h z
@@ -280,7 +281,7 @@ theorem realize_st (K : ModalStructure L W M)
       intro hsort
       obtain ⟨d, hd⟩ : ∃ d : M,
           Function.update val (Sum.inl x) z (Sum.inl x) = Sum.inr d := by
-        simpa [corrStructure_relMap_indiv] using hsort
+        simpa [correspondence_relMap_indiv] using hsort
       rw [Function.update_self] at hd
       subst hd
       exact (ih (sorted_update hind x d) (pinned_update hw x _)).mp (h d)
@@ -292,8 +293,8 @@ theorem realize_st (K : ModalStructure L W M)
       show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
       rw [Function.update_self]
   | @rel n R ts =>
-    let _S := K.corrStructure
-    rw [ModalFormula.st, Formula.realize_rel, corrStructure_relMap_rel,
+    let _S := K.correspondence
+    rw [ModalFormula.st, Formula.realize_rel, correspondence_relMap_rel,
       ModalFormula.realize_rel]
     constructor
     · intro h
@@ -324,22 +325,22 @@ def stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
   Formula.ex₁ (Sum.inr k)
     ((corrIndiv.formula₁ (corrWorldVar k)).not ⊓ ψ)
 
-/-- Over `corrStructure`, the guarded witness of `stClose` is exactly a
+/-- Over `correspondence`, the guarded witness of `stClose` is exactly a
     world. -/
 theorem realize_stClose (K : ModalStructure L W M)
     (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ))
     (val : Var ⊕ ℕ → W ⊕ M) :
-    (letI := K.corrStructure; (stClose k ψ).Realize val) ↔
+    (letI := K.correspondence; (stClose k ψ).Realize val) ↔
       ∃ w : W,
-        (letI := K.corrStructure
+        (letI := K.correspondence
          ψ.Realize (Function.update val (Sum.inr k) (Sum.inl w))) := by
-  let _S := K.corrStructure
+  let _S := K.correspondence
   unfold stClose
   rw [Formula.realize_ex₁]
   constructor
   · rintro ⟨z, hz⟩
     rw [Formula.realize_inf, Formula.realize_not, Formula.realize_rel₁,
-      corrStructure_relMap_indiv] at hz
+      correspondence_relMap_indiv] at hz
     obtain ⟨hguard, hzψ⟩ := hz
     cases z with
     | inl w => exact ⟨w, hzψ⟩
@@ -350,7 +351,7 @@ theorem realize_stClose (K : ModalStructure L W M)
   · rintro ⟨w, hw⟩
     refine ⟨Sum.inl w, ?_⟩
     rw [Formula.realize_inf, Formula.realize_not, Formula.realize_rel₁,
-      corrStructure_relMap_indiv]
+      correspondence_relMap_indiv]
     refine ⟨?_, hw⟩
     rintro ⟨d, hd⟩
     have hd' : Function.update val (Sum.inr k) (Sum.inl w) (Sum.inr k)

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -95,10 +95,8 @@ abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var 
     L.correspondence.Structure (W ⊕ M) where
   funMap := fun {n} f z => match n, f with
     | 0, f => f.elim
-    | _ + 1, f => match z 0 with
-      | Sum.inl w =>
-          Sum.inr (K.funInterp f w fun i => (z i.succ).getRight?.getD default)
-      | Sum.inr d => Sum.inr d
+    | _ + 1, f => Sum.inr <| (z 0).elim
+        (fun w => K.funInterp f w fun i => (z i.succ).getRight?.getD default) id
   RelMap := fun {n} r z => match n, r with
     | 0, r => r.elim
     | n + 1, r => r.elim
@@ -138,10 +136,8 @@ theorem correspondence_funMap_inl (K : ModalStructure L W M)
     (ds : Fin n → M) (hz : z 0 = Sum.inl w)
     (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
     (K.correspondence).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
-  show (match z 0 with
-    | Sum.inl w' =>
-        Sum.inr (K.funInterp f w' fun i => (z i.succ).getRight?.getD default)
-    | Sum.inr d => Sum.inr d) = _
+  show Sum.inr ((z 0).elim
+      (fun w' => K.funInterp f w' fun i => (z i.succ).getRight?.getD default) id) = _
   rw [hz]
   exact congrArg Sum.inr (congrArg _ (funext fun i => by rw [hds i]; rfl))
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -58,9 +58,9 @@ variable {W M Var : Type*}
 
 /-! ### The correspondence language and the encoded structure -/
 
-/-- The correspondence language of `L`: every `L`-symbol world-relativized
-    to one arity higher — the new first argument the world — plus an
-    individual-sort predicate and the accessibility relation. -/
+/-- The correspondence language of `L` has an `(n + 1)`-ary symbol for
+    each `n`-ary `L`-symbol — the new first argument the world — together
+    with an individual-sort predicate and an accessibility relation. -/
 def correspondence (L : Language) : Language where
   Functions := fun n => match n with
     | 0 => PEmpty
@@ -89,9 +89,9 @@ abbrev corrIndivVar (x : Var) :
 abbrev corrWorldVar (k : ℕ) :
     L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
-/-- The `W ⊕ M` encoding of a modal structure as a single mathlib
-    structure: worlds and individuals share the carrier, sorted by
-    `corrIndiv`; relational guards make all off-sort atoms false, and
+/-- `corrStructure` encodes a modal structure as a single mathlib
+    structure on `W ⊕ M`: worlds and individuals share the carrier, sorted
+    by `corrIndiv`; relational guards make all off-sort atoms false, and
     off-sort function arguments default. -/
 @[reducible] def ModalStructure.corrStructure [Inhabited M]
     (K : ModalStructure L W M) :
@@ -152,17 +152,18 @@ theorem corrStructure_funMap_inl (K : ModalStructure L W M)
 
 variable [DecidableEq Var]
 
-/-- Translate a term: variables stay, function symbols apply their
-    world-relativized forms at the current world variable. -/
+/-- `stTerm` translates terms: a variable stays put; a function symbol
+    applies its world-relativized form at the current world variable. -/
 def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
   | .var x => corrIndivVar x
   | .func f args =>
       Term.func (corrFunc f) (Fin.cons (corrWorldVar k) fun i => stTerm k (args i))
 
-/-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
-    current world is the free variable `Sum.inr k`; atoms world-relativize;
-    `box` relativizes a fresh world variable `Sum.inr (k + 1)` along
-    accessibility; quantifiers relativize to the individual sort. -/
+/-- The standard translation `ST_k` of [blackburn-derijke-venema-2001].
+    The current world is the free variable `Sum.inr k`; atoms
+    world-relativize; `box` relativizes a fresh world variable
+    `Sum.inr (k + 1)` along accessibility; quantifiers relativize to the
+    individual sort. -/
 def ModalFormula.st (k : ℕ) :
     ModalFormula L Var → L.correspondence.Formula (Var ⊕ ℕ)
   | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
@@ -314,10 +315,10 @@ theorem realize_st (K : ModalStructure L W M)
 
 /-! ### Sort-guarded sentence closure -/
 
-/-- Sort-guarded existential closure of the current-world variable
-    `Sum.inr k`: `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is load-bearing on the
-    mixed carrier — a bare `ex₁` could be witnessed by a junk
-    individual-as-world, which satisfies `□⊥` vacuously. -/
+/-- `stClose` closes the current-world variable `Sum.inr k` under a
+    sort-guarded existential, `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is
+    load-bearing on the mixed carrier — a bare `ex₁` could be witnessed by
+    a junk individual-as-world, which satisfies `□⊥` vacuously. -/
 def stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
     L.correspondence.Formula (Var ⊕ ℕ) :=
   Formula.ex₁ (Sum.inr k)

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -156,12 +156,11 @@ def ModalFormula.st (k : ℕ) :
   | .rel R ts =>
       (corrRel R).formula (Fin.cons (corrWorldVar k) fun i => stTerm k (ts i))
   | .falsum => ⊥
-  | .imp φ ψ => (φ.st k).imp (ψ.st k)
+  | .imp φ ψ => φ.st k ⟹ ψ.st k
   | .box φ => Formula.all₁ (Sum.inr (k + 1))
-      ((corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1))).imp
-        (φ.st (k + 1)))
+      (corrAcc.formula₂ (corrWorldVar k) (corrWorldVar (k + 1)) ⟹ φ.st (k + 1))
   | .all x φ => Formula.all₁ (Sum.inl x)
-      ((corrIndiv.formula₁ (corrIndivVar x)).imp (φ.st k))
+      (corrIndiv.formula₁ (corrIndivVar x) ⟹ φ.st k)
 
 /-! ### Satisfaction preservation -/
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -58,6 +58,14 @@ variable {W M Var : Type*}
 
 /-! ### The correspondence language and the encoded structure -/
 
+/-- The symbols a correspondence language adds beyond the world-relativized
+    `L`-symbols. -/
+inductive CorrExtra : ℕ → Type
+  /-- The individual-sort predicate symbol. -/
+  | indiv : CorrExtra 1
+  /-- The accessibility relation symbol. -/
+  | acc : CorrExtra 2
+
 /-- The correspondence language of `L` has an `(n + 1)`-ary symbol for
     each `n`-ary `L`-symbol — the new first argument the world — together
     with an individual-sort predicate and an accessibility relation. -/
@@ -67,7 +75,7 @@ def correspondence (L : Language) : Language where
     | n + 1 => L.Functions n
   Relations := fun n => match n with
     | 0 => PEmpty
-    | n + 1 => L.Relations n ⊕ (match n with | 0 | 1 => PUnit | _ => PEmpty)
+    | n + 1 => L.Relations n ⊕ CorrExtra (n + 1)
 
 variable {L : Language} {n : ℕ}
 
@@ -75,11 +83,9 @@ abbrev corrFunc (f : L.Functions n) : L.correspondence.Functions (n + 1) := f
 
 abbrev corrRel (R : L.Relations n) : L.correspondence.Relations (n + 1) := Sum.inl R
 
-/-- The individual-sort predicate. -/
-abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
+abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr .indiv
 
-/-- The accessibility relation symbol. -/
-abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr PUnit.unit
+abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr .acc
 
 abbrev corrIndivVar (x : Var) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
 
@@ -104,10 +110,9 @@ variable [Inhabited M] (K : ModalStructure L W M)
           z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
             K.relInterp R w ds)
         (fun u => match n, z, u with
-          | 0, z, _ => ∃ d : M, z 0 = Sum.inr d
-          | 1, z, _ =>
-              ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
-          | _ + 2, _, u => u.elim)
+          | _, z, .indiv => ∃ d : M, z 0 = Sum.inr d
+          | _, z, .acc =>
+              ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁)
 
 @[simp] theorem correspondence_relMap_rel (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
     (K.correspondence).RelMap (corrRel R) z ↔

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -69,11 +69,11 @@ def correspondence (L : Language) : Language where
     | 0 => PEmpty
     | n + 1 => L.Relations n ⊕ (match n with | 0 | 1 => PUnit | _ => PEmpty)
 
-variable {L : Language}
+variable {L : Language} {n : ℕ}
 
-abbrev corrFunc {n : ℕ} (f : L.Functions n) : L.correspondence.Functions (n + 1) := f
+abbrev corrFunc (f : L.Functions n) : L.correspondence.Functions (n + 1) := f
 
-abbrev corrRel {n : ℕ} (R : L.Relations n) : L.correspondence.Relations (n + 1) := Sum.inl R
+abbrev corrRel (R : L.Relations n) : L.correspondence.Relations (n + 1) := Sum.inl R
 
 /-- The individual-sort predicate. -/
 abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
@@ -112,7 +112,7 @@ abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var 
 variable [Inhabited M]
 
 @[simp] theorem correspondence_relMap_rel (K : ModalStructure L W M)
-    {n : ℕ} (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
+    (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
     (K.correspondence).RelMap (corrRel R) z ↔
       ∃ (w : W) (ds : Fin n → M),
         z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
@@ -132,13 +132,14 @@ variable [Inhabited M]
   Iff.rfl
 
 theorem correspondence_funMap_inl (K : ModalStructure L W M)
-    {n : ℕ} (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
+    (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
     (ds : Fin n → M) (hz : z 0 = Sum.inl w)
     (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
     (K.correspondence).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
   show Sum.inr ((z 0).elim
       (fun w' => K.funInterp f w' fun i => (z i.succ).getRight?.getD default) id) = _
   rw [hz]
+  show Sum.inr (K.funInterp f w fun i => (z i.succ).getRight?.getD default) = _
   exact congrArg Sum.inr (congrArg _ (funext fun i => by rw [hds i]; rfl))
 
 /-! ### The translation -/

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -25,28 +25,6 @@ satisfaction preservation.
 * `stClose` — sort-guarded existential closure of the current-world
   variable, turning translations into sentence candidates.
 
-## Implementation notes
-
-* The canonical object here is the *two-sorted* first-order view of a
-  modal structure (worlds with accessibility; individuals; world-relativized
-  symbols) — the same object, in the correspondence-theory sense. The
-  `W ⊕ M` carrier, the sort predicate, and the off-sort guards are the
-  standard many-sorted-to-one-sorted coding, forced by mathlib's
-  single-sorted `Structure`; they have no independent standing. Junk
-  totalization of world-relativized functions is by `[Inhabited M]` —
-  constant-domain semantics presupposes a nonempty domain.
-* `realize_st` evaluates translations at sorted valuations `stVal v u` —
-  the valuation invariant is carried by the constructor rather than by
-  hypotheses. `stVal`'s simp interface (evaluation plus the two
-  update-commutation lemmas) lets `simp` discharge every case, including
-  the off-sort quantifier instances behind the sort guards.
-* Freshness of world variables is by increment: each `box` shifts the
-  current index from `k` to `k + 1`, and the constraint set of the theorem
-  pins only index `k`, so no freshness side conditions arise.
-* `freeVarFinset = ∅` side conditions on closures are hypotheses,
-  dischargeable by `decide` per instance — no generic free-variable
-  bookkeeping for `st`.
-
 ## References
 
 * [blackburn-derijke-venema-2001] — the standard translation

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -58,14 +58,6 @@ variable {W M Var : Type*}
 
 /-! ### The correspondence language and the encoded structure -/
 
-/-- The symbols a correspondence language adds beyond the world-relativized
-    `L`-symbols. -/
-inductive CorrExtra : ℕ → Type
-  /-- The individual-sort predicate symbol. -/
-  | indiv : CorrExtra 1
-  /-- The accessibility relation symbol. -/
-  | acc : CorrExtra 2
-
 /-- The correspondence language of `L` has an `(n + 1)`-ary symbol for
     each `n`-ary `L`-symbol — the new first argument the world — together
     with an individual-sort predicate and an accessibility relation. -/
@@ -75,7 +67,7 @@ def correspondence (L : Language) : Language where
     | n + 1 => L.Functions n
   Relations := fun n => match n with
     | 0 => PEmpty
-    | n + 1 => L.Relations n ⊕ CorrExtra (n + 1)
+    | n + 1 => L.Relations n ⊕ (match n with | 0 | 1 => PUnit | _ => PEmpty)
 
 variable {L : Language} {n : ℕ}
 
@@ -83,9 +75,11 @@ abbrev corrFunc (f : L.Functions n) : L.correspondence.Functions (n + 1) := f
 
 abbrev corrRel (R : L.Relations n) : L.correspondence.Relations (n + 1) := Sum.inl R
 
-abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr .indiv
+/-- The individual-sort predicate. -/
+abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
 
-abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr .acc
+/-- The accessibility relation symbol. -/
+abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr PUnit.unit
 
 abbrev corrIndivVar (x : Var) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
 
@@ -110,36 +104,35 @@ variable [Inhabited M] (K : ModalStructure L W M)
           z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
             K.relInterp R w ds)
         (fun u => match n, z, u with
-          | _, z, .indiv => ∃ d : M, z 0 = Sum.inr d
-          | _, z, .acc =>
-              ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁)
+          | 0, z, _ => ∃ d : M, z 0 = Sum.inr d
+          | 1, z, _ =>
+              ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
+          | _ + 2, _, u => u.elim)
 
 @[simp] theorem correspondence_relMap_rel (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
-    (K.correspondence).RelMap (corrRel R) z ↔
+    K.correspondence.RelMap (corrRel R) z ↔
       ∃ (w : W) (ds : Fin n → M),
         z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
           K.relInterp R w ds :=
   Iff.rfl
 
 @[simp] theorem correspondence_relMap_acc (z : Fin 2 → W ⊕ M) :
-    (K.correspondence).RelMap (corrAcc (L := L)) z ↔
+    K.correspondence.RelMap corrAcc z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
 @[simp] theorem correspondence_relMap_indiv (z : Fin 1 → W ⊕ M) :
-    (K.correspondence).RelMap (corrIndiv (L := L)) z ↔
+    K.correspondence.RelMap corrIndiv z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
 theorem correspondence_funMap_inl (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
     (ds : Fin n → M) (hz : z 0 = Sum.inl w)
     (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
-    (K.correspondence).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
-  show Sum.inr ((z 0).elim
-      (fun w' => K.funInterp f w' fun i => (z i.succ).getRight?.getD default) id) = _
-  rw [hz]
-  show Sum.inr (K.funInterp f w fun i => (z i.succ).getRight?.getD default) = _
-  exact congrArg Sum.inr (congrArg _ (funext fun i => by rw [hds i]; rfl))
+    K.correspondence.funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
+  obtain rfl : z = Fin.cons (Sum.inl w) (fun i => Sum.inr (ds i)) :=
+    funext fun j => Fin.cases hz hds j
+  rfl
 
 /-! ### The translation -/
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -176,13 +176,7 @@ omit [Inhabited M] in
 theorem stVal_update_indiv (v : Var → M) (u : ℕ → W) (x : Var) (d : M) :
     Function.update (stVal v u) (Sum.inl x) (Sum.inr d) =
       stVal (Function.update v x d) u := by
-  funext y
-  rcases y with x' | j
-  · rcases eq_or_ne x' x with rfl | hx
-    · simp [stVal]
-    · rw [Function.update_of_ne (by simpa using hx)]
-      simp [stVal, Function.update_of_ne hx]
-  · rw [Function.update_of_ne (by simp)]; rfl
+  simp only [stVal, Sum.update_elim_inl, Function.comp_update]
 
 omit [Inhabited M] in
 /-- Updating a world slot of a sorted valuation updates the world
@@ -190,13 +184,7 @@ omit [Inhabited M] in
 theorem stVal_update_world (v : Var → M) (u : ℕ → W) (j : ℕ) (w : W) :
     Function.update (stVal v u) (Sum.inr j) (Sum.inl w) =
       stVal v (Function.update u j w) := by
-  funext y
-  rcases y with x | j'
-  · rw [Function.update_of_ne (by simp)]; rfl
-  · rcases eq_or_ne j' j with rfl | hj
-    · simp [stVal]
-    · rw [Function.update_of_ne (by simpa using hj)]
-      simp [stVal, Function.update_of_ne hj]
+  simp only [stVal, Sum.update_elim_inr, Function.comp_update]
 
 /-- A sort-guarded universal quantifies exactly over individuals. -/
 theorem realize_all₁_indivGuard {y : Var ⊕ ℕ}
@@ -206,21 +194,7 @@ theorem realize_all₁_indivGuard {y : Var ⊕ ℕ}
       ∀ d : M,
         (letI := K.correspondence;
           ψ.Realize (Function.update val y (Sum.inr d))) := by
-  let _S := K.correspondence
-  rw [Formula.realize_all₁]
-  constructor
-  · intro h d
-    have hz := h (Sum.inr d)
-    rw [Formula.realize_imp, Formula.realize_rel₁] at hz
-    exact hz ⟨d, Function.update_self ..⟩
-  · intro h z
-    rw [Formula.realize_imp, Formula.realize_rel₁]
-    intro hsort
-    obtain ⟨d, hd⟩ : ∃ d : M, Function.update val y z y = Sum.inr d := by
-      simpa [correspondence_relMap_indiv] using hsort
-    rw [Function.update_self] at hd
-    subst hd
-    exact h d
+  simp [Formula.realize_all₁]
 
 /-- An accessibility-guarded universal quantifies exactly over the worlds
     accessible from the world pinned at index `k`. -/
@@ -234,25 +208,7 @@ theorem realize_all₁_accGuard {j k : ℕ} (hjk : k ≠ j)
       ∀ w' ∈ K.access w,
         (letI := K.correspondence;
           ψ.Realize (Function.update val (Sum.inr j) (Sum.inl w'))) := by
-  let _S := K.correspondence
-  rw [Formula.realize_all₁]
-  constructor
-  · intro h w' hw'
-    have hz := h (Sum.inl w')
-    rw [Formula.realize_imp, Formula.realize_rel₂] at hz
-    simp only [Term.realize_var, Function.update_of_ne
-      (by simpa using hjk : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr j),
-      Function.update_self, hw] at hz
-    exact hz ⟨w, w', rfl, rfl, hw'⟩
-  · intro h z
-    rw [Formula.realize_imp, Formula.realize_rel₂]
-    simp only [Term.realize_var, Function.update_of_ne
-      (by simpa using hjk : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr j),
-      Function.update_self, hw]
-    rintro ⟨w₁, w₂, hw₁, hw₂, hmem⟩
-    obtain rfl : w = w₁ := Sum.inl.inj hw₁
-    subst hw₂
-    exact h w₂ hmem
+  simp [Formula.realize_all₁, Function.update_of_ne (Sum.inr_injective.ne hjk), hw]
 
 /-! ### Satisfaction preservation -/
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -37,9 +37,9 @@ satisfaction preservation.
   constant-domain semantics presupposes a nonempty domain.
 * `realize_st` evaluates translations at sorted valuations `stVal v u` —
   the valuation invariant is carried by the constructor rather than by
-  hypotheses. Binder cases reduce to the two update-commutation lemmas
-  (`stVal_update_indiv`, `stVal_update_world`) and the two relativization
-  lemmas, which discharge off-sort quantifier instances via the guards.
+  hypotheses. `stVal`'s simp interface (evaluation plus the two
+  update-commutation lemmas) lets `simp` discharge every case, including
+  the off-sort quantifier instances behind the sort guards.
 * Freshness of world variables is by increment: each `box` shifts the
   current index from `k` to `k + 1`, and the constraint set of the theorem
   pins only index `k`, so no freshness side conditions arise.
@@ -56,7 +56,7 @@ namespace FirstOrder.Language
 
 variable {W M Var : Type*}
 
-/-! ### The correspondence language and the encoded structure -/
+/-! ### The correspondence language -/
 
 /-- The correspondence language of `L` has an `(n + 1)`-ary symbol for
     each `n`-ary `L`-symbol — the new first argument the world — together
@@ -85,6 +85,35 @@ abbrev corrIndivVar (x : Var) : L.correspondence.Term (Var ⊕ ℕ) := Term.var 
 
 abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
+/-! ### Sorted valuations -/
+
+/-- The sorted valuation of an individual assignment `v` and a world
+    assignment `u`. `realize_st` evaluates translations at these. -/
+def stVal (v : Var → M) (u : ℕ → W) : Var ⊕ ℕ → W ⊕ M :=
+  Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u)
+
+@[simp] theorem stVal_inl (v : Var → M) (u : ℕ → W) (x : Var) :
+    stVal v u (Sum.inl x) = Sum.inr (v x) := rfl
+
+@[simp] theorem stVal_inr (v : Var → M) (u : ℕ → W) (j : ℕ) :
+    stVal v u (Sum.inr j) = Sum.inl (u j) := rfl
+
+/-- Updating an individual slot of a sorted valuation updates the
+    individual assignment. -/
+theorem stVal_update_indiv [DecidableEq Var] (v : Var → M) (u : ℕ → W) (x : Var) (d : M) :
+    Function.update (stVal v u) (Sum.inl x) (Sum.inr d) =
+      stVal (Function.update v x d) u := by
+  simp only [stVal, Sum.update_elim_inl, Function.comp_update]
+
+/-- Updating a world slot of a sorted valuation updates the world
+    assignment. -/
+theorem stVal_update_world [DecidableEq Var] (v : Var → M) (u : ℕ → W) (j : ℕ) (w : W) :
+    Function.update (stVal v u) (Sum.inr j) (Sum.inl w) =
+      stVal v (Function.update u j w) := by
+  simp only [stVal, Sum.update_elim_inr, Function.comp_update]
+
+/-! ### The encoded structure -/
+
 variable [Inhabited M] (K : ModalStructure L W M)
 
 /-- `K.correspondence` encodes a modal structure as a single mathlib
@@ -92,7 +121,8 @@ variable [Inhabited M] (K : ModalStructure L W M)
     worlds and individuals share the carrier, sorted by `corrIndiv`;
     relational guards make all off-sort atoms false, and off-sort function
     arguments default. -/
-@[reducible] def ModalStructure.correspondence : L.correspondence.Structure (W ⊕ M) where
+@[instance_reducible] def ModalStructure.correspondence :
+    L.correspondence.Structure (W ⊕ M) where
   funMap := fun {n} f z => match n, f with
     | 0, f => f.elim
     | _ + 1, f => Sum.inr <| (z 0).elim
@@ -136,8 +166,6 @@ theorem correspondence_funMap_inl (f : L.Functions n) (w : W) (z : Fin (n + 1) �
 
 /-! ### The translation -/
 
-variable [DecidableEq Var]
-
 /-- `stTerm` translates terms: a variable stays put; a function symbol
     applies its world-relativized form at the current world variable. -/
 def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
@@ -150,7 +178,7 @@ def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
     world-relativize; `box` relativizes a fresh world variable
     `Sum.inr (k + 1)` along accessibility; quantifiers relativize to the
     individual sort. -/
-def ModalFormula.st (k : ℕ) :
+def ModalFormula.st [DecidableEq Var] (k : ℕ) :
     ModalFormula L Var → L.correspondence.Formula (Var ⊕ ℕ)
   | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
   | .rel R ts =>
@@ -162,57 +190,8 @@ def ModalFormula.st (k : ℕ) :
   | .all x φ => Formula.all₁ (Sum.inl x)
       (corrIndiv.formula₁ (corrIndivVar x) ⟹ φ.st k)
 
-/-! ### Sorted valuations and relativized quantifiers -/
-
-omit [Inhabited M] in
-/-- The sorted valuation of an individual assignment `v` and a world
-    assignment `u`. `realize_st` evaluates translations at these. -/
-def stVal (v : Var → M) (u : ℕ → W) : Var ⊕ ℕ → W ⊕ M :=
-  Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u)
-
-omit [Inhabited M] in
-/-- Updating an individual slot of a sorted valuation updates the
-    individual assignment. -/
-theorem stVal_update_indiv (v : Var → M) (u : ℕ → W) (x : Var) (d : M) :
-    Function.update (stVal v u) (Sum.inl x) (Sum.inr d) =
-      stVal (Function.update v x d) u := by
-  simp only [stVal, Sum.update_elim_inl, Function.comp_update]
-
-omit [Inhabited M] in
-/-- Updating a world slot of a sorted valuation updates the world
-    assignment. -/
-theorem stVal_update_world (v : Var → M) (u : ℕ → W) (j : ℕ) (w : W) :
-    Function.update (stVal v u) (Sum.inr j) (Sum.inl w) =
-      stVal v (Function.update u j w) := by
-  simp only [stVal, Sum.update_elim_inr, Function.comp_update]
-
-/-- A sort-guarded universal quantifies exactly over individuals. -/
-theorem realize_all₁_indivGuard {y : Var ⊕ ℕ}
-    {ψ : L.correspondence.Formula (Var ⊕ ℕ)} {val : Var ⊕ ℕ → W ⊕ M} :
-    (letI := K.correspondence;
-      (Formula.all₁ y (corrIndiv.formula₁ (Term.var y) ⟹ ψ)).Realize val) ↔
-      ∀ d : M,
-        (letI := K.correspondence;
-          ψ.Realize (Function.update val y (Sum.inr d))) := by
-  simp [Formula.realize_all₁]
-
-/-- An accessibility-guarded universal quantifies exactly over the worlds
-    accessible from the world pinned at index `k`. -/
-theorem realize_all₁_accGuard {j k : ℕ} (hjk : k ≠ j)
-    {ψ : L.correspondence.Formula (Var ⊕ ℕ)} {val : Var ⊕ ℕ → W ⊕ M}
-    {w : W} (hw : val (Sum.inr k) = Sum.inl w) :
-    (letI := K.correspondence;
-      (Formula.all₁ (Sum.inr j)
-        (corrAcc.formula₂ (corrWorldVar k) (corrWorldVar j) ⟹ ψ)).Realize
-          val) ↔
-      ∀ w' ∈ K.access w,
-        (letI := K.correspondence;
-          ψ.Realize (Function.update val (Sum.inr j) (Sum.inl w'))) := by
-  simp [Formula.realize_all₁, Function.update_of_ne (Sum.inr_injective.ne hjk), hw]
-
 /-! ### Satisfaction preservation -/
 
-omit [DecidableEq Var] in
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
     realization at a sorted valuation. -/
 private theorem realize_stTerm {k : ℕ} {v : Var → M} {u : ℕ → W} :
@@ -234,52 +213,23 @@ private theorem realize_stTerm {k : ℕ} {v : Var → M} {u : ℕ → W} :
 
 /-- **Satisfaction preservation for the standard translation**: Kripke
     satisfaction at the world pinned at index `k` is first-order
-    realization over `K.correspondence` at the sorted valuation.
-    Off-sort quantifier instances are discharged by the relational guards
-    (`realize_all₁_indivGuard`, `realize_all₁_accGuard`), and `box`'s fresh
-    world variable `k + 1` leaves index `k` untouched. -/
-theorem realize_st {φ : ModalFormula L Var} {k : ℕ}
+    realization over `K.correspondence` at the sorted valuation. Off-sort
+    quantifier instances are discharged by the relational guards, and
+    `box`'s fresh world variable `k + 1` leaves index `k` untouched. -/
+theorem realize_st [DecidableEq Var] {φ : ModalFormula L Var} {k : ℕ}
     {v : Var → M} {u : ℕ → W} :
     φ.Realize K (u k) v ↔
       (letI := K.correspondence; (φ.st k).Realize (stVal v u)) := by
   induction φ generalizing k v u with
-  | equal t₁ t₂ =>
-    let _S := K.correspondence
-    rw [ModalFormula.st, ModalFormula.realize_equal, Formula.realize_equal,
-      realize_stTerm K, realize_stTerm K]
-    exact ⟨congrArg _, Sum.inr.inj⟩
+  | equal t₁ t₂ => simp [ModalFormula.st, realize_stTerm K]
   | falsum => exact Iff.rfl
-  | imp φ ψ ih₁ ih₂ =>
-    let _S := K.correspondence
-    rw [ModalFormula.realize_imp, ModalFormula.st, Formula.realize_imp]
-    exact imp_congr ih₁ ih₂
+  | imp φ ψ ih₁ ih₂ => simp [ModalFormula.st, ← ih₁, ← ih₂]
   | box φ ih =>
-    rw [ModalFormula.realize_box, ModalFormula.st,
-      realize_all₁_accGuard K (Nat.succ_ne_self k).symm rfl]
-    refine forall₂_congr fun w' _ => ?_
-    rw [stVal_update_world]
-    simpa using ih (k := k + 1) (u := Function.update u (k + 1) w')
+    simp [ModalFormula.st, Formula.realize_all₁, stVal_update_world, ← ih]
   | all x φ ih =>
-    rw [ModalFormula.realize_all, ModalFormula.st,
-      realize_all₁_indivGuard K]
-    refine forall_congr' fun d => ?_
-    rw [stVal_update_indiv]
-    exact ih
+    simp [ModalFormula.st, Formula.realize_all₁, stVal_update_indiv, ← ih]
   | @rel n R ts =>
-    let _S := K.correspondence
-    rw [ModalFormula.st, Formula.realize_rel, correspondence_relMap_rel,
-      ModalFormula.realize_rel]
-    constructor
-    · intro h
-      exact ⟨u k, (fun i => letI := K.interp (u k); (ts i).realize v), rfl,
-        fun i => by simpa [Fin.cons_succ] using realize_stTerm K (ts i), h⟩
-    · rintro ⟨w', ds, hw', hds, h⟩
-      obtain rfl : u k = w' := Sum.inl.inj hw'
-      have hds' : (fun i => letI := K.interp (u k); (ts i).realize v) = ds :=
-        funext fun i => Sum.inr.inj
-          ((realize_stTerm K (ts i)).symm.trans
-            (by simpa [Fin.cons_succ] using hds i))
-      exact hds' ▸ h
+    simp [ModalFormula.st, realize_stTerm K, ModalStructure.relInterp, ← funext_iff]
 
 /-! ### Sort-guarded sentence closure -/
 
@@ -287,15 +237,15 @@ theorem realize_st {φ : ModalFormula L Var} {k : ℕ}
     sort-guarded existential, `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is
     load-bearing on the mixed carrier — a bare `ex₁` could be witnessed by
     a junk individual-as-world, which satisfies `□⊥` vacuously. -/
-def stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
+def stClose [DecidableEq Var] (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
     L.correspondence.Formula (Var ⊕ ℕ) :=
   Formula.ex₁ (Sum.inr k)
     ((corrIndiv.formula₁ (corrWorldVar k)).not ⊓ ψ)
 
 /-- Over `correspondence`, the guarded witness of `stClose` is exactly a
     world. -/
-theorem realize_stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ))
-    (val : Var ⊕ ℕ → W ⊕ M) :
+theorem realize_stClose [DecidableEq Var] (k : ℕ)
+    (ψ : L.correspondence.Formula (Var ⊕ ℕ)) (val : Var ⊕ ℕ → W ⊕ M) :
     (letI := K.correspondence; (stClose k ψ).Realize val) ↔
       ∃ w : W,
         (letI := K.correspondence

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -35,11 +35,11 @@ satisfaction preservation.
   single-sorted `Structure`; they have no independent standing. Junk
   totalization of world-relativized functions is by `[Inhabited M]` —
   constant-domain semantics presupposes a nonempty domain.
-* The valuation in `realize_st` is an arbitrary `val : Var ⊕ ℕ → W ⊕ M`
-  constrained only at individual variables and at the current world index —
-  quantifiers in the translation range over the full mixed carrier, with
-  off-sort values discharged by the relational guards, so no
-  `Sum.elim`-update commutation is needed in the induction.
+* `realize_st` evaluates translations at sorted valuations `stVal v u` —
+  the valuation invariant is carried by the constructor rather than by
+  hypotheses. Binder cases reduce to the two update-commutation lemmas
+  (`stVal_update_indiv`, `stVal_update_world`) and the two relativization
+  lemmas, which discharge off-sort quantifier instances via the guards.
 * Freshness of world variables is by increment: each `box` shifts the
   current index from `k` to `k + 1`, and the constraint set of the theorem
   pins only index `k`, so no freshness side conditions arise.
@@ -162,137 +162,166 @@ def ModalFormula.st (k : ℕ) :
   | .all x φ => Formula.all₁ (Sum.inl x)
       (corrIndiv.formula₁ (corrIndivVar x) ⟹ φ.st k)
 
+/-! ### Sorted valuations and relativized quantifiers -/
+
+omit [Inhabited M] in
+/-- The sorted valuation of an individual assignment `v` and a world
+    assignment `u`. `realize_st` evaluates translations at these. -/
+def stVal (v : Var → M) (u : ℕ → W) : Var ⊕ ℕ → W ⊕ M :=
+  Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u)
+
+omit [Inhabited M] in
+/-- Updating an individual slot of a sorted valuation updates the
+    individual assignment. -/
+theorem stVal_update_indiv (v : Var → M) (u : ℕ → W) (x : Var) (d : M) :
+    Function.update (stVal v u) (Sum.inl x) (Sum.inr d) =
+      stVal (Function.update v x d) u := by
+  funext y
+  rcases y with x' | j
+  · rcases eq_or_ne x' x with rfl | hx
+    · simp [stVal]
+    · rw [Function.update_of_ne (by simpa using hx)]
+      simp [stVal, Function.update_of_ne hx]
+  · rw [Function.update_of_ne (by simp)]; rfl
+
+omit [Inhabited M] in
+/-- Updating a world slot of a sorted valuation updates the world
+    assignment. -/
+theorem stVal_update_world (v : Var → M) (u : ℕ → W) (j : ℕ) (w : W) :
+    Function.update (stVal v u) (Sum.inr j) (Sum.inl w) =
+      stVal v (Function.update u j w) := by
+  funext y
+  rcases y with x | j'
+  · rw [Function.update_of_ne (by simp)]; rfl
+  · rcases eq_or_ne j' j with rfl | hj
+    · simp [stVal]
+    · rw [Function.update_of_ne (by simpa using hj)]
+      simp [stVal, Function.update_of_ne hj]
+
+/-- A sort-guarded universal quantifies exactly over individuals. -/
+theorem realize_all₁_indivGuard {y : Var ⊕ ℕ}
+    {ψ : L.correspondence.Formula (Var ⊕ ℕ)} {val : Var ⊕ ℕ → W ⊕ M} :
+    (letI := K.correspondence;
+      (Formula.all₁ y (corrIndiv.formula₁ (Term.var y) ⟹ ψ)).Realize val) ↔
+      ∀ d : M,
+        (letI := K.correspondence;
+          ψ.Realize (Function.update val y (Sum.inr d))) := by
+  let _S := K.correspondence
+  rw [Formula.realize_all₁]
+  constructor
+  · intro h d
+    have hz := h (Sum.inr d)
+    rw [Formula.realize_imp, Formula.realize_rel₁] at hz
+    exact hz ⟨d, Function.update_self ..⟩
+  · intro h z
+    rw [Formula.realize_imp, Formula.realize_rel₁]
+    intro hsort
+    obtain ⟨d, hd⟩ : ∃ d : M, Function.update val y z y = Sum.inr d := by
+      simpa [correspondence_relMap_indiv] using hsort
+    rw [Function.update_self] at hd
+    subst hd
+    exact h d
+
+/-- An accessibility-guarded universal quantifies exactly over the worlds
+    accessible from the world pinned at index `k`. -/
+theorem realize_all₁_accGuard {j k : ℕ} (hjk : k ≠ j)
+    {ψ : L.correspondence.Formula (Var ⊕ ℕ)} {val : Var ⊕ ℕ → W ⊕ M}
+    {w : W} (hw : val (Sum.inr k) = Sum.inl w) :
+    (letI := K.correspondence;
+      (Formula.all₁ (Sum.inr j)
+        (corrAcc.formula₂ (corrWorldVar k) (corrWorldVar j) ⟹ ψ)).Realize
+          val) ↔
+      ∀ w' ∈ K.access w,
+        (letI := K.correspondence;
+          ψ.Realize (Function.update val (Sum.inr j) (Sum.inl w'))) := by
+  let _S := K.correspondence
+  rw [Formula.realize_all₁]
+  constructor
+  · intro h w' hw'
+    have hz := h (Sum.inl w')
+    rw [Formula.realize_imp, Formula.realize_rel₂] at hz
+    simp only [Term.realize_var, Function.update_of_ne
+      (by simpa using hjk : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr j),
+      Function.update_self, hw] at hz
+    exact hz ⟨w, w', rfl, rfl, hw'⟩
+  · intro h z
+    rw [Formula.realize_imp, Formula.realize_rel₂]
+    simp only [Term.realize_var, Function.update_of_ne
+      (by simpa using hjk : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr j),
+      Function.update_self, hw]
+    rintro ⟨w₁, w₂, hw₁, hw₂, hmem⟩
+    obtain rfl : w = w₁ := Sum.inl.inj hw₁
+    subst hw₂
+    exact h w₂ hmem
+
 /-! ### Satisfaction preservation -/
 
 omit [DecidableEq Var] in
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
-    realization, via the world pinned at index `k`. -/
-private theorem realize_stTerm {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
-    (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
-    (hw : val (Sum.inr k) = Sum.inl w) :
+    realization at a sorted valuation. -/
+private theorem realize_stTerm {k : ℕ} {v : Var → M} {u : ℕ → W} :
     ∀ t : L.Term Var,
-      (letI := K.correspondence; (stTerm k t).realize val) =
-        Sum.inr (letI := K.interp w; t.realize v)
-  | .var x => hind x
+      (letI := K.correspondence; (stTerm k t).realize (stVal v u)) =
+        Sum.inr (letI := K.interp (u k); t.realize v)
+  | .var x => rfl
   | .func f args => by
     let _S := K.correspondence
-    let _I := K.interp w
+    let _I := K.interp (u k)
     rw [show stTerm k (.func f args) = Term.func (corrFunc f)
         (Fin.cons (corrWorldVar k) fun i => stTerm k (args i)) from rfl,
       Term.realize_func,
-      correspondence_funMap_inl K f w _
-        (fun i => (letI := K.interp w; (args i).realize v))
-        (by simpa using hw)
-        (fun i => by
-          simpa [Fin.cons_succ] using realize_stTerm hind hw (args i))]
+      correspondence_funMap_inl K f (u k) _
+        (fun i => (letI := K.interp (u k); (args i).realize v))
+        rfl
+        (fun i => by simpa [Fin.cons_succ] using realize_stTerm (args i))]
     rfl
 
-omit [Inhabited M] in
-/-- An individual-sorted update of an individual-sorted valuation. -/
-private theorem sorted_update {val : Var ⊕ ℕ → W ⊕ M} {v : Var → M}
-    (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x)) (x : Var) (d : M) :
-    ∀ y, Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl y) =
-      Sum.inr (Function.update v x d y) := by
-  intro y
-  by_cases hy : y = x
-  · subst hy; rw [Function.update_self, Function.update_self]
-  · rw [Function.update_of_ne (by simpa using hy), Function.update_of_ne hy,
-      hind]
-
-omit [Inhabited M] in
-/-- Individual updates leave the pinned world index untouched. -/
-private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
-    (hw : val (Sum.inr k) = Sum.inl w) (x : Var) (z : W ⊕ M) :
-    Function.update val (Sum.inl x) z (Sum.inr k) = Sum.inl w := by
-  rw [Function.update_of_ne (by simp)]; exact hw
-
 /-- **Satisfaction preservation for the standard translation**: Kripke
-    satisfaction at `w` is first-order realization over `correspondence`, for
-    any valuation that is individual-sorted on `Var` and pins the current
-    world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
-    discharged by the relational guards, and `box`'s fresh world variable
-    `k + 1` leaves the pinned index untouched. -/
+    satisfaction at the world pinned at index `k` is first-order
+    realization over `K.correspondence` at the sorted valuation.
+    Off-sort quantifier instances are discharged by the relational guards
+    (`realize_all₁_indivGuard`, `realize_all₁_accGuard`), and `box`'s fresh
+    world variable `k + 1` leaves index `k` untouched. -/
 theorem realize_st {φ : ModalFormula L Var} {k : ℕ}
-    {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
-    (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
-    (hw : val (Sum.inr k) = Sum.inl w) :
-    φ.Realize K w v ↔ (letI := K.correspondence; (φ.st k).Realize val) := by
-  induction φ generalizing k val w v with
+    {v : Var → M} {u : ℕ → W} :
+    φ.Realize K (u k) v ↔
+      (letI := K.correspondence; (φ.st k).Realize (stVal v u)) := by
+  induction φ generalizing k v u with
   | equal t₁ t₂ =>
     let _S := K.correspondence
     rw [ModalFormula.st, ModalFormula.realize_equal, Formula.realize_equal,
-      realize_stTerm K hind hw, realize_stTerm K hind hw]
+      realize_stTerm K, realize_stTerm K]
     exact ⟨congrArg _, Sum.inr.inj⟩
   | falsum => exact Iff.rfl
   | imp φ ψ ih₁ ih₂ =>
     let _S := K.correspondence
     rw [ModalFormula.realize_imp, ModalFormula.st, Formula.realize_imp]
-    exact imp_congr (ih₁ hind hw) (ih₂ hind hw)
+    exact imp_congr ih₁ ih₂
   | box φ ih =>
-    let _S := K.correspondence
-    rw [ModalFormula.realize_box, ModalFormula.st, Formula.realize_all₁]
-    constructor
-    · intro h z
-      rw [Formula.realize_imp, Formula.realize_rel₂]
-      simp only [Term.realize_var, Function.update_of_ne
-        (by simp : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr (k + 1)),
-        Function.update_self, hw]
-      rintro ⟨w₁, w₂, hw₁, hw₂, hmem⟩
-      obtain rfl : w = w₁ := Sum.inl.inj hw₁
-      subst hw₂
-      refine (ih ?_ ?_).mp (h w₂ hmem)
-      · intro x
-        rw [Function.update_of_ne (by simp), hind]
-      · rw [Function.update_self]
-    · intro h w' hw'
-      have hz := h (Sum.inl w')
-      rw [Formula.realize_imp, Formula.realize_rel₂] at hz
-      simp only [Term.realize_var, Function.update_of_ne
-        (by simp : (Sum.inr k : Var ⊕ ℕ) ≠ Sum.inr (k + 1)),
-        Function.update_self, hw] at hz
-      refine (ih ?_ ?_).mpr (hz ⟨w, w', rfl, rfl, hw'⟩)
-      · intro x
-        rw [Function.update_of_ne (by simp), hind]
-      · rw [Function.update_self]
+    rw [ModalFormula.realize_box, ModalFormula.st,
+      realize_all₁_accGuard K (Nat.succ_ne_self k).symm rfl]
+    refine forall₂_congr fun w' _ => ?_
+    rw [stVal_update_world]
+    simpa using ih (k := k + 1) (u := Function.update u (k + 1) w')
   | all x φ ih =>
-    let _S := K.correspondence
-    rw [ModalFormula.realize_all, ModalFormula.st, Formula.realize_all₁]
-    constructor
-    · intro h z
-      rw [Formula.realize_imp, Formula.realize_rel₁]
-      intro hsort
-      obtain ⟨d, hd⟩ : ∃ d : M,
-          Function.update val (Sum.inl x) z (Sum.inl x) = Sum.inr d := by
-        simpa [correspondence_relMap_indiv] using hsort
-      rw [Function.update_self] at hd
-      subst hd
-      exact (ih (sorted_update hind x d) (pinned_update hw x _)).mp (h d)
-    · intro h d
-      have hz := h (Sum.inr d)
-      rw [Formula.realize_imp, Formula.realize_rel₁] at hz
-      refine (ih (sorted_update hind x d) (pinned_update hw x _)).mpr
-        (hz ⟨d, ?_⟩)
-      show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
-      rw [Function.update_self]
+    rw [ModalFormula.realize_all, ModalFormula.st,
+      realize_all₁_indivGuard K]
+    refine forall_congr' fun d => ?_
+    rw [stVal_update_indiv]
+    exact ih
   | @rel n R ts =>
     let _S := K.correspondence
     rw [ModalFormula.st, Formula.realize_rel, correspondence_relMap_rel,
       ModalFormula.realize_rel]
     constructor
     · intro h
-      refine ⟨w, (fun i => letI := K.interp w; (ts i).realize v),
-        by simpa using hw,
-        fun i => by simpa [Fin.cons_succ] using realize_stTerm K hind hw (ts i),
-        h⟩
+      exact ⟨u k, (fun i => letI := K.interp (u k); (ts i).realize v), rfl,
+        fun i => by simpa [Fin.cons_succ] using realize_stTerm K (ts i), h⟩
     · rintro ⟨w', ds, hw', hds, h⟩
-      obtain rfl : w = w' := by
-        rw [show ((Fin.cons (corrWorldVar k)
-            (fun i => stTerm k (ts i)) : Fin _ → _) 0).realize val =
-          val (Sum.inr k) from rfl] at hw'
-        exact Sum.inl.inj (hw.symm.trans hw')
-      have hds' : (fun i => letI := K.interp w; (ts i).realize v) = ds :=
+      obtain rfl : u k = w' := Sum.inl.inj hw'
+      have hds' : (fun i => letI := K.interp (u k); (ts i).realize v) = ds :=
         funext fun i => Sum.inr.inj
-          ((realize_stTerm K hind hw (ts i)).symm.trans
+          ((realize_stTerm K (ts i)).symm.trans
             (by simpa [Fin.cons_succ] using hds i))
       exact hds' ▸ h
 

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -85,14 +85,14 @@ abbrev corrIndivVar (x : Var) : L.correspondence.Term (Var ⊕ ℕ) := Term.var 
 
 abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
+variable [Inhabited M] (K : ModalStructure L W M)
+
 /-- `K.correspondence` encodes a modal structure as a single mathlib
     structure on `W ⊕ M` — the structure half of `Language.correspondence`:
     worlds and individuals share the carrier, sorted by `corrIndiv`;
     relational guards make all off-sort atoms false, and off-sort function
     arguments default. -/
-@[reducible] def ModalStructure.correspondence [Inhabited M]
-    (K : ModalStructure L W M) :
-    L.correspondence.Structure (W ⊕ M) where
+@[reducible] def ModalStructure.correspondence : L.correspondence.Structure (W ⊕ M) where
   funMap := fun {n} f z => match n, f with
     | 0, f => f.elim
     | _ + 1, f => Sum.inr <| (z 0).elim
@@ -109,30 +109,24 @@ abbrev corrWorldVar (k : ℕ) : L.correspondence.Term (Var ⊕ ℕ) := Term.var 
               ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
           | _ + 2, _, u => u.elim)
 
-variable [Inhabited M]
-
-@[simp] theorem correspondence_relMap_rel (K : ModalStructure L W M)
-    (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
+@[simp] theorem correspondence_relMap_rel (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
     (K.correspondence).RelMap (corrRel R) z ↔
       ∃ (w : W) (ds : Fin n → M),
         z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
           K.relInterp R w ds :=
   Iff.rfl
 
-@[simp] theorem correspondence_relMap_acc (K : ModalStructure L W M)
-    (z : Fin 2 → W ⊕ M) :
+@[simp] theorem correspondence_relMap_acc (z : Fin 2 → W ⊕ M) :
     (K.correspondence).RelMap (corrAcc (L := L)) z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
-@[simp] theorem correspondence_relMap_indiv (K : ModalStructure L W M)
-    (z : Fin 1 → W ⊕ M) :
+@[simp] theorem correspondence_relMap_indiv (z : Fin 1 → W ⊕ M) :
     (K.correspondence).RelMap (corrIndiv (L := L)) z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
-theorem correspondence_funMap_inl (K : ModalStructure L W M)
-    (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
+theorem correspondence_funMap_inl (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
     (ds : Fin n → M) (hz : z 0 = Sum.inl w)
     (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
     (K.correspondence).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
@@ -176,8 +170,7 @@ def ModalFormula.st (k : ℕ) :
 omit [DecidableEq Var] in
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
     realization, via the world pinned at index `k`. -/
-private theorem realize_stTerm (K : ModalStructure L W M)
-    {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
+private theorem realize_stTerm {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
     ∀ t : L.Term Var,
@@ -194,7 +187,7 @@ private theorem realize_stTerm (K : ModalStructure L W M)
         (fun i => (letI := K.interp w; (args i).realize v))
         (by simpa using hw)
         (fun i => by
-          simpa [Fin.cons_succ] using realize_stTerm K hind hw (args i))]
+          simpa [Fin.cons_succ] using realize_stTerm hind hw (args i))]
     rfl
 
 omit [Inhabited M] in
@@ -222,8 +215,7 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
     `k + 1` leaves the pinned index untouched. -/
-theorem realize_st (K : ModalStructure L W M)
-    {φ : ModalFormula L Var} {k : ℕ}
+theorem realize_st {φ : ModalFormula L Var} {k : ℕ}
     {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
@@ -320,8 +312,7 @@ def stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
 
 /-- Over `correspondence`, the guarded witness of `stClose` is exactly a
     world. -/
-theorem realize_stClose (K : ModalStructure L W M)
-    (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ))
+theorem realize_stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ))
     (val : Var ⊕ ℕ → W ⊕ M) :
     (letI := K.correspondence; (stClose k ψ).Realize val) ↔
       ∃ w : W,

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -1,22 +1,19 @@
-import Linglib.Core.ModelTheory.FiniteModel
 import Linglib.Logic.Modal.FirstOrder.Semantics
 
 /-!
 # The correspondence language and the standard translation
 
-The standard translation of modal logic into first-order logic, for the
-monadic signature with constants: modal formulas over
-`Language.monadicWithConstants Const Pred` translate into plain mathlib
-first-order formulas over the correspondence language
-`Language.correspondence Const Pred` — accessibility as a binary relation,
-predicates world-relativized to binary relations, constants world-indexed
-to unary functions, and an individual-sort predicate — interpreted on the
-two-sorted-as-one carrier `W ⊕ M`. `realize_st` is satisfaction
-preservation.
+The standard translation of quantified modal logic into first-order logic,
+for an arbitrary signature: modal formulas over `L` translate into plain
+mathlib first-order formulas over the correspondence language
+`L.correspondence` — every symbol world-relativized to one arity higher,
+plus a binary accessibility relation and an individual-sort predicate —
+interpreted on the two-sorted-as-one carrier `W ⊕ M`. `realize_st` is
+satisfaction preservation.
 
 ## Main declarations
 
-* `Language.correspondence` — the target signature;
+* `Language.correspondence` — the correspondence language of `L`;
   `ModalStructure.corrStructure` — the `W ⊕ M` encoding of a modal
   structure as one mathlib structure.
 * `ModalFormula.st` — the standard translation, total: the current world is
@@ -30,6 +27,14 @@ preservation.
 
 ## Implementation notes
 
+* The canonical object here is the *two-sorted* first-order view of a
+  modal structure (worlds with accessibility; individuals; world-relativized
+  symbols) — the same object, in the correspondence-theory sense. The
+  `W ⊕ M` carrier, the sort predicate, and the off-sort guards are the
+  standard many-sorted-to-one-sorted coding, forced by mathlib's
+  single-sorted `Structure`; they have no independent standing. Junk
+  totalization of world-relativized functions is by `[Inhabited M]` —
+  constant-domain semantics presupposes a nonempty domain.
 * The valuation in `realize_st` is an arbitrary `val : Var ⊕ ℕ → W ⊕ M`
   constrained only at individual variables and at the current world index —
   quantifiers in the translation range over the full mixed carrier, with
@@ -45,130 +50,130 @@ preservation.
 ## References
 
 * [blackburn-derijke-venema-2001] — the standard translation
-* [aloni-vanormondt-2023] — Proposition 4.1, composed with the translation
-  for compactness
 -/
 
 namespace FirstOrder.Language
 
-variable {W M Var Const Pred : Type*}
+variable {W M Var : Type*}
 
-/-! ### The target signature and the encoded structure -/
+/-! ### The correspondence language and the encoded structure -/
 
-/-- The standard-translation target signature: world-indexed constants as
-    unary functions, an individual-sort predicate (unary), and
-    world-relativized monadic predicates plus accessibility (binary). -/
-def correspondence (Const : Type*) (Pred : Type*) : FirstOrder.Language where
+/-- The correspondence language of `L`: every `L`-symbol world-relativized
+    to one arity higher (the new first argument the world), plus an
+    individual-sort predicate (unary, `corrIndiv`) and an accessibility
+    relation (binary, `corrAcc`). -/
+def correspondence (L : Language) : Language where
   Functions := fun n => match n with
-    | 1 => Const
-    | _ => PEmpty
+    | 0 => PEmpty
+    | n + 1 => L.Functions n
   Relations := fun n => match n with
-    | 1 => PUnit
-    | 2 => Pred ⊕ PUnit
-    | _ => PEmpty
+    | 0 => PEmpty
+    | n + 1 => L.Relations n ⊕ (match n with | 0 | 1 => PUnit | _ => PEmpty)
 
-/-- A constant as a unary function symbol of the target signature. -/
-abbrev corrConst (c : Const) :
-    (correspondence Const Pred).Functions 1 := c
+variable {L : Language}
+
+/-- An `L`-function symbol, world-relativized. -/
+abbrev corrFunc {n : ℕ} (f : L.Functions n) :
+    L.correspondence.Functions (n + 1) := f
+
+/-- An `L`-relation symbol, world-relativized. -/
+abbrev corrRel {n : ℕ} (R : L.Relations n) :
+    L.correspondence.Relations (n + 1) := Sum.inl R
 
 /-- The individual-sort predicate. -/
-abbrev corrIndiv : (correspondence Const Pred).Relations 1 :=
-  PUnit.unit
-
-/-- A predicate as a world-relativized binary relation symbol. -/
-abbrev corrRel (P : Pred) :
-    (correspondence Const Pred).Relations 2 := Sum.inl P
+abbrev corrIndiv : L.correspondence.Relations 1 := Sum.inr PUnit.unit
 
 /-- The accessibility relation symbol. -/
-abbrev corrAcc : (correspondence Const Pred).Relations 2 :=
-  Sum.inr PUnit.unit
+abbrev corrAcc : L.correspondence.Relations 2 := Sum.inr PUnit.unit
 
 /-- An individual variable as a sorted term of the correspondence
     language. -/
 abbrev corrIndivVar (x : Var) :
-    (correspondence Const Pred).Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
+    L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inl x)
 
 /-- A world variable as a sorted term of the correspondence language. -/
 abbrev corrWorldVar (k : ℕ) :
-    (correspondence Const Pred).Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
+    L.correspondence.Term (Var ⊕ ℕ) := Term.var (Sum.inr k)
 
-/-- The `W ⊕ M` encoding of a Kripke model over the monadic signature
-    as a single mathlib structure: worlds and individuals share the carrier,
-    sorted by `corrIndiv`; relational guards make all off-sort atoms false. -/
-@[reducible] def ModalStructure.corrStructure
-    (K : ModalStructure (monadicWithConstants Const Pred) W M) :
-    (correspondence Const Pred).Structure (W ⊕ M) where
-  funMap := fun {n} f => match n, f with
-    | 1, c => fun z => match z 0 with
-      | Sum.inl w => Sum.inr (K.constInterp c w)
-      | Sum.inr d => Sum.inr d
+/-- The `W ⊕ M` encoding of a modal structure as a single mathlib
+    structure: worlds and individuals share the carrier, sorted by
+    `corrIndiv`; relational guards make all off-sort atoms false, and
+    off-sort function arguments default. -/
+@[reducible] def ModalStructure.corrStructure [Inhabited M]
+    (K : ModalStructure L W M) :
+    L.correspondence.Structure (W ⊕ M) where
+  funMap := fun {n} f z => match n, f with
     | 0, f => f.elim
-    | _ + 2, f => f.elim
-  RelMap := fun {n} r => match n, r with
-    | 1, _ => fun z => ∃ d : M, z 0 = Sum.inr d
-    | 2, Sum.inl P => fun z =>
-        ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.relInterp₁ P w d
-    | 2, Sum.inr _ => fun z =>
-        ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
+    | _ + 1, f => match z 0 with
+      | Sum.inl w =>
+          Sum.inr (K.funInterp f w fun i => (z i.succ).elim (fun _ => default) id)
+      | Sum.inr d => Sum.inr d
+  RelMap := fun {n} r z => match n, r with
     | 0, r => r.elim
-    | _ + 3, r => r.elim
+    | n + 1, r => r.elim
+        (fun R => ∃ (w : W) (ds : Fin n → M),
+          z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
+            K.relInterp R w ds)
+        (fun u => match n, z, u with
+          | 0, z, _ => ∃ d : M, z 0 = Sum.inr d
+          | 1, z, _ =>
+              ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁
+          | _ + 2, _, u => u.elim)
 
-@[simp] theorem corrStructure_relMap_rel
-    (K : ModalStructure (monadicWithConstants Const Pred) W M)
-    (P : Pred) (z : Fin 2 → W ⊕ M) :
-    (K.corrStructure).RelMap (corrRel P) z ↔
-      ∃ w d, z 0 = Sum.inl w ∧ z 1 = Sum.inr d ∧ K.relInterp₁ P w d :=
+variable [Inhabited M]
+
+@[simp] theorem corrStructure_relMap_rel (K : ModalStructure L W M)
+    {n : ℕ} (R : L.Relations n) (z : Fin (n + 1) → W ⊕ M) :
+    (K.corrStructure).RelMap (corrRel R) z ↔
+      ∃ (w : W) (ds : Fin n → M),
+        z 0 = Sum.inl w ∧ (∀ i, z i.succ = Sum.inr (ds i)) ∧
+          K.relInterp R w ds :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_acc (K : ModalStructure (monadicWithConstants Const Pred) W M)
+@[simp] theorem corrStructure_relMap_acc (K : ModalStructure L W M)
     (z : Fin 2 → W ⊕ M) :
-    (K.corrStructure).RelMap (corrAcc (Const := Const)) z ↔
+    (K.corrStructure).RelMap (corrAcc (L := L)) z ↔
       ∃ w₁ w₂, z 0 = Sum.inl w₁ ∧ z 1 = Sum.inl w₂ ∧ w₂ ∈ K.access w₁ :=
   Iff.rfl
 
-@[simp] theorem corrStructure_relMap_indiv
-    (K : ModalStructure (monadicWithConstants Const Pred) W M)
+@[simp] theorem corrStructure_relMap_indiv (K : ModalStructure L W M)
     (z : Fin 1 → W ⊕ M) :
-    (K.corrStructure).RelMap (corrIndiv (Const := Const)) z ↔
+    (K.corrStructure).RelMap (corrIndiv (L := L)) z ↔
       ∃ d : M, z 0 = Sum.inr d :=
   Iff.rfl
 
-theorem corrStructure_funMap_inl (K : ModalStructure (monadicWithConstants Const Pred) W M)
-    (c : Const) (w : W) (z : Fin 1 → W ⊕ M) (hz : z 0 = Sum.inl w) :
-    (K.corrStructure).funMap (corrConst (Pred := Pred) c) z =
-      Sum.inr (K.constInterp c w) := by
+theorem corrStructure_funMap_inl (K : ModalStructure L W M)
+    {n : ℕ} (f : L.Functions n) (w : W) (z : Fin (n + 1) → W ⊕ M)
+    (ds : Fin n → M) (hz : z 0 = Sum.inl w)
+    (hds : ∀ i, z i.succ = Sum.inr (ds i)) :
+    (K.corrStructure).funMap (corrFunc f) z = Sum.inr (K.funInterp f w ds) := by
   show (match z 0 with
-    | Sum.inl w' => Sum.inr (K.constInterp c w')
+    | Sum.inl w' =>
+        Sum.inr (K.funInterp f w' fun i => (z i.succ).elim (fun _ => default) id)
     | Sum.inr d => Sum.inr d) = _
   rw [hz]
+  exact congrArg Sum.inr (congrArg _ (funext fun i => by rw [hds i]; rfl))
 
 /-! ### The translation -/
 
 variable [DecidableEq Var]
 
-/-- Translate a monadic term: variables stay, constants become their unary
-    function applied to the current world variable. -/
-def stTerm (k : ℕ) :
-    (monadicWithConstants Const Pred).Term Var →
-      (correspondence Const Pred).Term (Var ⊕ ℕ)
+/-- Translate a term: variables stay, function symbols apply their
+    world-relativized forms at the current world variable. -/
+def stTerm (k : ℕ) : L.Term Var → L.correspondence.Term (Var ⊕ ℕ)
   | .var x => corrIndivVar x
-  | @Term.func _ _ l f _ => match l, f with
-    | 0, c => Term.func (corrConst c) ![corrWorldVar k]
-    | _ + 1, f => f.elim
+  | .func f args =>
+      Term.func (corrFunc f) (Fin.cons (corrWorldVar k) fun i => stTerm k (args i))
 
 /-- The standard translation `ST_k` ([blackburn-derijke-venema-2001]): the
-    current world is the free variable `Sum.inr k`; `box` relativizes a
-    fresh world variable `Sum.inr (k + 1)` along accessibility; quantifiers
-    relativize to the individual sort. Total — `ModalFormula` atoms are
-    atomic. -/
+    current world is the free variable `Sum.inr k`; atoms world-relativize;
+    `box` relativizes a fresh world variable `Sum.inr (k + 1)` along
+    accessibility; quantifiers relativize to the individual sort. -/
 def ModalFormula.st (k : ℕ) :
-    ModalFormula (monadicWithConstants Const Pred) Var →
-      (correspondence Const Pred).Formula (Var ⊕ ℕ)
+    ModalFormula L Var → L.correspondence.Formula (Var ⊕ ℕ)
   | .equal t₁ t₂ => Term.equal (stTerm k t₁) (stTerm k t₂)
-  | @ModalFormula.rel _ _ l R ts => match l, R, ts with
-    | 1, P, ts => (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0))
-    | 0, r, _ => r.elim
-    | _ + 2, r, _ => r.elim
+  | .rel R ts =>
+      (corrRel R).formula (Fin.cons (corrWorldVar k) fun i => stTerm k (ts i))
   | .falsum => ⊥
   | .imp φ ψ => (φ.st k).imp (ψ.st k)
   | .box φ => Formula.all₁ (Sum.inr (k + 1))
@@ -182,34 +187,28 @@ def ModalFormula.st (k : ℕ) :
 omit [DecidableEq Var] in
 /-- Translated terms realize to the individual sort: `stTerm` commutes with
     realization, via the world pinned at index `k`. -/
-private theorem realize_stTerm
-    (K : ModalStructure (monadicWithConstants Const Pred) W M)
+private theorem realize_stTerm (K : ModalStructure L W M)
     {k : ℕ} {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
-    (hw : val (Sum.inr k) = Sum.inl w)
-    (t : (monadicWithConstants Const Pred).Term Var) :
-    (letI := K.corrStructure; (stTerm k t).realize val) =
-      Sum.inr (letI := K.interp w; t.realize v) := by
-  let _S := K.corrStructure
-  cases t with
-  | var x => exact hind x
-  | @func l f args =>
-    match l, f with
-    | _ + 1, f => exact f.elim
-    | 0, c =>
-      let _I := K.interp w
-      rw [show stTerm k (.func c args) =
-          Term.func (corrConst c) ![corrWorldVar k] from rfl,
-        show (Term.func (corrConst c) ![corrWorldVar k] :
-            (correspondence Const Pred).Term (Var ⊕ ℕ)).realize val =
-          (K.corrStructure).funMap (corrConst c)
-            fun i => (![corrWorldVar k] i).realize val from rfl,
-        corrStructure_funMap_inl K c w _ (by simpa using hw)]
-      refine congrArg Sum.inr ?_
-      show (K.interp w).funMap (monadicConst c) default = _
-      show _ = (K.interp w).funMap (monadicConst c) fun i => (args i).realize v
-      exact congrArg _ (funext fun i => i.elim0)
+    (hw : val (Sum.inr k) = Sum.inl w) :
+    ∀ t : L.Term Var,
+      (letI := K.corrStructure; (stTerm k t).realize val) =
+        Sum.inr (letI := K.interp w; t.realize v)
+  | .var x => hind x
+  | .func f args => by
+    let _S := K.corrStructure
+    let _I := K.interp w
+    rw [show stTerm k (.func f args) = Term.func (corrFunc f)
+        (Fin.cons (corrWorldVar k) fun i => stTerm k (args i)) from rfl,
+      Term.realize_func,
+      corrStructure_funMap_inl K f w _
+        (fun i => (letI := K.interp w; (args i).realize v))
+        (by simpa using hw)
+        (fun i => by
+          simpa [Fin.cons_succ] using realize_stTerm K hind hw (args i))]
+    rfl
 
+omit [Inhabited M] in
 /-- An individual-sorted update of an individual-sorted valuation. -/
 private theorem sorted_update {val : Var ⊕ ℕ → W ⊕ M} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x)) (x : Var) (d : M) :
@@ -221,6 +220,7 @@ private theorem sorted_update {val : Var ⊕ ℕ → W ⊕ M} {v : Var → M}
   · rw [Function.update_of_ne (by simpa using hy), Function.update_of_ne hy,
       hind]
 
+omit [Inhabited M] in
 /-- Individual updates leave the pinned world index untouched. -/
 private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     (hw : val (Sum.inr k) = Sum.inl w) (x : Var) (z : W ⊕ M) :
@@ -233,8 +233,8 @@ private theorem pinned_update {val : Var ⊕ ℕ → W ⊕ M} {w : W} {k : ℕ}
     world variable `Sum.inr k` to `w`. Off-sort quantifier instances are
     discharged by the relational guards, and `box`'s fresh world variable
     `k + 1` leaves the pinned index untouched. -/
-theorem realize_st (K : ModalStructure (monadicWithConstants Const Pred) W M)
-    {φ : ModalFormula (monadicWithConstants Const Pred) Var} {k : ℕ}
+theorem realize_st (K : ModalStructure L W M)
+    {φ : ModalFormula L Var} {k : ℕ}
     {val : Var ⊕ ℕ → W ⊕ M} {w : W} {v : Var → M}
     (hind : ∀ x, val (Sum.inl x) = Sum.inr (v x))
     (hw : val (Sum.inr k) = Sum.inl w) :
@@ -296,30 +296,27 @@ theorem realize_st (K : ModalStructure (monadicWithConstants Const Pred) W M)
         (hz ⟨d, ?_⟩)
       show Function.update val (Sum.inl x) (Sum.inr d) (Sum.inl x) = _
       rw [Function.update_self]
-  | @rel l R ts =>
-    match l, R with
-    | 0, r => exact r.elim
-    | (n + 2), r => exact r.elim
-    | 1, (P : Pred) =>
-      let _S := K.corrStructure
-      rw [show (ModalFormula.rel (P : (monadicWithConstants Const
-            Pred).Relations 1) ts).st k =
-          (corrRel P).formula₂ (corrWorldVar k) (stTerm k (ts 0)) from rfl,
-        Formula.realize_rel₂, corrStructure_relMap_rel,
-        ModalFormula.realize_rel,
-        show (fun i => letI := K.interp w; ((ts i).realize v)) =
-          fun _ => (letI := K.interp w; (ts 0).realize v) from
-          funext fun i => by rw [Subsingleton.elim i 0] ]
-      constructor
-      · intro h
-        exact ⟨w, (letI := K.interp w; (ts 0).realize v), by simpa using hw,
-          realize_stTerm K hind hw (ts 0), h⟩
-      · rintro ⟨w', d, hw', hd, h⟩
-        obtain rfl : w = w' := Sum.inl.inj ((by simpa using hw : (corrWorldVar
-          (Const := Const) (Pred := Pred) k).realize val = Sum.inl w).symm.trans hw')
-        obtain rfl : (letI := K.interp w; (ts 0).realize v) = d :=
-          Sum.inr.inj ((realize_stTerm K hind hw (ts 0)).symm.trans hd)
-        exact h
+  | @rel n R ts =>
+    let _S := K.corrStructure
+    rw [ModalFormula.st, Formula.realize_rel, corrStructure_relMap_rel,
+      ModalFormula.realize_rel]
+    constructor
+    · intro h
+      refine ⟨w, (fun i => letI := K.interp w; (ts i).realize v),
+        by simpa using hw,
+        fun i => by simpa [Fin.cons_succ] using realize_stTerm K hind hw (ts i),
+        h⟩
+    · rintro ⟨w', ds, hw', hds, h⟩
+      obtain rfl : w = w' := by
+        rw [show ((Fin.cons (corrWorldVar k)
+            (fun i => stTerm k (ts i)) : Fin _ → _) 0).realize val =
+          val (Sum.inr k) from rfl] at hw'
+        exact Sum.inl.inj (hw.symm.trans hw')
+      have hds' : (fun i => letI := K.interp w; (ts i).realize v) = ds :=
+        funext fun i => Sum.inr.inj
+          ((realize_stTerm K hind hw (ts i)).symm.trans
+            (by simpa [Fin.cons_succ] using hds i))
+      exact hds' ▸ h
 
 /-! ### Sort-guarded sentence closure -/
 
@@ -327,15 +324,15 @@ theorem realize_st (K : ModalStructure (monadicWithConstants Const Pred) W M)
     `Sum.inr k`: `∃z(¬IsIndiv(z) ∧ ψ)`. The guard is load-bearing on the
     mixed carrier — a bare `ex₁` could be witnessed by a junk
     individual-as-world, which satisfies `□⊥` vacuously. -/
-def stClose (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ)) :
-    (correspondence Const Pred).Formula (Var ⊕ ℕ) :=
+def stClose (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ)) :
+    L.correspondence.Formula (Var ⊕ ℕ) :=
   Formula.ex₁ (Sum.inr k)
     ((corrIndiv.formula₁ (corrWorldVar k)).not ⊓ ψ)
 
 /-- Over `corrStructure`, the guarded witness of `stClose` is exactly a
     world. -/
-theorem realize_stClose (K : ModalStructure (monadicWithConstants Const Pred) W M)
-    (k : ℕ) (ψ : (correspondence Const Pred).Formula (Var ⊕ ℕ))
+theorem realize_stClose (K : ModalStructure L W M)
+    (k : ℕ) (ψ : L.correspondence.Formula (Var ⊕ ℕ))
     (val : Var ⊕ ℕ → W ⊕ M) :
     (letI := K.corrStructure; (stClose k ψ).Realize val) ↔
       ∃ w : W,

--- a/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
+++ b/Linglib/Logic/Modal/FirstOrder/Correspondence.lean
@@ -59,9 +59,8 @@ variable {W M Var : Type*}
 /-! ### The correspondence language and the encoded structure -/
 
 /-- The correspondence language of `L`: every `L`-symbol world-relativized
-    to one arity higher (the new first argument the world), plus an
-    individual-sort predicate (unary, `corrIndiv`) and an accessibility
-    relation (binary, `corrAcc`). -/
+    to one arity higher — the new first argument the world — plus an
+    individual-sort predicate and the accessibility relation. -/
 def correspondence (L : Language) : Language where
   Functions := fun n => match n with
     | 0 => PEmpty

--- a/Linglib/Logic/Team/BSML/Scenarios.lean
+++ b/Linglib/Logic/Team/BSML/Scenarios.lean
@@ -38,7 +38,7 @@ inductive FCAtom
   | b
   /-- Third atom for embedded scenarios (negative free choice). -/
   | c
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Inhabited
 
 instance : Fintype FCAtom where
   elems := {.a, .b, .c}

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -23,7 +23,7 @@ open FirstOrder Language
 
 variable {W Var Const Pred Domain : Type*}
 variable [DecidableEq W] [DecidableEq Var] [Fintype Var]
-variable [DecidableEq Domain] [Fintype Domain]
+variable [DecidableEq Domain] [Fintype Domain] [Inhabited Domain]
 
 /-! ### Proposition 4.1, composed: QBSML support is first-order realization -/
 
@@ -72,7 +72,7 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
 
 /-- Conversely, the closed standard translation as a sentence of
     `corrStructure` yields support at some singleton state. -/
-theorem exists_support_of_models_toSentence [Nonempty Domain]
+theorem exists_support_of_models_toSentence
     (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var}
@@ -83,7 +83,7 @@ theorem exists_support_of_models_toSentence [Nonempty Domain]
     ∃ (i : Index W Var Domain) (v : Var → Domain),
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
   let _S := M.corrStructure
-  obtain ⟨d₀⟩ := ‹Nonempty Domain›
+  have d₀ : Domain := default
   have h0 : (stClose 0 (τ.st 0)).Realize
       (fun _ => (Sum.inr d₀ : W ⊕ Domain)) :=
     (Formula.realize_toSentence _ hcl _).mp h
@@ -120,7 +120,7 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
     (hτ : ∀ i, (φs i).toModal? = some (τs i))
     (hcl : ∀ i, (stClose 0 ((τs i).st 0)).freeVarFinset = ∅)
     (hfin : ∀ s : Finset ι, ∃ (W Domain : Type max u v)
-      (_ : DecidableEq W) (_ : DecidableEq Domain) (_ : Fintype Domain)
+      (_ : DecidableEq W) (_ : DecidableEq Domain) (_ : Fintype Domain) (_ : Inhabited Domain)
       (M : Model W Domain Const Pred) (i : Index W Var Domain)
       (v : Var → Domain), (∀ y, i.assign y = some (v y)) ∧
         ∀ j ∈ s, support M (φs j) {i}) :
@@ -130,10 +130,10 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
   intro T₀ hT₀
   classical
   choose f hf using fun x : T₀ => hT₀ x.2
-  obtain ⟨W, Domain, _, _, _, M, i, v, hv, hs⟩ := hfin (Finset.univ.image f)
+  obtain ⟨W, Domain, _, _, _, _, M, i, v, hv, hs⟩ := hfin (Finset.univ.image f)
   let _S := M.corrStructure
   have : Nonempty (W ⊕ Domain) := ⟨Sum.inl i.world⟩
-  have : (W ⊕ Domain) ⊨ (T₀ : (Language.correspondence Const Pred).Theory) := by
+  have : (W ⊕ Domain) ⊨ (T₀ : (Language.monadicWithConstants Const Pred).correspondence.Theory) := by
     refine ⟨fun σ hσ => ?_⟩
     obtain ⟨x, rfl⟩ : ∃ x : T₀,
         (stClose 0 ((τs (f x)).st 0)).toSentence (hcl (f x)) = σ :=

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -41,9 +41,8 @@ theorem support_singleton_iff_st (M : Model W Domain Const Pred)
     (hv : ∀ y, i.assign y = some (v y)) (hu : u k = i.world) :
     support M φ {i} ↔
       (letI := M.correspondence
-       (τ.st k).Realize (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u))) :=
-  (support_singleton_iff_realize M hτ hv).trans
-    (realize_st M (fun _ => rfl) (by rw [Sum.elim_inr, Function.comp_apply, hu]))
+       (τ.st k).Realize (stVal v u)) :=
+  (support_singleton_iff_realize M hτ hv).trans (hu ▸ realize_st M)
 
 /-- Support at a singleton state forces the closed standard translation,
     as a sentence of `M.correspondence`. -/
@@ -57,16 +56,13 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     (letI := M.correspondence
      (W ⊕ Domain) ⊨ (stClose 0 (τ.st 0)).toSentence hcl) := by
   let _S := M.correspondence
-  have h1 : (τ.st 0).Realize
-      (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world))) :=
+  have h1 : (τ.st 0).Realize (stVal v (fun _ => i.world)) :=
     (support_singleton_iff_st M hτ (fun _ => i.world) hv rfl).mp hsupp
   refine (Formula.realize_toSentence _ hcl
-    (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world)))).mpr ?_
+    (stVal v (fun _ => i.world))).mpr ?_
   refine (realize_stClose M 0 (τ.st 0) _).mpr ⟨i.world, ?_⟩
-  rw [show Function.update
-      (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world)))
-      (Sum.inr 0) (Sum.inl i.world)
-      = Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world)) from
+  rw [show Function.update (stVal v (fun _ => i.world))
+      (Sum.inr 0) (Sum.inl i.world) = stVal v (fun _ => i.world) from
     Function.update_eq_self _ _]
   exact h1
 
@@ -84,16 +80,13 @@ theorem exists_support_of_models_toSentence
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
   let _S := M.correspondence
   have d₀ : Domain := default
-  have h0 : (stClose 0 (τ.st 0)).Realize
-      (fun _ => (Sum.inr d₀ : W ⊕ Domain)) :=
-    (Formula.realize_toSentence _ hcl _).mp h
-  obtain ⟨w, hw⟩ := (realize_stClose M 0 (τ.st 0) _).mp h0
-  have hsorted : ∀ x : Var, Function.update
-      (fun _ : Var ⊕ ℕ => (Sum.inr d₀ : W ⊕ Domain)) (Sum.inr 0)
-      (Sum.inl w) (Sum.inl x) = Sum.inr d₀ := fun x => by
-    rw [Function.update_of_ne (by simp)]
-  have hmodal : τ.Realize M w (fun _ => d₀) :=
-    (realize_st M hsorted (Function.update_self _ _ _)).mpr hw
+  obtain ⟨w₀, -⟩ := (realize_stClose M 0 (τ.st 0) _).mp
+    ((Formula.realize_toSentence _ hcl (fun _ => (Sum.inr d₀ : W ⊕ Domain))).mp h)
+  obtain ⟨w, hw⟩ := (realize_stClose M 0 (τ.st 0) _).mp
+    ((Formula.realize_toSentence _ hcl (stVal (fun _ => d₀) (fun _ => w₀))).mp h)
+  rw [stVal_update_world] at hw
+  have hmodal := (realize_st (u := Function.update (fun _ => w₀) 0 w) M).mpr hw
+  rw [Function.update_self] at hmodal
   exact ⟨⟨w, fun _ => some d₀⟩, fun _ => d₀, fun _ => rfl,
     (support_singleton_iff_realize M hτ fun _ => rfl).mpr hmodal⟩
 

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -30,7 +30,7 @@ variable [DecidableEq Domain] [Fintype Domain] [Inhabited Domain]
 /-- **NE-free QBSML support is single-structure first-order satisfaction**:
     [aloni-vanormondt-2023] Proposition 4.1 composed with the standard
     translation. Support at a singleton state is mathlib `Formula.Realize`
-    of the standard translation over `corrStructure` — the link along which
+    of the standard translation over `M.correspondence` — the link along which
     classical model theory (compactness, Löwenheim–Skolem) transfers to the
     NE-free fragment. -/
 theorem support_singleton_iff_st (M : Model W Domain Const Pred)
@@ -40,13 +40,13 @@ theorem support_singleton_iff_st (M : Model W Domain Const Pred)
     {i : Index W Var Domain} {v : Var → Domain} (u : ℕ → W)
     (hv : ∀ y, i.assign y = some (v y)) (hu : u k = i.world) :
     support M φ {i} ↔
-      (letI := M.corrStructure
+      (letI := M.correspondence
        (τ.st k).Realize (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ u))) :=
   (support_singleton_iff_realize M hτ hv).trans
     (realize_st M (fun _ => rfl) (by rw [Sum.elim_inr, Function.comp_apply, hu]))
 
 /-- Support at a singleton state forces the closed standard translation,
-    as a sentence of `corrStructure`. -/
+    as a sentence of `M.correspondence`. -/
 theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var}
@@ -54,9 +54,9 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     (hcl : (stClose 0 (τ.st 0)).freeVarFinset = ∅)
     {i : Index W Var Domain} {v : Var → Domain}
     (hv : ∀ y, i.assign y = some (v y)) (hsupp : support M φ {i}) :
-    (letI := M.corrStructure
+    (letI := M.correspondence
      (W ⊕ Domain) ⊨ (stClose 0 (τ.st 0)).toSentence hcl) := by
-  let _S := M.corrStructure
+  let _S := M.correspondence
   have h1 : (τ.st 0).Realize
       (Sum.elim (Sum.inr ∘ v) (Sum.inl ∘ (fun _ => i.world))) :=
     (support_singleton_iff_st M hτ (fun _ => i.world) hv rfl).mp hsupp
@@ -71,18 +71,18 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
   exact h1
 
 /-- Conversely, the closed standard translation as a sentence of
-    `corrStructure` yields support at some singleton state. -/
+    `M.correspondence` yields support at some singleton state. -/
 theorem exists_support_of_models_toSentence
     (M : Model W Domain Const Pred)
     {φ : Formula Var Const Pred}
     {τ : ModalFormula (Language.monadicWithConstants Const Pred) Var}
     (hτ : φ.toModal? = some τ)
     (hcl : (stClose 0 (τ.st 0)).freeVarFinset = ∅)
-    (h : letI := M.corrStructure
+    (h : letI := M.correspondence
          (W ⊕ Domain) ⊨ (stClose 0 (τ.st 0)).toSentence hcl) :
     ∃ (i : Index W Var Domain) (v : Var → Domain),
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
-  let _S := M.corrStructure
+  let _S := M.correspondence
   have d₀ : Domain := default
   have h0 : (stClose 0 (τ.st 0)).Realize
       (fun _ => (Sum.inr d₀ : W ⊕ Domain)) :=
@@ -131,7 +131,7 @@ theorem support_compactness {Var : Type*} [DecidableEq Var] [Fintype Var]
   classical
   choose f hf using fun x : T₀ => hT₀ x.2
   obtain ⟨W, Domain, _, _, _, _, M, i, v, hv, hs⟩ := hfin (Finset.univ.image f)
-  let _S := M.corrStructure
+  let _S := M.correspondence
   have : Nonempty (W ⊕ Domain) := ⟨Sum.inl i.world⟩
   have : (W ⊕ Domain) ⊨ (T₀ : (Language.monadicWithConstants Const Pred).correspondence.Theory) := by
     refine ⟨fun σ hσ => ?_⟩

--- a/Linglib/Logic/Team/QBSML/Compactness.lean
+++ b/Linglib/Logic/Team/QBSML/Compactness.lean
@@ -60,7 +60,7 @@ theorem models_toSentence_of_support (M : Model W Domain Const Pred)
     (support_singleton_iff_st M hτ (fun _ => i.world) hv rfl).mp hsupp
   refine (Formula.realize_toSentence _ hcl
     (stVal v (fun _ => i.world))).mpr ?_
-  refine (realize_stClose M 0 (τ.st 0) _).mpr ⟨i.world, ?_⟩
+  refine (realize_stClose 0 (τ.st 0) _ fun _ => Iff.rfl).mpr ⟨i.world, ?_⟩
   rw [show Function.update (stVal v (fun _ => i.world))
       (Sum.inr 0) (Sum.inl i.world) = stVal v (fun _ => i.world) from
     Function.update_eq_self _ _]
@@ -80,9 +80,9 @@ theorem exists_support_of_models_toSentence
       (∀ y, i.assign y = some (v y)) ∧ support M φ {i} := by
   let _S := M.correspondence
   have d₀ : Domain := default
-  obtain ⟨w₀, -⟩ := (realize_stClose M 0 (τ.st 0) _).mp
+  obtain ⟨w₀, -⟩ := (realize_stClose 0 (τ.st 0) _ fun _ => Iff.rfl).mp
     ((Formula.realize_toSentence _ hcl (fun _ => (Sum.inr d₀ : W ⊕ Domain))).mp h)
-  obtain ⟨w, hw⟩ := (realize_stClose M 0 (τ.st 0) _).mp
+  obtain ⟨w, hw⟩ := (realize_stClose 0 (τ.st 0) _ fun _ => Iff.rfl).mp
     ((Formula.realize_toSentence _ hcl (stVal (fun _ => d₀) (fun _ => w₀))).mp h)
   rw [stVal_update_world] at hw
   have hmodal := (realize_st (u := Function.update (fun _ => w₀) 0 w) M).mpr hw

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -126,7 +126,7 @@ def univPxOrQxModal :
 /-- The standard translation of `∀x(Px ∨ Qx)`, computed by `st`: quantifiers
     relativized to the individual sort, predicates world-relativized to the
     current-world variable `Sum.inr 0`. -/
-def stUnivPxOrQx : (Language.correspondence FCAtom Predicate).Formula (QVar ⊕ ℕ) :=
+def stUnivPxOrQx : (Language.monadicWithConstants FCAtom Predicate).correspondence.Formula (QVar ⊕ ℕ) :=
   univPxOrQxModal.st 0
 
 /-- The closure is a genuine sentence: the compiler computes the
@@ -136,10 +136,10 @@ theorem stUnivPxOrQx_closed :
 
 /-- The sort-guarded closed standard translation of `∀x(Px ∨ Qx)`, as a
     sentence. -/
-def stUnivPxOrQxSentence : (Language.correspondence FCAtom Predicate).Sentence :=
+def stUnivPxOrQxSentence : (Language.monadicWithConstants FCAtom Predicate).correspondence.Sentence :=
   (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed
 
-local instance : (Language.correspondence FCAtom Predicate).Structure (TwoAtomWorld ⊕ FCAtom) :=
+local instance : (Language.monadicWithConstants FCAtom Predicate).correspondence.Structure (TwoAtomWorld ⊕ FCAtom) :=
   univAccessModel.corrStructure
 
 /-- Truth of the standard-translation sentence in `univAccessModel.corrStructure`
@@ -150,7 +150,6 @@ theorem models_stUnivPxOrQxSentence_iff :
     (TwoAtomWorld ⊕ FCAtom) ⊨ stUnivPxOrQxSentence ↔
       ∃ (i : Index TwoAtomWorld QVar FCAtom) (v : QVar → FCAtom),
         (∀ y, i.assign y = some (v y)) ∧ support univAccessModel univPxOrQx {i} :=
-  haveI : Nonempty FCAtom := ⟨.a⟩
   ⟨exists_support_of_models_toSentence univAccessModel (τ := univPxOrQxModal) rfl stUnivPxOrQx_closed,
     fun ⟨_, _, hv, h⟩ =>
       models_toSentence_of_support univAccessModel (τ := univPxOrQxModal) rfl stUnivPxOrQx_closed hv h⟩

--- a/Linglib/Studies/AloniVanOrmondt2023.lean
+++ b/Linglib/Studies/AloniVanOrmondt2023.lean
@@ -140,9 +140,9 @@ def stUnivPxOrQxSentence : (Language.monadicWithConstants FCAtom Predicate).corr
   (stClose 0 stUnivPxOrQx).toSentence stUnivPxOrQx_closed
 
 local instance : (Language.monadicWithConstants FCAtom Predicate).correspondence.Structure (TwoAtomWorld ⊕ FCAtom) :=
-  univAccessModel.corrStructure
+  univAccessModel.correspondence
 
-/-- Truth of the standard-translation sentence in `univAccessModel.corrStructure`
+/-- Truth of the standard-translation sentence in `univAccessModel.correspondence`
     is support of `∀x(Px ∨ Qx)` at some singleton with a total assignment —
     the compactness-ready form of Proposition 4.1, every translation step
     (`toModal?`, `st`, the free-variable check) computed by the compiler. -/


### PR DESCRIPTION
Language.correspondence becomes an operation on languages — every symbol world-relativized one arity up, plus accessibility and the sort predicate — with stTerm/st/realize_st generalized to arbitrary arities; L.correspondence reads as the correspondence language OF L, and nothing monadic remains in the file (QBSML/AvO instantiate). Junk totalization of world-relativized functions via [Inhabited M], which constant-domain semantics presupposes. Two-sorted-coding note in Implementation notes.