### PR TITLE
fix(Studies/NapoliNespor1976): che/lo diagnostics as admissibility

### DIFF
--- a/Linglib/Fragments/Italian/PolarityItems.lean
+++ b/Linglib/Fragments/Italian/PolarityItems.lean
@@ -92,10 +92,10 @@ def mica : Item :=
     DE/comparative environments where the speaker presupposes a contradicted
     prior belief.
 
-    [napoli-nespor-1976] §3.11 ex. 46–48: licensed under comparative
-    *non₂* alongside subjunctive co-occurrence and *neanche*-conjunction.
-    Treated by N&N as a diagnostic for underlying negation in the comparative
-    clause: where *pur* surfaces, *non₂* is licensed too. -/
+    [napoli-nespor-1976]: licensed under comparative *non₂* alongside
+    subjunctive co-occurrence and *neanche*-conjunction. Treated by N&N as
+    a diagnostic for underlying negation in the comparative clause: where
+    *pur* surfaces, *non₂* is licensed too. -/
 def pur : Item :=
   { form := "pur"
   , licensor := some .weak
@@ -107,8 +107,8 @@ def pur : Item :=
     knowledge of the listener's belief; blocked in N&N's comparative *non₂*
     on independent precision grounds.
 
-    [napoli-nespor-1976] §3.22 fn (i): *affatto* is *not* licensed by
-    bias-conditioned negation, even though it is a weak NPI elsewhere. The
+    [napoli-nespor-1976] observe in a footnote that *affatto* is *not*
+    licensed by bias-conditioned negation, though it is a weak NPI elsewhere. The
     block is semantic — *affatto* requires the listener's belief to be
     explicit, which fails N&N's "imprecise/inferred" Condition 4. The
     distributional fact is therefore *orthogonal* to NPI licensing.
@@ -133,10 +133,10 @@ def affatto : Item :=
     Boolean homomorphisms (monotone) and not NPI environments —
     `.comparativeNP` therefore licenses nothing. -/
 theorem pur_licensed_in_comparative :
-    pur.licensingContexts.contains .comparativeS = true := by decide
+    .comparativeS ∈ pur.licensingContexts := by decide
 
 theorem affatto_not_licensed_in_comparative :
-    affatto.licensingContexts.contains .comparativeS = false := by decide
+    .comparativeS ∉ affatto.licensingContexts := by decide
 
 /-! ### Pure Universal FCIs -/
 

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -1,397 +1,238 @@
 import Linglib.Pragmatics.Bias
-import Linglib.Studies.Rett2026
-import Linglib.Studies.Tsiakmakis2025
 import Linglib.Fragments.Italian.PolarityItems
 import Linglib.Semantics.Mood.Defs
 
 /-!
-# Napoli & Nespor (1976): Negatives in Comparatives [napoli-nespor-1976]
+# Napoli & Nespor (1976): Negatives in Comparatives
 
-*Language* 52(4), 811–838.
+Italian *non* appears in some comparative clauses without truth-conditional
+effect: *Maria è più intelligente di quanto non sia Carlo* 'Maria is more
+intelligent than Carlo (is)'. Earlier accounts treated this *non₂* as a
+pleonastic element ([antinucci-puglielli-1971]) or as surface evidence that
+*than*-clauses are underlyingly negative ([seuren-1969]).
+[napoli-nespor-1976] (*Language* 52(4), 811–838) reject both: *non₂* is real
+negation, licensed by a discourse condition — the speaker presupposes that the
+assertion contradicts a prior belief, the move is assertive, the matrix is
+unnegated, and neither the contradicted belief nor the construction involves
+precise knowledge. The licensing predicate is formalized once as
+`Pragmatics.Bias.BiasLicensingProfile.licenses`; this file is its first
+historical attestation, applied to the paper's Italian data. The paper's own
+implementation — a Generative Semantics abstract higher clause hosting *non₂*,
+optionally deleted — is historical; only the licensing predicate and its
+surface diagnostics are preserved.
 
-The Italian word *non* appears in some comparative clauses without
-truth-conditional effect: *Maria è più intelligente di quanto non sia
-Carlo* 'Maria is more intelligent than Carlo (is)'. The construction
-had previously been treated either as pleonastic (Antinucci & Puglielli
-1971) or as evidence that all *than*-clauses are underlyingly negative
-(Seuren 1969). [napoli-nespor-1976] reject both: *non₂* is real
-negation, but its distribution is governed by a discourse condition,
-not by the syntax of comparison.
+## Main declarations
 
-## Core Claim
-
-*Non₂* is licensed iff the speaker presupposes that their assertion
-contradicts a prior belief (their own or attributed to the addressee),
-the move is assertive, the matrix is unnegated, and the construction
-does not require precise knowledge. The four conditions are formalized
-once in `Pragmatics.Bias.BiasLicensingProfile` and consumed here; this
-study file is the first historical attestation of the predicate, applied
-to Italian comparatives.
-
-## What's Foundational vs. Historical
-
-[napoli-nespor-1976] bundles two contributions:
-
-- **Foundational (preserved):** the licensing predicate, the Dario/Paolo
-  context paradigm, the morphosyntactic diagnostics for underlying
-  negation (subjunctive co-occurrence, *pur*-NPI licensing, *neanche*-
-  conjunction, [-specific] indefinites, complementizer alternation),
-  and the cross-construction generalization to indirect questions and
-  cross-linguistic parallels (French *ne*, German modal particles).
-- **Historical (not preserved):** the Generative Semantics deep-structure
-  apparatus — abstract higher S₂ dominating S₃ with *non₂* base-generated
-  in S₃ and optionally deleted by transformation. The covert-operator
-  insight is preserved by modern verum / use-conditional / commitment-
-  update accounts ([romero-han-2004], [repp-2013],
-  [gutzmann-2015], [farkas-bruce-2010]); the deletion-rule
-  mechanism specifically is not.
-
-## Connection to Existing linglib Studies
-
-- [rett-2026] classifies Italian comparative EN as low/optional with
-  weak-NPI rejection. The N&N data refines this: optionality is
-  *contextually conditioned* (a `BiasLicensingProfile`, not a `Bool`),
-  and weak NPIs *are* licensed when the profile licenses (modulo
-  independent precision-blockers like *affatto*). See
-  `Rett2026.italianComparative` and the patches in §6 below.
-- [tsiakmakis-2025] classifies Italian comparative *non* as NEG₁
-  (apparent EN, standard negation masked). N&N's analysis is the
-  original NEG₁-style account: *non₂* is real negation in underlying
-  structure, masked at surface by deletion or by an abstract operator.
-- [greco-2020] lists *comparativeClauses* among Italian weak-EN
-  environments. N&N's *pur*-licensing data motivates this classification.
+* `noOpinionContext`, `chessContext`, `explicitCriticismContext`,
+  `complaintContext`: the dialogue paradigm probing the contradicted-belief
+  presupposition;
+* `questionedComparative` … `menoComparative`: distributional environments,
+  each isolating one licensing condition;
+* `predictedMood`, `predictedSpecificity`, `complementizerAdmissible`,
+  `cliticAdmissible`, `neancheConjunctionAdmissible`, `weakNPIAdmissible`:
+  morphosyntactic diagnostics for underlying negation;
+* `chissaSeNon`: the same profile licensing *non₂* in indirect questions.
 -/
 
 namespace NapoliNespor1976
 
 open Pragmatics.Bias
-  (BiasLicensingProfile licensedProfile blockedProfile
-   noContradictionProfile questionedProfile matrixNegatedProfile
-   preciseProfile imperativeProfile)
-open Italian.PolarityItems (pur affatto neanche)
-open Polarity (LicensingContext Item)
+open Italian.PolarityItems (pur affatto neanche
+  pur_licensed_in_comparative affatto_not_licensed_in_comparative)
+open Polarity (Item)
 
--- ════════════════════════════════════════════════════
--- § 1. The Dario/Paolo dialogue paradigm (§2)
--- ════════════════════════════════════════════════════
+/-! ### The dialogue-context paradigm
 
-/-! ### Four contexts varying the speaker's epistemic state
+Four dialogues between Dario and Paolo vary the speaker's epistemic state:
+*non₂* is felicitous exactly when the assertion contradicts a belief
+*inferred* from the interlocutor's prior discourse — infelicitous when there
+is no prior belief to contradict, and when the contradicted belief was
+explicitly stated rather than inferred. -/
 
-[napoli-nespor-1976] pp. 812–813 construct four dialogues showing
-that *non₂*'s acceptability tracks the speaker's presupposition that
-their assertion contradicts a prior belief — neither too uncertain
-(no presupposition to contradict) nor too explicit (use simple negation
-instead). -/
+/-- Dario gives no opinion of Maria or Carlo; Paolo asserts Maria > Carlo.
+No prior belief to contradict, so *non₂* is infelicitous. -/
+def noOpinionContext : BiasLicensingProfile := noContradictionProfile
 
-/-- Context (6): Dario gives no opinion of Maria or Carlo; Paolo asserts
-    Maria > Carlo. No prior belief to contradict ⇒ *non₂* infelicitous. -/
-def context6 : BiasLicensingProfile := noContradictionProfile
+/-- Dario implies Carlo would beat Maria at chess; Paolo asserts Maria is more
+intelligent. The contradicted belief is inferred, so *non₂* may appear. -/
+def chessContext : BiasLicensingProfile := licensedProfile
 
-/-- Context (7): Dario implies Carlo > Maria at chess; Paolo asserts
-    Maria more intelligent. Inferred contradiction ⇒ *non₂* may appear. -/
-def context7 : BiasLicensingProfile := licensedProfile
+/-- Dario explicitly calls Maria stupid; Paolo disagrees. The contradicted
+belief is explicitly stated rather than inferred, failing the
+imprecise/inferred condition, so *non₂* is out. -/
+def explicitCriticismContext : BiasLicensingProfile := preciseProfile
 
-/-- Context (8): Dario *explicitly* says Maria is dumb; Paolo disagrees.
-    The contradiction is too explicit; speaker should use simple negation,
-    not *non₂*. Modeled here as failing the imprecise/inferred condition. -/
-def context8 : BiasLicensingProfile := preciseProfile
+/-- Dario's complaint implies he expects Maria cannot help; Paolo asserts she
+is smart enough to ask. The contradicted belief is inferred: *non₂* is used. -/
+def complaintContext : BiasLicensingProfile := licensedProfile
 
-/-- Context (9): Dario's complaint implies he expects Maria can't help;
-    Paolo asserts Maria smart enough to ask. Inferred contradiction ⇒
-    *non₂* used. -/
-def context9 : BiasLicensingProfile := licensedProfile
+theorem noOpinion_blocks : ¬ noOpinionContext.licenses := no_contradiction_blocks
+theorem chess_licenses : chessContext.licenses := licensed_licenses
+theorem explicitCriticism_blocks : ¬ explicitCriticismContext.licenses := precise_blocks
+theorem complaint_licenses : complaintContext.licenses := licensed_licenses
 
-/-- Predictions: *non₂* infelicitous in (6), licensed in (7), blocked
-    in (8), licensed in (9). Each follows by `decide` from the licensing
-    predicate in `Pragmatics.Bias`. -/
-theorem context6_blocks : ¬ context6.licenses := by decide
-theorem context7_licenses : context7.licenses := by decide
-theorem context8_blocks : ¬ context8.licenses := by decide
-theorem context9_licenses : context9.licenses := by decide
+/-! ### Distributional environments
 
--- ════════════════════════════════════════════════════
--- § 2. Distributional environments (§2.1, §2.2, §2.3, §3.22)
--- ════════════════════════════════════════════════════
+Construction-level environments each isolate one licensing condition (the
+contradicted-belief condition is contextual and is witnessed by the dialogue
+paradigm above); equality and explicit-degree comparatives both fail the
+precision condition. *Meno*-comparatives are the positive control. -/
 
-/-! ### Five distributional environments, each isolating one axis
-
-[napoli-nespor-1976] demonstrates each licensing condition by
-exhibiting an environment where exactly that condition fails. -/
-
-/-- §2.1 ex. 10b: *È più intelligente di quanto non sia Carlo?*
-    'Is she more intelligent than Carlo is?' — questioned comparative
-    blocks *non₂*. Speaker cannot simultaneously question and contradict. -/
+/-- *È più intelligente di quanto non sia Carlo?* 'Is she more intelligent
+than Carlo?': questioning is non-assertive, blocking *non₂*. -/
 def questionedComparative : BiasLicensingProfile := questionedProfile
 
-/-- §2.2 ex. 18a: *Maria non è più intelligente di quanto non sia Carlo*
-    'Maria is not more intelligent than Carlo is' — matrix-negated
-    blocks *non₂*. -/
+/-- *Maria non è più intelligente di quanto non sia Carlo*: a negated matrix
+blocks *non₂*. -/
 def matrixNegatedComparative : BiasLicensingProfile := matrixNegatedProfile
 
-/-- §2.3 ex. 22b: *Maria è tanto intelligente *quanto non sia Carlo*
-    'Maria is as intelligent as Carlo is' — equality (*tanto…quanto*)
-    requires precise knowledge incompatible with the inferred-belief
-    presupposition. -/
+/-- Equality comparatives (*Maria è tanto intelligente quanto è Carlo*) demand
+explicit, precise knowledge of the compared degrees, while *non₂* demands
+inferred, imprecise knowledge — so the two are mutually exclusive. -/
 def equalityComparative : BiasLicensingProfile := preciseProfile
 
-/-- §3.22 ex. 32b, 33b: *Maria è {molto più / due metri più} intelligente
-    di quanto *tu non creda* — explicit precision modifiers fail the
-    imprecise condition. -/
+/-- Explicit degree modifiers (*molto più intelligente*, *due metri più alta*)
+require precise knowledge of the degree gap, failing the imprecise
+condition. -/
 def precisionComparative : BiasLicensingProfile := preciseProfile
 
-/-- §2.3 ex. 26b: *Maria è meno intelligente di quanto tu non creda*
-    'Maria is less intelligent than you think' — *meno* (less) allows
-    *non₂*. This is N&N's sanity check against Seuren 1969: if *non₂*
-    were just "negation triggered by than-clause", it should appear
-    equally with *meno*; in fact it does, but only under the same
-    contextual conditions as with *più*. -/
+/-- *Maria è meno intelligente di quanto tu non creda* 'Maria is less
+intelligent than you think': *meno*-comparatives admit *non₂* under the same
+contextual conditions as *più*. Negated equality comparatives are semantically
+close to *meno*-comparatives yet reject *non₂*, so the equality restriction
+cannot reduce to equality linking two similar things (contra [seuren-1969]
+and [antinucci-puglielli-1971]); it follows from matrix negation and the
+precision condition. -/
 def menoComparative : BiasLicensingProfile := licensedProfile
 
-theorem questioned_blocks_non2 : ¬ questionedComparative.licenses := by decide
-theorem matrix_negated_blocks_non2 : ¬ matrixNegatedComparative.licenses := by decide
-theorem equality_blocks_non2 : ¬ equalityComparative.licenses := by decide
-theorem precision_blocks_non2 : ¬ precisionComparative.licenses := by decide
-theorem meno_licenses_non2 : menoComparative.licenses := by decide
+theorem questioned_blocks_non2 : ¬ questionedComparative.licenses := questioned_blocks
+theorem matrix_negated_blocks_non2 : ¬ matrixNegatedComparative.licenses := matrix_negated_blocks
+theorem equality_blocks_non2 : ¬ equalityComparative.licenses := precise_blocks
+theorem precision_blocks_non2 : ¬ precisionComparative.licenses := precise_blocks
+theorem meno_licenses_non2 : menoComparative.licenses := licensed_licenses
 
--- ════════════════════════════════════════════════════
--- § 3. Morphosyntactic diagnostics for underlying negation
--- ════════════════════════════════════════════════════
+/-! ### Morphosyntactic diagnostics for underlying negation
 
-/-! ### Predictions derived from the licensing profile
+Six surface diagnostics witness underlying negation in the comparative
+clause. Two are forced choices — mood morphology and indefinite specificity.
+Four are admissibility asymmetries — complementizer *che*, predicative clitic
+*lo*, the weak NPI *pur*, and *neanche*-conjunction: the bias-marked
+alternant is possible only under licensed *non₂*, while the default
+(*di quanto*, clitic-less repetition) remains available throughout. The NPI
+diagnostics are derived from the Italian Fragment's `licensingContexts`
+registry. -/
 
-[napoli-nespor-1976] §3 marshals six independent diagnostics for
-the presence of underlying negation in the comparative clause. Each
-diagnostic targets a different surface correlate (mood morphology, NPI
-surface form, indefinite specificity, conjunction admissibility,
-complementizer choice, predicative clitic) and so returns a value of a
-*different type* — flattening them all to `Bool := p.licenses` would
-collapse six empirically distinct probes into one fact. The agreement
-theorem `licensed_diagnostics_agree` collects the six predictions on the
-licensed profile rather than asserting they are tautologically equal. -/
-
-/-- Specificity restriction on embedded indefinites. Without *non₂* an
-    indefinite in the *than*-clause is [±specific]; with *non₂* it is
-    restricted to [−specific] under the scope of the underlying negation.
-    [napoli-nespor-1976] §3.11 ex. 44–45. -/
+/-- Specificity of indefinites embedded in the *than*-clause. -/
 inductive SpecificityProfile where
-  | unrestricted    -- [+specific] reading available
-  | nonspecificOnly -- restricted to [−specific] (negation-scope)
+  /-- Both [+specific] and [−specific] readings available. -/
+  | unrestricted
+  /-- Restricted to [−specific] under the scope of underlying negation. -/
+  | nonspecificOnly
   deriving DecidableEq, Repr
 
-/-- Complementizer choice in Italian comparatives.
-    *Di quanto* is the standard *than*-complementizer; *che* surfaces
-    when the abstract higher S of [napoli-nespor-1976] §3.24 is
-    present, which co-varies with *non₂*. -/
+/-- The Italian comparative complementizers. -/
 inductive ComplementizerChoice where
-  | che      -- bias-licensed alternant
-  | diQuanto -- default
+  /-- The default *than*-complementizer. -/
+  | diQuanto
+  /-- The alternant admissible only under *non₂*. -/
+  | che
   deriving DecidableEq, Repr
 
-/-- Predicate-clitic *lo* presence. §3.25 treats the clitic as genuinely
-    binary (present iff the abstract higher S licenses *non₂*), but the
-    two outcomes carry distinct surface morphology — `Bool` would lose
-    that contrast at the type level. -/
+/-- Presence of the predicative clitic *lo* substituting for a repeated
+predicate adjective in the *than*-clause. -/
 inductive CliticPresence where
-  | present  -- clitic *lo* surfaces
-  | absent   -- no clitic
+  | present
+  | absent
   deriving DecidableEq, Repr
 
-/-- §3.21: grammatical mood of the *than*-clause. Subjunctive surfaces
-    iff *non₂* is underlyingly present (modulo lexical mood control by
-    *credere* etc., abstracted away here). Returning `Mood.Grammatical`
-    rather than `Bool` connects this prediction to the mood semantics in
-    `Semantics/Mood/`. -/
-def predictsGrammatical (p : BiasLicensingProfile) : Mood.Grammatical :=
+/-- Mood of the *than*-clause: subjunctive exactly when *non₂* is underlyingly
+present, indicative otherwise (lexical mood control by *credere* etc. is
+abstracted away). Surface subjunctive without *non* is derived by the paper's
+optional deletion of an underlying *non₂*. -/
+def predictedMood (p : BiasLicensingProfile) : Mood.Grammatical :=
   if p.licenses then .subjunctive else .indicative
 
-/-- §3.11 ex. 46–48: under bias-licensed negation the comparative admits
-    a weak NPI on its surface; the canonical witness in the Italian
-    Fragment is `pur`. Returning `Option String` carries the predicted
-    surface form (or `none` when blocked) rather than collapsing to a
-    coarse `Bool`. The form string is derived from the Fragment entry to
-    keep the connection true by construction. -/
-def predictsWeakNPISurface (p : BiasLicensingProfile) : Option String :=
-  if p.licenses then some pur.form else none
-
-/-- §3.11 ex. 44–45: specificity restriction on embedded indefinites.
-    Bias-licensed comparatives restrict the indefinite to [−specific];
-    blocked profiles leave it unrestricted. -/
-def predictsSpecificity (p : BiasLicensingProfile) : SpecificityProfile :=
+/-- Embedded indefinites are restricted to [−specific] under licensed *non₂*
+and unrestricted otherwise. -/
+def predictedSpecificity (p : BiasLicensingProfile) : SpecificityProfile :=
   if p.licenses then .nonspecificOnly else .unrestricted
 
-/-- §3.11 ex. 50–52: *neanche*-conjunction is grammatical iff the first
-    conjunct is underlyingly negated. The Fragment registers *neanche*
-    as requiring `.negation` among its licensing contexts — the prediction
-    is **derived** from that registry fact in conjunction with the bias
-    profile, so changing the *neanche* lexical entry would break this
-    prediction by construction rather than requiring a separate update
-    here. -/
-def predictsNeancheConjunction (p : BiasLicensingProfile) : Prop :=
-  p.licenses ∧ neanche.licensingContexts.contains .negation = true
+/-- Complementizer admissibility: *di quanto* occurs in comparatives with and
+without *non₂*; *che* only with it. -/
+def complementizerAdmissible (p : BiasLicensingProfile) :
+    ComplementizerChoice → Prop
+  | .diQuanto => True
+  | .che => p.licenses
 
-instance (p : BiasLicensingProfile) : Decidable (predictsNeancheConjunction p) :=
-  inferInstanceAs (Decidable (_ ∧ _))
+/-- Clitic admissibility: clitic-less comparatives are always available; *lo*
+is possible only under *non₂*, and optional there. -/
+def cliticAdmissible (p : BiasLicensingProfile) : CliticPresence → Prop
+  | .present => p.licenses
+  | .absent => True
 
-/-- §3.24: the complementizer *che* (vs. *di quanto*) is licensed iff
-    the abstract higher S is present, which co-varies with *non₂*.
-    Returning `ComplementizerChoice` exposes both alternants rather than
-    encoding "*che* present" as a Bool. -/
-def predictsComplementizer (p : BiasLicensingProfile) : ComplementizerChoice :=
-  if p.licenses then .che else .diQuanto
+/-- *Neanche*-conjunction ('and not even …') is admissible iff its host
+clause is negated at some underlying level — in a comparative, iff *non₂* is
+licensed. The negation requirement is the Fragment registry fact that
+*neanche* lists `.negation` among its licensing contexts. -/
+def neancheConjunctionAdmissible (p : BiasLicensingProfile) : Prop :=
+  p.licenses ∧ .negation ∈ neanche.licensingContexts
 
-/-- §3.25: clitic *lo* substituting for the predicate adjective is
-    licensed iff the comparative has the abstract S structure (*non₂*
-    present). Returns `CliticPresence` rather than `Bool` to keep the
-    surface alternants distinguishable at the type level. -/
-def predictsLoClitic (p : BiasLicensingProfile) : CliticPresence :=
-  if p.licenses then .present else .absent
+/-- The mood diagnostic tracks the licensing predicate: the *than*-clause is
+subjunctive exactly on licensed profiles. -/
+theorem predictedMood_eq_subjunctive_iff (p : BiasLicensingProfile) :
+    predictedMood p = .subjunctive ↔ p.licenses := by
+  by_cases h : p.licenses <;> simp [predictedMood, h]
 
-/-- The six diagnostics agree on the **licensed** profile: each surface
-    correlate takes its bias-marked value. The conjunction below is the
-    theoretical unification [napoli-nespor-1976] §3 argues for —
-    one licensing predicate explains all six surface diagnostics. The
-    *neanche*-conjunction conjunct is non-trivial: it factors through
-    the Italian Fragment's `neanche.licensingContexts` and needs `decide`
-    on the registry data. -/
-theorem licensed_diagnostics_agree :
-    predictsGrammatical licensedProfile = .subjunctive ∧
-    predictsWeakNPISurface licensedProfile = some pur.form ∧
-    predictsSpecificity licensedProfile = .nonspecificOnly ∧
-    predictsNeancheConjunction licensedProfile ∧
-    predictsComplementizer licensedProfile = .che ∧
-    predictsLoClitic licensedProfile = .present := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+/-- The specificity diagnostic tracks the licensing predicate. -/
+theorem predictedSpecificity_eq_nonspecificOnly_iff (p : BiasLicensingProfile) :
+    predictedSpecificity p = .nonspecificOnly ↔ p.licenses := by
+  by_cases h : p.licenses <;> simp [predictedSpecificity, h]
 
-/-- Dual: on a blocked profile every diagnostic returns its non-bias-marked
-    value. Together with `licensed_diagnostics_agree` this witnesses that
-    the six diagnostics are genuinely *predictive* (their values vary
-    with the bias profile) rather than constant functions. -/
-theorem blocked_diagnostics_agree :
-    predictsGrammatical blockedProfile = .indicative ∧
-    predictsWeakNPISurface blockedProfile = none ∧
-    predictsSpecificity blockedProfile = .unrestricted ∧
-    ¬ predictsNeancheConjunction blockedProfile ∧
-    predictsComplementizer blockedProfile = .diQuanto ∧
-    predictsLoClitic blockedProfile = .absent := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+/-- *Neanche*-conjunction is admissible under licensed *non₂*; the second
+conjunct is the Fragment's registry datum. -/
+theorem neanche_conjunction_with_non2 :
+    neancheConjunctionAdmissible licensedProfile :=
+  ⟨licensed_licenses, by decide⟩
 
--- ════════════════════════════════════════════════════
--- § 4. The pur / affatto contrast (§3.11 fn 6)
--- ════════════════════════════════════════════════════
+/-! ### The pur / affatto contrast
 
-/-! ### Why some weak NPIs are licensed and others blocked
+The weak NPI *pur* is licensed in *non₂*-comparatives; the weak NPI *affatto*
+is blocked, because *affatto* requires precise knowledge of the contradicted
+belief — incompatible with the imprecise/inferred licensing condition (a
+footnote observation of [napoli-nespor-1976]). The contrast is witnessed at
+the lexical layer: `pur.licensingContexts` lists the clausal-comparative slot
+`.comparativeS` while `affatto`'s does not, so the predictions below are
+derived from the Fragment registry. -/
 
-[napoli-nespor-1976] §3.11 ex. 46–48 show that *pur* (weak NPI) is
-licensed in *non₂*-comparatives. §3.22 fn (i) shows that *affatto* (also
-a weak NPI) is *blocked*. The contrast is not about NPI licensing per se:
-*affatto* requires *precise* knowledge of the listener's belief, which
-fails N&N's imprecise condition. The block is semantic, not licensing-
-theoretic.
+/-- A weak NPI is admissible in a bias-conditioned comparative iff its
+registry lists the clausal-comparative slot `.comparativeS` (surface
+NP-comparatives are not NPI environments) and the profile licenses *non₂*. -/
+def weakNPIAdmissible (p : BiasLicensingProfile) (npi : Item) : Prop :=
+  p.licenses ∧ .comparativeS ∈ npi.licensingContexts
 
-The `weakNPIs` field of `Rett2026.ENDatum` (refactored from `Bool` to a
-`WeakNPILicensing` sum type for exactly this reason) classifies
-italianComparative as `.selective [pur.form]`: it licenses *some* weak
-NPIs (*pur*) and blocks others (*affatto*) for *orthogonal* reasons.
+/-- *Pur* is admissible wherever *non₂* is licensed; the registry conjunct is
+the Fragment's `pur_licensed_in_comparative`. -/
+theorem pur_admissible_with_non2 : weakNPIAdmissible licensedProfile pur :=
+  ⟨licensed_licenses, pur_licensed_in_comparative⟩
 
-The two NPIs are registered in the Italian Fragment as
-`Italian.PolarityItems.pur` and
-`Italian.PolarityItems.affatto`. The contrast is **already**
-witnessed at the lexical layer (the structural theorems
-`pur_licensed_in_comparative` and `affatto_not_licensed_in_comparative`
-in the Fragment), so this study file just consumes those facts and
-shows them follow from the bias profile. -/
-
-/-- A weak NPI from the Italian Fragment is licensed in a bias-conditioned
-    negation environment iff (a) its registry lists `.comparativeS` (the
-    clausal-comparative slot — N&N's *non₂* originates in subjunctive
-    clausal complements, not surface NP-comparatives) among its licensing
-    contexts AND (b) the bias profile licenses. The first conjunct rules
-    out *affatto* (registry-blocked); the second rules out unlicensed
-    contexts.
-
-    `.comparativeS` rather than `.comparativeNP` because surface NP-
-    comparatives are not NPI environments ([hoeksema-1983] §3.6). -/
-def predictsWeakNPI (p : BiasLicensingProfile) (npi : Item) : Prop :=
-  p.licenses ∧ npi.licensingContexts.contains .comparativeS = true
-
-instance (p : BiasLicensingProfile) (npi : Item) :
-    Decidable (predictsWeakNPI p npi) :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- *Pur* is licensed in any context where *non₂* is licensed.
-    Combines `pur_licensed_in_comparative` from the Italian Fragment with
-    the bias profile's licensing predicate. -/
-theorem pur_licensed_with_non2 : predictsWeakNPI licensedProfile pur := by decide
-
-/-- *Affatto* is *never* licensed in *non₂*-comparatives — the block is
-    *registered in the lexical entry itself* (`affatto.licensingContexts`
-    excludes `.comparativeS` per [napoli-nespor-1976] §3.22 fn 6). The
-    bias profile's licensing status is irrelevant: the Fragment's
-    distributional fact alone settles the case.
-
-    This makes the N&N contrast structural — derived from the lexical
-    `licensingContexts` field — rather than stipulated by an inline
-    inductive in this study file. -/
+/-- *Affatto* is inadmissible in *non₂*-comparatives whatever the bias
+profile: the block is registered in the lexical entry itself. -/
 theorem affatto_blocked_in_non2 (p : BiasLicensingProfile) :
-    ¬ predictsWeakNPI p affatto := by
-  intro ⟨_, h⟩
-  rw [Italian.PolarityItems.affatto_not_licensed_in_comparative] at h
-  exact Bool.false_ne_true h
+    ¬ weakNPIAdmissible p affatto :=
+  λ ⟨_, h⟩ => affatto_not_licensed_in_comparative h
 
--- ════════════════════════════════════════════════════
--- § 5. Cross-construction generalization (§4)
--- ════════════════════════════════════════════════════
+/-! ### Beyond comparatives: indirect questions
 
-/-! ### *Non₂* outside comparatives: indirect questions
+The same *non₂* appears in indirect questions where the speaker presupposes
+the negated proposition is contrary to expectation: *Chissà se non vale la
+pena di comprarlo* 'Who knows if it's (not) worth buying it' suggests the
+speaker expected it to be worth buying. The licensing condition is a property
+of the discourse move, not of comparative syntax. -/
 
-[napoli-nespor-1976] §4 ex. 88–91 show that the same *non₂* appears
-in indirect questions where the speaker presupposes the negated
-proposition is contrary to expectation: *Chissà se non vale la pena di
-comprarlo* 'Who knows if it's not worth buying it' (suggests the
-speaker expects it to be worth buying).
-
-The licensing profile is the same. This is the foundational insight
-that makes N&N's contribution a general predicate rather than a
-construction-specific rule. -/
-
-/-- *Chissà se non…* — indirect question with biased negation.
-    Same licensing profile as the basic comparative. -/
+/-- *Chissà se non…*: indirect question with bias-conditioned negation, same
+licensing profile as the licensed comparative contexts. -/
 def chissaSeNon : BiasLicensingProfile := licensedProfile
 
