### PR TITLE
refactor(Semantics/Polarity): Czech.Negation, promote biasStrength

### DIFF
--- a/Linglib/Fragments/Slavic/Czech/Determiners.lean
+++ b/Linglib/Fragments/Slavic/Czech/Determiners.lean
@@ -20,14 +20,14 @@ on determiners is the primary scope diagnostic for negation position.
 - The žádný/nějaký contrast mirrors English *any* (NPI) vs *some* (PPI),
   but Czech žádný is an NCI requiring Agree with ¬,
   not just DE licensing.
-- Bridges to `Semantics.Negation.CzechNegation.Diagnostic` for per-position
+- Bridges to `Czech.Negation.Diagnostic` for per-position
   compatibility.
 
 -/
 
 namespace Czech.Determiners
 
-open Semantics.Negation.CzechNegation
+open Czech.Negation
 
 -- ============================================================================
 -- Polarity Type
@@ -150,7 +150,7 @@ def DetEntry.isPPI (d : DetEntry) : Bool := d.polarityType == .ppi
 
 /-- Whether a determiner is compatible with a given negation position,
 derived from the `licenses` function in CzechThreeWayNeg. -/
-def compatibleWith (d : DetEntry) (pos : NegPosition) : Bool :=
+def compatibleWith (d : DetEntry) (pos : Position) : Bool :=
   match d.diagnostic with
   | some diag => licenses pos diag
   | none      => true  -- neutral items are compatible everywhere
@@ -169,14 +169,14 @@ theorem nejaky_outer  : compatibleWith nejaky .outer  = true  := rfl
 exactly the positions where žádný is licensed, nějaký is blocked, and vice versa.
 This is the core diagnostic for distinguishing inner from non-inner negation. -/
 theorem zadny_nejaky_complementary :
-    ∀ pos : NegPosition,
+    ∀ pos : Position,
       compatibleWith zadny pos = !compatibleWith nejaky pos := by
   intro pos; cases pos <;> rfl
 
 /-- The NCI/PPI contrast uniquely identifies inner negation:
 inner is the only position where žádný is OK and nějaký is blocked. -/
 theorem nci_ppi_identifies_inner :
-    ∀ pos : NegPosition,
+    ∀ pos : Position,
       (compatibleWith zadny pos = true ∧ compatibleWith nejaky pos = false)
       → pos = .inner := by
   intro pos; cases pos <;> decide

--- a/Linglib/Semantics/Polarity/CzechNegation.lean
+++ b/Linglib/Semantics/Polarity/CzechNegation.lean
@@ -1,24 +1,28 @@
 import Mathlib.Order.Nat
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Tactic.DeriveFintype
+import Linglib.Semantics.Questions.Bias
 
 /-!
 # Czech Three-Way Negation: Core Types
 
-Pure type definitions for [stankova-2026]'s three-way negation distinction in
-Czech polar questions, kept free of empirical data so that Fragment files can
-reference these types without importing it. NCI licensing by Agree follows
-[zeijlstra-2004].
+The three-way negation distinction in Czech polar questions
+([stankova-2026]): the LF positions, the Table 1 diagnostics that
+fingerprint them, and their evidential bias strengths. Kept free of
+lexical entries so that Fragment files can reference these types
+without importing them. NCI licensing by Agree follows [zeijlstra-2004].
 -/
 
-namespace Semantics.Negation.CzechNegation
+namespace Czech.Negation
+
+open Semantics.Questions.Bias (EvidentialBiasStrength)
 
 /-- The three LF positions for negation in Czech PQs ([stankova-2026], her (16)).
 
   [CP... [PolP ne- [ModP ne- [TP ne-]]]]
               OUTER MEDIAL INNER
 -/
-inductive NegPosition where
+inductive Position where
   /-- Inner negation: in TP, propositional ¬p. Narrow scope.
       Licenses NCIs by Agree, licenses NPIs. Standard sentential negation. -/
   | inner
