### PR TITLE
refactor(Core/Order/Rat01): generic Set.Icc.symm; dissolve half/exceeds/Repr

### DIFF
--- a/Linglib/Core/Order/Rat01.lean
+++ b/Linglib/Core/Order/Rat01.lean
@@ -1,77 +1,66 @@
 import Mathlib.Algebra.Order.Interval.Set.Instances
 import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Order.Monotone.Basic
-import Mathlib.Tactic.NormNum
-import Linglib.Core.Order.Comparison
 
 /-!
-# The rational unit interval
+# The unit-interval involution, and the rational unit interval
 
-`Rat01` is `↥(Set.Icc (0 : ℚ) 1)`, the home of gradient linguistic degrees
-(at-issueness, projectivity, prior credence) and their contextual thresholds.
-Mathlib's `unitInterval` is real-valued and topological, while linguistic degrees
-are exact rationals, so this file instantiates the same interface at `ℚ`: the
-algebraic structure and `0`, `1` come from
-`Mathlib.Algebra.Order.Interval.Set.Instances`, and `symm` mirrors
-`unitInterval.symm`.
+The `Set.Icc` section states the involution `1 - t` of `Set.Icc (0 : β) 1` and
+its lemmas at the generality of `Mathlib.Algebra.Order.Interval.Set.Instances` —
+`[UPSTREAM]` verbatim: generalizing `unitInterval.symm` beyond `ℝ` is a stated
+TODO of that file.
 
-`[UPSTREAM]` `symm` and its lemmas generalize verbatim to `Set.Icc (0 : β) 1`
-over an ordered ring — a stated TODO of
-`Mathlib.Algebra.Order.Interval.Set.Instances`.
+`Rat01` abbreviates `↥(Set.Icc (0 : ℚ) 1)`, the home of gradient linguistic
+degrees (at-issueness, projectivity, prior credence) and their contextual
+thresholds; mathlib's `unitInterval` is real-valued and topological, while
+linguistic degrees are exact rationals. Its `0`, `1`, and algebraic structure
+come from the mathlib instances.
 -/
+
+namespace Set.Icc
+
+variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
+
+instance [NeZero (1 : β)] : NeZero (1 : Icc (0 : β) 1) :=
+  ⟨coe_ne_zero.mp (NeZero.ne 1)⟩
+
+/-- The involution `1 - t` of the unit interval — `unitInterval.symm` at the
+    generality of this file's instances. -/
+def symm (t : Icc (0 : β) 1) : Icc (0 : β) 1 :=
+  ⟨1 - t, mem_iff_one_sub_mem.mp t.prop⟩
+
+@[simp] theorem coe_symm_eq (t : Icc (0 : β) 1) : (symm t : β) = 1 - t := rfl
+
+@[simp] theorem symm_symm (t : Icc (0 : β) 1) : symm (symm t) = t :=
+  Subtype.ext (by simp)
+
+theorem symm_zero : symm (0 : Icc (0 : β) 1) = 1 := Subtype.ext (by simp)
+
+theorem symm_one : symm (1 : Icc (0 : β) 1) = 0 := Subtype.ext (by simp)
+
+theorem symm_involutive : Function.Involutive (symm : Icc (0 : β) 1 → Icc (0 : β) 1) :=
+  symm_symm
+
+theorem symm_bijective : Function.Bijective (symm : Icc (0 : β) 1 → Icc (0 : β) 1) :=
+  symm_involutive.bijective
+
+theorem symm_inj {s t : Icc (0 : β) 1} : symm s = symm t ↔ s = t :=
+  symm_bijective.injective.eq_iff
+
+theorem symm_eq_one {t : Icc (0 : β) 1} : symm t = 1 ↔ t = 0 := by
+  rw [← symm_zero, symm_inj]
+
+theorem symm_eq_zero {t : Icc (0 : β) 1} : symm t = 0 ↔ t = 1 := by
+  rw [← symm_one, symm_inj]
+
+theorem symm_antitone : Antitone (symm : Icc (0 : β) 1 → Icc (0 : β) 1) := fun _ _ h =>
+  Subtype.mk_le_mk.mpr (sub_le_sub_left (Subtype.coe_le_coe.mpr h) 1)
+
+end Set.Icc
 
 namespace Core.Order
 
 /-- The unit interval of rationals — the `ℚ` counterpart of `unitInterval`. -/
 abbrev Rat01 := ↥(Set.Icc (0 : ℚ) 1)
