### PR TITLE
refactor(Semantics/Attitudes): replace DecProp with Finset in Desire

### DIFF
--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -4,7 +4,6 @@ import Linglib.Semantics.Modality.Kratzer.Operators
 import Linglib.Semantics.Presupposition.Basic
 import Linglib.Core.Order.Satisfaction
 import Linglib.Core.Order.SimilarityOrdering
-import Linglib.Semantics.Questions.Hamblin
 import Linglib.Core.Probability.Decision.Basic
 import Mathlib.Order.Basic
 import Mathlib.Data.Set.Basic
@@ -74,42 +73,6 @@ section Generic
 
 variable {W : Type*} [Fintype W] [DecidableEq W]
 
-/-! ### Decidable propositions
-
-A `DecProp W` bundles a `Set W` with its `DecidablePred` witness so it
-can sit as the element type of a partition list while remaining
-`decide`-able. This is a structure (not `Subtype`) because
-`DecidablePred` lives in `Type`, not `Prop`. -/
-
-/-- A `Set W` paired with its `DecidablePred` witness. -/
-structure DecProp (W : Type*) where
-  /-- The underlying `Prop`-valued proposition. -/
-  prop : Set W
-  /-- Decidability witness for the underlying proposition. -/
-  dec : DecidablePred prop
-
-/-- Smart constructor for a `DecProp` from a `Set W` with synthesizable
-    decidability. -/
-@[reducible] def mkDec (p : Set W) [h : DecidablePred p] : DecProp W := ⟨p, h⟩
-
-instance (a : DecProp W) : DecidablePred a.prop := a.dec
-
-/-! ### Decidable subset and overlap on `Set W`
-
-Mathlib's `s ⊆ t` and `(s ∩ t).Nonempty` are not auto-decidable on `Set`
-(the elaborator does not unfold `Set.Subset` to see the underlying `∀`).
-We expose `@[reducible]` aliases that *are* decidable under
-`[Fintype W]` + `DecidablePred` for both arguments. The aliases are
-definitionally equal to their `Set`-API counterparts and are intended
-to read as the same operation. -/
-
-/-- `PropEntails p q ↔ p ⊆ q` (definitionally), with decidability. -/
-@[reducible] def PropEntails (p q : Set W) : Prop := ∀ w, p w → q w
-
-/-- `PropOverlap p q ↔ (p ∩ q).Nonempty` (definitionally), with
-    decidability. -/
-@[reducible] def PropOverlap (p q : Set W) : Prop := ∃ w, p w ∧ q w
-
 /-! ### Answer preference ([phillips-brown-2025] §3.5)
 
 The paper's preference relation between answers `a, a' ∈ Q_c-Bel_S`:
@@ -126,12 +89,12 @@ Pareto-undominated elements (see §3.5, p. 11:21). -/
     entails, `a` also entails. The Pareto-undominated elements under
     this relation are the "best answers" of [phillips-brown-2025]
     §3.5. -/
-def propositionOrdering (GS : List (DecProp W)) :
-    SatisfactionOrdering (DecProp W) (DecProp W) :=
-  SatisfactionOrdering.ofCriteria (fun a p => decide (PropEntails a.prop p.prop)) GS
+def propositionOrdering (GS : List (Finset W)) :
+    SatisfactionOrdering (Finset W) (Finset W) :=
+  SatisfactionOrdering.ofCriteria (fun a p => decide (a ⊆ p)) GS
 
 /-- Best (= Pareto-undominated) answers among a candidate list. -/
-abbrev undominatedAnswers (GS answers : List (DecProp W)) : List (DecProp W) :=
+abbrev undominatedAnswers (GS answers : List (Finset W)) : List (Finset W) :=
   (propositionOrdering GS).undominated answers
 
 /-! ### Question-relative belief ([phillips-brown-2025] §3.3)
@@ -139,21 +102,21 @@ abbrev undominatedAnswers (GS answers : List (DecProp W)) : List (DecProp W) :=
 Q_c-Bel_S = the cells of Q_c compatible with S's beliefs. -/
 
 /-- The cells of `answers` that overlap `belS`. -/
-def questionRelativeBelief (answers : List (DecProp W))
-    (belS : Set W) [DecidablePred belS] : List (DecProp W) :=
-  answers.filter fun a => decide (PropOverlap a.prop belS)
+def questionRelativeBelief (answers : List (Finset W))
+    (belS : Set W) [DecidablePred belS] : List (Finset W) :=
+  answers.filter fun a => decide (∃ w ∈ a, belS w)
 
 /-! ### Question-based want ([phillips-brown-2025] §3.4) -/
 
 /-- ⟦S wants p⟧^c = every undominated answer in Q_c-Bel_S entails p.
     The paper's central definition (§3.5). -/
 def WantQuestionBased (belS : Set W) [DecidablePred belS]
-    (GS answers : List (DecProp W)) (p : Set W) [DecidablePred p] : Prop :=
+    (GS answers : List (Finset W)) (p : Set W) [DecidablePred p] : Prop :=
   ∀ a ∈ undominatedAnswers GS (questionRelativeBelief answers belS),
-    PropEntails a.prop p
+    ∀ w ∈ a, p w
 
 instance (belS : Set W) [DecidablePred belS]
-    (GS answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
+    (GS answers : List (Finset W)) (p : Set W) [DecidablePred p] :
     Decidable (WantQuestionBased belS GS answers p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
@@ -167,24 +130,27 @@ desires, by definition. -/
 /-- World ordering induced by a desire list: `w ≤ z` iff every desire
     in `GS` satisfied at `z` is also satisfied at `w` — [kratzer-1981]'s
     `atLeastAsGoodAs` over the projected proposition list, by definition.
-    Decidability is transported from the per-`DecProp` witnesses via
-    `worldAtLeastAsGood_iff_decProp`. -/
-def WorldAtLeastAsGood (GS : List (DecProp W)) (w z : W) : Prop :=
-  Modality.Kratzer.atLeastAsGoodAs (GS.map (·.prop)) w z
+    Decidability is transported through the membership form
+    `worldAtLeastAsGood_iff_mem`. -/
+def WorldAtLeastAsGood (GS : List (Finset W)) (w z : W) : Prop :=
+  Modality.Kratzer.atLeastAsGoodAs (GS.map (fun s w => w ∈ s)) w z
 
 omit [Fintype W] [DecidableEq W] in
-/-- The ordering in its `DecProp`-quantified form, where each desire
-    carries its decidability witness. -/
-theorem worldAtLeastAsGood_iff_decProp (GS : List (DecProp W)) (w z : W) :
-    WorldAtLeastAsGood GS w z ↔ ∀ p ∈ GS, p.prop z → p.prop w := by
-  show (∀ p ∈ GS.map (·.prop), p z → p w) ↔ _
-  simp only [List.mem_map]
-  refine ⟨fun h a ha hpz => h a.prop ⟨a, ha, rfl⟩ hpz,
-          fun h _ ⟨a, ha, hap⟩ hpz => hap ▸ h a ha (hap ▸ hpz)⟩
+/-- The ordering in its membership form: every listed desire satisfied
+    at `z` is satisfied at `w`. -/
+theorem worldAtLeastAsGood_iff_mem (GS : List (Finset W)) (w z : W) :
+    WorldAtLeastAsGood GS w z ↔ ∀ s ∈ GS, z ∈ s → w ∈ s := by
+  show (∀ p ∈ GS.map (fun s w => w ∈ s), p z → p w) ↔ _
+  constructor
+  · intro h a ha hz
+    exact h _ (List.mem_map.mpr ⟨a, ha, rfl⟩) hz
+  · intro h q hq hz
+    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hq
+    exact h a ha hz
 
-instance (GS : List (DecProp W)) (w z : W) :
+instance (GS : List (Finset W)) (w z : W) :
     Decidable (WorldAtLeastAsGood GS w z) :=
-  decidable_of_iff _ (worldAtLeastAsGood_iff_decProp GS w z).symm
+  decidable_of_iff _ (worldAtLeastAsGood_iff_mem GS w z).symm
 
 /-- Standard von Fintel [von-fintel-1999] semantics: every undominated
     belS-world is a p-world. The `[DecidablePred]` hypotheses are not
@@ -192,13 +158,13 @@ instance (GS : List (DecProp W)) (w z : W) :
     so that abstract reasoning (e.g. instances of
     `BeliefBasedDesireSemantics`) can use `WantVonFintel` without supplying
     them. -/
-def WantVonFintel (belS : Set W) (GS : List (DecProp W)) (p : Set W) : Prop :=
+def WantVonFintel (belS : Set W) (GS : List (Finset W)) (p : Set W) : Prop :=
   ∀ w, belS w →
     (∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) →
     p w
 
 instance (belS : Set W) [DecidablePred belS]
-    (GS : List (DecProp W)) (p : Set W) [DecidablePred p] :
+    (GS : List (Finset W)) (p : Set W) [DecidablePred p] :
     Decidable (WantVonFintel belS GS p) :=
   inferInstanceAs (Decidable (∀ _, _))
 
@@ -207,23 +173,23 @@ instance (belS : Set W) [DecidablePred belS]
 /-- **Considering Constraint** (§3.6): every cell of Q_c either
     entails p or entails ¬p. Equivalently (over partition cells):
     p is a union of cells. -/
-def IsConsidered (answers : List (DecProp W))
+def IsConsidered (answers : List (Finset W))
     (p : Set W) [DecidablePred p] : Prop :=
-  ∀ a ∈ answers, (∀ w, a.prop w → p w) ∨ (∀ w, a.prop w → ¬ p w)
+  ∀ a ∈ answers, (∀ w ∈ a, p w) ∨ (∀ w ∈ a, ¬ p w)
 
-instance (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
+instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
     Decidable (IsConsidered answers p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-- **Diversity Constraint** (§3.7, attributed to
     [condoravdi-2002]): Q_c contains both p-cells and ¬p-cells.
     Without diversity, ⟦want p⟧ would be vacuously true (or false). -/
-def IsDiverse (answers : List (DecProp W))
+def IsDiverse (answers : List (Finset W))
     (p : Set W) [DecidablePred p] : Prop :=
-  (∃ a ∈ answers, ∀ w, a.prop w → p w) ∧
-  (∃ a ∈ answers, ∀ w, a.prop w → ¬ p w)
+  (∃ a ∈ answers, ∀ w ∈ a, p w) ∧
+  (∃ a ∈ answers, ∀ w ∈ a, ¬ p w)
 
-instance (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
+instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
     Decidable (IsDiverse answers p) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
@@ -255,12 +221,10 @@ basic dimensions). -/
     salient propositions; passing the empty list trivially satisfies the
     constraint, so study files must opt in by listing the basic
     propositions of their model. -/
-def IsAntiDeckstacking (naturalProps answers : List (DecProp W)) : Prop :=
-  ∀ q ∈ naturalProps,
-    (∀ a ∈ answers, ¬ ∀ w, a.prop w → q.prop w) ∨
-    (∀ a ∈ answers, (∀ w, a.prop w → q.prop w) ∨ (∀ w, a.prop w → ¬ q.prop w))
+def IsAntiDeckstacking (naturalProps answers : List (Finset W)) : Prop :=
+  ∀ q ∈ naturalProps, (∃ a ∈ answers, a ⊆ q) → IsConsidered answers (· ∈ q)
 
-instance (naturalProps answers : List (DecProp W)) :
+instance (naturalProps answers : List (Finset W)) :
     Decidable (IsAntiDeckstacking naturalProps answers) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
@@ -271,11 +235,11 @@ instance (naturalProps answers : List (DecProp W)) :
     like William III ⊨ "Avoid nuclear war" when the agent lacks the
     conceptual resources to grasp the question. -/
 def IsBelSensitive (belS : Set W) [DecidablePred belS]
-    (answers : List (DecProp W)) : Prop :=
+    (answers : List (Finset W)) : Prop :=
   let live := questionRelativeBelief answers belS
   live ≠ [] ∧ live.length ≠ answers.length
 
-instance (belS : Set W) [DecidablePred belS] (answers : List (DecProp W)) :
+instance (belS : Set W) [DecidablePred belS] (answers : List (Finset W)) :
     Decidable (IsBelSensitive belS answers) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
@@ -284,14 +248,14 @@ instance (belS : Set W) [DecidablePred belS] (answers : List (DecProp W)) :
     Anti-deckstacking §3.7, Belief-sensitivity §4.2). The
     `naturalProps` parameter feeds Anti-deckstacking. -/
 def WantDefined (belS : Set W) [DecidablePred belS]
-    (naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] : Prop :=
+    (naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] : Prop :=
   IsConsidered answers p ∧
   IsDiverse answers p ∧
   IsAntiDeckstacking naturalProps answers ∧
   IsBelSensitive belS answers
 
 instance (belS : Set W) [DecidablePred belS]
-    (naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
+    (naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] :
     Decidable (WantDefined belS naturalProps answers p) := by
   unfold WantDefined; infer_instance
 
@@ -307,7 +271,7 @@ suppressed. -/
 /-- Question-based `want` as a partial proposition (`Core.PartialProp`):
     presupposition = full definedness; assertion = question-based truth. -/
 def wantPartialProp (belS : Set W) [DecidablePred belS]
-    (GS naturalProps answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
+    (GS naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] :
     PartialProp W where
   presup _ := WantDefined belS naturalProps answers p
   assertion _ := WantQuestionBased belS GS answers p
@@ -321,8 +285,8 @@ the result is computable and `decide`-able for concrete models. -/
 
 /-- The finest partition over an explicit world list: one singleton
     cell per listed world. -/
-def finestPartition (worlds : List W) : List (DecProp W) :=
-  worlds.map fun w => mkDec (· = w)
+def finestPartition (worlds : List W) : List (Finset W) :=
+  worlds.map ({·})
 
 /-! ### Supporting lemmas
 
@@ -333,70 +297,48 @@ The §3.4 metasemantic identity is proved via three helper lemmas
 undominated singleton cells correspond to Pareto-undominated
 belS-worlds), then a direct two-direction `iff` proof. -/
 
+omit [Fintype W] in
 /-- Singleton-cell preference under `propositionOrdering` reduces to
-    single-world preference under `WorldAtLeastAsGood`: for cells
-    `mkDec (· = w)` and `mkDec (· = z)`, `mkDec (· = w) ≤ mkDec (· = z)`
-    in the proposition ordering iff `WorldAtLeastAsGood GS w z`. -/
-private theorem singleton_le_iff_world (GS : List (DecProp W)) (w z : W) :
-    (propositionOrdering GS).le (mkDec (· = w)) (mkDec (· = z)) ↔
-      WorldAtLeastAsGood GS w z := by
-  rw [worldAtLeastAsGood_iff_decProp]
+    single-world preference under `WorldAtLeastAsGood`: `{w} ≤ {z}` in
+    the proposition ordering iff `WorldAtLeastAsGood GS w z`. -/
+private theorem singleton_le_iff_world (GS : List (Finset W)) (w z : W) :
+    (propositionOrdering GS).le {w} {z} ↔ WorldAtLeastAsGood GS w z := by
+  rw [worldAtLeastAsGood_iff_mem]
   unfold propositionOrdering SatisfactionOrdering.ofCriteria
-  show (∀ q ∈ GS.filter (fun q => decide (PropEntails (mkDec (· = z)).prop q.prop)),
-          decide (PropEntails (mkDec (· = w)).prop q.prop) = true) ↔
-       (∀ q ∈ GS, q.prop z → q.prop w)
-  simp only [PropEntails, decide_eq_true_eq]
+  show (∀ q ∈ GS.filter (fun q => decide (({z} : Finset W) ⊆ q)),
+          decide (({w} : Finset W) ⊆ q) = true) ↔
+       (∀ s ∈ GS, z ∈ s → w ∈ s)
+  simp only [decide_eq_true_eq, Finset.singleton_subset_iff]
   constructor
   · intro h q hq hqz
-    have hqfilter : q ∈ GS.filter (fun q' => decide (∀ x, x = z → q'.prop x)) := by
-      rw [List.mem_filter]
-      refine ⟨hq, ?_⟩
-      simp only [decide_eq_true_eq]
-      intro x hx; exact hx ▸ hqz
-    exact h q hqfilter w rfl
-  · intro h q hq_filter
-    rw [List.mem_filter] at hq_filter
-    obtain ⟨hq, hqz_filter⟩ := hq_filter
-    simp only [decide_eq_true_eq] at hqz_filter
-    have hqz : q.prop z := hqz_filter z rfl
-    intro x hx
-    exact hx ▸ h q hq hqz
+    exact h q (by rw [List.mem_filter]; exact ⟨hq, by simpa using hqz⟩)
+  · intro h q hqf
+    rw [List.mem_filter] at hqf
+    exact h q hqf.1 (by simpa using hqf.2)
 
-/-- A singleton cell `mkDec (· = w)` is in `questionRelativeBelief
+omit [Fintype W] [DecidableEq W] in
+/-- The singleton cell `{w}` is in `questionRelativeBelief
     (finestPartition worlds) belS` iff `w ∈ worlds` and `belS w`. -/
 private theorem mem_qRB_finestPartition_iff (belS : Set W) [DecidablePred belS]
     (worlds : List W) (w : W) :