-theorem chissa_licenses_non2 : chissaSeNon.licenses := by decide
-
-/-- The licensing profile is *invariant under construction type*: the
-    same profile that licenses comparative *non₂* also licenses indirect-
-    question *non₂*. This is why N&N's analysis generalizes; it is also
-    the prediction we want for parallel phenomena (French *ne* in biased
-    contexts, etc.). -/
-theorem licensing_invariant_across_constructions :
-    context7.licenses ↔ chissaSeNon.licenses := Iff.rfl
-
--- ════════════════════════════════════════════════════
--- § 6. Bridge to Rett2026: refining italianComparative
--- ════════════════════════════════════════════════════
-
-/-! ### Refining `Rett2026.italianComparative.isOptional`
-
-`Rett2026.italianComparative.isOptional := true` is technically correct
-but coarse: optionality is *contextually conditioned* on a bias profile,
-not free. The function below derives `isOptional` from a bias profile,
-restoring the connection that the `Bool` field flattens. -/
-
-/-- Derived optionality: a construction is "optional" iff its licensing
-    profile is satisfied by some context but not all. For the
-    `BiasLicensingProfile` paradigm this is automatically true (the
-    licensed/blocked profiles witness both polarities). -/
-theorem bias_paradigm_is_optional :
-    licensedProfile.licenses ∧ ¬ blockedProfile.licenses := by
-  refine ⟨?_, ?_⟩ <;> decide
-
-/-- Bridge to [rett-2026]: the `italianComparative` datum's
-    `isOptional` field reflects exactly this contextual conditioning. -/
-theorem rett_italianComparative_optionality_grounded :
-    Rett2026.italianComparative.isOptional = true ∧
-    licensedProfile.licenses ∧ ¬ blockedProfile.licenses := by
-  refine ⟨rfl, ?_, ?_⟩ <;> decide
+theorem chissa_licenses_non2 : chissaSeNon.licenses := licensed_licenses
 
 end NapoliNespor1976

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -102,10 +102,10 @@ structure ENDatum where
       cases like Italian *non₂*-comparatives that license *some* weak
       NPIs (*pur*) but block others (*affatto*) for orthogonal semantic
       reasons (the precision requirement on *affatto* is incompatible
-      with bias-conditioned negation's imprecise condition;
-      [napoli-nespor-1976] §3.22 fn 6, and the Italian Fragment's
-      `affatto.licensingContexts` registry, which excludes
-      `.comparative`). -/
+      with bias-conditioned negation's imprecise condition; noted in a
+      footnote of [napoli-nespor-1976], and registered in the Italian
+      Fragment's `affatto.licensingContexts`, which excludes
+      `.comparativeS`). -/
   licensedNPIForms : List String
   /-- Manner implicature triggered by EN (if any) -/
   mannerEffect : Option MannerEffect := none
