### PR TITLE
refactor(Syntax/Minimalist): FeatureType-keyed Agree, drop wrappers

### DIFF
--- a/Linglib/Studies/AdamsonZompi2025.lean
+++ b/Linglib/Studies/AdamsonZompi2025.lean
@@ -459,8 +459,7 @@ theorem pconstraint_allows_imposter :
    predict the probe treats LEI like any 3rd person argument — no PCC
    effect. This is wrong.
 
-   We demonstrate this using the library's own `hasValuedFeature` from
-   `Agree.lean`: a probe seeking [participant] via φ-features will not
+   We demonstrate this using the library's own `FeatureBundle.hasValuedFeature`: a probe seeking [participant] via φ-features will not
    find it on a DP whose valued person is 3rd. -/
 
 /-- A feature bundle for a 3rd person DP (LEI's agreement features).
@@ -476,8 +475,8 @@ private def lei_interpretable_bundle : Minimalist.FeatureBundle :=
 /-- A probe seeking person features finds them on both bundles — the
     probe can Agree with either. The issue is WHICH person value it sees. -/
 theorem probe_finds_person_on_both :
-    Minimalist.hasValuedFeature lei_agreement_bundle (.phi (.person .third)) = true ∧
-    Minimalist.hasValuedFeature lei_interpretable_bundle (.phi (.person .second)) = true :=
+    lei_agreement_bundle.hasValuedFeature .person = true ∧
+    lei_interpretable_bundle.hasValuedFeature .person = true :=
   ⟨rfl, rfl⟩
 
 /-- Under morphosyntactic accounts, the probe sees LEI's agreement bundle

--- a/Linglib/Studies/AlokBhalla2026.lean
+++ b/Linglib/Studies/AlokBhalla2026.lean
@@ -276,7 +276,7 @@ theorem hon_features_match (level : HonLevel) :
 /-- Honorific valuation via Agree: applying Agree to an allocutive probe
     with [uHON] against an addressee with [iHON] values the probe. -/
 theorem hon_agree_values (level : HonLevel) :
-    applyAgree (allocProbeFeatures level) (addresseeDPFeatures level) (.hon level)
+    applyAgree (allocProbeFeatures level) (addresseeDPFeatures level) .hon
       = some (.ofGramFeatures [.valued (.hon level)]) := by
   cases level <;> native_decide
 

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -219,7 +219,7 @@ def mamAntipassiveVoice : Voice.Head :=
 
 /-- Mam Voice head carries [uOblique]. -/
 theorem mamVoice_has_uOblique :
-    hasUnvaluedFeature mamVoice.features (.oblique false) = true := by decide
+    mamVoice.features.hasUnvaluedFeature .oblique = true := by decide
 
 /-- Mam Voice is a phase head. -/
 theorem mamVoice_is_phase : mamVoice.IsPhasal := by decide
@@ -469,13 +469,13 @@ private def cp : SyntacticObject :=
 theorem derivation_tree_size : cp.nodeCount = 6 := by decide
 
 theorem voice_has_uOblique :
-    hasUnvaluedFeature mamVoice.features (.oblique false) = true := by decide
+    mamVoice.features.hasUnvaluedFeature .oblique = true := by decide
 
 private def oblique_goal_features : FeatureBundle := .ofGramFeatures [.valued (.oblique true)]
 
 /-- Agree at Voice: [uOblique] valued by oblique DP's [+oblique]. -/
 theorem voice_agree_values_oblique :
-    applyAgree mamVoice.features oblique_goal_features (.oblique false) =
+    applyAgree mamVoice.features oblique_goal_features .oblique =
     some (.ofGramFeatures [.valued (.oblique true)]) := by
   decide
 
@@ -487,7 +487,7 @@ theorem voice_spellout_eqya :
 
 /-- Full derivation pipeline: Agree then Spellout → "=(y)a'". -/
 theorem full_derivation_pipeline :
-    (applyAgree mamVoice.features oblique_goal_features (.oblique false)).bind
+    (applyAgree mamVoice.features oblique_goal_features .oblique).bind
       (λ fb => spellout mamVoiceVocab fb (some .Voice)) = some "=(y)a'" := by
   decide
 
@@ -530,11 +530,11 @@ theorem both_probes_unvalued :
     are probed and which vocabulary entries match. -/
 theorem phi_and_oblique_agree_parallel :
     -- φ-Agree pipeline: value person, then number, then spellout
-    (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
+    (applyAgree voiceProbe dp3sg .person).bind
+      (λ fb => applyAgree fb dp3sg .number) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Oblique-Agree pipeline: value oblique, then spellout
-    applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) (.oblique false) =
+    applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) .oblique =
       some (.ofGramFeatures [.valued (.oblique true)]) ∧
     spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
   exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -235,7 +235,7 @@ def dp3sg : FeatureBundle :=
 
 /-- Voice's [uPerson] is valued as [Person:3] from a 3SG agent. -/
 theorem voice_agrees_person :
