### PR TITLE
chore(Core/Algebra/RootedTree): move InsertionLieDuality to Primitive

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -42,7 +42,6 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
-import Linglib.Core.Algebra.RootedTree.InsertionLieDuality
 import Linglib.Core.Algebra.RootedTree.PreLie.Basic
 import Linglib.Core.Algebra.RootedTree.PreLie.Graft
 import Linglib.Core.Algebra.RootedTree.PreLie.Insert
@@ -55,6 +54,7 @@ import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNonplanar
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 import Linglib.Core.Algebra.RootedTree.PreLie.Path
+import Linglib.Core.Algebra.RootedTree.Primitive
 import Linglib.Core.Algebra.RotaBaxter
 import Linglib.Core.Algebra.RotaBaxterLaurent
 import Linglib.Core.Algebra.Semigroup.IdempotentPower

--- a/Linglib/Core/Algebra/RootedTree/Primitive.lean
+++ b/Linglib/Core/Algebra/RootedTree/Primitive.lean
@@ -7,7 +7,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.RingTheory.Bialgebra.Primitive
 
 /-!
-# Single-tree delta functionals are the dual primitives
+# Dual-primitive functionals on the Connes-Kreimer bialgebra
 [marcolli-chomsky-berwick-2025]
 
 Substrate for [marcolli-chomsky-berwick-2025]'s Lemma 1.7.3 (book pp. 78-79):


### PR DESCRIPTION
Renames the file to the per-development primitives-file convention that mathlib4#39841 establishes (`Coalgebra/Primitive` → `Bialgebra/Primitive` → per-carrier `Primitive`): after the #2029/#2030 splits its content is exactly the dual-primitives theory of the Connes-Kreimer bialgebra. The old name promised insertion/duality content the file never held; the insertion-side bridge will land with the pairing machinery.