### PR TITLE
refactor(Logic/Natural): dissolve pnot aliases, cleanse StrawsonEntailment

### DIFF
--- a/Linglib/Core/Order/AntiAdditive.lean
+++ b/Linglib/Core/Order/AntiAdditive.lean
@@ -1,3 +1,4 @@
+import Mathlib.Order.BooleanAlgebra.Basic
 import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Data.Set.Basic
@@ -157,6 +158,34 @@ theorem isAntiAdditive_iff_isAdditive_toDual [SemilatticeSup α]
   Iff.rfl
 
 end HomBridges
+
+/-! ### Complementation -/
+
+section BooleanAlgebra
+
+variable {α : Type*} [BooleanAlgebra α]
+
+theorem isAntiAdditive_compl : IsAntiAdditive (compl : α → α) :=
+  fun _ _ => compl_sup
+
+theorem isAntiMultiplicative_compl : IsAntiMultiplicative (compl : α → α) :=
+  fun _ _ => compl_inf
+
+theorem isAntiMorphic_compl : IsAntiMorphic (compl : α → α) :=
+  ⟨isAntiAdditive_compl, isAntiMultiplicative_compl⟩
+
+theorem antitone_compl : Antitone (compl : α → α) :=
+  isAntiAdditive_compl.antitone
+
+theorem isCompletelyAntiAdditive_compl :
+    IsCompletelyAntiAdditive (compl : α → α) :=
+  ⟨isAntiAdditive_compl, compl_top⟩
+
+theorem isCompletelyAntiMultiplicative_compl :
+    IsCompletelyAntiMultiplicative (compl : α → α) :=
+  ⟨isAntiMultiplicative_compl, compl_bot⟩
+
+end BooleanAlgebra
 
 /-! ### Pointwise bridges
 

--- a/Linglib/Logic/Natural/Soundness.lean
+++ b/Linglib/Logic/Natural/Soundness.lean
@@ -300,41 +300,35 @@ end SoundFor
 
 /-! ### Worked instance: double negation is a morphism, semantically
 
-`pnot` is completely anti-additive and completely anti-multiplicative, so
-the `.antiAddMult` row is sound for it; composing it with itself certifies
-the enum fact `◇⊟ ∘ ◇⊟ = ⊕⊞` against the actual function `pnot ∘ pnot`. -/
+Complementation in a Boolean algebra is completely anti-additive and
+anti-multiplicative, so the `.antiAddMult` row is sound for it;
+composing it with itself certifies the enum fact `◇⊟ ∘ ◇⊟ = ⊕⊞` against
+the actual function `compl ∘ compl`. -/
 
-section PnotInstance
+section ComplInstance
 
 open Entailment
 
-theorem pnot_isCompletelyAntiAdditive : IsCompletelyAntiAdditive pnot :=
-  ⟨pnot_isAntiAdditive, by show (Set.univ : Set World)ᶜ = ∅; exact Set.compl_univ⟩
+variable {α : Type*} [BooleanAlgebra α]
 
-theorem pnot_isCompletelyAntiMultiplicative :
-    IsCompletelyAntiMultiplicative pnot :=
-  ⟨pnot_isAntiMultiplicative, by show (∅ : Set World)ᶜ = Set.univ; exact Set.compl_empty⟩
-
-/-- Negation realizes the anti-morphism row. -/
-theorem pnot_soundFor_antiAddMult :
-    Signature.SoundFor .antiAddMult pnot :=
-  soundFor_antiAddMult pnot_isCompletelyAntiAdditive
-    pnot_isCompletelyAntiMultiplicative
+/-- Complementation realizes the anti-morphism row. -/
+theorem compl_soundFor_antiAddMult :
+    Signature.SoundFor .antiAddMult (compl : α → α) :=
+  soundFor_antiAddMult isCompletelyAntiAdditive_compl
+    isCompletelyAntiMultiplicative_compl
 
 /-- Double negation realizes the morphism row — the composed-signature
 fact `◇⊟ ∘ ◇⊟ = ⊕⊞`, certified semantically rather than by enum table
 lookup. -/
-example : Signature.SoundFor .addMult (pnot ∘ pnot) :=
-  pnot_soundFor_antiAddMult.comp pnot_soundFor_antiAddMult
+example : Signature.SoundFor .addMult ((compl : α → α) ∘ compl) :=
+  compl_soundFor_antiAddMult.comp compl_soundFor_antiAddMult
 
 /-- Propositional negation realizes the anti-morphism row at the `Prop`
 instance. -/
 theorem not_soundFor_antiAddMult : Signature.SoundFor .antiAddMult Not :=
-  soundFor_antiAddMult
-    ⟨fun p q => propext not_or, by show (¬True) = False; simp⟩
-    ⟨fun p q => propext not_and_or, by show (¬False) = True; simp⟩
+  compl_soundFor_antiAddMult
 
-end PnotInstance
+end ComplInstance
 
 /-! ### Per-position profiles
 

