### PR TITLE
refactor(Core/Algebra/RootedTree): split GL/CK pairings into Pairing

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -25,6 +25,7 @@ import Linglib.Core.Algebra.RootedTree.BirkhoffFactorizationSemiring
 import Linglib.Core.Algebra.RootedTree.BirkhoffLaurent
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Algebra.RootedTree.Coproduct.DeletionNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.Pairing
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pruning
 import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pairing.lean
@@ -1,0 +1,317 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
+import Mathlib.LinearAlgebra.TensorProduct.Basis
+import Mathlib.RingTheory.TensorProduct.Basic
+
+open RoseTree RoseTree.Nonplanar
+
+set_option autoImplicit false
+
+/-!
+# Tensor-extended Grossman-Larson/Connes-Kreimer pairings
+[foissy-typed-decorated-rooted-trees-2018]
+
+The symmetry-weighted pairing `⟨·, ·⟩` from `GrossmanLarsonPairing.lean`
+extended to the tensor square (`pairing₂`) and cube (`pairing₃`), with
+nondegeneracy over `[CharZero R] [NoZeroDivisors R]` lifted from the
+binary `pairing_nondegenerate` via the natural basis of
+`CK = (Forest T) →₀ R`.
+
+These are the instruments of the GL/CK duality proof of Δ^ρ
+coassociativity (`Coproduct/PruningDuality.lean`): the duality theorem
+pairs the GL product against Δ^ρ through `pairing₂`, and
+`pairing₃_unique` transports `GrossmanLarson.mul_assoc` to
+coassociativity. No analogous duality holds for the trace coproduct Δ^c
+(see the Trace-coherence section of `Coproduct/TraceNonplanar.lean`).
+-/
+
+namespace ConnesKreimer
+
+open scoped TensorProduct
+open GrossmanLarson
+
+variable {R : Type*} [CommSemiring R] {α : Type*}
+
+/-! ### Tensor-extended pairings
+
+The pairing `⟨·, ·⟩` from `GrossmanLarsonPairing.lean` extends to the
+tensor square (`pairing₂`) and cube (`pairing₃`). These power the GL/CK
+duality for the deletion coproduct Δ^ρ (`Coproduct/PruningDuality.lean`:
+`⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`). For the trace variant Δ^c no
+such duality holds — the trunk of a proper cut contains trace-marker
+leaves that GL grafting can never produce — so Δ^c coassociativity
+(`comulCN_coassoc`, `Coproduct/TraceNonplanar.lean`) is a separate
+combinatorial statement. -/
+
+/-- The **tensor-extended pairing** `H ⊗ H →ₗ H ⊗ H →ₗ R`, defined by
+    `pairing₂ (x ⊗ y) (w ⊗ z) = pairing x w * pairing y z` and extended
+    bilinearly.
+
+    Implementation: reshuffle `(x⊗y)⊗(w⊗z)` to `(x⊗w)⊗(y⊗z)` via
+    `tensorTensorTensorComm`; apply `TP.map pair pair` where
+    `pair = TP.lift pairing : H ⊗ H →ₗ R`; contract via `mul' R R`;
+    curry the result.
+
+    Decoration-free: works on `ConnesKreimer R (Nonplanar α)` for any
+    `α`. Consumed by the Δ^ρ duality (`Coproduct/PruningDuality.lean`). -/
+noncomputable def pairing₂ [DecidableEq α] :
+    (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) →ₗ[R]
+    (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) →ₗ[R] R :=
+  let pair : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)
+                →ₗ[R] R :=
+    TensorProduct.lift pairing
+  TensorProduct.curry <|
+    LinearMap.mul' R R ∘ₗ
+      TensorProduct.map pair pair ∘ₗ
+      (TensorProduct.tensorTensorTensorComm R
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))).toLinearMap
+
+/-- Evaluation of `pairing₂` on pure tensors: `pairing₂ (x ⊗ y) (w ⊗ z) =
+    pairing x w * pairing y z`. -/
+@[simp] theorem pairing₂_tmul_tmul [DecidableEq α]
+    (x y w z : ConnesKreimer R (Nonplanar α)) :
+    pairing₂ (R := R) (x ⊗ₜ y) (w ⊗ₜ z) =
+      pairing x w * pairing y z := by
+  rfl
+
+/-- The **triple-tensor pairing** `H ⊗ (H ⊗ H) →ₗ H ⊗ (H ⊗ H) →ₗ R`,
+    defined on pure tensors by
+    `pairing₃ (a ⊗ (b ⊗ c)) (x ⊗ (y ⊗ z)) = pairing a x · pairing b y · pairing c z`.
+
+    Consumed by the Δ^ρ duality chain (`Coproduct/PruningDuality.lean`):
+    coassociativity is transported through `pairing₃_unique` by pairing
+    against arbitrary `x ⊗ (y ⊗ z)` triple tensors.
+
+    Implementation: pairing on the first factor times `pairing₂` on the
+    second factor; both extended bilinearly. -/
+noncomputable def pairing₃ [DecidableEq α] :
+    (ConnesKreimer R (Nonplanar α) ⊗[R]
+      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))) →ₗ[R]
+    (ConnesKreimer R (Nonplanar α) ⊗[R]
+      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))) →ₗ[R] R :=
+  let pair1 : ConnesKreimer R (Nonplanar α) ⊗[R]
+                ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
+    TensorProduct.lift pairing
+  let pair2 : (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
+                ⊗[R] (ConnesKreimer R (Nonplanar α) ⊗[R]
+                      ConnesKreimer R (Nonplanar α)) →ₗ[R] R :=
+    TensorProduct.lift pairing₂
+  TensorProduct.curry <|
+    LinearMap.mul' R R ∘ₗ
+      TensorProduct.map pair1 pair2 ∘ₗ
+      (TensorProduct.tensorTensorTensorComm R
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α))).toLinearMap
+
+/-- Evaluation of `pairing₃` on pure tensors. -/
+@[simp] theorem pairing₃_tmul_tmul_tmul [DecidableEq α]
+    (a b c x y z : ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (a ⊗ₜ (b ⊗ₜ c)) (x ⊗ₜ (y ⊗ₜ z)) =
+      pairing a x *
+        (pairing b y * pairing c z) := by
+  rfl
+
+/-! ### Reduction helpers: `pairing₃` on shifted-tensor forms
+
+Two reduction lemmas that express `pairing₃ (x ⊗ (y ⊗ z'))` evaluated on
+shifted tensor forms in terms of `pairing₂` and binary `pairing`,
+consumed by the Δ^ρ duality chain in `Coproduct/PruningDuality.lean`.
+Both are proved by `TensorProduct.induction_on`, reducing to the
+pure-tensor case where `pairing₃_tmul_tmul_tmul` and
+`pairing₂_tmul_tmul` agree. -/
+
+/-- `pairing₃ (x ⊗ (y ⊗ z')) ∘ assoc` on a `(U ⊗ c)`-shape tensor:
+    factors as `pairing₂ (x ⊗ y) U * pairing z' c`. Generic in `α`
+    (the trace decoration is irrelevant). -/
+lemma pairing₃_assoc_tmul [DecidableEq α]
+    (x y z' : ConnesKreimer R (Nonplanar α))
+    (U : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
+    (c : ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((TensorProduct.assoc R _ _ _) (U ⊗ₜ[R] c)) =
+      pairing₂ (R := R) (x ⊗ₜ[R] y) U * pairing z' c := by
+  induction U using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a b =>
+    simp only [TensorProduct.assoc_tmul, pairing₃_tmul_tmul_tmul,
+               pairing₂_tmul_tmul, _root_.mul_assoc]
+  | add U₁ U₂ ih₁ ih₂ =>
+    rw [TensorProduct.add_tmul, map_add, map_add, ih₁, ih₂, map_add, add_mul]
+
+/-- `pairing₃ (x ⊗ (y ⊗ z'))` on a `(a ⊗ S)`-shape tensor: factors as
+    `pairing x a * pairing₂ (y ⊗ z') S`. Generic in `α`. -/
+lemma pairing₃_tmul_apply [DecidableEq α]
+    (x y z' a : ConnesKreimer R (Nonplanar α))
+    (S : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (a ⊗ₜ[R] S) =
+      pairing x a * pairing₂ (R := R) (y ⊗ₜ[R] z') S := by
+  induction S using TensorProduct.induction_on with
+  | zero => simp
+  | tmul b c =>
+    simp only [pairing₃_tmul_tmul_tmul, pairing₂_tmul_tmul]
+  | add S₁ S₂ ih₁ ih₂ =>
+    rw [TensorProduct.tmul_add, map_add, ih₁, ih₂, map_add, mul_add]
+
+/-! ### Nondegeneracy of `pairing₂` and `pairing₃` (lifted from binary)
+
+`pairing₂` and `pairing₃` are nondegenerate over `[CharZero R]
+[NoZeroDivisors R]`, lifted from binary `pairing_nondegenerate` via the
+natural basis of `CK = (Forest T) →₀ R`. -/
+
+/-- Bilinear extension: `pairing₃ (of' F ⊗ s) (of' G ⊗ t) = pairing (of' F)
+    (of' G) * pairing₂ s t` for arbitrary `s, t ∈ CK ⊗ CK`. Proven via
+    `TensorProduct.induction_on` on `s` and `t`, reducing to the pure-tensor
+    case where `pairing₃_tmul_tmul_tmul` and `pairing₂_tmul_tmul` agree. -/
+private theorem pairing₃_of'_tmul_of'_tmul [DecidableEq α] (F G : Forest (Nonplanar α))
+    (s t : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R)
+        (ConnesKreimer.of' F ⊗ₜ[R] s)
+        (ConnesKreimer.of' G ⊗ₜ[R] t) =
+      pairing (ConnesKreimer.of' (R := R) F)
+                              (ConnesKreimer.of' G) *
+        pairing₂ (R := R) s t := by
+  induction s using TensorProduct.induction_on with
+  | zero => simp
+  | tmul b c =>
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul y z =>
+      simp only [pairing₃_tmul_tmul_tmul, pairing₂_tmul_tmul]
+    | add t₁ t₂ ih₁ ih₂ =>
+      -- pairing₃ is linear in 2nd arg (map_add); also `of' G ⊗ ·` distributes.
+      rw [TensorProduct.tmul_add, map_add, ih₁, ih₂, map_add, mul_add]
+  | add s₁ s₂ ih₁ ih₂ =>
+    -- pairing₃ is linear in 1st arg, via map_add at the outer; same for pairing₂.
+    rw [TensorProduct.tmul_add, map_add, LinearMap.add_apply, ih₁, ih₂,
+        map_add, LinearMap.add_apply, mul_add]
+
+/-- **Nondegeneracy of `pairing₂`** (lifted from binary): if
+    `U ∈ CK ⊗ CK` pairs to zero against every pure tensor `x ⊗ y`,
+    then `U = 0`.
+
+    Proof: decompose `U` via the natural basis of `CK = (Forest T) →₀ R`
+    as `U = c.sum (fun F U_F => of' F ⊗ U_F)`. Pairing against
+    `of' F ⊗ y` extracts `autF · pairing y (c F)`. Over `CharZero`
+    (so `autF ≠ 0`), each `c F = 0` by `pairing_nondegenerate` +
+    `pairing_symm`, hence `c = 0` and `U = 0`. -/
+private theorem pairing₂_nondegenerate [DecidableEq α]
+    [CharZero R] [NoZeroDivisors R]
+    (U : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
+    (h : ∀ x y : ConnesKreimer R (Nonplanar α),
+      pairing₂ (R := R) (x ⊗ₜ[R] y) U = 0) : U = 0 := by
+  classical
+  let ℬ : Module.Basis (Forest (Nonplanar α)) R (ConnesKreimer R (Nonplanar α)) :=
+    ConnesKreimer.basisSingleOne
+  obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀ ConnesKreimer R (Nonplanar α),
+      c.sum (fun F U_F => ℬ F ⊗ₜ[R] U_F) = U :=
+    TensorProduct.eq_repr_basis_left ℬ U
+  have hℬ : ∀ G : Forest (Nonplanar α),
+      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G := fun _ =>
+    ConnesKreimer.basisSingleOne_apply _
+  have hc_zero : ∀ F, c F = 0 := by
+    intro F
+    apply pairing_nondegenerate (c F)
+    intro y
+    rw [pairing_symm]
+    have h_aut_ne : (Nonplanar.forestAutCard F : R) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (Nonplanar.forestAutCard_pos F).ne'
+    have h_eval := h (ConnesKreimer.of' F) y
+    rw [← hc] at h_eval
+    rw [map_finsuppSum (pairing₂ (R := R) (ConnesKreimer.of' F ⊗ₜ[R] y))] at h_eval
+    simp only [hℬ, pairing₂_tmul_tmul, pairing_of'_of'] at h_eval
+    rw [Finsupp.sum_eq_single F
+          (fun G _ hGF => by rw [if_neg (fun heq => hGF heq.symm), zero_mul])
+          (fun _ => by rw [LinearMap.map_zero, mul_zero])] at h_eval
+    rw [if_pos rfl] at h_eval
+    rcases mul_eq_zero.mp h_eval with h' | h'
+    · exact absurd h' h_aut_ne
+    · exact h'
+  have hc_zero' : c = 0 := Finsupp.ext hc_zero
+  rw [← hc, hc_zero', Finsupp.sum_zero_index]
+
+/-- **Nondegeneracy of `pairing₃`**: if `U ∈ CK ⊗ (CK ⊗ CK)` pairs to
+    zero against every test triple tensor, then `U = 0`.
+
+    Proof: decompose `U` via the basis on the outer factor as
+    `U = c.sum (fun F U_F => of' F ⊗ U_F)` where `U_F ∈ CK ⊗ CK`.
+    Pairing against `of' F ⊗ (x ⊗ y)` extracts `autF · pairing₂ (x ⊗ y)
+    (c F)` via `pairing₃_of'_tmul_of'_tmul`. Over `CharZero` (so
+    `autF ≠ 0`), each `pairing₂ (x ⊗ y) (c F) = 0` for all `x, y`; by
+    `pairing₂_nondegenerate`, `c F = 0`. Hence `c = 0` and `U = 0`. -/
+theorem pairing₃_nondegenerate [DecidableEq α]
+    [CharZero R] [NoZeroDivisors R]
+    (U : ConnesKreimer R (Nonplanar α) ⊗[R]
+          (ConnesKreimer R (Nonplanar α) ⊗[R]
+            ConnesKreimer R (Nonplanar α)))
+    (h : ∀ t, pairing₃ (R := R) t U = 0) : U = 0 := by
+  classical
+  let ℬ : Module.Basis (Forest (Nonplanar α)) R
+        (ConnesKreimer R (Nonplanar α)) :=
+    ConnesKreimer.basisSingleOne
+  obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀
+        (ConnesKreimer R (Nonplanar α) ⊗[R]
+          ConnesKreimer R (Nonplanar α)),
+      c.sum (fun F U_F => ℬ F ⊗ₜ[R] U_F) = U :=
+    TensorProduct.eq_repr_basis_left ℬ U
+  have hℬ : ∀ G : Forest (Nonplanar α),
+      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G :=
+    fun _ => ConnesKreimer.basisSingleOne_apply _
+  have hc_zero : ∀ F, c F = 0 := by
+    intro F
+    apply pairing₂_nondegenerate (c F)
+    intro x y
+    have h_aut_ne : (Nonplanar.forestAutCard F : R) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (Nonplanar.forestAutCard_pos F).ne'
+    have h_eval := h (ConnesKreimer.of' F ⊗ₜ[R] (x ⊗ₜ[R] y))
+    rw [← hc] at h_eval
+    rw [map_finsuppSum
+          (pairing₃ (R := R) (ConnesKreimer.of' F ⊗ₜ[R] (x ⊗ₜ[R] y)))] at h_eval
+    simp only [hℬ, pairing₃_of'_tmul_of'_tmul, pairing_of'_of'] at h_eval
+    rw [Finsupp.sum_eq_single F
+          (fun G _ hGF => by rw [if_neg (fun heq => hGF heq.symm), zero_mul])
+          (fun _ => by rw [LinearMap.map_zero, mul_zero])] at h_eval
+    rw [if_pos rfl] at h_eval
+    rcases mul_eq_zero.mp h_eval with h' | h'
+    · exact absurd h' h_aut_ne
+    · exact h'
+  have hc_zero' : c = 0 := Finsupp.ext hc_zero
+  rw [← hc, hc_zero', Finsupp.sum_zero_index]
+
+/-! ### Equality form of nondegeneracy
+
+`pairing₃_unique`: two tensors that pair the same against every test
+vector are equal. Follows from `pairing₃_nondegenerate` via
+`U = V ↔ U - V = 0`, requiring `AddCommGroup` on the triple tensor.
+
+**Single ring hypothesis**: this theorem lives in its own section with
+`[CommRing R₁]` only (NOT [CommSemiring R] from the file's top section +
+[CommRing R] added on top — those create two CommSemiring R instances
+that don't unify). The `AddCommGroup` on the wrapper comes from the
+global `ConnesKreimer.instCommRing`. -/
+
+section PairingUnique
+variable {R₁ : Type*} [CommRing R₁] {α₁ : Type*}
+
+theorem pairing₃_unique [DecidableEq α₁] [CharZero R₁] [NoZeroDivisors R₁]
+    (U V : ConnesKreimer R₁ (Nonplanar α₁) ⊗[R₁]
+          (ConnesKreimer R₁ (Nonplanar α₁) ⊗[R₁]
+            ConnesKreimer R₁ (Nonplanar α₁)))
+    (h : ∀ t, pairing₃ (R := R₁) t U = pairing₃ (R := R₁) t V) : U = V := by
+  rw [← sub_eq_zero]
+  apply pairing₃_nondegenerate
+  intro t
+  rw [map_sub, h t, sub_self]
+
+end PairingUnique
+
+end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Algebra.RootedTree.BMinus
-import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
+import Linglib.Core.Algebra.RootedTree.Coproduct.Pairing
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -6,11 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.Coproduct.Trace
 import Linglib.Core.Combinatorics.RootedTree.DoubleCut
 import Linglib.Core.Combinatorics.RootedTree.Cut
-import Linglib.Core.Algebra.RootedTree.GrossmanLarson
-import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
-import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 import Mathlib.RingTheory.Bialgebra.Basic
-import Mathlib.LinearAlgebra.TensorProduct.Basis
 
 open RoseTree RoseTree.Nonplanar
 
@@ -56,8 +52,7 @@ The GL/CK pairing duality that proves Δ^ρ coassociativity in
 removes trace markers, so no orientation of
 `⟨x ⋆ y, z⟩ = pairing₂ (…) (Δ^c z)` can hold, and B+ is not a Hochschild
 1-cocycle for Δ^c either (see the Trace-coherence section below). The
-pairings `pairing₂`/`pairing₃` defined here are the nondegeneracy
-instruments that duality proof uses for Δ^ρ.
+pairings themselves live in `Coproduct/Pairing.lean`.
 
 ## Status
 
@@ -67,7 +62,6 @@ instruments that duality proof uses for Δ^ρ.
 namespace ConnesKreimer
 
 open scoped TensorProduct
-open GrossmanLarson
 
 variable {R : Type*} [CommSemiring R] {α β : Type*}
 
@@ -130,90 +124,6 @@ noncomputable def comulCAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
   unfold comulCForestN
   rw [Multiset.map_singleton, Multiset.prod_singleton]
 
-/-! ### Tensor-extended pairings
-
-The pairing `⟨·, ·⟩` from `GrossmanLarsonPairing.lean` extends to the
-tensor square (`pairing₂`) and cube (`pairing₃`). These power the GL/CK
-duality for the deletion coproduct Δ^ρ (`Coproduct/PruningDuality.lean`:
-`⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`). For the trace variant Δ^c no
-such duality holds — the trunk of a proper cut contains trace-marker
-leaves that GL grafting can never produce — so Δ^c coassociativity
-(`comulCN_coassoc` below) is a separate combinatorial statement. -/
-
-/-- The **tensor-extended pairing** `H ⊗ H →ₗ H ⊗ H →ₗ R`, defined by
-    `pairing₂ (x ⊗ y) (w ⊗ z) = pairing x w * pairing y z` and extended
-    bilinearly.
-
-    Implementation: reshuffle `(x⊗y)⊗(w⊗z)` to `(x⊗w)⊗(y⊗z)` via
-    `tensorTensorTensorComm`; apply `TP.map pair pair` where
-    `pair = TP.lift pairing : H ⊗ H →ₗ R`; contract via `mul' R R`;
-    curry the result.
-
-    Decoration-free: works on `ConnesKreimer R (Nonplanar α)` for any
-    `α`. Consumed by the Δ^ρ duality (`Coproduct/PruningDuality.lean`). -/
-noncomputable def pairing₂ [DecidableEq α] :
-    (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) →ₗ[R]
-    (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) →ₗ[R] R :=
-  let pair : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)
-                →ₗ[R] R :=
-    TensorProduct.lift pairing
-  TensorProduct.curry <|
-    LinearMap.mul' R R ∘ₗ
-      TensorProduct.map pair pair ∘ₗ
-      (TensorProduct.tensorTensorTensorComm R
-        (ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α))).toLinearMap
-
-/-- Evaluation of `pairing₂` on pure tensors: `pairing₂ (x ⊗ y) (w ⊗ z) =
-    pairing x w * pairing y z`. -/
-@[simp] theorem pairing₂_tmul_tmul [DecidableEq α]
-    (x y w z : ConnesKreimer R (Nonplanar α)) :
-    pairing₂ (R := R) (x ⊗ₜ y) (w ⊗ₜ z) =
-      pairing x w * pairing y z := by
-  rfl
-
-/-- The **triple-tensor pairing** `H ⊗ (H ⊗ H) →ₗ H ⊗ (H ⊗ H) →ₗ R`,
-    defined on pure tensors by
-    `pairing₃ (a ⊗ (b ⊗ c)) (x ⊗ (y ⊗ z)) = pairing a x · pairing b y · pairing c z`.
-
-    Used in the duality-based proof of `comulCN_coassoc`: equating
-    LHS and RHS coassoc expressions via pairing against arbitrary
-    `x ⊗ (y ⊗ z)` triple tensors.
-
-    Implementation: pairing on the first factor times `pairing₂` on the
-    second factor; both extended bilinearly. -/
-noncomputable def pairing₃ [DecidableEq α] :
-    (ConnesKreimer R (Nonplanar α) ⊗[R]
-      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))) →ₗ[R]
-    (ConnesKreimer R (Nonplanar α) ⊗[R]
-      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))) →ₗ[R] R :=
-  let pair1 : ConnesKreimer R (Nonplanar α) ⊗[R]
-                ConnesKreimer R (Nonplanar α) →ₗ[R] R :=
-    TensorProduct.lift pairing
-  let pair2 : (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
-                ⊗[R] (ConnesKreimer R (Nonplanar α) ⊗[R]
-                      ConnesKreimer R (Nonplanar α)) →ₗ[R] R :=
-    TensorProduct.lift pairing₂
-  TensorProduct.curry <|
-    LinearMap.mul' R R ∘ₗ
-      TensorProduct.map pair1 pair2 ∘ₗ
-      (TensorProduct.tensorTensorTensorComm R
-        (ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α))
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α))).toLinearMap
-
-/-- Evaluation of `pairing₃` on pure tensors. -/
-@[simp] theorem pairing₃_tmul_tmul_tmul [DecidableEq α]
-    (a b c x y z : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (a ⊗ₜ (b ⊗ₜ c)) (x ⊗ₜ (y ⊗ₜ z)) =
-      pairing a x *
-        (pairing b y * pairing c z) := by
-  rfl
-
 /-! ### Trace coherence
 
 There is **no** GL/Δ^c pairing duality: for any marker-free `z` with a
@@ -251,215 +161,6 @@ def TraceCoherent (τ : Nonplanar (α ⊕ β) → β) : Prop :=
 theorem traceCoherent_const (b : β) :
     TraceCoherent (fun _ : Nonplanar (α ⊕ β) => b) :=
   fun _ _ _ => rfl
-
-/-! ### Auxiliary: `pairing₃` reduction helpers
-
-Generic reduction lemmas for `pairing₃` on shifted tensor shapes,
-consumed by the Δ^ρ duality chain in `Coproduct/PruningDuality.lean`. -/
-
-section CoassocChain
-variable (τ : Nonplanar (α ⊕ β) → β)
-
-/-! ### Helpers: `pairing₃` on shifted-tensor forms
-
-Two reduction lemmas that express `pairing₃ (x ⊗ (y ⊗ z'))` evaluated on
-shifted tensor forms in terms of `pairing₂` and binary `pairing`. Both
-are proved by `TensorProduct.induction_on`, reducing to the pure-tensor
-case where `pairing₃_tmul_tmul_tmul` and `pairing₂_tmul_tmul` agree. -/
-
-/-- `pairing₃ (x ⊗ (y ⊗ z')) ∘ assoc` on a `(U ⊗ c)`-shape tensor:
-    factors as `pairing₂ (x ⊗ y) U * pairing z' c`. Generic in `α`
-    (the trace decoration is irrelevant). -/
-lemma pairing₃_assoc_tmul [DecidableEq α]
-    (x y z' : ConnesKreimer R (Nonplanar α))
-    (U : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
-    (c : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((TensorProduct.assoc R _ _ _) (U ⊗ₜ[R] c)) =
-      pairing₂ (R := R) (x ⊗ₜ[R] y) U * pairing z' c := by
-  induction U using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a b =>
-    simp only [TensorProduct.assoc_tmul, pairing₃_tmul_tmul_tmul,
-               pairing₂_tmul_tmul, _root_.mul_assoc]
-  | add U₁ U₂ ih₁ ih₂ =>
-    rw [TensorProduct.add_tmul, map_add, map_add, ih₁, ih₂, map_add, add_mul]
-
-/-- `pairing₃ (x ⊗ (y ⊗ z'))` on a `(a ⊗ S)`-shape tensor: factors as
-    `pairing x a * pairing₂ (y ⊗ z') S`. Generic in `α`. -/
-lemma pairing₃_tmul_apply [DecidableEq α]
-    (x y z' a : ConnesKreimer R (Nonplanar α))
-    (S : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (a ⊗ₜ[R] S) =
-      pairing x a * pairing₂ (R := R) (y ⊗ₜ[R] z') S := by
-  induction S using TensorProduct.induction_on with
-  | zero => simp
-  | tmul b c =>
-    simp only [pairing₃_tmul_tmul_tmul, pairing₂_tmul_tmul]
-  | add S₁ S₂ ih₁ ih₂ =>
-    rw [TensorProduct.tmul_add, map_add, ih₁, ih₂, map_add, mul_add]
-
-/-! ### Chain lemmas: pairing₃ against `coassocLHSLin/RHSLin`
-
-These compose two applications of `pairing_gl_eq_pairing_coproduct_C`
-(Foissy 2018 §4.2) through the helper lemmas above. The intermediate
-`pairing₃_assoc_rTensor_comul` / `pairing₃_lTensor_comul` lemmas
-generalize over the inner Δ^c-image, enabling a clean specialization
-to `V = Δ^c z`. -/
-
-end CoassocChain
-
-/-! ### Nondegeneracy of `pairing₂` and `pairing₃` (lifted from binary)
-
-`pairing₂` and `pairing₃` are nondegenerate over `[CharZero R]
-[NoZeroDivisors R]`, lifted from binary `pairing_nondegenerate` via the
-natural basis of `CK = (Forest T) →₀ R`. -/
-
-/-- Bilinear extension: `pairing₃ (of' F ⊗ s) (of' G ⊗ t) = pairing (of' F)
-    (of' G) * pairing₂ s t` for arbitrary `s, t ∈ CK ⊗ CK`. Proven via
-    `TensorProduct.induction_on` on `s` and `t`, reducing to the pure-tensor
-    case where `pairing₃_tmul_tmul_tmul` and `pairing₂_tmul_tmul` agree. -/
-private theorem pairing₃_of'_tmul_of'_tmul [DecidableEq α] (F G : Forest (Nonplanar α))
-    (s t : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R)
-        (ConnesKreimer.of' F ⊗ₜ[R] s)
-        (ConnesKreimer.of' G ⊗ₜ[R] t) =
-      pairing (ConnesKreimer.of' (R := R) F)
-                              (ConnesKreimer.of' G) *
-        pairing₂ (R := R) s t := by
-  induction s using TensorProduct.induction_on with
-  | zero => simp
-  | tmul b c =>
-    induction t using TensorProduct.induction_on with
-    | zero => simp
-    | tmul y z =>
-      simp only [pairing₃_tmul_tmul_tmul, pairing₂_tmul_tmul]
-    | add t₁ t₂ ih₁ ih₂ =>
-      -- pairing₃ is linear in 2nd arg (map_add); also `of' G ⊗ ·` distributes.
-      rw [TensorProduct.tmul_add, map_add, ih₁, ih₂, map_add, mul_add]
-  | add s₁ s₂ ih₁ ih₂ =>
-    -- pairing₃ is linear in 1st arg, via map_add at the outer; same for pairing₂.
-    rw [TensorProduct.tmul_add, map_add, LinearMap.add_apply, ih₁, ih₂,
-        map_add, LinearMap.add_apply, mul_add]
-
-/-- **Nondegeneracy of `pairing₂`** (lifted from binary): if
-    `U ∈ CK ⊗ CK` pairs to zero against every pure tensor `x ⊗ y`,
-    then `U = 0`.
-
-    Proof: decompose `U` via the natural basis of `CK = (Forest T) →₀ R`
-    as `U = c.sum (fun F U_F => of' F ⊗ U_F)`. Pairing against
-    `of' F ⊗ y` extracts `autF · pairing y (c F)`. Over `CharZero`
-    (so `autF ≠ 0`), each `c F = 0` by `pairing_nondegenerate` +
-    `pairing_symm`, hence `c = 0` and `U = 0`. -/
-private theorem pairing₂_nondegenerate [DecidableEq α]
-    [CharZero R] [NoZeroDivisors R]
-    (U : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
-    (h : ∀ x y : ConnesKreimer R (Nonplanar α),
-      pairing₂ (R := R) (x ⊗ₜ[R] y) U = 0) : U = 0 := by
-  classical
-  let ℬ : Module.Basis (Forest (Nonplanar α)) R (ConnesKreimer R (Nonplanar α)) :=
-    ConnesKreimer.basisSingleOne
-  obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀ ConnesKreimer R (Nonplanar α),
-      c.sum (fun F U_F => ℬ F ⊗ₜ[R] U_F) = U :=
-    TensorProduct.eq_repr_basis_left ℬ U
-  have hℬ : ∀ G : Forest (Nonplanar α),
-      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G := fun _ =>
-    ConnesKreimer.basisSingleOne_apply _
-  have hc_zero : ∀ F, c F = 0 := by
-    intro F
-    apply pairing_nondegenerate (c F)
-    intro y
-    rw [pairing_symm]
-    have h_aut_ne : (Nonplanar.forestAutCard F : R) ≠ 0 :=
-      Nat.cast_ne_zero.mpr (Nonplanar.forestAutCard_pos F).ne'
-    have h_eval := h (ConnesKreimer.of' F) y
-    rw [← hc] at h_eval
-    rw [map_finsuppSum (pairing₂ (R := R) (ConnesKreimer.of' F ⊗ₜ[R] y))] at h_eval
-    simp only [hℬ, pairing₂_tmul_tmul, pairing_of'_of'] at h_eval
-    rw [Finsupp.sum_eq_single F
-          (fun G _ hGF => by rw [if_neg (fun heq => hGF heq.symm), zero_mul])
-          (fun _ => by rw [LinearMap.map_zero, mul_zero])] at h_eval
-    rw [if_pos rfl] at h_eval
-    rcases mul_eq_zero.mp h_eval with h' | h'
-    · exact absurd h' h_aut_ne
-    · exact h'
-  have hc_zero' : c = 0 := Finsupp.ext hc_zero
-  rw [← hc, hc_zero', Finsupp.sum_zero_index]
-
-/-- **Nondegeneracy of `pairing₃`**: if `U ∈ CK ⊗ (CK ⊗ CK)` pairs to
-    zero against every test triple tensor, then `U = 0`.
-
-    Proof: decompose `U` via the basis on the outer factor as
-    `U = c.sum (fun F U_F => of' F ⊗ U_F)` where `U_F ∈ CK ⊗ CK`.
-    Pairing against `of' F ⊗ (x ⊗ y)` extracts `autF · pairing₂ (x ⊗ y)
-    (c F)` via `pairing₃_of'_tmul_of'_tmul`. Over `CharZero` (so
-    `autF ≠ 0`), each `pairing₂ (x ⊗ y) (c F) = 0` for all `x, y`; by
-    `pairing₂_nondegenerate`, `c F = 0`. Hence `c = 0` and `U = 0`. -/
-theorem pairing₃_nondegenerate [DecidableEq α]
-    [CharZero R] [NoZeroDivisors R]
-    (U : ConnesKreimer R (Nonplanar α) ⊗[R]
-          (ConnesKreimer R (Nonplanar α) ⊗[R]
-            ConnesKreimer R (Nonplanar α)))
-    (h : ∀ t, pairing₃ (R := R) t U = 0) : U = 0 := by
-  classical
-  let ℬ : Module.Basis (Forest (Nonplanar α)) R
-        (ConnesKreimer R (Nonplanar α)) :=
-    ConnesKreimer.basisSingleOne
-  obtain ⟨c, hc⟩ : ∃ c : Forest (Nonplanar α) →₀
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)),
-      c.sum (fun F U_F => ℬ F ⊗ₜ[R] U_F) = U :=
-    TensorProduct.eq_repr_basis_left ℬ U
-  have hℬ : ∀ G : Forest (Nonplanar α),
-      (ℬ G : ConnesKreimer R (Nonplanar α)) = ConnesKreimer.of' G :=
-    fun _ => ConnesKreimer.basisSingleOne_apply _
-  have hc_zero : ∀ F, c F = 0 := by
-    intro F
-    apply pairing₂_nondegenerate (c F)
-    intro x y
-    have h_aut_ne : (Nonplanar.forestAutCard F : R) ≠ 0 :=
-      Nat.cast_ne_zero.mpr (Nonplanar.forestAutCard_pos F).ne'
-    have h_eval := h (ConnesKreimer.of' F ⊗ₜ[R] (x ⊗ₜ[R] y))
-    rw [← hc] at h_eval
-    rw [map_finsuppSum
-          (pairing₃ (R := R) (ConnesKreimer.of' F ⊗ₜ[R] (x ⊗ₜ[R] y)))] at h_eval
-    simp only [hℬ, pairing₃_of'_tmul_of'_tmul, pairing_of'_of'] at h_eval
-    rw [Finsupp.sum_eq_single F
-          (fun G _ hGF => by rw [if_neg (fun heq => hGF heq.symm), zero_mul])
-          (fun _ => by rw [LinearMap.map_zero, mul_zero])] at h_eval
-    rw [if_pos rfl] at h_eval
-    rcases mul_eq_zero.mp h_eval with h' | h'
-    · exact absurd h' h_aut_ne
-    · exact h'
-  have hc_zero' : c = 0 := Finsupp.ext hc_zero
-  rw [← hc, hc_zero', Finsupp.sum_zero_index]
-
-/-! ### Equality form of nondegeneracy
-
-`pairing₃_unique`: two tensors that pair the same against every test
-vector are equal. Follows from `pairing₃_nondegenerate` via
-`U = V ↔ U - V = 0`, requiring `AddCommGroup` on the triple tensor.
-
-**Single ring hypothesis**: this theorem lives in its own section with
-`[CommRing R₁]` only (NOT [CommSemiring R] from the file's top section +
-[CommRing R] added on top — those create two CommSemiring R instances
-that don't unify). The `AddCommGroup` on the wrapper comes from the
-global `ConnesKreimer.instCommRing`. -/
-
-section PairingUnique
-variable {R₁ : Type*} [CommRing R₁] {α₁ : Type*}
-
-theorem pairing₃_unique [DecidableEq α₁] [CharZero R₁] [NoZeroDivisors R₁]
-    (U V : ConnesKreimer R₁ (Nonplanar α₁) ⊗[R₁]
-          (ConnesKreimer R₁ (Nonplanar α₁) ⊗[R₁]
-            ConnesKreimer R₁ (Nonplanar α₁)))
-    (h : ∀ t, pairing₃ (R := R₁) t U = pairing₃ (R := R₁) t V) : U = V := by
-  rw [← sub_eq_zero]
-  apply pairing₃_nondegenerate
-  intro t
-  rw [map_sub, h t, sub_self]
-
-end PairingUnique
 
 /-! ### Double-cut enumeration — substrate for the direct coassoc proof
 


### PR DESCRIPTION
Seam (b) of the Coproduct/ cleanup: `pairing₂`/`pairing₃`, their reduction helpers, nondegeneracy, and `pairing₃_unique` move from `TraceNonplanar.lean` into a new `Coproduct/Pairing.lean` — they are Δ^ρ-duality instruments with no Δ^c content.

- `TraceNonplanar` (now ~900 lines) is pure Δ^c and sheds all three GrossmanLarson imports; `PruningDuality` imports `Pairing` + `GrossmanLarsonMonoid` for what it actually uses.
- Deletes a stale empty "chain lemmas" section header citing the nonexistent `pairing_gl_eq_pairing_coproduct_C`, and fixes `pairing₃`'s docstring claim that it powers a duality-based Δ^c coassoc proof (that route is dead; the Δ^ρ chain is the consumer).