### PR TITLE
refactor(Phonology): trivial-diagonal toERCSet; stratified via Prod.Lex

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -3,7 +3,7 @@ import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Grammar
 import Linglib.Core.Optimization.PermSubsetCombinatorics
-import Mathlib.Data.Sigma.Lex
+import Mathlib.Data.Prod.Basic
 import Mathlib.Order.Extension.Linear
 import Mathlib.Order.Preorder.Finite
 
@@ -28,8 +28,8 @@ theorems are a ℚ veneer over them.
   total order a ranking induces), and `stratified stratumOf inner`
   (mutually-ranked strata refined by an inner order —
   [tesar-smolensky-1995]'s Stratified Domination Hierarchies — defined as
-  mathlib's `Sigma.Lex` on the stratum map's fibers, characterized by
-  `stratified_iff`).
+  mathlib's `Prod.Lex` pulled back along `a ↦ (stratumOf a, a)`, characterized
+  by `stratified_iff`).
 - `IsConsistent r σ`: σ is a linear extension of `r`, defined as containment
   `r ≤ σ.toRel` in the pointwise lattice of relations.
   `consistentTotalOrders r` is the (nonempty, by Szpilrajn) `Finset` of them.
@@ -110,31 +110,29 @@ is a simple ERC `a ≫ b` ([merchant-riggle-2016]), and under this encoding the
 consistent total orders are exactly `ERCSet.linearExtensions` ([prince-2002]). -/
 
 /-- The simple-ERC encoding of a grammar, with one ERC `a ≫ b`
-(`simpleERC a b`) for each strict related pair. Transitively-implied pairs are
-entailed by the covering pairs, so the encoding has the same linear extensions
-as the Hasse-edge one. -/
+(`simpleERC a b`) for each related pair — diagonal pairs give trivial ERCs,
+matching `toRel`'s reflexivity. Transitively-implied pairs are entailed by the
+covering pairs, so the encoding has the same linear extensions as the
+Hasse-edge one. -/
 def toERCSet (r : Fin n → Fin n → Prop) [DecidableRel r] : ERCSet n :=
-  (Finset.univ.filter fun p : Fin n × Fin n => p.1 ≠ p.2 ∧ r p.1 p.2).image
+  (Finset.univ.filter fun p : Fin n × Fin n => r p.1 p.2).image
     fun p => simpleERC p.1 p.2
 
 theorem mem_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r] {α : ERC n} :
-    α ∈ toERCSet r ↔ ∃ a b, a ≠ b ∧ r a b ∧ simpleERC a b = α := by
-  simp [toERCSet, Finset.mem_filter, Prod.exists, and_assoc]
+    α ∈ toERCSet r ↔ ∃ a b, r a b ∧ simpleERC a b = α := by
+  simp [toERCSet, Prod.exists]
 
 /-- A ranking satisfies `toERCSet r` exactly when it is a linear extension of
-`r`: the `a ≫ b` ERCs are the strict dominance requirements, and reflexive
-pairs impose nothing. -/
+`r`: per pair, satisfaction of `simpleERC a b` *is* `σ.toRel a b`. -/
 theorem satisfiedBy_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r]
     {σ : Ranking n} :
     ERCSet.SatisfiedBy σ (toERCSet r) ↔ IsConsistent r σ := by
   constructor
   · intro h a b hrel
-    rcases eq_or_ne a b with rfl | hab
-    · exact le_refl _
-    · exact (simpleERC_satisfiedBy_toRel_iff a b σ).mp
-        (h _ (mem_toERCSet.mpr ⟨a, b, hab, hrel, rfl⟩))
+    exact (simpleERC_satisfiedBy_toRel_iff a b σ).mp
+      (h _ (mem_toERCSet.mpr ⟨a, b, hrel, rfl⟩))
   · intro hcons α hα
-    obtain ⟨a, b, hab, hrel, rfl⟩ := mem_toERCSet.mp hα
+    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCSet.mp hα
     exact (simpleERC_satisfiedBy_toRel_iff a b σ).mpr (hcons a b hrel)
 
 /-- The consistent total orders of a grammar are exactly the linear extensions
