### PR TITLE
refactor(Core): drop alias wrappers and duplicate sum lemma

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Algebra.BigOperators.Multiset
 import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pairing
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
@@ -130,7 +131,7 @@ private lemma pairing₂_of'_of'_mul (A B : Forest (Nonplanar α))
                 (ConnesKreimer.of' pq.2.2) v₁))) from
         Multiset.map_congr rfl fun pq _ => by
           rw [pairing₂_tmul_tmul, pairing₂_tmul_tmul]; ring]
-      rw [sum_map_product_mul (Multiset.antidiagonal A)
+      rw [Multiset.sum_map_product_mul (Multiset.antidiagonal A)
           (Multiset.antidiagonal B)
           (fun pa => pairing (R := R)
               (ConnesKreimer.of' pa.1) u₂ *

--- a/Linglib/Core/Algebra/RootedTree/FormSet.lean
+++ b/Linglib/Core/Algebra/RootedTree/FormSet.lean
@@ -76,32 +76,7 @@ open scoped TensorProduct
 
 variable {R : Type*} [CommSemiring R] {α : Type*}
 
-/-! ## §1: The grafting operator `B` (MCB Def 1.3.2)
-
-In our typed `Nonplanar α` substrate, `B` needs a root label parameter.
-This is exactly the existing `bPlusLin a` (Hochschild 1-cocycle for
-Δ^ρ; reused here as the FormSet grafting operator). -/
-
-/-- The **grafting operator** `B` (MCB Def 1.3.2): create a new tree
-    with a fresh root labeled `a` and the forest `F` as children.
-
-    Identical to the smart constructor `Nonplanar.node a F`; this name
-    highlights the FormSet usage. -/
-noncomputable def graft (a : α) (F : Forest (Nonplanar α)) : Nonplanar α :=
-  Nonplanar.node a F
-
-/-- The **grafting operator linearly extended**: re-export `bPlusLin`
-    from `Pruning.lean` under the FormSet-flavored name. -/
-noncomputable def graftLin (a : α) :
-    ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
-  bPlusLin (R := R) a
-
-@[simp] theorem graftLin_of' (a : α) (F : Forest (Nonplanar α)) :
-    graftLin (R := R) a (of' F) = ofTree (graft a F) := by
-  show bPlusLin (R := R) a (of' F) = ofTree (Nonplanar.node a F)
-  exact bPlusLin_of' a F
-
-/-! ## §2: The primitive coproduct `Δ_P` (MCB Remark 1.16.2)
+/-! ### The primitive coproduct `Δ_P` (MCB Remark 1.16.2)
 
 `Δ_P` treats every basis tree as primitive: `Δ_P(T) = T ⊗ 1 + 1 ⊗ T`.
 Extended multiplicatively to forests by `Δ_P(F + G) = Δ_P(F) · Δ_P(G)`,
@@ -161,7 +136,7 @@ noncomputable def comulPrim :
   rw [Multiset.map_singleton, Multiset.prod_singleton]
   rfl
 
-/-! ## §3: The k-component projection `Π_(k)` (MCB book p. 142)
+/-! ### The k-component projection `Π_(k)` (MCB book p. 142)
 
 `γ_(k)(F) = F` if F has exactly `k` components, else 0. Linearly
 extended to `ConnesKreimer R (Nonplanar α)`. Then `Π_(k) = γ_(k) ⊗ id`
@@ -184,10 +159,11 @@ noncomputable def projectKComponent (k : ℕ) :
     projectKComponent (R := R) k (of' F) = 0 := by
   rw [projectKComponent, ConnesKreimer.linearLift_of', if_neg h]
 
-/-! ## §4: The FormSet operator `FS^(k)` (MCB Def 1.16.1)
+/-! ### The FormSet operator `FS^(k)` (MCB Def 1.16.1)
 
 `FS^(k) = ⊔ ∘ (B ⊗ id) ∘ Π_(k) ∘ Δ_P` where `⊔` is CK multiplication
-(lifted to a LinearMap from the tensor product). -/
+(lifted to a LinearMap from the tensor product) and the grafting
+operator `B` (MCB Def 1.3.2) is `bPlusLin` (`Coproduct/Pruning.lean`). -/
 
 /-- The CK multiplication as a LinearMap from `H ⊗ H → H`. -/
 noncomputable def mulLin :
@@ -206,25 +182,26 @@ noncomputable def mulLin :
 noncomputable def formSet (a : α) (k : ℕ) :
     ConnesKreimer R (Nonplanar α) →ₗ[R] ConnesKreimer R (Nonplanar α) :=
   mulLin (R := R) (α := α) ∘ₗ
-    ((graftLin (R := R) a).rTensor _) ∘ₗ
+    ((bPlusLin (R := R) a).rTensor _) ∘ₗ
     ((projectKComponent (R := R) k).rTensor _) ∘ₗ
     (comulPrim (R := R) (α := α)).toLinearMap
 
-/-! ## §5: Basic API + sanity tests -/
+/-! ### Basic API + sanity tests -/
 
 @[simp] theorem formSet_apply (a : α) (k : ℕ) (x : ConnesKreimer R (Nonplanar α)) :
     formSet (R := R) a k x =
-      mulLin (((graftLin (R := R) a).rTensor _)
+      mulLin (((bPlusLin (R := R) a).rTensor _)
         (((projectKComponent (R := R) k).rTensor _) (comulPrim x))) := rfl
 
 /-- On a singleton tree `T`, `Δ_P(T) = T ⊗ 1 + 1 ⊗ T`. The left channel
     has cardinality 1 (`{T}.card`) and cardinality 0 (empty forest).
     For `k = 1`, only the `T ⊗ 1` summand survives Π_(1); grafting gives
-    `ofTree (graft a {T}) ⊗ 1`, and `⊔` produces `ofTree (graft a {T})`. -/
+    `ofTree (Nonplanar.node a {T}) ⊗ 1`, and `⊔` produces
+    `ofTree (Nonplanar.node a {T})`. -/
 example (a : α) (T : Nonplanar α) :
     formSet (R := R) a 1 (ofTree T) =
-      ofTree (graft a ({T} : Forest (Nonplanar α))) := by
-  show mulLin (((graftLin (R := R) a).rTensor _)
+      ofTree (Nonplanar.node a ({T} : Forest (Nonplanar α))) := by
+  show mulLin (((bPlusLin (R := R) a).rTensor _)
         (((projectKComponent (R := R) 1).rTensor _) (comulPrim (ofTree T)))) = _
   rw [comulPrim_apply_ofTree]
   -- Distribute rTensor / mulLin over the sum and reduce.
@@ -239,8 +216,8 @@ example (a : α) (T : Nonplanar α) :
   simp only [map_add, LinearMap.rTensor_tmul, h1, h0,
              TensorProduct.zero_tmul, add_zero, mulLin,
              LinearMap.mul'_apply, mul_one]
-  -- Bridge `graftLin a (ofTree T) = ofTree (graft a {T})` via `ofTree T = of' {T}`.
-  show graftLin (R := R) a (of' ({T} : Forest (Nonplanar α))) = _
+  -- Bridge via `ofTree T = of' {T}`.
+  show bPlusLin (R := R) a (of' ({T} : Forest (Nonplanar α))) = _
   exact bPlusLin_of' a ({T} : Forest (Nonplanar α))
 
 end ConnesKreimer

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -61,31 +61,14 @@ torsion subtleties when |Aut(F)| = 0 or non-invertible).
 
 `[UPSTREAM]` candidate. Sorry-free, including `pairing_nondegenerate`.
 The aut-cardinality substrate `Nonplanar.autCard` /
-`Nonplanar.forestAutCard` lives in
-`Linglib/Core/Combinatorics/RootedTree/Aut.lean` (re-exported here as
-`treeAutCard` / `forestAutCard`), also sorry-free.
+`Nonplanar.forestAutCard` (the symmetry weight in the pairing) lives in
+`Linglib/Core/Combinatorics/RootedTree/Aut.lean`, also sorry-free.
 -/
 
 
 namespace GrossmanLarson
 
 variable {R : Type*} [CommSemiring R] {α : Type*} [DecidableEq α]
-
-/-! ### Automorphism count
-
-The cardinality of the automorphism group of a rooted nonplanar tree
-(or forest) is the symmetry weight in the pairing. The actual
-substrate for these is in
-`Linglib/Core/Combinatorics/RootedTree/Aut.lean` — re-exported here
-under the `GrossmanLarson` namespace for use in the pairing. -/
-
-/-- Re-export `Nonplanar.autCard` for use in the pairing. -/
-noncomputable def treeAutCard (t : Nonplanar α) : ℕ :=
-  Nonplanar.autCard t
-
-/-- Re-export `Nonplanar.forestAutCard` for use in the pairing. -/
-noncomputable def forestAutCard (F : Forest (Nonplanar α)) : ℕ :=
-  Nonplanar.forestAutCard F
 
 /-! ### The bilinear pairing -/
 

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonSplit.lean
@@ -1,3 +1,4 @@
+import Linglib.Core.Algebra.BigOperators.Multiset
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 
@@ -665,20 +666,6 @@ theorem _root_.RoseTree.Nonplanar.insertionMultiset_antidiagonal
 
 /-! ### Generic sum/product plumbing -/
 
-/-- Sum of a product-indexed multiset of products factors. -/
-theorem sum_map_product_mul {β γ : Type*} (s : Multiset β) (t : Multiset γ)
-    (f : β → R) (g : γ → R) :
-    ((s ×ˢ t).map (fun p => f p.1 * g p.2)).sum = (s.map f).sum * (t.map g).sum := by
-  induction s using Multiset.induction_on with
-  | empty => simp only [Multiset.zero_product, Multiset.map_zero, Multiset.sum_zero,
-      zero_mul]
-  | cons a s ih =>
-    rw [Multiset.cons_product, Multiset.map_add, Multiset.sum_add, ih,
-        Multiset.map_map, Multiset.map_cons, Multiset.sum_cons, add_mul]
-    congr 1
-    rw [show ((fun p : β × γ => f p.1 * g p.2) ∘ Prod.mk a) = fun b => f a * g b from rfl,
-        Multiset.sum_map_mul_left]
-
 /-- `(s ×ˢ t).bind F = s.bind (a ↦ t.bind (b ↦ F (a, b)))`. -/
 private theorem product_bind {β γ δ : Type*} (s : Multiset β) (t : Multiset γ)
     (F : β × γ → Multiset δ) :
@@ -1027,7 +1014,7 @@ theorem pairing_product_of'_mul_of' (A B C₁ C₂ : Forest (Nonplanar α)) :
   refine Multiset.map_congr rfl fun pq _ => ?_
   show ((productIdx pq.1.1 pq.2.1 ×ˢ productIdx pq.1.2 pq.2.2).map φ).sum = _
   rw [hφ]
-  rw [sum_map_product_mul (productIdx pq.1.1 pq.2.1) (productIdx pq.1.2 pq.2.2)
+  rw [Multiset.sum_map_product_mul (productIdx pq.1.1 pq.2.1) (productIdx pq.1.2 pq.2.2)
       (fun W => pairing (R := R) (ConnesKreimer.of' W) (ConnesKreimer.of' C₁))
       (fun W => pairing (R := R) (ConnesKreimer.of' W) (ConnesKreimer.of' C₂))]
   rw [← pairing_product_of'_expand, ← pairing_product_of'_expand]


### PR DESCRIPTION
Algebra/RootedTree alias sweep (cone-built clean).

- Delete `GrossmanLarson.treeAutCard`/`forestAutCard` re-exports of `Nonplanar.autCard`/`forestAutCard` (the former was also a name collision with Aut.lean's planar `treeAutCard`, and had zero uses); bare references re-resolve through `open RoseTree.Nonplanar` with no churn.
- Delete `GrossmanLarsonSplit.sum_map_product_mul`, a duplicate of `Multiset.sum_map_product_mul`; consumers qualified.
- Delete FormSet's `graft`/`graftLin`/`graftLin_of'` aliases of `Nonplanar.node`/`bPlusLin`; fix its `## §N`-style section headers while there.