### PR TITLE
refactor(Phonology/OptimalityTheory): dissolve ERCSet into Finset (ERC n)

### DIFF
--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -42,8 +42,8 @@ theorems are a ℚ veneer over them.
 ## Main statements
 
 - `consistentTotalOrders_eq_linearExtensions`: POC's linear extensions are the
-  ERC ones — the simple-ERC (Hasse-edge) encoding `toERCSet` identifies
-  `consistentTotalOrders` with `ERCSet.linearExtensions`
+  ERC ones — the simple-ERC (Hasse-edge) encoding `toERCs` identifies
+  `consistentTotalOrders` with `ERC.linearExtensions`
   ([merchant-riggle-2016]; [prince-2002]). `toGrammar` routes POC through the
   `Grammar` hub, and `pocAntimatroid` realizes the Birkhoff correspondence
   with order-ideal antimatroids ([dilworth-1940]).
@@ -107,41 +107,41 @@ theorem mem_consistentTotalOrders {r : Fin n → Fin n → Prop} [DecidableRel r
 
 A partial order is a set of dominance requirements — each strict related pair
 is a simple ERC `a ≫ b` ([merchant-riggle-2016]), and under this encoding the
-consistent total orders are exactly `ERCSet.linearExtensions` ([prince-2002]). -/
+consistent total orders are exactly `ERC.linearExtensions` ([prince-2002]). -/
 
 /-- The simple-ERC encoding of a grammar, with one ERC `a ≫ b`
 (`simpleERC a b`) for each related pair — diagonal pairs give trivial ERCs,
 matching `toRel`'s reflexivity. Transitively-implied pairs are entailed by the
 covering pairs, so the encoding has the same linear extensions as the
 Hasse-edge one. -/
-def toERCSet (r : Fin n → Fin n → Prop) [DecidableRel r] : ERCSet n :=
+def toERCs (r : Fin n → Fin n → Prop) [DecidableRel r] : Finset (ERC n) :=
   (Finset.univ.filter fun p : Fin n × Fin n => r p.1 p.2).image
     fun p => simpleERC p.1 p.2
 
-theorem mem_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r] {α : ERC n} :
-    α ∈ toERCSet r ↔ ∃ a b, r a b ∧ simpleERC a b = α := by
-  simp [toERCSet, Prod.exists]
+theorem mem_toERCs {r : Fin n → Fin n → Prop} [DecidableRel r] {α : ERC n} :
+    α ∈ toERCs r ↔ ∃ a b, r a b ∧ simpleERC a b = α := by
+  simp [toERCs, Prod.exists]
 
-/-- A ranking satisfies `toERCSet r` exactly when it is a linear extension of
+/-- A ranking satisfies `toERCs r` exactly when it is a linear extension of
 `r`: per pair, satisfaction of `simpleERC a b` *is* `σ.toRel a b`. -/
-theorem satisfiedBy_toERCSet {r : Fin n → Fin n → Prop} [DecidableRel r]
+theorem satisfiedBy_toERCs {r : Fin n → Fin n → Prop} [DecidableRel r]
     {σ : Ranking n} :
-    ERCSet.SatisfiedBy σ (toERCSet r) ↔ IsConsistent r σ := by
+    (∀ α ∈ toERCs r, ERC.SatisfiedBy σ α) ↔ IsConsistent r σ := by
   constructor
   · intro h a b hrel
     exact (simpleERC_satisfiedBy_toRel_iff a b σ).mp
-      (h _ (mem_toERCSet.mpr ⟨a, b, hrel, rfl⟩))
+      (h _ (mem_toERCs.mpr ⟨a, b, hrel, rfl⟩))
   · intro hcons α hα
-    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCSet.mp hα
+    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCs.mp hα
     exact (simpleERC_satisfiedBy_toRel_iff a b σ).mpr (hcons a b hrel)
 
 /-- The consistent total orders of a grammar are exactly the linear extensions
 of its simple-ERC encoding ([merchant-riggle-2016]; [prince-2002]). -/
 theorem consistentTotalOrders_eq_linearExtensions (r : Fin n → Fin n → Prop)
     [DecidableRel r] :
-    consistentTotalOrders r = (toERCSet r).linearExtensions := by
+    consistentTotalOrders r = ERC.linearExtensions (toERCs r) := by
   ext σ
-  rw [mem_consistentTotalOrders, ERCSet.mem_linearExtensions, satisfiedBy_toERCSet]
+  rw [mem_consistentTotalOrders, ERC.mem_linearExtensions, satisfiedBy_toERCs]
 
 /-- For the discrete grammar, every permutation is a linear extension. -/
 theorem consistentTotalOrders_discrete (n : ℕ) :
@@ -313,40 +313,40 @@ a Birkhoff antimatroid whose feasible sets are exactly the order ideals of `r`
 variable (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r] [DecidableRel r]
 
 omit [IsPartialOrder (Fin n) r] in
-/-- Every member of `toERCSet r` is a simple ERC or (on the diagonal) trivial. -/
-theorem toERCSet_isSimple_or_isTrivial :
-    ∀ α ∈ toERCSet r, α.IsSimple ∨ α.IsTrivial := by
+/-- Every member of `toERCs r` is a simple ERC or (on the diagonal) trivial. -/
+theorem toERCs_isSimple_or_isTrivial :
+    ∀ α ∈ toERCs r, α.IsSimple ∨ α.IsTrivial := by
   intro α hα
-  obtain ⟨a, b, _, rfl⟩ := mem_toERCSet.mp hα
+  obtain ⟨a, b, _, rfl⟩ := mem_toERCs.mp hα
   exact simpleERC_isSimple_or_isTrivial a b
 
-/-- `toERCSet r` is consistent: any linear extension of `r` satisfies it. -/
-theorem toERCSet_consistent : ERCSet.Consistent (toERCSet r) := by
+/-- `toERCs r` is consistent: any linear extension of `r` satisfies it. -/
+theorem toERCs_consistent : (ERC.linearExtensions (toERCs r)).Nonempty := by
   obtain ⟨σ, hσ⟩ := exists_isConsistent r
-  exact ⟨σ, satisfiedBy_toERCSet.mpr hσ⟩
+  exact ⟨σ, ERC.mem_linearExtensions.mpr (satisfiedBy_toERCs.mpr hσ)⟩
 
 /-- The **order-ideal antimatroid** of a grammar — the simple-ERC Birkhoff
 antimatroid (`Antimat.ofSimple`) of its Hasse-edge encoding, whose feasible
 sets are exactly the order ideals of `r`
 (`pocAntimatroid_isFeasible_iff`). -/
 def pocAntimatroid : Antimatroid (Fin n) :=
-  Antimat.ofSimple (toERCSet r) (toERCSet_consistent r) (toERCSet_isSimple_or_isTrivial r)
+  Antimat.ofSimple (toERCs r) (toERCs_consistent r) (toERCs_isSimple_or_isTrivial r)
 
 omit [IsPartialOrder (Fin n) r] in
-/-- Local feasibility against `toERCSet r` is exactly the order-ideal
+/-- Local feasibility against `toERCs r` is exactly the order-ideal
 condition — whenever `b ∈ S` and `a` dominates `b`, also `a ∈ S`. -/
-theorem feasible_toERCSet_iff {S : Finset (Fin n)} :
-    Feasible (toERCSet r) S ↔ ∀ a b, r a b → b ∈ S → a ∈ S := by
+theorem feasible_toERCs_iff {S : Finset (Fin n)} :
+    Feasible (toERCs r) S ↔ ∀ a b, r a b → b ∈ S → a ∈ S := by
   constructor
   · intro h a b hrel hbS
     rcases eq_or_ne a b with rfl | hab
     · exact hbS
     · obtain ⟨w, hwW, hwS⟩ :=
