### PR TITLE
refactor(Semantics/Attitudes): cleanse CDistributivity to live surface

### DIFF
--- a/Linglib/Semantics/Attitudes/CDistributivity.lean
+++ b/Linglib/Semantics/Attitudes/CDistributivity.lean
@@ -2,249 +2,73 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Set.Basic
 
 /-!
-# C-Distributivity: Derivation from Compositional Semantics
-[uegaki-sudo-2019] [uegaki-2022]
+# C-distributivity
 
-This file derives C-distributivity as a **theorem** rather than stipulating it.
+A clause-embedding predicate is *C-distributive* when its question
+semantics is existential quantification over its propositional
+semantics: ⟦x V Q⟧ ↔ ∃p ∈ Q. ⟦x V p⟧ ([uegaki-sudo-2019];
+[uegaki-2022]). `IsCDistributive` states the property for a pair of
+propositional and question semantics, so it is proved from a predicate's
+semantic structure rather than stipulated per predicate.
 
-For the broader constraint hierarchy (P-to-Q Entailment, Strawson C-distributivity,
-Veridical Uniformity, fictitious predicates), see `EmbeddingConstraints.lean`.
+`degreeComparison_isCDistributive` proves it for the degree-comparison
+pattern of *hope*, *fear*, *expect*, *wish* ([villalta-2008]):
+⟦x V p⟧ = μ(x,p) > θ(C) with the question semantics the pointwise
+existential, so C-distributivity holds by construction. Predicates whose
+question semantics outruns the existential — global uncertainty for
+*worry*, decision-relevance for *care* ([elliott-etal-2017]) — are not
+C-distributive; the counterexample with actual worry semantics is
+`Preferential.worry_not_cDistributive`, and the per-predicate
+instantiations live in `Preferential.lean`.
 
-## Insight
-
-C-distributivity follows from the **structure** of the semantics:
-- If `⟦x V Q⟧ := ∃p ∈ Q. ⟦x V p⟧`, then V is C-distributive by construction
-- If the question semantics involves something beyond existential quantification
-  (e.g., uncertainty, resolution), then V is NOT C-distributive
-
-## Semantic Patterns
-
-### Pattern 1: Degree Comparison (hope, fear)
-```
-⟦x hopes p⟧ = μ_hope(x, p) > θ(C)
-⟦x hopes Q⟧ = ∃p ∈ Q. μ_hope(x, p) > θ(C)
-```
-This is C-distributive because the question semantics IS the existential.
-
-### Pattern 2: Uncertainty-Based (worry, care)
-```
-⟦x worries about p⟧ = μ(x, p) > θ ∧ x is uncertain about p
-⟦x worries about Q⟧ = x is uncertain which answer in Q is true
-                    ≠ ∃p ∈ Q. x worries about p
-```
-This is NOT C-distributive because worry-about-Q involves global uncertainty.
+Alternatives are the extensional, list-based `AlternativeList` over
+Bool propositions, pending migration of this file and its consumer
+`Preferential.lean` to the `Set`-based question substrate
+(`Semantics/Questions/`).
 -/
 
 namespace Semantics.Attitudes.CDistributivity
 
--- Basic Types
+variable {W E : Type*}
 
-/-- A Hamblin question denotation: set of possible answers -/
-abbrev AlternativeList (W : Type*) := List ((W → Bool))
+/-- A Hamblin question denotation: a list of possible answers. -/
+abbrev AlternativeList (W : Type*) := List (W → Bool)
 
-/-- Preference/attitude degree function -/
+/-- Preference/attitude degree function: `μ x p` is how strongly `x`
+    prefers (or fears) `p`. -/
 abbrev DegreeFn (W E : Type*) := E → (W → Bool) → ℚ
 
-/-- Contextual threshold function -/
+/-- Contextual threshold function over a comparison class. -/
 abbrev ThresholdFn (W : Type*) := AlternativeList W → ℚ
 
--- C-Distributivity Definition
-
-/--
-A predicate V is **C-distributive** iff its question semantics is equivalent
-to existential quantification over its propositional semantics.
-
-Formally: V is C-distributive iff
-  ∀ x Q w, V_Q(x, Q, w) ↔ ∃p ∈ Q, V_p(x, p, w)
-
-Where V_p is the propositional semantics and V_Q is the question semantics.
--/
-def IsCDistributive {W E : Type*}
-    (V_prop : E → (W → Bool) → W → Bool)           -- Propositional semantics
-    (V_question : E → AlternativeList W → W → Bool)  -- Question semantics
-    : Prop :=
+/-- A predicate with propositional semantics `V_prop` and question
+    semantics `V_question` is C-distributive iff
+    `V_question x Q w ↔ ∃ p ∈ Q, V_prop x p w`. -/
+def IsCDistributive (V_prop : E → (W → Bool) → W → Bool)
+    (V_question : E → AlternativeList W → W → Bool) : Prop :=
   ∀ (x : E) (Q : AlternativeList W) (w : W),
     V_question x Q w = true ↔ ∃ p ∈ Q, V_prop x p w = true
 