-
-namespace Rat01
-
-instance : Repr Rat01 where
-  reprPrec r _ := repr r.val
-
-instance : NeZero (1 : Rat01) := ⟨Set.Icc.coe_ne_zero.mp one_ne_zero⟩
-
-/-- The midpoint ½, the standard default threshold. -/
-def half : Rat01 := ⟨1/2, by norm_num, by norm_num⟩
-
-/-- Does the value strictly exceed a threshold? The `Rat01` face of
-    `Core.Order.Comparison.gt.over`. -/
-def exceeds (d θ : Rat01) : Prop :=
-  d ∈ Core.Order.Comparison.gt.over Subtype.val θ.val
-
-instance (d θ : Rat01) : Decidable (exceeds d θ) :=
-  inferInstanceAs (Decidable (θ.val < d.val))
-
-/-- The involution `1 - r` — e.g. not-at-issueness from at-issueness. Mirrors
-    `unitInterval.symm`. -/
-def symm (r : Rat01) : Rat01 :=
-  ⟨1 - r.val, Set.Icc.mem_iff_one_sub_mem.mp r.prop⟩
-
-@[simp] theorem coe_symm_eq (r : Rat01) : (symm r).val = 1 - r.val := rfl
-
-@[simp] theorem symm_symm (r : Rat01) : symm (symm r) = r :=
-  Subtype.ext (by simp)
-
-theorem symm_zero : symm 0 = 1 := Subtype.ext (by simp)
-
-theorem symm_one : symm 1 = 0 := Subtype.ext (by simp)
-
-theorem symm_involutive : Function.Involutive symm := symm_symm
-
-theorem symm_bijective : Function.Bijective symm := symm_involutive.bijective
-
-theorem symm_inj {r s : Rat01} : symm r = symm s ↔ r = s :=
-  symm_bijective.injective.eq_iff
-
-theorem symm_eq_one {r : Rat01} : symm r = 1 ↔ r = 0 := by rw [← symm_zero, symm_inj]
-
-theorem symm_eq_zero {r : Rat01} : symm r = 0 ↔ r = 1 := by rw [← symm_one, symm_inj]
-
-/-- `symm` is order-reversing. -/
-theorem symm_antitone : Antitone symm := fun _ _ h =>
-  Subtype.mk_le_mk.mpr (sub_le_sub_left (Subtype.coe_le_coe.mpr h) 1)
-
-end Rat01
 
 end Core.Order

--- a/Linglib/Data/Generalizations/Projectivity.lean
+++ b/Linglib/Data/Generalizations/Projectivity.lean
@@ -50,12 +50,11 @@ structure ProjectionDatum where
   projectivity : Rat01
   atIssueness  : Rat01
   source       : SourceRef
-  deriving Repr
 
 /-- Not-at-issueness is the complement of at-issueness — the quantity the GPP
     equates with projectivity. -/
 def ProjectionDatum.notAtIssueness (d : ProjectionDatum) : Rat01 :=
-  Rat01.symm d.atIssueness
+  Set.Icc.symm d.atIssueness
 
 /-! ### `LinguisticExample` adapter -/
 
@@ -76,7 +75,7 @@ def parsePercent (s : String) : Option Rat01 :=
 def readAtIssueness (pf : List (String × String)) : Option Rat01 :=
   match pf.lookup "atIssueness" with
   | some s => parsePercent s
-  | none => ((pf.lookup "notAtIssueness").bind parsePercent).map Rat01.symm
+  | none => ((pf.lookup "notAtIssueness").bind parsePercent).map Set.Icc.symm
 
 /-- Lift a `LinguisticExample` to a `ProjectionDatum` via its `expression`,
     `projectivity`, and (`atIssueness` or `notAtIssueness`) keys; `none` if any

