### PR TITLE
fix(Fragments/Hawaiian): recode possession; drop dead affixPosition

### DIFF
--- a/Linglib/Features/Possession.lean
+++ b/Linglib/Features/Possession.lean
@@ -17,7 +17,7 @@ bare `def`s in `Fragments/<Lang>/Possession.lean`, consumed by
 
 ## Main definitions
 
-`Obligatoriness` (WALS 58A), `Classification` (59A), `AffixPosition` (57A),
+`Obligatoriness` (WALS 58A), `Classification` (59A),
 `PredicativeStrategy` ([stassen-2009] four-way; [stassen-2013b] adds Genitive),
 `AdnominalMarking` ([nichols-1986]), `Notion` and `Source` ([heine-1997]),
 `InalienabilityRank`, and the neutral `Alienability` cut. Per-language values
@@ -83,18 +83,6 @@ inductive AdnominalMarking where
   | doubleMarking
   /-- No overt marker; word order alone (WALS "no marking"; Vietnamese). -/
   | zeroMarking
-  deriving DecidableEq, Repr
-
-/-- WALS 57A: position of pronominal possessive affixes on the noun. -/
-inductive AffixPosition where
-  /-- Possessive prefixes (Bantu, many Papuan). -/
-  | prefixes
-  /-- Possessive suffixes (Turkish, Hungarian, Finnish). -/
-  | suffixes
-  /-- Both prefixes and suffixes. -/
-  | both
-  /-- No affixes; independent words/clitics (English `my`, Mandarin `de`). -/
-  | noAffix
   deriving DecidableEq, Repr
 
 /-- [heine-1997]: semantic targets of possession (vs `Source`, the diachronic origin). -/

--- a/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
@@ -27,6 +27,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .zeroMarking
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Arabic.ModernStandard.Possession

--- a/Linglib/Fragments/English/Possession.lean
+++ b/Linglib/Fragments/English/Possession.lean
@@ -22,6 +22,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .haveVerb
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end English.Possession

--- a/Linglib/Fragments/Fijian/Possession.lean
+++ b/Linglib/Fragments/Fijian/Possession.lean
@@ -12,7 +12,10 @@ these values live in `Studies/NicholsBickel2013.lean`.
 
 Examples: na liga-qu (body-part); na ke-qu kakana (food); na me-qu ti
 (drink); na no-qu vale (house). Four-way possessive classification: direct
-(body/kin), ke- (edible), me- (drinkable), no- (general alienable).
+(body/kin), ke- (edible), me- (drinkable), no- (general alienable). WALS 59A
+nonetheless codes Fijian as *No possessive classification* under Nichols &
+Bickel's criterion; the value here follows the descriptive four-class
+tradition.
 -/
 
 set_option autoImplicit false
@@ -25,6 +28,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .threeOrMore
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .headMarking
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Fijian.Possession

--- a/Linglib/Fragments/Finnish/Possession.lean
+++ b/Linglib/Fragments/Finnish/Possession.lean
@@ -127,6 +127,5 @@ theorem covers_all_notions :
 
 def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Finnish.Possession

--- a/Linglib/Fragments/Georgian/Possession.lean
+++ b/Linglib/Fragments/Georgian/Possession.lean
@@ -24,6 +24,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .doubleMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Georgian.Possession

--- a/Linglib/Fragments/Greek/Grevena/Possession.lean
+++ b/Linglib/Fragments/Greek/Grevena/Possession.lean
@@ -79,6 +79,5 @@ def predicativeStrategy : PredicativeStrategy := .haveVerb
     distinguish from juxtaposition (a structure SMG apo-PPs do NOT support,
     see [kampanarou-alexiadou-2026] §4). -/
 def adnominalStrategy : AdnominalMarking := .zeroMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.Grevena.Possession

--- a/Linglib/Fragments/Greek/Smyrna/Possession.lean
+++ b/Linglib/Fragments/Greek/Smyrna/Possession.lean
@@ -70,6 +70,5 @@ def predicativeStrategy : PredicativeStrategy := .haveVerb
     Establishes the bidirectionality of the Modern Greek dialect continuum:
     SMG sits between Smyrna's over-extension and Grevena's complete loss. -/
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.Smyrna.Possession

