### PR TITLE
refactor(Data/Generalizations): drop Predict signatures; pools only

### DIFF
--- a/Linglib/Data/Generalizations/HomogeneityGap.lean
+++ b/Linglib/Data/Generalizations/HomogeneityGap.lean
@@ -6,7 +6,7 @@ import Linglib.Data.Examples.AghaJeretic2022
 import Linglib.Data.Examples.Kriz2015
 
 /-!
-# Generalizations.HomogeneityGap — cross-paper prediction target
+# Generalizations.HomogeneityGap — cross-paper data pool
 
 The homogeneity gap of unembedded plural definites (and their modal
 analogues): a positive sentence is true in the ALL scenario, its negation
@@ -19,14 +19,12 @@ supervaluation ([kriz-2016]).
 
 Sibling of `Generalizations.HomogeneityProjection`, which covers the
 *embedded* cells (operator × scenario); this file covers the unembedded
-polarity × scenario grid. The `Predict` signatures differ (`Polarity` vs
-`EmbeddingOperator` first argument), so the two pools stay separate.
+polarity × scenario grid. The datum types differ (`Polarity` vs
+`EmbeddingOperator` first component), so the two pools stay separate.
 
 ## Main declarations
 
 * `GapScenario` — ALL / NONE / GAP scenario triad.