@@ -31,14 +35,14 @@ inductive NegPosition where
   deriving DecidableEq, Repr, Fintype
 
 /-- Numeric embedding: inner ↦ 0, medial ↦ 1, outer ↦ 2 (by scope width). -/
-def NegPosition.toNat : NegPosition → Nat
+def Position.toNat : Position → Nat
   | .inner  => 0
   | .medial => 1
   | .outer  => 2
 
-instance : LinearOrder NegPosition :=
-  LinearOrder.lift' NegPosition.toNat
-    (fun a b h => by cases a <;> cases b <;> simp_all [NegPosition.toNat])
+instance : LinearOrder Position :=
+  LinearOrder.lift' Position.toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [Position.toNat])
 
 /-- Diagnostics that distinguish the three negation readings (Table 1). -/
 inductive Diagnostic where
@@ -59,7 +63,7 @@ with polarity items and particles.
 
 This is the core empirical fingerprint: each negation position has a unique
 Boolean signature across the five diagnostics. -/
-def licenses : NegPosition → Diagnostic → Bool
+def licenses : Position → Diagnostic → Bool
   | .outer,  .ppiOutscoping => true
   | .outer,  .nciLicensed   => false
   | .outer,  .nahodou       => true
@@ -76,7 +80,7 @@ def licenses : NegPosition → Diagnostic → Bool
   | .inner,  .jeste         => true
   | .inner,  .fakt          => true
 
-/-- Each NegPosition has a unique 5-bit diagnostic signature.
+/-- Each Position has a unique 5-bit diagnostic signature.
     This is the formal statement that the diagnostic table (Table 1)
     distinguishes all three negation readings. -/
 theorem licenses_injective :
@@ -87,9 +91,17 @@ theorem licenses_injective :
   have h3 : licenses a .fakt = licenses b .fakt := congr_fun h _
   cases a <;> cases b <;> simp_all [licenses]
 
-/-- Scope ordering: inner < medial < outer. -/
-theorem inner_lt_medial : NegPosition.inner < .medial := by decide
-theorem medial_lt_outer : NegPosition.medial < .outer := by decide
-theorem inner_lt_outer : NegPosition.inner < .outer := by decide
+/-- Evidential bias strength of a negation position — inner strong,
+medial weak, outer none, FALSUM being epistemic-bias-based
+([stankova-2026] §3.1). -/
+def Position.biasStrength : Position → EvidentialBiasStrength
+  | .inner  => .strong
+  | .medial => .weak
+  | .outer  => .none_
 
-end Semantics.Negation.CzechNegation
+/-- Scope ordering: inner < medial < outer. -/
+theorem inner_lt_medial : Position.inner < .medial := by decide
+theorem medial_lt_outer : Position.medial < .outer := by decide
+theorem inner_lt_outer : Position.inner < .outer := by decide
+
+end Czech.Negation

