### PR TITLE
refactor(Intensional): dissolve SitProp; WorldTimeIndex as leaf

### DIFF
--- a/Linglib/Semantics/Dynamic/Possibility.lean
+++ b/Linglib/Semantics/Dynamic/Possibility.lean
@@ -1,4 +1,5 @@
 import Linglib.Core.Data.Part
+import Linglib.Semantics.Intensional.WorldTimeIndex
 import Linglib.Core.Order.PartialUnify
 import Mathlib.Data.PFun
 import Mathlib.Logic.Function.Basic
@@ -273,3 +274,13 @@ def assignmentEquiv (V M : Type*) : Possibility Unit V M ≃ (V → M) where
 end Possibility
 
 end DynamicSemantics
+
+/-- The point of index-dref dynamic semantics (`Tense/Dynamic.lean`,
+`Mood/Dynamic.lean`): a `Possibility` whose world coordinate is the
+current evaluation index and whose `ℕ`-registered drefs are also
+world-time indices. Contexts are plain level-0 states
+(`Set (Intensional.WorldTimeIndex.Possibility W Time)`), so the update
+spine of `Semantics/Dynamic/Update.lean` applies directly. -/
+abbrev Intensional.WorldTimeIndex.Possibility (W Time : Type*) :=
+  DynamicSemantics.Possibility (Intensional.WorldTimeIndex W Time) ℕ
+    (Intensional.WorldTimeIndex W Time)

--- a/Linglib/Semantics/Intensional/WorldTimeIndex.lean
+++ b/Linglib/Semantics/Intensional/WorldTimeIndex.lean
@@ -1,4 +1,4 @@
-import Linglib.Semantics.Dynamic.Possibility
+import Mathlib.Tactic.TypeStar
 
 /-!
 # World–Time Indices
@@ -29,18 +29,5 @@ structure WorldTimeIndex (W Time : Type*) where
   /-- The temporal coordinate -/
   time : Time
   deriving Repr
-
-/-- The point of index-dref dynamic semantics (`Tense/Dynamic.lean`,
-`Mood/Dynamic.lean`): a `Possibility` whose world coordinate is the
-current evaluation index and whose `ℕ`-registered drefs are also
-world-time indices. Contexts are plain level-0 states
-(`Set (WorldTimeIndex.Possibility W Time)`), so the update spine of
-`Semantics/Dynamic/Update.lean` applies directly. -/
-abbrev WorldTimeIndex.Possibility (W Time : Type*) :=
-  DynamicSemantics.Possibility (WorldTimeIndex W Time) ℕ (WorldTimeIndex W Time)
-
-/-- A situation-level proposition: a predicate over world–time indices —
-    what tense operators modify. -/
-abbrev SitProp (W Time : Type*) := WorldTimeIndex W Time → Prop
 
 end Intensional

--- a/Linglib/Semantics/Mood/Dynamic.lean
+++ b/Linglib/Semantics/Mood/Dynamic.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Semantics.Dynamic.Update
 import Linglib.Semantics.Intensional.WorldTimeIndex
+import Linglib.Semantics.Dynamic.Possibility
 import Linglib.Semantics.Modality.HistoricalAlternatives
 import Linglib.Semantics.Mood.Situation
 import Linglib.Semantics.Mood.Defs

--- a/Linglib/Semantics/Reference/Context/Basic.lean
+++ b/Linglib/Semantics/Reference/Context/Basic.lean
@@ -53,7 +53,7 @@ def LocatedContext {W E P T : Type*} (c : KContext W E P T)
   located c.agent c.position c.time c.world
 
 /-- Project a KContext to a `WorldTimeIndex` (world + time pair). -/
-def KContext.toSituation {W E P T : Type*} (c : KContext W E P T) :
+def KContext.toWorldTimeIndex {W E P T : Type*} (c : KContext W E P T) :
     WorldTimeIndex W T :=
   ⟨c.world, c.time⟩
 
