### PR TITLE
refactor(Syntax/ConstructionGrammar): type the meaning pole

### DIFF
--- a/Linglib/Fragments/English/Binominals.lean
+++ b/Linglib/Fragments/English/Binominals.lean
@@ -183,84 +183,92 @@ def allN₁Entries : List BinominalN₁Entry :=
 
 open ConstructionGrammar
 
-/-- The six *of*-binominal constructions as CxG `Construction` entries
-    ([ten-wolde-2023]). -/
-def nPPConstruction : Construction where
+/-- The N+PP construction ([ten-wolde-2023]): N₁ denotes a referent; the
+PP ascribes a property onto the head. The first of the six
+*of*-binominal constructions. -/
+def nPPConstruction : Construction Unit where
   name := "N+PP"
   form :=
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "head", isHead := true }
+    , { filler := .open_ .NOUN, isHead := true }
     , { filler := .fixed "of" }
     , { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "property" } ]
-  meaning := "N₁ denotes a referent, PP ascribes a property onto the head"
+    , { filler := .open_ .NOUN } ]
+  meaning := ()
 
-def headClassifierConstruction : Construction where
+/-- The head-classifier construction: the construction denotes a referent; the PP classifies the head. -/
+def headClassifierConstruction : Construction Unit where
   name := "Head-Classifier"
   form :=
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "head", isHead := true }
+    , { filler := .open_ .NOUN, isHead := true }
     , { filler := .fixed "of" }
-    , { filler := .open_ .NOUN, role := some "classifier" } ]
-  meaning := "Construction denotes a referent, PP classifies head"
+    , { filler := .open_ .NOUN } ]
+  meaning := ()
 
-def pseudoPartitiveConstruction : Construction where
+/-- The pseudo-partitive: N₁ quantizes; N₂ denotes the measured substance. -/
+def pseudoPartitiveConstruction : Construction Unit where
   name := "Pseudo-partitive"
   form :=
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "quantizer", isHead := true }
+    , { filler := .open_ .NOUN, isHead := true }
     , { filler := .fixed "of" }
-    , { filler := .open_ .NOUN, role := some "substance" } ]
-  meaning := "N₁ quantizes, N₂ denotes measured substance"
+    , { filler := .open_ .NOUN } ]
+  meaning := ()
 
-def ebnpConstruction : Construction where
+/-- The evaluative binominal NP: N₁ ascribes an evaluative property to the N₂ referent. -/
+def ebnpConstruction : Construction Unit where
   name := "Evaluative BNP"
   form :=
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "evaluation" }
+    , { filler := .open_ .NOUN }
     , { filler := .fixed "of" }
     , { filler := .fixed "a" }
-    , { filler := .open_ .NOUN, role := some "referent", isHead := true } ]
-  meaning := "N₁ ascribes evaluative property to N₂ referent"
+    , { filler := .open_ .NOUN, isHead := true } ]
+  meaning := ()
 
-def emConstruction : Construction where
+/-- The evaluative modifier construction: [N₁ of a] is a complex modifier, a speaker evaluation of N₂. -/
+def emConstruction : Construction Unit where
   name := "Evaluative Modifier"
   form :=  -- optional "a" elided
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "evaluation" }
+    , { filler := .open_ .NOUN }
     , { filler := .fixed "of" }
-    , { filler := .open_ .NOUN, role := some "head", isHead := true } ]
-  meaning := "[N₁ of a] is complex modifier, speaker evaluation of N₂"
+    , { filler := .open_ .NOUN, isHead := true } ]
+  meaning := ()
 
-def biConstruction : Construction where
+/-- The binominal intensifier: [N₁ of a] intensifies the following adjective or quantifier. -/
+def biConstruction : Construction Unit where
   name := "Binominal Intensifier"
   form :=  -- optional "a" elided
-    [ { filler := .open_ .NOUN, role := some "intensifier" }
+    [ { filler := .open_ .NOUN }
     , { filler := .fixed "of" }
-    , { filler := .open_ .ADJ, role := some "intensified" }
-    , { filler := .open_ .NOUN, role := some "head", isHead := true } ]
-  meaning := "[N₁ of a] intensifies following adjective or quantifier"
+    , { filler := .open_ .ADJ }
+    , { filler := .open_ .NOUN, isHead := true } ]
+  meaning := ()
 
 /-- The simple NP construction ([ten-wolde-2023] §8.4).
 
 The simple NP [[Det] (Mod) [N]] plays a key role in the constructional
 network: the head-classifier shares a polysemy link with the classifier
 premodifier in the NP, and the evaluative constructions share polysemy
-links with evaluative/intensifier premodifiers in the NP. -/
-def simpleNPConstruction : Construction where
+links with evaluative/intensifier premodifiers in the NP. It denotes a
+referent; the premodifier ascribes a property onto the head. -/
+def simpleNPConstruction : Construction Unit where
   name := "Simple NP"
   form :=  -- optional premodifier elided
     [ { filler := .open_ .DET }
-    , { filler := .open_ .NOUN, role := some "head", isHead := true } ]
-  meaning := "denotes a referent, premodifier ascribes property to head"
+    , { filler := .open_ .NOUN, isHead := true } ]
+  meaning := ()
 
-/-- The adjective phrase construction, linked to BI ([ten-wolde-2023] Fig 8.13). -/
-def adjPhraseConstruction : Construction where
+/-- The adjective phrase construction, linked to BI ([ten-wolde-2023]
+Fig 8.13): the intensifier emphasizes the following adjective. -/
+def adjPhraseConstruction : Construction Unit where
   name := "AP"
   form :=
-    [ { filler := .open_ .ADV, role := some "intensifier" }
-    , { filler := .open_ .ADJ, role := some "head", isHead := true } ]
-  meaning := "intensifier emphasizes the following adjective"
+    [ { filler := .open_ .ADV }
+    , { filler := .open_ .ADJ, isHead := true } ]
+  meaning := ()
 
 /-- The *of*-binominal constructional network ([ten-wolde-2023]).
 
@@ -269,7 +277,7 @@ micro-construction level (Figs 8.7, 8.9, 8.11, 8.13): each step involves
 a conceptual metaphor that extends the source construction's meaning
 to a new domain. Each construction also has a taxonomic link to the
 schematic N+PP mother node at a higher level (not modeled here). -/
-def ofBinominalNetwork : Constructicon where
+def ofBinominalNetwork : Constructicon Unit where
   constructions :=
     [ nPPConstruction, headClassifierConstruction, pseudoPartitiveConstruction
     , ebnpConstruction, emConstruction, biConstruction

--- a/Linglib/Studies/FillmoreKayOConnor1988.lean
+++ b/Linglib/Studies/FillmoreKayOConnor1988.lean
@@ -154,15 +154,15 @@ p. 512), where F is a negative polarity operator, X and Y are shared
 non-focused material, and the paired foci A and B are points in a
 presupposed scalar model. The typed form is the paired-foci core,
 eliding the shared X/Y material. -/
-def letAloneConstruction : Construction :=
+def letAloneConstruction : Construction Unit :=
   { name := "let alone"
   , form :=
-      [ { filler := .open_ .NOUN, role := some "focusA" }
+      [ { filler := .open_ .NOUN }
       , { filler := .fixed "let" }
       , { filler := .fixed "alone" }
-      , { filler := .open_ .NOUN, role := some "focusB" } ]
-  , meaning := "F'⟨X A Y⟩; a fortiori F'⟨X B Y⟩ (scalar entailment)"
-  , pragmaticFunction := "presupposes scalar model; A clause = informative (Quantity), B clause = relevant (Relevance)" }
+      , { filler := .open_ .NOUN } ]
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-- *Let alone* is not fully compositional: a formal idiom with paired
 focus, scalar entailment, and NPI licensing requirements that cannot be
@@ -260,13 +260,13 @@ def npiTriggerToContext : LetAloneNPITrigger → LicensingContext
 /-- The garden-variety coordination construction *let alone* is measured
 against (§2.2.1): two like-category conjuncts joined by a coordinating
 conjunction. Present as the parent node of the inheritance link below. -/
-def coordinationConstruction : Construction :=
+def coordinationConstruction : Construction Unit :=
   { name := "Coordinating conjunction"
   , form :=
-      [ { filler := .phrasal, role := some "conjunct₁" }
+      [ { filler := .phrasal }
       , { filler := .open_ .CCONJ }
-      , { filler := .phrasal, role := some "conjunct₂" } ]
-  , meaning := "joins two like-category constituents" }
+      , { filler := .phrasal } ]
+  , meaning := () }
 
 /-- *Let alone* against the coordination diagnostics of §2.2.1 (p. 514–517).
 Shared with coordinating conjunctions: joins like categories, right node
@@ -290,7 +290,7 @@ def letAloneInheritance : InheritanceLink :=
       , "is a negative polarity item" ] }
 
 /-- The §2.2.1 comparison as a two-node network. -/
