### PR TITLE
docs(Studies): trim DegenTonhauser/GroveWhite docstrings to register

### DIFF
--- a/Linglib/Studies/DegenTonhauser2021.lean
+++ b/Linglib/Studies/DegenTonhauser2021.lean
@@ -15,28 +15,20 @@ under an entailment-canceling operator? The prior literature conflicted:
 priori more plausible, while [lorson-2018] found no effect of world knowledge on
 the projection of the prestate of *stop*. [degen-tonhauser-2021] resolve the
 conflict in favor of modulation: across 20 clause-embedding predicates and 20
-contents, higher-prior content projects more, at the group **and** the individual
+contents, higher-prior content projects more, at the group and the individual
 level.
 
-The deep claim is structural: projection tracks prior credence *monotonically*.
-An account is **prior-sensitive** when it is monotone in prior credence
-(`PriorSensitive`); such an account predicts the observed per-content modulation
-by its very shape (`sensitive_predicts_modulation`), whereas the
-prior-*insensitive* null account predicts no modulation at all
-(`priorInsensitive_not_sensitive`). This is the account family the paper argues
-for — projection as a posterior credence in a Bayesian / RSA listener
-([qing-goodman-lassiter-2016], [goodman-frank-2016]) — and the prior analogue of
-the at-issueness predictor of projection in [tonhauser-beaver-degen-2018]: both
-are gradient `Rat01 → Rat01` maps into the same projection space. The experiment
-1 by-predicate means (`certaintyHigh`, `certaintyLow`, `priorHigh`, `priorLow`,
-computed from `results/9-prior-projection/data/cd.csv` at
-github.com/judith-tonhauser/projective-probability, n = 286) realize the
-modulation for every predicate (`prior_modulates_projection`), refuting the null
-account (`certaintyLow_ne_certaintyHigh`); the predicates are bridged to their
-Fragment lexical entries (`toVerbEntry`, `toPredicateCore`,
-`all_predicates_take_clause_complement`).
+A *prior-sensitive* account is one monotone in prior credence (`PriorSensitive`);
+it predicts the modulation by its shape (`sensitive_predicts_modulation`), while
+the prior-*insensitive* null account predicts none (`priorInsensitive_not_sensitive`).
+This is the account family the paper argues for — projection as a posterior
+credence in a Bayesian / RSA listener ([qing-goodman-lassiter-2016],
+[goodman-frank-2016]) — and the prior analogue of the at-issueness predictor of
+[tonhauser-beaver-degen-2018]. The experiment 1 by-predicate means realize the
+modulation for every predicate (`prior_modulates_projection`), and the predicates
+are bridged to their Fragment entries (`all_predicates_take_clause_complement`).
 
-Regression detail, documented as prose rather than theorems. Experiment 1
+The regression coefficients are recorded as prose, not theorems. Experiment 1
 (within-participant, N = 286): the prior manipulation was successful (β = 0.45,
 SE = 0.01, t = 31.12), and prior probability predicted projection at every level —
 categorical high/low fact (β = 0.14, t = 12.24), group-level continuous prior
@@ -57,10 +49,8 @@ open Core.Order
 
 /-! ### The 20 clause-embedding predicates -/
 
-/-- The 20 clause-embedding predicates investigated in [degen-tonhauser-2021],
-    listed alphabetically as in Figure 1C. The set spans cognitive (`know`),
-    emotive (`beAnnoyed`), communication (`announce`), and inferential (`prove`)
-    predicates. For the traditional factive/nonfactive classification see
+/-- The 20 clause-embedding predicates of [degen-tonhauser-2021], listed
+    alphabetically as in Figure 1C. For the traditional classification see
     `DegenTonhauser2022.traditionalClass`. -/
 inductive Predicate where
   | acknowledge | admit | announce | beAnnoyed | beRight
@@ -69,51 +59,39 @@ inductive Predicate where
   | reveal | say | see | suggest | think
   deriving DecidableEq, Fintype, Repr
 