@@ -79,9 +79,9 @@ def KContext.shiftWorldTime {W E P T : Type*} (c : KContext W E P T)
     (c : KContext W E P T) (s : WorldTimeIndex W T) :
     (c.shiftWorldTime s).agent = c.agent := rfl
 
-@[simp] theorem KContext.shiftWorldTime_toSituation {W E P T : Type*}
+@[simp] theorem KContext.shiftWorldTime_toWorldTimeIndex {W E P T : Type*}
     (c : KContext W E P T) (s : WorldTimeIndex W T) :
-    (c.shiftWorldTime s).toSituation = s := rfl
+    (c.shiftWorldTime s).toWorldTimeIndex = s := rfl
 
 /-- Project a KContext into a root-clause ReichenbachFrame.
     Speech time S = context time; perspective time P = S (root clause

--- a/Linglib/Semantics/Reference/Context/Rich.lean
+++ b/Linglib/Semantics/Reference/Context/Rich.lean
@@ -77,8 +77,8 @@ def RichContext.addressee (rc : RichContext W E P T) : E := rc.base.addressee
 def RichContext.position (rc : RichContext W E P T) : P := rc.base.position
 
 /-- Project a RichContext to a `WorldTimeIndex` (world + time pair). -/
-def RichContext.toSituation (rc : RichContext W E P T) : Intensional.WorldTimeIndex W T :=
-  rc.base.toSituation
+def RichContext.toWorldTimeIndex (rc : RichContext W E P T) : Intensional.WorldTimeIndex W T :=
+  rc.base.toWorldTimeIndex
 
 -- ════════════════════════════════════════════════════════════════
 -- § KContext Lift

--- a/Linglib/Semantics/Tense/Compositional.lean
+++ b/Linglib/Semantics/Tense/Compositional.lean
@@ -17,7 +17,7 @@ cells behind the update spine's test filter.
 namespace Tense
 
 open Core.Order (holds)
-open Intensional (WorldTimeIndex SitProp)
+open Intensional (WorldTimeIndex)
 
 variable {W Time : Type*} [LinearOrder Time]
 
@@ -25,36 +25,36 @@ variable {W Time : Type*} [LinearOrder Time]
     ⟦s⟧ = λP.λsit.λsit'. `holds s τ(sit) τ(sit')` ∧ P(sit) — the cell
     constrains the event–evaluation comparison and the payload is
     evaluated at the event situation. -/
-def constrain (s : Finset Ordering) (P : SitProp W Time)
+def constrain (s : Finset Ordering) (P : (WorldTimeIndex W Time → Prop))
     (sit sit' : WorldTimeIndex W Time) : Prop :=
   holds s sit.time sit'.time ∧ P sit
 
 /-- ⟦PAST⟧ = `constrain past`: the event situation precedes the
     evaluation situation. -/
-abbrev PAST : SitProp W Time → WorldTimeIndex W Time →
+abbrev PAST : (WorldTimeIndex W Time → Prop) → WorldTimeIndex W Time →
     WorldTimeIndex W Time → Prop := constrain past
 
 /-- ⟦PRES⟧ = `constrain present`: the event situation is contemporaneous
     with the evaluation situation. -/
-abbrev PRES : SitProp W Time → WorldTimeIndex W Time →
+abbrev PRES : (WorldTimeIndex W Time → Prop) → WorldTimeIndex W Time →
     WorldTimeIndex W Time → Prop := constrain present
 
 /-- ⟦FUT⟧ = `constrain future`: the event situation follows the
     evaluation situation. -/
-abbrev FUT : SitProp W Time → WorldTimeIndex W Time →
+abbrev FUT : (WorldTimeIndex W Time → Prop) → WorldTimeIndex W Time →
     WorldTimeIndex W Time → Prop := constrain future
 
-@[simp] theorem constrain_past_iff (P : SitProp W Time)
+@[simp] theorem constrain_past_iff (P : (WorldTimeIndex W Time → Prop))
     (sit sit' : WorldTimeIndex W Time) :
     constrain past P sit sit' ↔ sit.time < sit'.time ∧ P sit := by
   simp [constrain]
 
-@[simp] theorem constrain_present_iff (P : SitProp W Time)
+@[simp] theorem constrain_present_iff (P : (WorldTimeIndex W Time → Prop))
     (sit sit' : WorldTimeIndex W Time) :
     constrain present P sit sit' ↔ sit.time = sit'.time ∧ P sit := by
   simp [constrain]
 
-@[simp] theorem constrain_future_iff (P : SitProp W Time)
+@[simp] theorem constrain_future_iff (P : (WorldTimeIndex W Time → Prop))
     (sit sit' : WorldTimeIndex W Time) :
     constrain future P sit sit' ↔ sit'.time < sit.time ∧ P sit := by
   simp [constrain]

--- a/Linglib/Semantics/Tense/DeRe.lean
+++ b/Linglib/Semantics/Tense/DeRe.lean
@@ -129,7 +129,7 @@ theorem isRigidAcrossAlternatives_of_isRigid
 def metaphysicalAlternatives [LE T]
     (history : HistoricalAlternatives W T) (dr : TemporalDeReReading W E P T) :
     Set (WorldTimeIndex W T) :=
-  actualHistoryBase history dr.holderContext.toSituation
+  actualHistoryBase history dr.holderContext.toWorldTimeIndex
 
 /-- **Doxastic** alternative set ([abusch-1997] §3, Hintikka belief
     alternatives): the world-time pairs the holder considers possible,

--- a/Linglib/Semantics/Tense/Dynamic.lean
+++ b/Linglib/Semantics/Tense/Dynamic.lean
@@ -1,5 +1,6 @@
 import Linglib.Semantics.Dynamic.Update
 import Linglib.Semantics.Intensional.WorldTimeIndex
+import Linglib.Semantics.Dynamic.Possibility
 import Linglib.Semantics.Tense.Compositional
 
 /-!

--- a/Linglib/Studies/HeimComments1994.lean
+++ b/Linglib/Studies/HeimComments1994.lean
@@ -50,7 +50,7 @@ of the substrate's: Heim works at `Intension (WorldTimeIndex W T) T`
 (world + time → time), the substrate at
 `Intension (KContext W E P T) T` (agent + addressee + world + time +
 position → time). The pullback `toSubstrate := Intension.precomp
