### PR TITLE
refactor(Features/LicensingContext): clausal/phrasal comparative slots

### DIFF
--- a/Linglib/Features/Indefinite.lean
+++ b/Linglib/Features/Indefinite.lean
@@ -120,14 +120,14 @@ def HaspelmathFunction.isFC : HaspelmathFunction → Bool
     polarity-relevant realization — although the same environments host plain
     irrealis uses of non-polarity indefinites; both comparative rows realize
     the standard-of-comparison function regardless of NPI-licensability
-    (`comparativeNP` licenses no NPIs, [hoeksema-1983]). -/
+    (`phrasalComparative` licenses no NPIs, [hoeksema-1983]). -/
 def _root_.Polarity.LicensingContext.haspelmathFunction :
     Polarity.LicensingContext → Option HaspelmathFunction
   | .negation => some .directNeg
   | .withoutClause | .doubtVerb | .denyVerb => some .indirectNeg
   | .question => some .question
   | .conditionalAntecedent => some .conditional
-  | .comparativeS | .comparativeNP => some .comparative
+  | .clausalComparative | .phrasalComparative => some .comparative
   | .modalPossibility | .modalNecessity | .imperative | .generic
   | .freeRelative => some .freeChoice
   | _ => none

--- a/Linglib/Features/LicensingContext.lean
+++ b/Linglib/Features/LicensingContext.lean
@@ -30,7 +30,7 @@ both import from `Features/`, no peer-layer crossings.
 ## Framework commitment
 
 The 22-case enum is theory-laden in its *naming* (constructor names
-like `adversative`, `doubtVerb`, `denyVerb`, `comparativeS` reflect
+like `adversative`, `doubtVerb`, `denyVerb`, `clausalComparative` reflect
 specific traditions' classification of contexts), but the cases
 themselves enumerate empirically-attested licensing environments any
 framework needs to talk about. The DE/anti-additive/anti-morphic
@@ -67,12 +67,12 @@ inductive LicensingContext where
   | withoutClause    -- "without" PPs
   | onlyFocus        -- Focus of "only"
   | question          -- Questions (for some NPIs)
-  | comparativeNP     -- surface "taller than NP" — Boolean homomorphism, monotone increasing,
+  | phrasalComparative     -- surface "taller than NP" — Boolean homomorphism, monotone increasing,
                       -- and per [hoeksema-1983] *not* an NPI environment.
                       -- Surface NPIs in "than NP" arise from a covert clausal source
                       -- (modern: [bhatt-pancheva-2004] interval reduction) — list
-                      -- such NPIs under `.comparativeS`, not here.
-  | comparativeS      -- "taller than S is" — anti-additive ([hoeksema-1983], refined
+                      -- such NPIs under `.clausalComparative`, not here.
+  | clausalComparative      -- "taller than S is" — anti-additive ([hoeksema-1983], refined
                       -- in interval semantics by [bhatt-pancheva-2004], [heim-2006])
   | superlative       -- "the most", "the least"
   | tooTo            -- "too ADJ to VP"

--- a/Linglib/Fragments/English/PolarityItems.lean
+++ b/Linglib/Fragments/English/PolarityItems.lean
@@ -47,7 +47,7 @@ def ever : Item :=
   , baseForce := .temporal
   , licensingContexts :=
       [ .negation, .nobody, .conditionalAntecedent, .question
-      , .superlative, .comparativeS, .onlyFocus, .adversative ]
+      , .superlative, .clausalComparative, .onlyFocus, .adversative ]
   , scalarDirection := some .strengthening
   , alternativeType := .domain }
 

--- a/Linglib/Fragments/Italian/PolarityItems.lean
+++ b/Linglib/Fragments/Italian/PolarityItems.lean
@@ -100,7 +100,7 @@ def pur : Item :=
   { form := "pur"
   , licensor := some .weak
   , baseForce := .degree
-  , licensingContexts := [.negation, .comparativeS]
+  , licensingContexts := [.negation, .clausalComparative]
   , scalarDirection := some .strengthening }
 
 /-- *affatto* ("at all", "completely") — weak NPI requiring *precise*
