### PR TITLE
refactor(Semantics/Attitudes): rename CDistributivity to Distributivity

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1495,13 +1495,13 @@ import Linglib.Semantics.Aspect.Stratified
 import Linglib.Semantics.Aspect.SubeventStructure
 import Linglib.Semantics.Aspect.SubintervalProperty
 import Linglib.Semantics.Attitudes.Anchor
-import Linglib.Semantics.Attitudes.CDistributivity
 import Linglib.Semantics.Attitudes.ClauseEmbedding
 import Linglib.Semantics.Attitudes.CondoravdiLauer
 import Linglib.Semantics.Attitudes.Confidence
 import Linglib.Semantics.Attitudes.ContentIndividual
 import Linglib.Semantics.Attitudes.ContextQuantification
 import Linglib.Semantics.Attitudes.Desire
+import Linglib.Semantics.Attitudes.Distributivity
 import Linglib.Semantics.Attitudes.Doxastic
 import Linglib.Semantics.Attitudes.EpistemicThreshold
 import Linglib.Semantics.Attitudes.Factivity

--- a/Linglib/Semantics/Attitudes/Distributivity.lean
+++ b/Linglib/Semantics/Attitudes/Distributivity.lean
@@ -2,22 +2,24 @@ import Mathlib.Data.Rat.Defs
 import Mathlib.Data.Set.Basic
 
 /-!
-# C-distributivity
+# Clausal distributivity
 
-A clause-embedding predicate is *C-distributive* when its question
+A clause-embedding predicate is *clausally distributive* — written
+C(lausal)-distributive in [qing-uegaki-2025] — when its question
 semantics is existential quantification over its propositional
 semantics: ⟦x V Q⟧ ↔ ∃p ∈ Q. ⟦x V p⟧ ([uegaki-sudo-2019];
-[uegaki-2022]). `IsCDistributive` states the property for a pair of
-propositional and question semantics, so it is proved from a predicate's
-semantic structure rather than stipulated per predicate.
+[uegaki-2022]). `IsDistributive` states the property for a pair of
+propositional and question semantics, so it is proved from a
+predicate's semantic structure rather than stipulated per predicate.
 
-`degreeComparison_isCDistributive` proves it for the degree-comparison
+`degreeComparison_isDistributive` proves it for the degree-comparison
 pattern of *hope*, *fear*, *expect*, *wish* ([villalta-2008]):
 ⟦x V p⟧ = μ(x,p) > θ(C) with the question semantics the pointwise
-existential, so C-distributivity holds by construction. Predicates whose
-question semantics outruns the existential — global uncertainty for
-*worry*, decision-relevance for *care* ([elliott-etal-2017]) — are not
-C-distributive; the counterexample with actual worry semantics is
+existential, so clausal distributivity holds by construction.
+Predicates whose question semantics outruns the existential — global
+uncertainty for *worry*, decision-relevance for *care*
+([elliott-etal-2017]) — are not clausally distributive; the
+counterexample with actual worry semantics is
 `Preferential.worry_not_cDistributive`, and the per-predicate
 instantiations live in `Preferential.lean`.
 
@@ -27,7 +29,7 @@ Bool propositions, pending migration of this file and its consumer
 (`Semantics/Questions/`).
 -/
 
-namespace Semantics.Attitudes.CDistributivity
+namespace Semantics.Attitudes.Distributivity
 
 variable {W E : Type*}
 
@@ -42,9 +44,9 @@ abbrev DegreeFn (W E : Type*) := E → (W → Bool) → ℚ
 abbrev ThresholdFn (W : Type*) := AlternativeList W → ℚ
 
 /-- A predicate with propositional semantics `V_prop` and question
-    semantics `V_question` is C-distributive iff
+    semantics `V_question` is clausally distributive iff
     `V_question x Q w ↔ ∃ p ∈ Q, V_prop x p w`. -/
-def IsCDistributive (V_prop : E → (W → Bool) → W → Bool)
+def IsDistributive (V_prop : E → (W → Bool) → W → Bool)
     (V_question : E → AlternativeList W → W → Bool) : Prop :=
   ∀ (x : E) (Q : AlternativeList W) (w : W),
     V_question x Q w = true ↔ ∃ p ∈ Q, V_prop x p w = true
@@ -63,12 +65,13 @@ def degreeComparisonQuestion (μ : DegreeFn W E) (θ : ThresholdFn W)
     (C : AlternativeList W) (x : E) (Q : AlternativeList W) (_w : W) : Bool :=
   Q.any λ p => decide (μ x p > θ C)
 
-/-- Degree-comparison predicates are C-distributive by construction. -/
-theorem degreeComparison_isCDistributive (μ : DegreeFn W E) (θ : ThresholdFn W)
+/-- Degree-comparison predicates are clausally distributive by
+    construction. -/
+theorem degreeComparison_isDistributive (μ : DegreeFn W E) (θ : ThresholdFn W)
     (C : AlternativeList W) :
-    IsCDistributive (degreeComparisonProp μ θ C)
+    IsDistributive (degreeComparisonProp μ θ C)
       (degreeComparisonQuestion μ θ C) := by
   intro x Q w
   simp [degreeComparisonProp, degreeComparisonQuestion]
 
-end Semantics.Attitudes.CDistributivity
+end Semantics.Attitudes.Distributivity

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -29,7 +29,7 @@ from the structure of its semantics. Each predicate defines:
 - `propSemantics`: how it combines with propositions
 - `questionSemantics`: how it combines with questions
 
