### PR TITLE
refactor(Phonology/Constraints): harmonic bounding via weightedViolations_mono

### DIFF
--- a/Linglib/Phonology/Constraints/Harmony.lean
+++ b/Linglib/Phonology/Constraints/Harmony.lean
@@ -9,22 +9,21 @@ import Mathlib.Algebra.Order.BigOperators.Group.Finset
 import Mathlib.Tactic.Ring
 
 /-!
-# Harmony evaluation lemmas
+# Harmony evaluation
 
-The reusable lemma layer over `harmonyScore`/`weightedViolations`
-(`Constraints.Defs`), shaped so Harmonic-Grammar study files reason about
-concrete grammars without hand-unfolding `Finset.sum`.
+Evaluation and order lemmas for `Constraints.harmonyScore` and
+`Constraints.weightedViolations`.
 
 ## Main results
 
-* `harmonyScore_cons` / `harmonyScore_nil`, `weightedViolations_cons` /
-  `weightedViolations_nil` — `@[simp]` cons-recursion that evaluates harmony on a
-  literal grammar `![C₀, …]` / `![w₀, …]` (fires only on `Matrix.vecCons`, so it is
-  inert on abstract `con`/`w`).
-* `harmonyScore_le_of_forall_le`, `harmonyDominates_of_lt` — **harmonic bounding**:
-  a candidate with pointwise-fewer violations under non-negative weights has at
-  least (resp. strictly greater) harmony. The Pareto argument most HG studies make,
-  stated directly over the violation profile rather than via the weighted sum.
+* `weightedViolations_cons`, `harmonyScore_cons`: `@[simp]` cons-recursion
+  evaluating harmony on literal grammars `![C₀, …]`, `![w₀, …]`.
+* `weightedViolations_mono`: for `0 ≤ w`, the weighted violation sum is
+  monotone in the violation profile.
+* `harmonyScore_le_of_forall_le`, `harmonyDominates_of_lt`: *harmonic
+  bounding* — a Pareto-dominant candidate has at least, and given a strict
+  advantage on a positively weighted constraint strictly greater, harmony
+  ([prince-smolensky-1993]).
 -/
 
 namespace Constraints
@@ -58,29 +57,34 @@ variable {C : Type*} {n : ℕ}
 
 variable {con : CON C n} {w : Fin n → ℝ} {a b : C}
 
-/-- **Harmonic bounding (weak)**: with non-negative weights, a candidate `a`
-that incurs no more violations than `b` on every constraint has at least `b`'s
-harmony. The monotone core of OT's harmonic-bounding argument. -/
-theorem harmonyScore_le_of_forall_le (hw : ∀ i, 0 ≤ w i)
-    (h : ∀ i, con i a ≤ con i b) :
-    harmonyScore con w b ≤ harmonyScore con w a := by
-  rw [harmonyScore_eq_neg_sum, harmonyScore_eq_neg_sum, neg_le_neg_iff]
-  exact Finset.sum_le_sum fun i _ =>
+/-- For non-negative weights, the weighted violation sum is monotone in the
+violation profile. -/
+theorem weightedViolations_mono (hw : 0 ≤ w) : Monotone (weightedViolations w) :=
+  fun _ _ h => Finset.sum_le_sum fun i _ =>
     mul_le_mul_of_nonneg_left (by exact_mod_cast h i) (hw i)
 
-/-- **Harmonic bounding (strict)**: with non-negative weights, if `a` incurs no
-more violations than `b` everywhere and strictly fewer on some positively-weighted
-constraint, then `a` strictly dominates `b` in harmony. Lets a study conclude
-`harmonyDominates con w a b` from a violation-profile comparison alone. -/
-theorem harmonyDominates_of_lt (hw : ∀ i, 0 ≤ w i)
-    (hle : ∀ i, con i a ≤ con i b)
-    (hlt : ∃ i, 0 < w i ∧ con i a < con i b) :
-    harmonyDominates con w a b := by
-  rw [harmonyDominates_iff, harmonyScore_eq_neg_sum, harmonyScore_eq_neg_sum,
-    neg_lt_neg_iff]
+/-- Pointwise `≤` with a strict advantage on a positively weighted coordinate
+gives a strictly smaller weighted violation sum. -/
+theorem weightedViolations_lt_weightedViolations {va vb : Fin n → ℕ} (hw : 0 ≤ w)
+    (hle : va ≤ vb) (hlt : ∃ i, 0 < w i ∧ va i < vb i) :
+    weightedViolations w va < weightedViolations w vb := by
   obtain ⟨j, hwj, hvj⟩ := hlt
-  refine Finset.sum_lt_sum (fun i _ =>
-    mul_le_mul_of_nonneg_left (by exact_mod_cast hle i) (hw i)) ⟨j, Finset.mem_univ j, ?_⟩
-  exact mul_lt_mul_of_pos_left (by exact_mod_cast hvj) hwj
+  exact Finset.sum_lt_sum
+    (fun i _ => mul_le_mul_of_nonneg_left (by exact_mod_cast hle i) (hw i))
+    ⟨j, Finset.mem_univ j, mul_lt_mul_of_pos_left (by exact_mod_cast hvj) hwj⟩
+
+/-- Harmonic bounding: with non-negative weights, a candidate incurring no more
+violations than `b` on every constraint has at least `b`'s harmony
+([prince-smolensky-1993]). -/
+theorem harmonyScore_le_of_forall_le (hw : 0 ≤ w) (h : ∀ i, con i a ≤ con i b) :
+    harmonyScore con w b ≤ harmonyScore con w a :=
+  neg_le_neg (weightedViolations_mono hw h)
+
+/-- Strict harmonic bounding: strictly fewer violations on some positively
+weighted constraint gives strictly greater harmony. -/
+theorem harmonyDominates_of_lt (hw : 0 ≤ w) (hle : ∀ i, con i a ≤ con i b)
+    (hlt : ∃ i, 0 < w i ∧ con i a < con i b) :
+    harmonyDominates con w a b :=
+  neg_lt_neg (weightedViolations_lt_weightedViolations hw hle hlt)
 
 end Constraints


### PR DESCRIPTION
Factors the two harmonic-bounding proofs through their shared core: `weightedViolations_mono` (for `0 ≤ w`, the weighted violation sum is monotone in the profile — the pointwise companion to Expressivity's lex-monotonicity `strictMonoOn_weightedViolations`) and its strict form, so `harmonyScore_le_of_forall_le` / `harmonyDominates_of_lt` become `neg_le_neg` / `neg_lt_neg` one-liners. Nonnegativity restated as `0 ≤ w` in the Pi order; module docstring moved to textbook register.