### PR TITLE
refactor(Semantics/Attitudes): inline preferential-background Pi types

### DIFF
--- a/Linglib/Semantics/Attitudes/CondoravdiLauer.lean
+++ b/Linglib/Semantics/Attitudes/CondoravdiLauer.lean
@@ -8,9 +8,11 @@ import Linglib.Core.Order.PreferenceStructure.MaxInducedOrdering
 Condoravdi & Lauer's analysis of *want*, developed across
 [condoravdi-lauer-2011], [condoravdi-lauer-2012], [lauer-2013],
 [lauer-condoravdi-2014], and [condoravdi-lauer-2016]: the verb is
-parameterized by a *preferential background* — analogous to Kratzer's
-modal base/ordering source — whose distinguished value is the agent's
-effective preference function `EP` (`Core.Order.EffectivePreference`).
+parameterized by a *preferential background*
+`P : Agent → W → PreferenceStructure W` — analogous to Kratzer's modal
+base/ordering source — whose distinguished value is the agent's
+effective preference function `EP : ∀ a w, EffectivePreference W (B a w)`
+(`Core.Order.EffectivePreference`).
 
 A want-report holds when some maximal preference in the background
 stands in a designated relation to the complement, and the relation is
@@ -23,10 +25,10 @@ schema, and the choice of relation fixes the reading's inferential
 profile: success-oriented want is downward-entailing in the
 complement, Quine-Hintikka want upward-entailing, exact-match want
 neither (counterexample-construction deferred).
-`wantEffectivePreference` is exact-match against the effective
-preferential background, and `maxOrderingSource` extracts the
-`Set`-valued ordering source `max[EP(Ad, w)]` (their eq. 88) consumed
-by the inner modal of the double-modal anankastic analysis.
+`wantEffectivePreference` is exact-match against the agent's effective
+preferences, and `maxOrderingSource` extracts the `Set`-valued
+ordering source `max[EP(Ad, w)]` (their eq. 88) consumed by the inner
+modal of the double-modal anankastic analysis.
 
 Declarations live in the `Desire` namespace, alongside the rival
 want-semantics of `Desire.lean`. The anankastic-conditional analysis
@@ -40,116 +42,95 @@ namespace Desire
 
 open Core.Order
 
-variable {Agent W : Type*}
-
-/-- A preferential background assigns each agent and world a
-    preference structure — Condoravdi & Lauer's analog of a Kratzerian
-    conversational background. -/
-abbrev PreferentialBackground (Agent W : Type*) :=
-  Agent → W → PreferenceStructure W
-
-/-- An effective preferential background assigns each agent and world
-    the agent's effective preference structure — consistent and
-    realistic with respect to the belief state `B a w`. -/
-abbrev EffectivePreferentialBackground (Agent W : Type*)
-    (B : Agent → W → Set W) :=
-  ∀ (a : Agent) (w : W), EffectivePreference W (B a w)
+variable {Agent W : Type*} (P : Agent → W → PreferenceStructure W)
 
 /-! ### The want schema and its three readings -/
 
-/-- `wantPreference P R a φ w` iff some maximal preference in `P(a, w)`
-    stands in `R` to `φ`. The readings of *want* instantiate `R`; the
-    choice determines the operator's inferential profile. -/
-def wantPreference (P : PreferentialBackground Agent W)
-    (R : Set W → Set W → Prop) (a : Agent) (φ : Set W) (w : W) : Prop :=
+/-- `wantPreference P R a φ w` iff some maximal preference in the
+    preferential background `P` — Condoravdi & Lauer's analog of a
+    Kratzerian conversational background — stands in `R` to `φ`. The
+    readings of *want* instantiate `R`; the choice determines the
+    operator's inferential profile. -/
+def wantPreference (R : Set W → Set W → Prop) (a : Agent) (φ : Set W)
+    (w : W) : Prop :=
   ∃ p ∈ (P a w).maxElts, R φ p
 
 /-- Exact-match want: some maximal preference is `φ` itself — the
     canonical reading. -/
-def wantExactMatch (P : PreferentialBackground Agent W) :
-    Agent → Set W → W → Prop :=
+def wantExactMatch : Agent → Set W → W → Prop :=
   wantPreference P (· = ·)
 
 /-- Success-oriented want: some maximal preference is entailed by `φ`
     — a preference satisfied if `φ` is true. -/
