### PR TITLE
refactor(Phonology/HarmonicGrammar): unbundle POC grammars to relations

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -11,23 +11,30 @@ import Mathlib.Order.Preorder.Finite
 # Partially Ordered Constraints (POC)
 
 A POC grammar is a partial order on the constraint set ([anttila-1997];
-[kiparsky-1993b]). Each evaluation samples a total order consistent with the
-partial order — a linear extension — and the OT optimum under that ranking is
-the output, so a single grammar induces a distribution over outputs, uniform
-over consistent linear extensions. The load-bearing identities are
-division-free cardinality equations (`sum_card_filter_picksAt` here, the
-head-fiber counting in `Core.Optimization.PermSubsetCombinatorics`);
-`pocPredict` and its rate theorems are a ℚ veneer over them.
+[kiparsky-1993b]) — represented as mathlib represents orders-as-data
+(`extend_partialOrder`): a bare relation `r : Fin n → Fin n → Prop` with
+`[IsPartialOrder (Fin n) r]`, and `[DecidableRel r]` where counting needs it.
+Each evaluation samples a total order consistent with the partial order — a
+linear extension — and the OT optimum under that ranking is the output, so a
+single grammar induces a distribution over outputs, uniform over consistent
+linear extensions. The load-bearing identities are division-free cardinality
+equations (`sum_card_filter_picksAt` here, the head-fiber counting in
+`Core.Optimization.PermSubsetCombinatorics`); `pocPredict` and its rate
+theorems are a ℚ veneer over them.
 
 ## Main definitions
 
-- `PartialOrderConstraints n`: a decidable partial order on `Fin n` constraint
-  indices, with constructors `discrete` (no rankings), `fromPermutation` (a
-  total order), and `stratified` (mutually-ranked strata refined by an inner
-  order — [tesar-smolensky-1995]'s Stratified Domination Hierarchies).
-- `IsConsistent p σ` / `consistentTotalOrders p`: the linear extensions of
-  `p`, a nonempty (Szpilrajn) decidable `Finset`.
-- `pocPredict cands vp p i o`: the probability that sampling under `p` selects
+- Grammars: `Eq` (the discrete grammar — no rankings), `fromPermutation σ`
+  (the total ranking a permutation induces), and `stratified stratumOf inner`
+  (mutually-ranked strata refined by an inner order —
+  [tesar-smolensky-1995]'s Stratified Domination Hierarchies — defined as
+  mathlib's `Sigma.Lex` on the stratum map's fibers, characterized by
+  `stratified_iff`).
+- `IsConsistent r σ`: σ is a linear extension of `r` — equivalently
+  (`isConsistent_iff_le`), containment `r ≤ fromPermutation σ` in the
+  pointwise lattice of relations. `consistentTotalOrders r` is the
+  (nonempty, by Szpilrajn) `Finset` of them.
+- `pocPredict cands vp r i o`: the probability that sampling under `r` selects
   output `o` for input `i` — a genuine distribution (`pocPredict_nonneg`,
   `pocPredict_le_one`, `sum_pocPredict_eq_one`).
 - `active vp i o o'` / `favoring vp i o o'`: the constraints distinguishing a
@@ -41,10 +48,6 @@ head-fiber counting in `Core.Optimization.PermSubsetCombinatorics`);
   ([merchant-riggle-2016]; [prince-2002]). `toGrammar` routes POC through the
   `Grammar` hub, and `pocAntimatroid` realizes the Birkhoff correspondence
   with order-ideal antimatroids ([dilworth-1940]).
-- `stratified_rel_iff_lex`: the stratified order is mathlib's lexicographic
-  sigma order (`Sigma.Lex`, underlying `Sigma.Lex.partialOrder`) transported
-  along the fiber partition of the stratum map — strata as an ordinal sum,
-  not a re-stipulation.
 - `isOTRealizable_iff_isPOCRealizable`: categorically, POC adds nothing over
   OT. Its advantage is probabilistic — `pocPredict` produces intermediate
   frequencies (e.g. [coetzee-pater-2011]'s 8/24 vs 12/24 t/d-deletion rates)
@@ -54,77 +57,72 @@ head-fiber counting in `Core.Optimization.PermSubsetCombinatorics`);
   earliest active constraint (`picksAt_binary_iff_head_mem_favoring`), so
   `chosen` wins at rate `|favoring ∩ active| / |active|` — restricted to the
   deciding stratum in the stratified case — with no enumeration of rankings.
+
+## Implementation notes
+
+Grammars are unbundled relations, never `PartialOrder (Fin n)` values: a
+class-typed binder would become a local instance and capture the `≤`/`<`
+notation that must keep meaning `Fin n`'s positional order. This is also
+mathlib's own idiom for orders treated as data (Szpilrajn's
+`extend_partialOrder`).
 -/
 
 namespace HarmonicGrammar
 
 open Core.Optimization OptimalityTheory Finset
 
-/-! ### PartialOrderConstraints -/
-
-/-- A partial order on `Fin n` constraint indices. The OT case is a total
-    order; the POC case allows incomparable pairs (multiple consistent
-    linear extensions). -/
-structure PartialOrderConstraints (n : ℕ) where
-  /-- The partial-order relation: `rel a b` reads "a is ranked at-most-as-low-as
-      b", i.e., a takes priority over b (or they're equal). -/
-  rel : Fin n → Fin n → Prop
-  /-- Decidability of the relation (required for `consistentTotalOrders` to
-      be a computable `Finset`). -/
-  [decidableRel : DecidableRel rel]
-  /-- `rel` is a partial order — reflexive, transitive, antisymmetric — bundled
-      as mathlib's `IsPartialOrder` instance instead of three loose proof
-      fields, so the order-relation API (`antisymm_of`, …) applies to it. -/
-  [isPartialOrder : IsPartialOrder (Fin n) rel]
-
-attribute [instance] PartialOrderConstraints.decidableRel
-  PartialOrderConstraints.isPartialOrder
-
-namespace PartialOrderConstraints
-
 variable {n : ℕ}
 
-/-- The discrete partial order on `Fin n`, relating `a` to `b` iff `a = b`.
-    Every permutation is a consistent linear extension — [anttila-1997]'s
-    "no ranking imposed" baseline. -/
-def discrete (n : ℕ) : PartialOrderConstraints n where
-  rel := Eq
-  isPartialOrder :=
-    { refl := fun _ => rfl
-      trans := fun _ _ _ h₁ h₂ => h₁.trans h₂
-      antisymm := fun _ _ h _ => h }
+/-- Equality is a partial order — the discrete order, relating nothing beyond
+    reflexivity. As a POC grammar it is [anttila-1997]'s "no ranking imposed"
+    baseline: every permutation is a consistent linear extension. -/
+instance {α : Type*} : IsPartialOrder α (· = ·) where
+  refl _ := rfl
+  trans _ _ _ := Eq.trans
+  antisymm _ _ h _ := h
 
-/-- The total order induced by a permutation `σ`: `rel a b` iff
-    `σ.symm a ≤ σ.symm b` (i.e., a appears at least as early as b in σ's
-    enumeration). This is a total order; its unique consistent linear
-    extension is σ itself (`fromPermutation_consistent_unique` below). -/
-def fromPermutation (σ : Ranking n) : PartialOrderConstraints n where
-  rel := fun a b => σ.symm a ≤ σ.symm b
-  isPartialOrder :=
-    { refl := fun _ => le_refl _
-      trans := fun _ _ _ h₁ h₂ => le_trans h₁ h₂
-      antisymm := fun _ _ h₁ h₂ => σ.symm.injective (le_antisymm h₁ h₂) }
+/-! ### Grammars from permutations -/
 
-/-- A permutation σ is **consistent** with the partial order p if whenever
-    `rel a b` holds, σ ranks a at least as early as b
-    (`σ.symm a ≤ σ.symm b`) — that is, σ is a linear extension of p. -/
-def IsConsistent (p : PartialOrderConstraints n) (σ : Ranking n) :
-    Prop :=
-  ∀ a b, p.rel a b → σ.symm a ≤ σ.symm b
+/-- The total ranking induced by a permutation σ: `a` dominates `b` iff σ
+    places `a` at least as early (`σ.symm a ≤ σ.symm b`). Its unique
+    consistent linear extension is σ itself
+    (`fromPermutation_consistent_unique`). -/
+def fromPermutation (σ : Ranking n) : Fin n → Fin n → Prop :=
+  fun a b => σ.symm a ≤ σ.symm b
 
