### PR TITLE
feat(Semantics/Polarity): ground Zwarts strength in DEStrength.HoldsFor

### DIFF
--- a/Linglib/Semantics/Entailment/AntiAdditivity.lean
+++ b/Linglib/Semantics/Entailment/AntiAdditivity.lean
@@ -29,15 +29,14 @@ domains, his §1.1).
 - `IsCompletely*`: Icard's "completely P" refinements (unit conditions);
 - `isAntiAdditive_iff_mem`, `isAntiAdditive_iff_gq`: pointwise bridges for
   the `Set`- and GQ-typed instances;
-- `licensesWeakNPI`, `licensesStrongNPI`, `licensesSuperstrongNPI`: the
-  Zwarts licensing thresholds ([icard-2012] §4);
+- the Zwarts licensing thresholds live semantically graded as
+  `DEStrength.HoldsFor` in `Semantics/Polarity/Witnesses.lean`;
 - toy-`World` witnesses: `pnot` (anti-morphic), `no_student` (anti-additive),
   `atMost1_student` (DE but not anti-additive — the strictness witness).
 -/
 
 namespace Entailment
 
-open NaturalLogic (DEStrength UEStrength strengthSufficient)
 open Entailment
 open List (Sublist)
 
@@ -227,7 +226,7 @@ theorem isAntiAdditive_iff_gq {f : Set γ → Prop} :
 
 end Bridges
 
-/-! ### Toy-`World` witnesses and NPI licensing thresholds -/
+/-! ### Toy-`World` witnesses -/
 
 section ToyWitnesses
 
@@ -376,35 +375,6 @@ theorem atMost_not_antiAdditive :
           exact ⟨Or.inr rfl, by right; rfl⟩
     simp at this
   exact hcontr (key.mpr ⟨hp, hq⟩)
-
-/-- Weak NPI licensing: requires DE. -/
-def licensesWeakNPI (f : Set World → Set World) : Prop := IsDownwardEntailing f
-
-/-- Strong NPI licensing: requires anti-additivity. -/
-def licensesStrongNPI (f : Set World → Set World) : Prop := IsAntiAdditive f
-
-/-- Superstrong NPI licensing ([icard-2012] §4, after Zwarts): requires
-anti-morphicity — *a tad bit* under *not* but not under *no*. -/
-def licensesSuperstrongNPI (f : Set World → Set World) : Prop := IsAntiMorphic f
-
-example : licensesWeakNPI pnot := pnot_isDownwardEntailing
-example : licensesStrongNPI pnot := pnot_isAntiAdditive
-example : licensesSuperstrongNPI pnot := pnot_isAntiMorphic
-
-example : licensesWeakNPI no_student := no_isDE_scope
-example : licensesStrongNPI no_student := no_isAntiAdditive_scope
-
-example : licensesWeakNPI atMost2_student := atMost_isDE_scope
-
-/-!
-### `DEStrength` ↔ proof hierarchy ([icard-2012] §4)
-
-| `DEStrength` | Proof predicate | Example licensor |
-|--------------|-----------------|------------------|
-| `.weak` | `IsDE` | few, at most n |
-| `.antiAdditive` | `IsAntiAdditive` | no, nobody, without |
-| `.antiMorphic` | `IsAntiMorphic` | not, never |
--/
 
 end ToyWitnesses
 

--- a/Linglib/Semantics/Entailment/NaturalLogic.lean
+++ b/Linglib/Semantics/Entailment/NaturalLogic.lean
@@ -569,23 +569,6 @@ inductive UEStrength where
   | additive       -- UE + ∨-distributive (strongest)
   deriving DecidableEq, Repr
 
