### PR TITLE
feat(Phonology/HarmonicGrammar): stratified POC + Anttila1997 repairs

### DIFF
--- a/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
+++ b/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
@@ -3,6 +3,7 @@ import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Data.Fintype.Perm
 import Mathlib.Data.List.FinRange
+import Mathlib.Data.List.OfFn
 import Mathlib.Data.Rat.Defs
 import Mathlib.GroupTheory.Perm.Basic
 import Mathlib.Tactic.FieldSimp
@@ -14,32 +15,32 @@ import Mathlib.Tactic.Linarith
 A closed-form count of `Equiv.Perm (Fin n)` filtered by predicates
 of the form "the head of a list filtered by `D` lies in `Y`".
 
-## Main result
+## Main results
 
-`perm_filter_head_in_card`: for `D Y : Finset (Fin n)`,
+For any family `S : Finset (Equiv.Perm (Fin n))` closed under
+left-multiplication by swaps of elements of `D`:
 
-  `(# σ where head of permDList σ D ∈ Y) × |D| = n! × |Y ∩ D|`
+- `filter_head_in_card_of_swaps`:
+  `(# σ ∈ S where head of permDList σ D ∈ Y) × |D| = |S| × |Y ∩ D|`
+- `filter_head_in_rate_of_swaps`: the rational form
+  `(count / |S|) = |Y ∩ D| / |D|`.
 
-This reduces O(n!) constraint-ranking enumeration to closed-form
-arithmetic. Two factorial-typology studies consume it:
-`Studies/Zuraw2010.lean` and
-`Studies/Anttila1997.lean`.
+`perm_filter_head_in_card` / `perm_filter_head_in_rate` are the
+`S = Finset.univ` specializations (`|S| = n!`), consumed by
+`Studies/Zuraw2010.lean` and `Studies/CoetzeePater2011.lean`. The
+swap-closed generality serves partially-ordered constraint grammars,
+whose consistent-linear-extension sets are swap-closed within a freely
+ranked stratum (`pocPredict_stratified_binary_rate` in
+`Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean`).
 
 ## Proof technique
 
-For each `y ∈ D`, the fiber `S_y = {σ : head of permDList σ D = y}`
-is in bijection with any other fiber `S_y'` via left-multiplication
-by `Equiv.swap y y'` (which preserves D-membership pointwise and
-swaps the head element). All fibers thus have equal cardinality.
-Summing over `D` (which partitions `Finset.univ` when `D` is nonempty)
-gives `|D| × |S_y| = n!`, hence `|S_y| = n!/|D|`.
-
-## Scope
-
-Specialized to head-in-Y predicates on `Equiv.Perm (Fin n)`. A more
-general factoring theorem for arbitrary D-determined predicates is
-feasible (via orbit-stabilizer on the fixing subgroup of `Dᶜ`) but
-
+For `y, y' ∈ D`, left-multiplication by `Equiv.swap y y'` preserves
+D-membership pointwise and swaps the head element, so it restricts to a
+bijection between the head-fibers `{σ ∈ S : head of permDList σ D = y}`
+and `{σ ∈ S : … = y'}` whenever `S` is closed under it. All fibers thus
+have equal cardinality; summing over `D` (which partitions `S` when `D`
+is nonempty) gives `|D| × |fiber| = |S|`.
 -/
 
 namespace Core.Optimization.PermSubsetCombinatorics
@@ -52,41 +53,23 @@ variable {n : ℕ}
 -- § 1: permToList and permDList
 -- ============================================================================
 
-/-- The list `[σ 0, σ 1, …, σ (n-1)]` of σ's values in increasing index order. -/
-def permToList (σ : Equiv.Perm (Fin n)) : List (Fin n) :=
-  (List.finRange n).map σ
-
-@[simp]
-theorem permToList_length (σ : Equiv.Perm (Fin n)) :
-    (permToList σ).length = n := by
-  simp only [permToList, List.length_map, List.length_finRange]
-
-theorem permToList_nodup (σ : Equiv.Perm (Fin n)) : (permToList σ).Nodup := by
-  unfold permToList
-  exact (List.nodup_finRange n).map σ.injective
-
-@[simp]
-theorem mem_permToList (σ : Equiv.Perm (Fin n)) (x : Fin n) :
-    x ∈ permToList σ := by
-  simp only [permToList, List.mem_map, List.mem_finRange, true_and]
-  exact ⟨σ.symm x, σ.apply_symm_apply x⟩
-
-/-- Subsequence of `permToList σ` filtered to elements of `D`. The head
-    of this list is the σ-image element that lies in D and has the
-    smallest preimage index — i.e., the highest-ranked constraint in
-    the OT interpretation. -/
+/-- Subsequence of `List.ofFn ⇑σ` (σ's values in increasing position order)
+    filtered to elements of `D`. The head of this list is the σ-image element
+    that lies in D and has the smallest preimage index — i.e., the
+    highest-ranked constraint in the OT interpretation. -/
 def permDList (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)) : List (Fin n) :=
-  (permToList σ).filter (· ∈ D)
+  (List.ofFn ⇑σ).filter (· ∈ D)
 
 theorem permDList_nodup (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)) :
     (permDList σ D).Nodup :=
-  (permToList_nodup σ).filter _
+  (List.nodup_ofFn.mpr σ.injective).filter _
 
 @[simp]
 theorem mem_permDList (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n))
     (x : Fin n) : x ∈ permDList σ D ↔ x ∈ D := by
-  simp only [permDList, List.mem_filter, decide_eq_true_eq, and_iff_right_iff_imp]
-  intro _; exact mem_permToList σ x
+  simp only [permDList, List.mem_filter, List.mem_ofFn, decide_eq_true_eq,
+    and_iff_right_iff_imp]
+  exact fun _ => ⟨σ.symm x, σ.apply_symm_apply x⟩
 
 @[simp]
 theorem permDList_toFinset (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)) :
@@ -99,26 +82,26 @@ theorem permDList_length (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)) :
     (permDList σ D).length = D.card := by
   rw [← List.toFinset_card_of_nodup (permDList_nodup σ D), permDList_toFinset]
 
-/-- Decompose `permToList σ` at any position: the list factors as
+/-- Decompose `List.ofFn ⇑σ` at any position: the list factors as
     `(take k).map σ ++ σ k :: (drop (k+1)).map σ`. -/
-theorem permToList_split_at (σ : Equiv.Perm (Fin n)) (k : Fin n) :
-    permToList σ =
+theorem ofFn_split_at (σ : Equiv.Perm (Fin n)) (k : Fin n) :
+    List.ofFn ⇑σ =
     ((List.finRange n).take k.val).map σ ++ σ k ::
       ((List.finRange n).drop (k.val + 1)).map σ := by
   have h_lt : k.val < (List.finRange n).length := by
     rw [List.length_finRange]; exact k.isLt
   have h_get : (List.finRange n)[k.val]'h_lt = k := by simp [List.getElem_finRange]
-  unfold permToList
+  rw [List.ofFn_eq_map]
   conv_lhs => rw [← List.take_append_drop k.val (List.finRange n)]
   rw [List.drop_eq_getElem_cons h_lt, h_get, List.map_append, List.map_cons]
 
-/-- Inverse: if `permToList σ = pre ++ x :: suf`, then σ at the
+/-- Inverse: if `List.ofFn ⇑σ = pre ++ x :: suf`, then σ at the
     canonical Fin-position `pre.length` equals `x`. -/
-theorem permToList_eq_append_cons_imp_apply (σ : Equiv.Perm (Fin n))
+theorem apply_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
     (pre suf : List (Fin n)) (x : Fin n)
-    (h_split : permToList σ = pre ++ x :: suf) (h_pre_lt : pre.length < n) :
+    (h_split : List.ofFn ⇑σ = pre ++ x :: suf) (h_pre_lt : pre.length < n) :
     σ ⟨pre.length, h_pre_lt⟩ = x := by
-  have h_split_pre := permToList_split_at σ ⟨pre.length, h_pre_lt⟩
+  have h_split_pre := ofFn_split_at σ ⟨pre.length, h_pre_lt⟩
   have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
     rw [List.length_map, List.length_take, List.length_finRange]
     omega
@@ -131,15 +114,51 @@ theorem permToList_eq_append_cons_imp_apply (σ : Equiv.Perm (Fin n))
     (List.append_inj h_combined h_lhs_pre_len).2
   exact (List.cons.inj h_suf_eq).1
 
+/-- Elements of the prefix of a `List.ofFn ⇑σ` decomposition occupy strictly
+    earlier positions than the distinguished element: if
+    `List.ofFn ⇑σ = pre ++ x :: suf` and `y ∈ pre` then `σ.symm y < σ.symm x`. -/
+theorem symm_lt_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
+    {pre suf : List (Fin n)} {x y : Fin n}
+    (h_split : List.ofFn ⇑σ = pre ++ x :: suf) (hy : y ∈ pre) :
+    σ.symm y < σ.symm x := by
+  have h_len : (List.ofFn ⇑σ).length = n := List.length_ofFn
+  rw [h_split, List.length_append, List.length_cons] at h_len
+  have h_pre_lt : pre.length < n := by omega
+  have hx_eq : σ ⟨pre.length, h_pre_lt⟩ = x :=
+    apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_lt
+  -- `pre` is the σ-image of the first `pre.length` positions
+  have h_split_pre := ofFn_split_at σ ⟨pre.length, h_pre_lt⟩
+  have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
+    rw [List.length_map, List.length_take, List.length_finRange]; omega
+  have h_combined : ((List.finRange n).take pre.length).map σ ++
+      σ ⟨pre.length, h_pre_lt⟩ ::
+      ((List.finRange n).drop (pre.length + 1)).map σ = pre ++ x :: suf := by
+    rw [← h_split_pre]; exact h_split
+  have h_pre_eq : ((List.finRange n).take pre.length).map σ = pre :=
+    (List.append_inj h_combined h_lhs_pre_len).1
+  rw [← h_pre_eq] at hy
+  obtain ⟨j, h_j_take, h_σj⟩ := List.mem_map.mp hy
+  rw [List.mem_take_iff_getElem] at h_j_take
+  obtain ⟨idx, h_idx_lt, h_idx_eq⟩ := h_j_take
+  simp only [List.getElem_finRange] at h_idx_eq
+  have h_idx_lt_pre : idx < pre.length := by
+    simp only [List.length_finRange, lt_min_iff] at h_idx_lt
+    omega
+  have hy_symm : σ.symm y = j := by rw [← h_σj, Equiv.symm_apply_apply]
+  have hx_symm : σ.symm x = ⟨pre.length, h_pre_lt⟩ := by
+    rw [← hx_eq, Equiv.symm_apply_apply]
+  rw [hy_symm, hx_symm, Fin.lt_def, ← h_idx_eq]
+  exact h_idx_lt_pre
+
 /-- The head of `permDList σ D` characterized via mathlib's
     `List.find?_eq_some_iff_append`: `head = some x` iff `x ∈ D` and
-    `permToList σ` decomposes as `prefix ++ x :: suffix` where every
+    `List.ofFn ⇑σ` decomposes as `prefix ++ x :: suffix` where every
     prefix element lies outside `D`. -/
 theorem permDList_head_eq_some_iff (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n))
     (x : Fin n) :
     (permDList σ D).head? = some x ↔
     x ∈ D ∧ ∃ pre suf : List (Fin n),
-      permToList σ = pre ++ x :: suf ∧ ∀ y ∈ pre, y ∉ D := by
+      List.ofFn ⇑σ = pre ++ x :: suf ∧ ∀ y ∈ pre, y ∉ D := by
   unfold permDList
   rw [List.head?_filter, List.find?_eq_some_iff_append]
   constructor
@@ -156,32 +175,17 @@ theorem permDList_head_eq_some_iff (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)
 -- § 2: Multiplicative lemma
 -- ============================================================================
 
-/-- `permToList` of a left-multiplied permutation: `(τ * σ).permToList`
-    equals `σ.permToList` with τ applied element-wise. -/
-theorem permToList_mul (τ σ : Equiv.Perm (Fin n)) :
-    permToList (τ * σ) = (permToList σ).map τ := by
-  unfold permToList
-  rw [List.map_map]
-  rfl
-
 /-- When `τ` preserves D-membership both ways, the D-image of `τ * σ` is
-    the D-image of `σ` with `τ` applied element-wise. -/
+    the D-image of `σ` with `τ` applied element-wise. Composes mathlib's
+    `List.map_ofFn` and `List.filter_map`. -/
 theorem permDList_mul_of_preserves_D
     (D : Finset (Fin n)) (σ τ : Equiv.Perm (Fin n))
     (h_pres : ∀ x : Fin n, x ∈ D ↔ τ x ∈ D) :
     permDList (τ * σ) D = (permDList σ D).map τ := by
   unfold permDList
-  rw [permToList_mul]
-  generalize permToList σ = l
-  induction l with
-  | nil => simp only [List.map_nil, List.filter_nil]
-  | cons x xs ih =>
-    simp only [List.map_cons, List.filter_cons]
-    by_cases hx : x ∈ D
-    · have hxD : τ x ∈ D := (h_pres x).mp hx
-      simp only [hx, hxD, decide_true, List.map_cons, ih, ↓reduceIte]
-    · have hxD : τ x ∉ D := fun h => hx ((h_pres x).mpr h)
-      simp only [hx, hxD, decide_false, ih, Bool.false_eq_true, ↓reduceIte]
+  rw [Equiv.Perm.coe_mul, ← List.map_ofFn, List.filter_map]
+  congr 1
+  exact List.filter_congr fun x _ => by simpa using (h_pres x).symm
 
 -- ============================================================================
 -- § 3: Swap preserves D-membership when both swap targets are in D
