### PR TITLE
refactor(Semantics/Polarity): bare Polarity namespace + dot API

### DIFF
--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -121,8 +121,8 @@ def HaspelmathFunction.isFC : HaspelmathFunction → Bool
     irrealis uses of non-polarity indefinites; both comparative rows realize
     the standard-of-comparison function regardless of NPI-licensability
     (`comparativeNP` licenses no NPIs, [hoeksema-1983]). -/
-def _root_.Features.LicensingContext.haspelmathFunction :
-    Features.LicensingContext → Option HaspelmathFunction
+def _root_.Polarity.LicensingContext.haspelmathFunction :
+    Polarity.LicensingContext → Option HaspelmathFunction
   | .negation => some .directNeg
   | .withoutClause | .doubtVerb | .denyVerb => some .indirectNeg
   | .question => some .question
@@ -133,13 +133,13 @@ def _root_.Features.LicensingContext.haspelmathFunction :
   | _ => none
 
 /-- The licensing environments realizing a map function — the preimage of
-    `Features.LicensingContext.haspelmathFunction`. Empty for the specificity
+    `Polarity.LicensingContext.haspelmathFunction`. Empty for the specificity
     triangle (`specificKnown`, `specificUnknown`, `irrealis`), whose
     realizations are positive or irrealis clauses outside the
     licensing-context inventory (matching the Fragment convention that an
     empty `licensingContexts` list means the item needs positive contexts). -/
 def HaspelmathFunction.contexts (f : HaspelmathFunction) :
-    Finset Features.LicensingContext :=
+    Finset Polarity.LicensingContext :=
   Finset.univ.filter (·.haspelmathFunction = some f)
 
 /-- BFS on the implicational map restricted to a given set of functions.

--- a/Linglib/Features/LicensingContext.lean
+++ b/Linglib/Features/LicensingContext.lean
@@ -1,7 +1,7 @@
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Features.LicensingContext
+# Licensing contexts
 [ladusaw-1979] [kadmon-landman-1993]
 
 The 22-case enum of licensing contexts for polarity-sensitive items.
@@ -15,7 +15,7 @@ to talk about these context labels.
 Extracted from `Semantics/Polarity/Licensing.lean` after
 audit consensus that `LicensingContext` is data, not theory: the
 22 cases are observational labels for syntactic environments, while
-only the *signatures* assigned to them in `contextProperties`
+only the *signatures* assigned to them in `LicensingContext.properties`
 (in the Theories file) carry theoretical commitment. Co-locating the
 enum here makes it Fragment-importable substrate without dragging in
 the Ladusaw/K&L theoretical apparatus.
@@ -35,7 +35,7 @@ specific traditions' classification of contexts), but the cases
 themselves enumerate empirically-attested licensing environments any
 framework needs to talk about. The DE/anti-additive/anti-morphic
 *labelling* of these contexts is theory-laden and lives in
-`Semantics/Polarity/Licensing.lean::contextProperties`
+`LicensingContext.properties` (in `Semantics/Polarity/Licensing.lean`)
 (Ladusaw/Zwarts canonical) — not here.
 
 UNVERIFIED: The 22-case carve-up is English-anchored and may need
@@ -45,7 +45,7 @@ per Giannakidou 1998, rather than by surface construction); see the
 for the documented gap.
 -/
 
-namespace Features
+namespace Polarity
 
 /-- Contexts that can license polarity-sensitive items.
 
@@ -56,7 +56,7 @@ namespace Features
 
     Per-context theoretical classifications (DE strength, K&L mechanism,
     Strawson-DE flagging) live in
-    `Semantics/Polarity/Licensing.lean::contextProperties`. -/
+    `LicensingContext.properties` (in `Semantics/Polarity/Licensing.lean`). -/
 inductive LicensingContext where
   | negation          -- "not", "never", "without"
   | nobody            -- "nobody", "nothing" (negative quantifiers)
@@ -88,4 +88,4 @@ inductive LicensingContext where
   | denyVerb          -- Anti-additive attitude verbs: "She denied seeing anyone"
   deriving DecidableEq, Fintype, Repr
 
-end Features
+end Polarity

--- a/Linglib/Features/NegativeConcord.lean
+++ b/Linglib/Features/NegativeConcord.lean
@@ -30,7 +30,7 @@ namespace Features.NegativeConcord
     NPI licensed by a null negation); this enum records only the distributional class,
     which [van-der-auwera-van-alsenoy-2016] take as the basis of the NC typology.
     Lets a strict-NC n-word (Russian никто, Italian *nessuno*) be classified honestly
-    rather than borrowing a strong-NPI slot in `Semantics.Polarity`. -/
+    rather than borrowing a strong-NPI slot in `Polarity`. -/
 inductive NWordStatus where
   /-- N-word: occurs in negative-concord structures (Romance *nessuno*, Slavic никто,
       Greek *típota*, Hungarian *semmi*); licenses a negative fragment answer ("Nothing.")

--- a/Linglib/Fragments/Dutch/Particles.lean
+++ b/Linglib/Fragments/Dutch/Particles.lean
@@ -15,7 +15,7 @@ finite verb.
 
 namespace Dutch.Particles
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- *wel* — Dutch affirmative polarity particle.
     Sentence-internal, accented, available in both contrast and correction.

--- a/Linglib/Fragments/English/PolarityItems.lean
+++ b/Linglib/Fragments/English/PolarityItems.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Polarity.Licensing
 /-!
 # English Polarity-Sensitive Items
 
-English polarity items, typed by `Semantics.Polarity.Item`: weak NPIs
+English polarity items, typed by `Polarity.Item`: weak NPIs
 (*any*, *ever*, *at all*), strong NPIs (*lift a finger*, *in years*,
 *either*), free-relative FCIs (*whatever*, *whoever*), maximizer NPIs
 (*wild horses*, *all the tea in China*), and PPIs both plain (*some*,
@@ -22,7 +22,7 @@ in `Studies/Israel2001.lean` as `ScalarItem`s over these entries.
 
 namespace English.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### Weak NPIs -/
 

--- a/Linglib/Fragments/English/PolarityMarking.lean
+++ b/Linglib/Fragments/English/PolarityMarking.lean
@@ -35,7 +35,7 @@ German Verum focus.
 
 namespace English.PolarityMarking
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- Emphatic *do* (Verum-focus use) — English polarity-marking strategy.
     Pitch accent on auxiliary *do* in an affirmative sentence contradicting

--- a/Linglib/Fragments/English/TemporalExpressions.lean
+++ b/Linglib/Fragments/English/TemporalExpressions.lean
@@ -34,7 +34,7 @@ namespace English.TemporalExpressions
 
 open Features
 open Tense.TemporalAdverbials (AdverbialType)
-open Semantics.Polarity
+open Polarity
 
 -- ============================================================================
 -- § 1: Shared Types

--- a/Linglib/Fragments/Finnish/PolarityItems.lean
+++ b/Linglib/Fragments/Finnish/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997], [karlsson-2017]
 
 Finnish indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 Unlike Russian *nikto*, Italian *nessuno*, German *niemand*, or Hungarian
 *senki* — all single-word negative quantifiers ("n-words") that have their own
