### PR TITLE
feat(Fragments/Mandarin): book-verify polarity items (Haspelmath A.36)

### DIFF
--- a/Linglib/Fragments/Mandarin/PolarityItems.lean
+++ b/Linglib/Fragments/Mandarin/PolarityItems.lean
@@ -2,42 +2,120 @@ import Linglib.Semantics.Polarity.Licensing
 
 /-!
 # Mandarin Polarity-Sensitive Items
-[haspelmath-1997]
 
-Mandarin indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+Mandarin indefinite polarity items, typed by `Semantics.Polarity.Item`.
+The system has three layers: the bare interrogatives (*shéi* 谁 'who',
+*shénme* 什么 'what') serve as indefinites in all non-specific
+non-emphatic functions — seven of the nine implicational-map functions,
+irrealis through free choice; the emphatic wh + *dōu*~*yě* series
+('even, also; every, all') is interchangeable between the two particles,
+restricted to the direct-negation function, and preverbal only; and the
+free-choice determiner *rènhé* 任何 'any' occurs mainly with *dōu*.
 
-Mandarin wh-words (*shéi* 谁, *shénme* 什么) double as indefinites in
-non-interrogative uses, covering an exceptionally wide range on
-[haspelmath-1997]'s map (7 of 9 functions):
-- **shéi** (non-interrogative): NPI/FCI — questions through free choice
+Per-item asymmetries are encoded per entry: under direct negation only
+*shénme* is perfect while bare *shéi* is degraded, and the survey
+reports no indirect-negation data for the bare interrogatives, so no
+entry lists those contexts.
+
+## References
+
+* [haspelmath-1997], §A.36, Fig. A.36
+* [li-1992]
+* [li-thompson-1981], pp. 528–530
 -/
 
 namespace Mandarin.PolarityItems
 
 open Semantics.Polarity
 
-/-! ### NPI/FCI -/
+/-! ### Bare interrogatives -/
 
-/-- *shéi* (谁, non-interrogative) — NPI/FCI.
-    Wh-word as indefinite covers 7 Haspelmath functions: irrealis through
-    free choice. Functions as both NPI (under negation, in questions) and
-    FCI (in modal/generic contexts). -/
+/-- *shéi* (谁 'who', non-interrogative) — NPI/FCI. The bare
+    interrogatives cover the seven non-specific map functions
+    ([haspelmath-1997] A.36.3, Fig. A.36); *shéi* is attested in questions
+    (A266) and the free-choice span, but direct negation is omitted:
+    *?Tā bù xǐhuan shéi* is degraded where *shénme* is perfect (A267,
+    [li-1992] p. 150) — that slot belongs to the emphatic series. -/
 def shei : Item :=
   { form := "shéi (谁, non-interrog.)"
   , licensor := some .weak
   , freeChoice := true
   , baseForce := .existential
   , licensingContexts :=
-      [ .negation, .nobody, .question, .conditionalAntecedent
-      , .modalPossibility, .modalNecessity, .imperative, .generic
-      , .comparativeS ]
+      [ .question, .conditionalAntecedent, .comparativeS
+      , .modalPossibility, .modalNecessity, .imperative, .generic ]
+  , scalarDirection := .strengthening }
+
+/-- *shénme* (什么 'what', non-interrogative) — NPI/FCI, the same
+    seven-function span plus perfect direct negation: *Tā bù xǐhuan
+    shénme* 'He does not like anything' (A267); irrealis imperative *Chī
+    diǎn shénme zài zǒu ba!* 'Please eat a little something before you
+    leave' (A264, [li-1992] p. 152); conditional (A266). -/
+def shenme : Item :=
+  { form := "shénme (什么, non-interrog.)"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts :=
+      [ .negation, .question, .conditionalAntecedent, .comparativeS
+      , .modalPossibility, .modalNecessity, .imperative, .generic ]
+  , scalarDirection := .strengthening }
+
+/-! ### The emphatic dōu~yě series -/
+
+/-- *shéi dōu* ~ *shéi yě* (谁都/谁也, with clausemate negation) — the
+    emphatic wh + *dōu*~*yě* series: *Tā shéi-dōu bù xìnren* 'She
+    doesn't trust anyone' ([li-thompson-1981] p. 528). The two particles
+    are interchangeable in the direct-negation function, the series' only
+    region on the map, and occur preverbally only ([haspelmath-1997]
+    A269, Fig. A.36). `baseForce` is universal: the same formation
+    without negation is 'everyone', and [haspelmath-1997] (p. 309) leaves
+    open whether the negated uses are indefinites or wide-scope
+    universals. -/
+def sheiDou : Item :=
+  { form := "shéi dōu/yě (谁都/谁也, neg)"
+  , licensor := some .antiMorphic
+  , baseForce := .universal
+  , licensingContexts := [.negation]
+  , scalarDirection := .strengthening
+  , morphology := .indefPlusEven }
+
+/-! ### The free-choice determiner -/
+
+/-- *rènhé* (任何 'any') — free-choice determiner, mainly with the adverb
+    *dōu*: free choice under modals (*Rènhé shíhou nǐ dōu kěyǐ lái* 'You
+    can come anytime', A270), comparatives (A271, a *bǐ* NP-comparative,
+    listed under `comparativeS` per the covert-clausal routing convention
+    of `Features.LicensingContext`), and direct negation (A272); the
+    superordinate-negation use (A273) has no matching context row.
+    Etymologically *rèn* 'allow; appoint' + old interrogative *hé* 'what'
+    ([haspelmath-1997] A.36.2). -/
+def renhe : Item :=
+  { form := "rènhé (任何)"
+  , licensor := some .weak
+  , freeChoice := true
+  , baseForce := .existential
+  , licensingContexts := [.negation, .modalPossibility, .comparativeS]
   , scalarDirection := .strengthening }
 
 /-! ### Verification -/
 
