### PR TITLE
refactor(Tense/Decomposition): content names, drop vacuous theorems

### DIFF
--- a/Linglib/Fragments/English/Tense.lean
+++ b/Linglib/Fragments/English/Tense.lean
@@ -86,44 +86,44 @@ def nonfutureEntries : List TAMEEntry :=
   allEntries.filter (decide ·.IsNonfuture)
 
 -- ════════════════════════════════════════════════════
--- § 6. Kratzer Decomposition ([kratzer-1998])
+-- § 6. Surface Tense ([kratzer-1998])
 -- ════════════════════════════════════════════════════
 
 open _root_.Tense.Decomposition
 open _root_.Tense
 
-/-- English simple past: Kratzer decomposition.
+/-- English simple past: surface-tense decomposition.
     Surface "V-ed" = PRESENT tense + PERFECT aspect.
     The tense head is present (indexical), so the form can be
     used deictically ("out of the blue"). -/
-def kratzerSimplePast : KratzerDecomposition where
-  tensePronoun := kratzerEnglishPast
+def simplePastSurface : SurfaceTense where
+  tensePronoun := indexicalPresent
   hasPerfect := true
 
 /-- English present perfect: no decomposition mismatch.
     Surface "have V-ed" = PRESENT tense + PERFECT aspect.
     Identical underlying structure to simple past — the difference
     is that the present perfect is morphologically transparent. -/
-def kratzerPresentPerfect : KratzerDecomposition where
-  tensePronoun := kratzerEnglishPast
+def presentPerfectSurface : SurfaceTense where
+  tensePronoun := indexicalPresent
   hasPerfect := true
 
 /-- English simple past can be deictic (from decomposition). -/
-theorem kratzerSimplePast_deictic :
-    kratzerSimplePast.canBeDeictic := by decide
+theorem simplePastSurface_deictic :
+    simplePastSurface.canBeDeictic := by decide
 
 /-- The underlying tense head is PRESENT, not PAST.
     Pastness comes from the PERF aspect head, not the tense. -/
-theorem kratzerSimplePast_underlyingPresent :
-    kratzerSimplePast.tensePronoun.constraint = _root_.Tense.present := rfl
+theorem simplePastSurface_underlyingPresent :
+    simplePastSurface.tensePronoun.constraint = _root_.Tense.present := rfl
 
 /-- Simple past and present perfect share the same underlying decomposition:
     both are PRESENT + PERFECT. The difference is that simple past fuses
     the two morphemes while present perfect makes the PERF transparent
     via auxiliary "have". -/
 theorem simplePast_presentPerfect_same_decomposition :
-    kratzerSimplePast.tensePronoun = kratzerPresentPerfect.tensePronoun ∧
-    kratzerSimplePast.hasPerfect = kratzerPresentPerfect.hasPerfect :=
+    simplePastSurface.tensePronoun = presentPerfectSurface.tensePronoun ∧
+    simplePastSurface.hasPerfect = presentPerfectSurface.hasPerfect :=
   ⟨rfl, rfl⟩
 
 end English.Tense

--- a/Linglib/Fragments/German/Tense.lean
+++ b/Linglib/Fragments/German/Tense.lean
@@ -33,21 +33,21 @@ open _root_.Tense
 open _root_.Tense.Decomposition
 
 -- ════════════════════════════════════════════════════
--- § 1. Kratzer Decomposition Entries
+-- § 1. Surface Tense Entries
 -- ════════════════════════════════════════════════════
 
 /-- German Preterit (Präteritum): genuine PAST pronoun.
     Anaphoric — requires a discourse-established temporal antecedent.
     No PERF aspect head intervenes; the pastness is in the tense itself. -/
-def kratzerPreterit : KratzerDecomposition where
-  tensePronoun := kratzerGermanPreterit 1
+def preteritSurface : SurfaceTense where
+  tensePronoun := anaphoricPast 1
   hasPerfect := false
 
 /-- German Perfekt (present perfect): PRESENT tense + PERFECT aspect.
     Parallel structure to English simple past. Can be used deictically
     because the tense head is present (indexical). -/
-def kratzerPerfekt : KratzerDecomposition where
-  tensePronoun := { varIndex := 0, constraint := Tense.present, mode := .indexical }
+def perfektSurface : SurfaceTense where
+  tensePronoun := indexicalPresent
   hasPerfect := true
 
 -- ════════════════════════════════════════════════════
