### PR TITLE
refactor(Core): dissolve Rat01 name; symm to mirror-path Instances file

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -14,6 +14,7 @@ import Linglib.Core.Algebra.Group.Submonoid.Operations
 import Linglib.Core.Algebra.Group.Subquotient
 import Linglib.Core.Algebra.Group.WithOne
 import Linglib.Core.Algebra.Opposites
+import Linglib.Core.Algebra.Order.Interval.Set.Instances
 import Linglib.Core.Algebra.Order.ToIntervalMod
 import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
@@ -253,7 +254,6 @@ import Linglib.Core.Order.PreferenceStructure.EffectivePreference
 import Linglib.Core.Order.PreferenceStructure.MaxInducedOrdering
 import Linglib.Core.Order.PreorderLattice
 import Linglib.Core.Order.PullbackPreorder
-import Linglib.Core.Order.Rat01
 import Linglib.Core.Order.Relation
 import Linglib.Core.Order.Satisfaction
 import Linglib.Core.Order.SetPreimage

--- a/Linglib/Core/Algebra/Order/Interval/Set/Instances.lean
+++ b/Linglib/Core/Algebra/Order/Interval/Set/Instances.lean
@@ -3,18 +3,16 @@ import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Order.Monotone.Basic
 
 /-!
-# The unit-interval involution, and the rational unit interval
+# The unit-interval involution
 
-The `Set.Icc` section states the involution `1 - t` of `Set.Icc (0 : β) 1` and
-its lemmas at the generality of `Mathlib.Algebra.Order.Interval.Set.Instances` —
-`[UPSTREAM]` verbatim: generalizing `unitInterval.symm` beyond `ℝ` is a stated
-TODO of that file.
+`[UPSTREAM]` additions to `Mathlib.Algebra.Order.Interval.Set.Instances`: the
+involution `1 - t` of `Set.Icc (0 : β) 1` and its lemmas, stated at that file's
+generality — generalizing `unitInterval.symm` beyond `ℝ` is its stated TODO.
 
-`Rat01` abbreviates `↥(Set.Icc (0 : ℚ) 1)`, the home of gradient linguistic
-degrees (at-issueness, projectivity, prior credence) and their contextual
-thresholds; mathlib's `unitInterval` is real-valued and topological, while
-linguistic degrees are exact rationals. Its `0`, `1`, and algebraic structure
-come from the mathlib instances.
+Linglib uses `Set.Icc (0 : ℚ) 1` as the home of gradient linguistic degrees
+(at-issueness, projectivity, prior credence): mathlib's `unitInterval` is
+real-valued and topological, while linguistic degrees are exact rationals.
+The domain-facing names live with their owners (`Discourse.AtIssueness`).
 -/
 
 namespace Set.Icc
@@ -57,10 +55,3 @@ theorem symm_antitone : Antitone (symm : Icc (0 : β) 1 → Icc (0 : β) 1) := f
   Subtype.mk_le_mk.mpr (sub_le_sub_left (Subtype.coe_le_coe.mpr h) 1)
 
 end Set.Icc
-
-namespace Core.Order
-
-/-- The unit interval of rationals — the `ℚ` counterpart of `unitInterval`. -/
-abbrev Rat01 := ↥(Set.Icc (0 : ℚ) 1)
-
-end Core.Order

--- a/Linglib/Data/Generalizations/Projectivity.lean
+++ b/Linglib/Data/Generalizations/Projectivity.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.Rat01
+import Linglib.Core.Algebra.Order.Interval.Set.Instances
 import Linglib.Data.Examples.TonhauserBeaverDegen2018
 import Linglib.Data.Examples.SolstadBott2024
 import Mathlib.Tactic.Linarith
@@ -40,27 +40,26 @@ only): accounts and divergence theorems live in the consuming study files.
 
 namespace Generalizations.Projectivity
 
-open Core.Order (Rat01)
 open Data.Examples (LinguisticExample SourceRef)
 
 /-- An observed datum: mean projectivity and at-issueness for one expression,
     with its originating `SourceRef`. -/
 structure ProjectionDatum where
   expression   : String