-* `GapPredict` — signature a rival account must implement:
-  `Polarity → GapScenario → Trivalent`.
 * `GapDatum` — typed empirical datum lifted from `LinguisticExample`
   rows by `fromExample` (paperFeatures keys `polarity`, `condition`,
   `gap_detected`; rows with an `embedding` key other than `unembedded`
@@ -35,8 +33,11 @@ polarity × scenario grid. The `Predict` signatures differ (`Polarity` vs
   baselines), [kriz-2015] (switches items), and [agha-jeretic-2022]
   (weak-necessity modal items).
 
-Divergence theorems between rival accounts live in the comparing
-paper's study file, not here.
+Rival accounts state their predictions in their own study files, at the
+granularity their paper supports, and are run against this pool there —
+restricted by `source.bibkey` to the papers available at each study's
+publication date. Divergence theorems between rival accounts likewise
+live in the comparing paper's study file, not here.
 -/
 
 namespace Generalizations.HomogeneityGap
@@ -56,14 +57,7 @@ inductive GapScenario where
   | gap   -- some but not all do (homogeneity violated)
   deriving Repr, DecidableEq
 
-/-! ### Test-suite schema -/
-
-/--
-Prediction signature for accounts of the unembedded homogeneity gap:
-given the sentence polarity and the scenario, the trivalent value the
-account assigns.
--/
-abbrev GapPredict := Polarity → GapScenario → Trivalent
+/-! ### Datum schema -/
 
 /--
 Empirical datum lifted from a paper-anchored `LinguisticExample`:
@@ -142,9 +136,9 @@ def fromExample (e : LinguisticExample) : Option GapDatum := do
 /-! ### Pool -/
 
 /--
-Cross-paper pool of unembedded homogeneity-gap data. Rival accounts
-pass their `GapPredict` implementations against this pool; per-datum
-and divergence theorems live in the comparing papers' study files.
+Cross-paper pool of unembedded homogeneity-gap data. Rival accounts are
+run against this pool in the study files; per-datum and divergence
+theorems live there too.
 -/
 def allData : List GapDatum :=
   (KrizChemla2015.Examples.all ++ AghaJeretic2022.Examples.all

--- a/Linglib/Data/Generalizations/HomogeneityProjection.lean
+++ b/Linglib/Data/Generalizations/HomogeneityProjection.lean
@@ -4,7 +4,7 @@ import Linglib.Data.Examples.KrizChemla2015
 import Linglib.Data.Generalizations.HomogeneityGap
 
 /-!
-# Generalizations.HomogeneityProjection — cross-paper prediction target
+# Generalizations.HomogeneityProjection — cross-paper data pool
 
 Cross-paper test substrate for how the homogeneity gap of plural definites
 projects under embedding quantifiers and operators. The pattern's empirical
@@ -20,9 +20,6 @@ generalisation predates any one formal account, justifying a theory-neutral
 * `EmbeddingOperator` — operator labels recurring across the literature.
 * `GapScenario` — scenario classification used by the C-series experiments
   (TRUE / FALSE / GAP / GAP? / GAP??).
-* `ProjectionPredict` — the shared signature any account of homogeneity
-  projection must satisfy; given an `(operator, scenario)` pair, predict a
-  `Trivalent` value.
 * `ProjectionDatum` — typed empirical datum; lifted from the raw
   `LinguisticExample` rows by `fromExample`.
 * `Examples` (generator-managed) — pooled stimulus rows from each paper
@@ -34,11 +31,13 @@ generalisation predates any one formal account, justifying a theory-neutral
 
 ## Implementation notes
 
-This file is the entry point for cross-account testing of homogeneity
-projection. The shape is: a `ProjectionPredict` signature each account
-implements; a `ProjectionDatum` carrying observed outcomes; decidable
-theorems comparing each account's prediction to each datum, including
-*divergence* theorems where two accounts disagree.
+This file is the data side of cross-account testing of homogeneity
+projection: a `ProjectionDatum` per observed outcome, pooled in `allData`.
+Accounts state their predictions in their own study files, at the
+granularity their paper supports, and are run against the pool there —
+restricted by `source.bibkey` to papers available at each study's
+publication date. Decidable per-datum and divergence theorems live in
+those study files too.
 
 The substrate is restricted to the smallest set of operator cases that
 closes the current ≥2-consumer graduation criterion: `every` / `no`
@@ -56,15 +55,16 @@ mapping would be wrong for at least one consumer.
 
 ## Todo
 
-* Wire total `ProjectionPredict` implementations from the rival accounts
-  postdating [kriz-chemla-2015]: the exhaustification account
-  ([bar-lev-2021]) and the mature supervaluation/trivalence accounts
-  ([kriz-2016], [kriz-spector-2021]). The account variants the paper
-  itself assesses — [magri-2014]-style implicature construals,
-  [spector-2013] supervaluation, and [schwarzschild-1994] /
-  [lobner-2000] / [gajewski-2005] presupposition with universal
-  projection — are implemented against this pool in
+* Run the rival accounts postdating [kriz-chemla-2015] against this
+  pool: the exhaustification account ([bar-lev-2021]) and the mature
+  supervaluation/trivalence accounts ([kriz-2016], [kriz-spector-2021]).
+  The account variants the paper itself assesses — [magri-2014]-style
+  implicature construals, [spector-2013] supervaluation, and
+  [schwarzschild-1994] / [lobner-2000] / [gajewski-2005] presupposition
+  with universal projection — are already run against it in
   `Studies/KrizChemla2015.lean`, restricted to the paper's tested cells.
+* Pool a second paper's rows (JSON-ify the [augurzky-etal-2023]
+  acceptance data) to close the ≥ 2-papers admission prong.
 * Add a denotation hook `EmbeddingOperator → ∀ α, Quantification.GQ α`
   once accounts derive predictions structurally rather than dispatch on
   label (per [peters-westerstahl-2006] discipline).
@@ -103,14 +103,7 @@ inductive GapScenario where
   | gapQQ          -- some-variant false, all-variant true (exactly-only)
   deriving Repr, DecidableEq
 
-/-! ### Test-suite schema -/
-
-/--
-Theoretical-prediction signature any account of homogeneity projection
-must satisfy: given an embedder label and a scenario, predict the
-trivalent `Trivalent` value the account commits to.
--/
-abbrev ProjectionPredict := EmbeddingOperator → GapScenario → Trivalent
+/-! ### Datum schema -/
 
 /--
 Empirical datum derived from a paper-anchored `LinguisticExample`.
@@ -174,8 +167,8 @@ def fromExample (e : LinguisticExample) : Option ProjectionDatum := do
 /--
 Cross-paper pool of projection-relevant data, derived from the imported
 per-paper `Examples.all` lists by `fromExample`. Each entry carries its
-originating `SourceRef` for provenance. Rival theories of projection
-should pass their `ProjectionPredict` implementations against this pool.
+originating `SourceRef` for provenance. Rival theories of projection are
+run against this pool in the study files.
 -/
 def allData : List ProjectionDatum :=
   KrizChemla2015.Examples.all.filterMap fromExample

--- a/Linglib/Data/Generalizations/Projectivity.lean
+++ b/Linglib/Data/Generalizations/Projectivity.lean
@@ -3,7 +3,7 @@ import Linglib.Data.Examples.TonhauserBeaverDegen2018
 import Linglib.Data.Examples.SolstadBott2024
 
 /-!
-# Generalizations.Projectivity — cross-paper prediction target
+# Generalizations.Projectivity — cross-paper data pool
 
 The Gradient Projection Principle of [tonhauser-beaver-degen-2018] — content
 projects to the extent that it is *not* at-issue — predicts a per-expression
@@ -15,13 +15,11 @@ not-at-issueness across triggers) predates any one formal account and spans
 ≥ 2 papers contributing generated `Data.Examples` rows
 ([tonhauser-beaver-degen-2018]: 9 + 12 English expressions;
 [solstad-bott-2024]: occasion + psychological verbs in German), with ≥ 2 rival
