### PR TITLE
refactor(Core/Algebra/RootedTree): GL associativity from the duality

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/Pruning.lean
@@ -219,10 +219,8 @@ theorem comulAlgHomN_bPlusLin_cocycle (a : α) (F : Forest (Nonplanar α)) :
 via `ConnesKreimer.algHom_ext`, then close the tree case by strong induction
 on depth through the cocycle `comulTreeN_node_cocycle`.
 
-Coassociativity (`comulRhoN_coassoc`, from the GL/CK duality
-`pairing_gl_eq_pairing_coproduct_Rho` + `GrossmanLarson.mul_assoc` via
-`pairing₃_unique`) and the `Bialgebra` instance live downstream in
-`Coproduct/PruningDuality.lean`. -/
+Coassociativity (`comulRhoN_coassoc`, Foissy's subalgebra argument) and
+the `Bialgebra` instance follow below. -/
 
 /-! ### Counit ⊗ id commutation with `lTensor (bPlusLin a)`
 

--- a/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
+++ b/Linglib/Core/Algebra/RootedTree/Coproduct/PruningDuality.lean
@@ -2,7 +2,7 @@ import Linglib.Core.Algebra.BigOperators.Multiset
 import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.Coproduct.Pairing
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
-import Linglib.Core.Algebra.RootedTree.GrossmanLarsonMonoid
+import Linglib.Core.Algebra.RootedTree.GrossmanLarson
 import Linglib.Core.Algebra.RootedTree.GrossmanLarsonSplit
 import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridgePairing
 
@@ -21,6 +21,10 @@ calculus of [oudom-guin-2008]).
 
 * `ConnesKreimer.pairing_gl_eq_pairing_coproduct_Rho` — the duality
   `⟨x ⋆ y, z⟩ = pairing₂ (y ⊗ x) (Δ^ρ z)`.
+* `ConnesKreimer.pairing_product_assoc` — Foissy coassociativity of Δ^ρ
+  pushed back through the duality: the two GL triple products pair
+  equally against everything (associativity up to separation, closed in
+  `GrossmanLarsonMonoid.lean`).
 * The `IsAdmissibleCuts cutSummandsN` model instance for the `WithCuts`
   carrier (coassociativity and counit laws from `Coproduct/Pruning.lean`).
 
@@ -287,6 +291,70 @@ theorem pairing_gl_eq_pairing_coproduct_Rho
                   (ConnesKreimer.of' pq.1.1) (ConnesKreimer.of' pq.2.1),
                 IH _ hC'lt C' rfl
                   (ConnesKreimer.of' pq.1.2) (ConnesKreimer.of' pq.2.2)]
