### PR TITLE
refactor(Phonology/HarmonicGrammar): cleanse POC via active/favoring API

### DIFF
--- a/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
+++ b/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
@@ -114,9 +114,22 @@ theorem apply_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
     (List.append_inj h_combined h_lhs_pre_len).2
   exact (List.cons.inj h_suf_eq).1
 
+/-- In a decomposition `List.ofFn ⇑σ = pre ++ x :: suf`, the prefix is the
+    σ-image of the first `pre.length` positions. -/
+theorem take_map_eq_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
+    {pre suf : List (Fin n)} {x : Fin n}
+    (h_split : List.ofFn ⇑σ = pre ++ x :: suf) (h_pre_lt : pre.length < n) :
+    ((List.finRange n).take pre.length).map ⇑σ = pre := by
+  have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
+    rw [List.length_map, List.length_take, List.length_finRange]; omega
+  have h_combined : ((List.finRange n).take pre.length).map σ ++
+      σ ⟨pre.length, h_pre_lt⟩ ::
+      ((List.finRange n).drop (pre.length + 1)).map σ = pre ++ x :: suf := by
+    rw [← ofFn_split_at σ ⟨pre.length, h_pre_lt⟩]; exact h_split
+  exact (List.append_inj h_combined h_lhs_pre_len).1
+
 /-- Elements of the prefix of a `List.ofFn ⇑σ` decomposition occupy strictly
-    earlier positions than the distinguished element: if
-    `List.ofFn ⇑σ = pre ++ x :: suf` and `y ∈ pre` then `σ.symm y < σ.symm x`. -/
+    earlier positions than the distinguished element. -/
 theorem symm_lt_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
     {pre suf : List (Fin n)} {x y : Fin n}
     (h_split : List.ofFn ⇑σ = pre ++ x :: suf) (hy : y ∈ pre) :
@@ -124,31 +137,37 @@ theorem symm_lt_of_ofFn_eq_append_cons (σ : Equiv.Perm (Fin n))
   have h_len : (List.ofFn ⇑σ).length = n := List.length_ofFn
   rw [h_split, List.length_append, List.length_cons] at h_len
   have h_pre_lt : pre.length < n := by omega
-  have hx_eq : σ ⟨pre.length, h_pre_lt⟩ = x :=
-    apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_lt
-  -- `pre` is the σ-image of the first `pre.length` positions
-  have h_split_pre := ofFn_split_at σ ⟨pre.length, h_pre_lt⟩
-  have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
-    rw [List.length_map, List.length_take, List.length_finRange]; omega
-  have h_combined : ((List.finRange n).take pre.length).map σ ++
-      σ ⟨pre.length, h_pre_lt⟩ ::
-      ((List.finRange n).drop (pre.length + 1)).map σ = pre ++ x :: suf := by
-    rw [← h_split_pre]; exact h_split
-  have h_pre_eq : ((List.finRange n).take pre.length).map σ = pre :=
-    (List.append_inj h_combined h_lhs_pre_len).1
-  rw [← h_pre_eq] at hy
-  obtain ⟨j, h_j_take, h_σj⟩ := List.mem_map.mp hy
+  rw [← take_map_eq_of_ofFn_eq_append_cons σ h_split h_pre_lt] at hy
+  obtain ⟨j, h_j_take, rfl⟩ := List.mem_map.mp hy
   rw [List.mem_take_iff_getElem] at h_j_take
   obtain ⟨idx, h_idx_lt, h_idx_eq⟩ := h_j_take
   simp only [List.getElem_finRange] at h_idx_eq
   have h_idx_lt_pre : idx < pre.length := by
     simp only [List.length_finRange, lt_min_iff] at h_idx_lt
     omega
-  have hy_symm : σ.symm y = j := by rw [← h_σj, Equiv.symm_apply_apply]
   have hx_symm : σ.symm x = ⟨pre.length, h_pre_lt⟩ := by
-    rw [← hx_eq, Equiv.symm_apply_apply]
-  rw [hy_symm, hx_symm, Fin.lt_def, ← h_idx_eq]
+    rw [← apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_lt, Equiv.symm_apply_apply]
+  rw [Equiv.symm_apply_apply, hx_symm, Fin.lt_def, ← h_idx_eq]
   exact h_idx_lt_pre
+
+/-- Converse of `symm_lt_of_ofFn_eq_append_cons`: a value positioned strictly
+    before `x` lies in the prefix. -/
+theorem mem_pre_of_symm_lt (σ : Equiv.Perm (Fin n))
+    {pre suf : List (Fin n)} {x y : Fin n}
+    (h_split : List.ofFn ⇑σ = pre ++ x :: suf)
+    (hy : σ.symm y < σ.symm x) : y ∈ pre := by
+  have h_len : (List.ofFn ⇑σ).length = n := List.length_ofFn
+  rw [h_split, List.length_append, List.length_cons] at h_len
+  have h_pre_lt : pre.length < n := by omega
+  have hx_symm : σ.symm x = ⟨pre.length, h_pre_lt⟩ := by
+    rw [← apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_lt, Equiv.symm_apply_apply]
+  rw [← take_map_eq_of_ofFn_eq_append_cons σ h_split h_pre_lt]
+  refine List.mem_map.mpr ⟨σ.symm y, ?_, σ.apply_symm_apply y⟩
+  rw [List.mem_take_iff_getElem]
+  refine ⟨(σ.symm y).val, ?_, by simp [List.getElem_finRange]⟩
+  rw [hx_symm, Fin.lt_def] at hy
+  simp only [List.length_finRange, lt_min_iff]
+  exact ⟨hy, (σ.symm y).isLt⟩
 
 /-- The head of `permDList σ D` characterized via mathlib's
     `List.find?_eq_some_iff_append`: `head = some x` iff `x ∈ D` and
@@ -170,6 +189,57 @@ theorem permDList_head_eq_some_iff (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n)
     refine ⟨by simpa using h_x, pre, suf, h_split, fun y hy => ?_⟩
     have := h_pre y hy
     simpa using this
+
+/-- If `(permDList σ D).head? = some x` then `x ∈ D` (the head of a
+    filtered list lies in the filter set). -/
+theorem mem_of_permDList_head?_eq_some {D : Finset (Fin n)}
+    {σ : Equiv.Perm (Fin n)} {x : Fin n}
+    (h : (permDList σ D).head? = some x) : x ∈ D := by
+  cases h_eq : permDList σ D with
+  | nil => rw [h_eq] at h; exact absurd h (by simp)
+  | cons z _ =>
+    rw [h_eq] at h
+    simp only [List.head?_cons, Option.some.injEq] at h
+    subst h
+    have h_mem : z ∈ permDList σ D := by rw [h_eq]; exact List.mem_cons_self
+    rw [mem_permDList] at h_mem; exact h_mem
+
+/-- For nonempty `D`, the head of `permDList σ D` is always defined and
+    lies in `D`. -/
+theorem exists_permDList_head?_eq_some {D : Finset (Fin n)} (h_nonempty : D.Nonempty)
+    (σ : Equiv.Perm (Fin n)) :
+    ∃ y ∈ D, (permDList σ D).head? = some y := by
+  cases h_eq : permDList σ D with
+  | nil =>
+    have h_card : (permDList σ D).length = D.card := permDList_length σ D
+    rw [h_eq] at h_card
+    have : D.card = 0 := by simpa using h_card.symm
+    rw [Finset.card_eq_zero] at this
+    rw [this] at h_nonempty
+    exact absurd h_nonempty Finset.not_nonempty_empty
+  | cons z _ =>
+    refine ⟨z, ?_, by simp⟩
+    have h_head : (permDList σ D).head? = some z := by rw [h_eq]; rfl
+    exact mem_of_permDList_head?_eq_some h_head
+
+/-- **The head of `permDList σ D` is the σ-earliest element of `D`**: `head? =
+    some x` iff `x` lies in `D` and no `D`-element occupies an earlier
+    position. The position-minimum characterization, complementing the
+    decomposition form `permDList_head_eq_some_iff`. -/
+theorem permDList_head?_eq_some_iff_min (σ : Equiv.Perm (Fin n)) (D : Finset (Fin n))
+    (x : Fin n) :
+    (permDList σ D).head? = some x ↔ x ∈ D ∧ ∀ y ∈ D, σ.symm x ≤ σ.symm y := by
+  have fwd : ∀ w, (permDList σ D).head? = some w → w ∈ D ∧ ∀ y ∈ D, σ.symm w ≤ σ.symm y := by
+    intro w h
+    obtain ⟨hwD, pre, suf, h_split, h_pre⟩ := (permDList_head_eq_some_iff σ D w).mp h
+    refine ⟨hwD, fun y hyD => ?_⟩
+    by_contra hlt
+    exact h_pre y (mem_pre_of_symm_lt σ h_split (not_le.mp hlt)) hyD
+  refine ⟨fwd x, ?_⟩
+  rintro ⟨hxD, hmin⟩
+  obtain ⟨z, hzD, hz⟩ := exists_permDList_head?_eq_some ⟨x, hxD⟩ σ
+  obtain ⟨-, hzmin⟩ := fwd z hz
+  rwa [show x = z from σ.symm.injective (le_antisymm (hmin z hzD) (hzmin x hxD))]
 
 -- ============================================================================
 -- § 2: Multiplicative lemma
