### PR TITLE
fix(Semantics/Causation): close ite instance mismatch in probSufficiency

### DIFF
--- a/Linglib/Semantics/Causation/SEM/Counterfactual.lean
+++ b/Linglib/Semantics/Causation/SEM/Counterfactual.lean
@@ -297,6 +297,7 @@ theorem probSufficiency_eq_indicator_of_deterministic
   unfold probSufficiency probOfValue
   rw [counterfactualSimulate_eq_pure_of_deterministic]
   simp only [PMF.probOfSet, PMF.toOuterMeasure_pure_apply, Set.mem_ofPred_eq]
+  congr
 
 end Causation.SEM
 


### PR DESCRIPTION
Main is red at `Counterfactual.lean:296`: `probSufficiency_eq_indicator_of_deterministic`'s terminal simp leaves `if P then 1 else 0 = if P then 1 else 0` with mismatched `Decidable` instances (classical vs derived) — latent breakage surfaced by the full untruncated local build after two cache-false-greens. `congr` closes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)