### PR TITLE
refactor(Semantics/Attitudes): cleanse RationalAttitude; demote to studies

### DIFF
--- a/Linglib/Fragments/Italian/Predicates.lean
+++ b/Linglib/Fragments/Italian/Predicates.lean
@@ -27,7 +27,7 @@ namespace Italian.Predicates
 
 open ArgumentStructure
 open Minimalist (ComplementSize)
-open Semantics.Attitudes.RationalAttitude (Reading readingFromSize)
+open RationalAttitude (Reading readingFromSize)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Italian Infinitival Complementizers

--- a/Linglib/Semantics/Attitudes/RationalAttitude.lean
+++ b/Linglib/Semantics/Attitudes/RationalAttitude.lean
@@ -1,326 +1,49 @@
-import Linglib.Discourse.SpeechAct
-import Linglib.Discourse.Commitment.Basic
-import Linglib.Semantics.Attitudes.Doxastic
-import Linglib.Semantics.Events.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 
 /-!
-# Rational Attitude Semantics [fusco-sgrizzi-2026]
-[dowty-1979]
+# Rational attitude readings
 
-Unified semantics for attitude verbs that support both belief and intention
-readings. The key insight: these are not two separate verb types but a single
-verb whose interpretation is determined by complement structure.
+[fusco-sgrizzi-2026] analyse verbs like Italian *convincere* as
+carrying a single *rational attitude* semantics whose belief or
+intention construal is fixed by complement size: a phase-sized (CP)
+complement is existentially closed into a proposition and evaluated
+against doxastic content, while a smaller complement leaves the event
+variable open and is evaluated against inertial continuation
+([dowty-1979]). `Reading` is the two-way construal and
+`readingFromSize` derives it from `ComplementSize`.
 
