### PR TITLE
refactor(Syntax/DependencyGrammar): mathlib-align the Graph API

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -95,6 +95,7 @@ import Linglib.Core.Computability.Variety.OmegaEquations
 import Linglib.Core.Computability.Variety.Definite
 import Linglib.Core.Computability.Variety.SemigroupLangs
 import Linglib.Core.Data.Fin.Tuple.Basic
+import Linglib.Core.Data.Fintype.ExistsUnique
 import Linglib.Core.Data.Fintype.List
 import Linglib.Core.Data.Fintype.Sets
 import Linglib.Core.Data.Fintype.Transfer

--- a/Linglib/Core/Data/Fintype/ExistsUnique.lean
+++ b/Linglib/Core/Data/Fintype/ExistsUnique.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Data.Fintype.Defs
+
+/-!
+# Decidability of unique existence on a finite type
+
+`∃! a, p a` unfolds to an existential bounded by a universal, both decidable
+over a `Fintype`, so unique existence is decidable. Mathlib has the
+list-bounded version (`List.decidableBExistsUnique`) but no `Fintype`
+instance.
+
+[UPSTREAM] `Mathlib.Data.Fintype.Defs`, beside `Fintype.decidableExistsFintype`.
+-/
+
+instance Fintype.decidableExistsUniqueFintype {α : Type*} {p : α → Prop}
+    [DecidablePred p] [Fintype α] [DecidableEq α] :
+    Decidable (∃! a, p a) :=
+  decidable_of_iff (∃ a, p a ∧ ∀ b, p b → b = a) Iff.rfl

--- a/Linglib/Core/Relation/ReflTransGen.lean
+++ b/Linglib/Core/Relation/ReflTransGen.lean
@@ -525,4 +525,24 @@ instance [Fintype α] [DecidableEq α] {r : α → α → Prop} [DecidableRel r]
     DecidableRel (Relation.TransGen r) :=
   decidable_TransGen_of_fintype
 
+-- ----------------------------------------------------------------------------
+-- Crossing a boundary
+-- ----------------------------------------------------------------------------
+
+/-- A reflexive-transitive path from inside `S` to outside it crosses the
+boundary at a single step, the source reaching the exit and the entry
+reaching the target — the `Relation.ReflTransGen` analogue of
+`SimpleGraph.Walk.exists_boundary_dart`. -/
+theorem exists_boundary {r : α → α → Prop} {S : Set α} {a b : α}
+    (h : Relation.ReflTransGen r a b) (ha : a ∈ S) (hb : b ∉ S) :
+    ∃ c d, r c d ∧ c ∈ S ∧ d ∉ S ∧
+      Relation.ReflTransGen r a c ∧ Relation.ReflTransGen r d b := by
+  induction h with
+  | refl => exact absurd ha hb
+  | @tail c d hac hcd ih =>
+    by_cases hc : c ∈ S
+    · exact ⟨c, d, hcd, hc, hb, hac, .refl⟩
+    · obtain ⟨p, q, hpq, hpS, hqS, hap, hqc⟩ := ih hc
+      exact ⟨p, q, hpq, hpS, hqS, hap, hqc.tail hcd⟩
+
 end Relation.ReflTransGen

--- a/Linglib/Core/Relation/ReflTransGen.lean
+++ b/Linglib/Core/Relation/ReflTransGen.lean
@@ -5,6 +5,7 @@ import Mathlib.Data.List.Perm.Subperm
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Finset.Union
 import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
 
 /-!
 # Decidability of `Relation.ReflTransGen` on a finite carrier
@@ -524,6 +525,46 @@ instance [Fintype α] [DecidableEq α] {r : α → α → Prop} [DecidableRel r]
 instance [Fintype α] [DecidableEq α] {r : α → α → Prop} [DecidableRel r] :
     DecidableRel (Relation.TransGen r) :=
   decidable_TransGen_of_fintype