-  projectivity : Rat01
-  atIssueness  : Rat01
+  projectivity : Set.Icc (0 : ℚ) 1
+  atIssueness  : Set.Icc (0 : ℚ) 1
   source       : SourceRef
 
 /-- Not-at-issueness is the complement of at-issueness — the quantity the GPP
     equates with projectivity. -/
-def ProjectionDatum.notAtIssueness (d : ProjectionDatum) : Rat01 :=
+def ProjectionDatum.notAtIssueness (d : ProjectionDatum) : Set.Icc (0 : ℚ) 1 :=
   Set.Icc.symm d.atIssueness
 
 /-! ### `LinguisticExample` adapter -/
 
-/-- Parse a percent-integer string (e.g. `"96"`) into a `Rat01`; `none` if
+/-- Parse a percent-integer string (e.g. `"96"`) into `Set.Icc (0 : ℚ) 1`; `none` if
     non-numeric or out of range. -/
-def parsePercent (s : String) : Option Rat01 :=
+def parsePercent (s : String) : Option (Set.Icc (0 : ℚ) 1) :=
   match s.toNat? with
   | some n =>
       if h : n ≤ 100 then
@@ -72,7 +71,7 @@ def parsePercent (s : String) : Option Rat01 :=
 
 /-- Read at-issueness from `paperFeatures`: directly from the `atIssueness` key,
     or as the complement of `notAtIssueness`. -/
-def readAtIssueness (pf : List (String × String)) : Option Rat01 :=
+def readAtIssueness (pf : List (String × String)) : Option (Set.Icc (0 : ℚ) 1) :=
   match pf.lookup "atIssueness" with
   | some s => parsePercent s
   | none => ((pf.lookup "notAtIssueness").bind parsePercent).map Set.Icc.symm
@@ -90,8 +89,8 @@ def fromExample (e : LinguisticExample) : Option ProjectionDatum :=
 
 /-! ### Pool -/
 
-/-- The pooled cross-paper projection data. Each rival account — a map
-    `Rat01 → Rat01` from at-issueness to predicted projectivity — is run
+/-- The pooled cross-paper projection data. Each rival account — a map from
+    at-issueness to predicted projectivity on `Set.Icc (0 : ℚ) 1` — is run
     against this list in the study files. -/
 def allData : List ProjectionDatum :=
   (TonhauserBeaverDegen2018.Examples.all ++ SolstadBott2024.Examples.all).filterMap fromExample
@@ -100,14 +99,16 @@ def allData : List ProjectionDatum :=
 
 /-- An account's absolute error on an observation: the gap between its predicted
     projectivity (from the observed at-issueness) and the observed projectivity. -/
-def predictionError (acc : Rat01 → Rat01) (d : ProjectionDatum) : ℚ :=
+def predictionError (acc : Set.Icc (0 : ℚ) 1 → Set.Icc (0 : ℚ) 1)
+    (d : ProjectionDatum) : ℚ :=
   |(acc d.atIssueness).val - d.projectivity.val|
 
 /-- An account predicts an observation within tolerance `ε`. -/
-def predictsWithin (ε : ℚ) (acc : Rat01 → Rat01) (d : ProjectionDatum) : Prop :=
+def predictsWithin (ε : ℚ) (acc : Set.Icc (0 : ℚ) 1 → Set.Icc (0 : ℚ) 1)
+    (d : ProjectionDatum) : Prop :=
   predictionError acc d ≤ ε
 
-instance (ε : ℚ) (acc : Rat01 → Rat01) (d : ProjectionDatum) :
+instance (ε : ℚ) (acc : Set.Icc (0 : ℚ) 1 → Set.Icc (0 : ℚ) 1) (d : ProjectionDatum) :
     Decidable (predictsWithin ε acc d) :=
   inferInstanceAs (Decidable (_ ≤ _))
 

