### PR TITLE
refactor(Core/Order/Rat01): dissolve into mathlib Icc API, compl to symm

### DIFF
--- a/Linglib/Core/Order/Rat01.lean
+++ b/Linglib/Core/Order/Rat01.lean
@@ -1,95 +1,76 @@
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.Rat.Defs
+import Mathlib.Algebra.Order.Interval.Set.Instances
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
+import Mathlib.Order.Monotone.Basic
 import Mathlib.Tactic.NormNum
 import Linglib.Core.Order.Comparison
-import Mathlib.Tactic.Linarith
-import Mathlib.Order.Monotone.Basic
 
 /-!
-# Core/Scales/Rat01.lean — rational unit interval
+# The rational unit interval
 
-A rational number in [0, 1] for gradient linguistic properties
-(at-issueness, projectivity) and their contextual thresholds.
+`Rat01` is `↥(Set.Icc (0 : ℚ) 1)`, the home of gradient linguistic degrees
+(at-issueness, projectivity, prior credence) and their contextual thresholds.
+Mathlib's `unitInterval` is real-valued and topological, while linguistic degrees
+are exact rationals, so this file instantiates the same interface at `ℚ`: the
+algebraic structure and `0`, `1` come from
+`Mathlib.Algebra.Order.Interval.Set.Instances`, and `symm` mirrors
+`unitInterval.symm`.
 
-This file is part of the Phase A decomposition of the legacy
-`Core/Scales/Scale.lean` dumping ground (master plan v4).
+`[UPSTREAM]` `symm` and its lemmas generalize verbatim to `Set.Icc (0 : β) 1`
+over an ordered ring — a stated TODO of
+`Mathlib.Algebra.Order.Interval.Set.Instances`.
 -/
 
 namespace Core.Order
 
--- ════════════════════════════════════════════════════
--- § 1a. Rational Unit Interval
--- ════════════════════════════════════════════════════
-
-/-- A rational number in the unit interval [0, 1].
-
-    Wraps Mathlib's `Set.Icc` subtype for gradient linguistic properties
-    (at-issueness, projectivity, etc.) and their contextual thresholds.
-    Using `Set.Icc` gives us standard interval infrastructure from Mathlib
-    (order, membership, etc.) without custom boilerplate.
-
-    Access: `r.val` for the rational value, `r.prop.1` for `0 ≤ r`,
-    `r.prop.2` for `r ≤ 1`. -/
+/-- The unit interval of rationals — the `ℚ` counterpart of `unitInterval`. -/
 abbrev Rat01 := ↥(Set.Icc (0 : ℚ) 1)
 
 namespace Rat01
 
-/-- The rational value. -/
-abbrev value (r : Rat01) : ℚ := r.val
-
-/-- Proof that the value is non-negative. -/
-theorem nonneg (r : Rat01) : 0 ≤ r.val := r.prop.1
-
-/-- Proof that the value is at most 1. -/
-theorem le_one (r : Rat01) : r.val ≤ 1 := r.prop.2
-
 instance : Repr Rat01 where
   reprPrec r _ := repr r.val
 
-/-- The endpoint 0. -/
-def zero : Rat01 := ⟨0, by norm_num, by norm_num⟩
-
-/-- The endpoint 1. -/
-def one : Rat01 := ⟨1, by norm_num, by norm_num⟩
-
-/-- The endpoints are distinct: `zero < one`. -/
-theorem zero_lt_one : zero < one := by
-  rw [zero, one, Subtype.mk_lt_mk]; norm_num
+instance : NeZero (1 : Rat01) := ⟨Set.Icc.coe_ne_zero.mp one_ne_zero⟩
 
 /-- The midpoint ½, the standard default threshold. -/
 def half : Rat01 := ⟨1/2, by norm_num, by norm_num⟩
 
 /-- Does the value strictly exceed a threshold? The `Rat01` face of
-`Core.Order.Comparison.gt.over`. -/
+    `Core.Order.Comparison.gt.over`. -/
 def exceeds (d θ : Rat01) : Prop :=
   d ∈ Core.Order.Comparison.gt.over Subtype.val θ.val
 
 instance (d θ : Rat01) : Decidable (exceeds d θ) :=
   inferInstanceAs (Decidable (θ.val < d.val))
 
