### PR TITLE
feat(Syntax/Minimalist/Theta): colored Merge closure and realization

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2879,6 +2879,7 @@ import Linglib.Syntax.Minimalist.SyntacticObject.Replace
 import Linglib.Syntax.Minimalist.SyntacticObject.Selection
 import Linglib.Syntax.Minimalist.SyntacticObject.Subterm
 import Linglib.Syntax.Minimalist.Theta.Basic
+import Linglib.Syntax.Minimalist.Theta.Realize
 import Linglib.Syntax.Minimalist.Verbal.Applicative
 import Linglib.Syntax.Minimalist.Verbal.Aspect
 import Linglib.Syntax.Minimalist.Verbal.Decomposition

--- a/Linglib/Core/Algebra/RootedTree/Bud.lean
+++ b/Linglib/Core/Algebra/RootedTree/Bud.lean
@@ -395,6 +395,26 @@ theorem Derives.nodeLocal {P : Ω → Ω → Ω → Prop} (h : B.Derives c x)
   | unit _ => exact Tree.nodeLocal_leaf
   | graft i _ hs hm ih => exact ih.graft (hR _ hs) hm
 
+/-- Bottom-up node formation: when the one-node operation on the parts'
+    output colors is a rule, joining two derivable trees under it is
+    derivable — top-down bud derivation subsumes bottom-up structure
+    building. -/
+theorem Derives.node {a b : Ω} {S S' : Tree Ω}
+    (hr : Tree.node c (.leaf a) (.leaf b) ∈ B.rules) (hc : c ∉ B.Terminal)
+    (ha : B.Derives a S) (hb : B.Derives b S') :
+    B.Derives c (.node c S S') := by
+  have h₀ : B.Derives c (Tree.node c (.leaf a) (.leaf b)) := by
+    have := (Derives.unit (B := B) hc).graft 0 hr (by simp)
+    simpa using this
+  have h₁ : B.Derives c (Tree.node c S (.leaf b)) := by
+    have := h₀.compose (i := 0) (by simp) (by simp) ha
+    simpa [Tree.graft_node, Tree.graft_leaf_zero] using this
+  have h₂ := h₁.compose (i := S.numInputs)
+    (by simp only [Tree.numInputs_node, Tree.numInputs_leaf]; omega)
+    (by rw [Tree.getElem?_inputs_node, if_neg (lt_irrefl _)]; simp)
+    hb
+  simpa [Tree.graft_node, lt_self_iff_false, Nat.sub_self] using h₂
+
 end System
 
 end Bud

--- a/Linglib/Studies/MarcolliLarson2025.lean
+++ b/Linglib/Studies/MarcolliLarson2025.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Theta.Basic
+import Linglib.Syntax.Minimalist.Theta.Realize
 
 /-!
 # Marcolli & Larson (2025): Theta theory, operads, and coloring
@@ -21,7 +22,7 @@ addition is the *se* marking.
 
 namespace MarcolliLarson2025
 
-open Minimalist.Theta
+open Minimalist Minimalist.Theta
 
 /-- The example's internal theta hierarchy: theme outranks goal, per the
     ditransitive grid the paper builds for *give*. -/
@@ -155,5 +156,44 @@ theorem parasiticGen_not_derivable :
   have := derives_soleReceiver h hroot hmove _ hd
     [.down .experiencer, .down .agent] rfl
   simp [receiverCount, PolarizedRole.down] at this
+
+/-! ### Realization: from colored trees to syntactic objects -/
+
+/-- An adjunct attaches to the *give* comb by colored Merge, staying
+    derivable: the closure half of the paper's build-by-coloring
+    equivalence, at the example. -/
+theorem giveComb_adjunct_derivable :
+    (system (L := Unit) giveHier).Derives .nontheta
+      (.node .nontheta giveComb (.leaf .nontheta)) :=
+  derives_node_of_thetaLocal ⟨[], rfl, .inl (.adjunct [])⟩
+    giveComb_derivable (.unit (by simp [system, Color.IsTerminal]))
+
+variable (brian gave theBook toMary : LIToken)
+
+/-- The lexically anchored *give* comb. -/
+def anchoredGiveComb : Bud.Tree (Color LIToken) :=
+  .node .nontheta (.leaf (.lex brian [.down .agent]))
+    (.node (.free (upGrid [.agent])) (.leaf (.lex theBook [.down .theme]))
+      (.node (.free (upGrid [.agent, .theme]))
+        (.leaf (.lex toMary [.down .goal]))
+        (.leaf (.lex gave (upGrid [.agent, .theme, .goal])))))
+
+/-- Pruning the colors realizes the anchored comb as the bare Merge
+    structure of *Brian gave the book to Mary*. -/
+theorem realize_anchoredGiveComb :
+    realize (anchoredGiveComb brian gave theBook toMary) =
+      some ((SyntacticObject.lexLeaf brian).node
+        ((SyntacticObject.lexLeaf theBook).node
+          ((SyntacticObject.lexLeaf toMary).node
+            (SyntacticObject.lexLeaf gave)))) := rfl
+
+/-- A movement landing site above the anchored comb realizes to the same
+    syntactic object: the empty-tree marker exists only for the
+    coloring. -/
+theorem realize_anchored_move_landing :
+    realize (.node .nontheta (anchoredGiveComb brian gave theBook toMary)
+        (.leaf .emptyTree)) =
+      realize (anchoredGiveComb brian gave theBook toMary) :=
+  realize_node_emptyTree_right
 
 end MarcolliLarson2025

--- a/Linglib/Syntax/Minimalist/Theta/Realize.lean
+++ b/Linglib/Syntax/Minimalist/Theta/Realize.lean
@@ -1,0 +1,109 @@
+import Linglib.Syntax.Minimalist.Theta.Basic
+import Linglib.Syntax.Minimalist.SyntacticObject.Basic
+
+/-!
+# Colored Merge and realization
+
+The bridge from the theta bud system to the syntactic-object carrier
+([marcolli-larson-2025]'s reinterpretation of theta filtering as colored
+structure formation). The compatibility relation on a colored binary
+Merge — the root and children colors form a generator — is `ThetaLocal`,
+and the colored Merge of derivable structures under a compatible root is
+derivable (`derives_node_of_thetaLocal`, via the bottom-up
+`Bud.System.Derives.node`): structure building through colored Merge
+stays within the theta-lawful language. `realize` prunes the colors,
+sending a colored tree to the `SyntacticObject` it builds — lexically
+anchored leaves become lexical leaves, binary nodes become bare Merge
+nodes, and the empty-tree marker is the magma unit, so a movement landing
+site realizes to its host unchanged (`realize_node_emptyTree_right`).
+
+## Main declarations
+
+* `derives_node_of_thetaLocal` — colored Merge closure: joining derivable
+  structures under a generator-compatible root color is derivable.
+* `realize` — pruning to the `SyntacticObject` carrier, `none` playing the
+  magma unit; intended on trees with terminal inputs, where `none` arises
+  only from the empty-tree marker.
+* `realize_node_emptyTree_right` — the unit law `M(T, 1) = T`: movement
+  landing sites leave no mark on the realized object.
+* `realize_isSome` — a tree with a lexically anchored input realizes.
+-/
+
+namespace Minimalist.Theta
+
+variable {L : Type*} {hier : ThetaRole → ThetaRole → Prop}
+
+/-- Colored Merge closure: joining two derivable structures under a root
+    color that forms a generator with their output colors is derivable.
+    Structure building by compatible colored Merge stays within the
+    theta-lawful language. -/
+theorem derives_node_of_thetaLocal {c : Color L}
+    {S S' : Bud.Tree (Color L)} (hΞ : ThetaLocal hier c S.out S'.out)
+    (hS : (system (L := L) hier).Derives S.out S)
+    (hS' : (system (L := L) hier).Derives S'.out S') :
+    (system (L := L) hier).Derives c (.node c S S') := by
+  obtain ⟨g₀, rfl, hg⟩ := hΞ
+  have hr : Bud.Tree.node (Color.free g₀) (.leaf S.out) (.leaf S'.out) ∈
+      rules (L := L) hier := by
+    rcases hg with hg | hg
+    · exact ⟨g₀, _, _, hg, .inl rfl⟩
+    · exact ⟨g₀, _, _, hg, .inr rfl⟩
+  exact .node hr (by simp [system, Color.IsTerminal]) hS hS'
+
+/-- Prune a colored tree to the syntactic object it builds: lexically
+    anchored leaves become lexical leaves, nodes become bare Merge nodes,
+    and `none` is the magma unit — contributed by the empty-tree marker
+    (and, degenerately, by bare-grid leaves, which do not occur in trees
+    with terminal inputs). -/
+noncomputable def realize : Bud.Tree (Color LIToken) → Option SyntacticObject
+  | .leaf (.lex tok _) => some (.lexLeaf tok)
+  | .leaf _ => none
+  | .node _ l r =>
+      match realize l, realize r with
+      | some L, some R => some (L.node R)
+      | some L, none => some L
+      | none, some R => some R
+      | none, none => none
+
+@[simp] theorem realize_leaf_lex (tok : LIToken) (g : List PolarizedRole) :
+    realize (.leaf (.lex tok g)) = some (.lexLeaf tok) := rfl
+
+@[simp] theorem realize_leaf_emptyTree :
+    realize (.leaf .emptyTree) = none := rfl
+
+@[simp] theorem realize_leaf_free (g : List PolarizedRole) :
+    realize (.leaf (.free g)) = none := rfl
+
+theorem realize_node_some_some {l r : Bud.Tree (Color LIToken)}
+    {c : Color LIToken} {L R : SyntacticObject} (hl : realize l = some L)
+    (hr : realize r = some R) :
+    realize (.node c l r) = some (L.node R) := by
+  simp [realize, hl, hr]
+
+/-- The unit law `M(T, 1) = T`: a movement landing site realizes to its
+    host unchanged — the empty-tree marker exists only for the coloring. -/
+@[simp] theorem realize_node_emptyTree_right {x : Bud.Tree (Color LIToken)}
+    {c : Color LIToken} :
+    realize (.node c x (.leaf .emptyTree)) = realize x := by
+  cases h : realize x <;> simp [realize, h]
+
+/-- A tree with a lexically anchored input realizes to a syntactic
+    object. -/
+theorem realize_isSome {x : Bud.Tree (Color LIToken)}
+    (h : ∃ tok g, Color.lex tok g ∈ x.inputs) : (realize x).isSome := by
+  induction x with
+  | leaf c =>
+    obtain ⟨tok, g, hmem⟩ := h
+    obtain rfl : Color.lex tok g = c := by simpa using hmem
+    simp
+  | node c l r ihl ihr =>
+    obtain ⟨tok, g, hmem⟩ := h
+    rcases List.mem_append.mp (by simpa using hmem) with hmem | hmem
+    · have := ihl ⟨tok, g, hmem⟩
+      obtain ⟨L, hL⟩ := Option.isSome_iff_exists.mp this
+      cases hr : realize r <;> simp [realize, hL, hr]
+    · have := ihr ⟨tok, g, hmem⟩
+      obtain ⟨R, hR⟩ := Option.isSome_iff_exists.mp this
+      cases hl : realize l <;> simp [realize, hl, hR]
+
+end Minimalist.Theta


### PR DESCRIPTION
The SyntacticObject bridge (recovers a commit stranded on #2211's branch after its merge).

- Core `Bud.lean`: `Derives.node` — bottom-up node formation: joining two derivable trees under a cherry rule is derivable, so top-down bud derivation subsumes bottom-up structure building.
- `Theta/Realize.lean`: `derives_node_of_thetaLocal` — the tree-level core of Marcolli–Larson's build-by-coloring equivalence (their Def 4.1 compatibility relation is `ThetaLocal`; gated colored Merge of derivable structures stays in the theta-lawful language); `realize` prunes colored trees to the `SyntacticObject` carrier (lex anchors → lexical leaves, nodes → bare Merge nodes, the empty-tree marker as magma unit), with `realize_node_emptyTree_right` (M(T,1) = T: movement landings leave no mark) and `realize_isSome` (lex-anchored trees realize).
- Study: adjunct attachment to the *give* comb by colored Merge stays derivable; the lexically anchored comb realizes by `rfl` to the bare Merge structure of *Brian gave the book to Mary*; a movement landing above it realizes identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)