### PR TITLE
refactor(Core/Algebra/RootedTree): content names for MCB-numbered decls

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -61,7 +61,7 @@ work (B+ is not a Hochschild 1-cocycle for Δ^c; see CHANGELOG entry
 ## Status
 
 `[UPSTREAM]` candidate. Sorry-free. MCB Lemma 1.2.10 is fully proved: both
-its grading content (`mcb_lemma_1_2_10`) and Δ^c coassociativity
+its grading content (`comulCAlgHomN_of'_mem_gradedSpan`) and Δ^c coassociativity
 (`comulCN_coassoc`), the latter under the `TraceCoherent` hypothesis. The
 coassoc proof is the direct double-cut bijection `doubleCut_eq`, descended
 from the tree-level `DoubleCut.coassT` (`Coproduct/TraceCoassoc.lean`) through
@@ -1795,9 +1795,9 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
 
 end BialgebraInst
 
-/-! ## MCB Lemma 1.2.10 — graded bialgebra structure
+/-! ### Edge-count grading
 
-Per `marcolli-chomsky-berwick-2025` p. 37, Lemma 1.2.10:
+Per [marcolli-chomsky-berwick-2025] p. 37, Lemma 1.2.10:
 
 > Let V^c(𝔉_{SO_0}) denote the vector space (over ℚ) spanned by the
 > workspaces F ∈ 𝔉_{SO_0}, endowed with the product given by the
@@ -1805,14 +1805,13 @@ Per `marcolli-chomsky-berwick-2025` p. 37, Lemma 1.2.10:
 > V(𝔉_{SO_0}) is graded by the number of edges. Then
 > (V^c(𝔉_{SO_0}), ⊔, Δ^c) is a graded bialgebra.
 
-This section formalizes the statement: defines edge-count grading on
-forests, sets up the graded subspaces, and packages MCB Lemma 1.2.10
-as a theorem combining the Δ^c bialgebra structure (`bialgebraC`, for
-trace-coherent encoders) with grading compatibility. Both grading
-halves are fully proved (edge conservation through the trace cut
-machinery: `cutSummandsCN_numNodes`). -/
+This section defines the edge-count grading on forests and its graded
+subspaces, and proves the coproduct half of the grading compatibility
+(`comulCAlgHomN_of'_mem_gradedSpan`); the product half is edge-count
+additivity over disjoint union, and edge conservation through the trace
+cut machinery is `cutSummandsCN_numNodes`. -/
 
-section MCBLemma1_2_10
+section EdgeGrading
 variable {R'' : Type*} [CommRing R''] {α'' β'' : Type*}
 
 /-- **Edge count of a forest**: total edges across all trees.
@@ -1994,62 +1993,33 @@ private theorem comulCForestN_mem (τ : Nonplanar (α'' ⊕ β'') → β'')
         rfl]
     exact gradedTensorSpan_mul (comulCTreeN_mem τ T) ih
 