@@ -118,25 +118,25 @@ def affatto : Item :=
   { form := "affatto"
   , licensor := some .weak
   , baseForce := .degree
-  , licensingContexts := [.negation]  -- not .comparativeS: blocked by precision
+  , licensingContexts := [.negation]  -- not .clausalComparative: blocked by precision
   , scalarDirection := some .strengthening }
 
 /-- N&N's central diagnostic: *pur* is licensed in comparative-clause
     contexts (which encode bias-conditioned negation in Italian), *affatto*
     is not. The contrast is structural in the registry — *pur*'s
-    `licensingContexts` includes `.comparativeS` while *affatto*'s does
+    `licensingContexts` includes `.clausalComparative` while *affatto*'s does
     not, so the Italian Fragment alone witnesses the distributional
     contrast that motivated the *non₂* analysis.
 
-    `.comparativeS` (clausal-comparative) is the relevant slot:
+    `.clausalComparative` is the relevant slot:
     [hoeksema-1983] establishes that surface NP-comparatives are
     Boolean homomorphisms (monotone) and not NPI environments —
-    `.comparativeNP` therefore licenses nothing. -/
+    `.phrasalComparative` therefore licenses nothing. -/
 theorem pur_licensed_in_comparative :
-    .comparativeS ∈ pur.licensingContexts := by decide
+    .clausalComparative ∈ pur.licensingContexts := by decide
 
 theorem affatto_not_licensed_in_comparative :
-    .comparativeS ∉ affatto.licensingContexts := by decide
+    .clausalComparative ∉ affatto.licensingContexts := by decide
 
 /-! ### Pure Universal FCIs -/
 

--- a/Linglib/Fragments/Mandarin/PolarityItems.lean
+++ b/Linglib/Fragments/Mandarin/PolarityItems.lean
@@ -42,7 +42,7 @@ def shei : Item :=
   , freeChoice := true
   , baseForce := .existential
   , licensingContexts :=
-      [ .question, .conditionalAntecedent, .comparativeS
+      [ .question, .conditionalAntecedent, .clausalComparative
       , .modalPossibility, .modalNecessity, .imperative, .generic ]
   , scalarDirection := some .strengthening }
 
@@ -57,7 +57,7 @@ def shenme : Item :=
   , freeChoice := true
   , baseForce := .existential
   , licensingContexts :=
-      [ .negation, .question, .conditionalAntecedent, .comparativeS
+      [ .negation, .question, .conditionalAntecedent, .clausalComparative
       , .modalPossibility, .modalNecessity, .imperative, .generic ]
   , scalarDirection := some .strengthening }
 
@@ -85,7 +85,7 @@ def sheiDou : Item :=
 /-- *rènhé* (任何 'any') — free-choice determiner, mainly with the adverb
     *dōu*: free choice under modals (*Rènhé shíhou nǐ dōu kěyǐ lái* 'You
     can come anytime', A270), comparatives (A271, a *bǐ* NP-comparative,
-    listed under `comparativeS` per the covert-clausal routing convention
+    listed under `clausalComparative` per the covert-clausal routing convention
     of `Polarity.LicensingContext`), and direct negation (A272); the
     superordinate-negation use (A273) has no matching context row.
     Etymologically *rèn* 'allow; appoint' + old interrogative *hé* 'what'
@@ -95,7 +95,7 @@ def renhe : Item :=
   , licensor := some .weak
   , freeChoice := true
   , baseForce := .existential
-  , licensingContexts := [.negation, .modalPossibility, .comparativeS]
+  , licensingContexts := [.negation, .modalPossibility, .clausalComparative]
   , scalarDirection := some .strengthening }
 
 /-! ### Verification -/

--- a/Linglib/Fragments/Quechua/PolarityItems.lean
+++ b/Linglib/Fragments/Quechua/PolarityItems.lean
@@ -24,7 +24,7 @@ def piPis : Item :=
   , freeChoice := true
   , baseForce := .existential
   , licensingContexts :=
-      [.negation, .question, .conditionalAntecedent, .comparativeS,
+      [.negation, .question, .conditionalAntecedent, .clausalComparative,
        .modalPossibility, .imperative, .generic]
   , scalarDirection := some .strengthening
   , morphology := .indefPlusEven }