-/-! ### Projection as a function of prior credence
+/-! ### Projection as a function of prior credence -/
 
-The account family the paper argues for: projection strength is a function of the
-listener's prior credence in the content. A *prior-sensitive* account is monotone
-in that credence; the null account is constant (prior-insensitive). The monotone
-shape alone predicts the modulation; the constant one cannot. -/
-
-/-- A predictor of projection strength from prior credence in the complement —
-    the same gradient shape as the at-issueness predictor of
-    [tonhauser-beaver-degen-2018]. -/
+/-- A predictor of projection strength from prior credence in the complement. -/
 abbrev PriorAccount := Rat01 → Rat01
 
 /-- The prior-insensitive null account: projection is constant in prior credence. -/
 def priorInsensitive (c : Rat01) : PriorAccount := fun _ => c
 
 /-- An account is prior-sensitive when projection is strictly monotone in prior
-    credence — the structural form of the paper's positive prior coefficient. -/
+    credence. -/
 def PriorSensitive (acc : PriorAccount) : Prop := StrictMono acc
 
 /-- The null account predicts identical projection for any two priors. -/
 theorem priorInsensitive_no_modulation (c p q : Rat01) :
     priorInsensitive c p = priorInsensitive c q := rfl
 
-/-- The null account is not prior-sensitive: it cannot produce the observed gap. -/
+/-- The null account is not prior-sensitive. -/
 theorem priorInsensitive_not_sensitive (c : Rat01) :
     ¬ PriorSensitive (priorInsensitive c) :=
   fun h => lt_irrefl c (h Rat01.zero_lt_one)
 
-/-- A prior-sensitive account predicts stronger projection for higher-prior
-    content — the modulation, derived from the account's shape, not stipulated. -/
+/-- A prior-sensitive account predicts stronger projection for higher-prior content. -/
 theorem sensitive_predicts_modulation {acc : PriorAccount} (h : PriorSensitive acc)
     {p q : Rat01} (hpq : p < q) : acc p < acc q := h hpq
 
 /-! ### Data: prior modulates projection for every predicate
 
-By-predicate means from experiment 1, computed from
-`results/9-prior-projection/data/cd.csv` at
-github.com/judith-tonhauser/projective-probability (n = 286 participants) and
-rounded to two decimals. Contents were paired with predicates at random per
-participant, so the prior means average over the contents each predicate
-appeared with. -/
+Experiment 1 by-predicate means from `results/9-prior-projection/data/cd.csv` at
+github.com/judith-tonhauser/projective-probability (n = 286), rounded to two decimals;
+prior means average over the contents each predicate was randomly paired with. -/
 
-/-- Mean certainty rating (projection) by predicate under the higher-probability
-    fact (experiment 1 projection block, Figure 3; nonprojective main-clause
-    control mean 0.21). -/
+/-- Mean certainty rating (projection) under the higher-probability fact
+    (Figure 3; nonprojective main-clause control mean 0.21). -/
 def certaintyHigh : Predicate → ℚ
   | .acknowledge => 0.65
   | .admit => 0.60
@@ -136,7 +114,7 @@ def certaintyHigh : Predicate → ℚ
   | .suggest => 0.32
   | .think => 0.40
 
-/-- Mean certainty rating by predicate under the lower-probability fact. -/
+/-- Mean certainty rating under the lower-probability fact. -/
 def certaintyLow : Predicate → ℚ
   | .acknowledge => 0.49
   | .admit => 0.43
@@ -160,7 +138,7 @@ def certaintyLow : Predicate → ℚ
   | .think => 0.20
 
 /-- Mean prior probability rating of the complement content given the
-    higher-probability fact (experiment 1 prior block). -/
+    higher-probability fact. -/
 def priorHigh : Predicate → ℚ
   | .acknowledge => 0.67
   | .admit => 0.68
@@ -206,18 +184,16 @@ def priorLow : Predicate → ℚ
   | .suggest => 0.22
   | .think => 0.19
 