-accounts consuming the `ProjectionAccount` signature in their study files
-(`gppProjection` and `pottsProjection` in `Studies/TonhauserBeaverDegen2018`).
+accounts run against the pool in their study files (`gppProjection` and
+`pottsProjection` in `Studies/TonhauserBeaverDegen2018`).
 
 ## Main declarations
 
-* `ProjectionAccount` — the prediction signature any account implements: given a
-  content's at-issueness, predict its projectivity (`Rat01 → Rat01`).
 * `ProjectionDatum` — a typed observed datum (`projectivity`, `atIssueness`),
   lifted from a paper-anchored `LinguisticExample` by `fromExample`.
 * `allData` — the pooled test set: every projectivity row from the contributing
@@ -43,13 +41,6 @@ namespace Generalizations.Projectivity
 
 open Core.Order (Rat01)
 open Data.Examples (LinguisticExample SourceRef)
-
-/-! ### Prediction signature -/
-
-/-- A theory of projection: predict a content's projectivity from its
-    at-issueness. Rival accounts (`gppProjection`, `pottsProjection`) live in the
-    study files and are run against `allData`. -/
-abbrev ProjectionAccount := Rat01 → Rat01
 
 /-- An observed datum: mean projectivity and at-issueness for one expression,
     with its originating `SourceRef`. -/
@@ -99,7 +90,8 @@ def fromExample (e : LinguisticExample) : Option ProjectionDatum :=
 
 /-! ### Pool -/
 
-/-- The pooled cross-paper projection data. Each rival `ProjectionAccount` is run
+/-- The pooled cross-paper projection data. Each rival account — a map
+    `Rat01 → Rat01` from at-issueness to predicted projectivity — is run
     against this list in the study files. -/
 def allData : List ProjectionDatum :=
   (TonhauserBeaverDegen2018.Examples.all ++ SolstadBott2024.Examples.all).filterMap fromExample
@@ -108,14 +100,14 @@ def allData : List ProjectionDatum :=
 
 /-- An account's absolute error on an observation: the gap between its predicted
     projectivity (from the observed at-issueness) and the observed projectivity. -/
-def predictionError (acc : ProjectionAccount) (d : ProjectionDatum) : ℚ :=
+def predictionError (acc : Rat01 → Rat01) (d : ProjectionDatum) : ℚ :=
   |(acc d.atIssueness).val - d.projectivity.val|
 
 /-- An account predicts an observation within tolerance `ε`. -/
