### PR TITLE
fix(Fragments/Mandarin): source-verify particles; drop unanchored layers

### DIFF
--- a/Linglib/Fragments/English/QuestionParticles.lean
+++ b/Linglib/Fragments/English/QuestionParticles.lean
@@ -17,11 +17,14 @@ only ([dayal-2025] pp. 670-671, the MQP class), ungrammatical embedded
 def quick : Particle where
   form := "quick"
   position := some .clauseInitial
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded
-      quasiSubordinated := some .excluded
-      quotation := some .optional }
+  distribution := fun c e => match c with
+    | .polar | .alternative | .constituent =>
+      match e with
+      | .matrix => some .optional
+      | .subordinated => some .excluded
+      | .quasiSubordinated => some .excluded
+      | .quotation => some .optional
+    | _ => none
 
 def allQuestionParticles : List Particle := [quick]
 

--- a/Linglib/Fragments/German/Particles.lean
+++ b/Linglib/Fragments/German/Particles.lean
@@ -28,14 +28,16 @@ particle *ja* (`PolarityMarking.lean`). -/
 def ja : Particle where
   form := "ja"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .excluded
-      constituentInterrogative := some .excluded
-      imperative := some .excluded }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded }
+  distribution := fun c e => match e with
+    | .matrix =>
+      match c with
+      | .declarative => some .optional
+      | .polar => some .excluded
+      | .constituent => some .excluded
+      | .imperative => some .excluded
+      | _ => none
+    | .subordinated => some .excluded
+    | _ => none
 
 /-- *denn* — interrogative-only particle, one lexeme under two analyses:
 [gutzmann-2015]'s question-prompting UCI (the interrogative counterpart
@@ -46,14 +48,16 @@ from declaratives and imperatives. -/
 def denn : Particle where
   form := "denn"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .optional
-      imperative := some .excluded }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded }
+  distribution := fun c e => match e with
+    | .matrix =>
+      match c with
+      | .declarative => some .excluded
+      | .polar => some .optional
+      | .constituent => some .optional
+      | .imperative => some .excluded
+      | _ => none
+    | .subordinated => some .excluded
+    | _ => none
 
 /-- *wohl* — epistemic hedging particle: declaratives and interrogatives
 (which involve EPIS), never imperatives (which lack it); see
@@ -61,28 +65,32 @@ def denn : Particle where
 def wohl : Particle where
   form := "wohl"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .optional
-      constituentInterrogative := some .optional
-      imperative := some .excluded }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded }
+  distribution := fun c e => match e with
+    | .matrix =>
+      match c with
+      | .declarative => some .optional
+      | .polar => some .optional
+      | .constituent => some .optional
+      | .imperative => some .excluded
+      | _ => none
+    | .subordinated => some .excluded
+    | _ => none
 
 /-- *halt* — resignation/acceptance particle ("that's just the way it
 is"). Declaratives only. -/
 def halt : Particle where
   form := "halt"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .excluded
-      constituentInterrogative := some .excluded
-      imperative := some .excluded }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded }
+  distribution := fun c e => match e with
+    | .matrix =>
+      match c with
+      | .declarative => some .optional
+      | .polar => some .excluded
+      | .constituent => some .excluded
+      | .imperative => some .excluded
+      | _ => none
+    | .subordinated => some .excluded
+    | _ => none
 
 /-- *doch* — contradiction/insistence particle. Uniquely among common
 MPs, licensed in both declaratives and imperatives. Distinct from the
@@ -91,14 +99,16 @@ is formalized in `SeeligerRepp2018.doch_dual_role`). -/
 def doch : Particle where
   form := "doch"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .excluded
