### PR TITLE
docs(Syntax/ConstructionGrammar): mathlib docstring register

### DIFF
--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.ConstructionGrammar.Basic
 import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
@@ -5,18 +10,23 @@ import Linglib.Data.UD.Basic
 
 /-!
 # Argument Structure Constructions
-[goldberg-1995]
 
-CxG's argument structure constructions: explicit slot structure, full
-compositionality, polysemy families, and verb–construction fusion.
+An argument structure construction is an independent form–meaning
+pairing whose meaning pole records the meaning components it contributes
+beyond the verb ([goldberg-1995]); a verb appearing in the construction
+fuses its own components with them, which derives
+construction-dependent alternation behavior.
 
-Fully abstract constructions without pragmatic point are fully
-compositional (`isFullyCompositional`); constructions with idiosyncratic
-form–meaning pairings (*let alone*, WXDY, PAL) are irreducible phrasal
-patterns that only CxG can capture. The decomposition of fully abstract constructions into
-[mueller-2013]'s three universal combination schemata lives in
-`Studies/Mueller2013.lean` (`Mueller2013.decompose`).
+## Main definitions
 
+* `ditransitive`, `causedMotion`, `resultative`, `intransitiveMotion`,
+  `conative`: [goldberg-1995]'s constructions
+* `isFullyCompositional`: analyzable by the universal combination
+  schemata alone
+* `PolysemyFamily`, `goldberg1995Network`: one argument frame with many
+  senses, and the ch. 2–3 network
+* `composedMeaning`, `predictedAlternationInConstruction`:
+  verb–construction fusion
 -/
 
 namespace ConstructionGrammar
@@ -99,16 +109,10 @@ def conative : Construction MeaningComponents :=
 
 /-! ## Full compositionality -/
 
-/-- A construction is fully compositional if it has specificity `fullyAbstract`
-and no construction-specific pragmatic point.
-
-This is a proxy for [mueller-2013]'s structural criterion (whether the
-construction can be analyzed as a sequence of headed binary combinations).
-The proxy works because fully abstract constructions without pragmatic
-functions have no idiosyncratic form–meaning pairings that would resist
-decomposition into the three universal schemata. The Boolean approximates
-what [kay-michaelis-2019] survey as a continuum of constructional meaning
-contributions. -/
+/-- Whether a construction is analyzable by universal combination
+schemata alone: fully abstract form and no pragmatic point — a Boolean
+proxy for [mueller-2013]'s structural criterion, approximating what
+[kay-michaelis-2019] survey as a continuum. -/
 def isFullyCompositional {Sem : Type*} (c : Construction Sem) : Bool :=
   c.specificity == .fullyAbstract && !c.pragmaticPoint
 
@@ -152,8 +156,8 @@ def PolysemyFamily.centralConstruction (f : PolysemyFamily Sem) :
     Construction Sem :=
   { name := f.name, form := f.form, meaning := f.centralMeaning }
 
-/-- Build an extension construction. Uses the family's `form` — shared
-by construction, not by assertion. -/
+/-- An extension construction, sharing the family's `form`
+definitionally rather than by assertion. -/
 def PolysemyFamily.extensionConstruction (f : PolysemyFamily Sem)
     (ext : String × Sem × List String) : Construction Sem :=
   { name := f.name ++ "-" ++ ext.1, form := f.form, meaning := ext.2.1 }
@@ -168,7 +172,7 @@ def PolysemyFamily.allConstructions (f : PolysemyFamily Sem) :
     List (Construction Sem) :=
   f.centralConstruction :: f.extensionConstructions
 