--- a/Linglib/Logic/Natural/StrawsonEntailment.lean
+++ b/Linglib/Logic/Natural/StrawsonEntailment.lean
@@ -1,5 +1,4 @@
 import Mathlib.Order.Monotone.Defs
-import Linglib.Logic.Natural.World
 import Linglib.Core.Order.AntiAdditive
 import Linglib.Logic.Natural.World
 import Linglib.Semantics.Presupposition.Basic
@@ -23,7 +22,7 @@ take a polymorphic world type and the corresponding presupposition /
 ordering / modal-base parameters in their natural mathlib types
 (`Set W`, `W → Set W`, `W → Prop`). Concrete counterexamples (proofs of
 the form "X is *not* classically DE") are specialized to the 4-element
-`World` enum from `Entailment/Basic.lean` as a witness type, since
+`World` enum from `Logic/Natural/World.lean` as a witness type, since
 non-DE-ness is an *existence* claim about some inhabited domain.
 
 ## Hierarchy
@@ -36,9 +35,7 @@ namespace Entailment
 
 open Entailment
 
--- ============================================================================
--- §1 Core definitions (polymorphic)
--- ============================================================================
+/-! ### Strawson entailment -/
 
 /--
 **Strawson-DE** ([von-fintel-1999], Definition 14, p. 104).
@@ -69,9 +66,7 @@ def StrawsonValid {W : Type*} (premises : List (Set W)) (conclusion : Set W)
   presupSatisfied →
     (∀ w, (∀ p ∈ premises, p w) → conclusion w)
 
--- ============================================================================
--- §2 Hierarchy: classical → Strawson
--- ============================================================================
+/-! ### The classical-to-Strawson hierarchy -/
 
 /-- Classical DE implies Strawson-DE (for any definedness predicate).
     The `defined p w` hypothesis is simply ignored. Polymorphic over
@@ -80,24 +75,6 @@ theorem antitone_implies_strawsonDE {α β : Type*} (f : Set α → Set β)
     (hAnti : Antitone f) (defined : Set α → β → Prop) :
     IsStrawsonDE f defined :=
   fun _p _q hpq _w _hdef hfqw => hAnti hpq hfqw
-
-/-- Convenience: `Antitone` (the toy-`World` abbrev) implies
-    Strawson-DE. -/
-theorem de_implies_strawsonDE (f : Set World → Set World) (hDE : Antitone f)
-    (defined : Set World → World → Prop) : IsStrawsonDE f defined :=
-  antitone_implies_strawsonDE f hDE defined
-
-/-- Anti-additive ⇒ Strawson-DE. -/
-theorem antiAdditive_implies_strawsonDE (f : Set World → Set World)
-    (hAA : IsAntiAdditive f) (defined : Set World → World → Prop) :
-    IsStrawsonDE f defined :=
-  de_implies_strawsonDE f hAA.antitone defined
-
-/-- Anti-morphic ⇒ Strawson-DE. -/
-theorem antiMorphic_implies_strawsonDE (f : Set World → Set World)
-    (hAM : IsAntiMorphic f) (defined : Set World → World → Prop) :
-    IsStrawsonDE f defined :=
-  de_implies_strawsonDE f hAM.antitone defined
 
 /--
 **Strawson anti-additive** — the Strawson-relativized version of
@@ -151,22 +128,7 @@ theorem strawsonAA_implies_strawsonDE {W : Type*} (f : Set W → Set W)
   have hfunion : f (p ∪ q) w := by rw [hUnion]; exact hfqw
   exact (hAA p q w hdefp hdefq |>.mp hfunion).1
 
