### PR TITLE
refactor(Syntax/Minimalist/Agree): assignment-parameterized validAgree

### DIFF
--- a/Linglib/Studies/ArregiPietraszko2021.lean
+++ b/Linglib/Studies/ArregiPietraszko2021.lean
@@ -116,56 +116,49 @@ abbrev MValue := FeatureBundle
 -- § GenHM.2  GenHM Relation
 -- ============================================================================
 
-/-- The Generalized Head Movement relation.
+/-- A&P's **Generalized Head Movement** (GenHM) relation.
 
     GenHM relates two terminal nodes X (probe) and Y (goal) in a local
     syntactic configuration. This is an instance of Agree specialized for
     head displacement: the record captures the pre-Agree configuration
-    (probe's M-slot unvalued, goal's valued); the *shared* M-value A&P's
-    structure-sharing establishes is the transmission outcome
-    `applyAgree probeM goalM feature`. -/
-structure GenHMRelation where
+    under an M-value assignment (probe's M-slot unvalued, goal's valued);
+    the *shared* M-value A&P's structure-sharing establishes is the
+    transmission outcome of valuing the probe's slot from the goal's
+    (`applyAgree`). -/
+structure HeadMovement where
   /-- The higher terminal (e.g., T or C) — the probe -/
-  probe : SyntacticObject
+  probe : LIToken
   /-- The lower terminal (e.g., V or Aux) — the goal -/
-  goal : SyntacticObject
-  /-- The probe's M-features before sharing -/
-  probeM : MValue
-  /-- The goal's M-features before sharing -/
-  goalM : MValue
-  /-- The feature type being shared (tense, phi, etc.) -/
-  feature : FeatureVal
+  goal : LIToken
+  /-- The M-value assignment for the tree's terminals -/
+  feats : LIToken → MValue
+  /-- The feature dimension being shared (tense, phi, etc.) -/
+  feature : FeatureType
   /-- The containing tree -/
   root : SyntacticObject
   /-- Structural condition: probe c-commands goal -/
-  probe_commands_goal : SyntacticObject.cCommandsIn root probe goal
+  probe_commands_goal :
+    SyntacticObject.cCommandsIn root (.lexLeaf probe) (.lexLeaf goal)
   /-- The goal bears valued M-features -/
-  goal_has_mvalue : hasValuedFeature goalM feature = true
+  goal_has_mvalue : (feats goal).hasValuedFeature feature = true
   /-- The probe bears unvalued M-features -/
-  probe_needs_mvalue : hasUnvaluedFeature probeM feature = true
+  probe_needs_mvalue : (feats probe).hasUnvaluedFeature feature = true
 
-/-- GenHM is an instance of Agree: it relates a probe with unvalued features
-    to a goal with valued features under c-command. -/
-def genHM_to_agree (g : GenHMRelation) : AgreeRelation :=
-  { probe := g.probe
-    goal := g.goal
-    feature := g.feature
-    probeFeatures := g.probeM
-    goalFeatures := g.goalM }
-
-/-- A valid GenHM relation satisfies the conditions for valid Agree. -/
-theorem genHM_is_agree (g : GenHMRelation) :
-    validAgree (genHM_to_agree g) g.root :=
+/-- GenHM is an instance of Agree: a valid GenHM relation is a valid Agree
+    relation over the same tree and M-value assignment. -/
+theorem headMovement_is_agree (g : HeadMovement) :
+    validAgree g.feats g.root (.lexLeaf g.probe) (.lexLeaf g.goal) g.feature :=
   ⟨g.probe_commands_goal, g.probe_needs_mvalue, g.goal_has_mvalue⟩
 
 /-- The GenHM configuration is realizable: in `[TP T° V°]`, T° with
     unvalued tense probes V° with valued tense. -/