-/-- **MCB Lemma 1.2.10** — the graded bialgebra structure.
+/-- **Δ^c preserves the edge-count grading** ([marcolli-chomsky-berwick-2025]
+    Lemma 1.2.10, p. 37): the coproduct of a basis forest lies in the span of
+    homogeneous tensors `xi ⊗ yi` with degrees summing to the forest's edge
+    count. With edge-count additivity over the product (disjoint union) and
+    `comulCN_coassoc`, this gives the lemma's graded bialgebra structure on
+    `V^c(𝔉_{SO_0})`. -/
+theorem comulCAlgHomN_of'_mem_gradedSpan
+    (τ : Nonplanar (α'' ⊕ β'') → β'') (F : Forest (Nonplanar (α'' ⊕ β''))) :
+    comulCAlgHomN (R := R'') τ (ConnesKreimer.of' F) ∈
+      Submodule.span R'' {y | ∃ (i j : ℕ) (_hi : i + j = Forest.edgeCount F)
+        (xi yi : ConnesKreimer R'' (Nonplanar (α'' ⊕ β''))),
+        xi ∈ gradedPiece (α'' ⊕ β'') i ∧
+        yi ∈ gradedPiece (α'' ⊕ β'') j ∧
+        y = xi ⊗ₜ[R''] yi} := by
+  -- Each cut summand splits the edges (the trace marker replaces the cut
+  -- subtree by a unit-weight leaf, `cutSummandsCN_numNodes`), and the
+  -- homogeneous tensor spans multiply additively (`gradedTensorSpan_mul`).
+  rw [comulCAlgHomN_apply_of']
+  refine SetLike.le_def.mp (Submodule.span_le.mpr ?_)
+    (comulCForestN_mem (R'' := R'') τ F)
+  rintro y ⟨F₁, F₂, hsum, rfl⟩
+  exact Submodule.subset_span
+    ⟨Forest.edgeCount F₁, Forest.edgeCount F₂, hsum,
+      ConnesKreimer.of' F₁, ConnesKreimer.of' F₂,
+      Submodule.subset_span ⟨F₁, rfl, rfl⟩,
+      Submodule.subset_span ⟨F₂, rfl, rfl⟩, rfl⟩
 
-    States that:
-    1. The bialgebra structure `bialgebraC` (from `comulCAlgHomN`, for
-       trace-coherent encoders).
-    2. The space `V^c(𝔉_{SO_0})` is graded by `edgeCount`.
-    3. The product (⊔ = disjoint union) preserves grading additively:
-       `V_n ⊗ V_m → V_{n+m}` (because `edgeCount(F + G) = edgeCount(F) + edgeCount(G)`).
-    4. The coproduct (Δ^c) preserves grading: for `x ∈ V_n`,
-       `Δ^c(x) ∈ Σ_{i+j=n} V_i ⊗ V_j`.
-
-    **Status**: statement packaged. The grading-compatibility proofs are
-    sorry'd (substrate work).
-
-    **Hopf structure** (corollary, deferred):
-    > induces a Hopf algebra structure on the complement in V^c(𝔉_{SO_0})
-    > of the span of the lexical items and features.
-
-    Antipode emerges via the graded connected bialgebra construction
-    (inductive formula `S(x) = -x - Σ S(x_(1)) · x_(2)`) after quotienting
-    by the (1 - α) ideal for α a lexical-item generator. Deferred to
-    sibling file. -/
-theorem mcb_lemma_1_2_10
-    (τ : Nonplanar (α'' ⊕ β'') → β'') :
-    -- (1) Bialgebra structure: `bialgebraC` (for trace-coherent τ).
-    -- (2) Edge-count grading: each gradedPiece is a Submodule.
-    -- (3) Product preserves grading: of'(F+G).edgeCount = F.edgeCount + G.edgeCount.
-    (∀ F G : Forest (Nonplanar (α'' ⊕ β'')),
-      Forest.edgeCount (F + G) = Forest.edgeCount F + Forest.edgeCount G) ∧
-    -- (4) Coproduct preserves grading: for basis x = of' F with edge count n,
-    -- comulCAlgHomN τ x ∈ ⊕_{i+j=n} V_i ⊗ V_j.
-    (∀ (n : ℕ) (F : Forest (Nonplanar (α'' ⊕ β''))),
-      Forest.edgeCount F = n →
-      comulCAlgHomN (R := R'') τ (ConnesKreimer.of' F) ∈
-        Submodule.span R'' {y | ∃ (i j : ℕ) (_hi : i + j = n)
-          (xi yi : ConnesKreimer R'' (Nonplanar (α'' ⊕ β''))),
-          xi ∈ gradedPiece (α'' ⊕ β'') i ∧
-          yi ∈ gradedPiece (α'' ⊕ β'') j ∧
-          y = xi ⊗ₜ[R''] yi}) := by
-  refine ⟨edgeCount_add, ?_⟩
-  · -- Δ^c preserves grading exactly: each cut summand splits the edges
-    -- (the trace marker replaces the cut subtree by a unit-weight leaf,
-    -- `cutSummandsCN_numNodes`), and the homogeneous tensor spans multiply
-    -- additively (`gradedTensorSpan_mul`).
-    intro n F hF
-    rw [comulCAlgHomN_apply_of']
-    have hmem := comulCForestN_mem (R'' := R'') τ F
-    rw [hF] at hmem
-    refine SetLike.le_def.mp (Submodule.span_le.mpr ?_) hmem
-    rintro y ⟨F₁, F₂, hsum, rfl⟩
-    exact Submodule.subset_span
-      ⟨Forest.edgeCount F₁, Forest.edgeCount F₂, hsum,
-        ConnesKreimer.of' F₁, ConnesKreimer.of' F₂,
-        Submodule.subset_span ⟨F₁, rfl, rfl⟩,
-        Submodule.subset_span ⟨F₂, rfl, rfl⟩, rfl⟩
-
-end MCBLemma1_2_10
+end EdgeGrading
 
 end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
+++ b/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
@@ -33,13 +33,13 @@ Eq 1.17.3 (interpreted as a type-level recursion on `SyntacticObject`)
 belongs in `Syntax/Minimalist/` — those Studies files
 consume this substrate.
 
-## §1.17.1: B+ as Hochschild 1-cocycle for Δ^ρ
+## B+ as Hochschild 1-cocycle for Δ^ρ (MCB Eq 1.17.1)
 
 Already proven as `comulTreeN_node_cocycle` /
-`comulAlgHomN_bPlusLin_cocycle` in `Coproduct/PruningNonplanar.lean`.
-Surfaced here with an MCB-citation alias for citation discovery.
+`comulAlgHomN_bPlusLin_cocycle` in `Coproduct/PruningNonplanar.lean`;
+this file consumes those theorems directly.
 
-## §1.17.2: The Dyson-Schwinger map and equation
+## The Dyson-Schwinger map and equation (MCB Eq 1.17.2)
 
 For `P : H →ₗ[R] H` a linear self-map and `a : α` a root label, the
 **Dyson-Schwinger map** is
@@ -51,7 +51,7 @@ equivalently `X = B+_a(P(X))`. The classical existence theorem
 (Foissy 2008) requires the degree-completion of `H` (formal power series
 in the grading variable) and is out of scope for this substrate file.
 
-## §1.17.3 algebraic analog
+## Algebraic analog of MCB Eq 1.17.3
 
 The quadratic case `X = B+_a(X * X)` is the direct algebraic analog of
 MCB Eq 1.17.3. It is not literally `X = M(X, X)` (which is a type-level
@@ -72,36 +72,7 @@ open scoped TensorProduct
 
 variable {R : Type*} [CommSemiring R] {α : Type*}
 
-/-! ## §1: B+ as Hochschild 1-cocycle (MCB Eq 1.17.1)
-
-Re-export of `comulTreeN_node_cocycle` and `comulAlgHomN_bPlusLin_cocycle`
-under MCB-anchored names. The substantive content was proven in
-`Coproduct/PruningNonplanar.lean` (Phase A.7-γ). -/
-
-/-- **MCB Eq 1.17.1** (Hochschild 1-cocycle property of `B+_a` for `Δ^ρ`,
-    basis-level form). For every forest `F : Forest (Nonplanar α)`,
-    applying `Δ^ρ` after `B+_a` (i.e., `comulTreeN ∘ Nonplanar.node a`)
-    decomposes as the explicit primitive term plus the right-channel
-    application of `B+_a` to `comulForestN F`.
-
-    This is the central algebraic property of `B+_a`; it makes
-    `(ConnesKreimer R (Nonplanar α), Δ^ρ, ε)` a graded connected
-    Hopf algebra (Foissy clean coassoc + antipode by induction). -/
-theorem mcb_1_17_1_hochschild_cocycle_basis (a : α) (F : Forest (Nonplanar α)) :
-    comulTreeN (R := R) (Nonplanar.node a F) =
-      ofTree (Nonplanar.node a F) ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α)) +
-      (LinearMap.lTensor _ (bPlusLin (R := R) a)) (comulForestN F) :=
-  comulTreeN_node_cocycle a F
-
-/-- **MCB Eq 1.17.1** lifted to the algebra-hom level on tree basis
-    elements. Re-export of `comulAlgHomN_bPlusLin_cocycle`. -/
-theorem mcb_1_17_1_hochschild_cocycle_algHom (a : α) (F : Forest (Nonplanar α)) :
-    comulAlgHomN (R := R) (bPlusLin (R := R) a (of' F)) =
-      bPlusLin (R := R) a (of' F) ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α)) +
-      (LinearMap.lTensor _ (bPlusLin (R := R) a)) (comulAlgHomN (of' F)) :=
-  comulAlgHomN_bPlusLin_cocycle a F
-
-/-! ## §2: The Dyson-Schwinger map and equation (MCB Eq 1.17.2)
+/-! ### The Dyson-Schwinger map and equation
 
 For a linear endomorphism `P : H →ₗ[R] H` and a root label `a : α`,
 `dsMap P a := bPlusLin a ∘ₗ P` is the DS self-map. -/
@@ -167,7 +138,7 @@ theorem isDSSolution_zero_iff_zero (a : α) (X : ConnesKreimer R (Nonplanar α))
   unfold IsDSSolution
   rw [dsMap_zero, LinearMap.zero_apply]
 
-/-! ## §3: Quadratic Dyson-Schwinger (algebraic analog of MCB Eq 1.17.3)
+/-! ### Quadratic Dyson-Schwinger
 
 The equation `X = B+_a(X * X)` is the direct algebraic analog of
 MCB Eq 1.17.3 (`X = M(X, X)`). Not a `dsMap` instance — multiplication
@@ -190,7 +161,7 @@ theorem zero_isQuadDSSolution (a : α) :
   unfold IsQuadDSSolution
   rw [mul_zero, map_zero]
 
-/-! ## §4: Sanity tests -/
+/-! ### Sanity tests -/
 
 /-- Sanity: for `P = id`, the DS map is exactly `B+_a`. -/
 example (a : α) :


### PR DESCRIPTION
Sweeps the remaining paper-numbered identifiers out of Core substrate (follow-up lead from the #2027 audit; paper numbering stays in docstrings with `[key]` cites).

- `mcb_lemma_1_2_10` → `comulCAlgHomN_of'_mem_gradedSpan`, dropping the conjunct that re-exported the private `edgeCount_add` and a stale "sorry'd" status note (the proof is complete).
- DysonSchwinger: delete the two unused re-export aliases `mcb_1_17_1_hochschild_cocycle_{basis,algHom}` (consumers cite the original `PruningNonplanar` theorems); `## §N:` headers → `###` descriptive style.