### PR TITLE
refactor(Studies/Icard2012): table verifications leave the substrate

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2309,6 +2309,7 @@ import Linglib.Studies.Hyman2006
 import Linglib.Studies.Iatridou2000
 import Linglib.Studies.IatridouEtAl2001
 import Linglib.Studies.IatridouZeijlstra2021
+import Linglib.Studies.Icard2012
 import Linglib.Studies.Imanishi2014
 import Linglib.Studies.Imanishi2020
 import Linglib.Studies.ImelGuoST2026

--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -185,13 +185,6 @@ def join : NLRelation → NLRelation → NLRelation
   -- # column
   | .independent, _ => .independent
 
--- Spot-checks from Lemma 1.5 table
-example : join .forward .forward = .forward := rfl       -- ⊑ ⋈ ⊑ = ⊑
-example : join .negation .negation = .equiv := rfl       -- ^ ⋈ ^ = ≡
-example : join .alternation .negation = .forward := rfl  -- | ⋈ ^ = ⊑
-example : join .negation .forward = .cover := rfl        -- ^ ⋈ ⊑ = ⌣
-example : join .cover .negation = .reverse := rfl        -- ⌣ ⋈ ^ = ⊒
-
 /-- ≡ is the identity for join. -/
 theorem join_identity_left (r : NLRelation) : join .equiv r = r := by
   cases r <;> rfl
@@ -203,7 +196,6 @@ theorem join_identity_right (r : NLRelation) : join r .equiv = r := by
 -- This is expected: xRy and yR'z is directional.
 
 end NLRelation
-
 
 /-! ### Entailment signatures -/
 
@@ -307,15 +299,6 @@ instance : LE EntailmentSig := ⟨Refines⟩
 instance decidableLE (a b : EntailmentSig) : Decidable (a ≤ b) :=
   inferInstanceAs (Decidable (Refines a b))
 
--- Spot-checks for the refinement lattice
-example : ¬ ((EntailmentSig.all : EntailmentSig) ≤ .mono) := by decide
-example : (EntailmentSig.mono : EntailmentSig) ≤ .all := by decide
-example : (EntailmentSig.anti : EntailmentSig) ≤ .all := by decide
-example : (EntailmentSig.addMult : EntailmentSig) ≤ .additive := by decide
-example : (EntailmentSig.antiAddMult : EntailmentSig) ≤ .anti := by decide
-example : ¬ ((EntailmentSig.mono : EntailmentSig) ≤ .additive) := by decide
-example : ¬ ((EntailmentSig.additive : EntailmentSig) ≤ .mult) := by decide
-
 private theorem Refines_refl (a : EntailmentSig) : Refines a a := by
   cases a <;> decide
 
@@ -413,23 +396,6 @@ def project : NLRelation → EntailmentSig → NLRelation
   | .cover, .antiMult => .independent            -- x∨y=1 gives nothing
   | .independent, .antiMult => .independent
 
--- Spot-checks from Lemma 2.4 tables (p.715)
-example : project .forward .mono = .forward := rfl            -- [⊑]^+ = ⊑
-example : project .forward .anti = .reverse := rfl            -- [⊑]^− = ⊒
-example : project .negation .mono = .independent := rfl       -- [^]^+ = #
-example : project .negation .anti = .independent := rfl       -- [^]^− = #
-example : project .negation .additive = .cover := rfl         -- [^]^⊕ = ∼
-example : project .negation .mult = .alternation := rfl       -- [^]^⊞ = |
-example : project .negation .antiAddMult = .negation := rfl   -- [^]^◇⊟ = ^
-example : project .alternation .mult = .alternation := rfl    -- [|]^⊞ = |
-example : project .alternation .additive = .independent := rfl -- [|]^⊕ = #
-example : project .cover .additive = .cover := rfl            -- [∼]^⊕ = ∼
-example : project .cover .mult = .independent := rfl          -- [∼]^⊞ = #
-example : project .cover .antiAdd = .alternation := rfl       -- [∼]^◇ = |
-example : project .alternation .antiMult = .cover := rfl      -- [|]^⊟ = ∼
-example : project .alternation .antiAddMult = .cover := rfl   -- [|]^◇⊟ = ∼
-example : project .cover .antiAddMult = .alternation := rfl   -- [∼]^◇⊟ = |
-
 /-- Every signature except • preserves equiv (• is the class of arbitrary
 functions, which need not respect equivalence). -/
 theorem project_equiv (φ : EntailmentSig) (h : φ ≠ .all) :
