### PR TITLE
style(Studies/Kawahara2015): 2-sentence docstring; prefix-sum AAR

### DIFF
--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -24,23 +24,13 @@ open Prosody Japanese.Prosody Constraints
 Language-neutral accent-placement rules over a syllable-weight profile,
 compared on loanword default accentuation (§2). -/
 
-private def findSyllable (weights : List Syllable.Weight) (targetMora : ℕ) : Option ℕ :=
-  go weights targetMora 0
-where
-  go : List Syllable.Weight → ℕ → ℕ → Option ℕ
-    | [], _, _ => none
-    | w :: ws, target, idx => if target < w then some idx else go ws (target - w) (idx + 1)
-
 /-- The antepenultimate accent rule, which accents the syllable containing
     the antepenultimate mora and the initial syllable of shorter words
     ([mccawley-1968]). Returns the 0-indexed syllable. -/
 def defaultAccentAAR (weights : List Syllable.Weight) : Option ℕ :=
   match weights with
   | [] => none
-  | _ =>
-    let totalMorae := weights.foldl (· + ·) 0
-    let targetMora := if totalMorae ≥ 3 then totalMorae - 3 else 0
-    findSyllable weights targetMora
+  | _ => some ((weights.scanl (· + ·) 0).tail.findIdx (weights.sum - 3 < ·))
 
 /-- The Latin Stress Rule, which accents a heavy (≥ 2μ) penult and the
     antepenult otherwise, with mono- and disyllables accented initially

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -5,15 +5,14 @@ import Linglib.Fragments.Japanese.Prosody
 /-!
 # Kawahara (2015) [kawahara-2015]
 
-Tokyo Japanese pitch accent, after the survey *The phonology of Japanese
-accent*. The antepenultimate accent rule ([mccawley-1968]) and the Latin
-Stress Rule ([hayes-1995]) agree on six of Table 1's eight trisyllabic
-weight conditions and diverge exactly on HLH and LLH; the accent-to-tone
-derivation (accentual HL, initial rise, spreading) determines surface tones
-and is culminative — at most one HL fall per word, for every accent
-location and length (`accentToTones_culminative`); the eight-way affix
-accent typology projects onto the coarse dominant/recessive split; and both
-compound-accent rules satisfy NonFinality ([prince-smolensky-1993]).
+*The phonology of Japanese accent* surveys Tokyo Japanese pitch accent: a
+single lexical accent per word determines the surface tone contour, and its
+location is predictable in loanwords, compounds, and affixed words. This
+file formalizes the survey's core generalizations — the Table 1 comparison
+of the antepenultimate accent rule ([mccawley-1968]) with the Latin Stress
+Rule ([hayes-1995]), the accent-to-tone derivation and its culminativity
+(`accentToTones_culminative`), the eight-way affix accent typology, and
+NonFinality ([prince-smolensky-1993]) in compound accent.
 -/
 
 namespace Kawahara2015


### PR DESCRIPTION
Follow-up to #2013: module docstring cut to two sentences (paper claim + what is formalized), and `findSyllable`'s accumulator helper dissolved — the AAR is now a `findIdx` over prefix sums, with Nat subtraction absorbing the short-word guard. All `decide` theorems re-verify unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)