@@ -56,31 +56,31 @@ def kratzerPerfekt : KratzerDecomposition where
 
 /-- German Preterit cannot be deictic. -/
 theorem preterit_not_deictic :
-    ¬ kratzerPreterit.canBeDeictic := by decide
+    ¬ preteritSurface.canBeDeictic := by decide
 
 /-- German Perfekt CAN be deictic. -/
 theorem perfekt_deictic :
-    kratzerPerfekt.canBeDeictic := by decide
+    perfektSurface.canBeDeictic := by decide
 
 /-- The Preterit–Perfekt contrast: different underlying tense heads.
     Preterit has a PAST head (anaphoric); Perfekt has PRESENT + PERF (indexical).
     Both can refer to past events, but only Perfekt is deictic-compatible.
     This explains why Perfekt has largely replaced Preterit in spoken German. -/
 theorem preterit_perfekt_contrast :
-    kratzerPreterit.tensePronoun.constraint = Tense.past ∧
-    kratzerPerfekt.tensePronoun.constraint = Tense.present ∧
-    ¬ kratzerPreterit.canBeDeictic ∧
-    kratzerPerfekt.canBeDeictic := by
+    preteritSurface.tensePronoun.constraint = Tense.past ∧
+    perfektSurface.tensePronoun.constraint = Tense.present ∧
+    ¬ preteritSurface.canBeDeictic ∧
+    perfektSurface.canBeDeictic := by
   refine ⟨rfl, rfl, ?_, ?_⟩ <;> decide
 
 /-- German Preterit is always overt (anaphoric = free). -/
 theorem preterit_always_overt (localDomain : Bool) :
-    kratzerPreterit.tenseOvertness localDomain = .overt := by
+    preteritSurface.tenseOvertness localDomain = .overt := by
   cases localDomain <;> rfl
 
 /-- German Perfekt tense head is always overt (indexical = free). -/
 theorem perfekt_always_overt (localDomain : Bool) :
-    kratzerPerfekt.tenseOvertness localDomain = .overt := by
+    perfektSurface.tenseOvertness localDomain = .overt := by
   cases localDomain <;> rfl
 
 end German.Tense

--- a/Linglib/Fragments/Italian/Tense.lean
+++ b/Linglib/Fragments/Italian/Tense.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Tense.Evidential
-import Linglib.Semantics.Tense.Decomposition
 
 /-! # Italian Tense Fragment
 
@@ -36,8 +35,6 @@ open Tense
 namespace Italian.Tense
 
 open _root_.Tense.Evidential
-open _root_.Tense.Decomposition
-open _root_.Tense
 open _root_.Tense
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Semantics/Tense/Decomposition.lean
+++ b/Linglib/Semantics/Tense/Decomposition.lean
@@ -1,62 +1,34 @@
 import Linglib.Semantics.Tense.Basic
-import Linglib.Semantics.Tense.TenseAspectComposition
 
 /-!
-# [kratzer-1998]: More Structural Analogies Between Pronouns and Tenses
-[kratzer-1998] [klein-1994] [partee-1973]
+# Tense decomposition and SOT deletion
 
-[kratzer-1998] extends [partee-1973]'s tense–pronoun analogy in three
-directions beyond the shared indexical/anaphoric/bound classification:
+[kratzer-1998]'s architecture relating tense morphology to underlying
+tense–aspect structure, extending [partee-1973]'s tense–pronoun analogy.
+A surface tense form is a `SurfaceTense`: an underlying tense pronoun plus
+an optional PERFECT aspect head. The three pronoun values the account uses
+are `indexicalPresent` (the head of the English simple past — pastness from
+PERF, hence deictic), `anaphoricPast` (the German Preterit — requires a
+discourse antecedent), and `boundPresent` (zero tense — locally bound,
+surfaces as zero via `Overtness`). SOT deletion (`sotDeletionApplicable`,
+`applyDeletion`) deletes an embedded tense under morphological identity with
+the matrix, leaving the embedded clause temporally dependent on the matrix
+event time (`applyDeletion_isPresent`).
 