-/-- The complement `1 - r`, again in `[0, 1]`.
+/-- The involution `1 - r` — e.g. not-at-issueness from at-issueness. Mirrors
+    `unitInterval.symm`. -/
+def symm (r : Rat01) : Rat01 :=
+  ⟨1 - r.val, Set.Icc.mem_iff_one_sub_mem.mp r.prop⟩
 
-    Models the relationship between a gradient property and its dual on the
-    same scale — e.g. not-at-issueness as the complement of at-issueness. -/
-def compl (r : Rat01) : Rat01 :=
-  ⟨1 - r.val, by linarith [r.le_one], by linarith [r.nonneg]⟩
+@[simp] theorem coe_symm_eq (r : Rat01) : (symm r).val = 1 - r.val := rfl
 
-@[simp] theorem compl_val (r : Rat01) : (compl r).val = 1 - r.val := rfl
+@[simp] theorem symm_symm (r : Rat01) : symm (symm r) = r :=
+  Subtype.ext (by simp)
 
-@[simp] theorem compl_compl (r : Rat01) : compl (compl r) = r := by
-  apply Subtype.ext; simp
+theorem symm_zero : symm 0 = 1 := Subtype.ext (by simp)
 
-theorem compl_zero : compl zero = one := by apply Subtype.ext; simp [zero, one]
+theorem symm_one : symm 1 = 0 := Subtype.ext (by simp)
 
-theorem compl_one : compl one = zero := by apply Subtype.ext; simp [zero, one]
+theorem symm_involutive : Function.Involutive symm := symm_symm
 
-/-- The complement is order-reversing: a larger value has a smaller complement. -/
-theorem compl_antitone : Antitone compl := by
-  intro a b h
-  show 1 - b.val ≤ 1 - a.val
-  have : a.val ≤ b.val := h
-  linarith
+theorem symm_bijective : Function.Bijective symm := symm_involutive.bijective
+
+theorem symm_inj {r s : Rat01} : symm r = symm s ↔ r = s :=
+  symm_bijective.injective.eq_iff
+
+theorem symm_eq_one {r : Rat01} : symm r = 1 ↔ r = 0 := by rw [← symm_zero, symm_inj]
+
+theorem symm_eq_zero {r : Rat01} : symm r = 0 ↔ r = 1 := by rw [← symm_one, symm_inj]
+
+/-- `symm` is order-reversing. -/
+theorem symm_antitone : Antitone symm := fun _ _ h =>
+  Subtype.mk_le_mk.mpr (sub_le_sub_left (Subtype.coe_le_coe.mpr h) 1)
 
 end Rat01
 

--- a/Linglib/Data/Generalizations/Projectivity.lean
+++ b/Linglib/Data/Generalizations/Projectivity.lean
@@ -1,6 +1,7 @@
 import Linglib.Core.Order.Rat01
 import Linglib.Data.Examples.TonhauserBeaverDegen2018
 import Linglib.Data.Examples.SolstadBott2024
+import Mathlib.Tactic.Linarith
 
 /-!
 # Generalizations.Projectivity — cross-paper data pool
@@ -54,7 +55,7 @@ structure ProjectionDatum where
 /-- Not-at-issueness is the complement of at-issueness — the quantity the GPP
     equates with projectivity. -/
 def ProjectionDatum.notAtIssueness (d : ProjectionDatum) : Rat01 :=
-  Rat01.compl d.atIssueness
+  Rat01.symm d.atIssueness
 
 /-! ### `LinguisticExample` adapter -/
 
@@ -75,7 +76,7 @@ def parsePercent (s : String) : Option Rat01 :=
 def readAtIssueness (pf : List (String × String)) : Option Rat01 :=
   match pf.lookup "atIssueness" with
   | some s => parsePercent s
-  | none => ((pf.lookup "notAtIssueness").bind parsePercent).map Rat01.compl
+  | none => ((pf.lookup "notAtIssueness").bind parsePercent).map Rat01.symm
 
 /-- Lift a `LinguisticExample` to a `ProjectionDatum` via its `expression`,
     `projectivity`, and (`atIssueness` or `notAtIssueness`) keys; `none` if any

