### PR TITLE
feat(Syntax/Comparative): construction object with derived WALS type

### DIFF
--- a/Linglib/Fragments/Arabic/ModernStandard/Comparison.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Comparison.lean
@@ -3,10 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # Modern Standard Arabic comparative data
 
-MSA marks the standard of comparison with *min* 'from' (WALS Ch 121A:
-locational, [stassen-2013]); the elative pattern *ʔafʕal* carries the
-comparison, with no separate degree word. Superlative via the elative without a
-comparison standard.
+MSA compares with *X ʔafʕal min Y*: the separative preposition *min* 'from'
+marks the standard (WALS Ch 121A: locational, [stassen-2013]) and the elative
+pattern *ʔafʕal* carries the comparison, with no separate degree word.
+Superlative via the elative without a comparison standard.
 -/
 
 set_option autoImplicit false
@@ -15,16 +15,17 @@ namespace Arabic.ModernStandard.Comparison
 
 open Comparative
 
+/-- The *min*-comparative: separative preposition-marked standard. -/
+def min : Comparative :=
+  { standardMarker := some "min"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .adverbial
+  , standardCase := some .abl }
+
 /-- The elative pattern carries comparison; no separate degree word. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Elative superlative. -/
 def superlative : SuperlativeStrategy := .elative
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X ʔafʕal min Y"
-
-/-- The separative standard marker. -/
-def standardMarker : String := "min (from)"
 
 end Arabic.ModernStandard.Comparison

--- a/Linglib/Fragments/English/Comparison.lean
+++ b/Linglib/Fragments/English/Comparison.lean
@@ -3,9 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # English comparative data
 
-English marks the standard of comparison with the particle *than* (WALS Ch 121A:
-particle, [stassen-2013]), degree with the free word *more* or the bound affix
-*-er*, and the superlative morphologically (*-est*).
+English compares with *X is taller than Y* / *X is more Adj than Y*: the
+particle *than* marks the standard (WALS Ch 121A: particle, [stassen-2013]),
+degree is marked by the free word *more* or the bound affix *-er*, and the
+superlative is morphological (*-est*).
 -/
 
 set_option autoImplicit false
@@ -14,19 +15,17 @@ namespace English.Comparison
 
 open Comparative
 
+/-- The *than*-comparative: particle-marked standard, *more* or *-er* degree. -/
+def than : Comparative :=
+  { standardMarker := some "than"
+  , caseAssignment := .derived
+  , degreeMarker := some "more / -er"
+  , degreeMorphology := true }
+
 /-- Free degree word *more* alongside the affix *-er*. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
 
 /-- Morphological superlative (*-est*). -/
 def superlative : SuperlativeStrategy := .morphological
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X is taller/more Adj than Y"
-
-/-- The comparative particle marking the standard. -/
-def standardMarker : String := "than"
-
-/-- Degree markers: free word and bound affix. -/
-def degreeMarker : String := "more / -er"
 
 end English.Comparison

--- a/Linglib/Fragments/Finnish/Comparison.lean
+++ b/Linglib/Fragments/Finnish/Comparison.lean
@@ -3,10 +3,11 @@ import Linglib.Syntax.Comparative
 /-!
 # Finnish comparative data
 
-Finnish marks the standard of comparison with the particle *kuin* (WALS Ch 121A:
-particle, [stassen-2013]); [stassen-1985] classifies Finnish as particle-primary
-with a secondary separative option (partitive-marked standard). Degree is marked
-by the bound affix *-mpi*, and the superlative is morphological.
+Finnish compares with *X on Adj-mpi kuin Y*: the particle *kuin* marks the
+standard (WALS Ch 121A: particle, [stassen-2013]), with a secondary
+separative option marking the standard with the partitive instead —
+[stassen-1985] classifies Finnish as particle-primary, separative-secondary.
+Degree is marked by the bound affix *-mpi*; the superlative is morphological.
 -/
 
 set_option autoImplicit false
@@ -15,21 +16,25 @@ namespace Finnish.Comparison
 
 open Comparative
 
+/-- The *kuin*-comparative: the primary, particle-marked construction. -/
+def kuin : Comparative :=
+  { standardMarker := some "kuin"
+  , caseAssignment := .derived
+  , degreeMarker := some "-mpi"
+  , degreeMorphology := true }
+
+/-- The secondary separative construction: partitive-marked standard. -/
+def partitive : Comparative :=
+  { caseAssignment := .fixed
+  , fixedEncoding := some .adverbial
+  , standardCase := some .part
+  , degreeMarker := some "-mpi"
+  , degreeMorphology := true }
+
 /-- Bound comparative affix *-mpi*. -/
 def degreeWord : DegreeWordType := .morphological
 
 /-- Morphological superlative. -/
 def superlative : SuperlativeStrategy := .morphological
-
-/-- Illustrative comparative (particle strategy; the secondary separative
-    option marks the standard with the partitive instead). -/
-def comparativeForm : String := "X on Adj-mpi kuin Y"
-
-/-- The comparative particle; the partitive-marked standard is the secondary
-    separative option. -/
-def standardMarker : String := "kuin"
-
-/-- The bound comparative affix. -/
-def degreeMarker : String := "-mpi"
 
 end Finnish.Comparison

--- a/Linglib/Fragments/German/Comparison.lean
+++ b/Linglib/Fragments/German/Comparison.lean
@@ -3,14 +3,15 @@ import Linglib.Syntax.Comparative
 /-!
 # German comparative data
 
