### PR TITLE
refactor(Semantics/Attitudes): reorganize Desire; cleanse docstrings

### DIFF
--- a/Linglib/Semantics/Attitudes/Desire.lean
+++ b/Linglib/Semantics/Attitudes/Desire.lean
@@ -18,15 +18,15 @@ Rival semantics for desire ascriptions (*want*, *wish*, *hope*),
 collected so their predictions about conflicting desires — ⌜S wants p⌝
 together with ⌜S wants ¬p⌝ against one belief state — can be compared:
 
-1. **von Fintel** ([von-fintel-1999]) — `WantVonFintel`: every
-   undominated belief-world is a p-world, the world ordering induced by
-   which desires each world satisfies. The ordering is [kratzer-1981]'s
-   `atLeastAsGoodAs` over the projected desire propositions, called
-   directly by `WorldAtLeastAsGood`.
-2. **Heim** ([heim-1992]) — `WantHeimNaive`, her (27), the
+1. **Heim** ([heim-1992]) — `WantHeimNaive`, her (27), the
    Hintikka-style baseline she rejects; `WantHeim`, the (37/39)
    comparative-belief semantics restricted to the doxastic base; and
    her (40) definedness amendment `WantHeimDefined`.
+2. **von Fintel** ([von-fintel-1999]) — `WantVonFintel`: every
+   undominated belief-world is a p-world, under the world ordering
+   induced by which desires each world satisfies — [kratzer-1981]'s
+   `atLeastAsGoodAs` over the projected desire propositions
+   (`WorldAtLeastAsGood`).
 3. **Phillips-Brown** ([phillips-brown-2025]) — `WantQuestionBased`:
    every best answer in Q_c-Bel_S entails p, for a contextual question
    Q_c, with the paper's metasemantic constraints (`IsConsidered`,
@@ -49,14 +49,14 @@ together with ⌜S wants ¬p⌝ against one belief state — can be compared:
    (`Lassiter.WantWithSloman`).
 
 On conflicting desires: the belief-based semantics block simultaneous
-`want(p)` and `want(¬p)` (`wantVonFintel_no_conflict`,
-`wantHeim_no_conflict`); Condoravdi & Lauer's exact-match want over a
-consistent background blocks it too
+`want(p)` and `want(¬p)` (`wantHeim_no_conflict`,
+`wantVonFintel_no_conflict`); Condoravdi & Lauer's exact-match want
+over a consistent background blocks it too
 (`PreferenceStructure.maxElts_pair_belief_compatible` applied to
 `WantExactMatch` facts — the agent's designated *effective* preference
 function, their (68), is a background pointwise `consistent` with the
-belief state); Phillips-Brown evades the blockage by varying
-Q_c; Lassiter's bare threshold admits it outright
+belief state); Phillips-Brown evades the blockage by varying Q_c;
+Lassiter's bare threshold admits it outright
 (`Lassiter.threshold_admits_conflict_witness`) while his full account
 does not (`Lassiter.wantWithSloman_blocks_conflict`). The
 belief-based-*class* packaging of this argument is
@@ -69,403 +69,42 @@ namespace Desire
 open Semantics.Presupposition (PartialProp)
 open Core.Order (SatisfactionOrdering)
 
-section Generic
+section
 
 variable {W : Type*} [Fintype W] [DecidableEq W]
 
-/-! ### Answer preference ([phillips-brown-2025] §3.5)
+/-! ## Comparative-belief semantics ([heim-1992])
 