-def predictsWithin (ε : ℚ) (acc : ProjectionAccount) (d : ProjectionDatum) : Prop :=
+def predictsWithin (ε : ℚ) (acc : Rat01 → Rat01) (d : ProjectionDatum) : Prop :=
   predictionError acc d ≤ ε
 
-instance (ε : ℚ) (acc : ProjectionAccount) (d : ProjectionDatum) :
+instance (ε : ℚ) (acc : Rat01 → Rat01) (d : ProjectionDatum) :
     Decidable (predictsWithin ε acc d) :=
   inferInstanceAs (Decidable (_ ≤ _))
 

--- a/Linglib/Studies/AghaJeretic2022.lean
+++ b/Linglib/Studies/AghaJeretic2022.lean
@@ -69,7 +69,8 @@ semantics), and extends it to explain the neg-raising asymmetry between
 
 namespace AghaJeretic2022
 
-open Generalizations.HomogeneityGap (GapDatum GapScenario GapPredict fromExample)
+open Features (Polarity)
+open Generalizations.HomogeneityGap (GapDatum GapScenario fromExample)
 open Semantics.Homogeneity (negRaising_iff_subsingleton)
 
 -- ============================================================================
@@ -282,10 +283,10 @@ def scenarioDomain : GapScenario → List Bool
   | .none => [false, false]
   | .gap  => [true, false]
 
-/-- The trivalent semantics as a `GapPredict`: negative polarity predicates
-    the negated prejacent of the same plurality (homogeneity = symmetric
-    negation, §3.1). -/
-def gapPredict : GapPredict := fun pol s =>
+/-- The trivalent semantics' prediction for each polarity × scenario cell:
+    negative polarity predicates the negated prejacent of the same plurality
+    (homogeneity = symmetric negation, §3.1). -/
+def gapPredict (pol : Polarity) (s : GapScenario) : Trivalent :=
   match pol with
   | .positive => shouldEval (scenarioDomain s) id
   | .negative => shouldEval (scenarioDomain s) (fun w => !w)
@@ -574,10 +575,10 @@ theorem shouldEval_can_gap :
     ∃ (D : List Bool) (p : Bool → Bool), shouldEval D p = Trivalent.indet :=
   ⟨[true, false], id, by native_decide⟩
 
-/-- Domain restriction as a `GapPredict`: *should* = ∀ over the refined
-    domain, with negation as Strong Kleene `Trivalent.neg`. Bivalent on every
-    cell. -/
-def domainRestrictionPredict : GapPredict := fun pol s =>
+/-- Domain restriction's prediction for each polarity × scenario cell:
+    *should* = ∀ over the refined domain, with negation as Strong Kleene
+    `Trivalent.neg`. Bivalent on every cell. -/
+def domainRestrictionPredict (pol : Polarity) (s : GapScenario) : Trivalent :=
   match pol with
   | .positive => mustEval (scenarioDomain s) id
   | .negative => (mustEval (scenarioDomain s) id).neg

--- a/Linglib/Studies/BarLev2021.lean
+++ b/Linglib/Studies/BarLev2021.lean
@@ -64,8 +64,9 @@ A key prediction: the positive and negative cases are *not symmetric*.
 
 This asymmetry is derived in `negative_universal` below.
 
-TODO: derive a `Generalizations.HomogeneityGap.GapPredict` implementation
-from the exhaustification account and prove divergence theorems vs rivals.
+TODO: state the exhaustification account's polarity × scenario
+predictions, run them against the pooled `Generalizations.HomogeneityGap`
+data, and prove divergence theorems vs rivals.
 -/
 
 namespace BarLev2021
@@ -707,32 +708,36 @@ theorem partial_pruning_not_universal :
 -- SECTION 8: Bridges to Empirical Data
 -- ============================================================
 
