### PR TITLE
feat(Syntax/Minimalist): theta theory as colored-operad bud system

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -20,6 +20,7 @@ import Linglib.Core.Algebra.RootedTree.BMinus
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorization
 import Linglib.Core.Algebra.RootedTree.BirkhoffFactorizationSemiring
 import Linglib.Core.Algebra.RootedTree.BirkhoffLaurent
+import Linglib.Core.Algebra.RootedTree.Bud
 import Linglib.Core.Algebra.RootedTree.ConnesKreimer
 import Linglib.Core.Algebra.RootedTree.Coproduct.Deletion
 import Linglib.Core.Algebra.RootedTree.Coproduct.WithCuts
@@ -2441,6 +2442,7 @@ import Linglib.Studies.Mandelkern2022
 import Linglib.Studies.Marantz1991
 import Linglib.Studies.MarcoRasin2026
 import Linglib.Studies.MarcolliChomskyBerwick2025
+import Linglib.Studies.MarcolliLarson2025
 import Linglib.Studies.MartinRoseNichols2025
 import Linglib.Studies.MartinSchaeferKastner2025
 import Linglib.Studies.MartinezVera2026
@@ -2876,6 +2878,7 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Lift
 import Linglib.Syntax.Minimalist.SyntacticObject.Replace
 import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
+import Linglib.Syntax.Minimalist.Theta.Basic
 import Linglib.Syntax.Minimalist.Verbal.Applicative
 import Linglib.Syntax.Minimalist.Verbal.Aspect
 import Linglib.Syntax.Minimalist.Verbal.Decomposition

