### PR TITLE
feat(Studies/StankovaSimik2025): typed stimuli checked against licensing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2929,3 +2929,4 @@ import Linglib.Data.Examples.Zheng2025
 import Linglib.Data.Examples.Lahiri1998
 import Linglib.Data.Examples.VonStechow1984
 import Linglib.Data.Examples.Hacquard2006
+import Linglib.Data.Examples.StankovaSimik2025

--- a/Linglib/Data/Examples/StankovaSimik2025.json
+++ b/Linglib/Data/Examples/StankovaSimik2025.json
@@ -1,0 +1,186 @@
+[
+  {
+    "id": "stankovasimik2025_ex13_v1_nci",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(13) B"},
+    "language": "czec1258",
+    "primaryText": "Nezasadila tam Dana žádné květiny?",
+    "glossedTokens": [
+      ["Nezasadila", "NEG.planted"],
+      ["tam", "there"],
+      ["Dana", "Dana"],
+      ["žádné", "DET.NCI"],
+      ["květiny", "flowers"]
+    ],
+    "translation": "Didn't Dana plant there any flowers?",
+    "context": "Dana má na zahradě záhon, který vybudovala před rokem. ('Dana has a garden bed, which she built a year ago.' — neutral, implying neither p nor ¬p)",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["verbPosition", "v1"],
+      ["indefinite", "nci"],
+      ["context", "neutral"]
+    ],
+    "comment": "Mean rating ≈ 3 (Figure 2a). V1 forces the outer reading (FALSUM), which cannot license the NCI žádné: main effect of INDEFINITE in V1, z = −15.674, p < .001."
+  },
+  {
+    "id": "stankovasimik2025_ex13_v1_ppi",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(13) B"},
+    "language": "czec1258",
+    "primaryText": "Nezasadila tam Dana nějaké květiny?",
+    "glossedTokens": [
+      ["Nezasadila", "NEG.planted"],
+      ["tam", "there"],
+      ["Dana", "Dana"],
+      ["nějaké", "DET.PPI"],
+      ["květiny", "flowers"]
+    ],
+    "translation": "Didn't Dana plant there some flowers?",
+    "context": "Dana má na zahradě záhon, který vybudovala před rokem. ('Dana has a garden bed, which she built a year ago.' — neutral, implying neither p nor ¬p)",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["verbPosition", "v1"],
+      ["indefinite", "ppi"],
+      ["context", "neutral"]
+    ],
+    "comment": "Mean rating ≈ 5, highest in neutral context (Figure 2a; CONTEXT within PPI z = −3.522, p < .001). FALSUM allows the PPI nějaké in its scope."
+  },
+  {
+    "id": "stankovasimik2025_ex13_nonv1_nci",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(13) B′"},
+    "language": "czec1258",
+    "primaryText": "Dana tam nezasadila žádné květiny?",
+    "glossedTokens": [
+      ["Dana", "Dana"],
+      ["tam", "there"],
+      ["nezasadila", "NEG.planted"],
+      ["žádné", "DET.NCI"],
+      ["květiny", "flowers"]
+    ],
+    "translation": "Dana didn't plant there any flowers?",
+    "context": "Dana má na zahradě záhon, kam zasadila zeleninu. ('Dana has a garden bed, where she planted vegetables.' — negative, implying ¬p)",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["verbPosition", "nonv1"],
+      ["indefinite", "nci"],
+      ["context", "negative"]
+    ],
+    "comment": "Mean rating ≈ 5 in negative context (Figure 2b). The inner default reading licenses the NCI; nonV1 PQs need negative evidential bias (main effect of CONTEXT, z = 8.674, p < 0.01)."
+  },
+  {
+    "id": "stankovasimik2025_ex13_nonv1_ppi",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(13) B′"},
+    "language": "czec1258",
+    "primaryText": "Dana tam nezasadila nějaké květiny?",
+    "glossedTokens": [
+      ["Dana", "Dana"],
+      ["tam", "there"],
+      ["nezasadila", "NEG.planted"],
+      ["nějaké", "DET.PPI"],
+      ["květiny", "flowers"]
+    ],
+    "translation": "Dana didn't plant there some flowers?",
+    "context": "Dana má na zahradě záhon, kam zasadila zeleninu. ('Dana has a garden bed, where she planted vegetables.' — negative, implying ¬p)",
+    "judgment": "marginal",
+    "paperFeatures": [
+      ["verbPosition", "nonv1"],
+      ["indefinite", "ppi"],
+      ["context", "negative"]
+    ],
+    "comment": "Mean rating ≈ 4 in negative context (Figure 2b). The PPI needs the outer reading, available in nonV1 but dispreferred: main effect of INDEFINITE, z = 6.208, p < 0.01, NCI over PPI."
+  },
+  {
+    "id": "stankovasimik2025_ex14",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(14) B"},
+    "language": "czec1258",
+    "primaryText": "Nevyhrála Eva nějakou cenu?",
+    "glossedTokens": [
+      ["Nevyhrála", "NEG.won"],
+      ["Eva", "Eva"],
+      ["nějakou", "DET.PPI"],
+      ["cenu", "prize"]
+    ],
+    "translation": "Didn't Eva win a prize?",
+    "context": "Eva se zúčastnila lingvistické olympiády, kde skončila jako první. ('Eva participated in a linguistic olympiad, where she won the first place.' — positive evidence for p)",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["verbPosition", "v1"],
+      ["indefinite", "ppi"],
+      ["context", "positive"]
+    ],
+    "comment": "Median 6, vs 5 for the analogous neutral-context condition (§5.3): Czech FALSUM is compatible even with positive evidential bias, unlike English high negation."
+  },
+  {
+    "id": "stankovasimik2025_ex17_ppi",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(17) B"},
+    "language": "czec1258",
+    "primaryText": "Nezarezervoval si Mikuláš náhodou nějaké sedadlo?",
+    "glossedTokens": [
+      ["Nezarezervoval", "NEG.booked"],
+      ["si", "REFL"],
+      ["Mikuláš", "Mikuláš"],
+      ["náhodou", "NÁHODOU"],
+      ["nějaké", "DET.PPI"],
+      ["sedadlo", "seat"]
+    ],
+    "translation": "Didn't Mikuláš book a seat?",
+    "context": "Mikuláš cestoval vlakem, který jel do Košic. ('Mikuláš was on the train which went to Košice.' — neutral)",
+    "judgment": "acceptable",
+    "paperFeatures": [
+      ["particle", "nahodou"],
+      ["verbPosition", "v1"],
+      ["indefinite", "ppi"],
+      ["context", "neutral"]
+    ],
+    "comment": "Mean rating ≈ 4.8 in both contexts (Figure 3): náhodou, like its licensor FALSUM, is insensitive to contextual evidence."
+  },
+  {
+    "id": "stankovasimik2025_ex17_nci",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(17) B"},
+    "language": "czec1258",
+    "primaryText": "Nezarezervoval si Mikuláš náhodou žádné sedadlo?",
+    "glossedTokens": [
+      ["Nezarezervoval", "NEG.booked"],
+      ["si", "REFL"],
+      ["Mikuláš", "Mikuláš"],
+      ["náhodou", "NÁHODOU"],
+      ["žádné", "DET.NCI"],
+      ["sedadlo", "seat"]
+    ],
+    "translation": "Didn't Mikuláš book a seat?",
+    "context": "Mikuláš cestoval vlakem, který jel do Košic. ('Mikuláš was on the train which went to Košice.' — neutral)",
+    "judgment": "unacceptable",
+    "paperFeatures": [
+      ["particle", "nahodou"],
+      ["verbPosition", "v1"],
+      ["indefinite", "nci"],
+      ["context", "neutral"]
+    ],
+    "comment": "Mean rating ≈ 2.3 neutral / ≈ 3.0 negative (Figure 3). náhodou requires FALSUM, which cannot license the NCI: main effect of INDEFINITE, z = −12.845, p < .001."
+  },
+  {
+    "id": "stankovasimik2025_ex18",
+    "source": {"bibkey": "stankova-2025", "paperLabel": "(18) B"},
+    "language": "czec1258",
+    "primaryText": "A Petr si náhodou nekoupil nějakou knihu?",
+    "glossedTokens": [
+      ["A", "and"],
+      ["Petr", "Petr"],
+      ["si", "REFL"],
+      ["náhodou", "NÁHODOU"],
+      ["nekoupil", "NEG.bought"],
+      ["nějakou", "DET.PPI"],
+      ["knihu", "book"]
+    ],
+    "translation": "And as for Petr, did he buy a book, too, by any chance?",
+    "context": "Hanka si koupila knihu. ('Hanka bought a book.')",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "A Petr si náhodou nekoupil žádnou knihu?", "judgment": "unacceptable"}
+    ],
+    "paperFeatures": [
+      ["particle", "nahodou"],
+      ["verbPosition", "nonv1"],
+      ["indefinite", "ppi"]
+    ],
+    "comment": "náhodou in a nonV1 PQ: needs a contrastive topic (Petr) and contrastive focus on the negated verb, and the negation must still be FALSUM — witness the infelicitous NCI alternative žádnou."
+  }
+]

