### PR TITLE
refactor(Semantics/Polarity): Semantics.Negation → top-level Negation

### DIFF
--- a/Linglib/Fragments/Januubi/Negation.lean
+++ b/Linglib/Fragments/Januubi/Negation.lean
@@ -127,7 +127,7 @@ def allExamples : List ENExample :=
 
 /-! ### Structural Constraints on EN -/
 
-open Semantics.Negation (ENBlockingReason)
+open _root_.Negation (ENBlockingReason)
 
 /-- Why REGRET does not trigger EN in Januubi: Januubi speakers disprefer
     modal operators in complement clauses, and REGRET-class EN requires

--- a/Linglib/Fragments/ZarmaSonrai/Negation.lean
+++ b/Linglib/Fragments/ZarmaSonrai/Negation.lean
@@ -180,7 +180,7 @@ def enNegatorForAspect : ENAspect → String
 theorem fear_uses_ipfv_neg : enNegatorForAspect .ipfv = "si" := rfl
 theorem delay_uses_pfv_neg : enNegatorForAspect .pfv = "batu" := rfl
 
-open Semantics.Negation (ENBlockingReason)
+open _root_.Negation (ENBlockingReason)
 
 /-- Why WITHOUT and TOO…TO do not trigger EN in Zarma-Sonrai.
 

--- a/Linglib/Pragmatics/Bias.lean
+++ b/Linglib/Pragmatics/Bias.lean
@@ -49,7 +49,7 @@ so consumers can use `obtain`/`rintro` directly. Decidability is provided.
 ## Cross-construction connections
 
 §6 connects the predicate to [greco-2020]'s weak-EN polarity profile
-in `Semantics.Negation.PolarityLicensing`. The Romero-2024 HiNQ bridge — a
+in `Negation.PolarityLicensing`. The Romero-2024 HiNQ bridge — a
 predicate-level correspondence between this licensing condition and
 Romero's bias requirement — lives in
 `Studies/Romero2024.lean`, so that this file does
@@ -74,7 +74,7 @@ commitment-update ([farkas-bruce-2010]) reanalyses.
 
 namespace Pragmatics.Bias
 
-open Semantics.Negation (PolarityLicensing weakENProfile)
+open Negation (PolarityLicensing weakENProfile)
 open Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Semantics/Polarity/ExpletiveNegation.lean
+++ b/Linglib/Semantics/Polarity/ExpletiveNegation.lean
@@ -26,7 +26,7 @@ without committing to a syntactic analysis. The syntactic derivation
 `Studies/Greco2020.lean` under `namespace Minimalist.NegScope`.
 -/
 
-namespace Semantics.Negation
+namespace Negation
 
 
 /-! ### EN blocking reasons -/
@@ -235,4 +235,4 @@ instance : OrderTop PolarityLicensing where
 /-- Strong EN (⊥) ≤ weak EN in the licensing lattice. -/
 theorem strongEN_le_weakEN : strongENProfile ≤ weakENProfile := by decide
 
-end Semantics.Negation
+end Negation

--- a/Linglib/Semantics/Polarity/Negation.lean
+++ b/Linglib/Semantics/Polarity/Negation.lean
@@ -14,14 +14,14 @@ coherent architecture with three layers:
    (weak DE / anti-additive / anti-morphic) determines the polarity licensing
    profile, connecting the `Prop`-based semantic properties in
    `Entailment` to the `Bool`-valued empirical classification
-   in `Semantics.Negation`
+   in `Negation`
 3. **Scoped vs unscoped negation** — a negation operator that retains scope
    into a domain preserves its semantic properties; when scope is blocked
    (e.g., by phase transfer), it loses antitonicity and hence licensing ability
 
 ## Dependencies
 
