### PR TITLE
refactor(Core/RingTheory): dual-primitives substrate to mathlib mirror homes

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -310,6 +310,10 @@ import Linglib.Core.Probability.Softmax
 import Linglib.Core.Probability.SoftmaxLimits
 import Linglib.Core.Probability.SoftmaxTheory
 import Linglib.Core.Relation.ReflTransGen
+import Linglib.Core.RingTheory.Bialgebra.Basic
+import Linglib.Core.RingTheory.Bialgebra.DualPrimitives
+import Linglib.Core.RingTheory.Coalgebra.Basic
+import Linglib.Core.RingTheory.Coalgebra.Convolution
 import Linglib.Core.RingTheory.HopfAlgebra.SymmetricAlgebra
 import Linglib.Data.Complementation.Noonan2007
 import Linglib.Data.Complementation.Schema

--- a/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/InsertionLieDuality.lean
@@ -4,27 +4,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
-import Mathlib.RingTheory.Coalgebra.Convolution
-import Mathlib.Algebra.Lie.OfAssociative
-import Mathlib.Algebra.Lie.Subalgebra
+import Linglib.Core.RingTheory.Bialgebra.DualPrimitives
 
 /-!
-# Dual primitives of a bialgebra and the single-tree delta functionals
+# Single-tree delta functionals are the dual primitives
 [marcolli-chomsky-berwick-2025]
 
 Substrate for [marcolli-chomsky-berwick-2025]'s Lemma 1.7.3 (book pp. 78-79):
 the insertion Lie algebra is the Lie algebra of primitive elements in the dual
 Hopf algebra of the Hopf algebra of workspaces. This file proves the
 dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
-(deletion-remainder) coproduct.
+(deletion-remainder) coproduct, specializing the general
+`Bialgebra.dualPrimitives` theory of `Core/RingTheory/Bialgebra/DualPrimitives`.
 
 ## Main definitions
 
-* `Bialgebra.IsDualPrimitive`: a linear functional `L : H →ₗ[R] R` on a
-  bialgebra is primitive in the dual when `L (x * y) = L x * ε y + ε x * L y`.
-* `Bialgebra.dualPrimitives`: the dual primitives as a Lie subalgebra of the
-  convolution algebra `WithConv (H →ₗ[R] R)` under the ring commutator bracket.
-* `Coalgebra.Repr.mul`: Sweedler representation of a product in a bialgebra.
 * `RootedTree.ConnesKreimer.deltaSingleton`: the dual-basis functional `δ_T`
   extracting the coefficient of the singleton forest `{T}`.
 * `RootedTree.ConnesKreimer.countSingleCutsRho`: number of Δ^ρ cut summands of
@@ -32,8 +26,6 @@ dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
 
 ## Main results
 
-* `Bialgebra.IsDualPrimitive.lie`: dual primitives are closed under the
-  convolution commutator bracket.
 * `RootedTree.ConnesKreimer.deltaSingleton_isDualPrimitive`: each single-tree
   delta `δ_T` is a dual primitive.
 * `RootedTree.ConnesKreimer.lie_deltaSingleton_apply_singleton`: the explicit
@@ -42,163 +34,10 @@ dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
   `c^T_{T₁,T₂} − c^T_{T₂,T₁}`. The Δ^c (trace-leaf) version follows via the
   strip machinery in `Coproduct/DeletionNonplanar.lean`.
 
-The `Coalgebra.Repr` and `Bialgebra` sections are general substrate and
-`[UPSTREAM]` candidates — mathlib has no primitives API. Not yet stated: the
-Lie algebra isomorphism with the insertion Lie algebra
+Not yet stated: the Lie algebra isomorphism with the insertion Lie algebra
 (`RootedTree.InsertionAlgebra`); this file proves the dual-primitives side
 only.
 -/
