### PR TITLE
feat(Syntax/Minimalist/Theta): theta criterion + parasitic generator

### DIFF
--- a/Linglib/Studies/MarcolliLarson2025.lean
+++ b/Linglib/Studies/MarcolliLarson2025.lean
@@ -13,7 +13,10 @@ External/Internal Merge dichotomy, and the derivability of the bare theta
 combs live in `Syntax/Minimalist/Theta/Basic.lean`; this file runs them on
 the paper's ditransitive example — *Brian gave the book to Mary*, whose
 verb assigns the grid (agent, theme, goal) with the internal hierarchy
-theme before goal — and on a movement generator.
+theme before goal — on a movement generator, and on [siloni-2012]'s
+parasitic assignment, recast as a language-specific generator whose
+absence from the standard rule set is the sole-role requirement and whose
+addition is the *se* marking.
 -/
 
 namespace MarcolliLarson2025
@@ -56,5 +59,82 @@ theorem moveRule_mem : moveRule ∈ rules (L := Unit) giveHier :=
     the empty-tree input forces the non-theta output. -/
 theorem moveRule_out_nontheta : moveRule.out = Color.nontheta :=
   rules_emptyTree_out moveRule_mem (by simp [moveRule, gen])
+
+/-- The *give* comb satisfies the theta criterion: agent, theme, and goal
+    receivers exactly match the head's grid. -/
+theorem giveComb_criterion : SatisfiesCriterion giveComb :=
+  comb_satisfiesCriterion [] .agent [.theme, .goal]
+
+/-! ### A language-specific generator: parasitic assignment
+
+[siloni-2012]'s syntactic reciprocalization assigns a retained internal
+role together with the external role to one argument — parasitic
+assignment, a last resort licensed by the *se* morphology. In the coloring
+model this is a dual-receiver generator: one argument receives two roles
+against a dual-giver residue, as in the ECM derivation where *Jean* ends
+with the matrix experiencer role and the embedded verb's retained agent
+role. The generator is absent from the standard rule set
+(`parasiticGen_notMem` — the model's form of the sole-role requirement),
+and adding it, as the *se* marking does, makes the dual-role structure
+derivable (`parasiticGen_derivable`). -/
+
+/-- Parasitic assignment as a generator: a dual-receiver argument
+    discharges a dual-giver residue in one step. -/
+def parasiticGen : Bud.Tree (Color Unit) :=
+  gen .nontheta (.free [.down .experiencer, .down .agent])
+    (.free (upGrid [.experiencer, .agent]))
+
+/-- The standard theta bud system contains no parasitic generator: every
+    generator discharges at most one role per argument. -/
+theorem parasiticGen_notMem : parasiticGen ∉ rules (L := Unit) giveHier := by
+  rintro ⟨g₀, a, b, hg, hor⟩
+  cases hg with
+  | close g₀' ρE ha hb =>
+    rcases hor with heq | heq <;>
+      simp only [parasiticGen, gen, Bud.Tree.node.injEq,
+        Bud.Tree.leaf.injEq] at heq <;>
+      obtain ⟨-, h2, h3⟩ := heq
+    · subst h2
+      simp at ha
+    · subst h3
+      simp [upGrid, PolarizedRole.up, PolarizedRole.down] at ha
+  | discharge g ρ hg' hchain ha hb =>
+    rcases hor with heq | heq <;>
+      simp only [parasiticGen, gen, Bud.Tree.node.injEq,
+        Bud.Tree.leaf.injEq] at heq <;>
+      obtain ⟨-, h2, h3⟩ := heq
+    · subst h2
+      simp at ha
+    · subst h3
+      simp [upGrid, PolarizedRole.up, PolarizedRole.down] at ha
+  | adjunct g₀' =>
+    rcases hor with heq | heq <;>
+      simp only [parasiticGen, gen, Bud.Tree.node.injEq,
+        Bud.Tree.leaf.injEq] at heq <;>
+      obtain ⟨-, h2, h3⟩ := heq
+    · simp [Color.nontheta, upGrid] at h3
+    · simp [Color.nontheta] at h2
+  | move c' hc' =>
+    rcases hor with heq | heq <;>
+      simp only [parasiticGen, gen, Bud.Tree.node.injEq,
+        Bud.Tree.leaf.injEq] at heq <;>
+      obtain ⟨-, h2, h3⟩ := heq
+    · simp at h3
+    · simp at h2
+
+/-- The system extended by the parasitic generator: the *se*-marked
+    grammar. -/
+def seSystem : Bud.System (Color Unit) :=
+  ⟨insert parasiticGen (rules giveHier), {c | c.IsTerminal}⟩
+
+/-- With the marking, the dual-role discharge is derivable: *Jean* ends
+    with both the matrix experiencer role and the retained embedded
+    agent role. -/
+theorem parasiticGen_derivable :
+    seSystem.Derives Color.nontheta parasiticGen := by
+  have hunit : seSystem.Derives Color.nontheta (.leaf .nontheta) :=
+    .unit (by simp [seSystem, Color.IsTerminal])
+  simpa using hunit.graft 0 (Set.mem_insert ..)
+    (by simp [parasiticGen, gen])
 
 end MarcolliLarson2025

--- a/Linglib/Syntax/Minimalist/Theta/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Theta/Basic.lean
@@ -33,6 +33,9 @@ toward the maximal projection.
 * `rules_emptyTree_out` — a generator with an empty-tree input has a
   non-theta output: movement lands only in non-theta positions, the
   External/Internal Merge dichotomy at generator level.
+* `SatisfiesCriterion`, `comb_satisfiesCriterion` — the theta criterion
+  (a head grid matched bijectively by single receivers at the other
+  positions) and its verification on the bare combs.
 -/
 
 namespace Minimalist.Theta
@@ -61,6 +64,10 @@ def PolarizedRole.down (ρ : ThetaRole) : PolarizedRole := ⟨ρ, .receiver⟩
 def upGrid (g : List ThetaRole) : List PolarizedRole := g.map .up
 
 @[simp] theorem upGrid_nil : upGrid [] = [] := rfl
+
+@[simp] theorem down_notMem_upGrid {ρ : ThetaRole} {g : List ThetaRole} :
+    PolarizedRole.down ρ ∉ upGrid g := by
+  simp [upGrid, PolarizedRole.up, PolarizedRole.down]
 
 @[simp] theorem upGrid_append (g h : List ThetaRole) :
     upGrid (g ++ h) = upGrid g ++ upGrid h := List.map_append ..
@@ -294,6 +301,64 @@ theorem comb_derivable (g₀ : List PolarizedRole) (ρE : ThetaRole)
   have hcomp := hgen.compose (i := 1) (by simp [gen]) (by simp [gen]) hspine
   simpa [comb, gen, Bud.Tree.graft] using hcomp
 
+/-- The inputs of a comb spine: one receiver per internal role, then the
+    head carrying the accumulated grid. -/
+theorem combSpine_inputs (g : List ThetaRole) (rest : List ThetaRole) :
+    (combSpine (L := L) g rest).inputs =
+      rest.map (fun ρ => Color.free [.down ρ]) ++
+        [.free (upGrid (g ++ rest))] := by
+  induction rest generalizing g with
+  | nil => simp [combSpine]
+  | cons ρ rest ih =>
+    simp [combSpine, ih (g ++ [ρ])]
+
+/-- The inputs of a comb: the external receiver, one receiver per internal
+    role, and the head carrying the complete grid. -/
+theorem comb_inputs (g₀ : List PolarizedRole) (ρE : ThetaRole)
+    (ρIs : List ThetaRole) :
+    (comb (L := L) g₀ ρE ρIs).inputs =
+      .free [.down ρE] :: ρIs.map (fun ρ => Color.free [.down ρ]) ++
+        [.free (upGrid (ρE :: ρIs))] := by
+  simp [comb, combSpine_inputs]
+
 end Comb
+
+/-! ### The theta criterion -/
+
+/-- The role a color receives, when it is a single receiver. -/
+def Color.receiver? : Color L → Option ThetaRole := fun c =>
+  match c.grid? with
+  | some [⟨ρ, .receiver⟩] => some ρ
+  | _ => none
+
+@[simp] theorem Color.receiver?_free_down (ρ : ThetaRole) :
+    (Color.free [.down ρ] : Color L).receiver? = some ρ := rfl
+
+/-- The theta criterion on a colored operation: some input (the head)
+    carries an all-giver grid, every other input is a single receiver, and
+    the received roles match the head's grid bijectively — as multisets,
+    since the trees are nonplanar. -/
+def SatisfiesCriterion (x : Bud.Tree (Color L)) : Prop :=
+  ∃ i c g, x.inputs[i]? = some c ∧ c.Matches (upGrid g) ∧
+    (↑((x.inputs.eraseIdx i).map Color.receiver?) : Multiset (Option ThetaRole))
+      = ↑(g.map some)
+
+/-- The bare theta combs satisfy the theta criterion: the head's grid is
+    matched exactly by the receivers at the other positions. -/
+theorem comb_satisfiesCriterion (g₀ : List PolarizedRole) (ρE : ThetaRole)
+    (ρIs : List ThetaRole) :
+    SatisfiesCriterion (comb (L := L) g₀ ρE ρIs) := by
+  refine ⟨ρIs.length + 1, .free (upGrid (ρE :: ρIs)), ρE :: ρIs, ?_, by simp, ?_⟩
+  · rw [comb_inputs, List.getElem?_append_right (by simp)]
+    simp
+  · rw [comb_inputs,
+      show Color.free [PolarizedRole.down ρE] ::
+          ρIs.map (fun ρ => Color.free [.down ρ]) ++
+          [Color.free (upGrid (ρE :: ρIs))] =
+        (Color.free [PolarizedRole.down ρE] ::
+          ρIs.map (fun ρ => Color.free (L := L) [.down ρ])) ++
+          [Color.free (upGrid (ρE :: ρIs))] by simp,
+      List.eraseIdx_append_of_length_le (by simp)]
+    simp [List.map_map, Function.comp_def]
 
 end Minimalist.Theta


### PR DESCRIPTION
Continues #2209 with the next theta-operads layer.

- `SatisfiesCriterion`: the theta criterion on a colored operation — a head input carrying an all-giver grid, matched bijectively (as multisets; the trees are nonplanar) by single receivers at the other positions — plus `comb_satisfiesCriterion`: the bare combs satisfy it (the generator core of Marcolli–Larson's Lemma that bare theta structures obey the criterion), via new `combSpine_inputs`/`comb_inputs` computation lemmas.
- Siloni's parasitic assignment recast in the coloring model (`Studies/MarcolliLarson2025.lean`, citing the older [siloni-2012]): `parasiticGen` is a dual-receiver generator; `parasiticGen_notMem` proves the standard rule set contains no such generator — the model's form of the sole-role requirement — and `parasiticGen_derivable` shows the se-extended system derives the dual-role discharge (the ECM configuration where *Jean* ends with matrix experiencer + retained embedded agent).
- `giveComb_criterion` instance; `down_notMem_upGrid` simp lemma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)