### PR TITLE
fix(Fragments/Lakhota): anaphoric kiŋ flips cell to generallyMarked

### DIFF
--- a/Linglib/Fragments/Lakhota/Determiners.lean
+++ b/Linglib/Fragments/Lakhota/Determiners.lean
@@ -3,36 +3,46 @@ import Linglib.Syntax.Category.Determiner.Basic
 /-!
 # Lakhota determiner inventory
 
-Lakhota (Siouan, ISO `lkt`) has two overt definite articles: *kiŋ*, used for
-situationally and globally unique referents, and *k'uŋ*, glossed 'the
-above-mentioned' and treated as an anaphoric article in much of the
-literature. The classification is tentative: [ingham-2003] reports an
-anaphoric use of *kiŋ*, rival accounts analyze *k'uŋ* in terms of
-accessibility or switch reference, and covarying (donkey) uses are
-unreported for either article. The singular realis indefinite article is
-*waŋ* ([rood-taylor-1996] Table 3; the hypothetical and negative
-counterparts *waŋži* and *waŋžini* and the plural series are not typed
-here).
+Lakhota (Siouan, ISO `lkt`) has two overt definite articles: the general
+*kiŋ*, with both situational and anaphoric uses, and *k'uŋ* 'the
+above-mentioned', restricted to previously-mentioned referents and far
+rarer ([latrouite-van-valin-2014]; [ingham-2003b] §15.1 has *ki* "for new
+or previously mentioned items without distinction" and *k'uŋ* as an
+infrequent switch back to an earlier topic — endorsing [curl-1999]'s
+topic-marking account — or an emphatic marker of 'enforced reality').
+Because *kiŋ* covers anaphora, the inventory derives `.generallyMarked`;
+the `.bipartite` cell follows only under [schwarz-2013] §4.2.1's tentative
+weak/strong construal of the pair, disputed also by [ingham-2003] (the
+element is basically a topic marker) and [ogorman-2011] (accessibility).
+Covarying (donkey) uses are unreported for either article. The singular
+specific (realis) indefinite article is *waŋ*, opposed to non-specific
+*waŋži* ([rood-taylor-1996] Table 3; [latrouite-van-valin-2014] Table 1;
+[ingham-2003b] §15.1.4); the non-specific, negative, and plural series
+are not typed here.
 
 ## References
 
-* [schwarz-2013], §4.2.1
+* [latrouite-van-valin-2014]
 * [ingham-2003]
+* [ingham-2003b], §14–§15
+* [schwarz-2013], §4.2.1
 * [rood-taylor-1996]
 -/
 
 namespace Lakhota.Determiners
 
-/-- The Lakhota determiners are the weak definite *kiŋ*, the strong
-    definite *k'uŋ*, and the indefinite *waŋ*. -/
+/-- The Lakhota determiners are the general definite *kiŋ*, the
+    anaphoric-only definite *k'uŋ*, and the specific indefinite *waŋ*. -/
 def inventory : Determiner.Inventory :=
   [ .article { form := "kiŋ", definiteness := .definite, exponent := .dedicatedMorpheme,
-               uses := [.immediateSituation, .largerSituation] },
+               uses := [.immediateSituation, .largerSituation, .anaphoric] },
     .article { form := "k'uŋ", definiteness := .definite, exponent := .dedicatedMorpheme,
                uses := [.anaphoric] },
     .article { form := "waŋ", definiteness := .indefinite, exponent := .dedicatedMorpheme } ]
 