--- a/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
+++ b/Linglib/Fragments/Slavic/Russian/PolarityItems.lean
@@ -39,7 +39,7 @@ def ktoLibo : Item :=
   { form := "кто-либо (kto-libo)"
   , licensor := some .weak
   , baseForce := .existential
-  , licensingContexts := [.question, .conditionalAntecedent, .negation, .comparativeS]
+  , licensingContexts := [.question, .conditionalAntecedent, .negation, .clausalComparative]
   , scalarDirection := some .strengthening }
 
 /-! ### Strict-NC *ни-* words (the direct-negation series) -/

--- a/Linglib/Semantics/Polarity/Licensing.lean
+++ b/Linglib/Semantics/Polarity/Licensing.lean
@@ -164,17 +164,17 @@ def LicensingContext.properties : LicensingContext → ContextProperties
       { strawsonSignature := .anti, mechanism := .byStrengthening
       , prototype := "He was too tired to say anything."
       , citations := ["ladusaw-1979"] }
-  | .comparativeNP =>
+  | .phrasalComparative =>
       -- [hoeksema-1983]: the NP-comparative is a Boolean
       -- homomorphism `Set (Set U) → Set U`, hence monotone increasing — it
       -- does *not* license NPIs. Modern interval-semantic accounts
       -- ([bhatt-pancheva-2004], [heim-2006]) reduce surface
       -- "than NP" with NPI to a covert clausal source — those NPIs are
-      -- licensed by `.comparativeS`, not by this slot.
+      -- licensed by `.clausalComparative`, not by this slot.
       { strawsonSignature := .mono, mechanism := .strengtheningFails
       , prototype := "Surface NP-comparative; no NPI licensing under genuine NP reading."
       , citations := ["hoeksema-1983", "bhatt-pancheva-2004", "heim-2006"] }
-  | .comparativeS =>
+  | .clausalComparative =>
       { strawsonSignature := .antiAdd, mechanism := .byStrengthening
       , prototype := "Mary is taller than anyone is."
       , citations := ["ladusaw-1979", "hoeksema-1983", "bhatt-pancheva-2004"] }

--- a/Linglib/Semantics/Polarity/Witnesses.lean
+++ b/Linglib/Semantics/Polarity/Witnesses.lean
@@ -353,8 +353,8 @@ noncomputable def contextWitness? :
   | .beforeClause => none
   | .withoutClause => none
   | .question => none
-  | .comparativeNP => none
-  | .comparativeS => none
+  | .phrasalComparative => none
+  | .clausalComparative => none
   | .tooTo => none
   | .modalPossibility => none
   | .modalNecessity => none

--- a/Linglib/Studies/BhattPancheva2004.lean
+++ b/Linglib/Studies/BhattPancheva2004.lean
@@ -180,8 +180,8 @@ theorem npGQ_principal_eq_sComp_thanClause
     Hoeksema's two registry theorems so that any future change to
     either signature surfaces here as a recompile failure. -/
 theorem reduction_preserves_polarity_signatures :
-    LicensingContext.comparativeNP.properties.strawsonSignature = .mono ∧
-    LicensingContext.comparativeS.properties.strawsonSignature = .antiAdd :=
+    LicensingContext.phrasalComparative.properties.strawsonSignature = .mono ∧
+    LicensingContext.clausalComparative.properties.strawsonSignature = .antiAdd :=
   ⟨comparativeNP_signature_monotone, comparativeS_signature_anti_additive⟩
 
 /- ## Note on the Bresnan 1973 contrast (B&P §1.1.1 fn. 4)

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -242,7 +242,7 @@ catalogued in `Polarity`. -/
 def npiTriggerToContext : LetAloneNPITrigger → LicensingContext
   | .simpleNegation         => .negation
   | .tooComplementation     => .tooTo
-  | .comparisonOfInequality => .comparativeS
+  | .comparisonOfInequality => .clausalComparative
   | .onlyDeterminer         => .onlyFocus
   | .minimalAttainment      => .negation              -- "barely" ≈ negation
   | .conditionalSurprise    => .conditionalAntecedent