@@ -207,11 +211,9 @@ private lemma swap_preserves_finset {D : Finset (Fin n)} {y y' : Fin n}
 -- § 4: Equinumerosity of head-fibers via swap bijection
 -- ============================================================================
 
-/-- If `(permDList σ D).head? = some x` then `x ∈ D` (since the head of
-    a filtered list lies in the filter set) and `permDList σ D` is a
-    cons. Used to dispatch cases when bridging head-equality hypotheses
-    to membership facts. -/
-private lemma head?_eq_some_imp_mem_D {D : Finset (Fin n)}
+/-- If `(permDList σ D).head? = some x` then `x ∈ D` (the head of a
+    filtered list lies in the filter set). -/
+theorem mem_of_permDList_head?_eq_some {D : Finset (Fin n)}
     {σ : Equiv.Perm (Fin n)} {x : Fin n}
     (h : (permDList σ D).head? = some x) : x ∈ D := by
   cases h_eq : permDList σ D with
@@ -223,41 +225,46 @@ private lemma head?_eq_some_imp_mem_D {D : Finset (Fin n)}
     have h_mem : z ∈ permDList σ D := by rw [h_eq]; exact List.mem_cons_self
     rw [mem_permDList] at h_mem; exact h_mem
 
-/-- For `y, y' ∈ D`, the fibers `{σ : head of permDList σ D = y}` and
-    `{σ : head of permDList σ D = y'}` have equal cardinality, witnessed
+/-- For `y, y' ∈ D` and a family `S` closed under `σ ↦ swap y y' * σ`, the
+    fibers `{σ ∈ S : head of permDList σ D = y}` and
+    `{σ ∈ S : head of permDList σ D = y'}` have equal cardinality, witnessed
     by the involution `σ ↦ Equiv.swap y y' * σ`. -/
-private theorem card_filter_head_fibers_eq {D : Finset (Fin n)} (y y' : Fin n)
-    (hy : y ∈ D) (hy' : y' ∈ D) :
-    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      (permDList σ D).head? = some y)).card =
-    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      (permDList σ D).head? = some y')).card := by
+private theorem card_filter_head_fibers_eq {D : Finset (Fin n)}
+    {S : Finset (Equiv.Perm (Fin n))} (y y' : Fin n) (hy : y ∈ D) (hy' : y' ∈ D)
+    (h_closed : ∀ σ ∈ S, Equiv.swap y y' * σ ∈ S) :
+    (S.filter (fun σ => (permDList σ D).head? = some y)).card =
+    (S.filter (fun σ => (permDList σ D).head? = some y')).card := by
   apply Finset.card_bij (fun σ _ => Equiv.swap y y' * σ)
   · -- Maps into target fiber
     intros σ hσ
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hσ ⊢
+    simp only [Finset.mem_filter] at hσ ⊢
+    obtain ⟨hσS, hσh⟩ := hσ
+    refine ⟨h_closed σ hσS, ?_⟩
     rw [permDList_mul_of_preserves_D D σ _ (swap_preserves_finset hy hy')]
     cases h_eq : permDList σ D with
-    | nil => rw [h_eq] at hσ; exact absurd hσ (by simp)
+    | nil => rw [h_eq] at hσh; exact absurd hσh (by simp)
     | cons z _ =>
-      rw [h_eq] at hσ
-      simp only [List.head?_cons, Option.some.injEq] at hσ
-      subst hσ
+      rw [h_eq] at hσh
+      simp only [List.head?_cons, Option.some.injEq] at hσh
+      subst hσh
       simp only [List.map_cons, List.head?_cons, Equiv.swap_apply_left]
   · -- Injective
     intros σ₁ _ σ₂ _ heq
     exact mul_left_cancel heq
   · -- Surjective
     intros σ' hσ'
+    simp only [Finset.mem_filter] at hσ'
+    obtain ⟨hσS, hσh⟩ := hσ'
     refine ⟨Equiv.swap y y' * σ', ?_, ?_⟩
-    · simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hσ' ⊢
+    · simp only [Finset.mem_filter]
+      refine ⟨h_closed σ' hσS, ?_⟩
       rw [permDList_mul_of_preserves_D D σ' _ (swap_preserves_finset hy hy')]
       cases h_eq : permDList σ' D with
-      | nil => rw [h_eq] at hσ'; exact absurd hσ' (by simp)
+      | nil => rw [h_eq] at hσh; exact absurd hσh (by simp)
       | cons z _ =>
-        rw [h_eq] at hσ'
-        simp only [List.head?_cons, Option.some.injEq] at hσ'
-        subst hσ'
+        rw [h_eq] at hσh
+        simp only [List.head?_cons, Option.some.injEq] at hσh
+        subst hσh
         simp only [List.map_cons, List.head?_cons, Equiv.swap_apply_right]
     · -- swap is an involution: swap * (swap * σ') = σ'
       rw [← mul_assoc, Equiv.swap_mul_self, one_mul]
@@ -268,7 +275,7 @@ private theorem card_filter_head_fibers_eq {D : Finset (Fin n)} (y y' : Fin n)
 
 /-- For nonempty `D`, the head of `permDList σ D` is always defined and
     lies in `D`. -/
-private lemma head_in_D {D : Finset (Fin n)} (h_nonempty : D.Nonempty)
+theorem exists_permDList_head?_eq_some {D : Finset (Fin n)} (h_nonempty : D.Nonempty)
     (σ : Equiv.Perm (Fin n)) :
     ∃ y ∈ D, (permDList σ D).head? = some y := by
   cases h_eq : permDList σ D with
@@ -282,151 +289,160 @@ private lemma head_in_D {D : Finset (Fin n)} (h_nonempty : D.Nonempty)
   | cons z _ =>
     refine ⟨z, ?_, by simp⟩
     have h_head : (permDList σ D).head? = some z := by rw [h_eq]; rfl
-    exact head?_eq_some_imp_mem_D h_head
+    exact mem_of_permDList_head?_eq_some h_head
 
-/-- For nonempty `D`, summing fiber cardinalities over `y ∈ D` gives `n!`,
-    since every σ has its head in `D`. -/
-private theorem sum_head_eq_card_eq_factorial {D : Finset (Fin n)}
-    (h_nonempty : D.Nonempty) :
-    ∑ y ∈ D, (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      (permDList σ D).head? = some y)).card = n.factorial := by
+/-- For nonempty `D`, summing head-fiber cardinalities over `y ∈ D` recovers
+    the cardinality of any family `S`, since every σ has its head in `D`. -/
+private theorem sum_card_filter_head_eq {D : Finset (Fin n)}
+    (S : Finset (Equiv.Perm (Fin n))) (h_nonempty : D.Nonempty) :
+    ∑ y ∈ D, (S.filter (fun σ => (permDList σ D).head? = some y)).card = S.card := by
   classical
   have h_disjoint : (↑D : Set (Fin n)).PairwiseDisjoint
-      (fun y => Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-        (permDList σ D).head? = some y)) := by
+      (fun y => S.filter (fun σ => (permDList σ D).head? = some y)) := by
     intros y _ y' _ hne
     simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
     rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
     exact hne (Option.some.inj (h₁.symm.trans h₂))
-  have h_union : D.biUnion (fun y => Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      (permDList σ D).head? = some y)) = Finset.univ := by
+  have h_union : D.biUnion
+      (fun y => S.filter (fun σ => (permDList σ D).head? = some y)) = S := by
     ext σ
-    simp only [Finset.mem_biUnion, Finset.mem_filter, Finset.mem_univ, true_and]
-    refine ⟨fun _ => trivial, fun _ => head_in_D h_nonempty σ⟩
-  calc ∑ y ∈ D, (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-        (permDList σ D).head? = some y)).card
-      = (D.biUnion (fun y => Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+    simp only [Finset.mem_biUnion, Finset.mem_filter]
+    constructor
+    · rintro ⟨y, _, hσS, _⟩; exact hσS
+    · intro hσS
+      obtain ⟨y, hyD, hhead⟩ := exists_permDList_head?_eq_some h_nonempty σ
+      exact ⟨y, hyD, hσS, hhead⟩
+  calc ∑ y ∈ D, (S.filter (fun σ => (permDList σ D).head? = some y)).card
+      = (D.biUnion (fun y => S.filter (fun σ =>
           (permDList σ D).head? = some y))).card :=
         (Finset.card_biUnion h_disjoint).symm
-    _ = Finset.univ.card := by rw [h_union]
-    _ = n.factorial := by rw [Finset.card_univ, Fintype.card_perm, Fintype.card_fin]
+    _ = S.card := by rw [h_union]
 
-/-- For `y ∈ D`, the count of perms whose `permDList σ D` starts with `y`
-    is `n!/|D|`, expressed in multiplied form to avoid ℕ division. -/
-private theorem head_eq_card {D : Finset (Fin n)} (y : Fin n) (hy : y ∈ D) :
-    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      (permDList σ D).head? = some y)).card * D.card = n.factorial := by
-  have h_nonempty : D.Nonempty := ⟨y, hy⟩
+/-- For `y ∈ D` and swap-closed `S`, the count of `σ ∈ S` whose
+    `permDList σ D` starts with `y` is `|S| / |D|`, expressed in multiplied
+    form to avoid ℕ division. -/
+private theorem card_filter_head_eq_mul {D : Finset (Fin n)}
+    {S : Finset (Equiv.Perm (Fin n))} (y : Fin n) (hy : y ∈ D)
+    (h_closed : ∀ y₁ ∈ D, ∀ y₂ ∈ D, ∀ σ ∈ S, Equiv.swap y₁ y₂ * σ ∈ S) :
+    (S.filter (fun σ => (permDList σ D).head? = some y)).card * D.card = S.card := by
   have h_const : ∀ y' ∈ D,
-      (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-        (permDList σ D).head? = some y')).card =
-      (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-        (permDList σ D).head? = some y)).card :=
-    fun y' hy' => card_filter_head_fibers_eq y' y hy' hy
-  have h_sum := sum_head_eq_card_eq_factorial h_nonempty
+      (S.filter (fun σ => (permDList σ D).head? = some y')).card =
+      (S.filter (fun σ => (permDList σ D).head? = some y)).card :=
+    fun y' hy' => card_filter_head_fibers_eq y' y hy' hy (h_closed y' hy' y hy)
+  have h_sum := sum_card_filter_head_eq S ⟨y, hy⟩
   rw [Finset.sum_congr rfl h_const, Finset.sum_const, smul_eq_mul] at h_sum
-  -- h_sum : D.card * (...).card = n.factorial; goal: (...).card * D.card = n.factorial
   rw [mul_comm]; exact h_sum
 
 -- ============================================================================
 -- § 6: Closed form for "head ∈ Y" predicates
 -- ============================================================================
 
-/-- **The closed-form count**: for the predicate "head of `permDList σ D`
-    lies in `Y`", the number of permutations satisfying it is
-    `n! × |Y ∩ D| / D.card`, expressed in multiplied form to avoid ℕ
-    division.
-
-    For each consonant in a factorial typology, this gives the per-consonant
-    substitution count from a single application of the underlying head-fiber
-    counting `head_eq_card` summed over `Y ∩ D`. -/
-theorem perm_filter_head_in_card (D Y : Finset (Fin n)) :
-    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      ∃ x ∈ Y, (permDList σ D).head? = some x)).card * D.card =
-    n.factorial * (Y ∩ D).card := by
+/-- **The closed-form count over a swap-closed family**: for `S` closed under
+    left-multiplication by swaps of `D`-elements, the number of `σ ∈ S` whose
+    `permDList σ D` head lies in `Y` is `|S| × |Y ∩ D| / |D|`, expressed in
+    multiplied form to avoid ℕ division. -/
+theorem filter_head_in_card_of_swaps (S : Finset (Equiv.Perm (Fin n)))
+    (D Y : Finset (Fin n))
+    (h_closed : ∀ y₁ ∈ D, ∀ y₂ ∈ D, ∀ σ ∈ S, Equiv.swap y₁ y₂ * σ ∈ S) :
+    (S.filter (fun σ => ∃ x ∈ Y, (permDList σ D).head? = some x)).card * D.card =
+    S.card * (Y ∩ D).card := by
   classical
   rcases (Y ∩ D).eq_empty_or_nonempty with h_empty | h_nonempty
   · -- Y ∩ D = ∅: no σ has head in Y, both sides 0
-    have h_filter : Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+    have h_filter : S.filter (fun σ =>
         ∃ x ∈ Y, (permDList σ D).head? = some x) = ∅ := by
       apply Finset.eq_empty_of_forall_notMem
       rintro σ hσ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hσ
-      obtain ⟨x, hxY, hhead⟩ := hσ
+      simp only [Finset.mem_filter] at hσ
+      obtain ⟨-, x, hxY, hhead⟩ := hσ
       have : x ∈ Y ∩ D :=
-        Finset.mem_inter.mpr ⟨hxY, head?_eq_some_imp_mem_D hhead⟩
+        Finset.mem_inter.mpr ⟨hxY, mem_of_permDList_head?_eq_some hhead⟩
       rw [h_empty] at this
       exact absurd this (Finset.notMem_empty x)
     rw [h_filter, Finset.card_empty, Nat.zero_mul, h_empty,
         Finset.card_empty, Nat.mul_zero]
   · -- Y ∩ D nonempty: decompose by head value
-    have h_decomp : Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+    have h_decomp : S.filter (fun σ =>
         ∃ x ∈ Y, (permDList σ D).head? = some x) =
-        (Y ∩ D).biUnion (fun y => Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+        (Y ∩ D).biUnion (fun y => S.filter (fun σ =>
           (permDList σ D).head? = some y)) := by
       ext σ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_biUnion,
-        Finset.mem_inter]
+      simp only [Finset.mem_filter, Finset.mem_biUnion, Finset.mem_inter]
       refine ⟨?_, ?_⟩
-      · rintro ⟨x, hxY, hhead⟩
-        exact ⟨x, ⟨hxY, head?_eq_some_imp_mem_D hhead⟩, hhead⟩
-      · rintro ⟨y, ⟨hyY, _⟩, hhead⟩
-        exact ⟨y, hyY, hhead⟩
+      · rintro ⟨hσS, x, hxY, hhead⟩
+        exact ⟨x, ⟨hxY, mem_of_permDList_head?_eq_some hhead⟩, hσS, hhead⟩
+      · rintro ⟨y, ⟨hyY, _⟩, hσS, hhead⟩
+        exact ⟨hσS, y, hyY, hhead⟩
     have h_disjoint : (↑(Y ∩ D) : Set (Fin n)).PairwiseDisjoint
-        (fun y => Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-          (permDList σ D).head? = some y)) := by
+        (fun y => S.filter (fun σ => (permDList σ D).head? = some y)) := by
       intros y _ y' _ hne
       simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
       rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
       exact hne (Option.some.inj (h₁.symm.trans h₂))
     rw [h_decomp, Finset.card_biUnion h_disjoint, Finset.sum_mul,
         Finset.sum_congr rfl
-          (fun y hy => head_eq_card y (Finset.mem_inter.mp hy).2),
+          (fun y hy => card_filter_head_eq_mul y (Finset.mem_inter.mp hy).2 h_closed),
         Finset.sum_const, smul_eq_mul, mul_comm]
 
-/-- **Rational variation rate**: the fraction of permutations with
-    `permDList`-head in `Y` is `|Y ∩ D| / |D|` (both as ℚ).
-
-    Direct rational form of `perm_filter_head_in_card`, intended for
-    consumers stating per-context probabilities (e.g.
-    `pocPredict … = 1/3`). For empty `D`, both sides are `0/0 = 0` by
-    Lean's convention. -/
-theorem perm_filter_head_in_rate (D Y : Finset (Fin n)) :
-    ((Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-      ∃ x ∈ Y, (permDList σ D).head? = some x)).card : ℚ) / n.factorial =
-    ((Y ∩ D).card : ℚ) / D.card := by
-  have h := perm_filter_head_in_card D Y
-  -- h : count * D.card = n.factorial * (Y ∩ D).card (in ℕ)
-  have h_fact_pos : 0 < n.factorial := Nat.factorial_pos n
+/-- **Rational rate over a swap-closed family**: the fraction of `σ ∈ S` with
+    `permDList`-head in `Y` is `|Y ∩ D| / |D|` (both as ℚ). For empty `D`,
+    both sides are `0` by Lean's `0/0 = 0` convention. -/
+theorem filter_head_in_rate_of_swaps (S : Finset (Equiv.Perm (Fin n)))
+    (D Y : Finset (Fin n)) (h_S : S.Nonempty)
+    (h_closed : ∀ y₁ ∈ D, ∀ y₂ ∈ D, ∀ σ ∈ S, Equiv.swap y₁ y₂ * σ ∈ S) :
+    ((S.filter (fun σ => ∃ x ∈ Y, (permDList σ D).head? = some x)).card : ℚ) /
+      (S.card : ℚ) =
+    ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
+  have h := filter_head_in_card_of_swaps S D Y h_closed
+  have h_S_pos : 0 < S.card := h_S.card_pos
   rcases Nat.eq_zero_or_pos D.card with h_zero | h_pos
-  · -- D empty: |Y ∩ D| = 0; both sides reduce to 0/...
-    have hYD : (Y ∩ D).card = 0 := by
-      rw [Finset.card_eq_zero] at h_zero
-      simp [h_zero]
+  · -- D empty: both sides reduce to 0
     have h_D_empty : D = ∅ := Finset.card_eq_zero.mp h_zero
-    have h_count_zero : (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+    have hYD : (Y ∩ D).card = 0 := by simp [h_D_empty]
+    have h_count_zero : (S.filter (fun σ =>
         ∃ x ∈ Y, (permDList σ D).head? = some x)).card = 0 := by
       apply Finset.card_eq_zero.mpr
       apply Finset.eq_empty_of_forall_notMem
       intro σ hσ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hσ
-      obtain ⟨x, _, hhead⟩ := hσ
-      have hxD : x ∈ D := head?_eq_some_imp_mem_D hhead
+      simp only [Finset.mem_filter] at hσ
+      obtain ⟨-, x, -, hhead⟩ := hσ
+      have hxD : x ∈ D := mem_of_permDList_head?_eq_some hhead
       rw [h_D_empty] at hxD
       exact (Finset.notMem_empty x) hxD
     rw [h_count_zero, hYD, h_zero, Nat.cast_zero, zero_div, zero_div]
-  · -- D nonempty: derive rational form by clearing denominators
+  · -- D nonempty: clear denominators
     have h_d_ne : (D.card : ℚ) ≠ 0 := by
       simpa using Nat.pos_iff_ne_zero.mp h_pos
-    have h_fact_ne : (n.factorial : ℚ) ≠ 0 := by
-      simpa using Nat.pos_iff_ne_zero.mp h_fact_pos
-    have h_cast : ((Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
-        ∃ x ∈ Y, (permDList σ D).head? = some x)).card : ℚ) *
-        (D.card : ℚ) =
-        (n.factorial : ℚ) * ((Y ∩ D).card : ℚ) := by
+    have h_s_ne : (S.card : ℚ) ≠ 0 := by
+      simpa using Nat.pos_iff_ne_zero.mp h_S_pos
+    have h_cast : ((S.filter (fun σ =>
+        ∃ x ∈ Y, (permDList σ D).head? = some x)).card : ℚ) * (D.card : ℚ) =
+        (S.card : ℚ) * ((Y ∩ D).card : ℚ) := by
       exact_mod_cast h
     field_simp
     linarith [h_cast]
+
+/-- **The closed-form count over all permutations**: `S = Finset.univ`
+    specialization of `filter_head_in_card_of_swaps` (`|S| = n!`). -/
+theorem perm_filter_head_in_card (D Y : Finset (Fin n)) :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+      ∃ x ∈ Y, (permDList σ D).head? = some x)).card * D.card =
+    n.factorial * (Y ∩ D).card := by
+  have h := filter_head_in_card_of_swaps Finset.univ D Y
+    (fun _ _ _ _ σ _ => Finset.mem_univ _)
+  rwa [Finset.card_univ, Fintype.card_perm, Fintype.card_fin] at h
+
+/-- **Rational variation rate**: the fraction of permutations with
+    `permDList`-head in `Y` is `|Y ∩ D| / |D|` (both as ℚ). `S = Finset.univ`
+    specialization of `filter_head_in_rate_of_swaps`, intended for consumers
+    stating per-context probabilities (e.g. `pocPredict … = 1/3`). -/
+theorem perm_filter_head_in_rate (D Y : Finset (Fin n)) :
+    ((Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+      ∃ x ∈ Y, (permDList σ D).head? = some x)).card : ℚ) / n.factorial =
+    ((Y ∩ D).card : ℚ) / D.card := by
+  have h := filter_head_in_rate_of_swaps Finset.univ D Y Finset.univ_nonempty
+    (fun _ _ _ _ σ _ => Finset.mem_univ _)
+  rwa [Finset.card_univ, Fintype.card_perm, Fintype.card_fin] at h
 
 -- ============================================================================
 -- § 7: List-filter head monotonicity under subset relations