@@ -474,20 +440,6 @@ def compose (ψ φ : EntailmentSig) : EntailmentSig :=
     (project (project .forward φ) ψ)
     (project (project .negation φ) ψ)
 
--- Spot-checks (Lemma 2.7 table, p.716)
-example : compose .anti .anti = .mono := rfl                   -- − ∘ − = +
-example : compose .antiAddMult .antiAddMult = .addMult := rfl  -- ◇⊟ ∘ ◇⊟ = ⊕⊞
-example : compose .additive .additive = .additive := rfl       -- ⊕ ∘ ⊕ = ⊕
-example : compose .antiAdd .additive = .antiAdd := rfl         -- ◇ ∘ ⊕ = ◇
-example : compose .addMult .anti = .anti := rfl                -- ⊕⊞ ∘ − = −
-example : compose .mult .antiAdd = .antiAdd := rfl             -- ⊞ ∘ ◇ = ◇
-example : compose .additive .antiMult = .antiMult := rfl       -- ⊕ ∘ ⊟ = ⊟
-example : compose .antiMult .antiAdd = .additive := rfl        -- ⊟ ∘ ◇ = ⊕
-example : compose .mult .mult = .mult := rfl                   -- ⊞ ∘ ⊞ = ⊞
-example : compose .additive .antiAdd = .anti := rfl            -- ⊕ ∘ ◇ = −
-example : compose .all .mono = .all := rfl                     -- • ∘ + = • (absorbing)
-example : compose .anti .all = .all := rfl                     -- − ∘ • = • (absorbing)
-
 /-- `addMult` (⊕⊞, the morphism class) is the identity for composition
 ([icard-2012] Lemma 2.7). -/
 theorem compose_identity_left (s : EntailmentSig) : compose .addMult s = s := by
@@ -518,7 +470,6 @@ instance : Monoid EntailmentSig where
   mul_one := compose_identity_right
 
 end EntailmentSig
-
 
 /-! ### Context polarity -/
 
@@ -556,10 +507,6 @@ def compose : ContextPolarity → ContextPolarity → ContextPolarity
   | .nonMonotonic, _ => .nonMonotonic
   | _, .nonMonotonic => .nonMonotonic
 
-example : compose .upward .downward = .downward := rfl
-example : compose .downward .downward = .upward := rfl
-example : compose .downward .upward = .downward := rfl
-
 end ContextPolarity
 
 namespace EntailmentSig
@@ -575,17 +522,6 @@ def toContextPolarity (φ : EntailmentSig) : ContextPolarity :=
   if project .forward φ == .forward then .upward
   else if project .forward φ == .reverse then .downward
   else .nonMonotonic
-
--- Exhaustive verification
-example : toContextPolarity .all = .nonMonotonic := rfl
-example : toContextPolarity .mono = .upward := rfl
-example : toContextPolarity .additive = .upward := rfl
-example : toContextPolarity .mult = .upward := rfl
-example : toContextPolarity .addMult = .upward := rfl
-example : toContextPolarity .anti = .downward := rfl
-example : toContextPolarity .antiAdd = .downward := rfl
-example : toContextPolarity .antiMult = .downward := rfl
-example : toContextPolarity .antiAddMult = .downward := rfl
 
 /--
 `toContextPolarity` is a monoid homomorphism: composing signatures then
@@ -626,29 +562,7 @@ def projectThrough (R : NLRelation) (path : List EntailmentSig) : NLRelation :=
 -- Icard §2.4: path lists signatures from root (outermost) to target (innermost).
 -- List.prod applies them right-to-left: the last element is applied first.
 
--- "animal" in "Every animal runs": path = [◇] (every_restrictor = anti-additive)
-example : contextProjectivity [.antiAdd] = .antiAdd := rfl
-
--- "runs" in "Every animal runs": path = [⊞] (every_scope = multiplicative)
-example : contextProjectivity [.mult] = .mult := rfl
-
--- "cat" in "No big cat runs": path = [◇, ⊕⊞] (no_restrictor = ◇, big = ⊕⊞)
--- ◇ ∘ ⊕⊞ = ◇ (anti-additive composed with morphism stays anti-additive)
-example : contextProjectivity [.antiAdd, .addMult] = .antiAdd := rfl
-
--- "runs" in "It's not the case that every animal runs":
--- path = [◇⊟, ⊞] (negation = ◇⊟, every_scope = ⊞)
--- ◇⊟ ∘ ⊞ = ⊟ (anti-multiplicative)
-example : contextProjectivity [.antiAddMult, .mult] = .antiMult := rfl
-
--- Double negation: ◇⊟ ∘ ◇⊟ = ⊕⊞ (morphism = preserves everything)
-example : contextProjectivity [.antiAddMult, .antiAddMult] = .addMult := rfl
-
--- And its polarity: morphism → upward
-example : toContextPolarity (contextProjectivity [.antiAddMult, .antiAddMult]) = .upward := rfl
-
 end EntailmentSig
