### PR TITLE
feat(Semantics): profile order, Landman groups, reciprocal entries

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1715,6 +1715,7 @@ import Linglib.Semantics.Plurality.Basic
 import Linglib.Semantics.Plurality.Cover
 import Linglib.Semantics.Plurality.Cumulativity
 import Linglib.Semantics.Plurality.Distributivity
+import Linglib.Semantics.Plurality.Groups
 import Linglib.Semantics.Plurality.Implicature
 import Linglib.Semantics.Plurality.Reciprocal
 import Linglib.Semantics.Plurality.Trivalent
@@ -2787,6 +2788,7 @@ import Linglib.Syntax.Category.Verb.Basic
 import Linglib.Syntax.Category.Verb.Complement.Basic
 import Linglib.Syntax.Category.Verb.Complement.Takes
 import Linglib.Syntax.Category.Verb.Defs
+import Linglib.Syntax.Category.Verb.Reciprocal
 import Linglib.Syntax.Category.Verb.Stem
 import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Chaining

--- a/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
+++ b/Linglib/Semantics/ArgumentStructure/EntailmentProfile.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.Fintype.Pi
+import Mathlib.Order.BooleanAlgebra.Basic
 import Mathlib.Tactic.DeriveFintype
 
 /-!
@@ -20,6 +21,10 @@ with Proto-Patient dominance breaking ties.
 - `EntailmentProfile.pAgentScore`, `EntailmentProfile.pPatientScore` —
   flat feature counts
 - `PAgentDominates`, `PPatientDominates` — subset ordering on feature sets
+- the pointwise `BooleanAlgebra` instance, `EntailmentProfile.support`, and
+  the cluster sets `ProtoRoleFeature.agentCluster`/`patientCluster` — the
+  Boolean-cube order, with the counting accessors and dominance relations
+  recharacterized as cardinality and cluster-restricted inclusion
 - `OutranksForSubject` — the lattice-based Argument Selection Principle
 - `PredictsUnaccusative`, `PredictsUnergative` — split-intransitivity
   predictions
@@ -318,6 +323,188 @@ themes (*eat*, *build*) add IT per class or per verb — not all accomplishment
 objects measure the event. -/
 def accomplishmentObjectProfile : EntailmentProfile :=
   { changeOfState := true, causallyAffected := true }