-German marks the standard of comparison with the particle *als*, degree with the
-bound affix *-er* (*größer*, never periphrastic for adjectives), and the
-superlative morphologically (*am größten*). German is absent from the
-167-language WALS Ch 121A sample, so `comparativeType` is coded here: it applies
+German compares with *X ist größer als Y*: the particle *als* marks the
+standard, the bound affix *-er* marks degree (never periphrastic for
+adjectives), and the superlative is morphological (*am größten*). German is
+absent from the 167-language WALS Ch 121A sample; its particle classification
+is derived from the construction's anatomy (`als.type`), consistent with
 [stassen-2013]'s criteria (the chapter cites German for the comparative affix)
-and matches [haspelmath-2001]'s Standard Average European comparative-particle
-feature. WALS Ch 81A classifies German as lacking a dominant word order (V2 main
-clauses, verb-final subordinate clauses).
+and [haspelmath-2001]'s Standard Average European comparative-particle
+feature. WALS Ch 81A classifies German as lacking a dominant word order (V2
+main clauses, verb-final subordinate clauses).
 -/
 
 set_option autoImplicit false
@@ -19,23 +20,17 @@ namespace German.Comparison
 
 open Comparative
 
-/-- Particle comparative — grammar-based coding; German is uncoded in
-    WALS Ch 121A. -/
-def comparativeType : ComparativeType := .particle
+/-- The *als*-comparative: particle-marked standard, bound degree affix. -/
+def als : Comparative :=
+  { standardMarker := some "als"
+  , caseAssignment := .derived
+  , degreeMarker := some "-er"
+  , degreeMorphology := true }
 
 /-- Bound comparative affix *-er*; no free degree word for adjectives. -/
 def degreeWord : DegreeWordType := .morphological
 
 /-- Morphological superlative (*am größten*). -/
 def superlative : SuperlativeStrategy := .morphological
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X ist größer als Y"
-
-/-- The comparative particle marking the standard. -/
-def standardMarker : String := "als"
-
-/-- The bound comparative affix. -/
-def degreeMarker : String := "-er"
 
 end German.Comparison

--- a/Linglib/Fragments/HindiUrdu/Comparison.lean
+++ b/Linglib/Fragments/HindiUrdu/Comparison.lean
@@ -3,10 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # Hindi-Urdu comparative data
 
-Hindi-Urdu marks the standard of comparison with the ablative postposition *se*
-'from' (WALS Ch 121A: locational, [stassen-2013]); the free degree word
-*zyaadaa* 'more' is optional. Superlative via comparative with a universal
-standard (*sab se* 'than all').
+Hindi-Urdu compares with *X Y se (zyaadaa) Adj hai*: the ablative postposition
+*se* 'from' marks the standard (WALS Ch 121A: locational, [stassen-2013]), and
+the free degree word *zyaadaa* 'more' is optional. Superlative via comparative
+with a universal standard (*sab se* 'than all').
 -/
 
 set_option autoImplicit false
@@ -15,19 +15,18 @@ namespace HindiUrdu.Comparison
 
 open Comparative
 
+/-- The *se*-comparative: separative postposition-marked standard. -/
+def se : Comparative :=
+  { standardMarker := some "se"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .adverbial
+  , standardCase := some .abl
+  , degreeMarker := some "zyaadaa" }
+
 /-- Optional free degree word *zyaadaa*. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
 
 /-- Superlative as comparative with universal standard (*sab se*). -/
 def superlative : SuperlativeStrategy := .comparativeUniversal
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X Y se (zyaadaa) Adj hai"
-
-/-- The ablative standard marker. -/
-def standardMarker : String := "se"
-
-/-- The free degree word. -/
-def degreeMarker : String := "zyaadaa"
 
 end HindiUrdu.Comparison

--- a/Linglib/Fragments/Japanese/Comparison.lean
+++ b/Linglib/Fragments/Japanese/Comparison.lean
@@ -1,4 +1,3 @@
-import Linglib.Features.Case.Basic
 import Linglib.Syntax.Comparative
 
 /-!
@@ -25,32 +24,18 @@ namespace Japanese.Comparison
 
 open Comparative
 
-/-- The separative (ablative) standard marker. -/
-def standardMarker : String := "yori"
-
-/-- Japanese comparative: separative (ablative) standard marker *yori*. -/
-def entry : ComparativeEntry :=
-  { standardCase := .abl
+/-- The *yori*-comparative: separative (ablative) postposition-marked
+    standard, no degree morphology. -/
+def yori : Comparative :=
+  { standardMarker := some "yori"
   , caseAssignment := .fixed
   , fixedEncoding := some .adverbial
-  , standardMarker := standardMarker
-  , hasDegreeMorphology := false }
-
--- Per-datum verification
-theorem standard_is_ablative : entry.standardCase = .abl := rfl
-theorem case_is_fixed : entry.caseAssignment = .fixed := rfl
-theorem encoding_is_adverbial : entry.fixedEncoding = some .adverbial := rfl
-theorem no_degree_morphology : entry.hasDegreeMorphology = false := rfl
-
-/-! ### WALS Ch 121 classification data -/
+  , standardCase := some .abl }
 
 /-- No overt degree marking. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Superlative as comparative with universal standard (*dare yori mo*). -/
 def superlative : SuperlativeStrategy := .comparativeUniversal
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "Y yori X ga Adj"
 
 end Japanese.Comparison

--- a/Linglib/Fragments/Korean/Comparison.lean
+++ b/Linglib/Fragments/Korean/Comparison.lean
@@ -1,4 +1,3 @@
-import Linglib.Features.Case.Basic
 import Linglib.Syntax.Comparative
 
 /-!