-        h (simpleERC a b) (mem_toERCSet.mpr ⟨a, b, hrel, rfl⟩)
+        h (simpleERC a b) (mem_toERCs.mpr ⟨a, b, hrel, rfl⟩)
           ⟨b, simpleERC_apply_L hab, hbS⟩
       rwa [(simpleERC_eq_W_iff w).mp hwW] at hwS
   · intro h α hα
-    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCSet.mp hα
+    obtain ⟨a, b, hrel, rfl⟩ := mem_toERCs.mp hα
     rintro ⟨l, hlL, hlS⟩
     have hab : a ≠ b := by rintro rfl; exact simpleERC_self_isTrivial a l hlL
     rw [(simpleERC_eq_L_iff hab l).mp hlL] at hlS
@@ -357,7 +357,7 @@ Birkhoff correspondence, made concrete and decidable. -/
 @[simp] theorem pocAntimatroid_isFeasible_iff {S : Finset (Fin n)} :
     (pocAntimatroid r).IsFeasible (↑S : Set (Fin n)) ↔
       ∀ a b, r a b → b ∈ S → a ∈ S := by
-  simp only [pocAntimatroid, ofSimple_isFeasible_coe, feasible_toERCSet_iff]
+  simp only [pocAntimatroid, ofSimple_isFeasible_coe, feasible_toERCs_iff]
 
 variable {r}
 
@@ -733,17 +733,17 @@ theorem pocPredict_stratified_binary_rate
 
 A partial order on constraints is the simple-ERC fragment of an OT grammar —
 its consistent total orders are exactly the legs of
-`Grammar.ofERCSet (toERCSet r)` ([merchant-riggle-2016]). -/
+`Grammar.ofERCs (toERCs r)` ([merchant-riggle-2016]). -/
 
 /-- The `Grammar` whose legs are `r`'s consistent total orders. -/
 def toGrammar (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r]
     [DecidableRel r] : Grammar n :=
-  Grammar.ofERCSet (toERCSet r) (toERCSet_consistent r)
+  Grammar.ofERCs (toERCs r) (toERCs_consistent r)
 
 @[simp] theorem toGrammar_legs (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r]
     [DecidableRel r] :
     (toGrammar r).legs = consistentTotalOrders r := by
-  show (Grammar.ofERCSet (toERCSet r) (toERCSet_consistent r)).legs = consistentTotalOrders r
-  rw [Grammar.legs_ofERCSet, consistentTotalOrders_eq_linearExtensions]
+  show (Grammar.ofERCs (toERCs r) (toERCs_consistent r)).legs = consistentTotalOrders r
+  rw [Grammar.legs_ofERCs, consistentTotalOrders_eq_linearExtensions]
 
 end HarmonicGrammar

--- a/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
+++ b/Linglib/Phonology/OptimalityTheory/Antimatroid.lean
@@ -91,8 +91,8 @@ theorem maximalChain_last {n : Nat} (r : Ranking n) :
     set of the top-`k` constraints under `r`.
 
     [merchant-riggle-2016] Definition 1. -/
-def MChain {n : Nat} (E : ERCSet n) : Set (Fin n) → Prop :=
-  fun S => ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧
+def MChain {n : Nat} (E : Finset (ERC n)) : Set (Fin n) → Prop :=
+  fun S => ∃ r : Ranking n, (∀ α ∈ E, ERC.SatisfiedBy r α) ∧
     ∃ k : Fin (n + 1), maximalChain r k = S
 
 /-! ### Local feasibility — a decidable sound over-approximation -/
@@ -109,14 +109,14 @@ inside `S` with no consistent global order realizing it
 (each ERC one `W`/one `L` = a Hasse edge = a partial order,
 `feasible_iff_feasiblePrefix_of_simple`). The faithful, *also decidable* notion
 is `FeasiblePrefix`. -/
-def Feasible {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) : Prop :=
+def Feasible {n : Nat} (E : Finset (ERC n)) (S : Finset (Fin n)) : Prop :=
   ∀ α ∈ E, (∃ l, α l = .L ∧ l ∈ S) → (∃ w, α w = .W ∧ w ∈ S)
 
-instance {n : Nat} (E : ERCSet n) : DecidablePred (Feasible E) :=
+instance {n : Nat} (E : Finset (ERC n)) : DecidablePred (Feasible E) :=
   fun S => by unfold Feasible; infer_instance
 
 /-- The empty prefix is locally feasible (no losers present). -/
-@[simp] theorem Feasible.empty {n : Nat} (E : ERCSet n) :
+@[simp] theorem Feasible.empty {n : Nat} (E : Finset (ERC n)) :
     Feasible E (∅ : Finset (Fin n)) := by
   intro α _ ⟨l, _, hl⟩; exact absurd hl (Finset.notMem_empty l)
 
@@ -124,7 +124,7 @@ instance {n : Nat} (E : ERCSet n) : DecidablePred (Feasible E) :=
 in one of them, whose winner then lies in `S ∪ T`. (This is union-closure of the
 over-approximation; the faithful family's union-closure is `MChain.union_closed`,
 [merchant-riggle-2016] Lemma 3.) -/
-theorem Feasible.union_closed {n : Nat} (E : ERCSet n) {S T : Finset (Fin n)}
+theorem Feasible.union_closed {n : Nat} (E : Finset (ERC n)) {S T : Finset (Fin n)}
     (hS : Feasible E S) (hT : Feasible E T) : Feasible E (S ∪ T) := by
   intro α hα ⟨l, hlL, hlST⟩
   rcases Finset.mem_union.mp hlST with hlS | hlT
@@ -145,8 +145,8 @@ def prefixFinset {n : Nat} (r : Ranking n) (k : Fin (n + 1)) : Finset (Fin n) :=
 isomorphism): a prefix of a ranking that satisfies `E` is locally feasible.
 Winners dominate their losers, so a loser inside the prefix drags its winner in
 (`maximalChain_dominance` in `Finset` form). -/
-theorem feasible_of_satisfiedBy {n : Nat} {E : ERCSet n} {r : Ranking n}
-    (hr : ERCSet.SatisfiedBy r E) (k : Fin (n + 1)) : Feasible E (prefixFinset r k) := by
+theorem feasible_of_satisfiedBy {n : Nat} {E : Finset (ERC n)} {r : Ranking n}
+    (hr : ∀ α ∈ E, ERC.SatisfiedBy r α) (k : Fin (n + 1)) : Feasible E (prefixFinset r k) := by
   intro α hα ⟨l, hlL, hlmem⟩
   rw [mem_prefixFinset] at hlmem
   obtain ⟨w, hwW, hdom⟩ := (ERC.satisfiedBy_iff_dominance r α).mp (hr α hα) l hlL
@@ -158,14 +158,14 @@ theorem feasible_of_satisfiedBy {n : Nat} {E : ERCSet n} {r : Ranking n}
 satisfying `E` — the `Finset`-valued form of `MChain`. Decidable by finite search
 over `Ranking n` (a `Fintype`) and `Fin (n+1)`, so `decide` reduces — *and*
 unlike `Feasible` it is the genuine antimatroid family, not an over-approximation. -/
-def FeasiblePrefix {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) : Prop :=
-  ∃ r : Ranking n, ERCSet.SatisfiedBy r E ∧ ∃ k : Fin (n + 1), prefixFinset r k = S
+def FeasiblePrefix {n : Nat} (E : Finset (ERC n)) (S : Finset (Fin n)) : Prop :=
+  ∃ r : Ranking n, (∀ α ∈ E, ERC.SatisfiedBy r α) ∧ ∃ k : Fin (n + 1), prefixFinset r k = S
 