--- a/Linglib/Studies/Hoeksema1983.lean
+++ b/Linglib/Studies/Hoeksema1983.lean
@@ -81,8 +81,8 @@ The §3 algebraic content is formalized in five layers:
 
 The licensing-context registry `Core/Lexical/PolarityItem.lean` records
 this paper's central asymmetry as a structural invariant:
-- `.comparativeNP` has signature `.mono` (Boolean hom is monotone, not DE)
-- `.comparativeS` has signature `.antiAdd`
+- `.phrasalComparative` has signature `.mono` (Boolean hom is monotone, not DE)
+- `.clausalComparative` has signature `.antiAdd`
 
 The `comparativeNP_signature_monotone` and
 `comparativeS_signature_anti_additive` theorems below witness the
@@ -326,23 +326,23 @@ theorem npComparativeGQ_principal_eq_gtOverSet_singleton
 
 /-! ## Connection to the licensing-context registry -/
 
-/-- The `.comparativeNP` registry slot is monotone, matching
+/-- The `.phrasalComparative` registry slot is monotone, matching
     `npComparativeGQ_monotone`. This is the registry-level encoding of
     Hoeksema's central asymmetry: the NP-comparative is monotone
     *increasing* and therefore not an NPI environment. -/
 theorem comparativeNP_signature_monotone :
-    LicensingContext.comparativeNP.properties.strawsonSignature = .mono := rfl
+    LicensingContext.phrasalComparative.properties.strawsonSignature = .mono := rfl
 
-/-- The `.comparativeS` registry slot is anti-additive, matching
+/-- The `.clausalComparative` registry slot is anti-additive, matching
     `gtOverSet_isAntiAdditive`. -/
 theorem comparativeS_signature_anti_additive :
-    LicensingContext.comparativeS.properties.strawsonSignature = .antiAdd := rfl
+    LicensingContext.clausalComparative.properties.strawsonSignature = .antiAdd := rfl
 
 /-- Both registry slots cite Hoeksema 1983, anchoring the registry's
     classification to this study file. -/
 theorem both_comparatives_cite_hoeksema :
-    "hoeksema-1983" ∈ LicensingContext.comparativeNP.properties.citations ∧
-    "hoeksema-1983" ∈ LicensingContext.comparativeS.properties.citations := by
+    "hoeksema-1983" ∈ LicensingContext.phrasalComparative.properties.citations ∧
+    "hoeksema-1983" ∈ LicensingContext.clausalComparative.properties.citations := by
   refine ⟨?_, ?_⟩ <;> decide
 
 end Hoeksema1983

--- a/Linglib/Studies/NapoliNespor1976.lean
+++ b/Linglib/Studies/NapoliNespor1976.lean
@@ -23,93 +23,112 @@ surface diagnostics are preserved.
 
 ## Main declarations
 
-* `noOpinionContext`, `chessContext`, `explicitCriticismContext`,
-  `complaintContext`: the dialogue paradigm probing the contradicted-belief
-  presupposition;
-* `questionedComparative` … `menoComparative`: distributional environments,
-  each isolating one licensing condition;
+* `Non2Datum`, `paradigm`: the paper's acceptability paradigm — dialogue
+  contexts, comparative environments, and indirect questions, each pairing a
+  bias profile with the reported judgment for *non₂*;
+* `paradigm_licenses_iff_non2Ok`: the licensing predicate reproduces every
+  judgment in the paradigm;
 * `predictedMood`, `predictedSpecificity`, `complementizerAdmissible`,
   `cliticAdmissible`, `neancheConjunctionAdmissible`, `weakNPIAdmissible`:
-  morphosyntactic diagnostics for underlying negation;
-* `chissaSeNon`: the same profile licensing *non₂* in indirect questions.
+  morphosyntactic diagnostics for underlying negation.
 -/
 
 namespace NapoliNespor1976
 
 open Pragmatics.Bias
-open Italian.PolarityItems (pur affatto neanche
-  pur_licensed_in_comparative affatto_not_licensed_in_comparative)
+open Italian.PolarityItems
 open Polarity (Item)
 
-/-! ### The dialogue-context paradigm
+/-! ### The acceptability paradigm
 
