### PR TITLE
feat(Phonology/Constraints): binary_eq_zero_iff and binary_eq_one_iff

### DIFF
--- a/Linglib/Phonology/Constraints/Defs.lean
+++ b/Linglib/Phonology/Constraints/Defs.lean
@@ -52,6 +52,16 @@ theorem Constraint.binary_le_one (P : C → Prop) [DecidablePred P] (c : C) :
     Constraint.binary P c ≤ 1 := by
   simp only [Constraint.binary]; split <;> omega
 
+/-- A binary constraint is satisfied exactly when its predicate fails. -/
+theorem Constraint.binary_eq_zero_iff (P : C → Prop) [DecidablePred P] (c : C) :
+    Constraint.binary P c = 0 ↔ ¬P c := by
+  simp [Constraint.binary]
+
+/-- A binary constraint is violated exactly when its predicate holds. -/
+theorem Constraint.binary_eq_one_iff (P : C → Prop) [DecidablePred P] (c : C) :
+    Constraint.binary P c = 1 ↔ P c := by
+  simp [Constraint.binary]
+
 /-- Pull a constraint back along `f : C → D`: evaluate the `D`-constraint on the
 image. Lets a specific carrier reuse a constraint defined on a more general one. -/
 def Constraint.comap (f : C → D) (con : Constraint D) : Constraint C := con ∘ f


### PR DESCRIPTION
Satisfaction/violation characterizations for `Constraint.binary` — every binary-constraint consumer currently re-derives `= 0 ↔ ¬P` from the raw `if` (e.g. the NonFinality proofs in Studies/Kawahara2015). Untagged, since `binary_apply` already carries `@[simp]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)