-open Generalizations.HomogeneityGap (allData)
+open Generalizations.HomogeneityGap (GapDatum allData)
 
-/-- The account against the pooled unembedded homogeneity-gap data
-    ([kriz-chemla-2015], [kriz-2015], [agha-jeretic-2022]): `.indet` is
-    observed in gap cells of both polarities — the non-complementarity
-    derived in `gap_both_false` — and only there (baseline cells are
-    bivalent, as `universality` and `negative_universal` require). -/
+/-- The pooled rows from the plural-definite papers available to
+    [bar-lev-2021]: [kriz-2015] and [kriz-chemla-2015]. Quantifying over
+    this slice rather than all of `allData` keeps the claims fixed as
+    later papers' rows join the pool. -/
+def pluralDefiniteRows : List GapDatum :=
+  allData.filter fun d =>
+    d.source.bibkey == "kriz-2015" || d.source.bibkey == "kriz-chemla-2015"
+
+/-- The account against the pooled unembedded homogeneity-gap rows of
+    [kriz-2015] and [kriz-chemla-2015]: `.indet` is observed in gap cells
+    of both polarities — the non-complementarity derived in
+    `gap_both_false` — and only there (baseline cells are bivalent, as
+    `universality` and `negative_universal` require). -/
 theorem matches_pooled_gap_data :
