### PR TITLE
feat(Studies/KrizChemla2015): account predictions against pooled data

### DIFF
--- a/Linglib/Data/Examples/KrizChemla2015.json
+++ b/Linglib/Data/Examples/KrizChemla2015.json
@@ -11,13 +11,10 @@
       ["presents", "present.PL"]
     ],
     "translation": "Every boy found his presents.",
-    "context": "Four boys, each with nine presents to find; every boy found some but not all of his.",
+    "context": "Four boys, each with nine presents to find; three boys found all their presents, one boy found some but not all (Table 13 gap displays, e.g. 9929).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [
-      {"name": "strong/maximal", "judgment": "acceptable"},
-      {"name": "weak/non-maximal", "judgment": "marginal"}
-    ],
+    "readings": [],
     "paperFeatures": [
       ["operator", "every"],
       ["embedding", "E-every"],
@@ -25,7 +22,7 @@
       ["experiment", "C2"],
       ["gap_detected", "true"]
     ],
-    "comment": "C2 target condition. All three gap diagnostics significant (Table 9): Diag.1 β=6.7 χ²=26.7 p<10⁻⁶; Diag.2 β=7.7 χ²=35.1 p<10⁻⁸; Diag.3 β=4.9 χ²=4.0 p=.046. The 'weak/non-maximal' reading would interpret the sentence as 'every boy found some of his presents'; the paper finds this reading is marginal-to-rare in target-stimulus presentation, motivating the gap finding.",
+    "comment": "C2 target condition. All three gap diagnostics significant (Table 9): Diag.1 β=6.7 χ²=26.7 p<10⁻⁶; Diag.2 β=7.7 χ²=35.1 p<10⁻⁸; Diag.3 β=4.9 χ²=4.0 p=.046. The dominant neither-response shows participants did not fall back on the weak/non-maximal reading ('every boy found some of his presents'), which would have made the sentence true here.",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
@@ -41,13 +38,10 @@
       ["presents", "present.PL"]
     ],
     "translation": "No boy found his presents.",
-    "context": "Four boys, each with nine presents; some boys found some of their presents, but no boy found all of his.",
+    "context": "Four boys, each with nine presents; one boy found some but not all of his presents, the others found none (Table 13 gap displays, e.g. 0070).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [
-      {"name": "strong/no-any", "judgment": "acceptable"},
-      {"name": "weak/no-all", "judgment": "marginal"}
-    ],
+    "readings": [],
     "paperFeatures": [
       ["operator", "no"],
       ["embedding", "E-no"],
@@ -56,7 +50,111 @@
       ["gap_detected", "true"],
       ["gap_size", "small_but_robust"]
     ],
-    "comment": "C2 corrects the apparent null result from A2/B2 (which used the accidentally-ungrammatical 'In none of the cells...' stimulus, per fn. 10 and fn. 14). C2's grammatical 'No boy found his presents.' yields a small-but-robust gap on all three diagnostics (Table 9): Diag.1 β=1.3 χ²=8.2 p=.004; Diag.2 β=1.1 χ²=5.2 p=.022; Diag.3 β=1.6 χ²=7.8 p=.005. Quoting §5.2.3: 'this time, E-no does show a gap, which, albeit small, is robust.' This is the empirical finding the file records — not the pre-C2 null.",
+    "comment": "C2 corrects the apparent null result from A2/B2, whose E-no stimuli ('In none of the cells, ...') were accidentally ungrammatical for lack of negative inversion (fn. 10) and plausibly parsed with an unbound definite (fn. 14). C2's grammatical 'No boy found his presents.' yields a small-but-robust gap on all three diagnostics (Table 9): Diag.1 β=1.3 χ²=8.2 p=.004; Diag.2 β=1.1 χ²=5.2 p=.022; Diag.3 β=1.6 χ²=7.8 p=.005. Quoting §5.2.3: 'this time, E-no does show a gap, which, albeit small, is robust.'",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_every_C2_true",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (19) E-every+true condition"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Every boy found his presents.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Every", "every"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
+    ],
+    "translation": "Every boy found his presents.",
+    "context": "Four boys, each with nine presents; every boy found all nine of his (Table 13 display 9999).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "every"],
+      ["embedding", "E-every"],
+      ["condition", "TRUE"],
+      ["experiment", "C2"]
+    ],
+    "comment": "Judged completely true (Fig. 16).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_every_C2_false",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (19) E-every+false condition"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Every boy found his presents.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Every", "every"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
+    ],
+    "translation": "Every boy found his presents.",
+    "context": "Four boys; one boy found none of his presents, and two others found some but not all (Table 13 false displays, e.g. 9770).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "every"],
+      ["embedding", "E-every"],
+      ["condition", "FALSE"],
+      ["experiment", "C2"]
+    ],
+    "comment": "Judged completely false although some boys' present-sets are non-homogeneous — the basis of §6.3's argument (42) that a homogeneity presupposition cannot project universally from the scope of every/all.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_no_C2_true",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (20) E-no+true condition"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "No boy found his presents.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["No", "no"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
+    ],
+    "translation": "No boy found his presents.",
+    "context": "Four boys; no boy found any of his presents (Table 13 display 0000).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "no"],
+      ["embedding", "E-no"],
+      ["condition", "TRUE"],
+      ["experiment", "C2"]
+    ],
+    "comment": "Judged completely true (Fig. 16).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_no_C2_false",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C2, (20) E-no+false condition"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "No boy found his presents.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["No", "no"], ["boy", "boy"], ["found", "find.PST"], ["his", "3SG.M.POSS"],
+      ["presents", "present.PL"]
+    ],
+    "translation": "No boy found his presents.",
+    "context": "Four boys; one boy found all nine of his presents, another found five (Table 13 replacement displays, e.g. 5009).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "no"],
+      ["embedding", "E-no"],
+      ["condition", "FALSE"],
+      ["experiment", "C2"]
+    ],
+    "comment": "Judged completely false although the five-presents boy's set is non-homogeneous; like the E-every false condition, this excludes universal projection of a homogeneity presupposition (§6.3). C2's false-condition items replace the ungrammatical A2/B2 ones (Table 13 note).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
@@ -72,13 +170,10 @@
       ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
-    "context": "Four boys; exactly two of them found at least some of their presents, but in at most one of those two cells did the boy find all of his presents.",
+    "context": "Four boys; exactly two of them found some of their presents (in at most one case all of them), the other two found none (Table 13 gap displays, e.g. 9200, 3300).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [
-      {"name": "exactly/maximal", "judgment": "acceptable"},
-      {"name": "exactly/non-maximal", "judgment": "marginal"}
-    ],
+    "readings": [],
     "paperFeatures": [
       ["operator", "exactlyTwo"],
       ["embedding", "E-exactly"],
@@ -86,7 +181,7 @@
       ["experiment", "C3"],
       ["gap_detected", "true"]
     ],
-    "comment": "C3 proper-GAP condition: target stimulus designed so that the literal exactly-2-found-all reading and the exactly-2-found-some reading yield different truth values, isolating homogeneity projection in the non-monotonic embedded scope. All three gap diagnostics significant (Table 10): Diag.1 β=3.9 χ²=21.0 p<10⁻⁵; Diag.2 β=7.7 χ²=38.8 p<10⁻⁹; Diag.3 β=6.6 χ²=13.5 p=.0002.",
+    "comment": "C3 proper-gap condition: exactly 2 boys found some, but it is not the case that exactly 2 found all, so the some-substituted and all-substituted variants of the sentence differ in truth value. All three gap diagnostics significant (Table 10): Diag.1 β=3.9 χ²=21.0 p<10⁻⁵; Diag.2 β=7.7 χ²=38.8 p<10⁻⁹; Diag.3 β=6.6 χ²=13.5 p=.0002.",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
@@ -102,22 +197,19 @@
       ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
-    "context": "Four boys; one boy found all his presents; two boys each found some (not all) of theirs; one boy found none.",
+    "context": "Four boys; one boy found all his presents; two boys each found some (not all) of theirs; one boy found none (Table 13 gap? displays, e.g. 9202).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [
-      {"name": "exactly/maximal", "judgment": "questionable"},
-      {"name": "at-least-2/some", "judgment": "acceptable"}
-    ],
+    "readings": [],
     "paperFeatures": [
       ["operator", "exactlyTwo"],
       ["embedding", "E-exactly"],
       ["condition", "GAP?"],
       ["experiment", "C3"],
       ["gap_detected", "false"],
-      ["interpretation", "at_least_reading_emerges"]
+      ["classical_value", "false"]
     ],