@@ -448,14 +464,13 @@ variable {α : Type*} [DecidableEq α]
 theorem filter_cons_head_of_mem (D : Finset α) (z : α) (zs : List α)
     (hzD : z ∈ D) :
     ((z :: zs).filter (· ∈ D)).head? = some z := by
-  rw [List.filter_cons, if_pos (by simpa using hzD)]
-  rfl
+  rw [List.head?_filter, List.find?_cons_of_pos (by simpa using hzD)]
 
 /-- Filtering `z :: zs` by `(· ∈ D)` when `z ∉ D` recurses to `zs`. -/
 theorem filter_cons_head_of_not_mem (D : Finset α) (z : α) (zs : List α)
     (hzD : z ∉ D) :
     ((z :: zs).filter (· ∈ D)).head? = (zs.filter (· ∈ D)).head? := by
-  rw [List.filter_cons, if_neg (by simpa using hzD)]
+  rw [List.head?_filter, List.head?_filter, List.find?_cons_of_neg (by simpa using hzD)]
 
 /-- The head of a list filtered by a larger set `D ⊇ D'` still satisfies a
     "head-in-Y" property, provided `Y' ⊆ Y` and any element of the extra

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -35,7 +35,16 @@ new content here is:
   one, not a third re-stipulation ([merchant-riggle-2016]; [prince-2002]).
 - `pocPredict P p i o`: the probability that POC sampling under p selects
   output o for input i, computed as a ratio of consistent extensions
-  realizing o vs. all consistent extensions.
+  realizing o vs. all consistent extensions. It is a genuine probability
+  distribution: `pocPredict_nonneg`, `pocPredict_le_one`, and — for candidate
+  sets with pairwise-distinct violation profiles — `sum_pocPredict_eq_one`.
+- `stratified stratumOf inner`: the ordinal-sum partial order of a stratum
+  assignment (earlier strata dominate wholesale; `inner` refines within
+  strata) — [anttila-1997]'s stratum grammars and [tesar-smolensky-1995]'s
+  Stratified Domination Hierarchies. `pocPredict_stratified_binary_rate`
+  localizes a binary competition to its deciding stratum: the win probability
+  is `|Y ∩ D| / |D|` over the deciding stratum's distinguishing set, with all
+  lower strata provably irrelevant.
 - `IsPOCRealizable P`: some non-trivial partial order has every consistent
   extension realizing the target. This is the categorical realizability
   notion; the probabilistic story is captured by `pocPredict`.
@@ -264,6 +273,83 @@ theorem consistentTotalOrders_fromPermutation (σ : Ranking n) :
   rw [hτ]
   exact isConsistent_fromPermutation σ
 
