### PR TITLE
style(Semantics/Attitudes): symmetrize the anchor-sort verb types

### DIFF
--- a/Linglib/Semantics/Attitudes/ContentIndividual.lean
+++ b/Linglib/Semantics/Attitudes/ContentIndividual.lean
@@ -41,8 +41,10 @@ structure ContentIndividual (W : Type*) where
   /-- Propositional content: CONT(c) -/
   cont : W → Prop
 
-/-- An attitude verb relates an agent to a content individual at a world. -/
-abbrev AttitudeVerb (W E : Type*) := E → ContentIndividual W → W → Prop
+/-- A content-selecting verb (*say*, *believe*) relates an agent to a
+    content individual at a world — the content-sort sibling of
+    `SituationVerb`. -/
+abbrev ContentVerb (W E : Type*) := E → ContentIndividual W → W → Prop
 
 namespace ContentIndividual
 

--- a/Linglib/Semantics/Attitudes/SituationIndividual.lean
+++ b/Linglib/Semantics/Attitudes/SituationIndividual.lean
@@ -38,10 +38,20 @@ structure SituationIndividual (S : Type*) where
   /-- Situation predicate: SIT(s_i) -/
   sit : S → Prop
 
-/-- A situation-selecting verb relates an agent to a situation individual
-    at a situation. -/
-abbrev SituationVerb (S X : Type*) := X → SituationIndividual S → S → Prop
+/-- A situation-selecting verb (*be happy that*, *regret*) relates an
+    agent to a situation individual at a situation — the situation-sort
+    sibling of `ContentVerb`. -/
+abbrev SituationVerb (S E : Type*) := E → SituationIndividual S → S → Prop
 
 instance {S : Type*} : Anchor (SituationIndividual S) S :=
   ⟨SituationIndividual.sit⟩
+
+/-- Every situation predicate is the SIT of some individual, so the
+    situation-mode projection is surjective — the situation-sort analogue
+    of `ContentIndividual.cont_surjective`, making
+    `Anchor.existsClosure_ofAccessibility` applicable to situation
+    reports. -/
+theorem SituationIndividual.sit_surjective {S : Type*} :
+    Function.Surjective (SituationIndividual.sit : SituationIndividual S → S → Prop) :=
+  fun p => ⟨⟨p⟩, rfl⟩
 

--- a/Linglib/Studies/Angelopoulos2026.lean
+++ b/Linglib/Studies/Angelopoulos2026.lean
@@ -332,7 +332,7 @@ theorem pu_report_factive {S X : Type*} {verb : SituationVerb S X}
 
 /-- Content reports carry no such entailment. -/
 theorem content_report_not_factive :
-    ¬ ∀ (verb : AttitudeVerb Bool Unit) (a : Unit) (p : Bool → Prop)
+    ¬ ∀ (verb : ContentVerb Bool Unit) (a : Unit) (p : Bool → Prop)
         (w : Bool), existsClosure verb a p w → p w :=
   fun h => h (fun _ _ _ => True) () (fun _ => False) true
     ⟨⟨fun _ => False⟩, trivial, rfl⟩


### PR DESCRIPTION
Res-cluster polish from the SituationIndividual/ContentIndividual audit: `AttitudeVerb` → `ContentVerb` (it is the content-selecting sibling of `SituationVerb`, not the generic attitude-verb type), binder symmetry for `SituationVerb` (agent letter `E` matching its sibling), and the missing `sit_surjective` mirror of `cont_surjective` that makes the Hintikka-recovery theorem applicable to situation reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)