### PR TITLE
refactor(Syntax/Category/Particle): drop Option layer on facets

### DIFF
--- a/Linglib/Fragments/English/QuestionParticles.lean
+++ b/Linglib/Fragments/English/QuestionParticles.lean
@@ -17,7 +17,7 @@ only ([dayal-2025] pp. 670-671, the MQP class), ungrammatical embedded
 def quick : Particle where
   form := "quick"
   position := some .clauseInitial
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded
       quasiSubordinated := some .excluded

--- a/Linglib/Fragments/German/Particles.lean
+++ b/Linglib/Fragments/German/Particles.lean
@@ -28,12 +28,12 @@ particle *ja* (`PolarityMarking.lean`). -/
 def ja : Particle where
   form := "ja"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .excluded
       constituentInterrogative := some .excluded
       imperative := some .excluded }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded }
 
@@ -46,12 +46,12 @@ from declaratives and imperatives. -/
 def denn : Particle where
   form := "denn"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .optional
       imperative := some .excluded }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded }
 
@@ -61,12 +61,12 @@ def denn : Particle where
 def wohl : Particle where
   form := "wohl"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .optional
       constituentInterrogative := some .optional
       imperative := some .excluded }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded }
 
@@ -75,12 +75,12 @@ is"). Declaratives only. -/
 def halt : Particle where
   form := "halt"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .excluded
       constituentInterrogative := some .excluded
       imperative := some .excluded }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded }
 
@@ -91,12 +91,12 @@ is formalized in `SeeligerRepp2018.doch_dual_role`). -/
 def doch : Particle where
   form := "doch"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .excluded
       constituentInterrogative := some .excluded
       imperative := some .optional }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded }
 
@@ -108,7 +108,7 @@ PRQ/NRQ bias profile lives in `SeeligerRepp2018`. -/
 def dochWohl : Particle where
   form := "doch wohl"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/HindiUrdu/Particles.lean
+++ b/Linglib/Fragments/HindiUrdu/Particles.lean
@@ -35,7 +35,7 @@ disjunction *ki* of alternative questions. -/
 def ki : Particle where
   form := "ki"
   position := some .clauseInitial
-  embedding := some
+  embedding :=
     { matrix := some .excluded
       subordinated := some .optional
       quasiSubordinated := some .optional }
@@ -44,11 +44,11 @@ def ki : Particle where
 def kya : Particle where
   form := "kya:"
   position := some .free
-  distribution := some
+  distribution :=
     { polarInterrogative := some .optional
       alternativeInterrogative := some .optional
       constituentInterrogative := some .excluded }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded
       quasiSubordinated := some .optional }
@@ -58,9 +58,9 @@ alternative question. -/
 def ya_nahi : Particle where
   form := "ya: nahii:"
   position := some .clauseFinal
-  distribution := some
+  distribution :=
     { alternativeInterrogative := some .optional }
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .obligatory
       quasiSubordinated := some .optional }

--- a/Linglib/Fragments/Japanese/Particles.lean
+++ b/Linglib/Fragments/Japanese/Particles.lean
@@ -32,7 +32,7 @@ def ka : Particle where
   form := "ka"
   script := some "か"
   position := some .clauseFinal
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .obligatory
       quasiSubordinated := some .optional
@@ -43,7 +43,7 @@ def no_ : Particle where
   form := "no"
   script := some "の"
   position := some .clauseFinal
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .optional
       quasiSubordinated := some .optional }
@@ -56,7 +56,7 @@ def koto : Particle where
   form := "koto"
   script := some "こと"
   position := some .clauseFinal
-  embedding := some
+  embedding :=
     { matrix := some .excluded
       subordinated := some .optional
       quasiSubordinated := some .excluded }
@@ -69,7 +69,7 @@ def kke : Particle where
   form := "kke"
   script := some "っけ"
   position := some .clauseFinal
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded
       quasiSubordinated := some .excluded
@@ -86,7 +86,7 @@ def daroo : Particle where
   form := "daroo"
   script := some "だろう"
   position := some .clauseFinal
-  embedding := some
+  embedding :=
     { matrix := some .optional
       subordinated := some .excluded
       quasiSubordinated := some .optional }

