### PR TITLE
chore(Phonology/HarmonicGrammar): NoisyHG.lean as Noise.lean

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1312,7 +1312,7 @@ import Linglib.Phonology.Constraints.Directional
 import Linglib.Phonology.Constraints.Lift
 import Linglib.Phonology.Constraints.Profile
 import Linglib.Phonology.HarmonicGrammar.Expressivity
-import Linglib.Phonology.HarmonicGrammar.NoisyHG
+import Linglib.Phonology.HarmonicGrammar.Noise
 import Linglib.Phonology.Hiatus
 import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Phonology.Constraints.Harmony

--- a/Linglib/Phonology/HarmonicGrammar/Noise.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Noise.lean
@@ -3,8 +3,12 @@ import Linglib.Core.Probability.RandomUtility
 import Linglib.Core.Probability.LogitChoice
 
 /-!
-# Noisy Harmonic Grammar and Normal MaxEnt
-[boersma-pater-2016] [flemming-2021]
+# Harmony under noise
+
+The stochastic readings of harmonic grammar: injecting noise into harmony
+evaluation turns the argmax into a choice probability. Gaussian noise gives
+the probit models (Noisy HG, Normal MaxEnt); Gumbel noise gives MaxEnt's
+softmax, whose logit identities close the family.
 
 Noisy HG ([boersma-pater-2016]) adds i.i.d. Gaussian noise N(0,σ²) to
 each constraint weight before evaluation. For binary choice between

--- a/Linglib/Phonology/HarmonicGrammar/Separability.lean
+++ b/Linglib/Phonology/HarmonicGrammar/Separability.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.HarmonicGrammar.NoisyHG
+import Linglib.Phonology.HarmonicGrammar.Noise
 
 /-!
 # Separable Harmonies and HZ's Generalization [magri-2025]
@@ -37,7 +37,7 @@ a single constraint.
 
 ## Connection to existing infrastructure
 
-The forward direction leverages `logit_uniformity` (in `NoisyHG.lean`)
+The forward direction leverages `logit_uniformity` (in `Noise.lean`)
 and `maxent_logit_harmony`, which already prove that MaxEnt log-odds
 equal harmony score differences. [magri-2025]'s contribution is
 showing this is *the only* mode of constraint interaction with this

--- a/Linglib/Studies/Flemming2021.lean
+++ b/Linglib/Studies/Flemming2021.lean
@@ -1,4 +1,4 @@
-import Linglib.Phonology.HarmonicGrammar.NoisyHG
+import Linglib.Phonology.HarmonicGrammar.Noise
 import Linglib.Phonology.HarmonicGrammar.Separability
 import Linglib.Phonology.Constraints.Defs
 import Linglib.Core.Probability.Choice.GumbelLuce
@@ -222,7 +222,7 @@ theorem clash_increases_schwa (pair : Fin 4) :
 /-- Sum of squared violation differences for a context.
 
     This is the study-local analogue of `violationDiffSqSumQ` from
-    `NoisyHG.lean`: both compute `Σⱼ (cⱼ(ə) − cⱼ(∅))²`, but `schwaSqSum`
+    `Noise.lean`: both compute `Σⱼ (cⱼ(ə) − cⱼ(∅))²`, but `schwaSqSum`
     operates on the pre-computed difference matrix `schwaDiff` (Table (35))
     rather than a `CON` constraint set. -/
 def schwaSqSum (ctx : Fin 8) : Nat :=


### PR DESCRIPTION
`HarmonicGrammar.NoisyHG` stuttered (the `HG` expands to the directory name) and misdescribed the content: the file holds three noise readings of harmony — Noisy HG (Gaussian on weights), Normal MaxEnt (Gaussian on scores), and the MaxEnt logit-harmony identities (Gumbel) — not just the first. Now `Noise.lean`, with the module docstring opening on the shared subject (noise turns the harmony argmax into a choice probability). Declaration names (`nhgChoiceProb`, …) unchanged — there "NHG" names the specific Boersma–Pater framework, per the literature.