-example : GenHMRelation where
-  probe := SyntacticObject.lexLeaf ⟨.simple .T [], 1⟩
-  goal := SyntacticObject.lexLeaf ⟨.simple .V [], 2⟩
-  probeM := .ofGramFeatures [.unvalued (.tense true)]
-  goalM := .ofGramFeatures [.valued (.tense true)]
-  feature := .tense true
+example : HeadMovement where
+  probe := ⟨.simple .T [], 1⟩
+  goal := ⟨.simple .V [], 2⟩
+  feats := λ tok =>
+    if tok.item.outerCat = .T then .ofGramFeatures [.unvalued (.tense true)]
+    else .ofGramFeatures [.valued (.tense true)]
+  feature := .tense
   root := SyntacticObject.ofPlanar
     (SyntacticObject.nodeP (SyntacticObject.leafP ⟨.simple .T [], 1⟩)
       (SyntacticObject.leafP ⟨.simple .V [], 2⟩))
@@ -370,7 +363,7 @@ theorem lexical_verb_needs_doSupport_when_split (chain : GenHMChain)
 inductive HeadDisplacementExt where
   | syntactic : HeadDisplacementExt
   | amalgam : Amalgamation → HeadDisplacementExt
-  | genHM : GenHMRelation → HeadDisplacementExt
+  | headMovement : HeadMovement → HeadDisplacementExt
 
 /-- GenHM subsumes both "raising" and "lowering" as surface realizations
     of a single operation. -/

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -15,48 +15,60 @@ Agree is the mechanism by which features are checked/valued:
 
 This file states Agree's structural conditions over `SyntacticObject`
 trees (c-command locality, horizons, phase-boundedness) and the valuation
-step over `FeatureBundle`s. The feature *types* live in `Features.lean`;
-the search kernel and failure model ([preminger-2014] Ch. 5) in
-`Probe/Basic.lean`; richer satisfaction conditions ([deal-2024],
-[keine-2019]) in `Probe/Satisfaction.lean`; the Case Filter in
-`Syntax/Case/Filter.lean`.
+step over `FeatureBundle`s. Bundles live in a *feature assignment*
+`LIToken → FeatureBundle` rather than in the carrier — the free-Merge core
+keeps `SO₀` features atomic (`Features/Slot.lean`) — and a constituent
+exposes its projecting head's bundle through selection-driven labeling
+(`headBundle`). The feature *types* live in `Features.lean`; the search
+kernel and failure model ([preminger-2014] Ch. 5) in `Probe/Basic.lean`;
+richer satisfaction conditions ([deal-2024], [keine-2019]) in
+`Probe/Satisfaction.lean`; the Case Filter in `Syntax/Case/Filter.lean`.
 -/
 
 namespace Minimalist
 
 open SyntacticObject
 
-/-! ### Agree relations -/
+/-! ### Agree relations
 
-/-- A probe-goal pair for Agree. The feature bundles are supplied with the
-    relation — `SyntacticObject` leaves do not carry bundles — so `validAgree`
-    checks a stipulated configuration for well-formedness rather than deriving
-    the bundles from the tree. -/
-structure AgreeRelation where
-  probe : SyntacticObject
-  goal : SyntacticObject
-  /-- The feature being checked; only its dimension matters. -/
-  feature : FeatureVal
-  probeFeatures : FeatureBundle
-  goalFeatures : FeatureBundle
+Feature bundles live in a *feature assignment* `LIToken → FeatureBundle`,
+not in the carrier (`Features/Slot.lean`). A constituent exposes its
+projecting head's bundle through selection-driven labeling
+(`SyntacticObject.selHead`), so an Agree relation's feature conditions and
+its structural conditions are read off one tree and one assignment. -/
 