@@ -25,32 +24,18 @@ namespace Korean.Comparison
 
 open Comparative
 
-/-- The separative standard marker. -/
-def standardMarker : String := "-boda"
-
-/-- Korean comparative: separative standard marker *-boda*. -/
-def entry : ComparativeEntry :=
-  { standardCase := .abl
+/-- The *-boda* comparative: separative postposition-marked standard, no
+    degree morphology. -/
+def boda : Comparative :=
+  { standardMarker := some "-boda"
   , caseAssignment := .fixed
   , fixedEncoding := some .adverbial
-  , standardMarker := standardMarker
-  , hasDegreeMorphology := false }
-
--- Per-datum verification
-theorem standard_is_ablative : entry.standardCase = .abl := rfl
-theorem case_is_fixed : entry.caseAssignment = .fixed := rfl
-theorem encoding_is_adverbial : entry.fixedEncoding = some .adverbial := rfl
-theorem no_degree_morphology : entry.hasDegreeMorphology = false := rfl
-
-/-! ### WALS Ch 121 classification data -/
+  , standardCase := some .abl }
 
 /-- No overt degree marking; the adverb *deo* is an optional intensifier. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Superlative as comparative with universal standard. -/
 def superlative : SuperlativeStrategy := .comparativeUniversal
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "Y-boda X-ga Adj"
 
 end Korean.Comparison

--- a/Linglib/Fragments/Latin/Comparison.lean
+++ b/Linglib/Fragments/Latin/Comparison.lean
@@ -3,11 +3,12 @@ import Linglib.Syntax.Comparative
 /-!
 # Latin comparative data
 
-Latin has two productive comparative strategies: the particle *quam* and the
-bare ablative standard. Latin is uncoded in WALS Ch 121A, so `comparativeType`
-is coded here as `mixed`; [stassen-1985] classifies Latin as particle-primary
-with a secondary separative option. Degree is marked by the bound affix *-ior*,
-and the superlative is morphological.
+Latin has two productive comparative constructions: *X Adj-ior quam Y* with
+the particle *quam*, and *X Adj-ior Y-ABL* with a bare ablative standard —
+[stassen-1985] classifies Latin as particle-primary, separative-secondary.
+Latin is uncoded in WALS Ch 121A; each construction's type is derived from
+its anatomy (`quam.type`, `ablative.type`). Degree is marked by the bound
+affix *-ior*; the superlative is morphological.
 -/
 
 set_option autoImplicit false
@@ -16,23 +17,25 @@ namespace Latin.Comparison
 
 open Comparative
 
-/-- Mixed comparative (particle *quam* + ablative standard) — grammar-based
-    coding; Latin is uncoded in WALS Ch 121A. -/
-def comparativeType : ComparativeType := .mixed
+/-- The *quam*-comparative: the primary, particle-marked construction. -/
+def quam : Comparative :=
+  { standardMarker := some "quam"
+  , caseAssignment := .derived
+  , degreeMarker := some "-ior"
+  , degreeMorphology := true }
+
+/-- The bare-ablative comparative: no segmental marker, ablative standard. -/
+def ablative : Comparative :=
+  { caseAssignment := .fixed
+  , fixedEncoding := some .adverbial
+  , standardCase := some .abl
+  , degreeMarker := some "-ior"
+  , degreeMorphology := true }
 
 /-- Bound comparative affix *-ior*. -/
 def degreeWord : DegreeWordType := .morphological
 
 /-- Morphological superlative. -/
 def superlative : SuperlativeStrategy := .morphological
-
-/-- Illustrative comparatives (ablative and particle strategies). -/
-def comparativeForm : String := "X Adj-ior Y-ABL / X Adj-ior quam Y"
-
-/-- The two standard-marking strategies. -/
-def standardMarker : String := "ablative case / quam"
-
-/-- The bound comparative affix. -/
-def degreeMarker : String := "-ior"
 
 end Latin.Comparison

--- a/Linglib/Fragments/Mandarin/Comparison.lean
+++ b/Linglib/Fragments/Mandarin/Comparison.lean
@@ -3,10 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # Mandarin comparative data
 
-Mandarin encodes comparison with the *bǐ* construction (WALS Ch 121A: exceed,
-[stassen-2013]); the free degree word *gèng* 'even more' is available. No
-superlative strategy is recorded: the free superlative word *zuì* fits none of
-`SuperlativeStrategy`'s cases.
+Mandarin compares with *X bǐ Y Adj* (WALS Ch 121A: exceed, [stassen-2013]):
+the standard is the object of *bǐ*, and the free degree word *gèng* 'even
+more' is available. No superlative strategy is recorded: the free superlative
+word *zuì* fits none of `SuperlativeStrategy`'s cases.
 -/
 
 set_option autoImplicit false
@@ -15,16 +15,14 @@ namespace Mandarin.Comparison
 
 open Comparative
 
+/-- The *bǐ*-comparative: the standard is *bǐ*'s object. -/
+def bi : Comparative :=
+  { standardMarker := some "bi"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .directObject
+  , degreeMarker := some "geng" }
+
 /-- Free degree word *gèng*. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X bi Y Adj"
-
-/-- The standard marker of the *bǐ* construction. -/
-def standardMarker : String := "bi"
-
-/-- The free degree word. -/
-def degreeMarker : String := "geng"
 
 end Mandarin.Comparison

