### PR TITLE
feat(Logic/Natural): relation monoid, projection action, join characterization

### DIFF
--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -2,6 +2,7 @@ import Mathlib.Data.Finset.Basic
 import Mathlib.Order.BoundedOrder.Basic
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Algebra.BigOperators.Group.List.Defs
+import Mathlib.Algebra.Group.Action.Defs
 import Mathlib.Data.Nat.Basic
 
 /-!
@@ -28,7 +29,8 @@ theorems for projection.
 ## Main declarations
 
 * `Relation`, `Relation.join`, `Relation.constraints` — the
-  relation algebra, ordered by reverse constraint inclusion.
+  relation algebra: a monoid under `join`, ordered by reverse
+  constraint inclusion.
 * `Signature`, `Signature.project`, `Signature.compose` —
   signatures, projection, and the composition monoid.
 * `Signature.contextProjectivity` — a position's signature as the
@@ -120,7 +122,10 @@ join, not lattice join. The table is derived from the non-strict
 `Holds` reading, certified sound cell-by-cell by `Relation.Holds.join`
 in `Logic/Natural/Soundness.lean`, and tight by `Relation.isLeast_join`
 in `Logic/Natural/Completeness.lean`: each cell is the least relation
-sound for the chaining.
+sound for the chaining ([icard-2012]'s Definition 1.4;
+[maccartney-manning-2009]'s §3 join is instead exact relation
+composition, valued in *union relations* outside the seven on 17 of
+the 49 cells — this table is its best single-relation weakening).
 -/
 def join : Relation → Relation → Relation
   -- ≡ is the identity
@@ -164,15 +169,24 @@ def join : Relation → Relation → Relation
   -- # column
   | .independent, _ => .independent
 
-/-- ≡ is the identity for join. -/
-theorem join_identity_left (r : Relation) : join .equiv r = r := by
-  cases r <;> rfl
+instance : Mul Relation := ⟨join⟩
+instance : One Relation := ⟨.equiv⟩
 
-theorem join_identity_right (r : Relation) : join r .equiv = r := by
-  cases r <;> rfl
+/-- The relations form a monoid under ⋈ with identity `≡`. The identity
+and absorption laws are printed in [icard-2012] (p. 710); associativity
+appears in neither [icard-2012] nor [maccartney-manning-2009] and is
+verified here by kernel `decide`. Not commutative: `^ ⋈ ⌣ = ⊑` but
+`⌣ ⋈ ^ = ⊒` (chaining is directional). -/
+instance : Monoid Relation where
+  mul_assoc := by decide
+  one_mul r := by cases r <;> rfl
+  mul_one r := by cases r <;> rfl
 
--- Note: join is NOT commutative. E.g., ^⋈⌣ = ⊑ but ⌣⋈^ = ⊒.
--- This is expected: xRy and yR'z is directional.
+/-- `#` absorbs on the left ([icard-2012] p. 710). -/
+@[simp] theorem top_mul (r : Relation) : ⊤ * r = ⊤ := by cases r <;> rfl
+
+/-- `#` absorbs on the right ([icard-2012] p. 710). -/
+@[simp] theorem mul_top (r : Relation) : r * ⊤ = ⊤ := by cases r <;> rfl
 
 end Relation
 
@@ -509,6 +523,17 @@ theorem projection_composition (R : Relation) (φ ψ : Signature) :
     Signature.project (Signature.project R φ) ψ =
     Signature.project R (Signature.compose ψ φ) := by
   cases R <;> cases φ <;> cases ψ <;> rfl
+
+instance : SMul Signature Relation := ⟨λ σ R => Signature.project R σ⟩
+
+@[simp] theorem Signature.smul_def (σ : Signature) (R : Relation) :
+    σ • R = Signature.project R σ := rfl
+
+/-- Projection is an action of the signature monoid on the relations:
+`projection_composition` is the `mul_smul` law. -/
+instance : MulAction Signature Relation where
+  one_smul := by decide
+  mul_smul ψ φ R := (projection_composition R φ ψ).symm
 
 /-! ### The negation signature -/
 

--- a/Linglib/Logic/Natural/Completeness.lean
+++ b/Linglib/Logic/Natural/Completeness.lean
@@ -21,16 +21,21 @@ relations *classify* the nondegenerately realizable constraint
 conjunctions (`Relation.mem_range_constraints_iff`): of the sixteen
 subsets of `Relation.Atom`, the nine outside the range of `constraints`
 force an argument to `⊥` or `⊤` in every bounded lattice —
-[maccartney-manning-2009]'s nontrivial-denotation proviso, as a
-theorem.
+[maccartney-manning-2009] §2's sixteen-class partition, following
+Sánchez Valencia, with its nine degenerate classes, as a theorem. Its
+corollary `Relation.exists_isLeast_holds` is [icard-2012]'s Lemma 1.3:
+nondegenerate pairs stand in a strongest relation.
 
 ## Main declarations
 