-def letAloneNetwork : Constructicon :=
+def letAloneNetwork : Constructicon Unit :=
   { constructions := [coordinationConstruction, letAloneConstruction]
   , links := [letAloneInheritance] }
 
@@ -304,30 +304,29 @@ theorem letAloneNetwork_wellFormed : letAloneNetwork.WellFormed := by decide
 far as we can tell, found generally elsewhere in the language" (p. 507;
 fn. 4 notes relatives like "all the more reason" and the Old English
 instrumental demonstrative source). -/
-def comparativeCorrelative : Construction :=
+def comparativeCorrelative : Construction Unit :=
   { name := "the X-er the Y-er"
   , form :=
       [ { filler := .fixed "the" }
-      , { filler := .open_ .ADJ, role := some "comparative₁" }
-      , { filler := .phrasal, role := some "clause₁", level := some .phrase }
+      , { filler := .open_ .ADJ }
+      , { filler := .phrasal, level := some .phrase }
       , { filler := .fixed "the" }
-      , { filler := .open_ .ADJ, role := some "comparative₂" }
-      , { filler := .phrasal, role := some "clause₂", level := some .phrase } ]
-  , meaning := "The degree to which X correlates with the degree to which Y"
-  , pragmaticFunction := none }
+      , { filler := .open_ .ADJ }
+      , { filler := .phrasal, level := some .phrase } ]
+  , meaning := () }
 
 /-- The Incredulity Response construction ("Him be a doctor?", ex. 14h in
 the §2 opening list, pp. 510–511; the type is introduced in §1.1.4): a
 non-nominative subject with a bare-stem predicate, "used to challenge or
 question a proposition just posed by an interlocutor" (p. 511). -/
