### PR TITLE
feat(Logic/Natural): completeness of the relation algebra

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1629,6 +1629,7 @@ import Linglib.Core.Order.AntiAdditive
 import Linglib.Semantics.Alternatives.AsymStronger
 import Linglib.Semantics.Exhaustification.Extremum
 import Linglib.Logic.Natural.Basic
+import Linglib.Logic.Natural.Completeness
 import Linglib.Logic.Natural.Monotonicity.Defs
 import Linglib.Logic.Natural.Monotonicity.Structure
 import Linglib.Semantics.Quantification.Signatures

--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -74,8 +74,11 @@ inductive Atom where
 
 /-- The constraint set of a relation: each relation is the conjunction
 of its atoms (`≡` = `{le, ge}`, `^` = `{disjoint, codisjoint}`, `#` =
-`∅`), `≤` is reverse inclusion of constraint sets, and `Holds` (in
-`Logic/Natural/Soundness.lean`) is their conjunction. -/
+`∅`), `≤` is reverse inclusion of constraint sets, and `Holds` is their
+conjunction (`Relation.holds_iff` in `Logic/Natural/Soundness.lean`).
+Exactly the seven images are nondegenerately realizable among the
+sixteen subsets (`Relation.mem_range_constraints_iff` in
+`Logic/Natural/Completeness.lean`). -/
 def constraints : Relation → Finset Atom
   | .equiv => {.le, .ge}
   | .forward => {.le}
@@ -110,8 +113,10 @@ instance : OrderTop Relation where
 Join operation ⋈ ([icard-2012], Lemma 1.5): given `xRy` and `yR'z`, the
 strongest relation guaranteed between `x` and `z` — relation-algebra
 join, not lattice join. The table is derived from the non-strict
-`Holds` reading and certified cell-by-cell by `Relation.Holds.join`
-in `Logic/Natural/Soundness.lean`.
+`Holds` reading, certified sound cell-by-cell by `Relation.Holds.join`
+in `Logic/Natural/Soundness.lean`, and tight by `Relation.isLeast_join`
+in `Logic/Natural/Completeness.lean`: each cell is the least relation
+sound for the chaining.
 -/
 def join : Relation → Relation → Relation
   -- ≡ is the identity