@@ -23,7 +23,7 @@ combination, not a single lexical entry.
 
 namespace Finnish.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPI -/
 

--- a/Linglib/Fragments/Georgian/PolarityItems.lean
+++ b/Linglib/Fragments/Georgian/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997]
 
 Georgian indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 - **aravin** (არავინ): Negative indefinite (ara- NEG prefix + vin 'who')
 - **nebismieri** (ნებისმიერი): Free choice item
@@ -20,7 +20,7 @@ preverbal neg-words). Mood-conditioned variants: vera-vin (modal), nura-vin
 
 namespace Georgian.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPI -/
 

--- a/Linglib/Fragments/German/PolarityItems.lean
+++ b/Linglib/Fragments/German/PolarityItems.lean
@@ -14,7 +14,7 @@ neither has an entry here.
 
 namespace German.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *irgendein/irgendwer* — [chierchia-2006]'s EFCI class: existential FCI
     with NPI uses (questions, conditionals) and FCI uses (modals,

--- a/Linglib/Fragments/German/PolarityMarking.lean
+++ b/Linglib/Fragments/German/PolarityMarking.lean
@@ -26,7 +26,7 @@ German's strategy is non-particulate.
 
 namespace German.PolarityMarking
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- Verum focus — pitch accent on the finite verb.
     Dominant strategy in German for neg→affirm switches in both contexts.

--- a/Linglib/Fragments/Hindi/PolarityItems.lean
+++ b/Linglib/Fragments/Hindi/PolarityItems.lean
@@ -16,7 +16,7 @@ indefinite + negation route. Attested contexts follow [lahiri-1998]
 
 namespace Hindi.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *koii nahiiN* — negative indefinite, koii + negation:
 'koii nahiiN aayaa' (nobody came). -/

--- a/Linglib/Fragments/Hungarian/PolarityItems.lean
+++ b/Linglib/Fragments/Hungarian/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997]
 
 Hungarian indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 - **senki**: N-word, negative concord (with *sem* in direct negation)
 - **akárki / bárki**: Free choice items
@@ -13,7 +13,7 @@ Hungarian indefinite pronoun polarity items, typed by the categories from
 
 namespace Hungarian.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPI -/
 

--- a/Linglib/Fragments/Italian/PolarityItems.lean
+++ b/Linglib/Fragments/Italian/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [chierchia-2006] [chierchia-2013]
 
 Lexical entries for Italian PSIs, typed by the theory-neutral categories
-from `Semantics.Polarity`.
+from `Polarity`.
 
 ## The Italian PSI system
 
@@ -17,7 +17,7 @@ Italian lexicalizes the NPI/FCI distinction that English *any* collapses:
 
 namespace Italian.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### Pure NPIs -/
 

--- a/Linglib/Fragments/Italian/PolarityMarking.lean
+++ b/Linglib/Fragments/Italian/PolarityMarking.lean
@@ -67,7 +67,7 @@ the strategy taxonomy, and the explicit endorsement of Matić & Nikolaeva's
 
 namespace Italian.PolarityMarking
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- *sì che* — Italian polarity-reversing affirmative construction.
     Cleft-like or left-peripheral PolP structure (analyses contested):

--- a/Linglib/Fragments/Japanese/PolarityItems.lean
+++ b/Linglib/Fragments/Japanese/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997] [kratzer-shimoyama-2002] [shimoyama-2011] [watanabe-2004]
 
 Japanese indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 Japanese builds polarity items from wh-indeterminates + particles
 ([kratzer-shimoyama-2002]):
@@ -15,7 +15,7 @@ Japanese builds polarity items from wh-indeterminates + particles
 
 namespace Japanese.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPI -/
 

--- a/Linglib/Fragments/Korean/PolarityItems.lean
+++ b/Linglib/Fragments/Korean/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997]
 
 Korean indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 Korean, like Japanese, builds polarity items from wh-words + particles:
 - **nwukwu** (bare): Weak NPI in non-interrogative uses
@@ -15,7 +15,7 @@ Korean, like Japanese, builds polarity items from wh-words + particles:
 
 namespace Korean.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPIs -/
 

--- a/Linglib/Fragments/Mandarin/PolarityItems.lean
+++ b/Linglib/Fragments/Mandarin/PolarityItems.lean
@@ -3,7 +3,7 @@ import Linglib.Semantics.Polarity.Licensing
 /-!
 # Mandarin Polarity-Sensitive Items
 
-Mandarin indefinite polarity items, typed by `Semantics.Polarity.Item`.
+Mandarin indefinite polarity items, typed by `Polarity.Item`.
 The system has three layers: the bare interrogatives (*shéi* 谁 'who',
 *shénme* 什么 'what') serve as indefinites in all non-specific
 non-emphatic functions — seven of the nine implicational-map functions,
@@ -26,7 +26,7 @@ entry lists those contexts.
 
 namespace Mandarin.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### Bare interrogatives -/
 
@@ -86,7 +86,7 @@ def sheiDou : Item :=
     *dōu*: free choice under modals (*Rènhé shíhou nǐ dōu kěyǐ lái* 'You
     can come anytime', A270), comparatives (A271, a *bǐ* NP-comparative,
     listed under `comparativeS` per the covert-clausal routing convention
-    of `Features.LicensingContext`), and direct negation (A272); the
+    of `Polarity.LicensingContext`), and direct negation (A272); the
     superordinate-negation use (A273) has no matching context row.
     Etymologically *rèn* 'allow; appoint' + old interrogative *hé* 'what'
     ([haspelmath-1997] A.36.2). -/

--- a/Linglib/Fragments/Quechua/PolarityItems.lean
+++ b/Linglib/Fragments/Quechua/PolarityItems.lean
@@ -14,7 +14,7 @@ choice (A278). A dual NPI/FCI on the indefinite-plus-even pattern of
 
 namespace Quechua.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *pi-pis* — wh + 'also/even': dual NPI/FCI covering the map's whole
     non-specific span (A.37). -/

--- a/Linglib/Fragments/Romance/French/PolarityItems.lean
+++ b/Linglib/Fragments/Romance/French/PolarityItems.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Polarity.Licensing
 
 Lexical entries for French polarity-sensitive items (n-word series and
 related), typed by the theory-neutral categories from
-`Semantics.Polarity`. Standard sentential negation lives in the
+`Polarity`. Standard sentential negation lives in the
 sibling `Fragments/French/Negation.lean`; this file holds only the
 lexical reactives (operator/lexical-reactive split documented in
 `Core/Lexical/NegMarker.lean`).
@@ -31,7 +31,7 @@ bipartite *ne* dependency would live in the substrate, not per-Fragment.
 
 namespace French.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *personne* — N-word for human ('nobody').
     Grammaticalized from the noun 'person'. Co-occurs with *ne* in