-## Core Contributions
-
-1. **Aspect decomposition of English simple past** (§4): English "simple past"
-   is morphologically fused but semantically = PRESENT tense + PERFECT aspect.
-   This explains why English past can be used "out of the blue" (deictically):
-   the tense head is PRESENT (indexical). German Preterit is a genuine PAST
-   pronoun (anaphoric — requires a discourse antecedent).
-
-2. **SOT deletion** (§5): the simultaneous reading under attitude embedding
-   arises from morphological identity triggering optional deletion of the
-   embedded tense, leaving the embedded clause tenseless (hence simultaneous).
-   Past is NEVER ambiguous — it always encodes temporal precedence.
-
-3. **Zero forms and locality** (§3): zero (phonologically empty) pronouns and
-   tenses are licensed when a referential expression is locally bound by an
-   agreeing head. This unifies zero tense under SOT, Japanese pro-drop, and
-   reflexive reduction, and explains why Persian has zero pronouns but NOT
-   zero tense (tense is in C, outside the local agreement domain of Agr/Infl).
-
-4. **Reflexive ↔ simultaneous parallel** (§3): reflexive pronouns = locally
-   bound zero pronouns; simultaneous tense = locally bound zero tense.
-   Same locality condition, different referential domains.
-
-## Key Distinction from Ogihara
-
-Kratzer and Ogihara make the same SOT predictions (both derive shifted
-and simultaneous readings) but differ on what "past" means:
-- Kratzer: past is NEVER ambiguous; simultaneous = deletion of past
-- Ogihara: past IS ambiguous; simultaneous = zero-tense reading of past
-
+The paper-attributed predictions, the Fragment instances, and the
+divergence from [ogihara-1996] live in `Studies/Kratzer1998.lean`.
 -/
-
-open Time
 
 namespace Tense.Decomposition
 
-open Tense
+open Time Tense
 
+/-! ### SOT deletion -/
 
-/-! ### SOT Deletion -/
-
-/-- Kratzer's SOT deletion: when embedded tense morphology is identical
-    to matrix tense morphology, the embedded tense can be optionally
-    deleted, making the embedded clause temporally dependent on the
-    matrix event time.
-
-    `matrixTense`: the tense of the matrix clause
-    `embeddedTense`: the tense of the embedded clause
-    Returns whether deletion is possible. -/
+/-- [kratzer-1998]'s SOT deletion condition: an embedded tense whose
+    morphology is identical to the matrix tense can be optionally deleted,
+    making the embedded clause temporally dependent on the matrix event
+    time. -/
 def sotDeletionApplicable (matrixTense embeddedTense : Finset Ordering) : Bool :=
   decide (matrixTense = embeddedTense)
 
@@ -64,232 +36,92 @@ def sotDeletionApplicable (matrixTense embeddedTense : Finset Ordering) : Bool :
 theorem past_past_deletion :
     sotDeletionApplicable past past = true := by decide
 