--- Pattern 1: Degree-Comparison Semantics (C-Distributive)
+/-! ### The degree-comparison pattern -/
 
-/--
-Degree-comparison propositional semantics.
-
-⟦x V p⟧(w, C) = μ(x, p) > θ(C)
-
-This is the pattern for hope, fear, expect, wish, etc.
-The degree μ(x, p) measures how strongly x prefers/fears p.
--/
-def degreeComparisonProp {W E : Type*} (μ : DegreeFn W E) (θ : ThresholdFn W)
-    (C : AlternativeList W) (x : E) (p : (W → Bool)) (_w : W) : Bool :=
+/-- Degree-comparison propositional semantics:
+    `degreeComparisonProp μ θ C x p w` iff `μ x p > θ C`. -/
+def degreeComparisonProp (μ : DegreeFn W E) (θ : ThresholdFn W)
+    (C : AlternativeList W) (x : E) (p : W → Bool) (_w : W) : Bool :=
   decide (μ x p > θ C)
 
-/--
-Degree-comparison question semantics (existential).
-
-⟦x V Q⟧(w, C) = ∃p ∈ Q. μ(x, p) > θ(C)
-
-This is the standard Hamblin-style composition: pointwise application
-with existential closure.
--/
-def degreeComparisonQuestion {W E : Type*} (μ : DegreeFn W E) (θ : ThresholdFn W)
+/-- Degree-comparison question semantics, the pointwise existential:
+    `degreeComparisonQuestion μ θ C x Q w` iff `∃ p ∈ Q, μ x p > θ C`. -/
+def degreeComparisonQuestion (μ : DegreeFn W E) (θ : ThresholdFn W)
     (C : AlternativeList W) (x : E) (Q : AlternativeList W) (_w : W) : Bool :=
   Q.any λ p => decide (μ x p > θ C)
 
-/--
-**Theorem**: Degree-comparison predicates are C-distributive.
-
-This follows directly from the definition: the question semantics
-IS the existential over the propositional semantics.
--/
-theorem degreeComparison_isCDistributive {W E : Type*}
-    (μ : DegreeFn W E) (θ : ThresholdFn W) (C : AlternativeList W) :
-    IsCDistributive
-      (degreeComparisonProp μ θ C)
+/-- Degree-comparison predicates are C-distributive by construction. -/
+theorem degreeComparison_isCDistributive (μ : DegreeFn W E) (θ : ThresholdFn W)
+    (C : AlternativeList W) :
+    IsCDistributive (degreeComparisonProp μ θ C)
       (degreeComparisonQuestion μ θ C) := by
   intro x Q w