-/--
-Check if a context's DE strength is sufficient for an NPI.
-
-`strengthSufficient contextStrength requiredStrength` returns true
-when `requiredStrength ≤ contextStrength` in the Zwarts hierarchy (`LinearOrder DEStrength`).
--/
-def strengthSufficient (contextStrength requiredStrength : DEStrength) : Bool :=
-  decide (requiredStrength ≤ contextStrength)
-
-#guard strengthSufficient .antiMorphic .weak          -- negation licenses weak NPIs
-#guard strengthSufficient .antiMorphic .antiAdditive   -- negation licenses strong NPIs
-#guard strengthSufficient .antiAdditive .weak          -- "no" licenses weak NPIs
-#guard strengthSufficient .antiAdditive .antiAdditive   -- "no" licenses strong NPIs
-#guard strengthSufficient .weak .weak                  -- "few" licenses weak NPIs
-#guard !strengthSufficient .weak .antiAdditive          -- "few" does NOT license strong NPIs
-
-
 -- ============================================================================
 -- §4 — Signature ↔ Strength Bridge Maps
 -- ============================================================================

--- a/Linglib/Semantics/Polarity/Negation.lean
+++ b/Linglib/Semantics/Polarity/Negation.lean
@@ -25,19 +25,18 @@ coherent architecture with three layers:
   PolarityClass, PolarityLicensing) with Mathlib lattice instances
 - `Mathlib.Data.Set.Basic` — set complement (`pᶜ`) is the canonical
   propositional negation (no custom `pnot` wrapper)
-- `NaturalLogic` — `DEStrength` (weak/antiAdditive/antiMorphic),
-  `strengthSufficient`
+- `NaturalLogic` — `DEStrength` (weak/antiAdditive/antiMorphic)
 - `Entailment` — `IsDE = Antitone`,
   `IsUE = Monotone`, `pnot_isDownwardEntailing`
 - `Entailment` — `IsAntiAdditive`,
-  `IsAntiMorphic`, `pnot_isAntiMorphic`, `licensesWeakNPI`, `licensesStrongNPI`
+  `IsAntiMorphic`, `pnot_isAntiMorphic`
 -/
 
 namespace Negation
 
 open Negation (ENType ENStrength PolarityLicensing PolarityClass
            weakENProfile strongENProfile standardNegProfile)