-/-- Prior credence and projection are both higher under the higher-probability
-    fact for every predicate (Figure 3): the manipulation held and projection
-    tracked it — the joint pattern a prior-sensitive account predicts
-    (`sensitive_predicts_modulation`) and the null account rules out. -/
+/-- Prior credence and certainty are both higher under the higher-probability fact
+    for every predicate (Figure 3) — the pattern a prior-sensitive account predicts
+    and the null account rules out. -/
 theorem prior_modulates_projection (p : Predicate) :
     priorLow p < priorHigh p ∧ certaintyLow p < certaintyHigh p := by
   cases p <;> exact ⟨by norm_num [priorLow, priorHigh],
     by norm_num [certaintyLow, certaintyHigh]⟩
 
-/-- The null account predicts equal certainty across the prior manipulation
-    (`priorInsensitive_no_modulation`); the observed certainties differ for
-    every predicate. -/
+/-- The observed certainties differ across the manipulation, contra the null
+    account (`priorInsensitive_no_modulation`). -/
 theorem certaintyLow_ne_certaintyHigh (p : Predicate) :
     certaintyLow p ≠ certaintyHigh p :=
   (prior_modulates_projection p).2.ne

--- a/Linglib/Studies/DegenTonhauser2022.lean
+++ b/Linglib/Studies/DegenTonhauser2022.lean
@@ -14,28 +14,24 @@ those of all other predicates — `Separates`, which over a finite domain holds 
 some threshold puts exactly the factive class on top (`separates_iff_exists_threshold`).
 
 The data refute that expectation in both response tasks: the optionally factive
