### PR TITLE
style(Studies/Kawahara2015): spread as scanl; compound-rule golf

### DIFF
--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -179,50 +179,31 @@ theorem trisyllabic_tone_patterns :
 `accentToTones_culminative` derives this for every accent location and word
 length. -/
 
-/-- The number of H-to-L falls in a tone string. -/
-def hlFallCount : List LevelTone → ℕ
-  | .H :: .L :: rest => hlFallCount (.L :: rest) + 1
-  | _ :: rest => hlFallCount rest
-  | [] => 0
-
-theorem count_L_tail_le : ∀ l : List LevelTone, l.tail.count .L ≤ l.count .L
-  | [] => Nat.le_refl _
-  | .H :: _ => by rw [List.tail_cons, List.count_cons_of_ne (by decide)]
-  | .L :: _ => by rw [List.tail_cons, List.count_cons_self]; exact Nat.le_succ _
+/-- The number of H-to-L falls in a tone string — the occurrences of
+    `(H, L)` among adjacent pairs. -/
+def hlFallCount (l : List LevelTone) : ℕ := (l.zip l.tail).count (.H, .L)
 
 /-- An L head opens no fall. -/
 theorem hlFallCount_L_cons (l : List LevelTone) :
     hlFallCount (.L :: l) = hlFallCount l := by
-  cases l with
-  | nil => rfl
-  | cons b rest => cases b <;> rfl
-
-/-- Every fall consumes an L strictly after the first position. -/
-theorem hlFallCount_le_count_tail :
-    ∀ l : List LevelTone, hlFallCount l ≤ l.tail.count .L
-  | [] => Nat.le_refl _
-  | [t] => by cases t <;> simp [hlFallCount]
-  | .H :: .L :: rest => by
-      have ih := hlFallCount_le_count_tail (.L :: rest)
-      rw [show hlFallCount (.H :: .L :: rest) = hlFallCount (.L :: rest) + 1 from rfl,
-        List.tail_cons, List.count_cons_self]
-      rw [List.tail_cons] at ih
-      omega
-  | .H :: .H :: rest => by
-      have ih := hlFallCount_le_count_tail (.H :: rest)
-      rw [show hlFallCount (.H :: .H :: rest) = hlFallCount (.H :: rest) from rfl,
-        List.tail_cons, List.count_cons_of_ne (by decide)]
-      rw [List.tail_cons] at ih
-      exact ih
-  | .L :: b :: rest => by
-      have ih := hlFallCount_le_count_tail (b :: rest)
-      rw [hlFallCount_L_cons, List.tail_cons]
-      exact ih.trans (count_L_tail_le _)
+  cases l <;> simp [hlFallCount]
 
 theorem hlFallCount_cons_cons (t u : LevelTone) (l : List LevelTone) :
     hlFallCount (t :: u :: l) =
       hlFallCount (u :: l) + if t = .H ∧ u = .L then 1 else 0 := by
   cases t <;> cases u <;> simp [hlFallCount]
+
+/-- Every fall consumes an L strictly after the first position. -/
+theorem hlFallCount_le_count_tail :
+    ∀ l : List LevelTone, hlFallCount l ≤ l.tail.count .L
+  | [] => Nat.le_refl _
+  | [_] => by simp [hlFallCount]
+  | t :: u :: rest => by
+      have ih := hlFallCount_le_count_tail (u :: rest)
+      rw [hlFallCount_cons_cons, List.tail_cons]
+      rw [List.tail_cons] at ih
+      cases t <;> cases u <;> simp_all
+      omega
 
 /-- Spreading is fall-invariant, since copying a tone neither creates nor
     destroys an HL fall. -/
