### PR TITLE
style(Studies/Kawahara2015): one-line Latin Stress Rule

### DIFF
--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -52,10 +52,7 @@ def latinStressRule (weights : List Syllable.Weight) : Option ℕ :=
   match weights with
   | [] => none
   | _ =>
-    if weights.length ≤ 2 then some 0
-    else if Syllable.Weight.heavy ≤ weights.getD (weights.length - 2) 0 then
-      some (weights.length - 2)
-    else some (weights.length - 3)
+    some (weights.length - if Syllable.Weight.heavy ≤ weights.reverse.getD 1 0 then 2 else 3)
 
 /-- The eight trisyllabic weight conditions of Table 1. -/
 def trisyllabicConditions : List (List Syllable.Weight) :=


### PR DESCRIPTION
The `length ≤ 2` guard is redundant under Nat truncated subtraction (both `length − 2` and `length − 3` are already 0), and the penult reads more directly as `reverse.getD 1` than as `getD (length − 2)` — the rule collapses to accenting `2` or `3` back from the word edge by penult weight. All `decide` theorems re-verify unchanged. Independent of #2014 (different hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)