### PR TITLE
fix(Fragments): source-verify Hindi-Urdu particle facets; register pass

### DIFF
--- a/Linglib/Fragments/English/QuestionParticles.lean
+++ b/Linglib/Fragments/English/QuestionParticles.lean
@@ -5,9 +5,7 @@ import Linglib.Syntax.Category.Particle.Basic
 [dayal-2025] [bhatt-dayal-2020]
 
 Lexical entry for the English MQP-like adverb *quick/quickly* as a
-`Particle` value with an embedding-distribution facet. The
-left-peripheral layer assignment is derived from that facet in
-`BhattDayal2020`.
+`Particle` value with an embedding-distribution facet.
 -/
 
 namespace English.QuestionParticles

--- a/Linglib/Fragments/HindiUrdu/Particles.lean
+++ b/Linglib/Fragments/HindiUrdu/Particles.lean
@@ -1,33 +1,39 @@
 import Linglib.Syntax.Category.Particle.Basic
 
 /-!
-# Hindi-Urdu Interrogative Particles
-[bhatt-dayal-2014] [bhatt-dayal-2020] [dayal-2025]
+# Hindi-Urdu interrogative particles
 
-Particles related to question formation in Hindi-Urdu, as `Particle`
-values with embedding-distribution facets, following [bhatt-dayal-2014]
-and [dayal-2025].
+Hindi-Urdu has no polar *wh*-complementizer (English *whether*, Italian
+*se*): finite complements of every clause type are introduced by the
+general subordinator *ki* (compare Hungarian *hogy*), and matrix polar
+questions are marked by rising intonation plus the optional particle
+*kya:*. *kya:* occurs in polar and alternative but not constituent
+questions and occupies a projection above CP (Bhatt and Dayal's ForceP,
+Dayal's later PerspP); it embeds only in quasi-subordination. Since
+nothing clause-types a bare embedded polar clause, subordinated polar
+questions require the overt alternative *ya: nahii:* "or not". This file
+provides the three particles as `Particle` values with clause-type and
+embedding facets.
 
-Hindi-Urdu lacks a dedicated *wh*-complementizer for polar questions
-(unlike English *whether* or Italian *se*). Instead, it uses:
+## Main declarations
 
-1. *kya:* — analyzed by [bhatt-dayal-2020] as a polar question particle
-   at PerspP (not CP); the layer is derived from the embedding facet in
-   `BhattDayal2020`, together with its predicate-selection profile.
-2. *ki* — a general subordinator (like Hungarian *hogy*), compatible
-   with both declarative and interrogative complements.
+* `HindiUrdu.Particles.kya` — the polar question particle.
+* `HindiUrdu.Particles.ki` — the general subordinator.
+* `HindiUrdu.Particles.ya_nahi` — the overt polar alternative.
 
-The absence of a clause-typing particle means:
-- Simplex polar questions (just *p*, no "or not") cannot be subordinated
-  (clause-typing cannot be forced at CP).
-- *kya:* in embedded position is the hallmark of quasi-subordination.
+## References
+
+* [bhatt-dayal-2014]
+* [bhatt-dayal-2020], §2, §5
+* [dayal-2025], §1.3, ex. 70–71
 -/
 
 namespace HindiUrdu.Particles
 
-/-- *ki* — general subordinator. Compatible with both declarative and
-interrogative complements (and with responsive and rogative predicates
-alike). NOT a clause-typing particle. -/
+/-- *ki* — the general subordinator: introduces finite complements of
+any clause type, under responsive and rogative predicates alike, and
+does no clause-typing. Distinct from the homophonous disjunction *ki*,
+which is restricted to alternative questions. -/
 def ki : Particle where
   form := "ki"
   position := some .clauseInitial
@@ -36,38 +42,39 @@ def ki : Particle where
       subordinated := some .optional
       quasiSubordinated := some .optional }
 
