### PR TITLE
fix(Fragments): Mandarin/Thai demonstratives expone donkey anaphora

### DIFF
--- a/Linglib/Fragments/Mandarin/Determiners.lean
+++ b/Linglib/Fragments/Mandarin/Determiners.lean
@@ -11,8 +11,9 @@ Quantifier phrases in Mandarin, following [kuo-yu-2012]'s GQ-theoretic
 inventory (§12.1) and [tsai-2015]'s strong/weak classification (§5.3),
 plus the definiteness-marking inventory: Mandarin has no overt articles —
 bare nouns serve unique definites, the demonstrative *nà* 'that'
-obligatorily expones anaphoric definites, and possession is marked with
-*de* ([jenks-2018], [moroney-2021]).
+obligatorily expones anaphoric definites including donkey anaphora, where
+bare nouns are impossible ([jenks-2018] §3.3), and possession is marked
+with *de* ([moroney-2021]).
 
 Existential (intersective) quantifiers — weak ([kuo-yu-2012] §12.1.1):
 - hěnduō 很多 (many)
@@ -158,10 +159,10 @@ theorem typical_classifier_is_default :
 /-! ### Definiteness marking -/
 
 /-- The Mandarin definiteness-relevant determiners are the demonstrative
-    *nà*, the obligatory exponent of anaphoric definites, and the possessive
-    *de*. -/
+    *nà*, the obligatory exponent of anaphoric definites including donkey
+    anaphora, and the possessive *de*. -/
 def inventory : Determiner.Inventory :=
-  [ .demonstrative { form := "na", deictic := .distal, definiteUses := [.anaphoric] },
+  [ .demonstrative { form := "na", deictic := .distal, definiteUses := [.anaphoric, .donkey] },
     .possessive { form := "de" } ]
 
 /-- Mandarin derives the `.markedAnaphoric` Moroney cell. -/

--- a/Linglib/Fragments/Thai/Determiners.lean
+++ b/Linglib/Fragments/Thai/Determiners.lean
@@ -3,22 +3,25 @@ import Linglib.Syntax.Category.Determiner.Basic
 /-!
 # Thai determiner inventory
 
-Thai patterns with Mandarin: bare nouns serve unique definites, the
-demonstrative *nán* 'that' obligatorily expones anaphoric definites, and
+Thai patterns with Mandarin ([jenks-2015]; [jenks-2018] reports identical
+facts): bare nouns serve unique definites, the demonstrative *nán* 'that'
+obligatorily expones anaphoric definites including donkey anaphora, and
 possession is marked with *khɔ̌ɔng*.
 
 ## References
 
 * [jenks-2015]
+* [jenks-2018]
 * [moroney-2021]
 -/
 
 namespace Thai.Determiners
 
 /-- The Thai determiners are the demonstrative *nán*, the obligatory exponent
-    of anaphoric definites, and the possessive *khɔ̌ɔng*. -/
+    of anaphoric definites including donkey anaphora, and the possessive
+    *khɔ̌ɔng*. -/
 def inventory : Determiner.Inventory :=
-  [ .demonstrative { form := "nan", deictic := .distal, definiteUses := [.anaphoric] },
+  [ .demonstrative { form := "nan", deictic := .distal, definiteUses := [.anaphoric, .donkey] },
     .possessive { form := "khong" } ]
 
 /-- Thai derives the `.markedAnaphoric` Moroney cell. -/


### PR DESCRIPTION
Jenks-2018 fulltext verification pass over the classifier-language inventories (follow-up to #2020; the commit predates #2020 merging and is tree-identical to the built sweep tip).

- [jenks-2018] §3.3: Mandarin donkey definites "require demonstratives and prohibit bare nouns", so *nà* adds `.donkey` to its `definiteUses`; the paper reports identical facts for Thai (after [jenks-2015]), so *nán* follows. Moroney cells unchanged.
- Cantonese [Clf-N] checked out as landed: the donkey sentence (4) and the unique+anaphoric distribution (§6) support all four uses.