-    "comment": "C3 GAP? condition does NOT yield a gap (Diag.1 p=.23, Diag.2 p=.15, Diag.3 p=.88 — Table 10). Theoretically load-bearing null: per §3.4 the result follows if 'exactly N' admits an at-least reading in this configuration (Marty, Chemla & Spector 2014 for parallel modified-numeral evidence), so what looks like a missing homogeneity gap is actually the at-least-reading rendering the sentence true. This null distinguishes supervaluation accounts (which would predict a gap) from exhaustification accounts (which allow the at-least reading).",
+    "comment": "No gap (Table 10: Diag.1 p=.23, Diag.2 p=.15, Diag.3 p=.88), replicating A3/B3. A predicted null: both the some-substituted ('exactly 2 found some': three did) and the all-substituted ('exactly 2 found all': one did) variants are false here, so every implicature construal and the two-candidate supervaluation account predict plain falsity (Table 12, s5); the observed value is recorded as classical_value=false accordingly ('the at least-reading, discussed in Sect. 3.4, seems to have disappeared in this experiment', §5.3). The null instead disfavors richer-candidate supervaluation variants (fn. 19) and universal projection of a homogeneity presupposition, which predict a gap here. §3.4's at-least reading of 'exactly 2' (Marty, Chemla & Spector 2014 on modified numerals) explains only the residual true/gap tendencies in A3.",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
@@ -133,13 +225,10 @@
       ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
     "translation": "Exactly 2 of the 4 boys found their presents.",
-    "context": "Four boys; exactly two boys each found all their presents; a third boy found some (not all) of his; the fourth found none. The at-least-reading is false here (since three boys found some), so the only way to judge 'true' is via the homogeneity-bridged exactly-reading.",
+    "context": "Four boys; exactly two boys each found all their presents; a third boy found some (not all) of his; the fourth found none (Table 13 gap?? displays, e.g. 9209).",
     "judgment": "acceptable",
     "alternatives": [],
-    "readings": [
-      {"name": "exactly/maximal", "judgment": "marginal"},
-      {"name": "at-least-2/some", "judgment": "unacceptable"}
-    ],
+    "readings": [],
     "paperFeatures": [
       ["operator", "exactlyTwo"],
       ["embedding", "E-exactly"],
@@ -147,22 +236,74 @@
       ["experiment", "C4"],
       ["gap_detected", "true"]
     ],
-    "comment": "C4 extends the C3 GAP? configuration to one where the at-least reading is false, ruling out the explanation that nulled GAP?. All three gap diagnostics significant (Table 11): Diag.1 β=4.4 χ²=13.4 p=.0002; Diag.2 β=7.6 χ²=49.4 p<10⁻¹¹; Diag.3 β=7.0 χ²=11.5 p=.0007. Combined with the GAP? null, this confirms that homogeneity *does* project from under 'exactly N', but only in configurations the at-least reading cannot rescue.",
+    "comment": "C4's new condition: the some-substituted variant ('exactly 2 found some') is false — three boys found some — while the all-substituted variant ('exactly 2 found all') is true, the mirror image of the gap condition. All three diagnostics significant (Table 11): Diag.1 β=4.4 χ²=13.4 p=.0002; Diag.2 β=7.6 χ²=49.4 p<10⁻¹¹; Diag.3 β=7.0 χ²=11.5 p=.0007. Table 12 (s6): construals that equate the gap with a literal-vs-global-exhaustification conflict predict plain falsity here, so the observed gap requires the implicature to be singled out as a meaning component or local exhaustification (§6.1.3).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_pos_all",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "id": "krizchemla2015_exactlyTwo_C3_true",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+true condition"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann liked the books.",
+    "primaryText": "Exactly 2 of the 4 boys found their presents.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["liked", "like.PST"], ["the", "DEF"], ["books", "book.PL"]
+      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"],
+      ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
     ],
-    "translation": "Ann liked the books.",
-    "context": "Six shortlisted books; Ann liked all 6 shortlisted books.",
+    "translation": "Exactly 2 of the 4 boys found their presents.",
+    "context": "Four boys; exactly two boys found all nine of their presents, the other two found none (Table 13 displays, e.g. 9900).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "exactlyTwo"],
+      ["embedding", "E-exactly"],
+      ["condition", "TRUE"],
+      ["experiment", "C3"]
+    ],
+    "comment": "Judged completely true (Fig. 17).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_exactlyTwo_C3_false",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. C3, (24) E-exactly+false condition"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "Exactly 2 of the 4 boys found their presents.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Exactly", "exactly"], ["2", "two"], ["of", "of"], ["the", "DEF"], ["4", "four"],
+      ["boys", "boy.PL"], ["found", "find.PST"], ["their", "3PL.POSS"], ["presents", "present.PL"]
+    ],
+    "translation": "Exactly 2 of the 4 boys found their presents.",
+    "context": "Four boys; one boy found some but not all of his presents, the others found none (Table 13 false displays, e.g. 4000).",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["operator", "exactlyTwo"],
+      ["embedding", "E-exactly"],
+      ["condition", "FALSE"],
+      ["experiment", "C3"]
+    ],
+    "comment": "Judged completely false (Fig. 17). §3.4 notes elevated true-responses on false displays where more than 2 boys' cells contain target objects (9990-type items), evidence of a non-salient at-least reading of 'exactly 2' (Marty, Chemla & Spector 2014).",
+    "metaLanguage": "stan1293",
+    "lgrConformance": "WORD_ALIGNED"
+  },
+  {
+    "id": "krizchemla2015_pos_A1_all",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-∅, 9/9 target-color display"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "The triangles are blue.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["are", "COP.PL"], ["blue", "blue"]
+    ],
+    "translation": "The triangles are blue.",
+    "context": "Nine triangles in the display; all nine are blue.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
@@ -171,22 +312,22 @@
       ["condition", "ALL"],
       ["embedding", "unembedded"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInAll = clearlyTrue): sentence judged clearly true in the ALL scenario.",
+    "comment": "Judged completely true. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_pos_none",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "id": "krizchemla2015_pos_A1_none",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-∅, 0/9 target-color display"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann liked the books.",
+    "primaryText": "The triangles are blue.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["liked", "like.PST"], ["the", "DEF"], ["books", "book.PL"]
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["are", "COP.PL"], ["blue", "blue"]
     ],
-    "translation": "Ann liked the books.",
-    "context": "Six shortlisted books; Ann liked none of the 6 shortlisted books.",
+    "translation": "The triangles are blue.",
+    "context": "Nine triangles in the display; none is blue.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
@@ -195,23 +336,23 @@
       ["condition", "NONE"],
       ["embedding", "unembedded"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInNone = clearlyFalse): sentence is grammatical and felicitous but judged clearly FALSE in the NONE scenario; the 5-level scale has no truth-value slot, so falsity is recorded here.",
+    "comment": "Judged completely false. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_pos_gap",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books)"},
+    "id": "krizchemla2015_pos_A1_gap",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-∅, mixed display"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann liked the books.",
+    "primaryText": "The triangles are blue.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["liked", "like.PST"], ["the", "DEF"], ["books", "book.PL"]
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["are", "COP.PL"], ["blue", "blue"]
     ],
-    "translation": "Ann liked the books.",
-    "context": "Six shortlisted books; Ann liked 3 of the 6 shortlisted books.",
-    "judgment": "questionable",
+    "translation": "The triangles are blue.",
+    "context": "Nine triangles in the display; four are blue, five are another color.",
+    "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
@@ -220,23 +361,22 @@
       ["embedding", "unembedded"],
       ["gap_detected", "true"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario.",
+    "comment": "Judged neither completely true nor completely false: the unembedded homogeneity gap. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_neg_all",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "id": "krizchemla2015_neg_A1_all",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-neg, 9/9 target-color display"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann didn't like the books.",
+    "primaryText": "The triangles aren't blue.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
-      ["books", "book.PL"]
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["aren't", "COP.PL.NEG"], ["blue", "blue"]
     ],
-    "translation": "Ann didn't like the books.",
-    "context": "Six shortlisted books; Ann liked all 6 shortlisted books.",
+    "translation": "The triangles aren't blue.",
+    "context": "Nine triangles in the display; all nine are blue.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
@@ -245,23 +385,22 @@
       ["condition", "ALL"],
       ["embedding", "unembedded"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInAll = clearlyFalse): sentence is grammatical and felicitous but judged clearly FALSE in the ALL scenario.",
+    "comment": "Judged completely false. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_neg_none",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "id": "krizchemla2015_neg_A1_none",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-neg, 0/9 target-color display"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann didn't like the books.",
+    "primaryText": "The triangles aren't blue.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
-      ["books", "book.PL"]
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["aren't", "COP.PL.NEG"], ["blue", "blue"]
     ],
-    "translation": "Ann didn't like the books.",
-    "context": "Six shortlisted books; Ann liked none of the 6 shortlisted books.",
+    "translation": "The triangles aren't blue.",
+    "context": "Nine triangles in the display; none is blue.",
     "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
@@ -270,24 +409,23 @@
       ["condition", "NONE"],
       ["embedding", "unembedded"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInNone = clearlyTrue): sentence judged clearly true in the NONE scenario — negation requires existential denial (none liked).",