-/-- *kya:* — [bhatt-dayal-2020]'s polar question particle: occurs in
-polar questions but not wh-questions, optionally in matrix and in a
-restricted way in embedded questions, with flexible clause-internal
-positioning ("can occur almost anywhere within a clause", §2).
-Selectionally: incompatible with *nirbhar kar-na:* "depend on" (a
-responsive selecting CP only); compatible with *pu:ch-na:* "ask" and
-*sava:l yeh hai* "the question is" (rogatives). Its PerspP layer is
-derived in `BhattDayal2020`. -/
+/-- *kya:* — the polar question particle: optional in matrix polar
+questions, excluded from constituent questions, acceptable in
+alternative questions (parsed as *kya:* on a disjoined polar question),
+with no fixed clause-internal position. It embeds only in
+quasi-subordination: under rogatives like *pu:ch-na:* "ask", not under
+responsives or CP-only rogatives like *nirbhar kar-na:* "depend on". -/
 def kya : Particle where
   form := "kya:"
   position := some .free
   distribution := some
     { polarInterrogative := some .optional
+      alternativeInterrogative := some .optional
       constituentInterrogative := some .excluded }
   embedding := some
     { matrix := some .optional
       subordinated := some .excluded
-      quasiSubordinated := some .optional
-      quotation := some .excluded }
+      quasiSubordinated := some .optional }
 
-/-- *ya: nahii:* — "or not", provides an overt alternative for polar
-questions. Required in subordinated polar questions (since *kya:* is
-unavailable there); forms specifically alternative questions. -/
+/-- *ya: nahii:* — "or not", the overt disjunct that turns a polar
+question into a polar alternative question: optional in matrix and
+quasi-subordinated positions, obligatory under subordination, where a
+simplex polar cannot be clause-typed. -/
 def ya_nahi : Particle where
   form := "ya: nahii:"
   position := some .clauseFinal
   distribution := some
     { alternativeInterrogative := some .optional }
   embedding := some
-    { subordinated := some .obligatory
+    { matrix := some .optional
+      subordinated := some .obligatory
       quasiSubordinated := some .optional }
 
+/-- All Hindi-Urdu question-formation particles indexed in this file. -/
 def allParticles : List Particle := [ki, kya, ya_nahi]
 
 end HindiUrdu.Particles

--- a/Linglib/Fragments/HindiUrdu/Questions.lean
+++ b/Linglib/Fragments/HindiUrdu/Questions.lean
@@ -6,10 +6,7 @@ import Linglib.Syntax.Question
 
 `QuestionProfile` bundle for Hindi-Urdu (ISO `hin`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Syntax/Question.lean`. The
-PerspP analysis of *kya:* lives in
-`Studies/BhattDayal2020.lean`; clause-typing typology
-in `Studies/Dayal2025.lean`.
+`Linglib/Syntax/Question.lean`.
 
 Hindi-Urdu: initial polar Q particle *kya:*, wh-in-situ, polar formed by
 particle.

--- a/Linglib/Fragments/Japanese/Particles.lean
+++ b/Linglib/Fragments/Japanese/Particles.lean
@@ -8,8 +8,7 @@ import Linglib.Features.Expressive
 ## Part 1: Interrogative Particles
 
 Q-morphemes and related particles in Japanese, as `Particle` values with
-embedding-distribution facets. The left-peripheral layer assignments are
-derived from those facets in `BhattDayal2020`.
+embedding-distribution facets.
 
 1. *ka/no*: Clause-typing Q-morphemes — appear in subordinated interrogatives
 2. *koto*: Declarative complementizer (contrast with *ka* in interrogatives)

--- a/Linglib/Fragments/Japanese/Questions.lean
+++ b/Linglib/Fragments/Japanese/Questions.lean
@@ -2,13 +2,11 @@ import Linglib.Syntax.Question
 
 /-!
 # Japanese question profile
-[wals-2013] [bhatt-dayal-2020] [sauerland-yatsushiro-2017]
+[wals-2013] [bhatt-dayal-2020] [dayal-2025] [sauerland-yatsushiro-2017]
 
 `QuestionProfile` bundle for Japanese (ISO `jpn`) per the project's
 "per-language data flows through Fragments" rule. Substrate types live in
-`Linglib/Syntax/Question.lean`. The
-CP-layer *ka* and SAP-layer *kke* analyses live in
-`Studies/BhattDayal2020.lean`.
+`Linglib/Syntax/Question.lean`.
 
 Japanese: final polar Q particle *ka*, wh-in-situ, polar formed by particle.
 -/


### PR DESCRIPTION
Deep audit of `Fragments/HindiUrdu/Particles.lean` against the B&D 2020 full text and Dayal 2025.

- Facet cells corrected to what the sources record: unsourced kya: `quotation := excluded` dropped; kya: alternative-question cell and ya: nahii: matrix cell added (B&D §5; Dayal ex. 70).
- *nirbhar kar-na:* is a rogative, not "a responsive"; ForceP/PerspP attribution untangled; stale post-#1192 layer-derivation pointers removed from sibling fragments.
- Docstrings moved to the fragment register (References section, no consumer pointers, de-cited decl docs).