--- a/Linglib/Fragments/Romance/French/PolarityMarking.lean
+++ b/Linglib/Fragments/Romance/French/PolarityMarking.lean
@@ -33,7 +33,7 @@ affirmative particles like Dutch *wel* and from Verum focus.
 
 namespace French.PolarityMarking
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- *si* — French polarity-reversing affirmative particle.
     Assigns [+Pol] while contradicting a negative assertion or question.

--- a/Linglib/Fragments/Slavic/Czech/PolarityItems.lean
+++ b/Linglib/Fragments/Slavic/Czech/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997]
 
 Lexical entries for Czech n-words (the *ni-* series), typed by the
-theory-neutral categories from `Semantics.Polarity`. Standard
+theory-neutral categories from `Polarity`. Standard
 sentential negation (the *ne-* prefix) lives in the sibling
 `Fragments/Czech/Negation.lean`; this file holds only the lexical
 reactives (operator/lexical-reactive split documented in
@@ -22,7 +22,7 @@ Spanish position-dependent NC.
 
 namespace Czech.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *nikdo* — N-word for human ('nobody').
     Strict NC: requires the *ne-* prefix on the verb regardless of

--- a/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
+++ b/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997] [zeijlstra-2004] [giannakidou-1998]
 
 Russian indefinite-pronoun polarity items, typed by the theory-neutral
-categories from `Semantics.Polarity`. The classification follows
+categories from `Polarity`. The classification follows
 [haspelmath-1997]'s implicational map for the Russian series: the
 *-либо* series spans the weak-NPI functions (irrealis non-specific,
 question, conditional, comparative, indirect negation), while the *ни-*
@@ -27,7 +27,7 @@ characterized exactly by the licensing keystone
 
 namespace Russian.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### Weak NPI (the *-либо* series) -/
 

--- a/Linglib/Fragments/Spanish/PolarityItems.lean
+++ b/Linglib/Fragments/Spanish/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Item
 [haspelmath-1997] [zanuttini-1997]
 
 Lexical entries for Spanish polarity-sensitive items (n-word series),
-typed by the theory-neutral categories from `Semantics.Polarity`.
+typed by the theory-neutral categories from `Polarity`.
 Standard sentential negation (the *no* marker) lives in the sibling
 `Fragments/Spanish/Negation.lean`; this file holds only the lexical
 reactives (operator/lexical-reactive split documented in
@@ -24,7 +24,7 @@ lexical-feature distinction across n-words.
 
 namespace Spanish.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-- *nadie* — N-word for human ('nobody').
     Preverbal alone: *Nadie vino*. Postverbal with *no*: *No vino nadie*. -/

--- a/Linglib/Fragments/Spanish/PolarityMarking.lean
+++ b/Linglib/Fragments/Spanish/PolarityMarking.lean
@@ -38,7 +38,7 @@ clause-initial and targets polarity directly via a dedicated particle.
 
 namespace Spanish.PolarityMarking
 
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 
 /-- *sí (que)* — Spanish emphatic polarity affirmation particle.
     Clause-initial EPPA. [batllori-hernanz-2013]: merges with

--- a/Linglib/Fragments/Swedish/AnswerParticles.lean
+++ b/Linglib/Fragments/Swedish/AnswerParticles.lean
@@ -27,7 +27,7 @@ Swedish also allows verb-echo answers alongside particles (mixed strategy).
 namespace Swedish.AnswerParticles
 
 open Features.Polarity
-open Semantics.Polarity.Marking (Entry Strategy Env)
+open Polarity.Marking (Entry Strategy Env)
 open Features (AnsweringSystem AnswerStrategy PolarAnswerProfile)
 
 /-- *ja* — standard affirmative. Assigns [+Pol]. Responds only to

--- a/Linglib/Fragments/Turkish/PolarityItems.lean
+++ b/Linglib/Fragments/Turkish/PolarityItems.lean
@@ -5,7 +5,7 @@ import Linglib.Semantics.Polarity.Licensing
 [haspelmath-1997]
 
 Turkish indefinite pronoun polarity items, typed by the categories from
-`Semantics.Polarity`.
+`Polarity`.
 
 - **kimse**: Weak NPI (questions, conditionals, indirect negation)
 - **hiç kimse**: Emphatic negative indefinite (direct negation)
@@ -14,7 +14,7 @@ Turkish indefinite pronoun polarity items, typed by the categories from
 
 namespace Turkish.PolarityItems
 
-open Semantics.Polarity
+open Polarity
 
 /-! ### NPIs -/
 

--- a/Linglib/Fragments/Turkish/QuestionParticles.lean
+++ b/Linglib/Fragments/Turkish/QuestionParticles.lean
@@ -13,7 +13,7 @@ study files that actually adopt the relevant theory (e.g.,
 [fox-katzir-2011]-style category match needs a UPOS tagging;
 [laka-1990]-style PolP needs a head label).
 
-The semantic operator is `Semantics.Polarity.affirm` (identity), reflecting
+The semantic operator is `Polarity.affirm` (identity), reflecting
 the consensus that *mI* is propositionally vacuous and contributes only
 question force / focus marking — a claim that is theory-neutral up to the
 choice of denotation type for propositions.
@@ -21,7 +21,7 @@ choice of denotation type for propositions.
 
 namespace Turkish.QuestionParticles
 
-open Semantics.Polarity
+open Polarity
 
 /-- A Turkish question particle: form, vowel-harmony allomorphs, and the
     bare semantic operator it contributes. No syntactic categorization. -/

--- a/Linglib/Semantics/Entailment/StrawsonSoundness.lean
+++ b/Linglib/Semantics/Entailment/StrawsonSoundness.lean
@@ -17,7 +17,7 @@ definedness (`EntailmentSig.SoundFor.strawsonSoundFor`).
 
 The operator instances are the semantic content of the
 `classicalSignature = none` rows of
-`Semantics.Polarity.Licensing.contextProperties`: `onlyFull`,
+`Polarity.LicensingContext.properties`: `onlyFull`,
 `sorryFull`, `superlativeAssert`, and `sinceFull` realize the `.anti` row
 Strawson-ly while failing it classically.
 

--- a/Linglib/Semantics/Polarity/Item.lean
+++ b/Linglib/Semantics/Polarity/Item.lean
@@ -40,9 +40,7 @@ items that have one.
 * `NPIMorphology`, `AlternativeType` — composition typology.
 -/
 
-namespace Semantics.Polarity
-
-open Features (LicensingContext)
+namespace Polarity
 
 /-! ### Scalar direction -/
 
@@ -137,10 +135,4 @@ abbrev Item.isFCI (e : Item) : Prop := e.freeChoice = true
 /-- A positive polarity item. -/
 abbrev Item.isPPI (e : Item) : Prop := e.ppi = true
 
-end Semantics.Polarity
-
--- Re-export `LicensingContext` from `Features/` into `Semantics.Polarity` so
--- consumers doing `open Semantics.Polarity` see its constructors in scope.
-namespace Semantics.Polarity
-export Features (LicensingContext)
-end Semantics.Polarity
+end Polarity

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -15,7 +15,7 @@ import Linglib.Semantics.Polarity.Item
 [iatridou-2000] [dayal-1996] [horn-1996] [vanderwouden-1997]
 
 The monotonicity-based licensing theory for `Polarity.Item`:
-`contextProperties` assigns every `LicensingContext` its Strawson and
+`LicensingContext.properties` assigns every `LicensingContext` its Strawson and
 classical entailment signatures, its [kadmon-landman-1993] licensing
 mechanism, and its citation lineage; `StrengthScale` is the polymorphic
 item↔context strength pattern with `zwartsScale` as its canonical
@@ -23,18 +23,19 @@ instance; and the keystone `LicensingContext.licenses` dispatches on the
 row's mechanism — Zwarts strength on signature rows, free choice on
 generic-indefinite rows ([dayal-1996]), entropy on questions
 ([van-rooy-2003-npi]). Per-paper classifiers (`Ladusaw1979`,
-`KadmonLandman1993`) project from `contextProperties` rather than
+`KadmonLandman1993`) project from `LicensingContext.properties` rather than
 parallel-stipulating; the grounded grade — deriving the signatures from
 the model witnesses of `Witnesses.lean` via the Kadmon–Landman
 strengthening chain — is the planned next step.
 
 ## Main declarations
 