-/-- The full hierarchy: AM → AA → DE → Strawson-DE. -/
-structure FullHierarchy (f : Set World → Set World)
-    (defined : Set World → World → Prop) where
-  am : IsAntiMorphic f
-  aa : IsAntiAdditive f := am.1
-  de : Antitone f := aa.antitone
-  strawsonDE : IsStrawsonDE f defined := de_implies_strawsonDE f de defined
-
-/-- Negation satisfies the full hierarchy. -/
-def pnot_fullHierarchy (defined : Set World → World → Prop) :
-    FullHierarchy pnot defined :=
-  { am := pnot_isAntiMorphic }
-
--- ============================================================================
--- §3 `only` (Horn's asymmetric analysis; [horn-1996])
--- ============================================================================
+/-! ### `only` (Horn's asymmetric analysis; [horn-1996]) -/
 
 /-!
 ### `only`
@@ -293,9 +255,7 @@ theorem onlyFull_not_de : ¬ Antitone (onlyFull (· = World.w0)) := by
   rcases h with ⟨⟨_, _, hp_y⟩, _⟩
   exact hp_y
 
--- ============================================================================
--- §4 Adversative attitudes (vF §3, [heim-1992], [kadmon-landman-1993])
--- ============================================================================
+/-! ### Adversative attitudes ([heim-1992], [kadmon-landman-1993]) -/
 
 /-!
 ### Adversative/Factive Attitudes
@@ -337,22 +297,6 @@ def sorryFull {W : Type*} (dox : W → Set W) (bestOf : W → Set W)
 def gladFull {W : Type*} (dox : W → Set W) (bestOf : W → Set W)
     (p : Set W) : Set W :=
   fun w => (∀ w' ∈ dox w, p w') ∧ ∀ w' ∈ bestOf w, p w'
-
-/-- `glad` (von Fintel eq. 52, the replacement vF prefers over K&L eq. 50).
-    `α is glad that p` at `w` iff every belief world is strictly preferred
-    (under `lt` from the perspective of `w`) to every relevant non-`p`
-    world: i.e., `DOX(α, w) <_g (relevant w − p)`.
-
-    Both `gladFull` and `gladFullVF` are UE in `p`. They differ on cases
-    like vF's Honda-Civic example (p. 124): when the agent buys a Honda
-    Civic and discovers it's a lemon, the K&L version makes "I'm glad I
-    bought a Honda Civic" automatic from "I wanted a Honda Civic and got
-    one"; the vF version permits the reasonable "I wanted to but I'm not
-    glad I did" because the actual world is now worse than the belief
-    worlds at the time of evaluation. -/
-def gladFullVF {W : Type*} (dox : W → Set W) (relevant : W → Set W)
-    (lt : W → W → W → Prop) (p : Set W) : Set W :=
-  fun w => ∀ w₁ ∈ dox w, ∀ w₂ ∈ relevant w, ¬ p w₂ → lt w w₂ w₁
 
 /-- Ex. 28b (p. 111): `sorry` IS Strawson-DE in its complement.
     Definedness is doxastic factivity (`dox w ⊆ p`). Given doxastic
@@ -432,16 +376,7 @@ theorem gladFull_isUE {W : Type*} (dox bestOf : W → Set W) :
   obtain ⟨hdef, hAll⟩ := h
   exact ⟨fun w' hw' => hpq (hdef w' hw'), fun w' hw' => hpq (hAll w' hw')⟩
 
-/-- `glad` (vF eq. 52) is UE in its complement. -/
-theorem gladFullVF_isUE {W : Type*} (dox relevant : W → Set W)
-    (lt : W → W → W → Prop) : Monotone (gladFullVF dox relevant lt) := by
-  intro p q hpq w h w₁ hw₁ w₂ hw₂ hnq
-  -- ¬ q w₂ → ¬ p w₂ (contraposition of p ⊆ q)
-  exact h w₁ hw₁ w₂ hw₂ (fun hp => hnq (hpq hp))
-
--- ============================================================================
--- §5 Superlatives (vF §4.2)
--- ============================================================================
+/-! ### Superlatives -/
 
 /-!
 ### Superlatives
@@ -517,9 +452,7 @@ theorem superlative_isStrawsonAA {W : Type*} (α : W) :
         · exact hnp hp
         · exact hnq hq
 
--- ============================================================================
--- §6 Conditional antecedents (vF §4.1)
--- ============================================================================
+/-! ### Conditional antecedents -/
 
 /-!
 ### Conditional Antecedents
@@ -594,24 +527,7 @@ theorem wouldFull_isStrawsonAA {W : Type*} (domain : W → Set W) (q : Set W) :
       (fun p w => ∃ w' ∈ domain w, p w') :=
   antiAdditive_implies_strawsonAA _ (condNecessity_isAntiAdditive domain q) _
 
--- ============================================================================
--- §7 Bridge theorems (toy-`World` instantiations)
--- ============================================================================
-
-/-- Negation is Strawson-DE. -/
-theorem pnot_isStrawsonDE (defined : Set World → World → Prop) :
-    IsStrawsonDE pnot defined :=
-  de_implies_strawsonDE pnot pnot_antitone defined
-
-/-- "No student" is Strawson-DE. -/
-theorem no_student_isStrawsonDE (defined : Set World → World → Prop) :
-    IsStrawsonDE no_student defined :=
-  de_implies_strawsonDE no_student no_antitone_scope defined
-
-/-- "At most 2 students" is Strawson-DE. -/
-theorem atMost2_isStrawsonDE (defined : Set World → World → Prop) :
-    IsStrawsonDE atMost2_student defined :=
-  de_implies_strawsonDE atMost2_student atMost_antitone_scope defined
+/-! ### Strictness -/
 
 /-- Strawson-DE is *strictly* weaker than DE: `onlyFull` is the canonical
     witness — Strawson-DE without classical DE. -/
@@ -623,9 +539,7 @@ theorem strawsonDE_strictly_weaker_than_DE :
    onlyFull_isStrawsonDE _,
    onlyFull_not_de⟩
 
--- ============================================================================
--- §8 Additional operators (vF coverage gaps)
--- ============================================================================
+/-! ### Additional operators -/
 
 /-!
 ### `since` (Iatridou, vF §2.2 exs. 20-22)
@@ -683,75 +597,5 @@ abbrev amazedFull {W : Type*} := @sorryFull W
 
 /-- `surprised`: expectation-based adversative attitude. -/
 abbrev surprisedFull {W : Type*} := @sorryFull W
-
-/-!
-### `want` (vF §3.2 eq. 45, pp. 116-118)
-
-`α wants p` iff in `α`'s preferred worlds (drawn from a doxastic modal
-base `dox`), `p` holds. This is UE — the headline result vF defends in
-§3.2 against Asher (1987) / Heim (1992) non-monotonicity puzzles
-(Concorde, couch).
--/
-
-/-- `want(p)` denotation: in α's preferred worlds among `dox w`, `p` holds. -/
-def wantFull {W : Type*} (bestOf : W → Set W) (p : Set W) : Set W :=
-  fun w => ∀ w' ∈ bestOf w, p w'
-
-/-- `want` is upward entailing in its complement (vF §3.2 headline). -/
-theorem wantFull_isUE {W : Type*} (bestOf : W → Set W) :
-    Monotone (wantFull bestOf) := by
-  intro p q hpq w h w' hw'
-  exact hpq (h w' hw')
-
-/-!
-### `wish` (Iatridou; vF Curveball #1, pp. 127-129)
-
-`α wishes p` ≈ `α thinks: if p were the case, α would be glad that p`.
-Iatridou's analysis (eq. 59) embeds a counterfactual conditional inside
-the attitude, making `wish` non-monotonic in p. We do not formalize
-this analysis — its non-monotonicity is itself the puzzle vF flags as a
-threat to the K&L claim that `wish that p` ≡ `sorry that ¬p`.
-
-A simpler "wish ≡ sorry-of-negation" placeholder is recoverable as
-`fun p => sorryFull dox bestOf (compl p)`, which preserves DE-ness on
-the K&L side; this is what `wishFull_simple` below offers.
--/
-
-/-- A simplified `wish(p) ≡ sorry(¬p)` denotation (the K&L analysis vF
-    discusses on p. 126; Iatridou's counterfactual analysis is more
-    complex and breaks monotonicity — see module docstring). -/
-def wishFull_simple {W : Type*} (dox bestOf : W → Set W) (p : Set W) : Set W :=
-  sorryFull dox bestOf (fun w => ¬ p w)
-
-/-!
-### `IsWDE` — Asher 1987 Weakened Downward Entailment
-[asher-1987]
-
-vF p. 112 (footnote 8) cites Asher's WDE as a sibling of Strawson-DE.
-Asher's schema:
-
-  α regrets that φ
-  ⟦φ⟧ ⇒ ⟦ψ⟧
-  α believes that ψ
-  ⊢ α regrets that ψ
-
-This is the *upward* direction (φ → ψ) with a doxastic side condition
-on the conclusion's complement (`believes ψ`). Compare Strawson-DE,
-which is the *downward* direction with a presupposition side condition
-on the conclusion. The two schemas are not equivalent; vF (p. 112,
-footnote 8) writes "the intent of defining something like Strawson
-Entailment is clear" but the formal apparatus differs.
--/
-
-/-- Asher's WDE: f(p) plus belief in q implies f(q), when p ⊆ q. -/
-def IsWDE {W : Type*} (f : Set W → Set W) (believes : Set W → W → Prop) : Prop :=
-  ∀ p q : Set W, p ⊆ q → ∀ w, believes q w → f p w → f q w
-
-/-- Classical UE (Monotone) implies WDE: the doxastic side condition is
-    redundant when monotonicity already holds. -/
-theorem monotone_implies_WDE {W : Type*} (f : Set W → Set W)
-    (hMono : Monotone f) (believes : Set W → W → Prop) :
-    IsWDE f believes :=
-  fun _p _q hpq _w _hbel hfp => hMono hpq hfp
 
 end Entailment

