### PR TITLE
refactor(Semantics/Attitudes): cleanse Preferential; demote to studies

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2696,6 +2696,7 @@ import Linglib.Studies.TsvilodubEtAl2026
 import Linglib.Studies.TurcoBraunDimroth2014
 import Linglib.Studies.TurkHirsch2026
 import Linglib.Studies.Uchihara2021
+import Linglib.Studies.UegakiSudo2019
 import Linglib.Studies.Umbach2004
 import Linglib.Studies.VanDerAuweraVanAlsenoy2016
 import Linglib.Studies.VanDerLeer2026

--- a/Linglib/Features/Attitudes.lean
+++ b/Linglib/Features/Attitudes.lean
@@ -103,12 +103,13 @@ inductive AttitudeValence where
 /-- Which Montague predicate strategy this preferential verb uses.
 
     Links the Fragment entry to the compositional semantics in
-    `Semantics.Attitudes.Preferential`. Properties like C-distributivity
-    are DERIVED from this tag via theorems, not stipulated.
+    `Preferential`; clausal distributivity is derived from the tag's
+    constructor (`Preferential.mkDegreeComparison_isDistributive`,
+    `Preferential.worry_not_distributive`), not stipulated.
 
-    - `degreeComparison`: Uses `mkDegreeComparisonPredicate` → C-distributive
-    - `uncertaintyBased`: Uses `worry` constructor → NOT C-distributive
-    - `relevanceBased`: Uses `qidai` constructor → NOT C-distributive -/
+    - `degreeComparison`: `Preferential.mkDegreeComparison` — distributive
+    - `uncertaintyBased`: `Preferential.worry` — not distributive
+    - `relevanceBased`: `Preferential.qidai` — not distributive -/
 inductive Preferential where
   /-- Degree comparison semantics: ⟦x V Q⟧ = ∃p ∈ Q. μ(x,p) > θ. C-distributive. -/
   | degreeComparison (valence : AttitudeValence)

--- a/Linglib/Fragments/English/Predicates/Adjectival.lean
+++ b/Linglib/Fragments/English/Predicates/Adjectival.lean
@@ -49,8 +49,8 @@ def short : AdjectivalPredicateEntry where
 "happy" — open scale, contrary to "unhappy"
 
 Note: This is the 1-place adjectival predicate "x is happy".
-For the 2-place attitude predicate "x is happy that p", see
-`Semantics/Attitudes/Preferential.lean`.
+For the 2-place veridical-preferential attitude predicate
+"x is happy that p", see `Studies/UegakiSudo2019.lean`.
 -/
 def happy : AdjectivalPredicateEntry where
   form := "happy"

--- a/Linglib/Fragments/Japanese/Predicates.lean
+++ b/Linglib/Fragments/Japanese/Predicates.lean
@@ -1,4 +1,3 @@
-import Linglib.Semantics.Attitudes.Preferential
 import Linglib.Syntax.Category.Verb.Basic
 
 /-!
@@ -12,7 +11,6 @@ C-distributivity and NVP class are DERIVED from the `attitude` field.
 namespace Japanese.Predicates
 
 open ArgumentStructure
-open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 
 /-- Japanese verb entry: extends Verb with Japanese inflectional paradigm. -/
 structure JapaneseVerbEntry extends Verb where

--- a/Linglib/Fragments/Mandarin/Predicates.lean
+++ b/Linglib/Fragments/Mandarin/Predicates.lean
@@ -1,4 +1,3 @@
-import Linglib.Semantics.Attitudes.Preferential
 import Linglib.Syntax.Category.Verb.Basic
 
 /-!
@@ -12,7 +11,6 @@ C-distributivity and NVP class are DERIVED from the `attitude` field.
 namespace Mandarin.Predicates
 
 open ArgumentStructure
-open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 
 /-- Mandarin verb entry: extends Verb with no inflectional morphology
     (Mandarin is an isolating language). -/

--- a/Linglib/Fragments/Turkish/Predicates.lean
+++ b/Linglib/Fragments/Turkish/Predicates.lean
@@ -1,4 +1,3 @@
-import Linglib.Semantics.Attitudes.Preferential
 import Linglib.Syntax.Category.Verb.Basic
 
 /-!
@@ -12,7 +11,6 @@ C-distributivity and NVP class are DERIVED from the `attitude` field.
 namespace Turkish.Predicates
 
 open ArgumentStructure
-open Semantics.Attitudes.Preferential (AttitudeValence NVPClass)
 
 /-- Turkish verb entry: extends Verb with Turkish inflectional paradigm. -/
 structure TurkishVerbEntry extends Verb where

--- a/Linglib/Semantics/Attitudes/Distributivity.lean
+++ b/Linglib/Semantics/Attitudes/Distributivity.lean
@@ -1,5 +1,4 @@
-import Mathlib.Data.Rat.Defs
-import Mathlib.Data.Set.Basic
+import Mathlib.Data.Finset.Basic
 
 /-!
 # Clausal distributivity
