### PR TITLE
docs(Semantics/Attitudes): add kratzer-2013 and cite in Anchor

### DIFF
--- a/Linglib/Semantics/Attitudes/Anchor.lean
+++ b/Linglib/Semantics/Attitudes/Anchor.lean
@@ -9,7 +9,7 @@ On the standard analysis a *that*-clause denotes a proposition,
 ⟦that p⟧ = p. On the projection analysis the complementizer instead
 identifies p as the projection of an anchor individual, so a clause
 denotes a predicate of anchors. The `Anchor` class carries the mode of
-projection: CONT for content individuals ([kratzer-2006];
+projection: CONT for content individuals ([kratzer-2006]; [kratzer-2013];
 [moulton-2015]), SIT for situation individuals ([bondarenko-2022];
 [moltmann-2021]). The sorts stay distinct types, so sort-sensitive
 selection — content verbs rejecting situation clauses and vice versa,

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -7802,6 +7802,21 @@
   role      = {foundational},
   sources   = {Studies/Kratzer2012Informational.lean;Studies/Kratzer2012Lumping.lean;Studies/Kratzer2012Conditionals.lean}
 }
+@incollection{kratzer-2013,
+  author    = {Kratzer, Angelika},
+  year      = {2013},
+  title     = {Modality for the 21st Century},
+  booktitle = {L'interface langage-cognition / The Language-Cognition Interface: Actes du 19e Congr{\`e}s International des Linguistes, Gen{\`e}ve, 22--27 juillet 2013},
+  editor    = {Anderson, Stephen R. and Moeschler, Jacques and Reboul, Fabienne},
+  pages     = {179--199},
+  publisher = {Librairie Droz},
+  address   = {Gen{\`e}ve},
+  isbn      = {978-2-600-01725-1},
+  subfield  = {semantics/modality},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Attitudes/Anchor.lean}
+}
 @article{phillips-brown-2025,
   author    = {Phillips-Brown, Milo},
   year      = {2025},


### PR DESCRIPTION
Adds the verified `kratzer-2013` entry (Modality for the 21st Century, Actes du 19e Congrès International des Linguistes, Droz — fields checked against the publisher page and Moulton's bibliography) and cites it at the mode-of-projection sentence in `Anchor.lean`. Follow-up to #2124.