### PR TITLE
feat(Syntax/Minimalist/Theta): sole-role invariant and underivability

### DIFF
--- a/Linglib/Core/Algebra/RootedTree/Bud.lean
+++ b/Linglib/Core/Algebra/RootedTree/Bud.lean
@@ -201,6 +201,81 @@ theorem getElem?_inputs_graft_middle (hi : i < x.numInputs)
     hA]
   simp
 
+/-- An input of the grafted tree comes from the host or from the inserted
+    tree. -/
+theorem mem_inputs_graft (h : x.inputs[i]? = some s.out) :
+    ∀ d ∈ (x.graft i s).inputs, d ∈ x.inputs ∨ d ∈ s.inputs := by
+  induction x generalizing i with
+  | leaf c =>
+    cases i with
+    | zero => exact fun d hd => .inr hd
+    | succ n => exact fun d hd => .inl hd
+  | node c l r ihl ihr =>
+    rw [getElem?_inputs_node] at h
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi] at h ⊢
+      intro d hd
+      rcases List.mem_append.mp hd with hd | hd
+      · rcases ihl h d hd with hd | hd
+        · exact .inl (List.mem_append.mpr (.inl hd))
+        · exact .inr hd
+      · exact .inl (List.mem_append.mpr (.inr hd))
+    · rw [if_neg hi] at h ⊢
+      intro d hd
+      rcases List.mem_append.mp hd with hd | hd
+      · exact .inl (List.mem_append.mpr (.inl hd))
+      · rcases ihr h d hd with hd | hd
+        · exact .inl (List.mem_append.mpr (.inr hd))
+        · exact .inr hd
+
+/-- A host input survives grafting, unless it is the matched color. -/
+theorem mem_inputs_graft_of_mem (h : x.inputs[i]? = some s.out) :
+    ∀ d ∈ x.inputs, d ∈ (x.graft i s).inputs ∨ d = s.out := by
+  induction x generalizing i with
+  | leaf c =>
+    cases i with
+    | zero =>
+      intro d hd
+      have hc : c = s.out := by simpa using h
+      exact .inr ((by simpa using hd : d = c).trans hc)
+    | succ n => simp at h
+  | node c l r ihl ihr =>
+    rw [getElem?_inputs_node] at h
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi] at h ⊢
+      intro d hd
+      rcases List.mem_append.mp hd with hd | hd
+      · rcases ihl h d hd with hd | hd
+        · exact .inl (List.mem_append.mpr (.inl hd))
+        · exact .inr hd
+      · exact .inl (List.mem_append.mpr (.inr hd))
+    · rw [if_neg hi] at h ⊢
+      intro d hd
+      rcases List.mem_append.mp hd with hd | hd
+      · exact .inl (List.mem_append.mpr (.inl hd))
+      · rcases ihr h d hd with hd | hd
+        · exact .inl (List.mem_append.mpr (.inr hd))
+        · exact .inr hd
+
+/-- The inserted tree's inputs are inputs of the grafted tree. -/
+theorem mem_inputs_graft_of_mem_right (h : x.inputs[i]? = some s.out) :
+    ∀ d ∈ s.inputs, d ∈ (x.graft i s).inputs := by
+  induction x generalizing i with
+  | leaf c =>
+    cases i with
+    | zero => exact fun d hd => hd
+    | succ n => simp at h
+  | node c l r ihl ihr =>
+    rw [getElem?_inputs_node] at h
+    rw [graft_node]
+    by_cases hi : i < l.numInputs
+    · rw [if_pos hi] at h ⊢
+      exact fun d hd => List.mem_append.mpr (.inl (ihl h d hd))
+    · rw [if_neg hi] at h ⊢
+      exact fun d hd => List.mem_append.mpr (.inr (ihr h d hd))
+
 /-- Nested insertions compose, with the inner index offset by the outer
     insertion point: the nested case of the operadic insertion relations. -/
 theorem graft_graft (hi : i < x.numInputs) (hj : j < s.numInputs) :