--- a/Linglib/Discourse/QUD/AtIssueness.lean
+++ b/Linglib/Discourse/QUD/AtIssueness.lean
@@ -1,31 +1,32 @@
 import Linglib.Semantics.Questions.Partition.QUD
 import Linglib.Core.Order.Boundedness
 import Linglib.Core.Order.Comparison
-import Linglib.Core.Order.Rat01
+import Mathlib.Algebra.Order.Interval.Set.Instances
+import Mathlib.Algebra.Order.Ring.Unbundled.Rat
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Linarith
 /-!
 # Gradient At-Issueness and Projectivity
 [roberts-2012] [tonhauser-beaver-degen-2018]
 Tonhauser-Beaver-Degen 2018's gradient at-issueness model: degrees
-and thresholds in `Rat01`, with at-issueness anti-correlated with
-projectivity. Mirrors the gradable-adjective pattern (degree > θ →
+and thresholds in `Set.Icc (0 : ℚ) 1`, with at-issueness anti-correlated
+with projectivity. Mirrors the gradable-adjective pattern (degree > θ →
 positive meaning).
 -/
 namespace Discourse.AtIssueness
-open Core.Order (Boundedness Rat01)
+open Core.Order (Boundedness)
 /-! ### Degree Types -/
 /-- A degree of at-issueness ∈ [0, 1].
     0 = fully backgrounded (not at-issue), 1 = fully at-issue. -/
-abbrev AtIssuenessDegree := Rat01
+abbrev AtIssuenessDegree := ↥(Set.Icc (0 : ℚ) 1)
 /-- A degree of projectivity ∈ [0, 1].
     0 = no projection, 1 = obligatory projection. -/
-abbrev ProjectivityDegree := Rat01
+abbrev ProjectivityDegree := ↥(Set.Icc (0 : ℚ) 1)
 /-- Contextual threshold for at-issueness classification.
     Content with degree above this threshold counts as at-issue. -/
-abbrev AtIssuenessThreshold := Rat01
+abbrev AtIssuenessThreshold := ↥(Set.Icc (0 : ℚ) 1)
 /-- Contextual threshold for projectivity classification. -/
-abbrev ProjectivityThreshold := Rat01
+abbrev ProjectivityThreshold := ↥(Set.Icc (0 : ℚ) 1)
 /-! ### Threshold Semantics -/
 /-- Content is at-issue when its degree exceeds the threshold — the
     `Core.Order.Comparison.gt.over` face of the scale. -/
@@ -90,6 +91,6 @@ def atIssuenessBoundedness : Boundedness := .closed
 def projectivityBoundedness : Boundedness := .closed
 /-! ### Smart Constructors -/
 /-- Construct a degree from [0, 100], normalizing to [0, 1]. -/
-def ofPercent (n : ℚ) (h0 : 0 ≤ n) (h1 : n ≤ 100) : Rat01 :=
+def ofPercent (n : ℚ) (h0 : 0 ≤ n) (h1 : n ≤ 100) : Set.Icc (0 : ℚ) 1 :=
   ⟨n / 100, div_nonneg h0 (by norm_num), by linarith⟩
 end Discourse.AtIssueness

--- a/Linglib/Studies/DegenTonhauser2021.lean
+++ b/Linglib/Studies/DegenTonhauser2021.lean
@@ -1,6 +1,6 @@
 import Linglib.Fragments.English.Predicates.Verbal
 import Linglib.Fragments.English.Predicates.Copular
-import Linglib.Core.Order.Rat01
+import Linglib.Core.Algebra.Order.Interval.Set.Instances
 import Mathlib.Order.Monotone.Basic
 import Mathlib.Tactic.DeriveFintype
 import Mathlib.Tactic.NormNum
@@ -45,8 +45,6 @@ N = 266). The main-clause control projected at floor (mean certainty 0.21).
 
 namespace DegenTonhauser2021
 
-open Core.Order
-
 /-! ### The 20 clause-embedding predicates -/
 
 /-- The 20 clause-embedding predicates of [degen-tonhauser-2021], listed
@@ -62,27 +60,27 @@ inductive Predicate where
 /-! ### Projection as a function of prior credence -/
 
 /-- A predictor of projection strength from prior credence in the complement. -/
