### PR TITLE
docs(Features/Possession): References sections; drop autoImplicit lines

### DIFF
--- a/Linglib/Features/Possession.lean
+++ b/Linglib/Features/Possession.lean
@@ -6,23 +6,22 @@ Authors: Robert Hawkins
 
 /-!
 # Possession — typological feature substrate
-[stassen-2009] [stassen-2013b] [nichols-1986] [nichols-bickel-2013]
-[nichols-bickel-2013c] [heine-1997] [heine-2009] [aikhenvald-2012] [wals-2013]
 
-Theory-neutral classification enums for possession. Per-language values are
-bare `def`s in `Fragments/<Lang>/Possession.lean`, consumed by
-`Studies/NicholsBickel2013`, `Studies/Heine1997`, and
-`Studies/KampanarouAlexiadou2026`. Bare-root `Possession` namespace under
-`Features/`, like `Features/Case`.
+Theory-neutral classification enums for possession, following the WALS
+possession chapters ([wals-2013]). Per-language values are bare `def`s in
+`Fragments/<Lang>/Possession.lean`, consumed by `Studies/NicholsBickel2013`,
+`Studies/Heine1997`, and `Studies/KampanarouAlexiadou2026`. Bare-root
+`Possession` namespace under `Features/`, like `Features/Case`.
 
 ## Main definitions
 
-`Obligatoriness` (WALS 58A), `Classification` (59A),
-`PredicativeStrategy` ([stassen-2009] four-way; [stassen-2013b] adds Genitive),
-`AdnominalMarking` ([nichols-1986]), `Notion` and `Source` ([heine-1997]),
-`InalienabilityRank`, and the neutral `Alienability` cut. Per-language values
-are bare `def`s in `Fragments/<Lang>/Possession.lean`; cross-linguistic
-aggregation uses a study-local row in `Studies/NicholsBickel2013.lean`.
+`Obligatoriness` and `Classification` (WALS 58A and 59A,
+[nichols-bickel-2013]), `PredicativeStrategy` ([stassen-2009] four-way;
+[stassen-2013b] adds Genitive), `AdnominalMarking` ([nichols-1986]; WALS 24A,
+[nichols-bickel-2013c]), `Notion` and `Source` ([heine-1997], [heine-2009]),
+`InalienabilityRank` ([aikhenvald-2012]), and the neutral `Alienability` cut.
+Cross-linguistic aggregation uses a study-local row in
+`Studies/NicholsBickel2013.lean`.
 
 ## Notes
 
@@ -32,13 +31,20 @@ grouped with Locational as "Oblique Possessive"); `Classification` collapses
 Mayan/Oceanic multi-class systems into `threeOrMore`; `Source` (Heine's event
 schemas) and `PredicativeStrategy` are parallel typologies bridged by
 `predicativeSource`.
--/
 
-set_option autoImplicit false
+## References
+
+* [nichols-bickel-2013], [nichols-bickel-2013c], [wals-2013] — the WALS
+  chapters (24A, 58A, 59A)
+* [stassen-2009], [stassen-2013b] — predicative possession (WALS 117A)
+* [nichols-1986] — head- vs dependent-marking
+* [heine-1997], [heine-2009] — possessive notions and source schemas
+* [aikhenvald-2012] — inalienability
+-/
 
 namespace Possession
 
-/-- WALS 58A: whether some nouns (kinship, body parts) require possessive marking. -/
+/-- Whether some nouns (kinship, body parts) require possessive marking (WALS 58A). -/
 inductive Obligatoriness where
   /-- Obligatory possessive inflection exists (Mohawk, Navajo). -/
   | exists_
@@ -48,18 +54,19 @@ inductive Obligatoriness where
   | unclear
   deriving DecidableEq, Repr
 
-/-- WALS 59A: whether possession is morphosyntactically classified (alienability). -/
+/-- Whether possession is morphosyntactically classified, typically by
+    alienability (WALS 59A). -/
 inductive Classification where
   /-- One construction for all nouns (English, Russian). -/
   | noClassification
-  /-- Two-way, typically alienable vs inalienable (Fijian, Hawaiian). -/
+  /-- Two-way, typically alienable vs inalienable (Ewe, Rapanui). -/
   | twoWay
   /-- Three or more possessive classes. -/
   | threeOrMore
   deriving DecidableEq, Repr
 