-      constituentInterrogative := some .excluded
-      imperative := some .optional }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded }
+  distribution := fun c e => match e with
+    | .matrix =>
+      match c with
+      | .declarative => some .optional
+      | .polar => some .excluded
+      | .constituent => some .excluded
+      | .imperative => some .optional
+      | _ => none
+    | .subordinated => some .excluded
+    | _ => none
 
 /-- *doch wohl* — non-compositional marker of rejecting questions
 ([seeliger-repp-2018]): declarative-syntax polar questions (recorded
@@ -108,10 +118,11 @@ PRQ/NRQ bias profile lives in `SeeligerRepp2018`. -/
 def dochWohl : Particle where
   form := "doch wohl"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 /-- The modal-particle inventory ([gutzmann-2015] Table 6.1). -/
 def modalParticles : List Particle := [ja, denn, wohl, halt, doch]
@@ -124,10 +135,10 @@ def questionParticles : List Particle := [denn, dochWohl]
 the clause-type facet (dass-VL clauses exclude modal particles). -/
 def licensedInClause (p : Particle) : GermanClauseType → Bool
   | .dassVL          => false
-  | .v2Declarative   => decide (p.LicensedIn (·.declarative))
-  | .v2Interrogative => decide (p.LicensedIn (·.polarInterrogative))
-  | .vlInterrogative => decide (p.LicensedIn (·.constituentInterrogative))
-  | .imperative      => decide (p.LicensedIn (·.imperative))
+  | .v2Declarative   => decide (p.LicensedIn .declarative)
+  | .v2Interrogative => decide (p.LicensedIn .polar)
+  | .vlInterrogative => decide (p.LicensedIn .constituent)
+  | .imperative      => decide (p.LicensedIn .imperative)
 
 /-- Every MP is excluded from dass-VL clauses. -/
 theorem all_excluded_from_dassVL :

--- a/Linglib/Fragments/HindiUrdu/Particles.lean
+++ b/Linglib/Fragments/HindiUrdu/Particles.lean
@@ -12,8 +12,8 @@ questions and occupies a projection above CP (Bhatt and Dayal's ForceP,
 Dayal's later PerspP); it embeds only in quasi-subordination. Since
 nothing clause-types a bare embedded polar clause, subordinated polar
 questions require the overt alternative *ya: nahii:* "or not". This file
-provides the three particles as `Particle` values with clause-type and
-embedding facets.
+provides the three particles as `Particle` values with recorded
+licensing distributions.
 
 ## Main declarations
 
@@ -35,35 +35,37 @@ disjunction *ki* of alternative questions. -/
 def ki : Particle where
   form := "ki"
   position := some .clauseInitial
-  embedding :=
-    { matrix := some .excluded
-      subordinated := some .optional
-      quasiSubordinated := some .optional }
+  distribution := fun c e => match c with
+    | .declarative | .polar | .alternative | .constituent =>
+      match e with
+      | .matrix => some .excluded
+      | .subordinated => some .optional
+      | .quasiSubordinated => some .optional
+      | .quotation => none
+    | _ => none
 
 /-- *kya:* is a polar question particle. -/
 def kya : Particle where
   form := "kya:"
   position := some .free
-  distribution :=
-    { polarInterrogative := some .optional
-      alternativeInterrogative := some .optional
-      constituentInterrogative := some .excluded }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded
-      quasiSubordinated := some .optional }
+  distribution := fun c e => match c, e with
+    | .polar, .matrix => some .optional
+    | .polar, .subordinated => some .excluded
+    | .polar, .quasiSubordinated => some .optional
+    | .alternative, .matrix => some .optional
+    | .constituent, _ => some .excluded
+    | _, _ => none
 
 /-- *ya: nahii:* "or not" is the overt disjunct forming a polar
 alternative question. -/
 def ya_nahi : Particle where
   form := "ya: nahii:"
   position := some .clauseFinal
-  distribution :=
-    { alternativeInterrogative := some .optional }
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .obligatory
-      quasiSubordinated := some .optional }
+  distribution := fun c e => match c, e with
+    | .polar, .matrix => some .optional
+    | .polar, .subordinated => some .obligatory
+    | .polar, .quasiSubordinated => some .optional
+    | _, _ => none
 
 /-- All Hindi-Urdu question-formation particles indexed in this file. -/
 def allParticles : List Particle := [ki, kya, ya_nahi]

--- a/Linglib/Fragments/Japanese/Particles.lean
+++ b/Linglib/Fragments/Japanese/Particles.lean
@@ -32,21 +32,28 @@ def ka : Particle where
   form := "ka"
   script := some "か"
   position := some .clauseFinal
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .obligatory
-      quasiSubordinated := some .optional
-      quotation := some .optional }
+  distribution := fun c e => match c with
+    | .polar | .alternative | .constituent =>
+      match e with
+      | .matrix => some .optional
+      | .subordinated => some .obligatory
+      | .quasiSubordinated => some .optional
+      | .quotation => some .optional
+    | _ => none
 
 /-- *no* — clause-typing particle for questions (informal). -/
 def no_ : Particle where
   form := "no"
   script := some "の"
   position := some .clauseFinal
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .optional
-      quasiSubordinated := some .optional }
+  distribution := fun c e => match c with
+    | .polar | .alternative | .constituent =>
+      match e with
+      | .matrix => some .optional
+      | .subordinated => some .optional
+      | .quasiSubordinated => some .optional
+      | .quotation => none
+    | _ => none
 
 /-- *koto* — complementizer for declarative clauses. Contrast with *ka*:
 having *ka* in the embedded clause suffices for interrogative
@@ -56,10 +63,11 @@ def koto : Particle where
   form := "koto"
   script := some "こと"
   position := some .clauseFinal
-  embedding :=
-    { matrix := some .excluded
-      subordinated := some .optional
-      quasiSubordinated := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .declarative, .subordinated => some .optional
+    | .declarative, .quasiSubordinated => some .excluded
+    | _, _ => none
 
 /-- *kke* — meta question particle (MQP). Only in matrix questions and
 quotations ([sauerland-yatsushiro-2017]). Has a "remind-me"
@@ -69,11 +77,14 @@ def kke : Particle where
   form := "kke"
   script := some "っけ"
   position := some .clauseFinal
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded
-      quasiSubordinated := some .excluded
-      quotation := some .optional }
+  distribution := fun c e => match c with
+    | .polar | .alternative | .constituent =>
+      match e with
+      | .matrix => some .optional
+      | .subordinated => some .excluded
+      | .quasiSubordinated => some .excluded
+      | .quotation => some .optional
+    | _ => none
 
 /-- *daroo* (だろう) — conjectural/epistemic copula.
 With declarative complement: "x thinks p" (⟦daroo⟧({p})(x) = INQ_x ⊆ {p}↓).