-abbrev PriorAccount := Rat01 → Rat01
+abbrev PriorAccount := Set.Icc (0 : ℚ) 1 → Set.Icc (0 : ℚ) 1
 
 /-- The prior-insensitive null account: projection is constant in prior credence. -/
-def priorInsensitive (c : Rat01) : PriorAccount := fun _ => c
+def priorInsensitive (c : Set.Icc (0 : ℚ) 1) : PriorAccount := fun _ => c
 
 /-- An account is prior-sensitive when projection is strictly monotone in prior
     credence. -/
 def PriorSensitive (acc : PriorAccount) : Prop := StrictMono acc
 
 /-- The null account predicts identical projection for any two priors. -/
-theorem priorInsensitive_no_modulation (c p q : Rat01) :
+theorem priorInsensitive_no_modulation (c p q : Set.Icc (0 : ℚ) 1) :
     priorInsensitive c p = priorInsensitive c q := rfl
 
 /-- The null account is not prior-sensitive. -/
-theorem priorInsensitive_not_sensitive (c : Rat01) :
+theorem priorInsensitive_not_sensitive (c : Set.Icc (0 : ℚ) 1) :
     ¬ PriorSensitive (priorInsensitive c) :=
   fun h => lt_irrefl c (h zero_lt_one)
 
 /-- A prior-sensitive account predicts stronger projection for higher-prior content. -/
 theorem sensitive_predicts_modulation {acc : PriorAccount} (h : PriorSensitive acc)
-    {p q : Rat01} (hpq : p < q) : acc p < acc q := h hpq
+    {p q : Set.Icc (0 : ℚ) 1} (hpq : p < q) : acc p < acc q := h hpq
 
 /-! ### Data: prior modulates projection for every predicate
 

--- a/Linglib/Studies/GroveWhite2025.lean
+++ b/Linglib/Studies/GroveWhite2025.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Attitudes.Factivity
 import Linglib.Semantics.Probabilistic.ParamPred
 import Linglib.Studies.DegenTonhauser2022
 import Linglib.Studies.ScontrasTonhauser2025
-import Linglib.Core.Order.Rat01
+import Linglib.Core.Algebra.Order.Interval.Set.Instances
 import Linglib.Core.Probability.Constructions
 
 /-!
@@ -38,7 +38,7 @@ The discrete-factivity model is a `ParamPred` over `FactivityReading`:
 
 - `clauseEmbeddingSem .factive`     = `factivePos` (`BEL ∧ C`)
 - `clauseEmbeddingSem .nonfactive`  = `nonFactivePos` (`BEL`)
-- prior over readings: `⟨τ, 1 − τ⟩` for `τ : Rat01`
+- prior over readings: `⟨τ, 1 − τ⟩` for `τ : Set.Icc (0 : ℚ) 1`
 
 The graded truth value of a predicate at a world `w` then unfolds to
 `τ · 1[BEL∧C] + (1−τ) · 1[BEL]` (`discreteFactivity_gradedTruth`).
@@ -93,7 +93,6 @@ open Semantics.Attitudes.Factivity
 open Semantics.Probabilistic
 open DegenTonhauser2021
 open DegenTonhauser2022
-open Core.Order (Rat01)
 open scoped ENNReal NNReal
 
 /-! ## §1. Clause-embedding semantics -/
@@ -140,39 +139,36 @@ section Prior
 
 variable {W : Type*}
 
-/-- `τ.val : ℚ` lifted to `ℝ≥0` via the canonical `ℝ`-coercion. Lives
-    outside the `Rat01` namespace because `Rat01` is an `abbrev` for
-    a `Subtype`, so dot notation on `τ : Rat01` resolves through the
-    underlying `Subtype` rather than the `Rat01` namespace. -/
-noncomputable def Rat01.toNNReal (τ : Rat01) : ℝ≥0 :=
+/-- `τ.val : ℚ` lifted to `ℝ≥0` via the canonical `ℝ`-coercion. -/
+noncomputable def toNNReal (τ : Set.Icc (0 : ℚ) 1) : ℝ≥0 :=
   Real.toNNReal τ.val
 