@@ -168,11 +168,11 @@ def spanishComparative : ENDatum :=
       §2). The Bool here is the satisfiability of the licensing profile
       across contexts, not free choice in any single context.
     - `licensedNPIForms = [pur.form]`: the weak NPI *pur* is licensed
-      under *non₂*-comparatives ([napoli-nespor-1976] §3.11 ex.
-      46–48), but *affatto* is blocked for orthogonal semantic reasons
-      (precision requirement incompatible with the imprecise/inferred
-      presupposition, §3.22 fn 6). The list encodes the asymmetry that
-      the previous `Bool` field flattened. -/
+      under *non₂*-comparatives ([napoli-nespor-1976]), but *affatto*
+      is blocked for orthogonal semantic reasons (a precision requirement
+      incompatible with the imprecise/inferred presupposition, noted in
+      a footnote of [napoli-nespor-1976]). The list encodes the asymmetry
+      that the previous `Bool` field flattened. -/
 def italianComparative : ENDatum :=
   { language := "Italian", construction := "più ... di quanto"
   , constructionType := .comparative

--- a/references.bib
+++ b/references.bib
@@ -3801,6 +3801,31 @@
   role      = {cited},
   validated = {true},
   sources   = {Studies/NapoliNespor1976.lean}
+}% REF: Seuren, P. A. M. (1969). Operators and Nucleus. Cambridge University Press.
+@book{seuren-1969,
+  author    = {Seuren, Pieter A. M.},
+  year      = {1969},
+  title     = {Operators and Nucleus: A Contribution to the Theory of Grammar},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  subfield  = {semantics/compositional},
+  role      = {cited},
+  validated = {true},
+  sources   = {Studies/NapoliNespor1976.lean}
+}% REF: Antinucci, F. & Puglielli, A. (1971). Struttura della quantificazione. In Medici & Simone (eds.), Grammatica trasformazionale italiana. Bulzoni. Fields transcribed from the reference list of napoli-nespor-1976; chapter title/pages not independently verified.
+@incollection{antinucci-puglielli-1971,
+  author    = {Antinucci, Francesco and Puglielli, Annarita},
+  year      = {1971},
+  title     = {Struttura della quantificazione},
+  booktitle = {Grammatica trasformazionale italiana},
+  editor    = {Medici, Mario and Simone, Raffaele},
+  publisher = {Bulzoni},
+  address   = {Roma},
+  pages     = {47--62},
+  subfield  = {semantics/compositional},
+  role      = {cited},
+  validated = {false},
+  sources   = {Studies/NapoliNespor1976.lean}
 }% REF: Schank, R.C. & Abelson, R.P. (1977). Scripts, Plans, Goals and Understanding.
 @incollection{schank-abelson-1977,
   author    = {Schank, R.C. and Abelson, R.P.},


### PR DESCRIPTION
Deep-audit fix pass for `Studies/NapoliNespor1976.lean`.

- *che*/*lo* diagnostics restated as admissibility: the paper licenses *di quanto* and clitic-less forms with and without *non₂*, so the old forced-value encodings contradicted the file's own examples.
- Forward bridge to Rett 2026 and unused Tsiakmakis 2025 import removed (chronology rule); re-proofs of `Pragmatics.Bias` theorems replaced by term references; vacuous `Iff.rfl` invariance theorem dropped.
- Unverifiable example/footnote-number citations replaced with content descriptions here, in the Italian Fragment, and in Rett2026; `seuren-1969` + `antinucci-puglielli-1971` added to the bib; Fragment NPI theorems restated with `∈`.