-The paper's preference relation between answers `a, a' ∈ Q_c-Bel_S`:
+The paper develops three successive truth conditions for *want*, each
+repairing a defect of the previous:
 
-  S prefers a to a' iff {p ∈ G_S : a' ⊆ p} ⊊ {p ∈ G_S : a ⊆ p}
+* (27), §3 p. 192 — the naive Hintikka-style condition: every bouletic
+  alternative is a φ-world (`WantHeimNaive`). Rejected via Asher's
+  Concorde counterexample at (32), p. 194.
+* (31), §4.1 p. 193 — the canonical comparative-belief condition: for
+  every doxastic alternative w', every φ-world maximally similar to w'
+  is more desirable than any ¬φ-world maximally similar to w'.
+* (37/39), §4.2.2 p. 197 — the CCP rephrasal (`WantHeim`): the same
+  comparison with the proposition restricted to the doxastic base
+  first. The (40) amendment (`WantHeimDefined`, §4.2.3 p. 198) makes
+  the ascription undefined when the agent already believes φ or
+  already believes ¬φ.
 
-— i.e. *strict* subset inclusion of satisfied desires. We expose the
-weak relation `≤` via `SatisfactionOrdering.ofCriteria` and the strict
-relation via `SatisfactionOrdering.strictlyBetter`; the paper's "best
-answers" are the maxima under the strict relation, i.e. the
-Pareto-undominated elements (see §3.5, p. 11:21). -/
+Heim's ordering apparatus is a [lewis-1973]/[stalnaker-1968]
+similarity ordering on worlds together with a primitive comparative
+desirability relation — not a Kratzer ordering source, and not derived
+from a desire list the way von Fintel's ordering is. -/
 
-/-- Proposition ordering: `a ≤ a'` iff every desire in `GS` that `a'`
-    entails, `a` also entails. The Pareto-undominated elements under
-    this relation are the "best answers" of [phillips-brown-2025]
-    §3.5. -/
-def propositionOrdering (GS : List (Finset W)) :
-    SatisfactionOrdering (Finset W) (Finset W) :=
-  SatisfactionOrdering.ofCriteria (fun a p => decide (a ⊆ p)) GS
-
-/-- Best (= Pareto-undominated) answers among a candidate list. -/
-abbrev undominatedAnswers (GS answers : List (Finset W)) : List (Finset W) :=
-  (propositionOrdering GS).undominated answers
-
-/-! ### Question-relative belief ([phillips-brown-2025] §3.3)
-
-Q_c-Bel_S = the cells of Q_c compatible with S's beliefs. -/
-
-/-- The cells of `answers` that overlap `belS`. -/
-def questionRelativeBelief (answers : List (Finset W))
-    (belS : Set W) [DecidablePred belS] : List (Finset W) :=
-  answers.filter fun a => decide (∃ w ∈ a, belS w)
-
-/-! ### Question-based want ([phillips-brown-2025] §3.4) -/
-
-/-- ⟦S wants p⟧^c = every undominated answer in Q_c-Bel_S entails p.
-    The paper's central definition (§3.5). -/
-def WantQuestionBased (belS : Set W) [DecidablePred belS]
-    (GS answers : List (Finset W)) (p : Set W) [DecidablePred p] : Prop :=
-  ∀ a ∈ undominatedAnswers GS (questionRelativeBelief answers belS),
-    ∀ w ∈ a, p w
+/-- Heim's (27), the naive Hintikka-style baseline: every belief-world
+    is a p-world (the bouletic/doxastic distinction is collapsed).
+    Heim rejects it via Asher's Concorde counterexample, her (32). -/
+def WantHeimNaive (belS p : Set W) : Prop :=
+  ∀ w, belS w → p w
 
 instance (belS : Set W) [DecidablePred belS]
-    (GS answers : List (Finset W)) (p : Set W) [DecidablePred p] :
-    Decidable (WantQuestionBased belS GS answers p) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, _))
-
-/-! ### von Fintel baseline ([von-fintel-1999])
-
-`WantVonFintel` evaluates to "every undominated belief-world is a p-world",
-where the world ordering is induced by which desires each world
-satisfies — [kratzer-1981]'s `atLeastAsGoodAs` over the projected
-desires, by definition. -/
-
-/-- World ordering induced by a desire list: `w ≤ z` iff every desire
-    in `GS` satisfied at `z` is also satisfied at `w` — [kratzer-1981]'s
-    `atLeastAsGoodAs` over the projected proposition list, by definition.
-    Decidability is transported through the membership form
-    `worldAtLeastAsGood_iff_mem`. -/
-def WorldAtLeastAsGood (GS : List (Finset W)) (w z : W) : Prop :=
-  Modality.Kratzer.atLeastAsGoodAs (GS.map (fun s w => w ∈ s)) w z
-
-omit [Fintype W] [DecidableEq W] in
-/-- The ordering in its membership form: every listed desire satisfied
-    at `z` is satisfied at `w`. -/
-theorem worldAtLeastAsGood_iff_mem (GS : List (Finset W)) (w z : W) :
-    WorldAtLeastAsGood GS w z ↔ ∀ s ∈ GS, z ∈ s → w ∈ s := by
-  show (∀ p ∈ GS.map (fun s w => w ∈ s), p z → p w) ↔ _
-  constructor
-  · intro h a ha hz
-    exact h _ (List.mem_map.mpr ⟨a, ha, rfl⟩) hz
-  · intro h q hq hz
-    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hq
-    exact h a ha hz
-
-instance (GS : List (Finset W)) (w z : W) :
-    Decidable (WorldAtLeastAsGood GS w z) :=
-  decidable_of_iff _ (worldAtLeastAsGood_iff_mem GS w z).symm
-
-/-- Standard von Fintel [von-fintel-1999] semantics: every undominated
-    belS-world is a p-world. The `[DecidablePred]` hypotheses are not
-    used in the definition body; they live on the `Decidable` instance
-    so that abstract reasoning (e.g. instances of
-    `BeliefBasedDesireSemantics`) can use `WantVonFintel` without supplying
-    them. -/
-def WantVonFintel (belS : Set W) (GS : List (Finset W)) (p : Set W) : Prop :=
-  ∀ w, belS w →
-    (∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) →
-    p w
-
-instance (belS : Set W) [DecidablePred belS]
-    (GS : List (Finset W)) (p : Set W) [DecidablePred p] :
-    Decidable (WantVonFintel belS GS p) :=
-  inferInstanceAs (Decidable (∀ _, _))
-
-/-! ### Metasemantic constraints ([phillips-brown-2025] §3.6–§4.2) -/
-
-/-- **Considering Constraint** (§3.6): every cell of Q_c either
-    entails p or entails ¬p. Equivalently (over partition cells):
-    p is a union of cells. -/
-def IsConsidered (answers : List (Finset W))
-    (p : Set W) [DecidablePred p] : Prop :=
-  ∀ a ∈ answers, (∀ w ∈ a, p w) ∨ (∀ w ∈ a, ¬ p w)
-
-instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
-    Decidable (IsConsidered answers p) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, _))
-
-/-- **Diversity Constraint** (§3.7, attributed to
-    [condoravdi-2002]): Q_c contains both p-cells and ¬p-cells.
-    Without diversity, ⟦want p⟧ would be vacuously true (or false). -/
-def IsDiverse (answers : List (Finset W))
-    (p : Set W) [DecidablePred p] : Prop :=
-  (∃ a ∈ answers, ∀ w ∈ a, p w) ∧
-  (∃ a ∈ answers, ∀ w ∈ a, ¬ p w)
-
-instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
-    Decidable (IsDiverse answers p) :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-! ### Anti-deckstacking ([phillips-brown-2025] §3.7)
-
-The paper quantifies over "all q": if some cell entails q, then q must
-itself be considered relative to Q_c. The naive `∀ q : Set W` over a
-finite model trivially fails on gerrymandered subsets — e.g. for the
-`qNapRest` 4-cell partition, `q = {w₀, w₁, w₂}` is entailed by the
-`nap ∧ rested` cell `{w₀, w₁}` but not settled by the `nap ∧ ¬rested`
-cell `{w₂, w₃}` (which contains `w₂ ∈ q` and `w₃ ∉ q`). These
-violations are artifacts of the encoding, not of the question.
-
-The substrate solves this by parameterizing the constraint on a
-**test set of natural propositions** `naturalProps` — the propositions
-the modeller deems salient for the model. For PB's `qDeckstacked`
-example, `naturalProps = [r, h]` correctly fails AD (cell `¬r ∧ h`
-entails `h`, but `h` is not considered by `qDeckstacked` — the `r` cell
-neither entails `h` nor entails `¬h`). For `qNapRest` and `qRainHappy`
-with the same `naturalProps`, AD passes (those questions cross-cut both
-basic dimensions). -/
-
-/-- **Anti-deckstacking Constraint** (§3.7), parameterized on the
-    test set of natural propositions `naturalProps`: for every
-    `q ∈ naturalProps`, if some cell of `answers` entails `q`, then `q`
-    must be considered relative to `answers`.
-
-    The `naturalProps` parameter is the modeller's chosen vocabulary of
-    salient propositions; passing the empty list trivially satisfies the
-    constraint, so study files must opt in by listing the basic
-    propositions of their model. -/
-def IsAntiDeckstacking (naturalProps answers : List (Finset W)) : Prop :=
-  ∀ q ∈ naturalProps, (∃ a ∈ answers, a ⊆ q) → IsConsidered answers (· ∈ q)
-
-instance (naturalProps answers : List (Finset W)) :
-    Decidable (IsAntiDeckstacking naturalProps answers) :=
-  inferInstanceAs (Decidable (∀ _ ∈ _, _))
-
-/-- **Belief-sensitivity Constraint** (§4.2, building on
-    [yalcin-2018]'s question-sensitive belief): Bel_S discriminates
-    among the cells of Q_c — at least one answer is compatible with
-    S's beliefs and at least one is incompatible. Blocks inferences
-    like William III ⊨ "Avoid nuclear war" when the agent lacks the
-    conceptual resources to grasp the question. -/
-def IsBelSensitive (belS : Set W) [DecidablePred belS]
-    (answers : List (Finset W)) : Prop :=
-  let live := questionRelativeBelief answers belS
-  live ≠ [] ∧ live.length ≠ answers.length
-
-instance (belS : Set W) [DecidablePred belS] (answers : List (Finset W)) :
-    Decidable (IsBelSensitive belS answers) :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- Full definedness condition for ⟦S wants p⟧^c. The paper requires
-    all four constraints (Considering §3.6, Diversity §3.7,
-    Anti-deckstacking §3.7, Belief-sensitivity §4.2). The
-    `naturalProps` parameter feeds Anti-deckstacking. -/
-def WantDefined (belS : Set W) [DecidablePred belS]
-    (naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] : Prop :=
-  IsConsidered answers p ∧
-  IsDiverse answers p ∧
-  IsAntiDeckstacking naturalProps answers ∧
-  IsBelSensitive belS answers
-
-instance (belS : Set W) [DecidablePred belS]
-    (naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] :
-    Decidable (WantDefined belS naturalProps answers p) := by
-  unfold WantDefined; infer_instance
-
-/-! ### Partial-proposition wrapper
-
-The presupposition is the four-constraint definedness predicate; the
-assertion is the question-based truth condition. Both are
-world-independent because Q_c is contextually fixed prior to
-evaluation; we expose them as a `PartialProp W` for uniformity with
-linglib's presupposition infrastructure, with the world argument
-suppressed. -/
-
-/-- Question-based `want` as a partial proposition (`Core.PartialProp`):
-    presupposition = full definedness; assertion = question-based truth. -/
-def wantPartialProp (belS : Set W) [DecidablePred belS]
-    (GS naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] :
-    PartialProp W where
-  presup _ := WantDefined belS naturalProps answers p
-  assertion _ := WantQuestionBased belS GS answers p
-
-/-! ### The finest question simulates von Fintel ([phillips-brown-2025] §3.4)
-
-When Q_c is the finest partition (every cell is a singleton world),
-the question-based semantics reduces to standard vF. The substrate
-provides the construction parameterized on an explicit world list so
-the result is computable and `decide`-able for concrete models. -/
-
-/-- The finest partition over an explicit world list: one singleton
-    cell per listed world. -/
-def finestPartition (worlds : List W) : List (Finset W) :=
-  worlds.map ({·})
-
-/-! ### Supporting lemmas
-
-The §3.4 metasemantic identity is proved via three helper lemmas
-(singleton-cell preference reduces to single-world preference under
-`WorldAtLeastAsGood`; the question-relative belief filter on
-`finestPartition` selects exactly the singleton cells of belS-worlds;
-undominated singleton cells correspond to Pareto-undominated
-belS-worlds), then a direct two-direction `iff` proof. -/
-
-omit [Fintype W] in
-/-- Singleton-cell preference under `propositionOrdering` reduces to
-    single-world preference under `WorldAtLeastAsGood`: `{w} ≤ {z}` in
-    the proposition ordering iff `WorldAtLeastAsGood GS w z`. -/
-private theorem singleton_le_iff_world (GS : List (Finset W)) (w z : W) :
-    (propositionOrdering GS).le {w} {z} ↔ WorldAtLeastAsGood GS w z := by
-  rw [worldAtLeastAsGood_iff_mem]
-  unfold propositionOrdering SatisfactionOrdering.ofCriteria
-  show (∀ q ∈ GS.filter (fun q => decide (({z} : Finset W) ⊆ q)),
-          decide (({w} : Finset W) ⊆ q) = true) ↔
-       (∀ s ∈ GS, z ∈ s → w ∈ s)
-  simp only [decide_eq_true_eq, Finset.singleton_subset_iff]
-  constructor
-  · intro h q hq hqz
-    exact h q (by rw [List.mem_filter]; exact ⟨hq, by simpa using hqz⟩)
-  · intro h q hqf
-    rw [List.mem_filter] at hqf
-    exact h q hqf.1 (by simpa using hqf.2)
-
-omit [Fintype W] [DecidableEq W] in
-/-- The singleton cell `{w}` is in `questionRelativeBelief
-    (finestPartition worlds) belS` iff `w ∈ worlds` and `belS w`. -/
-private theorem mem_qRB_finestPartition_iff (belS : Set W) [DecidablePred belS]
-    (worlds : List W) (w : W) :
-    ({w} : Finset W) ∈ questionRelativeBelief (finestPartition worlds) belS ↔
-      w ∈ worlds ∧ belS w := by
-  simp [questionRelativeBelief, finestPartition, List.mem_filter,
-    Finset.singleton_inj]
-
-omit [Fintype W] in
-theorem wantQuestionBased_finestPartition_iff_WantVonFintel
-    (belS : Set W) [DecidablePred belS] (GS : List (Finset W))
-    (worlds : List W) (hUniv : ∀ w, w ∈ worlds)
     (p : Set W) [DecidablePred p] :
-    WantQuestionBased belS GS (finestPartition worlds) p ↔ WantVonFintel belS GS p := by
-  unfold WantQuestionBased WantVonFintel undominatedAnswers SatisfactionOrdering.undominated
-  refine ⟨fun hLHS w hw hUnd => ?_, fun hRHS a ha => ?_⟩
-  · -- LHS → RHS: pick the cell `{w}`, show it's undominated, apply
-    have hcell_mem : ({w} : Finset W) ∈
-        questionRelativeBelief (finestPartition worlds) belS :=
-      (mem_qRB_finestPartition_iff belS worlds w).mpr ⟨hUniv w, hw⟩
-    have hcell_undom : ({w} : Finset W) ∈
-        ((propositionOrdering GS).undominated
-          (questionRelativeBelief (finestPartition worlds) belS)) := by
-      unfold SatisfactionOrdering.undominated
-      rw [List.mem_filter]
-      refine ⟨hcell_mem, ?_⟩
-      simp only [decide_eq_true_eq]
-      rintro ⟨c, hc_mem, hc_strict⟩
-      -- c is in qRB; via mem_qRB_finestPartition_iff, c = {z} for
-      -- some z with belS z. Translate hc_strict to wAALG and contradict hUnd.
-      have hc_in_fp : c ∈ finestPartition worlds := by
-        unfold questionRelativeBelief at hc_mem
-        exact (List.mem_filter.mp hc_mem).1
-      obtain ⟨z, _hz_mem, hz_eq⟩ := List.mem_map.mp hc_in_fp
-      have hz_bel : belS z := by
-        rw [← hz_eq] at hc_mem
-        exact ((mem_qRB_finestPartition_iff belS worlds z).mp hc_mem).2
-      rw [← hz_eq] at hc_strict
-      have hzw : WorldAtLeastAsGood GS z w := (singleton_le_iff_world GS z w).mp hc_strict.1
-      have hnwz : ¬ WorldAtLeastAsGood GS w z := fun h =>
-        hc_strict.2 ((singleton_le_iff_world GS w z).mpr h)
-      exact hUnd z hz_bel ⟨hzw, hnwz⟩
-    exact hLHS _ hcell_undom w (Finset.mem_singleton_self w)
-  · -- RHS → LHS: a is in undominated qRB; extract its world and apply hRHS
-    rw [List.mem_filter] at ha
-    obtain ⟨ha_mem, ha_min⟩ := ha
-    -- a ∈ qRB; extract w with a = {w}, w ∈ worlds, belS w
-    have ha_in_fp : a ∈ finestPartition worlds := by
-      unfold questionRelativeBelief at ha_mem
-      exact (List.mem_filter.mp ha_mem).1
-    obtain ⟨w, _hw_mem, hw_eq⟩ := List.mem_map.mp ha_in_fp
-    -- Substitute a := {w} throughout
-    subst hw_eq
-    have hbelw : belS w :=
-      ((mem_qRB_finestPartition_iff belS worlds w).mp ha_mem).2
-    -- ha_min: ¬ ∃ c ∈ qRB, c strictly better than {w}
-    simp only [decide_eq_true_eq] at ha_min
-    have hUnd : ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧
-                                  ¬ WorldAtLeastAsGood GS w z) := by
-      intro z hz_bel ⟨hzw, hnwz⟩
-      apply ha_min
-      refine ⟨{z}, ?_, ?_⟩
-      · exact (mem_qRB_finestPartition_iff belS worlds z).mpr ⟨hUniv z, hz_bel⟩
-      · exact ⟨(singleton_le_iff_world GS z w).mpr hzw,
-               fun h => hnwz ((singleton_le_iff_world GS w z).mp h)⟩
-    have hpw : p w := hRHS w hbelw hUnd
-    intro x hx
-    exact (Finset.mem_singleton.mp hx) ▸ hpw
-
-/-! ### The belief-based no-go for von Fintel ([phillips-brown-2025] §2)
-
-The paper's central argument against belief-based semantics. For any
-non-empty belief state with at least one undominated world, vF cannot
-make both `WantVonFintel belS GS p` and `WantVonFintel belS GS (¬p)` true at the
-same context. -/
-
-omit [Fintype W] [DecidableEq W] in
-/-- **No-go for vF** (§2.1): if some belS-world is undominated,
-    then no vF-prediction makes both `want p` and `want ¬p` true. -/
-theorem wantVonFintel_no_conflict
-    (belS : Set W) [DecidablePred belS]
-    (GS : List (Finset W)) (p : Set W) [DecidablePred p]
-    (h : ∃ w, belS w ∧
-      ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) :
-    ¬ (WantVonFintel belS GS p ∧ WantVonFintel belS GS (fun w => ¬ p w)) := by
-  rintro ⟨hp, hnp⟩
-  obtain ⟨w, hw, hund⟩ := h
-  exact (hnp w hw hund) (hp w hw hund)
-
-/-! ### Closure properties ([phillips-brown-2025] §4) -/
-
-omit [Fintype W] [DecidableEq W] in
-/-- vF is **upward monotonic**: if `p ⊆ q` and `WantVonFintel belS GS p`,
-    then `WantVonFintel belS GS q`. This is the [villalta-2008]
-    doxastic-closure problem that motivates the question-based
-    approach (§4.1). -/
-theorem wantVonFintel_upward_monotonic (belS : Set W) [DecidablePred belS]
-    (GS : List (Finset W)) (p q : Set W) [DecidablePred p] [DecidablePred q]
-    (hpq : ∀ w, p w → q w) (h : WantVonFintel belS GS p) :
-    WantVonFintel belS GS q :=
-  fun w hw hund => hpq w (h w hw hund)
-
-omit [Fintype W] in
-/-- Question-based `want` is **Strawson upward monotonic** (§4.2):
-    `WantQuestionBased belS GS Q p`, `p ⊆ q`, and `q` considered
-    relative to `Q` jointly imply `WantQuestionBased belS GS Q q`. The
-    Considering presupposition is what blocks naive upward monotonicity
-    that derived "Avoid-war ⊨ Avoid-nuclear-war" from "wants
-    Avoid-war". -/
-theorem wantQuestionBased_strawson_upward_monotonic
-    (belS : Set W) [DecidablePred belS]
-    (GS answers : List (Finset W)) (p q : Set W)
-    [DecidablePred p] [DecidablePred q]
-    (hpq : ∀ w, p w → q w) (_hCons : IsConsidered answers q)
-    (h : WantQuestionBased belS GS answers p) :
-    WantQuestionBased belS GS answers q :=
-  fun a ha w hw => hpq w (h a ha w hw)
-
-/-! ### Comparative-belief semantics ([heim-1992])
-
-The paper has three successive truth conditions for `want`, each fixing
-a defect of the prior. We expose all three as a feature, not a bug — it
-shows the trajectory and lets future readers reproduce the argument.
-
-(27) The naive Hintikka-style `want` (§3, p. 192): "every bouletic
-alternative is a φ-world." Heim immediately rejects it via Asher's
-Concorde counterexample at (32) p. 194. We formalize it as `WantHeimNaive`
-to make the rejection-by-counterexample testable.
-
-(31) Truth-conditional comparative-belief `want` (§4.1, p. 193 —
-the canonical "Heim semantics"): "α wants φ is true at w iff for every
-w' ∈ Dox_α(w): every φ-world maximally similar to w' is more desirable
-to α than any non-φ-world maximally similar to w'." This is the textbook
-formulation.
-
-(37/39) CCP-rephrased Heim `want` (§4.2.2, p. 197): same content,
-but the proposition is restricted to Dox first
-(`Sim_w'(Dox_α(w) + φ) <_{α,w} Sim_w'(Dox_α(w) + ¬φ)`). The (40)
-amendment makes this **undefined** when the agent already believes φ
-or already believes ¬φ — a presupposition failure that is the
-formal mechanism behind Heim's account being unable to predict
-simultaneous `want(p) ∧ want(¬p)`.
-
-Heim does NOT use a Kratzer-style ordering source — she uses a
-[lewis-1973] / [stalnaker-1968] similarity ordering on worlds.
-The desirability `<_{α,w}` is treated as primitive (a relation between
-worlds, parameterized by agent and evaluation world), not derived from
-a desire-list the way vF's is. -/
+    Decidable (WantHeimNaive belS p) :=
+  inferInstanceAs (Decidable (∀ _, _))
 
 /-- Parameters for Heim 1992's desire semantics: a similarity ordering
     on worlds (for `Sim_w(p)` = closest p-worlds to w) and a comparative
@@ -486,40 +125,20 @@ instance (params : HeimDesireParams W) (w x y : W) :
   params.prefDec w x y
 
 /-- Sim_w(p) restricted to `belS ∩ p`: the closest worlds in
-    `belS ∩ p` to `w` under the similarity ordering. Heim's formulation
-    (37) restricts the proposition argument of `Sim` to the doxastic
-    base, which is what makes the Limit Assumption automatic on a
-    finite model. -/
-def heimSim {W : Type*} [Fintype W] [DecidableEq W]
-    (params : HeimDesireParams W)
+    `belS ∩ p` to `w` under the similarity ordering. Heim's (37)
+    restricts the proposition argument of `Sim` to the doxastic base,
+    which is what makes the Limit Assumption automatic on a finite
+    model. -/
+def heimSim (params : HeimDesireParams W)
     (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] (w : W) : Finset W :=
   params.sim.closestWorlds w
     (Finset.univ.filter (fun z => belS z ∧ p z))
 
-/-- Heim 1992 (27), the naive Hintikka-style baseline: "α wants φ" iff
-    every bouletic alternative (here: every belief-world; we suppress
-    the bouletic/doxastic distinction at the substrate level) is a
-    φ-world. Provided to enable formalizing Asher's (32) Concorde
-    counterexample as a test of the analysis Heim *rejected*. -/
-def WantHeimNaive (belS : Set W) [DecidablePred belS]
-    (p : Set W) [DecidablePred p] : Prop :=
-  ∀ w, belS w → p w
-
-instance (belS : Set W) [DecidablePred belS]
-    (p : Set W) [DecidablePred p] :
-    Decidable (WantHeimNaive belS p) :=
-  inferInstanceAs (Decidable (∀ _, _))
-
-/-- Heim 1992 (37/39), the canonical comparative-belief semantics:
-    "α wants φ" at `w_eval` iff for every doxastic alternative `w' ∈ belS`,
-    every closest `belS ∩ φ`-world to `w'` is at least as desirable as
-    every closest `belS ∩ ¬φ`-world to `w'`.
-
-    The doxastic-alternative quantifier ranges over a `Finset` so the
-    `Decidable` instance below can be derived via `Finset.decidableBAll`.
-    The `[DecidablePred belS]`/`[DecidablePred p]` are needed because
-    `heimSim` uses them. -/
+/-- Heim's (37/39), the canonical comparative-belief semantics:
+    "α wants φ" at `w_eval` iff for every doxastic alternative
+    `w' ∈ belS`, every closest `belS ∩ φ`-world to `w'` is at least as
+    desirable as every closest `belS ∩ ¬φ`-world to `w'`. -/
 def WantHeim (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p] : Prop :=
   ∀ w' ∈ (Finset.univ : Finset W).filter belS,
