### PR TITLE
refactor(Core/Algebra/RootedTree): Foissy coassociativity for Δ^ρ

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
@@ -2,6 +2,7 @@ import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
 import Linglib.Core.Combinatorics.RootedTree.Cut
 import Linglib.Core.Data.RoseTree.Nonplanar
 import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.RingTheory.Bialgebra.Basic
 import Mathlib.RingTheory.TensorProduct.Maps
 
 open RoseTree RoseTree.Nonplanar
@@ -33,6 +34,11 @@ deletes cut subtrees outright, unlike the trace variant Δ^c
   1-cocycle law `Δ^ρ ∘ B+_a = B+_a ⊗ 1 + (id ⊗ B+_a) ∘ Δ^ρ`.
 * `ConnesKreimer.counit_rTensor_comulAlgHomN`,
   `ConnesKreimer.counit_lTensor_comulAlgHomN` — the counit laws.
+* `ConnesKreimer.comulAlgHomN_coassoc_algHom`, `comulRhoN_coassoc` —
+  coassociativity, by Foissy's subalgebra argument
+  ([foissy-introduction-hopf-algebras-trees]; [grinberg-reiner-2020]).
+* `ConnesKreimer.instBialgebraRho` — the Δ^ρ `Bialgebra`
+  ([marcolli-chomsky-berwick-2025] Lemma 1.2.11), over any `CommSemiring`.
 
 ## Implementation notes
 
@@ -43,10 +49,10 @@ at the `Nonplanar` level. The clean-coassoc route through the cocycle
 does not generalize to Δ^c (B+ is not a 1-cocycle for the trace
 variant, which instead uses the direct double-cut bijection).
 
-Coassociativity and the `Bialgebra` instance live downstream in
-`Coproduct/PruningDuality.lean` (the GL/CK duality proof needs the B⁻
-calculus of `BMinus.lean`, which imports this file); the full
-`HopfAlgebra` instance is in `HopfAlgebra.lean`.
+The GL/CK duality theorem lives downstream in
+`Coproduct/PruningDuality.lean` (its proof needs the B⁻ calculus of
+`BMinus.lean`, which imports this file); the full `HopfAlgebra`
+instance is in `HopfAlgebra.lean`.
 
 ## Status
 