-theorem Rat01.toNNReal_le_one (τ : Rat01) : Rat01.toNNReal τ ≤ 1 :=
+theorem toNNReal_le_one (τ : Set.Icc (0 : ℚ) 1) : toNNReal τ ≤ 1 :=
   Real.toNNReal_le_one.mpr (by exact_mod_cast τ.prop.2)
 
-theorem Rat01.toNNReal_val (τ : Rat01) : ((Rat01.toNNReal τ : ℝ≥0) : ℝ) = τ.val :=
+theorem toNNReal_val (τ : Set.Icc (0 : ℚ) 1) : ((toNNReal τ : ℝ≥0) : ℝ) = τ.val :=
   Real.coe_toNNReal _ (by exact_mod_cast τ.prop.1)
 
 /-- The Bernoulli prior over `FactivityReading`: factive with probability
     `τ.val`, nonfactive with probability `1 − τ.val`. The τ parameter is
-    bundled as `Rat01` (`↥(Set.Icc (0:ℚ) 1)`), so the [0,1] constraint is
+    bundled as `Set.Icc (0 : ℚ) 1`, so the [0,1] constraint is
     intrinsic to the type rather than threaded as side hypotheses. This is
     the τ-vertex of the discrete-factivity DAG (definition (13), p. 20).
 
     A `PMF.mix` of point masses at the two readings. -/
-noncomputable def factivityPrior (τ : Rat01) : PMF FactivityReading :=
-  PMF.mix (Rat01.toNNReal τ) (Rat01.toNNReal_le_one τ)
+noncomputable def factivityPrior (τ : Set.Icc (0 : ℚ) 1) : PMF FactivityReading :=
+  PMF.mix (toNNReal τ) (toNNReal_le_one τ)
     (PMF.pure .nonfactive) (PMF.pure .factive)
 
-@[simp] theorem factivityPrior_apply_factive (τ : Rat01) :
+@[simp] theorem factivityPrior_apply_factive (τ : Set.Icc (0 : ℚ) 1) :
     (factivityPrior τ) FactivityReading.factive