-def incredulityResponse : Construction :=
+def incredulityResponse : Construction Unit :=
   { name := "Incredulity Response"
   , form :=
-      [ { filler := .open_ .PRON, role := some "subject", gf := some .subj }
-      , { filler := .phrasal, role := some "predicate", level := some .phrase
+      [ { filler := .open_ .PRON, gf := some .subj }
+      , { filler := .phrasal, level := some .phrase
         , gf := some .pred } ]
-  , meaning := "Speaker challenges the just-posed proposition as incredible"
-  , pragmaticFunction := "challenges or questions a proposition just posed by an interlocutor" }
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-! ### A one-dimensional rank model (ex. 21)
 

--- a/Linglib/Studies/GoldbergShirtz2025.lean
+++ b/Linglib/Studies/GoldbergShirtz2025.lean
@@ -58,83 +58,85 @@ is phrasal modifies a head N, forming an N′ (the paper's structure (7),
 `[N′ PAL⁰ N]`, vs. the NN compound's `[N⁰ N⁰ N⁰]`). The head N's bar level
 is left underspecified since PALs may modify nouns with complements
 ("a 'don't mess with me' type of driver"). -/
-def palConstruction : Construction :=
+def palConstruction : Construction Unit :=
   { name := "PAL"
   , form :=
-      [ { filler := .phrasal, role := some "situation type", level := some .zero }
-      , { filler := .open_ .NOUN, role := some "instance", isHead := true } ]
-  , meaning := "the PAL names a situation type; the head N is an instance of it"
-  , pragmaticFunction := "presumes familiarity with the situation type named by the PAL" }
+      [ { filler := .phrasal, level := some .zero }
+      , { filler := .open_ .NOUN, isHead := true } ]
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-- The semiproductive must-V subtype, frequently instantiated by
 *must-read*, *must-see*, *must-have*. Study 5 tested only rare tokens
 (≤ 10 COCA hits) against *should-V* foils. -/
-def mustVerbConstruction : Construction :=
+def mustVerbConstruction : Construction Unit :=
   { name := "must-V"
   , form :=
       [ { filler := .fixed "must" }
-      , { filler := .open_ .VERB, role := some "predicate" }
-      , { filler := .open_ .NOUN, role := some "theme", isHead := true } ]
-  , meaning := "N is something one must V"
-  , pragmaticFunction := "presumes familiarity with the situation type named by the PAL" }
+      , { filler := .open_ .VERB }
+      , { filler := .open_ .NOUN, isHead := true } ]
+  , meaning := ()
+  , pragmaticPoint := true }
 
-/-- The *a simple ⟨PAL⟩* subtype: the PAL is itself the head noun
-("Could've tried a simple 'I'm sorry.'"). Study 5's foils used *a short*. -/
-def aSimplePALConstruction : Construction :=
+/-- The *a simple ⟨PAL⟩* subtype: the PAL is itself the head noun, with
+*simple* marking the situation type as routine ("Could've tried a simple
+'I'm sorry.'"). Study 5's foils used *a short*. -/
+def aSimplePALConstruction : Construction Unit :=
   { name := "a simple [PAL⁰]"
   , form :=
       [ { filler := .fixed "a" }
       , { filler := .fixed "simple" }
-      , { filler := .phrasal, role := some "situation type", level := some .zero
+      , { filler := .phrasal, level := some .zero
         , isHead := true } ]
-  , meaning := "a routine instance of the situation type named by the PAL"
-  , pragmaticFunction := "presumes familiarity; 'simple' marks the situation type as routine" }
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-- The *Don't ⟨PAL⟩ me* subtype: the PAL fills a V slot, must quote the
 immediately preceding discourse, and occurs in an interdiction context
 ("A: you're welcome. B: No, don't 'you're welcome' me."). Study 5's foils
 broke exactly the quote-from-context or interdiction condition. -/
-def dontPALmeConstruction : Construction :=
+def dontPALmeConstruction : Construction Unit :=
   { name := "Don't [PAL⁰ x y z] me"
   , form :=
       [ { filler := .fixed "Don't" }
-      , { filler := .phrasal, role := some "quoted move", level := some .zero
+      , { filler := .phrasal, level := some .zero
         , isHead := true }
       , { filler := .fixed "me" } ]
-  , meaning := "don't direct the just-quoted utterance at me"
-  , pragmaticFunction := "interdicts the quoted conversational move; presumes the quote from the immediately preceding context" }
+  , meaning := ()
+  , pragmaticPoint := true }
 
-/-- The *the old ⟨PAL⟩ (N)* subtype, with optional head N ("my dad pulled
-the old 'I'm going to the store for smokes, be back in five'"). Study 5's
-foils used *the tired*. -/
-def theOldPALConstruction : Construction :=
+/-- The *the old ⟨PAL⟩ (N)* subtype, with optional head N and *old*
+marking the situation type as conventional ("my dad pulled the old 'I'm
+going to the store for smokes, be back in five'"). Study 5's foils used
+*the tired*. -/
+def theOldPALConstruction : Construction Unit :=
   { name := "the old [PAL⁰] (N)"
   , form :=
       [ { filler := .fixed "the" }
       , { filler := .fixed "old" }
-      , { filler := .phrasal, role := some "situation type", level := some .zero
+      , { filler := .phrasal, level := some .zero
         , isHead := true }
-      , { filler := .open_ .NOUN, role := some "instance" } ]
-  , meaning := "a well-worn instance of the situation type named by the PAL"
-  , pragmaticFunction := "presumes familiarity; 'old' marks the situation type as conventional" }
+      , { filler := .open_ .NOUN } ]
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-- NN compound construction (parent: PAL-internal stress, tight unit). -/
-def nnCompound : Construction :=
+def nnCompound : Construction Unit :=
   { name := "NN compound"
   , form :=
-      [ { filler := .open_ .NOUN, role := some "modifier", level := some .zero }
-      , { filler := .open_ .NOUN, role := some "head", isHead := true
+      [ { filler := .open_ .NOUN, level := some .zero }
+      , { filler := .open_ .NOUN, isHead := true
         , level := some .zero } ]
-  , meaning := "compound nominal: modifier noun narrows head noun denotation" }
+  , meaning := () }
 
 /-- Adjectival modification construction (parent: prenominal slot). -/
-def adjNModification : Construction :=
+def adjNModification : Construction Unit :=
   { name := "Adj+N modification"
   , form :=
-      [ { filler := .open_ .ADJ, role := some "modifier", level := some .zero }
-      , { filler := .open_ .NOUN, role := some "head", isHead := true
+      [ { filler := .open_ .ADJ, level := some .zero }
+      , { filler := .open_ .NOUN, isHead := true
         , level := some .bar } ]
-  , meaning := "adjective restricts noun denotation" }
+  , meaning := () }
 
 /-! ### Degrees of abstraction (Table 8) -/
 
@@ -159,7 +161,7 @@ and adjectival modification constructions; the four conventional subtypes
 confirmed by study 5 inherit from it. The figure's caption labels all
 arrows "motivation and (normal mode) inheritance links", so no
 Goldberg-1995 link type is assigned. -/
-def palConstructicon : Constructicon :=
+def palConstructicon : Constructicon Unit :=
   { constructions :=
       [ palConstruction
       , mustVerbConstruction
@@ -320,7 +322,7 @@ def palOwnSpec : CxnSpec :=
 mothers carry their specifications, PAL legislates exactly its mothers'
 conflicts, and the conventional subtypes add no form-side constraints of
 their own. -/
-def figure5Spec (c : Construction) : CxnSpec :=
+def figure5Spec (c : Construction Unit) : CxnSpec :=
   if c.name == "NN compound" then nnCompoundSpec
   else if c.name == "Adj+N modification" then adjNSpec
   else if c.name == "PAL" then palOwnSpec
@@ -388,15 +390,15 @@ def demoLexicon : String → Option UD.UPOS
 
 /-- The internal syntax of the *must-do* PAL: must-V
 (cf. `mustVerbConstruction`, which is the full prenominal construction). -/
-def mustVCore : Construction :=
+def mustVCore : Construction Unit :=
   { name := "must-V core"
   , form :=
       [ { filler := .fixed "must" }
-      , { filler := .open_ .VERB, role := some "predicate", isHead := true } ]
-  , meaning := "obligatory V-ing" }
+      , { filler := .open_ .VERB, isHead := true } ]
+  , meaning := () }
 
 /-- The Figure 5 network plus the must-V-internal construction. -/
-def demoNetwork : Constructicon :=
+def demoNetwork : Constructicon Unit :=
   { constructions := mustVCore :: palConstructicon.constructions
   , links := palConstructicon.links }
 
@@ -415,7 +417,7 @@ theorem pal_load_bearing :
     ¬ ({ demoNetwork with
          constructions :=
            demoNetwork.constructions.filter (·.name != "PAL") }
-        : Constructicon).Licenses demoLexicon mustDoTask := by decide
+        : Constructicon Unit).Licenses demoLexicon mustDoTask := by decide
 
 /-! ### Lemma-like meaning -/
 
@@ -450,7 +452,7 @@ theorem pal_children :
 /-- Own pragmatic contributions for the Figure 5 network: only PAL itself
 carries one — the familiarity-presupposing meaning. -/
 def figure5Pragmatics (W : Type*) (situationType headNoun : W → Prop) :
-    Construction → Option (PartialProp W) :=
+    Construction Unit → Option (PartialProp W) :=
   λ c => if c.name == "PAL" then some (palMeaning W situationType headNoun)
          else none
 

--- a/Linglib/Studies/KayFillmore1999.lean
+++ b/Linglib/Studies/KayFillmore1999.lean
@@ -47,20 +47,20 @@ Figure 13); WXDY-*what* is left-isolated ([loc -]) and nonreferential
 reports being unable to deduce, §4.6). X is constrained semantically, as
 a referential argument of the predicate Y (§4.7), and Y is a predicate
 phrase of any category. -/
-def wxdyConstruction : Construction :=
+def wxdyConstruction : Construction Unit :=
   { name := "What's X doing Y?"
   , form :=
-      [ { filler := .semantic "referential", role := some "subject"
+      [ { filler := .semantic "referential"
         , gf := some .subj, refIdx := some 2 }
       , { filler := .headed "be" .AUX, isHead := true }
       , { filler := .headed "doing" .VERB, gf := some .comp
         , constraints := [.negMinus] }
       , { filler := .fixed "what", gf := some .obj
         , constraints := [.locMinus, .refEmpty] }
-      , { filler := .phrasal, role := some "predicate", gf := some .pred
+      , { filler := .phrasal, gf := some .pred
         , refIdx := some 2 } ]
-  , meaning := "incongruity of the presupposed situation (incredulity) or genuine activity question (literal)"
-  , pragmaticFunction := "attributes incongruity to the presupposed situation" }
+  , meaning := ()
+  , pragmaticPoint := true }
 
 /-! ### Coreference (Figure 12) -/
 
@@ -171,10 +171,10 @@ and control. It figures twice in every WXDY clause — the flat rendering
 here unifies a predicator's subject with its complement's subject via a
 shared `refIdx`. -/
 def coinstantiationForm : TypedForm String :=
-  [ { filler := .open_ .NOUN, role := some "subject", gf := some .subj
+  [ { filler := .open_ .NOUN, gf := some .subj
     , refIdx := some 1 }
-  , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-  , { filler := .open_ .VERB, role := some "complement", gf := some .comp
+  , { filler := .open_ .VERB, isHead := true }
+  , { filler := .open_ .VERB, gf := some .comp
     , refIdx := some 1 } ]
 
 /-- Coinstantiation is fully abstract: every slot is open. -/

--- a/Linglib/Studies/KayMichaelis2019.lean
+++ b/Linglib/Studies/KayMichaelis2019.lean
@@ -68,29 +68,27 @@ abbrev CompositionRule (D : Type*) := List D → Option D
 mutual
 
 /-- All readings of a token: each construction whose typed form the
-daughters instantiate contributes the readings its composition rule
-produces from the daughters' readings; words read from the lexicon. -/
+daughters instantiate contributes the readings its meaning pole — its
+composition rule — produces from the daughters' readings; words read
+from the lexicon. -/
 def _root_.ConstructionGrammar.Constructicon.interps {D : Type*}
-    (cx : Constructicon) (pos : String → Option UD.UPOS)
-    (rules : Construction → Option (CompositionRule D))
+    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
     (lex : String → Option D) : Token → List D
   | .word w => (lex w).toList
   | .node ts =>
       cx.constructions.flatMap (λ c =>
         if formMatches pos c.form ts then
-          (cx.interpsList pos rules lex ts).filterMap
-            (λ seq => (rules c).bind (· seq))
+          (cx.interpsList pos lex ts).filterMap c.meaning
         else [])
 
 /-- All sequences of daughter readings. -/
 def _root_.ConstructionGrammar.Constructicon.interpsList {D : Type*}
-    (cx : Constructicon) (pos : String → Option UD.UPOS)
-    (rules : Construction → Option (CompositionRule D))
+    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
     (lex : String → Option D) : List Token → List (List D)
   | [] => [[]]
   | t :: ts =>
-      (cx.interps pos rules lex t).flatMap (λ d =>
-        (cx.interpsList pos rules lex ts).map (d :: ·))
+      (cx.interps pos lex t).flatMap (λ d =>
+        (cx.interpsList pos lex ts).map (d :: ·))
 
 end
 
@@ -121,29 +119,32 @@ def operatorRule (E : Type*) : CompositionRule (Den E)
 
 /-- The shared prenominal-modification form. -/
 def modificationForm : TypedForm String :=
-  [ { filler := .open_ .ADJ, role := some "modifier" }
-  , { filler := .open_ .NOUN, role := some "head", isHead := true } ]
+  [ { filler := .open_ .ADJ }
+  , { filler := .open_ .NOUN, isHead := true } ]
 
-/-- Intersective Adj+N modification. -/
-def intersectiveModification : Construction :=
+/-- Intersective Adj+N modification: its meaning pole is the
+intersective rule. -/
+def intersectiveModification (E : Type*) :
+    Construction (CompositionRule (Den E)) :=
   { name := "Intersective modification"
   , form := modificationForm
-  , meaning := "x is Adj and x is N" }
+  , meaning := intersectiveRule E }
 
-/-- Operator Adj+N modification. -/
-def operatorModification : Construction :=
+/-- Operator Adj+N modification: its meaning pole is the operator rule. -/
+def operatorModification (E : Type*) :
+    Construction (CompositionRule (Den E)) :=
   { name := "Operator modification"
   , form := modificationForm
-  , meaning := "x satisfies Adj applied to N" }
+  , meaning := operatorRule E }
 
 /-- §1's premise: one rule of syntactic formation, two semantic
 specifications — the constructions share their typed form. -/
-theorem same_form :
-    intersectiveModification.form = operatorModification.form := rfl
+theorem same_form (E : Type*) :
+    (intersectiveModification E).form = (operatorModification E).form := rfl
 
 /-- The demo network: both modification constructions. -/
-def demoCx : Constructicon :=
-  { constructions := [intersectiveModification, operatorModification]
+def demoCx (E : Type*) : Constructicon (CompositionRule (Den E)) :=
+  { constructions := [intersectiveModification E, operatorModification E]
   , links := [] }
 
 /-- Toy POS lexicon. -/
@@ -166,25 +167,18 @@ def demoLex : String → Option (Den E)
   | "thief" => some (.pred thief)
   | _ => none
 
-/-- Rule assignment for the demo network. -/
-def demoRules : Construction → Option (CompositionRule (Den E)) :=
-  λ c =>
-    if c = intersectiveModification then some (intersectiveRule E)
-    else if c = operatorModification then some (operatorRule E)
-    else none
-
 /-- *Purple plum* has exactly one reading: the intersection. The operator
 construction matches the form but its rule rejects two predicate
 daughters. -/
 theorem purple_plum_intersective :
-    demoCx.interps demoPos demoRules (demoLex purple plum thief alleged)
+    (demoCx E).interps demoPos (demoLex purple plum thief alleged)
         (.node [.word "purple", .word "plum"])
       = [.pred (λ x => purple x ∧ plum x)] := rfl
 
 /-- *Alleged thief* has exactly one reading: the operator applied to the
 head predicate — not an intersection. -/
 theorem alleged_thief_operator :
-    demoCx.interps demoPos demoRules (demoLex purple plum thief alleged)
+    (demoCx E).interps demoPos (demoLex purple plum thief alleged)
         (.node [.word "alleged", .word "thief"])
       = [.pred (alleged thief)] := rfl
 
@@ -192,8 +186,8 @@ theorem alleged_thief_operator :
 reading at all: the chapter's point that intersection cannot be the
 single rule of adjectival modification. -/
 theorem alleged_thief_needs_operator_construction :
-    ({ constructions := [intersectiveModification], links := [] }
-        : Constructicon).interps demoPos demoRules
+    ({ constructions := [intersectiveModification E], links := [] }
+        : Constructicon (CompositionRule (Den E))).interps demoPos
         (demoLex purple plum thief alleged)
         (.node [.word "alleged", .word "thief"])
       = [] := rfl
@@ -209,8 +203,8 @@ meaning each contributes. -/
 (§5, exx. 19–22, *Frank sneezed the tissue off the table*), *let alone*
 (§6, ex. 32), and the incredulity type (§7, ex. 14, *Him get first
 prize?!*). -/
-def chapterCases : List (Construction × MeaningKind) :=
-  [ (causedMotion.construction, .argumentStructure)
+def chapterCases : List (Construction Unit × MeaningKind) :=
+  [ (causedMotion.map fun _ => (), .argumentStructure)
   , (_root_.FillmoreKayOConnor1988.letAloneConstruction, .conventionalImplicature)
   , (_root_.FillmoreKayOConnor1988.incredulityResponse, .illocutionaryForce) ]
 

--- a/Linglib/Studies/Levin2026.lean
+++ b/Linglib/Studies/Levin2026.lean
@@ -74,7 +74,7 @@ open English.Predicates.Adjectival (open_ closed_ shut free_ loose flat
 open Causation.Resultatives (resultativeCausativeBuilder)
 open Features.ChangeOfState (CoSType)
 open ConstructionGrammar (resultative composedMeaning predictedAlternationInConstruction
-  ArgStructureConstruction)
+  Construction)
 open GoldbergJackendoff2004 (ResultativeType)
 
 -- ════════════════════════════════════════════════════
@@ -201,7 +201,7 @@ theorem pushPull_is_activity :
     adds [CAUSE [BECOME [STATE]]]). -/
 theorem pushPull_accomplishment_in_resultative :
     (LevinClass.pushPull.meaningComponents.fuse
-      resultative.semanticContribution).predictedTemplate = .accomplishment := by
+      resultative.meaning).predictedTemplate = .accomplishment := by
   exact fuse_cos_caus_yields_accomplishment _ _ rfl rfl
 
 /-- Hit alone is an activity. -/
@@ -211,19 +211,19 @@ theorem hit_is_activity' :
 /-- Hit in the resultative shifts to accomplishment. -/
 theorem hit_accomplishment_in_resultative :
     (LevinClass.hit.meaningComponents.fuse
-      resultative.semanticContribution).predictedTemplate = .accomplishment := by
+      resultative.meaning).predictedTemplate = .accomplishment := by
   exact fuse_cos_caus_yields_accomplishment _ _ rfl rfl
 
 /-- Full dual prediction for pushPull in the resultative: template shift
     AND alternation AND intransitive variant, all from one fusion. -/
 theorem pushPull_dual_in_resultative :
     (LevinClass.pushPull.meaningComponents.fuse
-      resultative.semanticContribution).predictedTemplate = .accomplishment ∧
+      resultative.meaning).predictedTemplate = .accomplishment ∧
     (LevinClass.pushPull.meaningComponents.fuse
-      resultative.semanticContribution).predictedAlternation
+      resultative.meaning).predictedAlternation
         .causativeInchoative = true ∧
     (LevinClass.pushPull.meaningComponents.fuse
-      resultative.semanticContribution).predictedTemplate.intransitiveVariant
+      resultative.meaning).predictedTemplate.intransitiveVariant
         = some .achievement := by
   exact fuse_dual_prediction _ _ rfl rfl rfl rfl
 
@@ -232,7 +232,7 @@ theorem pushPull_dual_in_resultative :
 theorem pushPull_vendler_shift :
     LevinClass.pushPull.eventTemplate.vendlerClass = .activity ∧
     (LevinClass.pushPull.meaningComponents.fuse
-      resultative.semanticContribution).predictedTemplate.vendlerClass
+      resultative.meaning).predictedTemplate.vendlerClass
         = .accomplishment :=
   ⟨rfl, fuse_vendler_class_shift _ _ rfl rfl⟩
 
@@ -811,7 +811,7 @@ structure FilledResultative where
   /-- The result-state adjective (from Fragment) -/
   adjective : AdjectivalPredicateEntry
   /-- The argument structure construction (typically `resultative`) -/
-  construction : ArgStructureConstruction
+  construction : Construction MeaningComponents
   /-- The construction adds what the verb lacks: fusion predicts the
       causative alternation for the composed meaning. -/
   alternationPredicted :

--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -10,7 +10,7 @@ import Linglib.Data.UD.Basic
 CxG's argument structure constructions: explicit slot structure, full
 compositionality, polysemy families, and verb–construction fusion.
 
-Fully abstract constructions without pragmatic functions are fully
+Fully abstract constructions without pragmatic point are fully
 compositional (`isFullyCompositional`); constructions with idiosyncratic
 form–meaning pairings (*let alone*, WXDY, PAL) are irreducible phrasal
 patterns that only CxG can capture. The decomposition of fully abstract constructions into
@@ -23,65 +23,38 @@ namespace ConstructionGrammar
 
 open ArgumentStructure
 
-/-! ## Construction slots and argument frames -/
+/-! ## Concrete argument structure constructions
 
-/-- An argument structure construction: a `Construction` whose typed form
-serves as the argument frame, enabling formal analysis of how the
-construction relates to the three universal combination schemata.
-
-The `semanticContribution` field captures which meaning components
-([levin-1993]) the construction adds independently of the verb
-([goldberg-1995]). When a verb fuses with a construction, the
-composed meaning = `verb.meaningComponents.fuse cxn.semanticContribution`.
-This is how constructions can license alternation behavior that verbs
-lack in isolation — e.g., the resultative adds CoS + causation, enabling
-the causative alternation for manner verbs ([levin-2026]). -/
-structure ArgStructureConstruction where
-  /-- The underlying construction -/
-  construction : Construction
-  /-- At least one slot of the form should be the head -/
-  hasHead : construction.form.any (·.isHead) = true
-  /-- What meaning components this construction contributes independently
-      of the verb. Defaults to `.none` (no augmentation). -/
-  semanticContribution : MeaningComponents := .none
-  deriving Repr
-
-/-- The argument frame: the underlying construction's typed form. -/
-def ArgStructureConstruction.slots (asc : ArgStructureConstruction) :
-    TypedForm String :=
-  asc.construction.form
-
-/-! ## Concrete argument structure constructions -/
+An argument structure construction is a `Construction MeaningComponents`:
+its typed form is the argument frame, and its meaning pole records which
+meaning components ([levin-1993]) the construction adds independently of
+the verb ([goldberg-1995]) — `.none` for constructions that do not
+augment. -/
 
 /-- Ditransitive construction: [Subj V Obj1 Obj2].
 "X CAUSES Y to RECEIVE Z" (e.g., "She gave him a book"). -/
-def ditransitive : ArgStructureConstruction :=
-  { construction :=
-      { name := "Ditransitive"
-      , form :=
-          [ { filler := .open_ .NOUN, role := some "agent" }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .NOUN, role := some "recipient" }
-          , { filler := .open_ .NOUN, role := some "theme" } ]
-      , meaning := "X CAUSES Y to RECEIVE Z" }
-  , hasHead := by decide }
+def ditransitive : Construction MeaningComponents :=
+  { name := "Ditransitive"
+  , form :=
+      [ { filler := .open_ .NOUN }                 -- agent
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .NOUN }                 -- recipient
+      , { filler := .open_ .NOUN } ]               -- theme
+  , meaning := .none }
 
 /-- Caused-motion construction: [Subj V Obj Obl].
 "X CAUSES Y to MOVE Z", Z a directional ("Pat sneezed the napkin off the
 table", p. 3). Contributes motion + causation: verbs that lexicalize
 neither (like *sneeze*) acquire both from the construction
 ([goldberg-1995] p. 152–179). -/
-def causedMotion : ArgStructureConstruction :=
-  { construction :=
-      { name := "Caused-motion"
-      , form :=
-          [ { filler := .open_ .NOUN, role := some "agent" }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .NOUN, role := some "theme" }
-          , { filler := .open_ .ADP, role := some "goal" } ]
-      , meaning := "X CAUSES Y to MOVE Z" }
-  , hasHead := by decide
-  , semanticContribution :=
+def causedMotion : Construction MeaningComponents :=
+  { name := "Caused-motion"
+  , form :=
+      [ { filler := .open_ .NOUN }                 -- agent
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .NOUN }                 -- theme
+      , { filler := .open_ .ADP } ]                -- goal
+  , meaning :=
       { changeOfState := false, contact := false, motion := true, causation := true } }
 
 /-- Resultative construction: [Subj V Obj Pred].