-/-- Deletion is NOT applicable for present-under-past (no morphological
+/-- Deletion is not applicable for present-under-past (no morphological
     identity between present and past). -/
 theorem present_past_no_deletion :
     sotDeletionApplicable past present = false := by decide
 
-/-- When SOT deletion applies, the embedded reference time becomes
-    the matrix event time (the embedded clause inherits matrix temporal
-    coordinates). -/
+/-- The embedded frame after SOT deletion: the embedded reference time
+    becomes the matrix event time (the embedded clause inherits the matrix
+    temporal coordinates). -/
 def applyDeletion {Time : Type*}
     (matrixFrame : ReichenbachFrame Time) : ReichenbachFrame Time where
   speechTime := matrixFrame.speechTime
   perspectiveTime := matrixFrame.eventTime
-  referenceTime := matrixFrame.eventTime  -- R' = E_matrix after deletion
+  referenceTime := matrixFrame.eventTime
   eventTime := matrixFrame.eventTime
 
-/-- Kratzer's deletion and the SOT `simultaneousFrame` agree definitionally:
-    deleting the embedded tense yields exactly the simultaneous-reading frame
-    whose embedded event time is the matrix event time. This is the formal
-    core of the Kratzer/Ogihara "same predictions" agreement — the two
-    accounts build the same embedded frame by different mechanisms. -/
+/-- Deletion and the SOT `simultaneousFrame` agree definitionally: deleting
+    the embedded tense yields exactly the simultaneous-reading frame whose
+    embedded event time is the matrix event time — the formal core of the
+    Kratzer/Ogihara "same predictions" agreement. -/
 theorem applyDeletion_eq_simultaneousFrame {Time : Type*}
     (matrixFrame : ReichenbachFrame Time) :
     applyDeletion matrixFrame = simultaneousFrame matrixFrame matrixFrame.eventTime :=
   rfl
 
-
-/-! ### Derivation Theorems -/
-
-/-- Kratzer derives the simultaneous reading via SOT deletion.
-    When deletion applies, R' = E_matrix, giving the PRESENT relation. -/
-theorem kratzer_derives_simultaneous {Time : Type*}
+/-- Deletion derives the simultaneous reading: after deletion the embedded
+    reference time is the matrix event time, the PRESENT relation. -/
+theorem applyDeletion_isPresent {Time : Type*}
     (matrixFrame : ReichenbachFrame Time) :
     (applyDeletion matrixFrame).isPresent := rfl
 
-/-- Kratzer derives the shifted reading: genuine past (no deletion).
-    When deletion does not apply (or is not chosen), the embedded
-    past tense contributes its own temporal precedence. -/
-theorem kratzer_derives_shifted {Time : Type*} [LinearOrder Time]
-    (matrixFrame : ReichenbachFrame Time) (embeddedR embeddedE : Time)
-    (hPast : embeddedR < matrixFrame.eventTime) :
-    (embeddedFrame matrixFrame embeddedR embeddedE).isPast := by
-  simp only [embeddedFrame, ReichenbachFrame.isPast_def]
-  exact hPast
+/-! ### Surface tense -/
 
-/-- SOT deletion yields the simultaneous reading: R' = E_matrix. -/
-theorem kratzer_deletion_yields_simultaneous {Time : Type*}
-    (matrixFrame : ReichenbachFrame Time) :
-    (applyDeletion matrixFrame).referenceTime = matrixFrame.eventTime :=
-  rfl
-
-/-! ### Tense Decomposition Structure -/
-
-/-- Kratzer's decomposition of surface tense morphology into
-    underlying tense head + optional aspect head ([kratzer-1998] §4).
-
-    The key insight: surface morphology can fuse tense and aspect,
-    hiding the underlying tense head. English "simple past" fuses
-    PRESENT + PERFECT; German Preterit is a bare PAST. Surface-form
-    metadata (language, orthographic shape) lives with the Fragment
-    entries that instantiate this structure, not here. -/
-structure KratzerDecomposition where
+/-- [kratzer-1998] §4's decomposition of a surface tense form: an
+    underlying tense pronoun plus an optional PERFECT aspect head between
+    VP and Tense. Surface morphology can fuse the two (English simple past
+    = `indexicalPresent` + PERFECT); surface-form metadata lives with the
+    Fragment entries that instantiate this structure. -/
+structure SurfaceTense where
   /-- The underlying tense pronoun (tense head proper) -/
   tensePronoun : TensePronoun
   /-- Whether a PERFECT aspect head intervenes between VP and Tense -/
   hasPerfect : Bool
   deriving DecidableEq
 
-/-- Can this form be used deictically ("out of the blue")?
-    Derived: indexical tense head → deictic-compatible. -/
-def KratzerDecomposition.canBeDeictic (d : KratzerDecomposition) : Prop :=
+/-- A surface form can be used deictically ("out of the blue") iff its
+    tense head is indexical. -/
+def SurfaceTense.canBeDeictic (d : SurfaceTense) : Prop :=
   d.tensePronoun.isIndexical
 
-instance (d : KratzerDecomposition) : Decidable d.canBeDeictic :=
+instance (d : SurfaceTense) : Decidable d.canBeDeictic :=
   inferInstanceAs (Decidable d.tensePronoun.isIndexical)
 
 /-- Phonological overtness of the tense head, given locality. -/
-def KratzerDecomposition.tenseOvertness (d : KratzerDecomposition)
+def SurfaceTense.tenseOvertness (d : SurfaceTense)
     (localDomain : Bool) : Overtness :=
   Overtness.fromBinding d.tensePronoun.mode localDomain
 
+/-! ### The tense pronouns -/
 
-/-! ### Aspect Decomposition: English Simple Past = PRES + PERF -/
-
-/-! Kratzer (1998 §4): English "simple past" is morphologically fused but
-semantically decomposes into PRESENT tense + PERFECT aspect. The tense head
-is present (indexical, anchored to speech time); the aspect head (PERF)
-introduces temporal precedence. This is literally `presPerfSimple` from
-`TenseAspectComposition.lean`.
-
-German Preterit, by contrast, has a genuine PAST tense head with no
-intervening PERF. The PAST pronoun is anaphoric — it requires a
-discourse-salient temporal antecedent. This explains the striking contrast:
-
-  English: "I didn't turn off the stove." ✓ (out of the blue — deictic)
-  German: #"Ich schaltete den Herd nicht aus." ✗ (needs narrative context)
-  German: "Ich habe den Herd nicht ausgeschaltet." ✓ (present perfect ok) -/
-
-open Tense.TenseAspectComposition
-open Semantics.Aspect
-
-/-- Kratzer's English simple past = PRESENT tense + PERFECT aspect.
-    The tense head is PRESENT (indexical-compatible), so the surface form
-    can be used deictically. Pastness comes from the PERF aspect head. -/
-def kratzerEnglishPast : TensePronoun where
+/-- The indexical PRESENT pronoun — [kratzer-1998] §4's tense head of the
+    English simple past (and German Perfekt): pastness comes from the
+    PERFECT aspect head, so the form can be used deictically ("out of the
+    blue"). English simple past and present perfect share this head; they
+    differ only in whether the PERF is morphologically fused. -/
+def indexicalPresent : TensePronoun where
   varIndex := 0
-  constraint := present   -- KEY: present, not past!
-  mode := .indexical        -- Can be deictic ("out of the blue")
+  constraint := present
+  mode := .indexical
 
-/-- German Preterit: a genuine PAST pronoun.
-    Must be anaphoric — requires a discourse-established temporal antecedent.
-    Cannot be used "out of the blue" in modern German. -/
-def kratzerGermanPreterit (n : ℕ) : TensePronoun where
+/-- The anaphoric PAST pronoun — the German Preterit: a genuine past
+    requiring a discourse-established temporal antecedent, so it cannot be
+    used "out of the blue". -/
+def anaphoricPast (n : ℕ) : TensePronoun where
   varIndex := n
-  constraint := past       -- Genuine past
-  mode := .anaphoric         -- Must find antecedent in discourse
+  constraint := past
+  mode := .anaphoric
 
-/-- English simple past has PRESENT tense constraint.
-    Pastness is in the aspect (PERF), not the tense head. -/
-theorem english_past_is_present :
-    kratzerEnglishPast.constraint = present := rfl
-
-/-- German Preterit has PAST tense constraint. -/
-theorem german_preterit_is_past (n : ℕ) :
-    (kratzerGermanPreterit n).constraint = past := rfl
-
-/-- English simple past is indexical-compatible: can be used "out of the blue."
-    German Preterit forces anaphoric mode: cannot be used "out of the blue." -/
-theorem english_deictic_german_anaphoric (n : ℕ) :
-    kratzerEnglishPast.isIndexical ∧
-    ¬ (kratzerGermanPreterit n).isIndexical :=
-  ⟨by decide, nofun⟩
-
-/-- Kratzer's aspect decomposition bridge: the English simple past
-    (PRESENT + PERFECT) maps to `presPerfSimple` from the compositional
-    tense–aspect pipeline. The PRESENT tense head contributes `evalPres`;
-    the PERFECT aspect head contributes `PERF (PRFV V)`.
-
-    `presPerfSimple V tc w = evalPres (PERF (PRFV V)) tc w`
-
-    This is the central prediction: English simple past and English
-    present perfect have the SAME compositional semantics. They differ
-    only in whether the PERF is morphologically fused or transparent. -/
-theorem english_past_eq_presPerfSimple {W Time : Type*} [LinearOrder Time]
-    (V : W → Event Time → Prop) (tc : Time) (w : W) :
-    presPerfSimple V tc w ↔
-    ∃ pts : NonemptyInterval Time, RB pts tc ∧ PRFV V w pts := Iff.rfl
-
-/-- German Preterit maps to `simplePast` from the pipeline: genuine
-    past tense (existential over past times) + perfective aspect. -/
-theorem german_preterit_eq_simplePast {W Time : Type*} [LinearOrder Time]
-    (V : W → Event Time → Prop) (tc : Time) (w : W) :
-    simplePast V tc w ↔
-    ∃ t : Time, t < tc ∧ PRFV V w (NonemptyInterval.pure t) := Iff.rfl
-
-
-/-! ### Zero Tense and Locality -/
-
-/-! Kratzer (1998 §3): zero (phonologically empty) referential expressions
-arise when a bound variable is in a local agreement domain. This applies
-uniformly to pronouns and tenses:
-
-  - Zero tense under SOT: the embedded tense is locally bound by the
-    attitude verb's Agr → surfaces as ∅
-  - Japanese subject pro: locally bound by Agr → surfaces as ∅
-  - Persian: zero PRONOUNS (locally bound by Agr) but NOT zero TENSE
-    (tense is in C, outside the local domain of Agr in Infl)
-
-The distribution of overt vs. zero follows from `Overtness`. -/
-
-/-- Zero tense: a bound present tense in a local agreement domain.
-
-    Under SOT in English, the embedded "past" morphology is analyzed as
-    a locally bound PRESENT tense that surfaces as zero because of
-    agreement locality. This is Kratzer's alternative to Ogihara's
-    zero-tense ambiguity: the "zero" isn't an ambiguity of PAST — it's
-    a genuinely different morpheme (bound PRESENT) licensed by locality. -/
-def kratzerZeroTense (n : ℕ) : TensePronoun where
+/-- The bound PRESENT pronoun — [kratzer-1998] §3's zero tense: locally
+    bound by the attitude verb's agreement head, it surfaces as zero
+    (`Overtness.fromBinding`), by the same locality that reduces locally
+    bound entity pronouns to reflexives. This is Kratzer's alternative to
+    [ogihara-1996]'s ambiguous past: the "zero" is not a reading of PAST
+    but a distinct bound PRESENT morpheme. -/
+def boundPresent (n : ℕ) : TensePronoun where
   varIndex := n
-  constraint := present    -- Present, not past
-  mode := .bound            -- Locally bound → surfaces as zero
-
-/-- Zero tense has present constraint (not past).
-    Past is NEVER zero/ambiguous in Kratzer's theory. -/
-theorem zero_tense_is_present (n : ℕ) :
-    (kratzerZeroTense n).constraint = present := rfl
-
-/-- Zero tense surfaces as zero (from Overtness). -/
-theorem zero_tense_overtness (n : ℕ) :
-    Overtness.fromBinding (kratzerZeroTense n).mode true = .zero := rfl
-
-
-/-! ### Reflexive ↔ Simultaneous Parallel -/
-
-/-! Kratzer (1998 §3) draws an explicit structural parallel between
-reflexive binding and simultaneous tense:
-
-  - Reflexive pronouns = locally bound entity pronouns → zero/reduced form
-  - Simultaneous tense = locally bound temporal pronoun → zero tense
-
-Both are instances of the same generalization: local binding by an
-agreeing head yields a phonologically reduced (zero) referential expression.
-The locality condition is the same; only the domain differs (entities
-vs. times). -/
-
-/-- The reflexive ↔ simultaneous parallel: both are locally bound
-    referential expressions that surface as zero.
-
-    Left conjunct: zero tense is bound (like a reflexive).
-    Right conjunct: it surfaces as zero (like reflexive morphology). -/
-theorem reflexive_simultaneous_parallel (n : ℕ) :
-    (kratzerZeroTense n).isBound ∧
-    Overtness.fromBinding (kratzerZeroTense n).mode true = .zero :=
-  ⟨rfl, rfl⟩
-
-/-- The German Preterit is NOT zero-compatible: it's free (anaphoric),
-    so it surfaces as overt morphology regardless of locality.
-    This parallels overt (non-reflexive) pronouns. -/
-theorem german_preterit_always_overt (n : ℕ) (localDomain : Bool) :
-    Overtness.fromBinding (kratzerGermanPreterit n).mode localDomain = .overt := by
-  cases localDomain <;> rfl
-
-/-- English indexical tense is also always overt: free expressions
-    surface as overt regardless of locality. -/
-theorem english_indexical_always_overt (localDomain : Bool) :
-    Overtness.fromBinding kratzerEnglishPast.mode localDomain = .overt := by
-  cases localDomain <;> rfl
-
+  constraint := present
+  mode := .bound
 
 end Tense.Decomposition

--- a/Linglib/Studies/Kratzer1998.lean
+++ b/Linglib/Studies/Kratzer1998.lean
@@ -14,15 +14,15 @@ import Linglib.Data.Examples.Kratzer1998
 tense–pronoun analogy in three directions: an aspect-based decomposition
 of English simple past, SOT deletion via zero tenses, and zero forms with
 locality constraints. The substrate machinery (deletion mechanism +
-Kratzer-named lexical entries used by Fragments) is at
+tense pronouns used by Fragments) is at
 `Semantics/Tense/Decomposition.lean`; this study file
 collects the paper-anchored cross-references and the empirical chain
 theorems connecting Fragments → Theory → Data → Empirical judgments.
 
 ## Architectural note
 
-The `kratzerEnglishPast` / `kratzerGermanPreterit` / `kratzerZeroTense`
-lexical entries live at the Theories layer
+The `indexicalPresent` / `anaphoricPast` / `boundPresent`
+tense pronouns live at the Theories layer
 (`Tense/Decomposition.lean`) because
 `Fragments/{English,German,Italian}/Tense.lean` consume them via the
 `Fragments → Theories` import direction. The "Fragments import
@@ -68,17 +68,17 @@ Reichenbach integers). The empirical anchor is now the
 numbered example, which is verifiable from the paper itself.
 
 Predictions tested:
-- `kratzerSimplePast.canBeDeictic = true` ↔ `Examples.ex40a.judgment = .acceptable`
+- `simplePastSurface.canBeDeictic = true` ↔ `Examples.ex40a.judgment = .acceptable`
   (English simple past, out of the blue).
-- `kratzerPreterit.canBeDeictic = false` ↔ `Examples.ex40b.judgment = .ungrammatical`
+- `preteritSurface.canBeDeictic = false` ↔ `Examples.ex40b.judgment = .ungrammatical`
   (German Präteritum, out of the blue).
-- `kratzerPerfekt.canBeDeictic = true` ↔ `Examples.ex40c.judgment = .acceptable`
+- `perfektSurface.canBeDeictic = true` ↔ `Examples.ex40c.judgment = .acceptable`
   (German Perfekt, out of the blue). -/
 
 section KratzerChain
 
-open English.Tense (kratzerSimplePast)
-open German.Tense (kratzerPreterit kratzerPerfekt)
+open English.Tense (simplePastSurface)
+open German.Tense (preteritSurface perfektSurface)
 open Features (Judgment)
 
 /-- **English simple past = perfect + present.** Per Kratzer §7
@@ -91,20 +91,20 @@ open Features (Judgment)
     out-of-the-blue example (40a) ("Who built this Church?…") is
     `.acceptable`. -/
 theorem english_simple_past_chain :