--- a/Linglib/Logic/Natural/World.lean
+++ b/Linglib/Logic/Natural/World.lean
@@ -40,25 +40,17 @@ instance (p q : Set World) [DecidablePred (· ∈ p)] [DecidablePred (· ∈ q)]
     Decidable (entails p q) :=
   Fintype.decidableForallFintype
 
-/-- Negation: thin alias for set complement. -/
-def pnot : Set World → Set World := compl
-
-/-- Conjunction: thin alias for set intersection. -/
-def pand : Set World → Set World → Set World := (· ∩ ·)
-
-/-- Disjunction: thin alias for set union. -/
-def por : Set World → Set World → Set World := (· ∪ ·)
-
-instance (p : Set World) [DecidablePred (· ∈ p)] : DecidablePred (· ∈ pnot p) :=
-  fun w => inferInstanceAs (Decidable (¬ w ∈ p))
+instance (p : Set World) [DecidablePred (· ∈ p)] :
+    DecidablePred (· ∈ pᶜ) :=
+  fun w => inferInstanceAs (Decidable ¬(w ∈ p))
 
 instance (p q : Set World) [DecidablePred (· ∈ p)] [DecidablePred (· ∈ q)] :
-    DecidablePred (· ∈ pand p q) :=
-  fun w => inferInstanceAs (Decidable (w ∈ p ∧ w ∈ q))
-
-instance (p q : Set World) [DecidablePred (· ∈ p)] [DecidablePred (· ∈ q)] :
-    DecidablePred (· ∈ por p q) :=
+    DecidablePred (· ∈ p ∪ q) :=
   fun w => inferInstanceAs (Decidable (w ∈ p ∨ w ∈ q))