+The licensing conditions are established through an acceptability paradigm.
 Four dialogues between Dario and Paolo vary the speaker's epistemic state:
 *non₂* is felicitous exactly when the assertion contradicts a belief
-*inferred* from the interlocutor's prior discourse — infelicitous when there
-is no prior belief to contradict, and when the contradicted belief was
-explicitly stated rather than inferred. -/
+*inferred* from the interlocutor's prior discourse. Construction-level
+environments then isolate the remaining conditions (equality and
+explicit-degree comparatives both fail the precision condition;
+*meno*-comparatives are the positive control), and indirect questions show
+the condition is a property of the discourse move, not of comparative
+syntax. -/
 
-/-- Dario gives no opinion of Maria or Carlo; Paolo asserts Maria > Carlo.
-No prior belief to contradict, so *non₂* is infelicitous. -/
-def noOpinionContext : BiasLicensingProfile := noContradictionProfile
+/-- One row of the acceptability paradigm: a dialogue context or
+construction, its bias-licensing profile, and the reported acceptability of
+*non₂*. -/
+structure Non2Datum where
+  profile : BiasLicensingProfile
+  /-- Whether the paper reports *non₂* as felicitous. -/
+  non2Ok : Bool
+  deriving Repr
 
-/-- Dario implies Carlo would beat Maria at chess; Paolo asserts Maria is more
-intelligent. The contradicted belief is inferred, so *non₂* may appear. -/
-def chessContext : BiasLicensingProfile := licensedProfile
+/-- Dario gives no opinion of Maria or Carlo; Paolo asserts Maria > Carlo:
+no prior belief to contradict. -/
+def noOpinionContext : Non2Datum :=
+  { profile := noContradictionProfile, non2Ok := false }
 
-/-- Dario explicitly calls Maria stupid; Paolo disagrees. The contradicted
+/-- Dario implies Carlo would beat Maria at chess; Paolo asserts Maria is
+more intelligent: the contradicted belief is inferred. -/
+def chessContext : Non2Datum :=
+  { profile := licensedProfile, non2Ok := true }
+
+/-- Dario explicitly calls Maria stupid; Paolo disagrees: the contradicted
 belief is explicitly stated rather than inferred, failing the
-imprecise/inferred condition, so *non₂* is out. -/
-def explicitCriticismContext : BiasLicensingProfile := preciseProfile
+imprecise/inferred condition. -/
+def explicitCriticismContext : Non2Datum :=
+  { profile := preciseProfile, non2Ok := false }
 
-/-- Dario's complaint implies he expects Maria cannot help; Paolo asserts she
-is smart enough to ask. The contradicted belief is inferred: *non₂* is used. -/
-def complaintContext : BiasLicensingProfile := licensedProfile
-
-theorem noOpinion_blocks : ¬ noOpinionContext.licenses := no_contradiction_blocks
-theorem chess_licenses : chessContext.licenses := licensed_licenses
-theorem explicitCriticism_blocks : ¬ explicitCriticismContext.licenses := precise_blocks
-theorem complaint_licenses : complaintContext.licenses := licensed_licenses
-
-/-! ### Distributional environments
-
-Construction-level environments each isolate one licensing condition (the
-contradicted-belief condition is contextual and is witnessed by the dialogue
-paradigm above); equality and explicit-degree comparatives both fail the
-precision condition. *Meno*-comparatives are the positive control. -/
+/-- Dario's complaint implies he expects Maria cannot help; Paolo asserts
+she is smart enough to ask: the contradicted belief is inferred. -/
+def complaintContext : Non2Datum :=
+  { profile := licensedProfile, non2Ok := true }
 
 /-- *È più intelligente di quanto non sia Carlo?* 'Is she more intelligent
-than Carlo?': questioning is non-assertive, blocking *non₂*. -/
-def questionedComparative : BiasLicensingProfile := questionedProfile
+than Carlo?': questioning is non-assertive. -/
+def questionedComparative : Non2Datum :=
+  { profile := questionedProfile, non2Ok := false }
 