-    mkDec (· = w) ∈ questionRelativeBelief (finestPartition worlds) belS ↔
+    ({w} : Finset W) ∈ questionRelativeBelief (finestPartition worlds) belS ↔
       w ∈ worlds ∧ belS w := by
-  unfold questionRelativeBelief finestPartition
-  rw [List.mem_filter]
-  simp only [List.mem_map, decide_eq_true_eq, PropOverlap, mkDec]
-  constructor
-  · rintro ⟨⟨v, hv_mem, hv_eq⟩, ⟨x, hxv, hxBel⟩⟩
-    -- mkDec injection on `prop`: (· = v) = (· = w), evaluate at v
-    have hpropEq : (fun x => x = v) = (fun x => x = w) :=
-      congrArg DecProp.prop hv_eq
-    have hvw : v = w := by
-      have := congrFun hpropEq v
-      simpa using this
-    subst hvw
-    subst hxv
-    exact ⟨hv_mem, hxBel⟩
-  · rintro ⟨hw_mem, hbel⟩
-    exact ⟨⟨w, hw_mem, rfl⟩, ⟨w, rfl, hbel⟩⟩
+  simp [questionRelativeBelief, finestPartition, List.mem_filter,
+    Finset.singleton_inj]
 
+omit [Fintype W] in
 theorem wantQuestionBased_finestPartition_iff_WantVonFintel
-    (belS : Set W) [DecidablePred belS] (GS : List (DecProp W))
+    (belS : Set W) [DecidablePred belS] (GS : List (Finset W))
     (worlds : List W) (hUniv : ∀ w, w ∈ worlds)
     (p : Set W) [DecidablePred p] :
     WantQuestionBased belS GS (finestPartition worlds) p ↔ WantVonFintel belS GS p := by
   unfold WantQuestionBased WantVonFintel undominatedAnswers SatisfactionOrdering.undominated
   refine ⟨fun hLHS w hw hUnd => ?_, fun hRHS a ha => ?_⟩
-  · -- LHS → RHS: pick the cell `mkDec (· = w)`, show it's undominated, apply
-    have hcell_mem : mkDec (· = w) ∈
+  · -- LHS → RHS: pick the cell `{w}`, show it's undominated, apply
+    have hcell_mem : ({w} : Finset W) ∈
         questionRelativeBelief (finestPartition worlds) belS :=
       (mem_qRB_finestPartition_iff belS worlds w).mpr ⟨hUniv w, hw⟩
-    have hcell_undom : mkDec (· = w) ∈
+    have hcell_undom : ({w} : Finset W) ∈
         ((propositionOrdering GS).undominated
           (questionRelativeBelief (finestPartition worlds) belS)) := by
       unfold SatisfactionOrdering.undominated