-    kratzerSimplePast.tensePronoun.constraint = Tense.present ∧
-    kratzerSimplePast.hasPerfect = true ∧
+    simplePastSurface.tensePronoun.constraint = Tense.present ∧
+    simplePastSurface.hasPerfect = true ∧
     Examples.ex40a.judgment = Judgment.acceptable :=
   ⟨rfl, rfl, rfl⟩
 
 /-- **German Preterit = genuine past pronoun.** Per Kratzer §7
     (ex (40b), p. 16): the German Präteritum requires a contextually
     salient past time, behaving like an anaphoric pronoun. The Fragment
-    encodes this as `kratzerPreterit.tensePronoun.constraint = .past`
+    encodes this as `preteritSurface.tensePronoun.constraint = .past`
     + `hasPerfect = false`; the empirical anchor is `Examples.ex40b`
     (deviant out of the blue, star per Kratzer). -/
 theorem german_preterit_chain :
-    kratzerPreterit.tensePronoun.constraint = Tense.past ∧
-    kratzerPreterit.hasPerfect = false ∧
+    preteritSurface.tensePronoun.constraint = Tense.past ∧
+    preteritSurface.hasPerfect = false ∧
     Examples.ex40b.judgment = Judgment.ungrammatical :=
   ⟨rfl, rfl, rfl⟩
 
