### PR TITLE
refactor(Tense/LexicalType): move pronominal (30a) side to Sharvit2014

### DIFF
--- a/Linglib/Semantics/Tense/LexicalType.lean
+++ b/Linglib/Semantics/Tense/LexicalType.lean
@@ -1,7 +1,5 @@
 import Mathlib.Data.Set.Basic
-import Linglib.Semantics.Tense.Pronoun
 import Linglib.Semantics.Quantification.Basic
-import Linglib.Semantics.Reference.Nominal
 
 /-!
 # Tense as a typed lexical object
@@ -10,13 +8,13 @@ import Linglib.Semantics.Reference.Nominal
 *pronominal* (after [partee-1973]; an element of `D_i`) and *quantificational* (a Priorean
 operator over time-predicates). They diverge on past-under-past in *before*-clauses, where
 quantificational past triggers Inherent Presupposition Failure under [beaver-condoravdi-2003]'s
-`before` (`Tense.TemporalConnectives.Before`); the cross-linguistic typology ((98), (99)) is
-in `Studies.Sharvit2014`.
+`before` (`Tense.TemporalConnectives.Before`). The pronominal-past lookup ((30a)), its
+grounding in `TensePronoun`, and the cross-linguistic typology ((98), (99)) live in
+`Studies.Sharvit2014`.
 
 ## Main definitions
 
 * `Tense.LexicalType` — pronominal vs quantificational tense.
-* `Tense.pronominalLookup` — the pronominal-past partial lookup ((30a)).
 * `Tense.quantificationalPast` — the quantificational past, the GQ `some` over `K` ((30b)).
 -/
 
@@ -30,65 +28,6 @@ inductive LexicalType
   | quantificational
   deriving DecidableEq, Repr
 
-/-- The two semantic types are distinct. ([sharvit-2014]'s language-level no-mixing
-    constraint — a language has tenses of just one type — lives in `Studies.Sharvit2014`.) -/
-theorem LexicalType.pronominal_ne_quantificational :
-    LexicalType.pronominal ≠ LexicalType.quantificational :=
-  nofun
-
-/-- [sharvit-2014] (30a): pronominal-past lookup `[[past_{j,k}]]^g`. Indices `j`
-    (evaluation), `k` (referential); defined iff `g k < g j`, then `g k`. Uses `Option`
-    (not `Part`/`PFun`) as the domain is decidable; the shape is `Option.guard`. -/
-def pronominalLookup {Time : Type*} [LT Time] [DecidableLT Time]
-    (g : ℕ → Time) (j k : ℕ) : Option Time :=
-  if g k < g j then some (g k) else none
-
-/-- The pronominal past denotes the referential index when defined. -/
-@[simp]
-theorem pronominalLookup_eq_some_iff {Time : Type*} [LT Time]
-    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) (t : Time) :
-    pronominalLookup g j k = some t ↔ g k < g j ∧ g k = t := by
-  unfold pronominalLookup; split <;> simp_all
-
-/-- The pronominal past is undefined exactly when the constraint fails. -/
-@[simp]
-theorem pronominalLookup_eq_none_iff {Time : Type*} [LT Time]
-    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) :
-    pronominalLookup g j k = none ↔ ¬ g k < g j := by
-  unfold pronominalLookup; split <;> simp_all
-
-/-- A tense pronoun is a nominal denotation over `Time` ([partee-1973]): the
-    referent selector is the total assignment lookup `resolve`, the intrinsic
-    presupposition is the tense constraint. Entity pronouns
-    (`Semantics.Reference.PronounDenotation`) are the same `NominalDenot`
-    construction over `Entity`, so "tense is a pronoun" holds by construction. -/
-def TensePronoun.toNominalDenot {Time : Type*} [LinearOrder Time]
-    (tp : TensePronoun) :
-    Semantics.Reference.NominalDenot (TemporalAssignment Time) PUnit Time where
-  presup := fun g _ => tp.fullPresupposition g
-  selector := fun g _ => some (tp.resolve g)
-
-@[simp] theorem TensePronoun.toNominalDenot_presup {Time : Type*} [LinearOrder Time]
-    (tp : TensePronoun) (g : TemporalAssignment Time) (w : PUnit) :
-    tp.toNominalDenot.presup g w = tp.fullPresupposition g := rfl
-
-@[simp] theorem TensePronoun.toNominalDenot_selector {Time : Type*} [LinearOrder Time]
-    (tp : TensePronoun) (g : TemporalAssignment Time) (w : PUnit) :
-    tp.toNominalDenot.selector g w = some (tp.resolve g) := rfl
-
-/-- The two codebase formalizations of [partee-1973] pronominal tense coincide:
-    `pronominalLookup` is the presupposition-gated referent of the tense pronoun's
-    `NominalDenot` (`TensePronoun.toNominalDenot`), for any binding `mode`. -/
-theorem pronominalLookup_eq_some_iff_tensePronoun {Time : Type*} [LinearOrder Time]
-    (g : TemporalAssignment Time) (j k : ℕ) (t : Time) (mode : Intensional.ReferentialMode) :
-    pronominalLookup g j k = some t ↔
-      (TensePronoun.mk k past mode j).toNominalDenot.presup g ⟨⟩ ∧
-      (TensePronoun.mk k past mode j).toNominalDenot.selector g ⟨⟩ = some t := by
-  simp only [TensePronoun.toNominalDenot_presup, TensePronoun.toNominalDenot_selector,
-    TensePronoun.fullPresupposition, TensePronoun.resolve, TensePronoun.evalTime,
-    interpTense, Tense.past, Core.Order.holds_before, Option.some.injEq]
-  exact pronominalLookup_eq_some_iff g j k t
-
 /-- [sharvit-2014] (30b): quantificational past as the generalized quantifier
     `some` (`Quantification.some_sem`) over the contextual restrictor `K`,
     with scope "precedes `t` and satisfies `p`". Definitionally