@@ -230,7 +211,7 @@ theorem hlFallCount_cons_scanl (spec : List (Option LevelTone)) (x t : LevelTone
     hlFallCount (x :: spec.scanl (fun t o => o.getD t) t) =
       hlFallCount (x :: t :: spec.filterMap id) := by
   induction spec generalizing x t with
-  | nil => cases x <;> cases t <;> rfl
+  | nil => rfl
   | cons o rest ih =>
     cases o with
     | some u =>

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -1,4 +1,5 @@
 import Linglib.Phonology.Prosody.Syllable
+import Mathlib.Data.Nat.PSub
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Fragments.Japanese.Prosody
 
@@ -327,70 +328,60 @@ The traditional dichotomy by N2 length: short N2s (≤ 2μ) either retain
 accent or pre-accent the N1-final position; long N2s (≥ 3μ) take N2-initial
 accent unless their own accent is nonfinal. Both rules are stated over mora
 counts; the paper's rules target syllables, and the two coincide on the
-light-syllable data of (22)–(24) formalized below. -/
+light-syllable data of (21)–(24) formalized below. -/
 
-/-- The compound accent under a short (≤ 2μ) N2, which either pre-accents
-    the N1-final position, its own accent lost to NonFinality, or retains
-    its accent shifted by N1's length (§4.1). -/
-def shortN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
-    (preAccenting : Bool) : Option ℕ :=
-  if preAccenting then
-    match n1Morae with
-    | 0 => none
-    | n + 1 => some n
-  else
-    n2Accent.map (· + n1Morae)
+/-- A retaining short N2 keeps its own accent, shifted into the compound
+    (§4.1, (21)). -/
+def shortN2Retain (n1Morae : ℕ) (n2Accent : Option ℕ) : Option ℕ :=
+  n2Accent.map (n1Morae + ·)
+
+/-- A pre-accenting short N2 accents the N1-final mora — the partial
+    predecessor of N1's length — its own accent lost to NonFinality
+    (§4.1, (22)). -/
+def shortN2PreAccent (n1Morae : ℕ) : Option ℕ :=
+  n1Morae.ppred
 
 /-- The compound accent under a long (≥ 3μ) N2, which receives N2-initial
     accent when unaccented or finally-accented and otherwise retains its
     own accent (§4.2). -/
-def longN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
-    (n2Morae : ℕ) : Option ℕ :=
+def longN2CompoundAccent (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ) : Option ℕ :=
   some (n1Morae + (n2Accent.filter (· + 1 != n2Morae)).getD 0)
 
 /-- The NonFinality constraint over an (accent, mora count) pair, violated
     once when the accent sits on the final mora ([prince-smolensky-1993];
     §4.1 invokes it for the loss of final accent in compounds). -/
 def nonFinality : Constraint (Option ℕ × ℕ) :=
-  Constraint.binary fun an => an.1 = some (an.2 - 1) ∧ 1 ≤ an.2
+  Constraint.binary fun an => an.1.map (· + 1) = some an.2
+
+/-- In *fa'asuto+ki'su → faasuto+ki'su* 'first kiss', the short N2 retains
+    its accent on *ki* ((21a)). -/
+theorem faasuto_kisu_compound : shortN2Retain 4 (some 0) = some 4 := rfl
 
 /-- In *ka'buto+musi → kabuto'+musi* 'beetle', the pre-accenting short N2
     puts the accent on N1-final *to* ((22a)). -/
-theorem kabuto_musi_compound :
-    shortN2CompoundAccent 3 (some 0) true = some 2 := by decide
+theorem kabuto_musi_compound : shortN2PreAccent 3 = some 2 := rfl
 
 /-- In *si'n+yokohama → sin+yo'kohama* 'Shin-Yokohama', the unaccented long
     N2 receives N2-initial accent ((23a)). -/
-theorem sin_yokohama_compound :
-    longN2CompoundAccent 2 none 4 = some 2 := by decide
+theorem sin_yokohama_compound : longN2CompoundAccent 2 4 none = some 2 := rfl
 
 /-- In *si'n+tamane'gi → sin+tamane'gi* 'new onion', the long N2 retains
     its nonfinal accent ((24a)). -/
-theorem sin_tamanegi_compound :
-    longN2CompoundAccent 2 (some 2) 4 = some 4 := by decide
+theorem sin_tamanegi_compound : longN2CompoundAccent 2 4 (some 2) = some 4 := rfl
 
-/-- A nonfinal (or absent) accent satisfies `nonFinality`. -/
-theorem nonFinality_eq_zero {acc : Option ℕ} {n : ℕ} (h : ∀ p ∈ acc, p + 1 ≠ n) :
-    nonFinality (acc, n) = 0 := by
-  rcases acc with _ | p
-  · simp [nonFinality, Constraint.binary]
-  · have hp := h p rfl
-    simp only [nonFinality, Constraint.binary_apply]
-    rw [if_neg]
-    rintro ⟨h1, h2⟩
-    simp only [Option.some.injEq] at h1
-    omega
+/-- `nonFinality` is satisfied exactly when the accent's successor is not
+    the mora count. -/
+@[simp] theorem nonFinality_eq_zero {acc : Option ℕ} {n : ℕ} :
+    nonFinality (acc, n) = 0 ↔ acc.map (· + 1) ≠ some n := by
+  simp [nonFinality, Constraint.binary]
 
 /-- Short-N2 pre-accenting never yields final accent, since the new accent
     lands on the N1-final position and N2 intervenes (§4.1). -/
-theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
-    (h : 1 ≤ n2Morae) :
-    nonFinality (shortN2CompoundAccent n1Morae n2Accent true, n1Morae + n2Morae) = 0 := by
-  refine nonFinality_eq_zero fun p hp => ?_
+theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (h : 1 ≤ n2Morae) :
+    nonFinality (shortN2PreAccent n1Morae, n1Morae + n2Morae) = 0 := by
   rcases n1Morae with _ | k
-  · exact absurd (show p ∈ (none : Option ℕ) from hp) (by simp)
-  · have hp' : p ∈ (some k : Option ℕ) := hp
-    rw [Option.mem_some_iff] at hp'
+  · simp [shortN2PreAccent, Nat.ppred_zero]
+  · simp [shortN2PreAccent, Nat.ppred_succ]
     omega
 
 /-- Long-N2 compound accent never yields final accent, since unaccented and
@@ -398,20 +389,18 @@ theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option �
     nonfinal within N2 (§4.2). -/
 theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
     (h2 : 3 ≤ n2Morae) (hacc : ∀ p ∈ n2Accent, p < n2Morae) :
-    nonFinality (longN2CompoundAccent n1Morae n2Accent n2Morae, n1Morae + n2Morae) = 0 := by
-  refine nonFinality_eq_zero fun p hp => ?_
-  unfold longN2CompoundAccent at hp
-  rw [Option.mem_some_iff] at hp
+    nonFinality (longN2CompoundAccent n1Morae n2Morae n2Accent, n1Morae + n2Morae) = 0 := by
   rcases n2Accent with _ | pos
-  · simp only [Option.filter_none, Option.getD_none] at hp
+  · simp [longN2CompoundAccent, Option.filter_none]
     omega
   · have hlt := hacc pos rfl
-    simp only [Option.filter_some] at hp
-    split_ifs at hp with hfin
+    simp only [longN2CompoundAccent, nonFinality_eq_zero, Option.filter_some,
+      Option.map_some, ne_eq, Option.some.injEq]
+    split_ifs with hfin
     · rw [bne_iff_ne] at hfin
-      simp only [Option.getD_some] at hp
+      simp only [Option.getD_some]
       omega
-    · simp only [Option.getD_none] at hp
+    · simp only [Option.getD_none]
       omega
 
 end Kawahara2015

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -1,4 +1,5 @@
 import Linglib.Phonology.Prosody.Syllable
+import Mathlib.Data.List.ReduceOption
 import Mathlib.Data.Nat.PSub
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Fragments.Japanese.Prosody
@@ -205,26 +206,26 @@ theorem hlFallCount_le_count_tail :
       cases t <;> cases u <;> simp_all
       omega
 
+/-- Stuttering a tone creates no fall. -/
+theorem hlFallCount_cons_self (t : LevelTone) (l : List LevelTone) :
+    hlFallCount (t :: t :: l) = hlFallCount (t :: l) := by
+  cases t <;> simp [hlFallCount]
+
 /-- Spreading is fall-invariant, since copying a tone neither creates nor
     destroys an HL fall. -/
 theorem hlFallCount_cons_scanl (spec : List (Option LevelTone)) (x t : LevelTone) :
     hlFallCount (x :: spec.scanl (fun t o => o.getD t) t) =
-      hlFallCount (x :: t :: spec.filterMap id) := by
+      hlFallCount (x :: t :: spec.reduceOption) := by
   induction spec generalizing x t with
   | nil => rfl
   | cons o rest ih =>
     cases o with
     | some u =>
-      simp only [List.scanl_cons, Option.getD_some,
-        show (some u :: rest).filterMap id = u :: rest.filterMap id from rfl]
+      simp only [List.scanl_cons, Option.getD_some, List.reduceOption_cons_of_some]
       rw [hlFallCount_cons_cons, hlFallCount_cons_cons, ih t u]
     | none =>
-      have hδ : (if t = LevelTone.H ∧ t = LevelTone.L then 1 else 0) = 0 := by
-        cases t <;> simp
-      simp only [List.scanl_cons, Option.getD_none,
-        show (none :: rest).filterMap id = rest.filterMap id from rfl]
-      rw [hlFallCount_cons_cons, hlFallCount_cons_cons, ih t t,
-        hlFallCount_cons_cons, hδ, Nat.add_zero]
+      simp only [List.scanl_cons, Option.getD_none, List.reduceOption_cons_of_none]
+      rw [hlFallCount_cons_cons, hlFallCount_cons_cons, ih t t, hlFallCount_cons_self]
 
 /-- Mora 0 is always specified, as H under initial accent and otherwise as
     the initial-rise L. -/
@@ -277,7 +278,9 @@ theorem accentToTones_culminative (a : Option ℕ) (n : ℕ) :
         List.scanl_cons, List.tail_cons, Option.getD_some]
     rw [hpeel, ← hlFallCount_L_cons, hlFallCount_cons_scanl, hlFallCount_L_cons]
     refine (hlFallCount_le_count_tail _).trans ?_