--- a/Linglib/Logic/Natural/Completeness.lean
+++ b/Linglib/Logic/Natural/Completeness.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Logic.Natural.Soundness
+import Mathlib.Data.Finset.BooleanAlgebra
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Order.Bounds.Basic
+
+/-!
+# Completeness of the relation algebra
+[icard-2012] [maccartney-manning-2009]
+
+The converse halves that upgrade `Logic/Natural/Soundness.lean` from
+sound to complete. The join table is *tight* (`Relation.isLeast_join`,
+making [icard-2012]'s Lemma 1.5 an equality): `R.join S` is the least
+relation sound for chaining `R` then `S`, with countermodels already on
+the three-atom Boolean algebra `Finset (Fin 3)`. And the seven
+relations *classify* the nondegenerately realizable constraint
+conjunctions (`Relation.mem_range_constraints_iff`): of the sixteen
+subsets of `Relation.Atom`, the nine outside the range of `constraints`
+force an argument to `⊥` or `⊤` in every bounded lattice —
+[maccartney-manning-2009]'s nontrivial-denotation proviso, as a
+theorem.
+
+## Main declarations
+
+- `Relation.isLeast_join`: each join cell is the least sound chaining.
+- `Relation.mem_range_constraints_of_holds`: a constraint set realized
+  by a nondegenerate pair is one of the seven.
+- `Relation.mem_range_constraints_iff`: the classification, as an iff
+  against realizability on `Finset (Fin 3)`.
+-/
+
+namespace NaturalLogic
+
+/-! ### Tightness of the join table -/
+
+/-- **Tightness of the join table** ([icard-2012] Lemma 1.5 is an
+equality): `R.join S` is the least — strongest — relation sound for
+chaining `R` then `S`, already over the three-atom Boolean algebra.
+Soundness over any bounded distributive lattice is
+`Relation.Holds.join`; conversely any `T` sound on `Finset (Fin 3)`
+alone weakens the table entry. -/
+theorem Relation.isLeast_join (R S : Relation) :
+    IsLeast {T : Relation | ∀ x y z : Finset (Fin 3),
+      R.Holds x y → S.Holds y z → T.Holds x z} (R.join S) := by
+  refine ⟨λ x y z hR hS => hR.join hS, λ T hT => ?_⟩
+  by_contra hle
+  have h : ∀ R S T : Relation, ¬ R.join S ≤ T →
+      ∃ x y z : Finset (Fin 3), R.Holds x y ∧ S.Holds y z ∧ ¬ T.Holds x z := by
+    decide
+  obtain ⟨x, y, z, hR, hS, hT'⟩ := h R S T hle
+  exact hT' (hT x y z hR hS)
+
+/-! ### Why seven relations -/
+
+/-- Completeness half of the classification: a conjunction of atomic
+constraints satisfied by a nondegenerate pair, in any bounded lattice,
+is the constraint set of one of the seven relations. -/
+theorem Relation.mem_range_constraints_of_holds {α : Type*} [Lattice α]
+    [BoundedOrder α] {s : Finset Relation.Atom} {x y : α}
+    (h : ∀ a ∈ s, a.Holds x y) (hx : x ≠ ⊥) (hx' : x ≠ ⊤)
+    (hy : y ≠ ⊥) (hy' : y ≠ ⊤) :
+    s ∈ Set.range Relation.constraints := by
+  by_contra hs
+  have key : ∀ s : Finset Relation.Atom, (¬ ∃ R : Relation, R.constraints = s) →
+      ({.le, .disjoint} ⊆ s ∨ {.le, .codisjoint} ⊆ s ∨
+       {.ge, .disjoint} ⊆ s ∨ {.ge, .codisjoint} ⊆ s) := by decide
+  rcases key s (λ ⟨R, hR⟩ => hs ⟨R, hR⟩) with hp | hp | hp | hp
+  · exact hx ((h .disjoint (hp (by decide))).eq_bot_of_le (h .le (hp (by decide))))
+  · exact hy' ((h .codisjoint (hp (by decide))).eq_top_of_ge (h .le (hp (by decide))))
+  · exact hy ((h .disjoint (hp (by decide))).eq_bot_of_ge (h .ge (hp (by decide))))
+  · exact hx' ((h .codisjoint (hp (by decide))).eq_top_of_le (h .ge (hp (by decide))))
+
+/-- **Why seven**: of the sixteen conjunctions of atomic constraints,
+exactly the seven in the range of `constraints` are nondegenerately
+realizable — here already on the three-atom Boolean algebra; the other
+nine force an argument to `⊥` or `⊤` on every bounded lattice
+([maccartney-manning-2009]'s nontrivial-denotation proviso,
+[icard-2012] §1). -/
+theorem Relation.mem_range_constraints_iff {s : Finset Relation.Atom} :
+    s ∈ Set.range Relation.constraints ↔
+      ∃ x y : Finset (Fin 3), x ≠ ⊥ ∧ x ≠ ⊤ ∧ y ≠ ⊥ ∧ y ≠ ⊤ ∧
+        ∀ a ∈ s, a.Holds x y := by
+  constructor
+  · rintro ⟨R, rfl⟩
+    revert R; decide
+  · rintro ⟨x, y, hx, hx', hy, hy', h⟩
+    exact Relation.mem_range_constraints_of_holds h hx hx' hy hy'
+
+end NaturalLogic

--- a/Linglib/Logic/Natural/Soundness.lean
+++ b/Linglib/Logic/Natural/Soundness.lean
@@ -23,6 +23,8 @@ the enum become corollaries of facts about actual context functions.
 ## Main declarations
 
 - `Relation.Holds`: lattice content of the seven relations;
+- `Relation.holds_iff`: `Holds` is the conjunction of the `constraints`
+  atoms (`Relation.Atom.Holds`);
 - `Signature.SoundFor`: σ's projection row is sound for `f`;
 - `soundFor_mono_iff`, `soundFor_anti_iff`: the monotone rows, as iffs;
 - `soundFor_additive` … `soundFor_antiAddMult`: the algebraic rows, from
@@ -50,8 +52,8 @@ namespace NaturalLogic
 /-- The lattice content of a natural-logic relation ([icard-2012]
 Definition 1.2), in mathlib's complementation vocabulary: `negation` is
 `IsCompl`, `alternation` is `Disjoint`, `cover` is `Codisjoint`; `forward`
-is non-strict `≤` (the enum comments' `⊂` follows MacCartney's exclusive
-reading, which the projectivity tables do not need). -/
+is non-strict `≤` (MacCartney's exclusive reading takes it proper, which
+the projectivity tables do not need). -/
 def Relation.Holds {α : Type*} [Lattice α] [BoundedOrder α] :
     Relation → α → α → Prop
   | .equiv => (· = ·)
@@ -61,6 +63,45 @@ def Relation.Holds {α : Type*} [Lattice α] [BoundedOrder α] :
   | .alternation => Disjoint
   | .cover => Codisjoint
   | .independent => fun _ _ => True
+
+/-- The lattice content of an atomic constraint ([icard-2012]
+Definition 1.2). -/
+def Relation.Atom.Holds {α : Type*} [Lattice α] [BoundedOrder α] :
+    Relation.Atom → α → α → Prop
+  | .le => (· ≤ ·)
+  | .ge => (· ≥ ·)
+  | .disjoint => Disjoint
+  | .codisjoint => Codisjoint
+
+/-- A relation's content is the conjunction of its constraint atoms:
+`constraints` is the single source of truth for `Holds`. -/
+theorem Relation.holds_iff {α : Type*} [Lattice α] [BoundedOrder α]
+    {R : Relation} {x y : α} :
+    R.Holds x y ↔ ∀ a ∈ R.constraints, a.Holds x y := by
+  cases R <;>
+    simp [Relation.Holds, Relation.Atom.Holds, Relation.constraints,
+      isCompl_iff, le_antisymm_iff]
+
+instance Relation.Atom.decidableHolds {α : Type*} [Lattice α] [BoundedOrder α]
+    [DecidableEq α] [DecidableLE α] :
+    ∀ (a : Relation.Atom) (x y : α), Decidable (a.Holds x y)
+  | .le, x, y => inferInstanceAs (Decidable (x ≤ y))
+  | .ge, x, y => inferInstanceAs (Decidable (y ≤ x))
+  | .disjoint, x, y => decidable_of_iff (x ⊓ y = ⊥) disjoint_iff.symm
+  | .codisjoint, x, y => decidable_of_iff (x ⊔ y = ⊤) codisjoint_iff.symm
+
+instance Relation.decidableHolds {α : Type*} [Lattice α] [BoundedOrder α]
+    [DecidableEq α] [DecidableLE α] :
+    ∀ (R : Relation) (x y : α), Decidable (R.Holds x y)
+  | .equiv, x, y => inferInstanceAs (Decidable (x = y))
+  | .forward, x, y => inferInstanceAs (Decidable (x ≤ y))
+  | .reverse, x, y => inferInstanceAs (Decidable (y ≤ x))
+  | .negation, x, y =>
+      decidable_of_iff (x ⊓ y = ⊥ ∧ x ⊔ y = ⊤)
+        (by rw [← disjoint_iff, ← codisjoint_iff]; exact isCompl_iff.symm)
+  | .alternation, x, y => decidable_of_iff (x ⊓ y = ⊥) disjoint_iff.symm
+  | .cover, x, y => decidable_of_iff (x ⊔ y = ⊤) codisjoint_iff.symm
+  | .independent, _, _ => .isTrue trivial
 
 /-! ### Join soundness -/
 

--- a/Linglib/Studies/Icard2012.lean
+++ b/Linglib/Studies/Icard2012.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Logic.Natural.Basic
+import Linglib.Logic.Natural.Completeness
 
 /-!
 # [icard-2012]: Inclusion and Exclusion in Natural Language
@@ -11,7 +11,8 @@ import Linglib.Logic.Natural.Basic
 Table verifications for [icard-2012]'s relation algebra against the
 substrate implementations in `Logic/Natural/Basic.lean`: the join table
 (Lemma 1.5, p. 710 — the printed cells, independently certified against
-the non-strict `Holds` reading by `Relation.Holds.join`), the
+the non-strict `Holds` reading by `Relation.Holds.join` and tight by
+`Relation.isLeast_join`), the
 projectivity tables (Lemma 2.4, p. 715), the composition table
 (Lemma 2.7, p. 716) with its signature order (§2.2), the polarity
 coarsening, the classification of *not* as the anti-morphism (p. 713),
@@ -33,6 +34,11 @@ example : join .alternation .negation = .forward := rfl  -- | ⋈ ^ = ⊑
 example : join .negation .forward = .cover := rfl        -- ^ ⋈ ⊑ = ⌣
 example : join .forward .negation = .alternation := rfl  -- ⊑ ⋈ ^ = |
 example : join .cover .negation = .reverse := rfl        -- ⌣ ⋈ ^ = ⊒
+
+-- Lemma 1.5 is an equality: each printed cell is the *least* sound relation.
+example : IsLeast {T : Relation | ∀ x y z : Finset (Fin 3),
+    Relation.Holds .forward x y → Relation.Holds .negation y z → T.Holds x z}
+    .alternation := Relation.isLeast_join .forward .negation
 
 /-! ### The refinement order (§2.2) -/
 


### PR DESCRIPTION
Upgrades the relation algebra from sound to model-theoretically complete (design reviewed and kernel-validated against the worktree before landing):

- `Relation.isLeast_join`: the join table is *tight* — [icard-2012]'s Lemma 1.5 as an equality. Each cell is the least relation sound for the chaining, with countermodels a kernel `decide` over the three-atom Boolean algebra `Finset (Fin 3)` (covering incomparable candidates via `¬ ≤`, not just strict strengthenings).
- `Relation.mem_range_constraints_iff`: **why seven** — of the sixteen conjunctions of the four constraint atoms, exactly the seven in `constraints`' range are nondegenerately realizable; the other nine collapse in every bounded lattice via `Disjoint.eq_bot_of_le` and its three duals ([maccartney-manning-2009]'s nontrivial-denotation proviso, as a theorem).
- `Soundness.lean` gains the generic API at zero import cost: `Relation.Atom.Holds`, `Relation.holds_iff` (`constraints` is now the proved single source of truth for `Holds`), and decidability instances for `Holds`.
- Witness-algebra imports are quarantined in the new `Completeness.lean` so `Soundness.lean`'s lean cone is unchanged; `Studies/Icard2012.lean` records the tightness with a consuming spot-check.