-* `LicensingMechanism`, `ContextProperties`, `contextProperties` — the
+* `LicensingMechanism`, `ContextProperties`, `LicensingContext.properties` — the
   per-context theory table.
 * `StrengthScale`, `zwartsScale` — polymorphic strength licensing.
 * `LicensingContext.licenses` — the item↔context licensing keystone.
-* `IsStrawsonOnly` and the Haspelmath-map grounding theorems.
+* `LicensingContext.IsStrawsonOnly` and the Haspelmath-map grounding
+  theorems.
 
 ## Implementation notes
 
@@ -48,9 +49,7 @@ contested attribution (Zwarts 1981 / van Benthem 1986 / Sánchez Valencia
 1991; none in `references.bib`).
 -/
 
-namespace Semantics.Polarity.Licensing
-
-open Features (LicensingContext)
+namespace Polarity
 
 /-! ### Licensing Mechanism (refined 5-way) -/
 
@@ -87,7 +86,7 @@ inductive LicensingMechanism where
     Every classification of `LicensingContext` (DE strength, K&L mechanism,
     canonical example, citation lineage) projects out of this single record.
     Per-paper classifiers (`Ladusaw1979.licensingStrength`,
-    `KadmonLandman1993.klExplanation`) are derivations from `contextProperties`,
+    `KadmonLandman1993.klExplanation`) are derivations from `LicensingContext.properties`,
     not parallel stipulations. -/
 structure ContextProperties where
   /-- Icard signature modulo presuppositions ([von-fintel-1999]'s
@@ -118,7 +117,7 @@ structure ContextProperties where
     none currently in `references.bib`. The substrate uses the standard
     `.antiAdd` signature for `.universalRestrictor` without committing
     to a specific source. -/
-def contextProperties : LicensingContext → ContextProperties
+def LicensingContext.properties : LicensingContext → ContextProperties
   | .negation =>
       { strawsonSignature := .antiAddMult, mechanism := .byStrengthening
       , prototype := "Mary didn't see anyone."
@@ -234,31 +233,30 @@ instantiate different carriers. -/
 /-- A **strength scale** for NPI licensing: how items and contexts project onto
 an ordered strength carrier `S`. `none` on either side = "no strength here" (the
 item licenses via another mechanism, or the context supplies none). -/
-structure StrengthScale (Item Context S : Type*) [Preorder S] where
+structure StrengthScale (α β S : Type*) [Preorder S] where
   /-- The strength an item requires (`none` = not strength-licensed). -/
-  required : Item → Option S
+  required : α → Option S
   /-- The strength a context supplies (`none` = supplies no strength). -/
-  supplied : Context → Option S
+  supplied : β → Option S
 
 /-- Licensing on a scale: the context supplies at least the strength the item
 requires (both sides present). -/
-def StrengthScale.licenses {Item Context S : Type*} [Preorder S]
-    (L : StrengthScale Item Context S) (i : Item) (c : Context) : Prop :=
+def StrengthScale.licenses {α β S : Type*} [Preorder S]
+    (L : StrengthScale α β S) (i : α) (c : β) : Prop :=
   ∃ r ∈ L.required i, ∃ s ∈ L.supplied c, r ≤ s
 
-instance {Item Context S : Type*} [Preorder S]
-    [DecidableRel (α := S) (· ≤ ·)] (L : StrengthScale Item Context S)
-    (i : Item) (c : Context) : Decidable (L.licenses i c) := by
+instance {α β S : Type*} [Preorder S]
+    [DecidableRel (α := S) (· ≤ ·)] (L : StrengthScale α β S)
+    (i : α) (c : β) : Decidable (L.licenses i c) := by
   unfold StrengthScale.licenses; infer_instance
 
 /-- The canonical Zwarts scale ([ladusaw-1979], [zwarts-1998],
 [gajewski-2011]): carrier `DEStrength`, item strength from `Item.licensor`,
 context strength from the row's Strawson signature. -/
 def zwartsScale :
-    StrengthScale Semantics.Polarity.Item LicensingContext
-      NaturalLogic.DEStrength where
+    StrengthScale Item LicensingContext NaturalLogic.DEStrength where
   required e := e.licensor
-  supplied c := (contextProperties c).strawsonSignature.toDEStrength
+  supplied c := c.properties.strawsonSignature.toDEStrength
 
 /-! ### The licensing keystone -/
 
@@ -277,24 +275,23 @@ Dispatched on the row's `LicensingMechanism`:
 The grounded grade — deriving the signature side from the context
 witnesses of `Witnesses.lean` via the Kadmon–Landman strengthening
 chain — is planned (N1 of the NPI-API sweep). -/
-def _root_.Features.LicensingContext.licenses (c : LicensingContext)
-    (e : Semantics.Polarity.Item) : Prop :=
-  match (contextProperties c).mechanism with
+def LicensingContext.licenses (c : LicensingContext) (e : Item) : Prop :=
+  match c.properties.mechanism with
   | .byStrengthening | .byStrawsonDE => zwartsScale.licenses e c
   | .byGenericIndefinite => e.isFCI
   | .byEntropy => e.licensor = some .weak
   | .strengtheningFails => False
 
-instance (c : LicensingContext) (e : Semantics.Polarity.Item) :
+instance (c : LicensingContext) (e : Item) :
     Decidable (c.licenses e) := by
-  unfold Features.LicensingContext.licenses; split <;> infer_instance
+  unfold LicensingContext.licenses; split <;> infer_instance
 
 /-! ### The Haspelmath map meets the licensing table
 
-`Features.LicensingContext.haspelmathFunction` (in `Features/Indefinite.lean`)
+`Polarity.LicensingContext.haspelmathFunction` (in `Features/Indefinite.lean`)
 classifies each licensing environment by the [haspelmath-1997] map function it
 realizes. The theorems here ground the map's stipulated polarity-side
-classifiers (`HaspelmathFunction.isDE`/`isFC`) in `contextProperties`. -/
+classifiers (`HaspelmathFunction.isDE`/`isFC`) in `LicensingContext.properties`. -/
 
 /-- [haspelmath-1997]'s free-choice region coincides exactly with the
 [kadmon-landman-1993] generic-indefinite mechanism class: a context realizes
@@ -303,7 +300,7 @@ the `freeChoice` function iff its licensing mechanism is
 theorem haspelmathFunction_freeChoice_iff_genericIndefinite
     (c : LicensingContext) :
     c.haspelmathFunction = some .freeChoice ↔
-      (contextProperties c).mechanism = .byGenericIndefinite := by
+      c.properties.mechanism = .byGenericIndefinite := by
   cases c <;> decide
 
 /-- Every context realizing an NPI-region function (`HaspelmathFunction.isDE`:
@@ -313,22 +310,22 @@ not uniformly DE (questions license by entropy, [van-rooy-2003-npi]). -/
 theorem haspelmathFunction_npi_region_licensable (c : LicensingContext)
     (f : Indefinite.HaspelmathFunction) (hf : c.haspelmathFunction = some f)
     (hDE : f.isDE = true) :
-    (contextProperties c).strawsonSignature.toDEStrength.isSome ∨
-      (contextProperties c).mechanism = .byEntropy := by
+    c.properties.strawsonSignature.toDEStrength.isSome ∨
+      c.properties.mechanism = .byEntropy := by
   revert hf hDE; cases c <;> cases f <;> decide
 
 /-- A context is **Strawson-only** when no classical signature row holds
 ([von-fintel-1999]): only-focus, adversatives, temporal *since*,
 superlatives. -/
-def IsStrawsonOnly (c : LicensingContext) : Prop :=
-  (contextProperties c).classicalSignature = none
+def LicensingContext.IsStrawsonOnly (c : LicensingContext) : Prop :=
+  c.properties.classicalSignature = none
 
 /-- When a classical row exists it coincides with the Strawson row:
 presupposition-free contexts carry a single signature. -/
 theorem classicalSignature_eq_strawson (c : LicensingContext) :
-    (contextProperties c).classicalSignature = none ∨
-    (contextProperties c).classicalSignature =
-      some (contextProperties c).strawsonSignature := by
+    c.properties.classicalSignature = none ∨
+    c.properties.classicalSignature =
+      some c.properties.strawsonSignature := by
   cases c <;> decide
 
-end Semantics.Polarity.Licensing
+end Polarity

--- a/Linglib/Semantics/Polarity/Marking.lean
+++ b/Linglib/Semantics/Polarity/Marking.lean
@@ -4,7 +4,7 @@ import Mathlib.Tactic.DeriveFintype
 # Polarity marking: strategy typology
 
 (A separate system from the `Polarity.Item` licensing API — the two share
-only the `Semantics.Polarity` namespace.)
+only the `Polarity` namespace.)
 [turco-braun-dimroth-2014] [bluhdorn-lohnstein-2012] [sudhoff-2012]
 [hohle-1992] [holmberg-2016]
 
@@ -66,7 +66,7 @@ with the form-class encoding for different reasons; the
 incompatibilities are recorded, not silently resolved.
 -/
 
-namespace Semantics.Polarity.Marking
+namespace Polarity.Marking
 
 /-- How a language marks polarity switches (neg → affirm). See module
     docstring for the framework-commitment note. -/
@@ -131,4 +131,4 @@ structure Entry where
   /-- The polarity-marking strategy category -/
   strategy : Strategy
 
-end Semantics.Polarity.Marking
+end Polarity.Marking

--- a/Linglib/Semantics/Polarity/Operator.lean
+++ b/Linglib/Semantics/Polarity/Operator.lean
@@ -2,7 +2,7 @@
 # Polarity Operators
 
 (A separate system from the `Polarity.Item` licensing API — the two share
-only the `Semantics.Polarity` namespace.)
+only the `Polarity` namespace.)
 [laka-1990] [turk-hirsch-2026]
 
 The two semantic operators that polarity heads spell out, as bare functions
@@ -20,7 +20,7 @@ Equational simp lemmas (`affirm_eq_id`, `neg_apply`, `neg_neg`) make the
 operators transparent to downstream reasoning.
 -/
 
-namespace Semantics.Polarity
+namespace Polarity
 
 universe u
 
@@ -46,4 +46,4 @@ theorem neg_neg {W : Type u} (p : W → Prop) (w : W) :
   unfold neg
   exact ⟨fun h => Classical.byContradiction h, fun h hn => hn h⟩
 
-end Semantics.Polarity
+end Polarity

--- a/Linglib/Semantics/Polarity/ScalarModel.lean
+++ b/Linglib/Semantics/Polarity/ScalarModel.lean
@@ -32,7 +32,7 @@ remains deferred to `Studies/Israel2001.lean`.
   the English lexicon and `Studies/Israel2001.lean`).
 -/
 