-- `Relation.isLeast_join`: each join cell is the least sound chaining.
+- `Relation.isLeast_join`, `Relation.join_le_iff`: each join cell is
+  the least sound chaining ([icard-2012] Definition 1.4).
 - `Relation.mem_range_constraints_of_holds`: a constraint set realized
   by a nondegenerate pair is one of the seven.
 - `Relation.mem_range_constraints_iff`: the classification, as an iff
   against realizability on `Finset (Fin 3)`.
+- `Relation.exists_isLeast_holds`: Icard's Lemma 1.3, on any bounded
+  lattice.
 -/
 
 namespace NaturalLogic
@@ -89,5 +94,33 @@ theorem Relation.mem_range_constraints_iff {s : Finset Relation.Atom} :
     revert R; decide
   · rintro ⟨x, y, hx, hx', hy, hy', h⟩
     exact Relation.mem_range_constraints_of_holds h hx hx' hy hy'
+
+/-! ### The join characterization and the strongest relation -/
+
+/-- [icard-2012]'s Definition 1.4 as a characterization: `R.join S ≤ T`
+exactly when chaining `R`'s content with `S`'s lands inside `T`'s —
+soundness and tightness in one iff, the `sup_le_iff` idiom. -/
+theorem Relation.join_le_iff {R S T : Relation} :
+    R.join S ≤ T ↔
+      ∀ x y z : Finset (Fin 3), R.Holds x y → S.Holds y z → T.Holds x z :=
+  ⟨λ h _ _ _ hR hS => (hR.join hS).of_le h, λ h => (Relation.isLeast_join R S).2 h⟩
+
+/-- [icard-2012]'s Lemma 1.3: any two elements distinct from `⊥` and `⊤`
+stand in a strongest natural-logic relation — stated there for Boolean
+lattices, proved here for any bounded lattice. It fails at `⊥`/`⊤`:
+`x ⌣ ⊤` and `x ⊑ ⊤` hold with no common strengthening. -/
+theorem Relation.exists_isLeast_holds {α : Type*} [Lattice α] [BoundedOrder α]
+    {x y : α} (hx : x ≠ ⊥) (hx' : x ≠ ⊤) (hy : y ≠ ⊥) (hy' : y ≠ ⊤) :
+    ∃ R : Relation, IsLeast {S : Relation | S.Holds x y} R := by
+  classical
+  obtain ⟨R, hR⟩ := Relation.mem_range_constraints_of_holds
+    (s := Finset.univ.filter (λ a => a.Holds x y))
+    (λ a ha => (Finset.mem_filter.mp ha).2) hx hx' hy hy'
+  refine ⟨R, Relation.holds_iff.mpr (λ a ha => ?_),
+    λ S hS => Relation.le_iff.mpr (λ a ha => ?_)⟩
+  · rw [hR] at ha
+    exact (Finset.mem_filter.mp ha).2
+  · rw [hR]
+    exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, Relation.holds_iff.mp hS a ha⟩
 
 end NaturalLogic

--- a/Linglib/Studies/Icard2012.lean
+++ b/Linglib/Studies/Icard2012.lean
@@ -35,6 +35,10 @@ example : join .negation .forward = .cover := rfl        -- ^ ⋈ ⊑ = ⌣
 example : join .forward .negation = .alternation := rfl  -- ⊑ ⋈ ^ = |
 example : join .cover .negation = .reverse := rfl        -- ⌣ ⋈ ^ = ⊒
 
+-- Printed below the table: ≡ ⋈ R = R = R ⋈ ≡ and # ⋈ R = # = R ⋈ #.
+example : ∀ R : Relation, 1 * R = R ∧ R * 1 = R := by decide
+example : ∀ R : Relation, ⊤ * R = ⊤ ∧ R * ⊤ = ⊤ := by decide
+
 -- Lemma 1.5 is an equality: each printed cell is the *least* sound relation.
 example : IsLeast {T : Relation | ∀ x y z : Finset (Fin 3),
     Relation.Holds .forward x y → Relation.Holds .negation y z → T.Holds x z}


### PR DESCRIPTION
Surfaces the algebraic structure of the relation calculus, checked against both source papers (Icard 2012 read in full; MacCartney–Manning 2009 §§2–3 fetched and read):

- `Monoid Relation`: ⋈ is associative — printed in neither source ([icard-2012] p. 710 prints only the identity and absorption laws; [maccartney-manning-2009]'s §3 join is exact relation composition, valued in *union relations* on 17 of 49 cells, a different operation) — verified by kernel `decide`. `top_mul`/`mul_top` capture the printed absorption; `join_identity_left/right` dissolve into the instance.
- `MulAction Signature Relation`: projection is an action of the signature monoid — `projection_composition` is the `mul_smul` law.
- `Relation.join_le_iff`: [icard-2012]'s Definition 1.4 as a single characterization (the `sup_le_iff` idiom), packaging soundness and tightness.
- `Relation.exists_isLeast_holds`: [icard-2012]'s Lemma 1.3 — nondegenerate pairs stand in a strongest relation — generalized from Boolean to bounded lattices, as a corollary of the classification.
- Docstrings now draw the Icard-vs-MacCartney join distinction and credit the sixteen-class partition to [maccartney-manning-2009] §2 (after Sánchez Valencia); the Icard2012 study spot-checks the printed identity/absorption laws.