-    ((allData.any fun d =>
+    ((pluralDefiniteRows.any fun d =>
         d.polarity == .positive && d.scenario == .gap && d.observed == .indet) = true) ∧
-    ((allData.any fun d =>
+    ((pluralDefiniteRows.any fun d =>
         d.polarity == .negative && d.scenario == .gap && d.observed == .indet) = true) ∧
-    ((allData.filter (fun d => d.scenario != .gap)).all
+    ((pluralDefiniteRows.filter (fun d => d.scenario != .gap)).all
         (fun d => d.observed != .indet) = true) :=
   ⟨by decide, by decide, by decide⟩
 
-/-- For plural-definite rows ([kriz-2015], [kriz-chemla-2015]), no gap
-    cell observes clear falsity: those cells resolve to `.indet` (the
-    gap, `gap_both_false`) or `.true` (a non-maximal reading, derived
-    by pruning — `pruned_existential`), never `.false`. The restriction
-    matters: [agha-jeretic-2022]'s strong-necessity rows (*have to*)
-    observe `.false` in the positive gap cell — strong modals are
-    gap-free, outside this account's plural-definite scope. -/
+/-- No plural-definite gap cell observes clear falsity: those cells
+    resolve to `.indet` (the gap, `gap_both_false`) or `.true` (a
+    non-maximal reading, derived by pruning — `pruned_existential`),
+    never `.false`. -/
 theorem plural_definite_gap_cells_never_false :
-    (allData.filter (fun d =>
-        d.scenario == .gap && d.source.bibkey != "agha-jeretic-2022")).all
+    (pluralDefiniteRows.filter (fun d => d.scenario == .gap)).all
       (fun d => d.observed != .false) = true := by decide
 
 

--- a/Linglib/Studies/KrizChemla2015.lean
+++ b/Linglib/Studies/KrizChemla2015.lean
@@ -69,6 +69,7 @@ against those pools.
 
 namespace KrizChemla2015
 
+open Features (Polarity)
 open Generalizations Generalizations.HomogeneityProjection
 
 /-! ### Displays -/
@@ -192,8 +193,8 @@ def display : EmbeddingOperator → GapScenario → Option Display
   | .exactlyTwo, .gapQQ         => some [.full, .mixed, .empty, .full]   -- 9209
   | _, _ => none
 
-/-- Restrict a display-level account to the paper's tested grid — the
-scenario-partial analogue of the hub's `ProjectionPredict`. -/
+/-- Restrict a display-level account to the paper's tested grid, `none`
+marking cells the paper did not test. -/
 def predictOn (account : EmbeddingOperator → Display → Trivalent)
     (op : EmbeddingOperator) (sc : GapScenario) : Option Trivalent :=
   (display op sc).map (account op)
@@ -271,7 +272,7 @@ def scenarioCell : HomogeneityGap.GapScenario → Cell
 
 /-- Supervaluation over the unembedded grid: resolve the definite
 existentially and universally, under negation for negative polarity. -/
-def supervaluationGap : HomogeneityGap.GapPredict := fun pol sc =>
+def supervaluationGap (pol : Polarity) (sc : HomogeneityGap.GapScenario) : Trivalent :=
   match pol with
   | .positive => gapValue (scenarioCell sc ≠ .empty) (scenarioCell sc = .full)
   | .negative => gapValue (scenarioCell sc = .empty) (scenarioCell sc ≠ .full)

--- a/Linglib/Studies/Magri2014.lean
+++ b/Linglib/Studies/Magri2014.lean
@@ -73,8 +73,9 @@ just plain meanings) determine outer-level excludability. Spector's
 single-EXH result `Max(P) = {Exhaust(P)}` is formalized in
 `ScalarImplicatures/Studies/Spector2007.lean`.
 
-TODO: derive a `Generalizations.HomogeneityGap.GapPredict` implementation
-from the double-strengthening account and prove divergence theorems vs rivals.
+TODO: state the double-strengthening account's polarity × scenario
+predictions, run them against the pooled `Generalizations.HomogeneityGap`
+data, and prove divergence theorems vs rivals.
 -/
 
 namespace Magri2014

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -22,8 +22,8 @@ correlation with item-level variance, not this identity (cf. the dependency's
 ## Main definitions
 * `gppProjection` — the GPP map, the complement of at-issueness (`Rat01.compl`).
 * `pottsProjection` — [potts-2005]'s rival: CI projects maximally, at-issueness-blind.
-* both are `Generalizations.Projectivity.ProjectionAccount`s, run against the
-  pooled per-expression data (`allData`) in that hub.
+* both are run against the pooled per-expression data
+  (`Generalizations.Projectivity.allData`).
 
 ## Main results
 * `gppProjection_antitone` — the GPP as order-reversal.
@@ -167,9 +167,10 @@ theorem appositive_not_maximally_projective
 
 /-! ### Predicting against the data
 
-`gppProjection` and `pottsProjection` are `Generalizations.Projectivity`
-`ProjectionAccount`s; the paper's per-expression means are pooled in that hub's
-`allData` (artifact-sourced rows in `Data.Examples.TonhauserBeaverDegen2018`). The
+`gppProjection` and `pottsProjection` map at-issueness to predicted
+projectivity; the paper's per-expression means are pooled in
+`Generalizations.Projectivity.allData` (artifact-sourced rows in
+`Data.Examples.TonhauserBeaverDegen2018`). The
 means are continuous, so per-row predictions are *computed* over `allData` (string
 `paperFeatures` and `ℚ` do not reduce in the kernel); the *provable* content is
 each account's systematic error. -/


### PR DESCRIPTION
Tightens the `Data/Generalizations/` charter: hubs are cross-paper data pools — cell-space enums, typed `Datum` schemas, interpretation-free adapters, pooled `allData`, and account-neutral scoring helpers — with no prediction signatures. Accounts state their predictions in their own study files, at the granularity their paper supports, and are run against the pool there.

- Deletes `GapPredict`, `ProjectionPredict`, and `ProjectionAccount`; consumers (AghaJeretic2022, KrizChemla2015, TonhauserBeaverDegen2018) spell the types inline; stale TODOs in Magri2014/BarLev2021 reworded.
- BarLev2021's pool theorems restate over a `pluralDefiniteRows` slice (positive `source.bibkey` filter to the two ≤2021 papers), so the claims stay fixed — and chronology-clean — as later papers' rows join the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)