--- a/Linglib/Studies/DegenTonhauser2021.lean
+++ b/Linglib/Studies/DegenTonhauser2021.lean
@@ -78,7 +78,7 @@ theorem priorInsensitive_no_modulation (c p q : Rat01) :
 /-- The null account is not prior-sensitive. -/
 theorem priorInsensitive_not_sensitive (c : Rat01) :
     ¬ PriorSensitive (priorInsensitive c) :=
-  fun h => lt_irrefl c (h Rat01.zero_lt_one)
+  fun h => lt_irrefl c (h zero_lt_one)
 
 /-- A prior-sensitive account predicts stronger projection for higher-prior content. -/
 theorem sensitive_predicts_modulation {acc : PriorAccount} (h : PriorSensitive acc)

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -212,10 +212,10 @@ theorem discreteFactivity_gradedTruth (τ : Rat01) (w : W) :
 
 /-- With τ = 1 (certainly factive), graded truth reduces to `factivePos`. -/
 theorem discreteFactivity_certain_factive (w : W) :
-    (discreteFactivityPred (W := W) Rat01.one).gradedTruth w =
+    (discreteFactivityPred (W := W) 1).gradedTruth w =
     if factivePos w then 1 else 0 := by
   rw [discreteFactivity_gradedTruth]
-  have hτ : Rat01.toNNReal Rat01.one = 1 := by
+  have hτ : Rat01.toNNReal 1 = 1 := by
     show Real.toNNReal ((1 : ℚ) : ℝ) = 1
     simp
   rw [hτ]
@@ -223,10 +223,10 @@ theorem discreteFactivity_certain_factive (w : W) :
 
 /-- With τ = 0 (certainly nonfactive), graded truth reduces to `nonFactivePos`. -/
 theorem discreteFactivity_certain_nonfactive (w : W) :
-    (discreteFactivityPred (W := W) Rat01.zero).gradedTruth w =
+    (discreteFactivityPred (W := W) 0).gradedTruth w =
     if nonFactivePos (W := W) w then 1 else 0 := by
   rw [discreteFactivity_gradedTruth]
-  have hτ : Rat01.toNNReal Rat01.zero = 0 := by
+  have hτ : Rat01.toNNReal 0 = 0 := by
     show Real.toNNReal ((0 : ℚ) : ℝ) = 0
     simp
   rw [hτ]
@@ -375,10 +375,10 @@ theorem clauseEmbedding_nonfactive_eq_st_think :
     the same predicate across occasions of use. -/
 theorem st_is_limiting_case :
     (∀ w : ScontrasTonhauser2025.WorldState,
-      (discreteFactivityPred Rat01.one).gradedTruth w =
+      (discreteFactivityPred 1).gradedTruth w =
       if ScontrasTonhauser2025.literalMeaning .knowPos w then 1 else 0) ∧
     (∀ w : ScontrasTonhauser2025.WorldState,
-      (discreteFactivityPred Rat01.zero).gradedTruth w =
+      (discreteFactivityPred 0).gradedTruth w =
       if ScontrasTonhauser2025.literalMeaning .thinkPos w then 1 else 0) :=
   ⟨discreteFactivity_certain_factive, discreteFactivity_certain_nonfactive⟩
 

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -5,6 +5,7 @@ import Linglib.Studies.SolstadBott2022
 import Linglib.Fragments.German.Predicates
 import Linglib.Data.Generalizations.Projectivity
 import Linglib.Studies.TonhauserBeaverDegen2018
+import Mathlib.Tactic.Linarith
 
 /-!
 # [solstad-bott-2024]: Cataphoric resolution of projective content — occasion verbs
@@ -258,7 +259,7 @@ theorem gpp_underpredicts_above_diagonal (d : ProjectionDatum)
     (h : d.notAtIssueness.val < d.projectivity.val) :
     (TonhauserBeaverDegen2018.gppProjection d.atIssueness).val < d.projectivity.val := by
   simp only [TonhauserBeaverDegen2018.gppProjection,
-    ProjectionDatum.notAtIssueness, Rat01.compl_val] at *
+    ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
   linarith
 
 end SolstadBott2024

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -1,6 +1,7 @@
 import Linglib.Discourse.QUD.AtIssueness
 import Linglib.Pragmatics.Expressives.Basic
 import Linglib.Data.Generalizations.Projectivity