-/-- Every attested context is predicted licensed. -/
-theorem shei_licensing_sound :
-    ∀ c ∈ shei.licensingContexts, c.licenses shei := by decide
+/-- Every attested context of every entry is predicted licensed. -/
+theorem mandarin_licensing_sound :
+    ∀ e ∈ [shei, shenme, sheiDou, renhe], ∀ c ∈ e.licensingContexts,
+      c.licenses e := by decide
+
+/-- The licensing keystone characterizes the emphatic series exactly: its
+    anti-morphic licensor makes clausal negation the only licensing row,
+    matching its direct-negation-only distribution. -/
+theorem sheiDou_licensing_characterized :
+    ∀ c, c.licenses sheiDou ↔ c ∈ sheiDou.licensingContexts := by decide
+
+/-- Direct negation is attested with *shénme* but not with bare *shéi*,
+    whose direct-negation slot the emphatic series fills instead. -/
+theorem direct_negation_asymmetry :
+    .negation ∈ shenme.licensingContexts ∧
+      .negation ∉ shei.licensingContexts ∧
+      .negation ∈ sheiDou.licensingContexts := by decide
 
 end Mandarin.PolarityItems

--- a/Linglib/Studies/Haspelmath1997.lean
+++ b/Linglib/Studies/Haspelmath1997.lean
@@ -41,9 +41,9 @@ geometry of `Indefinite.HaspelmathFunction.adjacent`). Two samples:
   with contiguity, coverage, and overlap theorems, and decide-checks
   connecting the paradigms to `Fragments/{Lang}/PolarityItems.lean`.
 
-The German, Hungarian, Japanese, Korean, and Quechua (Ancash) paradigms
-are verified against the book (appendix A.1, A.26, A.37–A.39; Table 4.1);
-the rest are hand-stipulated pending the same pass. English in particular
+The German, Hungarian, Japanese, Korean, Mandarin, and Quechua (Ancash)
+paradigms are verified against the book (appendix A.1, A.26, A.36–A.39;
+Table 4.1); the rest are hand-stipulated pending the same pass. English in particular
 follows a narrower polarity-view allocation than both the book's coding
 (Table 4.1: *some-* 12345, *any-* 456789) and the
 [degano-aloni-2025]-shaped `Fragments/English/Indefinites.lean`; the
@@ -53,12 +53,13 @@ competition).
 
 ## Main results
 
-* `english_matches_wals_F46A` … `kannada_matches_wals_F46A` —
-  Fragment-derived F46A classifications agree with WALS.
+* `english_matches_wals_F46A` … `kannada_matches_wals_F46A`,
+  `mandarin_matches_wals_F46A` — F46A classifications (Fragment-derived,
+  plus the stipulated Mandarin paradigm) agree with WALS.
 * `all_languages_contiguous`, `all_languages_cover_all_functions` — the
   map hypothesis and full coverage on the 17-language sample.
