### PR TITLE
refactor(Tense/Compositional): cell-indexed operators; cell algebra

### DIFF
--- a/Linglib/Core/Order/Relation.lean
+++ b/Linglib/Core/Order/Relation.lean
@@ -60,6 +60,22 @@ of the relation-algebra homomorphism (the `converse`/`comp` half is below). -/
 @[simp] theorem holds_bot (a b : α) : holds (⊥ : Finset Ordering) a b ↔ False := by
   simp only [holds, Finset.bot_eq_empty, Finset.notMem_empty]
 
+/-- Categories with empty meet never both hold of a pair — pairwise exclusion,
+    e.g. `before ⊓ overlapping = ⊥`. -/
+theorem not_holds_and_holds {s t : Finset Ordering} (h : s ⊓ t = ⊥) (a b : α) :
+    ¬ (holds s a b ∧ holds t a b) :=
+  fun ⟨hs, ht⟩ => (holds_bot a b).mp (h ▸ (holds_inf s t a b).mpr ⟨hs, ht⟩)
+
+/-- Three categories that join to `⊤` cover every comparison — exhaustive case
+    analysis, e.g. `before ⊔ overlapping ⊔ after = ⊤`. -/
+theorem holds_or_holds₃ {s t u : Finset Ordering} (h : s ⊔ t ⊔ u = ⊤) (a b : α) :
+    holds s a b ∨ holds t a b ∨ holds u a b := by
+  have htop := (holds_top a b).mpr trivial
+  rw [← h] at htop
+  rcases (holds_sup _ _ a b).mp htop with h' | h'
+  · exact ((holds_sup _ _ a b).mp h').imp_right Or.inl
+  · exact Or.inr (Or.inr h')
+
 /-- `holds`, bundled. For every `[LinearOrder α]`, the map `s ↦ fun a b => holds s a b` is a
     `BoundedLatticeHom` from the eight-element Boolean algebra `Finset Ordering` (= `𝒫 {lt, eq, gt}`)
     into the relation algebra `α → α → Prop` — the Stone-dual evaluation of the comparison-category

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -1,245 +1,62 @@
 import Linglib.Semantics.Tense.Pronoun
 
 /-!
-# Compositional Tense Operators
+# Compositional tense operators
 [mendes-2025] [partee-1973]
 
-Semantic operators for grammatical tense (PAST, PRES, FUT) in the
-situation-semantic style ([mendes-2025]: operators constrain the temporal
-coordinate of a situation argument), driven by the shared temporal-relation
-kernel (`precedes`/`coincides`/`follows`), which also grounds the dynamic
-counterparts in `Tense/Dynamic.lean`. (Reichenbach frame-based tense
-predicates live in `Tense/Reichenbach.lean`.)
-Following [partee-1973], tenses are pronoun-like: they retrieve temporal
-reference points rather than quantify over all times.
+The compositional interpretation of a tense cell (`Tense/Defs.lean`) in the
+situation-semantic style of [mendes-2025]: `constrain s P sit sit'` holds
+when the cell `s` relates the event situation's time to the evaluation
+situation's time and the payload `P` holds at the event situation.
+Following [partee-1973], the event situation is retrieved (an argument),
+not quantified over. `PAST`/`PRES`/`FUT` name the three atomic cells'
+operators; the dynamic counterparts in `Tense/Dynamic.lean` are the same
+cells behind the update spine's test filter.
 -/
 
 namespace Tense
 
+open Core.Order (holds)
 open Intensional (WorldTimeIndex)
 
+variable {W Time : Type*} [LinearOrder Time]
 
+/-- The tense cell `s`, applied compositionally ([mendes-2025]):
+    ⟦s⟧ = λP.λsit.λsit'. `holds s τ(sit) τ(sit')` ∧ P(sit) — the cell
+    constrains the event–evaluation comparison and the payload is
+    evaluated at the event situation. -/
+def constrain (s : Finset Ordering) (P : SitProp W Time)
+    (sit sit' : WorldTimeIndex W Time) : Prop :=
+  holds s sit.time sit'.time ∧ P sit
 
-/--
-Type of tense operators.
+/-- ⟦PAST⟧ = `constrain past`: the event situation precedes the
+    evaluation situation. -/
+abbrev PAST : SitProp W Time → WorldTimeIndex W Time →
+    WorldTimeIndex W Time → Prop := constrain past
 
-A tense operator takes:
-- A temporal predicate P : (s, s') → Prop
-- Two situations: the "now" situation s and evaluation situation s'
-- Returns whether P holds with the tense constraint
--/
-abbrev TenseOp (W Time : Type*) := SitProp W Time → WorldTimeIndex W Time → WorldTimeIndex W Time → Prop
+/-- ⟦PRES⟧ = `constrain present`: the event situation is contemporaneous
+    with the evaluation situation. -/
+abbrev PRES : SitProp W Time → WorldTimeIndex W Time →
+    WorldTimeIndex W Time → Prop := constrain present
 
-/-! ### Temporal-relation kernel -/
+/-- ⟦FUT⟧ = `constrain future`: the event situation follows the
+    evaluation situation. -/
+abbrev FUT : SitProp W Time → WorldTimeIndex W Time →
+    WorldTimeIndex W Time → Prop := constrain future
 
-/-!
-The temporal constraint of each tense, factored out as a pure relation
-on `WorldTimeIndex` pairs and shared with the dynamic-context-update
-counterparts in `Tense/Dynamic.lean` via the spine test filter. This is the
-Heim-Kratzer "tense as relation between times" intuition isolated from
-the propositional payload, so that a single relation kernel (`precedes`/
-`coincides`/`follows`) is the source of truth for both static `PAST`/
-`PRES`/`FUT` (Compositional, this file) and their dynamic eliminative-
-update counterparts (`Tense/Dynamic.lean`). Trichotomy and pairwise
-exclusion proved at this layer propagate to both static and dynamic
-operators by definitional unfolding.
--/
+@[simp] theorem constrain_past_iff (P : SitProp W Time)
+    (sit sit' : WorldTimeIndex W Time) :
+    constrain past P sit sit' ↔ sit.time < sit'.time ∧ P sit := by
+  simp [constrain]
 
-/-- Event time precedes reference time. The temporal kernel of `PAST`
-and `dynPAST`. Reducible so `decide` and `rw` see through to the
-underlying `<` on `.time`. -/
-abbrev precedes {W Time : Type*} [LT Time]
-    (s₁ s₂ : WorldTimeIndex W Time) : Prop :=
-  s₁.time < s₂.time
+@[simp] theorem constrain_present_iff (P : SitProp W Time)
+    (sit sit' : WorldTimeIndex W Time) :
+    constrain present P sit sit' ↔ sit.time = sit'.time ∧ P sit := by
+  simp [constrain]
 
-/-- Event time coincides with reference time. The temporal kernel of
-`PRES` and `dynPRES`. -/
-abbrev coincides {W Time : Type*}
-    (s₁ s₂ : WorldTimeIndex W Time) : Prop :=
-  s₁.time = s₂.time
-
-/-- Event time follows reference time. The temporal kernel of `FUT`
-and `dynFUT`. -/
-abbrev follows {W Time : Type*} [LT Time]
-    (s₁ s₂ : WorldTimeIndex W Time) : Prop :=
-  s₁.time > s₂.time
-
-/-- The three temporal relations partition any pair of situations on a
-linear order. Used downstream by `temporal_partition` (in
-`Tense/Dynamic.lean`) and by static analyses that need exhaustive case
-analysis on tense. -/
-theorem precedes_or_coincides_or_follows {W Time : Type*} [LinearOrder Time]
-    (s₁ s₂ : WorldTimeIndex W Time) :
-    precedes s₁ s₂ ∨ coincides s₁ s₂ ∨ follows s₁ s₂ :=
-  lt_trichotomy s₁.time s₂.time
-
-/-- `precedes` and `follows` are mutually exclusive on any preorder. -/
-theorem not_precedes_and_follows {W Time : Type*} [Preorder Time]
-    (s₁ s₂ : WorldTimeIndex W Time) :
-    ¬ (precedes s₁ s₂ ∧ follows s₁ s₂) :=
-  fun ⟨h₁, h₂⟩ => lt_asymm h₁ h₂
-
-/-- `precedes` and `coincides` are mutually exclusive on any preorder. -/
-theorem not_precedes_and_coincides {W Time : Type*} [Preorder Time]
-    (s₁ s₂ : WorldTimeIndex W Time) :
-    ¬ (precedes s₁ s₂ ∧ coincides s₁ s₂) :=
-  fun ⟨h₁, h₂⟩ =>
-    have h₁' : s₁.time < s₂.time := h₁
-    have h₂' : s₁.time = s₂.time := h₂
-    lt_irrefl _ (h₂' ▸ h₁')
-
-/-- `coincides` and `follows` are mutually exclusive on any preorder. -/
-theorem not_coincides_and_follows {W Time : Type*} [Preorder Time]
-    (s₁ s₂ : WorldTimeIndex W Time) :
-    ¬ (coincides s₁ s₂ ∧ follows s₁ s₂) :=
-  fun ⟨h₁, h₂⟩ =>
-    have h₁' : s₁.time = s₂.time := h₁
-    have h₂' : s₂.time < s₁.time := h₂
-    lt_irrefl _ (h₁' ▸ h₂')
-
-/--
-PAST operator ([mendes-2025] style)
-
-⟦PAST⟧ = λP.λs.λs'. τ(s) < τ(s') ∧ P(s)
-
-The PAST operator:
-1. Requires the event situation s to precede reference situation s'
-2. Evaluates P at the past situation s
-
-Defined via the `precedes` kernel (above) so the temporal constraint is
-shared with `dynPAST` in `Tense/Dynamic.lean`.
--/
-def PAST {W Time : Type*} [LT Time] : TenseOp W Time :=
-  λ P s s' => precedes s s' ∧ P s
-
-/--
-PRES operator ([mendes-2025] style)
-
-⟦PRES⟧ = λP.λs.λs'. τ(s) = τ(s') ∧ P(s)
-
-The PRESENT operator:
-1. Requires the event situation s to be contemporaneous with s'
-2. Evaluates P at situation s
-
-Defined via the `coincides` kernel.
--/
-def PRES {W Time : Type*} : TenseOp W Time :=
-  λ P s s' => coincides s s' ∧ P s
-
-/--
-FUT operator ([mendes-2025] style)
-
-⟦FUT⟧ = λP.λs.λs'. τ(s) > τ(s') ∧ P(s)
-
-The FUTURE operator:
-1. Requires the event situation s to follow reference situation s'
-2. Evaluates P at the future situation s
-
-Defined via the `follows` kernel.
--/
-def FUT {W Time : Type*} [LT Time] : TenseOp W Time :=
-  λ P s s' => follows s s' ∧ P s
-
-
-/-
-For simpler analyses, tense can modify a predicate relative to a fixed
-speech time, without threading through two situations.
-
-These are the "traditional" tense operators.
--/
-
-/--
-Simple PAST: Event time precedes speech time.
-
-⟦PAST⟧ₛᵢₘₚₗₑ = λP.λt.λt_s. t < t_s ∧ P(t)
--/
-def pastSimple {Time : Type*} [LT Time] (P : Time → Prop) (eventTime speechTime : Time) : Prop :=
-  eventTime < speechTime ∧ P eventTime
-
-/--
-Simple PRESENT: Event time equals speech time.
--/
-def presSimple {Time : Type*} (P : Time → Prop) (eventTime speechTime : Time) : Prop :=
-  eventTime = speechTime ∧ P eventTime
-
-/--
-Simple FUTURE: Event time follows speech time.
--/
-def futSimple {Time : Type*} [LT Time] (P : Time → Prop) (eventTime speechTime : Time) : Prop :=
-  eventTime > speechTime ∧ P eventTime
-
-
-/--
-PAST requires temporal precedence.
--/
-theorem past_requires_precedence {W Time : Type*} [LT Time]
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    PAST P s s' → s.time < s'.time := by
-  intro ⟨h, _⟩
-  exact h
-
-/--
-FUT requires temporal succession.
--/
-theorem fut_requires_succession {W Time : Type*} [LT Time]
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    FUT P s s' → s.time > s'.time := by
-  intro ⟨h, _⟩
-  exact h
-
-/--
-PRES requires contemporaneity.
--/
-theorem pres_requires_contemporaneity {W Time : Type*}
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    PRES P s s' → s.time = s'.time := by
-  intro ⟨h, _⟩
-  exact h
-
-/--
-Tense preserves the predicate.
-
-If TENSE(P)(s, s'), then P(s).
--/
-theorem past_preserves_pred {W Time : Type*} [LT Time]
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    PAST P s s' → P s := by
-  intro ⟨_, h⟩
-  exact h
-
-theorem pres_preserves_pred {W Time : Type*}
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    PRES P s s' → P s := by
-  intro ⟨_, h⟩
-  exact h
-
-theorem fut_preserves_pred {W Time : Type*} [LT Time]
-    (P : SitProp W Time) (s s' : WorldTimeIndex W Time) :
-    FUT P s s' → P s := by
-  intro ⟨_, h⟩
-  exact h
-
-
-section Examples
-
-/-- Example predicate: "rain at situation s" -/
-def raining (W : Type*) : SitProp W ℤ := λ _s => True  -- placeholder
-
-/-- "It rained" is true iff there's a past situation where it rained -/
-example : PAST (raining Unit) ⟨(), -1⟩ ⟨(), 0⟩ := by
-  constructor
-  · -- -1 < 0
-    decide
-  · -- raining holds (trivially true)
-    trivial
-
-/-- "It will rain" is true iff there's a future situation where it rains -/
-example : FUT (raining Unit) ⟨(), 1⟩ ⟨(), 0⟩ := by
-  constructor
-  · -- 1 > 0
-    decide
-  · trivial
-
-end Examples
+@[simp] theorem constrain_future_iff (P : SitProp W Time)
+    (sit sit' : WorldTimeIndex W Time) :
+    constrain future P sit sit' ↔ sit'.time < sit.time ∧ P sit := by
+  simp [constrain]
 
 end Tense

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -8,14 +8,13 @@ import Linglib.Semantics.Tense.Compositional
 
 `dynPAST`/`dynPRES`/`dynFUT` are the dynamic-context-update counterparts
 of the static `PAST`/`PRES`/`FUT` operators in `Tense/Compositional.lean`.
-Each is the spine's test filter `lift (test ·)` at the static temporal-
-relation kernel (`precedes`/`coincides`/`follows`) between two dref
-lookups — so the static and dynamic operators are *the same temporal
-constraint*, lifted from a state-level predicate to a context-level
-filter, and the temporal algebra (partition, contradiction, chaining) is
-inherited from the generic filter algebra of `Update.lean`
-(`lift_test_cover₃`, `lift_test_disjoint`) at the kernel facts of
-`Tense/Compositional.lean`.
+Each is the spine's test filter `lift (test ·)` at the tense cell
+(`Tense/Defs.lean`) between two dref lookups — so the static and dynamic
+operators are *the same cell*, lifted from a state-level predicate to a
+context-level filter, and the temporal algebra (partition, contradiction,
+chaining) is the cells' Boolean algebra (`Core.Order.holds_or_holds₃`,
+`Core.Order.not_holds_and_holds`) through the generic filter algebra of
+`Update.lean` (`lift_test_cover₃`, `lift_test_disjoint`).
 
 Contexts are level-0 states over `WorldTimeIndex.Possibility` — the
 world coordinate is the current evaluation index, drefs are indices.
@@ -29,7 +28,7 @@ world coordinate is the current evaluation index, drefs are indices.
   eliminative updates (`CCP.IsEliminative`).
 - [de-groote-2006] recovers static readings from dynamic ones by the
   trivial continuation; [charlow-2021] recasts the lift monadically.
-  The `dynPAST = lift (test (precedes · ·))` factoring below is the
+  The `dynPAST = lift (test (holds past · ·))` factoring below is the
   tense fragment of that lift.
 
 ## Main results
@@ -38,60 +37,65 @@ world coordinate is the current evaluation index, drefs are indices.
   the dynamic filter iff the static operator holds at its
   event/reference indices — the "wrapper actually wraps" check.
 - `temporal_partition`, the contradictory-pair lemmas, and
-  `dynPAST_transitive`: the temporal algebra, derived from the kernel
-  facts through the spine's filter algebra.
+  `dynPAST_transitive`: the temporal algebra, derived from the cells'
+  Boolean algebra through the spine's filter algebra.
 
-Sibling of `Tense/Compositional.lean` (the static kernel) and
+Sibling of `Tense/Compositional.lean` (the static operators) and
 `Mood/Dynamic.lean` (the parallel pattern for SUBJ/IND). Used by
 `Studies/Mendes2025.lean`'s analysis of the Subordinate Future.
 -/
 
 namespace Tense
 
+open Core.Order (holds)
 open _root_.Intensional (WorldTimeIndex)
 open DynamicSemantics
 open DynamicSemantics.Update (test closure)
 
-variable {W Time : Type*}
+variable {W Time : Type*} [LinearOrder Time]
 
-/--
-Dynamic PAST: the spine's test filter at the static `precedes` relation
-between two dref lookups. A context entry survives iff its event-variable
-index precedes its reference-variable index in time.
--/
-def dynPAST [LT Time] (eventVar refVar : ℕ) :
+/-- Dynamic PAST: the spine's test filter at the `past` cell. A context
+    entry survives iff its event-variable index precedes its
+    reference-variable index in time. -/
+def dynPAST (eventVar refVar : ℕ) :
     Set (WorldTimeIndex.Possibility W Time) →
       Set (WorldTimeIndex.Possibility W Time) :=
-  lift (test fun p => precedes (p.assignment eventVar) (p.assignment refVar))
+  lift (test fun p =>
+    holds past (p.assignment eventVar).time (p.assignment refVar).time)
 
-/-- Dynamic PRES: the test filter at `coincides`. -/
+/-- Dynamic PRES: the test filter at the `present` cell. -/
 def dynPRES (eventVar refVar : ℕ) :
     Set (WorldTimeIndex.Possibility W Time) →
       Set (WorldTimeIndex.Possibility W Time) :=
-  lift (test fun p => coincides (p.assignment eventVar) (p.assignment refVar))
+  lift (test fun p =>
+    holds present (p.assignment eventVar).time (p.assignment refVar).time)
 
-/-- Dynamic FUT: the test filter at `follows`. -/
-def dynFUT [LT Time] (eventVar refVar : ℕ) :
+/-- Dynamic FUT: the test filter at the `future` cell. -/
+def dynFUT (eventVar refVar : ℕ) :
     Set (WorldTimeIndex.Possibility W Time) →
       Set (WorldTimeIndex.Possibility W Time) :=
-  lift (test fun p => follows (p.assignment eventVar) (p.assignment refVar))
+  lift (test fun p =>
+    holds future (p.assignment eventVar).time (p.assignment refVar).time)
 
 variable (e r : ℕ) (c : Set (WorldTimeIndex.Possibility W Time))
   (p : WorldTimeIndex.Possibility W Time)
 
 /-! ### Membership characterizations -/
 
-@[simp] theorem mem_dynPAST [LT Time] :
-    p ∈ dynPAST e r c ↔ p ∈ c ∧ precedes (p.assignment e) (p.assignment r) :=
-  mem_lift_test
+@[simp] theorem mem_dynPAST :
+    p ∈ dynPAST e r c ↔
+      p ∈ c ∧ (p.assignment e).time < (p.assignment r).time := by
+  simp [dynPAST, mem_lift_test]
 
 @[simp] theorem mem_dynPRES :
-    p ∈ dynPRES e r c ↔ p ∈ c ∧ coincides (p.assignment e) (p.assignment r) :=
-  mem_lift_test
+    p ∈ dynPRES e r c ↔
+      p ∈ c ∧ (p.assignment e).time = (p.assignment r).time := by
+  simp [dynPRES, mem_lift_test]
 
-@[simp] theorem mem_dynFUT [LT Time] :
-    p ∈ dynFUT e r c ↔ p ∈ c ∧ follows (p.assignment e) (p.assignment r) :=
-  mem_lift_test
+@[simp] theorem mem_dynFUT :
+    p ∈ dynFUT e r c ↔
+      p ∈ c ∧ (p.assignment r).time < (p.assignment e).time := by
+  simp [dynFUT, mem_lift_test]
 
 /-! ### Static realization: dynamic IS the eliminative update of static
 
@@ -101,61 +105,63 @@ the dynamic filter retains the entry — the [de-groote-2006] sense in
 which static and dynamic tense are the same operator at different
 layers. -/
 
-theorem dynPAST_iff_PAST_with_true [LT Time] :
+theorem dynPAST_iff_PAST_with_true :
     p ∈ dynPAST e r c ↔
-      p ∈ c ∧ PAST (fun _ => True) (p.assignment e) (p.assignment r) :=
-  ⟨fun h => ⟨(mem_lift_test.mp h).1, (mem_lift_test.mp h).2, trivial⟩,
-   fun ⟨hc, hp, _⟩ => mem_lift_test.mpr ⟨hc, hp⟩⟩
+      p ∈ c ∧ PAST (fun _ => True) (p.assignment e) (p.assignment r) := by
+  simp
 
 theorem dynPRES_iff_PRES_with_true :
     p ∈ dynPRES e r c ↔
-      p ∈ c ∧ PRES (fun _ => True) (p.assignment e) (p.assignment r) :=
-  ⟨fun h => ⟨(mem_lift_test.mp h).1, (mem_lift_test.mp h).2, trivial⟩,
-   fun ⟨hc, hp, _⟩ => mem_lift_test.mpr ⟨hc, hp⟩⟩
+      p ∈ c ∧ PRES (fun _ => True) (p.assignment e) (p.assignment r) := by
+  simp
 
-theorem dynFUT_iff_FUT_with_true [LT Time] :
+theorem dynFUT_iff_FUT_with_true :
     p ∈ dynFUT e r c ↔
-      p ∈ c ∧ FUT (fun _ => True) (p.assignment e) (p.assignment r) :=
-  ⟨fun h => ⟨(mem_lift_test.mp h).1, (mem_lift_test.mp h).2, trivial⟩,
-   fun ⟨hc, hp, _⟩ => mem_lift_test.mpr ⟨hc, hp⟩⟩
+      p ∈ c ∧ FUT (fun _ => True) (p.assignment e) (p.assignment r) := by
+  simp
 
-/-! ### Temporal algebra (kernel facts through the filter algebra) -/
+/-! ### Temporal algebra (cell algebra through the filter algebra) -/
 
-/-- PAST ∪ PRES ∪ FUT = identity: `lift_test_cover₃` at the kernel's
-`precedes_or_coincides_or_follows`. -/
-theorem temporal_partition [LinearOrder Time] (v₁ v₂ : ℕ) :
+/-- PAST ∪ PRES ∪ FUT = identity: `lift_test_cover₃` at the cells' cover
+`past ⊔ present ⊔ future = ⊤`. -/
+theorem temporal_partition (v₁ v₂ : ℕ) :
     dynPAST v₁ v₂ c ∪ dynPRES v₁ v₂ c ∪ dynFUT v₁ v₂ c = c := by
   unfold dynPAST dynPRES dynFUT
   exact lift_test_cover₃ _ _ _
-    (fun p => precedes_or_coincides_or_follows
-      (p.assignment v₁) (p.assignment v₂)) c
+    (fun p => Core.Order.holds_or_holds₃
+      (s := past) (t := present) (u := future) (by decide)
+      (p.assignment v₁).time (p.assignment v₂).time) c
 
 /-- PAST and FUT are contradictory on the same variables:
-`lift_test_disjoint` at the kernel's `not_precedes_and_follows`. -/
-theorem dynPAST_dynFUT_empty [Preorder Time] (v₁ v₂ : ℕ) :
+`lift_test_disjoint` at the disjoint cells `past ⊓ future = ⊥`. -/
+theorem dynPAST_dynFUT_empty (v₁ v₂ : ℕ) :
     dynPAST v₁ v₂ (dynFUT v₁ v₂ c) = ∅ := by
   unfold dynPAST dynFUT
   exact lift_test_disjoint _ _
-    (fun p h₂ h₁ => not_precedes_and_follows _ _ ⟨h₁, h₂⟩) c
+    (fun p h₂ h₁ => Core.Order.not_holds_and_holds
+      (s := past) (t := future) (by decide) _ _ ⟨h₁, h₂⟩) c
 
 /-- PAST and PRES are contradictory on the same variables. -/
-theorem dynPAST_dynPRES_empty [Preorder Time] (v₁ v₂ : ℕ) :
+theorem dynPAST_dynPRES_empty (v₁ v₂ : ℕ) :
     dynPAST v₁ v₂ (dynPRES v₁ v₂ c) = ∅ := by
   unfold dynPAST dynPRES
   exact lift_test_disjoint _ _
-    (fun p h₂ h₁ => not_precedes_and_coincides _ _ ⟨h₁, h₂⟩) c
+    (fun p h₂ h₁ => Core.Order.not_holds_and_holds
+      (s := past) (t := present) (by decide) _ _ ⟨h₁, h₂⟩) c
 
 /-- PRES and FUT are contradictory on the same variables. -/
-theorem dynPRES_dynFUT_empty [Preorder Time] (v₁ v₂ : ℕ) :
+theorem dynPRES_dynFUT_empty (v₁ v₂ : ℕ) :
     dynPRES v₁ v₂ (dynFUT v₁ v₂ c) = ∅ := by
   unfold dynPRES dynFUT
   exact lift_test_disjoint _ _
-    (fun p h₂ h₁ => not_coincides_and_follows _ _ ⟨h₁, h₂⟩) c
+    (fun p h₂ h₁ => Core.Order.not_holds_and_holds
+      (s := present) (t := future) (by decide) _ _ ⟨h₁, h₂⟩) c
 
 /-- Chained PAST constraints compose: e < r ∧ r < s → e < s. -/
-theorem dynPAST_transitive [Preorder Time] (e r s : ℕ)
+theorem dynPAST_transitive (e r s : ℕ)
     (h : p ∈ dynPAST r s (dynPAST e r c)) :
-    (p.assignment e).time < (p.assignment s).time :=
-  lt_trans (mem_lift_test.mp (mem_lift_test.mp h).1).2 (mem_lift_test.mp h).2
+    (p.assignment e).time < (p.assignment s).time := by
+  rw [mem_dynPAST, mem_dynPAST] at h
+  exact lt_trans h.1.2 h.2
 
 end Tense

--- a/Linglib/Semantics/Tense/Evidential.lean
+++ b/Linglib/Semantics/Tense/Evidential.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Tense.Compositional
+import Linglib.Semantics.Tense.Reichenbach
 import Linglib.Semantics.Evidential.Source
 import Linglib.Features.Mirativity
 import Linglib.Semantics.Presupposition.Basic

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -34,7 +34,6 @@ The eval* operators instantiate the situation (fixing world and time).
 -/
 
 import Linglib.Semantics.Aspect.Basic
-import Linglib.Semantics.Tense.Compositional
 import Linglib.Semantics.Tense.LexicalType
 import Linglib.Semantics.Quantification.Basic
 

--- a/Linglib/Studies/Kiparsky2002.lean
+++ b/Linglib/Studies/Kiparsky2002.lean
@@ -2,7 +2,6 @@ import Linglib.Semantics.Aspect.SubeventStructure
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Core.Order.Interval
 import Linglib.Semantics.Tense.Reichenbach
-import Linglib.Semantics.Tense.Compositional
 
 /-!
 # [kiparsky-2002]: Event structure and the perfect

--- a/Linglib/Studies/Mendes2025.lean
+++ b/Linglib/Studies/Mendes2025.lean
@@ -65,7 +65,7 @@ Structure ([mendes-2025] §3.2):
 This is the compositional derivation:
 ⟦SF⟧ = ⟦SUBJ⟧ ∘ ⟦FUT⟧
 -/
-def subordinateFuture {W Time : Type*} [LE Time] [LT Time]
+def subordinateFuture {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (newSitVar : ℕ)   -- Fresh variable for introduced situation
     (refSitVar : ℕ)   -- Variable for reference situation
@@ -84,7 +84,7 @@ Conditional with SF antecedent (dynamic version).
 2. Antecedent predicate evaluated at s₁
 3. Consequent: temporally anchored to s₁ (future relative to s₀)
 -/
-def conditionalWithSF {W Time : Type*} [LE Time] [LT Time]
+def conditionalWithSF {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (antecedentVar : ℕ)  -- Situation introduced by SF
     (speechVar : ℕ)      -- Speech time situation
@@ -109,7 +109,7 @@ Structure:
 2. Restrictor (boy ∧ awake) evaluated at s₁
 3. Nuclear scope (get cookie) evaluated with temporal anchor from s₁
 -/
-def relativeClauseSF {W Time : Type*} [LE Time] [LT Time]
+def relativeClauseSF {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (rcVar : ℕ)           -- Situation variable for relative clause
     (speechVar : ℕ)       -- Speech time situation
@@ -127,7 +127,7 @@ The SF in the restrictor:
 2. Quantification over books is relativized to s₁
 3. Nuclear scope inherits temporal anchor from s₁
 -/
-def everyWithSFRestrictor {W Time : Type*} [LE Time] [LT Time]
+def everyWithSFRestrictor {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (rcVar speechVar : ℕ)
     (restrictor : Set (WorldTimeIndex.Possibility W Time) → Set (WorldTimeIndex.Possibility W Time))  -- "book that M reads"
@@ -150,7 +150,7 @@ SF introduces a future situation.
 
 The subordinate future always introduces a situation with time ≥ current.
 -/
-theorem sf_introduces_future {W Time : Type*} [Preorder Time]
+theorem sf_introduces_future {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (newVar refVar : ℕ)
     (c : Set (WorldTimeIndex.Possibility W Time))
@@ -161,7 +161,7 @@ theorem sf_introduces_future {W Time : Type*} [Preorder Time]
   -- FUT requires the new situation to be after the reference
   unfold subordinateFuture at h
   obtain ⟨-, h_gt⟩ := DynamicSemantics.mem_lift_test.mp h
-  exact le_of_lt h_gt
+  exact le_of_lt ((Core.Order.holds_after _ _).mp h_gt)
 
 /--
 Temporal shift is parasitic on modal donkey anaphora.
@@ -178,7 +178,7 @@ The temporal shift is *derived* from the modal semantics, not stipulated.
 Modal donkey anaphora explains
 why subjunctive mood enables future reference in subordinate clauses.
 -/
-theorem temporal_shift_parasitic_on_modal {W Time : Type*} [Preorder Time]
+theorem temporal_shift_parasitic_on_modal {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (sfVar speechVar : ℕ)
     (c : Set (WorldTimeIndex.Possibility W Time))
@@ -217,7 +217,7 @@ theorem temporal_shift_parasitic_on_modal {W Time : Type*} [Preorder Time]
     simp only [Set.mem_ofPred_eq] at h_hist
     exact h_hist.2
   -- 3. The FUT constraint gives us the strict ordering
-  · exact h_gt
+  · exact (Core.Order.holds_after _ _).mp h_gt
 
 /--
 SF in restrictor enables future reference for strong quantifiers.
@@ -227,7 +227,7 @@ With SF in the relative clause, "every" can quantify over future entities.
 Restrictor and nuclear must be context filters (`IsEliminative`).
 Linguistically, predicates filter contexts without modifying assignments.
 -/
-theorem sf_restrictor_future_reference {W Time : Type*} [Preorder Time]
+theorem sf_restrictor_future_reference {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     (rcVar speechVar : ℕ)
     (restrictor nuclear : Set (WorldTimeIndex.Possibility W Time) → Set (WorldTimeIndex.Possibility W Time))
@@ -243,14 +243,14 @@ theorem sf_restrictor_future_reference {W Time : Type*} [Preorder Time]
     Set.Subset.trans (hN _) (hR _) h
   -- subordinateFuture guarantees the future ordering via dynFUT
   unfold subordinateFuture at h_sf
-  exact (DynamicSemantics.mem_lift_test.mp h_sf).2
+  exact (Core.Order.holds_after _ _).mp (DynamicSemantics.mem_lift_test.mp h_sf).2
 
 
 -- ════════════════════════════════════════════════════════════════
 -- § 3. Compositional CDRT Derivations (§4.3.1)
 -- ════════════════════════════════════════════════════════════════
 
-variable {W Time E : Type*} [LE Time] [LT Time]
+variable {W Time E : Type*} [LinearOrder Time]
 variable (history : HistoricalAlternatives W Time)
 
 /--
@@ -288,7 +288,7 @@ def lexAnswer
 SF (Subordinate Future).
 `⟦SF⟧ = SUBJ ∘ FUT`
 -/
-def lexSF := @subordinateFuture W Time _ _
+def lexSF := @subordinateFuture W Time _
 
 /--
 ela — "she" (pronoun bound to Maria).
@@ -418,7 +418,7 @@ theorem derivation_future_ordering
   simp only [Set.mem_ofPred_eq] at h_ant
   obtain ⟨h_sf, _⟩ := h_ant
   unfold lexSF subordinateFuture at h_sf
-  exact (DynamicSemantics.mem_lift_test.mp h_sf).2
+  exact (Core.Order.holds_after _ _).mp (DynamicSemantics.mem_lift_test.mp h_sf).2
 
 /--
 If Maria is at home at s₁, she answers at s₁.
@@ -456,7 +456,7 @@ def deriveCounterfactual
 /--
 SF constrains to future; counterfactual allows past/present.
 -/
-theorem sf_vs_counterfactual_temporal {W Time : Type*} [Preorder Time]
+theorem sf_vs_counterfactual_temporal {W Time : Type*} [LinearOrder Time]
     (history : HistoricalAlternatives W Time)
     {E : Type*}
     (maria : E)

--- a/Linglib/Studies/Ogihara1989.lean
+++ b/Linglib/Studies/Ogihara1989.lean
@@ -23,10 +23,11 @@ open Intensional (WorldTimeIndex)
     time precedes the speech situation and (2) the predicate holds at the
     referential time: the referential analysis picks the time, the
     operator imposes the constraint. -/
-theorem referential_past_decomposition {W Time : Type*} [LT Time]
+theorem referential_past_decomposition {W Time : Type*} [LinearOrder Time]
     (P : SitProp W Time) (g : TemporalAssignment Time) (n : ℕ)
     (w : W) (speechTime : Time) :
     PAST P ⟨w, interpTense n g⟩ ⟨w, speechTime⟩ ↔
-    (g n < speechTime ∧ P ⟨w, g n⟩) := by rfl
+    (g n < speechTime ∧ P ⟨w, g n⟩) := by
+  simp [Tense.constrain]
 
 end Ogihara1989

--- a/Linglib/Studies/Partee1973.lean
+++ b/Linglib/Studies/Partee1973.lean
@@ -58,7 +58,7 @@ theorem stove_refutes_prior :
     parteeStoveExample (· == (-1 : ℤ)) (λ _ => (-1 : ℤ)) 0 = false ∧
     ∃ s : WorldTimeIndex Unit ℤ,
       PAST (λ s => (s.time == (-1 : ℤ)) = false) s ⟨(), 0⟩ :=
-  ⟨by decide, ⟨(), -2⟩, by exact (by decide : ((-2 : ℤ) < 0)), by decide⟩
+  ⟨by decide, ⟨(), -2⟩, by decide, by decide⟩
 
 /-- Partee's narrative example: "He turned the corner. He saw a house."
 


### PR DESCRIPTION
Audit recut of `Tense/Compositional.lean` to mathlib shape: one primitive, named specializations.

- `constrain (s : Finset Ordering)` is the single compositional operator over `Core.Order.holds`; `PAST`/`PRES`/`FUT` become transparent abbrevs at the atomic cells (a Klecha-style `constrain nonpast` is now expressible for free), with reduction simp lemmas
- delete the parallel `precedes`/`coincides`/`follows` kernel and its four order-lemma restatements, plus dead `TenseOp`, the `*Simple` trio, six And-projection theorems, and the placeholder examples; `Dynamic.lean`'s temporal algebra now derives from the cells' Boolean algebra via new `Core.Order.not_holds_and_holds` / `holds_or_holds₃` — the first external consumers of the `holds` hom lemmas
- drop false import edges: TAC and Kiparsky2002 never used Compositional; Evidential's real dependency is Reichenbach