-      = ((Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
+      = ((toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
   simp
 
-@[simp] theorem factivityPrior_apply_nonfactive (τ : Rat01) :
+@[simp] theorem factivityPrior_apply_nonfactive (τ : Set.Icc (0 : ℚ) 1) :
     (factivityPrior τ) FactivityReading.nonfactive
-      = (((1 : ℝ≥0) - Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
+      = (((1 : ℝ≥0) - toNNReal τ : ℝ≥0) : ℝ≥0∞) := by
   unfold factivityPrior
   simp
 
@@ -189,7 +185,7 @@ variable {W : Type*} [HasBelief W] [HasComplement W]
     that reading. The graded truth value `gradedTruth` is then the
     `ℝ≥0∞`-valued probability mass on the satisfied-readings set —
     `PMF.probOfSet` of the "predicate satisfied at this world" event. -/
-noncomputable def discreteFactivityPred (τ : Rat01) :
+noncomputable def discreteFactivityPred (τ : Set.Icc (0 : ℚ) 1) :
     ParamPred W FactivityReading where
   semantics := clauseEmbeddingSem
   prior     := factivityPrior τ
@@ -198,11 +194,11 @@ noncomputable def discreteFactivityPred (τ : Rat01) :
     This is the substantive content of the τ-parameterised model — graded
     inference values arise from a τ-weighted mixture of two crisp Boolean
     readings. -/
-theorem discreteFactivity_gradedTruth (τ : Rat01) (w : W) :
+theorem discreteFactivity_gradedTruth (τ : Set.Icc (0 : ℚ) 1) (w : W) :
     (discreteFactivityPred τ).gradedTruth w =
-    (if factivePos w then ((Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) else 0) +
+    (if factivePos w then ((toNNReal τ : ℝ≥0) : ℝ≥0∞) else 0) +
     (if nonFactivePos (W := W) w
-      then (((1 : ℝ≥0) - Rat01.toNNReal τ : ℝ≥0) : ℝ≥0∞) else 0) := by
+      then (((1 : ℝ≥0) - toNNReal τ : ℝ≥0) : ℝ≥0∞) else 0) := by
   classical
   show (factivityPrior τ).probOfSet
       {θ | clauseEmbeddingSem (W := W) θ w = true} = _
@@ -215,7 +211,7 @@ theorem discreteFactivity_certain_factive (w : W) :
     (discreteFactivityPred (W := W) 1).gradedTruth w =
     if factivePos w then 1 else 0 := by
   rw [discreteFactivity_gradedTruth]
-  have hτ : Rat01.toNNReal 1 = 1 := by
+  have hτ : toNNReal 1 = 1 := by
     show Real.toNNReal ((1 : ℚ) : ℝ) = 1
     simp
   rw [hτ]
@@ -226,7 +222,7 @@ theorem discreteFactivity_certain_nonfactive (w : W) :
     (discreteFactivityPred (W := W) 0).gradedTruth w =
     if nonFactivePos (W := W) w then 1 else 0 := by
   rw [discreteFactivity_gradedTruth]
-  have hτ : Rat01.toNNReal 0 = 0 := by
+  have hτ : toNNReal 0 = 0 := by
     show Real.toNNReal ((0 : ℚ) : ℝ) = 0
     simp
   rw [hτ]
@@ -240,7 +236,7 @@ theorem discreteFactivity_certain_nonfactive (w : W) :
     case is the *contrapositive* one supplied by `discreteFactivity_gradedTruth`
     plus monotonicity of the Bernoulli mixture. -/
 theorem higher_tau_higher_gradedTruth
-    (τ₁ τ₂ : Rat01) (w : W)
+    (τ₁ τ₂ : Set.Icc (0 : ℚ) 1) (w : W)
     (h_tau : τ₁.val > τ₂.val)
     (h_factive : factivePos w = true)
     (h_nonfactive : nonFactivePos (W := W) w = false) :
@@ -248,9 +244,9 @@ theorem higher_tau_higher_gradedTruth
     (discreteFactivityPred τ₂).gradedTruth w := by
   rw [discreteFactivity_gradedTruth, discreteFactivity_gradedTruth]
   simp only [h_factive, h_nonfactive, Bool.false_eq_true, ↓reduceIte, add_zero]
-  have hlt : Rat01.toNNReal τ₂ < Rat01.toNNReal τ₁ := by
-    have : ((Rat01.toNNReal τ₂ : ℝ≥0) : ℝ) < ((Rat01.toNNReal τ₁ : ℝ≥0) : ℝ) := by
-      rw [Rat01.toNNReal_val, Rat01.toNNReal_val]
+  have hlt : toNNReal τ₂ < toNNReal τ₁ := by
+    have : ((toNNReal τ₂ : ℝ≥0) : ℝ) < ((toNNReal τ₁ : ℝ≥0) : ℝ) := by
+      rw [toNNReal_val, toNNReal_val]
       exact_mod_cast h_tau
     exact_mod_cast this
   exact_mod_cast hlt
@@ -402,7 +398,7 @@ theorem empirical_ordering_consistent_with_tau :
     projection (`DegenTonhauser2021.sensitive_predicts_modulation`), which their
     data confirm for all 20 predicates. -/
 theorem prior_effect_consistent {acc : PriorAccount} (h : PriorSensitive acc)
-    {p q : Rat01} (hpq : p < q) : acc p < acc q :=
+    {p q : Set.Icc (0 : ℚ) 1} (hpq : p < q) : acc p < acc q :=
   sensitive_predicts_modulation h hpq
 
 end EmpiricalAnchor

--- a/Linglib/Studies/LuPanDegen2025.lean
+++ b/Linglib/Studies/LuPanDegen2025.lean
@@ -1024,7 +1024,7 @@ say+adverb (53), which is more degraded than say (73–80), even under identical
 prosodic conditions. The binary model predicts MoS = say+adverb (both `.given`)
 and cannot express this gradient.
 
-We lift the model to **gradient at-issueness** using `Rat01` from
+We lift the model to **gradient at-issueness** using the degree scales of
 `Discourse/AtIssueness.lean`. `MannerWeightSource` determines not just
 whether the complement is backgrounded, but *how* backgrounded. Lexical manner
 (inherent to verb root) produces stronger backgroundedness than compositional

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -64,7 +64,6 @@ open German.Predicates
 open Semantics.Presupposition
 open Semantics.Presupposition.Context
 open CommonGround
-open Core.Order (Rat01)
 open Generalizations.Projectivity
 
 /-! ### Filtering direction and context resolution -/

--- a/Linglib/Studies/TonhauserBeaverDegen2018.lean
+++ b/Linglib/Studies/TonhauserBeaverDegen2018.lean
@@ -34,15 +34,14 @@ correlation with item-level variance, not this identity (cf. the dependency's
 * `gpp_beats_potts_below_diagonal` — on low-projectivity items the GPP beats Potts.
 
 ## Implementation notes
-Degrees and thresholds are the `Rat01` types from `Discourse.AtIssueness`; the GPP
-map is the `Rat01` complement. Potts's maximal projection is grounded in
+Degrees and thresholds are the `Discourse.AtIssueness` scales on `Set.Icc (0 : ℚ) 1`; the GPP
+map is `Set.Icc.symm`. Potts's maximal projection is grounded in
 `Pragmatics.Expressives.TwoDimProp.ci_projects_through_neg`.
 -/
 
 namespace TonhauserBeaverDegen2018
 
 open Discourse.AtIssueness
-open Core.Order (Rat01)
 open Pragmatics.Expressives
 open Generalizations.Projectivity
 
@@ -67,7 +66,7 @@ The binary principle ([simons-tonhauser-beaver-roberts-2010]) — projects iff n
 at-issue — is the threshold collapse of the gradient GPP. -/
 
 /-- The GPP projects past `θ` iff at-issueness is below the complementary threshold. -/
-theorem gpp_projects_iff (ai θ : Rat01) :
+theorem gpp_projects_iff (ai : AtIssuenessDegree) (θ : ProjectivityThreshold) :
     isProjective (gppProjection ai) θ ↔ ai.val < (Set.Icc.symm θ).val := by
   simp only [isProjective, Core.Order.Comparison.mem_over,
     Core.Order.Comparison.rel, gppProjection, Set.Icc.coe_symm_eq]
@@ -75,7 +74,7 @@ theorem gpp_projects_iff (ai θ : Rat01) :
 
 /-- The binary Projection Principle: never both at-issue and projecting at
     complementary thresholds. -/
-theorem gpp_excludes_atIssue (ai θ : Rat01) :
+theorem gpp_excludes_atIssue (ai : AtIssuenessDegree) (θ : ProjectivityThreshold) :
     ¬ (isAtIssue ai (Set.Icc.symm θ) ∧ isProjective (gppProjection ai) θ) := by
   rintro ⟨ha, hp⟩
   simp only [isAtIssue, Core.Order.Comparison.mem_over,


### PR DESCRIPTION
Removes the `Rat01` name entirely, following up #2112 — mathlib would not mint it (no `01` suffixes), and its answer for non-ℝ unit intervals is no name at all, just `Set.Icc (0 : β) 1`.

- `Core/Order/Rat01.lean` → `Core/Algebra/Order/Interval/Set/Instances.lean`: the generic `Set.Icc.symm` section now lives at the mirror path of its mathlib destination file, and the bare abbrev is gone.
- `Discourse.AtIssueness`'s degree/threshold abbrevs — the discoverable domain layer — are defined directly as `↥(Set.Icc (0 : ℚ) 1)`; the few raw uses (DT2021's `PriorAccount`, GroveWhite's τ, the Projectivity pool) write the `Icc` type inline; GroveWhite's `Rat01.toNNReal` pseudo-namespace def becomes plain file-local `toNNReal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)