@@ -12,66 +11,29 @@ semantics: ⟦x V Q⟧ ↔ ∃p ∈ Q. ⟦x V p⟧ ([uegaki-sudo-2019];
 propositional and question semantics, so it is proved from a
 predicate's semantic structure rather than stipulated per predicate.
 
-`degreeComparison_isDistributive` proves it for the degree-comparison
-pattern of *hope*, *fear*, *expect*, *wish* ([villalta-2008]):
-⟦x V p⟧ = μ(x,p) > θ(C) with the question semantics the pointwise
-existential, so clausal distributivity holds by construction.
-Predicates whose question semantics outruns the existential — global
-uncertainty for *worry*, decision-relevance for *care*
-([elliott-etal-2017]) — are not clausally distributive; the
-counterexample with actual worry semantics is
-`Preferential.worry_not_cDistributive`, and the per-predicate
-instantiations live in `Preferential.lean`.
+The degree-comparison preferentials of `Preferential.lean` are
+distributive by construction
+(`Preferential.mkDegreeComparison_isDistributive`); predicates whose
+question semantics outruns the existential — global uncertainty for
+*worry*, decision-relevance for *care* ([elliott-etal-2017]) — are
+not (`Preferential.worry_not_distributive`). Veridical preferentials
+instantiate the world-sensitive form (`Studies/UegakiSudo2019.lean`).
 
-Alternatives are the extensional, list-based `AlternativeList` over
-Bool propositions, pending migration of this file and its consumer
-`Preferential.lean` to the `Set`-based question substrate
-(`Semantics/Questions/`).
+Questions are alternative lists over `Finset W` propositions,
+matching the question representation of
+`Semantics/Attitudes/Desire.lean`.
 -/
 
-namespace Semantics.Attitudes.Distributivity
+namespace Distributivity
 
 variable {W E : Type*}
 
-/-- A Hamblin question denotation: a list of possible answers. -/
-abbrev AlternativeList (W : Type*) := List (W → Bool)
+/-- A predicate with propositional semantics `Vprop` and question
+    semantics `Vquestion` is clausally distributive iff
+    `Vquestion x Q w ↔ ∃ p ∈ Q, Vprop x p w`. -/
+def IsDistributive (Vprop : E → Finset W → W → Prop)
+    (Vquestion : E → List (Finset W) → W → Prop) : Prop :=
+  ∀ (x : E) (Q : List (Finset W)) (w : W),
+    Vquestion x Q w ↔ ∃ p ∈ Q, Vprop x p w
 
-/-- Preference/attitude degree function: `μ x p` is how strongly `x`
-    prefers (or fears) `p`. -/
-abbrev DegreeFn (W E : Type*) := E → (W → Bool) → ℚ
-
-/-- Contextual threshold function over a comparison class. -/
-abbrev ThresholdFn (W : Type*) := AlternativeList W → ℚ
-
-/-- A predicate with propositional semantics `V_prop` and question
-    semantics `V_question` is clausally distributive iff
-    `V_question x Q w ↔ ∃ p ∈ Q, V_prop x p w`. -/
-def IsDistributive (V_prop : E → (W → Bool) → W → Bool)
-    (V_question : E → AlternativeList W → W → Bool) : Prop :=
-  ∀ (x : E) (Q : AlternativeList W) (w : W),
-    V_question x Q w = true ↔ ∃ p ∈ Q, V_prop x p w = true
-
-/-! ### The degree-comparison pattern -/
-
-/-- Degree-comparison propositional semantics:
-    `degreeComparisonProp μ θ C x p w` iff `μ x p > θ C`. -/
-def degreeComparisonProp (μ : DegreeFn W E) (θ : ThresholdFn W)
-    (C : AlternativeList W) (x : E) (p : W → Bool) (_w : W) : Bool :=
-  decide (μ x p > θ C)
-
-/-- Degree-comparison question semantics, the pointwise existential:
-    `degreeComparisonQuestion μ θ C x Q w` iff `∃ p ∈ Q, μ x p > θ C`. -/
-def degreeComparisonQuestion (μ : DegreeFn W E) (θ : ThresholdFn W)
-    (C : AlternativeList W) (x : E) (Q : AlternativeList W) (_w : W) : Bool :=
-  Q.any λ p => decide (μ x p > θ C)
-
-/-- Degree-comparison predicates are clausally distributive by
-    construction. -/
-theorem degreeComparison_isDistributive (μ : DegreeFn W E) (θ : ThresholdFn W)
-    (C : AlternativeList W) :
-    IsDistributive (degreeComparisonProp μ θ C)
-      (degreeComparisonQuestion μ θ C) := by
-  intro x Q w
-  simp [degreeComparisonProp, degreeComparisonQuestion]
-
-end Semantics.Attitudes.Distributivity
+end Distributivity

--- a/Linglib/Semantics/Attitudes/Preferential.lean
+++ b/Linglib/Semantics/Attitudes/Preferential.lean
@@ -1,1256 +1,165 @@
-/-
-# Preferential Attitude Semantics
+import Mathlib.Data.Rat.Defs
+import Linglib.Features.Attitudes
+import Linglib.Semantics.Attitudes.Distributivity
 
-Degree-based semantics for preferential attitude verbs like `hope`, `fear`,
-`worry`, `wish`, `expect`, following [villalta-2008] and [romero-2015-salt].
+/-!
+# Preferential attitude semantics
 
-## Semantic Mechanism
+Degree-based semantics for preferential attitude verbs (*hope*,
+*fear*, *worry*, *wish*, *expect*), following [villalta-2008]:
+⟦x V p⟧(C) = μ(x, p) > θ(C), for a preference degree function μ and a
+contextual threshold θ over a comparison class C of propositions.
 
-Unlike doxastic attitudes (which use accessibility relations), preferential
-attitudes use **degree comparison**:
+[qing-uegaki-2025] classify non-veridical preferentials by two
+factors — clausal distributivity (`Distributivity.IsDistributive`)
+and evaluative valence — and show that only the distributive positive
+class (*hope*, *wish*, *expect*) is anti-rogative. The
+degree-comparison predicates built here are distributive by
+construction (`mkDegreeComparison_isDistributive`); *worry* and
+Mandarin *qidai* carry an extra global condition on the question that
+breaks distributivity (`worry_not_distributive`).
 
-⟦x hopes p⟧(w, C) = μ_hope(x, p) > θ_hope(C)
-
-Where:
-- μ_hope : Entity → Prop → Degree (preference function)
-- θ_hope : ComparisonClass → Degree (contextual threshold)
-- C : the comparison class of propositions
-
-## Key Properties
-
-1. **C-distributivity**: Does `x V Q` ⟺ `∃p ∈ Q. x V p`?
-2. **Valence**: Evaluatively positive (hope) vs. negative (fear)
-3. **TSP**: Threshold Significance Presupposition
-
-## Architecture: C-Distributivity as Provable Property
-
-C-distributivity is NOT stipulated — it must be PROVED for each predicate
-from the structure of its semantics. Each predicate defines:
-- `propSemantics`: how it combines with propositions
-- `questionSemantics`: how it combines with questions
-
-Then `IsDistributive propSemantics questionSemantics` is a theorem.
-
-## NVP Classification
-
-| Class | C-dist | Valence | TSP | Takes Q? | Examples |
-|-------|--------|---------|-----|----------|----------|
-| 1 | ✗ | any | any | ✓ | worry, qidai, tanosimi |
-| 2 | ✓ | negative | ✗ | ✓ | fear, osore, kork- |
-| 3 | ✓ | positive | ✓ | ✗ | hope, wish, expect |
-
+`ThresholdSignificance` is the presupposition [uegaki-sudo-2019]
+posit for degree constructions: some member of the comparison class
+clears the threshold. Positive preferentials trigger it while
+negative ones do not ([qing-uegaki-2025] §3.2). The anti-rogativity
+of the distributive positive class is derived from it in
+`Studies/UegakiSudo2019.lean`; the classification's cross-linguistic
+support lives in `Studies/QingEtAl2025.lean`; the emotive doxastic
+refinement of *hope* and *fear* ([anand-hacquard-2013]) in
+`Studies/AnandHacquard2013.lean`.
 -/
 
-import Mathlib.Data.Rat.Defs
-import Mathlib.Data.Set.Basic
-import Linglib.Features.Aktionsart
-import Linglib.Features.Attitudes
-import Linglib.Semantics.Causation.VerbClass
-import Linglib.Semantics.ArgumentStructure.LevinClass
-import Linglib.Semantics.ArgumentStructure.MeaningComponents
-import Linglib.Semantics.Attitudes.Distributivity
-import Linglib.Semantics.Attitudes.Doxastic
-
-namespace Semantics.Attitudes.Preferential
+namespace Preferential
 
 open Features (AttitudeValence)
-export Features (AttitudeValence)
-open Semantics.Attitudes.Distributivity (IsDistributive degreeComparison_isDistributive
-                      degreeComparisonProp degreeComparisonQuestion DegreeFn ThresholdFn)
 
--- Re-export types under more descriptive names for downstream use
+variable {W E : Type*}
 
-/-- Question denotation: set of possible answers. Re-exported from `Distributivity`. -/
-abbrev AlternativeList (W : Type*) := Semantics.Attitudes.Distributivity.AlternativeList W
-
-/-- Preference function: μ(agent, prop) → degree. Alias for `DegreeFn`. -/
-abbrev PreferenceFunction (W E : Type*) := DegreeFn W E
-
-/-- Threshold function: θ(comparison_class) → degree. Alias for `ThresholdFn`. -/
-abbrev ThresholdFunction (W : Type*) := ThresholdFn W
-
--- Connection to Question Semantics
-
-/-!
-## Grounding in Question Semantics
-[uegaki-sudo-2019] [villalta-2008] [rooth-1992] [qing-uegaki-2025]
-
-Questions are **alternative sets**. Our `AlternativeList W` is the
-extensional, list-based representation of question denotations used by
-the C-distributivity machinery (still Bool-shaped pending a follow-up
-migration of `Semantics.Attitudes.Distributivity` to substrate-aligned
-Set propositions).
-
-### Why This Matters for TSP
-
-[uegaki-sudo-2019] derive TSP from the interaction of:
-1. Degree semantics (μ(x,p) > θ) — from [villalta-2008]
-2. Alternative semantics (questions as Hamblin sets) — from [hamblin-1973b]
-3. Focus-induced presuppositions — from [rooth-1992]
-
-The key insight: **questions introduce alternatives**, and combining a degree
-predicate with alternatives triggers significance presuppositions.
-
-### The Derivation Chain
-
-```
-Hamblin alternative set Q = {p₁, p₂,...} [[hamblin-1973b]]
-        ↓
-Alternatives trigger focus semantics [[rooth-1992]]
-        ↓
-Focus triggers significance presup [[kennedy-2007]]
-        ↓
-For positive valence: significance = ∃p ∈ C. μ(x,p) > θ = TSP
-```
-
-### Rooth Integration
-
-The squiggle's two constraints (Γ ⊆ ⟦α⟧f, ⟦α⟧o ∈ Γ) live in
-`Semantics/Focus/Control.lean` (`SquiggleSet`, `Antecedent.Resolves`);
-deriving the significance presupposition from a degree predicate plus
-a resolved contrast set is an open TODO.
--/
-
-/--
-Key semantic operations are equivalent across representations.
-
-The existential quantification `∃p ∈ Q. φ(p)` that appears in:
-- C-distributivity: `V x Q C ↔ ∃p ∈ Q. V x p C`
-- TSP: `∃p ∈ C. μ(x,p) > θ(C)`
-
-works identically on List (via `List.any`) and Hamblin (via function application
-to the characteristic function of answers satisfying φ).
--/
-theorem exists_equiv_any {W : Type*} (Q : AlternativeList W) (φ : (W → Bool) → Bool) :
-    (∃ p ∈ Q, φ p = true) ↔ (Q.any φ = true) := by
-  simp only [List.any_eq_true]
-
-/--
-Subset relations are preserved.
-
-`Q ⊆ C` (all answers to Q are in comparison class C) is the same whether
-we use List containment or Hamblin entailment.
--/
-def questionSubset {W : Type*} (Q C : AlternativeList W) : Prop :=
-  ∀ p ∈ Q, p ∈ C
-
-/--
-The triviality condition uses subset + existential, both of which are
-representation-independent for finite cases.
--/
-theorem triviality_representation_independent {W : Type*}
-    (Q C : AlternativeList W) (φ : (W → Bool) → Bool)
-    (h_subset : questionSubset Q C)
-    (h_exists_Q : Q.any φ = true) :
-    C.any φ = true := by
-  simp only [List.any_eq_true] at *
-  obtain ⟨p, hp_in_Q, hp_holds⟩ := h_exists_Q
-  exact ⟨p, h_subset p hp_in_Q, hp_holds⟩
-
--- Significance Presuppositions ([kennedy-2007], [uegaki-sudo-2019])
-
-/-!
-## Deriving TSP from Degree Semantics
-
-### Background: Significance in Degree Constructions
-
-[kennedy-2007] observes that degree constructions carry **significance presuppositions**.
-The positive form of a gradable adjective presupposes the scale is "significant" in context:
-
-  "John is tall" presupposes height is relevant/significant
-
-### Application to Preferential Predicates
-
-[villalta-2008] shows preferential predicates ARE gradable predicates with degree semantics:
-
-  ⟦x hopes p⟧ = μ_hope(x, p) > θ(C)
-
-As degree constructions, they inherit significance presuppositions. But the CONTENT
-of "significance" differs by valence:
-
-### Positive Valence (hope, wish, expect)
-
-For predicates expressing desires/goals:
-- Significance = "there exists something the agent desires"
-- Presupposition: ∃p ∈ C. μ(x, p) > θ(C)
-- This IS the Threshold Significance Presupposition (TSP)
-
-### Negative Valence (fear, dread)
-
-For predicates expressing aversions/threats:
-- Significance = "there exists something the agent wants to avoid"
-- But this is NOT symmetric with TSP!
-- You can identify threats without presupposing a positive desire
-- The presupposition is about threat-identification, not desire-existence
-
-### Why the Asymmetry?
-
-The key insight ([uegaki-sudo-2019]): Positive predicates express **bouletic goals** — states
-the agent wants to achieve. Goals inherently presuppose there's something desirable.
-
-Negative predicates express **threats** — states to avoid. Threats don't require
-a symmetric positive goal. "I fear the worst" doesn't presuppose "I desire something."
-
-### Consequence for Anti-Rogativity
-
-Only TSP (positive significance) creates triviality with questions:
-- Assertion: ∃p ∈ Q. μ(x,p) > θ(C)
-- TSP: ∃p ∈ C. μ(x,p) > θ(C)
-- When Q ⊆ C: Assertion ⊆ TSP → trivial!
-
-Negative predicates lack TSP, so no triviality, so they CAN take questions.
-
--/
-
-/--
-Significance presupposition content varies by valence.
-
-This captures the insight that ALL degree predicates have significance
-presuppositions, but the content differs:
-- Positive: presupposes desired alternative exists (= TSP)
-- Negative: presupposes threat identified (weaker, different structure)
--/
-inductive SignificanceContent where
-  /-- Positive: ∃p ∈ C. μ(x,p) > θ — "something is desired" (= TSP) -/
-  | desiredExists
-  /-- Negative: threat identification — no symmetric existence presupposition -/
-  | threatIdentified
-  deriving DecidableEq, Repr
-
-/--
-Derive significance content from valence.
-
-This is the key derivation: TSP is not stipulated, it FOLLOWS from
-positive valence + degree semantics.
--/
-def significanceFromValence (valence : AttitudeValence) : SignificanceContent :=
-  match valence with
-  | .positive => .desiredExists    -- Bouletic goals → TSP
-  | .negative => .threatIdentified -- Threats → no TSP
-
-/--
-Does this significance content yield TSP?
-
-TSP = presupposition that ∃p ∈ C. μ(x,p) > θ(C).
-Only `desiredExists` has this form.
--/
-def SignificanceContent.yieldsTSP : SignificanceContent → Bool
-  | .desiredExists => true
-  | .threatIdentified => false
-
-/--
-TSP distribution DERIVED from valence via significance presuppositions.
-
-This theorem shows TSP is not stipulated — it follows from:
-1. Degree predicates have significance presuppositions (Kennedy)
-2. Significance content depends on valence (bouletic goals vs threats)
-3. Only positive valence yields TSP-type significance
--/
-def hasTSP (valence : AttitudeValence) : Bool :=
-  (significanceFromValence valence).yieldsTSP
-
-/-- Positive predicates have TSP. -/
-theorem positive_hasTSP : hasTSP .positive = true := rfl
-
-/-- Negative predicates lack TSP. -/
-theorem negative_lacks_TSP : hasTSP .negative = false := rfl
-
-/-- Check if TSP is satisfied for given parameters -/
-def tspSatisfied {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (agent : E) (C : AlternativeList W) : Bool :=
-  C.any λ p => μ agent p > θ C
-
-/--
-The significance presupposition for a degree predicate.
-
-For positive valence, this is exactly TSP.
-For negative valence, this is the weaker threat-identification condition.
--/
-def significancePresupSatisfied {W E : Type*}
-    (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (agent : E) (C : AlternativeList W) : Bool :=
-  match significanceFromValence valence with
-  | .desiredExists => tspSatisfied μ θ agent C  -- ∃p. μ(x,p) > θ
-  | .threatIdentified => true  -- Weaker: just requires threat context
-
--- Preferential Predicate Structure
-
-/--
-A preferential attitude predicate with explicit semantics.
-
-Each predicate defines:
-- `propSemantics`: ⟦x V p⟧(w, C)
-- `questionSemantics`: ⟦x V Q⟧(w, C)
-
-C-distributivity is then a PROVABLE property, not a stipulated field.
--/
+/-- A preferential attitude predicate: an evaluative valence, a
+    preference degree function, a contextual threshold, and
+    propositional and question semantics relative to a comparison
+    class of propositions. -/
 structure PreferentialPredicate (W E : Type*) where
-  /-- Name of the predicate -/
-  name : String
-  /-- Is the predicate veridical? (NVPs are non-veridical by definition) -/
-  veridical : Bool := false
-  /-- Evaluative valence (positive/negative) -/
+  /-- Evaluative valence (positive for *hope*, negative for *fear*). -/
   valence : AttitudeValence
-  /-- Preference function μ -/
-  μ : PreferenceFunction W E
-  /-- Threshold function θ -/
-  θ : ThresholdFunction W
-  /-- Propositional semantics: ⟦x V p⟧(C) -/
-  propSemantics : E → (W → Bool) → AlternativeList W → Bool
-  /-- Question semantics: ⟦x V Q⟧(C) -/
-  questionSemantics : E → AlternativeList W → AlternativeList W → Bool
+  /-- Preference degree function: `μ x p` is how strongly `x` prefers
+      (or, for negative valence, dreads) `p`. -/
+  μ : E → Finset W → ℚ
+  /-- Contextual threshold over a comparison class. -/
+  θ : List (Finset W) → ℚ
+  /-- ⟦x V p⟧(C), the propositional semantics. -/
+  propSemantics : E → Finset W → List (Finset W) → Prop
+  /-- ⟦x V Q⟧(C), the question semantics. -/
+  questionSemantics : E → List (Finset W) → List (Finset W) → Prop
 
-/-- Does the predicate have TSP? Derived from valence. -/
-def PreferentialPredicate.hasTSP {W E : Type*}
-    (V : PreferentialPredicate W E) : Bool :=
-  Preferential.hasTSP V.valence
+/-- A preferential predicate is clausally distributive when its
+    question semantics is the existential over its propositional
+    semantics — the world-free instance of
+    `Distributivity.IsDistributive` (preferential semantics are
+    world-independent because the predicates are non-veridical). -/
+def PreferentialPredicate.IsDistributive (V : PreferentialPredicate W E) : Prop :=
+  ∀ (x : E) (Q C : List (Finset W)),
+    V.questionSemantics x Q C ↔ ∃ p ∈ Q, V.propSemantics x p C
 
--- C-Distributivity: A Provable Property
+/-! ### Degree-comparison predicates -/
 
-/--
-C-distributivity is a PROPERTY of a predicate's semantics, not a field.
+/-- Degree-comparison predicate ([villalta-2008]): ⟦x V p⟧(C) =
+    μ(x, p) > θ(C), with the question semantics the pointwise
+    existential. -/
+def mkDegreeComparison (valence : AttitudeValence)
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
+    PreferentialPredicate W E where
+  valence := valence
+  μ := μ
+  θ := θ
+  propSemantics x p C := μ x p > θ C
+  questionSemantics x Q C := ∃ p ∈ Q, μ x p > θ C
 
-A predicate V is C-distributive iff:
-  ∀ x Q C, V.questionSemantics x Q C ↔ ∃p ∈ Q, V.propSemantics x p C
+/-- Degree-comparison predicates are clausally distributive by
+    construction: the question semantics is the existential over the
+    propositional semantics. -/
+theorem mkDegreeComparison_isDistributive (valence : AttitudeValence)
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
+    (mkDegreeComparison valence μ θ).IsDistributive :=
+  fun _ _ _ => Iff.rfl
 
-This must be PROVED for each predicate from its semantic definition.
--/
-def PreferentialPredicate.isCDistributive {W E : Type*}
-    (V : PreferentialPredicate W E) : Prop :=
-  ∀ (x : E) (Q C : AlternativeList W) (_w : W),
-    V.questionSemantics x Q C = true ↔
-    ∃ p ∈ Q, V.propSemantics x p C = true
-
-/-- Boolean version for computation -/
-def PreferentialPredicate.cDistributive {W E : Type*}
-    (V : PreferentialPredicate W E) (x : E) (Q C : AlternativeList W) : Bool :=
-  V.questionSemantics x Q C == Q.any (λ p => V.propSemantics x p C)
-
--- Degree-Comparison Predicates (hope, fear, expect, wish)
-
-/--
-Build a degree-comparison predicate.
-
-These have semantics:
-- ⟦x V p⟧(C) = μ(x, p) > θ(C)
-- ⟦x V Q⟧(C) = ∃p ∈ Q. μ(x, p) > θ(C)
-
-C-distributivity follows AUTOMATICALLY from this structure.
--/
-def mkDegreeComparisonPredicate {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
+/-- *hope*: degree comparison, positive valence. What distinguishes
+    *hope* from *want* is an additional doxastic component
+    ([anand-hacquard-2013]), formalized in
+    `Studies/AnandHacquard2013.lean`. -/
+def hope (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     PreferentialPredicate W E :=
-  { name := name
-  , veridical := false
-  , valence := valence
-  , μ := μ
-  , θ := θ
-  , propSemantics := λ x p C => decide (μ x p > θ C)
-  , questionSemantics := λ x Q C => Q.any λ p => decide (μ x p > θ C)
-  }
+  mkDegreeComparison .positive μ θ
 
-/--
-**Theorem**: Degree-comparison predicates are C-distributive.
-
-This is PROVED, not stipulated. The proof follows from the structure
-of the semantics: questionSemantics IS the existential over propSemantics.
--/
-theorem degreeComparisonPredicate_isCDistributive {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (mkDegreeComparisonPredicate name valence μ θ).isCDistributive := by
-  intro x Q C w
-  simp only [mkDegreeComparisonPredicate, List.any_eq_true]
-
--- Standard Predicates with C-Distributivity Proofs
-
-/-- Hope (preferential component): degree-comparison, positive valence.
-This captures the preference ordering from [villalta-2008] — the
-component shared by all emotive doxastic analyses. For the full emotive
-doxastic semantics with doxastic + uncertainty + preference components
-([anand-hacquard-2013]), see `hopeHybrid` below.
-
-Note: `hope` is structurally identical to `want` except for the name —
-both are positive-valence degree-comparison predicates. What distinguishes
-hope from want linguistically is the *additional* doxastic component
-(uncertainty condition, epistemic licensing) that `hopeHybrid` captures. -/
-def hope {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
+/-- *fear*: degree comparison, negative valence. -/
+def fear (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     PreferentialPredicate W E :=
-  mkDegreeComparisonPredicate "hope" .positive μ θ
+  mkDegreeComparison .negative μ θ
 
-/-- Hope is C-distributive (PROVED from its semantics) -/
-theorem hope_isCDistributive {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (hope μ θ).isCDistributive :=
-  degreeComparisonPredicate_isCDistributive "hope" .positive μ θ
-
-/-- Fear (preferential component): degree-comparison, negative valence.
-Captures the preference ordering only. For the full emotive doxastic
-semantics with uncertainty condition, see `fearHybrid` below. -/
-def fear {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
+/-- *expect*: degree comparison, positive valence. -/
+def expect (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     PreferentialPredicate W E :=
-  mkDegreeComparisonPredicate "fear" .negative μ θ
+  mkDegreeComparison .positive μ θ
 
-/-- Fear is C-distributive (PROVED from its semantics) -/
-theorem fear_isCDistributive {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (fear μ θ).isCDistributive :=
-  degreeComparisonPredicate_isCDistributive "fear" .negative μ θ
-
-/-- Expect: degree-comparison, positive valence -/
-def expect {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
+/-- *wish*: degree comparison, positive valence. -/
+def wish (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     PreferentialPredicate W E :=
-  mkDegreeComparisonPredicate "expect" .positive μ θ
+  mkDegreeComparison .positive μ θ
 
-/-- Expect is C-distributive -/
-theorem expect_isCDistributive {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (expect μ θ).isCDistributive :=
-  degreeComparisonPredicate_isCDistributive "expect" .positive μ θ
-
-/-- Wish: degree-comparison, positive valence -/
-def wish {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
+/-- *dread*: degree comparison, negative valence. -/
+def dread (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     PreferentialPredicate W E :=
-  mkDegreeComparisonPredicate "wish" .positive μ θ
-
-/-- Wish is C-distributive -/
-theorem wish_isCDistributive {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (wish μ θ).isCDistributive :=
-  degreeComparisonPredicate_isCDistributive "wish" .positive μ θ
-
-/-- Dread: degree-comparison, negative valence -/
-def dread {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  mkDegreeComparisonPredicate "dread" .negative μ θ
-
-/-- Dread is C-distributive -/
-theorem dread_isCDistributive {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (dread μ θ).isCDistributive :=
-  degreeComparisonPredicate_isCDistributive "dread" .negative μ θ
-
-/-- Hope and wish have identical preference semantics — they differ only
-in name. [anand-hacquard-2013]: what distinguishes hope from
-want/wish is the doxastic component (captured by `hopeHybrid`), not
-the preferential semantics. -/
-theorem hope_eq_wish_semantics {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    (hope μ θ).propSemantics = (wish μ θ).propSemantics ∧
-    (hope μ θ).questionSemantics = (wish μ θ).questionSemantics := by
-  constructor <;> rfl
-
--- Non-C-Distributive Predicates (worry, qidai)
-
-/--
-Worry has DIFFERENT question semantics involving global uncertainty.
-
-⟦x worries about Q⟧ ≠ ∃p ∈ Q. ⟦x worries about p⟧
-
-The question semantics involves uncertainty about WHICH answer is true,
-not just whether some answer satisfies the predicate.
--/
-def worry {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (isUncertain : E → AlternativeList W → Bool)  -- Epistemic uncertainty
-    : PreferentialPredicate W E :=
-  { name := "worry"
-  , veridical := false
-  , valence := .negative
-  , μ := μ
-  , θ := θ
-  -- Propositional: degree comparison (like fear)
-  , propSemantics := λ x p C => decide (μ x p > θ C)
-  -- Question: GLOBAL uncertainty, not existential over prop semantics
-  , questionSemantics := λ x Q C =>
-      isUncertain x Q && Q.any (λ p => decide (μ x p > θ C))
-  }
-
-/--
-Worry is NOT C-distributive when there's an uncertainty requirement.
-
-The question semantics requires global uncertainty, which is NOT
-reducible to existential quantification over propositional semantics.
--/
-theorem worry_not_cDistributive {W E : Type*} [Inhabited W]
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (isUncertain : E → AlternativeList W → Bool)
-    (x : E) (Q C : AlternativeList W)
-    (h_uncertain_false : isUncertain x Q = false)
-    (h_exists : ∃ p ∈ Q, decide (μ x p > θ C) = true) :
-    ¬(worry μ θ isUncertain).isCDistributive := by
-  intro h_cdist
-  -- questionSemantics x Q C = false (because isUncertain = false)
-  have h1 : (worry μ θ isUncertain).questionSemantics x Q C = false := by
-    simp only [worry, h_uncertain_false, Bool.false_and]
-  -- But if C-distributive, questionSemantics should ↔ ∃p ∈ Q. propSemantics
-  -- And propSemantics x p C = decide (μ x p > θ C), so h_exists gives us a witness
-  have h2 : ∃ p ∈ Q, (worry μ θ isUncertain).propSemantics x p C = true := by
-    simp only [worry]
-    exact h_exists
-  -- So by C-distributivity, questionSemantics should be true
-  have h3 := (h_cdist x Q C default).mpr h2
-  -- Contradiction: h1 says false, h3 says true
-  rw [h1] at h3
-  exact Bool.false_ne_true h3
-
-/--
-Mandarin "qidai" (look forward to): positive but non-C-distributive.
-
-Like worry, it involves anticipation of RESOLUTION, not just existential
-over individual propositions.
--/
-def qidai {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (anticipatesResolution : E → AlternativeList W → Bool)
-    : PreferentialPredicate W E :=
-  { name := "qidai"
-  , veridical := false
-  , valence := .positive
-  , μ := μ
-  , θ := θ
-  , propSemantics := λ x p C => decide (μ x p > θ C)
-  -- Question semantics involves resolution anticipation
-  , questionSemantics := λ x Q C =>
-      anticipatesResolution x Q && Q.any (λ p => decide (μ x p > θ C))
-  }
-
--- NVP Classification
-
-/--
-The three classes of Non-Veridical Preferential predicates.
--/
-inductive NVPClass where
-  | class1_nonCDist       -- Non-C-distributive: worry, qidai, tanosimi
-  | class2_cDist_negative -- C-distributive + negative: fear, dread
-  | class3_cDist_positive -- C-distributive + positive: hope, wish, expect
-  deriving DecidableEq, Repr
-
-/--
-Classify an NVP. Note: this now requires knowing whether the predicate
-is C-distributive, which must be PROVED separately.
--/
-def classifyNVP (cDistributive : Bool) (valence : AttitudeValence) : NVPClass :=
-  if !cDistributive then .class1_nonCDist
-  else if valence == .negative then .class2_cDist_negative
-  else .class3_cDist_positive
-
-/-- Can this NVP class take questions canonically? -/
-def NVPClass.canTakeQuestion : NVPClass → Bool
-  | .class1_nonCDist => true       -- No triviality
-  | .class2_cDist_negative => true -- No TSP, so no triviality
-  | .class3_cDist_positive => false -- Triviality
-
--- Triviality for Class 3
-
-/--
-Class 3 triviality for degree-comparison predicates specifically.
-
-Class 3 predicates (C-distributive + positive + TSP) yield trivial meanings
-when combined with questions. When Q ⊆ C:
-- Assertion: ∃p ∈ Q. μ(x,p) > θ(C)
-- Presupposition (TSP): ∃p ∈ C. μ(x,p) > θ(C)
-- Assertion ⊆ Presupposition → trivial!
-
-For predicates built with `mkDegreeComparisonPredicate`, we can prove
-that assertion implies presupposition when Q ⊆ C.
--/
-theorem degreeComparison_triviality {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W)
-    (h_subset : ∀ p, p ∈ Q → p ∈ C)
-    (h_assert : (mkDegreeComparisonPredicate name valence μ θ).questionSemantics x Q C = true) :
-    tspSatisfied μ θ x C = true := by
-  unfold mkDegreeComparisonPredicate at h_assert
-  unfold tspSatisfied
-  simp only [List.any_eq_true, decide_eq_true_eq] at *
-  obtain ⟨p, hp_in_Q, hp_holds⟩ := h_assert
-  exact ⟨p, h_subset p hp_in_Q, hp_holds⟩
-
-/-- Hope + question yields trivial meaning when Q ⊆ C -/
-theorem hope_triviality {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W)
-    (h_subset : ∀ p, p ∈ Q → p ∈ C)
-    (h_assert : (hope μ θ).questionSemantics x Q C = true) :
-    tspSatisfied μ θ x C = true :=
-  degreeComparison_triviality "hope" .positive μ θ x Q C h_subset h_assert
-
-/--
-**Reverse direction**: TSP → assertion when C ⊆ Q.
-
-This is the other half of the triviality argument from [uegaki-2022] §6.5.4:
-TSP says ∃p ∈ C. μ(x,p) > θ(C). When C ⊆ Q, this p is also in Q,
-so the assertion ∃p ∈ Q. μ(x,p) > θ(C) holds too.
--/
-theorem hope_triviality_reverse {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W)
-    (h_subset : ∀ p, p ∈ C → p ∈ Q)
-    (h_tsp : tspSatisfied μ θ x C = true) :
-    (hope μ θ).questionSemantics x Q C = true := by
-  unfold tspSatisfied at h_tsp
-  unfold hope mkDegreeComparisonPredicate
-  simp only [List.any_eq_true, decide_eq_true_eq] at *
-  obtain ⟨p, hp_in_C, hp_holds⟩ := h_tsp
-  exact ⟨p, h_subset p hp_in_C, hp_holds⟩
-
-/--
-**Triviality identity**: When C = Q, assertion ↔ TSP.
-
-This is the core of [uegaki-2022] §6.5.4: the assertion of a non-veridical
-preferential with an interrogative complement is **identical** to its
-presupposition (TSP). Whenever TSP is satisfied (defined), the assertion
-is true; whenever TSP fails, the assertion is false. The meaning is
-L-analytic — its truth value is determined entirely by the presupposition,
-leaving no informative content. This is what [gajewski-2002] identifies
-as the trigger for unacceptability.
--/
-theorem hope_triviality_identity {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q : AlternativeList W) :
-    (hope μ θ).questionSemantics x Q Q = tspSatisfied μ θ x Q := by
-  simp only [hope, mkDegreeComparisonPredicate, tspSatisfied]
-
--- Classification Verification
-
-/-- Hope is Class 3 (anti-rogative) -/
-example : classifyNVP true .positive = .class3_cDist_positive := rfl
-
-/-- Fear is Class 2 (takes questions) -/
-example : classifyNVP true .negative = .class2_cDist_negative := rfl
-
-/-- Worry is Class 1 (non-C-distributive, takes questions) -/
-example : classifyNVP false .negative = .class1_nonCDist := rfl
-
-/-- Qidai is Class 1 (positive but non-C-distributive, takes questions) -/
-example : classifyNVP false .positive = .class1_nonCDist := rfl
-
--- Veridical Preferential Predicates ([uegaki-sudo-2019])
-
-/-!
-## Veridical vs Non-Veridical Preferential Predicates
-
-[uegaki-sudo-2019] established a crucial distinction:
-
-### Non-Veridical (hope) - TRIVIAL
-```
-Presup (TSP): ∃p ∈ C. μ(x,p) > θ(C)
-Assertion: ∃p ∈ Q. μ(x,p) > θ(C)
-When Q ⊆ C: Assertion ⊆ TSP → TRIVIAL
-```
-
-### Veridical (be happy) - NOT TRIVIAL
-```
-Presup: ∃p ∈ Q. p(w) ∧ μ(x,p) > θ(C)
-Assertion: ∃p ∈ Q. p(w) ∧ μ(x,p) > θ(C)
-                       ^^^^
-                       TRUTH REQUIREMENT breaks triviality!
-```
-
-Even when Q ⊆ C, whether the assertion is true depends on WHICH answer p
-is TRUE in the actual world w. This is the key insight: veridicality
-breaks triviality because it adds a world-dependent constraint.
-
-### The Deep Theorem (formalized below as `veridical_breaks_triviality`)
-
-Triviality requires ALL THREE conditions:
-1. C-distributive
-2. Positive valence (TSP)
-3. **Non-veridical**
-
-If ANY condition fails, the predicate can embed questions:
-- Non-C-dist → Class 1 (takes questions)
-- Negative valence → Class 2 (no TSP, takes questions)
-- **Veridical → Responsive** (truth requirement breaks triviality)
-
-### Examples
-
-| Predicate | Veridical | C-Dist | Valence | TSP | Takes Q? | Why |
-|-----------|-----------|--------|---------|-----|----------|-----|
-| hope | ✗ | ✓ | + | ✓ | ✗ | C-dist + TSP → trivial |
-| fear | ✗ | ✓ | - | ✗ | ✓ | No TSP |
-| worry | ✗ | ✗ | - | ✗ | ✓ | Non-C-dist |
-| be happy | ✓ | ✓ | + | ✓ | ✓ | Veridical breaks triviality! |
-| be surprised | ✓ | ✓ | + | ✓ | ✓ | Veridical breaks triviality! |
--/
-
-/--
-Build a veridical preferential predicate.
-
-Unlike non-veridical predicates, veridical ones require the complement
-proposition to be TRUE in the actual world:
-
-⟦x is happy that p⟧(w, C) = p(w) ∧ μ(x, p) > θ(C)
-⟦x is happy about Q⟧(w, C) = ∃p ∈ Q. p(w) ∧ μ(x, p) > θ(C)
-
-The truth requirement p(w) is what breaks triviality: even if TSP holds
-(some proposition is preferred), the assertion may be false because
-the TRUE answer in w might not be the preferred one.
--/
-def mkVeridicalPreferential {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  { name := name
-  , veridical := true  -- Veridical (unlike non-veridical preferentials)
-  , valence := valence
-  , μ := μ
-  , θ := θ
-  -- Propositional: requires p(w) = true (veridical requirement)
-  -- Note: We return a function W → Bool to enable world-sensitivity
-  , propSemantics := λ x p C => decide (μ x p > θ C)
-  -- Question: ∃p ∈ Q. μ(x,p) > θ(C)
-  -- The world-sensitivity is handled at usage site via propSemanticsAt
-  , questionSemantics := λ x Q C => Q.any λ p => decide (μ x p > θ C)
-  }
-
-/--
-World-sensitive propositional semantics for veridical predicates.
-
-⟦x V p⟧(w, C) = p(w) ∧ μ(x, p) > θ(C)
-
-The truth requirement p(w) is what distinguishes veridical from non-veridical.
--/
-def PreferentialPredicate.propSemanticsAt {W E : Type*}
-    (V : PreferentialPredicate W E) (x : E) (p : (W → Bool)) (C : AlternativeList W) (w : W) : Bool :=
-  if V.veridical then
-    p w && V.propSemantics x p C
-  else
-    V.propSemantics x p C
-
-/--
-World-sensitive question semantics for veridical predicates.
-
-⟦x V Q⟧(w, C) = ∃p ∈ Q. p(w) ∧ μ(x, p) > θ(C)
-
-For veridical predicates, the assertion requires some TRUE answer to be preferred.
--/
-def PreferentialPredicate.questionSemanticsAt {W E : Type*}
-    (V : PreferentialPredicate W E) (x : E) (Q C : AlternativeList W) (w : W) : Bool :=
-  if V.veridical then
-    Q.any λ p => p w && V.propSemantics x p C
-  else
-    V.questionSemantics x Q C
-
-/--
-**World-independence contrast**: Non-veridical predicates have world-independent
-semantics (`questionSemanticsAt` ignores the world), while veridical predicates
-have world-dependent semantics. This is the structural basis for L-analyticity:
-for non-veridical predicates, assertion ⊆ presupposition holds at ALL worlds
-because the world variable doesn't appear.
--/
-theorem nonveridical_worldIndependent {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) (w₁ w₂ : W) :
-    (mkDegreeComparisonPredicate name valence μ θ).questionSemanticsAt x Q C w₁ =
-    (mkDegreeComparisonPredicate name valence μ θ).questionSemanticsAt x Q C w₂ := by
-  simp [PreferentialPredicate.questionSemanticsAt, mkDegreeComparisonPredicate]
-
--- Veridical Predicate Instances
-
-/-- "be happy": veridical, positive valence -/
-def beHappy {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  mkVeridicalPreferential "be happy" .positive μ θ
-
-/-- "be surprised": veridical, positive valence (expectation-violation).
-    Classified as positive following [uegaki-sudo-2019]: the degree
-    function measures how much the true answer exceeds the subject's
-    expectations, a positive-direction evaluation. -/
-def beSurprised {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  mkVeridicalPreferential "be surprised" .positive μ θ
-
-/-- "be glad": veridical, positive valence -/
-def beGlad {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  mkVeridicalPreferential "be glad" .positive μ θ
-
-/-- "be sad": veridical, negative valence -/
-def beSad {W E : Type*} (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    PreferentialPredicate W E :=
-  mkVeridicalPreferential "be sad" .negative μ θ
-
--- Veridical Breaks Triviality: The Core Theorem
-
-/--
-**Core Theorem**: Veridicality breaks triviality.
-
-Even when:
-- TSP holds (some proposition is preferred above threshold)
-- Q ⊆ C (question answers are in comparison class)
-
-The question assertion can still be FALSE for veridical predicates,
-because no TRUE answer in w may be the preferred one.
-
-This is the key insight from [uegaki-sudo-2019]: non-veridicality
-is a NECESSARY condition for the triviality that makes predicates
-anti-rogative.
-
-### Proof Strategy
-
-We show that under the specified conditions:
-1. TSP is satisfied (h_tsp)
-2. But for every answer p in Q, if p is true in w, it's not preferred (h_no_true_preferred)
-3. Therefore the question assertion is false
-
-This proves that TSP satisfaction does NOT guarantee assertion truth
-for veridical predicates — the triviality derivation fails!
--/
-theorem veridical_breaks_triviality {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) (w : W)
-    (_h_subset : ∀ p, p ∈ Q → p ∈ C)
-    (_h_tsp : tspSatisfied μ θ x C = true)
-    (h_no_true_preferred : ∀ p ∈ Q, p w = true → decide (μ x p > θ C) = false) :
-    -- Even with TSP satisfied, the question assertion can be FALSE
-    (mkVeridicalPreferential name valence μ θ).questionSemanticsAt x Q C w = false := by
-  unfold PreferentialPredicate.questionSemanticsAt mkVeridicalPreferential
-  simp only [↓reduceIte]
-  rw [List.any_eq_false]
-  intro p hp
-  simp only [Bool.and_eq_true, not_and, decide_eq_true_eq]
-  intro hp_true
-  have := h_no_true_preferred p hp hp_true
-  simp only [decide_eq_false_iff_not] at this
-  exact this
-
-/--
-**Contrast Theorem**: Non-veridical predicates ARE trivial.
-
-When TSP holds and Q ⊆ C, the assertion is ALWAYS true for non-veridical
-C-distributive predicates. This is the triviality that makes them anti-rogative.
-
-Combined with `veridical_breaks_triviality`, this shows the asymmetry:
-- Non-veridical + C-dist + positive → trivial → anti-rogative
-- Veridical + C-dist + positive → NOT trivial → responsive
--/
-theorem nonveridical_is_trivial {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W)
-    (h_subset : ∀ p, p ∈ Q → p ∈ C)
-    (h_assert : (hope μ θ).questionSemantics x Q C = true) :
-    tspSatisfied μ θ x C = true :=
-  hope_triviality μ θ x Q C h_subset h_assert
-
--- C-Distributivity for Veridical Predicates
-
-/--
-Veridical predicates ARE C-distributive (at a given world).
-
-The world-sensitive semantics preserves the existential structure:
-⟦x V Q⟧(w, C) = ∃p ∈ Q. ⟦x V p⟧(w, C)
-
-Note: This is C-distributivity for the world-sensitive semantics,
-which is the relevant notion for veridical predicates.
--/
-theorem veridicalPreferential_isCDistributiveAt {W E : Type*}
-    (name : String) (valence : AttitudeValence)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) (w : W) :
-    (mkVeridicalPreferential name valence μ θ).questionSemanticsAt x Q C w = true ↔
-    ∃ p ∈ Q, (mkVeridicalPreferential name valence μ θ).propSemanticsAt x p C w = true := by
-  simp only [PreferentialPredicate.questionSemanticsAt, PreferentialPredicate.propSemanticsAt,
-             mkVeridicalPreferential, ↓reduceIte, List.any_eq_true]
-
-/-- beHappy is C-distributive (at a given world) -/
-theorem beHappy_isCDistributiveAt {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) (w : W) :
-    (beHappy μ θ).questionSemanticsAt x Q C w = true ↔
-    ∃ p ∈ Q, (beHappy μ θ).propSemanticsAt x p C w = true :=
-  veridicalPreferential_isCDistributiveAt "be happy" .positive μ θ x Q C w
-
-/-- beSurprised is C-distributive (at a given world) -/
-theorem beSurprised_isCDistributiveAt {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) (w : W) :
-    (beSurprised μ θ).questionSemanticsAt x Q C w = true ↔
-    ∃ p ∈ Q, (beSurprised μ θ).propSemanticsAt x p C w = true :=
-  veridicalPreferential_isCDistributiveAt "be surprised" .positive μ θ x Q C w
-
--- The Complete Picture: Why Veridicality Matters
-
-/-!
-## The Triviality Conditions ([uegaki-sudo-2019])
-
-For a preferential predicate to be anti-rogative (unable to embed questions),
-ALL THREE conditions must hold:
-
-1. **C-distributive**: ⟦x V Q⟧ ↔ ∃p ∈ Q. ⟦x V p⟧
-2. **Positive valence**: Predicate has TSP (threshold significance presupposition)
-3. **Non-veridical**: Truth of complement is NOT required
-
-### Why Each Condition is Necessary
-
-**If not C-distributive** (worry, qidai):
-- Question semantics has additional structure (uncertainty, anticipation)
-- Assertion ≠ ∃p ∈ Q. propSemantics, so triviality derivation fails
-- Predicate CAN take questions (Class 1)
-
-**If negative valence** (fear, dread):
-- No TSP (threat-identification ≠ desire-existence)
-- Assertion not entailed by any presupposition
-- Predicate CAN take questions (Class 2)
-
-**If veridical** (be happy, be surprised):
-- Assertion: ∃p ∈ Q. p(w) ∧ μ(x,p) > θ(C)
-- TSP: ∃p ∈ C. μ(x,p) > θ(C)
-- TSP does NOT entail assertion (wrong p might be true in w)
-- Predicate CAN take questions (Responsive)
-
-### The Formalized Results
-
-- `hope_triviality` / `nonveridical_is_trivial`: Non-veridical predicates
-  with C-dist and positive valence yield trivial meanings (assertion ⊆ TSP)
-
-- `veridical_breaks_triviality`: Even with TSP satisfied, veridical
-  predicates can have false assertions (truth requirement adds constraint)
-
-Together, these theorems prove that non-veridicality is NECESSARY for
-the triviality derivation that creates anti-rogativity.
--/
-
--- Summary
-
-/-!
-## Main Results
-
-### Proved Theorems (no axioms!):
-
-1. `degreeComparisonPredicate_isCDistributive`: Any predicate built with
-   `mkDegreeComparisonPredicate` is C-distributive. This follows from the
-   semantic structure: questionSemantics = ∃p ∈ Q. propSemantics.
-
-2. `hope_isCDistributive`, `fear_isCDistributive`, `expect_isCDistributive`,
-   `wish_isCDistributive`, `dread_isCDistributive`: C-distributivity for
-   standard degree-comparison predicates (derived from #1).
-
-3. `worry_not_cDistributive`: Worry with uncertainty requirement is NOT
-   C-distributive. Proved by contradiction: global uncertainty breaks
-   the equivalence.
-
-4. `degreeComparison_triviality` / `hope_triviality`: Class 3 predicates
-   yield trivial meanings with questions (assertion ⊆ presupposition when Q ⊆ C).
-
-5. **`veridical_breaks_triviality`** (NEW): The core [uegaki-sudo-2019] insight —
-   veridical predicates break triviality because even when TSP holds, the
-   assertion can be false (no TRUE answer is preferred).
-
-6. `veridicalPreferential_isCDistributiveAt`: Veridical predicates preserve
-   C-distributivity for their world-sensitive semantics.
-
-### Architecture:
-
-- C-distributivity is a PROVABLE PROPERTY, not a stipulated field
-- Each predicate DEFINES its propositional and question semantics
-- Veridical predicates use world-sensitive semantics (`propSemanticsAt`, `questionSemanticsAt`)
-- The classification follows from proved properties
-
-This gives genuine explanatory force: "hope" is anti-rogative BECAUSE
-its degree-comparison semantics makes it C-distributive, and combined
-with positive valence (TSP) and non-veridicality, this yields triviality.
-
-"Be happy" takes questions DESPITE being C-distributive and positive BECAUSE
-it is veridical — the truth requirement breaks the triviality derivation.
--/
-
--- ============================================================================
--- Highlighting ([uegaki-2022] Ch 6 §6.6, [pruitt-roelofsen-2011])
--- ============================================================================
-
-/-!
-## Highlighted Propositions and hope-whether
-
-[uegaki-2022] Ch 6 addresses apparent counterexamples to the anti-rogativity
-of positive NVPs: attested "hope whether" constructions ([white-2021]).
-
-The solution uses **highlighting** ([pruitt-roelofsen-2011]): clauses have both
-an ordinary semantic value and a **highlighted value** — a subset of propositions
-with privileged status.
-
-### Key Insight
-
-- Polar interrogatives (`whether p`): highlighted value = `{p}` (singleton)
-- Constituent interrogatives (`who left`): highlighted value = ordinary value
-- Declaratives (`that p`): highlighted value = `{p}` (singleton)
-
-When `hope` is sensitive to the highlighted value rather than the ordinary
-semantic value, `hope whether p` reduces to `hope that p` — no triviality!
-The anti-rogativity prediction is preserved for constituent interrogatives
-(highlighted value = full question = trivial) while allowing polar ones.
--/
-
-/-- Clause types relevant to highlighting. -/
-inductive HighlightingClauseType where
-  | declarative         -- "that p"
-  | polarInterrogative  -- "whether/if p"
-  | constituentInterrog -- "who/what/which..."
-  deriving DecidableEq, Repr
-
-/--
-Highlighted propositions of a clause ([pruitt-roelofsen-2011]).
-
-- Polar interrogatives highlight the overtly-realized proposition (singleton)
-- Declaratives highlight the asserted proposition (singleton)
-- Constituent interrogatives highlight all alternatives (= ordinary value)
-
-The key asymmetry: polar and declarative both yield singletons,
-while constituent interrogatives yield the full question.
--/
-def highlightedValue {W : Type*} (ct : HighlightingClauseType) (Q : AlternativeList W) :
-    AlternativeList W :=
-  match ct with
-  | .declarative => Q.take 1
-  | .polarInterrogative => Q.take 1
-  | .constituentInterrog => Q
-
-/--
-Highlighting-sensitive version of hope's denotation.
-
-The Dayal-answer preferred by the subject is restricted to be a
-**highlighted** proposition of the complement φ, rather than a member
-of the ordinary semantic value.
-
-⟦hope_C φ⟧ = λx: ∃w'[AnsD_w'(⟦φ⟧_H) ∈ C] .
-              ∃d ∈ { Pref_w(x,p) | p ∈ C } [d > θ(C)] .
-              ∃w''[ AnsD_w''(Q) ∈ ⟦φ⟧_H ∧ Pref_w(x, AnsD_w''(Q)) > θ(C) ]
--/
-def hopeHighlightSemantics {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (ct : HighlightingClauseType) (x : E) (Q C : AlternativeList W) : Bool :=
-  let highlighted := highlightedValue ct Q
-  highlighted.any fun p => decide (μ x p > θ C)
-
-/--
-With a declarative complement, highlighting changes nothing:
-the highlighted value is {p}, and hopeSemanticsHighlight reduces to
-whether μ(x, p) > θ(C). Same as standard hope.
--/
-theorem hope_highlight_declarative_equiv {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (p : (W → Bool)) (C : AlternativeList W) :
-    hopeHighlightSemantics μ θ .declarative x [p] C =
-    decide (μ x p > θ C) := by
-  simp [hopeHighlightSemantics, highlightedValue]
-
-/--
-With a polar interrogative "whether p", highlighting reduces to the
-singleton {p}. So "hope whether p" ≈ "hope that p" — NOT trivial.
--/
-theorem hope_highlight_polar_equiv {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (p : (W → Bool)) (neg_p : (W → Bool)) (C : AlternativeList W) :
-    hopeHighlightSemantics μ θ .polarInterrogative x [p, neg_p] C =
-    decide (μ x p > θ C) := by
-  simp [hopeHighlightSemantics, highlightedValue]
-
-/--
-With a constituent interrogative "who V", all alternatives are highlighted.
-This is identical to the standard (non-highlighting) semantics —
-still trivial when combined with TSP and Q ⊆ C.
--/
-theorem hope_highlight_constituent_equiv {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W) :
-    hopeHighlightSemantics μ θ .constituentInterrog x Q C =
-    Q.any (fun p => decide (μ x p > θ C)) := by
-  simp [hopeHighlightSemantics, highlightedValue]
-
-/--
-Constituent interrogatives with TSP are still trivial under highlighting.
-This preserves the anti-rogativity prediction for "*hope who left".
--/
-theorem hope_highlight_constituent_trivial {W E : Type*}
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W)
-    (x : E) (Q C : AlternativeList W)
-    (h_subset : ∀ p, p ∈ Q → p ∈ C)
-    (h_assert : hopeHighlightSemantics μ θ .constituentInterrog x Q C = true) :
-    tspSatisfied μ θ x C = true := by
-  rw [hope_highlight_constituent_equiv] at h_assert
-  unfold tspSatisfied
-  simp only [List.any_eq_true, decide_eq_true_eq] at *
-  obtain ⟨p, hp_in_Q, hp_holds⟩ := h_assert
-  exact ⟨p, h_subset p hp_in_Q, hp_holds⟩
-
--- ════════════════════════════════════════════════════════════════
--- § Emotive Doxastic Predicates (hope, fear as hybrids)
--- [anand-hacquard-2013] [scheffler-2008]
--- ════════════════════════════════════════════════════════════════
-
-/-!
-## Emotive Doxastics: Hybrid Representational + Preferential
-
-[anand-hacquard-2013] show that `hope` and `fear` are not pure
-preferential predicates (like `want`). They have three components:
-
-1. **Doxastic assertion**: the attitude holder believes φ is *possible*
-   (∃w' ∈ DOX: φ(w') = 1)
-2. **Preference assertion**: φ-verifiers are preferred to φ-falsifiers
-3. **Uncertainty condition**: the attitude holder is *uncertain* about φ
-   (both φ-verifiers and φ-falsifiers exist in DOX)
-
-The doxastic component is what licenses embedded epistemic *possibility*
-modals. The uncertainty condition is what blocks epistemic *necessity*:
-necessity entails certainty, contradicting the uncertainty requirement.
-
-This hybrid structure distinguishes `hope` from `want`:
-- `want` is pure preferential — no doxastic component, no epistemic licensing
-- `hope` has a doxastic component — licenses `might` but not `must`
-
-### Evidence for the doxastic component ([scheffler-2008])
-
-`hope` can felicitously answer questions (providing doxastic information):
-  A: "Is Peter coming today?"
-  B: "I hope/\*want that he is coming today."
-
-`hope` is infelicitous with certainty about the complement:
-  "It is raining. #I hope it is raining." (vs. ✓"I want it to be raining.")
-
-### Verifiers and Falsifiers
-
-[anand-hacquard-2013] define φ-verifiers in information state S as
-subsets of S that are *certain* about φ — where φ's truth value doesn't
-change with (monotonically) increasing information:
-
-  φ-verifiers in S = {S' ⊂ S | ∀S'' ⊂ S': ∀w' ∈ S'': ⟦φ⟧(w') = 1}
-
-For unmodalized φ, this simplifies to pow(S ∩ φ).
-For modalized φ (might p, must p), verifiers are still pow(S ∩ p) —
-modalized complements raise the same issue as unmodalized ones.
--/
-
-open Doxastic (DiamondAt BoxAt)
-
-/-- An emotive doxastic predicate: hybrid representational + preferential.
-
-Combines a doxastic accessibility relation (from `Doxastic.lean`)
-with a preference function (from `Preferential`). The accessibility
-relation provides the information state that epistemics quantify over;
-the preference function orders verifiers against falsifiers. -/
-structure EmotiveDoxasticPredicate (W E : Type*) where
-  /-- Name of the predicate -/
-  name : String
-  /-- Doxastic accessibility relation: DOX(x, w) -/
-  access : E → W → W → Prop
-  /-- Preference function: μ(x, p) → degree -/
-  μ : PreferenceFunction W E
-  /-- Threshold function: θ(C) → degree -/
-  θ : ThresholdFunction W
-  /-- Evaluative valence (positive for hope, negative for fear) -/
-  valence : AttitudeValence
-
-/-- The doxastic assertion: ∃w' ∈ DOX(x,w) such that φ(w').
-
-This is the component that licenses embedded epistemic possibility modals.
-When the complement is `might p`, the doxastic assertion reduces to
-`DOX ∩ p ≠ ∅` by vacuous quantification — identical to the unmodalized
-case. -/
-def EmotiveDoxasticPredicate.doxasticAssertion {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W) : Prop :=
-  DiamondAt V.access agent w worlds p
-
-/-- The uncertainty condition: both φ-verifiers and φ-falsifiers exist
-in DOX. The attitude holder is genuinely uncertain about φ.
-
-This is what blocks epistemic necessity: `must p` under `hope` would
-require ∀w' ∈ DOX: p(w'), which combined with the uncertainty condition
-(∃w' ∈ DOX: ¬p(w')) yields a contradiction. -/
-def EmotiveDoxasticPredicate.uncertaintyCondition {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W) : Prop :=
-  -- ∃w' ∈ DOX: p(w') — verifiers exist
-  DiamondAt V.access agent w worlds p ∧
-  -- ∃w' ∈ DOX: ¬p(w') — falsifiers exist
-  DiamondAt V.access agent w worlds (fun w' => ¬ p w')
-
-/-- The preference assertion: φ-verifying doxastic alternatives are
-preferred to φ-falsifying ones.
-
-For positive valence (hope): μ(x, p) > θ(C) — the agent prefers p.
-For negative valence (fear): μ(x, p) > θ(C) — where μ measures dispreference. -/
-def EmotiveDoxasticPredicate.preferenceAssertion {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop) [DecidablePred p]
-    (C : AlternativeList W) : Prop :=
-  V.μ agent (fun w => decide (p w)) > V.θ C
-
-/-- Full semantics for an emotive doxastic: all three components must hold.
-
-⟦a hopes_C that φ⟧ is defined iff:
-  (i)   φ-verifiers in S' ≠ ∅ ∧ φ-falsifiers in S' ≠ ∅    (uncertainty)
-  (ii)  ∃w' ∈ S': ⟦φ⟧(w') = 1                              (doxastic)
-  (iii) φ-verifiers >_DES φ-falsifiers                       (preference)
-
-where S' = DOX(a, w).
-
-Note: condition (ii) is entailed by the first conjunct of (i), so it is
-redundant in the conjunction. We include it explicitly for clarity and
-because it is the component responsible for epistemic licensing — it
-provides the information state that embedded epistemics are anaphoric to. -/
-def EmotiveDoxasticPredicate.HoldsAt {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop) [DecidablePred p]
-    (w : W) (worlds : List W) (C : AlternativeList W) : Prop :=
-  V.uncertaintyCondition agent p w worlds ∧
-  V.doxasticAssertion agent p w worlds ∧
-  V.preferenceAssertion agent p C
-
-/-- Hope: emotive doxastic with positive valence. -/
-def hopeHybrid {W E : Type*} (R : E → W → W → Prop)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    EmotiveDoxasticPredicate W E :=
-  { name := "hope", access := R, μ := μ, θ := θ, valence := .positive }
-
-/-- Fear: emotive doxastic with negative valence. -/
-def fearHybrid {W E : Type*} (R : E → W → W → Prop)
-    (μ : PreferenceFunction W E) (θ : ThresholdFunction W) :
-    EmotiveDoxasticPredicate W E :=
-  { name := "fear", access := R, μ := μ, θ := θ, valence := .negative }
-
--- ════════════════════════════════════════════════════════════════
--- § Epistemic Embedding Theorems
--- ════════════════════════════════════════════════════════════════
-
-/-- Under emotive doxastics, `might p` contributes the same doxastic
-assertion as bare `p` — modal concord.
-
-When the complement is `might p`, the doxastic assertion becomes:
-  ∃w' ∈ DOX: (∃w'' ∈ DOX: p(w''))
-By vacuous quantification over the shared information state, this
-reduces to: ∃w'' ∈ DOX: p(w'').
-Both yield: DOX ∩ p ≠ ∅.
-
-We model this by showing that the doxastic assertion for `p` and for
-the function `λ w. DiamondAt R x w worlds p` (= "might p" evaluated at
-the same DOX) are equivalent when the information state is shared. -/
-theorem doxastic_assertion_might_concord {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W)
-    (h : V.doxasticAssertion agent p w worlds) :
-    V.doxasticAssertion agent
-      (fun _ => DiamondAt V.access agent w worlds p) w worlds := by
-  simp only [EmotiveDoxasticPredicate.doxasticAssertion, DiamondAt] at *
-  obtain ⟨w', hw'_in, hw'_acc, hw'_p⟩ := h
-  exact ⟨w', hw'_in, hw'_acc, ⟨w', hw'_in, hw'_acc, hw'_p⟩⟩
-
-/-- Under emotive doxastics, `must p` contradicts the uncertainty
-condition. If ∀w' ∈ DOX: p(w'), then there are no falsifiers in DOX,
-violating the uncertainty condition's requirement that
-∃w' ∈ DOX: ¬p(w'). -/
-theorem must_contradicts_uncertainty {W E : Type*}
-    (V : EmotiveDoxasticPredicate W E) (agent : E) (p : W → Prop)
-    (w : W) (worlds : List W)
-    (h_must : BoxAt V.access agent w worlds p) :
-    ¬ V.uncertaintyCondition agent p w worlds := by
-  simp only [EmotiveDoxasticPredicate.uncertaintyCondition, DiamondAt, BoxAt] at *
-  rintro ⟨_, ⟨w', hw'_in, hw'_acc, hw'_np⟩⟩
-  exact hw'_np (h_must w' hw'_in hw'_acc)
-
-end Semantics.Attitudes.Preferential
+  mkDegreeComparison .negative μ θ
+
+/-! ### Non-distributive preferentials -/
+
+/-- *worry*: propositionally a degree comparison, but the question
+    semantics adds a global uncertainty condition on the question —
+    not reducible to the existential over answers
+    ([qing-uegaki-2025] §3.1.2). -/
+def worry (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (Uncertain : E → List (Finset W) → Prop) :
+    PreferentialPredicate W E where
+  valence := .negative
+  μ := μ
+  θ := θ
+  propSemantics x p C := μ x p > θ C
+  questionSemantics x Q C := Uncertain x Q ∧ ∃ p ∈ Q, μ x p > θ C
+
+/-- Mandarin *qidai* "look forward to": positive valence, with an
+    anticipation-of-resolution condition on the question — a positive
+    non-distributive preferential ([qing-uegaki-2025] §3.1.1). -/
+def qidai (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (AnticipatesResolution : E → List (Finset W) → Prop) :
+    PreferentialPredicate W E where
+  valence := .positive
+  μ := μ
+  θ := θ
+  propSemantics x p C := μ x p > θ C
+  questionSemantics x Q C := AnticipatesResolution x Q ∧ ∃ p ∈ Q, μ x p > θ C
+
+/-- *worry* is not clausally distributive: when the agent is not
+    uncertain about `Q` but some answer clears the threshold, the
+    existential over the propositional semantics holds while the
+    question semantics fails. -/
+theorem worry_not_distributive (μ : E → Finset W → ℚ)
+    (θ : List (Finset W) → ℚ) (Uncertain : E → List (Finset W) → Prop)
+    (x : E) (Q C : List (Finset W)) (hu : ¬ Uncertain x Q)
+    (h : ∃ p ∈ Q, μ x p > θ C) :
+    ¬ (worry μ θ Uncertain).IsDistributive :=
+  fun hdist => hu (((hdist x Q C).mpr h).1)
+
+/-! ### Threshold significance -/
+
+/-- The Threshold Significance Presupposition ([uegaki-sudo-2019]):
+    some member of the comparison class clears the threshold. Degree
+    constructions presuppose it generally; positive preferentials
+    trigger it while negative ones do not ([qing-uegaki-2025] §3.2),
+    which is how *fear*-type predicates escape the anti-rogativity
+    triviality derived in `Studies/UegakiSudo2019.lean`. -/
+def ThresholdSignificance (μ : E → Finset W → ℚ)
+    (θ : List (Finset W) → ℚ) (x : E) (C : List (Finset W)) : Prop :=
+  ∃ p ∈ C, μ x p > θ C
+
+end Preferential

--- a/Linglib/Semantics/Attitudes/Representationality.lean
+++ b/Linglib/Semantics/Attitudes/Representationality.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Attitudes.Doxastic
-import Linglib.Semantics.Attitudes.Preferential
 import Linglib.Semantics.Mood.Defs
 
 /-!

--- a/Linglib/Semantics/Questions/Highlighting.lean
+++ b/Linglib/Semantics/Questions/Highlighting.lean
@@ -37,8 +37,6 @@ This substrate landed alongside [martinez-vera-2026]'s formalisation;
 existing files that use highlighting-shaped notions but have not yet been
 migrated:
 
-* `Semantics/Attitudes/Preferential.lean` — `HighlightingClauseType`
-  + `highlightedValue` for Pruitt-Roelofsen 2011 / Uegaki 2022 hope-whether.
 * `Studies/FarkasRoelofsen2017.lean` — paper-side
   highlighted-alternative prose; F&R 2015 is the substrate's own anchor.
 * `Semantics/Questions/Singleton.lean` — `IsSingleton` documents itself in

--- a/Linglib/Studies/AnandHacquard2013.lean
+++ b/Linglib/Studies/AnandHacquard2013.lean
@@ -57,7 +57,7 @@ computed from BToM marginals.
 namespace AnandHacquard2013
 
 open Semantics.Attitudes.Representationality
-open Semantics.Attitudes.Preferential
+open Preferential
 open Doxastic
 
 -- ════════════════════════════════════════════════════════════════
@@ -156,7 +156,7 @@ For representational attitudes: S' = DOX(x,w) (non-trivial)
 For non-representational attitudes: S' = ∅ (trivial → tautology/contradiction)
 -/
 
-variable {W : Type*} [DecidableEq W]
+variable {W : Type*}
 
 /-- Information state: a set of worlds (represented as a list). -/
 abbrev InfoState (W : Type*) := List W
@@ -183,7 +183,7 @@ instance {S : InfoState W} {φ : W → Prop} [DecidablePred φ] :
     epistemics presuppose their modal base is non-trivial. -/
 def nonTrivial (S : InfoState W) : Prop := S ≠ []
 
-instance {S : InfoState W} : Decidable (nonTrivial S) := by
+instance [DecidableEq W] {S : InfoState W} : Decidable (nonTrivial S) := by
   unfold nonTrivial; infer_instance
 
 /-- Epistemic possibility is defined (non-trivial) whenever S ≠ ∅. -/
@@ -263,6 +263,61 @@ theorem want_must_trivial (p : W → Prop) :
 theorem want_might_trivial (p : W → Prop) :
     ¬ mightS (nonRepresentationalS : InfoState W) p := by
   simp [mightS, nonRepresentationalS]
+
+/-! ### The emotive doxastic lexical entry (56)
+
+⟦a hopes_C that p⟧: *defined* iff both p-verifiers and p-falsifiers
+exist among the doxastic alternatives (the uncertainty condition);
+where defined, *true* iff some doxastic alternative verifies p (the
+doxastic assertion) and the p-verifiers are preferred to the
+p-falsifiers above the contextual threshold (the preference
+assertion). φ-verifiers in S are the subsets of S certain about φ —
+for unmodalized p, pow(S ∩ p) — so verifier/falsifier non-emptiness
+is `mightS S p ∧ mightS S ¬p`. The doxastic component is what lets
+*hope* answer a question ([scheffler-2008]'s dialogue, attributed to
+Truckenbrodt: "Kommt Peter heute?" — "Ich hoffe/*will, dass er heute
+kommt") and distinguishes *hope* from pure-preferential *want*. -/
+
+open Semantics.Presupposition (PartialProp) in
+/-- The (56) entry over the study's information-state semantics:
+    presupposition = uncertainty, assertion = doxastic possibility
+    plus preference. The doxastic conjunct is entailed by the first
+    presupposition conjunct; the paper states it separately as the
+    component embedded epistemics are anaphoric to. -/
+def hopeAt {E : Type*} (R : E → W → W → Prop) [∀ a w w', Decidable (R a w w')]
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (agent : E) (p : Finset W) (w : W) (worlds : List W)
+    (C : List (Finset W)) : PartialProp W where
+  presup _ := mightS (representationalS R agent w worlds) (· ∈ p) ∧
+              mightS (representationalS R agent w worlds) (· ∉ p)
+  assertion _ := mightS (representationalS R agent w worlds) (· ∈ p) ∧
+                 μ agent p > θ C
+
+/-- Embedded *must p* contradicts the uncertainty presupposition
+    ((48) against (47c)): if p holds throughout the doxastic state,
+    there are no falsifiers — epistemic necessity is blocked under
+    *hope* and *fear*. -/
+theorem must_contradicts_uncertainty {E : Type*} (R : E → W → W → Prop)
+    [∀ a w w', Decidable (R a w w')]
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (agent : E) (p : Finset W) (w : W) (worlds : List W)
+    (C : List (Finset W))
+    (h_must : mustS (representationalS R agent w worlds) (· ∈ p)) :
+    ¬ (hopeAt R μ θ agent p w worlds C).presup w := by
+  rintro ⟨-, w', hw', hnp⟩
+  exact hnp (h_must w' hw')
+
+/-- Embedded *might p* contributes the same doxastic content as bare
+    p ((58), modal concord): a modalized complement is settled by the
+    shared information state, so its verifiers are the p-verifiers —
+    epistemic possibility is licensed. -/
+theorem might_concord {E : Type*} (R : E → W → W → Prop)
+    [∀ a w w', Decidable (R a w w')]
+    (agent : E) (p : W → Prop) (w : W) (worlds : List W)
+    (h : mightS (representationalS R agent w worlds) p) :
+    mightS (representationalS R agent w worlds)
+      (fun _ => mightS (representationalS R agent w worlds) p) :=
+  let ⟨w', hw', _⟩ := h; ⟨w', hw', h⟩
 
 -- ════════════════════════════════════════════════════════════════
 -- § 6. Emotive Doxastic Finite Model

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -69,8 +69,8 @@ EN triggers obey one of four semantic licensing conditions:
 
 namespace JinKoenig2021
 
-open Semantics.Attitudes.Preferential (AttitudeValence PreferentialPredicate NVPClass
-                                        classifyNVP fear dread worry)
+open Features (AttitudeValence)
+open Preferential (fear dread worry)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Typological Survey Data (Tables 1–4)
@@ -625,23 +625,20 @@ def negativeValenceEntailsDual (v : AttitudeValence) : Bool :=
 
 /-- Fear has negative valence → satisfies the dual-inference condition. -/
 theorem fear_has_dual_inference {W E : Type*}
-    (μ : Semantics.Attitudes.Preferential.PreferenceFunction W E)
-    (θ : Semantics.Attitudes.Preferential.ThresholdFunction W) :
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     negativeValenceEntailsDual (fear μ θ).valence = true := rfl
 
 /-- Dread has negative valence → satisfies the dual-inference condition. -/
 theorem dread_has_dual_inference {W E : Type*}
-    (μ : Semantics.Attitudes.Preferential.PreferenceFunction W E)
-    (θ : Semantics.Attitudes.Preferential.ThresholdFunction W) :
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
     negativeValenceEntailsDual (dread μ θ).valence = true := rfl
 
 /-- Worry has negative valence → satisfies the dual-inference condition.
-    (Non-C-distributive, but still negative valence.) -/
+    (Not clausally distributive, but still negative valence.) -/
 theorem worry_has_dual_inference {W E : Type*}
-    (μ : Semantics.Attitudes.Preferential.PreferenceFunction W E)
-    (θ : Semantics.Attitudes.Preferential.ThresholdFunction W)
-    (isUncertain : E → Semantics.Attitudes.Preferential.AlternativeList W → Bool) :
-    negativeValenceEntailsDual (worry μ θ isUncertain).valence = true := rfl
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (Uncertain : E → List (Finset W) → Prop) :
+    negativeValenceEntailsDual (worry μ θ Uncertain).valence = true := rfl
 
 /-- Hope has positive valence → does NOT satisfy the dual-inference
     condition → NOT an EN trigger. While 'hope' has been reported as a
@@ -649,14 +646,13 @@ theorem worry_has_dual_inference {W E : Type*}
     exx. 5–6), JK2021 exclude these based on their definition (2): the
     complement negation reflects epistemic uncertainty, not EN. -/
 theorem hope_no_dual_inference {W E : Type*}
-    (μ : Semantics.Attitudes.Preferential.PreferenceFunction W E)
-    (θ : Semantics.Attitudes.Preferential.ThresholdFunction W) :
-    negativeValenceEntailsDual
-      (Semantics.Attitudes.Preferential.hope μ θ).valence = false := rfl
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ) :
+    negativeValenceEntailsDual (Preferential.hope μ θ).valence = false := rfl
 
-/-- NVP Class 2 (C-distributive + negative valence) = the class that
-    licenses EN in complement clauses. This connects the preferential
-    attitude classification to the EN trigger taxonomy. -/
+/-- The distributive negative preferential class ([qing-uegaki-2025])
+    is the class that licenses EN in complement clauses — connecting
+    the preferential attitude classification to the EN trigger
+    taxonomy. -/
 theorem class2_licenses_EN :
     negativeValenceEntailsDual .negative = true ∧
     negativeValenceEntailsDual .positive = false := ⟨rfl, rfl⟩

--- a/Linglib/Studies/QingEtAl2025.lean
+++ b/Linglib/Studies/QingEtAl2025.lean
@@ -1,36 +1,66 @@
-/-
-# [qing-uegaki-2025] Empirical Data
+import Linglib.Semantics.Attitudes.Preferential
 
-Data from: "When can non-veridical preferential attitude predicates take questions?"
-Authors: Qing, Özyıldız, Roelofsen, Romero, Uegaki
+/-!
+# Qing, Özyıldız, Roelofsen, Romero & Uegaki 2025: question-taking preferentials
 
-## Architecture
-
-This file imports verb entries from `Fragments/` and records empirical observations.
-The lexical properties (valence, C-distributivity, NVP class) come from the fragments;
-only the empirical acceptability judgments are specified here.
-
-## Findings
-
-The paper identifies three classes of NVPs based on:
-1. **C-distributivity**: Does `x V Q` ⟺ `∃p ∈ Q. x V that p`?
-2. **Valence**: Evaluatively positive vs. negative
-3. **TSP**: Threshold Significance Presupposition
-
-| Class | C-dist | Valence | TSP | Takes Q? |
-|-------|--------|---------|-----|----------|
-| 1 | ✗ | any | any | ✓ |
-| 2 | ✓ | negative | ✗ | ✓ |
-| 3 | ✓ | positive | ✓ | ✗ |
-
+[qing-uegaki-2025] classify non-veridical preferential predicates by
+two factors — clausal distributivity and evaluative valence — and
+show that only the distributive positive class (*hope*-type) is
+anti-rogative: non-distributive predicates (*worry*, Mandarin
+*qidai*, Japanese *tanosimi*) and distributive negative ones (*fear*,
+Japanese *osore*, Turkish *kork-*) take questions canonically,
+because the [uegaki-sudo-2019] triviality needs both distributivity
+and the positive-valence Threshold Significance Presupposition
+(`Studies/UegakiSudo2019.lean`). `PredicateClass` and `classify`
+render the classification (their Table 1); the observations record
+the paper's cross-linguistic acceptability judgments over English,
+Mandarin, Japanese, and Turkish. Apparent *hope* + question cases are
+analyzed as non-canonical adjunction-style composition (their §4),
+with the highlighting analysis considered and dispreferred.
 -/
 
-import Linglib.Fragments.English.Predicates.Verbal
-import Linglib.Fragments.Mandarin.Predicates
-import Linglib.Fragments.Japanese.Predicates
-import Linglib.Fragments.Turkish.Predicates
-
 namespace QingEtAl2025
+
+open Features (AttitudeValence)
+
+/-! ### The classification (Table 1) -/
+
+/-- The three classes of non-veridical preferential predicates: the
+    two distributivity-by-valence cells that take questions, and the
+    anti-rogative distributive positive class. -/
+inductive PredicateClass where
+  /-- Non-distributive (*worry*, *qidai*, *tanosimi*): the question
+      semantics outruns the existential over answers. -/
+  | nonDistributive
+  /-- Distributive with negative valence (*fear*, *osore*, *kork-*):
+      no Threshold Significance Presupposition. -/
+  | distributiveNegative
+  /-- Distributive with positive valence (*hope*, *wish*, *expect*):
+      anti-rogative via the [uegaki-sudo-2019] triviality. -/
+  | distributivePositive
+  deriving DecidableEq, Repr
+
+/-- The class determined by the two factors. Distributivity facts for
+    the substrate's predicates are
+    `Preferential.mkDegreeComparison_isDistributive` and
+    `Preferential.worry_not_distributive`. -/
+def classify (distributive : Bool) (valence : AttitudeValence) :
+    PredicateClass :=
+  match distributive, valence with
+  | false, _ => .nonDistributive
+  | true, .negative => .distributiveNegative
+  | true, .positive => .distributivePositive
+
+/-- Only the distributive positive class is anti-rogative (Table 1). -/
+def PredicateClass.takesQuestions : PredicateClass → Prop
+  | .nonDistributive => True
+  | .distributiveNegative => True
+  | .distributivePositive => False
+
+example : classify true .positive = .distributivePositive := rfl
+example : classify true .negative = .distributiveNegative := rfl
+example : classify false .negative = .nonDistributive := rfl
+example : classify false .positive = .nonDistributive := rfl
 
 -- Language Type
 
@@ -92,7 +122,7 @@ def qidaiZh : Observation := ⟨"qidai", .mandarin, "look forward to", true, tru
 def danxinZh : Observation := ⟨"danxin", .mandarin, "worry", true, true, ""⟩
 
 def xiwangZh : Observation := ⟨"xiwang", .mandarin, "hope", false, false,
-  "Class 3: anti-rogative like English hope"⟩
+  "distributive positive: anti-rogative like English hope"⟩
 
 def haipaZh : Observation := ⟨"haipa", .mandarin, "fear", true, true, ""⟩
 
@@ -106,7 +136,7 @@ def tanosimiJa : Observation := ⟨"tanosimi", .japanese, "looking forward to", 
 def osoreJa : Observation := ⟨"osore", .japanese, "fear", true, true, ""⟩
 
 def kitaiJa : Observation := ⟨"kitai", .japanese, "expect/hope", false, false,
-  "Class 3: behaves like English hope"⟩
+  "distributive positive: behaves like English hope"⟩
 
 def shinpaiJa : Observation := ⟨"shinpai", .japanese, "worry", true, true, ""⟩
 
@@ -130,16 +160,15 @@ def allObservations : List Observation :=
   englishObs ++ mandarinObs ++ japaneseObs ++ turkishObs
 
 /-!
-## Verifying Predictions Against Observations
+## Verifying predictions against observations
 
-The NVP class of each predicate follows from its C-distributivity and
-valence via `Semantics.Attitudes.Preferential.classifyNVP`, with
-C-distributivity proved from the semantics
-(`PreferentialPredicate.isCDistributive` and the hope/fear/worry
-theorems in `Semantics/Attitudes/Preferential.lean`); the class then
-predicts question-embedding, checked against the observations here:
+Each predicate's class follows from its distributivity and valence
+via `classify` — distributivity proved from the semantics
+(`Preferential.mkDegreeComparison_isDistributive`,
+`Preferential.worry_not_distributive`) — and the class predicts
+question-embedding, checked against the observations:
 
-### Cross-Linguistic Verification
+### Cross-linguistic verification
 
 | Language | Predicate | Class | Predicted | Observed | ✓/✗ |
 |----------|-----------|-------|-----------|----------|-----|
@@ -157,44 +186,25 @@ predicts question-embedding, checked against the observations here:
 -- Key Examples from the Paper
 
 /-!
-## Example: The hope-wh puzzle (Section 1)
+## Key examples
 
-Why can't "hope" embed questions in English?
+*Hope* cannot embed questions in English (*John hopes whether Mary
+will come; *John hopes who will come): *hope* is distributive and
+positive, so with the answers drawn from the comparison class the
+assertion is settled by the Threshold Significance Presupposition —
+the [uegaki-sudo-2019] triviality, `Studies/UegakiSudo2019.lean`.
 
-(1) *John hopes whether Mary will come.
-(2) *John hopes who will come.
+Mandarin *qidai* is positive yet embeds questions (Zhangsan qidai
+shei hui lai, "Zhangsan looks forward to who will come"): its
+question semantics carries an anticipation-of-resolution condition,
+so it is not distributive and the triviality derivation does not go
+through (§3.1).
 
-**Explanation (Qing et al.)**:
-- hope is C-distributive: "hope Q" ≈ "∃p ∈ Q. hope p"
-- hope is positive → has TSP: presupposes ∃p ∈ C. μ(x,p) > θ
-- When Q ⊆ C: assertion ⊆ presupposition → trivial!
-
-## Example: Mandarin qidai (Section 3.1)
-
-Why can positive "qidai" embed questions?
-
-(5) Zhangsan qidai shei hui lai.
-    "Zhangsan looks forward to who will come."
-    ✓ Grammatical (unlike English *"hope who")
-
-**Explanation**:
-- qidai is positive (like hope)
-- BUT qidai is NON-C-distributive!
-- "qidai Q" ≠ "∃p ∈ Q. qidai p"
-- Non-C-distributivity breaks the triviality derivation.
-
-## Example: Turkish kork- (Section 3.2)
-
-Why does "kork-" have symmetric interpretation with questions?
-
-(6) Ali kork-uyor kim gel-ecek diye.
-    "Ali fears who will come."
-    = Ali fears that X will come OR fears that Y will come...
-
-**Explanation**:
-- kork- is negative → no bouletic goal
-- No preferred outcome → symmetric interpretation
-- Contrast with "hopefully" which is asymmetric (positive valence)
+Turkish *kork-* "fear" embeds questions with a symmetric
+interpretation — "John fears whether his neighbor will be home" is
+felicitous whether he fears the neighbor's presence or absence
+(their GoodFriend and NoiseHater contexts, §3.2) — because negative
+predicates do not trigger the Threshold Significance Presupposition.
 -/
 
 end QingEtAl2025

--- a/Linglib/Studies/UegakiSudo2019.lean
+++ b/Linglib/Studies/UegakiSudo2019.lean
@@ -1,0 +1,107 @@
+import Linglib.Semantics.Attitudes.Preferential
+import Mathlib.Tactic.NormNum
+
+/-!
+# Uegaki & Sudo 2019: The *hope*-wh puzzle
+
+[uegaki-sudo-2019] derive the anti-rogativity of non-veridical
+preferential predicates (*hope*, *wish*) from triviality. With the
+degree semantics ⟦x V p⟧ = μ(x,p) > θ(C) ([villalta-2008]), the
+Threshold Significance Presupposition, and clausal distributivity,
+combining the predicate with a question whose answers exhaust the
+comparison class yields an assertion identical to its presupposition
+(`hope_question_iff_significance`) — an L-analytic meaning in the
+sense of [gajewski-2002], hence ungrammaticality.
+
+Veridical preferentials (*be surprised*, *be happy*, *be glad*,
+*like*, *hate*) escape and take questions: the truth requirement on
+the complement makes the assertion world-dependent, so threshold
+significance no longer settles it. `veridicalQuestion` is the
+world-sensitive semantics — still clausally distributive
+(`veridical_isDistributive`) — and `veridicality_breaks_triviality`
+exhibits a model where the presupposition holds, the non-veridical
+assertion is (trivially) true, and the veridical assertion is false
+because the true answer is not the preferred one.
+-/
+
+namespace UegakiSudo2019
+
+open Preferential
+
+variable {W E : Type*}
+
+/-! ### Triviality for non-veridical preferentials -/
+
+/-- With the question's answers drawn from the comparison class, the
+    *hope*-question assertion entails threshold significance. -/
+theorem hope_question_entails_significance
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (x : E) (Q C : List (Finset W)) (hQC : Q ⊆ C)
+    (h : (hope μ θ).questionSemantics x Q C) :
+    ThresholdSignificance μ θ x C :=
+  let ⟨p, hp, hd⟩ := h; ⟨p, hQC hp, hd⟩
+
+/-- Conversely, threshold significance entails the assertion when the
+    comparison class is contained in the question. -/
+theorem significance_entails_hope_question
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (x : E) (Q C : List (Finset W)) (hCQ : C ⊆ Q)
+    (h : ThresholdSignificance μ θ x C) :
+    (hope μ θ).questionSemantics x Q C :=
+  let ⟨p, hp, hd⟩ := h; ⟨p, hCQ hp, hd⟩
+
+/-- When the question's answers are exactly the comparison class, the
+    assertion of *hope* + question is its presupposition: the meaning
+    is L-analytic ([gajewski-2002]) — true whenever defined — which
+    is the triviality that makes *hope* anti-rogative. -/
+theorem hope_question_iff_significance
+    (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (x : E) (Q : List (Finset W)) :
+    (hope μ θ).questionSemantics x Q Q ↔ ThresholdSignificance μ θ x Q :=
+  Iff.rfl
+
+/-! ### Veridical preferentials -/
+
+/-- Veridical propositional semantics: ⟦x is happy that p⟧(w, C)
+    requires the complement to be true at the evaluation world. -/
+def veridicalProp (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (C : List (Finset W)) (x : E) (p : Finset W) (w : W) : Prop :=
+  w ∈ p ∧ μ x p > θ C
+
+/-- Veridical question semantics: some true answer clears the
+    threshold. -/
+def veridicalQuestion (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+    (C : List (Finset W)) (x : E) (Q : List (Finset W)) (w : W) : Prop :=
+  ∃ p ∈ Q, w ∈ p ∧ μ x p > θ C
+
+/-- Veridical preferentials are clausally distributive — it is
+    veridicality, not a failure of distributivity, that lets them
+    take questions. -/
+theorem veridical_isDistributive (μ : E → Finset W → ℚ)
+    (θ : List (Finset W) → ℚ) (C : List (Finset W)) :
+    Distributivity.IsDistributive (veridicalProp μ θ C)
+      (veridicalQuestion μ θ C) :=
+  fun _ _ _ => Iff.rfl
+
+/-- Veridicality breaks the triviality: a model where threshold
+    significance holds and the non-veridical assertion is therefore
+    true, but the veridical assertion is false — the true answer is
+    not the preferred one. Two worlds, the polar question over them,
+    evaluated at the dispreferred world. -/
+theorem veridicality_breaks_triviality :
+    ∃ (W E : Type) (μ : E → Finset W → ℚ) (θ : List (Finset W) → ℚ)
+      (x : E) (Q : List (Finset W)) (w : W),
+      ThresholdSignificance μ θ x Q ∧
+      (hope μ θ).questionSemantics x Q Q ∧
+      ¬ veridicalQuestion μ θ Q x Q w := by
+  refine ⟨Bool, Unit, (fun _ p => if true ∈ p then 1 else -1), (fun _ => 0),
+          (), [{true}, {false}], false, ?_, ?_, ?_⟩
+  · exact ⟨{true}, by simp, by norm_num⟩
+  · exact ⟨{true}, by simp, by norm_num⟩
+  · rintro ⟨p, hp, hw, hd⟩
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at hp
+    rcases hp with rfl | rfl
+    · simp at hw
+    · norm_num [Finset.mem_singleton] at hd
+
+end UegakiSudo2019

--- a/blog/references.bib
+++ b/blog/references.bib
@@ -104,6 +104,16 @@
   validated = {true},
   sources   = {Pragmatics/SocialMeaning/SocialUtility.lean;Pragmatics/GameTheory.lean}
 }
+@phdthesis{scheffler-2008,
+  author    = {Scheffler, Tatjana},
+  year      = {2008},
+  title     = {Semantic Operators in Different Dimensions},
+  school    = {University of Pennsylvania},
+  subfield  = {semantics/attitudes},
+  role      = {cited},
+  sources   = {Studies/AnandHacquard2013.lean}
+}
+
 @phdthesis{frank-1996,
   author    = {Frank, Anette},
   year      = {1996},


### PR DESCRIPTION
Deep audit of `Preferential.lean` (1256 → 176 lines) against the primary sources (Qing, Özyıldız, Roelofsen, Romero & Uegaki 2025 fulltext; Anand & Hacquard 2013 S&P). The theory file keeps the consumed core — `PreferentialPredicate`, the degree-comparison builder and constructors, distributivity results, `ThresholdSignificance` — Finset/Prop-migrated with bare `Preferential`/`Distributivity` namespaces.

- New `Studies/UegakiSudo2019.lean`: the TSP triviality (assertion = presupposition on exhaustive questions, L-analyticity) and veridicality-breaks-triviality as a concrete witness model; veridical semantics rebuilt world-indexed (the old `mkVeridicalPreferential` ignored the world in its own fields).
- `Studies/QingEtAl2025.lean` gains the paper's Table-1 classification (`PredicateClass`, `classify`); Turkish `kork-` example corrected to the paper's (45)–(47).
- `Studies/AnandHacquard2013.lean` gains the (56) emotive-doxastic entry as a `PartialProp` (presupposition = uncertainty, assertion = doxastic + preference — the old `HoldsAt` mislabeled all three as definedness) plus might-concord and must-blocking over the study's own S-parameter semantics.
- Deleted: the `SignificanceContent` "derivation" (fabricated Hamblin→Rooth→Kennedy chain; the paper states negative NVPs simply do not trigger TSP), the highlighting section (zero consumers; Qing et al. §4.2 explicitly disprefer that analysis), zero-consumer veridical/emotive apparatus, alias abbrevs, 4 dead imports, and dead Preferential imports in three Fragments and Representationality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)