@@ -404,7 +346,7 @@ theorem wantQuestionBased_finestPartition_iff_WantVonFintel
       refine ⟨hcell_mem, ?_⟩
       simp only [decide_eq_true_eq]
       rintro ⟨c, hc_mem, hc_strict⟩
-      -- c is in qRB; via mem_qRB_finestPartition_iff, c = mkDec (· = z) for
+      -- c is in qRB; via mem_qRB_finestPartition_iff, c = {z} for
       -- some z with belS z. Translate hc_strict to wAALG and contradict hUnd.
       have hc_in_fp : c ∈ finestPartition worlds := by
         unfold questionRelativeBelief at hc_mem
@@ -418,38 +360,32 @@ theorem wantQuestionBased_finestPartition_iff_WantVonFintel
       have hnwz : ¬ WorldAtLeastAsGood GS w z := fun h =>
         hc_strict.2 ((singleton_le_iff_world GS w z).mpr h)
       exact hUnd z hz_bel ⟨hzw, hnwz⟩
-    have := hLHS _ hcell_undom
-    exact this w rfl
+    exact hLHS _ hcell_undom w (Finset.mem_singleton_self w)
   · -- RHS → LHS: a is in undominated qRB; extract its world and apply hRHS
     rw [List.mem_filter] at ha
     obtain ⟨ha_mem, ha_min⟩ := ha
-    -- a ∈ qRB; extract w with a = mkDec (· = w), w ∈ worlds, belS w
+    -- a ∈ qRB; extract w with a = {w}, w ∈ worlds, belS w
     have ha_in_fp : a ∈ finestPartition worlds := by
       unfold questionRelativeBelief at ha_mem
       exact (List.mem_filter.mp ha_mem).1
     obtain ⟨w, _hw_mem, hw_eq⟩ := List.mem_map.mp ha_in_fp
-    -- Substitute a := mkDec (· = w) throughout
+    -- Substitute a := {w} throughout
     subst hw_eq
     have hbelw : belS w :=
       ((mem_qRB_finestPartition_iff belS worlds w).mp ha_mem).2
-    -- ha_min: ¬ ∃ c ∈ qRB, c strictly better than mkDec (· = w)
+    -- ha_min: ¬ ∃ c ∈ qRB, c strictly better than {w}
     simp only [decide_eq_true_eq] at ha_min
     have hUnd : ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧
                                   ¬ WorldAtLeastAsGood GS w z) := by
       intro z hz_bel ⟨hzw, hnwz⟩
       apply ha_min
-      refine ⟨mkDec (· = z), ?_, ?_⟩
+      refine ⟨{z}, ?_, ?_⟩
       · exact (mem_qRB_finestPartition_iff belS worlds z).mpr ⟨hUniv z, hz_bel⟩
       · exact ⟨(singleton_le_iff_world GS z w).mpr hzw,
                fun h => hnwz ((singleton_le_iff_world GS w z).mp h)⟩
-    -- Apply hRHS at w; get p w; convert to PropEntails
     have hpw : p w := hRHS w hbelw hUnd
     intro x hx
-    -- hx : (mkDec (· = w)).prop x = (x = w)
-    -- Goal: p x
-    show p x
-    have : x = w := hx
-    exact this ▸ hpw
+    exact (Finset.mem_singleton.mp hx) ▸ hpw
 
 /-! ### The belief-based no-go for von Fintel ([phillips-brown-2025] §2)
 
@@ -463,7 +399,7 @@ omit [Fintype W] [DecidableEq W] in
     then no vF-prediction makes both `want p` and `want ¬p` true. -/
 theorem wantVonFintel_no_conflict
     (belS : Set W) [DecidablePred belS]
-    (GS : List (DecProp W)) (p : Set W) [DecidablePred p]
+    (GS : List (Finset W)) (p : Set W) [DecidablePred p]
     (h : ∃ w, belS w ∧
       ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) :
     ¬ (WantVonFintel belS GS p ∧ WantVonFintel belS GS (fun w => ¬ p w)) := by
@@ -479,12 +415,12 @@ omit [Fintype W] [DecidableEq W] in
     doxastic-closure problem that motivates the question-based
     approach (§4.1). -/
 theorem wantVonFintel_upward_monotonic (belS : Set W) [DecidablePred belS]
-    (GS : List (DecProp W)) (p q : Set W) [DecidablePred p] [DecidablePred q]
+    (GS : List (Finset W)) (p q : Set W) [DecidablePred p] [DecidablePred q]
     (hpq : ∀ w, p w → q w) (h : WantVonFintel belS GS p) :
     WantVonFintel belS GS q :=
   fun w hw hund => hpq w (h w hw hund)
 
-omit [DecidableEq W] in
+omit [Fintype W] in
 /-- Question-based `want` is **Strawson upward monotonic** (§4.2):
     `WantQuestionBased belS GS Q p`, `p ⊆ q`, and `q` considered
     relative to `Q` jointly imply `WantQuestionBased belS GS Q q`. The
@@ -493,7 +429,7 @@ omit [DecidableEq W] in
     Avoid-war". -/
 theorem wantQuestionBased_strawson_upward_monotonic
     (belS : Set W) [DecidablePred belS]
-    (GS answers : List (DecProp W)) (p q : Set W)
+    (GS answers : List (Finset W)) (p q : Set W)
     [DecidablePred p] [DecidablePred q]
     (hpq : ∀ w, p w → q w) (_hCons : IsConsidered answers q)
     (h : WantQuestionBased belS GS answers p) :
@@ -693,46 +629,6 @@ theorem wantHeim_no_conflict
     exact this.2
   exact hynp (hxy_eq ▸ hxp)
 
-/-! ### Bridge to the `Question` API
-
-PB's `List (DecProp W)` is a finite-presentation view of a partition
-question. The substrate exposes bridge theorems showing each PB
-predicate corresponds to a property of the underlying
-`Question W`:
-
-* `WantQuestionBased` "every undominated answer entails p" relates to
-  the partition property "every undominated cell of `Q` entails `p`"
-  — i.e., `∀ q ∈ alt Q, q ∈ undominated → q ⊆ p`.
-
-* `IsConsidered` corresponds to `partial-answerhood for the polar
-  question of p`: every cell of Q is either a confirming or refuting
-  answer to "p?".
-
-The `toQuestion` constructor lifts a `List (DecProp W)` to
-`Question W` via `Question.ofList`. -/
-
-/-- Lift a list of decidable cells to a `Question W`. -/
-def toQuestion (answers : List (DecProp W)) : Question W :=
-  Question.ofList (answers.map (·.prop))
-
-omit [Fintype W] [DecidableEq W] in
-/-- `IsConsidered Q p` agrees with the polar-answerhood reading of
-    every cell: each cell either entails `p` or entails `pᶜ`, which is
-    exactly "every cell is a partial answer to the polar question of
-    `p`". -/
-theorem isConsidered_iff_polar_partial_answer
-    (answers : List (DecProp W)) (p : Set W) [DecidablePred p] :
-    IsConsidered answers p ↔
-    ∀ a ∈ answers, a.prop ⊆ p ∨ a.prop ⊆ {w | ¬ p w} := by
-  unfold IsConsidered
-  refine ⟨fun h a ha => ?_, fun h a ha => ?_⟩
-  · rcases h a ha with hp | hnp
-    · exact Or.inl (fun w hw => hp w hw)
-    · exact Or.inr (fun w hw hpw => hnp w hw hpw)
-  · rcases h a ha with hp | hnp
-    · exact Or.inl (fun w hw => hp hw)
-    · exact Or.inr (fun w hw hpw => hnp hw hpw)
-
 end Generic
 
 /-! ### Effective-preference readings ([condoravdi-lauer-2016])
@@ -901,27 +797,22 @@ simultaneous truth of `ought(φ) ∧ ought(¬φ)` when both are in the
 alternative set. -/
 
 /-- Sloman's Principle: `p` strictly dominates every other listed
