### PR TITLE
fix(Semantics/Dynamic/DRS): repair vacuous subordination relation

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -5,10 +5,12 @@ import Linglib.Semantics.Dynamic.DRS.Defs
 
 This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
 functorial renaming of discourse referents (`DRS.map`), the merge algebra,
-transport of the extension relation along renaming, and the referent
-predicates `varFinset`, `freeVarFinset` and `IsProper`, `ReuseFreeAt`, and
-`Accessible`. Renaming along a bijection is [kamp-reyle-1993]'s *alphabetic
-variant* (the prose preceding Def. 1.4.8).
+transport of the extension relation along renaming, the referent predicates
+`varFinset`, `freeVarFinset` and `IsProper`, `ReuseFreeAt`, and accessibility —
+computed (`accessibleFrom`, `Accessible`) and as [geurts-beaver-maier-2024]'s
+smallest preorder (`AccessibleTo`, `accessibleDomain`), connected by
+`DRS.Accessible.exists_mem_accessibleDomain`. Renaming along a bijection is
+[kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
 -/
 
 open FirstOrder
@@ -186,12 +188,14 @@ def ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
 
 /-! ### Accessibility threading
 
-Accessibility (Def. 1.4.11) is intrinsically *relative to a
-host DRS*: "`u` accessible at box `B`" means `u` lies in the universe of `B` or of
-a box on the path from the host down to `B`. A host-free `∃ D, WeakSubordinate K D
-∧ u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent
-can always be manufactured. So accessibility is computed *top-down*, threading the
-in-scope referents (the same threading as `DRS.Bound`), which is also decidable. -/
+Accessibility (Def. 1.4.11) is intrinsically *relative to a host DRS*: "`u`
+accessible at box `B`" means `u` lies in the universe of `B` or of a box on the
+path from the host down to `B`. A host-free `∃ D, WeakSubordinate K D ∧
+u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent can
+always be manufactured. `accScope` computes accessibility *top-down*, threading
+the in-scope referents along the first path to the box declaring the target; the
+declarative counterpart is the host-anchored preorder `AccessibleTo` at the end of
+this file, with soundness `DRS.Accessible.exists_mem_accessibleDomain`. -/
 
 /-- Accessibility threading through a condition. -/
 def accScope (s : Finset V) : Condition L V → V → Option (Finset V)
@@ -347,6 +351,9 @@ theorem freeVarFinset_merge_subset {X : Finset V} {K₁ K₂ : DRS L V}
 (Def. 1.4.2–1.4.3). -/
 def IsProper (K : DRS L V) : Prop := K.freeVarFinset = ∅
 
+instance (K : DRS L V) : Decidable K.IsProper :=
+  decidable_of_iff (K.freeVarFinset = ∅) Iff.rfl
+
 /-- Merging preserves properness when the increment's free referents are
 supplied by the context DRS's universe. -/
 theorem isProper_merge {K₁ K₂ : DRS L V} (h₁ : K₁.IsProper)
@@ -471,5 +478,183 @@ theorem Condition.accScope_dis (s : Finset V) (l r : DRS L V) (x : V) :
     Condition.accScope s (.dis l r) x =
       (DRS.accScope s l x).orElse fun _ => DRS.accScope s r x := by
   simp only [Condition.accScope]; rfl
+
+/-! ## Accessibility as the smallest preorder
+
+[geurts-beaver-maier-2024]'s §4.2 presentation: accessibility is the smallest
+preorder on the sub-DRSs of a host such that a box is accessible to the sub-boxes
+of its complex conditions and a conditional's antecedent is accessible to its
+consequent. Each generating edge anchors its containing box below the host — the
+anchor is what keeps the relation non-vacuous. `accScope` above computes accessible
+referents top-down; `DRS.Accessible.exists_mem_accessibleDomain` shows every
+computed verdict is realized by genuine edges. -/
+
+/-- A generating edge of the accessibility preorder over the sub-DRSs of `host`
+(§4.2): a box is accessible to the sub-boxes of its complex conditions, and the
+antecedent of a conditional is accessible to its consequent. -/
+inductive AccessibleEdge (host : DRS L V) : DRS L V → DRS L V → Prop where
+  /-- A box is accessible to the body of its `¬`-conditions. -/
+  | neg {K K' : DRS L V} : WeakSubordinate K host → Condition.neg K' ∈ K.conditions →
+      AccessibleEdge host K K'
+  /-- A box is accessible to the antecedents of its `⇒`-conditions. -/
+  | impAnte {K K' K'' : DRS L V} : WeakSubordinate K host →
+      Condition.imp K' K'' ∈ K.conditions → AccessibleEdge host K K'
+  /-- The antecedent of a `⇒`-condition is accessible to its consequent. -/
+  | impCons {K K' K'' : DRS L V} : WeakSubordinate K host →
+      Condition.imp K' K'' ∈ K.conditions → AccessibleEdge host K' K''
+  /-- A box is accessible to the left disjunct of its `∨`-conditions. -/
+  | disLeft {K K' K'' : DRS L V} : WeakSubordinate K host →
+      Condition.dis K' K'' ∈ K.conditions → AccessibleEdge host K K'
+  /-- A box is accessible to the right disjunct of its `∨`-conditions. -/
+  | disRight {K K' K'' : DRS L V} : WeakSubordinate K host →
+      Condition.dis K' K'' ∈ K.conditions → AccessibleEdge host K K''
+
+/-- `AccessibleTo host K K'`: `K` is accessible to `K'` among the sub-DRSs of
+`host` — the smallest preorder containing the generating edges (§4.2). -/
+abbrev AccessibleTo (host : DRS L V) : DRS L V → DRS L V → Prop :=
+  Relation.ReflTransGen (AccessibleEdge host)
+
+omit [DecidableEq V] in
+/-- The target of an accessibility edge is a sub-DRS of the host. -/
+theorem AccessibleEdge.weakSubordinate_right {host K K' : DRS L V}
+    (h : AccessibleEdge host K K') : WeakSubordinate K' host := by
+  cases h with
+  | neg hK hc => exact .head (.neg hc) hK
+  | impAnte hK hc => exact .head (.impAnte hc) hK
+  | impCons hK hc => exact .head (.impCons hc) hK
+  | disLeft hK hc => exact .head (.disL hc) hK
+  | disRight hK hc => exact .head (.disR hc) hK
+
+/-- The accessible domain `A_K` of `K` in `host` (§4.2): the referents declared in
+some box accessible to `K`. -/
+def accessibleDomain (host K : DRS L V) : Set V :=
+  {x | ∃ K', AccessibleTo host K' K ∧ x ∈ K'.referents}
+
+omit [DecidableEq V] in
+theorem referents_subset_accessibleDomain (host K : DRS L V) :
+    ↑K.referents ⊆ accessibleDomain host K := fun _ hx => ⟨K, .refl, hx⟩
+
+omit [DecidableEq V] in
+theorem accessibleDomain_mono {host K K' : DRS L V} (h : AccessibleTo host K K') :
+    accessibleDomain host K ⊆ accessibleDomain host K' :=
+  fun _ ⟨K₀, hK₀, hx⟩ => ⟨K₀, hK₀.trans h, hx⟩
+
+/-! ### Soundness of the computed accessibility -/
+
+/-- The soundness invariant for `Condition.accScope`: a hit inside `c` — reached from
+a containing box `D` below `host` whose base `s` is already accessible — names a
+sub-DRS of `host` declaring the target, accessible from `D`, whose accessible domain
+covers the returned scope. -/
+private abbrev AccScopeSound (host : DRS L V) (c : Condition L V) : Prop :=
+  ∀ {s : Finset V} {x : V} {acc : Finset V} {D : DRS L V},
+    Condition.accScope s c x = some acc → WeakSubordinate D host → c ∈ D.conditions →
+    (∀ w ∈ s, w ∈ accessibleDomain host D) →
+    ∃ K, WeakSubordinate K host ∧ x ∈ K.referents ∧ AccessibleTo host D K ∧
+      ∀ w ∈ acc, w ∈ accessibleDomain host K
+
+private theorem accScopeL_eq_some {s : Finset V} {cs : List (Condition L V)} {x : V}
+    {acc : Finset V} (h : Condition.accScopeL s cs x = some acc) :
+    ∃ c ∈ cs, Condition.accScope s c x = some acc := by
+  induction cs with
+  | nil => simp [Condition.accScopeL] at h
+  | cons c cs ih =>
+    have hcons : Condition.accScopeL s (c :: cs) x =
+        (Condition.accScope s c x).orElse fun _ => Condition.accScopeL s cs x := rfl
+    rw [hcons] at h
+    cases hc : Condition.accScope s c x with
+    | some v =>
+      rw [hc] at h
+      obtain rfl : v = acc := by simpa [Option.orElse] using h
+      exact ⟨c, by simp, hc⟩
+    | none =>
+      rw [hc] at h
+      obtain ⟨d, hd, hds⟩ := ih (by simpa [Option.orElse] using h)
+      exact ⟨d, by simp [hd], hds⟩
+
+/-- Any `DRS.accScope` hit on a box `B` below `host`, given the sub-condition
+invariants and an accessible base. -/
+private theorem accScope_sound_box {host B : DRS L V} {s : Finset V} {x : V}
+    {acc : Finset V} (ih : ∀ d ∈ B.conditions, AccScopeSound host d)
+    (h : DRS.accScope s B x = some acc) (hB : WeakSubordinate B host)
+    (hs : ∀ w ∈ s, w ∈ accessibleDomain host B) :
+    ∃ K, WeakSubordinate K host ∧ x ∈ K.referents ∧ AccessibleTo host B K ∧
+      ∀ w ∈ acc, w ∈ accessibleDomain host K := by
+  have hs' : ∀ w ∈ s ∪ B.referents, w ∈ accessibleDomain host B := fun w hw =>
+    (Finset.mem_union.mp hw).elim (hs w)
+      (fun hw => referents_subset_accessibleDomain host B hw)
+  rw [DRS.accScope] at h
+  split at h
+  · next hx => exact ⟨B, hB, hx, .refl, Option.some.inj h ▸ hs'⟩
+  · obtain ⟨d, hd, hds⟩ := accScopeL_eq_some h
+    exact ih d hd hds hB hd hs'
+
+private theorem accScopeSound (host : DRS L V) (c : Condition L V) : AccScopeSound host c := by
+  induction c with
+  | rel R args => intro s x acc D h hD hc hs; simp [Condition.accScope] at h
+  | eq u v => intro s x acc D h hD hc hs; simp [Condition.accScope] at h
+  | neg K' ihK =>
+    intro s x acc D h hD hc hs
+    rw [Condition.accScope_neg] at h
+    have e : AccessibleEdge host D K' := .neg hD hc
+    obtain ⟨K, h1, h2, h3, h4⟩ := accScope_sound_box ihK h e.weakSubordinate_right
+      (fun w hw => accessibleDomain_mono (.single e) (hs w hw))
+    exact ⟨K, h1, h2, (Relation.ReflTransGen.single e).trans h3, h4⟩
+  | imp a c iha ihc =>
+    intro s x acc D h hD hc hs
+    rw [Condition.accScope_imp] at h
+    have eA : AccessibleEdge host D a := .impAnte hD hc
+    have eC : AccessibleEdge host a c := .impCons hD hc
+    cases ha : DRS.accScope s a x with
+    | some v =>
+      rw [ha] at h
+      obtain rfl : v = acc := by simpa [Option.orElse] using h
+      obtain ⟨K, h1, h2, h3, h4⟩ := accScope_sound_box iha ha eA.weakSubordinate_right
+        (fun w hw => accessibleDomain_mono (.single eA) (hs w hw))
+      exact ⟨K, h1, h2, (Relation.ReflTransGen.single eA).trans h3, h4⟩
+    | none =>
+      rw [ha] at h
+      have h' : DRS.accScope (s ∪ a.referents) c x = some acc := by
+        simpa [Option.orElse] using h
+      have path : AccessibleTo host D c := .head eA (.single eC)
+      obtain ⟨K, h1, h2, h3, h4⟩ := accScope_sound_box ihc h' eC.weakSubordinate_right
+        (fun w hw => (Finset.mem_union.mp hw).elim
+          (fun hw => accessibleDomain_mono path (hs w hw))
+          (fun hw => accessibleDomain_mono (.single eC)
+            (referents_subset_accessibleDomain host a hw)))
+      exact ⟨K, h1, h2, path.trans h3, h4⟩
+  | dis l r ihl ihr =>
+    intro s x acc D h hD hc hs
+    rw [Condition.accScope_dis] at h
+    have eL : AccessibleEdge host D l := .disLeft hD hc
+    have eR : AccessibleEdge host D r := .disRight hD hc
+    cases hl : DRS.accScope s l x with
+    | some v =>
+      rw [hl] at h
+      obtain rfl : v = acc := by simpa [Option.orElse] using h
+      obtain ⟨K, h1, h2, h3, h4⟩ := accScope_sound_box ihl hl eL.weakSubordinate_right
+        (fun w hw => accessibleDomain_mono (.single eL) (hs w hw))
+      exact ⟨K, h1, h2, (Relation.ReflTransGen.single eL).trans h3, h4⟩
+    | none =>
+      rw [hl] at h
+      have h' : DRS.accScope s r x = some acc := by simpa [Option.orElse] using h
+      obtain ⟨K, h1, h2, h3, h4⟩ := accScope_sound_box ihr h' eR.weakSubordinate_right
+        (fun w hw => accessibleDomain_mono (.single eR) (hs w hw))
+      exact ⟨K, h1, h2, (Relation.ReflTransGen.single eR).trans h3, h4⟩
+
+/-- Every computed accessibility verdict is realized by genuine §4.2 edges: if
+`v ∈ accessibleFrom T u`, then `u` is declared in a sub-DRS `K` of `T` and `v`
+lies in `K`'s accessible domain. The converse choice among multiple declaration
+sites of `u` is algorithmic (first hit); its characterization is future work. -/
+theorem DRS.Accessible.exists_mem_accessibleDomain {T : DRS L V} {u v : V}
+    (h : DRS.Accessible T u v) :
+    ∃ K, WeakSubordinate K T ∧ u ∈ K.referents ∧ v ∈ accessibleDomain T K := by
+  unfold DRS.Accessible DRS.accessibleFrom at h
+  cases hacc : DRS.accScope ∅ T u with
+  | none => rw [hacc] at h; simp at h
+  | some acc =>
+    rw [hacc] at h
+    obtain ⟨K, h1, h2, _, h4⟩ := accScope_sound_box (fun d _ => accScopeSound T d) hacc
+      .refl (by simp)
+    exact ⟨K, h1, h2, h4 v (by simpa using h)⟩
 
 end DRT

--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -7,8 +7,9 @@ This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
 functorial renaming of discourse referents (`DRS.map`), the merge algebra,
 transport of the extension relation along renaming, the referent predicates
 `varFinset`, `freeVarFinset` and `IsProper`, `ReuseFreeAt`, and accessibility —
-computed (`accessibleFrom`, `Accessible`) and as [geurts-beaver-maier-2024]'s
-smallest preorder (`AccessibleTo`, `accessibleDomain`), connected by
+computed as [vaneijck-2006]'s left-and-up walk (`accessibleFrom`, `Accessible`)
+and as [geurts-beaver-maier-2024]'s smallest preorder (`AccessibleTo`,
+`accessibleDomain`), connected by
 `DRS.Accessible.exists_mem_accessibleDomain`. Renaming along a bijection is
 [kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
 -/
@@ -192,10 +193,12 @@ Accessibility (Def. 1.4.11) is intrinsically *relative to a host DRS*: "`u`
 accessible at box `B`" means `u` lies in the universe of `B` or of a box on the
 path from the host down to `B`. A host-free `∃ D, WeakSubordinate K D ∧
 u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent can
-always be manufactured. `accScope` computes accessibility *top-down*, threading
-the in-scope referents along the first path to the box declaring the target; the
-declarative counterpart is the host-anchored preorder `AccessibleTo` at the end of
-this file, with soundness `DRS.Accessible.exists_mem_accessibleDomain`. -/
+always be manufactured. `accScope` computes accessibility *top-down* — the walk of
+[vaneijck-2006] "in the directions *left*, i.e. from the consequent of a pair
+`R ⇒ R'` to the antecedent, and *up*" — threading the in-scope referents along the
+first path to the box declaring the target; the declarative counterpart is the
+host-anchored preorder `AccessibleTo` at the end of this file, with soundness
+`DRS.Accessible.exists_mem_accessibleDomain`. -/
 
 /-- Accessibility threading through a condition. -/
 def accScope (s : Finset V) : Condition L V → V → Option (Finset V)
@@ -374,9 +377,9 @@ def ReuseFreeAt (X : Finset V) (K : DRS L V) : Prop :=
 
 /-! ### Accessibility -/
 
-/-- Descend `K`, accumulating in-scope referents `s` ("left and up"); on reaching
-the box introducing `x`, return that box's in-scope set `s ∪ U`. The `⇒`-consequent
-additionally sees the antecedent's universe. -/
+/-- Descend `K`, accumulating in-scope referents `s` ([vaneijck-2006]'s "left and
+up" walk); on reaching the box introducing `x`, return that box's in-scope set
+`s ∪ U`. The `⇒`-consequent additionally sees the antecedent's universe. -/
 def accScope (s : Finset V) (K : DRS L V) (x : V) : Option (Finset V) :=
   if x ∈ K.referents then some (s ∪ K.referents)
   else Condition.accScopeL (s ∪ K.referents) K.conditions x

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -31,10 +31,10 @@ its instantiation at `Condition L V`.
 * `DRS.merge` — the `⊕` operation (set-union referents, concatenate
   conditions); [muskens-1996]'s compositional operation.
 * `DirectlySubordinate`, `Subordinate`, `WeakSubordinate` — immediate
-  subordination (Def. 1.4.10(i), extended to `⇒`/`∨` by Def. 2.1.2; see the
-  deviation note on `DirectlySubordinate`) and its `Relation.TransGen` /
-  `ReflTransGen` closures (Def. 1.4.10(ii)). Accessibility (Def. 1.4.11) is
-  host-relative and lives in `DRS/Basic.lean` (`accessibleFrom`).
+  subordination (Def. 1.4.10(i), extended to `⇒`/`∨` by Def. 2.1.2) and its
+  `Relation.TransGen` / `ReflTransGen` closures (Def. 1.4.10(ii)); weak
+  subordination is a partial order (`WeakSubordinate.antisymm`). Accessibility is
+  host-relative and lives in `DRS/Basic.lean` (`AccessibleTo`, `accessibleFrom`).
 
 ## Implementation notes
 
@@ -130,34 +130,28 @@ of its sub-boxes. -/
 
 /-! ### Subordination -/
 
-/-- One-step subordination: `DirectlySubordinate K' K` says `K'` is *directly
-subordinate* to `K` — the `neg` case per Def. 1.4.10(i), the `⇒`/`∨` cases per
-its Chapter 2 extension (Def. 2.1.2). Deviation: Def. 2.1.2 subordinates *both*
-components of an implicative condition to the DRS containing it; here `impCons`
-subordinates the consequent to the *antecedent* instead, folding the `⇒` clause
-of the accessibility definition (Def. 2.1.3(ii)(b)) into the geometry — the
-closure below the host is unchanged, and antecedent referents lie weakly above
-the consequent. A relation on DRS values, where the textbook's is on box
-occurrences: on a degenerate `imp a a` the consequent edge makes `a`
-subordinate to itself. -/
+/-- One-step subordination: `DirectlySubordinate K' K` says `K'` is a sub-box of one
+of `K`'s conditions — the `neg` case per Def. 1.4.10(i), the `⇒`/`∨` cases per its
+Chapter 2 extension (Def. 2.1.2, which subordinates *both* components of a
+conditional to the containing DRS). A relation on DRS values, where the textbook's
+is on box occurrences. Every clause pins the containing box in its conclusion: an
+unpinned clause (such as consequent-below-antecedent) would hold of *every* pair of
+DRSs via a manufactured container, collapsing the relation. The `⇒` visibility
+asymmetry is not subordination but accessibility (`AccessibleTo`,
+`DRS/Basic.lean`). -/
 inductive DirectlySubordinate : DRS L V → DRS L V → Prop where
   /-- The body of a `¬` is directly subordinate to the containing DRS. -/
   | neg {D K : DRS L V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D
   /-- The antecedent of a `⇒` is directly subordinate to the containing DRS. -/
   | impAnte {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate a D
-  /-- The consequent of a `⇒` is directly subordinate to its *antecedent* — the
-  asymmetry that makes antecedent referents accessible in the consequent
-  (Def. 2.1.3(ii)(b), folded into the geometry; Def. 2.1.2 itself subordinates
-  the consequent to `D`). -/
-  | impCons {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c a
+  /-- The consequent of a `⇒` is directly subordinate to the containing DRS. -/
+  | impCons {D a c : DRS L V} : Condition.imp a c ∈ D.conditions → DirectlySubordinate c D
   /-- The left disjunct of a `∨` is directly subordinate to the containing DRS. -/
   | disL {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate l D
   /-- The right disjunct of a `∨` is directly subordinate to the containing DRS. -/
   | disR {D l r : DRS L V} : Condition.dis l r ∈ D.conditions → DirectlySubordinate r D
 
-/-- The `<` of Def. 1.4.10(ii): the transitive closure of `DirectlySubordinate`.
-Accessibility (`accessibleFrom`, `DRS/Basic.lean`) is host-relative and does
-not build on this closure. -/
+/-- The `<` of Def. 1.4.10(ii): the transitive closure of `DirectlySubordinate`. -/
 abbrev Subordinate : DRS L V → DRS L V → Prop :=
   Relation.TransGen DirectlySubordinate
 
@@ -165,5 +159,34 @@ abbrev Subordinate : DRS L V → DRS L V → Prop :=
 `DirectlySubordinate`. -/
 abbrev WeakSubordinate : DRS L V → DRS L V → Prop :=
   Relation.ReflTransGen DirectlySubordinate
+
+/-- A directly subordinate DRS is a structurally smaller value. -/
+theorem DirectlySubordinate.sizeOf_lt {K' K : DRS L V} (h : DirectlySubordinate K' K) :
+    sizeOf K' < sizeOf K := by
+  obtain ⟨U, conds⟩ := K
+  cases h with
+  | neg h | impAnte h | impCons h | disL h | disR h =>
+    have := List.sizeOf_lt_of_mem h
+    simp_all
+    omega
+
+/-- Subordinate DRSs are structurally smaller; subordination chains terminate. -/
+theorem Subordinate.sizeOf_lt {K' K : DRS L V} (h : Subordinate K' K) :
+    sizeOf K' < sizeOf K := by
+  induction h with
+  | single h => exact h.sizeOf_lt
+  | tail _ h ih => exact ih.trans h.sizeOf_lt
+
+theorem Subordinate.irrefl (K : DRS L V) : ¬ Subordinate K K :=
+  fun h => absurd h.sizeOf_lt (lt_irrefl _)
+
+/-- Weak subordination is a partial order on DRS values. -/
+theorem WeakSubordinate.antisymm {K' K : DRS L V} (h : WeakSubordinate K' K)
+    (h' : WeakSubordinate K K') : K' = K := by
+  rcases Relation.reflTransGen_iff_eq_or_transGen.mp h with rfl | h₁
+  · rfl
+  rcases Relation.reflTransGen_iff_eq_or_transGen.mp h' with rfl | h₂
+  · rfl
+  exact absurd ((Subordinate.sizeOf_lt h₁).trans (Subordinate.sizeOf_lt h₂)) (lt_irrefl _)
 
 end DRT

--- a/Linglib/Studies/KampReyle1993.lean
+++ b/Linglib/Studies/KampReyle1993.lean
@@ -17,10 +17,11 @@ donkey he beats it." (2.47) receives the universal reading through the `⇒` ver
 clause of (2.31)/Def. 2.1.4 (`donkey_universal_reading`), the pronoun-completed
 (2.45)-style variant having the same truth conditions (`donkeyPronoun_agree`).
 
-The structural facts — subordination of the donkey boxes (Def. 1.4.10/2.1.2),
-accessibility (Def. 2.1.3), properness, truth in concrete models — are proved by
-evaluation; the truth-conditions are claims over arbitrary models, proved by unfolding
-the verifying-embedding semantics. Sequencing a discourse is `DRS.merge`, whose
+The structural facts — subordination of the donkey boxes (Def. 1.4.10/2.1.2), the
+accessibility asymmetry ([geurts-beaver-maier-2024] §4.2: the antecedent is accessible
+to the consequent, not conversely), properness, truth in concrete models — are proved
+by evaluation or by cases on the geometry; the truth-conditions are claims over
+arbitrary models, proved by unfolding the verifying-embedding semantics. Sequencing a discourse is `DRS.merge`, whose
 dynamics is the substrate Merging Lemma `DRS.toRel_merge`, so merged-vs-compositional
 equalities are definitional.
 -/
@@ -213,24 +214,55 @@ theorem donkeyPronoun_agree (a : ℕ → M) :
     DRS.trueRel donkeyPronoun a ↔ DRS.trueRel donkey a :=
   (donkeyPronoun_tc a).trans (donkey_universal_reading a).symm
 
-/-! ### Subordination geometry -/
+/-! ### Subordination and accessibility geometry -/
 
 /-- The antecedent box is directly subordinate to the donkey DRS (Def. 1.4.10 as
 extended by Def. 2.1.2). -/
 theorem donkey_antecedent_subordinate : DirectlySubordinate donkeyAnte donkey :=
   .impAnte (c := donkeyCons) (by simp [donkey])
 
-/-- The consequent box is directly subordinate to the *antecedent* — the substrate's
-rendering of the `⇒` accessibility asymmetry (Def. 2.1.3(ii)(b)); Def. 2.1.2 itself
-subordinates the consequent to the containing DRS, recovered here by closure
-(`donkey_consequent_subordinate_host`). -/
-theorem donkey_consequent_subordinate : DirectlySubordinate donkeyCons donkeyAnte :=
-  .impCons (show Condition.imp donkeyAnte donkeyCons ∈ donkey.conditions by
-    simp [donkey])
+/-- The consequent box is likewise directly subordinate to the donkey DRS. -/
+theorem donkey_consequent_subordinate : DirectlySubordinate donkeyCons donkey :=
+  .impCons (a := donkeyAnte) (by simp [donkey])
 
-/-- Def. 2.1.2's own claim: the consequent box sits below the donkey DRS. -/
-theorem donkey_consequent_subordinate_host : Subordinate donkeyCons donkey :=
-  .head donkey_consequent_subordinate (.single donkey_antecedent_subordinate)
+/-- The antecedent is accessible to the consequent ([geurts-beaver-maier-2024]
+§4.2) — the geometry that licenses the donkey anaphora. -/
+theorem donkey_antecedent_accessible : AccessibleTo donkey donkeyAnte donkeyCons :=
+  .single (.impCons .refl (by simp [donkey]))
+
+private theorem weakSubordinate_donkey {K : DRS krLang ℕ} (h : WeakSubordinate K donkey) :
+    K = donkey ∨ K = donkeyAnte ∨ K = donkeyCons := by
+  induction h using Relation.ReflTransGen.head_induction_on with
+  | refl => exact .inl rfl
+  | head hstep hrest ih =>
+    rcases ih with rfl | rfl | rfl
+    · cases hstep with
+      | neg hc => simp [donkey] at hc
+      | impAnte hc => simp [donkey] at hc; exact .inr (.inl hc.1)
+      | impCons hc => simp [donkey] at hc; exact .inr (.inr hc.2)
+      | disL hc => simp [donkey] at hc
+      | disR hc => simp [donkey] at hc
+    · cases hstep with
+      | neg hc | impAnte hc | impCons hc | disL hc | disR hc => simp [donkeyAnte] at hc
+    · cases hstep with
+      | neg hc | impAnte hc | impCons hc | disL hc | disR hc => simp [donkeyCons] at hc
+
+/-- Not conversely: the consequent has no outgoing accessibility edge, so its
+(empty) universe contributes nothing to the antecedent — the `⇒` asymmetry. -/
+theorem donkey_not_consequent_accessible : ¬ AccessibleTo donkey donkeyCons donkeyAnte := by
+  intro h
+  rcases h.cases_head with heq | ⟨X, hedge, -⟩
+  · exact absurd (congrArg Box.referents heq) (by decide)
+  · cases hedge with
+    | neg hK hc => simp [donkeyCons] at hc
+    | impAnte hK hc => simp [donkeyCons] at hc
+    | disLeft hK hc => simp [donkeyCons] at hc
+    | disRight hK hc => simp [donkeyCons] at hc
+    | impCons hK hc =>
+      rcases weakSubordinate_donkey hK with rfl | rfl | rfl
+      · simp [donkey, donkeyAnte, donkeyCons] at hc
+      · simp [donkeyAnte] at hc
+      · simp [donkeyCons] at hc
 
 /-! ### Model evaluation: the donkey conditional in concrete models
 

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -1708,6 +1708,20 @@
   role      = {formalized},
   validated = {true},
   sources   = {Semantics/Dynamic/DRS/Basic.lean;Semantics/Dynamic/DRS/Defs.lean}
+}
+@incollection{vaneijck-2006,
+  author    = {van Eijck, Jan},
+  year      = {2006},
+  title     = {Discourse Representation Theory},
+  booktitle = {Encyclopedia of Language and Linguistics},
+  edition   = {2},
+  editor    = {Brown, Keith},
+  publisher = {Elsevier},
+  url       = {https://staff.fnwi.uva.nl/d.j.n.vaneijck2/papers/06/pdfs/drt.pdf},
+  subfield  = {semantics/dynamic},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Semantics/Dynamic/DRS/Basic.lean}
 }% REF: Sperber, D., et al. (2010). Epistemic vigilance. *Mind & Language*, 25, 359–393.
 @article{sperber-2010,
   author    = {Sperber, Dan and Clément, Fabrice and Heintz, Christophe and Mascaro, Olivier and Mercier, Hugo and Origgi, Gloria and Wilson, Deirdre},

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -1694,6 +1694,20 @@
   role      = {cited},
   validated = {true},
   sources   = {Core/Order/Comparison.lean;Semantics/Degree/Predicate.lean;Semantics/Quantification/Numerals/Basic.lean}
+}
+@incollection{geurts-beaver-maier-2024,
+  author    = {Geurts, Bart and Beaver, David I. and Maier, Emar},
+  year      = {2024},
+  title     = {Discourse Representation Theory},
+  booktitle = {The Stanford Encyclopedia of Philosophy},
+  editor    = {Zalta, Edward N. and Nodelman, Uri},
+  publisher = {Metaphysics Research Lab, Stanford University},
+  note      = {First published 2007; substantive revision July 11, 2024},
+  url       = {https://plato.stanford.edu/entries/discourse-representation-theory/},
+  subfield  = {semantics/dynamic},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Semantics/Dynamic/DRS/Basic.lean;Semantics/Dynamic/DRS/Defs.lean}
 }% REF: Sperber, D., et al. (2010). Epistemic vigilance. *Mind & Language*, 25, 359–393.
 @article{sperber-2010,
   author    = {Sperber, Dan and Clément, Fabrice and Heintz, Christophe and Mascaro, Olivier and Mercier, Hugo and Origgi, Gloria and Wilson, Deirdre},


### PR DESCRIPTION
`DirectlySubordinate.impCons` left its containing box unpinned, so `DirectlySubordinate c a` was derivable for every pair via a manufactured container (`D := ⟨∅, [.imp a c]⟩`) — the relation was total and all downstream subordination theorems vacuous. The constructor now subordinates the consequent to the containing DRS (Kamp & Reyle Def. 2.1.2), with `sizeOf`-based irreflexivity/antisymmetry as regression witnesses.

- The `⇒` visibility asymmetry moves to accessibility, credited to its sources: the computed `accScope` is [vaneijck-2006]'s left-and-up walk; the declarative host-anchored `AccessibleEdge`/`AccessibleTo` (smallest preorder) and `accessibleDomain` follow [geurts-beaver-maier-2024] §4.2 (both bib entries new), with soundness `DRS.Accessible.exists_mem_accessibleDomain` — every `accScope` verdict is realized by genuine edges. Also a `Decidable IsProper` instance.
- `Studies/KampReyle1993.lean` (rebased over #2076): subordination theorems restated on the repaired relation, plus the now-provable accessibility asymmetry (`donkey_antecedent_accessible` / `donkey_not_consequent_accessible`).