--- a/Linglib/Fragments/Romance/French/Comparison.lean
+++ b/Linglib/Fragments/Romance/French/Comparison.lean
@@ -3,9 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # French comparative data
 
-French marks the standard of comparison with the particle *que* (WALS Ch 121A:
-particle, [stassen-2013]) and degree with the free word *plus*; the superlative
-is the definite article plus the comparative (*le plus grand*).
+French compares with *X est plus Adj que Y*: the particle *que* marks the
+standard (WALS Ch 121A: particle, [stassen-2013]) and the free word *plus*
+marks degree; the superlative is the definite article plus the comparative
+(*le plus grand*).
 -/
 
 set_option autoImplicit false
@@ -14,19 +15,16 @@ namespace French.Comparison
 
 open Comparative
 
+/-- The *que*-comparative: particle-marked standard, free *plus* degree. -/
+def que : Comparative :=
+  { standardMarker := some "que"
+  , caseAssignment := .derived
+  , degreeMarker := some "plus" }
+
 /-- Free degree word *plus*. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
 
 /-- Definite article + comparative superlative. -/
 def superlative : SuperlativeStrategy := .definiteComparative
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X est plus Adj que Y"
-
-/-- The comparative particle marking the standard. -/
-def standardMarker : String := "que"
-
-/-- The free degree word. -/
-def degreeMarker : String := "plus"
 
 end French.Comparison

--- a/Linglib/Fragments/Slavic/Russian/Comparison.lean
+++ b/Linglib/Fragments/Slavic/Russian/Comparison.lean
@@ -3,9 +3,11 @@ import Linglib.Syntax.Comparative
 /-!
 # Russian comparative data
 
-Russian marks the standard of comparison with the particle *chem* or the bare
-genitive (WALS Ch 121A: particle, [stassen-2013]); degree is marked by the
-bound affix *-ee* ~ *-ej*, and the superlative is morphological.
+Russian compares with *X Adj-ee, chem Y*: the particle *chem* marks the
+standard (WALS Ch 121A: particle, [stassen-2013]); a bare genitive standard
+(*X Adj-ee Y-GEN*) is also available, its anatomy unrecorded here pending a
+source for its Stassen classification. Degree is marked by the bound affix
+*-ee* ~ *-ej*; the superlative is morphological.
 -/
 
 set_option autoImplicit false
@@ -14,19 +16,17 @@ namespace Russian.Comparison
 
 open Comparative
 
+/-- The *chem*-comparative: particle-marked standard. -/
+def chem : Comparative :=
+  { standardMarker := some "chem"
+  , caseAssignment := .derived
+  , degreeMarker := some "-ee/-ej"
+  , degreeMorphology := true }
+
 /-- Bound comparative affix *-ee* ~ *-ej*. -/
 def degreeWord : DegreeWordType := .morphological
 
 /-- Morphological superlative. -/
 def superlative : SuperlativeStrategy := .morphological
-
-/-- Illustrative comparatives (particle and genitive strategies). -/
-def comparativeForm : String := "X Adj-ee, chem Y / X Adj-ee Y-GEN"
-
-/-- The standard markers. -/
-def standardMarker : String := "chem / genitive case"
-
-/-- The bound comparative affix. -/
-def degreeMarker : String := "-ee/-ej"
 
 end Russian.Comparison

--- a/Linglib/Fragments/Swahili/Comparison.lean
+++ b/Linglib/Fragments/Swahili/Comparison.lean
@@ -3,9 +3,11 @@ import Linglib.Syntax.Comparative
 /-!
 # Swahili comparative data
 
-Swahili encodes comparison with *kuliko* or the verb *-zidi* 'exceed'
-(WALS Ch 121A: exceed, [stassen-2013]); the adjective carries no degree
-marking. Superlative via exceeding a universal standard.
+Swahili compares with *X ni Adj kuliko Y* (WALS Ch 121A: exceed,
+[stassen-2013]): *kuliko*, grammaticalized from an exceed verb, takes the
+standard as its object; the verbal variant *X anazidi Y* '-zidi exceed' is
+also available. The adjective carries no degree marking; superlative via
+exceeding a universal standard.
 -/
 
 set_option autoImplicit false
@@ -14,16 +16,17 @@ namespace Swahili.Comparison
 
 open Comparative
 
+/-- The *kuliko*-comparative: exceed-derived marker taking the standard as
+    object; the *-zidi* verbal variant shares the anatomy. -/
+def kuliko : Comparative :=
+  { standardMarker := some "kuliko"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .directObject }
+
 /-- No degree marking on the adjective. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Superlative by exceeding a universal standard. -/
 def superlative : SuperlativeStrategy := .exceedAll
-
-/-- Illustrative comparatives. -/
-def comparativeForm : String := "X ni Adj kuliko Y / X anazidi Y kwa uAdj"
-
-/-- The standard markers. -/
-def standardMarker : String := "kuliko / -zidi"
 
 end Swahili.Comparison

--- a/Linglib/Fragments/Tagalog/Comparison.lean
+++ b/Linglib/Fragments/Tagalog/Comparison.lean
@@ -3,11 +3,13 @@ import Linglib.Syntax.Comparative
 /-!
 # Tagalog comparative data
 
