### PR TITLE
feat(Logic/Natural): projection completeness and the adjoint reading

### DIFF
--- a/Linglib/Core/Order/AntiAdditive.lean
+++ b/Linglib/Core/Order/AntiAdditive.lean
@@ -1,4 +1,6 @@
+import Mathlib.Data.Fintype.Order
 import Mathlib.Order.BooleanAlgebra.Basic
+import Mathlib.Order.GaloisConnection.Basic
 import Mathlib.Order.Monotone.Defs
 import Mathlib.Order.Hom.BoundedLattice
 import Mathlib.Data.Set.Basic
@@ -25,6 +27,10 @@ classes read into the order dual, so an additive function bundles as a
   bundled-hom and duality bridges.
 - `isAntiAdditive_iff_mem`, `isAntiAdditive_iff_gq` — pointwise forms at
   the `Set`- and `Prop`-valued instances.
+- `GaloisConnection.isAdditive` and friends — adjoints land in the
+  classes; `exists_galoisConnection_iff_forall_sSup` — the poset adjoint
+  functor theorem (`[UPSTREAM]` candidate), with the finite corollary
+  `isAdditive_and_bot_iff_exists_galoisConnection`.
 -/
 
 
@@ -243,4 +249,123 @@ theorem isAntiAdditive_forall_mem {α β : Type*} (P : α → β → Prop) :
   · exact hB x hx
 
 end Bridges