-namespace Semantics.Polarity
+namespace Polarity
 
 /-! ### The scalar-model axes -/
 
@@ -111,4 +111,4 @@ abbrev ScalarItem.canonicityConsistent (p : ScalarItem) : Prop :=
     ∀ c ∈ predictCanonicity le (p.freeChoice && p.licensor.isNone),
       p.canonicity = c
 
-end Semantics.Polarity
+end Polarity

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -9,7 +9,7 @@ import Linglib.Semantics.Quantification.Counting
 /-!
 # Model witnesses for the licensing-context table
 
-Each witnessed row of `contextProperties` carries a model operator
+Each witnessed row of `LicensingContext.properties` carries a model operator
 realizing its signatures: the classical row via `EntailmentSig.SoundFor`,
 the Strawson row via `EntailmentSig.StrawsonSoundFor`. This converts the
 table's `strawsonSignature`/`classicalSignature` annotations into derived
@@ -31,9 +31,8 @@ table at the polarity quotient but retains external consumers; its
 retirement is deferred.
 -/
 
-namespace Semantics.Polarity.Licensing
+namespace Polarity
 
-open Features (LicensingContext)
 open NaturalLogic
 open Quantification
 open Entailment (World pnot)
@@ -54,11 +53,11 @@ structure ContextWitness (c : LicensingContext) where
   [boundedβ : BoundedOrder β]
   /-- The Strawson row is Strawson-sound for `f`. -/
   strawson :
-    EntailmentSig.StrawsonSoundFor (contextProperties c).strawsonSignature
+    EntailmentSig.StrawsonSoundFor c.properties.strawsonSignature
       f defined
   /-- The classical row, when present, is classically sound for `f`. -/
   classical :