-/-- *Maria non è più intelligente di quanto non sia Carlo*: a negated matrix
-blocks *non₂*. -/
-def matrixNegatedComparative : BiasLicensingProfile := matrixNegatedProfile
+/-- *Maria non è più intelligente di quanto non sia Carlo*: the matrix is
+negated. -/
+def matrixNegatedComparative : Non2Datum :=
+  { profile := matrixNegatedProfile, non2Ok := false }
 
-/-- Equality comparatives (*Maria è tanto intelligente quanto è Carlo*) demand
-explicit, precise knowledge of the compared degrees, while *non₂* demands
-inferred, imprecise knowledge — so the two are mutually exclusive. -/
-def equalityComparative : BiasLicensingProfile := preciseProfile
+/-- Equality comparatives (*Maria è tanto intelligente quanto è Carlo*)
+demand explicit, precise knowledge of the compared degrees, while *non₂*
+demands inferred, imprecise knowledge. -/
+def equalityComparative : Non2Datum :=
+  { profile := preciseProfile, non2Ok := false }
 
-/-- Explicit degree modifiers (*molto più intelligente*, *due metri più alta*)
-require precise knowledge of the degree gap, failing the imprecise
-condition. -/
-def precisionComparative : BiasLicensingProfile := preciseProfile
+/-- Explicit degree modifiers (*molto più intelligente*, *due metri più
+alta*) require precise knowledge of the degree gap. -/
+def precisionComparative : Non2Datum :=
+  { profile := preciseProfile, non2Ok := false }
 
 /-- *Maria è meno intelligente di quanto tu non creda* 'Maria is less
 intelligent than you think': *meno*-comparatives admit *non₂* under the same
-contextual conditions as *più*. Negated equality comparatives are semantically
-close to *meno*-comparatives yet reject *non₂*, so the equality restriction
-cannot reduce to equality linking two similar things (contra [seuren-1969]
-and [antinucci-puglielli-1971]); it follows from matrix negation and the
-precision condition. -/
-def menoComparative : BiasLicensingProfile := licensedProfile
+contextual conditions as *più*. Negated equality comparatives are
+semantically close to *meno*-comparatives yet reject *non₂*, so the equality
+restriction cannot reduce to equality linking two similar things (contra
+[seuren-1969] and [antinucci-puglielli-1971]); it follows from matrix
+negation and the precision condition. -/
+def menoComparative : Non2Datum :=
+  { profile := licensedProfile, non2Ok := true }
 
-theorem questioned_blocks_non2 : ¬ questionedComparative.licenses := questioned_blocks
-theorem matrix_negated_blocks_non2 : ¬ matrixNegatedComparative.licenses := matrix_negated_blocks
-theorem equality_blocks_non2 : ¬ equalityComparative.licenses := precise_blocks
-theorem precision_blocks_non2 : ¬ precisionComparative.licenses := precise_blocks
-theorem meno_licenses_non2 : menoComparative.licenses := licensed_licenses
+/-- *Chissà se non vale la pena di comprarlo* 'Who knows if it's (not) worth
+buying it': an indirect question whose negated proposition the speaker
+presupposes to be contrary to expectation, licensed by the same profile as
+the comparatives. -/
+def chissaSeNon : Non2Datum :=
+  { profile := licensedProfile, non2Ok := true }
+
+/-- The paper's acceptability paradigm. -/
+def paradigm : List Non2Datum :=
+  [ noOpinionContext, chessContext, explicitCriticismContext, complaintContext
+  , questionedComparative, matrixNegatedComparative, equalityComparative
+  , precisionComparative, menoComparative, chissaSeNon ]
+
+/-- The licensing predicate reproduces the paper's judgment on every row of
+the paradigm. -/
+theorem paradigm_licenses_iff_non2Ok :
+    ∀ d ∈ paradigm, (d.profile.licenses ↔ d.non2Ok = true) := by decide
 
 /-! ### Morphosyntactic diagnostics for underlying negation
 
@@ -201,14 +220,14 @@ is blocked, because *affatto* requires precise knowledge of the contradicted
 belief — incompatible with the imprecise/inferred licensing condition (a
 footnote observation of [napoli-nespor-1976]). The contrast is witnessed at
 the lexical layer: `pur.licensingContexts` lists the clausal-comparative slot