-KContext.toSituation` carries Heim's framework into the substrate by
+KContext.toWorldTimeIndex` carries Heim's framework into the substrate by
 pre-composing with the forgetful projection. The image is exactly the
 **agent-blind** substrate concepts (universal property below). Rigidity
 preservation, set-relativized rigidity preservation, and
@@ -103,29 +103,29 @@ abbrev TimeConcept (W T : Type*) := Intension (WorldTimeIndex W T) T
 -- ════════════════════════════════════════════════════════════════
 
 /-- **Substrate-level pullback** of a Heim time-concept along the
-    forgetful projection `Semantics.Context.KContext.toSituation`. This IS
+    forgetful projection `Semantics.Context.KContext.toWorldTimeIndex`. This IS
     the substrate's intensional pre-composition operator
-    `Intension.precomp` instantiated at `g := KContext.toSituation` —
+    `Intension.precomp` instantiated at `g := KContext.toWorldTimeIndex` —
     no new content; the pullback's structural properties transport
     from the substrate's `precomp`/`IsRigid.precomp`/`IsRigidOn.precomp`
     closure lemmas (`Semantics/Intensional/Rigidity.lean`). -/
 def toSubstrate {W E P T : Type*} (c : TimeConcept W T) :
     Tense.DeRe.TimeConcept W E P T :=
-  Intension.precomp KContext.toSituation c
+  Intension.precomp KContext.toWorldTimeIndex c
 
 /-- **Pullback preserves rigidity**: a rigid Heim time-concept lifts to
     a rigid substrate `TimeConcept`. Direct application of substrate's