@@ -113,26 +113,30 @@ theorem german_preterit_chain :
     fills the deictic-past slot that the Preterit cannot. The chain
     asserts BOTH the empirical agreement on (40c) AND the cross-Fragment
     parallelism (Perfekt's tense head + perfect-aspect coincide with
-    `kratzerSimplePast`'s), which is the substantive content of "same
+    `simplePastSurface`'s), which is the substantive content of "same
     decomposition." -/
 theorem german_perfekt_chain :
-    kratzerPerfekt.tensePronoun.constraint = Tense.present ∧
-    kratzerPerfekt.hasPerfect = true ∧
+    perfektSurface.tensePronoun.constraint = Tense.present ∧
+    perfektSurface.hasPerfect = true ∧
     Examples.ex40c.judgment = Judgment.acceptable ∧
-    kratzerPerfekt.tensePronoun.constraint =
-      kratzerSimplePast.tensePronoun.constraint ∧
-    kratzerPerfekt.hasPerfect = kratzerSimplePast.hasPerfect :=
+    perfektSurface.tensePronoun.constraint =
+      simplePastSurface.tensePronoun.constraint ∧
+    perfektSurface.hasPerfect = simplePastSurface.hasPerfect :=
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
-/-- **Zero tense surface properties.** Per Kratzer §4 (p. 10–11):
-    English has two indexical tenses (present, past) and a zero tense.
-    The substrate lemmas `zero_tense_is_present` and `zero_tense_overtness`
-    in `Tense/Decomposition.lean` carry the underlying claims; this
-    theorem just binds them locally for cross-reference. -/
-theorem zero_tense_chain :
-    (kratzerZeroTense 1).constraint = Tense.present ∧
-    Overtness.fromBinding (kratzerZeroTense 1).mode true = .zero :=
-  ⟨zero_tense_is_present 1, zero_tense_overtness 1⟩
+/-- **Zero tense surface properties and the reflexive parallel.** Per
+    [kratzer-1998] §4 (p. 10–11) English has two indexical tenses and a
+    zero tense; per §3 the zero tense is a locally bound PRESENT that
+    surfaces as zero, exactly as a locally bound entity pronoun surfaces
+    as a reflexive, while the free pronouns (indexical present, anaphoric
+    past) stay overt. -/
+theorem zero_tense_chain (n : ℕ) :
+    (boundPresent n).constraint = Tense.present ∧
+    (boundPresent n).isBound ∧
+    Overtness.fromBinding (boundPresent n).mode true = .zero ∧
+    Overtness.fromBinding indexicalPresent.mode true = .overt ∧
+    Overtness.fromBinding (anaphoricPast n).mode true = .overt :=
+  ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 end KratzerChain
 
@@ -150,13 +154,13 @@ theorem deletion_agrees_with_zero_tense_binding {Time : Type*}
     (m : ReichenbachFrame Time) :
     applyDeletion m = Tense.simultaneousFrame m m.eventTime ∧
     (applyDeletion m).isPresent :=
-  ⟨applyDeletion_eq_simultaneousFrame m, kratzer_derives_simultaneous m⟩
+  ⟨applyDeletion_eq_simultaneousFrame m, applyDeletion_isPresent m⟩
 
 /-! ### Cross-paper bridge theorems (Phase F)
 
 The contrast theorems with Ogihara, Sharvit, von Stechow, Klecha are
 intentionally not yet landed; substrate is ready (`applyDeletion`,
-`sotDeletionApplicable`, the kratzer-named lexical entries are all
-exported from `Tense/Decomposition.lean`). -/
+`sotDeletionApplicable`, and the tense pronouns are exported from
+`Tense/Decomposition.lean`). -/
 
 end Kratzer1998

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -1,5 +1,4 @@
 import Linglib.Semantics.Tense.Compositional