@@ -532,12 +151,10 @@ instance (belS : Set W) [DecidablePred belS]
     Decidable (WantHeim belS params w_eval p) :=
   inferInstanceAs (Decidable (∀ _ ∈ _, _))
 
-/-- Heim's (40) amendment (§4.2.3, p. 198): ⟦α wants φ⟧ is defined
-    only when the agent does not already believe φ and does not already
-    believe ¬φ. Equivalently: both `belS ∩ φ` and `belS ∩ ¬φ` are
-    non-empty. -/
-def WantHeimDefined (belS : Set W) [DecidablePred belS]
-    (p : Set W) [DecidablePred p] : Prop :=
+/-- Heim's (40) amendment: ⟦α wants φ⟧ is defined only when the agent
+    neither already believes φ nor already believes ¬φ — both
+    `belS ∩ φ` and `belS ∩ ¬φ` are non-empty. -/
+def WantHeimDefined (belS p : Set W) : Prop :=
   (∃ w, belS w ∧ p w) ∧ (∃ w, belS w ∧ ¬ p w)
 
 instance (belS : Set W) [DecidablePred belS]
@@ -545,27 +162,11 @@ instance (belS : Set W) [DecidablePred belS]
     Decidable (WantHeimDefined belS p) :=
   inferInstanceAs (Decidable (_ ∧ _))
 
