### PR TITLE
refactor(Core/Algebra/RootedTree): dissolve umbrella namespace

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/BMinus.lean
+++ b/Linglib/Core/Algebra/RootedTree/BMinus.lean
@@ -9,6 +9,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.InsertionNodeDecomp
 import Linglib.Core.Data.Multiset.Antidiagonal
 import Mathlib.Tactic.Ring
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -46,7 +48,6 @@ route in Prop 3.2 uses B+/B- duality with Δ^ρ instead. This file
 provides the B+/B- adjoint property — the foundation of that route.
 -/
 
-namespace RootedTree
 
 namespace GrossmanLarson
 
@@ -1535,4 +1536,3 @@ theorem bMinusLin_gl_mul (a : α)
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffFactorization.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffFactorization.lean
@@ -9,6 +9,8 @@ import Mathlib.RingTheory.Coalgebra.Convolution
 import Mathlib.RingTheory.Bialgebra.Convolution
 import Mathlib.RingTheory.HopfAlgebra.Convolution
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Birkhoff factorization on the Connes–Kreimer Hopf algebra  `[UPSTREAM]`
 
@@ -52,7 +54,7 @@ convolution inverse `φ₋ ∘ S` of the character `φ₋` is read off directly 
 Prop. 3.1.7, Rem. 3.1.8)
 -/
 
-namespace RootedTree.ConnesKreimer
+namespace ConnesKreimer
 
 open scoped TensorProduct
 
@@ -342,4 +344,4 @@ theorem birkhoffFactorization (φ : ConnesKreimer R (Nonplanar α) →ₐ[R] ℛ
 
 end Factorization
 
-end RootedTree.ConnesKreimer
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffFactorizationSemiring.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffFactorizationSemiring.lean
@@ -6,6 +6,8 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.HopfAlgebraNonplanar
 import Linglib.Core.Algebra.RotaBaxter
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Semiring Birkhoff factorization on the Connes–Kreimer Hopf algebra  `[UPSTREAM]`
 
@@ -43,7 +45,7 @@ ring case `φ₋ = −R(φ̃)`, `φ₊ = (1−R)(φ̃)`). Because a semiring has
 [marcolli-chomsky-berwick-2025] (Def. 3.1.2, Def. 3.1.6, Prop. 3.1.9, Rem. 3.1.10)
 -/
 
-namespace RootedTree.ConnesKreimer.SemiringRenorm
+namespace ConnesKreimer.SemiringRenorm
 
 open scoped TensorProduct
 
@@ -142,4 +144,4 @@ theorem birkhoffFactorization_ofTree (hφ : φ 1 = 1) (T : Nonplanar α) :
   rw [← birkhoffPrepTree_unfold, birkhoffPlusTree]
   exact add_comm _ _
 
-end RootedTree.ConnesKreimer.SemiringRenorm
+end ConnesKreimer.SemiringRenorm

--- a/Linglib/Core/Algebra/RootedTree/BirkhoffLaurent.lean
+++ b/Linglib/Core/Algebra/RootedTree/BirkhoffLaurent.lean
@@ -6,6 +6,8 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
 import Linglib.Core.Algebra.RotaBaxterLaurent
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Birkhoff renormalization of Laurent-series characters  `[UPSTREAM]`
 
@@ -33,7 +35,7 @@ lives downstream in `Syntax/Minimalist/Merge/`.
 [marcolli-chomsky-berwick-2025] (§3.5.2, Prop. 3.1.7, Prop. 3.5.6)
 -/
 
-namespace RootedTree.ConnesKreimer
+namespace ConnesKreimer
 
 open LaurentSeries
 
@@ -87,4 +89,4 @@ theorem polarHahn_birkhoffPlus_of' (F : Forest (Nonplanar α)) :
     rw [Multiset.map_cons, Multiset.prod_cons]
     exact polarHahn_mul _ _ (polarHahn_birkhoffPlusTree φ T) ih
 
-end RootedTree.ConnesKreimer
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
+++ b/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
@@ -19,9 +19,9 @@ sibling `Coproduct/` files and `HopfAlgebraNonplanar.lean`.
 
 ## Main declarations
 
-* `RootedTree.Forest`: forests as multisets of trees; multiset addition is
+* `Nonplanar.Forest`: forests as multisets of trees; multiset addition is
   disjoint union.
-* `RootedTree.ConnesKreimer`: one-field wrapper around
+* `ConnesKreimer`: one-field wrapper around
   `AddMonoidAlgebra R (Forest T)`.
 * `ConnesKreimer.single`, `ConnesKreimer.of'`, `ConnesKreimer.ofTree`,
   `ConnesKreimer.coeff`: basis embeddings and coefficient extraction.
@@ -46,7 +46,6 @@ transport.
 
 noncomputable section
 
-namespace RootedTree
 
 /-! ## Forests
 
@@ -54,7 +53,9 @@ A **forest** is a multiset of trees. Multiset addition is the disjoint
 union (forest concatenation). -/
 
 /-- A forest of T-shaped trees: finite multiset. -/
-abbrev Forest (T : Type*) : Type _ := Multiset T
+abbrev RoseTree.Nonplanar.Forest (T : Type*) : Type _ := Multiset T
+
+open RoseTree RoseTree.Nonplanar
 
 /-! ## The carrier -/
 
@@ -473,6 +474,5 @@ def counit : ConnesKreimer R T →ₐ[R] R :=
 
 end ConnesKreimer
 
-end RootedTree
 
 end

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/CutAvoidingNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/CutAvoidingNonplanar.lean
@@ -1,5 +1,7 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Cut-avoiding trees in the nonplanar Connes–Kreimer coproduct
 [marcolli-chomsky-berwick-2025] [foissy-2002]
@@ -28,7 +30,7 @@ Consumed by `Minimalist.Merge.mergeOp_factor_out_singleton` /
 `mergeOp_pair_residual` (MCB Lemma 1.4.1 Case 1).
 -/
 
-namespace RootedTree.ConnesKreimer
+namespace ConnesKreimer
 
 variable {α : Type*}
 
@@ -98,4 +100,4 @@ lemma not_mem_pair {S S' : Nonplanar α} {W : Forest (Nonplanar α)}
 
 end CutAvoidingForestN
 
-end RootedTree.ConnesKreimer
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Defs.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Defs.lean
@@ -2,6 +2,8 @@ import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Data.RoseTree.Basic
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -43,7 +45,6 @@ but the cut enumeration F_v is the same. This file factors the cut
 enumeration out of the remainder choice.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -243,4 +244,3 @@ end Tests
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
@@ -6,6 +6,8 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -72,7 +74,6 @@ embedding); the right-channel trace-removal uses
 `strip_cutSummandsCP_sum_eq` + `strip_cutListSummandsG_unwrap_sum_eq`.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -220,10 +221,10 @@ private theorem stripTraceList_permList :
 end
 
 /-- Strip trace-placeholder subtrees from a `Nonplanar` tree. -/
-noncomputable def Nonplanar.stripTrace : Nonplanar (α ⊕ β) → Option (Nonplanar α) :=
+noncomputable def _root_.RoseTree.Nonplanar.stripTrace : Nonplanar (α ⊕ β) → Option (Nonplanar α) :=
   Quotient.lift stripTraceQuotient (fun _ _ h => stripTraceQuotient_perm h)
 
-@[simp] theorem Nonplanar.stripTrace_mk (t : RoseTree (α ⊕ β)) :
+@[simp] theorem _root_.RoseTree.Nonplanar.stripTrace_mk (t : RoseTree (α ⊕ β)) :
     Nonplanar.stripTrace (Nonplanar.mk t) =
       (RoseTree.stripTrace t).map Nonplanar.mk := rfl
 
@@ -265,7 +266,7 @@ The embedding `α → α ⊕ β` lifts componentwise to trees and forests via
 `RoseTree.map` / `Nonplanar.map` / `Multiset.map`. -/
 
 /-- Embed a `Nonplanar α` tree into `Nonplanar (α ⊕ β)` via `Sum.inl`. -/
-def Nonplanar.embedInl : Nonplanar α → Nonplanar (α ⊕ β) :=
+def _root_.RoseTree.Nonplanar.embedInl : Nonplanar α → Nonplanar (α ⊕ β) :=
   Nonplanar.map (Sum.inl : α → α ⊕ β)
 
 /-- Embed a forest of `Nonplanar α` trees into a forest of
@@ -321,7 +322,7 @@ private theorem RoseTree.stripTraceList_mapList_inl :
 
 end
 
-theorem Nonplanar.stripTrace_embedInl (T : Nonplanar α) :
+theorem _root_.RoseTree.Nonplanar.stripTrace_embedInl (T : Nonplanar α) :
     Nonplanar.stripTrace (Nonplanar.embedInl (β := β) T) = some T := by
   refine Quotient.inductionOn T ?_
   intro p
@@ -1072,4 +1073,3 @@ theorem comulDN_embedInl_eq_comulAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/GenericNonplanar.lean
@@ -1,5 +1,7 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -28,7 +30,7 @@ serves every coproduct instead of one bespoke copy per Δ.
   `comulCAlgHomN_eq_G` — the Δ^ρ / Δ^c instance bridges.
 -/
 
-namespace RootedTree.ConnesKreimer
+namespace ConnesKreimer
 
 open scoped TensorProduct
 
@@ -121,4 +123,4 @@ theorem comulAlgHomN_eq_G :
 theorem comulCAlgHomN_eq_G {β : Type*} (τ : Nonplanar (α ⊕ β) → β) :
     comulCAlgHomN (R := R) τ = comulAlgHomNG (R := R) (cutSummandsCN τ) := rfl
 
-end RootedTree.ConnesKreimer
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
@@ -3,6 +3,8 @@ import Linglib.Core.Data.RoseTree.Basic
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -66,7 +68,7 @@ The B+ operator only well-defines on `Multiset (Nonplanar α) → Nonplanar α`
 (unordered children of a new root). On `RoseTree α` with `Multiset`
 forests, B+ would need a canonical ordering. Hence the sorry-free
 coassoc proof for Δ^ρ lives in `Coproduct/PruningNonplanar.lean` on
-`RootedTree.Nonplanar α`. (Note: this Foissy clean coassoc strategy
+`Nonplanar α`. (Note: this Foissy clean coassoc strategy
 does NOT generalize to Δ^c — B+ is not a Hochschild 1-cocycle for the
 trace variant. Δ^c coassoc uses Grossman-Larson duality instead; see
 the GL substrate when it lands.)
@@ -78,7 +80,6 @@ Bialgebra structure (descent + coassoc + counit + Hopf antipode) lives
 in `Coproduct/PruningNonplanar.lean` and `HopfAlgebraNonplanar.lean`.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -212,4 +213,3 @@ noncomputable def comulAlgHomP :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -2,6 +2,8 @@ import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 -- Nested tensor squares `CK ⊗ (CK ⊗ CK)` need one extra pending step during
 -- instance synthesis: the chain `Semiring (CK ⊗ (CK ⊗ CK)) → Algebra R (CK ⊗ CK)
@@ -61,7 +63,6 @@ total weight of `C`:
   hypothesis at `ofTree T` and `of' C'`.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -698,4 +699,3 @@ noncomputable instance instBialgebraRho
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -6,6 +6,8 @@ import Mathlib.LinearAlgebra.TensorProduct.Basic
 import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.RingTheory.TensorProduct.Maps
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -50,7 +52,6 @@ calculus of `BMinus.lean`, which imports this file). The full
   `List.Forall₂` lift for the componentwise version.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -908,9 +909,9 @@ mutual
 /-- The empty cut `(0, T)` is a cut summand of every tree-level tree `T`. -/
 private theorem mem_cutSummandsP_zero : ∀ (T : RoseTree α),
     ((0 : Forest (RoseTree α)), T) ∈ cutSummandsP T
-  | .node a children => by
+  | .node a cs => by
     rw [cutSummandsP_node, Multiset.mem_map]
-    exact ⟨(0, children), mem_cutListSummandsP_zero children, rfl⟩
+    exact ⟨(0, cs), mem_cutListSummandsP_zero cs, rfl⟩
 
 /-- The empty cut `(0, ps)` is a list cut summand of every tree-level list `ps`. -/
 private theorem mem_cutListSummandsP_zero : ∀ (ps : List (RoseTree α)),
@@ -947,7 +948,7 @@ private theorem cutForestSummandsN_zero_mem (F : Forest (Nonplanar α)) :
 
 /-- A tree's depth is strictly less than the depth of any node containing
     it as a child. -/
-theorem Nonplanar.depth_lt_of_mem (T : Nonplanar α) (F : Forest (Nonplanar α))
+theorem _root_.RoseTree.Nonplanar.depth_lt_of_mem (T : Nonplanar α) (F : Forest (Nonplanar α))
     (hT : T ∈ F) (a : α) : T.depth < (Nonplanar.node a F).depth := by
   obtain ⟨ps, hps⟩ := exists_planar_list_rep F
   subst hps
@@ -1221,4 +1222,3 @@ calculus drives the duality proof). -/
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Trace.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Trace.lean
@@ -2,6 +2,8 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.Defs
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -84,10 +86,9 @@ policy `extractC τ`:
 ## Status
 
 `[UPSTREAM]` candidate; future home something like
-`Mathlib.Combinatorics.RootedTree.CoproductDecorated`. Sorry-free.
+`Mathlib.Combinatorics.Nonplanar.CoproductDecorated`. Sorry-free.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -249,4 +250,3 @@ end Tests
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceCoassoc.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceCoassoc.lean
@@ -31,7 +31,7 @@ exhaustive small-tree computation (canonical-form multiset comparison) before
 the structural proof, including the failure for marker-sensitive `τ`.
 -/
 
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 namespace DoubleCut
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -11,6 +11,8 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 -- Nested tensor squares `CK ⊗ (CK ⊗ CK)` need one extra pending step during
 -- instance synthesis: the chain `Semiring (CK ⊗ (CK ⊗ CK)) → Algebra R (CK ⊗ CK)
@@ -72,7 +74,7 @@ counterexamples in `scratch/validate_duality.lean` V4). The duality route
 works for the deletion variant Δ^ρ — see `Coproduct/PruningDuality.lean`.
 -/
 
-namespace RootedTree
+namespace ConnesKreimer
 
 open scoped TensorProduct
 open GrossmanLarson
@@ -88,7 +90,6 @@ remainder rather than `Option`). The descent applies whenever the
 `Nonplanar.mk`. For Δ^c (`extractC (τ ∘ Nonplanar.mk)`) this follows
 from `Perm.value_eq`. -/
 
-namespace ConnesKreimer
 
 /-! ### Pointwise projection for the G-form -/
 
@@ -482,7 +483,6 @@ theorem cutSummandsCP_proj_perm (τ : Nonplanar (α ⊕ β) → β)
       (cutSummandsCP (τ ∘ Nonplanar.mk) s).map projSummand :=
   cutSummandsG_proj_perm (extractC_mkComp_invariant τ) h
 
-end ConnesKreimer
 
 /-! ### Descent of `cutSummandsCP` through `Nonplanar.mk` -/
 
@@ -1323,7 +1323,6 @@ per-child cases. This is the substrate for the Δ^c per-tree counit law:
 under `(counit ⊗ id)`, only this summand survives, contributing
 `1 ⊗ ofTree T`. -/
 
-namespace ConnesKreimer
 
 /-- Helper: filter of `(s ×ˢ t)` by a conjunction predicate distributes
     into a product of filters. Used to factor the cardinality-zero
@@ -1501,7 +1500,6 @@ private theorem cutSummandsCN_filter_empty {α β : Type*}
   rw [Multiset.map_zero]
   rfl
 
-end ConnesKreimer
 
 /-- Sum-of-conditional helper: sum of a multiset map where each entry is
     conditionally zero equals the sum over the filtered subset. -/
@@ -1824,7 +1822,7 @@ variable {R'' : Type*} [CommRing R''] {α'' β'' : Type*}
     immediate from `Multiset.map_add` + `Multiset.sum_add`.
 
     Per MCB Lemma 1.2.10, this is the grading on V^c(𝔉_{SO_0}). -/
-def Forest.edgeCount {X : Type*} (F : Forest (Nonplanar X)) : ℕ :=
+def _root_.RoseTree.Nonplanar.Forest.edgeCount {X : Type*} (F : Forest (Nonplanar X)) : ℕ :=
   (F.map (fun T => T.numNodes - 1)).sum
 
 /-- **Graded piece V_n**: the subspace of `ConnesKreimer R'' (Nonplanar X)`
@@ -2022,4 +2020,4 @@ theorem comulCAlgHomN_of'_mem_gradedSpan
 
 end EdgeGrading
 
-end RootedTree
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
+++ b/Linglib/Core/Algebra/RootedTree/DysonSchwinger.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -64,7 +66,6 @@ shape in the CK algebra.
 `PruningNonplanar.lean` (B+ + Δ^ρ).
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -192,4 +193,3 @@ example (a : α) :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/FormSet.lean
+++ b/Linglib/Core/Algebra/RootedTree/FormSet.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -67,7 +69,6 @@ Lemma 1.16.5 (Δ^ω extends to extended workspaces F̃^R) deferred — needs
 a new "extended forest" type.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -244,4 +245,3 @@ example (a : α) (T : Nonplanar α) :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
@@ -17,6 +17,8 @@ import Mathlib.Data.Multiset.ZeroCons
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -100,7 +102,6 @@ bridge in `OudomGuinBridge.lean`
 and `Monoid` typeclass instances are registered there.
 -/
 
-namespace RootedTree
 
 /-! ### The Grossman-Larson Hopf algebra carrier -/
 