-instance {n : Nat} (E : ERCSet n) : DecidablePred (FeasiblePrefix E) :=
+instance {n : Nat} (E : Finset (ERC n)) : DecidablePred (FeasiblePrefix E) :=
   fun _ => Fintype.decidableExistsFintype
 
 /-- The faithful predicate implies the over-approximation (`feasible_of_satisfiedBy`). -/
-theorem feasible_of_feasiblePrefix {n : Nat} {E : ERCSet n} {S : Finset (Fin n)}
+theorem feasible_of_feasiblePrefix {n : Nat} {E : Finset (ERC n)} {S : Finset (Fin n)}
     (h : FeasiblePrefix E S) : Feasible E S := by
   obtain ⟨r, hr, k, rfl⟩ := h; exact feasible_of_satisfiedBy hr k
 
@@ -176,7 +176,7 @@ theorem feasible_of_feasiblePrefix {n : Nat} {E : ERCSet n} {S : Finset (Fin n)}
 
 /-- `FeasiblePrefix` is `MChain` over `Finset` — the decidable counterpart of the
 existential, `Set`-valued antimatroid family. -/
-theorem mChain_coe_iff_feasiblePrefix {n : Nat} (E : ERCSet n) (S : Finset (Fin n)) :
+theorem mChain_coe_iff_feasiblePrefix {n : Nat} (E : Finset (ERC n)) (S : Finset (Fin n)) :
     MChain E (↑S) ↔ FeasiblePrefix E S := by
   constructor
   · rintro ⟨r, hr, k, hk⟩
@@ -191,8 +191,8 @@ antimatroid for general ERC sets. Hence `Antimat.IsFeasible` stays `MChain`
 ([merchant-riggle-2016]'s "beyond partial orders"); the local form is exact only
 on the simple-ERC fragment. -/
 theorem feasible_not_accessible :
-    ∃ (E : ERCSet 4) (S : Finset (Fin 4)),
-      ERCSet.Consistent E ∧ Feasible E S ∧ ¬ FeasiblePrefix E S ∧
+    ∃ (E : Finset (ERC 4)) (S : Finset (Fin 4)),
+      (ERC.linearExtensions E).Nonempty ∧ Feasible E S ∧ ¬ FeasiblePrefix E S ∧
         S.Nonempty ∧ ¬ ∃ x ∈ S, Feasible E (S \ {x}) :=
   ⟨{fun i => if i = 0 then .W else if i = 1 then .L else if i = 2 then .W else .e,
     fun i => if i = 0 then .L else if i = 1 then .W else if i = 2 then .e else .W},
@@ -298,8 +298,8 @@ set_option maxHeartbeats 1600000 in
     so `f w < f l`.
 
     [merchant-riggle-2016] Lemma 3. -/
-theorem MChain.union_closed {n : Nat} (E : ERCSet n)
-    (_hcons : ERCSet.Consistent E) (S T : Set (Fin n))
+theorem MChain.union_closed {n : Nat} (E : Finset (ERC n))
+    (_hcons : (ERC.linearExtensions E).Nonempty) (S T : Set (Fin n))
     (_hS : MChain E S) (_hT : MChain E T) : MChain E (S ∪ T) := by
   obtain ⟨r₁, hr₁, k₁, hk₁⟩ := _hS
   obtain ⟨r₂, hr₂, k₂, hk₂⟩ := _hT
@@ -393,7 +393,7 @@ theorem MChain.union_closed {n : Nat} (E : ERCSet n)
     · exact ⟨fun h => by have := countBelow_lt_card r₁ sR i ((in_sR i).mpr ⟨h1, h2⟩); omega,
         fun h => by rcases h with h | h <;> contradiction⟩
   -- ERC satisfaction
-  have hsat : ERCSet.SatisfiedBy r₃ E := by
+  have hsat : ∀ α ∈ E, ERC.SatisfiedBy r₃ α := by
     intro α hα
     rw [ERC.satisfiedBy_iff_dominance]
     intro l hl_L
@@ -443,17 +443,17 @@ theorem MChain.union_closed {n : Nat} (E : ERCSet n)
     maximal chains consistent with `E`.
 
     [merchant-riggle-2016] Definition 6, Lemma 4. -/
-def Antimat {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E) :
+def Antimat {n : Nat} (E : Finset (ERC n)) (hcons : (ERC.linearExtensions E).Nonempty) :
     Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := MChain E
   empty_feasible := by
     obtain ⟨r, hr⟩ := hcons
-    exact ⟨r, hr, ⟨0, Nat.zero_lt_succ n⟩, maximalChain_zero r⟩
+    exact ⟨r, ERC.mem_linearExtensions.mp hr, ⟨0, Nat.zero_lt_succ n⟩, maximalChain_zero r⟩
   feasible_sub := fun _ _ => Set.subset_univ _
   ground_feasible := by
     obtain ⟨r, hr⟩ := hcons
-    exact ⟨r, hr, ⟨n, Nat.lt_succ_of_le le_rfl⟩, maximalChain_last r⟩
+    exact ⟨r, ERC.mem_linearExtensions.mp hr, ⟨n, Nat.lt_succ_of_le le_rfl⟩, maximalChain_last r⟩
   augmentation := fun S hS hne => by
     -- S = maximalChain r k for some consistent r and position k.
     -- Since S ≠ Set.univ, k < n, and the next element r(k) can be added.
@@ -523,12 +523,13 @@ the order-ideal ↔ linear-extension-prefix correspondence — reorder a witness
 ranking `r₀` into the block `S` (in `r₀`'s order) followed by `Sᶜ` (in `r₀`'s
 order); winner-uniqueness makes every Hasse edge respected, so the result
 satisfies `E` and has `S` as its length-`|S|` prefix. -/
-theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : Finset (ERC n)}
+    (hcons : (ERC.linearExtensions E).Nonempty) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
     (S : Finset (Fin n)) :
     Feasible E S ↔ FeasiblePrefix E S := by
   refine ⟨fun hfeas => ?_, feasible_of_feasiblePrefix⟩
   obtain ⟨r₀, hr₀⟩ := hcons
+  rw [ERC.mem_linearExtensions] at hr₀
   -- Two-block reordering of `r₀`: `S` first (in `r₀` order), then `Sᶜ`.
   have hcard : S.card + Sᶜ.card = n := by
     rw [Finset.card_add_card_compl]; exact Fintype.card_fin n