@@ -91,50 +64,43 @@ acquire both — [rappaport-hovav-levin-1998]'s Template Augmentation,
 cast lexically there (their appendix maps it onto the constructional
 approach); [levin-2026] §3. This is what enables the causative
 alternation for verbs like *push* that lack it in isolation. -/
-def resultative : ArgStructureConstruction :=
-  { construction :=
-      { name := "Resultative"
-      , form :=
-          [ { filler := .open_ .NOUN, role := some "agent" }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .NOUN, role := some "patient" }
-          , { filler := .open_ .ADJ, role := some "result" } ]
-      , meaning := "X CAUSES Y to BECOME Z" }
-  , hasHead := by decide
-  , semanticContribution :=
+def resultative : Construction MeaningComponents :=
+  { name := "Resultative"
+  , form :=
+      [ { filler := .open_ .NOUN }                 -- agent
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .NOUN }                 -- patient
+      , { filler := .open_ .ADJ } ]                -- result
+  , meaning :=
       { changeOfState := true, contact := false, motion := false, causation := true } }
 
 /-- Intransitive motion construction: [Subj V Obl].
 "X MOVES to Y" (e.g., "The ball rolled down the hill"). -/
-def intransitiveMotion : ArgStructureConstruction :=
-  { construction :=
-      { name := "Intransitive-motion"
-      , form :=
-          [ { filler := .open_ .NOUN, role := some "theme" }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .ADP, role := some "path" } ]
-      , meaning := "X MOVES to Y" }
-  , hasHead := by decide }
+def intransitiveMotion : Construction MeaningComponents :=
+  { name := "Intransitive-motion"
+  , form :=
+      [ { filler := .open_ .NOUN }                 -- theme
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .ADP } ]                -- path
+  , meaning := .none }
 
 /-- Conative construction: [Subj V Obl_at].
 "X DIRECTS ACTION at Y" (e.g., "Sam kicked at Bill").
 The verb designates the intended result of the directed action;
 the at-PP marks the target without entailing contact
 ([goldberg-1995] p. 3–4, 63–64). -/
