### PR TITLE
fix(Studies/Benz2025): reground against dissertation; derive ch.5 table

### DIFF
--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -351,6 +351,18 @@ def malen : GermanVerbEntry where
   frames := [Frame.np]
   vendlerClass := some .activity
 
+/-- *bemalen* — "paint (all over)" (*be-* prefix): accomplishment. The
+    prefixed counterpart of *malen*; the pair grounds the *-ung* contrast
+    *Be-mal-ung* vs **Mal-ung* ([benz-2025]'s illustration that *-ung*
+    needs complex change-of-state event structure). -/
+def bemalen : GermanVerbEntry where
+  form := "bemalen"
+  form3sg := "bemalt"
+  formPast := "bemalte"
+  formPastPart := "bemalt"
+  frames := [Frame.np]
+  vendlerClass := some .accomplishment
+
 /-- *küssen* — "kiss": activity. Used in RSP examples (*wach-küssen*). -/
 def kuessen : GermanVerbEntry where
   form := "küssen"
@@ -383,9 +395,8 @@ def rauben : GermanVerbEntry where
 
 /-! ### Change-of-state verbs
 
-These verbs have inherent result states and can form *-ung* nominalizations
-(complex event reading). Their root type determines the canonical v alloseme
-via `VAlloseme.fromRootType`. -/
+These verbs have inherent result states. Their root type determines the
+canonical v alloseme via `VAlloseme.fromRootType`. -/
 
 /-- *brechen* — "break": achievement with result root. The broken state
     entails prior change (you can't be broken without having been broken).
@@ -566,7 +577,7 @@ def allVerbs : List GermanVerbEntry :=
    verklagen, gratulieren, zurechtweisen,
    anzeigen, auszeichnen, belangen, ehren, entlassen,
    raechen, revanchieren, zurVerantwortungZiehen,
-   haemmern, malen, kuessen, fuehren, rauben,
+   haemmern, malen, bemalen, kuessen, fuehren, rauben,
    brechen, frieren, beobachten, einfuehren, verbinden,
    beenden, streichen, uebereilen, entwickeln,
    veranlassen, vergessen, erwarten, beschliessen]

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -376,7 +376,7 @@ def nAllosemic : AllosemicHead NAlloseme where
     , context := { belowCat := none } },
     { label := "n_content"
     , denotation := .content
-    , context := { belowCat := some .v, complementIsEventive := true } },
+    , context := { belowCat := some .v } },
     { label := "n_zero"
     , denotation := .zero
     , context := { belowCat := some .v, complementIsEventive := true } },
@@ -532,28 +532,37 @@ inductive NominalizationReading where
     Integrates [benz-2025] Ch. 3 and [wood-2023] Ch. 5–6:
 
     - v_eventive + n_zero → CEN (n is identity, noun = verb meaning)
-    - v_eventive + n_sortal → CEN ([benz-2025] mapping)
-    - v_eventive + n_result → result/product RN (entity from event)
-    - v_zero + n_simpleEvent → SEN (v absent, n picks out event-entity)
-    - v_zero + n_state → simple state (v absent, n picks out state)
+    - v_zero + n_simpleEvent → SEN (v vacuous, n picks out event-entity)
+    - v_zero + n_state → simple state (v vacuous, n picks out state)
     - v_zero + n_entity → simple entity RN (no event connection)
-    - v_zero + n_sortal → simple entity RN ([benz-2025] mapping)
-    - v_eventive + n_content → CCN (content requires eventive v)
-    - v_zero + n_content → impossible (content requires eventive v) -/
+    - v_zero + n_result → result/product RN
+    - v_zero + n_content → CCN
+
+    For the result and content readings, [benz-2025] §3.5 notes two
+    analytical options (both already noted by [wood-2023]): either v is
+    semantically vacuous on all readings but the CEN — so the event and
+    result readings are "mirror images" (only v vs. only n interpreted),
+    the option the dissertation's denotations adopt — or the eventive
+    component always comes from v, so both heads are interpreted. Both
+    derivations are admitted here (the eventive-v cells alongside the
+    zero-v cells). Content does *not* require an eventive verbal source:
+    simple content nouns (*Gerücht* 'rumor', *fact*, *idea*) have a
+    content reading with no corresponding verb at all ([benz-2025]
+    Table 2, §3.5). Bare categorization (n_sortal) yields a plain noun,
+    not a deverbal reading — its semantics lives in CategorizerSemantics. -/
 def readingFromAllosemes : VAlloseme → NAlloseme → Option NominalizationReading
   | .eventive, .zero        => some .complexEvent
-  | .eventive, .sortal      => some .complexEvent
-  | .eventive, .result      => some .result          -- result/product RN
+  | .eventive, .result      => some .result   -- both-heads-interpreted option
+  | .eventive, .content     => some .content  -- both-heads-interpreted option
   | .zero,     .simpleEvent => some .simpleEvent
   | .zero,     .state       => some .simpleState
   | .zero,     .entity      => some .simpleEntity
-  | .zero,     .sortal      => some .simpleEntity
-  | .eventive, .content     => some .content
-  | .zero,     .content     => none   -- content requires eventive v
+  | .zero,     .result      => some .result   -- v-vacuous option ([benz-2025] §3.5)
+  | .zero,     .content     => some .content  -- v-vacuous option; simple content nouns
+  | _,         .sortal      => none   -- bare categorization: plain noun, not deverbal
   | _,         .relational  => none   -- relational n yields possessive
   | _,         .alienator   => none   -- alienator yields alienated noun
-  | .zero,     .zero        => none   -- both zero is vacuous
-  | .zero,     .result      => none   -- result requires eventive v
+  | .zero,     .zero        => none   -- both vacuous: no reading
   | .eventive, .simpleEvent => none   -- SEN requires v = Ø
   | .eventive, .state       => none   -- state requires v = Ø
   | .eventive, .entity      => none   -- entity-n requires v = Ø
@@ -562,13 +571,15 @@ def readingFromAllosemes : VAlloseme → NAlloseme → Option NominalizationRead
 theorem cen_from_zero_n :
     readingFromAllosemes .eventive .zero = some .complexEvent := rfl
 
-/-- CEN from eventive v + sortal n ([benz-2025]). -/
-theorem cen_from_sortal_n :
-    readingFromAllosemes .eventive .sortal = some .complexEvent := rfl
-
 /-- Result/product RN from eventive v + result n ([wood-2023] Ch. 6 (6.30)). -/
 theorem result_from_eventive_v :
     readingFromAllosemes .eventive .result = some .result := rfl
+
+/-- Result/product RN with vacuous v: on the option the dissertation's
+    denotations adopt, only n is interpreted in the result reading —
+    the event and result readings are "mirror images" ([benz-2025] §3.5). -/
+theorem result_from_zero_v :
+    readingFromAllosemes .zero .result = some .result := rfl
 
 /-- SEN from zero v + simpleEvent n ([wood-2023] Ch. 5). -/
 theorem sen_from_zero_v :
@@ -582,17 +593,16 @@ theorem state_from_zero_v :
 theorem simpleEntity_from_entity_n :
     readingFromAllosemes .zero .entity = some .simpleEntity := rfl
 
-/-- Simple entity from zero v + sortal n ([benz-2025]). -/
-theorem simpleEntity_from_sortal_n :
-    readingFromAllosemes .zero .sortal = some .simpleEntity := rfl
-
-/-- CCN requires eventive v AND content n. -/
-theorem ccn_requires_eventive_content :
+/-- CCN from content n with eventive v (both-heads-interpreted option). -/
+theorem content_from_eventive_v :
     readingFromAllosemes .eventive .content = some .content := rfl
 
-/-- Content reading is impossible with zero v. -/
-theorem no_content_without_event :
-    readingFromAllosemes .zero .content = none := rfl
+/-- CCN from content n with vacuous v: the content interpretation "depends
+    on an alloseme of n, not v", and simple content nouns (*Gerücht*,
+    *rumor*, *idea*) have it with no verbal source at all ([benz-2025]
+    Table 2, §3.5). -/
+theorem content_from_zero_v :
+    readingFromAllosemes .zero .content = some .content := rfl
 
 /-- The six readings are pairwise distinct. -/
 theorem readings_distinct :

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -5,57 +5,50 @@ import Linglib.Fragments.German.Predicates
 
 /-!
 # Benz (2025): Structure and Interpretation Across Categories
-[benz-2025]
 
-*Structure and Interpretation Across Categories*.
-PhD dissertation, University of Pennsylvania.
+[benz-2025], PhD dissertation, University of Pennsylvania. Three case studies of
+the syntax–LF interface in German, unified by contextual allosemy
+(`Morphology.DM.Allosemy`):
 
