### PR TITLE
refactor(Syntax/DependencyGrammar): recut the projectivity API

### DIFF
--- a/Linglib/Studies/FutrellEtAl2020.lean
+++ b/Linglib/Studies/FutrellEtAl2020.lean
@@ -66,8 +66,8 @@ def whMovement : Graph 8 :=
     [(1, 0, .nsubj), (1, 4, .ccomp), (4, 3, .nsubj), (4, 6, .ccomp),
      (6, 5, .nsubj), (6, 2, .obj), (6, 7, .advmod)]
 
-example : ¬ IsProjective extraposition := by decide
-example : ¬ IsProjective whMovement := by decide
+example : ¬ extraposition.IsProjective := by decide
+example : ¬ whMovement.IsProjective := by decide
 
 /-- Displacement stays mildly non-context-free: both trees have gap degree 1. -/
 theorem displacement_gap_degree_one :

--- a/Linglib/Studies/Gibson2025.lean
+++ b/Linglib/Studies/Gibson2025.lean
@@ -166,8 +166,8 @@ example : harmonicHI.IsTree ∧ harmonicHF.IsTree ∧
 /-- All four regimes are projective: the disharmonic ones are longer not
     because of non-projectivity — consistent direction is a separate,
     stronger constraint. -/
-example : IsProjective harmonicHI ∧ IsProjective harmonicHF ∧
-    IsProjective disharmonicHF ∧ IsProjective disharmonicFH := by decide
+example : harmonicHI.IsProjective ∧ harmonicHF.IsProjective ∧
+    disharmonicHF.IsProjective ∧ disharmonicFH.IsProjective := by decide
 
 /-- Harmonic order is strictly cheaper in both directions, and the mirror
     pair costs exactly the same. -/

--- a/Linglib/Studies/Kuhlmann2013.lean
+++ b/Linglib/Studies/Kuhlmann2013.lean
@@ -1,21 +1,79 @@
+import Linglib.Syntax.DependencyGrammar.Projectivity
+import Linglib.Morphology.Word.Basic
+
 /-!
 # Kuhlmann 2013: Mildly Non-Projective Dependency Grammar
 [kuhlmann-2013]
 
-LCFRS coverage data from [kuhlmann-2013] Tables 3-4 (Computational Linguistics
-39(2)): rule and tree loss under fan-out and well-nestedness bounds for five
-languages from the CoNLL 2006 shared task.
+Figure 1's Dutch/German minimal pair — cross-serial dependencies against
+nested infinitives, the same dependencies in opposite verb-cluster orders —
+and the LCFRS coverage data of Tables 3-4: rule and tree loss under fan-out
+and well-nestedness bounds for five languages from the CoNLL 2006 shared
+task.
 
 ## Main declarations
 
+- `Kuhlmann2013.dutchCrossSerial`, `Kuhlmann2013.germanNested`: Figure 1's
+  minimal pair, separated by gap degree
 - `Kuhlmann2013.LCFRSCoverage`: rule/tree loss row under fan-out bounds
 - `Kuhlmann2013.arabic`, `Kuhlmann2013.czech`, `Kuhlmann2013.danish`,
   `Kuhlmann2013.slovene`, `Kuhlmann2013.turkish`: Tables 3-4 rows
-- `Kuhlmann2013.fanout2_good_coverage`: fan-out ≤ 2 loses under 1% of trees in
-  every language
+- `Kuhlmann2013.fanout2_good_coverage`: fan-out ≤ 2 loses under 1% of trees
+  in every language
 -/
 
 namespace Kuhlmann2013
