### PR TITLE
refactor(Phonology): move POC to OptimalityTheory; algebraic kernel form

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1314,7 +1314,7 @@ import Linglib.Phonology.Constraints.Profile
 import Linglib.Phonology.HarmonicGrammar.Expressivity
 import Linglib.Phonology.HarmonicGrammar.NoisyHG
 import Linglib.Phonology.Hiatus
-import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
+import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Phonology.Constraints.Harmony
 import Linglib.Phonology.HarmonicGrammar.Separability
 import Linglib.Studies.Riggle2009

--- a/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
+++ b/Linglib/Core/Optimization/PermSubsetCombinatorics.lean
@@ -31,7 +31,7 @@ left-multiplication by swaps of elements of `D`:
 swap-closed generality serves partially-ordered constraint grammars,
 whose consistent-linear-extension sets are swap-closed within a freely
 ranked stratum (`winProb_stratified_binary_rate` in
-`Phonology/HarmonicGrammar/PartiallyOrderedConstraints.lean`).
+`Phonology/OptimalityTheory/PartiallyOrderedConstraints.lean`).
 
 ## Proof technique
 

--- a/Linglib/Phonology/HarmonicGrammar/Expressivity.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Expressivity.lean
@@ -1,4 +1,5 @@
 import Linglib.Phonology.Constraints.Defs
+import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Tableau
 import Linglib.Core.Optimization.Evaluation
@@ -38,6 +39,9 @@ high-weight one, is HG-expressible but not OT-expressible.
   `hg_strictly_contains_ot`: OT ⊆ HG, strictly — the witness is
   [coetzee-pater-2011]'s abstract Lyman's Law instance (eq 18-19, after
   [ito-mester-1986]).
+- `RealizationProblem.isOTRealizable_iff_isPartialOrderRealizable`:
+  categorically, partially ordered grammars add nothing over OT — their
+  advantage is probabilistic (`OptimalityTheory.winProb`).
 -/
 
 namespace HarmonicGrammar
@@ -251,6 +255,16 @@ theorem lex_imp_lower_violations {n : Nat} (w : Fin n → ℝ) (M : Nat)
     linarith [Finset.sum_le_sum h_each]
   -- Combine: w_k − M · Σ_{i>k} w_i > 0 from ExponentiallySeparated
   linarith [hw.2 k, hlt_zero]
+
+/-- The algebraic form of the agreement kernel: an exponentially separated
+weighting reads the `M`-bounded fragment of the lex order strictly
+monotonically — [riggle-2009]'s order-preserving weight map from the violation
+semiring to tropical costs, in concrete form. -/
+theorem strictMonoOn_weightedViolations {n : Nat} {w : Fin n → ℝ} {M : Nat}
+    (hw : ExponentiallySeparated w M) :
+    StrictMonoOn (fun v : ViolationProfile n => weightedViolations w (ofLex v))
+      {v | ∀ i, ofLex v i ≤ M} :=
+  fun _ ha _ hb hlex => lex_imp_lower_violations w M _ _ (fun i => ⟨ha i, hb i⟩) hw hlex
 
 /-- HG–OT agreement for a concrete candidate type: if candidate `a`
     lexicographically beats `b` on the violation profile induced by `ranking`,
@@ -535,5 +549,51 @@ theorem hg_strictly_contains_ot :
     · exact absurd hwW (by decide)
     · exact absurd h₁ (not_le.mpr hdom)
     · exact absurd h₂ (not_le.mpr hdom)