-## Overview
-
-This file formalizes three interconnected contributions from [benz-2025]:
-
-1. **Content nominalizations** (Ch. 3): German *-ung* nominalizations are
-   systematically three-ways ambiguous (event/result/content), derived from
-   allosemy of v and n in the structure [nP n [vP v [√Root]]].
-
-2. **Co-occurrence restrictions** (Ch. 4): German preverbal elements
-   (prefixes, particles, RSPs) show a striking co-occurrence paradigm
-   explained by the conjunction of phrase-structural and interpretive
-   constraints.
-
-3. **Allosemy and locality** (Ch. 2, Ch. 4): RSPs are always interpreted
-   transparently (outside v's locality domain), while prefixes and particles
-   can receive non-transparent interpretations (inside v's complex head).
-
-## Architecture
-
-- `Morphology.DM.Allosemy`: general framework + v/n/Voice allosemy
-- `Features.Acceptability`: Acceptability type
+1. **Content nominalizations** (Ch. 3): nominalizations like *Beobachtung* have
+   event, referential (RN), and content readings, all from one syntactic
+   structure — n over a prefixed complex verbal head — with the variation
+   located in the allosemes of v and n. The content reading rests on an
+   n[CONTENT] alloseme that composes with a CP complement.
+2. **Prefixes, particles, and resultatives** (Ch. 4): the co-occurrence
+   restrictions among the three preverbal-element types (Table 3) follow from
+   the conjunction of two independent factors — phrase structure (particles and
+   resultative secondary predicates are phrasal complements of the verb, which
+   has only one complement position; prefixes form a complex head with the
+   root) and event structure (an event is delimited at most once,
+   [tenny-1994]'s Single Delimiting Constraint).
+3. **Prefixes in nominalizations** (Ch. 5): the three nominalization types
+   resolve the particle "structure problem" ([luedeling-2001]) differently —
+   phrasal inputs (nominalized infinitive), particles-as-heads (*-ung*), outer
+   attachment (*Ge-...-e*) — and the distribution of preverbal elements across
+   them follows.
 -/
 
 namespace Benz2025
 
 open Morphology.DM.Allosemy
-open Features (Acceptability)
+open Features (Acceptability VendlerClass)
 open German.Predicates
 open ArgumentStructure
-open Features
 
--- ════════════════════════════════════════════════════════════════════
--- Part I: Content Nominalizations (Ch. 3)
--- ════════════════════════════════════════════════════════════════════
+/-! ## Part I: Content nominalizations (Ch. 3) -/
 
--- ────────────────────────────────────────────────────
--- § 1. German Nominalization Data
--- ────────────────────────────────────────────────────
+/-! ### The three readings of *Beobachtung* -/
 
-/-- A German nominalization datum with reading and diagnostic properties. -/
+/-- A German nominalization datum: reading plus the diagnostic profile its
+example sentence exhibits ([benz-2025] (32), diagnostics after
+[grimshaw-1990]). -/
 structure NominalizationDatum where
-  /-- The nominalized form. -/
+  /-- The nominalized form (lemma). -/
   form : String
   /-- Base verb. -/
   baseVerb : String
-  /-- Nominalizing suffix. -/
+  /-- The nominalizing suffix. -/
   suffix : String := "-ung"
   /-- The reading exhibited in this example. -/
   reading : NominalizationReading
@@ -63,42 +56,49 @@ structure NominalizationDatum where
   sentence : String
   /-- Translation. -/
   translation : String
-  /-- Accepts temporal modifiers? -/
+  /-- Accepts temporal/durative modification in this reading? -/
   temporalModifiers : Bool
-  /-- Can be pluralized? -/
+  /-- Pluralizable in this reading? -/
   pluralizable : Bool
-  /-- Takes CP complement? -/
+  /-- Takes a content-specifying CP complement? -/
   takesCPComplement : Bool
   deriving Repr, BEq
 
-/-- *Beobachtung* ('observation') — the running example in Ch. 3.
-    All three readings are available for this single form. -/
+/-- Event reading ([benz-2025] (32a)): duration predicate diagnoses the
+complex event nominal; CENs resist pluralization ([grimshaw-1990]; Benz notes
+the exceptions reported for German are marginal). -/
 def beobachtung_CEN : NominalizationDatum :=
   { form := "Beobachtung"
   , baseVerb := "beobachten"
   , reading := .complexEvent
-  , sentence := "Die Beobachtung der Delfine dauerte drei Stunden"
-  , translation := "The observation of the dolphins lasted three hours"
+  , sentence := "Die Beobachtung des Nachthimmels dauerte drei Stunden"
+  , translation := "The observation of the night sky took three hours"
   , temporalModifiers := true
   , pluralizable := false
   , takesCPComplement := false }
 
+/-- Referential reading ([benz-2025] (32b)): pluralized, referring to concrete
+objects (e.g. a ledger of observations). Benz uses the "RN" label loosely for
+readings distinct from both the event and the content reading. -/
 def beobachtung_RN : NominalizationDatum :=
   { form := "Beobachtung"
   , baseVerb := "beobachten"
   , reading := .simpleEntity
-  , sentence := "Die Beobachtungen der Astronomin sind verloren"
-  , translation := "The astronomer's observations are lost"
+  , sentence := "Die Beobachtungen der Astronomin sind für immer verloren"
+  , translation := "The astronomer's observations are lost forever"
   , temporalModifiers := false
   , pluralizable := true
   , takesCPComplement := false }
 
+/-- Content reading ([benz-2025] (32c)): the CP complement specifies the
+content the noun refers to. The content reading is also available in the
+pluralized (32b), so it tolerates pluralization. -/
 def beobachtung_CCN : NominalizationDatum :=
   { form := "Beobachtung"
   , baseVerb := "beobachten"
   , reading := .content
   , sentence := "Seine Beobachtung, dass Planeten sich bewegen, veränderte die Wissenschaft"
-  , translation := "His observation that planets move changed science"
+  , translation := "His observation that planets move changed the science"
   , temporalModifiers := false
   , pluralizable := true
   , takesCPComplement := true }
@@ -106,284 +106,378 @@ def beobachtung_CCN : NominalizationDatum :=
 def allBeobachtungReadings : List NominalizationDatum :=
   [beobachtung_CEN, beobachtung_RN, beobachtung_CCN]
 
-/-- All three readings are attested for *Beobachtung*. -/
+/-- *Beobachtung* exhibits all three readings ([benz-2025] (32)). -/
 theorem beobachtung_three_readings :
-    (allBeobachtungReadings.any (·.reading == .complexEvent)) = true ∧
-    (allBeobachtungReadings.any (·.reading == .simpleEntity)) = true ∧
-    (allBeobachtungReadings.any (·.reading == .content)) = true := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+    allBeobachtungReadings.map (·.reading) = [.complexEvent, .simpleEntity, .content] := rfl
 
--- ────────────────────────────────────────────────────
--- § 2. Diagnostic Properties
--- ────────────────────────────────────────────────────
+/-- The three readings have pairwise distinct diagnostic profiles: duration
+modification picks out the event reading, pluralization the referential and
+content readings, CP complementation the content reading. -/
+theorem beobachtung_diagnostics :
+    allBeobachtungReadings.map
+        (λ d => (d.temporalModifiers, d.pluralizable, d.takesCPComplement)) =
+      [(true, false, false), (false, true, false), (false, true, true)] := rfl
 
-/-- CENs accept temporal modifiers. -/
-theorem cen_temporal : beobachtung_CEN.temporalModifiers = true := rfl
+/-! ### Readings from allosemes -/
 
-/-- RNs are pluralizable. -/
-theorem rn_plural : beobachtung_RN.pluralizable = true := rfl
+/-- The alloseme pair deriving each reading, on the analysis the
+dissertation's denotations adopt: v is semantically vacuous on all readings
+but the CEN, so each non-CEN reading is carried by a contentful alloseme of n
+([benz-2025] §3.5, following [wood-2023]). The alternative — attributing every
+eventive component to v — is noted but not adopted; `readingFromAllosemes`
+admits both. -/
+def adoptedAllosemes : NominalizationReading → VAlloseme × NAlloseme
+  | .complexEvent => (.eventive, .zero)
+  | .simpleEvent  => (.zero, .simpleEvent)
+  | .result       => (.zero, .result)
+  | .simpleState  => (.zero, .state)
+  | .simpleEntity => (.zero, .entity)
+  | .content      => (.zero, .content)
 
-/-- CCNs take CP complements. -/
-theorem ccn_cp : beobachtung_CCN.takesCPComplement = true := rfl
-
-/-- CENs resist pluralization (event readings are mass-like). -/
-theorem cen_no_plural : beobachtung_CEN.pluralizable = false := rfl
-
-/-- RNs lack temporal modifiers. -/
-theorem rn_no_temporal : beobachtung_RN.temporalModifiers = false := rfl
-
--- ────────────────────────────────────────────────────
--- § 3. Allosemy Derivation
--- ────────────────────────────────────────────────────
-
-/-- Map each reading to its alloseme pair. -/
-def readingAllosemePair : NominalizationReading → VAlloseme × NAlloseme
-  | .complexEvent => (.eventive, .sortal)
-  | .simpleEvent  => (.zero,    .simpleEvent)
-  | .result       => (.eventive, .result)
-  | .simpleState  => (.zero,    .state)
-  | .simpleEntity => (.zero,    .sortal)
-  | .content      => (.eventive, .content)
-
-/-- The alloseme pair correctly derives each reading. -/
-theorem alloseme_derivation_CEN :
-    readingFromAllosemes (.eventive) (.sortal) = some .complexEvent := rfl
-
-theorem alloseme_derivation_RN :
-    readingFromAllosemes (.zero) (.sortal) = some .simpleEntity := rfl
-
-theorem alloseme_derivation_CCN :
-    readingFromAllosemes (.eventive) (.content) = some .content := rfl
-
-/-- Round-trip: each reading maps to allosemes that reconstruct it. -/
-theorem alloseme_roundtrip (r : NominalizationReading) :
-    let (v, n) := readingAllosemePair r
-    readingFromAllosemes v n = some r := by
+/-- Each reading is recovered from its adopted alloseme pair. -/
+theorem adopted_roundtrip (r : NominalizationReading) :
+    readingFromAllosemes (adoptedAllosemes r).1 (adoptedAllosemes r).2 = some r := by
   cases r <;> rfl
 
-/-- The impossible combination: zero v + content n yields no reading.
-    Content requires an underlying event. -/
-theorem zero_content_impossible :
-    readingFromAllosemes .zero .content = none := rfl
+/-- The event and result readings are "mirror images ... in terms of semantic
+interpretation: In the event interpretation, (only) v is interpreted, in the
+result interpretation, it is (only) n" ([benz-2025] §3.5). -/
+theorem event_result_mirror :
+    (adoptedAllosemes .complexEvent).1.introducesEvent = true ∧
+    (adoptedAllosemes .complexEvent).2 = .zero ∧
+    (adoptedAllosemes .result).1.introducesEvent = false ∧
+    (adoptedAllosemes .result).2 ≠ .zero :=
+  ⟨rfl, rfl, rfl, by decide⟩
 
-/-- CEN and simple entity RN are "mirror images" of the division of
-    semantic labor: in CEN, v does the work (introducing the event
-    variable) while n merely nominalizes; in simple entity RN, v is null
-    (zero) and the referential/object interpretation comes from the
-    nominalization context. Both use the same n alloseme (sortal) —
-    it's v that varies. -/
-theorem cen_simpleEntity_mirror :
-    (readingAllosemePair .complexEvent).1 = .eventive ∧
-    (readingAllosemePair .simpleEntity).1 = .zero ∧
-    (readingAllosemePair .complexEvent).2 = .sortal ∧
-    (readingAllosemePair .simpleEntity).2 = .sortal := by
-  exact ⟨rfl, rfl, rfl, rfl⟩
+/-- One structure, three readings: every attested *Beobachtung* reading is
+derived by varying only the allosemes of v and n ([benz-2025] Ch. 3's chapter
+claim). The content reading needs no eventive v — simple content nouns like
+*Gerücht* 'rumor' have it with no corresponding verb at all (Table 2). -/
+theorem beobachtung_readings_from_allosemy :
+    allBeobachtungReadings.all (λ d =>
+      readingFromAllosemes (adoptedAllosemes d.reading).1 (adoptedAllosemes d.reading).2
+        == some d.reading) = true := by decide
 
--- ════════════════════════════════════════════════════════════════════
--- Part II: Prefixes, Particles, and Resultatives (Ch. 4)
--- ════════════════════════════════════════════════════════════════════
+/-! ## Part II: Prefixes, particles, and resultatives (Ch. 4) -/
 
--- ────────────────────────────────────────────────────
--- § 4. German Preverbal Element Typology
--- ────────────────────────────────────────────────────
+/-! ### The three preverbal-element types -/
 
-/-- The three types of German preverbal elements.
-
-    Ch. 4: prefixes are inseparable and attach as heads;
-    particles are separable and attach as phrases; RSPs are adjectival
-    phrases that form complex predicates with the verb. -/
+/-- The three types of German preverbal elements ([benz-2025] Ch. 4):
+inseparable prefixes, separable particles, and resultative secondary
+predicates (RSPs). -/
 inductive PreverbalElement where
   | pfx  -- inseparable prefix (be-, ent-, er-, ge-, miss-, ver-, zer-)
-  | prt  -- separable particle (ab-, an-, auf-, aus-, ein-, los-, nach-, vor-, zu-, ...)
+  | prt  -- separable particle (ab-, an-, auf-, aus-, ein-, ...)
   | rsp  -- resultative secondary predicate (platt, tot, kaputt, ...)
   deriving DecidableEq, Repr
 
-/-- Syntactic status: head or phrase.
+/-- The syntactic level of a morphological element: head (X⁰) or phrase (XP). -/
+inductive SynLevel where
+  | head    -- X⁰: can occur inside a complex head
+  | phrase  -- XP: cannot incorporate
+  deriving DecidableEq, Repr
 
-    §4.3.1: following Wurmbrand (1998) and Zeller (2001a),
-    prefixes are heads (inseparable under V2 movement) while particles
-    are phrases (obligatorily stranded under V2). RSPs are unambiguously
-    phrasal (they can be modified: *total flach gehämmert*). -/
-def PreverbalElement.isHead : PreverbalElement → Bool
-  | .pfx => true
-  | .prt => false
-  | .rsp => false
+/-- Prefixes are heads forming a complex head with the root (inseparable under
+V2 movement); particles and RSPs are phrasal (stranded under V2; RSPs are
+modifiable aPs). Following [wurmbrand-1998] and [zeller-2001], particles are
+phrasal complements of the verb not dominated by further functional
+material. -/
+def PreverbalElement.synLevel : PreverbalElement → SynLevel
+  | .pfx => .head
+  | .prt => .phrase
+  | .rsp => .phrase
 
-/-- Does this element always specify a result state that conflicts with
-    other delimiters?
+/-- Whether an element obligatorily introduces a result-state specification.
+Prefixes and RSPs always specify a result state; particles can have
+non-delimiting (directional, completive) readings ([benz-2025] §4.4). -/
+inductive ResultStateSpec where
+  | specifies  -- obligatorily introduces a result state
+  | neutral    -- has non-delimiting readings
+  deriving DecidableEq, Repr
 
-    §4.1: prefixes and RSPs always contribute a
-    (potentially conflicting) result state specification. Particles
-    can have non-delimiting readings (directional, completive) that
-    don't necessarily conflict — this is why PRT-pfx combinations
-    like *aus-er-wählen* are interpretively acceptable. -/
-def PreverbalElement.alwaysSpecifiesResult : PreverbalElement → Bool
-  | .pfx => true
-  | .prt => false
-  | .rsp => true
+def PreverbalElement.resultSpec : PreverbalElement → ResultStateSpec
+  | .pfx => .specifies
+  | .prt => .neutral
+  | .rsp => .specifies
 
--- ────────────────────────────────────────────────────
--- § 5. Prefix and Particle Inventory (Table 4)
--- ────────────────────────────────────────────────────
+/-! ### The two compatibility factors -/
 
-/-- German inseparable prefixes (closed class).
+/-- Structural combinability of an outer and an inner element (inner = closer
+to the root). A phrasal inner element is impossible: a head outside it cannot
+form a complex head with the root, and a phrasal outer element competes with
+it for the verb's single complement position — "Because the verb can take only
+one complement, these elements are structurally incompatible" ([benz-2025]
+§4.4). -/
+def incorporationAllowed (outer inner : SynLevel) : Bool :=
+  match outer, inner with
+  | .head,   .head   => true   -- complex head formation
+  | .phrase, .head   => true   -- phrasal complement + complex head
+  | .head,   .phrase => false  -- head cannot attach outside a phrase
+  | .phrase, .phrase => false  -- one complement position
 
-    Table 4. The prefix *ge-* is the rare
-    non-participial prefix (as in *ge-bären*, *ge-denken*). -/
-def inseparablePrefixes : List String :=
-  ["be", "ent", "er", "ge", "miss", "ver", "zer"]
+/-- Structural combinability depends only on the inner element's level —
+derived, not stipulated. -/
+theorem incorporation_only_depends_on_inner (outer inner : SynLevel) :
+    incorporationAllowed outer inner = (inner == .head) := by
+  cases outer <;> cases inner <;> rfl
 
-/-- German separable particles (open class, representative sample).
+/-- **Single Delimiting Constraint**: "The event described by a verb may only
+have one measuring-out and be delimited only once" ([tenny-1994] p. 79, quoted
+at [benz-2025] (159)). Two elements that both obligatorily specify a result
+state cannot co-occur: the end state Pred₂ of the complex event semantics can
+only be specified once. -/
+def resultStatesCompatible (a b : ResultStateSpec) : Bool :=
+  match a, b with
+  | .specifies, .specifies => false
+  | _, _ => true
 
-    Table 4. Elements like durch-, über-, um-
-    are ambiguous between prefix and particle uses. -/
-def separableParticles : List String :=
-  ["ab", "an", "auf", "aus", "bei", "ein", "los", "nach", "vor", "zu"]
-
-/-- Ambiguous preverbal elements: prefix or particle depending on verb. -/
-def ambiguousElements : List String :=
-  ["durch", "hinter", "über", "um", "unter", "wider"]
-
--- ────────────────────────────────────────────────────
--- § 6. Co-occurrence Restrictions (Table 3)
--- ────────────────────────────────────────────────────
-
-/-- A co-occurrence pair: two preverbal elements in order (outer, inner),
-    where the inner element is closer to the root. -/
-structure CooccurrenceDatum where
-  outer : PreverbalElement
-  inner : PreverbalElement
-  allowed : Bool
-  /-- Structure (head/phrase) predicts this restriction? -/
-  structurePredicts : Bool
-  /-- Interpretation (delimitation) predicts this restriction? -/
-  interpretationPredicts : Bool
-  exampleStr : String
-  deriving Repr, BEq
-
-/-- The full co-occurrence paradigm from Table 3. -/
-def cooccurrenceTable : List CooccurrenceDatum := [
-  -- pfx-pfx: *ent-ver-trauen. Structure allows (two heads), but
-  -- double delimitation blocks.
-  { outer := .pfx, inner := .pfx
-  , allowed := false
-  , structurePredicts := true
-  , interpretationPredicts := false
-  , exampleStr := "*ent-ver-trauen (intended: stop trusting)" },
-  -- pfx-PRT: *zer-ab-schneiden. Head cannot wrap phrase.
-  { outer := .pfx, inner := .prt
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := true
-  , exampleStr := "*zer-ab-schneiden (intended: cut off into strips)" },
-  -- PRT-pfx: aus-er-wählen. THE productive combination.
-  { outer := .prt, inner := .pfx
-  , allowed := true
-  , structurePredicts := true
-  , interpretationPredicts := true
-  , exampleStr := "aus-er-wählen (choose, cf. er-wählen 'pick')" },
-  -- PRT-PRT: *rad-ein-fahren. Two phrases cannot stack.
-  { outer := .prt, inner := .prt
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := true
-  , exampleStr := "*rad-ein-fahren (intended: ride in on a bike)" },
-  -- RSP-pfx: *arm be-raubt. Structure allows (phrase + head),
-  -- but double delimitation blocks.
-  { outer := .rsp, inner := .pfx
-  , allowed := false
-  , structurePredicts := true
-  , interpretationPredicts := false
-  , exampleStr := "*arm be-raubt (intended: robbed poor)" },
-  -- RSP-PRT: *nass an-gespuckt. Two phrasal elements cannot stack.
-  { outer := .rsp, inner := .prt
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := true
-  , exampleStr := "*nass an-gespuckt (intended: spat at wet)" },
-  -- RSP-RSP: *kaputt müde gearbeitet. Both factors block.
-  { outer := .rsp, inner := .rsp
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := false
-  , exampleStr := "*kaputt müde gearbeitet (intended: worked to exhaustion)" },
-  -- pfx-RSP: head cannot wrap phrase, and double delimitation.
-  { outer := .pfx, inner := .rsp
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := false
-  , exampleStr := "*ver-platt-hämmern (blocked in all orders)" },
-  -- PRT-RSP: two phrases cannot stack. PRT doesn't always delimit,
-  -- so interpretation alone would allow it, but structure blocks.
-  { outer := .prt, inner := .rsp
-  , allowed := false
-  , structurePredicts := false
-  , interpretationPredicts := true
-  , exampleStr := "*an-wach-küssen (intended: kiss awake at)" }
-]
-
--- ────────────────────────────────────────────────────
--- § 7. Structural Prediction: Head/Phrase Compatibility
--- ────────────────────────────────────────────────────
-
-/-- Structural compatibility: phrase can take headed complement; two heads
-    can combine; head cannot wrap phrase; two phrases cannot stack.
-
-    §4.3.1, §4.4. -/
 def structurallyCompatible (outer inner : PreverbalElement) : Bool :=
-  match outer.isHead, inner.isHead with
-  | true,  true  => true   -- head + head
-  | false, true  => true   -- phrase + head
-  | true,  false => false  -- head cannot wrap phrase
-  | false, false => false  -- phrases cannot stack
+  incorporationAllowed outer.synLevel inner.synLevel
 
-/-- The structural prediction matches Table 3's "Structure Predicts" column. -/
-theorem structural_prediction_matches :
-    cooccurrenceTable.map (λ d => structurallyCompatible d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.structurePredicts) := by decide
-
--- ────────────────────────────────────────────────────
--- § 8. Interpretive Prediction: Result State Conflict
--- ────────────────────────────────────────────────────
-
-/-- Two elements that both always specify a result state cannot co-occur,
-    as a single event cannot be delimited twice with conflicting endpoints.
-
-    §4.1: the interpretive constraint is about conflicting
-    result state specifications. Particles escape this because they can
-    have non-result (directional/completive) readings. -/
 def interpretivelyCompatible (outer inner : PreverbalElement) : Bool :=
-  !(outer.alwaysSpecifiesResult && inner.alwaysSpecifiesResult)
+  resultStatesCompatible outer.resultSpec inner.resultSpec
 
-/-- The interpretive prediction matches Table 3's "Interpretation Predicts" column. -/
-theorem interpretive_prediction_matches :
-    cooccurrenceTable.map (λ d => interpretivelyCompatible d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.interpretationPredicts) := by decide
-
--- ────────────────────────────────────────────────────
--- § 9. Combined Prediction
--- ────────────────────────────────────────────────────
-
-/-- A combination is allowed iff both structurally compatible AND
-    interpretively compatible (no conflicting result states).
-
-    §4.4: both factors are needed; neither alone
-    explains the full paradigm. -/
+/-- A combination is predicted possible iff both factors permit it
+([benz-2025] §4.4). -/
 def predictedAllowed (outer inner : PreverbalElement) : Bool :=
   structurallyCompatible outer inner && interpretivelyCompatible outer inner
 
-/-- The combined prediction matches Table 3's "Allowed" column. -/
+/-! ### Prefix and particle inventory (Table 4) -/
+
+/-- German inseparable prefixes ([benz-2025] Table 4). *ge-* is the rare
+non-participial prefix (*ge-bären*, *ge-denken*, *ge-fallen*). -/
+def inseparablePrefixes : List String :=
+  ["be", "ent", "er", "ge", "miss", "ver", "zer"]
+
+/-- German prepositional separable particles ([benz-2025] Table 4; the table
+additionally lists nominal and adjectival particles like *klavier-*, *rad-*,
+*leicht-*, whose classification is controversial). -/
+def separableParticles : List String :=
+  ["ab", "an", "auf", "aus", "bei", "ein", "los", "nach", "vor", "zu"]
+
+/-- Elements occurring both as prefix and as particle ([benz-2025] Table 4). -/
+def ambiguousElements : List String :=
+  ["durch", "hinter", "über", "um", "unter", "wider"]
+
+/-- Table 4's three-way partition: the ambiguous elements appear in neither
+pure inventory. -/
+theorem ambiguous_not_pure :
+    ambiguousElements.all (λ e =>
+      !inseparablePrefixes.contains e && !separableParticles.contains e) = true := by
+  decide
+
+/-! ### The co-occurrence paradigm (Table 3) -/
+
+/-- A cell of Table 3's factor columns: does this factor predict the
+combination to be possible? `particleDependent` renders the table's
+parenthesized check mark — "the predictions depend on the specific particles
+involved" ([benz-2025] §4.1). -/
+inductive FactorVerdict where
+  | predicts           -- ✓: factor predicts the combination possible
+  | particleDependent  -- (✓): possible for result-neutral particles
+  | excludes           -- ✗: factor predicts the combination impossible
+  deriving DecidableEq, Repr
+
+/-- Boolean reading of a factor cell: `particleDependent` counts as possible
+(the generic classification treats particles as result-neutral). -/
+def FactorVerdict.possible : FactorVerdict → Bool
+  | .predicts => true
+  | .particleDependent => true
+  | .excludes => false
+
+/-- A row of [benz-2025] Table 3 (repeated as Table 5): outer element(s),
+inner element (closer to the root), observed availability, and the two factor
+verdicts. The printed table's final row merges pfx-RSP and PRT-RSP into one
+row "pfx/PRT-RSP", rendered here by a two-element `outers` list. -/
+structure CooccurrenceRow where
+  outers : List PreverbalElement
+  inner : PreverbalElement
+  allowed : Bool
+  structureVerdict : FactorVerdict
+  interpretationVerdict : FactorVerdict
+  deriving Repr, BEq
+
+/-- [benz-2025] Table 3, cell for cell. Attested examples per row: pfx-pfx
+(81) *ent-ver-trauen; pfx-PRT (83) *zer-ab-schneiden; PRT-pfx (84)
+aus-er-wählen, an-ver-trauen, vor-ent-halten; PRT-PRT (82) *rad-ein-fahren;
+RSP-pfx (87) *arm be-raubt; RSP-PRT (88) *nass an-gespuckt; RSP-RSP (86)
+*sich kaputt müde gearbeitet. -/
+def cooccurrenceTable : List CooccurrenceRow := [
+  { outers := [.pfx], inner := .pfx, allowed := false
+  , structureVerdict := .predicts, interpretationVerdict := .excludes },
+  { outers := [.pfx], inner := .prt, allowed := false
+  , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  { outers := [.prt], inner := .pfx, allowed := true
+  , structureVerdict := .predicts, interpretationVerdict := .particleDependent },
+  { outers := [.prt], inner := .prt, allowed := false
+  , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  { outers := [.rsp], inner := .pfx, allowed := false
+  , structureVerdict := .predicts, interpretationVerdict := .excludes },
+  { outers := [.rsp], inner := .prt, allowed := false
+  , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  { outers := [.rsp], inner := .rsp, allowed := false
+  , structureVerdict := .excludes, interpretationVerdict := .excludes },
+  { outers := [.pfx, .prt], inner := .rsp, allowed := false
+  , structureVerdict := .excludes, interpretationVerdict := .excludes }
+]
+
+/-- The conjunction of the two factors reproduces the Allowed column at every
+cell of Table 3. -/
 theorem combined_prediction_matches :
-    cooccurrenceTable.map (λ d => predictedAllowed d.outer d.inner) =
-    cooccurrenceTable.map (λ d => d.allowed) := by decide
+    cooccurrenceTable.all (λ r => r.outers.all λ o =>
+      predictedAllowed o r.inner == r.allowed) = true := by decide
 
-/-- PRT-pfx is the unique allowed combination. -/
+/-- The structural factor reproduces the Structure column at every cell. -/
+theorem structural_prediction_matches :
+    cooccurrenceTable.all (λ r => r.outers.all λ o =>
+      structurallyCompatible o r.inner == r.structureVerdict.possible) = true := by decide
+
+/-- The interpretive factor reproduces the Interpretation column at every cell
+except the merged row's particle half (see
+`prt_rsp_interpretation_particle_dependent`). -/
+theorem interpretive_prediction_matches :
+    cooccurrenceTable.all (λ r => r.outers.all λ o =>
+      (o == .prt && r.inner == .rsp) ||
+        (interpretivelyCompatible o r.inner == r.interpretationVerdict.possible)) = true := by
+  decide
+
+/-- The printed table marks the merged pfx/PRT-RSP row's interpretation cell
+✗, but on the account's own classification only the prefix half is
+interpretively excluded: "the unavailability of particle verbs with RSPs is
+due to the fact that RSPs cannot attach to phrasal VPs. Of course, some
+RSP-particle verbs are additionally also ruled out semantically, because some
+particles introduce end states" ([benz-2025] §4.4) — the structural factor
+does the work, and the interpretive verdict is particle-dependent. -/
+theorem prt_rsp_interpretation_particle_dependent :
+    structurallyCompatible .prt .rsp = false ∧
+    interpretivelyCompatible .prt .rsp = true := ⟨rfl, rfl⟩
+
+/-- PRT-pfx is the unique allowed combination — "much more widely attested
+than any of the others" ([benz-2025] (84): *aus-er-wählen*, *an-ver-trauen*,
+*vor-ent-halten*, *um-ent-scheiden*, *ab-er-kennen*). -/
 theorem prt_pfx_uniquely_allowed :
-    (cooccurrenceTable.filter (·.allowed)).length = 1 := by decide
+    (cooccurrenceTable.filter (·.allowed)).map (λ r => (r.outers, r.inner)) =
+      [([.prt], .pfx)] := by decide
 
--- ────────────────────────────────────────────────────
--- § 10. German Resultative Data (§4.2)
--- ────────────────────────────────────────────────────
+/-- Neither factor alone predicts the paradigm: structure alone misses the
+double-delimitation rows (pfx-pfx, RSP-pfx), and interpretation alone misses
+the phrase-structure rows (pfx-PRT, PRT-PRT, RSP-PRT). -/
+theorem two_factors_needed :
+    (cooccurrenceTable.any (λ r => r.structureVerdict.possible && !r.allowed)) = true ∧
+    (cooccurrenceTable.any (λ r => r.interpretationVerdict.possible && !r.allowed)) = true := by
+  constructor <;> decide
+
+/-! ### Blocking derivations
+
+The two principles as a derivation system: a combination is blocked iff a
+derivation exists. Soundness and completeness against `predictedAllowed` show
+the two principles exactly generate the paradigm. -/
+
+/-- A proof that a preverbal-element combination violates one of the two
+principles.
+
+**`byPhrasalInner`**: a phrasal element cannot occupy the inner position —
+a head outside it cannot form a complex head with the root, and a phrasal
+outer competes for the verb's single complement position ([benz-2025] §4.4).
+
+**`bySingleDelimiting`**: two obligatory result-state specifiers conflict —
+the end state of a complex event can only be specified once ([tenny-1994]
+p. 79's Single Delimiting Constraint, [benz-2025] (159)). -/
+inductive Blocked : PreverbalElement → PreverbalElement → Prop where
+  | byPhrasalInner {o i : PreverbalElement} :
+      i.synLevel = .phrase → Blocked o i
+  | bySingleDelimiting {o i : PreverbalElement} :
+      o.resultSpec = .specifies → i.resultSpec = .specifies → Blocked o i
+
+/-- **Soundness**: every blocking derivation corresponds to a predicted-blocked
+combination — the theory does not over-generate. -/
+theorem blocked_sound {o i : PreverbalElement} (h : Blocked o i) :
+    predictedAllowed o i = false := by
+  cases h with
+  | byPhrasalInner hi =>
+      cases o <;> cases i <;> first | rfl | exact absurd hi (by decide)
+  | bySingleDelimiting ho _ =>
+      cases o <;> cases i <;> first | rfl | exact absurd ho (by decide)
+
+/-- **Completeness**: every blocked combination has a derivation — the two
+principles account for all restrictions. -/
+theorem blocked_complete {o i : PreverbalElement}
+    (h : predictedAllowed o i = false) : Blocked o i := by
+  cases o <;> cases i <;>
+    first
+    | exact .byPhrasalInner rfl
+    | exact .bySingleDelimiting rfl rfl
+    | exact absurd h (by decide)
+
+/-- The allowed combination has no derivation: the prefix is a head, and the
+particle is result-neutral. -/
+theorem prt_pfx_no_derivation : ¬ Blocked .prt .pfx := by
+  intro h
+  cases h with
+  | byPhrasalInner hi => exact absurd hi (by decide)
+  | bySingleDelimiting ho _ => exact absurd ho (by decide)
+
+/-- pfx-pfx is blocked only by the Single Delimiting Constraint (both are
+heads), so the interpretive rule is not redundant. -/
+theorem pfx_pfx_only_interpretive :
+    Blocked .pfx .pfx ∧ PreverbalElement.pfx.synLevel ≠ .phrase :=
+  ⟨.bySingleDelimiting rfl rfl, by decide⟩
+
+/-- pfx-PRT is blocked only structurally (particles are result-neutral), so
+the structural rule is not redundant. -/
+theorem pfx_prt_only_structural :
+    Blocked .pfx .prt ∧ PreverbalElement.prt.resultSpec ≠ .specifies :=
+  ⟨.byPhrasalInner rfl, by decide⟩
+
+/-! ### Cross-framework contrast: the phrase-in-word-slot cell
+
+`ConstructionGrammar.Slot.IsPhraseInWordSlot` — a phrasal filler in a
+zero-level position — is the configuration of phrasal compounds and the PAL
+construction ([goldberg-shirtz-2025]; contemporaneous with this dissertation,
+neither cites the other). In this file's terms that configuration is exactly
+the banned phrasal-inner cell: the structural principle rejects what the
+constructionist analysis licenses (cf. `GoldbergShirtz2025.pal_load_bearing`). -/
+
+/-- A CxG bar level in `SynLevel` terms: zero-level positions are head sites;
+bar- and phrase-level positions are phrasal. -/
+def SynLevel.ofBarLevel : ConstructionGrammar.BarLevel → SynLevel
+  | .zero => .head
+  | .bar => .phrase
+  | .phrase => .phrase
+
+/-- The `SynLevel` of a CxG slot filler: word fillers are heads, phrasal
+fillers (with or without a fixed head) are phrases; SEM+ fillers are
+level-unspecified. -/
+def _root_.ConstructionGrammar.SlotFiller.synLevel :
+    ConstructionGrammar.SlotFiller String → Option SynLevel
+  | .fixed _ => some .head
+  | .open_ _ => some .head
+  | .headed _ _ => some .phrase
+  | .phrasal => some .phrase
+  | .semantic _ => none
+
+/-- A phrase in a word-level slot occupies the banned cell: its site is a
+head, its filler a phrase, and `incorporationAllowed` rejects the pair. The
+standing counterexample class is the PAL construction, which licenses exactly
+this configuration. -/
+theorem phraseInWordSlot_incorporation_banned
+    (s : ConstructionGrammar.Slot String) (h : s.IsPhraseInWordSlot) :
+    ∃ site filler,
+      s.level.map SynLevel.ofBarLevel = some site ∧
+      s.filler.synLevel = some filler ∧
+      incorporationAllowed site filler = false := by
+  obtain ⟨hf, hl⟩ := h
+  refine ⟨.head, .phrase, ?_, ?_, rfl⟩ <;>
+    simp [hl, hf, SynLevel.ofBarLevel, ConstructionGrammar.SlotFiller.synLevel]
+
+/-! ### German resultative data (§4.2)
+
+Complex predicate semantics after [williams-2015], adopted at [benz-2025]
+(158): ⟦v⟧ = λx λe₁ ∃e₂ ∃s. Means(e₁,e₂) & Pred₁(e₂) & Theme(e₁,x) &
+End(e₁,s) & Pred₂(s). The M(eans) predicate is the verb, the R(esult)
+predicate the RSP; the End Theme Postulate (108) links the Theme of the
+complex event to the end state. See `Causation.Resultatives` for the
+complementary causal-dynamics analysis. -/
 
 /-- A German resultative datum with gloss and judgment. -/
 structure GermanResultativeDatum where
@@ -394,10 +488,9 @@ structure GermanResultativeDatum where
   verbClass : String
   deriving Repr, BEq
 
-/-- German RSP data from §4.2.
-
-    German allows obligatorily transitive, unaccusative, and inherently
-    reflexive M predicates in resultatives — not just unergatives. -/
+/-- German RSP data ([benz-2025] (89), (115); (115a,e,f) after
+[creemers-2020] and Rapp). German allows obligatorily transitive,
+unaccusative, and inherently reflexive M predicates in resultatives. -/
 def germanRSPData : List GermanResultativeDatum := [
   { sentence := "Er hämmerte das Metall platt"
   , gloss := "he hammered the.ACC metal flat"
@@ -426,20 +519,19 @@ def germanRSPData : List GermanResultativeDatum := [
   , verbClass := "inherently reflexive" }
 ]
 
-/-- German allows non-unergative M predicates in resultatives. -/
+/-- German allows non-unergative M predicates in resultatives ([benz-2025]
+(115)) — against weak-resultative reanalyses of the whole class. -/
 theorem german_allows_non_unergative_M :
     (germanRSPData.any (·.verbClass == "obligatorily transitive")) = true ∧
     (germanRSPData.any (·.verbClass == "unaccusative")) = true ∧
     (germanRSPData.any (·.verbClass == "inherently reflexive")) = true := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
 
--- ────────────────────────────────────────────────────
--- § 11. RSP Co-occurrence Restriction Data (§4.1)
--- ────────────────────────────────────────────────────
+/-! ### RSP co-occurrence contrasts (§4.1) -/
 
-/-- RSPs are incompatible with prefixed verbs.
-    Ch. 4: adding an RSP to a prefix verb is ungrammatical,
-    but the same RSP with the simplex verb is fine. -/
+/-- RSPs are incompatible with prefixed verbs; the same RSP with the simplex
+verb is fine ([benz-2025] (87), from [creemers-2020]). The *ge-* in the
+grammatical examples is participial, not a prefix in the relevant sense. -/
 def rsp_pfx_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) := [
   ( { sentence := "*Sie haben uns arm be-raubt"
     , gloss := "they have us.ACC poor BE-robbed.PTCP"
@@ -473,15 +565,15 @@ def rsp_pfx_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) 
     , verbClass := "simplex verb" } )
 ]
 
-/-- Every RSP+pfx-verb contrast: pfx-verb ungrammatical, simplex OK. -/
+/-- Every RSP + prefix-verb contrast: prefixed verb out, simplex fine. -/
 theorem rsp_pfx_contrast_pattern :
-    rsp_pfx_contrasts.all (fun (bad, good) =>
+    rsp_pfx_contrasts.all (λ (bad, good) =>
       bad.judgment == .unacceptable && good.judgment == .ok) = true := by
   decide
 
-/-- RSPs are also incompatible with particles.
-    Ch. 4: adding an RSP to a particle verb is ungrammatical,
-    but the same RSP with the simplex verb is fine. -/
+/-- RSPs are likewise incompatible with particle verbs ([benz-2025] (88)) —
+including particles not characterizable as resultative, like *an-* in
+(88d). -/
 def rsp_prt_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) := [
   ( { sentence := "*Sie hat den Tisch trocken ab-gewischt"
     , gloss := "she has the.ACC table dry AB-wiped.PTCP"
@@ -495,7 +587,7 @@ def rsp_prt_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) 
     , verbClass := "simplex verb" } ),
   ( { sentence := "*Das Baby hat mich nass an-gespuckt"
     , gloss := "the baby has me.ACC wet AN-spit.PTCP"
-    , translation := "The baby spat up on me and I was wet"
+    , translation := "The baby spat up on me and I was wet as a result"
     , judgment := .unacceptable
     , verbClass := "particle verb (an-)" },
     { sentence := "Das Baby hat mich nass gespuckt"
@@ -505,127 +597,95 @@ def rsp_prt_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) 
     , verbClass := "simplex verb" } )
 ]
 