-`.comparativeS` while `affatto`'s does not, so the predictions below are
-derived from the Fragment registry. -/
+`.clausalComparative` while `affatto`'s does not, so the predictions below
+are derived from the Fragment registry. -/
 
 /-- A weak NPI is admissible in a bias-conditioned comparative iff its
-registry lists the clausal-comparative slot `.comparativeS` (surface
-NP-comparatives are not NPI environments) and the profile licenses *non₂*. -/
+registry lists the clausal-comparative slot (surface phrasal comparatives are
+not NPI environments) and the profile licenses *non₂*. -/
 def weakNPIAdmissible (p : BiasLicensingProfile) (npi : Item) : Prop :=
-  p.licenses ∧ .comparativeS ∈ npi.licensingContexts
+  p.licenses ∧ .clausalComparative ∈ npi.licensingContexts
 
 /-- *Pur* is admissible wherever *non₂* is licensed; the registry conjunct is
 the Fragment's `pur_licensed_in_comparative`. -/
@@ -220,19 +239,5 @@ profile: the block is registered in the lexical entry itself. -/
 theorem affatto_blocked_in_non2 (p : BiasLicensingProfile) :
     ¬ weakNPIAdmissible p affatto :=
   λ ⟨_, h⟩ => affatto_not_licensed_in_comparative h
-
-/-! ### Beyond comparatives: indirect questions
-
-The same *non₂* appears in indirect questions where the speaker presupposes
-the negated proposition is contrary to expectation: *Chissà se non vale la
-pena di comprarlo* 'Who knows if it's (not) worth buying it' suggests the
-speaker expected it to be worth buying. The licensing condition is a property
-of the discourse move, not of comparative syntax. -/
-
-/-- *Chissà se non…*: indirect question with bias-conditioned negation, same
-licensing profile as the licensed comparative contexts. -/
-def chissaSeNon : BiasLicensingProfile := licensedProfile
-
-theorem chissa_licenses_non2 : chissaSeNon.licenses := licensed_licenses
 
 end NapoliNespor1976

--- a/Linglib/Studies/Rett2026.lean
+++ b/Linglib/Studies/Rett2026.lean
@@ -105,7 +105,7 @@ structure ENDatum where
       with bias-conditioned negation's imprecise condition; noted in a
       footnote of [napoli-nespor-1976], and registered in the Italian
       Fragment's `affatto.licensingContexts`, which excludes
-      `.comparativeS`). -/
+      `.clausalComparative`). -/
   licensedNPIForms : List String
   /-- Manner implicature triggered by EN (if any) -/
   mannerEffect : Option MannerEffect := none

--- a/Linglib/Studies/VonStechow1984.lean
+++ b/Linglib/Studies/VonStechow1984.lean
@@ -93,7 +93,7 @@ example : ¬ deDictoComparative yachtLength false () :=
 /-- (v) (`Examples.exV`; §§VI–VII): a disjunctive standard entails both
 disjuncts — the downward-entailingness of the than-clause that also
 licenses its NPIs (`Degree.comparative_than_DE`;
-`Ladusaw1979.licensingStrength .comparativeS = .antiAdditive`). -/
+`Ladusaw1979.licensingStrength .clausalComparative = .antiAdditive`). -/
 theorem disjunction_to_conjunction_in_than (μa μb μc : D)
     (h : μb ⊔ μc < μa) : μb < μa ∧ μc < μa :=
   sup_lt_iff.mp h


### PR DESCRIPTION
Renames `LicensingContext.comparativeS`/`.comparativeNP` to `.clausalComparative`/`.phrasalComparative` — the field-standard clausal/phrasal comparative terminology, and `comparativeS` read as a plural of `.comparative` (the typo Rett2026's docstring actually had). Whole-word rename across 15 files.

- `NapoliNespor1976` recut to an acceptability datum table: `Non2Datum` rows pair each context's bias profile with the paper's reported judgment, and one classification theorem (`paradigm_licenses_iff_non2Ok`) replaces the per-context restatements of `Pragmatics.Bias` lemmas.
- Wholesale `open Italian.PolarityItems` in the study file.