-/-- Derive polysemy links from the family structure. -/
+/-- The polysemy links a family determines, one per extension. -/
 def PolysemyFamily.polysemyLinks (f : PolysemyFamily Sem) : List InheritanceLink :=
   f.extensions.map fun ⟨extName, _, overrides⟩ =>
     { parent := f.name
@@ -308,24 +312,15 @@ theorem PolysemyFamily.polysemyLinks_typed (f : PolysemyFamily Sem) :
 
 /-! ## Verb–construction fusion
 
-[goldberg-1995]'s central claim: argument structure constructions are
-independent form–meaning pairings. When a verb appears in a construction,
-its meaning **fuses** with the construction's meaning. The composed meaning
-can have properties neither has alone.
+A verb appearing in a construction fuses its meaning components with the
+construction's — componentwise, so the composed meaning can have
+properties neither has alone ([goldberg-1995]; [levin-2026]): *push*
+lacks change of state and causation, but *push* in the resultative
+acquires both, and the causative alternation is predicted. -/
 
-At the level of [levin-1993] meaning components, fusion is componentwise
-OR: if either the verb or the construction contributes a component, the
-composed meaning has it. This simple mechanism derives construction-dependent
-alternation behavior ([levin-2026]):
-
-- *push* alone: `{−CoS, +contact, +motion, −causation}` → no causative alternation
-- *push* + resultative: `{+CoS, +contact, +motion, +causation}` → causative alternation predicted
-
-The construction adds what the verb lacks; `predictedAlternation` on the
-fused result gives the correct prediction without any new alternation logic. -/
-
-/-- The composed meaning of a verb in an argument structure construction.
-    Verb root semantics fused with the construction's semantic contribution. -/
+/-- The composed meaning of a verb in an argument structure construction:
+the verb's meaning components fused with the construction's meaning
+pole. -/
 def composedMeaning (verbMC : MeaningComponents) (cxn : Construction MeaningComponents) :
     MeaningComponents :=
   verbMC.fuse cxn.meaning
@@ -359,13 +354,11 @@ theorem causedMotion_adds_motion_causation :
     causedMotion.meaning.motion = true ∧
     causedMotion.meaning.causation = true := ⟨rfl, rfl⟩
 
-/-! ### Key derivation: construction-dependent alternation
+/-! ### Construction-dependent alternation
 
-The payoff: `predictedAlternation` on fused components derives that manner
-verbs participate in the causative alternation inside the resultative, even
-though they cannot outside it. No new alternation logic is needed — the
-existing component-based prediction (`mc.changeOfState && mc.causation`)
-fires on the fused result. -/
+Manner verbs participate in the causative alternation inside the
+resultative but not outside it: the component-based prediction fires on
+the fused result, with no alternation logic specific to constructions. -/
 
 /-- A pure manner verb (no CoS, no causation) cannot alternate alone. -/
 theorem manner_verb_no_alternation (mc : MeaningComponents)
@@ -391,27 +384,21 @@ theorem hit_no_alternation_alone :
 
 /-! ### Multiple alternation flips from a single construction
 
-The key architectural insight: fusing a construction's components with a verb's
-components can flip *multiple* alternation predictions simultaneously. The
-resultative adds CoS + causation, which unlocks not just causativeInchoative but
-also middle, instrumentSubject, and the resultative alternation itself — all
-from the same mechanism, with no new alternation logic.
+Fusion can flip several alternation predictions at once: every
+alternation whose required components the augmented profile satisfies
+becomes available ([goldberg-1995]). -/
 
-This is the formal payoff of Goldbergian fusion ([goldberg-1995]):
-constructions don't just license one new alternation — they systematically
-augment the verb's meaning component profile, and every alternation whose
-required components are now satisfied becomes available. -/
-
-/-- Hit-class verbs alone: no middle, no instrumentSubject, no resultative alternation. -/
+/-- Hit-class verbs alone permit neither the middle, the
+instrument-subject, nor the resultative alternation. -/
 theorem hit_blocked_alone :
     MeaningComponents.hit.predictedAlternation .middle = false
     ∧ MeaningComponents.hit.predictedAlternation .instrumentSubject = false
     ∧ MeaningComponents.hit.predictedAlternation .resultative = false := by
   exact ⟨rfl, rfl, rfl⟩
 
-/-- Hit-class in resultative: ALL FOUR component-derived alternations flip.
-    The resultative adds CoS + causation → fused = ⟨true, true, true, true, false, false⟩.
-    This unlocks causativeInchoative, middle, instrumentSubject, AND resultative. -/
+/-- Hit-class verbs in the resultative permit all four component-derived
+alternations: the construction's change of state and causation complete
+the profile. -/
 theorem hit_resultative_full_profile :
     predictedAlternationInConstruction .hit resultative .causativeInchoative = true
     ∧ predictedAlternationInConstruction .hit resultative .middle = true

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -1,105 +1,89 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Data.UD.Basic
 import Mathlib.Data.List.Dedup
 
 /-!
 # Construction Grammar: Core Types
 
-Constructions — learned pairings of form and function ([goldberg-2006]) —
-are the basic units of grammatical knowledge in CxG. The form side is
-typed: a `TypedForm` is a sequence of `Slot`s, each fixing a lexeme,
-opening a category, or admitting any phrase ([dunn-2025]'s LEX/SYN/SEM
-slot-constraint levels, plus [kay-fillmore-1999]'s grammatical functions,
-coreference indices, and slot constraints). `Specificity` is *derived*
-from the slot structure (`Construction.specificity`), not stipulated.
+A construction is a learned pairing of a form and a meaning
+([goldberg-2006]), the basic unit of grammatical knowledge in CxG. The
+form side is a `TypedForm`: a sequence of `Slot`s, each fixing a lexeme,
+opening a category, or admitting any phrase, with a construction's
+`Specificity` derived from its slot structure rather than stipulated.
 
-A slot also records the bar level of its position; a `phrasal` filler in
-a `zero`-level position (`Slot.IsPhraseInWordSlot`) is the
-phrase-in-word-slot configuration of phrasal compounds and the PAL
-construction.
+## Main definitions
 
-## Main declarations
-
-- `SlotFiller`, `Slot`, `TypedForm`: the typed form side
-- `derivedSpecificity`, `HasConstraint`, `refGroupCount`: measures derived
+* `SlotFiller`, `Slot`, `TypedForm`: the typed form side
+* `derivedSpecificity`, `HasConstraint`, `refGroupCount`: measures derived
   from forms
-- `Construction`, `Construction.specificity`, `Construction.map`: typed
+* `Construction`, `Construction.specificity`, `Construction.map`: typed
   form–meaning pairings
-- `InheritanceLink`, `Constructicon`: the network
+* `InheritanceLink`, `Constructicon`: the network
 -/
 
 namespace ConstructionGrammar
 
-/-- How specified a construction's form side is: the degree-of-abstraction
-continuum of [goldberg-2003]:220, discretized as in [goldberg-shirtz-2025]'s
-Table 8.
-
-| Specificity | Example |
-|---|---|
-| lexicallySpecified | "veggie-wrap", "must-read" |
-| partiallyOpen | "N-wrap", "a simple ⟨PAL⟩" |
-| fullyAbstract | [N⁰ N⁰ N⁰], [N′ PAL⁰ N] |
--/
+/-- How specified a construction's form side is: [goldberg-2003]'s
+degree-of-abstraction continuum, discretized as in
+[goldberg-shirtz-2025]'s Table 8. -/
 inductive Specificity where
+  /-- Every slot lexically filled: *veggie-wrap*, *must-read*. -/
   | lexicallySpecified
+  /-- Fixed and open slots mixed: *N-wrap*, *a simple ⟨PAL⟩*. -/
   | partiallyOpen
+  /-- Every slot open: [N⁰ N⁰ N⁰], [N′ PAL⁰ N]. -/
   | fullyAbstract
   deriving Repr, DecidableEq
 
-/-- Mode of information transfer in an inheritance link
-([goldberg-1995] §3.3.1, p. 73–74).
-
-[goldberg-1995] distinguishes two modes, orthogonal to link type:
-- **Normal**: child inherits defaults from parent but may override them.
-  Allows subregularities and exceptions. The only mode used in
-  [goldberg-1995]'s system.
-- **Complete**: all information from dominating nodes is inherited strictly;
-  no conflicts allowed. The mode "normally assumed in unification-based
-  grammars" (p. 74, citing Kay 1984 and Fillmore & Kay 1993); the
-  normal/complete distinction follows Flickinger, Pollard & Wasow (1985).
-  Not exploited in [goldberg-1995]'s constructional analysis.
-
-Computational semantics for both modes: `ConstructionGrammar.Inheritance`. -/
+/-- Mode of information transfer in an inheritance link, orthogonal to
+the link's semantic relation ([goldberg-1995] §3.3.1, p. 73–74). -/
 inductive InheritanceMode where
-  | normal     -- child inherits defaults, may override
-  | complete   -- all properties inherited strictly (not used in Goldberg 1995)
+  /-- The child inherits defaults from its parents but may override
+  them — the only mode [goldberg-1995] uses. -/
+  | normal
+  /-- All information is inherited strictly, with no conflicts allowed —
+  the mode "normally assumed in unification-based grammars" (p. 74). -/
+  | complete
   deriving Repr, DecidableEq
 
-/-- Type of semantic relation in an inheritance link
-([goldberg-1995] §3.3.2, p. 75).
-
-[goldberg-1995] distinguishes four major link types:
-- **I_P (Polysemy)**: relates the central sense of a construction to its
-  extensions. Each extension inherits syntax but differs in meaning
-  (e.g., the six senses of the ditransitive, pp. 75–77).
-- **I_M (Metaphorical extension)**: source and target related by systematic
-  metaphor (e.g., caused-motion → resultative via the motion→change
-  metaphor, p. 81).
-- **I_S (Subpart)**: one construction is a proper subpart of another
-  (e.g., intransitive motion is a subpart of caused-motion, p. 78).
-- **I_I (Instance)**: one construction is a more fully specified version
-  of another (e.g., *drive*-crazy is an instance of the resultative, p. 79). -/
+/-- The semantic relation an inheritance link records: [goldberg-1995]'s
+four major link types (§3.3.2, p. 75). -/
 inductive LinkType where
-  | polysemy       -- I_P: central sense → extension
-  | metaphorical   -- I_M: source → target via metaphor
-  | subpart        -- I_S: child is proper subpart of parent
-  | instance       -- I_I: child is special case of parent
+  /-- I_P: relates a construction's central sense to an extension, which
+  inherits the syntax but differs in meaning (the six senses of the
+  ditransitive, pp. 75–77). -/
+  | polysemy
+  /-- I_M: source and target related by a systematic metaphor
+  (caused-motion → resultative via motion→change, p. 81). -/
+  | metaphorical
+  /-- I_S: the child is a proper subpart of the parent (intransitive
+  motion inside caused-motion, p. 78). -/
+  | subpart
+  /-- I_I: the child is a more fully specified version of the parent
+  (*drive*-crazy as an instance of the resultative, p. 79). -/
+  | instance
   deriving Repr, DecidableEq
 
 /-- X-bar level of a syntactic position or constructional output. -/
 inductive BarLevel where
-  | zero    -- X⁰
-  | bar     -- X′
-  | phrase  -- XP
+  /-- X⁰, a word-level position. -/
+  | zero
+  /-- X′, an intermediate projection. -/
+  | bar
+  /-- XP, a full phrase. -/
+  | phrase
   deriving DecidableEq, Repr
 
 /-! ### Typed slots
 
-[dunn-2025] distinguishes three representation levels for slot content —
-LEX (a fixed lexeme), SYN (any word of a category), SEM (any expression
-meeting a semantic constraint) — and [kay-fillmore-1999] add headed
-phrases, grammatical functions, coreference indices, and syntactic
-constraints. The `phrasal` filler (any phrase, no fixed head) is the
-filler type of phrasal compounds and PAL constructions. -/
+Slot content comes at [dunn-2025]'s three representation levels — LEX (a
+fixed lexeme), SYN (any word of a category), SEM (a semantic constraint) —
+plus [kay-fillmore-1999]'s headed phrases, grammatical functions,
+coreference indices, and slot constraints. -/
 
 /-- A slot's filler: the representation level of slot content.
 
