### PR TITLE
style(Core/Algebra/RootedTree): docstring register sweep; golf Δ^d lift

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
@@ -104,9 +104,9 @@ noncomputable def eraseTracesAlgHom :
 The embedding `α → α ⊕ β` lifts componentwise to trees and forests via
 `RoseTree.map` / `Nonplanar.map` / `Multiset.map`. -/
 
-/-- The **Sum.inl embedding algebra hom**
-    `ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar (α ⊕ β))`
-    induced by `Nonplanar.map Sum.inl` via `ConnesKreimer.mapDomainAlgHom`. -/
+/-- The **`Sum.inl` embedding algebra hom**: relabel every basis forest
+    componentwise along `Sum.inl`, embedding trace-free trees into the
+    marked alphabet. -/
 noncomputable def embedInlAlgHom :
     ConnesKreimer R (Nonplanar α) →ₐ[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
   ConnesKreimer.mapDomainAlgHom (Multiset.mapAddMonoidHom (Nonplanar.map Sum.inl))
@@ -120,9 +120,8 @@ noncomputable def embedInlAlgHom :
 
 /-! ### Erasure inverts embed -/
 
-/-- `eraseTracesAlgHom ∘ embedInlAlgHom = id`. Erasure inverts the
-    Sum.inl embedding at the AlgHom level: trace-free trees survive a
-    round-trip through embedding + erasure. -/
+/-- Erasure inverts the `Sum.inl` embedding: trace-free trees survive
+    the round trip. -/
 theorem eraseTracesAlgHom_comp_embedInlAlgHom :
     (eraseTracesAlgHom (R := R) (α := α) (β := β)).comp embedInlAlgHom =
       AlgHom.id R (ConnesKreimer R (Nonplanar α)) := by
@@ -217,8 +216,8 @@ private theorem cutTensor_some (p : Multiset (RoseTree α) × RoseTree α) :
 
 /-! ### Lift from tree-level to Nonplanar -/
 
-/-- **Per-tree**: `(Π ⊗ Π) (comulCTreeN τ (map inl T)) = comulTreeN T`.
-    Descent of `cutSummandsCP_map_inl_filterMap` through `Quotient.inductionOn`. -/
+/-- Per-tree form of the Δ^ρ comparison, descended from the cut-summand
+    identity `cutSummandsCP_map_inl_filterMap` through the quotient. -/
 private theorem eraseTraces_comulCTreeN_map_inl
     (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar α) :
     (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R) (α := α) (β := β))
@@ -280,9 +279,8 @@ private theorem eraseTraces_comulCTreeN_map_inl
     exact (cutTensor_some p).symm]
   rw [← Multiset.map_map, ← Multiset.map_map, cutSummandsCP_map_inl_filterMap]
 
-/-- **Per-forest**: `(Π ⊗ Π) (comulCForestN τ (F.map (map inl))) = comulForestN F`.
-    Lift per-tree via `Multiset.induction` + multiplicativity of forest coproducts
-    and the AlgHom `(S ⊗ S)`. -/
+/-- Forest-level form of the Δ^ρ comparison: the per-tree form lifted
+    multiplicatively. -/
 private theorem eraseTraces_comulCForestN_map_inl
     (τ : Nonplanar (α ⊕ β) → β) (F : Forest (Nonplanar α)) :
     (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R) (α := α) (β := β))
@@ -301,17 +299,11 @@ private theorem eraseTraces_comulCForestN_map_inl
       comulForestNG_cons _ _ _
     rw [hcons, map_mul, eraseTraces_comulCTreeN_map_inl, ih]
 
