### PR TITLE
refactor(Core): one generic sum-over-cuts expansion for Δ^ρ and Δ^c

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Deletion.lean
@@ -173,35 +173,35 @@ summands and the `some`-embedded Δ^ρ summands of
 `Core/Combinatorics/RootedTree/CutFilterMap.lean` both land in its
 domain. -/
 
-private noncomputable def cutTensor
+private noncomputable def optionCutTensor
     (q : Multiset (Option (RoseTree α)) × Option (RoseTree α)) :
     ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
   (of' (q.1.filterMap (Option.map Nonplanar.mk)) : ConnesKreimer R (Nonplanar α))
     ⊗ₜ[R] (q.2.map Nonplanar.mk).elim 1 ofTree
 
-/-- The `(Π ⊗ Π)`-image of a projected Δ^c summand is `cutTensor` of its
+/-- The `(Π ⊗ Π)`-image of a projected Δ^c summand is `optionCutTensor` of its
     filtered form. -/
-private theorem cutTensor_filterMap
+private theorem optionCutTensor_filterMap
     (p : Multiset (RoseTree (α ⊕ β)) × RoseTree (α ⊕ β)) :
     eraseTracesAlgHom (R := R) (of' (p.1.map Nonplanar.mk)) ⊗ₜ[R]
         eraseTracesAlgHom (ofTree (Nonplanar.mk p.2)) =
-      cutTensor (R := R)
+      optionCutTensor (R := R)
         (Prod.map (Multiset.map (RoseTree.filterMap Sum.getLeft?))
           (RoseTree.filterMap Sum.getLeft?) p) := by
-  unfold cutTensor
+  unfold optionCutTensor
   congr 1
   · rw [eraseTracesAlgHom_of', Prod.map_fst, Multiset.filterMap_map,
         Multiset.filterMap_map]
     rfl
   · rw [eraseTracesAlgHom_ofTree, Nonplanar.filterMap_mk, Prod.map_snd]
 
-/-- On `some`-embedded Δ^ρ summands, `cutTensor` is the plain summand
+/-- On `some`-embedded Δ^ρ summands, `optionCutTensor` is the plain summand
     tensor. -/
-private theorem cutTensor_some (p : Multiset (RoseTree α) × RoseTree α) :
-    cutTensor (R := R) (Prod.map (Multiset.map some) some p) =
+private theorem optionCutTensor_some (p : Multiset (RoseTree α) × RoseTree α) :
+    optionCutTensor (R := R) (Prod.map (Multiset.map some) some p) =
       (of' (p.1.map Nonplanar.mk) : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R]
         ofTree (Nonplanar.mk p.2) := by
-  unfold cutTensor
+  unfold optionCutTensor
   congr 1
   · rw [Prod.map_fst, Multiset.filterMap_map,
         show (Option.map Nonplanar.mk ∘ (some : RoseTree α → Option (RoseTree α)))
@@ -211,30 +211,30 @@ private theorem cutTensor_some (p : Multiset (RoseTree α) × RoseTree α) :
 /-! ### Lift from tree-level to Nonplanar -/
 
 /-- The `(Π ⊗ Π)`-image of a projected Δ^c summand tensor, as a composed
-    map: `cutTensor` after the summand filter. -/
-private theorem cutTensor_filterMap_comp :
+    map: `optionCutTensor` after the summand filter. -/
+private theorem optionCutTensor_filterMap_comp :
     (((Algebra.TensorProduct.map (eraseTracesAlgHom (R := R) (α := α) (β := β))
         eraseTracesAlgHom) ∘
       (fun p : Forest (Nonplanar (α ⊕ β)) × Nonplanar (α ⊕ β) =>
         of' (R := R) p.1 ⊗ₜ[R] ofTree p.2)) ∘ projSummand) =
-    (cutTensor (R := R)) ∘
+    (optionCutTensor (R := R)) ∘
       (Prod.map (Multiset.map (RoseTree.filterMap Sum.getLeft?))
         (RoseTree.filterMap Sum.getLeft?)) := by
   funext p
   show (Algebra.TensorProduct.map eraseTracesAlgHom eraseTracesAlgHom)
       (of' (p.1.map Nonplanar.mk) ⊗ₜ[R] ofTree (Nonplanar.mk p.2)) = _
   rw [Algebra.TensorProduct.map_tmul]
-  exact cutTensor_filterMap p
+  exact optionCutTensor_filterMap p
 
-/-- The plain Δ^ρ summand tensor, as a composed map: `cutTensor` after
+/-- The plain Δ^ρ summand tensor, as a composed map: `optionCutTensor` after
     the `some` embedding. -/
-private theorem cutTensor_some_comp :
+private theorem optionCutTensor_some_comp :
     ((fun p : Forest (Nonplanar α) × Nonplanar α =>
         (of' (R := R) p.1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ[R] ofTree p.2) ∘
       projSummand) =
-    (cutTensor (R := R)) ∘ (Prod.map (Multiset.map some) some) := by
+    (optionCutTensor (R := R)) ∘ (Prod.map (Multiset.map some) some) := by
   funext p
-  exact (cutTensor_some p).symm
+  exact (optionCutTensor_some p).symm
 
 /-- Per-tree form of the Δ^ρ comparison, descended from the cut-summand
     identity `cutSummandsCP_map_inl_filterMap` through the quotient. -/
@@ -257,7 +257,7 @@ private theorem eraseTraces_comulCTreeN_map_inl
           (Algebra.TensorProduct.map (eraseTracesAlgHom (R := R)) eraseTracesAlgHom),
         cutSummandsCN_mk, cutSummandsN_mk,
         Multiset.map_map, Multiset.map_map, Multiset.map_map,
-        cutTensor_filterMap_comp, cutTensor_some_comp,
+        optionCutTensor_filterMap_comp, optionCutTensor_some_comp,
         ← Multiset.map_map, ← Multiset.map_map, cutSummandsCP_map_inl_filterMap]
 
 /-- Forest-level form of the Δ^ρ comparison: the per-tree form lifted

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningNonplanar.lean
@@ -146,25 +146,6 @@ noncomputable def bPlusLin (a : α) :
   show ofTree (Nonplanar.node a 0) = ofTree (Nonplanar.leaf a)
   rfl
 
-/-! ### Tensor-algebra and multiset distributivity helpers -/
-
-/-- The fundamental distributivity in `H ⊗ H` for basis-vector tensors:
-    `(of' a ⊗ of' b) * (of' c ⊗ of' d) = of' (a + c) ⊗ of' (b + d)`.
-    Combines `Algebra.TensorProduct.tmul_mul_tmul` with `of'_add` on
-    both channels. -/
-private theorem of'_tmul_mul_of'_tmul (a b c d : Forest (Nonplanar α)) :
-    (of' (R := R) a ⊗ₜ[R] of' (R := R) b) * (of' (R := R) c ⊗ₜ[R] of' (R := R) d) =
-      of' (R := R) (a + c) ⊗ₜ[R] of' (R := R) (b + d) := by
-  rw [Algebra.TensorProduct.tmul_mul_tmul, ← of'_add, ← of'_add]
-
-/-- Cartesian product distributes the head map: `(s.map f) ×ˢ t = s.bind (a ↦ t.map (Prod.mk (f a)))`.
-    Pure `Multiset.product`/`Multiset.bind_map` algebra; included locally because mathlib
-    doesn't ship this exact form. -/
-private theorem map_first_product {β γ δ : Type*}
-    (f : β → γ) (s : Multiset β) (t : Multiset δ) :
-    (s.map f) ×ˢ t = s.bind (fun a => t.map (Prod.mk (f a))) :=
-  Multiset.bind_map s _ f
-
 /-! ### `comulForestN` as a sum over forest cuts
 
 Together with `cutSummandsN_node` (`Combinatorics/RootedTree/Cut.lean`),
@@ -172,74 +153,15 @@ the expansion `comulForestN_eq_sum` drives the cocycle: cuts of a node
 decompose along the per-tree decisions of `cutForestSummandsN`, and
 `comulForestN` expands as the matching multiset sum. -/
 
-/-- Extract-branch of the `comulForestN_eq_sum` cons step: `(ofTree T ⊗ 1)`
-    times the forest-cuts sum collapses into the "extract T whole"
-    summand of `cutForestSummandsN_cons` (the `({T}, none)` decision). -/
-private theorem comulForestN_cons_extract_branch (T : Nonplanar α)
-    (P : Multiset (Forest (Nonplanar α) × Forest (Nonplanar α))) :
-    (ofTree T ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α))) *
-        (P.map (fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2)).sum =
-      (((P.map (Prod.mk
-          (({T}, Option.none) : Forest (Nonplanar α) × Option (Nonplanar α)))).map
-        innerCombinerProj).map
-        (fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2)).sum := by
-  rw [← of'_singleton, ← of'_zero (R := R) (T := Nonplanar α),
-      ← Multiset.sum_map_mul_left]
-  simp only [Multiset.map_map]
-  refine congr_arg Multiset.sum (Multiset.map_congr rfl (fun p _ => ?_))
-  show (of' (R := R) ({T} : Forest (Nonplanar α)) ⊗ₜ[R] of' (R := R) 0) *
-        (of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2) =
-       ((fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2) ∘ innerCombinerProj ∘
-          Prod.mk (({T}, Option.none) :
-            Forest (Nonplanar α) × Option (Nonplanar α))) p
-  rw [of'_tmul_mul_of'_tmul, zero_add]
-  rfl
-
-/-- Recurse-branch of the `comulForestN_eq_sum` cons step: the
-    `cutSummandsN T`-indexed sum part of `comulTreeN T` times the
-    forest-cuts sum collapses into the cartesian product of
-    "recurse-with-cut" decisions on `T` against the rest. -/
-private theorem comulForestN_cons_recurse_branch (T : Nonplanar α)
-    (P : Multiset (Forest (Nonplanar α) × Forest (Nonplanar α))) :
-    (((cutSummandsN T).map (fun s => of' (R := R) s.1 ⊗ₜ[R] ofTree s.2)).sum) *
-        (P.map (fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2)).sum =
-      (((((cutSummandsN T).map (fun s => (s.1, Option.some s.2))) ×ˢ P).map
-        innerCombinerProj).map
-        (fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2)).sum := by
-  rw [← Multiset.sum_map_mul_right,
-      show (cutSummandsN T).map (fun s =>
-        (of' (R := R) s.1 ⊗ₜ[R] ofTree s.2) *
-        (P.map (fun p => of' (R := R) p.1 ⊗ₜ[R] of' (R := R) p.2)).sum) =
-      (cutSummandsN T).map (fun s =>
-        (P.map (fun p => of' (R := R) (s.1 + p.1) ⊗ₜ[R]
-          of' (R := R) (s.2 ::ₘ p.2))).sum) from
-        Multiset.map_congr rfl (fun s _ => by
-          rw [← of'_singleton (R := R) s.2, ← Multiset.sum_map_mul_left]
-          refine congr_arg Multiset.sum
-            (Multiset.map_congr rfl (fun p _ => ?_))
-          rw [of'_tmul_mul_of'_tmul, Multiset.singleton_add]),
-      ← Multiset.sum_bind, map_first_product]
-  simp only [Multiset.map_bind, Multiset.map_map]
-  refine congr_arg Multiset.sum (Multiset.bind_congr (fun s _ => ?_))
-  apply Multiset.map_congr rfl
-  intro p _
-  rfl
-
 /-- The forest coproduct `comulForestN F` expands as a multiset sum of
-    `of' cf ⊗ of' rem` over `(cf, rem) ∈ cutForestSummandsN F`. -/
+    `of' cf ⊗ of' rem` over `(cf, rem) ∈ cutForestSummandsN F`: the generic
+    `comulForestNG_eq_sum` at `cuts := cutSummandsN`, transported along
+    `cutForestSummandsN_eq_forestCutsG`. -/
 theorem comulForestN_eq_sum (F : Forest (Nonplanar α)) :
     comulForestN (R := R) F = ((cutForestSummandsN F).map
       (fun pf => of' (R := R) pf.1 ⊗ₜ[R] of' (R := R) pf.2)).sum := by
-  induction F using Multiset.induction with
-  | empty =>
-    rw [comulForestN_zero, cutForestSummandsN_zero,
-        Multiset.map_singleton, Multiset.sum_singleton, of'_zero]
-    rfl
-  | cons T F' ih =>
-    rw [comulForestN_cons, ih, cutForestSummandsN_cons]
-    unfold comulTreeN comulTreeNG augActionN
-    rw [add_mul, Multiset.cons_product, Multiset.map_add, Multiset.map_add, Multiset.sum_add,
-        comulForestN_cons_extract_branch, comulForestN_cons_recurse_branch]
+  rw [cutForestSummandsN_eq_forestCutsG]
+  exact comulForestNG_eq_sum cutSummandsN F
 
 /-! ### The cocycle theorem (basis-level) -/
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/TraceNonplanar.lean
@@ -180,12 +180,6 @@ The proof structure:
 section DoubleCut
 variable {R : Type*} [CommSemiring R] {α β : Type*}
 
-/-- Tensor-product factor of a (crown, trunk) cut pair. -/
-private noncomputable def cutTensor
-    (p : Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β))) :
-    ConnesKreimer R (Nonplanar (α ⊕ β)) ⊗[R] ConnesKreimer R (Nonplanar (α ⊕ β)) :=
-  ConnesKreimer.of' (R := R) p.1 ⊗ₜ[R] ConnesKreimer.of' p.2
-
 /-- Triple-tensor factor for the coassoc target `CK ⊗ (CK ⊗ CK)`. -/
 private noncomputable def tripleTensor
     (q : Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β)) ×
@@ -195,77 +189,43 @@ private noncomputable def tripleTensor
   ConnesKreimer.of' (R := R) q.1 ⊗ₜ[R]
     (ConnesKreimer.of' q.2.1 ⊗ₜ[R] ConnesKreimer.of' q.2.2)
 
-/-- Convolution-of-cuts is left-commutative (it is the symmetric
-    `combinerProjG` of the descent layer); needed for `Multiset.foldr`. -/
-instance instLeftCommConvCut : LeftCommutative
-    (fun (s acc : Multiset (Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β)))) =>
-      (s ×ˢ acc).map ConnesKreimer.combinerProjG) :=
-  ⟨fun a b c => ConnesKreimer.swap_double_combinerProjG a b c⟩
-
 /-- All cut summands of a tree as (crown forest, trunk forest) pairs:
-    full cut `({T}, ∅)`, plus `cutSummandsCN` (which already includes the
-    empty cut `(∅, {T})` and all proper cuts, each with a single-tree
-    trunk). -/
+    `treeCutsG` at the Δ^c enumeration `cutSummandsCN τ` (full cut
+    `({T}, ∅)`, plus each proper/empty cut with a single-tree trunk). -/
 private noncomputable def treeCutsN (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
     Multiset (Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β))) :=
-  ({T}, 0) ::ₘ (cutSummandsCN τ T).map (fun p => (p.1, {p.2}))
+  treeCutsG (cutSummandsCN τ) T
 
-/-- `comulCTreeN` as a single multiset sum over `treeCutsN`. -/
+/-- `comulCTreeN` as a single multiset sum over `treeCutsN`:
+    `comulTreeNG_eq_sum` at the Δ^c enumeration. -/
 private theorem comulCTreeN_eq_sum (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) :
-    comulCTreeN (R := R) τ T = ((treeCutsN τ T).map (cutTensor (R := R))).sum := by
-  unfold comulCTreeN comulTreeNG treeCutsN
-  rw [Multiset.map_cons, Multiset.sum_cons, Multiset.map_map]
-  congr 1
+    comulCTreeN (R := R) τ T = ((treeCutsN τ T).map (cutTensor (R := R))).sum :=
+  comulTreeNG_eq_sum _ T
 
-/-- Forest-level cut enumeration via convolution over the component trees. -/
+/-- Forest-level cut enumeration: `forestCutsG` at the Δ^c enumeration. -/
 private noncomputable def forestCutsN (τ : Nonplanar (α ⊕ β) → β)
     (F : Forest (Nonplanar (α ⊕ β))) :
     Multiset (Forest (Nonplanar (α ⊕ β)) × Forest (Nonplanar (α ⊕ β))) :=
-  (F.map (treeCutsN τ)).foldr
-    (fun s acc => (s ×ˢ acc).map ConnesKreimer.combinerProjG) {(0, 0)}
+  forestCutsG (cutSummandsCN τ) F
 
 private theorem forestCutsN_zero (τ : Nonplanar (α ⊕ β) → β) :
-    forestCutsN τ (0 : Forest (Nonplanar (α ⊕ β))) = {(0, 0)} := by
-  unfold forestCutsN; simp
+    forestCutsN τ (0 : Forest (Nonplanar (α ⊕ β))) = {(0, 0)} :=
+  forestCutsG_zero _
 
 private theorem forestCutsN_cons (τ : Nonplanar (α ⊕ β) → β)
     (T : Nonplanar (α ⊕ β)) (F : Forest (Nonplanar (α ⊕ β))) :
     forestCutsN τ (T ::ₘ F) =
-      (treeCutsN τ T ×ˢ forestCutsN τ F).map ConnesKreimer.combinerProjG := by
-  unfold forestCutsN
-  rw [Multiset.map_cons, Multiset.foldr_cons]
+      (treeCutsN τ T ×ˢ forestCutsN τ F).map ConnesKreimer.combinerProjG :=
+  forestCutsG_cons _ T F
 
-/-- `comulCForestN` as a single multiset sum over `forestCutsN`. -/
+/-- `comulCForestN` as a single multiset sum over `forestCutsN`:
+    `comulForestNG_eq_sum` at the Δ^c enumeration. -/
 private theorem comulCForestN_eq_sum (τ : Nonplanar (α ⊕ β) → β)
     (F : Forest (Nonplanar (α ⊕ β))) :
-    comulCForestN (R := R) τ F = ((forestCutsN τ F).map (cutTensor (R := R))).sum := by
-  induction F using Multiset.induction with
-  | empty =>
-    rw [comulCForestN_zero, forestCutsN_zero, Multiset.map_singleton,
-        Multiset.sum_singleton]
-    show (1 : _) = ConnesKreimer.of' (R := R) (0 : Forest (Nonplanar (α ⊕ β))) ⊗ₜ[R]
-      ConnesKreimer.of' 0
-    rw [ConnesKreimer.of'_zero, Algebra.TensorProduct.one_def]
-  | cons T F ih =>
-    rw [show (T ::ₘ F : Forest (Nonplanar (α ⊕ β))) = {T} + F from
-          (Multiset.singleton_add T F).symm, comulCForestN_add]
-    rw [show comulCForestN (R := R) τ {T} = comulCTreeN τ T from by
-          unfold comulCForestN comulForestNG
-          rw [Multiset.map_singleton, Multiset.prod_singleton]; rfl,
-        comulCTreeN_eq_sum, ih]
-    rw [show ({T} + F : Forest (Nonplanar (α ⊕ β))) = T ::ₘ F from
-          (Multiset.singleton_add T F), forestCutsN_cons, Multiset.map_map]
-    rw [show (cutTensor (R := R) ∘ ConnesKreimer.combinerProjG) =
-          (fun p => cutTensor (R := R) p.1 * cutTensor p.2) from ?_]
-    · rw [Multiset.sum_map_product_mul]
-    · funext p
-      obtain ⟨⟨F1, m1⟩, ⟨F2, m2⟩⟩ := p
-      show cutTensor (R := R) (F1 + F2, m1 + m2) =
-        cutTensor (R := R) (F1, m1) * cutTensor (F2, m2)
-      unfold cutTensor
-      simp only [ConnesKreimer.of'_add, Algebra.TensorProduct.tmul_mul_tmul]
+    comulCForestN (R := R) τ F = ((forestCutsN τ F).map (cutTensor (R := R))).sum :=
+  comulForestNG_eq_sum _ F
 
 /-- LHS double-cut enumerator: outer cut of `T`, then re-cut its crown. -/
 private noncomputable def dcLHS (τ : Nonplanar (α ⊕ β) → β) (T : Nonplanar (α ⊕ β)) :
@@ -395,7 +355,7 @@ private def projPair (p : Forest (RoseTree (α ⊕ β)) × Forest (RoseTree (α 
 private theorem treeCutsN_mk (τ : Nonplanar (α ⊕ β) → β) (t : RoseTree (α ⊕ β)) :
     treeCutsN τ (Nonplanar.mk t)
       = (DoubleCut.treeCutsP (τ ∘ Nonplanar.mk) t).map projPair := by
-  unfold treeCutsN DoubleCut.treeCutsP
+  unfold treeCutsN treeCutsG DoubleCut.treeCutsP
   rw [cutSummandsCN_mk, Multiset.map_cons, Multiset.map_map, Multiset.map_map]
   congr 1
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/WithCuts.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/WithCuts.lean
@@ -1,4 +1,6 @@
+import Linglib.Core.Algebra.BigOperators.Multiset
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
+import Linglib.Core.Combinatorics.RootedTree.Cut
 import Linglib.Core.Data.RoseTree.Nonplanar
 import Mathlib.RingTheory.Bialgebra.Basic
 
@@ -28,6 +30,9 @@ serves every coproduct instead of one bespoke copy per Δ.
 
 * `comulTreeNG cuts` / `comulForestNG cuts` — the generic coproduct.
 * `comulAlgHomNG cuts` — packaged as an `AlgHom`.
+* `comulTreeNG_eq_sum` / `comulForestNG_eq_sum` — the coproduct as a single
+  sum over the cut convolutions `treeCutsG`/`forestCutsG`
+  (`Combinatorics/RootedTree/Cut.lean`).
 * `WithCuts R cuts` — the policy-indexed carrier, with `Bialgebra` gated
   on `IsAdmissibleCuts cuts`.
 -/
@@ -109,6 +114,61 @@ noncomputable def comulAlgHomNG
       show ({T} : Forest (Nonplanar α)) = T ::ₘ (0 : Forest (Nonplanar α)) from rfl,
       comulForestNG_cons, comulForestNG_zero, mul_one]
 
+/-! ### The generic coproduct as a sum over cut convolutions
+
+`treeCutsG`/`forestCutsG` (`Combinatorics/RootedTree/Cut.lean`) enumerate
+the (crown, trunk-forest) pairs of a tree and their convolution over a
+forest; `cutTensor` sends a pair to `of' crown ⊗ of' trunk`. These
+single-sum expansions serve the Δ^ρ cocycle substrate
+(`Coproduct/PruningNonplanar.lean`) and the Δ^c double-cut coassoc proof
+(`Coproduct/TraceNonplanar.lean`). -/
+
+/-- Tensor-product factor of a (crown, trunk) cut pair. -/
+noncomputable def cutTensor (p : Forest (Nonplanar α) × Forest (Nonplanar α)) :
+    ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α) :=
+  of' (R := R) p.1 ⊗ₜ[R] of' p.2
+
+/-- `cutTensor` is multiplicative over the cut convolution `combinerProjG`. -/
+theorem cutTensor_combinerProjG (p q : Forest (Nonplanar α) × Forest (Nonplanar α)) :
+    cutTensor (R := R) (combinerProjG (p, q)) = cutTensor p * cutTensor q := by
+  obtain ⟨F1, m1⟩ := p
+  obtain ⟨F2, m2⟩ := q
+  show cutTensor (R := R) (F1 + F2, m1 + m2) = _
+  unfold cutTensor
+  simp only [of'_add, Algebra.TensorProduct.tmul_mul_tmul]
+
+/-- `comulTreeNG` as a single multiset sum over `treeCutsG`. -/
+theorem comulTreeNG_eq_sum
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) :
+    comulTreeNG (R := R) cuts T =
+      ((treeCutsG cuts T).map (cutTensor (R := R))).sum := by
+  unfold comulTreeNG treeCutsG
+  rw [Multiset.map_cons, Multiset.sum_cons, Multiset.map_map]
+  congr 1
+
+/-- `comulForestNG` as a single multiset sum over `forestCutsG`. -/
+theorem comulForestNG_eq_sum
+    (cuts : Nonplanar α → Multiset (Forest (Nonplanar α) × Nonplanar α))
+    (F : Forest (Nonplanar α)) :
+    comulForestNG (R := R) cuts F =
+      ((forestCutsG cuts F).map (cutTensor (R := R))).sum := by
+  induction F using Multiset.induction with
+  | empty =>
+    rw [comulForestNG_zero, forestCutsG_zero, Multiset.map_singleton,
+        Multiset.sum_singleton]
+    show (1 : _) = of' (R := R) (0 : Forest (Nonplanar α)) ⊗ₜ[R] of' 0
+    rw [of'_zero, Algebra.TensorProduct.one_def]
+  | cons T F ih =>
+    rw [comulForestNG_cons, comulTreeNG_eq_sum, ih, forestCutsG_cons,
+        Multiset.map_map,
+        show (cutTensor (R := R) ∘ combinerProjG) =
+            (fun p => cutTensor (R := R) p.1 * cutTensor p.2) from by
+          funext p
+          obtain ⟨p₁, p₂⟩ := p
+          exact cutTensor_combinerProjG p₁ p₂,
+        Multiset.sum_map_product_mul]
+
 /-! ### The policy-indexed carrier `WithCuts`
 
 The `WithLp` pattern: a type synonym indexed by the cut policy, whose
@@ -116,6 +176,7 @@ The `WithLp` pattern: a type synonym indexed by the cut policy, whose
 carrier (`instBialgebraRho`, the Hopf algebra of
 [marcolli-chomsky-berwick-2025] Lemma 1.2.11); the marked variants live here. -/
 
+set_option linter.unusedVariables false in
 variable (R) in
 /-- Type synonym for `ConnesKreimer R (Nonplanar α)` carrying the generic
 admissible-cut coproduct at the fixed policy `cuts`. -/

--- a/Linglib/Core/Combinatorics/RootedTree/Cut.lean
+++ b/Linglib/Core/Combinatorics/RootedTree/Cut.lean
@@ -1266,6 +1266,91 @@ private theorem cutListSummandsG_proj_permList
     (cutListSummandsG_proj_permList hExt h₁).trans (cutListSummandsG_proj_permList hExt h₂)
 end
 
+/-! ### Generic cut convolution: `treeCutsG` and `forestCutsG`
+
+All cut summands of a tree as (crown forest, trunk forest) pairs — the
+full cut `({T}, 0)` plus each `cuts`-summand with a singleton trunk —
+and their `combinerProjG`-convolution over the trees of a forest. The
+generic coproduct expands as a single sum over these
+(`comulTreeNG_eq_sum`/`comulForestNG_eq_sum`, `Coproduct/WithCuts.lean`). -/
+
+/-- All cut summands of a tree as (crown, trunk-forest) pairs: the full
+    cut `({T}, 0)` plus each summand of `cuts T` with a singleton trunk. -/
+noncomputable def treeCutsG
+    (cuts : Nonplanar α → Multiset (Multiset (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) :
+    Multiset (Multiset (Nonplanar α) × Multiset (Nonplanar α)) :=
+  ({T}, 0) ::ₘ (cuts T).map (fun p => (p.1, {p.2}))
+
+/-- Convolution-of-cuts is left-commutative (it is the symmetric
+    `combinerProjG`); needed for `Multiset.foldr`. -/
+instance instLeftCommConvCut : LeftCommutative
+    (fun (s acc : Multiset (Multiset (Nonplanar α) × Multiset (Nonplanar α))) =>
+      (s ×ˢ acc).map combinerProjG) :=
+  ⟨fun a b c => swap_double_combinerProjG a b c⟩
+
+/-- Forest-level cut enumeration: `combinerProjG`-convolution of
+    `treeCutsG` over the component trees. -/
+noncomputable def forestCutsG
+    (cuts : Nonplanar α → Multiset (Multiset (Nonplanar α) × Nonplanar α))
+    (F : Multiset (Nonplanar α)) :
+    Multiset (Multiset (Nonplanar α) × Multiset (Nonplanar α)) :=
+  (F.map (treeCutsG cuts)).foldr
+    (fun s acc => (s ×ˢ acc).map combinerProjG) {(0, 0)}
+
+theorem forestCutsG_zero
+    (cuts : Nonplanar α → Multiset (Multiset (Nonplanar α) × Nonplanar α)) :
+    forestCutsG cuts (0 : Multiset (Nonplanar α)) = {(0, 0)} := by
+  unfold forestCutsG; simp
+
+theorem forestCutsG_cons
+    (cuts : Nonplanar α → Multiset (Multiset (Nonplanar α) × Nonplanar α))
+    (T : Nonplanar α) (F : Multiset (Nonplanar α)) :
+    forestCutsG cuts (T ::ₘ F) =
+      (treeCutsG cuts T ×ˢ forestCutsG cuts F).map combinerProjG := by
+  unfold forestCutsG
+  rw [Multiset.map_cons, Multiset.foldr_cons]
+
+/-- Mapping the head factor through the cartesian product commutes with a
+    final map. -/
+private theorem map_map_product_left {α' β' γ δ : Type*}
+    (f : α' → γ) (g : γ × β' → δ) (s : Multiset α') (t : Multiset β') :
+    ((s.map f) ×ˢ t).map g = (s ×ˢ t).map (fun p => g (f p.1, p.2)) := by
+  conv_lhs => rw [show s.map f ×ˢ t = (s ×ˢ t).map (Prod.map f id) from by
+    rw [map_prodMap_product_G, Multiset.map_id]]
+  rw [Multiset.map_map]
+  rfl
+
+/-- The Option-encoded per-tree decisions `augActionN` map onto the
+    forest-encoded `treeCutsG cutSummandsN` (`none` ↦ empty trunk,
+    `some` ↦ singleton trunk). -/
+private theorem treeCutsG_cutSummandsN (T : Nonplanar α) :
+    treeCutsG cutSummandsN T =
+      (augActionN T).map
+        (fun d => (d.1, d.2.elim 0 (fun r => ({r} : Multiset (Nonplanar α))))) := by
+  unfold treeCutsG augActionN
+  simp only [Multiset.map_cons, Multiset.map_map]
+  rfl
+
+/-- The Δ^ρ forest cut enumeration is the generic convolution at
+    `cuts := cutSummandsN`: `augActionN` (Option-encoded) and
+    `treeCutsG cutSummandsN` (forest-encoded) enumerate the same
+    per-tree decisions, and `innerCombinerProj` matches `combinerProjG`
+    across the encoding. -/
+theorem cutForestSummandsN_eq_forestCutsG (F : Multiset (Nonplanar α)) :
+    cutForestSummandsN F = forestCutsG cutSummandsN F := by
+  induction F using Multiset.induction with
+  | empty => rw [cutForestSummandsN_zero, forestCutsG_zero]
+  | cons T F ih =>
+    rw [cutForestSummandsN_cons, forestCutsG_cons, ← ih, treeCutsG_cutSummandsN,
+        map_map_product_left]
+    refine Multiset.map_congr rfl (fun p _ => ?_)
+    obtain ⟨⟨G, _ | r⟩, q1, q2⟩ := p
+    · show (G + q1, q2) = (G + q1, 0 + q2)
+      rw [zero_add]
+    · show (G + q1, r ::ₘ q2) = (G + q1, {r} + q2)
+      rw [Multiset.singleton_add]
+
 /-! ### Trace specialization
 
 The Δ^c policy `extractC (τ ∘ Nonplanar.mk)` is `ExtractInvariant`:


### PR DESCRIPTION
The `eq_sum` layer was proved twice in different encodings — Pruning via private extract/recurse branch helpers over the Option-encoded `cutForestSummandsN`, Trace via private `treeCutsN`/`forestCutsN` over `combinerProjG`.

- `Cut.lean` gains the generic enumeration `treeCutsG`/`forestCutsG` (with the `LeftCommutative` instance, moved from TraceNonplanar) and the encoding bridge `cutForestSummandsN_eq_forestCutsG`.
- `WithCuts.lean` gains `cutTensor` and the one proof: `comulTreeNG_eq_sum`/`comulForestNG_eq_sum`; both files' private machinery becomes definitional instantiations (Trace) or a two-line transport (Pruning). Also silences the pre-existing unused-binder warning on the `WithCuts` phantom parameter.
- `Deletion.lean`'s unrelated private Option-tolerant `cutTensor` renamed `optionCutTensor` to clear the namespace for the public one.