-instance (p : PartialOrderConstraints n) (σ : Ranking n) :
-    Decidable (p.IsConsistent σ) := by
+instance (σ : Ranking n) : IsPartialOrder (Fin n) (fromPermutation σ) where
+  refl _ := le_refl _
+  trans _ _ _ := le_trans
+  antisymm _ _ h₁ h₂ := σ.symm.injective (le_antisymm h₁ h₂)
+
+instance (σ : Ranking n) : DecidableRel (fromPermutation σ) :=
+  fun a b => inferInstanceAs (Decidable (σ.symm a ≤ σ.symm b))
+
+/-- A permutation σ is **consistent** with grammar `r` if whenever `r a b`
+    holds, σ ranks a at least as early as b — that is, σ is a linear
+    extension of `r`. -/
+def IsConsistent (r : Fin n → Fin n → Prop) (σ : Ranking n) : Prop :=
+  ∀ a b, r a b → σ.symm a ≤ σ.symm b
+
+/-- Consistency is containment in the pointwise lattice of relations:
+    `r` lies below the total ranking σ induces. -/
+theorem isConsistent_iff_le {r : Fin n → Fin n → Prop} {σ : Ranking n} :
+    IsConsistent r σ ↔ r ≤ fromPermutation σ :=
+  Iff.rfl
+
+instance (r : Fin n → Fin n → Prop) [DecidableRel r] (σ : Ranking n) :
+    Decidable (IsConsistent r σ) := by
   unfold IsConsistent; infer_instance
 
-/-- The (decidable, finite) set of linear extensions of `p`. -/
-def consistentTotalOrders (p : PartialOrderConstraints n) :
+/-- The (decidable, finite) set of linear extensions of `r`. -/
+def consistentTotalOrders (r : Fin n → Fin n → Prop) [DecidableRel r] :
     Finset (Ranking n) :=
-  Finset.univ.filter p.IsConsistent
+  Finset.univ.filter (IsConsistent r)
 
 @[simp]
-theorem mem_consistentTotalOrders {p : PartialOrderConstraints n}
+theorem mem_consistentTotalOrders {r : Fin n → Fin n → Prop} [DecidableRel r]
     {σ : Ranking n} :
-    σ ∈ p.consistentTotalOrders ↔ p.IsConsistent σ := by
+    σ ∈ consistentTotalOrders r ↔ IsConsistent r σ := by
   simp [consistentTotalOrders]
 
 /-! ### Grounding in the ERC lex API
@@ -133,17 +131,17 @@ A partial order is a set of dominance requirements — each strict related pair
 is a simple ERC `a ≫ b` ([merchant-riggle-2016]), and under this encoding the
 consistent total orders are exactly `ERCSet.linearExtensions` ([prince-2002]). -/
 
-/-- The simple-ERC encoding of a partial order, with one ERC `a ≫ b`
+/-- The simple-ERC encoding of a grammar, with one ERC `a ≫ b`
 (`simpleERC a b`) for each strict related pair. Transitively-implied pairs are
 entailed by the covering pairs, so the encoding has the same linear extensions
 as the Hasse-edge one. -/
-def toERCSet (p : PartialOrderConstraints n) : ERCSet n :=
+def toERCSet (r : Fin n → Fin n → Prop) [DecidableRel r] : ERCSet n :=
   (List.finRange n).flatMap fun a =>
     (List.finRange n).filterMap fun b =>
-      if a ≠ b ∧ p.rel a b then some (simpleERC a b) else none
+      if a ≠ b ∧ r a b then some (simpleERC a b) else none
 
-theorem mem_toERCSet {p : PartialOrderConstraints n} {α : ERC n} :
-    α ∈ p.toERCSet ↔ ∃ a b, a ≠ b ∧ p.rel a b ∧ simpleERC a b = α := by
+theorem mem_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r] {α : ERC n} :
+    α ∈ toERCSet r ↔ ∃ a b, a ≠ b ∧ r a b ∧ simpleERC a b = α := by
   simp only [toERCSet, List.mem_flatMap, List.mem_filterMap, List.mem_finRange, true_and]
   constructor
   · rintro ⟨a, b, hif⟩
@@ -152,11 +150,12 @@ theorem mem_toERCSet {p : PartialOrderConstraints n} {α : ERC n} :
   · rintro ⟨a, b, hab, hrel, rfl⟩
     exact ⟨a, b, by rw [if_pos ⟨hab, hrel⟩]⟩
 
-/-- A ranking satisfies `p.toERCSet` exactly when it is a linear extension of `p`:
-the `a ≫ b` ERCs are the strict dominance requirements, and reflexive pairs impose
-nothing. -/
-theorem satisfiedBy_toERCSet {p : PartialOrderConstraints n} {σ : Ranking n} :
-    ERCSet.SatisfiedBy σ p.toERCSet ↔ p.IsConsistent σ := by
+/-- A ranking satisfies `toERCSet r` exactly when it is a linear extension of
+`r`: the `a ≫ b` ERCs are the strict dominance requirements, and reflexive
+pairs impose nothing. -/
+theorem satisfiedBy_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r]
+    {σ : Ranking n} :
+    ERCSet.SatisfiedBy σ (toERCSet r) ↔ IsConsistent r σ := by
   constructor
   · intro h a b hrel
     rcases eq_or_ne a b with rfl | hab
@@ -168,38 +167,40 @@ theorem satisfiedBy_toERCSet {p : PartialOrderConstraints n} {σ : Ranking n} :
     exact (simpleERC_satisfiedBy_iff hab σ).mpr
       (lt_of_le_of_ne (hcons a b hrel) (fun heq => hab (σ.symm.injective heq)))
 
-/-- The consistent total orders of a partial order are exactly the linear
-extensions of its simple-ERC encoding ([merchant-riggle-2016];
-[prince-2002]). -/
-theorem consistentTotalOrders_eq_linearExtensions (p : PartialOrderConstraints n) :
-    p.consistentTotalOrders = p.toERCSet.linearExtensions := by
+/-- The consistent total orders of a grammar are exactly the linear extensions
+of its simple-ERC encoding ([merchant-riggle-2016]; [prince-2002]). -/
+theorem consistentTotalOrders_eq_linearExtensions (r : Fin n → Fin n → Prop)
+    [DecidableRel r] :
+    consistentTotalOrders r = (toERCSet r).linearExtensions := by
   ext σ
   rw [mem_consistentTotalOrders, ERCSet.mem_linearExtensions, satisfiedBy_toERCSet]
 
-/-- For the discrete partial order, every permutation is a linear extension. -/
+/-- For the discrete grammar, every permutation is a linear extension. -/
 theorem consistentTotalOrders_discrete (n : ℕ) :
-    (discrete n).consistentTotalOrders = Finset.univ := by
+    consistentTotalOrders (· = · : Fin n → Fin n → Prop) = Finset.univ := by
   ext σ
-  simp [consistentTotalOrders, IsConsistent, discrete]
+  simp only [mem_consistentTotalOrders, Finset.mem_univ, iff_true]
+  rintro a b rfl
+  exact le_refl _
 
-/-- σ is consistent with the partial order it induces. -/
+/-- σ is consistent with the total ranking it induces. -/
 theorem isConsistent_fromPermutation (σ : Ranking n) :
-    (fromPermutation σ).IsConsistent σ := by
+    IsConsistent (fromPermutation σ) σ := by
   intro a b h
   exact h
 
-/-- The σ-induced total order has σ as a consistent linear extension. -/
+/-- The σ-induced total ranking has σ as a consistent linear extension. -/
 theorem mem_consistentTotalOrders_fromPermutation (σ : Ranking n) :
-    σ ∈ (fromPermutation σ).consistentTotalOrders :=
+    σ ∈ consistentTotalOrders (fromPermutation σ) :=
   mem_consistentTotalOrders.mpr (isConsistent_fromPermutation σ)
 
-/-- The σ-induced total order has σ as its *unique* consistent linear
+/-- The σ-induced total ranking has σ as its *unique* consistent linear
     extension. -/
 theorem fromPermutation_consistent_unique {σ τ : Ranking n}