-import Linglib.Semantics.Tense.Decomposition
 import Linglib.Semantics.Reference.KaplanLD
 import Linglib.Semantics.Intensional.Rigidity
 
@@ -220,7 +219,6 @@ This explains why Persian has zero PRONOUNS but NOT zero TENSE
 `Overtness.fromBinding` (Core/Tense.lean) formalizes this as a function
 from `(ReferentialMode × localDomain)` to `Overtness`. -/
 
-open Tense.Decomposition
 
 /-- The four-way classification: all three referential modes produce
     overt forms except bound+local, which produces zero.
@@ -241,19 +239,6 @@ theorem overtness_classification :
     -- Bound, non-local: overt
     Overtness.fromBinding .bound false = .overt :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
-
-/-- The zero tense under SOT is bound + local → zero, just as
-    a reflexive pronoun is bound + local → reduced/zero.
-    This connects Kratzer's zero tense analysis to `Overtness`. -/
-theorem zero_tense_parallels_reflexive (n : ℕ) :
-    -- Zero tense: bound + local = zero
-    (kratzerZeroTense n).isBound ∧
-    Overtness.fromBinding (kratzerZeroTense n).mode true = .zero ∧
-    -- Kratzer's English indexical tense: free = overt
-    Overtness.fromBinding kratzerEnglishPast.mode true = .overt ∧
-    -- German Preterit: free (anaphoric) = overt
-    Overtness.fromBinding (kratzerGermanPreterit n).mode true = .overt :=
-  ⟨rfl, rfl, rfl, rfl⟩
 
 /-- The Partee analogy extended from three to four dimensions:
 


### PR DESCRIPTION
Follow-up to #2185: mathlib-register cleanse of `Tense/Decomposition.lean`.

- rename researcher-named API to content names (`SurfaceTense`; `indexicalPresent` / `anaphoricPast` / `boundPresent`), Fragments/Studies updated — German Perfekt now reuses `indexicalPresent` instead of an inline copy
- delete unconsumed rfl-projection and `Iff.rfl`-bridge theorems; substrate-register module docstring; keyed citations
- move the Kratzer-1998 reflexive-parallel theorem out of `Partee1973` (chronology) into `Kratzer1998.zero_tense_chain`; drop dead `Decomposition` imports in Italian/Partee