-    ∀ σ ∈ (contextProperties c).classicalSignature, EntailmentSig.SoundFor σ f
+    ∀ σ ∈ c.properties.classicalSignature, EntailmentSig.SoundFor σ f
 
 private theorem soundFor_of_mem_some {W : Type*} {β : Type*} [Lattice β]
     [BoundedOrder β] {f : Set W → β} {σ₀ : EntailmentSig}
@@ -228,4 +227,4 @@ example : (contextWitness? .superlative).isSome = true := rfl
 example : (contextWitness? .atMost).isSome = true := rfl
 example : (contextWitness? .withoutClause).isSome = false := rfl
 
-end Semantics.Polarity.Licensing
+end Polarity

--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -76,8 +76,8 @@ open Minimalist.DegreeMovement
    williams_scope_correlation williams_exempt_when_no_binding)
 open Core.Order (Comparison)
 open Degree (gtOverSet_eq_singleton_of_isGreatest)
-open Semantics.Polarity (LicensingContext)
-open Semantics.Polarity.Licensing (contextProperties)
+open Polarity (LicensingContext)
+open Polarity (LicensingContext)
 
 variable {Entity : Type*}
 
@@ -180,8 +180,8 @@ theorem npGQ_principal_eq_sComp_thanClause
     Hoeksema's two registry theorems so that any future change to
     either signature surfaces here as a recompile failure. -/
 theorem reduction_preserves_polarity_signatures :
-    (contextProperties .comparativeNP).strawsonSignature = .mono ∧
-    (contextProperties .comparativeS).strawsonSignature = .antiAdd :=
+    LicensingContext.comparativeNP.properties.strawsonSignature = .mono ∧
+    LicensingContext.comparativeS.properties.strawsonSignature = .antiAdd :=
   ⟨comparativeNP_signature_monotone, comparativeS_signature_anti_additive⟩
 
 /- ## Note on the Bresnan 1973 contrast (B&P §1.1.1 fn. 4)

--- a/Linglib/Studies/Chierchia2006.lean
+++ b/Linglib/Studies/Chierchia2006.lean
@@ -439,7 +439,7 @@ free-choice licensing), and each Fragment entry's instantiated parameters
 should match its profile's prediction.
 -/
 
-open Semantics.Polarity
+open Polarity
 open English.PolarityItems (any ever)
 open Italian.PolarityItems
   (mai qualsiasi nessuno qualunque uno_qualsiasi alcuno)

--- a/Linglib/Studies/DenicEtAl2021.lean
+++ b/Linglib/Studies/DenicEtAl2021.lean
@@ -233,7 +233,7 @@ def ppiItemTested : String := "some"
 -- ============================================================================
 
 open NaturalLogic
-open Semantics.Polarity
+open Polarity
 open English.PolarityItems
 
 /-- Map the paper's environments to canonical entailment signatures. -/

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -236,9 +236,9 @@ inductive LetAloneNPITrigger where
   | anyoneWhod            -- ex. 70: "Anyone who'd been to HIGH SCHOOL, let alone GRADUATE students in MATH, should be able to solve that problem"
   deriving DecidableEq, Repr
 
-open Semantics.Polarity in
+open Polarity in
 /-- Map the *let alone* licensing environments to the licensing contexts
-catalogued in `Semantics.Polarity`. -/
+catalogued in `Polarity`. -/
 def npiTriggerToContext : LetAloneNPITrigger → LicensingContext
   | .simpleNegation         => .negation
   | .tooComplementation     => .tooTo

--- a/Linglib/Studies/Gajewski2011.lean
+++ b/Linglib/Studies/Gajewski2011.lean
@@ -628,7 +628,7 @@ Fragment registry encodes this through:
   `budgeAnInch`, `inYears`, `until_`, `either_npi`) all list
   `licensingContexts := [.negation, .nobody]` — i.e., classical-AA
   contexts only.
-- `Semantics/Polarity/Licensing.lean::IsStrawsonOnly`: the four
+- `Polarity.LicensingContext.IsStrawsonOnly`: the four
   Strawson-only contexts (`.onlyFocus`, `.adversative`,
   `.sinceTemporal`, `.superlative`) carry `classicalSignature := none`.
 
@@ -636,8 +636,8 @@ Gajewski's prediction: no strong NPI lists any Strawson-only
 context. The substrate makes this `decide`-checkable.
 -/
 
-open Semantics.Polarity (LicensingContext)
-open Semantics.Polarity.Licensing (contextProperties IsStrawsonOnly)
+open Polarity (LicensingContext)
+open Polarity (LicensingContext)
 open English.PolarityItems
   (any ever yet anymore atAll inTheLeast aSingle whatsoever
    liftAFinger budgeAnInch inYears until_ either_npi)
@@ -649,15 +649,15 @@ open English.PolarityItems
     `.withoutClause`), excluding `.onlyFocus`, `.adversative`,
     `.sinceTemporal`, `.superlative`. -/
 theorem gaj2011_strongNPIs_excluded_from_strawson_only_contexts :
-    ∀ ctx : LicensingContext, IsStrawsonOnly ctx →
+    ∀ ctx : LicensingContext, ctx.IsStrawsonOnly →
       ctx ∉ liftAFinger.licensingContexts ∧
       ctx ∉ budgeAnInch.licensingContexts ∧
       ctx ∉ inYears.licensingContexts ∧
       ctx ∉ until_.licensingContexts ∧
       ctx ∉ either_npi.licensingContexts := by
   intro ctx hStrawson
-  cases ctx <;> simp_all [IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
-    until_, either_npi, contextProperties]
+  cases ctx <;> simp_all [LicensingContext.IsStrawsonOnly, liftAFinger, budgeAnInch, inYears,
+    until_, either_npi, LicensingContext.properties]
 
 /-- The registry agrees with keystone licensing on the strong NPIs: every
 context a strong NPI lists supplies anti-additive strength. -/
