### PR TITLE
style(Tense/SentDenotation): mathlib idiom pass

### DIFF
--- a/Linglib/Semantics/Tense/SentDenotation.lean
+++ b/Linglib/Semantics/Tense/SentDenotation.lean
@@ -23,82 +23,49 @@ BeaverCondoravdi2003, Rett2020, …).
 
 namespace Tense
 
-open NonemptyInterval
 
 variable {Time : Type*} [LinearOrder Time]
 
-/-! ### Sentence Denotations as NonemptyInterval Sets -/
-
-/-- A sentence denotes a set of temporal intervals (its "run-times").
-    Statives denote homogeneous interval sets; accomplishments denote singletons. -/
+/-- A sentence denotes a set of temporal intervals — its "run-times". -/
 abbrev SentDenotation (Time : Type*) [LinearOrder Time] := Set (NonemptyInterval Time)
 
-/-- The set of all time points contained in some interval of a denotation.
-    This projects from interval-set representation to time-set representation,
-    which is what [rett-2020]'s formalization quantifies over. -/
+/-- The time points contained in some interval of a denotation. -/
 def timeTrace (p : SentDenotation Time) : Set Time :=
   { t | ∃ i ∈ p, t ∈ i }
 
+@[simp] theorem mem_timeTrace {p : SentDenotation Time} {t : Time} :
+    t ∈ timeTrace p ↔ ∃ i ∈ p, t ∈ i := Iff.rfl
+
 theorem timeTrace_image {α : Type*} (f : α → NonemptyInterval Time) (s : Set α) :
     timeTrace (f '' s) = { t | ∃ a ∈ s, t ∈ f a } := by
-  ext t; simp [timeTrace]
+  ext t; simp
 
-/-- Stative denotation: the maximal interval `i` plus all its subintervals — the
-    principal downset `Set.Iic i`. It is therefore an `IsLowerSet` (`isLowerSet_Iic`),
-    which *is* the subinterval-closure property.
-
-    This models the idealized *stative* subinterval property (homogeneous down to
-    instants). The *activity* case has a minimal-parts floor — a single step is not
-    "running" — which is the proper-subinterval *stratified reference* of
-    `Aspect/Stratified` / [champollion-2017], not this lower set. -/
+/-- Stative denotation: the maximal interval `i` with all its subintervals —
+    the principal downset `Set.Iic i`, a lower set, which *is* the
+    subinterval-closure property. The *activity* case (a minimal-parts floor:
+    a single step is not "running") is the stratified reference of
+    `Aspect/Stratified` ([champollion-2017]), not this lower set. -/
 def stativeDenotation (i : NonemptyInterval Time) : SentDenotation Time :=
   Set.Iic i
 
-/-- Accomplishment denotation: exactly the singleton interval `i` (`{i}`).
-    Captures the quantized property of telic events. -/
+/-- Accomplishment denotation: exactly the singleton `{i}` — quantization. -/
 def accomplishmentDenotation (i : NonemptyInterval Time) : SentDenotation Time :=
   {i}
 
-/-! ### Basic Properties -/
-
-/-- Every point subinterval of a stative denotation's maximal interval is in the set. -/
-theorem stativeDenotation_contains_point (i : NonemptyInterval Time) (t : Time)
-    (ht : t ∈ i) : NonemptyInterval.pure t ∈ stativeDenotation i :=
-  ⟨ht.1, ht.2⟩
-
-/-- An accomplishment denotation has exactly one member. -/
-theorem accomplishmentDenotation_singleton (i : NonemptyInterval Time) :
-    ∀ j, j ∈ accomplishmentDenotation i ↔ j = i :=
-  λ _ => Iff.rfl
-
-/-- The maximal interval is in its own stative denotation (reflexivity). -/
 theorem stativeDenotation_self (i : NonemptyInterval Time) :
     i ∈ stativeDenotation i :=
-  ⟨le_refl _, le_refl _⟩
+  Set.mem_Iic.mpr le_rfl
 
-/-- The time trace of a stative denotation is exactly the set of times
-    contained in the maximal interval. -/
 theorem timeTrace_stativeDenotation (i : NonemptyInterval Time) :
     timeTrace (stativeDenotation i) = { t | t ∈ i } := by
   ext t
-  simp only [timeTrace, stativeDenotation, Set.mem_Iic, Set.mem_ofPred_eq, NonemptyInterval.mem_def, NonemptyInterval.le_def]
-  constructor
-  · rintro ⟨j, ⟨hjs, hjf⟩, hjt_s, hjt_f⟩
-    exact ⟨le_trans hjs hjt_s, le_trans hjt_f hjf⟩
-  · rintro ⟨hs, hf⟩
-    exact ⟨NonemptyInterval.pure t, ⟨hs, hf⟩, le_refl _, le_refl _⟩
+  simp only [mem_timeTrace, stativeDenotation, Set.mem_Iic, Set.mem_ofPred_eq,
+    NonemptyInterval.mem_def, NonemptyInterval.le_def]
+  grind
 
-/-- The time trace of an accomplishment denotation is exactly the set of times
-    contained in the unique interval. -/
 theorem timeTrace_accomplishmentDenotation (i : NonemptyInterval Time) :
     timeTrace (accomplishmentDenotation i) = { t | t ∈ i } := by
-  ext t
-  simp only [timeTrace, accomplishmentDenotation, Set.mem_singleton_iff, Set.mem_ofPred_eq, NonemptyInterval.mem_def]
-  constructor
-  · rintro ⟨j, rfl, hs, hf⟩
-    exact ⟨hs, hf⟩
-  · rintro ⟨hs, hf⟩
-    exact ⟨i, rfl, hs, hf⟩
+  ext t; simp [timeTrace, accomplishmentDenotation]
 
 
 theorem timeTrace_eventDenotation (P : Event Time → Prop) :


### PR DESCRIPTION
Follow-up to #2200: the merge had concatenated `Basic` + `Projection` without re-idiomatizing the `Basic` half.

- delete two zero-consumer restatement lemmas (`stativeDenotation_contains_point`, the `Iff.rfl` singleton-membership lemma)
- add the missing `@[simp] mem_timeTrace` membership interface (consumers had been unfolding the def by name); `timeTrace_image` becomes `ext; simp`
- derive instead of reprove: `stativeDenotation_self := Set.mem_Iic.mpr le_rfl`; the two 8-line constructor proofs collapse to `simp only \[…\]; grind` and a terminal `simp`
- docstrings to one-liners (keeping the stative/activity caveat), section banners and a dead `open` dropped