-Then `IsCDistributive propSemantics questionSemantics` is a theorem.
+Then `IsDistributive propSemantics questionSemantics` is a theorem.
 
 ## NVP Classification
 
@@ -48,20 +48,20 @@ import Linglib.Features.Attitudes
 import Linglib.Semantics.Causation.VerbClass
 import Linglib.Semantics.ArgumentStructure.LevinClass
 import Linglib.Semantics.ArgumentStructure.MeaningComponents
-import Linglib.Semantics.Attitudes.CDistributivity
+import Linglib.Semantics.Attitudes.Distributivity
 import Linglib.Semantics.Attitudes.Doxastic
 
 namespace Semantics.Attitudes.Preferential
 
 open Features (AttitudeValence)
 export Features (AttitudeValence)
-open Semantics.Attitudes.CDistributivity (IsCDistributive degreeComparison_isCDistributive
+open Semantics.Attitudes.Distributivity (IsDistributive degreeComparison_isDistributive
                       degreeComparisonProp degreeComparisonQuestion DegreeFn ThresholdFn)
 
 -- Re-export types under more descriptive names for downstream use
 
-/-- Question denotation: set of possible answers. Re-exported from `CDistributivity`. -/
-abbrev AlternativeList (W : Type*) := Semantics.Attitudes.CDistributivity.AlternativeList W
+/-- Question denotation: set of possible answers. Re-exported from `Distributivity`. -/
+abbrev AlternativeList (W : Type*) := Semantics.Attitudes.Distributivity.AlternativeList W
 
 /-- Preference function: μ(agent, prop) → degree. Alias for `DegreeFn`. -/
 abbrev PreferenceFunction (W E : Type*) := DegreeFn W E
@@ -78,7 +78,7 @@ abbrev ThresholdFunction (W : Type*) := ThresholdFn W
 Questions are **alternative sets**. Our `AlternativeList W` is the
 extensional, list-based representation of question denotations used by
 the C-distributivity machinery (still Bool-shaped pending a follow-up
-migration of `Semantics.Attitudes.CDistributivity` to substrate-aligned
+migration of `Semantics.Attitudes.Distributivity` to substrate-aligned
 Set propositions).
 
 ### Why This Matters for TSP

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -14450,7 +14450,7 @@
   role      = {cited},
   doi       = {10.1007/s11229-015-0722-4},
   validated = {true},
-  sources   = {Semantics/Attitudes/CDistributivity.lean}
+  sources   = {Semantics/Attitudes/Distributivity.lean}
 }% REF: Elliott et al. (2017). Predicates of relevance and theories of question embedding. JoS 34(3):547–554.
 @article{elliott-etal-2017,
   author    = {Elliott, Patrick D. and Klinedinst, Nathan and Sudo, Yasutada and Uegaki, Wataru},
@@ -14464,7 +14464,7 @@
   subfield  = {semantics/presupposition},
   role      = {cited},
   validated = {true},
-  sources   = {Semantics/Attitudes/BuilderProperties.lean;Semantics/Attitudes/CDistributivity.lean}
+  sources   = {Semantics/Attitudes/Distributivity.lean}
 }% REF: Bondarenko, T. (2019). From think to remember. SALT 29.
 @article{uegaki-2019,
   author    = {Uegaki, Wataru},
@@ -14502,7 +14502,7 @@
   doi       = {10.1007/978-3-031-15940-4},
   subfield  = {semantics/questions},
   role      = {formalized},
-  sources   = {Semantics/Attitudes/CDistributivity.lean;Semantics/Attitudes/Preferential.lean}
+  sources   = {Semantics/Attitudes/Distributivity.lean;Semantics/Attitudes/Preferential.lean}
 }% REF: Roelofsen, F. & Uegaki, W. (2016). The distributive ignorance puzzle. SuB 21.
 @inproceedings{roelofsen-uegaki-2016b,
   author    = {Roelofsen, Floris and Uegaki, Wataru},
@@ -14525,7 +14525,7 @@
   doi       = {10.3765/salt.v30i0.4834},
   subfield  = {semantics/questions},
   role      = {formalized},
-  sources   = {Semantics/Attitudes/CDistributivity.lean;Fragments/Japanese/Particles.lean}
+  sources   = {Semantics/Attitudes/Distributivity.lean;Fragments/Japanese/Particles.lean}
 }% REF: Uegaki, W. & Roelofsen, F. (2018). Do modals take propositions or sets of propositions? Evidence from Japanese daroo. SALT 28.
 @inproceedings{uegaki-roelofsen-2018,
   author    = {Uegaki, Wataru and Roelofsen, Floris},


### PR DESCRIPTION
Owner-relative naming per the `Plurality.Distributivity` / `DynamicSemantics.CCP.IsDistributive` precedent: the namespace says whose distributivity, so the opaque `C` prefix goes — `Attitudes/Distributivity.lean`, `IsDistributive`, `degreeComparison_isDistributive`. Docstrings use the spelled-out field term *clausally distributive*, glossing [qing-uegaki-2025]'s C(lausal)-distributivity notation once for greppability. Also drops the deleted `BuilderProperties.lean` from a bib `sources` field. `Preferential.lean`'s own `cDist`-flavored declaration names are left for its own pass.