-/-! ### Heim no-go: comparative-belief blocks simultaneous `want(p) ∧ want(¬p)`
+/-! ### Comparative belief blocks conflicting desires -/
 
-The proof shape: pick any `w' ∈ belS` (exists since `WantHeimDefined`
-gives non-empty `belS ∩ p`). Pick any `x ∈ Sim p w'` and any
-`y ∈ Sim ¬p w'` (both non-empty under `WantHeimDefined`). Then
-`WantHeim belS params w_eval p` gives `pref w_eval x y` and
-`WantHeim belS params w_eval ¬p` gives `pref w_eval y x`. Strict
-asymmetry of `pref` — i.e., `pref w x y ∧ pref w y x → x = y` for the
-weak relation, or `pref w x y → ¬ pref w y x` for the strict — yields
-`x = y`, but `x ∈ p` and `y ∈ ¬p` (since Sim's first arg restricts to
-`belS ∩ p` / `belS ∩ ¬p`), contradiction.
-
-The substrate exposes the asymmetry as a hypothesis to keep the
-no-go applicable to both strict and partial-order desirability
-relations. -/
-
-/-- A `belS ∩ p`-world reachable via similarity from any belS-world
-    under the limit assumption, i.e. when `WantHeimDefined` holds, gives
-    a non-empty `heimSim params belS p w'`. Discharges Heim's Limit
-    Assumption automatically on finite types via
-    `Core.Order.SimilarityOrdering.closestWorlds_nonempty`. -/
+/-- `heimSim` is non-empty whenever `belS ∩ p` is — Heim's Limit
+    Assumption, automatic on a finite model via
+    `SimilarityOrdering.closestWorlds_nonempty`. -/
 theorem heimSim_nonempty (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (p : Set W) [DecidablePred p]
     (w' : W) (hNE : ∃ z, belS z ∧ p z) :
@@ -575,18 +176,11 @@ theorem heimSim_nonempty (belS : Set W) [DecidablePred belS]
   obtain ⟨z, hzBel, hzp⟩ := hNE
   exact ⟨z, by simp [Finset.mem_filter, hzBel, hzp]⟩
 
-/-- **Heim no-go theorem**: under the (40) definedness amendment and a
-    *strictly asymmetric* desirability relation, no Heim-semantic
-    prediction makes both `want(p)` and `want(¬p)` true.
-
-    Proof: extract a witness from each `Sim` (non-empty by
-    `heimSim_nonempty`), then chase strict asymmetry of `pref` to a
-    `p w ∧ ¬ p w` contradiction.
-
-    The asymmetry hypothesis `hAsym` is the substantive condition: it
-    says `pref` is a strict (irreflexive) preference, i.e., a world
-    cannot be strictly preferred to itself. Standard for any
-    well-formed comparative desirability. -/
+/-- Under the (40) definedness amendment and an antisymmetric
+    desirability relation, Heim's semantics cannot make `want(p)` and
+    `want(¬p)` simultaneously true. Antisymmetry is a hypothesis
+    rather than structure so the theorem applies to strict and
+    partial-order desirability alike. -/
 theorem wantHeim_no_conflict
     (belS : Set W) [DecidablePred belS]
     (params : HeimDesireParams W) (w_eval : W) (p : Set W) [DecidablePred p]
@@ -629,14 +223,333 @@ theorem wantHeim_no_conflict
     exact this.2
   exact hynp (hxy_eq ▸ hxp)
 
-end Generic
+end
 
-/-! ### Effective-preference readings ([condoravdi-lauer-2016])
+section
+
+variable {W : Type*}
+
+/-! ## Ordering semantics ([von-fintel-1999])
+
+Every undominated belief-world is a p-world, under the world ordering
+induced by which desires each world satisfies — [kratzer-1981]'s
+`atLeastAsGoodAs` over the projected desire propositions. -/
+
+/-- World ordering induced by a desire list: `w ≤ z` iff every desire
+    in `GS` satisfied at `z` is also satisfied at `w` — [kratzer-1981]'s
+    `atLeastAsGoodAs` over the projected proposition list, by
+    definition. -/
+def WorldAtLeastAsGood (GS : List (Finset W)) (w z : W) : Prop :=
+  Modality.Kratzer.atLeastAsGoodAs (GS.map (fun s w => w ∈ s)) w z
+
+/-- The ordering in its membership form: every listed desire satisfied
+    at `z` is satisfied at `w`. -/
+theorem worldAtLeastAsGood_iff_mem (GS : List (Finset W)) (w z : W) :
+    WorldAtLeastAsGood GS w z ↔ ∀ s ∈ GS, z ∈ s → w ∈ s := by
+  show (∀ p ∈ GS.map (fun s w => w ∈ s), p z → p w) ↔ _
+  constructor
+  · intro h a ha hz
+    exact h _ (List.mem_map.mpr ⟨a, ha, rfl⟩) hz
+  · intro h q hq hz
+    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hq
+    exact h a ha hz
+
+instance [DecidableEq W] (GS : List (Finset W)) (w z : W) :
+    Decidable (WorldAtLeastAsGood GS w z) :=
+  decidable_of_iff _ (worldAtLeastAsGood_iff_mem GS w z).symm
+
+/-- von Fintel's *want*: every undominated belief-world is a
+    p-world. -/
+def WantVonFintel (belS : Set W) (GS : List (Finset W)) (p : Set W) : Prop :=
+  ∀ w, belS w →
+    (∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) →
+    p w
+
+instance [Fintype W] [DecidableEq W] (belS : Set W) [DecidablePred belS]
+    (GS : List (Finset W)) (p : Set W) [DecidablePred p] :
+    Decidable (WantVonFintel belS GS p) :=
+  inferInstanceAs (Decidable (∀ _, _))
+
+/-- If some belief-world is undominated, `WantVonFintel` cannot hold
+    of both `p` and `¬p` — the no-go [phillips-brown-2025] §2.1 runs
+    against belief-based semantics. -/
+theorem wantVonFintel_no_conflict
+    (belS : Set W) (GS : List (Finset W)) (p : Set W)
+    (h : ∃ w, belS w ∧
+      ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧ ¬ WorldAtLeastAsGood GS w z)) :
+    ¬ (WantVonFintel belS GS p ∧ WantVonFintel belS GS (fun w => ¬ p w)) := by
+  rintro ⟨hp, hnp⟩
+  obtain ⟨w, hw, hund⟩ := h
+  exact (hnp w hw hund) (hp w hw hund)
+
+/-- `WantVonFintel` is upward monotonic in the complement — the
+    [villalta-2008] doxastic-closure problem that motivates the
+    question-based approach ([phillips-brown-2025] §4.1). -/
+theorem wantVonFintel_upward_monotonic (belS : Set W)
+    (GS : List (Finset W)) (p q : Set W)
+    (hpq : ∀ w, p w → q w) (h : WantVonFintel belS GS p) :
+    WantVonFintel belS GS q :=
+  fun w hw hund => hpq w (h w hw hund)
+
+end
+
+section
+
+variable {W : Type*} [DecidableEq W]
+
+/-! ## Question-based semantics ([phillips-brown-2025])
+
+⟦S wants p⟧^c is evaluated against a contextual question Q_c: the
+answers compatible with S's beliefs (`questionRelativeBelief`, §3.3)
+are ordered by which desires they entail (`propositionOrdering`,
+§3.5), and the ascription is true iff every undominated answer
+entails p (`WantQuestionBased`). Definedness is governed by four
+metasemantic constraints (§3.6–§4.2), and on the finest question the
+semantics is von Fintel's (§3.4,
+`wantQuestionBased_finestPartition_iff_WantVonFintel`). -/
+
+/-! ### Answer preference (§3.5)
+
+S prefers answer `a` to `a'` iff the desires `a'` satisfies are a
+strict subset of those `a` satisfies:
+
+  {p ∈ G_S : a' ⊆ p} ⊊ {p ∈ G_S : a ⊆ p}
+
+The weak relation is `SatisfactionOrdering.ofCriteria`, the strict one
+`SatisfactionOrdering.strictlyBetter`; the paper's "best answers" are
+the Pareto-undominated elements (§3.5, p. 11:21). -/
+
+/-- Answer ordering: `a ≤ a'` iff every desire in `GS` that `a'`
+    entails, `a` also entails. -/
+def propositionOrdering (GS : List (Finset W)) :
+    SatisfactionOrdering (Finset W) (Finset W) :=
+  SatisfactionOrdering.ofCriteria (fun a p => decide (a ⊆ p)) GS
+
+/-- Best (= Pareto-undominated) answers among a candidate list. -/
+abbrev undominatedAnswers (GS answers : List (Finset W)) : List (Finset W) :=
+  (propositionOrdering GS).undominated answers
+
+/-- Q_c-Bel_S (§3.3): the cells of `answers` compatible with `belS`. -/
+def questionRelativeBelief (answers : List (Finset W))
+    (belS : Set W) [DecidablePred belS] : List (Finset W) :=
+  answers.filter fun a => decide (∃ w ∈ a, belS w)
+
+/-- ⟦S wants p⟧^c (§3.5): every undominated answer in Q_c-Bel_S
+    entails p. -/
+def WantQuestionBased (belS : Set W) [DecidablePred belS]
+    (GS answers : List (Finset W)) (p : Set W) : Prop :=
+  ∀ a ∈ undominatedAnswers GS (questionRelativeBelief answers belS),
+    ∀ w ∈ a, p w
+
+instance (belS : Set W) [DecidablePred belS]
+    (GS answers : List (Finset W)) (p : Set W) [DecidablePred p] :
+    Decidable (WantQuestionBased belS GS answers p) :=
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+
+/-! ### Metasemantic constraints (§3.6–§4.2) -/
+
+/-- The Considering Constraint (§3.6): every cell of Q_c either
+    entails p or entails ¬p — over partition cells, p is a union of
+    cells. -/
+def IsConsidered (answers : List (Finset W)) (p : Set W) : Prop :=
+  ∀ a ∈ answers, (∀ w ∈ a, p w) ∨ (∀ w ∈ a, ¬ p w)
+
+instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
+    Decidable (IsConsidered answers p) :=
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+
+/-- The Diversity Constraint (§3.7, attributed to [condoravdi-2002]):
+    Q_c contains both p-cells and ¬p-cells; without it ⟦want p⟧ is
+    vacuously true (or false). -/
+def IsDiverse (answers : List (Finset W)) (p : Set W) : Prop :=
+  (∃ a ∈ answers, ∀ w ∈ a, p w) ∧
+  (∃ a ∈ answers, ∀ w ∈ a, ¬ p w)
+
+instance (answers : List (Finset W)) (p : Set W) [DecidablePred p] :
+    Decidable (IsDiverse answers p) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-! ### Anti-deckstacking (§3.7)
+
+The paper quantifies over all propositions q: if some cell entails q,
+then q must itself be considered. Over a finite model the unrestricted
+`∀ q : Set W` fails on gerrymandered unions of part-cells — artifacts
+of the encoding, not of the question — so the constraint is
+parameterized on a test set of salient propositions that each concrete
+model declares. -/
+
+/-- The Anti-deckstacking Constraint (§3.7) over the test set
+    `naturalProps`: any test proposition entailed by some cell must be
+    considered. The empty test set satisfies the constraint trivially,
+    so concrete models must opt in by listing their basic
+    propositions. -/
+def IsAntiDeckstacking (naturalProps answers : List (Finset W)) : Prop :=
+  ∀ q ∈ naturalProps, (∃ a ∈ answers, a ⊆ q) → IsConsidered answers (· ∈ q)
+
+instance (naturalProps answers : List (Finset W)) :
+    Decidable (IsAntiDeckstacking naturalProps answers) :=
+  inferInstanceAs (Decidable (∀ _ ∈ _, _))
+
+/-- The Belief-sensitivity Constraint (§4.2, building on
+    [yalcin-2018]'s question-sensitive belief): `belS` discriminates
+    among the cells of Q_c — at least one answer is compatible with
+    the beliefs and at least one is not. Blocks ascriptions whose
+    question the agent cannot grasp (the paper's William III /
+    nuclear-war case). -/
+def IsBelSensitive (belS : Set W) [DecidablePred belS]
+    (answers : List (Finset W)) : Prop :=
+  let live := questionRelativeBelief answers belS
+  live ≠ [] ∧ live.length ≠ answers.length
+
+instance (belS : Set W) [DecidablePred belS] (answers : List (Finset W)) :
+    Decidable (IsBelSensitive belS answers) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Full definedness for ⟦S wants p⟧^c: Considering, Diversity,
+    Anti-deckstacking, and Belief-sensitivity jointly. -/
+def WantDefined (belS : Set W) [DecidablePred belS]
+    (naturalProps answers : List (Finset W)) (p : Set W) : Prop :=
+  IsConsidered answers p ∧ IsDiverse answers p ∧
+  IsAntiDeckstacking naturalProps answers ∧ IsBelSensitive belS answers
+
+instance (belS : Set W) [DecidablePred belS]
+    (naturalProps answers : List (Finset W)) (p : Set W) [DecidablePred p] :
+    Decidable (WantDefined belS naturalProps answers p) := by
+  unfold WantDefined; infer_instance
+
+/-- Question-based *want* as a `PartialProp`: presupposition = full
+    definedness, assertion = question-based truth. Both are
+    world-independent because Q_c is fixed contextually prior to
+    evaluation. -/
+def wantPartialProp (belS : Set W) [DecidablePred belS]
+    (GS naturalProps answers : List (Finset W)) (p : Set W) :
+    PartialProp W where
+  presup _ := WantDefined belS naturalProps answers p
+  assertion _ := WantQuestionBased belS GS answers p
+
+/-- Question-based *want* is Strawson upward monotonic (§4.2): given
+    `p ⊆ q` and the Considering presupposition for `q`, `want(p)`
+    entails `want(q)`. The presupposition is what blocks the naive
+    monotonicity that would derive "wants Avoid-nuclear-war" from
+    "wants Avoid-war". -/
+theorem wantQuestionBased_strawson_upward_monotonic
+    (belS : Set W) [DecidablePred belS]
+    (GS answers : List (Finset W)) (p q : Set W)
+    (hpq : ∀ w, p w → q w) (_hCons : IsConsidered answers q)
+    (h : WantQuestionBased belS GS answers p) :
+    WantQuestionBased belS GS answers q :=
+  fun a ha w hw => hpq w (h a ha w hw)
+
+/-! ### The finest question simulates von Fintel (§3.4)
+
+On the finest partition — one singleton cell per world — the
+question-based semantics is von Fintel's. The construction is
+parameterized on an explicit world list so concrete models can
+`decide` it. -/
+
+/-- The finest partition over an explicit world list: one singleton
+    cell per listed world. -/
+def finestPartition (worlds : List W) : List (Finset W) :=
+  worlds.map ({·})
+
+/-- Singleton-cell preference under `propositionOrdering` reduces to
+    single-world preference under `WorldAtLeastAsGood`: `{w} ≤ {z}` in
+    the proposition ordering iff `WorldAtLeastAsGood GS w z`. -/
+private theorem singleton_le_iff_world (GS : List (Finset W)) (w z : W) :
+    (propositionOrdering GS).le {w} {z} ↔ WorldAtLeastAsGood GS w z := by
+  rw [worldAtLeastAsGood_iff_mem]
+  unfold propositionOrdering SatisfactionOrdering.ofCriteria
+  show (∀ q ∈ GS.filter (fun q => decide (({z} : Finset W) ⊆ q)),
+          decide (({w} : Finset W) ⊆ q) = true) ↔
+       (∀ s ∈ GS, z ∈ s → w ∈ s)
+  simp only [decide_eq_true_eq, Finset.singleton_subset_iff]
+  constructor
+  · intro h q hq hqz
+    exact h q (by rw [List.mem_filter]; exact ⟨hq, by simpa using hqz⟩)
+  · intro h q hqf
+    rw [List.mem_filter] at hqf
+    exact h q hqf.1 (by simpa using hqf.2)
+
+omit [DecidableEq W] in
+/-- The singleton cell `{w}` is in `questionRelativeBelief
+    (finestPartition worlds) belS` iff `w ∈ worlds` and `belS w`. -/
+private theorem singleton_mem_questionRelativeBelief_finestPartition
+    (belS : Set W) [DecidablePred belS] (worlds : List W) (w : W) :
+    ({w} : Finset W) ∈ questionRelativeBelief (finestPartition worlds) belS ↔
+      w ∈ worlds ∧ belS w := by
+  simp [questionRelativeBelief, finestPartition, List.mem_filter,
+    Finset.singleton_inj]
+
+/-- On the finest partition over an exhaustive world list,
+    question-based want is von Fintel's ([phillips-brown-2025]
+    §3.4). -/
+theorem wantQuestionBased_finestPartition_iff_WantVonFintel
+    (belS : Set W) [DecidablePred belS] (GS : List (Finset W))
+    (worlds : List W) (hUniv : ∀ w, w ∈ worlds)
+    (p : Set W) [DecidablePred p] :
+    WantQuestionBased belS GS (finestPartition worlds) p ↔ WantVonFintel belS GS p := by
+  unfold WantQuestionBased WantVonFintel undominatedAnswers SatisfactionOrdering.undominated
+  refine ⟨fun hLHS w hw hUnd => ?_, fun hRHS a ha => ?_⟩
+  · -- LHS → RHS: pick the cell {w}, show it is undominated, apply
+    have hcell_mem : ({w} : Finset W) ∈
+        questionRelativeBelief (finestPartition worlds) belS :=
+      (singleton_mem_questionRelativeBelief_finestPartition belS worlds w).mpr ⟨hUniv w, hw⟩
+    have hcell_undom : ({w} : Finset W) ∈
+        ((propositionOrdering GS).undominated
+          (questionRelativeBelief (finestPartition worlds) belS)) := by
+      unfold SatisfactionOrdering.undominated
+      rw [List.mem_filter]
+      refine ⟨hcell_mem, ?_⟩
+      simp only [decide_eq_true_eq]
+      rintro ⟨c, hc_mem, hc_strict⟩
+      -- c is a question-relative belief cell, so c = {z} for some z with
+      -- belS z; translate hc_strict to the world ordering and contradict hUnd.
+      have hc_in_fp : c ∈ finestPartition worlds := by
+        unfold questionRelativeBelief at hc_mem
+        exact (List.mem_filter.mp hc_mem).1
+      obtain ⟨z, _hz_mem, hz_eq⟩ := List.mem_map.mp hc_in_fp
+      have hz_bel : belS z := by
+        rw [← hz_eq] at hc_mem
+        exact ((singleton_mem_questionRelativeBelief_finestPartition belS worlds z).mp hc_mem).2
+      rw [← hz_eq] at hc_strict
+      have hzw : WorldAtLeastAsGood GS z w := (singleton_le_iff_world GS z w).mp hc_strict.1
+      have hnwz : ¬ WorldAtLeastAsGood GS w z := fun h =>
+        hc_strict.2 ((singleton_le_iff_world GS w z).mpr h)
+      exact hUnd z hz_bel ⟨hzw, hnwz⟩
+    exact hLHS _ hcell_undom w (Finset.mem_singleton_self w)
+  · -- RHS → LHS: a is an undominated question-relative belief cell
+    rw [List.mem_filter] at ha
+    obtain ⟨ha_mem, ha_min⟩ := ha
+    -- extract w with a = {w}, w ∈ worlds, belS w
+    have ha_in_fp : a ∈ finestPartition worlds := by
+      unfold questionRelativeBelief at ha_mem
+      exact (List.mem_filter.mp ha_mem).1
+    obtain ⟨w, _hw_mem, hw_eq⟩ := List.mem_map.mp ha_in_fp
+    -- Substitute a := {w} throughout
+    subst hw_eq
+    have hbelw : belS w :=
+      ((singleton_mem_questionRelativeBelief_finestPartition belS worlds w).mp ha_mem).2
+    -- ha_min: no question-relative belief cell is strictly better than {w}
+    simp only [decide_eq_true_eq] at ha_min
+    have hUnd : ∀ z, belS z → ¬ (WorldAtLeastAsGood GS z w ∧
+                                  ¬ WorldAtLeastAsGood GS w z) := by
+      intro z hz_bel ⟨hzw, hnwz⟩
+      apply ha_min
+      refine ⟨{z}, ?_, ?_⟩
+      · exact (singleton_mem_questionRelativeBelief_finestPartition belS worlds z).mpr ⟨hUniv z, hz_bel⟩
+      · exact ⟨(singleton_le_iff_world GS z w).mpr hzw,
+               fun h => hnwz ((singleton_le_iff_world GS w z).mp h)⟩
+    have hpw : p w := hRHS w hbelw hUnd
+    intro x hx
+    exact (Finset.mem_singleton.mp hx) ▸ hpw
+
+end
+
+/-! ## Effective-preference readings ([condoravdi-lauer-2016])
 
 The inferential profile is fixed by the choice of relation:
 success-oriented want is downward-entailing in the complement,
-Quine-Hintikka want upward-entailing, exact-match want neither
-(counterexample-construction deferred). The conflicting-desires
+Quine-Hintikka want upward-entailing, exact-match want neither. The conflicting-desires
 blockage for exact-match want over a consistent background is
 `PreferenceStructure.maxElts_pair_belief_compatible` directly,
 prosecuted in `Studies/CondoravdiLauer2016.lean`; the anankastic
@@ -689,56 +602,24 @@ theorem wantQuineHintikka_upward_entailing
 
 end EffectivePreferenceReadings
 
+/-! ## Expected-value semantics ([lassiter-2017]; [lassiter-2011])
 
-/-! ### Expected-value semantics ([lassiter-2017]; [lassiter-2011])
+[lassiter-2017] ch.7 ("Scalar goodness") develops an expected-value
+semantics for evaluative gradable predicates:
+`E_V(φ) = Σ_{w ∈ φ ∩ D} V(w) · prob({w} | φ ∩ D)` (eq. 7.22, p.187),
+with the positive form the threshold reading `μ(φ) > θ` (§8.14
+eq. 8.72a, p.253). The extension to *want* is §8.13 (p.249) — "*want*
+behaves as a gradable verb like *like, matter, care, need*" — with the
+detailed account in [lassiter-2011] ch.6.
 
-[lassiter-2017] ch.7 (titled "Scalar goodness", *not* a desire
-chapter) develops an expected-value semantics for evaluative gradable
-predicates: `E_V(φ) = Σ_{w ∈ φ ∩ D} V(w) · prob({w} | φ ∩ D)` (eq. 7.22,
-p.187). The book's positive-form *ought* (§8.14 eq. 8.72a, p.253) is
-exactly the threshold reading `μ_ought(φ) > θ_ought` we adopt as `want`.
-The book extends to *want* in a single sentence at §8.13 (p.249):
-"*want* behaves as a gradable verb like *like, matter, care, [...]
-need*." The detailed *want*-as-EU account lives in [lassiter-2011]
-ch.6 (NYU dissertation).
-
-The substrate exposes:
-
-* `Lassiter.expectedValue pr V belS p` — conditional expected value of
-  `p` given the agent's belief state. Convention: returns `0` when
-  `p ∩ belS = ∅` (Lassiter notes E_V undefined here, p.187 fn.).
-* `Lassiter.Want belS pr V θ p` — Lassiter-style positive-form want:
-  `E_V(p|bel) > θ`. Matches §8.14 eq. 8.72a.
-* `Lassiter.SlomanPrinciple` (§8.6 eq. 8.16, p.216) — a constraint
-  that the wanted proposition strictly dominates every other relevant
-  alternative on the value scale.
-* `Lassiter.WantWithSloman` — Lassiter's *full* account: bare threshold
-  AND Sloman's Principle.
-
-**The bare threshold form admits simultaneous want(p) ∧ want(¬p)**
-(`Lassiter.threshold_admits_conflict_witness`), violating the substrate's
-`BeliefBasedDesireSemantics.IsConflictBlocking`. This makes Lassiter's
-*bare apparatus* a sibling of vF/Heim/PB, *not* a `BBSemantics`
-instance. Lassiter and Phillips-Brown are *different ways* of escaping
-the no-go: PB via question-sensitivity, Lassiter via
-probabilistic-decision-theoretic gradability.
-
-**However, Lassiter's full account blocks the witness.** Per paper
-§8.11 (p.245): *"we should not weaken the semantics to make room for
-the simultaneous truth of ought(φ) and ought(¬φ). Instead, we should
-allow that there are various, possibly conflicting **sources of
-value**..."* Sloman's Principle (eq. 8.16, p.216;
-`Lassiter.wantWithSloman_blocks_conflict`) excludes the witness on a
-single value function; genuine conflicting wants come from multiple
-value sources with weighted aggregation (§8.11 pp.243-245), not from
-single-V threshold-tuning. The bare threshold's admission of conflict
-is what Cariani 2013 attacks; Lassiter's response is *not* "let
-single-V conflict happen" but "let multi-source aggregation explain
-the data without single-V conflict."
-
-The substrate exposes both layers (bare threshold + Sloman-augmented
-full account) so the reader can see exactly which Lassiter-flavored
-claim is being made. -/
+The bare threshold admits simultaneous `want(p) ∧ want(¬p)`
+(`threshold_admits_conflict_witness`), so Lassiter escapes the
+belief-based no-go by a different route than Phillips-Brown:
+probabilistic gradability rather than question-sensitivity. The full
+account adds Sloman's Principle, which blocks single-value conflict
+(`wantWithSloman_blocks_conflict`); per §8.11 (pp.243–245), genuine
+conflicting wants come from multiple sources of value with weighted
+aggregation, not from threshold-tuning on one value function. -/
 
 namespace Lassiter
 