@@ -595,8 +596,8 @@ theorem feasible_iff_feasiblePrefix_of_simple {n : Nat} {E : ERCSet n}
 /-- The `Set`-level feasible family of the simple fragment: a set is the coercion
 of a locally-feasible `Finset` iff it is `MChain`-feasible. (Bridges the decidable
 `Finset` side to `Antimat`'s `Set`-valued `MChain` family.) -/
-theorem feasible_coe_iff_mChain {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+theorem feasible_coe_iff_mChain {n : Nat} {E : Finset (ERC n)}
+    (hcons : (ERC.linearExtensions E).Nonempty) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
     (T : Set (Fin n)) :
     (∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S') ↔ MChain E T := by
   constructor
@@ -613,7 +614,7 @@ trivial) ERCs yields an antimatroid on `Fin n` whose feasible sets are the *loca
 union closure transfer from `Antimat`; concrete membership is checked by `decide`
 via `ofSimple_isFeasible_coe`. This is the order-ideal antimatroid of the
 constraint partial order ([merchant-riggle-2016]). -/
-def Antimat.ofSimple {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E)
+def Antimat.ofSimple {n : Nat} (E : Finset (ERC n)) (hcons : (ERC.linearExtensions E).Nonempty)
     (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial) : Antimatroid (Fin n) where
   E := Set.univ
   IsFeasible := fun T => ∃ S' : Finset (Fin n), (↑S' : Set (Fin n)) = T ∧ Feasible E S'
@@ -637,8 +638,8 @@ def Antimat.ofSimple {n : Nat} (E : ERCSet n) (hcons : ERCSet.Consistent E)
 
 /-- Concrete feasibility of `Antimat.ofSimple` is the decidable `Feasible` — the
 hook that lets `decide` settle membership queries. -/
-@[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : ERCSet n}
-    (hcons : ERCSet.Consistent E) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
+@[simp] theorem ofSimple_isFeasible_coe {n : Nat} {E : Finset (ERC n)}
+    (hcons : (ERC.linearExtensions E).Nonempty) (hsimple : ∀ α ∈ E, α.IsSimple ∨ α.IsTrivial)
     (S : Finset (Fin n)) :
     (Antimat.ofSimple E hcons hsimple).IsFeasible (↑S : Set (Fin n)) ↔ Feasible E S := by
   constructor
@@ -670,8 +671,8 @@ noncomputable def RCErc_single {n : Nat} (A : Antimatroid (Fin n))
     ([merchant-riggle-2016] Theorems 1–2).
 
     Represented as a `Set (ERC n)`; a ranking `r` *satisfies* `RCErc A` when
-    `∀ α ∈ RCErc A, ERC.SatisfiedBy r α` — the `Set` analogue of
-    `ERCSet.SatisfiedBy`, used to state the isomorphism theorems below. -/
+    `∀ α ∈ RCErc A, ERC.SatisfiedBy r α`, the same spelling used for `Finset`
+    ERC sets throughout. -/
 noncomputable def RCErc {n : Nat} (A : Antimatroid (Fin n)) : Set (ERC n) :=
   Set.range (RCErc_single A)
 
@@ -726,10 +727,10 @@ theorem Antimat_RCErc_inv {n : Nat} (A : Antimatroid (Fin n)) (S : Set (Fin n)) 
     [merchant-riggle-2016] actually proves. The general proof rests on
     [dietrich-1987]'s rooted-circuit characterization (via Lemmas 7, 9), so it
     carries an honest `sorry`. -/
-theorem RCErc_Antimat_inv {n : Nat} (E : ERCSet n)
-    (hcons : ERCSet.Consistent E) :
+theorem RCErc_Antimat_inv {n : Nat} (E : Finset (ERC n))
+    (hcons : (ERC.linearExtensions E).Nonempty) :
     ∀ r : Ranking n,
-      (∀ α ∈ RCErc (Antimat E hcons), ERC.SatisfiedBy r α) ↔ ERCSet.SatisfiedBy r E := by
+      (∀ α ∈ RCErc (Antimat E hcons), ERC.SatisfiedBy r α) ↔ ∀ α ∈ E, ERC.SatisfiedBy r α := by
   -- TODO: [merchant-riggle-2016] Theorem 2 (logical-equivalence form). Needs the
   -- rooted-circuit characterization of `Antimat E`'s feasible sets ([dietrich-1987];
   -- [merchant-riggle-2016] Lemmas 7, 9).
@@ -738,15 +739,15 @@ theorem RCErc_Antimat_inv {n : Nat} (E : ERCSet n)
 /-- **Theorem 3** ([merchant-riggle-2016]): `Antimat` preserves
     entailment.
 
-    If ERC set `E` entails `F` (every ranking satisfying `E` also
-    satisfies `F`), then `Antimat(E) ⊆ Antimat(F)` (every feasible
-    set of `Antimat(E)` is also feasible in `Antimat(F)`). -/
-theorem Antimat_entailment {n : Nat} (E F : ERCSet n)
-    (hE : ERCSet.Consistent E) (hF : ERCSet.Consistent F)
-    (h : ERCSet.Entails E F) :
+    If ERC set `E` entails `F` (`E`'s linear extensions are contained in
+    `F`'s), then `Antimat(E) ⊆ Antimat(F)` (every feasible set of
+    `Antimat(E)` is also feasible in `Antimat(F)`). -/
+theorem Antimat_entailment {n : Nat} (E F : Finset (ERC n))
+    (hE : (ERC.linearExtensions E).Nonempty) (hF : (ERC.linearExtensions F).Nonempty)
+    (h : ERC.linearExtensions E ⊆ ERC.linearExtensions F) :
     ∀ S, (Antimat E hE).IsFeasible S → (Antimat F hF).IsFeasible S := by
   intro S ⟨r, hr, k, hk⟩
-  exact ⟨r, h r hr, k, hk⟩
+  exact ⟨r, ERC.mem_linearExtensions.mp (h (ERC.mem_linearExtensions.mpr hr)), k, hk⟩
 
 /-- **Theorem 4** ([merchant-riggle-2016]): `RCErc` preserves
     containment.

--- a/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
+++ b/Linglib/Phonology/OptimalityTheory/ElementaryRankingCondition.lean
@@ -21,9 +21,9 @@ is lex-nonnegative — equivalently (`ERC.satisfiedBy_iff_dominance`), every
 ## Main declarations
 
 * `ERCVal`, `ERC n` — the sign alphabet and sign vectors `Fin n → ERCVal`.
-* `ERC.SatisfiedBy`, `ERCSet.Consistent`, `ERCSet.Entails` — the
-  satisfaction/consistency/entailment algebra; `ERCSet.linearExtensions` the
-  satisfying rankings as a `Finset`.
+* `ERC.SatisfiedBy` — satisfaction of one ERC; `ERC.linearExtensions` the
+  rankings satisfying a `Finset` of them. Consistency and entailment of ERC
+  sets are `Nonempty` and `⊆` of linear-extension sets — no separate algebra.
 * `ercOfProfiles`, `tableauERC` — ERCs from violation profiles and winner–loser
   pairs; `satisfiedBy_ercOfProfiles_iff_le` bridges to the Core lex order.
 * `simpleERC` — a single-`W`/single-`L` ERC, one Hasse edge `i ≫ j`
@@ -167,65 +167,30 @@ theorem trivial_satisfiedBy {α : ERC n} (htriv : α.IsTrivial) (r : Ranking n) 
 
 end ERC
 
-/-! ### Sets of ERCs -/
+/-! ### Linear extensions
 
-/-- A set of ERCs, carrying the satisfaction/consistency/entailment algebra of
-OT grammars. -/
-abbrev ERCSet (n : ℕ) := Finset (ERC n)
+Satisfaction of a `Finset (ERC n)` needs no vocabulary of its own: a ranking
+satisfies the set iff `∀ α ∈ E, α.SatisfiedBy r`, the set is *consistent*
+([prince-2002]) iff `(ERC.linearExtensions E).Nonempty`, and `E` *entails* `E'`
+iff `ERC.linearExtensions E ⊆ ERC.linearExtensions E'`. -/
 
-namespace ERCSet
+namespace ERC
 