-def wantSuccessOriented (P : PreferentialBackground Agent W) :
-    Agent → Set W → W → Prop :=
+def wantSuccessOriented : Agent → Set W → W → Prop :=
   wantPreference P (· ⊆ ·)
 
 /-- Quine-Hintikka want: some maximal preference entails `φ` — a
     preference satisfied only if `φ` is true. -/
-def wantQuineHintikka (P : PreferentialBackground Agent W) :
-    Agent → Set W → W → Prop :=
+def wantQuineHintikka : Agent → Set W → W → Prop :=
   wantPreference P (· ⊇ ·)
 
+variable {P}
+
 /-- `wantExactMatch P a φ w` iff `φ ∈ max[P(a, w)]`. -/
-theorem wantExactMatch_iff (P : PreferentialBackground Agent W)
-    (a : Agent) (φ : Set W) (w : W) :
+theorem wantExactMatch_iff {a : Agent} {φ : Set W} {w : W} :
     wantExactMatch P a φ w ↔ φ ∈ (P a w).maxElts :=
   ⟨fun ⟨_, hp, h⟩ => by rwa [h], fun h => ⟨φ, h, rfl⟩⟩
 
 /-- A pointwise implication between relations transfers between
     readings. -/
-theorem wantPreference_mono {P : PreferentialBackground Agent W}
-    {R R' : Set W → Set W → Prop} (h : ∀ φ p, R φ p → R' φ p)
-    {a : Agent} {φ : Set W} {w : W} :
+theorem wantPreference_mono {R R' : Set W → Set W → Prop}
+    (h : ∀ φ p, R φ p → R' φ p) {a : Agent} {φ : Set W} {w : W} :
     wantPreference P R a φ w → wantPreference P R' a φ w :=
   fun ⟨p, hp, hR⟩ => ⟨p, hp, h φ p hR⟩
 
 /-- Exact match implies the success-oriented reading. -/
-theorem wantSuccessOriented_of_exactMatch {P : PreferentialBackground Agent W}
-    {a : Agent} {φ : Set W} {w : W} :
+theorem wantSuccessOriented_of_exactMatch {a : Agent} {φ : Set W} {w : W} :
     wantExactMatch P a φ w → wantSuccessOriented P a φ w :=
   wantPreference_mono fun _ _ h => h.subset
 
 /-- Exact match implies the Quine-Hintikka reading. -/
-theorem wantQuineHintikka_of_exactMatch {P : PreferentialBackground Agent W}
-    {a : Agent} {φ : Set W} {w : W} :
+theorem wantQuineHintikka_of_exactMatch {a : Agent} {φ : Set W} {w : W} :
     wantExactMatch P a φ w → wantQuineHintikka P a φ w :=
   wantPreference_mono fun _ _ h => h.superset
 
 /-- Success-oriented want is downward-entailing in the complement. -/
 theorem wantSuccessOriented_downward_entailing
-    {P : PreferentialBackground Agent W} {a : Agent} {φ ψ : Set W} {w : W}
-    (hφψ : φ ⊆ ψ) :
+    {a : Agent} {φ ψ : Set W} {w : W} (hφψ : φ ⊆ ψ) :
     wantSuccessOriented P a ψ w → wantSuccessOriented P a φ w :=
   fun ⟨p, hp, hψp⟩ => ⟨p, hp, hφψ.trans hψp⟩
 
 /-- Quine-Hintikka want is upward-entailing in the complement. -/
 theorem wantQuineHintikka_upward_entailing
-    {P : PreferentialBackground Agent W} {a : Agent} {φ ψ : Set W} {w : W}
-    (hφψ : φ ⊆ ψ) :
+    {a : Agent} {φ ψ : Set W} {w : W} (hφψ : φ ⊆ ψ) :
     wantQuineHintikka P a φ w → wantQuineHintikka P a ψ w :=
   fun ⟨p, hp, hpφ⟩ => ⟨p, hp, hpφ.trans hφψ⟩
 
-/-! ### The effective preferential background -/
+/-! ### Effective preferences -/
 
-/-- Exact-match want against the effective preferential background. -/
-def wantEffectivePreference {B : Agent → W → Set W}
-    (EP : EffectivePreferentialBackground Agent W B) :
-    Agent → Set W → W → Prop :=
+variable {B : Agent → W → Set W} (EP : ∀ a w, EffectivePreference W (B a w))
+
+/-- Exact-match want against the agent's effective preferences —
+    Condoravdi & Lauer's designated background `EP`. -/
+def wantEffectivePreference : Agent → Set W → W → Prop :=
   wantExactMatch fun a w => (EP a w).toPreferenceStructure
 
 /-- Two effective-preference wants are jointly belief-consistent:
     wanting propositions the agent believes incompatible is
     impossible. -/
 theorem wantEffectivePreference_jointly_belief_consistent
-    {B : Agent → W → Set W}
-    (EP : EffectivePreferentialBackground Agent W B)
     {a : Agent} {φ ψ : Set W} {w : W}
     (hφ : wantEffectivePreference EP a φ w)
     (hψ : wantEffectivePreference EP a ψ w) :
     (φ ∩ ψ) ∩ B a w ≠ ∅ :=
   (EP a w).toPreferenceStructure.maxElts_pair_belief_compatible
     (EP a w).isConsistent
-    ((wantExactMatch_iff _ _ _ _).mp hφ) ((wantExactMatch_iff _ _ _ _).mp hψ)
+    (wantExactMatch_iff.mp hφ) (wantExactMatch_iff.mp hψ)
 
 /-- `maxOrderingSource EP Ad w` is the set of maximal preferences in
     `EP(Ad, w)` — the ordering source consumed by the inner modal of
     the double-modal anankastic analysis. -/
-def maxOrderingSource {B : Agent → W → Set W}
-    (EP : EffectivePreferentialBackground Agent W B) (Ad : Agent) :
-    W → Set (Set W) :=
+def maxOrderingSource (Ad : Agent) : W → Set (Set W) :=
   fun w => (EP Ad w).toPreferenceStructure.maxElts
 
 end Desire

--- a/Linglib/Studies/CondoravdiLauer2016.lean
+++ b/Linglib/Studies/CondoravdiLauer2016.lean
@@ -101,7 +101,7 @@ The four contextual parameters:
   module docstring); v1 takes `gInner` as a parameter. -/
 def harlemLF {Agent W : Type u}
     (fBelS : ModalBase W) (gNorm : OrderingSource W)
-    {B : Agent → W → Set W} (EP : EffectivePreferentialBackground Agent W B)
+    {B : Agent → W → Set W} (EP : ∀ a w, EffectivePreference W (B a w))
     (fHist : ModalBase W) (gInner : OrderingSource W)
     (Ad : Agent) (Harlem ATrain : Set W) (w : W) : Prop :=
   doubleModalLF fBelS gNorm
@@ -113,7 +113,7 @@ def harlemLF {Agent W : Type u}
 construction. Documentation theorem (the equality is `rfl`). -/
 theorem harlemLF_eq_doubleModalLF {Agent W : Type u}
     (fBelS : ModalBase W) (gNorm : OrderingSource W)
-    {B : Agent → W → Set W} (EP : EffectivePreferentialBackground Agent W B)
+    {B : Agent → W → Set W} (EP : ∀ a w, EffectivePreference W (B a w))
     (fHist : ModalBase W) (gInner : OrderingSource W)
     (Ad : Agent) (Harlem ATrain : Set W) (w : W) :
     harlemLF fBelS gNorm EP fHist gInner Ad Harlem ATrain w =
@@ -202,13 +202,13 @@ noncomputable def epAtW1 : EffectivePreference World Set.univ :=
 /-- The effective preferential background: at `w₀` Hoboken-preferring,
 at `w₁` Harlem-preferring. Uses `if`-on-decidable equality to keep the
 reduction simple at the use sites. -/
-noncomputable def EP : EffectivePreferentialBackground Unit World belAd :=
+noncomputable def EP : ∀ u w, EffectivePreference World (belAd u w) :=
   fun _ w => if w = (0 : World) then epAtW0 else epAtW1
 
 /-- At `wActual = w₀`: Ad effectively prefers Hoboken. -/
 theorem wantEffectivePreference_hoboken_at_wActual :
     wantEffectivePreference EP () Hoboken wActual := by
-  refine (wantExactMatch_iff _ _ _ _).mpr ?_
+  refine wantExactMatch_iff.mpr ?_
   show Hoboken ∈ (EP () wActual).toPreferenceStructure.maxElts
   simp only [EP, wActual]
   exact singletonPS_mem_maxElts Hoboken

--- a/Linglib/Studies/Deo2025.lean
+++ b/Linglib/Studies/Deo2025.lean
@@ -47,7 +47,7 @@ makes this a higher-order operation that *uses* the 2×2, not a single
 The secondary felicity condition (eq. 21): addressee uptake of *p* must
 be a precondition for fulfilling a contextually salient
 addressee-benefiting goal `g_c ∈ EP(s, w)`
-(`Desire.EffectivePreferentialBackground`).
+(a background of `Core.Order.EffectivePreference` structures).
 
 ## Out of scope
 

--- a/Linglib/Studies/Lassiter2017.lean
+++ b/Linglib/Studies/Lassiter2017.lean
@@ -42,6 +42,7 @@ formalized in that study file).
 namespace Lassiter2017Desire
 
 open Desire
