### PR TITLE
refactor(Core/Algebra/RootedTree): comul eval API + count formula golf

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
+++ b/Linglib/Core/Algebra/RootedTree/ConnesKreimer.lean
@@ -328,6 +328,7 @@ theorem coeff_of' (F G : Forest T) [Decidable (F = G)] :
 theorem ext_coeff (h : ∀ F, p.coeff F = q.coeff F) : p = q :=
   ext (AddMonoidAlgebra.coeff_inj.mp (Finsupp.ext h))
 
+variable (R) in
 /-- `coeff` bundled as a linear functional (`Polynomial.lcoeff` analogue). -/
 def lcoeff (F : Forest T) : ConnesKreimer R T →ₗ[R] R where
   toFun p := p.coeff F
@@ -335,7 +336,7 @@ def lcoeff (F : Forest T) : ConnesKreimer R T →ₗ[R] R where
   map_smul' s p := coeff_smul s p F
 
 @[simp] theorem lcoeff_apply (F : Forest T) (p : ConnesKreimer R T) :
-    lcoeff F p = p.coeff F := rfl
+    lcoeff R F p = p.coeff F := rfl
 
 /-! ## Lifts and hom extensionality
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -697,5 +697,16 @@ noncomputable instance instBialgebraRho
     counit_rTensor_comulAlgHomN
     counit_lTensor_comulAlgHomN
 
