### PR TITLE
refactor(Phonology/OptimalityTheory): ERCSet as Finset

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -3,7 +3,6 @@ import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Grammar
 import Linglib.Core.Optimization.PermSubsetCombinatorics
-import Mathlib.Data.List.ProdSigma
 import Mathlib.Data.Sigma.Lex
 import Mathlib.Order.Extension.Linear
 import Mathlib.Order.Preorder.Finite
@@ -115,12 +114,12 @@ consistent total orders are exactly `ERCSet.linearExtensions` ([prince-2002]). -
 entailed by the covering pairs, so the encoding has the same linear extensions
 as the Hasse-edge one. -/
 def toERCSet (r : Fin n → Fin n → Prop) [DecidableRel r] : ERCSet n :=
-  ((List.finRange n ×ˢ List.finRange n).filter
-    fun p => decide (p.1 ≠ p.2 ∧ r p.1 p.2)).map fun p => simpleERC p.1 p.2
+  (Finset.univ.filter fun p : Fin n × Fin n => p.1 ≠ p.2 ∧ r p.1 p.2).image
+    fun p => simpleERC p.1 p.2
 
 theorem mem_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r] {α : ERC n} :
     α ∈ toERCSet r ↔ ∃ a b, a ≠ b ∧ r a b ∧ simpleERC a b = α := by
-  simp [toERCSet, List.mem_filter, List.mem_product, Prod.exists, and_assoc]
+  simp [toERCSet, Finset.mem_filter, Prod.exists, and_assoc]
 
 /-- A ranking satisfies `toERCSet r` exactly when it is a linear extension of
 `r`: the `a ≫ b` ERCs are the strict dominance requirements, and reflexive

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -91,7 +91,7 @@ theorem maximalChain_last {n : Nat} (r : Ranking n) :
     set of the top-`k` constraints under `r`.
 
     [merchant-riggle-2016] Definition 1. -/
-def MChain {n : Nat} (E : List (ERC n)) : Set (Fin n) → Prop :=
+def MChain {n : Nat} (E : ERCSet n) : Set (Fin n) → Prop :=
   fun S => ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧
     ∃ k : Fin (n + 1), maximalChain r k = S
 
@@ -109,14 +109,14 @@ inside `S` with no consistent global order realizing it
 (each ERC one `W`/one `L` = a Hasse edge = a partial order,
 `feasible_iff_feasiblePrefix_of_simple`). The faithful, *also decidable* notion
 is `FeasiblePrefix`. -/
-def Feasible {n : Nat} (E : List (ERC n)) (S : Finset (Fin n)) : Prop :=
+def Feasible {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) : Prop :=
   ∀ α ∈ E, (∃ l, α l = .L ∧ l ∈ S) → (∃ w, α w = .W ∧ w ∈ S)
 
-instance {n : Nat} (E : List (ERC n)) : DecidablePred (Feasible E) :=
+instance {n : Nat} (E : ERCSet n) : DecidablePred (Feasible E) :=
   fun S => by unfold Feasible; infer_instance
 
 /-- The empty prefix is locally feasible (no losers present). -/
-@[simp] theorem Feasible.empty {n : Nat} (E : List (ERC n)) :
+@[simp] theorem Feasible.empty {n : Nat} (E : ERCSet n) :
     Feasible E (∅ : Finset (Fin n)) := by
   intro α _ ⟨l, _, hl⟩; exact absurd hl (Finset.notMem_empty l)
 
@@ -124,7 +124,7 @@ instance {n : Nat} (E : List (ERC n)) : DecidablePred (Feasible E) :=
 in one of them, whose winner then lies in `S ∪ T`. (This is union-closure of the
 over-approximation; the faithful family's union-closure is `MChain.union_closed`,
 [merchant-riggle-2016] Lemma 3.) -/
-theorem Feasible.union_closed {n : Nat} (E : List (ERC n)) {S T : Finset (Fin n)}
+theorem Feasible.union_closed {n : Nat} (E : ERCSet n) {S T : Finset (Fin n)}
     (hS : Feasible E S) (hT : Feasible E T) : Feasible E (S ∪ T) := by
   intro α hα ⟨l, hlL, hlST⟩
   rcases Finset.mem_union.mp hlST with hlS | hlT
