### PR TITLE
chore(blog): remove stale ROADMAP.md link

### DIFF
--- a/blog/content/roadmap.md
+++ b/blog/content/roadmap.md
@@ -2,8 +2,6 @@
 title: "Roadmap"
 ---
 
-See the full [roadmap on GitHub](https://github.com/hawkrobe/linglib/blob/main/docs/ROADMAP.md).
-
 ## North Stars
 
 > **For phenomenon P with behavioral data D, prove that theory T₁ predicts D and theory T₂ doesn't (or both do, via different assumptions).**


### PR DESCRIPTION
The blog's Roadmap page (blog/content/roadmap.md, rendered at linglib.io/roadmap) opens with "See the full roadmap on GitHub", the link does not work.

Looks like the target was removed in 05b9fe6 ("chore: remove stale docs/", May 22), which described it as a generic wishlist, but the blog page (from c63c28e, back in February) still points to it.