+
+/-! ### Realizability by a partial order -/
+
+namespace RealizationProblem
+
+/-- A grammar `r` **POC-realizes** the target if every consistent extension
+    realizes it. Since consistent extensions always exist
+    (`exists_isConsistent`), this is never vacuous. -/
+def realizedByPartialOrder (P : RealizationProblem Input Output n)
+    (r : Fin n → Fin n → Prop) : Prop :=
+  ∀ σ, IsConsistent r σ → P.realizedByRanking σ
+
+/-- A `RealizationProblem` is **POC-realizable** if some partial order
+    categorically realizes the target. -/
+def IsPartialOrderRealizable (P : RealizationProblem Input Output n) : Prop :=
+  ∃ r : Fin n → Fin n → Prop, IsPartialOrder (Fin n) r ∧ P.realizedByPartialOrder r
+
+end RealizationProblem
+
+/-! ### Containments — OT ⊆ POC, POC ⊆ OT (categorical) -/
+
+/-- Every partial-order-realized target is OT-realized, since any single
+    consistent extension realizes it. -/
+theorem RealizationProblem.IsPartialOrderRealizable.isOTRealizable
+    {P : RealizationProblem Input Output n}
+    (h : P.IsPartialOrderRealizable) : P.IsOTRealizable := by
+  obtain ⟨r, hpo, hreal⟩ := h
+  have := hpo
+  obtain ⟨σ, hσ⟩ := exists_isConsistent r
+  exact ⟨σ, hreal σ hσ⟩
+
+/-- Every OT-realized target is partial-order-realized — the witness is the
+    σ-induced total ranking, whose unique consistent extension is σ itself. -/
+theorem RealizationProblem.IsOTRealizable.isPartialOrderRealizable
+    {P : RealizationProblem Input Output n}
+    (h : P.IsOTRealizable) : P.IsPartialOrderRealizable := by
+  obtain ⟨σ, hσ⟩ := h
+  exact ⟨σ.toRel, inferInstance,
+    fun τ hτ => Ranking.toRel_le_toRel_iff.mp hτ ▸ hσ⟩
+
+/-- Under categorical realizability, OT and partial orders coincide; the
+    partial order's advantage is probabilistic, captured by `winProb`. -/
+theorem RealizationProblem.isOTRealizable_iff_isPartialOrderRealizable
+    (P : RealizationProblem Input Output n) :
+    P.IsOTRealizable ↔ P.IsPartialOrderRealizable :=
+  ⟨IsOTRealizable.isPartialOrderRealizable, IsPartialOrderRealizable.isOTRealizable⟩
 
 end HarmonicGrammar

--- a/Linglib/Phonology/OptimalityTheory/PartiallyOrderedConstraints.lean
+++ b/Linglib/Phonology/OptimalityTheory/PartiallyOrderedConstraints.lean
@@ -1,8 +1,8 @@
-import Linglib.Phonology.HarmonicGrammar.Expressivity
 import Linglib.Phonology.OptimalityTheory.ElementaryRankingCondition
 import Linglib.Phonology.OptimalityTheory.Antimatroid
 import Linglib.Phonology.OptimalityTheory.Grammar
 import Linglib.Core.Optimization.PermSubsetCombinatorics
+import Mathlib.Algebra.BigOperators.Field
 import Mathlib.Data.Prod.Basic
 import Mathlib.Order.Extension.Linear
 import Mathlib.Order.Preorder.Finite
@@ -47,10 +47,11 @@ theorems are a ℚ veneer over them.
   ([merchant-riggle-2016]; [prince-2002]). `toGrammar` routes POC through the
   `Grammar` hub, and `orderIdealAntimatroid` realizes the Birkhoff correspondence
   with order-ideal antimatroids ([dilworth-1940]).
-- `isOTRealizable_iff_isPartialOrderRealizable`: categorically, POC adds nothing over
-  OT. Its advantage is probabilistic — `winProb` produces intermediate
-  frequencies (e.g. [coetzee-pater-2011]'s 8/24 vs 12/24 t/d-deletion rates)
-  that no single ranking reproduces.
+- `winProb` produces intermediate frequencies (e.g. [coetzee-pater-2011]'s
+  8/24 vs 12/24 t/d-deletion rates) that no single ranking reproduces;
+  categorically, partial orders add nothing over OT
+  (`RealizationProblem.isOTRealizable_iff_isPartialOrderRealizable` in
+  `HarmonicGrammar.Expressivity`).
 - `winProb_discrete_binary_rate` / `winProb_stratified_binary_rate`:
   closed-form win rates for binary competitions. A ranking is decided by its
   earliest active constraint (`picksAt_binary_iff_head_mem_favoring`), so
@@ -66,9 +67,9 @@ mathlib's own idiom for orders treated as data (Szpilrajn's
 `extend_partialOrder`).
 -/
 