-*inform* rates as projective as the canonically factive *reveal* or *discover*
-(0.81 vs 0.70 and 0.78 in experiment 1a; 0.90 vs 0.69 and 0.84 in 1b), so the
-ratings do not separate the class (`certainty1a_not_separated`) and no nonarbitrary
-line can be drawn (`certainty1a_no_threshold`; likewise `certainty1b_*`). The
-entailment experiments undermine definition 3b in turn: in experiment 2a only
-*be right* and *prove* rated with the entailed controls, yet both project below
-every canonically factive predicate (`entailment_projection_dissociation`);
-experiment 2b adds *know*, *see*, *discover*, and *confirm* — a heterogeneous
-class — and the contradictoriness experiments 3a/3b identify no entailed CCs at
-all. Degen & Tonhauser conclude that the experiments support no coherent class of
-factive predicates, while cautioning (their objection 3) that gradient ratings
-alone cannot rule out a binary factivity category combined with lexical ambiguity
-and interpreter uncertainty. The results bear on projection analyses ([heim-1983],
+*inform* outrates the canonically factive *reveal* (0.81 vs 0.70 in experiment 1a,
+0.90 vs 0.69 in 1b), so the ratings do not separate the class and no nonarbitrary
+line can be drawn (`certainty1a_not_separated`, `certainty1a_no_threshold`;
+likewise for 1b). The entailment experiments undermine definition 3b: in
+experiment 2a only *be right* and *prove* rated with the entailed controls, yet
+both project below every canonically factive predicate
+(`entailment_projection_dissociation`); experiment 2b adds *know*, *see*,
+*discover*, and *confirm* — a heterogeneous class — and the contradictoriness
+experiments 3a/3b identify no entailed CCs at all. The paper concludes that no
+coherent class of factive predicates is supported, while cautioning (objection 3)
+that gradient ratings alone cannot rule out a binary category plus lexical
+ambiguity. The results bear on projection analyses ([heim-1983],
 [van-der-sandt-1992]) whose explanandum is delimited by exactly this class.
 
 Per-predicate mean ratings (`certainty1a`, `certainty1b`, `inference2a`) are
-computed from the authors' data at github.com/judith-tonhauser/projective-probability
-(results 5-projectivity-no-fact, 8-projectivity-no-fact-binary, 4-veridicality3),
-rounded to two decimal places, and stored as `ℚ` so comparisons close by `norm_num`.
-The predicates are bridged to their Fragment lexical entries via
-`DegenTonhauser2021.toVerbEntry`; the traditional classification agrees with the
-Fragment's factivity flags (`traditionalClass_consistent_with_fragment`).
+stored as `ℚ`, so comparisons close by `norm_num`; the traditional classification
+agrees with the Fragment's factivity flags
+(`traditionalClass_consistent_with_fragment`).
 -/
 
 namespace DegenTonhauser2022
@@ -66,11 +62,7 @@ def traditionalClass : Predicate → TraditionalClass
   | .acknowledge | .admit | .announce | .confess | .confirm
   | .establish | .hear | .inform | .prove => .optionallyFactive
 
-/-! ### Categorical distinction as separation
-
-Definition 3a expects factive certainty ratings "categorically higher" than the
-rest. For a class and a rating over a finite domain this is the same demand as a
-separating threshold, so a single interleaved pair refutes both readings. -/
+/-! ### Categorical distinction as separation -/
 
 section Separation
 
@@ -110,9 +102,8 @@ end Separation
 Computed from the authors' data at github.com/judith-tonhauser/projective-probability,
 rounded to two decimals and listed in descending order as in the paper's figures. -/
 
-/-- Mean certainty rating by predicate, experiment 1a ('certain that' diagnostic,
-    gradient slider; Figure 2). From results/5-projectivity-no-fact (n = 266 per
-    predicate; nonprojective main-clause control mean 0.11). -/
+/-- Mean certainty rating, experiment 1a ('certain that', gradient slider; Figure 2).
+    From results/5-projectivity-no-fact (n = 266; main-clause control mean 0.11). -/
 def certainty1a : Predicate → ℚ
   | .beAnnoyed => 0.88
   | .know => 0.86
@@ -135,9 +126,9 @@ def certainty1a : Predicate → ℚ
   | .beRight => 0.18
   | .pretend => 0.15
 
-/-- Proportion of 'yes' responses by predicate, experiment 1b ('certain that'
-    diagnostic, forced choice; Figure 4). From results/8-projectivity-no-fact-binary
-    (n = 436 per predicate; main-clause control mean 0.00). -/
+/-- Proportion of 'yes' responses, experiment 1b ('certain that', forced choice;
+    Figure 4). From results/8-projectivity-no-fact-binary (n = 436; main-clause
+    control mean 0.00). -/
 def certainty1b : Predicate → ℚ
   | .know => 0.93
   | .beAnnoyed => 0.92
@@ -160,9 +151,9 @@ def certainty1b : Predicate → ℚ
   | .think => 0.04
   | .beRight => 0.03
 
-/-- Mean inference rating by predicate, experiment 2a ('does it follow' diagnostic,
-    gradient slider; Figure 9). From results/4-veridicality3 (n = 259 per predicate;
-    entailing control mean 0.96, non-entailing control mean 0.03). -/
+/-- Mean inference rating, experiment 2a ('does it follow', gradient slider;
+    Figure 9). From results/4-veridicality3 (n = 259; entailing control mean 0.96,
+    non-entailing 0.03). -/
 def inference2a : Predicate → ℚ
   | .prove => 0.96
   | .beRight => 0.96
@@ -193,9 +184,8 @@ theorem certainty1a_not_separated :
     ¬ Separates (traditionalClass · = .factive) certainty1a :=
   not_separates (p := .reveal) (q := .inform) rfl (by decide) (by norm_num [certainty1a])
 
-/-- Hence no threshold recovers the classification from the exp 1a ratings — the
-    paper's "a nonarbitrary line between canonically factive and optionally factive
-    predicates cannot be drawn". -/
+/-- No threshold recovers the classification from the exp 1a ratings — the paper's
+    "nonarbitrary line" argument. -/
 theorem certainty1a_no_threshold :
     ¬ ∃ t, ∀ p, traditionalClass p = .factive ↔ t < certainty1a p :=
   fun h => certainty1a_not_separated
@@ -215,10 +205,9 @@ theorem certainty1b_no_threshold :
 
 /-! ### Entailment vs projection (definition 3b) -/
 
-/-- Exp 2a's best contenders for factivity under definition 3b are the least
-    projective: *be right* and *prove* carry the top inference ratings (0.96 each,
-    level with the entailed controls) yet project below every canonically factive
-    predicate (0.18 and 0.30 vs 0.70 at the bottom of the factive class). -/
+/-- Definition 3b's best contenders are the least projective: *be right* and *prove*
+    carry the top exp 2a inference ratings yet project below every canonically
+    factive predicate. -/
 theorem entailment_projection_dissociation :
     (∀ p, inference2a p ≤ inference2a .beRight ∧ inference2a p ≤ inference2a .prove) ∧
     (∀ p, traditionalClass p = .factive →
@@ -235,10 +224,9 @@ section FragmentBridge
 
 open English.Predicates.Verbal English.Predicates.Copular
 
-/-- Canonically factive verbs have `factivePresup = true` in the Fragment,
-    matching the classification in (13). "be annoyed" is copular and emotive —
-    its presupposition derives from emotive semantics, not doxastic veridicality —
-    and is covered by `copular_presup_matches_classification`. -/
+/-- Canonically factive verbs have `factivePresup = true` in the Fragment, matching
+    (13); the copular "be annoyed" is covered by
+    `copular_presup_matches_classification`. -/
 theorem factive_entries_have_factivePresup :
     know.factivePresup = true ∧ discover.factivePresup = true ∧
     see.factivePresup = true ∧ reveal.factivePresup = true :=
@@ -250,9 +238,8 @@ theorem nonfactive_entries_lack_factivePresup :
     say.factivePresup = false ∧ think.factivePresup = false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
-/-- The traditional classification is consistent with Fragment factivity for
-    verbal entries: factive verbs have `factivePresup = true`, nonveridical
-    nonfactives `false`. -/
+/-- The traditional classification matches Fragment factivity: factive verbs have
+    `factivePresup = true`, nonveridical nonfactives `false`. -/
 theorem traditionalClass_consistent_with_fragment (p : Predicate)
     (v : VerbEntry) (h : toVerbEntry p = some v) :
     (traditionalClass p = .factive → v.factivePresup = true) ∧
@@ -260,9 +247,7 @@ theorem traditionalClass_consistent_with_fragment (p : Predicate)
   cases p <;> (unfold toVerbEntry at h; cases h) <;>
     refine ⟨fun hc => ?_, fun hc => ?_⟩ <;> first | rfl | simp [traditionalClass] at hc
 
-/-- "be annoyed" is a presupposition trigger (emotive factive) while "be right"
-    is not, matching (13): factives trigger presuppositions, veridical
-    nonfactives do not. -/
+/-- "be annoyed" is a presupposition trigger while "be right" is not, matching (13). -/
 theorem copular_presup_matches_classification :
     (toPredicateCore .beAnnoyed).isPresupTrigger = true ∧
     (toPredicateCore .beRight).isPresupTrigger = false :=

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -388,11 +388,9 @@ end ScontrasTonhauserBridge
 
 section EmpiricalAnchor
 
-/-- Under the discrete-factivity model with `τ_know > τ_think`, the model
-    predicts a `know > think` projection ordering. The empirical ordering
-    from [degen-tonhauser-2022] (exp 1a, gradient slider) confirms this
-    direction: mean certainty ratings for *know* exceed those for *think*
-    (0.86 vs 0.20). -/
+/-- With `τ_know > τ_think` the discrete-factivity model predicts a `know > think`
+    projection ordering; [degen-tonhauser-2022]'s exp 1a ratings confirm the
+    direction (0.86 vs 0.20). -/
 theorem empirical_ordering_consistent_with_tau :
     certainty1a .know > certainty1a .think := by
   norm_num [certainty1a]


### PR DESCRIPTION
Mathlib-register pass over #2108/#2109's docstrings: drops editorial openers and meta-commentary clauses, section-intro prose restating the module docstring, duplicated provenance, and "by predicate" type restatements; declaration docstrings cut to one or two plain sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)