@@ -675,8 +675,8 @@ theorem gaj2011_weak_npis_licensed :
 -- The strength cut as a derived prediction (Gajewski's few-contrast):
 -- *few* (weak DE) licenses *any* but not *in years*; *nobody*
 -- (anti-additive) licenses both.
-example : Features.LicensingContext.few.licenses any := by decide
-example : ¬ Features.LicensingContext.few.licenses inYears := by decide
-example : Features.LicensingContext.nobody.licenses inYears := by decide
+example : Polarity.LicensingContext.few.licenses any := by decide
+example : ¬ Polarity.LicensingContext.few.licenses inYears := by decide
+example : Polarity.LicensingContext.nobody.licenses inYears := by decide
 
 end Gajewski2011

--- a/Linglib/Studies/GarassinoJacob2018.lean
+++ b/Linglib/Studies/GarassinoJacob2018.lean
@@ -20,7 +20,7 @@ as Romance polarity-focus (PF) realization strategies.
 
 1. **A typology of PF-marking strategies** in Italian, French and Spanish
    that carves the inventory differently from the
-   `Semantics.Polarity.Marking.Strategy` enum: G&J split
+   `Polarity.Marking.Strategy` enum: G&J split
    lexical means (adverbs, affirmative particles, embedded-clause
    structures) from syntactic means (non-focal fronting, cleft family,
    clitic dislocation, *sì che* / *sí que* clefts) — see §1 below for
@@ -55,7 +55,7 @@ as Romance polarity-focus (PF) realization strategies.
 
 namespace GarassinoJacob2018
 
-open Semantics.Polarity.Marking (Entry Strategy
+open Polarity.Marking (Entry Strategy
   Env)
 open Italian.PolarityMarking (siChe)
 open Spanish.PolarityMarking (siQue)

--- a/Linglib/Studies/Hoeksema1983.lean
+++ b/Linglib/Studies/Hoeksema1983.lean
@@ -92,13 +92,13 @@ registry's classification, by `rfl`.
 
 namespace Hoeksema1983
 
-open Semantics.Polarity.Licensing
+open Polarity
 
 open Entailment
 open Core.Order (Comparison)
 open Degree (gtOverSet_isAntiAdditive gtOverSet_atomic_eq_comparativeSem)
-open Semantics.Polarity (LicensingContext)
-open Semantics.Polarity.Licensing (contextProperties)
+open Polarity (LicensingContext)
+open Polarity (LicensingContext)
 
 variable {Entity : Type*} {D : Type*} [Preorder D]
 
@@ -332,18 +332,18 @@ theorem npComparativeGQ_principal_eq_gtOverSet_singleton
     Hoeksema's central asymmetry: the NP-comparative is monotone
     *increasing* and therefore not an NPI environment. -/
 theorem comparativeNP_signature_monotone :
-    (contextProperties .comparativeNP).strawsonSignature = .mono := rfl
+    LicensingContext.comparativeNP.properties.strawsonSignature = .mono := rfl
 
 /-- The `.comparativeS` registry slot is anti-additive, matching
     `gtOverSet_isAntiAdditive`. -/
 theorem comparativeS_signature_anti_additive :
-    (contextProperties .comparativeS).strawsonSignature = .antiAdd := rfl
+    LicensingContext.comparativeS.properties.strawsonSignature = .antiAdd := rfl
 
 /-- Both registry slots cite Hoeksema 1983, anchoring the registry's
     classification to this study file. -/
 theorem both_comparatives_cite_hoeksema :
-    "hoeksema-1983" ∈ (contextProperties .comparativeNP).citations ∧
-    "hoeksema-1983" ∈ (contextProperties .comparativeS).citations := by
+    "hoeksema-1983" ∈ LicensingContext.comparativeNP.properties.citations ∧
+    "hoeksema-1983" ∈ LicensingContext.comparativeS.properties.citations := by
   refine ⟨?_, ?_⟩ <;> decide
 
 end Hoeksema1983

--- a/Linglib/Studies/Israel2001.lean
+++ b/Linglib/Studies/Israel2001.lean
@@ -29,7 +29,7 @@ canonicity. The paper's items are `ScalarItem`s
 
 namespace Israel2001
 
-open Semantics.Polarity
+open Polarity
 open English.PolarityItems
 
 /-! ### Canonical items (Figure 1)

--- a/Linglib/Studies/KadmonLandman1993.lean
+++ b/Linglib/Studies/KadmonLandman1993.lean
@@ -27,7 +27,7 @@ not sufficient: *each* and comparative *more often than* are DE yet resist
   `C` creates a stronger statement;
 - `de_satisfies_strengthening`: antitone (DE) contexts satisfy strengthening;
 - `GuaranteesStrengthening`, `klExplanation`: per-context classification,
-  projected from `Semantics.Polarity.Licensing.contextProperties`;
+  projected from `Polarity.LicensingContext.properties`;
 - `ladusaw_de_is_kl_strengthening`: Ladusaw-DE contexts are strengthening
   contexts;
 - `sorry_licenses_any`, `glad_does_not_license`: the adversative asymmetry
@@ -46,8 +46,8 @@ not sufficient: *each* and comparative *more often than* are DE yet resist
 namespace KadmonLandman1993
 
 open NaturalLogic
-open Semantics.Polarity (LicensingContext)
-open Semantics.Polarity.Licensing (LicensingMechanism)
+open Polarity (LicensingContext)
+open Polarity (LicensingMechanism)
 open Entailment
 open Exhaustification.FreeChoice (Ctx existsInDomain
   widening_strengthens_in_de widening_weakens_in_ue)
@@ -90,14 +90,14 @@ theorem ue_widening_weakens {World Entity : Type*} {C : Ctx World}
 /-! ### Licensing contexts and entailment signatures
 
 Each context's entailment signature and licensing mechanism are projected
-from the canonical `Semantics.Polarity.Licensing.contextProperties` table, so
+from the canonical `Polarity.LicensingContext.properties` table, so
 this file's classification cannot drift from the substrate's. -/
 
 /-- A licensing context's entailment signature in [icard-2012]'s lattice —
 the Strawson-operative row, matching K&L's own convention of checking the
 DE pattern modulo factive presuppositions. -/
 abbrev contextEntailmentSig (c : LicensingContext) : EntailmentSig :=
-  (Semantics.Polarity.Licensing.contextProperties c).strawsonSignature
+  c.properties.strawsonSignature
 
 /-- A context guarantees K&L strengthening iff its entailment signature is on
 the DE side. Contexts with `.mono` or higher signatures are licensed by other
@@ -116,10 +116,10 @@ example : ∀ c ∈ [LicensingContext.negation, .nobody, .withoutClause, .few,
 example : ∀ c ∈ [LicensingContext.question, .modalPossibility, .generic],
     ¬ GuaranteesStrengthening c := by decide
 
-/-- A licensing context's K&L mechanism, projected from `contextProperties`:
+/-- A licensing context's K&L mechanism, projected from `LicensingContext.properties`:
 *why* the context licenses, not merely *that* it does. -/
 abbrev klExplanation (c : LicensingContext) : LicensingMechanism :=
-  (Semantics.Polarity.Licensing.contextProperties c).mechanism
+  c.properties.mechanism
 
 /-- Drift sentry: every context classified `byStrengthening` has a DE
 entailment signature. -/

--- a/Linglib/Studies/Ladusaw1979.lean
+++ b/Linglib/Studies/Ladusaw1979.lean
@@ -14,7 +14,7 @@ NPI licensing to downward entailingness (DE). The core claim:
 
 This file bridges the GQ monotonicity proofs from `Quantification` and
 `Quantification.Quantifier` to the NPI licensing classification
-indexed by `Semantics.Polarity.LicensingContext`, making the DE ↔ NPI
+indexed by `Polarity.LicensingContext`, making the DE ↔ NPI
 connection formally explicit.
 
 ## Key connections
@@ -31,7 +31,7 @@ connection formally explicit.
 namespace Ladusaw1979
 
 open Quantification
-open Semantics.Polarity (LicensingContext)
+open Polarity (LicensingContext)
 open Intensional
 open Semantics.Montague (ToyEntity)
 
@@ -59,11 +59,11 @@ def LicensingStrength.ofDEStrength : Option NaturalLogic.DEStrength → Licensin
   | none                                    => .nonDE
 
 /-- Classify NPI licensing contexts by their monotonicity-based strength,
-    derived from `Semantics.Polarity.Licensing.contextProperties`. The Ladusaw
+    derived from `Polarity.LicensingContext.properties`. The Ladusaw
     classification is a coarsening of the Icard signature lattice. -/
 def licensingStrength (c : LicensingContext) : LicensingStrength :=
   LicensingStrength.ofDEStrength
-    (Semantics.Polarity.Licensing.contextProperties c).strawsonSignature.toDEStrength
+    c.properties.strawsonSignature.toDEStrength
 
 -- ============================================================================
 -- §2. GQ monotonicity → NPI licensing (the Ladusaw bridge)

--- a/Linglib/Studies/Lahiri1998.lean
+++ b/Linglib/Studies/Lahiri1998.lean
@@ -29,7 +29,7 @@ namespace Lahiri1998
 
 open Focus.Particles (evenPresup LikelihoodMonotone)
 open Entailment (World entails pnot)
-open Semantics.Polarity
+open Polarity
 open Data.Examples (LinguisticExample)
 
 /-! ### Morphological decomposition (paper (1), p. 58)
@@ -230,12 +230,12 @@ def allHindiNPIData : List HindiNPIDatum :=
   , ⟨Examples.ex34a, some .question⟩
   , ⟨Examples.ex41a, some .negation⟩ ]
 
-/-- A DE-or-question licenser, derived from `contextProperties`: the
+/-- A DE-or-question licenser, derived from `LicensingContext.properties`: the
 context's Strawson row supplies Zwarts strength, or it licenses by
 entropy (questions license via negative bias rather than pure DE). -/
 abbrev isDEOrQuestion (c : LicensingContext) : Prop :=
-  ((Semantics.Polarity.Licensing.contextProperties c).strawsonSignature.toDEStrength).isSome ∨
-    (Semantics.Polarity.Licensing.contextProperties c).mechanism = .byEntropy
+  (c.properties.strawsonSignature.toDEStrength).isSome ∨
+    c.properties.mechanism = .byEntropy
 
 /-- The datum's context is some DE-or-question licenser. -/
 def hasDELicenser (d : HindiNPIDatum) : Prop :=

--- a/Linglib/Studies/MaticNikolaeva2018.lean
+++ b/Linglib/Studies/MaticNikolaeva2018.lean
@@ -55,7 +55,7 @@ docstring) with a back-pointer here.
 
 namespace MaticNikolaeva2018
 
-open Semantics.Polarity.Marking (Strategy Entry)
+open Polarity.Marking (Strategy Entry)
 open English.PolarityMarking (emphaticDo)
 open German.PolarityMarking (verumFocus dochPreUtterance)
 

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -69,7 +69,7 @@ open Pragmatics.Bias
    noContradictionProfile questionedProfile matrixNegatedProfile
    preciseProfile imperativeProfile)
 open Italian.PolarityItems (pur affatto neanche)
