### PR TITLE
feat(Data/Examples): add Baker1985 stimuli; ground study in rows

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2927,3 +2927,4 @@ import Linglib.Data.Examples.Lahiri1998
 import Linglib.Data.Examples.VonStechow1984
 import Linglib.Data.Examples.Hacquard2006
 import Linglib.Data.Examples.StankovaSimik2025
+import Linglib.Data.Examples.Baker1985

--- a/Linglib/Data/Examples/Baker1985.json
+++ b/Linglib/Data/Examples/Baker1985.json
@@ -1,0 +1,258 @@
+[
+  {
+    "id": "baker1985_chamorro_15a",
+    "source": {"bibkey": "gibson-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(15a)"},
+    "language": "cham1312",
+    "primaryText": "Man-dikiki'.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Man-dikiki'", "PL-small"]
+    ],
+    "translation": "They are small.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Plural number agreement man- on an intransitive predicate; the singular form is null. Baker credits the Chamorro data to Gibson 1980.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_chamorro_15b",
+    "source": {"bibkey": "gibson-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(15b)"},
+    "language": "cham1312",
+    "primaryText": "Para#u#fan-s-in-aolak i famagu'un gi as tata-n-niha.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Para#u#fan-s-in-aolak", "IRR-3PL.SBJ-PL-PASS-spank"], ["i", "the"],
+      ["famagu'un", "children"], ["gi as", "OBL"], ["tata-n-niha", "father-their"]
+    ],
+    "translation": "The children are going to be spanked by their father.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "fan- (outside passive -in-) registers the plurality of the surface subject; -in- is infixed after the stem-initial consonant (s-in-aolak).",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_chamorro_15c",
+    "source": {"bibkey": "gibson-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(15c)"},
+    "language": "cham1312",
+    "primaryText": "Hu#na'-fan-otchu siha.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hu#na'-fan-otchu", "1SG.SBJ-CAUS-PL-eat"], ["siha", "them"]
+    ],
+    "translation": "I made them eat.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "fan- (inside causative na'-) registers the plurality of the semantic subject of 'eat', not the surface subject. Repeated as Baker's (30).",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_chamorro_25",
+    "source": {"bibkey": "gibson-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(25)"},
+    "language": "cham1312",
+    "primaryText": "Hu#na'-fan-s-in-aolak i famagu'un gi as tata-n-niha.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hu#na'-fan-s-in-aolak", "1SG.SBJ-CAUS-PL-PASS-spank"], ["i famagu'un", "children"],
+      ["gi as", "OBL"], ["tata-n-niha", "father-their"]
+    ],
+    "translation": "I had the children spanked by their father.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Causative of passive: fan- sits between -in- and na'- and registers the intermediate subject (post-passive, pre-causative) -- 'the children' is neither the semantic nor the surface subject.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_quechua_39a",
+    "source": {"bibkey": "muysken-1981", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(39a)"},
+    "language": "quec1387",
+    "primaryText": "Maqa-naku-ya-chi-n.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Maqa-naku-ya-chi-n", "beat-RECP-DUR-CAUS-3SBJ"]
+    ],
+    "translation": "He is causing them to beat each other.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Baker's translation carries coreference indices ('He_j is causing them_i to beat each other_i'): the reciprocal binds within the caused event. Quechua variety unspecified; Baker credits Muysken 1981. Glottocode is the Quechuan family.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_quechua_39b",
+    "source": {"bibkey": "muysken-1981", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(39b)"},
+    "language": "quec1387",
+    "primaryText": "Maqa-chi-naku-rka-n.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Maqa-chi-naku-rka-n", "beat-CAUS-RECP-PL-3SBJ"]
+    ],
+    "translation": "They let someone beat each other.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Baker's translation carries coreference indices ('They_j let someone_i beat each other_j'): the reciprocal binds the causers, applying after the causative.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_bemba_49a",
+    "source": {"bibkey": "givon-1976", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(49a)"},
+    "language": "bemb1257",
+    "primaryText": "Naa-mon-an-ya Mwape na Mutumba.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Naa-mon-an-ya", "1SG.SBJ.PST-see-RECP-CAUS"], ["Mwape", "Mwape"], ["na", "and"],
+      ["Mutumba", "Mutumba"]
+    ],
+    "translation": "I made Mwape and Mutumba see each other.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Reciprocal -an inside causative -ya: the same order and interpretation as Quechua (39a). Baker credits the Bemba data to Givon 1976.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_bemba_49b",
+    "source": {"bibkey": "givon-1976", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(49b)"},
+    "language": "bemb1257",
+    "primaryText": "Mwape na Chilufya baa-mon-eshy-ana Mutumba.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mwape", "Mwape"], ["na", "and"], ["Chilufya", "Chilufya"],
+      ["baa-mon-eshy-ana", "3PL.SBJ-see-CAUS-RECP"], ["Mutumba", "Mutumba"]
+    ],
+    "translation": "Mwape and Chilufya made each other see Mutumba.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Causative -eshy inside reciprocal -ana. Bemba's causative is Chamorro-type (Baker's (50)-(51)), so Reciprocal links causer and initial agent -- unlike Quechua (39b), where it links causer and initial patient.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_huichol_55",
+    "source": {"bibkey": "comrie-1982", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(55)"},
+    "language": "huic1243",
+    "primaryText": "Tiiri yi-nauka-ti nawazi me-puutinanai-ri-yeri.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Tiiri", "children"], ["yi-nauka-ti", "four-SBJ"], ["nawazi", "knife"],
+      ["me-puutinanai-ri-yeri", "3PL.SBJ-buy-BEN-PASS"]
+    ],
+    "translation": "Four children were bought a knife.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Passive of the applicative (54b): the beneficiary has become subject (quantifier morphology, subject agreement), and benefactive -ri is closer to the verb than passive -yeri. Baker credits the Huichol data to Comrie 1982.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_chimwiini_56c",
+    "source": {"bibkey": "kisseberth-abasheikh-1977", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(56c)"},
+    "language": "chim1312",
+    "primaryText": "Mwa:limu ∅-tet-el-el-a chibu:ku na Nu:ru.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Mwa:limu", "teacher"], ["∅-tet-el-el-a", "SP-bring-APPL-ASP-PASS"], ["chibu:ku", "book"],
+      ["na", "by"], ["Nu:ru", "Nuru"]
+    ],
+    "translation": "The teacher was brought the book by Nuru.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Passive of the applicative (56b): the goal 'the teacher' is surface subject; passive -a outside applied -el. SP = subject prefix (here null).",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_chimwiini_56d",
+    "source": {"bibkey": "kisseberth-abasheikh-1977", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(56d)"},
+    "language": "chim1312",
+    "primaryText": "Chibu:ku chi-tet-el-el-a mwa:limu na Nu:ru.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Chibu:ku", "book"], ["chi-tet-el-el-a", "SP-bring-APPL-ASP-PASS"], ["mwa:limu", "teacher"],
+      ["na", "by"], ["Nu:ru", "Nuru"]
+    ],
+    "translation": "The book was brought the teacher by Nuru.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Starred by the Mirror Principle: Applicative precedes Passive morphologically (its affix is closer to the root), but Passive would have to precede Applicative syntactically (the patient, not the goal, maps to subject).",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_kinyarwanda_57c",
+    "source": {"bibkey": "kimenyi-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(57c)"},
+    "language": "kiny1244",
+    "primaryText": "Ikaramu i-ra-andik-iish-w-a ibaruwa n'umugabo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ikaramu", "pen"], ["i-ra-andik-iish-w-a", "SP-PRS-write-INSTR-PASS-ASP"],
+      ["ibaruwa", "letter"], ["n'umugabo", "by-man"]
+    ],
+    "translation": "The pen was written-with the letter by the man.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "The instrument has become subject; passive -w outside applied -iish, as the Mirror Principle predicts. Baker credits the Kinyarwanda data to Kimenyi 1980.",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "baker1985_kinyarwanda_57d",
+    "source": {"bibkey": "kimenyi-1980", "paperLabel": ""},
+    "reportedIn": {"bibkey": "baker-1985", "paperLabel": "(57d)"},
+    "language": "kiny1244",
+    "primaryText": "Ibaruwa i-ra-andik-iish-w-a ikaramu n'umugabo.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Ibaruwa", "letter"], ["i-ra-andik-iish-w-a", "SP-PRS-write-INSTR-PASS-ASP"],
+      ["ikaramu", "pen"], ["n'umugabo", "by-man"]
+    ],
+    "translation": "The letter was written with the pen by the man.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [],
+    "comment": "Grammatical, unlike Chi-Mwi:ni (56d): Kinyarwanda passive independently promotes either postverbal NP of a double-object verb (Baker's (58)), so this is not a Mirror Principle counterexample.",
+    "lgrConformance": "WORD_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/Baker1985.lean
+++ b/Linglib/Data/Examples/Baker1985.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Baker1985` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Baker1985.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Baker1985.Examples`.
+-/
+
+namespace Baker1985.Examples
+
+open Data.Examples
+
+def chamorro_15a : LinguisticExample :=
+  { id := "baker1985_chamorro_15a"
+    source := ⟨"gibson-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(15a)"⟩
+    language := "cham1312"
+    primaryText := "Man-dikiki'."
+    discourseSegments := []
+    glossedTokens := [("Man-dikiki'", "PL-small")]
+    translation := "They are small."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Plural number agreement man- on an intransitive predicate; the singular form is null. Baker credits the Chamorro data to Gibson 1980."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def chamorro_15b : LinguisticExample :=
+  { id := "baker1985_chamorro_15b"
+    source := ⟨"gibson-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(15b)"⟩
+    language := "cham1312"
+    primaryText := "Para#u#fan-s-in-aolak i famagu'un gi as tata-n-niha."
+    discourseSegments := []
+    glossedTokens := [("Para#u#fan-s-in-aolak", "IRR-3PL.SBJ-PL-PASS-spank"), ("i", "the"), ("famagu'un", "children"), ("gi as", "OBL"), ("tata-n-niha", "father-their")]
+    translation := "The children are going to be spanked by their father."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "fan- (outside passive -in-) registers the plurality of the surface subject; -in- is infixed after the stem-initial consonant (s-in-aolak)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def chamorro_15c : LinguisticExample :=
+  { id := "baker1985_chamorro_15c"
+    source := ⟨"gibson-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(15c)"⟩
+    language := "cham1312"
+    primaryText := "Hu#na'-fan-otchu siha."
+    discourseSegments := []
+    glossedTokens := [("Hu#na'-fan-otchu", "1SG.SBJ-CAUS-PL-eat"), ("siha", "them")]
+    translation := "I made them eat."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "fan- (inside causative na'-) registers the plurality of the semantic subject of 'eat', not the surface subject. Repeated as Baker's (30)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def chamorro_25 : LinguisticExample :=
+  { id := "baker1985_chamorro_25"
+    source := ⟨"gibson-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(25)"⟩
+    language := "cham1312"
+    primaryText := "Hu#na'-fan-s-in-aolak i famagu'un gi as tata-n-niha."
+    discourseSegments := []
+    glossedTokens := [("Hu#na'-fan-s-in-aolak", "1SG.SBJ-CAUS-PL-PASS-spank"), ("i famagu'un", "children"), ("gi as", "OBL"), ("tata-n-niha", "father-their")]
+    translation := "I had the children spanked by their father."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Causative of passive: fan- sits between -in- and na'- and registers the intermediate subject (post-passive, pre-causative) -- 'the children' is neither the semantic nor the surface subject."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def quechua_39a : LinguisticExample :=
+  { id := "baker1985_quechua_39a"
+    source := ⟨"muysken-1981", ""⟩
+    reportedIn := some ⟨"baker-1985", "(39a)"⟩
+    language := "quec1387"
+    primaryText := "Maqa-naku-ya-chi-n."
+    discourseSegments := []
+    glossedTokens := [("Maqa-naku-ya-chi-n", "beat-RECP-DUR-CAUS-3SBJ")]
+    translation := "He is causing them to beat each other."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Baker's translation carries coreference indices ('He_j is causing them_i to beat each other_i'): the reciprocal binds within the caused event. Quechua variety unspecified; Baker credits Muysken 1981. Glottocode is the Quechuan family."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def quechua_39b : LinguisticExample :=
+  { id := "baker1985_quechua_39b"
+    source := ⟨"muysken-1981", ""⟩
+    reportedIn := some ⟨"baker-1985", "(39b)"⟩
+    language := "quec1387"
+    primaryText := "Maqa-chi-naku-rka-n."
+    discourseSegments := []
+    glossedTokens := [("Maqa-chi-naku-rka-n", "beat-CAUS-RECP-PL-3SBJ")]
+    translation := "They let someone beat each other."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Baker's translation carries coreference indices ('They_j let someone_i beat each other_j'): the reciprocal binds the causers, applying after the causative."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def bemba_49a : LinguisticExample :=
+  { id := "baker1985_bemba_49a"
+    source := ⟨"givon-1976", ""⟩
+    reportedIn := some ⟨"baker-1985", "(49a)"⟩
+    language := "bemb1257"
+    primaryText := "Naa-mon-an-ya Mwape na Mutumba."
+    discourseSegments := []
+    glossedTokens := [("Naa-mon-an-ya", "1SG.SBJ.PST-see-RECP-CAUS"), ("Mwape", "Mwape"), ("na", "and"), ("Mutumba", "Mutumba")]
+    translation := "I made Mwape and Mutumba see each other."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Reciprocal -an inside causative -ya: the same order and interpretation as Quechua (39a). Baker credits the Bemba data to Givon 1976."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def bemba_49b : LinguisticExample :=
+  { id := "baker1985_bemba_49b"
+    source := ⟨"givon-1976", ""⟩
+    reportedIn := some ⟨"baker-1985", "(49b)"⟩
+    language := "bemb1257"
+    primaryText := "Mwape na Chilufya baa-mon-eshy-ana Mutumba."
+    discourseSegments := []
+    glossedTokens := [("Mwape", "Mwape"), ("na", "and"), ("Chilufya", "Chilufya"), ("baa-mon-eshy-ana", "3PL.SBJ-see-CAUS-RECP"), ("Mutumba", "Mutumba")]
+    translation := "Mwape and Chilufya made each other see Mutumba."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Causative -eshy inside reciprocal -ana. Bemba's causative is Chamorro-type (Baker's (50)-(51)), so Reciprocal links causer and initial agent -- unlike Quechua (39b), where it links causer and initial patient."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def huichol_55 : LinguisticExample :=
+  { id := "baker1985_huichol_55"
+    source := ⟨"comrie-1982", ""⟩
+    reportedIn := some ⟨"baker-1985", "(55)"⟩
+    language := "huic1243"
+    primaryText := "Tiiri yi-nauka-ti nawazi me-puutinanai-ri-yeri."
+    discourseSegments := []
+    glossedTokens := [("Tiiri", "children"), ("yi-nauka-ti", "four-SBJ"), ("nawazi", "knife"), ("me-puutinanai-ri-yeri", "3PL.SBJ-buy-BEN-PASS")]
+    translation := "Four children were bought a knife."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Passive of the applicative (54b): the beneficiary has become subject (quantifier morphology, subject agreement), and benefactive -ri is closer to the verb than passive -yeri. Baker credits the Huichol data to Comrie 1982."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def chimwiini_56c : LinguisticExample :=
+  { id := "baker1985_chimwiini_56c"
+    source := ⟨"kisseberth-abasheikh-1977", ""⟩
+    reportedIn := some ⟨"baker-1985", "(56c)"⟩
+    language := "chim1312"
+    primaryText := "Mwa:limu ∅-tet-el-el-a chibu:ku na Nu:ru."
+    discourseSegments := []
+    glossedTokens := [("Mwa:limu", "teacher"), ("∅-tet-el-el-a", "SP-bring-APPL-ASP-PASS"), ("chibu:ku", "book"), ("na", "by"), ("Nu:ru", "Nuru")]
+    translation := "The teacher was brought the book by Nuru."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Passive of the applicative (56b): the goal 'the teacher' is surface subject; passive -a outside applied -el. SP = subject prefix (here null)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def chimwiini_56d : LinguisticExample :=
+  { id := "baker1985_chimwiini_56d"
+    source := ⟨"kisseberth-abasheikh-1977", ""⟩
+    reportedIn := some ⟨"baker-1985", "(56d)"⟩
+    language := "chim1312"
+    primaryText := "Chibu:ku chi-tet-el-el-a mwa:limu na Nu:ru."
+    discourseSegments := []
+    glossedTokens := [("Chibu:ku", "book"), ("chi-tet-el-el-a", "SP-bring-APPL-ASP-PASS"), ("mwa:limu", "teacher"), ("na", "by"), ("Nu:ru", "Nuru")]
+    translation := "The book was brought the teacher by Nuru."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Starred by the Mirror Principle: Applicative precedes Passive morphologically (its affix is closer to the root), but Passive would have to precede Applicative syntactically (the patient, not the goal, maps to subject)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def kinyarwanda_57c : LinguisticExample :=
+  { id := "baker1985_kinyarwanda_57c"
+    source := ⟨"kimenyi-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(57c)"⟩
+    language := "kiny1244"
+    primaryText := "Ikaramu i-ra-andik-iish-w-a ibaruwa n'umugabo."
+    discourseSegments := []
+    glossedTokens := [("Ikaramu", "pen"), ("i-ra-andik-iish-w-a", "SP-PRS-write-INSTR-PASS-ASP"), ("ibaruwa", "letter"), ("n'umugabo", "by-man")]
+    translation := "The pen was written-with the letter by the man."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "The instrument has become subject; passive -w outside applied -iish, as the Mirror Principle predicts. Baker credits the Kinyarwanda data to Kimenyi 1980."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def kinyarwanda_57d : LinguisticExample :=
+  { id := "baker1985_kinyarwanda_57d"
+    source := ⟨"kimenyi-1980", ""⟩
+    reportedIn := some ⟨"baker-1985", "(57d)"⟩
+    language := "kiny1244"
+    primaryText := "Ibaruwa i-ra-andik-iish-w-a ikaramu n'umugabo."
+    discourseSegments := []
+    glossedTokens := [("Ibaruwa", "letter"), ("i-ra-andik-iish-w-a", "SP-PRS-write-INSTR-PASS-ASP"), ("ikaramu", "pen"), ("n'umugabo", "by-man")]
+    translation := "The letter was written with the pen by the man."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := []
+    comment := "Grammatical, unlike Chi-Mwi:ni (56d): Kinyarwanda passive independently promotes either postverbal NP of a double-object verb (Baker's (58)), so this is not a Mirror Principle counterexample."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def all : List LinguisticExample := [chamorro_15a, chamorro_15b, chamorro_15c, chamorro_25, quechua_39a, quechua_39b, bemba_49a, bemba_49b, huichol_55, chimwiini_56c, chimwiini_56d, kinyarwanda_57c, kinyarwanda_57d]
+
+end Baker1985.Examples

--- a/Linglib/Studies/Baker1985.lean
+++ b/Linglib/Studies/Baker1985.lean
@@ -1,3 +1,4 @@
+import Linglib.Data.Examples.Baker1985
 import Linglib.Morphology.Morphotactics.MirrorPrinciple
 
 /-!
@@ -22,6 +23,9 @@ ordering in Huichol, Chi-Mwi:ni, and Kinyarwanda (§4.2).
 * `quechuaRecipInsideCaus` … `bembaCausInsideRecip`: the §4.1 ordering pairs.
 * `huichol`, `chiMwini`, `kinyarwanda`: the applied affix universally inner to the
   passive affix (§4.2).
+
+The glossed stimuli live in `Data/Examples/Baker1985.json` (generated module
+`Data.Examples.Baker1985`); each analysis below names its stimulus row.
 -/
 
 namespace Baker1985
@@ -31,10 +35,11 @@ open Morphology.MirrorPrinciple
 /-! ### The Agreement Restriction ([baker-1985] §3.2)
 
 Of the four combinations of agreement position and GF reference, Baker's (27) records
-only two as attested: inner agreement referencing semantic GFs (27a: Chamorro
-causative *fan-*, Turkish, Sanskrit, Quechua) and outer agreement referencing surface
-GFs (27d: by far the most common pattern cross-linguistically). No clear cases of
-(27b) or (27c) are found.
+only two as attested: outer agreement referencing surface GFs (27d: by far the most
+common — Chamorro person-number agreement, Turkish, Sanskrit, Quechua) and inner
+agreement referencing semantic GFs (27a: Chamorro causative *fan-*, with Achenese
+agreement and Huichol verb suppletion consistent with it). No clear cases of (27b) or
+(27c) are found.
 
 Achenese ((31)) is a defused near-falsifier, not an instance of (27a): its verbal
 agreement references semantic subjects under passivization, which would instantiate
@@ -67,19 +72,22 @@ theorem isAttested_derived (pos : AgreementPosition) :
 /-! ### Chamorro ([baker-1985] §§1, 3.1)
 
 Chamorro number agreement *man-* ~ *fan-* registers plurality of the subject; passive
-*-in-* promotes the object to subject; causative *na'-* adds a causer as subject.
+*-in-* promotes the object to subject; causative *na'-* adds a causer as subject
+(data from [gibson-1980]).
 Which "subject" *fan-* registers tracks its morphological position: outside the
 passive marker it references the surface subject, inside the causative marker the
 semantic subject. -/
 
 /-- Passive *Para#u#fan-s-in-aolak* 'The children are going to be spanked by their
 father': *fan-* outside *-in-* ([fan [in [saolak]]]), so *fan-* was added after
-passive and references the derived (surface) subject ([baker-1985] (15b), (21)). -/
+passive and references the derived (surface) subject ([baker-1985] (15b), (21)).
+Stimulus row: `Examples.chamorro_15b`. -/
 def chamorroPassiveAgreement : AgreementPattern := ⟨.outer, .surface⟩
 
 /-- Causative *Hu#na'-fan-otchu* 'I made them eat': *fan-* inside *na'-*
 ([na' [fan [otchu]]]), so *fan-* was added before causative and references the
-semantic subject of 'eat' ([baker-1985] (15c), (23)). -/
+semantic subject of 'eat' ([baker-1985] (15c), (23)). Stimulus row:
+`Examples.chamorro_15c`. -/
 def chamorroCausativeAgreement : AgreementPattern := ⟨.inner, .semantic⟩
 
 /-- The Chamorro passive pattern is the derived — hence attested — pattern for outer
@@ -97,7 +105,8 @@ theorem chamorroCausativeAgreement_isAttested : IsAttested chamorroCausativeAgre
 /-- Causative of passive *Hu#na'-fan-s-in-aolak i famagu'un gi as tata-n-niha* 'I had
 the children spanked by their father': passive applies first, then causative; *fan-*
 sits between the two GF-rule morphemes and registers the intermediate subject —
-post-passive, pre-causative ([baker-1985] (25), (26)). -/
+post-passive, pre-causative ([baker-1985] (25), (26)). Stimulus row:
+`Examples.chamorro_25`. -/
 def chamorroCausativePassive : Derivation :=
   [⟨.passive, "-in-"⟩, ⟨.causative, "na'-"⟩]
 
@@ -112,17 +121,20 @@ pre-change grammatical functions. Quechua and Bemba show the same two orders; th
 caus-recip order is interpreted differently in the two languages — Quechua links the
 causer to the initial patient ((39b)), Bemba to the initial agent ((49b)) — because
 Bemba's causative is Chamorro-type: the initial agent, not the patient, occupies the
-object position Reciprocal Formation binds ((50)–(52)). -/
+object position Reciprocal Formation binds ((50)–(52)). Quechua data from
+[muysken-1981]; Bemba data from [givon-1976]. -/
 
 /-- *Maqa-naku-ya-chi-n* 'He is causing them to beat each other': reciprocal *-naku*
 inside causative *-chi*, so Reciprocal applies first, linking agent and patient of
-the root; Causative then adds the causer ([baker-1985] (39a), (45)–(46)). -/
+the root; Causative then adds the causer ([baker-1985] (39a), (45)–(46)). Stimulus
+row: `Examples.quechua_39a`. -/
 def quechuaRecipInsideCaus : Derivation :=
   [⟨.reflexReciprocal, "-naku"⟩, ⟨.causative, "-chi"⟩]
 
 /-- *Maqa-chi-naku-rka-n* 'They let someone beat each other': causative *-chi* inside
 reciprocal *-naku*, so Causative applies first; Reciprocal then links the causers to
-the initial patients ([baker-1985] (39b), (47)–(48)). -/
+the initial patients ([baker-1985] (39b), (47)–(48)). Stimulus row:
+`Examples.quechua_39b`. -/
 def quechuaCausInsideRecip : Derivation :=
   [⟨.causative, "-chi"⟩, ⟨.reflexReciprocal, "-naku"⟩]
 
@@ -140,14 +152,15 @@ theorem quechua_ruleOrders_differ :
 
 /-- *Naa-mon-an-ya Mwape na Mutumba* 'I made Mwape and Mutumba see each other':
 reciprocal *-an* inside causative *-ya* — the same order and interpretation as
-Quechua (39a) ([baker-1985] (49a)). -/
+Quechua (39a) ([baker-1985] (49a)). Stimulus row: `Examples.bemba_49a`. -/
 def bembaRecipInsideCaus : Derivation :=
   [⟨.reflexReciprocal, "-an"⟩, ⟨.causative, "-ya"⟩]
 
 /-- *Mwape na Chilufya baa-mon-eshy-ana Mutumba* 'Mwape and Chilufya made each other
 see Mutumba': causative *-eshy* inside reciprocal *-ana*. Causative applies first
 and — being Chamorro-type — puts the initial agent in object position, so Reciprocal
-links causer and initial agent, unlike Quechua (39b) ([baker-1985] (49b), (52)). -/
+links causer and initial agent, unlike Quechua (39b) ([baker-1985] (49b), (52)).
+Stimulus row: `Examples.bemba_49b`. -/
 def bembaCausInsideRecip : Derivation :=
   [⟨.causative, "-eshy"⟩, ⟨.reflexReciprocal, "-ana"⟩]
 
@@ -165,26 +178,46 @@ theorem bemba_ruleOrders_match_quechua :
     ruleOrder bembaCausInsideRecip = ruleOrder quechuaCausInsideRecip :=
   ⟨rfl, rfl⟩
 
+/-- Both Quechua orders are acceptable stimuli with distinct interpretations — the
+morphological contrast carries an interpretive one, as the Mirror Principle requires. -/
+theorem quechua_both_orders_attested :
+    Examples.quechua_39a.judgment = .acceptable ∧
+    Examples.quechua_39b.judgment = .acceptable ∧
+    Examples.quechua_39a.translation ≠ Examples.quechua_39b.translation :=
+  ⟨rfl, rfl, by decide⟩
+
+/-- Both Bemba orders are likewise acceptable with distinct interpretations. -/
+theorem bemba_both_orders_attested :
+    Examples.bemba_49a.judgment = .acceptable ∧
+    Examples.bemba_49b.judgment = .acceptable ∧
+    Examples.bemba_49a.translation ≠ Examples.bemba_49b.translation :=
+  ⟨rfl, rfl, by decide⟩
+
 /-! ### Passive-applicative ordering ([baker-1985] §4.2)
 
 Applicative creates a new direct object ((53)); passive promotes a direct object to
 subject ((12)). When an applicative feeds a passive — the applied object becomes the
 surface subject — Applicative must apply first, so the Mirror Principle predicts the
 applied affix universally closer to the root than the passive affix. Attested:
-verb-appl-pass. Unattested: verb-pass-appl with oblique-to-subject promotion. -/
+verb-appl-pass. Unattested: verb-pass-appl with oblique-to-subject promotion.
+Huichol data from [comrie-1982], Chi-Mwi:ni from [kisseberth-abasheikh-1977],
+Kinyarwanda from [kimenyi-1980]. -/
 
 /-- Huichol *Tiiri yi-nauka-ti nawazi me-puutinanai-ri-yeri* 'Four children were
-bought a knife': benefactive *-ri* inside passive *-yeri* ([baker-1985] (55)). -/
+bought a knife': benefactive *-ri* inside passive *-yeri* ([baker-1985] (55)).
+Stimulus row: `Examples.huichol_55`. -/
 def huichol : Derivation := [⟨.applicative, "-ri"⟩, ⟨.passive, "-yeri"⟩]
 
 /-- Chi-Mwi:ni *Mwa:limu tet-el-el-a chibu:ku na Nu:ru* 'The teacher was brought the
 book by Nuru': applied *-el* inside passive *-a*, with aspect between them
-([baker-1985] (56c)). -/
+([baker-1985] (56c)). Stimulus rows: `Examples.chimwiini_56c` and the starred
+`Examples.chimwiini_56d`. -/
 def chiMwini : Derivation := [⟨.applicative, "-el"⟩, ⟨.passive, "-a"⟩]
 
 /-- Kinyarwanda *Ikaramu i-ra-andik-iish-w-a ibaruwa n'umugabo* 'The pen was
 written-with the letter by the man': instrumental applicative *-iish* inside passive
-*-w* ([baker-1985] (57c)). -/
+*-w* ([baker-1985] (57c)). Stimulus rows: `Examples.kinyarwanda_57c` and
+`Examples.kinyarwanda_57d`. -/
 def kinyarwanda : Derivation := [⟨.applicative, "-iish"⟩, ⟨.passive, "-w"⟩]
 
 /-- All three languages place the applied affix before the passive affix, as the
@@ -194,5 +227,20 @@ theorem appl_before_pass :
     ruleOrder chiMwini = [.applicative, .passive] ∧
     ruleOrder kinyarwanda = [.applicative, .passive] :=
   ⟨rfl, rfl, rfl⟩
+
+/-- The Mirror Principle's negative prediction in Chi-Mwi:ni: goal-to-subject promotion
+under appl-inside-pass morphology is acceptable ((56c)); reading the same morphology
+with patient-to-subject promotion is starred ((56d)), since Passive would then have to
+precede Applicative syntactically while following it morphologically. -/
+theorem chiMwini_star_contrast :
+    Examples.chimwiini_56c.judgment = .acceptable ∧
+    Examples.chimwiini_56d.judgment = .ungrammatical :=
+  ⟨rfl, rfl⟩
+
+/-- Kinyarwanda's counterpart of the starred Chi-Mwi:ni sentence is grammatical:
+Kinyarwanda passive independently promotes either postverbal NP of a double-object
+verb ((58)), so (57d) is not a Mirror Principle counterexample. -/
+theorem kinyarwanda_57d_acceptable :
+    Examples.kinyarwanda_57d.judgment = .acceptable := rfl
 
 end Baker1985

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -38674,3 +38674,71 @@
   role      = {cited},
   sources   = {Syntax/Clause/Construction.lean}
 }
+% REF: Gibson, J. D. (1980). Clause Union in Chamorro and in Universal Grammar. UCSD dissertation.
+@phdthesis{gibson-1980,
+  author    = {Gibson, Jeanne D.},
+  year      = {1980},
+  title     = {Clause Union in {Chamorro} and in Universal Grammar},
+  school    = {University of California, San Diego},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Baker1985.lean}
+}
+% REF: Muysken, P. (1981). Quechua word structure. In F. Heny (ed.), Binding and Filtering. MIT Press.
+@incollection{muysken-1981,
+  author    = {Muysken, Pieter},
+  year      = {1981},
+  title     = {Quechua Word Structure},
+  booktitle = {Binding and Filtering},
+  editor    = {Heny, Frank},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  subfield  = {morphology},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Baker1985.lean}
+}
+% REF: Givon, T. (1976). Some constraints on Bantu causativization. In M. Shibatani (ed.), Syntax and Semantics 6: The Grammar of Causative Constructions. Academic Press.
+@incollection{givon-1976,
+  author    = {Giv{\'o}n, Talmy},
+  year      = {1976},
+  title     = {Some Constraints on {Bantu} Causativization},
+  booktitle = {Syntax and Semantics 6: The Grammar of Causative Constructions},
+  editor    = {Shibatani, Masayoshi},
+  publisher = {Academic Press},
+  address   = {New York},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Baker1985.lean}
+}
+% REF: Comrie, B. (1982). Grammatical relations in Huichol. In P. J. Hopper & S. A. Thompson (eds.), Syntax and Semantics 15: Studies in Transitivity. Academic Press.
+@incollection{comrie-1982,
+  author    = {Comrie, Bernard},
+  year      = {1982},
+  title     = {Grammatical Relations in {Huichol}},
+  booktitle = {Syntax and Semantics 15: Studies in Transitivity},
+  editor    = {Hopper, Paul J. and Thompson, Sandra A.},
+  publisher = {Academic Press},
+  address   = {New York},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Baker1985.lean}
+}
+% REF: Kisseberth, C. W. & Abasheikh, M. I. (1977). The object relationship in Chi-Mwi:ni, a Bantu language. In P. Cole & J. M. Sadock (eds.), Syntax and Semantics 8: Grammatical Relations. Academic Press, 179-218.
+@incollection{kisseberth-abasheikh-1977,
+  author    = {Kisseberth, Charles W. and Abasheikh, Mohammad Imam},
+  year      = {1977},
+  title     = {The Object Relationship in {Chi-Mwi:ni}, a {Bantu} Language},
+  booktitle = {Syntax and Semantics 8: Grammatical Relations},
+  editor    = {Cole, Peter and Sadock, Jerrold M.},
+  publisher = {Academic Press},
+  address   = {New York},
+  pages     = {179--218},
+  subfield  = {syntax},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/Baker1985.lean}
+}


### PR DESCRIPTION
Promote the Baker 1985 glossed stimuli to `Data/Examples/Baker1985.json` (13 rows, every form verified against the PDF page images, not OCR), following up #2072.

- New bib entries for the originating sources (Gibson 1980, Muysken 1981, Givon 1976, Comrie 1982, Kisseberth & Abasheikh 1977), verified against the paper's reference list; rows carry source vs reportedIn provenance.
- Study file consumes the generated module: stimulus pointers on each analysis, plus row-grounded theorems (`chiMwini_star_contrast` for the starred (56d), `quechua_both_orders_attested` / `bemba_both_orders_attested`, `kinyarwanda_57d_acceptable`).
- Fixes a docstring misattribution caught against the print: Turkish/Sanskrit/Quechua evidence pattern (27d), not (27a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)