@@ -361,7 +362,7 @@ combinatorial formula at the `RoseTree` level (`PreLie/Insertion.lean`'s
 `Finsupp.linearCombination`. The substrate invariance theorems
 (Perm on host/guest, Perm on multiset arguments) are proved
 sorry-free in `PreLie/Insertion.lean` and
-`Algebra/RootedTree/PreLie/InsertionNonplanar.lean`. -/
+`Algebra/Nonplanar/PreLie/InsertionNonplanar.lean`. -/
 
 /-- Basis-level multi-graft on Multiset forests: each pair `(F_basis,
     G_basis)` produces a multiset of grafted forests, summed as basis
@@ -745,4 +746,3 @@ proved sorry-free in `GrossmanLarsonMonoid.lean` via the Oudom-Guin
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonAssoc.lean
@@ -8,6 +8,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.InsertionAddHost
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionCompose
 import Linglib.Core.Data.Multiset.Antidiagonal
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -44,7 +46,6 @@ closed; see `GrossmanLarsonMonoid.lean`.
 `[UPSTREAM]` candidate (jointly with the OudomGuinCirc layer).
 -/
 
-namespace RootedTree
 
 namespace GrossmanLarson
 
@@ -70,7 +71,7 @@ separately and prove by descent from the `RoseTree`-level `insertionForest`.
     bridge `RoseTree.Pathed.listChoices_bridge_powerset_paired`, plus
     `insertionForest_msform_invariance_guests` to bridge `RoseTree`-level guests with
     canonical `Quotient.out` representatives. -/
-theorem _root_.RootedTree.Nonplanar.insertionMultiset_add_host
+theorem _root_.RoseTree.Nonplanar.insertionMultiset_add_host
     (A B C : Forest (Nonplanar α)) :
     Nonplanar.insertionMultiset (A + B) C =
       (C.powerset.bind fun C₁ =>
@@ -424,7 +425,7 @@ private theorem forall2_perm_symm :
     This is the workhorse for descents that need to swap canonical reps for
     a convenient `RoseTree`-level list (e.g. `Q.out v :: B.toList.map Q.out` standing
     in for `(B + {v}).toList.map Q.out`). -/
-theorem _root_.RootedTree.Nonplanar.insertionMultiset_eq_of_reps
+theorem _root_.RoseTree.Nonplanar.insertionMultiset_eq_of_reps
     (F G : Forest (Nonplanar α)) (hosts guests : List (RoseTree α))
     (h_hosts : (Multiset.ofList (hosts.map Nonplanar.mk) :
       Multiset (Nonplanar α)) = F)
@@ -535,7 +536,7 @@ theorem _root_.RootedTree.Nonplanar.insertionMultiset_eq_of_reps
     representative-invariance lemma
     `Nonplanar.insertionMultiset_eq_of_reps` per-output to swap NIM applied
     to a `RoseTree`-level output `msform L` for the `RoseTree`-level engine applied to `L`. -/
-theorem _root_.RootedTree.Nonplanar.insertionMultiset_singleton_assoc
+theorem _root_.RoseTree.Nonplanar.insertionMultiset_singleton_assoc
     (A B : Forest (Nonplanar α)) (v : Nonplanar α) :
     (Nonplanar.insertionMultiset A B).bind
         (fun X => Nonplanar.insertionMultiset X {v}) =
@@ -1256,4 +1257,3 @@ theorem rhs_quintuple_form (F₁ F₂ F₃ : Forest (Nonplanar α)) :
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
@@ -7,6 +7,8 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarson
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -15,7 +17,7 @@ set_option autoImplicit false
 
 Completes the multiplicative structure of `GrossmanLarson R α` (defined in
 `GrossmanLarson.lean`) by lifting the integer-case associativity
-`GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw` (proved sorry-free in
+`ConnesKreimer.mul_assoc_basis_via_oudom_guin_pbw` (proved sorry-free in
 `OudomGuinBridge.lean` via Oudom-Guin + PBW) to arbitrary
 `CommSemiring R`, then registering `Semigroup`/`Monoid` instances.
 
@@ -42,7 +44,6 @@ injectivity), and that R-free equality re-applies for any R.
 `[UPSTREAM]` candidate. All results sorry-free.
 -/
 
-namespace RootedTree
 
 namespace GrossmanLarson
 
@@ -181,7 +182,7 @@ private theorem lhsMultiset_eq_rhsMultiset
   apply multiset_eq_of_sum_eq_int
   -- Reduce to associativity equation at ℤ.
   rw [← lhs_eq_sum_of' (R := ℤ), ← rhs_eq_sum_of' (R := ℤ)]
-  exact mul_assoc_basis_via_oudom_guin_pbw F₁ F₂ F₃
+  exact ConnesKreimer.mul_assoc_basis_via_oudom_guin_pbw F₁ F₂ F₃
 
 /-- **Basis-level associativity** (R-generic, `α : Type*`). Lifts the
     integer case `mul_assoc_basis_via_oudom_guin_pbw` (Q6, proved
@@ -371,4 +372,3 @@ noncomputable instance (priority := 50) instMonoid {R : Type*} [CommSemiring R] 
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -7,6 +7,8 @@ import Linglib.Core.Algebra.RootedTree.GrossmanLarson
 import Linglib.Core.Combinatorics.RootedTree.Aut
 import Mathlib.Tactic.Ring
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -64,7 +66,6 @@ The aut-cardinality substrate `Nonplanar.autCard` /
 `treeAutCard` / `forestAutCard`), also sorry-free.
 -/
 
-namespace RootedTree
 
 namespace GrossmanLarson
 
@@ -454,4 +455,3 @@ theorem pairing_of'_mul (W : Forest (Nonplanar α))
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
@@ -1,6 +1,8 @@
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -27,7 +29,6 @@ simulation harness (`scratch/validate_duality.lean`, V3/V3b batteries,
 exhaustive over forests of weight ≤ 3 plus duplicate-tree traps).
 -/
 
-namespace RootedTree
 
 namespace GrossmanLarson
 
@@ -222,7 +223,7 @@ private theorem antidiagonal_singleton_add {β : Type*} [DecidableEq β] (T' : �
     Proved by induction on `A` from `insertionMultiset_add_host`
     (peeling one host tree; `NIM({T}, G)` outputs are singleton
     forests, whose antidiagonal is the trivial two-way split). -/
-theorem _root_.RootedTree.Nonplanar.insertionMultiset_antidiagonal
+theorem _root_.RoseTree.Nonplanar.insertionMultiset_antidiagonal
     (A G : Forest (Nonplanar α)) :
     (Nonplanar.insertionMultiset A G).bind Multiset.antidiagonal =
       (Multiset.antidiagonal A).bind (fun pa =>
@@ -1033,4 +1034,3 @@ theorem pairing_product_of'_mul_of' (A B C₁ C₂ : Forest (Nonplanar α)) :
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/HopfAlgebraNonplanar.lean
@@ -3,6 +3,8 @@ import Mathlib.RingTheory.HopfAlgebra.Basic
 import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 import Mathlib.RingTheory.Coalgebra.Convolution
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -68,7 +70,6 @@ file is a candidate factoring of Foissy's specific recursion.
 
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -92,20 +93,20 @@ mutual
 private theorem cutSummandsP_subtree_depth_le :
     ∀ (T : RoseTree α) (cf : Forest (RoseTree α)) (rem : RoseTree α),
       (cf, rem) ∈ cutSummandsP T → ∀ T_i ∈ cf, T_i.depth ≤ T.depth
-  | .node a children, cf, rem, h_mem, T_i, h_T_i => by
+  | .node a cs₀, cf, rem, h_mem, T_i, h_T_i => by
     rw [cutSummandsP_node, Multiset.mem_map] at h_mem
     obtain ⟨⟨cf', rem'⟩, h_mem', h_eq⟩ := h_mem
     -- h_eq : (cf', .node a rem') = (cf, rem). Extract first component via congrArg.
     have h_cf : cf' = cf := congrArg Prod.fst h_eq
     rw [← h_cf] at h_T_i
-    -- (cf', rem') ∈ cutListSummandsP children, T_i ∈ cf'.
-    have hbd : T_i.depth ≤ (children.map RoseTree.depth).foldr max 0 :=
-      cutListSummandsP_subtree_depth_le children cf' rem' h_mem' T_i h_T_i
+    -- (cf', rem') ∈ cutListSummandsP cs₀, T_i ∈ cf'.
+    have hbd : T_i.depth ≤ (cs₀.map RoseTree.depth).foldr max 0 :=
+      cutListSummandsP_subtree_depth_le cs₀ cf' rem' h_mem' T_i h_T_i
     rw [RoseTree.depth_node]
     omega
 
 /-- For any `(cf, rem_list) ∈ cutListSummandsP cs`, every tree `T_i ∈ cf`
-    has depth bounded by the children's max depth. Mutual with
+    has depth bounded by the cs₀'s max depth. Mutual with
     `cutSummandsP_subtree_depth_le`. -/
 private theorem cutListSummandsP_subtree_depth_le :
     ∀ (cs : List (RoseTree α)) (cf : Forest (RoseTree α)) (rem_list : List (RoseTree α)),
@@ -159,7 +160,7 @@ end
 
 /-- For any `(cf, rem) ∈ cutSummandsN T` (any tree `T : Nonplanar α`), every
     tree `T_i ∈ cf` has strictly smaller depth than `T`. The strict bound
-    comes from the fact that `cf`'s trees are subtrees of children of `T`
+    comes from the fact that `cf`'s trees are subtrees of cs₀ of `T`
     (whose depth is `T.depth - 1`), and via the empty-cut term `(0, T)`'s
     `cf = 0` (no `T_i` to consider). -/
 theorem cutSummandsN_subtree_depth_lt (T : Nonplanar α)
@@ -181,17 +182,17 @@ theorem cutSummandsN_subtree_depth_lt (T : Nonplanar α)
   show (Nonplanar.mk T_i_p).depth < T₀.depth
   rw [Nonplanar.depth_mk]
   -- Use tree-level lemma: T_i_p.depth ≤ T₀.depth - 1.
-  -- Strategy: T₀ = .node a children for some a, children. cf_p ∈ cutListSummandsP children.
-  -- T_i_p ∈ cf_p means T_i_p.depth ≤ (children's max depth) = T₀.depth - 1.
+  -- Strategy: T₀ = .node a cs₀ for some a, cs₀. cf_p ∈ cutListSummandsP cs₀.
+  -- T_i_p ∈ cf_p means T_i_p.depth ≤ (cs₀'s max depth) = T₀.depth - 1.
   match T₀, h_mem_p with
-  | .node a children, h_mem_p =>
+  | .node a cs₀, h_mem_p =>
     rw [cutSummandsP_node, Multiset.mem_map] at h_mem_p
     obtain ⟨⟨cf_p', rem_p'⟩, h_mem_p', h_eq⟩ := h_mem_p
     have h_cf_eq : cf_p' = cf_p := congrArg Prod.fst h_eq
     rw [← h_cf_eq] at h_T_i_p_mem
-    have hbd : T_i_p.depth ≤ (children.map RoseTree.depth).foldr max 0 :=
-      cutListSummandsP_subtree_depth_le children cf_p' rem_p' h_mem_p' T_i_p h_T_i_p_mem
-    show T_i_p.depth < (RoseTree.node a children).depth
+    have hbd : T_i_p.depth ≤ (cs₀.map RoseTree.depth).foldr max 0 :=
+      cutListSummandsP_subtree_depth_le cs₀ cf_p' rem_p' h_mem_p' T_i_p h_T_i_p_mem
+    show T_i_p.depth < (RoseTree.node a cs₀).depth
     rw [RoseTree.depth_node]
     omega
 
@@ -210,14 +211,14 @@ mutual
 private theorem cutSummandsP_numNodes_eq :
     ∀ (T : RoseTree α) (cf : Forest (RoseTree α)) (rem : RoseTree α),
       (cf, rem) ∈ cutSummandsP T → (cf.map RoseTree.numNodes).sum + rem.numNodes = T.numNodes
-  | .node a children, cf, rem, h_mem => by
+  | .node a cs₀, cf, rem, h_mem => by
     rw [cutSummandsP_node, Multiset.mem_map] at h_mem
     obtain ⟨⟨cf', rem'⟩, h_mem', h_eq⟩ := h_mem
     have h_cf : cf' = cf := congrArg Prod.fst h_eq
     have h_rem : (RoseTree.node a rem' : RoseTree α) = rem := congrArg Prod.snd h_eq
     rw [← h_cf, ← h_rem]
-    -- (cf', rem') ∈ cutListSummandsP children, weight conservation by IH.
-    have hc := cutListSummandsP_numNodes_eq children cf' rem' h_mem'
+    -- (cf', rem') ∈ cutListSummandsP cs₀, weight conservation by IH.
+    have hc := cutListSummandsP_numNodes_eq cs₀ cf' rem' h_mem'
     rw [RoseTree.numNodes_node, RoseTree.numNodes_node]
     omega
 
@@ -368,11 +369,11 @@ mutual
 private lemma cutSummandsP_filter_card_zero :
     ∀ (T : RoseTree α),
       (cutSummandsP T).filter (fun pf => pf.1.card = 0) = {(0, T)}
-  | .node a children => by
+  | .node a cs₀ => by
     rw [cutSummandsP_node, Multiset.filter_map]
     -- Beta-reduce the composed predicate to (fun p => p.1.card = 0).
     simp only [Function.comp_def]
-    rw [cutListSummandsP_filter_card_zero children, Multiset.map_singleton]
+    rw [cutListSummandsP_filter_card_zero cs₀, Multiset.map_singleton]
 
 /-- The empty cut `(0, [])` appears with multiplicity exactly 1 in
     `cutListSummandsP cs`. Mutual with `cutSummandsP_filter_card_zero`. -/
@@ -908,4 +909,3 @@ noncomputable instance [DecidableEq α] [CharZero R] [NoZeroDivisors R] :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/Basic.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/Basic.lean
@@ -8,6 +8,8 @@ import Mathlib.Data.Finsupp.SMul
 import Mathlib.LinearAlgebra.Finsupp.LSum
 import Mathlib.Tactic.Abel
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -97,7 +99,6 @@ evaluation isn't the point."
 - `instRightPreLieRing` / `instRightPreLieAlgebra` — typeclass instances.
 -/
 
-namespace RootedTree
 
 /-! ### Carrier + module instances -/
 
@@ -1044,4 +1045,3 @@ noncomputable instance instRightPreLieAlgebra :
 
 end InsertionAlgebra
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertSum.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertSum.lean
@@ -10,6 +10,8 @@ import Mathlib.Data.Multiset.MapFold
 import Mathlib.Data.Multiset.ZeroCons
 import Mathlib.Tactic.Abel
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -253,9 +255,8 @@ The descent layer: lift `RoseTree.insertSum` to `Nonplanar α` via
 `Quotient.lift₂`, requiring invariance under `Perm` on both
 arguments. -/
 
-namespace RootedTree
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*}
 
@@ -651,6 +652,5 @@ example : Multiset.card
 
 end Tests
 
-end Nonplanar
+end RoseTree.Nonplanar
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/Insertion.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/Insertion.lean
@@ -43,7 +43,7 @@ namespace RoseTree
 
 namespace Pathed
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {α : Type*}
 

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionAddHost.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionAddHost.lean
@@ -44,7 +44,7 @@ namespace RoseTree
 
 namespace Pathed
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {α : Type*}
 

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionCompose.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionCompose.lean
@@ -7,6 +7,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.Graft
 import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
 import Linglib.Core.Algebra.RootedTree.PreLie.InsertionAddHost
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Singleton-guest composition of the multi-graft insertion
 

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNodeDecomp.lean
@@ -35,7 +35,7 @@ namespace RoseTree
 
 namespace Pathed
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {α : Type*}
 

--- a/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/InsertionNonplanar.lean
@@ -7,6 +7,8 @@ import Linglib.Core.Algebra.RootedTree.PreLie.Insertion
 import Linglib.Core.Data.RoseTree.Nonplanar
 import Mathlib.Data.Multiset.Basic
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -38,9 +40,8 @@ the Algebra leg; were it to graduate to `Combinatorics/`, the imports
 would become strictly hierarchical.
 -/
 
-namespace RootedTree
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*}
 
@@ -244,6 +245,5 @@ theorem insertionMultiset_singleton_rootValue
         = (Nonplanar.mk (Quotient.out T)).rootValue := (Nonplanar.rootValue_mk _).symm
       _ = T.rootValue := by rw [h_eq]
 
-end Nonplanar
+end RoseTree.Nonplanar
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridge.lean
@@ -12,6 +12,8 @@ import Mathlib.LinearAlgebra.Finsupp.VectorSpace
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Algebra.MonoidAlgebra.Basic
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -46,13 +48,13 @@ construction to the concrete Grossman-Larson product on
 
 Q3 + Q5c + Q6 chain fully proved. Grossman-Larson associativity over ℤ
 is now established via the OG `★` bridge.
-`#print axioms RootedTree.GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw`
+`#print axioms GrossmanLarson.mul_assoc_basis_via_oudom_guin_pbw`
 yields `[propext, Classical.choice, Quot.sound]` (no sorryAx).
 -/
 
 open PreLie.OudomGuinCirc
 
-namespace RootedTree
+namespace ConnesKreimer
 
 open GrossmanLarson
 
@@ -90,12 +92,12 @@ noncomputable def ckIsoSymmetricAlgebra :
 
 /-! ## §1b: Basis identification
 
-The iso `ckIsoSymmetricAlgebra` sends `ι (single t 1)` to `of' (singleton t)`.
+The iso `ckIsoSymmetricAlgebra` sends `ι (single t 1)` to `GrossmanLarson.of' (singleton t)`.
 This is the basis-level fingerprint we use to translate proofs between
 `SymAlg ℤ (InsertionAlgebra α)` and `ConnesKreimer ℤ (Nonplanar α)`. -/
 
 /-- The iso sends `ι(single t 1)` (basis element of SymAlg) to
-    `of'(singleton t)` (basis element of CK). -/
+    `GrossmanLarson.of'(singleton t)` (basis element of CK). -/
 theorem ckIsoSymmetricAlgebra_ι_single (t : Nonplanar α) :
     ckIsoSymmetricAlgebra
         (SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (Finsupp.single t (1 : ℤ))) =
@@ -134,9 +136,9 @@ theorem ckIsoSymmetricAlgebra_ι_single (t : Nonplanar α) :
 
 The two products on `ConnesKreimer ℤ (Nonplanar α)`:
 
-* Disjoint-union (the `CommSemiring` instance): `of' F * of' G = of' (F + G)`.
+* Disjoint-union (the `CommSemiring` instance): `GrossmanLarson.of' F * GrossmanLarson.of' G = GrossmanLarson.of' (F + G)`.
 * Grossman-Larson (the custom `Mul` on `GrossmanLarson R α`):
-  `of' F * of' G = Σ_{G₁ ⊆ G} of'(insertion F G₁) · (G - G₁)`.
+  `GrossmanLarson.of' F * GrossmanLarson.of' G = Σ_{G₁ ⊆ G} GrossmanLarson.of'(insertion F G₁) · (G - G₁)`.
 
 The Oudom-Guin `★` on `SymmetricAlgebra ℤ (InsertionAlgebra α)`, transported
 via `ckIsoSymmetricAlgebra`, equals the **Grossman-Larson** product (NOT the
@@ -176,9 +178,9 @@ will use:
    (Nonplanar.insertSum t s).map (fun r => {r})`. Descends (1) through
    `Quotient.mk` using `insertionForest_singleton` + `mk_insertSum`.
 
-3. **GL Leibniz substrate**: `insertion(op(A *_CK B))(op(of'({v}))) =
-   op(unop(insertion(op A)(op(of'({v})))) *_CK B) + op(A *_CK
-   unop(insertion(op B)(op(of'({v})))))`. Derived from existing
+3. **GL Leibniz substrate**: `insertion(op(A *_CK B))(op(GrossmanLarson.of'({v}))) =
+   op(unop(insertion(op A)(op(GrossmanLarson.of'({v})))) *_CK B) + op(A *_CK
+   unop(insertion(op B)(op(GrossmanLarson.of'({v})))))`. Derived from existing
    `Nonplanar.insertionMultiset_add_host` (powerset of `{v}` collapses to
    the Leibniz split) + bilinear extension.
 
@@ -327,35 +329,35 @@ omit [DecidableEq α] in
 /-- **Basis form of sub-substrate 1.3**: GL Leibniz at basis level.
 
     For `F_A, F_B : Forest, v : Nonplanar α`:
-    `insertion (of' (F_A + F_B)) (of' {v}) =
-        op (of' F_A * unop (insertion (of' F_B) (of' {v})))
-      + op (unop (insertion (of' F_A) (of' {v})) * of' F_B)`
+    `insertion (GrossmanLarson.of' (F_A + F_B)) (GrossmanLarson.of' {v}) =
+        op (GrossmanLarson.of' F_A * unop (insertion (GrossmanLarson.of' F_B) (GrossmanLarson.of' {v})))
+      + op (unop (insertion (GrossmanLarson.of' F_A) (GrossmanLarson.of' {v})) * GrossmanLarson.of' F_B)`
 
     Follows from `insertion_mul_distrib` with `C := {v}`. Since
     `{v}.powerset = 0 ::ₘ {{v}}`, the sum has exactly 2 terms; each
-    reduces via `of'_zero` + `insertion_one_right`. The `unop` on `of' F_A`
-    and `of' F_B` collapses to the CK side by definitional equality
-    (`unop` and `of'` are both identity wrt the underlying
+    reduces via `GrossmanLarson.of'_zero` + `insertion_one_right`. The `unop` on `GrossmanLarson.of' F_A`
+    and `GrossmanLarson.of' F_B` collapses to the CK side by definitional equality
+    (`unop` and `GrossmanLarson.of'` are both identity wrt the underlying
     `ConnesKreimer.of'`). -/
 private theorem GL_insertion_leibniz_basis_form [DecidableEq α]
     (F_A F_B : Forest (Nonplanar α)) (v : Nonplanar α) :
     insertion (R := ℤ)
-        (of' (F_A + F_B))
-        (of' ({v} : Multiset (Nonplanar α))) =
+        (GrossmanLarson.of' (F_A + F_B))
+        (GrossmanLarson.of' ({v} : Multiset (Nonplanar α))) =
       op
         ((ConnesKreimer.of' F_A : ConnesKreimer ℤ (Nonplanar α)) *
           unop (insertion (R := ℤ)
-            (of' F_B)
-            (of' ({v} : Multiset _)))) +
+            (GrossmanLarson.of' F_B)
+            (GrossmanLarson.of' ({v} : Multiset _)))) +
       op
         (unop (insertion (R := ℤ)
-            (of' F_A)
-            (of' ({v} : Multiset _))) *
+            (GrossmanLarson.of' F_A)
+            (GrossmanLarson.of' ({v} : Multiset _))) *
           (ConnesKreimer.of' F_B : ConnesKreimer ℤ (Nonplanar α))) := by
   rw [insertion_mul_distrib]
   -- LHS now: ({v}.powerset.map f).sum where
-  --   f C₁ = op (unop (insertion (of' F_A) (of' C₁)) *
-  --              unop (insertion (of' F_B) (of' ({v} - C₁))))
+  --   f C₁ = op (unop (insertion (GrossmanLarson.of' F_A) (GrossmanLarson.of' C₁)) *
+  --              unop (insertion (GrossmanLarson.of' F_B) (GrossmanLarson.of' ({v} - C₁))))
   -- Step 1: powerset {v} = 0 ::ₘ {{v}}.
   have h_powerset : (({v} : Multiset (Nonplanar α))).powerset =
         (0 : Multiset (Nonplanar α)) ::ₘ {({v} : Multiset (Nonplanar α))} := by
@@ -368,15 +370,15 @@ private theorem GL_insertion_leibniz_basis_form [DecidableEq α]
       Multiset.sum_singleton]
   -- Step 3: reduce {v} - 0 = {v} and {v} - {v} = 0.
   rw [tsub_zero, tsub_self]
-  -- Step 4: of' 0 = 1, insertion X 1 = X (twice).
-  rw [of'_zero,
+  -- Step 4: GrossmanLarson.of' 0 = 1, insertion X 1 = X (twice).
+  rw [GrossmanLarson.of'_zero,
       insertion_one_right,
       insertion_one_right]
-  -- LHS: op (unop (of' F_A) * unop (insertion (of' F_B) (of' {v}))) +
-  --      op (unop (insertion (of' F_A) (of' {v})) * unop (of' F_B))
-  -- RHS: op (of' F_A * unop (insertion (of' F_B) (of' {v}))) +
-  --      op (unop (insertion (of' F_A) (of' {v})) * of' F_B)
-  -- unop (of' F_X) = of' F_X by definitional equality.
+  -- LHS: op (unop (GrossmanLarson.of' F_A) * unop (insertion (GrossmanLarson.of' F_B) (GrossmanLarson.of' {v}))) +
+  --      op (unop (insertion (GrossmanLarson.of' F_A) (GrossmanLarson.of' {v})) * unop (GrossmanLarson.of' F_B))
+  -- RHS: op (GrossmanLarson.of' F_A * unop (insertion (GrossmanLarson.of' F_B) (GrossmanLarson.of' {v}))) +
+  --      op (unop (insertion (GrossmanLarson.of' F_A) (GrossmanLarson.of' {v})) * GrossmanLarson.of' F_B)
+  -- unop (GrossmanLarson.of' F_X) = GrossmanLarson.of' F_X by definitional equality.
   rfl
 
 /-- **Helper for 1.3**: Leibniz rule with right argument forced to be a
@@ -461,18 +463,18 @@ private theorem GL_insertion_leibniz_basis_right
           (A_single * unop (insertion
             (op (ConnesKreimer.of' F_B : ConnesKreimer ℤ _))
             (op (ConnesKreimer.of' ({v} : Multiset _)))))
-    -- Unfold A_single = r • of' F_A.
+    -- Unfold A_single = r • GrossmanLarson.of' F_A.
     have hA : A_single = r • (ConnesKreimer.of' F_A : ConnesKreimer ℤ (Nonplanar α)) :=
       ConnesKreimer.smul_single_one F_A r
     rw [hA]
     rw [smul_mul_assoc, ← ConnesKreimer.of'_add, op_smul,
         (insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
         LinearMap.smul_apply]
-    -- Bridge `op (of' (F_A + F_B))` ≡ `of' (F_A + F_B)` so
-    -- `GL_insertion_leibniz_basis_form` (stated with `of'`)
+    -- Bridge `op (GrossmanLarson.of' (F_A + F_B))` ≡ `GrossmanLarson.of' (F_A + F_B)` so
+    -- `GL_insertion_leibniz_basis_form` (stated with `GrossmanLarson.of'`)
     -- applies.
     show r • insertion
-        (of' (F_A + F_B)) (of' ({v} : Multiset _)) =
+        (GrossmanLarson.of' (F_A + F_B)) (GrossmanLarson.of' ({v} : Multiset _)) =
       _
     rw [GL_insertion_leibniz_basis_form, op_smul,
         (insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
@@ -551,7 +553,7 @@ private theorem GL_insertion_leibniz_left_singleton_guest
     have hB : B_single = r • (ConnesKreimer.of' F_B : ConnesKreimer ℤ (Nonplanar α)) :=
       ConnesKreimer.smul_single_one F_B r
     rw [hB]
-    -- A * (r • of' F_B) = r • (A * of' F_B). Then op + insertion scale out.
+    -- A * (r • GrossmanLarson.of' F_B) = r • (A * GrossmanLarson.of' F_B). Then op + insertion scale out.
     rw [mul_smul_comm, op_smul,
         (insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
         LinearMap.smul_apply, GL_insertion_leibniz_basis_right, op_smul,
@@ -559,7 +561,7 @@ private theorem GL_insertion_leibniz_left_singleton_guest
         LinearMap.smul_apply]
     simp only [smul_add, unop_smul, mul_smul_comm, op_smul]
 
-/-- **Helper**: `ckIso (ι (ofMultiset m)) = sum over m of of' {r}`. Used in
+/-- **Helper**: `ckIso (ι (ofMultiset m)) = sum over m of GrossmanLarson.of' {r}`. Used in
     the `ι w` case of `ckIso_circ_intertwine_basis_v`. -/
 private theorem ckIso_ι_ofMultiset (m : Multiset (Nonplanar α)) :
     (ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofMultiset m)) :
@@ -572,20 +574,20 @@ private theorem ckIso_ι_ofMultiset (m : Multiset (Nonplanar α)) :
   | cons a s ih =>
     rw [InsertionAlgebra.ofMultiset_cons, map_add, map_add, ih,
         Multiset.map_cons, Multiset.sum_cons]
-    -- Need: ckIso (ι (ofTree a)) = of' {a}.
+    -- Need: ckIso (ι (ofTree a)) = GrossmanLarson.of' {a}.
     congr 1
     show ckIsoSymmetricAlgebra (SymmetricAlgebra.ι ℤ _ (Finsupp.single a (1 : ℤ))) = _
     exact ckIsoSymmetricAlgebra_ι_single a
 
 /-- **Helper for Substrate 1**: special case where `v` is a single basis
-    tree `ofTree t` (so `ι v` corresponds to `of' {t}` on the GL side).
+    tree `ofTree t` (so `ι v` corresponds to `GrossmanLarson.of' {t}` on the GL side).
 
     Bilinearity-in-`v` extends this to the full substrate 1 via
     `Finsupp.induction_linear` on `v`.
 
     Proof by `SymmetricAlgebra.induction` on X, in 4 cases:
     * `algebraMap r`: `(r•1) ○ ι(ofTree t) = 0` (counit kills primitive);
-      RHS: `insertion 1 (of' {t}) = 0`.
+      RHS: `insertion 1 (GrossmanLarson.of' {t}) = 0`.
     * `ι w`: by Finsupp.induction_linear on w. Basis case `w = ofTree s`
       uses `circ_ι_ι` + `ofTree_mul_ofTree` + sub-substrate 1.2.
     * `mul X Y`: by `oudomGuinCirc_mul_ι` (Leibniz form) + IHs +
@@ -610,8 +612,8 @@ private theorem ckIso_circ_intertwine_basis_v
         (SymmetricAlgebra ℤ (InsertionAlgebra α)) 0)) = _
     rw [(algebraMap ℤ (SymmetricAlgebra ℤ (InsertionAlgebra α))).map_zero,
         smul_zero, map_zero]
-    -- RHS: insertion (op (ckIso (algebraMap r))) (op (of' {t})) =
-    --      insertion (r • op 1) (op (of' {t})) = r • insertion 1 (of' {t}) = r • 0 = 0.
+    -- RHS: insertion (op (ckIso (algebraMap r))) (op (GrossmanLarson.of' {t})) =
+    --      insertion (r • op 1) (op (GrossmanLarson.of' {t})) = r • insertion 1 (GrossmanLarson.of' {t}) = r • 0 = 0.
     show (0 : ConnesKreimer ℤ (Nonplanar α)) =
       unop (insertion
         (op (ckIsoSymmetricAlgebra
@@ -627,9 +629,9 @@ private theorem ckIso_circ_intertwine_basis_v
         (op (ConnesKreimer.of' ({t} : Multiset _))))
     rw [(insertion : GrossmanLarson ℤ α →ₗ[ℤ] _).map_smul,
         LinearMap.smul_apply]
-    -- Goal: 0 = (r • insertion 1 (op (of' {t}))).unop
+    -- Goal: 0 = (r • insertion 1 (op (GrossmanLarson.of' {t}))).unop
     rw [show op (ConnesKreimer.of' ({t} : Multiset (Nonplanar α))) =
-            of' ({t} : Multiset _) from rfl]
+            GrossmanLarson.of' ({t} : Multiset _) from rfl]
     rw [insertion_one_of'_ne_zero ({t} : Multiset _)
           (Multiset.singleton_ne_zero t),
         smul_zero, unop_zero]
@@ -644,9 +646,9 @@ private theorem ckIso_circ_intertwine_basis_v
       rw [oudomGuinCirc_eq_ofConv, map_add, WithConv.ofConv_add, LinearMap.add_apply,
           ← oudomGuinCirc_eq_ofConv, ← oudomGuinCirc_eq_ofConv]
     rw [h_add, map_add, ih_X, ih_Y]
-    -- RHS: unop (insertion (op (ckIso (X + Y))) (op (of' {t}))).
-    --    = unop (insertion (op (ckIso X + ckIso Y)) (op (of' {t})))   [ckIso preserves +]
-    --    = unop (insertion (op (ckIso X) + op (ckIso Y)) (op (of' {t})))   [op preserves +]
+    -- RHS: unop (insertion (op (ckIso (X + Y))) (op (GrossmanLarson.of' {t}))).
+    --    = unop (insertion (op (ckIso X + ckIso Y)) (op (GrossmanLarson.of' {t})))   [ckIso preserves +]
+    --    = unop (insertion (op (ckIso X) + op (ckIso Y)) (op (GrossmanLarson.of' {t})))   [op preserves +]
     --    = unop (insertion (op (ckIso X)) _ + insertion (op (ckIso Y)) _)   [insertion linear]
     --    = unop (insertion (op (ckIso X)) _) + unop (insertion (op (ckIso Y)) _)   [unop preserves +]
     rw [show ckIsoSymmetricAlgebra (X + Y) =
@@ -748,9 +750,9 @@ private theorem ckIso_circ_intertwine_basis_v
                 (Finsupp.single s (1 : ℤ))) = _
           exact ckIsoSymmetricAlgebra_ι_single s]
       rw [show op (ConnesKreimer.of' ({s} : Multiset (Nonplanar α))) =
-              of' ({s} : Multiset _) from rfl,
+              GrossmanLarson.of' ({s} : Multiset _) from rfl,
           show op (ConnesKreimer.of' ({t} : Multiset (Nonplanar α))) =
-              of' ({t} : Multiset _) from rfl,
+              GrossmanLarson.of' ({t} : Multiset _) from rfl,
           insertion_of'_of']
       show ((Nonplanar.insertSum s t).map fun r' =>
               (ConnesKreimer.of' ({r'} : Multiset (Nonplanar α)) :
@@ -760,7 +762,7 @@ private theorem ckIso_circ_intertwine_basis_v
       rw [show insertionBasis ({s} : Multiset (Nonplanar α))
               ({t} : Multiset _) =
             ((Nonplanar.insertionMultiset ({s} : Multiset _) ({t} : Multiset _)).map
-              fun F' => (of' (R := ℤ) F' :
+              fun F' => (GrossmanLarson.of' (R := ℤ) F' :
                 GrossmanLarson ℤ α)).sum from rfl,
           nonplanar_insertionMultiset_singletons s t,
           Multiset.map_map]
@@ -774,8 +776,8 @@ private theorem ckIso_circ_intertwine_basis_v
     rw [show ckIsoSymmetricAlgebra (X * Y) =
             ckIsoSymmetricAlgebra X * ckIsoSymmetricAlgebra Y from map_mul _ _ _]
     rw [GL_insertion_leibniz_left_singleton_guest]
-    -- RHS after 1.3: unop (op (unop (insertion (op (ckIso X)) (op (of' {t}))) * ckIso Y) +
-    --                       op (ckIso X * unop (insertion (op (ckIso Y)) (op (of' {t})))))
+    -- RHS after 1.3: unop (op (unop (insertion (op (ckIso X)) (op (GrossmanLarson.of' {t}))) * ckIso Y) +
+    --                       op (ckIso X * unop (insertion (op (ckIso Y)) (op (GrossmanLarson.of' {t})))))
     -- = unop (op (unop_thing * ckIso Y) + op (ckIso X * unop_thing)) [unop_add]
     -- = unop_thing * ckIso Y + ckIso X * unop_thing [unop ∘ op = id]
     show unop (insertion (op (ckIsoSymmetricAlgebra X))
@@ -804,7 +806,7 @@ private theorem ckIso_circ_intertwine_basis_v
 
     * `algebraMap r`: trivial. `(r•1) ○ ι v = r • (ε(ιv) • 1) = 0` since
       `ε(ιv) = 0` for primitive `ιv`. RHS reduces to `r • 0 = 0` since
-      `insertion (op (of' 0)) (of' {v}) = 0` (no original vertices to graft
+      `insertion (op (GrossmanLarson.of' 0)) (GrossmanLarson.of' {v}) = 0` (no original vertices to graft
       into for empty host).
     * `add`: linearity + IHs.
     * `ι w`: basis case. Uses `circ_ι_ι` (`ι w ○ ι w' = ι(w·w')`),
@@ -918,9 +920,9 @@ private theorem ckIso_circ_intertwine_insertion
             (op (ckIsoSymmetricAlgebra X))).map_smul r _)]
       rw [unop_smul]
     rw [lhs_reduce, rhs_reduce, h_basis]
-    -- Now: r • (insertion ... (op (of' {t}))).unop =
+    -- Now: r • (insertion ... (op (GrossmanLarson.of' {t}))).unop =
     --      r • (insertion ... (op (ckIso (ι (ofTree t))))).unop
-    -- Equal since ckIso (ι (ofTree t)) = of' {t}.
+    -- Equal since ckIso (ι (ofTree t)) = GrossmanLarson.of' {t}.
     rw [show ckIsoSymmetricAlgebra
             (SymmetricAlgebra.ι ℤ (InsertionAlgebra α) (InsertionAlgebra.ofTree t)) =
           ConnesKreimer.of' ({t} : Multiset _) from
@@ -934,9 +936,9 @@ splitting lemma (Prop 2.7(ii)). It is the route for the per-tprod
 singleton case `Nonplanar.insertionMultiset_singleton_assoc`. -/
 
 /-- **Helper for substrate 2**: iterated single-guest insertion
-    `ins (ins F (of' C)) (op of'{v})` splits into a "single-shot"
-    `ins F (of' (C + {v}))` term plus a sum over `Y ∈ NIM C {v}`
-    of `ins F (of' Y)`. The basis case `F = of' A` follows directly
+    `ins (ins F (GrossmanLarson.of' C)) (op GrossmanLarson.of'{v})` splits into a "single-shot"
+    `ins F (GrossmanLarson.of' (C + {v}))` term plus a sum over `Y ∈ NIM C {v}`
+    of `ins F (GrossmanLarson.of' Y)`. The basis case `F = GrossmanLarson.of' A` follows directly
     from `insertion_of'_of'` (twice) plus
     `Nonplanar.insertionMultiset_singleton_assoc`. -/
 private theorem GL_iterated_insertion_singleton_v
@@ -1017,8 +1019,8 @@ private theorem GL_iterated_insertion_singleton_v
         ins F_single (ConnesKreimer.of' (C + {v})) +
         ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
           (fun Y => ins F_single (ConnesKreimer.of' Y))).sum
-    -- ins is bilinear; reduce F_single = r • of' A.
-    have hF : F_single = r • (of' A : GrossmanLarson ℤ α) :=
+    -- ins is bilinear; reduce F_single = r • GrossmanLarson.of' A.
+    have hF : F_single = r • (GrossmanLarson.of' A : GrossmanLarson ℤ α) :=
       ConnesKreimer.smul_single_one A r
     rw [hF]
     -- Helper: insertion respects smul in first arg.
@@ -1027,11 +1029,11 @@ private theorem GL_iterated_insertion_singleton_v
       rw [show ins (r • X) = r • ins X from ins.map_smul r X]
       rfl
     rw [hins_smul_left]
-    -- Now LHS has `ins (r • ins (of'A) (of'C)) (op of'{v}) = r • ins (ins (of'A) (of'C)) (op of'{v})`
-    rw [show ins (r • ins (of' A : GrossmanLarson ℤ α)
+    -- Now LHS has `ins (r • ins (GrossmanLarson.of'A) (GrossmanLarson.of'C)) (op GrossmanLarson.of'{v}) = r • ins (ins (GrossmanLarson.of'A) (GrossmanLarson.of'C)) (op GrossmanLarson.of'{v})`
+    rw [show ins (r • ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
                   (ConnesKreimer.of' C : GrossmanLarson ℤ α))
               (op (ConnesKreimer.of' ({v} : Multiset _))) =
-            r • ins (ins (of' A : GrossmanLarson ℤ α)
+            r • ins (ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
                   (ConnesKreimer.of' C : GrossmanLarson ℤ α))
               (op (ConnesKreimer.of' ({v} : Multiset _))) from
         hins_smul_left _ _]
@@ -1039,10 +1041,10 @@ private theorem GL_iterated_insertion_singleton_v
     -- Sum side: pull r out.
     have h_smul_sum :
         ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
-          (fun Y => ins (r • (of' A : GrossmanLarson ℤ α))
+          (fun Y => ins (r • (GrossmanLarson.of' A : GrossmanLarson ℤ α))
             (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum =
         r • ((Nonplanar.insertionMultiset C ({v} : Multiset _)).map
-          (fun Y => ins (of' A : GrossmanLarson ℤ α)
+          (fun Y => ins (GrossmanLarson.of' A : GrossmanLarson ℤ α)
             (ConnesKreimer.of' Y : GrossmanLarson ℤ α))).sum := by
       rw [Multiset.smul_sum, Multiset.map_map]
       apply congr_arg Multiset.sum
@@ -1050,69 +1052,69 @@ private theorem GL_iterated_insertion_singleton_v
       intro Y _
       exact hins_smul_left _ _
     rw [h_smul_sum, ← smul_add]
-    -- Reduce to basis identity at F = of' A.
+    -- Reduce to basis identity at F = GrossmanLarson.of' A.
     congr 1
-    -- Basis identity: ins(ins(of'A)(of'C))(op of'{v}) = ins(of'A)(of'(C+{v})) +
-    --                                                  Σ_{Y ∈ NIM C {v}} ins(of'A)(of'Y)
+    -- Basis identity: ins(ins(GrossmanLarson.of'A)(GrossmanLarson.of'C))(op GrossmanLarson.of'{v}) = ins(GrossmanLarson.of'A)(GrossmanLarson.of'(C+{v})) +
+    --                                                  Σ_{Y ∈ NIM C {v}} ins(GrossmanLarson.of'A)(GrossmanLarson.of'Y)
     rw [hins]
     show insertion
-        (insertion (of' A : GrossmanLarson ℤ α)
-          (of' C : GrossmanLarson ℤ α))
-        (of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
+        (insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+          (GrossmanLarson.of' C : GrossmanLarson ℤ α))
+        (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
     rw [insertion_of'_of']
-    -- Inner: insertionBasis A C = (NIM A C).map of'.sum.
+    -- Inner: insertionBasis A C = (NIM A C).map GrossmanLarson.of'.sum.
     show insertion
         (((Nonplanar.insertionMultiset A C).map
-          fun F' => of' (R := ℤ) F').sum)
-        (of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
+          fun F' => GrossmanLarson.of' (R := ℤ) F').sum)
+        (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) = _
     -- Push insertion through the sum via insertion_sum_left.
     rw [insertion_sum_left, Multiset.map_map]
-    -- Per X ∈ NIM A C, insertion (of' X) (of' {v}) = insertionBasis X {v}.
+    -- Per X ∈ NIM A C, insertion (GrossmanLarson.of' X) (GrossmanLarson.of' {v}) = insertionBasis X {v}.
     have h_per_X : ∀ X : Forest (Nonplanar α),
-        insertion (of' X)
-            (of' ({v} : Multiset _) : GrossmanLarson ℤ α) =
+        insertion (GrossmanLarson.of' X)
+            (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) =
           ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
-            fun F' => of' (R := ℤ) F').sum := by
+            fun F' => GrossmanLarson.of' (R := ℤ) F').sum := by
       intro X
       rw [insertion_of'_of']
       rfl
     -- Rewrite the inner expression. After Multiset.map_map, the goal's map function
-    -- has shape (fun X => insertion (of' X) (of'{v}) : GrossmanLarson ℤ α).
+    -- has shape (fun X => insertion (GrossmanLarson.of' X) (GrossmanLarson.of'{v}) : GrossmanLarson ℤ α).
     rw [show ((fun (Y : GrossmanLarson ℤ α) =>
               insertion Y
-                (of' ({v} : Multiset _) : GrossmanLarson ℤ α)) ∘
-              fun (F' : Forest (Nonplanar α)) => of' (R := ℤ) F') =
+                (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α)) ∘
+              fun (F' : Forest (Nonplanar α)) => GrossmanLarson.of' (R := ℤ) F') =
           (fun X : Forest (Nonplanar α) =>
             ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
-              fun F' => of' (R := ℤ) F').sum) from by
+              fun F' => GrossmanLarson.of' (R := ℤ) F').sum) from by
         funext X
         exact h_per_X X]
-    -- Push the outer sum: ((bind).map of').sum form.
+    -- Push the outer sum: ((bind).map GrossmanLarson.of').sum form.
     rw [show ((Nonplanar.insertionMultiset A C).map
               (fun X => ((Nonplanar.insertionMultiset X ({v} : Multiset _)).map
-                fun F' => of' (R := ℤ) F').sum)).sum =
+                fun F' => GrossmanLarson.of' (R := ℤ) F').sum)).sum =
             (((Nonplanar.insertionMultiset A C).bind
                 fun X => Nonplanar.insertionMultiset X ({v} : Multiset _)).map
-              fun F' => of' (R := ℤ) F').sum from by
+              fun F' => GrossmanLarson.of' (R := ℤ) F').sum from by
           rw [Multiset.map_bind, Multiset.sum_bind]]
     -- Apply insertionMultiset_singleton_assoc.
     rw [Nonplanar.insertionMultiset_singleton_assoc]
     rw [Multiset.map_add, Multiset.sum_add]
     congr 1
-    · -- Left: NIM A (C + {v}) → ins (of' A) (of' (C+{v})) = insertionBasis A (C+{v}).
-      rw [show insertion (of' A : GrossmanLarson ℤ α)
+    · -- Left: NIM A (C + {v}) → ins (GrossmanLarson.of' A) (GrossmanLarson.of' (C+{v})) = insertionBasis A (C+{v}).
+      rw [show insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
                   (ConnesKreimer.of' (C + {v}) : GrossmanLarson ℤ α) =
-              insertion (of' A : GrossmanLarson ℤ α)
-                (of' (C + {v}) : GrossmanLarson ℤ α) from rfl,
+              insertion (GrossmanLarson.of' A : GrossmanLarson ℤ α)
+                (GrossmanLarson.of' (C + {v}) : GrossmanLarson ℤ α) from rfl,
           insertion_of'_of']
       rfl
-    · -- Right: (NIM C {v}).bind (NIM A ·) → Σ_{Y ∈ NIM C {v}} ins (of'A) (of'Y).
+    · -- Right: (NIM C {v}).bind (NIM A ·) → Σ_{Y ∈ NIM C {v}} ins (GrossmanLarson.of'A) (GrossmanLarson.of'Y).
       rw [Multiset.map_bind, Multiset.sum_bind]
       apply congr_arg Multiset.sum
       apply Multiset.map_congr rfl
       intro Y _
       rw [show (ConnesKreimer.of' Y : GrossmanLarson ℤ α) =
-              (of' Y : GrossmanLarson ℤ α) from rfl,
+              (GrossmanLarson.of' Y : GrossmanLarson ℤ α) from rfl,
           insertion_of'_of']
       rfl
 
@@ -1187,7 +1189,7 @@ private theorem zip_filter_f_map_mk (L : List (RoseTree α)) (m : List Bool) :
         rw [ih m]; rfl
 
 /-- **T2 reindexing key step**: the multiset-level reindexing that
-    expresses `F * insertion (op (of' B)) (op of'{v})` (expanded via
+    expresses `F * insertion (op (GrossmanLarson.of' B)) (op GrossmanLarson.of'{v})` (expanded via
     `mul_of'_sum_form` over `NIM B {v}`) as a sum over `B.powerset`.
     This is the `RoseTree`-level bucket-split lemma after descent through
     `listChoices_bridge_powerset_paired`.
@@ -1536,14 +1538,14 @@ private theorem GL_T2_reindexing_key
     `Nonplanar.insertionMultiset_singleton_assoc`.
 
     The four terms (T1 + T2 = T3 + T4):
-    * T1 = `F * op (G * of'{v})` — single-shot CK multiplication.
-    * T2 = `F * insertion (op G) (op of'{v})` — insert v into G first.
-    * T3 = `insertion (F * op G) (op of'{v})` — insert v into the
+    * T1 = `F * op (G * GrossmanLarson.of'{v})` — single-shot CK multiplication.
+    * T2 = `F * insertion (op G) (op GrossmanLarson.of'{v})` — insert v into G first.
+    * T3 = `insertion (F * op G) (op GrossmanLarson.of'{v})` — insert v into the
       GL-product.
-    * T4 = `op (unop (F * op G) * of'{v})` — append v to the CK image
+    * T4 = `op (unop (F * op G) * GrossmanLarson.of'{v})` — append v to the CK image
       of the GL-product.
 
-    Strategy: linearize G to basis `of' B`, expand T1, T3, T4 via
+    Strategy: linearize G to basis `GrossmanLarson.of' B`, expand T1, T3, T4 via
     `mul_of'_sum_form` over `Multiset.powerset_cons (v ::ₘ B)`. Apply
     `GL_insertion_leibniz_left_singleton_guest` summand-wise to T3,
     then `GL_iterated_insertion_singleton_v` to split each iterated
@@ -1583,7 +1585,7 @@ private theorem GL_product_split_mul_ι
           (0 : GrossmanLarson ℤ α) from rfl]
     rw [mul_zero_gl]
     rw [zero_mul, op_zero, mul_zero_gl]
-    -- LHS: 0 + F * insertion 0 (op of'{v}); push insertion 0 = 0.
+    -- LHS: 0 + F * insertion 0 (op GrossmanLarson.of'{v}); push insertion 0 = 0.
     have h_ins_zero : insertion (0 : GrossmanLarson ℤ α)
         (op (ConnesKreimer.of' ({v} : Multiset _))) = 0 :=
       ((insertion :
@@ -1609,7 +1611,7 @@ private theorem GL_product_split_mul_ι
           ConnesKreimer.of' {v})
     -- Distribute (G₁' + G₂') through each operation. We rewrite each subterm
     -- to a (G₁'-part + G₂'-part) form, then apply ih₁, ih₂.
-    -- T1: F * op((G₁'+G₂') * of'{v}) = F * op(G₁'*of'{v}) + F * op(G₂'*of'{v}).
+    -- T1: F * op((G₁'+G₂') * GrossmanLarson.of'{v}) = F * op(G₁'*GrossmanLarson.of'{v}) + F * op(G₂'*GrossmanLarson.of'{v}).
     have hT1 : F * op
           ((G₁' + G₂') * ConnesKreimer.of' ({v} : Multiset _)) =
         F * op (G₁' * ConnesKreimer.of' ({v} : Multiset _)) +
@@ -1622,7 +1624,7 @@ private theorem GL_product_split_mul_ι
           op (G₂' * ConnesKreimer.of' ({v} : Multiset _)) from rfl]
       exact (product F).map_add _ _
     rw [hT1]
-    -- T2: F * ins(op(G₁'+G₂'))(op of'{v}) = F * ins(opG₁')... + F * ins(opG₂')...
+    -- T2: F * ins(op(G₁'+G₂'))(op GrossmanLarson.of'{v}) = F * ins(opG₁')... + F * ins(opG₂')...
     have hT2 : F * insertion (op (G₁' + G₂'))
             (op (ConnesKreimer.of' ({v} : Multiset _))) =
         F * insertion (op G₁')
@@ -1644,7 +1646,7 @@ private theorem GL_product_split_mul_ι
         rw [LinearMap.map_add]; rfl]
       exact (product F).map_add _ _
     rw [hT2]
-    -- T3: ins(F * op(G₁'+G₂'))(op of'{v}) = ins(F * opG₁')(...) + ins(F * opG₂')(...)
+    -- T3: ins(F * op(G₁'+G₂'))(op GrossmanLarson.of'{v}) = ins(F * opG₁')(...) + ins(F * opG₂')(...)
     have hT3 : insertion (F * op (G₁' + G₂'))
             (op (ConnesKreimer.of' ({v} : Multiset _))) =
         insertion (F * op G₁')
@@ -1662,7 +1664,7 @@ private theorem GL_product_split_mul_ι
             (F * op G₁' + F * op G₂') = _
       rw [LinearMap.map_add]; rfl
     rw [hT3]
-    -- T4: op (unop (F * op (G₁'+G₂')) * of'{v}) similarly.
+    -- T4: op (unop (F * op (G₁'+G₂')) * GrossmanLarson.of'{v}) similarly.
     have hT4 : op
             (unop (F * op (G₁' + G₂')) *
               ConnesKreimer.of' ({v} : Multiset _)) =
@@ -1720,7 +1722,7 @@ private theorem GL_product_split_mul_ι
             (op (ConnesKreimer.of' ({v} : Multiset _)))) := by abel
     rw [hLHS_perm, ih₁', ih₂']
     abel
-  · -- G = single B r: scale out r, reduce to basis G = of' B.
+  · -- G = single B r: scale out r, reduce to basis G = GrossmanLarson.of' B.
     intro B r
     let G_single : ConnesKreimer ℤ (Nonplanar α) := ConnesKreimer.single B r
     show F * op (G_single * ConnesKreimer.of' {v}) +
@@ -1760,13 +1762,13 @@ private theorem GL_product_split_mul_ι
             (r • (F * op (ConnesKreimer.of' B : ConnesKreimer ℤ _))) = _
       rw [LinearMap.map_smul]
       rfl
-    -- T1: (r•of'B) * of'{v} = r • (of'B * of'{v}); op_smul; F * r•x = r•(F*x).
+    -- T1: (r•GrossmanLarson.of'B) * GrossmanLarson.of'{v} = r • (GrossmanLarson.of'B * GrossmanLarson.of'{v}); op_smul; F * r•x = r•(F*x).
     rw [smul_mul_assoc, op_smul, mul_smul_gl]
-    -- T2: op(r•of'B) = r•opof'B; insertion(r•_)_ = r•insertion__; F * r•x = r•(F*x).
+    -- T2: op(r•GrossmanLarson.of'B) = r•opof'B; insertion(r•_)_ = r•insertion__; F * r•x = r•(F*x).
     rw [op_smul, h_ins_smul_first, mul_smul_gl]
     -- T3: F * r•opof'B = r•(F*opof'B); insertion(r•_)_ = r•insertion__.
     rw [mul_smul_gl, h_T3_smul]
-    -- T4: unop(r•x) = r•unop x; (r•_)*of'{v} = r•(_*of'{v}); op(r•_) = r•op _.
+    -- T4: unop(r•x) = r•unop x; (r•_)*GrossmanLarson.of'{v} = r•(_*GrossmanLarson.of'{v}); op(r•_) = r•op _.
     rw [show unop (r • (F * op
             (ConnesKreimer.of' B : ConnesKreimer ℤ _))) =
           r • unop (F * op
@@ -1774,21 +1776,21 @@ private theorem GL_product_split_mul_ι
         smul_mul_assoc, op_smul]
     rw [← smul_add, ← smul_add]
     congr 1
-    -- ===== BASIS CASE G = of' B =====
-    -- T1 = F * op(of' B * of'{v}) = F * of'(B + {v}).
+    -- ===== BASIS CASE G = GrossmanLarson.of' B =====
+    -- T1 = F * op(GrossmanLarson.of' B * GrossmanLarson.of'{v}) = F * GrossmanLarson.of'(B + {v}).
     have hT1 : F * op
           ((ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) *
             ConnesKreimer.of' ({v} : Multiset _)) =
-        F * (of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) := by
+        F * (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) := by
       rw [← ConnesKreimer.of'_add]
       rfl
     rw [hT1]
-    -- op (of' B) = of' B, op (of' {v}) = of' {v} (definitionally).
+    -- op (GrossmanLarson.of' B) = GrossmanLarson.of' B, op (GrossmanLarson.of' {v}) = GrossmanLarson.of' {v} (definitionally).
     have hopofB : op
         (ConnesKreimer.of' B : ConnesKreimer ℤ (Nonplanar α)) =
-        (of' B : GrossmanLarson ℤ α) := rfl
+        (GrossmanLarson.of' B : GrossmanLarson ℤ α) := rfl
     rw [hopofB]
-    -- The basis case G = of' B has four terms aligned via:
+    -- The basis case G = GrossmanLarson.of' B has four terms aligned via:
     -- T1 split via mul_of'_sum_form + powerset_cons (two halves: T1a, T1b)
     -- T3 split via mul_of'_sum_form + insertion_sum_left + Leibniz + iterated split
     --   (three pieces: T3-first, T3-residue, T3-second).
@@ -1800,8 +1802,8 @@ private theorem GL_product_split_mul_ι
     --   T1b = T3-first (both = Σ_C₁ g_F (C₁+{v}) (B-C₁))
     --   T2 = T3-residue + T3-second (via GL_T2_reindexing_key).
     --
-    -- Goal: F * of'(B+{v}) + F * insertion (of' B) (op of'{v}) =
-    --       insertion (F * of' B) (op of'{v}) + op(unop(F * of' B) * of'{v}).
+    -- Goal: F * GrossmanLarson.of'(B+{v}) + F * insertion (GrossmanLarson.of' B) (op GrossmanLarson.of'{v}) =
+    --       insertion (F * GrossmanLarson.of' B) (op GrossmanLarson.of'{v}) + op(unop(F * GrossmanLarson.of' B) * GrossmanLarson.of'{v}).
     -- Define the per-(D : Multiset _) summand of mul_of'_sum_form, shared
     -- across T1, T3, T4 (the second slot varies, captured in T4 and T1a
     -- by passing in the "appended {v}" version).
@@ -1818,11 +1820,11 @@ private theorem GL_product_split_mul_ι
     --     T1a = Σ_{C₁ ⊆ B} g C₁ (v ::ₘ (B - C₁))
     --     T1b = Σ_{C₁ ⊆ B} g (v ::ₘ C₁) (B - C₁)
     have hT1_split :
-        F * (of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
+        F * (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
         (B.powerset.map (fun C₁ => g C₁ (v ::ₘ (B - C₁)))).sum +
         (B.powerset.map (fun C₁ => g (v ::ₘ C₁) (B - C₁))).sum := by
-      rw [show (of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
-              (of' (v ::ₘ B) : GrossmanLarson ℤ α) by rw [hB_add_v],
+      rw [show (GrossmanLarson.of' (B + ({v} : Multiset _)) : GrossmanLarson ℤ α) =
+              (GrossmanLarson.of' (v ::ₘ B) : GrossmanLarson ℤ α) by rw [hB_add_v],
           mul_of'_sum_form, Multiset.powerset_cons,
           Multiset.map_add, Multiset.sum_add, Multiset.map_map]
       congr 1
@@ -1873,26 +1875,26 @@ private theorem GL_product_split_mul_ι
     let f_F : Multiset (Nonplanar α) → ConnesKreimer ℤ (Nonplanar α) := fun C₁ =>
       unop
         (insertion F (ConnesKreimer.of' C₁ : GrossmanLarson ℤ α))
-    -- §B: T4 = T1a, i.e. op(unop(F * of'B) * of'{v}) = Σ_{C₁ ⊆ B} g C₁ (v ::ₘ (B - C₁)).
+    -- §B: T4 = T1a, i.e. op(unop(F * GrossmanLarson.of'B) * GrossmanLarson.of'{v}) = Σ_{C₁ ⊆ B} g C₁ (v ::ₘ (B - C₁)).
     have hT4_eq_T1a :
         op
-          (unop (F * (of' B : GrossmanLarson ℤ α)) *
+          (unop (F * (GrossmanLarson.of' B : GrossmanLarson ℤ α)) *
             ConnesKreimer.of' ({v} : Multiset _)) =
         (B.powerset.map (fun C₁ => g C₁ (v ::ₘ (B - C₁)))).sum := by
       rw [mul_of'_sum_form]
-      -- LHS = op (unop ((Σ_C₁ op(...)).sum) * of'{v}).
+      -- LHS = op (unop ((Σ_C₁ op(...)).sum) * GrossmanLarson.of'{v}).
       -- Step 1: unop pushes through the sum (general op-sum lemma).
       rw [h_unop_sum_gen, Multiset.map_map]
       -- Now the sum is over (unop ∘ op (... CK product ...)), which definitionally
       -- reduces to the CK product.
       rw [show (unop ∘ fun G₁ =>
             op
-              ((insertion F (of' G₁ : GrossmanLarson ℤ α)).unop *
-                (of' (B - G₁) : GrossmanLarson ℤ α).unop)) =
+              ((insertion F (GrossmanLarson.of' G₁ : GrossmanLarson ℤ α)).unop *
+                (GrossmanLarson.of' (B - G₁) : GrossmanLarson ℤ α).unop)) =
               fun G₁ => f_F G₁ * ConnesKreimer.of' (B - G₁) from rfl]
-      -- Step 2: push (* of'{v}) into the sum (CK comm-semiring distributivity).
+      -- Step 2: push (* GrossmanLarson.of'{v}) into the sum (CK comm-semiring distributivity).
       rw [← Multiset.sum_map_mul_right]
-      -- Step 3: per-summand, B - C₁ + {v} = v ::ₘ (B - C₁); fold up via of'_add.
+      -- Step 3: per-summand, B - C₁ + {v} = v ::ₘ (B - C₁); fold up via GrossmanLarson.of'_add.
       rw [show (B.powerset.map (fun C₁ : Multiset (Nonplanar α) =>
                 f_F C₁ * ConnesKreimer.of' (B - C₁) *
                   ConnesKreimer.of' ({v} : Multiset _))) =
@@ -1916,7 +1918,7 @@ private theorem GL_product_split_mul_ι
     --                       Σ_{Y' ∈ NIM (B - C₁) {v}} g C₁ Y']
     --       = T1b + Σ_{C₁ ⊆ B} (T3-residue(C₁) + T3-second(C₁))
     have hT3 :
-        insertion (F * (of' B : GrossmanLarson ℤ α))
+        insertion (F * (GrossmanLarson.of' B : GrossmanLarson ℤ α))
           (op (ConnesKreimer.of' ({v} : Multiset _))) =
         (B.powerset.map (fun C₁ => g (v ::ₘ C₁) (B - C₁))).sum +
         (B.powerset.map (fun C₁ =>
@@ -1925,18 +1927,18 @@ private theorem GL_product_split_mul_ι
           ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
             (fun Y' => g C₁ Y')).sum)).sum := by
       rw [mul_of'_sum_form]
-      -- LHS = insertion ((sum over C₁) g_F(C₁)(B-C₁)) (op of'{v}).
+      -- LHS = insertion ((sum over C₁) g_F(C₁)(B-C₁)) (op GrossmanLarson.of'{v}).
       rw [insertion_sum_left, Multiset.map_map]
       -- Per C₁: apply Leibniz. The composed map function is
-      --   (fun X => insertion X (op of'{v})) ∘ (fun G₁ => op (unop(...) * unop(...))),
-      -- which beta-reduces to (fun G₁ => insertion (op (...)) (op of'{v})). We
+      --   (fun X => insertion X (op GrossmanLarson.of'{v})) ∘ (fun G₁ => op (unop(...) * unop(...))),
+      -- which beta-reduces to (fun G₁ => insertion (op (...)) (op GrossmanLarson.of'{v})). We
       -- match the post-beta form (h_per_C₁) and step through it summand-wise.
       have h_per_C₁ : ∀ C₁ : Multiset (Nonplanar α),
           insertion
             (op
-              ((insertion F (of' C₁ :
+              ((insertion F (GrossmanLarson.of' C₁ :
                   GrossmanLarson ℤ α)).unop *
-                (of' (B - C₁) : GrossmanLarson ℤ α).unop))
+                (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α).unop))
             (op (ConnesKreimer.of' ({v} : Multiset _))) =
           g (v ::ₘ C₁) (B - C₁) +
           (((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
@@ -1945,41 +1947,41 @@ private theorem GL_product_split_mul_ι
             (fun Y' => g C₁ Y')).sum) := by
         intro C₁
         -- Apply GL_insertion_leibniz_left_singleton_guest with
-        --   A := unop(ins F (of' C₁)), B := of'(B - C₁) (as CK).
+        --   A := unop(ins F (GrossmanLarson.of' C₁)), B := GrossmanLarson.of'(B - C₁) (as CK).
         set A_arg : ConnesKreimer ℤ (Nonplanar α) :=
-          (insertion F (of' C₁ :
+          (insertion F (GrossmanLarson.of' C₁ :
             GrossmanLarson ℤ α)).unop with hA_arg
         set B_arg : ConnesKreimer ℤ (Nonplanar α) :=
-          (of' (B - C₁) : GrossmanLarson ℤ α).unop with hB_arg
+          (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α).unop with hB_arg
         have h_leibniz := GL_insertion_leibniz_left_singleton_guest A_arg B_arg v
         rw [h_leibniz]
-        -- First Leibniz piece: op(unop(ins (op A_arg)(op of'{v})) * B_arg).
-        --   op A_arg = op (unop (ins F (of' C₁))) = ins F (of' C₁).
+        -- First Leibniz piece: op(unop(ins (op A_arg)(op GrossmanLarson.of'{v})) * B_arg).
+        --   op A_arg = op (unop (ins F (GrossmanLarson.of' C₁))) = ins F (GrossmanLarson.of' C₁).
         rw [show op A_arg = insertion F
               (ConnesKreimer.of' C₁ : GrossmanLarson ℤ α) from
           op_unop _]
         -- Apply GL_iterated_insertion_singleton_v.
         rw [GL_iterated_insertion_singleton_v F C₁ v]
-        -- Second Leibniz piece: op(A_arg * unop(ins (op B_arg)(op of'{v}))).
-        --   op B_arg = of'(B - C₁).
+        -- Second Leibniz piece: op(A_arg * unop(ins (op B_arg)(op GrossmanLarson.of'{v}))).
+        --   op B_arg = GrossmanLarson.of'(B - C₁).
         rw [show op B_arg =
-              (of' (B - C₁) : GrossmanLarson ℤ α) from rfl]
+              (GrossmanLarson.of' (B - C₁) : GrossmanLarson ℤ α) from rfl]
         rw [show op (ConnesKreimer.of' ({v} : Multiset _)) =
-              (of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl]
+              (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl]
         rw [insertion_of'_of']
         -- After Leibniz + iterated split + insertion_of'_of':
-        --   LHS = op(unop((ins F (of'(C₁+{v})) + Σ_Y ins F (of' Y))) * B_arg) +
-        --         op(A_arg * unop((Σ_Y' of' Y').sum))
+        --   LHS = op(unop((ins F (GrossmanLarson.of'(C₁+{v})) + Σ_Y ins F (GrossmanLarson.of' Y))) * B_arg) +
+        --         op(A_arg * unop((Σ_Y' GrossmanLarson.of' Y').sum))
         rw [unop_add, add_mul, op_add]
         -- The first piece becomes T1b summand: g(v ::ₘ C₁)(B-C₁).
         rw [show C₁ + ({v} : Multiset (Nonplanar α)) = v ::ₘ C₁ by
           rw [add_comm, Multiset.singleton_add]]
         rw [add_assoc]
-        -- The first summand op(unop(ins F (of'(v::C₁))) * B_arg) reduces to
+        -- The first summand op(unop(ins F (GrossmanLarson.of'(v::C₁))) * B_arg) reduces to
         -- g (v::C₁) (B-C₁) definitionally; the congr 1 then leaves T3R+T3S = sum.
         congr 1
-        -- Remaining goal: op(unop(Σ_Y ins F (of' Y)) * B_arg) +
-        --                 op(A_arg * unop((Σ_Y' of' Y').sum)) =
+        -- Remaining goal: op(unop(Σ_Y ins F (GrossmanLarson.of' Y)) * B_arg) +
+        --                 op(A_arg * unop((Σ_Y' GrossmanLarson.of' Y').sum)) =
         --                 Σ_Y g Y (B-C₁) + Σ_Y' g C₁ Y'
         congr 1
         · -- T3-residue: distribute * B_arg through the sum.
@@ -2008,7 +2010,7 @@ private theorem GL_product_split_mul_ι
                 (fun Y' => g C₁ Y')).sum
           show op (A_arg *
               (((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
-                (fun F' => (of' (R := ℤ) F' :
+                (fun F' => (GrossmanLarson.of' (R := ℤ) F' :
                   GrossmanLarson ℤ α))).sum).unop) =
               ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
                 (fun Y' => g C₁ Y')).sum
@@ -2016,12 +2018,12 @@ private theorem GL_product_split_mul_ι
           rw [show (A_arg *
               ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
                 (unop ∘ fun F' : Multiset (Nonplanar α) =>
-                  (of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum :
+                  (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum :
               ConnesKreimer ℤ (Nonplanar α)) =
               ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
                 (fun F' : Multiset (Nonplanar α) => A_arg *
                   (unop ∘ fun F'' : Multiset (Nonplanar α) =>
-                    (of' (R := ℤ) F'' :
+                    (GrossmanLarson.of' (R := ℤ) F'' :
                       GrossmanLarson ℤ α)) F')).sum from
             Multiset.sum_map_mul_left.symm]
           rw [h_op_sum_gen, Multiset.map_map]
@@ -2034,8 +2036,8 @@ private theorem GL_product_split_mul_ι
       · apply congr_arg Multiset.sum
         apply Multiset.map_congr rfl
         intro C₁ _hC₁
-        -- The map function is (fun X => insertion X (op of'{v})) ∘ (fun G₁ => op (...))
-        -- which beta-reduces to insertion (op (...)) (op of'{v}) per C₁.
+        -- The map function is (fun X => insertion X (op GrossmanLarson.of'{v})) ∘ (fun G₁ => op (...))
+        -- which beta-reduces to insertion (op (...)) (op GrossmanLarson.of'{v}) per C₁.
         exact h_per_C₁ C₁
       -- Split the Σ(_ + _) into two sums via Multiset.sum_map_add.
       rw [← Multiset.sum_map_add]
@@ -2044,21 +2046,21 @@ private theorem GL_product_split_mul_ι
     --    via GL_T2_reindexing_key with g_consumer = g.
     have hT2 :
         F * insertion
-            (of' B : GrossmanLarson ℤ α)
+            (GrossmanLarson.of' B : GrossmanLarson ℤ α)
             (op (ConnesKreimer.of' ({v} : Multiset _))) =
         (B.powerset.map (fun C₁ =>
           ((Nonplanar.insertionMultiset C₁ ({v} : Multiset _)).map
             (fun Y => g Y (B - C₁))).sum +
           ((Nonplanar.insertionMultiset (B - C₁) ({v} : Multiset _)).map
             (fun Y' => g C₁ Y')).sum)).sum := by
-      -- Rewrite insertion (of' B)(op of'{v}) = insertion (of' B)(of' {v})
-      -- (definitional: op = id on of'{v}), then = insertionBasis B {v}.
+      -- Rewrite insertion (GrossmanLarson.of' B)(op GrossmanLarson.of'{v}) = insertion (GrossmanLarson.of' B)(GrossmanLarson.of' {v})
+      -- (definitional: op = id on GrossmanLarson.of'{v}), then = insertionBasis B {v}.
       rw [show op (ConnesKreimer.of' ({v} : Multiset _)) =
-              (of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl,
+              (GrossmanLarson.of' ({v} : Multiset _) : GrossmanLarson ℤ α) from rfl,
           insertion_of'_of']
       show F * ((Nonplanar.insertionMultiset B ({v} : Multiset _)).map
               (fun F' : Multiset (Nonplanar α) =>
-                (of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum = _
+                (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))).sum = _
       -- Push F * through the sum (general bilinear distribution).
       have h_F_mul_sum : ∀ s : Multiset (GrossmanLarson ℤ α),
           F * s.sum = (s.map (fun X => F * X)).sum := by
@@ -2077,9 +2079,9 @@ private theorem GL_product_split_mul_ι
           rw [ih]
           rfl
       rw [h_F_mul_sum, Multiset.map_map]
-      -- Per Y' ∈ NIM B {v}: F * of' Y' = mul_of'_sum_form over Y'.
+      -- Per Y' ∈ NIM B {v}: F * GrossmanLarson.of' Y' = mul_of'_sum_form over Y'.
       have h_per_Y : ∀ Y : Multiset (Nonplanar α),
-          F * (of' Y : GrossmanLarson ℤ α) =
+          F * (GrossmanLarson.of' Y : GrossmanLarson ℤ α) =
             (Y.powerset.map (fun D => g D (Y - D))).sum := by
         intro Y
         rw [mul_of'_sum_form]
@@ -2089,7 +2091,7 @@ private theorem GL_product_split_mul_ι
         rfl
       rw [show ((fun X : GrossmanLarson ℤ α => F * X) ∘
                 (fun F' : Multiset (Nonplanar α) =>
-                  (of' (R := ℤ) F' : GrossmanLarson ℤ α))) =
+                  (GrossmanLarson.of' (R := ℤ) F' : GrossmanLarson ℤ α))) =
               (fun Y => (Y.powerset.map (fun D => g D (Y - D))).sum) from by
         funext Y; exact h_per_Y Y]
       exact GL_T2_reindexing_key B v g
@@ -2273,7 +2275,7 @@ private theorem gl_product_eq_oudomGuinStar_tprod
       congr 1
       -- Basis case: v = ofTree t.
       -- This is the heart of the proof.
-      -- Notation: F := op(ckIso X), G := ckIso D, T := of'{t}.
+      -- Notation: F := op(ckIso X), G := ckIso D, T := GrossmanLarson.of'{t}.
       -- Goal: ckIso(X ★ (D · ι(ofTree t))) = F * op(ckIso D · ι(ofTree t)).
       -- Step 1: Apply SL split (oudomGuinStar_mul_ι_split) on LHS:
       --   X ★ (D · ι(ofTree t)) =
@@ -2345,11 +2347,11 @@ private theorem gl_product_eq_oudomGuinStar_tprod
           (Fin.init a i * InsertionAlgebra.ofTree t))
       -- Step 4: Apply ckIso to h_SL_split, split into +/- in CK, then transport
       -- to GL. The LHS (X★D) ○ ι v term goes via ckIso_circ_intertwine_insertion.
-      -- Define F := op(ckIso X), G := ckIso D, T := of'{t} as a CK Multiset.
+      -- Define F := op(ckIso X), G := ckIso D, T := GrossmanLarson.of'{t} as a CK Multiset.
       set F : GrossmanLarson ℤ α := op (ckIsoSymmetricAlgebra X)
         with hF
       set G : ConnesKreimer ℤ (Nonplanar α) := ckIsoSymmetricAlgebra D with hG
-      -- ckIso(ι(ofTree t)) = of'{t}.
+      -- ckIso(ι(ofTree t)) = GrossmanLarson.of'{t}.
       have h_ckIso_ι_ofTree :
           ckIsoSymmetricAlgebra
               (SymmetricAlgebra.ι ℤ (InsertionAlgebra α)
@@ -2394,29 +2396,29 @@ private theorem gl_product_eq_oudomGuinStar_tprod
         abel
       -- GL split (additive form).
       have h_GL_split := GL_product_split_mul_ι F G t
-      -- h_GL_split : F * op(G * of'{t}) + F * insertion(op G)(op of'{t})
-      --              = insertion(F * op G)(op of'{t}) + op(unop(F * op G) * of'{t})
+      -- h_GL_split : F * op(G * GrossmanLarson.of'{t}) + F * insertion(op G)(op GrossmanLarson.of'{t})
+      --              = insertion(F * op G)(op GrossmanLarson.of'{t}) + op(unop(F * op G) * GrossmanLarson.of'{t})
       -- Goal: ckIso(X★(D·ι(ofTree t))) = F * op(ckIso(D·ι(ofTree t)))
-      -- Rewrite ckIso(D · ι(ofTree t)) = G * of'{t}.
+      -- Rewrite ckIso(D · ι(ofTree t)) = G * GrossmanLarson.of'{t}.
       have h_ckIso_DιV :
           ckIsoSymmetricAlgebra
               (D * SymmetricAlgebra.ι ℤ _ (InsertionAlgebra.ofTree t)) =
             G * ConnesKreimer.of' ({t} : Multiset _) := by
         rw [map_mul, h_ckIso_ι_ofTree]
       rw [h_ckIso_DιV]
-      -- Now goal: ckIso(X★(D·ι(ofTree t))) = F * op(G * of'{t}).
+      -- Now goal: ckIso(X★(D·ι(ofTree t))) = F * op(G * GrossmanLarson.of'{t}).
       -- The plan:
-      -- (A) Express the (X★D)○ιv term in GL: ckIso((X★D)○ιv) = insertion(op(ckIso(X★D)))(op of'{t}) [substrate 1]
+      -- (A) Express the (X★D)○ιv term in GL: ckIso((X★D)○ιv) = insertion(op(ckIso(X★D)))(op GrossmanLarson.of'{t}) [substrate 1]
       --     and op(ckIso(X★D)) = F * op G [IH], so
-      --     ckIso((X★D)○ιv) = unop(insertion(F * op G)(op of'{t})).
-      -- (B) ckIso((X★D)·ιv) = ckIso(X★D) * of'{t} [ring hom + ι_single]
-      --                    = unop(F * op G) * of'{t} [IH] (in CK product).
-      -- (C) ckIso(X★(D○ιv)) = F * insertion(op G)(op of'{t}) [substrate via h_ih_sum + intertwine]
+      --     ckIso((X★D)○ιv) = unop(insertion(F * op G)(op GrossmanLarson.of'{t})).
+      -- (B) ckIso((X★D)·ιv) = ckIso(X★D) * GrossmanLarson.of'{t} [ring hom + ι_single]
+      --                    = unop(F * op G) * GrossmanLarson.of'{t} [IH] (in CK product).
+      -- (C) ckIso(X★(D○ιv)) = F * insertion(op G)(op GrossmanLarson.of'{t}) [substrate via h_ih_sum + intertwine]
       -- Combining (A)+(B) on RHS of h_SL_split_additive, and (C) for the third term:
       -- LHS = ckIso(X★(D·ιv)) and RHS = ckIso((X★D)○ιv) + ckIso((X★D)·ιv) - ckIso(X★(D○ιv))
       -- so:
-      --   ckIso(X★(D·ιv)) = unop(ins(F*opG)(op of'{t})) + (unop(F*opG)*of'{t}) - F*ins(opG)(op of'{t})
-      -- Using h_GL_split: F * op(G * of'{t}) = ins(F*opG)(...) + op(unop(F*opG) * of'{t}) - F * ins(op G)(...)
+      --   ckIso(X★(D·ιv)) = unop(ins(F*opG)(op GrossmanLarson.of'{t})) + (unop(F*opG)*GrossmanLarson.of'{t}) - F*ins(opG)(op GrossmanLarson.of'{t})
+      -- Using h_GL_split: F * op(G * GrossmanLarson.of'{t}) = ins(F*opG)(...) + op(unop(F*opG) * GrossmanLarson.of'{t}) - F * ins(op G)(...)
       -- These should match modulo unop/op being identity.
       --
       -- Step (A): rewrite term (X★D)○ιv via substrate.
@@ -2441,7 +2443,7 @@ private theorem gl_product_eq_oudomGuinStar_tprod
             unop (F * op G) *
               ConnesKreimer.of' ({t} : Multiset _) := by
         rw [map_mul, h_ckIso_ι_ofTree]
-        -- Need: ckIso(X★D) * of'{t} = unop(F * op G) * of'{t}.
+        -- Need: ckIso(X★D) * GrossmanLarson.of'{t} = unop(F * op G) * GrossmanLarson.of'{t}.
         -- h_ih_init says ckIso(X★D) = F * op G (as GL, but GL=CK by def).
         -- unop(F * op G) = F * op G as CK element (unop is identity).
         rw [show ckIsoSymmetricAlgebra (oudomGuinStar X D) =
@@ -2457,17 +2459,17 @@ private theorem gl_product_eq_oudomGuinStar_tprod
               (op (ConnesKreimer.of' ({t} : Multiset _))) := by
         -- Rewrite LHS via direct chain: use the substrate intertwine on D ○ ι(ofTree t)
         -- and IH-summand sum.
-        -- ckIso(D ○ ι(ofTree t)) = unop(insertion(op(ckIso D))(op of'{t}))
-        --                       = unop(insertion(op G)(op of'{t}))
-        -- so as a CK element, equals the GL `insertion(op G)(op of'{t})`.
+        -- ckIso(D ○ ι(ofTree t)) = unop(insertion(op(ckIso D))(op GrossmanLarson.of'{t}))
+        --                       = unop(insertion(op G)(op GrossmanLarson.of'{t}))
+        -- so as a CK element, equals the GL `insertion(op G)(op GrossmanLarson.of'{t})`.
         -- Now we need ckIso(X ★ Z) where Z = ckIso(D ○ ι(ofTree t)) (as CK element).
         -- We use h_ih_sum which expresses this as a sum, and the sum-form via
         -- h_DcircTV (D ○ ι v = ∑ algHomL(...)) gives us the sum.
-        -- Final identification: F * insertion(op G)(op of'{t}) is in GL; the sum
+        -- Final identification: F * insertion(op G)(op GrossmanLarson.of'{t}) is in GL; the sum
         -- of F * op(ckIso(algHomL ...)) equals F * op(ckIso(∑ algHomL ...))
         -- (by map_sum + multiplication distributivity).
         rw [h_ih_sum]
-        -- Goal: ∑ i, F * op(ckIso(algHomL(tprod _ ...))) = F * insertion(op G)(op of'{t})
+        -- Goal: ∑ i, F * op(ckIso(algHomL(tprod _ ...))) = F * insertion(op G)(op GrossmanLarson.of'{t})
         -- Convert F * (...) to (product F) (...) (definitionally).
         show ∑ i : Fin m, (product F)
           (op (ckIsoSymmetricAlgebra
@@ -2479,7 +2481,7 @@ private theorem gl_product_eq_oudomGuinStar_tprod
             (op (ConnesKreimer.of' ({t} : Multiset _)))
         -- Push F * out of the sum.
         rw [← _root_.map_sum (product F) _ Finset.univ]
-        -- Goal: GL.product F (∑ ...) = F * insertion(op G)(op of'{t})
+        -- Goal: GL.product F (∑ ...) = F * insertion(op G)(op GrossmanLarson.of'{t})
         show F * _ = _
         congr 1
         -- ∑ i, op(ckIso(algHomL(...))) = op(ckIso(∑ i, algHomL(...))) [op,ckIso linear].
@@ -2512,7 +2514,7 @@ private theorem gl_product_eq_oudomGuinStar_tprod
         rw [← h_DcircTV]
         rw [ckIso_circ_intertwine_insertion D (InsertionAlgebra.ofTree t)]
         rw [h_ckIso_ι_ofTree]
-        -- Goal: op(unop(insertion(op G)(op of'{t}))) = insertion(op G)(op of'{t})
+        -- Goal: op(unop(insertion(op G)(op GrossmanLarson.of'{t}))) = insertion(op G)(op GrossmanLarson.of'{t})
         rfl
       -- Apply h_GL_split + the three step rewrites to close the goal.
       -- h_SL_split_additive (in CK):
@@ -2520,23 +2522,23 @@ private theorem gl_product_eq_oudomGuinStar_tprod
       -- Substitute h_term_A, h_term_B, h_term_C (the latter two as
       -- equations in GL, but since CK = GL by def, all live additively).
       -- After substitution:
-      --   LHS_target + F*ins(op G)(op of'{t})
-      --     = unop(ins(F*opG)(op of'{t})) + (unop(F*opG) * of'{t})
+      --   LHS_target + F*ins(op G)(op GrossmanLarson.of'{t})
+      --     = unop(ins(F*opG)(op GrossmanLarson.of'{t})) + (unop(F*opG) * GrossmanLarson.of'{t})
       -- Apply h_GL_split rearranged:
-      --   ins(F*opG)(op of'{t}) + op(unop(F*opG) * of'{t})
-      --     = F * op(G * of'{t}) + F * ins(op G)(op of'{t})
+      --   ins(F*opG)(op GrossmanLarson.of'{t}) + op(unop(F*opG) * GrossmanLarson.of'{t})
+      --     = F * op(G * GrossmanLarson.of'{t}) + F * ins(op G)(op GrossmanLarson.of'{t})
       -- The unop/op identity pair turns this CK equality (via CK=GL=def) into:
-      --   unop(ins(F*opG)(op of'{t})) + unop(F*opG) * of'{t}
-      --     = F * op(G * of'{t}) + F * ins(op G)(op of'{t})
+      --   unop(ins(F*opG)(op GrossmanLarson.of'{t})) + unop(F*opG) * GrossmanLarson.of'{t}
+      --     = F * op(G * GrossmanLarson.of'{t}) + F * ins(op G)(op GrossmanLarson.of'{t})
       -- which combined with h_SL_split_additive gives the goal.
-      -- Concretely: derive goal by add_right_cancel on F*ins(op G)(op of'{t}).
-      -- Goal: LHS_target = F * op(G * of'{t}).
+      -- Concretely: derive goal by add_right_cancel on F*ins(op G)(op GrossmanLarson.of'{t}).
+      -- Goal: LHS_target = F * op(G * GrossmanLarson.of'{t}).
       -- Approach: prove
-      --   LHS_target + F*ins(op G)(op of'{t}) = F*op(G*of'{t}) + F*ins(op G)(op of'{t})
+      --   LHS_target + F*ins(op G)(op GrossmanLarson.of'{t}) = F*op(G*GrossmanLarson.of'{t}) + F*ins(op G)(op GrossmanLarson.of'{t})
       -- and cancel.
       -- Work in CK throughout for the `+` form (avoids GL HAdd mismatch).
       -- Form ALL CK equations from substrates:
-      -- (C-as-CK): ckIso(X ★ (D○ι(ofTree t))) = unop(F * insertion(op G)(op of'{t}))
+      -- (C-as-CK): ckIso(X ★ (D○ι(ofTree t))) = unop(F * insertion(op G)(op GrossmanLarson.of'{t}))
       have h_term_C_CK :
           ckIsoSymmetricAlgebra
               (oudomGuinStar X
@@ -2547,11 +2549,11 @@ private theorem gl_product_eq_oudomGuinStar_tprod
               (op (ConnesKreimer.of' ({t} : Multiset _)))) :=
         h_term_C
       -- Apply unop to h_GL_split to get a CK equation.
-      -- h_GL_split: F*op(G*of'{t}) + F*insertion(op G)(op of'{t})
-      --           = insertion(F*op G)(op of'{t}) + op(unop(F*op G) * of'{t})
+      -- h_GL_split: F*op(G*GrossmanLarson.of'{t}) + F*insertion(op G)(op GrossmanLarson.of'{t})
+      --           = insertion(F*op G)(op GrossmanLarson.of'{t}) + op(unop(F*op G) * GrossmanLarson.of'{t})
       -- Take unop of both sides (op_unop = id):
-      -- unop(F*op(G*of'{t})) + unop(F*insertion(op G)(op of'{t}))
-      --   = unop(insertion(F*op G)(op of'{t})) + (unop(F*op G) * of'{t})
+      -- unop(F*op(G*GrossmanLarson.of'{t})) + unop(F*insertion(op G)(op GrossmanLarson.of'{t}))
+      --   = unop(insertion(F*op G)(op GrossmanLarson.of'{t})) + (unop(F*op G) * GrossmanLarson.of'{t})
       have h_GL_split_CK :
           unop (F * op
               (G * ConnesKreimer.of' ({t} : Multiset _))) +
@@ -2571,11 +2573,11 @@ private theorem gl_product_eq_oudomGuinStar_tprod
       --   ckIso(X★(D·ι(ofTree t))) + ckIso(X★(D○ι(ofTree t)))
       --     = ckIso((X★D)○ι(ofTree t)) + ckIso((X★D)·ι(ofTree t))
       -- Substitute the term_A/B/C-CK forms:
-      --   ckIso(X★(D·ι(ofTree t))) + unop(F * ins(op G)(op of'{t}))
-      --     = unop(ins(F*op G)(op of'{t})) + (unop(F*op G) * of'{t})
+      --   ckIso(X★(D·ι(ofTree t))) + unop(F * ins(op G)(op GrossmanLarson.of'{t}))
+      --     = unop(ins(F*op G)(op GrossmanLarson.of'{t})) + (unop(F*op G) * GrossmanLarson.of'{t})
       -- By h_GL_split_CK this equals:
-      --   unop(F*op(G*of'{t})) + unop(F*ins(op G)(op of'{t}))
-      -- Cancel the common unop(F*ins(op G)(op of'{t})) term.
+      --   unop(F*op(G*GrossmanLarson.of'{t})) + unop(F*ins(op G)(op GrossmanLarson.of'{t}))
+      -- Cancel the common unop(F*ins(op G)(op GrossmanLarson.of'{t})) term.
       have h_goal_CK :
           ckIsoSymmetricAlgebra
               (oudomGuinStar X
@@ -2597,12 +2599,12 @@ private theorem gl_product_eq_oudomGuinStar_tprod
           -- Apply ← h_term_C_CK ONLY on LHS, then chain rewrites on LHS.
           conv_lhs => rw [← h_term_C_CK]
           rw [h_SL_split_additive, h_term_A, h_term_B]
-          -- Now LHS is `unop(ins(F*op G)(...)) + (unop(F*op G) * of'{t})`
-          -- and RHS is `unop(F*op(G*of'{t})) + unop(F*ins(op G)(...))`.
+          -- Now LHS is `unop(ins(F*op G)(...)) + (unop(F*op G) * GrossmanLarson.of'{t})`
+          -- and RHS is `unop(F*op(G*GrossmanLarson.of'{t})) + unop(F*ins(op G)(...))`.
           -- These match h_GL_split_CK (with sides swapped).
           exact h_GL_split_CK.symm
         exact add_right_cancel h_LHS_plus_CK
-      -- The original goal is the GL form: ckIso(X★(D·ι(ofTree t))) = F * op(G*of'{t}).
+      -- The original goal is the GL form: ckIso(X★(D·ι(ofTree t))) = F * op(G*GrossmanLarson.of'{t}).
       -- h_goal_CK gives the same equation with unop on the GL RHS.
       -- Since CK = GL definitionally and op/unop are identity, this is the goal.
       exact h_goal_CK
@@ -2656,27 +2658,27 @@ proved above) closes `mul_assoc_basis` for `R = ℤ`. -/
     are proved sorry-free; this theorem combines them. -/
 theorem mul_assoc_basis_via_oudom_guin_pbw
     (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    ((of' F₁ : GrossmanLarson ℤ α) *
-        of' F₂) * of' F₃ =
-      of' F₁ *
-        (of' F₂ * of' F₃) := by
-  -- Lift `of' Fᵢ` back through `ckIsoSymmetricAlgebra⁻¹` to SymmetricAlgebra,
+    ((GrossmanLarson.of' F₁ : GrossmanLarson ℤ α) *
+        GrossmanLarson.of' F₂) * GrossmanLarson.of' F₃ =
+      GrossmanLarson.of' F₁ *
+        (GrossmanLarson.of' F₂ * GrossmanLarson.of' F₃) := by
+  -- Lift `GrossmanLarson.of' Fᵢ` back through `ckIsoSymmetricAlgebra⁻¹` to SymmetricAlgebra,
   -- apply oudomGuinStar_assoc there, transport back via Q5c.
   set X₁ := ckIsoSymmetricAlgebra.symm
-    ((unop (of' F₁ : GrossmanLarson ℤ α))) with hX₁
+    ((unop (GrossmanLarson.of' F₁ : GrossmanLarson ℤ α))) with hX₁
   set X₂ := ckIsoSymmetricAlgebra.symm
-    ((unop (of' F₂ : GrossmanLarson ℤ α))) with hX₂
+    ((unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α))) with hX₂
   set X₃ := ckIsoSymmetricAlgebra.symm
-    ((unop (of' F₃ : GrossmanLarson ℤ α))) with hX₃
-  -- ckIso X_i = unop(of' F_i) = of' F_i (since ckIso ∘ ckIso.symm = id).
+    ((unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α))) with hX₃
+  -- ckIso X_i = unop(GrossmanLarson.of' F_i) = GrossmanLarson.of' F_i (since ckIso ∘ ckIso.symm = id).
   have hckIsoX₁ : (ckIsoSymmetricAlgebra X₁ : ConnesKreimer ℤ (Nonplanar α)) =
-      unop (of' F₁ : GrossmanLarson ℤ α) := by
+      unop (GrossmanLarson.of' F₁ : GrossmanLarson ℤ α) := by
     rw [hX₁]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
   have hckIsoX₂ : (ckIsoSymmetricAlgebra X₂ : ConnesKreimer ℤ (Nonplanar α)) =
-      unop (of' F₂ : GrossmanLarson ℤ α) := by
+      unop (GrossmanLarson.of' F₂ : GrossmanLarson ℤ α) := by
     rw [hX₂]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
   have hckIsoX₃ : (ckIsoSymmetricAlgebra X₃ : ConnesKreimer ℤ (Nonplanar α)) =
-      unop (of' F₃ : GrossmanLarson ℤ α) := by
+      unop (GrossmanLarson.of' F₃ : GrossmanLarson ℤ α) := by
     rw [hX₃]; exact ckIsoSymmetricAlgebra.apply_symm_apply _
   -- Apply Q5c to peel ckIso ∘ ★ into op(ckIso) * op(ckIso) at each fold.
   have h_LHS_step1 := gl_product_eq_oudomGuinStar (oudomGuinStar X₁ X₂) X₃
@@ -2699,4 +2701,4 @@ theorem mul_assoc_basis_via_oudom_guin_pbw
       op_unop, op_unop, op_unop] at h_iso_assoc
   exact h_iso_assoc
 
-end RootedTree
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/PreLie/OudomGuinBridgePairing.lean
@@ -7,6 +7,8 @@ import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
 import Mathlib.Tactic.Ring
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -50,7 +52,6 @@ for `z = 1`.
 Skeleton only. Sub-proofs sorry-fenced for incremental closure.
 -/
 
-namespace RootedTree
 
 open ConnesKreimer
 open PreLie.OudomGuinCirc
@@ -494,4 +495,3 @@ theorem gl_product_eq_oudomGuinStar_via_pairing
 
 end GrossmanLarson
 
-end RootedTree

--- a/Linglib/Core/Algebra/RootedTree/Primitive.lean
+++ b/Linglib/Core/Algebra/RootedTree/Primitive.lean
@@ -6,6 +6,8 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.RingTheory.Bialgebra.Primitive
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Dual-primitive functionals on the Connes-Kreimer bialgebra
 [marcolli-chomsky-berwick-2025]
@@ -19,27 +21,26 @@ dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
 
 ## Main definitions
 
-* `RootedTree.ConnesKreimer.deltaSingleton`: the dual-basis functional `δ_T`
+* `ConnesKreimer.deltaSingleton`: the dual-basis functional `δ_T`
   extracting the coefficient of the singleton forest `{T}`.
-* `RootedTree.ConnesKreimer.countSingleCutsRho`: number of Δ^ρ cut summands of
+* `ConnesKreimer.countSingleCutsRho`: number of Δ^ρ cut summands of
   `T` with cut forest `{T₁}` and remainder `T₂`.
 
 ## Main results
 
-* `RootedTree.ConnesKreimer.deltaSingleton_isDualPrimitive`: each single-tree
+* `ConnesKreimer.deltaSingleton_isDualPrimitive`: each single-tree
   delta `δ_T` is a dual primitive.
-* `RootedTree.ConnesKreimer.lie_deltaSingleton_apply_singleton`: the explicit
+* `ConnesKreimer.lie_deltaSingleton_apply_singleton`: the explicit
   count form `⁅δ_{T₁}, δ_{T₂}⁆ (of' {T}) = countSingleCutsRho T T₁ T₂ −
   countSingleCutsRho T T₂ T₁`, the Δ^ρ analog of the book's
   `c^T_{T₁,T₂} − c^T_{T₂,T₁}`. The Δ^c (trace-leaf) version follows via the
   strip machinery in `Coproduct/DeletionNonplanar.lean`.
 
 Not yet stated: the Lie algebra isomorphism with the insertion Lie algebra
-(`RootedTree.InsertionAlgebra`); this file proves the dual-primitives side
+(`InsertionAlgebra`); this file proves the dual-primitives side
 only.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -209,4 +210,3 @@ theorem lie_deltaSingleton_apply_singleton (T T₁ T₂ : Nonplanar α) :
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/Aut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Aut.lean
@@ -12,6 +12,8 @@ import Mathlib.Data.Nat.Choose.Basic
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Tactic.Ring
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Automorphism cardinality for rooted nonplanar trees
 
@@ -22,21 +24,20 @@ automorphisms of a forest.
 
 ## Main definitions
 
-* `RootedTree.Nonplanar.autCard`: the automorphism count `|Aut(t)|` of a rooted nonplanar tree.
-* `RootedTree.Nonplanar.forestAutCard`: the automorphism count of a forest (multiset of rooted
+* `Nonplanar.autCard`: the automorphism count `|Aut(t)|` of a rooted nonplanar tree.
+* `Nonplanar.forestAutCard`: the automorphism count of a forest (multiset of rooted
   nonplanar trees).
 
 ## Main results
 
-* `RootedTree.Nonplanar.autCard_node`: the recursion `autCard (node a M) = forestAutCard M`.
-* `RootedTree.Nonplanar.forestAutCard_add`: the multinomial split identity
+* `Nonplanar.autCard_node`: the recursion `autCard (node a M) = forestAutCard M`.
+* `Nonplanar.forestAutCard_add`: the multinomial split identity
   `forestAutCard (F + G) = (antidiagonal (F + G)).count (F, G) * (forestAutCard F *
   forestAutCard G)`, the combinatorial core of the pairing's product-coproduct adjunction.
 -/
 
-namespace RootedTree
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*} [DecidableEq α]
 
@@ -211,6 +212,5 @@ theorem forestAutCard_add (F G : Multiset (Nonplanar α)) :
       ← Nat.add_choose_mul_factorial_mul_factorial (F.count t) (G.count t)]
   ring
 
-end Nonplanar
+end RoseTree.Nonplanar
 
-end RootedTree

--- a/Linglib/Core/Combinatorics/RootedTree/ContractUnary.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/ContractUnary.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Data.RoseTree.Nonplanar
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Contracting unary vertices of a rose tree
 
@@ -149,7 +151,7 @@ end RoseTree
 
 /-! ### Descent to `Nonplanar` -/
 
-namespace RootedTree.Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*}
 
@@ -180,4 +182,4 @@ theorem numNodes_contractUnary_add_numUnary (t : Nonplanar α) :
     contractUnary (contractUnary t) = contractUnary t :=
   Quotient.inductionOn t fun p => congrArg mk (RoseTree.contractUnary_idem p)
 
-end RootedTree.Nonplanar
+end RoseTree.Nonplanar

--- a/Linglib/Core/Data/Multiset/Rel.lean
+++ b/Linglib/Core/Data/Multiset/Rel.lean
@@ -39,7 +39,7 @@ Core's `List.isPerm_iff` proves the greedy matcher correct only under `LawfulBEq
 forces `p` to coincide with equality. The lemmas here assume instead that `p` is
 symmetric and transitive *on a predicate `P` covering the lists' members* — the form a
 consumer needs when `p` is defined by recursion and its equivalence properties are only
-available beneath a termination bound (see `RootedTree/DecEq.lean`). The unconditional
+available beneath a termination bound (see `Nonplanar/DecEq.lean`). The unconditional
 `Std.Symm`/`IsTrans` version is a corollary.
 
 `[UPSTREAM]` candidate.

--- a/Linglib/Core/Data/RoseTree/Count.lean
+++ b/Linglib/Core/Data/RoseTree/Count.lean
@@ -7,6 +7,8 @@ import Mathlib.Algebra.BigOperators.Group.Multiset.Basic
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Linglib.Core.Data.RoseTree.Leaves
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Size measures on rooted nonplanar trees and their forests
 
@@ -16,12 +18,12 @@ import Linglib.Core.Data.RoseTree.Leaves
   `Nonplanar` descents): leaf statistics by predicate over the leaf projection — the
   count is `Multiset.countP`, and the depth statistics are the card and sum of the
   depth multiset (`card_leafDepthsP`).
-* `RootedTree.Nonplanar.numEdges`: the edge count `numNodes - 1` of a rooted tree.
-* `RootedTree.Forest.numNodes` / `RootedTree.Forest.numEdges`: the forest totals.
+* `Nonplanar.numEdges`: the edge count `numNodes - 1` of a rooted tree.
+* `Nonplanar.Forest.numNodes` / `Nonplanar.Forest.numEdges`: the forest totals.
 
 ## Main results
 
-* `RootedTree.Forest.numNodes_eq_card_add_numEdges`: Euler's relation `#V = b₀ + #E`
+* `Nonplanar.Forest.numNodes_eq_card_add_numEdges`: Euler's relation `#V = b₀ + #E`
   for forests, with `Multiset.card` the component count.
 * `RoseTree.leafCountP_le_numNodes`: a counted leaf is a vertex; strict when the root
   is uncounted (`leafCountP_lt_numNodes_of_not`).
@@ -197,9 +199,8 @@ theorem leafCountP_le_leafDepthSumP_of_not (a : α)
 
 end RoseTree
 
-namespace RootedTree
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*} (p : α → Prop) [DecidablePred p]
 
@@ -305,7 +306,7 @@ theorem leafCountP_le_numEdges (t : Nonplanar α)
     (h : t.leafCountP p < t.numNodes) : t.leafCountP p ≤ t.numEdges :=
   Nat.le_sub_one_of_lt h
 
-end Nonplanar
+end RoseTree.Nonplanar
 
 /-! ### Forest measures -/
 
@@ -354,4 +355,3 @@ theorem numNodes_eq_card_add_numEdges (F : Multiset (Nonplanar α)) :
 
 end Forest
 
-end RootedTree

--- a/Linglib/Core/Data/RoseTree/DecEq.lean
+++ b/Linglib/Core/Data/RoseTree/DecEq.lean
@@ -23,7 +23,7 @@ so concrete `Nonplanar` equalities close by `decide`.
 
 - `RoseTree.eqv_iff_perm`: `eqv` decides `Perm`.
 - `RoseTree.instDecidableRelPerm`: the resulting `DecidableRel Perm`.
-- `RootedTree.Nonplanar.instDecidableEq`: decidable equality on the quotient, via
+- `Nonplanar.instDecidableEq`: decidable equality on the quotient, via
   `Quotient.decidableEq`.
 
 ## Implementation notes
@@ -38,7 +38,7 @@ correctness from `Core/Data/Multiset/Rel.lean`.
 
 namespace RoseTree
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {α : Type*} [DecidableEq α] {cs ds : List (RoseTree α)} {t s : RoseTree α}
 
@@ -145,7 +145,7 @@ instance : DecidableRel ((· ≈ ·) : RoseTree α → RoseTree α → Prop) :=
 
 end RoseTree
 
-namespace RootedTree.Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*} [DecidableEq α]
 
@@ -155,4 +155,4 @@ variable {α : Type*} [DecidableEq α]
 instance instDecidableEq : DecidableEq (Nonplanar α) :=
   inferInstanceAs (DecidableEq (Quotient (RoseTree.isSetoid (α := α))))
 
-end RootedTree.Nonplanar
+end RoseTree.Nonplanar

--- a/Linglib/Core/Data/RoseTree/Leaves.lean
+++ b/Linglib/Core/Data/RoseTree/Leaves.lean
@@ -8,6 +8,8 @@ import Mathlib.Algebra.Order.Group.Multiset
 import Mathlib.Algebra.Order.BigOperators.Group.List
 import Mathlib.Algebra.Order.Group.Nat
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Leaf projections of a rose tree
 
@@ -19,7 +21,7 @@ import Mathlib.Algebra.Order.Group.Nat
 ## Main definitions
 
 * `RoseTree.leavesWithDepth`, `RoseTree.leaves`: the projections, with descents
-  `RootedTree.Nonplanar.leavesWithDepth` and `RootedTree.Nonplanar.leaves`.
+  `Nonplanar.leavesWithDepth` and `Nonplanar.leaves`.
 
 ## Main results
 
@@ -131,7 +133,7 @@ end RoseTree
 
 /-! ### Descent to `Nonplanar` -/
 
-namespace RootedTree.Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*} (a : α)
 
@@ -165,4 +167,4 @@ theorem card_leaves (t : Nonplanar α) : Multiset.card t.leaves = t.numLeaves :=
 theorem numLeaves_le_numNodes (t : Nonplanar α) : t.numLeaves ≤ t.numNodes :=
   Quotient.inductionOn t fun p => RoseTree.numLeaves_le_numNodes p
 
-end RootedTree.Nonplanar
+end RoseTree.Nonplanar

--- a/Linglib/Core/Data/RoseTree/Nonplanar.lean
+++ b/Linglib/Core/Data/RoseTree/Nonplanar.lean
@@ -55,13 +55,12 @@ arity.
 
 /-! ## Nonplanar — the quotient type -/
 
-namespace RootedTree
 
 /-- A nonplanar n-ary rooted tree with α-labeled vertices: the quotient
     of `RoseTree α` by `RoseTree.Perm`. -/
-def Nonplanar (α : Type*) : Type _ := Quotient (RoseTree.isSetoid : Setoid (RoseTree α))
+def RoseTree.Nonplanar (α : Type*) : Type _ := Quotient (RoseTree.isSetoid : Setoid (RoseTree α))
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α : Type*}
 
@@ -337,11 +336,10 @@ theorem numNodes_pos (t : Nonplanar α) : 0 < t.numNodes := by
   show (mk (Quotient.out t)).numNodes = numNodes t
   exact congrArg numNodes (Quotient.out_eq t)
 
-end Nonplanar
+end RoseTree.Nonplanar
 
-end RootedTree
 
-namespace RootedTree.Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α β γ : Type*}
 
@@ -417,4 +415,4 @@ theorem map_map (f : α → β) (g : β → γ) (t : Nonplanar α) :
   show (map f (mk p)).numLeaves = (mk p).numLeaves
   rw [map_mk, numLeaves_mk, numLeaves_mk, RoseTree.numLeaves_map]
 
-end RootedTree.Nonplanar
+end RoseTree.Nonplanar

--- a/Linglib/Studies/Adger2025.lean
+++ b/Linglib/Studies/Adger2025.lean
@@ -3,6 +3,8 @@ import Linglib.Syntax.SynGraph
 import Linglib.Syntax.Minimalist.Merge.MinimalYield
 import Linglib.Syntax.Minimalist.Defs
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -206,11 +208,11 @@ no such bridge is in scope here. -/
     parameters `T_i Tnode T_iq`; the MCB conjunct does not reference the
     AL graph. The bundling is documentation, not a reduction. -/
 theorem adger_and_mcb_both_reject_sideward
-    (T_i Tnode T_iq : RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit)) :
+    (T_i Tnode T_iq : Nonplanar (Minimalist.LIToken ⊕ Unit)) :
     -- MCB: Sideward 3(a)-shape transformation violates MinimalYieldWeak
     (¬ Minimalist.Merge.MinimalYieldWeak
-        ({T_i} : RootedTree.Forest (RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit)))
-        ({Tnode, T_iq} : RootedTree.Forest (RootedTree.Nonplanar (Minimalist.LIToken ⊕ Unit))))
+        ({T_i} : Nonplanar.Forest (Nonplanar (Minimalist.LIToken ⊕ Unit)))
+        ({Tnode, T_iq} : Nonplanar.Forest (Nonplanar (Minimalist.LIToken ⊕ Unit))))
     ∧
     -- Adger: the canonical Sideward subjunction configuration fails AL
     (g_sideward.satisfiesAL ⟨2, by decide⟩ ⟨1, by decide⟩ = false) :=

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -870,7 +870,7 @@ theorem tseltalan_case_locus :
 section AttractClosest
 
 open Minimalist SyntacticObject
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-! ### Attract Closest on Concrete Trees
 

--- a/Linglib/Studies/Cinque2005.lean
+++ b/Linglib/Studies/Cinque2005.lean
@@ -52,7 +52,7 @@ needs four distinct categories.
 namespace Cinque2005
 
 open Minimalist SyntacticObject
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-! ### The four elements (head-initial leaves) -/
 

--- a/Linglib/Studies/ColeHermon2008.lean
+++ b/Linglib/Studies/ColeHermon2008.lean
@@ -96,7 +96,7 @@ end Minimalist
 namespace ColeHermon2008
 
 open Minimalist SyntacticObject
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 -- ============================================================================
 -- § 1: Toba Batak Lexical Items

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -443,7 +443,7 @@ theorem dir_spellout_eqya :
 
 section Derivation
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-- Leaf tokens for the SJO Mam transitive-CP derivation. -/
 private def obliqueTok : LIToken := ⟨.simple .D [] "jawu'", 1⟩

--- a/Linglib/Studies/Larson1988.lean
+++ b/Linglib/Studies/Larson1988.lean
@@ -76,7 +76,7 @@ DP arguments, not the position of V.
 namespace Larson1988
 
 open Minimalist SyntacticObject
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 -- ============================================================================
 -- § 1: Lexical Items

--- a/Linglib/Studies/MarcolliChomskyBerwick2025.lean
+++ b/Linglib/Studies/MarcolliChomskyBerwick2025.lean
@@ -20,7 +20,7 @@ holds its concrete examples, kernel-checked against that substrate.
 
 namespace MarcolliChomskyBerwick2025
 
-open RootedTree Minimalist SyntacticObject
+open RoseTree RoseTree.Nonplanar Minimalist SyntacticObject
 
 /-- A determiner over a noun: `D` selects `N`, so `D` projects. -/
 private def theDog : SyntacticObject :=

--- a/Linglib/Studies/Pylkkanen2008.lean
+++ b/Linglib/Studies/Pylkkanen2008.lean
@@ -66,7 +66,7 @@ in the "Applicative diagnostics" section below.
 namespace Pylkkanen2008
 
 open Minimalist Minimalist.Voice SyntacticObject
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-! ### Voice projection (relocated from Minimalist/VoiceProjection.lean)
 

--- a/Linglib/Syntax/Minimalist/Agree/Consistency.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Consistency.lean
@@ -23,7 +23,7 @@ This file instantiates that map for **feature consistency** in the Boolean (pars
 (a `Nonplanar SOLabel` subtree, `SOLabel = LIToken ⊕ Unit`) embeds into the Hopf algebra via
 `ofTree S.val` (no head decoration — the single MCB carrier, `FreeCommMagma`/`toNonplanar`
 retired). A local feature character `φ` is renormalized by the weight-`+1` semiring Birkhoff
-factorization (`RootedTree.ConnesKreimer.SemiringRenorm`) into the consistency map `φ₊`.
+factorization (`ConnesKreimer.SemiringRenorm`) into the consistency map `φ₊`.
 
 The Birkhoff machinery is noncomputable (the coproduct goes through `Quotient.out`), so `φ₊` is a
 *specification* of consistency, not an executable checker; concrete verdicts are established by
@@ -41,7 +41,7 @@ structural proof.
 
 namespace Minimalist
 
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 /-! ### The Boolean consistency semiring -/
 

--- a/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Externalization.lean
@@ -60,7 +60,7 @@ for head–complement structure but does not model specifier placement (that nee
 
 namespace Minimalist
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-- Place the head daughter's yield on the convention side: `.initial` → head-yield
     first, `.final` → head-yield last. -/

--- a/Linglib/Syntax/Minimalist/Linearization/Replay.lean
+++ b/Linglib/Syntax/Minimalist/Linearization/Replay.lean
@@ -29,7 +29,7 @@ linearization (`Linearization/Cyclic.lean`).
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 /-! ## Derivation-grounded externalization (computable PF order)
 

--- a/Linglib/Syntax/Minimalist/Merge/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Basic.lean
@@ -45,7 +45,7 @@ substrate.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 variable {R : Type*} [CommSemiring R] {α : Type*} [DecidableEq (Nonplanar α)]
 

--- a/Linglib/Syntax/Minimalist/Merge/External.lean
+++ b/Linglib/Syntax/Minimalist/Merge/External.lean
@@ -54,7 +54,7 @@ leaf). This is the coupling point that validates the carrier bridge's design.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 /-- **Algebraic Merge on a 2-tree workspace** (M-C-B Lemma 1.4.1, F̂ = ∅
     subcase). For any pair `(S, S') : Nonplanar α` and root label `lbl`,

--- a/Linglib/Syntax/Minimalist/Merge/Internal.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Internal.lean
@@ -41,7 +41,7 @@ IM, not the unit stage on its own.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 /-- **Per-cut reduction of `mergeOpUnit β (of' {T})`.** Unfolds the operator chain
     through `comulTreeN`'s primitive-plus-cut-sum decomposition; each cut's

--- a/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalSearch.lean
@@ -18,7 +18,7 @@ already-generic cut layer (`cutSummandsG`).
 
 The Δ^c instance is the home of the **Minimal-Search ε arc** (MCB §1.5,
 Prop 1.5.1): the trace coproduct is where extraction depth is recoverable
-(`RootedTree.Cut.depthC`), so the ε-weighted graft and the ε → 0
+(`Nonplanar.Cut.depthC`), so the ε-weighted graft and the ε → 0
 Sideward-elimination belong on `mergeOpC`, not the Δ^ρ `mergeOp`.
 
 ## Main definitions
@@ -37,7 +37,7 @@ Sideward-elimination belong on `mergeOpC`, not the Δ^ρ `mergeOp`.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 variable {R : Type*} [CommSemiring R] {α : Type*}
 
@@ -75,7 +75,7 @@ The ε-weighted Merge `M^ε = ⊔ ∘ (Bᵉ ⊗ id) ∘ δ ∘ Δ` (eq 1.5.1) sc
 Since `mergePost` is linear and the graft is its only creation, scaling the
 graft by `ε^c` equals scaling the whole operator: `mergeOpCEps = ε^c • mergeOpC`.
 The net cost `c` is the sum of the two operands' signed depth-costs (MCB rules
-1–2, `RootedTree.Cut.extractionCost`/`quotientCost`):
+1–2, `Nonplanar.Cut.extractionCost`/`quotientCost`):
 
 * **EM** `𝔐(T_i, T_j)`: both whole, `c = 0`.
 * **IM** `𝔐(T_v, T_i/T_v)`: extracted crown `+d` and its own quotient `−d`
@@ -101,7 +101,7 @@ end Minimalist.Merge
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 variable {R : Type*} [CommSemiring R] {α β : Type*}
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYield.lean
@@ -5,6 +5,8 @@ import Linglib.Syntax.Minimalist.Workspace.DeletionConservation
 import Linglib.Core.Order.PullbackPreorder
 import Mathlib.Order.OrderDual
 
+open ConnesKreimer
+
 /-!
 # Minimal Yield (MCB Definition 1.6.1)
 [marcolli-chomsky-berwick-2025] §1.6.1, Def 1.6.1 on book p. 63
@@ -38,7 +40,7 @@ Sideward 3(a)/3(b) are ruled out by both forms via Δb₀ > 0.
 
 namespace Minimalist.Merge
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {α β : Type*}
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldBirkhoff.lean
@@ -35,7 +35,7 @@ derivation pairs `(F, F')`) is left to future work.
 
 namespace Minimalist.Merge
 
-open RootedTree RootedTree.ConnesKreimer LaurentSeries
+open RoseTree RoseTree.Nonplanar ConnesKreimer LaurentSeries
 
 variable {α : Type*} {R : Type*} [CommRing R]
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldCharacter.lean
@@ -34,7 +34,7 @@ factorization (Prop. 3.5.6) are needed to separate Internal/External from Sidewa
 
 namespace Minimalist.Merge
 
-open RootedTree RootedTree.ConnesKreimer LaurentSeries
+open RoseTree RoseTree.Nonplanar ConnesKreimer LaurentSeries
 
 variable {α : Type*} {R : Type*} [CommRing R]
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldGrading.lean
@@ -41,7 +41,7 @@ negative. Minimal-Yield-respecting steps (External/Internal Merge) have `δ ≥ 
 
 namespace Minimalist.Merge
 
-open RootedTree LaurentSeries
+open RoseTree RoseTree.Nonplanar LaurentSeries
 
 variable {α β : Type*}
 

--- a/Linglib/Syntax/Minimalist/Merge/MinimalYieldPsi.lean
+++ b/Linglib/Syntax/Minimalist/Merge/MinimalYieldPsi.lean
@@ -38,7 +38,7 @@ which the Birkhoff factorization then renormalizes away (`Core/Algebra/RootedTre
 
 namespace Minimalist.Merge
 
-open RootedTree LaurentSeries
+open RoseTree RoseTree.Nonplanar LaurentSeries
 
 variable {α β : Type*} {R : Type*} [CommRing R]
 

--- a/Linglib/Syntax/Minimalist/Merge/NoComplexityLoss.lean
+++ b/Linglib/Syntax/Minimalist/Merge/NoComplexityLoss.lean
@@ -41,7 +41,7 @@ leaf-count port.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 /-- **M-C-B Definition 1.6.2 (book p. 64), existential form.** A workspace
     transformation `F → F'` satisfies No Complexity Loss if some component

--- a/Linglib/Syntax/Minimalist/Merge/Sideward.lean
+++ b/Linglib/Syntax/Minimalist/Merge/Sideward.lean
@@ -44,7 +44,7 @@ behind that substrate and omitted here.
 namespace Minimalist.Merge
 
 open scoped TensorProduct
-open RootedTree RootedTree.ConnesKreimer
+open RoseTree RoseTree.Nonplanar ConnesKreimer
 
 /-! ### Matching-cut multisets -/
 

--- a/Linglib/Syntax/Minimalist/Phase/Domain.lean
+++ b/Linglib/Syntax/Minimalist/Phase/Domain.lean
@@ -35,7 +35,7 @@ out of the formalization.
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 namespace SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Basic.lean
@@ -45,7 +45,7 @@ existing `comul{D,C}N`; P1 continued), the structural ops (`contains`/`subtrees`
 
 namespace Minimalist
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 /-- The SyntacticObject label alphabet, in the algebra's `α ⊕ β` form (`α = LIToken` lexical,
     `β = Unit` bare). Each **role is fixed by arity**, not by a third label:

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Build.lean
@@ -30,7 +30,7 @@ is workspace-level), so there is exactly **one** trace leaf — `SyntacticObject
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 namespace SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Derivation.lean
@@ -37,7 +37,7 @@ ordered planar accumulator, since `final` (a `Nonplanar` quotient) is unordered.
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 namespace SyntacticObject
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Lift.lean
@@ -36,7 +36,7 @@ lexical-leaf value and a trace value, and inherit `Perm`-invariance from
 
 namespace Minimalist.SyntacticObject
 
-open RootedTree
+open RoseTree RoseTree.Nonplanar
 
 variable {β : Type*}
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Replace.lean
@@ -30,7 +30,7 @@ are related by the reduction lemmas (`replace_lexLeaf`/`_traceLeaf`/`_node`), no
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 /-! ### Substitution on the planar carrier -/
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Selection.lean
@@ -54,7 +54,7 @@ trace leaf gets the canonical saturated value `.of (mkTraceToken 0) []`;
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 /-! ### The selection state -/
 

--- a/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
+++ b/Linglib/Syntax/Minimalist/SyntacticObject/Subterm.lean
@@ -25,7 +25,7 @@ variants.
 
 namespace Minimalist
 
-open RootedTree SyntacticObject
+open RoseTree RoseTree.Nonplanar SyntacticObject
 
 /-! ### Immediate containment (via `Nonplanar.rootChildren`) -/
 

--- a/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/SmallClause.lean
@@ -131,8 +131,8 @@ study files need — a binary node has the summed leaf count of its children
 and exactly one more internal node — by quotient induction, mirroring
 `Nonplanar.numNodes_node`. -/
 
-open RootedTree in
-private theorem Nonplanar.numLeaves_node_pair {α : Type*} (a : α)
+open RoseTree RoseTree.Nonplanar in
+private theorem _root_.RoseTree.Nonplanar.numLeaves_node_pair {α : Type*} (a : α)
     (c d : Nonplanar α) :
     (Nonplanar.node a {c, d}).numLeaves = c.numLeaves + d.numLeaves := by
   refine Quotient.inductionOn₂ c d fun pc pd => ?_
@@ -148,7 +148,7 @@ private theorem Nonplanar.numLeaves_node_pair {α : Type*} (a : α)
 /-- Leaf count of a binary Merge node is the sum of its children's. -/
 theorem SyntacticObject.leafCount_node (l r : SyntacticObject) :
     (node l r).leafCount = l.leafCount + r.leafCount := by
-  rw [leafCount, node_val, Nonplanar.numLeaves_node_pair]; rfl
+  rw [leafCount, node_val, RoseTree.Nonplanar.numLeaves_node_pair]; rfl
 
 /-- Leaf count of a Merge is the sum of its children's (`SyntacticObject.merge =
 SyntacticObject.node`). -/

--- a/Linglib/Syntax/Minimalist/Workspace/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Basic.lean
@@ -48,7 +48,7 @@ on this carrier (the P1 spike, now as carrier tests).
 
 namespace Minimalist
 
-open RootedTree RootedTree.ConnesKreimer SyntacticObject
+open RoseTree RoseTree.Nonplanar ConnesKreimer SyntacticObject
 
 /-! ### Workspaces (MCB Def 1.2.1)
 

--- a/Linglib/Syntax/Minimalist/Workspace/Conservation.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/Conservation.lean
@@ -1,6 +1,8 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
 import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
 
+open RoseTree RoseTree.Nonplanar
+
 set_option autoImplicit false
 
 /-!
@@ -43,9 +45,8 @@ and `cut_leafCount_conservation`.
   modulo truncated-ℕ positivity bookkeeping.
 -/
 
-namespace RootedTree
-
 namespace ConnesKreimer
+
 
 variable {α β : Type*}
 
@@ -255,7 +256,6 @@ private theorem extractC_numNodes_sum_one (τ : RoseTree (α ⊕ β) → β) :
     | inl a => rw [extractC_inl] at h; obtain rfl := Option.some.inj h; simp [traceLeaf]
     | inr b => rw [extractC_inr] at h; exact absurd h (by simp)
 
-end ConnesKreimer
 
 /-! ### Nonplanar descent -/
 
@@ -381,11 +381,10 @@ vertex, so that `accCountC = #V − 1 − #trace` does not truncate. Crown
 components are always `Sum.inl`-rooted (the Δ^c policy declines to cut trace
 nodes), and the trunk keeps the tree's root. -/
 
-end RootedTree
-
-namespace RootedTree
+end ConnesKreimer
 
 namespace ConnesKreimer
+
 
 variable {α β : Type*}
 
@@ -445,7 +444,6 @@ theorem extractC_ne_none_imp_inl (τ : RoseTree (α ⊕ β) → β) (t : RoseTre
     | inl a => exact ⟨a, cs, rfl⟩
     | inr b => rw [extractC_inr] at h; exact absurd rfl h
 
-end ConnesKreimer
 
 /-! ### α extraction identity (MCB eq. 1.6.8) -/
 
@@ -611,4 +609,4 @@ theorem Cut.extractionCost_pos (τ : Nonplanar (α ⊕ β) → β) (T : Nonplana
   simp only [Cut.extractionCost]
   exact_mod_cast h
 
-end RootedTree
+end ConnesKreimer

--- a/Linglib/Syntax/Minimalist/Workspace/DeletionConservation.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/DeletionConservation.lean
@@ -4,6 +4,8 @@ import Linglib.Core.Combinatorics.RootedTree.ContractUnary
 import Linglib.Core.Data.RoseTree.Count
 import Linglib.Syntax.Minimalist.Workspace.TraceMeasures
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Vertex conservation for the Δ^ρ / Δᵈ (deletion) cut enumeration
 [marcolli-chomsky-berwick-2025]
@@ -19,7 +21,6 @@ contracted unary node drops one vertex, giving the `+2`-per-cut accessible-term
 extraction (eq. 1.6.7) downstream.
 -/
 
-namespace RootedTree
 
 namespace ConnesKreimer
 
@@ -176,4 +177,3 @@ theorem cutSummandsN_accCount_single_deletion (T : Nonplanar α)
 
 end ConnesKreimer
 
-end RootedTree

--- a/Linglib/Syntax/Minimalist/Workspace/TraceMeasures.lean
+++ b/Linglib/Syntax/Minimalist/Workspace/TraceMeasures.lean
@@ -5,6 +5,8 @@ Authors: Robert Hawkins
 -/
 import Linglib.Core.Data.RoseTree.Count
 
+open RoseTree RoseTree.Nonplanar
+
 /-!
 # Trace vocabulary for the leaf statistics
 [marcolli-chomsky-berwick-2025]
@@ -91,9 +93,8 @@ theorem traceLeafCount_le_traceDepthSum_of_inl (a : α) (cs : List (RoseTree (α
 
 end RoseTree
 
-namespace RootedTree
 
-namespace Nonplanar
+namespace RoseTree.Nonplanar
 
 variable {α β : Type*} (p : α → Prop) [DecidablePred p]
 
@@ -210,7 +211,7 @@ theorem accCountC_merge (a : α) (l r : Nonplanar (α ⊕ β))
     (Nonplanar.node (Sum.inl a) {l, r}).accCountC = l.accCountC + r.accCountC + 2 :=
   accCountP_node_pair _ _ l r (by simp) hl hr
 
-end Nonplanar
+end RoseTree.Nonplanar
 
 namespace Forest
 
@@ -331,4 +332,3 @@ theorem sigmaC_eq (F : Multiset (Nonplanar (α ⊕ β))) : sigmaC F = b₀ F + a
 
 end Forest
 
-end RootedTree


### PR DESCRIPTION
Dissolves the `RootedTree` umbrella namespace (user-approved design): `ConnesKreimer`, `GrossmanLarson`, `InsertionAlgebra` become top-level types with per-type namespaces, and the ~85 declarations that sat directly in the umbrella (TraceNonplanar's Δ^c machinery, the Oudom-Guin bridge, Conservation's cut theorems) re-home into `ConnesKreimer`.

The quotient type is renamed `Nonplanar` → `RoseTree.Nonplanar` (the SimpleGraph.Walk pattern; consumers `open RoseTree`). The field name `RootedTree` is unavailable: mathlib's `Order/SuccPred/Tree.lean` owns it for the bundled order-theoretic tree, and the collision is unconditional. `Forest` moves to `RoseTree.Nonplanar.Forest`. ~90 files, mechanical; no statement changes.