+open Core.Order (EffectivePreference)
 open Desire.Lassiter
 
 /-! ## §1. The 4-world conflict-witness model
@@ -103,7 +104,7 @@ theorem conflict_concrete :
 /-! ## §3. Cross-paper bridge: [condoravdi-lauer-2016]
 
 C&L's `wantEffectivePreference_jointly_belief_consistent` says that for any
-`EffectivePreferentialBackground EP` and any agent `a`, world `w`,
+effective-preference background `EP` and any agent `a`, world `w`,
 `wantEffectivePreference EP a φ w ∧ wantEffectivePreference EP a ψ w`
 implies `(φ ∩ ψ) ∩ B(a, w) ≠ ∅`.
 Specialized to `ψ = φᶜ`: the intersection is empty, so simultaneous
@@ -118,7 +119,7 @@ configuration. The two frameworks make orthogonal predictions on the
     C&L cannot reproduce Lassiter's witness. -/
 theorem condoravdiLauer_blocks_lassiter_witness
     {Agent : Type} {B : Agent → W → Set W}
-    (EP : Desire.EffectivePreferentialBackground Agent W B)
+    (EP : ∀ a w, EffectivePreference W (B a w))
     (a : Agent) (w : W) (φ : Set W)
     (hφ : Desire.wantEffectivePreference EP a φ w)
     (hnegφ : Desire.wantEffectivePreference EP a (fun w => ¬ φ w) w) :