-    applyAgree voiceProbe dp3sg (.phi (.person .third)) =
+    applyAgree voiceProbe dp3sg .person =
     some (.ofGramFeatures
       [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]) := by
   native_decide
@@ -245,7 +245,7 @@ theorem voice_agrees_person :
 theorem voice_agrees_number :
     let afterPerson : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]
-    applyAgree afterPerson dp3sg (.phi (.number .singular)) =
+    applyAgree afterPerson dp3sg .number =
     some (.ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) := by
   native_decide
@@ -256,8 +256,8 @@ def voiceFullyAgreed : FeatureBundle :=
 
 /-- The two-step Agree pipeline produces a fully valued bundle. -/
 theorem voice_agree_pipeline :
-    (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) =
+    (applyAgree voiceProbe dp3sg .person).bind
+      (λ fb => applyAgree fb dp3sg .number) =
     some voiceFullyAgreed := by
   native_decide
 
@@ -378,11 +378,11 @@ theorem intransitive_pipeline_1sg :
     (applyAgree inflProbe
       (.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
-      (.phi (.person .third))).bind
+      .person).bind
       (λ fb => applyAgree fb
         (.ofGramFeatures
           [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
-        (.phi (.number .singular))) =
+        .number) =
     some (.ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) ∧
     -- Spells out as "chin" (not default "tz'=")
@@ -405,8 +405,8 @@ theorem intransitive_pipeline_1sg :
     5. Patient is not φ-Agreed-with → overt pronoun required -/
 theorem full_pipeline_3sg_transitive :
     -- Step 1-2: Voice Agrees and spells out as Set A
-    (applyAgree voiceProbe dp3sg (.phi (.person .third))).bind
-      (λ fb => applyAgree fb dp3sg (.phi (.number .singular))) = some voiceFullyAgreed ∧
+    (applyAgree voiceProbe dp3sg .person).bind
+      (λ fb => applyAgree fb dp3sg .number) = some voiceFullyAgreed ∧
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
     -- Step 3-4: Infl probe blocked → default Set B
     spellout setBVocab (⊥ : FeatureBundle) (some .T) = some "tz'=" ∧
@@ -491,13 +491,13 @@ theorem different_probe_heads :
     unvalued (empty) bundle spells out as the Elsewhere entry — the Set B "tz'="
     observed in Mam transitives. -/
 theorem transitive_is_probe_failure :
-    (phiProbe (.phi (.person .third))).outcome [⊥] = .unvalued := by
+    (phiProbe .person).outcome [⊥] = .unvalued := by
   native_decide
 
 /-- The intransitive case is real agreement: Infl's φ-probe finds S, so its
     outcome is `valued`. -/
 theorem intransitive_is_real_agreement :
-    (phiProbe (.phi (.person .third))).outcome
+    (phiProbe .person).outcome
       [.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]]
       = .valued := by
@@ -599,7 +599,7 @@ def voiceTR : Encounter := ⟨none, ⊥, some .v⟩
 def dpGoal (p : ArgPosition) (φ : FeatureBundle) : Encounter := ⟨some p, φ, none⟩
 
 /-- Voice's probe: standard φ feature-match (no head-encounter disjunct). -/
-def voiceSat : SatisfactionCond := .featureMatch (.phi (.person .third))
+def voiceSat : SatisfactionCond := .featureMatch .person
 
 /-- A probe over an empty search space agrees with nothing. -/
 theorem agreesWith_nil (cond : SatisfactionCond) :