+
+open DependencyGrammar
+open Morphology (Word)
+
+/-! ### Figure 1: cross-serial against nested
+
+The same dependencies in opposite verb-cluster orders. The Dutch order is
+non-projective and the German one is not, so the pair separates the two
+regimes while holding the dependency structure fixed. -/
+
+/-- Dutch cross-serial: "dat Jan Piet Marie zag helpen lezen". -/
+def dutchCrossSerial : Graph 7 :=
+  .ofArcs
+    [Word.mk' "dat" .SCONJ, Word.mk' "Jan" .PROPN, Word.mk' "Piet" .PROPN,
+     Word.mk' "Marie" .PROPN, Word.mk' "zag" .VERB, Word.mk' "helpen" .VERB,
+     Word.mk' "lezen" .VERB]
+    0
+    [(0, 4, .dep), (4, 1, .nsubj), (4, 5, .xcomp),
+     (5, 2, .nsubj), (5, 6, .xcomp), (6, 3, .nsubj)]
+
+/-- German nested: "dass Jan Piet Marie lesen helfen sah". -/
+def germanNested : Graph 7 :=
+  .ofArcs
+    [Word.mk' "dass" .SCONJ, Word.mk' "Jan" .PROPN, Word.mk' "Piet" .PROPN,
+     Word.mk' "Marie" .PROPN, Word.mk' "lesen" .VERB, Word.mk' "helfen" .VERB,
+     Word.mk' "sah" .VERB]
+    0
+    [(0, 6, .dep), (6, 1, .nsubj), (6, 5, .xcomp),
+     (5, 2, .nsubj), (5, 4, .xcomp), (4, 3, .nsubj)]
+
+example : dutchCrossSerial.IsTree := by decide
+example : germanNested.IsTree := by decide
+
+/-- The cross-serial order is non-projective and the nested order is not. -/
+example : ¬ dutchCrossSerial.IsProjective ∧ germanNested.IsProjective := by decide
+
+/-- One gap in the Dutch order, none in the German one: block-degree 2
+    against block-degree 1, the fan-out of the extracted LCFRS rule. -/
+example : dutchCrossSerial.gapDegree = 1 ∧ germanNested.gapDegree = 0 := by decide
+
+/-- Cross-serial dependencies stay well-nested; they are not planar. -/
+example : dutchCrossSerial.IsWellNested ∧ ¬ dutchCrossSerial.IsPlanar := by decide
+
+/-- The Dutch fixture as a bundled `Tree`: the dominance-order API applies
+    with no side conditions. -/
+def dutchTree : Tree 7 := .mk' dutchCrossSerial
+
+example : (⊥ : DominanceOrder dutchTree.toGraph) = 0 := by decide
+example : Order.pred (5 : DominanceOrder dutchTree.toGraph) = 4 := by decide
+
+/-! ### Tables 3-4: LCFRS coverage -/
 
 /-- [kuhlmann-2013] Table 3: rule/tree loss under fan-out bounds.
     Five languages from the CoNLL 2006 shared task. -/

--- a/Linglib/Studies/KuhlmannNivre2006.lean
+++ b/Linglib/Studies/KuhlmannNivre2006.lean
@@ -1,21 +1,60 @@
+import Linglib.Syntax.DependencyGrammar.Projectivity
+import Linglib.Morphology.Word.Basic
+
 /-!
 # Kuhlmann & Nivre 2006: Mildly Non-Projective Dependency Structures
 [kuhlmann-nivre-2006]
 
-Treebank coverage data from [kuhlmann-nivre-2006] Table 1 (COLING/ACL 2006):
-prevalence of gap degree, well-nestedness, and planarity in the Prague and
-Danish dependency treebanks.
+Figure 2a's planar-but-not-projective structure, and the treebank coverage
+data of Table 1: prevalence of gap degree, well-nestedness, and planarity in
+the Prague and Danish dependency treebanks.
 
 ## Main declarations
 
+- `KuhlmannNivre2006.planarNotProjective`: Figure 2a, adapted to a single
+  root, separating planarity from projectivity
 - `KuhlmannNivre2006.TreebankCoverage`: coverage row (percentages scaled x100)
 - `KuhlmannNivre2006.pdt`, `KuhlmannNivre2006.ddt`: Table 1 rows
-- `KuhlmannNivre2006.wellNested_near_universal`: well-nestedness covers ≥99% of both treebanks
-- `KuhlmannNivre2006.gapDeg_leq1_sufficient`: gap degree ≤ 1 covers ≥99% of both treebanks
-- `KuhlmannNivre2006.planarity_insufficient`: planarity covers less than well-nestedness
+- `KuhlmannNivre2006.wellNested_near_universal`: well-nestedness covers ≥99%
+  of both treebanks
+- `KuhlmannNivre2006.gapDeg_leq1_sufficient`: gap degree ≤ 1 covers ≥99% of
+  both treebanks
+- `KuhlmannNivre2006.planarity_insufficient`: planarity covers less than
+  well-nestedness
 -/
 
 namespace KuhlmannNivre2006
+
+open DependencyGrammar
+open Morphology (Word)
+
+/-! ### Figure 2a: planar but not projective -/
+
+/-- Planar but not projective: no crossing links, yet the positions
+    dominated by 0 are `{0, 3}`, which is not an interval.
+
+    Figure 2a's own witness is a forest, with the skipped position a second
+    root; this adapts it to a single root. The root sits at position 2,
+    inside the gap, and it has to: the paper observes that in a planar tree
+    every gap contains the root, so a planar tree rooted at a sentence
+    boundary is projective. -/
+def planarNotProjective : Graph 4 :=
+  .ofArcs
+    [Word.mk' "w0" .X, Word.mk' "w1" .X, Word.mk' "w2" .X, Word.mk' "w3" .X]
+    2
+    [(2, 0, .dep), (2, 1, .dep), (0, 3, .dep)]
+
+example : planarNotProjective.IsTree := by decide
+
+/-- Planarity is strictly weaker than projectivity. -/
+example : planarNotProjective.IsPlanar ∧ ¬ planarNotProjective.IsProjective := by
+  decide
+
+/-- The root lies strictly inside the gap of position 0. -/
+example : (0 : Fin 4) < planarNotProjective.root ∧
+    planarNotProjective.root < 3 := by decide
+
+/-! ### Table 1: treebank coverage -/
 
 /-- Treebank coverage data from [kuhlmann-nivre-2006], Table 1.
     Percentages scaled x100 for Nat arithmetic. -/

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -159,6 +159,9 @@ def Linked {n : ℕ} (g : Graph n) (a b : Fin n) : Prop := g.Adj a b ∨ g.Adj b
 instance {n : ℕ} (g : Graph n) (a b : Fin n) : Decidable (Linked g a b) :=
   inferInstanceAs (Decidable (_ ∨ _))
 
+theorem Linked.symm {n : ℕ} {g : Graph n} {a b : Fin n} (h : Linked g a b) :
+    Linked g b a := Or.symm h
+
 @[simp] theorem Graph.toSimpleGraph_adj {n : ℕ} (g : Graph n) (v w : Fin n) :
     g.toSimpleGraph.Adj v w ↔ v ≠ w ∧ Linked g v w := Iff.rfl
 

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -161,6 +161,48 @@ theorem projection_root (hT : g.IsTree) :
     projection g g.root = List.finRange n :=
   List.filter_eq_self.mpr λ x _ => decide_eq_true (hT.root_dominates x)
 
+/-! ### Paths across a boundary -/
+
+/-- Disjoint subtrees of a tree share no dominated position. -/
+theorem disjoint_dominated (hT : g.IsTree) (hvw : ¬ Dominates g v w)
+    (hwv : ¬ Dominates g w v) {x : Fin n} (hv : Dominates g v x)
+    (hw : Dominates g w x) : False :=
+  (Dominates.comparable hT hv hw).elim hvw hwv
+
+/-- A dominance path leaving `S` crosses the boundary at an arc, both of whose
+    endpoints the source still dominates. -/
+theorem exists_adj_out {S : Set (Fin n)} {x : Fin n} (h : Dominates g v x)
+    (hv : v ∈ S) (hx : x ∉ S) :
+    ∃ p q, g.Adj p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
+  induction h with
+  | refl => exact absurd hv hx
+  | @tail b c hvb hbc ih =>
+    by_cases hb : b ∈ S
+    · exact ⟨b, c, hbc, hvb, hvb.tail hbc, hb, hx⟩
+    · exact ih hb
+
+/-- Dually for a path entering `S`. -/
+theorem exists_adj_in {S : Set (Fin n)} {x : Fin n} (h : Dominates g v x)
+    (hv : v ∉ S) (hx : x ∈ S) :
+    ∃ p q, g.Adj p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∉ S ∧ q ∈ S := by
+  induction h with
+  | refl => exact absurd hx hv
+  | @tail b c hvb hbc ih =>
+    by_cases hb : b ∈ S
+    · exact ih hb
+    · exact ⟨b, c, hbc, hvb, hvb.tail hbc, hb, hx⟩
+
+/-- If `v` dominates a position inside `S` and one outside it, some link below
+    `v` crosses the boundary of `S`. -/
+theorem exists_link_across {S : Set (Fin n)} {x y : Fin n}
+    (hx : Dominates g v x) (hy : Dominates g v y) (hxS : x ∈ S) (hyS : y ∉ S) :
+    ∃ p q, Linked g p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
+  by_cases hv : v ∈ S
+  · obtain ⟨p, q, hpq, hp, hq, h1, h2⟩ := exists_adj_out hy hv hyS
+    exact ⟨p, q, Or.inl hpq, hp, hq, h1, h2⟩
+  · obtain ⟨p, q, hpq, hp, hq, h1, h2⟩ := exists_adj_in hx hv hxS
+    exact ⟨q, p, Or.inr hpq, hq, hp, h2, h1⟩
+
 /-! ### The head function -/
 
 /-- The first listed head of `v`, defaulting to `v` when headless —

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -18,9 +18,8 @@ Planarity bans crossing arcs, well-nestedness bans interleaved subtrees, and
 gap degree counts the discontinuities a single node may show.
 
 In this file we define those constraints and prove the inclusions among them
-that hold on trees. The fixtures witness that the constraints are genuinely
-distinct: `planarNotProjective` is planar but not projective, and
-`dutchCrossSerial` is well-nested but not planar.
+that hold on trees. The witnesses separating the constraints are the source
+papers' own figures, and live in their study files.
 
 ## Main declarations
 
@@ -38,16 +37,12 @@ distinct: `planarNotProjective` is planar but not projective, and
 ## References
 
 [kuhlmann-nivre-2006] — Mildly non-projective dependency structures, source
-of the Definition numbers cited above and, in Figure 2a, of the forest that
-`planarNotProjective` adapts to a single root
-[kuhlmann-2013] — Mildly non-projective dependency grammar, whose Figure 1
-is the `dutchCrossSerial`/`germanNested` pair
+of the Definition numbers cited above
+[kuhlmann-2013] — Mildly non-projective dependency grammar
 [melcuk-1988] — Dependency syntax: theory and practice
 -/
 
 namespace DependencyGrammar
-
-open Morphology (Word)
 
 variable {n : ℕ} (g : Graph n)
 
@@ -162,58 +157,5 @@ theorem Graph.IsProjective.isWellNested (hT : g.IsTree) (hP : g.IsProjective) :
     g.IsWellNested := by
   rintro v w ⟨a, hva, b, hvb, c, hwc, -, -, hac, hcb, -⟩
   exact Dominates.comparable hT ((hP v).out hva hvb ⟨hac.le, hcb.le⟩) hwc
-
-/-! ### Canonical fixtures
-
-[kuhlmann-2013] Figure 1: Dutch cross-serial dependencies against German
-nested infinitives — same dependencies, opposite verb-cluster orders. -/
-
-/-- Dutch cross-serial: "dat Jan Piet Marie zag helpen lezen". -/
-def dutchCrossSerial : Graph 7 :=
-  .ofArcs
-    [Word.mk' "dat" .SCONJ, Word.mk' "Jan" .PROPN, Word.mk' "Piet" .PROPN,
-     Word.mk' "Marie" .PROPN, Word.mk' "zag" .VERB, Word.mk' "helpen" .VERB,
-     Word.mk' "lezen" .VERB]
-    0
-    [(0, 4, .dep), (4, 1, .nsubj), (4, 5, .xcomp),
-     (5, 2, .nsubj), (5, 6, .xcomp), (6, 3, .nsubj)]
-
-/-- German nested: "dass Jan Piet Marie lesen helfen sah". -/
-def germanNested : Graph 7 :=
-  .ofArcs
-    [Word.mk' "dass" .SCONJ, Word.mk' "Jan" .PROPN, Word.mk' "Piet" .PROPN,
-     Word.mk' "Marie" .PROPN, Word.mk' "lesen" .VERB, Word.mk' "helfen" .VERB,
-     Word.mk' "sah" .VERB]
-    0
-    [(0, 6, .dep), (6, 1, .nsubj), (6, 5, .xcomp),
-     (5, 2, .nsubj), (5, 4, .xcomp), (4, 3, .nsubj)]
-
-/-- Planar but not projective: no crossing links, yet the positions
-    dominated by 0 do not form an interval. -/
-def planarNotProjective : Graph 4 :=
-  .ofArcs
-    [Word.mk' "w0" .X, Word.mk' "w1" .X, Word.mk' "w2" .X, Word.mk' "w3" .X]
-    2
-    [(2, 0, .dep), (2, 1, .dep), (0, 3, .dep)]
-
-example : dutchCrossSerial.IsTree := by decide
-example : germanNested.IsTree := by decide
-example : planarNotProjective.IsTree := by decide
-example : ¬ dutchCrossSerial.IsPlanar := by decide
-example : ¬ dutchCrossSerial.IsProjective := by decide
-example : dutchCrossSerial.IsWellNested := by decide
-example : germanNested.IsPlanar := by decide
-example : germanNested.IsProjective := by decide
-example : planarNotProjective.IsPlanar := by decide
-example : ¬ planarNotProjective.IsProjective := by decide
-example : dutchCrossSerial.gapDegree = 1 := by decide
-example : germanNested.gapDegree = 0 := by decide
-
-/-- The Dutch fixture as a bundled `Tree`: the dominance-order API
-    applies with no side conditions. -/
-def dutchTree : Tree 7 := .mk' dutchCrossSerial
-
-example : (⊥ : DominanceOrder dutchTree.toGraph) = 0 := by decide
-example : Order.pred (5 : DominanceOrder dutchTree.toGraph) = 4 := by decide
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -24,9 +24,9 @@ distinct: `planarNotProjective` is planar but not projective, and
 
 ## Main declarations
 
-* `Graph.yield`, `Alternate` — the positions a node dominates, and the
+* `Graph.dominated`, `Alternate` — the positions a node dominates, and the
   alternation `a < c < b < d` that both binary constraints forbid.
-* `Graph.IsProjective` — the yields are intervals (Definition 3).
+* `Graph.IsProjective` — those positions form an interval (Definition 3).
 * `Graph.IsPlanar` — no two links cross (Definition 4), the Link Grammar
   notion, traced there to [melcuk-1988].
 * `Graph.Interleave`, `Graph.IsWellNested` — Definition 8.
@@ -53,19 +53,19 @@ variable {n : ℕ} (g : Graph n)
 
 /-! ### The binary constraints: projectivity, planarity, well-nestedness -/
 
-/-- The yield of `v` is the set of positions `v` dominates. `projection`
-    lists the same positions in ascending order. -/
-def Graph.yield (v : Fin n) : Set (Fin n) := {x | Dominates g v x}
+/-- The positions `v` dominates, `v` itself included — the *yield* of `v` in
+    the source terminology. `projection` lists them in ascending order. -/
+def Graph.dominated (v : Fin n) : Set (Fin n) := {x | Dominates g v x}
 
-@[simp] theorem Graph.mem_yield {g : Graph n} {v x : Fin n} :
-    x ∈ g.yield v ↔ Dominates g v x := Iff.rfl
+@[simp] theorem Graph.mem_dominated {g : Graph n} {v x : Fin n} :
+    x ∈ g.dominated v ↔ Dominates g v x := Iff.rfl
 
-instance (v : Fin n) : DecidablePred (· ∈ g.yield v) :=
+instance (v : Fin n) : DecidablePred (· ∈ g.dominated v) :=
   λ x => inferInstanceAs (Decidable (Dominates g v x))
 
-/-- A dependency graph is projective if the yield of every position is
-    order-convex. -/
-def Graph.IsProjective : Prop := ∀ v, (g.yield v).OrdConnected
+/-- A dependency graph is projective if the positions dominated by any one
+    position are order-convex. -/
+def Graph.IsProjective : Prop := ∀ v, (g.dominated v).OrdConnected
 
 /-- Positions `a b c d` alternate if `a < c < b < d`, so that the pairs
     `{a, b}` and `{c, d}` strictly interleave. -/
@@ -82,7 +82,7 @@ def Graph.IsPlanar : Prop :=
 /-- The subtrees at `v` and `w` interleave if each contributes two positions
     and the two pairs alternate. -/
 def Graph.Interleave (v w : Fin n) : Prop :=
-  ∃ a ∈ g.yield v, ∃ b ∈ g.yield v, ∃ c ∈ g.yield w, ∃ d ∈ g.yield w,
+  ∃ a ∈ g.dominated v, ∃ b ∈ g.dominated v, ∃ c ∈ g.dominated w, ∃ d ∈ g.dominated w,
     Alternate a b c d
 
 /-- A dependency graph is well-nested if interleaved subtrees are never
@@ -94,7 +94,7 @@ theorem Graph.isProjective_iff :
     g.IsProjective ↔ ∀ v x y, Dominates g v x → Dominates g v y →
       ∀ z, x ≤ z → z ≤ y → Dominates g v z := by
   simp only [IsProjective, Set.ordConnected_def, Set.subset_def, Set.mem_Icc,
-    Graph.mem_yield, and_imp]
+    Graph.mem_dominated, and_imp]
   exact ⟨λ h v x y hx hy z h1 h2 => h v hx hy z h1 h2,
          λ h v x hx y hy z h1 h2 => h v x y hx hy z h1 h2⟩
 
@@ -127,30 +127,35 @@ def Graph.gapDegree : Nat := Finset.univ.sup g.gapDegreeAt
 
 variable {g}
 
+/-- In a projective graph the head of an arc dominates every position the arc
+    spans, since the head dominates both endpoints and is order-convex. -/
+theorem Graph.IsProjective.dominates_of_mem_uIcc (hP : g.IsProjective)
+    {p t x : Fin n} (h : g.Adj p t) (hx : x ∈ Set.uIcc p t) : Dominates g p x :=
+  (hP p).uIcc_subset .refl (.single h) hx
+
 /-- Every projective tree is planar. -/
 theorem Graph.IsProjective.isPlanar (hT : g.IsTree) (hP : g.IsProjective) :
     g.IsPlanar := by
   rintro a b c d hL1 hL2 ⟨hac, hcb, hbd⟩
+  -- The head of an arc dominates the head of any arc it spans an endpoint of.
+  have step : ∀ {p t q u x : Fin n}, g.Adj p t → g.Adj q u →
+      x ∈ Set.uIcc p t → (x = q ∨ x = u) → p ≠ x → Dominates g p q := by
+    rintro p t q u x h1 h2 hx (rfl | rfl) hne
+    exacts [hP.dominates_of_mem_uIcc h1 hx,
+            Dominates.to_head hT (hP.dominates_of_mem_uIcc h1 hx) hne h2]
+  have hab : c ∈ Set.uIcc a b := Set.mem_uIcc.mpr (.inl ⟨hac.le, hcb.le⟩)
+  have hba : c ∈ Set.uIcc b a := Set.mem_uIcc.mpr (.inr ⟨hac.le, hcb.le⟩)
+  have hcd : b ∈ Set.uIcc c d := Set.mem_uIcc.mpr (.inl ⟨hcb.le, hbd.le⟩)
+  have hdc : b ∈ Set.uIcc d c := Set.mem_uIcc.mpr (.inr ⟨hcb.le, hbd.le⟩)
   rcases hL1 with h1 | h1 <;> rcases hL2 with h2 | h2
-  · -- heads a and c
-    have hac' : Dominates g a c := (hP a).out .refl (.single h1) ⟨hac.le, hcb.le⟩
-    have hcb' : Dominates g c b := (hP c).out .refl (.single h2) ⟨hcb.le, hbd.le⟩
-    exact hac.ne (Dominates.antisymm hT.acyclic hac'
-      (Dominates.to_head hT hcb' hcb.ne h1))
-  · -- heads a and d
-    have hac' : Dominates g a c := (hP a).out .refl (.single h1) ⟨hac.le, hcb.le⟩
-    have hdb' : Dominates g d b := (hP d).out (.single h2) .refl ⟨hcb.le, hbd.le⟩
-    exact ((hac.trans hcb).trans hbd).ne (Dominates.antisymm hT.acyclic
-      (Dominates.to_head hT hac' hac.ne h2) (Dominates.to_head hT hdb' hbd.ne' h1))
-  · -- heads b and c
-    have hbc' : Dominates g b c := (hP b).out (.single h1) .refl ⟨hac.le, hcb.le⟩
-    have hcb' : Dominates g c b := (hP c).out .refl (.single h2) ⟨hcb.le, hbd.le⟩
-    exact hcb.ne (Dominates.antisymm hT.acyclic hcb' hbc')
-  · -- heads b and d
-    have hbc' : Dominates g b c := (hP b).out (.single h1) .refl ⟨hac.le, hcb.le⟩
-    have hdb' : Dominates g d b := (hP d).out (.single h2) .refl ⟨hcb.le, hbd.le⟩
-    exact hbd.ne (Dominates.antisymm hT.acyclic
-      (Dominates.to_head hT hbc' hcb.ne' h2) hdb')
+  · exact hac.ne (Dominates.antisymm hT.acyclic
+      (step h1 h2 hab (.inl rfl) hac.ne) (step h2 h1 hcd (.inr rfl) hcb.ne))
+  · exact ((hac.trans hcb).trans hbd).ne (Dominates.antisymm hT.acyclic
+      (step h1 h2 hab (.inr rfl) hac.ne) (step h2 h1 hdc (.inr rfl) hbd.ne'))
+  · exact hcb.ne' (Dominates.antisymm hT.acyclic
+      (step h1 h2 hba (.inl rfl) hcb.ne') (step h2 h1 hcd (.inl rfl) hcb.ne))
+  · exact hbd.ne (Dominates.antisymm hT.acyclic
+      (step h1 h2 hba (.inr rfl) hcb.ne') (step h2 h1 hdc (.inl rfl) hbd.ne'))
 
 /-- Every projective tree is well-nested. -/
 theorem Graph.IsProjective.isWellNested (hT : g.IsTree) (hP : g.IsProjective) :
@@ -183,9 +188,8 @@ def germanNested : Graph 7 :=
     [(0, 6, .dep), (6, 1, .nsubj), (6, 5, .xcomp),
      (5, 2, .nsubj), (5, 4, .xcomp), (4, 3, .nsubj)]
 
-/-- Planar but **not** projective — no crossing links, yet the yield of
-    position 0 is not an interval. A single-rooted adaptation of
-    [kuhlmann-nivre-2006] Figure 2a (whose witness is a forest). -/
+/-- Planar but not projective: no crossing links, yet the positions
+    dominated by 0 do not form an interval. -/
 def planarNotProjective : Graph 4 :=
   .ofArcs
     [Word.mk' "w0" .X, Word.mk' "w1" .X, Word.mk' "w2" .X, Word.mk' "w3" .X]

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -13,101 +13,112 @@ import Mathlib.Data.List.Sort
 
 [kuhlmann-nivre-2006]'s hierarchy of structural constraints between
 projective and unrestricted dependency structures: projectivity as
-order-convexity of dominance cones (`Set.OrdConnected`; Definition 3),
-planarity (Definition 4 — the Link Grammar notion, traced there to
-[melcuk-1988]), gap degree (Definitions 6–7; gap degree + 1 is
-[kuhlmann-2013]'s block-degree, the LCFRS fan-out), and well-nestedness
-(Definition 8).
+order-convexity of dominance cones (Definition 3), planarity (Definition 4 —
+the Link Grammar notion, traced there to [melcuk-1988]), gap degree
+(Definitions 6–7; gap degree + 1 is [kuhlmann-2013]'s block-degree, the
+LCFRS fan-out), and well-nestedness (Definition 8).
 
-Of the §3.5 hierarchy `projective ⊂ planar ⊂ well-nested`,
-`IsProjective.isPlanar` and `IsProjective.isWellNested` prove the
-inclusions from projectivity on trees; strictness is witnessed by
-`decide` on `planarNotProjective` (a single-rooted adaptation of
-Figure 2a) and on `dutchCrossSerial` (well-nested but not planar),
-[kuhlmann-2013] Figure 1's cross-serial half.
+## Main declarations
+
+* `Graph.yield`, `Alternate` — the positions a node dominates, and the
+  alternation `a < c < b < d` that both binary constraints forbid.
+* `Graph.IsProjective` — the yields are intervals (Definition 3).
+* `Graph.IsPlanar` — no two links cross (Definition 4).
+* `Graph.Interleave`, `Graph.IsWellNested` — Definition 8.
+* `Graph.gapDegree` — Definitions 6–7.
+* `Graph.IsProjective.isPlanar`, `Graph.IsProjective.isWellNested` — the
+  §3.5 inclusions from projectivity, on trees. Strictness is witnessed by
+  `decide` on `planarNotProjective` (a single-rooted adaptation of Figure 2a,
+  whose own witness is a forest) and on `dutchCrossSerial` (well-nested but
+  not planar), [kuhlmann-2013] Figure 1's cross-serial half.
 -/
 
 namespace DependencyGrammar
 
 open Morphology (Word)
 
-section Defs
-
-variable {n : ℕ}
+variable {n : ℕ} (g : Graph n)
 
 /-! ### The binary constraints: projectivity, planarity, well-nestedness -/
 
-/-- **Projectivity**: every dominance cone is order-convex. Equivalent
-    to "the yields of all nodes are intervals"
-    ([kuhlmann-nivre-2006], Definition 3). -/
-def IsProjective (g : Graph n) : Prop :=
-  ∀ v : Fin n, Set.OrdConnected {x | Dominates g v x}
+/-- The yield of `v` is the set of positions `v` dominates. `projection`
+    lists the same positions in ascending order. -/
+def Graph.yield (v : Fin n) : Set (Fin n) := {x | Dominates g v x}
 
-/-- **Planarity**: no two links cross — spans, taken left-to-right, never
-    strictly interleave. ([kuhlmann-nivre-2006], Definition 4; the Link
-    Grammar notion, traced there to [melcuk-1988].) -/
-def IsPlanar (g : Graph n) : Prop :=
-  ∀ ⦃a b c d : Fin n⦄, a < b → c < d → Linked g a b → Linked g c d →
-    ¬ (a < c ∧ c < b ∧ b < d)
+@[simp] theorem Graph.mem_yield {g : Graph n} {v x : Fin n} :
+    x ∈ g.yield v ↔ Dominates g v x := Iff.rfl
 
-/-- The subtrees at `v` and `w` interleave: each contributes two positions
-    arranged strictly alternately. ([kuhlmann-nivre-2006], Definition 8) -/
-def Interleave (g : Graph n) (v w : Fin n) : Prop :=
-  ∃ a b, Dominates g v a ∧ Dominates g v b ∧
-    ∃ c d, Dominates g w c ∧ Dominates g w d ∧ a < c ∧ c < b ∧ b < d
+instance (v : Fin n) : DecidablePred (· ∈ g.yield v) :=
+  λ x => inferInstanceAs (Decidable (Dominates g v x))
 
-/-- **Well-nestedness**: disjoint subtrees (neither root dominating the
-    other) never interleave. ([kuhlmann-nivre-2006], Definition 8) -/
-def IsWellNested (g : Graph n) : Prop :=
-  ∀ v w : Fin n, ¬ Dominates g v w → ¬ Dominates g w v → ¬ Interleave g v w
+/-- A dependency graph is projective if the yield of every position is
+    order-convex. -/
+def Graph.IsProjective : Prop := ∀ v, (g.yield v).OrdConnected
 
-instance (g : Graph n) : Decidable (IsProjective g) :=
-  decidable_of_iff (∀ v x, Dominates g v x → ∀ y, Dominates g v y → x ≤ y →
-      ∀ z, x ≤ z → z ≤ y → Dominates g v z) <| by
-    simp only [IsProjective, Set.ordConnected_iff, Set.subset_def, Set.mem_Icc,
-      Set.mem_ofPred_eq, and_imp]
+/-- Positions `a b c d` alternate if `a < c < b < d`, so that the pairs
+    `{a, b}` and `{c, d}` strictly interleave. -/
+def Alternate (a b c d : Fin n) : Prop := a < c ∧ c < b ∧ b < d
 
-instance (g : Graph n) : Decidable (IsPlanar g) :=
-  inferInstanceAs (Decidable (∀ _, _))
+instance (a b c d : Fin n) : Decidable (Alternate a b c d) :=
+  inferInstanceAs (Decidable (_ ∧ _))
 
-instance (g : Graph n) (v w : Fin n) : Decidable (Interleave g v w) :=
+/-- A dependency graph is planar if no two links alternate, so that its arcs
+    can be drawn above the sentence without crossing. -/
+def Graph.IsPlanar : Prop :=
+  ∀ ⦃a b c d : Fin n⦄, Linked g a b → Linked g c d → ¬ Alternate a b c d
+
+/-- The subtrees at `v` and `w` interleave if each contributes two positions
+    and the two pairs alternate. -/
+def Graph.Interleave (v w : Fin n) : Prop :=
+  ∃ a ∈ g.yield v, ∃ b ∈ g.yield v, ∃ c ∈ g.yield w, ∃ d ∈ g.yield w,
+    Alternate a b c d
+
+/-- A dependency graph is well-nested if interleaved subtrees are never
+    disjoint, one of the two roots always dominating the other. -/
+def Graph.IsWellNested : Prop :=
+  ∀ v w : Fin n, g.Interleave v w → Dominates g v w ∨ Dominates g w v
+
+theorem Graph.isProjective_iff :
+    g.IsProjective ↔ ∀ v x y, Dominates g v x → Dominates g v y →
+      ∀ z, x ≤ z → z ≤ y → Dominates g v z := by
+  simp only [IsProjective, Set.ordConnected_def, Set.subset_def, Set.mem_Icc,
+    Graph.mem_yield, and_imp]
+  exact ⟨λ h v x y hx hy z h1 h2 => h v hx hy z h1 h2,
+         λ h v x hx y hy z h1 h2 => h v x y hx hy z h1 h2⟩
+
+instance : Decidable g.IsProjective := decidable_of_iff _ g.isProjective_iff.symm
+instance : Decidable g.IsPlanar := inferInstanceAs (Decidable (∀ _, _))
+instance (v w : Fin n) : Decidable (g.Interleave v w) :=
   inferInstanceAs (Decidable (∃ _, _))
-
-instance (g : Graph n) : Decidable (IsWellNested g) :=
-  inferInstanceAs (Decidable (∀ _, _))
+instance : Decidable g.IsWellNested := inferInstanceAs (Decidable (∀ _, _))
 
 /-! ### Gap degree -/
 
 /-- The projection of `v`, as position values. -/
-def projectionVals (g : Graph n) (v : Fin n) : List Nat :=
-  (projection g v).map (·.val)
+def Graph.projectionVals (v : Fin n) : List Nat := (projection g v).map (·.val)
 
-/-- The projection is strictly sorted. -/
-theorem projectionVals_sortedLT (g : Graph n) (v : Fin n) :
-    (projectionVals g v).SortedLT := by
+theorem Graph.projectionVals_sortedLT (v : Fin n) :
+    (g.projectionVals v).SortedLT := by
   refine List.Pairwise.sortedLT (List.Pairwise.map _ (λ _ _ h => h) ?_)
   exact (List.pairwise_lt_finRange n).filter _
 
-/-- **Gap degree** of a position: the discontinuities in its projection —
-    adjacent projection members more than one position apart.
-    ([kuhlmann-nivre-2006], Definition 6) -/
-def gapDegreeAt (g : Graph n) (v : Fin n) : Nat :=
-  ((projectionVals g v).zip (projectionVals g v).tail).countP
+/-- The gap degree of a position counts the discontinuities in its
+    projection, the adjacent members more than one position apart. -/
+def Graph.gapDegreeAt (v : Fin n) : Nat :=
+  ((g.projectionVals v).zip (g.projectionVals v).tail).countP
     (λ p => decide (1 < p.2 - p.1))
 
-/-- **Gap degree** of a graph: the maximum over its positions
-    ([kuhlmann-nivre-2006], Definition 7). -/
-def Graph.gapDegree (g : Graph n) : Nat :=
-  Finset.univ.sup (gapDegreeAt g)
+/-- The gap degree of a graph is the maximum over its positions. -/
+def Graph.gapDegree : Nat := Finset.univ.sup g.gapDegreeAt
 
 /-! ### The hierarchy on trees -/
 
-variable {g : Graph n}
+variable {g}
 
-/-- Every projective tree is planar ([kuhlmann-nivre-2006] §3.5). -/
-theorem IsProjective.isPlanar (hT : g.IsTree) (hP : IsProjective g) :
-    IsPlanar g := by
-  rintro a b c d hab hcd hL1 hL2 ⟨hac, hcb, hbd⟩
+/-- Every projective tree is planar. -/
+theorem Graph.IsProjective.isPlanar (hT : g.IsTree) (hP : g.IsProjective) :
+    g.IsPlanar := by
+  rintro a b c d hL1 hL2 ⟨hac, hcb, hbd⟩
   rcases hL1 with h1 | h1 <;> rcases hL2 with h2 | h2
   · -- heads a and c
     have hac' : Dominates g a c := (hP a).out .refl (.single h1) ⟨hac.le, hcb.le⟩
@@ -129,14 +140,11 @@ theorem IsProjective.isPlanar (hT : g.IsTree) (hP : IsProjective g) :
     exact hbd.ne (Dominates.antisymm hT.acyclic
       (Dominates.to_head hT hbc' hcb.ne' h2) hdb')
 
-/-- Every projective tree is well-nested ([kuhlmann-nivre-2006] §3.5). -/
-theorem IsProjective.isWellNested (hT : g.IsTree) (hP : IsProjective g) :
-    IsWellNested g := by
-  rintro v w hvw hwv ⟨a, b, hva, hvb, c, _, hwc, _, hac, hcb, _⟩
-  exact (Dominates.comparable hT ((hP v).out hva hvb ⟨hac.le, hcb.le⟩) hwc).elim
-    hvw hwv
-
-end Defs
+/-- Every projective tree is well-nested. -/
+theorem Graph.IsProjective.isWellNested (hT : g.IsTree) (hP : g.IsProjective) :
+    g.IsWellNested := by
+  rintro v w ⟨a, hva, b, hvb, c, hwc, -, -, hac, hcb, -⟩
+  exact Dominates.comparable hT ((hP v).out hva hvb ⟨hac.le, hcb.le⟩) hwc
 
 /-! ### Canonical fixtures
 
@@ -175,13 +183,13 @@ def planarNotProjective : Graph 4 :=
 example : dutchCrossSerial.IsTree := by decide
 example : germanNested.IsTree := by decide
 example : planarNotProjective.IsTree := by decide
-example : ¬ IsPlanar dutchCrossSerial := by decide
-example : ¬ IsProjective dutchCrossSerial := by decide
-example : IsWellNested dutchCrossSerial := by decide
-example : IsPlanar germanNested := by decide
-example : IsProjective germanNested := by decide
-example : IsPlanar planarNotProjective := by decide
-example : ¬ IsProjective planarNotProjective := by decide
+example : ¬ dutchCrossSerial.IsPlanar := by decide
+example : ¬ dutchCrossSerial.IsProjective := by decide
+example : dutchCrossSerial.IsWellNested := by decide
+example : germanNested.IsPlanar := by decide
+example : germanNested.IsProjective := by decide
+example : planarNotProjective.IsPlanar := by decide
+example : ¬ planarNotProjective.IsProjective := by decide
 example : dutchCrossSerial.gapDegree = 1 := by decide
 example : germanNested.gapDegree = 0 := by decide
 

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -31,8 +31,9 @@ papers' own figures, and live in their study files.
 * `Graph.Interleave`, `Graph.IsWellNested` — Definition 8.
 * `Graph.gapDegree` — Definitions 6–7. Gap degree + 1 is the block-degree,
   the fan-out of the LCFRS rule extracted for that node.
-* `Graph.IsProjective.isPlanar`, `Graph.IsProjective.isWellNested` — the
-  inclusions from projectivity.
+* `Graph.IsProjective.isPlanar`, `Graph.IsPlanar.isWellNested` — the §3.5
+  chain `projective ⊆ planar ⊆ well-nested` on trees, with
+  `Graph.IsProjective.isWellNested` its composite.
 
 ## References
 
@@ -152,10 +153,87 @@ theorem Graph.IsProjective.isPlanar (hT : g.IsTree) (hP : g.IsProjective) :
   · exact hbd.ne (Dominates.antisymm hT.acyclic
       (step h1 h2 hba (.inr rfl) hcb.ne') (step h2 h1 hdc (.inl rfl) hbd.ne'))
 
-/-- Every projective tree is well-nested. -/
-theorem Graph.IsProjective.isWellNested (hT : g.IsTree) (hP : g.IsProjective) :
+/-- In a planar graph, a link with one endpoint strictly inside the span of
+    another link has its other endpoint inside that span too. -/
+theorem Graph.IsPlanar.mem_uIcc_of_linked (hPl : g.IsPlanar) {lo hi p q : Fin n}
+    (hL : Linked g lo hi) (hL' : Linked g p q)
+    (hlp : lo < p) (hph : p < hi) : q ∈ Set.uIcc lo hi := by
+  by_contra hq
+  have hout : q < lo ∨ hi < q := by
+    by_contra hc
+    push Not at hc
+    exact hq (Set.mem_uIcc.mpr (Or.inl ⟨hc.1, hc.2⟩))
+  rcases hout with h | h
+  · exact hPl hL'.symm hL ⟨h, hlp, hph⟩
+  · exact hPl hL hL' ⟨hlp, hph, h⟩
+
+/-- Planarity forbids a link with one endpoint strictly inside another link's
+    span and the other endpoint outside it. -/
+theorem Graph.IsPlanar.no_strict_straddle (hPl : g.IsPlanar) {p q p' q' : Fin n}
+    (hL : Linked g p q) (hL' : Linked g p' q') (hin : p' ∈ Set.uIcc p q)
+    (hne1 : p' ≠ p) (hne2 : p' ≠ q) (hout : q' ∉ Set.uIcc p q) : False := by
+  rw [Set.mem_uIcc] at hin
+  rcases lt_trichotomy p q with h | rfl | h
+  · have hb : p ≤ p' ∧ p' ≤ q := by
+      rcases hin with h1 | h2
+      · exact h1
+      · exact absurd (h2.1.trans h2.2) (not_le.mpr h)
+    exact hout (hPl.mem_uIcc_of_linked hL hL'
+      (lt_of_le_of_ne hb.1 (Ne.symm hne1)) (lt_of_le_of_ne hb.2 hne2))
+  · exact hne1 (by rcases hin with ⟨h1, h2⟩ | ⟨h1, h2⟩ <;> exact le_antisymm h2 h1)
+  · have hb : q ≤ p' ∧ p' ≤ p := by
+      rcases hin with h1 | h2
+      · exact absurd (h1.1.trans h1.2) (not_le.mpr h)
+      · exact h2
+    rw [Set.uIcc_comm] at hout
+    exact hout (hPl.mem_uIcc_of_linked hL.symm hL'
+      (lt_of_le_of_ne hb.1 (Ne.symm hne2)) (lt_of_le_of_ne hb.2 hne1))
+
+/-- Every planar tree is well-nested: interleaved subtrees would force a link
+    below one of them to straddle a link below the other. -/
+theorem Graph.IsPlanar.isWellNested (hT : g.IsTree) (hPl : g.IsPlanar) :
     g.IsWellNested := by
-  rintro v w ⟨a, hva, b, hvb, c, hwc, -, -, hac, hcb, -⟩
-  exact Dominates.comparable hT ((hP v).out hva hvb ⟨hac.le, hcb.le⟩) hwc
+  rintro v w ⟨a, hva, b, hvb, c, hwc, d, hwd, hac, hcb, hbd⟩
+  by_contra hcon
+  push Not at hcon
+  obtain ⟨hvw, hwv⟩ := hcon
+  have hdis : ∀ {x}, Dominates g v x → Dominates g w x → False :=
+    λ h1 h2 => disjoint_dominated hT hvw hwv h1 h2
+  have hab : a < b := hac.trans hcb
+  -- A link below `w` crosses the boundary of the span of `a` and `b`.
+  have hcS : c ∈ Set.uIcc a b := Set.mem_uIcc.mpr (.inl ⟨hac.le, hcb.le⟩)
+  have hdS : d ∉ Set.uIcc a b := by
+    rw [Set.uIcc_of_le hab.le, Set.mem_Icc]
+    exact λ h => absurd h.2 (not_le.mpr hbd)
+  obtain ⟨p, q, hLpq, hwp, hwq, hpS, hqS⟩ := exists_link_across hwc hwd hcS hdS
+  rw [Set.uIcc_of_le hab.le, Set.mem_Icc] at hpS hqS
+  push Not at hqS
+  have hap : a < p := lt_of_le_of_ne hpS.1 (λ h => hdis hva (h ▸ hwp))
+  have hpb : p < b := lt_of_le_of_ne hpS.2 (λ h => hdis hvb (h ▸ hwp))
+  -- Any link below `v` crossing that link's span contradicts planarity.
+  have hfin : ∀ {p' q' : Fin n}, Linked g p' q' → Dominates g v p' →
+      p' ∈ Set.uIcc p q → q' ∉ Set.uIcc p q → False := by
+    intro p' q' hL' hvp' hin hout
+    exact hPl.no_strict_straddle hLpq hL' hin
+      (λ h => hdis hvp' (h ▸ hwp)) (λ h => hdis hvp' (h ▸ hwq)) hout
+  have hqa0 : q ≠ a := λ h => hdis hva (h ▸ hwq)
+  rcases lt_or_gt_of_ne hqa0 with hqa | hqa
+  · have h1 : a ∈ Set.uIcc p q := Set.mem_uIcc.mpr (.inr ⟨hqa.le, hap.le⟩)
+    have h2 : b ∉ Set.uIcc p q := by
+      rw [Set.uIcc_comm, Set.uIcc_of_le (hqa.trans hap).le, Set.mem_Icc]
+      exact λ h => absurd h.2 (not_le.mpr hpb)
+    obtain ⟨_, _, hL', hvp', _, hin, hout⟩ := exists_link_across hva hvb h1 h2
+    exact hfin hL' hvp' hin hout
+  · have hbq : b < q := hqS hqa.le
+    have h1 : b ∈ Set.uIcc p q := Set.mem_uIcc.mpr (.inl ⟨hpb.le, hbq.le⟩)
+    have h2 : a ∉ Set.uIcc p q := by
+      rw [Set.uIcc_of_le (hpb.trans hbq).le, Set.mem_Icc]
+      exact λ h => absurd h.1 (not_le.mpr hap)
+    obtain ⟨_, _, hL', hvp', _, hin, hout⟩ := exists_link_across hvb hva h1 h2
+    exact hfin hL' hvp' hin hout
+
+/-- Every projective tree is well-nested, via planarity. -/
+theorem Graph.IsProjective.isWellNested (hT : g.IsTree) (hP : g.IsProjective) :
+    g.IsWellNested := (hP.isPlanar hT).isWellNested hT
 
 end DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -11,26 +11,38 @@ import Mathlib.Data.List.Sort
 /-!
 # Projectivity and its relaxations
 
-[kuhlmann-nivre-2006]'s hierarchy of structural constraints between
-projective and unrestricted dependency structures: projectivity as
-order-convexity of dominance cones (Definition 3), planarity (Definition 4 —
-the Link Grammar notion, traced there to [melcuk-1988]), gap degree
-(Definitions 6–7; gap degree + 1 is [kuhlmann-2013]'s block-degree, the
-LCFRS fan-out), and well-nestedness (Definition 8).
+A dependency graph is projective when the positions each node dominates form
+a contiguous stretch of the sentence. Natural language is not always
+projective, so the literature weakens the constraint in several directions.
+Planarity bans crossing arcs, well-nestedness bans interleaved subtrees, and
+gap degree counts the discontinuities a single node may show.
+
+In this file we define those constraints and prove the inclusions among them
+that hold on trees. The fixtures witness that the constraints are genuinely
+distinct: `planarNotProjective` is planar but not projective, and
+`dutchCrossSerial` is well-nested but not planar.
 
 ## Main declarations
 
 * `Graph.yield`, `Alternate` — the positions a node dominates, and the
   alternation `a < c < b < d` that both binary constraints forbid.
 * `Graph.IsProjective` — the yields are intervals (Definition 3).
-* `Graph.IsPlanar` — no two links cross (Definition 4).
+* `Graph.IsPlanar` — no two links cross (Definition 4), the Link Grammar
+  notion, traced there to [melcuk-1988].
 * `Graph.Interleave`, `Graph.IsWellNested` — Definition 8.
-* `Graph.gapDegree` — Definitions 6–7.
+* `Graph.gapDegree` — Definitions 6–7. Gap degree + 1 is the block-degree,
+  the fan-out of the LCFRS rule extracted for that node.
 * `Graph.IsProjective.isPlanar`, `Graph.IsProjective.isWellNested` — the
-  §3.5 inclusions from projectivity, on trees. Strictness is witnessed by
-  `decide` on `planarNotProjective` (a single-rooted adaptation of Figure 2a,
-  whose own witness is a forest) and on `dutchCrossSerial` (well-nested but
-  not planar), [kuhlmann-2013] Figure 1's cross-serial half.
+  inclusions from projectivity.
+
+## References
+
+[kuhlmann-nivre-2006] — Mildly non-projective dependency structures, source
+of the Definition numbers cited above and, in Figure 2a, of the forest that
+`planarNotProjective` adapts to a single root
+[kuhlmann-2013] — Mildly non-projective dependency grammar, whose Figure 1
+is the `dutchCrossSerial`/`germanNested` pair
+[melcuk-1988] — Dependency syntax: theory and practice
 -/
 
 namespace DependencyGrammar


### PR DESCRIPTION
Names the paper's own concepts and drops accumulated boilerplate in `Projectivity.lean`.

- `Graph.yield` (the dominance cone, [kuhlmann-nivre-2006] §2) and `Alternate` (the `a < c < b < d` shape both binary constraints forbid) are named rather than spelled inline; the four constraints move into `Graph` to match `Graph.IsTree`/`Graph.gapDegree`.
- `IsPlanar` sheds two hypotheses implied by its own conclusion, and `IsWellNested` goes contrapositive, which shrinks `IsProjective.isWellNested` to the `Dominates.comparable` call it always was.
- Declaration docstrings become copula sentences; the repeated per-decl citations collapse into a `## Main declarations` block carrying the Definition numbers.