+
+/-! ### The Boolean cube order
+
+Pointwise order and Boolean-algebra structure, transported along
+`equivFeatures`: `p ≤ q` is entailment-set inclusion, and `p ⊔ q` imposes
+the union of the two profiles' entailments — [reinhart-siloni-2005]'s role
+bundling. `support` is the imposed entailment set; the counting accessors
+and dominance relations are its cardinality and cluster-restricted
+inclusion (`pAgentScore_eq_card`, `pAgentDominates_iff_subset`). -/
+
+/-- [dowty-1991]'s five Proto-Agent entailments as a feature set. -/
+def ProtoRoleFeature.agentCluster : Finset ProtoRoleFeature :=
+  {.volition, .sentience, .causation, .movement, .independentExistence}
+
+/-- The five Proto-Patient entailments as a feature set. -/
+def ProtoRoleFeature.patientCluster : Finset ProtoRoleFeature :=
+  {.changeOfState, .incrementalTheme, .causallyAffected, .stationary,
+   .dependentExistence}
+
+theorem ProtoRoleFeature.disjoint_agentCluster_patientCluster :
+    Disjoint ProtoRoleFeature.agentCluster ProtoRoleFeature.patientCluster :=
+  Finset.disjoint_left.mpr (by decide)
+
+theorem ProtoRoleFeature.agentCluster_union_patientCluster :
+    ProtoRoleFeature.agentCluster ∪ ProtoRoleFeature.patientCluster =
+      Finset.univ := by decide
+
+namespace EntailmentProfile
+
+instance : BooleanAlgebra EntailmentProfile := equivFeatures.booleanAlgebra
+
+theorem le_def {p q : EntailmentProfile} :
+    p ≤ q ↔ ∀ f, p.feature f ≤ q.feature f := Iff.rfl
+
+instance : DecidableRel (α := EntailmentProfile) (· ≤ ·) := fun _ _ =>
+  decidable_of_iff _ le_def.symm
+
+@[simp] theorem feature_sup (p q : EntailmentProfile) (f : ProtoRoleFeature) :
+    (p ⊔ q).feature f = (p.feature f || q.feature f) := by
+  cases f <;> rfl
+
+/-- The set of entailments a profile imposes. -/
+def support (p : EntailmentProfile) : Finset ProtoRoleFeature :=
+  Finset.univ.filter (fun f => p.feature f)
+
+@[simp] theorem mem_support {p : EntailmentProfile} {f : ProtoRoleFeature} :
+    f ∈ p.support ↔ p.feature f = true := by
+  simp [support]
+
+@[simp] theorem support_sup (p q : EntailmentProfile) :
+    (p ⊔ q).support = p.support ∪ q.support := by
+  ext f; simp
+
+theorem le_iff_support_subset {p q : EntailmentProfile} :
+    p ≤ q ↔ p.support ⊆ q.support := by
+  simp [le_def, Finset.subset_iff, Bool.le_iff_imp]
+
+theorem support_inter_eq_filter (p : EntailmentProfile)
+    (s : Finset ProtoRoleFeature) :
+    p.support ∩ s = s.filter (fun f => p.feature f) := by
+  ext f; simp [and_comm]
+
+/-- The Proto-Agent count is the size of the support's agent-cluster part. -/
+theorem pAgentScore_eq_card (p : EntailmentProfile) :
+    p.pAgentScore = (p.support ∩ ProtoRoleFeature.agentCluster).card := by
+  rw [support_inter_eq_filter]
+  obtain ⟨v, s, c, m, ie, _, _, _, _, _⟩ := p
+  cases v <;> cases s <;> cases c <;> cases m <;> cases ie <;> rfl
+
+/-- The Proto-Patient count is the size of the support's patient-cluster
+    part. -/
+theorem pPatientScore_eq_card (p : EntailmentProfile) :
+    p.pPatientScore = (p.support ∩ ProtoRoleFeature.patientCluster).card := by
+  rw [support_inter_eq_filter]
+  obtain ⟨_, _, _, _, _, cs, it, ca, st, de⟩ := p
+  cases cs <;> cases it <;> cases ca <;> cases st <;> cases de <;> rfl
+
+theorem pAgentScore_mono : Monotone pAgentScore := fun _ _ h => by
+  rw [pAgentScore_eq_card, pAgentScore_eq_card]
+  exact Finset.card_le_card
+    (Finset.inter_subset_inter (le_iff_support_subset.mp h) Finset.Subset.rfl)
+
+theorem pPatientScore_mono : Monotone pPatientScore := fun _ _ h => by
+  rw [pPatientScore_eq_card, pPatientScore_eq_card]
+  exact Finset.card_le_card
+    (Finset.inter_subset_inter (le_iff_support_subset.mp h) Finset.Subset.rfl)
+
+/-- The profile imposes entailments from both proto-role clusters —
+    [reinhart-siloni-2005]'s complex role. -/
+def IsComplexRole (p : EntailmentProfile) : Prop :=
+  0 < p.pAgentScore ∧ 0 < p.pPatientScore
+
+instance : DecidablePred IsComplexRole := fun p =>
+  inferInstanceAs (Decidable (0 < p.pAgentScore ∧ 0 < p.pPatientScore))
+
+/-- Joining an agentive profile with an affected one yields a complex
+    role. -/
+theorem isComplexRole_sup {p q : EntailmentProfile}
+    (ha : 0 < p.pAgentScore) (hp : 0 < q.pPatientScore) :
+    IsComplexRole (p ⊔ q) :=
+  ⟨ha.trans_le (pAgentScore_mono le_sup_left),
+   hp.trans_le (pPatientScore_mono le_sup_right)⟩
+
+end EntailmentProfile
+
+/-- Proto-Agent dominance is inclusion of the supports' agent-cluster
+    parts. -/
+theorem pAgentDominates_iff_subset (p q : EntailmentProfile) :
+    PAgentDominates p q ↔
+      q.support ∩ ProtoRoleFeature.agentCluster ⊆
+        p.support ∩ ProtoRoleFeature.agentCluster := by
+  constructor
+  · rintro ⟨h1, h2, h3, h4, h5⟩ f hf
+    rw [Finset.mem_inter, EntailmentProfile.mem_support] at hf ⊢
+    obtain ⟨hq, hA⟩ := hf
+    refine ⟨?_, hA⟩
+    simp only [ProtoRoleFeature.agentCluster, Finset.mem_insert,
+      Finset.mem_singleton] at hA
+    rcases hA with rfl | rfl | rfl | rfl | rfl
+    exacts [h1 hq, h2 hq, h3 hq, h4 hq, h5 hq]
+  · intro h
+    have H : ∀ f ∈ ProtoRoleFeature.agentCluster,
+        q.feature f = true → p.feature f = true := fun f hA hq =>
+      EntailmentProfile.mem_support.mp
+        (Finset.mem_inter.mp (h (Finset.mem_inter.mpr
+          ⟨EntailmentProfile.mem_support.mpr hq, hA⟩))).1
+    exact ⟨H .volition (by decide), H .sentience (by decide),
+      H .causation (by decide), H .movement (by decide),
+      H .independentExistence (by decide)⟩
+
+/-- Proto-Patient dominance is inclusion of the supports' patient-cluster
+    parts. -/
+theorem pPatientDominates_iff_subset (p q : EntailmentProfile) :
+    PPatientDominates p q ↔
+      q.support ∩ ProtoRoleFeature.patientCluster ⊆
+        p.support ∩ ProtoRoleFeature.patientCluster := by
+  constructor
+  · rintro ⟨h1, h2, h3, h4, h5⟩ f hf
+    rw [Finset.mem_inter, EntailmentProfile.mem_support] at hf ⊢
+    obtain ⟨hq, hA⟩ := hf
+    refine ⟨?_, hA⟩
+    simp only [ProtoRoleFeature.patientCluster, Finset.mem_insert,
+      Finset.mem_singleton] at hA
+    rcases hA with rfl | rfl | rfl | rfl | rfl
+    exacts [h1 hq, h2 hq, h3 hq, h4 hq, h5 hq]
+  · intro h
+    have H : ∀ f ∈ ProtoRoleFeature.patientCluster,
+        q.feature f = true → p.feature f = true := fun f hA hq =>
+      EntailmentProfile.mem_support.mp
+        (Finset.mem_inter.mp (h (Finset.mem_inter.mpr
+          ⟨EntailmentProfile.mem_support.mpr hq, hA⟩))).1
+    exact ⟨H .changeOfState (by decide), H .incrementalTheme (by decide),
+      H .causallyAffected (by decide), H .stationary (by decide),
+      H .dependentExistence (by decide)⟩
+
+/-- The join retains the left component's Proto-Agent entailments. -/
+theorem pAgentDominates_sup_left (p q : EntailmentProfile) :
+    PAgentDominates (p ⊔ q) p :=
+  (pAgentDominates_iff_subset _ _).mpr <| by
+    rw [EntailmentProfile.support_sup]
+    exact Finset.inter_subset_inter Finset.subset_union_left Finset.Subset.rfl
+
+/-- The join retains the right component's Proto-Agent entailments. -/
+theorem pAgentDominates_sup_right (p q : EntailmentProfile) :
+    PAgentDominates (p ⊔ q) q :=
+  (pAgentDominates_iff_subset _ _).mpr <| by
+    rw [EntailmentProfile.support_sup]
+    exact Finset.inter_subset_inter Finset.subset_union_right Finset.Subset.rfl
+
+/-- The join inherits the left component's Proto-Patient entailments. -/
+theorem pPatientDominates_sup_left (p q : EntailmentProfile) :
+    PPatientDominates (p ⊔ q) p :=
+  (pPatientDominates_iff_subset _ _).mpr <| by
+    rw [EntailmentProfile.support_sup]
+    exact Finset.inter_subset_inter Finset.subset_union_left Finset.Subset.rfl
+
+/-- The join inherits the right component's Proto-Patient entailments. -/
+theorem pPatientDominates_sup_right (p q : EntailmentProfile) :
+    PPatientDominates (p ⊔ q) q :=
+  (pPatientDominates_iff_subset _ _).mpr <| by
+    rw [EntailmentProfile.support_sup]
+    exact Finset.inter_subset_inter Finset.subset_union_right Finset.Subset.rfl
 
 end ArgumentStructure
 

