### PR TITLE
refactor(Studies/Kawahara2015): audit fixes + culminativity theorem

### DIFF
--- a/Linglib/Fragments/Japanese/Prosody.lean
+++ b/Linglib/Fragments/Japanese/Prosody.lean
@@ -1,221 +1,89 @@
 import Linglib.Features.Prosody
-import Linglib.Phonology.Prosody.Syllable
 import Mathlib.Data.Real.Basic
-import Linglib.Studies.BeckmanPierrehumbert1986
 
 /-!
 # Japanese Prosody Fragment
-[beckman-pierrehumbert-1986] [kawahara-2015]
 
-Japanese prosodic entries following the autosegmental-metrical analysis
-of [beckman-pierrehumbert-1986], with accent assignment rules and
-affix typology from [kawahara-2015].
+Word-level prosodic entries for Tokyo Japanese: lexical pitch accent as a mora
+position ([beckman-pierrehumbert-1986]; [kawahara-2015]), frequency-annotated
+entries and compounds ([breiss-katsuda-kawahara-2026]), and an affix lexicon
+classified by the eight-way `Features.Prosody.AffixAccentType` typology
+([kawahara-2015] §6).
 
-## Key Properties
-
-- **Lexical accent**: accent location specified in the lexicon as a linked
-  H tone. The accent shape is fixed (H*+L); only the location varies.
-- **Accented vs unaccented**: some words are lexically unaccented (e.g.,
-  compound nouns formed from unaccented words). Unaccented words can
-  form well-formed utterances without any pitch accent.
-- **Accentual phrase**: delimited by a phrasal H (on the second sonorant
-  mora) and a boundary L. Contains at most one accent.
-- **Sparse tonal specification**: only the accent H, the phrasal H, and
-  the boundary L are specified; F0 between them is interpolated.
-- **Culminativity**: at most one HL fall per prosodic word — Japanese is
-  a pitch-accent language, not a tone language.
-- **Default accent**: loanwords and nonce words receive antepenultimate
-  accent (AAR) or Latin Stress Rule (LSR) accent.
-- **Eight affix accent types**: recessive, dominant, recessive
-  pre-accenting, dominant pre-accenting, accent-shifting,
-  post-accenting, deaccenting, initial-accenting.
+Accent values are grounded in the sources' own data: the presence/location
+minimal pairs of [kawahara-2015] (1) and (28), and the accentual-phrase
+materials of [beckman-pierrehumbert-1986] (Figs. 6–13).
 -/
 
 namespace Japanese.Prosody
 
 open Features.Prosody
-open _root_.Prosody (Syllable.Weight)
-open BeckmanPierrehumbert1986
 
-/-! ### Default-accent rules (formerly `Phonology/Prosody/Accent`)
-
-Language-neutral accent-placement rules over a syllable-weight profile, used in the Japanese
-accent analysis below ([mccawley-1968]; [hayes-1995]; [kubozono-2006]; [prince-smolensky-1993]). -/
-
-/-- The 0-indexed syllable containing mora `targetMora` (0-indexed), or `none` if it exceeds the
-    total mora count. -/
-private def findSyllable (weights : List Syllable.Weight) (targetMora : Nat) : Option Nat :=
-  go weights targetMora 0
-where
-  go : List Syllable.Weight → Nat → Nat → Option Nat
-    | [], _, _ => none
-    | w :: ws, target, idx => if target < w then some idx else go ws (target - w) (idx + 1)
-
-/-- The Antepenultimate Accent Rule ([mccawley-1968]): accent the syllable containing the
-    antepenultimate (3rd-from-last) mora; words with fewer than three morae accent the initial
-    syllable. Returns the 0-indexed syllable. -/
-def defaultAccentAAR (weights : List Syllable.Weight) : Option Nat :=
-  match weights with
-  | [] => none
-  | _ =>
-    let totalMorae := weights.foldl (· + ·) 0
-    let targetMora := if totalMorae ≥ 3 then totalMorae - 3 else 0
-    findSyllable weights targetMora
-
-/-- The Latin Stress Rule ([hayes-1995]): accent the penult if heavy (≥ 2μ), else the antepenult.
-    Monosyllables accent the only syllable; disyllables the penult (= initial). [kubozono-2006]
-    argues it fits Japanese default accentuation better than `defaultAccentAAR`. -/
-def latinStressRule : List Syllable.Weight → Option Nat
-  | [] => none
-  | [_] => some 0
-  | [_, _] => some 0
-  | [_, 0, _] | [_, 1, _] => some 0
-  | [_, _, _] => some 1
-  | _ :: rest@(_ :: _ :: _) => (latinStressRule rest).map (· + 1)
-
-/-- NonFinality(σ) ([prince-smolensky-1993]): `1` if accent is on the word-final syllable, else
-    `0` — drives the avoidance of final accent in Japanese compounds and loanwords
-    ([kawahara-2015]). -/
-def nonFinalitySigma (accentSyll : Option Nat) (nSyll : Nat) : Nat :=
-  match accentSyll with
-  | some pos => if pos + 1 == nSyll then 1 else 0
-  | none => 0
-
-/-! ### Accent-to-tone derivation and compound accent (Japanese-specific)
-
-The Japanese pitch-accent tonal melody and the compound-accent rules
-([kawahara-2015]) — the accentual HL + initial rise and the N1/N2 compound rules,
-which build on the default-accent placement above. -/
-
-/-- A level tone for pitch-accent systems. Japanese uses only `H` (high) and
-    `L` (low) at the lexical level ([kawahara-2015]). -/
-inductive LevelTone where
-  | H
-  | L
-  deriving DecidableEq, Repr, BEq
-
-/-- Derive the surface tone of each mora from accent position and mora count
-    ([kawahara-2015]), returning one `LevelTone` per mora:
-    1. accentual HL — `H` on the accented mora, `L` on the next;
-    2. initial rise — `L` on mora 0, `H` on mora 1 (blocked by initial accent);
-    3. spreading — unspecified moras copy the rightmost specified tone. -/
-def accentToTones (accentMora : Option Nat) (nMorae : Nat) : List LevelTone :=
-  -- Steps 1+2: accentual HL + initial rise (`none` = still unspecified).
-  -- `nMorae = 0` needs no special case: `List.range 0 = []` flows through to `[]`.
-  let specified : List (Option LevelTone) := (List.range nMorae).map λ i =>
-    if accentMora == some i then some .H
-    else if accentMora == some (i - 1) && i ≥ 1 then some .L
-    else if i == 0 && accentMora != some 0 then some .L
-    else if i == 1 && accentMora != some 1 && accentMora != some 0 then some .H
-    else none
-  -- Step 3: spreading — fill `none`s from the rightmost specified tone (mora 0
-  -- is always specified, so the `.H` seed is never reached for well-formed input).
-  spread specified .H
-where
-  spread : List (Option LevelTone) → LevelTone → List LevelTone
-    | [], _ => []
-    | some t :: rest, _ => t :: spread rest t
-    | none :: rest, last => last :: spread rest last
-
-/-- Short-N2 compound accent ([kawahara-2015]): when the second member N2 is
-    short (≤ 2μ), accent may pre-accent the last syllable of N1, or N2 retains
-    its own accent. Pre-accenting N2s lose their accent to NonFinality(Ft) and
-    receive a new one, like dominant pre-accenting suffixes. -/
-def shortN2CompoundAccent (n1Morae : Nat) (n2Accent : Option Nat)
-    (preAccenting : Bool) : Option Nat :=
-  if preAccenting then
-    -- Pre-accenting: accent on last mora of N1
-    if n1Morae > 0 then some (n1Morae - 1) else none
-  else
-    -- Retain N2 accent (shifted by N1 length)
-    n2Accent.map (· + n1Morae)
-
-/-- Long-N2 compound accent ([kawahara-2015]): when N2 is long (≥ 3μ), an
-    unaccented or final-accented N2 accents its initial syllable; otherwise
-    N2's own accent is retained. -/
-def longN2CompoundAccent (n1Morae : Nat) (n2Accent : Option Nat)
-    (n2Morae : Nat) : Option Nat :=
-  match n2Accent with
-  | none => some n1Morae  -- unaccented N2 → accent N2-initial
-  | some pos =>
-    if pos + 1 == n2Morae then some n1Morae  -- final accent → accent N2-initial
-    else some (pos + n1Morae)                 -- retain N2 accent
-
--- ============================================================================
--- § 1: Lexical Accent
--- ============================================================================
-
-/-- A Japanese lexical entry with prosodic specification.
-
-    The accent is specified as the mora position of the linked H tone
-    (0-indexed from the beginning of the word). Unaccented words have
-    `accentMora = none`. -/
-structure JProsodicEntry where
+/-- A Japanese lexical entry with prosodic specification: the accent is the
+    0-indexed mora position of the linked H tone; unaccented words have
+    `accentMora = none` ([beckman-pierrehumbert-1986]). -/
+structure ProsodicEntry where
   /-- Surface form (romanized) -/
   form : String
   /-- Gloss -/
   gloss : String
-  /-- Mora position of the accent (none = unaccented) -/
-  accentMora : Option Nat
+  /-- Mora position of the accent (`none` = unaccented) -/
+  accentMora : Option ℕ
   /-- Number of morae in the word -/
-  nMorae : Nat
+  nMorae : ℕ
   deriving Repr
 
 /-- Is this entry accented? -/
-def JProsodicEntry.isAccented (e : JProsodicEntry) : Bool :=
+def ProsodicEntry.isAccented (e : ProsodicEntry) : Bool :=
   e.accentMora.isSome
 
-/-- Convert to Bool accentedness for bridge to AccentualPhrase. -/
-def JProsodicEntry.accentedBool (e : JProsodicEntry) : Bool :=
-  e.isAccented
+/-! ### Sample entries
 
--- ============================================================================
--- § 2: Sample Entries (§2.1, §2.2)
--- ============================================================================
+The presence-vs-absence minimal pair *ame* ~ *a'me* of [kawahara-2015] (1a–b),
+and the adjective and noun materials of [beckman-pierrehumbert-1986]'s
+accentual-phrase experiments (Figs. 6–13), also cited as [kawahara-2015] (28). -/
 
-/-- *kami* 'god' — accented on first mora (initial accent).
-    Contrasts with *kami* 'paper' (unaccented) and *kamí* 'hair'
-    (accent on second mora). -/
-def kami_god : JProsodicEntry :=
-  { form := "kami", gloss := "god", accentMora := some 0, nMorae := 2 }
+/-- *ame* 'candy' — unaccented ([kawahara-2015] (1a); the unaccented noun of
+    [beckman-pierrehumbert-1986] Fig. 6). -/
+def ameCandy : ProsodicEntry :=
+  { form := "ame", gloss := "candy", accentMora := none, nMorae := 2 }
 
-/-- *kami* 'paper' — unaccented.
-    No HL fall in the accentual phrase. -/
-def kami_paper : JProsodicEntry :=
-  { form := "kami", gloss := "paper", accentMora := none, nMorae := 2 }
+/-- *a'me* 'rain' — initial accent, minimal with `ameCandy`
+    ([kawahara-2015] (1b)). -/
+def ameRain : ProsodicEntry :=
+  { form := "ame", gloss := "rain", accentMora := some 0, nMorae := 2 }
 