--- a/Linglib/Fragments/Greek/StandardModern/Possession.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Possession.lean
@@ -67,6 +67,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .haveVerb
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Greek.StandardModern.Possession

--- a/Linglib/Fragments/Hawaiian/Possession.lean
+++ b/Linglib/Fragments/Hawaiian/Possession.lean
@@ -2,17 +2,19 @@ import Linglib.Features.Possession
 
 /-!
 # Hawaiian possession profile
-[stassen-2009] [nichols-1986] [heine-1997]
 
-Bare per-language possession `def`s for Hawaiian (Austronesian, ISO `haw`),
-per the project's "per-language data flows through Fragments" rule.
-Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
-`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
-these values live in `Studies/NicholsBickel2013.lean`.
+Per-language possession values for Hawaiian (Polynesian, ISO `haw`), coded from
+[elbert-pukui-1979] and consumed by `Studies/NicholsBickel2013`; of the WALS
+possession chapters only 57A samples Hawaiian.
 
-Examples: ko'u makuahine (o-class); ka'u puke (a-class). Classic Oceanic
-alienable vs inalienable: a-class (alienable) vs o-class (inalienable body
-parts, kinship, clothing, land).
+The two possessive classes are relation-based ([wilson-1976]): relations the
+possessor controls — creates or instigates — take a-class (*kaʻu puke* "my
+book"; children, spouses, food, implements), while uncontrolled relations
+(body parts, parents, siblings, chiefs) and those where the possessed serves
+as the possessor's location (houses, clothing, ridden animals) take o-class
+(*koʻu makuahine* "my mother"). Not classic Oceanic alienability: the same
+noun shifts class with the relation, *koʻu hale* "my house (I live in)" vs
+*kaʻu hale* "my house (that I built)".
 -/
 
 set_option autoImplicit false
@@ -21,10 +23,20 @@ namespace Hawaiian.Possession
 
 open _root_.Possession
 
+/-- Possessives are free determiners; no noun requires one ([elbert-pukui-1979]). -/
 def obligatoryPossession : Obligatoriness := .noObligatory
+
+/-- The a-class vs o-class contrast ([wilson-1976]). WALS 59A splits on parallel
+    Polynesian systems — Rapanui and Tongan two classes, Māori none — so this
+    follows the descriptive tradition. -/
 def possessiveClassification : Classification := .twoWay
-def predicativeStrategy : PredicativeStrategy := .locational
+
+/-- *He puke kaʻu* "I have a book": existential possessee with genitive
+    possessor, the type WALS 117A assigns to Māori and Tahitian ([stassen-2013b]). -/
+def predicativeStrategy : PredicativeStrategy := .genitive
+
+/-- The possessor carries the genitive particle *a* or *o* (*ka hale o Pua*
+    "Pua's house"); the possessum is unmarked ([nichols-1986]). -/
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Hawaiian.Possession

--- a/Linglib/Fragments/HindiUrdu/Possession.lean
+++ b/Linglib/Fragments/HindiUrdu/Possession.lean
@@ -23,6 +23,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := Option.none
 
 end HindiUrdu.Possession

--- a/Linglib/Fragments/Hungarian/Possession.lean
+++ b/Linglib/Fragments/Hungarian/Possession.lean
@@ -38,6 +38,5 @@ def obligatoryPossession : Obligatoriness := .exists_
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .headMarking
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Hungarian.Possession

--- a/Linglib/Fragments/Irish/Possession.lean
+++ b/Linglib/Fragments/Irish/Possession.lean
@@ -22,6 +22,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Irish.Possession

--- a/Linglib/Fragments/Japanese/Possession.lean
+++ b/Linglib/Fragments/Japanese/Possession.lean
@@ -22,6 +22,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .topic
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Japanese.Possession

--- a/Linglib/Fragments/Korean/Possession.lean
+++ b/Linglib/Fragments/Korean/Possession.lean
@@ -22,6 +22,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := Option.none
 
 end Korean.Possession

--- a/Linglib/Fragments/Mandarin/Possession.lean
+++ b/Linglib/Fragments/Mandarin/Possession.lean
@@ -22,6 +22,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .haveVerb
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Mandarin.Possession

--- a/Linglib/Fragments/Mayan/Tseltal/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Possession.lean
@@ -11,7 +11,7 @@ through Fragments" rule ([stassen-2009]; [nichols-1986]; [heine-1997];
 ## Main declarations
 
 * `obligatoryPossession`, `possessiveClassification`, `predicativeStrategy`,
-  `adnominalStrategy`, `affixPosition`: the five possession-profile values.
+  `adnominalStrategy`: the four possession-profile values.
 
 ## Implementation notes
 
@@ -35,6 +35,5 @@ def obligatoryPossession : Obligatoriness := .exists_
 def possessiveClassification : Classification := .threeOrMore
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .headMarking
-def affixPosition : Option AffixPosition := some .prefixes
 
 end Tseltal.Possession

--- a/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
@@ -11,7 +11,7 @@ through Fragments" rule ([stassen-2009]; [nichols-1986]; [heine-1997];
 ## Main declarations
 
 * `obligatoryPossession`, `possessiveClassification`, `predicativeStrategy`,
-  `adnominalStrategy`, `affixPosition`: the five possession-profile values.
+  `adnominalStrategy`: the four possession-profile values.
 
 ## Implementation notes
 
@@ -36,6 +36,5 @@ def obligatoryPossession : Obligatoriness := .exists_
 def possessiveClassification : Classification := .threeOrMore
 def predicativeStrategy : PredicativeStrategy := .locational
 def adnominalStrategy : AdnominalMarking := .headMarking
-def affixPosition : Option AffixPosition := some .prefixes
 
 end Tsotsil.Possession

--- a/Linglib/Fragments/Quechua/Possession.lean
+++ b/Linglib/Fragments/Quechua/Possession.lean
@@ -25,6 +25,5 @@ def obligatoryPossession : Obligatoriness := .exists_
 def possessiveClassification : Classification := .twoWay
 def predicativeStrategy : PredicativeStrategy := .haveVerb
 def adnominalStrategy : AdnominalMarking := .doubleMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Quechua.Possession

--- a/Linglib/Fragments/Slavic/Russian/Possession.lean
+++ b/Linglib/Fragments/Slavic/Russian/Possession.lean
@@ -105,6 +105,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 /-- Adnominal NP-GEN (`kniga Ivana`): dependent-marking. -/
 def adnominalStrategy : AdnominalMarking := .dependentMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Russian.Possession

--- a/Linglib/Fragments/Swahili/Possession.lean
+++ b/Linglib/Fragments/Swahili/Possession.lean
@@ -125,6 +125,5 @@ def possessiveClassification : Classification := .noClassification
     (the strict [nichols-1986] typology classifies it differently in some
     descriptions). -/
 def adnominalStrategy : AdnominalMarking := .headMarking
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Swahili.Possession

--- a/Linglib/Fragments/Turkish/Possession.lean
+++ b/Linglib/Fragments/Turkish/Possession.lean
@@ -142,6 +142,5 @@ def obligatoryPossession : Obligatoriness := .exists_
 def possessiveClassification : Classification := .noClassification
 /-- GEN on possessor + possessive suffix on the head (`Ali-nin kitab-i`). -/
 def adnominalStrategy : AdnominalMarking := .doubleMarking
-def affixPosition : Option AffixPosition := some .suffixes
 
 end Turkish.Possession

--- a/Linglib/Fragments/Yoruba/Possession.lean
+++ b/Linglib/Fragments/Yoruba/Possession.lean
@@ -24,6 +24,5 @@ def obligatoryPossession : Obligatoriness := .noObligatory
 def possessiveClassification : Classification := .noClassification
 def predicativeStrategy : PredicativeStrategy := .haveVerb
 def adnominalStrategy : AdnominalMarking := .zeroMarking
-def affixPosition : Option AffixPosition := some .noAffix
 
 end Yoruba.Possession

--- a/Linglib/Studies/NicholsBickel2013.lean
+++ b/Linglib/Studies/NicholsBickel2013.lean
@@ -192,12 +192,12 @@ theorem two_way_dominates_three_plus :
 -- ============================================================================
 
 /-- In the sample, locational strategies are the most common predicative
-    possession type (12 languages), followed by have-verb (4), genitive (1),
+    possession type (11 languages), followed by have-verb (4), genitive (2),
     topic (1), and comitative (1). -/
 theorem predicative_distribution :
-    countByPredicative allLanguages .locational = 12 ∧
+    countByPredicative allLanguages .locational = 11 ∧
     countByPredicative allLanguages .haveVerb = 4 ∧
-    countByPredicative allLanguages .genitive = 1 ∧
+    countByPredicative allLanguages .genitive = 2 ∧
     countByPredicative allLanguages .topic = 1 ∧
     countByPredicative allLanguages .comitative = 1 := by
   native_decide
@@ -269,14 +269,16 @@ theorem head_marking_mostly_complex_possession :
 -- ============================================================================
 
 /-- In the sample, locational/existential predicative possession is the most
-    widespread strategy (12 languages: Russian, Finnish, Hungarian, Korean,
-    Georgian, Hawaiian, Fijian, Tsotsil, Tseltal, plus Hindi-Urdu, Irish, and
+    widespread strategy (11 languages: Russian, Finnish, Hungarian, Korean,
+    Georgian, Fijian, Tsotsil, Tseltal, plus Hindi-Urdu, Irish, and
     Arabic, whose "at/near"-oblique possessives are Locational, not Genitive).
     The Eurasian "habeo-less" belt stretches from Finland through Korea, and
-    locational strategies also appear in Oceanic and Mayan languages. (Turkish,
-    with its genitive `var`-existential, is the sample's sole Genitive type.) -/
+    locational strategies also appear in Oceanic and Mayan languages. (The
+    Genitive type appears twice: Turkish's genitive `var`-existential and
+    Hawaiian's *He puke kaʻu*, the construction WALS 117A codes as Genitive
+    in Māori and Tahitian.) -/
 theorem locational_count :
-    (allLanguages.filter (·.usesLocational)).length = 12 := by
+    (allLanguages.filter (·.usesLocational)).length = 11 := by
   native_decide
 
 -- ============================================================================

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4258,6 +4258,33 @@
   validated = {true},
   sources   = {Features/Possession.lean}
 }% REF: Szabolcsi, A. (1986). Comparative superlatives.
+
+@article{wilson-1976,
+  author    = {Wilson, William H.},
+  year      = {1976},
+  title     = {The o/a distinction in {Hawaiian} possessives},
+  journal   = {Oceanic Linguistics},
+  volume    = {15},
+  number    = {1/2},
+  pages     = {39--50},
+  url       = {https://www.jstor.org/stable/3622775},
+  subfield  = {comparative},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Hawaiian/Possession.lean}
+}
+
+@book{elbert-pukui-1979,
+  author    = {Elbert, Samuel H. and Pukui, Mary Kawena},
+  year      = {1979},
+  title     = {Hawaiian Grammar},
+  publisher = {University Press of Hawaii},
+  address   = {Honolulu},
+  subfield  = {comparative},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Hawaiian/Possession.lean}
+}
 @incollection{szabolcsi-1986,
   author    = {Szabolcsi, Anna},
   year      = {1986},


### PR DESCRIPTION
Audit of `Fragments/Hawaiian/Possession.lean`: predicative possession recoded Locational → Genitive (WALS 117A codes the parallel Māori/Tahitian construction as Genitive; Stassen's Locational requires a spatial marker), with count ripples in `Studies/NicholsBickel2013`; docstring rewritten to Wilson 1976's control-plus-location analysis (verified against the paper) with elbert-pukui-1979 / wilson-1976 added to the bib.

- drops the `affixPosition` field from all 22 possession fragments and the `AffixPosition` enum from `Features/Possession` — zero consumers, and Hawaiian's value hand-copied the existing WALS F57A row
- discloses the Fijian 59A divergence (fragment `.threeOrMore` vs Nichols & Bickel's *No possessive classification* row) in the Fijian docstring; coding decision left to a follow-up