@@ -123,11 +107,9 @@ inductive SlotFiller (Lex : Type*) where
   | phrasal : SlotFiller Lex
   deriving DecidableEq, Repr
 
-/-- Is this slot open (not lexically anchored)?
-
-`open_` (SYN), `semantic` (SEM+), and `phrasal` slots count as open for
-abstraction-level computation. `headed` slots do not: they fix the head
-lexeme even though the phrase is open. -/
+/-- Whether a slot is open — not lexically anchored: `open_`, `semantic`,
+and `phrasal` fillers count as open; `fixed` and `headed` do not, the
+latter fixing its head lexeme even though the phrase is open. -/
 def SlotFiller.isOpen {Lex : Type*} : SlotFiller Lex → Bool
   | .fixed _ => false
   | .open_ _ => true
@@ -135,14 +117,18 @@ def SlotFiller.isOpen {Lex : Type*} : SlotFiller Lex → Bool
   | .semantic _ => true
   | .phrasal => true
 
-/-- Grammatical function of a valence member ([kay-fillmore-1999], Figure 12).
-    Distinct from semantic role: a subject (gf) can be an agent, theme,
-    or experiencer (role). -/
+/-- Grammatical function of a valence member ([kay-fillmore-1999],
+Figure 12), distinct from semantic role: a subject can be an agent, a
+theme, or an experiencer. -/
 inductive GramFunction where