-    alternative on the expected-value scale. Decidable via the
-    underlying `expectedValue` decidability. -/
-def SlomanPrinciple [Fintype W]
+    alternative on the expected-value scale. -/
+def SlomanPrinciple [Fintype W] [DecidableEq W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ)
-    (alts : List (Σ' (q : Set W), DecidablePred q))
-    (p : Set W) [DecidablePred p] : Prop :=
-  ∀ entry ∈ alts,
-    let _ : DecidablePred entry.fst := entry.snd
-    entry.fst ≠ p →
-    expectedValue pr V belS p > expectedValue pr V belS entry.fst
+    (alts : List (Finset W)) (p : Finset W) : Prop :=
+  ∀ entry ∈ alts, entry ≠ p →
+    expectedValue pr V belS (· ∈ p) > expectedValue pr V belS (· ∈ entry)
 
 /-- **Lassiter's full account**: the bare threshold AND Sloman's
     Principle. This is the *actual* account Lassiter defends in §8;
     the bare `want` operator alone is the apparatus, not the position. -/
-def WantWithSloman [Fintype W]
+def WantWithSloman [Fintype W] [DecidableEq W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
-    (alts : List (Σ' (q : Set W), DecidablePred q))
-    (p : Set W) [DecidablePred p] : Prop :=
-  Want belS pr V θ p ∧ SlomanPrinciple belS pr V alts p
+    (alts : List (Finset W)) (p : Finset W) : Prop :=
+  Want belS pr V θ (· ∈ p) ∧ SlomanPrinciple belS pr V alts p
 
 /-! ### Bridge to decision theory
 
@@ -974,34 +865,25 @@ theorem threshold_admits_conflict_witness :
 /-! ### Sloman's Principle blocks the witness
 
 Lassiter's *full* account adds Sloman's Principle (eq. 8.16 p.216).
-On the conflict-witness model with `alts = [propP, ¬propP]`, Sloman
-holds for `propP` (E_V(propP) = 7 > 2 = E_V(¬propP) ✓) but FAILS for
-`¬propP` (E_V(¬propP) = 2 ≯ 7 = E_V(propP) ✗). So
-`WantWithSloman` makes only `propP` wanted, blocking the conflict.
+On the conflict-witness model with `alts = [p, pᶜ]`, Sloman holds for
+`p` (E_V(p) = 7 > 2 = E_V(pᶜ) ✓) but FAILS for `pᶜ`
+(E_V(pᶜ) = 2 ≯ 7 = E_V(p) ✗). So `WantWithSloman` makes only `p`
+wanted, blocking the conflict.
 
 This formalizes Lassiter's §8.11 (p.245) position: single-V conflict
 is blocked by his own constraints; genuine conflicting wants come from
 multi-source aggregation, not from threshold-tuning. -/
 
 theorem wantWithSloman_blocks_conflict
-    [Fintype W] (belS : Set W) [DecidablePred belS]
+    [Fintype W] [DecidableEq W] (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
-    (p : Set W) [DecidablePred p]
-    (alts : List (Σ' (q : Set W), DecidablePred q))
-    (h_p_in_alts : ⟨p, inferInstance⟩ ∈ alts)
-    (h_negp_in_alts : ⟨fun w => ¬ p w, inferInstance⟩ ∈ alts)
-    (h_p_ne_negp : (p : Set W) ≠ (fun w => ¬ p w)) :
+    (alts : List (Finset W)) (p : Finset W)
+    (hp : p ∈ alts) (hpc : pᶜ ∈ alts) (hne : p ≠ pᶜ) :
     ¬ (WantWithSloman belS pr V θ alts p ∧
-       WantWithSloman belS pr V θ alts (fun w => ¬ p w)) := by
-  simp only [WantWithSloman, SlomanPrinciple]
-  rintro ⟨⟨_, hSlomanP⟩, ⟨_, hSlomanNegP⟩⟩
-  -- Sloman for p: E_V(p) > E_V(¬p) (since ¬p is in alts and ≠ p)
-  have h1 : expectedValue pr V belS p > expectedValue pr V belS (fun w => ¬ p w) := by
-    exact hSlomanP ⟨fun w => ¬ p w, inferInstance⟩ h_negp_in_alts h_p_ne_negp.symm
-  -- Sloman for ¬p: E_V(¬p) > E_V(p) (since p is in alts and ≠ ¬p)
-  have h2 : expectedValue pr V belS (fun w => ¬ p w) > expectedValue pr V belS p := by
-    exact hSlomanNegP ⟨p, inferInstance⟩ h_p_in_alts h_p_ne_negp
-  exact absurd (lt_trans h1 h2) (lt_irrefl _)
+       WantWithSloman belS pr V θ alts pᶜ) := by
+  rintro ⟨⟨_, hSlomanP⟩, ⟨_, hSlomanPc⟩⟩
+  exact absurd (lt_trans (hSlomanPc p hp hne) (hSlomanP pᶜ hpc hne.symm))
+    (lt_irrefl _)
 
 /-! ### Intermediacy of expected value ([lassiter-2017] §7.5–§7.6)
 

--- a/Linglib/Studies/Cariani2013.lean
+++ b/Linglib/Studies/Cariani2013.lean
@@ -98,7 +98,7 @@ INHERITANCE." See `cariani_duality_right_to_left_failure`.
 
 namespace Cariani2013
 
-open Desire (DecProp mkDec IsConsidered)
+open Desire (IsConsidered)
 
 /-! ## §1. Resolution Semantics primitives
 
@@ -110,9 +110,9 @@ parameters are options, ordering, benchmark. Per §4 (p.545):
 > exclusive propositions—i.e., as a partition of a subset S of
 > logical space.
 
-We model options as a `List (DecProp W)` — finite, with decidable
-membership — matching the substrate's `Desire`
-representation of partition cells. Mutual exclusivity is a hypothesis
+We model options as a `List (Finset W)` — finite, with decidable
+membership — matching the substrate's `Desire` representation of
+partition cells. Mutual exclusivity is a hypothesis
 on consumers, not a structure field. -/
 
 variable {W : Type*} [Fintype W] [DecidableEq W]
@@ -124,23 +124,23 @@ variable {W : Type*} [Fintype W] [DecidableEq W]
     quantitative scales, p.545). -/
 structure ResolutionContext (W : Type*) where
   /-- Mutually exclusive options (a partition of the relevant action
-      space). Stored as a list of `DecProp` for `decide`-friendliness. -/
-  options : List (DecProp W)
+      space). Stored as `Finset` cells for `decide`-friendliness. -/
+  options : List (Finset W)
   /-- Ranking on options: `betterThan o₁ o₂` means `o₁` is at least as
       preferable as `o₂`. -/
-  betterThan : DecProp W → DecProp W → Prop
+  betterThan : Finset W → Finset W → Prop
   /-- Decidability of the ordering. -/
   betterThanDec : ∀ a b, Decidable (betterThan a b)
   /-- Benchmark predicate: an option `meetsBenchmark` if it is at or
       above the threshold. -/
-  meetsBenchmark : DecProp W → Prop
+  meetsBenchmark : Finset W → Prop
   /-- Decidability of the benchmark predicate. -/
   meetsBenchmarkDec : ∀ o, Decidable (meetsBenchmark o)
 
-instance (rc : ResolutionContext W) (a b : DecProp W) :
+instance (rc : ResolutionContext W) (a b : Finset W) :
     Decidable (rc.betterThan a b) := rc.betterThanDec a b
 
-instance (rc : ResolutionContext W) (o : DecProp W) :
+instance (rc : ResolutionContext W) (o : Finset W) :
     Decidable (rc.meetsBenchmark o) := rc.meetsBenchmarkDec o
 
 /-! ## §2. The four derived predicates (Cariani §4 p.545-546)
@@ -156,12 +156,12 @@ instance (rc : ResolutionContext W) (o : DecProp W) :
 -/
 
 /-- Option `o` is a *way of* `p` iff `o` entails `p`. -/
-def isWayOf (o : DecProp W) (p : Set W) [DecidablePred p] : Prop :=
-  ∀ w, o.prop w → p w
+def isWayOf (o : Finset W) (p : Set W) [DecidablePred p] : Prop :=
+  ∀ w ∈ o, p w
 
-instance (o : DecProp W) (p : Set W) [DecidablePred p] :
+instance (o : Finset W) (p : Set W) [DecidablePred p] :
     Decidable (isWayOf o p) :=
-  inferInstanceAs (Decidable (∀ _, _))
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
 /-- `p` is **visible** in Cariani's options iff every option settles `p`.
 
@@ -194,15 +194,13 @@ instance (rc : ResolutionContext W) (p : Set W) [DecidablePred p] :
 
 /-- An option `o` is **best** iff it's at-least-as-good-as every other
     listed option. The `o ∈ rc.options` membership check is the
-    caller's responsibility (it's implicit in the typical
+    caller's responsibility — it's implicit in the typical
     `∀ o ∈ rc.options, isBest rc o → ...` consumption pattern in
-    `isOptimal`); dropping it from the definition avoids requiring
-    `DecidableEq (DecProp W)` (DecProp is a structure with a function
-    field — equality is not generally decidable). -/
-def isBest (rc : ResolutionContext W) (o : DecProp W) : Prop :=
+    `isOptimal`. -/
+def isBest (rc : ResolutionContext W) (o : Finset W) : Prop :=
   ∀ o' ∈ rc.options, rc.betterThan o o'
 
-instance (rc : ResolutionContext W) (o : DecProp W) :
+instance (rc : ResolutionContext W) (o : Finset W) :
     Decidable (isBest rc o) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
@@ -290,11 +288,7 @@ INHERITANCE fails because `attend ⊨ (attend ∨ burn)` but
 
 inductive RossW where
   | attend | stay_home | burn
-  deriving DecidableEq, Repr
-
-instance : Fintype RossW where
-  elems := {.attend, .stay_home, .burn}
-  complete := fun w => by cases w <;> decide
+  deriving DecidableEq, Fintype, Repr
 
 def attendProp : Set RossW | .attend => True | _ => False
 def stayHomeProp : Set RossW | .stay_home => True | _ => False
@@ -307,39 +301,33 @@ instance : DecidablePred stayHomeProp :=
 instance : DecidablePred burnProp :=
   fun w => by cases w <;> unfold burnProp <;> infer_instance
 
-/-- The three options. Each is the singleton extension of its
-    corresponding world-property. -/
-def rossOptions : List (DecProp RossW) :=
-  [mkDec attendProp, mkDec stayHomeProp, mkDec burnProp]
+/-- The three options: singleton courses of action. -/
+def rossOptions : List (Finset RossW) :=
+  [{.attend}, {.stay_home}, {.burn}]
 
-/-- Direct rank function on `RossW` worlds. We define rank on the
-    underlying world (not by introspecting the proposition) and lift
-    to options that entail a unique world. The lift returns 0 (below
-    benchmark) for any option whose extension isn't a singleton
-    matching one of the named worlds — which is the right behavior for
-    the paper's analysis. -/
+/-- Rank on `RossW` worlds: attend > stay_home > burn. -/
 def rossWorldRank : RossW → ℕ
   | .attend => 3
   | .stay_home => 2
   | .burn => 1
 
-/-- Rank of an option: max of `rossWorldRank` over the worlds in the
-    option (or 0 if the option is empty). For our three singleton
-    options, this is just the world's rank. -/
-def rossRank (o : DecProp RossW) : ℕ :=
-  ((Finset.univ : Finset RossW).filter (fun w => o.prop w)).sup rossWorldRank
+/-- Rank of an option: max of `rossWorldRank` over its worlds (0 for
+    the empty option). For the three singleton options, this is just
+    the world's rank. -/
+def rossRank (o : Finset RossW) : ℕ :=
+  o.sup rossWorldRank
 
-def rossBetterThan : DecProp RossW → DecProp RossW → Prop :=
+def rossBetterThan : Finset RossW → Finset RossW → Prop :=
   fun o o' => rossRank o ≥ rossRank o'
 
-instance (o o' : DecProp RossW) : Decidable (rossBetterThan o o') :=
+instance (o o' : Finset RossW) : Decidable (rossBetterThan o o') :=
   inferInstanceAs (Decidable (_ ≥ _))
 
 /-- Benchmark: only attend (rank 3) and stay_home (rank 2) meet
     benchmark. Burn (rank 1) is impermissible. -/
-def rossMeetsBenchmark : DecProp RossW → Prop := fun o => rossRank o ≥ 2
+def rossMeetsBenchmark : Finset RossW → Prop := fun o => rossRank o ≥ 2
 
-instance (o : DecProp RossW) : Decidable (rossMeetsBenchmark o) :=
+instance (o : Finset RossW) : Decidable (rossMeetsBenchmark o) :=
   inferInstanceAs (Decidable (_ ≥ _))
 
 def rossContext : ResolutionContext RossW where
@@ -349,47 +337,28 @@ def rossContext : ResolutionContext RossW where
   meetsBenchmark := rossMeetsBenchmark
   meetsBenchmarkDec := fun o => inferInstanceAs (Decidable (rossMeetsBenchmark o))
 
+/-- `ought(attend)` holds in Ross's context: visible, optimal, and
+    strongly permissible. -/
+theorem ross_ought_attend : ought rossContext attendProp := by decide
+
 /-- `attend` is visible in Ross's context — every option settles it. -/
-theorem ross_attend_visible : isVisible rossContext attendProp := by
-  intro o ho
-  unfold rossContext rossOptions at ho
-  simp only [List.mem_cons, List.not_mem_nil, or_false] at ho
-  rcases ho with rfl | rfl | rfl
-  · left; intro w hw; exact hw
-  · right; intro w hw; cases w <;> simp [stayHomeProp, attendProp] at hw ⊢
-  · right; intro w hw; cases w <;> simp [burnProp, attendProp] at hw ⊢
+theorem ross_attend_visible : isVisible rossContext attendProp := by decide
 
 /-- `attend ∨ burn` is also visible (every option settles it). -/
 theorem ross_attend_or_burn_visible :
-    isVisible rossContext (fun w => attendProp w ∨ burnProp w) := by
-  intro o ho
-  unfold rossContext rossOptions at ho
-  simp only [List.mem_cons, List.not_mem_nil, or_false] at ho
-  rcases ho with rfl | rfl | rfl
-  · left; intro w hw; exact Or.inl hw
-  · right; intro w hw
-    cases w <;> simp [stayHomeProp, attendProp, burnProp] at hw ⊢
-  · left; intro w hw; exact Or.inr hw
+    isVisible rossContext (fun w => attendProp w ∨ burnProp w) := by decide
 
 /-- The disjunction `attend ∨ burn` is NOT strongly permissible — `burn`
     is a way-of-(attend ∨ burn) but doesn't meet the benchmark. -/
 theorem ross_attend_or_burn_not_stronglyPermissible :
     ¬ isStronglyPermissible rossContext (fun w => attendProp w ∨ burnProp w) := by
-  intro hSP
-  have h := hSP (mkDec burnProp)
-              (by show mkDec burnProp ∈ rossOptions; unfold rossOptions; simp)
-              (fun w hw => Or.inr hw)
-  -- h : rossContext.meetsBenchmark (mkDec burnProp) reduces to 2 ≤ 1
-  have h' : rossMeetsBenchmark (mkDec burnProp) := h
-  exact absurd h' (by decide)
+  decide
 
 /-- **Ross's Puzzle, formal**: `ought(attend ∨ burn)` is FALSE in
     Cariani's Resolution Semantics, even though `attend ⊨ attend ∨ burn`
     and `ought(attend)` is true. This is the INHERITANCE failure. -/
 theorem ross_puzzle_inheritance_failure :
-    ¬ ought rossContext (fun w => attendProp w ∨ burnProp w) := by
-  intro ⟨_, _, hSP⟩
-  exact ross_attend_or_burn_not_stronglyPermissible hSP
+    ¬ ought rossContext (fun w => attendProp w ∨ burnProp w) := by decide
 
 /-! ## §6. INHERITANCE failure on Procrastinate (paper §II)
 
@@ -402,11 +371,7 @@ ordered as `accept_and_write > do_not_accept > benchmark > accept_without_writin
 
 inductive ProcW where
   | accept_write | do_not_accept | accept_no_write
-  deriving DecidableEq, Repr
-
-instance : Fintype ProcW where
-  elems := {.accept_write, .do_not_accept, .accept_no_write}
-  complete := fun w => by cases w <;> decide
+  deriving DecidableEq, Fintype, Repr
 
 def acceptWriteProp : Set ProcW | .accept_write => True | _ => False
 def doNotAcceptProp : Set ProcW | .do_not_accept => True | _ => False
@@ -419,26 +384,26 @@ instance : DecidablePred doNotAcceptProp :=
 instance : DecidablePred acceptNoWriteProp :=
   fun w => by cases w <;> unfold acceptNoWriteProp <;> infer_instance
 
-def procOptions : List (DecProp ProcW) :=
-  [mkDec acceptWriteProp, mkDec doNotAcceptProp, mkDec acceptNoWriteProp]
+def procOptions : List (Finset ProcW) :=
+  [{.accept_write}, {.do_not_accept}, {.accept_no_write}]
 
 def procWorldRank : ProcW → ℕ
   | .accept_write => 3
   | .do_not_accept => 2
   | .accept_no_write => 1
 
-def procRank (o : DecProp ProcW) : ℕ :=
-  ((Finset.univ : Finset ProcW).filter (fun w => o.prop w)).sup procWorldRank
+def procRank (o : Finset ProcW) : ℕ :=
+  o.sup procWorldRank
 
-def procBetterThan : DecProp ProcW → DecProp ProcW → Prop :=
+def procBetterThan : Finset ProcW → Finset ProcW → Prop :=
   fun o o' => procRank o ≥ procRank o'
 
-instance (o o' : DecProp ProcW) : Decidable (procBetterThan o o') :=
+instance (o o' : Finset ProcW) : Decidable (procBetterThan o o') :=
   inferInstanceAs (Decidable (_ ≥ _))
 
-def procMeetsBenchmark : DecProp ProcW → Prop := fun o => procRank o ≥ 2
+def procMeetsBenchmark : Finset ProcW → Prop := fun o => procRank o ≥ 2
 
-instance (o : DecProp ProcW) : Decidable (procMeetsBenchmark o) :=
+instance (o : Finset ProcW) : Decidable (procMeetsBenchmark o) :=
   inferInstanceAs (Decidable (_ ≥ _))
 
 def procContext : ResolutionContext ProcW where
@@ -457,21 +422,13 @@ instance : DecidablePred acceptProp := fun w => by unfold acceptProp; infer_inst
 
 /-- `accept_no_write` is a way-of-`accept` but does NOT meet benchmark. -/
 theorem proc_accept_not_stronglyPermissible :
-    ¬ isStronglyPermissible procContext acceptProp := by
-  intro hSP
-  have h := hSP (mkDec acceptNoWriteProp)
-              (by show mkDec acceptNoWriteProp ∈ procOptions; unfold procOptions; simp)
-              (fun w hw => by cases w <;> simp [acceptNoWriteProp, acceptProp] at hw ⊢)
-  have h' : procMeetsBenchmark (mkDec acceptNoWriteProp) := h
-  exact absurd h' (by decide)
+    ¬ isStronglyPermissible procContext acceptProp := by decide
 
 /-- **Procrastinate, formal**: `ought(accept)` is FALSE in Cariani's
     Resolution Semantics, even though `accept_write ⊨ accept` and
     `ought(accept_write)` is true. -/
 theorem procrastinate_inheritance_failure :
-    ¬ ought procContext acceptProp := by
-  intro ⟨_, _, hSP⟩
-  exact proc_accept_not_stronglyPermissible hSP
+    ¬ ought procContext acceptProp := by decide
 
 /-! ## §7. Boxing as a special case (paper p.546)
 
@@ -523,7 +480,7 @@ omit [Fintype W] [DecidableEq W] in
     Ross's puzzle. -/
 theorem ought_negation_via_coarse_falsemaking
     (rc : ResolutionContext W) (p : Set W) [DecidablePred p]
-    (o : DecProp W) (ho : o ∈ rc.options)
+    (o : Finset W) (ho : o ∈ rc.options)
     (hWay : isWayOf o p) (hImp : ¬ rc.meetsBenchmark o) :
     ¬ ought rc p := by
   intro ⟨_, _, hSP⟩
@@ -556,87 +513,22 @@ No: the relevant case is the contrapositive. The actual right-to-left
 DUALITY failure: pick a `q` where `permitted q` is false but
 `ought ¬q` is also false. -/
 
-/-- **DUALITY right-to-left FAILS** on Ross's puzzle. Specifically:
-    `q := burnProp` is *not* permitted in `rossContext` (no way-of-burn
-    option meets benchmark — burn itself doesn't), so `¬ permitted q`
-    holds. But `ought ¬q = ought (¬burn)` is *also* false — it would
-    require every way-of-¬burn option to meet benchmark, but
-    `stay_home ∨ attend` includes options at-or-above benchmark while
-    `attend ∨ stay_home ∨ burn = univ`... let me actually check via
-    the simpler witness: `ought (attend ∨ burn)` is false (Ross's
-    puzzle) but `¬ permitted ¬(attend ∨ burn) = ¬ permitted stay_home`
-    is also false (stay_home itself is permitted, meeting benchmark).
-    So the right-to-left direction `¬ permitted ¬p → ought p` would
-    require `ought (attend ∨ burn)` to be true given `¬ permitted stay_home`
-    — but `permitted stay_home` IS true (stay_home meets benchmark).
-
-    The cleanest witness: pick `p := attend ∨ burn`. Then
-    `permitted ¬p = permitted (¬attend ∧ ¬burn) = permitted stay_home`,
-    which IS true (stay_home is the way-of-stay_home option and meets
-    benchmark). So `¬ permitted ¬p` is FALSE. The right-to-left
-    direction `¬ permitted ¬p → ought p` is vacuously true here.
-
-    For a real DUALITY-failure witness, we need `¬ permitted ¬p` true
-    and `ought p` false simultaneously. This requires a richer model
-    than rossContext. Per Cariani p.547, the failure is real but the
-    witness construction is non-trivial; we document the conceptual
-    point and mark the witness construction as future work. -/
-theorem cariani_ought_inheritance_failure_implies_duality_concern :
+/-- The INHERITANCE failure, existentially packaged: a context and
+    propositions `p ⊨ q` with `ought p` true and `ought q` false
+    (Ross's puzzle: `p = attend`, `q = attend ∨ burn`). This is the
+    failure Cariani p.547 invokes to reject the right-to-left
+    direction of DUALITY (`¬ permitted ¬p → ought p`); `rossContext`
+    itself satisfies that direction vacuously, and a direct
+    DUALITY-failure witness needs a richer model. -/
+theorem inheritance_failure_exists :
     ∃ (W : Type) (_ : Fintype W) (_ : DecidableEq W)
       (rc : ResolutionContext W) (p : Set W) (_ : DecidablePred p)
       (q : Set W) (_ : DecidablePred q),
-      (∀ w, p w → q w) ∧  -- p ⊨ q
-      ought rc p ∧  -- ought p
-      ¬ ought rc q := by
-  -- Use rossContext: p = attend, q = attend ∨ burn.
-  -- attend ⊨ attend ∨ burn ✓
-  -- ought(attend) ✓ (best option, single way-of-attend, meets benchmark)
-  -- ¬ ought(attend ∨ burn) ✓ (Ross's puzzle)
-  -- This is the INHERITANCE failure that Cariani p.547 invokes for the
-  -- DUALITY discussion.
-  refine ⟨RossW, inferInstance, inferInstance,
-          rossContext, attendProp, inferInstance,
-          (fun w => attendProp w ∨ burnProp w), inferInstance,
-          ?_, ?_, ross_puzzle_inheritance_failure⟩
-  · intro w hw; exact Or.inl hw
-  · refine ⟨ross_attend_visible, ?_, ?_⟩
-    · intro o ho _hbest
-      -- Every best option is a way-of-attend. The best option in
-      -- rossOptions is attend (rank 3 > 2 > 1). Other options aren't best.
-      unfold rossContext rossOptions at ho
-      simp only [List.mem_cons, List.not_mem_nil, or_false] at ho
-      rcases ho with rfl | rfl | rfl
-      · intro w hw; exact hw
-      · -- stay_home isn't best: attend > stay_home, so isBest stay_home fails
-        exfalso
-        -- _hbest : isBest rossContext (mkDec stayHomeProp)
-        -- → rossBetterThan (mkDec stayHomeProp) (mkDec attendProp)
-        -- → rossRank (mkDec stayHomeProp) ≥ rossRank (mkDec attendProp)
-        -- → 2 ≥ 3, contradiction
-        have := _hbest (mkDec attendProp) (by
-          show mkDec attendProp ∈ rossOptions; unfold rossOptions; simp)
-        exact absurd this (by decide)
-      · -- burn isn't best: attend > burn
-        exfalso
-        have := _hbest (mkDec attendProp) (by
-          show mkDec attendProp ∈ rossOptions; unfold rossOptions; simp)
-        exact absurd this (by decide)
-    · intro o ho hWay
-      -- Strong permissibility: every way-of-attend option meets benchmark.
-      unfold rossContext rossOptions at ho
-      simp only [List.mem_cons, List.not_mem_nil, or_false] at ho
-      rcases ho with rfl | rfl | rfl
-      · -- attend itself: rank 3 ≥ 2 ✓
-        show rossMeetsBenchmark (mkDec attendProp); decide
-      · -- stay_home is a way-of-attend? Means stay_home ⊆ attend, but
-        -- stay_home ∩ attend = ∅. So hWay vacuously fails.
-        exfalso
-        have := hWay RossW.stay_home (by decide : stayHomeProp RossW.stay_home)
-        cases this
-      · -- burn is a way-of-attend? Same vacuity.
-        exfalso
-        have := hWay RossW.burn (by decide : burnProp RossW.burn)
-        cases this
+      (∀ w, p w → q w) ∧ ought rc p ∧ ¬ ought rc q :=
+  ⟨RossW, inferInstance, inferInstance,
+   rossContext, attendProp, inferInstance,
+   (fun w => attendProp w ∨ burnProp w), inferInstance,
+   fun _ => Or.inl, ross_ought_attend, ross_puzzle_inheritance_failure⟩
 
 /-! ## §10. Weakening failure (paper §III pre-figured; [cariani-2016] core)
 
@@ -648,38 +540,15 @@ Weakening failures, but the explicit Weakening attack
 `ought(attend ∨ stay_home ∨ burn)` is false — because `burn` is a
 way-of-the-disjunction that doesn't meet benchmark.
 
-For the simple disjunction `ought(attend) ∧ ought(stay_home) →
-ought(attend ∨ stay_home)`: `attend ∨ stay_home` is visible
-(every option is settled), optimal (best = attend, which is in
-attend ∨ stay_home), strongly permissible (attend, stay_home both
-meet benchmark; burn is NOT a way-of-(attend ∨ stay_home) so vacuous).
-Hmm, that one *holds*.
-
-The interesting Weakening failure: pick disjuncts whose union has a
-new way-of-disjunction option that's impermissible. -/
+(For the simple disjunction `attend ∨ stay_home`, Weakening holds in
+`rossContext`; the failure needs disjuncts whose union acquires an
+impermissible way-of-disjunction option, as with `burn` above.) -/
 
 /-- `ought(stay_home)` is false in rossContext — stay_home is a
     way-of-stay_home, meets benchmark, but `attend` is the unique best
     option and `attend` is NOT a way-of-stay_home. So `isOptimal` fails. -/
 theorem ross_ought_stay_home_false :
-    ¬ ought rossContext stayHomeProp := by
-  intro ⟨_, hO, _⟩
-  -- best option = attend. isOptimal stay_home means best is way-of-stay_home.
-  -- attend is best, but attend isn't a way-of-stay_home (attend ∩ stay_home = ∅).
-  have hbest_attend : isBest rossContext (mkDec attendProp) := by
-    intro o' ho'
-    unfold rossContext rossOptions at ho'
-    simp only [List.mem_cons, List.not_mem_nil, or_false] at ho'
-    rcases ho' with rfl | rfl | rfl
-    · show rossBetterThan (mkDec attendProp) (mkDec attendProp); decide
-    · show rossBetterThan (mkDec attendProp) (mkDec stayHomeProp); decide
-    · show rossBetterThan (mkDec attendProp) (mkDec burnProp); decide
-  have := hO (mkDec attendProp) (by
-    show mkDec attendProp ∈ rossOptions; unfold rossOptions; simp) hbest_attend
-  -- this : isWayOf (mkDec attendProp) stayHomeProp
-  -- means: ∀ w, attendProp w → stayHomeProp w. But attendProp .attend = True,
-  -- stayHomeProp .attend = False. Contradiction.
-  exact absurd (this RossW.attend (by decide)) (by decide)
+    ¬ ought rossContext stayHomeProp := by decide
 
 /-! ## §11. Cross-framework summary
 

--- a/Linglib/Studies/Lassiter2017.lean
+++ b/Linglib/Studies/Lassiter2017.lean
@@ -176,27 +176,19 @@ is exhibited by `conflict_concrete` *only because* it ignores Sloman;
 Lassiter himself would say this is the wrong way to formalize his
 account. -/
 
-/-- The two-element alternative set for the witness model. -/
-def witnessAlts : List (Σ' (q : Set W), DecidablePred q) :=
-  [⟨targetProp, inferInstance⟩,
-   ⟨fun w => ¬ targetProp w, inferInstance⟩]
+/-- The target proposition as a `Finset`, derived from `targetProp`. -/
+def targetFinset : Finset W := Finset.univ.filter targetProp
 
-theorem targetProp_ne_negTargetProp : (targetProp : Set W) ≠ (fun w => ¬ targetProp w) := by
-  intro h
-  have hp : targetProp 0 := by decide
-  have h0 := congrFun h 0
-  change targetProp 0 = ¬ targetProp 0 at h0
-  exact (h0 ▸ hp : ¬ targetProp 0) hp
+/-- The two-element alternative set for the witness model. -/
+def witnessAlts : List (Finset W) := [targetFinset, targetFinsetᶜ]
 
 /-- **Lassiter's full account blocks the witness** via Sloman's
     Principle. Direct instance of the substrate theorem
     `wantWithSloman_blocks_conflict`. -/
 theorem wantWithSloman_blocks_conflict_on_witness :
-    ¬ (Lassiter.WantWithSloman belTotal prior value threshold witnessAlts targetProp ∧
-       Lassiter.WantWithSloman belTotal prior value threshold witnessAlts
-         (fun w => ¬ targetProp w)) :=
-  Lassiter.wantWithSloman_blocks_conflict belTotal prior value threshold targetProp
-    witnessAlts (by simp [witnessAlts]) (by simp [witnessAlts])
-    targetProp_ne_negTargetProp
+    ¬ (Lassiter.WantWithSloman belTotal prior value threshold witnessAlts targetFinset ∧
+       Lassiter.WantWithSloman belTotal prior value threshold witnessAlts targetFinsetᶜ) :=
+  Lassiter.wantWithSloman_blocks_conflict belTotal prior value threshold witnessAlts
+    targetFinset (by simp [witnessAlts]) (by simp [witnessAlts]) (by decide)
 
 end Lassiter2017Desire

--- a/Linglib/Studies/PhillipsBrown2025.lean
+++ b/Linglib/Studies/PhillipsBrown2025.lean
@@ -66,11 +66,7 @@ below; the structural isomorphism is documented and not coincidental
 
 inductive W where
   | w0 | w1 | w2 | w3 | w4 | w5 | w6 | w7
-  deriving DecidableEq, Repr, Inhabited
-
-instance : Fintype W where
-  elems := {.w0, .w1, .w2, .w3, .w4, .w5, .w6, .w7}
-  complete := λ w => by cases w <;> decide
+  deriving DecidableEq, Fintype, Repr, Inhabited
 
 /-! ## §2. Propositions
 
@@ -99,24 +95,24 @@ instance : DecidablePred fail := fun w => by unfold fail; infer_instance
 /-- The natural propositions of the model (basic dimensions), used to
     feed `IsAntiDeckstacking`. AD's quantifier is restricted to this
     test set — see `Desire.IsAntiDeckstacking` docstring. -/
-def naturalProps : List (DecProp W) :=
-  [mkDec nap, mkDec rested, mkDec pass]
+def naturalProps : List (Finset W) :=
+  [Finset.univ.filter nap, Finset.univ.filter rested, Finset.univ.filter pass]
 
 /-! ## §3. Nap scenario -/
 
 /-- Q' = partition by nap × rested (4 cells). -/
-def qNapRest : List (DecProp W) :=
-  [mkDec (fun w => nap w ∧ rested w),
-   mkDec (fun w => nap w ∧ ¬ rested w),
-   mkDec (fun w => ¬ nap w ∧ rested w),
-   mkDec (fun w => ¬ nap w ∧ ¬ rested w)]
+def qNapRest : List (Finset W) :=
+  [Finset.univ.filter (fun w => nap w ∧ rested w),
+   Finset.univ.filter (fun w => nap w ∧ ¬ rested w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ rested w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ ¬ rested w)]
 
 /-- Q'' = partition by nap × pass (4 cells). -/
-def qNapPass : List (DecProp W) :=
-  [mkDec (fun w => nap w ∧ pass w),
-   mkDec (fun w => nap w ∧ ¬ pass w),
-   mkDec (fun w => ¬ nap w ∧ pass w),
-   mkDec (fun w => ¬ nap w ∧ ¬ pass w)]
+def qNapPass : List (Finset W) :=
+  [Finset.univ.filter (fun w => nap w ∧ pass w),
+   Finset.univ.filter (fun w => nap w ∧ ¬ pass w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ pass w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ ¬ pass w)]
 
 /-- Beliefs for Nap: nap ↔ rested. Bel = {w0, w1, w6, w7}. -/
 def belNapRest : Set W := fun w => if nap w then rested w else ¬ rested w
@@ -126,25 +122,25 @@ instance : DecidablePred belNapRest := fun w => by unfold belNapRest; infer_inst
 def belNapPass : Set W := fun w => if nap w then ¬ pass w else pass w
 instance : DecidablePred belNapPass := fun w => by unfold belNapPass; infer_instance
 
-def desRest : List (DecProp W) := [mkDec rested]
-def desPass : List (DecProp W) := [mkDec pass]
+def desRest : List (Finset W) := [Finset.univ.filter rested]
+def desPass : List (Finset W) := [Finset.univ.filter pass]
 
 /-- **Nap is true** relative to Q' with beliefs nap↔rested, desires [rested]. -/
-theorem nap_true : WantQuestionBased belNapRest desRest qNapRest nap := by decide
+theorem nap_true : WantQuestionBased belNapRest desRest qNapRest nap := by decide +kernel
 
 /-- **Not-nap is true** relative to Q'' with beliefs pass↔¬nap, desires [pass]. -/
 theorem not_nap_true :
-    WantQuestionBased belNapPass desPass qNapPass (fun w => ¬ nap w) := by decide
+    WantQuestionBased belNapPass desPass qNapPass (fun w => ¬ nap w) := by decide +kernel
 
 /-- Fail is NOT considered relative to Q'. -/
-theorem fail_not_considered : ¬ IsConsidered qNapRest fail := by decide
+theorem fail_not_considered : ¬ IsConsidered qNapRest fail := by decide +kernel
 
 /-- Fail is also not predicted true. -/
 theorem fail_not_true :
-    ¬ WantQuestionBased belNapRest desRest qNapRest fail := by decide
+    ¬ WantQuestionBased belNapRest desRest qNapRest fail := by decide +kernel
 
 /-- Q' is diverse w.r.t. nap. -/
-theorem nap_diverse : IsDiverse qNapRest nap := by decide
+theorem nap_diverse : IsDiverse qNapRest nap := by decide +kernel
 
 /-! ## §4. Lobster scenario (paper §2.2)
 
@@ -158,20 +154,20 @@ abbrev gustatory : Set W := rested
 abbrev die : Set W := fail
 
 /-- Q_{c''} = partition by lobster × gustatory (= `qNapRest`). -/
-abbrev qLobGus : List (DecProp W) := qNapRest
+abbrev qLobGus : List (Finset W) := qNapRest
 
 /-- Q_{c'''} = partition by lobster × die. -/
-def qLobDie : List (DecProp W) :=
-  [mkDec (fun w => nap w ∧ fail w),
-   mkDec (fun w => nap w ∧ ¬ fail w),
-   mkDec (fun w => ¬ nap w ∧ fail w),
-   mkDec (fun w => ¬ nap w ∧ ¬ fail w)]
+def qLobDie : List (Finset W) :=
+  [Finset.univ.filter (fun w => nap w ∧ fail w),
+   Finset.univ.filter (fun w => nap w ∧ ¬ fail w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ fail w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ ¬ fail w)]
 
 /-- Beliefs: die ↔ eat lobster. Bel = {w1, w3, w4, w6}. -/
 def belLobDie : Set W := fun w => if nap w then fail w else ¬ fail w
 instance : DecidablePred belLobDie := fun w => by unfold belLobDie; infer_instance
 
-def desNotDie : List (DecProp W) := [mkDec (fun w => ¬ fail w)]
+def desNotDie : List (Finset W) := [Finset.univ.filter (fun w => ¬ fail w)]
 
 /-- **Lobster is true** in c'' (considering taste, ignoring death). -/
 theorem lobster_true :
@@ -185,11 +181,11 @@ theorem die_not_considered_in_qLobGus :
 
 /-- **Not-lobster is true** in c''' (considering death, ignoring taste). -/
 theorem not_lobster_true :
-    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ nap w) := by decide
+    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ nap w) := by decide +kernel
 
 /-- **Not-die is also true** in c''' (best answer entails both ¬lobster and ¬die). -/
 theorem not_die_true :
-    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ fail w) := by decide
+    WantQuestionBased belLobDie desNotDie qLobDie (fun w => ¬ fail w) := by decide +kernel
 
 /-! ## §5. Von Fintel comparison and the no-go theorem
 
@@ -198,10 +194,10 @@ predict both `want p` and `want ¬p` simultaneously. Specialised here
 for the Nap example, then derived from the substrate's general
 `wantVonFintel_no_conflict`. -/
 
-theorem vf_nap_true : WantVonFintel belNapRest desRest nap := by decide
+theorem vf_nap_true : WantVonFintel belNapRest desRest nap := by decide +kernel
 
 theorem vf_not_nap_false :
-    ¬ WantVonFintel belNapRest desRest (fun w => ¬ nap w) := by decide
+    ¬ WantVonFintel belNapRest desRest (fun w => ¬ nap w) := by decide +kernel
 
 /-- vF cannot predict both Nap and Not-nap with the same parameter set
     (specific instance). -/
@@ -217,8 +213,8 @@ theorem vf_no_conflict_nap :
     ¬ (WantVonFintel belNapRest desRest nap ∧
        WantVonFintel belNapRest desRest (fun w => ¬ nap w)) :=
   wantVonFintel_no_conflict belNapRest desRest nap
-    ⟨.w0, by decide,
-     by intro z hz ⟨_, hbad⟩; revert hz hbad; cases z <;> decide⟩
+    ⟨.w0, by decide +kernel,
+     by intro z hz ⟨_, hbad⟩; revert hz hbad; cases z <;> decide +kernel⟩
 
 /-! ## §6. Doxastic closure blocking (paper §4.1)
 
@@ -233,10 +229,10 @@ With Q'' (the nap × pass partition), `fail` is settled — and the
 contrast is exactly the paper's point. -/
 
 theorem nap_considered_in_qNapPass :
-    IsConsidered qNapPass nap := by decide
+    IsConsidered qNapPass nap := by decide +kernel
 
 theorem fail_considered_in_qNapPass :
-    IsConsidered qNapPass fail := by decide
+    IsConsidered qNapPass fail := by decide +kernel
 
 /-! ## §7. Anti-deckstacking (paper §3.7)
 
@@ -257,77 +253,77 @@ instance : DecidablePred happy := fun w => by cases w <;> unfold happy <;> infer
 instance : DecidablePred rain := fun w => by cases w <;> unfold rain <;> infer_instance
 
 /-- Test set of natural propositions for the Lu scenario. -/
-def naturalPropsLu : List (DecProp W) := [mkDec rain, mkDec happy]
+def naturalPropsLu : List (Finset W) := [Finset.univ.filter rain, Finset.univ.filter happy]
 
 /-- Q'''' (deck-stacked): {r, ¬r∧h, ¬r∧¬h}. -/
-def qDeckstacked : List (DecProp W) :=
-  [mkDec rain,
-   mkDec (fun w => ¬ rain w ∧ happy w),
-   mkDec (fun w => ¬ rain w ∧ ¬ happy w)]
+def qDeckstacked : List (Finset W) :=
+  [Finset.univ.filter rain,
+   Finset.univ.filter (fun w => ¬ rain w ∧ happy w),
+   Finset.univ.filter (fun w => ¬ rain w ∧ ¬ happy w)]
 
 /-- Lu's beliefs: happy unconditionally. -/
 def belLu : Set W := happy
 instance : DecidablePred belLu := inferInstanceAs (DecidablePred happy)
 
-def desHappy : List (DecProp W) := [mkDec happy]
+def desHappy : List (Finset W) := [Finset.univ.filter happy]
 
 /-- `happy` is not considered in the deck-stacked Q'''' (the `rain`
     cell contains both happy and unhappy worlds). -/
 theorem happy_not_considered_deckstacked :
-    ¬ IsConsidered qDeckstacked happy := by decide
+    ¬ IsConsidered qDeckstacked happy := by decide +kernel
 
 /-- A `happy`-answer exists in qDeckstacked (the `¬r∧h` cell entails
     `happy`) — the deck is stacked in favor of ¬rain. -/
 theorem happy_answer_exists_deckstacked :
-    ∃ a ∈ qDeckstacked, ∀ w, a.prop w → happy w := by decide
+    ∃ a ∈ qDeckstacked, ∀ w ∈ a, happy w := by decide +kernel
 
 /-- Without the constraint, the question-based semantics wrongly
     predicts Not-rain. -/
 theorem not_rain_deckstacked_true :
-    WantQuestionBased belLu desHappy qDeckstacked (fun w => ¬ rain w) := by decide
+    WantQuestionBased belLu desHappy qDeckstacked (fun w => ¬ rain w) := by decide +kernel
 
 /-- Q''''' (level playing field): partition by rain × happy. -/
-def qRainHappy : List (DecProp W) :=
-  [mkDec (fun w => rain w ∧ happy w),
-   mkDec (fun w => rain w ∧ ¬ happy w),
-   mkDec (fun w => ¬ rain w ∧ happy w),
-   mkDec (fun w => ¬ rain w ∧ ¬ happy w)]
+def qRainHappy : List (Finset W) :=
+  [Finset.univ.filter (fun w => rain w ∧ happy w),
+   Finset.univ.filter (fun w => rain w ∧ ¬ happy w),
+   Finset.univ.filter (fun w => ¬ rain w ∧ happy w),
+   Finset.univ.filter (fun w => ¬ rain w ∧ ¬ happy w)]
 
 theorem happy_considered_fair :
-    IsConsidered qRainHappy happy := by decide
+    IsConsidered qRainHappy happy := by decide +kernel
 
 /-- With the fair question, Not-rain is correctly predicted false. -/
 theorem not_rain_false_fair :
-    ¬ WantQuestionBased belLu desHappy qRainHappy (fun w => ¬ rain w) := by decide
+    ¬ WantQuestionBased belLu desHappy qRainHappy (fun w => ¬ rain w) := by decide +kernel
 
 /-- The deck-stacked question fails Anti-deckstacking on test set
     `[r, h]` (`h` is predetermined by the `¬r∧h` cell but not
     considered by Q''''). -/
 theorem qDeckstacked_fails_antideckstacking :
-    ¬ IsAntiDeckstacking naturalPropsLu qDeckstacked := by decide
+    ¬ IsAntiDeckstacking naturalPropsLu qDeckstacked := by decide +kernel
 
 /-- The fair (cross-product) question satisfies Anti-deckstacking —
     every basic proposition is settled by every cell. -/
 theorem qRainHappy_satisfies_antideckstacking :
-    IsAntiDeckstacking naturalPropsLu qRainHappy := by decide
+    IsAntiDeckstacking naturalPropsLu qRainHappy := by decide +kernel
 
 /-- Q' (`qNapRest`) satisfies Anti-deckstacking on the natural-prop
     test set `[nap, rested, pass]` — the cross-product over `nap` and
     `rested` settles `nap` and `rested`; no cell entails `pass`, so
     AD's antecedent is vacuous for `pass`. -/
 theorem qNapRest_satisfies_antideckstacking :
-    IsAntiDeckstacking naturalProps qNapRest := by decide
+    IsAntiDeckstacking naturalProps qNapRest := by decide +kernel
 
 /-! ## §8. Finest-question simulation (paper §3.4)
 
 When Q_c is the finest partition (singleton cells = individual worlds),
 the question-based semantics reduces to vF. The substrate provides
-`finestPartition : List W → List (DecProp W)`; here we instantiate it
+`finestPartition : List W → List (Finset W)`; here we instantiate it
 on the explicit world list of the model. -/
 
 def allWorldsW : List W := [.w0, .w1, .w2, .w3, .w4, .w5, .w6, .w7]
 
-def qFinest : List (DecProp W) := finestPartition allWorldsW
+def qFinest : List (Finset W) := finestPartition allWorldsW
 
 /-- The 8-world list `allWorldsW` covers `W`. Hypothesis required by the
     substrate's general `wantQuestionBased_finestPartition_iff_WantVonFintel`. -/
@@ -362,19 +358,19 @@ theorem finest_simulates_vf_not_lobster :
 /-! ## §9. Definedness via PartialProp (paper §3.6) -/
 
 theorem nap_defined_in_qNapRest :
-    WantDefined belNapRest naturalProps qNapRest nap := by decide
+    WantDefined belNapRest naturalProps qNapRest nap := by decide +kernel
 
 theorem fail_not_defined_in_qNapRest :
-    ¬ WantDefined belNapRest naturalProps qNapRest fail := by decide
+    ¬ WantDefined belNapRest naturalProps qNapRest fail := by decide +kernel
 
 theorem nap_prprop_holds :
     (wantPartialProp belNapRest desRest naturalProps qNapRest nap).presup .w0 ∧
     (wantPartialProp belNapRest desRest naturalProps qNapRest nap).assertion .w0 := by
-  refine ⟨?_, ?_⟩ <;> simp only [wantPartialProp] <;> decide
+  refine ⟨?_, ?_⟩ <;> simp only [wantPartialProp] <;> decide +kernel
 
 theorem fail_prprop_undefined :
     ¬(wantPartialProp belNapRest desRest naturalProps qNapRest fail).presup .w0 := by
-  simp only [wantPartialProp]; decide
+  simp only [wantPartialProp]; decide +kernel
 
 /-! ## §10. Belief-sensitivity: William III / nuclear war (paper §4.2)
 
@@ -402,48 +398,48 @@ def avoidNuclearWar : Set W := fun w => nap w ∨ rested w
 instance : DecidablePred avoidWar := inferInstanceAs (DecidablePred nap)
 instance : DecidablePred avoidNuclearWar := fun w => by unfold avoidNuclearWar; infer_instance
 
-def qNuclear : List (DecProp W) :=
-  [mkDec nap,
-   mkDec (fun w => ¬ nap w ∧ rested w),
-   mkDec (fun w => ¬ nap w ∧ ¬ rested w)]
+def qNuclear : List (Finset W) :=
+  [Finset.univ.filter nap,
+   Finset.univ.filter (fun w => ¬ nap w ∧ rested w),
+   Finset.univ.filter (fun w => ¬ nap w ∧ ¬ rested w)]
 
 /-- Natural-prop test set for the nuclear-war scenario. The Nap-vs-war
     distinction (`nap`) and the war-of-any-kind distinction
     (`avoidNuclearWar`) are the salient dimensions; `rested` and
     `pass` are not part of this scenario's vocabulary. -/
-def naturalPropsNuclear : List (DecProp W) :=
-  [mkDec nap, mkDec avoidNuclearWar]
+def naturalPropsNuclear : List (Finset W) :=
+  [Finset.univ.filter nap, Finset.univ.filter avoidNuclearWar]
 
 theorem avoidWar_entails_avoidNuclearWar :
-    ∀ w, avoidWar w → avoidNuclearWar w := by decide
+    ∀ w, avoidWar w → avoidNuclearWar w := by decide +kernel
 
 theorem avoidNuclearWar_considered :
-    IsConsidered qNuclear avoidNuclearWar := by decide
+    IsConsidered qNuclear avoidNuclearWar := by decide +kernel
 
 /-- William III: total uncertainty (all worlds compatible). -/
 def belWilliam : Set W := fun _ => True
 instance : DecidablePred belWilliam := fun _ => isTrue trivial
 
 theorem william_insensitive :
-    ¬ IsBelSensitive belWilliam qNuclear := by decide
+    ¬ IsBelSensitive belWilliam qNuclear := by decide +kernel
 
 theorem avoidNuclearWar_not_defined_william :
-    ¬ WantDefined belWilliam naturalPropsNuclear qNuclear avoidNuclearWar := by decide
+    ¬ WantDefined belWilliam naturalPropsNuclear qNuclear avoidNuclearWar := by decide +kernel
 
 /-- Modern person: beliefs rule out nuclear war (peace ∨ conventional). -/
 def belModern : Set W := fun w => nap w ∨ rested w
 instance : DecidablePred belModern := fun w => by unfold belModern; infer_instance
 
 theorem modern_sensitive :
-    IsBelSensitive belModern qNuclear := by decide
+    IsBelSensitive belModern qNuclear := by decide +kernel
 
 theorem avoidNuclearWar_defined_modern :
-    WantDefined belModern naturalPropsNuclear qNuclear avoidNuclearWar := by decide
+    WantDefined belModern naturalPropsNuclear qNuclear avoidNuclearWar := by decide +kernel
 
-def desAvoidWar : List (DecProp W) := [mkDec nap]
+def desAvoidWar : List (Finset W) := [Finset.univ.filter nap]
 
 theorem modern_wants_avoidNuclearWar :
-    WantQuestionBased belModern desAvoidWar qNuclear avoidNuclearWar := by decide
+    WantQuestionBased belModern desAvoidWar qNuclear avoidNuclearWar := by decide +kernel
 
 /-! ## §11. Cross-paper bridge: [condoravdi-lauer-2016]
 
@@ -530,7 +526,7 @@ def BeliefBasedDesireSemantics.IsConflictBlocking
     belS-world is necessarily undominated, which the no-go needs. -/
 def vonFintelSemantics {W : Type*} [Fintype W] :
     BeliefBasedDesireSemantics W where
-  Param := List (DecProp W)
+  Param := List (Finset W)
   defined belS _ p := (∃ w, belS w ∧ p w) ∧ (∃ w, belS w ∧ ¬ p w)
   want belS GS _ p := WantVonFintel belS GS p
 


### PR DESCRIPTION
Dissolves the custom `DecProp` bundle (Set + DecidablePred) into mathlib's `Finset W`: partition cells, desire lists, and Lassiter alternative sets are now `Finset W` with native decidable `⊆`/membership; the Sloman apparatus takes the wanted proposition as a `Finset` with its complement written `pᶜ`. Cariani2013's Resolution Semantics options gain `DecidableEq`, collapsing its manual case-analysis proofs to `decide`; also cuts the dead Question-API bridge and its `Questions.Hamblin` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)