-/-- Every RSP+PRT-verb contrast: PRT-verb ungrammatical, simplex OK. -/
+/-- Every RSP + particle-verb contrast: particle verb out, simplex fine. -/
 theorem rsp_prt_contrast_pattern :
-    rsp_prt_contrasts.all (fun (bad, good) =>
+    rsp_prt_contrasts.all (λ (bad, good) =>
       bad.judgment == .unacceptable && good.judgment == .ok) = true := by
   decide
 
--- ════════════════════════════════════════════════════════════════════
--- Part III: Allosemy and Locality (Ch. 2, Ch. 4)
--- ════════════════════════════════════════════════════════════════════
+/-! ### Interpretive transparency -/
 
--- ────────────────────────────────────────────────────
--- § 12. Interpretive Transparency
--- ────────────────────────────────────────────────────
+/-- Whether the element can receive a non-transparent (idiosyncratic)
+interpretation with the verb. Prefixes and particles can (*an-fangen* 'start',
+[benz-2025] (161)); RSPs "are always interpreted transparently, in contrast to
+particles" (*platt klopfen* 'pound flat', (162)) — RSPs sit outside the
+locality domain for allosemy, while particles, though phrasal, are bare
+complements not dominated by functional material. -/
+def PreverbalElement.canBeNonTransparent : PreverbalElement → Bool
+  | .pfx => true
+  | .prt => true
+  | .rsp => false
 
-/-- Claim 2: RSPs are always transparent (outside v's
-    locality domain for allosemy); prefixes and particles can be opaque
-    (inside the complex head). -/
-inductive InterpretiveTransparency where
-  | transparent
-  | nonTransparent
-  deriving DecidableEq, Repr
+/-- Transparency cross-cuts the structural classification: particles pattern
+with RSPs structurally (both phrasal) but with prefixes interpretively (both
+can be non-transparent). This is the evidence that particles are phrasal yet
+local enough for allosemy ([benz-2025] §4.3). -/
+theorem transparency_crosscuts_synLevel :
+    PreverbalElement.prt.synLevel = PreverbalElement.rsp.synLevel ∧
+    PreverbalElement.prt.canBeNonTransparent ≠ PreverbalElement.rsp.canBeNonTransparent :=
+  ⟨rfl, by decide⟩
 
-def typicalTransparency : PreverbalElement → InterpretiveTransparency
-  | .rsp => .transparent
-  | .pfx => .nonTransparent
-  | .prt => .nonTransparent
+/-! ## Part III: Prefixes in nominalizations (Ch. 5) -/
 
-theorem rsp_always_transparent :
-    typicalTransparency .rsp = .transparent := rfl
+/-! ### Nominalization types and the structure problem -/
 
--- ────────────────────────────────────────────────────
--- § 13. Means/End Event Decomposition (§4.2)
--- ────────────────────────────────────────────────────
-
-/-! ### Complex predicate semantics
-
-Following Williams (2015), adopted by §4.2:
-resultatives are complex predicates with semantics:
-
-    K(e₁, e₂, s) = Means(e₁, e₂) & End(e₁, s)
-
-where e₁ is the complex event of change, e₂ is the means/manner
-subevent, and s is the result state. The M predicate is the verb;
-the R predicate is the RSP. This is NOT a causal relation — the
-means event can be concurrent with the change.
-
-The End Theme Postulate links the Theme of the complex event to the
-end state: End(e₁, s) & Theme(e₁, x) |= Theme(s, x).
-
-See also `Causation.Resultatives` for the complementary analysis
-via causal dynamics, structural sufficiency, and CC-selection. -/
-
--- ────────────────────────────────────────────────────
--- § 14. Central Claims
--- ────────────────────────────────────────────────────
-
-/-- **Claim 1**: Neither factor alone predicts the full co-occurrence paradigm.
-    Structure alone is insufficient: some structurally OK combinations are
-    blocked by interpretation (pfx-pfx, RSP-pfx).
-    Interpretation alone is insufficient: some interpretively OK combinations
-    are blocked by structure (pfx-PRT, PRT-PRT, RSP-PRT). -/
-theorem claim1_two_factors :
-    -- Structure alone is insufficient
-    (cooccurrenceTable.any (λ d =>
-      d.structurePredicts && !d.interpretationPredicts && !d.allowed)) = true ∧
-    -- Interpretation alone is insufficient
-    (cooccurrenceTable.any (λ d =>
-      d.interpretationPredicts && !d.structurePredicts && !d.allowed)) = true := by
-  constructor <;> decide
-
--- ════════════════════════════════════════════════════════════════════
--- Part IV: Prefixes in Nominalizations (Ch. 5)
--- ════════════════════════════════════════════════════════════════════
-
--- ────────────────────────────────────────────────────
--- § 15. Nominalization Type Inventory
--- ────────────────────────────────────────────────────
-
-/-- German nominalization types discussed in Ch. 5.
-
-    - **ung**: *-ung* suffixation (*Beobachtung*, *Erzählung*). Requires
-      the verb to project a full verbal shell including v; the entire
-      vP is nominalized by n.
-    - **ge_e**: *Ge-...-e* circumfixation (*Gerede*, *Gelaufe*). Directly
-      nominalizes the root without a full verbal projection; the root
-      must be able to stand without obligatory internal arguments.
-    - **nomInfinitive**: Nominalized infinitive (*das Beobachten*,
-      *das Erzählen*). The most permissive: the full verbal structure
-      is preserved under nominalization. -/
+/-- German nominalization types discussed in [benz-2025] Ch. 5:
+*-ung* suffixation (*Beobachtung*), *Ge-...-e* circumfixation (*Gerede*),
+and the nominalized infinitive (*das Beobachten*). -/
 inductive NominalizationType where
   | ung           -- -ung suffixation
   | ge_e          -- Ge-...-e circumfixation
   | nomInfinitive -- nominalized infinitive (das V-en)
   deriving DecidableEq, Repr
 
--- ────────────────────────────────────────────────────
--- § 16. PE Acceptability across Nominalization Types
--- ────────────────────────────────────────────────────
+/-- A solution to the particle "structure problem" ([luedeling-2001]): how can
+a phrasal particle end up inside a derived nominal? [benz-2025] Ch. 5 argues
+the three nominalization types favor *different* solutions — reinforcing "the
+strange status of particles in the grammar". -/
+inductive StructureSolution where
+  | phrasalInput    -- the nominalizer takes phrasal structure
+  | particleAsHead  -- the particle attaches low, as a head
+  | outerAttachment -- the particle attaches outside the nominalizer
+  deriving DecidableEq, Repr
 
-/-- Whether a preverbal element is acceptable in a given nominalization type.
+/-- The solution each nominalization type favors ([benz-2025] §5.2–5.4):
+nominalized infinitives take phrasal inputs (even *das
+Durch-den-Wald-Reiten*); *-ung* favors particles-as-heads (particles but not
+resultatives occur, and *-ung* needs its input identifiable as complex
+change-of-state); *Ge-...-e* favors outer attachment (particles and RSPs
+attach outside *Ge-*, (223), while prefixes cannot, and its
+no-internal-argument eventive semantics conflicts with prefix verbs'
+argument-structural demands). -/
+def NominalizationType.solution : NominalizationType → StructureSolution
+  | .nomInfinitive => .phrasalInput
+  | .ung => .particleAsHead
+  | .ge_e => .outerAttachment
 
-    Ch. 5: the distribution of preverbal elements across
-    nominalization types reveals complementary distribution between prefixes
-    and RSPs:
+/-- Whether the element can attach as a (non-phrasal) head: prefixes always
+do; particles can attach low as heads ([benz-2025] §5.3's particles-as-heads
+solution); RSPs, "unlike particles, ... cannot be attached non-phrasally"
+((205)–(206)). -/
+def PreverbalElement.canAttachAsHead : PreverbalElement → Bool
+  | .pfx => true
+  | .prt => true
+  | .rsp => false
 
-    |             | pfx | prt | RSP |
-    |-------------|-----|-----|-----|
-    | -ung        |  ✓  |  ✓  |  ✗  |
-    | Ge-...-e    |  ✗  |  ✓  |  ✓  |
-    | nom. inf.   |  ✓  |  ✓  |  ✓  |
+/-- Which preverbal elements a structure-problem solution admits: phrasal
+inputs admit everything; particles-as-heads admits exactly the head-attachers;
+outer attachment admits exactly the phrasal elements (prefixes are verbal
+heads and cannot attach outside a noun). -/
+def StructureSolution.admits : StructureSolution → PreverbalElement → Bool
+  | .phrasalInput, _ => true
+  | .particleAsHead, pe => pe.canAttachAsHead
+  | .outerAttachment, pe => pe.synLevel == .phrase
 
-    - **-ung + RSP = ✗**: RSPs are phrasal and cannot be trapped inside the
-      complex head that -ung nominalization creates. The RSP would need to
-      be inside the vP that n selects, but as a phrase it cannot incorporate.
-    - **Ge-...-e + pfx = ✗**: Ge-...-e directly nominalizes the root; it
-      requires the root to be available without obligatory internal arguments.
-      Prefixed verbs (where the prefix saturates argument structure) are
-      incompatible because the prefix has already formed a complex head with
-      the root, and the Ge-...-e circumfix cannot wrap around a complex head.
-    - **Nom. inf.**: maximally permissive because the full verbal projection
-      (including any preverbal element) is preserved under nominalization. -/
+/-- The observed distribution ([benz-2025] Ch. 5): *-ung* takes prefixes
+(197d–f) and particles (197a–c) but not RSPs ((204) **Platt-hämmer-ung*,
+**Wach-küss-ung*); *Ge-...-e* takes particles (212) and (a subset of) RSPs
+((216) *das Wach-ge-küss-e*, restricted to non-obligatorily-transitive bases
+by its no-internal-argument semantics) but not prefixes ((218) **Ge-be-such-e*,
+**Be-ge-such-e*, in either order); nominalized infinitives take all three
+((193) *das Ver-kaufen*, *das Ein-führen*, *das Wach-küssen*). -/
 def peAcceptable : NominalizationType → PreverbalElement → Bool
   | .ung,           .pfx => true
   | .ung,           .prt => true
@@ -635,462 +695,90 @@ def peAcceptable : NominalizationType → PreverbalElement → Bool
   | .ge_e,          .rsp => true
   | .nomInfinitive, _    => true
 
--- ────────────────────────────────────────────────────
--- § 17. Complementary Distribution Theorems
--- ────────────────────────────────────────────────────
+/-- **The Ch. 5 distribution is derived**: each nominalization type admits
+exactly the elements its structure-problem solution can accommodate. The
+distribution is a projection of the same head/phrase classification that
+drives the Ch. 4 co-occurrence paradigm. -/
+theorem peAcceptable_from_solutions (nt : NominalizationType) (pe : PreverbalElement) :
+    peAcceptable nt pe = nt.solution.admits pe := by
+  cases nt <;> cases pe <;> rfl
 
-/-- Prefixes and RSPs show complementary distribution across -ung and Ge-...-e:
-    pfx is accepted where RSP is rejected, and vice versa.
-
-    Ch. 5: this complementarity follows from the structural
-    difference between head-level (pfx) and phrase-level (RSP) preverbal
-    elements, interacting with the different structural requirements of
-    -ung (requires full vP) vs Ge-...-e (directly nominalizes root). -/
+/-- Prefixes and RSPs are in complementary distribution across *-ung* and
+*Ge-...-e*: head-attachment and outer attachment make opposite demands. -/
 theorem pfx_rsp_complementary_ung_ge :
     peAcceptable .ung .pfx = true ∧ peAcceptable .ung .rsp = false ∧
-    peAcceptable .ge_e .pfx = false ∧ peAcceptable .ge_e .rsp = true := by
-  exact ⟨rfl, rfl, rfl, rfl⟩
+    peAcceptable .ge_e .pfx = false ∧ peAcceptable .ge_e .rsp = true :=
+  ⟨rfl, rfl, rfl, rfl⟩
 
-/-- Particles are accepted in both -ung and Ge-...-e: they are structurally
-    flexible enough to appear in both configurations. -/
+/-- Particles occur in both *-ung* and *Ge-...-e* — the dual attachment
+options (head or phrase) that constitute the structure problem. -/
 theorem prt_accepted_in_both :
-    peAcceptable .ung .prt = true ∧ peAcceptable .ge_e .prt = true := by
-  exact ⟨rfl, rfl⟩
+    peAcceptable .ung .prt = true ∧ peAcceptable .ge_e .prt = true := ⟨rfl, rfl⟩
 
-/-- Nominalized infinitives accept all three PE types. -/
+/-- Nominalized infinitives accept all three element types ([benz-2025]
+(193)). -/
 theorem nom_inf_maximally_permissive (pe : PreverbalElement) :
     peAcceptable .nomInfinitive pe = true := by
   cases pe <;> rfl
 
-/-- RSPs are blocked in -ung nominalizations — this connects to the
-    co-occurrence restriction: RSPs as phrases cannot incorporate into
-    the complex head structure that -ung creates. -/
-theorem rsp_blocked_in_ung : peAcceptable .ung .rsp = false := rfl
+/-! ### *-ung* and event structure -/
 
-/-- Prefixes are blocked in Ge-...-e nominalizations — the circumfix
-    cannot wrap around a root that already has a prefix head. -/
-theorem pfx_blocked_in_ge_e : peAcceptable .ge_e .pfx = false := rfl
-
-/-- The head/phrase distinction predicts the -ung pattern:
-    heads (pfx) are accepted, phrases (rsp) are not.
-    Particles are the exception — separable but still accepted. -/
-theorem ung_head_phrase_pattern :
-    (peAcceptable .ung .pfx = PreverbalElement.pfx.isHead) ∧
-    (peAcceptable .ung .rsp = PreverbalElement.rsp.isHead) := by
-  exact ⟨rfl, rfl⟩
-
--- ════════════════════════════════════════════════════════════════════
--- Part V: Principled Derivation of the Co-occurrence Paradigm
--- ════════════════════════════════════════════════════════════════════
-
-/-! ### Benz's core theoretical argument (Chs. 4–5)
-
-central claim is that the 9-cell co-occurrence paradigm
-(§6, Table 3) and the PE×nominalization distribution (§16, the table in
-Ch. 5) are not stipulated — they follow from the conjunction of two
-independently motivated principles:
-
-1. **Lexical Integrity** (structural): a phrase cannot incorporate into a
-   head. Only head+head or phrase+head are licit; head+phrase and
-   phrase+phrase are not.
-
-2. **Result State Uniqueness** (interpretive): an event can have at most
-   one telos. Two elements that both obligatorily specify a result state
-   cannot co-occur.
-
-The types `SynLevel` and `ResultStateSpec` below formalize these two
-dimensions abstractly. The compatibility functions `incorporationAllowed`
-and `resultStatesCompatible` are defined purely over these abstract types,
-with no reference to `PreverbalElement`. Only then do we classify each PE
-into these dimensions and prove that the predicted paradigm matches. -/
-
--- ────────────────────────────────────────────────────
--- § 18. Abstract Structural Dimension: Syntactic Level
--- ────────────────────────────────────────────────────
-
-/-- The syntactic level of a morphological element: head (X⁰) or phrase (XP).
-
-    This distinction is standard in X-bar theory and is logically prior to
-    the PE typology — it applies to any syntactic object, not just German
-    preverbal elements. -/
-inductive SynLevel where
-  | head    -- X⁰: can incorporate into other heads
-  | phrase  -- XP: cannot incorporate
-  deriving DecidableEq, Repr
-
-/-- **Lexical Integrity**: a head can take a head complement (head-adjunction
-    / incorporation), and a phrase can take a head complement (normal
-    complementation), but a head cannot take a phrase complement in a
-    word-internal structure, and two phrases cannot form a word.
-
-    This is a general principle of morphosyntactic structure, not specific
-    to German preverbal elements. It follows from the ban on phrasal
-    incorporation (§4.3.1, following Baker 1988). -/
-def incorporationAllowed (outer inner : SynLevel) : Bool :=
-  match outer, inner with
-  | .head,   .head   => true   -- incorporation / head-adjunction
-  | .phrase, .head   => true   -- normal complementation
-  | .head,   .phrase => false  -- *phrasal incorporation
-  | .phrase, .phrase => false  -- *phrase stacking inside a word
-
-/-! #### Cross-framework contrast: the phrase-in-word-slot cell
-
-`ConstructionGrammar.Slot.IsPhraseInWordSlot` — a phrasal filler in a
-zero-level position — is the configuration of phrasal compounds and the
-PAL construction ([goldberg-shirtz-2025]; contemporaneous with this
-dissertation, neither cites the other). In this file's terms that
-configuration is exactly the banned phrasal-incorporation cell: lexical
-integrity rejects what the constructionist analysis licenses (cf.
-`GoldbergShirtz2025.pal_load_bearing`). -/
-
-/-- A CxG bar level in `SynLevel` terms: zero-level positions are head
-sites; bar- and phrase-level positions are phrasal. -/
-def SynLevel.ofBarLevel : ConstructionGrammar.BarLevel → SynLevel
-  | .zero => .head
-  | .bar => .phrase
-  | .phrase => .phrase
-
-/-- The `SynLevel` of a CxG slot filler: word fillers are heads, phrasal
-fillers (with or without a fixed head) are phrases; SEM+ fillers are
-level-unspecified. -/
-def _root_.ConstructionGrammar.SlotFiller.synLevel :
-    ConstructionGrammar.SlotFiller String → Option SynLevel
-  | .fixed _ => some .head
-  | .open_ _ => some .head
-  | .headed _ _ => some .phrase
-  | .phrasal => some .phrase
-  | .semantic _ => none
-
-/-- A phrase in a word-level slot occupies the banned cell: its site is a
-head, its filler a phrase, and `incorporationAllowed` rejects the pair.
-The standing counterexample class is the PAL construction, which licenses
-exactly this configuration. -/
-theorem phraseInWordSlot_incorporation_banned
-    (s : ConstructionGrammar.Slot String) (h : s.IsPhraseInWordSlot) :
-    ∃ site filler,
-      s.level.map SynLevel.ofBarLevel = some site ∧
-      s.filler.synLevel = some filler ∧
-      incorporationAllowed site filler = false := by
-  obtain ⟨hf, hl⟩ := h
-  refine ⟨.head, .phrase, ?_, ?_, rfl⟩ <;>
-    simp [hl, hf, SynLevel.ofBarLevel, ConstructionGrammar.SlotFiller.synLevel]
-
--- ────────────────────────────────────────────────────
--- § 19. Abstract Interpretive Dimension: Result State Specification
--- ────────────────────────────────────────────────────
-
-/-- Whether an element obligatorily introduces a result state specification.
-
-    This is a semantic property that applies to any predicate-modifying
-    element — it is not specific to German PEs. An element that always
-    specifies a result state will conflict with another such element
-    because a single event has at most one telos. -/
-inductive ResultStateSpec where
-  | specifies  -- obligatorily introduces a result state
-  | neutral    -- compatible with either (e.g. directional/completive readings)
-  deriving DecidableEq, Repr
-
-/-- **Result State Uniqueness**: two elements that both obligatorily specify
-    a result state cannot co-occur, because a single event cannot be
-    delimited by two conflicting endpoints.
-
-    This is an instance of a general thematic uniqueness constraint: just as
-    an event has at most one agent (Carlson 1998), it has at most one telos.
-    The constraint is purely interpretive — it says nothing about syntax. -/
-def resultStatesCompatible (a b : ResultStateSpec) : Bool :=
-  match a, b with
-  | .specifies, .specifies => false  -- conflicting result states
-  | _, _ => true
-
--- ────────────────────────────────────────────────────
--- § 20. PE Classification into Abstract Dimensions
--- ────────────────────────────────────────────────────
-
-/-- Classify each PE by its syntactic level.
-
-    §4.3.1: prefixes are heads (inseparable under V2);
-    particles and RSPs are phrases (stranded under V2, can be modified). -/
-def PreverbalElement.synLevel : PreverbalElement → SynLevel
-  | .pfx => .head
-  | .prt => .phrase
-  | .rsp => .phrase
-
-/-- Classify each PE by its result state specification.
-
-    §4.1: prefixes and RSPs obligatorily specify a result
-    state. Particles are neutral — they can have non-delimiting readings
-    (directional, completive) that do not introduce a result state. -/
-def PreverbalElement.resultSpec : PreverbalElement → ResultStateSpec
-  | .pfx => .specifies
-  | .prt => .neutral
-  | .rsp => .specifies
-
--- ────────────────────────────────────────────────────
--- § 21. Bridge: Abstract Classification Matches PE Booleans
--- ────────────────────────────────────────────────────
-
-/-- The abstract `synLevel` classification is equivalent to `isHead`. -/
-theorem synLevel_matches_isHead (pe : PreverbalElement) :
-    (pe.synLevel == .head) = pe.isHead := by
-  cases pe <;> rfl
-
-/-- The abstract `resultSpec` classification is equivalent to
-    `alwaysSpecifiesResult`. -/
-theorem resultSpec_matches_alwaysSpecifies (pe : PreverbalElement) :
-    (pe.resultSpec == .specifies) = pe.alwaysSpecifiesResult := by
-  cases pe <;> rfl
-
--- ────────────────────────────────────────────────────
--- § 22. Blocking Derivations
--- ────────────────────────────────────────────────────
-
-/-- A blocking derivation: a proof that a PE combination violates one of
-    Benz's two independently motivated principles.
-
-    Each constructor is a derivation rule whose premises are stated in terms
-    of the abstract classification (`SynLevel`, `ResultStateSpec`), not
-    PE-specific Booleans. A combination is blocked iff at least one
-    derivation can be constructed.
-
-    **`byLexicalIntegrity`** (§4.3.1, Baker 1988): only
-    heads can occupy the inner (closer-to-root) position in a word-internal
-    combination. A phrasal inner element cannot incorporate.
-
-    **`byResultUniqueness`** (§4.1): an event has at most
-    one telos. Two elements that both obligatorily specify a result state
-    yield conflicting endpoints. -/
-inductive Blocked : PreverbalElement → PreverbalElement → Prop where
-  | byLexicalIntegrity {o i : PreverbalElement} :
-      i.synLevel = .phrase → Blocked o i
-  | byResultUniqueness {o i : PreverbalElement} :
-      o.resultSpec = .specifies → i.resultSpec = .specifies → Blocked o i
-
-/-- Boolean decomposition lemma: `predictedAllowed` factors into the
-    conjunction of the two abstract compatibility functions. Used as a
-    stepping stone in the soundness proof below. -/
-theorem paradigm_from_principles (o i : PreverbalElement) :
-    predictedAllowed o i =
-      (incorporationAllowed o.synLevel i.synLevel &&
-       resultStatesCompatible o.resultSpec i.resultSpec) := by
-  cases o <;> cases i <;> rfl
-
--- ────────────────────────────────────────────────────
--- § 23. Characterization Theorem
--- ────────────────────────────────────────────────────
-
-/-! The derivation system (`Blocked`) is both *sound* and *complete* with
-respect to the empirical paradigm (`predictedAllowed`). Together with
-`combined_prediction_matches` (§9), this means the two principles exactly
-generate the data: every blocked cell has a derivation, every derivation
-corresponds to a blocked cell, and the unique allowed cell (PRT-pfx) has
-no derivation. -/
-
-/-- **Soundness**: every blocking derivation corresponds to a genuinely
-    blocked combination. The theory does not over-generate.
-
-    - `byLexicalIntegrity`: a phrasal inner element makes `incorporationAllowed`
-      return `false` regardless of the outer element's level.
-    - `byResultUniqueness`: two result-specifying elements make
-      `resultStatesCompatible` return `false` regardless of structure. -/
-theorem blocked_sound {o i : PreverbalElement} (h : Blocked o i) :
-    predictedAllowed o i = false := by
-  rw [paradigm_from_principles]
-  cases h with
-  | byLexicalIntegrity hi =>
-    have : incorporationAllowed o.synLevel i.synLevel = false := by
-      rw [hi]; cases o <;> rfl
-    simp [this]
-  | byResultUniqueness ho hi =>
-    have : resultStatesCompatible o.resultSpec i.resultSpec = false := by
-      rw [ho, hi]; rfl
-    simp [this]
-
-/-- **Completeness**: every blocked combination has a blocking derivation.
-    The two principles account for ALL restrictions — nothing is left
-    unexplained.
-
-    For each of the 8 blocked cells, an explicit derivation is constructed
-    (6 by Lexical Integrity, 2 by Result State Uniqueness). For PRT-pfx,
-    the hypothesis is contradictory. -/
-theorem blocked_complete {o i : PreverbalElement}
-    (h : predictedAllowed o i = false) : Blocked o i := by
-  cases o <;> cases i <;>
-    first
-    | exact .byLexicalIntegrity rfl
-    | exact .byResultUniqueness rfl rfl
-    | simp [predictedAllowed, structurallyCompatible, interpretivelyCompatible,
-            PreverbalElement.isHead, PreverbalElement.alwaysSpecifiesResult] at h
-
-/-- **The allowed combination has no derivation.** PRT-pfx is allowed
-    precisely because neither principle applies:
-    - pfx is a head (not a phrase), so Lexical Integrity is satisfied
-    - prt is result-neutral (not specifying), so Result Uniqueness is satisfied
-
-    We examine each possible derivation and show its premises are
-    contradicted by the PE classifications. -/
-theorem prt_pfx_no_derivation : ¬ Blocked .prt .pfx := by
-  intro h
-  cases h with
-  | byLexicalIntegrity hi => exact absurd hi (by decide)
-  | byResultUniqueness ho _ => exact absurd ho (by decide)
-
--- ────────────────────────────────────────────────────
--- § 24. Both Derivation Rules Are Needed
--- ────────────────────────────────────────────────────
-
-/-- pfx-pfx is blocked ONLY by Result State Uniqueness — Lexical Integrity
-    cannot derive it (both are heads, so the inner is not phrasal). This
-    shows the interpretive rule is not redundant. -/
-theorem pfx_pfx_only_by_result :
-    Blocked .pfx .pfx ∧ PreverbalElement.pfx.synLevel ≠ .phrase :=
-  ⟨.byResultUniqueness rfl rfl, by decide⟩
-
-/-- pfx-PRT is blocked ONLY by Lexical Integrity — Result State Uniqueness
-    cannot derive it (PRT is result-neutral). This shows the structural
-    rule is not redundant. -/
-theorem pfx_prt_only_by_structure :
-    Blocked .pfx .prt ∧ PreverbalElement.prt.resultSpec ≠ .specifies :=
-  ⟨.byLexicalIntegrity rfl, by decide⟩
-
-/-- Incorporation depends only on the inner element's level: the outer
-    element's level is irrelevant. This is a derived property of the
-    `incorporationAllowed` function, not stipulated. -/
-theorem incorporation_only_depends_on_inner (outer inner : SynLevel) :
-    incorporationAllowed outer inner = (inner == .head) := by
-  cases outer <;> cases inner <;> rfl
-
--- ────────────────────────────────────────────────────
--- § 24. Ch. 5 Nominalization Distribution from Principles
--- ────────────────────────────────────────────────────
-
-/-- **The nominalization theorem.** *-ung* acceptability (Ch. 5) follows from
-    the same two abstract principles applied reflexively: a PE is acceptable
-    in *-ung* iff it can incorporate with itself (headedness) OR its result
-    state does not conflict with itself (neutrality).
-
-    This connects Ch. 5 to Ch. 4: the PE×nominalization distribution is not
-    an independent observation — it is a projection of the same two principles
-    that generate the co-occurrence paradigm. -/
-theorem ung_from_principles (pe : PreverbalElement) :
-    peAcceptable .ung pe =
-      (incorporationAllowed pe.synLevel pe.synLevel ||
-       resultStatesCompatible pe.resultSpec pe.resultSpec) := by
-  cases pe <;> rfl
-
-/-- *Ge-...-e* acceptability reduces to a single abstract principle:
-    a PE is acceptable in *Ge-...-e* iff it is a phrase (not a head).
-    The circumfix directly nominalizes the root, so only non-head elements
-    are compatible. -/
-theorem ge_e_from_principles (pe : PreverbalElement) :
-    peAcceptable .ge_e pe = (pe.synLevel == .phrase) := by
-  cases pe <;> rfl
-
-/-- The *-ung* / *Ge-...-e* mirror: for heads, the two nominalization types
-    give opposite results. This follows from `ge_e_from_principles` and the
-    fact that heads satisfy `incorporationAllowed` reflexively. -/
-theorem ung_ge_e_mirror (pe : PreverbalElement) (h : pe.synLevel = .head) :
-    peAcceptable .ung pe = true ∧ peAcceptable .ge_e pe = false := by
-  cases pe <;> simp_all [PreverbalElement.synLevel, peAcceptable]
-
--- ────────────────────────────────────────────────────
--- § 25. End-to-End: Root Semantics → v Allosemy → Nominalization → PE
--- ────────────────────────────────────────────────────
-
-/-! These theorems chain through four independently defined modules:
-`Verb/Root/Classification.lean` (root semantics) → `Allosemy.lean` (v alloseme
-selection) → `Allosemy.lean` (nominalization reading) → `Benz2025.lean`
-(PE distribution from abstract principles). No single module defines
-the full path. -/
-
-/-- End-to-end for result roots: a result root selects eventive v, yielding
-    CEN in *-ung* nominalizations. *-ung* accepts heads (pfx) and rejects
-    phrases that specify results (RSP) — both predictions derived from
-    the abstract principles, not from the `peAcceptable` table. -/
-theorem end_to_end_result_root :
-    let v := VAlloseme.fromRootType .result
-    v = .eventive ∧
-    readingFromAllosemes v .sortal = some .complexEvent ∧
-    -- PE distribution derived from principles, not table lookup
-    incorporationAllowed (PreverbalElement.pfx).synLevel (PreverbalElement.pfx).synLevel = true ∧
-    resultStatesCompatible (PreverbalElement.rsp).resultSpec (PreverbalElement.rsp).resultSpec = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
-
-/-- Mirror chain for PC roots: zero v → simple entity reading → *Ge-...-e*,
-    which accepts phrases (RSP) and rejects heads (pfx). -/
-theorem end_to_end_pc_root :
-    let v := VAlloseme.fromRootType .propertyConcept
-    v = .zero ∧
-    readingFromAllosemes v .sortal = some .simpleEntity ∧
-    -- Ge-...-e distribution: phrase (RSP) accepted, head (pfx) rejected
-    ((PreverbalElement.rsp).synLevel == .phrase) = true ∧
-    ((PreverbalElement.pfx).synLevel == .phrase) = false :=
-  ⟨rfl, rfl, rfl, rfl⟩
-
--- ════════════════════════════════════════════════════════════════════
--- Part VI: Fragment Grounding
--- ════════════════════════════════════════════════════════════════════
-
--- ────────────────────────────────────────────────────
--- § 21. -ung Nominalizability (Event Structure)
--- ────────────────────────────────────────────────────
-
-/-- Whether a verb can undergo *-ung* nominalization, based on its
-    Vendler class.
-
-    Ch. 5, following Roßdeutscher & Kamp (2010):
-    *-ung* requires complex change-of-state event structure. Only
-    accomplishments and achievements (which contain a result state
-    component) qualify. Activities and states do not. -/
+/-- Whether a verb can undergo *-ung* nominalization. [rossdeutscher-kamp-2010]
+(endorsed at [benz-2025] §5.3.1): *-ung* requires complex ("bi-eventive")
+change-of-state event structure. Over this fragment's entries, the bi-eventive
+verbs are the accomplishments (prefix/particle change-of-state verbs); the
+simplex deadjectival cases ([benz-2025] (199), *Klär-ung*) are not
+represented. -/
 def canUngNominalize : Option VendlerClass → Bool
   | some .accomplishment => true
-  | some .achievement => true
   | _ => false
 
-/-- Activity simplex verbs cannot form *-ung* nominalizations:
-    **Hämmer-ung*, **Mal-ung*, **Küss-ung*. -/
-theorem activity_no_ung :
+/-- The (198c) minimal pair: **Mal-ung* vs *Be-mal-ung* — the prefix supplies
+the complex change-of-state structure *-ung* needs, derived here from the
+fragment entries' Vendler classes. -/
+theorem malen_bemalen_ung_contrast :
+    canUngNominalize malen.vendlerClass = false ∧
+    canUngNominalize bemalen.vendlerClass = true := ⟨rfl, rfl⟩
+
+/-- Simplex activity verbs cannot form *-ung* nominalizations ([benz-2025]
+(198): **Mal-ung*, **Arbeit-ung*, **Schieß-ung*; the other fragment activities
+pattern identically). -/
+theorem simplex_activity_no_ung :
     canUngNominalize haemmern.vendlerClass = false ∧
     canUngNominalize malen.vendlerClass = false ∧
     canUngNominalize kuessen.vendlerClass = false ∧
     canUngNominalize fuehren.vendlerClass = false ∧
-    canUngNominalize rauben.vendlerClass = false := by
-  refine ⟨?_, ?_, ?_, ?_, ?_⟩ <;> rfl
+    canUngNominalize rauben.vendlerClass = false :=
+  ⟨rfl, rfl, rfl, rfl, rfl⟩
 
-/-- Prefix/particle verbs with complex event structure CAN form
-    *-ung* nominalizations: *Beobacht-ung*, *Einführ-ung*, *Verbind-ung*. -/
-theorem complex_event_ung :
+/-- Prefix and particle verbs with complex event structure form *-ung*
+nominalizations ([benz-2025] (197): *Ein-führ-ung*, *Ver-bind-ung*; Ch. 3:
+*Beobacht-ung*). -/
+theorem complex_change_of_state_ung :
     canUngNominalize beobachten.vendlerClass = true ∧
     canUngNominalize einfuehren.vendlerClass = true ∧
-    canUngNominalize verbinden.vendlerClass = true ∧
-    canUngNominalize brechen.vendlerClass = true := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> rfl
+    canUngNominalize verbinden.vendlerClass = true :=
+  ⟨rfl, rfl, rfl⟩
 
--- ────────────────────────────────────────────────────
--- § 22. Fragment Entries Ground RSP Data
--- ────────────────────────────────────────────────────
+/-! ### Fragment grounding -/
 
 /-- Transitivity derived from fragment fields (not from a raw string). -/
 def isTransitiveVerb (v : GermanVerbEntry) : Bool :=
   v.complementType == .np && !v.unaccusative
 
-/-- The verb classifications in the RSP data (§10, encoded as raw strings)
-    are derivable from the fragment entries' typed fields. Changing
-    *frieren*'s `unaccusative` field or *hämmern*'s `complementType` would
-    break this theorem without touching the RSP data. -/
+/-- The verb classifications in the RSP data are derivable from the fragment
+entries' typed fields: changing *frieren*'s `unaccusative` field or
+*hämmern*'s `complementType` would break this theorem without touching the
+RSP data. -/
 theorem rsp_data_grounded_in_fragments :
     isTransitiveVerb haemmern = true ∧
     isTransitiveVerb brechen = true ∧
     frieren.unaccusative = true ∧
     isTransitiveVerb frieren = false := ⟨rfl, rfl, rfl, rfl⟩
 
--- ────────────────────────────────────────────────────
--- § 23. Root Type → v Alloseme on Fragment Entries
--- ────────────────────────────────────────────────────
-
-/-- *brechen* (result root) and *frieren* (PC root) yield opposite v
-    allosemes. This connects three modules: the fragment entry's
-    `rootType` (Predicates.lean), `VAlloseme.fromRootType` (Allosemy.lean),
-    and `VAlloseme.introducesEvent` (Allosemy.lean). -/
+/-- *brechen* (result root) and *frieren* (property-concept root) yield
+opposite canonical v allosemes, connecting the fragment's `rootType` to
+`VAlloseme.fromRootType` and `VAlloseme.introducesEvent`. -/
 theorem rootType_alloseme_divergence :
     brechen.rootType.map VAlloseme.fromRootType = some .eventive ∧
     frieren.rootType.map VAlloseme.fromRootType = some .zero ∧
@@ -1098,32 +786,19 @@ theorem rootType_alloseme_divergence :
     frieren.rootType.map (VAlloseme.fromRootType · |>.introducesEvent) = some false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
-/-- The allosemy-based CEN prediction and the event-structure-based *-ung*
-    prediction agree for *brechen*: result root → eventive v → CEN reading
-    → can -ung, and achievement vendlerClass → can -ung. Two independent
-    paths to the same conclusion. -/
-theorem brechen_two_paths :
-    -- Path 1: rootType → VAlloseme → readingFromAllosemes → CEN
-    brechen.rootType.bind (λ rt =>
-      readingFromAllosemes (VAlloseme.fromRootType rt) .sortal)
-      = some .complexEvent ∧
-    -- Path 2: vendlerClass → canUngNominalize
-    canUngNominalize brechen.vendlerClass = true := ⟨rfl, rfl⟩
+/-- End-to-end for *brechen*: result root → eventive v → with vacuous n, the
+complex event reading. -/
+theorem brechen_cen_path :
+    brechen.rootType.bind
+      (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .zero) =
+      some .complexEvent := rfl
 
-/-- The two paths DISAGREE for *frieren*: the canonical PC root → zero
-    v → RN (not CEN), yet the achievement vendlerClass → can -ung. This
-    is not a bug — it captures key insight that allosemy
-    means BOTH v allosemes are available for any verb. The canonical
-    alloseme is a default, not a constraint. *Frieren* CAN have eventive v
-    and thus CAN form a CEN, even though its canonical alloseme is zero. -/
-theorem frieren_canonical_vs_possible :
-    -- Canonical path: PC root → zero v → simple entity (no CEN)
-    frieren.rootType.bind (λ rt =>
-      readingFromAllosemes (VAlloseme.fromRootType rt) .sortal)
-      = some .simpleEntity ∧
-    -- But -ung is still possible (achievement vendlerClass)
-    canUngNominalize frieren.vendlerClass = true ∧
-    -- Because eventive v is always available (that's what allosemy means)
-    readingFromAllosemes .eventive .sortal = some .complexEvent := ⟨rfl, rfl, rfl⟩
+/-- End-to-end for *frieren*: property-concept root → vacuous v → with entity
+n, the simple entity reading. Allosemy makes the eventive v available too —
+the canonical alloseme is a default, not a constraint. -/
+theorem frieren_entity_path :
+    frieren.rootType.bind
+      (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .entity) =
+      some .simpleEntity := rfl
 
 end Benz2025

--- a/references.bib
+++ b/references.bib
@@ -1638,6 +1638,73 @@
   role      = {formalized},
   validated = {true},
   sources   = {Morphology/DM/Allosemy.lean;Studies/Benz2025.lean}
+}
+@book{williams-2015,
+  author    = {Williams, Alexander},
+  year      = {2015},
+  title     = {Arguments in Syntax and Semantics},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  subfield  = {semantics/lexical},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
+}
+@article{creemers-2020,
+  author    = {Creemers, Ava},
+  year      = {2020},
+  title     = {Resultative Secondary Predicates and Prefixes in {German} and {Dutch}},
+  journal   = {University of Pennsylvania Working Papers in Linguistics},
+  volume    = {26},
+  number    = {1},
+  pages     = {67--76},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
+}
+@incollection{wurmbrand-1998,
+  author    = {Wurmbrand, Susi},
+  year      = {1998},
+  title     = {Heads or Phrases? {P}articles in Particular},
+  booktitle = {Phonology and Morphology of the Germanic Languages},
+  editor    = {Kehrein, Wolfgang and Wiese, Richard},
+  publisher = {Niemeyer},
+  address   = {T{\"u}bingen},
+  pages     = {267--295},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
+}
+@book{zeller-2001,
+  author    = {Zeller, Jochen},
+  year      = {2001},
+  title     = {Particle Verbs and Local Domains},
+  publisher = {John Benjamins},
+  address   = {Amsterdam},
+  subfield  = {syntax},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
+}
+@book{luedeling-2001,
+  author    = {L{\"u}deling, Anke},
+  year      = {2001},
+  title     = {On Particle Verbs and Similar Constructions in {German}},
+  publisher = {CSLI Publications},
+  address   = {Stanford, CA},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
+}
+@incollection{rossdeutscher-kamp-2010,
+  author    = {Ro{\ss}deutscher, Antje and Kamp, Hans},
+  year      = {2010},
+  title     = {Syntactic and Semantic Constraints on the Formation and Interpretation of \emph{ung}-Nouns},
+  booktitle = {The Semantics of Nominalizations across Languages and Frameworks},
+  editor    = {Alexiadou, Artemis and Rathert, Monika},
+  publisher = {De Gruyter Mouton},
+  address   = {Berlin},
+  subfield  = {morphology},
+  role      = {cited},
+  sources   = {Studies/Benz2025.lean}
 }% REF: Benz & Salzmann (2025). Evidence from German for N-stranding NP-ellipsis.
 @inproceedings{benz-salzmann-2025,
   author    = {Benz, Johanna and Salzmann, Martin},


### PR DESCRIPTION
Audit of Studies/Benz2025.lean against the Benz (2025) dissertation PDF. Fixes fabricated content and regrounds derivations:

- Table 3 encoded as printed (8 rows, merged pfx/PRT-RSP row, tri-valued factor cells for the parenthesized checks); invented examples (*ver-platt-hämmern*, *an-wach-küssen*) and a fabricated PRT-RSP interpretation cell removed; fabricated citations (Carlson 1998, Baker-1988-as-phrasal-incorporation) replaced by Tenny 1994's Single Delimiting Constraint as the paper has it.
- Ch. 5 PE-by-nominalization table now derived from the three structure-problem solutions the dissertation argues for (phrasal inputs / particles-as-heads / outer attachment), replacing a coincidental boolean disjunction; *Beobachtung* (32) sentences corrected; *-ung* classifier no longer predicts nonexistent *Frierung.
- Allosemy substrate: content readings no longer require eventive v (contradicted by Table 2's *Gerücht* row); v-vacuous result/content cells added per §3.5's adopted analysis; falsely benz-attributed sortal cells dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)