@@ -145,7 +145,7 @@ def prefixFinset {n : Nat} (r : Ranking n) (k : Fin (n + 1)) : Finset (Fin n) :=
 isomorphism): a prefix of a ranking that satisfies `E` is locally feasible.
 Winners dominate their losers, so a loser inside the prefix drags its winner in
 (`maximalChain_dominance` in `Finset` form). -/
-theorem feasible_of_satisfiedBy {n : Nat} {E : List (ERC n)} {r : Ranking n}
+theorem feasible_of_satisfiedBy {n : Nat} {E : ERCSet n} {r : Ranking n}
     (hr : ERCSet.SatisfiedBy r E) (k : Fin (n + 1)) : Feasible E (prefixFinset r k) := by
   intro α hα ⟨l, hlL, hlmem⟩
   rw [mem_prefixFinset] at hlmem
@@ -158,14 +158,14 @@ theorem feasible_of_satisfiedBy {n : Nat} {E : List (ERC n)} {r : Ranking n}
 satisfying `E` — the `Finset`-valued form of `MChain`. Decidable by finite search
 over `Ranking n` (a `Fintype`) and `Fin (n+1)`, so `decide` reduces — *and*
 unlike `Feasible` it is the genuine antimatroid family, not an over-approximation. -/
-def FeasiblePrefix {n : Nat} (E : List (ERC n)) (S : Finset (Fin n)) : Prop :=
+def FeasiblePrefix {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) : Prop :=
   ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧ ∃ k : Fin (n + 1), prefixFinset r k = S
 
-instance {n : Nat} (E : List (ERC n)) : DecidablePred (FeasiblePrefix E) :=
+instance {n : Nat} (E : ERCSet n) : DecidablePred (FeasiblePrefix E) :=
   fun _ => Fintype.decidableExistsFintype
 
 /-- The faithful predicate implies the over-approximation (`feasible_of_satisfiedBy`). -/
-theorem feasible_of_feasiblePrefix {n : Nat} {E : List (ERC n)} {S : Finset (Fin n)}
+theorem feasible_of_feasiblePrefix {n : Nat} {E : ERCSet n} {S : Finset (Fin n)}
     (h : FeasiblePrefix E S) : Feasible E S := by
   obtain ⟨r, hr, k, rfl⟩ := h; exact feasible_of_satisfiedBy hr k
 