-/-- *uma'i* — accented adjective (§2.2, Figs. 6, 8, 9). -/
-def umai : JProsodicEntry :=
+/-- *uma'i* 'delicious' — accented adjective ([kawahara-2015] (28a);
+    [beckman-pierrehumbert-1986] Figs. 6, 9). -/
+def umai : ProsodicEntry :=
   { form := "umai", gloss := "delicious", accentMora := some 1, nMorae := 3 }
 
-/-- *amai* — accented adjective (§2.3, Fig. 8). -/
-def amai : JProsodicEntry :=
-  { form := "amai", gloss := "sweet", accentMora := some 1, nMorae := 3 }
+/-- *amai* 'sweet' — unaccented adjective, minimal with `umai`
+    ([kawahara-2015] (28b); [beckman-pierrehumbert-1986] Fig. 8). -/
+def amai : ProsodicEntry :=
+  { form := "amai", gloss := "sweet", accentMora := none, nMorae := 3 }
 
-/-- *mame* — unaccented noun (§2.2, Fig. 6). -/
-def mame : JProsodicEntry :=
-  { form := "mame", gloss := "beans", accentMora := none, nMorae := 2 }
+/-- *mame'* 'beans' — final accent ([beckman-pierrehumbert-1986] Fig. 6,
+    where AP-grouping with *uma'i* deletes this accent). -/
+def mame : ProsodicEntry :=
+  { form := "mame", gloss := "beans", accentMora := some 1, nMorae := 2 }
 
-/-- *ame* — unaccented noun (§2.2, Fig. 6). -/
-def ame : JProsodicEntry :=
-  { form := "ame", gloss := "rain", accentMora := none, nMorae := 2 }
+/-- Accent presence distinguishes *a'me* 'rain' from *ame* 'candy'. -/
+theorem ameRain_accented : ameRain.isAccented = true := rfl
 
--- ============================================================================
--- § 2b: Frequency-annotated lexical entries
--- ============================================================================
+/-- Unaccented words lack an accent location. -/
+theorem ameCandy_unaccented : ameCandy.isAccented = false := rfl
 
-/-- A Japanese lexical entry extending `JProsodicEntry` with the two
-    annotations needed for frequency-conditioned phonology (e.g., the
+/-! ### Frequency-annotated lexical entries -/
+
+/-- A Japanese lexical entry extending `ProsodicEntry` with the two
+    annotations needed for frequency-conditioned phonology (the
     Breiss-Katsuda-Kawahara compounds in
-    `Studies/BreissKatsudaKawahara2026.lean`):
-    a corpus token log-frequency and a free/bound flag.
-
-    Following CLAUDE.md's "infrastructure on demand", these annotations
-    are kept on a thin extension structure rather than added to
-    `JProsodicEntry`, so existing accent-only consumers are unaffected.
-    The `jTokenFreq` accessor below exposes its token frequency as the
-    `ℝ`-valued channel that frequency-conditioned phonology reads. -/
-structure JLexicalEntry extends JProsodicEntry where
+    `Studies/BreissKatsudaKawahara2026.lean`): a corpus token log-frequency
+    and a free/bound flag. The annotations live on a thin extension so
+    accent-only consumers are unaffected; `LexicalEntry.tokenFreq` exposes
+    the `ℝ`-valued channel that frequency-conditioned phonology reads. -/
+structure LexicalEntry extends ProsodicEntry where
   /-- Token log-frequency in a reference corpus (e.g., BCCWJ). `0`
       conventionally means "log of 1 occurrence" — used as the no-info
       default for unannotated items. Stored as `ℚ` so that the lexicon
@@ -228,376 +96,88 @@ structure JLexicalEntry extends JProsodicEntry where
   canStandAlone : Bool := true
   deriving Repr
 
-/-- The token-log-frequency of a `JLexicalEntry`: the fragment-level
+/-- The token-log-frequency of a `LexicalEntry`: the fragment-level
     `ℚ` field cast to `ℝ` for frequency-conditioned phonology.
     `noncomputable` because `ℝ` is; the `ℚ` field itself stays
     computable for `decide`-style proofs. -/
-noncomputable def jTokenFreq (e : JLexicalEntry) : ℝ := (e.tokenLogFreq : ℝ)
+noncomputable def LexicalEntry.tokenFreq (e : LexicalEntry) : ℝ := (e.tokenLogFreq : ℝ)
 
--- ============================================================================
--- § 2c: Compounds
--- ============================================================================
+/-! ### Compounds -/
 
 /-- A Japanese N1 + N2 nominal compound. Compound-medial position is
     the locus of voiced velar nasalisation (/g/ → [ŋ]) studied in
     [breiss-katsuda-kawahara-2026]: obligatory when N2 is bound,
-    optional and frequency-conditioned when N2 is free.
-
-    The compound's own `tokenLogFreq` is **independent** of N1's and
-    N2's — high-frequency compounds with low-frequency components, and
-    vice versa, both occur. Frequency-conditioned theories that treat
-    the compound's frequency as inherited from constituents (e.g., some
-    `RepresentationStrength` variants with multiplicative inheritance)
-    must reconcile this independence with empirical reality. -/
-structure JCompound where
-  n1 : JLexicalEntry
-  n2 : JLexicalEntry
-  /-- Token log-frequency of the compound *as a unit* — typically much
-      lower than either constituent in isolation, but the principal
-      conditioning variable on optional nasalisation. -/
+    optional and frequency-conditioned when N2 is free. -/
+structure NominalCompound where
+  n1 : LexicalEntry
+  n2 : LexicalEntry
+  /-- Token log-frequency of the compound *as a unit* — independent of the
+      constituents' frequencies, and the principal conditioning variable on
+      optional nasalisation. -/
   compoundLogFreq : ℚ := 0
   deriving Repr
 
 /-- The compound's surface form: simple concatenation of N1 and N2
     forms (the segmental alternation /g/→[ŋ] applies on top). -/
-def JCompound.form (c : JCompound) : String := c.n1.form ++ c.n2.form
+def NominalCompound.form (c : NominalCompound) : String := c.n1.form ++ c.n2.form
 
 /-- A compound's nasalisation is *obligatory* iff its N2 is bound. The
     free-N2 case is the gradient one tested in
     [breiss-katsuda-kawahara-2026]. -/
-def JCompound.nasalisationObligatory (c : JCompound) : Bool :=
+def NominalCompound.nasalisationObligatory (c : NominalCompound) : Bool :=
   ! c.n2.canStandAlone
 
--- ============================================================================
--- § 3: Accentual Phrase Structure (§2.2)
--- ============================================================================
+/-! ### Affix accent lexicon
 
-/-- Japanese accentual phrase tonal specification.
+One canonical affix per accent type of [kawahara-2015] §6's eight-way
+typology, encoded by `Features.Prosody.AffixAccentType`. -/
 
