### PR TITLE
docs(Semantics/Dynamic/DRS): directory docstrings in mathlib register

### DIFF
--- a/Linglib/Semantics/Dynamic/DRS/Basic.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Basic.lean
@@ -4,14 +4,26 @@ import Linglib.Semantics.Dynamic.DRS.Defs
 # Structural operations on DRSs
 
 This file develops the structural theory of the `DRS` type of `DRS/Defs.lean`:
-functorial renaming of discourse referents (`DRS.map`), the merge algebra,
-transport of the extension relation along renaming, the referent predicates
-`varFinset`, `freeVarFinset` and `IsProper`, `ReuseFreeAt`, and accessibility —
-computed as [vaneijck-2006]'s left-and-up walk (`accessibleFrom`, `Accessible`)
-and as [geurts-beaver-maier-2024]'s smallest preorder (`AccessibleTo`,
-`accessibleDomain`), connected by
-`DRS.Accessible.exists_mem_accessibleDomain`. Renaming along a bijection is
-[kamp-reyle-1993]'s *alphabetic variant* (the prose preceding Def. 1.4.8).
+renaming of discourse referents, the merge algebra, transport of the extension
+relation along renaming, occurrence and freeness predicates, and accessibility.
+Renaming along a bijection is [kamp-reyle-1993]'s *alphabetic variant* (the
+prose preceding Def. 1.4.8).
+
+## Main declarations
+
+* `DRS.map`: renaming along `f : V → W`, functorial.
+* `DRS.varFinset`, `DRS.freeVarFinset`: occurring and free referents.
+* `DRS.IsProper`: no free referent (Def. 1.4.2–1.4.3); decidable.
+* `DRS.ReuseFreeAt`: no referent declared twice along a nesting path.
+* `DRS.accessibleFrom`, `DRS.Accessible`: accessible referents, computed by
+  [vaneijck-2006]'s left-and-up walk; decidable.
+* `AccessibleTo`, `accessibleDomain`: [geurts-beaver-maier-2024]'s accessibility
+  preorder over the sub-DRSs of a host, and its accessible domain `A_K`.
+
+## Main statements
+
+* `DRS.Accessible.exists_mem_accessibleDomain`: every computed accessibility
+  verdict is realized by genuine accessibility edges.
 -/
 
 open FirstOrder
@@ -189,16 +201,15 @@ def ReuseFreeAllAt (X : Finset V) (cs : List (Condition L V)) : Prop :=
 
 /-! ### Accessibility threading
 
-Accessibility (Def. 1.4.11) is intrinsically *relative to a host DRS*: "`u`
-accessible at box `B`" means `u` lies in the universe of `B` or of a box on the
-path from the host down to `B`. A host-free `∃ D, WeakSubordinate K D ∧
-u ∈ D.referents` is **vacuous** — a superordinate `D` introducing any referent can
-always be manufactured. `accScope` computes accessibility *top-down* — the walk of
-[vaneijck-2006] "in the directions *left*, i.e. from the consequent of a pair
-`R ⇒ R'` to the antecedent, and *up*" — threading the in-scope referents along the
-first path to the box declaring the target; the declarative counterpart is the
-host-anchored preorder `AccessibleTo` at the end of this file, with soundness
-`DRS.Accessible.exists_mem_accessibleDomain`. -/
+Accessibility (Def. 1.4.11) is relative to a host DRS: "`u` accessible at box
+`B`" means `u` lies in the universe of `B` or of a box on the path from the host
+down to `B`. A host-free `∃ D, WeakSubordinate K D ∧ u ∈ D.referents` is
+vacuous, since a superordinate `D` introducing any referent can be manufactured.
+`accScope` computes accessibility top-down, by [vaneijck-2006]'s walk in the
+directions *left* (from the consequent of a `⇒` to its antecedent) and *up*,
+threading the in-scope referents along the first path to the box declaring the
+target; the declarative counterpart is the host-anchored preorder `AccessibleTo`
+at the end of this file. -/
 
 /-- Accessibility threading through a condition. -/
 def accScope (s : Finset V) : Condition L V → V → Option (Finset V)
@@ -484,13 +495,13 @@ theorem Condition.accScope_dis (s : Finset V) (l r : DRS L V) (x : V) :
 
 /-! ## Accessibility as the smallest preorder
 
