### PR TITLE
refactor(Semantics/Attitudes): UpperCamelCase Props; inline want schema

### DIFF
--- a/Linglib/Core/Order/OfCriteria.lean
+++ b/Linglib/Core/Order/OfCriteria.lean
@@ -17,7 +17,7 @@ One construction, several instantiations across the library:
   worlds ordered by an ordering source.
 - `Core.Order.NormalityOrder.fromProps` — the same order repackaged as a
   `NormalityOrder` for the default-reasoning infrastructure.
-- `Desire.worldAtLeastAsGood` — worlds ordered by
+- `Desire.WorldAtLeastAsGood` — worlds ordered by
   desires (via `atLeastAsGoodAs`).
 - `Core.Order.SatisfactionOrdering.ofCriteria` — the bundled
   `Bool`-valued/`List`-criteria specialization with decidable `≤`

--- a/Linglib/Semantics/Attitudes/CondoravdiLauer.lean
+++ b/Linglib/Semantics/Attitudes/CondoravdiLauer.lean
@@ -16,19 +16,19 @@ effective preference function `EP : ∀ a w, EffectivePreference W (B a w)`
 
 A want-report holds when some maximal preference in the background
 stands in a designated relation to the complement, and the relation is
-the locus of variation: [condoravdi-lauer-2016] eq. 71 considers
-equality (`wantExactMatch`, the canonical reading, their eq. 69),
-reverse inclusion (`wantSuccessOriented` — a preference satisfied *if*
-the complement is true), and inclusion (`wantQuineHintikka` —
-satisfied *only if* it is true). `wantPreference` is the shared
-schema, and the choice of relation fixes the reading's inferential
-profile: success-oriented want is downward-entailing in the
-complement, Quine-Hintikka want upward-entailing, exact-match want
-neither (counterexample-construction deferred).
-`wantEffectivePreference` is exact-match against the agent's effective
-preferences, and `maxOrderingSource` extracts the `Set`-valued
-ordering source `max[EP(Ad, w)]` (their eq. 88) consumed by the inner
-modal of the double-modal anankastic analysis.
+the locus of variation among the three readings of
+[condoravdi-lauer-2016] eq. 71: equality (`WantExactMatch`, the
+canonical reading, their eq. 69), reverse inclusion
+(`WantSuccessOriented` — a preference satisfied *if* the complement is
+true), and inclusion (`WantQuineHintikka` — satisfied *only if* it is
+true). The choice fixes the reading's inferential profile:
+success-oriented want is downward-entailing in the complement,
+Quine-Hintikka want upward-entailing, exact-match want neither
+(counterexample-construction deferred). `WantEffectivePreference` is
+exact-match against the agent's effective preferences, and
+`maxOrderingSource` extracts the `Set`-valued ordering source
+`max[EP(Ad, w)]` (their eq. 88) consumed by the inner modal of the
+double-modal anankastic analysis.
 
 Declarations live in the `Desire` namespace, alongside the rival
 want-semantics of `Desire.lean`. The anankastic-conditional analysis
@@ -44,66 +44,47 @@ open Core.Order
 
 variable {Agent W : Type*} (P : Agent → W → PreferenceStructure W)
 
-/-! ### The want schema and its three readings -/
+/-! ### The three readings of want -/
 
-/-- `wantPreference P R a φ w` iff some maximal preference in the
-    preferential background `P` — Condoravdi & Lauer's analog of a
-    Kratzerian conversational background — stands in `R` to `φ`. The
-    readings of *want* instantiate `R`; the choice determines the
-    operator's inferential profile. -/
-def wantPreference (R : Set W → Set W → Prop) (a : Agent) (φ : Set W)
-    (w : W) : Prop :=
-  ∃ p ∈ (P a w).maxElts, R φ p
-
-/-- Exact-match want: some maximal preference is `φ` itself — the
+/-- Exact-match want: some maximal preference in the preferential
+    background `P` — Condoravdi & Lauer's analog of a Kratzerian
+    conversational background — is `φ` itself: `φ ∈ max[P(a, w)]`. The
     canonical reading. -/
-def wantExactMatch : Agent → Set W → W → Prop :=
-  wantPreference P (· = ·)
+def WantExactMatch (a : Agent) (φ : Set W) (w : W) : Prop :=
+  φ ∈ (P a w).maxElts
 
 /-- Success-oriented want: some maximal preference is entailed by `φ`
     — a preference satisfied if `φ` is true. -/
-def wantSuccessOriented : Agent → Set W → W → Prop :=
-  wantPreference P (· ⊆ ·)
+def WantSuccessOriented (a : Agent) (φ : Set W) (w : W) : Prop :=
+  ∃ p ∈ (P a w).maxElts, φ ⊆ p
 
 /-- Quine-Hintikka want: some maximal preference entails `φ` — a
     preference satisfied only if `φ` is true. -/
-def wantQuineHintikka : Agent → Set W → W → Prop :=
-  wantPreference P (· ⊇ ·)
+def WantQuineHintikka (a : Agent) (φ : Set W) (w : W) : Prop :=
+  ∃ p ∈ (P a w).maxElts, p ⊆ φ
 
 variable {P}
 