-## Core Idea
-
-A *rational attitude* is a mental state that can be either:
-- **Belief**: a propositional attitude evaluated via CONTENT (doxastic modal base)
-- **Intention**: a sub-propositional attitude evaluated via INERTIA (inertial modal base)
-
-The difference is determined by **complement size**:
-- CP complement → CLOSURE applies → propositional content → belief
-- Sub-CP complement → event variable open → intention
-
-## Denotation ([fusco-sgrizzi-2026], ex. 24)
-
-⟦convincere⟧ = λP.λx.λy.λe. ∃e'. Convince(e) ∧ Agent(e,y) ∧ Patient(e,x)
-                                   ∧ CAUSE(e,e') ∧ RATIONAL-ATTITUDE(e')
-                                   ∧ Experiencer(x,e') ∧ P(e')
-
-The parameter P is determined by complement size:
-- *di*-infinitive (CP): P = CLOSURE(λe. VP(e)) — existentially closed
-- *a*-infinitive (aP): P = λe. VP(e) — event variable open
-
+The paper's single-denotation analysis of *convincere* and its
+reading diagnostics live in `Studies/FuscoSgrizzi2026.lean`; the
+causal-self-reference semantics for intention reports
+([grano-2024]) in `Studies/Grano2024.lean`; the Italian *di*/*a*
+complementizer data in `Fragments/Italian/Predicates.lean`.
 -/
 
-namespace Semantics.Attitudes.RationalAttitude
+namespace RationalAttitude
 
 open Minimalist (ComplementSize fValue)
 
--- ════════════════════════════════════════════════════════════════
--- § 1. Rational Attitude Reading
--- ════════════════════════════════════════════════════════════════
-
-/-- The two readings of a rational attitude verb, determined by complement size.
-
-    - `belief`: complement is propositional (existentially closed by CLOSURE);
-      evaluated via CONTENT modal base (doxastic alternatives)
-    - `intention`: complement is sub-propositional (event variable open);
-      evaluated via INERTIA modal base (normal continuation) -/
+/-- The two construals of a rational attitude verb: propositional
+    belief, evaluated against doxastic content, or sub-propositional
+    intention, evaluated against inertial continuation. -/
 inductive Reading where
   | belief
   | intention
   deriving DecidableEq, Repr
 
-/-- Map complement size to rational attitude reading.
-
-    CP-sized complements (fLevel ≥ 6) trigger CLOSURE, yielding a propositional
-    content suitable for belief evaluation. Sub-CP complements leave the event
-    variable unsaturated, producing an intention reading via INERTIA. -/
+/-- The construal determined by complement size: a phase-sized (CP)
+    complement is existentially closed into a proposition and read as
+    belief; a smaller complement leaves the event variable open and is
+    read as intention. -/
 def readingFromSize (cs : ComplementSize) : Reading :=
-  if cs.fLevel ≥ 6 then .belief else .intention
+  if cs.isPhaseSized then .belief else .intention
 
--- ════════════════════════════════════════════════════════════════
--- § 2. Complement Size → Reading Theorems
--- ════════════════════════════════════════════════════════════════
+/-- Complement size determines the construal, with the CP phase
+    boundary as the threshold. -/
+theorem readingFromSize_eq_belief_iff (cs : ComplementSize) :
+    readingFromSize cs = .belief ↔ fValue .C ≤ cs.fLevel := by
+  unfold readingFromSize
+  cases h : cs.isPhaseSized <;>
+    simp_all [ComplementSize.isPhaseSized]
 
-theorem cp_yields_belief : readingFromSize .cP = .belief := by decide
-theorem tp_yields_intention : readingFromSize .tP = .intention := by decide
-theorem vp_yields_intention : readingFromSize .vP = .intention := by decide
-theorem belief_ne_intention : Reading.belief ≠ Reading.intention := nofun
-
-/-- Complement size determines reading: CP boundary is the threshold.
-    This formalizes Fusco & Sgrizzi's structural size hypothesis. -/
-theorem size_determines_reading (cs : ComplementSize) :
-    readingFromSize cs = .belief ↔ cs.fLevel ≥ 6 := by
-  constructor
-  · intro h
-    unfold readingFromSize at h
-    split at h
-    · assumption
-    · exact absurd h nofun
-  · intro h
-    unfold readingFromSize
-    simp [h]
-
--- ════════════════════════════════════════════════════════════════
--- § 3. CLOSURE Operator
--- ════════════════════════════════════════════════════════════════
-
-/-- CLOSURE: existential closure of the event variable at the CP level.
-
-    For CP complements, CLOSURE converts an event predicate P(e) into a
-    proposition ∃e. P(e), yielding a belief-compatible propositional content.
-
-    This is pointwise Davidsonian existential closure (`Event.existsClosure`),
-    re-exported under the name used in [fusco-sgrizzi-2026]. -/
-abbrev closure {W Time : Type*} [LinearOrder Time] (P : W → Event Time → Prop) : W → Prop :=
-  fun w => Event.existsClosure (P w)
-
--- ════════════════════════════════════════════════════════════════
--- § 4. Causative Attitude Verb (convincere-type)
--- ════════════════════════════════════════════════════════════════
-
-/-- A causative attitude verb: Agent causes Experiencer to enter a rational
-    attitude state whose content is determined by complement P.
-
-    ⟦convincere⟧ = λP.λx.λy.λe. ∃e'. VerbPred(e) ∧ Agent(e,y)
-      ∧ Patient(e,x) ∧ CAUSE(e,e') ∧ RATIONAL-ATTITUDE(e')
-      ∧ Experiencer(x,e') ∧ P(e')
-
-    The parameter P is supplied by the complement:
-    - CP (*di*): CLOSURE applied → P is propositional (belief)
-    - Sub-CP (*a*): P is an event predicate (intention) -/
-structure CausativeAttitude (E Time : Type*) [LinearOrder Time] where
-  /-- The verb's descriptive predicate (e.g., Convince) -/
-  verbPred : Event Time → Prop
-  /-- The agent of the matrix event -/
-  agent : E
-  /-- The patient/experiencer who enters the attitude -/
-  experiencer : E
-  /-- Agent thematic role -/
-  isAgent : Event Time → E → Prop
-  /-- Patient thematic role -/
-  isPatient : Event Time → E → Prop
-  /-- Experiencer thematic role (on the attitude event) -/
-  isExperiencer : Event Time → E → Prop
-  /-- CAUSE(e, e'): the matrix event e causally brings about the attitude
-      state e'. Abstract relation; instantiated per verb/scenario. -/
-  cause : Event Time → Event Time → Prop
-
-/-- Semantics of a causative attitude verb applied to complement P.
-
-    Returns a proposition existentially closed over both the matrix
-    event and the resulting attitude event. -/
-def CausativeAttitude.denote {E Time : Type*} [LinearOrder Time]
-    (v : CausativeAttitude E Time) (P : Event Time → Prop) : Prop :=
-  ∃ e e' : Event Time,
-    v.verbPred e ∧
-    v.isAgent e v.agent ∧
-    v.isPatient e v.experiencer ∧
-    v.cause e e' ∧
-    e'.sort = .stative ∧  -- Rational attitudes are stative
-    v.isExperiencer e' v.experiencer ∧
-    P e'
-
-/-- Belief reading: CLOSURE applies to the embedded VP, yielding a proposition.
-    The attitude is evaluated via CONTENT (doxastic alternatives). -/
-def CausativeAttitude.beliefReading {E Time : Type*} [LinearOrder Time]
-    (v : CausativeAttitude E Time) (embeddedVP : Event Time → Prop) : Prop :=
-  v.denote (λ _ => ∃ e'' : Event Time, embeddedVP e'')
-
-/-- Intention reading: no CLOSURE — the embedded VP is applied directly as an
-    event predicate. The attitude is evaluated via INERTIA. -/
-def CausativeAttitude.intentionReading {E Time : Type*} [LinearOrder Time]
-    (v : CausativeAttitude E Time) (embeddedVP : Event Time → Prop) : Prop :=
-  v.denote embeddedVP
-
-/-- Both readings are instances of the same `denote` applied to different P.
-    This is the paper's central formal claim (ex. 24): *convincere* has ONE
-    denotation; the belief/intention split is compositional, arising from
-    complement size (CP triggers CLOSURE, sub-CP does not). -/
-theorem CausativeAttitude.readings_from_single_denote {E Time : Type*} [LinearOrder Time]
-    (v : CausativeAttitude E Time) (VP : Event Time → Prop) :
-    v.beliefReading VP = v.denote (fun _ => ∃ e, VP e) ∧
-    v.intentionReading VP = v.denote VP :=
-  ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 3b. CAUSE* — Causal Self-Reference ([grano-2024])
--- ════════════════════════════════════════════════════════════════
-
-/-- CAUSE*(s, e, w): causal self-reference relation ([grano-2024], (79);
-    [searle-1983]).
-
-    The attitude state `s` causally brings about event `e` in world `w`
-    "in the right way." Distinguished from plain CAUSE by requiring that
-    the causation proceed via the agent's intention-in-action, not via
-    a deviant causal chain ([harman-1976]; [chisholm-1966]).
-
-    Example (Harman): Betty aims her gun intending to kill the target.
-    Her intention makes her nervous; nervousness causes her to pull the
-    trigger; the target is killed. The outcome was caused by the intention,
-    but not "in the right way" — the causal chain was deviant. CAUSE*
-    would not hold, correctly predicting that Betty did not carry out
-    her intention. -/
-abbrev CauseStar (W Time : Type*) [LinearOrder Time] := Event Time → Event Time → W → Prop
-
-/-- Semantics for intention reports with causal self-reference
-    ([grano-2024], version 4, (79)).
-
-    ⟦Kim intends to leave⟧ᵂ·ᵗ =
-      ∃s. INTENTION(s,w) ∧ HOLDER(k,s,w)
-        ∧ ∀⟨w',x⟩ ∈ CONTENT(s):
-            ∃e. CAUSE*(s,e,w') ∧ P(x,w',e)
-
-    The complement `P` has type `(E → W → Event Time → Prop)` — an event
-    predicate with an open eventuality argument. This is the formal
-    correlate of [grano-2024]'s Premise 3: IND would existentially
-    close the event argument, yielding `(E → W → Prop)`, which is
-    type-incompatible with CAUSE*. The type system enforces that
-    intention reports require eventuality abstraction. -/
-def intentionHolds {E W Time : Type*} [LinearOrder Time]
-    (isIntention : Event Time → W → Prop)
-    (holder : E → Event Time → W → Prop)
-    (content : Event Time → Set (W × E))
-    (causeStar : CauseStar W Time)
-    (agent : E) (P : E → W → Event Time → Prop) (w : W) : Prop :=
-  ∃ s : Event Time,
-    s.sort = .stative ∧
-    isIntention s w ∧
-    holder agent s w ∧
-    ∀ p ∈ content s, ∃ e : Event Time, causeStar s e p.1 ∧ P p.2 p.1 e
-
-/-- Plain belief reports do NOT require CAUSE*: the complement is a
-    proposition (event argument already closed by IND), so there is no
-    event for CAUSE* to bind.
-
-    ⟦Kim believes that Sandy left⟧ᵂ =
-      ∀w' ∈ DOX(k,w): P(w')
-
-    The contrast in complement type — `(W → Prop)` for belief vs
-    `(E → W → Event Time → Prop)` for intention — is what makes 'believe'
-    indicative-selecting and 'intend' subjunctive-selecting. -/
-def beliefHolds {E W : Type*}
-    (dox : E → W → Set W)
-    (agent : E) (P : W → Prop) (w : W) : Prop :=
-  ∀ w' ∈ dox agent w, P w'
-
-/-! ### Premise 3: Type-Level Enforcement ([grano-2024], §4.3)
-
-Intention reports require eventuality abstraction: `intentionHolds`
-demands a complement with an open event argument (`P : E → W → Event Time → Prop`),
-while `beliefHolds` takes a closed proposition (`P : W → Prop`).
-
-Indicative mood existentially closes the event argument ((87)),
-yielding `W → Prop`, which is type-incompatible with `intentionHolds`.
-Only subjunctive/nonfinite clauses leave the event argument open,
-enabling the `E → W → Event Time → Prop` type that CAUSE* requires.
-
-The distinction is enforced by construction — no theorem is needed
-because you literally cannot pass a `W → Prop` where
-`E → W → Event Time → Prop` is expected. The Lean type checker is the proof.
--/
-
--- ════════════════════════════════════════════════════════════════
--- § 5. Diagnostics
--- ════════════════════════════════════════════════════════════════
-
-/-- Truth assessment is available for belief readings but not intention readings.
-    "It's true/false" can felicitously evaluate a belief but not an intention. -/
-def truthAssessable : Reading → Bool
-  | .belief => true
-  | .intention => false
-
-/-- Modal auxiliaries can appear in CP complements (belief) but not in
-    sub-CP complements (intention). The CP provides the structural space
-    to host modal heads (Mod, F-level 2). -/
-def allowsModalAux : Reading → Bool
-  | .belief => true
-  | .intention => false
-
-/-- Intention readings are obligatorily future-oriented: the intended event
-    is projected into inertia worlds (future continuation). Belief readings
-    have no temporal constraint (they can be about past, present, or future). -/
-def forcedFutureOrientation : Reading → Bool
-  | .belief => false
-  | .intention => true
-
-/-- Object control is obligatory for intention readings: the experiencer
-    must be the agent of the intended event. Belief readings allow both
-    subject and object control configurations. -/
-def objectControlOnly : Reading → Bool
-  | .belief => false
-  | .intention => true
-
-theorem diagnostics_distinguish_readings :
-    truthAssessable .belief = true ∧
-    allowsModalAux .belief = true ∧
-    forcedFutureOrientation .belief = false ∧
-    objectControlOnly .belief = false ∧
-    truthAssessable .intention = false ∧
-    allowsModalAux .intention = false ∧
-    forcedFutureOrientation .intention = true ∧
-    objectControlOnly .intention = true :=
-  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
-
--- ════════════════════════════════════════════════════════════════
--- § 6. Bridge: Reading → [searle-1983] Direction of Fit
--- ════════════════════════════════════════════════════════════════
-
-
-/-- Map rational attitude readings to [searle-1983]'s direction of fit.
-
-    Belief readings have mind-to-world fit: the propositional content must
-    match independently existing reality. Intention readings have
-    world-to-mind fit: reality must be changed to match the content. -/
-def Reading.directionOfFit : Reading → DirectionOfFit
-  | .belief    => .mindToWorld
-  | .intention => .worldToMind
-
-/-- Map rational attitude readings to [searle-1983]'s psychological mode.
-
-    This connects [fusco-sgrizzi-2026]'s complement-size analysis to
-    Searle's theory of Intentional states: the same verb produces different
-    psychological modes depending on syntactic complement structure. -/
-def Reading.psychMode : Reading → PsychMode
-  | .belief    => .belief
-  | .intention => .intention
-
-/-- The direction of fit derived from the reading matches the direction
-    derived from the corresponding psychological mode. -/
-theorem reading_direction_matches_psychMode :
-    ∀ r : Reading, r.directionOfFit = r.psychMode.directionOfFit := by
-  intro r; cases r <;> rfl
-
-/-- Belief readings are not causally self-referential; intention readings are.
-    This is the formal correlate of [fusco-sgrizzi-2026]'s CONTENT vs
-    INERTIA modal base distinction: INERTIA worlds are those where the agent's
-    intentions *cause* the events to come about. -/
-theorem intention_self_referential_belief_not :
-    Reading.intention.psychMode.causalSelfRef = .stateToWorld ∧
-    Reading.belief.psychMode.causalSelfRef = .none :=
-  ⟨rfl, rfl⟩
-
-end Semantics.Attitudes.RationalAttitude
+end RationalAttitude

--- a/Linglib/Studies/FuscoSgrizzi2026.lean
+++ b/Linglib/Studies/FuscoSgrizzi2026.lean
@@ -1,4 +1,6 @@
 import Linglib.Semantics.Modality.Kratzer.Flavor
+import Linglib.Semantics.Attitudes.RationalAttitude
+import Linglib.Semantics.Events.Basic
 
 /-!
 # Inertial modality for Italian non-finite belief/action readings
@@ -18,6 +20,9 @@ circumstantial-base + inertial-ordering pair.
 * `inertial_duality`: modal duality, delegated to `Kratzer.duality`.
 * `empty_inertia_is_simple`: with an empty ordering source, inertial
   necessity collapses to circumstantial `simpleNecessity`.
+* `CausativeAttitude`: the single denotation of *convincere*-type
+  verbs (their ex. 24), with `beliefReading`/`intentionReading` the
+  two complement-size construals and the reading diagnostics.
 
 ## Implementation notes
 
@@ -79,5 +84,98 @@ theorem empty_inertia_is_simple (circ : ModalBase W) (prop : W → Prop) (w : W)
     and teleological modality concern what happens given the facts — they
     differ only in ordering source, not modal base. -/
 def InertialParams.flavorTag : ModalFlavor := .circumstantial
+
+/-! ## The single denotation of *convincere* (ex. 24)
+
+⟦convincere⟧ = λP.λx.λy.λe. ∃e'. Convince(e) ∧ Agent(e,y) ∧ Patient(e,x)
+∧ CAUSE(e,e') ∧ RATIONAL-ATTITUDE(e') ∧ Experiencer(x,e') ∧ P(e').
+The parameter P is supplied by the complement: a *di*-infinitive (CP)
+is existentially closed, yielding the belief reading; an
+*a*-infinitive (aP) leaves the event variable open, yielding the
+intention reading. The belief/intention split is compositional — one
+verb, two complement sizes. -/
+
+/-- A causative attitude verb: the agent causes the experiencer to
+    enter a rational attitude state whose content is the complement
+    predicate. -/
+structure CausativeAttitude (E Time : Type*) [LinearOrder Time] where
+  /-- The verb's descriptive predicate (Convince). -/
+  verbPred : Event Time → Prop
+  /-- The agent of the matrix event. -/
+  agent : E
+  /-- The patient of the matrix event and experiencer of the attitude. -/
+  experiencer : E
+  /-- Agent thematic role. -/
+  isAgent : Event Time → E → Prop
+  /-- Patient thematic role. -/
+  isPatient : Event Time → E → Prop
+  /-- Experiencer thematic role, on the attitude event. -/
+  isExperiencer : Event Time → E → Prop
+  /-- The matrix event causally brings about the attitude state. -/
+  cause : Event Time → Event Time → Prop
+
+variable {E Time : Type*} [LinearOrder Time]
+
+/-- The verb applied to a complement predicate `P`: some matrix event
+    causes a stative rational-attitude event satisfying `P`. -/
+def CausativeAttitude.denote (v : CausativeAttitude E Time)
+    (P : Event Time → Prop) : Prop :=
+  ∃ e e' : Event Time,
+    v.verbPred e ∧ v.isAgent e v.agent ∧ v.isPatient e v.experiencer ∧
+    v.cause e e' ∧ e'.sort = .stative ∧
+    v.isExperiencer e' v.experiencer ∧ P e'
+
+/-- Belief reading: the CP complement is existentially closed into a
+    proposition, evaluated against doxastic content. -/
+def CausativeAttitude.beliefReading (v : CausativeAttitude E Time)
+    (embeddedVP : Event Time → Prop) : Prop :=
+  v.denote (fun _ => ∃ e : Event Time, embeddedVP e)
+
+/-- Intention reading: the sub-CP complement is applied directly as an
+    event predicate, evaluated against inertial continuation. -/
+def CausativeAttitude.intentionReading (v : CausativeAttitude E Time)
+    (embeddedVP : Event Time → Prop) : Prop :=
+  v.denote embeddedVP
+
+/-- The paper's central claim (ex. 24): both readings are the one
+    `denote` applied to different complement predicates — the
+    belief/intention split is compositional, not lexical. -/
+theorem CausativeAttitude.readings_from_single_denote
+    (v : CausativeAttitude E Time) (VP : Event Time → Prop) :
+    v.beliefReading VP = v.denote (fun _ => ∃ e, VP e) ∧
+    v.intentionReading VP = v.denote VP :=
+  ⟨rfl, rfl⟩
+
+/-! ## Reading diagnostics
+
+The paper's empirical differentiators of the two construals: belief
+readings are truth-assessable and host modal auxiliaries; intention
+readings are obligatorily future-oriented and object-control. -/
+
+open RationalAttitude (Reading)
+
+/-- "It's true/false" can felicitously evaluate a belief but not an
+    intention. -/
+def truthAssessable : Reading → Bool
+  | .belief => true
+  | .intention => false
+
+/-- CP complements host modal auxiliary heads; sub-CP complements
+    lack the structural space. -/
+def allowsModalAux : Reading → Bool
+  | .belief => true
+  | .intention => false
+
+/-- The intended event is projected into inertia worlds, so intention
+    readings are obligatorily future-oriented. -/
+def forcedFutureOrientation : Reading → Bool
+  | .belief => false
+  | .intention => true
+
+/-- The experiencer must be the agent of the intended event, so
+    intention readings are obligatorily object-control. -/
+def objectControlOnly : Reading → Bool
+  | .belief => false
+  | .intention => true
 
 end FuscoSgrizzi2026

--- a/Linglib/Studies/Grano2024.lean
+++ b/Linglib/Studies/Grano2024.lean
@@ -52,7 +52,7 @@ namespace Grano2024
 open ArgumentStructure
 open Mood (Grammatical EventDenotation)
 open Mood
-open Semantics.Attitudes.RationalAttitude
+open RationalAttitude
 
 -- ════════════════════════════════════════════════════════════════
 -- § 1. Cross-Linguistic Mood Choice Data (Table 1)
@@ -141,20 +141,20 @@ def causativeData : List MoodChoiceDatum :=
 
 /-- 'want' robustly rejects indicative across all 7 languages. -/
 theorem want_robustly_rejects_ind :
-    wantData.all (·.rejectsIndicative) = true := by native_decide
+    wantData.all (·.rejectsIndicative) = true := by decide
 
 /-- 'hope' does NOT robustly reject indicative — it varies
     (IND accepted in French, Portuguese, Italian, Greek, Romanian, English). -/
 theorem hope_does_not_robustly_reject_ind :
-    hopeData.all (·.rejectsIndicative) = false := by native_decide
+    hopeData.all (·.rejectsIndicative) = false := by decide
 
 /-- 'intend' robustly rejects indicative (where testable). -/
 theorem intend_robustly_rejects_ind :
-    intendData.all (·.rejectsIndicative) = true := by native_decide
+    intendData.all (·.rejectsIndicative) = true := by decide
 
 /-- Causatives robustly reject indicative (§2.4). -/
 theorem causatives_robustly_reject_ind :
-    causativeData.all (·.rejectsIndicative) = true := by native_decide
+    causativeData.all (·.rejectsIndicative) = true := by decide
 
 /-- 'intend' patterns with 'want', not 'hope', on indicative rejection.
     This is the central empirical finding ([grano-2024], Table 1). -/
@@ -163,14 +163,14 @@ theorem intend_patterns_with_want :
       wantData.all (·.rejectsIndicative) ∧
     intendData.all (·.rejectsIndicative) ≠
       hopeData.all (·.rejectsIndicative) := by
-  native_decide
+  decide
 
 /-- Causatives pattern with 'intend' and 'want' (not 'hope').
     Independent support for the eventuality abstraction analysis (§2.4). -/
 theorem causatives_pattern_with_intend :
     causativeData.all (·.rejectsIndicative) =
       intendData.all (·.rejectsIndicative) := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3. Bridge: Empirical Data → Selector
@@ -184,14 +184,50 @@ open English.Predicates.Verbal (want hope)
 theorem want_selector_matches_data :
     deriveSelector want = .subjunctiveSelecting ∧
     wantData.all (·.rejectsIndicative) = true := by
-  native_decide
+  decide
 
 /-- The deriveSelector function correctly classifies 'hope' as
     cross-linguistically variable, matching the data showing variation. -/
 theorem hope_selector_matches_data :
     deriveSelector hope = .crossLinguisticallyVariable ∧
     hopeData.all (·.rejectsIndicative) = false := by
-  native_decide
+  decide
+
+/-! ### Causal self-reference and the two report types
+
+CAUSE*(s, e, w): the attitude state `s` brings about event `e` in `w`
+"in the right way" — via the agent's intention-in-action, not a
+deviant causal chain ([grano-2024] (79); [searle-1983]; on deviance,
+[harman-1976] and [chisholm-1966]: Betty's intention to shoot makes
+her nervous, the nervousness makes her pull the trigger — the
+intention caused the killing, but not in the right way, so she did
+not carry out her intention). -/
+
+/-- Intention reports with causal self-reference ([grano-2024], (79)):
+    some stative intention state held by the agent, each of whose
+    content pairs ⟨w', x⟩ supports an event that the state brings
+    about in the right way and that satisfies the complement. The
+    complement type `E → W → Event Time → Prop` keeps the event
+    argument open — the formal correlate of Premise 3: indicative
+    would existentially close it to `W → Prop`, which cannot compose
+    with the causal self-reference relation. -/
+def intentionHolds {E W Time : Type*} [LinearOrder Time]
+    (isIntention : Event Time → W → Prop)
+    (holder : E → Event Time → W → Prop)
+    (content : Event Time → Set (W × E))
+    (causeStar : Event Time → Event Time → W → Prop)
+    (agent : E) (P : E → W → Event Time → Prop) (w : W) : Prop :=
+  ∃ s : Event Time,
+    s.sort = .stative ∧ isIntention s w ∧ holder agent s w ∧
+    ∀ p ∈ content s, ∃ e : Event Time, causeStar s e p.1 ∧ P p.2 p.1 e
+
+/-- Plain belief reports need no causal self-reference: the complement
+    is a closed proposition evaluated over doxastic alternatives —
+    which is why *believe* is indicative-selecting while *intend*
+    selects subjunctive. -/
+def beliefHolds {E W : Type*} (dox : E → W → Set W)
+    (agent : E) (P : W → Prop) (w : W) : Prop :=
+  ∀ w' ∈ dox agent w, P w'
 
 -- ════════════════════════════════════════════════════════════════
 -- § 4. Bridge: Event Denotation → Indicative Rejection
@@ -228,7 +264,7 @@ theorem grano_argument_chain :
     intendData.all (·.rejectsIndicative) = true ∧
     -- Empirical confirmation: causatives also reject IND (independent support)
     causativeData.all (·.rejectsIndicative) = true := by
-  refine ⟨fun _ => rfl, fun _ => rfl, ?_, ?_⟩ <;> native_decide
+  refine ⟨fun _ => rfl, fun _ => rfl, ?_, ?_⟩ <;> decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 5. Bridge: Unified Theory — Two Kinds of Departure
@@ -352,19 +388,19 @@ open English.Predicates.Verbal (intend try_ persuade promise decide_
     and has no alternate finite complement type. -/
 theorem try_rejects_finite :
     try_.complementType = .infinitival ∧
-    try_.altComplementType = none := by native_decide
+    try_.altComplementType = none := by decide
 
 /-- 'persuade' is a hybrid predicate: nonfinite complement with object
     control → intention reading. This matches [grano-2024] §6.2 (96). -/
 theorem persuade_is_hybrid :
     persuade.complementType = .infinitival ∧
-    persuade.controlType = .objectControl := by native_decide
+    persuade.controlType = .objectControl := by decide
 
 /-- 'promise' is a hybrid predicate: nonfinite complement with subject
     control → intention (commissive). Matches §6.2 (98a). -/
 theorem promise_is_hybrid :
     promise.complementType = .infinitival ∧
-    promise.controlType = .subjectControl := by native_decide
+    promise.controlType = .subjectControl := by decide
 
 /-- Aspectual predicates are phasal (cosType.isSome) and take gerund
     complements in English, consistent with requiring eventuality
@@ -372,19 +408,19 @@ theorem promise_is_hybrid :
     or subjunctive complements ((117)–(119)). -/
 theorem start_is_phasal :
     start.cosType.isSome = true ∧
-    start.complementType = .gerund := by native_decide
+    start.complementType = .gerund := by decide
 
 theorem stop_is_phasal :
     stop.cosType.isSome = true ∧
-    stop.complementType = .gerund := by native_decide
+    stop.complementType = .gerund := by decide
 
 theorem begin_is_phasal :
     begin_.cosType.isSome = true ∧
-    begin_.complementType = .gerund := by native_decide
+    begin_.complementType = .gerund := by decide
 
 theorem continue_is_phasal :
     continue_.cosType.isSome = true ∧
-    continue_.complementType = .gerund := by native_decide
+    continue_.complementType = .gerund := by decide
 
 /-- 'see' takes NP complements primarily (bare perception), with
     factive presupposition. The bare infinitive (eventive, §6.4 (124))
@@ -392,7 +428,7 @@ theorem continue_is_phasal :
     eventuality abstraction. -/
 theorem see_is_factive_perception :
     see.factivePresup = true ∧
-    see.levinClass = some .see := by native_decide
+    see.levinClass = some .see := by decide
 
 /-- 'decide' is a hybrid predicate: nonfinite complement → intention,
     finite complement → belief ([grano-2024] §6.2, (96)–(97)).
@@ -401,14 +437,14 @@ theorem see_is_factive_perception :
 theorem decide_is_hybrid :
     decide_.complementType = .infinitival ∧
     decide_.altComplementType = some .finiteClause ∧
-    decide_.controlType = .subjectControl := by native_decide
+    decide_.controlType = .subjectControl := by decide
 
 /-- 'remember' takes infinitival (implicative/eventive, §6.4 (120)).
     The gerund construal enables event memory; the *that*-clause
     enables propositional memory ((120)–(121)). -/
 theorem remember_is_implicative :
     remember.complementType = .infinitival ∧
-    remember.implicative.isSome = true := by native_decide
+    remember.implicative.isSome = true := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 7. Bridge: Fusco & Sgrizzi 2026 Connection
@@ -478,23 +514,23 @@ theorem cp_to_indicative :
 /-- 'want' involves non-simplifiable comparison (robust SBJV). -/
 theorem want_moodPrediction_agrees :
     DepartureKind.comparisonNonSimplifiable.moodPrediction =
-      deriveSelector want := by native_decide
+      deriveSelector want := by decide
 
 /-- 'hope' involves simplifiable comparison (variable mood). -/
 theorem hope_moodPrediction_agrees :
     DepartureKind.comparisonSimplifiable.moodPrediction =
-      deriveSelector hope := by native_decide
+      deriveSelector hope := by decide
 
 /-- 'intend' involves both comparison and eventuality abstraction
     (robust SBJV). -/
 theorem intend_moodPrediction_agrees :
     DepartureKind.comparisonAndAbstraction.moodPrediction =
-      deriveSelector intend := by native_decide
+      deriveSelector intend := by decide
 
 /-- Causatives involve eventuality abstraction (robust SBJV). -/
 theorem causative_moodPrediction_agrees :
     DepartureKind.eventualityAbstraction.moodPrediction =
-      deriveSelector English.Predicates.Verbal.make := by native_decide
+      deriveSelector English.Predicates.Verbal.make := by decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 8b. Bridge: deriveSelector → VerbalOp
@@ -514,12 +550,12 @@ ready to feed State-side glosses (`ExpState.boxLe` for subjunctive,
 /-- 'want' lifts to the subjunctive State operator. -/
 theorem want_verbalMood :
     (deriveSelector want).toVerbalOp = some .subjunctive := by
-  native_decide
+  decide
 
 /-- 'hope' is cross-linguistically variable, so it lifts to `none`. -/
 theorem hope_verbalMood :
     (deriveSelector hope).toVerbalOp = none := by
-  native_decide
+  decide
 
 /-- The robust subjunctive predicates (e.g. 'want') project to the
     `preferential` POSW component — they quantify over the best-ranked
@@ -529,7 +565,7 @@ theorem hope_verbalMood :
 theorem want_target :
     Option.map (Mood.HasTarget.target ·) (deriveSelector want).toVerbalOp
       = some .preferential := by
-  native_decide
+  decide
 
 -- ════════════════════════════════════════════════════════════════
 -- § 9. Cross-Linguistic Fragment Integration


### PR DESCRIPTION
Deep audit of `RationalAttitude.lean` (326 → 49 lines). The consumed core — `Reading` and `readingFromSize`, used by the Italian Fragment and `Studies/Grano2024.lean` — stays, with `readingFromSize` now calling `ComplementSize.isPhaseSized` instead of a hand-coded `fLevel ≥ 6`.

- `Studies/FuscoSgrizzi2026.lean` (same paper, existing study) absorbs the ex. 24 single-denotation apparatus (`CausativeAttitude` + both readings) and the four reading diagnostics; the vacuous 8-way rfl conjunction and the editorial Searle direction-of-fit bridge are dropped.
- `Studies/Grano2024.lean` absorbs the causal-self-reference semantics (`intentionHolds`/`beliefHolds`, the paper's (79)) its own prose already referenced, with the `CauseStar` alias inlined; also replaces all 24 `native_decide`s with kernel-checked `decide`.
- Dead imports cut (Doxastic, SpeechAct, Commitment, Events in the theory file); umbrella namespace flipped to bare `RationalAttitude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)