-  | subj   -- subject
-  | comp   -- complement (clausal/verbal)
-  | obj    -- direct object
-  | pred   -- predicative complement / secondary predicate
+  /-- Subject. -/
+  | subj
+  /-- Clausal or verbal complement. -/
+  | comp
+  /-- Direct object. -/
+  | obj
+  /-- Predicative complement or secondary predicate. -/
+  | pred
   deriving DecidableEq, Repr
 
 /-- Referential index for cross-slot coreference constraints. Slots
@@ -152,9 +138,12 @@ abbrev RefIndex := Nat
 
 /-- Syntactic constraint on a slot ([kay-fillmore-1999], Figure 12). -/
 inductive SlotConstraint where
-  | locMinus   -- [loc -]: must occur left-isolated, not VP-internal
-  | negMinus   -- [neg -]: cannot be negated
-  | refEmpty   -- [ref ∅]: nonreferential (no variable-binding function)
+  /-- [loc -]: must occur left-isolated, not VP-internal. -/
+  | locMinus
+  /-- [neg -]: cannot be negated. -/
+  | negMinus
+  /-- [ref ∅]: nonreferential — no variable-binding function. -/
+  | refEmpty
   deriving DecidableEq, Repr
 
 /-- A slot in a construction's form: filler content, headedness, and the