-/-- How a language predicates possession ("I have X"); [stassen-2009] four-way,
-    [stassen-2013b] (WALS 117A) adds Genitive. -/
+/-- Stassen's classification of how a language predicates possession
+    ("I have X"), with the Genitive type added in WALS 117A. -/
 inductive PredicativeStrategy where
   /-- Transitive 'have' verb (English, Mandarin). -/
   | haveVerb
@@ -73,7 +80,7 @@ inductive PredicativeStrategy where
   | comitative
   deriving DecidableEq, Repr
 
-/-- [nichols-1986]; WALS 24A [nichols-bickel-2013c]: locus of NP-internal marking. -/
+/-- The locus of marking inside the possessive NP (WALS 24A). -/
 inductive AdnominalMarking where
   /-- Marker on the possessed head noun (Hungarian, Swahili). -/
   | headMarking
@@ -85,7 +92,8 @@ inductive AdnominalMarking where
   | zeroMarking
   deriving DecidableEq, Repr
 
-/-- [heine-1997]: semantic targets of possession (vs `Source`, the diachronic origin). -/
+/-- Heine's semantic targets of possession, as opposed to `Source`, the
+    diachronic origin. -/
 inductive Notion where
   /-- Physical possession ("a pen in my hand"). -/
   | physical
@@ -103,9 +111,10 @@ inductive Notion where
   | inanimateAlienable
   deriving DecidableEq, Repr
 
-/-- Coarse inalienability cline (body-part/kinship rank highest). `toNat` is an
-    operationalization for comparison, not a claimed universal — [nichols-1986]
-    and [aikhenvald-2012] treat kinship and body-parts as co-central. -/
+/-- Coarse inalienability cline, body parts and kinship ranking highest.
+    `toNat` is an operationalization for comparison rather than a claimed
+    universal, since Nichols and Aikhenvald treat kinship and body parts as
+    co-central. -/
 inductive InalienabilityRank where
   | bodyPart
   | kinship
@@ -124,7 +133,7 @@ def InalienabilityRank.toNat : InalienabilityRank → Nat
   | .culturalItem    => 1
   | .generalProperty => 0
 
-/-- [heine-1997] / [heine-2009]: diachronic source schemas of predicative possession. -/
+/-- Heine's diachronic source schemas of predicative possession. -/
 inductive Source where
   /-- Action "X takes Y" (English `have` < OE `habban`). -/
   | action
@@ -167,7 +176,8 @@ def Classification.drawsAlienabilityCut : Classification → Bool
   | .noClassification => false
   | _                 => true
 
-/-- Coarsen the cline at a language's `cut`: ranks at or above `cut` are inalienable. -/
+/-- Coarsening of the cline that counts ranks at or above `cut` as
+    inalienable. -/
 def InalienabilityRank.alienabilityAt (cut : InalienabilityRank) :
     InalienabilityRank → Alienability :=
   fun r => if cut.toNat ≤ r.toNat then .inalienable else .alienable

--- a/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Possession.lean
@@ -17,8 +17,6 @@ construct state (no nunation, no definite article) and the possessor in
 the genitive.
 -/
 
-set_option autoImplicit false
-
 namespace Arabic.ModernStandard.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/English/Possession.lean
+++ b/Linglib/Fragments/English/Possession.lean
@@ -12,8 +12,6 @@ Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace English.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Fijian/Possession.lean
+++ b/Linglib/Fragments/Fijian/Possession.lean
@@ -1,24 +1,20 @@
 import Linglib.Features.Possession
 
 /-!