-namespace HarmonicGrammar
+namespace OptimalityTheory
 
-open Core.Optimization OptimalityTheory Finset
+open Core.Optimization Finset
 
 variable {n : ℕ}
 
@@ -366,58 +367,9 @@ def toGrammar (r : Fin n → Fin n → Prop) [IsPartialOrder (Fin n) r]
   show (Grammar.ofERCs (toERCs r) (toERCs_consistent r)).legs = consistentTotalOrders r
   rw [Grammar.legs_ofERCs, consistentTotalOrders_eq_linearExtensions]
 
-/-! ### Realizability by a partial order -/
-
-namespace RealizationProblem
-
-variable {Input Output : Type*}
-
-/-- A grammar `r` **POC-realizes** the target if every consistent extension
-    realizes it. Since consistent extensions always exist
-    (`exists_isConsistent`), this is never vacuous. -/
-def realizedByPartialOrder (P : RealizationProblem Input Output n)
-    (r : Fin n → Fin n → Prop) : Prop :=
-  ∀ σ, IsConsistent r σ → P.realizedByRanking σ
-
-/-- A `RealizationProblem` is **POC-realizable** if some partial order
-    categorically realizes the target. -/
-def IsPartialOrderRealizable (P : RealizationProblem Input Output n) : Prop :=
-  ∃ r : Fin n → Fin n → Prop, IsPartialOrder (Fin n) r ∧ P.realizedByPartialOrder r
-
-end RealizationProblem
-
-/-! ### Containments — OT ⊆ POC, POC ⊆ OT (categorical) -/
-
-variable {Input Output : Type*}
-
-/-- Every partial-order-realized target is OT-realized, since any single
-    consistent extension realizes it. -/
-theorem RealizationProblem.IsPartialOrderRealizable.isOTRealizable
-    {P : RealizationProblem Input Output n}
-    (h : P.IsPartialOrderRealizable) : P.IsOTRealizable := by
-  obtain ⟨r, hpo, hreal⟩ := h
-  have := hpo
-  obtain ⟨σ, hσ⟩ := exists_isConsistent r
-  exact ⟨σ, hreal σ hσ⟩
-
-/-- Every OT-realized target is partial-order-realized — the witness is the
-    σ-induced total ranking, whose unique consistent extension is σ itself. -/
-theorem RealizationProblem.IsOTRealizable.isPartialOrderRealizable
-    {P : RealizationProblem Input Output n}
-    (h : P.IsOTRealizable) : P.IsPartialOrderRealizable := by
-  obtain ⟨σ, hσ⟩ := h
-  exact ⟨σ.toRel, inferInstance,
-    fun τ hτ => Ranking.toRel_le_toRel_iff.mp hτ ▸ hσ⟩
-
-/-- Under categorical realizability, OT and partial orders coincide; the
-    partial order's advantage is probabilistic, captured by `winProb`. -/
-theorem RealizationProblem.isOTRealizable_iff_isPartialOrderRealizable
-    (P : RealizationProblem Input Output n) :
-    P.IsOTRealizable ↔ P.IsPartialOrderRealizable :=
-  ⟨IsOTRealizable.isPartialOrderRealizable, IsPartialOrderRealizable.isOTRealizable⟩
-
 /-! ### Probabilistic POC — winProb -/
 