-def conative : ArgStructureConstruction :=
-  { construction :=
-      { name := "Conative"
-      , form :=
-          [ { filler := .open_ .NOUN, role := some "agent" }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .ADP, role := some "target" } ]
-      , meaning := "X DIRECTS ACTION at Y" }
-  , hasHead := by decide }
+def conative : Construction MeaningComponents :=
+  { name := "Conative"
+  , form :=
+      [ { filler := .open_ .NOUN }                 -- agent
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .ADP } ]                -- target
+  , meaning := .none }
 
 /-! ## Full compositionality -/
 
 /-- A construction is fully compositional if it has specificity `fullyAbstract`
-and no construction-specific pragmatic function.
+and no construction-specific pragmatic point.
 
 This is a proxy for [mueller-2013]'s structural criterion (whether the
 construction can be analyzed as a sequence of headed binary combinations).
@@ -143,15 +109,15 @@ functions have no idiosyncratic form–meaning pairings that would resist
 decomposition into the three universal schemata. The Boolean approximates
 what [kay-michaelis-2019] survey as a continuum of constructional meaning
 contributions. -/
-def isFullyCompositional (c : Construction) : Bool :=
-  c.specificity == .fullyAbstract && c.pragmaticFunction.isNone
+def isFullyCompositional {Sem : Type*} (c : Construction Sem) : Bool :=
+  c.specificity == .fullyAbstract && !c.pragmaticPoint
 
 /-! ## Core theorems -/
 
-/-- Fully abstract constructions without pragmatic functions are fully compositional. -/
-theorem fullyAbstract_isFullyCompositional (c : Construction)
+/-- Fully abstract constructions without pragmatic point are fully compositional. -/
+theorem fullyAbstract_isFullyCompositional {Sem : Type*} (c : Construction Sem)
     (h₁ : c.specificity = .fullyAbstract)
-    (h₂ : c.pragmaticFunction = none) :
+    (h₂ : c.pragmaticPoint = false) :
     isFullyCompositional c = true := by
   unfold isFullyCompositional
   rw [h₁, h₂]
@@ -161,57 +127,49 @@ theorem fullyAbstract_isFullyCompositional (c : Construction)
 
 A polysemy family groups constructions that share one syntactic frame
 but differ in meaning. The shared form is enforced by construction —
-all senses are generated from the same `slots`, making it impossible
+all senses are generated from the same `form`, making it impossible
 for a polysemy extension to silently diverge in syntax. -/
 
 /-- A polysemy family: one argument frame, multiple meanings.
 
-All constructions in a family share the same `slots` definitionally —
+All constructions in a family share the same `form` definitionally —
 there is no way to create an extension with different syntax. The
 polysemy links (I_P) are derived, not manually assembled. -/
-structure PolysemyFamily where
+structure PolysemyFamily (Sem : Type*) where
   /-- Name of the construction family -/
   name : String
   /-- The shared argument frame -/
-  slots : TypedForm String
-  /-- At least one slot is the head -/
-  hasHead : slots.any (·.isHead) = true
+  form : TypedForm String
   /-- Central sense meaning -/
-  centralMeaning : String
+  centralMeaning : Sem
   /-- Extended senses: (extension name, meaning, overridden properties) -/
-  extensions : List (String × String × List String)
+  extensions : List (String × Sem × List String)
 
-/-- The central sense as an `ArgStructureConstruction`. -/
-def PolysemyFamily.centralConstruction (f : PolysemyFamily) :
-    ArgStructureConstruction :=
-  { construction :=
-      { name := f.name
-      , form := f.slots
-      , meaning := f.centralMeaning }
-  , hasHead := f.hasHead }
+variable {Sem : Type*}
 
-/-- Build an extension construction. Uses the family's `slots` — shared
+/-- The central sense as a construction. -/
+def PolysemyFamily.centralConstruction (f : PolysemyFamily Sem) :
+    Construction Sem :=
+  { name := f.name, form := f.form, meaning := f.centralMeaning }
+
+/-- Build an extension construction. Uses the family's `form` — shared
 by construction, not by assertion. -/
-def PolysemyFamily.extensionConstruction (f : PolysemyFamily)
-    (ext : String × String × List String) : ArgStructureConstruction :=
-  { construction :=
-      { name := f.name ++ "-" ++ ext.1
-      , form := f.slots
-      , meaning := ext.2.1 }
-  , hasHead := f.hasHead }
+def PolysemyFamily.extensionConstruction (f : PolysemyFamily Sem)
+    (ext : String × Sem × List String) : Construction Sem :=
+  { name := f.name ++ "-" ++ ext.1, form := f.form, meaning := ext.2.1 }
 
 /-- All extension constructions. -/
-def PolysemyFamily.extensionConstructions (f : PolysemyFamily) :
-    List ArgStructureConstruction :=
+def PolysemyFamily.extensionConstructions (f : PolysemyFamily Sem) :
+    List (Construction Sem) :=
   f.extensions.map f.extensionConstruction
 
 /-- All constructions (central + extensions). -/
-def PolysemyFamily.allConstructions (f : PolysemyFamily) :
-    List ArgStructureConstruction :=
+def PolysemyFamily.allConstructions (f : PolysemyFamily Sem) :
+    List (Construction Sem) :=
   f.centralConstruction :: f.extensionConstructions
 
 /-- Derive polysemy links from the family structure. -/
-def PolysemyFamily.polysemyLinks (f : PolysemyFamily) : List InheritanceLink :=
+def PolysemyFamily.polysemyLinks (f : PolysemyFamily Sem) : List InheritanceLink :=
   f.extensions.map fun ⟨extName, _, overrides⟩ =>
     { parent := f.name
     , child := f.name ++ "-" ++ extName
@@ -220,16 +178,16 @@ def PolysemyFamily.polysemyLinks (f : PolysemyFamily) : List InheritanceLink :=
     , sharedProperties := ["shared argument frame"]
     , overriddenProperties := overrides }
 
-/-- Central construction uses the family's slots (definitionally true). -/
-theorem PolysemyFamily.central_slots (f : PolysemyFamily) :
-    f.centralConstruction.slots = f.slots := rfl
+/-- Central construction uses the family's form (definitionally true). -/
+theorem PolysemyFamily.central_form (f : PolysemyFamily Sem) :
+    f.centralConstruction.form = f.form := rfl
 
