### PR TITLE
docs(Syntax/ConstructionGrammar): content-named module titles

### DIFF
--- a/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
+++ b/Linglib/Syntax/ConstructionGrammar/ArgumentStructure.lean
@@ -9,13 +9,16 @@ import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
 import Linglib.Data.UD.Basic
 
 /-!
-# Argument Structure Constructions
+# Argument structure in Construction Grammar
 
-An argument structure construction is an independent form–meaning
-pairing whose meaning pole records the meaning components it contributes
-beyond the verb ([goldberg-1995]); a verb appearing in the construction
-fuses its own components with them, which derives
-construction-dependent alternation behavior.
+[goldberg-1995]'s account of argument structure: clausal argument
+realization is not projected from verb entries alone but contributed by
+independent form–meaning pairings — argument structure constructions —
+whose meaning pole records the components they add beyond the verb. A
+verb appearing in a construction fuses its components with the
+construction's, deriving alternation behavior the verb lacks in
+isolation, and the constructions themselves form a network of polysemy
+and inheritance links.
 
 ## Main definitions
 

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -7,7 +7,7 @@ import Linglib.Data.UD.Basic
 import Mathlib.Data.List.Dedup
 
 /-!
-# Construction Grammar: Core Types
+# Constructions and the constructicon
 
 A construction is a learned pairing of a form and a meaning
 ([goldberg-2006]), the basic unit of grammatical knowledge in CxG. The

--- a/Linglib/Syntax/ConstructionGrammar/Idiom.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Idiom.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Syntax.ConstructionGrammar.Basic
 
 /-!
-# Construction Grammar: Idioms
+# Idiom classification
 
 An idiomatic expression is something a language user could fail to know
 while knowing everything else in the language ([fillmore-kay-oconnor-1988]

--- a/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Inheritance.lean
@@ -7,7 +7,7 @@ import Linglib.Core.Order.Flat
 import Linglib.Syntax.ConstructionGrammar.Basic
 
 /-!
-# Construction Grammar: Inheritance Modes
+# Constructional inheritance
 
 Computational content for the two modes of constructional inheritance
 distinguished by [goldberg-1995] §3.3.1 (the `InheritanceMode` enum in

--- a/Linglib/Syntax/ConstructionGrammar/Licensing.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Licensing.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Syntax.ConstructionGrammar.Basic
 
 /-!
-# Construction Grammar: Licensing
+# Constructional licensing
 
 The licensing model of constructional grammar ([sag-2012]; [goldberg-1995]):
 an utterance token is grammatical iff every constituent in it instantiates


### PR DESCRIPTION
Module titles name the content, not the file's architectural role or directory: Basic → "Constructions and the constructicon", Idiom → "Idiom classification", Licensing → "Constructional licensing", Inheritance → "Constructional inheritance"; ArgumentStructure retitled "Argument structure in Construction Grammar" with an opener stating the account's thesis (realization not projected from verb entries alone), per Goldberg 1995's own subtitle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)