@@ -86,10 +97,14 @@ def daroo : Particle where
   form := "daroo"
   script := some "だろう"
   position := some .clauseFinal
-  embedding :=
-    { matrix := some .optional
-      subordinated := some .excluded
-      quasiSubordinated := some .optional }
+  distribution := fun c e => match c with
+    | .declarative | .polar =>
+      match e with
+      | .matrix => some .optional
+      | .subordinated => some .excluded
+      | .quasiSubordinated => some .optional
+      | .quotation => none
+    | _ => none
 
 def allParticles : List Particle := [ka, no_, koto, kke, daroo]
 

--- a/Linglib/Fragments/Mandarin/QuestionParticles.lean
+++ b/Linglib/Fragments/Mandarin/QuestionParticles.lean
@@ -1,69 +1,69 @@
 import Linglib.Syntax.Category.Particle.Basic
 
 /-!
-# Mandarin Question Particles
-[zheng-2025]
+# Mandarin question particles
 
-Lexical entries for Mandarin interrogative particles as `Particle` values.
-Bias profiles (ba's speaker-bias requirement, nandao's evidential
-requirement) are analytical classifications and live with the analysis
-that assigns them, in `Zheng2025` — alongside the left-peripheral layer
-assignments.
+Mandarin marks polar questions with the neutral sentence-final particle
+*ma* 吗 and the confirmation-seeking *ba* 吧; both attach to declarative
+word order, and neither forms constituent questions — *wh*-words stay in
+situ, and under *ma* a *wh*-word takes only its indefinite reading, so
+the string remains a polar question. The clause-initial evidential
+adverb *nándào* 难道 forms surprise polar questions and is incompatible
+with declaratives and *wh*-questions. This file provides the three as
+`Particle` values with recorded licensing distributions; *nandao*'s
+evidential felicity conditions live with their analysis.
 
-## Particles
+## Main declarations
 
-| Particle | Gloss | Restriction |
-|----------|-------|-------------|
-| 吗 ma | PQ marker | polar + wh |
-| 吧 ba | TAG/confirm | polar only |
-| 难道 nándào | NANDAO | polar only |
+* `Mandarin.QuestionParticles.ma` — the neutral polar question particle.
+* `Mandarin.QuestionParticles.ba` — the confirmation-seeking particle.
+* `Mandarin.QuestionParticles.nandao` — the evidential question adverb.
 
-## Cross-Module Connections
+## References
 
-- `Zheng2025`: bias profiles, layer assignments, `Kernel.nandaoFelicitous`
+* [li-thompson-1981]
+* [xu-2012]
+* [zheng-2025]
 -/
 
 namespace Mandarin.QuestionParticles
 
-/-- 吗 ma — unmarked polar question particle. Sentence-final; turns a
-declarative into a yes/no question. Bias-neutral (see `Zheng2025`). -/
+/-- *ma* 吗 is the neutral sentence-final polar question particle. -/
 def ma : Particle where
   form := "ma"
   script := some "吗"
   position := some .clauseFinal
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
-/-- 吧 ba — confirmation-seeking particle. Speaker expects a positive
-answer and seeks confirmation, comparable to English tag questions
-("It's raining, isn't it?"). Its speaker-bias requirement lives in
-`Zheng2025`. -/
+/-- *ba* 吧 is the confirmation-seeking question particle, distinct from
+the homophonous suggestion-softening *ba* of imperatives. -/
 def ba : Particle where
   form := "ba"
   script := some "吧"
   position := some .clauseFinal
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
-/-- 难道 nándào — evidential question particle: marks that the speaker has
-encountered unexpected contextual evidence supporting the prejacent;
-compatible with a neutral epistemic state (pure inquiry use, [zheng-2025]
-ex. 3). Canonically clause-initial (post-subject placement possible).
-Polar-only — the contrast with wh-compatible *denn* lives in `Theiler2021`.
-Its evidential requirement lives in `Zheng2025`. -/
+/-- *nándào* 难道 is a clause-initial evidential adverb forming surprise
+polar questions. -/
 def nandao : Particle where
   form := "nándào"
   script := some "难道"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
+/-- All Mandarin question particles indexed in this file. -/
 def allQuestionParticles : List Particle := [ma, ba, nandao]
 
 end Mandarin.QuestionParticles

--- a/Linglib/Fragments/Marathi/Particles.lean
+++ b/Linglib/Fragments/Marathi/Particles.lean
@@ -21,11 +21,12 @@ and the preferential-vs-doxastic classification live in
 def bara : Particle where
   form := "bərə"
   position := some .clauseFinal
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .excluded
-      constituentInterrogative := some .optional
-      imperative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .optional
+    | .polar, .matrix => some .excluded
+    | .constituent, .matrix => some .optional
+    | .imperative, .matrix => some .optional
+    | _, _ => none
 
 /-- *na* — utterance-final particle analyzed in [deo-2023] as
 signalling preference for *independent* shared commitment (the doxastic
@@ -35,8 +36,9 @@ mirror of *bərə*). Only the imperative-augmenting use is attested in
 def na : Particle where
   form := "na"
   position := some .clauseFinal