@@ -747,20 +628,14 @@ variable {W : Type*}
 /-! ### Expected value -/
 
 /-- Conditional expected value of `p` given belief state `belS` under
-    prior `pr` and value function `V`. Lassiter 2017 §7.6 eq. 7.22:
-
-      E_V(p) = Σ_{w ∈ p ∩ belS} V(w) · pr({w} | p ∩ belS)
-
-    Expanded as a ratio:
+    prior `pr` and value function `V` (eq. 7.22):
 
       E_V(p) = (Σ pr·V over (p ∩ belS)) / (Σ pr over (p ∩ belS))
 
-    Indicator-style sums (rather than `Finset.filter`) make the
-    definition `decide`-friendly for concrete witness models. The two
-    sums are inlined (not `let`-bound) so that downstream `rw` calls
-    don't have to unfold a `have`-binding. Returns `0` when the
-    denominator is zero (Lassiter notes E_V undefined for the empty
-    proposition, p.187 fn.; we make the 0 convention). -/
+    Indicator-style sums keep the definition `decide`-friendly for
+    concrete witness models. Returns `0` when the denominator is zero
+    (Lassiter leaves E_V undefined for the empty proposition,
+    p.187 fn.). -/
 def expectedValue [Fintype W]
     (pr : W → ℚ) (V : W → ℚ)
     (belS : Set W) [DecidablePred belS]