-    [beckman-pierrehumbert-1986] §2.2: the AP is defined by:
-    - A boundary L at the beginning (or end of preceding AP)
-    - A phrasal H on the second sonorant mora
-    - An optional accent HL (if the word is accented)
-    - A boundary L at the end
-
-    The phrasal H is NOT the same as H-tone spreading from the accent;
-    it has its own local pitch range and is always present, even in
-    unaccented phrases (Fig. 3 vs earlier accounts). -/
-structure JAccentualPhrase where
-  /-- Words grouped in this AP -/
-  words : List JProsodicEntry
-  /-- Whether the phrasal H is present (always true in Japanese) -/
-  hasPhrasalH : Bool := true
-  deriving Repr
-
-/-- An AP is accented if any word in it is accented. -/
-def JAccentualPhrase.isAccented (ap : JAccentualPhrase) : Bool :=
-  ap.words.any (·.isAccented)
-
-/-- Convert to the generic AccentualPhrase type.
-    Japanese accent shape is always H*+L; unaccented APs get null. -/
-def JAccentualPhrase.toGeneric (ap : JAccentualPhrase) : AccentualPhrase :=
-  { accent := if ap.isAccented then .H_star_plus_L else .null
-    nWords := ap.words.length }
-
--- ============================================================================
--- § 4: Verification
--- ============================================================================
-
-/-- Accented words have accent location. -/
-theorem kami_god_accented : kami_god.isAccented = true := rfl
-
-/-- Unaccented words lack accent location. -/
-theorem kami_paper_unaccented : kami_paper.isAccented = false := rfl
-
-/-- Japanese accent is lexical. -/
-theorem japanese_accent_is_lexical :
-    (BeckmanPierrehumbert1986.japanese).accentSpec
-    = .lexical := rfl
-
-/-- The Japanese pitch accent shape is H*+L (a single bitonal accent). -/
-theorem japanese_accent_is_bitonal :
-    PitchAccent.H_star_plus_L.isBitonal = true := rfl
-
-/-- A Japanese accented AP always triggers catathesis (because H*+L is bitonal). -/
-theorem japanese_accented_ap_triggers_catathesis (ap : JAccentualPhrase)
-    (h : ap.isAccented = true) :
-    ap.toGeneric.accent.isBitonal = true := by
-  unfold JAccentualPhrase.toGeneric; rw [if_pos h]; rfl
-
-/-- A Japanese unaccented AP never triggers catathesis. -/
-theorem japanese_unaccented_ap_no_catathesis (ap : JAccentualPhrase)
-    (h : ap.isAccented = false) :
-    ap.toGeneric.accent.isBitonal = false := by
-  unfold JAccentualPhrase.toGeneric; rw [if_neg (by simp [h])]; rfl
-
-/-- An AP containing only unaccented words is unaccented. -/
-theorem unaccented_ap :
-    ({ words := [kami_paper, mame] : JAccentualPhrase }).isAccented = false := rfl
-
-/-- An AP containing an accented word is accented. -/
-theorem accented_ap :
-    ({ words := [kami_god, mame] : JAccentualPhrase }).isAccented = true := rfl
-
--- ============================================================================
--- § 5: Suffix Prosodic Dominance ([kawahara-2015])
--- ============================================================================
-
-/-- Japanese suffix accent specification.
-
-    Japanese suffixes exhibit the same dominant/recessive distinction
-    as IE accent systems ([kiparsky-halle-1977]) and GT systems
-    ([rolle-2018]). Dominant suffixes remove stem accent;
-    recessive suffixes preserve it when present. -/
-structure JSuffixAccent where
-  form : String
-  gloss : String
-  dominance : Features.Prosody.ProsodicDominance
-  deriving Repr
-
-/-- *-teki* (的): deaccenting suffix. Removes stem accent regardless
-    of whether the stem is accented or unaccented — classified as
-    subtractive-dominant in GT terms ([kawahara-2015]). -/
-def teki_suffix : JSuffixAccent :=
-  { form := "-teki", gloss := "的 ADJ", dominance := .dominant }
-
-/-- *-si* (氏): non-deaccenting suffix. Preserves stem accent when
-    present — classified as recessive ([kawahara-2015]). -/
-def si_suffix : JSuffixAccent :=
-  { form := "-si", gloss := "氏 Mr.", dominance := .recessive }
-
-/-- Deaccenting suffixes are dominant. -/
-theorem teki_is_dominant : teki_suffix.dominance.IsDominant := by decide
-
-/-- Non-deaccenting suffixes are not dominant. -/
-theorem si_is_not_dominant : ¬ si_suffix.dominance.IsDominant := by decide
-
--- ============================================================================
--- § 6: Accent Combination ([kawahara-2015])
--- ============================================================================
-
-/-- Derive the accent of a suffixed word from stem accent + suffix dominance. -/
-def suffixedAccent (stem : JProsodicEntry) (suffix : JSuffixAccent) : Option Nat :=
-  suffix.dominance.combineAccent stem.accentMora
-
-/-- *-teki* deaccents *kami* 'god' (accented). -/
-theorem teki_deaccents_kami_god :
-    suffixedAccent kami_god teki_suffix = none := rfl
-
-/-- *-teki* leaves *kami* 'paper' (unaccented) unchanged. -/
-theorem teki_leaves_kami_paper :
-    suffixedAccent kami_paper teki_suffix = none := rfl
-
-/-- *-teki* neutralizes the *kami* 'god' / *kami* 'paper' contrast. -/
-theorem teki_neutralizes_kami :
-    suffixedAccent kami_god teki_suffix =
-    suffixedAccent kami_paper teki_suffix := rfl
-
-/-- *-si* preserves the accent on *kami* 'god'. -/
-theorem si_preserves_kami_god :
-    suffixedAccent kami_god si_suffix = some 0 := rfl
-
-/-- *-si* preserves the unaccentedness of *kami* 'paper'. -/
-theorem si_preserves_kami_paper :
-    suffixedAccent kami_paper si_suffix = none := rfl
-
-/-- *-si* maintains the *kami* 'god' / *kami* 'paper' contrast. -/
-theorem si_maintains_kami_contrast :
-    suffixedAccent kami_god si_suffix ≠
-    suffixedAccent kami_paper si_suffix := by decide
-
--- ============================================================================
--- § 7: Loanword Entries ([kawahara-2015] §2)
--- ============================================================================
-
-/-- Loanword prosodic entry. Extends `JProsodicEntry` with syllable weight
-    profile for testing AAR vs LSR predictions. -/
-structure JLoanwordEntry where
-  entry : JProsodicEntry
-  /-- Syllable weight profile (left to right) -/
-  weights : List Syllable.Weight
-  deriving Repr
-
-/-- *kurisumasu* 'Christmas' — accent on antepenultimate mora (su).
-    [kawahara-2015] (10a). -/
-def kurisumasu : JLoanwordEntry :=
-  { entry := { form := "kurisumasu", gloss := "Christmas"
-               accentMora := some 2, nMorae := 5 }
-    weights := [.light, .light, .light, .light, .light] }
-
-/-- *asufaruto* 'asphalt' — accent on antepenultimate mora (fa).
-    [kawahara-2015] (10g). -/
-def asufaruto : JLoanwordEntry :=
-  { entry := { form := "asufaruto", gloss := "asphalt"
-               accentMora := some 2, nMorae := 5 }
-    weights := [.light, .light, .light, .light, .light] }
-
-/-- *makudonarudo* 'McDonald' — accent on antepenultimate mora (na).
-    [kawahara-2015] (10h). -/
-def makudonarudo : JLoanwordEntry :=
-  { entry := { form := "makudonarudo", gloss := "McDonald's"
-               accentMora := some 4, nMorae := 7 }
-    weights := [.light, .light, .light, .light, .light, .light, .light] }
-
-/-- *amerika* 'America' — unaccented (4-mora with two final light σ).
-    [kawahara-2015] (16a). -/
-def amerika : JLoanwordEntry :=
-  { entry := { form := "amerika", gloss := "America"
-               accentMora := none, nMorae := 4 }
-    weights := [.light, .light, .light, .light] }
-
-/-- Loanword accent matches AAR prediction for all-light syllables. -/
-theorem kurisumasu_matches_aar :
-    defaultAccentAAR kurisumasu.weights = kurisumasu.entry.accentMora := rfl
-
-/-- Loanword accent matches LSR prediction for all-light syllables. -/
-theorem kurisumasu_matches_lsr :
-    latinStressRule kurisumasu.weights = kurisumasu.entry.accentMora := by
-  unfold latinStressRule; unfold latinStressRule; unfold latinStressRule; rfl
-
--- ============================================================================
--- § 8: AAR vs LSR Mismatch Cases ([kawahara-2015] Table 1)
--- ============================================================================
-
-/-- HLH: AAR predicts penultimate (σ₂), LSR predicts antepenultimate (σ₁).
-    [kawahara-2015] Table 1, row (c). -/
-theorem aar_lsr_mismatch_hlh :
-    defaultAccentAAR [.heavy, .light, .heavy] = some 1 ∧
-    latinStressRule [.heavy, .light, .heavy] = some 0 := by
-  constructor <;> (first | rfl | (unfold latinStressRule; rfl))
-
-/-- LLH: AAR predicts penultimate (σ₂), LSR predicts antepenultimate (σ₁).
-    [kawahara-2015] Table 1, row (g). -/
-theorem aar_lsr_mismatch_llh :
-    defaultAccentAAR [.light, .light, .heavy] = some 1 ∧
-    latinStressRule [.light, .light, .heavy] = some 0 := by
-  constructor <;> (first | rfl | (unfold latinStressRule; rfl))
-
-/-- The remaining 6 conditions in Table 1 produce matching predictions. -/
-theorem aar_lsr_match_hhh :
-    defaultAccentAAR [.heavy, .heavy, .heavy] =
-    latinStressRule [.heavy, .heavy, .heavy] := by unfold latinStressRule; rfl
-theorem aar_lsr_match_hhl :
-    defaultAccentAAR [.heavy, .heavy, .light] =
-    latinStressRule [.heavy, .heavy, .light] := by unfold latinStressRule; rfl
-theorem aar_lsr_match_hll :
-    defaultAccentAAR [.heavy, .light, .light] =
-    latinStressRule [.heavy, .light, .light] := by unfold latinStressRule; rfl
-theorem aar_lsr_match_lhh :
-    defaultAccentAAR [.light, .heavy, .heavy] =
-    latinStressRule [.light, .heavy, .heavy] := by unfold latinStressRule; rfl
-theorem aar_lsr_match_lhl :
-    defaultAccentAAR [.light, .heavy, .light] =
-    latinStressRule [.light, .heavy, .light] := by unfold latinStressRule; rfl
-theorem aar_lsr_match_lll :
-    defaultAccentAAR [.light, .light, .light] =
-    latinStressRule [.light, .light, .light] := by unfold latinStressRule; rfl
-
--- ============================================================================
--- § 9: Fine-Grained Affix Accent Typology ([kawahara-2015] §6)
--- ============================================================================
-
-/-- Japanese suffix with fine-grained accent classification. -/
-structure JAffixEntry where
+/-- A Japanese affix with its accentual behavior class. -/
+structure AffixEntry where
   form : String
   gloss : String
   accentType : AffixAccentType
   deriving Repr
 
--- The eight affix types with canonical examples from Kawahara (2015):
-
-/-- *-tara* (conditional): recessive suffix — bears accent, loses to root.
-    [kawahara-2015] (29). -/
-def tara_suffix : JAffixEntry :=
+/-- *-ta'ra* (conditional): recessive — bears accent, loses it to an accented
+    root ([kawahara-2015] (29)). -/
+def taraSuffix : AffixEntry :=
   { form := "-tara", gloss := "conditional", accentType := .recessive }
 
-/-- *-ppoi* (-ish): dominant suffix — bears accent, overrides root.
-    [kawahara-2015] (30). -/
-def ppoi_suffix : JAffixEntry :=
+/-- *-ppo'i* '-ish': dominant — bears accent and deletes root accent
+    ([kawahara-2015] (30)). -/
+def ppoiSuffix : AffixEntry :=
   { form := "-ppoi", gloss := "-ish", accentType := .dominant }
 
-/-- *-si* (Mr.): recessive pre-accenting — inserts accent on root-final σ
-    when root is unaccented, preserves root accent when present.
-    [kawahara-2015] (31). -/
-def si_affix : JAffixEntry :=
+/-- *-si* (氏 'Mr.'): recessive pre-accenting — inserts accent on the
+    root-final syllable when the root is unaccented, preserves root accent
+    when present ([kawahara-2015] (31)). -/
+def siSuffix : AffixEntry :=
   { form := "-si", gloss := "Mr.", accentType := .recessivePreAccent }
 
-/-- *-ke* (family of): dominant pre-accenting — always inserts accent on
-    root-final σ, deleting any root accent.
-    [kawahara-2015] (32). -/
-def ke_suffix : JAffixEntry :=
+/-- *-ke* 'family of': dominant pre-accenting — always inserts accent on the
+    root-final syllable, deleting any root accent ([kawahara-2015] (32)). -/
+def keSuffix : AffixEntry :=
   { form := "-ke", gloss := "family of", accentType := .dominantPreAccent }
 
-/-- *-mono* (thing): accent-shifting — shifts existing root accent to
-    pre-suffix position. Unaccented roots stay unaccented.
-    [kawahara-2015] (33). -/
-def mono_suffix : JAffixEntry :=
+/-- *-mono* 'thing': accent-shifting — shifts existing root accent to
+    pre-suffix position, never creates new accent ([kawahara-2015] (33)). -/
+def monoSuffix : AffixEntry :=
   { form := "-mono", gloss := "thing", accentType := .accentShifting }
 
-/-- *o-* (honorific prefix): post-accenting — inserts accent after prefix.
-    [kawahara-2015] (34). -/
-def o_prefix : JAffixEntry :=
+/-- *o-* (honorific prefix): post-accenting — inserts accent after the prefix
+    ([kawahara-2015] (34)). -/
+def oPrefix : AffixEntry :=
   { form := "o-", gloss := "honorific", accentType := .postAccenting }
 
-/-- *-teki* (的 -like): deaccenting — deletes root accent, no new accent.
-    [kawahara-2015] (36). -/
-def teki_affix : JAffixEntry :=
+/-- *-teki* (的 '-like'): deaccenting — deletes root accent, inserts none
+    ([kawahara-2015] (36)). -/
+def tekiSuffix : AffixEntry :=
   { form := "-teki", gloss := "的 -like", accentType := .deaccenting }
 
-/-- *-zu* (group/plural): initial-accenting — inserts accent on root-initial σ.
-    [kawahara-2015] (39). -/
-def zu_suffix : JAffixEntry :=
+/-- *-zu* (group names): initial-accenting — inserts accent on the
+    root-initial syllable ([kawahara-2015] (39)). -/
+def zuSuffix : AffixEntry :=
   { form := "-zu", gloss := "group", accentType := .initialAccenting }