-    `Intension.IsRigid.precomp` at `g := KContext.toSituation`. -/
+    `Intension.IsRigid.precomp` at `g := KContext.toWorldTimeIndex`. -/
 theorem toSubstrate_isRigid {W E P T : Type*}
     {c : TimeConcept W T} (h : Intension.IsRigid c) :
     Intension.IsRigid (toSubstrate (E := E) (P := P) c) :=
-  h.precomp KContext.toSituation
+  h.precomp KContext.toWorldTimeIndex
 
 /-- **Pullback preserves set-relativized rigidity**: rigidity on a set
     `S : Set (WorldTimeIndex W T)` of Heim alternatives lifts to
-    rigidity on the preimage `Set.preimage KContext.toSituation S` of
+    rigidity on the preimage `Set.preimage KContext.toWorldTimeIndex S` of
     substrate alternatives. Direct application of substrate's
-    `Intension.IsRigidOn.precomp` at `g := KContext.toSituation`.
+    `Intension.IsRigidOn.precomp` at `g := KContext.toWorldTimeIndex`.
 
     This is the last-mile companion to `toSubstrate_isRigid` that
     closes the substrate's `IsRigidAcrossAlternatives` family
@@ -137,13 +137,13 @@ theorem toSubstrate_isRigidOn {W E P T : Type*}
     {c : TimeConcept W T} {S : Set (WorldTimeIndex W T)}
     (h : Intension.IsRigidOn c S) :
     Intension.IsRigidOn (toSubstrate (E := E) (P := P) c)
-      (Set.preimage KContext.toSituation S) :=
-  h.precomp KContext.toSituation
+      (Set.preimage KContext.toWorldTimeIndex S) :=
+  h.precomp KContext.toWorldTimeIndex
 
 /-- **Universal property of the pullback** (the deep structural
     claim): a substrate `TimeConcept` `k` arises as the pullback of
     some Heim time-concept iff `k` is **agent-blind** (factors
-    through `KContext.toSituation`).
+    through `KContext.toWorldTimeIndex`).
 
     This characterises Heim's framework as the *quotient* of the
     substrate's framework by agent variation — Heim works at the
@@ -161,10 +161,10 @@ theorem toSubstrate_factors_iff_agent_blind {W E P T : Type*}
     (k : Tense.DeRe.TimeConcept W E P T) :
     (∃ c : TimeConcept W T, k = toSubstrate c) ↔
     (∀ c₁ c₂ : KContext W E P T,
-      c₁.toSituation = c₂.toSituation → k c₁ = k c₂) := by
+      c₁.toWorldTimeIndex = c₂.toWorldTimeIndex → k c₁ = k c₂) := by
   constructor
   · rintro ⟨c, rfl⟩ k₁ k₂ heq
-    show c k₁.toSituation = c k₂.toSituation
+    show c k₁.toWorldTimeIndex = c k₂.toWorldTimeIndex
     rw [heq]
   · intro h
     refine ⟨fun s => k ⟨Classical.arbitrary E, Classical.arbitrary E,
@@ -236,7 +236,7 @@ theorem toSubstrate_image_isExhaustiveOn {W E P T : Type*}
       ((fun c : TimeConcept W T =>
         toSubstrate (E := E) (P := P) c) '' cov) dom := by
   intro k r hr
-  obtain ⟨c, hcov, hcr⟩ := h k.toSituation hr
+  obtain ⟨c, hcov, hcr⟩ := h k.toWorldTimeIndex hr
   refine ⟨toSubstrate (E := E) (P := P) c, ⟨c, hcov, rfl⟩, ?_⟩
   exact hcr
 

--- a/Linglib/Studies/Klecha2016.lean
+++ b/Linglib/Studies/Klecha2016.lean
@@ -852,7 +852,7 @@ theorem klecha_covers_hope_future_oriented_reading
 -- ════════════════════════════════════════════════════════════════
 
 /-- **Substrate bridge**: [klecha-2016]'s actual-history base
