### PR TITLE
refactor(Semantics/Attitudes): cleanse Doxastic; demote paper sections

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2565,6 +2565,7 @@ import Linglib.Studies.Rett2026
 import Linglib.Studies.RitchieSchiller2024
 import Linglib.Studies.Roberts2012
 import Linglib.Studies.Roberts2023
+import Linglib.Studies.RobertsOzyildiz2025
 import Linglib.Studies.RobertsSimons2024
 import Linglib.Studies.RohdeEtAl2022
 import Linglib.Studies.Rolle2018

--- a/Linglib/Semantics/Attitudes/ContextQuantification.lean
+++ b/Linglib/Semantics/Attitudes/ContextQuantification.lean
@@ -37,7 +37,7 @@ consults only the reported context.
 namespace ContextQuantification
 
 open Semantics.Context
-open Semantics.Attitudes.Doxastic (boxAt)
+open Doxastic (BoxAt)
 
 variable {W E P T : Type*}
 
@@ -82,7 +82,7 @@ def reportedContext (t : ContextTower (KContext W E P T)) (holder : E)
     `w'` the embedded meaning `φ` holds of the context of the reported
     speech act — [schlenker-2003]'s attitude verb quantifying over
     contexts, with the finite `worlds` list as the decidable rendering
-    of the quantification (cf. `boxAt`). -/
+    of the quantification (cf. `BoxAt`). -/
 def ContextBox (R : E → W → W → Prop) (holder : E)
     (φ : KContext W E P T → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) : Prop :=
@@ -101,21 +101,21 @@ theorem contextBox_world_only
     (R : E → W → W → Prop) (holder : E) (p : W → Prop)
     (t : ContextTower (KContext W E P T)) (w : W) (worlds : List W) :
     ContextBox R holder (fun c => p c.world) t w worlds ↔
-    boxAt R holder w worlds p := by
-  simp only [ContextBox, boxAt, reportedContext_world]
+    BoxAt R holder w worlds p := by
+  simp only [ContextBox, BoxAt, reportedContext_world]
 
-/-- `DoxasticPredicate.holdsAt` is a veridicality check plus context
+/-- `DoxasticPredicate.HoldsAt` is a veridicality check plus context
     quantification over a world-only meaning — every doxastic predicate
     of `Doxastic.lean` is a special case of [schlenker-2003]'s context
     quantification. -/
 theorem doxastic_holdsAt_iff_contextBox
-    (V : Semantics.Attitudes.Doxastic.DoxasticPredicate W E) (agent : E)
+    (V : Doxastic.DoxasticPredicate W E) (agent : E)
     (p : W → Prop) (w : W) (worlds : List W)
     (t : ContextTower (KContext W E P T)) :