-
--- Classification theorems: the 8 types project correctly to the
--- coarser dominant/recessive distinction.
-
-/-- Recessive pre-accenting is recessive at the coarse level
-    (preserves root accent when present). -/
-theorem si_is_recessive_coarse :
-    si_affix.accentType.toProsodicDominance = .recessive := rfl
-
-/-- Deaccenting is dominant at the coarse level (overrides root accent).
-    This corrects the earlier classification of *-teki* in this fragment,
-    which used `ProsodicDominance.dominant` — functionally the same
-    projection, but the fine-grained type makes the behavior explicit. -/
-theorem teki_is_dominant_coarse :
-    teki_affix.accentType.toProsodicDominance = .dominant := rfl
-
-/-- Accent-shifting is recessive at the coarse level: it only operates
-    on accent that is already present, never creating new accent. -/
-theorem mono_is_recessive_coarse :
-    mono_suffix.accentType.toProsodicDominance = .recessive := rfl
-
--- ============================================================================
--- § 10: Compound Accent ([kawahara-2015] §4)
--- ============================================================================
-
-/-- *kabuto+musi* 'beetle': short N2 (*musi*, 2μ) pre-accents on
-    N1-final syllable. [kawahara-2015] (22a). -/
-theorem kabuto_musi_compound :
-    shortN2CompoundAccent 3 (some 0) true = some 2 := rfl
-
-/-- *sin+yokohama* 'Shin-Yokohama': long N2 (*yokohama*, 4μ, unaccented)
-    → accent on N2-initial syllable. [kawahara-2015] (23a). -/
-theorem sin_yokohama_compound :
-    longN2CompoundAccent 2 none 4 = some 2 := rfl
-
-/-- *sin+tamane'gi* 'new onion': long N2 retains accent.
-    [kawahara-2015] (24a). -/
-theorem sin_tamanegi_compound :
-    longN2CompoundAccent 2 (some 2) 4 = some 4 := rfl
-
--- ============================================================================
--- § 11: Accent-to-Tone Verification ([kawahara-2015] §1.4)
--- ============================================================================
-
-/-- Unaccented trisyllable *ame+ga* → LHH (initial rise + H spread). -/
-theorem ame_ga_tones :
-    accentToTones ame.accentMora 3 = [.L, .H, .H] := rfl
-
-/-- Accented *ka'mi+ga* → HLL (accent HL + L spread). -/
-theorem kami_god_ga_tones :
-    accentToTones kami_god.accentMora 3 = [.H, .L, .L] := rfl
 
 end Japanese.Prosody

--- a/Linglib/Studies/BeckmanPierrehumbert1986.lean
+++ b/Linglib/Studies/BeckmanPierrehumbert1986.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Prosody
 import Linglib.Phonology.Tone.Basic
 import Linglib.Syntax.CCG.Intonation
 import Linglib.Studies.KratzerSelkirk2020
+import Linglib.Fragments.Japanese.Prosody
 
 /-!
 # Beckman & Pierrehumbert (1986) [beckman-pierrehumbert-1986]
@@ -473,5 +474,41 @@ theorem japanese_catathesis_timing :
 /-- English catathesis timing: catathesis applies after the accent. -/
 theorem english_catathesis_timing :
     english.catathesisTiming = .afterAccent := rfl
+
+/-! ### Japanese accentual phrases from the lexicon
+
+Grouping Japanese word entries into a single AP: the AP is accented iff
+some word is lexically accented (its accent shape is always H*+L), and
+grouping deletes all but one accent — Fig. 6's contrast between accented
+*uma'i mame'* and the unaccented *amai ame* materials, built from the
+`Fragments.Japanese.Prosody` word entries. -/
+
+section JapaneseAP
+open Japanese.Prosody
+
+/-- The accentual phrase over grouped word entries: accented — always H*+L
+    in Japanese — iff some word is lexically accented (§2.2). -/
+def AccentualPhrase.ofWords (ws : List ProsodicEntry) : AccentualPhrase :=
+  { accent := if ws.any (·.isAccented) then .H_star_plus_L else .null
+    nWords := ws.length }
+
+/-- An AP of words triggers catathesis iff some word is accented: the H*+L
+    accent is bitonal, and bitonal accents trigger catathesis (§3). -/
+theorem ofWords_isBitonal (ws : List ProsodicEntry) :
+    (AccentualPhrase.ofWords ws).accent.isBitonal = ws.any (·.isAccented) := by
+  unfold AccentualPhrase.ofWords
+  split <;> simp_all [PitchAccent.isBitonal]
+
+/-- *uma'i mame'* 'delicious beans' (Figs. 6, 9) — an accented AP, so it
+    triggers catathesis on the following phrase. -/
+theorem umai_mame_bitonal :
+    (AccentualPhrase.ofWords [umai, mame]).accent.isBitonal = true := rfl
+
+/-- *amai ame* 'sweet candy' (Figs. 8, 10–13) — an unaccented AP: no
+    catathesis. -/
+theorem amai_ame_not_bitonal :
+    (AccentualPhrase.ofWords [amai, ameCandy]).accent.isBitonal = false := rfl
+
+end JapaneseAP
 
 end BeckmanPierrehumbert1986

--- a/Linglib/Studies/BreissKatsudaKawahara2026.lean
+++ b/Linglib/Studies/BreissKatsudaKawahara2026.lean
@@ -130,7 +130,7 @@ open Constraints
 -- ============================================================================
 
 /-- *hai* 'lung' (肺) — N1 of /haigan/ "lung cancer", example (1a). -/
-def n1_hai : JLexicalEntry :=
+def n1_hai : LexicalEntry :=
   { form := "hai", gloss := "lung",
     accentMora := some 0, nMorae := 2,
     tokenLogFreq := 5, canStandAlone := true }
@@ -138,33 +138,33 @@ def n1_hai : JLexicalEntry :=
 /-- *gan* 'cancer' (癌) — high-token-frequency free N2.
     Free-form [g] is well-attested; PU pressure should be strong,
     suppressing nasalisation. Example (1a). -/
-def n2_gan : JLexicalEntry :=
+def n2_gan : LexicalEntry :=
   { form := "gan", gloss := "cancer",
     accentMora := some 0, nMorae := 2,
     tokenLogFreq := 9, canStandAlone := true }
 
 /-- *noo* 'brain' (脳) — N1 of /noogeka/ "brain surgery", example (1b). -/
-def n1_noo : JLexicalEntry :=
+def n1_noo : LexicalEntry :=
   { form := "noo", gloss := "brain",
     accentMora := some 0, nMorae := 2,
     tokenLogFreq := 5, canStandAlone := true }
 
 /-- *geka* 'surgery' (外科) — free N2, mid-frequency. Example (1b). -/
-def n2_geka : JLexicalEntry :=
+def n2_geka : LexicalEntry :=
   { form := "geka", gloss := "surgery",
     accentMora := some 0, nMorae := 3,
     tokenLogFreq := 6, canStandAlone := true }
 
 /-- *doku* 'poison' (毒) — N1 of both /dokuga/ "poison moth" and
     /dokuŋa/ "poison fang" — the minimal pair (2a)/(2b). -/
-def n1_doku : JLexicalEntry :=
+def n1_doku : LexicalEntry :=
   { form := "doku", gloss := "poison",
     accentMora := some 0, nMorae := 2,
     tokenLogFreq := 5, canStandAlone := true }
 
 /-- *ga* 'moth' (蛾) — low-frequency *free* N2. The free /ga/ standalone
     supplies the PU anchor. Example (2a). -/
-def n2_ga_moth : JLexicalEntry :=
+def n2_ga_moth : LexicalEntry :=
   { form := "ga", gloss := "moth",
     accentMora := some 0, nMorae := 1,
     tokenLogFreq := 1, canStandAlone := true }
@@ -172,7 +172,7 @@ def n2_ga_moth : JLexicalEntry :=
 /-- *ga* 'fang' (牙) — *bound* N2; never appears as a free wordform.
     With no /ga/ anchor, PU pressure is null and nasalisation is
     categorical. The minimal-pair partner of `n2_ga_moth`. Example (2b). -/
-def n2_ga_fang : JLexicalEntry :=
+def n2_ga_fang : LexicalEntry :=
   { form := "ga", gloss := "fang",
     accentMora := some 0, nMorae := 1,
     tokenLogFreq := 0, canStandAlone := false }
@@ -182,31 +182,31 @@ def n2_ga_fang : JLexicalEntry :=
 -- ============================================================================
 
 /-- /haigan/ "lung cancer" — example (1a). High-frequency free N2. -/
-def cpd_haigan : JCompound :=
+def cpd_haigan : NominalCompound :=
   { n1 := n1_hai, n2 := n2_gan, compoundLogFreq := 4 }
 
 /-- /noogeka/ "brain surgery" — example (1b). Mid-frequency free N2. -/
-def cpd_noogeka : JCompound :=
+def cpd_noogeka : NominalCompound :=
   { n1 := n1_noo, n2 := n2_geka, compoundLogFreq := 3 }
 
 /-- /dokuga/ "poison moth" — example (2a). Low-frequency free N2;
     optional nasalisation. -/
-def cpd_dokuga : JCompound :=
+def cpd_dokuga : NominalCompound :=
   { n1 := n1_doku, n2 := n2_ga_moth, compoundLogFreq := 2 }
 
 /-- /dokuŋa/ "poison fang" — example (2b). Bound N2 → categorical [ŋ]. -/
-def cpd_dokunga : JCompound :=
+def cpd_dokunga : NominalCompound :=
   { n1 := n1_doku, n2 := n2_ga_fang, compoundLogFreq := 2 }
 
 -- ============================================================================
 -- § 3: Bound vs. free split — the categorical/gradient boundary
 -- ============================================================================
 
-/-- The bound case: `JCompound.nasalisationObligatory` returns `true`. -/
+/-- The bound case: `NominalCompound.nasalisationObligatory` returns `true`. -/
 theorem dokunga_obligatory :
     cpd_dokunga.nasalisationObligatory = true := rfl
 
-/-- The free cases: `JCompound.nasalisationObligatory` returns `false`
+/-- The free cases: `NominalCompound.nasalisationObligatory` returns `false`
     — the compound is in the gradient/optional zone. -/
 theorem dokuga_optional :
     cpd_dokuga.nasalisationObligatory = false := rfl
@@ -243,7 +243,7 @@ theorem free_zone_freq_independent :
     primitive. The anchor-presence channel is exactly what
     [steriade-1997] introduced, and BKK's bound/free split is the
     same architectural channel applied to a new domain. -/
-def n2Paradigm (c : JCompound) : List String :=
+def n2Paradigm (c : NominalCompound) : List String :=
   lcParadigm c.form (if c.n2.canStandAlone then some c.n2.form else none)
 
 /-- Surface mismatch between two strings: 0 on the diagonal, 1
@@ -270,7 +270,7 @@ def puFaith : Constraint (List String) :=
   mkLCFaith "PU-N2-FAITH" stringMismatch
 
 /-- Number of PU-FAITH violations on a compound's paradigm. -/