-/-- Every extension uses the family's slots (definitionally true).
+/-- Every extension uses the family's form (definitionally true).
 This is the structural enforcement: shared syntax is impossible
 to violate because it follows from the definition, not from a proof. -/
-theorem PolysemyFamily.extension_slots (f : PolysemyFamily)
-    (ext : String × String × List String) :
-    (f.extensionConstruction ext).slots = f.slots := rfl
+theorem PolysemyFamily.extension_form (f : PolysemyFamily Sem)
+    (ext : String × Sem × List String) :
+    (f.extensionConstruction ext).form = f.form := rfl
 
 /-! ## Ditransitive polysemy network ([goldberg-1995] pp. 75–77)
 
@@ -238,6 +196,23 @@ senses connected by polysemy links (I_P). Each sense inherits the
 ditransitive's syntactic form [Subj V Obj Obj₂] but differs in the
 semantic relation between the event participants. -/
 
+/-- The modality of the CAUSE-RECEIVE relation distinguishing the
+ditransitive's senses ([goldberg-1995] pp. 75–77). -/
+inductive TransferModality where
+  /-- Actual transfer: X CAUSES Y TO RECEIVE Z. -/
+  | actual
+  /-- Conditions of satisfaction imply X CAUSES Y TO RECEIVE Z. -/
+  | satisfaction
+  /-- X ENABLES Y TO RECEIVE Z. -/
+  | enablement
+  /-- X CAUSES Y NOT TO RECEIVE Z. -/
+  | negated
+  /-- X INTENDS TO CAUSE Y TO RECEIVE Z. -/
+  | intended
+  /-- X ACTS TO CAUSE Y TO RECEIVE Z at some future point in time. -/
+  | future
+  deriving DecidableEq, Repr
+
 /-- The ditransitive polysemy family: six senses sharing one argument
 frame ([goldberg-1995] pp. 75–77; verb classes per Figure 2.2, p. 38).
 The extension labels are the formalizer's — Goldberg numbers the senses
@@ -245,27 +220,16 @@ and calls the Intended extension "the benefactive construction" (Figure
 3.2). Her warrant for the shared frame is exactly what `PolysemyFamily`
 enforces definitionally: "The syntactic specifications of the central
 sense are inherited by the extensions" (p. 75). -/
-def ditransitiveFamily : PolysemyFamily :=
+def ditransitiveFamily : PolysemyFamily TransferModality :=
   { name := "Ditransitive"
-  , slots := ditransitive.slots
-  , hasHead := by decide
-  , centralMeaning := "X CAUSES Y TO RECEIVE Z"
+  , form := ditransitive.form
+  , centralMeaning := .actual
   , extensions :=
-      [ ("Satisfaction",
-         "Conditions of satisfaction imply X CAUSES Y TO RECEIVE Z",
-         ["transfer is implied, not entailed"])
-      , ("Enablement",
-         "X ENABLES Y TO RECEIVE Z",
-         ["enablement replaces direct causation"])
-      , ("Negated",
-         "X CAUSES Y NOT TO RECEIVE Z",
-         ["transfer is negated"])
-      , ("Intended",
-         "X INTENDS TO CAUSE Y TO RECEIVE Z",
-         ["transfer is intended, not actual"])
-      , ("Future",
-         "X ACTS TO CAUSE Y TO RECEIVE Z at some future point in time",
-         ["transfer deferred to future"]) ] }
+      [ ("Satisfaction", .satisfaction, ["transfer is implied, not entailed"])
+      , ("Enablement", .enablement, ["enablement replaces direct causation"])
+      , ("Negated", .negated, ["transfer is negated"])
+      , ("Intended", .intended, ["transfer is intended, not actual"])
+      , ("Future", .future, ["transfer deferred to future"]) ] }
 
 /-- Derived polysemy links. -/
 def ditransitivePolysemy : List InheritanceLink :=
@@ -310,12 +274,15 @@ the book's construction inventory (p. 4) but participates in no
 inheritance link — it is a node without edges, and linking it would be
 invention. -/
 
-/-- The ch. 2–3 constructional network. -/
-def goldberg1995Network : Constructicon :=
+/-- The ch. 2–3 constructional network, with meaning poles erased: the
+network theorems concern the links and forms only, and the family's
+`TransferModality` meanings and the argument-structure constructions'
+`MeaningComponents` meanings live in different types. -/
+def goldberg1995Network : Constructicon Unit :=
   { constructions :=
-      ditransitiveFamily.allConstructions.map (·.construction) ++
-        [ causedMotion.construction, intransitiveMotion.construction
-        , resultative.construction, conative.construction ]
+      ditransitiveFamily.allConstructions.map (.map fun _ => ()) ++
+        ([causedMotion, intransitiveMotion, resultative, conative].map
+          (.map fun _ => ()))
   , links :=
       ditransitivePolysemy ++ [causedMotionSubpart, causedMotionToResultative] }
 
@@ -326,12 +293,13 @@ theorem goldberg1995Network_wellFormed : goldberg1995Network.WellFormed := by
 /-- The links, not hand-listed parents, determine the resultative's mother:
 the caused-motion construction, via the metaphorical link. -/
 theorem resultative_parent :
-    goldberg1995Network.parentsOf "Resultative" = [causedMotion.construction] := by
+    goldberg1995Network.parentsOf "Resultative"
+      = [causedMotion.map fun _ => ()] := by
   decide
 
 /-- Every link a polysemy family derives is an I_P link — a fact about the
 construction, not about one table. -/
-theorem PolysemyFamily.polysemyLinks_typed (f : PolysemyFamily) :
+theorem PolysemyFamily.polysemyLinks_typed (f : PolysemyFamily Sem) :
     ∀ l ∈ f.polysemyLinks, l.linkType = some .polysemy := by
   intro l hl
   simp only [PolysemyFamily.polysemyLinks, List.mem_map] at hl
@@ -358,21 +326,21 @@ fused result gives the correct prediction without any new alternation logic. -/
 
 /-- The composed meaning of a verb in an argument structure construction.
     Verb root semantics fused with the construction's semantic contribution. -/
-def composedMeaning (verbMC : MeaningComponents) (cxn : ArgStructureConstruction) :
+def composedMeaning (verbMC : MeaningComponents) (cxn : Construction MeaningComponents) :
     MeaningComponents :=
-  verbMC.fuse cxn.semanticContribution
+  verbMC.fuse cxn.meaning
 
 /-- Whether an alternation is predicted for a verb *in a construction*.
     Generalizes `MeaningComponents.predictedAlternation` to construction contexts. -/
 def predictedAlternationInConstruction (verbMC : MeaningComponents)
-    (cxn : ArgStructureConstruction) (alt : DiathesisAlternation) : Bool :=
+    (cxn : Construction MeaningComponents) (alt : DiathesisAlternation) : Bool :=
   (composedMeaning verbMC cxn).predictedAlternation alt
 
 /-! ### Core theorems: constructions that don't augment -/
 
 /-- Ditransitive contributes nothing beyond the verb (`.none`). -/
 theorem ditransitive_no_augmentation :
-    ditransitive.semanticContribution = .none := rfl
+    ditransitive.meaning = .none := rfl
 
 /-- With no augmentation, the composed meaning equals the verb's own. -/
 theorem no_augmentation_identity (mc : MeaningComponents) :
@@ -383,13 +351,13 @@ theorem no_augmentation_identity (mc : MeaningComponents) :
 
 /-- The resultative adds CoS + causation. -/
 theorem resultative_adds_cos_causation :
-    resultative.semanticContribution.changeOfState = true ∧
-    resultative.semanticContribution.causation = true := ⟨rfl, rfl⟩
+    resultative.meaning.changeOfState = true ∧
+    resultative.meaning.causation = true := ⟨rfl, rfl⟩
 
 /-- The caused-motion construction adds motion + causation. -/
 theorem causedMotion_adds_motion_causation :
-    causedMotion.semanticContribution.motion = true ∧
-    causedMotion.semanticContribution.causation = true := ⟨rfl, rfl⟩
+    causedMotion.meaning.motion = true ∧
+    causedMotion.meaning.causation = true := ⟨rfl, rfl⟩
 
 /-! ### Key derivation: construction-dependent alternation
 

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -22,7 +22,8 @@ construction.
 - `SlotFiller`, `Slot`, `TypedForm`: the typed form side
 - `derivedSpecificity`, `HasConstraint`, `refGroupCount`: measures derived
   from forms
-- `Construction`, `Construction.specificity`: form–function pairings
+- `Construction`, `Construction.specificity`, `Construction.map`: typed
+  form–meaning pairings
 - `InheritanceLink`, `Constructicon`: the network
 -/
 
@@ -156,16 +157,13 @@ inductive SlotConstraint where
   | refEmpty   -- [ref ∅]: nonreferential (no variable-binding function)
   deriving DecidableEq, Repr
 