-Tagalog compares with the Spanish-derived degree word *mas* plus the standard
-marker *kaysa*, or with *higit* 'exceed'. Tagalog is uncoded in WALS Ch 121A;
-`comparativeType` is coded here as `exceed` on the basis of *higit*, though the
-*mas … kaysa* pattern is particle-like, so the coding is contestable. No
-superlative strategy is recorded.
+Tagalog compares with *mas Adj si X kaysa (kay) Y* — the Spanish-derived
+degree word *mas* plus the standard marker *kaysa* — or with *higit na Adj sa
+Y* built on *higit* 'exceed' with an oblique *sa*-marked standard. Tagalog is
+uncoded in WALS Ch 121A, and neither construction's anatomy is recorded here
+pending a grammar source: *kaysa* itself embeds the oblique marker *kay*, and
+the *higit* standard is oblique rather than a direct object, so neither the
+particle nor the exceed classification can be derived responsibly.
 -/
 
 set_option autoImplicit false
@@ -16,20 +18,7 @@ namespace Tagalog.Comparison
 
 open Comparative
 
-/-- Exceed comparative (*higit*) — grammar-based coding; Tagalog is uncoded in
-    WALS Ch 121A, and the *mas … kaysa* pattern is particle-like. -/
-def comparativeType : ComparativeType := .exceed
-
 /-- Free degree words *mas* and *higit*. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
-
-/-- Illustrative comparatives. -/
-def comparativeForm : String := "mas Adj si X kaysa kay Y / higit na Adj si X"
-
-/-- The standard markers. -/
-def standardMarker : String := "kaysa / higit sa"
-
-/-- The free degree words. -/
-def degreeMarker : String := "mas / higit"
 
 end Tagalog.Comparison

--- a/Linglib/Fragments/Thai/Comparison.lean
+++ b/Linglib/Fragments/Thai/Comparison.lean
@@ -3,9 +3,10 @@ import Linglib.Syntax.Comparative
 /-!
 # Thai comparative data
 
-Thai encodes comparison with *kwàa* 'exceed' after the predicate
-(WALS Ch 121A: exceed, [stassen-2013]); the adjective carries no degree
-marking. Superlative via exceeding a universal standard.
+Thai compares with *X Adj kwàa Y* (WALS Ch 121A: exceed, [stassen-2013]):
+*kwàa* 'exceed' takes the standard as its object after the predicate. The
+adjective carries no degree marking; superlative via exceeding a universal
+standard.
 -/
 
 set_option autoImplicit false
@@ -14,16 +15,16 @@ namespace Thai.Comparison
 
 open Comparative
 
+/-- The *kwàa*-comparative: exceed marker taking the standard as object. -/
+def kwaa : Comparative :=
+  { standardMarker := some "kwaa"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .directObject }
+
 /-- No degree marking on the adjective. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Superlative by exceeding a universal standard. -/
 def superlative : SuperlativeStrategy := .exceedAll
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X Adj kwaa Y"
-
-/-- The exceed marker. -/
-def standardMarker : String := "kwaa"
 
 end Thai.Comparison

--- a/Linglib/Fragments/Turkish/Comparison.lean
+++ b/Linglib/Fragments/Turkish/Comparison.lean
@@ -1,4 +1,3 @@
-import Linglib.Features.Case.Basic
 import Linglib.Syntax.Comparative
 
 /-!
@@ -26,33 +25,17 @@ namespace Turkish.Comparison
 
 open Comparative
 
-/-- The separative (ablative) standard marker, subject to vowel harmony. -/
-def standardMarker : String := "-dan/-den"
-
-/-- Turkish comparative: separative (ablative) standard marker `-dan`/`-den`. -/
-def entry : ComparativeEntry :=
-  { standardCase := .abl
+/-- The ablative comparative: `-dan`/`-den`-marked standard, optional free
+    *daha*, no degree morphology. -/
+def dan : Comparative :=
+  { standardMarker := some "-dan/-den"
   , caseAssignment := .fixed
   , fixedEncoding := some .adverbial
-  , standardMarker := standardMarker
-  , hasDegreeMorphology := false }
-
--- Per-datum verification
-theorem standard_is_ablative : entry.standardCase = .abl := rfl
-theorem case_is_fixed : entry.caseAssignment = .fixed := rfl
-theorem encoding_is_adverbial : entry.fixedEncoding = some .adverbial := rfl
-theorem no_degree_morphology : entry.hasDegreeMorphology = false := rfl
-
-/-! ### WALS Ch 121 classification data -/
+  , standardCase := some .abl
+  , degreeMarker := some "daha" }
 
 /-- Optional free degree word *daha*; the adjective itself carries no
-    comparative morphology (`entry.hasDegreeMorphology = false`). -/
+    comparative morphology. -/
 def degreeWord : DegreeWordType := .hasDegreeWord
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X Y-den daha Adj"
-
-/-- The optional free degree word. -/
-def degreeMarker : String := "daha"
 
 end Turkish.Comparison

--- a/Linglib/Fragments/Yoruba/Comparison.lean
+++ b/Linglib/Fragments/Yoruba/Comparison.lean
@@ -3,9 +3,9 @@ import Linglib.Syntax.Comparative
 /-!
 # Yoruba comparative data
 
-Yoruba encodes comparison with the exceed verb *ju … lọ* (WALS Ch 121A: exceed,
-[stassen-2013]); the adjective carries no degree marking. Superlative via
-exceeding a universal standard.
+Yoruba compares with *X Adj ju Y lọ* (WALS Ch 121A: exceed, [stassen-2013]):
+the exceed verb *ju … lọ* takes the standard as its object. The adjective
+carries no degree marking; superlative via exceeding a universal standard.
 -/
 
 set_option autoImplicit false
@@ -14,16 +14,16 @@ namespace Yoruba.Comparison
 
 open Comparative
 
