### PR TITLE
docs(Logic/Natural): module docstrings to mathlib voice

### DIFF
--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -8,48 +8,52 @@ import Mathlib.Data.Nat.Basic
 /-!
 # The natural-logic relation algebra
 
-The seven natural-logic relations (≡ ⊑ ⊒ ^ | ⌣ #) and the nine
-entailment signatures of [icard-2012], with the operations that run the
-calculus: `join` chains relations, `project` pushes a relation through
-a function of known signature, and `compose` — derived from `project`
-by probing, so `projection_composition` holds by construction — makes
-the signatures a monoid (identity `addMult`, `all` absorbing). `join`
-makes the relations one (identity `equiv`, `independent` absorbing;
-associativity is printed in neither source), and projection is an
-action of the signature monoid on the relations.
+This file defines the seven natural-logic relations between
+denotations (≡, ⊑, ⊒, ^, |, ⌣, #) and the nine entailment signatures
+of [icard-2012], with the operations of the projectivity calculus:
+chaining two relations, projecting a relation through a function of
+known signature, and composing signatures.
 
-Relations are read non-strictly: each is the conjunction of its
-`constraints` atoms, so distinct relations overlap and `≤` compares
-strength; [maccartney-manning-2009]'s seven mutually exclusive
-relations are the strict refinements. Both implication orders arise as
-reverse inclusion of constraint sets via `PartialOrder.lift`, with `#`
-(resp. `•`) at top and no bottom (`≡` does not entail the exclusion
-relations). Semantic certification lives in
-`Logic/Natural/Soundness.lean` (`Relation.Holds.join`, the `soundFor_*`
-rows) and `Logic/Natural/Completeness.lean` (tightness and the
-classification of the seven).
+A relation is read non-strictly, as the conjunction of its constraint
+atoms: distinct relations overlap, and `R ≤ R'` iff `R` entails `R'`,
+by reverse inclusion of constraint sets. The mutually exclusive seven
+of [maccartney-manning-2009] are the strict refinements. Signatures
+are ordered likewise by reverse inclusion of property sets; `#` and
+`•` are the tops, and there is no bottom.
 
 ## Main declarations
 
-* `Relation`, `Relation.join`, `Relation.constraints` — the relation
-  algebra: a monoid under `join`, ordered by reverse constraint
-  inclusion.
-* `Signature`, `Signature.project`, `Signature.compose` — signatures,
-  projection, and the composition monoid; projection is a
-  `MulAction Signature Relation`.
-* `Signature.contextProjectivity` — a position's signature as the
+* `Relation`: the seven relations, a monoid under `Relation.join` with
+  identity `equiv` and absorbing element `independent`.
+* `Relation.constraints`: a relation as a conjunction of atomic
+  lattice constraints; the source of the implication order.
+* `Signature`: the nine signatures, a monoid under `Signature.compose`
+  with identity `addMult` and absorbing element `all`.
+* `Signature.project`: projection of a relation through a signature —
+  an action of the signature monoid on the relations
+  (`MulAction Signature Relation`).
+* `Signature.contextProjectivity`: the signature of a position, as the
   monoid product along its path.
-* `ContextPolarity`, `Signature.toContextPolarity` — the coarse UE/DE
-  quotient, a monoid homomorphism target
-  (`toContextPolarity_compose`).
+* `ContextPolarity`: the coarse upward/downward quotient, a monoid
+  homomorphism target (`toContextPolarity_compose`).
+
+## Implementation notes
+
+`compose` is derived from `project` by probing at the relations
+`forward` and `negation`, so `projection_composition` holds by
+construction. Associativity of `join` is printed in neither source and
+is verified by `decide`. The tables are certified semantically in
+`Logic/Natural/Soundness.lean` (`Relation.Holds.join`, the
+`soundFor_*` rows) and shown tight in
+`Logic/Natural/Completeness.lean`, which also derives the seven
+relations as the nondegenerately realizable constraint conjunctions.
 
 ## References
 
 * [icard-2012] — the projectivity calculus: the relations, signatures,
   and tables this file implements.
-* [maccartney-manning-2009] — the extended natural-logic model; its
-  §3 join is exact relation composition, union-valued outside the
-  seven.
+* [maccartney-manning-2009] — the extended natural-logic model; its §3
+  join is exact relation composition, union-valued outside the seven.
 -/
 
 namespace NaturalLogic

--- a/Linglib/Logic/Natural/Completeness.lean
+++ b/Linglib/Logic/Natural/Completeness.lean
@@ -11,29 +11,28 @@ import Mathlib.Order.Bounds.Basic
 /-!
 # Completeness of the relation algebra
 
-The converse halves that upgrade `Logic/Natural/Soundness.lean` from
-sound to complete. The join table is *tight* (`Relation.isLeast_join`,
-making [icard-2012]'s Lemma 1.5 an equality): `R.join S` is the least
-relation sound for chaining `R` then `S`, with countermodels already on
-the three-atom Boolean algebra `Finset (Fin 3)`. And the seven
-relations *classify* the nondegenerately realizable constraint
-conjunctions (`Relation.mem_range_constraints_iff`): of the sixteen
-subsets of `Relation.Atom`, the nine outside the range of `constraints`
-force an argument to `⊥` or `⊤` in every bounded lattice —
-[maccartney-manning-2009] §2's sixteen-class partition, following
-Sánchez Valencia, with its nine degenerate classes, as a theorem. Its
-corollary `Relation.exists_isLeast_holds` is [icard-2012]'s Lemma 1.3:
-nondegenerate pairs stand in a strongest relation.
+This file proves the converses to `Logic/Natural/Soundness.lean` for
+the relation algebra: the join table is tight, and the seven relations
+are exactly the nondegenerately realizable conjunctions of constraint
+atoms.
+
+Tightness ([icard-2012]'s Lemma 1.5, as an equality) has countermodels
+already on the three-atom Boolean algebra `Finset (Fin 3)`. The
+classification is [maccartney-manning-2009] §2's sixteen-class
+partition, following Sánchez Valencia: the nine subsets outside the
+range of `Relation.constraints` force an argument to `⊥` or `⊤` in
+every bounded lattice.
 
 ## Main declarations
 
-- `Relation.isLeast_join`, `Relation.join_le_iff`: each join cell is
+* `Relation.isLeast_join`, `Relation.join_le_iff`: each join cell is
   the least sound chaining ([icard-2012] Definition 1.4).
-- `Relation.mem_range_constraints_of_holds`: a constraint set realized
+* `Relation.mem_range_constraints_of_holds`: a constraint set realized
   by a nondegenerate pair is one of the seven.
-- `Relation.mem_range_constraints_iff`: the classification, as an iff
+* `Relation.mem_range_constraints_iff`: the classification, as an iff
   against realizability on `Finset (Fin 3)`.
-- `Relation.exists_isLeast_holds`: Icard's Lemma 1.3, on any bounded
+* `Relation.exists_isLeast_holds`: [icard-2012]'s Lemma 1.3 — any
+  nondegenerate pair stands in a strongest relation — on any bounded
   lattice.
 
 ## References

--- a/Linglib/Logic/Natural/Monotonicity/Defs.lean
+++ b/Linglib/Logic/Natural/Monotonicity/Defs.lean
@@ -10,25 +10,21 @@ import Mathlib.Order.Lattice
 /-!
 # Marked types for the monotonicity calculus
 
-The type system of the [icard-moss-tune-2017] monotonicity calculus:
-simple types over a set of base types, with each arrow *marked* as
-monotone (`+`), antitone (`−`), or unmarked (`·`). `Marking` is a
-commutative monoid (valence composition, `+` the identity, `·`
-absorbing) and a join-semilattice with `·` on top; `Ty` carries
-the subtyping preorder `≤` — contravariant in domains, covariant in
-codomains and markings — under which a term of a smaller type can be
-coerced to any larger one (their Definition 3.2), together with the
-compatibility join `sup?` and the marking-erasure `unmark` (their
-Definition 3.3).
+This file defines the type system of the [icard-moss-tune-2017]
+monotonicity calculus: simple types over a set of base types, with
+each arrow marked as monotone (`+`), antitone (`−`), or unmarked
+(`·`).
 
 ## Main declarations
 
-* `Marking` — the three markings with their monoid and order.
-* `Ty` — marked simple types.
-* `Ty.instPartialOrder` — the subtyping order, decidable over a
+* `Marking`: the three markings — a commutative monoid under valence
+  composition (`+` the identity, `·` absorbing), and a
+  join-semilattice with `·` on top.
+* `Ty`: marked simple types, with the subtyping order — contravariant
+  in domains, covariant in codomains and markings — decidable over a
   `DecidableEq` base.
-* `Ty.sup?` — the partial join of compatible types.
-* `Ty.unmark` — erase the markings along the codomain spine.
+* `Ty.sup?`: the partial join of compatible types.
+* `Ty.unmark`: erasure of the markings along the codomain spine.
 
 ## References
 

--- a/Linglib/Logic/Natural/Monotonicity/Structure.lean
+++ b/Linglib/Logic/Natural/Monotonicity/Structure.lean
@@ -10,20 +10,20 @@ import Mathlib.Order.Hom.Basic
 /-!
 # Domains for the monotonicity calculus
 
-The functional structures of the [icard-moss-tune-2017] monotonicity
-calculus: each marked type is interpreted as a preordered domain — base
-types by a given assignment, `+`-arrows as the monotone maps (`→o`),
-`−`-arrows as the antitone maps (`·ᵒᵈ →o ·`), unmarked arrows as all
-maps, each with the pointwise order — and each subtyping `σ ≤ τ` as an
-order-preserving coercion `castLE : Dom Db σ →o Dom Db τ`, functorial
-in `≤` (their Definition 3.5's coherence conditions, here theorems).
+This file interprets the marked types of the [icard-moss-tune-2017]
+monotonicity calculus as preordered domains: base types by a given
+assignment, `+`-arrows as the monotone maps (`→o`), `−`-arrows as the
+antitone maps (`·ᵒᵈ →o ·`), unmarked arrows as all maps, each with the
+pointwise order. Each subtyping `σ ≤ τ` is interpreted as an
+order-preserving coercion, functorial in `≤`.
 
 ## Main declarations
 
-* `Ty.Dom` — the domain interpretation of a marked type.
-* `Ty.castLE` — the coercion along subtyping: the identity on base
+* `Ty.Dom`: the domain interpretation of a marked type.
+* `Ty.castLE`: the coercion along subtyping — the identity on base
   types, conjugation by the inner coercions on arrows.
-* `Ty.castLE_rfl`, `Ty.castLE_castLE` — the functor laws.
+* `Ty.castLE_rfl`, `Ty.castLE_castLE`: the functor laws
+  ([icard-moss-tune-2017] Definition 3.5's coherence conditions).
 
 ## References
 

--- a/Linglib/Logic/Natural/Soundness.lean
+++ b/Linglib/Logic/Natural/Soundness.lean
@@ -4,44 +4,40 @@ import Linglib.Core.Order.AntiAdditive
 /-!
 # Soundness of the projectivity calculus
 
-Semantic grounding for [icard-2012]'s projectivity machinery: `Relation`
-gets its lattice content (`Holds`, his Definition 1.2 — non-exclusive
-equations, so `⊑` is plain `≤`), and a signature is *sound* for a function
-(`Signature.SoundFor`) when the function projects every relation as the
-signature's `project` row says (his Lemma 2.5). The characterization
-theorems discharge each row from the property family in
-`Entailment` — the additive-family rows need the
-`IsCompletely*` unit conditions, exactly as Icard's tables assume; the
-soundness proofs go through over bounded lattices, not just his Boolean
-lattices.
-
-`SoundFor.comp` and `soundFor_contextProjectivity` certify
-`Signature.compose` and path projection against function composition
-(his Lemma 2.7 and Proposition 2.10): study-file locality computations over
-the enum become corollaries of facts about actual context functions.
+This file gives the seven relations their lattice content and proves
+the tables of `Logic/Natural/Basic.lean` sound for it, over bounded
+lattices: chained relations compose as the join table says, and each
+signature's projection row holds of every function in the signature's
+class.
 
 ## Main declarations
 
-- `Relation.Holds`: lattice content of the seven relations;
-- `Relation.holds_iff`: `Holds` is the conjunction of the `constraints`
-  atoms (`Relation.Atom.Holds`);
-- `Signature.SoundFor`: σ's projection row is sound for `f`;
-- `soundFor_mono_iff`, `soundFor_anti_iff`: the monotone rows, as iffs;
-- `soundFor_additive` … `soundFor_antiAddMult`: the algebraic rows, from
-  `IsCompletely*` hypotheses (sound direction; the converses fail —
-  projection rows are class-maximal, not function-characterizing);
-- `SoundFor.comp`: soundness composes along `Signature.compose`;
-- `soundFor_contextProjectivity`: soundness folds along a signature path.
+* `Relation.Holds`: the lattice content of a relation; `equiv` is
+  equality, `forward` is `≤`, `negation` is `IsCompl`, `alternation`
+  is `Disjoint`, `cover` is `Codisjoint`.
+* `Relation.holds_iff`: `Holds` is the conjunction of the
+  `Relation.constraints` atoms (`Relation.Atom.Holds`).
+* `Relation.Holds.join`: soundness of the join table.
+* `Signature.SoundFor`: a signature's projection row is sound for a
+  function.
+* `soundFor_mono_iff`, `soundFor_anti_iff`: the monotone rows
+  characterize the monotone and antitone functions.
+* `soundFor_additive` … `soundFor_antiAddMult`: the algebraic rows,
+  from `IsCompletely*` hypotheses.
+* `SoundFor.comp`, `soundFor_contextProjectivity`: soundness composes
+  along `Signature.compose` and folds along a signature path.
+* `Relation.Holds.of_le`, `Signature.SoundFor.of_le`: both implication
+  orders are semantically sound.
 
-## Order soundness
+## Implementation notes
 
-With the implication orders carrying their [icard-2012] readings (`.all` =
-•, the no-property top; `≡` not below the exclusion relations), both
-orders are certified here: `Relation.Holds.of_le` (relation-level
-implication) and `Signature.SoundFor.of_le` (a more specific
-signature's soundness implies a less specific one's), via the projection
-monotonicity `Signature.project_mono`. `soundFor_all` holds
-unconditionally — every function realizes the no-property row.
+The algebraic rows hold in the sound direction only — projection rows
+are class-maximal, not function-characterizing; tightness is proved in
+`Logic/Natural/Completeness.lean` for the join table. The
+additive-family rows need the `IsCompletely*` unit conditions, exactly
+as [icard-2012]'s tables assume, and the proofs go through over
+bounded lattices rather than his Boolean lattices. `soundFor_all`
+holds unconditionally: every function realizes the no-property row.
 
 ## References
 

--- a/Linglib/Logic/Natural/Strawson/Basic.lean
+++ b/Linglib/Logic/Natural/Strawson/Basic.lean
@@ -5,31 +5,35 @@ import Linglib.Semantics.Presupposition.Basic
 /-!
 # Strawson entailment
 
-Strawson-DE: a weakened downward entailingness that checks DE inferences
-only when presuppositions of the conclusion are satisfied. This rescues
-the Fauconnier-Ladusaw analysis for four "recalcitrant" NPI licensors:
-`only` (§2), adversative attitude verbs (§3), superlatives (§4.2), and
-conditional antecedents (§4.1). These are not classically DE but do
-license NPIs; Strawson-DE explains why.
+This file defines Strawson-DE — downward entailingness checked only
+where the conclusion's presuppositions are satisfied
+([von-fintel-1999]) — and the presuppositional operators that motivate
+it: `only`, adversative attitude verbs, superlatives, and conditional
+antecedents license NPIs without being classically DE.
 
-## Polymorphism
+## Main declarations
 
-The substrate is polymorphic over `{W : Type*}`. The operators
-(`onlyFull`, `sorryFull`, `gladFull`, `superlativeAssert`, `condNecessity`)
-take a polymorphic world type and the corresponding presupposition /
-ordering / modal-base parameters in their natural mathlib types
-(`Set W`, `W → Set W`, `W → Prop`). Concrete counterexamples (proofs of
-the form "X is *not* classically DE") are specialized to `Fin 4` as a witness type, since
-non-DE-ness is an *existence* claim about some inhabited domain.
+* `IsStrawsonDE`, `IsStrawsonAntiAdditive`, `StrawsonValid`: the DE
+  notions and validity, relativized to a definedness predicate.
+* `antitone_implies_strawsonDE`, `antiAdditive_implies_strawsonAA`:
+  the classical notions imply their Strawson forms.
+* `onlyFull`, `sorryFull`, `gladFull`, `superlativeAssert`,
+  `condNecessity`, `sinceFull`: the operators, each Strawson-DE (or
+  Strawson-anti-additive) but not classically DE.
+* `strawsonDE_strictly_weaker_than_DE`: each step of
+  AM ⊂ AA ⊂ DE ⊂ Strawson-DE is strict.
 
-## Hierarchy
+## Implementation notes
 
-AM ⊂ AA ⊂ DE ⊂ Strawson-DE (each strict — see
-`strawsonDE_strictly_weaker_than_DE`).
+The operators are polymorphic over a world type, taking their
+presupposition, ordering, and modal-base parameters at mathlib types
+(`Set W`, `W → Set W`, `W → Prop`). The concrete counterexamples
+("not classically DE") are specialized to `Fin 4`: non-DE-ness is an
+existence claim about some inhabited domain.
 
 ## References
 
-* [von-fintel-1999] — Strawson entailment and the four licensor case
+* [von-fintel-1999] — Strawson entailment and the licensor case
   studies.
 * [strawson-1952] — the presuppositional notion of entailment.
 -/

--- a/Linglib/Logic/Natural/Strawson/Soundness.lean
+++ b/Linglib/Logic/Natural/Strawson/Soundness.lean
@@ -4,34 +4,34 @@ import Linglib.Logic.Natural.Strawson.Basic
 /-!
 # Strawson-relativized soundness
 
-[von-fintel-1999]'s Strawson move, at signature level: a projection row
-holds *modulo presuppositions* when the projected relation holds on the
-region where the arguments' presuppositions are satisfied.
-`Relation.HoldsOn D` relativizes the lattice content of a relation to a
-region `D`; `Signature.StrawsonSoundFor σ f defined` is `SoundFor`
-with every projected relation read on `defined x ⊓ defined y` — the
-symmetric definedness gate of [gajewski-2011]'s Strawson
-anti-additivity. Classical soundness is the trivial-definedness case
-(`strawsonSoundFor_top_iff`) and implies the Strawson form at any
-definedness (`Signature.SoundFor.strawsonSoundFor`).
-
-The operator instances are the semantic content of the
-`classicalSignature = none` rows of
-`Polarity.LicensingContext.properties`: `onlyFull`,
-`sorryFull`, `superlativeAssert`, and `sinceFull` realize the `.anti` row
-Strawson-ly while failing it classically.
+This file relativizes the soundness layer of
+`Logic/Natural/Soundness.lean` to presuppositions ([von-fintel-1999]'s
+Strawson move, at signature level): a projection row holds modulo
+presuppositions when the projected relation holds on the region where
+the arguments' presuppositions are satisfied.
 
 ## Main declarations
 
-- `Relation.HoldsOn`: relation content relativized to a region;
-- `Signature.StrawsonSoundFor`: row soundness modulo presupposition;
-- `strawsonSoundFor_top_iff`, `Signature.SoundFor.strawsonSoundFor`:
-  the classical ↔ Strawson bridges;
-- `strawsonSoundFor_anti_of_isStrawsonDE` and the four operator instances.
+* `Relation.HoldsOn`: the lattice content of a relation, relativized
+  to a region; at `⊤` it is `Relation.Holds`.
+* `Signature.StrawsonSoundFor`: `Signature.SoundFor` with every
+  projected relation read on the symmetric definedness region
+  `defined x ⊓ defined y` of [gajewski-2011]'s Strawson
+  anti-additivity.
+* `strawsonSoundFor_top_iff`, `Signature.SoundFor.strawsonSoundFor`:
+  classical soundness is the trivial-definedness case, and implies the
+  Strawson form at any definedness.
+* `strawsonSoundFor_anti_of_isStrawsonDE` and the operator instances:
+  `onlyFull`, `sorryFull`, `superlativeAssert`, and `sinceFull`
+  realize the `.anti` row Strawson-ly while failing it classically.
 
-Composing definedness along a path is presupposition projection and is
-deliberately not attempted here — its home is a bridge to
-`Semantics/Presupposition/`, not an ad-hoc operator.
+## Implementation notes
+
+The operator instances are the semantic content of the
+`classicalSignature = none` rows of
+`Polarity.LicensingContext.properties`. Composing definedness along a
+path is presupposition projection and is deliberately not attempted
+here; its home is a bridge to `Semantics/Presupposition/`.
 
 ## References
 


### PR DESCRIPTION
Register pass on the prose itself, calibrated against `Order/Compare`, `Data/Sign/Defs`, `ModelTheory/Syntax`, and `Order/Heyting/Basic`: every module docstring in the directory now opens with a plain "This file defines/proves X." sentence, keeps context paragraphs short and declarative, and quarantines design commentary (the probing derivation, certified-elsewhere pointers, the unprinted-associativity remark, polymorphism conventions) in `## Implementation notes`. Structure is intro → Main declarations → Implementation notes → References throughout. Follow-up to #2101.