+
+-- ----------------------------------------------------------------------------
+-- The closure of an acyclic relation as an order
+-- ----------------------------------------------------------------------------
+
+/-- The dual of `Relation.ReflTransGen.total_of_right_unique`: over a
+left-unique relation, positions reaching a common target are comparable. -/
+theorem total_of_left_unique {r : α → α → Prop} (U : Relator.LeftUnique r)
+    {a b c : α} (ac : Relation.ReflTransGen r a c)
+    (bc : Relation.ReflTransGen r b c) :
+    Relation.ReflTransGen r a b ∨ Relation.ReflTransGen r b a :=
+  (total_of_right_unique
+      (show Relator.RightUnique (Function.swap r) from λ _ _ _ h h' => U h h')
+      (Relation.reflTransGen_swap.mpr ac)
+      (Relation.reflTransGen_swap.mpr bc)).symm.imp
+    Relation.reflTransGen_swap.mp Relation.reflTransGen_swap.mp
+
+/-- The reflexive-transitive closure of a relation whose transitive closure
+is irreflexive is antisymmetric. -/
+theorem antisymm_of_irrefl_transGen {r : α → α → Prop}
+    (h : ∀ a, ¬ Relation.TransGen r a a) {a b : α}
+    (hab : Relation.ReflTransGen r a b) (hba : Relation.ReflTransGen r b a) :
+    a = b := by
+  rcases cases_head hab with rfl | ⟨c, hac, hcb⟩
+  · rfl
+  · exact absurd (Relation.TransGen.head' hac (hcb.trans hba)) (h a)
+
+/-- On a finite carrier, if the relation is acyclic and every element other
+than `a` has a predecessor, then `a` reaches everything. -/
+theorem of_forall_exists [Finite α] {r : α → α → Prop}
+    (hirr : ∀ v, ¬ Relation.TransGen r v v) {a : α}
+    (h : ∀ v, v ≠ a → ∃ u, r u v) (v : α) : Relation.ReflTransGen r a v := by
+  have : Std.Irrefl (Relation.TransGen r) := ⟨hirr⟩
+  refine (Finite.wellFounded_of_trans_of_irrefl
+    (Relation.TransGen r)).induction (C := (Relation.ReflTransGen r a ·)) v ?_
+  intro v ih
+  by_cases hv : v = a
+  · exact hv ▸ .refl
+  · obtain ⟨u, hu⟩ := h v hv
+    exact (ih u (Relation.TransGen.single hu)).tail hu
 
 -- ----------------------------------------------------------------------------
 -- Crossing a boundary

--- a/Linglib/Core/Relation/ReflTransGen.lean
+++ b/Linglib/Core/Relation/ReflTransGen.lean
@@ -513,4 +513,16 @@ def decidable_TransGen_of_fintype [Fintype α] [DecidableEq α] {r : α → α �
     (fun a b => by simp [decide_eq_true_eq])
     a b
 
+/-- Reachability on a `[Fintype]` carrier is decidable — the
+`Relation.ReflTransGen` analogue of mathlib's `DecidableRel G.Reachable`
+for finite simple graphs. Concrete `decide`s over this instance may need
+`+kernel`. -/
+instance [Fintype α] [DecidableEq α] {r : α → α → Prop} [DecidableRel r] :
+    DecidableRel (Relation.ReflTransGen r) :=
+  decidable_of_fintype
+
+instance [Fintype α] [DecidableEq α] {r : α → α → Prop} [DecidableRel r] :
+    DecidableRel (Relation.TransGen r) :=
+  decidable_TransGen_of_fintype
+
 end Relation.ReflTransGen

--- a/Linglib/Studies/Kuhlmann2013.lean
+++ b/Linglib/Studies/Kuhlmann2013.lean
@@ -64,7 +64,8 @@ example : ¬ dutchCrossSerial.IsProjective ∧ germanNested.IsProjective := by d
 example : dutchCrossSerial.gapDegree = 1 ∧ germanNested.gapDegree = 0 := by decide
 
 /-- Cross-serial dependencies stay well-nested; they are not planar. -/
-example : dutchCrossSerial.IsWellNested ∧ ¬ dutchCrossSerial.IsPlanar := by decide
+example : dutchCrossSerial.IsWellNested ∧ ¬ dutchCrossSerial.IsPlanar := by
+  decide +kernel
 
 /-- The nested order has no crossing links; the cross-serial order has five. -/
 example : germanNested.crossings = 0 := by decide +kernel

--- a/Linglib/Studies/OsborneLi2023.lean
+++ b/Linglib/Studies/OsborneLi2023.lean
@@ -60,16 +60,16 @@ open Morphology (Word)
 /-! ### Predicate-valent type -/
 
 /-- The conjuncts of the coordinate structure headed at `c`: the head
-    (first conjunct, per UD) plus its `.conj` dependents. -/
-def allConjuncts {n : ℕ} (g : Graph n) (c : Fin n) : List (Fin n) :=
-  c :: (g.children c).filter (λ w => g.label c w == some .conj)
+    (the first conjunct, per UD) plus its `.conj` dependents. -/
+def allConjuncts {n : ℕ} (g : Graph n) (c : Fin n) : Finset (Fin n) :=
+  insert c {w ∈ g.children c | g.label c w = some .conj}
 
 /-- Position `c` heads a coordinate structure: it has a `conj` dependent. -/
 def HasConjuncts {n : ℕ} (g : Graph n) (c : Fin n) : Prop :=
   ∃ w ∈ g.children c, g.label c w = some .conj
 
 instance {n : ℕ} (g : Graph n) (c : Fin n) : Decidable (HasConjuncts g c) :=
-  List.decidableBEx _ _
+  Finset.decidableExistsAndFinset
 
 /-- Word `valentIdx` is a *conjunct valent* of predicate `predIdx`: a
     conjunct of a coordinate structure that fills a valency role of
@@ -80,7 +80,7 @@ def IsConjunctValent {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) : Prop 
 
 instance {n : ℕ} (g : Graph n) (predIdx valentIdx : Fin n) :
     Decidable (IsConjunctValent g predIdx valentIdx) :=
-  List.decidableBEx _ _
+  Finset.decidableExistsAndFinset
 
 /-- Word `valentIdx` is a *full valent* of `predIdx`: a valent that is
     not a conjunct valent — the paper's definition (p. 651): "a valent

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -11,19 +11,15 @@ import Linglib.Data.UD.Basic
 import Linglib.Morphology.Word.Basic
 
 /-!
-# Dependency grammar substrate
+# Dependency graphs
 
-This file defines the dependency structure of a sentence, following the
-formal dependency-grammar literature ([kuhlmann-nivre-2006],
-[kuhlmann-2013]; the presentation as arcs among ordered words goes back to
-[melcuk-1988]). The vertices are the sentence positions `Fin n` with their
-linear order, and the arcs are a partial labeling of ordered position
-pairs by UD v2 dependency relations.
+This file defines the dependency structure of a sentence: the vertices are
+the sentence positions `Fin n` with their linear order, and the arcs are a
+partial labeling of ordered position pairs by UD v2 dependency relations.
+A distinguished `root` position replaces CoNLL-U's artificial root token.
 
-A distinguished `root` position replaces CoNLL-U's artificial root token,
-following [kuhlmann-nivre-2006]. Well-formedness (`Graph.IsTree`) is
-defined in `Dominance.lean`, beside the dominance relation it is stated
-through.
+Well-formedness (`Graph.IsTree`) is defined in `Dominance.lean`, beside
+the dominance relation it is stated through.
 
 ## Main definitions
 
@@ -39,9 +35,8 @@ through.
 * `Graph.ofArcs` builds a graph from a CoNLL-U-style token list and arc
   list.
 * `Graph.enhance` adds arcs to a graph, as in UD's *enhanced*
-  representation ([de-marneffe-nivre-2019]); `HasUnrepresentedArg` says
-  that an enhanced graph gives a position an argument relation its basic
-  graph lacks.
+  representation; `HasUnrepresentedArg` says that an enhanced graph gives
+  a position an argument relation its basic graph lacks.
 
 ## Implementation notes
 
@@ -56,10 +51,13 @@ carrier's.
 
 ## References
 
-[kuhlmann-nivre-2006] — Mildly non-projective dependency structures
+[melcuk-1988] — Dependency syntax: theory and practice, source of the
+arcs-among-ordered-words presentation
+[kuhlmann-nivre-2006] — Mildly non-projective dependency structures,
+source of the root convention
 [kuhlmann-2013] — Mildly non-projective dependency grammar
-[melcuk-1988] — Dependency syntax: theory and practice
-[de-marneffe-nivre-2019] — Dependency grammar, the UD survey
+[de-marneffe-nivre-2019] — Dependency grammar, on UD's enhanced
+representation
 -/
 
 open Morphology (Word)

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -13,40 +13,53 @@ import Linglib.Morphology.Word.Basic
 /-!
 # Dependency grammar substrate
 
-The dependency structure of a sentence, in the carrier of the formal
-dependency-grammar literature ([kuhlmann-nivre-2006], [kuhlmann-2013];
-the arcs-among-ordered-words presentation goes back to [melcuk-1988]): the
-nodes are the sentence positions `Fin n` with their linear order, and the
-arcs are a labeling of ordered pairs of positions by UD v2 dependency
-relations (`Data/UD/Basic.lean`). A distinguished `root` replaces CoNLL-U's
-artificial root token, following [kuhlmann-nivre-2006].
+This file defines the dependency structure of a sentence, following the
+formal dependency-grammar literature ([kuhlmann-nivre-2006],
+[kuhlmann-2013]; the presentation as arcs among ordered words goes back to
+[melcuk-1988]). The vertices are the sentence positions `Fin n` with their
+linear order, and the arcs are a partial labeling of ordered position
+pairs by UD v2 dependency relations.
 
-## Main declarations
+A distinguished `root` position replaces CoNLL-U's artificial root token,
+following [kuhlmann-nivre-2006]. Well-formedness (`Graph.IsTree`) is
+defined in `Dominance.lean`, beside the dominance relation it is stated
+through.
 
-* `Graph n` — a dependency graph on `n` words: vertex-labeling `words`,
-  arc-labeling `label`, distinguished `root`. `Graph.Adj` is the induced
-  adjacency (decidable), `Graph.Linked` its symmetrization, and
-  `Graph.toDigraph` / `Graph.toSimpleGraph` the projections onto mathlib's
-  graph carriers.
-* `Graph.parents`, `Graph.children` — the head and dependent sets, with
-  membership characterized by `Graph.Adj`.
-* `Graph.ofArcs`, `Graph.enhance` — the CoNLL-U-style constructor, and arc
-  addition for UD's *enhanced* representation ([de-marneffe-nivre-2019]),
-  which adds the predicate-argument relations a single-headed tree cannot
-  encode. Both are characterized by adjacency simp lemmas
-  (`Graph.ofArcs_adj`, `Graph.enhance_adj`); `HasUnrepresentedArg` is the
-  basic-vs-enhanced diagnostic.
-* Well-formedness (`Graph.IsTree`) lives in `Dominance.lean`, beside the
-  dominance relation it is stated through. Feature-level constraints
-  (agreement) are `Syntax/Agreement/`'s domain, not the carrier's.
+## Main definitions
+
+* `Graph n` is a dependency graph on `n` words: a token at every position,
+  an optional UD relation on every ordered pair of positions (head to
+  dependent), and a root position.
+* `Graph.Adj` is the arc relation from heads to dependents.
+* `Graph.Linked` is the symmetrization of `Graph.Adj`.
+* `Graph.toDigraph` and `Graph.toSimpleGraph` are the directed and
+  undirected views of a graph as mathlib's graph carriers.
+* `Graph.parents` and `Graph.children` are the finsets of heads and of
+  dependents of a position.
+* `Graph.ofArcs` builds a graph from a CoNLL-U-style token list and arc
+  list.
+* `Graph.enhance` adds arcs to a graph, as in UD's *enhanced*
+  representation ([de-marneffe-nivre-2019]); `HasUnrepresentedArg` says
+  that an enhanced graph gives a position an argument relation its basic
+  graph lacks.
 
 ## Implementation notes
 
-* Positions are 0-indexed; CoNLL-U is 1-indexed with `0` as an artificial
-  root, so wire-format conversion shifts indices.
-* `label` returns at most one relation per ordered pair: faithful to
-  dependency trees and basic UD. If an enhanced-UD fixture ever needs
-  parallel arcs on one pair, the field generalizes to a list.
+Positions are 0-indexed; CoNLL-U is 1-indexed with `0` as an artificial
+root, so wire-format conversion shifts indices.
+
+`label` returns at most one relation per ordered pair, faithful to
+dependency trees and basic UD. If an enhanced-UD fixture ever needs
+parallel arcs on one pair, the field generalizes to a list. Feature-level
+constraints (agreement) are `Syntax/Agreement/`'s domain, not the
+carrier's.
+
+## References
+
+[kuhlmann-nivre-2006] — Mildly non-projective dependency structures
+[kuhlmann-2013] — Mildly non-projective dependency grammar
+[melcuk-1988] — Dependency syntax: theory and practice
+[de-marneffe-nivre-2019] — Dependency grammar, the UD survey
 -/
 
 open Morphology (Word)

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -25,17 +25,18 @@ artificial root token, following [kuhlmann-nivre-2006].
 
 * `Graph n` — a dependency graph on `n` words: vertex-labeling `words`,
   arc-labeling `label`, distinguished `root`. `Graph.Adj` is the induced
-  adjacency (decidable), `Graph.toDigraph` the projection onto mathlib's
-  `Digraph`, `Linked` / `Graph.toSimpleGraph` its symmetrization (mathlib
-  `SimpleGraph`), and `Graph.ofArcs` the constructor from CoNLL-U-style
-  arc lists.
-* `Graph.parents`, `children`, `inDegree` — the local graph API.
-* `Graph.enhance`, `HasUnrepresentedArg` — arc addition and the
-  basic-vs-enhanced diagnostic for UD's *enhanced* representation
-  ([de-marneffe-nivre-2019]), which adds the predicate-argument
-  relations a single-headed tree cannot encode; basic sits below
-  enhanced in the `Digraph` order (`Graph.toDigraph_le_enhance`).
-* Well-formedness (`Graph.IsTree`) lives in `Projection.lean`, beside the
+  adjacency (decidable), `Graph.Linked` its symmetrization, and
+  `Graph.toDigraph` / `Graph.toSimpleGraph` the projections onto mathlib's
+  graph carriers.
+* `Graph.parents`, `Graph.children` — the head and dependent sets, with
+  membership characterized by `Graph.Adj`.
+* `Graph.ofArcs`, `Graph.enhance` — the CoNLL-U-style constructor, and arc
+  addition for UD's *enhanced* representation ([de-marneffe-nivre-2019]),
+  which adds the predicate-argument relations a single-headed tree cannot
+  encode. Both are characterized by adjacency simp lemmas
+  (`Graph.ofArcs_adj`, `Graph.enhance_adj`); `HasUnrepresentedArg` is the
+  basic-vs-enhanced diagnostic.
+* Well-formedness (`Graph.IsTree`) lives in `Dominance.lean`, beside the
   dominance relation it is stated through. Feature-level constraints
   (agreement) are `Syntax/Agreement/`'s domain, not the carrier's.
 
@@ -58,6 +59,7 @@ namespace DependencyGrammar
     the positions `Fin n`, the arcs as a partial labeling of ordered position
     pairs (head → dependent) by UD relations, and a distinguished root
     position. -/
+@[ext]
 structure Graph (n : ℕ) where
   /-- The token at each position. -/
   words : Fin n → Word
@@ -75,52 +77,76 @@ def Adj (v w : Fin n) : Prop := (g.label v w).isSome
 
 instance : DecidableRel g.Adj := λ _ _ => inferInstanceAs (Decidable (_ = true))
 
+theorem adj_iff_exists {g : Graph n} {v w : Fin n} :
+    g.Adj v w ↔ ∃ r, g.label v w = some r := Option.isSome_iff_exists
+
+/-- Positions linked by an arc in either direction — the undirected view of
+    adjacency. -/
+def Linked (a b : Fin n) : Prop := g.Adj a b ∨ g.Adj b a
+
+instance (a b : Fin n) : Decidable (g.Linked a b) :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+theorem Linked.symm {g : Graph n} {a b : Fin n} (h : g.Linked a b) :
+    g.Linked b a := Or.symm h
+
+/-! ### Views onto mathlib's graph carriers -/
+
 /-- The graph as a mathlib `Digraph` on positions. -/
 def toDigraph : Digraph (Fin n) := ⟨g.Adj⟩
 
 @[simp] theorem toDigraph_adj (v w : Fin n) : g.toDigraph.Adj v w ↔ g.Adj v w :=
   Iff.rfl
 
-attribute [coe] toDigraph
-
-instance : Coe (Graph n) (Digraph (Fin n)) := ⟨toDigraph⟩
-
-/-- Fewer arcs, smaller digraph, in the `Digraph` lattice order. -/
-theorem toDigraph_mono {g g' : Graph n} (h : ∀ v w, g.Adj v w → g'.Adj v w) :
-    g.toDigraph ≤ g'.toDigraph := h
-
 /-- The graph's undirected view: mathlib's orientation-forgetting
     `Digraph.toSimpleGraphInclusive` applied to `toDigraph`. Planarity and
     catena connectivity are stated through it. -/
 def toSimpleGraph : SimpleGraph (Fin n) := g.toDigraph.toSimpleGraphInclusive
 
+@[simp] theorem toSimpleGraph_adj (v w : Fin n) :
+    g.toSimpleGraph.Adj v w ↔ v ≠ w ∧ g.Linked v w := Iff.rfl
+
 instance : DecidableRel g.toSimpleGraph.Adj :=
-  inferInstanceAs (DecidableRel (SimpleGraph.fromRel g.Adj).Adj)
+  λ v w => decidable_of_iff _ (g.toSimpleGraph_adj v w).symm
+
+/-- Off the diagonal the two undirected views agree; they can differ only on
+    self-arcs, which `toSimpleGraph` drops and `Linked` keeps. -/
+theorem toSimpleGraph_adj_of_ne {g : Graph n} {v w : Fin n} (h : v ≠ w) :
+    g.toSimpleGraph.Adj v w ↔ g.Linked v w := by simp [h]
+
+/-! ### Heads and dependents -/
 
 /-- The head positions of `w`. -/
-def parents (w : Fin n) : List (Fin n) :=
-  (List.finRange n).filter (g.Adj · w)
+def parents (w : Fin n) : Finset (Fin n) := {v | g.Adj v w}
 
 /-- The dependent positions of `v`. -/
-def children (v : Fin n) : List (Fin n) :=
-  (List.finRange n).filter (g.Adj v ·)
-
-/-- The number of incoming arcs at `w`. -/
-def inDegree (w : Fin n) : Nat := (g.parents w).length
+def children (v : Fin n) : Finset (Fin n) := {w | g.Adj v w}
 
 @[simp] theorem mem_parents {g : Graph n} {v w : Fin n} :
-    v ∈ g.parents w ↔ g.Adj v w := by
-  simp [parents, List.mem_filter]
+    v ∈ g.parents w ↔ g.Adj v w := by simp [parents]
 
 @[simp] theorem mem_children {g : Graph n} {v w : Fin n} :
-    w ∈ g.children v ↔ g.Adj v w := by
-  simp [children, List.mem_filter]
+    w ∈ g.children v ↔ g.Adj v w := by simp [children]
+
+/-! ### Constructors -/
 
 /-- The partial label function induced by a CoNLL-U-style arc list of
     (head, dependent, relation) triples. First match wins. -/
 def arcsLabel (arcs : List (Fin n × Fin n × UD.DepRel)) (v w : Fin n) :
     Option UD.DepRel :=
   (arcs.find? λ a => a.1 == v && a.2.1 == w).map (·.2.2)
+
+/-- An arc list labels a pair exactly when some triple mentions it; which
+    relation wins on duplicates is `arcsLabel`'s business, not whether. -/
+theorem arcsLabel_isSome_iff {arcs : List (Fin n × Fin n × UD.DepRel)}
+    {v w : Fin n} : (arcsLabel arcs v w).isSome ↔ ∃ r, (v, w, r) ∈ arcs := by
+  simp only [arcsLabel, Option.isSome_map, List.find?_isSome, Bool.and_eq_true,
+    beq_iff_eq]
+  constructor
+  · rintro ⟨⟨a, b, r⟩, hmem, rfl, rfl⟩
+    exact ⟨r, hmem⟩
+  · rintro ⟨r, hmem⟩
+    exact ⟨(v, w, r), hmem, rfl, rfl⟩
 
 /-- Build a graph from CoNLL-U-style data: the token list (whose length
     fixes `n`), the root position, and the arcs as
@@ -131,6 +157,12 @@ def ofArcs (words : List Word) (root : Fin words.length)
     Graph words.length :=
   { words := words.get, label := arcsLabel arcs, root }
 
+@[simp] theorem ofArcs_adj {words : List Word} {root : Fin words.length}
+    {arcs : List (Fin words.length × Fin words.length × UD.DepRel)}
+    {v w : Fin words.length} :
+    (ofArcs words root arcs).Adj v w ↔ ∃ r, (v, w, r) ∈ arcs :=
+  arcsLabel_isSome_iff
+
 /-- Add arcs to a graph (existing labels win), as in UD's *enhanced*
     representation: semantic relations the single-headed tree cannot
     encode — shared dependents in coordination, controlled subjects,
@@ -138,32 +170,14 @@ def ofArcs (words : List Word) (root : Fin words.length)
 def enhance (extra : List (Fin n × Fin n × UD.DepRel)) : Graph n :=
   { g with label := λ v w => g.label v w <|> arcsLabel extra v w }
 
-/-- Enhancement only adds arcs. -/
-theorem Adj.enhance {g : Graph n} {v w : Fin n} (h : g.Adj v w)
-    (extra : List (Fin n × Fin n × UD.DepRel)) :
-    (g.enhance extra).Adj v w := by
-  obtain ⟨r, hr⟩ := Option.isSome_iff_exists.mp h
-  simp [Graph.Adj, Graph.enhance, hr]
-
-/-- The basic graph sits below its enhancement in the `Digraph` lattice. -/
-theorem toDigraph_le_enhance (extra : List (Fin n × Fin n × UD.DepRel)) :
-    g.toDigraph ≤ (g.enhance extra).toDigraph :=
-  toDigraph_mono (λ _ _ h => h.enhance extra)
+@[simp] theorem enhance_adj {g : Graph n}
+    {extra : List (Fin n × Fin n × UD.DepRel)} {v w : Fin n} :
+    (g.enhance extra).Adj v w ↔ g.Adj v w ∨ ∃ r, (v, w, r) ∈ extra := by
+  cases h : g.label v w with
+  | some r => simp [Adj, enhance, h]
+  | none => simpa [Adj, enhance, h] using arcsLabel_isSome_iff
 
 end Graph
-
-/-- Positions linked by an arc in either direction — the unbundled adjacency
-    of `Graph.toSimpleGraph`, without its `≠` guard. -/
-def Linked {n : ℕ} (g : Graph n) (a b : Fin n) : Prop := g.Adj a b ∨ g.Adj b a
-
-instance {n : ℕ} (g : Graph n) (a b : Fin n) : Decidable (Linked g a b) :=
-  inferInstanceAs (Decidable (_ ∨ _))
-
-theorem Linked.symm {n : ℕ} {g : Graph n} {a b : Fin n} (h : Linked g a b) :
-    Linked g b a := Or.symm h
-
-@[simp] theorem Graph.toSimpleGraph_adj {n : ℕ} (g : Graph n) (v w : Fin n) :
-    g.toSimpleGraph.Adj v w ↔ v ≠ w ∧ Linked g v w := Iff.rfl
 
 /-- Position `w` has an argument relation in the enhanced graph that the
     basic graph fails to encode. -/

--- a/Linglib/Syntax/DependencyGrammar/Basic.lean
+++ b/Linglib/Syntax/DependencyGrammar/Basic.lean
@@ -26,14 +26,8 @@ the dominance relation it is stated through.
 * `Graph n` is a dependency graph on `n` words: a token at every position,
   an optional UD relation on every ordered pair of positions (head to
   dependent), and a root position.
-* `Graph.Adj` is the arc relation from heads to dependents.
-* `Graph.Linked` is the symmetrization of `Graph.Adj`.
 * `Graph.toDigraph` and `Graph.toSimpleGraph` are the directed and
   undirected views of a graph as mathlib's graph carriers.
-* `Graph.parents` and `Graph.children` are the finsets of heads and of
-  dependents of a position.
-* `Graph.ofArcs` builds a graph from a CoNLL-U-style token list and arc
-  list.
 * `Graph.enhance` adds arcs to a graph, as in UD's *enhanced*
   representation; `HasUnrepresentedArg` says that an enhanced graph gives
   a position an argument relation its basic graph lacks.

--- a/Linglib/Syntax/DependencyGrammar/Crossings.lean
+++ b/Linglib/Syntax/DependencyGrammar/Crossings.lean
@@ -46,7 +46,7 @@ variable {n : ℕ} (g : Graph n)
     in `g`'s own. -/
 def Graph.crossingsUnder (σ : Perm (Fin n)) : Nat :=
   (Finset.univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-    Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2 ∧
+    g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2 ∧
       Alternate (σ x.1) (σ x.2.1) (σ x.2.2.1) (σ x.2.2.2))).card
 
 /-- The unordered pairs of links sharing no endpoint — the pairs that can
@@ -55,7 +55,7 @@ def Graph.crossingsUnder (σ : Perm (Fin n)) : Nat :=
     and the earlier-starting link first. -/
 def Graph.disjointLinkPairs : Nat :=
   (Finset.univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-    Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2 ∧
+    g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2 ∧
       x.1 < x.2.1 ∧ x.2.2.1 < x.2.2.2 ∧ x.1 < x.2.2.1 ∧
         x.2.1 ≠ x.2.2.1 ∧ x.2.1 ≠ x.2.2.2)).card
 