--- a/Linglib/Discourse/QUD/AtIssueness.lean
+++ b/Linglib/Discourse/QUD/AtIssueness.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Core.Order.Boundedness
+import Linglib.Core.Order.Comparison
 import Linglib.Core.Order.Rat01
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Linarith
@@ -26,18 +27,19 @@ abbrev AtIssuenessThreshold := Rat01
 /-- Contextual threshold for projectivity classification. -/
 abbrev ProjectivityThreshold := Rat01
 /-! ### Threshold Semantics -/
-/-- Content is at-issue when its degree exceeds the threshold. -/
+/-- Content is at-issue when its degree exceeds the threshold — the
+    `Core.Order.Comparison.gt.over` face of the scale. -/
 def isAtIssue (d : AtIssuenessDegree) (θ : AtIssuenessThreshold) : Prop :=
-  Rat01.exceeds d θ
+  d ∈ Core.Order.Comparison.gt.over Subtype.val θ.val
 instance (d : AtIssuenessDegree) (θ : AtIssuenessThreshold) :
     Decidable (isAtIssue d θ) :=
-  inferInstanceAs (Decidable (Rat01.exceeds d θ))
+  inferInstanceAs (Decidable (θ.val < d.val))
 /-- Content is projective when its projectivity degree exceeds the threshold. -/
 def isProjective (d : ProjectivityDegree) (θ : ProjectivityThreshold) : Prop :=
-  Rat01.exceeds d θ
+  d ∈ Core.Order.Comparison.gt.over Subtype.val θ.val
 instance (d : ProjectivityDegree) (θ : ProjectivityThreshold) :
     Decidable (isProjective d θ) :=
-  inferInstanceAs (Decidable (Rat01.exceeds d θ))
+  inferInstanceAs (Decidable (θ.val < d.val))
 /-! ### Classical Recovery -/
 /-- Binary at-issueness, recoverable from gradient degree + threshold. -/
 inductive AtIssuenessClassical where
@@ -48,9 +50,9 @@ inductive AtIssuenessClassical where
 def toClassical (d : AtIssuenessDegree) (θ : AtIssuenessThreshold) : AtIssuenessClassical :=
   if isAtIssue d θ then .atIssue else .notAtIssue
 /-- Default threshold at 0.5, matching the midpoint of the [0, 1] scale. -/
-def defaultThreshold : AtIssuenessThreshold := Rat01.half
+def defaultThreshold : AtIssuenessThreshold := ⟨1/2, by norm_num, by norm_num⟩
 /-- Default projectivity threshold at 0.5. -/
-def defaultProjectivityThreshold : ProjectivityThreshold := Rat01.half
+def defaultProjectivityThreshold : ProjectivityThreshold := ⟨1/2, by norm_num, by norm_num⟩
 /-! ### Anti-Correlation -/
 /-- A pair of at-issueness and projectivity ratings for a single expression. -/
 structure GradientPair where

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -1144,20 +1144,20 @@ def factiveComplementAI : AtIssuenessDegree := ⟨3/4, by norm_num, by norm_num�
 
 private theorem isAtIssue_lexical :
     ¬ isAtIssue (complementAtIssueness .lexical) defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, complementAtIssueness,
-             defaultThreshold, Core.Order.Rat01.half, not_lt]
+  simp only [isAtIssue, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel,
+             complementAtIssueness, defaultThreshold, not_lt]
   norm_num
 
 private theorem isAtIssue_none :
     isAtIssue (complementAtIssueness .none) defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, complementAtIssueness,
-             defaultThreshold, Core.Order.Rat01.half]
+  simp only [isAtIssue, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel,
+             complementAtIssueness, defaultThreshold]
   norm_num
 
 private theorem isAtIssue_factive :
     isAtIssue factiveComplementAI defaultThreshold := by
-  simp only [isAtIssue, Core.Order.Rat01.exceeds, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel, factiveComplementAI,
-             defaultThreshold, Core.Order.Rat01.half]
+  simp only [isAtIssue, Core.Order.Comparison.mem_over, Core.Order.Comparison.rel,
+             factiveComplementAI, defaultThreshold]
   norm_num
 
 -- ── Known-case recovery ──────────────────────────────────────────────