@@ -769,11 +644,10 @@ def expectedValue [Fintype W]
   else (∑ w, (if belS w ∧ p w then pr w * V w else 0)) /
        (∑ w, (if belS w ∧ p w then pr w else 0))
 
-/-- **Lassiter-style positive-form `want`**: ⟦S wants p⟧ iff the
-    conditional expected value of `p` given S's beliefs exceeds
-    threshold `θ`. Matches §8.14 eq. 8.72a's scalar
-    interpretation `μ_ought(φ) > θ_ought`, extended to *want* per
-    §8.13 + Lassiter 2011 ch.6. -/
+/-- Positive-form *want*: the conditional expected value of `p` given
+    S's beliefs exceeds the threshold `θ` — the scalar reading
+    `μ_ought(φ) > θ_ought` of §8.14 eq. 8.72a, extended to *want* per
+    §8.13 and [lassiter-2011] ch.6. -/
 def Want [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
@@ -805,9 +679,9 @@ def SlomanPrinciple [Fintype W] [DecidableEq W]
   ∀ entry ∈ alts, entry ≠ p →
     expectedValue pr V belS (· ∈ p) > expectedValue pr V belS (· ∈ entry)
 
-/-- **Lassiter's full account**: the bare threshold AND Sloman's
-    Principle. This is the *actual* account Lassiter defends in §8;
-    the bare `want` operator alone is the apparatus, not the position. -/
+/-- Lassiter's full account: the bare threshold and Sloman's
+    Principle. This is the account Lassiter defends in §8; the bare
+    `Want` operator alone is apparatus, not the position. -/
 def WantWithSloman [Fintype W] [DecidableEq W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
@@ -816,9 +690,10 @@ def WantWithSloman [Fintype W] [DecidableEq W]
 
 /-! ### Bridge to decision theory
 
-`Lassiter.expectedValue` is the proposition-conditional analog of
-`Core.Agent.DecisionTheory.DecisionProblem.condExpectedUtility`. Wrapping the value function
-as a unit-action utility makes the bridge explicit. -/
+`expectedValue` is the proposition-conditional analog of
+`Core.DecisionTheory.DecisionProblem.condExpectedUtility`; wrapping
+the value function as a unit-action utility makes the bridge
+explicit. -/
 
 /-- Wrap a Lassiter `(prior, value)` pair as a unit-action
     `DecisionProblem`. -/
@@ -839,8 +714,10 @@ Weakening-failure pattern [cariani-2016] attacks within actualism,
 applied to the EV semantics. Cariani 2016's own counter-model
 (p.405) uses an actualist closeness ordering, not EV. Lassiter's
 *response* is to add Sloman's Principle, which excludes the witness
-(see `wantWithSloman_blocks_conflict_on_witness` below). -/
+(`wantWithSloman_blocks_conflict`; the witness-model instance is in
+`Studies/Lassiter2017.lean`). -/
 
+/-- The bare threshold admits simultaneous `want(p)` and `want(¬p)`. -/
 theorem threshold_admits_conflict_witness :
     ∃ (W : Type) (_ : Fintype W) (_ : DecidableEq W)
       (belS : Set W) (_ : DecidablePred belS)
@@ -862,18 +739,16 @@ theorem threshold_admits_conflict_witness :
     simp [Fin.sum_univ_succ]
     norm_num
 
-/-! ### Sloman's Principle blocks the witness
+/-! ### Sloman's Principle blocks the conflict
 
-Lassiter's *full* account adds Sloman's Principle (eq. 8.16 p.216).
-On the conflict-witness model with `alts = [p, pᶜ]`, Sloman holds for
-`p` (E_V(p) = 7 > 2 = E_V(pᶜ) ✓) but FAILS for `pᶜ`
-(E_V(pᶜ) = 2 ≯ 7 = E_V(p) ✗). So `WantWithSloman` makes only `p`
-wanted, blocking the conflict.
+On the witness model with `alts = [p, pᶜ]`, Sloman holds for `p`
+(E_V(p) = 7 > 2 = E_V(pᶜ)) and fails for `pᶜ`, so `WantWithSloman`
+makes only `p` wanted — Lassiter's §8.11 (p.245) position that
+single-value conflict is excluded by his own constraints, with
+genuine conflicting wants coming from multi-source aggregation. -/
 
-This formalizes Lassiter's §8.11 (p.245) position: single-V conflict
-is blocked by his own constraints; genuine conflicting wants come from
-multi-source aggregation, not from threshold-tuning. -/
-
+/-- `WantWithSloman` cannot hold of both `p` and its complement when
+    both are among the alternatives. -/
 theorem wantWithSloman_blocks_conflict
     [Fintype W] [DecidableEq W] (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)
@@ -898,25 +773,21 @@ formula
 shows E_V is a weighted average over disjoint propositions, hence
 intermediate.
 
-We formalize the disjoint case directly: for disjoint p, q with
-positive belief mass, `min(E_V(p), E_V(q)) ≤ E_V(p ∪ q) ≤ max(...)`.
-This is the key abstract scalar property that underlies Weakening
-(below) and is the empirical motivation for Lassiter's whole
-expected-value semantics. -/
+Formalized here in the disjoint case: for disjoint p, q with
+positive belief mass,
+`min(E_V(p), E_V(q)) ≤ E_V(p ∪ q) ≤ max(E_V(p), E_V(q))` — the scalar
+property underlying Weakening below. -/
 
-/-- A proposition has *positive belief mass* if some belS-world
-    satisfies it. Decidability is inherited via the fact that
-    `Set.Nonempty (belS ∩ p)` is decidable on finite types. -/
+/-- `p` carries positive prior mass inside the belief state. -/
 def HasPositiveBeliefMass [Fintype W]
     (pr : W → ℚ) (belS : Set W) [DecidablePred belS]
     (p : Set W) [DecidablePred p] : Prop :=
   (∑ w, (if belS w ∧ p w then pr w else 0)) > 0
 
-/-- **Intermediacy of E_V (disjoint case)**: for disjoint propositions
-    p, q with positive belief mass,
-    `min(E_V(p), E_V(q)) ≤ E_V(p ∪ q) ≤ max(E_V(p), E_V(q))` — the
-    disjoint-union expectation is the mediant
-    `(E(p)·μ(p) + E(q)·μ(q)) / (μ(p) + μ(q))`, a weighted average. -/
+/-- Intermediacy of E_V, disjoint case: for disjoint p, q with
+    positive belief mass, the disjoint-union expectation is the
+    mediant `(E(p)·μ(p) + E(q)·μ(q)) / (μ(p) + μ(q))` — a weighted
+    average, hence between `min(E_V(p), E_V(q))` and the `max`. -/
 theorem expectedValue_intermediate_disjoint [Fintype W]
     (pr : W → ℚ) (V : W → ℚ)
     (belS : Set W) [DecidablePred belS]
@@ -999,13 +870,10 @@ intermediacy of expected value (§8.14);
 disjoint case, so Weakening is derived from the underlying scalar
 property rather than stipulated. -/
 
-/-- **Weakening from intermediacy** (disjoint case): when `p ⊥ q` and
-    both have positive belief mass, the disjoint-union expected value
-    is at least the smaller of `E_V(p)` and `E_V(q)`. So if both
-    exceed `θ`, so does their union.
-
-    This is Lassiter §8.14 eq. (8.78)'s derivation: intermediacy
-    means `E_V(p ∨ q) ≥ min(E_V(p), E_V(q)) > θ`. -/
+/-- Weakening from intermediacy, disjoint case: when disjoint `p`
+    and `q` both exceed the threshold, so does their disjunction —
+    `E_V(p ∨ q) ≥ min(E_V(p), E_V(q)) > θ`, Lassiter's §8.14
+    eq. (8.78) derivation. -/
 theorem want_satisfies_weakening_disjoint [Fintype W]
     (belS : Set W) [DecidablePred belS]
     (pr : W → ℚ) (V : W → ℚ) (θ : ℚ)


### PR DESCRIPTION
Reorganizes `Desire.lean` into one section per account (Heim → von Fintel → Phillips-Brown → C&L → Lassiter), each with exactly the section variables it needs — dissolving the `Generic` mega-section and cutting the `omit` count from 7 to 1 — and drops vestigial `[DecidablePred]` binders from defs whose bodies never use them. Docstring register pass: plumbing prose, proof-sketch essays, and stale references (`Core.PartialProp`, `Core.Agent.DecisionTheory`, a dead `WantVonFintel` binder note, a "see below" pointing at a study-file theorem) removed; `vF`/`AD`/`qRB` shorthand expanded. Net −131 lines, no proof changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)