+
+/-! ### Galois connections
+
+Adjoints land in the function classes: a left adjoint is additive, a
+right adjoint multiplicative, and the anti-classes are adjoints into the
+order dual. A single adjunction yields `⊥`- (resp. `⊤`-) preservation,
+never the opposite unit, so only *bi*-adjoints reach the `IsCompletely*`
+classes. `exists_galoisConnection_iff_forall_sSup` is the poset adjoint
+functor theorem, an `[UPSTREAM]` candidate: mathlib has
+`GaloisConnection.l_sSup` but not the converse. -/
+
+section GaloisBridges
+
+variable {α β : Type*}
+
+/-- A left adjoint is additive. -/
+theorem GaloisConnection.isAdditive [SemilatticeSup α] [SemilatticeSup β]
+    {l : α → β} {u : β → α} (gc : GaloisConnection l u) : IsAdditive l :=
+  λ _ _ => gc.l_sup
+
+/-- A right adjoint is multiplicative. -/
+theorem GaloisConnection.isMultiplicative [SemilatticeInf α] [SemilatticeInf β]
+    {l : β → α} {u : α → β} (gc : GaloisConnection l u) : IsMultiplicative u :=
+  λ _ _ => gc.u_inf
+
+/-- An antitone left adjoint — a left adjoint into the order dual — is
+anti-additive. -/
+theorem GaloisConnection.isAntiAdditive [SemilatticeSup α] [SemilatticeInf β]
+    {f : α → β} {u : βᵒᵈ → α}
+    (gc : GaloisConnection (OrderDual.toDual ∘ f) u) : IsAntiAdditive f :=
+  isAntiAdditive_iff_isAdditive_toDual.mpr gc.isAdditive
+
+/-- An antitone right adjoint — a right adjoint into the order dual — is
+anti-multiplicative. -/
+theorem GaloisConnection.isAntiMultiplicative [SemilatticeInf α] [SemilatticeSup β]
+    {f : α → β} {l : βᵒᵈ → α}
+    (gc : GaloisConnection l (OrderDual.toDual ∘ f)) : IsAntiMultiplicative f :=
+  λ _ _ => gc.u_inf
+
+/-- A map with adjoints on both sides is completely additive: additivity
+from its left adjunction, `f ⊤ = ⊤` from its right one. -/
+theorem isCompletelyAdditive_of_galoisConnection
+    [SemilatticeSup α] [OrderTop α] [SemilatticeSup β] [OrderTop β]
+    {f : α → β} {u : β → α} {l : β → α}
+    (gc₁ : GaloisConnection f u) (gc₂ : GaloisConnection l f) :
+    IsCompletelyAdditive f :=
+  ⟨gc₁.isAdditive, gc₂.u_top⟩
+
+/-- A map with adjoints on both sides is completely multiplicative:
+multiplicativity from its right adjunction, `f ⊥ = ⊥` from its left
+one. -/
+theorem isCompletelyMultiplicative_of_galoisConnection
+    [SemilatticeInf α] [OrderBot α] [SemilatticeInf β] [OrderBot β]
+    {f : α → β} {u : β → α} {l : β → α}
+    (gc₁ : GaloisConnection f u) (gc₂ : GaloisConnection l f) :
+    IsCompletelyMultiplicative f :=
+  ⟨gc₂.isMultiplicative, gc₁.l_bot⟩
+
+/-- The morphism and anti-morphism unit conditions collide on a
+nontrivial codomain. -/
+theorem IsCompletelyAdditive.not_isCompletelyAntiAdditive
+    [SemilatticeSup α] [OrderTop α] [Lattice β] [BoundedOrder β] [Nontrivial β]
+    {f : α → β} (h : IsCompletelyAdditive f) (h' : IsCompletelyAntiAdditive f) :
+    False :=
+  top_ne_bot (h.2.symm.trans h'.2)
+
+end GaloisBridges
+
+section AdjointFunctorTheorem
+
+variable {α β : Type*} [CompleteLattice α] [CompleteLattice β]
+
+/-- Poset adjoint functor theorem, construction half: a `sSup`-preserving
+map between complete lattices is a left adjoint, with right adjoint
+`λ b => sSup {a | f a ≤ b}`. -/
+theorem galoisConnection_of_forall_sSup {f : α → β}
+    (hf : ∀ s : Set α, f (sSup s) = ⨆ a ∈ s, f a) :
+    GaloisConnection f λ b => sSup {a | f a ≤ b} := by
+  have hmono : Monotone f := λ a b hab => by
+    have h := hf {a, b}
+    rw [sSup_pair, sup_eq_right.mpr hab, iSup_pair] at h
+    exact le_sup_left.trans h.ge
+  intro a b
+  refine ⟨λ h => le_sSup h, λ h => (hmono h).trans ?_⟩
+  rw [hf]
+  exact iSup₂_le λ x hx => hx
+
+/-- Poset adjoint functor theorem: a map between complete lattices is a
+left adjoint iff it preserves arbitrary suprema. -/
+theorem exists_galoisConnection_iff_forall_sSup (f : α → β) :
+    (∃ u, GaloisConnection f u) ↔ ∀ s : Set α, f (sSup s) = ⨆ a ∈ s, f a :=
+  ⟨λ ⟨_, gc⟩ _ => gc.l_sSup, λ hf => ⟨_, galoisConnection_of_forall_sSup hf⟩⟩
+
+end AdjointFunctorTheorem
+
+/-- On a finite lattice, binary additivity plus `⊥`-preservation is
+exactly left-adjointness. -/
+theorem isAdditive_and_bot_iff_exists_galoisConnection
+    {α β : Type*} [Lattice α] [BoundedOrder α] [Finite α]
+    [SemilatticeSup β] [OrderBot β] (f : α → β) :
+    IsAdditive f ∧ f ⊥ = ⊥ ↔ ∃ u, GaloisConnection f u := by
+  constructor
+  · rintro ⟨hadd, hbot⟩
+    cases nonempty_fintype α
+    let _ : CompleteLattice α := Fintype.toCompleteLattice α
+    have key : ∀ s : Set α, ∀ b, (∀ x ∈ s, f x ≤ b) → f (sSup s) ≤ b := by
+      intro s
+      induction s, (Set.toFinite s) using Set.Finite.induction_on with
+      | empty => intro b _; rw [sSup_empty, hbot]; exact bot_le
+      | insert _ _ ih =>
+          intro b hb
+          rw [sSup_insert, hadd]
+          exact sup_le (hb _ (Set.mem_insert ..))
+            (ih b λ x hx => hb x (Set.mem_insert_of_mem _ hx))
+    refine ⟨λ b => sSup {a | f a ≤ b}, λ a b => ⟨λ h => le_sSup h, λ h => ?_⟩⟩
+    exact (hadd.monotone h).trans (key _ b λ x hx => hx)
+  · rintro ⟨u, gc⟩
+    exact ⟨gc.isAdditive, gc.l_bot⟩
+
 

--- a/Linglib/Logic/Natural/Basic.lean
+++ b/Linglib/Logic/Natural/Basic.lean
@@ -289,8 +289,14 @@ instance : OrderTop Signature where
 signature ([icard-2012] Definition 2.3, computed by his Lemma 2.4):
 the strongest relation guaranteed between `f x` and `f y` when `x R y`
 and `f` has signature `σ`. The rows are certified sound against the
-function classes in `Logic/Natural/Soundness.lean` (`soundFor_*`). -/
+function classes in `Logic/Natural/Soundness.lean` (`soundFor_*`) and
+tight by `Signature.isLeast_project` in
+`Logic/Natural/Completeness.lean`. One cell deviates from the printed
+table: [icard-2012] prints `[R]^• = #` for all `R` (p. 715), but every
+function preserves equality, so his Definition 2.3 forces
+`[≡]^• = ≡`. -/
 def project : Relation → Signature → Relation
+  | .equiv, .all => .equiv
   | _, .all => .independent
   | r, .addMult => r
   | .equiv, .antiAddMult => .equiv
@@ -345,9 +351,8 @@ def project : Relation → Signature → Relation
 
 /-- Every signature except • preserves equiv (• is the class of arbitrary
 functions, which need not respect equivalence). -/
-theorem project_equiv (φ : Signature) (h : φ ≠ .all) :
-    project .equiv φ = .equiv := by
-  cases φ <;> simp_all <;> rfl
+theorem project_equiv (φ : Signature) : project .equiv φ = .equiv := by
+  cases φ <;> rfl
 
 /-- Projection preserves independent for all signatures. -/
 theorem project_independent (φ : Signature) : project .independent φ = .independent := by

--- a/Linglib/Logic/Natural/Completeness.lean
+++ b/Linglib/Logic/Natural/Completeness.lean
@@ -6,15 +6,17 @@ Authors: Robert Hawkins
 import Linglib.Logic.Natural.Soundness
 import Mathlib.Data.Finset.BooleanAlgebra
 import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Fintype.Pi
 import Mathlib.Order.Bounds.Basic
 
 /-!
-# Completeness of the relation algebra
+# Completeness of the projectivity calculus
 
-This file proves the converses to `Logic/Natural/Soundness.lean` for
-the relation algebra: the join table is tight, and the seven relations
-are exactly the nondegenerately realizable conjunctions of constraint
-atoms.
+This file proves the converses to `Logic/Natural/Soundness.lean`: the
+join and projection tables are tight, the seven relations are exactly
+the nondegenerately realizable conjunctions of constraint atoms, and
+the refinement order on signatures coincides with inclusion of
+function classes.
 
 Tightness ([icard-2012]'s Lemma 1.5, as an equality) has countermodels
 already on the three-atom Boolean algebra `Finset (Fin 3)`. The
@@ -34,10 +36,30 @@ every bounded lattice.
 * `Relation.exists_isLeast_holds`: [icard-2012]'s Lemma 1.3 — any
   nondegenerate pair stands in a strongest relation — on any bounded
   lattice.
+* `Signature.isLeast_project`: each projection cell is the least
+  relation sound for the signature's function class ([icard-2012]
+  Definition 2.3), with countermodels on the two-element Boolean
+  algebra.
+* `Signature.le_iff_holdsFor`: the refinement order is inclusion of
+  function classes — [icard-2012]'s semantic definition of ≼,
+  recovered.
+* `Signature.isLeast_compose`, `Signature.holdsFor_comp`: composition
+  is the least signature covering composites ([icard-2012]
+  Definition 2.6).
+
+## Implementation notes
+
+The nine signatures are not an exhaustive classification of realizable
+property profiles: the constant-`⊤` function is simultaneously
+monotone, antitone, completely additive, and completely
+anti-multiplicative, and `{+, −, ⊕, ⊟}` is no signature's property
+set. The signatures are the downward-closed profiles [icard-2012]
+names, each tight for its own row.
 
 ## References
 
-* [icard-2012] — Definition 1.4, Lemmas 1.3 and 1.5.
+* [icard-2012] — Definitions 1.4, 2.3, and 2.6, Lemmas 1.3, 1.5,
+  and 2.4.
 * [maccartney-manning-2009] — §2's sixteen-class partition, following
   Sánchez Valencia.
 -/
@@ -126,5 +148,67 @@ theorem Relation.exists_isLeast_holds {α : Type*} [Lattice α] [BoundedOrder α
     exact (Finset.mem_filter.mp ha).2
   · rw [hR]
     exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, Relation.holds_iff.mp hS a ha⟩
+
+
+/-! ### Tightness of the projection tables -/
+
+set_option synthInstance.maxSize 400 in
+/-- **Tightness of the projection tables** ([icard-2012] Definition 2.3;
+his Lemma 2.4 as an equality): `project R σ` is the least relation `T`
+such that every σ-function sends `R`-pairs to `T`-pairs, already over
+the two-element Boolean algebra. -/
+theorem Signature.isLeast_project (R : Relation) (σ : Signature) :
+    IsLeast {T : Relation | ∀ f : Finset (Fin 1) → Finset (Fin 1),
+      σ.HoldsFor f → ∀ x y, R.Holds x y → T.Holds (f x) (f y)}
+      (Signature.project R σ) := by
+  refine ⟨λ f hf x y hR => σ.soundFor_of_holdsFor hf R x y hR, λ T hT => ?_⟩
+  by_contra hle
+  have counter : ∀ (R : Relation) (σ : Signature) (T : Relation),
+      ¬ Signature.project R σ ≤ T →
+      ∃ f : Finset (Fin 1) → Finset (Fin 1), σ.HoldsFor f ∧
+        ∃ x y, R.Holds x y ∧ ¬ T.Holds (f x) (f y) := by decide
+  obtain ⟨f, hf, x, y, hR, hT'⟩ := counter R σ T hle
+  exact hT' (hT f hf x y hR)
+
+set_option synthInstance.maxSize 400 in
+/-- The refinement order on signatures is inclusion of function classes —
+[icard-2012]'s semantic definition of ≼ (§2.2) recovered as a
+characterization of the property-set order, with countermodels on the
+two-element Boolean algebra. -/
+theorem Signature.le_iff_holdsFor {σ τ : Signature} :
+    σ ≤ τ ↔
+      ∀ f : Finset (Fin 1) → Finset (Fin 1), σ.HoldsFor f → τ.HoldsFor f := by
+  refine ⟨λ h f hf => hf.of_le h, λ h => ?_⟩
+  by_contra hle
+  have counter : ∀ σ τ : Signature, ¬ σ ≤ τ →
+      ∃ f : Finset (Fin 1) → Finset (Fin 1), σ.HoldsFor f ∧ ¬ τ.HoldsFor f := by
+    decide
+  obtain ⟨f, hσ, hτ⟩ := counter σ τ hle
+  exact hτ (h f hσ)
+
+/-! ### Tightness of signature composition -/
+
+set_option synthInstance.maxSize 400 in
+/-- Function classes compose along `Signature.compose`: a ψ-function
+after a φ-function is a `ψ * φ`-function, on the two-element Boolean
+algebra. -/
+theorem Signature.holdsFor_comp :
+    ∀ (ψ φ : Signature) (f g : Finset (Fin 1) → Finset (Fin 1)),
+      ψ.HoldsFor f → φ.HoldsFor g → (ψ * φ).HoldsFor (f ∘ g) := by decide
+
+set_option synthInstance.maxSize 400 in
+/-- **Tightness of signature composition** ([icard-2012]
+Definition 2.6): `ψ * φ` is the least signature whose class contains
+every composite of a ψ-function after a φ-function. -/
+theorem Signature.isLeast_compose (ψ φ : Signature) :
+    IsLeast {χ : Signature | ∀ f g : Finset (Fin 1) → Finset (Fin 1),
+      ψ.HoldsFor f → φ.HoldsFor g → χ.HoldsFor (f ∘ g)} (ψ * φ) := by
+  refine ⟨λ f g hf hg => Signature.holdsFor_comp ψ φ f g hf hg, λ χ hχ => ?_⟩
+  by_contra hle
+  have counter : ∀ ψ φ χ : Signature, ¬ ψ * φ ≤ χ →
+      ∃ f g : Finset (Fin 1) → Finset (Fin 1),
+        ψ.HoldsFor f ∧ φ.HoldsFor g ∧ ¬ χ.HoldsFor (f ∘ g) := by decide
+  obtain ⟨f, g, hf, hg, hχ'⟩ := counter ψ φ χ hle
+  exact hχ' (hχ f g hf hg)
 
 end NaturalLogic

--- a/Linglib/Logic/Natural/Soundness.lean
+++ b/Linglib/Logic/Natural/Soundness.lean
@@ -267,8 +267,11 @@ theorem soundFor_antiAddMult {f : α → β} (haa : IsCompletelyAntiAdditive f)
 
 /-- Every function realizes the • row: `.all` is the no-property
 signature, projecting every relation to `#`. -/
-theorem soundFor_all (f : α → β) : Signature.SoundFor .all f :=
-  fun _ _ _ _ => trivial
+theorem soundFor_all (f : α → β) : Signature.SoundFor .all f := by
+  intro R x y hR
+  cases R
+  case equiv => exact congrArg f hR
+  all_goals trivial
 
 /-- Relation-level order soundness: `≤` is the implication order on
 the lattice content ([icard-2012] §1). -/
@@ -407,5 +410,101 @@ theorem Signature.SoundFor.comp₂ {ψ : Signature} {g : γ → δ}
   ⟨fun y => hg.comp (hf.1 y), fun x => hg.comp (hf.2 x)⟩
 
 end Signature₂
+
+
+/-! ### The function class of a signature -/
+
+section HoldsFor
+
+variable {α β : Type*} [Lattice α] [BoundedOrder α] [Lattice β] [BoundedOrder β]
+
+/-- The function class a property asserts. -/
+def Signature.Property.HoldsFor : Signature.Property → (α → β) → Prop
+  | .monotone => Monotone
+  | .antitone => Antitone
+  | .additive => IsCompletelyAdditive
+  | .multiplicative => IsCompletelyMultiplicative
+  | .antiAdditive => IsCompletelyAntiAdditive
+  | .antiMultiplicative => IsCompletelyAntiMultiplicative
+
+/-- A function has signature σ — is a "σ-function" — when it has every
+property σ asserts. -/
+def Signature.HoldsFor (σ : Signature) (f : α → β) : Prop :=
+  ∀ p ∈ σ.properties, p.HoldsFor f
+
+/-- σ's projection row is sound for every σ-function ([icard-2012]
+Lemma 2.5), aggregating the per-row theorems. -/
+theorem Signature.soundFor_of_holdsFor {σ : Signature} {f : α → β}
+    (h : σ.HoldsFor f) : σ.SoundFor f := by
+  cases σ with
+  | all => exact soundFor_all f
+  | mono => exact soundFor_mono_iff.mpr (h .monotone (by decide))
+  | anti => exact soundFor_anti_iff.mpr (h .antitone (by decide))
+  | additive => exact soundFor_additive (h .additive (by decide))
+  | antiAdd => exact soundFor_antiAdd (h .antiAdditive (by decide))
+  | mult => exact soundFor_mult (h .multiplicative (by decide))
+  | antiMult => exact soundFor_antiMult (h .antiMultiplicative (by decide))
+  | addMult =>
+      exact soundFor_addMult (h .additive (by decide)) (h .multiplicative (by decide))
+  | antiAddMult =>
+      exact soundFor_antiAddMult (h .antiAdditive (by decide))
+        (h .antiMultiplicative (by decide))
+
+/-- The class of a more specific signature is included in the class of a
+less specific one — the sound direction of the refinement order, with the
+converse in `Logic/Natural/Completeness.lean` (`le_iff_holdsFor`). -/
+theorem Signature.HoldsFor.of_le {σ τ : Signature} {f : α → β}
+    (h : σ.HoldsFor f) (hστ : σ ≤ τ) : τ.HoldsFor f :=
+  λ p hp => h p (Signature.le_iff.mp hστ hp)
+
+/-- A map with adjoints on both sides is in the morphism class ⊕⊞ — the
+Lawvere reading of the signature: bi-adjoints preserve everything. -/
+theorem Signature.holdsFor_addMult_of_galoisConnection {f u l : α → α}
+    (gc₁ : GaloisConnection f u) (gc₂ : GaloisConnection l f) :
+    Signature.HoldsFor .addMult f := by
+  intro p hp
+  cases p with
+  | monotone => exact gc₁.monotone_l
+  | additive => exact ⟨λ _ _ => gc₁.l_sup, gc₂.u_top⟩
+  | multiplicative => exact ⟨λ _ _ => gc₂.u_inf, gc₁.l_bot⟩
+  | antitone | antiAdditive | antiMultiplicative => exact absurd hp (by decide)
+
+/-- Complementation, the self-dual adjoint pair, is in the anti-morphism
+class ◇⊟. -/
+theorem Signature.holdsFor_antiAddMult_compl {γ : Type*} [BooleanAlgebra γ] :
+    Signature.HoldsFor .antiAddMult (compl : γ → γ) := by
+  intro p hp
+  cases p with
+  | antitone => exact antitone_compl
+  | antiAdditive => exact isCompletelyAntiAdditive_compl
+  | antiMultiplicative => exact isCompletelyAntiMultiplicative_compl
+  | monotone | additive | multiplicative => exact absurd hp (by decide)
+
+end HoldsFor
+
+section DecidableHoldsFor
+
+variable {α β : Type*} [Lattice α] [BoundedOrder α] [Lattice β] [BoundedOrder β]
+  [Fintype α] [DecidableLE α] [DecidableEq β] [DecidableLE β]
+
+instance Signature.Property.decidableHoldsFor :
+    ∀ (p : Signature.Property) (f : α → β), Decidable (p.HoldsFor f)
+  | .monotone, f => decidable_of_iff (∀ a b, a ≤ b → f a ≤ f b) Iff.rfl
+  | .antitone, f => decidable_of_iff (∀ a b, a ≤ b → f b ≤ f a) Iff.rfl
+  | .additive, f =>
+      decidable_of_iff ((∀ p q, f (p ⊔ q) = f p ⊔ f q) ∧ f ⊤ = ⊤) Iff.rfl
+  | .multiplicative, f =>
+      decidable_of_iff ((∀ p q, f (p ⊓ q) = f p ⊓ f q) ∧ f ⊥ = ⊥) Iff.rfl
+  | .antiAdditive, f =>
+      decidable_of_iff ((∀ p q, f (p ⊔ q) = f p ⊓ f q) ∧ f ⊤ = ⊥) Iff.rfl
+  | .antiMultiplicative, f =>
+      decidable_of_iff ((∀ p q, f (p ⊓ q) = f p ⊔ f q) ∧ f ⊥ = ⊤) Iff.rfl
+
+instance Signature.decidableHoldsFor (σ : Signature) (f : α → β) :
+    Decidable (σ.HoldsFor f) :=
+  inferInstanceAs (Decidable (∀ p ∈ σ.properties, p.HoldsFor f))
+
+end DecidableHoldsFor
+
 
 end NaturalLogic

--- a/Linglib/Studies/Icard2012.lean
+++ b/Linglib/Studies/Icard2012.lean
@@ -85,6 +85,18 @@ example : project .cover .mult = .independent := rfl        -- ⊞ : ∼ lost
 example : project .cover .antiAdd = .alternation := rfl     -- ◇ : ∼ flips to |
 example : project .cover .antiAddMult = .alternation := rfl -- ◇⊟ : ∼ flips to |
 
+-- Deviation from the printed remark "[R]^• = #, for all R ∈ ℛ" (p. 715):
+-- every function preserves equality, so Definition 2.3 forces [≡]^• = ≡ —
+-- the blanket remark overshoots at ≡ by the paper's own definition.
+example : project .equiv .all = .equiv := rfl
+example : project .forward .all = .independent := rfl  -- • elsewhere as printed
+
+-- Lemma 2.4 as an equality: each cell is the least relation sound for the
+-- signature's function class.
+example : IsLeast {T : Relation | ∀ f : Finset (Fin 1) → Finset (Fin 1),
+    Signature.HoldsFor .antiAdd f → ∀ x y, Relation.Holds .cover x y →
+      T.Holds (f x) (f y)} .alternation := Signature.isLeast_project .cover .antiAdd
+
 /-! ### The composition table (Lemma 2.7, p. 716) -/
 
 example : compose .anti .anti = .mono := rfl                   -- − ∘ − = +


### PR DESCRIPTION
Closes the sound-but-not-tight gap for the projection side of [icard-2012], with the API organized around the Lawvere reading of the signature classes (design compiled and validated by a mathlib-reviewer pass before landing):

- **A table cell was wrong — in the paper too.** Every function preserves equality, so by Definition 2.3 the ≪-maximal entry at `(≡, •)` is `≡`, yet p. 715 prints the blanket remark `[R]^• = #` for all R. The cell is corrected to the semantically forced value (all downstream laws verified to survive; `project_equiv` loses its `φ ≠ •` hypothesis), and the study records the deviation against the printed text.
- `Signature.HoldsFor` — the φ-function class ([icard-2012]'s "φ-function") — with `soundFor_of_holdsFor` aggregating the six row theorems, decidability instances, and two Lawvere lemmas: bi-adjoints are ⊕⊞-functions, complementation is a ◇⊟-function.
- `Signature.isLeast_project`: Lemma 2.4 as an equality — every projection cell is the least sound relation, countermodels a kernel `decide` over the two-element Boolean algebra (the full 4-function space; no probe family needed).
- `Signature.le_iff_holdsFor`: the refinement order is exactly inclusion of function classes — Icard's semantic definition of ≼ recovered as a theorem about the `properties` lift.
- `Signature.isLeast_compose` + `holdsFor_comp`: Definition 2.6's maximality for the composition monoid.
- `Core/Order/AntiAdditive` gains a Galois section: adjoints land in the classes (`GaloisConnection.isAdditive` etc.), bi-adjoints reach the `IsCompletely*` classes, the unit-clash impossibility, and the poset adjoint functor theorem (`exists_galoisConnection_iff_forall_sSup`, `[UPSTREAM]` candidate — mathlib has `l_sSup` but no converse) with its finite corollary.
- Honesty note in Implementation notes: the nine signatures are not an exhaustive profile classification (constant-⊤ realizes `{+, −, ⊕, ⊟}`); they are the downward-closed profiles the paper names, each tight for its own row.