@@ -179,10 +168,10 @@ structure Slot (Lex : Type*) where
 /-- A typed form: the form side of a construction as a sequence of slots. -/
 abbrev TypedForm (Lex : Type*) := List (Slot Lex)
 
-/-- A phrase in a word-level slot: phrasal filler, zero-level position.
-The defining configuration of phrasal compounds and the PAL construction
-([goldberg-shirtz-2025]) — and the cell lexical-integrity hypotheses rule
-out. -/
+/-- A phrase in a word-level slot: phrasal filler, zero-level position —
+the defining configuration of phrasal compounds and the PAL construction
+([goldberg-shirtz-2025]), and the cell that lexical-integrity hypotheses
+rule out. -/
 def Slot.IsPhraseInWordSlot {Lex : Type*} (s : Slot Lex) : Prop :=
   s.filler = .phrasal ∧ s.level = some .zero
 
@@ -195,16 +184,9 @@ instance {Lex : Type*} [DecidableEq Lex] (s : Slot Lex) :
 section DerivedSpecificity
 variable {Lex : Type*}
 
-/-- Derive `Specificity` from the slot structure.
-
-| Condition | Result |
-|-----------|--------|
-| All slots open | `.fullyAbstract` |
-| No slots open | `.lexicallySpecified` |
-| Mix of fixed and open | `.partiallyOpen` |
-
-Changing a slot from open to fixed automatically changes the
-specificity. -/
+/-- The specificity of a form: `fullyAbstract` when every slot is open
+(vacuously so for the empty form), `lexicallySpecified` when none is,
+and `partiallyOpen` otherwise. -/
 def derivedSpecificity (form : TypedForm Lex) : Specificity :=
   let openCount := (form.filter (·.filler.isOpen)).length
   if openCount = form.length then .fullyAbstract
@@ -269,12 +251,10 @@ end DerivedSpecificity
 
 /-! ### Constructions and the network -/
 
-/-- A construction: a learned pairing of form and meaning. The form is a
-`TypedForm`; the meaning pole is typed by the domain that owns the
-construction — a composition rule, a `MeaningComponents` contribution, a
-presupposition — with `Unit` for a purely formal record or a defective,
-form-only construction. Specificity is derived from the form
-(`Construction.specificity`), not stipulated. -/
+/-- A construction: a learned pairing of form and meaning. The meaning
+pole is typed by the domain that owns the construction — a composition
+rule, a `MeaningComponents` contribution, a presupposition — with `Unit`
+for a purely formal record or a defective, form-only construction. -/
 structure Construction (Sem : Type*) where
   name : String
   form : TypedForm String
@@ -297,24 +277,30 @@ def Construction.map {Sem' : Type*} (f : Sem → Sem') (c : Construction Sem) :
   { name := c.name, form := c.form, meaning := f c.meaning
   , pragmaticPoint := c.pragmaticPoint }
 
-/-- An inheritance link between two constructions in the network.
-
-Each link specifies both how information flows (`mode`, §3.3.1) and
-what semantic relation holds (`linkType`, §3.3.2). Links without a
-specific semantic relation (e.g., general taxonomic inheritance of
-shared morphophonological properties) use `linkType := none`. -/
+/-- An inheritance link between two constructions in the network,
+recording how information flows and what semantic relation holds; purely
+taxonomic links use `linkType := none`. -/
 structure InheritanceLink where
+  /-- Name of the parent construction. -/
   parent : String
+  /-- Name of the child construction. -/
   child : String
+  /-- How information flows along the link. -/
   mode : InheritanceMode
+  /-- The semantic relation the link records, if any. -/
   linkType : Option LinkType := none