+
+instance (p q : Set World) [DecidablePred (· ∈ p)] [DecidablePred (· ∈ q)] :
+    DecidablePred (· ∈ p ∩ q) :=
+  fun w => inferInstanceAs (Decidable (w ∈ p ∧ w ∈ q))
 
 /-- Proposition true only in w0. -/
 def p0 : Set World := {.w0}
@@ -87,24 +79,6 @@ theorem p01_entails_p012 : entails p01 p012 := by decide
 /-! ### Toy-`World` witnesses -/
 
 section ToyWitnesses
-
-/-- Negation is anti-additive. -/
-theorem pnot_isAntiAdditive : IsAntiAdditive pnot := fun p q => by
-  show (p ∪ q)ᶜ = pᶜ ∩ qᶜ
-  exact Set.compl_union p q
-
-/-- Negation is anti-multiplicative. -/
-theorem pnot_isAntiMultiplicative : IsAntiMultiplicative pnot := fun p q => by
-  show (p ∩ q)ᶜ = pᶜ ∪ qᶜ
-  exact Set.compl_inter p q
-
-/-- Negation is anti-morphic. -/
-theorem pnot_isAntiMorphic : IsAntiMorphic pnot :=
-  ⟨pnot_isAntiAdditive, pnot_isAntiMultiplicative⟩
-
-/-- Negation is antitone (downward entailing). -/
-theorem pnot_antitone : Antitone pnot :=
-  pnot_isAntiAdditive.antitone
 
 /-- "No A is B" = ∀x. A(x) → ¬B(x). -/
 def no' (restr : Set World) (scope : Set World) : Set World :=
@@ -176,7 +150,7 @@ theorem atMost_not_antiAdditive :
   intro hAA
   have h := isAntiAdditive_iff_mem.mp hAA
   let qProp : Set World := λ w => w = .w1
-  have key : atMost1_student (por p0 qProp) .w0 ↔
+  have key : atMost1_student (p0 ∪ qProp) .w0 ↔
              atMost1_student p0 .w0 ∧ atMost1_student qProp .w0 :=
     h p0 qProp World.w0
   -- p0 has just w0 as a witness; ≤ 1 ✓
@@ -213,8 +187,8 @@ theorem atMost_not_antiAdditive :
         have hb : b = .w1 := hall_w1 b (List.mem_cons_of_mem _ (List.mem_cons_self ..))
         have : a ≠ b := List.ne_of_not_mem_cons (List.Nodup.notMem hnd)
         exact this (ha.trans hb.symm)
-  -- por p0 qProp has both w0 and w1 as witnesses; not ≤ 1
-  have hcontr : ¬ atMost1_student (por p0 qProp) .w0 := by
+  -- p0 ∪ qProp has both w0 and w1 as witnesses; not ≤ 1
+  have hcontr : ¬ atMost1_student (p0 ∪ qProp) .w0 := by
     intro hle
     have : ([World.w0, World.w1]).length ≤ 1 := by
       apply hle [.w0, .w1]

--- a/Linglib/Semantics/Polarity/Negation.lean
+++ b/Linglib/Semantics/Polarity/Negation.lean
@@ -10,7 +10,7 @@ This module unifies the scattered negation semantics in linglib into a
 coherent architecture with three layers:
 
 1. **NegOp** — a semantic negation operator bundling involution + antitonicity,
-   with `standardNeg` (`pnot`) as the canonical instance
+   with `standardNeg` (set complement) as the canonical instance
 2. **DEStrength ↔ PolarityLicensing bridge** — the entailment hierarchy
    (weak DE / anti-additive / anti-morphic) determines the polarity licensing
    profile, connecting the `Prop`-based semantic properties in
@@ -28,7 +28,7 @@ coherent architecture with three layers:
   propositional negation (no custom `pnot` wrapper)
 - `NaturalLogic` — `DEStrength` (weak/antiAdditive/antiMorphic)
 - `Entailment` — `IsAntiAdditive`,
-  `IsAntiMorphic`, `pnot_isAntiMorphic`
+  `IsAntiMorphic`, `isAntiMorphic_compl`
 -/
 
 namespace Negation
@@ -37,7 +37,6 @@ open Negation (ENType ENStrength PolarityLicensing PolarityClass
            weakENProfile strongENProfile standardNegProfile)
 open Polarity (DEStrength)
 open Entailment (World)
-open Entailment (pnot_isAntiAdditive pnot_isAntiMorphic)
 
 /-- Pointwise Bool negation on `W → Bool`. -/
 private def boolPnot (W : Type*) : (W → Bool) → (W → Bool) := fun p w => !p w
@@ -52,7 +51,7 @@ private def boolPnot (W : Type*) : (W → Bool) → (W → Bool) := fun p w => !
     - **Involution**: `¬¬p = p` (double negation elimination)
     - **Antitonicity**: `p ≤ q → ¬q ≤ ¬p` (downward entailment)
 