--- a/Linglib/Studies/PhillipsBrown2025.lean
+++ b/Linglib/Studies/PhillipsBrown2025.lean
@@ -55,6 +55,7 @@ a common predicate.
 namespace PhillipsBrown2025
 
 open Desire
+open Core.Order (EffectivePreference)
 
 /-! ## §1. Eight-world model
 
@@ -473,7 +474,7 @@ desire, but they make non-overlapping claims. -/
     the contrast. -/
 theorem condoravdiLauer_blocks_simultaneous_pq_and_negpq
     {Agent W : Type} {B : Agent → W → Set W}
-    (EP : Desire.EffectivePreferentialBackground Agent W B)
+    (EP : ∀ a w, EffectivePreference W (B a w))
     (a : Agent) (φ : Set W) (w : W)
     (hφ : Desire.wantEffectivePreference EP a φ w)
     (hnegφ : Desire.wantEffectivePreference EP a (fun w => ¬ φ w) w) :


### PR DESCRIPTION
Dissolves the `PreferentialBackground` / `EffectivePreferentialBackground` abbrevs per mathlib practice: lawless Pi types are written inline (`P : Agent → W → PreferenceStructure W`, `EP : ∀ a w, EffectivePreference W (B a w)`), with C&L's terms — *preferential background*, *effective preferences* — carried in docstrings. ("Effective preferential" occurs nowhere in [condoravdi-lauer-2016]; the compound mis-scoped the adjective.) Recurring binders lift to `variable` blocks; `wantExactMatch_iff` args go implicit.