@@ -176,7 +176,7 @@ theorem feasible_of_feasiblePrefix {n : Nat} {E : List (ERC n)} {S : Finset (Fin
 
 /-- `FeasiblePrefix` is `MChain` over `Finset` — the decidable counterpart of the
 existential, `Set`-valued antimatroid family. -/
-theorem mChain_coe_iff_feasiblePrefix {n : Nat} (E : List (ERC n)) (S : Finset (Fin n)) :
+theorem mChain_coe_iff_feasiblePrefix {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) :
     MChain E (↑S) ↔ FeasiblePrefix E S := by
   constructor
   · rintro ⟨r, hr, k, hk⟩
@@ -191,12 +191,13 @@ antimatroid for general ERC sets. Hence `Antimat.IsFeasible` stays `MChain`
 ([merchant-riggle-2016]'s "beyond partial orders"); the local form is exact only
 on the simple-ERC fragment. -/
 theorem feasible_not_accessible :
-    ∃ (E : List (ERC 4)) (S : Finset (Fin 4)),
+    ∃ (E : ERCSet 4) (S : Finset (Fin 4)),
       ERCSet.Consistent E ∧ Feasible E S ∧ ¬ FeasiblePrefix E S ∧
         S.Nonempty ∧ ¬ ∃ x ∈ S, Feasible E (S \ {x}) :=
-  ⟨[fun i => if i = 0 then .W else if i = 1 then .L else if i = 2 then .W else .e,
-    fun i => if i = 0 then .L else if i = 1 then .W else if i = 2 then .e else .W],
-   {0, 1}, by decide, by decide, by decide, by decide, by decide⟩
+  ⟨{fun i => if i = 0 then .W else if i = 1 then .L else if i = 2 then .W else .e,
+    fun i => if i = 0 then .L else if i = 1 then .W else if i = 2 then .e else .W},
+   {0, 1}, by decide +kernel, by decide +kernel, by decide +kernel, by decide +kernel,
+   by decide +kernel⟩
 
 -- ============================================================================
 -- § 11: Union Closure (Lemma 3)
@@ -297,7 +298,7 @@ set_option maxHeartbeats 1600000 in
     so `f w < f l`.
 
     [merchant-riggle-2016] Lemma 3. -/
-theorem MChain.union_closed {n : Nat} (E : List (ERC n))
+theorem MChain.union_closed {n : Nat} (E : ERCSet n)
     (_hcons : ERCSet.Consistent E) (S T : Set (Fin n))
     (_hS : MChain E S) (_hT : MChain E T) : MChain E (S ∪ T) := by
   obtain ⟨r₁, hr₁, k₁, hk₁⟩ := _hS
@@ -442,7 +443,7 @@ theorem MChain.union_closed {n : Nat} (E : List (ERC n))
     maximal chains consistent with `E`.
 
     [merchant-riggle-2016] Definition 6, Lemma 4. -/
-def Antimat {n : Nat} (E : List (ERC n)) (hcons : ERCSet.Consistent E) :
+def Antimat {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E) :
     Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := MChain E
@@ -521,7 +522,7 @@ the order-ideal ↔ linear-extension-prefix correspondence — reorder a witness
 ranking `r₀` into the block `S` (in `r₀`'s order) followed by `Sᶜ` (in `r₀`'s
 order); winner-uniqueness makes every Hasse edge respected, so the result
 satisfies `E` and has `S` as its length-`|S|` prefix. -/
-theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : List (ERC n)}
+theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
     (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
     Feasible E S ↔ FeasiblePrefix E S := by
   refine ⟨fun hfeas => ?_, feasible_of_feasiblePrefix⟩
@@ -591,7 +592,7 @@ theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : List (ERC n)}
 /-- The `Set`-level feasible family of the simple fragment: a set is the coercion
 of a locally-feasible `Finset` iff it is `MChain`-feasible. (Bridges the decidable
 `Finset` side to `Antimat`'s `Set`-valued `MChain` family.) -/
-theorem feasible_coe_iff_mChain {n : Nat} {E : List (ERC n)}
+theorem feasible_coe_iff_mChain {n : Nat} {E : ERCSet n}
     (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (T : Set (Fin n)) :
     (∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S') ↔ MChain E T := by
   constructor
@@ -608,7 +609,7 @@ yields an antimatroid on `Fin n` whose feasible sets are the *locally feasible*
 union closure transfer from `Antimat`; concrete membership is checked by `decide`
 via `ofSimple_isFeasible_coe`. This is the order-ideal antimatroid of the
 constraint partial order ([merchant-riggle-2016]). -/
-def Antimat.ofSimple {n : Nat} (E : List (ERC n)) (hcons : ERCSet.Consistent E)
+def Antimat.ofSimple {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E)
     (hsimple : ERCSet.IsSimpleSet E) : Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := fun T => ∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S'
@@ -632,7 +633,7 @@ def Antimat.ofSimple {n : Nat} (E : List (ERC n)) (hcons : ERCSet.Consistent E)
 
 /-- Concrete feasibility of `Antimat.ofSimple` is the decidable `Feasible` — the
 hook that lets `decide` settle membership queries. -/
-@[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : List (ERC n)}
+@[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : ERCSet n}
     (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
     (Antimat.ofSimple E hcons hsimple).IsFeasible (↑S : Set (Fin n)) ↔ Feasible E S := by
   constructor
@@ -720,7 +721,7 @@ theorem Antimat_RCErc_inv {n : Nat} (A : Antimatroid (Fin n)) (S : Set (Fin n)) 
     [merchant-riggle-2016] actually proves. The general proof rests on
     [dietrich-1987]'s rooted-circuit characterization (via Lemmas 7, 9), so it
     carries an honest `sorry`. -/
-theorem RCErc_Antimat_inv {n : Nat} (E : List (ERC n))
+theorem RCErc_Antimat_inv {n : Nat} (E : ERCSet n)
     (hcons : ERCSet.Consistent E) :
     ∀ r : Ranking n,
       (∀ α ∈ RCErc (Antimat E hcons), ERC.SatisfiedBy r α) ↔ ERCSet.SatisfiedBy r E := by
@@ -735,7 +736,7 @@ theorem RCErc_Antimat_inv {n : Nat} (E : List (ERC n))
     If ERC set `E` entails `F` (every ranking satisfying `E` also
     satisfies `F`), then `Antimat(E) ⊆ Antimat(F)` (every feasible
     set of `Antimat(E)` is also feasible in `Antimat(F)`). -/
-theorem Antimat_entailment {n : Nat} (E F : List (ERC n))
+theorem Antimat_entailment {n : Nat} (E F : ERCSet n)
     (hE : ERCSet.Consistent E) (hF : ERCSet.Consistent F)
     (h : ERCSet.Entails E F) :
     ∀ S, (Antimat E hE).IsFeasible S → (Antimat F hF).IsFeasible S := by

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -170,9 +170,8 @@ end ERC
 /-! ### Sets of ERCs -/
 
 /-- A set of ERCs, carrying the satisfaction/consistency/entailment algebra of
-OT grammars. Represented as a `List` so that `decide` can search the finitely
-many rankings; entailment is invariant under reordering and duplication. -/
-abbrev ERCSet (n : ℕ) := List (ERC n)
+OT grammars. -/
+abbrev ERCSet (n : ℕ) := Finset (ERC n)
 
 namespace ERCSet
 
@@ -183,7 +182,7 @@ def SatisfiedBy : Prop :=
   ∀ α ∈ E, ERC.SatisfiedBy r α
 
 instance : Decidable (SatisfiedBy r E) :=
-  List.decidableBAll _ E
+  inferInstanceAs (Decidable (∀ α ∈ E, ERC.SatisfiedBy r α))
 
 /-- An ERC set is *consistent* iff some ranking satisfies all its members. -/
 def Consistent : Prop := ∃ r : Ranking n, SatisfiedBy r E
@@ -193,7 +192,7 @@ instance : Decidable (Consistent E) :=
 
 /-- A singleton is consistent iff some ranking satisfies its ERC. -/
 @[simp] theorem consistent_singleton {α : ERC n} :
-    Consistent [α] ↔ ∃ r : Ranking n, α.SatisfiedBy r := by
+    Consistent {α} ↔ ∃ r : Ranking n, α.SatisfiedBy r := by
   simp [Consistent, SatisfiedBy]
 
 /-- The rankings consistent with an ERC set, as a `Finset` — its *linear extensions*
@@ -216,15 +215,15 @@ theorem entails_trans {E₁ E₂ E₃ : ERCSet n}
     (h₁₂ : Entails E₁ E₂) (h₂₃ : Entails E₂ E₃) : Entails E₁ E₃ :=
   fun r hr => h₂₃ r (h₁₂ r hr)
 
-/-- Adding an ERC strengthens the set: `α :: E` entails `E`. -/
-theorem entails_of_cons (α : ERC n) : Entails (α :: E) E :=
-  fun _ hr β hβ => hr β (List.mem_cons_of_mem α hβ)
+/-- A superset entails: adding ERCs only strengthens the set. -/
+theorem entails_of_superset {E E' : ERCSet n} (h : E ⊆ E') : Entails E' E :=
+  fun _ hr β hβ => hr β (h hβ)
 
 /-- Pointwise characterization: `E` entails `E'` if it entails each member
 singleton. -/
 theorem entails_of_forall_mem {E E' : ERCSet n}
-    (h : ∀ α ∈ E', Entails E [α]) : Entails E E' :=
-  fun r hr α hα => h α hα r hr α (List.mem_cons.mpr (Or.inl rfl))
+    (h : ∀ α ∈ E', Entails E {α}) : Entails E E' :=
+  fun r hr α hα => h α hα r hr α (Finset.mem_singleton_self α)
 
 /-- An ERC set is *simple* if every member is a simple ERC — a set of Hasse edges
 ([merchant-riggle-2016]). -/
@@ -283,7 +282,7 @@ theorem simpleERC_satisfiedBy_toRel_iff (i j : Fin n) (r : Ranking n) :
 
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is consistent. -/
 theorem simpleERC_consistent (hij : i ≠ j) :
-    ERCSet.Consistent [simpleERC i j] :=
+    ERCSet.Consistent {simpleERC i j} :=
   have ⟨r, hr⟩ := Ranking.exists_dominates hij
   ERCSet.consistent_singleton.mpr ⟨r, (simpleERC_satisfiedBy_iff hij r).mpr hr⟩
 

--- a/Linglib/Phonology/OptimalityTheory/Grammar.lean
+++ b/Linglib/Phonology/OptimalityTheory/Grammar.lean
@@ -172,8 +172,8 @@ theorem coe_linearExtensions_eq_models (E : ERCSet n) :
 
 /-- The empty ERC set is satisfied by every ranking: its linear extensions are all
 of `Ord(S.Con)`. This is the trivial grammar (no ranking conditions). -/
-@[simp] theorem ERCSet.linearExtensions_nil :
-    ERCSet.linearExtensions ([] : ERCSet n) = Finset.univ := by
+@[simp] theorem ERCSet.linearExtensions_empty :
+    ERCSet.linearExtensions (∅ : ERCSet n) = Finset.univ := by
   ext r; simp [ERCSet.mem_linearExtensions, ERCSet.SatisfiedBy]
 
 /-- An OT **grammar**: a set of rankings realizable as the linear extensions of
@@ -311,8 +311,8 @@ theorem exists_grammar_of_isGrammarClosed {R : Set (Ranking n)}
     (hcl : IsGrammarClosed R) (hne : R.Nonempty) :
     ∃ G : Grammar n, (↑G.legs : Set (Ranking n)) = R := by
   obtain ⟨E, hAeq⟩ : ∃ E : ERCSet n, {α | α ∈ E} = conditions R := by
-    refine ⟨(Set.toFinite (conditions R)).toFinset.toList, ?_⟩
-    ext α; simp [Set.Finite.mem_toFinset, Finset.mem_toList]
+    refine ⟨(Set.toFinite (conditions R)).toFinset, ?_⟩
+    ext α; simp [Set.Finite.mem_toFinset]
   have hReq : (↑E.linearExtensions : Set (Ranking n)) = R := by
     rw [coe_linearExtensions_eq_models, hAeq]; exact hcl
   have hcons : ERCSet.Consistent E := by
@@ -355,11 +355,11 @@ theorem ofERCSet_le_iff_entails {E E' : ERCSet n}
     exact ERCSet.mem_linearExtensions.mpr (hent r (ERCSet.mem_linearExtensions.mp hr))
 
 /-- The **trivial grammar** — the terminal object of the specificity order: all
-rankings, no ranking conditions (`ofERCSet []`). -/
-def trivial : Grammar n := ofERCSet [] ⟨Ranking.id n, by simp [ERCSet.SatisfiedBy]⟩
+rankings, no ranking conditions (`ofERCSet ∅`). -/
+def trivial : Grammar n := ofERCSet ∅ ⟨Ranking.id n, by simp [ERCSet.SatisfiedBy]⟩
 
 @[simp] theorem legs_trivial : (Grammar.trivial : Grammar n).legs = Finset.univ := by
-  simp only [Grammar.trivial, legs_ofERCSet, ERCSet.linearExtensions_nil]
+  simp only [Grammar.trivial, legs_ofERCSet, ERCSet.linearExtensions_empty]
 
 instance : OrderTop (Grammar n) where
   top := trivial

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -499,17 +499,17 @@ theorem lunarisERC_isContradictory : lunarisERC.IsContradictory := by decide
     trivial. -/
 theorem latinERCSet_consistent_without_lunaris :
     ERCSet.Consistent
-      [popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC] :=
+      {popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC} :=
   ⟨Ranking.id 2, by decide⟩
 
 /-- Bridge to the dominance characterisation: under any ranking
     satisfying the empirical ERC set (sans lunaris), OCP dominates \*r. -/
 theorem latin_OCP_dominates_starR (r : Ranking 2)
     (hr : ERCSet.SatisfiedBy r
-      [popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC]) :
+      {popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC}) :
     r.Dominates 0 1 := by
   have hpop : popularisERC.SatisfiedBy r :=
-    hr popularisERC (List.mem_cons.mpr (Or.inl rfl))
+    hr popularisERC (Finset.mem_insert_self _ _)
   have : (simpleERC (n := 2) 0 1).SatisfiedBy r := by
     rw [← popularisERC_is_simple]; exact hpop
   exact (simpleERC_satisfiedBy_iff (by decide) r).mp this

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -117,7 +117,7 @@ def ercA : ERC numConstraints := ercFor .nanWinner .nanLoser
 def ercB : ERC numConstraints := ercFor .kakWinner .kakLoser
 
 /-- The ranking-paradox support. -/
-def pokoSupport : List (ERC numConstraints) := [ercA, ercB]
+def pokoSupport : ERCSet numConstraints := {ercA, ercB}
 
 /-- The derived `ercA` matches eq. 59 row a: `[W, L, L, L]`. -/
 example : ercA maxHIdx = .W ∧ ercA depLinkHIdx = .L ∧

--- a/Linglib/Studies/MerchantPrince2022.lean
+++ b/Linglib/Studies/MerchantPrince2022.lean
@@ -48,17 +48,15 @@ variable {C : Type*} [DecidableEq C] {n : ℕ}
 
 /-- The ERC set of a tableau row `w`: `w`'s winner-loser ERCs against every *other*
 candidate. These are the ranking conditions a leg must satisfy for `w` to be the
-optimum ([prince-2002]). (Noncomputable: it enumerates the competitor `Finset` via
-`Finset.toList`; only the *set* of conditions matters, and consistency/membership
-stay decidable.) -/
-noncomputable def rowERCSet (t : Tableau C n) (w : C) : ERCSet n :=
-  (t.candidates.erase w).toList.map (tableauERC t w)
+optimum ([prince-2002]). -/
+def rowERCSet (t : Tableau C n) (w : C) : ERCSet n :=
+  (t.candidates.erase w).image (tableauERC t w)
 
 /-- The **grammar of a tableau row** — the bridge from the Concrete-OT tableau
 engine to the abstract `Grammar` hub ([merchant-prince-2022]; [merchant-riggle-2016]).
 `h` is the consistency of the row's conditions, i.e. that `w` is a genuine,
 non-harmonically-bounded optimum. -/
-noncomputable def rowGrammar (t : Tableau C n) (w : C)
+def rowGrammar (t : Tableau C n) (w : C)
     (h : ERCSet.Consistent (rowERCSet t w)) : Grammar n :=
   Grammar.ofERCSet (rowERCSet t w) h
 
@@ -82,9 +80,9 @@ theorem mem_rowGrammar_legs_iff_lex {t : Tableau C n} {w : C}
   constructor
   · intro hsat l hl
     exact (tableauERC_satisfiedBy_iff t r w l).mp
-      (hsat _ (List.mem_map.mpr ⟨l, Finset.mem_toList.mpr hl, rfl⟩))
+      (hsat _ (Finset.mem_image.mpr ⟨l, hl, rfl⟩))
   · intro hlex α hα
-    obtain ⟨l, hl, rfl⟩ := List.mem_map.mp hα
-    exact (tableauERC_satisfiedBy_iff t r w l).mpr (hlex l (Finset.mem_toList.mp hl))
+    obtain ⟨l, hl, rfl⟩ := Finset.mem_image.mp hα
+    exact (tableauERC_satisfiedBy_iff t r w l).mpr (hlex l hl)
 
 end MerchantPrince2022


### PR DESCRIPTION
Migrate `ERCSet n` from `List (ERC n)` to `Finset (ERC n)` — the honest carrier: the List's order and multiplicity were exploited by no theorem, and its stated rationale (decidability) holds equally for Finsets.

- ERC file: decidability instances re-derived; `consistent_singleton`/`simpleERC_consistent` on `{α}`; `entails_of_cons` generalizes to `entails_of_superset`
- Antimatroid/Grammar: signature sweep (`List (ERC n)` → `ERCSet n`), `∅` for the trivial grammar, one example literal to a Finset (`decide +kernel` for the Finset-of-functions reduction); the three sorried Merchant–Riggle statements now quantify over the final carrier
- `toERCSet` becomes `filter.image` over `Finset.univ`; `MerchantPrince2022.rowERCSet` becomes **computable** (`Finset.image` replaces the `toList` workaround), dropping two `noncomputable` markers

Sequenced before the Antimatroid sorries so they are proven once, against the final carrier.