-    `actualHistoryBase history matrix.toSituation` IS the substrate's
+    `actualHistoryBase history matrix.toWorldTimeIndex` IS the substrate's
     `TemporalDeReReading.metaphysicalAlternatives` (defined in
     `Semantics/Tense/DeRe.lean`) for a `TemporalDeReReading`
     whose holderContext projects to `matrix`. The substrate's
@@ -866,7 +866,7 @@ theorem klecha_actualHistoryBase_eq_substrate_metaphysicalAlternatives
     let dr : Tense.DeRe.TemporalDeReReading W Unit Unit ℤ :=
       ⟨concept, matrix⟩
     dr.metaphysicalAlternatives history =
-    actualHistoryBase history matrix.toSituation := rfl
+    actualHistoryBase history matrix.toWorldTimeIndex := rfl
 
 
 end Klecha2016

--- a/Linglib/Studies/Ogihara1989.lean
+++ b/Linglib/Studies/Ogihara1989.lean
@@ -16,7 +16,7 @@ open Tense
 namespace Ogihara1989
 
 open Tense (interpTense PAST)
-open Intensional (WorldTimeIndex SitProp)
+open Intensional (WorldTimeIndex)
 
 /-- The Priorean `PAST` operator, applied at a referentially determined
     time g(n), decomposes into the conjunction of (1) the referential
@@ -24,7 +24,7 @@ open Intensional (WorldTimeIndex SitProp)
     referential time: the referential analysis picks the time, the
     operator imposes the constraint. -/
 theorem referential_past_decomposition {W Time : Type*} [LinearOrder Time]
-    (P : SitProp W Time) (g : TemporalAssignment Time) (n : ℕ)
+    (P : (WorldTimeIndex W Time → Prop)) (g : TemporalAssignment Time) (n : ℕ)
     (w : W) (speechTime : Time) :
     PAST P ⟨w, interpTense n g⟩ ⟨w, speechTime⟩ ↔
     (g n < speechTime ∧ P ⟨w, g n⟩) := by

--- a/Linglib/Studies/VonStechow2009.lean
+++ b/Linglib/Studies/VonStechow2009.lean
@@ -31,7 +31,7 @@ The paper's second contribution is the situation-indexed attitude
 semantics it synthesizes from [lewis-1979-attitudes],
 [heim-kratzer-1998], and [ogihara-1989]: *believe*'s complement type
 shifts from propositions to situation-dependent propositions
-(`SitProp`), and the doxastic alternatives become world–time pairs.
+(predicates over `WorldTimeIndex`), and the doxastic alternatives become world–time pairs.
 `sitBoxAt` is the universal modal over situations, with Hintikka
 world-only semantics the time-invariant special case
 (`sitBoxAt_lift_eq_BoxAt`); genuinely temporal accessibility
@@ -120,10 +120,10 @@ theorem feature_checking_is_fullPresupposition {Time : Type*} [LinearOrder Time]
 /-! ### Situation-indexed attitudes
 
 The complement type of *believe* shifts from `W → Prop` to
-`SitProp W Time`, and doxastic alternatives become world–time pairs:
+predicates over `WorldTimeIndex W Time`, and doxastic alternatives become world–time pairs:
 ⟦x believes p⟧(w,t) = ∀(w',t') ∈ Dox_x(w,t). p(w',t'). -/
 
-open Intensional (WorldTimeIndex SitProp)
+open Intensional (WorldTimeIndex)
 open Doxastic (Veridicality DoxasticPredicate BoxAt VeridicalityHolds)
 
 variable {W Time E : Type*}
@@ -132,18 +132,18 @@ variable {W Time E : Type*}
     world–time pair. -/
 def sitBoxAt (R : E → WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
     (agent : E) (s : WorldTimeIndex W Time)
-    (situations : List (WorldTimeIndex W Time)) (p : SitProp W Time) : Prop :=
+    (situations : List (WorldTimeIndex W Time)) (p : (WorldTimeIndex W Time → Prop)) : Prop :=
   ∀ s' ∈ situations, R agent s s' → p s'
 
 instance (R : E → WorldTimeIndex W Time → WorldTimeIndex W Time → Prop)
     [∀ a s s', Decidable (R a s s')] (agent : E) (s : WorldTimeIndex W Time)
