### PR TITLE
refactor(Syntax/Minimalist/Agree): cleanse Basic, Prop-valued locality

### DIFF
--- a/Linglib/Morphology/DM/VocabSimple.lean
+++ b/Linglib/Morphology/DM/VocabSimple.lean
@@ -1,4 +1,5 @@
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Defs
+import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.DM.VocabularyInsertion

--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Agreement.PersonCaseConstraint
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Features
 import Linglib.Fragments.Italian.Pronouns
 import Linglib.Fragments.Spanish.Pronouns
 import Linglib.Fragments.Spanish.PersonFeatures

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -89,8 +89,9 @@ alongside Tz'utujil, Chickasaw, Sinitic double-unaccusative).
 - `JudgmentType` — [kuroda-1972]'s categorical/thetic distinction, defined in §9
 - `GramFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
 - `ABSPosition` from `Fragments/Mayan/Params.lean`
-- `Probe.Profile`, `closestGoalB`, `behindHorizonB` from
-  `Syntax/Minimalist/Agree.lean`; `SyntacticObject` construction DSL (`SyntacticObject.ofPlanar`,
+- `Probe.Profile` from `Syntax/Minimalist/Probe/Profile.lean`;
+  `isClosestGoalIn`, `behindHorizonIn` from `Syntax/Minimalist/Agree/Basic.lean`;
+  `SyntacticObject` construction DSL (`SyntacticObject.ofPlanar`,
   `SyntacticObject.leafP`, `SyntacticObject.nodeP`, `SyntacticObject.lexLeaf`) from
   `Syntax/Minimalist/SyntacticObject/Build.lean`
 -/
@@ -878,8 +879,8 @@ The boolean functions `dLayerShields`, `hasIntervener`, and
 `canExtractPossessor` above capture the paper's predictions but
 **stipulate** them directly. Here we **derive** them from Attract
 Closest applied to concrete `SyntacticObject` trees
-([aissen-polian-2025] (9a-c)), using `closestGoalB` from
-`Minimalist.Agree`.
+([aissen-polian-2025] (9a-c)), using `isClosestGoalIn` from
+`Syntax/Minimalist/Agree/Basic.lean`.
 
 **Key derivation**: T°'s [EPP:D] probe searches its c-command domain
 for the closest D-bearing element. The result depends only on tree
@@ -910,7 +911,7 @@ private def hasDFeatures (s : SyntacticObject) : Bool :=
 
 Concrete trees are built **planar-first**
 (`SyntacticObject.ofPlanar`/`SyntacticObject.nodeP`/`SyntacticObject.leafP`)
-because Merge (`SyntacticObject.node`) is noncomputable; `closestGoalB`/`behindHorizonB` then
+because Merge (`SyntacticObject.node`) is noncomputable; `isClosestGoalIn`/`behindHorizonIn` then
 reduce under `decide`. Each leaf `SyntacticObject` is `SyntacticObject.lexLeaf` of its token, and
 the trees
 reference the same tokens via `SyntacticObject.leafP` so the two match definitionally. -/
@@ -973,41 +974,41 @@ private def treeTransDP : SyntacticObject :=
 
 /-! ### Core Predictions
 
-Each theorem shows that `closestGoalB` computes the correct
+Each theorem shows that `isClosestGoalIn` computes the correct
 result for T°'s [EPP:D] probe searching for the possessor. -/
 
 /-- **Unaccusative + PossP**: possessor IS the closest D-bearer to T°.
     No D-layer, no agent → T°'s probe reaches possessor directly.
     This is why stranding is available. -/
 theorem unacc_possP_psr_closest :
-    closestGoalB treeUnaccPossP T₀ Psr hasDFeatures = true := by decide
+    isClosestGoalIn treeUnaccPossP T₀ Psr hasDFeatures := by decide
 
 /-- **Unaccusative + DP**: possessor is NOT the closest D-bearer.
     D° is closer to T° than the possessor inside Spec,PossP.
     This is D-layer shielding — stranding is blocked. -/
 theorem unacc_dp_psr_blocked :
-    closestGoalB treeUnaccDP T₀ Psr hasDFeatures = false := by decide
+    ¬ isClosestGoalIn treeUnaccDP T₀ Psr hasDFeatures := by decide
 
 /-- **Unaccusative + DP**: D° IS the closest D-bearer to T°.
     The whole DP is what T°'s probe attracts — basis for pied-piping. -/
 theorem unacc_dp_dHead_closest :
-    closestGoalB treeUnaccDP T₀ D₀ hasDFeatures = true := by decide
+    isClosestGoalIn treeUnaccDP T₀ D₀ hasDFeatures := by decide
 
 /-- **Transitive + PossP**: possessor is NOT the closest D-bearer.
     Agent in Spec,vP is closer — the agent intervenes.
     This is why stranding is blocked in transitives. -/
 theorem trans_possP_psr_blocked :
-    closestGoalB treeTransPossP T₀ Psr hasDFeatures = false := by decide
+    ¬ isClosestGoalIn treeTransPossP T₀ Psr hasDFeatures := by decide
 
 /-- **Transitive + PossP**: agent IS the closest D-bearer to T°.
     T°'s probe attracts the agent, not the possessor. -/
 theorem trans_possP_agt_closest :
-    closestGoalB treeTransPossP T₀ Agt hasDFeatures = true := by decide
+    isClosestGoalIn treeTransPossP T₀ Agt hasDFeatures := by decide
 
 /-- **Transitive + DP**: double blocking — both agent AND D° shield
     the possessor from T°'s probe. -/
 theorem trans_dp_psr_blocked :
-    closestGoalB treeTransDP T₀ Psr hasDFeatures = false := by decide
+    ¬ isClosestGoalIn treeTransDP T₀ Psr hasDFeatures := by decide
 
 /-! ### Bridge Theorems
 
@@ -1017,23 +1018,23 @@ corresponding boolean function, showing they make identical claims. -/
 
 /-- D-layer shielding: tree geometry matches `DLayerShields .dp`. -/
 theorem bridge_dLayer_dp :
-    closestGoalB treeUnaccDP T₀ Psr hasDFeatures = false ∧
+    ¬ isClosestGoalIn treeUnaccDP T₀ Psr hasDFeatures ∧
     DLayerShields .dp := ⟨by decide, trivial⟩
 
 /-- No D-layer for PossP: tree geometry matches `DLayerShields .possP`. -/
 theorem bridge_no_dLayer_possP :
-    closestGoalB treeUnaccPossP T₀ Psr hasDFeatures = true ∧
+    isClosestGoalIn treeUnaccPossP T₀ Psr hasDFeatures ∧
     ¬ DLayerShields .possP := ⟨by decide, id⟩
 
 /-- Agent intervention: tree geometry matches `HasIntervener .t .transitive`. -/
 theorem bridge_intervention_trans :
-    closestGoalB treeTransPossP T₀ Psr hasDFeatures = false ∧
+    ¬ isClosestGoalIn treeTransPossP T₀ Psr hasDFeatures ∧
     HasIntervener .t .transitive false := ⟨by decide, trivial⟩
 
 /-- No intervention in unaccusative: tree geometry matches
     `HasIntervener .t .unaccusative`. -/
 theorem bridge_no_intervention_unacc :
-    closestGoalB treeUnaccPossP T₀ Psr hasDFeatures = true ∧
+    isClosestGoalIn treeUnaccPossP T₀ Psr hasDFeatures ∧
     ¬ HasIntervener .t .unaccusative false := ⟨by decide, id⟩
 
 -- ============================================================================
@@ -1045,7 +1046,7 @@ theorem bridge_no_intervention_unacc :
 Selective opacity ([keine-2019], [aissen-polian-2025] (33))
 states that N° is a horizon for wh-probes: C°'s [EPP:WH] probe
 cannot see elements c-commanded by N° (= inside the nominal's
-lexical projection). Here we derive this from `behindHorizonB`
+lexical projection). Here we derive this from `behindHorizonIn`
 applied to concrete trees.
 
 The key geometric fact: in `[PossP Psr N°]`, N° and Psr are sisters,
@@ -1055,8 +1056,8 @@ N°) remains visible — which is why pied-piping works.
 
 Together with § 15 (Attract Closest), both pillars of A&P's analysis
 are now derived from tree geometry:
-- **D-layer shielding / intervention** → `closestGoalB` (§ 15)
-- **Selective opacity** → `behindHorizonB` (§ 16)
+- **D-layer shielding / intervention** → `isClosestGoalIn` (§ 15)
+- **Selective opacity** → `behindHorizonIn` (§ 16)
 -/
 
 private def tC₀ : LIToken := ⟨.simple .C [], 8⟩
@@ -1084,20 +1085,20 @@ private def treeCPUnaccPossP : SyntacticObject :=
     subextract the possessor from inside the DP. N° (Psm) c-commands
     Psr (they are sisters in PossP), so Psr is in N°'s opaque domain. -/
 theorem psr_behind_horizon_dp :
-    behindHorizonB treeCPUnaccDP C₀ Psr .N = true := by decide
+    behindHorizonIn treeCPUnaccDP C₀ Psr .N := by decide
 
 /-- Psr is behind the N-horizon in the PossP tree: selective opacity
     applies regardless of nominal size. Even without a D layer, N°
     c-commands Psr. -/
 theorem psr_behind_horizon_possP :
-    behindHorizonB treeCPUnaccPossP C₀ Psr .N = true := by decide
+    behindHorizonIn treeCPUnaccPossP C₀ Psr .N := by decide
 
 /-- D° is NOT behind the N-horizon: N° (Psm) does not c-command D°.
     D° is a sister of PossP, not inside N°'s c-command domain. This
     is why pied-piping (whole DP movement to Spec,CP) is available:
     the wh-probe can see D° even though it cannot see inside PossP. -/
 theorem dHead_not_behind_horizon :
-    behindHorizonB treeCPUnaccDP C₀ D₀ .N = false := by decide
+    ¬ behindHorizonIn treeCPUnaccDP C₀ D₀ .N := by decide
 
 /-- The N-horizon is geometrically present even for D-probes — N°
     c-commands Psr regardless of probe type. The difference is that
@@ -1105,7 +1106,7 @@ theorem dHead_not_behind_horizon :
     This is the "selective" in selective opacity: the same tree
     geometry produces different results for different probe types. -/
 theorem horizon_present_but_dprobe_ignores :
-    behindHorizonB treeUnaccPossP T₀ Psr .N = true ∧
+    behindHorizonIn treeUnaccPossP T₀ Psr .N ∧
     ¬ SelectivelyOpaque .dProbe := ⟨by decide, id⟩
 
 /-! ### Bridge Theorems -/
@@ -1114,8 +1115,8 @@ theorem horizon_present_but_dprobe_ignores :
     wh-subextraction of Psr from both DP and PossP nominals,
     agreeing with `CanĀSubextract` (which is size-independent). -/
 theorem bridge_selective_opacity :
-    behindHorizonB treeCPUnaccDP C₀ Psr .N = true ∧
-    behindHorizonB treeCPUnaccPossP C₀ Psr .N = true ∧
+    behindHorizonIn treeCPUnaccDP C₀ Psr .N ∧
+    behindHorizonIn treeCPUnaccPossP C₀ Psr .N ∧
     ¬ CanĀSubextract :=
   ⟨by decide, by decide, subextraction_impossible⟩
 
@@ -1123,7 +1124,7 @@ theorem bridge_selective_opacity :
     D° is outside N°'s c-command domain. Agrees with
     `ExtractionAvailable .piedPiping .dp`. -/
 theorem bridge_piedpiping_ok :
-    behindHorizonB treeCPUnaccDP C₀ D₀ .N = false ∧
+    ¬ behindHorizonIn treeCPUnaccDP C₀ D₀ .N ∧
     ExtractionAvailable .piedPiping .dp := ⟨by decide, trivial⟩
 
 /-! ### Unified Derivation -/
@@ -1132,16 +1133,16 @@ theorem bridge_piedpiping_ok :
     intervention, selective opacity, and pied-piping availability
     all follow from Attract Closest + N-horizons on concrete trees.
 
-    (a) D-layer shielding: D° closer to T° than Psr (`closestGoalB`)
-    (b) Agent intervention: Agt closer to T° than Psr (`closestGoalB`)
-    (c) Selective opacity: N° c-commands Psr (`behindHorizonB`)
-    (d) Pied-piping: D° NOT c-commanded by N° (`behindHorizonB`) -/
+    (a) D-layer shielding: D° closer to T° than Psr (`isClosestGoalIn`)
+    (b) Agent intervention: Agt closer to T° than Psr (`isClosestGoalIn`)
+    (c) Selective opacity: N° c-commands Psr (`behindHorizonIn`)
+    (d) Pied-piping: D° NOT c-commanded by N° (`behindHorizonIn`) -/
 theorem unified_tree_derivation :
-    closestGoalB treeUnaccDP T₀ Psr hasDFeatures = false ∧
-    closestGoalB treeTransPossP T₀ Psr hasDFeatures = false ∧
-    behindHorizonB treeCPUnaccDP C₀ Psr .N = true ∧
-    behindHorizonB treeCPUnaccPossP C₀ Psr .N = true ∧
-    behindHorizonB treeCPUnaccDP C₀ D₀ .N = false :=
+    ¬ isClosestGoalIn treeUnaccDP T₀ Psr hasDFeatures ∧
+    ¬ isClosestGoalIn treeTransPossP T₀ Psr hasDFeatures ∧
+    behindHorizonIn treeCPUnaccDP C₀ Psr .N ∧
+    behindHorizonIn treeCPUnaccPossP C₀ Psr .N ∧
+    ¬ behindHorizonIn treeCPUnaccDP C₀ D₀ .N :=
   ⟨by decide, by decide, by decide, by decide, by decide⟩
 
 end AttractClosest

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -24,7 +24,8 @@ where honorification surfaces (`HonDomain`).
 
 ## Connections
 
-- **Agree.lean**: AA validity reduces to `validAgree`
+- **Agree/Basic.lean**: allocutive [uHON] valuation is `applyAgree`
+  (`hon_agree_values`) — AA is ordinary phi-style agreement
 - **Phase.lean**: `isPhaseHeadOf .SA` — SAP as the highest phase
 - **Studies/Dayal2025.lean**: `particle_layer_predicts_embedding`
   — SAP unembeddability parallels allocutive root-only restriction
@@ -244,12 +245,6 @@ def HonP.level (hp : HonP) : HonLevel :=
 -- ============================================================================
 -- Section D: Bridge Theorems
 -- ============================================================================
-
-/-- AA validity reduces to `validAgree`: allocutive agreement is not special
-    machinery — it IS phi-agreement between a functional head and a null
-    addressee DP. -/
-theorem aa_is_agree (rel : AgreeRelation) (root : SyntacticObject)
-    (hValid : validAgree rel root) : validAgree rel root := hValid
 
 /-- SA-based allocutive agreement is root-only.
     Follows directly from SAP being the highest phase. -/

--- a/Linglib/Studies/ArregiPietraszko2021.lean
+++ b/Linglib/Studies/ArregiPietraszko2021.lean
@@ -119,15 +119,20 @@ abbrev MValue := FeatureBundle
 /-- The Generalized Head Movement relation.
 
     GenHM relates two terminal nodes X (probe) and Y (goal) in a local
-    syntactic configuration, sharing an M-value between them. This is an
-    instance of Agree specialized for head displacement. -/
+    syntactic configuration. This is an instance of Agree specialized for
+    head displacement: the record captures the pre-Agree configuration
+    (probe's M-slot unvalued, goal's valued); the *shared* M-value A&P's
+    structure-sharing establishes is the transmission outcome
+    `applyAgree probeM goalM feature`. -/
 structure GenHMRelation where
   /-- The higher terminal (e.g., T or C) — the probe -/
   probe : SyntacticObject
   /-- The lower terminal (e.g., V or Aux) — the goal -/
   goal : SyntacticObject
-  /-- The shared morphological features -/
-  mValue : MValue
+  /-- The probe's M-features before sharing -/
+  probeM : MValue
+  /-- The goal's M-features before sharing -/
+  goalM : MValue
   /-- The feature type being shared (tense, phi, etc.) -/
   feature : FeatureVal
   /-- The containing tree -/
@@ -135,9 +140,9 @@ structure GenHMRelation where
   /-- Structural condition: probe c-commands goal -/
   probe_commands_goal : SyntacticObject.cCommandsIn root probe goal
   /-- The goal bears valued M-features -/
-  goal_has_mvalue : hasValuedFeature mValue feature = true
+  goal_has_mvalue : hasValuedFeature goalM feature = true
   /-- The probe bears unvalued M-features -/
-  probe_needs_mvalue : hasUnvaluedFeature mValue feature = true
+  probe_needs_mvalue : hasUnvaluedFeature probeM feature = true
 
 /-- GenHM is an instance of Agree: it relates a probe with unvalued features
     to a goal with valued features under c-command. -/
@@ -145,16 +150,28 @@ def genHM_to_agree (g : GenHMRelation) : AgreeRelation :=
   { probe := g.probe
     goal := g.goal
     feature := g.feature
-    probeFeatures := g.mValue
-    goalFeatures := g.mValue }
+    probeFeatures := g.probeM
+    goalFeatures := g.goalM }
 
 /-- A valid GenHM relation satisfies the conditions for valid Agree. -/
 theorem genHM_is_agree (g : GenHMRelation) :
-    validAgree (genHM_to_agree g) g.root := by
-  refine ⟨?_, ?_, ?_⟩
-  · exact g.probe_commands_goal
-  · exact g.probe_needs_mvalue
-  · exact g.goal_has_mvalue
+    validAgree (genHM_to_agree g) g.root :=
+  ⟨g.probe_commands_goal, g.probe_needs_mvalue, g.goal_has_mvalue⟩
+
+/-- The GenHM configuration is realizable: in `[TP T° V°]`, T° with
+    unvalued tense probes V° with valued tense. -/
+example : GenHMRelation where
+  probe := SyntacticObject.lexLeaf ⟨.simple .T [], 1⟩
+  goal := SyntacticObject.lexLeaf ⟨.simple .V [], 2⟩
+  probeM := .ofGramFeatures [.unvalued (.tense true)]
+  goalM := .ofGramFeatures [.valued (.tense true)]
+  feature := .tense true
+  root := SyntacticObject.ofPlanar
+    (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .T [], 1⟩)
+      (SyntacticObject.leafP ⟨.simple .V [], 2⟩))
+  probe_commands_goal := by decide
+  goal_has_mvalue := by decide
+  probe_needs_mvalue := by decide
 
 -- ============================================================================
 -- § GenHM.3  Chain-Splitting and Chain Structure

--- a/Linglib/Studies/Cacchioli2025.lean
+++ b/Linglib/Studies/Cacchioli2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Data.UD.Basic
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Fragments.Tigrinya.ClausePrefixes
 import Linglib.Studies.Bondarenko2022

--- a/Linglib/Studies/Holmberg2016.lean
+++ b/Linglib/Studies/Holmberg2016.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.AnsweringSystem
 import Linglib.Semantics.Questions.Hamblin
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Semantics.Mood.Defs
 import Linglib.Features.Polarity

--- a/Linglib/Studies/Keine2019.lean
+++ b/Linglib/Studies/Keine2019.lean
@@ -1,4 +1,3 @@
-import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Syntax.Minimalist.Probe.Profile
 

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -1,15 +1,11 @@
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Phase.Basic
-import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Syntax.Minimalist.Probe.Transmission
 
 /-!
 # Agree (Minimalist Feature Checking)
 
-
 Formalization of Agree following [chomsky-2000] and [adger-2003].
-
-## The Agree Operation
 
 Agree is the mechanism by which features are checked/valued:
 1. A **probe** (head with unvalued feature) searches its c-command domain
@@ -17,115 +13,77 @@ Agree is the mechanism by which features are checked/valued:
 3. The probe's feature is valued by copying from the goal
 4. Both features are then checked (and may delete at PF/LF)
 
-## Architecture
-
-This file contains the Agree *operation* and its structural conditions
-(locality, activity, phase-boundedness, defective intervention). For
-the feature *types* (PhiFeature, FeatureVal, etc.), see `Features.lean`.
-For the *failure model* (what happens when Agree fails — a `Probe.outcome` of
-`unvalued`, tolerated per [preminger-2014] Ch. 5), see `Probe/Basic.lean`. For
-the Case Filter, see `CaseFilter.lean`.
-
-## Satisfaction Conditions
-
-Standard Agree assumes a probe is satisfied by finding a matching valued
-feature. [deal-2024] and [keine-2019] argue for richer conditions:
-- **Feature match**: the standard case
-- **Head encounter**: probe is satisfied by encountering a head of a
-  particular category (e.g., Infl's probe stopped by transitive Voice)
-- **Disjunctive**: probe is satisfied by ANY of several conditions
-
-This captures e.g. Mam's Infl probe, which has satisfaction condition
-[SAT: φ or Voice_TR] — it stops when it finds either matching
-φ-features OR transitive Voice, whichever comes first.
-
+This file states Agree's structural conditions over `SyntacticObject`
+trees (c-command locality, horizons, phase-boundedness) and the valuation
+step over `FeatureBundle`s. The feature *types* live in `Features.lean`;
+the search kernel and failure model ([preminger-2014] Ch. 5) in
+`Probe/Basic.lean`; richer satisfaction conditions ([deal-2024],
+[keine-2019]) in `Probe/Satisfaction.lean`; the Case Filter in
+`Syntax/Case/Filter.lean`.
 -/
 
 namespace Minimalist
 
-open Features.Prominence SyntacticObject
+open SyntacticObject
 
--- ============================================================================
--- § 1: Extended Lexical Items with Features
--- ============================================================================
+/-! ### Agree relations -/
 
-/-- Extended LI with grammatical features
-
-    This extends Harizanov's LI with Agree-relevant features.
-    The original ⟨CAT, SEL⟩ handles selection; this adds φ, Case, etc. -/
-structure ExtendedLI where
-  base : LexicalItem        -- The base ⟨CAT, SEL⟩ structure
-  features : FeatureBundle  -- Agree-relevant features
-  deriving Repr
-
-/-- Create an extended LI from a simple LI -/
-def ExtendedLI.fromSimple (cat : Cat) (sel : SelStack) (feats : FeatureBundle) : ExtendedLI :=
-  ⟨.simple cat sel, feats⟩
-
-/-- Is this LI a probe (has unvalued features)? -/
-def ExtendedLI.isProbe (li : ExtendedLI) : Bool :=
-  FeatureType.all.any λ t => (li.features t).isUnvalued
-
-/-- Is this LI a potential goal for a given feature type? -/
-def ExtendedLI.isGoalFor (li : ExtendedLI) (ftype : FeatureVal) : Bool :=
-  hasValuedFeature li.features ftype
-
--- ============================================================================
--- § 2: Agree Relation
--- ============================================================================
-
-/-- A probe-goal pair for Agree -/
+/-- A probe-goal pair for Agree. The feature bundles are supplied with the
+    relation — `SyntacticObject` leaves do not carry bundles — so `validAgree`
+    checks a stipulated configuration for well-formedness rather than deriving
+    the bundles from the tree. -/
 structure AgreeRelation where
   probe : SyntacticObject
   goal : SyntacticObject
-  feature : FeatureVal      -- The feature type being checked
+  /-- The feature being checked; only its dimension matters. -/
+  feature : FeatureVal
   probeFeatures : FeatureBundle
   goalFeatures : FeatureBundle
 
-/-- The probe c-commands the goal within a given tree -/
+/-- The probe c-commands the goal within a given tree. -/
 def AgreeRelation.probeCommands (a : AgreeRelation) (root : SyntacticObject) : Prop :=
   cCommandsIn root a.probe a.goal
 
-/-- The goal has the relevant valued feature -/
+/-- The goal has the relevant valued feature. -/
 def AgreeRelation.goalHasFeature (a : AgreeRelation) : Bool :=
   hasValuedFeature a.goalFeatures a.feature
 
-/-- The probe has the relevant unvalued feature -/
+/-- The probe has the relevant unvalued feature. -/
 def AgreeRelation.probeNeedsFeature (a : AgreeRelation) : Bool :=
   hasUnvaluedFeature a.probeFeatures a.feature
 
-/-- Valid Agree: probe c-commands goal (in tree), probe has unvalued, goal has valued -/
+/-- Valid Agree: probe c-commands goal (in tree), probe has unvalued, goal has valued. -/
 def validAgree (a : AgreeRelation) (root : SyntacticObject) : Prop :=
   a.probeCommands root ∧
   a.probeNeedsFeature = true ∧
   a.goalHasFeature = true
 
--- ============================================================================
--- § 3: Locality (Closest Goal)
--- ============================================================================
+/-! ### Locality: closest goal
 
--- "Closest matching goal, no intervener" is the canonical list engine
--- `Probe.search` (`Probe/Basic.lean`, `search_eq_some_iff_closest`); the
--- tree-native `closestGoal`/`closestGoalWith`/`intervenes` reinventions
--- (zero consumers) were retired. `SyntacticObject` is a commutative magma
--- with no canonical c-command linearization, so the tree↔list bridge is
--- not definitional; `closestGoalB` below is the decidable tree presentation.
+"Closest matching goal, no intervener" is canonically the list engine
+`Probe.search` (`Probe/Basic.lean`, `search_eq_some_iff_closest`, with `pred`
+playing `Probe.vis`). `SyntacticObject` is a commutative magma with no
+canonical c-command linearization, so the tree↔list bridge is not
+definitional; `isClosestGoalIn` is the decidable tree-native presentation. -/
 
-/-- Decidable tree presentation of `Probe.search`-locality
-    (`Probe.search_eq_some_iff_closest`, `pred` playing `Probe.vis`):
-    `goal` is `pred`-matching and c-commanded by `probe`, with no
-    `pred`-matching node c-commanded by `probe` c-commanding `goal`. -/
-def closestGoalB (root probe goal : SyntacticObject)
-    (pred : SyntacticObject → Bool) : Bool :=
-  decide (cCommandsIn root probe goal) &&
-  pred goal &&
-  (! @decide (∃ x ∈ root.subtrees,
-    x ≠ goal ∧ pred x = true ∧ cCommandsIn root probe x ∧ cCommandsIn root x goal)
-    Multiset.decidableExistsMultiset)
+/-- `goal` is a closest `pred`-goal for `probe` in `root`: `pred`-matching and
+    c-commanded by `probe`, with no `pred`-matching node c-commanded by `probe`
+    c-commanding `goal`. -/
+def isClosestGoalIn (root probe goal : SyntacticObject)
+    (pred : SyntacticObject → Bool) : Prop :=
+  cCommandsIn root probe goal ∧ pred goal = true ∧
+    ¬∃ x ∈ root.subtrees,
+      x ≠ goal ∧ pred x = true ∧ cCommandsIn root probe x ∧ cCommandsIn root x goal
 
--- ============================================================================
--- § 3c: Horizons ([keine-2019])
--- ============================================================================
+instance (root probe goal : SyntacticObject) (pred : SyntacticObject → Bool) :
+    Decidable (isClosestGoalIn root probe goal pred) := by
+  unfold isClosestGoalIn
+  have : Decidable (∃ x ∈ root.subtrees,
+      x ≠ goal ∧ pred x = true ∧ cCommandsIn root probe x ∧ cCommandsIn root x goal) :=
+    Multiset.decidableExistsMultiset
+  infer_instance
+
+/-! ### Horizons ([keine-2019]) -/
 
 /-- Per-vertex horizon predicate: leaf with category = horizonCat. -/
 private def isHorizonLeafFor (horizonCat : Cat) (n : SyntacticObject) : Prop :=
@@ -138,34 +96,27 @@ instance (horizonCat : Cat) (n : SyntacticObject) :
   unfold isHorizonLeafFor
   cases getLIToken n <;> infer_instance
 
-/-- Is `target` behind a horizon of category `horizonCat` relative to
-    `probe` in tree `root`?
+/-- `target` is behind a horizon of category `horizonCat` for `probe` in
+    `root`: some `horizonCat` leaf sits in `probe`'s search domain and
+    c-commands `target`, rendering it invisible ([keine-2019]).
 
-    A leaf head `n` of category `horizonCat` creates a horizon: its
-    c-command domain is opaque to the probe. `target` is behind the
-    horizon iff there exists a leaf `n` with category `horizonCat`
-    such that:
-    1. `probe` c-commands `n` (n is in probe's search domain)
-    2. `n` c-commands `target` (target is in n's opaque domain)
+    Example: N° is a horizon for wh-probes ([aissen-polian-2025]). In
+    `[DP D° [PossP Psr N°]]`, N° c-commands Psr, so wh-probes on C° cannot
+    reach Psr; D° is not c-commanded by N°, so the whole DP stays visible
+    for pied-piping.
 
-    This captures [keine-2019]'s horizon mechanism: the probe
-    cannot see past a head of the horizon category. Elements that
-    are c-commanded by the horizon head are invisible to the probe.
+    The canonical list-native horizon specification is `Probe.Profile`
+    (`Probe/Profile.lean`); this is the tree-native presentation. -/
+def behindHorizonIn (root probe target : SyntacticObject)
+    (horizonCat : Cat) : Prop :=
+  ∃ n ∈ root.subtrees,
+    isHorizonLeafFor horizonCat n ∧ cCommandsIn root n target ∧ cCommandsIn root probe n
 
-    Example: N° is a horizon for wh-probes ([aissen-polian-2025]).
-    In `[DP D° [PossP Psr N°]]`, N° c-commands Psr (they are sisters),
-    so wh-probes on C° cannot reach Psr. But D° is a sister of PossP,
-    NOT c-commanded by N°, so the whole DP remains visible for
-    pied-piping. -/
-def behindHorizonB (root probe target : SyntacticObject)
-    (horizonCat : Cat) : Bool :=
-  @decide (∃ n ∈ root.subtrees,
-    isHorizonLeafFor horizonCat n ∧ cCommandsIn root n target ∧ cCommandsIn root probe n)
-    Multiset.decidableExistsMultiset
+instance (root probe target : SyntacticObject) (horizonCat : Cat) :
+    Decidable (behindHorizonIn root probe target horizonCat) :=
+  Multiset.decidableExistsMultiset
 
--- ============================================================================
--- § 4: Feature Valuation
--- ============================================================================
+/-! ### Feature valuation -/
 
 /-- Apply Agree: value the probe's feature from the goal.
     Matching is by *dimension* (`ftype.dimension`), so a probe with
@@ -181,219 +132,18 @@ def applyAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) :
             then Function.update probeFeats ftype.dimension (.valued v)
             else probeFeats
 
--- ============================================================================
--- § 5: Common Agree Configurations
--- ============================================================================
+/-! ### Phase-bounded Agree -/
 
-/-- T-Agree: T probes for φ-features on subject DP
-
-    T has [uφ], subject DP has [φ] → T gets valued φ.
-    The `.third` value on person probes is a conventional placeholder —
-    `sameType` ignores the specific `Person` value, matching any
-    `.person _` against any `.person _`. -/
-structure TAgree where
-  tHead : SyntacticObject
-  subject : SyntacticObject
-  tFeatures : FeatureBundle
-  subjFeatures : FeatureBundle
-  -- T has unvalued phi
-  t_has_uphi : hasUnvaluedFeature tFeatures (.phi (.person .third)) = true ∨
-               hasUnvaluedFeature tFeatures (.phi (.number .singular)) = true
-  -- Subject has valued phi
-  subj_has_phi : hasValuedFeature subjFeatures (.phi (.person .third)) = true ∨
-                 hasValuedFeature subjFeatures (.phi (.number .singular)) = true
-
-/-- C-Agree: C probes for [Q] feature
-
-    C has [uQ], interrogative element has [+Q] → question is licensed -/
-structure CAgree where
-  cHead : SyntacticObject
-  qElement : SyntacticObject
-  cFeatures : FeatureBundle
-  qFeatures : FeatureBundle
-  -- C has unvalued Q
-  c_has_uq : hasUnvaluedFeature cFeatures (.q false) = true
-  -- Q-element has valued [+Q]
-  q_has_q : hasValuedFeature qFeatures (.q true) = true
-
--- ============================================================================
--- § 6: Movement Triggered by Agree
--- ============================================================================
-
-/-- EPP triggers movement to specifier
-
-    When a head has [EPP], Agree is not enough - the goal must MOVE
-    to the specifier position of the agreeing head. -/
-def hasEPP (fb : FeatureBundle) : Bool :=
-  match fb .epp with
-  | .valued b => b
-  | .unvalued => true
-  | .absent => false
-
-/-- T-to-C movement is triggered by [uQ] + [EPP] on C
-
-    In matrix questions:
-    - C has [uQ, EPP]
-    - T has [+Q] (in some analyses) or movement satisfies EPP
-    - T moves to C (head movement) -/
-def tToCTriggered (cFeats : FeatureBundle) : Bool :=
-  hasUnvaluedFeature cFeats (.q false) && hasEPP cFeats
-
--- ============================================================================
--- § 7: Worked Example - Subject-Auxiliary Inversion
--- ============================================================================
-
-/-- Matrix C features: [uQ, EPP] -/
-def matrixCFeatures : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.q false), .valued (.epp true)]
-
-/-- Embedded C features: [uQ] only (satisfied by wh-movement) -/
-def embeddedCFeatures : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.q false)]
-
-/-- Matrix C triggers T-to-C -/
-theorem matrix_triggers_t_to_c : tToCTriggered matrixCFeatures = true := rfl
-
-/-- Embedded C does not trigger T-to-C -/
-theorem embedded_no_t_to_c : tToCTriggered embeddedCFeatures = false := rfl
-
--- ============================================================================
--- § 8: Activity Condition ([chomsky-2000], 2001)
--- ============================================================================
-
-/-- Is a feature bundle active? (has at least one unvalued feature)
-
-    An element is active iff it has at least one unvalued feature.
-    Typically, DPs are active when they have unvalued Case. -/
-def isActive (fb : FeatureBundle) : Bool :=
-  FeatureType.all.any λ t => (fb t).isUnvalued
-
-/-- An element needs Case (has unvalued Case feature) -/
-def needsCase (fb : FeatureBundle) : Bool :=
-  (fb .case).isUnvalued
-
-/-- An element has valued Case -/
-def hasCase (fb : FeatureBundle) : Bool :=
-  (fb .case).isValued
-
-/-- Activity is typically determined by Case:
-    A DP is active iff it lacks Case
-
-    When a feature bundle contains only Case features, the bundle is active
-    (has unvalued features) iff it needs Case (has unvalued Case). -/
-theorem activity_via_case (fb : FeatureBundle)
-    (h : ∀ t, t ≠ .case → fb t = .absent) :
-    isActive fb ↔ needsCase fb := by
-  unfold isActive needsCase
-  simp only [List.any_eq_true]
-  constructor
-  · rintro ⟨t, _, hUnval⟩
-    by_cases ht : t = .case
-    · exact ht ▸ hUnval
-    · rw [h t ht] at hUnval; simp [Features.FeatureSlot.isUnvalued] at hUnval
-  · intro hNeeds
-    exact ⟨.case, by decide, hNeeds⟩
-
--- ============================================================================
--- § 9: Active Goal (for Agree with Activity)
--- ============================================================================
-
-/-- A goal that satisfies the Activity Condition -/
-structure ActiveGoal where
-  goal : SyntacticObject
-  goalFeatures : FeatureBundle
-  isActive : isActive goalFeatures = true
-
-/-- Create an ActiveGoal if the features are indeed active -/
-def mkActiveGoal (goal : SyntacticObject) (feats : FeatureBundle) : Option ActiveGoal :=
-  if h : isActive feats then some ⟨goal, feats, h⟩
-  else none
-
-/-- Valid Agree with Activity Condition
-
-    Agree requires:
-    1. Probe c-commands goal (within tree)
-    2. Probe has unvalued feature
-    3. Goal has matching valued feature
-    4. Goal is ACTIVE (has some unvalued feature) -/
-def validAgreeWithActivity (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  validAgree a root ∧
-  isActive a.goalFeatures = true
-
--- Defective intervention ([chomsky-2000]) is a visible-but-inactive
--- closest goal absorbing the probe (`Probe.agree_eq_none_of_inactive`).
--- The former `MultipleAgree`/`DefectiveElement` reinventions (zero
--- consumers) were retired. Hiraiwa's Multiple Agree (simultaneous
--- valuation of *all* matching goals) is a transmission operation the
--- search-only `Probe` API does not model — see `Probe/Basic.lean`'s
--- scope note.
-
--- ============================================================================
--- § 12: Phase-Bounded Agree
--- ============================================================================
-
-/-- Valid Agree with Phase Impenetrability Condition.
-
-    Agree is blocked if the goal is frozen in a phase interior
-    (`Phase.Impenetrable`, MCB eq 1.14.3). The `strength` parameter is
-    **load-bearing**: `strong`/`weak` apply the PIC block, while
-    `linearizationBound` ([sande-clem-dabkowski-2026]) drops it (locality is then
-    enforced by Cyclic Linearization, not phasehood). -/
+/-- Agree bounded by the Phase Impenetrability Condition: valid Agree whose
+    goal every phase admits extraction from (`Phase.admitsExtraction`). Under
+    `strong`/`weak` this blocks goals frozen in a phase interior; under
+    `linearizationBound` ([sande-clem-dabkowski-2026]) the phasehood layer is
+    transparent and locality falls to Cyclic Linearization. -/
 def validAgreeWithPIC (strength : PICStrength) (phases : List Phase)
     (rel : AgreeRelation) (root : SyntacticObject) : Prop :=
-  validAgree rel root ∧
-    match strength with
-    | .linearizationBound => True
-    | .strong | .weak => ¬∃ ph ∈ phases, ph.Impenetrable rel.goal
+  validAgree rel root ∧ ∀ ph ∈ phases, admitsExtraction strength ph rel.goal
 
-/-- PIC-bounded Agree with Activity Condition.
-
-    The full Agree constraint: probe c-commands goal, feature matching holds,
-    goal is active, AND no intervening phase boundary blocks the relation.
-    See `validAgreeWithPIC` for the role of `strength`. -/
-def fullAgree (strength : PICStrength) (phases : List Phase)
-    (rel : AgreeRelation) (root : SyntacticObject) : Prop :=
-  validAgreeWithActivity rel root ∧
-    match strength with
-    | .linearizationBound => True
-    | .strong | .weak => ¬∃ ph ∈ phases, ph.Impenetrable rel.goal
-
--- ============================================================================
--- § 13: Clause-Typing Agree Configurations
--- ============================================================================
-
-/-- Fin-Agree: Fin probes for [±finite] on its complement (TP). -/
-def finAgreeFeatures (isFinite : Bool) : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.finite isFinite)]
-
-/-- Force-Fin-Agree: Force/C probes for clause-type features on Fin. -/
-def forceFinAgreeFeatures (isFactive : Bool) : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.factive isFactive)]
-
-/-- Neg-Agree: Neg probes for [±neg], licensing sentential negation. -/
-def negAgreeFeatures : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.neg true)]
-
-/-- Rel-Agree: Rel probes for [±rel], licensing relative clause formation. -/
-def relAgreeFeatures : FeatureBundle :=
-  .ofGramFeatures [.unvalued (.rel true)]
-
-/-- Clause-typing features match correctly. -/
-theorem finite_features_match :
-    featuresMatch (.unvalued (.finite true)) (.valued (.finite true)) = true := rfl
-
-theorem factive_features_match :
-    featuresMatch (.unvalued (.factive true)) (.valued (.factive false)) = true := rfl
-
-theorem neg_features_match :
-    featuresMatch (.unvalued (.neg true)) (.valued (.neg true)) = true := rfl
-
-theorem rel_features_match :
-    featuresMatch (.unvalued (.rel true)) (.valued (.rel false)) = true := rfl
-
--- ============================================================================
--- § N: `applyAgree` as a Probe transmission (retire into the Probe API)
--- ============================================================================
+/-! ### `applyAgree` as a `Probe` transmission -/
 
 /-- The φ-probe: relativized search ([bejar-rezac-2003]/[preminger-2014]) for a
     goal bearing a valued `ftype` feature. -/

--- a/Linglib/Syntax/Minimalist/Agree/Checking.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Checking.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Features
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Defs
 
 /-!
 # Host-dependent interpretability and ordered feature activation

--- a/Linglib/Syntax/Minimalist/Verbal/Voice.lean
+++ b/Linglib/Syntax/Minimalist/Verbal/Voice.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.Minimalist.Agree.Basic
+import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Verbal.Decomposition
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Syntax.Voice.Alternation


### PR DESCRIPTION
Deep-audit fixes for `Syntax/Minimalist/Agree/Basic.lean` (423 → 170 lines):

- delete ~20 zero-consumer declarations (`ExtendedLI`, `TAgree`/`CAgree`, the T-to-C worked example, activity/clause-typing apparatus); derive `validAgreeWithPIC` through `Phase.admitsExtraction` instead of duplicating its strength dispatch; fix stale docstring pointers
- Prop-valued `isClosestGoalIn`/`behindHorizonIn` with `Decidable` instances (house style of `SyntacticObject/Subterm.lean`), migrating AissenPolian2025's decide theorems
- ArregiPietraszko2021: `GenHMRelation` was uninhabited (one bundle constrained valued ∧ unvalued at the same slot, kernel-checked), so `genHM_is_agree` was vacuous — split into `probeM`/`goalM` and add an inhabitation witness; drop AlokBhalla2026's identity-function bridge theorem; retarget 7 imports that used nothing from Agree/Basic