--- a/Linglib/Studies/MarcolliLarson2025.lean
+++ b/Linglib/Studies/MarcolliLarson2025.lean
@@ -137,4 +137,23 @@ theorem parasiticGen_derivable :
   simpa using hunit.graft 0 (Set.mem_insert ..)
     (by simp [parasiticGen, gen])
 
+/-- Without the marking, the dual-role configuration is underivable: the
+    structure is movement-free and its root receives no role, so the
+    sole-role invariant forbids the dual-receiver argument. The sole-role
+    requirement of [siloni-2012]'s "I"-reading account, as an
+    underivability theorem. -/
+theorem parasiticGen_not_derivable :
+    ¬ (system (L := Unit) giveHier).Derives .nontheta parasiticGen := by
+  intro h
+  have hroot : (Color.nontheta : Color Unit).SoleReceiver :=
+    Color.soleReceiver_of_receiverCount_le (g := []) rfl
+      (by simp [receiverCount])
+  have hmove : Color.emptyTree ∉ parasiticGen.inputs := by
+    simp [parasiticGen, gen]
+  have hd : (Color.free [.down .experiencer, .down .agent] : Color Unit)
+      ∈ parasiticGen.inputs := by simp [parasiticGen, gen]
+  have := derives_soleReceiver h hroot hmove _ hd
+    [.down .experiencer, .down .agent] rfl
+  simp [receiverCount, PolarizedRole.down] at this
+
 end MarcolliLarson2025

--- a/Linglib/Syntax/Minimalist/Theta/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Theta/Basic.lean
@@ -36,6 +36,9 @@ toward the maximal projection.
 * `SatisfiesCriterion`, `comb_satisfiesCriterion` — the theta criterion
   (a head grid matched bijectively by single receivers at the other
   positions) and its verification on the bare combs.
+* `derives_soleReceiver` — the sole-role invariant: in a movement-free
+  derivable structure with a sole-receiver root, every position receives
+  at most one role.
 -/
 
 namespace Minimalist.Theta
@@ -360,5 +363,100 @@ theorem comb_satisfiesCriterion (g₀ : List PolarizedRole) (ρE : ThetaRole)
           [Color.free (upGrid (ρE :: ρIs))] by simp,
       List.eraseIdx_append_of_length_le (by simp)]
     simp [List.map_map, Function.comp_def]