--- a/Linglib/Semantics/ArgumentStructure/Projection.lean
+++ b/Linglib/Semantics/ArgumentStructure/Projection.lean
@@ -103,10 +103,9 @@ theorem grimm_agentivity_consistent_with_dowty
   obtain ⟨h1, h2, h3, h4⟩ := (Agentivity.le_iff _ _).mp h
   exact ⟨bImpl _ _ h1, bImpl _ _ h2, bImpl _ _ h3, bImpl _ _ h4⟩
 
-/-- The Dowty→Grimm projection is monotone: if one EntailmentProfile
-    dominates another on P-Agent features, the projected agentivity values
-    are ordered. -/
-theorem fromEntailmentProfile_monotone
+/-- If one EntailmentProfile dominates another on the four lattice P-Agent
+    features, the projected agentivity values are ordered. -/
+theorem fromEntailmentProfile_le
     (p q : EntailmentProfile)
     (hv : p.volition = true → q.volition = true)
     (hs : p.sentience = true → q.sentience = true)
@@ -115,6 +114,16 @@ theorem fromEntailmentProfile_monotone
     Agentivity.fromEntailmentProfile p ≤
     Agentivity.fromEntailmentProfile q :=
   (Agentivity.le_iff _ _).mpr ⟨hv, hs, hc, hm⟩
+
+/-- The Dowty→Grimm projection is monotone in the pointwise profile
+    order. -/
+theorem fromEntailmentProfile_monotone :
+    Monotone Agentivity.fromEntailmentProfile := fun p q h =>
+  fromEntailmentProfile_le p q
+    (Bool.le_iff_imp.mp (EntailmentProfile.le_def.mp h .volition))
+    (Bool.le_iff_imp.mp (EntailmentProfile.le_def.mp h .sentience))
+    (Bool.le_iff_imp.mp (EntailmentProfile.le_def.mp h .causation))
+    (Bool.le_iff_imp.mp (EntailmentProfile.le_def.mp h .movement))
 
 /-! ### Dominance is lattice order plus independent existence
 
@@ -145,7 +154,7 @@ theorem pAgentScore_decomposition (p : EntailmentProfile) :
 /-- Dowty's subset dominance is exactly Grimm's lattice order plus an
     independent-existence implication ([grimm-2011] §2.2, Fig. 1): the
     projection loses no dominance information. Derived from
-    `fromEntailmentProfile_monotone` and
+    `fromEntailmentProfile_le` and
     `grimm_agentivity_consistent_with_dowty`. -/
 theorem pAgentDominates_iff (p q : EntailmentProfile) :
     PAgentDominates p q ↔
@@ -154,7 +163,7 @@ theorem pAgentDominates_iff (p q : EntailmentProfile) :
       (q.independentExistence = true → p.independentExistence = true) := by
   constructor
   · rintro ⟨hv, hs, hc, hm, hie⟩
-    exact ⟨fromEntailmentProfile_monotone q p hv hs hc hm, hie⟩
+    exact ⟨fromEntailmentProfile_le q p hv hs hc hm, hie⟩
   · rintro ⟨hle, hie⟩
     obtain ⟨h1, h2, h3, h4⟩ := grimm_agentivity_consistent_with_dowty q p hle
     exact ⟨fun hq => by simpa [hq] using h1, fun hq => by simpa [hq] using h2,