-/-- Lakhota derives the `.bipartite` Moroney cell. -/
-theorem marking : inventory.markingStrategy = .bipartite := by decide
+/-- Lakhota derives the `.generallyMarked` Moroney cell: *kiŋ* syncretically
+    covers both presupposition types, so the anaphoric-only *k'uŋ* does not
+    make the system `.bipartite`. -/
+theorem marking : inventory.markingStrategy = .generallyMarked := by decide
 
 end Lakhota.Determiners

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -28574,7 +28574,7 @@
 @article{ingham-2003,
   author    = {Ingham, Bruce},
   year      = {2003},
-  title     = {The Function of the Post-Nominal Element ki{\textasciitilde}k'un in {Lakota}},
+  title     = {The Function of the Post-Nominal Element ki{\textasciitilde}k'uŋ in {Lakota}},
   journal   = {Transactions of the Philological Society},
   volume    = {101},
   number    = {3},
@@ -28582,6 +28582,7 @@
   doi       = {10.1111/j.0079-1636.2003.00123.x},
   subfield  = {grammar},
   role      = {cited},
+  validated = {true},
   sources   = {Fragments/Lakhota/Determiners.lean}
 }
 
@@ -38820,6 +38821,62 @@
   address   = {Washington, DC},
   pages     = {440--482},
   subfield  = {grammar},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Lakhota/Determiners.lean}
+}
+% REF: Ingham, B. (2003). Lakota. Languages of the World/Materials 426. Lincom Europa.
+@book{ingham-2003b,
+  author    = {Ingham, Bruce},
+  year      = {2003},
+  title     = {Lakota},
+  series    = {Languages of the World/Materials},
+  number    = {426},
+  publisher = {Lincom Europa},
+  address   = {Muenchen},
+  isbn      = {3-89586-849-3},
+  subfield  = {grammar},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Lakhota/Determiners.lean}
+}
+% REF: Curl, T. S. (1999). The Lakhota definite articles and topic marking. Kansas Working Papers in Linguistics 24(2), 1-16.
+@article{curl-1999,
+  author    = {Curl, Traci S.},
+  year      = {1999},
+  title     = {The {Lakhota} Definite Articles and Topic Marking},
+  journal   = {Kansas Working Papers in Linguistics},
+  volume    = {24},
+  number    = {2},
+  pages     = {1--16},
+  url       = {https://journals.ku.edu/kwpl/article/view/17252},
+  subfield  = {semantics/dynamic},
+  role      = {cited},
+  validated = {true},
+  sources   = {Fragments/Lakhota/Determiners.lean}
+}
+% REF: O'Gorman, T. (2011). Two kinds of definiteness in Lakhota. Ms., University of Colorado at Boulder.
+@unpublished{ogorman-2011,
+  author    = {O'Gorman, Tim},
+  year      = {2011},
+  title     = {Two Kinds of Definiteness in {Lakhota}},
+  note      = {Ms., University of Colorado at Boulder},
+  subfield  = {semantics/dynamic},
+  role      = {cited},
+  sources   = {Fragments/Lakhota/Determiners.lean}
+}
+% REF: Latrouite, A. & Van Valin, R. D. (2014). Referentiality and telicity in Lakhota and Tagalog. In Gerland, Horn, Latrouite & Ortmann (eds.), Meaning and Grammar of Nouns and Verbs. Duesseldorf University Press, 401-426.
+@incollection{latrouite-van-valin-2014,
+  author    = {Latrouite, Anja and Van Valin, Robert D.},
+  year      = {2014},
+  title     = {Referentiality and Telicity in {Lakhota} and {Tagalog}},
+  booktitle = {Meaning and Grammar of Nouns and Verbs},
+  editor    = {Gerland, Doris and Horn, Christian and Latrouite, Anja and Ortmann, Albert},
+  publisher = {D{\"u}sseldorf University Press},
+  address   = {D{\"u}sseldorf},
+  pages     = {401--426},
+  url       = {https://docserv.uni-duesseldorf.de/servlets/DerivateServlet/Derivate-31480/z675pcuh/19_Referentiality_and_telicity_in_Lakhota_and_Tagalog_Latrouite_Van_Valin.pdf},
+  subfield  = {semantics/reference},
   role      = {cited},
   validated = {true},
   sources   = {Fragments/Lakhota/Determiners.lean}


### PR DESCRIPTION
Follow-up to #2114, from reading the primary sources directly (Ingham 2003 TPS + LWM grammar, Latrouite & Van Valin 2014).

- the descriptive literature agrees *kiŋ* has anaphoric uses and *k'uŋ* is a rare, anaphoric-only 'aforementioned' form — so *kiŋ* is syncretic and the Moroney cell is `.generallyMarked`, not `.bipartite` (which needed Schwarz 2013's tentative weak/strong construal, now hedged in prose)
- docstring carries the rival accounts first-hand: Ingham's topic-marker analysis, Curl's topic-discontinuity, O'Gorman's accessibility
- bib: fix ingham-2003 title (*k'uŋ*), add verified ingham-2003b, curl-1999, ogorman-2011, latrouite-van-valin-2014