### PR TITLE
refactor(Core): delete dead Δ^ρ API; re-home cut enumeration lemmas

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -1,9 +1,7 @@
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Linglib.Core.Combinatorics.RootedTree.Cut
 import Linglib.Core.Data.RoseTree.Nonplanar
-import Mathlib.LinearAlgebra.Finsupp.LSum
 import Mathlib.LinearAlgebra.TensorProduct.Basic
-import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.RingTheory.TensorProduct.Maps
 
 open RoseTree RoseTree.Nonplanar
@@ -27,10 +25,7 @@ deletes cut subtrees outright, unlike the trace variant Δ^c
   `ConnesKreimer.comulAlgHomN` — the Δ^ρ coproduct, as the generic
   admissible-cut coproduct (`Coproduct/WithCuts.lean`) at the
   enumeration `cutSummandsN`.
-* `ConnesKreimer.comulTreeNFiltered` — the phase-restricted variant
-  ([marcolli-chomsky-berwick-2025] §1.14).
-* `ConnesKreimer.bPlus`, `ConnesKreimer.bPlusLin` — grafting `B+_a` as
-  smart constructor and linear map.
+* `ConnesKreimer.bPlusLin` — grafting `B+_a` as a linear map.
 
 ## Main results
 
@@ -76,27 +71,6 @@ noncomputable def comulTreeN :
       ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
   comulTreeNG cutSummandsN
 
-/-- A **filtered nonplanar tree-level Δ^ρ**: the `T ⊗ 1` primitive term plus
-    the cut-summand sum restricted to summands satisfying `pred`. Generalizes
-    `comulTreeN` (the `pred = always-true` case); used to carve phase-restricted
-    sub-coproducts (e.g. the phase coproduct Δ^c_Φ of
-    [marcolli-chomsky-berwick-2025] §1.14). -/
-noncomputable def comulTreeNFiltered (T : Nonplanar α)
-    (pred : Forest (Nonplanar α) × Nonplanar α → Prop) [DecidablePred pred] :
-    ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
-  ofTree T ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α))
-  + (((cutSummandsN T).filter pred).map
-      (fun p => of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)).sum
-
-/-- The filter drops nothing when every cut summand satisfies `pred`, recovering
-    the full `comulTreeN`. -/
-theorem comulTreeNFiltered_eq_comulTreeN (T : Nonplanar α)
-    (pred : Forest (Nonplanar α) × Nonplanar α → Prop) [DecidablePred pred]
-    (hAll : ∀ p ∈ cutSummandsN T, pred p) :
-    comulTreeNFiltered (R := R) T pred = comulTreeN (R := R) T := by
-  unfold comulTreeNFiltered comulTreeN comulTreeNG
-  rw [Multiset.filter_eq_self.mpr hAll]
-
 /-- The nonplanar forest-level Δ^ρ (multiplicative extension). -/
 noncomputable def comulForestN :
     Forest (Nonplanar α) →
@@ -117,12 +91,6 @@ noncomputable def comulForestN :
     comulForestN (R := R) (T ::ₘ F) =
       comulTreeN (R := R) T * comulForestN (R := R) F :=
   comulForestNG_cons _ T F