+
+/-! ### Associativity of the GL product, pairing form
+
+Foissy coassociativity of Δ^ρ (`Coproduct/Pruning.lean`) transports back
+through the duality: pairing the two GL triple products against an
+arbitrary element yields the two sides of coassociativity. Separation
+over a characteristic-zero domain and the descent to any `CommSemiring`
+live in `GrossmanLarsonMonoid.lean`. -/
+
+/-- One duality application under `assoc ∘ rTensor Δ^ρ` (crossed
+    orientation: the inner coproduct expansion produces `y ⋆ x`). -/
+private lemma pairing₃_assoc_rTensor_comul_rho
+    (x y z' : ConnesKreimer R (Nonplanar α))
+    (V : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((TensorProduct.assoc R _ _ _)
+          ((comulAlgHomN (R := R)).toLinearMap.rTensor _ V)) =
+      pairing₂ (R := R) (product y x ⊗ₜ[R] z') V := by
+  induction V using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a b =>
+    rw [LinearMap.rTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_assoc_tmul,
+        ← pairing_gl_eq_pairing_coproduct_Rho y x a, pairing₂_tmul_tmul]
+  | add V₁ V₂ ih₁ ih₂ =>
+    rw [map_add, map_add, map_add, ih₁, ih₂, map_add]
+
+/-- One duality application under `lTensor Δ^ρ` (crossed orientation:
+    produces `z' ⋆ y`). -/
+private lemma pairing₃_lTensor_comul_rho
+    (x y z' : ConnesKreimer R (Nonplanar α))
+    (W : ConnesKreimer R (Nonplanar α) ⊗[R] ConnesKreimer R (Nonplanar α)) :
+    pairing₃ (R := R) (x ⊗ₜ[R] (y ⊗ₜ[R] z'))
+        ((comulAlgHomN (R := R)).toLinearMap.lTensor _ W) =
+      pairing₂ (R := R) (x ⊗ₜ[R] product z' y) W := by
+  induction W using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a b =>
+    rw [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, pairing₃_tmul_apply,
+        ← pairing_gl_eq_pairing_coproduct_Rho z' y b, pairing₂_tmul_tmul]
+  | add W₁ W₂ ih₁ ih₂ =>
+    rw [map_add, map_add, ih₁, ih₂, map_add]
+
+/-- **Associativity of the GL product, pairing form**: the two triple
+    products pair equally against everything — Δ^ρ coassociativity
+    (`comulRhoN_coassoc`) pushed through the duality twice on each side. -/
+theorem pairing_product_assoc (x y z w : ConnesKreimer R (Nonplanar α)) :
+    pairing (product x (product y z)) w =
+      pairing (product (product x y) z) w :=
+  calc pairing (product x (product y z)) w
+      = pairing₂ (R := R) (product y z ⊗ₜ[R] x) (comulAlgHomN (R := R) w) :=
+        pairing_gl_eq_pairing_coproduct_Rho x (product y z) w
+    _ = pairing₃ (R := R) (z ⊗ₜ[R] (y ⊗ₜ[R] x))
+          ((TensorProduct.assoc R _ _ _)
+            ((comulAlgHomN (R := R)).toLinearMap.rTensor _
+              ((comulAlgHomN (R := R)).toLinearMap w))) :=
+        (pairing₃_assoc_rTensor_comul_rho z y x _).symm
+    _ = pairing₃ (R := R) (z ⊗ₜ[R] (y ⊗ₜ[R] x))
+          ((comulAlgHomN (R := R)).toLinearMap.lTensor _
+            ((comulAlgHomN (R := R)).toLinearMap w)) :=
+        congrArg _ (LinearMap.congr_fun (comulRhoN_coassoc (R := R) (α := α)) w)
+    _ = pairing₂ (R := R) (z ⊗ₜ[R] product x y) (comulAlgHomN (R := R) w) :=
+        pairing₃_lTensor_comul_rho z y x _
+    _ = pairing (product (product x y) z) w :=
+        (pairing_gl_eq_pairing_coproduct_Rho (product x y) z w).symm
 
 /-- Δ^ρ is the generic coproduct at `cuts := cutSummandsN` — definitional. -/
 theorem comulAlgHomN_eq_G {R : Type*} [CommSemiring R] {α : Type*} :

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarson.lean
@@ -95,10 +95,9 @@ insertion, multi-tree `insertion`, GL product, `Mul` instance), with
 `mul_one` and `one_mul` proved in-file.
 
 `mul_assoc_basis` and `mul_assoc` (R-generic, `α : Type*`) live in
-`GrossmanLarsonMonoid.lean`, proved sorry-free via the OudomGuin / PBW
-bridge in `OudomGuinBridge.lean`
-(`mul_assoc_basis_via_oudom_guin_pbw`) lifted to arbitrary
-`CommSemiring R` by multiset-coefficient extraction. The `Semigroup`
+`GrossmanLarsonMonoid.lean`: Foissy coassociativity of Δ^ρ transports
+back through the GL/CK duality, with base change (`map_product` below)
+descending the basis case to any `CommSemiring R`. The `Semigroup`
 and `Monoid` typeclass instances are registered there.
 -/
 
@@ -743,11 +742,10 @@ theorem one_mul (F : GrossmanLarson R α) : (1 : GrossmanLarson R α) * F = F :=
 /-! ### Associativity
 
 `mul_assoc_basis` and `mul_assoc` (both R-generic, `α : Type*`) are
-proved sorry-free in `GrossmanLarsonMonoid.lean` via the Oudom-Guin
-/ PBW route — see `OudomGuinBridge.lean`'s
-`mul_assoc_basis_via_oudom_guin_pbw` (Q6 for `R = ℤ`), lifted to arbitrary
-`CommSemiring R` via multiset-coefficient extraction. The
-`Semigroup`/`Monoid` instances are registered there. -/
+proved in `GrossmanLarsonMonoid.lean` from Foissy coassociativity of
+Δ^ρ through the GL/CK duality, descended to arbitrary `CommSemiring R`
+by base change. The `Semigroup`/`Monoid` instances are registered
+there. -/
 
 /-! ### Base change
 
@@ -763,12 +761,14 @@ omit [DecidableEq α] in
     ConnesKreimer.map f (of' (R := R) F : GrossmanLarson R α) = of' F :=
   ConnesKreimer.map_of' f F
 
+omit [DecidableEq α] in
 theorem map_insertionBasis (F G : Forest (Nonplanar α)) :
     ConnesKreimer.map f (insertionBasis (R := R) F G) = insertionBasis F G := by
   unfold insertionBasis
   rw [ConnesKreimer.map_multiset_sum, Multiset.map_map]
   exact congrArg Multiset.sum (Multiset.map_congr rfl fun F' _ => map_of' f F')
 
+omit [DecidableEq α] in
 theorem map_insertion (x : GrossmanLarson R α) (G : Forest (Nonplanar α)) :
     ConnesKreimer.map f (insertion x (of' (R := R) G)) =
       insertion (ConnesKreimer.map f x) (of' G) := by

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonMonoid.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
+import Linglib.Core.Algebra.RootedTree.Coproduct.PruningDuality
 import Linglib.Core.Algebra.RootedTree.GrossmanLarson
-import Linglib.Core.Algebra.RootedTree.GrossmanLarsonAssoc
-import Linglib.Core.Algebra.RootedTree.PreLie.OudomGuinBridge
+import Linglib.Core.Algebra.RootedTree.GrossmanLarsonPairing
 
 open RoseTree RoseTree.Nonplanar
 
@@ -15,33 +15,20 @@ set_option autoImplicit false
 # Grossman-Larson monoid structure
 [grossman-larson-1989] [foissy-2021] [oudom-guin-2008]
 
-Completes the multiplicative structure of `GrossmanLarson R α` (defined in
-`GrossmanLarson.lean`) by lifting the integer-case associativity
-`ConnesKreimer.mul_assoc_basis_via_oudom_guin_pbw` (proved sorry-free in
-`OudomGuinBridge.lean` via Oudom-Guin + PBW) to arbitrary
-`CommSemiring R`, then registering `Semigroup`/`Monoid` instances.
-
-## Architecture
-
-The lift uses the R-generic, basis-form closed expressions
-`lhs_quadruple_form` and `rhs_quintuple_form` (in `GrossmanLarsonAssoc.lean`),
-which present both sides of `(of' F₁) * (of' F₂) * (of' F₃) = (of' F₁) *
-((of' F₂) * (of' F₃))` as `(M.map of').sum` for R-independent multisets `M
-: Multiset (Forest (Nonplanar α))`. The integer case implies the indexing
-multisets are equal (via `Finsupp` coefficient extraction + Nat→ℤ
-injectivity), and that R-free equality re-applies for any R.
+Associativity of the Grossman-Larson product and the
+`Semigroup`/`Monoid` instances. Foissy coassociativity of Δ^ρ
+(`Coproduct/Pruning.lean`) transports back through the GL/CK duality
+(`ConnesKreimer.pairing_product_assoc`): over `ℤ` the symmetry-weighted
+pairing separates points, giving associativity, and `ConnesKreimer.map`
+base change descends the basis case through `ℤ → ℕ → R` to any
+`CommSemiring` (the product's structure constants are ℕ-valued).
 
 ## Main results (all `α : Type*`-generic)
 
-* `mul_assoc_basis` (R-generic) : `(of' F₁ * of' F₂) * of' F₃ =
-  of' F₁ * (of' F₂ * of' F₃)` on basis vectors.
-* `mul_assoc` (R-generic) : full associativity, by triple
-  `ConnesKreimer.addHom_ext`.
+* `mul_assoc_basis`, `mul_assoc` — associativity, `R`-generic.
 * `instSemigroup`, `instMonoid` instances.
 
-## Status
-
-`[UPSTREAM]` candidate. All results sorry-free.
+`[UPSTREAM]` candidate.
 -/
 
 
@@ -49,304 +36,45 @@ namespace GrossmanLarson
 
 variable {α : Type*} [DecidableEq α]
 
-/-! ### `(M.map of').sum` coefficient extraction (multiset injectivity) -/
+/-- Associativity over `ℤ`: the pairing form
+    `ConnesKreimer.pairing_product_assoc` plus separation. -/
+private theorem product_assoc_int (x y z : GrossmanLarson ℤ α) :
+    product (product x y) z = product x (product y z) :=
+  (ext_pairing_right fun w => ConnesKreimer.pairing_product_assoc x y z w).symm
 
-/-- Coefficient of `((M.map of').sum)` at `H` is `M.count H`, mapped from
-    Nat to R. Holds for any `CommSemiring R`. Used to extract multiset
-    equality from sum equality at `R = ℤ`. -/
-private theorem sum_of'_apply
-    {R : Type*} [CommSemiring R]
-    (M : Multiset (Forest (Nonplanar α))) (H : Forest (Nonplanar α)) :
-    (((M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
-        GrossmanLarson R α) H : R) = (M.count H : R) := by
-  induction M using Multiset.induction with
-  | empty =>
-    rw [Multiset.map_zero, Multiset.sum_zero, Multiset.count_zero, Nat.cast_zero]
-    rfl
-  | cons F M ih =>
-    rw [Multiset.map_cons, Multiset.sum_cons, Multiset.count_cons]
-    -- Step 1: split + through FunLike (Finsupp.add_apply).
-    show ((of' (R := R) F : GrossmanLarson R α) +
-            (M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H =
-          ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
-    rw [show ((of' (R := R) F : GrossmanLarson R α) +
-              (M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H =
-            (of' (R := R) F : GrossmanLarson R α) H +
-            ((M.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum) H
-          from Finsupp.add_apply _ _ _]
-    rw [ih]
-    -- Step 2: of' F = Finsupp.single F 1.
-    show (Finsupp.single F (1 : R)) H + (M.count H : R) =
-          ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
-    rw [Finsupp.single_apply]
-    -- Goal: (if F = H then (1 : R) else 0) + (M.count H : R)
-    --     = ((M.count H + (if H = F then 1 else 0) : ℕ) : R)
-    rw [Nat.cast_add, Nat.cast_ite, Nat.cast_one, Nat.cast_zero]
-    by_cases hFH : F = H
-    · rw [if_pos hFH, if_pos hFH.symm, add_comm]
-    · rw [if_neg hFH, if_neg (fun h => hFH h.symm), add_comm]
-
-/-- Multiset equality at `R = ℤ` from sum equality. -/
-private theorem multiset_eq_of_sum_eq_int
-    (M₁ M₂ : Multiset (Forest (Nonplanar α)))
-    (h : ((M₁.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
-          GrossmanLarson ℤ α) =
-         (M₂.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum) :
-    M₁ = M₂ := by
-  apply Multiset.ext.mpr
-  intro H
-  have h1 := sum_of'_apply (R := ℤ) M₁ H
-  have h2 := sum_of'_apply (R := ℤ) M₂ H
-  -- From h: the sums are equal as GL ℤ α, so their FunLike values at H agree.
-  have heq : ((((M₁.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
-                GrossmanLarson ℤ α) H : ℤ)) =
-             (((M₂.map (fun F => (of' (R := ℤ) F : GrossmanLarson ℤ α))).sum :
-                GrossmanLarson ℤ α) H : ℤ) := by
-    rw [h]
-  rw [h1, h2] at heq
-  exact_mod_cast heq
-
-omit [DecidableEq α] in
-/-- Map-then-sum of `of'` is preserved under multiset equality (R-generic). -/
-private theorem sum_of'_congr
-    {R : Type*} [CommSemiring R]
-    {M₁ M₂ : Multiset (Forest (Nonplanar α))} (h : M₁ = M₂) :
-    ((M₁.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
-      GrossmanLarson R α) =
-    (M₂.map (fun F => (of' (R := R) F : GrossmanLarson R α))).sum := by
-  rw [h]
-
-/-! ### `mul_assoc_basis` (R-generic) via the ℤ-case + multiset lift -/
-
-/-- The LHS indexing multiset for `(of' F₁ * of' F₂) * of' F₃`.
-    R-independent; abstracts `lhs_quadruple_form`'s closed form. -/
-private noncomputable def lhsMultiset
-    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    Multiset (Forest (Nonplanar α)) :=
-  F₂.powerset.bind fun B₁ =>
-    (Nonplanar.insertionMultiset F₁ B₁).bind fun X =>
-      F₃.powerset.bind fun C₁ =>
-        C₁.powerset.bind fun D =>
-          ((Nonplanar.insertionMultiset X D) ×ˢ
-            (Nonplanar.insertionMultiset (F₂ - B₁) (C₁ - D))).map
-              fun p => p.1 + p.2 + (F₃ - C₁)
-
-/-- The RHS indexing multiset for `of' F₁ * (of' F₂ * of' F₃)`. -/
-private noncomputable def rhsMultiset
-    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    Multiset (Forest (Nonplanar α)) :=
-  F₃.powerset.bind fun C₁' =>
-    (Nonplanar.insertionMultiset F₂ C₁').bind fun Z =>
-      Z.powerset.bind fun P_Z =>
-        (F₃ - C₁').powerset.bind fun P_F =>
-          (Nonplanar.insertionMultiset F₁ (P_Z + P_F)).map
-            fun W => W + ((Z - P_Z) + ((F₃ - C₁') - P_F))
-
-/-- LHS = sum-of-`of'` over `lhsMultiset` (R-generic). -/
-private theorem lhs_eq_sum_of'
-    {R : Type*} [CommSemiring R]
-    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
-      (((lhsMultiset F₁ F₂ F₃).map
-          (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
-        GrossmanLarson R α) := by
-  rw [lhs_quadruple_form]
-  -- Goal: nested-bind sum with `of'` inside = (lhsMultiset.map of').sum
-  -- Push `map of'` outside by induction over the binds.
-  unfold lhsMultiset
-  -- The inner-most layer: `(...).map fun p => of' (p.1+p.2+(F₃-C₁))`
-  --  vs. `((...).map fun p => p.1+p.2+(F₃-C₁)).map of'` — Multiset.map_map.
-  -- We turn the nested binds into one bind via Multiset.map_bind on each layer.
-  -- Equivalent: rewrite `(A.bind f).map g = A.bind (fun a => (f a).map g)`.
-  simp only [Multiset.map_bind, Multiset.map_map, Function.comp]
-
-/-- RHS = sum-of-`of'` over `rhsMultiset` (R-generic). -/
-private theorem rhs_eq_sum_of'
-    {R : Type*} [CommSemiring R]
-    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    (of' F₁ : GrossmanLarson R α) * (of' F₂ * of' F₃) =
-      (((rhsMultiset F₁ F₂ F₃).map
-          (fun F => (of' (R := R) F : GrossmanLarson R α))).sum :
-        GrossmanLarson R α) := by
-  rw [rhs_quintuple_form]
-  unfold rhsMultiset
-  simp only [Multiset.map_bind, Multiset.map_map, Function.comp]
-
-/-- The LHS and RHS indexing multisets are equal (R-free). Proved by
-    invoking the closed integer case `mul_assoc_basis_via_oudom_guin_pbw`
-    and pulling out the multiset equality via `Finsupp` coefficient
-    extraction. -/
-private theorem lhsMultiset_eq_rhsMultiset
-    (F₁ F₂ F₃ : Forest (Nonplanar α)) :
-    lhsMultiset F₁ F₂ F₃ = rhsMultiset F₁ F₂ F₃ := by
-  apply multiset_eq_of_sum_eq_int
-  -- Reduce to associativity equation at ℤ.
-  rw [← lhs_eq_sum_of' (R := ℤ), ← rhs_eq_sum_of' (R := ℤ)]
-  exact ConnesKreimer.mul_assoc_basis_via_oudom_guin_pbw F₁ F₂ F₃
-
-/-- **Basis-level associativity** (R-generic, `α : Type*`). Lifts the
-    integer case `mul_assoc_basis_via_oudom_guin_pbw` (Q6, proved
-    sorry-free in `OudomGuinBridge.lean`) to arbitrary
-    `CommSemiring R` via R-free multiset identification. -/
+/-- **Basis-level associativity** (`R`-generic): the `ℤ` case descends
+    through `ConnesKreimer.map` base change — along `ℕ → ℤ` by
+    injectivity, then along `Nat.cast : ℕ → R`. -/
 theorem mul_assoc_basis {R : Type*} [CommSemiring R]
     (F₁ F₂ F₃ : Forest (Nonplanar α)) :
     ((of' F₁ : GrossmanLarson R α) * of' F₂) * of' F₃ =
       of' F₁ * (of' F₂ * of' F₃) := by
-  rw [lhs_eq_sum_of' (R := R), rhs_eq_sum_of' (R := R),
-      sum_of'_congr (lhsMultiset_eq_rhsMultiset F₁ F₂ F₃)]
+  have hℕ : ((of' F₁ : GrossmanLarson ℕ α) * of' F₂) * of' F₃ =
+      of' F₁ * (of' F₂ * of' F₃) := by
+    refine ConnesKreimer.map_injective (Nat.castRingHom ℤ) Nat.cast_injective ?_
+    simp only [mul_def, map_product, map_of']
+    exact product_assoc_int _ _ _
+  have h := congrArg (ConnesKreimer.map (Nat.castRingHom R)) hℕ
+  simpa only [mul_def, map_product, map_of'] using h
 
-/-! ### Full `mul_assoc` via triple `ConnesKreimer.addHom_ext` -/
-
-/-- Right multiplication by `y` as an `AddMonoidHom`, additive in `x`. -/
-private noncomputable def mulRightHom
-    {R : Type*} [CommSemiring R] (y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α where
-  toFun x := x * y
-  map_zero' := by
-    show product 0 y = 0
-    rw [product.map_zero, LinearMap.zero_apply]
-  map_add' x₁ x₂ := by
-    show product (x₁ + x₂) y = product x₁ y + product x₂ y
-    rw [product.map_add, LinearMap.add_apply]
-
-/-- Left multiplication by `x` as an `AddMonoidHom`, additive in `y`. -/
-private noncomputable def mulLeftHom
-    {R : Type*} [CommSemiring R] (x : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α where
-  toFun y := x * y
-  map_zero' := by
-    show product x 0 = 0
-    exact (product x).map_zero
-  map_add' y₁ y₂ := by
-    show product x (y₁ + y₂) = product x y₁ + product x y₂
-    exact (product x).map_add y₁ y₂
-
-@[simp] private theorem mulRightHom_apply
-    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
-    mulRightHom y x = x * y := rfl
-
-@[simp] private theorem mulLeftHom_apply
-    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
-    mulLeftHom x y = x * y := rfl
-
-/-- Scalar pull-out on the LEFT factor: `(c • x) * y = c • (x * y)`. -/
-private theorem smul_mul_left
-    {R : Type*} [CommSemiring R] (c : R) (x y : GrossmanLarson R α) :
-    ((c • x : GrossmanLarson R α) * y) = c • (x * y) := by
-  show product (c • x) y = c • product x y
-  rw [product.map_smul, LinearMap.smul_apply]
-
-/-- Scalar pull-out on the RIGHT factor: `x * (c • y) = c • (x * y)`. -/
-private theorem mul_smul_right
-    {R : Type*} [CommSemiring R] (c : R) (x y : GrossmanLarson R α) :
-    (x * (c • y : GrossmanLarson R α)) = c • (x * y) := by
-  show product x (c • y) = c • product x y
-  exact (product x).map_smul c y
-
-/-- AddMonoidHom for `x ↦ x * y * z`, additive in `x`. -/
-private noncomputable def assocLHSHom
-    {R : Type*} [CommSemiring R] (y z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulRightHom z).comp (mulRightHom y)
-
-/-- AddMonoidHom for `x ↦ x * (y * z)`, additive in `x`. -/
-private noncomputable def assocRHSHom
-    {R : Type*} [CommSemiring R] (y z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  mulRightHom (y * z)
-
-@[simp] private theorem assocLHSHom_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocLHSHom y z x = x * y * z := rfl
-
-@[simp] private theorem assocRHSHom_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocRHSHom y z x = x * (y * z) := rfl
-
-/-- AddMonoidHom for `y ↦ x * y * z`, additive in `y`. -/
-private noncomputable def assocLHSHomY
-    {R : Type*} [CommSemiring R] (x z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulRightHom z).comp (mulLeftHom x)
-
-/-- AddMonoidHom for `y ↦ x * (y * z)`, additive in `y`. -/
-private noncomputable def assocRHSHomY
-    {R : Type*} [CommSemiring R] (x z : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom x).comp (mulRightHom z)
-
-@[simp] private theorem assocLHSHomY_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocLHSHomY x z y = x * y * z := rfl
-
-@[simp] private theorem assocRHSHomY_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocRHSHomY x z y = x * (y * z) := by
-  show (mulLeftHom x) ((mulRightHom z) y) = x * (y * z)
-  rfl
-
-/-- AddMonoidHom for `z ↦ x * y * z`, additive in `z`. -/
-private noncomputable def assocLHSHomZ
-    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom (x * y))
-
-/-- AddMonoidHom for `z ↦ x * (y * z)`, additive in `z`. -/
-private noncomputable def assocRHSHomZ
-    {R : Type*} [CommSemiring R] (x y : GrossmanLarson R α) :
-    GrossmanLarson R α →+ GrossmanLarson R α :=
-  (mulLeftHom x).comp (mulLeftHom y)
-
-@[simp] private theorem assocLHSHomZ_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocLHSHomZ x y z = x * y * z := rfl
-
-@[simp] private theorem assocRHSHomZ_apply
-    {R : Type*} [CommSemiring R] (x y z : GrossmanLarson R α) :
-    assocRHSHomZ x y z = x * (y * z) := by
-  show (mulLeftHom x) ((mulLeftHom y) z) = x * (y * z)
-  rfl
-
-/-- **Associativity** (R-generic, `α : Type*`). Triple bilinearity
-    reduction to `mul_assoc_basis`. -/
+/-- **Associativity** (`R`-generic): trilinear reduction of
+    `mul_assoc_basis`, one `ConnesKreimer.lhom_ext'` per slot. -/
 theorem mul_assoc {R : Type*} [CommSemiring R]
-    (F₁ F₂ F₃ : GrossmanLarson R α) :
-    F₁ * F₂ * F₃ = F₁ * (F₂ * F₃) := by
-  have h₁ : assocLHSHom F₂ F₃ = assocRHSHom F₂ F₃ := by
-    refine ConnesKreimer.addHom_ext (T := Nonplanar α)
-      (M := GrossmanLarson R α) fun T₁ a₁ => ?_
-    set s₁ : GrossmanLarson R α := ConnesKreimer.single T₁ a₁ with s₁_def
-    show assocLHSHom F₂ F₃ s₁ = assocRHSHom F₂ F₃ s₁
-    rw [assocLHSHom_apply, assocRHSHom_apply]
-    have h₂ : assocLHSHomY s₁ F₃ = assocRHSHomY s₁ F₃ := by
-      refine ConnesKreimer.addHom_ext (T := Nonplanar α)
-        (M := GrossmanLarson R α) fun T₂ a₂ => ?_
-      set s₂ : GrossmanLarson R α := ConnesKreimer.single T₂ a₂ with s₂_def
-      show assocLHSHomY s₁ F₃ s₂ = assocRHSHomY s₁ F₃ s₂
-      rw [assocLHSHomY_apply, assocRHSHomY_apply]
-      have h₃ : assocLHSHomZ s₁ s₂ = assocRHSHomZ s₁ s₂ := by
-        refine ConnesKreimer.addHom_ext (T := Nonplanar α)
-          (M := GrossmanLarson R α) fun T₃ a₃ => ?_
-        set s₃ : GrossmanLarson R α := ConnesKreimer.single T₃ a₃ with s₃_def
-        show assocLHSHomZ s₁ s₂ s₃ = assocRHSHomZ s₁ s₂ s₃
-        rw [assocLHSHomZ_apply, assocRHSHomZ_apply]
-        rw [show s₁ = a₁ • (of' T₁ : GrossmanLarson R α) from
-              ConnesKreimer.smul_single_one T₁ a₁,
-            show s₂ = a₂ • (of' T₂ : GrossmanLarson R α) from
-              ConnesKreimer.smul_single_one T₂ a₂,
-            show s₃ = a₃ • (of' T₃ : GrossmanLarson R α) from
-              ConnesKreimer.smul_single_one T₃ a₃]
-        simp only [smul_mul_left, mul_smul_right]
-        rw [mul_assoc_basis T₁ T₂ T₃]
-      have h₃App := DFunLike.congr_fun h₃ F₃
-      rw [assocLHSHomZ_apply, assocRHSHomZ_apply] at h₃App
-      exact h₃App
-    have h₂App := DFunLike.congr_fun h₂ F₂
-    rw [assocLHSHomY_apply, assocRHSHomY_apply] at h₂App
-    exact h₂App
-  have h₁App := DFunLike.congr_fun h₁ F₁
-  rw [assocLHSHom_apply, assocRHSHom_apply] at h₁App
-  exact h₁App
+    (x y z : GrossmanLarson R α) :
+    x * y * z = x * (y * z) := by
+  show product (product x y) z = product x (product y z)
+  have h₁ : ∀ F₁ F₂ : Forest (Nonplanar α),
+      product (product (of' (R := R) F₁) (of' F₂)) =
+        (product (of' F₁)).comp (product (of' F₂)) := fun F₁ F₂ =>
+    ConnesKreimer.lhom_ext' fun F₃ => mul_assoc_basis F₁ F₂ F₃
+  have h₂ : ∀ (F₁ : Forest (Nonplanar α)) (w : GrossmanLarson R α),
+      (product.flip w).comp (product (of' (R := R) F₁)) =
+        (product (of' F₁)).comp (product.flip w) := fun F₁ w =>
+    ConnesKreimer.lhom_ext' fun F₂ => LinearMap.congr_fun (h₁ F₁ F₂) w
+  have h₃ : ∀ w y : GrossmanLarson R α,
+      (product.flip w).comp (product.flip y) = product.flip (product y w) :=
+    fun w y => ConnesKreimer.lhom_ext' fun F₁ => LinearMap.congr_fun (h₂ F₁ w) y
+  exact LinearMap.congr_fun (h₃ z y) x
 
 /-! ### `Semigroup` and `Monoid` instances
 
@@ -371,4 +99,3 @@ noncomputable instance (priority := 50) instMonoid {R : Type*} [CommSemiring R] 
   mul_one := mul_one
 
 end GrossmanLarson
-

--- a/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
+++ b/Linglib/Core/Algebra/RootedTree/GrossmanLarsonPairing.lean
@@ -222,6 +222,18 @@ theorem pairing_nondegenerate
   · exact hx
   · exact absurd hx hauts_ne
 
+section Ring
+variable {R : Type*} [CommRing R] [CharZero R] [NoZeroDivisors R]
+
+/-- Separation form of `pairing_nondegenerate`: elements pairing equally
+    against everything are equal. -/
+theorem ext_pairing_right {x y : ConnesKreimer R (Nonplanar α)}
+    (h : ∀ z, pairing (R := R) x z = pairing y z) : x = y :=
+  sub_eq_zero.mp <| pairing_nondegenerate _ fun z => by
+    rw [map_sub, LinearMap.sub_apply, h, sub_self]
+
+end Ring
+
 /-! ### Product rule
 
 Pairing against a CK product decomposes over the two-sided sub-multiset


### PR DESCRIPTION
Invert the associativity architecture: Foissy coassociativity of Δ^ρ (`Coproduct/Pruning.lean`) pushes back through the GL/CK duality (`pairing_product_assoc`, CommSemiring-generic), the symmetry-weighted pairing separates points over ℤ (`ext_pairing_right`), and `ConnesKreimer.map` base change descends the basis case ℤ → ℕ → R. `GrossmanLarsonMonoid.lean` shrinks 374 → 104 lines (the closed-form multiset lift and the AddMonoidHom wall are gone) and no longer imports the Oudom-Guin route; full `mul_assoc` is three `lhom_ext'` applications.