--- a/Linglib/Studies/Greco2020.lean
+++ b/Linglib/Studies/Greco2020.lean
@@ -79,7 +79,7 @@ open Negation (ENType ENStrength PolarityLicensing PolarityClass weakENProfile s
     above the inflectional domain. The merge position determines scope,
     truth-conditionality, and polarity licensing.
 
-    Compare `Semantics.Negation.CzechNegation.NegPosition`
+    Compare `Czech.Negation.Position`
     which classifies three LF positions (inner/medial/outer) for
     Czech negation. This type is coarser: TP subsumes both inner
     and medial positions. -/
@@ -269,7 +269,7 @@ abstraction over the three-way Czech distinction — any result
 proved for `NegMergePosition` applies to Czech negation positions
 via this mapping. -/
 
-open Semantics.Negation.CzechNegation (NegPosition)
+open Czech.Negation (Position)
 
 /-- Map Czech three-way negation positions to the coarser two-way
     EN merge position.
@@ -277,35 +277,35 @@ open Semantics.Negation.CzechNegation (NegPosition)
     - **Inner** (TP, propositional ¬p): inflectional domain → tp
     - **Medial** (ModP, scopes over □_ev): still inflectional → tp
     - **Outer** (PolP, FALSUM): CP area → cp -/
-def NegPosition.toNegMergePosition : NegPosition → NegMergePosition
+def Position.toNegMergePosition : Position → NegMergePosition
   | .inner  => .tp
   | .medial => .tp
   | .outer  => .cp
 
 /-- Inner/medial map to tp, outer maps to cp. -/
-theorem inner_is_tp : NegPosition.toNegMergePosition .inner = .tp := rfl
-theorem medial_is_tp : NegPosition.toNegMergePosition .medial = .tp := rfl
-theorem outer_is_cp : NegPosition.toNegMergePosition .outer = .cp := rfl
+theorem inner_is_tp : Position.toNegMergePosition .inner = .tp := rfl
+theorem medial_is_tp : Position.toNegMergePosition .medial = .tp := rfl
+theorem outer_is_cp : Position.toNegMergePosition .outer = .cp := rfl
 
 /-- The Czech NCI licensing diagnostic aligns with vP scope:
     inner licenses NCIs (scopes into vP), outer does not (no vP scope). -/
 theorem nci_licensing_matches_scope :
-    Semantics.Negation.CzechNegation.licenses .inner .nciLicensed =
-    (NegPosition.toNegMergePosition .inner).scopesIntoVP ∧
-    Semantics.Negation.CzechNegation.licenses .outer .nciLicensed =
-    (NegPosition.toNegMergePosition .outer).scopesIntoVP := ⟨rfl, rfl⟩
+    Czech.Negation.licenses .inner .nciLicensed =
+    (Position.toNegMergePosition .inner).scopesIntoVP ∧
+    Czech.Negation.licenses .outer .nciLicensed =
+    (Position.toNegMergePosition .outer).scopesIntoVP := ⟨rfl, rfl⟩
 
 /-- The Czech three-way → two-way coarsening preserves scope ordering:
     inner ≤ medial ≤ outer maps to tp ≤ tp ≤ cp (monotone). -/
 theorem toNegMergePosition_monotone :
-    Monotone NegPosition.toNegMergePosition := by
+    Monotone Position.toNegMergePosition := by
   intro a b hab
   -- Both ≤ relations reduce to toNat comparisons via LinearOrder.lift'
   change NegMergePosition.toNat _ ≤ NegMergePosition.toNat _
-  change NegPosition.toNat a ≤ NegPosition.toNat b at hab
+  change Position.toNat a ≤ Position.toNat b at hab
   cases a <;> cases b <;>
-    simp only [NegPosition.toNegMergePosition, NegMergePosition.toNat,
-               NegPosition.toNat] at * <;> omega
+    simp only [Position.toNegMergePosition, NegMergePosition.toNat,
+               Position.toNat] at * <;> omega
 
 end Minimalist.NegScope
 

--- a/Linglib/Studies/Stankova2026.lean
+++ b/Linglib/Studies/Stankova2026.lean
@@ -27,7 +27,7 @@ three LF positions (her (16)) — outer (PolP), medial (ModP), inner (TP)
   columns jointly fingerprint the three positions.
 * `nahodou_identifies_outer`, `jeste_identifies_inner`,
   `fakt_plus_no_jeste_identifies_medial` — per-particle pinning.
-* `instance Distributed Particle NegPosition` — Table 1 as a licensing
+* `instance Distributed Particle Position` — Table 1 as a licensing
   axis alongside clause type and embedding.
 * `czech_refines_loNQ` — Czech splits [romero-2024]'s LoNQ into inner
   and medial.
@@ -44,13 +44,13 @@ three LF positions (her (16)) — outer (PolP), medial (ModP), inner (TP)
 
 namespace Stankova2026
 
-open Semantics.Negation.CzechNegation
+open Czech.Negation
 
 /-! ### Table 1 fingerprints -/
 
 /-- The Boolean signature of a negation position across the five
 Table 1 diagnostics. -/
-def signature (pos : NegPosition) : List Bool :=
+def signature (pos : Position) : List Bool :=
   [ licenses pos .ppiOutscoping
   , licenses pos .nciLicensed
   , licenses pos .nahodou
@@ -69,7 +69,7 @@ theorem signatures_distinct :
 requires LF c-command, and medial and outer negation are too high
 ([stankova-2026] (6), (10)). -/
 theorem only_inner_licenses_nci :
-    ∀ p : NegPosition, licenses p .nciLicensed = true → p = .inner := by
+    ∀ p : Position, licenses p .nciLicensed = true → p = .inner := by
   intro p h; cases p <;> simp_all [licenses]
 
 /-! ### The diagnostic particles ([stankova-2026] §2.2, Table 1)
@@ -103,31 +103,31 @@ def diagnostic? (p : Particle) : Option Diagnostic :=
 
 /-- Table 1 as a `Distributed` axis: negation position is a licensing
 context like clause type and embedding. -/
-instance : Distributed Particle NegPosition :=
+instance : Distributed Particle Position :=
   ⟨fun p pos => (diagnostic? p).map fun d =>
     if licenses pos d then .optional else .excluded⟩
 
 /-- Table 1 compatibility of a particle with a negation position, when
 the particle carries a diagnostic. -/
-def compatibleWith? (p : Particle) (pos : NegPosition) : Option Bool :=
+def compatibleWith? (p : Particle) (pos : Position) : Option Bool :=
   (diagnostic? p).map (licenses pos)
 
-example : Distributed.LicensedIn nahodou NegPosition.outer := by decide
+example : Distributed.LicensedIn nahodou Position.outer := by decide
 
 /-- *náhodou* uniquely identifies outer negation. -/
 theorem nahodou_identifies_outer :
-    ∀ pos : NegPosition, compatibleWith? nahodou pos = some true → pos = .outer := by
+    ∀ pos : Position, compatibleWith? nahodou pos = some true → pos = .outer := by
   intro pos; cases pos <;> decide
 
 /-- *ještě* uniquely identifies inner negation. -/
 theorem jeste_identifies_inner :
-    ∀ pos : NegPosition, compatibleWith? jeste pos = some true → pos = .inner := by
+    ∀ pos : Position, compatibleWith? jeste pos = some true → pos = .inner := by
   intro pos; cases pos <;> decide
 
 /-- *fakt* accepted while *ještě* is rejected identifies medial
 negation. -/
 theorem fakt_plus_no_jeste_identifies_medial :
-    ∀ pos : NegPosition,
+    ∀ pos : Position,
       compatibleWith? fakt pos = some true ∧ compatibleWith? jeste pos = some false →
       pos = .medial := by
   intro pos; cases pos <;> decide
@@ -135,7 +135,7 @@ theorem fakt_plus_no_jeste_identifies_medial :
 /-- The three Table 1 particles jointly fingerprint the three negation
 positions. -/
 theorem particle_signatures_distinct :
-    ∀ pos pos' : NegPosition,
+    ∀ pos pos' : Position,
       (∀ p ∈ [nahodou, jeste, fakt], compatibleWith? p pos = compatibleWith? p pos') →
       pos = pos' := by
   intro pos pos' h
@@ -175,7 +175,7 @@ inductive CzechPQForm where
 
 end Stankova2026
 
-namespace Semantics.Negation.CzechNegation
+namespace Czech.Negation
 
 open Semantics.Questions.Bias
 open Stankova2026 (CzechPQForm)
@@ -183,41 +183,33 @@ open StankovaSimik2025 (VerbPosition)
 
 /-- [romero-2024] PQ form of a negation position: outer is high
 negation (HiNQ), inner and medial are both low (LoNQ). -/
-def NegPosition.toPQForm : NegPosition → PQForm
+def Position.toPQForm : Position → PQForm
   | .inner | .medial => .LoNQ
   | .outer => .HiNQ
 
-/-- Evidential bias strength of a negation position ([stankova-2026]
-§3.1): inner strong, medial weak, outer none (FALSUM is
-epistemic-bias-based). -/
-def NegPosition.biasStrength : NegPosition → EvidentialBiasStrength
-  | .inner  => .strong
-  | .medial => .weak
-  | .outer  => .none_
-
 /-- Only outer negation (FALSUM) is obligatorily focused
 ([stankova-2026] §3.2). -/
-def NegPosition.requiresFocus : NegPosition → Bool
+def Position.requiresFocus : Position → Bool
   | .outer => true
   | .medial | .inner => false
 
 /-- Verb position realizing a negation position: outer is V1, inner and
 medial are nonV1. -/
-def NegPosition.toVerbPosition : NegPosition → VerbPosition
+def Position.toVerbPosition : Position → VerbPosition
   | .inner | .medial => .nonV1
   | .outer => .v1
 
 /-- [simik-2024] PQ form of a negation position: outer is InterNPQ,
 inner and medial are DeclNPQ. -/
-def NegPosition.toCzechPQForm : NegPosition → CzechPQForm
+def Position.toCzechPQForm : Position → CzechPQForm
   | .inner | .medial => .declNPQ
   | .outer => .interNPQ
 
-end Semantics.Negation.CzechNegation
+end Czech.Negation
 
 namespace Stankova2026
 
-open Semantics.Negation.CzechNegation
+open Czech.Negation
 open Semantics.Questions.Bias
 open StankovaSimik2025 (VerbPosition)
 
@@ -231,47 +223,47 @@ def CzechPQForm.toPQForm : CzechPQForm → PQForm
 /-- The two form typologies agree: [simik-2024]'s grid refines
 [romero-2024]'s. -/
 theorem czechPQForm_consistent_with_pqForm :
-    ∀ pos : NegPosition, pos.toCzechPQForm.toPQForm = pos.toPQForm := by
+    ∀ pos : Position, pos.toCzechPQForm.toPQForm = pos.toPQForm := by
   intro pos; cases pos <;> rfl
 
 /-- Czech refines [romero-2024]'s LoNQ: inner and medial share the LoNQ
 form but differ in evidential bias strength and in their Table 1
 signatures. -/
 theorem czech_refines_loNQ :
-    NegPosition.inner.toPQForm = NegPosition.medial.toPQForm ∧
-    NegPosition.inner.biasStrength ≠ NegPosition.medial.biasStrength ∧
+    Position.inner.toPQForm = Position.medial.toPQForm ∧
+    Position.inner.biasStrength ≠ Position.medial.biasStrength ∧
     signature .inner ≠ signature .medial :=
   ⟨rfl, by decide, by (unfold signature licenses; decide)⟩
 
 /-- Obligatory focus singles out outer negation ([stankova-2026]
 §3.2). -/
 theorem only_outer_requires_focus :
-    ∀ p : NegPosition, p.requiresFocus = true → p = .outer := by
-  intro p h; cases p <;> simp_all [NegPosition.requiresFocus]
+    ∀ p : Position, p.requiresFocus = true → p = .outer := by
+  intro p h; cases p <;> simp_all [Position.requiresFocus]
 
 /-- Czech outer negation is a HiNQ with mandatory original bias for p,
 matching [romero-2024]'s Table 1. -/
 theorem czech_outer_matches_romero_hiNQ_bias :
-    NegPosition.outer.toPQForm = .HiNQ ∧
+    Position.outer.toPQForm = .HiNQ ∧
     originalBiasOK .HiNQ .forP = true ∧
     originalBiasOK .HiNQ .neutral = false := ⟨rfl, rfl, rfl⟩
 
 /-- Czech low negation is a LoNQ compatible with neutral original bias,
 matching [romero-2024]'s Table 1. -/
 theorem czech_low_neg_matches_romero_loNQ_bias :
-    NegPosition.inner.toPQForm = .LoNQ ∧
+    Position.inner.toPQForm = .LoNQ ∧
     originalBiasOK .LoNQ .neutral = true := ⟨rfl, rfl⟩
 
 /-- Czech inner negation requires contextual evidence against p,
 matching [romero-2024]'s Table 2 for LoNQs. -/
 theorem czech_inner_matches_romero_evidence_bias :
-    NegPosition.inner.toPQForm = .LoNQ ∧
+    Position.inner.toPQForm = .LoNQ ∧
     evidenceBiasOK .LoNQ .againstP = true := ⟨rfl, rfl⟩
 
 /-- Czech outer negation (HiNQ) is compatible with evidence against p
 (contradiction scenarios). -/
 theorem czech_outer_matches_romero_evidence :
-    NegPosition.outer.toPQForm = .HiNQ ∧
+    Position.outer.toPQForm = .HiNQ ∧
     evidenceBiasOK .HiNQ .againstP = true := ⟨rfl, rfl⟩
 
 /-! ### Verb position and context sensitivity
@@ -286,14 +278,6 @@ nonV1/inner strong. -/
 theorem context_tracks_bias_strength :
     VerbPosition.v1.defaultReading.biasStrength = .none_ ∧
     VerbPosition.nonV1.defaultReading.biasStrength = .strong := ⟨rfl, rfl⟩
-
-/-- [stankova-2025]'s evidence requirement is the strong tier of this
-paper's bias-strength scale; a reading needs negative contextual
-evidence iff its evidential bias is strong. -/
-theorem needsNegativeEvidence_iff_strong :
-    ∀ pos : NegPosition,
-      pos.needsNegativeEvidence = true ↔ pos.biasStrength = .strong := by
-  intro pos; cases pos <;> simp [NegPosition.needsNegativeEvidence, NegPosition.biasStrength]
 
 /-! ### The Czech bias profile ([simik-2024] Table 2) -/
 
@@ -345,7 +329,7 @@ open Data.Examples (LinguisticExample)
 
 /-- The paper's polarity/particle examples with their negation reading
 and tested diagnostic. -/
-def analyzedExamples : List (LinguisticExample × NegPosition × Diagnostic) :=
+def analyzedExamples : List (LinguisticExample × Position × Diagnostic) :=
   [ (Examples.ex6a,  .inner,  .nciLicensed)
   , (Examples.ex6b,  .outer,  .nciLicensed)
   , (Examples.ex7a,  .medial, .ppiOutscoping)

--- a/Linglib/Studies/StankovaSimik2025.lean
+++ b/Linglib/Studies/StankovaSimik2025.lean
@@ -23,23 +23,11 @@ diagnostics are [stankova-2026]'s and live in `Stankova2026`.
 * [stankova-2025], [stankova-2023], [simik-2024], [nekula-1996].
 -/
 
-namespace Semantics.Negation.CzechNegation
-
-/-- Whether a negation reading requires negative contextual evidence
-(§5.3); by inner negation the speaker "questions or double-checks
-evidential bias", by FALSUM epistemic bias. Medial, [stankova-2026]'s
-refinement, carries only weak evidential bias. -/
-def NegPosition.needsNegativeEvidence : NegPosition → Bool
-  | .inner => true
-  | .medial | .outer => false
-
-end Semantics.Negation.CzechNegation
-
 namespace StankovaSimik2025
 
 open Czech.Particles (nahodou snad copak)
 open Czech.Determiners (zadny nejaky)
-open Semantics.Negation.CzechNegation
+open Czech.Negation
 open Semantics.Questions.Bias (ContextualEvidence evidenceBiasOK)
 open Features (Judgment)
 
@@ -61,29 +49,29 @@ inductive VerbPosition where
   | nonV1
   deriving DecidableEq, Repr
 
-/-- Height of the negated verb in `NegPosition.toNat` coordinates; the
+/-- Height of the negated verb in `Position.toNat` coordinates; the
 V1 verb raises into the outer (PolP) region, the nonV1 verb stays in TP
 ((11)-(12)). -/
 def VerbPosition.verbHeight : VerbPosition → ℕ
-  | .v1    => NegPosition.outer.toNat
-  | .nonV1 => NegPosition.inner.toNat
+  | .v1    => Position.outer.toNat
+  | .nonV1 => Position.inner.toNat
 
 /-- Negation readings available per verb position ((11)-(12)) — V1 only
 outer; nonV1 also inner (outer there needs a contrastive topic and a
 focused verb, ex. 18). The substrate's medial reading, [stankova-2026]'s
 refinement, patterns with inner. -/
-def VerbPosition.availableReadings : VerbPosition → List NegPosition
+def VerbPosition.availableReadings : VerbPosition → List Position
   | .v1    => [.outer]
   | .nonV1 => [.inner, .medial, .outer]
 
 /-- A reading is available at a verb position iff its operator sits at
 or above the negated verb — the c-command condition behind (11)-(12). -/
-theorem mem_availableReadings_iff (wp : VerbPosition) (pos : NegPosition) :
+theorem mem_availableReadings_iff (wp : VerbPosition) (pos : Position) :
     pos ∈ wp.availableReadings ↔ wp.verbHeight ≤ pos.toNat := by
   cases wp <;> cases pos <;> decide
 
 /-- The default (unmarked) negation reading per verb position. -/
-def VerbPosition.defaultReading : VerbPosition → NegPosition
+def VerbPosition.defaultReading : VerbPosition → Position
   | .v1    => .outer
   | .nonV1 => .inner
 
@@ -98,7 +86,7 @@ evidence (§5). Context sensitivity tracks the reading, not the word
 order; V1's FALSUM default is natural under any evidential bias,
 nonV1's inner default needs negative evidence. -/
 def VerbPosition.requiresContextualEvidence (wp : VerbPosition) : Bool :=
-  wp.defaultReading.needsNegativeEvidence
+  wp.defaultReading.biasStrength == .strong
 
 /-- An NCI-tolerant default reading identifies declarative word order;
 the NCI advantage in nonV1 PQs diagnoses inner negation. -/
@@ -132,7 +120,7 @@ def Indefinite.diagnostic : Indefinite → Diagnostic
   | .ppi => .ppiOutscoping
 
 /-- The negation reading each indefinite proxies for (§5.1). -/
-def Indefinite.reading : Indefinite → NegPosition
+def Indefinite.reading : Indefinite → Position
   | .nci => .inner
   | .ppi => .outer
 
@@ -150,7 +138,7 @@ reading, indefinite against context, verb position against context. -/
 /-- The number of clashes in a condition of the §5.1 design. -/
 def clashCount (wp : VerbPosition) (ind : Indefinite) (ctx : ContextualEvidence) : ℕ :=
   (if ind.reading == wp.defaultReading then 0 else 1) +
-  (if ind.reading.needsNegativeEvidence && (ctx != .againstP) then 1 else 0) +
+  (if (ind.reading.biasStrength == .strong) && (ctx != .againstP) then 1 else 0) +
   (if wp.requiresContextualEvidence && (ctx != .againstP) then 1 else 0)
 
 /-- The judgment tier predicted from the clash count. -/


### PR DESCRIPTION
Renames `Semantics.Negation.CzechNegation` to `Czech.Negation` (joining the `Czech.Particles`/`Czech.Determiners` family) with `NegPosition` → `Position`, and promotes `Position.biasStrength` from `Stankova2026.lean` into the substrate. `needsNegativeEvidence` and its bridge theorem dissolve: `requiresContextualEvidence` and the clash count now read `biasStrength == .strong` directly, so medial's non-clashing behavior comes from its weak tier instead of a stipulated Bool.