-/-- **MCB equivalence** (n-ary specialization): the Δ^d-via-Δ^c
-    construction agrees with Δ^ρ on trace-free trees.
-
-    `comulDN ∘ embed_{Sum.inl} = comulAlgHomN`
-
-    Closed via: (a) `ConnesKreimer.algHom_ext` reduces to per-basis `of' F`;
-    (b) Multiset multiplicativity of `comulCForestN`, `comulForestN`, and
-    `(eraseTracesAlgHom ⊗ eraseTracesAlgHom)` reduces to per-tree; (c)
-    `Quotient.inductionOn` reduces per-tree to tree-level; (d) tree-level
-    mutual structural induction on tree / children-list closes the
-    cut-summand bijection via `cutSummandsCP_map_inl_filterMap`. -/
+/-- On embedded trace-free trees the deletion coproduct agrees with the
+    pruning coproduct Δ^ρ: the n-ary form of the
+    [marcolli-chomsky-berwick-2025] comparison
+    `Δ^d = (id ⊗ Π_{d,p}) ∘ Δ^ρ`, exact here because the rebinarize step
+    `Π_{d,p}` is the identity. -/
 theorem comulDN_embedInl_eq_comulAlgHomN (τ : Nonplanar (α ⊕ β) → β) :
     (comulDN (R := R) τ).comp (embedInlAlgHom (R := R) (β := β)) =
       comulAlgHomN := by

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
@@ -60,14 +60,11 @@ recovering MCB's one-channel form `(id ⊗ Π_{d,c}) ∘ Δ^c`.
 `[UPSTREAM]` candidate.
 -/
 
-
 namespace ConnesKreimer
 
 open scoped TensorProduct
 
 variable {R : Type*} [CommSemiring R] {α β : Type*}
-
-
 
 /-! ## The trace-erasure algebra hom Π_{d,c} -/
 
@@ -116,7 +113,6 @@ noncomputable def embedInlAlgHom :
       of' (R := R) (F.map (Nonplanar.map Sum.inl)) := by
   rw [embedInlAlgHom, ConnesKreimer.mapDomainAlgHom_of']
   rfl
-
 
 /-! ### Erasure inverts embed -/
 
@@ -169,7 +165,6 @@ private theorem eraseTracesAlgHom_ofTree_map_inl
   rw [eraseTracesAlgHom_ofTree, Nonplanar.filterMap_getLeft?_map_inl]
   rfl
 
-
 /-! ### The cut-summand tensor builder
 
 `Option`-tolerant on both channels: a filtered-out crown entry (`none`)
@@ -213,8 +208,33 @@ private theorem cutTensor_some (p : Multiset (RoseTree α) × RoseTree α) :
           = (some ∘ (Nonplanar.mk : RoseTree α → Nonplanar α)) from rfl,
         Multiset.filterMap_eq_map]
 
-
 /-! ### Lift from tree-level to Nonplanar -/
+
+/-- The `(Π ⊗ Π)`-image of a projected Δ^c summand tensor, as a composed
+    map: `cutTensor` after the summand filter. -/
+private theorem cutTensor_filterMap_comp :
+    (((Algebra.TensorProduct.map (eraseTracesAlgHom (R := R) (α := α) (β := β))
+        eraseTracesAlgHom) ∘
+      (fun p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β) =>
+        of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)) ∘ projSummand) =
+    (cutTensor (R := R)) ∘
+      (Prod.map (Multiset.map (RoseTree.filterMap Sum.getLeft?))
+        (RoseTree.filterMap Sum.getLeft?)) := by
+  funext p
+  show (Algebra.TensorProduct.map eraseTracesAlgHom eraseTracesAlgHom)
+      (of' (p.1.map Nonplanar.mk) ⊗ₜ[R] ofTree (Nonplanar.mk p.2)) = _
+  rw [Algebra.TensorProduct.map_tmul]
+  exact cutTensor_filterMap p
+
+/-- The plain Δ^ρ summand tensor, as a composed map: `cutTensor` after
+    the `some` embedding. -/
+private theorem cutTensor_some_comp :
+    ((fun p : Forest (Nonplanar α) × Nonplanar α =>
+        (of' (R := R) p.1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R] ofTree p.2) ∘
+      projSummand) =
+    (cutTensor (R := R)) ∘ (Prod.map (Multiset.map some) some) := by
+  funext p
+  exact (cutTensor_some p).symm
 
 /-- Per-tree form of the Δ^ρ comparison, descended from the cut-summand
     identity `cutSummandsCP_map_inl_filterMap` through the quotient. -/
@@ -223,61 +243,22 @@ private theorem eraseTraces_comulCTreeN_map_inl
     (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R) (α := α) (β := β))
         eraseTracesAlgHom) (comulCTreeN τ (Nonplanar.map Sum.inl T)) =
       comulTreeN T := by
-  refine Quotient.inductionOn T ?_
-  intro t
-  -- Unfold both sides via comulCTreeN definition.
+  refine Quotient.inductionOn T fun t => ?_
   show (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom)
         (comulCTreeN τ (Nonplanar.mk (RoseTree.map Sum.inl t))) =
-       comulTreeN (Nonplanar.mk t)
-  unfold comulCTreeN comulTreeNG
+      comulTreeN (Nonplanar.mk t)
+  unfold comulCTreeN comulTreeNG comulTreeN
   rw [map_add]
-  -- First summand: (S ⊗ S) (ofTree (mk (embed t)) ⊗ 1) = ofTree (mk t) ⊗ 1.
-  rw [show (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom)
-            (ofTree (Nonplanar.mk (RoseTree.map Sum.inl t)) ⊗ₜ[R]
-              (1 : ConnesKreimer R (Nonplanar (α ⊕ β)))) =
-          ofTree (Nonplanar.mk t) ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α)) from by
-    rw [Algebra.TensorProduct.map_tmul, map_one]
-    congr 1
-    -- mk (RoseTree.map Sum.inl t) = embedInl (mk t)
-    exact eraseTracesAlgHom_ofTree_map_inl (Nonplanar.mk t)]
   congr 1