+variable {R' : Type*} [CommRing R'] [CharZero R'] [NoZeroDivisors R'] {α' : Type*}
+  [DecidableEq α']
+
+/-- The coproduct of `instBialgebraRho` is `comulAlgHomN`. -/
+theorem coalgebra_comul_apply (x : ConnesKreimer R' (Nonplanar α')) :
+    Coalgebra.comul (R := R') x = comulAlgHomN x := rfl
+
+/-- The counit of `instBialgebraRho` is `ConnesKreimer.counit`. -/
+theorem coalgebraCounit_apply (x : ConnesKreimer R' (Nonplanar α')) :
+    CoalgebraStruct.counit (R := R') x = counit x := rfl
+
 end ConnesKreimer
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -467,6 +467,12 @@ noncomputable def cutSummandsN :
 @[simp] theorem cutSummandsN_mk (T : RoseTree α) :
     cutSummandsN (Nonplanar.mk T) = (cutSummandsP T).map projSummand := rfl
 
+/-- Number of Δ^ρ cut summands of `T` whose cut forest is `{T₁}` and whose
+    remainder tree is `T₂` — the Δ^ρ analog of the count `c^T_{T₁,T₂}` of
+    [marcolli-chomsky-berwick-2025]. -/
+noncomputable def countSingleCutsRho [DecidableEq α] (T T₁ T₂ : Nonplanar α) : ℕ :=
+  (cutSummandsN T).countP fun p => p.1 = ({T₁} : Forest (Nonplanar α)) ∧ p.2 = T₂
+
 /-- The **nonplanar tree-level Δ^ρ**: explicit `T ⊗ 1` term plus the
     sum of cut-summand tensors at the Nonplanar level. -/
 noncomputable def comulTreeN (T : Nonplanar α) :

--- a/Linglib/Core/Algebra/RootedTree/Primitive.lean
+++ b/Linglib/Core/Algebra/RootedTree/Primitive.lean
@@ -19,12 +19,8 @@ dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
 (deletion-remainder) coproduct, specializing the general
 `Bialgebra.dualPrimitives` theory of `Core/RingTheory/Bialgebra/Primitive`.
 
-## Main definitions
-
-* `ConnesKreimer.countSingleCutsRho`: number of Δ^ρ cut summands of
-  `T` with cut forest `{T₁}` and remainder `T₂`.
-
-The paper's dual-basis functional `δ_T` is `lcoeff R {T}`.
+The paper's dual-basis functional `δ_T` is `lcoeff R {T}`; the cut count
+`countSingleCutsRho` lives with `cutSummandsN` in `Coproduct/PruningNonplanar`.
 
 ## Main results
 
@@ -49,18 +45,9 @@ open Coalgebra Bialgebra WithConv
 
 variable {R : Type*} [CommRing R] {α : Type*} (T T₁ T₂ : Nonplanar α)
 
-/-! ### Cut counting -/
+/-! ### Single-tree deltas are dual primitives -/
 
 variable [DecidableEq α]
-
-open scoped Classical in
-/-- Number of Δ^ρ cut summands of `T` whose cut forest is `{T₁}` and whose
-remainder tree is `T₂` — the Δ^ρ analog of the count `c^T_{T₁,T₂}` of
-[marcolli-chomsky-berwick-2025]. -/
-noncomputable def countSingleCutsRho : ℕ :=
-  (cutSummandsN T).countP fun p => p.1 = ({T₁} : Forest (Nonplanar α)) ∧ p.2 = T₂
-
-/-! ### Single-tree deltas are dual primitives -/
 
 variable [CharZero R] [NoZeroDivisors R]
 

--- a/Linglib/Core/Algebra/RootedTree/Primitive.lean
+++ b/Linglib/Core/Algebra/RootedTree/Primitive.lean
@@ -21,16 +21,16 @@ dual-primitives side on the Connes-Kreimer bialgebra with the Δ^ρ
 
 ## Main definitions
 
-* `ConnesKreimer.deltaSingleton`: the dual-basis functional `δ_T`
-  extracting the coefficient of the singleton forest `{T}`.
 * `ConnesKreimer.countSingleCutsRho`: number of Δ^ρ cut summands of
   `T` with cut forest `{T₁}` and remainder `T₂`.
 
+The paper's dual-basis functional `δ_T` is `lcoeff R {T}`.
+
 ## Main results
 
-* `ConnesKreimer.deltaSingleton_isDualPrimitive`: each single-tree
+* `ConnesKreimer.lcoeff_singleton_isDualPrimitive`: each single-tree
   delta `δ_T` is a dual primitive.
-* `ConnesKreimer.lie_deltaSingleton_apply_ofTree`: the explicit
+* `ConnesKreimer.lie_lcoeff_singleton_apply_ofTree`: the explicit
   count form `⁅δ_{T₁}, δ_{T₂}⁆ (ofTree T) = countSingleCutsRho T T₁ T₂ −
   countSingleCutsRho T T₂ T₁`, the Δ^ρ analog of the book's
   `c^T_{T₁,T₂} − c^T_{T₂,T₁}`. The Δ^c (trace-leaf) version follows via the
@@ -49,39 +49,6 @@ open Coalgebra Bialgebra WithConv
 
 variable {R : Type*} [CommRing R] {α : Type*} (T T₁ T₂ : Nonplanar α)
 
-variable (R) in
-/-- The dual-basis functional `δ_T` on a singleton forest: extracts the
-coefficient of `{T}` from a Connes-Kreimer element. -/
-noncomputable def deltaSingleton :
-    ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
-  lcoeff ({T} : Forest (Nonplanar α))
-
-theorem deltaSingleton_of' (F : Forest (Nonplanar α))
-    [Decidable (F = ({T} : Forest (Nonplanar α)))] :
-    deltaSingleton R T (of' F) = if F = ({T} : Forest (Nonplanar α)) then 1 else 0 := by
-  rw [deltaSingleton, lcoeff_apply, coeff_of']
-
-@[simp] theorem deltaSingleton_of'_self :
-    deltaSingleton R T (of' ({T} : Forest (Nonplanar α))) = 1 := by
-  classical rw [deltaSingleton_of', if_pos rfl]
-
-theorem deltaSingleton_ofTree (T' : Nonplanar α) [Decidable (T' = T)] :
-    deltaSingleton R T (ofTree T') = if T' = T then 1 else 0 := by
-  classical
-  rw [show (ofTree T' : ConnesKreimer R (Nonplanar α)) =
-    of' ({T'} : Forest (Nonplanar α)) from rfl, deltaSingleton_of']
-  simp [Multiset.singleton_inj]
-
-@[simp] theorem deltaSingleton_ofTree_self :
-    deltaSingleton R T (ofTree T) = 1 := by
-  classical rw [deltaSingleton_ofTree, if_pos rfl]
-
-@[simp] theorem deltaSingleton_one :
-    deltaSingleton R T (1 : ConnesKreimer R (Nonplanar α)) = 0 := by
-  classical
-  rw [← of'_zero, deltaSingleton_of', if_neg]
-  exact fun h => by simpa using congrArg Multiset.card h
-
 /-! ### Cut counting -/
 
 variable [DecidableEq α]
@@ -97,21 +64,22 @@ noncomputable def countSingleCutsRho : ℕ :=
 
 variable [CharZero R] [NoZeroDivisors R]
 
-/-- `δ_T` is a dual primitive: the bialgebraic content of
-[marcolli-chomsky-berwick-2025]'s observation (book p. 79) that primitives in
-the dual are exactly the single-tree deltas. -/
-theorem deltaSingleton_isDualPrimitive :
-    IsDualPrimitive R (deltaSingleton R T) := by
+/-- The single-tree delta `δ_T = lcoeff R {T}` is a dual primitive: the
+bialgebraic content of [marcolli-chomsky-berwick-2025]'s observation (book
+p. 79) that primitives in the dual are exactly the single-tree deltas. -/
+theorem lcoeff_singleton_isDualPrimitive :
+    IsDualPrimitive R (lcoeff R ({T} : Forest (Nonplanar α))) := by
   classical
-  refine ⟨deltaSingleton_one T, ?_⟩
-  have key : (LinearMap.mul R (ConnesKreimer R (Nonplanar α))).compr₂ (deltaSingleton R T) =
-      (deltaSingleton R T).smulRight CoalgebraStruct.counit +
-        (CoalgebraStruct.counit).smulRight (deltaSingleton R T) := by
+  refine ⟨by rw [← of'_zero, lcoeff_apply, coeff_of',
+    if_neg (Multiset.zero_ne_singleton T)], ?_⟩
+  have key : (LinearMap.mul R (ConnesKreimer R (Nonplanar α))).compr₂ (lcoeff R {T}) =
+      (lcoeff R ({T} : Forest (Nonplanar α))).smulRight CoalgebraStruct.counit +
+        (CoalgebraStruct.counit).smulRight (lcoeff R {T}) := by
     refine lhom_ext' fun F => lhom_ext' fun G => ?_
     simp only [LinearMap.compr₂_apply, LinearMap.mul_apply', LinearMap.add_apply,
       LinearMap.smulRight_apply, LinearMap.smul_apply, smul_eq_mul, coalgebraCounit_apply]
     rw [← of'_add]
-    simp only [deltaSingleton_of', counit_of', ite_zero_mul_ite_zero, one_mul]
+    simp only [lcoeff_apply, coeff_of', counit_of', ite_zero_mul_ite_zero, one_mul]
     have hiff : F + G = ({T} : Forest (Nonplanar α)) ↔
         (F = ({T} : Forest (Nonplanar α)) ∧ G.card = 0) ∨
           (F.card = 0 ∧ G = ({T} : Forest (Nonplanar α))) := by
@@ -138,24 +106,26 @@ theorem deltaSingleton_isDualPrimitive :
 /-- [marcolli-chomsky-berwick-2025] Lemma 1.7.3, membership form: single-tree
 deltas lie in the Lie subalgebra of dual primitives (so their brackets do too,
 by `LieSubalgebra.lie_mem`). -/
-theorem toConv_deltaSingleton_mem_dualPrimitives :
-    toConv (deltaSingleton R T) ∈
+theorem toConv_lcoeff_singleton_mem_dualPrimitives :
+    toConv (lcoeff R ({T} : Forest (Nonplanar α))) ∈
       dualPrimitives R (ConnesKreimer R (Nonplanar α)) :=
-  deltaSingleton_isDualPrimitive T
+  lcoeff_singleton_isDualPrimitive T
 
 /-! ### The explicit count formula -/
 
 /-- The convolution product of two single-tree deltas evaluated on a
 single-tree basis vector counts the Δ^ρ cut summands of `T` extracting `{T₁}`
 and leaving `T₂`. -/
-theorem convMul_deltaSingleton_apply_ofTree :
-    (toConv (deltaSingleton R T₁) * toConv (deltaSingleton R T₂)) (ofTree T) =
+theorem convMul_lcoeff_singleton_apply_ofTree :
+    (toConv (lcoeff R {T₁}) * toConv (lcoeff R ({T₂} : Forest (Nonplanar α))))
+        (ofTree T) =
       countSingleCutsRho T T₁ T₂ := by
   classical
   rw [LinearMap.convMul_apply, coalgebra_comul_apply, comulAlgHomN_apply_ofTree, comulTreeN]
   simp only [map_add, map_multiset_sum, Multiset.map_map, Function.comp_apply,
-    TensorProduct.map_tmul, LinearMap.mul'_apply, deltaSingleton_one, mul_zero, zero_add,
-    deltaSingleton_of', deltaSingleton_ofTree, ite_zero_mul_ite_zero, one_mul]
+    TensorProduct.map_tmul, LinearMap.mul'_apply, ofTree, lcoeff_apply, ← of'_zero,
+    coeff_of', Multiset.singleton_inj, ite_zero_mul_ite_zero, one_mul,
+    Multiset.zero_ne_singleton, if_false, mul_zero, zero_add]
   unfold countSingleCutsRho
   rw [Multiset.countP_eq_card_filter]
   induction cutSummandsN T using Multiset.induction with
@@ -170,11 +140,12 @@ theorem convMul_deltaSingleton_apply_ofTree :
 [marcolli-chomsky-berwick-2025] in Δ^ρ form; the book's
 `c^T_{T₁,T₂} − c^T_{T₂,T₁}` is stated for the trace-leaf coproduct `Δ^c`,
 which agrees under the trace-strip bijection (`stripTraceAlgHom`). -/
-theorem lie_deltaSingleton_apply_ofTree :
-    ⁅toConv (deltaSingleton R T₁), toConv (deltaSingleton R T₂)⁆ (ofTree T) =
+theorem lie_lcoeff_singleton_apply_ofTree :
+    ⁅toConv (lcoeff R {T₁}), toConv (lcoeff R ({T₂} : Forest (Nonplanar α)))⁆
+        (ofTree T) =
       (countSingleCutsRho T T₁ T₂ : R) - countSingleCutsRho T T₂ T₁ := by
   simp only [Ring.lie_def, ofConv_sub, LinearMap.sub_apply,
-    convMul_deltaSingleton_apply_ofTree]
+    convMul_lcoeff_singleton_apply_ofTree]
 
 end ConnesKreimer
 

--- a/Linglib/Core/Algebra/RootedTree/Primitive.lean
+++ b/Linglib/Core/Algebra/RootedTree/Primitive.lean
@@ -47,36 +47,36 @@ namespace ConnesKreimer
 open scoped TensorProduct
 open Coalgebra Bialgebra WithConv
 
-variable {R : Type*} [CommRing R] {α : Type*}
+variable {R : Type*} [CommRing R] {α : Type*} (T T₁ T₂ : Nonplanar α)
 
 variable (R) in
 /-- The dual-basis functional `δ_T` on a singleton forest: extracts the
 coefficient of `{T}` from a Connes-Kreimer element. -/
-noncomputable def deltaSingleton (T : Nonplanar α) :
+noncomputable def deltaSingleton :
     ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
   lcoeff ({T} : Forest (Nonplanar α))
 
-theorem deltaSingleton_of' (T : Nonplanar α) (F : Forest (Nonplanar α))
+theorem deltaSingleton_of' (F : Forest (Nonplanar α))
     [Decidable (F = ({T} : Forest (Nonplanar α)))] :
     deltaSingleton R T (of' F) = if F = ({T} : Forest (Nonplanar α)) then 1 else 0 := by
   rw [deltaSingleton, lcoeff_apply, coeff_of']
 
-@[simp] theorem deltaSingleton_of'_self (T : Nonplanar α) :
+@[simp] theorem deltaSingleton_of'_self :
     deltaSingleton R T (of' ({T} : Forest (Nonplanar α))) = 1 := by
   classical rw [deltaSingleton_of', if_pos rfl]
 
-theorem deltaSingleton_ofTree (T T' : Nonplanar α) [Decidable (T' = T)] :
+theorem deltaSingleton_ofTree (T' : Nonplanar α) [Decidable (T' = T)] :
     deltaSingleton R T (ofTree T') = if T' = T then 1 else 0 := by
   classical
   rw [show (ofTree T' : ConnesKreimer R (Nonplanar α)) =
     of' ({T'} : Forest (Nonplanar α)) from rfl, deltaSingleton_of']
   simp [Multiset.singleton_inj]
 
-@[simp] theorem deltaSingleton_ofTree_self (T : Nonplanar α) :
+@[simp] theorem deltaSingleton_ofTree_self :
     deltaSingleton R T (ofTree T) = 1 := by
   classical rw [deltaSingleton_ofTree, if_pos rfl]
 
-@[simp] theorem deltaSingleton_one (T : Nonplanar α) :
+@[simp] theorem deltaSingleton_one :
     deltaSingleton R T (1 : ConnesKreimer R (Nonplanar α)) = 0 := by
   classical
   rw [← of'_zero, deltaSingleton_of', if_neg]
@@ -90,34 +90,17 @@ open scoped Classical in
 /-- Number of Δ^ρ cut summands of `T` whose cut forest is `{T₁}` and whose
 remainder tree is `T₂` — the Δ^ρ analog of the count `c^T_{T₁,T₂}` of
 [marcolli-chomsky-berwick-2025]. -/
-noncomputable def countSingleCutsRho (T T₁ T₂ : Nonplanar α) : ℕ :=
+noncomputable def countSingleCutsRho : ℕ :=
   (cutSummandsN T).countP fun p => p.1 = ({T₁} : Forest (Nonplanar α)) ∧ p.2 = T₂
-
-private theorem countSingleCutsRho_countP (T T₁ T₂ : Nonplanar α)
-    [DecidablePred fun p : Forest (Nonplanar α) × Nonplanar α =>
-      p.1 = ({T₁} : Forest (Nonplanar α)) ∧ p.2 = T₂] :
-    countSingleCutsRho T T₁ T₂ =
-      (cutSummandsN T).countP fun p => p.1 = ({T₁} : Forest (Nonplanar α)) ∧ p.2 = T₂ := by
-  unfold countSingleCutsRho; congr!
-
-private theorem sum_map_indicator {β : Type*} (s : Multiset β) (p : β → Prop)
-    [DecidablePred p] :
-    (s.map fun b => if p b then (1 : R) else 0).sum = s.countP p := by
-  induction s using Multiset.induction with
-  | empty => simp
-  | cons a s ih => by_cases h : p a <;> simp [h, ih, add_comm]
 
 /-! ### Single-tree deltas are dual primitives -/
 
 variable [CharZero R] [NoZeroDivisors R]
 
-private theorem coalgebraCounit_apply (z : ConnesKreimer R (Nonplanar α)) :
-    CoalgebraStruct.counit (R := R) z = counit z := rfl
-
 /-- `δ_T` is a dual primitive: the bialgebraic content of
 [marcolli-chomsky-berwick-2025]'s observation (book p. 79) that primitives in
 the dual are exactly the single-tree deltas. -/
-theorem deltaSingleton_isDualPrimitive (T : Nonplanar α) :
+theorem deltaSingleton_isDualPrimitive :
     IsDualPrimitive R (deltaSingleton R T) := by
   classical
   refine ⟨deltaSingleton_one T, ?_⟩
@@ -155,44 +138,39 @@ theorem deltaSingleton_isDualPrimitive (T : Nonplanar α) :
 /-- [marcolli-chomsky-berwick-2025] Lemma 1.7.3, membership form: single-tree
 deltas lie in the Lie subalgebra of dual primitives (so their brackets do too,
 by `LieSubalgebra.lie_mem`). -/
-theorem toConv_deltaSingleton_mem_dualPrimitives (T : Nonplanar α) :
+theorem toConv_deltaSingleton_mem_dualPrimitives :
     toConv (deltaSingleton R T) ∈
       dualPrimitives R (ConnesKreimer R (Nonplanar α)) :=
   deltaSingleton_isDualPrimitive T
 
 /-! ### The explicit count formula -/
 
-private theorem comul_ofTree (T : Nonplanar α) :
-    (Coalgebra.comul (R := R) (ofTree T) :
-        ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) =
-      comulTreeN T := by
-  show comulAlgHomN (R := R) (of' ({T} : Forest (Nonplanar α))) = _
-  rw [comulAlgHomN_apply_of']
-  show comulForestN (R := R) ({T} : Forest (Nonplanar α)) = comulTreeN T
-  unfold comulForestN
-  rw [Multiset.map_singleton, Multiset.prod_singleton]
-
 /-- The convolution product of two single-tree deltas evaluated on a
 single-tree basis vector counts the Δ^ρ cut summands of `T` extracting `{T₁}`
 and leaving `T₂`. -/
-theorem convMul_deltaSingleton_apply_ofTree (T T₁ T₂ : Nonplanar α) :
+theorem convMul_deltaSingleton_apply_ofTree :
     (toConv (deltaSingleton R T₁) * toConv (deltaSingleton R T₂)) (ofTree T) =
       countSingleCutsRho T T₁ T₂ := by
   classical
-  rw [LinearMap.convMul_apply, comul_ofTree]
-  unfold comulTreeN
-  rw [map_add, map_add, map_multiset_sum, map_multiset_sum]
-  simp only [Multiset.map_map, Function.comp_apply, TensorProduct.map_tmul,
-    LinearMap.mul'_apply, deltaSingleton_one, mul_zero, zero_add,
+  rw [LinearMap.convMul_apply, coalgebra_comul_apply, comulAlgHomN_apply_ofTree, comulTreeN]
+  simp only [map_add, map_multiset_sum, Multiset.map_map, Function.comp_apply,
+    TensorProduct.map_tmul, LinearMap.mul'_apply, deltaSingleton_one, mul_zero, zero_add,
     deltaSingleton_of', deltaSingleton_ofTree, ite_zero_mul_ite_zero, one_mul]
-  rw [sum_map_indicator, countSingleCutsRho_countP]
+  unfold countSingleCutsRho
+  rw [Multiset.countP_eq_card_filter]
+  induction cutSummandsN T using Multiset.induction with
+  | empty => simp
+  | cons q s ih =>
+    rw [Multiset.map_cons, Multiset.sum_cons, Multiset.filter_cons, ih]
+    by_cases h : q.1 = ({T₁} : Forest (Nonplanar α)) ∧ q.2 = T₂ <;> simp [h, add_comm]
 
-/-- **[marcolli-chomsky-berwick-2025] Lemma 1.7.3** (Δ^ρ explicit form): the
-commutator bracket of two single-tree deltas evaluated on a single-tree basis
-vector is the antisymmetrized single-cut count, the Δ^ρ analog of the book's
-`c^T_{T₁,T₂} − c^T_{T₂,T₁}`. The Δ^c (trace-leaf) version follows via the
-strip bijection in `Coproduct/DeletionNonplanar.lean`. -/
-theorem lie_deltaSingleton_apply_ofTree (T T₁ T₂ : Nonplanar α) :
+/-- The commutator of two single-tree delta functionals, evaluated at a tree
+`T`, is the antisymmetrized count of single Δ^ρ cuts of `T` with cut forest
+`{T₁}` and remainder `T₂`. This is Lemma 1.7.3 of
+[marcolli-chomsky-berwick-2025] in Δ^ρ form; the book's
+`c^T_{T₁,T₂} − c^T_{T₂,T₁}` is stated for the trace-leaf coproduct `Δ^c`,
+which agrees under the trace-strip bijection (`stripTraceAlgHom`). -/
+theorem lie_deltaSingleton_apply_ofTree :
     ⁅toConv (deltaSingleton R T₁), toConv (deltaSingleton R T₂)⁆ (ofTree T) =
       (countSingleCutsRho T T₁ T₂ : R) - countSingleCutsRho T T₂ T₁ := by
   simp only [Ring.lie_def, ofConv_sub, LinearMap.sub_apply,


### PR DESCRIPTION
Post-#2033 refinement pass on the CK primitives file (recovers the commit stranded by the #2033 merge race, plus the live-review rounds):

- Public evaluation lemmas `coalgebra_comul_apply` / `coalgebraCounit_apply` beside `instBialgebraRho`, killing the defeq `show`s and private bridges downstream.
- `deltaSingleton` dissolved: `lcoeff` now takes `R` explicitly (aligning with its `Polynomial.lcoeff` model), so the paper's `δ_T` is just `lcoeff R {T}` — the wrapper def and its five evaluation lemmas are gone, inlined via `coeff_of'`/`Multiset.zero_ne_singleton`. `δ_T` vocabulary survives in docstrings.
- Count theorems stated on `ofTree` with inferable ascriptions dropped; single-use helpers (`comul_ofTree`, `countSingleCutsRho_countP`, `sum_map_indicator`) inlined or deleted; `T T₁ T₂` lifted to the variable block; Lemma 1.7.3 docstring rewritten fact-first.