-[geurts-beaver-maier-2024]'s §4.2 presentation: accessibility is the smallest
-preorder on the sub-DRSs of a host such that a box is accessible to the sub-boxes
-of its complex conditions and a conditional's antecedent is accessible to its
-consequent. Each generating edge anchors its containing box below the host — the
-anchor is what keeps the relation non-vacuous. `accScope` above computes accessible
-referents top-down; `DRS.Accessible.exists_mem_accessibleDomain` shows every
-computed verdict is realized by genuine edges. -/
+Following [geurts-beaver-maier-2024] §4.2, accessibility is the smallest
+preorder on the sub-DRSs of a host such that a box is accessible to the
+sub-boxes of its complex conditions and a conditional's antecedent is accessible
+to its consequent. Each generating edge anchors its containing box below the
+host, which keeps the relation non-vacuous.
+`DRS.Accessible.exists_mem_accessibleDomain` shows every verdict of the computed
+`accScope` is realized by genuine edges. -/
 
 /-- A generating edge of the accessibility preorder over the sub-DRSs of `host`
 (§4.2): a box is accessible to the sub-boxes of its complex conditions, and the
@@ -512,8 +523,8 @@ inductive AccessibleEdge (host : DRS L V) : DRS L V → DRS L V → Prop where
   | disRight {K K' K'' : DRS L V} : WeakSubordinate K host →
       Condition.dis K' K'' ∈ K.conditions → AccessibleEdge host K K''
 
-/-- `AccessibleTo host K K'`: `K` is accessible to `K'` among the sub-DRSs of
-`host` — the smallest preorder containing the generating edges (§4.2). -/
+/-- `AccessibleTo host K K'` says `K` is accessible to `K'` among the sub-DRSs
+of `host` — the smallest preorder containing the generating edges (§4.2). -/
 abbrev AccessibleTo (host : DRS L V) : DRS L V → DRS L V → Prop :=
   Relation.ReflTransGen (AccessibleEdge host)
 
@@ -528,8 +539,8 @@ theorem AccessibleEdge.weakSubordinate_right {host K K' : DRS L V}
   | disLeft hK hc => exact .head (.disL hc) hK
   | disRight hK hc => exact .head (.disR hc) hK
 
-/-- The accessible domain `A_K` of `K` in `host` (§4.2): the referents declared in
-some box accessible to `K`. -/
+/-- The accessible domain `A_K` of `K` in `host` — the set of referents declared
+in some box accessible to `K` (§4.2). -/
 def accessibleDomain (host K : DRS L V) : Set V :=
   {x | ∃ K', AccessibleTo host K' K ∧ x ∈ K'.referents}
 

--- a/Linglib/Semantics/Dynamic/DRS/Category.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Category.lean
@@ -12,38 +12,35 @@ the context or introduced by the DRS itself — and whose introductions
 are fresh for the context, growing `X` to `Y`. Composition is `merge`;
 identity is the empty DRS.
 
-The visibility invariant is what makes composition unconditional: it
-*derives* the Merging Lemma's capture-freshness side condition, so
-`merge` needs no hypotheses here. Interpretation (`Ctx.sem`) is then an
-identity-on-objects functor into the semantic category of contexts
-`DynamicSemantics.Ctx`, and its functoriality on composition *is* the
+The visibility invariant derives the Merging Lemma's capture-freshness
+side condition, so composition needs no hypotheses. Interpretation
+(`Ctx.sem`) is an identity-on-objects functor into the semantic category
+of contexts `DynamicSemantics.Ctx`, functorial on composition by the
 Merging Lemma (`DRS.transition_merge`).
-
-"Category of contexts" is the field's name for this structure: it is a
-syntactic category in the sense of categorical logic (objects are
-contexts — declarations of variables, type theory's *bases*, cf.
-[visser-1998] — and arrows are syntax), and the diachronic information
-ordering of [visser-vermeulen-1996]'s bracketing approach, in which
-contexts under merge form a category
-([muskens-van-benthem-visser-2011]'s m-categories). `DRT.Ctx` and
-`DynamicSemantics.Ctx` name the two levels of DRT's architecture, not
-rival theories: DRT's distinctive *representation* level, where contexts
-compose by merging boxes, and the framework-neutral semantic level,
-where they compose transitions relationally — the level other dynamic
-frameworks interpret into as well.
 
 ## Main definitions
 
-- `DRT.Ctx L V`: contexts, with well-formed DRSs as morphisms and
+* `DRT.Ctx L V`: contexts, with well-formed DRSs as morphisms and
   `merge` as composition.
-- `DRT.Ctx.sem`: interpretation as a functor into
+* `DRT.Ctx.sem`: interpretation as a functor into
   `DynamicSemantics.Ctx W M V`, given a model of the language.
+
+## Implementation notes
+
+This is a syntactic category in the sense of categorical logic (objects
+are declarations of variables, type theory's bases, cf. [visser-1998]),
+and the context-under-merge category of [visser-vermeulen-1996]'s
+bracketing approach ([muskens-van-benthem-visser-2011]'s m-categories).
+`DRT.Ctx` and `DynamicSemantics.Ctx` name the two levels of DRT's
+architecture, not rival theories: contexts compose by merging boxes at
+the representation level and by relational composition of transitions at
+the semantic level.
 
 ## References
 
-- [visser-vermeulen-1996], [visser-1998], [muskens-1996] (the merge
+* [visser-vermeulen-1996], [visser-1998], [muskens-1996] (the merge
   algebra and context typing)
-- [kamp-vangenabith-reyle-2011], [kamp-reyle-1993]
+* [kamp-vangenabith-reyle-2011], [kamp-reyle-1993]
 -/
 
 namespace DRT

--- a/Linglib/Semantics/Dynamic/DRS/Defs.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Defs.lean
@@ -87,10 +87,10 @@ def empty : DRS L V := .mk ∅ []
 
 instance : Inhabited (DRS L V) := ⟨empty⟩
 
-/-- Merge `⊕`: set-union the referents, concatenate the conditions. The binary
-DRS merge is Muskens's compositional operation — Kamp & Reyle themselves
-combine DRSs incrementally via the construction algorithm, not a symmetric
-binary `⊕`. An operation, not a syntactic constructor. -/
+/-- The merge `K₁ ⊕ K₂` unions the referents and appends the conditions —
+[muskens-1996]'s compositional operation (Kamp & Reyle combine DRSs
+incrementally via the construction algorithm instead). An operation, not a
+syntactic constructor. -/
 def merge [DecidableEq V] (K₁ K₂ : DRS L V) : DRS L V :=
   .mk (K₁.referents ∪ K₂.referents) (K₁.conditions ++ K₂.conditions)
 
@@ -123,15 +123,14 @@ of its sub-boxes. -/
 
 /-! ### Subordination -/
 
-/-- One-step subordination: `DirectlySubordinate K' K` says `K'` is a sub-box of one
-of `K`'s conditions — the `neg` case per Def. 1.4.10(i), the `⇒`/`∨` cases per its
-Chapter 2 extension (Def. 2.1.2, which subordinates *both* components of a
-conditional to the containing DRS). A relation on DRS values, where the textbook's
-is on box occurrences. Every clause pins the containing box in its conclusion: an
-unpinned clause (such as consequent-below-antecedent) would hold of *every* pair of
-DRSs via a manufactured container, collapsing the relation. The `⇒` visibility
-asymmetry is not subordination but accessibility (`AccessibleTo`,
-`DRS/Basic.lean`). -/
+/-- `DirectlySubordinate K' K` says `K'` is a sub-box of one of `K`'s conditions —
+the `neg` case per Def. 1.4.10(i), the `⇒`/`∨` cases per its Chapter 2 extension
+(Def. 2.1.2, which subordinates *both* components of a conditional to the
+containing DRS). A relation on DRS values, where the textbook's is on box
+occurrences. Every clause pins the containing box in its conclusion: an unpinned
+clause (such as consequent-below-antecedent) would hold of every pair of DRSs via
+a manufactured container, collapsing the relation. The `⇒` visibility asymmetry
+is not subordination but accessibility (`AccessibleTo`, `DRS/Basic.lean`). -/
 inductive DirectlySubordinate : DRS L V → DRS L V → Prop where
   /-- The body of a `¬` is directly subordinate to the containing DRS. -/
   | neg {D K : DRS L V} : Condition.neg K ∈ D.conditions → DirectlySubordinate K D

--- a/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Dynamics.lean
@@ -5,41 +5,37 @@ import Linglib.Semantics.Dynamic.Update
 /-!
 # The box relation: dynamic face of DRS verification
 
-The relational (input–output) face of the unified verification semantics
-(`DRS/Verification.lean`): the *box relation* `K.toRel a a'` holds when the
-output `a'` extends the input `a` across `K` and verifies `K`, and a DRS is
-*true* under an input iff some output is related to it (the spine's anaphoric
-`closure`). This is [muskens-1996]'s SEM3 format (input → output, the format
-of [groenendijk-stokhof-1991]), definable in one line from verification —
-Muskens's remark that his relational interpretation "is in fact equivalent"
-to the standard one (his fn. 3–4 scope it: constant-free constructs, and both
-sides in the total-assignment rendering; see the deviation note in
-`DRS/Verification.lean`). His SEM1/2 clauses — complex conditions as the
-spine connectives `neg`/`impl`/`disj` on box relations — are derived
-characterizations (`verifies_neg_toRel`, …), connecting DRS verification to
-the connective algebra shared across the dynamic-semantics spine.
+This file gives DRS verification (`DRS/Verification.lean`) its relational,
+input–output face. The *box relation* `K.toRel a a'` holds when the output `a'`
+extends the input `a` across `K` and verifies `K`; a DRS is *true* under an
+input iff some output is related to it (the spine's anaphoric `closure`). This
+is [muskens-1996]'s SEM3 format, in the style of [groenendijk-stokhof-1991];
+his SEM1/2 clauses — complex conditions as the spine connectives on box
+relations — are derived characterizations, connecting DRS verification to the
+connective algebra shared across the dynamic-semantics spine.
 
 ## Main declarations
 
-* `DRS.toRel` — the box relation; `DRS.trueRel` — relational truth, its
+* `DRS.toRel`: the box relation; `DRS.trueRel`: relational truth, its
   `closure`.
-* `Embedding.verifies_neg_toRel` (`_imp_`, `_dis_`) — complex conditions are
+* `Embedding.verifies_neg_toRel` (`_imp_`, `_dis_`): complex conditions are
   the spine connectives on box relations (SEM1/2).
-* `DRS.trueRel_iff_realize_toFormula` — dynamic truth equals the first-order
+* `DRS.trueRel_iff_realize_toFormula`: dynamic truth equals the first-order
   translation's `Realize` (`DRS/Reduction.lean`).
-* `DRS.trueRel_congr` — coincidence: truth reads the input only at the
-  occurring referents.
-* `DRS.toRel_merge` — the Merging Lemma: under freshness, `merge` denotes the
+* `DRS.trueRel_congr`: truth reads the input only at the occurring referents.
+* `DRS.toRel_merge`: the Merging Lemma — under freshness, `merge` denotes the
   spine sequencing `Update.seq` of the two box relations.
-* `DRS.trueRel_map` — alphabetic variants have the same truth conditions.
+* `DRS.trueRel_map`: alphabetic variants have the same truth conditions.
 
 ## Implementation notes
 
-Naming: the relational face (`toRel`, `trueRel`) follows the spine's
-lowerCamel operation names (`neg`, `seq`, `closure`); verification
-(`Embedding.Verifies`, `DRS/Verification.lean`) uses the field's own verb, and
-the first-order reduction (`DRS/Reduction.lean`) speaks mathlib's
-`Formula.Realize`.
+* Muskens scopes the equivalence of the relational and standard
+  interpretations to constant-free constructs, both sides in the
+  total-assignment rendering (fn. 3–4; see the deviation note in
+  `DRS/Verification.lean`).
+* The relational face (`toRel`, `trueRel`) follows the spine's lowerCamel
+  operation names (`neg`, `seq`, `closure`); verification uses the field's own
+  verb, and the first-order reduction speaks mathlib's `Formula.Realize`.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -54,8 +50,8 @@ variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 
 /-! ### The box relation -/
 
-/-- The box relation (SEM3): the output `a'` extends the input `a` across `K`
-and verifies `K`. -/
+/-- The box relation (SEM3), relating an input `a` to the outputs that extend
+it across `K` and verify `K`. -/
 def DRS.toRel (K : DRS L V) : Update (V → M) :=
   fun a a' => K.Extends a a' ∧ Embedding.Verifies a' K
 

--- a/Linglib/Semantics/Dynamic/DRS/Indexed.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Indexed.lean
@@ -5,37 +5,33 @@ import Linglib.Semantics.Dynamic.Transition
 /-!
 # Indexed relational semantics of DRSs
 
-The base-threaded verification semantics: `toRelAt X K f g` holds when the
-output `g` agrees with the input `f` *on the context base* `X` and verifies
-`K`'s conditions, sub-boxes entered at the grown base. This is the
-total-assignment rendering of [kamp-vangenabith-reyle-2011]'s
+This file defines the base-threaded verification semantics: `toRelAt X K f g`
+holds when the output `g` agrees with the input `f` on the context base `X`
+and verifies `K`'s conditions, sub-boxes entered at the grown base. This is
+the total-assignment rendering of [kamp-vangenabith-reyle-2011]'s
 partial-embedding semantics (Defs. 19, 22, 24): values at established
-referents *persist*, as in [kamp-reyle-1993]'s original embeddings — contrast
-the flat `DRS.toRel` (`DRS/Dynamics.lean`), whose agree-off-universe clause
-freely reassigns re-declared referents ([muskens-1996]'s fn. 4 divergence).
+referents persist, as in [kamp-reyle-1993]'s original embeddings — in contrast
+to the flat `DRS.toRel` (`DRS/Dynamics.lean`), which freely reassigns
+re-declared referents ([muskens-1996]'s fn. 4 divergence).
 
-Persistence is what makes the indexed semantics well-typed: `toRelAt X K` is
-read only at `X` (`toRelAt_congr_left` — one line, no witness surgery) and
-written only at `X ∪ U` (`toRelAt_congr_right`, given the *referential
-presupposition* `K.freeVarFinset ⊆ X`), so a well-formed DRS denotes a spine
-`Transition X (X ∪ U)` (`DRS.transition`), and a proper DRS expresses an
-information state by acting on `⊥` (`DRS.state`, Def. 22).
-
-The Merging Lemma for this semantics (`toRelAt_merge`) needs strictly less
-than the flat freshness hypothesis — only *capture* by sub-box universes is
-fatal, re-declaration is harmless — and lifts to the spine
-(`transition_merge`), where the action equation (`state_merge`) becomes an
-instance of functoriality (`Transition.apply_comp`).
+Persistence types the semantics: `toRelAt X K` is read only at `X` and, given
+the referential presupposition `K.freeVarFinset ⊆ X`, written only at `X ∪ U`,
+so a well-formed DRS denotes a spine transition `Transition X (X ∪ U)` and a
+proper DRS expresses an information state by acting on `⊥` (Def. 22). The
+Merging Lemma here needs less than the flat freshness hypothesis — only
+capture by sub-box universes is fatal, re-declaration is harmless — and lifts
+to the spine, where the action equation is an instance of functoriality
+(`Transition.apply_comp`).
 
 ## Main declarations
 
-* `DRS.toRelAt` / `Condition.holdsAt` — the base-threaded semantics.
-* `DRS.toRelAt_congr_left` / `toRelAt_congr_right` — read/write support.
-* `DRS.transition` — a DRS as a spine transition `X ⟶ X ∪ U`.
-* `DRS.state` — the information state a proper DRS expresses.
-* `DRS.transition_merge` / `DRS.state_merge` — the Merging Lemma on the
-  spine and the action equation.
-* `DRS.trueRel_iff_toRelAt` — on reuse-free DRSs the flat and indexed
+* `DRS.toRelAt`, `Condition.holdsAt`: the base-threaded semantics.
+* `DRS.toRelAt_congr_left`, `DRS.toRelAt_congr_right`: read/write support.
+* `DRS.transition`: a DRS as a spine transition `X ⟶ X ∪ U`.
+* `DRS.state`: the information state a proper DRS expresses.
+* `DRS.transition_merge`, `DRS.state_merge`: the Merging Lemma on the spine
+  and the action equation.
+* `DRS.trueRel_iff_toRelAt`: on reuse-free DRSs the flat and indexed
   semantics have the same truth conditions.
 -/
 

--- a/Linglib/Semantics/Dynamic/DRS/Reduction.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Reduction.lean
@@ -2,25 +2,21 @@ import Linglib.Semantics.Dynamic.DRS.Verification
 import Mathlib.ModelTheory.Semantics
 
 /-!
-# From DRT to predicate logic: the DRS → first-order reduction
+# From DRT to predicate logic
 
-The bespoke DRS box language is *equivalent to ordinary first-order
-logic*. We translate each DRS into a mathlib
-`FirstOrder.Language.Formula` and prove its `Realize` coincides with the
-bespoke `Embedding.Verifies` — [kamp-reyle-1993]'s §1.5 ("From DRT to Predicate
-Logic") and [muskens-1996]'s "DRSs are already present in classical logic",
-now a Lean theorem (`DRS.realize_toFormula`) rather than an assertion.
-
-The universe of a (sub-)DRS is *existentially closed* (`closeExists`, via
-mathlib's `Formula.iExs`); the antecedent of a `⇒` is *universally closed*
-(`closeForall`, via `Formula.iAlls`).
+This file translates each DRS into a mathlib `FirstOrder.Language.Formula` and
+proves that the translation's `Realize` coincides with `Embedding.Verifies` —
+[kamp-reyle-1993]'s §1.5 reduction of the DRS language to first-order logic
+(cf. [muskens-1996]). The universe of a sub-DRS is existentially closed
+(`closeExists`, via `Formula.iExs`); the antecedent of a `⇒` is universally
+closed (`closeForall`, via `Formula.iAlls`).
 
 ## Main declarations
 
-* `DRS.toFormula` / `Condition.toFormula` — the translation into `L.Formula V`.
-* `DRS.realize_toFormula` — the agreement theorem: a DRS's bespoke truth matches
-  its first-order translation's `Realize`.
-* `realize_closeExists` / `realize_closeForall` — the universe-closure operators
+* `DRS.toFormula`, `Condition.toFormula`: the translation into `L.Formula V`.
+* `DRS.realize_toFormula`: truth of a DRS matches its first-order
+  translation's `Realize`.
+* `realize_closeExists`, `realize_closeForall`: the universe-closure operators
   realize as `∃`/`∀` over embeddings extending `v` on the closed referents.
 -/
 

--- a/Linglib/Semantics/Dynamic/DRS/Verification.lean
+++ b/Linglib/Semantics/Dynamic/DRS/Verification.lean
@@ -3,49 +3,39 @@ import Linglib.Semantics.Dynamic.DRS.Basic
 /-!
 # Verifying embeddings for DRSs
 
-[kamp-reyle-1993]'s Def. 1.4.4 in the *total-assignment* rendering, over a
-mathlib `FirstOrder.Language.Structure`. An *embedding function*
-`f : Embedding V M` assigns discourse referents to individuals in the model;
-`Box.Extends K f g` is the extension relation `f [K] g` (both in
-`DRS/Box.lean`); `f.Verifies K` says the embedding `f` *verifies* the DRS
-`K` — it verifies every condition of `K` — and `f.VerifiesCondition c` that it
-verifies the DRS-condition `c`. A sub-DRS is entered by existentially
-(re)assigning along its extension relation. For `imp`, the consequent witness
-extends the *antecedent* embedding, not the host one — antecedent referents
-stay visible in the consequent, the `⇒` accessibility asymmetry. The atomic
-and `¬` clauses are Def. 1.4.4(ii); the `⇒`/`∨` clauses are the Chapter 2
-conditional and disjunction semantics. Truth (Def. 1.4.5) is the existential
-closure of verification over the outer universe; it is delivered downstream
-as `DRS.trueRel` (`DRS/Dynamics.lean`) and as the first-order translation's
-realization (`DRS/Reduction.lean`).
-
-**Deviation** ([muskens-1996], fn. 4): the book's embeddings are *partial*
-functions that sub-DRSs strictly *extend*, so a re-declared referent keeps its
-value; here embeddings are total and a re-declared referent is freely
-reassigned. The two agree on DRSs that declare each referent once — the
-construction algorithm never re-declares — but diverge on re-declaration:
-`[ | [x | man x] ⇒ [x | mortal x]]` says "every man is mortal" there, "if
-there is a man there is a mortal" here.
+This file defines verification of DRSs by embeddings into a model, following
+[kamp-reyle-1993]'s Def. 1.4.4 over a mathlib `FirstOrder.Language.Structure`.
+An embedding `f : Embedding V M` assigns discourse referents to individuals;
+`f.Verifies K` says `f` verifies every condition of `K`, and a sub-DRS is
+entered by existentially (re)assigning along its extension relation
+`Box.Extends`. For `imp`, the consequent witness extends the *antecedent*
+embedding, so antecedent referents stay visible in the consequent (the `⇒`
+clause is Def. 2.1.4; the `∨` clause is the Chapter 2 disjunction semantics).
+Truth (Def. 1.4.5) is the existential closure of verification over the outer
+universe, delivered downstream as `DRS.trueRel` (`DRS/Dynamics.lean`) and as
+the first-order translation's realization (`DRS/Reduction.lean`).
 
 ## Main declarations
 
-* `Embedding.Verifies` / `Embedding.VerifiesCondition` — `f.Verifies K` is the
-  field's "`f` verifies `K`": `f` verifies every condition of `K`
-  (`∀ c ∈ K.conditions`, the `Theory.Model` idiom — no mutual recursion, no
-  list helper).
-* `Embedding.verifies_perm` — verification reads the condition list as a set,
-  cashing the `List`-representation note in `DRS/Defs.lean`.
-* `Embedding.verifies_map` — renaming along a bijection transports
-  verification: alphabetic variants (Def. 1.4.8, via `DRS.map` in
-  `DRS/Basic.lean`) have the same semantics.
+* `Embedding.Verifies`, `Embedding.VerifiesCondition`: `f` verifies the DRS
+  `K`, resp. a single DRS-condition.
+* `Embedding.verifies_perm`: verification reads the condition list as a set.
+* `Embedding.verifies_map`: renaming along a bijection transports
+  verification, so alphabetic variants (Def. 1.4.8) have the same semantics.
 
 ## Implementation notes
 
-`VerifiesCondition` descends into sub-DRSs through the nested
-`List (Condition L V)` by well-founded recursion on `sizeOf`, so its clause
-characterizations (`verifies_neg`, …) are equation-lemma rewrites rather than
-`Iff.rfl`; they restate the clauses with `Verifies` of the sub-DRS, as the
-textbook states them.
+* Embeddings here are total, and a re-declared referent is freely reassigned;
+  the book's are partial functions that sub-DRSs strictly *extend*, so a
+  re-declared referent keeps its value ([muskens-1996], fn. 4). The two agree
+  on DRSs that declare each referent once — the construction algorithm never
+  re-declares — but diverge on re-declaration: `[ | [x | man x] ⇒ [x | mortal x]]`
+  says "every man is mortal" there, "if there is a man there is a mortal" here.
+* `Verifies` quantifies over the condition list (`∀ c ∈ K.conditions`, the
+  `Theory.Model` idiom), avoiding mutual recursion. `VerifiesCondition`
+  descends into sub-DRSs by well-founded recursion on `sizeOf`, so its clause
+  characterizations (`verifies_neg`, …) are equation-lemma rewrites rather
+  than `Iff.rfl`.
 -/
 
 open FirstOrder FirstOrder.Language
@@ -58,8 +48,8 @@ variable {L : Language.{u, v}} {V : Type w} {M : Type x} [L.Structure M]
 
 namespace Embedding
 
-/-- `f.VerifiesCondition c`: the embedding `f` *verifies* the DRS-condition `c`
-(Def. 1.4.4(ii)); a sub-DRS is entered by existentially (re)assigning along
+/-- `f.VerifiesCondition c` says the embedding `f` *verifies* the DRS-condition
+`c` (Def. 1.4.4(ii)); a sub-DRS is entered by existentially (re)assigning along
 its extension relation and verifying each of its conditions. -/
 def VerifiesCondition : Embedding V M → Condition L V → Prop
   | f, .rel R args => Structure.RelMap R (fun i => f (args i))
@@ -72,7 +62,7 @@ def VerifiesCondition : Embedding V M → Condition L V → Prop
       (∃ g, l.Extends f g ∧ ∀ c ∈ l.conditions, g.VerifiesCondition c) ∨
       (∃ g, r.Extends f g ∧ ∀ c ∈ r.conditions, g.VerifiesCondition c)
 
-/-- `f.Verifies K`: the embedding `f` *verifies* the DRS `K` — `f` verifies
+/-- `f.Verifies K` says the embedding `f` *verifies* the DRS `K` — `f` verifies
 every condition of `K` (Def. 1.4.4). -/
 def Verifies (f : Embedding V M) (K : DRS L V) : Prop :=
   ∀ c ∈ K.conditions, f.VerifiesCondition c


### PR DESCRIPTION
Continues #2078 across the directory: object-first declarative openings (no fragment leads or formalization narration), Main-declarations bullets cut to name-plus-gloss with `:` separators, deviation/scoping caveats moved to Implementation notes, Category's terminology essay compressed there too, colon-opener declaration docstrings reworded, emphasis flourishes trimmed. Box.lean was already in register and is untouched.