-    V.holdsAt agent p w worlds ↔
-    (Semantics.Attitudes.Doxastic.veridicalityHolds V.veridicality p w ∧
+    V.HoldsAt agent p w worlds ↔
+    (Doxastic.VeridicalityHolds V.veridicality p w ∧
      ContextBox V.access agent (fun c => p c.world) t w worlds) := by
-  simp only [Semantics.Attitudes.Doxastic.DoxasticPredicate.holdsAt,
+  simp only [Doxastic.DoxasticPredicate.HoldsAt,
     contextBox_world_only]
 
 /-! ### The Fixity Thesis -/

--- a/Linglib/Semantics/Attitudes/Doxastic.lean
+++ b/Linglib/Semantics/Attitudes/Doxastic.lean
@@ -1,721 +1,191 @@
-/-
-# Doxastic Attitude Semantics
-[pearl-2000] [glass-2025] [hintikka-1962] [roberts-ozyildiz-2025]
+import Linglib.Semantics.Presupposition.Basic
+import Linglib.Features.Attitudes
+import Linglib.Discourse.SpeechAct
 
-Modal/accessibility-based semantics for doxastic attitude verbs like
-`believe`, `know`, `think`.
+/-!
+# Doxastic attitude semantics
 
-## Semantic Mechanism
+Accessibility-based semantics for doxastic attitude verbs (*believe*,
+*know*, *think*) in the tradition of [hintikka-1962]: `R x w w'` reads
+"`w'` is compatible with what `x` believes/knows in `w`", and
+⟦x believes p⟧(w) is the universal modal over accessible worlds —
+`BoxAt`, with `DiamondAt` its existential dual, both quantifying over a
+finite `worlds` list as the decidable rendering.
 
-Doxastic attitudes use Hintikka-style accessibility relations:
-- R(x, w, w') means w' is compatible with what x believes/knows in w
-- ⟦x believes p⟧(w) = ∀w'. R(x,w,w') → p(w')
+A `DoxasticPredicate` bundles the accessibility relation with
+veridicality and opacity. Its proposition-taking semantics
+`HoldsAt` conjoins a veridicality check (`VeridicalityHolds`: veridical
+verbs require the complement at the evaluation world,
+`veridical_entails_complement`) with the universal modal, and
+`toPartialProp` exposes the same content as a
+`Semantics.Presupposition.PartialProp` — presupposition = veridicality
+check, assertion = modal — connecting doxastic verbs to the projection
+infrastructure. `HoldsAtQuestion` is the [karttunen-1977]
+question-taking semantics: knowing a question is knowing a true answer.
+`believeTemplate`/`knowTemplate`/`thinkTemplate` are the standard
+instantiations, and `doxastic_k_axiom` records closure under known
+implication.
 
-## PartialProp Decomposition
+Opacity: `SubstitutionMayFail` states that an opaque predicate can
+distinguish co-extensional complements, and `DeDicto`/`DeRe` give the
+two quantifier construals of an embedded indefinite. `psychMode` maps
+veridicality to [searle-1983]'s psychological mode: veridical attitudes
+are perception-like (the world must cause the state), non-veridical
+ones belief-like.
 
-`DoxasticPredicate.toPartialProp` decomposes a doxastic predicate into a
-`PartialProp` (partial proposition):
-- `presup` = veridicality check (for veridical verbs: p(w); otherwise: true)
-- `assertion` = universal modal (∀w'. R(x,w,w') → p(w'))
-
-This connects doxastic attitudes to the presupposition infrastructure
-in `Semantics.Presupposition`, enabling uniform treatment of factive
-presuppositions, projection, and the [glass-2025] typology.
-
-## PresupClass
-
-`PresupClass` classifies doxastic verbs by their presuppositional profile:
-- `.factive` (know): presup = p → satisfies PLC
-- `.nonfactive` (believe): no presupposition → PLC does not apply
-- `.contrafactive` (hypothetical *contra*): presup = ¬p → violates PLC (UNATTESTED)
-
-## Question Embedding
-
-Doxastic attitudes can embed questions via exhaustive interpretation:
-- ⟦x knows Q⟧ = ∃p ∈ Q. p(w) ∧ x knows p
-
+The presuppositional typology of doxastic verbs ([glass-2025]) lives in
+`Studies/Glass2025.lean`; the causal derivation of the contrafactive
+gap ([roberts-ozyildiz-2025]) in `Studies/RobertsOzyildiz2025.lean`;
+embedded scalar implicature ([goodman-stuhlmuller-2013]) in
+`Studies/GoodmanStuhlmuller2013.lean`.
 -/
 
-import Linglib.Discourse.SpeechAct
-import Linglib.Discourse.Commitment.Basic
-import Linglib.Semantics.Presupposition.Basic
-import Linglib.Logic.Modal.Basic
-import Linglib.Semantics.Causation.SEM.Bool
-import Linglib.Semantics.Causation.SEM.Counterfactual
-import Linglib.Features.Aktionsart
-import Linglib.Features.Attitudes
-import Linglib.Semantics.Causation.VerbClass
-import Linglib.Semantics.ArgumentStructure.LevinClass
-import Linglib.Semantics.ArgumentStructure.MeaningComponents
-
-namespace Semantics.Attitudes.Doxastic
-
-open Intensional (WorldTimeIndex)
+namespace Doxastic
 
 open Features (Veridicality)
-open Features
 export Features (Veridicality)
 
--- Accessibility Relations
+variable {W E : Type*}
 
-/--
-Universal modal: holds at w iff p holds at all accessible worlds.
+/-! ### Accessibility modals -/
 
-⟦□p⟧(w) = ∀w' ∈ worlds. R(agent, w, w') → p(w')
--/
-def boxAt {W E : Type*} (R : E → W → W → Prop) (agent : E) (w : W)
+/-- Universal modal: `BoxAt R agent w worlds p` iff `p` holds at every
+    accessible world in `worlds`. -/
+def BoxAt (R : E → W → W → Prop) (agent : E) (w : W)
     (worlds : List W) (p : W → Prop) : Prop :=
   ∀ w' ∈ worlds, R agent w w' → p w'
 
-/--
-Existential modal: holds at w iff p holds at some accessible world.
-
-⟦◇p⟧(w) = ∃w' ∈ worlds. R(agent, w, w') ∧ p(w')
--/
-def diaAt {W E : Type*} (R : E → W → W → Prop) (agent : E) (w : W)
+/-- Existential modal: `DiamondAt R agent w worlds p` iff `p` holds at some
+    accessible world in `worlds`. -/
+def DiamondAt (R : E → W → W → Prop) (agent : E) (w : W)
     (worlds : List W) (p : W → Prop) : Prop :=
   ∃ w' ∈ worlds, R agent w w' ∧ p w'
 
-instance boxAt_decidable {W E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
+instance (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
-    Decidable (boxAt R agent w worlds p) :=
+    Decidable (BoxAt R agent w worlds p) :=
   inferInstanceAs (Decidable (∀ w' ∈ worlds, _))
 
-instance diaAt_decidable {W E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
+instance (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
-    Decidable (diaAt R agent w worlds p) :=
+    Decidable (DiamondAt R agent w worlds p) :=
   inferInstanceAs (Decidable (∃ w' ∈ worlds, _))
 
--- ============================================================================
--- Presuppositional Classification ([glass-2025])
--- ============================================================================
-
-/-!
-## Presuppositional Classification of Doxastic Verbs
-
-[glass-2025] proposes a typology of belief verbs based on their
-presuppositional profile — what they require of the Common Ground:
-
-- **Factive** (know): presupposes p — CommonGround must entail p
-- **Nonfactive** (think): no presupposition — no CommonGround requirement
-- **Contrafactive** (hypothetical *contra*): would presuppose ¬p — UNATTESTED
-- **Weak contrafactive** (Mandarin yǐwéi): postsupposition ◇¬p — CommonGround compatible with ¬p
-
-The key insight: this classification is DERIVED from the `PartialProp` produced by
-`DoxasticPredicate.toPartialProp`, not stipulated as a separate type. The presup
-field of the PartialProp determines the classification.
-
-Postsuppositions (yǐwéi's ◇¬p) are output-context constraints, formalized
-separately in `PPCDRT`.
--/
-
-/--
-Classification of a doxastic verb's presuppositional profile.
-
-This emerges from the presup field of the `PartialProp` produced by
-`DoxasticPredicate.toPartialProp`. Not a primitive — a derived label.
--/
-inductive PresupClass where
-  | factive         -- presup = p (know: CommonGround must entail p)
-  | contrafactive   -- presup = ¬p (hypothetical *contra*: CommonGround must entail ¬p — UNATTESTED)
-  | nonfactive      -- presup = true (believe/think: no CommonGround requirement)
-  | other           -- none of the above
-  deriving DecidableEq, Repr
-
-/-- Classify a doxastic verb by its veridicality. -/
-def classifyVeridicality : Veridicality → PresupClass
-  | .veridical => .factive
-  | .nonVeridical => .nonfactive
-
-/-- Veridical verbs are factive. -/
-theorem veridical_is_factive :
-    classifyVeridicality .veridical = .factive := rfl
-
-/-- Non-veridical verbs are nonfactive. -/
-theorem nonVeridical_is_nonfactive :
-    classifyVeridicality .nonVeridical = .nonfactive := rfl
-
--- ============================================================================
--- Causal Models for Lexical Coherence (Roberts & Özyıldız 2025)
--- ============================================================================
-
-/-!
-## Causal Explanation of the Contrafactive Gap
-
-Roberts & Özyıldız (2025) propose that the contrafactive gap follows from
-a general constraint on lexicalization: **presupposed content must be
-causally upstream of at-issue content**.
-
-### The Predicate Lexicalization Constraint (PLC)
-
-A verbal predicate V with at-issue content α can have presupposition π iff
-in the normative world wₙ, a causal chain from π(wₙ) to α(wₙ) can be
-constructed for any assignment of the arguments of V.
-
-### Why Factives Work (know)
-
-For "Delilah knows that Konstanz is in Germany":
-- Presupposition: p (Konstanz is in Germany)
-- At-issue: B(d)(p) (Delilah believes Konstanz is in Germany)
-
-Causal chain: p → indic(p) → acq(d)(iₚ) → B(d)(p)
-
-1. The fact p generates indicators (evidence) for p
-2. Delilah can become acquainted with these indicators
-3. This acquaintance leads to belief formation
-
-### Why Strong Contrafactives Don't Work (contra)
-
-For hypothetical "Marianne contras that the Earth is flat":
-- Presupposition: ¬p (Earth is round, i.e., ¬flat)
-- At-issue: B(m)(p) (Marianne believes Earth is flat)
-
-NO causal chain: ¬p (ROUND) does NOT generate indicators for p (FLAT)
-- ROUND generates indicators for ROUND
-- There's no typical causal path from ¬p to B(x)(p)
-
-This asymmetry DERIVES the gap from independent causal-cognitive principles.
-
--/
-
--- ============================================================================
--- Causal Model Infrastructure (via Causation)
--- ============================================================================
-
-/-!
-The belief formation causal model uses `Causation` — the V2 SEM
-substrate (PMF-canonical Mechanism, BoolSEM specialization for the
-deterministic-binary case). The PLC predicate is defined via
-`SEM.developDetOn` with an explicit vertex list so kernel reduction
-works structurally (no `decide`; mathlib-quality `rfl`/`decide`
-proofs).
--/
-
-open Causation Causation.Mechanism Causation.SEM
-
--- ============================================================================
--- Belief Formation Causal Model (Roberts & Özyıldız 2025)
--- ============================================================================
-
-/-- Standard variables in belief formation. Inductive enum so the type
-    is `Fintype` and the developDet fixpoint reduces structurally. -/
-inductive BeliefVar
-  | p | not_p
-  | indic_p | indic_not_p
-  | acq_a_ip | acq_a_inp
-  | B_a_p | B_a_not_p
-  deriving DecidableEq, Fintype, Repr
-
-/-- The causal graph for belief formation. Chain structure:
-    `p → indic(p) → acq(a)(iₚ) → B(a)(p)` (parallel chain for ¬p).
-    Each derived vertex has its single causal predecessor as parent. -/
-def beliefGraph : CausalGraph BeliefVar :=
-  ⟨fun
-    | .p => ∅
-    | .not_p => ∅
-    | .indic_p => {.p}
-    | .indic_not_p => {.not_p}
-    | .acq_a_ip => {.indic_p}
-    | .acq_a_inp => {.indic_not_p}
-    | .B_a_p => {.acq_a_ip}
-    | .B_a_not_p => {.acq_a_inp}⟩
-
-/-- The belief-formation BoolSEM. Roots (`p`, `¬p`) get `Mechanism.const false`
-    (default; the input valuation overrides). Each derived vertex's mechanism
-    is "true iff its sole parent is true" — the chain copies values forward. -/
-noncomputable def beliefSEM : BoolSEM BeliefVar :=
-  { graph := beliefGraph
-    mech := fun v => match v with
-      | .p => const (G := beliefGraph) false
-      | .not_p => const (G := beliefGraph) false
-      | .indic_p => deterministic (fun ρ => ρ ⟨.p, by simp [beliefGraph]⟩)
-      | .indic_not_p => deterministic (fun ρ => ρ ⟨.not_p, by simp [beliefGraph]⟩)
-      | .acq_a_ip => deterministic (fun ρ => ρ ⟨.indic_p, by simp [beliefGraph]⟩)
-      | .acq_a_inp => deterministic (fun ρ => ρ ⟨.indic_not_p, by simp [beliefGraph]⟩)
-      | .B_a_p => deterministic (fun ρ => ρ ⟨.acq_a_ip, by simp [beliefGraph]⟩)
-      | .B_a_not_p => deterministic (fun ρ => ρ ⟨.acq_a_inp, by simp [beliefGraph]⟩) }
-
-noncomputable instance : SEM.IsDeterministic beliefSEM where
-  mech_det v := match v with
-    | .p => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .not_p => inferInstanceAs (Mechanism.IsDeterministic (const _))
-    | .indic_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-    | .indic_not_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-    | .acq_a_ip => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-    | .acq_a_inp => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-    | .B_a_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-    | .B_a_not_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
-
-/-- Explicit vertex list for `developDetOn`. Topological order ensures one
-    `stepOnceDetOn` pass propagates the entire chain. -/
-def beliefVarList : List BeliefVar :=
-  [.p, .not_p, .indic_p, .indic_not_p, .acq_a_ip, .acq_a_inp, .B_a_p, .B_a_not_p]
-
--- ============================================================================
--- The Predicate Lexicalization Constraint
--- ============================================================================
-
-/-- **Predicate Lexicalization Constraint (PLC)** ([roberts-ozyildiz-2025]).
-
-    A verbal predicate with at-issue content α can have presupposition π iff
-    setting π to true and running the belief-formation SEM's `developDetOn`
-    produces α at the at-issue vertex.
-
-    Defined via `developDetOn` with the explicit `beliefVarList` so kernel
-    reduction works structurally (no `decide`). One iteration of
-    `stepOnceDetOn` over a topologically-ordered list propagates the entire
-    chain; we use `8 = beliefVarList.length` iterations conservatively. -/
-noncomputable def satisfiesPLC (presup atIssue : BeliefVar) : Prop :=
-  (developDetOn beliefSEM beliefVarList 1
-    (Valuation.empty.extend presup true)).hasValue atIssue true
-
-noncomputable instance (presup atIssue : BeliefVar) : Decidable (satisfiesPLC presup atIssue) :=
-  Classical.dec _
-
--- ============================================================================
--- Deriving the Contrafactive Gap
--- ============================================================================
-
-/-- **Theorem: Factives satisfy the PLC**
-
-    For "x knows p":
-    - Presupposition: p
-    - At-issue: B(a)(p)
-    - Causal chain: p → indic(p) → acq(a)(iₚ) → B(a)(p) ✓ -/
-theorem factive_satisfies_plc :
-    satisfiesPLC .p .B_a_p := by
-  unfold satisfiesPLC
-  rfl
-
-/-- **Theorem: Strong contrafactives VIOLATE the PLC**
-
-    For hypothetical "x contras p":
-    - Presupposition: ¬p
-    - At-issue: B(a)(p)
-    - NO causal chain from ¬p to B(a)(p) ✗
-
-    The fact that the Earth is round does not generate evidence
-    that the Earth is flat. -/
-theorem strong_contrafactive_violates_plc :
-    ¬ satisfiesPLC .not_p .B_a_p := by
-  unfold satisfiesPLC
-  intro h
-  exact Bool.false_ne_true (Option.some.inj h)
-
-/-- **The Contrafactive Gap Theorem**
-
-    The asymmetry between factives and strong contrafactives follows from
-    the Predicate Lexicalization Constraint:
-
-    1. Factives (know): presup p → at-issue B(a)(p) — PLC SATISFIED
-    2. Strong contrafactives (contra): presup ¬p → at-issue B(a)(p) — PLC VIOLATED
-
-    This DERIVES the gap from the independently motivated causal constraint. -/
-theorem contrafactive_gap :
-    satisfiesPLC .p .B_a_p ∧ ¬ satisfiesPLC .not_p .B_a_p :=
-  ⟨factive_satisfies_plc, strong_contrafactive_violates_plc⟩
-
-/-- **Corollary: The asymmetry is structural, not stipulated**
-
-    The contrafactive gap emerges from the structure of belief formation:
-    - Beliefs are formed based on evidence
-    - Evidence for p comes from p being true
-    - Evidence for p does NOT come from ¬p being true
-
-    Therefore any predicate trying to presuppose ¬p while asserting B(x)(p)
-    is describing a causally incoherent eventuality. -/
-theorem contrafactive_gap_is_structural :
-    satisfiesPLC .p .B_a_p ∧
-    ¬ satisfiesPLC .not_p .B_a_p ∧
-    satisfiesPLC .not_p .B_a_not_p := by
-  refine ⟨factive_satisfies_plc, strong_contrafactive_violates_plc, ?_⟩
-  unfold satisfiesPLC
-  rfl
-
--- ============================================================================
--- Why Weak Contrafactives Escape the Gap
--- ============================================================================
-
-/-!
-## Weak Contrafactives (yǐwéi) and the PLC
-
-Weak contrafactives like Mandarin yǐwéi don't violate the PLC because
-their projective content is fundamentally different:
-
-1. **Not a presupposition**: [glass-2025] argues yǐwéi's falsity inference
-   is a postsupposition (about output context) not presupposition (input).
-   Postsuppositions are formalized in `PPCDRT`.
-
-2. **Different requirement**: yǐwéi requires CommonGround ◇ ¬p (CommonGround compatible with ¬p),
-   not CommonGround ⊨ ¬p (CommonGround entails ¬p)
-
-3. **No causal incoherence**: "p is unsettled in CommonGround" is compatible with
-   "there's evidence for p that x acquired" — these are about different
-   epistemic states (communal knowledge vs individual belief)
-
-The PLC only constrains the relationship between presupposition and
-at-issue content within the SAME eventuality. Postsuppositions about
-discourse context update are not subject to this constraint.
--/
-
--- ============================================================================
--- PLC Validation via PresupClass
--- ============================================================================
-
-/--
-Map a `PresupClass` to the corresponding causal variables for PLC checking.
-
-- Factive: presup = p, at-issue = B(a)(p)
-- Contrafactive: presup = ¬p, at-issue = B(a)(p)
-
-For nonfactive (no presupposition) and other, the PLC doesn't apply.
--/
-def presupClassToCausalVars : PresupClass → Option (BeliefVar × BeliefVar)
-  | .factive => some (.p, .B_a_p)
-  | .contrafactive => some (.not_p, .B_a_p)
-  | .nonfactive => none
-  | .other => none
-
-/--
-Check if a `PresupClass` satisfies the Predicate Lexicalization Constraint.
-
-Returns `none` if the PLC doesn't apply (nonfactive, postsuppositions).
-Returns `some true` if it satisfies PLC, `some false` if it violates PLC.
--/
-noncomputable def presupClassSatisfiesPLC (pc : PresupClass) : Option Bool :=
-  match presupClassToCausalVars pc with
-  | none => none
-  | some (presup, atIssue) => some (decide (satisfiesPLC presup atIssue))
-
-/--
-Is this presuppositional profile valid (attestable)?
-
-Valid means: either satisfies PLC (factives) or not subject to PLC
-(nonfactives, postsuppositions). Invalid = violates PLC (contrafactives).
-
-Direct (computable) classification. The PLC-derivation chain
-(via `presupClassSatisfiesPLC`) is given as
-`presupClassIsValid_eq_via_plc` below. -/
-def presupClassIsValid : PresupClass → Bool
-  | .factive       => true
-  | .nonfactive    => true
-  | .contrafactive => false
-  | .other         => true
-
-/-- The PLC derivation: `presupClassIsValid` agrees with running the
-    `presupClassSatisfiesPLC` chain (taking `none` as `true`). This
-    bridges the direct classifier to the [roberts-ozyildiz-2025]
-    causal account. -/
-theorem presupClassIsValid_eq_via_plc (pc : PresupClass) :
-    presupClassIsValid pc = (presupClassSatisfiesPLC pc).getD true := by
-  cases pc <;> simp [presupClassIsValid, presupClassSatisfiesPLC,
-    presupClassToCausalVars]
-  · exact factive_satisfies_plc
-  · exact strong_contrafactive_violates_plc
-
-/-- Factive presuppositions are valid (satisfy PLC). -/
-theorem factive_presup_valid :
-    presupClassIsValid .factive = true := rfl
-
-/-- Contrafactive presuppositions are invalid (violate PLC). -/
-theorem contrafactive_presup_invalid :
-    presupClassIsValid .contrafactive = false := rfl
-
-/-- Nonfactive verbs are trivially valid (no presupposition to check). -/
-theorem nonfactive_presup_valid :
-    presupClassIsValid .nonfactive = true := rfl
-
--- ============================================================================
--- Additional Derived Properties
--- ============================================================================
-
-variable {W : Type*}
-
-/--
-Veridicality constraint: if veridical, p must hold at the evaluation world.
-
-For "know", we require p(w) at the evaluation world w.
--/
-def veridicalityHolds {W : Type*} (v : Veridicality) (p : W → Prop) (w : W) : Prop :=
+/-- Closure under known implication — the K axiom: if the agent
+    believes `p` and believes `p → q`, the agent believes `q`. -/
+theorem doxastic_k_axiom (R : E → W → W → Prop) (agent : E)
+    (p q : W → Prop) (w : W) (worlds : List W)
+    (hp : BoxAt R agent w worlds p)
+    (hpq : BoxAt R agent w worlds (fun w' => p w' → q w')) :
+    BoxAt R agent w worlds q :=
+  fun w' hw' hR => hpq w' hw' hR (hp w' hw' hR)
+
+/-! ### Doxastic predicates -/
+
+/-- `VeridicalityHolds v p w` is the veridicality check: veridical
+    verbs require `p w`; non-veridical verbs require nothing. -/
+def VeridicalityHolds (v : Veridicality) (p : W → Prop) (w : W) : Prop :=
   match v with
   | .veridical => p w
   | .nonVeridical => True
 
-instance veridicalityHolds_decidable {W : Type*} (v : Veridicality) (p : W → Prop)
-    [DecidablePred p] (w : W) : Decidable (veridicalityHolds v p w) := by
-  cases v <;> simp [veridicalityHolds] <;> infer_instance
+instance (v : Veridicality) (p : W → Prop) [DecidablePred p] (w : W) :
+    Decidable (VeridicalityHolds v p w) := by
+  cases v <;> simp [VeridicalityHolds] <;> infer_instance
 
--- Doxastic Predicate Structure
-
-/--
-A doxastic attitude predicate.
-
-Bundles the accessibility relation with veridicality and other properties.
--/
+/-- A doxastic attitude predicate: an accessibility relation bundled
+    with veridicality and opacity. -/
 structure DoxasticPredicate (W E : Type*) where
-  /-- Name of the predicate -/
+  /-- Name of the predicate. -/
   name : String
-  /-- Accessibility relation -/
+  /-- Accessibility relation. -/
   access : E → W → W → Prop
-  /-- Veridicality (veridical or not) -/
+  /-- Veridicality (veridical or not). -/
   veridicality : Veridicality
-  /-- Does it create an opaque context? (substitution failures) -/
+  /-- Does it create an opaque context (substitution failures)? -/
   createsOpaqueContext : Bool := true
 
-/--
-Semantics for a doxastic predicate taking a proposition.
+/-- `V.HoldsAt agent p w worlds` iff the veridicality check passes at
+    `w` and `p` holds at every accessible world:
+    ⟦x V that p⟧(w) = VeridicalityHolds ∧ BoxAt. -/
+def DoxasticPredicate.HoldsAt (V : DoxasticPredicate W E) (agent : E)
+    (p : W → Prop) (w : W) (worlds : List W) : Prop :=
+  VeridicalityHolds V.veridicality p w ∧ BoxAt V.access agent w worlds p
 
-⟦x V that p⟧(w) = (veridicalityHolds V p w) ∧ ∀w'. R(x,w,w') → p(w')
-
-For veridical predicates, we also require p(w).
--/
-def DoxasticPredicate.holdsAt {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W) : Prop :=
-  veridicalityHolds V.veridicality p w ∧ boxAt V.access agent w worlds p
-
-instance DoxasticPredicate.holdsAt_decidable {W E : Type*}
-    (V : DoxasticPredicate W E) [∀ a w w', Decidable (V.access a w w')]
+instance (V : DoxasticPredicate W E) [∀ a w w', Decidable (V.access a w w')]
     (agent : E) (p : W → Prop) [DecidablePred p] (w : W) (worlds : List W) :
-    Decidable (V.holdsAt agent p w worlds) :=
+    Decidable (V.HoldsAt agent p w worlds) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
--- ============================================================================
--- PartialProp Construction: Doxastic Predicates as Partial Propositions
--- ============================================================================
-
-open Semantics.Presupposition
-
-/--
-Convert a doxastic predicate application to a `PartialProp`.
-
-The decomposition makes the presuppositional structure explicit:
-- `presup` = veridicality check (for veridical: p(w); for non-veridical: true)
-- `assertion` = universal modal (∀w'. R(x,w,w') → p(w'))
-
-`holdsAt` computes `presup(w) && assertion(w)` — the same as `PartialProp.holds`.
--/
-def DoxasticPredicate.toPartialProp {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (worlds : List W) : PartialProp W :=
-  { presup := λ w => veridicalityHolds V.veridicality p w
-  , assertion := λ w => boxAt V.access agent w worlds p }
-
-/-- `toPartialProp` decomposes `holdsAt`: the presup field is the veridicality
-    check and the assertion field is the modal. -/
-theorem DoxasticPredicate.toPartialProp_presup {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W) :
-    (V.toPartialProp agent p worlds).presup w =
-    veridicalityHolds V.veridicality p w := rfl
-
-theorem DoxasticPredicate.toPartialProp_assertion {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W) :
-    (V.toPartialProp agent p worlds).assertion w =
-    boxAt V.access agent w worlds p := rfl
-
-/-- PartialProp for a hypothetical contrafactive verb: presupposes ¬p,
-    asserts agent believes p. UNATTESTED — see [glass-2025]. -/
-def contrafactivePartialProp {W E : Type*} (R : E → W → W → Prop) (agent : E)
-    (p : W → Prop) (worlds : List W) : PartialProp W :=
-  { presup := λ w => ¬ p w
-  , assertion := λ w => boxAt R agent w worlds p }
-
-/--
-Semantics for doxastic predicate taking a Hamblin question.
-
-Following [karttunen-1977], "know Q" means knowing the true answer:
-⟦x knows Q⟧(w) = ∃p ∈ Q. p(w) ∧ x knows p
-
-For non-veridical predicates, we drop the p(w) requirement:
-⟦x believes Q⟧(w) = ∃p ∈ Q. x believes p
--/
-def DoxasticPredicate.holdsAtQuestion {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (Q : (W → Prop) → Prop)
-    (w : W) (worlds : List W) (answers : List (W → Prop)) : Prop :=
-  ∃ p ∈ answers,
-    Q p ∧
-    (match V.veridicality with
-     | .veridical => p w
-     | .nonVeridical => True) ∧
-    boxAt V.access agent w worlds p
-
--- Standard Doxastic Predicates (Abstract)
-
-/--
-Abstract "believe" predicate template.
-
-Users instantiate with their specific accessibility relation.
--/
-def believeTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
-  { name := "believe"
-  , access := R
-  , veridicality := .nonVeridical
-  , createsOpaqueContext := true
-  }
-
-/--
-Abstract "know" predicate template.
-
-Veridical: knowing p requires p to be true.
--/
-def knowTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
-  { name := "know"
-  , access := R
-  , veridicality := .veridical
-  , createsOpaqueContext := true
-  }
-
-/--
-Abstract "think" predicate template.
-
-Non-veridical, typically less commitment than "believe".
--/
-def thinkTemplate {W E : Type*} (R : E → W → W → Prop) : DoxasticPredicate W E :=
-  { name := "think"
-  , access := R
-  , veridicality := .nonVeridical
-  , createsOpaqueContext := true
-  }
-
--- Properties and Theorems
-
-/--
-Veridical predicates entail their complement.
-
-If x knows p at w, then p is true at w.
--/
-theorem veridical_entails_complement {W E : Type*}
-    (V : DoxasticPredicate W E) (hV : V.veridicality = .veridical)
-    (agent : E) (p : W → Prop) (w : W) (worlds : List W)
-    (holds : V.holdsAt agent p w worlds) : p w := by
-  unfold DoxasticPredicate.holdsAt at holds
-  simp only [hV, veridicalityHolds] at holds
+/-- Veridical predicates entail their complement: if `x` knows `p` at
+    `w`, then `p w`. -/
+theorem veridical_entails_complement (V : DoxasticPredicate W E)
+    (hV : V.veridicality = .veridical) (agent : E) (p : W → Prop)
+    (w : W) (worlds : List W) (holds : V.HoldsAt agent p w worlds) : p w := by
+  unfold DoxasticPredicate.HoldsAt at holds
+  simp only [hV, VeridicalityHolds] at holds
   exact holds.1
 
-/--
-Non-veridical predicates don't entail their complement.
+open Semantics.Presupposition in
+/-- The predicate application as a `PartialProp`: presupposition =
+    veridicality check, assertion = universal modal. `HoldsAt` is the
+    conjunction of the two fields. -/
+def DoxasticPredicate.toPartialProp (V : DoxasticPredicate W E)
+    (agent : E) (p : W → Prop) (worlds : List W) : PartialProp W :=
+  { presup := fun w => VeridicalityHolds V.veridicality p w
+  , assertion := fun w => BoxAt V.access agent w worlds p }
 
-There exist cases where x believes p but p is false.
--/
-theorem nonVeridical_not_entails {W E : Type*} [Inhabited W] [Inhabited E]
-    (V : DoxasticPredicate W E) (hV : V.veridicality = .nonVeridical) :
-    ∃ (agent : E) (p : W → Prop) (w : W) (worlds : List W),
-      V.holdsAt agent p w worlds ∧ ¬ p w :=
-  -- Use empty worlds list: boxAt is vacuously true, p w can be False
-  ⟨default, fun _ => False, default, [], by
-    simp [DoxasticPredicate.holdsAt, hV, veridicalityHolds, boxAt]⟩
+/-- `HoldsAtQuestion`: the [karttunen-1977] question-taking semantics —
+    ⟦x knows Q⟧(w) = some true answer in `Q` is known (for
+    non-veridical predicates the truth requirement is dropped). -/
+def DoxasticPredicate.HoldsAtQuestion (V : DoxasticPredicate W E)
+    (agent : E) (Q : (W → Prop) → Prop) (w : W) (worlds : List W)
+    (answers : List (W → Prop)) : Prop :=
+  ∃ p ∈ answers,
+    Q p ∧ VeridicalityHolds V.veridicality p w ∧
+    BoxAt V.access agent w worlds p
 
-/--
-Doxastic predicates are closed under known implication.
+/-! ### Standard templates -/
 
-If x knows p and x knows (p → q), then x knows q.
-(This is the K axiom of modal logic)
--/
-theorem doxastic_k_axiom {W E : Type*}
-    (V : DoxasticPredicate W E) (agent : E) (p q : W → Prop)
-    (w : W) (worlds : List W)
-    (hp : boxAt V.access agent w worlds p)
-    (hpq : boxAt V.access agent w worlds (λ w' => p w' → q w')) :
-    boxAt V.access agent w worlds q := by
-  intro w' hw' hR
-  exact hpq w' hw' hR (hp w' hw' hR)
+/-- Abstract *believe*: non-veridical, opaque. -/
+def believeTemplate (R : E → W → W → Prop) : DoxasticPredicate W E :=
+  { name := "believe", access := R, veridicality := .nonVeridical }
 
--- Substitution and Opacity
+/-- Abstract *know*: veridical, opaque. -/
+def knowTemplate (R : E → W → W → Prop) : DoxasticPredicate W E :=
+  { name := "know", access := R, veridicality := .veridical }
 
-/-!
-## Substitution and Opacity
+/-- Abstract *think*: non-veridical, opaque. -/
+def thinkTemplate (R : E → W → W → Prop) : DoxasticPredicate W E :=
+  { name := "think", access := R, veridicality := .nonVeridical }
 
-Opaque contexts block substitution of co-referential terms.
+/-! ### Opacity and construals -/
 
-Even if a = b (extensionally), "x believes Fa" may differ from "x believes Fb"
-because the agent may not know a = b.
-
-This is formalized by the `createsOpaqueContext` field: when true, the predicate
-operates on intensions (functions from worlds), not extensions.
--/
-
-/--
-For opaque predicates, substitution failure is possible.
-
-This is a statement that the predicate distinguishes intensions that
-happen to have the same extension at the evaluation world.
--/
-def substitutionMayFail {W E : Type*} (V : DoxasticPredicate W E) : Prop :=
+/-- An opaque predicate can distinguish co-extensional complements:
+    some `p`, `q` agree at `w` but embed differently. -/
+def SubstitutionMayFail (V : DoxasticPredicate W E) : Prop :=
   V.createsOpaqueContext = true →
   ∃ (agent : E) (p q : W → Prop) (w : W) (worlds : List W),
-    (p w ↔ q w) ∧  -- Same extension at w
-    p ≠ q ∧        -- Different intensions
-    ¬ (V.holdsAt agent p w worlds ↔ V.holdsAt agent q w worlds)
+    (p w ↔ q w) ∧ p ≠ q ∧
+    ¬ (V.HoldsAt agent p w worlds ↔ V.HoldsAt agent q w worlds)
 
--- De Dicto vs De Re
-
-/--
-De dicto reading: quantifier under the attitude.
-
-"John believes someone is a spy" (de dicto) =
-John believes ∃x. spy(x)
--/
-def deDicto {W E : Type*} (V : DoxasticPredicate W E)
-    (agent : E) (p : W → Prop) (w : W) (worlds : List W) : Prop :=
-  V.holdsAt agent p w worlds
-
-/--
-De re reading: quantifier over the attitude.
-
-"John believes someone is a spy" (de re) =
-∃x. John believes spy(x)
-
-Here we need a domain of individuals to quantify over.
--/
-def deRe {W E D : Type*} (V : DoxasticPredicate W E)
-    (agent : E) (predicate : D → W → Prop) (domain : List D)
+/-- De re construal: the quantifier scopes over the attitude —
+    some individual in the domain is believed to satisfy the
+    predicate. The de dicto construal, with the quantifier under the
+    attitude, is `HoldsAt` applied to the existential complement. -/
+def DeRe {D : Type*} (V : DoxasticPredicate W E) (agent : E)
+    (predicate : D → W → Prop) (domain : List D)
     (w : W) (worlds : List W) : Prop :=
-  ∃ x ∈ domain, V.holdsAt agent (predicate x) w worlds
+  ∃ x ∈ domain, V.HoldsAt agent (predicate x) w worlds
 
--- Connection to Scalar Implicature
+/-! ### Psychological mode -/
 
-/-!
-## Attitude Embedding and Scalar Implicature
-
-When scalar expressions are embedded under attitudes, the implicature
-can be computed locally (inside the attitude) or globally (about speaker):
-
-**Global**: Speaker implicates ¬(speaker believes all)
-**Local**: x believes (some ∧ ¬all) [apparent local reading]
-
-[goodman-stuhlmuller-2013] show the "local" reading arises from
-pragmatic inference about speaker knowledge, not true local computation.
-
-See `Studies/GoodmanStuhlmuller2013.lean`
-for the RSA treatment.
--/
-
--- ════════════════════════════════════════════════════════════════
--- Bridge: Veridicality → [searle-1983] Causal Self-Referentiality
--- ════════════════════════════════════════════════════════════════
-
-
-/-- Map veridicality to [searle-1983]'s psychological mode.
-
-    Veridical attitudes (know, realize) are like perception: the world must
-    *cause* the mental state (you can only know p if p is the case and your
-    epistemic state is appropriately caused by p's being the case).
-    Non-veridical attitudes (believe, think) are like belief: satisfaction
-    depends only on whether p obtains, not on the causal chain. -/
+/-- [searle-1983]'s psychological mode from veridicality: veridical
+    attitudes are perception-like (the world must cause the state);
+    non-veridical attitudes are belief-like (satisfaction requires only
+    that the content match reality). -/
 def psychMode : Veridicality → PsychMode
-  | .veridical    => .perception  -- know: world must cause the state
-  | .nonVeridical  => .belief     -- believe: no causal requirement
+  | .veridical => .perception
+  | .nonVeridical => .belief
 
-/-- Veridical attitudes are causally self-referential (world→state);
-    non-veridical attitudes are not. This connects the linguistic
-    veridicality distinction to [searle-1983]'s metaphysics:
-    knowledge requires the world to cause the knowing, while belief
-    requires only that the content match reality. -/
-theorem veridical_self_referential :
-    (psychMode .veridical).causalSelfRef = .worldToState ∧
-    (psychMode .nonVeridical).causalSelfRef = .none :=
-  ⟨rfl, rfl⟩
-
-end Semantics.Attitudes.Doxastic
+end Doxastic

--- a/Linglib/Semantics/Attitudes/NegRaising.lean
+++ b/Linglib/Semantics/Attitudes/NegRaising.lean
@@ -50,8 +50,8 @@ file is the doxastic (believe / think / know) application layer.
 namespace Semantics.Attitudes.NegRaising
 
 open Aristotelian (Square SquareRelations)
-open Semantics.Attitudes.Doxastic
-  (DoxasticPredicate Veridicality boxAt diaAt)
+open Doxastic
+  (DoxasticPredicate Veridicality BoxAt DiamondAt)
 
 /-! ### The doxastic square -/
 
@@ -65,10 +65,10 @@ corners of the doxastic square of opposition:
 - O = ¬Bel(p): not all doxastic alternatives satisfy p -/
 def doxasticSquare {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) : Square (W → Prop) where
-  A := λ w => boxAt R agent w worlds p
-  E := λ w => boxAt R agent w worlds (λ w' => ¬ p w')
-  I := λ w => diaAt R agent w worlds p
-  O := λ w => ¬ boxAt R agent w worlds p
+  A := λ w => BoxAt R agent w worlds p
+  E := λ w => BoxAt R agent w worlds (λ w' => ¬ p w')
+  I := λ w => DiamondAt R agent w worlds p
+  O := λ w => ¬ BoxAt R agent w worlds p
 
 /-- The doxastic square satisfies the A–O contradiction diagonal. -/
 theorem doxasticSquare_contradAO {W E : Type*} (R : E → W → W → Prop)
@@ -79,13 +79,13 @@ theorem doxasticSquare_contradAO {W E : Type*} (R : E → W → W → Prop)
 
 /-- The doxastic square satisfies the E–I contradiction diagonal.
 
-This requires that `diaAt` is the dual of `boxAt`: ◇p = ¬□¬p.
+This requires that `DiamondAt` is the dual of `BoxAt`: ◇p = ¬□¬p.
 We prove this from the definitions. -/
 theorem doxasticSquare_contradEI {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W) :
     (doxasticSquare R agent worlds p).E w ↔
     ¬ (doxasticSquare R agent worlds p).I w := by
-  simp only [doxasticSquare, boxAt, diaAt]
+  simp only [doxasticSquare, BoxAt, DiamondAt]
   constructor
   · rintro h ⟨w', hw', hR, hp⟩
     exact h w' hw' hR hp
@@ -106,14 +106,14 @@ validity rather than a defeasible move. -/
 /-- Neg-raising: the O→E inference `¬Bel(p) → Bel(¬p)` at a world. -/
 def negRaisesAt {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) : Prop :=
-  ¬ boxAt R agent w worlds p →
-  boxAt R agent w worlds (λ w' => ¬ p w')
+  ¬ BoxAt R agent w worlds p →
+  BoxAt R agent w worlds (λ w' => ¬ p w')
 
 /-- The **excluded-middle premise**: the agent is *opinionated* about `p`,
 believing `p` or believing `¬p`. Gajewski's neg-raising presupposition. -/
 def opinionated {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) : Prop :=
-  boxAt R agent w worlds p ∨ boxAt R agent w worlds (λ w' => ¬ p w')
+  BoxAt R agent w worlds p ∨ BoxAt R agent w worlds (λ w' => ¬ p w')
 
 /-- **The pragmatic mechanism.** Opinionatedness about `p` licenses the O→E
 strengthening — a disjunctive syllogism. Neg-raising is this inference run on the
@@ -123,15 +123,15 @@ theorem negRaisesAt_of_opinionated {W E : Type*} (R : E → W → W → Prop) (a
     opinionated R agent worlds p w → negRaisesAt R agent worlds p w :=
   fun hem hnot => hem.resolve_left hnot
 
-/-- The accessible-worlds set at `w`; `boxAt … p` is `∀ w' ∈ accessibleSet, p w'`. -/
+/-- The accessible-worlds set at `w`; `BoxAt … p` is `∀ w' ∈ accessibleSet, p w'`. -/
 def accessibleSet {W E : Type*} (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (w : W) : Set W :=
   {w' | w' ∈ worlds ∧ R agent w w'}
 
 theorem boxAt_iff_forall_accessibleSet {W E : Type*} (R : E → W → W → Prop) (agent : E)
     (worlds : List W) (p : W → Prop) (w : W) :
-    boxAt R agent w worlds p ↔ ∀ w' ∈ accessibleSet R agent worlds w, p w' := by
-  simp only [boxAt, accessibleSet, Set.mem_setOf_eq, and_imp]
+    BoxAt R agent w worlds p ↔ ∀ w' ∈ accessibleSet R agent worlds w, p w' := by
+  simp only [BoxAt, accessibleSet, Set.mem_setOf_eq, and_imp]
 
 /-- **Validity ⟺ decided state.** The agent is opinionated about *every* prejacent
 (neg-raising then holds as a validity) iff the accessible state is decided — a

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -1127,7 +1127,7 @@ For modalized φ (might p, must p), verifiers are still pow(S ∩ p) —
 modalized complements raise the same issue as unmodalized ones.
 -/
 
-open Semantics.Attitudes.Doxastic (diaAt boxAt)
+open Doxastic (DiamondAt BoxAt)
 
 /-- An emotive doxastic predicate: hybrid representational + preferential.
 
@@ -1156,7 +1156,7 @@ case. -/
 def EmotiveDoxasticPredicate.doxasticAssertion {W E : Type*}
     (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W) : Prop :=
-  diaAt V.access agent w worlds p
+  DiamondAt V.access agent w worlds p
 
 /-- The uncertainty condition: both φ-verifiers and φ-falsifiers exist
 in DOX. The attitude holder is genuinely uncertain about φ.
@@ -1168,9 +1168,9 @@ def EmotiveDoxasticPredicate.uncertaintyCondition {W E : Type*}
     (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W) : Prop :=
   -- ∃w' ∈ DOX: p(w') — verifiers exist
-  diaAt V.access agent w worlds p ∧
+  DiamondAt V.access agent w worlds p ∧
   -- ∃w' ∈ DOX: ¬p(w') — falsifiers exist
-  diaAt V.access agent w worlds (fun w' => ¬ p w')
+  DiamondAt V.access agent w worlds (fun w' => ¬ p w')
 
 /-- The preference assertion: φ-verifying doxastic alternatives are
 preferred to φ-falsifying ones.
@@ -1195,7 +1195,7 @@ Note: condition (ii) is entailed by the first conjunct of (i), so it is
 redundant in the conjunction. We include it explicitly for clarity and
 because it is the component responsible for epistemic licensing — it
 provides the information state that embedded epistemics are anaphoric to. -/
-def EmotiveDoxasticPredicate.holdsAt {W E : Type*}
+def EmotiveDoxasticPredicate.HoldsAt {W E : Type*}
     (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop) [DecidablePred p]
     (w : W) (worlds : List W) (C : AlternativeList W) : Prop :=
   V.uncertaintyCondition agent p w worlds ∧
@@ -1228,15 +1228,15 @@ reduces to: ∃w'' ∈ DOX: p(w'').
 Both yield: DOX ∩ p ≠ ∅.
 
 We model this by showing that the doxastic assertion for `p` and for
-the function `λ w. diaAt R x w worlds p` (= "might p" evaluated at
+the function `λ w. DiamondAt R x w worlds p` (= "might p" evaluated at
 the same DOX) are equivalent when the information state is shared. -/
 theorem doxastic_assertion_might_concord {W E : Type*}
     (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W)
     (h : V.doxasticAssertion agent p w worlds) :
     V.doxasticAssertion agent
-      (fun _ => diaAt V.access agent w worlds p) w worlds := by
-  simp only [EmotiveDoxasticPredicate.doxasticAssertion, diaAt] at *
+      (fun _ => DiamondAt V.access agent w worlds p) w worlds := by
+  simp only [EmotiveDoxasticPredicate.doxasticAssertion, DiamondAt] at *
   obtain ⟨w', hw'_in, hw'_acc, hw'_p⟩ := h
   exact ⟨w', hw'_in, hw'_acc, ⟨w', hw'_in, hw'_acc, hw'_p⟩⟩
 
@@ -1247,9 +1247,9 @@ violating the uncertainty condition's requirement that
 theorem must_contradicts_uncertainty {W E : Type*}
     (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
     (w : W) (worlds : List W)
-    (h_must : boxAt V.access agent w worlds p) :
+    (h_must : BoxAt V.access agent w worlds p) :
     ¬ V.uncertaintyCondition agent p w worlds := by
-  simp only [EmotiveDoxasticPredicate.uncertaintyCondition, diaAt, boxAt] at *
+  simp only [EmotiveDoxasticPredicate.uncertaintyCondition, DiamondAt, BoxAt] at *
   rintro ⟨_, ⟨w', hw'_in, hw'_acc, hw'_np⟩⟩
   exact hw'_np (h_must w' hw'_in hw'_acc)
 

--- a/Linglib/Semantics/Attitudes/SituationDependent.lean
+++ b/Linglib/Semantics/Attitudes/SituationDependent.lean
@@ -37,8 +37,8 @@ open Tense
 namespace Semantics.Attitudes.SituationDependent
 
 open Intensional (WorldTimeIndex)
-open Semantics.Attitudes.Doxastic
-  (Veridicality DoxasticPredicate boxAt veridicalityHolds)
+open Doxastic
+  (Veridicality DoxasticPredicate BoxAt VeridicalityHolds)
 
 
 
@@ -64,7 +64,7 @@ abbrev SitAccessRel (W Time E : Type*) := E → WorldTimeIndex W Time → WorldT
 
     ⟦□p⟧(s) = ∀s' ∈ situations. R(agent, s, s') → p(s')
 
-    Generalizes `Doxastic.boxAt` from worlds to situations. -/
+    Generalizes `Doxastic.BoxAt` from worlds to situations. -/
 def sitBoxAt {W Time E : Type*} (R : SitAccessRel W Time E) (agent : E)
     (s : WorldTimeIndex W Time) (situations : List (WorldTimeIndex W Time))
     (p : SitProp W Time) : Prop :=
@@ -74,7 +74,7 @@ def sitBoxAt {W Time E : Type*} (R : SitAccessRel W Time E) (agent : E)
 
     ⟦◇p⟧(s) = ∃s' ∈ situations. R(agent, s, s') ∧ p(s')
 
-    Generalizes `Doxastic.diaAt` from worlds to situations. -/
+    Generalizes `Doxastic.DiamondAt` from worlds to situations. -/
 def sitDiaAt {W Time E : Type*} (R : SitAccessRel W Time E) (agent : E)
     (s : WorldTimeIndex W Time) (situations : List (WorldTimeIndex W Time))
     (p : SitProp W Time) : Prop :=
@@ -123,16 +123,16 @@ def liftAccess {W Time E : Type*} (R : E → W → W → Prop) : SitAccessRel W 
 
     `sitBoxAt (liftAccess R) agent s sits (liftProp p)`
     is equivalent to
-    `boxAt R agent s.world (sits.map (·.world)) p`.
+    `BoxAt R agent s.world (sits.map (·.world)) p`.
 
     This means code using the old world-only operators produces
     identical results when embedded in the situation framework. -/
-theorem sitBoxAt_lift_eq_boxAt {W Time E : Type*}
+theorem sitBoxAt_lift_eq_BoxAt {W Time E : Type*}
     (R : E → W → W → Prop) (agent : E) (s : WorldTimeIndex W Time)
     (sits : List (WorldTimeIndex W Time)) (p : W → Prop) :
     sitBoxAt (liftAccess R) agent s sits (liftProp p) ↔
-    boxAt R agent s.world (sits.map (·.world)) p := by
-  simp only [sitBoxAt, boxAt, liftAccess, liftProp, List.mem_map]
+    BoxAt R agent s.world (sits.map (·.world)) p := by
+  simp only [sitBoxAt, BoxAt, liftAccess, liftProp, List.mem_map]
   constructor
   · intro h w' ⟨s', hs', heq⟩ hR
     exact heq ▸ h s' hs' (heq ▸ hR)
@@ -147,7 +147,7 @@ theorem sitBoxAt_lift_eq_boxAt {W Time E : Type*}
 /-- Veridicality check for situation-dependent propositions.
 
     For veridical predicates (know), requires p(s) at the
-    evaluation situation. Mirrors `Doxastic.veridicalityHolds`. -/
+    evaluation situation. Mirrors `Doxastic.VeridicalityHolds`. -/
 def sitVeridicalityHolds {W Time : Type*} (v : Veridicality)
     (p : SitProp W Time) (s : WorldTimeIndex W Time) : Prop :=
   match v with
@@ -162,8 +162,8 @@ instance sitVeridicalityHolds_decidable {W Time : Type*} (v : Veridicality)
 /-- Lifted veridicality matches world-level veridicality. -/
 theorem sitVeridicalityHolds_lift {W Time : Type*} (v : Veridicality)
     (p : W → Prop) (s : WorldTimeIndex W Time) :
-    sitVeridicalityHolds v (liftProp p) s ↔ veridicalityHolds v p s.world := by
-  cases v <;> simp [sitVeridicalityHolds, veridicalityHolds, liftProp]
+    sitVeridicalityHolds v (liftProp p) s ↔ VeridicalityHolds v p s.world := by
+  cases v <;> simp [sitVeridicalityHolds, VeridicalityHolds, liftProp]
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -187,10 +187,10 @@ structure SitDoxasticPredicate (W Time E : Type*) where
 
 /-- Semantics for a situation-dependent doxastic predicate.
 
-    ⟦x V that p⟧(s) = veridicalityHolds(V, p, s) ∧ ∀s'. R(x,s,s') → p(s')
+    ⟦x V that p⟧(s) = VeridicalityHolds(V, p, s) ∧ ∀s'. R(x,s,s') → p(s')
 
-    Generalizes `DoxasticPredicate.holdsAt` to situations. -/
-def SitDoxasticPredicate.holdsAt {W Time E : Type*}
+    Generalizes `DoxasticPredicate.HoldsAt` to situations. -/
+def SitDoxasticPredicate.HoldsAt {W Time E : Type*}
     (V : SitDoxasticPredicate W Time E) (agent : E) (p : SitProp W Time)
     (s : WorldTimeIndex W Time) (situations : List (WorldTimeIndex W Time)) : Prop :=
   sitVeridicalityHolds V.veridicality p s ∧ sitBoxAt V.access agent s situations p
@@ -214,8 +214,8 @@ def liftDoxastic {W E : Type*} (V : DoxasticPredicate W E)
 
 /-- The lifted predicate matches the original semantics.
 
-    `(liftDoxastic V Time).holdsAt agent (liftProp p) s sits`
-    iff `V.holdsAt agent p s.world (sits.map.world)`.
+    `(liftDoxastic V Time).HoldsAt agent (liftProp p) s sits`
+    iff `V.HoldsAt agent p s.world (sits.map.world)`.
 
     This is the key backward-compatibility theorem: any existing
     analysis using `DoxasticPredicate` can be replayed exactly
@@ -224,10 +224,10 @@ theorem liftDoxastic_holdsAt_eq {W Time E : Type*}
     (V : DoxasticPredicate W E) (agent : E)
     (p : W → Prop) (s : WorldTimeIndex W Time)
     (sits : List (WorldTimeIndex W Time)) :
-    (liftDoxastic V Time).holdsAt agent (liftProp p) s sits ↔
-    V.holdsAt agent p s.world (sits.map (·.world)) := by
-  simp only [SitDoxasticPredicate.holdsAt, DoxasticPredicate.holdsAt,
-    liftDoxastic, sitVeridicalityHolds_lift, sitBoxAt_lift_eq_boxAt]
+    (liftDoxastic V Time).HoldsAt agent (liftProp p) s sits ↔
+    V.HoldsAt agent p s.world (sits.map (·.world)) := by
+  simp only [SitDoxasticPredicate.HoldsAt, DoxasticPredicate.HoldsAt,
+    liftDoxastic, sitVeridicalityHolds_lift, sitBoxAt_lift_eq_BoxAt]
 
 
 -- ════════════════════════════════════════════════════════════════
@@ -241,8 +241,8 @@ theorem sit_veridical_entails_complement {W Time E : Type*}
     (V : SitDoxasticPredicate W Time E) (hV : V.veridicality = .veridical)
     (agent : E) (p : SitProp W Time) (s : WorldTimeIndex W Time)
     (sits : List (WorldTimeIndex W Time))
-    (holds : V.holdsAt agent p s sits) : p s := by
-  unfold SitDoxasticPredicate.holdsAt at holds
+    (holds : V.HoldsAt agent p s sits) : p s := by
+  unfold SitDoxasticPredicate.HoldsAt at holds
   rw [hV] at holds
   exact holds.1
 

--- a/Linglib/Semantics/Reference/Almog2014.lean
+++ b/Linglib/Semantics/Reference/Almog2014.lean
@@ -265,7 +265,7 @@ structural fact about ⟨individual, property⟩ pairs, not an explanation of
 attitude opacity. Per (Ch 2, §2.1), no doctrine regarding
 modal or cognitive matters follows from direct reference theory proper.
 Substitution failure in attitude reports requires an independent theory
-of attitudinal verb semantics (see `Attitudes.Doxastic.substitutionMayFail`
+of attitudinal verb semantics (see `Attitudes.Doxastic.SubstitutionMayFail`
 for the formal framework). -/
 theorem structured_content_distinguishes {W E : Type*} :
     ∀ (a b : E) (P : E → W → Prop), a ≠ b →

--- a/Linglib/Semantics/Truthmaker/Entailment.lean
+++ b/Linglib/Semantics/Truthmaker/Entailment.lean
@@ -39,13 +39,13 @@ mereological parthood are exactly what the world-extensional notion
 drops. This non-equivalence is theorematised in
 `santorio_truthmaker_neq_fine_content_part` in the same study file.
 
-`Semantics/Attitudes/Doxastic.lean`'s Hintikka `boxAt` is
+`Semantics/Attitudes/Doxastic.lean`'s Hintikka `BoxAt` is
 ∀-over-accessible-worlds; truthmaker `attHolds` (`Basic.lean`) is
 ∃-verifier-part-of-info-state. The empirical heart of
 [bondarenko-elliott-2026] is exactly this divergence: `attHolds`
 distinguishes hyperintensional content (witness: the headline theorem
 `subjectMatter_distinguishes_classically_equivalent` in `Basic.lean`),
-which `boxAt` cannot.
+which `BoxAt` cannot.
 
 -/
 

--- a/Linglib/Studies/AnandHacquard2013.lean
+++ b/Linglib/Studies/AnandHacquard2013.lean
@@ -58,7 +58,7 @@ namespace AnandHacquard2013
 
 open Semantics.Attitudes.Representationality
 open Semantics.Attitudes.Preferential
-open Semantics.Attitudes.Doxastic
+open Doxastic
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Empirical Data: Acceptability Ratings (Table 4)
@@ -245,8 +245,8 @@ theorem believe_must {E : Type*} (R : E → W → W → Prop)
     [∀ a w w', Decidable (R a w w')]
     (agent : E) (w : W) (worlds : List W) (p : W → Prop) [DecidablePred p] :
     mustS (representationalS R agent w worlds) p ↔
-    boxAt R agent w worlds p := by
-  simp only [mustS, representationalS, boxAt,
+    BoxAt R agent w worlds p := by
+  simp only [mustS, representationalS, BoxAt,
     List.mem_filter, decide_eq_true_eq]
   constructor
   · intro h w' hw' hR

--- a/Linglib/Studies/BondarenkoElliott2026.lean
+++ b/Linglib/Studies/BondarenkoElliott2026.lean
@@ -75,7 +75,7 @@ The contrast in (2) follows.
   one-line application.
 - `believes_does_not_always_close_under_intersection` — cross-framework:
   B&E's mereological `Believes` does NOT close under conjunction the way
-  Hintikka's `boxAt` does, witnessed by a non-believings-closed model.
+  Hintikka's `BoxAt` does, witnessed by a non-believings-closed model.
 
 ## Implementation notes
 
@@ -692,13 +692,13 @@ closes under intersection; B&E does **not** always close (witnessed by
 a model where `CONTSum` is violated).
 
 A self-contained `hintikkaBox` is used here rather than importing
-`Semantics/Attitudes/Doxastic.boxAt` directly — same definition,
+`Semantics/Attitudes/Doxastic.BoxAt` directly — same definition,
 no transitive deps. -/
 
 section CrossFramework
 
 /-- Hintikka-style box modality: `p` is believed iff every accessible
-    world makes `p` true. Equivalent to `Doxastic.boxAt`; defined here
+    world makes `p` true. Equivalent to `Doxastic.BoxAt`; defined here
     self-contained to avoid the heavyweight Doxastic import. -/
 def hintikkaBox {W E : Type*} (R : E → W → W → Prop) (x : E) (w : W)
     (worlds : List W) (p : Set W) : Prop :=

--- a/Linglib/Studies/Glass2025.lean
+++ b/Linglib/Studies/Glass2025.lean
@@ -34,17 +34,68 @@ Semantics and Pragmatics 18, Article 8: 1-17.
 Belief verb denotations are `PartialProp W` values produced by
 `DoxasticPredicate.toPartialProp`. The presup field captures the factive
 presupposition (or lack thereof). yǐwéi's postsupposition is a
-`Postsupposition` value (§2 below). The `PresupClass` classification and PLC
-validation from `Doxastic.lean` derive the contrafactive gap.
+`Postsupposition` value (§2 below). The `PresupClass` typology and the
+attestation classifier `presupClassIsValid` are defined here; their
+causal derivation via the Predicate Lexicalization Constraint is
+[roberts-ozyildiz-2025]'s account, prosecuted in
+`Studies/RobertsOzyildiz2025.lean`.
 -/
 
 namespace Glass2025
 
-open Semantics.Attitudes.Doxastic
+open Doxastic
 open Semantics.Presupposition
 open ArgumentStructure
 open English.Predicates.Verbal
 open Mandarin.Predicates
+
+
+/-! ### The presuppositional classes
+
+The typology of belief verbs by presuppositional profile: factive
+(*know* — CommonGround must entail p), nonfactive (*think* — no
+requirement), contrafactive (hypothetical *contra* — CommonGround must
+entail ¬p; UNATTESTED), with yǐwéi's ◇¬p requirement a postsupposition
+(§2), not a presupposition. The class of a verb is derived from its
+veridicality, and `presupClassIsValid` records the attestation facts —
+valid iff not contrafactive. -/
+
+/-- Presuppositional profile of a doxastic verb. -/
+inductive PresupClass where
+  /-- Presupposes p (*know*). -/
+  | factive
+  /-- Would presuppose ¬p (hypothetical *contra*; unattested). -/
+  | contrafactive
+  /-- No presupposition (*believe*, *think*). -/
+  | nonfactive
+  /-- None of the above. -/
+  | other
+  deriving DecidableEq, Repr
+
+/-- Classify a doxastic verb by its veridicality. -/
+def classifyVeridicality : Veridicality → PresupClass
+  | .veridical => .factive
+  | .nonVeridical => .nonfactive
+
+/-- The attestation facts: every profile is attested except the
+    contrafactive. The causal derivation of this table is
+    `RobertsOzyildiz2025.presupClassIsValid_eq_via_plc`. -/
+def presupClassIsValid : PresupClass → Bool
+  | .factive       => true
+  | .nonfactive    => true
+  | .contrafactive => false
+  | .other         => true
+
+/-- Factive presuppositions are attested. -/
+theorem factive_presup_valid : presupClassIsValid .factive = true := rfl
+
+/-- Contrafactive presuppositions are unattested. -/
+theorem contrafactive_presup_invalid :
+    presupClassIsValid .contrafactive = false := rfl
+
+/-- Nonfactive profiles are attested (no presupposition to check). -/
+theorem nonfactive_presup_valid :
+    presupClassIsValid .nonfactive = true := rfl
 
 -- ============================================================================
 -- §1. MiniWorld Model
@@ -276,43 +327,43 @@ veridicality in the Fragment entry. These theorems will BREAK if:
 
 theorem know_is_factive :
     know.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  native_decide
+  decide
 
 theorem realize_is_factive :
     realize.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  native_decide
+  decide
 
 theorem discover_is_factive :
     discover.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  native_decide
+  decide
 
 theorem notice_is_factive :
     notice.toVerb.veridicality.map classifyVeridicality = some .factive := by
-  native_decide
+  decide
 
 -- Non-factive verbs → .nonfactive
 
 theorem believe_is_nonfactive :
     believe.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  native_decide
+  decide
 
 theorem think_is_nonfactive :
     think.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  native_decide
+  decide
 
 theorem hope_is_nonfactive :
     hope.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  native_decide
+  decide
 
 theorem fear_is_nonfactive :
     fear.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  native_decide
+  decide
 
 -- yǐwéi: classified as nonfactive by veridicality alone
 
 theorem yiwei_veridicality_nonfactive :
     yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- §6. yǐwéi Exception: Postsupposition Not Derivable from Veridicality
@@ -343,7 +394,7 @@ def yiweiPostsupType : PostsupType := .weakContrafactive
 
 /-- yǐwéi's veridicality gives nonfactive — no presupposition. -/
 theorem yiwei_derived_nonfactive :
-    yiwei.toVerb.veridicality = some .nonVeridical := by native_decide
+    yiwei.toVerb.veridicality = some .nonVeridical := by decide
 
 /-- The postsupposition IS necessary: veridicality alone gives .nonfactive
     (no presupposition), but yǐwéi actually has a weak contrafactive
@@ -353,7 +404,7 @@ theorem yiwei_derived_nonfactive :
 theorem yiwei_postsup_not_from_veridicality :
     yiwei.toVerb.veridicality.map classifyVeridicality = some .nonfactive ∧
     yiweiPostsupType = .weakContrafactive :=
-  ⟨by native_decide, rfl⟩
+  ⟨by decide, rfl⟩
 
 -- ============================================================================
 -- §7. The Contrafactive Gap
@@ -384,7 +435,7 @@ theorem all_english_attitude_verbs_valid :
      expect, wish, fear, dread, worry].all (fun v =>
       v.toVerb.veridicality.map classifyVeridicality |>.map
         presupClassIsValid |>.getD true) = true := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- §8. End-to-End Derivation
@@ -401,12 +452,12 @@ This section exercises the complete pipeline for representative verbs.
 /-- End-to-end: "know" is factive, and factive presuppositions are valid. -/
 theorem know_endtoend_valid :
     (know.toVerb.veridicality.map classifyVeridicality).map
-      presupClassIsValid = some true := by native_decide
+      presupClassIsValid = some true := by decide
 
 /-- End-to-end: "believe" is nonfactive, and nonfactive is valid. -/
 theorem believe_endtoend_valid :
     (believe.toVerb.veridicality.map classifyVeridicality).map
-      presupClassIsValid = some true := by native_decide
+      presupClassIsValid = some true := by decide
 
 /-- End-to-end: know's presupposition is satisfied in a factive context. -/
 theorem know_presup_satisfied_endtoend :

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -682,7 +682,7 @@ DENY triggers in French often require the matrix clause to be negated
 or questioned for EN to occur (§6.1.3). -/
 
 open Semantics.Attitudes.NegRaising (negRaisingAvailable)
-open Semantics.Attitudes.Doxastic (Veridicality)
+open Doxastic (Veridicality)
 
 /-- DENY triggers license EN through the doxastic square:
 

--- a/Linglib/Studies/Mirrazi2024.lean
+++ b/Linglib/Studies/Mirrazi2024.lean
@@ -60,7 +60,7 @@ descriptive content.
 namespace Mirrazi2024
 
 open Quantification.ChoiceFunction
-open Semantics.Attitudes.Doxastic (boxAt)
+open Doxastic (BoxAt)
 open Semantics.Attitudes.NegRaising (negRaisesAt)
 open Farsi.Determiners (ye candTa doTa PlainIndefiniteEntry)
 
@@ -130,9 +130,9 @@ theorem nonNegRaiser_suffices :
     without claiming neg-raising explains the scope paradox. -/
 theorem think_does_neg_raise {W E : Type*} (R : E → W → W → Prop)
     (agent : E) (worlds : List W) (p : W → Prop) (w : W)
-    (hNeg : ¬ boxAt R agent w worlds p)
+    (hNeg : ¬ BoxAt R agent w worlds p)
     (hExclMiddle : negRaisesAt R agent worlds p w) :
-    boxAt R agent w worlds (λ w' => ¬ p w') :=
+    BoxAt R agent w worlds (λ w' => ¬ p w') :=
   hExclMiddle hNeg
 
 -- ============================================================================
@@ -222,7 +222,7 @@ end TruthConditions
     intensional operator, forcing de re. There is no landing site that
     is simultaneously above NEG and below the intensional operator
     (since NEG is syntactically below the operator). -/
-theorem movement_above_neg_forces_deRe
+theorem movement_above_neg_forces_DeRe
     {W E : Type*} (f : SkolemCF W E)
     (R : E → W → W → Prop) (agent : E) (worlds : List W)
     (nounProp : W → E → Prop) (vp : E → W → Prop) (w₀ : W) :

--- a/Linglib/Studies/RobertsOzyildiz2025.lean
+++ b/Linglib/Studies/RobertsOzyildiz2025.lean
@@ -1,0 +1,172 @@
+import Linglib.Studies.Glass2025
+import Linglib.Semantics.Causation.SEM.Bool
+import Linglib.Semantics.Causation.SEM.Counterfactual
+
+/-!
+# Roberts & Özyıldız 2025: The causal derivation of the contrafactive gap
+
+[roberts-ozyildiz-2025] derive the contrafactive gap — the absence of
+verbs presupposing ¬p while asserting belief in p — from the
+**Predicate Lexicalization Constraint (PLC)**: presupposed content must
+be causally upstream of at-issue content. A verbal predicate with
+at-issue content α can carry presupposition π only if a causal chain
+runs from π to α in the normative belief-formation model
+p → indic(p) → acq(a)(iₚ) → B(a)(p): the fact generates indicators,
+acquaintance with which causes belief.
+
+Factives satisfy the PLC (`factive_satisfies_plc`: the chain from p to
+B(a)(p) exists); strong contrafactives violate it
+(`strong_contrafactive_violates_plc`: ¬p generates indicators for ¬p,
+not for p, so no chain reaches B(a)(p)) — the gap follows
+(`contrafactive_gap`), and structurally so
+(`contrafactive_gap_is_structural`: presupposing ¬p while asserting
+B(a)(¬p) is fine). Weak contrafactives like Mandarin yǐwéi escape:
+their falsity inference is a postsupposition about the output context
+([glass-2025]), not a presupposition inside the same eventuality, so
+the PLC does not apply. `presupClassIsValid_eq_via_plc` derives
+[glass-2025]'s attestation table from the causal account.
+
+The belief-formation model is a deterministic `BoolSEM` over the
+`Causation` substrate; the PLC check runs `developDetOn` over a
+topologically ordered vertex list so proofs reduce structurally.
+-/
+
+namespace RobertsOzyildiz2025
+
+open Doxastic Glass2025
+open Semantics.Presupposition
+open Causation Causation.Mechanism Causation.SEM
+
+/-! ### The belief-formation causal model -/
+
+/-- Variables of belief formation: the fact, its negation, their
+    indicators, acquaintance with the indicators, and the resulting
+    beliefs. An enum so the `developDet` fixpoint reduces
+    structurally. -/
+inductive BeliefVar
+  | p | not_p
+  | indic_p | indic_not_p
+  | acq_a_ip | acq_a_inp
+  | B_a_p | B_a_not_p
+  deriving DecidableEq, Fintype, Repr
+
+/-- The causal graph: the chain `p → indic(p) → acq(a)(iₚ) → B(a)(p)`
+    and its parallel ¬p chain. -/
+def beliefGraph : CausalGraph BeliefVar :=
+  ⟨fun
+    | .p => ∅
+    | .not_p => ∅
+    | .indic_p => {.p}
+    | .indic_not_p => {.not_p}
+    | .acq_a_ip => {.indic_p}
+    | .acq_a_inp => {.indic_not_p}
+    | .B_a_p => {.acq_a_ip}
+    | .B_a_not_p => {.acq_a_inp}⟩
+
+/-- The belief-formation `BoolSEM`: roots default to `false` (the input
+    valuation overrides); each derived vertex copies its sole parent. -/
+noncomputable def beliefSEM : BoolSEM BeliefVar :=
+  { graph := beliefGraph
+    mech := fun v => match v with
+      | .p => const (G := beliefGraph) false
+      | .not_p => const (G := beliefGraph) false
+      | .indic_p => deterministic (fun ρ => ρ ⟨.p, by simp [beliefGraph]⟩)
+      | .indic_not_p => deterministic (fun ρ => ρ ⟨.not_p, by simp [beliefGraph]⟩)
+      | .acq_a_ip => deterministic (fun ρ => ρ ⟨.indic_p, by simp [beliefGraph]⟩)
+      | .acq_a_inp => deterministic (fun ρ => ρ ⟨.indic_not_p, by simp [beliefGraph]⟩)
+      | .B_a_p => deterministic (fun ρ => ρ ⟨.acq_a_ip, by simp [beliefGraph]⟩)
+      | .B_a_not_p => deterministic (fun ρ => ρ ⟨.acq_a_inp, by simp [beliefGraph]⟩) }
+
+noncomputable instance : SEM.IsDeterministic beliefSEM where
+  mech_det v := match v with
+    | .p => inferInstanceAs (Mechanism.IsDeterministic (const _))
+    | .not_p => inferInstanceAs (Mechanism.IsDeterministic (const _))
+    | .indic_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .indic_not_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .acq_a_ip => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .acq_a_inp => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .B_a_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+    | .B_a_not_p => inferInstanceAs (Mechanism.IsDeterministic (deterministic _))
+
+/-- Topologically ordered vertex list: one `stepOnceDetOn` pass
+    propagates the whole chain. -/
+def beliefVarList : List BeliefVar :=
+  [.p, .not_p, .indic_p, .indic_not_p, .acq_a_ip, .acq_a_inp, .B_a_p, .B_a_not_p]
+
+/-! ### The Predicate Lexicalization Constraint -/
+
+/-- The PLC: presupposition `presup` can be lexicalized with at-issue
+    content `atIssue` iff setting the presupposition true and running
+    the belief-formation model produces the at-issue content. -/
+noncomputable def SatisfiesPLC (presup atIssue : BeliefVar) : Prop :=
+  (developDetOn beliefSEM beliefVarList 1
+    (Valuation.empty.extend presup true)).hasValue atIssue true
+
+noncomputable instance (presup atIssue : BeliefVar) :
+    Decidable (SatisfiesPLC presup atIssue) :=
+  Classical.dec _
+
+/-- Factives satisfy the PLC: the chain from `p` reaches `B(a)(p)`. -/
+theorem factive_satisfies_plc : SatisfiesPLC .p .B_a_p := by
+  unfold SatisfiesPLC
+  rfl
+
+/-- Strong contrafactives violate the PLC: `¬p` generates indicators
+    for `¬p`, not for `p`, so no chain reaches `B(a)(p)`. -/
+theorem strong_contrafactive_violates_plc : ¬ SatisfiesPLC .not_p .B_a_p := by
+  unfold SatisfiesPLC
+  intro h
+  exact Bool.false_ne_true (Option.some.inj h)
+
+/-- The contrafactive gap: the factive/contrafactive asymmetry follows
+    from the PLC. -/
+theorem contrafactive_gap :
+    SatisfiesPLC .p .B_a_p ∧ ¬ SatisfiesPLC .not_p .B_a_p :=
+  ⟨factive_satisfies_plc, strong_contrafactive_violates_plc⟩
+
+/-- The asymmetry is structural: presupposing `¬p` while asserting
+    `B(a)(¬p)` is causally coherent — only the crossed profile is
+    ruled out. -/
+theorem contrafactive_gap_is_structural :
+    SatisfiesPLC .p .B_a_p ∧
+    ¬ SatisfiesPLC .not_p .B_a_p ∧
+    SatisfiesPLC .not_p .B_a_not_p := by
+  refine ⟨factive_satisfies_plc, strong_contrafactive_violates_plc, ?_⟩
+  unfold SatisfiesPLC
+  rfl
+
+/-! ### Deriving the attestation table -/
+
+/-- The causal variables checked by the PLC for each presuppositional
+    class: factives pair `p` with `B(a)(p)`, contrafactives `¬p` with
+    `B(a)(p)`; the PLC does not apply to nonfactives (no
+    presupposition) or postsuppositional profiles. -/
+def presupClassToCausalVars : PresupClass → Option (BeliefVar × BeliefVar)
+  | .factive => some (.p, .B_a_p)
+  | .contrafactive => some (.not_p, .B_a_p)
+  | .nonfactive => none
+  | .other => none
+
+/-- PLC verdict per class: `none` where the PLC does not apply. -/
+noncomputable def presupClassSatisfiesPLC (pc : PresupClass) : Option Bool :=
+  match presupClassToCausalVars pc with
+  | none => none
+  | some (presup, atIssue) => some (decide (SatisfiesPLC presup atIssue))
+
+/-- [glass-2025]'s attestation table is derived from the PLC: a class
+    is attested iff it satisfies the PLC or the PLC does not apply. -/
+theorem presupClassIsValid_eq_via_plc (pc : PresupClass) :
+    presupClassIsValid pc = (presupClassSatisfiesPLC pc).getD true := by
+  cases pc <;> simp [presupClassIsValid, presupClassSatisfiesPLC,
+    presupClassToCausalVars]
+  · exact factive_satisfies_plc
+  · exact strong_contrafactive_violates_plc
+
+/-- `PartialProp` of the hypothetical contrafactive: presupposes `¬p`,
+    asserts belief in `p` — the causally incoherent profile. -/
+def contrafactivePartialProp {W E : Type*} (R : E → W → W → Prop)
+    (agent : E) (p : W → Prop) (worlds : List W) : PartialProp W :=
+  { presup := fun w => ¬ p w
+  , assertion := fun w => BoxAt R agent w worlds p }
+
+end RobertsOzyildiz2025

--- a/Linglib/Studies/Schlenker2003.lean
+++ b/Linglib/Studies/Schlenker2003.lean
@@ -14,7 +14,7 @@ End-to-end verification of [schlenker-2003]'s core argument:
    to the actual speaker, even under attitude verbs
 2. Amharic violates the thesis: "I" shifts to the attitude holder
 3. Context quantification (`ContextBox`) captures both patterns:
-   - With world-only meaning → reduces to standard `boxAt` (Fixity holds)
+   - With world-only meaning → reduces to standard `BoxAt` (Fixity holds)
    - With agent-reading meaning → strictly more expressive (Fixity fails)
 4. Person features as presuppositions derive logophoric pronouns
 
@@ -41,7 +41,7 @@ namespace Schlenker2003
 
 open Semantics.Context
 open ContextQuantification
-open Semantics.Attitudes.Doxastic (boxAt)
+open Doxastic (BoxAt)
 open Semantics.Reference.ShiftedIndexicals (amharic_pronI)
 open Semantics.Reference.Kaplan (pronI_access)
 
@@ -111,9 +111,9 @@ instance : ∀ p w, Decidable (isHappy p w) := by
 /-- English: "Bob said that I am happy" = "Bob said that Alice is happy."
     The meaning is world-only (Alice is fixed by origin-reading "I"),
     so context quantification reduces to standard world quantification. -/
-theorem english_reduces_to_boxAt :
+theorem english_reduces_to_BoxAt :
     ContextBox bobBel .bob (fun c => isHappy .alice c.world) rootT .w0 [.w0, .w1] ↔
-    boxAt bobBel .bob .w0 [.w0, .w1] (isHappy .alice) :=
+    BoxAt bobBel .bob .w0 [.w0, .w1] (isHappy .alice) :=
   contextBox_world_only bobBel .bob (isHappy .alice) rootT .w0 [.w0, .w1]
 
 /-- English version is false: Alice is NOT happy in all of Bob's
@@ -125,7 +125,7 @@ theorem english_result :
 
 /-- Amharic: "Bob said that I am happy" = "Bob said that Bob is happy."
     The meaning reads the agent from the shifted context (Bob),
-    so ContextBox does NOT reduce to boxAt. -/
+    so ContextBox does NOT reduce to BoxAt. -/
 theorem amharic_result :
     ContextBox bobBel .bob (fun c => isHappy c.agent c.world)
       rootT .w0 [.w0, .w1] := by

--- a/Linglib/Syntax/Minimalist/LeftPeriphery.lean
+++ b/Linglib/Syntax/Minimalist/LeftPeriphery.lean
@@ -246,21 +246,21 @@ theorem derived_class_matches_manual :
 
 PerspP introduces a not-at-issue presupposition: the perspectival center
 *possibly doesn't know* the answer to the question. We formalize this using
-`diaAt` (existential modal, ◇) from `Doxastic.lean` and `QUD.ans` from
+`DiamondAt` (existential modal, ◇) from `Doxastic.lean` and `QUD.ans` from
 `Semantics/Questions/Partition/Cells.lean`.
 -/
 
-open Semantics.Attitudes.Doxastic
+open Doxastic
 
 /-- Whether x possibly doesn't know Ans(Q) at world w:
     ◇¬know(x, Ans(Q)) = ∃w' ∈ R(x,w). ¬(Ans(Q,w) holds at w')
 
     This is PerspP's not-at-issue presupposition ([dayal-2025]: §2.3).
-    Uses `diaAt` from Doxastic.lean and `QUD.ans` from
+    Uses `DiamondAt` from Doxastic.lean and `QUD.ans` from
     Semantics/Questions/Partition/Cells.lean. -/
 def possibleIgnorance {W E : Type*} (R : E → W → W → Prop) (center : E)
     (Q : QUD W) (w : W) (worlds : List W) : Prop :=
-  diaAt R center w worlds (fun w' => QUD.ans Q w w' = false)
+  DiamondAt R center w worlds (fun w' => QUD.ans Q w w' = false)
 
 /-- PerspP as a presuppositional question denotation.
     At-issue: the question Q itself.
@@ -291,8 +291,8 @@ in bare (non-negated, non-questioned) contexts.
 theorem box_excludes_dia_neg {W E : Type*}
     (R : E → W → W → Prop) (agent : E) (w : W) (worlds : List W)
     (p : W → Prop)
-    (hBox : boxAt R agent w worlds p) :
-    ¬ diaAt R agent w worlds (fun w' => ¬ p w') := by
+    (hBox : BoxAt R agent w worlds p) :
+    ¬ DiamondAt R agent w worlds (fun w' => ¬ p w') := by
   rintro ⟨w', hw', hR, hNotP⟩
   exact hNotP (hBox w' hw' hR)
 
@@ -300,15 +300,15 @@ theorem box_excludes_dia_neg {W E : Type*}
     "x knows Q" at w means there exists a true answer p that x box-believes.
     In particular, x box-believes Ans(Q,w) (the complete answer at w).
 
-    TODO: Full proof requires showing that holdsAtQuestion with the G&S-derived
-    Hamblin denotation implies boxAt for Ans(Q,w). The key step is:
-    holdsAtQuestion finds *some* true p that x box-believes; since the question
+    TODO: Full proof requires showing that HoldsAtQuestion with the G&S-derived
+    Hamblin denotation implies BoxAt for Ans(Q,w). The key step is:
+    HoldsAtQuestion finds *some* true p that x box-believes; since the question
     is a partition, that p determines the same cell as Ans(Q,w). -/
 theorem veridical_question_entails_box_ans {W E : Type*}
     (V : DoxasticPredicate W E) (_hV : V.veridicality = .veridical)
     (agent : E) (Q : QUD W) (w : W) (worlds : List W)
-    (hHolds : boxAt V.access agent w worlds (fun w' => QUD.ans Q w w' = true)) :
-    ¬ diaAt V.access agent w worlds (fun w' => QUD.ans Q w w' = false) := by
+    (hHolds : BoxAt V.access agent w worlds (fun w' => QUD.ans Q w w' = true)) :
+    ¬ DiamondAt V.access agent w worlds (fun w' => QUD.ans Q w w' = false) := by
   rintro ⟨w', hw', hR, hFalse⟩
   have hTrue : QUD.ans Q w w' = true := hHolds w' hw' hR
   rw [hFalse] at hTrue
@@ -323,7 +323,7 @@ theorem veridical_question_entails_box_ans {W E : Type*}
 theorem veridical_blocks_perspP {W E : Type*}
     (V : DoxasticPredicate W E) (hV : V.veridicality = .veridical)
     (agent : E) (Q : QUD W) (w : W) (worlds : List W)
-    (hBox : boxAt V.access agent w worlds (fun w' => QUD.ans Q w w' = true)) :
+    (hBox : BoxAt V.access agent w worlds (fun w' => QUD.ans Q w w' = true)) :
     ¬ possibleIgnorance V.access agent Q w worlds := by
   simp only [possibleIgnorance]
   exact veridical_question_entails_box_ans V hV agent Q w worlds hBox
@@ -533,19 +533,19 @@ to the abstract epistemic layer used by PerspP. -/
 def doxasticToEpistemicModel {W E : Type*}
     (V : DoxasticPredicate W E) [∀ a w w', Decidable (V.access a w w')]
     (agent : E) (w : W) (worlds : List W) : EpistemicModel W where
-  knows := fun p => decide (V.holdsAt agent (fun w' => p w' = true) w worlds)
+  knows := fun p => decide (V.HoldsAt agent (fun w' => p w' = true) w worlds)
 
 /-- A veridical predicate that box-knows Ans(Q) blocks PerspP through
     the epistemic model bridge.
 
-    TODO: Full proof requires showing holdsAt for veridical predicates
+    TODO: Full proof requires showing HoldsAt for veridical predicates
     at the answer proposition entails the answer is true at the eval world
-    (which follows from veridical_entails_complement + boxAt). -/
+    (which follows from veridical_entails_complement + BoxAt). -/
 theorem veridical_model_blocks_perspP {W E : Type*}
     (V : DoxasticPredicate W E) [∀ a w w', Decidable (V.access a w w')]
     (_hV : V.veridicality = .veridical)
     (agent : E) (Q : QUD W) (w : W) (worlds : List W)
-    (hHolds : V.holdsAt agent (fun w' => QUD.ans Q w w' = true) w worlds) :
+    (hHolds : V.HoldsAt agent (fun w' => QUD.ans Q w w' = true) w worlds) :
     perspPPresupComp (doxasticToEpistemicModel V agent w worlds) Q w = false := by
   simp [perspPPresupComp, doxasticToEpistemicModel, hHolds]
 


### PR DESCRIPTION
Deep cleanse of `Doxastic.lean` (721 → ~200 lines). The ~290-line Roberts–Özyıldız causal apparatus (belief-formation SEM, PLC, contrafactive-gap theorems) had zero consumers outside Glass2025 — demoted to a new `Studies/RobertsOzyildiz2025.lean`, which imports Glass2025 and derives its attestation table from the PLC; the Glass typology (`PresupClass`, `classifyVeridicality`, `presupClassIsValid`) demotes to `Studies/Glass2025.lean` (whose two `native_decide`s become `decide`). Eight imports drop from the core file — consumers no longer pull `Causation`/`LevinClass`/`Aktionsart` through it. Dead cuts: `contrafactivePartialProp`-in-substrate, `nonVeridical_not_entails`, `veridical_self_referential`, the `DeDicto` alias of `HoldsAt`, two rfl projection lemmas. Bare `Doxastic` namespace + UpperCamelCase Props per policy (`BoxAt`, `DiamondAt` — spelling out the `dia` truncation — `HoldsAt`, `VeridicalityHolds`, …) across 16 consumers; the module docstring becomes a real `/-!` block after imports (it was a plain comment before them, invisible to doc-gen).