+
+/-! ### The sole-role invariant -/
+
+/-- The number of receiver occurrences in a grid. -/
+def receiverCount (g : List PolarizedRole) : ℕ :=
+  g.countP (fun p => p.polarity == .receiver)
+
+@[simp] theorem receiverCount_upGrid (g : List ThetaRole) :
+    receiverCount (upGrid g) = 0 := by
+  simp [receiverCount, upGrid, List.countP_map, Function.comp_def,
+    PolarizedRole.up]
+
+@[simp] theorem receiverCount_down_singleton (ρ : ThetaRole) :
+    receiverCount [.down ρ] = 1 := rfl
+
+/-- The color receives at most one role: its grid, if any, has at most one
+    receiver occurrence. -/
+def Color.SoleReceiver (c : Color L) : Prop :=
+  ∀ g, c.grid? = some g → receiverCount g ≤ 1
+
+theorem Color.soleReceiver_emptyTree :
+    (Color.emptyTree : Color L).SoleReceiver := by
+  intro g hg
+  simp [Color.grid?] at hg
+
+theorem Color.soleReceiver_of_receiverCount_le {c : Color L}
+    {g : List PolarizedRole} (hc : c.grid? = some g)
+    (hg : receiverCount g ≤ 1) : c.SoleReceiver := by
+  intro g' hg'
+  rw [hc] at hg'
+  exact Option.some_injective _ hg' ▸ hg
+
+section SoleRole
+
+variable {hier : ThetaRole → ThetaRole → Prop} {c : Color L}
+  {x : Bud.Tree (Color L)}
+
+/-- The sole-role invariant: in a movement-free derivable structure whose
+    root color receives at most one role, every argument position receives
+    at most one role. Adding a dual-receiver generator — as *se*-marked
+    parasitic assignment does — is the only way to violate it. -/
+theorem derives_soleReceiver (h : (system (L := L) hier).Derives c x)
+    (hroot : c.SoleReceiver) (hmove : Color.emptyTree ∉ x.inputs) :
+    ∀ d ∈ x.inputs, d.SoleReceiver := by
+  induction h with
+  | unit hc =>
+    intro d hd
+    exact (by simpa using hd : d = c) ▸ hroot
+  | @graft y r i hy hr hm ih =>
+    have hout : ∃ g₀ : List PolarizedRole, r.out = .free g₀ := by
+      obtain ⟨g₀, a, b, -, hor⟩ := hr
+      rcases hor with rfl | rfl <;> exact ⟨g₀, rfl⟩
+    have hmove' : Color.emptyTree ∉ y.inputs := by
+      intro hmem
+      rcases Bud.Tree.mem_inputs_graft_of_mem hm _ hmem with hmem' | hmem'
+      · exact hmove hmem'
+      · obtain ⟨g₀, hg₀⟩ := hout
+        simp [hg₀] at hmem'
+    have ihy := ih hmove'
+    intro d hd
+    rcases Bud.Tree.mem_inputs_graft hm d hd with hd' | hd'
+    · exact ihy d hd'
+    · obtain ⟨g₀, a, b, hg, hor⟩ := hr
+      have hd'' : d = a ∨ d = b := by
+        rcases hor with rfl | rfl <;>
+          simpa [gen, or_comm] using hd'
+      have hroot' : (Color.free g₀ : Color L).SoleReceiver := by
+        have : Color.free g₀ ∈ y.inputs := by
+          have := hm
+          rcases hor with rfl | rfl <;>
+            exact List.mem_of_getElem? (by simpa [gen] using this)
+        exact ihy _ this
+      cases hg with
+      | close g₀' ρE ha hb =>
+        rcases hd'' with rfl | rfl
+        · exact Color.soleReceiver_of_receiverCount_le ha (by simp)
+        · exact Color.soleReceiver_of_receiverCount_le hb
+            (by simp [receiverCount, PolarizedRole.up])
+      | discharge g ρ hg' hchain ha hb =>
+        rcases hd'' with rfl | rfl
+        · exact Color.soleReceiver_of_receiverCount_le ha (by simp)
+        · exact Color.soleReceiver_of_receiverCount_le hb
+            (by rw [receiverCount_upGrid]; exact Nat.zero_le _)
+      | adjunct g₀' =>
+        rcases hd'' with rfl | rfl
+        · exact hroot'
+        · exact Color.soleReceiver_of_receiverCount_le (g := []) rfl
+            (by simp [receiverCount])
+      | move c' hc' =>
+        exfalso
+        apply hmove
+        refine Bud.Tree.mem_inputs_graft_of_mem_right hm Color.emptyTree ?_
+        rcases hor with rfl | rfl <;> simp [gen]
+
+end SoleRole
 
 end Minimalist.Theta


### PR DESCRIPTION
The negative half of the parasitic-assignment story (#2210's complement).

- Core `Bud.lean`: three graft-membership lemmas (`mem_inputs_graft`, `mem_inputs_graft_of_mem`, `mem_inputs_graft_of_mem_right`) — inputs of a grafted tree decompose into host and inserted inputs.
- `derives_soleReceiver`: in any movement-free derivable structure whose root receives at most one role, every position receives at most one role — by induction on derivations, with the adjunct case threading the invariant through the matched leaf and the move case discharged against movement-freeness.
- `parasiticGen_not_derivable`: the dual-role ECM configuration is underivable in the unmarked grammar — Siloni's sole-role requirement as an underivability theorem, completing the pair with `parasiticGen_derivable` (derivable once *se* adds the generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)