### PR TITLE
feat(Studies/Siloni2012): derive the nine properties from lex-syn affordances

### DIFF
--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Reciprocal
+import Mathlib.Order.Irreducible
 
 /-!
 # Siloni (2012): Reciprocal verbs and symmetry
@@ -8,22 +9,29 @@ Beyond periphrastic reciprocals (*each other*), languages have reciprocal
 [siloni-2012] (building on [siloni-2008]) splits them by where
 reciprocalization applies — the `Formation` parameter of
 `Syntax/Reciprocal.lean`, an instance of [reinhart-siloni-2005]'s lex-syn
-parameter. **Lexical** formation (Hebrew *hitnašek*, English intransitive
-*kiss*) bundles θ-roles in the lexicon and yields symmetric verbs whose
-reciprocity is a singular atomic event; **syntactic** formation (French
-*s'embrasser*, Czech *se políbit*) is a productive clitic operation whose
-reciprocity accumulates sub-events. Nine empirical properties cluster along
-this divide (`PropertyCluster`, with the two predicted clusters complementary
-on every property, `properties_complementary`). The paper's sample is
-recorded per-language (`hebrew` … `bulgarian`): lexical in Hebrew, Russian,
-Hungarian, and English; syntactic in French, Italian, Spanish, Romanian,
-Czech, Serbo-Croatian, and Bulgarian (fn. 13 extends the split family-wide:
-East Slavic lexical, West and South Slavic syntactic).
+parameter — and derives nine clustering properties from that split alone:
+"the distinctions all follow from the fact that the two types of verbs are
+formed in different components of the grammar."
 
-Both verb types disallow the "I" reading of embedded reciprocals
-([higginbotham-1980]) because both associate the subject with two θ-roles,
-while the two types fail different necessary conditions along the way; the
-derivation chain (§3.5 → §4.3) culminates in `no_I_reading_either_formation`.
+The file formalizes the reduction, not just its output. A `Component`
+records four architectural facts about a locus of application: whether
+plural events are available (generalization (29) denies them to the
+lexicon), whether the operation works over listed entries, whether it sees
+the θ-roles of two distinct predicates, and whether it must reduce
+accusative case ([reinhart-siloni-2005]). `Component.properties` computes
+the nine-property cluster from these affordances; the paper's concluding
+table is then a theorem (`predictedProperties_lexical`), and the perfect
+complementarity of the two clusters follows from the components differing
+on every affordance (`Component.lexicon_compl`) via a polarity-preserving
+reduction (`Component.properties_compl`). The event-semantic content of
+the singular-event column is order-theoretic: an atomic (sup-irreducible)
+event admits no decomposition into directional sub-events
+(`SubEventReading.not_supIrred`). Both verb types disallow the "I" reading
+of embedded reciprocals ([higginbotham-1980]): reciprocalization cumulates
+both core roles onto the subject (`Voice.reciprocalization`), and the two
+types fail different necessary conditions along the way
+(`no_I_reading_either_formation`). The paper's eleven-language sample is
+recorded per-language (`hebrew` … `bulgarian`).
 -/
 
 namespace Siloni2012
@@ -50,21 +58,79 @@ def Construction.ofFormation : Formation → Construction
   | .lexical   => .lexicalVerb
   | .syntactic => .syntacticVerb
 
-/-- Number of θ-roles associated with the subject: one for periphrastic
-    reciprocals (Theme sits on the anaphoric object), two for both verb
-    types (bundled or parasitic). -/
-def Construction.subjectRoleCount : Construction → Nat
-  | .periphrastic  => 1
-  | .lexicalVerb   => 2
-  | .syntacticVerb => 2
+/-! ### The lex-syn architecture (§3.5, §§5–6) -/
 
-/-- Whether reciprocity is built from sub-events (§2.2): true except for
-    lexical reciprocal verbs, whose singular atomic event has no accessible
-    sub-events. -/
-def Construction.allowsSubEventReading : Construction → Bool
-  | .periphrastic  => true
-  | .lexicalVerb   => false
-  | .syntacticVerb => true
+/-- What a component of the grammar affords an arity operation applying
+    there: the four architectural facts from which the nine properties of
+    reciprocal verbs derive. -/
+structure Component where
+  /-- Plural events are available. Generalization (29) — "plural events are
+      not part of the lexicon's inventory" — denies them to the lexicon
+      (§3.5), so its outputs denote atomic events. -/
+  pluralEvents : Bool
+  /-- The operation works within the stored inventory: its inputs may be
+      frozen entries, and its outputs are listed — so they can drift, head
+      idioms, and feed lexical nominalization (§5.3, §6); listing also caps
+      productivity. -/
+  listedEntries : Bool
+  /-- The θ-roles of two distinct predicates are visible, as in ECM
+      configurations (§5.2); a lexical operation sees a single entry. -/
+  spansPredicates : Bool
+  /-- An arity operation here must reduce accusative case whichever
+      argument it suppresses ([reinhart-siloni-2005]); the syntactic clitic
+      instead absorbs the suppressed argument's own case (§5.1). -/
+  reducesAccusative : Bool
+  deriving DecidableEq, Repr
+
+/-- Pointwise complement of a component's affordances. -/
+def Component.compl (c : Component) : Component where
+  pluralEvents := !c.pluralEvents
+  listedEntries := !c.listedEntries
+  spansPredicates := !c.spansPredicates
+  reducesAccusative := !c.reducesAccusative
+
+/-- The lexicon: listed entries and obligatory accusative reduction, but no
+    plural events and no cross-predicate visibility. -/
+def Component.lexicon : Component where
+  pluralEvents := false
+  listedEntries := true
+  spansPredicates := false
+  reducesAccusative := true
+
+/-- The syntactic derivation: plural events and cross-predicate visibility,
+    with a case-indiscriminate clitic and nothing listed. -/
+def Component.derivation : Component where
+  pluralEvents := true
+  listedEntries := false
+  spansPredicates := true
+  reducesAccusative := false
+
+/-- The two components differ on every affordance. -/
+theorem Component.lexicon_compl :
+    Component.lexicon.compl = Component.derivation := rfl
+
+/-- The component where a construction's reciprocity is composed: in the
+    lexicon only for lexical reciprocal verbs; periphrastic reciprocity is
+    composed by the anaphor's plural operator in the syntax (§2.4). -/
+def Construction.component : Construction → Component
+  | .lexicalVerb => .lexicon
+  | .periphrastic | .syntacticVerb => .derivation
+
+open Voice in
+/-- Number of θ-roles borne by the subject. Both verb types realize
+    [creissels-2025]'s `Voice.reciprocalization`, which cumulates the two
+    core roles onto the derived subject (bundling in the lexicon §4.1,
+    parasitic assignment in the syntax §4.2); the periphrastic subject
+    keeps the transitive frame's single external role. -/
+def Construction.subjectRoleCount : Construction → Nat
+  | .periphrastic => 1
+  | .lexicalVerb | .syntacticVerb =>
+      [reciprocalization.fateOfA, reciprocalization.fateOfP].count .cumulated
+
+/-- Whether reciprocity is built from sub-events: plural events must be
+    available where it is composed (§2.2, generalization (29)). -/
+def Construction.allowsSubEventReading (k : Construction) : Bool :=
+  k.component.pluralEvents
 
 /-! ### The nine-property cluster (§§2–7) -/
 
@@ -102,8 +168,11 @@ structure PropertyCluster where
       verbal Romance clitic, attaches to nouns. -/
   eventNominals : Bool
   /-- (ix) Allows the discontinuous reciprocal construction — subject plus
-      comitative *with*-phrase (§7). Language-level availability; English
-      *kiss* and *hug* resist it despite the lexical setting (fn. 32). -/
+      comitative *with*-phrase (§7). A property of symmetric verbs (§7.5),
+      with verb-level exceptions in both directions: English *kiss* and
+      *hug* resist it (fn. 32), while listed lexical entries in
+      syntax-setting languages (French *se battre* 'fight') allow it
+      (§7.2). -/
   discontinuous : Bool
   deriving DecidableEq, Repr
 
@@ -119,49 +188,51 @@ def PropertyCluster.compl (p : PropertyCluster) : PropertyCluster where
   eventNominals := !p.eventNominals
   discontinuous := !p.discontinuous
 
-/-- Predicted cluster for lexically-formed reciprocal verbs: a closed class
-    of symmetric verbs that can be frozen or drifted, head idioms, derive
-    event nominals, and license discontinuity, but form no ECM reciprocals
-    and retain no accusative on dative suppression. Property (ix) calls the
-    substrate classifier `Formation.allowsDiscontinuous`, so the two agree
-    by construction. -/
-def lexicalProperties : PropertyCluster where
-  singularEvent := true
-  productive := false
-  ecmReciprocals := false
-  frozenInput := true
-  semanticDrift := true
-  phrasalIdioms := true
-  retainsAccOnDativeSuppression := false
-  eventNominals := true
-  discontinuous := Formation.lexical.allowsDiscontinuous
+/-- The property cluster an arity operation's outputs display, computed
+    from the component's affordances: the paper's reduction of the nine
+    properties to the locus of formation. -/
+def Component.properties (c : Component) : PropertyCluster where
+  singularEvent := !c.pluralEvents
+  productive := !c.listedEntries
+  ecmReciprocals := c.spansPredicates
+  frozenInput := c.listedEntries
+  semanticDrift := c.listedEntries
+  phrasalIdioms := c.listedEntries
+  retainsAccOnDativeSuppression := !c.reducesAccusative
+  eventNominals := c.listedEntries
+  discontinuous := !c.pluralEvents
 
-/-- Predicted cluster for syntactically-formed reciprocal verbs: productive,
-    with sub-events, ECM reciprocals, and accusative retention, but no
-    frozen inputs, drift, idioms, event nominals, or discontinuity. -/
-def syntacticProperties : PropertyCluster where
-  singularEvent := false
-  productive := true
-  ecmReciprocals := true
-  frozenInput := false
-  semanticDrift := false
-  phrasalIdioms := false
-  retainsAccOnDativeSuppression := true
-  eventNominals := false
-  discontinuous := Formation.syntactic.allowsDiscontinuous
+/-- The reduction is polarity-preserving: complementary affordances yield
+    complementary property clusters. -/
+theorem Component.properties_compl (c : Component) :
+    c.compl.properties = c.properties.compl := rfl
 
 /-- The predicted property cluster of a formation locus. [nordlinger-2023]'s
     later per-language profiles check the discontinuity prediction against
     attested judgments in `Studies/Nordlinger2023.lean`. -/
-def predictedProperties : Formation → PropertyCluster
-  | .lexical   => lexicalProperties
-  | .syntactic => syntacticProperties
+def predictedProperties (f : Formation) : PropertyCluster :=
+  (Construction.ofFormation f).component.properties
 
-/-- The two predicted clusters are complementary on every property. -/
+/-- The derived lexical cluster matches the paper's concluding table. -/
+theorem predictedProperties_lexical :
+    predictedProperties .lexical =
+      { singularEvent := true, productive := false, ecmReciprocals := false,
+        frozenInput := true, semanticDrift := true, phrasalIdioms := true,
+        retainsAccOnDativeSuppression := false, eventNominals := true,
+        discontinuous := true } := rfl
+
+/-- The two predicted clusters are complementary on every property — by
+    `Component.lexicon_compl` and `Component.properties_compl`. -/
 theorem properties_complementary :
-    syntacticProperties = lexicalProperties.compl := rfl
+    predictedProperties .syntactic = (predictedProperties .lexical).compl := rfl
 
-/-! ### Symmetric verbs (§2.3, §4.1) -/
+/-- The derived discontinuity prediction agrees with the substrate
+    classifier `Formation.allowsDiscontinuous`. -/
+theorem discontinuous_eq_allowsDiscontinuous (f : Formation) :
+    (predictedProperties f).discontinuous = f.allowsDiscontinuous := by
+  cases f <;> rfl
+
+/-! ### Symmetric verbs (§2.3, §7.5) -/
 
 /-- Lexically-formed reciprocal verbs are symmetric verbs: both participants
     are identically involved in a singular atomic event (§2.3), as with
@@ -175,6 +246,43 @@ instance : DecidablePred IsSymmetricVerb :=
 theorem symmetric_iff_singular (f : Formation) :
     IsSymmetricVerb f ↔ (predictedProperties f).singularEvent := by
   cases f <;> decide
+
+/-- "The discontinuous construction is a property of symmetric verbs"
+    (§7.5). -/
+theorem discontinuous_iff_symmetric (f : Formation) :
+    (predictedProperties f).discontinuous ↔ IsSymmetricVerb f := by
+  cases f <;> decide
+
+/-! ### Atomic events and the sub-event reading (§2.2–2.3, §3.5)
+
+The event-semantic content of the singular-event column: generalization
+(29) means lexicon-formed reciprocals denote atomic — sup-irreducible —
+events, and such an event admits no decomposition into directional
+sub-events; reciprocity composed in the syntax sums directional
+sub-events, which license the reading when neither contains the other. -/
+
+section Events
+
+variable {α E : Type*} [SemilatticeSup E] {R : α → α → E → Prop} {x y : α}
+
+/-- The sub-event reading of a reciprocal event (§2.2): the event
+    decomposes into two proper parts, one realizing each direction. -/
+def SubEventReading (R : α → α → E → Prop) (x y : α) (e : E) : Prop :=
+  ∃ e₁ e₂, e₁ < e ∧ e₂ < e ∧ R x y e₁ ∧ R y x e₂ ∧ e = e₁ ⊔ e₂
+
+/-- An event with the sub-event reading is not atomic: symmetric verbs,
+    denoting sup-irreducible events, lack the reading (§2.2–2.3). -/
+theorem SubEventReading.not_supIrred {e : E} :
+    SubEventReading R x y e → ¬ SupIrred e :=
+  fun ⟨_, _, h₁, h₂, _, _, he⟩ hs => (hs.2 he.symm).elim h₁.ne h₂.ne
+
+/-- The sum of incomparable directional sub-events has the sub-event
+    reading: reciprocity by accumulation (§4.2). -/
+theorem subEventReading_sup {e₁ e₂ : E} (h₁ : ¬ e₂ ≤ e₁) (h₂ : ¬ e₁ ≤ e₂)
+    (hxy : R x y e₁) (hyx : R y x e₂) : SubEventReading R x y (e₁ ⊔ e₂) :=
+  ⟨e₁, e₂, left_lt_sup.2 h₁, right_lt_sup.2 h₂, hxy, hyx, rfl⟩
+
+end Events
 
 /-! ### The "I" reading (§2.1, §4.3)
 
@@ -195,6 +303,57 @@ def Construction.allowsIReading (c : Construction) : Bool :=
 theorem I_reading_iff_periphrastic (c : Construction) :
     c.allowsIReading ↔ c = .periphrastic := by
   cases c <;> decide
+
+/-! ### Derivation: formation locus → no "I" reading (§3.5 → §4.3)
+
+The lexical path fails the sub-event condition (generalization (29): no
+plural events in the lexicon); the syntactic path fails the sole-role
+condition (cumulation). Both end at `no_I_reading_either_formation`. -/
+
+/-- Both reciprocal verb types associate the subject with two θ-roles:
+    `Voice.reciprocalization` cumulates both core roles (§4.1, §4.2). -/
+theorem recip_verb_dual_role (f : Formation) :
+    (Construction.ofFormation f).subjectRoleCount = 2 := by
+  cases f <;> rfl
+
+/-- Singular-event verbs lack the sub-event reading: both are projections
+    of the same affordance, `Component.pluralEvents` (§2.2–2.3). -/
+theorem singular_event_no_subevents (f : Formation)
+    (h : (predictedProperties f).singularEvent = true) :
+    (Construction.ofFormation f).allowsSubEventReading = false := by
+  simpa [predictedProperties, Component.properties,
+    Construction.allowsSubEventReading] using h
+
+/-- Sub-event availability is necessary for the "I" reading (§4.3). -/
+theorem subevents_necessary_for_I (c : Construction)
+    (h : c.allowsSubEventReading = false) :
+    c.allowsIReading = false := by
+  simp [Construction.allowsIReading, h]
+
+/-- A sole θ-role on the subject is necessary for the "I" reading (§4.3). -/
+theorem sole_role_necessary_for_I (c : Construction)
+    (h : c.subjectRoleCount ≠ 1) :
+    c.allowsIReading = false := by
+  cases c
+  exacts [absurd rfl h, rfl, rfl]
+
+/-- Lexical derivation: singular event → no sub-events → no "I" reading
+    (§3.5 → §2.2 → §4.3). -/
+theorem lexical_no_I_reading :
+    (Construction.ofFormation .lexical).allowsIReading = false :=
+  subevents_necessary_for_I _ (singular_event_no_subevents _ rfl)
+
+/-- Syntactic derivation: dual role → no "I" reading (§4.2 → §4.3), despite
+    the sub-event reading being available. -/
+theorem syntactic_no_I_reading :
+    (Construction.ofFormation .syntactic).allowsIReading = false :=
+  sole_role_necessary_for_I _ (by decide)
+
+/-- Neither reciprocal verb type allows the "I" reading. -/
+theorem no_I_reading_either_formation (f : Formation) :
+    (Construction.ofFormation f).allowsIReading = false := by
+  cases f
+  exacts [lexical_no_I_reading, syntactic_no_I_reading]
 
 /-! ### Cross-linguistic sample (§2.4, §5, §7) -/
 
@@ -230,59 +389,5 @@ def bulgarian     : LangRecipVerb := ⟨"Bulgarian",      "bul", .syntactic⟩
 def sample : List LangRecipVerb :=
   [hebrew, russian, hungarian, english,
    french, italian, spanish, czech, romanian, serboCroatian, bulgarian]
-
-/-! ### Derivation: formation locus → no "I" reading (§3.5 → §4.3)
-
-Generalization (29): "Plural events are not part of the lexicon's
-inventory." Lexical reciprocalization therefore yields symmetric verbs
-with no sub-events, failing the first condition on the "I" reading;
-syntactic reciprocal verbs have sub-events but fail the sole-role
-condition. Both paths end at `no_I_reading_either_formation`. -/
-
-/-- Both reciprocal verb types associate the subject with two θ-roles:
-    bundling in the lexicon (§4.1), parasitic assignment in the syntax
-    (§4.2). -/
-theorem recip_verb_dual_role (f : Formation) :
-    (Construction.ofFormation f).subjectRoleCount = 2 := by
-  cases f <;> rfl
-
-/-- Singular-event verbs lack the sub-event reading (§2.2–2.3). -/
-theorem singular_event_no_subevents (f : Formation)
-    (h : (predictedProperties f).singularEvent = true) :
-    (Construction.ofFormation f).allowsSubEventReading = false := by
-  cases f
-  · rfl
-  · exact nomatch h
-
-/-- Sub-event availability is necessary for the "I" reading (§4.3). -/
-theorem subevents_necessary_for_I (c : Construction)
-    (h : c.allowsSubEventReading = false) :
-    c.allowsIReading = false := by
-  simp [Construction.allowsIReading, h]
-
-/-- A sole θ-role on the subject is necessary for the "I" reading (§4.3). -/
-theorem sole_role_necessary_for_I (c : Construction)
-    (h : c.subjectRoleCount ≠ 1) :
-    c.allowsIReading = false := by
-  cases c
-  exacts [absurd rfl h, rfl, rfl]
-
-/-- Lexical derivation: singular event → no sub-events → no "I" reading
-    (§3.5 → §2.2 → §4.3). -/
-theorem lexical_no_I_reading :
-    (Construction.ofFormation .lexical).allowsIReading = false :=
-  subevents_necessary_for_I _ (singular_event_no_subevents _ rfl)
-
-/-- Syntactic derivation: dual role → no "I" reading (§4.2 → §4.3), despite
-    the sub-event reading being available. -/
-theorem syntactic_no_I_reading :
-    (Construction.ofFormation .syntactic).allowsIReading = false :=
-  sole_role_necessary_for_I _ (by decide)
-
-/-- Neither reciprocal verb type allows the "I" reading. -/
-theorem no_I_reading_either_formation (f : Formation) :
-    (Construction.ofFormation f).allowsIReading = false := by
-  cases f
-  exacts [lexical_no_I_reading, syntactic_no_I_reading]
 
 end Siloni2012


### PR DESCRIPTION
Replace the stipulated property tables with the paper's own reduction: a `Component` records four architectural affordances (plural events per generalization (29), listed entries, cross-predicate visibility, obligatory accusative reduction), `Component.properties` computes the nine-property cluster from them, and the paper's concluding table becomes a theorem. Complementarity follows from the components differing on every affordance via a polarity-preserving reduction.

- dual θ-role derived from the substrate's `Voice.reciprocalization` cumulation; sub-event availability derived from the composition component
- event-semantic content of the singular-event column: `SubEventReading.not_supIrred` (atomic events admit no directional decomposition) and `subEventReading_sup`, via mathlib's `SupIrred`
- the singular-event → no-sub-events bridge now holds structurally (both project one affordance), not by two-case table check

🤖 Generated with [Claude Code](https://claude.com/claude-code)