+/-- The *ju … lọ* comparative: exceed verb taking the standard as object. -/
+def ju : Comparative :=
+  { standardMarker := some "ju...lo"
+  , caseAssignment := .fixed
+  , fixedEncoding := some .directObject }
+
 /-- No degree marking on the adjective. -/
 def degreeWord : DegreeWordType := .noDegreeMarking
 
 /-- Superlative by exceeding a universal standard. -/
 def superlative : SuperlativeStrategy := .exceedAll
-
-/-- Illustrative comparative. -/
-def comparativeForm : String := "X Adj ju Y lo"
-
-/-- The exceed-verb standard marker. -/
-def standardMarker : String := "ju...lo"
 
 end Yoruba.Comparison

--- a/Linglib/Studies/Stassen1985.lean
+++ b/Linglib/Studies/Stassen1985.lean
@@ -66,7 +66,6 @@ namespace Stassen1985
 
 open Comparative
 open Features (CaseAssignment FixedCaseEncoding)
-open Comparative (ComparativeEntry)
 
 -- ════════════════════════════════════════════════════
 -- § 0. The Stassen 1985 six-way typology
@@ -333,73 +332,71 @@ theorem particle_no_spatial :
     ComparativeType1985.particle.spatialCase = none := rfl
 
 -- ════════════════════════════════════════════════════
--- § 8. Fragment bridge: ComparativeEntry ↔ Typology
+-- § 8. Fragment bridge: `Comparative` objects ↔ Typology
 -- ════════════════════════════════════════════════════
 
 /-- Japanese Fragment standard case matches 1985 spatial case prediction. -/
 theorem japanese_fragment_case :
-    some Japanese.Comparison.entry.standardCase =
-    japanese1985.spatialCase := rfl
+    Japanese.Comparison.yori.standardCase = japanese1985.spatialCase := rfl
 
 /-- Korean Fragment standard case matches 1985 spatial case prediction. -/
 theorem korean_fragment_case :
-    some Korean.Comparison.entry.standardCase =
-    korean1985.spatialCase := rfl
+    Korean.Comparison.boda.standardCase = korean1985.spatialCase := rfl
 
 /-- Turkish Fragment standard case matches 1985 spatial case prediction. -/
 theorem turkish_fragment_case :
-    some Turkish.Comparison.entry.standardCase =
-    turkish1985.spatialCase := rfl
+    Turkish.Comparison.dan.standardCase = turkish1985.spatialCase := rfl
 
-/-- All three separative Fragment entries use fixed case assignment. -/
+/-- All three separative Fragment constructions use fixed case assignment. -/
 theorem all_separative_fixed_case :
-    Japanese.Comparison.entry.caseAssignment = .fixed ∧
-    Korean.Comparison.entry.caseAssignment = .fixed ∧
-    Turkish.Comparison.entry.caseAssignment = .fixed :=
+    Japanese.Comparison.yori.caseAssignment = .fixed ∧
+    Korean.Comparison.boda.caseAssignment = .fixed ∧
+    Turkish.Comparison.dan.caseAssignment = .fixed :=
   ⟨rfl, rfl, rfl⟩
 
-/-- All three separative Fragment entries use adverbial encoding. -/
+/-- All three separative Fragment constructions use adverbial encoding. -/
 theorem all_separative_adverbial :
-    Japanese.Comparison.entry.fixedEncoding = some .adverbial ∧
-    Korean.Comparison.entry.fixedEncoding = some .adverbial ∧
-    Turkish.Comparison.entry.fixedEncoding = some .adverbial :=
+    Japanese.Comparison.yori.fixedEncoding = some .adverbial ∧
+    Korean.Comparison.boda.fixedEncoding = some .adverbial ∧
+    Turkish.Comparison.dan.fixedEncoding = some .adverbial :=
   ⟨rfl, rfl, rfl⟩
 
 /-- Separative languages lack degree morphology (p. 28). -/
 theorem separative_no_degree_morphology :
-    Japanese.Comparison.entry.hasDegreeMorphology = false ∧
-    Korean.Comparison.entry.hasDegreeMorphology = false ∧
-    Turkish.Comparison.entry.hasDegreeMorphology = false :=
+    Japanese.Comparison.yori.degreeMorphology = false ∧
+    Korean.Comparison.boda.degreeMorphology = false ∧
+    Turkish.Comparison.dan.degreeMorphology = false :=
   ⟨rfl, rfl, rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 9. Three-Layer Consistency
 -- ════════════════════════════════════════════════════
 
-/-- Japanese: Fragment (ablative) ↔ 1985 type (separative) ↔ chaining type
-    (absolute deranking). All three layers agree. -/
+/-- Japanese: Fragment anatomy (ablative standard, whose derived WALS type
+    matches the 1985 classification under `toWALS`) ↔ 1985 type (separative)
+    ↔ chaining type (absolute deranking). All three layers agree. -/
 theorem japanese_three_layer :
-    some Japanese.Comparison.entry.standardCase =
-      japanese1985.spatialCase ∧
+    Japanese.Comparison.yori.standardCase = japanese1985.spatialCase ∧
+    Japanese.Comparison.yori.type = japanese1985.toWALS ∧
     japaneseCT = .absoluteDeranking ∧
     universal2B japanese1985 japaneseCT :=
-  ⟨rfl, rfl, by intro _; rfl⟩
+  ⟨rfl, rfl, rfl, by intro _; rfl⟩
 
 /-- Korean: three-layer consistency. -/
 theorem korean_three_layer :