--- a/Linglib/Fragments/Mandarin/QuestionParticles.lean
+++ b/Linglib/Fragments/Mandarin/QuestionParticles.lean
@@ -31,7 +31,7 @@ def ma : Particle where
   form := "ma"
   script := some "吗"
   position := some .clauseFinal
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .optional }
@@ -44,7 +44,7 @@ def ba : Particle where
   form := "ba"
   script := some "吧"
   position := some .clauseFinal
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }
@@ -59,7 +59,7 @@ def nandao : Particle where
   form := "nándào"
   script := some "难道"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Marathi/Particles.lean
+++ b/Linglib/Fragments/Marathi/Particles.lean
@@ -21,7 +21,7 @@ and the preferential-vs-doxastic classification live in
 def bara : Particle where
   form := "bərə"
   position := some .clauseFinal
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .excluded
       constituentInterrogative := some .optional
@@ -35,7 +35,7 @@ mirror of *bərə*). Only the imperative-augmenting use is attested in
 def na : Particle where
   form := "na"
   position := some .clauseFinal
-  distribution := some
+  distribution :=
     { imperative := some .optional }
 
 /-- All Marathi utterance-final particles indexed in this file. -/

--- a/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
@@ -25,7 +25,7 @@ def li : Particle where
   form := "li"
   script := some "ли"
   position := some .secondPosition
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }
@@ -38,7 +38,7 @@ def nima : Particle where
   form := "nima"
   script := some "нима"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Czech/Particles.lean
+++ b/Linglib/Fragments/Slavic/Czech/Particles.lean
@@ -17,7 +17,7 @@ negative polar questions ([stankova-2026] §2.2.1; the adverbial reading
 (`Stankova2026`); FALSUM experiments in `StankovaSimik2025`. -/
 def nahodou : Particle where
   form := "náhodou"
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional }
 
@@ -26,7 +26,7 @@ questions ([stankova-2026] (13)-(14)); inner-negation diagnostic in
 `Stankova2026`. -/
 def jeste : Particle where
   form := "ještě"
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .optional }
 
@@ -35,7 +35,7 @@ questions ([stankova-2026] (15)); inner/medial-negation diagnostic in
 `Stankova2026`. -/
 def fakt : Particle where
   form := "fakt"
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .optional }
 
@@ -43,7 +43,7 @@ def fakt : Particle where
 ([stankova-2026] (9)); parallels English *at all*. -/
 def vubec : Particle where
   form := "vůbec"
-  distribution := some
+  distribution :=
     { declarative := some .optional
       polarInterrogative := some .optional }
 
@@ -52,14 +52,14 @@ the cross-Slavic RAZVE family ([simik-2024] §4.2.4, [nekula-1996],
 [stankova-2023]). -/
 def snad : Particle where
   form := "snad"
-  distribution := some { polarInterrogative := some .optional }
+  distribution := { polarInterrogative := some .optional }
 
 /-- *copak* 'what then' — RAZVE-family particle of positive and
 negative polar questions ([stankova-2025] exs. 19a-b, [nekula-1996]);
 evidential-bias experiments in `StankovaSimik2025`. -/
 def copak : Particle where
   form := "copak"
-  distribution := some { polarInterrogative := some .optional }
+  distribution := { polarInterrogative := some .optional }
 
 /-- All Czech PQ particles indexed in this file. -/
 def allParticles : List Particle :=

--- a/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
@@ -24,7 +24,7 @@ def dali : Particle where
   form := "dali"
   script := some "дали"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
@@ -22,7 +22,7 @@ Verb-initial PQs possible but unacceptable in quiz scenarios. -/
 def czy : Particle where
   form := "czy"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .obligatory
       constituentInterrogative := some .optional }
@@ -33,7 +33,7 @@ classification in `Simik2024`. -/
 def czyzby : Particle where
   form := "czyżby"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
@@ -24,7 +24,7 @@ def li : Particle where
   form := "li"
   script := some "ли"
   position := some .secondPosition
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }
@@ -37,7 +37,7 @@ def razve_ : Particle where
   form := "razve"
   script := some "разве"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
@@ -21,7 +21,7 @@ clause-initial particle + verb movement. Neutral baseline. -/
 def daLi : Particle where
   form := "da li"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }
@@ -32,7 +32,7 @@ razve). Evidential classification in `Simik2024`. -/
 def zar_ : Particle where
   form := "zar"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
@@ -19,7 +19,7 @@ default PQs; incompatible with DeclPQs. -/
 def ali : Particle where
   form := "ali"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
@@ -24,7 +24,7 @@ def cy : Particle where
   form := "čy"
   script := some "чи"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .obligatory
       constituentInterrogative := some .optional }
