### PR TITLE
fix(Fragments/German): drop SVO/V2 coding; rework SAE particle claim

### DIFF
--- a/Linglib/Fragments/Arabic/ModernStandard/Comparison.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Arabic (MSA) (ISO `arb`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/English/Comparison.lean
+++ b/Linglib/Fragments/English/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for English (ISO `eng`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Finnish/Comparison.lean
+++ b/Linglib/Fragments/Finnish/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Finnish (ISO `fin`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/German/Comparison.lean
+++ b/Linglib/Fragments/German/Comparison.lean
@@ -2,14 +2,15 @@ import Linglib.Syntax.Comparative
 
 /-!
 # German comparative profile
-[stassen-2013] [wals-2013]
 
-`ComparativeProfile` bundle for German (ISO `deu`) per the project's
-"per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
-this profile live in `Studies/Stassen2013Comparison.lean`. The
-[stassen-1985] 6-way classification (where applicable) lives in
-`Studies/Stassen1985.lean`.
+German marks the standard of comparison with the particle *als*, degree with the
+bound affix *-er* (*größer*, never periphrastic for adjectives), and the superlative
+morphologically (*am größten*). German is absent from the 167-language WALS Ch 121A
+sample; the particle classification applies [stassen-2013]'s criteria (the chapter
+cites German for the comparative affix) and matches [haspelmath-2001]'s Standard
+Average European comparative-particle feature. No `basicOrder` is coded: WALS
+Ch 81A classifies German as lacking a dominant word order (V2 main clauses,
+verb-final subordinate clauses).
 -/
 
 set_option autoImplicit false
@@ -27,7 +28,6 @@ def comparison : ComparativeProfile :=
   , superlative := .morphological
   , comparativeForm := "X ist größer als Y"
   , standardMarker := "als"
-  , degreeMarker := "-er (suffix)"
-  , basicOrder := "SVO/V2" }
+  , degreeMarker := "-er (suffix)" }
 
 end German.Comparison