@@ -429,12 +435,408 @@ theorem counit_lTensor_comulAlgHomN :
   rw [comulAlgHomN_apply_of', Algebra.TensorProduct.rid_symm_apply]
   exact comulForestN_counit_lTensor F (fun T _ => comulTreeN_counit_lTensor T)
 
-/-! ### Δ^ρ coassoc and Bialgebra instance: moved
+section CoassocFoissy
+-- The nested tensor squares `CK ⊗ (CK ⊗ CK)` of the coassociativity statement
+-- need one extra pending step during instance synthesis.
+set_option maxSynthPendingDepth 2
 
-The GL/CK duality theorem (`pairing_gl_eq_pairing_coproduct_Rho`), the
-coassociativity of `comulAlgHomN`, and the `Bialgebra` instance live in
+/-! ### Coassociativity: Foissy's subalgebra argument
+
+Foissy's clean proof ([foissy-introduction-hopf-algebras-trees]; for the
+connected-graded-bialgebra framing see [grinberg-reiner-2020]): the set
+`A := {x | (id ⊗ Δ)(Δ x) = assoc ((Δ ⊗ id)(Δ x))}` is a subalgebra, closed
+under `B+_a` by the Hochschild cocycle, and contains every `ofTree T` by
+depth induction — hence `A = ⊤`. Works over any `CommSemiring`, with no
+pairing or nondegeneracy input. -/
+
+/-- The "compute coassociativity left-hand side" algebra hom:
+    `x ↦ assoc((Δ ⊗ id)(Δ x))`. -/
+noncomputable def coassocLHS :
+    ConnesKreimer R (Nonplanar α) →ₐ[R]
+      ConnesKreimer R (Nonplanar α) ⊗[R]
+        (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :=
+  (Algebra.TensorProduct.assoc R R R _ _ _).toAlgHom.comp
+    ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+      (AlgHom.id R _)).comp comulAlgHomN)
+
+/-- The "compute coassociativity right-hand side" algebra hom:
+    `x ↦ (id ⊗ Δ)(Δ x)`. -/
+noncomputable def coassocRHS :
+    ConnesKreimer R (Nonplanar α) →ₐ[R]
+      ConnesKreimer R (Nonplanar α) ⊗[R]
+        (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :=
+  (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+    (comulAlgHomN (R := R) (α := α))).comp comulAlgHomN
+
+/-- The **Foissy coassociativity subalgebra**: elements where the two
+    sides of coassociativity agree. By Foissy's clean argument
+    (`coassocSubalg_eq_top`), this is all of `H`. -/
+noncomputable def coassocSubalg : Subalgebra R (ConnesKreimer R (Nonplanar α)) :=
+  AlgHom.equalizer (coassocLHS (R := R) (α := α)) coassocRHS
+
+theorem mem_coassocSubalg (x : ConnesKreimer R (Nonplanar α)) :
+    x ∈ coassocSubalg (R := R) (α := α) ↔ coassocLHS x = coassocRHS x :=
+  AlgHom.mem_equalizer _ _ _
+
+/-! ### Linear extension of the cocycle
+
+The cocycle `comulAlgHomN_bPlusLin_cocycle` is stated for `of' F`. Since
+both sides are R-linear in `x : H`, it extends to arbitrary `x` via
+`ConnesKreimer.lhom_ext` (all linear maps out of `H = R[Forest]` are determined
+by their action on basis vectors `of' F = ConnesKreimer.single F 1`). -/
+
+/-- The cocycle, extended to arbitrary `x : H` via linearity. -/
+theorem comulAlgHomN_bPlusLin_cocycle_general (a : α)
+    (x : ConnesKreimer R (Nonplanar α)) :
+    comulAlgHomN (bPlusLin (R := R) a x) =
+      bPlusLin (R := R) a x ⊗ₜ[R] (1 : ConnesKreimer R (Nonplanar α)) +
+      (LinearMap.lTensor _ (bPlusLin (R := R) a)) (comulAlgHomN x) := by
+  -- LHS and RHS are both R-linear in x. Reduce to checking on ConnesKreimer.single F r
+  -- (= r • of' F), then to F = of' F (r = 1) via scalar linearity, then apply cocycle.
+  have heq :
+      ((comulAlgHomN (R := R) (α := α)).toLinearMap.comp (bPlusLin (R := R) a) :
+        ConnesKreimer R (Nonplanar α) →ₗ[R]
+          ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) =
+      ((TensorProduct.mk R _ _).flip 1).comp (bPlusLin (R := R) a) +
+      (LinearMap.lTensor _ (bPlusLin (R := R) a)).comp
+        (comulAlgHomN (R := R) (α := α)).toLinearMap := by
+    apply ConnesKreimer.lhom_ext
+    intro F r
+    -- Convert single F r to r • of' F, then use cocycle. Use `change` to force the
+    -- smul to elaborate via Module instance (matching what map_smul expects), avoiding
+    -- the SMulZeroClass mismatch.
+    show comulAlgHomN.toLinearMap (bPlusLin a (ConnesKreimer.single F r)) =
+         (TensorProduct.mk R _ _).flip 1 (bPlusLin a (ConnesKreimer.single F r)) +
+         LinearMap.lTensor _ (bPlusLin a) (comulAlgHomN.toLinearMap (ConnesKreimer.single F r))
+    have hr : ConnesKreimer.single F r = (r : R) • (of' F : ConnesKreimer R (Nonplanar α)) := ConnesKreimer.smul_single_one F r
+    rw [hr]
+    -- Force re-elaboration through Module-flavored smul:
+    change comulAlgHomN.toLinearMap (bPlusLin a ((r : R) • (of' F : ConnesKreimer R (Nonplanar α)))) =
+           (TensorProduct.mk R _ _).flip 1
+              (bPlusLin a ((r : R) • (of' F : ConnesKreimer R (Nonplanar α)))) +
+           LinearMap.lTensor _ (bPlusLin a)
+              (comulAlgHomN.toLinearMap ((r : R) • (of' F : ConnesKreimer R (Nonplanar α))))
+    rw [(bPlusLin (R := R) a).map_smul,
+        (comulAlgHomN (R := R) (α := α)).toLinearMap.map_smul,
+        AlgHom.toLinearMap_apply, AlgHom.toLinearMap_apply,
+        comulAlgHomN_bPlusLin_cocycle, smul_add, TensorProduct.smul_tmul']
+    -- Now match the second summand on both sides:
+    --   r • (lTensor _ (bPlusLin a)) (comulAlgHomN (of' F))
+    --   = (lTensor _ (bPlusLin a)) (comulAlgHomN (r • of' F))
+    -- via map_smul on comulAlgHomN and lTensor in turn.
+    simp only [LinearMap.flip_apply, TensorProduct.mk_apply]
+    congr 1
+    -- Now isolate the r-smul mismatch: (lTensor _ ...) (r • _) vs r • (lTensor _ ...) _.
+    change (r : R) • (LinearMap.lTensor _ (bPlusLin (R := R) a))
+              (comulAlgHomN (of' F)) =
+           (LinearMap.lTensor _ (bPlusLin (R := R) a))
+              (comulAlgHomN ((r : R) • (of' F : ConnesKreimer R (Nonplanar α))))
+    rw [_root_.map_smul (comulAlgHomN (R := R) (α := α)), (LinearMap.lTensor _ (bPlusLin (R := R) a)).map_smul]
+  exact congr($heq x)
+
+/-! ### Closure of `coassocSubalg` under `B+_a`
+
+The substantive Foissy bit. Uses the cocycle (twice) plus tensor-algebra
+calculations. Sketch (Sweedler-style, with `Δ x = Σᵢ aᵢ ⊗ bᵢ`):
+
+* `Δ(B+_a x) = (B+_a x) ⊗ 1 + Σᵢ aᵢ ⊗ B+_a bᵢ` (cocycle).
+* `(Δ ⊗ id)(Δ(B+_a x)) = Δ(B+_a x) ⊗ 1 + Σᵢ Δ(aᵢ) ⊗ B+_a bᵢ`. Re-apply cocycle to
+  `Δ(B+_a x)` to expand the first summand.
+* `assoc((Δ ⊗ id)(Δ(B+_a x))) = (B+_a x) ⊗ (1 ⊗ 1) + Σᵢ aᵢ ⊗ (B+_a bᵢ ⊗ 1) +
+  Σᵢ assoc(Δ(aᵢ) ⊗ B+_a bᵢ)`.
+* `(id ⊗ Δ)(Δ(B+_a x)) = (B+_a x) ⊗ (1 ⊗ 1) + Σᵢ aᵢ ⊗ (B+_a bᵢ ⊗ 1) +
+  Σᵢ aᵢ ⊗ ((id ⊗ B+_a)(Δ bᵢ))`.
+* The "shared" first two summands match by inspection. The third summands match via
+  `(id ⊗ id ⊗ B+_a)` applied to the hypothesis `assoc((Δ ⊗ id)(Δ x)) = (id ⊗ Δ)(Δ x)`.
+
+A clean Lean implementation would extract a `LinearMap`-level helper
+`assoc_lTensor_bPlus_eq : assoc ∘ (Δ ⊗ id) ∘ (id ⊗ B+_a) = (id ⊗ id ⊗ B+_a) ∘ assoc ∘ (Δ ⊗ id)`
+(provable by `TensorProduct.induction_on`), then close by `congrArg ((id ⊗ id ⊗ B+_a))` on `hx`. -/
+/-! ### Helper commutations for the bPlus closure proof
+
+Three commutation/identity lemmas for the substantive Foissy bit:
+
+* `comulAlgHomN_lTensor_bPlus_commute`: `(Δ ⊗ id) ∘ (id ⊗ B+) = (id ⊗ id ⊗ B+) ∘ (Δ ⊗ id)`,
+  i.e., the comul on the left factor commutes with B+ on the right factor.
+* `assoc_lTensor_bPlus_commute`: `assoc ∘ (id ⊗ id_R ⊗ B+ on (H⊗H)⊗H) =
+  (id ⊗ id ⊗ B+ on H⊗(H⊗H)) ∘ assoc`, i.e., the associator commutes with B+
+  acting on the rightmost factor.
+* `lTensor_id_Δ_bPlus_eq`: `(id ⊗ Δ) ∘ (id ⊗ B+) z = assoc((id ⊗ B+)(z) ⊗ 1) +
+  (id ⊗ id ⊗ B+) ∘ (id ⊗ Δ)(z)`, by cocycle on the right factor of `(id ⊗ B+)(z)`. -/
+
+private theorem comulAlgHomN_lTensor_bPlus_commute (a : α)
+    (z : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    (Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+        (AlgHom.id R (ConnesKreimer R (Nonplanar α))))
+      ((LinearMap.lTensor _ (bPlusLin (R := R) a)) z) =
+    (LinearMap.lTensor _ (bPlusLin (R := R) a))
+      ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+        (AlgHom.id R (ConnesKreimer R (Nonplanar α)))) z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => rw [map_zero, map_zero, map_zero]
+  | tmul x y =>
+    rw [LinearMap.lTensor_tmul, Algebra.TensorProduct.map_tmul,
+        Algebra.TensorProduct.map_tmul, AlgHom.id_apply, AlgHom.id_apply,
+        LinearMap.lTensor_tmul]
+  | add z₁ z₂ ih₁ ih₂ => rw [map_add, map_add, ih₁, ih₂, map_add, map_add]
+
+private theorem assoc_lTensor_bPlus_commute (a : α)
+    (z : (ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) ⊗[R]
+          ConnesKreimer R (Nonplanar α)) :
+    (Algebra.TensorProduct.assoc R R R (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α)) (ConnesKreimer R (Nonplanar α)))
+      ((LinearMap.lTensor _ (bPlusLin (R := R) a)) z) =
+    (LinearMap.lTensor _ (LinearMap.lTensor _ (bPlusLin (R := R) a)))
+      ((Algebra.TensorProduct.assoc R R R (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α)) (ConnesKreimer R (Nonplanar α))) z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul w c =>
+    -- w : H ⊗ H, c : H. Need to induct on w to expose the (a ⊗ b) ⊗ c form.
+    induction w using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x y =>
+      rw [LinearMap.lTensor_tmul, Algebra.TensorProduct.assoc_tmul,
+          Algebra.TensorProduct.assoc_tmul, LinearMap.lTensor_tmul,
+          LinearMap.lTensor_tmul]
+    | add w₁ w₂ ih₁ ih₂ =>
+      simp only [TensorProduct.add_tmul, map_add]
+      rw [ih₁, ih₂]
+  | add z₁ z₂ ih₁ ih₂ =>
+    simp only [map_add]
+    rw [ih₁, ih₂]
+
+private theorem lTensor_id_Δ_bPlus_eq (a : α)
+    (z : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+        (comulAlgHomN (R := R) (α := α)))
+      ((LinearMap.lTensor _ (bPlusLin (R := R) a)) z) =
+    (Algebra.TensorProduct.assoc R R R (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α)) (ConnesKreimer R (Nonplanar α)))
+      ((LinearMap.lTensor _ (bPlusLin (R := R) a) z) ⊗ₜ
+        (1 : ConnesKreimer R (Nonplanar α))) +
+    (LinearMap.lTensor _ (LinearMap.lTensor _ (bPlusLin (R := R) a)))
+      ((Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+        (comulAlgHomN (R := R) (α := α))) z) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul x y =>
+    -- LHS: (map id Δ)((lTensor B+a)(x ⊗ y)) = (map id Δ)(x ⊗ B+a y) = x ⊗ Δ(B+a y)
+    --    = x ⊗ ((B+a y) ⊗ 1 + (lTensor B+a)(Δ y)) = x ⊗ ((B+a y) ⊗ 1) + x ⊗ (lTensor B+a)(Δ y)
+    -- RHS: assoc((x ⊗ B+a y) ⊗ 1) + (lTensor (lTensor B+a))(x ⊗ Δy)
+    --    = x ⊗ ((B+a y) ⊗ 1) + x ⊗ (lTensor B+a)(Δ y)
+    -- ✓ by simp with all the relevant tmul + cocycle lemmas.
+    simp only [LinearMap.lTensor_tmul, Algebra.TensorProduct.map_tmul,
+               Algebra.TensorProduct.assoc_tmul, AlgHom.id_apply,
+               comulAlgHomN_bPlusLin_cocycle_general, TensorProduct.tmul_add]
+  | add z₁ z₂ ih₁ ih₂ =>
+    simp only [map_add, TensorProduct.add_tmul]
+    rw [ih₁, ih₂]
+    abel
+
+theorem bPlus_mem_coassocSubalg (a : α) (x : ConnesKreimer R (Nonplanar α))
+    (hx : x ∈ coassocSubalg (R := R) (α := α)) :
+    bPlusLin (R := R) a x ∈ coassocSubalg (R := R) (α := α) := by
+  rw [mem_coassocSubalg] at hx ⊢
+  -- The proof structure: express both `coassocLHS (B+_a x)` and `coassocRHS (B+_a x)`
+  -- in the form `shared + (lTensor H (lTensor H B+_a))(coassocXXX x)` with the
+  -- *same* shared part, then use hx (coassocLHS x = coassocRHS x) to conclude.
+  --
+  -- shared := (B+_a x) ⊗ (1 ⊗ 1) + assoc(((lTensor H B+_a)(Δ x)) ⊗ 1)
+  show (Algebra.TensorProduct.assoc R R R _ _ _)
+        ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+          (AlgHom.id R _)) (comulAlgHomN (bPlusLin (R := R) a x))) =
+       (Algebra.TensorProduct.map (AlgHom.id R _)
+          (comulAlgHomN (R := R) (α := α))) (comulAlgHomN (bPlusLin (R := R) a x))
+  -- Apply cocycle on x: Δ(B+_a x) = (B+_a x) ⊗ 1 + (lTensor _ B+_a)(Δ x).
+  rw [comulAlgHomN_bPlusLin_cocycle_general]
+  -- Distribute (map ⊗ id), (map id ⊗ ·), assoc through the addition.
+  rw [map_add, map_add, map_add]
+  -- LHS first term: assoc((map Δ id)(Bx ⊗ 1)) = assoc(Δ(Bx) ⊗ 1)
+  --                  = assoc(((Bx ⊗ 1) + (lTensor _ B+a)(Δx)) ⊗ 1) [cocycle on Bx]
+  --                  = assoc((Bx ⊗ 1) ⊗ 1) + assoc(((lTensor _ B+a)(Δx)) ⊗ 1)
+  --                  = Bx ⊗ (1 ⊗ 1) + assoc(((lTensor _ B+a)(Δx)) ⊗ 1)
+  rw [show (Algebra.TensorProduct.assoc R R R _ _ _)
+        ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+          (AlgHom.id R _)) (bPlusLin (R := R) a x ⊗ₜ
+            (1 : ConnesKreimer R (Nonplanar α)))) =
+      (bPlusLin (R := R) a x) ⊗ₜ ((1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ
+        (1 : ConnesKreimer R (Nonplanar α))) +
+      (Algebra.TensorProduct.assoc R R R _ _ _)
+        ((LinearMap.lTensor _ (bPlusLin (R := R) a))
+          (comulAlgHomN x) ⊗ₜ (1 : ConnesKreimer R (Nonplanar α))) from by
+    rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply,
+        comulAlgHomN_bPlusLin_cocycle_general, TensorProduct.add_tmul, map_add,
+        Algebra.TensorProduct.assoc_tmul]]
+  -- LHS second term: use Δ⊗id-vs-id⊗B+a commutation, then assoc-vs-B+a commutation.
+  rw [comulAlgHomN_lTensor_bPlus_commute, assoc_lTensor_bPlus_commute]
+  -- RHS first term: (map id Δ)(Bx ⊗ 1) = Bx ⊗ Δ(1) = Bx ⊗ (1 ⊗ 1).
+  rw [show (Algebra.TensorProduct.map (AlgHom.id R _)
+            (comulAlgHomN (R := R) (α := α)))
+          (bPlusLin (R := R) a x ⊗ₜ (1 : ConnesKreimer R (Nonplanar α))) =
+        (bPlusLin (R := R) a x) ⊗ₜ
+          ((1 : ConnesKreimer R (Nonplanar α)) ⊗ₜ
+            (1 : ConnesKreimer R (Nonplanar α))) from by
+    rw [Algebra.TensorProduct.map_tmul, AlgHom.id_apply, map_one,
+        Algebra.TensorProduct.one_def]]
+  -- RHS second term: use cocycle-driven identity `lTensor_id_Δ_bPlus_eq`.
+  rw [lTensor_id_Δ_bPlus_eq]
+  -- Now both sides are `Bx ⊗ (1⊗1) + assoc(...) + (lTensor (lTensor B+a))(coassocXXX_inner x)`,
+  -- modulo associativity. Use hx (coassocLHS x = coassocRHS x — defeq to the inner forms)
+  -- to bridge the two third summands; then `abel` for reordering.
+  have hlift : (LinearMap.lTensor _ (LinearMap.lTensor _ (bPlusLin (R := R) a)))
+                ((Algebra.TensorProduct.assoc R R R _ _ _)
+                  ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+                    (AlgHom.id R _)) (comulAlgHomN x))) =
+              (LinearMap.lTensor _ (LinearMap.lTensor _ (bPlusLin (R := R) a)))
+                ((Algebra.TensorProduct.map (AlgHom.id R _)
+                  (comulAlgHomN (R := R) (α := α))) (comulAlgHomN x)) :=
+    congrArg _ hx
+  rw [hlift]
+  abel
+
+/-! ### Tree induction: every `ofTree T` is in `coassocSubalg` -/
+
+/-- Helper: `of' F` is in `coassocSubalg` whenever every `ofTree T` for `T ∈ F` is.
+    By Multiset.induction on F using `of'_singleton`, `of'_zero`, `of'_add`, plus
+    subalgebra closure under * and 1. -/
+private theorem of'_mem_coassocSubalg_of_trees (F : Forest (Nonplanar α))
+    (h : ∀ T ∈ F, ofTree T ∈ coassocSubalg (R := R) (α := α)) :
+    of' (R := R) F ∈ coassocSubalg (R := R) (α := α) := by
+  induction F using Multiset.induction with
+  | empty =>
+    rw [show ((0 : Forest (Nonplanar α)) : Forest (Nonplanar α)) = (0 : Forest (Nonplanar α)) from rfl,
+        of'_zero]
+    exact one_mem _
+  | cons T F' ih =>
+    have hT : ofTree T ∈ coassocSubalg (R := R) (α := α) := h T (Multiset.mem_cons_self T F')
+    have hF' : ∀ T' ∈ F', ofTree T' ∈ coassocSubalg (R := R) (α := α) :=
+      fun T' hT' => h T' (Multiset.mem_cons_of_mem hT')
+    have ih' := ih hF'
+    rw [show ((T ::ₘ F') : Forest (Nonplanar α)) = ({T} + F') from rfl, of'_add, of'_singleton]
+    exact mul_mem hT ih'
+
+/-- Every Nonplanar tree's `ofTree` lies in `coassocSubalg`. By strong
+    induction on tree depth: leaves are `B+_a 1` (closed under `B+_a` from `1`);
+    nodes are `B+_a (of' F)` where `of' F` is a product of `ofTree` of smaller-depth
+    trees. -/
+theorem ofTree_mem_coassocSubalg (T : Nonplanar α) :
+    ofTree T ∈ coassocSubalg (R := R) (α := α) := by
+  -- Strong induction on T.depth.
+  suffices aux : ∀ n : ℕ, ∀ T : Nonplanar α, T.depth = n →
+      ofTree T ∈ coassocSubalg (R := R) (α := α) by
+    exact aux T.depth T rfl
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n IH =>
+    intro T hT
+    -- Pick a planar rep T = mk (RoseTree.node a children).
+    obtain ⟨T₀, rfl⟩ : ∃ T₀ : RoseTree α, T = Nonplanar.mk T₀ :=
+      ⟨Quotient.out T, (Quotient.out_eq T).symm⟩
+    obtain ⟨a, children⟩ := T₀
+    -- T = mk (.node a children) = Nonplanar.node a (Multiset.ofList (children.map mk))
+    rw [show (Nonplanar.mk (RoseTree.node a children) : Nonplanar α) =
+        Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk))
+        from (Nonplanar.node_mk_tree_list a children).symm]
+    -- ofTree (Nonplanar.node a F) = bPlusLin a (of' F) by bPlusLin_of'.
+    rw [show ofTree (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk)))
+            = bPlusLin (R := R) a (of' (Multiset.ofList (children.map Nonplanar.mk)))
+            from (bPlusLin_of' a _).symm]
+    apply bPlus_mem_coassocSubalg
+    -- of' F ∈ coassocSubalg, where F = Multiset.ofList (children.map mk).
+    apply of'_mem_coassocSubalg_of_trees
+    intro T' hT'
+    -- T' ∈ Multiset.ofList (children.map mk). Use IH on T'.depth < (mk (.node a children)).depth.
+    have hT'_depth : T'.depth < (Nonplanar.mk (RoseTree.node a children)).depth := by
+      have := Nonplanar.depth_lt_of_mem T'
+        (Multiset.ofList (children.map Nonplanar.mk)) hT' a
+      rw [show (Nonplanar.node a (Multiset.ofList (children.map Nonplanar.mk)) : Nonplanar α) =
+          Nonplanar.mk (RoseTree.node a children) from
+          Nonplanar.node_mk_tree_list a children] at this
+      exact this
+    rw [hT] at hT'_depth
+    exact IH T'.depth hT'_depth T' rfl
+
+/-! ### `coassocSubalg = ⊤`
+
+Since `H` is generated as an algebra by `{ofTree T | T : Nonplanar α}` and
+each generator is in `coassocSubalg`, the subalgebra is the whole thing. -/
+
+theorem coassocSubalg_eq_top :
+    coassocSubalg (R := R) (α := α) = ⊤ := by
+  rw [eq_top_iff]
+  intro x _
+  -- Induct on x; each piece is in coassocSubalg.
+  refine ConnesKreimer.induction_linear x ?_ ?_ ?_
+  · exact zero_mem _
+  · intro f g hf hg
+    exact add_mem hf hg
+  · intro F r
+    -- ConnesKreimer.single F r = r • of' F ∈ coassocSubalg via algebraMap.
+    show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) ∈ _
+    rw [show (ConnesKreimer.single F r : ConnesKreimer R (Nonplanar α)) = r • of' F from
+        ConnesKreimer.smul_single_one F r]
+    exact Subalgebra.smul_mem _ (of'_mem_coassocSubalg_of_trees F
+      (fun T _ => ofTree_mem_coassocSubalg T)) r
+
+/-! ### Coassociativity at the algebra-hom level
+
+Direct corollary: `coassocLHS = coassocRHS` as algebra homs. The
+`Bialgebra.ofAlgHom` constructor takes this in its unfolded form
+(without going through the `coassocLHS`/`coassocRHS` named bundles),
+so we expose both. -/
+
+theorem coassocLHS_eq_coassocRHS :
+    coassocLHS (R := R) (α := α) = coassocRHS := by
+  ext x
+  have h : x ∈ coassocSubalg (R := R) (α := α) := by
+    rw [coassocSubalg_eq_top]; trivial
+  exact (mem_coassocSubalg x).mp h
+
+theorem comulAlgHomN_coassoc_algHom :
+    (Algebra.TensorProduct.assoc R R R (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α)) (ConnesKreimer R (Nonplanar α))).toAlgHom.comp
+      ((Algebra.TensorProduct.map (comulAlgHomN (R := R) (α := α))
+        (AlgHom.id R _)).comp comulAlgHomN) =
+    (Algebra.TensorProduct.map (AlgHom.id R (ConnesKreimer R (Nonplanar α)))
+      (comulAlgHomN (R := R) (α := α))).comp comulAlgHomN :=
+  coassocLHS_eq_coassocRHS
+
+/-- Coassociativity of Δ^ρ (LinearMap form). -/
+theorem comulRhoN_coassoc :
+    (TensorProduct.assoc R
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))
+        (ConnesKreimer R (Nonplanar α))).toLinearMap ∘ₗ
+      (comulAlgHomN (R := R) (α := α)).toLinearMap.rTensor _ ∘ₗ
+      (comulAlgHomN (R := R) (α := α)).toLinearMap =
+    (comulAlgHomN (R := R) (α := α)).toLinearMap.lTensor _ ∘ₗ
+      (comulAlgHomN (R := R) (α := α)).toLinearMap :=
+  congrArg AlgHom.toLinearMap comulAlgHomN_coassoc_algHom
+
+end CoassocFoissy
+
+/-- The Δ^ρ **`Bialgebra`** on `ConnesKreimer R (Nonplanar α)`
+    ([marcolli-chomsky-berwick-2025] Lemma 1.2.11), over any `CommSemiring`. -/
+noncomputable instance instBialgebraRho :
+    Bialgebra R (ConnesKreimer R (Nonplanar α)) :=
+  Bialgebra.ofAlgHom (A := ConnesKreimer R (Nonplanar α)) comulAlgHomN counit
+    comulAlgHomN_coassoc_algHom
+    counit_rTensor_comulAlgHomN
+    counit_lTensor_comulAlgHomN
+
+/-- The coproduct of `instBialgebraRho` is `comulAlgHomN`. -/
+theorem coalgebra_comul_apply (x : ConnesKreimer R (Nonplanar α)) :
+    Coalgebra.comul (R := R) x = comulAlgHomN x := rfl
+
+/-- The counit of `instBialgebraRho` is `ConnesKreimer.counit`. -/
+theorem coalgebra_counit_apply (x : ConnesKreimer R (Nonplanar α)) :
+    CoalgebraStruct.counit (R := R) x = counit x := rfl
+
+/-! ### GL/CK duality: downstream
+
+The GL/CK duality theorem (`pairing_gl_eq_pairing_coproduct_Rho`) lives in
 `Coproduct/PruningDuality.lean`, downstream of `BMinus.lean` (whose B⁻
-calculus drives the duality proof). -/
+calculus drives its proof). -/
 
 end ConnesKreimer
-

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -11,23 +11,18 @@ open RoseTree RoseTree.Nonplanar
 set_option autoImplicit false
 
 /-!
-# GL/CK duality and coassociativity of the pruning coproduct
+# GL/CK duality for the pruning coproduct
 
 The Grossman-Larson product and the pruning coproduct Δ^ρ are adjoint
 under the symmetry-weighted pairing ([foissy-2002]; the grafting
-calculus of [oudom-guin-2008]), and Δ^ρ coassociativity plus the
-`Bialgebra` instance of [marcolli-chomsky-berwick-2025] Lemma 1.2.11
-transport from `mul_assoc` through that duality.
+calculus of [oudom-guin-2008]).
 
 ## Main results
 
 * `ConnesKreimer.pairing_gl_eq_pairing_coproduct_Rho` — the duality
   `⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`.
-* `ConnesKreimer.comulRhoN_coassoc`,
-  `ConnesKreimer.comulAlgHomN_coassoc_algHom` — Δ^ρ coassociativity.
-* `ConnesKreimer.instBialgebraRho` — the Δ^ρ `Bialgebra` on the plain
-  Connes-Kreimer carrier, and the `IsAdmissibleCuts cutSummandsN` model
-  instance for the `WithCuts` carrier.
+* The `IsAdmissibleCuts cutSummandsN` model instance for the `WithCuts`
+  carrier (coassociativity and counit laws from `Coproduct/Pruning.lean`).
 
 ## Implementation notes
 
@@ -293,175 +288,13 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
                 IH _ hC'lt C' rfl
                   (ConnesKreimer.of' pq.1.2) (ConnesKreimer.of' pq.2.2)]
 
-/-! ### Coassoc LinearMaps + chain lemmas via the duality -/
-
-/-- The LHS LinearMap of Δ^ρ coassoc:
-    `assoc ∘ (Δ^ρ ⊗ id) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
-private noncomputable def coassocLHSLinRho :
-    ConnesKreimer R (Nonplanar α) →ₗ[R]
-      ConnesKreimer R (Nonplanar α) ⊗[R]
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :=
-  (TensorProduct.assoc R _ _ _).toLinearMap ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap.rTensor _ ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap
-
-/-- The RHS LinearMap of Δ^ρ coassoc:
-    `(id ⊗ Δ^ρ) ∘ Δ^ρ : CK →ₗ CK ⊗ (CK ⊗ CK)`. -/
-private noncomputable def coassocRHSLinRho :
-    ConnesKreimer R (Nonplanar α) →ₗ[R]
-      ConnesKreimer R (Nonplanar α) ⊗[R]
-        (ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :=
-  (comulAlgHomN (R := R)).toLinearMap.lTensor _ ∘ₗ
-    (comulAlgHomN (R := R)).toLinearMap
-
-/-- Intermediate: `assoc + rTensor (Δ^ρ) + pairing₃` via one application
-    of the duality. Note the crossed orientation: the inner coproduct
-    expansion produces the GL product `y ⋆ x`. -/
-private lemma pairing₃_assoc_rTensor_comul_rho
-    (x y z' : ConnesKreimer R (Nonplanar α))
-    (V : ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((TensorProduct.assoc R _ _ _)
-          ((comulAlgHomN (R := R)).toLinearMap.rTensor _ V)) =
-      pairing₂ (R := R) (product y x ⊗ₜ[R] z') V := by
-  induction V using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a b =>
-    rw [LinearMap.rTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_assoc_tmul,
-        ← pairing_gl_eq_pairing_coproduct_Rho y x a, pairing₂_tmul_tmul]
-  | add V₁ V₂ ih₁ ih₂ =>
-    rw [map_add, map_add, map_add, ih₁, ih₂, map_add]
-
-/-- Intermediate: `lTensor (Δ^ρ) + pairing₃` via one application of the
-    duality (crossed orientation: produces `z' ⋆ y`). -/
-private lemma pairing₃_lTensor_comul_rho
-    (x y z' : ConnesKreimer R (Nonplanar α))
-    (W : ConnesKreimer R (Nonplanar α) ⊗[R]
-          ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((comulAlgHomN (R := R)).toLinearMap.lTensor _ W) =
-      pairing₂ (R := R) (x ⊗ₜ[R] product z' y) W := by
-  induction W using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a b =>
-    rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_tmul_apply,
-        ← pairing_gl_eq_pairing_coproduct_Rho z' y b, pairing₂_tmul_tmul]
-  | add W₁ W₂ ih₁ ih₂ =>
-    rw [map_add, map_add, ih₁, ih₂, map_add]
-
-/-- LHS chain: pairing the LHS coassoc
-    expression against a pure triple tensor reduces to pairing the
-    GL product `z' ⋆ (y ⋆ x)` against `z`. -/
-private theorem pairing₃_coassocLHSLinRho
-    (x y z' z : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocLHSLinRho (R := R) z) =
-      pairing
-        (product z' (product y x)) z := by
-  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((TensorProduct.assoc R _ _ _)
-          ((comulAlgHomN (R := R)).toLinearMap.rTensor _
-            ((comulAlgHomN (R := R)).toLinearMap z))) = _
-  rw [AlgHom.toLinearMap_apply, pairing₃_assoc_rTensor_comul_rho]
-  exact (pairing_gl_eq_pairing_coproduct_Rho z'
-          (product y x) z).symm
-
-/-- RHS chain: pairing the RHS coassoc
-    expression against a pure triple tensor reduces to pairing the
-    GL product `(z' ⋆ y) ⋆ x` against `z`. -/
-private theorem pairing₃_coassocRHSLinRho
-    (x y z' z : ConnesKreimer R (Nonplanar α)) :
-    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z')) (coassocRHSLinRho (R := R) z) =
-      pairing
-        (product (product z' y) x) z := by
-  show pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
-        ((comulAlgHomN (R := R)).toLinearMap.lTensor _
-          ((comulAlgHomN (R := R)).toLinearMap z)) = _
-  rw [AlgHom.toLinearMap_apply, pairing₃_lTensor_comul_rho]
-  exact (pairing_gl_eq_pairing_coproduct_Rho
-          (product z' y) x z).symm
-
-/-! ### Coassociativity of Δ^ρ via GL/CK duality (LinearMap form)
-
-Specialized to `[CommRing R]` (rather than `[CommSemiring R]`) since the
-proof uses subtraction (via `sub_eq_zero` in `pairing₃_unique`), which
-requires `R` to be a Ring (so `CK R T` has `AddCommGroup`). -/
-
-section CoassocCommRingRho
-variable {R' : Type*} [CommRing R'] {α' : Type*} [DecidableEq α']
-
-/-- Coassociativity of Δ^ρ (LinearMap form): transported from
-    `GrossmanLarson.mul_assoc` through the duality and the nondegeneracy
-    of `pairing₃`. -/
-theorem comulRhoN_coassoc [CharZero R'] [NoZeroDivisors R'] :
-    (TensorProduct.assoc R'
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))).toLinearMap ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap.rTensor _ ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap =
-    (comulAlgHomN (R := R')).toLinearMap.lTensor _ ∘ₗ
-      (comulAlgHomN (R := R')).toLinearMap := by
-  ext z
-  apply pairing₃_unique
-  intro t
-  induction t using TensorProduct.induction_on with
-  | zero => simp
-  | tmul x rest =>
-    induction rest using TensorProduct.induction_on with
-    | zero => simp
-    | tmul y z' =>
-      show pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocLHSLinRho z) =
-           pairing₃ (x ⊗ₜ[R'] (y ⊗ₜ[R'] z')) (coassocRHSLinRho z)
-      rw [pairing₃_coassocLHSLinRho, pairing₃_coassocRHSLinRho,
-          ← mul_def, ← mul_def,
-          ← mul_def, ← mul_def,
-          GrossmanLarson.mul_assoc]
-    | add a b iha ihb =>
-      simp only [TensorProduct.tmul_add, map_add, LinearMap.add_apply,
-                 iha, ihb]
-  | add a b iha ihb =>
-    simp only [map_add, LinearMap.add_apply, iha, ihb]
-
-/-- The AlgHom form of Δ^ρ coassociativity. -/
-theorem comulAlgHomN_coassoc_algHom [CharZero R'] [NoZeroDivisors R'] :
-    (Algebra.TensorProduct.assoc R' R' R'
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))
-        (ConnesKreimer R' (Nonplanar α'))).toAlgHom.comp
-      ((Algebra.TensorProduct.map (comulAlgHomN (R := R') (α := α'))
-        (AlgHom.id R' (ConnesKreimer R' (Nonplanar α')))).comp comulAlgHomN) =
-    (Algebra.TensorProduct.map (AlgHom.id R' (ConnesKreimer R' (Nonplanar α')))
-      (comulAlgHomN (R := R') (α := α'))).comp comulAlgHomN := by
-  apply AlgHom.toLinearMap_injective
-  exact comulRhoN_coassoc
-
-end CoassocCommRingRho
-
-/-! ### `Bialgebra` instance
-
-Built via `Bialgebra.ofAlgHom` from `comulAlgHomN_coassoc_algHom` (GL/CK
-duality) and the two counit AlgHom laws. The duality-based coassoc proof
-forces `[CommRing R] [CharZero R] [NoZeroDivisors R]`; the counit laws
-hold over `[CommSemiring R]` and are automatically satisfied. -/
-
-noncomputable instance instBialgebraRho
-    {R' : Type*} [CommRing R'] [CharZero R'] [NoZeroDivisors R'] {α' : Type*}
-    [DecidableEq α'] :
-    Bialgebra R' (ConnesKreimer R' (Nonplanar α')) :=
-  Bialgebra.ofAlgHom comulAlgHomN counit
-    comulAlgHomN_coassoc_algHom
-    counit_rTensor_comulAlgHomN
-    counit_lTensor_comulAlgHomN
-
 /-- Δ^ρ is the generic coproduct at `cuts := cutSummandsN` — definitional. -/
 theorem comulAlgHomN_eq_G {R : Type*} [CommSemiring R] {α : Type*} :
     comulAlgHomN (R := R) (α := α) = comulAlgHomNG (R := R) cutSummandsN := rfl
 
-/-- Δ^ρ is admissible: the GL/CK-duality coassociativity and the counit laws,
-transported through the `rfl` bridge `comulAlgHomN_eq_G`. -/
+/-- Δ^ρ is admissible: Foissy coassociativity and the counit laws
+(`Coproduct/Pruning.lean`), transported through the `rfl` bridge
+`comulAlgHomN_eq_G`. -/
 instance {α : Type*} [DecidableEq α] : IsAdmissibleCuts (cutSummandsN (α := α)) where
   coassoc := by
     intro R _ _ _
@@ -476,16 +309,6 @@ instance {α : Type*} [DecidableEq α] : IsAdmissibleCuts (cutSummandsN (α := �
     rw [← comulAlgHomN_eq_G]
     exact counit_lTensor_comulAlgHomN
 
-variable {R' : Type*} [CommRing R'] [CharZero R'] [NoZeroDivisors R'] {α' : Type*}
-  [DecidableEq α']
-
-/-- The coproduct of `instBialgebraRho` is `comulAlgHomN`. -/
-theorem coalgebra_comul_apply (x : ConnesKreimer R' (Nonplanar α')) :
-    Coalgebra.comul (R := R') x = comulAlgHomN x := rfl
-
-/-- The counit of `instBialgebraRho` is `ConnesKreimer.counit`. -/
-theorem coalgebra_counit_apply (x : ConnesKreimer R' (Nonplanar α')) :
-    CoalgebraStruct.counit (R := R') x = counit x := rfl
 
 end ConnesKreimer
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -6399,6 +6399,19 @@
   validated = {true},
   sources   = {Semantics/ArgumentStructure/RoleList.lean}
 }
+@misc{grinberg-reiner-2020,
+  author    = {Grinberg, Darij and Reiner, Victor},
+  title     = {{H}opf algebras in combinatorics},
+  year      = {2020},
+  eprint    = {1409.8356v7},
+  archiveprefix = {arXiv},
+  url       = {https://arxiv.org/abs/1409.8356},
+  subfield  = {algebra/hopf-algebras},
+  role      = {cited},
+  validated = {true},
+  sources   = {Core/Algebra/RootedTree/Coproduct/Pruning.lean}
+}
+
 @mastersthesis{grimm-2005,
   author    = {Grimm, Scott},
   year      = {2005},


### PR DESCRIPTION
Prove Δ^ρ coassociativity directly in `Coproduct/Pruning.lean` by Foissy's subalgebra argument (equalizer of the two `AlgHom` composites, closed under B⁺ via the Hochschild cocycle, containing all trees by depth induction), replacing the duality-transported proof in `PruningDuality.lean`. `instBialgebraRho` moves up with it and now holds over any `CommSemiring` (previously `CharZero` `CommRing`s with `NoZeroDivisors`); `PruningDuality.lean` keeps only the GL/CK duality theorem and the `IsAdmissibleCuts` instance. Adds the verified `grinberg-reiner-2020` bib entry.