+/-! ### Stratified partial orders
+
+A stratum assignment `stratumOf : Fin n → Fin s` together with an inner order
+refining each stratum induces the **stratified** partial order: earlier strata
+dominate later ones wholesale, and within a stratum the inner order applies.
+With the discrete inner order this is the freely-ranked stratum grammar of
+[anttila-1997] eq. (50) — the "Stratified (Domination) Hierarchy" format of
+[tesar-smolensky-1995] that constraint-demotion learning produces. -/
+
+variable {s : ℕ}
+
+/-- The stratified partial order induced by `stratumOf` and an inner order
+`inner`: `rel a b` iff a's stratum strictly precedes b's, or they share a
+stratum and `inner.rel a b`. Cross-stratum `inner` edges are ignored. -/
+def stratified (stratumOf : Fin n → Fin s) (inner : PartialOrderConstraints n) :
+    PartialOrderConstraints n where
+  rel a b := stratumOf a < stratumOf b ∨ (stratumOf a = stratumOf b ∧ inner.rel a b)
+  isPartialOrder :=
+    { refl := fun a => Or.inr ⟨rfl, refl_of inner.rel a⟩
+      trans := fun a b c hab hbc => by
+        rcases hab with hab | ⟨hab, hab'⟩ <;> rcases hbc with hbc | ⟨hbc, hbc'⟩
+        · exact Or.inl (hab.trans hbc)
+        · exact Or.inl (lt_of_lt_of_eq hab hbc)
+        · exact Or.inl (lt_of_eq_of_lt hab hbc)
+        · exact Or.inr ⟨hab.trans hbc, trans_of inner.rel hab' hbc'⟩
+      antisymm := fun a b hab hba => by
+        rcases hab with hab | ⟨hab, hab'⟩ <;> rcases hba with hba | ⟨hba, hba'⟩
+        · exact absurd (hab.trans hba) (lt_irrefl _)
+        · exact absurd (lt_of_lt_of_eq hab hba) (lt_irrefl _)
+        · exact absurd (lt_of_lt_of_eq hba hab) (lt_irrefl _)
+        · exact antisymm_of inner.rel hab' hba' }
+
+/-- Under a stratified order, an earlier-stratum constraint occupies a strictly
+    earlier position in every consistent ranking. -/
+theorem IsConsistent.symm_lt_of_stratum_lt {stratumOf : Fin n → Fin s}
+    {inner : PartialOrderConstraints n} {σ : Ranking n}
+    (hσ : (stratified stratumOf inner).IsConsistent σ) {a b : Fin n}
+    (h : stratumOf a < stratumOf b) : σ.symm a < σ.symm b :=
+  lt_of_le_of_ne (hσ a b (Or.inl h))
+    (fun heq => absurd (σ.symm.injective heq ▸ h) (lt_irrefl _))
+
+/-- Consistent rankings of a stratified order are closed under swapping two
+    constraints of a stratum on which the inner order is trivial — the
+    exchangeability that makes the deciding stratum's internal ranking
+    uniform (`pocPredict_stratified_binary_rate`). -/
+theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
+    {inner : PartialOrderConstraints n} {k : Fin s}
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
+    {d d' : Fin n} (hd : stratumOf d = k) (hd' : stratumOf d' = k)
+    {σ : Ranking n} (hσ : (stratified stratumOf inner).IsConsistent σ) :
+    (stratified stratumOf inner).IsConsistent (Equiv.swap d d' * σ) := by
+  have h_str : ∀ x, stratumOf (Equiv.swap d d' x) = stratumOf x := by
+    intro x
+    rcases eq_or_ne x d with rfl | hxd
+    · rw [Equiv.swap_apply_left, hd', hd]
+    rcases eq_or_ne x d' with rfl | hxd'
+    · rw [Equiv.swap_apply_right, hd, hd']
+    · rw [Equiv.swap_apply_of_ne_of_ne hxd hxd']
+  intro a b hab
+  have h_symm : ∀ x, (Equiv.swap d d' * σ).symm x = σ.symm (Equiv.swap d d' x) := by
+    intro x
+    rw [Equiv.Perm.mul_def, Equiv.symm_trans_apply, Equiv.symm_swap]
+  rw [h_symm a, h_symm b]
+  rcases hab with hlt | ⟨heq, hinner⟩
+  · exact hσ _ _ (Or.inl (by rw [h_str a, h_str b]; exact hlt))
+  · rcases eq_or_ne (stratumOf a) k with hk | hk
+    · obtain rfl : a = b := h_triv a b hk (heq ▸ hk) hinner
+      exact le_refl _
+    · have ha : Equiv.swap d d' a = a :=
+        Equiv.swap_apply_of_ne_of_ne (fun h => hk (by rw [h]; exact hd))
+          (fun h => hk (by rw [h]; exact hd'))
+      have hb : Equiv.swap d d' b = b :=
+        Equiv.swap_apply_of_ne_of_ne (fun h => (heq ▸ hk) (by rw [h]; exact hd))
+          (fun h => (heq ▸ hk) (by rw [h]; exact hd'))
+      rw [ha, hb]
+      exact hσ a b (Or.inr ⟨heq, hinner⟩)
+
 /-- Opaque carrier for the extended linear order. Wrapping `Fin n` in a fresh
     structure lets us equip it with the linear-extension order `s` *without*
     clashing with `Fin n`'s standard order — the diamond that would otherwise
@@ -287,8 +373,8 @@ theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
   let wEquiv : LinExtCarrier n ≃ Fin n :=
     { toFun := LinExtCarrier.toFin, invFun := LinExtCarrier.ofFin,
       left_inv := fun ⟨_⟩ => rfl, right_inv := fun _ => rfl }
-  letI : Fintype (LinExtCarrier n) := Fintype.ofEquiv (Fin n) wEquiv.symm
-  letI : LinearOrder (LinExtCarrier n) :=
+  let : Fintype (LinExtCarrier n) := Fintype.ofEquiv (Fin n) wEquiv.symm
+  let : LinearOrder (LinExtCarrier n) :=
     { le := fun a b => s a.toFin b.toFin
       le_refl := fun a => hs_lin.refl a.toFin
       le_trans := fun a b c => hs_lin.trans a.toFin b.toFin c.toFin
@@ -490,6 +576,96 @@ theorem pocPredict_discrete
     (Finset.univ : Finset (Ranking n)).card := by
   simp only [pocPredict, consistentTotalOrders_discrete]
 
+/-! #### `pocPredict` is a probability distribution -/
+
+theorem pocPredict_nonneg (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n)
+    (i : Input) (o : Output) : 0 ≤ pocPredict cands vp p i o :=
+  div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+theorem pocPredict_le_one (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n)
+    (i : Input) (o : Output) : pocPredict cands vp p i o ≤ 1 := by
+  unfold pocPredict
+  rw [div_le_one (by exact_mod_cast p.consistentTotalOrders_card_pos)]
+  exact_mod_cast Finset.card_filter_le _ _
+
+/-- A ranking picks at most one output: strict lex domination is asymmetric. -/
+theorem picksAt_unique {cands : Input → Finset Output}
+    {vp : Input → Output → Fin n → ℕ} {σ : Ranking n} {i : Input} {o o' : Output}
+    (h : PicksAt cands vp σ i o) (h' : PicksAt cands vp σ i o') : o = o' := by
+  by_contra hne
+  exact absurd (h'.2 o h.1 hne) (lt_asymm (h.2 o' h'.1 fun heq => hne heq.symm))
+
+omit [DecidableEq Output] in
+/-- With pairwise-distinct violation profiles, every ranking picks some output:
+    the candidate with the lex-minimal permuted profile wins strictly. -/
+theorem exists_picksAt (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) {i : Input}
+    (h_ne : (cands i).Nonempty)
+    (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o')
+    (σ : Ranking n) : ∃ o ∈ cands i, PicksAt cands vp σ i o := by
+  obtain ⟨m, hm, hmin⟩ := Finset.exists_min_image (cands i)
+    (fun o => toLex (fun j : Fin n => vp i o (σ j))) h_ne
+  refine ⟨m, hm, hm, fun o' ho' hne' => lt_of_le_of_ne (hmin o' ho') fun heq => hne' ?_⟩
+  have h_fun : (fun j : Fin n => vp i m (σ j)) = fun j => vp i o' (σ j) := toLex_inj.mp heq
+  refine h_inj o' ho' m hm (funext fun c => ?_)
+  have := congrFun h_fun (σ.symm c)
+  simpa using this.symm
+
+/-- **`pocPredict` sums to 1** over any candidate set with pairwise-distinct
+    violation profiles: every consistent ranking picks exactly one winner
+    (`exists_picksAt`, `picksAt_unique`), so the win probabilities form a
+    genuine distribution — for *any* partial order. -/
+theorem sum_pocPredict_eq_one (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
+    (h_ne : (cands i).Nonempty)
+    (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o') :
+    ∑ o ∈ cands i, pocPredict cands vp p i o = 1 := by
+  classical
+  have h_nat : ∑ o ∈ cands i, (p.consistentTotalOrders.filter
+      (fun σ => PicksAt cands vp σ i o)).card = p.consistentTotalOrders.card := by
+    have h_disjoint : (↑(cands i) : Set Output).PairwiseDisjoint
+        (fun o => p.consistentTotalOrders.filter (fun σ => PicksAt cands vp σ i o)) := by
+      intro o _ o' _ hne'
+      simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
+      rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
+      exact hne' (picksAt_unique h₁ h₂)
+    have h_union : (cands i).biUnion (fun o => p.consistentTotalOrders.filter
+        (fun σ => PicksAt cands vp σ i o)) = p.consistentTotalOrders := by
+      ext σ
+      simp only [Finset.mem_biUnion, Finset.mem_filter]
+      constructor
+      · rintro ⟨o, _, hσ, _⟩; exact hσ
+      · intro hσ
+        obtain ⟨o, ho, hpick⟩ := exists_picksAt cands vp h_ne h_inj σ
+        exact ⟨o, ho, hσ, hpick⟩
+    calc ∑ o ∈ cands i, (p.consistentTotalOrders.filter
+          (fun σ => PicksAt cands vp σ i o)).card
+        = ((cands i).biUnion (fun o => p.consistentTotalOrders.filter
+            (fun σ => PicksAt cands vp σ i o))).card :=
+          (Finset.card_biUnion h_disjoint).symm
+      _ = p.consistentTotalOrders.card := by rw [h_union]
+  unfold pocPredict
+  rw [← Finset.sum_div, ← Nat.cast_sum, h_nat]
+  exact div_self (by exact_mod_cast p.consistentTotalOrders_card_pos.ne')
+
+/-- Binary form of `sum_pocPredict_eq_one`: two distinct candidates with
+    distinct violation profiles split the probability mass. -/
+theorem pocPredict_binary_add_eq_one (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
+    {o₁ o₂ : Output} (h_two : cands i = {o₁, o₂}) (h_ne : o₁ ≠ o₂)
+    (h_vp : vp i o₁ ≠ vp i o₂) :
+    pocPredict cands vp p i o₁ + pocPredict cands vp p i o₂ = 1 := by
+  have h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o' := by
+    intro o ho o' ho' hvv
+    rw [h_two, Finset.mem_insert, Finset.mem_singleton] at ho ho'
+    rcases ho with rfl | rfl <;> rcases ho' with rfl | rfl <;>
+      first | rfl | exact absurd hvv h_vp | exact absurd hvv.symm h_vp
+  have h := sum_pocPredict_eq_one cands vp p
+    (by rw [h_two]; exact Finset.insert_nonempty _ _) h_inj
+  rwa [h_two, Finset.sum_pair h_ne] at h
+
 end PartialOrderConstraints
 
 /-! ### Bridge — PicksAt for binary candidates ↔ head-in-Y on permDList -/
@@ -520,8 +696,8 @@ variable {Input : Type*} {n : ℕ}
     constraints distinguishing `chosen` from `other` and `Y` is the
     favoring subset (`vp chosen < vp other`).
 
-    The bridge uses `permDList_head_eq_some_iff` + `permToList_split_at` +
-    `permToList_eq_append_cons_imp_apply` (substrate) to translate
+    The bridge uses `permDList_head_eq_some_iff` + `ofFn_split_at` +
+    `apply_of_ofFn_eq_append_cons` (substrate) to translate
     between the lex `∃k` form and the head-in-Y characterization. -/
 theorem picksAt_binary_iff_permDList_head_lt {Output : Type*} [DecidableEq Output]
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
@@ -569,7 +745,7 @@ theorem picksAt_binary_iff_permDList_head_lt {Output : Type*} [DecidableEq Outpu
     refine ⟨σ k, h_σk_Y, ?_⟩
     rw [permDList_head_eq_some_iff]
     refine ⟨h_σk_D, ((List.finRange n).take k.val).map σ,
-            ((List.finRange n).drop (k.val + 1)).map σ, permToList_split_at σ k, ?_⟩
+            ((List.finRange n).drop (k.val + 1)).map σ, ofFn_split_at σ k, ?_⟩
     intro y hy
     obtain ⟨j, h_j_take, h_σj⟩ := List.mem_map.mp hy
     rw [List.mem_take_iff_getElem] at h_j_take
@@ -587,17 +763,17 @@ theorem picksAt_binary_iff_permDList_head_lt {Output : Type*} [DecidableEq Outpu
     rw [permDList_head_eq_some_iff] at h_head
     obtain ⟨h_x_D, pre, suf, h_split, h_pre⟩ := h_head
     have h_pre_len_lt : pre.length < n := by
-      have h_perm_len : (permToList σ).length = n := permToList_length σ
+      have h_perm_len : (List.ofFn ⇑σ).length = n := List.length_ofFn
       rw [h_split] at h_perm_len
       simp [List.length_append, List.length_cons] at h_perm_len
       omega
-    have h_σk_x := permToList_eq_append_cons_imp_apply σ pre suf x h_split h_pre_len_lt
+    have h_σk_x := apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_len_lt
     refine ⟨⟨pre.length, h_pre_len_lt⟩, ?_, ?_⟩
     · -- ∀ j < ⟨pre.length, _⟩, vp chosen (σ j) = vp other (σ j)
       intro j h_j_lt
       rw [Fin.lt_def] at h_j_lt
       -- σ j is the j-th element of `((finRange n).take pre.length).map σ` (= pre)
-      have h_split_pre := permToList_split_at σ ⟨pre.length, h_pre_len_lt⟩
+      have h_split_pre := ofFn_split_at σ ⟨pre.length, h_pre_len_lt⟩
       -- Combined: ((take pre.length).map σ) ++ σ ⟨...⟩ :: ((drop _).map σ) = pre ++ x :: suf
       have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
         rw [List.length_map, List.length_take, List.length_finRange]; omega
@@ -695,6 +871,93 @@ theorem pocPredict_discrete_binary_rate
     ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
   rw [pocPredict_discrete, Finset.card_univ, Fintype.card_perm, Fintype.card_fin]
   exact picksAt_rate_eq cands vp i chosen other h_two h_ne D Y h_D h_Y
+
+/-! ### Deciding-stratum rate for stratified grammars
+
+For a stratified grammar, a binary competition decided at stratum `k` — the
+variants tie on every earlier stratum and some stratum-`k` constraint
+distinguishes them — reduces to the within-stratum closed form
+`|Y ∩ D| / |D|` over the deciding stratum's distinguishing set, regardless of
+the profiles (and inner rankings) of later strata. This is [anttila-1997]'s
+tableau-count shortcut stated against the full grammar rather than a
+per-stratum sub-grammar: strata below the deciding one never matter, and the
+deciding stratum's free internal ranking is uniform by exchangeability
+(`isConsistent_swap_mul` + `filter_head_in_rate_of_swaps`). -/
+
+/-- On rankings consistent with a stratified order, the first distinguishing
+    constraint overall is the first distinguishing constraint of the deciding
+    stratum: strata before `k` don't distinguish, and constraints of strata
+    after `k` come later in every consistent ranking. -/
+private theorem permDList_head?_of_stratified {s : ℕ} {stratumOf : Fin n → Fin s}
+    {inner : PartialOrderConstraints n} {σ : Ranking n}
+    (hσ : (stratified stratumOf inner).IsConsistent σ) {k : Fin s}
+    {Dfull Dk : Finset (Fin n)}
+    (h_below : ∀ c ∈ Dfull, ¬ stratumOf c < k)
+    (h_at : ∀ c ∈ Dfull, stratumOf c = k → c ∈ Dk)
+    (h_sub : ∀ c ∈ Dk, c ∈ Dfull ∧ stratumOf c = k)
+    (h_ne : Dk.Nonempty) :
+    (permDList σ Dfull).head? = (permDList σ Dk).head? := by
+  obtain ⟨x, hxDk, hx⟩ := exists_permDList_head?_eq_some h_ne σ
+  rw [hx]
+  obtain ⟨-, pre, suf, h_split, h_pre⟩ := (permDList_head_eq_some_iff σ Dk x).mp hx
+  refine (permDList_head_eq_some_iff σ Dfull x).mpr
+    ⟨(h_sub x hxDk).1, pre, suf, h_split, fun y hy hyD => ?_⟩
+  rcases lt_trichotomy (stratumOf y) k with hlt | heq | hgt
+  · exact h_below y hyD hlt
+  · exact h_pre y hy (h_at y hyD heq)
+  · have h1 : σ.symm x < σ.symm y :=
+      hσ.symm_lt_of_stratum_lt (by rw [(h_sub x hxDk).2]; exact hgt)
+    exact absurd (symm_lt_of_ofFn_eq_append_cons σ h_split hy) (asymm h1)
+
+/-- **Deciding-stratum rate**: for binary candidates under a stratified
+    grammar, if the variants tie on every stratum before `k`, the inner order
+    is trivial on stratum `k`, and some stratum-`k` constraint distinguishes
+    them (`h_dec`), then the win probability is the within-stratum closed form
+    `|Y ∩ D| / |D|` — `D` the stratum-`k` distinguishing set, `Y` its
+    `chosen`-favoring subset. Later strata, including any inner rankings among
+    them, cannot affect the outcome. Consumed by `Studies/Anttila1997.lean`,
+    whose six motif competitions run against the full 20-constraint grammar. -/
+theorem pocPredict_stratified_binary_rate {s : ℕ}
+    (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
+    (stratumOf : Fin n → Fin s) (inner : PartialOrderConstraints n)
+    (i : Input) (chosen other : Output)
+    (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other) (k : Fin s)
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
+    (h_above : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
+    (D Y : Finset (Fin n))
+    (h_D : ∀ c, c ∈ D ↔ stratumOf c = k ∧ vp i chosen c ≠ vp i other c)
+    (h_Y : ∀ c, c ∈ Y ↔ stratumOf c = k ∧ vp i chosen c < vp i other c)
+    (h_dec : D.Nonempty) :
+    pocPredict cands vp (stratified stratumOf inner) i chosen =
+      ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
+  classical
+  have h_iff : ∀ σ ∈ (stratified stratumOf inner).consistentTotalOrders,
+      (PicksAt cands vp σ i chosen ↔ ∃ x ∈ Y, (permDList σ D).head? = some x) := by
+    intro σ hσ
+    rw [mem_consistentTotalOrders] at hσ
+    rw [picksAt_binary_iff_permDList_head_lt cands vp i chosen other h_two h_ne σ]
+    have h_head : (permDList σ (Finset.univ.filter
+        (fun c => vp i chosen c ≠ vp i other c))).head? = (permDList σ D).head? := by
+      refine permDList_head?_of_stratified (k := k) (Dk := D) hσ (fun c hc hlt => ?_)
+        (fun c hc hck => ?_) (fun c hc => ?_) h_dec
+      · exact (Finset.mem_filter.mp hc).2 (h_above c hlt)
+      · exact (h_D c).mpr ⟨hck, (Finset.mem_filter.mp hc).2⟩
+      · obtain ⟨hck, hne'⟩ := (h_D c).mp hc
+        exact ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ _, hne'⟩, hck⟩
+    rw [h_head]
+    constructor
+    · rintro ⟨x, hxY, hhead⟩
+      have hxD := mem_of_permDList_head?_eq_some hhead
+      exact ⟨x, (h_Y x).mpr ⟨((h_D x).mp hxD).1, (Finset.mem_filter.mp hxY).2⟩, hhead⟩
+    · rintro ⟨x, hxY, hhead⟩
+      exact ⟨x, Finset.mem_filter.mpr ⟨Finset.mem_univ _, ((h_Y x).mp hxY).2⟩, hhead⟩
+  unfold pocPredict
+  rw [Finset.filter_congr h_iff]
+  exact filter_head_in_rate_of_swaps _ D Y
+    (stratified stratumOf inner).consistentTotalOrders_nonempty
+    (fun y₁ h₁ y₂ h₂ σ hσ => by
+      rw [mem_consistentTotalOrders] at hσ ⊢
+      exact isConsistent_swap_mul h_triv ((h_D y₁).mp h₁).1 ((h_D y₂).mp h₂).1 hσ)
 
 /-! ### Bridge to the `Grammar` hub
 

--- a/Linglib/Studies/Anttila1997.lean
+++ b/Linglib/Studies/Anttila1997.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
-import Mathlib.Tactic.NormNum
+import Mathlib.Data.Fin.VecNotation
 
 /-!
 # [anttila-1997]: Deriving Variation from Grammar
@@ -16,44 +16,43 @@ published chapter [anttila-1997] paginates 35–68.
 
 ## The grammar
 
-Anttila's final grammar (eq. (50), page 21) stratifies 20 constraints into 5
-mutually-ranked sets:
+`finnishGrammar` is "the grammar for Finnish, final version" (eq. (50),
+page 21) in full: 20 constraints in 5 mutually-ranked sets, as a single
+`stratified` partial order on `Fin 20`:
 
   - Set 1: \*X́.X́ (No Clash)
   - Set 2: \*Ĺ (Peak Prominence: no stressed lights), \*H (Weight-to-Stress:
     no unstressed heavies)
   - Set 3: \*H/I, \*Í, \*L.L
   - Set 4: \*H/O, \*Ó, \*L/A, \*H.H, \*H́, \*X.X
-  - Set 5: 8 lower constraints (\*H/A, \*Á, \*L/O, \*L/I, \*A, \*O, \*I, \*L)
+  - Set 5: \*H/A, \*Á, \*L/O, \*L/I, \*A, \*O, \*I, \*L, with internal
+    rankings \*L/O ≫ \*L/I and \*A ≫ \*O ≫ \*I (`setFiveInner`)
 
-Sets 3 and 4 — the two "intermediary constraint sets" of eq. (49) — are
-internally unranked: "While mutually ranked, the sets are internally random"
-(page 21), so each evaluation samples a total order of the deciding stratum.
-(Set 5 carries internal rankings, \*L/O ≫ \*L/I and \*A ≫ \*O ≫ \*I, but never
-decides the motifs modeled here.)
+Sets 3 and 4 — the "intermediary constraint sets" of eq. (49) — are internally
+unranked: "While mutually ranked, the sets are internally random" (page 21),
+so each evaluation samples a total order.
 
 ## Substrate consumption
 
-This file routes through the POC (Partially Ordered Constraints) substrate.
-Per stratum, a violation-profile function `vp : Motif → Variant → Fin n → ℕ`
-feeds `pocPredict` over `discrete n` (uniform sampling over all `n!`
-stratum-internal rankings), and `pocPredict_discrete_binary_rate` reduces each
-probability to the closed form `|Y ∩ D| / |D|`, where `D` is the set of
-constraints distinguishing the two variants and `Y` those favoring the chosen
-one — mirroring the paper's own shortcut ("Drawing the tableaux was in fact
-unnecessary … knowing that the weak variant violates one constraint (\*L.L)
-while the strong variant violates two (\*H/I, \*Í) gives us the result
-directly", page 22).
+Each motif's probability is `pocPredict` over `finnishGrammar` — uniform
+sampling of the total rankings consistent with the whole grammar, not a
+per-stratum sub-grammar. The substrate's deciding-stratum theorem
+(`pocPredict_stratified_binary_rate`) reduces each competition to the closed
+form `|Y ∩ D| / |D|` over the deciding stratum's distinguishing set — the
+paper's own shortcut ("Drawing the tableaux was in fact unnecessary … knowing
+that the weak variant violates one constraint (\*L.L) while the strong variant
+violates two (\*H/I, \*Í) gives us the result directly", page 22) — with the
+irrelevance of the lower strata a theorem rather than an aside.
 
-Two POC instances, one per stratum: Set 3 (n = 3) decides motifs 1ab, 2ab,
-3ab, 6ab; Set 4 (n = 6) decides motifs 4ab, 5ab.
-
-We stipulate violation profiles via `vp` rather than defining `Constraint`
-instances over candidate structures: the paper's quantitative section works
-directly at violation-profile granularity (table (52)). True `Constraint`
-formalisations would need a Finnish syllable substrate (stress / weight /
-sonority features feeding syllable structure) which doesn't yet exist in
-linglib.
+Violation profiles are stipulated from table (52) rather than derived from
+`Constraint` instances: the paper's quantitative section works directly at
+violation-profile granularity. True `Constraint` formalisations would need a
+Finnish syllable substrate (stress / weight / sonority features feeding
+syllable structure) which doesn't yet exist in linglib. Sets 1–2 tie on every
+motif (the stress constraints are inactive on these long-stem competitions,
+witnessed by table (52) carrying only Set 3 and Set 4 columns); Set-5 cells
+are set to 0 — the deciding-stratum theorem makes them provably irrelevant,
+so no Set-5 profile fidelity is claimed.
 
 ## Predictions formalized
 
@@ -73,11 +72,13 @@ frequencies from table (53) (page 23):
   - **6ab** (`H.TÍI` ∼ `H.TI`, `pó.lii.sèi.den` ∼ `pó.lii.si.en`): strong
     loses in all rankings. Observed: 1.6% / 98.4% (13 / 806).
 
+`winProb_strong_add_weak` verifies the two variants partition the probability
+mass for every motif (`sum_pocPredict_eq_one` substrate instance).
+
 ## Out of scope
 
-- **Sets 1, 2, and 5**, and the categorical short-stem patterns that the
-  stress constraints of Sets 1–2 decide (mono- and disyllabic stems, the
-  paper's §2.1 and §5.1–5.2).
+- **The categorical short-stem patterns** decided by the stress constraints of
+  Sets 1–2 (mono- and disyllabic stems, the paper's §2.1 and §5.1–5.2).
 - **Observed-vs-predicted comparison theorems.** Table (53)'s small gap
   between predicted and observed is empirical noise around the discrete
   prediction ("as the quantitative predictions of our model are discrete
@@ -87,9 +88,9 @@ frequencies from table (53) (page 23):
 
 namespace Anttila1997
 
-open HarmonicGrammar.PartialOrderConstraints
+open HarmonicGrammar HarmonicGrammar.PartialOrderConstraints
 
-/-! ### Variants -/
+/-! ### Variants and motifs -/
 
 /-- The two genitive-plural variants: strong (heavy penult, final-syllable
 onset /t/ or /d/) vs weak (light penult, onset /j/ or absent)
@@ -111,175 +112,185 @@ theorem Variant.ne_other (v : Variant) : v ≠ v.other := by cases v <;> decide
 theorem Variant.univ_eq_pair (v : Variant) :
     (Finset.univ : Finset Variant) = {v, v.other} := by cases v <;> decide
 
-/-! ### Set 3 — three constraints, motifs 1ab, 2ab, 3ab, 6ab -/
-
-/-- The four motifs of [anttila-1997] table (52) decided by Set 3: 1ab
-(`L.TÁA` ∼ `L.TA`), 2ab (`L.TÓO` ∼ `L.TO`), 3ab (`L.TÍI` ∼ `L.TI`), 6ab
-(`H.TÍI` ∼ `H.TI`). -/
-inductive Set3Motif
+/-- The six motif competitions of [anttila-1997] table (52): 1ab
+(`L.TÁA` ∼ `L.TA`), 2ab (`L.TÓO` ∼ `L.TO`), 3ab (`L.TÍI` ∼ `L.TI`), 4ab
+(`H.TÁA` ∼ `H.TA`), 5ab (`H.TÓO` ∼ `H.TO`), 6ab (`H.TÍI` ∼ `H.TI`). -/
+inductive Motif
   | one
   | two
   | three
+  | four
+  | five
   | six
   deriving DecidableEq, Repr, Fintype
 
-/-- Set-3 violation profile from [anttila-1997] table (52). Constraint
-indices follow eq. (50): `*H/I = 0`, `*Í = 1`, `*L.L = 2`. -/
-def set3Vp : Set3Motif → Variant → Fin 3 → ℕ
-  | .one,   .weak,   ⟨2, _⟩ => 1   -- L.TA  violates *L.L
-  | .two,   .weak,   ⟨2, _⟩ => 1   -- L.TO  violates *L.L
-  | .three, .strong, ⟨0, _⟩ => 1   -- L.TÍI violates *H/I
-  | .three, .strong, ⟨1, _⟩ => 1   -- L.TÍI violates *Í
-  | .three, .weak,   ⟨2, _⟩ => 1   -- L.TI  violates *L.L
-  | .six,   .strong, ⟨0, _⟩ => 1   -- H.TÍI violates *H/I
-  | .six,   .strong, ⟨1, _⟩ => 1   -- H.TÍI violates *Í
-  | _,      _,       _      => 0
+/-! ### The grammar for Finnish, final version
+
+Constraint roster, in eq. (50)'s column order: `0` = \*X́.X́ (Set 1); `1` =
+\*Ĺ, `2` = \*H (Set 2); `3` = \*H/I, `4` = \*Í, `5` = \*L.L (Set 3); `6` =
+\*H/O, `7` = \*Ó, `8` = \*L/A, `9` = \*H.H, `10` = \*H́, `11` = \*X.X
+(Set 4); `12` = \*H/A, `13` = \*Á, `14` = \*L/O, `15` = \*L/I, `16` = \*A,
+`17` = \*O, `18` = \*I, `19` = \*L (Set 5). -/
+
+/-- Stratum assignment: constraint `c` belongs to Set `stratumOf c + 1` of
+[anttila-1997] eq. (50). -/
+def stratumOf : Fin 20 → Fin 5 :=
+  ![0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4]
+
+/-- The Set-5-internal rankings of [anttila-1997] eq. (50): \*L/O ≫ \*L/I
+(`14 ≫ 15`) and \*A ≫ \*O ≫ \*I (`16 ≫ 17 ≫ 18`), transitively closed. -/
+def setFiveInner : PartialOrderConstraints 20 where
+  rel a b := a = b ∨
+    (a, b) ∈ ([(14, 15), (16, 17), (17, 18), (16, 18)] : List (Fin 20 × Fin 20))
+  isPartialOrder :=
+    { refl := fun _ => Or.inl rfl
+      trans := by decide
+      antisymm := by decide }
+
+/-- **The grammar for Finnish, final version** ([anttila-1997] eq. (50),
+page 21): five mutually-ranked strata, internally free except for
+`setFiveInner`'s Set-5 rankings. -/
+def finnishGrammar : PartialOrderConstraints 20 := stratified stratumOf setFiveInner
+
+/-- Violation profile over the full constraint roster, from [anttila-1997]
+table (52). Sets 1–2 tie on every motif and Set-5 cells are 0 (provably
+irrelevant; see module docstring). -/
+def vp : Motif → Variant → Fin 20 → ℕ
+  | .one,   .weak,   ⟨5, _⟩  => 1   -- L.TA  violates *L.L
+  | .two,   .weak,   ⟨5, _⟩  => 1   -- L.TO  violates *L.L
+  | .three, .strong, ⟨3, _⟩  => 1   -- L.TÍI violates *H/I
+  | .three, .strong, ⟨4, _⟩  => 1   -- L.TÍI violates *Í
+  | .three, .weak,   ⟨5, _⟩  => 1   -- L.TI  violates *L.L
+  | .four,  .strong, ⟨9, _⟩  => 1   -- H.TÁA violates *H.H
+  | .four,  .strong, ⟨10, _⟩ => 1   -- H.TÁA violates *H́
+  | .four,  .weak,   ⟨8, _⟩  => 1   -- H.TA  violates *L/A
+  | .four,  .weak,   ⟨11, _⟩ => 1   -- H.TA  violates *X.X
+  | .five,  .strong, ⟨6, _⟩  => 1   -- H.TÓO violates *H/O
+  | .five,  .strong, ⟨7, _⟩  => 1   -- H.TÓO violates *Ó
+  | .five,  .strong, ⟨9, _⟩  => 1   -- H.TÓO violates *H.H
+  | .five,  .strong, ⟨10, _⟩ => 1   -- H.TÓO violates *H́
+  | .five,  .weak,   ⟨11, _⟩ => 1   -- H.TO  violates *X.X
+  | .six,   .strong, ⟨3, _⟩  => 1   -- H.TÍI violates *H/I
+  | .six,   .strong, ⟨4, _⟩  => 1   -- H.TÍI violates *Í
+  | _,      _,       _       => 0
 
 /-- Probability that variant `v` wins motif `m` under uniform sampling of the
-`3! = 6` Set-3-internal rankings. -/
-def set3Prob (m : Set3Motif) (v : Variant) : ℚ :=
-  pocPredict (fun _ => Finset.univ) set3Vp (discrete 3) m v
+total rankings consistent with `finnishGrammar`. -/
+def winProb (m : Motif) (v : Variant) : ℚ :=
+  pocPredict (fun _ => Finset.univ) vp finnishGrammar m v
 
-/-- Bridge from `pocPredict` to the closed-form rate `|Y ∩ D| / |D|` for
-Set 3, shared by all eight rate theorems. -/
-private theorem set3Prob_eq_rate (m : Set3Motif) (v : Variant)
-    (D Y : Finset (Fin 3))
-    (h_D : ∀ k, k ∈ D ↔ set3Vp m v k ≠ set3Vp m v.other k)
-    (h_Y : ∀ k, k ∈ Y ↔ set3Vp m v k < set3Vp m v.other k) :
-    set3Prob m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
-  pocPredict_discrete_binary_rate _ set3Vp m v v.other (Variant.univ_eq_pair v)
-    v.ne_other D Y h_D h_Y
+/-- Bridge to the deciding-stratum closed form `|Y ∩ D| / |D|`, shared by all
+twelve rate theorems. -/
+private theorem winProb_eq_rate (m : Motif) (v : Variant) (k : Fin 5)
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → setFiveInner.rel a b → a = b)
+    (h_above : ∀ c, stratumOf c < k → vp m v c = vp m v.other c)
+    (D Y : Finset (Fin 20))
+    (h_D : ∀ c, c ∈ D ↔ stratumOf c = k ∧ vp m v c ≠ vp m v.other c)
+    (h_Y : ∀ c, c ∈ Y ↔ stratumOf c = k ∧ vp m v c < vp m v.other c)
+    (h_dec : D.Nonempty) :
+    winProb m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
+  pocPredict_stratified_binary_rate _ vp stratumOf setFiveInner m v v.other
+    (Variant.univ_eq_pair v) v.ne_other k h_triv h_above D Y h_D h_Y h_dec
+
+/-! ### Rate theorems — table (52), all six motifs -/
 
 /-- **Motif 1ab strong `L.TÁA` wins in all rankings** — only the weak variant
-violates a Set-3 constraint (`*L.L`), so `D = Y = {2}` and the rate is `1`:
-the categorical limiting case. -/
-theorem strongProb_1ab : set3Prob .one .strong = 1 := by
-  rw [set3Prob_eq_rate .one .strong {2} {2} (by decide) (by decide)]
+violates a deciding-stratum constraint (`*L.L`), so `D = Y = {5}` and the rate
+is `1`: the categorical limiting case. -/
+theorem strongProb_1ab : winProb .one .strong = 1 := by
+  rw [winProb_eq_rate .one .strong 2 (by decide) (by decide) {5} {5}
+    (by decide) (by decide) ⟨5, by decide⟩]
   decide +kernel
 
 /-- **Motif 1ab weak `L.TA` loses in all rankings** ([anttila-1997]
 table (53): observed 0.6%, an artefact of the spelling of /kollega/). -/
-theorem weakProb_1ab : set3Prob .one .weak = 0 := by
-  rw [set3Prob_eq_rate .one .weak {2} ∅ (by decide) (by decide)]
+theorem weakProb_1ab : winProb .one .weak = 0 := by
+  rw [winProb_eq_rate .one .weak 2 (by decide) (by decide) {5} ∅
+    (by decide) (by decide) ⟨5, by decide⟩]
   decide +kernel
 
 /-- **Motif 2ab strong `L.TÓO` wins in all rankings** — same Set-3 profile as
 motif 1ab. -/
-theorem strongProb_2ab : set3Prob .two .strong = 1 := by
-  rw [set3Prob_eq_rate .two .strong {2} {2} (by decide) (by decide)]
+theorem strongProb_2ab : winProb .two .strong = 1 := by
+  rw [winProb_eq_rate .two .strong 2 (by decide) (by decide) {5} {5}
+    (by decide) (by decide) ⟨5, by decide⟩]
   decide +kernel
 
 /-- **Motif 2ab weak `L.TO` loses in all rankings**. -/
-theorem weakProb_2ab : set3Prob .two .weak = 0 := by
-  rw [set3Prob_eq_rate .two .weak {2} ∅ (by decide) (by decide)]
+theorem weakProb_2ab : winProb .two .weak = 0 := by
+  rw [winProb_eq_rate .two .weak 2 (by decide) (by decide) {5} ∅
+    (by decide) (by decide) ⟨5, by decide⟩]
   decide +kernel
 
-/-- **Motif 3ab strong `L.TÍI` wins 1/3 of Set-3 rankings**: `D = {0, 1, 2}`,
-`Y = {2}` (`*L.L`, violated by weak alone). Observed 36.9% for
-`náa.pu.rèi.den` ([anttila-1997] table (53), row 3a). -/
-theorem strongProb_3ab : set3Prob .three .strong = 1/3 := by
-  rw [set3Prob_eq_rate .three .strong {0, 1, 2} {2} (by decide) (by decide)]
+/-- **Motif 3ab strong `L.TÍI` wins 1/3 of rankings**: decided in Set 3 with
+`D = {*H/I, *Í, *L.L}`, `Y = {*L.L}` (violated by weak alone). Observed 36.9%
+for `náa.pu.rèi.den` ([anttila-1997] table (53), row 3a). -/
+theorem strongProb_3ab : winProb .three .strong = 1/3 := by
+  rw [winProb_eq_rate .three .strong 2 (by decide) (by decide) {3, 4, 5} {5}
+    (by decide) (by decide) ⟨5, by decide⟩]
   decide +kernel
 
-/-- **Motif 3ab weak `L.TI` wins 2/3 of Set-3 rankings**: `Y = {0, 1}`
-(`*H/I`, `*Í`, violated by strong alone). Observed 63.1% for `náa.pu.ri.en`
-([anttila-1997] table (53), row 3b). -/
-theorem weakProb_3ab : set3Prob .three .weak = 2/3 := by
-  rw [set3Prob_eq_rate .three .weak {0, 1, 2} {0, 1} (by decide) (by decide)]
+/-- **Motif 3ab weak `L.TI` wins 2/3 of rankings**: `Y = {*H/I, *Í}` (violated
+by strong alone). Observed 63.1% for `náa.pu.ri.en` ([anttila-1997]
+table (53), row 3b). -/
+theorem weakProb_3ab : winProb .three .weak = 2/3 := by
+  rw [winProb_eq_rate .three .weak 2 (by decide) (by decide) {3, 4, 5} {3, 4}
+    (by decide) (by decide) ⟨5, by decide⟩]
+  decide +kernel
+
+/-- **Motif 4ab strong `H.TÁA` wins 1/2 of rankings**: decided in Set 4 with
+`D = {*L/A, *H.H, *H́, *X.X}`, `Y = {*L/A, *X.X}` (violated by weak alone).
+Observed 50.5% for `máa.il.mòi.den` ([anttila-1997] table (53), row 4a). -/
+theorem strongProb_4ab : winProb .four .strong = 1/2 := by
+  rw [winProb_eq_rate .four .strong 3 (by decide) (by decide) {8, 9, 10, 11} {8, 11}
+    (by decide) (by decide) ⟨8, by decide⟩]
+  decide +kernel
+
+/-- **Motif 4ab weak `H.TA` wins 1/2 of rankings**: `Y = {*H.H, *H́}`.
+Observed 49.5% for `máa.il.mo.jen` ([anttila-1997] table (53), row 4b). -/
+theorem weakProb_4ab : winProb .four .weak = 1/2 := by
+  rw [winProb_eq_rate .four .weak 3 (by decide) (by decide) {8, 9, 10, 11} {9, 10}
+    (by decide) (by decide) ⟨8, by decide⟩]
+  decide +kernel
+
+/-- **Motif 5ab strong `H.TÓO` wins 1/5 of rankings**: decided in Set 4 with
+`D = {*H/O, *Ó, *H.H, *H́, *X.X}`, `Y = {*X.X}` (violated by weak alone).
+Observed 17.8% for `kór.jaa.mòi.den` ([anttila-1997] table (53), row 5a). -/
+theorem strongProb_5ab : winProb .five .strong = 1/5 := by
+  rw [winProb_eq_rate .five .strong 3 (by decide) (by decide)
+    {6, 7, 9, 10, 11} {11} (by decide) (by decide) ⟨6, by decide⟩]
+  decide +kernel
+
+/-- **Motif 5ab weak `H.TO` wins 4/5 of rankings**: `Y = {*H/O, *Ó, *H.H,
+*H́}`. Observed 82.2% for `kór.jaa.mo.jen` ([anttila-1997] table (53),
+row 5b). -/
+theorem weakProb_5ab : winProb .five .weak = 4/5 := by
+  rw [winProb_eq_rate .five .weak 3 (by decide) (by decide)
+    {6, 7, 9, 10, 11} {6, 7, 9, 10} (by decide) (by decide) ⟨6, by decide⟩]
   decide +kernel
 
 /-- **Motif 6ab strong `H.TÍI` loses in all rankings** — only the strong
-variant violates Set-3 constraints (`*H/I`, `*Í`), so `Y = ∅`. -/
-theorem strongProb_6ab : set3Prob .six .strong = 0 := by
-  rw [set3Prob_eq_rate .six .strong {0, 1} ∅ (by decide) (by decide)]
+variant violates deciding-stratum constraints (`*H/I`, `*Í`), so `Y = ∅`. -/
+theorem strongProb_6ab : winProb .six .strong = 0 := by
+  rw [winProb_eq_rate .six .strong 2 (by decide) (by decide) {3, 4} ∅
+    (by decide) (by decide) ⟨3, by decide⟩]
   decide +kernel
 
 /-- **Motif 6ab weak `H.TI` wins in all rankings** ([anttila-1997]
 table (53): observed 98.4%). -/
-theorem weakProb_6ab : set3Prob .six .weak = 1 := by
-  rw [set3Prob_eq_rate .six .weak {0, 1} {0, 1} (by decide) (by decide)]
+theorem weakProb_6ab : winProb .six .weak = 1 := by
+  rw [winProb_eq_rate .six .weak 2 (by decide) (by decide) {3, 4} {3, 4}
+    (by decide) (by decide) ⟨3, by decide⟩]
   decide +kernel
 
-/-! ### Set 4 — six constraints, motifs 4ab and 5ab -/
+/-! ### Completeness -/
 
-/-- The two motifs of [anttila-1997] table (52) decided by Set 4: 4ab
-(`H.TÁA` ∼ `H.TA`) and 5ab (`H.TÓO` ∼ `H.TO`). -/
-inductive Set4Motif
-  | four
-  | five
-  deriving DecidableEq, Repr, Fintype
-
-/-- Set-4 violation profile from [anttila-1997] table (52). Constraint
-indices follow eq. (50): `*H/O = 0`, `*Ó = 1`, `*L/A = 2`, `*H.H = 3`,
-`*H́ = 4`, `*X.X = 5`. -/
-def set4Vp : Set4Motif → Variant → Fin 6 → ℕ
-  | .four, .strong, ⟨3, _⟩ => 1   -- H.TÁA violates *H.H
-  | .four, .strong, ⟨4, _⟩ => 1   -- H.TÁA violates *H́
-  | .four, .weak,   ⟨2, _⟩ => 1   -- H.TA  violates *L/A
-  | .four, .weak,   ⟨5, _⟩ => 1   -- H.TA  violates *X.X
-  | .five, .strong, ⟨0, _⟩ => 1   -- H.TÓO violates *H/O
-  | .five, .strong, ⟨1, _⟩ => 1   -- H.TÓO violates *Ó
-  | .five, .strong, ⟨3, _⟩ => 1   -- H.TÓO violates *H.H
-  | .five, .strong, ⟨4, _⟩ => 1   -- H.TÓO violates *H́
-  | .five, .weak,   ⟨5, _⟩ => 1   -- H.TO  violates *X.X
-  | _,     _,       _      => 0
-
-/-- Probability that variant `v` wins motif `m` under uniform sampling of the
-`6! = 720` Set-4-internal rankings. -/
-def set4Prob (m : Set4Motif) (v : Variant) : ℚ :=
-  pocPredict (fun _ => Finset.univ) set4Vp (discrete 6) m v
-
-/-- Bridge from `pocPredict` to the closed-form rate `|Y ∩ D| / |D|` for
-Set 4, shared by all four rate theorems. -/
-private theorem set4Prob_eq_rate (m : Set4Motif) (v : Variant)
-    (D Y : Finset (Fin 6))
-    (h_D : ∀ k, k ∈ D ↔ set4Vp m v k ≠ set4Vp m v.other k)
-    (h_Y : ∀ k, k ∈ Y ↔ set4Vp m v k < set4Vp m v.other k) :
-    set4Prob m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
-  pocPredict_discrete_binary_rate _ set4Vp m v v.other (Variant.univ_eq_pair v)
-    v.ne_other D Y h_D h_Y
-
-/-- **Motif 4ab strong `H.TÁA` wins 1/2 of Set-4 rankings**: `D = {2, 3, 4, 5}`,
-`Y = {2, 5}` (`*L/A`, `*X.X`, violated by weak alone). Observed 50.5% for
-`máa.il.mòi.den` ([anttila-1997] table (53), row 4a). -/
-theorem strongProb_4ab : set4Prob .four .strong = 1/2 := by
-  rw [set4Prob_eq_rate .four .strong {2, 3, 4, 5} {2, 5} (by decide) (by decide)]
-  decide +kernel
-
-/-- **Motif 4ab weak `H.TA` wins 1/2 of Set-4 rankings**: `Y = {3, 4}`
-(`*H.H`, `*H́`). Observed 49.5% for `máa.il.mo.jen` ([anttila-1997]
-table (53), row 4b). -/
-theorem weakProb_4ab : set4Prob .four .weak = 1/2 := by
-  rw [set4Prob_eq_rate .four .weak {2, 3, 4, 5} {3, 4} (by decide) (by decide)]
-  decide +kernel
-
-/-- **Motif 5ab strong `H.TÓO` wins 1/5 of Set-4 rankings**:
-`D = {0, 1, 3, 4, 5}`, `Y = {5}` (`*X.X`, violated by weak alone). Observed
-17.8% for `kór.jaa.mòi.den` ([anttila-1997] table (53), row 5a). -/
-theorem strongProb_5ab : set4Prob .five .strong = 1/5 := by
-  rw [set4Prob_eq_rate .five .strong {0, 1, 3, 4, 5} {5} (by decide) (by decide)]
-  decide +kernel
-
-/-- **Motif 5ab weak `H.TO` wins 4/5 of Set-4 rankings**: `Y = {0, 1, 3, 4}`
-(`*H/O`, `*Ó`, `*H.H`, `*H́`). Observed 82.2% for `kór.jaa.mo.jen`
-([anttila-1997] table (53), row 5b). -/
-theorem weakProb_5ab : set4Prob .five .weak = 4/5 := by
-  rw [set4Prob_eq_rate .five .weak {0, 1, 3, 4, 5} {0, 1, 3, 4} (by decide) (by decide)]
-  decide +kernel
-
-/-! ### Completeness — each variable motif's two outcomes partition the mass -/
-
-/-- Every Set-3 ranking picks a winner for motif 3ab: the two variants'
-probabilities sum to 1. -/
-theorem complete_3ab : set3Prob .three .strong + set3Prob .three .weak = 1 := by
-  rw [strongProb_3ab, weakProb_3ab]; norm_num
-
-/-- Every Set-4 ranking picks a winner for motif 4ab. -/
-theorem complete_4ab : set4Prob .four .strong + set4Prob .four .weak = 1 := by
-  rw [strongProb_4ab, weakProb_4ab]; norm_num
-
-/-- Every Set-4 ranking picks a winner for motif 5ab. -/
-theorem complete_5ab : set4Prob .five .strong + set4Prob .five .weak = 1 := by
-  rw [strongProb_5ab, weakProb_5ab]; norm_num
+/-- Every ranking of `finnishGrammar` picks a winner for every motif: the two
+variants' probabilities sum to 1 (`sum_pocPredict_eq_one` instance). -/
+theorem winProb_strong_add_weak (m : Motif) :
+    winProb m .strong + winProb m .weak = 1 :=
+  pocPredict_binary_add_eq_one (fun _ => Finset.univ) vp finnishGrammar
+    (i := m) (Variant.univ_eq_pair .strong) (Variant.ne_other .strong)
+    (by cases m <;> decide)
 
 end Anttila1997

--- a/Linglib/Studies/Anttila1997.lean
+++ b/Linglib/Studies/Anttila1997.lean
@@ -1,115 +1,99 @@
 import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
-import Linglib.Core.Optimization.PermSubsetCombinatorics
 import Mathlib.Tactic.NormNum
 
 /-!
 # [anttila-1997]: Deriving Variation from Grammar
 
-Formalizes the quantitative variation predictions for Finnish genitive
-plurals from [anttila-1997]. Anttila's claim: free variation in
-Finnish (and crucially, its statistical biases) is derivable from a
-single partially-ranked OT grammar — the variant probabilities equal
-the fraction of total rankings consistent with the partial ranking
-under which that variant wins.
+Formalizes the Finnish genitive-plural predictions of [anttila-1997]: free
+variation — including its statistical biases — follows from a single
+partially-ranked OT grammar, a variant's probability being the fraction of
+total rankings under which it wins. Categorical outputs are the limiting case
+where every ranking converges on the same winner (probability 1 or 0), so
+categorical and variable motifs fall out of the same grammar.
+
+Page and item numbers cite the ROA-63 manuscript version (May 1995); the
+published chapter [anttila-1997] paginates 35–68.
 
 ## The grammar
 
-Anttila stratifies 16 constraints into 5 mutually-ranked strata, with
-internal random ordering within each stratum
-([anttila-1997] eq. (49)–(50), page 21):
+Anttila's final grammar (eq. (50), page 21) stratifies 20 constraints into 5
+mutually-ranked sets:
 
-  Set 1 ≫ Set 2 ≫ Set 3 ≫ Set 4 ≫ Set 5
+  - Set 1: \*X́.X́ (No Clash)
+  - Set 2: \*Ĺ (Peak Prominence: no stressed lights), \*H (Weight-to-Stress:
+    no unstressed heavies)
+  - Set 3: \*H/I, \*Í, \*L.L
+  - Set 4: \*H/O, \*Ó, \*L/A, \*H.H, \*H́, \*X.X
+  - Set 5: 8 lower constraints (\*H/A, \*Á, \*L/O, \*L/I, \*A, \*O, \*I, \*L)
 
-  - Set 1: \*X̀.X̀ (1 constraint, NoClash)
-  - Set 2: \*L̀, \*H̀ (2 constraints; secondary-stress *L, *H)
-  - Set 3: \*H/I, \*Í, \*L.L (3 constraints)
-  - Set 4: \*H/O, \*Ó, \*L/A, \*H.H, \*X.X, \*H́ (6 constraints; final
-    constraint is `*H́` acute = primary-stressed-heavy, distinct from
-    Set 2's `*H̀` grave = secondary-stressed-heavy)
-  - Set 5: 8 lower constraints (irrelevant for the variation cases here)
+Sets 3 and 4 — the two "intermediary constraint sets" of eq. (49) — are
+internally unranked: "While mutually ranked, the sets are internally random"
+(page 21), so each evaluation samples a total order of the deciding stratum.
+(Set 5 carries internal rankings, \*L/O ≫ \*L/I and \*A ≫ \*O ≫ \*I, but never
+decides the motifs modeled here.)
 
 ## Substrate consumption
 
-This file routes through the project's POC (Partially Ordered
-Constraints) substrate. For each motif, a violation-profile function
-`vp : Input → Variant → Fin n → ℕ` derives `relevant` (where vp
-disagrees on the two variants) and `yesFav` (where vp favors the
-chosen variant). `pocPredict` over `discrete n` (uniform sampling
-over all `n!` total orders) gives the variant probability;
-`picksAt_rate_eq` reduces `pocPredict` to `|Y ∩ D| / |D|` in closed
-form — no enumeration of `n!` rankings.
+This file routes through the POC (Partially Ordered Constraints) substrate.
+Per stratum, a violation-profile function `vp : Motif → Variant → Fin n → ℕ`
+feeds `pocPredict` over `discrete n` (uniform sampling over all `n!`
+stratum-internal rankings), and `pocPredict_discrete_binary_rate` reduces each
+probability to the closed form `|Y ∩ D| / |D|`, where `D` is the set of
+constraints distinguishing the two variants and `Y` those favoring the chosen
+one — mirroring the paper's own shortcut ("Drawing the tableaux was in fact
+unnecessary … knowing that the weak variant violates one constraint (\*L.L)
+while the strong variant violates two (\*H/I, \*Í) gives us the result
+directly", page 22).
 
-Two POC instances, one per stratum:
+Two POC instances, one per stratum: Set 3 (n = 3) decides motifs 1ab, 2ab,
+3ab, 6ab; Set 4 (n = 6) decides motifs 4ab, 5ab.
 
-- **Set 3 (n = 3)**: motif 3ab only. Input is `Unit` (single motif).
-- **Set 4 (n = 6)**: motifs 4ab and 5ab. Input is `Set4Motif` to
-  distinguish the two motifs' violation profiles.
-
-## Note on candidate-feature substrate
-
-We stipulate violation profiles via `vp` rather than defining
-`Constraint` instances. This matches Anttila's own level of
-abstraction: the paper works directly with violation profiles
-([anttila-1997] page 22: "knowing that the weak variant violates
-one constraint (\*L.L) while the strong variant violates two (\*H/I,
-\*Í) gives us the result directly"). True `Constraint`
-formalisations would require a Finnish syllable substrate (input
-forms with stress / weight / sonority features feeding into syllable
-structure) which doesn't yet exist in linglib.
+We stipulate violation profiles via `vp` rather than defining `Constraint`
+instances over candidate structures: the paper's quantitative section works
+directly at violation-profile granularity (table (52)). True `Constraint`
+formalisations would need a Finnish syllable substrate (stress / weight /
+sonority features feeding syllable structure) which doesn't yet exist in
+linglib.
 
 ## Predictions formalized
 
-From [anttila-1997] table 52 (page 22) and table 53 (page 23):
+All six motif competitions of table (52) (page 22); observed 3-syllabic-stem
+frequencies from table (53) (page 23):
 
-  - **3ab** (`L.TÍI` ∼ `L.TI`, e.g. `naa.pu.rei.den` ∼ `naa.pu.ri.en`):
-    decided in Set 3 (n=3). Strong wins 1/3, weak wins 2/3.
-    Observed: 36.9% / 63.1% (215 / 368 corpus tokens).
-  - **4ab** (`H.TÁA` ∼ `H.TA`, e.g. `máa.il.mòi.den` ∼ `máa.il.mo.jen`):
-    decided in Set 4 (n=6) with both variants violating two Set-4
-    constraints. Each wins 1/2.
-    Observed: 50.5% / 49.5% (46 / 45 corpus tokens).
-  - **5ab** (`H.TÓO` ∼ `H.TO`, e.g. `kór.jaa.mòi.den` ∼ `kór.jaa.mo.jen`):
-    decided in Set 4. Strong wins 1/5, weak wins 4/5.
-    Observed: 17.8% / 82.2% (76 / 350 corpus tokens).
+  - **1ab** (`L.TÁA` ∼ `L.TA`, `ká.me.ròi.den` ∼ `ká.me.ro.jen`): strong wins
+    in all rankings. Observed: 99.4% / 0.6% (720 / 4 corpus tokens).
+  - **2ab** (`L.TÓO` ∼ `L.TO`, `hé.te.ròi.den` ∼ `hé.te.ro.jen`): strong wins
+    in all rankings. Observed: 99.5% / 0.5% (389 / 2).
+  - **3ab** (`L.TÍI` ∼ `L.TI`, `náa.pu.rèi.den` ∼ `náa.pu.ri.en`): strong wins
+    1/3, weak 2/3. Observed: 36.9% / 63.1% (215 / 368).
+  - **4ab** (`H.TÁA` ∼ `H.TA`, `máa.il.mòi.den` ∼ `máa.il.mo.jen`): each wins
+    1/2. Observed: 50.5% / 49.5% (46 / 45).
+  - **5ab** (`H.TÓO` ∼ `H.TO`, `kór.jaa.mòi.den` ∼ `kór.jaa.mo.jen`): strong
+    wins 1/5, weak 4/5. Observed: 17.8% / 82.2% (76 / 350).
+  - **6ab** (`H.TÍI` ∼ `H.TI`, `pó.lii.sèi.den` ∼ `pó.lii.si.en`): strong
+    loses in all rankings. Observed: 1.6% / 98.4% (13 / 806).
 
 ## Out of scope
 
-- **Categorical motifs 1ab, 2ab, 6ab.** Per [anttila-1997] table 52,
-  these are decided by Set 1 (NoClash) and Set 2 (\*L̀ / \*H̀), which this
-  file doesn't model. The categorical predictions follow from
-  higher-stratum constraints decisively favoring one variant.
-- **`Constraint` instances** for \*H/I, \*Í, \*L.L, etc. — would
-  require a Finnish syllable substrate (see "Note on candidate-feature
-  substrate" above).
-- **Observed-vs-predicted comparison theorems.** The paper's table 53
-  shows a small gap between predicted (1/3, 2/3, 1/2, 1/2, 1/5, 4/5)
-  and observed; this gap is empirical noise around the discrete
-  prediction (the paper itself notes "as the quantitative predictions
-  of our model are discrete probabilities (1/2, 1/3, 1/5 etc.) it
-  would be difficult to get any closer", page 23).
-
-## Same closed form as [zuraw-2010], [coetzee-pater-2011]
-
-Anttila's Finnish variation, Zuraw's Tagalog factorial typology, and
-Coetzee & Pater's English t/d-deletion all reduce to the same
-substrate predictor `pocPredict (discrete n)` with binary candidate
-spaces — variant probability = `|Y ∩ D| / |D|` (where D distinguishes
-and Y favors the chosen variant). The reusability across three
-phonological domains validates the abstraction; see
-`Studies/Zuraw2010.lean` and
-`Studies/CoetzeePater2011.lean` for sister
-consumers.
+- **Sets 1, 2, and 5**, and the categorical short-stem patterns that the
+  stress constraints of Sets 1–2 decide (mono- and disyllabic stems, the
+  paper's §2.1 and §5.1–5.2).
+- **Observed-vs-predicted comparison theorems.** Table (53)'s small gap
+  between predicted and observed is empirical noise around the discrete
+  prediction ("as the quantitative predictions of our model are discrete
+  probabilities (1/2, 1/3, 1/5 etc.) it would be difficult to get any
+  closer", page 23).
 -/
 
 namespace Anttila1997
 
-open Core.Optimization HarmonicGrammar.PartialOrderConstraints
+open HarmonicGrammar.PartialOrderConstraints
 
-/-! ## § 0: Variant type — strong vs weak genitive plural -/
+/-! ### Variants -/
 
-/-- The two genitive-plural variants: strong (heavy penult, final
-    syllable onset /t/ or /d/) vs weak (light penult, onset /j/ or
-    absent). See [anttila-1997] ex. (1) page 3. -/
+/-- The two genitive-plural variants: strong (heavy penult, final-syllable
+onset /t/ or /d/) vs weak (light penult, onset /j/ or absent)
+([anttila-1997] ex. (1), page 3). -/
 inductive Variant
   | strong
   | weak
@@ -120,242 +104,182 @@ def Variant.other : Variant → Variant
   | .strong => .weak
   | .weak   => .strong
 
-@[simp] theorem Variant.other_strong : Variant.other .strong = .weak := rfl
-@[simp] theorem Variant.other_weak   : Variant.other .weak   = .strong := rfl
+theorem Variant.ne_other (v : Variant) : v ≠ v.other := by cases v <;> decide
 
-/-- The two variants are distinct. -/
-theorem Variant.ne_other : ∀ v : Variant, v ≠ v.other
-  | .strong => fun heq => Variant.noConfusion heq
-  | .weak   => fun heq => Variant.noConfusion heq
+/-- Both variants compete for every input: the candidate set is the pair
+`{v, v.other}` for either choice of `v`. -/
+theorem Variant.univ_eq_pair (v : Variant) :
+    (Finset.univ : Finset Variant) = {v, v.other} := by cases v <;> decide
 
--- ============================================================================
--- § 1: Set 3 — three constraints, n = 3 (motif 3ab)
--- ============================================================================
+/-! ### Set 3 — three constraints, motifs 1ab, 2ab, 3ab, 6ab -/
 
-/-- Set-3 candidate set per (trivial, single-motif) input. -/
-def m3Cands : Unit → Finset Variant := fun _ => Finset.univ
+/-- The four motifs of [anttila-1997] table (52) decided by Set 3: 1ab
+(`L.TÁA` ∼ `L.TA`), 2ab (`L.TÓO` ∼ `L.TO`), 3ab (`L.TÍI` ∼ `L.TI`), 6ab
+(`H.TÍI` ∼ `H.TI`). -/
+inductive Set3Motif
+  | one
+  | two
+  | three
+  | six
+  deriving DecidableEq, Repr, Fintype
 
-/-- Set-3 violation profile for motif 3ab (`L.TÍI` ∼ `L.TI`). Constraint
-    indexing matches [anttila-1997] eq. (50): `*H/I = 0`, `*Í = 1`,
-    `*L.L = 2`. Strong (`L.TÍI`) violates `*H/I` and `*Í`; weak (`L.TI`)
-    violates `*L.L`. -/
-def m3Vp : Unit → Variant → Fin 3 → ℕ
-  | (), .strong, ⟨0, _⟩ => 1   -- L.TÍI violates *H/I
-  | (), .strong, ⟨1, _⟩ => 1   -- L.TÍI violates *Í
-  | (), .weak,   ⟨2, _⟩ => 1   -- L.TI   violates *L.L
-  | _,  _,       _      => 0
+/-- Set-3 violation profile from [anttila-1997] table (52). Constraint
+indices follow eq. (50): `*H/I = 0`, `*Í = 1`, `*L.L = 2`. -/
+def set3Vp : Set3Motif → Variant → Fin 3 → ℕ
+  | .one,   .weak,   ⟨2, _⟩ => 1   -- L.TA  violates *L.L
+  | .two,   .weak,   ⟨2, _⟩ => 1   -- L.TO  violates *L.L
+  | .three, .strong, ⟨0, _⟩ => 1   -- L.TÍI violates *H/I
+  | .three, .strong, ⟨1, _⟩ => 1   -- L.TÍI violates *Í
+  | .three, .weak,   ⟨2, _⟩ => 1   -- L.TI  violates *L.L
+  | .six,   .strong, ⟨0, _⟩ => 1   -- H.TÍI violates *H/I
+  | .six,   .strong, ⟨1, _⟩ => 1   -- H.TÍI violates *Í
+  | _,      _,       _      => 0
 
-/-- Constraints in Set 3 that distinguish strong from weak for motif 3ab. -/
-def relevant_3 : Finset (Fin 3) :=
-  Finset.univ.filter (fun i => m3Vp () .strong i ≠ m3Vp () .weak i)
+/-- Probability that variant `v` wins motif `m` under uniform sampling of the
+`3! = 6` Set-3-internal rankings. -/
+def set3Prob (m : Set3Motif) (v : Variant) : ℚ :=
+  pocPredict (fun _ => Finset.univ) set3Vp (discrete 3) m v
 
-/-- Constraints in Set 3 that favor strong for motif 3ab. -/
-def yesFav_3_strong : Finset (Fin 3) :=
-  Finset.univ.filter (fun i => m3Vp () .strong i < m3Vp () .weak i)
-
-/-- Constraints in Set 3 that favor weak for motif 3ab. -/
-def yesFav_3_weak : Finset (Fin 3) :=
-  Finset.univ.filter (fun i => m3Vp () .weak i < m3Vp () .strong i)
-
-@[simp] theorem relevant_3_eq : relevant_3 = ({0, 1, 2} : Finset (Fin 3)) := by decide
-@[simp] theorem yesFav_3_strong_eq : yesFav_3_strong = ({2} : Finset (Fin 3)) := by decide
-@[simp] theorem yesFav_3_weak_eq : yesFav_3_weak = ({0, 1} : Finset (Fin 3)) := by decide
-
-/-- Variant probability via POC sampling under the discrete partial order. -/
-def subProb_3 (v : Variant) : ℚ :=
-  pocPredict m3Cands m3Vp (discrete 3) () v
-
-/-- The candidate set for motif 3, written as `{v, v.other}` for any
-    variant `v` (used to satisfy `picksAt_rate_eq`'s two-cand hypothesis
-    for both choices of `chosen`). -/
-private theorem m3Cands_eq_pair (v : Variant) :
-    m3Cands () = ({v, v.other} : Finset Variant) := by
-  unfold m3Cands; cases v <;> (ext o; cases o <;> simp [Variant.other])
-
-/-- Bridge from `pocPredict` to closed-form rate `|Y ∩ D| / |D|` for
-    motif 3, factored once and reused by both rate theorems. -/
-private theorem subProb_3_eq_rate (v : Variant)
+/-- Bridge from `pocPredict` to the closed-form rate `|Y ∩ D| / |D|` for
+Set 3, shared by all eight rate theorems. -/
+private theorem set3Prob_eq_rate (m : Set3Motif) (v : Variant)
     (D Y : Finset (Fin 3))
-    (h_D : ∀ k, k ∈ D ↔ m3Vp () v k ≠ m3Vp () v.other k)
-    (h_Y : ∀ k, k ∈ Y ↔ m3Vp () v k < m3Vp () v.other k) :
-    subProb_3 v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
-  pocPredict_discrete_binary_rate m3Cands m3Vp () v v.other
-    (m3Cands_eq_pair v) (Variant.ne_other v) D Y h_D h_Y
+    (h_D : ∀ k, k ∈ D ↔ set3Vp m v k ≠ set3Vp m v.other k)
+    (h_Y : ∀ k, k ∈ Y ↔ set3Vp m v k < set3Vp m v.other k) :
+    set3Prob m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
+  pocPredict_discrete_binary_rate _ set3Vp m v v.other (Variant.univ_eq_pair v)
+    v.ne_other D Y h_D h_Y
 
-/-- **Strong `L.TÍI` wins 1/3 of Set-3 rankings**. Closed form via
-    `picksAt_rate_eq`: `|{2} ∩ {0,1,2}| / |{0,1,2}| = 1/3`. -/
-theorem strongProb_3_eq : subProb_3 .strong = 1/3 := by
-  rw [subProb_3_eq_rate .strong relevant_3 yesFav_3_strong
-        (fun k => by simp [relevant_3])
-        (fun k => by simp [yesFav_3_strong]),
-      relevant_3_eq, yesFav_3_strong_eq,
-      show (({2} : Finset (Fin 3)) ∩ {0, 1, 2}).card = 1 from by decide,
-      show ({0, 1, 2} : Finset (Fin 3)).card = 3 from by decide]
-  norm_num
+/-- **Motif 1ab strong `L.TÁA` wins in all rankings** — only the weak variant
+violates a Set-3 constraint (`*L.L`), so `D = Y = {2}` and the rate is `1`:
+the categorical limiting case. -/
+theorem strongProb_1ab : set3Prob .one .strong = 1 := by
+  rw [set3Prob_eq_rate .one .strong {2} {2} (by decide) (by decide)]
+  decide +kernel
 
-/-- **Weak `L.TI` wins 2/3 of Set-3 rankings**. Matches
-    [anttila-1997]'s observed frequency 63.1% for `naa.pu.ri.en`
-    (table 53, row 3b). -/
-theorem weakProb_3_eq : subProb_3 .weak = 2/3 := by
-  rw [subProb_3_eq_rate .weak relevant_3 yesFav_3_weak
-        (fun k => by
-          simp only [relevant_3, Finset.mem_filter, Finset.mem_univ, true_and]
-          exact ⟨fun h => h.symm, fun h => h.symm⟩)
-        (fun k => by simp [yesFav_3_weak]),
-      relevant_3_eq, yesFav_3_weak_eq,
-      show (({0, 1} : Finset (Fin 3)) ∩ {0, 1, 2}).card = 2 from by decide,
-      show ({0, 1, 2} : Finset (Fin 3)).card = 3 from by decide]
-  norm_num
+/-- **Motif 1ab weak `L.TA` loses in all rankings** ([anttila-1997]
+table (53): observed 0.6%, an artefact of the spelling of /kollega/). -/
+theorem weakProb_1ab : set3Prob .one .weak = 0 := by
+  rw [set3Prob_eq_rate .one .weak {2} ∅ (by decide) (by decide)]
+  decide +kernel
 
--- ============================================================================
--- § 2: Set 4 — six constraints, n = 6 (motifs 4ab and 5ab)
--- ============================================================================
+/-- **Motif 2ab strong `L.TÓO` wins in all rankings** — same Set-3 profile as
+motif 1ab. -/
+theorem strongProb_2ab : set3Prob .two .strong = 1 := by
+  rw [set3Prob_eq_rate .two .strong {2} {2} (by decide) (by decide)]
+  decide +kernel
 
-/-- The two motifs decided by Set 4: 4ab (`H.TÁA` ∼ `H.TA`) and 5ab
-    (`H.TÓO` ∼ `H.TO`). They share the same six-constraint stratum but
-    have different violation profiles. -/
+/-- **Motif 2ab weak `L.TO` loses in all rankings**. -/
+theorem weakProb_2ab : set3Prob .two .weak = 0 := by
+  rw [set3Prob_eq_rate .two .weak {2} ∅ (by decide) (by decide)]
+  decide +kernel
+
+/-- **Motif 3ab strong `L.TÍI` wins 1/3 of Set-3 rankings**: `D = {0, 1, 2}`,
+`Y = {2}` (`*L.L`, violated by weak alone). Observed 36.9% for
+`náa.pu.rèi.den` ([anttila-1997] table (53), row 3a). -/
+theorem strongProb_3ab : set3Prob .three .strong = 1/3 := by
+  rw [set3Prob_eq_rate .three .strong {0, 1, 2} {2} (by decide) (by decide)]
+  decide +kernel
+
+/-- **Motif 3ab weak `L.TI` wins 2/3 of Set-3 rankings**: `Y = {0, 1}`
+(`*H/I`, `*Í`, violated by strong alone). Observed 63.1% for `náa.pu.ri.en`
+([anttila-1997] table (53), row 3b). -/
+theorem weakProb_3ab : set3Prob .three .weak = 2/3 := by
+  rw [set3Prob_eq_rate .three .weak {0, 1, 2} {0, 1} (by decide) (by decide)]
+  decide +kernel
+
+/-- **Motif 6ab strong `H.TÍI` loses in all rankings** — only the strong
+variant violates Set-3 constraints (`*H/I`, `*Í`), so `Y = ∅`. -/
+theorem strongProb_6ab : set3Prob .six .strong = 0 := by
+  rw [set3Prob_eq_rate .six .strong {0, 1} ∅ (by decide) (by decide)]
+  decide +kernel
+
+/-- **Motif 6ab weak `H.TI` wins in all rankings** ([anttila-1997]
+table (53): observed 98.4%). -/
+theorem weakProb_6ab : set3Prob .six .weak = 1 := by
+  rw [set3Prob_eq_rate .six .weak {0, 1} {0, 1} (by decide) (by decide)]
+  decide +kernel
+
+/-! ### Set 4 — six constraints, motifs 4ab and 5ab -/
+
+/-- The two motifs of [anttila-1997] table (52) decided by Set 4: 4ab
+(`H.TÁA` ∼ `H.TA`) and 5ab (`H.TÓO` ∼ `H.TO`). -/
 inductive Set4Motif
   | four
   | five
   deriving DecidableEq, Repr, Fintype
 
-/-- Set-4 candidate set per motif. -/
-def m45Cands : Set4Motif → Finset Variant := fun _ => Finset.univ
-
-/-- Set-4 violation profile for motifs 4ab and 5ab. Constraint indexing
-    matches [anttila-1997] eq. (50): `*H/O = 0`, `*Ó = 1`,
-    `*L/A = 2`, `*H.H = 3`, `*X.X = 4`, `*H́ = 5`.
-
-    Motif 4ab (`H.TÁA` ∼ `H.TA`): strong violates `*H.H, *H́`; weak
-    violates `*L/A, *X.X` (per [anttila-1997] table 52).
-    Motif 5ab (`H.TÓO` ∼ `H.TO`): strong violates `*H/O, *Ó, *H.H, *H́`;
-    weak violates only `*X.X`. -/
-def m45Vp : Set4Motif → Variant → Fin 6 → ℕ
+/-- Set-4 violation profile from [anttila-1997] table (52). Constraint
+indices follow eq. (50): `*H/O = 0`, `*Ó = 1`, `*L/A = 2`, `*H.H = 3`,
+`*H́ = 4`, `*X.X = 5`. -/
+def set4Vp : Set4Motif → Variant → Fin 6 → ℕ
   | .four, .strong, ⟨3, _⟩ => 1   -- H.TÁA violates *H.H
-  | .four, .strong, ⟨5, _⟩ => 1   -- H.TÁA violates *H́
+  | .four, .strong, ⟨4, _⟩ => 1   -- H.TÁA violates *H́
   | .four, .weak,   ⟨2, _⟩ => 1   -- H.TA  violates *L/A
-  | .four, .weak,   ⟨4, _⟩ => 1   -- H.TA  violates *X.X
+  | .four, .weak,   ⟨5, _⟩ => 1   -- H.TA  violates *X.X
   | .five, .strong, ⟨0, _⟩ => 1   -- H.TÓO violates *H/O
   | .five, .strong, ⟨1, _⟩ => 1   -- H.TÓO violates *Ó
   | .five, .strong, ⟨3, _⟩ => 1   -- H.TÓO violates *H.H
-  | .five, .strong, ⟨5, _⟩ => 1   -- H.TÓO violates *H́
-  | .five, .weak,   ⟨4, _⟩ => 1   -- H.TO  violates *X.X
+  | .five, .strong, ⟨4, _⟩ => 1   -- H.TÓO violates *H́
+  | .five, .weak,   ⟨5, _⟩ => 1   -- H.TO  violates *X.X
   | _,     _,       _      => 0
 
-/-- Set-4 distinguishing-constraint set for motif `m`. -/
-def relevant_45 (m : Set4Motif) : Finset (Fin 6) :=
-  Finset.univ.filter (fun i => m45Vp m .strong i ≠ m45Vp m .weak i)
+/-- Probability that variant `v` wins motif `m` under uniform sampling of the
+`6! = 720` Set-4-internal rankings. -/
+def set4Prob (m : Set4Motif) (v : Variant) : ℚ :=
+  pocPredict (fun _ => Finset.univ) set4Vp (discrete 6) m v
 
-/-- Set-4 strong-favoring constraint set for motif `m`. -/
-def yesFav_45_strong (m : Set4Motif) : Finset (Fin 6) :=
-  Finset.univ.filter (fun i => m45Vp m .strong i < m45Vp m .weak i)
-
-/-- Set-4 weak-favoring constraint set for motif `m`. -/
-def yesFav_45_weak (m : Set4Motif) : Finset (Fin 6) :=
-  Finset.univ.filter (fun i => m45Vp m .weak i < m45Vp m .strong i)
-
-@[simp] theorem relevant_45_four : relevant_45 .four = ({2, 3, 4, 5} : Finset (Fin 6)) := by decide
-@[simp] theorem relevant_45_five : relevant_45 .five = ({0, 1, 3, 4, 5} : Finset (Fin 6)) := by decide
-@[simp] theorem yesFav_45_strong_four : yesFav_45_strong .four = ({2, 4} : Finset (Fin 6)) := by decide
-@[simp] theorem yesFav_45_weak_four : yesFav_45_weak .four = ({3, 5} : Finset (Fin 6)) := by decide
-@[simp] theorem yesFav_45_strong_five : yesFav_45_strong .five = ({4} : Finset (Fin 6)) := by decide
-@[simp] theorem yesFav_45_weak_five : yesFav_45_weak .five = ({0, 1, 3, 5} : Finset (Fin 6)) := by decide
-
-/-- Variant probability via POC sampling under the discrete partial order. -/
-def subProb_45 (m : Set4Motif) (v : Variant) : ℚ :=
-  pocPredict m45Cands m45Vp (discrete 6) m v
-
-/-- The Set-4 candidate set for any motif, written as `{v, v.other}` for
-    any variant `v`. -/
-private theorem m45Cands_eq_pair (m : Set4Motif) (v : Variant) :
-    m45Cands m = ({v, v.other} : Finset Variant) := by
-  unfold m45Cands; cases v <;> (ext o; cases o <;> simp [Variant.other])
-
-/-- Bridge from `pocPredict` to closed-form rate `|Y ∩ D| / |D|` for
-    Set-4 motifs, factored once and reused by all four rate theorems. -/
-private theorem subProb_45_eq_rate (m : Set4Motif) (v : Variant)
+/-- Bridge from `pocPredict` to the closed-form rate `|Y ∩ D| / |D|` for
+Set 4, shared by all four rate theorems. -/
+private theorem set4Prob_eq_rate (m : Set4Motif) (v : Variant)
     (D Y : Finset (Fin 6))
-    (h_D : ∀ k, k ∈ D ↔ m45Vp m v k ≠ m45Vp m v.other k)
-    (h_Y : ∀ k, k ∈ Y ↔ m45Vp m v k < m45Vp m v.other k) :
-    subProb_45 m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
-  pocPredict_discrete_binary_rate m45Cands m45Vp m v v.other
-    (m45Cands_eq_pair m v) (Variant.ne_other v) D Y h_D h_Y
+    (h_D : ∀ k, k ∈ D ↔ set4Vp m v k ≠ set4Vp m v.other k)
+    (h_Y : ∀ k, k ∈ Y ↔ set4Vp m v k < set4Vp m v.other k) :
+    set4Prob m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
+  pocPredict_discrete_binary_rate _ set4Vp m v v.other (Variant.univ_eq_pair v)
+    v.ne_other D Y h_D h_Y
 
-/-- **Motif 4ab strong `H.TÁA` wins 1/2 of Set-4 rankings**. Closed form
-    via `picksAt_rate_eq`: `|{2,4} ∩ {2,3,4,5}| / |{2,3,4,5}| = 2/4 = 1/2`. -/
-theorem strongProb_4ab_eq : subProb_45 .four .strong = 1/2 := by
-  rw [subProb_45_eq_rate .four .strong (relevant_45 .four) (yesFav_45_strong .four)
-        (fun k => by simp [relevant_45])
-        (fun k => by simp [yesFav_45_strong]),
-      relevant_45_four, yesFav_45_strong_four,
-      show (({2, 4} : Finset (Fin 6)) ∩ {2, 3, 4, 5}).card = 2 from by decide,
-      show ({2, 3, 4, 5} : Finset (Fin 6)).card = 4 from by decide]
-  norm_num
+/-- **Motif 4ab strong `H.TÁA` wins 1/2 of Set-4 rankings**: `D = {2, 3, 4, 5}`,
+`Y = {2, 5}` (`*L/A`, `*X.X`, violated by weak alone). Observed 50.5% for
+`máa.il.mòi.den` ([anttila-1997] table (53), row 4a). -/
+theorem strongProb_4ab : set4Prob .four .strong = 1/2 := by
+  rw [set4Prob_eq_rate .four .strong {2, 3, 4, 5} {2, 5} (by decide) (by decide)]
+  decide +kernel
 
-/-- **Motif 4ab weak `H.TA` wins 1/2 of Set-4 rankings**. Matches
-    [anttila-1997] observed 49.5% (table 53, row 4b). -/
-theorem weakProb_4ab_eq : subProb_45 .four .weak = 1/2 := by
-  rw [subProb_45_eq_rate .four .weak (relevant_45 .four) (yesFav_45_weak .four)
-        (fun k => by
-          simp only [relevant_45, Finset.mem_filter, Finset.mem_univ, true_and]
-          exact ⟨fun h => h.symm, fun h => h.symm⟩)
-        (fun k => by simp [yesFav_45_weak]),
-      relevant_45_four, yesFav_45_weak_four,
-      show (({3, 5} : Finset (Fin 6)) ∩ {2, 3, 4, 5}).card = 2 from by decide,
-      show ({2, 3, 4, 5} : Finset (Fin 6)).card = 4 from by decide]
-  norm_num
+/-- **Motif 4ab weak `H.TA` wins 1/2 of Set-4 rankings**: `Y = {3, 4}`
+(`*H.H`, `*H́`). Observed 49.5% for `máa.il.mo.jen` ([anttila-1997]
+table (53), row 4b). -/
+theorem weakProb_4ab : set4Prob .four .weak = 1/2 := by
+  rw [set4Prob_eq_rate .four .weak {2, 3, 4, 5} {3, 4} (by decide) (by decide)]
+  decide +kernel
 
-/-- **Motif 5ab strong `H.TÓO` wins 1/5 of Set-4 rankings**. Closed form:
-    `|{4} ∩ {0,1,3,4,5}| / |{0,1,3,4,5}| = 1/5`. -/
-theorem strongProb_5ab_eq : subProb_45 .five .strong = 1/5 := by
-  rw [subProb_45_eq_rate .five .strong (relevant_45 .five) (yesFav_45_strong .five)
-        (fun k => by simp [relevant_45])
-        (fun k => by simp [yesFav_45_strong]),
-      relevant_45_five, yesFav_45_strong_five,
-      show (({4} : Finset (Fin 6)) ∩ {0, 1, 3, 4, 5}).card = 1 from by decide,
-      show ({0, 1, 3, 4, 5} : Finset (Fin 6)).card = 5 from by decide]
-  norm_num
+/-- **Motif 5ab strong `H.TÓO` wins 1/5 of Set-4 rankings**:
+`D = {0, 1, 3, 4, 5}`, `Y = {5}` (`*X.X`, violated by weak alone). Observed
+17.8% for `kór.jaa.mòi.den` ([anttila-1997] table (53), row 5a). -/
+theorem strongProb_5ab : set4Prob .five .strong = 1/5 := by
+  rw [set4Prob_eq_rate .five .strong {0, 1, 3, 4, 5} {5} (by decide) (by decide)]
+  decide +kernel
 
-/-- **Motif 5ab weak `H.TO` wins 4/5 of Set-4 rankings**. Matches
-    [anttila-1997] observed 82.2% (table 53, row 5b). -/
-theorem weakProb_5ab_eq : subProb_45 .five .weak = 4/5 := by
-  rw [subProb_45_eq_rate .five .weak (relevant_45 .five) (yesFav_45_weak .five)
-        (fun k => by
-          simp only [relevant_45, Finset.mem_filter, Finset.mem_univ, true_and]
-          exact ⟨fun h => h.symm, fun h => h.symm⟩)
-        (fun k => by simp [yesFav_45_weak]),
-      relevant_45_five, yesFav_45_weak_five,
-      show (({0, 1, 3, 5} : Finset (Fin 6)) ∩ {0, 1, 3, 4, 5}).card = 4 from by decide,
-      show ({0, 1, 3, 4, 5} : Finset (Fin 6)).card = 5 from by decide]
-  norm_num
+/-- **Motif 5ab weak `H.TO` wins 4/5 of Set-4 rankings**: `Y = {0, 1, 3, 4}`
+(`*H/O`, `*Ó`, `*H.H`, `*H́`). Observed 82.2% for `kór.jaa.mo.jen`
+([anttila-1997] table (53), row 5b). -/
+theorem weakProb_5ab : set4Prob .five .weak = 4/5 := by
+  rw [set4Prob_eq_rate .five .weak {0, 1, 3, 4, 5} {0, 1, 3, 4} (by decide) (by decide)]
+  decide +kernel
 
--- ============================================================================
--- § 3: Variation rates aggregator + binary completeness
--- ============================================================================
+/-! ### Completeness — each variable motif's two outcomes partition the mass -/
 
-/-- All six variation rate predictions from [anttila-1997] table 52
-    derived in closed form from the POC substrate. -/
-theorem variation_rates :
-    subProb_3 .strong = 1/3 ∧ subProb_3 .weak = 2/3 ∧
-    subProb_45 .four .strong = 1/2 ∧ subProb_45 .four .weak = 1/2 ∧
-    subProb_45 .five .strong = 1/5 ∧ subProb_45 .five .weak = 4/5 :=
-  ⟨strongProb_3_eq, weakProb_3_eq,
-   strongProb_4ab_eq, weakProb_4ab_eq,
-   strongProb_5ab_eq, weakProb_5ab_eq⟩
+/-- Every Set-3 ranking picks a winner for motif 3ab: the two variants'
+probabilities sum to 1. -/
+theorem complete_3ab : set3Prob .three .strong + set3Prob .three .weak = 1 := by
+  rw [strongProb_3ab, weakProb_3ab]; norm_num
 
-/-- The two binary outcomes for motif 3ab partition the probability mass
-    (sum to 1). Direct corollary of the rate equalities. -/
-theorem binary_complete_3ab : subProb_3 .strong + subProb_3 .weak = 1 := by
-  rw [strongProb_3_eq, weakProb_3_eq]; norm_num
+/-- Every Set-4 ranking picks a winner for motif 4ab. -/
+theorem complete_4ab : set4Prob .four .strong + set4Prob .four .weak = 1 := by
+  rw [strongProb_4ab, weakProb_4ab]; norm_num
 
-/-- The two binary outcomes for motif 4ab partition the probability mass. -/
-theorem binary_complete_4ab :
-    subProb_45 .four .strong + subProb_45 .four .weak = 1 := by
-  rw [strongProb_4ab_eq, weakProb_4ab_eq]; norm_num
-
-/-- The two binary outcomes for motif 5ab partition the probability mass. -/
-theorem binary_complete_5ab :
-    subProb_45 .five .strong + subProb_45 .five .weak = 1 := by
-  rw [strongProb_5ab_eq, weakProb_5ab_eq]; norm_num
+/-- Every Set-4 ranking picks a winner for motif 5ab. -/
+theorem complete_5ab : set4Prob .five .strong + set4Prob .five .weak = 1 := by
+  rw [strongProb_5ab, weakProb_5ab]; norm_num
 
 end Anttila1997

--- a/references.bib
+++ b/references.bib
@@ -23415,6 +23415,7 @@
   pages     = {35--68},
   publisher = {John Benjamins},
   address   = {Amsterdam},
+  url       = {https://roa.rutgers.edu/files/63-0000/63-0000-ANTTILA-0-0.PDF},
   subfield  = {phonology},
   role      = {formalized},
   sources   = {Studies/Anttila1997.lean}

--- a/references.bib
+++ b/references.bib
@@ -23404,6 +23404,19 @@
   role      = {cited},
   sources   = {Studies/Bruening2021.lean}
 }
+@inproceedings{tesar-smolensky-1995,
+  author    = {Tesar, Bruce and Smolensky, Paul},
+  title     = {The Learnability of Optimality Theory},
+  year      = {1995},
+  booktitle = {The Proceedings of the Thirteenth West Coast Conference on Formal Linguistics},
+  editor    = {Aranovich, R. and Byrne, W. and Preuss, S. and Senturia, M.},
+  pages     = {122--137},
+  publisher = {Stanford Linguistics Association/CSLI},
+  address   = {Stanford, CA},
+  subfield  = {phonology},
+  role      = {cited},
+  sources   = {Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean}
+}
 @incollection{anttila-1997,
   author    = {Anttila, Arto},
   title     = {Deriving Variation from Grammar},


### PR DESCRIPTION
Deep audit of `Studies/Anttila1997.lean` plus the POC substrate deepening it exercises.

- fix docstring fabrications against the ROA-63 ms (20-constraint roster, Set 1–2 names, categorical motifs are Set-3-decided) and formalize all six table (52) motifs — categorical rows as probability 1/0
- add `stratified` grammars with the deciding-stratum rate (lower strata provably irrelevant) and distribution laws for `pocPredict`; the study now runs against the full 20-constraint eq. (50) grammar including Set 5's internal rankings
- align `PermSubsetCombinatorics` with mathlib (`permToList` → `List.ofFn`, `List.filter_map`, `find?_cons_*`) and generalize the head-fiber counting from `Finset.univ` to swap-closed families