-* `russian_not_disjoint`, `german_not_disjoint`, `hungarian_not_disjoint`
-  — series overlap is attested and normal (p. 76).
+* `russian_not_disjoint`, `german_not_disjoint`, `hungarian_not_disjoint`,
+  `mandarin_not_disjoint` — series overlap is attested and normal (p. 76).
 * `freeChoice_multifunction_implies_comparative`,
   `japanese_comparative_patterns_with_negation` — free choice's only map
   neighbour is the comparative, which may instead pattern with negation.
@@ -238,21 +239,38 @@ def japanese : IndefiniteParadigm :=
         basis := .interrogative,
         functions := {.freeChoice} } ] }
 
-/-- Mandarin: 2 series, mixed bases (*yǒu rén* existential, *shéi*
-    interrogative). -/
+/-- Mandarin: the four regions of Fig. A.36 (A.36.1): generic nouns
+    (*rén* 'person', typically in the existential frame *yǒu rén*) for
+    the specific functions, bare interrogatives "in all non-specific
+    non-emphatic functions", the emphatic *dōu*~*yě* series on direct
+    negation, and the free-choice determiner *rènhé*. -/
 def mandarin : IndefiniteParadigm :=
   { language := "Mandarin Chinese"
   , isoCode := "cmn"
   , forms :=
-    [ { form := "yǒu rén (有人)",
+    [ { form := "rén (人, generic noun: yǒu rén)",
         ontology := .person,
-        basis := .existentialConstruction,
+        basis := .genericNoun,
         functions := {.specificKnown, .specificUnknown} }
     , { form := "shéi (谁, non-interrog.)",
         ontology := .person,
         basis := .interrogative,
         functions := {.irrealis, .question, .conditional, .indirectNeg,
-                      .directNeg, .comparative, .freeChoice} } ] }
+                      .directNeg, .comparative, .freeChoice} }
+    , { form := "shéi dōu/yě (谁都/谁也)",
+        ontology := .person,
+        basis := .interrogative,
+        functions := {.directNeg} }
+    , { form := "rènhé (任何)",
+        ontology := .determiner,
+        basis := .special,
+        functions := {.comparative, .freeChoice} } ] }
+
+/-- Mandarin's generic-noun, interrogative, and special bases derive
+    `.mixed`, matching WALS for iso "cmn". -/
+theorem mandarin_matches_wals_F46A :
+    mandarin.toWALS46A =
+      (Datapoint.lookupISO F46A.allData "cmn").map (·.value) := by decide
 
 /-- Turkish: 5 generic-noun-based series (*bir-* 'one'). -/
 def turkish : IndefiniteParadigm :=
@@ -528,6 +546,10 @@ theorem german_not_disjoint : ¬ german.FormsDisjoint := by decide
     question and conditional (A.26). -/
 theorem hungarian_not_disjoint : ¬ hungarian.FormsDisjoint := by decide
 
+/-- Mandarin fails `FormsDisjoint` maximally: the bare-interrogative span
+    contains both emphatic series' regions outright (Fig. A.36). -/
+theorem mandarin_not_disjoint : ¬ mandarin.FormsDisjoint := by decide
+
 /-! ### Typological generalizations -/
 
 /-- A form covering free choice plus anything else covers the comparative —
@@ -579,7 +601,7 @@ theorem bridges_negation :
     ∀ e ∈ [Italian.PolarityItems.nessuno, Russian.PolarityItems.nikto,
            Japanese.PolarityItems.dareMo, Korean.PolarityItems.nwukwuTo,
            Hungarian.PolarityItems.senki, Georgian.PolarityItems.aravin,
-           Quechua.PolarityItems.piPis],
+           Quechua.PolarityItems.piPis, Mandarin.PolarityItems.sheiDou],
       .negation ∈ e.licensingContexts := by decide
 
 /-- Every question-span form's Fragment counterpart is licensed in


### PR DESCRIPTION
Random-file deep audit of `Fragments/Mandarin/PolarityItems.lean`, verified against Haspelmath (1997) §A.36 (Fig. A.36, examples A264–A273).

- Fragment: adds the *shénme*, *shéi dōu/yě*, and *rènhé* entries; drops the unattested `.nobody` context and moves direct negation from *shéi* (degraded, Li 1992: 150) to *shénme*; module docstring in mathlib register with a References section.
- Study: Mandarin paradigm expanded to the four regions of Fig. A.36 (generic noun, bare QU, *dōu*~*yě*, *rènhé*) and marked book-verified; new `mandarin_matches_wals_F46A` and `mandarin_not_disjoint`; `bridges_negation` gains *shéi dōu/yě*.