-open Semantics.Polarity (LicensingContext Item)
+open Polarity (LicensingContext Item)
 
 -- ════════════════════════════════════════════════════
 -- § 1. The Dario/Paolo dialogue paradigm (§2)

--- a/Linglib/Studies/Roussou2010.lean
+++ b/Linglib/Studies/Roussou2010.lean
@@ -175,7 +175,7 @@ whether supplied lexically by a rogative (ex. 10) or structurally
 *ksexnó* 'forget', ex. 14). True/False predicates (ex. 7) are
 veridical embedders: no licensing row corresponds to them, which is
 the account's rendering of their blocking effect. -/
-def anItem : Semantics.Polarity.Item where
+def anItem : Polarity.Item where
   form := "an"
   baseForce := .existential
   licensor := some .weak

--- a/Linglib/Studies/Schwab2022.lean
+++ b/Linglib/Studies/Schwab2022.lean
@@ -36,7 +36,7 @@ illusion arises.
 
 namespace Schwab2022
 
-open Semantics.Polarity (ScalarDirection)
+open Polarity (ScalarDirection)
 
 -- ============================================================================
 -- Experimental Data

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -481,7 +481,7 @@ theorem dq_epistemic_lacks_romero_counterpart :
 open Swedish.QuestionParticles
 open German.Particles
 open German.PolarityMarking (dochPreUtterance)
-open Semantics.Polarity.Marking (Env)
+open Polarity.Marking (Env)
 
 /-- Swedish *väl* is question-inducing — declaratives with *väl* are
     questions, not assertions ([seeliger-repp-2018] §5.2). Derived from

--- a/Linglib/Studies/TurcoBraunDimroth2014.lean
+++ b/Linglib/Studies/TurcoBraunDimroth2014.lean
@@ -54,7 +54,7 @@ Note: Production percentages are approximate (read from bar charts).
 
 namespace TurcoBraunDimroth2014
 
-open Semantics.Polarity.Marking (Strategy Entry Env)
+open Polarity.Marking (Strategy Entry Env)
 open Discourse.Coherence (CoherenceRelation)
 open Dutch.Particles (wel)
 open German.PolarityMarking (verumFocus dochPreUtterance)

--- a/Linglib/Studies/TurkHirsch2026.lean
+++ b/Linglib/Studies/TurkHirsch2026.lean
@@ -300,7 +300,7 @@ theorem categoryMatch_fixes_applyFoC :
     reusable across syntactic theories. -/
 
 open Turkish.QuestionParticles
-open Semantics.Polarity
+open Polarity
 
 /-- Polarity-head labels assumed by this study (Laka-style ΣP/NEGP).
     Lean reserves `Σ` for sigma types, so the affirmative head's
@@ -315,8 +315,8 @@ inductive Head where
 
 /-- The bare semantic operator each head spells out. -/
 def Head.toOp : Head → ((PolarWorld → Prop) → (PolarWorld → Prop))
-  | .affirm => Semantics.Polarity.affirm _
-  | .neg    => Semantics.Polarity.neg _
+  | .affirm => Polarity.affirm _
+  | .neg    => Polarity.neg _
 
 /-- This study's commitments about Turkish *mI*. -/
 structure MiAnalysis where


### PR DESCRIPTION
Namespace cleanse per the no-umbrella-prefix ruling: `Semantics.Polarity` → `Polarity` family-wide (53 files; module paths unchanged).

- `LicensingContext` moves from the `Features` namespace to `Polarity` — kills the re-export hack in `Item.lean` and both `_root_.Features.LicensingContext.*` escapes.
- The `.Licensing` sub-namespace dissolves; `contextProperties` → `LicensingContext.properties` and `IsStrawsonOnly` → `LicensingContext.IsStrawsonOnly` (dot-notation at all 6 consuming studies); `StrengthScale` type parameters go Greek to unshadow `Item`.
- Verified by a full-library build (6671 jobs, clean).