--- a/Linglib/Semantics/Plurality/Groups.lean
+++ b/Linglib/Semantics/Plurality/Groups.lean
@@ -1,0 +1,47 @@
+import Linglib.Semantics.Mereology
+
+/-!
+# Group formation and dissolution
+
+[landman-1989] [landman-2000]
+
+Landman's group operators over a part-of domain: `up` packs a plural sum
+into a group atom — *the committee* as a singular entity over its
+members — and `down` dissolves the group back into the underlying sum.
+The carrier is any `SemilatticeSup`, so the operators serve the domain of
+individuals and the domain of events alike ([landman-2000]); in the event
+domain, a symmetric verb's atomic event dissolves into the sum of its
+directional sub-events ([siloni-2012] §4.1).
+
+## Main declarations
+
+* `GroupStructure` — `up`/`down` with the atomicity and dissolution laws.
+* `GroupStructure.up_injective` — distinct sums form distinct groups.
+-/
+
+namespace Semantics.Plurality
+
+/-- Landman's group structure: `up` packs a sum into a group atom, `down`
+    recovers the underlying sum. The two laws are the operative core of
+    [landman-1989]'s postulates. -/
+structure GroupStructure (E : Type*) [SemilatticeSup E] where
+  /-- Group formation (Landman's `↑`). -/
+  up : E → E
+  /-- Group dissolution (Landman's `↓`). -/
+  down : E → E
+  /-- A group is an atom: it has no proper parts. -/
+  atom_up (x : E) : Mereology.Atom (up x)
+  /-- Dissolution inverts formation. -/
+  down_up (x : E) : down (up x) = x
+
+namespace GroupStructure
+
+variable {E : Type*} [SemilatticeSup E] (G : GroupStructure E)
+
+/-- Distinct sums form distinct group atoms. -/
+theorem up_injective : Function.Injective G.up :=
+  Function.LeftInverse.injective G.down_up
+
+end GroupStructure
+
+end Semantics.Plurality

--- a/Linglib/Studies/Nordlinger2023.lean
+++ b/Linglib/Studies/Nordlinger2023.lean
@@ -285,13 +285,14 @@ theorem valency_follows_default_except_wambaya :
 
     Checked against independently recorded judgments: every profile
     carrying both a formation locus and an attested discontinuity
-    judgment ([nordlinger-2023] ex. 36–40) satisfies the prediction —
+    judgment ([nordlinger-2023] ex. 36–40) satisfies the cluster value
+    `Siloni2012.predictedProperties` derives from the formation locus —
     Greek, Swahili, Hungarian (lexical, attested) vs French, Czech
     (syntactic, ungrammatical). -/
 theorem siloni_discontinuity_prediction :
     allRecipProfiles.all fun p =>
       match p.formation, p.discontinuousAttested with
-      | some f, some d => f.allowsDiscontinuous == d
+      | some f, some d => (Siloni2012.predictedProperties f).discontinuous == d
       | _, _ => true := by decide
 
 /-! ### WALS grounding

--- a/Linglib/Studies/Siloni2012.lean
+++ b/Linglib/Studies/Siloni2012.lean
@@ -1,47 +1,50 @@
 import Linglib.Syntax.Reciprocal
+import Linglib.Syntax.Category.Verb.Reciprocal
 import Linglib.Semantics.ArgumentStructure.RoleList
-import Mathlib.Order.Irreducible
+import Linglib.Semantics.Plurality.Groups
 
 /-!
 # Siloni (2012): Reciprocal verbs and symmetry
 
 Beyond periphrastic reciprocals (*each other*), languages have reciprocal
-*verbs* — predicates that express reciprocity without an anaphoric object.
-[siloni-2012] (building on [siloni-2008]) splits them by where
-reciprocalization applies — the `Formation` parameter of
-`Syntax/Reciprocal.lean`, an instance of [reinhart-siloni-2005]'s lex-syn
-parameter — and derives nine clustering properties from that split alone:
-"the distinctions all follow from the fact that the two types of verbs are
-formed in different components of the grammar."
+*verbs* — predicates that express reciprocity without an anaphoric object,
+carried as `Verb.Reciprocal` entries. [siloni-2012] (building on
+[siloni-2008]) splits them by where reciprocalization applies — the
+`Formation` parameter of `Syntax/Reciprocal.lean`, an instance of
+[reinhart-siloni-2005]'s lex-syn parameter — and derives nine clustering
+properties from that split alone: "the distinctions all follow from the
+fact that the two types of verbs are formed in different components of the
+grammar."
 
-The reciprocalization operation itself acts on argument structure:
-`reciprocalize` takes a transitive `RoleList` and returns an intransitive
-one whose subject bears the `bundle` of the two base profiles — the
-pointwise join on `EntailmentProfile`, [reinhart-siloni-2005]'s complex
-[θᵢ · θⱼ] role. The bundled subject retains the base subject's Proto-Agent
-entailments and inherits the object's Proto-Patient entailments
-(`pAgentDominates_bundle_left`, `pPatientDominates_bundle_right` — the
-depictive and comparative-ellipsis diagnostics of §3.1–3.2), so it bears
-entailments from both clusters (`reciprocalize_isComplexRole`). Since the
-"I" reading of embedded reciprocals ([higginbotham-1980]) requires a
-sub-event reading plus a sole-role subject, both verb types lack it for
-*any* transitive base with an agentive subject and an affected object
-(`I_reading_iff_periphrastic`), each failing a different condition.
+Reciprocalization acts on argument structure: `reciprocalize` takes a
+transitive `RoleList` and returns an intransitive one whose subject bears
+the join of the two base profiles — [reinhart-siloni-2005]'s complex
+`[θᵢ · θⱼ]` role, `EntailmentProfile`'s `⊔`. The bundled subject retains
+the base subject's Proto-Agent entailments and inherits the object's
+Proto-Patient entailments (`reciprocalize_dominates` — the depictive and
+comparative-ellipsis diagnostics of §3.1–3.2), so it is a complex role
+(`EntailmentProfile.IsComplexRole`). Event-semantically, a symmetric verb
+denotes a *group* event ([landman-2000]'s `up`, `Plurality.GroupStructure`):
+`SymmetricEvent.down_eq` is the paper's (41) — dissolution recovers the
+directional sub-events — while `SymmetricEvent.not_subEventReading`
+delivers §2.2's observation that the atom itself never decomposes. Since
+the "I" reading of embedded reciprocals ([higginbotham-1980]; the
+LF-decomposed periphrastic arm is `Studies/HeimLasnikMay1991.lean`)
+requires a sub-event reading plus a sole-role subject, both verb types
+lack it for any transitive base with an agentive subject and an affected
+object (`I_reading_iff_periphrastic`), each failing a different condition.
 
 The nine surface properties derive from four affordances of the locus of
 application (`pluralEventsAvailable` per generalization (29),
 `storesOutputs`, `spansPredicates`, `reducesAccusative`): the paper's
 concluding table is a theorem (`predictedProperties_lexical`), as is the
-perfect complementarity of the two clusters. The event-semantic content of
-the singular-event column is order-theoretic: an atomic (sup-irreducible)
-event admits no decomposition into directional sub-events
-(`SubEventReading.not_supIrred`). The paper's eleven-language sample is
-recorded per-language (`hebrew` … `bulgarian`).
+perfect complementarity of the two clusters. The paper's eleven-language
+sample is recorded per-language (`hebrew` … `bulgarian`).
 -/
 
 namespace Siloni2012
 
-open Reciprocal ArgumentStructure
+open Reciprocal ArgumentStructure Semantics.Plurality
 
 /-! ### Three-way reciprocal classification (§2.4) -/
 
@@ -71,15 +74,18 @@ paper's mechanisms; the nine surface properties are computed from them in
 
 /-- Generalization (29): "plural events are not part of the lexicon's
     inventory" (§3.5) — sub-event accumulation is available only in the
-    syntactic derivation. -/
+    syntactic derivation, so lexicon-formed reciprocals denote group atoms
+    (`SymmetricEvent`), whose sub-events are recovered only by
+    dissolution. -/
 def pluralEventsAvailable : Formation → Bool
   | .lexical   => false
   | .syntactic => true
 
 /-- Whether the operation's outputs are stored entries. Applying within the
-    inventory, the lexical operation may also take frozen entries as input;
-    stored outputs can drift, head idioms, and feed lexical nominalization,
-    and listing caps productivity (§5.3, §6). -/
+    inventory, the lexical operation may also take frozen entries as input
+    (`Verb.Reciprocal.IsFrozen`); stored outputs can drift, head idioms,
+    and feed lexical nominalization, and listing caps productivity
+    (§5.3, §6). -/
 def storesOutputs : Formation → Bool
   | .lexical   => true
   | .syntactic => false
@@ -114,77 +120,85 @@ theorem compositionLocus_ofFormation (f : Formation) :
     (Construction.ofFormation f).compositionLocus = f := by
   cases f <;> rfl
 
-/-! ### θ-role bundling on argument structure (§4.1–4.2)
+/-! ### Group events and the sub-event reading (§2.2–2.3, §4.1)
+
+The event domain is a semilattice of events under sum; a symmetric verb
+denotes a *group* event — [landman-2000]'s `up` applied to the sum of the
+two directional sub-events. Dissolution recovers the sub-events (the
+paper's (41)), but the group atom itself has no proper parts, so counting
+and modification never see them. -/
+
+section Events
+
+variable {α E : Type*} [SemilatticeSup E] {R : α → α → E → Prop} {x y : α}
+  {e : E}
+
+/-- The sub-event reading of a reciprocal event (§2.2): the event
+    decomposes into two proper parts, one realizing each direction. -/
+def SubEventReading (R : α → α → E → Prop) (x y : α) (e : E) : Prop :=
+  ∃ e₁ e₂, e₁ < e ∧ e₂ < e ∧ R x y e₁ ∧ R y x e₂ ∧ e = e₁ ⊔ e₂
+
+/-- An event with the sub-event reading has proper parts, so it is not
+    atomic (§2.2–2.3). -/
+theorem SubEventReading.not_atom :
+    SubEventReading R x y e → ¬ Mereology.Atom e :=
+  fun ⟨_, _, h₁, _, _, _, _⟩ ha => h₁.ne (ha.eq h₁.le)
+
+/-- The sum of incomparable directional sub-events has the sub-event
+    reading: reciprocity by accumulation (§4.2). -/
+theorem subEventReading_sup {e₁ e₂ : E} (h₁ : ¬ e₂ ≤ e₁) (h₂ : ¬ e₁ ≤ e₂)
+    (hxy : R x y e₁) (hyx : R y x e₂) : SubEventReading R x y (e₁ ⊔ e₂) :=
+  ⟨e₁, e₂, left_lt_sup.2 h₁, right_lt_sup.2 h₂, hxy, hyx, rfl⟩
+
+/-- The symmetric-verb denotation ((36)'s SYM marking, (41a)): an atomic
+    mutual event packing the two directional sub-events into a group
+    event. "SYM is not a feature": it abbreviates the meaning postulate
+    relating V_SYM to V, `SymmetricEvent.down_eq`. -/
+def SymmetricEvent (G : GroupStructure E) (R : α → α → E → Prop)
+    (x y : α) (e : E) : Prop :=
+  ∃ e₁ e₂, R x y e₁ ∧ R y x e₂ ∧ e = G.up (e₁ ⊔ e₂)
+
+/-- The paper's (41): a symmetric reciprocal event dissolves into
+    underlying directional events — "John and Mary kissed" entails a
+    kissing by John of Mary and one by Mary of John. -/
+theorem SymmetricEvent.down_eq {G : GroupStructure E}
+    (h : SymmetricEvent G R x y e) :
+    ∃ e₁ e₂, G.down e = e₁ ⊔ e₂ ∧ R x y e₁ ∧ R y x e₂ := by
+  obtain ⟨e₁, e₂, h₁, h₂, rfl⟩ := h
+  exact ⟨e₁, e₂, G.down_up _, h₁, h₂⟩
+
+/-- The symmetric event itself is atomic: count adverbials count it once,
+    and the sub-event reading is unavailable for any directional relation
+    (§2.2–2.3). -/
+theorem SymmetricEvent.not_subEventReading {G : GroupStructure E}
+    (h : SymmetricEvent G R x y e) {R' : α → α → E → Prop} {x' y' : α} :
+    ¬ SubEventReading R' x' y' e := by
+  obtain ⟨e₁, e₂, -, -, rfl⟩ := h
+  exact fun hs => hs.not_atom (G.atom_up _)
+
+end Events
+
+/-! ### Reciprocalization on argument structure (§4.1–4.2)
 
 Reciprocalization eliminates the internal argument position and associates
 its θ-role with the subject — bundling in the lexicon, parasitic
 assignment in the syntax; the resulting role state is the same. On the
-Dowty substrate this is the pointwise join of entailment profiles, applied
-to a transitive `RoleList`. -/
+Dowty substrate this is `EntailmentProfile`'s join, applied to a
+transitive `RoleList`; realizes [creissels-2025]'s `Voice.reciprocalization`
+coding-frame operation (both core roles cumulated, derived construction
+intransitive). -/
 
-section Bundling
+section Reciprocalize
 
-variable (p q : EntailmentProfile) {r : RoleList} {o : EntailmentProfile}
+variable {r : RoleList} {o : EntailmentProfile}
 
-/-- [reinhart-siloni-2005]'s bundling `[θᵢ · θⱼ]`: the complex role imposing
-    both components' entailments — the pointwise join on the Boolean cube
-    of proto-role features. -/
-def bundle : EntailmentProfile where
-  volition := p.volition || q.volition
-  sentience := p.sentience || q.sentience
-  causation := p.causation || q.causation
-  movement := p.movement || q.movement
-  independentExistence := p.independentExistence || q.independentExistence
-  changeOfState := p.changeOfState || q.changeOfState
-  incrementalTheme := p.incrementalTheme || q.incrementalTheme
-  causallyAffected := p.causallyAffected || q.causallyAffected
-  stationary := p.stationary || q.stationary
-  dependentExistence := p.dependentExistence || q.dependentExistence
-
-/-- The bundled role retains the first component's Proto-Agent entailments:
-    the reciprocal subject is still agentive. -/
-theorem pAgentDominates_bundle_left : PAgentDominates (bundle p q) p := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> intro h <;> simp [bundle, h]
-
-/-- The bundled role inherits the second component's Proto-Patient
-    entailments: the reciprocal subject bears the base object's theme
-    entailments — Czech depictives (§3.1) and comparative ellipsis (§3.2). -/
-theorem pPatientDominates_bundle_right : PPatientDominates (bundle p q) q := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> intro h <;> simp [bundle, h]
-
-theorem pAgentScore_le_bundle : p.pAgentScore ≤ (bundle p q).pAgentScore := by
-  have H : ∀ a b : Bool, a.toNat ≤ (a || b).toNat := by decide
-  exact Nat.add_le_add (Nat.add_le_add (Nat.add_le_add (Nat.add_le_add
-    (H .. ) (H ..)) (H ..)) (H ..)) (H ..)
-
-theorem pPatientScore_le_bundle : q.pPatientScore ≤ (bundle p q).pPatientScore := by
-  have H : ∀ a b : Bool, b.toNat ≤ (a || b).toNat := by decide
-  exact Nat.add_le_add (Nat.add_le_add (Nat.add_le_add (Nat.add_le_add
-    (H ..) (H ..)) (H ..)) (H ..)) (H ..)
-
-/-- A complex role in [reinhart-siloni-2005]'s sense: entailments from both
-    proto-role clusters. The "sole role requirement" on the "I" reading
-    (§4.3) is the negation of this. -/
-def IsComplexRole (p : EntailmentProfile) : Prop :=
-  0 < p.pAgentScore ∧ 0 < p.pPatientScore
-
-instance : DecidablePred IsComplexRole :=
-  fun p => inferInstanceAs (Decidable (0 < p.pAgentScore ∧ 0 < p.pPatientScore))
-
-/-- Bundling an agentive profile with an affected one yields a complex
-    role. -/
-theorem bundle_isComplexRole (ha : 0 < p.pAgentScore) (hp : 0 < q.pPatientScore) :
-    IsComplexRole (bundle p q) :=
-  ⟨ha.trans_le (pAgentScore_le_bundle p q), hp.trans_le (pPatientScore_le_bundle p q)⟩
-
-/-- Reciprocalization on argument structure: the internal position is
-    eliminated and its profile bundled onto the subject. Realizes
-    [creissels-2025]'s `Voice.reciprocalization` coding-frame operation —
-    both core roles cumulated, derived construction intransitive. -/
+/-- Reciprocalization ((35)): the internal position is eliminated and its
+    profile bundled onto the subject; "the bundle [θᵢ - θⱼ] retains the
+    thematic properties of [θᵢ] and [θⱼ]" (`reciprocalize_dominates`). -/
 def reciprocalize (r : RoleList) : RoleList where
   subjectProfile :=
     match r.objectProfile with
-    | some o => bundle r.subjectProfile o
+    | some o => r.subjectProfile ⊔ o
     | none   => r.subjectProfile
 
 /-- Reciprocalization denucleativizes: no internal argument survives. -/
@@ -192,22 +206,66 @@ theorem reciprocalize_objectProfile (r : RoleList) :
     (reciprocalize r).objectProfile = none := rfl
 
 theorem reciprocalize_subjectProfile (ho : r.objectProfile = some o) :
-    (reciprocalize r).subjectProfile = bundle r.subjectProfile o := by
+    (reciprocalize r).subjectProfile = r.subjectProfile ⊔ o := by
   simp [reciprocalize, ho]
+
+/-- The reciprocalized subject retains the base subject's Proto-Agent
+    entailments and inherits the object's Proto-Patient entailments — the
+    Czech depictive (§3.1) and comparative-ellipsis (§3.2) diagnostics. -/
+theorem reciprocalize_dominates (ho : r.objectProfile = some o) :
+    PAgentDominates (reciprocalize r).subjectProfile r.subjectProfile ∧
+    PPatientDominates (reciprocalize r).subjectProfile o := by
+  rw [reciprocalize_subjectProfile ho]
+  exact ⟨pAgentDominates_sup_left .., pPatientDominates_sup_right ..⟩
 
 /-- For any transitive base with an agentive subject and an affected
     object, the reciprocalized subject bears a complex role (§4.1). -/
 theorem reciprocalize_isComplexRole (ho : r.objectProfile = some o)
     (ha : 0 < r.subjectProfile.pAgentScore) (hp : 0 < o.pPatientScore) :
-    IsComplexRole (reciprocalize r).subjectProfile := by
+    ((reciprocalize r).subjectProfile).IsComplexRole := by
   rw [reciprocalize_subjectProfile ho]
-  exact bundle_isComplexRole _ _ ha hp
+  exact EntailmentProfile.isComplexRole_sup ha hp
 
-end Bundling
+/-- A reciprocal verb entry's bundled subject role is the subject of its
+    reciprocalized base grid: the entry-level and grid-level operations
+    agree. -/
+theorem bundledSubjectProfile_eq_reciprocalize (v : Verb.Reciprocal)
+    {b : Verb} {ps po : EntailmentProfile} (hb : v.base = some b)
+    (hs : b.subjectEntailments = some ps)
+    (ho : b.objectEntailments = some po) :
+    v.bundledSubjectProfile = some (reciprocalize ⟨ps, some po⟩).subjectProfile := by
+  rw [Verb.Reciprocal.bundledSubjectProfile_eq hb hs ho]; rfl
+
+variable {α E : Type*} [SemilatticeSup E] in
+/-- Reciprocal bundling ((36)): `V(ACC) [θᵢ] [θⱼ] → V_SYM [θᵢ - θⱼ]` — one
+    lexical operation, two components. On the grid, the accusative is
+    reduced and the internal role bundled onto the subject
+    (`reciprocalize`; `RoleList` carries no case slot, so the reduction
+    surfaces as the loss of the object position, and its typological trace
+    is `reducesAccusative`). On the denotation, SYM packs the base
+    relation's directional events into group atoms (`SymmetricEvent`). -/
+def reciprocalBundling (G : GroupStructure E) (grid : RoleList)
+    (den : α → α → E → Prop) : RoleList × (α → α → E → Prop) :=
+  (reciprocalize grid, SymmetricEvent G den)
+
+variable {α E : Type*} [SemilatticeSup E] {den : α → α → E → Prop}
+  {grid : RoleList} {x y : α} {e : E} in
+/-- What SYM buys ((36), (41)): each event of the derived verb is a single
+    atom — counting and modification see one event — yet entails a base
+    event in each direction. -/
+theorem reciprocalBundling_symmetric (G : GroupStructure E)
+    (hden : (reciprocalBundling G grid den).2 x y e) :
+    Mereology.Atom e ∧
+      ∃ e₁ e₂, G.down e = e₁ ⊔ e₂ ∧ den x y e₁ ∧ den y x e₂ := by
+  obtain ⟨e₁, e₂, h₁, h₂, rfl⟩ := hden
+  exact ⟨G.atom_up _, e₁, e₂, G.down_up _, h₁, h₂⟩
+
+end Reciprocalize
 
 -- Reciprocalizing the manner-of-contact template (the surface-contact
 -- *kiss*/*hug* family) yields a complex subject role.
-example : IsComplexRole (reciprocalize mannerContact).subjectProfile := by decide
+example : ((reciprocalize mannerContact).subjectProfile).IsComplexRole := by
+  decide
 
 /-! ### The nine-property cluster (§§2–7) -/
 
@@ -322,44 +380,14 @@ theorem discontinuous_iff_symmetric (f : Formation) :
     (predictedProperties f).discontinuous = true ↔ IsSymmetricVerb f := by
   cases f <;> decide
 
-/-! ### Atomic events and the sub-event reading (§2.2–2.3, §3.5)
-
-The event-semantic content of the singular-event column: generalization
-(29) means lexicon-formed reciprocals denote atomic — sup-irreducible —
-events, and such an event admits no decomposition into directional
-sub-events; reciprocity composed in the syntax sums directional
-sub-events, which license the reading when neither contains the other. -/
-
-section Events
-
-variable {α E : Type*} [SemilatticeSup E] {R : α → α → E → Prop} {x y : α}
-
-/-- The sub-event reading of a reciprocal event (§2.2): the event
-    decomposes into two proper parts, one realizing each direction. -/
-def SubEventReading (R : α → α → E → Prop) (x y : α) (e : E) : Prop :=
-  ∃ e₁ e₂, e₁ < e ∧ e₂ < e ∧ R x y e₁ ∧ R y x e₂ ∧ e = e₁ ⊔ e₂
-
-/-- An event with the sub-event reading is not atomic: symmetric verbs,
-    denoting sup-irreducible events, lack the reading (§2.2–2.3). -/
-theorem SubEventReading.not_supIrred {e : E} :
-    SubEventReading R x y e → ¬ SupIrred e :=
-  fun ⟨_, _, h₁, h₂, _, _, he⟩ hs => (hs.2 he.symm).elim h₁.ne h₂.ne
-
-/-- The sum of incomparable directional sub-events has the sub-event
-    reading: reciprocity by accumulation (§4.2). -/
-theorem subEventReading_sup {e₁ e₂ : E} (h₁ : ¬ e₂ ≤ e₁) (h₂ : ¬ e₁ ≤ e₂)
-    (hxy : R x y e₁) (hyx : R y x e₂) : SubEventReading R x y (e₁ ⊔ e₂) :=
-  ⟨e₁, e₂, left_lt_sup.2 h₁, right_lt_sup.2 h₂, hxy, hyx, rfl⟩
-
-end Events
-
 /-! ### The "I" reading (§2.1, §4.3)
 
 In "John and Paul said they defeated each other in the final"
 ([higginbotham-1980]), the "I" reading — John said he defeated Paul, and
 Paul said he defeated John — requires both that the embedded verb allow
 the sub-event reading and that its subject bear exactly one θ-role
-(§4.3, p. 287). -/
+(§4.3, p. 287). The LF decomposition of the periphrastic side and the
+full grain problem live in `Studies/HeimLasnikMay1991.lean`. -/
 
 section IReading
 
@@ -376,7 +404,7 @@ def Construction.subjectProfile (r : RoleList) : Construction → EntailmentProf
     reading must be available and the subject must bear a sole role — a
     profile that is not complex. -/
 def Construction.allowsIReading (r : RoleList) (c : Construction) : Prop :=
-  c.allowsSubEventReading ∧ ¬ IsComplexRole (c.subjectProfile r)
+  c.allowsSubEventReading ∧ ¬ (c.subjectProfile r).IsComplexRole
 
 /-- Sub-event availability is necessary for the "I" reading (§4.3). -/
 theorem subevents_necessary_for_I (h : c.allowsSubEventReading = false) :
@@ -384,14 +412,14 @@ theorem subevents_necessary_for_I (h : c.allowsSubEventReading = false) :
   fun hc => absurd hc.1 (by simp [h])
 
 /-- A sole θ-role on the subject is necessary for the "I" reading (§4.3). -/
-theorem complex_role_blocks_I (h : IsComplexRole (c.subjectProfile r)) :
+theorem complex_role_blocks_I (h : (c.subjectProfile r).IsComplexRole) :
     ¬ c.allowsIReading r :=
   fun hc => hc.2 h
 
 /-- A periphrastic reciprocal over a non-complex subject role allows the
     "I" reading: sub-events from the anaphor's plural operator, sole role
     on the subject. -/
-theorem periphrastic_allows_I (hs : ¬ IsComplexRole r.subjectProfile) :
+theorem periphrastic_allows_I (hs : ¬ r.subjectProfile.IsComplexRole) :
     Construction.periphrastic.allowsIReading r :=
   ⟨rfl, hs⟩
 
@@ -420,7 +448,7 @@ theorem no_I_reading_either_formation (f : Formation)
 /-- Over any transitive base whose subject role is agentive but not
     complex and whose object is affected, the "I" reading is available in
     the periphrastic construction and only there. -/
-theorem I_reading_iff_periphrastic (hs : ¬ IsComplexRole r.subjectProfile)
+theorem I_reading_iff_periphrastic (hs : ¬ r.subjectProfile.IsComplexRole)
     (ho : r.objectProfile = some o) (ha : 0 < r.subjectProfile.pAgentScore)
     (hp : 0 < o.pPatientScore) :
     c.allowsIReading r ↔ c = .periphrastic := by

--- a/Linglib/Syntax/Category/Verb/Reciprocal.lean
+++ b/Linglib/Syntax/Category/Verb/Reciprocal.lean
@@ -1,0 +1,63 @@
+import Linglib.Syntax.Category.Verb.Defs
+import Linglib.Syntax.Reciprocal
+
+/-!
+# Reciprocal verb entries
+
+A reciprocal verb expresses mutual action without a reciprocal anaphor —
+intransitive *kiss*, Hebrew *hitnašek*, French *s'embrasser*. An entry
+records the verb, the locus where reciprocalization formed it
+([reinhart-siloni-2005]'s lex-syn parameter; [siloni-2008], [siloni-2012]),
+and its transitive alternate when the vocabulary has one — frozen entries
+(Hebrew *hitgošeš* 'wrestle') lack one. The subject profile bundled from
+the base's grid is the join of the base's two entailment profiles,
+[reinhart-siloni-2005]'s `[θᵢ · θⱼ]` role bundling.
+-/
+
+open ArgumentStructure
+
+/-- A reciprocal verb entry: the intransitive verb, its formation locus,
+    and its transitive alternate when one exists in the vocabulary. -/
+structure Verb.Reciprocal where
+  verb : Verb
+  /-- Where reciprocalization applied (the lex-syn parameter). -/
+  formation : _root_.Reciprocal.Formation
+  /-- The transitive alternate; `none` for frozen entries. -/
+  base : Option Verb := none
+  deriving Repr, BEq
+
+namespace Verb.Reciprocal
+
+/-- A frozen entry has no transitive alternate in the vocabulary. -/
+def IsFrozen (v : Verb.Reciprocal) : Prop := v.base = none
+
+instance : DecidablePred IsFrozen := fun v =>
+  decidable_of_iff (v.base.isNone = true) Option.isNone_iff_eq_none
+
+/-- The subject profile bundled from the base's grid: the join of the
+    base's subject and object entailments; `none` when the entry is frozen
+    or the base's grid is unannotated. -/
+def bundledSubjectProfile (v : Verb.Reciprocal) : Option EntailmentProfile := do
+  let b ← v.base
+  return (← b.subjectEntailments) ⊔ (← b.objectEntailments)
+
+theorem bundledSubjectProfile_eq {v : Verb.Reciprocal} {b : Verb}
+    {ps po : EntailmentProfile} (hb : v.base = some b)
+    (hs : b.subjectEntailments = some ps)
+    (ho : b.objectEntailments = some po) :
+    v.bundledSubjectProfile = some (ps ⊔ po) := by
+  simp [bundledSubjectProfile, hb, hs, ho]
+
+/-- The bundled subject role of an entry whose base has an agentive
+    subject and an affected object is a complex role. -/
+theorem bundledSubjectProfile_isComplexRole {v : Verb.Reciprocal} {b : Verb}
+    {ps po : EntailmentProfile} (hb : v.base = some b)
+    (hs : b.subjectEntailments = some ps)
+    (ho : b.objectEntailments = some po)
+    (ha : 0 < ps.pAgentScore) (hp : 0 < po.pPatientScore) :
+    ∃ prof, v.bundledSubjectProfile = some prof ∧
+      EntailmentProfile.IsComplexRole prof :=
+  ⟨ps ⊔ po, bundledSubjectProfile_eq hb hs ho,
+    EntailmentProfile.isComplexRole_sup ha hp⟩
+
+end Verb.Reciprocal


### PR DESCRIPTION
The reciprocal arc regrounded in real objects, per review of #2205.

- `EntailmentProfile` gets its promised Boolean-cube order (transported along `equivFeatures`), `support`, the Dowty cluster sets, and recharacterizations: scores as cardinalities, dominance as cluster-restricted inclusion, `Monotone` score/projection lemmas (Projection's hypothesis-form lemma renamed `fromEntailmentProfile_le`).
- `Semantics/Plurality/Groups.lean`: Landman's `up`/`down` over any `SemilatticeSup` — the unified group mechanism for individuals and events.
- `Syntax/Category/Verb/Reciprocal.lean`: reciprocal verb entries — formation locus, optional transitive base (frozen when absent), bundled subject profile as the base grid's join.
- Siloni2012 rewritten on top: (36) as one operation (`reciprocalBundling` = grid bundling + SYM meaning postulate), (41) derived from `down_up`, no-sub-event-reading from group atomicity; Nordlinger2023's discontinuity check now consumes `Siloni2012.predictedProperties` (import made live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)