### PR TITLE
feat(Core/Algebra/RootedTree): gated Δ^c Bialgebra instance on WithCuts

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/DeletionNonplanar.lean
@@ -949,7 +949,7 @@ private theorem strip_comulCTreeN_embedInl
   show (Algebra.TensorProduct.map (stripTraceAlgHom (R := R)) stripTraceAlgHom)
         (comulCTreeN τ (Nonplanar.mk (RoseTree.map Sum.inl t))) =
        comulTreeN (Nonplanar.mk t)
-  unfold comulCTreeN
+  unfold comulCTreeN comulTreeNG
   rw [map_add]
   -- First summand: (S ⊗ S) (ofTree (mk (embed t)) ⊗ 1) = ofTree (mk t) ⊗ 1.
   rw [show (Algebra.TensorProduct.map (stripTraceAlgHom (R := R)) stripTraceAlgHom)
@@ -1018,9 +1018,8 @@ private theorem strip_comulCForestN_embedInl
     have hcons : comulCForestN (R := R) τ
         (Nonplanar.embedInl T ::ₘ F'.map Nonplanar.embedInl) =
         comulCTreeN τ (Nonplanar.embedInl T) *
-          comulCForestN (R := R) τ (F'.map Nonplanar.embedInl) := by
-      unfold comulCForestN
-      rw [Multiset.map_cons, Multiset.prod_cons]
+          comulCForestN (R := R) τ (F'.map Nonplanar.embedInl) :=
+      comulForestNG_cons _ _ _
     rw [hcons, map_mul, strip_comulCTreeN_embedInl, ih]
 
 /-- **MCB equivalence** (n-ary specialization): the Δ^d-via-Δ^c

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -694,6 +694,10 @@ noncomputable instance instBialgebraRho
     counit_rTensor_comulAlgHomN
     counit_lTensor_comulAlgHomN
 
+/-- Δ^ρ is the generic coproduct at `cuts := cutSummandsN` — definitional. -/
+theorem comulAlgHomN_eq_G {R : Type*} [CommSemiring R] {α : Type*} :
+    comulAlgHomN (R := R) (α := α) = comulAlgHomNG (R := R) cutSummandsN := rfl
+
 /-- Δ^ρ is admissible: the GL/CK-duality coassociativity and the counit laws,
 transported through the `rfl` bridge `comulAlgHomN_eq_G`. -/
 instance {α : Type*} [DecidableEq α] : IsAdmissibleCuts (cutSummandsN (α := α)) where

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceGrading.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceGrading.lean
@@ -173,7 +173,7 @@ private theorem comulCTreeN_mem (τ : Nonplanar (α'' ⊕ β'') → β'')
     (T : Nonplanar (α'' ⊕ β'')) :
     comulCTreeN (R := R'') τ T ∈
       gradedTensorSpan (R'' := R'') (α'' := α'') (β'' := β'') (T.numNodes - 1) := by
-  unfold comulCTreeN
+  unfold comulCTreeN comulTreeNG
   refine Submodule.add_mem _ ?_ ?_
   · refine Submodule.subset_span ⟨{T}, 0, ?_, ?_⟩
     · rw [edgeCount_singleton]

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Core.Algebra.RootedTree.Coproduct.Trace
 import Linglib.Core.Combinatorics.RootedTree.DoubleCut
 import Linglib.Core.Combinatorics.RootedTree.Cut
+import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Mathlib.RingTheory.Bialgebra.Basic
 
 open RoseTree RoseTree.Nonplanar
@@ -43,7 +44,10 @@ structure of `(V(F_{SO_0}), ⊔, Δ^c)`.
    through `Nonplanar.mk`.
 3. **Counit laws** from the empty-cut uniqueness of the enumeration
    (`cutSummandsCN_filter_empty`, `Core/Combinatorics/RootedTree/Cut.lean`).
-4. **`bialgebraC`** — the `Bialgebra` structure, via `Bialgebra.ofAlgHom`.
+4. **`instIsAdmissibleCutsCN`** — the laws packaged as `IsAdmissibleCuts
+   (cutSummandsCN τ)`, gated on `Fact (TraceCoherent τ)`, so
+   `WithCuts R (cutSummandsCN τ)` carries the Δ^c `Bialgebra` instance
+   (`Coproduct/WithCuts.lean`).
 
 ## No GL/Δ^c duality
 
@@ -65,64 +69,59 @@ open scoped TensorProduct
 
 variable {R : Type*} [CommSemiring R] {α β : Type*}
 
-/-! ### Nonplanar tree- and forest-level Δ^c -/
+/-! ### Nonplanar tree- and forest-level Δ^c
 
-/-- The Nonplanar tree-level Δ^c coproduct. -/
-noncomputable def comulCTreeN (τ : Nonplanar (α ⊕ β) → β)
-    (T : Nonplanar (α ⊕ β)) :
-    ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  ConnesKreimer.ofTree T ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar (α ⊕ β)))
-  + ((cutSummandsCN τ T).map
-      (fun p => ConnesKreimer.of' (R := R) p.1 ⊗ₜ[R] ConnesKreimer.ofTree p.2)).sum
+Definitional instantiations of the generic admissible-cut coproduct
+(`Coproduct/WithCuts.lean`) at the Δ^c enumeration `cutSummandsCN τ`. -/
+
+/-- The Nonplanar tree-level Δ^c coproduct: `comulTreeNG` at
+    `cuts := cutSummandsCN τ`. -/
+noncomputable def comulCTreeN (τ : Nonplanar (α ⊕ β) → β) :
+    Nonplanar (α ⊕ β) →
+      ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
+  comulTreeNG (cutSummandsCN τ)
 
 /-- The Nonplanar forest-level Δ^c (multiplicative extension). -/
-noncomputable def comulCForestN (τ : Nonplanar (α ⊕ β) → β)
-    (F : Forest (Nonplanar (α ⊕ β))) :
-    ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  (F.map (comulCTreeN (R := R) τ)).prod
+noncomputable def comulCForestN (τ : Nonplanar (α ⊕ β) → β) :
+    Forest (Nonplanar (α ⊕ β)) →
+      ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
+  comulForestNG (cutSummandsCN τ)
 
 @[simp] theorem comulCForestN_zero (τ : Nonplanar (α ⊕ β) → β) :
-    comulCForestN (R := R) τ (0 : Forest (Nonplanar (α ⊕ β))) = 1 := by
-  simp only [comulCForestN, Multiset.map_zero, Multiset.prod_zero]
+    comulCForestN (R := R) τ (0 : Forest (Nonplanar (α ⊕ β))) = 1 :=
+  comulForestNG_zero _
 
 @[simp] theorem comulCForestN_add (τ : Nonplanar (α ⊕ β) → β)
     (F G : Forest (Nonplanar (α ⊕ β))) :
     comulCForestN (R := R) τ (F + G) =
-      comulCForestN (R := R) τ F * comulCForestN (R := R) τ G := by
-  unfold comulCForestN
-  rw [Multiset.map_add, Multiset.prod_add]
+      comulCForestN (R := R) τ F * comulCForestN (R := R) τ G :=
+  comulForestNG_add _ F G
 
 /-- Forest-level Δ^c as a `MonoidHom` from `Multiplicative (Forest ...)`. -/
 noncomputable def comulCMonoidHomN (τ : Nonplanar (α ⊕ β) → β) :
     Multiplicative (Forest (Nonplanar (α ⊕ β))) →*
       (ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R]
-        ConnesKreimer R (Nonplanar (α ⊕ β))) where
-  toFun F := comulCForestN (R := R) τ F.toAdd
-  map_one' := comulCForestN_zero τ
-  map_mul' F G := comulCForestN_add τ F.toAdd G.toAdd
+        ConnesKreimer R (Nonplanar (α ⊕ β))) :=
+  comulMonoidHomNG (cutSummandsCN τ)
 
 /-- The **Δ^c coproduct on `ConnesKreimer R (Nonplanar (α ⊕ β))`** as
-    an algebra hom, parameterized by the trace encoder `τ`. -/
+    an algebra hom: `comulAlgHomNG` at `cuts := cutSummandsCN τ`,
+    parameterized by the trace encoder `τ`. -/
 noncomputable def comulCAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
     ConnesKreimer R (Nonplanar (α ⊕ β)) →ₐ[R]
       ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R]
         ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  ConnesKreimer.lift (comulCMonoidHomN τ)
+  comulAlgHomNG (cutSummandsCN τ)
 
 @[simp] theorem comulCAlgHomN_apply_of' (τ : Nonplanar (α ⊕ β) → β)
     (F : Forest (Nonplanar (α ⊕ β))) :
-    comulCAlgHomN (R := R) τ (ConnesKreimer.of' F) = comulCForestN τ F := by
-  rw [comulCAlgHomN, ConnesKreimer.lift_of']
-  rfl
+    comulCAlgHomN (R := R) τ (ConnesKreimer.of' F) = comulCForestN τ F :=
+  comulAlgHomNG_apply_of' _ F
 
 @[simp] theorem comulCAlgHomN_apply_ofTree (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
-    comulCAlgHomN (R := R) τ (ConnesKreimer.ofTree T) = comulCTreeN τ T := by
-  rw [show (ConnesKreimer.ofTree T : ConnesKreimer R (Nonplanar (α ⊕ β)))
-        = ConnesKreimer.of' {T} from rfl, comulCAlgHomN_apply_of']
-  show comulCForestN τ {T} = _
-  unfold comulCForestN
-  rw [Multiset.map_singleton, Multiset.prod_singleton]
+    comulCAlgHomN (R := R) τ (ConnesKreimer.ofTree T) = comulCTreeN τ T :=
+  comulAlgHomNG_apply_ofTree _ T
 
 /-! ### Trace coherence
 
@@ -233,7 +232,7 @@ private noncomputable def treeCutsN (τ : Nonplanar (α ⊕ β) → β)
 private theorem comulCTreeN_eq_sum (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
     comulCTreeN (R := R) τ T = ((treeCutsN τ T).map (cutTensor (R := R))).sum := by
-  unfold comulCTreeN treeCutsN
+  unfold comulCTreeN comulTreeNG treeCutsN
   rw [Multiset.map_cons, Multiset.sum_cons, Multiset.map_map]
   congr 1
 
@@ -270,7 +269,8 @@ private theorem comulCForestN_eq_sum (τ : Nonplanar (α ⊕ β) → β)
     rw [show (T ::ₘ F : Forest (Nonplanar (α ⊕ β))) = {T} + F from
           (Multiset.singleton_add T F).symm, comulCForestN_add]
     rw [show comulCForestN (R := R) τ {T} = comulCTreeN τ T from by
-          unfold comulCForestN; rw [Multiset.map_singleton, Multiset.prod_singleton],
+          unfold comulCForestN comulForestNG
+          rw [Multiset.map_singleton, Multiset.prod_singleton]; rfl,
         comulCTreeN_eq_sum, ih]
     rw [show ({T} + F : Forest (Nonplanar (α ⊕ β))) = T ::ₘ F from
           (Multiset.singleton_add T F), forestCutsN_cons, Multiset.map_map]
@@ -629,11 +629,18 @@ theorem comulCAlgHomN_coassoc_algHom
   -- LinearMap composition. `comulCN_coassoc` gives the equality.
   exact comulCN_coassoc τ hτ
 
+end BialgebraInst
+
 /-! ### Counit laws — factored via per-tree + forest helpers
 
 Mirrors the Δ^ρ proof structure in `Coproduct/PruningNonplanar.lean`:
 per-tree laws from empty-cut uniqueness, lifted to forests by
-multiplicativity. -/
+multiplicativity. Stated over `CommSemiring` (unlike the coassoc, which
+needs a ring) so they can feed the ring-uniform `IsAdmissibleCuts`
+counit fields directly. -/
+
+section CounitLaws
+variable {R' : Type*} [CommSemiring R'] {α' β' : Type*}
 
 /-- **Per-tree right counit law**: under `(counit ⊗ id)`, only the `(0, T)`
     cut summand of `cutSummandsCN τ T` survives, contributing `1 ⊗ ofTree T`.
@@ -650,7 +657,7 @@ private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
         (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β')))))
       (comulCTreeN τ T) = (1 : R') ⊗ₜ ConnesKreimer.ofTree T := by
   -- Expand comulCTreeN τ T.
-  unfold comulCTreeN
+  unfold comulCTreeN comulTreeNG
   rw [map_add]
   -- First summand: (counit ⊗ id)(ofTree T ⊗ 1) = counit(ofTree T) ⊗ 1 = 0 ⊗ 1 = 0.
   rw [show (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
@@ -709,7 +716,7 @@ private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
         ((ConnesKreimer.counit (R := R')) :
           ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R'))
       (comulCTreeN τ T) = ConnesKreimer.ofTree T ⊗ₜ (1 : R') := by
-  unfold comulCTreeN
+  unfold comulCTreeN comulTreeNG
   rw [map_add]
   -- First summand: (id ⊗ counit)(ofTree T ⊗ 1) = ofTree T ⊗ counit(1) = ofTree T ⊗ 1.
   rw [show (Algebra.TensorProduct.map
@@ -777,9 +784,8 @@ private theorem counit_rTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
           ConnesKreimer.of'_add, ConnesKreimer.of'_singleton]
     -- comulCForestN (T ::ₘ F') = comulCTreeN τ T * comulCForestN τ F'
     have hCons : comulCForestN (R := R') τ (T ::ₘ F') =
-        comulCTreeN (R := R') τ T * comulCForestN (R := R') τ F' := by
-      unfold comulCForestN
-      rw [Multiset.map_cons, Multiset.prod_cons]
+        comulCTreeN (R := R') τ T * comulCForestN (R := R') τ F' :=
+      comulForestNG_cons _ T F'
     rw [hCons, map_mul, hT, ih',
         Algebra.TensorProduct.tmul_mul_tmul, _root_.mul_one, hForest]
 
@@ -808,9 +814,8 @@ private theorem counit_lTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
             (Multiset.singleton_add T F').symm,
           ConnesKreimer.of'_add, ConnesKreimer.of'_singleton]
     have hCons : comulCForestN (R := R') τ (T ::ₘ F') =
-        comulCTreeN (R := R') τ T * comulCForestN (R := R') τ F' := by
-      unfold comulCForestN
-      rw [Multiset.map_cons, Multiset.prod_cons]
+        comulCTreeN (R := R') τ T * comulCForestN (R := R') τ F' :=
+      comulForestNG_cons _ T F'
     rw [hCons, map_mul, hT, ih',
         Algebra.TensorProduct.tmul_mul_tmul, _root_.one_mul, hForest]
 
@@ -850,24 +855,39 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
   rw [comulCAlgHomN_apply_of', Algebra.TensorProduct.rid_symm_apply]
   exact counit_lTensor_comulCForestN τ F (fun T _ => counit_lTensor_comulCTreeN τ T)
 
-/-- **`Bialgebra` structure** on `ConnesKreimer R' (Nonplanar (α' ⊕ β'))`
-    with Δ^c as the coproduct, for a trace-coherent encoder.
+/-- Δ^c is the generic coproduct at `cuts := cutSummandsCN τ` — definitional. -/
+theorem comulCAlgHomN_eq_G {R : Type*} [CommSemiring R] (τ : Nonplanar (α' ⊕ β') → β') :
+    comulCAlgHomN (R := R) τ = comulAlgHomNG (R := R) (cutSummandsCN τ) := rfl
 
-    The graded bialgebra structure of MCB Lemma 1.2.10. Built via
-    `Bialgebra.ofAlgHom` with `comulCAlgHomN τ` as the coproduct and the
-    inherited `counit` from CK. A `def`, not an `instance`: coassociativity
-    needs `TraceCoherent τ` (it is false for arbitrary `τ` — see
-    `comulCN_coassoc`), which instance resolution cannot synthesize. -/
-@[reducible] noncomputable def bialgebraC
-    (τ : Nonplanar (α' ⊕ β') → β')
-    (hτ : TraceCoherent τ) :
-    Bialgebra R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))) :=
-  Bialgebra.ofAlgHom (comulCAlgHomN (R := R') τ) ((ConnesKreimer.counit (R := R')) :
-          ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
-    (comulCAlgHomN_coassoc_algHom τ hτ)
-    (counit_rTensor_comulCAlgHomN τ)
-    (counit_lTensor_comulCAlgHomN τ)
+/-- **Δ^c is an admissible cut policy** for a trace-coherent encoder:
+    `comulCAlgHomN_coassoc_algHom` and the counit laws packaged as the
+    `IsAdmissibleCuts` mixin, so `WithCuts R (cutSummandsCN τ)` receives its
+    `Bialgebra` instance — the bialgebra structure of MCB Lemma 1.2.10.
+    Gated on `Fact (TraceCoherent τ)`: coassociativity is false for
+    arbitrary `τ` (see `comulCN_coassoc`), and instance resolution cannot
+    synthesize the coherence hypothesis without the `Fact` wrapper. -/
+instance instIsAdmissibleCutsCN (τ : Nonplanar (α' ⊕ β') → β')
+    [Fact (TraceCoherent τ)] :
+    IsAdmissibleCuts (cutSummandsCN τ) where
+  coassoc := by
+    intro R _ _ _
+    rw [← comulCAlgHomN_eq_G]
+    exact comulCAlgHomN_coassoc_algHom τ Fact.out
+  counit_rTensor := by
+    intro R _
+    exact counit_rTensor_comulCAlgHomN τ
+  counit_lTensor := by
+    intro R _
+    exact counit_lTensor_comulCAlgHomN τ
 
-end BialgebraInst
+/-- Resolution check: a trace-coherent encoder yields the Δ^c `Bialgebra`
+    on the marked carrier through the gated instance chain. -/
+noncomputable example {R : Type*} [CommRing R] [CharZero R] [NoZeroDivisors R]
+    (τ : Nonplanar (α' ⊕ β') → β') (hτ : TraceCoherent τ) :
+    Bialgebra R (WithCuts R (cutSummandsCN τ)) :=
+  haveI : Fact (TraceCoherent τ) := ⟨hτ⟩
+  inferInstance
+
+end CounitLaws
 
 end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/WithCuts.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/WithCuts.lean
@@ -1,5 +1,6 @@
-import Linglib.Core.Algebra.RootedTree.Coproduct.PruningNonplanar
-import Linglib.Core.Algebra.RootedTree.Coproduct.TraceNonplanar
+import Linglib.Core.Algebra.RootedTree.ConnesKreimer
+import Linglib.Core.Data.RoseTree.Nonplanar
+import Mathlib.RingTheory.Bialgebra.Basic
 
 open RoseTree RoseTree.Nonplanar
 
@@ -13,10 +14,10 @@ The three MCB coproducts — Δ^ρ (pruning), Δ^c (contraction/trace), Δ^d
 (deletion) — share one shape: a primitive `ofTree T ⊗ 1` plus a sum over *cut
 summands* `(crown, trunk)` of `of' crown ⊗ ofTree trunk`. They differ **only**
 in the cut enumeration `cuts T`. This file factors that shape into a single
-`cuts`-parameterized algebra hom `comulAlgHomNG`, recovering the existing
-`comulTreeN`/`comulAlgHomN` (Δ^ρ, `cuts := cutSummandsN`) and
-`comulCTreeN`/`comulCAlgHomN τ` (Δ^c, `cuts := cutSummandsCN τ`) as instances —
-the bridges are definitional (`rfl`).
+`cuts`-parameterized algebra hom `comulAlgHomNG`; the concrete coproducts are
+its instantiations — Δ^ρ at `cuts := cutSummandsN`
+(`Coproduct/PruningNonplanar.lean`) and Δ^c at `cuts := cutSummandsCN τ`
+(`Coproduct/TraceNonplanar.lean`, definitionally).
 
 The cut-*enumeration* layer was already generic (`ConnesKreimer.cutSummandsG`,
 over an extraction policy); this lifts that genericity to the coproduct
@@ -27,8 +28,8 @@ serves every coproduct instead of one bespoke copy per Δ.
 
 * `comulTreeNG cuts` / `comulForestNG cuts` — the generic coproduct.
 * `comulAlgHomNG cuts` — packaged as an `AlgHom`.
-* `comulTreeN_eq_G`, `comulCTreeN_eq_G`, `comulAlgHomN_eq_G`,
-  `comulCAlgHomN_eq_G` — the Δ^ρ / Δ^c instance bridges.
+* `WithCuts R cuts` — the policy-indexed carrier, with `Bialgebra` gated
+  on `IsAdmissibleCuts cuts`.
 -/
 
 namespace ConnesKreimer
@@ -107,22 +108,6 @@ noncomputable def comulAlgHomNG
         from rfl, comulAlgHomNG_apply_of',
       show ({T} : Forest (Nonplanar α)) = T ::ₘ (0 : Forest (Nonplanar α)) from rfl,
       comulForestNG_cons, comulForestNG_zero, mul_one]
-
-/-! ### Instance bridges (Δ^ρ, Δ^c) — definitional -/
-
-/-- Δ^ρ is the generic coproduct at `cuts := cutSummandsN`. -/
-theorem comulTreeN_eq_G (T : Nonplanar α) :
-    comulTreeN (R := R) T = comulTreeNG (R := R) cutSummandsN T := rfl
-
-/-- Δ^c is the generic coproduct at `cuts := cutSummandsCN τ`. -/
-theorem comulCTreeN_eq_G {β : Type*} (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) :
-    comulCTreeN (R := R) τ T = comulTreeNG (R := R) (cutSummandsCN τ) T := rfl
-
-theorem comulAlgHomN_eq_G :
-    comulAlgHomN (R := R) (α := α) = comulAlgHomNG (R := R) cutSummandsN := rfl
-
-theorem comulCAlgHomN_eq_G {β : Type*} (τ : Nonplanar (α ⊕ β) → β) :
-    comulCAlgHomN (R := R) τ = comulAlgHomNG (R := R) (cutSummandsCN τ) := rfl
 
 /-! ### The policy-indexed carrier `WithCuts`
 


### PR DESCRIPTION
Step 4 endgame of the Coproduct/ cleanup, completing what #2039 deferred.

- `WithCuts.lean` slims to a true base file (`ConnesKreimer` + `RoseTree.Nonplanar` imports); the four instance bridges re-home beside their consumers.
- The `comulC*` family is now *definitionally* the generic coproduct at `cuts := cutSummandsCN τ` — derive-don't-duplicate, which also makes the instance transport one delta step instead of the whnf-heavy defeq that forced #2039's deferral.
- `bialgebraC` (zero consumers) is deleted for `instIsAdmissibleCutsCN`, gated on `Fact (TraceCoherent τ)`; a `noncomputable example` checks end-to-end resolution of `Bialgebra R (WithCuts R (cutSummandsCN τ))`. Counit laws re-sectioned to `CommSemiring` (they never needed a ring) to feed the ring-uniform mixin.