-
 
 /-! ### Projection composition -/
 
@@ -668,45 +582,9 @@ theorem projection_composition (R : NLRelation) (φ ψ : EntailmentSig) :
     EntailmentSig.project R (EntailmentSig.compose ψ φ) := by
   cases R <;> cases φ <;> cases ψ <;> rfl
 
-
-/-! ### The negation signature and worked projections -/
+/-! ### The negation signature -/
 
 /-- Negation has the anti-morphism signature ◇⊟ (strongest DE signature). -/
 def negationSig : EntailmentSig := .antiAddMult
-
-example : EntailmentSig.toContextPolarity negationSig = .downward := rfl
-
--- Monoid notation: negationSig * negationSig = double negation = morphism
-example : negationSig * negationSig = .addMult := rfl
-
--- negationSig ^ 2 = ⊕⊞ (via Monoid.npow)
-example : negationSig ^ 2 = .addMult := rfl
-
--- Negation is its own inverse (up to •/⊕⊞ equivalence):
--- ◇⊟ * ◇⊟ = ⊕⊞ (the monoid identity on non-• signatures)
-example : negationSig * negationSig * negationSig = negationSig := rfl
-
--- Composing negation with "every" scope: ◇⊟ * ⊞ = ⊟ (anti-multiplicative)
-example : negationSig * .mult = .antiMult := rfl
-
--- Chain composition: not(not(every ... )) scope = ⊟ * ◇⊟ * ◇⊟ = ⊟ * ⊕⊞ = ⊟
-example : .antiMult * negationSig * negationSig = .antiMult := rfl
-
--- Forward entailment (dog ⊑ animal) projected through various signatures:
-example : EntailmentSig.project .forward .mono = .forward := rfl           -- + : dog ⊑ animal ⟹ f(dog) ⊑ f(animal)
-example : EntailmentSig.project .forward .anti = .reverse := rfl           -- − : dog ⊑ animal ⟹ f(dog) ⊒ f(animal)
-example : EntailmentSig.project .forward .additive = .forward := rfl       -- ⊕ : same as mono for ⊑
-example : EntailmentSig.project .forward .antiAddMult = .reverse := rfl    -- ◇⊟ : same as anti for ⊑
-
--- Alternation (cat | dog) projected through various signatures:
-example : EntailmentSig.project .alternation .mono = .independent := rfl     -- + : mono alone can't track disjointness
-example : EntailmentSig.project .alternation .mult = .alternation := rfl     -- ⊞ : mult preserves ∧, so preserves |
-example : EntailmentSig.project .alternation .antiMult = .cover := rfl       -- ⊟ : anti-mult flips | to ∼
-
--- Cover (animal ∼ nondog) projected through various signatures:
-example : EntailmentSig.project .cover .additive = .cover := rfl             -- ⊕ : additive preserves ∨, so preserves ∼
-example : EntailmentSig.project .cover .mult = .independent := rfl           -- ⊞ : mult can't track ∨-structure
-example : EntailmentSig.project .cover .antiAdd = .alternation := rfl        -- ◇ : anti-additive flips ∼ to |
-example : EntailmentSig.project .cover .antiAddMult = .alternation := rfl    -- ◇⊟ : anti-morph swaps | ↔ ∼
 
 end NaturalLogic