-  distribution :=
-    { imperative := some .optional }
+  distribution := fun c e => match c, e with
+    | .imperative, .matrix => some .optional
+    | _, _ => none
 
 /-- All Marathi utterance-final particles indexed in this file. -/
 def allParticles : List Particle := [bara, na]

--- a/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Bulgarian/QuestionParticles.lean
@@ -25,10 +25,11 @@ def li : Particle where
   form := "li"
   script := some "ли"
   position := some .secondPosition
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 /-- нима nima — mirative/dubitative particle (RAZVE family, [simik-2024]
 §4.2.4). Expresses incredulity: speaker encounters evidence conflicting
@@ -38,10 +39,11 @@ def nima : Particle where
   form := "nima"
   script := some "нима"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [li, nima]
 

--- a/Linglib/Fragments/Slavic/Czech/Particles.lean
+++ b/Linglib/Fragments/Slavic/Czech/Particles.lean
@@ -17,49 +17,57 @@ negative polar questions ([stankova-2026] §2.2.1; the adverbial reading
 (`Stankova2026`); FALSUM experiments in `StankovaSimik2025`. -/
 def nahodou : Particle where
   form := "náhodou"
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- *ještě* 'yet, still' — aspectual particle of declaratives and polar
 questions ([stankova-2026] (13)-(14)); inner-negation diagnostic in
 `Stankova2026`. -/
 def jeste : Particle where
   form := "ještě"
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .optional
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- *fakt* 'really' — emphatic particle of declaratives and polar
 questions ([stankova-2026] (15)); inner/medial-negation diagnostic in
 `Stankova2026`. -/
 def fakt : Particle where
   form := "fakt"
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .optional
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- *vůbec* 'at all' — NPI particle of assertions and polar questions
 ([stankova-2026] (9)); parallels English *at all*. -/
 def vubec : Particle where
   form := "vůbec"
-  distribution :=
-    { declarative := some .optional
-      polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .optional
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- *snad* 'perhaps, surely not' — adversative/mirative PQ particle of
 the cross-Slavic RAZVE family ([simik-2024] §4.2.4, [nekula-1996],
 [stankova-2023]). -/
 def snad : Particle where
   form := "snad"
-  distribution := { polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- *copak* 'what then' — RAZVE-family particle of positive and
 negative polar questions ([stankova-2025] exs. 19a-b, [nekula-1996]);
 evidential-bias experiments in `StankovaSimik2025`. -/
 def copak : Particle where
   form := "copak"
-  distribution := { polarInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .polar, .matrix => some .optional
+    | _, _ => none
 
 /-- All Czech PQ particles indexed in this file. -/
 def allParticles : List Particle :=

--- a/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Macedonian/QuestionParticles.lean
@@ -24,10 +24,11 @@ def dali : Particle where
   form := "dali"
   script := some "дали"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [dali]
 

--- a/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Polish/QuestionParticles.lean
@@ -22,10 +22,11 @@ Verb-initial PQs possible but unacceptable in quiz scenarios. -/
 def czy : Particle where
   form := "czy"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .obligatory
-      constituentInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .obligatory
+    | .constituent, .matrix => some .optional
+    | _, _ => none
 
 /-- czyżby — mirative/dubitative particle (RAZVE family, [simik-2024]
 §4.2.4). Polish member of the cross-Slavic razve family. Evidential
@@ -33,10 +34,11 @@ classification in `Simik2024`. -/
 def czyzby : Particle where
   form := "czyżby"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [czy, czyzby]
 

--- a/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Russian/QuestionParticles.lean
@@ -24,10 +24,11 @@ def li : Particle where
   form := "li"
   script := some "ли"
   position := some .secondPosition
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 /-- разве razve — mirative/dubitative question particle ([simik-2024]
 §4.2.4). Indicates conflict between speaker's prior epistemic state and
@@ -37,10 +38,11 @@ def razve_ : Particle where
   form := "razve"
   script := some "разве"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [li, razve_]
 

--- a/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Serbian/QuestionParticles.lean
@@ -21,10 +21,11 @@ clause-initial particle + verb movement. Neutral baseline. -/
 def daLi : Particle where
   form := "da li"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 /-- zar — mirative/dubitative particle (RAZVE family, [simik-2024]
 §4.2.4). Compatible with both outer and inner negation (like Russian
@@ -32,10 +33,11 @@ razve). Evidential classification in `Simik2024`. -/
 def zar_ : Particle where
   form := "zar"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [daLi, zar_]
 

--- a/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Slovenian/QuestionParticles.lean
@@ -19,10 +19,11 @@ default PQs; incompatible with DeclPQs. -/
 def ali : Particle where
   form := "ali"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [ali]
 

--- a/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
+++ b/Linglib/Fragments/Slavic/Ukrainian/QuestionParticles.lean
@@ -24,10 +24,11 @@ def cy : Particle where
   form := "čy"
   script := some "чи"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .obligatory
-      constituentInterrogative := some .optional }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .obligatory
+    | .constituent, .matrix => some .optional
+    | _, _ => none
 
 /-- хіба xiba — mirative/dubitative particle (RAZVE family, [simik-2024]
 §4.2.4). Ukrainian cognate of Russian razve: indicates conflict between
@@ -37,10 +38,11 @@ def xiba : Particle where
   form := "xiba"
   script := some "хіба"
   position := some .clauseInitial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [cy, xiba]
 

--- a/Linglib/Fragments/Swedish/QuestionParticles.lean
+++ b/Linglib/Fragments/Swedish/QuestionParticles.lean
@@ -33,10 +33,11 @@ signal and evidential bias live in `SeeligerRepp2018`. -/
 def val : Particle where
   form := "väl"
   position := some .clauseMedial
-  distribution :=
-    { declarative := some .excluded
-      polarInterrogative := some .optional
-      constituentInterrogative := some .excluded }
+  distribution := fun c e => match c, e with
+    | .declarative, .matrix => some .excluded
+    | .polar, .matrix => some .optional
+    | .constituent, .matrix => some .excluded
+    | _, _ => none
 
 def allQuestionParticles : List Particle := [val]
 

--- a/Linglib/Studies/Gutzmann2015.lean
+++ b/Linglib/Studies/Gutzmann2015.lean
@@ -659,11 +659,11 @@ theorem wohl_iff_epis (ct : GermanClauseType) :
 /-- *ja* is restricted to declaratives, matching the clause type with
 deontic + epistemic mood but without the hearer knowledge condition. -/
 theorem ja_declarative_restriction :
-    ja.LicensedIn (·.declarative) ∧ ¬ ja.LicensedIn (·.polarInterrogative) := by decide
+    ja.LicensedIn .declarative ∧ ¬ ja.LicensedIn .polar := by decide
 
 /-- *denn* is the interrogative counterpart of *ja*. -/
 theorem denn_interrogative_restriction :
-    ¬ denn.LicensedIn (·.declarative) ∧ denn.LicensedIn (·.polarInterrogative) := by decide
+    ¬ denn.LicensedIn .declarative ∧ denn.LicensedIn .polar := by decide
 
 /-- *ja* and *denn* partition clause types: they are never both
 licensed in the same clause type. -/

--- a/Linglib/Studies/SeeligerRepp2018.lean
+++ b/Linglib/Studies/SeeligerRepp2018.lean
@@ -487,7 +487,7 @@ open Polarity.Marking (Env)
     questions, not assertions ([seeliger-repp-2018] §5.2). Derived from
     the fragment's distribution facet. -/
 theorem val_creates_questions :
-    ¬ Swedish.QuestionParticles.val.LicensedIn (·.declarative) := by decide
+    ¬ Swedish.QuestionParticles.val.LicensedIn .declarative := by decide
 
 /-- S&R's bias classification of *väl* (formerly fragment fields; a
     particle's bias requirement is the analysis, so it lives here):
@@ -522,7 +522,7 @@ def dochWohlOriginalBias : Option Semantics.Questions.Bias.OriginalBias :=
 /-- *doch wohl* is not usable in assertions — it marks questions.
     Derived from the fragment's distribution facet. -/
 theorem dochWohl_not_assertion :
-    ¬ German.Particles.dochWohl.LicensedIn (·.declarative) := by decide
+    ¬ German.Particles.dochWohl.LicensedIn .declarative := by decide
 
 /-- The derived RQ property behind `dochWohlOriginalBias`: both DQ types
     *doch wohl* can mark have active ("plus") epistemic bias — the
@@ -565,7 +565,7 @@ theorem dochWohl_is_complex :
     In RQs, *doch* has a "conflict" meaning — it signals surprise or
     realization — rather than the "reminding" function of assertive *doch*. -/
 theorem dochWohl_is_question_marker :
-    ¬ German.Particles.dochWohl.LicensedIn (·.declarative) := by decide
+    ¬ German.Particles.dochWohl.LicensedIn .declarative := by decide
 
 /-- German *doch* is formally ambiguous between two distinct roles:
     1. **Polarity-reversal *doch***: pre-utterance correction particle
@@ -586,7 +586,7 @@ theorem doch_dual_role :
     Env.correction ∈ dochPreUtterance.environments ∧
     Env.sentenceInternal ∉ dochPreUtterance.environments ∧
     -- The RQ *doch wohl* is a question marker (not usable in assertions)
-    ¬ dochWohl.LicensedIn (·.declarative) := ⟨rfl, by decide, by decide, by decide⟩
+    ¬ dochWohl.LicensedIn .declarative := ⟨rfl, by decide, by decide, by decide⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 13. Romero-bridge applied to the Swedish/German data

--- a/Linglib/Studies/Theiler2021.lean
+++ b/Linglib/Studies/Theiler2021.lean
@@ -52,8 +52,8 @@ def dennBias : Option Semantics.Questions.Bias.ContextualEvidence := none
     *nandao*'s polar-only restriction. Derived from the fragments'
     distribution facets. -/
 theorem denn_wh_unlike_nandao :
-    German.Particles.denn.LicensedIn (·.constituentInterrogative) ∧
-    ¬ Mandarin.QuestionParticles.nandao.LicensedIn (·.constituentInterrogative) := by
+    German.Particles.denn.LicensedIn .constituent ∧
+    ¬ Mandarin.QuestionParticles.nandao.LicensedIn .constituent := by
   decide
 
 end Theiler2021

--- a/Linglib/Studies/Zheng2025.lean
+++ b/Linglib/Studies/Zheng2025.lean
@@ -2,7 +2,6 @@ import Linglib.Data.UD.Basic
 import Linglib.Data.Examples.Zheng2025
 import Linglib.Fragments.Mandarin.QuestionParticles
 import Linglib.Semantics.Modality.Kernel
-import Linglib.Features.QParticleLayer
 import Linglib.Semantics.Questions.Bias
 import Linglib.Semantics.Questions.Singleton
 import Mathlib.Data.Set.Card
@@ -191,7 +190,7 @@ theorem expected_evidence_infelicitous :
 
 /-! ### Bias classification -/
 
-open Mandarin.QuestionParticles (nandao ma ba)
+open Mandarin.QuestionParticles (nandao)
 
 /-- *Nandao* requires contextual evidence for p — Zheng's evidential
 classification, the lexical face of `evidential_bias_necessary`. -/
@@ -211,30 +210,18 @@ theorem kernel_requires_evidence (k : Kernel World) (u : List (World → Prop))
     evidenceSupports k φ :=
   h.1
 
-/-! ### Left-peripheral layer assignments ([dayal-2025] cartography)
+/-! ### Selectional profile (§4)
 
-Zheng's layer assignments for the three Mandarin Q-particles in the
-[dayal-2025] cartography `[SAP [PerspP [CP ...]]]`. The layer split mirrors
-the bias split: the unbiased particle *ma* is CP (widest distribution:
-matrix, subordinated, quasi-subordinated); the biased *ba* and *nandao* are
-PerspP (matrix + quasi-subordinated only). The `_` argument is unused: the
-layer is a theoretical overlay on the fragment particle, not a computed
-property of its lexical fields. -/
+Nandao combines only with polar questions — it is incompatible with
+declaratives and wh-questions ([zheng-2025] ex. 12, after [xu-2012]) —
+and §4 derives the restriction from the felicity conditions: only a
+polar prejacent both follows from the contextual evidence and targets
+the source of the incompatibility. -/
 
-open Features (QParticleLayer)
-
-/-- *ma*: the unmarked CP-layer particle. -/
-def ma_layer (_ : Particle) : QParticleLayer := .cp
-
-/-- *ba*: PerspP-layer biased particle. -/
-def ba_layer (_ : Particle) : QParticleLayer := .perspP
-
-/-- *nandao*: PerspP-layer biased particle. -/
-def nandao_layer (_ : Particle) : QParticleLayer := .perspP
-
-/-- *Ba* carries speaker bias (expects a positive answer, seeks confirmation)
-with no evidential requirement; the unbiased *ma* imposes neither. -/
-def baOriginalBias : Option Semantics.Questions.Bias.OriginalBias := some .forP
+/-- The fragment's recorded distribution matches the paper's ex. 12. -/
+theorem nandao_distribution :
+    ¬ nandao.LicensedIn .declarative ∧ nandao.LicensedIn .polar ∧
+      ¬ nandao.LicensedIn .constituent := by decide
 
 /-! ### Singleton-alternative presupposition (parallel to kya:)
 

--- a/Linglib/Syntax/Category/Particle/Basic.lean
+++ b/Linglib/Syntax/Category/Particle/Basic.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.Clause.Basic
 import Linglib.Morphology.Word.Basic
+import Mathlib.Data.Fintype.Basic
 
 open Morphology (Word)
 
@@ -7,25 +8,21 @@ open Morphology (Word)
 # Particle
 
 This file defines `Particle`, the lexical core for uninflectable
-function words ([zwicky-1985-clitics]): form, position, and
-three-valued distribution facets over the [sadock-zwicky-1985]
-sentence-type cells and `Clause.EmbeddingContext`. Facets record
+function words ([zwicky-1985-clitics]): form, position, and a recorded
+distribution over licensing cells — pairs of a [sadock-zwicky-1985]
+sentence type (interrogatives subtyped by the `Semantics/Questions`
+constructions) and a `Clause.EmbeddingContext`. The distribution records
 distributional felicity, not licensing mechanism (analytical,
 study-side); a `none` cell means the source records nothing, not
-exclusion, and an unrecorded facet is the empty record `{}`. The two
-facets are marginals of a joint table: embedding cells are read
-relative to the particle's clause-type restriction (a polar-question
-particle's `matrix` cell concerns matrix polar questions). The cells are record fields, not a taxonomy: force is
-`Mood.Illocutionary`, and the interrogative subtypes are the question
-constructions of `Semantics/Questions` — a lookup is keyed by field
-projection (`p.LicensedIn (·.declarative)`).
+exclusion. Sentence-type and embedding-context profiles are marginals of
+the table, derived by existential projection (`LicensedIn`,
+`LicensedInEmbed`), never stored separately.
 
 ## Main declarations
 
-* `Particle`, `Particle.Position`
-* `ParticleStatus`, `ClauseDistribution`, `EmbedDistribution`
-* `Particle.LicensedIn`, `Particle.LicensedInEmbed` — derived,
-  decidable
+* `Particle`, `Particle.ClauseType`, `Particle.Position`, `ParticleStatus`
+* `Particle.Licensed`, `Particle.LicensedIn`, `Particle.LicensedInEmbed`
+  — derived, decidable
 * `Particle.toWord` — projection to `Word` (UD `PART`)
 -/
 
@@ -58,38 +55,19 @@ inductive ParticleStatus where
   | excluded
   deriving DecidableEq, Repr
 
-/-- Per-clause-context distribution record over the
-[sadock-zwicky-1985] sentence-type cells (interrogatives subtyped:
-polar, alternative, constituent — the `Semantics/Questions`
-constructions). Each cell is `Option`-valued: `none` means the
-anchoring source records nothing for that context — distinct from
-`some .excluded`, which is a positive claim. Cells are addressed by
-field projection; there is no index enum (force is
-`Mood.Illocutionary`, not a parallel type here). -/
-structure ClauseDistribution where
-  declarative : Option ParticleStatus := none
-  polarInterrogative : Option ParticleStatus := none
-  alternativeInterrogative : Option ParticleStatus := none
-  constituentInterrogative : Option ParticleStatus := none
-  imperative : Option ParticleStatus := none
-  exclamative : Option ParticleStatus := none
-  deriving DecidableEq, Repr
-
-/-- Per-embedding-context distribution record ([bhatt-dayal-2020]
-axis). Same `Option`-valued honesty convention as `ClauseDistribution`. -/
-structure EmbedDistribution where
-  matrix : Option ParticleStatus := none
-  subordinated : Option ParticleStatus := none
-  quasiSubordinated : Option ParticleStatus := none
-  quotation : Option ParticleStatus := none
-  deriving DecidableEq, Repr
-
-/-- Recorded status in embedding context `c`, if any. -/
-def EmbedDistribution.status? (d : EmbedDistribution) : Clause.EmbeddingContext → Option ParticleStatus
-  | .matrix => d.matrix
-  | .subordinated => d.subordinated
-  | .quasiSubordinated => d.quasiSubordinated
-  | .quotation => d.quotation
+/-- Sentence-type cells of the particle licensing space: the
+[sadock-zwicky-1985] types, interrogatives subtyped. -/
+inductive Particle.ClauseType where
+  | declarative
+  /-- Polar (yes/no) interrogative. -/
+  | polar
+  /-- Alternative interrogative (*p or q?*). -/
+  | alternative
+  /-- Constituent (wh) interrogative. -/
+  | constituent
+  | imperative
+  | exclamative
+  deriving DecidableEq, Repr, Fintype
 
 /-- An uninflectable function word associated with a host constituent
 ([zwicky-1985-clitics]). -/
@@ -100,65 +78,51 @@ structure Particle where
   script : Option String := none
   /-- Host/position class; `none` when the source records no placement. -/
   position : Option Particle.Position := none
-  /-- Clause-type distribution facet; `{}` when the source records no
-      clause-type data. -/
-  distribution : ClauseDistribution := {}
-  /-- Interrogative-embedding distribution facet ([bhatt-dayal-2020]
-      axis); `{}` when the source records no embedding data. -/
-  embedding : EmbedDistribution := {}
-  deriving DecidableEq, Repr
+  /-- Recorded status per licensing cell (sentence type × embedding
+      context); `none` when the source records nothing for that cell. -/
+  distribution : Particle.ClauseType → EmbeddingContext → Option ParticleStatus :=
+    fun _ _ => none
+  deriving DecidableEq
 
 namespace Particle
 
-
-/-- Recorded clause-type distribution status in the cell picked out by
-projection `c` (e.g. `(·.declarative)`), if any. -/
-def status? (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
-    Option ParticleStatus :=
-  c p.distribution
+variable (p : Particle) (c : ClauseType) (e : EmbeddingContext)
 
 /-- The particle is positively recorded as available (obligatorily or
-optionally) in the cell picked out by projection `c`. -/
-def LicensedIn (p : Particle) (c : ClauseDistribution → Option ParticleStatus) : Prop :=
-  match p.status? c with
+optionally) in the sentence-type × embedding cell `(c, e)`. -/
+def Licensed : Prop :=
+  match p.distribution c e with
   | some .obligatory | some .optional => True
   | _ => False
 
-instance (p : Particle) (c : ClauseDistribution → Option ParticleStatus) :
-    Decidable (p.LicensedIn c) := by
-  unfold LicensedIn; exact match p.status? c with
+instance : Decidable (p.Licensed c e) := by
+  unfold Licensed; exact match p.distribution c e with
     | some .obligatory => .isTrue trivial
     | some .optional => .isTrue trivial
     | some .excluded => .isFalse nofun
     | none => .isFalse nofun
 
-/-- Recorded embedding-distribution status in context `c`, if any. -/
-def embedStatus? (p : Particle) (c : Clause.EmbeddingContext) : Option ParticleStatus :=
-  p.embedding.status? c
+/-- Positively recorded in sentence type `c`, in some embedding context. -/
+def LicensedIn : Prop := ∃ e, p.Licensed c e
 
-/-- The particle is positively recorded as available in embedding
-context `c`. -/
-def LicensedInEmbed (p : Particle) (c : Clause.EmbeddingContext) : Prop :=
-  match p.embedStatus? c with
-  | some .obligatory | some .optional => True
-  | _ => False
+instance : Decidable (p.LicensedIn c) :=
+  inferInstanceAs (Decidable (∃ e, p.Licensed c e))
 
-instance (p : Particle) (c : Clause.EmbeddingContext) : Decidable (p.LicensedInEmbed c) := by
-  unfold LicensedInEmbed; exact match p.embedStatus? c with
-    | some .obligatory => .isTrue trivial
-    | some .optional => .isTrue trivial
-    | some .excluded => .isFalse nofun
-    | none => .isFalse nofun
+/-- Positively recorded in embedding context `e`, for some sentence type. -/
+def LicensedInEmbed : Prop := ∃ c, p.Licensed c e
 
-/-- Carries a clause-type distribution (the sentential/illocutionary
-particle family: question, modal, sentence-final particles). -/
-def IsSentential (p : Particle) : Prop := p.distribution ≠ {}
+instance : Decidable (p.LicensedInEmbed e) :=
+  inferInstanceAs (Decidable (∃ c, p.Licensed c e))
 
-instance (p : Particle) : Decidable p.IsSentential :=
-  inferInstanceAs (Decidable (_ ≠ _))
+/-- Some cell is recorded (the sentential/illocutionary particle family:
+question, modal, sentence-final particles). -/
+def IsSentential : Prop := ∃ c e, (p.distribution c e).isSome
+
+instance : Decidable p.IsSentential :=
+  inferInstanceAs (Decidable (∃ c e, (p.distribution c e).isSome = true))
 
 /-- Projection to `Word` (UD `PART`). -/
-def toWord (p : Particle) : Word :=
+def toWord : Word :=
   { form := p.form, cat := .PART, features := {} }
 
 end Particle

--- a/Linglib/Syntax/Category/Particle/Capabilities.lean
+++ b/Linglib/Syntax/Category/Particle/Capabilities.lean
@@ -5,11 +5,9 @@ import Linglib.Syntax.Category.Particle.Basic
 
 This file defines `Distributed α Ctx`: a carrier `α` with a recorded
 three-valued distribution over licensing contexts `Ctx`, the
-`HasPhi`-style capability behind `Particle`'s embedding facet
-(instance for `Clause.EmbeddingContext`; `Studies/Stankova2026` adds a
-negation-position axis). The clause-type facet is projection-keyed
-(`ClauseDistribution` fields), so it has no context type to
-instantiate.
+`HasPhi`-style capability abstracting `Particle`'s distribution table
+over further licensing axes (`Studies/Stankova2026` adds a
+negation-position axis).
 
 There is deliberately no universal clause carrier: a theory whose
 clause representation `C` classifies into these cells obtains
@@ -46,5 +44,3 @@ instance (a : α) (c : Ctx) : Decidable (LicensedIn a c) := by
     | none => .isFalse nofun
 
 end Distributed
-
-instance : Distributed Particle Clause.EmbeddingContext := ⟨Particle.embedStatus?⟩

--- a/Linglib/Syntax/Clause/Basic.lean
+++ b/Linglib/Syntax/Clause/Basic.lean
@@ -1,6 +1,7 @@
 import Linglib.Semantics.Mood.Defs
 import Linglib.Syntax.Clause.Complementation
 import Linglib.Features.Case.Basic
+import Mathlib.Tactic.DeriveFintype
 
 /-!
 # The clause interface
@@ -88,6 +89,6 @@ inductive EmbeddingContext where
   /-- Embedded root-like interrogatives (Hindi-Urdu *kya:*). -/
   | quasiSubordinated
   | quotation
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Fintype
 
 end Clause


### PR DESCRIPTION
Audit of `Fragments/Mandarin/QuestionParticles.lean` against the [zheng-2025] full text.

- *ma*'s `constituent ↦ optional` cell (and the module table's "polar + wh" gloss) had no source and is wrong — under *ma* a *wh*-word takes only its indefinite reading; corrected to `excluded` ([li-thompson-1981] consensus, matching [xu-2012] via Zheng's ex. 12).
- `Zheng2025`'s layer section attributed a [dayal-2025]-cartography analysis with embedding profiles to Zheng; the paper contains no such content, and the paper never discusses *ba* — `ma_layer`/`ba_layer`/`nandao_layer`/`baOriginalBias` (all consumerless) are removed, replaced by the paper-anchored `nandao_distribution` (§4 ex. 12) checked against the fragment.
- Fragment docstrings moved to the established register; *nandao* is an adverb per the source.

Carries #2121's files, so it lands cleanly in either merge order.