-    rw [List.tail_cons, List.filterMap_map, Function.id_comp]
+    rw [List.tail_cons]
+    simp only [List.reduceOption]
+    rw [List.filterMap_map, Function.id_comp]
     exact count_L_toneSpec_dense a _
       (List.nodup_range.map Nat.succ_injective)
       (fun j hj => by

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -242,28 +242,19 @@ theorem toneSpec_eq_L {a : Option ℕ} {j : ℕ} (hj : 1 ≤ j) :
 
 /-- The specified tones after mora 0 contain at most one L, since the
     post-accent L pins the accent location and positions are distinct. -/
-theorem count_L_toneSpec_dense (a : Option ℕ) :
-    ∀ l : List ℕ, l.Nodup → (∀ j ∈ l, 1 ≤ j) →
-      (l.filterMap (toneSpec a)).count .L ≤ 1 := by
-  intro l
-  induction l with
-  | nil => simp
-  | cons j rest ih =>
-    intro hnd hpos
-    rw [List.filterMap_cons]
-    rcases hj : toneSpec a j with _ | t
-    · exact ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
-    rcases t with _ | _
-    · simpa [List.count_cons] using ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
-    · have ha : a.map (· + 1) = some j := (toneSpec_eq_L (hpos j (.head _))).mp hj
-      have hrest : (rest.filterMap (toneSpec a)).count .L = 0 := by
-        rw [List.count_eq_zero]
-        intro hmem
-        obtain ⟨k, hk, hspec⟩ := List.mem_filterMap.mp hmem
-        have hak : a.map (· + 1) = some k := (toneSpec_eq_L (hpos k (.tail _ hk))).mp hspec
-        rw [ha] at hak
-        exact (List.nodup_cons.mp hnd).1 ((Option.some_inj.mp hak) ▸ hk)
-      simp [hrest]
+theorem count_L_toneSpec_dense (a : Option ℕ) (l : List ℕ) (hnd : l.Nodup)
+    (hpos : ∀ j ∈ l, 1 ≤ j) :
+    (l.filterMap (toneSpec a)).count .L ≤ 1 := by
+  rw [List.count_filterMap]
+  rcases a with _ | p
+  · rw [List.countP_eq_zero.mpr fun j hj => by simp [toneSpec_eq_L (hpos j hj)]]
+    exact Nat.zero_le _
+  · rw [List.countP_congr (q := (· == p + 1)) fun j hj => by
+        simp only [beq_iff_eq, toneSpec_eq_L (hpos j hj), Option.map_some,
+          Option.some.injEq]
+        omega,
+      ← List.count_eq_countP]
+    exact List.nodup_iff_count_le_one.mp hnd _
 
 /-- A word carries at most one HL fall, whatever its accent location and
     length (culminativity, §1.4). -/
@@ -271,21 +262,18 @@ theorem accentToTones_culminative (a : Option ℕ) (n : ℕ) :
     hlFallCount (accentToTones a n) ≤ 1 := by
   obtain _ | m := n
   · exact Nat.zero_le _
-  · have hpeel : accentToTones a (m + 1) =
-        (((List.range m).map Nat.succ).map (toneSpec a)).scanl (fun t o => o.getD t)
-          (if a = some 0 then LevelTone.H else .L) := by
-      simp only [accentToTones, List.range_succ_eq_map, List.map_cons, toneSpec_zero,
+  · obtain ⟨t₀, ht₀⟩ : ∃ t, toneSpec a 0 = some t := ⟨_, toneSpec_zero a⟩
+    have hpeel : accentToTones a (m + 1) =
+        (((List.range m).map Nat.succ).map (toneSpec a)).scanl (fun t o => o.getD t) t₀ := by
+      simp only [accentToTones, List.range_succ_eq_map, List.map_cons, ht₀,
         List.scanl_cons, List.tail_cons, Option.getD_some]
     rw [hpeel, ← hlFallCount_L_cons, hlFallCount_cons_scanl, hlFallCount_L_cons]
     refine (hlFallCount_le_count_tail _).trans ?_
     rw [List.tail_cons]
     simp only [List.reduceOption]
     rw [List.filterMap_map, Function.id_comp]
-    exact count_L_toneSpec_dense a _
-      (List.nodup_range.map Nat.succ_injective)
-      (fun j hj => by
-        obtain ⟨k, -, rfl⟩ := List.mem_map.mp hj
-        exact Nat.succ_le_succ k.zero_le)
+    exact count_L_toneSpec_dense a _ (List.nodup_range.map Nat.succ_injective)
+      fun j hj => by simp only [List.mem_map] at hj; omega
 
 /-! ### Compound accent (§4)
 

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -131,23 +131,27 @@ inductive LevelTone where
   | L
   deriving DecidableEq, Repr
 
-/-- The tonal specification of mora `i` (0-indexed) before spreading
-    ((4)–(5)). The accented mora is H and its successor L (accentual HL),
-    while mora 0 is L and mora 1 H (initial rise) unless the accentual
-    tones win, and other moras are unspecified. -/
-def toneSpec (accentMora : Option ℕ) (i : ℕ) : Option LevelTone :=
+/-- The accentual HL — H on the accented mora, L on its successor ((4)). -/
+def accentualHL (accentMora : Option ℕ) (i : ℕ) : Option LevelTone :=
   if accentMora = some i then some .H
-  else if 1 ≤ i ∧ accentMora = some (i - 1) then some .L
-  else if i = 0 then some .L
-  else if i = 1 then some .H
+  else if accentMora.map (· + 1) = some i then some .L
   else none
+
+/-- The initial rise — L on mora 0, H on mora 1 ((5)). -/
+def initialRise (i : ℕ) : Option LevelTone :=
+  if i = 0 then some .L else if i = 1 then some .H else none
+
+/-- The tonal specification of mora `i` before spreading, with the
+    accentual HL taking precedence over the initial rise ((5b)). -/
+def toneSpec (accentMora : Option ℕ) (i : ℕ) : Option LevelTone :=
+  (accentualHL accentMora i).or (initialRise i)
 
 /-- The surface tones of an `nMorae`-word from its accent position, by
     specification (`toneSpec`) followed by spreading — a left scan copying
     the most recent specified tone rightward ((7)–(9)). The seed is never
     consulted, since mora 0 is always specified. -/
 def accentToTones (accentMora : Option ℕ) (nMorae : ℕ) : List LevelTone :=
-  ((((List.range nMorae).map (toneSpec accentMora)).scanl (fun t o => o.getD t)) .H).tail
+  (((List.range nMorae).map (toneSpec accentMora)).scanl (fun t o => o.getD t) .H).tail
 
 /-- Unaccented *ame(+ga)* 'candy' surfaces LHH by initial rise and
     spreading ((6b)). -/
@@ -160,13 +164,11 @@ theorem ameRain_ga_tones : accentToTones ameRain.accentMora 3 = [.H, .L, .L] := 
   decide
 
 /-- Of the n+1 accent patterns of a trisyllable ((3)), the unaccented,
-    initial, and medial ones are pairwise distinct, while final accent
+    initial, and medial contours are distinct, while final accent
     neutralizes with unaccentedness word-internally because the post-accent
     L falls off the word edge (§1.4). -/
 theorem trisyllabic_tone_patterns :
-    accentToTones none 3 ≠ accentToTones (some 0) 3 ∧
-      accentToTones none 3 ≠ accentToTones (some 1) 3 ∧
-      accentToTones (some 0) 3 ≠ accentToTones (some 1) 3 ∧
+    [accentToTones none 3, accentToTones (some 0) 3, accentToTones (some 1) 3].Nodup ∧
       accentToTones none 3 = accentToTones (some 2) 3 := by decide
 
 /-! ### Culminativity
@@ -245,15 +247,14 @@ theorem hlFallCount_cons_scanl (spec : List (Option LevelTone)) (x t : LevelTone
     the initial-rise L. -/
 theorem toneSpec_zero (a : Option ℕ) :
     toneSpec a 0 = some (if a = some 0 then .H else .L) := by
-  by_cases h : a = some 0 <;> simp [toneSpec, h]
+  by_cases h : a = some 0 <;> simp [toneSpec, accentualHL, initialRise, h]
 
 /-- After mora 0, the only source of a specified L is the post-accent L,
     which pins the accent location. -/
 theorem toneSpec_eq_L {a : Option ℕ} {j : ℕ} (hj : 1 ≤ j) :
-    toneSpec a j = some .L ↔ a = some (j - 1) := by
-  unfold toneSpec
-  split_ifs with h1 h2 <;> simp_all
-  omega
+    toneSpec a j = some .L ↔ a.map (· + 1) = some j := by
+  unfold toneSpec accentualHL initialRise
+  split_ifs with h1 h2 <;> simp_all [Option.or]
 
 /-- The specified tones after mora 0 contain at most one L, since the
     post-accent L pins the accent location and positions are distinct. -/
@@ -270,19 +271,14 @@ theorem count_L_toneSpec_dense (a : Option ℕ) :
     · exact ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
     rcases t with _ | _
     · simpa [List.count_cons] using ih hnd.of_cons fun k hk => hpos k (.tail _ hk)
-    · have ha : a = some (j - 1) := (toneSpec_eq_L (hpos j (.head _))).mp hj
+    · have ha : a.map (· + 1) = some j := (toneSpec_eq_L (hpos j (.head _))).mp hj
       have hrest : (rest.filterMap (toneSpec a)).count .L = 0 := by
         rw [List.count_eq_zero]
         intro hmem
         obtain ⟨k, hk, hspec⟩ := List.mem_filterMap.mp hmem
-        have hk1 := hpos k (.tail _ hk)
-        have hak : a = some (k - 1) := (toneSpec_eq_L hk1).mp hspec
-        have hj1 := hpos j (.head _)
-        have hkj : k = j := by
-          rw [ha] at hak
-          simp only [Option.some.injEq] at hak
-          omega
-        exact (List.nodup_cons.mp hnd).1 (hkj ▸ hk)
+        have hak : a.map (· + 1) = some k := (toneSpec_eq_L (hpos k (.tail _ hk))).mp hspec
+        rw [ha] at hak
+        exact (List.nodup_cons.mp hnd).1 ((Option.some_inj.mp hak) ▸ hk)
       simp [hrest]
 
 /-- A word carries at most one HL fall, whatever its accent location and

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -414,15 +414,4 @@ theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
     · simp only [Option.getD_none] at hp
       omega
 
-/-! ### Weight sensitivity (§2.3)
-
-Japanese moraic structure: coda nasals, geminate first halves, long vowels,
-and diphthongs are moraic, so closed syllables are heavy — the weight
-sensitivity the LSR analysis rests on. -/
-
-/-- With Weight-by-Position active, a CVC syllable is heavy regardless of
-    its segments, e.g. /tan/ = 2μ (§2.3). -/
-theorem japanese_wbp_active (o n c : Phonology.Segment) :
-    (Syllable.ofCV [o] [n] [c] true).weight = .heavy := rfl
-
 end Kawahara2015

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -12,8 +12,9 @@ location is predictable in loanwords, compounds, and affixed words. This
 file formalizes the survey's core generalizations — the Table 1 comparison
 of the antepenultimate accent rule ([mccawley-1968]) with the Latin Stress
 Rule ([hayes-1995]), the accent-to-tone derivation and its culminativity
-(`accentToTones_culminative`), the eight-way affix accent typology, and
-NonFinality ([prince-smolensky-1993]) in compound accent.
+(`accentToTones_culminative`), and NonFinality ([prince-smolensky-1993]) in
+compound accent. The §6 affix accent lexicon lives in
+`Fragments/Japanese/Prosody.lean`.
 -/
 
 namespace Kawahara2015
@@ -301,26 +302,6 @@ theorem accentToTones_culminative (a : Option ℕ) (n : ℕ) :
       (fun j hj => by
         obtain ⟨k, -, rfl⟩ := List.mem_map.mp hj
         exact Nat.succ_le_succ k.zero_le)
-
-/-! ### Affix accent typology (§6)
-
-The eight affix accent types and their projection to the coarse
-dominant/recessive split. -/
-
-/-- The eight affix types project onto the coarse dominant/recessive
-    distinction, with three preserving root accent when present (recessive,
-    recessive pre-accenting, accent-shifting) and five overriding it
-    (§6). -/
-theorem affix_typology_coarse_partition :
-    taraSuffix.accentType.toProsodicDominance = .recessive ∧
-      siSuffix.accentType.toProsodicDominance = .recessive ∧
-      monoSuffix.accentType.toProsodicDominance = .recessive ∧
-      ppoiSuffix.accentType.toProsodicDominance = .dominant ∧
-      keSuffix.accentType.toProsodicDominance = .dominant ∧
-      oPrefix.accentType.toProsodicDominance = .dominant ∧
-      tekiSuffix.accentType.toProsodicDominance = .dominant ∧
-      zuSuffix.accentType.toProsodicDominance = .dominant :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-! ### Compound accent (§4)
 

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -384,23 +384,17 @@ theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (h : 1 ≤ n2Morae) :
   · simp [shortN2PreAccent, Nat.ppred_succ]
     omega
 
-/-- Long-N2 compound accent never yields final accent, since unaccented and
-    finally-accented N2s take N2-initial accent and retained accents are
-    nonfinal within N2 (§4.2). -/
-theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
-    (h2 : 3 ≤ n2Morae) (hacc : ∀ p ∈ n2Accent, p < n2Morae) :
+/-- Long-N2 compound accent never yields final accent, since retention is
+    filtered to N2-nonfinal accents and the N2-initial default is nonfinal
+    in a trimoraic-or-longer N2 (§4.2). -/
+theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ) (h2 : 3 ≤ n2Morae) :
     nonFinality (longN2CompoundAccent n1Morae n2Morae n2Accent, n1Morae + n2Morae) = 0 := by
-  rcases n2Accent with _ | pos
-  · simp [longN2CompoundAccent, Option.filter_none]
+  rcases hX : n2Accent.filter (· + 1 != n2Morae) with _ | pos
+  · simp [longN2CompoundAccent, hX]
     omega
-  · have hlt := hacc pos rfl
-    simp only [longN2CompoundAccent, nonFinality_eq_zero, Option.filter_some,
-      Option.map_some, ne_eq, Option.some.injEq]
-    split_ifs with hfin
-    · rw [bne_iff_ne] at hfin
-      simp only [Option.getD_some]
-      omega
-    · simp only [Option.getD_none]
-      omega
+  · have hpos := (Option.filter_eq_some_iff.mp hX).2
+    rw [bne_iff_ne] at hpos
+    simp [longN2CompoundAccent, hX]
+    omega
 
 end Kawahara2015

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -167,16 +167,11 @@ def toneSpec (accentMora : Option ℕ) (i : ℕ) : Option LevelTone :=
   else none
 
 /-- The surface tones of an `nMorae`-word from its accent position, by
-    specification (`toneSpec`) followed by spreading ((7)–(9)). -/
+    specification (`toneSpec`) followed by spreading — a left scan copying
+    the most recent specified tone rightward ((7)–(9)). The seed is never
+    consulted, since mora 0 is always specified. -/
 def accentToTones (accentMora : Option ℕ) (nMorae : ℕ) : List LevelTone :=
-  spread ((List.range nMorae).map (toneSpec accentMora)) .H
-where
-  /-- Rightward spreading into unspecified positions. The seed is never
-      consulted on well-formed input, since mora 0 is always specified. -/
-  spread : List (Option LevelTone) → LevelTone → List LevelTone
-    | [], _ => []
-    | some t :: rest, _ => t :: spread rest t
-    | none :: rest, last => last :: spread rest last
+  ((((List.range nMorae).map (toneSpec accentMora)).scanl (fun t o => o.getD t)) .H).tail
 
 /-- Unaccented *ame(+ga)* 'candy' surfaces LHH by initial rise and
     spreading ((6b)). -/
@@ -215,6 +210,13 @@ theorem count_L_tail_le : ∀ l : List LevelTone, l.tail.count .L ≤ l.count .L
   | .H :: _ => by rw [List.tail_cons, List.count_cons_of_ne (by decide)]
   | .L :: _ => by rw [List.tail_cons, List.count_cons_self]; exact Nat.le_succ _
 
+/-- An L head opens no fall. -/
+theorem hlFallCount_L_cons (l : List LevelTone) :
+    hlFallCount (.L :: l) = hlFallCount l := by
+  cases l with
+  | nil => rfl
+  | cons b rest => cases b <;> rfl
+
 /-- Every fall consumes an L strictly after the first position. -/
 theorem hlFallCount_le_count_tail :
     ∀ l : List LevelTone, hlFallCount l ≤ l.tail.count .L
@@ -234,9 +236,7 @@ theorem hlFallCount_le_count_tail :
       exact ih
   | .L :: b :: rest => by
       have ih := hlFallCount_le_count_tail (b :: rest)
-      have e : hlFallCount (.L :: b :: rest) = hlFallCount (b :: rest) := by
-        cases b <;> rfl
-      rw [e, List.tail_cons]
+      rw [hlFallCount_L_cons, List.tail_cons]
       exact ih.trans (count_L_tail_le _)
 
 theorem hlFallCount_cons_cons (t u : LevelTone) (l : List LevelTone) :
@@ -246,25 +246,24 @@ theorem hlFallCount_cons_cons (t u : LevelTone) (l : List LevelTone) :
 
 /-- Spreading is fall-invariant, since copying a tone neither creates nor
     destroys an HL fall. -/
-theorem hlFallCount_spread (spec : List (Option LevelTone)) (t : LevelTone) :
-    hlFallCount (t :: accentToTones.spread spec t) =
-      hlFallCount (t :: spec.filterMap id) := by
-  induction spec generalizing t with
-  | nil => rfl
+theorem hlFallCount_cons_scanl (spec : List (Option LevelTone)) (x t : LevelTone) :
+    hlFallCount (x :: spec.scanl (fun t o => o.getD t) t) =
+      hlFallCount (x :: t :: spec.filterMap id) := by
+  induction spec generalizing x t with
+  | nil => cases x <;> cases t <;> rfl
   | cons o rest ih =>
     cases o with
     | some u =>
-      rw [show accentToTones.spread (some u :: rest) t =
-            u :: accentToTones.spread rest u from rfl,
-        show (some u :: rest).filterMap id = u :: rest.filterMap id from rfl,
-        hlFallCount_cons_cons, hlFallCount_cons_cons, ih u]
+      simp only [List.scanl_cons, Option.getD_some,
+        show (some u :: rest).filterMap id = u :: rest.filterMap id from rfl]
+      rw [hlFallCount_cons_cons, hlFallCount_cons_cons, ih t u]
     | none =>
-      rw [show accentToTones.spread (none :: rest) t =
-            t :: accentToTones.spread rest t from rfl,
-        show (none :: rest).filterMap id = rest.filterMap id from rfl,
-        hlFallCount_cons_cons, ih t]
-      have hδ : (if t = .H ∧ t = .L then 1 else 0) = 0 := by cases t <;> simp
-      rw [hδ, Nat.add_zero]
+      have hδ : (if t = LevelTone.H ∧ t = LevelTone.L then 1 else 0) = 0 := by
+        cases t <;> simp
+      simp only [List.scanl_cons, Option.getD_none,
+        show (none :: rest).filterMap id = rest.filterMap id from rfl]
+      rw [hlFallCount_cons_cons, hlFallCount_cons_cons, ih t t,
+        hlFallCount_cons_cons, hδ, Nat.add_zero]
 
 /-- Mora 0 is always specified, as H under initial accent and otherwise as
     the initial-rise L. -/
@@ -317,12 +316,11 @@ theorem accentToTones_culminative (a : Option ℕ) (n : ℕ) :
   obtain _ | m := n
   · exact Nat.zero_le _
   · have hpeel : accentToTones a (m + 1) =
-        (if a = some 0 then LevelTone.H else .L) ::
-          accentToTones.spread (((List.range m).map Nat.succ).map (toneSpec a))
-            (if a = some 0 then LevelTone.H else .L) := by
-      rw [accentToTones, List.range_succ_eq_map, List.map_cons, toneSpec_zero]
-      rfl
-    rw [hpeel, hlFallCount_spread]
+        (((List.range m).map Nat.succ).map (toneSpec a)).scanl (fun t o => o.getD t)
+          (if a = some 0 then LevelTone.H else .L) := by
+      simp only [accentToTones, List.range_succ_eq_map, List.map_cons, toneSpec_zero,
+        List.scanl_cons, List.tail_cons, Option.getD_some]
+    rw [hpeel, ← hlFallCount_L_cons, hlFallCount_cons_scanl, hlFallCount_L_cons]
     refine (hlFallCount_le_count_tail _).trans ?_
     rw [List.tail_cons, List.filterMap_map, Function.id_comp]
     exact count_L_toneSpec_dense a _
@@ -365,7 +363,9 @@ light-syllable data of (22)–(24) formalized below. -/
 def shortN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
     (preAccenting : Bool) : Option ℕ :=
   if preAccenting then
-    if n1Morae > 0 then some (n1Morae - 1) else none
+    match n1Morae with
+    | 0 => none
+    | n + 1 => some n
   else
     n2Accent.map (· + n1Morae)
 
@@ -374,11 +374,7 @@ def shortN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
     own accent (§4.2). -/
 def longN2CompoundAccent (n1Morae : ℕ) (n2Accent : Option ℕ)
     (n2Morae : ℕ) : Option ℕ :=
-  match n2Accent with
-  | none => some n1Morae
-  | some pos =>
-    if pos + 1 = n2Morae then some n1Morae
-    else some (pos + n1Morae)
+  some (n1Morae + (n2Accent.filter (· + 1 != n2Morae)).getD 0)
 
 /-- The NonFinality constraint over an (accent, mora count) pair, violated
     once when the accent sits on the final mora ([prince-smolensky-1993];
@@ -419,11 +415,11 @@ theorem shortN2_preaccent_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option �
     (h : 1 ≤ n2Morae) :
     nonFinality (shortN2CompoundAccent n1Morae n2Accent true, n1Morae + n2Morae) = 0 := by
   refine nonFinality_eq_zero fun p hp => ?_
-  have hp' : p ∈ (if n1Morae > 0 then some (n1Morae - 1) else none) := hp
-  split_ifs at hp' with h1
-  · rw [Option.mem_some_iff] at hp'
+  rcases n1Morae with _ | k
+  · exact absurd (show p ∈ (none : Option ℕ) from hp) (by simp)
+  · have hp' : p ∈ (some k : Option ℕ) := hp
+    rw [Option.mem_some_iff] at hp'
     omega
-  · exact absurd hp' (by simp)
 
 /-- Long-N2 compound accent never yields final accent, since unaccented and
     finally-accented N2s take N2-initial accent and retained accents are
@@ -432,13 +428,19 @@ theorem longN2_nonfinal (n1Morae n2Morae : ℕ) (n2Accent : Option ℕ)
     (h2 : 3 ≤ n2Morae) (hacc : ∀ p ∈ n2Accent, p < n2Morae) :
     nonFinality (longN2CompoundAccent n1Morae n2Accent n2Morae, n1Morae + n2Morae) = 0 := by
   refine nonFinality_eq_zero fun p hp => ?_
+  unfold longN2CompoundAccent at hp
+  rw [Option.mem_some_iff] at hp
   rcases n2Accent with _ | pos
-  · have hp' : p ∈ (some n1Morae : Option ℕ) := hp
-    rw [Option.mem_some_iff] at hp'
+  · simp only [Option.filter_none, Option.getD_none] at hp
     omega
   · have hlt := hacc pos rfl
-    have hp' : p ∈ (if pos + 1 = n2Morae then some n1Morae else some (pos + n1Morae)) := hp
-    split_ifs at hp' with hfin <;> rw [Option.mem_some_iff] at hp' <;> omega
+    simp only [Option.filter_some] at hp
+    split_ifs at hp with hfin
+    · rw [bne_iff_ne] at hfin
+      simp only [Option.getD_some] at hp
+      omega
+    · simp only [Option.getD_none] at hp
+      omega
 
 /-! ### Weight sensitivity (§2.3)
 

--- a/Linglib/Studies/Kawahara2015.lean
+++ b/Linglib/Studies/Kawahara2015.lean
@@ -74,60 +74,50 @@ theorem aar_lsr_mismatch_llh :
 Loanwords lack lexical accent specifications, so their accentuation reveals
 the default pattern (§2.1; [kubozono-2006]). -/
 
-/-- A loanword entry paired with its syllable-weight profile. -/
-structure LoanwordEntry where
-  entry : ProsodicEntry
-  /-- Syllable weight profile (left to right) -/
-  weights : List Syllable.Weight
-  deriving Repr
+/-- The weight profile of an all-light loanword — one light syllable per
+    mora. -/
+def lightProfile (e : ProsodicEntry) : List Syllable.Weight :=
+  List.replicate e.nMorae .light
 
 /-- *ku-ri-su'-ma-su* 'Christmas', accented on the antepenultimate mora
     ((10a)). -/
-def kurisumasu : LoanwordEntry :=
-  { entry := { form := "kurisumasu", gloss := "Christmas"
-               accentMora := some 2, nMorae := 5 }
-    weights := [.light, .light, .light, .light, .light] }
+def kurisumasu : ProsodicEntry :=
+  { form := "kurisumasu", gloss := "Christmas", accentMora := some 2, nMorae := 5 }
 
 /-- *a-su-fa'-ru-to* 'asphalt', accented on the antepenultimate mora
     ((10g)). -/
-def asufaruto : LoanwordEntry :=
-  { entry := { form := "asufaruto", gloss := "asphalt"
-               accentMora := some 2, nMorae := 5 }
-    weights := [.light, .light, .light, .light, .light] }
+def asufaruto : ProsodicEntry :=
+  { form := "asufaruto", gloss := "asphalt", accentMora := some 2, nMorae := 5 }
 
 /-- *ma-ku-do-na'-ru-do* 'McDonald', accented on the antepenultimate mora
     ((10h)). -/
-def makudonarudo : LoanwordEntry :=
-  { entry := { form := "makudonarudo", gloss := "McDonald's"
-               accentMora := some 3, nMorae := 6 }
-    weights := [.light, .light, .light, .light, .light, .light] }
+def makudonarudo : ProsodicEntry :=
+  { form := "makudonarudo", gloss := "McDonald's", accentMora := some 3, nMorae := 6 }
 
 /-- *a.me.ri.ka* 'America', unaccented as a four-mora word with two final
     light non-epenthetic syllables ((16a)). -/
-def amerika : LoanwordEntry :=
-  { entry := { form := "amerika", gloss := "America"
-               accentMora := none, nMorae := 4 }
-    weights := [.light, .light, .light, .light] }
+def amerika : ProsodicEntry :=
+  { form := "amerika", gloss := "America", accentMora := none, nMorae := 4 }
 
 /-- The accented loanwords of (10) carry the accent the AAR assigns. -/
 theorem loanwords_match_aar :
-    defaultAccentAAR kurisumasu.weights = kurisumasu.entry.accentMora ∧
-      defaultAccentAAR asufaruto.weights = asufaruto.entry.accentMora ∧
-      defaultAccentAAR makudonarudo.weights = makudonarudo.entry.accentMora := by decide
+    defaultAccentAAR (lightProfile kurisumasu) = kurisumasu.accentMora ∧
+      defaultAccentAAR (lightProfile asufaruto) = asufaruto.accentMora ∧
+      defaultAccentAAR (lightProfile makudonarudo) = makudonarudo.accentMora := by decide
 
 /-- On all-light profiles the LSR agrees with the AAR, so the (10)
     loanwords match it as well (§2.3). -/
 theorem loanwords_match_lsr :
-    latinStressRule kurisumasu.weights = kurisumasu.entry.accentMora ∧
-      latinStressRule asufaruto.weights = asufaruto.entry.accentMora ∧
-      latinStressRule makudonarudo.weights = makudonarudo.entry.accentMora := by decide
+    latinStressRule (lightProfile kurisumasu) = kurisumasu.accentMora ∧
+      latinStressRule (lightProfile asufaruto) = asufaruto.accentMora ∧
+      latinStressRule (lightProfile makudonarudo) = makudonarudo.accentMora := by decide
 
 /-- Neither default rule derives *amerika*'s unaccentedness, as neither
     produces unaccented outputs (§2.3 n. 10). Four-mora light-final
     unaccentedness is §2.4's separate generalization. -/
 theorem amerika_beyond_default_rules :
-    defaultAccentAAR amerika.weights ≠ amerika.entry.accentMora ∧
-      latinStressRule amerika.weights ≠ amerika.entry.accentMora := by decide
+    defaultAccentAAR (lightProfile amerika) ≠ amerika.accentMora ∧
+      latinStressRule (lightProfile amerika) ≠ amerika.accentMora := by decide
 
 /-! ### From accent to surface tones (§1.4)
 


### PR DESCRIPTION
Elegance pass over the remaining definitions, same spirit as #2014/#2015 (held as draft).

- `accentToTones`: the bespoke `spread` where-helper is a stdlib left scan (`scanl (fun t o => o.getD t)`); `toneSpec` decomposed into the paper's two rules — `accentualHL` ((4)) and `initialRise` ((5)) — with `Option.or` as (5b)'s precedence; post-accent condition via `accentMora.map (· + 1)` (no truncated subtraction).
- `hlFallCount` is a zip-count: `(l.zip l.tail).count (.H, .L)` — kills the bespoke recursion, one helper lemma, and most case analysis in the culminativity chain.
- Compound accent: the short-N2 `Bool` split into the paper's two classes — `shortN2Retain` ((21), with new (21a) datum) and `shortN2PreAccent` (= `Nat.ppred`); `longN2CompoundAccent` as one `Option.filter`/`getD` line; `nonFinality` via the successor-map predicate, characterized by a simp-iff; `longN2_nonfinal` loses its in-range hypothesis (the filter makes NonFinality intrinsic) and proves via `Option.filter_eq_some_iff`.
- `LoanwordEntry` dissolved: the (10)/(16) words are plain `ProsodicEntry`s with the all-light profile derived (`lightProfile`), not duplicated.
- Deleted: the substrate-generic WBP theorem and the stipulation-echo affix-partition theorem (§6 is carried by the Features enum + fragment lexicon).

All `decide`/`rfl` theorems re-verify unchanged.