@@ -632,7 +632,7 @@ theorem infl_truncated_at_voiceTR (rest : List Encounter) :
 /-- In an intransitive, Infl's search finds S and copies its features,
     provided S bears person. -/
 theorem infl_finds_S (φS : FeatureBundle)
-    (hS : hasValuedFeature φS (.phi (.person .third)) = true) :
+    (hS : φS.hasValuedFeature .person = true) :
     agreesWith mamInflSatisfaction [dpGoal .S φS] = some .S := by
   simp [agreesWith, satProbe, SatisfactionCond.toProbe, Probe.agree, Probe.search,
     Option.filter_some, dpGoal, mamInflSatisfaction_isSatisfied,
@@ -641,7 +641,7 @@ theorem infl_finds_S (φS : FeatureBundle)
 /-- Voice's search finds the agent (closest goal), provided A bears
     person. -/
 theorem voice_finds_A (φA φP : FeatureBundle)
-    (hA : hasValuedFeature φA (.phi (.person .third)) = true) :
+    (hA : φA.hasValuedFeature .person = true) :
     agreesWith voiceSat [dpGoal .A φA, dpGoal .P φP] = some .A := by
   simp [agreesWith, satProbe, SatisfactionCond.toProbe, Probe.agree, Probe.search,
     Option.filter_some, dpGoal, voiceSat, SatisfactionCond.isSatisfied,
@@ -660,8 +660,8 @@ def derivedAgreeProbe (φA φP φS : FeatureBundle) (p : ArgPosition) :
 /-- The stipulated table coincides with the derivation, for any clause
     whose A and S bear person features. -/
 theorem agreeProbe_eq_derived (φA φP φS : FeatureBundle)
-    (hA : hasValuedFeature φA (.phi (.person .third)) = true)
-    (hS : hasValuedFeature φS (.phi (.person .third)) = true) :
+    (hA : φA.hasValuedFeature .person = true)
+    (hS : φS.hasValuedFeature .person = true) :
     ∀ p, agreeProbe p = derivedAgreeProbe φA φP φS p := by
   intro p
   cases p with

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -130,18 +130,17 @@ instance (root probe target : SyntacticObject) (horizonCat : Cat) :
 
 /-! ### Feature valuation -/
 
-/-- Apply Agree: value the probe's feature from the goal.
-    Matching is by *dimension* (`ftype.dimension`), so a probe with
-    `[uPerson:_]` is valued by a goal with `[Person:3rd]` — the placeholder
-    value is irrelevant. If the goal has a valued feature at the dimension and
-    the probe's slot there is unvalued, the probe's slot is set to that value. -/
-def applyAgree (probeFeats goalFeats : FeatureBundle) (ftype : FeatureVal) :
+/-- Apply Agree: value the probe's feature from the goal. If the goal has a
+    valued feature at dimension `t` and the probe's `t`-slot is unvalued, the
+    probe's slot is set to that value; `none` when the goal has nothing to
+    transmit. -/
+def applyAgree (probeFeats goalFeats : FeatureBundle) (t : FeatureType) :
     Option FeatureBundle :=
-  match getValuedFeature goalFeats ftype with
+  match goalFeats.getValuedFeature t with
   | none => none
   | some v =>
-    some <| if (probeFeats ftype.dimension).isUnvalued
-            then Function.update probeFeats ftype.dimension (.valued v)
+    some <| if (probeFeats t).isUnvalued
+            then Function.update probeFeats t (.valued v)
             else probeFeats
 
 /-! ### Phase-bounded Agree -/
@@ -165,24 +164,24 @@ instance (strength : PICStrength) (phases : List Phase)
 /-! ### `applyAgree` as a `Probe` transmission -/
 
 /-- The φ-probe: relativized search ([bejar-rezac-2003]/[preminger-2014]) for a
-    goal bearing a valued `ftype` feature. -/
-def phiProbe (ftype : FeatureVal) : Probe FeatureBundle :=
-  Probe.ofVis (fun gf => (getValuedFeature gf ftype).isSome)
+    goal bearing a valued feature at dimension `t`. -/
+def phiProbe (t : FeatureType) : Probe FeatureBundle :=
+  Probe.ofVis (fun gf => (gf.getValuedFeature t).isSome)
 
 /-- **`applyAgree` is the φ goal→probe transmission.** A φ-Agree is
     `Probe.transmit` of the φ-probe with the valuation `applyAgree`: search the
-    goal sequence for a `ftype`-bearing goal, then value the probe's features
+    goal sequence for a `t`-bearing goal, then value the probe's features
     from it. This recognizes the standalone `applyAgree` as the transmission
     step of the unified Agree operation (`Probe/Transmission.lean`), rather than
     a parallel mechanism. (The probe→goal direction — dependent case — and a
     full clause's worth of valuations are *folds* of `transmit`s: the
     composition axis, not a single transmit.) -/
-theorem applyAgree_is_phi_transmit (probeFeats : FeatureBundle) (ftype : FeatureVal)
+theorem applyAgree_is_phi_transmit (probeFeats : FeatureBundle) (t : FeatureType)
     {goals : List FeatureBundle} {gf : FeatureBundle}
-    (h : (phiProbe ftype).search goals = some gf) :
-    (phiProbe ftype).transmit (fun g pf => (applyAgree pf g ftype).getD pf)
+    (h : (phiProbe t).search goals = some gf) :
+    (phiProbe t).transmit (fun g pf => (applyAgree pf g t).getD pf)
         probeFeats goals
-      = (applyAgree probeFeats gf ftype).getD probeFeats := by
+      = (applyAgree probeFeats gf t).getD probeFeats := by
   unfold phiProbe at h ⊢
   exact Probe.transmit_ofVis_eq_of_search h
 

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -414,25 +414,6 @@ def FeatureBundle.toGramFeatures (fb : FeatureBundle) : List GramFeature :=
     | .unvalued => some (.unvalued (t.toFeatureVal t.placeholderValue))
     | .valued v => some (.valued (t.toFeatureVal v))
 
-/-! ### `FeatureVal`-keyed query wrappers
-
-Convenience over the `FeatureType`-keyed methods: pass a sample `FeatureVal`
-(its carried value is ignored, only the dimension matters — the old
-`sameType` semantics). These keep probe-spec call sites that pass a
-placeholder feature (`.phi (.person .third)`) unchanged. -/
-
-/-- The bundle has a valued feature of `fv`'s dimension. -/
-def hasValuedFeature (fb : FeatureBundle) (fv : FeatureVal) : Bool :=
-  FeatureBundle.hasValuedFeature fb fv.dimension
-
-/-- The bundle has an unvalued (probe) feature of `fv`'s dimension. -/
-def hasUnvaluedFeature (fb : FeatureBundle) (fv : FeatureVal) : Bool :=
-  FeatureBundle.hasUnvaluedFeature fb fv.dimension
-
-/-- The value at `fv`'s dimension, when valued. -/
-def getValuedFeature (fb : FeatureBundle) (fv : FeatureVal) : Option fv.dimension.ValueOf :=
-  FeatureBundle.getValuedFeature fb fv.dimension
-
 -- ============================================================================
 -- § 6: ±Interpretable Features
 -- ============================================================================

--- a/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
+++ b/Linglib/Syntax/Minimalist/Probe/Satisfaction.lean
@@ -49,12 +49,12 @@ namespace Minimalist
     This turns the Mam bridge's prose account into a computable derivation:
     ```
     def mamInflSatisfaction : SatisfactionCond :=
-.disjunctive [.featureMatch (.phi (.person.third)),.headEncounter.v]
+.disjunctive [.featureMatch .person, .headEncounter .v]
     ```
 -/
 inductive SatisfactionCond where
   /-- Standard: probe is satisfied by finding a matching valued feature. -/
-  | featureMatch : FeatureVal → SatisfactionCond
+  | featureMatch : FeatureType → SatisfactionCond
   /-- Disjunctive: probe is satisfied by ANY of these conditions.
       Models [deal-2024]'s interaction-based probes. -/
   | disjunctive : List SatisfactionCond → SatisfactionCond
@@ -68,7 +68,7 @@ inductive SatisfactionCond where
 private def atomicSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
     (ctx : Option Cat) : Bool :=
   match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
+  | .featureMatch ft => fb.hasValuedFeature ft
   | .headEncounter cat => ctx == some cat
   | .disjunctive _ => false  -- nested disjunctions handled at top level
 
@@ -80,7 +80,7 @@ private def atomicSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
 def SatisfactionCond.isSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
     (ctx : Option Cat) : Bool :=
   match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
+  | .featureMatch ft => fb.hasValuedFeature ft
   | .disjunctive conds => conds.any (atomicSatisfied · fb ctx)
   | .headEncounter cat => ctx == some cat
 
@@ -93,10 +93,10 @@ def SatisfactionCond.isSatisfied (cond : SatisfactionCond) (fb : FeatureBundle)
 def SatisfactionCond.copiedFeatures (cond : SatisfactionCond) (fb : FeatureBundle)
     (ctx : Option Cat) : Bool :=
   match cond with
-  | .featureMatch ft => hasValuedFeature fb ft
+  | .featureMatch ft => fb.hasValuedFeature ft
   | .disjunctive conds =>
     match conds.find? (atomicSatisfied · fb ctx) with
-    | some (.featureMatch ft) => hasValuedFeature fb ft
+    | some (.featureMatch ft) => fb.hasValuedFeature ft
     | _ => false  -- head encounter or nested → no features copied
   | .headEncounter _ => false
 
@@ -111,7 +111,7 @@ def SatisfactionCond.toProbe {α : Type*} (cond : SatisfactionCond)
 /-- Mam's Infl probe satisfaction condition:
     satisfied by EITHER matching φ-features OR encountering transitive Voice. -/
 def mamInflSatisfaction : SatisfactionCond :=
-  .disjunctive [.featureMatch (.phi (.person .third)), .headEncounter .v]
+  .disjunctive [.featureMatch .person, .headEncounter .v]
 
 /-- Intransitive environment: the probe encounters a DP with φ-features
     (no Voice_TR in the way). Feature match is satisfied → real agreement. -/
@@ -138,15 +138,15 @@ theorem mam_intransitive_copies :
 /-- Infl's satisfaction condition, unfolded: φ-match or Voice_TR encounter. -/
 theorem mamInflSatisfaction_isSatisfied (fb : FeatureBundle) (ctx : Option Cat) :
     mamInflSatisfaction.isSatisfied fb ctx
-      = (hasValuedFeature fb (.phi (.person .third)) || ctx == some Cat.v) := by
+      = (fb.hasValuedFeature .person || ctx == some Cat.v) := by
   simp [mamInflSatisfaction, SatisfactionCond.isSatisfied, atomicSatisfied]
 
 /-- Head-encounter satisfaction never copies: Infl copies features iff
     they are there to copy, whatever the context. -/
 theorem mamInflSatisfaction_copiedFeatures (fb : FeatureBundle) (ctx : Option Cat) :
     mamInflSatisfaction.copiedFeatures fb ctx
-      = hasValuedFeature fb (.phi (.person .third)) := by
-  cases hv : hasValuedFeature fb (.phi (.person .third)) <;>
+      = fb.hasValuedFeature .person := by
+  cases hv : fb.hasValuedFeature .person <;>
     cases hc : ctx == some Cat.v <;>
       simp [mamInflSatisfaction, SatisfactionCond.copiedFeatures, atomicSatisfied,
         List.find?, hv, hc]


### PR DESCRIPTION
Arc 4 of the Agree/Basic audit (follow-up to #2049): key the Agree APIs by feature *dimension* and retire `Features.lean`'s legacy `FeatureVal`-keyed wrappers (`hasValuedFeature`/`hasUnvaluedFeature`/`getValuedFeature`), whose placeholder-value convention (`.phi (.person .third)`, `.oblique false`) they existed to support.

- `applyAgree`/`phiProbe`/`applyAgree_is_phi_transmit` and `SatisfactionCond.featureMatch` now take `FeatureType`; `mamInflSatisfaction` becomes `.disjunctive [.featureMatch .person, .headEncounter .v]`
- call sites migrated to the dimension-keyed `FeatureBundle` methods (Scott2023, ElkinsTorrenceBrown2026, AlokBhalla2026, AdamsonZompi2025)

Not built locally per request — CI is the gate.