--- a/Linglib/Studies/Icard2012.lean
+++ b/Linglib/Studies/Icard2012.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Logic.Natural.Basic
+
+/-!
+# [icard-2012]: Inclusion and Exclusion in Natural Language
+
+Table verifications for [icard-2012]'s relation algebra against the
+substrate implementations in `Logic/Natural/Basic.lean`: the join table
+(Lemma 1.5, p. 710 — the printed cells, independently certified against
+the non-strict `Holds` reading by `NLRelation.Holds.join`), the
+projectivity tables (Lemma 2.4, p. 715), the composition table
+(Lemma 2.7, p. 716) with its signature order (§2.2), the polarity
+coarsening, the classification of *not* as the anti-morphism (p. 713),
+and path computations illustrating the §2.4 context-projectivity
+mechanism. The tables' semantic soundness is certified once and for all
+in `Logic/Natural/Soundness.lean`; this file checks the implementations
+cell-by-cell against the paper's printed entries.
+-/
+
+namespace Icard2012
+
+open NaturalLogic NaturalLogic.NLRelation NaturalLogic.EntailmentSig
+
+/-! ### The join table (Lemma 1.5, p. 710) -/
+
+example : join .forward .forward = .forward := rfl       -- ⊑ ⋈ ⊑ = ⊑
+example : join .negation .negation = .equiv := rfl       -- ^ ⋈ ^ = ≡
+example : join .alternation .negation = .forward := rfl  -- | ⋈ ^ = ⊑
+example : join .negation .forward = .cover := rfl        -- ^ ⋈ ⊑ = ⌣
+example : join .forward .negation = .alternation := rfl  -- ⊑ ⋈ ^ = |
+example : join .cover .negation = .reverse := rfl        -- ⌣ ⋈ ^ = ⊒
+
+/-! ### The refinement order (§2.2) -/
+
+example : ¬ ((EntailmentSig.all : EntailmentSig) ≤ .mono) := by decide
+example : (EntailmentSig.mono : EntailmentSig) ≤ .all := by decide
+example : (EntailmentSig.anti : EntailmentSig) ≤ .all := by decide
+example : (EntailmentSig.addMult : EntailmentSig) ≤ .additive := by decide
+example : (EntailmentSig.antiAddMult : EntailmentSig) ≤ .anti := by decide
+example : ¬ ((EntailmentSig.mono : EntailmentSig) ≤ .additive) := by decide
+example : ¬ ((EntailmentSig.additive : EntailmentSig) ≤ .mult) := by decide
+
+/-! ### The projectivity tables (Lemma 2.4, p. 715)
+
+Forward entailment (*dog* ⊑ *animal*), negation, alternation
+(*cat* | *dog*), and cover (*animal* ⌣ *nondog*) pushed through each
+signature class. -/
+
+example : project .forward .mono = .forward := rfl        -- + : f(dog) ⊑ f(animal)
+example : project .forward .anti = .reverse := rfl        -- − : f(dog) ⊒ f(animal)
+example : project .forward .additive = .forward := rfl    -- ⊕ : as mono for ⊑
+example : project .forward .antiAddMult = .reverse := rfl -- ◇⊟ : as anti for ⊑
+example : project .negation .mono = .independent := rfl   -- + : ^ weakens to #
+example : project .negation .anti = .independent := rfl   -- − : ^ weakens to #
+example : project .negation .additive = .cover := rfl     -- ⊕ : x∨y=1 ⟹ f(x)∨f(y)=1
+example : project .negation .mult = .alternation := rfl   -- ⊞ : x∧y=0 ⟹ f(x)∧f(y)=0
+example : project .negation .antiAddMult = .negation := rfl -- ◇⊟ : ^ preserved
+example : project .alternation .mono = .independent := rfl  -- + : can't track |
+example : project .alternation .mult = .alternation := rfl  -- ⊞ : | preserved
+example : project .alternation .additive = .independent := rfl -- ⊕ : | lost
+example : project .alternation .antiMult = .cover := rfl    -- ⊟ : | flips to ∼
+example : project .alternation .antiAddMult = .cover := rfl -- ◇⊟ : | flips to ∼
+example : project .cover .additive = .cover := rfl          -- ⊕ : ∼ preserved
+example : project .cover .mult = .independent := rfl        -- ⊞ : ∼ lost
+example : project .cover .antiAdd = .alternation := rfl     -- ◇ : ∼ flips to |
+example : project .cover .antiAddMult = .alternation := rfl -- ◇⊟ : ∼ flips to |
+
+/-! ### The composition table (Lemma 2.7, p. 716) -/
+
+example : compose .anti .anti = .mono := rfl                   -- − ∘ − = +
+example : compose .antiAddMult .antiAddMult = .addMult := rfl  -- ◇⊟ ∘ ◇⊟ = ⊕⊞
+example : compose .additive .additive = .additive := rfl       -- ⊕ ∘ ⊕ = ⊕
+example : compose .antiAdd .additive = .antiAdd := rfl         -- ◇ ∘ ⊕ = ◇
+example : compose .addMult .anti = .anti := rfl                -- ⊕⊞ ∘ − = −
+example : compose .mult .antiAdd = .antiAdd := rfl             -- ⊞ ∘ ◇ = ◇
+example : compose .additive .antiMult = .antiMult := rfl       -- ⊕ ∘ ⊟ = ⊟
+example : compose .antiMult .antiAdd = .additive := rfl        -- ⊟ ∘ ◇ = ⊕
+example : compose .mult .mult = .mult := rfl                   -- ⊞ ∘ ⊞ = ⊞
+example : compose .additive .antiAdd = .anti := rfl            -- ⊕ ∘ ◇ = −
+example : compose .all .mono = .all := rfl                     -- • absorbing
+example : compose .anti .all = .all := rfl                     -- • absorbing
+
+/-! ### The polarity coarsening -/
+
+example : toContextPolarity .all = .nonMonotonic := rfl
+example : toContextPolarity .mono = .upward := rfl
+example : toContextPolarity .additive = .upward := rfl
+example : toContextPolarity .mult = .upward := rfl
+example : toContextPolarity .addMult = .upward := rfl
+example : toContextPolarity .anti = .downward := rfl
+example : toContextPolarity .antiAdd = .downward := rfl
+example : toContextPolarity .antiMult = .downward := rfl
+example : toContextPolarity .antiAddMult = .downward := rfl
+
+example : ContextPolarity.compose .upward .downward = .downward := rfl
+example : ContextPolarity.compose .downward .downward = .upward := rfl
+example : ContextPolarity.compose .downward .upward = .downward := rfl
+
+/-! ### Path computations (§2.4)
+
+A position's signature is the monoid product along the path from root
+to target (his `pro(s(u)) = top(s) ∘ pro(u)`); the sentences are
+illustrations of the mechanism, not the paper's own examples. -/
+
+-- "animal" in *Every animal runs*: path = [◇] (every-restrictor)
+example : contextProjectivity [.antiAdd] = .antiAdd := rfl
+-- "runs" in *Every animal runs*: path = [⊞] (every-scope)
+example : contextProjectivity [.mult] = .mult := rfl
+-- "cat" in *No big cat runs*: path = [◇, ⊕⊞] — a morphism leaves ◇ intact
+example : contextProjectivity [.antiAdd, .addMult] = .antiAdd := rfl
+-- "runs" in *It's not the case that every animal runs*: [◇⊟, ⊞] = ⊟
+example : contextProjectivity [.antiAddMult, .mult] = .antiMult := rfl
+-- Double negation is a morphism …
+example : contextProjectivity [.antiAddMult, .antiAddMult] = .addMult := rfl
+-- … and hence an upward context
+example : toContextPolarity (contextProjectivity [.antiAddMult, .antiAddMult]) =
+    .upward := rfl
+
+/-! ### The negation signature
+
+*Not* is anti-additive and anti-multiplicative (p. 713); ⊖ is its own
+inverse — the only non-identity signature with one (p. 716). -/
+
+example : toContextPolarity negationSig = .downward := rfl
+example : negationSig * negationSig = .addMult := rfl
+example : negationSig ^ 2 = .addMult := rfl
+-- ◇⊟ is its own inverse up to the monoid identity on non-• signatures
+example : negationSig * negationSig * negationSig = negationSig := rfl
+example : negationSig * .mult = .antiMult := rfl
+-- not(not(every …))-scope: ⊟ ∘ ◇⊟ ∘ ◇⊟ = ⊟
+example : .antiMult * negationSig * negationSig = .antiMult := rfl
+
+end Icard2012


### PR DESCRIPTION
All 74 spot-check examples move out of `Logic/Natural/Basic.lean` into a paper-anchored `Studies/Icard2012.lean`, organized by the paper's own structure and verified against the actual PDF: the join table (Lemma 1.5, p. 710 — printed cells match the #2087-corrected table on all 25 entries), the projectivity tables (Lemma 2.4, p. 715), the composition table (Lemma 2.7, p. 716) with its §2.2 signature order, the polarity coarsening, and the p. 713 classification of *not* as the anti-morphism. Path-computation sentences are labeled as illustrations of the §2.4 mechanism, not the paper's own examples (its worked example is the §3.2 giant-squid fragment — a natural future extension). `Basic.lean` is now definitions and theorems only.

Full-library build clean (6672 jobs).