### PR TITLE
feat(Syntax/ConstructionGrammar): composition + Michaelis 2004 coercion

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2458,6 +2458,7 @@ import Linglib.Studies.McCollumEtAl2020
 import Linglib.Studies.McKayVanInwagen1977
 import Linglib.Studies.McMullin2016
 import Linglib.Studies.McNallyDeSwart2011
+import Linglib.Studies.Michaelis2004
 import Linglib.Studies.McPhersonLamont2026
 import Linglib.Studies.MeinhardtEtAl2024
 import Linglib.Studies.Mendes2025
@@ -2802,6 +2803,7 @@ import Linglib.Syntax.Clause.Construction
 import Linglib.Syntax.Comparative
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Syntax.ConstructionGrammar.Basic
+import Linglib.Syntax.ConstructionGrammar.Composition
 import Linglib.Syntax.ConstructionGrammar.Idiom
 import Linglib.Syntax.ConstructionGrammar.Inheritance
 import Linglib.Syntax.ConstructionGrammar.Licensing

--- a/Linglib/Studies/KayMichaelis2019.lean
+++ b/Linglib/Studies/KayMichaelis2019.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.ConstructionGrammar.Licensing
+import Linglib.Syntax.ConstructionGrammar.Composition
 import Linglib.Syntax.ConstructionGrammar.ArgumentStructure
 import Linglib.Studies.FillmoreKayOConnor1988
 
@@ -59,38 +59,9 @@ inductive MeaningKind where
 
 "The construction also specifies how the semantics of the daughters are
 combined to produce the semantics of the mother, and what additional
-semantics, if any, is contributed by the construction itself." -/
-
-/-- A composition rule: from the daughters' denotations to the mother's,
-partial because a rule demands daughter denotations of the right shape. -/
-abbrev CompositionRule (D : Type*) := List D → Option D
-
-mutual
-
-/-- All readings of a token: each construction whose typed form the
-daughters instantiate contributes the readings its meaning pole — its
-composition rule — produces from the daughters' readings; words read
-from the lexicon. -/
-def _root_.ConstructionGrammar.Constructicon.interps {D : Type*}
-    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
-    (lex : String → Option D) : Token → List D
-  | .word w => (lex w).toList
-  | .node ts =>
-      cx.constructions.flatMap (λ c =>
-        if formMatches pos c.form ts then
-          (cx.interpsList pos lex ts).filterMap c.meaning
-        else [])
-
-/-- All sequences of daughter readings. -/
-def _root_.ConstructionGrammar.Constructicon.interpsList {D : Type*}
-    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
-    (lex : String → Option D) : List Token → List (List D)
-  | [] => [[]]
-  | t :: ts =>
-      (cx.interps pos lex t).flatMap (λ d =>
-        (cx.interpsList pos lex ts).map (d :: ·))
-
-end
+semantics, if any, is contributed by the construction itself" — the
+`CompositionRule` architecture of
+`ConstructionGrammar.Composition`, instantiated below. -/
 
 /-! ### §1: *purple plum* vs. *alleged thief*
 