-/-- A slot in a construction's form: filler content, semantic role,
-headedness, and the bar level of the position itself. Fixed slots (like
-"let" in *let alone*) have `role := none` since they carry no independent
-semantic role. `level := none` leaves the position's bar level
-unspecified. -/
+/-- A slot in a construction's form: filler content, headedness, and the
+bar level of the position itself. `level := none` leaves the position's
+bar level unspecified; slots sharing a `refIdx` are co-indexed, the hook
+by which a typed meaning pole refers to slots. -/
 structure Slot (Lex : Type*) where
   /-- What fills this slot -/
   filler : SlotFiller Lex
-  /-- Semantic role label (agent, theme, etc.), if any -/
-  role : Option String := none
   /-- Whether this slot is the head of the construction -/
   isHead : Bool := false
   /-- Bar level of the position (`some .zero` = a word-level slot) -/
@@ -271,19 +269,33 @@ end DerivedSpecificity
 
 /-! ### Constructions and the network -/
 
-/-- A construction: a learned pairing of form and function. The form is a
-`TypedForm`; `name` is a display label; specificity is derived from the
-form (`Construction.specificity`), not stipulated. -/
-structure Construction where
+/-- A construction: a learned pairing of form and meaning. The form is a
+`TypedForm`; the meaning pole is typed by the domain that owns the
+construction — a composition rule, a `MeaningComponents` contribution, a
+presupposition — with `Unit` for a purely formal record or a defective,
+form-only construction. Specificity is derived from the form
+(`Construction.specificity`), not stipulated. -/
+structure Construction (Sem : Type*) where
   name : String
   form : TypedForm String
-  meaning : String           -- semantic/pragmatic function description
-  pragmaticFunction : Option String := none  -- e.g. "presupposes familiarity"
+  /-- The meaning pole. -/
+  meaning : Sem
+  /-- Whether the construction carries a conventional pragmatic point
+      ([fillmore-kay-oconnor-1988] §1.1.4). -/
+  pragmaticPoint : Bool := false
   deriving DecidableEq, Repr
 
+variable {Sem : Type*}
+
 /-- A construction's specificity, derived from its slot structure. -/
-def Construction.specificity (c : Construction) : Specificity :=
+def Construction.specificity (c : Construction Sem) : Specificity :=
   derivedSpecificity c.form
+
+/-- Reinterpret the meaning pole along `f`, keeping the form. -/
+def Construction.map {Sem' : Type*} (f : Sem → Sem') (c : Construction Sem) :
+    Construction Sem' :=
+  { name := c.name, form := c.form, meaning := f c.meaning
+  , pragmaticPoint := c.pragmaticPoint }
 
 /-- An inheritance link between two constructions in the network.
 
@@ -301,8 +313,8 @@ structure InheritanceLink where
   deriving Repr, DecidableEq
 
 /-- A constructicon: a network of constructions connected by inheritance links. -/
-structure Constructicon where
-  constructions : List Construction
+structure Constructicon (Sem : Type*) where
+  constructions : List (Construction Sem)
   links : List InheritanceLink
   deriving Repr
 

--- a/Linglib/Syntax/ConstructionGrammar/Idiom.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Idiom.lean
@@ -30,7 +30,7 @@ stipulated.
 ## Implementation notes
 
 The paper's fourth contrast — idioms with vs. without pragmatic point
-(§1.1.4) — is carried by `Construction.pragmaticFunction`.
+(§1.1.4) — is the `Construction.pragmaticPoint` field.
 -/
 
 namespace ConstructionGrammar
@@ -85,10 +85,10 @@ theorem IdiomFormality.ofForm_eq_substantive_iff (form : TypedForm Lex) :
 
 /-- A formal idiom in the sense of [fillmore-kay-oconnor-1988] §1.1.3: a
 construction whose form is lexically open. -/
-def Construction.IsFormalIdiom (c : Construction) : Prop :=
+def Construction.IsFormalIdiom {Sem : Type*} (c : Construction Sem) : Prop :=
   IdiomFormality.ofForm c.form = .formal
 
-instance (c : Construction) : Decidable c.IsFormalIdiom :=
+instance {Sem : Type*} (c : Construction Sem) : Decidable c.IsFormalIdiom :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- How familiar are an idiom's pieces, and how familiar is their

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -97,47 +97,47 @@ parents its links name. The walk is generic in the specification type:
 record-valued specifications supply their componentwise `inherit` and
 `Resolves` lifts. -/
 
-variable {σ : Type*}
+variable {Sem σ : Type*}
 
 /-- The constructions a network's links name as parents of `name`. -/
-def Constructicon.parentsOf (cx : Constructicon) (name : String) :
-    List Construction :=
+def Constructicon.parentsOf (cx : Constructicon Sem) (name : String) :
+    List (Construction Sem) :=
   (cx.links.filter (·.child == name)).filterMap
     (λ l => cx.constructions.find? (·.name == l.parent))
 
 /-- The constructions a network's links name as children of `name`. -/
-def Constructicon.childrenOf (cx : Constructicon) (name : String) :
-    List Construction :=
+def Constructicon.childrenOf (cx : Constructicon Sem) (name : String) :
+    List (Construction Sem) :=
   (cx.links.filter (·.parent == name)).filterMap
     (λ l => cx.constructions.find? (·.name == l.child))
 
 /-- Every link endpoint resolves to a construction in the network — no
 dangling name-keyed links. -/
-def Constructicon.WellFormed (cx : Constructicon) : Prop :=
+def Constructicon.WellFormed (cx : Constructicon Sem) : Prop :=
   ∀ l ∈ cx.links,
     (∃ c ∈ cx.constructions, c.name = l.parent) ∧
     (∃ c ∈ cx.constructions, c.name = l.child)
 
-instance (cx : Constructicon) : Decidable cx.WellFormed :=
+instance (cx : Constructicon Sem) : Decidable cx.WellFormed :=
   inferInstanceAs (Decidable (∀ l ∈ _, _ ∧ _))
 
 /-- Normal-mode derived specification of `c` in the network: `c`'s own
 specification wins; fields it leaves open are filled from the parents its
 links name ([diessel-2023] Table 2's default mode, computed over the
 links rather than stipulated per node). -/
-def Constructicon.derivedSpec (cx : Constructicon)
-    (inherit : σ → List σ → σ) (own : Construction → σ)
-    (c : Construction) : σ :=
+def Constructicon.derivedSpec (cx : Constructicon Sem)
+    (inherit : σ → List σ → σ) (own : Construction Sem → σ)
+    (c : Construction Sem) : σ :=
   inherit (own c) ((cx.parentsOf c.name).map own)
 
 /-- Normal-mode well-formedness of the whole network: every construction
 legislates every field its parents conflict on. -/
-def Constructicon.ResolvesAll (cx : Constructicon)
-    (resolves : σ → List σ → Prop) (own : Construction → σ) : Prop :=
+def Constructicon.ResolvesAll (cx : Constructicon Sem)
+    (resolves : σ → List σ → Prop) (own : Construction Sem → σ) : Prop :=
   ∀ c ∈ cx.constructions, resolves (own c) ((cx.parentsOf c.name).map own)
 
-instance (cx : Constructicon) (resolves : σ → List σ → Prop)
-    [∀ o ps, Decidable (resolves o ps)] (own : Construction → σ) :
+instance (cx : Constructicon Sem) (resolves : σ → List σ → Prop)
+    [∀ o ps, Decidable (resolves o ps)] (own : Construction Sem → σ) :
     Decidable (cx.ResolvesAll resolves own) :=
   inferInstanceAs (Decidable (∀ c ∈ _, _))
 
@@ -163,8 +163,8 @@ def inheritFieldUnique {α : Type*} (own : Option α)
 /-- Derived value of a denotation-valued field for `c` in the network:
 `c`'s own value wins; otherwise the value of the unique supplying
 parent. -/
-def Constructicon.derivedField {α : Type*} (cx : Constructicon)
-    (own : Construction → Option α) (c : Construction) : Option α :=
+def Constructicon.derivedField {α : Type*} (cx : Constructicon Sem)
+    (own : Construction Sem → Option α) (c : Construction Sem) : Option α :=
   inheritFieldUnique (own c) ((cx.parentsOf c.name).map own)
 
 end ConstructionGrammar

--- a/Linglib/Syntax/ConstructionGrammar/Licensing.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Licensing.lean
@@ -106,12 +106,14 @@ def formMatches (pos : String → Option UD.UPOS)
   (form.zip ts).all (λ ⟨s, t⟩ =>
     s.filler.matches pos t && s.constraints.all (·.allows t))
 
+variable {Sem : Type*}
+
 mutual
 
 /-- The licensing recognizer: words are licensed lexically; a constituent
 is licensed iff its daughters instantiate some construction of the network
 and are each licensed themselves. -/
-def Constructicon.licenses (cx : Constructicon)
+def Constructicon.licenses (cx : Constructicon Sem)
     (pos : String → Option UD.UPOS) : Token → Bool
   | .word _ => true
   | .node ts =>