-variable (r : Ranking n) (E E' : ERCSet n)
+/-- The rankings satisfying every member of a set of ERCs, as a `Finset` — its
+*linear extensions* ([merchant-riggle-2016]). -/
+def linearExtensions (E : Finset (ERC n)) : Finset (Ranking n) :=
+  Finset.univ.filter fun r => ∀ α ∈ E, ERC.SatisfiedBy r α
 
-/-- A ranking satisfies an ERC set iff it satisfies every member. -/
-def SatisfiedBy : Prop :=
-  ∀ α ∈ E, ERC.SatisfiedBy r α
-
-instance : Decidable (SatisfiedBy r E) :=
-  inferInstanceAs (Decidable (∀ α ∈ E, ERC.SatisfiedBy r α))
-
-/-- An ERC set is *consistent* iff some ranking satisfies all its members. -/
-def Consistent : Prop := ∃ r : Ranking n, SatisfiedBy r E
-
-instance : Decidable (Consistent E) :=
-  Fintype.decidableExistsFintype
-
-/-- A singleton is consistent iff some ranking satisfies its ERC. -/
-@[simp] theorem consistent_singleton {α : ERC n} :
-    Consistent {α} ↔ ∃ r : Ranking n, α.SatisfiedBy r := by
-  simp [Consistent, SatisfiedBy]
-
-/-- The rankings consistent with an ERC set, as a `Finset` — its *linear extensions*
-([merchant-riggle-2016]). -/
-def linearExtensions : Finset (Ranking n) :=
-  Finset.univ.filter (fun r => SatisfiedBy r E)
-
-@[simp] theorem mem_linearExtensions {E : ERCSet n} {r : Ranking n} :
-    r ∈ E.linearExtensions ↔ SatisfiedBy r E := by
+@[simp] theorem mem_linearExtensions {E : Finset (ERC n)} {r : Ranking n} :
+    r ∈ linearExtensions E ↔ ∀ α ∈ E, ERC.SatisfiedBy r α := by
   simp [linearExtensions]
 
-/-! ### Entailment -/
+/-- The empty set constrains nothing: every ranking is a linear extension. -/
+@[simp] theorem linearExtensions_empty :
+    linearExtensions (∅ : Finset (ERC n)) = Finset.univ := by
+  ext r; simp
 
-/-- `E` *entails* `E'` iff every ranking satisfying `E` also satisfies `E'`. -/
-def Entails : Prop := ∀ r : Ranking n, SatisfiedBy r E → SatisfiedBy r E'
-
-theorem entails_refl : Entails E E := fun _ h => h
-
-theorem entails_trans {E₁ E₂ E₃ : ERCSet n}
-    (h₁₂ : Entails E₁ E₂) (h₂₃ : Entails E₂ E₃) : Entails E₁ E₃ :=
-  fun r hr => h₂₃ r (h₁₂ r hr)
-
-/-- A superset entails: adding ERCs only strengthens the set. -/
-theorem entails_of_superset {E E' : ERCSet n} (h : E ⊆ E') : Entails E' E :=
-  fun _ hr β hβ => hr β (h hβ)
-
-/-- Pointwise characterization: `E` entails `E'` if it entails each member
-singleton. -/
-theorem entails_of_forall_mem {E E' : ERCSet n}
-    (h : ∀ α ∈ E', Entails E {α}) : Entails E E' :=
-  fun r hr α hα => h α hα r hr α (Finset.mem_singleton_self α)
-
-end ERCSet
+end ERC
 
 /-! ### Simple ERCs -/
 
@@ -280,9 +245,9 @@ theorem simpleERC_satisfiedBy_toRel_iff (i j : Fin n) (r : Ranking n) :
 
 /-- A simple ERC `i ≫ j` (with `i ≠ j`) is consistent. -/
 theorem simpleERC_consistent (hij : i ≠ j) :
-    ERCSet.Consistent {simpleERC i j} :=
+    (ERC.linearExtensions {simpleERC i j}).Nonempty :=
   have ⟨r, hr⟩ := Ranking.exists_dominates hij
-  ERCSet.consistent_singleton.mpr ⟨r, (simpleERC_satisfiedBy_iff hij r).mpr hr⟩
+  ⟨r, by simp [(simpleERC_satisfiedBy_iff hij r).mpr hr]⟩
 
 /-- `simpleERC i j` (with `i ≠ j`) is a simple ERC. -/
 theorem simpleERC_isSimple (hij : i ≠ j) : (simpleERC i j).IsSimple :=

--- a/Linglib/Phonology/OptimalityTheory/Grammar.lean
+++ b/Linglib/Phonology/OptimalityTheory/Grammar.lean
@@ -13,10 +13,10 @@ exhibiting the other two faces as views.
 
 Taking the leg set as identity makes grammar equality decidable and dissolves the
 "up to entailment" hedge that the ERC-set presentation carries: two consistent ERC
-sets present the *same* grammar exactly when they are mutually entailing
-(`Grammar.ofERCSet_eq_iff_entails`), because they then have the same legs. The
-transitive-reduction ambiguity that forces [merchant-riggle-2016] Theorem 2 to be
-stated up to logical equivalence becomes literal `Grammar` equality here.
+sets present the *same* grammar exactly when they have the same linear extensions
+(`Grammar.ofERCs_eq_iff`). The transitive-reduction ambiguity that forces
+[merchant-riggle-2016] Theorem 2 to be stated up to logical equivalence becomes
+literal `Grammar` equality here.
 
 The antimatroid face (`Grammar.toAntimatroid`) is a one-directional view: every
 grammar is an antimatroid, but the converse — that every antimatroid is some
@@ -30,15 +30,15 @@ satisfying rankings.
 
 * `Grammar n` — a realizable leg set: a `Finset (Ranking n)` equal to the linear
   extensions of some consistent ERC set.
-* `Grammar.ofERCSet` — the canonical grammar of a consistent ERC set (the ERC face,
+* `Grammar.ofERCs` — the canonical grammar of a consistent ERC set (the ERC face,
   as a constructor).
 * `Grammar.feasible` / `Grammar.toAntimatroid` — the antimatroid face.
 
 ## Main results
 
-* `Grammar.ofERCSet_eq_iff_entails` — two consistent ERC sets present the same
-  grammar iff they are mutually entailing (the entailment quotient dissolves).
-* `Grammar.feasible_ofERCSet` — the antimatroid family of `ofERCSet E` is `MChain E`.
+* `Grammar.ofERCs_eq_iff` — two consistent ERC sets present the same grammar iff
+  they have the same linear extensions (the entailment quotient dissolves).
+* `Grammar.feasible_ofERCs` — the antimatroid family of `ofERCs E` is `MChain E`.
 * `Grammar.toAntimatroid_isFeasible` — the antimatroid face's feasible sets are
   exactly the prefixes of the grammar's legs.
 
@@ -51,8 +51,9 @@ and `models` as a **(dual) adjunction** between them. The induced monad
 `grammarClosure = models ∘ conditions` is the **idempotent closure monad**, and its
 algebras — the closed objects (`IsGrammarClosed`) — are exactly the grammars: a
 **reflective subcategory** of ranking-space with `grammarClosure` as the reflector.
-On `Grammar n` itself this lands as a `PartialOrder` (the specificity = entailment
-order, `ofERCSet_le_iff_entails`) with a **terminal object** (`OrderTop`, the trivial
+On `Grammar n` itself this lands as a `PartialOrder` (the specificity order —
+on the ERC face, definitionally containment of linear-extension sets, i.e.
+entailment) with a **terminal object** (`OrderTop`, the trivial
 grammar) and **binary coproducts** (`superGrammar`, the super-grammar join, with
 universal property `superGrammar_le`). Binary products (meets) may be empty, so the
 full complete lattice lives on the closed sets, not on `Grammar`.
@@ -162,19 +163,11 @@ theorem isGrammarClosed_inter {R R' : Set (Ranking n)}
   · exact (grammarClosure_mono Set.inter_subset_left).trans hR.le
   · exact (grammarClosure_mono Set.inter_subset_right).trans hR'.le
 
-/-- The coerced linear-extension set of an ERC list is the `models` of that list's
-conditions — the bridge from the `ERCSet` presentation to the Galois polarity. -/
-theorem coe_linearExtensions_eq_models (E : ERCSet n) :
-    (↑E.linearExtensions : Set (Ranking n)) = models {α | α ∈ E} := by
-  ext r
-  simp only [Finset.mem_coe, ERCSet.mem_linearExtensions, mem_models, Set.mem_ofPred_eq]
-  rfl
-
-/-- The empty ERC set is satisfied by every ranking: its linear extensions are all
-of `Ord(S.Con)`. This is the trivial grammar (no ranking conditions). -/
-@[simp] theorem ERCSet.linearExtensions_empty :
-    ERCSet.linearExtensions (∅ : ERCSet n) = Finset.univ := by
-  ext r; simp [ERCSet.mem_linearExtensions, ERCSet.SatisfiedBy]
+/-- The `Finset` and `Set` granularities of satisfaction agree: the coerced
+linear-extension set is the `models` of the coerced ERC set. -/
+theorem coe_linearExtensions_eq_models (E : Finset (ERC n)) :
+    (↑(ERC.linearExtensions E) : Set (Ranking n)) = models ↑E := by
+  ext r; simp [mem_models]
 
 /-- An OT **grammar**: a set of rankings realizable as the linear extensions of
 some consistent ERC set ([merchant-riggle-2016]). The leg set is the grammar's
@@ -183,7 +176,8 @@ structure Grammar (n : ℕ) where
   /-- The grammar's legs: the rankings that select its language's optima. -/
   legs : Finset (Ranking n)
   /-- Every grammar is the linear-extension set of some consistent ERC set. -/
-  realizable : ∃ E : ERCSet n, ERCSet.Consistent E ∧ legs = E.linearExtensions
+  realizable : ∃ E : Finset (ERC n),
+    (ERC.linearExtensions E).Nonempty ∧ legs = ERC.linearExtensions E
 
 namespace Grammar
 
@@ -193,12 +187,12 @@ so leg-set equality is grammar equality. -/
   cases G; cases G'; cases h; rfl
 
 /-- The grammar of a consistent ERC set — the ERC face, as a constructor. -/
-def ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) : Grammar n where
-  legs := E.linearExtensions
+def ofERCs (E : Finset (ERC n)) (hcons : (ERC.linearExtensions E).Nonempty) : Grammar n where
+  legs := ERC.linearExtensions E
   realizable := ⟨E, hcons, rfl⟩
 
-@[simp] theorem legs_ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) :
-    (ofERCSet E hcons).legs = E.linearExtensions := rfl
+@[simp] theorem legs_ofERCs (E : Finset (ERC n)) (hcons : (ERC.linearExtensions E).Nonempty) :
+    (ofERCs E hcons).legs = ERC.linearExtensions E := rfl
 
 /-- Membership: `r ∈ G` means `r` is one of `G`'s legs. -/
 instance : Membership (Ranking n) (Grammar n) where
@@ -206,37 +200,29 @@ instance : Membership (Ranking n) (Grammar n) where
 
 @[simp] theorem mem_iff {G : Grammar n} {r : Ranking n} : r ∈ G ↔ r ∈ G.legs := Iff.rfl
 
-@[simp] theorem mem_ofERCSet {E : ERCSet n} {hcons : ERCSet.Consistent E} {r : Ranking n} :
-    r ∈ ofERCSet E hcons ↔ ERCSet.SatisfiedBy r E := by
-  simp [mem_iff, ofERCSet]
+@[simp] theorem mem_ofERCs {E : Finset (ERC n)} {hcons : (ERC.linearExtensions E).Nonempty}
+    {r : Ranking n} :
+    r ∈ ofERCs E hcons ↔ ∀ α ∈ E, ERC.SatisfiedBy r α := by
+  simp [mem_iff, ofERCs]
 
 /-- A grammar has at least one leg: a harmonically-bounded row gives no grammar
 ([prince-2002]). -/
 theorem legs_nonempty (G : Grammar n) : G.legs.Nonempty := by
   obtain ⟨E, hcons, hlegs⟩ := G.realizable
-  obtain ⟨r, hr⟩ := hcons
-  exact ⟨r, by rw [hlegs]; exact ERCSet.mem_linearExtensions.mpr hr⟩
+  exact hlegs ▸ hcons
 
 /-! ### The ERC face: grammar equality is mutual entailment -/
 
 /-- **The entailment quotient dissolves at the grammar level.** Two consistent ERC
-sets present the same grammar iff they are mutually entailing — iff they have the
-same legs. This is why the leg set, not the ERC set, is the grammar's identity:
-the "logically equivalent, not literally equal" hedge of the ERC presentation
-([merchant-riggle-2016] Theorem 2) becomes literal `Grammar` equality. -/
-theorem ofERCSet_eq_iff_entails {E E' : ERCSet n}
-    (h : ERCSet.Consistent E) (h' : ERCSet.Consistent E') :
-    ofERCSet E h = ofERCSet E' h' ↔ ERCSet.Entails E E' ∧ ERCSet.Entails E' E := by
-  constructor
-  · intro he
-    have hl : E.linearExtensions = E'.linearExtensions := congrArg Grammar.legs he
-    rw [Finset.ext_iff] at hl
-    simp only [ERCSet.mem_linearExtensions] at hl
-    exact ⟨fun r => (hl r).mp, fun r => (hl r).mpr⟩
-  · rintro ⟨h12, h21⟩
-    apply ext
-    simp only [legs_ofERCSet, Finset.ext_iff, ERCSet.mem_linearExtensions]
-    exact fun r => ⟨h12 r, h21 r⟩
+sets present the same grammar iff they have the same linear extensions — iff each
+entails the other. This is why the leg set, not the ERC set, is the grammar's
+identity: the "logically equivalent, not literally equal" hedge of the ERC
+presentation ([merchant-riggle-2016] Theorem 2) becomes literal `Grammar`
+equality. -/
+theorem ofERCs_eq_iff {E E' : Finset (ERC n)}
+    (h : (ERC.linearExtensions E).Nonempty) (h' : (ERC.linearExtensions E').Nonempty) :
+    ofERCs E h = ofERCs E' h' ↔ ERC.linearExtensions E = ERC.linearExtensions E' :=
+  ⟨congrArg legs, fun hl => ext hl⟩
 
 /-! ### The antimatroid face -/
 
@@ -246,18 +232,19 @@ presentation. -/
 def feasible (G : Grammar n) (S : Set (Fin n)) : Prop :=
   ∃ r : Ranking n, r ∈ G.legs ∧ ∃ k : Fin (n + 1), maximalChain r k = S
 
-/-- The feasible family of `ofERCSet E` is exactly `MChain E`: the antimatroid face
+/-- The feasible family of `ofERCs E` is exactly `MChain E`: the antimatroid face
 agrees with [merchant-riggle-2016]'s `Antimat E` construction. -/
-theorem feasible_ofERCSet (E : ERCSet n) (hcons : ERCSet.Consistent E) (S : Set (Fin n)) :
-    (ofERCSet E hcons).feasible S ↔ MChain E S := by
-  simp only [feasible, legs_ofERCSet, ERCSet.mem_linearExtensions, MChain]
+theorem feasible_ofERCs (E : Finset (ERC n)) (hcons : (ERC.linearExtensions E).Nonempty)
+    (S : Set (Fin n)) :
+    (ofERCs E hcons).feasible S ↔ MChain E S := by
+  simp only [feasible, legs_ofERCs, ERC.mem_linearExtensions, MChain]
 
 /-- The feasible family is presentation-independent: it depends only on the legs,
 so any consistent ERC set realizing `G` computes it. -/
-theorem feasible_eq_mChain (G : Grammar n) {E : ERCSet n}
-    (hlegs : G.legs = E.linearExtensions) : G.feasible = MChain E := by
+theorem feasible_eq_mChain (G : Grammar n) {E : Finset (ERC n)}
+    (hlegs : G.legs = ERC.linearExtensions E) : G.feasible = MChain E := by
   funext S
-  simp only [feasible, hlegs, ERCSet.mem_linearExtensions, MChain]
+  simp only [feasible, hlegs, ERC.mem_linearExtensions, MChain]
 
 /-- The **antimatroid face** of a grammar ([merchant-riggle-2016]): ground set the
 constraints, feasible sets the prefixes of the legs. Every grammar is an
@@ -287,11 +274,11 @@ def toAntimatroid (G : Grammar n) : Antimatroid (Fin n) where
 @[simp] theorem toAntimatroid_isFeasible (G : Grammar n) (S : Set (Fin n)) :
     G.toAntimatroid.IsFeasible S ↔ G.feasible S := Iff.rfl
 
-/-- The antimatroid face of `ofERCSet E` has the same feasible sets as `Antimat E`. -/
-theorem toAntimatroid_ofERCSet_isFeasible (E : ERCSet n) (hcons : ERCSet.Consistent E)
-    (S : Set (Fin n)) :
-    (ofERCSet E hcons).toAntimatroid.IsFeasible S ↔ (Antimat E hcons).IsFeasible S := by
-  rw [toAntimatroid_isFeasible, feasible_ofERCSet]
+/-- The antimatroid face of `ofERCs E` has the same feasible sets as `Antimat E`. -/
+theorem toAntimatroid_ofERCs_isFeasible (E : Finset (ERC n))
+    (hcons : (ERC.linearExtensions E).Nonempty) (S : Set (Fin n)) :
+    (ofERCs E hcons).toAntimatroid.IsFeasible S ↔ (Antimat E hcons).IsFeasible S := by
+  rw [toAntimatroid_isFeasible, feasible_ofERCs]
   exact Iff.rfl
 
 /-! ### Grammars are exactly the nonempty closed sets -/
@@ -310,24 +297,25 @@ of the grammar–condition Galois connection. -/
 theorem exists_grammar_of_isGrammarClosed {R : Set (Ranking n)}
     (hcl : IsGrammarClosed R) (hne : R.Nonempty) :
     ∃ G : Grammar n, (↑G.legs : Set (Ranking n)) = R := by
-  obtain ⟨E, hAeq⟩ : ∃ E : ERCSet n, {α | α ∈ E} = conditions R := by
+  obtain ⟨E, hAeq⟩ : ∃ E : Finset (ERC n), (↑E : Set (ERC n)) = conditions R := by
     refine ⟨(Set.toFinite (conditions R)).toFinset, ?_⟩
-    ext α; simp [Set.Finite.mem_toFinset]
-  have hReq : (↑E.linearExtensions : Set (Ranking n)) = R := by
+    ext α; simp
+  have hReq : (↑(ERC.linearExtensions E) : Set (Ranking n)) = R := by
     rw [coe_linearExtensions_eq_models, hAeq]; exact hcl
-  have hcons : ERCSet.Consistent E := by
+  have hcons : (ERC.linearExtensions E).Nonempty := by
     obtain ⟨r, hr⟩ := hne
-    have hmem : r ∈ (↑E.linearExtensions : Set (Ranking n)) := hReq ▸ hr
-    rw [Finset.mem_coe, ERCSet.mem_linearExtensions] at hmem
-    exact ⟨r, hmem⟩
-  exact ⟨⟨E.linearExtensions, E, hcons, rfl⟩, hReq⟩
+    rw [← hReq] at hr
+    exact ⟨r, hr⟩
+  exact ⟨⟨ERC.linearExtensions E, E, hcons, rfl⟩, hReq⟩
 
 /-! ### The specificity order: grammars as a thin category
 
 `Grammar n` is a **poset** — a thin category — under leg-set inclusion: `G ≤ G'`
 means `G` is *more specific* (fewer legs, more ranking conditions). On the ERC face
-this is exactly the entailment order (`ofERCSet_le_iff_entails`), the order side of
-the Galois adjunction. `grammarClosure` is the **reflector** onto this subcategory
+`ofERCs E h ≤ ofERCs E' h'` is definitionally
+`ERC.linearExtensions E ⊆ ERC.linearExtensions E'` — the entailment order, the
+order side of the Galois adjunction. `grammarClosure` is the **reflector** onto
+this subcategory
 (grammars are its closed objects — the algebras of the idempotent closure monad).
 The **terminal object** is the trivial grammar (`OrderTop`); the **coproduct** of
 two grammars is their super-grammar — the closure of the union of legs. Binary
@@ -342,24 +330,12 @@ instance : PartialOrder (Grammar n) where
 
 theorem le_iff_legs {G G' : Grammar n} : G ≤ G' ↔ G.legs ⊆ G'.legs := Iff.rfl
 
-/-- The specificity order on grammars **is** the entailment order on their ERC sets
-— the order side of the grammar–condition Galois adjunction. -/
-theorem ofERCSet_le_iff_entails {E E' : ERCSet n}
-    (h : ERCSet.Consistent E) (h' : ERCSet.Consistent E') :
-    ofERCSet E h ≤ ofERCSet E' h' ↔ ERCSet.Entails E E' := by
-  rw [le_iff_legs]
-  constructor
-  · intro hle r hr
-    exact ERCSet.mem_linearExtensions.mp (hle (ERCSet.mem_linearExtensions.mpr hr))
-  · intro hent r hr
-    exact ERCSet.mem_linearExtensions.mpr (hent r (ERCSet.mem_linearExtensions.mp hr))
-
 /-- The **trivial grammar** — the terminal object of the specificity order: all
-rankings, no ranking conditions (`ofERCSet ∅`). -/
-def trivial : Grammar n := ofERCSet ∅ ⟨Ranking.id n, by simp [ERCSet.SatisfiedBy]⟩
+rankings, no ranking conditions (`ofERCs ∅`). -/
+def trivial : Grammar n := ofERCs ∅ ⟨Ranking.id n, by simp⟩
 
 @[simp] theorem legs_trivial : (Grammar.trivial : Grammar n).legs = Finset.univ := by
-  simp only [Grammar.trivial, legs_ofERCSet, ERCSet.linearExtensions_empty]
+  simp only [Grammar.trivial, legs_ofERCs, ERC.linearExtensions_empty]
 
 instance : OrderTop (Grammar n) where
   top := trivial

--- a/Linglib/Studies/Belth2026.lean
+++ b/Linglib/Studies/Belth2026.lean
@@ -497,16 +497,16 @@ theorem lunarisERC_isContradictory : lunarisERC.IsContradictory := by decide
     every word's ranking requirements. Two informative ERCs (popularis,
     pluvalis) both reduce to `simpleERC 0 1`; the other three are
     trivial. -/
-theorem latinERCSet_consistent_without_lunaris :
-    ERCSet.Consistent
-      {popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC} :=
+theorem latinERCs_consistent_without_lunaris :
+    (ERC.linearExtensions
+      {popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC}).Nonempty :=
   ⟨Ranking.id 2, by decide⟩
 
 /-- Bridge to the dominance characterisation: under any ranking
     satisfying the empirical ERC set (sans lunaris), OCP dominates \*r. -/
 theorem latin_OCP_dominates_starR (r : Ranking 2)
-    (hr : ERCSet.SatisfiedBy r
-      {popularisERC, pluvalisERC, navalisERC, floralisERC, legalisERC}) :
+    (hr : ∀ α ∈ ({popularisERC, pluvalisERC, navalisERC, floralisERC,
+      legalisERC} : Finset (ERC 2)), α.SatisfiedBy r) :
     r.Dominates 0 1 := by
   have hpop : popularisERC.SatisfiedBy r :=
     hr popularisERC (Finset.mem_insert_self _ _)

--- a/Linglib/Studies/McPhersonLamont2026.lean
+++ b/Linglib/Studies/McPhersonLamont2026.lean
@@ -117,7 +117,7 @@ def ercA : ERC numConstraints := ercFor .nanWinner .nanLoser
 def ercB : ERC numConstraints := ercFor .kakWinner .kakLoser
 
 /-- The ranking-paradox support. -/
-def pokoSupport : ERCSet numConstraints := {ercA, ercB}
+def pokoSupport : Finset (ERC numConstraints) := {ercA, ercB}
 
 /-- The derived `ercA` matches eq. 59 row a: `[W, L, L, L]`. -/
 example : ercA maxHIdx = .W ∧ ercA depLinkHIdx = .L ∧
@@ -131,8 +131,9 @@ example : ercB maxHIdx = .L ∧ ercB depLinkHIdx = .W ∧
 
 /-- **Parallel OT cannot model Poko** (eq. 59): the derived support is ERC-inconsistent.
     Structural proof — `Equiv.Perm (Fin n)`'s `Fintype` doesn't kernel-reduce under `decide`. -/
-theorem parallel_OT_inadequate : ¬ ERCSet.Consistent pokoSupport := by
+theorem parallel_OT_inadequate : ¬ (ERC.linearExtensions pokoSupport).Nonempty := by
   rintro ⟨r, hr⟩
+  rw [ERC.mem_linearExtensions] at hr
   have hA := (ERC.satisfiedBy_iff_dominance r ercA).mp (hr ercA (by simp [pokoSupport]))
   have hB := (ERC.satisfiedBy_iff_dominance r ercB).mp (hr ercB (by simp [pokoSupport]))
   -- per-position decide: reduction through `ercOfProfiles` stalls on the quantified form

--- a/Linglib/Studies/MerchantPrince2022.lean
+++ b/Linglib/Studies/MerchantPrince2022.lean
@@ -12,8 +12,8 @@ already build) to the abstract **`Grammar`** hub (`OptimalityTheory.Grammar`,
 [merchant-riggle-2016]).
 
 A row `w` of a tableau, asserted optimal, generates the ERC set of its winner-loser
-comparisons against the other candidates (`rowERCSet`); the **grammar of that row**
-(`rowGrammar`) is `Grammar.ofERCSet` of those conditions. Its legs are exactly the
+comparisons against the other candidates (`rowERCs`); the **grammar of that row**
+(`rowGrammar`) is `Grammar.ofERCs` of those conditions. Its legs are exactly the
 rankings under which `w` wins (`mem_rowGrammar_legs_iff_lex`) — this is the semantic
 anchor connecting the abstract hub back to lexicographic optimality
 ([prince-smolensky-1993]).
@@ -25,7 +25,7 @@ this bridge and is left to follow-on work.
 
 ## Main definitions
 
-* `rowERCSet` — the winner-loser ERCs of a tableau row against the other candidates.
+* `rowERCs` — the winner-loser ERCs of a tableau row against the other candidates.
 * `rowGrammar` — the `Grammar` of a tableau row (the tableau → hub bridge).
 
 ## Main results
@@ -49,7 +49,7 @@ variable {C : Type*} [DecidableEq C] {n : ℕ}
 /-- The ERC set of a tableau row `w`: `w`'s winner-loser ERCs against every *other*
 candidate. These are the ranking conditions a leg must satisfy for `w` to be the
 optimum ([prince-2002]). -/
-def rowERCSet (t : Tableau C n) (w : C) : ERCSet n :=
+def rowERCs (t : Tableau C n) (w : C) : Finset (ERC n) :=
   (t.candidates.erase w).image (tableauERC t w)
 
 /-- The **grammar of a tableau row** — the bridge from the Concrete-OT tableau
@@ -57,13 +57,13 @@ engine to the abstract `Grammar` hub ([merchant-prince-2022]; [merchant-riggle-2
 `h` is the consistency of the row's conditions, i.e. that `w` is a genuine,
 non-harmonically-bounded optimum. -/
 def rowGrammar (t : Tableau C n) (w : C)
-    (h : ERCSet.Consistent (rowERCSet t w)) : Grammar n :=
-  Grammar.ofERCSet (rowERCSet t w) h
+    (h : (ERC.linearExtensions (rowERCs t w)).Nonempty) : Grammar n :=
+  Grammar.ofERCs (rowERCs t w) h
 
 @[simp] theorem mem_rowGrammar_legs {t : Tableau C n} {w : C}
-    {h : ERCSet.Consistent (rowERCSet t w)} {r : Ranking n} :
-    r ∈ (rowGrammar t w h).legs ↔ ERCSet.SatisfiedBy r (rowERCSet t w) := by
-  simp only [rowGrammar, Grammar.legs_ofERCSet, ERCSet.mem_linearExtensions]
+    {h : (ERC.linearExtensions (rowERCs t w)).Nonempty} {r : Ranking n} :
+    r ∈ (rowGrammar t w h).legs ↔ ∀ α ∈ rowERCs t w, ERC.SatisfiedBy r α := by
+  simp only [rowGrammar, Grammar.legs_ofERCs, ERC.mem_linearExtensions]
 
 /-- **The semantic anchor.** A row's grammar collects exactly the rankings under
 which `w`'s violation profile, read in the ranking's priority order, lexicographically
@@ -71,12 +71,12 @@ dominates every competitor's — i.e. the rankings that select `w` as optimum
 ([prince-smolensky-1993]). This connects the abstract `Grammar` hub back to the
 tableau's lexicographic evaluation. -/
 theorem mem_rowGrammar_legs_iff_lex {t : Tableau C n} {w : C}
-    {h : ERCSet.Consistent (rowERCSet t w)} {r : Ranking n} :
+    {h : (ERC.linearExtensions (rowERCs t w)).Nonempty} {r : Ranking n} :
     r ∈ (rowGrammar t w h).legs ↔
       ∀ l ∈ t.candidates.erase w,
         toLex (fun p => t.profile w (r p)) ≤ toLex (fun p => t.profile l (r p)) := by
   rw [mem_rowGrammar_legs]
-  unfold ERCSet.SatisfiedBy rowERCSet
+  unfold rowERCs
   constructor
   · intro hsat l hl
     exact (tableauERC_satisfiedBy_iff t r w l).mp


### PR DESCRIPTION
`ERCSet` was an alias over `Finset (ERC n)` whose namespace duplicated the `models`/`conditions` Galois polarity already in `Grammar.lean` at Finset granularity. Dissolved: the one load-bearing primitive survives as `ERC.linearExtensions` (with `mem_`/`_empty` simp lemmas); satisfaction is spelled `∀ α ∈ E, α.SatisfiedBy r`, consistency `(ERC.linearExtensions E).Nonempty`, entailment `⊆` of extension sets — so `entails_refl`/`entails_trans` become mathlib `⊆` facts and `ofERCSet_le_iff_entails` dissolves (the grammar specificity order is definitionally entailment). Renames: `ofERCSet` → `ofERCs`, `toERCSet` → `toERCs`, `rowERCSet` → `rowERCs`.