-    (hτ : (fromPermutation σ).IsConsistent τ) : τ = σ := by
+    (hτ : IsConsistent (fromPermutation σ) τ) : τ = σ := by
   have hmono : Monotone (⇑τ.symm ∘ ⇑σ) := by
     intro a b hab
-    have hrel : (fromPermutation σ).rel (σ a) (σ b) := by
+    have hrel : fromPermutation σ (σ a) (σ b) := by
       show σ.symm (σ a) ≤ σ.symm (σ b)
       rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply]
       exact hab
@@ -214,14 +215,14 @@ theorem fromPermutation_consistent_unique {σ τ : Ranking n}
 
 @[simp]
 theorem consistentTotalOrders_fromPermutation (σ : Ranking n) :
-    (fromPermutation σ).consistentTotalOrders = {σ} := by
+    consistentTotalOrders (fromPermutation σ) = {σ} := by
   ext τ
   rw [mem_consistentTotalOrders, Finset.mem_singleton]
   refine ⟨fromPermutation_consistent_unique, fun hτ => ?_⟩
   rw [hτ]
   exact isConsistent_fromPermutation σ
 
-/-! ### Stratified partial orders
+/-! ### Stratified grammars
 
 Earlier strata dominate later ones wholesale, and within a stratum an inner
 order applies. With the discrete inner order this is the freely-ranked stratum
@@ -230,72 +231,84 @@ grammar of [anttila-1997] eq. (50) — the Stratified Domination Hierarchy of
 
 variable {s : ℕ}
 
