### PR TITLE
chore(Phonology/HarmonicGrammar): RealizationProblem.lean as Realizability.lean

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1311,7 +1311,7 @@ import Linglib.Phonology.Constraints.Defs
 import Linglib.Phonology.Constraints.Directional
 import Linglib.Phonology.Constraints.Lift
 import Linglib.Phonology.Constraints.Profile
-import Linglib.Phonology.HarmonicGrammar.RealizationProblem
+import Linglib.Phonology.HarmonicGrammar.Realizability
 import Linglib.Phonology.HarmonicGrammar.MaxEnt
 import Linglib.Phonology.HarmonicGrammar.NoisyHG
 import Linglib.Phonology.Hiatus

--- a/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.HarmonicGrammar.RealizationProblem
+import Linglib.Phonology.HarmonicGrammar.Realizability
 import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Grammar

--- a/Linglib/Phonology/HarmonicGrammar/Realizability.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Realizability.lean
@@ -41,7 +41,8 @@ variable {Input Output : Type*} {n : ℕ}
 /-! ### Realization problems -/
 
 /-- A multi-input optimization problem: a target mapping that a single
-    grammar must realize for every input simultaneously. -/
+    grammar must realize for every input simultaneously (for OT, the data of
+    [tesar-smolensky-1995]'s ranking problem). -/
 structure RealizationProblem (Input : Type*) (Output : Type*) (n : ℕ) where
   /-- The set of inputs the grammar handles. -/
   inputs : Finset Input


### PR DESCRIPTION
File named for the property that is its subject (`IsHGRealizable`/`IsOTRealizable` and the containments), on the `Mathlib/ModelTheory/Satisfiability.lean` precedent. The `RealizationProblem` type keeps its (transparent, coined) name — the literature has no bundled noun for the instance; its docstring now grounds the OT case as the data of Tesar–Smolensky's ranking problem.