+import Mathlib.Tactic.Linarith
 
 /-!
 # [tonhauser-beaver-degen-2018]: How Projective Is Projective Content?
@@ -20,7 +21,7 @@ correlation with item-level variance, not this identity (cf. the dependency's
 `MonotoneAntiCorrelation` docstring).
 
 ## Main definitions
-* `gppProjection` — the GPP map, the complement of at-issueness (`Rat01.compl`).
+* `gppProjection` — the GPP map, the complement of at-issueness (`Rat01.symm`).
 * `pottsProjection` — [potts-2005]'s rival: CI projects maximally, at-issueness-blind.
 * both are run against the pooled per-expression data
   (`Generalizations.Projectivity.allData`).
@@ -49,18 +50,16 @@ open Generalizations.Projectivity
 
 /-- The GPP map: projection degree is the complement of at-issueness — content
     projects to the extent it is not at-issue ([tonhauser-beaver-degen-2018]). -/
-def gppProjection (ai : AtIssuenessDegree) : ProjectivityDegree := Rat01.compl ai
+def gppProjection (ai : AtIssuenessDegree) : ProjectivityDegree := Rat01.symm ai
 
 /-- The GPP as order-reversal: more at-issue content is no more projective. -/
-theorem gppProjection_antitone : Antitone gppProjection := Rat01.compl_antitone
+theorem gppProjection_antitone : Antitone gppProjection := Rat01.symm_antitone
 
 /-- Fully not-at-issue content (at-issueness `0`) projects maximally. -/
-theorem gppProjection_zero : gppProjection Rat01.zero = Rat01.one := by
-  apply Subtype.ext; simp [gppProjection, Rat01.zero, Rat01.one]
+theorem gppProjection_zero : gppProjection 0 = 1 := Rat01.symm_zero
 
 /-- Fully at-issue content (at-issueness `1`) does not project. -/
-theorem gppProjection_one : gppProjection Rat01.one = Rat01.zero := by
-  apply Subtype.ext; simp [gppProjection, Rat01.zero, Rat01.one]
+theorem gppProjection_one : gppProjection 1 = 0 := Rat01.symm_one
 
 /-! ### Recovering the binary Projection Principle
 
@@ -69,17 +68,19 @@ at-issue — is the threshold collapse of the gradient GPP. -/
 
 /-- The GPP projects past `θ` iff at-issueness is below the complementary threshold. -/
 theorem gpp_projects_iff (ai θ : Rat01) :
-    isProjective (gppProjection ai) θ ↔ ai.val < (Rat01.compl θ).val := by
-  simp only [isProjective, Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, gppProjection, Rat01.compl_val]
+    isProjective (gppProjection ai) θ ↔ ai.val < (Rat01.symm θ).val := by
+  simp only [isProjective, Rat01.exceeds, Core.Order.Comparison.mem_over,
+    Core.Order.Comparison.rel, gppProjection, Rat01.coe_symm_eq]
   constructor <;> intro h <;> linarith
 
 /-- The binary Projection Principle: never both at-issue and projecting at
     complementary thresholds. -/
 theorem gpp_excludes_atIssue (ai θ : Rat01) :
-    ¬ (isAtIssue ai (Rat01.compl θ) ∧ isProjective (gppProjection ai) θ) := by
+    ¬ (isAtIssue ai (Rat01.symm θ) ∧ isProjective (gppProjection ai) θ) := by
   rintro ⟨ha, hp⟩
-  simp only [isAtIssue, Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, Rat01.compl_val] at ha
-  rw [gpp_projects_iff, Rat01.compl_val] at hp
+  simp only [isAtIssue, Rat01.exceeds, Core.Order.Comparison.mem_over,
+    Core.Order.Comparison.rel, Rat01.coe_symm_eq] at ha
+  rw [gpp_projects_iff, Rat01.coe_symm_eq] at hp
   linarith
 
 /-! ### Contra Potts
@@ -92,7 +93,7 @@ fully-backgrounded content. -/
 
 /-- [potts-2005]'s prediction: CI content projects maximally (degree `1`),
     regardless of at-issueness. -/
-def pottsProjection (_ : AtIssuenessDegree) : ProjectivityDegree := Rat01.one
+def pottsProjection (_ : AtIssuenessDegree) : ProjectivityDegree := 1
 
 @[simp] theorem pottsProjection_val (ai : AtIssuenessDegree) :
     (pottsProjection ai).val = 1 := rfl