@@ -178,61 +176,28 @@ grammar of [anttila-1997] eq. (50) — the Stratified Domination Hierarchy of
 variable {s : ℕ}
 
 /-- The stratified grammar induced by `stratumOf` and an inner order `inner` —
-    mathlib's lexicographic sigma order (`Sigma.Lex`, underlying
-    `Sigma.Lex.partialOrder`) on the fibers of `stratumOf`, pulled back along
-    the fiber partition. The plain characterization is `stratified_iff`;
-    cross-stratum `inner` edges are ignored. -/
+    mathlib's lexicographic order (`Prod.Lex`) pulled back along
+    `a ↦ (stratumOf a, a)`: strata compare strictly, ties defer to `inner`.
+    The plain characterization is `stratified_iff`; cross-stratum `inner`
+    edges are ignored. -/
 def stratified (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop) :
     Fin n → Fin n → Prop :=
-  fun a b =>
-    Sigma.Lex (· < ·) (fun k (x y : {c : Fin n // stratumOf c = k}) => inner x.1 y.1)
-      ⟨stratumOf a, a, rfl⟩ ⟨stratumOf b, b, rfl⟩
-
-private theorem sigmaMk_stratum_eq {stratumOf : Fin n → Fin s} {a : Fin n} {k : Fin s}
-    (h : stratumOf a = k) :
-    (⟨stratumOf a, a, rfl⟩ : Σ k, {c : Fin n // stratumOf c = k}) = ⟨k, a, h⟩ := by
-  subst h; rfl
+  fun a b => Prod.Lex (· < ·) inner (stratumOf a, a) (stratumOf b, b)
 
 /-- Dominance in a stratified grammar holds iff a's stratum strictly precedes
     b's, or they share a stratum and the inner order relates them. -/
 theorem stratified_iff {stratumOf : Fin n → Fin s} {inner : Fin n → Fin n → Prop}
     {a b : Fin n} :
     stratified stratumOf inner a b ↔
-      stratumOf a < stratumOf b ∨ stratumOf a = stratumOf b ∧ inner a b := by
-  constructor
-  · intro hlex
-    rcases Sigma.lex_iff.mp hlex with hlt | ⟨heq, -⟩
-    · exact Or.inl hlt
-    · refine Or.inr ⟨heq, ?_⟩
-      unfold stratified at hlex
-      rw [sigmaMk_stratum_eq heq] at hlex
-      cases hlex with
-      | left _ _ h => exact absurd h (lt_irrefl _)
-      | right _ _ hr => exact hr
-  · rintro (hlt | ⟨heq, hrel⟩)
-    · exact Sigma.Lex.left _ _ hlt
-    · show Sigma.Lex _ _ _ _
-      rw [sigmaMk_stratum_eq heq]
-      exact Sigma.Lex.right _ _ hrel
+      stratumOf a < stratumOf b ∨ stratumOf a = stratumOf b ∧ inner a b :=
+  Prod.lex_iff
 
 instance (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop)
     [IsPartialOrder (Fin n) inner] :
     IsPartialOrder (Fin n) (stratified stratumOf inner) where
-  refl a := stratified_iff.mpr (Or.inr ⟨rfl, refl_of inner a⟩)
-  trans a b c hab hbc := by
-    rcases stratified_iff.mp hab with h | ⟨h, h'⟩ <;>
-      rcases stratified_iff.mp hbc with g | ⟨g, g'⟩
-    · exact stratified_iff.mpr (Or.inl (h.trans g))
-    · exact stratified_iff.mpr (Or.inl (lt_of_lt_of_eq h g))
-    · exact stratified_iff.mpr (Or.inl (lt_of_eq_of_lt h g))
-    · exact stratified_iff.mpr (Or.inr ⟨h.trans g, trans_of inner h' g'⟩)
-  antisymm a b hab hba := by
-    rcases stratified_iff.mp hab with h | ⟨h, h'⟩ <;>
-      rcases stratified_iff.mp hba with g | ⟨g, g'⟩
-    · exact absurd (h.trans g) (lt_irrefl _)
-    · exact absurd (lt_of_lt_of_eq h g) (lt_irrefl _)
-    · exact absurd (lt_of_lt_of_eq g h) (lt_irrefl _)
-    · exact antisymm_of inner h' g'
+  refl a := Prod.Lex.right _ (refl_of inner a)
+  trans _ _ _ := Prod.Lex.trans
+  antisymm _ _ hab hba := congrArg Prod.snd (antisymm hab hba)
 
 instance (stratumOf : Fin n → Fin s) (inner : Fin n → Fin n → Prop)
     [DecidableRel inner] : DecidableRel (stratified stratumOf inner) :=
@@ -348,11 +313,12 @@ a Birkhoff antimatroid whose feasible sets are exactly the order ideals of `r`
 variable (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r] [DecidableRel r]
 
 omit [IsPartialOrder (Fin n) r] in
-/-- `toERCSet r` consists of simple ERCs (each is a `simpleERC` of a strict pair). -/
-theorem toERCSet_isSimpleSet : ERCSet.IsSimpleSet (toERCSet r) := by
+/-- Every member of `toERCSet r` is a simple ERC or (on the diagonal) trivial. -/
+theorem toERCSet_isSimple_or_isTrivial :
+    ∀ α ∈ toERCSet r, α.IsSimple ∨ α.IsTrivial := by
   intro α hα
-  obtain ⟨a, b, hab, _, rfl⟩ := mem_toERCSet.mp hα
-  exact simpleERC_isSimple hab
+  obtain ⟨a, b, _, rfl⟩ := mem_toERCSet.mp hα
+  exact simpleERC_isSimple_or_isTrivial a b
 
 /-- `toERCSet r` is consistent: any linear extension of `r` satisfies it. -/
 theorem toERCSet_consistent : ERCSet.Consistent (toERCSet r) := by
@@ -364,7 +330,7 @@ antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding, whose feasible
 sets are exactly the order ideals of `r`
 (`pocAntimatroid_isFeasible_iff`). -/
 def pocAntimatroid : Antimatroid (Fin n) :=
-  Antimat.ofSimple (toERCSet r) (toERCSet_consistent r) (toERCSet_isSimpleSet r)
+  Antimat.ofSimple (toERCSet r) (toERCSet_consistent r) (toERCSet_isSimple_or_isTrivial r)
 
 omit [IsPartialOrder (Fin n) r] in
 /-- Local feasibility against `toERCSet r` is exactly the order-ideal
@@ -376,12 +342,13 @@ theorem feasible_toERCSet_iff {S : Finset (Fin n)} :
     rcases eq_or_ne a b with rfl | hab
     · exact hbS
     · obtain ⟨w, hwW, hwS⟩ :=
-        h (simpleERC a b) (mem_toERCSet.mpr ⟨a, b, hab, hrel, rfl⟩)
+        h (simpleERC a b) (mem_toERCSet.mpr ⟨a, b, hrel, rfl⟩)
           ⟨b, simpleERC_apply_L hab, hbS⟩
       rwa [(simpleERC_eq_W_iff w).mp hwW] at hwS
   · intro h α hα
-    obtain ⟨a, b, hab, hrel, rfl⟩ := mem_toERCSet.mp hα
+    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCSet.mp hα
     rintro ⟨l, hlL, hlS⟩
+    have hab : a ≠ b := by rintro rfl; exact simpleERC_self_isTrivial a l hlL
     rw [(simpleERC_eq_L_iff hab l).mp hlL] at hlS
     exact ⟨a, simpleERC_apply_W, h a b hrel hlS⟩
 

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -508,22 +508,24 @@ def Antimat {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E) :
 
 /-! ### Simple-ERC feasibility coincides with the antimatroid family
 
-When every ERC is *simple* (one `W`, one `L` — a Hasse edge `w ≫ l`), the
-constraints carry a genuine partial order and the decidable local condition
-`Feasible` is exact: it agrees with the faithful `FeasiblePrefix`/`MChain` family.
+When every ERC is *simple* (one `W`, one `L` — a Hasse edge `w ≫ l`) or
+*trivial* (no `L`, imposing nothing), the constraints carry a genuine partial
+order and the decidable local condition `Feasible` is exact: it agrees with the
+faithful `FeasiblePrefix`/`MChain` family.
 This is the Birkhoff correspondence between order ideals of a poset and the
 prefixes of its linear extensions ([merchant-riggle-2016]). For non-simple `E`
 the agreement fails (`feasible_not_accessible`). -/
 
-/-- **Birkhoff representation on the simple-ERC fragment.** With every ERC simple,
-local feasibility coincides with the genuine antimatroid family: a set is locally
+/-- **Birkhoff representation on the simple-ERC fragment.** With every ERC simple
+or trivial, local feasibility coincides with the genuine antimatroid family: a set is locally
 feasible iff it is a prefix of some consistent ranking. The forward direction is
 the order-ideal ↔ linear-extension-prefix correspondence — reorder a witnessing
 ranking `r₀` into the block `S` (in `r₀`'s order) followed by `Sᶜ` (in `r₀`'s
 order); winner-uniqueness makes every Hasse edge respected, so the result
 satisfies `E` and has `S` as its length-`|S|` prefix. -/
 theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+    (S : Finset (Fin n)) :
     Feasible E S ↔ FeasiblePrefix E S := by
   refine ⟨fun hfeas => ?_, feasible_of_feasiblePrefix⟩
   obtain ⟨r₀, hr₀⟩ := hcons
@@ -560,7 +562,8 @@ theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
     intro α hα
     rw [ERC.satisfiedBy_iff_dominance]
     intro l hl_L
-    obtain ⟨⟨wα, hwαW, hwα_uniq⟩, _⟩ := hsimple α hα
+    obtain ⟨⟨wα, hwαW, hwα_uniq⟩, _⟩ :=
+      (hsimple α hα).resolve_right fun htriv => htriv l hl_L
     obtain ⟨w, hwW, hw_dom₀⟩ := (ERC.satisfiedBy_iff_dominance r₀ α).mp (hr₀ α hα) l hl_L
     have hdom₀ : (r₀.symm w : Nat) < (r₀.symm l : Nat) := hw_dom₀
     refine ⟨w, hwW, ?_⟩
@@ -593,7 +596,8 @@ theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
 of a locally-feasible `Finset` iff it is `MChain`-feasible. (Bridges the decidable
 `Finset` side to `Antimat`'s `Set`-valued `MChain` family.) -/
 theorem feasible_coe_iff_mChain {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (T : Set (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+    (T : Set (Fin n)) :
     (∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S') ↔ MChain E T := by
   constructor
   · rintro ⟨S', rfl, hfeas⟩
@@ -602,15 +606,15 @@ theorem feasible_coe_iff_mChain {n : Nat} {E : ERCSet n}
   · rintro ⟨r, hr, k, hk⟩
     exact ⟨prefixFinset r k, (prefixFinset_coe r k).trans hk, feasible_of_satisfiedBy hr k⟩
 
-/-- **The simple-ERC Birkhoff antimatroid.** A consistent set of simple ERCs
-yields an antimatroid on `Fin n` whose feasible sets are the *locally feasible*
+/-- **The simple-ERC Birkhoff antimatroid.** A consistent set of simple (or
+trivial) ERCs yields an antimatroid on `Fin n` whose feasible sets are the *locally feasible*
 `Finset`s — the decidable form. On the simple fragment this family equals
 `Antimat E`'s `MChain` family (`feasible_coe_iff_mChain`), so accessibility and
 union closure transfer from `Antimat`; concrete membership is checked by `decide`
 via `ofSimple_isFeasible_coe`. This is the order-ideal antimatroid of the
 constraint partial order ([merchant-riggle-2016]). -/
 def Antimat.ofSimple {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E)
-    (hsimple : ERCSet.IsSimpleSet E) : Antimatroid (Fin n) where
+    (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial) : Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := fun T => ∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S'
   empty_feasible := (feasible_coe_iff_mChain hcons hsimple ∅).mpr (Antimat E hcons).empty_feasible
@@ -634,7 +638,8 @@ def Antimat.ofSimple {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E)
 /-- Concrete feasibility of `Antimat.ofSimple` is the decidable `Feasible` — the
 hook that lets `decide` settle membership queries. -/
 @[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ERCSet.IsSimpleSet E) (S : Finset (Fin n)) :
+    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+    (S : Finset (Fin n)) :
     (Antimat.ofSimple E hcons hsimple).IsFeasible (↑S : Set (Fin n)) ↔ Feasible E S := by
   constructor
   · rintro ⟨S', hS'eq, hfeas⟩; rwa [Finset.coe_inj.mp hS'eq] at hfeas

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -225,10 +225,6 @@ theorem entails_of_forall_mem {E E' : ERCSet n}
     (h : ∀ α ∈ E', Entails E {α}) : Entails E E' :=
   fun r hr α hα => h α hα r hr α (Finset.mem_singleton_self α)
 
-/-- An ERC set is *simple* if every member is a simple ERC — a set of Hasse edges
-([merchant-riggle-2016]). -/
-def IsSimpleSet (E : ERCSet n) : Prop := ∀ α ∈ E, α.IsSimple
-
 end ERCSet
 
 /-! ### Simple ERCs -/
@@ -256,6 +252,10 @@ theorem simpleERC_eq_L_iff (hij : i ≠ j) (k : Fin n) :
 theorem simpleERC_apply_L (hij : i ≠ j) : simpleERC i j j = .L :=
   (simpleERC_eq_L_iff hij j).mpr rfl
 
+/-- The diagonal simple ERC `i ≫ i` has no `L`, hence is trivial. -/
+theorem simpleERC_self_isTrivial (i : Fin n) : (simpleERC i i).IsTrivial := fun k => by
+  simp only [simpleERC]; split_ifs <;> decide
+
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is satisfied by `r` iff `i` dominates
 `j` under `r`. -/
 theorem simpleERC_satisfiedBy_iff (hij : i ≠ j) (r : Ranking n) :
@@ -275,9 +275,7 @@ trivial and the relation reflexive, so no `i ≠ j` guard is needed. -/
 theorem simpleERC_satisfiedBy_toRel_iff (i j : Fin n) (r : Ranking n) :
     (simpleERC i j).SatisfiedBy r ↔ r.toRel i j := by
   rcases eq_or_ne i j with rfl | hij
-  · refine iff_of_true (ERC.trivial_satisfiedBy (fun k => ?_) r) (le_refl _)
-    simp only [simpleERC]
-    split_ifs <;> decide
+  · exact iff_of_true (ERC.trivial_satisfiedBy (simpleERC_self_isTrivial i) r) (le_refl _)
   · rw [simpleERC_satisfiedBy_iff hij, r.toRel_iff_dominates hij]
 
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is consistent. -/
@@ -290,6 +288,12 @@ theorem simpleERC_consistent (hij : i ≠ j) :
 theorem simpleERC_isSimple (hij : i ≠ j) : (simpleERC i j).IsSimple :=
   ⟨⟨i, simpleERC_apply_W, fun y hy => (simpleERC_eq_W_iff y).mp hy⟩,
    ⟨j, simpleERC_apply_L hij, fun y hy => (simpleERC_eq_L_iff hij y).mp hy⟩⟩
+
+/-- Every `simpleERC` is simple or (on the diagonal) trivial. -/
+theorem simpleERC_isSimple_or_isTrivial (i j : Fin n) :
+    (simpleERC i j).IsSimple ∨ (simpleERC i j).IsTrivial := by
+  rcases eq_or_ne i j with rfl | hij
+  exacts [.inr (simpleERC_self_isTrivial i), .inl (simpleERC_isSimple hij)]
 
 /-! ### Bridges: profiles, tableaux, and the Core lex order -/
 


### PR DESCRIPTION
Two residual-friction items from the POC cleanse arc:

- `toERCSet` encodes all related pairs (diagonal ERCs are trivial, matching `toRel`'s reflexivity), so `satisfiedBy_toERCSet` loses its case split; the Birkhoff-fragment hypotheses weaken from `IsSimpleSet` (now dead, deleted) to per-member simple-or-trivial, absorbed at the single material use site by `Or.resolve_right`.
- `stratified` regrounds from `Sigma.Lex` on stratum fibers to `Prod.Lex` pulled back along `a ↦ (stratumOf a, a)` — the inner order is stratum-uniform, so the dependent-fiber apparatus was unneeded: `stratified_iff` becomes `Prod.lex_iff` and the partial-order instance follows from mathlib's `Prod.Lex` instances.