+variable {Input Output : Type*}
 variable {cands : Input → Finset Output} {vp : Input → Output → Fin n → ℕ}
   {r : Fin n → Fin n → Prop} {σ : Ranking n} {i : Input} {o o' chosen other : Output}
 
@@ -709,4 +661,4 @@ theorem winProb_stratified_binary_rate
       (isConsistent_swap_mul h_triv (Finset.mem_filter.mp h₁).2 (Finset.mem_filter.mp h₂).2
         (mem_consistentTotalOrders.mp hσ))
 
-end HarmonicGrammar
+end OptimalityTheory

--- a/Linglib/Studies/Anttila1997.lean
+++ b/Linglib/Studies/Anttila1997.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
+import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Mathlib.Data.Fin.VecNotation
 
 /-!
@@ -88,7 +88,7 @@ mass for every motif (`sum_winProb_eq_one` substrate instance).
 
 namespace Anttila1997
 
-open HarmonicGrammar
+open OptimalityTheory
 
 /-! ### Variants and motifs -/
 
@@ -187,7 +187,7 @@ def vp : Motif → Variant → Fin 20 → ℕ
 /-- Probability that variant `v` wins motif `m` under uniform sampling of the
 total rankings consistent with `finnishGrammar`. -/
 def winProb (m : Motif) (v : Variant) : ℚ :=
-  HarmonicGrammar.winProb (fun _ => Finset.univ) vp finnishGrammar m v
+  OptimalityTheory.winProb (fun _ => Finset.univ) vp finnishGrammar m v
 
 /-- Bridge to the deciding-stratum closed form, shared by all twelve rate
 theorems. -/

--- a/Linglib/Studies/CoetzeePater2011.lean
+++ b/Linglib/Studies/CoetzeePater2011.lean
@@ -1,5 +1,5 @@
 import Linglib.Core.Optimization.System
-import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
+import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Core.Optimization.PermSubsetCombinatorics
 import Linglib.Phonology.Constraints.Basic
 import Linglib.Phonology.Constraints.Harmony
@@ -51,7 +51,7 @@ modeling phonological variation, illustrated with English t/d-deletion.
 namespace CoetzeePater2011
 
 open Constraints OptimalityTheory Core.Optimization Core.Optimization.Evaluation
-open Core.Optimization Constraints HarmonicGrammar
+open Core.Optimization Constraints
 open OptimalityTheory
 
 /-! ### Empirical data (tables 7 and 10) -/

--- a/Linglib/Studies/Zuraw2010.lean
+++ b/Linglib/Studies/Zuraw2010.lean
@@ -1,5 +1,5 @@
 import Linglib.Phonology.Constraints.Basic
-import Linglib.Phonology.HarmonicGrammar.PartiallyOrderedConstraints
+import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Core.Optimization.PermSubsetCombinatorics
 
 /-!
@@ -25,7 +25,7 @@ Constraints) substrate. For each stem-initial consonant `c`:
   computed from `vp` (`{i : vp c .yes i ≠ vp c .no i}` and
   `{i : vp c .yes i < vp c .no i}` respectively), with concrete
   `decide`-discharged values.
-- `subProb c : ℚ` is `HarmonicGrammar.winProb`
+- `subProb c : ℚ` is `OptimalityTheory.winProb`
   applied to the discrete partial order on `Fin 6` — i.e. uniform sampling
   over all 720 total orders.
 - The closed-form rate `|Y_c ∩ D_c| / |D_c|` follows by a single
@@ -94,7 +94,7 @@ those definitions must remain stable.
 namespace Zuraw2010
 
 open Constraints Core.Optimization Constraints OptimalityTheory OptimalityTheory
-open Core.Optimization HarmonicGrammar
+open Core.Optimization
 open Core.Optimization Core.Optimization.PermSubsetCombinatorics
 
 /-! ## § 0: Stems, Substitution Decisions, Dictionary Counts -/


### PR DESCRIPTION
Completes the HarmonicGrammar recut:

- `PartiallyOrderedConstraints.lean` → `Phonology/OptimalityTheory/`, namespace `HarmonicGrammar` → `OptimalityTheory`: POC is a ranking-based model — every load-bearing edge (Ranking, ERC, Antimatroid, Grammar) already pointed into the OT directory. Its partial-order realizability section moves to `Expressivity.lean` with the other framework comparisons, so POC no longer imports anything from `HarmonicGrammar` and the directory now means weighted grammars only (`Expressivity`, `NoisyHG`, `Separability`).
- New `strictMonoOn_weightedViolations` in `Expressivity`: the agreement kernel in its structural form — an exponentially separated weighting is strictly monotone from the lex order on the bounded fragment ([riggle-2009]'s order-preserving weight map, concretely), with `lex_imp_lower_violations` as its unfolding.