-# Fijian possession profile
+# Fijian possession
+
+Fijian possesses inalienables by direct suffixation of the possessor to the
+noun (*na liga-qu* "my hand") and alienables through a classifier: *ke-* for
+things to eat (*na ke-qu kakana* "my food"), *me-* for things to drink
+(*na me-qu ti* "my tea"), *no-* for general property (*na no-qu vale* "my
+house"). WALS 59A nonetheless codes Fijian as *No possessive classification*
+under Nichols & Bickel's criterion; the values here follow the descriptive
+four-class tradition.
+
+## References
+
 [stassen-2009] [nichols-1986] [heine-1997]
-
-Bare per-language possession `def`s for Fijian (Austronesian, ISO `fij`),
-per the project's "per-language data flows through Fragments" rule.
-Substrate types (`PredicativeStrategy`, `AdnominalMarking`, …) live in
-`Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming
-these values live in `Studies/NicholsBickel2013.lean`.
-
-Examples: na liga-qu (body-part); na ke-qu kakana (food); na me-qu ti
-(drink); na no-qu vale (house). Four-way possessive classification: direct
-(body/kin), ke- (edible), me- (drinkable), no- (general alienable). WALS 59A
-nonetheless codes Fijian as *No possessive classification* under Nichols &
-Bickel's criterion; the value here follows the descriptive four-class
-tradition.
 -/
-
-set_option autoImplicit false
 
 namespace Fijian.Possession
 

--- a/Linglib/Fragments/Finnish/Possession.lean
+++ b/Linglib/Fragments/Finnish/Possession.lean
@@ -29,8 +29,6 @@ Finnish lives in `Studies/Heine1997.lean`.
 - `Minulla ei ole rahaa.` 'I have no money.' (I.ADESS not be money.PART)
 -/
 
-set_option autoImplicit false
-
 namespace Finnish.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Georgian/Possession.lean
+++ b/Linglib/Fragments/Georgian/Possession.lean
@@ -14,8 +14,6 @@ Examples: me m-akvs cigni; kac-is saxl-i. Dative experiencer + verb
 agreeing with possessum; genitive on possessor in adnominal constructions.
 -/
 
-set_option autoImplicit false
-
 namespace Georgian.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Greek/Grevena/Possession.lean
+++ b/Linglib/Fragments/Greek/Grevena/Possession.lean
@@ -44,8 +44,6 @@ Kampanarou & Alexiadou's bidirectional cross-dialectal argument: SMG sits
 on a continuum between Smyrna's over-extension and GG's complete loss.
 -/
 
-set_option autoImplicit false
-
 namespace Greek.Grevena.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Greek/Smyrna/Possession.lean
+++ b/Linglib/Fragments/Greek/Smyrna/Possession.lean
@@ -40,8 +40,6 @@ Sibling profiles: `Fragments/Greek/Possession.lean` (SMG, transitional)
 and `Fragments/Greek/Grevena/Possession.lean` (GG, genitive lost).
 -/
 
-set_option autoImplicit false
-
 namespace Greek.Smyrna.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Greek/StandardModern/Possession.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Possession.lean
@@ -44,8 +44,6 @@ and `Fragments/Greek/Smyrna/Possession.lean` (over-extended genitive per
 [kampanarou-alexiadou-2026] fn 7, citing [liosis-2016]).
 -/
 
-set_option autoImplicit false
-
 namespace Greek.StandardModern.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Hawaiian/Possession.lean
+++ b/Linglib/Fragments/Hawaiian/Possession.lean
@@ -1,42 +1,52 @@
 import Linglib.Features.Possession
 
 /-!
-# Hawaiian possession profile
+# Hawaiian possession
 
-Per-language possession values for Hawaiian (Polynesian, ISO `haw`), coded from
-[elbert-pukui-1979] and consumed by `Studies/NicholsBickel2013`; of the WALS
-possession chapters only 57A samples Hawaiian.
+Hawaiian possessive particles come in pairs distinguished by the vowels *a*
+and *o*: *kaʻu puke* "my book" vs *koʻu makuahine* "my mother". The choice is
+relation-based rather than a lexical noun class ([wilson-1976]): relations
+the possessor creates or instigates take *a* (children, spouses, food,
+implements), while relations outside the possessor's control (body parts,
+parents, siblings, chiefs) take *o*, as do those in which the possessed
+serves as the possessor's location (houses, clothing, ridden animals). The
+same noun shifts class with the relation: *koʻu hale* "my house (I live in)"
+vs *kaʻu hale* "my house (that I built)".
 
-The two possessive classes are relation-based ([wilson-1976]): relations the
-possessor controls — creates or instigates — take a-class (*kaʻu puke* "my
-book"; children, spouses, food, implements), while uncontrolled relations
-(body parts, parents, siblings, chiefs) and those where the possessed serves
-as the possessor's location (houses, clothing, ridden animals) take o-class
-(*koʻu makuahine* "my mother"). Not classic Oceanic alienability: the same
-noun shifts class with the relation, *koʻu hale* "my house (I live in)" vs
-*kaʻu hale* "my house (that I built)".
+Hawaiian has no verb "to have" ([elbert-pukui-1979]): predicative possession
+is a verbless sentence with a genitive possessor — *He puke kaʻu* "I have a
+book" (lit. "a book of-mine"), the *pepeke nonoʻa* of [bardwell-etal-2024].
+Adnominal possessors carry the particle *a* or *o* (*ka hale o Pua* "Pua's
+house") while the possessum stays unmarked, and no noun requires possessive
+marking.
+
+## References
+
+* [wilson-1976] — the control analysis of the a-class vs o-class contrast
+* [elbert-pukui-1979] — reference grammar; possessives and verbless ownership
+  sentences §8.4, the a-form vs o-form possessives §9.6
+* [bardwell-etal-2024] — the possessive sentence (*pepeke nonoʻa*)
+* [stassen-2013b] — WALS 117A, the Genitive predicative type
 -/
-
-set_option autoImplicit false
 
 namespace Hawaiian.Possession
 
 open _root_.Possession
 
-/-- Possessives are free determiners; no noun requires one ([elbert-pukui-1979]). -/
+/-- No Hawaiian noun requires a possessor. -/
 def obligatoryPossession : Obligatoriness := .noObligatory
 
-/-- The a-class vs o-class contrast ([wilson-1976]). WALS 59A splits on parallel
-    Polynesian systems — Rapanui and Tongan two classes, Māori none — so this
-    follows the descriptive tradition. -/
+/-- The a-class vs o-class contrast. WALS 59A codes the parallel Māori
+    system as unclassified and Rapanui as two-class. -/
 def possessiveClassification : Classification := .twoWay
 
-/-- *He puke kaʻu* "I have a book": existential possessee with genitive
-    possessor, the type WALS 117A assigns to Māori and Tahitian ([stassen-2013b]). -/
+/-- The *pepeke nonoʻa* possessive sentence *He puke kaʻu* "I have a book",
+    an existential possessee with a genitive possessor and no locative
+    marking. WALS 117A assigns this type to Māori and Tahitian. -/
 def predicativeStrategy : PredicativeStrategy := .genitive
 
-/-- The possessor carries the genitive particle *a* or *o* (*ka hale o Pua*
-    "Pua's house"); the possessum is unmarked ([nichols-1986]). -/
+/-- The possessor carries the genitive particle *a* or *o* while the
+    possessum stays unmarked (*ka hale o Pua* "Pua's house"). -/
 def adnominalStrategy : AdnominalMarking := .dependentMarking
 
 end Hawaiian.Possession

--- a/Linglib/Fragments/HindiUrdu/Possession.lean
+++ b/Linglib/Fragments/HindiUrdu/Possession.lean
@@ -13,8 +13,6 @@ Cross-linguistic theorems consuming these values live in
 `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace HindiUrdu.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Hungarian/Possession.lean
+++ b/Linglib/Fragments/Hungarian/Possession.lean
@@ -28,8 +28,6 @@ morphological GEN, and `Fragments/Hungarian/Case.lean` reflects this
 by omitting `.gen` from its `caseInventory`.
 -/
 
-set_option autoImplicit false
-
 namespace Hungarian.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Irish/Possession.lean
+++ b/Linglib/Fragments/Irish/Possession.lean
@@ -12,8 +12,6 @@ genitive case on the possessor in adnominal possession. Substrate types
 values live in `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace Irish.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Japanese/Possession.lean
+++ b/Linglib/Fragments/Japanese/Possession.lean
@@ -12,8 +12,6 @@ in `Linglib/Features/Possession.lean`. Cross-linguistic theorems consuming these
 values live in `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace Japanese.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Korean/Possession.lean
+++ b/Linglib/Fragments/Korean/Possession.lean
@@ -12,8 +12,6 @@ Per-language possession values for Korean (Koreanic, ISO `kor`): forms
 values live in `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace Korean.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Mandarin/Possession.lean
+++ b/Linglib/Fragments/Mandarin/Possession.lean
@@ -12,8 +12,6 @@ adnominal possession but drops with inalienable/close relations. Substrate types
 values live in `Studies/NicholsBickel2013.lean`.
 -/
 
-set_option autoImplicit false
-
 namespace Mandarin.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Mayan/Tseltal/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Possession.lean
@@ -25,8 +25,6 @@ predicative; Set A prefixes on possessum for adnominal (head-marking); three
 noun classes as in Tsotsil ([aissen-polian-2025]).
 -/
 
-set_option autoImplicit false
-
 namespace Tseltal.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Possession.lean
@@ -26,8 +26,6 @@ possessum for adnominal (head-marking); three noun classes: must/may/cannot
 be possessed ([aissen-polian-2025]).
 -/
 
-set_option autoImplicit false
-
 namespace Tsotsil.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Quechua/Possession.lean
+++ b/Linglib/Fragments/Quechua/Possession.lean
@@ -15,8 +15,6 @@ obligatory on kinship and body-part nouns; -yuq 'having' for predicative;
 GEN + POSS double-marking.
 -/
 
-set_option autoImplicit false
-
 namespace Quechua.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Slavic/Russian/Possession.lean
+++ b/Linglib/Fragments/Slavic/Russian/Possession.lean
@@ -29,8 +29,6 @@ Russian lives in `Studies/Heine1997.lean`.
 - `On imeet pravo.` 'He has a right.' (he has.3SG right; Action Schema)
 -/
 
-set_option autoImplicit false
-
 namespace Russian.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Swahili/Possession.lean
+++ b/Linglib/Fragments/Swahili/Possession.lean
@@ -37,8 +37,6 @@ associative particle `a` carrying class agreement to the possessum.
 - `Saa ni y-angu.` 'The watch is mine.' (Equation: watch is of-me)
 -/
 
-set_option autoImplicit false
-
 namespace Swahili.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Turkish/Possession.lean
+++ b/Linglib/Fragments/Turkish/Possession.lean
@@ -26,8 +26,6 @@ Turkish lives in `Studies/Heine1997.lean`.
 - `Kitab-ım var.` 'I have a book.' (book-POSS.1SG existent; Genitive)
 -/
 
-set_option autoImplicit false
-
 namespace Turkish.Possession
 
 open _root_.Possession

--- a/Linglib/Fragments/Yoruba/Possession.lean
+++ b/Linglib/Fragments/Yoruba/Possession.lean
@@ -14,8 +14,6 @@ Examples: mo ni iwe; iwe mi. Have-verb ni; juxtaposition for adnominal
 (possessum-possessor).
 -/
 
-set_option autoImplicit false
-
 namespace Yoruba.Possession
 
 open _root_.Possession

--- a/Linglib/Studies/NicholsBickel2013.lean
+++ b/Linglib/Studies/NicholsBickel2013.lean
@@ -23,7 +23,6 @@ import Linglib.Fragments.Mayan.Tseltal.Possession
 
 /-!
 # Nichols & Bickel (2013): WALS chapters on possession (57A, 58A, 58B, 59A)
-[nichols-bickel-2013] [wals-2013]
 
 The four WALS chapters by Nichols & Bickel (2013):
 
@@ -44,9 +43,11 @@ absent** — verifying that `X.Possession.predicativeStrategy` equals
 `Data.WALS.lookup "iso"` is "encoding conclusions as definitions": the
 two would have to silently diverge for the theorem to fail, and the typed
 Fragment value already encodes the WALS coding at definition site.
--/
 
-set_option autoImplicit false
+## References
+
+[nichols-bickel-2013] [wals-2013]
+-/
 
 namespace NicholsBickel2013
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -4285,6 +4285,17 @@
   validated = {true},
   sources   = {Fragments/Hawaiian/Possession.lean}
 }
+
+@misc{bardwell-etal-2024,
+  author    = {Bardwell, Joe and Bardwell, Anita and Weltman, Lopaka and Westcott, Hoaloha and Corpuz, Manawaleʻa},
+  year      = {2024},
+  title     = {He Papa Kuhikuhi Pilinaʻōlelo: Reference Grammar of the {Hawaiian} Language (Version 1.6)},
+  url       = {https://hawaiian-grammar.org/current/},
+  subfield  = {comparative},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Hawaiian/Possession.lean}
+}
 @incollection{szabolcsi-1986,
   author    = {Szabolcsi, Anna},
   year      = {1986},


### PR DESCRIPTION
Register follow-up to #2010: textbook module docstrings for the Hawaiian and Fijian possession fragments, `## References` sections replacing bare `[key]` blocks (substrate, study, fragments), decl docstrings converted to single-clause mathlib register with citations lifted to module level, and redundant `set_option autoImplicit false` dropped from the 25 touched files (set globally in the lakefile).

- predicative-possession grounding verified against Elbert & Pukui 1979 (§8.4.2 "no verb 'to have' occurs in Hawaiian") and the hawaiian-grammar.org reference grammar (*pepeke nonoʻa*), both added to the bib
- substrate `twoWay` exemplars corrected to Ewe and Rapanui, the rows Nichols & Bickel actually code two-class