### PR TITLE
docs(Logic/Natural): module docstrings to references sections

### DIFF
--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -7,37 +7,49 @@ import Mathlib.Data.Nat.Basic
 
 /-!
 # The natural-logic relation algebra
-[icard-2012] [maccartney-manning-2009]
 
 The seven natural-logic relations (≡ ⊑ ⊒ ^ | ⌣ #) and the nine
 entailment signatures of [icard-2012], with the operations that run the
-calculus: `join` chains relations, `project` pushes a relation through a
-function of known signature, and `compose` — derived from `project` by
-probing, so `projection_composition` holds by construction — makes the
-signatures a monoid (identity `addMult`, `all` absorbing). Relations
-are read non-strictly: each is the conjunction of its `constraints`
-atoms, so distinct relations overlap and `≤` compares strength;
-[maccartney-manning-2009]'s seven mutually exclusive relations are the
-strict refinements. Both
-implication orders arise as reverse inclusion of constraint sets via
-`PartialOrder.lift`, with `#` (resp. `•`) at top and no bottom (`≡`
-does not entail the exclusion relations). Semantic
-certification lives in `Logic/Natural/Soundness.lean`:
-`Relation.Holds.join` for the join table, the `soundFor_*` row
-theorems for projection.
+calculus: `join` chains relations, `project` pushes a relation through
+a function of known signature, and `compose` — derived from `project`
+by probing, so `projection_composition` holds by construction — makes
+the signatures a monoid (identity `addMult`, `all` absorbing). `join`
+makes the relations one (identity `equiv`, `independent` absorbing;
+associativity is printed in neither source), and projection is an
+action of the signature monoid on the relations.
+
+Relations are read non-strictly: each is the conjunction of its
+`constraints` atoms, so distinct relations overlap and `≤` compares
+strength; [maccartney-manning-2009]'s seven mutually exclusive
+relations are the strict refinements. Both implication orders arise as
+reverse inclusion of constraint sets via `PartialOrder.lift`, with `#`
+(resp. `•`) at top and no bottom (`≡` does not entail the exclusion
+relations). Semantic certification lives in
+`Logic/Natural/Soundness.lean` (`Relation.Holds.join`, the `soundFor_*`
+rows) and `Logic/Natural/Completeness.lean` (tightness and the
+classification of the seven).
 
 ## Main declarations
 
-* `Relation`, `Relation.join`, `Relation.constraints` — the
-  relation algebra: a monoid under `join`, ordered by reverse
-  constraint inclusion.
-* `Signature`, `Signature.project`, `Signature.compose` —
-  signatures, projection, and the composition monoid.
+* `Relation`, `Relation.join`, `Relation.constraints` — the relation
+  algebra: a monoid under `join`, ordered by reverse constraint
+  inclusion.
+* `Signature`, `Signature.project`, `Signature.compose` — signatures,
+  projection, and the composition monoid; projection is a
+  `MulAction Signature Relation`.
 * `Signature.contextProjectivity` — a position's signature as the
   monoid product along its path.
-* `ContextPolarity`, `Signature.toContextPolarity` — the coarse
-  UE/DE quotient, a monoid homomorphism target
+* `ContextPolarity`, `Signature.toContextPolarity` — the coarse UE/DE
+  quotient, a monoid homomorphism target
   (`toContextPolarity_compose`).
+
+## References
+
+* [icard-2012] — the projectivity calculus: the relations, signatures,
+  and tables this file implements.
+* [maccartney-manning-2009] — the extended natural-logic model; its
+  §3 join is exact relation composition, union-valued outside the
+  seven.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Completeness.lean
+++ b/Linglib/Logic/Natural/Completeness.lean
@@ -10,7 +10,6 @@ import Mathlib.Order.Bounds.Basic
 
 /-!
 # Completeness of the relation algebra
-[icard-2012] [maccartney-manning-2009]
 
 The converse halves that upgrade `Logic/Natural/Soundness.lean` from
 sound to complete. The join table is *tight* (`Relation.isLeast_join`,
@@ -36,6 +35,12 @@ nondegenerate pairs stand in a strongest relation.
   against realizability on `Finset (Fin 3)`.
 - `Relation.exists_isLeast_holds`: Icard's Lemma 1.3, on any bounded
   lattice.
+
+## References
+
+* [icard-2012] — Definition 1.4, Lemmas 1.3 and 1.5.
+* [maccartney-manning-2009] — §2's sixteen-class partition, following
+  Sánchez Valencia.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Monotonicity/Defs.lean
+++ b/Linglib/Logic/Natural/Monotonicity/Defs.lean
@@ -9,7 +9,6 @@ import Mathlib.Order.Lattice
 
 /-!
 # Marked types for the monotonicity calculus
-[icard-moss-tune-2017]
 
 The type system of the [icard-moss-tune-2017] monotonicity calculus:
 simple types over a set of base types, with each arrow *marked* as
@@ -30,6 +29,10 @@ Definition 3.3).
   `DecidableEq` base.
 * `Ty.sup?` — the partial join of compatible types.
 * `Ty.unmark` — erase the markings along the codomain spine.
+
+## References
+
+* [icard-moss-tune-2017] — Definitions 3.1–3.3.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Monotonicity/Structure.lean
+++ b/Linglib/Logic/Natural/Monotonicity/Structure.lean
@@ -9,7 +9,6 @@ import Mathlib.Order.Hom.Basic
 
 /-!
 # Domains for the monotonicity calculus
-[icard-moss-tune-2017]
 
 The functional structures of the [icard-moss-tune-2017] monotonicity
 calculus: each marked type is interpreted as a preordered domain — base
@@ -25,6 +24,10 @@ in `≤` (their Definition 3.5's coherence conditions, here theorems).
 * `Ty.castLE` — the coercion along subtyping: the identity on base
   types, conjugation by the inner coercions on arrows.
 * `Ty.castLE_rfl`, `Ty.castLE_castLE` — the functor laws.
+
+## References
+
+* [icard-moss-tune-2017] — Definitions 3.5–3.6.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Soundness.lean
+++ b/Linglib/Logic/Natural/Soundness.lean
@@ -42,6 +42,10 @@ implication) and `Signature.SoundFor.of_le` (a more specific
 signature's soundness implies a less specific one's), via the projection
 monotonicity `Signature.project_mono`. `soundFor_all` holds
 unconditionally — every function realizes the no-property row.
+
+## References
+
+* [icard-2012] — Definitions 1.2 and 2.3, Lemmas 1.6 and 2.5.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Strawson/Basic.lean
+++ b/Linglib/Logic/Natural/Strawson/Basic.lean
@@ -3,8 +3,7 @@ import Linglib.Core.Order.AntiAdditive
 import Linglib.Semantics.Presupposition.Basic
 
 /-!
-# Strawson Entailment
-[von-fintel-1999] [strawson-1952]
+# Strawson entailment
 
 Strawson-DE: a weakened downward entailingness that checks DE inferences
 only when presuppositions of the conclusion are satisfied. This rescues
@@ -27,6 +26,12 @@ non-DE-ness is an *existence* claim about some inhabited domain.
 
 AM ⊂ AA ⊂ DE ⊂ Strawson-DE (each strict — see
 `strawsonDE_strictly_weaker_than_DE`).
+
+## References
+
+* [von-fintel-1999] — Strawson entailment and the four licensor case
+  studies.
+* [strawson-1952] — the presuppositional notion of entailment.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Strawson/Soundness.lean
+++ b/Linglib/Logic/Natural/Strawson/Soundness.lean
@@ -32,6 +32,11 @@ Strawson-ly while failing it classically.
 Composing definedness along a path is presupposition projection and is
 deliberately not attempted here — its home is a bridge to
 `Semantics/Presupposition/`, not an ad-hoc operator.
+
+## References
+
+* [von-fintel-1999] — the Strawson move.
+* [gajewski-2011] — the symmetric definedness gate.
 -/
 
 namespace NaturalLogic


### PR DESCRIPTION
Directory-wide docstring register pass: the bare `[key]` blocks under module titles move to `## References` sections (mathlib register), with brief locators verified against the papers this session; `Soundness.lean` and `Strawson/Soundness.lean` gain matching sections. `Basic.lean`'s module doc also absorbs the relation-monoid/action sentence that a #2100 edit silently missed, and `Strawson Entailment` drops to sentence case.