@@ -1207,7 +1207,7 @@ theorem predictIsland_monotone (d₁ d₂ : AtIssuenessDegree)
   by_cases h₁ : isAtIssue d₁ θ <;> by_cases h₂ : isAtIssue d₂ θ <;>
     simp [h₁, h₂]
   -- Contradictory case: d₁ at-issue but d₂ not, yet d₁.val ≤ d₂.val
-  unfold isAtIssue Core.Order.Rat01.exceeds at h₁ h₂
+  unfold isAtIssue at h₁ h₂
   simp only [Core.Order.Comparison.mem_over, Core.Order.Comparison.rel] at h₁ h₂
   rw [not_lt] at h₂
   exact absurd (lt_of_lt_of_le h₁ (le_trans h h₂)) (lt_irrefl _)

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -259,7 +259,7 @@ theorem gpp_underpredicts_above_diagonal (d : ProjectionDatum)
     (h : d.notAtIssueness.val < d.projectivity.val) :
     (TonhauserBeaverDegen2018.gppProjection d.atIssueness).val < d.projectivity.val := by
   simp only [TonhauserBeaverDegen2018.gppProjection,
-    ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
+    ProjectionDatum.notAtIssueness, Set.Icc.coe_symm_eq] at *
   linarith
 
 end SolstadBott2024

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -21,7 +21,7 @@ correlation with item-level variance, not this identity (cf. the dependency's
 `MonotoneAntiCorrelation` docstring).
 
 ## Main definitions
-* `gppProjection` — the GPP map, the complement of at-issueness (`Rat01.symm`).
+* `gppProjection` — the GPP map, the complement of at-issueness (`Set.Icc.symm`).
 * `pottsProjection` — [potts-2005]'s rival: CI projects maximally, at-issueness-blind.
 * both are run against the pooled per-expression data
   (`Generalizations.Projectivity.allData`).
@@ -50,16 +50,16 @@ open Generalizations.Projectivity
 
 /-- The GPP map: projection degree is the complement of at-issueness — content
     projects to the extent it is not at-issue ([tonhauser-beaver-degen-2018]). -/
-def gppProjection (ai : AtIssuenessDegree) : ProjectivityDegree := Rat01.symm ai
+def gppProjection (ai : AtIssuenessDegree) : ProjectivityDegree := Set.Icc.symm ai
 
 /-- The GPP as order-reversal: more at-issue content is no more projective. -/
-theorem gppProjection_antitone : Antitone gppProjection := Rat01.symm_antitone
+theorem gppProjection_antitone : Antitone gppProjection := Set.Icc.symm_antitone
 
 /-- Fully not-at-issue content (at-issueness `0`) projects maximally. -/
-theorem gppProjection_zero : gppProjection 0 = 1 := Rat01.symm_zero
+theorem gppProjection_zero : gppProjection 0 = 1 := Set.Icc.symm_zero
 
 /-- Fully at-issue content (at-issueness `1`) does not project. -/
-theorem gppProjection_one : gppProjection 1 = 0 := Rat01.symm_one
+theorem gppProjection_one : gppProjection 1 = 0 := Set.Icc.symm_one
 
 /-! ### Recovering the binary Projection Principle
 
@@ -68,19 +68,19 @@ at-issue — is the threshold collapse of the gradient GPP. -/
 
 /-- The GPP projects past `θ` iff at-issueness is below the complementary threshold. -/
 theorem gpp_projects_iff (ai θ : Rat01) :
-    isProjective (gppProjection ai) θ ↔ ai.val < (Rat01.symm θ).val := by
-  simp only [isProjective, Rat01.exceeds, Core.Order.Comparison.mem_over,
-    Core.Order.Comparison.rel, gppProjection, Rat01.coe_symm_eq]
+    isProjective (gppProjection ai) θ ↔ ai.val < (Set.Icc.symm θ).val := by
+  simp only [isProjective, Core.Order.Comparison.mem_over,
+    Core.Order.Comparison.rel, gppProjection, Set.Icc.coe_symm_eq]
   constructor <;> intro h <;> linarith
 
 /-- The binary Projection Principle: never both at-issue and projecting at
     complementary thresholds. -/
 theorem gpp_excludes_atIssue (ai θ : Rat01) :