+  /-- Properties the child inherits from the parent. -/
   sharedProperties : List String
+  /-- Inherited properties the child overrides. -/
   overriddenProperties : List String := []
   deriving Repr, DecidableEq
 
-/-- A constructicon: a network of constructions connected by inheritance links. -/
+/-- A constructicon: a network of constructions connected by inheritance
+links. -/
 structure Constructicon (Sem : Type*) where
+  /-- The inventory of constructions. -/
   constructions : List (Construction Sem)
+  /-- The inheritance links, keyed by construction name. -/
   links : List InheritanceLink
   deriving Repr
 

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Core.Order.Flat
 import Linglib.Syntax.ConstructionGrammar.Basic
 

--- a/Linglib/Syntax/ConstructionGrammar/Licensing.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Licensing.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.ConstructionGrammar.Basic
 
 /-!

--- a/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Resultatives.lean
@@ -1,43 +1,32 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.ArgumentStructure.EventStructure
 import Linglib.Semantics.ArgumentStructure.Linking
 
 /-!
-# ConstructionGrammar.Resultatives — Theory of the resultative construction family
-[goldberg-jackendoff-2004]
+# The resultative construction family
 
-Theory-side primitives for the four-way resultative construction family
-(causative/noncausative × property/path RP), the dual subevent structure,
-typed verbal/constructional subevent relations, and the compositional
-fusion machinery linking verb meaning to constructional contribution.
+[goldberg-jackendoff-2004]'s four-way resultative family — causative or
+noncausative, with a property or path result phrase — as a dual subevent
+structure: a verbal subevent related to a constructional subevent, with
+fusion linking verb meaning to constructional contribution.
 
-Paper data and per-datum verifications for [goldberg-jackendoff-2004]
-itself live in `Studies/GoldbergJackendoff2004.lean`,
-which imports this file.
+## Main definitions
 
-## Core types
-
-- `SubeventKind`, `SubeventRelation`, `RPType`, `Boundedness`,
-  `ObjectSelection`, `TemporalOrder`
-- `ResultativeSubconstruction` — the 2×2 family
-- `SubeventDesc`, `DualSubevent` — event-structural features
-- `ResultativeEntry` — schema for any resultative datum
-- `ArgSource` — argument-fusion bookkeeping
-
-## Key derivations (no per-paper data)
-
-- `ResultativeSubconstruction.constructionalDesc` — derived hasCause/hasBecome
-- `resultativeAspect`, `resultativeVendlerClass` — bounded RP → telic
-- `adjScaleToRPBoundedness` — Kennedy 2007 scale → G&J boundedness
-- `ResultativeSubconstruction.toConstruction` — derived family of
-  derived construction family + `inheritanceLink`
-- `farSatisfied`, `rolesCoherent`, `temporalConstraintSatisfied` —
-  the three substantive constraints (Principles 37, 44, §4.2)
-
-The fusion theorems (`alternation_chain`, `noncausative_partial_chain`,
-`instrumentSpec_blocks_across_subconstructions`, etc.) are universally
-quantified over arbitrary `MeaningComponents` and `ResultativeSubconstruction`.
+* `ResultativeSubconstruction`: the 2 × 2 family, with its derived
+  subevent structure (`constructionalDesc`) and constructions
+  (`toConstruction`, `resultativeNetwork`)
+* `SubeventDesc`, `DualSubevent`, `SubeventRelation`: dual subevent
+  structure
+* `ResultativeEntry`, `ResultativeEntry.fusedMC`: a verb in a
+  subconstruction, and its fused meaning
+* `farSatisfied`, `rolesCoherent`, `temporalConstraintSatisfied`: the
+  paper's three substantive constraints
 -/
 
 namespace ConstructionGrammar.Resultatives
@@ -56,33 +45,23 @@ inductive SubeventKind where
   | constructional
   deriving Repr, DecidableEq
 