-    Standard sentential negation (`pnot`) satisfies both. Expletive
+    Standard sentential negation (set complement) satisfies both. Expletive
     negation that has lost its scope may fail antitonicity — it is
     then no longer a `NegOp` in this sense.
 
@@ -68,7 +67,7 @@ structure NegOp (W : Type*) where
   /-- Antitone: reverses the entailment ordering (= DE). -/
   antitone : Antitone op
 
-/-- Standard sentential negation (`pnot`) is the canonical `NegOp`.
+/-- Standard sentential negation (set complement) is the canonical `NegOp`.
 
     It satisfies involution (`pnot_pnot`), antitonicity
     (`pnot_antitone`), and additionally anti-morphism (De Morgan). -/

--- a/Linglib/Semantics/Polarity/Strength.lean
+++ b/Linglib/Semantics/Polarity/Strength.lean
@@ -32,7 +32,7 @@ the chain (`HoldsFor.of_le`).
 
 namespace Polarity
 
-open Entailment (pnot pnot_isAntiMorphic)
+
 
 /-! ### The hierarchies -/
 
@@ -97,10 +97,11 @@ theorem DEStrength.HoldsFor.of_le {α β : Type*}
       | exact hf.antiAdditive
       | exact absurd h (by decide)
 
-example : DEStrength.antiMorphic.HoldsFor pnot := pnot_isAntiMorphic
-example : DEStrength.weak.HoldsFor pnot :=
+example : DEStrength.antiMorphic.HoldsFor (compl : Set Bool → Set Bool) :=
+  isAntiMorphic_compl
+example : DEStrength.weak.HoldsFor (compl : Set Bool → Set Bool) :=
   DEStrength.HoldsFor.of_le (s₂ := .antiMorphic) (by decide)
-    pnot_isAntiMorphic
+    isAntiMorphic_compl
 
 end Polarity
 

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -20,7 +20,7 @@ derive-don't-stipulate rule.
 
 Coverage is incremental (`contextWitness?` is `Option`-valued): the
 witnessed rows are those whose operators exist in the zoo — negation