-def cpdPuViolations (c : JCompound) : Nat :=
+def cpdPuViolations (c : NominalCompound) : Nat :=
   puFaith (n2Paradigm c)
 
 /-- **Bound case is structurally zero.** A bound N2 produces a singleton
@@ -278,7 +278,7 @@ def cpdPuViolations (c : JCompound) : Nat :=
     whose mismatch is 0 by definition. The categorical nasalisation in
     bound compounds is the structural consequence of the PU channel
     contributing nothing. -/
-theorem bound_cpdPuViolations_zero (c : JCompound)
+theorem bound_cpdPuViolations_zero (c : NominalCompound)
     (hbound : c.n2.canStandAlone = false) :
     cpdPuViolations c = 0 := by
   have hpar : n2Paradigm c = lcParadigm c.form none := by
@@ -291,7 +291,7 @@ theorem bound_cpdPuViolations_zero (c : JCompound)
     exactly two off-diagonal pairs, each contributing 1, for a total
     of 2 violations. The compound and N2 forms differ whenever N1 is
     non-empty — an empirically generic precondition. -/
-theorem free_cpdPuViolations_eq_two (c : JCompound)
+theorem free_cpdPuViolations_eq_two (c : NominalCompound)
     (hfree : c.n2.canStandAlone = true)
     (hdiff : c.form ≠ c.n2.form) :
     cpdPuViolations c = 2 := by
@@ -332,8 +332,8 @@ def scaledWeight (baseWeight slope x : ℝ) : ℝ := baseWeight + slope * x
     preservation of [g] → less nasalisation. This is the
     *negative-on-nasalisation* channel (negative regression coefficient
     on N2 token frequency in [breiss-katsuda-kawahara-2026]). -/
-noncomputable def puPressure (slope : ℝ) (c : JCompound) : ℝ :=
-  (cpdPuViolations c : ℝ) * scaledWeight (baseWeight := 0) (slope := slope) (jTokenFreq c.n2)
+noncomputable def puPressure (slope : ℝ) (c : NominalCompound) : ℝ :=
+  (cpdPuViolations c : ℝ) * scaledWeight (baseWeight := 0) (slope := slope) (c.n2.tokenFreq)
 
 /-- The **compound-frequency-weighted markedness pressure** *for*
     nasalisation: linear in compound log-frequency. Higher compound
@@ -345,7 +345,7 @@ noncomputable def puPressure (slope : ℝ) (c : JCompound) : ℝ :=
     Modelled as a one-parameter linear function of the compound's own
     log-frequency, parallel to `Scaled.scaledWeight` but on the
     compound (not lexical-entry) channel. -/
-noncomputable def cpdMarkednessPressure (slope : ℝ) (c : JCompound) : ℝ :=
+noncomputable def cpdMarkednessPressure (slope : ℝ) (c : NominalCompound) : ℝ :=
   slope * (c.compoundLogFreq : ℝ)
 
 /-- The predicted **nasalisation log-odds** of a compound: markedness
@@ -353,7 +353,7 @@ noncomputable def cpdMarkednessPressure (slope : ℝ) (c : JCompound) : ℝ :=
     (negative sign on nasalisation). The sign-inversion of the PU
     channel is *built into the difference* — increasing PU
     monotonically decreases the log-odds. -/
-noncomputable def nasLogOdds (n2Slope cpdSlope : ℝ) (c : JCompound) : ℝ :=
+noncomputable def nasLogOdds (n2Slope cpdSlope : ℝ) (c : NominalCompound) : ℝ :=
   cpdMarkednessPressure cpdSlope c - puPressure n2Slope c
 
 -- ============================================================================
@@ -366,7 +366,7 @@ noncomputable def nasLogOdds (n2Slope cpdSlope : ℝ) (c : JCompound) : ℝ :=
     source of the *negative* regression coefficient on N2 token
     frequency reported in [breiss-katsuda-kawahara-2026]. -/
 theorem nasLogOdds_antitone_in_puPressure (n2Slope cpdSlope : ℝ)
-    (c1 c2 : JCompound) (hcpd : c1.compoundLogFreq = c2.compoundLogFreq)
+    (c1 c2 : NominalCompound) (hcpd : c1.compoundLogFreq = c2.compoundLogFreq)
     (hpu : puPressure n2Slope c1 ≤ puPressure n2Slope c2) :
     nasLogOdds n2Slope cpdSlope c2 ≤ nasLogOdds n2Slope cpdSlope c1 := by
   unfold nasLogOdds cpdMarkednessPressure
@@ -378,8 +378,8 @@ theorem nasLogOdds_antitone_in_puPressure (n2Slope cpdSlope : ℝ)
     matched PU-violation counts, a higher N2 token log-frequency
     yields strictly *higher* PU pressure (when slope is positive). -/
 theorem puPressure_monotone_in_n2_freq (slope : ℝ) (hSlope : 0 ≤ slope)
-    (c1 c2 : JCompound) (hviol : cpdPuViolations c1 = cpdPuViolations c2)
-    (hfreq : jTokenFreq c1.n2 ≤ jTokenFreq c2.n2) :
+    (c1 c2 : NominalCompound) (hviol : cpdPuViolations c1 = cpdPuViolations c2)
+    (hfreq : c1.n2.tokenFreq ≤ c2.n2.tokenFreq) :
     puPressure slope c1 ≤ puPressure slope c2 := by
   unfold puPressure scaledWeight
   rw [hviol]
@@ -392,7 +392,7 @@ theorem puPressure_monotone_in_n2_freq (slope : ℝ) (hSlope : 0 ≤ slope)
     compound has strictly higher nasalisation log-odds (when slope is
     positive). -/
 theorem nasLogOdds_monotone_in_cpd_freq (n2Slope cpdSlope : ℝ)
-    (hSlope : 0 ≤ cpdSlope) (c1 c2 : JCompound)
+    (hSlope : 0 ≤ cpdSlope) (c1 c2 : NominalCompound)
     (hpu : puPressure n2Slope c1 = puPressure n2Slope c2)
     (hfreq : c1.compoundLogFreq ≤ c2.compoundLogFreq) :
     nasLogOdds n2Slope cpdSlope c1 ≤ nasLogOdds n2Slope cpdSlope c2 := by
@@ -407,7 +407,7 @@ theorem nasLogOdds_monotone_in_cpd_freq (n2Slope cpdSlope : ℝ)
     bound-case prediction depends only on the compound-frequency
     channel — i.e. the bound case has **one** frequency channel, not
     two. This is the architectural collapse the paper highlights. -/
-theorem bound_nasLogOdds_eq_markedness (n2Slope cpdSlope : ℝ) (c : JCompound)
+theorem bound_nasLogOdds_eq_markedness (n2Slope cpdSlope : ℝ) (c : NominalCompound)
     (hbound : c.n2.canStandAlone = false) :
     nasLogOdds n2Slope cpdSlope c = cpdMarkednessPressure cpdSlope c := by
   unfold nasLogOdds puPressure
@@ -431,9 +431,9 @@ theorem bound_nasLogOdds_eq_markedness (n2Slope cpdSlope : ℝ) (c : JCompound)
     different `puPressure` values when their N2 token frequencies
     differ and the slope is strictly positive. -/
 theorem novel_compounds_show_n2_gradient (slope : ℝ) (hSlope : 0 < slope)
-    (c1 c2 : JCompound) (hviol : cpdPuViolations c1 = cpdPuViolations c2)
+    (c1 c2 : NominalCompound) (hviol : cpdPuViolations c1 = cpdPuViolations c2)
     (hviol_pos : 0 < cpdPuViolations c1)
-    (hfreq : jTokenFreq c1.n2 < jTokenFreq c2.n2) :
+    (hfreq : c1.n2.tokenFreq < c2.n2.tokenFreq) :
     puPressure slope c1 < puPressure slope c2 := by
   unfold puPressure scaledWeight
   have hpos2 : (0 : ℝ) < (cpdPuViolations c2 : ℝ) := by
@@ -472,7 +472,7 @@ hypotheses. Concretely: for every `WugBKKCell`, we *prove* (not
 assume) that PU violations equal 2. -/
 
 structure WugBKKCell where
-  compound : JCompound
+  compound : NominalCompound
   freeN2 : compound.n2.canStandAlone = true
   formDistinct : compound.form ≠ compound.n2.form
   attestation : Attestation
@@ -621,7 +621,7 @@ paradigm membership alone. -/
 /-- The OP paradigm of a compound: symmetric over all members, no
     distinguished anchor. Because OP does not condition on
     attestation, both bound and free N2 contribute to the paradigm. -/
-def n2OpParadigm (c : JCompound) : List String :=
+def n2OpParadigm (c : NominalCompound) : List String :=
   [c.form, c.n2.form]
 
 /-- The OP-flavoured PU constraint, built from the same `liftPairwise`
@@ -631,7 +631,7 @@ def opPuFaith : Constraint (List String) :=
   liftPairwise stringMismatch
 
 /-- OP-flavoured violation count on a compound. -/
-def cpdOpPuViolations (c : JCompound) : Nat :=
+def cpdOpPuViolations (c : NominalCompound) : Nat :=
   opPuFaith (n2OpParadigm c)
 
 /-- **OP gives identical violation counts on bound and free
@@ -639,7 +639,7 @@ def cpdOpPuViolations (c : JCompound) : Nat :=
     `[c.form, c.n2.form]` has two off-diagonal pairs each contributing
     1, regardless of N2 attestation. This is the structural
     consequence of OP's anchor-blindness. -/
-theorem op_paradigm_uniform_in_bound_free (c : JCompound)
+theorem op_paradigm_uniform_in_bound_free (c : NominalCompound)
     (hdiff : c.form ≠ c.n2.form) :
     cpdOpPuViolations c = 2 := by
   show opPuFaith (n2OpParadigm c) = 2
@@ -664,7 +664,7 @@ theorem op_paradigm_uniform_in_bound_free (c : JCompound)
     with an *extended-OP* that applies the symmetric-paradigm
     architecture to N1+N2 compounds, which BKK take to be the natural
     OP-style competitor in this domain. -/
-theorem op_lc_disagree_on_bound (c : JCompound)
+theorem op_lc_disagree_on_bound (c : NominalCompound)
     (hbound : c.n2.canStandAlone = false)
     (hdiff : c.form ≠ c.n2.form) :
     cpdOpPuViolations c ≠ cpdPuViolations c := by

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -1,4 +1,5 @@
 import Linglib.Phonology.Prosody.Syllable
+import Linglib.Phonology.Constraints.Defs
 import Linglib.Fragments.Japanese.Prosody
 
 /-!
@@ -8,159 +9,473 @@ The phonology of Japanese accent. In Haruo Kubozono (ed.),
 *The handbook of Japanese phonetics and phonology*, 445–492.
 Berlin: De Gruyter Mouton.
 
-This survey chapter provides a comprehensive overview of Tokyo Japanese
-pitch accent, covering default accent assignment, compound accent,
-verb/adjective paradigms, affix accent typology, and interactions with
-epenthesis, rendaku, and vowel devoicing.
+Survey of Tokyo Japanese pitch accent. Formalized here:
 