-/-- How the verbal and constructional subevents are related (§3 of
-[goldberg-jackendoff-2004]).
-
-- **means**: The verbal subevent is the means by which the constructional subevent
-  is brought about. This is the default relation for all four core subconstructions
-  (97a–d). E.g., "hammer metal flat" — hammering is the means of causing flatness.
-  Also holds for noncausative cases: "the pond froze solid" — freezing is the
-  means of becoming solid; "the ball rolled down the hill" — rolling is the
-  means of motion along the path.
-- **result**: The verbal subevent is a result of the constructional subevent
-  (reversed directionality from means). Reserved for sound-emission resultatives
-  (schema 20; ex. 17a: "The trolley rumbled through the tunnel" — the sound
-  results from the motion) and disappearance resultatives (ex. 21a: "The witch
-  vanished into the forest").
-- **instance_**: The verbal subevent is an instance of the constructional subevent.
-  For the follow-type cases (§7.1, schema 55; ex. 50a: "Bill followed the thief
-  into the library" — following IS going-after) and *take* under schema 56;
-  the ride/drive cases of 56 (ex. 58a: "Bill rode a train to New York") are
-  instead means of going-by-way-of.
-- **coOccurrence**: The two subevents merely co-occur without causal connection.
-  The *way* construction (ex. 19a: "The car honked its way down the road") uses
-  this relation. Some speakers accept COOCCURRENCE for sound-emission
-  resultatives as well. -/
+/-- How the verbal and constructional subevents are related
+([goldberg-jackendoff-2004] §3). -/
 inductive SubeventRelation where
+  /-- The verbal subevent is the means of the constructional one — the
+  default for all four core subconstructions: in "hammer the metal flat",
+  hammering is the means of causing flatness. -/
   | means
+  /-- The verbal subevent results from the constructional one, as in
+  sound-emission ("the trolley rumbled through the tunnel", ex. 17a) and
+  disappearance resultatives (ex. 21a). -/
   | result
+  /-- The verbal subevent is an instance of the constructional one, as in
+  the *follow*-type cases ("Bill followed the thief into the library",
+  ex. 50a). -/
   | instance_
+  /-- The subevents merely co-occur, as in the *way* construction ("the
+  car honked its way down the road", ex. 19a). -/
   | coOccurrence
   deriving Repr, DecidableEq
 
@@ -94,13 +73,9 @@ inductive RPType where
   | path
   deriving Repr, DecidableEq
 
-/-- The four subconstructions in the resultative family
-([goldberg-jackendoff-2004] §2, summarized as (97)).
-
-|               | Property RP      | Path RP          |
-|---------------|------------------|------------------|
-| **Causative** | causativeProperty | causativePath   |
-| **Noncausative** | noncausativeProperty | noncausativePath | -/
+/-- The four subconstructions of the resultative family: causative or
+noncausative, crossed with a property or path result phrase
+([goldberg-jackendoff-2004] §2, summarized as (97)). -/
 inductive ResultativeSubconstruction where
   | causativeProperty
   | causativePath
@@ -122,7 +97,7 @@ def ResultativeSubconstruction.isPropertyRP : ResultativeSubconstruction → Boo
   | .noncausativeProperty => true
   | .noncausativePath => false
 
-/-- Get the RP type of a subconstruction. -/
+/-- The RP type of a subconstruction. -/
 def ResultativeSubconstruction.rpType : ResultativeSubconstruction → RPType
   | .causativeProperty => .property
   | .causativePath => .path
@@ -164,8 +139,8 @@ noncausative subconstructions have BECOME only. Verbal subevents are always
 bare (no CAUSE, no BECOME) — the manner comes from the verb's lexical
 semantics, not from event-structural operators. -/
 
-/-- Derive the constructional subevent description from the subconstruction.
-    This replaces per-entry stipulation: causative ↔ hasCause, all have hasBecome. -/
+/-- The constructional subevent description a subconstruction
+determines: CAUSE exactly for the causatives, BECOME for all four. -/
 def ResultativeSubconstruction.constructionalDesc : ResultativeSubconstruction → SubeventDesc
   | .causativeProperty    => { hasCause := true,  hasBecome := true }
   | .causativePath        => { hasCause := true,  hasBecome := true }
@@ -264,16 +239,9 @@ def ResultativeSubconstruction.defaultObjectSelection :
 
 /-! ## Resultative entry -/
 
-/-- A resultative entry: verb + subconstruction + aspect.
-
-The dual subevent structure is derived from the subconstruction:
-- verbal desc: always `verbalSubeventDesc` (bare manner/activity)
-- constructional desc: `subconstruction.constructionalDesc`
-The subevent relation defaults to MEANS for all four core subconstructions;
-RESULT is used only for sound-emission and disappearance subtypes.
-
-The Levin class enables compositional fusion: `verbMC.fuse cxn.semanticContribution`
-derives predictions about alternation participation. -/
+/-- A resultative entry: a verb in a subconstruction, with aspectual and
+selectional features. The dual subevent structure is derived from the
+subconstruction, and the Levin class feeds compositional fusion. -/
 structure ResultativeEntry where
   /-- The verb form -/
   verb : String
@@ -291,7 +259,7 @@ structure ResultativeEntry where
   levinClass : LevinClass
   deriving Repr, BEq
 
-/-- Derive the full dual subevent structure from the entry. -/
+/-- The dual subevent structure of an entry. -/
 def ResultativeEntry.dualSubevent (e : ResultativeEntry) : DualSubevent :=
   { verbal := verbalSubeventDesc
   , constructional := e.subconstruction.constructionalDesc
@@ -308,7 +276,7 @@ The resultative's aspect is derived compositionally:
 - Always durative (extends over time)
 - Telic iff the RP denotes a bounded path/property -/
 
-/-- Derive the aspectual profile of a resultative from RP boundedness. -/
+/-- The aspectual profile of a resultative, from RP boundedness. -/
 def resultativeAspect (b : Boundedness) : AspectualProfile :=
   { telicity := match b with
       | .bounded => .telic
@@ -316,7 +284,7 @@ def resultativeAspect (b : Boundedness) : AspectualProfile :=
   , duration := .durative
   , dynamicity := .dynamic }
 
-/-- Derive the Vendler class of a resultative. -/
+/-- The Vendler class of a resultative. -/
 def resultativeVendlerClass (b : Boundedness) : VendlerClass :=
   (resultativeAspect b).toVendlerClass
 
@@ -462,7 +430,7 @@ the parent `resultative` in ArgumentStructure.lean); noncausative ones
 contribute only CoS (BECOME without CAUSE). This is consistent with the
 `constructionalDesc`: `hasCause ↔ causation`, `hasBecome ↔ changeOfState`. -/
 
-/-- Derive the meaning components contributed by a subconstruction.
+/-- The meaning components a subconstruction contributes.
     Causative: CoS + causation (same as parent `resultative`).
     Noncausative: CoS only (BECOME without CAUSE). -/
 def ResultativeSubconstruction.semanticContribution :
@@ -558,7 +526,7 @@ def ResultativeSubconstruction.nameSuffix : ResultativeSubconstruction → Strin
   | .noncausativeProperty => "NoncausativeProperty"
   | .noncausativePath     => "NoncausativePath"
 
-/-- Derive the construction from a subconstruction, its meaning pole the
+/-- The construction a subconstruction determines, its meaning pole the
 subconstruction's `MeaningComponents` contribution.
 
 Slots are determined by the two dimensions:
@@ -582,10 +550,16 @@ def ResultativeSubconstruction.toConstruction (sc : ResultativeSubconstruction) 
 def ResultativeEntry.fusedMC (e : ResultativeEntry) : MeaningComponents :=
   composedMeaning e.verbMC e.subconstruction.toConstruction
 
-/-- Convenience aliases for downstream compatibility. -/
+/-- The causative property resultative as a construction. -/
 def causativePropertyConstruction := ResultativeSubconstruction.causativeProperty.toConstruction
+
+/-- The causative path resultative as a construction. -/
 def causativePathConstruction := ResultativeSubconstruction.causativePath.toConstruction
+
+/-- The noncausative property resultative as a construction. -/
 def noncausativePropertyConstruction := ResultativeSubconstruction.noncausativeProperty.toConstruction
+
+/-- The noncausative path resultative as a construction. -/
 def noncausativePathConstruction := ResultativeSubconstruction.noncausativePath.toConstruction
 
 /-- The full resultative family, derived from all four subconstructions. -/
@@ -593,7 +567,7 @@ def resultativeFamily : List (Construction MeaningComponents) :=
   [ResultativeSubconstruction.causativeProperty,
    .causativePath, .noncausativeProperty, .noncausativePath].map (·.toConstruction)
 
-/-- Derive an inheritance link from a subconstruction to the parent. -/
+/-- The inheritance link from a subconstruction to the parent resultative. -/
 def ResultativeSubconstruction.inheritanceLink (sc : ResultativeSubconstruction) :
     InheritanceLink :=
   let transStr := if sc.isCausative then "transitive" else "intransitive"


### PR DESCRIPTION
Register pass over the six substrate files, calibrated against Probability/Kernel/Defs and RingTheory/Bialgebra/GroupLike: module docstrings open by defining the object with one-clause Main-definitions bullets; declaration docstrings are 1–3 object-first sentences with trailing citations; constructor trailing comments become docstrings; tables, bold rhetoric, payoff narration, and the dangling Mueller2013 file pointer removed; copyright headers added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)