@@ -112,19 +113,12 @@ theorem potts_ci_invariant_under_neg {W : Type*} (p : TwoDimProp W) :
     maximally projective". -/
 theorem gpp_below_potts_of_atIssue {ai : AtIssuenessDegree} (h : 0 < ai.val) :
     (gppProjection ai).val < (pottsProjection ai).val := by
-  simp only [gppProjection, pottsProjection, Rat01.compl_val, Rat01.one]; linarith
+  simp only [gppProjection, Rat01.coe_symm_eq, pottsProjection_val]; linarith
 
 /-- The GPP and Potts agree iff the content is fully backgrounded (at-issueness `0`). -/
 theorem gpp_eq_potts_iff_backgrounded (ai : AtIssuenessDegree) :
-    gppProjection ai = pottsProjection ai ↔ ai = Rat01.zero := by
-  constructor
-  · intro h
-    apply Subtype.ext
-    have hv : (gppProjection ai).val = (pottsProjection ai).val := by rw [h]
-    simp only [gppProjection, pottsProjection, Rat01.compl_val, Rat01.one] at hv
-    simp only [Rat01.zero]; linarith
-  · intro h; subst h; apply Subtype.ext
-    simp [gppProjection, pottsProjection, Rat01.zero, Rat01.one]
+    gppProjection ai = pottsProjection ai ↔ ai = 0 :=
+  Rat01.symm_eq_one
 
 /-- Potts files appositives in the independent CI dimension — the source of the
     maximal-projection prediction the GPP refines. -/
@@ -163,7 +157,7 @@ theorem appositive_not_maximally_projective
     {apposAI : AtIssuenessDegree} (h : 0 < apposAI.val) :
     (gppProjection apposAI).val < 1 := by
   have := gpp_below_potts_of_atIssue h
-  simpa [pottsProjection, Rat01.one] using this
+  simpa using this
 
 /-! ### Predicting against the data
 
@@ -183,7 +177,7 @@ theorem gpp_errs_off_diagonal (d : ProjectionDatum)
     0 < predictionError gppProjection d := by
   rw [predictionError, gppProjection, abs_pos]
   intro hc; apply h
-  simp only [ProjectionDatum.notAtIssueness, Rat01.compl_val] at *
+  simp only [ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
   linarith [sub_eq_zero.mp hc]
 
 /-- Potts over-predicts every content below the ceiling (projectivity `< 1`). -/
@@ -200,7 +194,7 @@ theorem gpp_beats_potts_below_diagonal (d : ProjectionDatum)
     (h1 : d.projectivity.val < d.notAtIssueness.val) (h2 : d.notAtIssueness.val < 1) :
     predictionError gppProjection d < predictionError pottsProjection d := by
   rw [predictionError, predictionError, gppProjection]
-  simp only [pottsProjection_val, ProjectionDatum.notAtIssueness, Rat01.compl_val] at *
+  simp only [pottsProjection_val, ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
   rw [abs_of_pos (by linarith), abs_of_pos (by linarith)]
   linarith
 


### PR DESCRIPTION
Rat01 duplicated mathlib: `Mathlib.Algebra.Order.Interval.Set.Instances` already gives `Set.Icc (0:ℚ) 1` its `0`/`1`, coe simp lemmas, `nonneg`/`le_one`, monoid structure, and the `1 - t` membership lemmas.

- Deletes the unconsumed `value`/`nonneg`/`le_one` aliases and `zero`/`one` (consumers migrate to mathlib's literals; `zero_lt_one` becomes the generic fact via a `NeZero` instance).
- `compl` becomes `symm`, mirroring `unitInterval.symm` (`coe_symm_eq`, `symm_symm`, `symm_zero/one`, `symm_inj`, `symm_eq_one/zero`, `symm_antitone`), built on `Set.Icc.mem_iff_one_sub_mem`; marked `[UPSTREAM]` — the generalization is a stated TODO of the mathlib Instances file. `half`, `exceeds`, and `Repr` stay.
- Three consumers gain the `Mathlib.Tactic.Linarith` leaf import they had been inheriting through Rat01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)