-  unfold degreeComparisonProp degreeComparisonQuestion
-  simp only [List.any_eq_true, decide_eq_true_eq]
-
--- Pattern 2: Non-C-Distributive Semantics (Conceptual)
-
-/-!
-## Why Worry/Care are NOT C-Distributive
-[elliott-etal-2017] [spector-egr-2015]
-
-The key insight from [elliott-etal-2017] is that predicates like "worry"
-and "care" have question semantics that go beyond existential quantification.
-
-### Worry Semantics
-
-⟦x worries about p⟧ = μ(x, p) > θ ∧ x is uncertain about p
-⟦x worries about Q⟧ = x is uncertain which answer in Q is true
-                    ∧ has concern about the open possibilities
-
-The uncertainty component is **global** for questions but **pointwise** for
-propositions. This breaks C-distributivity.
-
-### Care/Relevance Semantics
-
-⟦x cares about Q⟧ = resolving Q is relevant to x's goals
-                  ≠ ∃p ∈ Q. resolving whether p is relevant
-
-Example: "Al cares about where to dock his boat"
-- This is about the DECISION, not about any particular location
-- Al doesn't "care that the boat docks at location A" (odd reading)
-
-### Mandarin qidai (期待, "look forward to")
-
-qidai appears to have similar non-C-distributive semantics:
-- ⟦x qidai Q⟧ involves anticipation of resolution
-- Not reducible to existential over individual answers
-
-This explains why qidai (positive valence, Class 1) takes questions
-while hope (positive valence, Class 3) doesn't: they have different
-semantic structures despite similar preference content.
--/
-
-/--
-There exist semantics for "worry" that are not C-distributive.
-
-Concrete counterexample: question semantics requires global uncertainty
-(conjunctive condition beyond existential), so V_question can be false
-even when V_prop holds for some answer.
--/
-theorem exists_nonCDistributive_worry :
-    ∃ (W E : Type) (V_prop : E → (W → Bool) → W → Bool)
-                   (V_question : E → AlternativeList W → W → Bool),
-    ¬IsCDistributive V_prop V_question := by
-  -- Use Bool as a 2-element world/entity type
-  refine ⟨Bool, Unit, fun _ _ _ => true, fun _ _ _ => false, ?_⟩
-  intro hCD
-  have hmem : (fun _ : Bool => true) ∈ ([fun _ => true] : List (Bool → Bool)) := by simp
-  have := (hCD () [fun _ => true] true).mpr ⟨fun _ => true, hmem, rfl⟩
-  exact Bool.false_ne_true this
-
-/--
-There exist semantics for "care" that are not C-distributive.
-
-Same construction: relevance-based question semantics is not reducible
-to existential quantification over propositional semantics.
--/
-theorem exists_nonCDistributive_care :
-    ∃ (W E : Type) (V_prop : E → (W → Bool) → W → Bool)
-                   (V_question : E → AlternativeList W → W → Bool),
-    ¬IsCDistributive V_prop V_question := by
-  exact exists_nonCDistributive_worry
-
--- Connection to NVP Classification
-
-/-!
-## Semantic Structure → C-Distributivity → NVP Class
-
-The key theorem chain:
-
-1. **Semantic structure determines C-distributivity**
-   - Degree-comparison → C-distributive (PROVED)
-   - Uncertainty/relevance-based → non-C-distributive (AXIOMATIZED)
-
-2. **C-distributivity + valence determines NVP class**
-   - Non-C-distributive → Class 1 (takes questions)
-   - C-distributive + negative → Class 2 (takes questions)
-   - C-distributive + positive → Class 3 (anti-rogative)
-
-3. **NVP class determines question-taking**
-   - Class 1, 2 → takes questions
-   - Class 3 → anti-rogative (triviality)
-
-This gives us a genuine derivation:
-
-```
-hopeSemantics is degree-comparison
-  → (by degreeComparison_isCDistributive) hope is C-distributive
-  → (by classifyNVP) hope is Class 3
-  → (by class3_yields_triviality) hope + Q is trivial
-  → (by L-analyticity) *hope who is ungrammatical
-```
-
-The first step is now PROVED rather than stipulated.
--/
-
-/--
-A predicate is "degree-comparison-like" if its question semantics
-is defined as existential quantification over propositional semantics.
--/
-def isDegreeComparisonLike {W E : Type*}
-    (V_prop : E → (W → Bool) → W → Bool)
-    (V_question : E → AlternativeList W → W → Bool) : Prop :=
-  ∀ x Q w, V_question x Q w = Q.any (λ p => V_prop x p w)
-
-/--
-Degree-comparison-like predicates are automatically C-distributive.
--/
-theorem degreeComparisonLike_implies_cDistributive {W E : Type*}
-    (V_prop : E → (W → Bool) → W → Bool)
-    (V_question : E → AlternativeList W → W → Bool)
-    (h : isDegreeComparisonLike V_prop V_question) :
-    IsCDistributive V_prop V_question := by
-  intro x Q w
-  rw [h]
-  simp only [List.any_eq_true]
-
--- Summary
-
-/-!
-## Main Results
-
-1. `degreeComparison_isCDistributive`: Any predicate with degree-comparison
-   semantics (⟦V Q⟧ = ∃p ∈ Q. μ(x,p) > θ) is C-distributive.
-
-2. `degreeComparisonLike_implies_cDistributive`: General theorem that
-   existential question semantics implies C-distributivity.
-
-3. `exists_nonCDistributive_worry`, `exists_nonCDistributive_care`:
-   Concrete counterexamples showing non-C-distributive semantics exist.
-
-Per-predicate instantiations (hope, fear, etc.) are in `Preferential.lean`.
-Constraint hierarchy and fictitious predicates are in `EmbeddingConstraints.lean`.
--/
+  simp [degreeComparisonProp, degreeComparisonQuestion]
 
 end Semantics.Attitudes.CDistributivity


### PR DESCRIPTION
Keeps the surface `Preferential.lean` consumes (`IsCDistributive`, the degree-comparison pattern and its theorem, the type abbrevs) and deletes the rest: `exists_nonCDistributive_worry`/`_care` (witnessed by constant functions unrelated to worry/care semantics — the real counterexample is `Preferential.worry_not_cDistributive`), the unconsumed `isDegreeComparisonLike` tautology pair, essay sections, and two references to a nonexistent `EmbeddingConstraints.lean`. Module doc rewritten to mathlib register; the pending Bool→Set-substrate migration note is kept.