-    some Korean.Comparison.entry.standardCase =
-      korean1985.spatialCase ∧
+    Korean.Comparison.boda.standardCase = korean1985.spatialCase ∧
+    Korean.Comparison.boda.type = korean1985.toWALS ∧
     koreanCT = .absoluteDeranking ∧
     universal2B korean1985 koreanCT :=
-  ⟨rfl, rfl, by intro _; rfl⟩
+  ⟨rfl, rfl, rfl, by intro _; rfl⟩
 
 /-- Turkish: three-layer consistency. -/
 theorem turkish_three_layer :
-    some Turkish.Comparison.entry.standardCase =
-      turkish1985.spatialCase ∧
+    Turkish.Comparison.dan.standardCase = turkish1985.spatialCase ∧
+    Turkish.Comparison.dan.type = turkish1985.toWALS ∧
     turkishCT = .absoluteDeranking ∧
     universal2B turkish1985 turkishCT :=
-  ⟨rfl, rfl, by intro _; rfl⟩
+  ⟨rfl, rfl, rfl, by intro _; rfl⟩
 
 -- ════════════════════════════════════════════════════
 -- § 10. Bridge to ClauseChaining/Data

--- a/Linglib/Syntax/Comparative.lean
+++ b/Linglib/Syntax/Comparative.lean
@@ -4,50 +4,59 @@ import Linglib.Features.Case.Basic
 /-!
 # Comparison: comparative-construction typology
 
-Per-language typological substrate for comparative-construction typology:
-[stassen-2013]'s WALS Ch 121 framework ([wals-2013]), the [beck-2009]
-degree-word typology, and superlative strategies. Fragment-importable.
+The `Comparative` object — a comparative construction's anatomy in
+[stassen-1985]'s parameters, with its WALS Ch 121 type ([stassen-2013],
+[wals-2013]) derived from that anatomy — plus the [beck-2009] degree-word
+typology, superlative strategies, and the WALS Ch 121A lookup and aggregates.
 
 ## Main definitions
 
-- `ComparativeType` (5-way Stassen 2013 / WALS Ch 121A:
-  `locational | exceed | conjoined | particle | mixed`).
-- `DegreeWordType` ([beck-2009] 3-way:
-  `hasDegreeWord | morphological | noDegreeMarking`).
-- `SuperlativeStrategy` (6-way: morphological, definiteComparative, elative,
-  exceedAll, comparativeUniversal, none).
-- `ComparativeType.ofWALS` : WALS Ch 121A comparative type by ISO 639-3 lookup
-  (via the `ofWALS121A` converter); `none` for languages the chapter leaves
-  uncoded.
+- `Comparative` : the construction object (standard marker, case assignment,
+  encoding role, spatial case, degree slot). Fragments instantiate one def per
+  construction (`German.Comparison.als`; Latin has `quam` *and* `ablative`).
+- `Comparative.type` : the WALS Ch 121 type, derived from the anatomy —
+  derived-case constructions split on marker presence (particle vs conjoined),
+  fixed-case constructions on encoding role (exceed vs locational).
+- `DegreeWordType` ([beck-2009] 3-way), `SuperlativeStrategy` (6-way).
+- `ComparativeType.ofWALS` : WALS Ch 121A comparative type by ISO 639-3
+  lookup; `none` for languages the chapter leaves uncoded.
 - WALS Ch 121A aggregate generalisations (`locational_most_common`,
   `particle_rarest`, `locational_and_particle_dominant`).
-- `ComparativeEntry` : [stassen-1985]'s construction parameters.
 
-There is no per-language bundle: Fragments export bare defs typed by these
-enums (`{Lang}.Comparison.degreeWord`, `superlative`, `standardMarker`, …, plus
-`comparativeType` only for languages uncoded in WALS Ch 121A); studies join
-them with the WALS lookups.
-
-## Theory-laden caveats
-
-- **`ComparativeType` is the WALS 2013 5-way typology.** Stassen's original
-  1985 6-way typology (`separative | allative | locative | exceed |
-  conjoined | particle`) lives in `Studies/Stassen1985.lean`
-  because the 3-way adverbial split is paper-distinctive — the WALS update
-  collapses it into a single `locational` for cross-linguistic indexing.
-- **`DegreeWordType` is Beck et al. 2009's three-way classification.** Other
-  approaches (Kennedy 1999, Beck 2011, Bochnak 2013) refine the typology with
-  scale-structure and degree-argument parameters; those live in
-  `Semantics/Degree/`.
-
-## Out of scope
-
-Stassen's 1985 fine-grained adverbial typology (`ComparativeType1985`,
-`caseAssignment`, `fixedEncoding`, `spatialCase`) and the 1985-↔-2013
-consistency theorems live in `Studies/Stassen1985.lean` (paper-anchored).
+Stassen's 1985 fine-grained adverbial typology (`ComparativeType1985`, the
+chaining universals) lives in `Studies/Stassen1985.lean` (paper-anchored).
 -/
 
 set_option autoImplicit false