@@ -119,7 +121,7 @@ def Constructicon.licenses (cx : Constructicon)
       cx.licensesList pos ts
 
 /-- All tokens in a list are licensed. -/
-def Constructicon.licensesList (cx : Constructicon)
+def Constructicon.licensesList (cx : Constructicon Sem)
     (pos : String → Option UD.UPOS) : List Token → Bool
   | [] => true
   | t :: ts => cx.licenses pos t && cx.licensesList pos ts
@@ -129,11 +131,11 @@ end
 /-- `cx` licenses token `t` (relative to a POS lexicon): every constituent
 instantiates some construction of the network. Defined via the
 `licenses` recognizer, so concrete cases are kernel-decidable. -/
-def Constructicon.Licenses (cx : Constructicon)
+def Constructicon.Licenses (cx : Constructicon Sem)
     (pos : String → Option UD.UPOS) (t : Token) : Prop :=
   cx.licenses pos t = true
 
-instance (cx : Constructicon) (pos : String → Option UD.UPOS) (t : Token) :
+instance (cx : Constructicon Sem) (pos : String → Option UD.UPOS) (t : Token) :
     Decidable (cx.Licenses pos t) :=
   inferInstanceAs (Decidable (_ = true))
 

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -31,7 +31,7 @@ which imports this file.
 - `resultativeAspect`, `resultativeVendlerClass` — bounded RP → telic
 - `adjScaleToRPBoundedness` — Kennedy 2007 scale → G&J boundedness
 - `ResultativeSubconstruction.toConstruction` — derived family of
-  `ArgStructureConstruction` instances + `inheritanceLink`
+  derived construction family + `inheritanceLink`
 - `farSatisfied`, `rolesCoherent`, `temporalConstraintSatisfied` —
   the three substantive constraints (Principles 37, 44, §4.2)
 
@@ -526,7 +526,7 @@ theorem noncausative_sc_contribution (sc : ResultativeSubconstruction)
 /-- Causative subconstructions match the parent `resultative`'s semantic contribution. -/
 theorem causative_semantics_match_parent (sc : ResultativeSubconstruction)
     (h : sc.isCausative = true) :
-    sc.semanticContribution = resultative.semanticContribution := by
+    sc.semanticContribution = resultative.meaning := by
   cases sc <;> simp_all [ResultativeSubconstruction.isCausative,
     ResultativeSubconstruction.semanticContribution, resultative]
 
@@ -558,35 +558,25 @@ def ResultativeSubconstruction.nameSuffix : ResultativeSubconstruction → Strin
   | .noncausativeProperty => "NoncausativeProperty"
   | .noncausativePath     => "NoncausativePath"
 
-/-- Derive the ArgStructureConstruction from a subconstruction.
+/-- Derive the construction from a subconstruction, its meaning pole the
+subconstruction's `MeaningComponents` contribution.
 
 Slots are determined by the two dimensions:
 - Causative: [NOUN subj, VERB head, NOUN obj, RP-UPOS rp]
 - Noncausative: [NOUN subj, VERB head, RP-UPOS rp] -/
 def ResultativeSubconstruction.toConstruction (sc : ResultativeSubconstruction) :
-    ArgStructureConstruction :=
-  let rpCat := sc.rpType.toUPOS
-  let rpRole := sc.rpType.roleLabel
-  let subjRole := if sc.isCausative then "agent" else "theme"
-  { construction :=
-      { name := s!"Resultative-{sc.nameSuffix}"
-      , form := if sc.isCausative then
-          [ { filler := .open_ .NOUN, role := some subjRole }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ .NOUN
-            , role := some (if sc.rpType == .property then "patient" else "theme") }
-          , { filler := .open_ rpCat, role := some rpRole } ]
-        else
-          [ { filler := .open_ .NOUN, role := some subjRole }
-          , { filler := .open_ .VERB, role := some "predicate", isHead := true }
-          , { filler := .open_ rpCat, role := some rpRole } ]
-      , meaning := match sc with
-          | .causativeProperty    => "X CAUSES Y to BECOME Z-state (via V-ing)"
-          | .causativePath        => "X CAUSES Y to GO to Z-location (via V-ing)"
-          | .noncausativeProperty => "X BECOMES Z-state (via V-ing)"
-          | .noncausativePath     => "X GOES to Z-location (via V-ing)" }
-  , hasHead := by cases sc <;> decide
-  , semanticContribution := sc.semanticContribution }
+    Construction MeaningComponents :=
+  { name := s!"Resultative-{sc.nameSuffix}"
+  , form := if sc.isCausative then
+      [ { filler := .open_ .NOUN }
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ .NOUN }
+      , { filler := .open_ sc.rpType.toUPOS } ]
+    else
+      [ { filler := .open_ .NOUN }
+      , { filler := .open_ .VERB, isHead := true }
+      , { filler := .open_ sc.rpType.toUPOS } ]
+  , meaning := sc.semanticContribution }
 
 /-- The composed meaning: verb MC fused with the subconstruction's contribution. -/
 def ResultativeEntry.fusedMC (e : ResultativeEntry) : MeaningComponents :=
@@ -599,7 +589,7 @@ def noncausativePropertyConstruction := ResultativeSubconstruction.noncausativeP
 def noncausativePathConstruction := ResultativeSubconstruction.noncausativePath.toConstruction
 
 /-- The full resultative family, derived from all four subconstructions. -/
-def resultativeFamily : List ArgStructureConstruction :=
+def resultativeFamily : List (Construction MeaningComponents) :=
   [ResultativeSubconstruction.causativeProperty,
    .causativePath, .noncausativeProperty, .noncausativePath].map (·.toConstruction)
 
@@ -625,9 +615,8 @@ def resultativeInheritance : List InheritanceLink :=
 /-- The [goldberg-jackendoff-2004] resultative family as a constructicon:
 the parent construction plus its four derived subconstructions and
 inheritance links. -/
-def resultativeNetwork : Constructicon :=
-  { constructions :=
-      resultative.construction :: resultativeFamily.map (·.construction)
+def resultativeNetwork : Constructicon MeaningComponents :=
+  { constructions := resultative :: resultativeFamily
   , links := resultativeInheritance }
 
 /-- Every derived link resolves to a member construction. -/
@@ -636,8 +625,8 @@ theorem resultativeNetwork_wellFormed : resultativeNetwork.WellFormed := by
 
 /-- The links determine each subconstruction's mother: the resultative. -/
 theorem subconstruction_parent (sc : ResultativeSubconstruction) :
-    resultativeNetwork.parentsOf sc.toConstruction.construction.name =
-      [resultative.construction] := by
+    resultativeNetwork.parentsOf sc.toConstruction.name =
+      [resultative] := by
   cases sc <;> decide
 
 /-- All inheritance links point to the same parent. -/
@@ -647,19 +636,19 @@ theorem all_inherit_from_resultative :
 
 /-- All four subconstructions are fully abstract (decomposable). -/
 theorem all_subconstructions_abstract :
-    resultativeFamily.all (λ c => c.construction.specificity == .fullyAbstract) = true := by
+    resultativeFamily.all (λ c => c.specificity == .fullyAbstract) = true := by
   decide
 
 /-- Causative subconstructions are transitive (4 slots);
     noncausative are intransitive (3 slots). -/
 theorem causative_are_transitive :
-    causativePropertyConstruction.slots.length = 4 ∧
-    causativePathConstruction.slots.length = 4 := by
+    causativePropertyConstruction.form.length = 4 ∧
+    causativePathConstruction.form.length = 4 := by
   constructor <;> decide
 
 theorem noncausative_are_intransitive :
-    noncausativePropertyConstruction.slots.length = 3 ∧
-    noncausativePathConstruction.slots.length = 3 := by
+    noncausativePropertyConstruction.form.length = 3 ∧
+    noncausativePathConstruction.form.length = 3 := by
   constructor <;> decide
 
 /-! Schema-decomposition theorems for the subconstruction family


### PR DESCRIPTION
Arc 3 of the ConstructionGrammar recut: `Construction Sem` replaces the untyped `meaning : String` / `pragmaticFunction : Option String` fields, with `pragmaticPoint : Bool` (FKO 1988 §1.1.4) as the typed pragmatics bit and `Construction.map` as the meaning-pole functor.

- `ArgStructureConstruction` dissolves into `Construction MeaningComponents` (its `hasHead` field had no consumers); `PolysemyFamily Sem` parameterized, the ditransitive's six senses typed as `TransferModality`
- KayMichaelis2019 goes fully typed: constructions' meaning poles ARE their composition rules (`Construction (CompositionRule (Den E))`), and the external `demoRules` equality-dispatch map dies
- `Slot.role : Option String` deleted (write-only decoration); cross-pole linking rides on `refIdx`
- studies without a closable typed meaning use `Construction Unit`, string glosses folded into docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)