-    ¬ (isAtIssue ai (Rat01.symm θ) ∧ isProjective (gppProjection ai) θ) := by
+    ¬ (isAtIssue ai (Set.Icc.symm θ) ∧ isProjective (gppProjection ai) θ) := by
   rintro ⟨ha, hp⟩
-  simp only [isAtIssue, Rat01.exceeds, Core.Order.Comparison.mem_over,
-    Core.Order.Comparison.rel, Rat01.coe_symm_eq] at ha
-  rw [gpp_projects_iff, Rat01.coe_symm_eq] at hp
+  simp only [isAtIssue, Core.Order.Comparison.mem_over,
+    Core.Order.Comparison.rel, Set.Icc.coe_symm_eq] at ha
+  rw [gpp_projects_iff, Set.Icc.coe_symm_eq] at hp
   linarith
 
 /-! ### Contra Potts
@@ -113,12 +113,12 @@ theorem potts_ci_invariant_under_neg {W : Type*} (p : TwoDimProp W) :
     maximally projective". -/
 theorem gpp_below_potts_of_atIssue {ai : AtIssuenessDegree} (h : 0 < ai.val) :
     (gppProjection ai).val < (pottsProjection ai).val := by
-  simp only [gppProjection, Rat01.coe_symm_eq, pottsProjection_val]; linarith
+  simp only [gppProjection, Set.Icc.coe_symm_eq, pottsProjection_val]; linarith
 
 /-- The GPP and Potts agree iff the content is fully backgrounded (at-issueness `0`). -/
 theorem gpp_eq_potts_iff_backgrounded (ai : AtIssuenessDegree) :
     gppProjection ai = pottsProjection ai ↔ ai = 0 :=
-  Rat01.symm_eq_one
+  Set.Icc.symm_eq_one
 
 /-- Potts files appositives in the independent CI dimension — the source of the
     maximal-projection prediction the GPP refines. -/
@@ -177,7 +177,7 @@ theorem gpp_errs_off_diagonal (d : ProjectionDatum)
     0 < predictionError gppProjection d := by
   rw [predictionError, gppProjection, abs_pos]
   intro hc; apply h
-  simp only [ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
+  simp only [ProjectionDatum.notAtIssueness, Set.Icc.coe_symm_eq] at *
   linarith [sub_eq_zero.mp hc]
 
 /-- Potts over-predicts every content below the ceiling (projectivity `< 1`). -/
@@ -194,7 +194,7 @@ theorem gpp_beats_potts_below_diagonal (d : ProjectionDatum)
     (h1 : d.projectivity.val < d.notAtIssueness.val) (h2 : d.notAtIssueness.val < 1) :
     predictionError gppProjection d < predictionError pottsProjection d := by
   rw [predictionError, predictionError, gppProjection]
-  simp only [pottsProjection_val, ProjectionDatum.notAtIssueness, Rat01.coe_symm_eq] at *
+  simp only [pottsProjection_val, ProjectionDatum.notAtIssueness, Set.Icc.coe_symm_eq] at *
   rw [abs_of_pos (by linarith), abs_of_pos (by linarith)]
   linarith
 


### PR DESCRIPTION
Aligns Rat01 maximally with mathlib, following up #2111.

- The `symm` family is restated generically in `namespace Set.Icc` over `[Ring β] [PartialOrder β] [IsOrderedRing β]` (the Instances file's own section header), plus a generic `NeZero (1 : Icc (0:β) 1)` instance — the `[UPSTREAM]` payload for mathlib's stated TODO of generalizing `unitInterval` lemmas; consumers use the `Set.Icc.*` names inline.
- `half`, `exceeds`, and the `Repr` instance dissolve into their owners: the default thresholds and `isAtIssue`/`isProjective` inline their bodies in `Discourse.QUD.AtIssueness` (which now imports `Comparison` directly), and `ProjectionDatum` drops its unused `deriving Repr`.
- `Rat01.lean` is now the generic section plus the bare abbrev, importing only mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)