-## Formalized contributions
-
-1. **AAR vs LSR** (§2, Table 1): the two accent assignment rules agree
-   on 6 of 8 trisyllabic weight conditions and diverge on HLH and LLH.
-2. **Accent-to-tone derivation** (§1.4): surface tones are fully
-   determined by accent location via accentual HL, initial rise, and
-   tonal spreading.
-3. **Eight affix accent types** (§6): the traditional dominant/recessive
-   distinction is refined into an 8-way typology.
-4. **Compound accent** (§4): short N2 (≤2μ) triggers pre-accenting or
-   retention; long N2 (≥3μ) triggers N2-initial accent or retention.
+1. **AAR vs LSR** (§2, Table 1): the antepenultimate accent rule
+   ([mccawley-1968]) and the Latin Stress Rule ([hayes-1995]) agree on six
+   of the eight trisyllabic weight conditions and diverge exactly on HLH
+   and LLH — `aar_lsr_mismatches`.
+2. **Accent-to-tone derivation** (§1.4, (7)–(9)): accentual HL, initial
+   rise, and tonal spreading determine surface tones from accent location —
+   `accentToTones`.
+3. **Culminativity** (§1.4): at most one HL fall per word, for every accent
+   location and word length — `accentToTones_culminative`.
+4. **Affix accent typology** (§6): the eight affix types and their
+   projection to the coarse dominant/recessive split.
+5. **Compound accent** (§4): the short-N2 and long-N2 rules; both satisfy
+   NonFinality ([prince-smolensky-1993]) — `shortN2_preaccent_nonfinal`,
+   `longN2_nonfinal`.
 -/
-
-open Prosody
 
 namespace Kawahara2015
 
-open Features.Prosody
-open Japanese.Prosody
+open Prosody Japanese.Prosody Constraints
 
--- ============================================================================
--- § 1: AAR vs LSR — Table 1 Completeness
--- ============================================================================
+/-! ### Default accent: the AAR vs the Latin Stress Rule
 
-/-- Table 1 completeness: exactly 2 of 8 conditions produce different
-    predictions between AAR and LSR. The mismatches are HLH and LLH.
+Language-neutral accent-placement rules over a syllable-weight profile,
+compared on loanword default accentuation ([kawahara-2015] §2). -/
 
-    In both mismatch cases, the AAR predicts accent on σ₂ (the syllable
-    containing the antepenultimate mora) while the LSR predicts accent
-    on σ₁ (the antepenultimate syllable, because the penult is light).
+/-- The 0-indexed syllable containing mora `targetMora` (0-indexed), or `none`
+    if it exceeds the total mora count. -/
+private def findSyllable (weights : List Syllable.Weight) (targetMora : ℕ) : Option ℕ :=
+  go weights targetMora 0
+where
+  go : List Syllable.Weight → ℕ → ℕ → Option ℕ
+    | [], _, _ => none
+    | w :: ws, target, idx => if target < w then some idx else go ws (target - w) (idx + 1)
 
-    [kubozono-2006] argues that LSR-conforming pronunciations
-    appear as variants even in the mismatch cases, suggesting the LSR
-    may be the better characterization. -/
-theorem table1_exactly_two_mismatches :
-    -- The 6 matching cases (re-exported from fragment for completeness)
-    defaultAccentAAR [.heavy, .heavy, .heavy] =
-      latinStressRule [.heavy, .heavy, .heavy] ∧
-    defaultAccentAAR [.heavy, .heavy, .light] =
-      latinStressRule [.heavy, .heavy, .light] ∧
-    defaultAccentAAR [.heavy, .light, .light] =
-      latinStressRule [.heavy, .light, .light] ∧
-    defaultAccentAAR [.light, .heavy, .heavy] =
-      latinStressRule [.light, .heavy, .heavy] ∧
-    defaultAccentAAR [.light, .heavy, .light] =
-      latinStressRule [.light, .heavy, .light] ∧
-    defaultAccentAAR [.light, .light, .light] =
-      latinStressRule [.light, .light, .light] ∧
-    -- The 2 mismatch cases
-    defaultAccentAAR [.heavy, .light, .heavy] ≠
-      latinStressRule [.heavy, .light, .heavy] ∧
-    defaultAccentAAR [.light, .light, .heavy] ≠
-      latinStressRule [.light, .light, .heavy] := by
-  exact ⟨by unfold latinStressRule; rfl,
-    by unfold latinStressRule; rfl,
-    by unfold latinStressRule; rfl,
-    by unfold latinStressRule; rfl,
-    by unfold latinStressRule; rfl,
-    by unfold latinStressRule; rfl,
-    by intro h; unfold latinStressRule at h; exact absurd h (by decide),
-    by intro h; unfold latinStressRule at h; exact absurd h (by decide)⟩
+/-- The antepenultimate accent rule ([mccawley-1968]): accent the syllable
+    containing the antepenultimate mora; words with fewer than three morae
+    accent the initial syllable. Returns the 0-indexed syllable. -/
+def defaultAccentAAR (weights : List Syllable.Weight) : Option ℕ :=
+  match weights with
+  | [] => none
+  | _ =>
+    let totalMorae := weights.foldl (· + ·) 0
+    let targetMora := if totalMorae ≥ 3 then totalMorae - 3 else 0
+    findSyllable weights targetMora
 
--- ============================================================================
--- § 2: Accent-to-Tone — the n+1 Pattern
--- ============================================================================
+/-- The Latin Stress Rule ([hayes-1995]): accent the penult if heavy (≥ 2μ),
+    else the antepenult; monosyllables and disyllables accent the initial
+    syllable. [kawahara-2015] §2.3 reviews arguments that LSR-conforming
+    variants occur even where the two rules diverge, making the LSR arguably
+    the better characterization of the Japanese default. -/
+def latinStressRule (weights : List Syllable.Weight) : Option ℕ :=
+  match weights with
+  | [] => none
+  | _ =>
+    if weights.length ≤ 2 then some 0
+    else if Syllable.Weight.heavy ≤ weights.getD (weights.length - 2) 0 then
+      some (weights.length - 2)
+    else some (weights.length - 3)
 
-/-- For n-mora words, there are n+1 distinct accent patterns: accent can
-    fall on any of the n moras, or the word can be unaccented.
+/-- The eight trisyllabic weight conditions of [kawahara-2015] Table 1. -/
+def trisyllabicConditions : List (List Syllable.Weight) :=
+  [[.heavy, .heavy, .heavy], [.heavy, .heavy, .light],
+   [.heavy, .light, .heavy], [.heavy, .light, .light],
+   [.light, .heavy, .heavy], [.light, .heavy, .light],
+   [.light, .light, .heavy], [.light, .light, .light]]
 
-    However, word-internally, final accent and unaccented produce the same
-    tonal contour (both LHH for 3 morae), because the post-accent L falls
-    off the word edge. They are distinguished only in phrasal context
-    (e.g., followed by a particle).
+/-- [kawahara-2015] Table 1: the AAR and the LSR agree on six of the eight
+    trisyllabic weight conditions and diverge exactly on HLH and LLH. -/
+theorem aar_lsr_mismatches :
+    trisyllabicConditions.filter (fun w => defaultAccentAAR w != latinStressRule w) =
+      [[.heavy, .light, .heavy], [.light, .light, .heavy]] := by decide
 
-    We verify that the first 3 patterns (unaccented, initial, medial) are
-    pairwise distinct, and that final-accented = unaccented word-internally. -/
+/-- On HLH the AAR accents σ₂ (the syllable containing the antepenultimate
+    mora), the LSR σ₁ (the antepenult, since the penult is light): `HL'H` vs
+    `H'LH` ([kawahara-2015] Table 1c). -/
+theorem aar_lsr_mismatch_hlh :
+    defaultAccentAAR [.heavy, .light, .heavy] = some 1 ∧
+      latinStressRule [.heavy, .light, .heavy] = some 0 := by decide
+
+/-- On LLH the AAR accents σ₂, the LSR σ₁: `LL'H` vs `L'LH`
+    ([kawahara-2015] Table 1g). -/
+theorem aar_lsr_mismatch_llh :
+    defaultAccentAAR [.light, .light, .heavy] = some 1 ∧
+      latinStressRule [.light, .light, .heavy] = some 0 := by decide
+
+/-! ### Loanword accent (§2)
+
+Loanwords lack lexical accent specifications, so their accentuation reveals
+the default pattern ([kawahara-2015] §2.1; [kubozono-2006]). -/
+
+/-- A loanword entry with its syllable-weight profile, for testing the
+    default accent rules against the attested accent. -/
+structure LoanwordEntry where
+  entry : ProsodicEntry
+  /-- Syllable weight profile (left to right) -/
+  weights : List Syllable.Weight
+  deriving Repr
+
+/-- *ku-ri-su'-ma-su* 'Christmas' — antepenultimate-mora accent
+    ([kawahara-2015] (10a)). -/
+def kurisumasu : LoanwordEntry :=
+  { entry := { form := "kurisumasu", gloss := "Christmas"
+               accentMora := some 2, nMorae := 5 }
+    weights := [.light, .light, .light, .light, .light] }
+
+/-- *a-su-fa'-ru-to* 'asphalt' — antepenultimate-mora accent
+    ([kawahara-2015] (10g)). -/
+def asufaruto : LoanwordEntry :=
+  { entry := { form := "asufaruto", gloss := "asphalt"
+               accentMora := some 2, nMorae := 5 }
+    weights := [.light, .light, .light, .light, .light] }
+
+/-- *ma-ku-do-na'-ru-do* 'McDonald' — antepenultimate-mora accent
+    ([kawahara-2015] (10h)). -/
+def makudonarudo : LoanwordEntry :=
+  { entry := { form := "makudonarudo", gloss := "McDonald's"
+               accentMora := some 3, nMorae := 6 }
+    weights := [.light, .light, .light, .light, .light, .light] }
+
+/-- *a.me.ri.ka* 'America' — unaccented: four morae with two final light
+    non-epenthetic syllables ([kawahara-2015] (16a)). -/
+def amerika : LoanwordEntry :=
+  { entry := { form := "amerika", gloss := "America"
+               accentMora := none, nMorae := 4 }
+    weights := [.light, .light, .light, .light] }
+
+/-- The accented loanwords of [kawahara-2015] (10) carry the accent the AAR
+    assigns. -/
+theorem loanwords_match_aar :
+    defaultAccentAAR kurisumasu.weights = kurisumasu.entry.accentMora ∧
+      defaultAccentAAR asufaruto.weights = asufaruto.entry.accentMora ∧
+      defaultAccentAAR makudonarudo.weights = makudonarudo.entry.accentMora := by decide
+
+/-- On all-light profiles the LSR agrees with the AAR, so the (10) loanwords
+    match it as well ([kawahara-2015] §2.3). -/
+theorem loanwords_match_lsr :
+    latinStressRule kurisumasu.weights = kurisumasu.entry.accentMora ∧
+      latinStressRule asufaruto.weights = asufaruto.entry.accentMora ∧
+      latinStressRule makudonarudo.weights = makudonarudo.entry.accentMora := by decide
+
+/-- *amerika*'s unaccentedness is beyond both default rules — neither
+    produces unaccented outputs ([kawahara-2015] §2.3 n. 10); four-mora
+    light-final unaccentedness is §2.4's separate generalization. -/
+theorem amerika_beyond_default_rules :
+    defaultAccentAAR amerika.weights ≠ amerika.entry.accentMora ∧
+      latinStressRule amerika.weights ≠ amerika.entry.accentMora := by decide
+
+/-! ### From accent to surface tones (§1.4)
+
+The derivation of [kawahara-2015] (7)–(9): tones are specified by the
+accentual HL and the initial rise, then spread rightward. -/
+
+/-- A level tone: Japanese uses only H and L at the lexical level
+    ([kawahara-2015] §1.3). -/
+inductive LevelTone where
+  | H
+  | L
+  deriving DecidableEq, Repr
+
+/-- The tonal specification of mora `i` (0-indexed) before spreading
+    ([kawahara-2015] (4)–(5)): the accented mora is H and its successor L
+    (accentual HL); mora 0 is L and mora 1 H (initial rise), except where
+    the accentual tones win. Other moras are unspecified. -/
+def toneSpec (accentMora : Option ℕ) (i : ℕ) : Option LevelTone :=
+  if accentMora = some i then some .H
+  else if 1 ≤ i ∧ accentMora = some (i - 1) then some .L
+  else if i = 0 then some .L
+  else if i = 1 then some .H
+  else none
+
+/-- Surface tones from accent position ([kawahara-2015] (7)–(9)): specify
+    tones by accent and initial rise (`toneSpec`), then spread — each
+    unspecified mora copies the nearest specified tone to its left. -/
+def accentToTones (accentMora : Option ℕ) (nMorae : ℕ) : List LevelTone :=
+  spread ((List.range nMorae).map (toneSpec accentMora)) .H
+where
+  /-- Fill unspecified positions from the most recent specified tone. The
+      seed is never consulted on well-formed input: mora 0 is always
+      specified. -/
+  spread : List (Option LevelTone) → LevelTone → List LevelTone
+    | [], _ => []
+    | some t :: rest, _ => t :: spread rest t
+    | none :: rest, last => last :: spread rest last
+
+/-- Unaccented *ame(+ga)* 'candy' surfaces LHH: initial rise, then spreading
+    ([kawahara-2015] (6b)). -/
+theorem ameCandy_ga_tones : accentToTones ameCandy.accentMora 3 = [.L, .H, .H] := by
+  decide
+
+/-- Initially-accented *a'me(+ga)* 'rain' surfaces HLL: the accentual HL
+    blocks the initial rise ([kawahara-2015] (5b), (8)). -/
+theorem ameRain_ga_tones : accentToTones ameRain.accentMora 3 = [.H, .L, .L] := by
+  decide
+
+/-- The n+1 accent patterns of a trisyllable ([kawahara-2015] (3)): the
+    unaccented, initial, and medial patterns are pairwise distinct, while
+    final accent and unaccentedness neutralize word-internally — the
+    post-accent L falls off the word edge, which is why examples carry the
+    nominative particle *+ga* ([kawahara-2015] §1.4). -/
 theorem trisyllabic_tone_patterns :