+    "comment": "Judged completely true: the negated sentence requires total absence, not mere non-totality. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   },
   {
-    "id": "krizchemla2015_books_neg_gap",
-    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "unembedded plural-definite baseline (books, negated)"},
+    "id": "krizchemla2015_neg_A1_gap",
+    "source": {"bibkey": "kriz-chemla-2015", "paperLabel": "Exp. A1, the+E-neg, mixed display"},
     "reportedIn": null,
     "language": "stan1293",
-    "primaryText": "Ann didn't like the books.",
+    "primaryText": "The triangles aren't blue.",
     "discourseSegments": [],
     "glossedTokens": [
-      ["Ann", "Ann"], ["didn't", "do.PST.NEG"], ["like", "like"], ["the", "DEF"],
-      ["books", "book.PL"]
+      ["The", "DEF"], ["triangles", "triangle.PL"], ["aren't", "COP.PL.NEG"], ["blue", "blue"]
     ],
-    "translation": "Ann didn't like the books.",
-    "context": "Six shortlisted books; Ann liked 3 of the 6 shortlisted books.",
-    "judgment": "questionable",
+    "translation": "The triangles aren't blue.",
+    "context": "Nine triangles in the display; four are blue, five are another color.",
+    "judgment": "acceptable",
     "alternatives": [],
     "readings": [],
     "paperFeatures": [
@@ -296,7 +434,7 @@
       ["embedding", "unembedded"],
       ["gap_detected", "true"]
     ],
-    "comment": "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario.",
+    "comment": "Judged neither completely true nor completely false: the gap projects through negation. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6).",
     "metaLanguage": "stan1293",
     "lgrConformance": "WORD_ALIGNED"
   }