-    (situations : List (WorldTimeIndex W Time)) (p : SitProp W Time)
+    (situations : List (WorldTimeIndex W Time)) (p : (WorldTimeIndex W Time → Prop))
     [DecidablePred p] : Decidable (sitBoxAt R agent s situations p) :=
   inferInstanceAs (Decidable (∀ s' ∈ situations, _))
 
 /-- A world-proposition as a situation-proposition ignoring the
     temporal coordinate. -/
-def liftProp (p : W → Prop) : SitProp W Time :=
+def liftProp (p : W → Prop) : (WorldTimeIndex W Time → Prop) :=
   fun s => p s.world
 
 /-- A world-accessibility relation as a situation-accessibility
@@ -170,13 +170,13 @@ theorem sitBoxAt_lift_eq_BoxAt (R : E → W → W → Prop) (agent : E)
 
 /-- The veridicality check at a situation: veridical predicates
     require the complement at the evaluation situation. -/
-def sitVeridicalityHolds (v : Veridicality) (p : SitProp W Time)
+def sitVeridicalityHolds (v : Veridicality) (p : (WorldTimeIndex W Time → Prop))
     (s : WorldTimeIndex W Time) : Prop :=
   match v with
   | .veridical => p s
   | .nonVeridical => True
 
-instance (v : Veridicality) (p : SitProp W Time) [DecidablePred p]
+instance (v : Veridicality) (p : (WorldTimeIndex W Time → Prop)) [DecidablePred p]
     (s : WorldTimeIndex W Time) :
     Decidable (sitVeridicalityHolds v p s) := by
   cases v <;> simp [sitVeridicalityHolds] <;> infer_instance
@@ -198,14 +198,14 @@ structure SitDoxasticPredicate (W Time E : Type*) where
 /-- ⟦x V that p⟧(s): the veridicality check at `s` plus the universal
     modal over accessible situations. -/
 def SitDoxasticPredicate.HoldsAt (V : SitDoxasticPredicate W Time E)
-    (agent : E) (p : SitProp W Time) (s : WorldTimeIndex W Time)
+    (agent : E) (p : (WorldTimeIndex W Time → Prop)) (s : WorldTimeIndex W Time)
     (situations : List (WorldTimeIndex W Time)) : Prop :=
   sitVeridicalityHolds V.veridicality p s ∧ sitBoxAt V.access agent s situations p
 
 /-- Veridical situation-indexed predicates entail their complement at
     the evaluation situation. -/
 theorem sit_veridical_entails_complement (V : SitDoxasticPredicate W Time E)
-    (hV : V.veridicality = .veridical) (agent : E) (p : SitProp W Time)
+    (hV : V.veridicality = .veridical) (agent : E) (p : (WorldTimeIndex W Time → Prop))
     (s : WorldTimeIndex W Time) (sits : List (WorldTimeIndex W Time))
     (holds : V.HoldsAt agent p s sits) : p s := by
   unfold SitDoxasticPredicate.HoldsAt at holds


### PR DESCRIPTION
Audit of `Intensional/WorldTimeIndex.lean`, plus the `SitProp` dissolution.

- `SitProp` dissolved: it was a lone alias for `WorldTimeIndex W Time → Prop` (and definitionally identical to `Aspect.PointPred`, which stays — its content is the `IntervalPred`/`PointPred` pipeline contrast); the type is now written inline at the ten signature sites
- `WorldTimeIndex.Possibility` moves to `Dynamic/Possibility.lean` (the machinery it instantiates), making `WorldTimeIndex.lean` a leaf — `Pronoun`, `Aspect`, `Causation`, `HistoricalAlternatives`, and the study importers no longer drag the dynamic spine for a two-field index
- `KContext.toSituation` → `KContext.toWorldTimeIndex`: the projection returns a `WorldTimeIndex`, under exactly the name the index file's docstring disavows