-    -- Distinct pairs
     accentToTones none 3 ≠ accentToTones (some 0) 3 ∧
-    accentToTones none 3 ≠ accentToTones (some 1) 3 ∧
-    accentToTones (some 0) 3 ≠ accentToTones (some 1) 3 ∧
-    -- Final accent = unaccented word-internally (post-accent L falls off)
-    accentToTones none 3 = accentToTones (some 2) 3 := by
-  exact ⟨by decide, by decide, by decide, rfl⟩
+      accentToTones none 3 ≠ accentToTones (some 1) 3 ∧
+      accentToTones (some 0) 3 ≠ accentToTones (some 1) 3 ∧
+      accentToTones none 3 = accentToTones (some 2) 3 := by decide
 
--- ============================================================================
--- § 3: Culminativity
--- ============================================================================
+/-! ### Culminativity
 
-/-- Culminativity: Japanese allows at most one accent per prosodic word.
-    We verify that `JProsodicEntry` structurally enforces this — accent
-    is a single `Option Nat`, so there can be at most one accented mora
-    by construction. -/
-theorem culminativity_by_construction (e : JProsodicEntry) :
-    (match e.accentMora with | none => 0 | some _ => 1) ≤ 1 := by
-  cases e.accentMora <;> simp
+[kawahara-2015] §1.4: "Japanese allows only one HL pitch fall within a
+word." `accentToTones_culminative` derives this for every accent location
+and word length from the derivation's shape: the single lexical accent is
+the only source of a specified post-initial L, spreading only copies tones,
+and a fall needs a following L. -/
 
--- ============================================================================
--- § 4: Affix Typology — Coarse Classification
--- ============================================================================
+/-- The number of H-to-L falls in a tone string. -/
+def hlFallCount : List LevelTone → ℕ
+  | .H :: .L :: rest => hlFallCount (.L :: rest) + 1
+  | _ :: rest => hlFallCount rest
+  | [] => 0
 
-/-- The 8 affix types collapse to exactly two prosodic dominance classes:
-    recessive (3 types) and dominant (5 types). -/
+/-- Dropping the head can only lose L's. -/
+theorem count_L_tail_le : ∀ l : List LevelTone, l.tail.count .L ≤ l.count .L
+  | [] => Nat.le_refl _
+  | .H :: _ => by rw [List.tail_cons, List.count_cons_of_ne (by decide)]
+  | .L :: _ => by rw [List.tail_cons, List.count_cons_self]; exact Nat.le_succ _
+
+/-- Every fall consumes an L strictly after the first position. -/
+theorem hlFallCount_le_count_tail :
+    ∀ l : List LevelTone, hlFallCount l ≤ l.tail.count .L
+  | [] => Nat.le_refl _
+  | [t] => by cases t <;> simp [hlFallCount]
+  | .H :: .L :: rest => by
+      have ih := hlFallCount_le_count_tail (.L :: rest)
+      rw [show hlFallCount (.H :: .L :: rest) = hlFallCount (.L :: rest) + 1 from rfl,
+        List.tail_cons, List.count_cons_self]
+      rw [List.tail_cons] at ih
+      omega
+  | .H :: .H :: rest => by
+      have ih := hlFallCount_le_count_tail (.H :: rest)
+      rw [show hlFallCount (.H :: .H :: rest) = hlFallCount (.H :: rest) from rfl,
+        List.tail_cons, List.count_cons_of_ne (by decide)]
+      rw [List.tail_cons] at ih
+      exact ih
+  | .L :: b :: rest => by
+      have ih := hlFallCount_le_count_tail (b :: rest)
+      have e : hlFallCount (.L :: b :: rest) = hlFallCount (b :: rest) := by
+        cases b <;> rfl
+      rw [e, List.tail_cons]
+      exact ih.trans (count_L_tail_le _)
+
+/-- Unfolding: a two-element prefix contributes a fall exactly when it is
+    H-then-L. -/
+theorem hlFallCount_cons_cons (t u : LevelTone) (l : List LevelTone) :
+    hlFallCount (t :: u :: l) =
+      hlFallCount (u :: l) + if t = .H ∧ u = .L then 1 else 0 := by
+  cases t <;> cases u <;> simp [hlFallCount]
+
+/-- Spreading is fall-invariant: copying a tone never creates or destroys an
+    HL fall, so the spread output has exactly the falls of the specified
+    subsequence. -/
+theorem hlFallCount_spread (spec : List (Option LevelTone)) (t : LevelTone) :
+    hlFallCount (t :: accentToTones.spread spec t) =
+      hlFallCount (t :: spec.filterMap id) := by
+  induction spec generalizing t with
+  | nil => rfl
+  | cons o rest ih =>
+    cases o with
+    | some u =>
+      rw [show accentToTones.spread (some u :: rest) t =
+            u :: accentToTones.spread rest u from rfl,
+        show (some u :: rest).filterMap id = u :: rest.filterMap id from rfl,
+        hlFallCount_cons_cons, hlFallCount_cons_cons, ih u]
+    | none =>
+      rw [show accentToTones.spread (none :: rest) t =
+            t :: accentToTones.spread rest t from rfl,
+        show (none :: rest).filterMap id = rest.filterMap id from rfl,
+        hlFallCount_cons_cons, ih t]
+      have hδ : (if t = .H ∧ t = .L then 1 else 0) = 0 := by cases t <;> simp
+      rw [hδ, Nat.add_zero]
+
+/-- Mora 0 is always specified: H under initial accent, else the
+    initial-rise L. -/
+theorem toneSpec_zero (a : Option ℕ) :
+    toneSpec a 0 = some (if a = some 0 then .H else .L) := by
+  by_cases h : a = some 0 <;> simp [toneSpec, h]
+
+/-- After mora 0, the only source of a specified L is the post-accent L,
+    which pins the accent location. -/
+theorem toneSpec_eq_L {a : Option ℕ} {j : ℕ} (hj : 1 ≤ j) :
+    toneSpec a j = some .L ↔ a = some (j - 1) := by
+  unfold toneSpec
+  split_ifs with h1 h2 <;> simp_all
+  omega
+
+/-- The specified tones after mora 0 contain at most one L: the post-accent
+    L pins the accent location, and positions are distinct. -/
+theorem count_L_toneSpec_dense (a : Option ℕ) :
+    ∀ l : List ℕ, l.Nodup → (∀ j ∈ l, 1 ≤ j) →
+      (l.filterMap (toneSpec a)).count .L ≤ 1 := by
+  intro l
+  induction l with
+  | nil => simp
+  | cons j rest ih =>
+    intro hnd hpos
+    rw [List.filterMap_cons]
+    rcases hj : toneSpec a j with _ | t
+    · exact ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
+    rcases t with _ | _
+    · simpa [List.count_cons] using ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
+    · have ha : a = some (j - 1) := (toneSpec_eq_L (hpos j (.head _))).mp hj
+      have hrest : (rest.filterMap (toneSpec a)).count .L = 0 := by
+        rw [List.count_eq_zero]
+        intro hmem
+        obtain ⟨k, hk, hspec⟩ := List.mem_filterMap.mp hmem
+        have hk1 := hpos k (.tail _ hk)
+        have hak : a = some (k - 1) := (toneSpec_eq_L hk1).mp hspec
+        have hj1 := hpos j (.head _)
+        have hkj : k = j := by
+          rw [ha] at hak
+          simp only [Option.some.injEq] at hak
+          omega
+        exact (List.nodup_cons.mp hnd).1 (hkj ▸ hk)
+      simp [hrest]
+
+/-- **Culminativity** ([kawahara-2015] §1.4): at most one HL fall per word,
+    for every accent location and word length. -/
+theorem accentToTones_culminative (a : Option ℕ) (n : ℕ) :
+    hlFallCount (accentToTones a n) ≤ 1 := by
+  obtain _ | m := n
+  · exact Nat.zero_le _
+  · have hpeel : accentToTones a (m + 1) =
+        (if a = some 0 then LevelTone.H else .L) ::
+          accentToTones.spread (((List.range m).map Nat.succ).map (toneSpec a))
+            (if a = some 0 then LevelTone.H else .L) := by
+      rw [accentToTones, List.range_succ_eq_map, List.map_cons, toneSpec_zero]
+      rfl
+    rw [hpeel, hlFallCount_spread]
+    refine (hlFallCount_le_count_tail _).trans ?_
+    rw [List.tail_cons, List.filterMap_map, Function.id_comp]
+    exact count_L_toneSpec_dense a _
+      (List.nodup_range.map Nat.succ_injective)
+      (fun j hj => by
+        obtain ⟨k, -, rfl⟩ := List.mem_map.mp hj
+        exact Nat.succ_le_succ k.zero_le)
+
+/-! ### Affix accent typology (§6)
+
+The eight affix accent types, one canonical affix each (fragment entries),
+and their projection to the coarse dominant/recessive split. -/
+
+/-- The eight affix types of [kawahara-2015] §6 project onto the coarse
+    dominant/recessive distinction: three preserve root accent when present
+    (recessive, recessive pre-accenting, accent-shifting), five override
+    it. -/
 theorem affix_typology_coarse_partition :