-/-- The stratified partial order induced by `stratumOf` and an inner order
-`inner`: `rel a b` iff a's stratum strictly precedes b's, or they share a
-stratum and `inner.rel a b`. Cross-stratum `inner` edges are ignored. -/
-def stratified (stratumOf : Fin n → Fin s) (inner : PartialOrderConstraints n) :
-    PartialOrderConstraints n where
-  rel a b := stratumOf a < stratumOf b ∨ (stratumOf a = stratumOf b ∧ inner.rel a b)
-  isPartialOrder :=
-    { refl := fun a => Or.inr ⟨rfl, refl_of inner.rel a⟩
-      trans := fun a b c hab hbc => by
-        rcases hab with hab | ⟨hab, hab'⟩ <;> rcases hbc with hbc | ⟨hbc, hbc'⟩
-        · exact Or.inl (hab.trans hbc)
-        · exact Or.inl (lt_of_lt_of_eq hab hbc)
-        · exact Or.inl (lt_of_eq_of_lt hab hbc)
-        · exact Or.inr ⟨hab.trans hbc, trans_of inner.rel hab' hbc'⟩
-      antisymm := fun a b hab hba => by
-        rcases hab with hab | ⟨hab, hab'⟩ <;> rcases hba with hba | ⟨hba, hba'⟩
-        · exact absurd (hab.trans hba) (lt_irrefl _)
-        · exact absurd (lt_of_lt_of_eq hab hba) (lt_irrefl _)
-        · exact absurd (lt_of_lt_of_eq hba hab) (lt_irrefl _)
-        · exact antisymm_of inner.rel hab' hba' }
+/-- The stratified grammar induced by `stratumOf` and an inner order `inner` —
+    mathlib's lexicographic sigma order (`Sigma.Lex`, underlying
+    `Sigma.Lex.partialOrder`) on the fibers of `stratumOf`, pulled back along
+    the fiber partition. The plain characterization is `stratified_iff`;
+    cross-stratum `inner` edges are ignored. -/
+def stratified (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop) :
+    Fin n → Fin n → Prop :=
+  fun a b =>
+    Sigma.Lex (· < ·) (fun k (x y : {c : Fin n // stratumOf c = k}) => inner x.1 y.1)
+      ⟨stratumOf a, a, rfl⟩ ⟨stratumOf b, b, rfl⟩
 
 private theorem sigmaMk_stratum_eq {stratumOf : Fin n → Fin s} {a : Fin n} {k : Fin s}
     (h : stratumOf a = k) :
     (⟨stratumOf a, a, rfl⟩ : Σ k, {c : Fin n // stratumOf c = k}) = ⟨k, a, h⟩ := by
   subst h; rfl
 
-/-- `stratified` is the lexicographic sigma order — the relation underlying
-    mathlib's `Sigma.Lex.partialOrder` — transported along the fiber partition
-    `Equiv.sigmaFiberEquiv stratumOf`: constraints compare by stratum first
-    and by the inner order within a stratum. -/
-theorem stratified_rel_iff_lex {stratumOf : Fin n → Fin s}
-    {inner : PartialOrderConstraints n} {a b : Fin n} :
-    (stratified stratumOf inner).rel a b ↔
-      Sigma.Lex (· < ·) (fun k (x y : {c : Fin n // stratumOf c = k}) => inner.rel x.1 y.1)
-        ⟨stratumOf a, a, rfl⟩ ⟨stratumOf b, b, rfl⟩ := by
+/-- Dominance in a stratified grammar holds iff a's stratum strictly precedes
+    b's, or they share a stratum and the inner order relates them. -/
+theorem stratified_iff {stratumOf : Fin n → Fin s} {inner : Fin n → Fin n → Prop}
+    {a b : Fin n} :
+    stratified stratumOf inner a b ↔
+      stratumOf a < stratumOf b ∨ stratumOf a = stratumOf b ∧ inner a b := by
   constructor
-  · rintro (hlt | ⟨heq, hrel⟩)
-    · exact Sigma.Lex.left _ _ hlt
-    · rw [sigmaMk_stratum_eq heq]
-      exact Sigma.Lex.right _ _ hrel
   · intro hlex
     rcases Sigma.lex_iff.mp hlex with hlt | ⟨heq, -⟩
     · exact Or.inl hlt
     · refine Or.inr ⟨heq, ?_⟩
+      unfold stratified at hlex
       rw [sigmaMk_stratum_eq heq] at hlex
       cases hlex with
       | left _ _ h => exact absurd h (lt_irrefl _)
       | right _ _ hr => exact hr
+  · rintro (hlt | ⟨heq, hrel⟩)
+    · exact Sigma.Lex.left _ _ hlt
+    · show Sigma.Lex _ _ _ _
+      rw [sigmaMk_stratum_eq heq]
+      exact Sigma.Lex.right _ _ hrel
 
-/-- Under a stratified order, an earlier-stratum constraint occupies a strictly
-    earlier position in every consistent ranking. -/
+instance (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) inner] :
+    IsPartialOrder (Fin n) (stratified stratumOf inner) where
+  refl a := stratified_iff.mpr (Or.inr ⟨rfl, refl_of inner a⟩)
+  trans a b c hab hbc := by
+    rcases stratified_iff.mp hab with h | ⟨h, h'⟩ <;>
+      rcases stratified_iff.mp hbc with g | ⟨g, g'⟩
+    · exact stratified_iff.mpr (Or.inl (h.trans g))
+    · exact stratified_iff.mpr (Or.inl (lt_of_lt_of_eq h g))
+    · exact stratified_iff.mpr (Or.inl (lt_of_eq_of_lt h g))
+    · exact stratified_iff.mpr (Or.inr ⟨h.trans g, trans_of inner h' g'⟩)
+  antisymm a b hab hba := by
+    rcases stratified_iff.mp hab with h | ⟨h, h'⟩ <;>
+      rcases stratified_iff.mp hba with g | ⟨g, g'⟩
+    · exact absurd (h.trans g) (lt_irrefl _)
+    · exact absurd (lt_of_lt_of_eq h g) (lt_irrefl _)
+    · exact absurd (lt_of_lt_of_eq g h) (lt_irrefl _)
+    · exact antisymm_of inner h' g'
+
+instance (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop)
+    [DecidableRel inner] : DecidableRel (stratified stratumOf inner) :=
+  fun _ _ => decidable_of_iff _ stratified_iff.symm
+
+/-- Under a stratified grammar, an earlier-stratum constraint occupies a
+    strictly earlier position in every consistent ranking. -/
 theorem IsConsistent.symm_lt_of_stratum_lt {stratumOf : Fin n → Fin s}
-    {inner : PartialOrderConstraints n} {σ : Ranking n}
-    (hσ : (stratified stratumOf inner).IsConsistent σ) {a b : Fin n}
+    {inner : Fin n → Fin n → Prop} {σ : Ranking n}
+    (hσ : IsConsistent (stratified stratumOf inner) σ) {a b : Fin n}
     (h : stratumOf a < stratumOf b) : σ.symm a < σ.symm b :=
-  lt_of_le_of_ne (hσ a b (Or.inl h))
+  lt_of_le_of_ne (hσ a b (stratified_iff.mpr (Or.inl h)))
     (fun heq => absurd (σ.symm.injective heq ▸ h) (lt_irrefl _))
 
-/-- Consistent rankings of a stratified order are closed under swapping two
+/-- Consistent rankings of a stratified grammar are closed under swapping two
     constraints of a stratum on which the inner order is trivial. -/
 theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
-    {inner : PartialOrderConstraints n} {k : Fin s}
-    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
+    {inner : Fin n → Fin n → Prop} {k : Fin s}
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner a b → a = b)
     {d d' : Fin n} (hd : stratumOf d = k) (hd' : stratumOf d' = k)
-    {σ : Ranking n} (hσ : (stratified stratumOf inner).IsConsistent σ) :
-    (stratified stratumOf inner).IsConsistent (Equiv.swap d d' * σ) := by
+    {σ : Ranking n} (hσ : IsConsistent (stratified stratumOf inner) σ) :
+    IsConsistent (stratified stratumOf inner) (Equiv.swap d d' * σ) := by
   have h_str : ∀ x, stratumOf (Equiv.swap d d' x) = stratumOf x := by
     intro x
     rcases eq_or_ne x d with rfl | hxd
@@ -304,12 +317,13 @@ theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
     · rw [Equiv.swap_apply_right, hd, hd']
     · rw [Equiv.swap_apply_of_ne_of_ne hxd hxd']
   intro a b hab
+  rw [stratified_iff] at hab
   have h_symm : ∀ x, (Equiv.swap d d' * σ).symm x = σ.symm (Equiv.swap d d' x) := by
     intro x
     rw [Equiv.Perm.mul_def, Equiv.symm_trans_apply, Equiv.symm_swap]
   rw [h_symm a, h_symm b]
   rcases hab with hlt | ⟨heq, hinner⟩
-  · exact hσ _ _ (Or.inl (by rw [h_str a, h_str b]; exact hlt))
+  · exact hσ _ _ (stratified_iff.mpr (Or.inl (by rw [h_str a, h_str b]; exact hlt)))
   · rcases eq_or_ne (stratumOf a) k with hk | hk
     · obtain rfl : a = b := h_triv a b hk (heq ▸ hk) hinner
       exact le_refl _
@@ -320,7 +334,9 @@ theorem isConsistent_swap_mul {stratumOf : Fin n → Fin s}
         Equiv.swap_apply_of_ne_of_ne (fun h => (heq ▸ hk) (by rw [h]; exact hd))
           (fun h => (heq ▸ hk) (by rw [h]; exact hd'))
       rw [ha, hb]
-      exact hσ a b (Or.inr ⟨heq, hinner⟩)
+      exact hσ a b (stratified_iff.mpr (Or.inr ⟨heq, hinner⟩))
+
+/-! ### Szpilrajn — every grammar has a consistent linear extension -/
 
 /-- Opaque carrier for the extended linear order, so that the extension can be
     installed as a `LinearOrder` instance without clashing with `Fin n`'s
@@ -329,13 +345,14 @@ private structure LinExtCarrier (n : ℕ) where ofFin ::
   /-- The underlying index. -/
   toFin : Fin n
 
-/-- Every partial order has a consistent linear extension (Szpilrajn, via
-    mathlib's `extend_partialOrder`). -/
-theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
-    p.consistentTotalOrders.Nonempty := by
+/-- Every grammar has a consistent linear extension (Szpilrajn, via mathlib's
+    `extend_partialOrder`). -/
+theorem exists_isConsistent (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] :
+    ∃ σ : Ranking n, IsConsistent r σ := by
   classical
-  -- Szpilrajn: extend the partial order `p.rel` to a linear order `s`.
-  obtain ⟨s, hs_lin, hsub⟩ := extend_partialOrder p.rel
+  -- Szpilrajn: extend the partial order `r` to a linear order `s`.
+  obtain ⟨s, hs_lin, hsub⟩ := extend_partialOrder r
   -- Equip the opaque carrier with `s`, then sort it against `Fin n`'s order.
   let wEquiv : LinExtCarrier n ≃ Fin n :=
     { toFun := LinExtCarrier.toFin, invFun := LinExtCarrier.ofFin,
@@ -355,7 +372,7 @@ theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
   -- The order iso `Fin n ≃o LinExtCarrier n` enumerates the carrier in `s`-order;
   -- composing with `wEquiv` yields the consistent permutation.
   let e : Fin n ≃o LinExtCarrier n := Fintype.orderIsoFinOfCardEq (LinExtCarrier n) hcard
-  refine ⟨e.toEquiv.trans wEquiv, mem_consistentTotalOrders.mpr ?_⟩
+  refine ⟨e.toEquiv.trans wEquiv, ?_⟩
   intro a b hab
   show ((e.toEquiv.trans wEquiv).symm a : Fin n) ≤ (e.toEquiv.trans wEquiv).symm b
   have key : ∀ c : Fin n, (e.toEquiv.trans wEquiv).symm c = e.symm (LinExtCarrier.ofFin c) :=
@@ -364,40 +381,49 @@ theorem consistentTotalOrders_nonempty (p : PartialOrderConstraints n) :
   exact e.symm.monotone (show s (LinExtCarrier.ofFin a).toFin (LinExtCarrier.ofFin b).toFin from
     hsub a b hab)
 
-theorem consistentTotalOrders_card_pos (p : PartialOrderConstraints n) :
-    0 < p.consistentTotalOrders.card :=
-  p.consistentTotalOrders_nonempty.card_pos
+theorem consistentTotalOrders_nonempty (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] [DecidableRel r] :
+    (consistentTotalOrders r).Nonempty :=
+  let ⟨σ, hσ⟩ := exists_isConsistent r
+  ⟨σ, mem_consistentTotalOrders.mpr hσ⟩
+
+theorem consistentTotalOrders_card_pos (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] [DecidableRel r] :
+    0 < (consistentTotalOrders r).card :=
+  (consistentTotalOrders_nonempty r).card_pos
 
 /-! ### The order-ideal antimatroid of a POC
 
-A partial order's Hasse-edge encoding is a consistent set of simple ERCs, so it
-has a Birkhoff antimatroid whose feasible sets are exactly the order ideals of
-`p` ([dilworth-1940]; [merchant-riggle-2016]). -/
+A grammar's Hasse-edge encoding is a consistent set of simple ERCs, so it has
+a Birkhoff antimatroid whose feasible sets are exactly the order ideals of `r`
+([dilworth-1940]; [merchant-riggle-2016]). -/
 
-/-- `p.toERCSet` consists of simple ERCs (each is a `simpleERC` of a strict pair). -/
-theorem toERCSet_isSimpleSet (p : PartialOrderConstraints n) :
-    ERCSet.IsSimpleSet p.toERCSet := by
+variable (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r] [DecidableRel r]
+
+omit [IsPartialOrder (Fin n) r] in
+/-- `toERCSet r` consists of simple ERCs (each is a `simpleERC` of a strict pair). -/
+theorem toERCSet_isSimpleSet : ERCSet.IsSimpleSet (toERCSet r) := by
   intro α hα
   obtain ⟨a, b, hab, _, rfl⟩ := mem_toERCSet.mp hα
   exact simpleERC_isSimple hab
 
-/-- `p.toERCSet` is consistent: any linear extension of `p` satisfies it. -/
-theorem toERCSet_consistent (p : PartialOrderConstraints n) :
-    ERCSet.Consistent p.toERCSet := by
-  obtain ⟨σ, hσ⟩ := p.consistentTotalOrders_nonempty
-  exact ⟨σ, satisfiedBy_toERCSet.mpr (mem_consistentTotalOrders.mp hσ)⟩
+/-- `toERCSet r` is consistent: any linear extension of `r` satisfies it. -/
+theorem toERCSet_consistent : ERCSet.Consistent (toERCSet r) := by
+  obtain ⟨σ, hσ⟩ := exists_isConsistent r
+  exact ⟨σ, satisfiedBy_toERCSet.mpr hσ⟩
 
-/-- The **order-ideal antimatroid** of a partial order — the simple-ERC
-Birkhoff antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding, whose
-feasible sets are exactly the order ideals of `p`
+/-- The **order-ideal antimatroid** of a grammar — the simple-ERC Birkhoff
+antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding, whose feasible
+sets are exactly the order ideals of `r`
 (`pocAntimatroid_isFeasible_iff`). -/
-def pocAntimatroid (p : PartialOrderConstraints n) : Antimatroid (Fin n) :=
-  Antimat.ofSimple p.toERCSet p.toERCSet_consistent p.toERCSet_isSimpleSet
+def pocAntimatroid : Antimatroid (Fin n) :=
+  Antimat.ofSimple (toERCSet r) (toERCSet_consistent r) (toERCSet_isSimpleSet r)
 
-/-- Local feasibility against `p.toERCSet` is exactly the order-ideal
+omit [IsPartialOrder (Fin n) r] in
+/-- Local feasibility against `toERCSet r` is exactly the order-ideal
 condition — whenever `b ∈ S` and `a` dominates `b`, also `a ∈ S`. -/
-theorem feasible_toERCSet_iff {p : PartialOrderConstraints n} {S : Finset (Fin n)} :
-    Feasible p.toERCSet S ↔ ∀ a b, p.rel a b → b ∈ S → a ∈ S := by
+theorem feasible_toERCSet_iff {S : Finset (Fin n)} :
+    Feasible (toERCSet r) S ↔ ∀ a b, r a b → b ∈ S → a ∈ S := by
   constructor
   · intro h a b hrel hbS
     rcases eq_or_ne a b with rfl | hab
@@ -412,71 +438,65 @@ theorem feasible_toERCSet_iff {p : PartialOrderConstraints n} {S : Finset (Fin n
     rw [(simpleERC_eq_L_iff hab l).mp hlL] at hlS
     exact ⟨a, simpleERC_apply_W, h a b hrel hlS⟩
 
-/-- The feasible sets of `pocAntimatroid` are the order ideals of `p` — the
+/-- The feasible sets of `pocAntimatroid` are the order ideals of `r` — the
 Birkhoff correspondence, made concrete and decidable. -/
-@[simp] theorem pocAntimatroid_isFeasible_iff {p : PartialOrderConstraints n}
-    {S : Finset (Fin n)} :
-    (p.pocAntimatroid).IsFeasible (↑S : Set (Fin n)) ↔
-      ∀ a b, p.rel a b → b ∈ S → a ∈ S := by
+@[simp] theorem pocAntimatroid_isFeasible_iff {S : Finset (Fin n)} :
+    (pocAntimatroid r).IsFeasible (↑S : Set (Fin n)) ↔
+      ∀ a b, r a b → b ∈ S → a ∈ S := by
   simp only [pocAntimatroid, ofSimple_isFeasible_coe, feasible_toERCSet_iff]
 
-end PartialOrderConstraints
+variable {r}
 
 /-! ### POC Realizability of SystemicProblem -/
 
 namespace SystemicProblem
 
-variable {Input Output : Type*} {n : ℕ}
+variable {Input Output : Type*}
 
-/-- A partial order p **POC-realizes** the target if every consistent
-    extension realizes it. Since consistent extensions always exist
-    (`consistentTotalOrders_nonempty`), this is never vacuous. -/
+/-- A grammar `r` **POC-realizes** the target if every consistent extension
+    realizes it. Since consistent extensions always exist
+    (`exists_isConsistent`), this is never vacuous. -/
 def realizedByPOC (P : SystemicProblem Input Output n)
-    (p : PartialOrderConstraints n) : Prop :=
-  ∀ σ ∈ p.consistentTotalOrders, P.realizedByRanking σ
+    (r : Fin n → Fin n → Prop) : Prop :=
+  ∀ σ, IsConsistent r σ → P.realizedByRanking σ
 
 /-- A `SystemicProblem` is **POC-realizable** if some partial order
     categorically realizes the target. -/
 def IsPOCRealizable (P : SystemicProblem Input Output n) : Prop :=
-  ∃ p : PartialOrderConstraints n, P.realizedByPOC p
+  ∃ r : Fin n → Fin n → Prop, IsPartialOrder (Fin n) r ∧ P.realizedByPOC r
 
 end SystemicProblem
 
 /-! ### Containments — OT ⊆ POC, POC ⊆ OT (categorical) -/
 
+variable {Input Output : Type*}
+
 /-- Every POC-realized target is OT-realized, since any single consistent
     extension realizes it. -/
-theorem poc_realizable_imp_ot_realizable {Input Output : Type*} {n : ℕ}
-    (P : SystemicProblem Input Output n) :
+theorem poc_realizable_imp_ot_realizable (P : SystemicProblem Input Output n) :
     P.IsPOCRealizable → P.IsOTRealizable := by
-  rintro ⟨p, hreal⟩
-  obtain ⟨σ, hσ⟩ := p.consistentTotalOrders_nonempty
+  rintro ⟨r, hpo, hreal⟩
+  have := hpo
+  obtain ⟨σ, hσ⟩ := exists_isConsistent r
   exact ⟨σ, hreal σ hσ⟩
 
 /-- Every OT-realized target is POC-realized — the witness is the σ-induced
-    total order, whose unique consistent extension is σ itself. -/
-theorem ot_realizable_imp_poc_realizable {Input Output : Type*} {n : ℕ}
-    (P : SystemicProblem Input Output n) :
+    total ranking, whose unique consistent extension is σ itself. -/
+theorem ot_realizable_imp_poc_realizable (P : SystemicProblem Input Output n) :
     P.IsOTRealizable → P.IsPOCRealizable := by
   rintro ⟨σ, hσ⟩
-  refine ⟨PartialOrderConstraints.fromPermutation σ, ?_⟩
-  simpa [SystemicProblem.realizedByPOC,
-    PartialOrderConstraints.consistentTotalOrders_fromPermutation] using hσ
+  exact ⟨fromPermutation σ, inferInstance,
+    fun τ hτ => fromPermutation_consistent_unique hτ ▸ hσ⟩
 
 /-- Under categorical realizability, OT-realizable and POC-realizable
     coincide. POC's advantage over OT is probabilistic, captured by
     `pocPredict`. -/
-theorem isOTRealizable_iff_isPOCRealizable {Input Output : Type*} {n : ℕ}
-    (P : SystemicProblem Input Output n) :
+theorem isOTRealizable_iff_isPOCRealizable (P : SystemicProblem Input Output n) :
     P.IsOTRealizable ↔ P.IsPOCRealizable :=
   ⟨ot_realizable_imp_poc_realizable P,
    poc_realizable_imp_ot_realizable P⟩
 
 /-! ### Probabilistic POC — pocPredict -/
-
-namespace PartialOrderConstraints
-
-variable {Input Output : Type*} {n : ℕ}
 
 /-- The constraints **active** on the candidate pair `o, o'` at input `i` —
     those assigning the two candidates different violation counts
@@ -546,17 +566,17 @@ instance (cands : Input → Finset Output) (vp : Input → Output → Fin n → 
     Decidable (PicksAt cands vp σ i o) := by
   unfold PicksAt; infer_instance
 
-/-- The probability that sampling under partial order p selects output o for
+/-- The probability that sampling under grammar `r` selects output o for
     input i — the fraction of consistent extensions picking o. The denominator
     is positive (`consistentTotalOrders_card_pos`), so this is a genuine
     probability. -/
 def pocPredict (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
-    (p : PartialOrderConstraints n) (i : Input) (o : Output) : ℚ :=
-  ((p.consistentTotalOrders.filter
+    (r : Fin n → Fin n → Prop) [DecidableRel r] (i : Input) (o : Output) : ℚ :=
+  (((consistentTotalOrders r).filter
     (fun σ => PicksAt cands vp σ i o)).card : ℚ) /
-  (p.consistentTotalOrders.card : ℚ)
+  ((consistentTotalOrders r).card : ℚ)
 
-/-- For the σ-induced total order, `pocPredict` collapses to a point mass —
+/-- For the σ-induced total ranking, `pocPredict` collapses to a point mass —
     probability 1 if σ picks o and 0 otherwise. -/
 theorem pocPredict_fromPermutation
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
@@ -570,12 +590,12 @@ theorem pocPredict_fromPermutation
   · simp [if_pos h]
   · simp [if_neg h]
 
-/-- Under the discrete order, `pocPredict` is the fraction of all `n!`
+/-- Under the discrete grammar, `pocPredict` is the fraction of all `n!`
     rankings picking o. -/
 theorem pocPredict_discrete
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (i : Input) (o : Output) :
-    pocPredict cands vp (discrete n) i o =
+    pocPredict cands vp (· = ·) i o =
     ((Finset.univ.filter
       (fun σ : Ranking n => PicksAt cands vp σ i o)).card : ℚ) /
     (Finset.univ : Finset (Ranking n)).card := by
@@ -584,35 +604,38 @@ theorem pocPredict_discrete
 /-! #### `pocPredict` is a probability distribution -/
 
 theorem pocPredict_nonneg (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n)
-    (i : Input) (o : Output) : 0 ≤ pocPredict cands vp p i o :=
+    (vp : Input → Output → Fin n → ℕ) (r : Fin n → Fin n → Prop)
+    [DecidableRel r] (i : Input) (o : Output) :
+    0 ≤ pocPredict cands vp r i o :=
   div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
 
 theorem pocPredict_le_one (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n)
-    (i : Input) (o : Output) : pocPredict cands vp p i o ≤ 1 := by
+    (vp : Input → Output → Fin n → ℕ) (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] [DecidableRel r] (i : Input) (o : Output) :
+    pocPredict cands vp r i o ≤ 1 := by
   unfold pocPredict
-  rw [div_le_one (by exact_mod_cast p.consistentTotalOrders_card_pos)]
+  rw [div_le_one (by exact_mod_cast consistentTotalOrders_card_pos r)]
   exact_mod_cast Finset.card_filter_le _ _
 
 /-- With pairwise-distinct violation profiles the picks-fibers over the
     candidate set partition the consistent extensions — the division-free core
     of `sum_pocPredict_eq_one`. -/
 theorem sum_card_filter_picksAt (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
+    (vp : Input → Output → Fin n → ℕ) (r : Fin n → Fin n → Prop)
+    [DecidableRel r] {i : Input}
     (h_ne : (cands i).Nonempty)
     (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o') :
-    ∑ o ∈ cands i, (p.consistentTotalOrders.filter
-      (fun σ => PicksAt cands vp σ i o)).card = p.consistentTotalOrders.card := by
+    ∑ o ∈ cands i, ((consistentTotalOrders r).filter
+      (fun σ => PicksAt cands vp σ i o)).card = (consistentTotalOrders r).card := by
   classical
   have h_disjoint : (↑(cands i) : Set Output).PairwiseDisjoint
-      (fun o => p.consistentTotalOrders.filter (fun σ => PicksAt cands vp σ i o)) := by
+      (fun o => (consistentTotalOrders r).filter (fun σ => PicksAt cands vp σ i o)) := by
     intro o _ o' _ hne'
     simp only [Function.onFun, Finset.disjoint_left, Finset.mem_filter]
     rintro σ ⟨_, h₁⟩ ⟨_, h₂⟩
     exact hne' (picksAt_unique h₁ h₂)
-  have h_union : (cands i).biUnion (fun o => p.consistentTotalOrders.filter
-      (fun σ => PicksAt cands vp σ i o)) = p.consistentTotalOrders := by
+  have h_union : (cands i).biUnion (fun o => (consistentTotalOrders r).filter
+      (fun σ => PicksAt cands vp σ i o)) = consistentTotalOrders r := by
     ext σ
     simp only [Finset.mem_biUnion, Finset.mem_filter]
     constructor
@@ -620,42 +643,42 @@ theorem sum_card_filter_picksAt (cands : Input → Finset Output)
     · intro hσ
       obtain ⟨o, ho, hpick⟩ := exists_picksAt cands vp h_ne h_inj σ
       exact ⟨o, ho, hσ, hpick⟩
-  calc ∑ o ∈ cands i, (p.consistentTotalOrders.filter
+  calc ∑ o ∈ cands i, ((consistentTotalOrders r).filter
         (fun σ => PicksAt cands vp σ i o)).card
-      = ((cands i).biUnion (fun o => p.consistentTotalOrders.filter
+      = ((cands i).biUnion (fun o => (consistentTotalOrders r).filter
           (fun σ => PicksAt cands vp σ i o))).card :=
         (Finset.card_biUnion h_disjoint).symm
-    _ = p.consistentTotalOrders.card := by rw [h_union]
+    _ = (consistentTotalOrders r).card := by rw [h_union]
 
 /-- Over a candidate set with pairwise-distinct violation profiles the win
-    probabilities sum to 1, for any partial order — every consistent ranking
-    picks exactly one winner. -/
+    probabilities sum to 1, for any grammar — every consistent ranking picks
+    exactly one winner. -/
 theorem sum_pocPredict_eq_one (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
+    (vp : Input → Output → Fin n → ℕ) (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] [DecidableRel r] {i : Input}
     (h_ne : (cands i).Nonempty)
     (h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o') :
-    ∑ o ∈ cands i, pocPredict cands vp p i o = 1 := by
+    ∑ o ∈ cands i, pocPredict cands vp r i o = 1 := by
   unfold pocPredict
-  rw [← Finset.sum_div, ← Nat.cast_sum, sum_card_filter_picksAt cands vp p h_ne h_inj]
-  exact div_self (by exact_mod_cast p.consistentTotalOrders_card_pos.ne')
+  rw [← Finset.sum_div, ← Nat.cast_sum, sum_card_filter_picksAt cands vp r h_ne h_inj]
+  exact div_self (by exact_mod_cast (consistentTotalOrders_card_pos r).ne')
 
 /-- Two distinct candidates with distinct violation profiles split the
     probability mass. -/
 theorem pocPredict_binary_add_eq_one (cands : Input → Finset Output)
-    (vp : Input → Output → Fin n → ℕ) (p : PartialOrderConstraints n) {i : Input}
+    (vp : Input → Output → Fin n → ℕ) (r : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) r] [DecidableRel r] {i : Input}
     {o₁ o₂ : Output} (h_two : cands i = {o₁, o₂}) (h_ne : o₁ ≠ o₂)
     (h_vp : vp i o₁ ≠ vp i o₂) :
-    pocPredict cands vp p i o₁ + pocPredict cands vp p i o₂ = 1 := by
+    pocPredict cands vp r i o₁ + pocPredict cands vp r i o₂ = 1 := by
   have h_inj : ∀ o ∈ cands i, ∀ o' ∈ cands i, vp i o = vp i o' → o = o' := by
     intro o ho o' ho' hvv
     rw [h_two, Finset.mem_insert, Finset.mem_singleton] at ho ho'
     rcases ho with rfl | rfl <;> rcases ho' with rfl | rfl <;>
       first | rfl | exact absurd hvv h_vp | exact absurd hvv.symm h_vp
-  have h := sum_pocPredict_eq_one cands vp p
+  have h := sum_pocPredict_eq_one cands vp r
     (by rw [h_two]; exact Finset.insert_nonempty _ _) h_inj
   rwa [h_two, Finset.sum_pair h_ne] at h
-
-end PartialOrderConstraints
 
 /-! ### Bridge — binary PicksAt is decided by the σ-earliest active constraint
 
@@ -667,11 +690,7 @@ the first position where the profiles differ — i.e., `chosen` wins iff the
 `Core.Optimization.PermSubsetCombinatorics`, this yields closed-form rates
 for binary POC competitions without enumerating rankings. -/
 
-namespace PartialOrderConstraints
-
 open Core.Optimization.PermSubsetCombinatorics
-
-variable {Input Output : Type*} [DecidableEq Output] {n : ℕ}
 
 /-- For binary candidate sets, `PicksAt σ i chosen` holds exactly when the
     σ-earliest active constraint favors `chosen`. -/
@@ -729,7 +748,7 @@ theorem pocPredict_discrete_binary_rate
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
     (i : Input) (chosen other : Output)
     (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other) :
-    pocPredict cands vp (discrete n) i chosen =
+    pocPredict cands vp (· = ·) i chosen =
       ((favoring vp i chosen other ∩ active vp i chosen other).card : ℚ) /
         ((active vp i chosen other).card : ℚ) := by
   rw [pocPredict_discrete, Finset.card_univ, Fintype.card_perm, Fintype.card_fin,
@@ -745,13 +764,13 @@ them — provably irrelevant. This is [anttila-1997]'s tableau-count shortcut
 stated against the full grammar rather than a per-stratum sub-grammar. -/
 
 omit [DecidableEq Output] in
-/-- On a consistent ranking of a stratified order, the σ-earliest active
+/-- On a consistent ranking of a stratified grammar, the σ-earliest active
     constraint lies in the deciding stratum: earlier strata are inactive
     (`h_tie`), and constraints of later strata come after all of stratum `k`. -/
-private theorem permDList_head?_active_filter_stratum {s : ℕ}
-    {stratumOf : Fin n → Fin s} {inner : PartialOrderConstraints n} {σ : Ranking n}
+private theorem permDList_head?_active_filter_stratum
+    {stratumOf : Fin n → Fin s} {inner : Fin n → Fin n → Prop} {σ : Ranking n}
     (vp : Input → Output → Fin n → ℕ) {i : Input} {chosen other : Output} {k : Fin s}
-    (hσ : (stratified stratumOf inner).IsConsistent σ)
+    (hσ : IsConsistent (stratified stratumOf inner) σ)
     (h_tie : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
     (h_dec : ((active vp i chosen other).filter (stratumOf · = k)).Nonempty) :
     (permDList σ (active vp i chosen other)).head? =
@@ -771,12 +790,13 @@ private theorem permDList_head?_active_filter_stratum {s : ℕ}
     and containing an active constraint (`h_dec`) — is won by `chosen` at rate
     `|favoring ∩ Dₖ| / |Dₖ|`, where `Dₖ` is the active set restricted to
     stratum `k`. Later strata cannot affect the outcome. -/
-theorem pocPredict_stratified_binary_rate {s : ℕ}
+theorem pocPredict_stratified_binary_rate
     (cands : Input → Finset Output) (vp : Input → Output → Fin n → ℕ)
-    (stratumOf : Fin n → Fin s) (inner : PartialOrderConstraints n)
+    (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop)
+    [IsPartialOrder (Fin n) inner] [DecidableRel inner]
     (i : Input) (chosen other : Output)
     (h_two : cands i = {chosen, other}) (h_ne : chosen ≠ other) (k : Fin s)
-    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner.rel a b → a = b)
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → inner a b → a = b)
     (h_tie : ∀ c, stratumOf c < k → vp i chosen c = vp i other c)
     (h_dec : ((active vp i chosen other).filter (stratumOf · = k)).Nonempty) :
     pocPredict cands vp (stratified stratumOf inner) i chosen =
@@ -789,7 +809,8 @@ theorem pocPredict_stratified_binary_rate {s : ℕ}
     (picksAt_binary_iff_head_mem_favoring cands vp i chosen other h_two h_ne σ).trans
       (by rw [permDList_head?_active_filter_stratum vp
         (mem_consistentTotalOrders.mp hσ) h_tie h_dec])]
-  exact filter_head_in_rate_of_swaps _ _ _ (consistentTotalOrders_nonempty _)
+  exact filter_head_in_rate_of_swaps _ _ _
+    (consistentTotalOrders_nonempty (stratified stratumOf inner))
     fun y₁ h₁ y₂ h₂ σ hσ => mem_consistentTotalOrders.mpr
       (isConsistent_swap_mul h_triv (Finset.mem_filter.mp h₁).2 (Finset.mem_filter.mp h₂).2
         (mem_consistentTotalOrders.mp hσ))
@@ -798,17 +819,17 @@ theorem pocPredict_stratified_binary_rate {s : ℕ}
 
 A partial order on constraints is the simple-ERC fragment of an OT grammar —
 its consistent total orders are exactly the legs of
-`Grammar.ofERCSet p.toERCSet` ([merchant-riggle-2016]). -/
+`Grammar.ofERCSet (toERCSet r)` ([merchant-riggle-2016]). -/
 
-/-- The `Grammar` whose legs are `p`'s consistent total orders. -/
-def toGrammar (p : PartialOrderConstraints n) : Grammar n :=
-  Grammar.ofERCSet p.toERCSet p.toERCSet_consistent
+/-- The `Grammar` whose legs are `r`'s consistent total orders. -/
+def toGrammar (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r]
+    [DecidableRel r] : Grammar n :=
+  Grammar.ofERCSet (toERCSet r) (toERCSet_consistent r)
 
-@[simp] theorem toGrammar_legs (p : PartialOrderConstraints n) :
-    p.toGrammar.legs = p.consistentTotalOrders := by
-  show (Grammar.ofERCSet p.toERCSet p.toERCSet_consistent).legs = p.consistentTotalOrders
+@[simp] theorem toGrammar_legs (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r]
+    [DecidableRel r] :
+    (toGrammar r).legs = consistentTotalOrders r := by
+  show (Grammar.ofERCSet (toERCSet r) (toERCSet_consistent r)).legs = consistentTotalOrders r
   rw [Grammar.legs_ofERCSet, consistentTotalOrders_eq_linearExtensions]
-
-end PartialOrderConstraints
 
 end HarmonicGrammar

--- a/Linglib/Studies/Anttila1997.lean
+++ b/Linglib/Studies/Anttila1997.lean
@@ -88,7 +88,7 @@ mass for every motif (`sum_pocPredict_eq_one` substrate instance).
 
 namespace Anttila1997
 
-open HarmonicGrammar HarmonicGrammar.PartialOrderConstraints
+open HarmonicGrammar
 
 /-! ### Variants and motifs -/
 
@@ -139,18 +139,28 @@ def stratumOf : Fin 20 → Fin 5 :=
 
 /-- The Set-5-internal rankings of [anttila-1997] eq. (50): \*L/O ≫ \*L/I
 (`14 ≫ 15`) and \*A ≫ \*O ≫ \*I (`16 ≫ 17 ≫ 18`), transitively closed. -/
-def setFiveInner : PartialOrderConstraints 20 where
-  rel a b := a = b ∨
+def setFiveInner : Fin 20 → Fin 20 → Prop :=
+  fun a b => a = b ∨
     (a, b) ∈ ([(14, 15), (16, 17), (17, 18), (16, 18)] : List (Fin 20 × Fin 20))
-  isPartialOrder :=
-    { refl := fun _ => Or.inl rfl
-      trans := by decide
-      antisymm := by decide }
+
+instance : DecidableRel setFiveInner := by
+  unfold setFiveInner; infer_instance
+
+instance : IsPartialOrder (Fin 20) setFiveInner where
+  refl _ := Or.inl rfl
+  trans := by decide
+  antisymm := by decide
 
 /-- **The grammar for Finnish, final version** ([anttila-1997] eq. (50),
 page 21): five mutually-ranked strata, internally free except for
 `setFiveInner`'s Set-5 rankings. -/
-def finnishGrammar : PartialOrderConstraints 20 := stratified stratumOf setFiveInner
+def finnishGrammar : Fin 20 → Fin 20 → Prop := stratified stratumOf setFiveInner
+
+instance : IsPartialOrder (Fin 20) finnishGrammar :=
+  inferInstanceAs (IsPartialOrder (Fin 20) (stratified stratumOf setFiveInner))
+
+instance : DecidableRel finnishGrammar :=
+  inferInstanceAs (DecidableRel (stratified stratumOf setFiveInner))
 
 /-- Violation profile over the full constraint roster, from [anttila-1997]
 table (52). Sets 1–2 tie on every motif and Set-5 cells are 0 (provably
@@ -182,7 +192,7 @@ def winProb (m : Motif) (v : Variant) : ℚ :=
 /-- Bridge to the deciding-stratum closed form, shared by all twelve rate
 theorems. -/
 private theorem winProb_eq_rate (m : Motif) (v : Variant) (k : Fin 5)
-    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → setFiveInner.rel a b → a = b)
+    (h_triv : ∀ a b, stratumOf a = k → stratumOf b = k → setFiveInner a b → a = b)
     (h_tie : ∀ c, stratumOf c < k → vp m v c = vp m v.other c)
     (h_dec : ((active vp m v v.other).filter (stratumOf · = k)).Nonempty) :
     winProb m v =

--- a/Linglib/Studies/CoetzeePater2011.lean
+++ b/Linglib/Studies/CoetzeePater2011.lean
@@ -235,7 +235,7 @@ theorem delete_pause_profile :
 /-! ### POC adapter: `tdCands` and `tdVp` for `pocPredict` consumption -/
 
 /-- Candidate set per context for POC: both retain and delete are available
-    in every context. Required by `PartialOrderConstraints.pocPredict`. -/
+    in every context. Required by `pocPredict`. -/
 def tdCands : Context → Finset TDOutput := fun _ => Finset.univ
 
 /-- Violation profile in POC's `Input → Output → Fin n → ℕ` shape.
@@ -262,7 +262,7 @@ def tdVp : Context → TDOutput → Fin 4 → ℕ
     the `picksAt_binary_iff_head_mem_favoring` bridge + the substrate's
     `perm_filter_head_in_rate`.
 
-    The discrete partial order (`PartialOrderConstraints.discrete 4`)
+    The discrete partial order (`(· = · : Fin 4 → Fin 4 → Prop)`)
     encodes "no rankings imposed" — uniform sampling over all 4! = 24
     total orders. -/
 
@@ -270,17 +270,17 @@ open Core.Optimization Core.Optimization.PermSubsetCombinatorics in
 /-- Probability that POC sampling selects deletion at context `ctx`,
     under the discrete partial order. -/
 def deletionProb (ctx : Context) : ℚ :=
-  PartialOrderConstraints.pocPredict tdCands tdVp
-    (PartialOrderConstraints.discrete 4) ctx .delete
+  pocPredict tdCands tdVp
+    ((· = · : Fin 4 → Fin 4 → Prop)) ctx .delete
 
 /-- Local specialisation of `pocPredict_discrete_binary_rate` to t/d-deletion,
     baking in `tdCands ctx = {.delete, .retain}` and `delete ≠ retain`. -/
 private theorem deletionProb_eq (ctx : Context) :
     deletionProb ctx =
-      ((PartialOrderConstraints.favoring tdVp ctx .delete .retain ∩
-          PartialOrderConstraints.active tdVp ctx .delete .retain).card : ℚ) /
-        ((PartialOrderConstraints.active tdVp ctx .delete .retain).card : ℚ) :=
-  PartialOrderConstraints.pocPredict_discrete_binary_rate
+      ((favoring tdVp ctx .delete .retain ∩
+          active tdVp ctx .delete .retain).card : ℚ) /
+        ((active tdVp ctx .delete .retain).card : ℚ) :=
+  pocPredict_discrete_binary_rate
     tdCands tdVp ctx .delete .retain
     (by unfold tdCands; ext o; cases o <;> simp)
     (fun heq => TDOutput.noConfusion heq)
@@ -327,9 +327,9 @@ theorem deletionProb_preV_eq_pause : deletionProb .preV = deletionProb .pause :=
 
 /-- The deletion pattern (preV?, pause?, preC?) produced by ranking `σ`. -/
 def deletionPattern (σ : Equiv.Perm (Fin 4)) : Bool × Bool × Bool :=
-  ( decide (PartialOrderConstraints.PicksAt tdCands tdVp σ .preV .delete)
-  , decide (PartialOrderConstraints.PicksAt tdCands tdVp σ .pause .delete)
-  , decide (PartialOrderConstraints.PicksAt tdCands tdVp σ .preC .delete) )
+  ( decide (PicksAt tdCands tdVp σ .preV .delete)
+  , decide (PicksAt tdCands tdVp σ .pause .delete)
+  , decide (PicksAt tdCands tdVp σ .preC .delete) )
 
 /-- Distinct categorical dialect types over all 4! = 24 total orders. -/
 def factorialTypes : Finset (Bool × Bool × Bool) :=
@@ -383,15 +383,15 @@ theorem no_preV_only :
     *CT >> MAX, the sole condition for pre-C deletion. -/
 theorem preV_deletion_implies_preC :
     ∀ σ : Equiv.Perm (Fin 4),
-    PartialOrderConstraints.PicksAt tdCands tdVp σ .preV .delete →
-    PartialOrderConstraints.PicksAt tdCands tdVp σ .preC .delete := by decide
+    PicksAt tdCands tdVp σ .preV .delete →
+    PicksAt tdCands tdVp σ .preC .delete := by decide
 
 /-- Similarly, every ranking producing pause deletion also produces
     pre-C deletion: *CT >> MAX ∧ *CT >> MAX-FINAL entails *CT >> MAX. -/
 theorem pause_deletion_implies_preC :
     ∀ σ : Equiv.Perm (Fin 4),
-    PartialOrderConstraints.PicksAt tdCands tdVp σ .pause .delete →
-    PartialOrderConstraints.PicksAt tdCands tdVp σ .preC .delete := by decide
+    PicksAt tdCands tdVp σ .pause .delete →
+    PicksAt tdCands tdVp σ .preC .delete := by decide
 
 /-- No ranking produces pre-V or pause deletion without also producing
     pre-C deletion. The formal basis for the cross-dialectal generalization

--- a/Linglib/Studies/Zuraw2010.lean
+++ b/Linglib/Studies/Zuraw2010.lean
@@ -25,7 +25,7 @@ Constraints) substrate. For each stem-initial consonant `c`:
   computed from `vp` (`{i : vp c .yes i ≠ vp c .no i}` and
   `{i : vp c .yes i < vp c .no i}` respectively), with concrete
   `decide`-discharged values.
-- `subProb c : ℚ` is `HarmonicGrammar.PartialOrderConstraints.pocPredict`
+- `subProb c : ℚ` is `HarmonicGrammar.pocPredict`
   applied to the discrete partial order on `Fin 6` — i.e. uniform sampling
   over all 720 total orders.
 - The closed-form rate `|Y_c ∩ D_c| / |D_c|` follows by a single
@@ -94,7 +94,7 @@ those definitions must remain stable.
 namespace Zuraw2010
 
 open Constraints Core.Optimization Constraints OptimalityTheory OptimalityTheory
-open Core.Optimization HarmonicGrammar.PartialOrderConstraints
+open Core.Optimization HarmonicGrammar
 open Core.Optimization Core.Optimization.PermSubsetCombinatorics
 
 /-! ## § 0: Stems, Substitution Decisions, Dictionary Counts -/
@@ -235,7 +235,7 @@ theorem assoc_eq_initAll (c : StemC) (s : SubSt) :
 
 /-- Violation profile derived from the constraint definitions, in the
     `Input → Output → Fin n → ℕ` shape required by
-    `PartialOrderConstraints.PicksAt` and `pocPredict`. -/
+    `PicksAt` and `pocPredict`. -/
 def vp (c : StemC) (s : SubSt) (i : Fin 6) : ℕ :=
   (constraint i) (c, s)
 
@@ -286,7 +286,7 @@ private theorem nsCands_two (c : StemC) : nsCands c = {SubSt.yes, SubSt.no} := b
     order: the fraction of all `6! = 720` total orders that pick YES as
     the OT optimum for stem `c`. -/
 def subProb (c : StemC) : ℚ :=
-  pocPredict nsCands vp (discrete 6) c .yes
+  pocPredict nsCands vp (· = ·) c .yes
 
 -- ============================================================================
 -- § 5: Closed-Form Rates via the Substrate


### PR DESCRIPTION
Reground POC on mathlib's own orders-as-data idiom: a grammar is a bare relation `r : Fin n → Fin n → Prop` with `[IsPartialOrder (Fin n) r]` and (at the counting layer only) `[DecidableRel r]` — exactly `extend_partialOrder`'s interface. The bespoke `PartialOrderConstraints` structure is deleted.

- the discrete grammar is literally `(· = ·)` (with a new, upstreamable `IsPartialOrder α (· = ·)` instance); `stratified` is defined as `Sigma.Lex` on the stratum map's fibers, characterized by `stratified_iff`; consistency gains its lattice reading `isConsistent_iff_le : IsConsistent r σ ↔ r ≤ fromPermutation σ`
- the Prop layer (consistency, Szpilrajn via new `exists_isConsistent`, realizability, containments) is decidability-free; `IsPOCRealizable` quantifies over lawful relations
- bundled `PartialOrder (Fin n)` values were tried and rejected: a class-typed binder becomes a local instance that captures `≤`/`<` on `Fin n`, silently corrupting mixed statements (noted in Implementation notes)