@@ -96,12 +35,5 @@ theorem pronominalLookup_eq_some_iff_tensePronoun {Time : Type*} [LinearOrder Ti
 def quantificationalPast {Time : Type*} [LT Time]
     (K : Set Time) (p : Time → Prop) (t : Time) : Prop :=
   Quantification.some_sem (· ∈ K) (fun t' => t' < t ∧ p t')
-
-/-- Monotone in the body predicate — inherited from scope-monotonicity of `some`
-    (`Quantification.some_scope_up`), not reproved. -/
-theorem quantificationalPast_mono {Time : Type*} [LT Time]
-    {K : Set Time} {p q : Time → Prop} (h : ∀ t, p t → q t) {t : Time} :
-    quantificationalPast K p t → quantificationalPast K q t :=
-  Quantification.some_scope_up _ _ _ fun _ hS => ⟨hS.1, h _ hS.2⟩
 
 end Tense

--- a/Linglib/Semantics/Tense/TenseAspectComposition.lean
+++ b/Linglib/Semantics/Tense/TenseAspectComposition.lean
@@ -77,7 +77,7 @@ def evalFut (p : PointPred W Time) (tc : Time) (w : W) : Prop :=
 /-- The pipeline's existential past is [sharvit-2014]'s quantificational
     past with trivial restrictor: `evalPast` = `quantificationalPast` over
     `Set.univ`. Together with `pronominalLookup_eq_some_iff_tensePronoun`
-    (in `LexicalType.lean`), this places both of Sharvit's tense lexical
+    (in `Studies/Sharvit2014.lean`), this places both of Sharvit's tense lexical
     types over the operators the rest of the codebase already uses. -/
 theorem evalPast_iff_quantificationalPast (p : PointPred W Time) (tc : Time) (w : W) :
     evalPast p tc w ↔ quantificationalPast Set.univ (λ t => p ⟨w, t⟩) tc := by

--- a/Linglib/Studies/Sharvit2014.lean
+++ b/Linglib/Studies/Sharvit2014.lean
@@ -40,6 +40,49 @@ open Tense (LexicalType)
 open Tense.TemporalConnectives.Before (triggersIPFInBefore)
 open Tense.Decomposition (sotDeletionApplicable)
 
+/-! ### The pronominal past ((30a))
+
+The pronominal-past lookup and its grounding in the codebase's canonical
+tense pronoun: `pronominalLookup` is the presupposition-gated referent of a
+past-constraint `TensePronoun`, so [sharvit-2014]'s (30a) and
+[partee-1973]'s tense-pronoun carrier coincide
+(`pronominalLookup_eq_some_iff_tensePronoun`). -/
+
+/-- [sharvit-2014] (30a): pronominal-past lookup `[[past_{j,k}]]^g`. Indices `j`
+    (evaluation), `k` (referential); defined iff `g k < g j`, then `g k`. Uses
+    `Option` (not `Part`/`PFun`) as the domain is decidable. -/
+def pronominalLookup {Time : Type*} [LT Time] [DecidableLT Time]
+    (g : ℕ → Time) (j k : ℕ) : Option Time :=
+  if g k < g j then some (g k) else none
+
+/-- The pronominal past denotes the referential index when defined. -/
+@[simp]
+theorem pronominalLookup_eq_some_iff {Time : Type*} [LT Time]
+    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) (t : Time) :
+    pronominalLookup g j k = some t ↔ g k < g j ∧ g k = t := by
+  unfold pronominalLookup; split <;> simp_all
+
+/-- The pronominal past is undefined exactly when the constraint fails. -/
+@[simp]
+theorem pronominalLookup_eq_none_iff {Time : Type*} [LT Time]
+    [DecidableLT Time] (g : ℕ → Time) (j k : ℕ) :
+    pronominalLookup g j k = none ↔ ¬ g k < g j := by
+  unfold pronominalLookup; split <;> simp_all
+
+/-- (30a) coincides with the codebase's [partee-1973] carrier: the lookup is
+    defined with value `t` iff the past-constraint `TensePronoun` with
+    referential index `k` and evaluation index `j` satisfies its presupposition
+    and resolves to `t` — for any binding `mode`. -/
+theorem pronominalLookup_eq_some_iff_tensePronoun {Time : Type*} [LinearOrder Time]
+    (g : Tense.TemporalAssignment Time) (j k : ℕ) (t : Time)
+    (mode : Intensional.ReferentialMode) :
+    pronominalLookup g j k = some t ↔
+      (Tense.TensePronoun.mk k Tense.past mode j).fullPresupposition g ∧
+      (Tense.TensePronoun.mk k Tense.past mode j).resolve g = t := by
+  simp only [Tense.TensePronoun.fullPresupposition, Tense.TensePronoun.resolve,
+    Tense.TensePronoun.evalTime, Tense.interpTense, Tense.past, Core.Order.holds_before]
+  exact pronominalLookup_eq_some_iff g j k t
+
 /-! ### The parameter space ((98)) -/
 
 /-- The present tense's shiftability, three-valued per [sharvit-2014] (71)/(78), pp. 288-291:


### PR DESCRIPTION
Audit of `Tense/LexicalType.lean`: the file earns its substrate place, but only half of it. `LexicalType` and `quantificationalPast` ((30b)) are genuinely consumed — `Before`'s IPF theorem, TAC's `evalPast_iff`, and Sharvit2014's language profiles. The entire pronominal chain — `pronominalLookup` ((30a)) + lemmas, `TensePronoun.toNominalDenot` + lemmas, the coincidence theorem — was internally closed with zero external code consumers.

- move `pronominalLookup` (+ its two lemmas) and the coincidence theorem into `Studies/Sharvit2014.lean`, restated directly against `TensePronoun.fullPresupposition`/`resolve` (the `NominalDenot` detour added nothing and is dropped)
- delete zero-consumer `pronominal_ne_quantificational` and `quantificationalPast_mono`
- `LexicalType.lean` keeps the enum + (30b) with trimmed imports; TAC's stale location pointer fixed