-    -- Recessive class (preserve root accent when present)
-    tara_suffix.accentType.toProsodicDominance = .recessive ∧
-    si_affix.accentType.toProsodicDominance = .recessive ∧
-    mono_suffix.accentType.toProsodicDominance = .recessive ∧
-    -- Dominant class (override root accent)
-    ppoi_suffix.accentType.toProsodicDominance = .dominant ∧
-    ke_suffix.accentType.toProsodicDominance = .dominant ∧
-    o_prefix.accentType.toProsodicDominance = .dominant ∧
-    teki_affix.accentType.toProsodicDominance = .dominant ∧
-    zu_suffix.accentType.toProsodicDominance = .dominant :=
+    taraSuffix.accentType.toProsodicDominance = .recessive ∧
+      siSuffix.accentType.toProsodicDominance = .recessive ∧
+      monoSuffix.accentType.toProsodicDominance = .recessive ∧
+      ppoiSuffix.accentType.toProsodicDominance = .dominant ∧
+      keSuffix.accentType.toProsodicDominance = .dominant ∧
+      oPrefix.accentType.toProsodicDominance = .dominant ∧
+      tekiSuffix.accentType.toProsodicDominance = .dominant ∧
+      zuSuffix.accentType.toProsodicDominance = .dominant :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
--- ============================================================================
--- § 5: Compound Accent — NonFinality Drives Pre-Accenting
--- ============================================================================
+/-! ### Compound accent (§4)
 
-/-- Short N2 pre-accenting moves accent off the final syllable of the
-    compound, consistent with NonFinality(σ). -/
-theorem short_n2_preaccent_avoids_final :
-    let result := shortN2CompoundAccent 3 (some 1) true  -- 3μ N1, pre-accenting
-    let totalMorae := 3 + 2  -- N1 + short N2
-    nonFinalitySigma result totalMorae = 0 := rfl
+The traditional dichotomy by N2 length: short N2s (≤ 2μ) either retain
+accent or pre-accent the N1-final position; long N2s (≥ 3μ) take N2-initial
+accent unless their own accent is nonfinal. Both rules are stated over mora
+counts; the paper's rules target syllables, and the two coincide on the
+light-syllable data of (22)–(24) formalized below. -/
 
-/-- Long N2 with unaccented N2 assigns accent to N2-initial syllable,
-    which is never word-final (since N2 is ≥ 3μ). -/
-theorem long_n2_initial_avoids_final :
-    let result := longN2CompoundAccent 3 none 4  -- 3μ N1, 4μ unaccented N2
-    let totalMorae := 3 + 4
-    nonFinalitySigma result totalMorae = 0 := rfl
+/-- Short-N2 compound accent ([kawahara-2015] §4.1): a pre-accenting short
+    N2 puts the compound accent on the final position of N1 (its own accent,
+    if any, is lost to NonFinality); otherwise N2 retains its accent,
+    shifted by N1's length. -/
+def shortN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
+    (preAccenting : Bool) : Option ℕ :=
+  if preAccenting then
+    if n1Morae > 0 then some (n1Morae - 1) else none
+  else
+    n2Accent.map (· + n1Morae)
 
--- ============================================================================
--- § 6: Weight Sensitivity — Japanese as Weight-Sensitive
--- ============================================================================
+/-- Long-N2 compound accent ([kawahara-2015] §4.2): an unaccented or
+    finally-accented N2 receives N2-initial accent; otherwise N2's own
+    accent is retained. -/
+def longN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
+    (n2Morae : ℕ) : Option ℕ :=
+  match n2Accent with
+  | none => some n1Morae
+  | some pos =>
+    if pos + 1 = n2Morae then some n1Morae
+    else some (pos + n1Morae)
 
-/-- Japanese moraic structure: WBP is active (coda consonants are moraic).
-    This means coda nasals (/N/), geminate first halves (/Q/), and long
-    vowels all contribute to syllable weight. The weight sensitivity of
-    accent assignment (AAR/LSR) operates on these moraic weights.
+/-- NonFinality over an (accent, mora count) pair: one violation iff the
+    accent sits on the final mora ([prince-smolensky-1993]; [kawahara-2015]
+    §4.1 invokes it for the loss of final accent in compounds). Mora-level
+    rendering of NonFinality(σ) — the two coincide on light-final words. -/
+def nonFinality : Constraint (Option ℕ × ℕ) :=
+  Constraint.binary fun an => an.1 = some (an.2 - 1) ∧ 1 ≤ an.2
 
-    [kawahara-2015] §2.3: syllables with coda nasal, first part of
-    geminate, long vowel, or diphthong are bimoraic (heavy). Open
-    syllables with short vowels are monomoraic (light). -/
+/-- *ka'buto+musi → kabuto'+musi* 'beetle': the pre-accenting short N2 puts
+    accent on N1-final *to* ([kawahara-2015] (22a)). -/
+theorem kabuto_musi_compound :
+    shortN2CompoundAccent 3 (some 0) true = some 2 := by decide
+
+/-- *si'n+yokohama → sin+yo'kohama* 'Shin-Yokohama': unaccented long N2
+    receives N2-initial accent ([kawahara-2015] (23a)). -/
+theorem sin_yokohama_compound :
+    longN2CompoundAccent 2 none 4 = some 2 := by decide
+
+/-- *si'n+tamane'gi → sin+tamane'gi* 'new onion': a long N2 with nonfinal
+    accent retains it ([kawahara-2015] (24a)). -/
+theorem sin_tamanegi_compound :
+    longN2CompoundAccent 2 (some 2) 4 = some 4 := by decide
+
+/-- A nonfinal (or absent) accent satisfies `nonFinality`. -/
+theorem nonFinality_eq_zero {acc : Option ℕ} {n : ℕ} (h : ∀ p ∈ acc, p + 1 ≠ n) :
+    nonFinality (acc, n) = 0 := by
+  rcases acc with _ | p
+  · simp [nonFinality, Constraint.binary]
+  · have hp := h p rfl
+    simp only [nonFinality, Constraint.binary_apply]
+    rw [if_neg]
+    rintro ⟨h1, h2⟩
+    simp only [Option.some.injEq] at h1
+    omega
+
+/-- Short-N2 pre-accenting never yields final accent: the new accent lands
+    on N1-final position and N2 intervenes, satisfying NonFinality
+    ([kawahara-2015] §4.1). -/
+theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
+    (h : 1 ≤ n2Morae) :
+    nonFinality (shortN2CompoundAccent n1Morae n2Accent true, n1Morae + n2Morae) = 0 := by
+  refine nonFinality_eq_zero fun p hp => ?_
+  have hp' : p ∈ (if n1Morae > 0 then some (n1Morae - 1) else none) := hp
+  split_ifs at hp' with h1
+  · rw [Option.mem_some_iff] at hp'
+    omega
+  · exact absurd hp' (by simp)
+
+/-- Long-N2 compound accent never yields final accent: unaccented and
+    finally-accented N2s get N2-initial accent (nonfinal since N2 ≥ 3μ), and
+    retained accents are nonfinal in N2 ([kawahara-2015] §4.2). -/
+theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
+    (h2 : 3 ≤ n2Morae) (hacc : ∀ p ∈ n2Accent, p < n2Morae) :
+    nonFinality (longN2CompoundAccent n1Morae n2Accent n2Morae, n1Morae + n2Morae) = 0 := by
+  refine nonFinality_eq_zero fun p hp => ?_
+  rcases n2Accent with _ | pos
+  · have hp' : p ∈ (some n1Morae : Option ℕ) := hp
+    rw [Option.mem_some_iff] at hp'
+    omega
+  · have hlt := hacc pos rfl
+    have hp' : p ∈ (if pos + 1 = n2Morae then some n1Morae else some (pos + n1Morae)) := hp
+    split_ifs at hp' with hfin <;> rw [Option.mem_some_iff] at hp' <;> omega
+
+/-! ### Weight sensitivity (§2.3)
+
+Japanese moraic structure: coda nasals, geminate first halves, long vowels,
+and diphthongs are moraic, so closed syllables are heavy — the weight
+sensitivity the LSR analysis rests on. -/
+
+/-- With Weight-by-Position active, any CVC syllable is heavy (e.g. /tan/ =
+    2μ), for arbitrary segments ([kawahara-2015] §2.3). -/
 theorem japanese_wbp_active (o n c : Phonology.Segment) :
-    -- CVC with WBP is heavy (e.g., /tan/ = 2μ)
-    (Prosody.Syllable.ofCV [o] [n] [c] true).weight = .heavy := rfl
+    (Syllable.ofCV [o] [n] [c] true).weight = .heavy := rfl
 
 end Kawahara2015


### PR DESCRIPTION
Deep audit of `Studies/Kawahara2015.lean` against the published chapter, consolidating the paper's content out of the Japanese prosody fragment.

- Data fixes against the sources: *makudonarudo* is 6μ with accent on μ3 (10h); *amai* 'sweet' and *mame'* 'beans' had inverted accent values (Kawahara (28), B&P Fig. 6/8); unaccented *ame* is 'candy', not 'rain' (1a–b); ungrounded *kami* pair replaced by the attested *ame ~ a'me* pair.
- Layering: fragment no longer imports `Studies.BeckmanPierrehumbert1986` (AP bridge moved there as `AccentualPhrase.ofWords`); AAR/LSR/tone/compound rules and Table-1/loanword/compound theorems consolidated into the study file; dead `JSuffixAccent` parallel API (whose `-si` theorem contradicted (31b–d)) removed; `J`-prefixed type names dropped.
- New: general culminativity theorem `accentToTones_culminative` (≤ 1 HL fall for every accent location and word length, sorry-free); NonFinality stated as a `Constraints.Constraint`; `latinStressRule` given kernel-computable closed form; vacuous by-construction culminativity theorem deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)