-(`pnot`), the quantifier rows (`every_sem`/`no_sem`/`few_sem` sections,
+(complementation), the quantifier rows (`every_sem`/`no_sem`/`few_sem` sections,
 `atMost2_student`), conditional antecedents (`condNecessity`), and the
 four Strawson-only rows (`onlyFull`, `sorryFull`, `superlativeAssert`,
 `sinceFull`). The `none` rows await operators (*without*, *deny*,
@@ -39,7 +39,7 @@ namespace Polarity
 
 open NaturalLogic
 open Quantification
-open Entailment (World pnot)
+open Entailment (World)
 open Entailment (atMost2_student atMost_antitone_scope)
 open Entailment
 
@@ -107,14 +107,14 @@ private theorem strength_of_mem_none {W : Type*} {β : Type*} [Lattice β]
 
 /-! ### Classical rows -/
 
-/-- Negation: `pnot` realizes the anti-morphism row. -/
+/-- Negation: complementation realizes the anti-morphism row. -/
 def negationWitness : ContextWitness .negation where
-  f := pnot
+  f := (compl : Set World → Set World)
   defined := fun _ => ⊤
-  strawson := pnot_soundFor_antiAddMult.strawsonSoundFor _
-  classical := soundFor_of_mem_some pnot_soundFor_antiAddMult
+  strawson := compl_soundFor_antiAddMult.strawsonSoundFor _
+  classical := soundFor_of_mem_some compl_soundFor_antiAddMult
   strength := strength_of_mem_some (s₀ := .antiMorphic) (by decide)
-    pnot_isAntiMorphic
+    isAntiMorphic_compl
 
 private theorem everyRestrictor_soundFor :
     Signature.SoundFor .antiAdd

--- a/Linglib/Studies/HeKaiserIskarous2025.lean
+++ b/Linglib/Studies/HeKaiserIskarous2025.lean
@@ -397,7 +397,7 @@ def negMeaningW : (HKIState → Bool) :=
   fun w => !(liftToWorlds .pos) w
 
 /-- Negation reverses entailment (DE property). -/
-theorem pnot_reverses_entailment_HKI (p q : (HKIState → Bool))
+theorem not_reverses_entailment_HKI (p q : (HKIState → Bool))
     (h : ∀ w, p w = true → q w = true) :
     ∀ w, (!q w) = true → (!p w) = true := by
   intro w hq
@@ -405,9 +405,10 @@ theorem pnot_reverses_entailment_HKI (p q : (HKIState → Bool))
   · rfl
   · exact absurd (h w hp) (by simpa using hq)
 
-/-- Negative sentences are downward-entailing: `pnot` is antitone. -/
-theorem neg_sentence_is_de : Antitone (pnot : Set World → Set World) :=
-  pnot_antitone
+/-- Negative sentences are downward-entailing: complementation is
+    antitone. -/
+theorem neg_sentence_is_de : Antitone (compl : Set World → Set World) :=
+  antitone_compl
 
 /-- Positive sentences are upward-entailing: the identity context. -/
 theorem pos_sentence_is_ue : Monotone (id : Set World → Set World) :=

--- a/Linglib/Studies/Lahiri1998.lean
+++ b/Linglib/Studies/Lahiri1998.lean
@@ -28,7 +28,7 @@ judged stimuli live in `Data/Examples/Lahiri1998.json`
 namespace Lahiri1998
 
 open Focus.Particles (evenPresup LikelihoodMonotone)
-open Entailment (World entails pnot)
+open Entailment (World entails)
 open Polarity
 open Data.Examples (LinguisticExample)
 
@@ -134,8 +134,8 @@ theorem ue_alt_entails_assertion :
 /-- DE pattern: the assertion entails all alternatives — EVEN is
 satisfiable. -/
 theorem de_assertion_entails_alt :
-    entails (pnot atLeastOne) (pnot atLeastTwo) ∧
-    entails (pnot atLeastOne) (pnot atLeastThree) := by
+    entails (atLeastOneᶜ) (atLeastTwoᶜ) ∧
+    entails (atLeastOneᶜ) (atLeastThreeᶜ) := by
   refine ⟨?_, ?_⟩
   · intro w hw hw'
     exact hw (two_entails_one hw')
@@ -150,19 +150,19 @@ theorem ue_not_reverse :
 
 /-- In DE the alternatives do NOT entail the assertion. -/
 theorem de_not_reverse :
-    ¬ entails (pnot atLeastTwo) (pnot atLeastOne) ∧
-    ¬ entails (pnot atLeastThree) (pnot atLeastOne) := by
+    ¬ entails (atLeastTwoᶜ) (atLeastOneᶜ) ∧
+    ¬ entails (atLeastThreeᶜ) (atLeastOneᶜ) := by
   refine ⟨?_, ?_⟩
   · intro h
-    have h1 : (.w2 : World) ∈ pnot atLeastTwo := by
-      simp [pnot, atLeastTwo, atLeastTwoB, Set.mem_compl_iff]
+    have h1 : (.w2 : World) ∈ atLeastTwoᶜ := by
+      simp [atLeastTwo, atLeastTwoB, Set.mem_compl_iff]
     have h2 := h h1
-    simp [pnot, atLeastOne, atLeastOneB] at h2
+    simp [atLeastOne, atLeastOneB] at h2
   · intro h
-    have h1 : (.w1 : World) ∈ pnot atLeastThree := by
-      simp [pnot, atLeastThree, atLeastThreeB, Set.mem_compl_iff]
+    have h1 : (.w1 : World) ∈ atLeastThreeᶜ := by
+      simp [atLeastThree, atLeastThreeB, Set.mem_compl_iff]
     have h2 := h h1
-    simp [pnot, atLeastOne, atLeastOneB] at h2
+    simp [atLeastOne, atLeastOneB] at h2
 
 end ImplicatureClash
 
@@ -196,8 +196,8 @@ theorem ekBhii_even_clash_UE
 the negated assertion entails each negated alternative (§7.4,
 eqs. 76–79). -/
 theorem ekBhii_even_ok_DE :
-    entails (pnot atLeastOne) (pnot atLeastTwo) ∧
-    entails (pnot atLeastOne) (pnot atLeastThree) :=
+    entails (atLeastOneᶜ) (atLeastTwoᶜ) ∧
+    entails (atLeastOneᶜ) (atLeastThreeᶜ) :=
   de_assertion_entails_alt
 
 /-! ### NPI data (§4, §6)

--- a/Linglib/Studies/TurkHirsch2026.lean
+++ b/Linglib/Studies/TurkHirsch2026.lean
@@ -28,7 +28,7 @@ predicting □p is a felicitous answer.
 ## The fix
 
 Category match restricts alternatives to items sharing *mI*'s UPOS tag
-`PART`. Polarity operators (Σ = `id`, NEG = `pnot`) are `PART`; "must"
+`PART`. Polarity operators (Σ = `id`, NEG = set complement) are `PART`; "must"
 is `AUX`. Category match yields {p, ¬p} — the correct polar question.
 
 ## Scenario

--- a/Linglib/Studies/VonFintel1999.lean
+++ b/Linglib/Studies/VonFintel1999.lean
@@ -49,6 +49,82 @@ namespace VonFintel1999
 
 open Entailment
 
+/-! ### `glad`, `want`, and Asher's weakened DE (single-consumer substrate) -/
+
+/-- `glad` (von Fintel eq. 52, the replacement vF prefers over K&L eq. 50).
+    `α is glad that p` at `w` iff every belief world is strictly preferred
+    (under `lt` from the perspective of `w`) to every relevant non-`p`
+    world: i.e., `DOX(α, w) <_g (relevant w − p)`.
+
+    Both `gladFull` and `gladFullVF` are UE in `p`. They differ on cases
+    like vF's Honda-Civic example (p. 124): when the agent buys a Honda
+    Civic and discovers it's a lemon, the K&L version makes "I'm glad I
+    bought a Honda Civic" automatic from "I wanted a Honda Civic and got
+    one"; the vF version permits the reasonable "I wanted to but I'm not
+    glad I did" because the actual world is now worse than the belief
+    worlds at the time of evaluation. -/
+def gladFullVF {W : Type*} (dox : W → Set W) (relevant : W → Set W)
+    (lt : W → W → W → Prop) (p : Set W) : Set W :=
+  fun w => ∀ w₁ ∈ dox w, ∀ w₂ ∈ relevant w, ¬ p w₂ → lt w w₂ w₁
+
+/-- `glad` (vF eq. 52) is UE in its complement. -/
+theorem gladFullVF_isUE {W : Type*} (dox relevant : W → Set W)
+    (lt : W → W → W → Prop) : Monotone (gladFullVF dox relevant lt) := by
+  intro p q hpq w h w₁ hw₁ w₂ hw₂ hnq
+  -- ¬ q w₂ → ¬ p w₂ (contraposition of p ⊆ q)
+  exact h w₁ hw₁ w₂ hw₂ (fun hp => hnq (hpq hp))
+
+/-!
+### `want` (vF §3.2 eq. 45, pp. 116-118)
+
+`α wants p` iff in `α`'s preferred worlds (drawn from a doxastic modal
+base `dox`), `p` holds. This is UE — the headline result vF defends in
+§3.2 against Asher (1987) / Heim (1992) non-monotonicity puzzles
+(Concorde, couch).
+-/
+
+/-- `want(p)` denotation: in α's preferred worlds among `dox w`, `p` holds. -/
+def wantFull {W : Type*} (bestOf : W → Set W) (p : Set W) : Set W :=
+  fun w => ∀ w' ∈ bestOf w, p w'
+
+/-- `want` is upward entailing in its complement (vF §3.2 headline). -/
+theorem wantFull_isUE {W : Type*} (bestOf : W → Set W) :
+    Monotone (wantFull bestOf) := by
+  intro p q hpq w h w' hw'
+  exact hpq (h w' hw')
+
+/-!
+### `IsWDE` — Asher 1987 Weakened Downward Entailment
+[asher-1987]
+
+vF p. 112 (footnote 8) cites Asher's WDE as a sibling of Strawson-DE.
+Asher's schema:
+
+  α regrets that φ
+  ⟦φ⟧ ⇒ ⟦ψ⟧
+  α believes that ψ
+  ⊢ α regrets that ψ
+
+This is the *upward* direction (φ → ψ) with a doxastic side condition
+on the conclusion's complement (`believes ψ`). Compare Strawson-DE,
+which is the *downward* direction with a presupposition side condition
+on the conclusion. The two schemas are not equivalent; vF (p. 112,
+footnote 8) writes "the intent of defining something like Strawson
+Entailment is clear" but the formal apparatus differs.
+-/
+
+/-- Asher's WDE: f(p) plus belief in q implies f(q), when p ⊆ q. -/
+def IsWDE {W : Type*} (f : Set W → Set W) (believes : Set W → W → Prop) : Prop :=
+  ∀ p q : Set W, p ⊆ q → ∀ w, believes q w → f p w → f q w
+
+/-- Classical UE (Monotone) implies WDE: the doxastic side condition is
+    redundant when monotonicity already holds. -/
+theorem monotone_implies_WDE {W : Type*} (f : Set W → Set W)
+    (hMono : Monotone f) (believes : Set W → W → Prop) :
+    IsWDE f believes :=
+  fun _p _q hpq _w _hbel hfp => hMono hpq hfp
+
+
 /-! ### *only* is Strawson-DE but not DE (§2)
 
 The licensing datum is `Examples.ex10`; the separation fails classically


### PR DESCRIPTION
Step A of the World-fixture retirement:

- `pnot`/`pand`/`por` (thin aliases for `ᶜ`/`∩`/`∪` that `Negation.lean`'s own docstring already ruled against) are deleted; the complementation algebra generalizes to a Boolean-algebra section in `Core/Order/AntiAdditive.lean` (`isAntiMorphic_compl` etc.), and `Soundness.lean`'s worked instance becomes `compl_soundFor_antiAddMult` over any Boolean algebra — the `Prop`-instance `not_soundFor_antiAddMult` is now the same theorem specialized.
- `StrawsonEntailment.lean`: the three consumer-less World-specialized hierarchy aliases, all of §7's bridge theorems, `FullHierarchy`, and `wishFull_simple` deleted; `wantFull`/`gladFullVF`/`IsWDE` demoted into `Studies/VonFintel1999` (sole consumer); strictness theorem kept; duplicate import, 16 banner sections, and a stale path mention fixed.
- Consumers swept: Witnesses (negation row is `compl` directly), Strength (examples at `Set Bool`), Negation, Lahiri1998 (`pnot X` → `Xᶜ`), HeKaiserIskarous2025, TurkHirsch2026.

Step B (next): retype the remaining World fixtures at `Bool` and delete the enum. Full-library build clean (6673 jobs).