-
-/-! ### Sweedler representation lemmas -/
-
-namespace Coalgebra.Repr
-
-open Coalgebra
-
-variable {R : Type*} [CommSemiring R] {C : Type*} [AddCommMonoid C] [Module R C]
-  [Coalgebra R C] {ι : Type*} {a : C}
-
-/-- Applying `L ⊗ ε` to a Sweedler representation of `a` recovers `L a`. -/
-theorem sum_apply_mul_counit (𝓡 : Repr R a ι) (L : C →ₗ[R] R) :
-    ∑ i ∈ 𝓡.index, L (𝓡.left i) * counit (𝓡.right i) = L a := by
-  simpa only [map_sum, LinearMap.mul'_apply, mul_one] using
-    congrArg (LinearMap.mul' R R) (sum_map_tmul_counit_eq L a (repr := 𝓡))
-
-/-- Applying `ε ⊗ L` to a Sweedler representation of `a` recovers `L a`. -/
-theorem sum_counit_mul_apply (𝓡 : Repr R a ι) (L : C →ₗ[R] R) :
-    ∑ i ∈ 𝓡.index, counit (𝓡.left i) * L (𝓡.right i) = L a := by
-  simpa only [map_sum, LinearMap.mul'_apply, one_mul] using
-    congrArg (LinearMap.mul' R R) (sum_counit_tmul_map_eq L a (repr := 𝓡))
-
-/-- Sweedler representation of a product `x * y` in a bialgebra, indexed by
-pairs: `left (i, j) = left i * left j` and `right (i, j) = right i * right j`. -/
-@[simps]
-noncomputable def mul {H : Type*} [Semiring H] [Bialgebra R H] {x y : H}
-    {ιx ιy : Type*} (𝓡x : Repr R x ιx) (𝓡y : Repr R y ιy) :
-    Repr R (x * y) (ιx × ιy) where
-  index := 𝓡x.index ×ˢ 𝓡y.index
-  left p := 𝓡x.left p.1 * 𝓡y.left p.2
-  right p := 𝓡x.right p.1 * 𝓡y.right p.2
-  eq := by
-    rw [Bialgebra.comul_mul, ← 𝓡x.eq, ← 𝓡y.eq, Finset.sum_product, Finset.sum_mul_sum]
-    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ =>
-      (Algebra.TensorProduct.tmul_mul_tmul _ _ _ _).symm
-
-open WithConv in
-/-- The ring commutator bracket on the convolution algebra, evaluated through a
-Sweedler representation. -/
-theorem lie_apply {A : Type*} [Ring A] [Algebra R A] (𝓡 : Repr R a ι)
-    (f g : WithConv (C →ₗ[R] A)) :
-    ⁅f, g⁆ a =
-      ∑ i ∈ 𝓡.index, (f (𝓡.left i) * g (𝓡.right i) - g (𝓡.left i) * f (𝓡.right i)) := by
-  rw [Ring.lie_def]
-  show (f * g) a - (g * f) a = _
-  rw [𝓡.convMul_apply, 𝓡.convMul_apply, Finset.sum_sub_distrib]
-
-end Coalgebra.Repr
-
-/-! ### Dual primitives -/
-
-namespace Bialgebra
-
-open Coalgebra
-
-section CommSemiring
-
-variable {R : Type*} [CommSemiring R] {H : Type*} [Semiring H] [Bialgebra R H]
-  {L : H →ₗ[R] R} {x y : H}
-
-variable (R) in
-/-- A linear functional `L : H →ₗ[R] R` is **primitive in the dual** of a
-bialgebra `H` if `L (x * y) = L x * ε y + ε x * L y`: the coproduct on the dual
-is dual to the product on `H`, so this reads `Δ L = L ⊗ ε + ε ⊗ L` after
-pairing against `x ⊗ y`. -/
-def IsDualPrimitive (L : H →ₗ[R] R) : Prop :=
-  ∀ x y : H, L (x * y) = L x * counit y + counit x * L y
-
-/-- A dual primitive vanishes on products of counit-less elements; in
-particular on decomposable basis elements of a graded bialgebra. -/
-theorem IsDualPrimitive.map_mul_eq_zero (hL : IsDualPrimitive R L)
-    (hx : counit (R := R) x = 0) (hy : counit (R := R) y = 0) : L (x * y) = 0 := by
-  rw [hL, hx, hy, mul_zero, zero_mul, add_zero]
-
-end CommSemiring
-
-/-! ### The Lie subalgebra of dual primitives -/
-
-attribute [local instance 100] LieRing.ofAssociativeRing
-
-section CommRing
-
-open WithConv
-
-variable {R : Type*} [CommRing R] {H : Type*} [Semiring H] [Bialgebra R H]
-  {L L₁ L₂ : H →ₗ[R] R} {x y : H}
-
-/-- A dual primitive vanishes at `1`. -/
-theorem IsDualPrimitive.map_one_eq_zero (hL : IsDualPrimitive R L) : L 1 = 0 := by
-  have h : L 1 = L 1 + L 1 := by simpa using hL 1 1
-  exact (add_left_cancel (a := L 1) (by rw [add_zero]; exact h)).symm
-
-private theorem sum_mul_expand {ιx ιy : Type*} (𝓡x : Coalgebra.Repr R x ιx)
-    (𝓡y : Coalgebra.Repr R y ιy) {M N : H →ₗ[R] R}
-    (hM : IsDualPrimitive R M) (hN : IsDualPrimitive R N) :
-    ∑ p ∈ 𝓡x.index ×ˢ 𝓡y.index,
-        M (𝓡x.left p.1 * 𝓡y.left p.2) * N (𝓡x.right p.1 * 𝓡y.right p.2) =
-      (∑ i ∈ 𝓡x.index, M (𝓡x.left i) * N (𝓡x.right i)) * counit y +
-        M x * N y + N x * M y +
-        counit x * ∑ j ∈ 𝓡y.index, M (𝓡y.left j) * N (𝓡y.right j) :=
-  calc
-    ∑ p ∈ 𝓡x.index ×ˢ 𝓡y.index,
-        M (𝓡x.left p.1 * 𝓡y.left p.2) * N (𝓡x.right p.1 * 𝓡y.right p.2) =
-        ∑ i ∈ 𝓡x.index, ∑ j ∈ 𝓡y.index,
-          ((M (𝓡x.left i) * N (𝓡x.right i)) * (counit (𝓡y.left j) * counit (𝓡y.right j)) +
-            ((M (𝓡x.left i) * counit (𝓡x.right i)) * (counit (𝓡y.left j) * N (𝓡y.right j)) +
-              ((counit (𝓡x.left i) * N (𝓡x.right i)) * (M (𝓡y.left j) * counit (𝓡y.right j)) +
-                (counit (𝓡x.left i) * counit (𝓡x.right i)) *
-                  (M (𝓡y.left j) * N (𝓡y.right j))))) := by
-      rw [Finset.sum_product]
-      exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by
-        rw [hM, hN]; ring
-    _ = _ := by
-      simp only [Finset.sum_add_distrib, ← Finset.sum_mul, ← Finset.mul_sum]
-      rw [𝓡y.sum_apply_mul_counit counit, 𝓡x.sum_apply_mul_counit M,
-        𝓡y.sum_counit_mul_apply N, 𝓡x.sum_counit_mul_apply N,
-        𝓡y.sum_apply_mul_counit M, 𝓡x.sum_apply_mul_counit counit]
-      ring
-
-/-- Dual primitives are closed under the convolution commutator bracket: the
-Sweedler expansion of `⁅L₁, L₂⁆ (x * y)` produces cross terms symmetric in
-`(L₁, L₂)`, which cancel in the commutator. -/
-theorem IsDualPrimitive.lie (h₁ : IsDualPrimitive R L₁) (h₂ : IsDualPrimitive R L₂) :
-    IsDualPrimitive R (⁅toConv L₁, toConv L₂⁆ : WithConv (H →ₗ[R] R)).ofConv := by
-  intro x y
-  rw [((ℛ R x).mul (ℛ R y)).lie_apply, (ℛ R x).lie_apply, (ℛ R y).lie_apply]
-  simp only [Coalgebra.Repr.mul_index, Coalgebra.Repr.mul_left, Coalgebra.Repr.mul_right,
-    Finset.sum_sub_distrib]
-  rw [sum_mul_expand _ _ h₁ h₂, sum_mul_expand _ _ h₂ h₁]
-  ring
-
-variable (R H) in
-/-- The dual primitives of a bialgebra `H`, as a Lie subalgebra of the
-convolution algebra `WithConv (H →ₗ[R] R)` under the ring commutator bracket. -/
-def dualPrimitives : LieSubalgebra R (WithConv (H →ₗ[R] R)) where
-  carrier := {L | IsDualPrimitive R L.ofConv}
-  zero_mem' x y := by simp
-  add_mem' {L₁ L₂} h₁ h₂ x y := by
-    simp only [ofConv_add, LinearMap.add_apply, h₁ x y, h₂ x y]; ring
-  smul_mem' c L hL x y := by
-    simp only [ofConv_smul, LinearMap.smul_apply, smul_eq_mul, hL x y]; ring
-  lie_mem' h₁ h₂ := h₁.lie h₂
-
-@[simp] theorem mem_dualPrimitives {L : WithConv (H →ₗ[R] R)} :
-    L ∈ dualPrimitives R H ↔ IsDualPrimitive R L.ofConv := Iff.rfl
-
-end CommRing
-
-end Bialgebra
-
-/-! ### Single-tree delta functionals on Connes-Kreimer -/
 
 namespace RootedTree
 

--- a/Linglib/Core/RingTheory/Bialgebra/Basic.lean
+++ b/Linglib/Core/RingTheory/Bialgebra/Basic.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.RingTheory.Bialgebra.Basic
+
+/-!
+# Sweedler representation of a product
+
+In a bialgebra, `comul (x * y) = comul x * comul y`, so Sweedler
+representations of `x` and `y` multiply to one of `x * y`. `[UPSTREAM]`
+candidate for `Mathlib.RingTheory.Bialgebra.Basic`, beside
+`Bialgebra.comul_mul`.
+-/
+
+namespace Coalgebra.Repr
+
+variable {R : Type*} [CommSemiring R]
+
+/-- Sweedler representation of a product `x * y` in a bialgebra, indexed by
+pairs: `left (i, j) = left i * left j` and `right (i, j) = right i * right j`. -/
+@[simps]
+noncomputable def mul {H : Type*} [Semiring H] [Bialgebra R H] {x y : H}
+    {ιx ιy : Type*} (𝓡x : Repr R x ιx) (𝓡y : Repr R y ιy) :
+    Repr R (x * y) (ιx × ιy) where
+  index := 𝓡x.index ×ˢ 𝓡y.index
+  left p := 𝓡x.left p.1 * 𝓡y.left p.2
+  right p := 𝓡x.right p.1 * 𝓡y.right p.2
+  eq := by
+    rw [Bialgebra.comul_mul, ← 𝓡x.eq, ← 𝓡y.eq, Finset.sum_product, Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ =>
+      (Algebra.TensorProduct.tmul_mul_tmul _ _ _ _).symm
+
+end Coalgebra.Repr

--- a/Linglib/Core/RingTheory/Bialgebra/DualPrimitives.lean
+++ b/Linglib/Core/RingTheory/Bialgebra/DualPrimitives.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.RingTheory.Coalgebra.Basic
+import Linglib.Core.RingTheory.Coalgebra.Convolution
+import Linglib.Core.RingTheory.Bialgebra.Basic
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Algebra.Lie.Subalgebra
+
+/-!
+# Dual primitives of a bialgebra
+
+A linear functional `L : H →ₗ[R] R` on a bialgebra is **primitive in the
+dual** when `L (x * y) = L x * ε y + ε x * L y`: the coproduct on the dual is
+dual to the product on `H`, so this reads `Δ L = L ⊗ ε + ε ⊗ L` after pairing
+against `x ⊗ y`.
+
+## Main declarations
+
+* `Bialgebra.IsDualPrimitive`: the predicate.
+* `Bialgebra.IsDualPrimitive.lie`: dual primitives are closed under the
+  convolution commutator bracket.
+* `Bialgebra.dualPrimitives`: the dual primitives as a Lie subalgebra of the
+  convolution algebra `WithConv (H →ₗ[R] R)` under the ring commutator
+  bracket.
+
+`[UPSTREAM]` candidate: mathlib has no primitives API; the structural
+precedent is `Mathlib.RingTheory.Coalgebra.GroupLike`.
+-/
+
+namespace Bialgebra
+
+open Coalgebra
+
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R] {H : Type*} [Semiring H] [Bialgebra R H]
+  {L : H →ₗ[R] R} {x y : H}
+
+variable (R) in
+/-- A linear functional `L : H →ₗ[R] R` is **primitive in the dual** of a
+bialgebra `H` if `L (x * y) = L x * ε y + ε x * L y`: the coproduct on the dual
+is dual to the product on `H`, so this reads `Δ L = L ⊗ ε + ε ⊗ L` after
+pairing against `x ⊗ y`. -/
+def IsDualPrimitive (L : H →ₗ[R] R) : Prop :=
+  ∀ x y : H, L (x * y) = L x * counit y + counit x * L y
+
+/-- A dual primitive vanishes on products of counit-less elements; in
+particular on decomposable basis elements of a graded bialgebra. -/
+theorem IsDualPrimitive.map_mul_eq_zero (hL : IsDualPrimitive R L)
+    (hx : counit (R := R) x = 0) (hy : counit (R := R) y = 0) : L (x * y) = 0 := by
+  rw [hL, hx, hy, mul_zero, zero_mul, add_zero]
+
+end CommSemiring
+
+/-! ### The Lie subalgebra of dual primitives -/
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+section CommRing
+
+open WithConv
+
+variable {R : Type*} [CommRing R] {H : Type*} [Semiring H] [Bialgebra R H]
+  {L L₁ L₂ : H →ₗ[R] R} {x y : H}
+
+/-- A dual primitive vanishes at `1`. -/
+theorem IsDualPrimitive.map_one_eq_zero (hL : IsDualPrimitive R L) : L 1 = 0 := by
+  have h : L 1 = L 1 + L 1 := by simpa using hL 1 1
+  exact (add_left_cancel (a := L 1) (by rw [add_zero]; exact h)).symm
+
+private theorem sum_mul_expand {ιx ιy : Type*} (𝓡x : Coalgebra.Repr R x ιx)
+    (𝓡y : Coalgebra.Repr R y ιy) {M N : H →ₗ[R] R}
+    (hM : IsDualPrimitive R M) (hN : IsDualPrimitive R N) :
+    ∑ p ∈ 𝓡x.index ×ˢ 𝓡y.index,
+        M (𝓡x.left p.1 * 𝓡y.left p.2) * N (𝓡x.right p.1 * 𝓡y.right p.2) =
+      (∑ i ∈ 𝓡x.index, M (𝓡x.left i) * N (𝓡x.right i)) * counit y +
+        M x * N y + N x * M y +
+        counit x * ∑ j ∈ 𝓡y.index, M (𝓡y.left j) * N (𝓡y.right j) :=
+  calc
+    ∑ p ∈ 𝓡x.index ×ˢ 𝓡y.index,
+        M (𝓡x.left p.1 * 𝓡y.left p.2) * N (𝓡x.right p.1 * 𝓡y.right p.2) =
+        ∑ i ∈ 𝓡x.index, ∑ j ∈ 𝓡y.index,
+          ((M (𝓡x.left i) * N (𝓡x.right i)) * (counit (𝓡y.left j) * counit (𝓡y.right j)) +
+            ((M (𝓡x.left i) * counit (𝓡x.right i)) * (counit (𝓡y.left j) * N (𝓡y.right j)) +
+              ((counit (𝓡x.left i) * N (𝓡x.right i)) * (M (𝓡y.left j) * counit (𝓡y.right j)) +
+                (counit (𝓡x.left i) * counit (𝓡x.right i)) *
+                  (M (𝓡y.left j) * N (𝓡y.right j))))) := by
+      rw [Finset.sum_product]
+      exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by
+        rw [hM, hN]; ring
+    _ = _ := by
+      simp only [Finset.sum_add_distrib, ← Finset.sum_mul, ← Finset.mul_sum]
+      rw [𝓡y.sum_apply_mul_counit counit, 𝓡x.sum_apply_mul_counit M,
+        𝓡y.sum_counit_mul_apply N, 𝓡x.sum_counit_mul_apply N,
+        𝓡y.sum_apply_mul_counit M, 𝓡x.sum_apply_mul_counit counit]
+      ring
+
+/-- Dual primitives are closed under the convolution commutator bracket: the
+Sweedler expansion of `⁅L₁, L₂⁆ (x * y)` produces cross terms symmetric in
+`(L₁, L₂)`, which cancel in the commutator. -/
+theorem IsDualPrimitive.lie (h₁ : IsDualPrimitive R L₁) (h₂ : IsDualPrimitive R L₂) :
+    IsDualPrimitive R (⁅toConv L₁, toConv L₂⁆ : WithConv (H →ₗ[R] R)).ofConv := by
+  intro x y
+  rw [((ℛ R x).mul (ℛ R y)).lie_apply, (ℛ R x).lie_apply, (ℛ R y).lie_apply]
+  simp only [Coalgebra.Repr.mul_index, Coalgebra.Repr.mul_left, Coalgebra.Repr.mul_right,
+    Finset.sum_sub_distrib]
+  rw [sum_mul_expand _ _ h₁ h₂, sum_mul_expand _ _ h₂ h₁]
+  ring
+
+variable (R H) in
+/-- The dual primitives of a bialgebra `H`, as a Lie subalgebra of the
+convolution algebra `WithConv (H →ₗ[R] R)` under the ring commutator bracket. -/
+def dualPrimitives : LieSubalgebra R (WithConv (H →ₗ[R] R)) where
+  carrier := {L | IsDualPrimitive R L.ofConv}
+  zero_mem' x y := by simp
+  add_mem' {L₁ L₂} h₁ h₂ x y := by
+    simp only [ofConv_add, LinearMap.add_apply, h₁ x y, h₂ x y]; ring
+  smul_mem' c L hL x y := by
+    simp only [ofConv_smul, LinearMap.smul_apply, smul_eq_mul, hL x y]; ring
+  lie_mem' h₁ h₂ := h₁.lie h₂
+
+@[simp] theorem mem_dualPrimitives {L : WithConv (H →ₗ[R] R)} :
+    L ∈ dualPrimitives R H ↔ IsDualPrimitive R L.ofConv := Iff.rfl
+
+end CommRing
+
+end Bialgebra

--- a/Linglib/Core/RingTheory/Coalgebra/Basic.lean
+++ b/Linglib/Core/RingTheory/Coalgebra/Basic.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.RingTheory.Coalgebra.Basic
+
+/-!
+# Counit collapse through a Sweedler representation
+
+Applying `L ⊗ ε` or `ε ⊗ L` to a Sweedler representation of `a` recovers
+`L a`, for any linear functional `L`. `[UPSTREAM]` candidates for
+`Mathlib.RingTheory.Coalgebra.Basic`, beside `Coalgebra.sum_counit_smul`.
+-/
+
+namespace Coalgebra.Repr
+
+variable {R : Type*} [CommSemiring R] {C : Type*} [AddCommMonoid C] [Module R C]
+  [Coalgebra R C] {ι : Type*} {a : C}
+
+/-- Applying `L ⊗ ε` to a Sweedler representation of `a` recovers `L a`. -/
+theorem sum_apply_mul_counit (𝓡 : Repr R a ι) (L : C →ₗ[R] R) :
+    ∑ i ∈ 𝓡.index, L (𝓡.left i) * counit (𝓡.right i) = L a := by
+  simpa only [map_sum, LinearMap.mul'_apply, mul_one] using
+    congrArg (LinearMap.mul' R R) (sum_map_tmul_counit_eq L a (repr := 𝓡))
+
+/-- Applying `ε ⊗ L` to a Sweedler representation of `a` recovers `L a`. -/
+theorem sum_counit_mul_apply (𝓡 : Repr R a ι) (L : C →ₗ[R] R) :
+    ∑ i ∈ 𝓡.index, counit (𝓡.left i) * L (𝓡.right i) = L a := by
+  simpa only [map_sum, LinearMap.mul'_apply, one_mul] using
+    congrArg (LinearMap.mul' R R) (sum_counit_tmul_map_eq L a (repr := 𝓡))
+
+end Coalgebra.Repr

--- a/Linglib/Core/RingTheory/Coalgebra/Convolution.lean
+++ b/Linglib/Core/RingTheory/Coalgebra/Convolution.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.RingTheory.Coalgebra.Convolution
+import Mathlib.Algebra.Ring.Commute
+
+/-!
+# Commutator bracket through a Sweedler representation
+
+Evaluation of the ring commutator `⁅f, g⁆` of the convolution algebra
+`WithConv (C →ₗ[R] A)` through a Sweedler representation. `[UPSTREAM]`
+candidate for `Mathlib.RingTheory.Coalgebra.Convolution`, beside
+`Coalgebra.Repr.convMul_apply`.
+-/
+
+namespace Coalgebra.Repr
+
+open WithConv
+
+variable {R : Type*} [CommSemiring R] {C : Type*} [AddCommMonoid C] [Module R C]
+  [Coalgebra R C] {ι : Type*} {a : C}
+
+/-- The ring commutator bracket on the convolution algebra, evaluated through a
+Sweedler representation. -/
+theorem lie_apply {A : Type*} [Ring A] [Algebra R A] (𝓡 : Repr R a ι)
+    (f g : WithConv (C →ₗ[R] A)) :
+    ⁅f, g⁆ a =
+      ∑ i ∈ 𝓡.index, (f (𝓡.left i) * g (𝓡.right i) - g (𝓡.left i) * f (𝓡.right i)) := by
+  rw [Ring.lie_def]
+  show (f * g) a - (g * f) a = _
+  rw [𝓡.convMul_apply, 𝓡.convMul_apply, Finset.sum_sub_distrib]
+
+end Coalgebra.Repr


### PR DESCRIPTION
Moves the general bialgebra sections of `InsertionLieDuality.lean` (#2027) to Core files mirroring their actual mathlib upstream destinations, leaving the file CK-specific:

- `Coalgebra/Basic.lean` (counit collapse lemmas, beside `sum_counit_smul`'s siblings), `Bialgebra/Basic.lean` (`Repr.mul`), `Coalgebra/Convolution.lean` (`Repr.lie_apply`), `Bialgebra/DualPrimitives.lean` (`IsDualPrimitive` + Lie subalgebra; precedent `RingTheory/Coalgebra/GroupLike`).
- Statements and proofs unchanged; MCB citations stay with the Connes-Kreimer application.