-- `Semantics.Negation` — framework-agnostic classification types (ENType, ENStrength,
+- `Negation` — framework-agnostic classification types (ENType, ENStrength,
   PolarityClass, PolarityLicensing) with Mathlib lattice instances
 - `Mathlib.Data.Set.Basic` — set complement (`pᶜ`) is the canonical
   propositional negation (no custom `pnot` wrapper)
@@ -33,9 +33,9 @@ coherent architecture with three layers:
   `IsAntiMorphic`, `pnot_isAntiMorphic`, `licensesWeakNPI`, `licensesStrongNPI`
 -/
 
-namespace Semantics.Negation
+namespace Negation
 
-open Semantics.Negation (ENType ENStrength PolarityLicensing PolarityClass
+open Negation (ENType ENStrength PolarityLicensing PolarityClass
            weakENProfile strongENProfile standardNegProfile)
 open NaturalLogic (DEStrength strengthSufficient)
 open Entailment (World)
@@ -125,7 +125,7 @@ theorem standardNeg_isAntiMorphic :
 
 /-! ### The entailment hierarchy determines polarity licensing
 
-The `Bool`-valued `PolarityLicensing` profile in `Semantics.Negation` is a
+The `Bool`-valued `PolarityLicensing` profile in `Negation` is a
 *consequence* of the `Prop`-based entailment properties in
 `Entailment`:
 
@@ -290,4 +290,4 @@ theorem unscoped_neg_licenses_nothing :
 theorem scope_determines_licensing (b : Bool) :
     scopeToLicensing b = enStrengthToLicensing (enTypeToStrength (scopeToENType b)) := rfl
 
-end Semantics.Negation
+end Negation

--- a/Linglib/Studies/Greco2020.lean
+++ b/Linglib/Studies/Greco2020.lean
@@ -46,7 +46,7 @@ the representation [CP ... [X° non] ... [FocP [TP ...] Foc° ...]]:
 
 ## Connections
 
-- `Semantics.Negation` — framework-agnostic EN types (ENType, ENStrength, PolarityLicensing)
+- `Negation` — framework-agnostic EN types (ENType, ENStrength, PolarityLicensing)
 - `Minimalist.NegScope` — merge position, scope, classification chain (defined below)
 - `ENEnvironment` (below) — the eleven Italian EN environments of Tables 1–2
 - `SnegAttestation` (below) — per-language head status, Greco's own classification
@@ -68,7 +68,7 @@ paper picks them up.
 namespace Minimalist.NegScope
 
 open Minimalist (Cat fValue isCPArea)
-open Semantics.Negation (ENType ENStrength PolarityLicensing PolarityClass weakENProfile strongENProfile)
+open Negation (ENType ENStrength PolarityLicensing PolarityClass weakENProfile strongENProfile)
 
 /-! ### Neg merge position -/
 
@@ -180,7 +180,7 @@ theorem equiv_factors_enstrength (p : NegMergePosition) :
 
 -- ── Bridge to Defs.lean semantic chain ──
 
-open Semantics.Negation (scopeToENType scopeToLicensing enTypeToLicensing)
+open Negation (scopeToENType scopeToLicensing enTypeToLicensing)
 
 /-- Merge position's `scopesIntoVP` determines EN type via the
     semantic chain from `Defs.lean`. -/
@@ -313,7 +313,7 @@ namespace Greco2020
 
 open Minimalist (Cat fValue isCPArea)
 open Minimalist.NegScope (NegMergePosition)
-open Semantics.Negation (ENStrength PolarityLicensing PolarityClass weakENProfile strongENProfile)
+open Negation (ENStrength PolarityLicensing PolarityClass weakENProfile strongENProfile)
 
 /-! ### Tables 1–2: the eleven Italian EN environments
 

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -58,7 +58,7 @@ structure MannerEffect where
 -- § 1. High vs Low EN (re-exported from ExpletiveNegation)
 -- ════════════════════════════════════════════════════
 
-open Semantics.Negation (ENType)
+open Negation (ENType)
 
 /-- Constructions relevant to EN licensing. Each has a theory-derived
     ambidirectionality status (§3) and an empirically-observed EN status


### PR DESCRIPTION
Dissolves the umbrella-directory namespace `Semantics.Negation` into a top-level `Negation` area namespace (the `Logic/`-cluster convention). Fragment files named `<Lang>.Negation` shadow it, so their opens use `_root_.Negation`. The nested `Semantics.Negation.CzechNegation` is untouched here — it becomes `Czech.Negation` in a follow-up once #2007 lands.