--- a/Linglib/Studies/Michaelis2004.lean
+++ b/Linglib/Studies/Michaelis2004.lean
@@ -1,0 +1,189 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.ConstructionGrammar.Composition
+import Linglib.Features.Aktionsart
+
+/-!
+# [michaelis-2004]: Type Shifting in Construction Grammar
+
+Aspectual coercion without interpolated coercion operators: constructions
+denote semantic types, and the override principle — "if a lexical item is
+semantically incompatible with its morphosyntactic context, the meaning
+of the lexical item conforms to the meaning of the structure in which it
+is embedded" ((20)) — resolves mismatches in favor of the construction.
+Concord constructions denote the type they select ((27)); shift
+constructions denote a different one ((28)); both perform implicit
+type-shifting via the override, and only shift constructions shift
+explicitly (Table 3).
+
+## Main declarations
+
+- `Michaelis2004.inchoativeAddition`, `onsetSelection`,
+  `conformToActivity`: the reconciliation operators
+- `Michaelis2004.frameAdverbial` (concord, Figure 5) and
+  `Michaelis2004.progressive` (shift, Figure 6), meaning poles their
+  composition rules
+- `Michaelis2004.frame_adverbial_activity_ambiguity`: the two readings of
+  ex. (41), derived from the two operators
+- `Michaelis2004.progressive_stativizes`: progressive predications denote
+  states whatever the complement's Aktionsart
+-/
+
+namespace Michaelis2004
+
+open ConstructionGrammar
+open Features
+
+/-! ### Reconciliation operators
+
+The override principle repairs a type mismatch by one of the paper's
+reconciliation operations on the input's aspectual representation. -/
+
+/-- The addition operator under inchoative construal (§5.1.2): a change
+is added to the causal representation, so a state yields the achievement
+of its onset — "They were bored in a minute" denotes the onset of
+boredom — and an activity a bounded accomplishment. Other types are left
+as they are. -/
+def inchoativeAddition (p : AspectualProfile) : AspectualProfile :=
+  if p.dynamicity = .stative then achievementProfile
+  else if p = activityProfile then accomplishmentProfile
+  else p
+
+/-- The selection operator (§5.1.2): the onset phase of a durative
+situation is selected, an achievement — ex. (41)'s reading on which the
+frame measures the delay before the program began to air. -/
+def onsetSelection (p : AspectualProfile) : AspectualProfile :=
+  if p.duration = .durative then achievementProfile else p
+
+/-- The reconciliation operators available to the frame adverbial. -/
+def reconciliation : List (AspectualProfile → AspectualProfile) :=
+  [inchoativeAddition, onsetSelection]
+
+/-- The progressive's complement is inherently processual (§5.2.1): the
+override conforms any input to the activity type — states via the
+addition of `hold` and an effector to their causal representation, telic
+events via their processual construal. -/
+def conformToActivity : AspectualProfile → AspectualProfile :=
+  fun _ => activityProfile
+
+/-! ### The frame adverbial construction (Figure 5, concord) -/
+
+/-- The frame adverbial's composition rule: the `within` frame demands a
+telic event and the construct denotes that same type. -/
+def frameAdverbialRule : CompositionRule AspectualProfile
+  | [p] => if p.telicity = .telic then some p else none
+  | _ => none
+
+/-- The frame adverbial construction (Figure 5): an *in*-headed adjunct
+added to the verbal valence. -/
+def frameAdverbial : Construction (CompositionRule AspectualProfile) :=
+  { name := "Frame adverbial"
+  , form :=
+      [ { filler := .open_ .VERB, isHead := true }
+      , { filler := .fixed "in" }
+      , { filler := .open_ .NOUN } ]
+  , meaning := frameAdverbialRule }
+
+/-! ### The progressive construction (Figure 6, shift) -/
+
+/-- The progressive's composition rule: an activity complement yields the
+state holding during the activity's interval, by selection of an
+intermediate rest in its temporal representation. -/
+def progressiveRule : CompositionRule AspectualProfile
+  | [p] => if p = activityProfile then some stateProfile else none
+  | _ => none
+
+/-- The progressive construction (Figure 6): auxiliary *be* with a
+participial complement whose subject unifies with the auxiliary's — an
+instance of [kay-fillmore-1999]'s coinstantiation construction. -/
+def progressive : Construction (CompositionRule AspectualProfile) :=
+  { name := "Progressive"
+  , form :=
+      [ { filler := .open_ .NOUN, gf := some .subj, refIdx := some 1 }
+      , { filler := .headed "be" .AUX, isHead := true }
+      , { filler := .open_ .VERB, gf := some .comp, refIdx := some 1 } ]
+  , meaning := progressiveRule }
+
+/-- Figure 6's raising property: the subject of *be* and the complement's
+subject form one coreference group, the coinstantiation pattern. -/
+theorem progressive_coinstantiation : refGroupCount progressive.form = 1 := by
+  decide
+
+/-! ### Concord vs. shift ((27), (28)) -/
+
+/-- A unary rule preserves type when its output type is its input's —
+(27)'s concord constructions; (28)'s shift constructions fail it. -/
+def PreservesType (r : CompositionRule AspectualProfile) : Prop :=
+  ∀ p q, r [p] = some q → q = p
+
+/-- The frame adverbial is a concord construction: it denotes the telic
+event type it selects. -/
+theorem frameAdverbial_concord : PreservesType frameAdverbialRule := by
+  intro p q h
+  simp only [frameAdverbialRule] at h
+  split at h
+  · exact (Option.some_inj.mp h).symm
+  · exact absurd h (by simp)
+
+/-- The progressive is a shift construction: it selects activities but
+denotes states. -/
+theorem progressive_shift : ¬ PreservesType progressiveRule := fun h =>
+  absurd (h activityProfile stateProfile (by decide)) (by decide)
+
+/-! ### Frame-adverbial predictions (§5.1.2) -/
+
+/-- "She solved the problem in ten minutes" (Figure 5's instantiation): a
+telic complement composes directly, with no coercion ambiguity. -/
+theorem frame_adverbial_instantiation :
+    frameAdverbialRule.override reconciliation [accomplishmentProfile]
+      = [accomplishmentProfile] :=
+  CompositionRule.override_eq_of_eq_some _ (by decide)
+
+/-- Ex. (30), "They were bored in a minute": the stative input conforms
+by inchoative construal — the onset of boredom, an achievement. -/
+theorem frame_adverbial_coerces_state :
+    frameAdverbialRule.override reconciliation [stateProfile]
+      = [achievementProfile] := by decide
+
+/-- Ex. (41), "My radio program ran in less than four minutes": an
+activity input is genuinely ambiguous — inchoative addition yields the
+accomplishment reading (the frame measures the running time), onset
+selection the achievement reading (the frame measures the delay before
+airing) — [de-swart-1998]'s observation, derived from the operator
+inventory. -/
+theorem frame_adverbial_activity_ambiguity :
+    frameAdverbialRule.override reconciliation [activityProfile]
+      = [accomplishmentProfile, achievementProfile] := by decide
+
+/-! ### Progressive predictions (§5.2.1) -/
+
+/-- "We were playing cards" (Figure 6's explicit shift): an activity
+complement yields a state directly. -/
+theorem progressive_explicit :
+    progressiveRule [activityProfile] = some stateProfile := by decide
+
+/-- Exx. (31), (42)–(44), "We were living in Boulder": a stative
+complement conforms to the activity type and the predication is again a
+state — the "temporary state" reading. -/
+theorem progressive_coerces_state :
+    progressiveRule.override [conformToActivity] [stateProfile]
+      = [stateProfile] := by decide
+
+/-- "They were baking a cake": a telic complement is construed as its
+process, so the culmination is not entailed. -/
+theorem progressive_coerces_telic :
+    progressiveRule.override [conformToActivity] [accomplishmentProfile]
+      = [stateProfile] := by decide
+
+/-- Progressive predications denote states whatever the Aktionsart of the
+complement (§5.2.1): the apparent paradox of a stativizing construction
+accepting stative input dissolves under the override. -/
+theorem progressive_stativizes (p : AspectualProfile) :
+    progressiveRule.override [conformToActivity] [p] = [stateProfile] := by
+  obtain ⟨t, d, dyn⟩ := p
+  cases t <;> cases d <;> cases dyn <;> decide
+
+end Michaelis2004

--- a/Linglib/Syntax/ConstructionGrammar/Composition.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Composition.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Linglib.Syntax.ConstructionGrammar.Licensing
+
+/-!
+# Construction-relative composition
+
+Rules of semantic combination are construction-relative: a construction
+"specifies how the semantics of the daughters are combined to produce the
+semantics of the mother, and what additional semantics, if any, is
+contributed by the construction itself" ([kay-michaelis-2019] §4). A
+composition rule is partial — it demands daughter denotations of the
+right shape — and mismatches are repaired by the override principle
+([michaelis-2004], (20)): the lexical item conforms to the meaning of the
+structure in which it is embedded.
+
+## Main definitions
+
+* `CompositionRule`: from the daughters' denotations to the mother's
+* `CompositionRule.override`: readings under the override principle, one
+  per reconciliation operator
+* `Constructicon.interps`: all readings of a token, through the licensing
+  recognizer
+-/
+
+namespace ConstructionGrammar
+
+variable {D : Type*}
+
+/-- A composition rule: from the daughters' denotations to the mother's,
+partial because a rule demands daughter denotations of the right shape
+([kay-michaelis-2019] §4). -/
+abbrev CompositionRule (D : Type*) := List D → Option D
+
+/-- Readings under the override principle ([michaelis-2004], (20)): the
+rule's own output where the daughters already conform, and otherwise one
+reading per reconciliation operator that makes them conform. Distinct
+operators yielding distinct repairs produce genuine ambiguity. -/
+def CompositionRule.override [DecidableEq D] (r : CompositionRule D)
+    (shifts : List (D → D)) (ds : List D) : List D :=
+  match r ds with
+  | some d => [d]
+  | none => (shifts.filterMap fun s => r (ds.map s)).dedup
+
+/-- Conforming daughters are composed directly: implicit type-shifting
+occurs only on mismatch ([michaelis-2004], Table 3). -/
+theorem CompositionRule.override_eq_of_eq_some [DecidableEq D]
+    {r : CompositionRule D} {ds : List D} {d : D} (shifts : List (D → D))
+    (h : r ds = some d) : r.override shifts ds = [d] := by
+  simp [CompositionRule.override, h]
+
+/-- With no reconciliation operators, a mismatch has no readings. -/
+@[simp]
+theorem CompositionRule.override_nil [DecidableEq D]
+    (r : CompositionRule D) (ds : List D) :
+    r.override [] ds = (r ds).toList := by
+  cases h : r ds <;> simp [CompositionRule.override, h]
+
+mutual
+
+/-- All readings of a token: each construction whose typed form the
+daughters instantiate contributes the readings its meaning pole — its
+composition rule — produces from the daughters' readings; words read
+from the lexicon. -/
+def Constructicon.interps {D : Type*}
+    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
+    (lex : String → Option D) : Token → List D
+  | .word w => (lex w).toList
+  | .node ts =>
+      cx.constructions.flatMap (λ c =>
+        if formMatches pos c.form ts then
+          (cx.interpsList pos lex ts).filterMap c.meaning
+        else [])
+
+/-- All sequences of daughter readings. -/
+def Constructicon.interpsList {D : Type*}
+    (cx : Constructicon (CompositionRule D)) (pos : String → Option UD.UPOS)
+    (lex : String → Option D) : List Token → List (List D)
+  | [] => [[]]
+  | t :: ts =>
+      (cx.interps pos lex t).flatMap (λ d =>
+        (cx.interpsList pos lex ts).map (d :: ·))
+
+end
+
+end ConstructionGrammar

--- a/references.bib
+++ b/references.bib
@@ -7367,6 +7367,20 @@
   role      = {cited},
   validated = {true},
   sources   = {Studies/Solt2018Proportional.lean}
+}
+@article{michaelis-2004,
+  author    = {Michaelis, Laura A.},
+  year      = {2004},
+  title     = {Type Shifting in Construction Grammar: {An} Integrated Approach to Aspectual Coercion},
+  journal   = {Cognitive Linguistics},
+  volume    = {15},
+  number    = {1},
+  pages     = {1--67},
+  doi       = {10.1515/cogl.2004.001},
+  subfield  = {semantics/aspect},
+  role      = {formalized},
+  validated = {true},
+  sources   = {Studies/Michaelis2004.lean;Syntax/ConstructionGrammar/Composition.lean}
 }% REF: Franke, M. & Jäger, G. (2016). Probabilistic pragmatics.
 @article{gotham-2017,
   author    = {Gotham, Matthew},


### PR DESCRIPTION
Arc 4 of the ConstructionGrammar recut: `Composition.lean` graduates KayMichaelis2019's `CompositionRule`/`Constructicon.interps` (second consumer landed) and adds `CompositionRule.override` — Michaelis 2004's override principle as a reconciliation combinator returning one reading per operator, with conservativity (implicit shifting only on mismatch, her Table 3).

- `Studies/Michaelis2004.lean`: frame adverbial (concord, Fig. 5) and progressive (shift, Fig. 6) with composition rules as meaning poles; de Swart's two-reading ambiguity of "my radio program ran in less than four minutes" derived from the addition/selection operator inventory; progressive predications proved stative for every complement Aktionsart; Fig. 6's coinstantiation coindexation checked
- reconciliation operators built on `Features.Aktionsart`'s existing `AspectualProfile` shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)