### PR TITLE
refactor(Semantics/Polarity): derive Fintype, drop hand-rolled equivFin

### DIFF
--- a/Linglib/Semantics/Polarity/CzechNegation.lean
+++ b/Linglib/Semantics/Polarity/CzechNegation.lean
@@ -1,5 +1,6 @@
 import Mathlib.Order.Nat
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # Czech Three-Way Negation: Core Types
@@ -27,9 +28,7 @@ inductive NegPosition where
   /-- Outer negation: in PolP, FALSUM operator. Widest scope.
       Maps to high negation (VSO word order). Obligatorily focused. -/
   | outer
-  deriving DecidableEq, Repr
-
--- ── NegPosition: LinearOrder, Fintype ──
+  deriving DecidableEq, Repr, Fintype
 
 /-- Numeric embedding: inner ↦ 0, medial ↦ 1, outer ↦ 2 (by scope width). -/
 def NegPosition.toNat : NegPosition → Nat
@@ -40,19 +39,6 @@ def NegPosition.toNat : NegPosition → Nat
 instance : LinearOrder NegPosition :=
   LinearOrder.lift' NegPosition.toNat
     (fun a b h => by cases a <;> cases b <;> simp_all [NegPosition.toNat])
-
-/-- NegPosition ≃ Fin 3. -/
-def NegPosition.equivFin : NegPosition ≃ Fin 3 where
-  toFun | .inner => 0 | .medial => 1 | .outer => 2
-  invFun | ⟨0, _⟩ => .inner | ⟨1, _⟩ => .medial | ⟨2, _⟩ => .outer
-         | ⟨n + 3, h⟩ => absurd h (by omega)
-  left_inv p := by cases p <;> rfl
-  right_inv i := by
-    match i with
-    | ⟨0, _⟩ => rfl | ⟨1, _⟩ => rfl | ⟨2, _⟩ => rfl
-    | ⟨n + 3, h⟩ => exact absurd h (by omega)
-
-instance : Fintype NegPosition := Fintype.ofEquiv _ NegPosition.equivFin.symm
 
 /-- Diagnostics that distinguish the three negation readings (Table 1). -/
 inductive Diagnostic where
@@ -66,25 +52,7 @@ inductive Diagnostic where
   | jeste
   /-- Particle *fakt* 'really' is compatible -/
   | fakt
-  deriving DecidableEq, Repr
-
--- ── Diagnostic: Fintype ──
-
-/-- Diagnostic ≃ Fin 5. -/
-def Diagnostic.equivFin : Diagnostic ≃ Fin 5 where
-  toFun | .ppiOutscoping => 0 | .nciLicensed => 1 | .nahodou => 2
-        | .jeste => 3 | .fakt => 4
-  invFun | ⟨0, _⟩ => .ppiOutscoping | ⟨1, _⟩ => .nciLicensed
-         | ⟨2, _⟩ => .nahodou | ⟨3, _⟩ => .jeste | ⟨4, _⟩ => .fakt
-         | ⟨n + 5, h⟩ => absurd h (by omega)
-  left_inv d := by cases d <;> rfl
-  right_inv i := by
-    match i with
-    | ⟨0, _⟩ => rfl | ⟨1, _⟩ => rfl | ⟨2, _⟩ => rfl
-    | ⟨3, _⟩ => rfl | ⟨4, _⟩ => rfl
-    | ⟨n + 5, h⟩ => exact absurd h (by omega)
-
-instance : Fintype Diagnostic := Fintype.ofEquiv _ Diagnostic.equivFin.symm
+  deriving DecidableEq, Repr, Fintype
 
 /-- [stankova-2026]'s Table 1: compatibility of each negation reading
 with polarity items and particles.


### PR DESCRIPTION
`NegPosition` and `Diagnostic` get their `Fintype` instances via `deriving` (mathlib `SignType` idiom) instead of hand-rolled `equivFin` + `Fintype.ofEquiv` blocks; the `equivFin` helpers had no consumers.