--- a/Linglib/Fragments/HindiUrdu/Comparison.lean
+++ b/Linglib/Fragments/HindiUrdu/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Hindi-Urdu (ISO `hin`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Latin/Comparison.lean
+++ b/Linglib/Fragments/Latin/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Latin (ISO `lat`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Mandarin/Comparison.lean
+++ b/Linglib/Fragments/Mandarin/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Mandarin (ISO `cmn`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Navajo/Comparison.lean
+++ b/Linglib/Fragments/Navajo/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Navajo (ISO `nav`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Romance/French/Comparison.lean
+++ b/Linglib/Fragments/Romance/French/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for French (ISO `fra`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Slavic/Russian/Comparison.lean
+++ b/Linglib/Fragments/Slavic/Russian/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Russian (ISO `rus`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Swahili/Comparison.lean
+++ b/Linglib/Fragments/Swahili/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Swahili (ISO `swh`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Tagalog/Comparison.lean
+++ b/Linglib/Fragments/Tagalog/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Tagalog (ISO `tgl`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Thai/Comparison.lean
+++ b/Linglib/Fragments/Thai/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Thai (ISO `tha`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Fragments/Yoruba/Comparison.lean
+++ b/Linglib/Fragments/Yoruba/Comparison.lean
@@ -6,7 +6,7 @@ import Linglib.Syntax.Comparative
 
 `ComparativeProfile` bundle for Yoruba (ISO `yor`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Typology/Comparison.lean`. Cross-linguistic theorems consuming
+`Linglib/Syntax/Comparative.lean`. Cross-linguistic theorems consuming
 this profile live in `Studies/Stassen2013Comparison.lean`. The
 [stassen-1985] 6-way classification (where applicable) lives in
 `Studies/Stassen1985.lean`.

--- a/Linglib/Studies/Stassen1985.lean
+++ b/Linglib/Studies/Stassen1985.lean
@@ -2,7 +2,6 @@ import Linglib.Syntax.Comparative
 import Linglib.Studies.SarvasyAikhenvald2025
 import Linglib.Features.Case.Basic
 import Linglib.Fragments.English.Comparison
-import Linglib.Fragments.German.Comparison
 import Linglib.Fragments.Japanese.Comparison
 import Linglib.Fragments.Korean.Comparison
 import Linglib.Fragments.Turkish.Comparison
@@ -35,7 +34,7 @@ The 1985 book (110-language sample) classifies comparatives into six types:
 **separative**, **allative**, **locative** (the three adverbial subtypes
 collectively making up the "locational" category in WALS 2013), plus
 **exceed**, **conjoined**, and **particle**. The WALS 2013 typology
-([stassen-2013], in the substrate `Linglib/Typology/Comparison.lean`)
+([stassen-2013], in the substrate `Linglib/Syntax/Comparative.lean`)
 collapses the spatial triad into single `locational`, dropping the spatial-
 relation distinction that drives Stassen's explanatory universals connecting
 comparison to temporal chaining.

--- a/Linglib/Studies/Stassen2013Comparison.lean
+++ b/Linglib/Studies/Stassen2013Comparison.lean
@@ -34,7 +34,7 @@ Per-language Fragment-vs-WALS data-equality theorems are deliberately absent
 — see `feedback_no_per_lang_wals_grounding_in_studies` for the rationale.
 
 WALS aggregate distribution theorems live in the substrate
-(`Linglib/Typology/Comparison.lean`). Stassen's 1985 fine-grained 6-way
+(`Linglib/Syntax/Comparative.lean`). Stassen's 1985 fine-grained 6-way
 typology and the chaining-based universals live in
 `Studies/Stassen1985.lean`.
 -/
@@ -131,17 +131,17 @@ theorem sample_no_superlative :
 -- §3. Generalisation 1: Particle concentrates in Europe (SAE)
 -- ============================================================================
 
-/-- All particle languages in the sample (English, German, Russian, French)
-    are SVO (or V2). This reflects [haspelmath-2001]'s identification of
-    the comparative particle as a Standard Average European feature. -/
+/-- Particle-comparative languages in the sample. [stassen-2013] finds the
+    particle type "has its base in the modern languages of Europe";
+    [haspelmath-2001] lists the comparative particle as a Standard Average
+    European feature. -/
 def particleLanguages : List ComparativeProfile :=
   allLanguages.filter (·.hasType .particle)
 
-theorem particle_languages_count :
-    particleLanguages.length = 4 := by native_decide
-
-theorem particle_implies_svo_in_sample :
-    particleLanguages.all (·.isSVO) = true := by native_decide
+/-- The sample's particle languages are exactly its four European languages. -/
+theorem particle_languages_european :
+    particleLanguages.map (·.language) =
+    ["English", "German", "Russian", "French"] := by native_decide
 
 -- ============================================================================
 -- §4. Generalisation 2: Exceed concentrates in W Africa and SE Asia
@@ -205,7 +205,7 @@ def svoLanguages : List ComparativeProfile :=
   allLanguages.filter (·.isSVO)
 
 theorem svo_languages_count :
-    svoLanguages.length = 9 := by native_decide
+    svoLanguages.length = 8 := by native_decide
 
 /-- Among SVO languages, exceed and particle types are both attested. -/
 theorem svo_exceed_particle_split :

--- a/Linglib/Syntax/Comparative.lean
+++ b/Linglib/Syntax/Comparative.lean
@@ -7,8 +7,7 @@ import Linglib.Features.Case.Basic
 
 Per-language typological substrate for comparative-construction typology
 (Stassen's WALS Ch 121 framework + Beck-Crisma-Krasikova degree-word
-typology + superlative strategies). Fragment-importable; mirrors the
-`Linglib/Typology/{Possession,Negation,Question}.lean` pattern.
+typology + superlative strategies). Fragment-importable.
 
 ## What lives here
 
@@ -44,7 +43,7 @@ Stassen's 1985 fine-grained adverbial typology (`ComparativeType1985`,
 `caseAssignment`, `fixedEncoding`, `spatialCase`) and the 1985-↔-2013
 consistency theorems live in `Studies/Stassen1985.lean` (paper-anchored).
 Cross-linguistic theorems consuming Fragment per-language data live in
-`Studies/Stassen2013.lean`.
+`Studies/Stassen2013Comparison.lean`.
 -/
 
 set_option autoImplicit false
@@ -180,7 +179,7 @@ def ComparativeProfile.isSOV (p : ComparativeProfile) : Bool :=
 
 /-- Is this an SVO language? -/
 def ComparativeProfile.isSVO (p : ComparativeProfile) : Bool :=
-  p.basicOrder == "SVO" || p.basicOrder == "SVO/V2"
+  p.basicOrder == "SVO"
 
 /-- Count of languages in a sample with a given comparative type. -/
 def countByType (langs : List ComparativeProfile) (t : ComparativeType) : Nat :=


### PR DESCRIPTION
Audit of `Fragments/German/Comparison.lean`. German is absent from the WALS Ch 121A sample and WALS Ch 81A codes it as lacking a dominant word order, yet the fragment coded `basicOrder := "SVO/V2"` — a string the substrate's `isSVO` special-cased so that `particle_implies_svo_in_sample` (a word-order universal neither Stassen 2013 nor Haspelmath 2001 states) would pass.

- Uncode German's `basicOrder`, remove the fitted `"SVO/V2"` arm of `isSVO`, and replace the SVO theorem with the areal identification the chapter does make (particle type "has its base in the modern languages of Europe").
- Drop the dead German import in `Studies/Stassen1985.lean`; fix stale `Linglib/Typology/Comparison.lean` docstring paths across the comparison family.