@@ -69,7 +69,7 @@ theorem Graph.crossings_relabel (σ : Perm (Fin n)) :
   refine Finset.card_equiv
     (σ.symm.prodCongr (σ.symm.prodCongr (σ.symm.prodCongr σ.symm))) ?_
   rintro ⟨a, b, c, d⟩
-  simp [Linked, Alternate]
+  simp [Graph.Linked, Alternate]
 
 /-! ### One linearization in twenty-four alternates a distinct quadruple -/
 
@@ -130,13 +130,13 @@ private instance : DecidablePred (distinct4 (n := n)) :=
 private theorem sum_crossingsUnder :
     ∑ σ : Perm (Fin n), g.crossingsUnder σ =
       ∑ x ∈ univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-          Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2),
+          g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2),
         #{σ : Perm (Fin n) | Alternate (σ x.1) (σ x.2.1) (σ x.2.2.1) (σ x.2.2.2)} := by
   simp only [Graph.crossingsUnder, Finset.card_filter]
   rw [Finset.sum_comm]
   rw [Finset.sum_filter]
   refine Finset.sum_congr rfl (λ x _ => ?_)
-  by_cases h1 : Linked g x.1 x.2.1 <;> by_cases h2 : Linked g x.2.2.1 x.2.2.2 <;>
+  by_cases h1 : g.Linked x.1 x.2.1 <;> by_cases h2 : g.Linked x.2.2.1 x.2.2.2 <;>
     simp [h1, h2]
 
 /-- Each linked quadruple of distinct positions contributes `n !` to