-/-- The probe c-commands the goal within a given tree. -/
-def AgreeRelation.probeCommands (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  cCommandsIn root a.probe a.goal
+/-- The feature bundle `s` exposes to Agree under the assignment `feats`:
+    its projecting head's bundle. An unlabelable constituent exposes no
+    features (`⊥`), so it can neither probe nor serve as a goal. -/
+def headBundle (feats : LIToken → FeatureBundle) (s : SyntacticObject) : FeatureBundle :=
+  (s.selHead.map feats).getD ⊥
 
-/-- The goal has the relevant valued feature. -/
-def AgreeRelation.goalHasFeature (a : AgreeRelation) : Bool :=
-  hasValuedFeature a.goalFeatures a.feature
+@[simp] theorem headBundle_lexLeaf (feats : LIToken → FeatureBundle) (tok : LIToken) :
+    headBundle feats (lexLeaf tok) = feats tok := rfl
 
-/-- The probe has the relevant unvalued feature. -/
-def AgreeRelation.probeNeedsFeature (a : AgreeRelation) : Bool :=
-  hasUnvaluedFeature a.probeFeatures a.feature
+/-- Valid Agree under a feature assignment: `probe` c-commands `goal` in
+    `root`, the probe's head bears an unvalued `t`-slot, and the goal's head
+    bears a valued one. -/
+def validAgree (feats : LIToken → FeatureBundle) (root probe goal : SyntacticObject)
+    (t : FeatureType) : Prop :=
+  cCommandsIn root probe goal ∧
+  (headBundle feats probe).hasUnvaluedFeature t = true ∧
+  (headBundle feats goal).hasValuedFeature t = true
 
-/-- Valid Agree: probe c-commands goal (in tree), probe has unvalued, goal has valued. -/
-def validAgree (a : AgreeRelation) (root : SyntacticObject) : Prop :=
-  a.probeCommands root ∧
-  a.probeNeedsFeature = true ∧
-  a.goalHasFeature = true
+instance (feats : LIToken → FeatureBundle) (root probe goal : SyntacticObject)
+    (t : FeatureType) : Decidable (validAgree feats root probe goal t) := by
+  unfold validAgree; infer_instance
+
+/-- Nothing Agrees with itself: one slot cannot be both unvalued and valued.
+    Irreflexivity is a fact about the assignment being a single source of
+    feature truth, not about c-command (a multiply-occurring subterm can
+    c-command itself). -/
+theorem validAgree_irrefl (feats : LIToken → FeatureBundle) (root s : SyntacticObject)
+    (t : FeatureType) : ¬ validAgree feats root s s t := by
+  rintro ⟨-, hu, hv⟩
+  cases h : headBundle feats s t <;>
+    simp [FeatureBundle.hasUnvaluedFeature, FeatureBundle.hasValuedFeature,
+      Features.FeatureSlot.isUnvalued, Features.FeatureSlot.isValued, h] at hu hv
 
 /-! ### Locality: closest goal
 
@@ -140,8 +152,15 @@ def applyAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) :
     `linearizationBound` ([sande-clem-dabkowski-2026]) the phasehood layer is
     transparent and locality falls to Cyclic Linearization. -/
 def validAgreeWithPIC (strength : PICStrength) (phases : List Phase)
-    (rel : AgreeRelation) (root : SyntacticObject) : Prop :=
-  validAgree rel root ∧ ∀ ph ∈ phases, admitsExtraction strength ph rel.goal
+    (feats : LIToken → FeatureBundle) (root probe goal : SyntacticObject)
+    (t : FeatureType) : Prop :=
+  validAgree feats root probe goal t ∧ ∀ ph ∈ phases, admitsExtraction strength ph goal
+
+instance (strength : PICStrength) (phases : List Phase)
+    (feats : LIToken → FeatureBundle) (root probe goal : SyntacticObject)
+    (t : FeatureType) :
+    Decidable (validAgreeWithPIC strength phases feats root probe goal t) := by
+  unfold validAgreeWithPIC; infer_instance
 
 /-! ### `applyAgree` as a `Probe` transmission -/
 


### PR DESCRIPTION
Arc 3 of the Agree/Basic audit (follow-up to #2048): replace the stipulated `AgreeRelation` record with a relation over a *feature assignment* `LIToken → FeatureBundle` — the carrier stays feature-atomic per `Features/Slot.lean`, and a constituent exposes its projecting head's bundle via `headBundle` (selection labeling, `selHead`).

- `validAgree feats root probe goal t` / `validAgreeWithPIC` now read feature conditions and structure off one tree and one assignment; Decidable instances for decide workflows
- `validAgree_irrefl`: nothing Agrees with itself — the same-bundle-both-roles contradiction behind the old uninhabited `GenHMRelation` is now provably impossible
- ArregiPietraszko2021: `GenHMRelation` → `HeadMovement` (content name; GenHM stays as the docstring term of art), carried by tokens + an M-value assignment; `headMovement_is_agree` derives Agree via the leaf-labeling roundtrip