-  -- Second summand: (S ⊗ S) (sum over cuts) = sum over Δ^ρ cuts.
-  rw [map_multiset_sum
-        (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom)]
-  simp only [Multiset.map_map]
-  -- Reduce sum-of-(S⊗S)-applied to sum of per-summand tensors.
-  rw [show ((Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom) ∘
-            (fun p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β) =>
-              of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)) =
-          (fun p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β) =>
-            eraseTracesAlgHom (of' (R := R) p.1) ⊗ₜ[R]
-              eraseTracesAlgHom (ofTree p.2)) from by
-    funext p
-    rw [Function.comp_apply, Algebra.TensorProduct.map_tmul]]
-  -- Cuts descend to tree-level: cutSummandsCN τ (mk t') = (cutSummandsCP (τ ∘ mk) t').map projSummand.
-  rw [show cutSummandsCN τ (Nonplanar.mk (RoseTree.map Sum.inl t)) =
-        (cutSummandsCP (τ ∘ Nonplanar.mk) (RoseTree.map Sum.inl t)).map projSummand from
-      cutSummandsCN_mk _ _]
-  rw [show cutSummandsN (Nonplanar.mk t) =
-        (cutSummandsP t).map projSummand from
-      cutSummandsN_mk _]
-  rw [Multiset.map_map, Multiset.map_map]
-  -- Both integrands factor through the Option-tolerant tensor builder.
-  rw [show ((fun p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β) =>
-              eraseTracesAlgHom (of' (R := R) p.1) ⊗ₜ[R]
-                eraseTracesAlgHom (ofTree p.2)) ∘ projSummand) =
-          (cutTensor (R := R)) ∘
-            (Prod.map (Multiset.map (RoseTree.filterMap Sum.getLeft?))
-              (RoseTree.filterMap Sum.getLeft?)) from by
-    funext p
-    exact cutTensor_filterMap p]
-  rw [show ((fun p : Forest (Nonplanar α) × Nonplanar α =>
-              (of' (R := R) p.1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R]
-                ofTree p.2) ∘ projSummand) =
-          (cutTensor (R := R)) ∘ (Prod.map (Multiset.map some) some) from by
-    funext p
-    exact (cutTensor_some p).symm]
-  rw [← Multiset.map_map, ← Multiset.map_map, cutSummandsCP_map_inl_filterMap]
+  · rw [Algebra.TensorProduct.map_tmul, map_one]
+    congr 1
+    exact eraseTracesAlgHom_ofTree_map_inl (Nonplanar.mk t)
+  · rw [map_multiset_sum
+          (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom),
+        cutSummandsCN_mk, cutSummandsN_mk,
+        Multiset.map_map, Multiset.map_map, Multiset.map_map,
+        cutTensor_filterMap_comp, cutTensor_some_comp,
+        ← Multiset.map_map, ← Multiset.map_map, cutSummandsCP_map_inl_filterMap]
 
 /-- Forest-level form of the Δ^ρ comparison: the per-tree form lifted
     multiplicatively. -/

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pairing.lean
@@ -195,15 +195,9 @@ private theorem pairing₃_of'_tmul_of'_tmul [DecidableEq α] (F G : Forest (Non
     rw [TensorProduct.tmul_add, map_add, LinearMap.add_apply, ih₁, ih₂,
         map_add, LinearMap.add_apply, mul_add]
 
-/-- **Nondegeneracy of `pairing₂`** (lifted from binary): if
-    `U ∈ CK ⊗ CK` pairs to zero against every pure tensor `x ⊗ y`,
-    then `U = 0`.
-
-    Proof: decompose `U` via the natural basis of `CK = (Forest T) →₀ R`
-    as `U = c.sum (fun F U_F => of' F ⊗ U_F)`. Pairing against
-    `of' F ⊗ y` extracts `autF · pairing y (c F)`. Over `CharZero`
-    (so `autF ≠ 0`), each `c F = 0` by `pairing_nondegenerate` +
-    `pairing_symm`, hence `c = 0` and `U = 0`. -/
+/-- Nondegeneracy of `pairing₂`, lifted from the binary
+    `pairing_nondegenerate` along the natural basis of
+    `CK = (Forest T) →₀ R`. -/
 private theorem pairing₂_nondegenerate [DecidableEq α]
     [CharZero R] [NoZeroDivisors R]
     (U : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α))
@@ -239,15 +233,8 @@ private theorem pairing₂_nondegenerate [DecidableEq α]
   have hc_zero' : c = 0 := Finsupp.ext hc_zero
   rw [← hc, hc_zero', Finsupp.sum_zero_index]
 
-/-- **Nondegeneracy of `pairing₃`**: if `U ∈ CK ⊗ (CK ⊗ CK)` pairs to
-    zero against every test triple tensor, then `U = 0`.
-
-    Proof: decompose `U` via the basis on the outer factor as
-    `U = c.sum (fun F U_F => of' F ⊗ U_F)` where `U_F ∈ CK ⊗ CK`.
-    Pairing against `of' F ⊗ (x ⊗ y)` extracts `autF · pairing₂ (x ⊗ y)
-    (c F)` via `pairing₃_of'_tmul_of'_tmul`. Over `CharZero` (so
-    `autF ≠ 0`), each `pairing₂ (x ⊗ y) (c F) = 0` for all `x, y`; by
-    `pairing₂_nondegenerate`, `c F = 0`. Hence `c = 0` and `U = 0`. -/
+/-- Nondegeneracy of `pairing₃`, lifted from `pairing₂_nondegenerate`
+    along the basis of the outer tensor factor. -/
 theorem pairing₃_nondegenerate [DecidableEq α]
     [CharZero R] [NoZeroDivisors R]
     (U : ConnesKreimer R (Nonplanar α) ⊗[R]

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -281,7 +281,7 @@ private lemma pairing_product_smul_right (r : R)
 
 /-! ### The duality theorem -/
 
-/-- **GL/CK duality for Δ^ρ** ([foissy-2002]): the GL `⋆` product and
+/-- The GL/CK duality for Δ^ρ ([foissy-2002]): the GL `⋆` product and
     the pruning coproduct Δ^ρ are adjoint under the symmetry-weighted
     pairing, with crossed tensor slots (see module docstring):
 
@@ -579,7 +579,7 @@ private lemma pairing₃_lTensor_comul_rho
   | add W₁ W₂ ih₁ ih₂ =>
     rw [map_add, map_add, ih₁, ih₂, map_add]
 
-/-- **LHS chain via the duality (twice)**: pairing the LHS coassoc
+/-- LHS chain: pairing the LHS coassoc
     expression against a pure triple tensor reduces to pairing the
     GL product `z' ⋆ (y ⋆ x)` against `z`. -/
 theorem pairing₃_coassocLHSLinRho
@@ -595,7 +595,7 @@ theorem pairing₃_coassocLHSLinRho
   exact (pairing_gl_eq_pairing_coproduct_Rho z'
           (product y x) z).symm
 
-/-- **RHS chain via the duality (twice)**: pairing the RHS coassoc
+/-- RHS chain: pairing the RHS coassoc
     expression against a pure triple tensor reduces to pairing the
     GL product `(z' ⋆ y) ⋆ x` against `z`. -/
 theorem pairing₃_coassocRHSLinRho
@@ -619,18 +619,9 @@ requires `R` to be a Ring (so `CK R T` has `AddCommGroup`). -/
 section CoassocCommRingRho
 variable {R' : Type*} [CommRing R'] {α' : Type*} [DecidableEq α']
 
-/-- **Coassociativity of `comulAlgHomN`** (LinearMap form), via GL/CK
-    duality. Parallel to `TraceNonplanar.comulCN_coassoc` for Δ^c.
-
-    Derived via the chain:
-    1. `ext z`: reduce to pointwise `LHS z = RHS z`.
-    2. `pairing₃_unique`: reduce to `∀ t, pairing₃ t (LHS z) = pairing₃ t (RHS z)`.
-    3. `TensorProduct.induction_on` thrice: reduce `t` to pure triple
-       tensors `x ⊗ (y ⊗ z')`.
-    4. `pairing₃_coassocLHSLinRho` / `pairing₃_coassocRHSLinRho`: reduce
-       both sides to GL products against `z` (two duality applications
-       each).
-    5. `mul_assoc z' y x` closes. -/
+/-- Coassociativity of Δ^ρ (LinearMap form): transported from
+    `GrossmanLarson.mul_assoc` through the duality and the nondegeneracy
+    of `pairing₃`. -/
 theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
     (TensorProduct.assoc R'
         (ConnesKreimer R' (Nonplanar α'))
@@ -661,9 +652,7 @@ theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
   | add a b iha ihb =>
     simp only [map_add, LinearMap.add_apply, iha, ihb]
 
-/-- **AlgHom-form coassociativity** of `comulAlgHomN`. Follows from
-    `comulRhoN_coassoc` (LinearMap form) by AlgHom extensionality, the
-    same one-liner pattern as `TraceNonplanar.comulCAlgHomN_coassoc_algHom`. -/
+/-- The AlgHom form of Δ^ρ coassociativity. -/
 theorem comulAlgHomN_coassoc_algHom [CharZero R'] [NoZeroDivisors R'] :
     (Algebra.TensorProduct.assoc R' R' R'
         (ConnesKreimer R' (Nonplanar α'))

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceGrading.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceGrading.lean
@@ -88,7 +88,7 @@ private theorem sum_map_numNodes_sub_one_add_card {γ : Type*}
         Multiset.sum_cons, Multiset.card_cons]
     omega
 
-/-- **Edge conservation for Δ^c cut summands**: the trace marker replaces
+/-- Edge conservation for Δ^c cut summands: the trace marker replaces
     the cut subtree by a unit-weight leaf, so crown edges plus trunk
     weight recover the tree weight exactly. Descends
     `cutSummandsG_numNodes` (`Core/Combinatorics/RootedTree/Cut.lean`)
@@ -222,7 +222,7 @@ private theorem comulCForestN_mem (τ : Nonplanar (α'' ⊕ β'') → β'')
         rfl]
     exact gradedTensorSpan_mul (comulCTreeN_mem τ T) ih
 
-/-- **Δ^c preserves the edge-count grading** ([marcolli-chomsky-berwick-2025]
+/-- Δ^c preserves the edge-count grading ([marcolli-chomsky-berwick-2025]
     Lemma 1.2.10, p. 37): the coproduct of a basis forest lies in the span of
     homogeneous tensors `xi ⊗ yi` with degrees summing to the forest's edge
     count. With edge-count additivity over the product (disjoint union) and

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -329,8 +329,8 @@ private theorem rhs_per_pair (τ : Nonplanar (α ⊕ β) → β)
   intro p _
   rfl
 
-/-- **LHS expansion**: `assoc ∘ (Δ^c ⊗ id) ∘ Δ^c` on a tree enumerates
-    `dcLHS`. -/
+/-- The composite `assoc ∘ (Δ^c ⊗ id) ∘ Δ^c` on a tree sums the `dcLHS`
+    enumeration. -/
 private theorem lhsExpand (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) :
     (TensorProduct.assoc R (ConnesKreimer R (Nonplanar (α ⊕ β)))
         (ConnesKreimer R (Nonplanar (α ⊕ β))) (ConnesKreimer R (Nonplanar (α ⊕ β))))
@@ -360,7 +360,7 @@ private theorem lhsExpand (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α
       lhs_per_pair]
   rfl
 
-/-- **RHS expansion**: `(id ⊗ Δ^c) ∘ Δ^c` on a tree enumerates `dcRHS`. -/
+/-- The composite `(id ⊗ Δ^c) ∘ Δ^c` on a tree sums the `dcRHS` enumeration. -/
 private theorem rhsExpand (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) :
     (comulCAlgHomN (R := R) τ).toLinearMap.lTensor _ (comulCTreeN τ T) =
       ((dcRHS τ T).map (tripleTensor (R := R))).sum := by
@@ -456,10 +456,10 @@ private theorem traceCoherentP_of_coherent (τ : Nonplanar (α ⊕ β) → β)
     rw [cutSummandsCN_mk]; exact Multiset.mem_map.mpr ⟨p, hp, rfl⟩
   exact hτ (Nonplanar.mk t) (ConnesKreimer.projSummand p) hmem
 
-/-- **The double-cut bijection** (MCB Lemma 1.2.10's combinatorial core):
-    the LHS and RHS double-cut enumerators of a tree agree as Nonplanar
-    multisets, under trace coherence. Proved by descending through
-    `Nonplanar.mk` to the tree-level `DoubleCut.coassT`. -/
+/-- The LHS and RHS double-cut enumerators of a tree agree as Nonplanar
+    multisets under trace coherence — [marcolli-chomsky-berwick-2025]
+    Lemma 1.2.10's combinatorial core, descended from the planar
+    `DoubleCut.coassT`. -/
 private theorem doubleCut_eq (τ : Nonplanar (α ⊕ β) → β)
     (hτ : TraceCoherent τ) (T : Nonplanar (α ⊕ β)) :
     dcLHS τ T = dcRHS τ T := by
@@ -480,15 +480,9 @@ uniformity with the `Bialgebra` consumers; the double-cut proof itself is
 section CoassocCommRing
 variable {R' : Type*} [CommRing R'] {α' β' : Type*}
 
-/-- **Per-tree Δ^c coassociativity** (LinearMap-applied form on a single
-    tree's coproduct `comulCTreeN τ T`). The combinatorial heart of
-    coassociativity: both sides enumerate ordered pairs of nested
-    admissible cuts of `T`, and `TraceCoherent τ` makes the trunk-marker
-    labels written by the two cut orders agree.
-
-    Reduced by the two expansion lemmas (`lhsExpand`, `rhsExpand`) to the
-    double-cut bijection `doubleCut_eq`. The headline `comulCN_coassoc`
-    reduces to this by multiplicativity (forest = product of trees). -/
+/-- Per-tree Δ^c coassociativity: both composites enumerate ordered pairs
+    of nested admissible cuts of `T`, and `TraceCoherent τ` makes the
+    trunk-marker labels written by the two cut orders agree. -/
 theorem comulCN_coassoc_tree
     (τ : Nonplanar (α' ⊕ β') → β') (hτ : TraceCoherent τ)
     (T : Nonplanar (α' ⊕ β')) :
@@ -500,8 +494,7 @@ theorem comulCN_coassoc_tree
       (comulCAlgHomN (R := R') τ).toLinearMap.lTensor _ (comulCTreeN τ T) := by
   rw [lhsExpand, rhsExpand, doubleCut_eq τ hτ T]
 
-/-- **Coassociativity of `comulCAlgHomN` (Δ^c on Nonplanar)**, under
-    trace coherence.
+/-- Coassociativity of Δ^c under trace coherence.
 
     NOT τ-generic: without `TraceCoherent τ`, iterating Δ^c writes
     second-stage markers computed on marked trunks, and the two cut
@@ -596,8 +589,7 @@ the enumeration (`cutSummandsCN_filter_empty`,
 section BialgebraInst
 variable {R' : Type*} [CommRing R'] {α' β' : Type*}
 
-/-- **AlgHom-form coassoc** of `comulCAlgHomN` under trace coherence.
-    Follows from `comulCN_coassoc` by AlgHom extensionality. -/
+/-- The AlgHom form of Δ^c coassociativity under trace coherence. -/
 theorem comulCAlgHomN_coassoc_algHom
     (τ : Nonplanar (α' ⊕ β') → β') (hτ : TraceCoherent τ) :
     (Algebra.TensorProduct.assoc R' R' R'
@@ -626,14 +618,9 @@ counit fields directly. -/
 section CounitLaws
 variable {R' : Type*} [CommSemiring R'] {α' β' : Type*}
 
-/-- **Per-tree right counit law**: under `(counit ⊗ id)`, only the `(0, T)`
-    cut summand of `cutSummandsCN τ T` survives, contributing `1 ⊗ ofTree T`.
-
-    Proof: expand `comulCTreeN τ T = ofTree T ⊗ 1 + Σ (of' p₁ ⊗ ofTree p₂)`.
-    Apply `(counit ⊗ id)`: the first summand vanishes via `counit_ofTree`;
-    each cut-summand contribution becomes `(if p₁.card = 0 then 1 else 0) ⊗
-    ofTree p₂`. Extract the filtered sum via `sum_map_ite_zero`, then use
-    `cutSummandsCN_filter_empty` to show the filter yields exactly `{(0, T)}`. -/
+/-- Per-tree right counit law: under `(counit ⊗ id)` only the empty-cut
+    summand of `cutSummandsCN τ T` survives, contributing `1 ⊗ ofTree T` —
+    the empty-cut uniqueness `cutSummandsCN_filter_empty` in tensor form. -/
 private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β')
     (T : Nonplanar (α' ⊕ β')) :
     (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
@@ -692,8 +679,8 @@ private theorem counit_rTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
   rw [ConnesKreimer.cutSummandsCN_filter_empty τ T,
       Multiset.map_singleton, Multiset.sum_singleton]
 
-/-- **Per-tree left counit law**: mirror of the right counit. Same
-    `cutSummandsCN` substrate, with `counit` on the right factor. -/
+/-- Per-tree left counit law: mirror of `counit_rTensor_comulCTreeN` with
+    `counit` on the right factor. -/
 private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β')
     (T : Nonplanar (α' ⊕ β')) :
     (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar (α' ⊕ β'))))
@@ -741,9 +728,8 @@ private theorem counit_lTensor_comulCTreeN (τ : Nonplanar (α' ⊕ β') → β'
     | cons _ _ ih => rw [Multiset.map_cons, Multiset.sum_cons, ih, add_zero]]
   rw [add_zero]
 
-/-- **Forest right counit law**: lift per-tree to forest via `Multiset.induction`
-    + multiplicativity of `comulCForestN` and `(counit ⊗ id)` as AlgHom.
-    Mirrors `PruningNonplanar.comulForestN_counit_rTensor`. -/
+/-- Forest right counit law, lifted from the per-tree law by
+    multiplicativity. -/
 private theorem counit_rTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → β')
     (F : Forest (Nonplanar (α' ⊕ β')))
     (hF : ∀ T ∈ F, (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
@@ -773,7 +759,7 @@ private theorem counit_rTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
     rw [hCons, map_mul, hT, ih',
         Algebra.TensorProduct.tmul_mul_tmul, _root_.mul_one, hForest]
 
-/-- **Forest left counit law**: mirror. -/
+/-- Forest left counit law: mirror of `counit_rTensor_comulCForestN`. -/
 private theorem counit_lTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → β')
     (F : Forest (Nonplanar (α' ⊕ β')))
     (hF : ∀ T ∈ F, (Algebra.TensorProduct.map
@@ -803,7 +789,7 @@ private theorem counit_lTensor_comulCForestN (τ : Nonplanar (α' ⊕ β') → �
     rw [hCons, map_mul, hT, ih',
         Algebra.TensorProduct.tmul_mul_tmul, _root_.one_mul, hForest]
 
-/-- **Right counit law** (CLOSED via per-tree + forest helpers): `(counit ⊗ id) ∘ Δ^c = lid⁻¹`. -/
+/-- The right counit law for Δ^c. -/
 theorem counit_rTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
     (Algebra.TensorProduct.map ((ConnesKreimer.counit (R := R')) :
           ConnesKreimer R' (Nonplanar (α' ⊕ β')) →ₐ[R'] R')
@@ -821,7 +807,7 @@ theorem counit_rTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
   rw [comulCAlgHomN_apply_of', Algebra.TensorProduct.lid_symm_apply]
   exact counit_rTensor_comulCForestN τ F (fun T _ => counit_rTensor_comulCTreeN τ T)
 
-/-- **Left counit law** (CLOSED via per-tree + forest helpers): `(id ⊗ counit) ∘ Δ^c = rid⁻¹`. -/
+/-- The left counit law for Δ^c. -/
 theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
     (Algebra.TensorProduct.map (AlgHom.id R' _)
         ((ConnesKreimer.counit (R := R')) :
@@ -843,7 +829,7 @@ theorem counit_lTensor_comulCAlgHomN (τ : Nonplanar (α' ⊕ β') → β') :
 theorem comulCAlgHomN_eq_G {R : Type*} [CommSemiring R] (τ : Nonplanar (α' ⊕ β') → β') :
     comulCAlgHomN (R := R) τ = comulAlgHomNG (R := R) (cutSummandsCN τ) := rfl
 
-/-- **Δ^c is an admissible cut policy** for a trace-coherent encoder:
+/-- Δ^c is an admissible cut policy for a trace-coherent encoder:
     `comulCAlgHomN_coassoc_algHom` and the counit laws packaged as the
     `IsAdmissibleCuts` mixin, so `WithCuts R (cutSummandsCN τ)` receives its
     `Bialgebra` instance — the bialgebra structure of MCB Lemma 1.2.10.

--- a/Linglib/Core/Combinatorics/RootedTree/CutFilterMap.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/CutFilterMap.lean
@@ -39,8 +39,8 @@ variable {α β : Type*}
 
 mutual
 
-/-- **Per-tree**: filtering the Δ^c cut summands of an embedded tree
-    yields the `some`-embedded Δ^ρ cut summands. -/
+/-- Filtering the Δ^c cut summands of an embedded tree yields the
+    `some`-embedded Δ^ρ cut summands. -/
 theorem cutSummandsCP_map_inl_filterMap (τ : RoseTree (α ⊕ β) → β) :
     ∀ (t : RoseTree α),
       (cutSummandsCP τ (RoseTree.map Sum.inl t)).map
@@ -71,8 +71,8 @@ theorem cutSummandsCP_map_inl_filterMap (τ : RoseTree (α ⊕ β) → β) :
     rw [← Multiset.map_map, ← Multiset.map_map,
         cutListSummandsG_map_inl_filterMap τ cs]
 
-/-- **Children-list**: companion of `cutSummandsCP_map_inl_filterMap` at
-    the list level, with `RoseTree.filterMapList` on the remainder. -/
+/-- Children-list companion of `cutSummandsCP_map_inl_filterMap`, with
+    `RoseTree.filterMapList` on the remainder. -/
 theorem cutListSummandsG_map_inl_filterMap (τ : RoseTree (α ⊕ β) → β) :
     ∀ (cs : List (RoseTree α)),
       (cutListSummandsG (extractC τ) (List.map (RoseTree.map Sum.inl) cs)).map
@@ -130,9 +130,9 @@ theorem cutListSummandsG_map_inl_filterMap (τ : RoseTree (α ⊕ β) → β) :
         augActionG_map_inl_filterMap τ c,
         cutListSummandsG_map_inl_filterMap τ cs']
 
-/-- **Per-child**: companion of `cutSummandsCP_map_inl_filterMap` for
-    the augmented action, with the Δ^ρ `Option` remainder listed via
-    `Option.toList`. The extract-whole branch filters to `({some c}, [])`,
+/-- Per-child companion of `cutSummandsCP_map_inl_filterMap` for the
+    augmented action, with the Δ^ρ `Option` remainder listed via
+    `Option.toList`: the extract-whole branch filters to `({some c}, [])`,
     matching Δ^ρ's delete branch `({c}, none)`. -/
 theorem augActionG_map_inl_filterMap (τ : RoseTree (α ⊕ β) → β) :
     ∀ (c : RoseTree α),


### PR DESCRIPTION
Declaration-docstring register sweep across the remaining Coproduct/ files, plus the Δ^d fixes that missed #2045's squash (cherry-picked).

- Bold-term openers now appear only on definitions; theorems open with plain sentences (TraceNonplanar ×12, PruningDuality ×5, TraceGrading ×2, Pairing ×2).
- "Proof: …" paragraphs and step-numbered derivation chains compressed to one-line technique notes; "(CLOSED via …)" status meta and formula restatements of the stated type deleted. Compact formula summaries survive only where the formal statement is many lines of tensor plumbing (the GL/CK duality display).
- `eraseTraces_comulCTreeN_map_inl` golfed: the two composed-integrand `rw [show … from by funext]` blocks become named private lemmas (`cutTensor_filterMap_comp`, `cutTensor_some_comp`) and the first summand splits off via `congr 1`, leaving the sum branch as one linear rewrite chain.