@@ -145,10 +145,10 @@ private theorem sum_crossingsUnder :
 private theorem mul_sum_crossingsUnder :
     24 * ∑ σ : Perm (Fin n), g.crossingsUnder σ =
       n ! * #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        (Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x)) := by
+        (g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x)) := by
   rw [sum_crossingsUnder, Finset.mul_sum]
   have hcongr : ∀ x ∈ univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-      Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2),
+      g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2),
       24 * #{σ : Perm (Fin n) |
         Alternate (σ x.1) (σ x.2.1) (σ x.2.2.1) (σ x.2.2.2)} =
         if distinct4 x then n ! else 0 := by
@@ -186,12 +186,12 @@ private theorem card_filter_eq_two_mul {α : Type*} [Fintype α] [DecidableEq α
     orientation for each link and the order of the two links. -/
 private theorem card_linked_distinct :
     #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        (Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x)) =
+        (g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x)) =
       8 * g.disjointLinkPairs := by
   have h1 : #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        (Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x)) =
+        (g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x)) =
       2 * #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        ((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        ((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1)) := by
     refine card_filter_eq_two_mul (λ x => (x.2.1, x.1, x.2.2)) (λ _ => rfl) ?_ ?_
     · rintro ⟨a, b, c, d⟩ ⟨⟨h1, h2⟩, d1, d2, d3, d4, d5, d6⟩
@@ -201,10 +201,10 @@ private theorem card_linked_distinct :
       show b < a ↔ ¬ a < b
       omega
   have h2 : #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        ((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        ((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1)) =
       2 * #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        (((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        (((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1) ∧ x.2.2.1 < x.2.2.2)) := by
     refine card_filter_eq_two_mul (λ x => (x.1, x.2.1, x.2.2.2, x.2.2.1))
       (λ _ => rfl) ?_ ?_
@@ -215,10 +215,10 @@ private theorem card_linked_distinct :
       show d < c ↔ ¬ c < d
       omega
   have h3 : #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        (((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        (((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1) ∧ x.2.2.1 < x.2.2.2)) =
       2 * #(univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        ((((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        ((((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1) ∧ x.2.2.1 < x.2.2.2) ∧ x.1 < x.2.2.1)) := by
     refine card_filter_eq_two_mul (λ x => (x.2.2.1, x.2.2.2, x.1, x.2.1))
       (λ _ => rfl) ?_ ?_