-open NaturalLogic (DEStrength strengthSufficient)
+open NaturalLogic (DEStrength)
 open Entailment (World)
 open Entailment (IsDE IsUE pnot_isDownwardEntailing)
 open Entailment (IsAntiAdditive IsAntiMorphic
@@ -151,10 +150,10 @@ def deToPolarityLicensing : DEStrength → PolarityLicensing
 
 /-- The bridge is monotone: stronger DE → more licensing in the lattice. -/
 theorem de_licensing_monotone :
-    ∀ d₁ d₂ : DEStrength, strengthSufficient d₂ d₁ = true →
+    ∀ d₁ d₂ : DEStrength, d₁ ≤ d₂ →
     deToPolarityLicensing d₁ ≤ deToPolarityLicensing d₂ := by
   intro d₁ d₂
-  cases d₁ <;> cases d₂ <;> simp [deToPolarityLicensing, strengthSufficient] <;> decide
+  cases d₁ <;> cases d₂ <;> decide
 
 /-- Weak DE licenses exactly weak NPIs and N-words. -/
 theorem weak_de_licensing :

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -26,6 +26,15 @@ four Strawson-only rows (`onlyFull`, `sorryFull`, `superlativeAssert`,
 content is the licensing mechanism rather than the signature (the
 FC/`mono` rows, questions).
 
+`DEStrength.HoldsFor` gives the Zwarts strength levels their semantic
+content (weak = `Antitone`, antiAdditive = `IsAntiAdditive`, antiMorphic
+= `IsAntiMorphic`), downward closed along the chain
+(`HoldsFor.of_le`); each witness carries a `strength` certificate for
+its classical row, and `ContextWitness.holdsFor_of_licenses` grounds
+the keystone: at a witnessed presupposition-free row, strength-matched
+licensing means the operator really holds the strength the item
+requires.
+
 `GroundedPolarity` (in `Entailment/Polarity.lean`) is subsumed by this
 table at the polarity quotient but retains external consumers; its
 retirement is deferred.
@@ -38,6 +47,37 @@ open Quantification
 open Entailment (World pnot)
 open Entailment (atMost2_student atMost_isDE_scope)
 open Entailment
+
+/-! ### The Zwarts hierarchy semantically -/
+
+/-- The semantic content of a `DEStrength` level for a context function
+([icard-2012] §4, after Zwarts): `weak` is antitonicity, `antiAdditive`
+the anti-additivity equation, `antiMorphic` the full anti-morphism —
+*few* is weak-only, *no* anti-additive, *not* anti-morphic. -/
+def _root_.NaturalLogic.DEStrength.HoldsFor {α β : Type*} [Lattice α]
+    [Lattice β] (s : DEStrength) (f : α → β) : Prop :=
+  match s with
+  | .weak => Antitone f
+  | .antiAdditive => IsAntiAdditive f
+  | .antiMorphic => IsAntiMorphic f
+
+/-- Strength facts are downward closed along the Zwarts chain
+`weak < antiAdditive < antiMorphic`: a function holding a level holds
+every weaker one. -/
+theorem _root_.NaturalLogic.DEStrength.HoldsFor.of_le {α β : Type*}
+    [Lattice α] [Lattice β] {f : α → β} {s₁ s₂ : DEStrength}
+    (h : s₁ ≤ s₂) (hf : s₂.HoldsFor f) : s₁.HoldsFor f := by
+  cases s₁ <;> cases s₂ <;>
+    first
+      | exact hf
+      | exact hf.antitone
+      | exact hf.antiAdditive
+      | exact absurd h (by decide)
+
+example : DEStrength.antiMorphic.HoldsFor pnot := pnot_isAntiMorphic
+example : DEStrength.weak.HoldsFor pnot :=
+  DEStrength.HoldsFor.of_le (s₂ := .antiMorphic) (by decide)
+    pnot_isAntiMorphic
 
 /-- A model-theoretic witness for a licensing-context row: an operator
 (with its definedness/presupposition function) realizing the row's
@@ -58,6 +98,11 @@ structure ContextWitness (c : LicensingContext) where
   /-- The classical row, when present, is classically sound for `f`. -/
   classical :
     ∀ σ ∈ c.properties.classicalSignature, EntailmentSig.SoundFor σ f
+  /-- The classical row's Zwarts strength holds semantically of `f`
+      (vacuous at Strawson-only rows). -/
+  strength :
+    ∀ σ ∈ c.properties.classicalSignature, ∀ s ∈ σ.toDEStrength,
+      s.HoldsFor f
 
 private theorem soundFor_of_mem_some {W : Type*} {β : Type*} [Lattice β]
     [BoundedOrder β] {f : Set W → β} {σ₀ : EntailmentSig}
@@ -75,6 +120,27 @@ private theorem soundFor_of_mem_none {W : Type*} {β : Type*} [Lattice β]
   rw [Option.mem_def] at hσ
   exact absurd hσ (by simp)
 
+private theorem strength_of_mem_some {W : Type*} {β : Type*} [Lattice β]
+    {f : Set W → β} {σ₀ : EntailmentSig} {s₀ : DEStrength}
+    (hσ : σ₀.toDEStrength = some s₀) (hf : s₀.HoldsFor f) :
+    ∀ σ ∈ (some σ₀ : Option EntailmentSig), ∀ s ∈ σ.toDEStrength,
+      s.HoldsFor f := by
+  intro σ hσ' s hs
+  rw [Option.mem_def] at hσ'
+  injection hσ' with h
+  subst h
+  rw [Option.mem_def, hσ] at hs
+  injection hs with h'
+  exact h' ▸ hf
+
+private theorem strength_of_mem_none {W : Type*} {β : Type*} [Lattice β]
+    {f : Set W → β} :
+    ∀ σ ∈ (none : Option EntailmentSig), ∀ s ∈ σ.toDEStrength,
+      s.HoldsFor f := by
+  intro σ hσ
+  rw [Option.mem_def] at hσ
+  exact absurd hσ (by simp)
+
 /-! ### Classical rows -/
 
 /-- Negation: `pnot` realizes the anti-morphism row. -/
@@ -83,6 +149,8 @@ def negationWitness : ContextWitness .negation where
   defined := fun _ => ⊤
   strawson := pnot_soundFor_antiAddMult.strawsonSoundFor _
   classical := soundFor_of_mem_some pnot_soundFor_antiAddMult
+  strength := strength_of_mem_some (s₀ := .antiMorphic) (by decide)
+    pnot_isAntiMorphic
 
 private theorem everyRestrictor_soundFor :
     EntailmentSig.SoundFor .antiAdd
@@ -100,6 +168,8 @@ noncomputable def universalRestrictorWitness :
   defined := fun _ => ⊤
   strawson := everyRestrictor_soundFor.strawsonSoundFor _
   classical := soundFor_of_mem_some everyRestrictor_soundFor
+  strength := strength_of_mem_some (s₀ := .antiAdditive) (by decide)
+    ((leftAntiAdditive_iff_isAntiAdditive _).mp every_laa _)
 
 private theorem noScope_soundFor :
     EntailmentSig.SoundFor .antiAdd
@@ -114,6 +184,8 @@ noncomputable def nobodyWitness : ContextWitness .nobody where
   defined := fun _ => ⊤
   strawson := noScope_soundFor.strawsonSoundFor _
   classical := soundFor_of_mem_some noScope_soundFor
+  strength := strength_of_mem_some (s₀ := .antiAdditive) (by decide)
+    ((rightAntiAdditive_iff_isAntiAdditive _).mp no_raa _)
 
 private noncomputable def fewScope : Set Bool → Prop :=
   few_sem (α := Bool) (fun _ => True)
@@ -128,6 +200,8 @@ noncomputable def fewWitness : ContextWitness .few where
   defined := fun _ => ⊤
   strawson := fewScope_soundFor.strawsonSoundFor _
   classical := soundFor_of_mem_some fewScope_soundFor
+  strength := strength_of_mem_some (s₀ := .weak) (by decide)
+    (soundFor_anti_iff.mp fewScope_soundFor)
 
 private theorem atMost_soundFor :
     EntailmentSig.SoundFor .anti atMost2_student :=
@@ -140,6 +214,8 @@ def atMostWitness : ContextWitness .atMost where
   defined := fun _ => ⊤
   strawson := atMost_soundFor.strawsonSoundFor _
   classical := soundFor_of_mem_some atMost_soundFor
+  strength := strength_of_mem_some (s₀ := .weak) (by decide)
+    atMost_isDE_scope
 
 private theorem condAntecedent_soundFor :
     EntailmentSig.SoundFor .anti
@@ -153,6 +229,8 @@ def conditionalAntecedentWitness : ContextWitness .conditionalAntecedent where
   defined := fun _ => ⊤
   strawson := condAntecedent_soundFor.strawsonSoundFor _
   classical := soundFor_of_mem_some condAntecedent_soundFor
+  strength := strength_of_mem_some (s₀ := .weak) (by decide)
+    (soundFor_anti_iff.mp condAntecedent_soundFor)
 
 /-! ### Strawson-only rows (`classicalSignature = none`) -/
 
@@ -163,6 +241,7 @@ def onlyFocusWitness : ContextWitness .onlyFocus where
   defined := fun scope => {w | ∃ w', w' = World.w0 ∧ scope w'}
   strawson := onlyFull_strawsonSoundFor_anti _
   classical := soundFor_of_mem_none
+  strength := strength_of_mem_none
 
 /-- Adversatives: Strawson-`.anti` with doxastic factivity; classically
 nothing (`sorryFull_not_de`). -/
@@ -171,6 +250,7 @@ def adversativeWitness : ContextWitness .adversative where
   defined := fun p => {w | ∀ w' ∈ ({w} : Set World), p w'}
   strawson := sorryFull_strawsonSoundFor_anti _ _
   classical := soundFor_of_mem_none
+  strength := strength_of_mem_none
 
 /-- Temporal *since*: Strawson-`.anti` with the past-event
 presupposition. -/
@@ -179,6 +259,7 @@ def sinceTemporalWitness : ContextWitness .sinceTemporal where
   defined := fun p => {w | ∃ w' ∈ ({World.w0} : Set World), p w'}
   strawson := sinceFull_strawsonSoundFor_anti _ _
   classical := soundFor_of_mem_none
+  strength := strength_of_mem_none
 
 /-- Superlatives: Strawson-`.anti` in the restriction with the
 designated-subject presupposition. -/
@@ -187,6 +268,7 @@ def superlativeWitness : ContextWitness .superlative where
   defined := fun restriction => {w | superlativePresup World.w0 restriction w}
   strawson := superlativeAssert_strawsonSoundFor_anti _
   classical := soundFor_of_mem_none
+  strength := strength_of_mem_none
 
 /-! ### The table -/
 
@@ -226,5 +308,32 @@ example : (contextWitness? .negation).isSome = true := rfl
 example : (contextWitness? .superlative).isSome = true := rfl
 example : (contextWitness? .atMost).isSome = true := rfl
 example : (contextWitness? .withoutClause).isSome = false := rfl
+
+/-! ### Grounded strength licensing -/
+
+instance {c : LicensingContext} (w : ContextWitness c) : Lattice w.β :=
+  w.latticeβ
+
+instance {c : LicensingContext} (w : ContextWitness c) : BoundedOrder w.β :=
+  w.boundedβ
+
+/-- At a witnessed presupposition-free row, keystone strength licensing
+is semantically real: the witness operator holds the strength the item
+requires. Strawson-only rows are exempt — their antitonicity holds only
+on the definedness region. -/
+theorem ContextWitness.holdsFor_of_licenses {c : LicensingContext}
+    (w : ContextWitness c)
+    (hcl : c.properties.classicalSignature =
+      some c.properties.strawsonSignature)
+    {e : Item} (hlic : zwartsScale.licenses e c) :
+    ∀ r ∈ e.licensor, r.HoldsFor w.f := by
+  obtain ⟨r, hr, s, hs, hrs⟩ := hlic
+  intro r' hr'
+  have hr₂ : r ∈ e.licensor := hr
+  rw [Option.mem_def] at hr₂ hr'
+  rw [hr₂] at hr'
+  injection hr' with h
+  subst h
+  exact (w.strength _ (Option.mem_def.mpr hcl) s hs).of_le hrs
 
 end Polarity


### PR DESCRIPTION
The Zwarts hierarchy gets its semantic content: `DEStrength.HoldsFor` (weak = `Antitone`, antiAdditive = `IsAntiAdditive`, antiMorphic = `IsAntiMorphic`), downward closed along the chain (`HoldsFor.of_le`).

- `ContextWitness` gains a `strength` certificate for its classical row, populated at all ten witnessed contexts (vacuous at the four Strawson-only rows, whose antitonicity holds only on the definedness region).
- `ContextWitness.holdsFor_of_licenses`: at a witnessed presupposition-free row, keystone strength licensing implies the witness operator semantically holds the strength the item requires — the enum keystone certified as the decidable shadow of the order-theoretic fact.
- Dissolves the dead shadows: `strengthSufficient : Bool` (= `decide (· ≤ ·)`, one consumer rewritten to the `LinearOrder`) and the three `licenses*NPI` threshold defs (zero code consumers); the DEStrength↔predicate comment-table in `AntiAdditivity.lean` is now the `HoldsFor` definition.

Verified by a full-library build (6671 jobs, clean).