--- a/Linglib/Data/Examples/KrizChemla2015.lean
+++ b/Linglib/Data/Examples/KrizChemla2015.lean
@@ -22,12 +22,12 @@ def every_C2_gap : LinguisticExample :=
     discourseSegments := []
     glossedTokens := [("Every", "every"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
     translation := "Every boy found his presents."
-    context := "Four boys, each with nine presents to find; every boy found some but not all of his."
+    context := "Four boys, each with nine presents to find; three boys found all their presents, one boy found some but not all (Table 13 gap displays, e.g. 9929)."
     judgment := .acceptable
     alternatives := []
-    readings := [("strong/maximal", .acceptable), ("weak/non-maximal", .marginal)]
+    readings := []
     paperFeatures := [("operator", "every"), ("embedding", "E-every"), ("condition", "GAP"), ("experiment", "C2"), ("gap_detected", "true")]
-    comment := "C2 target condition. All three gap diagnostics significant (Table 9): Diag.1 β=6.7 χ²=26.7 p<10⁻⁶; Diag.2 β=7.7 χ²=35.1 p<10⁻⁸; Diag.3 β=4.9 χ²=4.0 p=.046. The 'weak/non-maximal' reading would interpret the sentence as 'every boy found some of his presents'; the paper finds this reading is marginal-to-rare in target-stimulus presentation, motivating the gap finding."
+    comment := "C2 target condition. All three gap diagnostics significant (Table 9): Diag.1 β=6.7 χ²=26.7 p<10⁻⁶; Diag.2 β=7.7 χ²=35.1 p<10⁻⁸; Diag.3 β=4.9 χ²=4.0 p=.046. The dominant neither-response shows participants did not fall back on the weak/non-maximal reading ('every boy found some of his presents'), which would have made the sentence true here."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
@@ -40,12 +40,84 @@ def no_C2_gap : LinguisticExample :=
     discourseSegments := []
     glossedTokens := [("No", "no"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
     translation := "No boy found his presents."
-    context := "Four boys, each with nine presents; some boys found some of their presents, but no boy found all of his."
+    context := "Four boys, each with nine presents; one boy found some but not all of his presents, the others found none (Table 13 gap displays, e.g. 0070)."
     judgment := .acceptable
     alternatives := []
-    readings := [("strong/no-any", .acceptable), ("weak/no-all", .marginal)]
+    readings := []
     paperFeatures := [("operator", "no"), ("embedding", "E-no"), ("condition", "GAP"), ("experiment", "C2"), ("gap_detected", "true"), ("gap_size", "small_but_robust")]
-    comment := "C2 corrects the apparent null result from A2/B2 (which used the accidentally-ungrammatical 'In none of the cells...' stimulus, per fn. 10 and fn. 14). C2's grammatical 'No boy found his presents.' yields a small-but-robust gap on all three diagnostics (Table 9): Diag.1 β=1.3 χ²=8.2 p=.004; Diag.2 β=1.1 χ²=5.2 p=.022; Diag.3 β=1.6 χ²=7.8 p=.005. Quoting §5.2.3: 'this time, E-no does show a gap, which, albeit small, is robust.' This is the empirical finding the file records — not the pre-C2 null."
+    comment := "C2 corrects the apparent null result from A2/B2, whose E-no stimuli ('In none of the cells, ...') were accidentally ungrammatical for lack of negative inversion (fn. 10) and plausibly parsed with an unbound definite (fn. 14). C2's grammatical 'No boy found his presents.' yields a small-but-robust gap on all three diagnostics (Table 9): Diag.1 β=1.3 χ²=8.2 p=.004; Diag.2 β=1.1 χ²=5.2 p=.022; Diag.3 β=1.6 χ²=7.8 p=.005. Quoting §5.2.3: 'this time, E-no does show a gap, which, albeit small, is robust.'"
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def every_C2_true : LinguisticExample :=
+  { id := "krizchemla2015_every_C2_true"
+    source := ⟨"kriz-chemla-2015", "Exp. C2, (19) E-every+true condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every boy found his presents."
+    discourseSegments := []
+    glossedTokens := [("Every", "every"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
+    translation := "Every boy found his presents."
+    context := "Four boys, each with nine presents; every boy found all nine of his (Table 13 display 9999)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "every"), ("embedding", "E-every"), ("condition", "TRUE"), ("experiment", "C2")]
+    comment := "Judged completely true (Fig. 16)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def every_C2_false : LinguisticExample :=
+  { id := "krizchemla2015_every_C2_false"
+    source := ⟨"kriz-chemla-2015", "Exp. C2, (19) E-every+false condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Every boy found his presents."
+    discourseSegments := []
+    glossedTokens := [("Every", "every"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
+    translation := "Every boy found his presents."
+    context := "Four boys; one boy found none of his presents, and two others found some but not all (Table 13 false displays, e.g. 9770)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "every"), ("embedding", "E-every"), ("condition", "FALSE"), ("experiment", "C2")]
+    comment := "Judged completely false although some boys' present-sets are non-homogeneous — the basis of §6.3's argument (42) that a homogeneity presupposition cannot project universally from the scope of every/all."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def no_C2_true : LinguisticExample :=
+  { id := "krizchemla2015_no_C2_true"
+    source := ⟨"kriz-chemla-2015", "Exp. C2, (20) E-no+true condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No boy found his presents."
+    discourseSegments := []
+    glossedTokens := [("No", "no"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
+    translation := "No boy found his presents."
+    context := "Four boys; no boy found any of his presents (Table 13 display 0000)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "no"), ("embedding", "E-no"), ("condition", "TRUE"), ("experiment", "C2")]
+    comment := "Judged completely true (Fig. 16)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def no_C2_false : LinguisticExample :=
+  { id := "krizchemla2015_no_C2_false"
+    source := ⟨"kriz-chemla-2015", "Exp. C2, (20) E-no+false condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "No boy found his presents."
+    discourseSegments := []
+    glossedTokens := [("No", "no"), ("boy", "boy"), ("found", "find.PST"), ("his", "3SG.M.POSS"), ("presents", "present.PL")]
+    translation := "No boy found his presents."
+    context := "Four boys; one boy found all nine of his presents, another found five (Table 13 replacement displays, e.g. 5009)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "no"), ("embedding", "E-no"), ("condition", "FALSE"), ("experiment", "C2")]
+    comment := "Judged completely false although the five-presents boy's set is non-homogeneous; like the E-every false condition, this excludes universal projection of a homogeneity presupposition (§6.3). C2's false-condition items replace the ungrammatical A2/B2 ones (Table 13 note)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
@@ -58,12 +130,12 @@ def exactlyTwo_C3_gap : LinguisticExample :=
     discourseSegments := []
     glossedTokens := [("Exactly", "exactly"), ("2", "two"), ("of", "of"), ("the", "DEF"), ("4", "four"), ("boys", "boy.PL"), ("found", "find.PST"), ("their", "3PL.POSS"), ("presents", "present.PL")]
     translation := "Exactly 2 of the 4 boys found their presents."
-    context := "Four boys; exactly two of them found at least some of their presents, but in at most one of those two cells did the boy find all of his presents."
+    context := "Four boys; exactly two of them found some of their presents (in at most one case all of them), the other two found none (Table 13 gap displays, e.g. 9200, 3300)."
     judgment := .acceptable
     alternatives := []
-    readings := [("exactly/maximal", .acceptable), ("exactly/non-maximal", .marginal)]
+    readings := []
     paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "GAP"), ("experiment", "C3"), ("gap_detected", "true")]
-    comment := "C3 proper-GAP condition: target stimulus designed so that the literal exactly-2-found-all reading and the exactly-2-found-some reading yield different truth values, isolating homogeneity projection in the non-monotonic embedded scope. All three gap diagnostics significant (Table 10): Diag.1 β=3.9 χ²=21.0 p<10⁻⁵; Diag.2 β=7.7 χ²=38.8 p<10⁻⁹; Diag.3 β=6.6 χ²=13.5 p=.0002."
+    comment := "C3 proper-gap condition: exactly 2 boys found some, but it is not the case that exactly 2 found all, so the some-substituted and all-substituted variants of the sentence differ in truth value. All three gap diagnostics significant (Table 10): Diag.1 β=3.9 χ²=21.0 p<10⁻⁵; Diag.2 β=7.7 χ²=38.8 p<10⁻⁹; Diag.3 β=6.6 χ²=13.5 p=.0002."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
@@ -76,12 +148,12 @@ def exactlyTwo_C3_gap_q : LinguisticExample :=
     discourseSegments := []
     glossedTokens := [("Exactly", "exactly"), ("2", "two"), ("of", "of"), ("the", "DEF"), ("4", "four"), ("boys", "boy.PL"), ("found", "find.PST"), ("their", "3PL.POSS"), ("presents", "present.PL")]
     translation := "Exactly 2 of the 4 boys found their presents."
-    context := "Four boys; one boy found all his presents; two boys each found some (not all) of theirs; one boy found none."
+    context := "Four boys; one boy found all his presents; two boys each found some (not all) of theirs; one boy found none (Table 13 gap? displays, e.g. 9202)."
     judgment := .acceptable
     alternatives := []
-    readings := [("exactly/maximal", .questionable), ("at-least-2/some", .acceptable)]
-    paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "GAP?"), ("experiment", "C3"), ("gap_detected", "false"), ("interpretation", "at_least_reading_emerges")]
-    comment := "C3 GAP? condition does NOT yield a gap (Diag.1 p=.23, Diag.2 p=.15, Diag.3 p=.88 — Table 10). Theoretically load-bearing null: per §3.4 the result follows if 'exactly N' admits an at-least reading in this configuration (Marty, Chemla & Spector 2014 for parallel modified-numeral evidence), so what looks like a missing homogeneity gap is actually the at-least-reading rendering the sentence true. This null distinguishes supervaluation accounts (which would predict a gap) from exhaustification accounts (which allow the at-least reading)."
+    readings := []
+    paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "GAP?"), ("experiment", "C3"), ("gap_detected", "false"), ("classical_value", "false")]
+    comment := "No gap (Table 10: Diag.1 p=.23, Diag.2 p=.15, Diag.3 p=.88), replicating A3/B3. A predicted null: both the some-substituted ('exactly 2 found some': three did) and the all-substituted ('exactly 2 found all': one did) variants are false here, so every implicature construal and the two-candidate supervaluation account predict plain falsity (Table 12, s5); the observed value is recorded as classical_value=false accordingly ('the at least-reading, discussed in Sect. 3.4, seems to have disappeared in this experiment', §5.3). The null instead disfavors richer-candidate supervaluation variants (fn. 19) and universal projection of a homogeneity presupposition, which predict a gap here. §3.4's at-least reading of 'exactly 2' (Marty, Chemla & Spector 2014 on modified numerals) explains only the residual true/gap tendencies in A3."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
@@ -94,123 +166,159 @@ def exactlyTwo_C4_gap_qq : LinguisticExample :=
     discourseSegments := []
     glossedTokens := [("Exactly", "exactly"), ("2", "two"), ("of", "of"), ("the", "DEF"), ("4", "four"), ("boys", "boy.PL"), ("found", "find.PST"), ("their", "3PL.POSS"), ("presents", "present.PL")]
     translation := "Exactly 2 of the 4 boys found their presents."
-    context := "Four boys; exactly two boys each found all their presents; a third boy found some (not all) of his; the fourth found none. The at-least-reading is false here (since three boys found some), so the only way to judge 'true' is via the homogeneity-bridged exactly-reading."
+    context := "Four boys; exactly two boys each found all their presents; a third boy found some (not all) of his; the fourth found none (Table 13 gap?? displays, e.g. 9209)."
     judgment := .acceptable
     alternatives := []
-    readings := [("exactly/maximal", .marginal), ("at-least-2/some", .unacceptable)]
+    readings := []
     paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "GAP??"), ("experiment", "C4"), ("gap_detected", "true")]
-    comment := "C4 extends the C3 GAP? configuration to one where the at-least reading is false, ruling out the explanation that nulled GAP?. All three gap diagnostics significant (Table 11): Diag.1 β=4.4 χ²=13.4 p=.0002; Diag.2 β=7.6 χ²=49.4 p<10⁻¹¹; Diag.3 β=7.0 χ²=11.5 p=.0007. Combined with the GAP? null, this confirms that homogeneity *does* project from under 'exactly N', but only in configurations the at-least reading cannot rescue."
+    comment := "C4's new condition: the some-substituted variant ('exactly 2 found some') is false — three boys found some — while the all-substituted variant ('exactly 2 found all') is true, the mirror image of the gap condition. All three diagnostics significant (Table 11): Diag.1 β=4.4 χ²=13.4 p=.0002; Diag.2 β=7.6 χ²=49.4 p<10⁻¹¹; Diag.3 β=7.0 χ²=11.5 p=.0007. Table 12 (s6): construals that equate the gap with a literal-vs-global-exhaustification conflict predict plain falsity here, so the observed gap requires the implicature to be singled out as a meaning component or local exhaustification (§6.1.3)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_pos_all : LinguisticExample :=
-  { id := "krizchemla2015_books_pos_all"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books)"⟩
+def exactlyTwo_C3_true : LinguisticExample :=
+  { id := "krizchemla2015_exactlyTwo_C3_true"
+    source := ⟨"kriz-chemla-2015", "Exp. C3, (24) E-exactly+true condition"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann liked the books."
+    primaryText := "Exactly 2 of the 4 boys found their presents."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("liked", "like.PST"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann liked the books."
-    context := "Six shortlisted books; Ann liked all 6 shortlisted books."
+    glossedTokens := [("Exactly", "exactly"), ("2", "two"), ("of", "of"), ("the", "DEF"), ("4", "four"), ("boys", "boy.PL"), ("found", "find.PST"), ("their", "3PL.POSS"), ("presents", "present.PL")]
+    translation := "Exactly 2 of the 4 boys found their presents."
+    context := "Four boys; exactly two boys found all nine of their presents, the other two found none (Table 13 displays, e.g. 9900)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "TRUE"), ("experiment", "C3")]
+    comment := "Judged completely true (Fig. 17)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def exactlyTwo_C3_false : LinguisticExample :=
+  { id := "krizchemla2015_exactlyTwo_C3_false"
+    source := ⟨"kriz-chemla-2015", "Exp. C3, (24) E-exactly+false condition"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "Exactly 2 of the 4 boys found their presents."
+    discourseSegments := []
+    glossedTokens := [("Exactly", "exactly"), ("2", "two"), ("of", "of"), ("the", "DEF"), ("4", "four"), ("boys", "boy.PL"), ("found", "find.PST"), ("their", "3PL.POSS"), ("presents", "present.PL")]
+    translation := "Exactly 2 of the 4 boys found their presents."
+    context := "Four boys; one boy found some but not all of his presents, the others found none (Table 13 false displays, e.g. 4000)."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("operator", "exactlyTwo"), ("embedding", "E-exactly"), ("condition", "FALSE"), ("experiment", "C3")]
+    comment := "Judged completely false (Fig. 17). §3.4 notes elevated true-responses on false displays where more than 2 boys' cells contain target objects (9990-type items), evidence of a non-salient at-least reading of 'exactly 2' (Marty, Chemla & Spector 2014)."
+    metaLanguage := "stan1293"
+    lgrConformance := "WORD_ALIGNED" }
+
+def pos_A1_all : LinguisticExample :=
+  { id := "krizchemla2015_pos_A1_all"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-∅, 9/9 target-color display"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "The triangles are blue."
+    discourseSegments := []
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("are", "COP.PL"), ("blue", "blue")]
+    translation := "The triangles are blue."
+    context := "Nine triangles in the display; all nine are blue."
     judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "positive"), ("condition", "ALL"), ("embedding", "unembedded")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInAll = clearlyTrue): sentence judged clearly true in the ALL scenario."
+    comment := "Judged completely true. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_pos_none : LinguisticExample :=
-  { id := "krizchemla2015_books_pos_none"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books)"⟩
+def pos_A1_none : LinguisticExample :=
+  { id := "krizchemla2015_pos_A1_none"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-∅, 0/9 target-color display"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann liked the books."
+    primaryText := "The triangles are blue."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("liked", "like.PST"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann liked the books."
-    context := "Six shortlisted books; Ann liked none of the 6 shortlisted books."
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("are", "COP.PL"), ("blue", "blue")]
+    translation := "The triangles are blue."
+    context := "Nine triangles in the display; none is blue."
     judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "positive"), ("condition", "NONE"), ("embedding", "unembedded")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInNone = clearlyFalse): sentence is grammatical and felicitous but judged clearly FALSE in the NONE scenario; the 5-level scale has no truth-value slot, so falsity is recorded here."
+    comment := "Judged completely false. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_pos_gap : LinguisticExample :=
-  { id := "krizchemla2015_books_pos_gap"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books)"⟩
+def pos_A1_gap : LinguisticExample :=
+  { id := "krizchemla2015_pos_A1_gap"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-∅, mixed display"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann liked the books."
+    primaryText := "The triangles are blue."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("liked", "like.PST"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann liked the books."
-    context := "Six shortlisted books; Ann liked 3 of the 6 shortlisted books."
-    judgment := .questionable
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("are", "COP.PL"), ("blue", "blue")]
+    translation := "The triangles are blue."
+    context := "Nine triangles in the display; four are blue, five are another color."
+    judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "positive"), ("condition", "GAP"), ("embedding", "unembedded"), ("gap_detected", "true")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (positiveInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario."
+    comment := "Judged neither completely true nor completely false: the unembedded homogeneity gap. Exp. A1 target sentences had the form 'The [shapes] are [color]' (schema (6a)/(8a)), judged against displays of nine shapes with 0, 2, 4, 6, 8, or 9 in the target color. All three gap diagnostics significant for E-∅ (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_neg_all : LinguisticExample :=
-  { id := "krizchemla2015_books_neg_all"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books, negated)"⟩
+def neg_A1_all : LinguisticExample :=
+  { id := "krizchemla2015_neg_A1_all"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-neg, 9/9 target-color display"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann didn't like the books."
+    primaryText := "The triangles aren't blue."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("didn't", "do.PST.NEG"), ("like", "like"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann didn't like the books."
-    context := "Six shortlisted books; Ann liked all 6 shortlisted books."
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("aren't", "COP.PL.NEG"), ("blue", "blue")]
+    translation := "The triangles aren't blue."
+    context := "Nine triangles in the display; all nine are blue."
     judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "negative"), ("condition", "ALL"), ("embedding", "unembedded")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInAll = clearlyFalse): sentence is grammatical and felicitous but judged clearly FALSE in the ALL scenario."
+    comment := "Judged completely false. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_neg_none : LinguisticExample :=
-  { id := "krizchemla2015_books_neg_none"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books, negated)"⟩
+def neg_A1_none : LinguisticExample :=
+  { id := "krizchemla2015_neg_A1_none"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-neg, 0/9 target-color display"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann didn't like the books."
+    primaryText := "The triangles aren't blue."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("didn't", "do.PST.NEG"), ("like", "like"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann didn't like the books."
-    context := "Six shortlisted books; Ann liked none of the 6 shortlisted books."
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("aren't", "COP.PL.NEG"), ("blue", "blue")]
+    translation := "The triangles aren't blue."
+    context := "Nine triangles in the display; none is blue."
     judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "negative"), ("condition", "NONE"), ("embedding", "unembedded")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInNone = clearlyTrue): sentence judged clearly true in the NONE scenario — negation requires existential denial (none liked)."
+    comment := "Judged completely true: the negated sentence requires total absence, not mere non-totality. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def books_neg_gap : LinguisticExample :=
-  { id := "krizchemla2015_books_neg_gap"
-    source := ⟨"kriz-chemla-2015", "unembedded plural-definite baseline (books, negated)"⟩
+def neg_A1_gap : LinguisticExample :=
+  { id := "krizchemla2015_neg_A1_gap"
+    source := ⟨"kriz-chemla-2015", "Exp. A1, the+E-neg, mixed display"⟩
     reportedIn := none
     language := "stan1293"
-    primaryText := "Ann didn't like the books."
+    primaryText := "The triangles aren't blue."
     discourseSegments := []
-    glossedTokens := [("Ann", "Ann"), ("didn't", "do.PST.NEG"), ("like", "like"), ("the", "DEF"), ("books", "book.PL")]
-    translation := "Ann didn't like the books."
-    context := "Six shortlisted books; Ann liked 3 of the 6 shortlisted books."
-    judgment := .questionable
+    glossedTokens := [("The", "DEF"), ("triangles", "triangle.PL"), ("aren't", "COP.PL.NEG"), ("blue", "blue")]
+    translation := "The triangles aren't blue."
+    context := "Nine triangles in the display; four are blue, five are another color."
+    judgment := .acceptable
     alternatives := []
     readings := []
     paperFeatures := [("polarity", "negative"), ("condition", "GAP"), ("embedding", "unembedded"), ("gap_detected", "true")]
-    comment := "Migrated from Phenomena/Plurals/Homogeneity.lean booksExample (negativeInGap = neitherTrueNorFalse): homogeneity gap — neither clearly true nor clearly false in the some-but-not-all scenario."
+    comment := "Judged neither completely true nor completely false: the gap projects through negation. Exp. A1 negated targets had the form 'The [shapes] aren't [color]' (schema (8b)); homogeneity projects through sentential negation. All three gap diagnostics significant for E-neg (Table 3); replicated with the ternary method in Exp. B1 (Table 6)."
     metaLanguage := "stan1293"
     lgrConformance := "WORD_ALIGNED" }
 
-def all : List LinguisticExample := [every_C2_gap, no_C2_gap, exactlyTwo_C3_gap, exactlyTwo_C3_gap_q, exactlyTwo_C4_gap_qq, books_pos_all, books_pos_none, books_pos_gap, books_neg_all, books_neg_none, books_neg_gap]
+def all : List LinguisticExample := [every_C2_gap, no_C2_gap, every_C2_true, every_C2_false, no_C2_true, no_C2_false, exactlyTwo_C3_gap, exactlyTwo_C3_gap_q, exactlyTwo_C4_gap_qq, exactlyTwo_C3_true, exactlyTwo_C3_false, pos_A1_all, pos_A1_none, pos_A1_gap, neg_A1_all, neg_A1_none, neg_A1_gap]
 
 end KrizChemla2015.Examples

--- a/Linglib/Data/Generalizations/HomogeneityProjection.lean
+++ b/Linglib/Data/Generalizations/HomogeneityProjection.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Data.Trivalent
 import Linglib.Data.Examples.Schema
 import Linglib.Data.Examples.KrizChemla2015
+import Linglib.Data.Generalizations.HomogeneityGap
 
 /-!
 # Generalizations.HomogeneityProjection — cross-paper prediction target
@@ -21,7 +22,7 @@ generalisation predates any one formal account, justifying a theory-neutral
   (TRUE / FALSE / GAP / GAP? / GAP??).
 * `ProjectionPredict` — the shared signature any account of homogeneity
   projection must satisfy; given an `(operator, scenario)` pair, predict a
-  trivalent `Trivalent` value.
+  `Trivalent` value.
 * `ProjectionDatum` — typed empirical datum; lifted from the raw
   `LinguisticExample` rows by `fromExample`.
 * `Examples` (generator-managed) — pooled stimulus rows from each paper
@@ -30,10 +31,6 @@ generalisation predates any one formal account, justifying a theory-neutral
   generated `Data.Examples.<Paper>` module (see `scripts/gen_examples.py`).
 * `allData` — the test pool: every `LinguisticExample` whose
   `paperFeatures` carry the keys this hub recognises.
-
-Studies files (e.g. [[KrizChemla2015]], [[AugurzkyEtAl2023]]) retrieve their
-paper-specific slice from their own `<Paper>.Examples.all` (option-B
-per-paper accessor pattern).
 
 ## Implementation notes
 
@@ -59,14 +56,15 @@ mapping would be wrong for at least one consumer.
 
 ## Todo
 
-* Wire `ProjectionPredict` implementations from each rival account: the
-  scalar-implicature/exhaustification accounts ([magri-2014],
-  [bar-lev-2021]), the supervaluation/trivalence accounts
-  ([spector-2013], [kriz-2016], [kriz-spector-2021]), and
-  the presupposition account ([gajewski-2005] + Schwarzschild 1994 —
-  no linglib study file yet).
-* Prove decidable per-datum predictions and cross-account divergence
-  theorems once those implementations land.
+* Wire total `ProjectionPredict` implementations from the rival accounts
+  postdating [kriz-chemla-2015]: the exhaustification account
+  ([bar-lev-2021]) and the mature supervaluation/trivalence accounts
+  ([kriz-2016], [kriz-spector-2021]). The account variants the paper
+  itself assesses — [magri-2014]-style implicature construals,
+  [spector-2013] supervaluation, and [schwarzschild-1994] /
+  [lobner-2000] / [gajewski-2005] presupposition with universal
+  projection — are implemented against this pool in
+  `Studies/KrizChemla2015.lean`, restricted to the paper's tested cells.
 * Add a denotation hook `EmbeddingOperator → ∀ α, Quantification.GQ α`
   once accounts derive predictions structurally rather than dispatch on
   label (per [peters-westerstahl-2006] discipline).
@@ -93,15 +91,16 @@ inductive EmbeddingOperator where
 /--
 Scenario classification used by the trivalent-judgment paradigm
 ([kriz-chemla-2015]). The first three are the canonical TRUE / FALSE
-/ GAP triad; `gapQ` and `gapQQ` are the `exactly N` refinements that
-isolate the at-least-reading from genuine homogeneity projection.
+/ GAP triad; `gapQ` and `gapQQ` are the `exactly N` refinements probing
+the two ways the some-substituted and all-substituted variants of the
+sentence can pattern in a candidate gap situation (Table 12's s5/s6).
 -/
 inductive GapScenario where
-  | trueScenario   -- all-positive baseline
-  | falseScenario  -- all-negative baseline
-  | gap            -- standard mixed scenario (homogeneity violated)
-  | gapQ           -- at-least reading possible (exactly-only)
-  | gapQQ          -- at-least reading ruled out (exactly-only)
+  | trueScenario   -- clear-truth baseline
+  | falseScenario  -- clear-falsity baseline
+  | gap            -- some-variant true, all-variant false (homogeneity violated)
+  | gapQ           -- some-variant and all-variant both false (exactly-only)
+  | gapQQ          -- some-variant false, all-variant true (exactly-only)
   deriving Repr, DecidableEq
 
 /-! ### Test-suite schema -/
@@ -151,38 +150,24 @@ def parseScenario : String → Option GapScenario
   | _       => none
 
 /--
-Compute the observed `Trivalent` value for a `(scenario, gapDetected)` cell.
-
-Baseline conditions are unambiguous: `TRUE → .true`, `FALSE → .false`.
-For gap-bearing scenarios, gap detection means the empirical distribution
-peaks on the trivalent middle (`.indet`); a non-detection on a
-gap-bearing scenario means an alternative reading (typically an at-least
-reading for non-monotonic embedders) rendered the sentence non-gappy.
--/
-def observedTruth (scenario : GapScenario) (gapDetected : Bool) : Trivalent :=
-  match scenario, gapDetected with
-  | .trueScenario,  _    => .true
-  | .falseScenario, _    => .false
-  | _,              true => .indet
-  | _,              false => .true
-
-/--
 Lift a `LinguisticExample` to a `ProjectionDatum`, reading the
-`operator`, `condition`, and `gap_detected` keys from `paperFeatures`.
-Returns `none` for rows whose `paperFeatures` lack the recognised tags —
-those rows are not part of this hub's pool.
+`operator`, `condition`, `gap_detected`, and `classical_value` keys from
+`paperFeatures`. Baseline conditions are unambiguous (`TRUE → .true`,
+`FALSE → .false`); gap-family rows resolve via
+`HomogeneityGap.gapTruth`: `.indet` when the paper detected the gap,
+otherwise the bivalent value the row asserts through `classical_value`
+(e.g. the gap? cells of [kriz-chemla-2015] Exp. C3, judged completely
+false). Rows lacking the recognised tags are not part of this hub's pool.
 -/
-def fromExample (e : LinguisticExample) : Option ProjectionDatum :=
-  match e.paperFeatures.lookup "operator", e.paperFeatures.lookup "condition" with
-  | some opStr, some condStr =>
-    match parseOperator opStr, parseScenario condStr with
-    | some op, some sc =>
-      let gapDetected := (e.paperFeatures.lookup "gap_detected").getD "false" == "true"
-      some { operator := op, scenario := sc,
-             observed := observedTruth sc gapDetected,
-             source := e.source }
-    | _, _ => none
-  | _, _ => none
+def fromExample (e : LinguisticExample) : Option ProjectionDatum := do
+  let op ← parseOperator (← e.paperFeatures.lookup "operator")
+  let sc ← parseScenario (← e.paperFeatures.lookup "condition")
+  let observed ← match sc with
+    | .trueScenario  => some .true
+    | .falseScenario => some .false
+    | _              => HomogeneityGap.gapTruth e.paperFeatures
+  some { operator := op, scenario := sc, observed := observed,
+         source := e.source }
 
 /-! ### Pool -/
 

--- a/Linglib/Studies/KrizChemla2015.lean
+++ b/Linglib/Studies/KrizChemla2015.lean
@@ -1,71 +1,318 @@
 import Linglib.Data.Generalizations.HomogeneityProjection
-import Linglib.Data.Examples.KrizChemla2015
 
 /-!
-# [kriz-chemla-2015]: Trivalent truth-value judgments for embedded plurals
+# [kriz-chemla-2015]: Two methods to find truth-value gaps
 
-Empirical anchor for the homogeneity-projection literature. Križ & Chemla
-(2015), "Two methods to find truth-value gaps and their application to the
-projection problem of homogeneity," *Natural Language Semantics* 23(3):
-205-248, introduce a binary-then-ternary truth-value judgment paradigm and
-deploy it on plural definites embedded under quantifiers (`every`, `no`,
-`exactly N`) plus sentential negation, across three experiment batches
-(A1-A3 binary, B1-B3 ternary, C2-C4 ternary with grammatical
-boys/presents stimuli).
+[kriz-chemla-2015] introduce two experimental methods for detecting truth-value
+gaps — separate completely-true and completely-false tasks (Exps. A0-A3) and
+one-shot ternary judgments (Exps. B1-B3, C2-C4) — and apply them to the
+projection of plural-definite homogeneity from the scope of sentential negation,
+`every`/`all`, `no`, and `exactly 2`. The gap projects in every tested
+environment except the gap? configuration (where the some- and all-substituted
+variants of the sentence are both false); under `no` it emerges only with the
+grammatical restimulation of Exp. C2, small but robust (fn. 14).
+
+The stimulus rows live in the generated `Data.Examples.KrizChemla2015` module
+and are pooled by [[Generalizations.HomogeneityProjection]] (embedded cells) and
+[[Generalizations.HomogeneityGap]] (unembedded and negated cells). This file
+implements §6's assessment of the three theoretical approaches to homogeneity
+against those pools.
 
 ## Main declarations
 
-* `examples` — per-paper accessor (option B): K&C's contribution to the
-  cross-paper projection pool, i.e. `KrizChemla2015.Examples.all`.
+* `Cell`, `Display` — the experimental displays: arrays of nine objects, each
+  array classified by whether it is fully, partially, or not at all
+  target-satisfying.
+* `someReading`, `allReading` — the paper's guiding principle (§3): the
+  sentence variants with the definite plural replaced by an existential or a
+  universal quantifier.
+* `supervaluation` — two-candidate supervaluation ([spector-2013]): true iff
+  true on both resolutions of the definite, false iff false on both. As §6.2
+  notes, this coincides with the local-exhaustification implicature construals
+  (si2)/(si4) of §6.1.2 on the projection data.
+* `globalConstrual` — implicature construals (si1)/(si3) ([magri-2009],
+  [magri-2014]): gap iff the literal and globally exhaustified meanings
+  conflict.
+* `universalPresupposition` — homogeneity as a presupposition projecting
+  universally from the quantifier's scope ([schwarzschild-1994],
+  [lobner-2000], [gajewski-2005]).
+* `display` — a representative Table 13 display for each tested C-series cell.
 
-The encoded stimulus rows themselves live in the generated module
-`Data.Examples.KrizChemla2015` (from
-`Linglib/Data/Examples/KrizChemla2015.json` via `scripts/gen_examples.py`);
-the pool at [[Generalizations.HomogeneityProjection]] imports them, and is where
-cross-account testing of rival theories ([magri-2014],
-[kriz-2016], [kriz-spector-2021], [bar-lev-2021]) lands.
+## Main results
 
-## Implementation notes
-
-The K&C examples live in the generated `Data.Examples.KrizChemla2015`
-module; the projection hub imports them into its cross-paper test pool.
-This file remains the paper-anchored entry point and narrative hub.
-
-Three projector-synthesized fields are gone from the prior incarnation,
-verified against the paper PDF:
-- `Monotonicity` enum + `monotonicity` function — re-stipulated
-  `NaturalLogic.ContextPolarity` and contained a return-value /
-  comment contradiction for `notEvery`.
-- `ProjectionDatum`/`EmbeddedTruthConditions` structures with `Bool`
-  predicate-shape fields and `String` informal-prose fields — violated
-  CLAUDE.md's no-`Bool`-for-predicates and no-`String`-in-proof-relevant-code
-  conventions; superseded by the typed `LinguisticExample` rows.
-- Enum cases `exactlyOne` and `atLeastOne` — never tested in the paper.
-
-A fourth correction was the `no` projection finding: the prior
-encoding's `gapDetectable := false` reflected the A2/B2 null, but
-[kriz-chemla-2015] §5.2.3 (Exp. C2) explicitly overturns it ("E-no
-does show a gap, which, albeit small, is robust" — β=1.3 χ²=8.2 p=.004 on
-Diag. 1, Table 9). The C2 finding lands as
-`Examples.no_C2_gap` with `gap_detected = "true"`.
+* `supervaluation_matches_pool` — the supervaluation/local-exhaustification
+  prediction reproduces every pooled projection judgment: §6.4's bottom line,
+  at the price of either local exhaustification in downward-entailing contexts
+  (contra [chierchia-fox-spector-2012]) or a restricted candidate set.
+* `globalConstrual_divergence` — construals comparing the literal meaning with
+  *global* exhaustification fail on exactly the C2 `no` gap and the C4 gap??
+  gap, the paper's two problem cells for (si1)/(si3).
+* `universalPresupposition_divergence` — universal projection fails on exactly
+  the bivalently-judged conditions containing non-homogeneous cells (argument
+  (42) of §6.3) plus the gap? condition.
+* `globalConstrual_every`, `globalConstrual_no_never_gap` — §6.1.3's structural
+  observations: all implicature construals align in the scope of `every`, and
+  without local exhaustification no gap can arise in the scope of `no`.
+* `supervaluationGap_matches_pool`, `bareLiteral_misses_negation_gap`,
+  `wideScopeParse_matches_pool` — the unembedded grid: supervaluation predicts
+  the polarity × scenario judgments; the bare existential literal meaning
+  predicts no gap under negation (the downward-entailing problem of §6.1.3);
+  the wide-scope parse of the definite (fn. 18) restores the fit.
 
 ## Todo
 
-* The presupposition account named by [kriz-chemla-2015]
-  (Schwarzschild 1994 + [gajewski-2005]) has no linglib study file
-  yet; adding one would close the three-rival theoretical landscape the
-  paper discusses.
+* [george-2008]-style trivalent presupposition projection — the variant §6.3
+  endorses as matching the supervaluation predictions — is not implemented,
+  nor are the richer-candidate supervaluation variants of fn. 19, which
+  over-predict a gap in the gap? condition.
 -/
 
 namespace KrizChemla2015
 
-open Data.Examples (LinguisticExample)
+open Generalizations Generalizations.HomogeneityProjection
 
-/--
-Per-paper accessor: K&C 2015's stimulus rows (the generated
-`Examples.all`), which the projection hub pools for cross-account
-testing.
--/
-def examples : List LinguisticExample := Examples.all
+/-! ### Displays -/
+
+/-- One array of a display — one boy's presents (C series) or one cell of
+shapes (A/B series) — classified by how much of it is target-satisfying:
+all of it, some but not all (`mixed`), or none. -/
+inductive Cell where
+  | full
+  | mixed
+  | empty
+  deriving DecidableEq, Repr
+
+/-- A display: one `Cell` per boy. -/
+abbrev Display := List Cell
+
+/-- A cell is homogeneous when the target property holds of all of it or none
+of it — the presupposition [schwarzschild-1994]-style accounts attach to
+plural predication. -/
+def Cell.homogeneous (c : Cell) : Prop := c ≠ .mixed
+
+instance : DecidablePred Cell.homogeneous :=
+  fun c => inferInstanceAs (Decidable (c ≠ .mixed))
+
+/-- Number of cells whose boy found at least some of his presents. -/
+def occupied (d : Display) : ℕ := d.countP (· != Cell.empty)
+
+/-- Number of cells whose boy found all of his presents. -/
+def filled (d : Display) : ℕ := d.count .full
+
+/-! ### The some- and all-substituted readings
+
+§3's guiding principle: a sentence with a definite plural has a gap in a
+situation where the variant with an existential in place of the definite is
+true while the variant with a universal is false. -/
+
+/-- The some-substituted reading: *some (of his) presents* in place of the
+definite. This is the literal meaning on [magri-2014]'s analysis and the
+existential resolution of the definite on [spector-2013]'s. -/
+def someReading : EmbeddingOperator → Display → Prop
+  | .every,      d => ∀ c ∈ d, c ≠ .empty
+  | .no,         d => ∀ c ∈ d, c = .empty
+  | .exactlyTwo, d => occupied d = 2
+  | .notEvery,   d => ¬ ∀ c ∈ d, c ≠ .empty
+
+/-- The all-substituted reading: *all of his presents* in place of the
+definite. This is the locally exhaustified parse on [magri-2014]'s analysis
+and the universal resolution on [spector-2013]'s. -/
+def allReading : EmbeddingOperator → Display → Prop
+  | .every,      d => ∀ c ∈ d, c = .full
+  | .no,         d => ∀ c ∈ d, c ≠ .full
+  | .exactlyTwo, d => filled d = 2
+  | .notEvery,   d => ¬ ∀ c ∈ d, c = .full
+
+instance (op : EmbeddingOperator) (d : Display) : Decidable (someReading op d) := by
+  cases op <;> simp only [someReading] <;> infer_instance
+
+instance (op : EmbeddingOperator) (d : Display) : Decidable (allReading op d) := by
+  cases op <;> simp only [allReading] <;> infer_instance
+
+/-- The globally double-exhaustified meaning, (30) in [kriz-chemla-2015]:
+exhaustification is vacuous in the downward-entailing scope of `no` and
+conjoins the some- and all-substituted readings elsewhere. (`notEvery`
+postdates the paper's grid — [augurzky-etal-2023] — and takes the general
+clause; no theorem below exercises it.) -/
+def globalExh : EmbeddingOperator → Display → Prop
+  | .no, d => someReading .no d
+  | op,  d => someReading op d ∧ allReading op d
+
+instance (op : EmbeddingOperator) (d : Display) : Decidable (globalExh op d) := by
+  cases op <;> simp only [globalExh] <;> infer_instance
+
+/-! ### The three approaches -/
+
+/-- Trivalent verdict from two meaning components: clearly true when both
+hold, clearly false when neither does, a truth-value gap when they conflict.
+Each §6 construal instantiates this with a different pair of components. -/
+def gapValue (p q : Prop) [Decidable p] [Decidable q] : Trivalent :=
+  if p ∧ q then .true else if ¬p ∧ ¬q then .false else .indet
+
+/-- Two-candidate supervaluation ([spector-2013]; §6.2): supervaluate over
+the existential and universal resolutions of the definite. Extensionally this
+is also the (si2)/(si4) implicature construal of §6.1.2 — gap iff the literal
+and locally exhaustified meanings conflict — which is how §6.2 argues the two
+approaches make the same projection predictions. -/
+def supervaluation (op : EmbeddingOperator) (d : Display) : Trivalent :=
+  gapValue (someReading op d) (allReading op d)
+
+/-- Implicature construals (si1)/(si3) of §6.1.2 ([magri-2009]'s oddness
+condition): gap iff the literal meaning and the globally exhaustified meaning
+conflict. -/
+def globalConstrual (op : EmbeddingOperator) (d : Display) : Trivalent :=
+  gapValue (someReading op d) (globalExh op d)
+
+/-- Homogeneity as a presupposition projecting universally from the
+quantifier's scope ([schwarzschild-1994], [lobner-2000], [gajewski-2005], as
+assessed in §6.3): presupposition failure unless every cell is homogeneous,
+in which case the universal-force assertion decides the sentence. -/
+def universalPresupposition (op : EmbeddingOperator) (d : Display) : Trivalent :=
+  if (∀ c ∈ d, c.homogeneous) ∧ allReading op d then .true
+  else if (∀ c ∈ d, c.homogeneous) then .false
+  else .indet
+
+/-! ### The tested grid -/
+
+/-- A representative Table 13 display for each condition of Exps. C2-C4
+(`none` for cells the paper did not test). Read `[cell₁, ..., cell₄]` for the
+four boys; e.g. the `(every, gap)` display 9929 — three boys found all nine of
+their presents, one found two — is `[full, full, mixed, full]`. -/
+def display : EmbeddingOperator → GapScenario → Option Display
+  | .every, .trueScenario       => some [.full, .full, .full, .full]     -- 9999
+  | .every, .falseScenario      => some [.full, .mixed, .mixed, .empty]  -- 9770
+  | .every, .gap                => some [.full, .full, .mixed, .full]    -- 9929
+  | .no, .trueScenario          => some [.empty, .empty, .empty, .empty] -- 0000
+  | .no, .falseScenario         => some [.mixed, .empty, .empty, .full]  -- 5009
+  | .no, .gap                   => some [.empty, .empty, .mixed, .empty] -- 0070
+  | .exactlyTwo, .trueScenario  => some [.full, .full, .empty, .empty]   -- 9900
+  | .exactlyTwo, .falseScenario => some [.mixed, .empty, .empty, .empty] -- 4000
+  | .exactlyTwo, .gap           => some [.full, .mixed, .empty, .empty]  -- 9200
+  | .exactlyTwo, .gapQ          => some [.full, .mixed, .empty, .mixed]  -- 9202
+  | .exactlyTwo, .gapQQ         => some [.full, .mixed, .empty, .full]   -- 9209
+  | _, _ => none
+
+/-- Restrict a display-level account to the paper's tested grid — the
+scenario-partial analogue of the hub's `ProjectionPredict`. -/
+def predictOn (account : EmbeddingOperator → Display → Trivalent)
+    (op : EmbeddingOperator) (sc : GapScenario) : Option Trivalent :=
+  (display op sc).map (account op)
+
+/-! ### Predictions against the projection pool -/
+
+/-- The supervaluation (equivalently, local-exhaustification) prediction
+reproduces every pooled projection judgment — §6.4's bottom line. The fit is
+bought either by allowing local exhaustification in downward-entailing
+contexts, contra [chierchia-fox-spector-2012], or by restricting the
+supervaluation candidates to the existential and universal resolutions. -/
+theorem supervaluation_matches_pool :
+    ∀ d ∈ allData, d.source.bibkey = "kriz-chemla-2015" →
+      predictOn supervaluation d.operator d.scenario = some d.observed := by
+  decide
+
+/-- Construals locating the gap in a literal-vs-global-exhaustification
+conflict fail on exactly two cells: the small-but-robust `no` gap of Exp. C2
+(no implicature arises in a downward-entailing context, §6.1.3) and the gap??
+gap of Exp. C4 (Table 12's s6, where the literal meaning and the implicature
+are false and true respectively, so their conjunction is simply false). Both
+cells are predicted clearly false but observed gappy. -/
+theorem globalConstrual_divergence :
+    ∀ d ∈ allData, d.source.bibkey = "kriz-chemla-2015" →
+      (predictOn globalConstrual d.operator d.scenario ≠ some d.observed ↔
+        (d.operator, d.scenario) ∈
+          [(EmbeddingOperator.no, GapScenario.gap), (.exactlyTwo, .gapQQ)]) := by
+  decide
+
+/-- Universal projection of the homogeneity presupposition fails on exactly
+the bivalently-judged conditions whose displays contain non-homogeneous cells
+— the false conditions of Exps. C2/C3, argument (42) of §6.3 — plus the gap?
+condition, where a presupposition failure is predicted but falsity observed. -/
+theorem universalPresupposition_divergence :
+    ∀ d ∈ allData, d.source.bibkey = "kriz-chemla-2015" →
+      (predictOn universalPresupposition d.operator d.scenario ≠ some d.observed ↔
+        (d.operator, d.scenario) ∈
+          [(EmbeddingOperator.every, GapScenario.falseScenario),
+           (.no, .falseScenario), (.exactlyTwo, .falseScenario),
+           (.exactlyTwo, .gapQ)]) := by
+  decide
+
+/-! ### Structural observations (§6.1.3) -/
+
+/-- In the scope of `every` the implicature construals all align: comparing
+the literal meaning with global exhaustification and with local
+exhaustification comes to the same thing, on any display. -/
+theorem globalConstrual_every (d : Display) :
+    globalConstrual .every d = supervaluation .every d := by
+  have h : allReading .every d → someReading .every d :=
+    fun ha c hc => by simp [ha c hc]
+  by_cases hs : someReading .every d <;> by_cases ha : allReading .every d <;>
+    simp_all [globalConstrual, supervaluation, globalExh, gapValue]
+
+/-- Without local exhaustification, no gap can arise in the scope of `no`:
+exhaustification is vacuous there, so the literal and globally exhaustified
+meanings never conflict. The observed C2 gap therefore forces either local
+exhaustification or the supervaluation/presupposition alternatives. -/
+theorem globalConstrual_no_never_gap (d : Display) :
+    globalConstrual .no d ≠ .indet := by
+  by_cases h : someReading .no d <;>
+    simp [globalConstrual, globalExh, gapValue, h]
+
+/-! ### The unembedded grid
+
+The polarity × scenario cells of Exps. A0/A1/B1 live in the
+[[Generalizations.HomogeneityGap]] pool. An unembedded display is a single
+cell: nine shapes, of which all, some, or none are target-colored. -/
+
+/-- The display cell realizing each unembedded scenario. -/
+def scenarioCell : HomogeneityGap.GapScenario → Cell
+  | .all  => .full
+  | .none => .empty
+  | .gap  => .mixed
+
+/-- Supervaluation over the unembedded grid: resolve the definite
+existentially and universally, under negation for negative polarity. -/
+def supervaluationGap : HomogeneityGap.GapPredict := fun pol sc =>
+  match pol with
+  | .positive => gapValue (scenarioCell sc ≠ .empty) (scenarioCell sc = .full)
+  | .negative => gapValue (scenarioCell sc = .empty) (scenarioCell sc ≠ .full)
+
+/-- The supervaluation account reproduces the paper's unembedded and negated
+judgments: truth on uniform displays, the gap on mixed ones, projected
+through negation (Exps. A1/B1). -/
+theorem supervaluationGap_matches_pool :
+    ∀ d ∈ HomogeneityGap.allData, d.source.bibkey = "kriz-chemla-2015" →
+      supervaluationGap d.polarity d.scenario = d.observed := by
+  decide
+
+/-- The bare implicature construal assigns a negated sentence its existential
+literal meaning outright — negation is downward-entailing, so no implicature
+arises and no gap is predicted (§6.1.3). -/
+def bareLiteralNegative (sc : HomogeneityGap.GapScenario) : Trivalent :=
+  if scenarioCell sc = .empty then .true else .false
+
+/-- The E-neg gap of Exps. A1/B1 refutes the bare implicature construal: the
+negated mixed-display cell is observed gappy but predicted clearly false.
+This is §6.1.3's downward-entailing problem, which for plain negation the
+wide-scope parse solves (`wideScopeParse_matches_pool`) but for `no` — whose
+definite contains a variable bound by the quantifier ([steedman-2012]) —
+nothing does. -/
+theorem bareLiteral_misses_negation_gap :
+    ∃ d ∈ HomogeneityGap.allData, d.source.bibkey = "kriz-chemla-2015" ∧
+      d.polarity = .negative ∧ d.scenario = .gap ∧
+      bareLiteralNegative d.scenario ≠ d.observed := by
+  decide
+
+/-- The negated sentence with the definite parsed above negation (fn. 18):
+the existential and universal resolutions now scope over the negated
+predicate. -/
+def wideScopeParse (sc : HomogeneityGap.GapScenario) : Trivalent :=
+  gapValue (scenarioCell sc ≠ .full) (scenarioCell sc = .empty)
+
+/-- With the wide-scope parse, the implicature construal again reproduces the
+negated judgments — the paper's rescue for plain negation. -/
+theorem wideScopeParse_matches_pool :
+    ∀ d ∈ HomogeneityGap.allData, d.source.bibkey = "kriz-chemla-2015" →
+      d.polarity = .negative → wideScopeParse d.scenario = d.observed := by
+  decide
 
 end KrizChemla2015

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -23010,6 +23010,30 @@
   role      = {cited},
   sources   = {Data/Generalizations/HomogeneityGap.lean;Data/Generalizations/HomogeneityProjection.lean}
 }
+@article{schwarzschild-1994,
+  author    = {Schwarzschild, Roger},
+  year      = {1994},
+  title     = {Plurals, Presuppositions and the Sources of Distributivity},
+  journal   = {Natural Language Semantics},
+  volume    = {2},
+  number    = {3},
+  pages     = {201--248},
+  doi       = {10.1007/BF01256743},
+  subfield  = {semantics},
+  validated = {true},
+  role      = {cited}
+}
+@inproceedings{george-2008,
+  author    = {George, Benjamin R.},
+  year      = {2008},
+  title     = {A New Predictive Theory of Presupposition Projection},
+  booktitle = {Proceedings of SALT 18},
+  pages     = {358--375},
+  doi       = {10.3765/salt.v18i0.2472},
+  subfield  = {semantics/presupposition},
+  validated = {true},
+  role      = {cited}
+}
 @book{hawkins-1983,
   author    = {Hawkins, John A.},
   title     = {Word Order Universals},


### PR DESCRIPTION
Deep audit of `Studies/KrizChemla2015.lean` against the paper PDF. The study file had no theorems (one dead accessor def); it now formalizes §6's assessment of the implicature construals, two-candidate supervaluation, and universal-projection presupposition against the pooled projection data, with match/divergence theorems decided per cell.

- Re-anchors the six fabricated "Ann liked the books" rows (no such stimulus in the paper) to the real Exp. A1/B1 shape items, adds the tested true/false condition cells of Exps. C2/C3, and corrects stimulus-class descriptions against Table 13.
- `HomogeneityProjection.fromExample` no longer fabricates `.true` for undetected gaps; gap-family rows resolve via `HomogeneityGap.gapTruth` (`classical_value`), and the C3 gap? cell is now recorded as observed false per §5.3.
- Adds verified `schwarzschild-1994` and `george-2008` bib entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)