@@ -229,10 +229,10 @@ private theorem card_linked_distinct :
       show c < a ↔ ¬ a < c
       omega
   have h4 : univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        ((((Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
+        ((((g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2) ∧ distinct4 x) ∧
           x.1 < x.2.1) ∧ x.2.2.1 < x.2.2.2) ∧ x.1 < x.2.2.1) =
       univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-        Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2 ∧
+        g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2 ∧
           x.1 < x.2.1 ∧ x.2.2.1 < x.2.2.2 ∧ x.1 < x.2.2.1 ∧
             x.2.1 ≠ x.2.2.1 ∧ x.2.1 ≠ x.2.2.2) := by
     refine Finset.filter_congr (λ x _ => ?_)

--- a/Linglib/Syntax/DependencyGrammar/Crossings.lean
+++ b/Linglib/Syntax/DependencyGrammar/Crossings.lean
@@ -13,24 +13,33 @@ import Mathlib.Tactic.FinCases
 /-!
 # Crossings under random linearization
 
-[ferrer-i-cancho-2017]'s null hypothesis for dependency crossings: if a
-sentence's word order were lost and replaced by a uniformly random one, the
-expected number of crossings would depend only on the arc structure, because
-two links cross in a third of the linearizations when they share no endpoint
-and in none otherwise. Summed over all `n !` linearizations and cleared of
-denominators, that is `Graph.three_mul_sum_crossings_relabel`. No tree
-hypothesis is needed: the identity holds for any link structure.
+This file proves that if a sentence's word order were lost and replaced by
+a uniformly random one, the expected number of crossings would depend only
+on the arc structure: two links cross in a third of the linearizations
+when they share no endpoint, and in none otherwise. No tree hypothesis is
+needed; the identity holds for any link structure.
 
-## Main declarations
+## Main definitions
 
-* `Graph.crossingsUnder` — the crossings `g` would show under a permutation
-  of its positions; `Graph.crossings_relabel` equates it with the crossings
-  of `Graph.relabel`.
-* `Graph.disjointLinkPairs` — the pairs of links sharing no endpoint,
-  [ferrer-i-cancho-2017]'s potential crossings, which [ferrer-i-cancho-2013]
-  reduces to the link count and the degree second moment.
-* `Graph.three_mul_sum_crossings_relabel` — the expected-crossings identity
+* `Graph.crossingsUnder` is the crossings `g` would show under a
+  permutation of its positions.
+* `Graph.disjointLinkPairs` is the number of unordered pairs of links
+  sharing no endpoint — the pairs that can cross at all.
+
+## Main results
+
+* `Graph.crossings_relabel`: the crossings of a relabelled graph are the
+  crossings under the permutation.
+* `Graph.three_mul_sum_crossings_relabel`: the expected-crossings identity
   `3 * ∑ σ, (g.relabel σ).crossings = n ! * g.disjointLinkPairs`.
+
+## References
+
+[ferrer-i-cancho-2017] — Random crossings in dependency trees, source of
+the expected-crossings identity (eq. 13)
+[ferrer-i-cancho-2013] — Hubiness, length, crossings and their
+relationships in syntactic dependencies, reduces the disjoint-pair count
+to the link count and the degree second moment
 -/
 
 namespace DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -14,32 +14,30 @@ import Mathlib.Order.SuccPred.Tree
 import Linglib.Core.Order.SuccPred.Tree
 
 /-!
-# Dominance
+# Dominance and dependency trees
 
-Dominance as the reflexive-transitive closure of the arc relation, the
-projection (yield) it induces, tree well-formedness, and the order
-theory of dominance on trees ([kuhlmann-nivre-2006] §2).
+This file defines dominance as the reflexive-transitive closure of the
+arc relation, the projection (yield) it induces, tree well-formedness,
+and the order theory of dominance on trees.
 
-## Main declarations
+## Main definitions
 
-* `Dominates`, `Graph.dominated`, `Graph.projection`, `Graph.mem_projection` —
-  the dominance relation, the positions a node dominates, that set in
-  ascending order, and the bridge between them.
-* `Graph.IsTree` — no arc into the root, unique heads elsewhere,
-  acyclicity; decidable. `IsTree.root_dominates`: the root dominates
-  every position, so dominance on a tree is a partial order with the
-  root as bottom.
-* `Dominates.antisymm`, `Dominates.to_head`, `Dominates.comparable` —
-  on trees dominance is a partial order under which the dominators of
-  any position form a chain.
-* `Graph.headOf`, `DominanceOrder`, `Graph.toRootedTree` — the head
-  function; `Fin n` re-ordered by dominance, with `[Fact g.IsTree]` a
-  `PartialOrder` + `OrderBot` + `PredOrder` + `IsPredArchimedean` +
-  `SemilatticeInf` (root as `⊥`, head as `Order.pred`, lowest common
-  governor as `⊓`); and the bundling as mathlib's `RootedTree`.
-* `Tree n` — well-formed graphs bundled with their tree-hood
-  (`t.isTree`), so the dominance-order instances hold with no side
-  conditions and the graph API is a parent projection away.
+* `Dominates` is the reflexive-transitive closure of the arc relation.
+* `Graph.IsTree` is tree well-formedness: no arc into the root, a unique
+  head elsewhere, and acyclicity. It is decidable.
+* `DominanceOrder` is `Fin n` reordered by dominance. On a tree it is a
+  partial order with the root as bottom, the head as predecessor, and the
+  lowest common governor as meet, bundled as mathlib's `RootedTree` by
+  `Graph.toRootedTree`.
+* `Tree n` is a graph bundled with its tree-hood, so the dominance-order
+  instances hold with no side conditions.
+
+## Main results
+
+* `IsTree.root_dominates`: the root of a tree dominates every position.
+* `Dominates.antisymm` and `Dominates.comparable`: on trees dominance is
+  a partial order under which the dominators of any position form a
+  chain.
 
 ## Implementation notes
 
@@ -48,6 +46,11 @@ mathlib's closure API (`.refl`, `.tail`, `.trans`, `.single`,
 `cases_tail`, `total_of_right_unique`, …) applies to dominance facts
 directly; this file adds only what mentions the dependency carrier.
 Decidability comes from `Core/Relation/ReflTransGen.lean`.
+
+## References
+
+[kuhlmann-nivre-2006] — Mildly non-projective dependency structures,
+source of the dominance and projection definitions
 -/
 
 namespace DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -112,9 +112,9 @@ instance (g : Graph n) : Decidable g.IsTree :=
 variable {g : Graph n} {v w : Fin n}
 
 /-- In a tree, a position has at most one head. -/
-theorem Graph.IsTree.rightUnique_flip_adj (hT : g.IsTree) :
-    Relator.RightUnique (flip g.Adj) := by
-  intro y u u' hu hu'
+theorem Graph.IsTree.leftUnique_adj (hT : g.IsTree) :
+    Relator.LeftUnique g.Adj := by
+  intro u u' y hu hu'
   have hy : y ≠ g.root := λ he => hT.not_adj_root u (he ▸ hu)
   obtain ⟨z, _, hz⟩ := hT.existsUnique_adj y hy
   exact (hz u hu).trans (hz u' hu').symm
@@ -126,10 +126,8 @@ theorem not_adj_dominates (hacyc : ∀ v, ¬ TransGen g.Adj v v)
 
 /-- Dominance is antisymmetric on acyclic graphs. -/
 theorem Dominates.antisymm (hacyc : ∀ v, ¬ TransGen g.Adj v v)
-    (hvw : Dominates g v w) (hwv : Dominates g w v) : v = w := by
-  rcases ReflTransGen.cases_head hvw with rfl | ⟨u, hvu, huw⟩
-  · rfl
-  · exact absurd (huw.trans hwv) (λ h => not_adj_dominates hacyc hvu h)
+    (hvw : Dominates g v w) (hwv : Dominates g w v) : v = w :=
+  ReflTransGen.antisymm_of_irrefl_transGen hacyc hvw hwv
 
 /-- A strict dominator of `w` dominates `w`'s head. -/
 theorem Dominates.to_head {u : Fin n} (hT : g.IsTree)
@@ -137,30 +135,21 @@ theorem Dominates.to_head {u : Fin n} (hT : g.IsTree)
     Dominates g v u := by
   rcases ReflTransGen.cases_tail hvw with rfl | ⟨z, hvz, hzw⟩
   · exact absurd rfl hne
-  · exact hT.rightUnique_flip_adj hzw hu ▸ hvz
+  · exact hT.leftUnique_adj hzw hu ▸ hvz
 
 /-- On a tree, positions dominating a common position are comparable:
     the dominators of any position form a chain. -/
 theorem Dominates.comparable {x : Fin n} (hT : g.IsTree)
     (hv : Dominates g v x) (hw : Dominates g w x) :
     Dominates g v w ∨ Dominates g w v :=
-  (ReflTransGen.total_of_right_unique hT.rightUnique_flip_adj
-      (reflTransGen_swap.mpr hv)
-      (reflTransGen_swap.mpr hw)).symm.imp
-    reflTransGen_swap.mp reflTransGen_swap.mp
+  ReflTransGen.total_of_left_unique hT.leftUnique_adj hv hw
 
 /-- The root dominates every position: head chains ascend, without
     repetition, to the unique headless position. -/
 theorem Graph.IsTree.root_dominates (hT : g.IsTree) (v : Fin n) :
-    Dominates g g.root v := by
-  have : Std.Irrefl (TransGen g.Adj) := ⟨hT.acyclic⟩
-  refine (Finite.wellFounded_of_trans_of_irrefl
-    (TransGen g.Adj)).induction (C := (Dominates g g.root ·)) v ?_
-  intro v ih
-  by_cases hv : v = g.root
-  · exact hv ▸ ReflTransGen.refl
-  · obtain ⟨u, hu, -⟩ := hT.existsUnique_adj v hv
-    exact (ih u (TransGen.single hu)).tail hu
+    Dominates g g.root v :=
+  ReflTransGen.of_forall_exists hT.acyclic
+    (λ w hw => (hT.existsUnique_adj w hw).exists) v
 
 /-- The root's projection is the whole sentence. -/
 theorem Graph.IsTree.projection_root (hT : g.IsTree) :
@@ -203,7 +192,7 @@ theorem Graph.IsTree.adj_headOf (hT : g.IsTree) {v : Fin n} (hv : v ≠ g.root) 
 
 theorem Graph.IsTree.headOf_eq (hT : g.IsTree) {u v : Fin n} (h : g.Adj u v) :
     g.headOf v = u :=
-  hT.rightUnique_flip_adj
+  hT.leftUnique_adj
     (hT.adj_headOf (λ he => hT.not_adj_root u (he ▸ h))) h
 
 theorem Graph.IsTree.headOf_root (hT : g.IsTree) : g.headOf g.root = g.root := by

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -56,6 +56,8 @@ source of the dominance and projection definitions
 
 namespace DependencyGrammar
 
+open Relation
+
 section Dominance
 
 variable {n : ℕ}
@@ -63,7 +65,7 @@ variable {n : ℕ}
 /-- `v` dominates `x` if a (possibly empty) chain of arcs leads from `v`
     to `x` ([kuhlmann-nivre-2006] §2). -/
 abbrev Dominates (g : Graph n) : Fin n → Fin n → Prop :=
-  Relation.ReflTransGen g.Adj
+  ReflTransGen g.Adj
 
 /-- The positions `v` dominates, `v` itself included — the *yield* of `v` in
     the source terminology. -/
@@ -94,12 +96,12 @@ def Graph.projection (g : Graph n) (v : Fin n) : List (Fin n) :=
 structure Graph.IsTree (g : Graph n) : Prop where
   not_adj_root : ∀ v, ¬ g.Adj v g.root
   existsUnique_adj : ∀ w, w ≠ g.root → ∃! v, g.Adj v w
-  acyclic : ∀ v, ¬ Relation.TransGen g.Adj v v
+  acyclic : ∀ v, ¬ TransGen g.Adj v v
 
 theorem Graph.isTree_iff (g : Graph n) :
     g.IsTree ↔ (∀ v, ¬ g.Adj v g.root) ∧
       (∀ w, w ≠ g.root → ∃! v, g.Adj v w) ∧
-      (∀ v, ¬ Relation.TransGen g.Adj v v) :=
+      (∀ v, ¬ TransGen g.Adj v v) :=
   ⟨λ h => ⟨h.1, h.2, h.3⟩, λ h => ⟨h.1, h.2.1, h.2.2⟩⟩
 
 instance (g : Graph n) : Decidable g.IsTree :=
@@ -118,14 +120,14 @@ theorem Graph.IsTree.rightUnique_flip_adj (hT : g.IsTree) :
   exact (hz u hu).trans (hz u' hu').symm
 
 /-- No arc closes a dominance cycle, on acyclic graphs. -/
-theorem not_adj_dominates (hacyc : ∀ v, ¬ Relation.TransGen g.Adj v v)
+theorem not_adj_dominates (hacyc : ∀ v, ¬ TransGen g.Adj v v)
     (hadj : g.Adj v w) (hdom : Dominates g w v) : False :=
-  hacyc v (Relation.TransGen.head' hadj hdom)
+  hacyc v (TransGen.head' hadj hdom)
 
 /-- Dominance is antisymmetric on acyclic graphs. -/
-theorem Dominates.antisymm (hacyc : ∀ v, ¬ Relation.TransGen g.Adj v v)
+theorem Dominates.antisymm (hacyc : ∀ v, ¬ TransGen g.Adj v v)
     (hvw : Dominates g v w) (hwv : Dominates g w v) : v = w := by
-  rcases Relation.ReflTransGen.cases_head hvw with rfl | ⟨u, hvu, huw⟩
+  rcases ReflTransGen.cases_head hvw with rfl | ⟨u, hvu, huw⟩
   · rfl
   · exact absurd (huw.trans hwv) (λ h => not_adj_dominates hacyc hvu h)
 
@@ -133,7 +135,7 @@ theorem Dominates.antisymm (hacyc : ∀ v, ¬ Relation.TransGen g.Adj v v)
 theorem Dominates.to_head {u : Fin n} (hT : g.IsTree)
     (hvw : Dominates g v w) (hne : v ≠ w) (hu : g.Adj u w) :
     Dominates g v u := by
-  rcases Relation.ReflTransGen.cases_tail hvw with rfl | ⟨z, hvz, hzw⟩
+  rcases ReflTransGen.cases_tail hvw with rfl | ⟨z, hvz, hzw⟩
   · exact absurd rfl hne
   · exact hT.rightUnique_flip_adj hzw hu ▸ hvz
 
@@ -142,23 +144,23 @@ theorem Dominates.to_head {u : Fin n} (hT : g.IsTree)
 theorem Dominates.comparable {x : Fin n} (hT : g.IsTree)
     (hv : Dominates g v x) (hw : Dominates g w x) :
     Dominates g v w ∨ Dominates g w v :=
-  (Relation.ReflTransGen.total_of_right_unique hT.rightUnique_flip_adj
-      (Relation.reflTransGen_swap.mpr hv)
-      (Relation.reflTransGen_swap.mpr hw)).symm.imp
-    Relation.reflTransGen_swap.mp Relation.reflTransGen_swap.mp
+  (ReflTransGen.total_of_right_unique hT.rightUnique_flip_adj
+      (reflTransGen_swap.mpr hv)
+      (reflTransGen_swap.mpr hw)).symm.imp
+    reflTransGen_swap.mp reflTransGen_swap.mp
 
 /-- The root dominates every position: head chains ascend, without
     repetition, to the unique headless position. -/
 theorem Graph.IsTree.root_dominates (hT : g.IsTree) (v : Fin n) :
     Dominates g g.root v := by
-  have : Std.Irrefl (Relation.TransGen g.Adj) := ⟨hT.acyclic⟩
+  have : Std.Irrefl (TransGen g.Adj) := ⟨hT.acyclic⟩
   refine (Finite.wellFounded_of_trans_of_irrefl
-    (Relation.TransGen g.Adj)).induction (C := (Dominates g g.root ·)) v ?_
+    (TransGen g.Adj)).induction (C := (Dominates g g.root ·)) v ?_
   intro v ih
   by_cases hv : v = g.root
-  · exact hv ▸ Relation.ReflTransGen.refl
+  · exact hv ▸ ReflTransGen.refl
   · obtain ⟨u, hu, -⟩ := hT.existsUnique_adj v hv
-    exact (ih u (Relation.TransGen.single hu)).tail hu
+    exact (ih u (TransGen.single hu)).tail hu
 
 /-- The root's projection is the whole sentence. -/
 theorem Graph.IsTree.projection_root (hT : g.IsTree) :
@@ -167,47 +169,10 @@ theorem Graph.IsTree.projection_root (hT : g.IsTree) :
 
 /-! ### Paths across a boundary -/
 
-/-- Disjoint subtrees of a tree share no dominated position. -/
+/-- Incomparable positions of a tree dominate disjoint sets. -/
 theorem disjoint_dominated (hT : g.IsTree) (hvw : ¬ Dominates g v w)
-    (hwv : ¬ Dominates g w v) {x : Fin n} (hv : Dominates g v x)
-    (hw : Dominates g w x) : False :=
-  (Dominates.comparable hT hv hw).elim hvw hwv
-
-/-- A dominance path leaving `S` crosses the boundary at an arc, both of whose
-    endpoints the source still dominates. -/
-theorem exists_adj_out {S : Set (Fin n)} {x : Fin n} (h : Dominates g v x)
-    (hv : v ∈ S) (hx : x ∉ S) :
-    ∃ p q, g.Adj p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
-  induction h with
-  | refl => exact absurd hv hx
-  | @tail b c hvb hbc ih =>
-    by_cases hb : b ∈ S
-    · exact ⟨b, c, hbc, hvb, hvb.tail hbc, hb, hx⟩
-    · exact ih hb
-
-/-- Dually for a path entering `S`. -/
-theorem exists_adj_in {S : Set (Fin n)} {x : Fin n} (h : Dominates g v x)
-    (hv : v ∉ S) (hx : x ∈ S) :
-    ∃ p q, g.Adj p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∉ S ∧ q ∈ S := by
-  induction h with
-  | refl => exact absurd hx hv
-  | @tail b c hvb hbc ih =>
-    by_cases hb : b ∈ S
-    · exact ih hb
-    · exact ⟨b, c, hbc, hvb, hvb.tail hbc, hb, hx⟩
-
-/-- A path from `v` into `S` enters at an arc whose inner endpoint still
-    reaches the target. -/
-theorem exists_adj_in_dominating {S : Set (Fin n)} {x : Fin n}
-    (h : Dominates g v x) (hv : v ∉ S) (hx : x ∈ S) :
-    ∃ p q, g.Adj p q ∧ p ∉ S ∧ q ∈ S ∧ Dominates g q x := by
-  induction h with
-  | refl => exact absurd hx hv
-  | @tail b c _ hbc ih =>
-    by_cases hb : b ∈ S
-    · obtain ⟨p, q, h1, h2, h3, h4⟩ := ih hb
-      exact ⟨p, q, h1, h2, h3, h4.tail hbc⟩
-    · exact ⟨b, c, hbc, hb, hx, .refl⟩
+    (hwv : ¬ Dominates g w v) : Disjoint (g.dominated v) (g.dominated w) :=
+  Set.disjoint_left.mpr λ _ hv hw => (Dominates.comparable hT hv hw).elim hvw hwv
 
 /-- If `v` dominates a position inside `S` and one outside it, some link below
     `v` crosses the boundary of `S`. -/
@@ -215,10 +180,11 @@ theorem exists_link_across {S : Set (Fin n)} {x y : Fin n}
     (hx : Dominates g v x) (hy : Dominates g v y) (hxS : x ∈ S) (hyS : y ∉ S) :
     ∃ p q, g.Linked p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
   by_cases hv : v ∈ S
-  · obtain ⟨p, q, hpq, hp, hq, h1, h2⟩ := exists_adj_out hy hv hyS
-    exact ⟨p, q, Or.inl hpq, hp, hq, h1, h2⟩
-  · obtain ⟨p, q, hpq, hp, hq, h1, h2⟩ := exists_adj_in hx hv hxS
-    exact ⟨q, p, Or.inr hpq, hq, hp, h2, h1⟩
+  · obtain ⟨p, q, hpq, hpS, hqS, hvp, -⟩ := hy.exists_boundary hv hyS
+    exact ⟨p, q, Or.inl hpq, hvp, hvp.tail hpq, hpS, hqS⟩
+  · obtain ⟨p, q, hpq, hpS, hqS, hvp, -⟩ :=
+      hx.exists_boundary (S := Sᶜ) hv (not_not_intro hxS)
+    exact ⟨q, p, Or.inr hpq, hvp.tail hpq, hvp, not_not.mp hqS, hpS⟩
 
 /-! ### The head function -/
 
@@ -278,7 +244,7 @@ instance [Fact g.IsTree] : PredOrder (DominanceOrder g) where
     by_cases hv : v = g.root
     · subst hv
       exact le_of_eq ((Fact.out : g.IsTree).headOf_root)
-    · exact Relation.ReflTransGen.single ((Fact.out : g.IsTree).adj_headOf hv)
+    · exact ReflTransGen.single ((Fact.out : g.IsTree).adj_headOf hv)
   min_of_le_pred {v} h := by
     by_cases hv : v = g.root
     · subst hv
@@ -300,7 +266,7 @@ instance [Fact g.IsTree] :
 
 instance [Fact g.IsTree] : IsPredArchimedean (DominanceOrder g) where
   exists_pred_iterate_of_le {a b} h := by
-    have h' : Relation.ReflTransGen g.Adj a b := h
+    have h' : ReflTransGen g.Adj a b := h
     clear h
     induction h' with
     | refl => exact ⟨0, rfl⟩

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Core.Relation.ReflTransGen
+import Linglib.Core.Data.Fintype.ExistsUnique
 import Mathlib.Logic.Relation
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Finset.Max
@@ -64,10 +65,6 @@ variable {n : ℕ}
 abbrev Dominates (g : Graph n) : Fin n → Fin n → Prop :=
   Relation.ReflTransGen g.Adj
 
-instance (g : Graph n) : DecidableRel (Dominates g) :=
-  Relation.ReflTransGen.decidable_of_finite (List.finRange n)
-    (λ _ b _ => List.mem_finRange b)
-
 /-- The positions `v` dominates, `v` itself included — the *yield* of `v` in
     the source terminology. -/
 def Graph.dominated (g : Graph n) (v : Fin n) : Set (Fin n) :=
@@ -104,13 +101,6 @@ theorem Graph.isTree_iff (g : Graph n) :
       (∀ w, w ≠ g.root → ∃! v, g.Adj v w) ∧
       (∀ v, ¬ Relation.TransGen g.Adj v v) :=
   ⟨λ h => ⟨h.1, h.2, h.3⟩, λ h => ⟨h.1, h.2.1, h.2.2⟩⟩
-
-instance (g : Graph n) (v w : Fin n) : Decidable (Relation.TransGen g.Adj v w) :=
-  decidable_of_iff (∃ u, g.Adj v u ∧ Dominates g u w)
-    Relation.TransGen.head'_iff.symm
-
-instance (g : Graph n) (w : Fin n) : Decidable (∃! v, g.Adj v w) :=
-  decidable_of_iff (∃ v, g.Adj v w ∧ ∀ u, g.Adj u w → u = v) Iff.rfl
 
 instance (g : Graph n) : Decidable g.IsTree :=
   decidable_of_iff _ (g.isTree_iff).symm

--- a/Linglib/Syntax/DependencyGrammar/Dominance.lean
+++ b/Linglib/Syntax/DependencyGrammar/Dominance.lean
@@ -7,6 +7,7 @@ import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Core.Relation.ReflTransGen
 import Mathlib.Logic.Relation
 import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Finset.Max
 import Mathlib.Order.SuccPred.Basic
 import Mathlib.Order.SuccPred.Archimedean
 import Mathlib.Order.SuccPred.Tree
@@ -157,7 +158,7 @@ theorem Dominates.comparable {x : Fin n} (hT : g.IsTree)
     repetition, to the unique headless position. -/
 theorem Graph.IsTree.root_dominates (hT : g.IsTree) (v : Fin n) :
     Dominates g g.root v := by
-  haveI : Std.Irrefl (Relation.TransGen g.Adj) := ⟨hT.acyclic⟩
+  have : Std.Irrefl (Relation.TransGen g.Adj) := ⟨hT.acyclic⟩
   refine (Finite.wellFounded_of_trans_of_irrefl
     (Relation.TransGen g.Adj)).induction (C := (Dominates g g.root ·)) v ?_
   intro v ih
@@ -219,7 +220,7 @@ theorem exists_adj_in_dominating {S : Set (Fin n)} {x : Fin n}
     `v` crosses the boundary of `S`. -/
 theorem exists_link_across {S : Set (Fin n)} {x y : Fin n}
     (hx : Dominates g v x) (hy : Dominates g v y) (hxS : x ∈ S) (hyS : y ∉ S) :
-    ∃ p q, Linked g p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
+    ∃ p q, g.Linked p q ∧ Dominates g v p ∧ Dominates g v q ∧ p ∈ S ∧ q ∉ S := by
   by_cases hv : v ∈ S
   · obtain ⟨p, q, hpq, hp, hq, h1, h2⟩ := exists_adj_out hy hv hyS
     exact ⟨p, q, Or.inl hpq, hp, hq, h1, h2⟩
@@ -228,22 +229,18 @@ theorem exists_link_across {S : Set (Fin n)} {x y : Fin n}
 
 /-! ### The head function -/
 
-/-- The first listed head of `v`, defaulting to `v` when headless —
-    under `IsTree`, the unique head of a non-root position and the root
-    at the root. -/
+/-- The least head of `v`, defaulting to `v` when headless — under
+    `IsTree`, the unique head of a non-root position and the root at the
+    root. -/
 def Graph.headOf (g : Graph n) (v : Fin n) : Fin n :=
-  (g.parents v).head?.getD v
+  (g.parents v).min.untopD v
 
 theorem Graph.IsTree.adj_headOf (hT : g.IsTree) {v : Fin n} (hv : v ≠ g.root) :
     g.Adj (g.headOf v) v := by
-  obtain ⟨u, hu, -⟩ := hT.existsUnique_adj v hv
-  have hmem : u ∈ g.parents v := Graph.mem_parents.mpr hu
-  unfold Graph.headOf
-  cases hp : g.parents v with
-  | nil => exact absurd (hp ▸ hmem) List.not_mem_nil
-  | cons h t =>
-    simp only [List.head?_cons, Option.getD_some]
-    exact Graph.mem_parents.mp (hp ▸ List.mem_cons_self)
+  obtain ⟨u, hu, huniq⟩ := hT.existsUnique_adj v hv
+  have hp : g.parents v = {u} := Finset.eq_singleton_iff_unique_mem.mpr
+    ⟨Graph.mem_parents.mpr hu, λ w hw => huniq w (Graph.mem_parents.mp hw)⟩
+  simpa [Graph.headOf, hp] using hu
 
 theorem Graph.IsTree.headOf_eq (hT : g.IsTree) {u v : Fin n} (h : g.Adj u v) :
     g.headOf v = u :=
@@ -251,12 +248,9 @@ theorem Graph.IsTree.headOf_eq (hT : g.IsTree) {u v : Fin n} (h : g.Adj u v) :
     (hT.adj_headOf (λ he => hT.not_adj_root u (he ▸ h))) h
 
 theorem Graph.IsTree.headOf_root (hT : g.IsTree) : g.headOf g.root = g.root := by
-  unfold Graph.headOf
-  cases hp : g.parents g.root with
-  | nil => rfl
-  | cons h t =>
-    exact absurd (Graph.mem_parents.mp (hp ▸ List.mem_cons_self))
-      (hT.not_adj_root h)
+  have hp : g.parents g.root = ∅ := Finset.eq_empty_of_forall_notMem
+    (λ u hu => hT.not_adj_root u (Graph.mem_parents.mp hu))
+  simp [Graph.headOf, hp]
 
 /-! ### The dominance order -/
 
@@ -265,7 +259,7 @@ theorem Graph.IsTree.headOf_root (hT : g.IsTree) : g.headOf g.root = g.root := b
     with the root as bottom, the head as predecessor, and finite
     descent — the order-theoretic reading of a rooted dependency tree
     (cf. mathlib's `RootedTree`). -/
-def DominanceOrder (g : Graph n) := Fin n
+def DominanceOrder (_g : Graph n) := Fin n
 
 namespace DominanceOrder
 

--- a/Linglib/Syntax/DependencyGrammar/Length.lean
+++ b/Linglib/Syntax/DependencyGrammar/Length.lean
@@ -30,7 +30,7 @@ variable {n : ℕ}
 /-- Total dependency length: the sum of `Nat.dist` over all arcs — the
     quantity dependency-length minimisation is about. -/
 def Graph.totalLength (g : Graph n) : Nat :=
-  ∑ v : Fin n, ∑ w ∈ Finset.univ.filter (g.Adj v ·), Nat.dist v w
+  ∑ v : Fin n, ∑ w ∈ g.children v, Nat.dist v w
 
 /-- Total dependency length reads only the arc structure, never the
     tokens. -/
@@ -68,7 +68,7 @@ theorem Graph.totalLength_relabel (g : Graph n) (σ : Equiv.Perm (Fin n))
     (hσ : ∀ v w : Fin n, Nat.dist (σ v) (σ w) = Nat.dist v w) :
     (g.relabel σ).totalLength = g.totalLength := by
   unfold totalLength
-  simp only [Finset.sum_filter]
+  simp only [Graph.children, Finset.sum_filter]
   refine Fintype.sum_equiv σ.symm _ _ (λ v => ?_)
   refine Fintype.sum_equiv σ.symm _ _ (λ w => ?_)
   simp only [relabel_adj]

--- a/Linglib/Syntax/DependencyGrammar/Length.lean
+++ b/Linglib/Syntax/DependencyGrammar/Length.lean
@@ -10,17 +10,31 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 /-!
 # Dependency length
 
-The core quantity behind [futrell-gibson-2020]'s claim that natural
-languages minimise total dependency length beyond what independent
-constraints predict, together with [behaghel-1932]'s "Oberstes Gesetz"
-threshold. Arc length is `Nat.dist` on positions; the total is a
-`Finset` sum, so relabeling arguments are mathlib sum-reindexings.
+This file defines the total dependency length of a graph and its
+relabeling along a position permutation. Dependency-length minimisation
+claims natural languages reduce the former beyond what independent
+constraints predict; relabeling is the formal core of the
+random-reordering baselines that test the claim.
 
-`Graph.relabel` transports a graph along a position permutation — the
-formal core of [futrell-gibson-2020]'s random-reordering baselines — and
-`Graph.mirror` is relabeling along `Fin.rev`, with `totalLength_mirror`
-recording that the head-final mirror of a graph has the same total
-dependency length.
+## Main definitions
+
+* `Graph.totalLength` is the sum of `Nat.dist` over all arcs.
+* `OberstesGesetz` bounds every arc length by a threshold.
+* `Graph.relabel` transports a graph along a position permutation;
+  `Graph.mirror` is relabeling along `Fin.rev`.
+
+## Main results
+
+* `Graph.totalLength_relabel`: relabeling along an isometry of the
+  positions preserves total dependency length.
+
+## References
+
+[behaghel-1932] — Deutsche Syntax IV, source of the "Oberstes Gesetz"
+threshold
+[futrell-gibson-2020] — Dependency locality as an explanatory principle
+for word order, source of the minimisation claim and the
+random-reordering baselines
 -/
 
 namespace DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -68,7 +68,7 @@ abbrev Alternate (a b c d : Fin n) : Prop := a < c ∧ c < b ∧ b < d
 /-- A dependency graph is planar if no two links alternate, so that its arcs
     can be drawn above the sentence without crossing. -/
 def Graph.IsPlanar : Prop :=
-  ∀ ⦃a b c d : Fin n⦄, Linked g a b → Linked g c d → ¬ Alternate a b c d
+  ∀ ⦃a b c d : Fin n⦄, g.Linked a b → g.Linked c d → ¬ Alternate a b c d
 
 /-- The subtrees at `v` and `w` interleave if each contributes two positions
     and the two pairs alternate. -/
@@ -115,7 +115,7 @@ def Graph.gapDegree : Nat := Finset.univ.sup g.gapDegreeAt
     since of the two ways to order the pairs only one alternates. -/
 def Graph.crossings : Nat :=
   (Finset.univ.filter (λ x : Fin n × Fin n × Fin n × Fin n =>
-    Linked g x.1 x.2.1 ∧ Linked g x.2.2.1 x.2.2.2 ∧
+    g.Linked x.1 x.2.1 ∧ g.Linked x.2.2.1 x.2.2.2 ∧
       Alternate x.1 x.2.1 x.2.2.1 x.2.2.2)).card
 
 variable {g}
@@ -245,7 +245,7 @@ theorem Graph.IsProjective.isPlanar (hT : g.IsTree) (hP : g.IsProjective) :
 /-- In a planar graph, a link with one endpoint strictly inside the span of
     another link has its other endpoint inside that span too. -/
 theorem Graph.IsPlanar.mem_uIcc_of_linked (hPl : g.IsPlanar) {lo hi p q : Fin n}
-    (hL : Linked g lo hi) (hL' : Linked g p q)
+    (hL : g.Linked lo hi) (hL' : g.Linked p q)
     (hlp : lo < p) (hph : p < hi) : q ∈ Set.uIcc lo hi := by
   by_contra hq
   simp only [Set.mem_uIcc] at hq
@@ -257,7 +257,7 @@ theorem Graph.IsPlanar.mem_uIcc_of_linked (hPl : g.IsPlanar) {lo hi p q : Fin n}
 /-- Planarity forbids a link with one endpoint strictly inside another link's
     span and the other endpoint outside it. -/
 theorem Graph.IsPlanar.no_strict_straddle (hPl : g.IsPlanar) {p q p' q' : Fin n}
-    (hL : Linked g p q) (hL' : Linked g p' q') (hin : p' ∈ Set.uIcc p q)
+    (hL : g.Linked p q) (hL' : g.Linked p' q') (hin : p' ∈ Set.uIcc p q)
     (hne1 : p' ≠ p) (hne2 : p' ≠ q) (hout : q' ∉ Set.uIcc p q) : False := by
   simp only [Set.mem_uIcc] at hin
   rcases lt_trichotomy p q with h | rfl | h

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -276,7 +276,7 @@ theorem Graph.IsPlanar.isWellNested (hT : g.IsTree) (hPl : g.IsPlanar) :
   push Not at hcon
   obtain ⟨hvw, hwv⟩ := hcon
   have hdis : ∀ {x}, Dominates g v x → Dominates g w x → False :=
-    λ h1 h2 => disjoint_dominated hT hvw hwv h1 h2
+    λ h1 h2 => Set.disjoint_left.mp (disjoint_dominated hT hvw hwv) h1 h2
   have hab : a < b := hac.trans hcb
   -- A link below `w` crosses the boundary of the span of `a` and `b`.
   have hcS : c ∈ Set.uIcc a b := by simp [Set.mem_uIcc]; omega
@@ -322,8 +322,11 @@ theorem Graph.IsPlanar.root_mem_gap (hT : g.IsTree) (hPl : g.IsPlanar)
   have hrS : g.root ∉ Set.uIcc i j := by simp [Set.mem_uIcc]; omega
   -- The root's path to `k` enters the span of `i` and `j` at an arc that
   -- misses everything `v` dominates.
-  obtain ⟨p, q, hpq, hpS, hqS, hqk⟩ :=
-    exists_adj_in_dominating (hT.root_dominates k) hrS hkS
+  obtain ⟨p, q, hpq, hpS', hqS', -, hqk⟩ :=
+    (hT.root_dominates k).exists_boundary (S := (Set.uIcc i j)ᶜ) hrS
+      (not_not_intro hkS)
+  have hpS : p ∉ Set.uIcc i j := hpS'
+  have hqS : q ∈ Set.uIcc i j := not_not.mp hqS'
   have hqv : ¬ Dominates g v q := λ h => hk (h.trans hqk)
   have hpv : ¬ Dominates g v p := λ h =>
     hk (h.trans ((Relation.ReflTransGen.single hpq).trans hqk))

--- a/Linglib/Syntax/DependencyGrammar/Projectivity.lean
+++ b/Linglib/Syntax/DependencyGrammar/Projectivity.lean
@@ -21,34 +21,35 @@ In this file we define those constraints and prove the inclusions among them
 that hold on trees. The witnesses separating the constraints are the source
 papers' own figures, and live in their study files.
 
-## Main declarations
+## Main definitions
 
-* `Alternate` — the alternation `a < c < b < d` that both binary constraints
-  forbid.
-* `Graph.IsProjective` — every `Graph.dominated` set is an interval
-  (Definition 3).
-* `Graph.IsPlanar` — no two links cross (Definition 4), the Link Grammar
-  notion, traced there to [melcuk-1988].
-* `Graph.Interleave`, `Graph.IsWellNested` — Definition 8.
-* `Graph.gapDegree` — Definitions 6–7. Gap degree + 1 is the block-degree,
-  the fan-out of the LCFRS rule extracted for that node.
-* `Graph.isProjective_iff_gapDegree_eq_zero`,
-  `Graph.isPlanar_iff_crossings_eq_zero` — each binary constraint is the
-  least value of a count (`Graph.gapDegree`, `Graph.crossings`).
-* `Graph.IsProjective.isPlanar`, `Graph.IsPlanar.isWellNested` — the §3.5
-  chain `projective ⊆ planar ⊆ well-nested` on trees, with
-  `Graph.IsProjective.isWellNested` its composite.
-* `Graph.IsPlanar.root_mem_gap` — every gap of a planar tree contains the
-  root, so a planar tree rooted at a sentence boundary is already projective
-  (`Graph.IsPlanar.isProjective_of_isBot`). This is why planarity is a weaker
-  constraint than projectivity only by the root's position.
+* `Graph.IsProjective` is projectivity: every `Graph.dominated` set is an
+  interval (Definition 3).
+* `Graph.IsPlanar` is planarity: no two links cross (Definition 4), the
+  Link Grammar notion.
+* `Graph.Interleave` and `Graph.IsWellNested` are interleaving and
+  well-nestedness (Definition 8).
+* `Graph.gapDegree` counts the discontinuities in a node's projection
+  (Definitions 6–7).
+
+## Main results
+
+* `Graph.isProjective_iff_gapDegree_eq_zero` and
+  `Graph.isPlanar_iff_crossings_eq_zero`: each binary constraint is the
+  least value of a count.
+* `Graph.IsProjective.isPlanar` and `Graph.IsPlanar.isWellNested`: the
+  chain `projective ⊆ planar ⊆ well-nested` on trees.
+* `Graph.IsPlanar.isProjective_of_isBot`: every gap of a planar tree
+  contains the root (`Graph.IsPlanar.root_mem_gap`), so a planar tree
+  rooted at a sentence boundary is already projective.
 
 ## References
 
 [kuhlmann-nivre-2006] — Mildly non-projective dependency structures, source
 of the Definition numbers cited above
 [kuhlmann-2013] — Mildly non-projective dependency grammar
-[melcuk-1988] — Dependency syntax: theory and practice
+[melcuk-1988] — Dependency syntax: theory and practice, source of the Link
+Grammar planarity notion
 -/
 
 namespace DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Valency.lean
+++ b/Linglib/Syntax/DependencyGrammar/Valency.lean
@@ -7,28 +7,35 @@ import Linglib.Syntax.DependencyGrammar.Basic
 import Linglib.Syntax.Category.Verb.Complement.Basic
 
 /-!
-# Valency: argument-structure frames over dependency graphs
+# Valency frames
 
-The DG valency layer: slot data types, standard frame schemas for the basic
-valences, the map from a verb's lexical `ComplementType` into them, and
-satisfaction of a frame by a position's dependents. [hudson-2010],
-[osborne-2019].
+This file defines valency frames over dependency graphs: slot data,
+standard frame schemas for the basic valences, the map from a verb's
+lexical `ComplementType` into them, and satisfaction of a frame by a
+position's dependents.
 
-Frames are a *side table* (`Frames n`), not part of the graph carrier: the
+## Main definitions
+
+* `Valency` is a word's valency as a list of slots: relation, side of
+  the head, optionality.
+* `Frames n` is the per-position valency table.
+* `Graph.SatisfiesFrames` is frame satisfaction: every filler on its
+  slot's side of the head, required slots filled, and no unlicensed core
+  arguments.
+
+## Implementation notes
+
+Frames are a side table (`Frames n`), not part of the graph carrier: the
 frame is framework apparatus (like HPSG's ARG-ST), supplied alongside the
 graph by the consumers that reason about valency and populated from the
 lexical carrier (a verb's `complementType.valency`).
 
-## Main declarations
+## References
 
-* `Valency`, `Valency.Slot` — a word's valency ([tesniere-1959]'s term) as a
-  list of slots: relation, side of the head, optionality.
-* `Frames n`, `Frames.ofList` — the per-position valency table.
-* `Valency.intransitive/transitive/ditransitive/passiveTransitive`,
-  `ComplementType.valency` — standard schemas and the lexical map into them.
-* `SatisfiesValency`, `Graph.SatisfiesFrames` — valency satisfaction: every
-  filler on its slot's side of the head, required slots filled, no
-  unlicensed core arguments.
+[tesniere-1959] — Éléments de syntaxe structurale, source of the valency
+notion
+[hudson-2010] — An introduction to Word Grammar
+[osborne-2019] — A dependency grammar of English
 -/
 
 namespace DependencyGrammar

--- a/Linglib/Syntax/DependencyGrammar/Valency.lean
+++ b/Linglib/Syntax/DependencyGrammar/Valency.lean
@@ -105,14 +105,14 @@ section Satisfaction
 variable {n : ℕ}
 
 /-- The dependents of `v` linked by relation `rel`. -/
-def Graph.fillersOf (g : Graph n) (v : Fin n) (rel : UD.DepRel) : List (Fin n) :=
-  (g.children v).filter (g.label v · == some rel)
+def Graph.fillersOf (g : Graph n) (v : Fin n) (rel : UD.DepRel) : Finset (Fin n) :=
+  {w ∈ g.children v | g.label v w = some rel}
 
 /-- The graph satisfies a valency at head `v`: every filler of every slot
     sits on the slot's side of the head, and required slots are filled. -/
 def SatisfiesValency (g : Graph n) (v : Fin n) (val : Valency) : Prop :=
   ∀ slot ∈ val, (∀ w ∈ g.fillersOf v slot.depType, slot.dir.Admits v w) ∧
-    (slot.required → g.fillersOf v slot.depType ≠ [])
+    (slot.required → (g.fillersOf v slot.depType).Nonempty)
 
 instance (g : Graph n) (v : Fin n) (val : Valency) :
     Decidable (SatisfiesValency g v val) :=
@@ -133,7 +133,7 @@ private def CoreArgsLicensed (g : Graph n) (v : Fin n) (val : Valency) : Prop :=
 
 private instance (g : Graph n) (v : Fin n) (val : Valency) :
     Decidable (CoreArgsLicensed g v val) :=
-  List.decidableBAll _ _
+  Finset.decidableDforallFinset
 
 /-- Each verb's dependents satisfy its frame: required slots filled in the
     right direction (`SatisfiesValency`) and no unlicensed core arguments


### PR DESCRIPTION
Elegance pass on the dependency-graph carrier, per a mathlib-lens audit of Basic.lean.

- `Linked` moves into the `Graph` namespace (dot notation; one namespace span); `parents`/`children` become Finsets — every consumer was membership-shaped, and Length.lean had re-derived Finset children inline; `headOf` is now the least head via `Finset.min`.
- New characterization lemmas: `adj_iff_exists`, `arcsLabel_isSome_iff`, and simp lemmas `ofArcs_adj`, `enhance_adj` (replacing the one-directional `Adj.enhance`); `toSimpleGraph_adj_of_ne` pins the diagonal seam between the two undirected views; `@[ext]` on the structure.
- Deleted unconsumed API: the `Coe` to `Digraph`, `inDegree`, `toDigraph_mono`, `toDigraph_le_enhance`; fixed stale module-doc pointers and the two standing Dominance linter warnings.