+
+open Features (CaseAssignment FixedCaseEncoding)
+
+/-- A comparative construction: how it encodes the standard of comparison in
+    "X is more Adj than Y" — [stassen-1985]'s construction parameters. A
+    language may have more than one (Latin *quam* and the bare ablative).
+    Coexists with `namespace Comparative` (a type and a namespace may share a
+    name, cf. `Pronoun`). -/
+structure Comparative where
+  /-- Surface form of the standard marker (*than*, *als*, *yori*, *bǐ*);
+      `none` when no segmental marker flags the standard (conjoined
+      constructions, bare case-marked standards like the Latin ablative). -/
+  standardMarker : Option String := none
+  /-- Case assignment to the standard NP: derived from the comparee's case vs
+      fixed by the construction ([stassen-1985]). -/
+  caseAssignment : CaseAssignment
+  /-- For fixed-case constructions: the standard's syntactic role — direct
+      object of an exceed verb, or adverbial. -/
+  fixedEncoding : Option FixedCaseEncoding := none
+  /-- Case on an adverbially encoded standard (ablative for separatives,
+      partitive for the Finnish secondary option). Adpositions with the
+      corresponding semantics count (Japanese *yori*, Arabic *min* → `abl`). -/
+  standardCase : Option Case := none
+  /-- The construction's degree-slot filler (*more*, *-er*, *daha*), if any. -/
+  degreeMarker : Option String := none
+  /-- Dedicated bound degree morphology on the parameter (English *-er*,
+      Latin *-ior*) — [stassen-1985]'s binary parameter. -/
+  degreeMorphology : Bool := false
+  deriving Repr, BEq, DecidableEq
 
 namespace Comparative
 
@@ -55,12 +64,10 @@ private abbrev ch121 := Data.WALS.F121A.allData
 
 /-! ### Classifications -/
 
-/-- WALS Ch 121: how a language expresses comparison of inequality.
-
-    Stassen's classification is based on how the **standard of comparison**
-    (the Y in "X is more Adj than Y") is encoded. Five types are
-    cross-cutting; a single language may use more than one productively
-    (classified as "mixed"). -/
+/-- WALS Ch 121: how a comparative construction encodes the **standard of
+    comparison** (the Y in "X is more Adj than Y"). A language with more than
+    one productive construction has one `Comparative` object per construction,
+    each with its own type. -/
 inductive ComparativeType where
   /-- Locational: the standard is marked with a locational/ablative case
       or adposition. Example: Japanese `Y yori X tall` 'Y from/than X tall'.
@@ -75,8 +82,6 @@ inductive ComparativeType where
   /-- Particle: a dedicated comparative particle marks the standard
       (e.g. English `than`, German `als`). Standard Average European pattern. -/
   | particle
-  /-- Mixed: more than one type is productive without a clear dominant. -/
-  | mixed
   deriving DecidableEq, BEq, Repr
 
 /-- [beck-2009]: presence of degree words in comparison constructions. -/
@@ -107,11 +112,21 @@ inductive SuperlativeStrategy where
   | none
   deriving DecidableEq, BEq, Repr
 
+/-! ### The derived type -/
+
+/-- The WALS Ch 121 type of a construction, derived from its anatomy:
+    derived-case constructions split on marker presence (particle vs
+    conjoined); fixed-case constructions on encoding role (exceed vs
+    locational, with adverbial the default). -/
+def type (c : Comparative) : ComparativeType :=
+  match c.caseAssignment, c.fixedEncoding with
+  | .derived, _ => if c.standardMarker.isSome then .particle else .conjoined
+  | .fixed, some .directObject => .exceed
+  | .fixed, _ => .locational
+
 /-! ### WALS lookups -/
 
-/-- WALS Ch 121A → `ComparativeType`. The generated WALS data uses four
-    categories; `mixed` is not a separate WALS value (languages are assigned
-    to whichever single type best characterises them). -/
+/-- WALS Ch 121A → `ComparativeType`. -/
 def ofWALS121A : Data.WALS.F121A.ComparativeType → ComparativeType
   | .locational => .locational
   | .exceed     => .exceed
@@ -154,23 +169,5 @@ theorem locational_and_particle_dominant :
     let loc := (ch121.filter (·.value == .locational)).length
     let par := (ch121.filter (·.value == .particle)).length
     loc + par > ch121.length / 2 := by native_decide
-
-/-! ### Stassen 1985 — Comparative Entry [stassen-1985]
-
-A typed record for the parameters of a comparative construction in a
-particular language: standard case, how that case is assigned, optional
-fixed-encoding role, the standard marker (e.g., *than*, *より*), and
-whether the construction has dedicated degree morphology. -/
-
-open Features (CaseAssignment FixedCaseEncoding)
-
-/-- A language's comparative construction entry ([stassen-1985]). -/
-structure ComparativeEntry where
-  standardCase : Case
-  caseAssignment : CaseAssignment
-  fixedEncoding : Option FixedCaseEncoding
-  standardMarker : String
-  hasDegreeMorphology : Bool
-  deriving Repr, BEq
 
 end Comparative


### PR DESCRIPTION
Adds the `Comparative` construction object on the `Pronoun`/`Demonstrative` model: root structure carrying [stassen-1985]'s anatomy (standard marker, case assignment, encoding role, spatial case, degree slot), with the WALS Ch 121 type **derived** from the anatomy (`Comparative.type`) instead of stipulated. Fragments instantiate one marker-named def per construction (`German.Comparison.als`, `Japanese.Comparison.yori`).

- Subsumes `ComparativeEntry` and the per-language `comparativeType`/marker string defs; drops the `mixed` enum case — a language with two productive constructions has two objects (Latin `quam` + `ablative`, Finnish `kuin` + `partitive`), each with its own derived type.
- Tagalog's former `exceed` coding is not derivable from its anatomy (*higit* takes an oblique *sa*-standard) — left unrecorded pending a grammar source, like Navajo.
- `Stassen1985` §8–9 restate over the objects; the three-layer theorems gain a derived-type conjunct (`yori.type = japanese1985.toWALS`), all closing by `rfl`.