-/-- `wantExactMatch P a φ w` iff `φ ∈ max[P(a, w)]`. -/
-theorem wantExactMatch_iff {a : Agent} {φ : Set W} {w : W} :
-    wantExactMatch P a φ w ↔ φ ∈ (P a w).maxElts :=
-  ⟨fun ⟨_, hp, h⟩ => by rwa [h], fun h => ⟨φ, h, rfl⟩⟩
-
-/-- A pointwise implication between relations transfers between
-    readings. -/
-theorem wantPreference_mono {R R' : Set W → Set W → Prop}
-    (h : ∀ φ p, R φ p → R' φ p) {a : Agent} {φ : Set W} {w : W} :
-    wantPreference P R a φ w → wantPreference P R' a φ w :=
-  fun ⟨p, hp, hR⟩ => ⟨p, hp, h φ p hR⟩
-
 /-- Exact match implies the success-oriented reading. -/
-theorem wantSuccessOriented_of_exactMatch {a : Agent} {φ : Set W} {w : W} :
-    wantExactMatch P a φ w → wantSuccessOriented P a φ w :=
-  wantPreference_mono fun _ _ h => h.subset
+theorem wantSuccessOriented_of_exactMatch {a : Agent} {φ : Set W} {w : W}
+    (h : WantExactMatch P a φ w) : WantSuccessOriented P a φ w :=
+  ⟨φ, h, subset_rfl⟩
 
 /-- Exact match implies the Quine-Hintikka reading. -/
-theorem wantQuineHintikka_of_exactMatch {a : Agent} {φ : Set W} {w : W} :
-    wantExactMatch P a φ w → wantQuineHintikka P a φ w :=
-  wantPreference_mono fun _ _ h => h.superset
+theorem wantQuineHintikka_of_exactMatch {a : Agent} {φ : Set W} {w : W}
+    (h : WantExactMatch P a φ w) : WantQuineHintikka P a φ w :=
+  ⟨φ, h, subset_rfl⟩
 
 /-- Success-oriented want is downward-entailing in the complement. -/
 theorem wantSuccessOriented_downward_entailing
     {a : Agent} {φ ψ : Set W} {w : W} (hφψ : φ ⊆ ψ) :
-    wantSuccessOriented P a ψ w → wantSuccessOriented P a φ w :=
+    WantSuccessOriented P a ψ w → WantSuccessOriented P a φ w :=
   fun ⟨p, hp, hψp⟩ => ⟨p, hp, hφψ.trans hψp⟩
 
 /-- Quine-Hintikka want is upward-entailing in the complement. -/
 theorem wantQuineHintikka_upward_entailing
     {a : Agent} {φ ψ : Set W} {w : W} (hφψ : φ ⊆ ψ) :
-    wantQuineHintikka P a φ w → wantQuineHintikka P a ψ w :=
+    WantQuineHintikka P a φ w → WantQuineHintikka P a ψ w :=
   fun ⟨p, hp, hpφ⟩ => ⟨p, hp, hpφ.trans hφψ⟩
 
 /-! ### Effective preferences -/
@@ -112,20 +93,19 @@ variable {B : Agent → W → Set W} (EP : ∀ a w, EffectivePreference W (B a w
 
 /-- Exact-match want against the agent's effective preferences —
     Condoravdi & Lauer's designated background `EP`. -/
-def wantEffectivePreference : Agent → Set W → W → Prop :=
-  wantExactMatch fun a w => (EP a w).toPreferenceStructure
+def WantEffectivePreference : Agent → Set W → W → Prop :=
+  WantExactMatch fun a w => (EP a w).toPreferenceStructure
 
 /-- Two effective-preference wants are jointly belief-consistent:
     wanting propositions the agent believes incompatible is
     impossible. -/
 theorem wantEffectivePreference_jointly_belief_consistent
     {a : Agent} {φ ψ : Set W} {w : W}
-    (hφ : wantEffectivePreference EP a φ w)
-    (hψ : wantEffectivePreference EP a ψ w) :
+    (hφ : WantEffectivePreference EP a φ w)
+    (hψ : WantEffectivePreference EP a ψ w) :
     (φ ∩ ψ) ∩ B a w ≠ ∅ :=
   (EP a w).toPreferenceStructure.maxElts_pair_belief_compatible
-    (EP a w).isConsistent
-    (wantExactMatch_iff.mp hφ) (wantExactMatch_iff.mp hψ)
+    (EP a w).isConsistent hφ hψ
 
 /-- `maxOrderingSource EP Ad w` is the set of maximal preferences in
     `EP(Ad, w)` — the ordering source consumed by the inner modal of

--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -18,25 +18,25 @@ Rival semantics for desire ascriptions (*want*, *wish*, *hope*),
 collected so their predictions about conflicting desires — ⌜S wants p⌝
 together with ⌜S wants ¬p⌝ against one belief state — can be compared:
 
-1. **von Fintel** ([von-fintel-1999]) — `wantVonFintel`: every
+1. **von Fintel** ([von-fintel-1999]) — `WantVonFintel`: every
    undominated belief-world is a p-world, the world ordering induced by
    which desires each world satisfies. The ordering is [kratzer-1981]'s
    `atLeastAsGoodAs` over the projected desire propositions, called
-   directly by `worldAtLeastAsGood`.
-2. **Heim** ([heim-1992]) — `wantHeimNaive`, her (27), the
-   Hintikka-style baseline she rejects; `wantHeim`, the (37/39)
+   directly by `WorldAtLeastAsGood`.
+2. **Heim** ([heim-1992]) — `WantHeimNaive`, her (27), the
+   Hintikka-style baseline she rejects; `WantHeim`, the (37/39)
    comparative-belief semantics restricted to the doxastic base; and
-   her (40) definedness amendment `wantHeimDefined`.
-3. **Phillips-Brown** ([phillips-brown-2025]) — `wantQuestionBased`:
+   her (40) definedness amendment `WantHeimDefined`.
+3. **Phillips-Brown** ([phillips-brown-2025]) — `WantQuestionBased`:
    every best answer in Q_c-Bel_S entails p, for a contextual question
-   Q_c, with the paper's metasemantic constraints (`isConsidered`,
-   `isDiverse`, `isAntiDeckstacking`, `isBelSensitive`) and its §3.4
+   Q_c, with the paper's metasemantic constraints (`IsConsidered`,
+   `IsDiverse`, `IsAntiDeckstacking`, `IsBelSensitive`) and its §3.4
    simulation result: on the finest question the semantics is von
-   Fintel's (`wantQuestionBased_finestPartition_iff_wantVonFintel`).
+   Fintel's (`wantQuestionBased_finestPartition_iff_WantVonFintel`).
 4. **Lassiter** ([lassiter-2017] apparatus; [lassiter-2011] want
-   application) — `Lassiter.want`: conditional expected value above a
+   application) — `Lassiter.Want`: conditional expected value above a
    threshold, with Sloman's Principle added in the full account
-   (`Lassiter.wantWithSloman`).
+   (`Lassiter.WantWithSloman`).
 
 On conflicting desires: the belief-based semantics block simultaneous
 `want(p)` and `want(¬p)` (`wantVonFintel_no_conflict`,
@@ -87,12 +87,12 @@ We expose `@[reducible]` aliases that *are* decidable under
 definitionally equal to their `Set`-API counterparts and are intended
 to read as the same operation. -/
 
-/-- `propEntails p q ↔ p ⊆ q` (definitionally), with decidability. -/
-@[reducible] def propEntails (p q : Set W) : Prop := ∀ w, p w → q w
+/-- `PropEntails p q ↔ p ⊆ q` (definitionally), with decidability. -/
+@[reducible] def PropEntails (p q : Set W) : Prop := ∀ w, p w → q w
 
-/-- `propOverlap p q ↔ (p ∩ q).Nonempty` (definitionally), with
+/-- `PropOverlap p q ↔ (p ∩ q).Nonempty` (definitionally), with
     decidability. -/
-@[reducible] def propOverlap (p q : Set W) : Prop := ∃ w, p w ∧ q w
+@[reducible] def PropOverlap (p q : Set W) : Prop := ∃ w, p w ∧ q w
 
 /-! ### Answer preference ([phillips-brown-2025] §3.5)
 
@@ -112,7 +112,7 @@ Pareto-undominated elements (see §3.5, p. 11:21). -/
     §3.5. -/
 def propositionOrdering (GS : List (DecProp W)) :
     SatisfactionOrdering (DecProp W) (DecProp W) :=
-  SatisfactionOrdering.ofCriteria (fun a p => decide (propEntails a.prop p.prop)) GS
+  SatisfactionOrdering.ofCriteria (fun a p => decide (PropEntails a.prop p.prop)) GS
 
 /-- Best (= Pareto-undominated) answers among a candidate list. -/
 abbrev undominatedAnswers (GS answers : List (DecProp W)) : List (DecProp W) :=
@@ -125,25 +125,25 @@ Q_c-Bel_S = the cells of Q_c compatible with S's beliefs. -/
 /-- The cells of `answers` that overlap `belS`. -/
 def questionRelativeBelief (answers : List (DecProp W))
     (belS : Set W) [DecidablePred belS] : List (DecProp W) :=
-  answers.filter fun a => decide (propOverlap a.prop belS)
+  answers.filter fun a => decide (PropOverlap a.prop belS)
 
 /-! ### Question-based want ([phillips-brown-2025] §3.4) -/
 
 /-- ⟦S wants p⟧^c = every undominated answer in Q_c-Bel_S entails p.
     The paper's central definition (§3.5). -/
-def wantQuestionBased (belS : Set W) [DecidablePred belS]
+def WantQuestionBased (belS : Set W) [DecidablePred belS]
     (GS answers : List (DecProp W)) (p : Set W) [DecidablePred p] : Prop :=
   ∀ a ∈ undominatedAnswers GS (questionRelativeBelief answers belS),
-    propEntails a.prop p
+    PropEntails a.prop p
 
 instance (belS : Set W) [DecidablePred belS]
     (GS answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    Decidable (wantQuestionBased belS GS answers p) :=
+    Decidable (WantQuestionBased belS GS answers p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-! ### von Fintel baseline ([von-fintel-1999])
 
-`wantVonFintel` evaluates to "every undominated belief-world is a p-world",
+`WantVonFintel` evaluates to "every undominated belief-world is a p-world",
 where the world ordering is induced by which desires each world
 satisfies — [kratzer-1981]'s `atLeastAsGoodAs` over the projected
 desires, by definition. -/
@@ -153,37 +153,37 @@ desires, by definition. -/
     `atLeastAsGoodAs` over the projected proposition list, by definition.
     Decidability is transported from the per-`DecProp` witnesses via
     `worldAtLeastAsGood_iff_decProp`. -/
-def worldAtLeastAsGood (GS : List (DecProp W)) (w z : W) : Prop :=
+def WorldAtLeastAsGood (GS : List (DecProp W)) (w z : W) : Prop :=
   Modality.Kratzer.atLeastAsGoodAs (GS.map (·.prop)) w z
 
 omit [Fintype W] [DecidableEq W] in
 /-- The ordering in its `DecProp`-quantified form, where each desire
     carries its decidability witness. -/
 theorem worldAtLeastAsGood_iff_decProp (GS : List (DecProp W)) (w z : W) :
-    worldAtLeastAsGood GS w z ↔ ∀ p ∈ GS, p.prop z → p.prop w := by
+    WorldAtLeastAsGood GS w z ↔ ∀ p ∈ GS, p.prop z → p.prop w := by
   show (∀ p ∈ GS.map (·.prop), p z → p w) ↔ _
   simp only [List.mem_map]
   refine ⟨fun h a ha hpz => h a.prop ⟨a, ha, rfl⟩ hpz,
           fun h _ ⟨a, ha, hap⟩ hpz => hap ▸ h a ha (hap ▸ hpz)⟩
 
 instance (GS : List (DecProp W)) (w z : W) :
-    Decidable (worldAtLeastAsGood GS w z) :=
+    Decidable (WorldAtLeastAsGood GS w z) :=
   decidable_of_iff _ (worldAtLeastAsGood_iff_decProp GS w z).symm
 
 /-- Standard von Fintel [von-fintel-1999] semantics: every undominated
     belS-world is a p-world. The `[DecidablePred]` hypotheses are not
     used in the definition body; they live on the `Decidable` instance
     so that abstract reasoning (e.g. instances of
-    `BeliefBasedDesireSemantics`) can use `wantVonFintel` without supplying
+    `BeliefBasedDesireSemantics`) can use `WantVonFintel` without supplying
     them. -/
-def wantVonFintel (belS : Set W) (GS : List (DecProp W)) (p : Set W) : Prop :=
+def WantVonFintel (belS : Set W) (GS : List (DecProp W)) (p : Set W) : Prop :=
   ∀ w, belS w →
-    (∀ z, belS z → ¬ (worldAtLeastAsGood GS z w ∧ ¬ worldAtLeastAsGood GS w z)) →
+    (∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) →
     p w
 
 instance (belS : Set W) [DecidablePred belS]
     (GS : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    Decidable (wantVonFintel belS GS p) :=
+    Decidable (WantVonFintel belS GS p) :=
   inferInstanceAs (Decidable (∀ _, _))
 
 /-! ### Metasemantic constraints ([phillips-brown-2025] §3.6–§4.2) -/
@@ -191,24 +191,24 @@ instance (belS : Set W) [DecidablePred belS]
 /-- **Considering Constraint** (§3.6): every cell of Q_c either
     entails p or entails ¬p. Equivalently (over partition cells):
     p is a union of cells. -/
-def isConsidered (answers : List (DecProp W))
+def IsConsidered (answers : List (DecProp W))
     (p : Set W) [DecidablePred p] : Prop :=
   ∀ a ∈ answers, (∀ w, a.prop w → p w) ∨ (∀ w, a.prop w → ¬ p w)
 
 instance (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    Decidable (isConsidered answers p) :=
+    Decidable (IsConsidered answers p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-- **Diversity Constraint** (§3.7, attributed to
     [condoravdi-2002]): Q_c contains both p-cells and ¬p-cells.
     Without diversity, ⟦want p⟧ would be vacuously true (or false). -/
-def isDiverse (answers : List (DecProp W))
+def IsDiverse (answers : List (DecProp W))
     (p : Set W) [DecidablePred p] : Prop :=
   (∃ a ∈ answers, ∀ w, a.prop w → p w) ∧
   (∃ a ∈ answers, ∀ w, a.prop w → ¬ p w)
 
 instance (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    Decidable (isDiverse answers p) :=
+    Decidable (IsDiverse answers p) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Anti-deckstacking ([phillips-brown-2025] §3.7)
@@ -239,13 +239,13 @@ basic dimensions). -/
     salient propositions; passing the empty list trivially satisfies the
     constraint, so study files must opt in by listing the basic
     propositions of their model. -/
-def isAntiDeckstacking (naturalProps answers : List (DecProp W)) : Prop :=
+def IsAntiDeckstacking (naturalProps answers : List (DecProp W)) : Prop :=
   ∀ q ∈ naturalProps,
     (∀ a ∈ answers, ¬ ∀ w, a.prop w → q.prop w) ∨
     (∀ a ∈ answers, (∀ w, a.prop w → q.prop w) ∨ (∀ w, a.prop w → ¬ q.prop w))
 
 instance (naturalProps answers : List (DecProp W)) :
-    Decidable (isAntiDeckstacking naturalProps answers) :=
+    Decidable (IsAntiDeckstacking naturalProps answers) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-- **Belief-sensitivity Constraint** (§4.2, building on
@@ -254,30 +254,30 @@ instance (naturalProps answers : List (DecProp W)) :
     S's beliefs and at least one is incompatible. Blocks inferences
     like William III ⊨ "Avoid nuclear war" when the agent lacks the
     conceptual resources to grasp the question. -/
-def isBelSensitive (belS : Set W) [DecidablePred belS]
+def IsBelSensitive (belS : Set W) [DecidablePred belS]
     (answers : List (DecProp W)) : Prop :=
   let live := questionRelativeBelief answers belS
   live ≠ [] ∧ live.length ≠ answers.length
 
 instance (belS : Set W) [DecidablePred belS] (answers : List (DecProp W)) :
-    Decidable (isBelSensitive belS answers) :=
+    Decidable (IsBelSensitive belS answers) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-- Full definedness condition for ⟦S wants p⟧^c. The paper requires
     all four constraints (Considering §3.6, Diversity §3.7,
     Anti-deckstacking §3.7, Belief-sensitivity §4.2). The
     `naturalProps` parameter feeds Anti-deckstacking. -/
-def wantDefined (belS : Set W) [DecidablePred belS]
+def WantDefined (belS : Set W) [DecidablePred belS]
     (naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] : Prop :=
-  isConsidered answers p ∧
-  isDiverse answers p ∧
-  isAntiDeckstacking naturalProps answers ∧
-  isBelSensitive belS answers
+  IsConsidered answers p ∧
+  IsDiverse answers p ∧
+  IsAntiDeckstacking naturalProps answers ∧
+  IsBelSensitive belS answers
 
 instance (belS : Set W) [DecidablePred belS]
     (naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    Decidable (wantDefined belS naturalProps answers p) := by
-  unfold wantDefined; infer_instance
+    Decidable (WantDefined belS naturalProps answers p) := by
+  unfold WantDefined; infer_instance
 
 /-! ### Partial-proposition wrapper
 
@@ -293,8 +293,8 @@ suppressed. -/
 def wantPartialProp (belS : Set W) [DecidablePred belS]
     (GS naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
     PartialProp W where
-  presup _ := wantDefined belS naturalProps answers p
-  assertion _ := wantQuestionBased belS GS answers p
+  presup _ := WantDefined belS naturalProps answers p
+  assertion _ := WantQuestionBased belS GS answers p
 
 /-! ### The finest question simulates von Fintel ([phillips-brown-2025] §3.4)
 
@@ -312,24 +312,24 @@ def finestPartition (worlds : List W) : List (DecProp W) :=
 
 The §3.4 metasemantic identity is proved via three helper lemmas
 (singleton-cell preference reduces to single-world preference under
-`worldAtLeastAsGood`; the question-relative belief filter on
+`WorldAtLeastAsGood`; the question-relative belief filter on
 `finestPartition` selects exactly the singleton cells of belS-worlds;
 undominated singleton cells correspond to Pareto-undominated
 belS-worlds), then a direct two-direction `iff` proof. -/
 
 /-- Singleton-cell preference under `propositionOrdering` reduces to
-    single-world preference under `worldAtLeastAsGood`: for cells
+    single-world preference under `WorldAtLeastAsGood`: for cells
     `mkDec (· = w)` and `mkDec (· = z)`, `mkDec (· = w) ≤ mkDec (· = z)`
-    in the proposition ordering iff `worldAtLeastAsGood GS w z`. -/
+    in the proposition ordering iff `WorldAtLeastAsGood GS w z`. -/
 private theorem singleton_le_iff_world (GS : List (DecProp W)) (w z : W) :
     (propositionOrdering GS).le (mkDec (· = w)) (mkDec (· = z)) ↔
-      worldAtLeastAsGood GS w z := by
+      WorldAtLeastAsGood GS w z := by
   rw [worldAtLeastAsGood_iff_decProp]
   unfold propositionOrdering SatisfactionOrdering.ofCriteria
-  show (∀ q ∈ GS.filter (fun q => decide (propEntails (mkDec (· = z)).prop q.prop)),
-          decide (propEntails (mkDec (· = w)).prop q.prop) = true) ↔
+  show (∀ q ∈ GS.filter (fun q => decide (PropEntails (mkDec (· = z)).prop q.prop)),
+          decide (PropEntails (mkDec (· = w)).prop q.prop) = true) ↔
        (∀ q ∈ GS, q.prop z → q.prop w)
-  simp only [propEntails, decide_eq_true_eq]
+  simp only [PropEntails, decide_eq_true_eq]
   constructor
   · intro h q hq hqz
     have hqfilter : q ∈ GS.filter (fun q' => decide (∀ x, x = z → q'.prop x)) := by
@@ -354,7 +354,7 @@ private theorem mem_qRB_finestPartition_iff (belS : Set W) [DecidablePred belS]
       w ∈ worlds ∧ belS w := by
   unfold questionRelativeBelief finestPartition
   rw [List.mem_filter]
-  simp only [List.mem_map, decide_eq_true_eq, propOverlap, mkDec]
+  simp only [List.mem_map, decide_eq_true_eq, PropOverlap, mkDec]
   constructor
   · rintro ⟨⟨v, hv_mem, hv_eq⟩, ⟨x, hxv, hxBel⟩⟩
     -- mkDec injection on `prop`: (· = v) = (· = w), evaluate at v
@@ -369,12 +369,12 @@ private theorem mem_qRB_finestPartition_iff (belS : Set W) [DecidablePred belS]
   · rintro ⟨hw_mem, hbel⟩
     exact ⟨⟨w, hw_mem, rfl⟩, ⟨w, rfl, hbel⟩⟩
 
-theorem wantQuestionBased_finestPartition_iff_wantVonFintel
+theorem wantQuestionBased_finestPartition_iff_WantVonFintel
     (belS : Set W) [DecidablePred belS] (GS : List (DecProp W))
     (worlds : List W) (hUniv : ∀ w, w ∈ worlds)
     (p : Set W) [DecidablePred p] :
-    wantQuestionBased belS GS (finestPartition worlds) p ↔ wantVonFintel belS GS p := by
-  unfold wantQuestionBased wantVonFintel undominatedAnswers SatisfactionOrdering.undominated
+    WantQuestionBased belS GS (finestPartition worlds) p ↔ WantVonFintel belS GS p := by
+  unfold WantQuestionBased WantVonFintel undominatedAnswers SatisfactionOrdering.undominated
   refine ⟨fun hLHS w hw hUnd => ?_, fun hRHS a ha => ?_⟩
   · -- LHS → RHS: pick the cell `mkDec (· = w)`, show it's undominated, apply
     have hcell_mem : mkDec (· = w) ∈
@@ -398,8 +398,8 @@ theorem wantQuestionBased_finestPartition_iff_wantVonFintel
         rw [← hz_eq] at hc_mem
         exact ((mem_qRB_finestPartition_iff belS worlds z).mp hc_mem).2
       rw [← hz_eq] at hc_strict
-      have hzw : worldAtLeastAsGood GS z w := (singleton_le_iff_world GS z w).mp hc_strict.1
-      have hnwz : ¬ worldAtLeastAsGood GS w z := fun h =>
+      have hzw : WorldAtLeastAsGood GS z w := (singleton_le_iff_world GS z w).mp hc_strict.1
+      have hnwz : ¬ WorldAtLeastAsGood GS w z := fun h =>
         hc_strict.2 ((singleton_le_iff_world GS w z).mpr h)
       exact hUnd z hz_bel ⟨hzw, hnwz⟩
     have := hLHS _ hcell_undom
@@ -418,15 +418,15 @@ theorem wantQuestionBased_finestPartition_iff_wantVonFintel
       ((mem_qRB_finestPartition_iff belS worlds w).mp ha_mem).2
     -- ha_min: ¬ ∃ c ∈ qRB, c strictly better than mkDec (· = w)
     simp only [decide_eq_true_eq] at ha_min
-    have hUnd : ∀ z, belS z → ¬ (worldAtLeastAsGood GS z w ∧
-                                  ¬ worldAtLeastAsGood GS w z) := by
+    have hUnd : ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧
+                                  ¬ WorldAtLeastAsGood GS w z) := by
       intro z hz_bel ⟨hzw, hnwz⟩
       apply ha_min
       refine ⟨mkDec (· = z), ?_, ?_⟩
       · exact (mem_qRB_finestPartition_iff belS worlds z).mpr ⟨hUniv z, hz_bel⟩
       · exact ⟨(singleton_le_iff_world GS z w).mpr hzw,
                fun h => hnwz ((singleton_le_iff_world GS w z).mp h)⟩
-    -- Apply hRHS at w; get p w; convert to propEntails
+    -- Apply hRHS at w; get p w; convert to PropEntails
     have hpw : p w := hRHS w hbelw hUnd
     intro x hx
     -- hx : (mkDec (· = w)).prop x = (x = w)
@@ -439,7 +439,7 @@ theorem wantQuestionBased_finestPartition_iff_wantVonFintel
 
 The paper's central argument against belief-based semantics. For any
 non-empty belief state with at least one undominated world, vF cannot
-make both `wantVonFintel belS GS p` and `wantVonFintel belS GS (¬p)` true at the
+make both `WantVonFintel belS GS p` and `WantVonFintel belS GS (¬p)` true at the
 same context. -/
 
 omit [Fintype W] [DecidableEq W] in
@@ -449,8 +449,8 @@ theorem wantVonFintel_no_conflict
     (belS : Set W) [DecidablePred belS]
     (GS : List (DecProp W)) (p : Set W) [DecidablePred p]
     (h : ∃ w, belS w ∧
-      ∀ z, belS z → ¬ (worldAtLeastAsGood GS z w ∧ ¬ worldAtLeastAsGood GS w z)) :
-    ¬ (wantVonFintel belS GS p ∧ wantVonFintel belS GS (fun w => ¬ p w)) := by
+      ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) :
+    ¬ (WantVonFintel belS GS p ∧ WantVonFintel belS GS (fun w => ¬ p w)) := by
   rintro ⟨hp, hnp⟩
   obtain ⟨w, hw, hund⟩ := h
   exact (hnp w hw hund) (hp w hw hund)
@@ -458,20 +458,20 @@ theorem wantVonFintel_no_conflict
 /-! ### Closure properties ([phillips-brown-2025] §4) -/
 
 omit [Fintype W] [DecidableEq W] in
-/-- vF is **upward monotonic**: if `p ⊆ q` and `wantVonFintel belS GS p`,
-    then `wantVonFintel belS GS q`. This is the [villalta-2008]
+/-- vF is **upward monotonic**: if `p ⊆ q` and `WantVonFintel belS GS p`,
+    then `WantVonFintel belS GS q`. This is the [villalta-2008]
     doxastic-closure problem that motivates the question-based
     approach (§4.1). -/
 theorem wantVonFintel_upward_monotonic (belS : Set W) [DecidablePred belS]
     (GS : List (DecProp W)) (p q : Set W) [DecidablePred p] [DecidablePred q]
-    (hpq : ∀ w, p w → q w) (h : wantVonFintel belS GS p) :
-    wantVonFintel belS GS q :=
+    (hpq : ∀ w, p w → q w) (h : WantVonFintel belS GS p) :
+    WantVonFintel belS GS q :=
   fun w hw hund => hpq w (h w hw hund)
 
 omit [DecidableEq W] in
 /-- Question-based `want` is **Strawson upward monotonic** (§4.2):
-    `wantQuestionBased belS GS Q p`, `p ⊆ q`, and `q` considered
-    relative to `Q` jointly imply `wantQuestionBased belS GS Q q`. The
+    `WantQuestionBased belS GS Q p`, `p ⊆ q`, and `q` considered
+    relative to `Q` jointly imply `WantQuestionBased belS GS Q q`. The
     Considering presupposition is what blocks naive upward monotonicity
     that derived "Avoid-war ⊨ Avoid-nuclear-war" from "wants
     Avoid-war". -/
@@ -479,9 +479,9 @@ theorem wantQuestionBased_strawson_upward_monotonic
     (belS : Set W) [DecidablePred belS]
     (GS answers : List (DecProp W)) (p q : Set W)
     [DecidablePred p] [DecidablePred q]
-    (hpq : ∀ w, p w → q w) (_hCons : isConsidered answers q)
-    (h : wantQuestionBased belS GS answers p) :
-    wantQuestionBased belS GS answers q :=
+    (hpq : ∀ w, p w → q w) (_hCons : IsConsidered answers q)
+    (h : WantQuestionBased belS GS answers p) :
+    WantQuestionBased belS GS answers q :=
   fun a ha w hw => hpq w (h a ha w hw)
 
 /-! ### Comparative-belief semantics ([heim-1992])
@@ -492,7 +492,7 @@ shows the trajectory and lets future readers reproduce the argument.
 
 (27) The naive Hintikka-style `want` (§3, p. 192): "every bouletic
 alternative is a φ-world." Heim immediately rejects it via Asher's
-Concorde counterexample at (32) p. 194. We formalize it as `wantHeimNaive`
+Concorde counterexample at (32) p. 194. We formalize it as `WantHeimNaive`
 to make the rejection-by-counterexample testable.
 
 (31) Truth-conditional comparative-belief `want` (§4.1, p. 193 —
@@ -550,13 +550,13 @@ def heimSim {W : Type*} [Fintype W] [DecidableEq W]
     the bouletic/doxastic distinction at the substrate level) is a
     φ-world. Provided to enable formalizing Asher's (32) Concorde
     counterexample as a test of the analysis Heim *rejected*. -/
-def wantHeimNaive (belS : Set W) [DecidablePred belS]
+def WantHeimNaive (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] : Prop :=
   ∀ w, belS w → p w
 
 instance (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] :
-    Decidable (wantHeimNaive belS p) :=
+    Decidable (WantHeimNaive belS p) :=
   inferInstanceAs (Decidable (∀ _, _))
 
 /-- Heim 1992 (37/39), the canonical comparative-belief semantics:
@@ -568,7 +568,7 @@ instance (belS : Set W) [DecidablePred belS]
     `Decidable` instance below can be derived via `Finset.decidableBAll`.
     The `[DecidablePred belS]`/`[DecidablePred p]` are needed because
     `heimSim` uses them. -/
-def wantHeim (belS : Set W) [DecidablePred belS]
+def WantHeim (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p] : Prop :=
   ∀ w' ∈ (Finset.univ : Finset W).filter belS,
     ∀ x ∈ heimSim params belS p w',
@@ -577,29 +577,29 @@ def wantHeim (belS : Set W) [DecidablePred belS]
 
 instance (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p] :
-    Decidable (wantHeim belS params w_eval p) :=
+    Decidable (WantHeim belS params w_eval p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-- Heim's (40) amendment (§4.2.3, p. 198): ⟦α wants φ⟧ is defined
     only when the agent does not already believe φ and does not already
     believe ¬φ. Equivalently: both `belS ∩ φ` and `belS ∩ ¬φ` are
     non-empty. -/
-def wantHeimDefined (belS : Set W) [DecidablePred belS]
+def WantHeimDefined (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] : Prop :=
   (∃ w, belS w ∧ p w) ∧ (∃ w, belS w ∧ ¬ p w)
 
 instance (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] :
-    Decidable (wantHeimDefined belS p) :=
+    Decidable (WantHeimDefined belS p) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
 /-! ### Heim no-go: comparative-belief blocks simultaneous `want(p) ∧ want(¬p)`
 
-The proof shape: pick any `w' ∈ belS` (exists since `wantHeimDefined`
+The proof shape: pick any `w' ∈ belS` (exists since `WantHeimDefined`
 gives non-empty `belS ∩ p`). Pick any `x ∈ Sim p w'` and any
-`y ∈ Sim ¬p w'` (both non-empty under `wantHeimDefined`). Then
-`wantHeim belS params w_eval p` gives `pref w_eval x y` and
-`wantHeim belS params w_eval ¬p` gives `pref w_eval y x`. Strict
+`y ∈ Sim ¬p w'` (both non-empty under `WantHeimDefined`). Then
+`WantHeim belS params w_eval p` gives `pref w_eval x y` and
+`WantHeim belS params w_eval ¬p` gives `pref w_eval y x`. Strict
 asymmetry of `pref` — i.e., `pref w x y ∧ pref w y x → x = y` for the
 weak relation, or `pref w x y → ¬ pref w y x` for the strict — yields
 `x = y`, but `x ∈ p` and `y ∈ ¬p` (since Sim's first arg restricts to
@@ -610,7 +610,7 @@ no-go applicable to both strict and partial-order desirability
 relations. -/
 
 /-- A `belS ∩ p`-world reachable via similarity from any belS-world
-    under the limit assumption, i.e. when `wantHeimDefined` holds, gives
+    under the limit assumption, i.e. when `WantHeimDefined` holds, gives
     a non-empty `heimSim params belS p w'`. Discharges Heim's Limit
     Assumption automatically on finite types via
     `Core.Order.SimilarityOrdering.closestWorlds_nonempty`. -/
@@ -639,9 +639,9 @@ theorem wantHeim_no_conflict
     (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p]
     (hAsym : ∀ x y, params.pref w_eval x y → params.pref w_eval y x → x = y)
-    (h : wantHeimDefined belS p) :
-    ¬ (wantHeim belS params w_eval p ∧
-       wantHeim belS params w_eval (fun w => ¬ p w)) := by
+    (h : WantHeimDefined belS p) :
+    ¬ (WantHeim belS params w_eval p ∧
+       WantHeim belS params w_eval (fun w => ¬ p w)) := by
   rintro ⟨hp, hnp⟩
   obtain ⟨⟨wp, hwp_bel, hwp_p⟩, ⟨wn, hwn_bel, hwn_np⟩⟩ := h
   -- The negation argument's heimSim has a double-negation that needs
@@ -684,11 +684,11 @@ question. The substrate exposes bridge theorems showing each PB
 predicate corresponds to a property of the underlying
 `Question W`:
 
-* `wantQuestionBased` "every undominated answer entails p" relates to
+* `WantQuestionBased` "every undominated answer entails p" relates to
   the partition property "every undominated cell of `Q` entails `p`"
   — i.e., `∀ q ∈ alt Q, q ∈ undominated → q ⊆ p`.
 
-* `isConsidered` corresponds to `partial-answerhood for the polar
+* `IsConsidered` corresponds to `partial-answerhood for the polar
   question of p`: every cell of Q is either a confirming or refuting
   answer to "p?".
 
@@ -700,15 +700,15 @@ def toQuestion (answers : List (DecProp W)) : Question W :=
   Question.ofList (answers.map (·.prop))
 
 omit [Fintype W] [DecidableEq W] in
-/-- `isConsidered Q p` agrees with the polar-answerhood reading of
+/-- `IsConsidered Q p` agrees with the polar-answerhood reading of
     every cell: each cell either entails `p` or entails `pᶜ`, which is
     exactly "every cell is a partial answer to the polar question of
     `p`". -/
 theorem isConsidered_iff_polar_partial_answer
     (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    isConsidered answers p ↔
+    IsConsidered answers p ↔
     ∀ a ∈ answers, a.prop ⊆ p ∨ a.prop ⊆ {w | ¬ p w} := by
-  unfold isConsidered
+  unfold IsConsidered
   refine ⟨fun h a ha => ?_, fun h a ha => ?_⟩
   · rcases h a ha with hp | hnp
     · exact Or.inl (fun w hw => hp w hw)
@@ -736,17 +736,17 @@ The substrate exposes:
 * `Lassiter.expectedValue pr V belS p` — conditional expected value of
   `p` given the agent's belief state. Convention: returns `0` when
   `p ∩ belS = ∅` (Lassiter notes E_V undefined here, p.187 fn.).
-* `Lassiter.want belS pr V θ p` — Lassiter-style positive-form want:
+* `Lassiter.Want belS pr V θ p` — Lassiter-style positive-form want:
   `E_V(p|bel) > θ`. Matches §8.14 eq. 8.72a.
-* `Lassiter.slomanPrinciple` (§8.6 eq. 8.16, p.216) — a constraint
+* `Lassiter.SlomanPrinciple` (§8.6 eq. 8.16, p.216) — a constraint
   that the wanted proposition strictly dominates every other relevant
   alternative on the value scale.
-* `Lassiter.wantWithSloman` — Lassiter's *full* account: bare threshold
+* `Lassiter.WantWithSloman` — Lassiter's *full* account: bare threshold
   AND Sloman's Principle.
 
 **The bare threshold form admits simultaneous want(p) ∧ want(¬p)**
 (`Lassiter.threshold_admits_conflict_witness`), violating the substrate's
-`BeliefBasedDesireSemantics.isConflictBlocking`. This makes Lassiter's
+`BeliefBasedDesireSemantics.IsConflictBlocking`. This makes Lassiter's
 *bare apparatus* a sibling of vF/Heim/PB, *not* a `BBSemantics`
 instance. Lassiter and Phillips-Brown are *different ways* of escaping
 the no-go: PB via question-sensitivity, Lassiter via
@@ -803,7 +803,7 @@ def expectedValue [Fintype W]
     threshold `θ`. Matches §8.14 eq. 8.72a's scalar
     interpretation `μ_ought(φ) > θ_ought`, extended to *want* per
     §8.13 + Lassiter 2011 ch.6. -/
-def want [Fintype W]
+def Want [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
     (p : Set W) [DecidablePred p] : Prop :=
@@ -813,7 +813,7 @@ instance [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
     (p : Set W) [DecidablePred p] :
-    Decidable (want belS pr V θ p) :=
+    Decidable (Want belS pr V θ p) :=
   inferInstanceAs (Decidable (_ > θ))
 
 /-! ### Sloman's Principle ([lassiter-2017] §8.6)
@@ -828,7 +828,7 @@ alternative set. -/
 /-- Sloman's Principle: `p` strictly dominates every other listed
     alternative on the expected-value scale. Decidable via the
     underlying `expectedValue` decidability. -/
-def slomanPrinciple [Fintype W]
+def SlomanPrinciple [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ)
     (alts : List (Σ' (q : Set W), DecidablePred q))
@@ -841,12 +841,12 @@ def slomanPrinciple [Fintype W]
 /-- **Lassiter's full account**: the bare threshold AND Sloman's
     Principle. This is the *actual* account Lassiter defends in §8;
     the bare `want` operator alone is the apparatus, not the position. -/
-def wantWithSloman [Fintype W]
+def WantWithSloman [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
     (alts : List (Σ' (q : Set W), DecidablePred q))
     (p : Set W) [DecidablePred p] : Prop :=
-  want belS pr V θ p ∧ slomanPrinciple belS pr V alts p
+  Want belS pr V θ p ∧ SlomanPrinciple belS pr V alts p
 
 /-! ### Bridge to decision theory
 
@@ -880,8 +880,8 @@ theorem threshold_admits_conflict_witness :
       (belS : Set W) (_ : DecidablePred belS)
       (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
       (p : Set W) (_ : DecidablePred p),
-      want belS pr V θ p ∧
-      want belS pr V θ (fun w => ¬ p w) := by
+      Want belS pr V θ p ∧
+      Want belS pr V θ (fun w => ¬ p w) := by
   refine ⟨Fin 4, inferInstance, inferInstance,
           (fun _ => True), inferInstance,
           (fun _ => 1/4),
@@ -891,8 +891,8 @@ theorem threshold_admits_conflict_witness :
           (fun w => w = 0 ∨ w = 1), inferInstance,
           ?_, ?_⟩
   all_goals
-    show want _ _ _ _ _
-    unfold want expectedValue
+    show Want _ _ _ _ _
+    unfold Want expectedValue
     simp [Fin.sum_univ_succ]
     norm_num
 
@@ -902,7 +902,7 @@ Lassiter's *full* account adds Sloman's Principle (eq. 8.16 p.216).
 On the conflict-witness model with `alts = [propP, ¬propP]`, Sloman
 holds for `propP` (E_V(propP) = 7 > 2 = E_V(¬propP) ✓) but FAILS for
 `¬propP` (E_V(¬propP) = 2 ≯ 7 = E_V(propP) ✗). So
-`wantWithSloman` makes only `propP` wanted, blocking the conflict.
+`WantWithSloman` makes only `propP` wanted, blocking the conflict.
 
 This formalizes Lassiter's §8.11 (p.245) position: single-V conflict
 is blocked by his own constraints; genuine conflicting wants come from
@@ -916,9 +916,9 @@ theorem wantWithSloman_blocks_conflict
     (h_p_in_alts : ⟨p, inferInstance⟩ ∈ alts)
     (h_negp_in_alts : ⟨fun w => ¬ p w, inferInstance⟩ ∈ alts)
     (h_p_ne_negp : (p : Set W) ≠ (fun w => ¬ p w)) :
-    ¬ (wantWithSloman belS pr V θ alts p ∧
-       wantWithSloman belS pr V θ alts (fun w => ¬ p w)) := by
-  simp only [wantWithSloman, slomanPrinciple]
+    ¬ (WantWithSloman belS pr V θ alts p ∧
+       WantWithSloman belS pr V θ alts (fun w => ¬ p w)) := by
+  simp only [WantWithSloman, SlomanPrinciple]
   rintro ⟨⟨_, hSlomanP⟩, ⟨_, hSlomanNegP⟩⟩
   -- Sloman for p: E_V(p) > E_V(¬p) (since ¬p is in alts and ≠ p)
   have h1 : expectedValue pr V belS p > expectedValue pr V belS (fun w => ¬ p w) := by
@@ -950,7 +950,7 @@ expected-value semantics. -/
 /-- A proposition has *positive belief mass* if some belS-world
     satisfies it. Decidability is inherited via the fact that
     `Set.Nonempty (belS ∩ p)` is decidable on finite types. -/
-def hasPositiveBeliefMass [Fintype W]
+def HasPositiveBeliefMass [Fintype W]
     (pr : W → ℚ) (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] : Prop :=
   (∑ w, (if belS w ∧ p w then pr w else 0)) > 0
@@ -964,14 +964,14 @@ theorem expectedValue_intermediate_disjoint [Fintype W]
     (pr : W → ℚ) (V : W → ℚ)
     (belS : Set W) [DecidablePred belS]
     (p q : Set W) [DecidablePred p] [DecidablePred q]
-    (hPosP : hasPositiveBeliefMass pr belS p)
-    (hPosQ : hasPositiveBeliefMass pr belS q)
+    (hPosP : HasPositiveBeliefMass pr belS p)
+    (hPosQ : HasPositiveBeliefMass pr belS q)
     (hDisjoint : ∀ w, ¬ (p w ∧ q w)) :
     min (expectedValue pr V belS p) (expectedValue pr V belS q)
       ≤ expectedValue pr V belS (fun w => p w ∨ q w) ∧
     expectedValue pr V belS (fun w => p w ∨ q w)
       ≤ max (expectedValue pr V belS p) (expectedValue pr V belS q) := by
-  unfold hasPositiveBeliefMass at hPosP hPosQ
+  unfold HasPositiveBeliefMass at hPosP hPosQ
   have hsplit : ∀ f : W → ℚ,
       (∑ w, (if belS w ∧ (p w ∨ q w) then f w else 0)) =
       (∑ w, (if belS w ∧ p w then f w else 0)) +
@@ -1032,7 +1032,7 @@ theorem expectedValue_intermediate_disjoint [Fintype W]
 /-! ### Weakening from intermediacy
 
 [lassiter-2017] eq. 8.54 collects three constraints on *ought*: Sloman
-(formalized above as `slomanPrinciple`), Smith (restricted
+(formalized above as `SlomanPrinciple`), Smith (restricted
 agglomeration, whose derivation requires more structure than
 intermediacy and is not formalized here), and Weakening
 (`ought(φ) ∧ ought(ψ) → ought(φ ∨ ψ)`, the name due to [cariani-2016],
@@ -1053,12 +1053,12 @@ theorem want_satisfies_weakening_disjoint [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
     (p q : Set W) [DecidablePred p] [DecidablePred q]
-    (hPosP : hasPositiveBeliefMass pr belS p)
-    (hPosQ : hasPositiveBeliefMass pr belS q)
+    (hPosP : HasPositiveBeliefMass pr belS p)
+    (hPosQ : HasPositiveBeliefMass pr belS q)
     (hDisjoint : ∀ w, ¬ (p w ∧ q w))
-    (hp : want belS pr V θ p) (hq : want belS pr V θ q) :
-    want belS pr V θ (fun w => p w ∨ q w) := by
-  unfold want at hp hq ⊢
+    (hp : Want belS pr V θ p) (hq : Want belS pr V θ q) :
+    Want belS pr V θ (fun w => p w ∨ q w) := by
+  unfold Want at hp hq ⊢
   have ⟨hMin, _hMax⟩ :=
     expectedValue_intermediate_disjoint pr V belS p q hPosP hPosQ hDisjoint
   exact lt_of_lt_of_le (lt_min hp hq) hMin

--- a/Linglib/Studies/Cariani2013.lean
+++ b/Linglib/Studies/Cariani2013.lean
@@ -72,10 +72,10 @@ Our `ought_negation_via_coarse_falsemaking` makes this precise.
 ## Cross-framework: structural agreement with Phillips-Brown
 
 Cariani's `visible` is **definitionally identical** to Phillips-Brown's
-`isConsidered` (`Semantics/Attitudes/Desire.lean`,
+`IsConsidered` (`Semantics/Attitudes/Desire.lean`,
 [phillips-brown-2025] §3.6) — so much so that we don't redefine
-it: `Cariani2013.isVisible` is an `abbrev` for `isConsidered` over the
-options list. The bridge theorem `isVisible_iff_isConsidered` is
+it: `Cariani2013.isVisible` is an `abbrev` for `IsConsidered` over the
+options list. The bridge theorem `isVisible_iff_IsConsidered` is
 `Iff.rfl`.
 
 This is **parallel discovery, not chain-of-influence**: Cariani 2013's
@@ -98,7 +98,7 @@ INHERITANCE." See `cariani_duality_right_to_left_failure`.
 
 namespace Cariani2013
 
-open Desire (DecProp mkDec isConsidered)
+open Desire (DecProp mkDec IsConsidered)
 
 /-! ## §1. Resolution Semantics primitives
 
@@ -148,7 +148,7 @@ instance (rc : ResolutionContext W) (o : DecProp W) :
 * `isWayOf`: option `o` is a way-of-`p` iff every world in `o` is a
   `p`-world (the option *entails* `p`).
 * `isVisible`: `p` is visible iff every option is a way-of-`p` or a
-  way-of-`¬p`. **Definitionally identical** to PB's `isConsidered` —
+  way-of-`¬p`. **Definitionally identical** to PB's `IsConsidered` —
   we use it as an alias.
 * `isPermissible`: some way-of-`p` option meets benchmark.
 * `isStronglyPermissible`: every way-of-`p` option meets benchmark.
@@ -165,12 +165,12 @@ instance (o : DecProp W) (p : Set W) [DecidablePred p] :
 
 /-- `p` is **visible** in Cariani's options iff every option settles `p`.
 
-    **Definitionally identical to Phillips-Brown's `isConsidered`** —
+    **Definitionally identical to Phillips-Brown's `IsConsidered`** —
     aliased rather than restipulated, per CLAUDE.md "import don't
     restipulate" discipline. The bridge theorem
-    `isVisible_iff_isConsidered` is `Iff.rfl`. -/
+    `isVisible_iff_IsConsidered` is `Iff.rfl`. -/
 abbrev isVisible (rc : ResolutionContext W) (p : Set W) [DecidablePred p] : Prop :=
-  isConsidered rc.options p
+  IsConsidered rc.options p
 
 /-- `p` is **permissible** iff some option that's a way-of-`p` meets
     benchmark. (Not used in Cariani's `ought` definition — used to
@@ -248,9 +248,9 @@ instance (rc : ResolutionContext W) (p : Set W) [DecidablePred p] :
     Decidable (permitted rc p) :=
   inferInstanceAs (Decidable (isPermissible rc p))
 
-/-! ## §4. Bridge to Phillips-Brown's `isConsidered`
+/-! ## §4. Bridge to Phillips-Brown's `IsConsidered`
 
-[phillips-brown-2025]'s `isConsidered`
+[phillips-brown-2025]'s `IsConsidered`
 (`Desire`) is *definitionally* the same
 predicate as Cariani's `isVisible`. Since `isVisible` is now an
 `abbrev` (§2 above), the bridge theorem is `Iff.rfl`.
@@ -261,12 +261,12 @@ agreement is independent reinvention. Linglib's "make agreements
 visible" thesis surfaces the structural identity. -/
 
 omit [Fintype W] [DecidableEq W] in
-/-- Cariani's `isVisible` and Phillips-Brown's `isConsidered` are the
+/-- Cariani's `isVisible` and Phillips-Brown's `IsConsidered` are the
     same predicate. Since `isVisible` is an `abbrev` over
-    `isConsidered`, the proof is `Iff.rfl`. -/
-theorem isVisible_iff_isConsidered
+    `IsConsidered`, the proof is `Iff.rfl`. -/
+theorem isVisible_iff_IsConsidered
     (rc : ResolutionContext W) (p : Set W) [DecidablePred p] :
-    isVisible rc p ↔ isConsidered rc.options p := Iff.rfl
+    isVisible rc p ↔ IsConsidered rc.options p := Iff.rfl
 
 /-! ## §5. INHERITANCE failure on Ross's Puzzle (paper §I)
 
@@ -683,13 +683,13 @@ theorem ross_ought_stay_home_false :
 
 /-! ## §11. Cross-framework summary
 
-* Cariani's `isVisible` ≡ Phillips-Brown's `isConsidered`
-  (`isVisible_iff_isConsidered` is `Iff.rfl` since `isVisible` is an
+* Cariani's `isVisible` ≡ Phillips-Brown's `IsConsidered`
+  (`isVisible_iff_IsConsidered` is `Iff.rfl` since `isVisible` is an
   abbrev). Parallel discovery (Cariani via Lewis/Yalcin; PB via Crnič
   2011), not chain-of-influence.
 * Cariani's account is *anti-INHERITANCE by design* (proved in §5
-  Ross, §6 Procrastinate, §9 DUALITY-concern). vF (`wantVonFintel`) and Heim
-  (`wantHeim`) are *pro-INHERITANCE* (their universal-over-best-worlds
+  Ross, §6 Procrastinate, §9 DUALITY-concern). vF (`WantVonFintel`) and Heim
+  (`WantHeim`) are *pro-INHERITANCE* (their universal-over-best-worlds
   shape entails it). Lassiter is anti-INHERITANCE via *intermediacy
   of E_V* (a different mechanism — see Lassiter2017.lean).
 * `Cariani.ought` satisfies COARSENESS (paper §1 p.534) and is

--- a/Linglib/Studies/CondoravdiLauer2016.lean
+++ b/Linglib/Studies/CondoravdiLauer2016.lean
@@ -45,7 +45,7 @@ paper-specific; tracked in
 
 ## Cross-references
 
-* `Semantics/Attitudes/CondoravdiLauer.lean` — `wantEffectivePreference` and
+* `Semantics/Attitudes/CondoravdiLauer.lean` — `WantEffectivePreference` and
   `wantEffectivePreference_jointly_belief_consistent` (the load-bearing lemma).
 * `Studies/vonFintelIatridou2005.lean` — vF&I's
   primary-secondary ordering source analysis that C&L 2016 critiques
@@ -85,7 +85,7 @@ def doubleModalLF {W : Type u} (fOuter : ModalBase W) (gOuter : OrderingSource W
 
 /-- [condoravdi-lauer-2016] eq. (88) at the operator level: the
 Harlem-sentence LF parameterised over its four contextual backgrounds.
-`NEC_{fBelS, gNorm}[wantEffectivePreference(Ad, Harlem)] [MUST_{fHist, gInner}[ATrain]]`.
+`NEC_{fBelS, gNorm}[WantEffectivePreference(Ad, Harlem)] [MUST_{fHist, gInner}[ATrain]]`.
 
 The four contextual parameters:
 * `fBelS` — modal base of NEC, "speaker's true beliefs" (paper p. 41).
@@ -105,7 +105,7 @@ def harlemLF {Agent W : Type u}
     (fHist : ModalBase W) (gInner : OrderingSource W)
     (Ad : Agent) (Harlem ATrain : Set W) (w : W) : Prop :=
   doubleModalLF fBelS gNorm
-    (fun w' => wantEffectivePreference EP Ad Harlem w')
+    (fun w' => WantEffectivePreference EP Ad Harlem w')
     (fun w' => necessity fHist gInner (· ∈ ATrain) w')
     w
 
@@ -118,7 +118,7 @@ theorem harlemLF_eq_doubleModalLF {Agent W : Type u}
     (Ad : Agent) (Harlem ATrain : Set W) (w : W) :
     harlemLF fBelS gNorm EP fHist gInner Ad Harlem ATrain w =
       doubleModalLF fBelS gNorm
-        (fun w' => wantEffectivePreference EP Ad Harlem w')
+        (fun w' => WantEffectivePreference EP Ad Harlem w')
         (fun w' => necessity fHist gInner (· ∈ ATrain) w')
         w :=
   rfl
@@ -207,8 +207,7 @@ noncomputable def EP : ∀ u w, EffectivePreference World (belAd u w) :=
 
 /-- At `wActual = w₀`: Ad effectively prefers Hoboken. -/
 theorem wantEffectivePreference_hoboken_at_wActual :
-    wantEffectivePreference EP () Hoboken wActual := by
-  refine wantExactMatch_iff.mpr ?_
+    WantEffectivePreference EP () Hoboken wActual := by
   show Hoboken ∈ (EP () wActual).toPreferenceStructure.maxElts
   simp only [EP, wActual]
   exact singletonPS_mem_maxElts Hoboken
@@ -218,7 +217,7 @@ By `wantEffectivePreference_jointly_belief_consistent`, if Ad effectively prefer
 Hoboken and Harlem, then `(Hoboken ∩ Harlem) ∩ B Ad wActual ≠ ∅`. But
 Hoboken ∩ Harlem = ∅, contradiction. -/
 theorem not_wantEffectivePreference_harlem_at_wActual :
-    ¬ wantEffectivePreference EP () Harlem wActual := by
+    ¬ WantEffectivePreference EP () Harlem wActual := by
   intro hHarlem
   have hHoboken := wantEffectivePreference_hoboken_at_wActual
   have h := wantEffectivePreference_jointly_belief_consistent EP hHoboken hHarlem
@@ -254,7 +253,7 @@ conflicting-goals problem § 2.3 raised against Sæbø 2001.
 
 Mechanism: the NEC's modal base is `fBelS = [(· = wActual)]`, so
 `accessibleWorlds fBelS wActual = {wActual}`. Restricting by the
-antecedent `wantEffectivePreference EP Ad Harlem` removes `wActual` from the accessible
+antecedent `WantEffectivePreference EP Ad Harlem` removes `wActual` from the accessible
 set (by `not_wantEffectivePreference_harlem_at_wActual`, derived from the consistency of
 EP and `Harlem ∩ Hoboken = ∅`), leaving the empty set. The NEC
 quantifies over `bestWorlds` of that empty set, which is empty, so the
@@ -270,7 +269,7 @@ theorem harlem_true_in_hoboken_scenario :
   intro w' hw'
   exfalso
   have hAcc : w' ∈ accessibleWorlds (restrictedBase fBelS
-      (fun w'' => wantEffectivePreference EP () Harlem w'')) wActual := hw'.1
+      (fun w'' => WantEffectivePreference EP () Harlem w'')) wActual := hw'.1
   rw [restricted_accessible_eq] at hAcc
   obtain ⟨hAccBase, hAntec⟩ := hAcc
   have hEq : w' = wActual := by

--- a/Linglib/Studies/Heim1992Desire.lean
+++ b/Linglib/Studies/Heim1992Desire.lean
@@ -16,17 +16,17 @@ world.
 This study file replicates the desire-semantics half of [heim-1992]
 (the presupposition-projection half is at
 `Studies/Heim1992.lean`). Substrate is
-`Semantics/Attitudes/Desire.lean` (`wantHeim`,
-`wantHeimDefined`, `HeimDesireParams`, `wantHeim_no_conflict`).
+`Semantics/Attitudes/Desire.lean` (`WantHeim`,
+`WantHeimDefined`, `HeimDesireParams`, `wantHeim_no_conflict`).
 
 ## §-by-§ map
 
 | Paper | Study file |
 |-------|-----------|
-| §3 naive Hintikka (informally rejected) | §2 (`wantHeimNaive` + Asher-style failure case) |
+| §3 naive Hintikka (informally rejected) | §2 (`WantHeimNaive` + Asher-style failure case) |
 | (32) Asher Concorde example, p. 194 | §2 (analog scenario; see §2 caveat) |
-| §4.2.2 (37/39) CCP-rephrased | §3 / substrate `wantHeim` |
-| §4.2.3 (40) amendment | substrate `wantHeimDefined` |
+| §4.2.2 (37/39) CCP-rephrased | §3 / substrate `WantHeim` |
+| §4.2.3 (40) amendment | substrate `WantHeimDefined` |
 | §4.3 conflicting desires (implicit) | §4 (substrate no-go) |
 | Stalnaker get-well/¬have-been-sick (p. 195) | §5 (deferred — needs richer model) |
 
@@ -61,7 +61,7 @@ Models the Stalnaker [stalnaker-1984]-style example "I want to
 get well [recovered] but I don't want to have been sick" — the agent
 prefers `r ∧ ¬s` worlds (recovered without ever being sick) but believes
 they were sick (so all believed worlds have `s`). The (40) amendment
-makes `wantHeim ¬s` undefined under those beliefs. -/
+makes `WantHeim ¬s` undefined under those beliefs. -/
 
 inductive W where
   | w0 | w1 | w2 | w3
@@ -106,7 +106,7 @@ instance : DecidablePred belSick := inferInstanceAs (DecidablePred sick)
     ascription can be true, so the naive rule is inadequate — this
     motivates the move to a comparative semantics. -/
 theorem naive_predicts_false_for_wants_recover :
-    ¬ wantHeimNaive belSick recovered := by
+    ¬ WantHeimNaive belSick recovered := by
   intro h
   have : recovered .w2 := h .w2 (by decide : belSick .w2)
   exact this
@@ -139,11 +139,11 @@ def heimParams : HeimDesireParams W where
 
 instance : DecidablePred (Set.univ : Set W) := fun _ => isTrue trivial
 
-/-- The (40) amendment: `wantHeim recovered` is defined under
+/-- The (40) amendment: `WantHeim recovered` is defined under
     `Set.univ` (both recovered and ¬recovered worlds are believed
     possible). -/
 theorem wantHeim_recovered_defined :
-    wantHeimDefined (Set.univ : Set W) recovered := by
+    WantHeimDefined (Set.univ : Set W) recovered := by
   refine ⟨⟨.w0, ?_, ?_⟩, ⟨.w2, ?_, ?_⟩⟩ <;> decide
 
 /-! ## §4. Heim (40) does not validate simultaneous `want p ∧ want ¬p`
@@ -152,7 +152,7 @@ A side-effect of (40) — flagged by Heim herself in §4.3 (cf. (41)/(42),
 where she worries that (40) is in fact *too* restrictive and proposes
 shrinking Dox to a "favored" subset F_α) — is that under preference
 asymmetry, no `(belS, w_eval)` configuration validates both
-`wantHeim p` and `wantHeim ¬p`. The substrate theorem
+`WantHeim p` and `WantHeim ¬p`. The substrate theorem
 `wantHeim_no_conflict` discharges this generically.
 
 Whether this side-effect is a virtue (Heim's account *correctly*
@@ -173,11 +173,11 @@ theorem prefRecovered_asymm (w_eval : W) :
   exact absurd hy hny
 
 /-- Witness on this concrete model: under `Set.univ`, no
-    `wantHeim recovered ∧ wantHeim ¬recovered` configuration is
+    `WantHeim recovered ∧ WantHeim ¬recovered` configuration is
     consistent. Delegates to the substrate's general theorem. -/
 theorem heim_no_simultaneous_recovered :
-    ¬ (wantHeim (Set.univ : Set W) heimParams .w0 recovered ∧
-       wantHeim (Set.univ : Set W) heimParams .w0 (fun w => ¬ recovered w)) :=
+    ¬ (WantHeim (Set.univ : Set W) heimParams .w0 recovered ∧
+       WantHeim (Set.univ : Set W) heimParams .w0 (fun w => ¬ recovered w)) :=
   wantHeim_no_conflict (Set.univ : Set W) heimParams .w0
     recovered (prefRecovered_asymm .w0) wantHeim_recovered_defined
 

--- a/Linglib/Studies/Lassiter2017.lean
+++ b/Linglib/Studies/Lassiter2017.lean
@@ -20,7 +20,7 @@ This study file:
   `wantEffectivePreference_jointly_belief_consistent` forbids the witness; the
   Lassiter bare apparatus exhibits it. **Different mechanisms.**
 * §4 cross-paper bridge to [heim-1992]: same configuration is
-  `wantHeimDefined`-OK, but `wantHeim_no_conflict`
+  `WantHeimDefined`-OK, but `wantHeim_no_conflict`
   rules out joint truth. **Heim's (40) amendment is the structural
   analog of Lassiter's Sloman.**
 * §5 **Sloman's Principle blocks the witness** for Lassiter's *full*
@@ -85,27 +85,27 @@ instance : DecidablePred targetProp := fun w => by unfold targetProp; infer_inst
 `E_V(¬p | belS) = (1/4 · 4 + 1/4 · 0) / (1/4 + 1/4) = 1 / (1/2) = 2`
 With θ = 3/2, both are above threshold → both are wanted. -/
 
-theorem want_p : Lassiter.want belTotal prior value threshold targetProp := by
-  unfold Lassiter.want Lassiter.expectedValue targetProp belTotal prior value threshold
+theorem want_p : Lassiter.Want belTotal prior value threshold targetProp := by
+  unfold Lassiter.Want Lassiter.expectedValue targetProp belTotal prior value threshold
   simp [Fin.sum_univ_succ]
   norm_num
 
 theorem want_negp :
-    Lassiter.want belTotal prior value threshold (fun w => ¬ targetProp w) := by
-  unfold Lassiter.want Lassiter.expectedValue targetProp belTotal prior value threshold
+    Lassiter.Want belTotal prior value threshold (fun w => ¬ targetProp w) := by
+  unfold Lassiter.Want Lassiter.expectedValue targetProp belTotal prior value threshold
   simp [Fin.sum_univ_succ]
   norm_num
 
 theorem conflict_concrete :
-    Lassiter.want belTotal prior value threshold targetProp ∧
-    Lassiter.want belTotal prior value threshold (fun w => ¬ targetProp w) :=
+    Lassiter.Want belTotal prior value threshold targetProp ∧
+    Lassiter.Want belTotal prior value threshold (fun w => ¬ targetProp w) :=
   ⟨want_p, want_negp⟩
 
 /-! ## §3. Cross-paper bridge: [condoravdi-lauer-2016]
 
 C&L's `wantEffectivePreference_jointly_belief_consistent` says that for any
 effective-preference background `EP` and any agent `a`, world `w`,
-`wantEffectivePreference EP a φ w ∧ wantEffectivePreference EP a ψ w`
+`WantEffectivePreference EP a φ w ∧ WantEffectivePreference EP a ψ w`
 implies `(φ ∩ ψ) ∩ B(a, w) ≠ ∅`.
 Specialized to `ψ = φᶜ`: the intersection is empty, so simultaneous
 truth is impossible.
@@ -115,14 +115,14 @@ configuration. The two frameworks make orthogonal predictions on the
 4-world model. -/
 
 /-- C&L blocks any pair
-    `wantEffectivePreference φ ∧ wantEffectivePreference ¬φ` —
+    `WantEffectivePreference φ ∧ WantEffectivePreference ¬φ` —
     C&L cannot reproduce Lassiter's witness. -/
 theorem condoravdiLauer_blocks_lassiter_witness
     {Agent : Type} {B : Agent → W → Set W}
     (EP : ∀ a w, EffectivePreference W (B a w))
     (a : Agent) (w : W) (φ : Set W)
-    (hφ : Desire.wantEffectivePreference EP a φ w)
-    (hnegφ : Desire.wantEffectivePreference EP a (fun w => ¬ φ w) w) :
+    (hφ : Desire.WantEffectivePreference EP a φ w)
+    (hnegφ : Desire.WantEffectivePreference EP a (fun w => ¬ φ w) w) :
     False := by
   have h := Desire.wantEffectivePreference_jointly_belief_consistent
               EP hφ hnegφ
@@ -134,9 +134,9 @@ theorem condoravdiLauer_blocks_lassiter_witness
 /-! ## §4. Cross-paper bridge: [heim-1992]
 
 Heim's (40) amendment + comparative-belief semantics block simultaneous
-`wantHeim p ∧ wantHeim ¬p` (substrate's
+`WantHeim p ∧ WantHeim ¬p` (substrate's
 `wantHeim_no_conflict`). The 4-world conflict witness
-configuration is `wantHeimDefined`-OK on `targetProp` (both p-worlds
+configuration is `WantHeimDefined`-OK on `targetProp` (both p-worlds
 and ¬p-worlds are in `belTotal`), so Heim's no-go applies — and Heim's
 prediction differs from Lassiter's.
 
@@ -145,18 +145,18 @@ that Sloman plays for Lassiter — both block single-V/single-context
 conflict. -/
 
 theorem wantHeimDefined_on_witness :
-    wantHeimDefined belTotal targetProp := by
+    WantHeimDefined belTotal targetProp := by
   refine ⟨⟨0, ?_, ?_⟩, ⟨2, ?_, ?_⟩⟩ <;> decide
 
 /-- On the witness configuration, Heim's no-go theorem applies — for
     any Heim parameters with strictly asymmetric desirability,
-    `wantHeim` cannot make both `targetProp` and its negation true.
+    `WantHeim` cannot make both `targetProp` and its negation true.
     Direct application of the substrate theorem. -/
 theorem heim_blocks_witness
     (params : HeimDesireParams W) (w_eval : W)
     (hAsym : ∀ x y, params.pref w_eval x y → params.pref w_eval y x → x = y) :
-    ¬ (wantHeim belTotal params w_eval targetProp ∧
-       wantHeim belTotal params w_eval (fun w => ¬ targetProp w)) :=
+    ¬ (WantHeim belTotal params w_eval targetProp ∧
+       WantHeim belTotal params w_eval (fun w => ¬ targetProp w)) :=
   wantHeim_no_conflict belTotal params w_eval targetProp
     hAsym wantHeimDefined_on_witness
 
@@ -173,7 +173,7 @@ On the witness model with `alts = [targetProp, ¬targetProp]`:
 - Sloman for `targetProp`: requires `7 > 2` ✓.
 - Sloman for `¬targetProp`: requires `2 > 7` ✗.
 
-So `wantWithSloman` blocks the conflict on this configuration —
+So `WantWithSloman` blocks the conflict on this configuration —
 matching Lassiter's actual stated position. The bare-threshold witness
 is exhibited by `conflict_concrete` *only because* it ignores Sloman;
 Lassiter himself would say this is the wrong way to formalize his
@@ -195,8 +195,8 @@ theorem targetProp_ne_negTargetProp : (targetProp : Set W) ≠ (fun w => ¬ targ
     Principle. Direct instance of the substrate theorem
     `wantWithSloman_blocks_conflict`. -/
 theorem wantWithSloman_blocks_conflict_on_witness :
-    ¬ (Lassiter.wantWithSloman belTotal prior value threshold witnessAlts targetProp ∧
-       Lassiter.wantWithSloman belTotal prior value threshold witnessAlts
+    ¬ (Lassiter.WantWithSloman belTotal prior value threshold witnessAlts targetProp ∧
+       Lassiter.WantWithSloman belTotal prior value threshold witnessAlts
          (fun w => ¬ targetProp w)) :=
   Lassiter.wantWithSloman_blocks_conflict belTotal prior value threshold targetProp
     witnessAlts (by simp [witnessAlts]) (by simp [witnessAlts])

--- a/Linglib/Studies/Pasternak2019.lean
+++ b/Linglib/Studies/Pasternak2019.lean
@@ -71,7 +71,7 @@ do not exist. Corrected:
   `PartialOrder (Event Time)` instance Pasternak's part-whole relation
   consumes). Not a substrate gap; a refinement.
 - §5 `want`/`wish`/`regret`: `Semantics/Attitudes/Desire.lean`
-  already provides `wantVonFintel` (von Fintel-style) and
+  already provides `WantVonFintel` (von Fintel-style) and
   `worldSatisfactionOrdering`. The Pasternak §5 integration is a
   composition with the new `MentalStateHomogeneity` discipline, not
   fresh substrate.
@@ -434,8 +434,8 @@ follow-up. Out of scope here because it is not load-bearing for §1–§6.
 Pasternak §5 integrates Hintikkan world-quantification into the two-
 dimensional ontology via point-states (eq. 67), `WANT_vF` (eq. 73,
 [von-fintel-1999]), `WANT_H` (eq. 91, [heim-1992]), and DOG.
-The substrate has `Attitudes.Desire.wantVonFintel` and
-`Attitudes.Desire.worldAtLeastAsGood` already; the Pasternak §5
+The substrate has `Attitudes.Desire.WantVonFintel` and
+`Attitudes.Desire.WorldAtLeastAsGood` already; the Pasternak §5
 integration is a composition with `MentalStateHomogeneity`, not new
 substrate. A follow-on `Pasternak2019Attitudes.lean` (or extension of
 this file) is the natural next paper-level deepening, alongside
@@ -444,8 +444,8 @@ linglib bib yet.
 
 The chronologically-later [phillips-brown-2025] formalization
 (`Studies/PhillipsBrown2025.lean`) builds on the same
-`Attitudes.Desire` substrate, generalizing `wantVonFintel` to question-based
-`wantQuestionBased`. That study file's §11 makes the disagreement with
+`Attitudes.Desire` substrate, generalizing `WantVonFintel` to question-based
+`WantQuestionBased`. That study file's §11 makes the disagreement with
 [condoravdi-lauer-2016] explicit; the analogous Pasternak vs
 question-based contrast (intensity-based vs question-based resolution
 of conflicting desires) is left as future work.

--- a/Linglib/Studies/PhillipsBrown2025.lean
+++ b/Linglib/Studies/PhillipsBrown2025.lean
@@ -40,13 +40,13 @@ delegate to the substrate's general theorems
 
 ## Parallel discovery: Cariani 2013 `isVisible`
 
-PB's `isConsidered` (§3.6) is the same predicate as [cariani-2013]'s
+PB's `IsConsidered` (§3.6) is the same predicate as [cariani-2013]'s
 `isVisible` (§4 p.545–546): both require every cell of the
 partition/option-set to settle the prejacent. PB doesn't cite Cariani;
 Cariani doesn't anticipate PB. The identification is exposed in
 `Studies/Cariani2013.lean`, where Cariani's
-`isVisible` is defined as `abbrev isVisible rc p := isConsidered
-rc.options p` and the bridge theorem `isVisible_iff_isConsidered`
+`isVisible` is defined as `abbrev isVisible rc p := IsConsidered
+rc.options p` and the bridge theorem `isVisible_iff_IsConsidered`
 reduces to `Iff.rfl`. The agreement is independent reinvention across
 the desire/deontic-modality boundary, surfaced by the substrate sharing
 a common predicate.
@@ -99,8 +99,8 @@ instance : DecidablePred pass := fun w => by cases w <;> unfold pass <;> infer_i
 instance : DecidablePred fail := fun w => by unfold fail; infer_instance
 
 /-- The natural propositions of the model (basic dimensions), used to
-    feed `isAntiDeckstacking`. AD's quantifier is restricted to this
-    test set — see `Desire.isAntiDeckstacking` docstring. -/
+    feed `IsAntiDeckstacking`. AD's quantifier is restricted to this
+    test set — see `Desire.IsAntiDeckstacking` docstring. -/
 def naturalProps : List (DecProp W) :=
   [mkDec nap, mkDec rested, mkDec pass]
 
@@ -132,21 +132,21 @@ def desRest : List (DecProp W) := [mkDec rested]
 def desPass : List (DecProp W) := [mkDec pass]
 
 /-- **Nap is true** relative to Q' with beliefs nap↔rested, desires [rested]. -/
-theorem nap_true : wantQuestionBased belNapRest desRest qNapRest nap := by decide
+theorem nap_true : WantQuestionBased belNapRest desRest qNapRest nap := by decide
 
 /-- **Not-nap is true** relative to Q'' with beliefs pass↔¬nap, desires [pass]. -/
 theorem not_nap_true :
-    wantQuestionBased belNapPass desPass qNapPass (fun w => ¬ nap w) := by decide
+    WantQuestionBased belNapPass desPass qNapPass (fun w => ¬ nap w) := by decide
 
 /-- Fail is NOT considered relative to Q'. -/
-theorem fail_not_considered : ¬ isConsidered qNapRest fail := by decide
+theorem fail_not_considered : ¬ IsConsidered qNapRest fail := by decide
 
 /-- Fail is also not predicted true. -/
 theorem fail_not_true :
-    ¬ wantQuestionBased belNapRest desRest qNapRest fail := by decide
+    ¬ WantQuestionBased belNapRest desRest qNapRest fail := by decide
 
 /-- Q' is diverse w.r.t. nap. -/
-theorem nap_diverse : isDiverse qNapRest nap := by decide
+theorem nap_diverse : IsDiverse qNapRest nap := by decide
 
 /-! ## §4. Lobster scenario (paper §2.2)
 
@@ -177,21 +177,21 @@ def desNotDie : List (DecProp W) := [mkDec (fun w => ¬ fail w)]
 
 /-- **Lobster is true** in c'' (considering taste, ignoring death). -/
 theorem lobster_true :
-    wantQuestionBased belNapRest desRest qLobGus lobster := nap_true
+    WantQuestionBased belNapRest desRest qLobGus lobster := nap_true
 
 /-- **Die is undefined in the Lobster context c''** (paper §2.2): in
     `qLobGus = qNapRest`, no cell settles `die`, so the Considering
     presupposition fails. -/
 theorem die_not_considered_in_qLobGus :
-    ¬ isConsidered qLobGus die := fail_not_considered
+    ¬ IsConsidered qLobGus die := fail_not_considered
 
 /-- **Not-lobster is true** in c''' (considering death, ignoring taste). -/
 theorem not_lobster_true :
-    wantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ nap w) := by decide
+    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ nap w) := by decide
 
 /-- **Not-die is also true** in c''' (best answer entails both ¬lobster and ¬die). -/
 theorem not_die_true :
-    wantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ fail w) := by decide
+    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ fail w) := by decide
 
 /-! ## §5. Von Fintel comparison and the no-go theorem
 
@@ -200,24 +200,24 @@ predict both `want p` and `want ¬p` simultaneously. Specialised here
 for the Nap example, then derived from the substrate's general
 `wantVonFintel_no_conflict`. -/
 
-theorem vf_nap_true : wantVonFintel belNapRest desRest nap := by decide
+theorem vf_nap_true : WantVonFintel belNapRest desRest nap := by decide
 
 theorem vf_not_nap_false :
-    ¬ wantVonFintel belNapRest desRest (fun w => ¬ nap w) := by decide
+    ¬ WantVonFintel belNapRest desRest (fun w => ¬ nap w) := by decide
 
 /-- vF cannot predict both Nap and Not-nap with the same parameter set
     (specific instance). -/
 theorem vf_cannot_predict_both :
-    ¬(wantVonFintel belNapRest desRest nap ∧
-      wantVonFintel belNapRest desRest (fun w => ¬ nap w)) := by
+    ¬(WantVonFintel belNapRest desRest nap ∧
+      WantVonFintel belNapRest desRest (fun w => ¬ nap w)) := by
   intro ⟨_, h⟩; exact vf_not_nap_false h
 
 /-- vF cannot predict both Nap and Not-nap (general no-go, delegates
     to the substrate). The witness is any belS-world that is
     Pareto-undominated under the desire ordering. -/
 theorem vf_no_conflict_nap :
-    ¬ (wantVonFintel belNapRest desRest nap ∧
-       wantVonFintel belNapRest desRest (fun w => ¬ nap w)) :=
+    ¬ (WantVonFintel belNapRest desRest nap ∧
+       WantVonFintel belNapRest desRest (fun w => ¬ nap w)) :=
   wantVonFintel_no_conflict belNapRest desRest nap
     ⟨.w0, by decide,
      by intro z hz ⟨_, hbad⟩; revert hz hbad; cases z <;> decide⟩
@@ -235,10 +235,10 @@ With Q'' (the nap × pass partition), `fail` is settled — and the
 contrast is exactly the paper's point. -/
 
 theorem nap_considered_in_qNapPass :
-    isConsidered qNapPass nap := by decide
+    IsConsidered qNapPass nap := by decide
 
 theorem fail_considered_in_qNapPass :
-    isConsidered qNapPass fail := by decide
+    IsConsidered qNapPass fail := by decide
 
 /-! ## §7. Anti-deckstacking (paper §3.7)
 
@@ -276,7 +276,7 @@ def desHappy : List (DecProp W) := [mkDec happy]
 /-- `happy` is not considered in the deck-stacked Q'''' (the `rain`
     cell contains both happy and unhappy worlds). -/
 theorem happy_not_considered_deckstacked :
-    ¬ isConsidered qDeckstacked happy := by decide
+    ¬ IsConsidered qDeckstacked happy := by decide
 
 /-- A `happy`-answer exists in qDeckstacked (the `¬r∧h` cell entails
     `happy`) — the deck is stacked in favor of ¬rain. -/
@@ -286,7 +286,7 @@ theorem happy_answer_exists_deckstacked :
 /-- Without the constraint, the question-based semantics wrongly
     predicts Not-rain. -/
 theorem not_rain_deckstacked_true :
-    wantQuestionBased belLu desHappy qDeckstacked (fun w => ¬ rain w) := by decide
+    WantQuestionBased belLu desHappy qDeckstacked (fun w => ¬ rain w) := by decide
 
 /-- Q''''' (level playing field): partition by rain × happy. -/
 def qRainHappy : List (DecProp W) :=
@@ -296,29 +296,29 @@ def qRainHappy : List (DecProp W) :=
    mkDec (fun w => ¬ rain w ∧ ¬ happy w)]
 
 theorem happy_considered_fair :
-    isConsidered qRainHappy happy := by decide
+    IsConsidered qRainHappy happy := by decide
 
 /-- With the fair question, Not-rain is correctly predicted false. -/
 theorem not_rain_false_fair :
-    ¬ wantQuestionBased belLu desHappy qRainHappy (fun w => ¬ rain w) := by decide
+    ¬ WantQuestionBased belLu desHappy qRainHappy (fun w => ¬ rain w) := by decide
 
 /-- The deck-stacked question fails Anti-deckstacking on test set
     `[r, h]` (`h` is predetermined by the `¬r∧h` cell but not
     considered by Q''''). -/
 theorem qDeckstacked_fails_antideckstacking :
-    ¬ isAntiDeckstacking naturalPropsLu qDeckstacked := by decide
+    ¬ IsAntiDeckstacking naturalPropsLu qDeckstacked := by decide
 
 /-- The fair (cross-product) question satisfies Anti-deckstacking —
     every basic proposition is settled by every cell. -/
 theorem qRainHappy_satisfies_antideckstacking :
-    isAntiDeckstacking naturalPropsLu qRainHappy := by decide
+    IsAntiDeckstacking naturalPropsLu qRainHappy := by decide
 
 /-- Q' (`qNapRest`) satisfies Anti-deckstacking on the natural-prop
     test set `[nap, rested, pass]` — the cross-product over `nap` and
     `rested` settles `nap` and `rested`; no cell entails `pass`, so
     AD's antecedent is vacuous for `pass`. -/
 theorem qNapRest_satisfies_antideckstacking :
-    isAntiDeckstacking naturalProps qNapRest := by decide
+    IsAntiDeckstacking naturalProps qNapRest := by decide
 
 /-! ## §8. Finest-question simulation (paper §3.4)
 
@@ -332,42 +332,42 @@ def allWorldsW : List W := [.w0, .w1, .w2, .w3, .w4, .w5, .w6, .w7]
 def qFinest : List (DecProp W) := finestPartition allWorldsW
 
 /-- The 8-world list `allWorldsW` covers `W`. Hypothesis required by the
-    substrate's general `wantQuestionBased_finestPartition_iff_wantVonFintel`. -/
+    substrate's general `wantQuestionBased_finestPartition_iff_WantVonFintel`. -/
 theorem allWorldsW_complete : ∀ w : W, w ∈ allWorldsW := by
   intro w; cases w <;> decide
 
 /-- With the finest question, question-based want = standard vF want
     for `nap`. Derived from the substrate's general
-    `wantQuestionBased_finestPartition_iff_wantVonFintel`, not by `decide`. -/
+    `wantQuestionBased_finestPartition_iff_WantVonFintel`, not by `decide`. -/
 theorem finest_simulates_vf_nap :
-    wantQuestionBased belNapRest desRest qFinest nap ↔
-    wantVonFintel belNapRest desRest nap :=
-  wantQuestionBased_finestPartition_iff_wantVonFintel belNapRest desRest
+    WantQuestionBased belNapRest desRest qFinest nap ↔
+    WantVonFintel belNapRest desRest nap :=
+  wantQuestionBased_finestPartition_iff_WantVonFintel belNapRest desRest
     allWorldsW allWorldsW_complete nap
 
 /-- With the finest question, question-based want = standard vF want
     for `¬nap`. -/
 theorem finest_simulates_vf_not_nap :
-    wantQuestionBased belNapRest desRest qFinest (fun w => ¬ nap w) ↔
-    wantVonFintel belNapRest desRest (fun w => ¬ nap w) :=
-  wantQuestionBased_finestPartition_iff_wantVonFintel belNapRest desRest
+    WantQuestionBased belNapRest desRest qFinest (fun w => ¬ nap w) ↔
+    WantVonFintel belNapRest desRest (fun w => ¬ nap w) :=
+  wantQuestionBased_finestPartition_iff_WantVonFintel belNapRest desRest
     allWorldsW allWorldsW_complete (fun w => ¬ nap w)
 
 /-- With the finest question, question-based want = standard vF want
     for `¬lobster` in the Lobster context. -/
 theorem finest_simulates_vf_not_lobster :
-    wantQuestionBased belLobDie desNotDie qFinest (fun w => ¬ nap w) ↔
-    wantVonFintel belLobDie desNotDie (fun w => ¬ nap w) :=
-  wantQuestionBased_finestPartition_iff_wantVonFintel belLobDie desNotDie
+    WantQuestionBased belLobDie desNotDie qFinest (fun w => ¬ nap w) ↔
+    WantVonFintel belLobDie desNotDie (fun w => ¬ nap w) :=
+  wantQuestionBased_finestPartition_iff_WantVonFintel belLobDie desNotDie
     allWorldsW allWorldsW_complete (fun w => ¬ nap w)
 
 /-! ## §9. Definedness via PartialProp (paper §3.6) -/
 
 theorem nap_defined_in_qNapRest :
-    wantDefined belNapRest naturalProps qNapRest nap := by decide
+    WantDefined belNapRest naturalProps qNapRest nap := by decide
 
 theorem fail_not_defined_in_qNapRest :
-    ¬ wantDefined belNapRest naturalProps qNapRest fail := by decide
+    ¬ WantDefined belNapRest naturalProps qNapRest fail := by decide
 
 theorem nap_prprop_holds :
     (wantPartialProp belNapRest desRest naturalProps qNapRest nap).presup .w0 ∧
@@ -386,8 +386,8 @@ he lacked the conceptual resources to grasp nuclear war.
 
 Mechanism: William's beliefs are NOT sensitive to Q_nuc that
 distinguishes nuclear from conventional war. All Q_nuc answers are
-compatible with his beliefs (total uncertainty), so `isBelSensitive`
-returns false and `wantDefined` blocks the inference. A modern person
+compatible with his beliefs (total uncertainty), so `IsBelSensitive`
+returns false and `WantDefined` blocks the inference. A modern person
 whose beliefs rule out nuclear war DOES have belief-sensitive context,
 so the inference goes through.
 
@@ -420,38 +420,38 @@ theorem avoidWar_entails_avoidNuclearWar :
     ∀ w, avoidWar w → avoidNuclearWar w := by decide
 
 theorem avoidNuclearWar_considered :
-    isConsidered qNuclear avoidNuclearWar := by decide
+    IsConsidered qNuclear avoidNuclearWar := by decide
 
 /-- William III: total uncertainty (all worlds compatible). -/
 def belWilliam : Set W := fun _ => True
 instance : DecidablePred belWilliam := fun _ => isTrue trivial
 
 theorem william_insensitive :
-    ¬ isBelSensitive belWilliam qNuclear := by decide
+    ¬ IsBelSensitive belWilliam qNuclear := by decide
 
 theorem avoidNuclearWar_not_defined_william :
-    ¬ wantDefined belWilliam naturalPropsNuclear qNuclear avoidNuclearWar := by decide
+    ¬ WantDefined belWilliam naturalPropsNuclear qNuclear avoidNuclearWar := by decide
 
 /-- Modern person: beliefs rule out nuclear war (peace ∨ conventional). -/
 def belModern : Set W := fun w => nap w ∨ rested w
 instance : DecidablePred belModern := fun w => by unfold belModern; infer_instance
 
 theorem modern_sensitive :
-    isBelSensitive belModern qNuclear := by decide
+    IsBelSensitive belModern qNuclear := by decide
 
 theorem avoidNuclearWar_defined_modern :
-    wantDefined belModern naturalPropsNuclear qNuclear avoidNuclearWar := by decide
+    WantDefined belModern naturalPropsNuclear qNuclear avoidNuclearWar := by decide
 
 def desAvoidWar : List (DecProp W) := [mkDec nap]
 
 theorem modern_wants_avoidNuclearWar :
-    wantQuestionBased belModern desAvoidWar qNuclear avoidNuclearWar := by decide
+    WantQuestionBased belModern desAvoidWar qNuclear avoidNuclearWar := by decide
 
 /-! ## §11. Cross-paper bridge: [condoravdi-lauer-2016]
 
-[condoravdi-lauer-2016]'s effective-preferential `wantEffectivePreference` carries
+[condoravdi-lauer-2016]'s effective-preferential `WantEffectivePreference` carries
 a joint-belief-consistency theorem (`wantEffectivePreference_jointly_belief_consistent`):
-if both `wantEffectivePreference EP a φ w` and `wantEffectivePreference EP a ψ w` hold, then
+if both `WantEffectivePreference EP a φ w` and `WantEffectivePreference EP a ψ w` hold, then
 `(φ ∩ ψ) ∩ B(a, w) ≠ ∅`. Specialized to `ψ = φᶜ`, the conclusion
 becomes `∅ ∩ B(a, w) ≠ ∅`, which is contradictory. So C&L *forbids*
 simultaneous `want(p)` and `want(¬p)` against a single belief state and
@@ -460,7 +460,7 @@ preference structure.
 [phillips-brown-2025] resolves the conflict by varying the
 contextual question Q_c (and the contextually-relevant `belS`) per
 ascription. C&L resolves it by varying the preference structure (per
-reading: `wantExactMatch` / `wantSuccessOriented` / `wantQuineHintikka`). The two
+reading: `WantExactMatch` / `WantSuccessOriented` / `WantQuineHintikka`). The two
 resolutions are orthogonal — both can coexist in a unified theory of
 desire, but they make non-overlapping claims. -/
 
@@ -476,8 +476,8 @@ theorem condoravdiLauer_blocks_simultaneous_pq_and_negpq
     {Agent W : Type} {B : Agent → W → Set W}
     (EP : ∀ a w, EffectivePreference W (B a w))
     (a : Agent) (φ : Set W) (w : W)
-    (hφ : Desire.wantEffectivePreference EP a φ w)
-    (hnegφ : Desire.wantEffectivePreference EP a (fun w => ¬ φ w) w) :
+    (hφ : Desire.WantEffectivePreference EP a φ w)
+    (hnegφ : Desire.WantEffectivePreference EP a (fun w => ¬ φ w) w) :
     False := by
   have h := Desire.wantEffectivePreference_jointly_belief_consistent
               EP hφ hnegφ
@@ -498,7 +498,7 @@ Heim are instances (`vonFintelSemantics`, `heimSemantics`), each proved
 conflict-blocking by delegation to the substrate's per-account no-go
 theorems (`wantVonFintel_no_conflict`, `wantHeim_no_conflict`).
 
-PB's `wantQuestionBased` *evades* the no-go by selecting from
+PB's `WantQuestionBased` *evades* the no-go by selecting from
 `Q-Bel_S` rather than directly from `Bel_S` — it is *not* an
 instance of `BeliefBasedDesireSemantics` (the question parameter
 `answers` plays a non-trivial role outside the shape). -/
@@ -520,7 +520,7 @@ structure BeliefBasedDesireSemantics (W : Type*) where
 /-- A semantics is **conflict-blocking** if no parameters/world make
     `want(p)` and `want(¬p)` both true when both are defined — the
     paper's §2 no-go in slogan form. -/
-def BeliefBasedDesireSemantics.isConflictBlocking
+def BeliefBasedDesireSemantics.IsConflictBlocking
     {W : Type*} (F : BeliefBasedDesireSemantics W) : Prop :=
   ∀ belS Param w_eval (p : Set W),
     F.defined belS Param p → F.defined belS Param (fun w => ¬ p w) →
@@ -533,23 +533,23 @@ def vonFintelSemantics {W : Type*} [Fintype W] :
     BeliefBasedDesireSemantics W where
   Param := List (DecProp W)
   defined belS _ p := (∃ w, belS w ∧ p w) ∧ (∃ w, belS w ∧ ¬ p w)
-  want belS GS _ p := wantVonFintel belS GS p
+  want belS GS _ p := WantVonFintel belS GS p
 
-/-- `wantHeim` with decidability supplied classically, so the structure
+/-- `WantHeim` with decidability supplied classically, so the structure
     projection of `heimSemantics` is stable across ambient instances. -/
-noncomputable def wantHeimClassical {W : Type*} [Fintype W] [DecidableEq W]
+noncomputable def WantHeimClassical {W : Type*} [Fintype W] [DecidableEq W]
     (belS : Set W) (params : HeimDesireParams W) (w_eval : W) (p : Set W) : Prop :=
   letI : DecidablePred belS := Classical.decPred _
   letI : DecidablePred p := Classical.decPred _
-  wantHeim belS params w_eval p
+  WantHeim belS params w_eval p
 
-/-- The classical-decidability variant agrees with `wantHeim` under any
+/-- The classical-decidability variant agrees with `WantHeim` under any
     ambient decidability instances (`DecidablePred` is a subsingleton). -/
-theorem wantHeimClassical_iff_wantHeim {W : Type*} [Fintype W] [DecidableEq W]
+theorem wantHeimClassical_iff_WantHeim {W : Type*} [Fintype W] [DecidableEq W]
     (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p] :
-    wantHeimClassical belS params w_eval p ↔ wantHeim belS params w_eval p := by
-  unfold wantHeimClassical
+    WantHeimClassical belS params w_eval p ↔ WantHeim belS params w_eval p := by
+  unfold WantHeimClassical
   congr!
 
 /-- Heim as a `BeliefBasedDesireSemantics` instance: definedness is her
@@ -559,19 +559,19 @@ noncomputable def heimSemantics {W : Type*} [Fintype W] [DecidableEq W] :
   Param := HeimDesireParams W
   defined belS _ p :=
     (∃ w, belS w ∧ p w) ∧ (∃ w, belS w ∧ ¬ p w)
-  want belS params w_eval p := wantHeimClassical belS params w_eval p
+  want belS params w_eval p := WantHeimClassical belS params w_eval p
 
 /-- von Fintel is **conflict-blocking**: delegates to
     `wantVonFintel_no_conflict` after extracting a Pareto-undominated
     belS-world via finite-preorder minimal-element existence. -/
-theorem vonFintelSemantics_isConflictBlocking {W : Type*} [Fintype W] :
-    (vonFintelSemantics (W := W)).isConflictBlocking := by
+theorem vonFintelSemantics_IsConflictBlocking {W : Type*} [Fintype W] :
+    (vonFintelSemantics (W := W)).IsConflictBlocking := by
   classical
   intro belS GS _w_eval p hDef _hDefNeg ⟨hp, hnp⟩
   apply Desire.wantVonFintel_no_conflict belS GS p ?_ ⟨hp, hnp⟩
   obtain ⟨wp, hwp_bel, _⟩ := hDef.1
   let _ : Preorder W :=
-    { le := worldAtLeastAsGood GS
+    { le := WorldAtLeastAsGood GS
       le_refl := fun _ _ _ hp_w => hp_w
       le_trans := fun _ _ _ huv hvw q hq hqz => huv q hq (hvw q hq hqz) }
   have hbelNonempty : (belS : Set W).Nonempty := ⟨wp, hwp_bel⟩
@@ -580,7 +580,7 @@ theorem vonFintelSemantics_isConflictBlocking {W : Type*} [Fintype W] :
 
 /-- Heim is **conflict-blocking** at any `(params, w_eval)` with strict
     preference asymmetry: delegates to `wantHeim_no_conflict`. -/
-theorem heimSemantics_isConflictBlocking {W : Type*} [Fintype W] [DecidableEq W]
+theorem heimSemantics_IsConflictBlocking {W : Type*} [Fintype W] [DecidableEq W]
     (params : HeimDesireParams W) (w_eval : W)
     (hAsym : ∀ x y, params.pref w_eval x y → params.pref w_eval y x → x = y) :
     ∀ belS (p : Set W),
@@ -591,8 +591,8 @@ theorem heimSemantics_isConflictBlocking {W : Type*} [Fintype W] [DecidableEq W]
   classical
   intro belS p hDef _hDefNeg ⟨hp, hnp⟩
   rw [show (heimSemantics (W := W)).want = fun belS params w p =>
-        wantHeimClassical belS params w p from rfl] at hp hnp
-  rw [wantHeimClassical_iff_wantHeim] at hp hnp
+        WantHeimClassical belS params w p from rfl] at hp hnp
+  rw [wantHeimClassical_iff_WantHeim] at hp hnp
   exact Desire.wantHeim_no_conflict belS params w_eval p hAsym hDef
     ⟨hp, hnp⟩
 
@@ -602,9 +602,9 @@ theorem heim_no_go_covers_belief_based_family
     (hAsym : ∀ x y, params.pref w_eval x y → params.pref w_eval y x → x = y)
     (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p]
-    (h : Desire.wantHeimDefined belS p) :
-    ¬ (Desire.wantHeim belS params w_eval p ∧
-       Desire.wantHeim belS params w_eval (fun w => ¬ p w)) :=
+    (h : Desire.WantHeimDefined belS p) :
+    ¬ (Desire.WantHeim belS params w_eval p ∧
+       Desire.WantHeim belS params w_eval (fun w => ¬ p w)) :=
   Desire.wantHeim_no_conflict
     belS params w_eval p hAsym h
 
@@ -612,7 +612,7 @@ theorem heim_no_go_covers_belief_based_family
     threshold + graded value rather than question-sensitivity.** The
     Lassiter substrate's `threshold_admits_conflict_witness` exhibits a
     concrete configuration where both `want(p)` and `want(¬p)` fire on
-    a single `(belS, pr, V, θ)` — falsifying `isConflictBlocking`.
+    a single `(belS, pr, V, θ)` — falsifying `IsConflictBlocking`.
 
     Lassiter and PB are now formalized as *two distinct* non-instances
     of `BeliefBasedDesireSemantics`. PB's escape route: question
@@ -625,8 +625,8 @@ theorem lassiter_evades_no_go_via_grading :
       (belS : Set W) (_ : DecidablePred belS)
       (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
       (p : Set W) (_ : DecidablePred p),
-      Desire.Lassiter.want belS pr V θ p ∧
-      Desire.Lassiter.want belS pr V θ (fun w => ¬ p w) :=
+      Desire.Lassiter.Want belS pr V θ p ∧
+      Desire.Lassiter.Want belS pr V θ (fun w => ¬ p w) :=
   Desire.Lassiter.threshold_admits_conflict_witness
 
 /-! ## Summary
@@ -636,7 +636,7 @@ that fit the 3-binary-dimension encoding (Nap, Lobster-via-isomorphism,
 Lu/deck-stacking, William-III). The substrate carries the *general*
 arguments (no-go for vF, no-go for Heim, Strawson upward monotonicity,
 and the universal finest-question identity
-`wantQuestionBased_finestPartition_iff_wantVonFintel`); the
+`wantQuestionBased_finestPartition_iff_WantVonFintel`); the
 belief-based-class typology — the paper's own §2 packaging — is
 formalized above. The §11 bridge makes the disagreement with C&L explicit;
 the §12 foil shows the no-go covers the whole belief-based family.


### PR DESCRIPTION
Pilot family for mathlib's Prop-capitalization rule (`Monotone`-style: UpperCamelCase for Prop-valued defs, lowercase preserved for theorem names and structure fields per the `Preorder.le` convention): the `Desire` namespace flips — `WantHeim`, `WantVonFintel`, `WantQuestionBased`, `IsConsidered`, `Lassiter.Want`, etc. — with consumers updated.

Also inlines the `wantPreference` schema added in #2133: a parameterized def carrying only three instances and one trivial mono lemma is over-abstraction by the `Pairwise`/`Tendsto` standard, and its layer caused the defeq friction that forced `wantExactMatch_iff`. The three readings are now direct defs — `WantExactMatch` back in the paper's membership form (eq. 69), restoring defeq transparency; the iff lemma and the schema die; the shared-schema observation lives in the module doc.