-
-/-- Forest-level Δ^ρ as a `MonoidHom` from `Multiplicative (Forest ...)`. -/
-noncomputable def comulMonoidHomN :
-    Multiplicative (Forest (Nonplanar α)) →*
-      (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :=
-  comulMonoidHomNG cutSummandsN
 
 /-- The **Δ^ρ coproduct on `ConnesKreimer R (Nonplanar α)`** as an
     algebra hom: `comulAlgHomNG` at `cuts := cutSummandsN`. -/
@@ -157,18 +125,9 @@ coassociativity (§A.7-δ): the subalgebra `A := {x | (Δ ⊗ id)(Δ x) =
 (id ⊗ Δ)(Δ x)}` is closed under `B+_a`, contains all leaves (which are
 `B+_a 1`), hence equals the whole algebra. -/
 
-/-! ### B+_a as a function, smart constructor, and linear map -/
+/-! ### B+_a as a linear map -/
 
-/-- The **B+_a** operator: graft an unordered forest of Nonplanar trees
-    under a new root labeled `a`. Identical to the smart constructor. -/
-noncomputable def bPlus (a : α) (F : Forest (Nonplanar α)) :
-    Nonplanar α :=
-  Nonplanar.node a F
-
-@[simp] theorem bPlus_def (a : α) (F : Forest (Nonplanar α)) :
-    bPlus a F = Nonplanar.node a F := rfl
-
-/-- The **B+_a linear map**: linearly extend the smart constructor `bPlus a`
+/-- The **B+_a linear map**: linearly extend the smart constructor `Nonplanar.node a`
     to an `R`-linear endomorphism of `ConnesKreimer R (Nonplanar α)`,
     sending the basis element `of' F` to `ofTree (Nonplanar.node a F)`. -/
 noncomputable def bPlusLin (a : α) :
@@ -206,22 +165,12 @@ private theorem map_first_product {β γ δ : Type*}
     (s.map f) ×ˢ t = s.bind (fun a => t.map (Prod.mk (f a))) :=
   Multiset.bind_map s _ f
 
-/-! ### Public API
+/-! ### `comulForestN` as a sum over forest cuts
 
-The two structural facts that drive the cocycle: cuts of a node
-decompose along `cutForestSummandsN`, and `comulForestN` expands as the
-multiset sum over `cutForestSummandsN`. Both are pure Nonplanar-level
-statements; tree-level substrate is invisible to consumers. -/
-
-/-- Cuts of `Nonplanar.node a F` decompose along the per-tree decisions
-    of `F`: each pair `(cf, rem) ∈ cutForestSummandsN F` gives a cut
-    summand `(cf, Nonplanar.node a rem)`. The Nonplanar-level form. -/
-@[simp] theorem cutSummandsN_node (a : α) (F : Forest (Nonplanar α)) :
-    cutSummandsN (Nonplanar.node a F) =
-      (cutForestSummandsN F).map (fun pf => (pf.1, Nonplanar.node a pf.2)) := by
-  obtain ⟨ps, hps⟩ := exists_planar_list_rep F
-  subst hps
-  rw [cutSummandsN_node_planar_list, ← cutForestSummandsN_via_planar_list]
+Together with `cutSummandsN_node` (`Combinatorics/RootedTree/Cut.lean`),
+the expansion `comulForestN_eq_sum` drives the cocycle: cuts of a node
+decompose along the per-tree decisions of `cutForestSummandsN`, and
+`comulForestN` expands as the matching multiset sum. -/
 
 /-- Extract-branch of the `comulForestN_eq_sum` cons step: `(ofTree T ⊗ 1)`
     times the forest-cuts sum collapses into the "extract T whole"
@@ -294,21 +243,6 @@ theorem comulForestN_eq_sum (F : Forest (Nonplanar α)) :
 
 /-! ### The cocycle theorem (basis-level) -/
 
-/-- For the empty forest: `Nonplanar.node a 0 = Nonplanar.leaf a`. -/
-@[simp] theorem node_zero_eq_leaf (a : α) :
-    (Nonplanar.node a (0 : Multiset (Nonplanar α)) : Nonplanar α) =
-      Nonplanar.leaf a := rfl
-
-/-- The cut summands of a leaf: only one summand `(0, leaf a)`,
-    corresponding to the empty cut. -/
-theorem cutSummandsN_leaf (a : α) :
-    cutSummandsN (Nonplanar.leaf a : Nonplanar α) =
-      ({((0 : Forest (Nonplanar α)), Nonplanar.leaf a)} : Multiset _) := by
-  show (cutSummandsP (RoseTree.leaf a)).map (projSummand (α := α)) = _
-  rw [show RoseTree.leaf a = RoseTree.node a [] from rfl, cutSummandsP_node,
-      cutListSummandsP_nil, Multiset.map_singleton, Multiset.map_singleton]
-  rfl
-
 /-- The tree-level coproduct on a leaf:
     `comulTreeN (leaf a) = ofTree (leaf a) ⊗ 1 + 1 ⊗ ofTree (leaf a)`. -/
 theorem comulTreeN_leaf (a : α) :
@@ -353,41 +287,21 @@ theorem comulAlgHomN_bPlusLin_cocycle (a : α) (F : Forest (Nonplanar α)) :
 
 /-! ## Counit laws
 
-Counit laws follow by reducing to the tree case via
-`ConnesKreimer.algHom_ext` + multiplicativity (the empty-cut summand
-contributes `1 ⊗ of' F`; all others are killed by `counit`).
+`(ε ⊗ id) ∘ Δ^ρ = lid⁻¹` and `(id ⊗ ε) ∘ Δ^ρ = rid⁻¹`: reduce to `of' F`
+via `ConnesKreimer.algHom_ext`, then close the tree case by strong induction
+on depth through the cocycle `comulTreeN_node_cocycle`.
 
 Coassociativity (`comulRhoN_coassoc`, from the GL/CK duality
 `pairing_gl_eq_pairing_coproduct_Rho` + `GrossmanLarson.mul_assoc` via
 `pairing₃_unique`) and the `Bialgebra` instance live downstream in
 `Coproduct/PruningDuality.lean`. -/
 
-/-! ### Tree-depth induction substrate -/
-
-/-- A tree's depth is strictly less than the depth of any node containing
-    it as a child. -/
-theorem _root_.RoseTree.Nonplanar.depth_lt_of_mem (T : Nonplanar α) (F : Forest (Nonplanar α))
-    (hT : T ∈ F) (a : α) : T.depth < (Nonplanar.node a F).depth := by
-  obtain ⟨ps, hps⟩ := exists_planar_list_rep F
-  subst hps
-  rw [Nonplanar.node_mk_tree_list]
-  show T.depth < (RoseTree.node a ps).depth
-  rw [RoseTree.depth_node]
-  rw [show (Multiset.ofList (ps.map Nonplanar.mk) : Forest (Nonplanar α)) =
-        ((ps.map Nonplanar.mk : List (Nonplanar α)) : Multiset _) from rfl,
-      Multiset.mem_coe, List.mem_map] at hT
-  obtain ⟨c, hc, rfl⟩ := hT
-  show (Nonplanar.mk c).depth < 1 + (ps.map RoseTree.depth).foldr max 0
-  rw [Nonplanar.depth_mk, Nat.add_comm]
-  exact Nat.lt_succ_of_le (RoseTree.depth_le_foldr_max hc)
-
 /-! ### Counit ⊗ id commutation with `lTensor (bPlusLin a)`
 
 The factor-wise commutation `(counit ⊗ id) ∘ (id ⊗ B+_a) = (id ⊗ B+_a) ∘ (counit ⊗ id)`
 (where the right `id` is on different domains: `H` on the left, `R` on the right).
 Pure `TensorProduct.induction_on` calculation; both sides reduce to
-`counit x ⊗ B+_a y` on simple tensors. Used in the tree-level counit law and
-in the bPlus closure proof. -/
+`counit x ⊗ B+_a y` on simple tensors. Used in the tree-level counit law. -/
 
 private theorem counit_rTensor_lTensor_bPlus_apply (a : α)
     (z : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
@@ -405,33 +319,13 @@ private theorem counit_rTensor_lTensor_bPlus_apply (a : α)
         LinearMap.lTensor_tmul]
   | add z₁ z₂ ih₁ ih₂ => rw [map_add, map_add, ih₁, ih₂, map_add, map_add]
 
-/-! ### Symmetric: id ⊗ counit commutation with `lTensor (bPlusLin a)`
-
-Mirror of `counit_rTensor_lTensor_bPlus_apply`. Acting on the right factor with
-counit and on the left factor with B+_a — they don't interact. -/
-
-private theorem counit_lTensor_lTensor_bPlus_apply (a : α)
-    (z : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
-    (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
-        (counit (R := R)))
-      ((LinearMap.rTensor _ (bPlusLin (R := R) a)) z) =
-    (LinearMap.rTensor R (bPlusLin (R := R) a))
-      ((Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
-        (counit (R := R))) z) := by
-  induction z using TensorProduct.induction_on with
-  | zero => rw [map_zero, map_zero, map_zero]
-  | tmul x y =>
-    rw [LinearMap.rTensor_tmul, Algebra.TensorProduct.map_tmul,
-        Algebra.TensorProduct.map_tmul, AlgHom.id_apply, AlgHom.id_apply,
-        LinearMap.rTensor_tmul]
-  | add z₁ z₂ ih₁ ih₂ => rw [map_add, map_add, ih₁, ih₂, map_add, map_add]
-
 /-! ### Tree-level counit law (depth induction)
 
 `(counit ⊗ id)(Δ T) = 1 ⊗ T` for every nonplanar tree `T`. Strong induction
-on `T.depth`: leaves close directly via `comulTreeN_leaf`; nodes use the
+on `T.depth`: present `T` as `Nonplanar.node a F` via a planar rep, then the
 cocycle `comulTreeN_node_cocycle`, the commutation
-`counit_rTensor_lTensor_bPlus_apply`, and the forest law on the children. -/
+`counit_rTensor_lTensor_bPlus_apply`, and the forest law on the strictly
+shallower children close the goal. -/
 
 private theorem comulForestN_counit_rTensor (F : Forest (Nonplanar α))
     (hF : ∀ T ∈ F, (Algebra.TensorProduct.map (counit (R := R))
@@ -551,64 +445,45 @@ private theorem comulTreeN_counit_lTensor (T : Nonplanar α) :
     (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
         (counit (R := R)))
       (comulTreeN T) = ofTree T ⊗ₜ (1 : R) := by
-  -- Strong induction on T.depth.
-  suffices aux : ∀ n : ℕ, ∀ T : Nonplanar α, T.depth = n →
-      (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
-          (counit (R := R)))
-        (comulTreeN T) = ofTree T ⊗ₜ (1 : R) by
-    exact aux T.depth T rfl
-  intro n
-  induction n using Nat.strong_induction_on with
-  | _ n _IH =>
-    intro T _hT
-    obtain ⟨T₀, rfl⟩ : ∃ T₀ : RoseTree α, T = Nonplanar.mk T₀ :=
-      ⟨Quotient.out T, (Quotient.out_eq T).symm⟩
-    obtain ⟨a, children⟩ := T₀
-    rw [show (Nonplanar.mk (RoseTree.node a children) : Nonplanar α) =
-        Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))
-        from (Nonplanar.node_mk_tree_list a children).symm]
-    -- Use cocycle: comulTreeN T = ofTree T ⊗ 1 + (id ⊗ bPlusLin a)(comulForestN F).
-    rw [comulTreeN_node_cocycle, map_add]
-    -- First summand: (id ⊗ counit)(ofTree T ⊗ 1) = ofTree T ⊗ counit(1) = ofTree T ⊗ 1.
-    rw [show (Algebra.TensorProduct.map
-              (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
-              (counit (R := R)))
-          (ofTree (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))) ⊗ₜ
-            (1 : ConnesKreimer R (Nonplanar α))) =
-        ofTree (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))) ⊗ₜ
-          (1 : R) from by
-      rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply, map_one]]
-    -- Second summand: (id ⊗ counit) ∘ (lTensor (bPlusLin a)) z is zero,
-    -- because counit ∘ bPlusLin a = 0 (any tree from B+_a has counit 0).
-    rw [show (Algebra.TensorProduct.map
-              (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
-              (counit (R := R)))
-          ((LinearMap.lTensor _ (bPlusLin (R := R) a))
-            (comulForestN (Multiset.ofList (children.map Nonplanar.mk)))) = 0 from by
-      generalize comulForestN (R := R)
-        (Multiset.ofList (children.map Nonplanar.mk)) = z
-      induction z using TensorProduct.induction_on with
-      | zero => rw [map_zero, map_zero]
-      | tmul x y =>
-        rw [LinearMap.lTensor_tmul, Algebra.TensorProduct.map_tmul,
-            AlgHom.id_apply, counit_bPlusLin, TensorProduct.tmul_zero]
-      | add z₁ z₂ ih₁ ih₂ => rw [map_add, map_add, ih₁, ih₂, add_zero]]
-    rw [add_zero]
+  obtain ⟨T₀, rfl⟩ : ∃ T₀ : RoseTree α, T = Nonplanar.mk T₀ :=
+    ⟨Quotient.out T, (Quotient.out_eq T).symm⟩
+  obtain ⟨a, children⟩ := T₀
+  rw [show (Nonplanar.mk (RoseTree.node a children) : Nonplanar α) =
+      Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))
+      from (Nonplanar.node_mk_tree_list a children).symm]
+  -- Use cocycle: comulTreeN T = ofTree T ⊗ 1 + (id ⊗ bPlusLin a)(comulForestN F).
+  rw [comulTreeN_node_cocycle, map_add]
+  -- First summand: (id ⊗ counit)(ofTree T ⊗ 1) = ofTree T ⊗ counit(1) = ofTree T ⊗ 1.
+  rw [show (Algebra.TensorProduct.map
+            (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+            (counit (R := R)))
+        (ofTree (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))) ⊗ₜ
+          (1 : ConnesKreimer R (Nonplanar α))) =
+      ofTree (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))) ⊗ₜ
+        (1 : R) from by
+    rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply, map_one]]
+  -- Second summand: (id ⊗ counit) ∘ (lTensor (bPlusLin a)) z is zero,
+  -- because counit ∘ bPlusLin a = 0 (any tree from B+_a has counit 0).
+  rw [show (Algebra.TensorProduct.map
+            (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+            (counit (R := R)))
+        ((LinearMap.lTensor _ (bPlusLin (R := R) a))
+          (comulForestN (Multiset.ofList (children.map Nonplanar.mk)))) = 0 from by
+    generalize comulForestN (R := R)
+      (Multiset.ofList (children.map Nonplanar.mk)) = z
+    induction z using TensorProduct.induction_on with
+    | zero => rw [map_zero, map_zero]
+    | tmul x y =>
+      rw [LinearMap.lTensor_tmul, Algebra.TensorProduct.map_tmul,
+          AlgHom.id_apply, counit_bPlusLin, TensorProduct.tmul_zero]
+    | add z₁ z₂ ih₁ ih₂ => rw [map_add, map_add, ih₁, ih₂, add_zero]]
+  rw [add_zero]
 
 /-! ### Counit laws (algebra-hom level)
 
-Strategy: reduce to `of' F` via `ConnesKreimer.algHom_ext`. For each `F`, expand
-`comulAlgHomN (of' F) = comulForestN F` via `comulForestN_eq_sum`, then identify
-the unique cut summand `(0, F) ∈ cutForestSummandsN F` (the "all empty cuts"
-tuple). Other summands have `pf.1.card > 0`, so `counit (of' pf.1) = 0` and
-`(counit ⊗ id)` kills them. The surviving `(0, F)` summand contributes
-`1 ⊗ of' F = (lid).symm (of' F)`.
-
-Helper lemmas needed (substantive):
-* `mem_cutSummandsN_zero (T : Nonplanar α) : (0, T) ∈ cutSummandsN T` — the empty
-  cut exists at every tree.
-* `cutForestSummandsN_zero_mem (F : Forest (Nonplanar α)) : (0, F) ∈ cutForestSummandsN F`.
-* `cutForestSummandsN_pos_pi : ∀ pf ∈ cutForestSummandsN F, pf ≠ (0, F) → pf.1.card > 0`. -/
+Reduce to `of' F` via `ConnesKreimer.algHom_ext`; the forest laws
+`comulForestN_counit_rTensor` and `comulForestN_counit_lTensor` close from
+the tree-level laws. -/
 
 theorem counit_rTensor_comulAlgHomN :
     (Algebra.TensorProduct.map (counit (R := R)) (AlgHom.id R _)).comp comulAlgHomN =
@@ -631,6 +506,7 @@ theorem counit_lTensor_comulAlgHomN :
        (Algebra.TensorProduct.rid R R (ConnesKreimer R (Nonplanar α))).symm (of' F)
   rw [comulAlgHomN_apply_of', Algebra.TensorProduct.rid_symm_apply]
   exact comulForestN_counit_lTensor F (fun T _ => comulTreeN_counit_lTensor T)
+
 /-! ### Δ^ρ coassoc and Bialgebra instance: moved
 
 The GL/CK duality theorem (`pairing_gl_eq_pairing_coproduct_Rho`), the

--- a/Linglib/Core/Algebra/RootedTree/FormSet.lean
+++ b/Linglib/Core/Algebra/RootedTree/FormSet.lean
@@ -85,8 +85,8 @@ This is exactly the existing `bPlusLin a` (Hochschild 1-cocycle for
 /-- The **grafting operator** `B` (MCB Def 1.3.2): create a new tree
     with a fresh root labeled `a` and the forest `F` as children.
 
-    Identical to `bPlus a F = Nonplanar.node a F`; this name highlights
-    the FormSet usage. -/
+    Identical to the smart constructor `Nonplanar.node a F`; this name
+    highlights the FormSet usage. -/
 noncomputable def graft (a : α) (F : Forest (Nonplanar α)) : Nonplanar α :=
   Nonplanar.node a F
 

--- a/Linglib/Core/Combinatorics/RootedTree/Cut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Cut.lean
@@ -698,6 +698,15 @@ noncomputable def cutSummandsN :
 @[simp] theorem cutSummandsN_mk (T : RoseTree α) :
     cutSummandsN (Nonplanar.mk T) = (cutSummandsP T).map projSummand := rfl
 
+/-- The cut summands of a leaf: only the empty cut `(0, leaf a)`. -/
+theorem cutSummandsN_leaf (a : α) :
+    cutSummandsN (Nonplanar.leaf a : Nonplanar α) =
+      ({((0 : Multiset (Nonplanar α)), Nonplanar.leaf a)} : Multiset _) := by
+  show (cutSummandsP (RoseTree.leaf a)).map (projSummand (α := α)) = _
+  rw [show RoseTree.leaf a = RoseTree.node a [] from rfl, cutSummandsP_node,
+      cutListSummandsP_nil, Multiset.map_singleton, Multiset.map_singleton]
+  rfl
+
 /-- Number of Δ^ρ cut summands of `T` whose cut forest is `{T₁}` and whose
     remainder tree is `T₂` — the Δ^ρ analog of the count `c^T_{T₁,T₂}` of
     [marcolli-chomsky-berwick-2025]. -/
@@ -771,24 +780,8 @@ noncomputable def cutForestSummandsN (F : Multiset (Nonplanar α)) :
 /-! ### Bridges to the tree-level list representation
 
 The tree-level substrate `cutListSummandsP` (defined on `List (RoseTree α)`)
-is reused to evaluate `cutForestSummandsN` on a tree-level list rep, and
-to characterize cuts of a Nonplanar node. These bridges are private —
-the public `cutSummandsN_node` and `comulForestN_eq_sum` are stated
-purely at the Nonplanar level. -/
-
-/-- Witness: every `F : Multiset (Nonplanar α)` has a tree-level list
-    representative. Used internally to lift tree-level-side characterizations
-    to the Nonplanar level. -/
-theorem exists_planar_list_rep (F : Multiset (Nonplanar α)) :
-    ∃ ps : List (RoseTree α), F = Multiset.ofList (ps.map Nonplanar.mk) := by
-  refine ⟨F.toList.map Quotient.out, ?_⟩
-  conv_lhs => rw [← Multiset.coe_toList F]
-  congr 1
-  rw [List.map_map]
-  conv_lhs => rw [show F.toList = F.toList.map id from (List.map_id _).symm]
-  apply List.map_congr_left
-  intro x _
-  exact (Quotient.out_eq x).symm
+evaluates `cutForestSummandsN` on a tree-level list rep and characterizes
+cuts of a Nonplanar node (`cutSummandsN_node`). -/
 
 /-- `cutForestSummandsN` evaluated on a tree-level list rep agrees with the
     tree-level `cutListSummandsP` projected through `projForest`. By
@@ -825,53 +818,14 @@ theorem cutSummandsN_node_planar_list (a : α) (ps : List (RoseTree α)) :
   rw [← Nonplanar.node_mk_tree_list]
   rfl
 
-/-! ### Empty cut existence (substrate for counit laws)
-
-The empty cut `(0, T)` is always a cut summand of `T`. The tree-level
-substrate `cutSummandsP T` always contains `(0, T)`, by mutual structural
-induction with `cutListSummandsP`; the nonplanar `cutForestSummandsN F`
-contains `(0, F)` by descent. These witnesses split the `(counit ⊗ id)`
-sum into a single non-vanishing summand `1 ⊗ of' F`. -/
-
-mutual
-
-/-- The empty cut `(0, T)` is a cut summand of every tree-level tree `T`. -/
-theorem mem_cutSummandsP_zero : ∀ (T : RoseTree α),
-    ((0 : Multiset (RoseTree α)), T) ∈ cutSummandsP T
-  | .node a cs => by
-    rw [cutSummandsP_node, Multiset.mem_map]
-    exact ⟨(0, cs), mem_cutListSummandsP_zero cs, rfl⟩
-
-/-- The empty cut `(0, ps)` is a list cut summand of every tree-level list `ps`. -/
-theorem mem_cutListSummandsP_zero : ∀ (ps : List (RoseTree α)),
-    ((0 : Multiset (RoseTree α)), ps) ∈ cutListSummandsP ps
-  | [] => by
-    rw [cutListSummandsP_nil]; exact Multiset.mem_singleton.mpr rfl
-  | t :: ts => by
-    rw [cutListSummandsP_cons, Multiset.mem_map]
-    refine ⟨((0, Option.some t), (0, ts)), ?_, ?_⟩
-    · rw [Multiset.mem_product, augActionP_eq, Multiset.mem_cons]
-      refine ⟨Or.inr ?_, mem_cutListSummandsP_zero ts⟩
-      rw [Multiset.mem_map]
-      exact ⟨(0, t), mem_cutSummandsP_zero t, rfl⟩
-    · -- The cons combiner with `(0, some t)` and `(0, ts)` gives `(0, t :: ts)`
-      -- via `0 + 0 = 0`.
-      show (((0 : Multiset (RoseTree α)) + (0 : Multiset (RoseTree α))), t :: ts) =
-           ((0 : Multiset (RoseTree α)), t :: ts)
-      rw [zero_add]
-
-end
-
-/-- The empty cut `(0, F)` is a forest cut summand of every nonplanar forest `F`. -/
-theorem cutForestSummandsN_zero_mem (F : Multiset (Nonplanar α)) :
-    ((0 : Multiset (Nonplanar α)), F) ∈ cutForestSummandsN F := by
-  obtain ⟨ps, rfl⟩ := exists_planar_list_rep F
-  rw [cutForestSummandsN_via_planar_list, Multiset.mem_map]
-  refine ⟨(0, ps), mem_cutListSummandsP_zero ps, ?_⟩
-  show ((0 : Multiset (RoseTree α)).map Nonplanar.mk,
-        Multiset.ofList (ps.map Nonplanar.mk)) =
-       ((0 : Multiset (Nonplanar α)), Multiset.ofList (ps.map Nonplanar.mk))
-  rw [Multiset.map_zero]
+/-- Cuts of `Nonplanar.node a F` decompose along the per-tree decisions
+    of `F`: each pair `(cf, rem) ∈ cutForestSummandsN F` gives a cut
+    summand `(cf, Nonplanar.node a rem)`. The Nonplanar-level form. -/
+@[simp] theorem cutSummandsN_node (a : α) (F : Multiset (Nonplanar α)) :
+    cutSummandsN (Nonplanar.node a F) =
+      (cutForestSummandsN F).map (fun pf => (pf.1, Nonplanar.node a pf.2)) := by
+  induction F using Nonplanar.forest_inductionOn with
+  | h ps => rw [cutSummandsN_node_planar_list, ← cutForestSummandsN_via_planar_list]
 
 /-! ### `traceLeaf` — placeholder for a cut subtree -/
 

--- a/Linglib/Core/Data/RoseTree/Nonplanar.lean
+++ b/Linglib/Core/Data/RoseTree/Nonplanar.lean
@@ -243,6 +243,10 @@ theorem node_pair_mk (a : α) (p q : RoseTree α) :
     node a {mk p, mk q} = mk (.node a [p, q]) :=
   node_mk_tree_list a [p, q]
 
+/-- The empty-forest node is the leaf. -/
+@[simp] theorem node_zero (a : α) :
+    node a (0 : Multiset (Nonplanar α)) = leaf a := rfl
+
 /-- Choose planar representatives for a whole forest at once: every
     `Multiset (Nonplanar α)` is the `mk`-image of a list of planar trees. Descent
     proofs that use this eliminator meet `node_mk_tree_list` on the nose, with no
@@ -335,6 +339,27 @@ theorem numNodes_pos (t : Nonplanar α) : 0 < t.numNodes := by
   refine congrArg List.sum (List.map_congr_left fun t _ => ?_)
   show (mk (Quotient.out t)).numNodes = numNodes t
   exact congrArg numNodes (Quotient.out_eq t)
+
+/-! ### Depth of a `node` -/
+
+/-- A tree's depth is strictly less than the depth of any node containing
+    it as a child. -/
+theorem depth_lt_of_mem (T : Nonplanar α) (F : Multiset (Nonplanar α))
+    (hT : T ∈ F) (a : α) : T.depth < (node a F).depth := by
+  revert hT
+  induction F using forest_inductionOn with
+  | h ps =>
+    intro hT
+    rw [node_mk_tree_list]
+    show T.depth < (RoseTree.node a ps).depth
+    rw [RoseTree.depth_node]
+    rw [show (Multiset.ofList (ps.map mk) : Multiset (Nonplanar α)) =
+          ((ps.map mk : List (Nonplanar α)) : Multiset _) from rfl,
+        Multiset.mem_coe, List.mem_map] at hT
+    obtain ⟨c, hc, rfl⟩ := hT
+    show (mk c).depth < 1 + (ps.map RoseTree.depth).foldr max 0
+    rw [depth_mk, Nat.add_comm]
+    exact Nat.lt_succ_of_le (RoseTree.depth_le_foldr_max hc)
 
 end RoseTree.Nonplanar
 


### PR DESCRIPTION
Audit follow-up for `Coproduct/PruningNonplanar.lean` (net −145 lines, cone-built clean).

- Delete zero-consumer API: `bPlus`/`bPlus_def`, `comulMonoidHomN`, `comulTreeNFiltered`, `counit_lTensor_lTensor_bPlus_apply`, and Cut.lean's unused empty-cut block (`mem_cutSummandsP_zero`, `cutForestSummandsN_zero_mem`); drop `exists_planar_list_rep` in favor of the existing `forest_inductionOn`.
- Re-home enumeration-level `cutSummandsN_node`/`cutSummandsN_leaf` to `Combinatorics/RootedTree/Cut.lean`; `depth_lt_of_mem` and `node_zero` to `Data/RoseTree/Nonplanar.lean`.
- Rewrite stale counit-law strategy docstrings to match the actual cocycle + depth-induction proofs; drop the vestigial strong-induction scaffolding in `comulTreeN_counit_lTensor` and two vestigial imports.