@@ -37,7 +37,7 @@ def xiba : Particle where
   form := "xiba"
   script := some "хіба"
   position := some .clauseInitial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Fragments/Swedish/QuestionParticles.lean
+++ b/Linglib/Fragments/Swedish/QuestionParticles.lean
@@ -33,7 +33,7 @@ signal and evidential bias live in `SeeligerRepp2018`. -/
 def val : Particle where
   form := "väl"
   position := some .clauseMedial
-  distribution := some
+  distribution :=
     { declarative := some .excluded
       polarInterrogative := some .optional
       constituentInterrogative := some .excluded }

--- a/Linglib/Syntax/Category/Particle/Basic.lean
+++ b/Linglib/Syntax/Category/Particle/Basic.lean
@@ -7,12 +7,15 @@ open Morphology (Word)
 # Particle
 
 This file defines `Particle`, the lexical core for uninflectable
-function words ([zwicky-1985-clitics]): form, position, and optional
+function words ([zwicky-1985-clitics]): form, position, and
 three-valued distribution facets over the [sadock-zwicky-1985]
 sentence-type cells and `Clause.EmbeddingContext`. Facets record
 distributional felicity, not licensing mechanism (analytical,
 study-side); a `none` cell means the source records nothing, not
-exclusion. The cells are record fields, not a taxonomy: force is
+exclusion, and an unrecorded facet is the empty record `{}`. The two
+facets are marginals of a joint table: embedding cells are read
+relative to the particle's clause-type restriction (a polar-question
+particle's `matrix` cell concerns matrix polar questions). The cells are record fields, not a taxonomy: force is
 `Mood.Illocutionary`, and the interrogative subtypes are the question
 constructions of `Semantics/Questions` — a lookup is keyed by field
 projection (`p.LicensedIn (·.declarative)`).
@@ -97,12 +100,12 @@ structure Particle where
   script : Option String := none
   /-- Host/position class; `none` when the source records no placement. -/
   position : Option Particle.Position := none
-  /-- Clause-type distribution facet; `none` for particles with no
-      clause-type restriction (focus particles, case particles). -/
-  distribution : Option ClauseDistribution := none
+  /-- Clause-type distribution facet; `{}` when the source records no
+      clause-type data. -/
+  distribution : ClauseDistribution := {}
   /-- Interrogative-embedding distribution facet ([bhatt-dayal-2020]
-      axis); `none` when the source records no embedding data. -/
-  embedding : Option EmbedDistribution := none
+      axis); `{}` when the source records no embedding data. -/
+  embedding : EmbedDistribution := {}
   deriving DecidableEq, Repr
 
 namespace Particle
@@ -112,7 +115,7 @@ namespace Particle
 projection `c` (e.g. `(·.declarative)`), if any. -/
 def status? (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
     Option ParticleStatus :=
-  p.distribution.bind c
+  c p.distribution
 
 /-- The particle is positively recorded as available (obligatorily or
 optionally) in the cell picked out by projection `c`. -/
@@ -131,7 +134,7 @@ instance (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
 
 /-- Recorded embedding-distribution status in context `c`, if any. -/
 def embedStatus? (p : Particle) (c : Clause.EmbeddingContext) : Option ParticleStatus :=
-  p.embedding.bind (·.status? c)
+  p.embedding.status? c
 
 /-- The particle is positively recorded as available in embedding
 context `c`. -/
@@ -149,10 +152,10 @@ instance (p : Particle) (c : Clause.EmbeddingContext) : Decidable (p.LicensedInE
 
 /-- Carries a clause-type distribution (the sentential/illocutionary
 particle family: question, modal, sentence-final particles). -/
-def IsSentential (p : Particle) : Prop := p.distribution.isSome
+def IsSentential (p : Particle) : Prop := p.distribution ≠ {}
 
 instance (p : Particle) : Decidable p.IsSentential :=
-  inferInstanceAs (Decidable (_ = true))
+  inferInstanceAs (Decidable (_ ≠ _))
 
 /-- Projection to `Word` (UD `PART`). -/
 def toWord (p : Particle) : Word :=


### PR DESCRIPTION
`Particle.distribution`/`.embedding` become defaulted records (`:= {}`): the outer `Option` was observationally identical to the all-`none` record through `status?`, so it was a distinction without a difference costing a `some { ... }` wrapper at every fragment entry. Module docstring now states the marginal-reading convention for the two facets; `IsSentential` becomes `p.distribution ≠ {}`.