@@ -210,20 +280,6 @@ private lemma swap_preserves_finset {D : Finset (Fin n)} {y y' : Fin n}
 -- ============================================================================
 -- § 4: Equinumerosity of head-fibers via swap bijection
 -- ============================================================================
-
-/-- If `(permDList σ D).head? = some x` then `x ∈ D` (the head of a
-    filtered list lies in the filter set). -/
-theorem mem_of_permDList_head?_eq_some {D : Finset (Fin n)}
-    {σ : Equiv.Perm (Fin n)} {x : Fin n}
-    (h : (permDList σ D).head? = some x) : x ∈ D := by
-  cases h_eq : permDList σ D with
-  | nil => rw [h_eq] at h; exact absurd h (by simp)
-  | cons z _ =>
-    rw [h_eq] at h
-    simp only [List.head?_cons, Option.some.injEq] at h
-    subst h
-    have h_mem : z ∈ permDList σ D := by rw [h_eq]; exact List.mem_cons_self
-    rw [mem_permDList] at h_mem; exact h_mem
 
 /-- For `y, y' ∈ D` and a family `S` closed under `σ ↦ swap y y' * σ`, the
     fibers `{σ ∈ S : head of permDList σ D = y}` and
@@ -272,24 +328,6 @@ private theorem card_filter_head_fibers_eq {D : Finset (Fin n)}
 -- ============================================================================
 -- § 5: Partition by head over a nonempty D
 -- ============================================================================
-
-/-- For nonempty `D`, the head of `permDList σ D` is always defined and
-    lies in `D`. -/
-theorem exists_permDList_head?_eq_some {D : Finset (Fin n)} (h_nonempty : D.Nonempty)
-    (σ : Equiv.Perm (Fin n)) :
-    ∃ y ∈ D, (permDList σ D).head? = some y := by
-  cases h_eq : permDList σ D with
-  | nil =>
-    have h_card : (permDList σ D).length = D.card := permDList_length σ D
-    rw [h_eq] at h_card
-    have : D.card = 0 := by simpa using h_card.symm
-    rw [Finset.card_eq_zero] at this
-    rw [this] at h_nonempty
-    exact absurd h_nonempty Finset.not_nonempty_empty
-  | cons z _ =>
-    refine ⟨z, ?_, by simp⟩
-    have h_head : (permDList σ D).head? = some z := by rw [h_eq]; rfl
-    exact mem_of_permDList_head?_eq_some h_head
 
 /-- For nonempty `D`, summing head-fiber cardinalities over `y ∈ D` recovers
     the cardinality of any family `S`, since every σ has its head in `D`. -/

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -4,104 +4,56 @@ import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Grammar
 import Linglib.Core.Optimization.PermSubsetCombinatorics
 import Mathlib.Order.Extension.Linear
+import Mathlib.Order.Preorder.Finite
 
 /-!
 # Partially Ordered Constraints (POC)
-[anttila-1997] [kiparsky-1993b] [coetzee-pater-2011]
 
-A POC grammar is a partial order on the constraint set. Each evaluation
-samples a total order (i.e., a linear extension) consistent with the partial
-order, and the OT optimum under that ranking is the output. The induced
-distribution over outputs is uniform over consistent linear extensions.
+A POC grammar is a partial order on the constraint set ([anttila-1997];
+[kiparsky-1993b]). Each evaluation samples a total order consistent with the
+partial order — a linear extension — and the OT optimum under that ranking is
+the output, so a single grammar induces a distribution over outputs, uniform
+over consistent linear extensions. The load-bearing identities are
+division-free cardinality equations (`sum_card_filter_picksAt` here, the
+head-fiber counting in `Core.Optimization.PermSubsetCombinatorics`);
+`pocPredict` and its rate theorems are a ℚ veneer over them.
 
-This module provides the substrate counterpart to the per-paper POC
-analyses: every linear extension is a `Ranking n`, and every
-finite set of consistent extensions sits inside `Finset.univ` for that
-permutation type. The probability of an output is then a ratio of `Finset`
-cardinalities — a clean computation, no measure theory required.
+## Main definitions
 
-## Architecture
+- `PartialOrderConstraints n`: a decidable partial order on `Fin n` constraint
+  indices, with constructors `discrete` (no rankings), `fromPermutation` (a
+  total order), and `stratified` (mutually-ranked strata refined by an inner
+  order — [tesar-smolensky-1995]'s Stratified Domination Hierarchies).
+- `IsConsistent p σ` / `consistentTotalOrders p`: the linear extensions of
+  `p`, a nonempty (Szpilrajn) decidable `Finset`.
+- `pocPredict cands vp p i o`: the probability that sampling under `p` selects
+  output `o` for input `i` — a genuine distribution (`pocPredict_nonneg`,
+  `pocPredict_le_one`, `sum_pocPredict_eq_one`).
+- `active vp i o o'` / `favoring vp i o o'`: the constraints distinguishing a
+  candidate pair, and those preferring `o`.
 
-POC sits in the substrate alongside `Cumulativity.SystemicProblem`, sharing
-its multi-input optimization model and its `realizedByRanking` definition. The
-new content here is:
+## Main statements
 
-- `PartialOrderConstraints n`: a partial order on `Fin n` (constraint indices).
-- `IsConsistent p σ`: σ is a linear extension of p.
-- `consistentTotalOrders p`: the (decidable, finite) set of linear extensions.
-- `toERCSet p` / `consistentTotalOrders_eq_linearExtensions`: the simple-ERC
-  (Hasse-edge) encoding of `p`, identifying its consistent total orders with the
-  lex-grounded `ERCSet.linearExtensions` — so POC's "linear extension" is the ERC
-  one, not a third re-stipulation ([merchant-riggle-2016]; [prince-2002]).
-- `pocPredict P p i o`: the probability that POC sampling under p selects
-  output o for input i, computed as a ratio of consistent extensions
-  realizing o vs. all consistent extensions. It is a genuine probability
-  distribution: `pocPredict_nonneg`, `pocPredict_le_one`, and — for candidate
-  sets with pairwise-distinct violation profiles — `sum_pocPredict_eq_one`.
-- `stratified stratumOf inner`: the ordinal-sum partial order of a stratum
-  assignment (earlier strata dominate wholesale; `inner` refines within
-  strata) — [anttila-1997]'s stratum grammars and [tesar-smolensky-1995]'s
-  Stratified Domination Hierarchies. `pocPredict_stratified_binary_rate`
-  localizes a binary competition to its deciding stratum: the win probability
-  is `|Y ∩ D| / |D|` over the deciding stratum's distinguishing set, with all
-  lower strata provably irrelevant.
-- `IsPOCRealizable P`: some non-trivial partial order has every consistent
-  extension realizing the target. This is the categorical realizability
-  notion; the probabilistic story is captured by `pocPredict`.
-
-## Containments
-
-- `poc_realizable_imp_ot_realizable` — trivial (pick any consistent extension).
-- `ot_realizable_imp_poc_realizable` — non-trivial; the witness is the σ-induced
-  total order, whose unique consistent extension is σ. The uniqueness step
-  uses the standard fact that a strictly monotone bijection on a finite
-  linear order is the identity (proof via `StrictMono.id_le` + dual).
-
-The categorical containment `OT ⊆ POC` is somewhat misleading linguistically:
-POC's expressive advantage over OT is *probabilistic*, not categorical. The
-`pocPredict` API is the principled way to surface that — POC can produce
-intermediate frequencies (e.g., 8/24, 12/24 in [coetzee-pater-2011]'s
-t/d-deletion analysis) that no single OT ranking can reproduce.
-
-## Where this is used
-
-`Studies/CoetzeePater2011.lean` and `Studies/Zuraw2010.lean` consume this
-substrate directly — `pocPredict`, `PicksAt`, and `pocPredict_discrete_binary_rate`
-over the discrete partial order — rather than enumerating rankings by hand.
+- `consistentTotalOrders_eq_linearExtensions`: POC's linear extensions are the
+  ERC ones — the simple-ERC (Hasse-edge) encoding `toERCSet` identifies
+  `consistentTotalOrders` with `ERCSet.linearExtensions`
+  ([merchant-riggle-2016]; [prince-2002]). `toGrammar` routes POC through the
+  `Grammar` hub, and `pocAntimatroid` realizes the Birkhoff correspondence
+  with order-ideal antimatroids ([dilworth-1940]).
+- `isOTRealizable_iff_isPOCRealizable`: categorically, POC adds nothing over
+  OT. Its advantage is probabilistic — `pocPredict` produces intermediate
+  frequencies (e.g. [coetzee-pater-2011]'s 8/24 vs 12/24 t/d-deletion rates)
+  that no single ranking reproduces.
+- `pocPredict_discrete_binary_rate` / `pocPredict_stratified_binary_rate`:
+  closed-form win rates for binary competitions. A ranking is decided by its
+  earliest active constraint (`picksAt_binary_iff_head_mem_favoring`), so
+  `chosen` wins at rate `|favoring ∩ active| / |active|` — restricted to the
+  deciding stratum in the stratified case — with no enumeration of rankings.
 -/
 
 namespace HarmonicGrammar
 
-open Core.Optimization OptimalityTheory
-
-
-open Finset
-
-/-! ### Auxiliary — Strictly Monotone Bijection on Fin n is the Identity -/
-
-/-- A strictly monotone endo-function on `Fin n` is the identity. Both
-    inequalities `id ≤ f` and `f ≤ id` follow from `StrictMono.id_le` (using
-    `Fin n`'s `WellFoundedLT` instance) and its dual (using `WellFoundedGT`),
-    which combine to `f = id` by antisymmetry. -/
-private theorem fin_strictMono_eq_id {n : ℕ} (f : Fin n → Fin n)
-    (hf : StrictMono f) : f = id := by
-  funext k
-  have h₁ : k ≤ f k := hf.id_le k
-  have h₂ : f k ≤ k := hf.le_id k
-  exact le_antisymm h₂ h₁
-
-/-- A monotone bijection on `Fin n` is the identity. The bijection condition
-    promotes monotone to strictly monotone (since equality of f-images forces
-    equality of arguments), then `fin_strictMono_eq_id` finishes. -/
-private theorem fin_monotone_bij_eq_id {n : ℕ}
-    (f : Fin n → Fin n) (hbij : Function.Bijective f) (hmono : Monotone f) :
-    f = id := by
-  have hstrict : StrictMono f := by
-    intro a b hab
-    rcases lt_or_eq_of_le (hmono hab.le) with h | h
-    · exact h
-    · exact absurd (hbij.injective h) hab.ne
-  exact fin_strictMono_eq_id f hstrict
+open Core.Optimization OptimalityTheory Finset
 
 /-! ### PartialOrderConstraints -/
 
@@ -127,9 +79,8 @@ namespace PartialOrderConstraints
 
 variable {n : ℕ}
 
-/-- The discrete partial order on `Fin n`: `rel a b` iff `a = b`. No
-    constraint pair is comparable beyond reflexivity. Every permutation
-    is a consistent linear extension — this matches [anttila-1997]'s
+/-- The discrete partial order on `Fin n`, relating `a` to `b` iff `a = b`.
+    Every permutation is a consistent linear extension — [anttila-1997]'s
     "no ranking imposed" baseline. -/
 def discrete (n : ℕ) : PartialOrderConstraints n where
   rel := Eq
@@ -149,9 +100,9 @@ def fromPermutation (σ : Ranking n) : PartialOrderConstraints n where
       trans := fun _ _ _ h₁ h₂ => le_trans h₁ h₂
       antisymm := fun _ _ h₁ h₂ => σ.symm.injective (le_antisymm h₁ h₂) }
 
-/-- A permutation σ is **consistent** with the partial order p if σ⁻¹
-    respects rel: whenever `rel a b` holds, σ ranks a at least as early
-    as b (`σ.symm a ≤ σ.symm b`). σ is a linear extension of p. -/
+/-- A permutation σ is **consistent** with the partial order p if whenever
+    `rel a b` holds, σ ranks a at least as early as b
+    (`σ.symm a ≤ σ.symm b`) — that is, σ is a linear extension of p. -/
 def IsConsistent (p : PartialOrderConstraints n) (σ : Ranking n) :
     Prop :=
   ∀ a b, p.rel a b → σ.symm a ≤ σ.symm b
@@ -173,19 +124,14 @@ theorem mem_consistentTotalOrders {p : PartialOrderConstraints n}
 
 /-! ### Grounding in the ERC lex API
 
-A partial order is a set of dominance requirements; each strict related pair
-`a ≠ b` with `rel a b` is the Hasse-style ERC `a ≫ b` (`simpleERC a b`,
-[merchant-riggle-2016]'s simple ERCs). Encoding `p` this way shows
-`consistentTotalOrders p` *is* the ERC linear-extension set
-`ERCSet.linearExtensions`, so the POC notion of "consistent total order" is not a
-third re-stipulation of "linear extension" but the lex-grounded ERC one
-([prince-2002]). -/
+A partial order is a set of dominance requirements — each strict related pair
+is a simple ERC `a ≫ b` ([merchant-riggle-2016]), and under this encoding the
+consistent total orders are exactly `ERCSet.linearExtensions` ([prince-2002]). -/
 
-/-- The simple-ERC encoding of a partial order: one ERC `a ≫ b` (`simpleERC a b`)
-for each strict related pair (`a ≠ b` with `rel a b`). Transitively-implied pairs
-are included as well; they are entailed by the covering pairs, so this set has the
-same linear extensions as the Hasse-edge encoding. Built by computable enumeration
-over `List.finRange` so it carries no `noncomputable` marker. -/
+/-- The simple-ERC encoding of a partial order, with one ERC `a ≫ b`
+(`simpleERC a b`) for each strict related pair. Transitively-implied pairs are
+entailed by the covering pairs, so the encoding has the same linear extensions
+as the Hasse-edge one. -/
 def toERCSet (p : PartialOrderConstraints n) : ERCSet n :=
   (List.finRange n).flatMap fun a =>
     (List.finRange n).filterMap fun b =>
@@ -217,10 +163,9 @@ theorem satisfiedBy_toERCSet {p : PartialOrderConstraints n} {σ : Ranking n} :
     exact (simpleERC_satisfiedBy_iff hab σ).mpr
       (lt_of_le_of_ne (hcons a b hrel) (fun heq => hab (σ.symm.injective heq)))
 
-/-- **POC consistency is ERC linear extension.** The consistent total orders of a
-partial order are exactly the linear extensions of its simple-ERC encoding —
-collapsing the POC `consistentTotalOrders` into the lex-grounded
-`ERCSet.linearExtensions` ([merchant-riggle-2016]; [prince-2002]). -/
+/-- The consistent total orders of a partial order are exactly the linear
+extensions of its simple-ERC encoding ([merchant-riggle-2016];
+[prince-2002]). -/
 theorem consistentTotalOrders_eq_linearExtensions (p : PartialOrderConstraints n) :
     p.consistentTotalOrders = p.toERCSet.linearExtensions := by
   ext σ
@@ -243,21 +188,19 @@ theorem mem_consistentTotalOrders_fromPermutation (σ : Ranking n) :
     σ ∈ (fromPermutation σ).consistentTotalOrders :=
   mem_consistentTotalOrders.mpr (isConsistent_fromPermutation σ)
 
-/-- **Uniqueness**: the σ-induced total order has σ as its *unique*
-    consistent linear extension. Any consistent τ must agree with σ
-    pointwise (since τ.symm ∘ σ is a monotone bijection on `Fin n`, hence
-    the identity by `fin_monotone_bij_eq_id`). -/
+/-- The σ-induced total order has σ as its *unique* consistent linear
+    extension. -/
 theorem fromPermutation_consistent_unique {σ τ : Ranking n}
     (hτ : (fromPermutation σ).IsConsistent τ) : τ = σ := by
-  have hcomp : ⇑τ.symm ∘ ⇑σ = id := by
-    apply fin_monotone_bij_eq_id
-    · exact τ.symm.bijective.comp σ.bijective
-    · intro a b hab
-      have hrel : (fromPermutation σ).rel (σ a) (σ b) := by
-        show σ.symm (σ a) ≤ σ.symm (σ b)
-        rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply]
-        exact hab
-      exact hτ (σ a) (σ b) hrel
+  have hmono : Monotone (⇑τ.symm ∘ ⇑σ) := by
+    intro a b hab
+    have hrel : (fromPermutation σ).rel (σ a) (σ b) := by
+      show σ.symm (σ a) ≤ σ.symm (σ b)
+      rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+      exact hab
+    exact hτ (σ a) (σ b) hrel
+  have hcomp : ⇑τ.symm ∘ ⇑σ = id :=
+    (hmono.strictMono_of_injective (τ.symm.injective.comp σ.injective)).eq_id
   apply Equiv.ext
   intro k
   have hk : τ.symm (σ k) = k := congr_fun hcomp k
@@ -275,11 +218,9 @@ theorem consistentTotalOrders_fromPermutation (σ : Ranking n) :
 
 /-! ### Stratified partial orders
 
-A stratum assignment `stratumOf : Fin n → Fin s` together with an inner order
-refining each stratum induces the **stratified** partial order: earlier strata
-dominate later ones wholesale, and within a stratum the inner order applies.
-With the discrete inner order this is the freely-ranked stratum grammar of
-[anttila-1997] eq. (50) — the "Stratified (Domination) Hierarchy" format of
+Earlier strata dominate later ones wholesale, and within a stratum an inner
+order applies. With the discrete inner order this is the freely-ranked stratum
+grammar of [anttila-1997] eq. (50) — the Stratified Domination Hierarchy of
 [tesar-smolensky-1995] that constraint-demotion learning produces. -/
 
 variable {s : ℕ}
@@ -315,9 +256,7 @@ theorem IsConsistent.symm_lt_of_stratum_lt {stratumOf : Fin n → Fin s}
     (fun heq => absurd (σ.symm.injective heq ▸ h) (lt_irrefl _))
 
 /-- Consistent rankings of a stratified order are closed under swapping two
-    constraints of a stratum on which the inner order is trivial — the
-    exchangeability that makes the deciding stratum's internal ranking
-    uniform (`pocPredict_stratified_binary_rate`). -/
+    constraints of a stratum on which the inner order is trivial. -/
 theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
     {inner : PartialOrderConstraints n} {k : Fin s}
     (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
@@ -350,20 +289,15 @@ theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
       rw [ha, hb]
       exact hσ a b (Or.inr ⟨heq, hinner⟩)
 
-/-- Opaque carrier for the extended linear order. Wrapping `Fin n` in a fresh
-    structure lets us equip it with the linear-extension order `s` *without*
-    clashing with `Fin n`'s standard order — the diamond that would otherwise
-    make `≤` ambiguous in the goal. -/
+/-- Opaque carrier for the extended linear order, so that the extension can be
+    installed as a `LinearOrder` instance without clashing with `Fin n`'s
+    standard order. -/
 private structure LinExtCarrier (n : ℕ) where ofFin ::
   /-- The underlying index. -/
   toFin : Fin n
 
-/-- **Every POC has a consistent linear extension** (Szpilrajn): for *any*
-    partial order `p`, `consistentTotalOrders p` is nonempty. This is what the
-    `IsPartialOrder` instance buys — it is the hypothesis of mathlib's
-    `extend_partialOrder`. Consequently `pocPredict`'s denominator
-    (`consistentTotalOrders.card`) is provably positive for every POC, so
-    `pocPredict` is a genuine distribution, not just on `discrete`/`fromPermutation`. -/
+/-- Every partial order has a consistent linear extension (Szpilrajn, via
+    mathlib's `extend_partialOrder`). -/
 theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
     p.consistentTotalOrders.Nonempty := by
   classical
@@ -397,19 +331,15 @@ theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
   exact e.symm.monotone (show s (LinExtCarrier.ofFin a).toFin (LinExtCarrier.ofFin b).toFin from
     hsub a b hab)
 
-/-- `pocPredict`'s denominator `consistentTotalOrders.card` is strictly positive
-    for **any** POC — the `0/0` guard in `pocPredict` is never exercised on a real
-    partial order. Direct consequence of `consistentTotalOrders_nonempty`. -/
 theorem consistentTotalOrders_card_pos (p : PartialOrderConstraints n) :
     0 < p.consistentTotalOrders.card :=
   p.consistentTotalOrders_nonempty.card_pos
 
 /-! ### The order-ideal antimatroid of a POC
 
-A POC partial order's Hasse-edge encoding is a consistent set of *simple* ERCs, so
-it has a Birkhoff antimatroid (`Antimat.ofSimple`). Its feasible sets are exactly
-the order ideals of `p`, giving the antimatroid theory its first grammar-level
-consumer ([dilworth-1940]; [merchant-riggle-2016]). -/
+A partial order's Hasse-edge encoding is a consistent set of simple ERCs, so it
+has a Birkhoff antimatroid whose feasible sets are exactly the order ideals of
+`p` ([dilworth-1940]; [merchant-riggle-2016]). -/
 
 /-- `p.toERCSet` consists of simple ERCs (each is a `simpleERC` of a strict pair). -/
 theorem toERCSet_isSimpleSet (p : PartialOrderConstraints n) :
@@ -424,18 +354,15 @@ theorem toERCSet_consistent (p : PartialOrderConstraints n) :
   obtain ⟨σ, hσ⟩ := p.consistentTotalOrders_nonempty
   exact ⟨σ, satisfiedBy_toERCSet.mpr (mem_consistentTotalOrders.mp hσ)⟩
 
-/-- The **order-ideal antimatroid** of a POC partial order: the simple-ERC
-Birkhoff antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding. Its feasible
-sets are exactly the order ideals of `p` (`pocAntimatroid_isFeasible_iff`) — the
-Birkhoff correspondence between a partial order and its antimatroid
-([dilworth-1940]; [merchant-riggle-2016]). This is the first grammar-level
-consumer of the antimatroid theory. -/
+/-- The **order-ideal antimatroid** of a partial order — the simple-ERC
+Birkhoff antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding, whose
+feasible sets are exactly the order ideals of `p`
+(`pocAntimatroid_isFeasible_iff`). -/
 def pocAntimatroid (p : PartialOrderConstraints n) : Antimatroid (Fin n) :=
   Antimat.ofSimple p.toERCSet p.toERCSet_consistent p.toERCSet_isSimpleSet
 
-/-- Local feasibility against `p.toERCSet` is exactly the order-ideal condition
-(downward-closed under `rel`): if `b ∈ S` and `a` dominates `b` (`rel a b`), then
-`a ∈ S`. -/
+/-- Local feasibility against `p.toERCSet` is exactly the order-ideal
+condition — whenever `b ∈ S` and `a` dominates `b`, also `a ∈ S`. -/
 theorem feasible_toERCSet_iff {p : PartialOrderConstraints n} {S : Finset (Fin n)} :
     Feasible p.toERCSet S ↔ ∀ a b, p.rel a b → b ∈ S → a ∈ S := by
   constructor
@@ -452,7 +379,7 @@ theorem feasible_toERCSet_iff {p : PartialOrderConstraints n} {S : Finset (Fin n
     rw [(simpleERC_eq_L_iff hab l).mp hlL] at hlS
     exact ⟨a, simpleERC_apply_W, h a b hrel hlS⟩
 
-/-- **The feasible sets of `pocAntimatroid` are the order ideals of `p`** — the
+/-- The feasible sets of `pocAntimatroid` are the order ideals of `p` — the
 Birkhoff correspondence, made concrete and decidable. -/
 @[simp] theorem pocAntimatroid_isFeasible_iff {p : PartialOrderConstraints n}
     {S : Finset (Fin n)} :
@@ -469,10 +396,8 @@ namespace SystemicProblem
 variable {Input Output : Type*} {n : ℕ}
 
 /-- A partial order p **POC-realizes** the target if every consistent
-    extension realizes it. There is always at least one consistent extension
-    (`consistentTotalOrders_nonempty`), so this genuinely means target
-    probability = 1 under POC sampling — not the vacuous empty case, which is
-    why no explicit nonemptiness conjunct is needed. -/
+    extension realizes it. Since consistent extensions always exist
+    (`consistentTotalOrders_nonempty`), this is never vacuous. -/
 def realizedByPOC (P : SystemicProblem Input Output n)
     (p : PartialOrderConstraints n) : Prop :=
   ∀ σ ∈ p.consistentTotalOrders, P.realizedByRanking σ
@@ -486,8 +411,8 @@ end SystemicProblem
 
 /-! ### Containments — OT ⊆ POC, POC ⊆ OT (categorical) -/
 
-/-- **Trivial direction**: every POC-realized target is OT-realized
-    (pick any single consistent extension). -/
+/-- Every POC-realized target is OT-realized, since any single consistent
+    extension realizes it. -/
 theorem poc_realizable_imp_ot_realizable {Input Output : Type*} {n : ℕ}
     (P : SystemicProblem Input Output n) :
     P.IsPOCRealizable → P.IsOTRealizable := by
@@ -495,9 +420,8 @@ theorem poc_realizable_imp_ot_realizable {Input Output : Type*} {n : ℕ}
   obtain ⟨σ, hσ⟩ := p.consistentTotalOrders_nonempty
   exact ⟨σ, hreal σ hσ⟩
 
-/-- **Non-trivial direction**: every OT-realized target is POC-realized
-    (the witness is the σ-induced total order, whose unique consistent
-    extension is σ itself by `fromPermutation_consistent_unique`). -/
+/-- Every OT-realized target is POC-realized — the witness is the σ-induced
+    total order, whose unique consistent extension is σ itself. -/
 theorem ot_realizable_imp_poc_realizable {Input Output : Type*} {n : ℕ}
     (P : SystemicProblem Input Output n) :
     P.IsOTRealizable → P.IsPOCRealizable := by
@@ -506,10 +430,9 @@ theorem ot_realizable_imp_poc_realizable {Input Output : Type*} {n : ℕ}
   simpa [SystemicProblem.realizedByPOC,
     PartialOrderConstraints.consistentTotalOrders_fromPermutation] using hσ
 
-/-- **Categorical equivalence**: under categorical realizability,
-    OT-realizable and POC-realizable coincide. POC's *probabilistic*
-    advantage over OT is captured separately by `pocPredict` (next section);
-    no categorical theorem distinguishes them. -/
+/-- Under categorical realizability, OT-realizable and POC-realizable
+    coincide. POC's advantage over OT is probabilistic, captured by
+    `pocPredict`. -/
 theorem isOTRealizable_iff_isPOCRealizable {Input Output : Type*} {n : ℕ}
     (P : SystemicProblem Input Output n) :
     P.IsOTRealizable ↔ P.IsPOCRealizable :=
@@ -520,14 +443,38 @@ theorem isOTRealizable_iff_isPOCRealizable {Input Output : Type*} {n : ℕ}
 
 namespace PartialOrderConstraints
 
-variable {Input Output : Type*} [DecidableEq Output] {n : ℕ}
+variable {Input Output : Type*} {n : ℕ}
 
-/-- σ **picks** output o for input i if o is the unique strict OT winner
-    (every other in-set candidate is lex-strictly worse than o under σ).
+/-- The constraints **active** on the candidate pair `o, o'` at input `i` —
+    those assigning the two candidates different violation counts
+    ([anttila-1997]'s decisive constraints). Inactive constraints cannot
+    affect the competition. -/
+def active (vp : Input → Output → Fin n → ℕ) (i : Input) (o o' : Output) :
+    Finset (Fin n) :=
+  Finset.univ.filter fun c => vp i o c ≠ vp i o' c
 
-    Bare-args version: takes `cands` and `vp` directly rather than bundled
-    in a `SystemicProblem`. POC analyses don't need a target — they're about
-    distribution over outputs, not realization of a chosen one. -/
+/-- The constraints **favoring** `o` over `o'` at input `i` — those assigning
+    `o` strictly fewer violations. -/
+def favoring (vp : Input → Output → Fin n → ℕ) (i : Input) (o o' : Output) :
+    Finset (Fin n) :=
+  Finset.univ.filter fun c => vp i o c < vp i o' c
+
+@[simp] theorem mem_active {vp : Input → Output → Fin n → ℕ} {i : Input}
+    {o o' : Output} {c : Fin n} :
+    c ∈ active vp i o o' ↔ vp i o c ≠ vp i o' c := by
+  simp [active]
+
+@[simp] theorem mem_favoring {vp : Input → Output → Fin n → ℕ} {i : Input}
+    {o o' : Output} {c : Fin n} :
+    c ∈ favoring vp i o o' ↔ vp i o c < vp i o' c := by
+  simp [favoring]
+
+theorem favoring_subset_active (vp : Input → Output → Fin n → ℕ) (i : Input)
+    (o o' : Output) : favoring vp i o o' ⊆ active vp i o o' :=
+  fun _ hc => mem_active.mpr (Nat.ne_of_lt (mem_favoring.mp hc))
+
+/-- σ **picks** output o for input i if o is the unique strict OT winner —
+    every other in-set candidate is lex-strictly worse than o under σ. -/
 def PicksAt (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (σ : Ranking n) (i : Input) (o : Output) : Prop :=
   o ∈ cands i ∧
@@ -535,24 +482,49 @@ def PicksAt (cands : Input → Finset Output) (vp : Input → Output → Fin n �
     toLex (fun k : Fin n => vp i o (σ k)) <
     toLex (fun k : Fin n => vp i o' (σ k))
 
+/-- A ranking picks at most one output, since strict lex domination is
+    asymmetric. -/
+theorem picksAt_unique {cands : Input → Finset Output}
+    {vp : Input → Output → Fin n → ℕ} {σ : Ranking n} {i : Input} {o o' : Output}
+    (h : PicksAt cands vp σ i o) (h' : PicksAt cands vp σ i o') : o = o' := by
+  by_contra hne
+  exact absurd (h'.2 o h.1 hne) (lt_asymm (h.2 o' h'.1 fun heq => hne heq.symm))
+
+/-- With pairwise-distinct violation profiles, every ranking picks some
+    output — the candidate with the lex-minimal permuted profile wins
+    strictly. -/
+theorem exists_picksAt (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) {i : Input}
+    (h_ne : (cands i).Nonempty)
+    (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o')
+    (σ : Ranking n) : ∃ o ∈ cands i, PicksAt cands vp σ i o := by
+  obtain ⟨m, hm, hmin⟩ := Finset.exists_min_image (cands i)
+    (fun o => toLex (fun j : Fin n => vp i o (σ j))) h_ne
+  refine ⟨m, hm, hm, fun o' ho' hne' => lt_of_le_of_ne (hmin o' ho') fun heq => hne' ?_⟩
+  have h_fun : (fun j : Fin n => vp i m (σ j)) = fun j => vp i o' (σ j) := toLex_inj.mp heq
+  refine h_inj o' ho' m hm (funext fun c => ?_)
+  have := congrFun h_fun (σ.symm c)
+  simpa using this.symm
+
+variable [DecidableEq Output]
+
 instance (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (σ : Ranking n) (i : Input) (o : Output) :
     Decidable (PicksAt cands vp σ i o) := by
   unfold PicksAt; infer_instance
 
-/-- The probability that POC sampling under partial order p selects output
-    o for input i: ratio of consistent extensions picking o to total
-    consistent extensions. The denominator is always positive
-    (`consistentTotalOrders_card_pos`), so this is a genuine probability; ℚ's
-    `0/0 = 0` convention is a harmless fallback never exercised on a real POC. -/
+/-- The probability that sampling under partial order p selects output o for
+    input i — the fraction of consistent extensions picking o. The denominator
+    is positive (`consistentTotalOrders_card_pos`), so this is a genuine
+    probability. -/
 def pocPredict (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (p : PartialOrderConstraints n) (i : Input) (o : Output) : ℚ :=
   ((p.consistentTotalOrders.filter
     (fun σ => PicksAt cands vp σ i o)).card : ℚ) /
   (p.consistentTotalOrders.card : ℚ)
 
-/-- For the σ-induced total order, `pocPredict` collapses to a δ at σ's
-    OT-pick: probability 1 if σ picks o, probability 0 otherwise. -/
+/-- For the σ-induced total order, `pocPredict` collapses to a point mass —
+    probability 1 if σ picks o and 0 otherwise. -/
 theorem pocPredict_fromPermutation
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (σ : Ranking n) (i : Input) (o : Output) :
@@ -565,8 +537,8 @@ theorem pocPredict_fromPermutation
   · simp [if_pos h]
   · simp [if_neg h]
 
-/-- Discrete-PO predict: uniform over all permutations (no ranking imposed).
-    Counts the σ's that pick o, divides by `n!`. -/
+/-- Under the discrete order, `pocPredict` is the fraction of all `n!`
+    rankings picking o. -/
 theorem pocPredict_discrete
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (i : Input) (o : Output) :
@@ -590,68 +562,52 @@ theorem pocPredict_le_one (cands : Input → Finset Output)
   rw [div_le_one (by exact_mod_cast p.consistentTotalOrders_card_pos)]
   exact_mod_cast Finset.card_filter_le _ _
 
-/-- A ranking picks at most one output: strict lex domination is asymmetric. -/
-theorem picksAt_unique {cands : Input → Finset Output}
-    {vp : Input → Output → Fin n → ℕ} {σ : Ranking n} {i : Input} {o o' : Output}
-    (h : PicksAt cands vp σ i o) (h' : PicksAt cands vp σ i o') : o = o' := by
-  by_contra hne
-  exact absurd (h'.2 o h.1 hne) (lt_asymm (h.2 o' h'.1 fun heq => hne heq.symm))
-
-omit [DecidableEq Output] in
-/-- With pairwise-distinct violation profiles, every ranking picks some output:
-    the candidate with the lex-minimal permuted profile wins strictly. -/
-theorem exists_picksAt (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) {i : Input}
+/-- With pairwise-distinct violation profiles the picks-fibers over the
+    candidate set partition the consistent extensions — the division-free core
+    of `sum_pocPredict_eq_one`. -/
+theorem sum_card_filter_picksAt (cands : Input → Finset Output)
+    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
     (h_ne : (cands i).Nonempty)
-    (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o')
-    (σ : Ranking n) : ∃ o ∈ cands i, PicksAt cands vp σ i o := by
-  obtain ⟨m, hm, hmin⟩ := Finset.exists_min_image (cands i)
-    (fun o => toLex (fun j : Fin n => vp i o (σ j))) h_ne
-  refine ⟨m, hm, hm, fun o' ho' hne' => lt_of_le_of_ne (hmin o' ho') fun heq => hne' ?_⟩
-  have h_fun : (fun j : Fin n => vp i m (σ j)) = fun j => vp i o' (σ j) := toLex_inj.mp heq
-  refine h_inj o' ho' m hm (funext fun c => ?_)
-  have := congrFun h_fun (σ.symm c)
-  simpa using this.symm
+    (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o') :
+    ∑ o ∈ cands i, (p.consistentTotalOrders.filter
+      (fun σ => PicksAt cands vp σ i o)).card = p.consistentTotalOrders.card := by
+  classical
+  have h_disjoint : (↑(cands i) : Set Output).PairwiseDisjoint
+      (fun o => p.consistentTotalOrders.filter (fun σ => PicksAt cands vp σ i o)) := by
+    intro o _ o' _ hne'
+    simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
+    rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
+    exact hne' (picksAt_unique h₁ h₂)
+  have h_union : (cands i).biUnion (fun o => p.consistentTotalOrders.filter
+      (fun σ => PicksAt cands vp σ i o)) = p.consistentTotalOrders := by
+    ext σ
+    simp only [Finset.mem_biUnion, Finset.mem_filter]
+    constructor
+    · rintro ⟨o, _, hσ, _⟩; exact hσ
+    · intro hσ
+      obtain ⟨o, ho, hpick⟩ := exists_picksAt cands vp h_ne h_inj σ
+      exact ⟨o, ho, hσ, hpick⟩
+  calc ∑ o ∈ cands i, (p.consistentTotalOrders.filter
+        (fun σ => PicksAt cands vp σ i o)).card
+      = ((cands i).biUnion (fun o => p.consistentTotalOrders.filter
+          (fun σ => PicksAt cands vp σ i o))).card :=
+        (Finset.card_biUnion h_disjoint).symm
+    _ = p.consistentTotalOrders.card := by rw [h_union]
 
-/-- **`pocPredict` sums to 1** over any candidate set with pairwise-distinct
-    violation profiles: every consistent ranking picks exactly one winner
-    (`exists_picksAt`, `picksAt_unique`), so the win probabilities form a
-    genuine distribution — for *any* partial order. -/
+/-- Over a candidate set with pairwise-distinct violation profiles the win
+    probabilities sum to 1, for any partial order — every consistent ranking
+    picks exactly one winner. -/
 theorem sum_pocPredict_eq_one (cands : Input → Finset Output)
     (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
     (h_ne : (cands i).Nonempty)
     (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o') :
     ∑ o ∈ cands i, pocPredict cands vp p i o = 1 := by
-  classical
-  have h_nat : ∑ o ∈ cands i, (p.consistentTotalOrders.filter
-      (fun σ => PicksAt cands vp σ i o)).card = p.consistentTotalOrders.card := by
-    have h_disjoint : (↑(cands i) : Set Output).PairwiseDisjoint
-        (fun o => p.consistentTotalOrders.filter (fun σ => PicksAt cands vp σ i o)) := by
-      intro o _ o' _ hne'
-      simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
-      rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
-      exact hne' (picksAt_unique h₁ h₂)
-    have h_union : (cands i).biUnion (fun o => p.consistentTotalOrders.filter
-        (fun σ => PicksAt cands vp σ i o)) = p.consistentTotalOrders := by
-      ext σ
-      simp only [Finset.mem_biUnion, Finset.mem_filter]
-      constructor
-      · rintro ⟨o, _, hσ, _⟩; exact hσ
-      · intro hσ
-        obtain ⟨o, ho, hpick⟩ := exists_picksAt cands vp h_ne h_inj σ
-        exact ⟨o, ho, hσ, hpick⟩
-    calc ∑ o ∈ cands i, (p.consistentTotalOrders.filter
-          (fun σ => PicksAt cands vp σ i o)).card
-        = ((cands i).biUnion (fun o => p.consistentTotalOrders.filter
-            (fun σ => PicksAt cands vp σ i o))).card :=
-          (Finset.card_biUnion h_disjoint).symm
-      _ = p.consistentTotalOrders.card := by rw [h_union]
   unfold pocPredict
-  rw [← Finset.sum_div, ← Nat.cast_sum, h_nat]
+  rw [← Finset.sum_div, ← Nat.cast_sum, sum_card_filter_picksAt cands vp p h_ne h_inj]
   exact div_self (by exact_mod_cast p.consistentTotalOrders_card_pos.ne')
 
-/-- Binary form of `sum_pocPredict_eq_one`: two distinct candidates with
-    distinct violation profiles split the probability mass. -/
+/-- Two distinct candidates with distinct violation profiles split the
+    probability mass. -/
 theorem pocPredict_binary_add_eq_one (cands : Input → Finset Output)
     (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
     {o₁ o₂ : Output} (h_two : cands i = {o₁, o₂}) (h_ne : o₁ ≠ o₂)
@@ -668,307 +624,150 @@ theorem pocPredict_binary_add_eq_one (cands : Input → Finset Output)
 
 end PartialOrderConstraints
 
-/-! ### Bridge — PicksAt for binary candidates ↔ head-in-Y on permDList -/
+/-! ### Bridge — binary PicksAt is decided by the σ-earliest active constraint
 
-/-! For binary candidate sets `cands i = {chosen, other}`, `PicksAt σ i chosen`
-reduces to lex domination of `vp i chosen ∘ σ` over `vp i other ∘ σ` (the
-∀-quantifier collapses to a single check). And that lex predicate is exactly
-"the highest-ranked constraint in the distinguishing set `D` favors `chosen`"
-— i.e., `head of permDList σ D ∈ Y` where `D = {k : vp chosen k ≠ vp other k}`
-and `Y = {k : vp chosen k < vp other k}`.
-
-This bridges POC's lex-strict-better predicate to
-`Core.Optimization.PermSubsetCombinatorics.perm_filter_head_in_card`'s closed
-form, letting any binary-candidate POC study compute its `pocPredict` value
-in closed form (`n! × |Y ∩ D| / |D|`) without enumerating `n!` rankings.
-
-Used by `Studies/CoetzeePater2011.lean` (English t/d-deletion;
-binary `{retain, delete}` outputs across 3 contexts). -/
+For binary candidate sets `cands i = {chosen, other}`, `PicksAt σ i chosen`
+reduces to lex domination of `chosen`'s permuted profile, which is decided at
+the first position where the profiles differ — i.e., `chosen` wins iff the
+σ-earliest constraint of `active vp i chosen other` lies in
+`favoring vp i chosen other`. Combined with the head-fiber counting of
+`Core.Optimization.PermSubsetCombinatorics`, this yields closed-form rates
+for binary POC competitions without enumerating rankings. -/
 
 namespace PartialOrderConstraints
 
 open Core.Optimization.PermSubsetCombinatorics
 
-variable {Input : Type*} {n : ℕ}
+variable {Input Output : Type*} [DecidableEq Output] {n : ℕ}
 
-/-- For binary candidate sets, `PicksAt σ i chosen` is equivalent to
-    "the head of `permDList σ D` lies in `Y`", where `D` is the set of
-    constraints distinguishing `chosen` from `other` and `Y` is the
-    favoring subset (`vp chosen < vp other`).
-
-    The bridge uses `permDList_head_eq_some_iff` + `ofFn_split_at` +
-    `apply_of_ofFn_eq_append_cons` (substrate) to translate
-    between the lex `∃k` form and the head-in-Y characterization. -/
-theorem picksAt_binary_iff_permDList_head_lt {Output : Type*} [DecidableEq Output]
+/-- For binary candidate sets, `PicksAt σ i chosen` holds exactly when the
+    σ-earliest active constraint favors `chosen`. -/
+theorem picksAt_binary_iff_head_mem_favoring
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (i : Input) (chosen other : Output)
     (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other)
     (σ : Ranking n) :
     PicksAt cands vp σ i chosen ↔
-    ∃ x ∈ Finset.univ.filter (fun k : Fin n => vp i chosen k < vp i other k),
-      (permDList σ (Finset.univ.filter
-        (fun k : Fin n => vp i chosen k ≠ vp i other k))).head? = some x := by
+    ∃ x ∈ favoring vp i chosen other,
+      (permDList σ (active vp i chosen other)).head? = some x := by
   classical
-  -- Step 1: PicksAt with binary cands reduces to lex domination of chosen over other
-  have h_picksAt_iff_lex :
+  -- Binary candidates: `PicksAt` reduces to lex domination of `chosen` over `other`.
+  have h_lex :
       PicksAt cands vp σ i chosen ↔
       ∃ k : Fin n, (∀ j, j < k → vp i chosen (σ j) = vp i other (σ j)) ∧
         vp i chosen (σ k) < vp i other (σ k) := by
     unfold PicksAt
     constructor
-    · rintro ⟨_, h_lex⟩
-      exact h_lex other (by rw [h_two]; exact Finset.mem_insert_of_mem (Finset.mem_singleton.mpr rfl))
+    · rintro ⟨_, h⟩
+      exact h other
+        (by rw [h_two]; exact Finset.mem_insert_of_mem (Finset.mem_singleton.mpr rfl))
         (Ne.symm h_ne)
-    · intro h_lex
+    · intro h
       refine ⟨by rw [h_two]; exact Finset.mem_insert_self _ _, ?_⟩
       intro o' h_o' h_o'_ne
-      -- o' ∈ {chosen, other} ∧ o' ≠ chosen → o' = other
       rw [h_two, Finset.mem_insert, Finset.mem_singleton] at h_o'
-      rcases h_o' with h | h
-      · exact absurd h h_o'_ne
-      · subst h; exact h_lex
-  rw [h_picksAt_iff_lex]
-  -- Step 2: lex domination ↔ head-in-Y characterization
-  set D := Finset.univ.filter (fun k : Fin n => vp i chosen k ≠ vp i other k) with hD_def
-  set Y := Finset.univ.filter (fun k : Fin n => vp i chosen k < vp i other k) with hY_def
-  have h_D_iff : ∀ k, k ∈ D ↔ vp i chosen k ≠ vp i other k := by
-    intro k; simp [hD_def]
-  have h_Y_iff : ∀ k, k ∈ Y ↔ vp i chosen k < vp i other k := by
-    intro k; simp [hY_def]
+      rcases h_o' with h' | h'
+      · exact absurd h' h_o'_ne
+      · subst h'; exact h
+  rw [h_lex]
   constructor
-  · -- lex domination → head-in-Y
-    rintro ⟨k, h_below, h_lt⟩
-    have h_σk_Y : σ k ∈ Y := (h_Y_iff (σ k)).mpr h_lt
-    have h_σk_D : σ k ∈ D := (h_D_iff (σ k)).mpr (Nat.ne_of_lt h_lt)
-    have h_below_notD : ∀ j < k, σ j ∉ D := fun j hj h =>
-      ((h_D_iff (σ j)).mp h) (h_below j hj)
-    refine ⟨σ k, h_σk_Y, ?_⟩
-    rw [permDList_head_eq_some_iff]
-    refine ⟨h_σk_D, ((List.finRange n).take k.val).map σ,
-            ((List.finRange n).drop (k.val + 1)).map σ, ofFn_split_at σ k, ?_⟩
-    intro y hy
-    obtain ⟨j, h_j_take, h_σj⟩ := List.mem_map.mp hy
-    rw [List.mem_take_iff_getElem] at h_j_take
-    obtain ⟨idx, h_idx_lt, h_idx_eq⟩ := h_j_take
-    simp only [List.getElem_finRange] at h_idx_eq
-    have h_idx_lt_k : idx < k.val := by
-      simp only [List.length_finRange] at h_idx_lt
-      omega
-    have h_j_lt_k : j < k := by
-      rw [Fin.lt_def, ← h_idx_eq]; exact h_idx_lt_k
-    rw [← h_σj]
-    exact h_below_notD j h_j_lt_k
-  · -- head-in-Y → lex domination
-    rintro ⟨x, hx_Y, h_head⟩
-    rw [permDList_head_eq_some_iff] at h_head
-    obtain ⟨h_x_D, pre, suf, h_split, h_pre⟩ := h_head
-    have h_pre_len_lt : pre.length < n := by
-      have h_perm_len : (List.ofFn ⇑σ).length = n := List.length_ofFn
-      rw [h_split] at h_perm_len
-      simp [List.length_append, List.length_cons] at h_perm_len
-      omega
-    have h_σk_x := apply_of_ofFn_eq_append_cons σ pre suf x h_split h_pre_len_lt
-    refine ⟨⟨pre.length, h_pre_len_lt⟩, ?_, ?_⟩
-    · -- ∀ j < ⟨pre.length, _⟩, vp chosen (σ j) = vp other (σ j)
-      intro j h_j_lt
-      rw [Fin.lt_def] at h_j_lt
-      -- σ j is the j-th element of `((finRange n).take pre.length).map σ` (= pre)
-      have h_split_pre := ofFn_split_at σ ⟨pre.length, h_pre_len_lt⟩
-      -- Combined: ((take pre.length).map σ) ++ σ ⟨...⟩ :: ((drop _).map σ) = pre ++ x :: suf
-      have h_lhs_pre_len : (((List.finRange n).take pre.length).map σ).length = pre.length := by
-        rw [List.length_map, List.length_take, List.length_finRange]; omega
-      have h_combined : ((List.finRange n).take pre.length).map σ ++
-          σ ⟨pre.length, h_pre_len_lt⟩ ::
-          ((List.finRange n).drop (pre.length + 1)).map σ = pre ++ x :: suf := by
-        rw [← h_split_pre]; exact h_split
-      have h_pre_eq : ((List.finRange n).take pre.length).map σ = pre :=
-        (List.append_inj h_combined h_lhs_pre_len).1
-      -- σ j ∈ pre (j-th element of pre is σ j)
-      have h_σj_in_pre : σ j ∈ pre := by
-        rw [← h_pre_eq]
-        refine List.mem_map.mpr ⟨j, ?_, rfl⟩
-        rw [List.mem_take_iff_getElem]
-        refine ⟨j.val, ?_, by simp [List.getElem_finRange]⟩
-        simp only [List.length_finRange, lt_min_iff]
-        exact ⟨h_j_lt, j.isLt⟩
-      have h_eq : ¬ vp i chosen (σ j) ≠ vp i other (σ j) := fun h =>
-        (h_pre _ h_σj_in_pre) ((h_D_iff (σ j)).mpr h)
-      exact not_not.mp h_eq
-    · show vp i chosen (σ ⟨pre.length, h_pre_len_lt⟩) <
-          vp i other (σ ⟨pre.length, h_pre_len_lt⟩)
-      rw [h_σk_x]
-      exact (h_Y_iff x).mp hx_Y
+  · -- the first strict-difference position holds the σ-earliest active constraint
+    rintro ⟨k, h_tie, h_lt⟩
+    refine ⟨σ k, mem_favoring.mpr h_lt,
+      (permDList_head?_eq_some_iff_min σ _ (σ k)).mpr
+        ⟨mem_active.mpr (Nat.ne_of_lt h_lt), fun y hy => ?_⟩⟩
+    rw [Equiv.symm_apply_apply]
+    by_contra h
+    exact mem_active.mp hy (by simpa using h_tie (σ.symm y) (lt_of_not_ge h))
+  · -- the σ-earliest active constraint marks the first strict difference
+    rintro ⟨x, hxF, hhead⟩
+    obtain ⟨-, hmin⟩ := (permDList_head?_eq_some_iff_min σ _ x).mp hhead
+    refine ⟨σ.symm x, fun j hj => ?_, by simpa using mem_favoring.mp hxF⟩
+    by_contra h_ne'
+    exact absurd (hmin (σ j) (mem_active.mpr h_ne')) (by simpa using not_le.mpr hj)
 
 /-! ### Closed-form rate for binary candidates -/
 
-variable {Input Output : Type*} [DecidableEq Output] {n : ℕ}
-
-/-- **Closed-form rate for binary `pocPredict` under the discrete partial
-    order**: when `cands i = {chosen, other}`, the fraction of all `n!`
-    permutations that pick `chosen` for input `i` equals `|Y ∩ D| / |D|`,
-    where `D` is the distinguishing set (constraints where `vp` differs)
-    and `Y` is the favoring set (constraints where `chosen` has fewer
-    violations).
-
-    Combines `picksAt_binary_iff_permDList_head_lt` (the bridge from
-    `PicksAt` to head-of-`permDList`) with
-    `Core.Optimization.PermSubsetCombinatorics.perm_filter_head_in_rate`
-    (the rate form of the closed-form combinatorics).
-
-    Consumed by `Studies/CoetzeePater2011.lean`
-    (binary `{retain, delete}` over Fin 4) and
-    `Studies/Zuraw2010.lean` (binary `{yes, no}`
-    over Fin 6). -/
-theorem picksAt_rate_eq
-    (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
-    (i : Input) (chosen other : Output)
-    (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other)
-    (D Y : Finset (Fin n))
-    (h_D : ∀ k, k ∈ D ↔ vp i chosen k ≠ vp i other k)
-    (h_Y : ∀ k, k ∈ Y ↔ vp i chosen k < vp i other k) :
-    ((Finset.univ.filter (fun σ : Ranking n =>
-      PicksAt cands vp σ i chosen)).card : ℚ) / (Nat.factorial n : ℚ) =
-    ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
-  have h_filter_eq :
-      (Finset.univ.filter (fun σ : Ranking n =>
-        PicksAt cands vp σ i chosen)) =
-      (Finset.univ.filter (fun σ : Ranking n =>
-        ∃ x ∈ Finset.univ.filter
-          (fun k : Fin n => vp i chosen k < vp i other k),
-        (Core.Optimization.PermSubsetCombinatorics.permDList σ
-          (Finset.univ.filter
-            (fun k : Fin n => vp i chosen k ≠ vp i other k))).head?
-            = some x)) :=
-    Finset.filter_congr (fun σ _ =>
-      picksAt_binary_iff_permDList_head_lt cands vp i chosen other h_two h_ne σ)
-  rw [h_filter_eq]
-  have h_D_eq : D = Finset.univ.filter
-      (fun k : Fin n => vp i chosen k ≠ vp i other k) :=
-    Finset.ext (fun k => by simp [h_D k])
-  have h_Y_eq : Y = Finset.univ.filter
-      (fun k : Fin n => vp i chosen k < vp i other k) :=
-    Finset.ext (fun k => by simp [h_Y k])
-  rw [h_D_eq, h_Y_eq]
-  exact Core.Optimization.PermSubsetCombinatorics.perm_filter_head_in_rate _ _
-
-/-- **Closed-form rate for `pocPredict` under the discrete partial order**
-    with binary candidate sets: `pocPredict cands vp (.discrete n) i chosen
-    = |Y ∩ D| / |D|`. Composes `pocPredict_discrete` with `picksAt_rate_eq`,
-    absorbing the `Fintype.card_perm`/`Fintype.card_fin` arithmetic bridge.
-
-    This is the user-facing rate identity every binary-candidate POC study
-    wants. Consumed by `Studies/CoetzeePater2011.lean` (3 contexts),
-    `Studies/Anttila1997.lean` (2 grammar tiers), and
-    `Studies/Zuraw2010.lean`. -/
+/-- With binary candidates, the fraction of all `n!` rankings picking `chosen`
+    is `|favoring ∩ active| / |active|` — each ranking is decided by its
+    σ-earliest active constraint, and every active constraint is equally
+    likely to come first. -/
 theorem pocPredict_discrete_binary_rate
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (i : Input) (chosen other : Output)
-    (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other)
-    (D Y : Finset (Fin n))
-    (h_D : ∀ k, k ∈ D ↔ vp i chosen k ≠ vp i other k)
-    (h_Y : ∀ k, k ∈ Y ↔ vp i chosen k < vp i other k) :
+    (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other) :
     pocPredict cands vp (discrete n) i chosen =
-    ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
-  rw [pocPredict_discrete, Finset.card_univ, Fintype.card_perm, Fintype.card_fin]
-  exact picksAt_rate_eq cands vp i chosen other h_two h_ne D Y h_D h_Y
+      ((favoring vp i chosen other ∩ active vp i chosen other).card : ℚ) /
+        ((active vp i chosen other).card : ℚ) := by
+  rw [pocPredict_discrete, Finset.card_univ, Fintype.card_perm, Fintype.card_fin,
+    Finset.filter_congr fun σ _ =>
+      picksAt_binary_iff_head_mem_favoring cands vp i chosen other h_two h_ne σ]
+  exact perm_filter_head_in_rate _ _
 
 /-! ### Deciding-stratum rate for stratified grammars
 
-For a stratified grammar, a binary competition decided at stratum `k` — the
-variants tie on every earlier stratum and some stratum-`k` constraint
-distinguishes them — reduces to the within-stratum closed form
-`|Y ∩ D| / |D|` over the deciding stratum's distinguishing set, regardless of
-the profiles (and inner rankings) of later strata. This is [anttila-1997]'s
-tableau-count shortcut stated against the full grammar rather than a
-per-stratum sub-grammar: strata below the deciding one never matter, and the
-deciding stratum's free internal ranking is uniform by exchangeability
-(`isConsistent_swap_mul` + `filter_head_in_rate_of_swaps`). -/
+A binary competition whose variants tie on every stratum before `k` is decided
+within stratum `k`, with later strata — including any inner rankings among
+them — provably irrelevant. This is [anttila-1997]'s tableau-count shortcut
+stated against the full grammar rather than a per-stratum sub-grammar. -/
 
-/-- On rankings consistent with a stratified order, the first distinguishing
-    constraint overall is the first distinguishing constraint of the deciding
-    stratum: strata before `k` don't distinguish, and constraints of strata
-    after `k` come later in every consistent ranking. -/
-private theorem permDList_head?_of_stratified {s : ℕ} {stratumOf : Fin n → Fin s}
-    {inner : PartialOrderConstraints n} {σ : Ranking n}
-    (hσ : (stratified stratumOf inner).IsConsistent σ) {k : Fin s}
-    {Dfull Dk : Finset (Fin n)}
-    (h_below : ∀ c ∈ Dfull, ¬ stratumOf c < k)
-    (h_at : ∀ c ∈ Dfull, stratumOf c = k → c ∈ Dk)
-    (h_sub : ∀ c ∈ Dk, c ∈ Dfull ∧ stratumOf c = k)
-    (h_ne : Dk.Nonempty) :
-    (permDList σ Dfull).head? = (permDList σ Dk).head? := by
-  obtain ⟨x, hxDk, hx⟩ := exists_permDList_head?_eq_some h_ne σ
+omit [DecidableEq Output] in
+/-- On a consistent ranking of a stratified order, the σ-earliest active
+    constraint lies in the deciding stratum: earlier strata are inactive
+    (`h_tie`), and constraints of later strata come after all of stratum `k`. -/
+private theorem permDList_head?_active_filter_stratum {s : ℕ}
+    {stratumOf : Fin n → Fin s} {inner : PartialOrderConstraints n} {σ : Ranking n}
+    (vp : Input → Output → Fin n → ℕ) {i : Input} {chosen other : Output} {k : Fin s}
+    (hσ : (stratified stratumOf inner).IsConsistent σ)
+    (h_tie : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
+    (h_dec : ((active vp i chosen other).filter (stratumOf · = k)).Nonempty) :
+    (permDList σ (active vp i chosen other)).head? =
+      (permDList σ ((active vp i chosen other).filter (stratumOf · = k))).head? := by
+  obtain ⟨x, hx_mem, hx⟩ := exists_permDList_head?_eq_some h_dec σ
+  obtain ⟨hxD, hxk⟩ := Finset.mem_filter.mp hx_mem
+  obtain ⟨-, hmin⟩ := (permDList_head?_eq_some_iff_min σ _ x).mp hx
   rw [hx]
-  obtain ⟨-, pre, suf, h_split, h_pre⟩ := (permDList_head_eq_some_iff σ Dk x).mp hx
-  refine (permDList_head_eq_some_iff σ Dfull x).mpr
-    ⟨(h_sub x hxDk).1, pre, suf, h_split, fun y hy hyD => ?_⟩
+  refine (permDList_head?_eq_some_iff_min σ _ x).mpr ⟨hxD, fun y hyD => ?_⟩
   rcases lt_trichotomy (stratumOf y) k with hlt | heq | hgt
-  · exact h_below y hyD hlt
-  · exact h_pre y hy (h_at y hyD heq)
-  · have h1 : σ.symm x < σ.symm y :=
-      hσ.symm_lt_of_stratum_lt (by rw [(h_sub x hxDk).2]; exact hgt)
-    exact absurd (symm_lt_of_ofFn_eq_append_cons σ h_split hy) (asymm h1)
+  · exact absurd (h_tie y hlt) (mem_active.mp hyD)
+  · exact hmin y (Finset.mem_filter.mpr ⟨hyD, heq⟩)
+  · exact (hσ.symm_lt_of_stratum_lt (by rw [hxk]; exact hgt)).le
 
-/-- **Deciding-stratum rate**: for binary candidates under a stratified
-    grammar, if the variants tie on every stratum before `k`, the inner order
-    is trivial on stratum `k`, and some stratum-`k` constraint distinguishes
-    them (`h_dec`), then the win probability is the within-stratum closed form
-    `|Y ∩ D| / |D|` — `D` the stratum-`k` distinguishing set, `Y` its
-    `chosen`-favoring subset. Later strata, including any inner rankings among
-    them, cannot affect the outcome. Consumed by `Studies/Anttila1997.lean`,
-    whose six motif competitions run against the full 20-constraint grammar. -/
+/-- Under a stratified grammar, a binary competition whose variants tie on
+    every stratum before `k` — with `k` freely ranked internally (`h_triv`)
+    and containing an active constraint (`h_dec`) — is won by `chosen` at rate
+    `|favoring ∩ Dₖ| / |Dₖ|`, where `Dₖ` is the active set restricted to
+    stratum `k`. Later strata cannot affect the outcome. -/
 theorem pocPredict_stratified_binary_rate {s : ℕ}
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (stratumOf : Fin n → Fin s) (inner : PartialOrderConstraints n)
     (i : Input) (chosen other : Output)
     (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other) (k : Fin s)
     (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
-    (h_above : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
-    (D Y : Finset (Fin n))
-    (h_D : ∀ c, c ∈ D ↔ stratumOf c = k ∧ vp i chosen c ≠ vp i other c)
-    (h_Y : ∀ c, c ∈ Y ↔ stratumOf c = k ∧ vp i chosen c < vp i other c)
-    (h_dec : D.Nonempty) :
+    (h_tie : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
+    (h_dec : ((active vp i chosen other).filter (stratumOf · = k)).Nonempty) :
     pocPredict cands vp (stratified stratumOf inner) i chosen =
-      ((Y ∩ D).card : ℚ) / (D.card : ℚ) := by
+      ((favoring vp i chosen other ∩
+          (active vp i chosen other).filter (stratumOf · = k)).card : ℚ) /
+        (((active vp i chosen other).filter (stratumOf · = k)).card : ℚ) := by
   classical
-  have h_iff : ∀ σ ∈ (stratified stratumOf inner).consistentTotalOrders,
-      (PicksAt cands vp σ i chosen ↔ ∃ x ∈ Y, (permDList σ D).head? = some x) := by
-    intro σ hσ
-    rw [mem_consistentTotalOrders] at hσ
-    rw [picksAt_binary_iff_permDList_head_lt cands vp i chosen other h_two h_ne σ]
-    have h_head : (permDList σ (Finset.univ.filter
-        (fun c => vp i chosen c ≠ vp i other c))).head? = (permDList σ D).head? := by
-      refine permDList_head?_of_stratified (k := k) (Dk := D) hσ (fun c hc hlt => ?_)
-        (fun c hc hck => ?_) (fun c hc => ?_) h_dec
-      · exact (Finset.mem_filter.mp hc).2 (h_above c hlt)
-      · exact (h_D c).mpr ⟨hck, (Finset.mem_filter.mp hc).2⟩
-      · obtain ⟨hck, hne'⟩ := (h_D c).mp hc
-        exact ⟨Finset.mem_filter.mpr ⟨Finset.mem_univ _, hne'⟩, hck⟩
-    rw [h_head]
-    constructor
-    · rintro ⟨x, hxY, hhead⟩
-      have hxD := mem_of_permDList_head?_eq_some hhead
-      exact ⟨x, (h_Y x).mpr ⟨((h_D x).mp hxD).1, (Finset.mem_filter.mp hxY).2⟩, hhead⟩
-    · rintro ⟨x, hxY, hhead⟩
-      exact ⟨x, Finset.mem_filter.mpr ⟨Finset.mem_univ _, ((h_Y x).mp hxY).2⟩, hhead⟩
   unfold pocPredict
-  rw [Finset.filter_congr h_iff]
-  exact filter_head_in_rate_of_swaps _ D Y
-    (stratified stratumOf inner).consistentTotalOrders_nonempty
-    (fun y₁ h₁ y₂ h₂ σ hσ => by
-      rw [mem_consistentTotalOrders] at hσ ⊢
-      exact isConsistent_swap_mul h_triv ((h_D y₁).mp h₁).1 ((h_D y₂).mp h₂).1 hσ)
+  rw [Finset.filter_congr fun σ hσ =>
+    (picksAt_binary_iff_head_mem_favoring cands vp i chosen other h_two h_ne σ).trans
+      (by rw [permDList_head?_active_filter_stratum vp
+        (mem_consistentTotalOrders.mp hσ) h_tie h_dec])]
+  exact filter_head_in_rate_of_swaps _ _ _ (consistentTotalOrders_nonempty _)
+    fun y₁ h₁ y₂ h₂ σ hσ => mem_consistentTotalOrders.mpr
+      (isConsistent_swap_mul h_triv (Finset.mem_filter.mp h₁).2 (Finset.mem_filter.mp h₂).2
+        (mem_consistentTotalOrders.mp hσ))
 
 /-! ### Bridge to the `Grammar` hub
 
-A partial order on constraints is the simple-ERC fragment of an OT grammar: its
-consistent total orders are exactly the legs of `Grammar.ofERCSet p.toERCSet`,
-routing POC through the canonical `Grammar` type rather than its own bespoke
-linear-extension plumbing ([merchant-riggle-2016]). The simple-ERC encoding is
-consistent via `toERCSet_consistent` (Szpilrajn, above). -/
+A partial order on constraints is the simple-ERC fragment of an OT grammar —
+its consistent total orders are exactly the legs of
+`Grammar.ofERCSet p.toERCSet` ([merchant-riggle-2016]). -/
 
-/-- The **grammar of a partial order**: the `Grammar` whose legs are `p`'s
-consistent total orders — the simple-ERC fragment of the hub. -/
+/-- The `Grammar` whose legs are `p`'s consistent total orders. -/
 def toGrammar (p : PartialOrderConstraints n) : Grammar n :=
   Grammar.ofERCSet p.toERCSet p.toERCSet_consistent
 

--- a/Linglib/Studies/Anttila1997.lean
+++ b/Linglib/Studies/Anttila1997.lean
@@ -38,7 +38,7 @@ Each motif's probability is `pocPredict` over `finnishGrammar` — uniform
 sampling of the total rankings consistent with the whole grammar, not a
 per-stratum sub-grammar. The substrate's deciding-stratum theorem
 (`pocPredict_stratified_binary_rate`) reduces each competition to the closed
-form `|Y ∩ D| / |D|` over the deciding stratum's distinguishing set — the
+form `|favoring ∩ Dₖ| / |Dₖ|` over the deciding stratum's active set — the
 paper's own shortcut ("Drawing the tableaux was in fact unnecessary … knowing
 that the weak variant violates one constraint (\*L.L) while the strong variant
 violates two (\*H/I, \*Í) gives us the result directly", page 22) — with the
@@ -179,18 +179,18 @@ total rankings consistent with `finnishGrammar`. -/
 def winProb (m : Motif) (v : Variant) : ℚ :=
   pocPredict (fun _ => Finset.univ) vp finnishGrammar m v
 
-/-- Bridge to the deciding-stratum closed form `|Y ∩ D| / |D|`, shared by all
-twelve rate theorems. -/
+/-- Bridge to the deciding-stratum closed form, shared by all twelve rate
+theorems. -/
 private theorem winProb_eq_rate (m : Motif) (v : Variant) (k : Fin 5)
     (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → setFiveInner.rel a b → a = b)
-    (h_above : ∀ c, stratumOf c < k → vp m v c = vp m v.other c)
-    (D Y : Finset (Fin 20))
-    (h_D : ∀ c, c ∈ D ↔ stratumOf c = k ∧ vp m v c ≠ vp m v.other c)
-    (h_Y : ∀ c, c ∈ Y ↔ stratumOf c = k ∧ vp m v c < vp m v.other c)
-    (h_dec : D.Nonempty) :
-    winProb m v = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
+    (h_tie : ∀ c, stratumOf c < k → vp m v c = vp m v.other c)
+    (h_dec : ((active vp m v v.other).filter (stratumOf · = k)).Nonempty) :
+    winProb m v =
+      ((favoring vp m v v.other ∩
+          (active vp m v v.other).filter (stratumOf · = k)).card : ℚ) /
+        (((active vp m v v.other).filter (stratumOf · = k)).card : ℚ) :=
   pocPredict_stratified_binary_rate _ vp stratumOf setFiveInner m v v.other
-    (Variant.univ_eq_pair v) v.ne_other k h_triv h_above D Y h_D h_Y h_dec
+    (Variant.univ_eq_pair v) v.ne_other k h_triv h_tie h_dec
 
 /-! ### Rate theorems — table (52), all six motifs -/
 
@@ -198,89 +198,77 @@ private theorem winProb_eq_rate (m : Motif) (v : Variant) (k : Fin 5)
 violates a deciding-stratum constraint (`*L.L`), so `D = Y = {5}` and the rate
 is `1`: the categorical limiting case. -/
 theorem strongProb_1ab : winProb .one .strong = 1 := by
-  rw [winProb_eq_rate .one .strong 2 (by decide) (by decide) {5} {5}
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .one .strong 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 1ab weak `L.TA` loses in all rankings** ([anttila-1997]
 table (53): observed 0.6%, an artefact of the spelling of /kollega/). -/
 theorem weakProb_1ab : winProb .one .weak = 0 := by
-  rw [winProb_eq_rate .one .weak 2 (by decide) (by decide) {5} ∅
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .one .weak 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 2ab strong `L.TÓO` wins in all rankings** — same Set-3 profile as
 motif 1ab. -/
 theorem strongProb_2ab : winProb .two .strong = 1 := by
-  rw [winProb_eq_rate .two .strong 2 (by decide) (by decide) {5} {5}
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .two .strong 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 2ab weak `L.TO` loses in all rankings**. -/
 theorem weakProb_2ab : winProb .two .weak = 0 := by
-  rw [winProb_eq_rate .two .weak 2 (by decide) (by decide) {5} ∅
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .two .weak 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 3ab strong `L.TÍI` wins 1/3 of rankings**: decided in Set 3 with
 `D = {*H/I, *Í, *L.L}`, `Y = {*L.L}` (violated by weak alone). Observed 36.9%
 for `náa.pu.rèi.den` ([anttila-1997] table (53), row 3a). -/
 theorem strongProb_3ab : winProb .three .strong = 1/3 := by
-  rw [winProb_eq_rate .three .strong 2 (by decide) (by decide) {3, 4, 5} {5}
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .three .strong 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 3ab weak `L.TI` wins 2/3 of rankings**: `Y = {*H/I, *Í}` (violated
 by strong alone). Observed 63.1% for `náa.pu.ri.en` ([anttila-1997]
 table (53), row 3b). -/
 theorem weakProb_3ab : winProb .three .weak = 2/3 := by
-  rw [winProb_eq_rate .three .weak 2 (by decide) (by decide) {3, 4, 5} {3, 4}
-    (by decide) (by decide) ⟨5, by decide⟩]
+  rw [winProb_eq_rate .three .weak 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 4ab strong `H.TÁA` wins 1/2 of rankings**: decided in Set 4 with
 `D = {*L/A, *H.H, *H́, *X.X}`, `Y = {*L/A, *X.X}` (violated by weak alone).
 Observed 50.5% for `máa.il.mòi.den` ([anttila-1997] table (53), row 4a). -/
 theorem strongProb_4ab : winProb .four .strong = 1/2 := by
-  rw [winProb_eq_rate .four .strong 3 (by decide) (by decide) {8, 9, 10, 11} {8, 11}
-    (by decide) (by decide) ⟨8, by decide⟩]
+  rw [winProb_eq_rate .four .strong 3 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 4ab weak `H.TA` wins 1/2 of rankings**: `Y = {*H.H, *H́}`.
 Observed 49.5% for `máa.il.mo.jen` ([anttila-1997] table (53), row 4b). -/
 theorem weakProb_4ab : winProb .four .weak = 1/2 := by
-  rw [winProb_eq_rate .four .weak 3 (by decide) (by decide) {8, 9, 10, 11} {9, 10}
-    (by decide) (by decide) ⟨8, by decide⟩]
+  rw [winProb_eq_rate .four .weak 3 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 5ab strong `H.TÓO` wins 1/5 of rankings**: decided in Set 4 with
 `D = {*H/O, *Ó, *H.H, *H́, *X.X}`, `Y = {*X.X}` (violated by weak alone).
 Observed 17.8% for `kór.jaa.mòi.den` ([anttila-1997] table (53), row 5a). -/
 theorem strongProb_5ab : winProb .five .strong = 1/5 := by
-  rw [winProb_eq_rate .five .strong 3 (by decide) (by decide)
-    {6, 7, 9, 10, 11} {11} (by decide) (by decide) ⟨6, by decide⟩]
+  rw [winProb_eq_rate .five .strong 3 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 5ab weak `H.TO` wins 4/5 of rankings**: `Y = {*H/O, *Ó, *H.H,
 *H́}`. Observed 82.2% for `kór.jaa.mo.jen` ([anttila-1997] table (53),
 row 5b). -/
 theorem weakProb_5ab : winProb .five .weak = 4/5 := by
-  rw [winProb_eq_rate .five .weak 3 (by decide) (by decide)
-    {6, 7, 9, 10, 11} {6, 7, 9, 10} (by decide) (by decide) ⟨6, by decide⟩]
+  rw [winProb_eq_rate .five .weak 3 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 6ab strong `H.TÍI` loses in all rankings** — only the strong
 variant violates deciding-stratum constraints (`*H/I`, `*Í`), so `Y = ∅`. -/
 theorem strongProb_6ab : winProb .six .strong = 0 := by
-  rw [winProb_eq_rate .six .strong 2 (by decide) (by decide) {3, 4} ∅
-    (by decide) (by decide) ⟨3, by decide⟩]
+  rw [winProb_eq_rate .six .strong 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-- **Motif 6ab weak `H.TI` wins in all rankings** ([anttila-1997]
 table (53): observed 98.4%). -/
 theorem weakProb_6ab : winProb .six .weak = 1 := by
-  rw [winProb_eq_rate .six .weak 2 (by decide) (by decide) {3, 4} {3, 4}
-    (by decide) (by decide) ⟨3, by decide⟩]
+  rw [winProb_eq_rate .six .weak 2 (by decide) (by decide) (by decide)]
   decide +kernel
 
 /-! ### Completeness -/

--- a/Linglib/Studies/CoetzeePater2011.lean
+++ b/Linglib/Studies/CoetzeePater2011.lean
@@ -259,8 +259,8 @@ def tdVp : Context → TDOutput → Fin 4 → ℕ
 
     We formalize the §3.2 t/d-deletion analysis (table 10) using POC's
     `pocPredict`, with deletion probabilities derived in closed form via
-    the `picksAt_binary_iff_permDList_head_lt` bridge + the substrate's
-    `perm_filter_head_in_card`.
+    the `picksAt_binary_iff_head_mem_favoring` bridge + the substrate's
+    `perm_filter_head_in_rate`.
 
     The discrete partial order (`PartialOrderConstraints.discrete 4`)
     encodes "no rankings imposed" — uniform sampling over all 4! = 24
@@ -273,40 +273,35 @@ def deletionProb (ctx : Context) : ℚ :=
   PartialOrderConstraints.pocPredict tdCands tdVp
     (PartialOrderConstraints.discrete 4) ctx .delete
 
-/-- Local specialisation of `pocPredict_discrete_binary_rate` to t/d-deletion:
-    bakes in `tdCands ctx = {.delete, .retain}` and `delete ≠ retain`. -/
-private theorem deletionProb_eq (ctx : Context) (D Y : Finset (Fin 4))
-    (h_D : ∀ k, k ∈ D ↔ tdVp ctx .delete k ≠ tdVp ctx .retain k)
-    (h_Y : ∀ k, k ∈ Y ↔ tdVp ctx .delete k < tdVp ctx .retain k) :
-    deletionProb ctx = ((Y ∩ D).card : ℚ) / (D.card : ℚ) :=
+/-- Local specialisation of `pocPredict_discrete_binary_rate` to t/d-deletion,
+    baking in `tdCands ctx = {.delete, .retain}` and `delete ≠ retain`. -/
+private theorem deletionProb_eq (ctx : Context) :
+    deletionProb ctx =
+      ((PartialOrderConstraints.favoring tdVp ctx .delete .retain ∩
+          PartialOrderConstraints.active tdVp ctx .delete .retain).card : ℚ) /
+        ((PartialOrderConstraints.active tdVp ctx .delete .retain).card : ℚ) :=
   PartialOrderConstraints.pocPredict_discrete_binary_rate
     tdCands tdVp ctx .delete .retain
     (by unfold tdCands; ext o; cases o <;> simp)
-    (fun heq => TDOutput.noConfusion heq) D Y h_D h_Y
+    (fun heq => TDOutput.noConfusion heq)
 
 /-- Pre-vocalic deletion probability: `D = {*CT, MAX, MAX-PRE-V}` (3
     distinguishing), `Y ∩ D = {*CT}` (only *CT favors delete) → `1/3`. -/
 theorem deletionProb_preV : deletionProb .preV = 1/3 := by
-  rw [deletionProb_eq .preV {0, 1, 2} {0} (by decide) (by decide),
-      show (({0} : Finset (Fin 4)) ∩ {0, 1, 2}).card = 1 from by decide,
-      show ({0, 1, 2} : Finset (Fin 4)).card = 3 from by decide]
-  norm_num
+  rw [deletionProb_eq .preV]
+  decide +kernel
 
 /-- Phrase-final deletion probability: `D = {*CT, MAX, MAX-FINAL}`,
     `Y ∩ D = {*CT}` → `1/3`. -/
 theorem deletionProb_pause : deletionProb .pause = 1/3 := by
-  rw [deletionProb_eq .pause {0, 1, 3} {0} (by decide) (by decide),
-      show (({0} : Finset (Fin 4)) ∩ {0, 1, 3}).card = 1 from by decide,
-      show ({0, 1, 3} : Finset (Fin 4)).card = 3 from by decide]
-  norm_num
+  rw [deletionProb_eq .pause]
+  decide +kernel
 
 /-- Pre-consonantal deletion probability: `D = {*CT, MAX}`, `Y ∩ D = {*CT}`
     → `1/2` (highest — no positional faithfulness applies). -/
 theorem deletionProb_preC : deletionProb .preC = 1/2 := by
-  rw [deletionProb_eq .preC {0, 1} {0} (by decide) (by decide),
-      show (({0} : Finset (Fin 4)) ∩ {0, 1}).card = 1 from by decide,
-      show ({0, 1} : Finset (Fin 4)).card = 2 from by decide]
-  norm_num
+  rw [deletionProb_eq .preC]
+  decide +kernel
 
 /-- The cross-dialectal generalization: pre-C deletion rate exceeds
     pre-V and pre-pause rates. Direct consequence of the closed-form

--- a/Linglib/Studies/Zuraw2010.lean
+++ b/Linglib/Studies/Zuraw2010.lean
@@ -29,9 +29,8 @@ Constraints) substrate. For each stem-initial consonant `c`:
   applied to the discrete partial order on `Fin 6` — i.e. uniform sampling
   over all 720 total orders.
 - The closed-form rate `|Y_c ∩ D_c| / |D_c|` follows by a single
-  application of `picksAt_rate_eq` (which combines the binary-PicksAt
-  bridge with `perm_filter_head_in_card`'s rational form), with
-  no enumeration of 6! = 720 rankings.
+  application of `pocPredict_discrete_binary_rate`, with no enumeration of
+  6! = 720 rankings.
 
 The structural implication theorems in §7 reuse
 `Core.Optimization.PermSubsetCombinatorics.head_filter_subset_extends`
@@ -300,9 +299,6 @@ private theorem subProb_eq_rate (c : StemC) :
     subProb c = ((yesFav c ∩ relevant c).card : ℚ) / (relevant c).card :=
   pocPredict_discrete_binary_rate nsCands vp c .yes .no
     (nsCands_two c) (fun heq => SubSt.noConfusion heq)
-    (relevant c) (yesFav c)
-    (fun k => by simp [relevant])
-    (fun k => by simp [yesFav])
 
 /-- Substitution rate for voiceless labial p: 50% of 720 rankings. -/
 theorem subProb_p : subProb .p = 1/2 := by
@@ -349,7 +345,7 @@ theorem subProb_g : subProb .g = 1/5 := by
 /-- All six factorial percentages, matching [zuraw-2010] §4.2
     footnote 17 (page 446)'s free-ranking summary (50%, 40%, 33⅓%,
     33⅓%, 25%, 20% for p, t, k, b, d, g respectively). Each derived in
-    closed form from the substrate's `picksAt_rate_eq` — no 6!
+    closed form from the substrate's `pocPredict_discrete_binary_rate` — no 6!
     enumeration. -/
 theorem factorial_rates :
     subProb .p = 1/2 ∧ subProb .t = 2/5 ∧ subProb .k = 1/3 ∧
@@ -411,10 +407,10 @@ theorem PicksAt_extends_smaller_D
     (h_extra : ∀ x ∈ relevant c, x ∉ relevant c' → x ∈ yesFav c)
     (h_c' : PicksAt nsCands vp σ c' .yes) :
     PicksAt nsCands vp σ c .yes := by
-  rw [picksAt_binary_iff_permDList_head_lt
+  rw [picksAt_binary_iff_head_mem_favoring
         nsCands vp c' .yes .no (nsCands_two c')
         (fun heq => SubSt.noConfusion heq)] at h_c'
-  rw [picksAt_binary_iff_permDList_head_lt
+  rw [picksAt_binary_iff_head_mem_favoring
         nsCands vp c .yes .no (nsCands_two c)
         (fun heq => SubSt.noConfusion heq)]
   exact head_filter_subset_extends h_D h_Y h_extra _ h_c'
@@ -430,10 +426,10 @@ theorem PicksAt_extends_larger_D
     (h_subset : yesFav c' ⊆ relevant c)
     (h_c' : PicksAt nsCands vp σ c' .yes) :
     PicksAt nsCands vp σ c .yes := by
-  rw [picksAt_binary_iff_permDList_head_lt
+  rw [picksAt_binary_iff_head_mem_favoring
         nsCands vp c' .yes .no (nsCands_two c')
         (fun heq => SubSt.noConfusion heq)] at h_c'
-  rw [picksAt_binary_iff_permDList_head_lt
+  rw [picksAt_binary_iff_head_mem_favoring
         nsCands vp c .yes .no (nsCands_two c)
         (fun heq => SubSt.noConfusion heq)]
   exact head_filter_smaller_inherits h_D h_Y h_subset _ h_c'


### PR DESCRIPTION
Deep cleanse of `PartiallyOrderedConstraints.lean` and its counting substrate.

- name the canonical sets (`active`, `favoring`) and state every closed-form rate against them — the `D Y h_D h_Y` characterization-hypothesis plumbing disappears from `pocPredict_discrete_binary_rate`, `pocPredict_stratified_binary_rate`, and all three consuming studies (`decide +kernel` evaluates the filters directly)
- add the position-minimum characterization of `permDList`'s head (`permDList_head?_eq_some_iff_min`); the binary bridge's hard direction and the stratified localization collapse to short proofs, and `picksAt_rate_eq` is absorbed
- replace the private fin-monotone lemmas with mathlib's `StrictMono.eq_id`, expose the division-free partition identity `sum_card_filter_picksAt` (ℚ is veneer), and rewrite module/declaration docstrings to mathlib register