--- a/Linglib/Core/Algebra/RootedTree/Bud.lean
+++ b/Linglib/Core/Algebra/RootedTree/Bud.lean
@@ -1,0 +1,325 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.List.Lemmas
+
+/-!
+# Bud generating systems on colored binary trees
+
+A **bud generating system** ([giraudo-2019]) equips an operad with a set of
+colors, a set of colored operations (the rules), and a set of terminal
+colors; the generated language is the set of colored operations derivable
+from a single-color unit by color-matching operad composition. This file
+develops the construction over the free binary operad, whose operations are
+binary trees and whose insertions graft a tree onto a leaf. A `Bud.Tree`
+carries a color at every vertex: leaf colors are the operation's inputs,
+the root color its output, and the internal colors record the colors
+matched during composition — in a colored operad the color at a grafting
+vertex is determined by the matched pair, so the decorations are exactly
+the data of a decomposition into generators.
+
+## Main declarations
+
+* `Bud.Tree`, `Bud.Tree.out`, `Bud.Tree.inputs` — vertex-colored binary
+  trees with their output and input colors.
+* `Bud.Tree.graft` — insertion at the `i`-th leaf, the free binary operad's
+  partial composition; `Bud.Tree.graft_graft` is the nested-insertion
+  relation.
+* `Bud.Tree.NodeLocal` — a predicate holds at every internal vertex; the
+  invariant format preserved by color-matched grafting.
+* `Bud.System`, `Bud.System.Derives`, `Bud.System.Lang` — bud generating
+  systems with initial colors the non-terminal ones ([giraudo-2019]'s
+  `I = Ω ∖ T` case), derivability from a unit, and the generated language.
+* `Bud.System.Derives.compose` — derivations compose along color-matched
+  inputs; `Bud.System.Derives.nodeLocal` — any vertex-local property of
+  the rules holds throughout every derivable tree.
+
+## Implementation notes
+
+Bud generating systems are the operadic analogue of context-free
+grammars, with trees in place of words ([giraudo-2019] develops the
+correspondence); this file follows the register of
+`Mathlib.Computability.ContextFreeGrammar` — a rule set, an inductive
+derivation relation, and the generated language — with colors playing the
+role of `Symbol` and the terminal-color set replacing the
+terminal/nonterminal type split. Mathlib's `SimpleGraph.Coloring` is not
+applicable: proper graph coloring constrains adjacent colors to *differ*,
+while operadic coloring constrains composed colors to *match*.
+-/
+
+namespace Bud
+
+variable {Ω : Type*}
+
+/-- A binary tree with a color at every vertex: an operation of the bud
+    operad over the free binary operad, decorated with the colors it
+    propagates ([giraudo-2019]). -/
+inductive Tree (Ω : Type*) where
+  | leaf (c : Ω)
+  | node (c : Ω) (l r : Tree Ω)
+  deriving DecidableEq, Repr
+
+namespace Tree
+
+variable {x s y : Tree Ω} {c d : Ω} {i j : ℕ}
+
+/-- The output color: the color at the root. -/
+def out : Tree Ω → Ω
+  | leaf c => c
+  | node c _ _ => c
+
+@[simp] theorem out_leaf : (leaf c).out = c := rfl
+
+@[simp] theorem out_node {l r : Tree Ω} : (node c l r).out = c := rfl
+
+/-- The input colors: the leaf colors, left to right. -/
+def inputs : Tree Ω → List Ω
+  | leaf c => [c]
+  | node _ l r => l.inputs ++ r.inputs
+
+@[simp] theorem inputs_leaf : (leaf c).inputs = [c] := rfl
+
+@[simp] theorem inputs_node {l r : Tree Ω} :
+    (node c l r).inputs = l.inputs ++ r.inputs := rfl
+
+/-- The number of inputs. -/
+def numInputs : Tree Ω → ℕ
+  | leaf _ => 1
+  | node _ l r => l.numInputs + r.numInputs
+
+@[simp] theorem numInputs_leaf : (leaf c).numInputs = 1 := rfl
+
+@[simp] theorem numInputs_node {l r : Tree Ω} :
+    (node c l r).numInputs = l.numInputs + r.numInputs := rfl
+
+@[simp] theorem length_inputs (x : Tree Ω) :
+    x.inputs.length = x.numInputs := by
+  induction x <;> simp [*]
+
+theorem numInputs_pos (x : Tree Ω) : 0 < x.numInputs := by
+  induction x with
+  | leaf _ => exact Nat.one_pos
+  | node c l r ihl ihr => simp only [numInputs_node]; omega
+
+theorem getElem?_inputs_node {l r : Tree Ω} :
+    (node c l r).inputs[i]? =
+      if i < l.numInputs then l.inputs[i]? else r.inputs[i - l.numInputs]? := by
+  by_cases h : i < l.numInputs
+  · rw [if_pos h, inputs_node, List.getElem?_append_left (by simpa using h)]
+  · rw [if_neg h, inputs_node,
+      List.getElem?_append_right (by simpa using not_lt.mp h), length_inputs]
+
+/-- Graft `s` onto the `i`-th leaf of `x`: the free binary operad's
+    insertion `x ∘ᵢ s`. Out-of-range indices leave the tree unchanged. -/
+def graft : Tree Ω → ℕ → Tree Ω → Tree Ω
+  | leaf _, 0, s => s
+  | leaf c, _ + 1, _ => leaf c
+  | node c l r, i, s =>
+      if i < l.numInputs then node c (l.graft i s) r
+      else node c l (r.graft (i - l.numInputs) s)
+
+@[simp] theorem graft_leaf_zero : (leaf c).graft 0 s = s := rfl
+
+theorem graft_node {l r : Tree Ω} :
+    (node c l r).graft i s =
+      if i < l.numInputs then node c (l.graft i s) r
+      else node c l (r.graft (i - l.numInputs) s) := rfl
+
+/-- Color-matched grafting preserves the output color. -/
+theorem out_graft (h : x.inputs[i]? = some s.out) :
+    (x.graft i s).out = x.out := by
+  cases x with
+  | leaf c =>
+    cases i with
+    | zero => simpa using (by simpa using h : c = s.out).symm
+    | succ n => rfl
+  | node c l r => rw [graft_node]; split <;> rfl
+
+/-- Grafting the unit of the matched color changes nothing. -/
+theorem graft_unit (h : x.inputs[i]? = some d) : x.graft i (leaf d) = x := by
+  induction x generalizing i with
+  | leaf c =>
+    cases i with
+    | zero => simpa using congrArg leaf (by simpa using h : c = d).symm
+    | succ n => rfl
+  | node c l r ihl ihr =>
+    rw [getElem?_inputs_node] at h
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi] at h ⊢
+      rw [ihl h]
+    · rw [if_neg hi] at h ⊢
+      rw [ihr h]
+
+/-- Grafting splices the inserted tree's inputs into the host's. -/
+theorem inputs_graft (h : i < x.numInputs) :
+    (x.graft i s).inputs =
+      x.inputs.take i ++ s.inputs ++ x.inputs.drop (i + 1) := by
+  induction x generalizing i with
+  | leaf c =>
+    obtain rfl : i = 0 := Nat.lt_one_iff.mp (by simpa using h)
+    simp
+  | node c l r ihl ihr =>
+    have hlen : l.inputs.length = l.numInputs := l.length_inputs
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi]
+      have h0 : i - l.numInputs = 0 := by omega
+      have h1 : i + 1 - l.numInputs = 0 := by omega
+      simp [ihl hi, List.take_append,
+        List.drop_append, h0, h1]
+    · rw [if_neg hi]
+      have hle : l.inputs.length ≤ i := by omega
+      have h2 : i - l.numInputs < r.numInputs := by
+        have := numInputs_node (c := c) (l := l) (r := r) ▸ h
+        omega
+      have h3 : l.inputs.take i = l.inputs := List.take_of_length_le (by omega)
+      have h4 : l.inputs.drop (i + 1) = [] := List.drop_eq_nil_of_le (by omega)
+      have h5 : i + 1 - l.numInputs = i - l.numInputs + 1 := by omega
+      simp [ihr h2, List.take_append,
+        List.drop_append, h3, h4, h5, hlen]
+
+theorem numInputs_graft (h : i < x.numInputs) :
+    (x.graft i s).numInputs = x.numInputs + s.numInputs - 1 := by
+  have h1 := congrArg List.length (inputs_graft (s := s) h)
+  simp only [length_inputs, List.length_append, List.length_take,
+    List.length_drop] at h1
+  omega
+
+/-- The inserted tree's inputs sit at offset `i` in the grafted tree. -/
+theorem getElem?_inputs_graft_middle (hi : i < x.numInputs)
+    (hj : j < s.numInputs) :
+    (x.graft i s).inputs[i + j]? = s.inputs[j]? := by
+  have hA : (x.inputs.take i).length = i := by
+    simp only [List.length_take, length_inputs]
+    omega
+  rw [inputs_graft hi,
+    List.getElem?_append_left (by simp [hA]; omega),
+    List.getElem?_append_right (by omega : (x.inputs.take i).length ≤ i + j),
+    hA]
+  simp
+
+/-- Nested insertions compose, with the inner index offset by the outer
+    insertion point: the nested case of the operadic insertion relations. -/
+theorem graft_graft (hi : i < x.numInputs) (hj : j < s.numInputs) :
+    (x.graft i s).graft (i + j) y = x.graft i (s.graft j y) := by
+  induction x generalizing i with
+  | leaf c =>
+    obtain rfl : i = 0 := Nat.lt_one_iff.mp (by simpa using hi)
+    simp
+  | node c l r ihl ihr =>
+    by_cases hil : i < l.numInputs
+    · have hlg : i + j < (l.graft i s).numInputs := by
+        rw [numInputs_graft hil]
+        omega
+      rw [graft_node, if_pos hil, graft_node, if_pos hlg, graft_node,
+        if_pos hil, ihl hil]
+    · have hir : i - l.numInputs < r.numInputs := by
+        have := numInputs_node (c := c) (l := l) (r := r) ▸ hi
+        omega
+      rw [graft_node, if_neg hil, graft_node, if_neg (by omega), graft_node,
+        if_neg hil, (by omega : i + j - l.numInputs = i - l.numInputs + j),
+        ihr hir]
+
+/-- `P` holds at every internal vertex, of the vertex color and the two
+    children's output colors. -/
+def NodeLocal (P : Ω → Ω → Ω → Prop) : Tree Ω → Prop
+  | leaf _ => True
+  | node c l r => P c l.out r.out ∧ l.NodeLocal P ∧ r.NodeLocal P
+
+@[simp] theorem nodeLocal_leaf {P : Ω → Ω → Ω → Prop} :
+    (leaf c).NodeLocal P := trivial
+
+@[simp] theorem nodeLocal_node {P : Ω → Ω → Ω → Prop} {l r : Tree Ω} :
+    (node c l r).NodeLocal P ↔
+      P c l.out r.out ∧ l.NodeLocal P ∧ r.NodeLocal P := Iff.rfl
+
+/-- Color-matched grafting preserves vertex-local properties: the host's
+    vertices keep their colors (the replaced leaf's color equals the
+    inserted root's), and the inserted tree brings its own. -/
+theorem NodeLocal.graft {P : Ω → Ω → Ω → Prop} (hx : x.NodeLocal P)
+    (hs : s.NodeLocal P) (h : x.inputs[i]? = some s.out) :
+    (x.graft i s).NodeLocal P := by
+  induction x generalizing i with
+  | leaf c =>
+    cases i with
+    | zero => simpa using hs
+    | succ n => exact nodeLocal_leaf
+  | node c l r ihl ihr =>
+    obtain ⟨hP, hl, hr⟩ := hx
+    rw [getElem?_inputs_node] at h
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi] at h ⊢
+      exact ⟨(out_graft h).symm ▸ hP, ihl hl h, hr⟩
+    · rw [if_neg hi] at h ⊢
+      exact ⟨(out_graft h).symm ▸ hP, hl, ihr hr h⟩
+
+end Tree
+
+/-- A bud generating system over the free binary operad ([giraudo-2019],
+    with initial colors `I = Ω ∖ Terminal`): a set of colored operations
+    (the rules) and a set of terminal colors. -/
+structure System (Ω : Type*) where
+  rules : Set (Tree Ω)
+  Terminal : Set Ω
+
+namespace System
+
+variable {B : System Ω} {c d : Ω} {x s : Tree Ω} {i : ℕ}
+
+/-- Derivability from the unit of color `c`: start from the one-leaf tree
+    and repeatedly graft rules onto color-matched leaves. -/
+inductive Derives (B : System Ω) (c : Ω) : Tree Ω → Prop
+  | unit (hc : c ∉ B.Terminal) : Derives B c (.leaf c)
+  | graft {x s : Tree Ω} (i : ℕ) (hx : Derives B c x) (hs : s ∈ B.rules)
+      (hm : x.inputs[i]? = some s.out) : Derives B c (x.graft i s)
+
+/-- The generated language: trees derivable from some unit, all of whose
+    inputs are terminal. -/
+def Lang (B : System Ω) (x : Tree Ω) : Prop :=
+  (∃ c, B.Derives c x) ∧ ∀ d ∈ x.inputs, d ∈ B.Terminal
+
+/-- A derivation preserves the unit's color as output. -/
+theorem Derives.out_eq (h : B.Derives c x) : x.out = c := by
+  induction h with
+  | unit => rfl
+  | graft i _ _ hm ih => rw [Tree.out_graft hm, ih]
+
+/-- The output color of a derivable tree is non-terminal. -/
+theorem Derives.out_not_terminal (h : B.Derives c x) : c ∉ B.Terminal := by
+  induction h with
+  | unit hc => exact hc
+  | graft _ _ _ _ ih => exact ih
+
+/-- Derivations compose along a color-matched input: a derivation of the
+    matched color can be carried out in place inside the host. -/
+theorem Derives.compose (hx : B.Derives c x) (hi : i < x.numInputs)
+    (hm : x.inputs[i]? = some d) (hs : B.Derives d s) :
+    B.Derives c (x.graft i s) := by
+  induction hs with
+  | unit hc =>
+    rw [Tree.graft_unit hm]
+    exact hx
+  | @graft y r j hy hr hm' ih =>
+    have hjy : j < y.numInputs := by
+      by_contra hj
+      rw [List.getElem?_eq_none (by simpa using not_lt.mp hj)] at hm'
+      simp at hm'
+    rw [← Tree.graft_graft hi hjy]
+    exact ih.graft (i + j) hr
+      (by rw [Tree.getElem?_inputs_graft_middle hi hjy]; exact hm')
+
+/-- Any vertex-local property of the rules holds throughout every
+    derivable tree: the fundamental invariant of bud derivation. -/
+theorem Derives.nodeLocal {P : Ω → Ω → Ω → Prop} (h : B.Derives c x)
+    (hR : ∀ r ∈ B.rules, r.NodeLocal P) : x.NodeLocal P := by
+  induction h with
+  | unit _ => exact Tree.nodeLocal_leaf
+  | graft i _ hs hm ih => exact ih.graft (hR _ hs) hm
+
+end System
+
+end Bud

--- a/Linglib/Studies/MarcolliLarson2025.lean
+++ b/Linglib/Studies/MarcolliLarson2025.lean
@@ -1,0 +1,60 @@
+import Linglib.Syntax.Minimalist.Theta.Basic
+
+/-!
+# Marcolli & Larson (2025): Theta theory, operads, and coloring
+
+[marcolli-larson-2025] gives the explicit generating set of the colored
+operad that implements theta theory in mathematical Minimalism
+([marcolli-chomsky-berwick-2025] §3.8): theta-role assignment is a
+coloring algorithm on structures freely formed by Merge, and filtering by
+the coloring rules is equivalent to structure formation by a colored
+Merge. The generating system, its local conservation law, the derived
+External/Internal Merge dichotomy, and the derivability of the bare theta
+combs live in `Syntax/Minimalist/Theta/Basic.lean`; this file runs them on
+the paper's ditransitive example — *Brian gave the book to Mary*, whose
+verb assigns the grid (agent, theme, goal) with the internal hierarchy
+theme before goal — and on a movement generator.
+-/
+
+namespace MarcolliLarson2025
+
+open Minimalist.Theta
+
+/-- The example's internal theta hierarchy: theme outranks goal, per the
+    ditransitive grid the paper builds for *give*. -/
+def giveHier : ThetaRole → ThetaRole → Prop :=
+  fun a b => a = .theme ∧ b = .goal
+
+/-- The *give* comb: agent, then theme, then goal discharge one node at a
+    time; the head leaf carries the full giver grid. Colors only — the
+    lexical anchoring of terminal leaves is orthogonal to the theta
+    structure. -/
+def giveComb : Bud.Tree (Color Unit) :=
+  comb [] .agent [.theme, .goal]
+
+/-- The *give* comb is derivable in the complete theta bud system: the
+    three-role grid discharges against the theme-before-goal hierarchy. -/
+theorem giveComb_derivable :
+    (system (L := Unit) giveHier).Derives (.free []) giveComb :=
+  comb_derivable [] .agent [.theme, .goal]
+    (List.isChain_pair.mpr ⟨rfl, rfl⟩)
+
+/-- Every vertex of the *give* comb is a generator instance: the recursive
+    form of the theta criterion, checked structure-wide. -/
+theorem giveComb_thetaLocal :
+    giveComb.NodeLocal (ThetaLocal (L := Unit) giveHier) :=
+  derives_thetaLocal giveComb_derivable
+
+/-- A movement landing site over the residual agent grid. -/
+def moveRule : Bud.Tree (Color Unit) :=
+  gen .nontheta (.free (upGrid [.agent])) .emptyTree
+
+theorem moveRule_mem : moveRule ∈ rules (L := Unit) giveHier :=
+  ⟨[], _, _, .move _ (by simp), .inl rfl⟩
+
+/-- Movement lands only in non-theta positions, at the example rule:
+    the empty-tree input forces the non-theta output. -/
+theorem moveRule_out_nontheta : moveRule.out = Color.nontheta :=
+  rules_emptyTree_out moveRule_mem (by simp [moveRule, gen])
+
+end MarcolliLarson2025

--- a/Linglib/Syntax/Minimalist/Theta/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Theta/Basic.lean
@@ -1,0 +1,299 @@
+import Linglib.Core.Algebra.RootedTree.Bud
+import Linglib.Semantics.ArgumentStructure.Linking
+
+/-!
+# Theta theory as a coloring algorithm
+
+[marcolli-larson-2025] implements theta theory in the mathematical model
+of Minimalism ([marcolli-chomsky-berwick-2025] §3.8) as a coloring
+algorithm: structures freely formed by Merge are filtered by membership in
+the language of a bud generating system ([giraudo-2019],
+`Core/Algebra/RootedTree/Bud.lean`) whose colors are theta grids — tuples
+of giver- or receiver-marked roles — and whose generators are the local
+theta-discharge configurations. A grid injected at a predicate's leaf
+propagates up the tree like a conserved quantity: at each generator node
+one receiver peels off to the sister position, and the residue continues
+toward the maximal projection.
+
+## Main declarations
+
+* `PolarizedRole`, `Color` — giver/receiver-marked roles, and the color
+  set: bare grids (nonterminal; `[]` is the non-theta marker), lexically
+  anchored grids (terminal), and the empty-tree marker.
+* `IsGen`, `rules`, `system` — the generating set: external-role closure,
+  hierarchy-ordered internal discharge, adjunct attachment, and movement
+  landing ([marcolli-larson-2025]'s complete theta bud system).
+* `IsGen.conservation` — the local conservation law each generator
+  satisfies; `derives_thetaLocal` — every vertex of every derivable
+  structure is a generator instance, hence conserves theta roles.
+* `comb`, `comb_derivable` — the bare theta combs (complete grids
+  discharged one role per node) are derivable in the complete system:
+  the generator half of [marcolli-larson-2025]'s comparison of bare and
+  complete systems.
+* `rules_emptyTree_out` — a generator with an empty-tree input has a
+  non-theta output: movement lands only in non-theta positions, the
+  External/Internal Merge dichotomy at generator level.
+-/
+
+namespace Minimalist.Theta
+
+/-- Whether a role occurrence gives or receives: [marcolli-larson-2025]'s
+    `θ↑` and `θ↓` marks. -/
+inductive Polarity where
+  | giver
+  | receiver
+  deriving DecidableEq, Repr
+
+/-- A theta role marked as given or received. -/
+structure PolarizedRole where
+  role : ThetaRole
+  polarity : Polarity
+  deriving DecidableEq, Repr
+
+/-- The giver occurrence `θ↑`. -/
+def PolarizedRole.up (ρ : ThetaRole) : PolarizedRole := ⟨ρ, .giver⟩
+
+/-- The receiver occurrence `θ↓`. -/
+def PolarizedRole.down (ρ : ThetaRole) : PolarizedRole := ⟨ρ, .receiver⟩
+
+/-- A grid of giver occurrences: the undischarged residue a predicate
+    carries. -/
+def upGrid (g : List ThetaRole) : List PolarizedRole := g.map .up
+
+@[simp] theorem upGrid_nil : upGrid [] = [] := rfl
+
+@[simp] theorem upGrid_append (g h : List ThetaRole) :
+    upGrid (g ++ h) = upGrid g ++ upGrid h := List.map_append ..
+
+variable {L : Type*}
+
+/-- The color set: a bare grid (nonterminal; the empty grid is the
+    non-theta marker `θ0`), a lexically anchored grid (terminal), or the
+    empty-tree marker `(1, θ0)`. -/
+inductive Color (L : Type*) where
+  | free (g : List PolarizedRole)
+  | lex (item : L) (g : List PolarizedRole)
+  | emptyTree
+  deriving DecidableEq, Repr
+
+/-- The non-theta marker `θ0`: the empty grid. -/
+abbrev Color.nontheta : Color L := .free []
+
+/-- Terminal colors: lexically anchored grids and the empty-tree marker. -/
+def Color.IsTerminal : Color L → Prop
+  | .free _ => False
+  | .lex _ _ => True
+  | .emptyTree => True
+
+@[simp] theorem Color.isTerminal_free {g : List PolarizedRole} :
+    ¬ (Color.free g : Color L).IsTerminal := id
+
+/-- The grid a color carries, if any: lexical anchoring is transparent to
+    theta structure. -/
+def Color.grid? : Color L → Option (List PolarizedRole)
+  | .free g => some g
+  | .lex _ g => some g
+  | .emptyTree => none
+
+/-- The color carries exactly the grid `g`. -/
+def Color.Matches (c : Color L) (g : List PolarizedRole) : Prop :=
+  c.grid? = some g
+
+@[simp] theorem Color.matches_free {g h : List PolarizedRole} :
+    (Color.free g : Color L).Matches h ↔ g = h := by
+  simp [Color.Matches, Color.grid?]
+
+@[simp] theorem Color.matches_lex {α : L} {g h : List PolarizedRole} :
+    (Color.lex α g).Matches h ↔ g = h := by
+  simp [Color.Matches, Color.grid?]
+
+@[simp] theorem Color.not_matches_emptyTree {g : List PolarizedRole} :
+    ¬ (Color.emptyTree : Color L).Matches g := by
+  simp [Color.Matches, Color.grid?]
+
+section Rules
+
+variable (hier : ThetaRole → ThetaRole → Prop)
+
+/-- The generator shapes of the theta bud system, as a relation between
+    the root grid and the two children's colors (children unordered; the
+    rule set closes under swapping). The four cases are
+    [marcolli-larson-2025]'s complete-system generators:
+
+    * `close` — the external role discharges and the maximal projection is
+      recolored arbitrarily;
+    * `discharge` — one internal role, next in the hierarchy, peels off to
+      the sister while the residue propagates;
+    * `adjunct` — a non-theta position attaches without disturbing the
+      color;
+    * `move` — a movement landing site: the empty-tree marker attaches
+      under a non-theta root. -/
+inductive IsGen : List PolarizedRole → Color L → Color L → Prop
+  | close (g₀ : List PolarizedRole) (ρE : ThetaRole) {a b : Color L}
+      (ha : a.Matches [.down ρE]) (hb : b.Matches [.up ρE]) :
+      IsGen g₀ a b
+  | discharge (g : List ThetaRole) (ρ : ThetaRole) (hg : g ≠ [])
+      (hchain : ((g ++ [ρ]).tail).IsChain hier) {a b : Color L}
+      (ha : a.Matches [.down ρ]) (hb : b.Matches (upGrid (g ++ [ρ]))) :
+      IsGen (upGrid g) a b
+  | adjunct (g₀ : List PolarizedRole) : IsGen g₀ (.free g₀) .nontheta
+  | move (c' : Color L) (hc' : c' ≠ .emptyTree) : IsGen [] c' .emptyTree
+
+/-- A one-node colored operation. -/
+def gen (c a b : Color L) : Bud.Tree (Color L) := .node c (.leaf a) (.leaf b)
+
+/-- The rule set: the generator shapes in either orientation, rooted at a
+    nonterminal color. -/
+def rules : Set (Bud.Tree (Color L)) :=
+  {t | ∃ g₀ a b, IsGen hier g₀ a b ∧
+    (t = gen (.free g₀) a b ∨ t = gen (.free g₀) b a)}
+
+/-- The complete theta bud system. -/
+def system : Bud.System (Color L) := ⟨rules hier, {c | c.IsTerminal}⟩
+
+variable {hier}
+
+/-- The local conservation law: at every generator, either one child
+    receives the last role of the other child's giver grid while the root
+    keeps the residue, or the node is an adjunct attachment, or a movement
+    landing under a non-theta root. -/
+theorem IsGen.conservation {g₀ : List PolarizedRole} {a b : Color L}
+    (h : IsGen (L := L) hier g₀ a b) :
+    (∃ ρ g, a.Matches [.down ρ] ∧ b.Matches (upGrid g ++ [.up ρ]) ∧
+      (g₀ = upGrid g ∨ g = [])) ∨
+    (a = .free g₀ ∧ b = .nontheta) ∨
+    (g₀ = [] ∧ b = .emptyTree) := by
+  cases h with
+  | close g₀ ρE ha hb => exact .inl ⟨ρE, [], ha, by simpa using hb, .inr rfl⟩
+  | discharge g ρ hg hchain ha hb =>
+    exact .inl ⟨ρ, g, ha, by simpa [upGrid] using hb, .inl rfl⟩
+  | adjunct g₀ => exact .inr (.inl ⟨rfl, rfl⟩)
+  | move c' hc' => exact .inr (.inr ⟨rfl, rfl⟩)
+
+/-- The vertex-local law of the theta system: the vertex is a generator
+    instance in some orientation. -/
+def ThetaLocal (hier : ThetaRole → ThetaRole → Prop)
+    (c a b : Color L) : Prop :=
+  ∃ g₀, c = .free g₀ ∧ (IsGen hier g₀ a b ∨ IsGen hier g₀ b a)
+
+theorem rules_nodeLocal {r : Bud.Tree (Color L)} (hr : r ∈ rules hier) :
+    r.NodeLocal (ThetaLocal hier) := by
+  obtain ⟨g₀, a, b, hg, hor⟩ := hr
+  rcases hor with rfl | rfl
+  · exact ⟨⟨g₀, rfl, .inl hg⟩, trivial, trivial⟩
+  · exact ⟨⟨g₀, rfl, .inr hg⟩, trivial, trivial⟩
+
+/-- Every vertex of every derivable structure is a generator instance:
+    filtering by the coloring rules is checkable vertex-locally, the
+    engine of [marcolli-larson-2025]'s recursive theta criterion. -/
+theorem derives_thetaLocal {c : Color L} {x : Bud.Tree (Color L)}
+    (h : (system (L := L) hier).Derives c x) :
+    x.NodeLocal (ThetaLocal hier) :=
+  h.nodeLocal fun _ hr => rules_nodeLocal hr
+
+/-- Movement lands only in non-theta positions: a generator with an
+    empty-tree input has the non-theta output. The External/Internal Merge
+    dichotomy of theta theory, derived from the generator shapes. -/
+theorem rules_emptyTree_out {r : Bud.Tree (Color L)} (hr : r ∈ rules hier)
+    (h : Color.emptyTree ∈ r.inputs) : r.out = Color.nontheta := by
+  obtain ⟨g₀, a, b, hg, hor⟩ := hr
+  have hab : Color.emptyTree = a ∨ Color.emptyTree = b := by
+    rcases hor with rfl | rfl <;>
+      simpa [gen, or_comm] using h
+  suffices hs : g₀ = [] by
+    rcases hor with rfl | rfl <;> simp [gen, hs, Color.nontheta]
+  cases hg with
+  | close g₀' ρE ha hb =>
+    rcases hab with rfl | rfl
+    · exact absurd ha (Color.not_matches_emptyTree)
+    · exact absurd hb (Color.not_matches_emptyTree)
+  | discharge g ρ hg' hchain ha hb =>
+    rcases hab with rfl | rfl
+    · exact absurd ha (Color.not_matches_emptyTree)
+    · exact absurd hb (Color.not_matches_emptyTree)
+  | adjunct g₀' =>
+    rcases hab with h' | h' <;> exact absurd h' (by simp [Color.nontheta])
+  | move c' hc' =>
+    rfl
+
+end Rules
+
+section Comb
+
+variable {hier : ThetaRole → ThetaRole → Prop}
+
+/-- The spine of a bare theta comb: the residue grid grows by one role per
+    node on the path to the head leaf, which carries the complete grid. -/
+def combSpine (g : List ThetaRole) : List ThetaRole → Bud.Tree (Color L)
+  | [] => .leaf (.free (upGrid g))
+  | ρ :: rest =>
+      .node (.free (upGrid g)) (.leaf (.free [.down ρ]))
+        (combSpine (g ++ [ρ]) rest)
+
+/-- A bare theta comb ([marcolli-larson-2025]'s bare-system generators):
+    an external role, hierarchy-ordered internal roles, one receiver per
+    node, the full giver grid at the head leaf, and an arbitrary root
+    recoloring. -/
+def comb (g₀ : List PolarizedRole) (ρE : ThetaRole)
+    (ρIs : List ThetaRole) : Bud.Tree (Color L) :=
+  .node (.free g₀) (.leaf (.free [.down ρE])) (combSpine [ρE] ρIs)
+
+theorem combSpine_derivable (g : List ThetaRole) (hg : g ≠ [])
+    (rest : List ThetaRole)
+    (hchain : ((g ++ rest).tail).IsChain hier) :
+    (system (L := L) hier).Derives (.free (upGrid g)) (combSpine g rest) := by
+  induction rest generalizing g with
+  | nil => exact .unit (by simp [system, Color.IsTerminal])
+  | cons ρ rest ih =>
+    have hstep : ((g ++ [ρ]).tail).IsChain hier := by
+      refine List.IsChain.prefix hchain ?_
+      cases g with
+      | nil => exact absurd rfl hg
+      | cons a g' =>
+        exact ⟨rest, by simp⟩
+    have hrule : gen (.free (upGrid g)) (.free [.down ρ])
+        (.free (upGrid (g ++ [ρ]))) ∈ rules (L := L) hier :=
+      ⟨upGrid g, _, _,
+        .discharge g ρ hg hstep (by simp) (by simp), .inl rfl⟩
+    have hunit : (system (L := L) hier).Derives (.free (upGrid g))
+        (.leaf (.free (upGrid g))) :=
+      .unit (by simp [system, Color.IsTerminal])
+    have hgen := hunit.graft 0 hrule (by simp [gen])
+    have hgraft : (Bud.Tree.leaf ((Color.free (upGrid g) : Color L))).graft 0
+        (gen (.free (upGrid g)) (.free [.down ρ])
+          (.free (upGrid (g ++ [ρ])))) =
+        gen (.free (upGrid g)) (.free [.down ρ])
+          (.free (upGrid (g ++ [ρ]))) := rfl
+    rw [hgraft] at hgen
+    have hchain' : ((g ++ [ρ] ++ rest).tail).IsChain hier := by
+      simpa [List.append_assoc] using hchain
+    have hcomp := hgen.compose (i := 1) (by simp [gen])
+      (by simp [gen]) (ih (g ++ [ρ]) (by simp) hchain')
+    simpa [combSpine, gen, Bud.Tree.graft] using hcomp
+
+/-- The bare theta combs are derivable in the complete system, provided
+    the internal roles descend the hierarchy: the generator half of
+    [marcolli-larson-2025]'s reduction of the bare system to the complete
+    one. -/
+theorem comb_derivable (g₀ : List PolarizedRole) (ρE : ThetaRole)
+    (ρIs : List ThetaRole) (hchain : ρIs.IsChain hier) :
+    (system (L := L) hier).Derives (.free g₀) (comb g₀ ρE ρIs) := by
+  have hrule : gen (.free g₀) (.free [.down ρE]) (.free (upGrid [ρE]))
+      ∈ rules (L := L) hier :=
+    ⟨g₀, _, _, .close g₀ ρE (by simp) (by simp [upGrid]), .inl rfl⟩
+  have hunit : (system (L := L) hier).Derives (.free g₀)
+      (.leaf (.free g₀)) :=
+    .unit (by simp [system, Color.IsTerminal])
+  have hgen := hunit.graft 0 hrule (by simp [gen])
+  have hgraft : (Bud.Tree.leaf ((Color.free g₀ : Color L))).graft 0
+      (gen (.free g₀) (.free [.down ρE]) (.free (upGrid [ρE]))) =
+      gen (.free g₀) (.free [.down ρE]) (.free (upGrid [ρE])) := rfl
+  rw [hgraft] at hgen
+  have hspine := combSpine_derivable (L := L) (hier := hier) [ρE]
+    (by simp) ρIs (by simpa using hchain)
+  have hcomp := hgen.compose (i := 1) (by simp [gen]) (by simp [gen]) hspine
+  simpa [comb, gen, Bud.Tree.graft] using hcomp
+
+end Comb
+
+end Minimalist.Theta

--- a/references.bib
+++ b/references.bib
@@ -17406,6 +17406,31 @@
   role      = {formalized},
   sources   = {}
 }
+@article{giraudo-2019,
+  author    = {Giraudo, Samuele},
+  year      = {2019},
+  title     = {Colored Operads, Series on Colored Operads, and Combinatorial Generating Systems},
+  journal   = {Discrete Mathematics},
+  volume    = {342},
+  number    = {6},
+  pages     = {1624--1657},
+  doi       = {10.1016/j.disc.2019.02.008},
+  subfield  = {algebra/operads},
+  role      = {formalized},
+  sources   = {Core/Algebra/RootedTree/Bud.lean}
+}
+@article{marcolli-larson-2025,
+  author    = {Marcolli, Matilde and Larson, Richard K.},
+  year      = {2025},
+  title     = {Theta Theory: Operads and Coloring},
+  eprint    = {2503.06091},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CL},
+  url       = {https://arxiv.org/abs/2503.06091},
+  subfield  = {syntax},
+  role      = {formalized},
+  sources   = {Syntax/Minimalist/Theta/Basic.lean; Studies/MarcolliLarson2025.lean}
+}
 @article{marcolli-larson-huijbregts-2025,
   author    = {Marcolli, Matilde and Larson, Richard K. and Huijbregts, Riny},
   year      = {2025},


### PR DESCRIPTION
Formalizes Marcolli–Larson 2025 (*Theta Theory: operads and coloring*, arXiv 2503.06091), three layers:

- `Core/Algebra/RootedTree/Bud.lean`: Giraudo bud generating systems over the free binary operad — vertex-colored trees, grafting with the nested-insertion relation (`graft_graft`), derivability, language, and the two engine theorems: `Derives.compose` (derivations compose along color-matched inputs) and `Derives.nodeLocal` (vertex-local rule properties are derivation invariants). Register follows `Mathlib.Computability.ContextFreeGrammar` (bud systems are the operadic CFG analogue; mathlib's `SimpleGraph.Coloring` is inapplicable — properness vs matching).
- `Syntax/Minimalist/Theta/Basic.lean`: the theta instantiation — polarized roles over the existing `ThetaRole`, grid colors with θ0 as the empty grid, the four generator shapes (close/discharge/adjunct/move) parameterized by a theta-hierarchy relation, the derived local conservation law (`IsGen.conservation`), `derives_thetaLocal` (recursive theta criterion engine), `comb_derivable` (bare combs derivable in the complete system), and `rules_emptyTree_out` (movement lands only in non-theta positions — the EM/IM dichotomy at generator level).
- `Studies/MarcolliLarson2025.lean`: the ditransitive *give* example (agent–theme–goal comb, derivable + vertex-locally theta-lawful) and a movement generator instance.

Bib: verified `giraudo-2019` (Discrete Math 342(6), DOI 10.1016/j.disc.2019.02.008) and `marcolli-larson-2025` (arXiv-only; Crossref checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)