--- a/Linglib/Data/Examples/StankovaSimik2025.lean
+++ b/Linglib/Data/Examples/StankovaSimik2025.lean
@@ -1,0 +1,162 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `StankovaSimik2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/StankovaSimik2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace StankovaSimik2025.Examples`.
+-/
+
+namespace StankovaSimik2025.Examples
+
+open Data.Examples
+
+def ex13_v1_nci : LinguisticExample :=
+  { id := "stankovasimik2025_ex13_v1_nci"
+    source := ⟨"stankova-2025", "(13) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nezasadila tam Dana žádné květiny?"
+    discourseSegments := []
+    glossedTokens := [("Nezasadila", "NEG.planted"), ("tam", "there"), ("Dana", "Dana"), ("žádné", "DET.NCI"), ("květiny", "flowers")]
+    translation := "Didn't Dana plant there any flowers?"
+    context := "Dana má na zahradě záhon, který vybudovala před rokem. ('Dana has a garden bed, which she built a year ago.' — neutral, implying neither p nor ¬p)"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbPosition", "v1"), ("indefinite", "nci"), ("context", "neutral")]
+    comment := "Mean rating ≈ 3 (Figure 2a). V1 forces the outer reading (FALSUM), which cannot license the NCI žádné: main effect of INDEFINITE in V1, z = −15.674, p < .001."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13_v1_ppi : LinguisticExample :=
+  { id := "stankovasimik2025_ex13_v1_ppi"
+    source := ⟨"stankova-2025", "(13) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nezasadila tam Dana nějaké květiny?"
+    discourseSegments := []
+    glossedTokens := [("Nezasadila", "NEG.planted"), ("tam", "there"), ("Dana", "Dana"), ("nějaké", "DET.PPI"), ("květiny", "flowers")]
+    translation := "Didn't Dana plant there some flowers?"
+    context := "Dana má na zahradě záhon, který vybudovala před rokem. ('Dana has a garden bed, which she built a year ago.' — neutral, implying neither p nor ¬p)"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbPosition", "v1"), ("indefinite", "ppi"), ("context", "neutral")]
+    comment := "Mean rating ≈ 5, highest in neutral context (Figure 2a; CONTEXT within PPI z = −3.522, p < .001). FALSUM allows the PPI nějaké in its scope."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13_nonv1_nci : LinguisticExample :=
+  { id := "stankovasimik2025_ex13_nonv1_nci"
+    source := ⟨"stankova-2025", "(13) B′"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Dana tam nezasadila žádné květiny?"
+    discourseSegments := []
+    glossedTokens := [("Dana", "Dana"), ("tam", "there"), ("nezasadila", "NEG.planted"), ("žádné", "DET.NCI"), ("květiny", "flowers")]
+    translation := "Dana didn't plant there any flowers?"
+    context := "Dana má na zahradě záhon, kam zasadila zeleninu. ('Dana has a garden bed, where she planted vegetables.' — negative, implying ¬p)"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbPosition", "nonv1"), ("indefinite", "nci"), ("context", "negative")]
+    comment := "Mean rating ≈ 5 in negative context (Figure 2b). The inner default reading licenses the NCI; nonV1 PQs need negative evidential bias (main effect of CONTEXT, z = 8.674, p < 0.01)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex13_nonv1_ppi : LinguisticExample :=
+  { id := "stankovasimik2025_ex13_nonv1_ppi"
+    source := ⟨"stankova-2025", "(13) B′"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Dana tam nezasadila nějaké květiny?"
+    discourseSegments := []
+    glossedTokens := [("Dana", "Dana"), ("tam", "there"), ("nezasadila", "NEG.planted"), ("nějaké", "DET.PPI"), ("květiny", "flowers")]
+    translation := "Dana didn't plant there some flowers?"
+    context := "Dana má na zahradě záhon, kam zasadila zeleninu. ('Dana has a garden bed, where she planted vegetables.' — negative, implying ¬p)"
+    judgment := .marginal
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbPosition", "nonv1"), ("indefinite", "ppi"), ("context", "negative")]
+    comment := "Mean rating ≈ 4 in negative context (Figure 2b). The PPI needs the outer reading, available in nonV1 but dispreferred: main effect of INDEFINITE, z = 6.208, p < 0.01, NCI over PPI."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex14 : LinguisticExample :=
+  { id := "stankovasimik2025_ex14"
+    source := ⟨"stankova-2025", "(14) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nevyhrála Eva nějakou cenu?"
+    discourseSegments := []
+    glossedTokens := [("Nevyhrála", "NEG.won"), ("Eva", "Eva"), ("nějakou", "DET.PPI"), ("cenu", "prize")]
+    translation := "Didn't Eva win a prize?"
+    context := "Eva se zúčastnila lingvistické olympiády, kde skončila jako první. ('Eva participated in a linguistic olympiad, where she won the first place.' — positive evidence for p)"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verbPosition", "v1"), ("indefinite", "ppi"), ("context", "positive")]
+    comment := "Median 6, vs 5 for the analogous neutral-context condition (§5.3): Czech FALSUM is compatible even with positive evidential bias, unlike English high negation."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex17_ppi : LinguisticExample :=
+  { id := "stankovasimik2025_ex17_ppi"
+    source := ⟨"stankova-2025", "(17) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nezarezervoval si Mikuláš náhodou nějaké sedadlo?"
+    discourseSegments := []
+    glossedTokens := [("Nezarezervoval", "NEG.booked"), ("si", "REFL"), ("Mikuláš", "Mikuláš"), ("náhodou", "NÁHODOU"), ("nějaké", "DET.PPI"), ("sedadlo", "seat")]
+    translation := "Didn't Mikuláš book a seat?"
+    context := "Mikuláš cestoval vlakem, který jel do Košic. ('Mikuláš was on the train which went to Košice.' — neutral)"
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "nahodou"), ("verbPosition", "v1"), ("indefinite", "ppi"), ("context", "neutral")]
+    comment := "Mean rating ≈ 4.8 in both contexts (Figure 3): náhodou, like its licensor FALSUM, is insensitive to contextual evidence."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex17_nci : LinguisticExample :=
+  { id := "stankovasimik2025_ex17_nci"
+    source := ⟨"stankova-2025", "(17) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "Nezarezervoval si Mikuláš náhodou žádné sedadlo?"
+    discourseSegments := []
+    glossedTokens := [("Nezarezervoval", "NEG.booked"), ("si", "REFL"), ("Mikuláš", "Mikuláš"), ("náhodou", "NÁHODOU"), ("žádné", "DET.NCI"), ("sedadlo", "seat")]
+    translation := "Didn't Mikuláš book a seat?"
+    context := "Mikuláš cestoval vlakem, který jel do Košic. ('Mikuláš was on the train which went to Košice.' — neutral)"
+    judgment := .unacceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("particle", "nahodou"), ("verbPosition", "v1"), ("indefinite", "nci"), ("context", "neutral")]
+    comment := "Mean rating ≈ 2.3 neutral / ≈ 3.0 negative (Figure 3). náhodou requires FALSUM, which cannot license the NCI: main effect of INDEFINITE, z = −12.845, p < .001."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex18 : LinguisticExample :=
+  { id := "stankovasimik2025_ex18"
+    source := ⟨"stankova-2025", "(18) B"⟩
+    reportedIn := none
+    language := "czec1258"
+    primaryText := "A Petr si náhodou nekoupil nějakou knihu?"
+    discourseSegments := []
+    glossedTokens := [("A", "and"), ("Petr", "Petr"), ("si", "REFL"), ("náhodou", "NÁHODOU"), ("nekoupil", "NEG.bought"), ("nějakou", "DET.PPI"), ("knihu", "book")]
+    translation := "And as for Petr, did he buy a book, too, by any chance?"
+    context := "Hanka si koupila knihu. ('Hanka bought a book.')"
+    judgment := .acceptable
+    alternatives := [("A Petr si náhodou nekoupil žádnou knihu?", .unacceptable)]
+    readings := []
+    paperFeatures := [("particle", "nahodou"), ("verbPosition", "nonv1"), ("indefinite", "ppi")]
+    comment := "náhodou in a nonV1 PQ: needs a contrastive topic (Petr) and contrastive focus on the negated verb, and the negation must still be FALSUM — witness the infelicitous NCI alternative žádnou."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex13_v1_nci, ex13_v1_ppi, ex13_nonv1_nci, ex13_nonv1_ppi, ex14, ex17_ppi, ex17_nci, ex18]
+
+end StankovaSimik2025.Examples

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -4,6 +4,7 @@ import Linglib.Semantics.Polarity.CzechNegation
 import Linglib.Studies.StankovaSimik2025
 import Linglib.Semantics.Questions.Bias
 import Linglib.Data.Examples.Stankova2026
+import Linglib.Data.Examples.StankovaSimik2025
 
 /-!
 # Czech three-way negation in polar questions (Staňková 2026)
@@ -351,5 +352,18 @@ acceptable. -/
 theorem examples_match_table1 :
     analyzedExamples.all (fun (e, pos, d) =>
       (e.judgment == .acceptable) == licenses pos d) = true := by decide
+
+/-- [stankova-2025]'s positive-evidence stimulus ((14): V1 negative PQ
+after evidence for p) with the bias-profile cell it occupies. -/
+def biasCheckedExamples :
+    List (LinguisticExample × ContextualEvidence × OriginalBias × CzechPQForm) :=
+  [ (StankovaSimik2025.Examples.ex14, .forP, .neutral, .interNPQ) ]
+
+/-- The bias profile predicts the positive-evidence stimulus: the form
+is felicitous iff it appears in its evidence × original-bias cell. -/
+theorem bias_examples_match_profile :
+    biasCheckedExamples.all (fun (e, ev, ob, f) =>
+      (e.judgment == .acceptable) == (czechBiasProfile ev ob).contains f) = true := by
+  decide
 
 end Stankova2026

--- a/Linglib/Studies/StankovaSimik2025.lean
+++ b/Linglib/Studies/StankovaSimik2025.lean
@@ -1,5 +1,6 @@
 import Linglib.Fragments.Slavic.Czech.Particles
 import Linglib.Semantics.Polarity.CzechNegation
+import Linglib.Data.Examples.StankovaSimik2025
 
 /-!
 # Negation in Czech polar questions (Staňková & Šimík 2025)
@@ -17,6 +18,9 @@ Table 1 diagnostics are [stankova-2026]'s and live in `Stankova2026`.
 * `VerbPosition.defaultReading`, `nci_diagnoses_nonV1`,
   `ppi_diagnoses_v1` — the main experiment's INDEFINITE effects derived
   from Table 1 licensing: PPIs preferred in V1 PQs, NCIs in nonV1.
+* `stimuli_match_default_licensing`, `nahodou_stimuli_match_falsum` —
+  the typed stimuli ((13), (17)-(18); `Data.Examples.StankovaSimik2025`)
+  check against that licensing.
 * `requiresEvidentialBias`, `nahodou_copak_opposite_context` — the
   experimentally separated bias dimensions: *náhodou*
   context-insensitive, *copak* evidential-bias-sensitive.
@@ -34,12 +38,16 @@ open Semantics.Negation.CzechNegation
 /-! ### The main experiment (§5)
 
 A 2×2×2 naturalness rating study (75 participants, Likert 1-7, CLMM
-analysis) crossing verb position with indefinite type (NCI *žádný* vs
-PPI *nějaký*) and context (negative vs neutral). The indefinites proxy
-for the negation reading, so Table 1's licensing column derives the
-observed directions: PPIs more natural in V1 PQs (p < .001), NCIs in
-nonV1 (p < .001); context mattered only in nonV1 (p < .01, negative >
-neutral) — FALSUM conveys epistemic, not evidential, bias. -/
+analysis; §5.1, item (13)) crossing verb position with indefinite type
+(NCI *žádný* vs PPI *nějaký*) and context (negative vs neutral). The
+indefinites proxy for the negation reading, so Table 1's licensing
+column derives the observed directions (§5.2): PPIs more natural in V1
+PQs (z = −15.674, p < .001), NCIs in nonV1 (z = 6.208, p < 0.01);
+context mattered only in nonV1 (z = 8.674, p < 0.01, negative >
+neutral; V1 n.s., z = −1.374, p = 0.169) — FALSUM conveys epistemic,
+not evidential, bias. A follow-up in positive-evidence contexts ((14),
+§5.3; median 6 vs 5 neutral) shows Czech FALSUM compatible even with
+positive evidential bias, unlike English high negation. -/
 
 /-- Verb position in Czech PQs: V1 (interrogative word order) vs nonV1
 (declarative word order); *ne-* is inseparable from the finite verb, so
@@ -89,6 +97,24 @@ theorem ppi_diagnoses_v1 :
       licenses wp.defaultReading .ppiOutscoping = true → wp = .v1 := by
   intro wp; cases wp <;> decide
 
+open Data.Examples (LinguisticExample)
+
+/-- The (13) stimulus quadruple with the verb position and Table 1
+diagnostic each variant manipulates. -/
+def analyzedStimuli : List (LinguisticExample × VerbPosition × Diagnostic) :=
+  [ (Examples.ex13_v1_nci,    .v1,    .nciLicensed)
+  , (Examples.ex13_v1_ppi,    .v1,    .ppiOutscoping)
+  , (Examples.ex13_nonv1_nci, .nonV1, .nciLicensed)
+  , (Examples.ex13_nonv1_ppi, .nonV1, .ppiOutscoping) ]
+
+/-- Table 1 licensing under the default reading predicts each (13)
+variant's naturalness: the diagnostic is licensed at the verb position's
+default reading iff the variant is fully natural in its context. -/
+theorem stimuli_match_default_licensing :
+    analyzedStimuli.all (fun (e, wp, d) =>
+      (e.judgment == .acceptable) == licenses wp.defaultReading d) = true := by
+  decide
+
 /-! ### Classification -/
 
 /-- Semantic classification of the Czech PQ particles ([stankova-2025]
@@ -131,6 +157,21 @@ be used as an overt indicator of the covert FALSUM operator being
 present in the structure" — and FALSUM is context-insensitive. -/
 theorem nahodou_context_insensitive :
     requiresEvidentialBias nahodou = some false := by decide
+
+/-- The §6.1 stimuli ((17) both variants, plus the nonV1 (18)) with the
+diagnostic each manipulates. -/
+def nahodouStimuli : List (LinguisticExample × Diagnostic) :=
+  [ (Examples.ex17_ppi, .ppiOutscoping)
+  , (Examples.ex17_nci, .nciLicensed)
+  , (Examples.ex18,     .ppiOutscoping) ]
+
+/-- *náhodou* pins the negation to FALSUM, so Table 1's outer row
+predicts each §6.1 variant's naturalness — regardless of verb position:
+(18) is a nonV1 PQ and still patterns with outer negation. -/
+theorem nahodou_stimuli_match_falsum :
+    nahodouStimuli.all (fun (e, d) =>
+      (e.judgment == .acceptable) == licenses .outer d) = true := by
+  decide
 
 /-- The §6.2 subexperiment: *copak* "strongly indicates a conflict
 between speaker's prior belief and the currently available evidence"

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -13498,6 +13498,7 @@
   doi       = {10.1353/jsl.2025.a970006},
   url       = {https://muse.jhu.edu/article/970006},
   subfield  = {semantics/questions},
+  validated = {true},
   role      = {formalized},
   sources   = {Studies/StankovaSimik2025.lean}
 }


### PR DESCRIPTION
Adds `Data/Examples/StankovaSimik2025.json` (8 rows: the (13) main-experiment quadruple, the (14) positive-evidence stimulus, the (17)-(18) náhodou items — all transcribed and verified against the published JSL 33 version, which corrects the precursor's protagonist and pins the z-values now quoted in docstrings).

- `stimuli_match_default_licensing`, `nahodou_stimuli_match_falsum` (StankovaSimik2025) and `bias_examples_match_profile` (Stankova2026) check each stimulus's judgment against Table 1 licensing / the bias profile
- marks `stankova-2025` validated in the bib