### PR TITLE
refactor(Studies/Benz2025): register, JSON stimuli, engine readings

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2923,3 +2923,4 @@ import Linglib.Data.Examples.Hacquard2006
 import Linglib.Data.Examples.StankovaSimik2025
 import Linglib.Data.Examples.Baker1985
 import Linglib.Data.Examples.FillmoreKayOConnor1988
+import Linglib.Data.Examples.Benz2025

--- a/Linglib/Data/Examples/Benz2025.json
+++ b/Linglib/Data/Examples/Benz2025.json
@@ -1,0 +1,312 @@
+[
+  {
+    "id": "benz2025_ex32a",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(32a)"},
+    "language": "stan1295",
+    "primaryText": "Die Beobachtung des Nachthimmels dauerte drei Stunden",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Die", "the"], ["Beobacht-ung", "observe-NMLZ"], ["des", "the.GEN"],
+      ["Nachthimmels", "night.sky"], ["dauerte", "took"], ["drei", "three"], ["Stunden", "hours"]
+    ],
+    "translation": "The observation of the night sky took three hours.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["reading", "Event"],
+      ["duration_predicate", "yes"],
+      ["plural", "no"],
+      ["cp_complement", "no"]
+    ],
+    "comment": "The Event member of the three-way ambiguity; the duration predicate diagnoses the complex event reading."
+  },
+  {
+    "id": "benz2025_ex32b",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(32b)"},
+    "language": "stan1295",
+    "primaryText": "Die Beobachtungen der Astronomin sind für immer verloren",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Die", "the"], ["Beobacht-ung-en", "observe-NMLZ-PL"], ["der", "the.GEN"],
+      ["Astronomin", "astronomer"], ["sind", "are"], ["für", "for"], ["immer", "ever"],
+      ["verloren", "lost"]
+    ],
+    "translation": "The astronomer's observations are lost forever.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [
+      {"name": "concrete object", "judgment": "acceptable"},
+      {"name": "result", "judgment": "acceptable"},
+      {"name": "content", "judgment": "acceptable"}
+    ],
+    "paperFeatures": [
+      ["reading", "RN"],
+      ["duration_predicate", "no"],
+      ["plural", "yes"],
+      ["cp_complement", "no"]
+    ],
+    "comment": "The RN member; in this context the pluralized nominalization can refer to concrete objects, to results, or in principle to contents."
+  },
+  {
+    "id": "benz2025_ex32c",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(32c)"},
+    "language": "stan1295",
+    "primaryText": "Seine Beobachtung, dass Planeten sich bewegen, veränderte die Wissenschaft",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Seine", "his"], ["Beobacht-ung", "observe-NMLZ"], ["dass", "COMP"],
+      ["Planeten", "planets"], ["sich", "REFL"], ["bewegen", "move"], ["veränderte", "changed"],
+      ["die", "the"], ["Wissenschaft", "science"]
+    ],
+    "translation": "His observation that planets move changed the science.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["reading", "Content"],
+      ["duration_predicate", "no"],
+      ["plural", "no"],
+      ["cp_complement", "yes"]
+    ],
+    "comment": "The Content member; the CP complement specifies the content the noun refers to."
+  },
+  {
+    "id": "benz2025_ex89a",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(89a)"},
+    "language": "stan1295",
+    "primaryText": "Er hämmerte das Metall platt",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Er", "he"], ["hämmerte", "hammered"], ["das", "the.ACC"], ["Metall", "metal"],
+      ["platt", "flat"]
+    ],
+    "translation": "He hammered the metal flat.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["verb_class", "transitive"],
+      ["m_predicate", "hämmern"],
+      ["r_predicate", "platt"]
+    ],
+    "comment": "V2 order with the RSP in clause-final base position."
+  },
+  {
+    "id": "benz2025_ex89b",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(89b)"},
+    "language": "stan1295",
+    "primaryText": "Er schießt seinen Gegner tot",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Er", "he"], ["schießt", "shoots"], ["seinen", "his.ACC"], ["Gegner", "opponent"],
+      ["tot", "dead"]
+    ],
+    "translation": "He shoots his opponent dead.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["verb_class", "transitive"],
+      ["m_predicate", "schießen"],
+      ["r_predicate", "tot"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "benz2025_ex115a",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(115a)"},
+    "language": "stan1295",
+    "primaryText": "Hans hat den Stock kaputt gebrochen",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hans", "Hans"], ["hat", "has"], ["den", "the.ACC"], ["Stock", "stick"],
+      ["kaputt", "broken"], ["gebrochen", "broken.PTCP"]
+    ],
+    "translation": "Hans broke the stick.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["verb_class", "obligatorily transitive"],
+      ["m_predicate", "brechen"],
+      ["r_predicate", "kaputt"]
+    ],
+    "comment": "An RSP is in fact obligatory on most uses of brechen ((116))."
+  },
+  {
+    "id": "benz2025_ex115e",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(115e)"},
+    "language": "stan1295",
+    "primaryText": "Das Wasser fror fest",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Das", "the.NOM"], ["Wasser", "water"], ["fror", "froze"], ["fest", "solid"]
+    ],
+    "translation": "The water froze solid.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["verb_class", "unaccusative"],
+      ["m_predicate", "frieren"],
+      ["r_predicate", "fest"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "benz2025_ex115f",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(115f)"},
+    "language": "stan1295",
+    "primaryText": "Sie haben sich krank/tot geschämt",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sie", "they"], ["haben", "have"], ["sich", "REFL"], ["krank/tot", "sick/dead"],
+      ["geschämt", "shamed.PTCP"]
+    ],
+    "translation": "They were embarrassed sick/dead.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["verb_class", "inherently reflexive"],
+      ["m_predicate", "schämen"],
+      ["r_predicate", "krank/tot"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "benz2025_ex87ab",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(87a-b)"},
+    "language": "stan1295",
+    "primaryText": "Sie haben uns arm geraubt",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sie", "they"], ["haben", "have"], ["uns", "us.ACC"], ["arm", "poor"],
+      ["geraubt", "robbed.PTCP"]
+    ],
+    "translation": "They robbed us poor.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Sie haben uns arm be-raubt", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["blocker_type", "prefix"],
+      ["blocker", "be-"],
+      ["r_predicate", "arm"]
+    ],
+    "comment": "The ge- of the grammatical form is participial, not a prefix in the relevant sense."
+  },
+  {
+    "id": "benz2025_ex87cd",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(87c-d)"},
+    "language": "stan1295",
+    "primaryText": "Sie haben ihn tot geschossen",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sie", "they"], ["haben", "have"], ["ihn", "him.ACC"], ["tot", "dead"],
+      ["geschossen", "shot.PTCP"]
+    ],
+    "translation": "They shot him dead.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Sie haben ihn tot er-schossen", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["blocker_type", "prefix"],
+      ["blocker", "er-"],
+      ["r_predicate", "tot"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "benz2025_ex87ef",
+    "source": {"bibkey": "creemers-2020", "paperLabel": ""},
+    "reportedIn": {"bibkey": "benz-2025", "paperLabel": "(87e-f)"},
+    "language": "stan1295",
+    "primaryText": "Hans hat den Stock kaputt gebrochen",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Hans", "Hans"], ["hat", "has"], ["den", "the.ACC"], ["Stock", "stick"],
+      ["kaputt", "broken.ADJ"], ["gebrochen", "broken.PTCP"]
+    ],
+    "translation": "Hans broke the stick broken.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Hans hat den Stock kaputt zer-brochen", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["blocker_type", "prefix"],
+      ["blocker", "zer-"],
+      ["r_predicate", "kaputt"]
+    ],
+    "comment": "Same grammatical baseline as (115a)."
+  },
+  {
+    "id": "benz2025_ex88ab",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(88a-b)"},
+    "language": "stan1295",
+    "primaryText": "Sie hat den Tisch trocken gewischt",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Sie", "she"], ["hat", "has"], ["den", "the.ACC"], ["Tisch", "table"], ["trocken", "dry"],
+      ["gewischt", "wiped.PTCP"]
+    ],
+    "translation": "She wiped the table dry.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Sie hat den Tisch trocken ab-gewischt", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["blocker_type", "particle"],
+      ["blocker", "ab-"],
+      ["r_predicate", "trocken"]
+    ],
+    "comment": "The starred form is grammatical only under an adverbial reading of trocken, not the intended resultative one."
+  },
+  {
+    "id": "benz2025_ex88cd",
+    "source": {"bibkey": "benz-2025", "paperLabel": "(88c-d)"},
+    "language": "stan1295",
+    "primaryText": "Das Baby hat mich nass gespuckt",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Das", "the"], ["Baby", "baby"], ["hat", "has"], ["mich", "me.ACC"], ["nass", "wet"],
+      ["gespuckt", "spit.PTCP"]
+    ],
+    "translation": "The baby spat up on me.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Das Baby hat mich nass an-gespuckt", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["blocker_type", "particle"],
+      ["blocker", "an-"],
+      ["r_predicate", "nass"]
+    ],
+    "comment": "an- is not characterizable as a resultative particle, yet still blocks the RSP."
+  }
+]

--- a/Linglib/Data/Examples/Benz2025.lean
+++ b/Linglib/Data/Examples/Benz2025.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Benz2025` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Benz2025.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Benz2025.Examples`.
+-/
+
+namespace Benz2025.Examples
+
+open Data.Examples
+
+def ex32a : LinguisticExample :=
+  { id := "benz2025_ex32a"
+    source := ⟨"benz-2025", "(32a)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Die Beobachtung des Nachthimmels dauerte drei Stunden"
+    discourseSegments := []
+    glossedTokens := [("Die", "the"), ("Beobacht-ung", "observe-NMLZ"), ("des", "the.GEN"), ("Nachthimmels", "night.sky"), ("dauerte", "took"), ("drei", "three"), ("Stunden", "hours")]
+    translation := "The observation of the night sky took three hours."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("reading", "Event"), ("duration_predicate", "yes"), ("plural", "no"), ("cp_complement", "no")]
+    comment := "The Event member of the three-way ambiguity; the duration predicate diagnoses the complex event reading."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex32b : LinguisticExample :=
+  { id := "benz2025_ex32b"
+    source := ⟨"benz-2025", "(32b)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Die Beobachtungen der Astronomin sind für immer verloren"
+    discourseSegments := []
+    glossedTokens := [("Die", "the"), ("Beobacht-ung-en", "observe-NMLZ-PL"), ("der", "the.GEN"), ("Astronomin", "astronomer"), ("sind", "are"), ("für", "for"), ("immer", "ever"), ("verloren", "lost")]
+    translation := "The astronomer's observations are lost forever."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := [("concrete object", .acceptable), ("result", .acceptable), ("content", .acceptable)]
+    paperFeatures := [("reading", "RN"), ("duration_predicate", "no"), ("plural", "yes"), ("cp_complement", "no")]
+    comment := "The RN member; in this context the pluralized nominalization can refer to concrete objects, to results, or in principle to contents."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex32c : LinguisticExample :=
+  { id := "benz2025_ex32c"
+    source := ⟨"benz-2025", "(32c)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Seine Beobachtung, dass Planeten sich bewegen, veränderte die Wissenschaft"
+    discourseSegments := []
+    glossedTokens := [("Seine", "his"), ("Beobacht-ung", "observe-NMLZ"), ("dass", "COMP"), ("Planeten", "planets"), ("sich", "REFL"), ("bewegen", "move"), ("veränderte", "changed"), ("die", "the"), ("Wissenschaft", "science")]
+    translation := "His observation that planets move changed the science."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("reading", "Content"), ("duration_predicate", "no"), ("plural", "no"), ("cp_complement", "yes")]
+    comment := "The Content member; the CP complement specifies the content the noun refers to."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex89a : LinguisticExample :=
+  { id := "benz2025_ex89a"
+    source := ⟨"benz-2025", "(89a)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Er hämmerte das Metall platt"
+    discourseSegments := []
+    glossedTokens := [("Er", "he"), ("hämmerte", "hammered"), ("das", "the.ACC"), ("Metall", "metal"), ("platt", "flat")]
+    translation := "He hammered the metal flat."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb_class", "transitive"), ("m_predicate", "hämmern"), ("r_predicate", "platt")]
+    comment := "V2 order with the RSP in clause-final base position."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex89b : LinguisticExample :=
+  { id := "benz2025_ex89b"
+    source := ⟨"benz-2025", "(89b)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Er schießt seinen Gegner tot"
+    discourseSegments := []
+    glossedTokens := [("Er", "he"), ("schießt", "shoots"), ("seinen", "his.ACC"), ("Gegner", "opponent"), ("tot", "dead")]
+    translation := "He shoots his opponent dead."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb_class", "transitive"), ("m_predicate", "schießen"), ("r_predicate", "tot")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex115a : LinguisticExample :=
+  { id := "benz2025_ex115a"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(115a)"⟩
+    language := "stan1295"
+    primaryText := "Hans hat den Stock kaputt gebrochen"
+    discourseSegments := []
+    glossedTokens := [("Hans", "Hans"), ("hat", "has"), ("den", "the.ACC"), ("Stock", "stick"), ("kaputt", "broken"), ("gebrochen", "broken.PTCP")]
+    translation := "Hans broke the stick."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb_class", "obligatorily transitive"), ("m_predicate", "brechen"), ("r_predicate", "kaputt")]
+    comment := "An RSP is in fact obligatory on most uses of brechen ((116))."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex115e : LinguisticExample :=
+  { id := "benz2025_ex115e"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(115e)"⟩
+    language := "stan1295"
+    primaryText := "Das Wasser fror fest"
+    discourseSegments := []
+    glossedTokens := [("Das", "the.NOM"), ("Wasser", "water"), ("fror", "froze"), ("fest", "solid")]
+    translation := "The water froze solid."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb_class", "unaccusative"), ("m_predicate", "frieren"), ("r_predicate", "fest")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex115f : LinguisticExample :=
+  { id := "benz2025_ex115f"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(115f)"⟩
+    language := "stan1295"
+    primaryText := "Sie haben sich krank/tot geschämt"
+    discourseSegments := []
+    glossedTokens := [("Sie", "they"), ("haben", "have"), ("sich", "REFL"), ("krank/tot", "sick/dead"), ("geschämt", "shamed.PTCP")]
+    translation := "They were embarrassed sick/dead."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("verb_class", "inherently reflexive"), ("m_predicate", "schämen"), ("r_predicate", "krank/tot")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex87ab : LinguisticExample :=
+  { id := "benz2025_ex87ab"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(87a-b)"⟩
+    language := "stan1295"
+    primaryText := "Sie haben uns arm geraubt"
+    discourseSegments := []
+    glossedTokens := [("Sie", "they"), ("haben", "have"), ("uns", "us.ACC"), ("arm", "poor"), ("geraubt", "robbed.PTCP")]
+    translation := "They robbed us poor."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Sie haben uns arm be-raubt", .ungrammatical)]
+    readings := []
+    paperFeatures := [("blocker_type", "prefix"), ("blocker", "be-"), ("r_predicate", "arm")]
+    comment := "The ge- of the grammatical form is participial, not a prefix in the relevant sense."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex87cd : LinguisticExample :=
+  { id := "benz2025_ex87cd"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(87c-d)"⟩
+    language := "stan1295"
+    primaryText := "Sie haben ihn tot geschossen"
+    discourseSegments := []
+    glossedTokens := [("Sie", "they"), ("haben", "have"), ("ihn", "him.ACC"), ("tot", "dead"), ("geschossen", "shot.PTCP")]
+    translation := "They shot him dead."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Sie haben ihn tot er-schossen", .ungrammatical)]
+    readings := []
+    paperFeatures := [("blocker_type", "prefix"), ("blocker", "er-"), ("r_predicate", "tot")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex87ef : LinguisticExample :=
+  { id := "benz2025_ex87ef"
+    source := ⟨"creemers-2020", ""⟩
+    reportedIn := some ⟨"benz-2025", "(87e-f)"⟩
+    language := "stan1295"
+    primaryText := "Hans hat den Stock kaputt gebrochen"
+    discourseSegments := []
+    glossedTokens := [("Hans", "Hans"), ("hat", "has"), ("den", "the.ACC"), ("Stock", "stick"), ("kaputt", "broken.ADJ"), ("gebrochen", "broken.PTCP")]
+    translation := "Hans broke the stick broken."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Hans hat den Stock kaputt zer-brochen", .ungrammatical)]
+    readings := []
+    paperFeatures := [("blocker_type", "prefix"), ("blocker", "zer-"), ("r_predicate", "kaputt")]
+    comment := "Same grammatical baseline as (115a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex88ab : LinguisticExample :=
+  { id := "benz2025_ex88ab"
+    source := ⟨"benz-2025", "(88a-b)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Sie hat den Tisch trocken gewischt"
+    discourseSegments := []
+    glossedTokens := [("Sie", "she"), ("hat", "has"), ("den", "the.ACC"), ("Tisch", "table"), ("trocken", "dry"), ("gewischt", "wiped.PTCP")]
+    translation := "She wiped the table dry."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Sie hat den Tisch trocken ab-gewischt", .ungrammatical)]
+    readings := []
+    paperFeatures := [("blocker_type", "particle"), ("blocker", "ab-"), ("r_predicate", "trocken")]
+    comment := "The starred form is grammatical only under an adverbial reading of trocken, not the intended resultative one."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex88cd : LinguisticExample :=
+  { id := "benz2025_ex88cd"
+    source := ⟨"benz-2025", "(88c-d)"⟩
+    reportedIn := none
+    language := "stan1295"
+    primaryText := "Das Baby hat mich nass gespuckt"
+    discourseSegments := []
+    glossedTokens := [("Das", "the"), ("Baby", "baby"), ("hat", "has"), ("mich", "me.ACC"), ("nass", "wet"), ("gespuckt", "spit.PTCP")]
+    translation := "The baby spat up on me."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Das Baby hat mich nass an-gespuckt", .ungrammatical)]
+    readings := []
+    paperFeatures := [("blocker_type", "particle"), ("blocker", "an-"), ("r_predicate", "nass")]
+    comment := "an- is not characterizable as a resultative particle, yet still blocks the RSP."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex32a, ex32b, ex32c, ex89a, ex89b, ex115a, ex115e, ex115f, ex87ab, ex87cd, ex87ef, ex88ab, ex88cd]
+
+end Benz2025.Examples

--- a/Linglib/Morphology/DM/Allosemy.lean
+++ b/Linglib/Morphology/DM/Allosemy.lean
@@ -181,6 +181,14 @@ structure AllosemicHead (Sem : Type) where
 def AllosemicHead.allosemeCount {Sem : Type} (h : AllosemicHead Sem) : Nat :=
   h.entries.length
 
+/-- The denotations licensed for the head in context `c` — the entries whose
+conditioning context matches `c`. Alloseme ambiguity in a context is
+non-singleton licensing, and the canonical default among the licensed
+entries is the Elsewhere winner (`selectBy_score_isElsewhereWinner`). -/
+def AllosemicHead.licensed {Sem : Type} (h : AllosemicHead Sem)
+    (c : SyntacticContext) : List Sem :=
+  (h.entries.filter (·.context.matches c)).map (·.denotation)
+
 /-! ### Allosemy on the exponence core
 
 An `AllosemicEntry` is a rule of exponence (`Morphology/Exponence/`): its

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -1,131 +1,78 @@
 import Linglib.Morphology.DM.Allosemy
 import Linglib.Syntax.ConstructionGrammar.Basic
-import Linglib.Features.Acceptability
+import Linglib.Data.Examples.Benz2025
 import Linglib.Fragments.German.Predicates
 
 /-!
 # Benz (2025): Structure and Interpretation Across Categories
 
-[benz-2025], PhD dissertation, University of Pennsylvania. Three case studies of
-the syntax–LF interface in German, unified by contextual allosemy
-(`Morphology.DM.Allosemy`):
+Three case studies from [benz-2025] (PhD dissertation, University of
+Pennsylvania) on the syntax–LF interface in German, all running on the
+contextual-allosemy substrate of `Morphology.DM.Allosemy`. Nominalizations
+like *Beobachtung* carry event, referential, and content readings from a
+single syntactic structure, with the variation located in the allosemes of v
+and n (Ch. 3). The co-occurrence restrictions among prefixes, particles, and
+resultative secondary predicates follow from the conjunction of a
+phrase-structural factor and an event-structural one, [tenny-1994]'s Single
+Delimiting Constraint (Ch. 4, Table 3). The three nominalization types
+resolve the particle "structure problem" ([luedeling-2001]) in three
+different ways — phrasal inputs, particles-as-heads, outer attachment — from
+which the distribution of preverbal elements across them follows (Ch. 5).
 
-1. **Content nominalizations** (Ch. 3): nominalizations like *Beobachtung* have
-   event, referential (RN), and content readings, all from one syntactic
-   structure — n over a prefixed complex verbal head — with the variation
-   located in the allosemes of v and n. The content reading rests on an
-   n[CONTENT] alloseme that composes with a CP complement.
-2. **Prefixes, particles, and resultatives** (Ch. 4): the co-occurrence
-   restrictions among the three preverbal-element types (Table 3) follow from
-   the conjunction of two independent factors — phrase structure (particles and
-   resultative secondary predicates are phrasal complements of the verb, which
-   has only one complement position; prefixes form a complex head with the
-   root) and event structure (an event is delimited at most once,
-   [tenny-1994]'s Single Delimiting Constraint).
-3. **Prefixes in nominalizations** (Ch. 5): the three nominalization types
-   resolve the particle "structure problem" ([luedeling-2001]) differently —
-   phrasal inputs (nominalized infinitive), particles-as-heads (*-ung*), outer
-   attachment (*Ge-...-e*) — and the distribution of preverbal elements across
-   them follows.
+The (32), (87)–(89), and (115) stimuli live in `Data.Examples.Benz2025`.
+`availableReadings` derives the reading inventory from the exponence engine's
+licensed allosemes, with `adopted_unique` characterizing the adopted analysis
+as the unique economical derivation of each reading; `blocked_sound` and
+`blocked_complete` show the two Ch. 4 principles exactly generate the
+co-occurrence paradigm; `peAcceptable_from_solutions` derives the Ch. 5
+distribution from the structure-problem solutions.
 -/
 
 namespace Benz2025
 
-open Morphology.DM.Allosemy
-open Features (Acceptability VendlerClass)
-open German.Predicates
-open ArgumentStructure
+open Morphology.DM.Allosemy Data.Examples German.Predicates ArgumentStructure
+open Features (VendlerClass)
 
-/-! ## Part I: Content nominalizations (Ch. 3) -/
+/-! ## Content nominalizations (Ch. 3) -/
 
 /-! ### The three readings of *Beobachtung* -/
 
-/-- A German nominalization datum: reading plus the diagnostic profile its
-example sentence exhibits ([benz-2025] (32), diagnostics after
-[grimshaw-1990]). -/
-structure NominalizationDatum where
-  /-- The nominalized form (lemma). -/
-  form : String
-  /-- Base verb. -/
-  baseVerb : String
-  /-- The nominalizing suffix. -/
-  suffix : String := "-ung"
-  /-- The reading exhibited in this example. -/
-  reading : NominalizationReading
-  /-- Example sentence. -/
-  sentence : String
-  /-- Translation. -/
-  translation : String
-  /-- Accepts temporal/durative modification in this reading? -/
-  temporalModifiers : Bool
-  /-- Pluralizable in this reading? -/
-  pluralizable : Bool
-  /-- Takes a content-specifying CP complement? -/
-  takesCPComplement : Bool
-  deriving Repr, BEq
+/-- The (32) stimulus rows, in margin-label order Event, RN, Content. -/
+def beobachtungRows : List LinguisticExample :=
+  [Examples.ex32a, Examples.ex32b, Examples.ex32c]
 
-/-- Event reading ([benz-2025] (32a)): duration predicate diagnoses the
-complex event nominal; CENs resist pluralization ([grimshaw-1990]; Benz notes
-the exceptions reported for German are marginal). -/
-def beobachtung_CEN : NominalizationDatum :=
-  { form := "Beobachtung"
-  , baseVerb := "beobachten"
-  , reading := .complexEvent
-  , sentence := "Die Beobachtung des Nachthimmels dauerte drei Stunden"
-  , translation := "The observation of the night sky took three hours"
-  , temporalModifiers := true
-  , pluralizable := false
-  , takesCPComplement := false }
+/-- The reading a stimulus row exemplifies, from its `reading` feature. The
+paper's loose "RN" label is rendered as the simple entity reading. -/
+def readingOf (e : LinguisticExample) : Option NominalizationReading :=
+  match e.feature? "reading" with
+  | some "Event" => some .complexEvent
+  | some "RN" => some .simpleEntity
+  | some "Content" => some .content
+  | _ => none
 
-/-- Referential reading ([benz-2025] (32b)): pluralized, referring to concrete
-objects (e.g. a ledger of observations). Benz uses the "RN" label loosely for
-readings distinct from both the event and the content reading. -/
-def beobachtung_RN : NominalizationDatum :=
-  { form := "Beobachtung"
-  , baseVerb := "beobachten"
-  , reading := .simpleEntity
-  , sentence := "Die Beobachtungen der Astronomin sind für immer verloren"
-  , translation := "The astronomer's observations are lost forever"
-  , temporalModifiers := false
-  , pluralizable := true
-  , takesCPComplement := false }
-
-/-- Content reading ([benz-2025] (32c)): the CP complement specifies the
-content the noun refers to. The content reading is also available in the
-pluralized (32b), so it tolerates pluralization. -/
-def beobachtung_CCN : NominalizationDatum :=
-  { form := "Beobachtung"
-  , baseVerb := "beobachten"
-  , reading := .content
-  , sentence := "Seine Beobachtung, dass Planeten sich bewegen, veränderte die Wissenschaft"
-  , translation := "His observation that planets move changed the science"
-  , temporalModifiers := false
-  , pluralizable := true
-  , takesCPComplement := true }
-
-def allBeobachtungReadings : List NominalizationDatum :=
-  [beobachtung_CEN, beobachtung_RN, beobachtung_CCN]
-
-/-- *Beobachtung* exhibits all three readings ([benz-2025] (32)). -/
+/-- *Beobachtung* exhibits all three readings ((32)). -/
 theorem beobachtung_three_readings :
-    allBeobachtungReadings.map (·.reading) = [.complexEvent, .simpleEntity, .content] := rfl
+    beobachtungRows.map readingOf =
+      [some .complexEvent, some .simpleEntity, some .content] := rfl
 
-/-- The three readings have pairwise distinct diagnostic profiles: duration
-modification picks out the event reading, pluralization the referential and
-content readings, CP complementation the content reading. -/
+/-- Each (32) example exhibits exactly its characteristic diagnostic —
+duration modification for the event reading, pluralization for the RN
+reading, CP complementation for the content reading ([grimshaw-1990]-style
+diagnostics). -/
 theorem beobachtung_diagnostics :
-    allBeobachtungReadings.map
-        (λ d => (d.temporalModifiers, d.pluralizable, d.takesCPComplement)) =
-      [(true, false, false), (false, true, false), (false, true, true)] := rfl
+    beobachtungRows.map (λ e =>
+        (e.feature? "duration_predicate", e.feature? "plural",
+         e.feature? "cp_complement")) =
+      [(some "yes", some "no", some "no"),
+       (some "no", some "yes", some "no"),
+       (some "no", some "no", some "yes")] := rfl
 
 /-! ### Readings from allosemes -/
 
-/-- The alloseme pair deriving each reading, on the analysis the
-dissertation's denotations adopt: v is semantically vacuous on all readings
-but the CEN, so each non-CEN reading is carried by a contentful alloseme of n
-([benz-2025] §3.5, following [wood-2023]). The alternative — attributing every
-eventive component to v — is noted but not adopted; `readingFromAllosemes`
-admits both. -/
+/-- The alloseme pair deriving each reading on the adopted analysis, where v
+is semantically vacuous on all readings but the CEN (§3.5, following
+[wood-2023]). By `adopted_roundtrip` and `adopted_unique`, this is the unique
+derivation of each reading in which the two heads are not both contentful. -/
 def adoptedAllosemes : NominalizationReading → VAlloseme × NAlloseme
   | .complexEvent => (.eventive, .zero)
   | .simpleEvent  => (.zero, .simpleEvent)
@@ -139,57 +86,117 @@ theorem adopted_roundtrip (r : NominalizationReading) :
     readingFromAllosemes (adoptedAllosemes r).1 (adoptedAllosemes r).2 = some r := by
   cases r <;> rfl
 
-/-- The event and result readings are "mirror images ... in terms of semantic
-interpretation: In the event interpretation, (only) v is interpreted, in the
-result interpretation, it is (only) n" ([benz-2025] §3.5). -/
-theorem event_result_mirror :
-    (adoptedAllosemes .complexEvent).1.introducesEvent = true ∧
-    (adoptedAllosemes .complexEvent).2 = .zero ∧
-    (adoptedAllosemes .result).1.introducesEvent = false ∧
-    (adoptedAllosemes .result).2 ≠ .zero :=
-  ⟨rfl, rfl, rfl, by decide⟩
+/-- Among derivations in which the two heads are not both contentful, the
+adopted pair is the only one deriving the reading — economy of interpretation
+pins the analysis. -/
+theorem adopted_unique (r : NominalizationReading) (v : VAlloseme) (n : NAlloseme)
+    (hr : readingFromAllosemes v n = some r)
+    (h : v.introducesEvent = false ∨ n = .zero) :
+    (v, n) = adoptedAllosemes r := by
+  cases v <;> cases n <;> cases r <;>
+    first
+    | rfl
+    | exact absurd hr (by decide)
+    | rcases h with h | h <;> exact absurd h (by decide)
 
-/-- One structure, three readings: every attested *Beobachtung* reading is
-derived by varying only the allosemes of v and n ([benz-2025] Ch. 3's chapter
-claim). The content reading needs no eventive v — simple content nouns like
-*Gerücht* 'rumor' have it with no corresponding verb at all (Table 2). -/
-theorem beobachtung_readings_from_allosemy :
-    allBeobachtungReadings.all (λ d =>
-      readingFromAllosemes (adoptedAllosemes d.reading).1 (adoptedAllosemes d.reading).2
-        == some d.reading) = true := by decide
+/-- The reading pins the division of labor (the "mirror image" claim of
+§3.5): an event reading arises only from contentful v with vacuous n, while
+a result or content reading forces the corresponding contentful n, whatever
+v contributes. -/
+theorem reading_determines_contentful_head (v : VAlloseme) (n : NAlloseme) :
+    (readingFromAllosemes v n = some .complexEvent →
+      v.introducesEvent = true ∧ n = .zero) ∧
+    (readingFromAllosemes v n = some .result → n = .result) ∧
+    (readingFromAllosemes v n = some .content → n = .content) := by
+  cases v <;> cases n <;> refine ⟨?_, ?_, ?_⟩ <;> intro h <;>
+    first
+    | exact ⟨rfl, rfl⟩
+    | rfl
+    | exact absurd h (by decide)
 
-/-! ## Part II: Prefixes, particles, and resultatives (Ch. 4) -/
+/-! ### Alloseme selection in the nominalization structure
+
+The selection side is DM's own engine, not a further table: allosemes are
+vocabulary entries over `SyntacticContext`, applicability is context
+matching, and canonical defaults are Elsewhere competition
+(`Exponence.selectBy`). The readings available in the (66)/(68) structure
+[n [v √]] are whatever the licensed allosemes compose to. -/
+
+/-- v's context in the nominalization structure [n [v √]] — its complement is
+the root, event-entailing or not, and it is embedded under n. -/
+def vContext (eventive : Bool) : SyntacticContext :=
+  { aboveCat := some .n, complementIsEventive := eventive }
+
+/-- n's context in [n [v √]] — a verbal complement, eventive or not. -/
+def nContext (eventive : Bool) : SyntacticContext :=
+  { belowCat := some .v, complementIsEventive := eventive }
+
+/-- The readings derivable in the nominalization structure: any licensed v
+alloseme composed with any licensed n alloseme. -/
+def availableReadings (eventive : Bool) : List NominalizationReading :=
+  (vAllosemic.licensed (vContext eventive)).flatMap (λ v =>
+    (nAllosemic.licensed (nContext eventive)).filterMap (readingFromAllosemes v))
+
+/-- Over an event-entailing root both v allosemes are licensed — the premise
+of the reading ambiguity — while a non-eventive root licenses only vacuous
+v. -/
+theorem v_allosemes_licensed :
+    vAllosemic.licensed (vContext true) = [.eventive, .zero] ∧
+    vAllosemic.licensed (vContext false) = [.zero] := ⟨rfl, rfl⟩
+
+open Morphology.Exponence in
+/-- The canonical v alloseme of the root typology is the engine's Elsewhere
+winner: the more specified eventive entry beats vacuous v exactly when the
+root entails an event, so `VAlloseme.fromRootType` is derived, not
+stipulated. -/
+theorem fromRootType_is_selectBy_winner (rt : Verb.Root.ChangeType) :
+    (selectBy AllosemicEntry.score vAllosemic.entries
+        (vContext rt.entailsChange)).map (·.denotation) =
+      some (VAlloseme.fromRootType rt) := by
+  cases rt <;> rfl
+
+/-- Every attested *Beobachtung* reading is available in the single
+structure: the engine licenses the allosemes and composition delivers the
+readings (Ch. 3's chapter claim). -/
+theorem beobachtung_readings_available :
+    ∀ r ∈ beobachtungRows.filterMap readingOf, r ∈ availableReadings true := by
+  decide
+
+/-- Without an event-entailing root neither the complex event nor the result
+reading is derivable; the content reading survives, since simple content
+nouns like *Gerücht* 'rumor' need no verbal source (Table 2). -/
+theorem nonEventive_readings :
+    availableReadings false = [.content, .simpleEvent, .simpleState, .simpleEntity] := rfl
+
+/-! ## Prefixes, particles, and resultatives (Ch. 4) -/
 
 /-! ### The three preverbal-element types -/
 
-/-- The three types of German preverbal elements ([benz-2025] Ch. 4):
-inseparable prefixes, separable particles, and resultative secondary
-predicates (RSPs). -/
+/-- The three types of German preverbal elements (Ch. 4). -/
 inductive PreverbalElement where
   | pfx  -- inseparable prefix (be-, ent-, er-, ge-, miss-, ver-, zer-)
   | prt  -- separable particle (ab-, an-, auf-, aus-, ein-, ...)
   | rsp  -- resultative secondary predicate (platt, tot, kaputt, ...)
   deriving DecidableEq, Repr
 
-/-- The syntactic level of a morphological element: head (X⁰) or phrase (XP). -/
+/-- A morphological element is either a head (X⁰) or a phrase (XP). -/
 inductive SynLevel where
   | head    -- X⁰: can occur inside a complex head
   | phrase  -- XP: cannot incorporate
   deriving DecidableEq, Repr
 
 /-- Prefixes are heads forming a complex head with the root (inseparable under
-V2 movement); particles and RSPs are phrasal (stranded under V2; RSPs are
-modifiable aPs). Following [wurmbrand-1998] and [zeller-2001], particles are
-phrasal complements of the verb not dominated by further functional
-material. -/
+V2 movement), while particles and RSPs are phrasal (stranded under V2).
+Following [wurmbrand-1998] and [zeller-2001], particles are phrasal
+complements of the verb not dominated by further functional material. -/
 def PreverbalElement.synLevel : PreverbalElement → SynLevel
   | .pfx => .head
   | .prt => .phrase
   | .rsp => .phrase
 
 /-- Whether an element obligatorily introduces a result-state specification.
-Prefixes and RSPs always specify a result state; particles can have
-non-delimiting (directional, completive) readings ([benz-2025] §4.4). -/
+Prefixes and RSPs always specify a result state, while particles can have
+non-delimiting (directional, completive) readings (§4.4). -/
 inductive ResultStateSpec where
   | specifies  -- obligatorily introduces a result state
   | neutral    -- has non-delimiting readings
@@ -202,12 +209,10 @@ def PreverbalElement.resultSpec : PreverbalElement → ResultStateSpec
 
 /-! ### The two compatibility factors -/
 
-/-- Structural combinability of an outer and an inner element (inner = closer
-to the root). A phrasal inner element is impossible: a head outside it cannot
-form a complex head with the root, and a phrasal outer element competes with
-it for the verb's single complement position — "Because the verb can take only
-one complement, these elements are structurally incompatible" ([benz-2025]
-§4.4). -/
+/-- Structural combinability of an outer and an inner element, the inner one
+closer to the root. A phrasal inner element is impossible, since a head
+outside it cannot form a complex head with the root, and a phrasal outer
+element competes with it for the verb's single complement position (§4.4). -/
 def incorporationAllowed (outer inner : SynLevel) : Bool :=
   match outer, inner with
   | .head,   .head   => true   -- complex head formation
@@ -221,11 +226,9 @@ theorem incorporation_only_depends_on_inner (outer inner : SynLevel) :
     incorporationAllowed outer inner = (inner == .head) := by
   cases outer <;> cases inner <;> rfl
 
-/-- **Single Delimiting Constraint**: "The event described by a verb may only
-have one measuring-out and be delimited only once" ([tenny-1994] p. 79, quoted
-at [benz-2025] (159)). Two elements that both obligatorily specify a result
-state cannot co-occur: the end state Pred₂ of the complex event semantics can
-only be specified once. -/
+/-- Two elements that both obligatorily specify a result state cannot
+co-occur, since the end state of a complex event can only be specified once —
+[tenny-1994]'s Single Delimiting Constraint (p. 79, quoted at (159)). -/
 def resultStatesCompatible (a b : ResultStateSpec) : Bool :=
   match a, b with
   | .specifies, .specifies => false
@@ -237,30 +240,28 @@ def structurallyCompatible (outer inner : PreverbalElement) : Bool :=
 def interpretivelyCompatible (outer inner : PreverbalElement) : Bool :=
   resultStatesCompatible outer.resultSpec inner.resultSpec
 
-/-- A combination is predicted possible iff both factors permit it
-([benz-2025] §4.4). -/
+/-- A combination is predicted possible iff both factors permit it (§4.4). -/
 def predictedAllowed (outer inner : PreverbalElement) : Bool :=
   structurallyCompatible outer inner && interpretivelyCompatible outer inner
 
 /-! ### Prefix and particle inventory (Table 4) -/
 
-/-- German inseparable prefixes ([benz-2025] Table 4). *ge-* is the rare
-non-participial prefix (*ge-bären*, *ge-denken*, *ge-fallen*). -/
+/-- German inseparable prefixes (Table 4). *ge-* is the rare non-participial
+prefix (*ge-bären*, *ge-denken*, *ge-fallen*). -/
 def inseparablePrefixes : List String :=
   ["be", "ent", "er", "ge", "miss", "ver", "zer"]
 
-/-- German prepositional separable particles ([benz-2025] Table 4; the table
-additionally lists nominal and adjectival particles like *klavier-*, *rad-*,
-*leicht-*, whose classification is controversial). -/
+/-- German prepositional separable particles (Table 4, which additionally
+lists nominal and adjectival particles like *klavier-*, *rad-*, *leicht-*,
+whose classification is controversial). -/
 def separableParticles : List String :=
   ["ab", "an", "auf", "aus", "bei", "ein", "los", "nach", "vor", "zu"]
 
-/-- Elements occurring both as prefix and as particle ([benz-2025] Table 4). -/
+/-- Elements occurring both as prefix and as particle (Table 4). -/
 def ambiguousElements : List String :=
   ["durch", "hinter", "über", "um", "unter", "wider"]
 
-/-- Table 4's three-way partition: the ambiguous elements appear in neither
-pure inventory. -/
+/-- The ambiguous elements appear in neither pure inventory. -/
 theorem ambiguous_not_pure :
     ambiguousElements.all (λ e =>
       !inseparablePrefixes.contains e && !separableParticles.contains e) = true := by
@@ -268,55 +269,64 @@ theorem ambiguous_not_pure :
 
 /-! ### The co-occurrence paradigm (Table 3) -/
 
-/-- A cell of Table 3's factor columns: does this factor predict the
-combination to be possible? `particleDependent` renders the table's
-parenthesized check mark — "the predictions depend on the specific particles
-involved" ([benz-2025] §4.1). -/
+/-- A cell of Table 3's factor columns, recording whether the factor predicts
+the combination to be possible. `particleDependent` renders the table's
+parenthesized check mark, a prediction that depends on the specific particles
+involved (§4.1). -/
 inductive FactorVerdict where
   | predicts           -- ✓: factor predicts the combination possible
   | particleDependent  -- (✓): possible for result-neutral particles
   | excludes           -- ✗: factor predicts the combination impossible
   deriving DecidableEq, Repr
 
-/-- Boolean reading of a factor cell: `particleDependent` counts as possible
-(the generic classification treats particles as result-neutral). -/
+/-- Boolean reading of a factor cell, on which `particleDependent` counts as
+possible since the generic classification treats particles as
+result-neutral. -/
 def FactorVerdict.possible : FactorVerdict → Bool
   | .predicts => true
   | .particleDependent => true
   | .excludes => false
 
-/-- A row of [benz-2025] Table 3 (repeated as Table 5): outer element(s),
-inner element (closer to the root), observed availability, and the two factor
-verdicts. The printed table's final row merges pfx-RSP and PRT-RSP into one
-row "pfx/PRT-RSP", rendered here by a two-element `outers` list. -/
+/-- A row of Table 3 (repeated as Table 5). The printed table's final row
+merges pfx-RSP and PRT-RSP into one row "pfx/PRT-RSP", rendered here by a
+two-element `outers` list. -/
 structure CooccurrenceRow where
+  /-- The outer element(s) of the printed row. -/
   outers : List PreverbalElement
+  /-- The inner element, closer to the root. -/
   inner : PreverbalElement
+  /-- The Allowed column. -/
   allowed : Bool
+  /-- The Structure Predicts column. -/
   structureVerdict : FactorVerdict
+  /-- The Interpretation Predicts column. -/
   interpretationVerdict : FactorVerdict
   deriving Repr, BEq
 
-/-- [benz-2025] Table 3, cell for cell. Attested examples per row: pfx-pfx
-(81) *ent-ver-trauen; pfx-PRT (83) *zer-ab-schneiden; PRT-pfx (84)
-aus-er-wählen, an-ver-trauen, vor-ent-halten; PRT-PRT (82) *rad-ein-fahren;
-RSP-pfx (87) *arm be-raubt; RSP-PRT (88) *nass an-gespuckt; RSP-RSP (86)
-*sich kaputt müde gearbeitet. -/
+/-- Table 3, cell for cell. -/
 def cooccurrenceTable : List CooccurrenceRow := [
+  -- pfx-pfx ((81) *ent-ver-trauen)
   { outers := [.pfx], inner := .pfx, allowed := false
   , structureVerdict := .predicts, interpretationVerdict := .excludes },
+  -- pfx-PRT ((83) *zer-ab-schneiden)
   { outers := [.pfx], inner := .prt, allowed := false
   , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  -- PRT-pfx ((84) aus-er-wählen, an-ver-trauen, vor-ent-halten)
   { outers := [.prt], inner := .pfx, allowed := true
   , structureVerdict := .predicts, interpretationVerdict := .particleDependent },
+  -- PRT-PRT ((82) *rad-ein-fahren)
   { outers := [.prt], inner := .prt, allowed := false
   , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  -- RSP-pfx ((87) *arm be-raubt)
   { outers := [.rsp], inner := .pfx, allowed := false
   , structureVerdict := .predicts, interpretationVerdict := .excludes },
+  -- RSP-PRT ((88) *nass an-gespuckt)
   { outers := [.rsp], inner := .prt, allowed := false
   , structureVerdict := .excludes, interpretationVerdict := .particleDependent },
+  -- RSP-RSP ((86) *sich kaputt müde gearbeitet)
   { outers := [.rsp], inner := .rsp, allowed := false
   , structureVerdict := .excludes, interpretationVerdict := .excludes },
+  -- pfx/PRT-RSP (merged in the printed table)
   { outers := [.pfx, .prt], inner := .rsp, allowed := false
   , structureVerdict := .excludes, interpretationVerdict := .excludes }
 ]
@@ -343,54 +353,46 @@ theorem interpretive_prediction_matches :
 
 /-- The printed table marks the merged pfx/PRT-RSP row's interpretation cell
 ✗, but on the account's own classification only the prefix half is
-interpretively excluded: "the unavailability of particle verbs with RSPs is
-due to the fact that RSPs cannot attach to phrasal VPs. Of course, some
-RSP-particle verbs are additionally also ruled out semantically, because some
-particles introduce end states" ([benz-2025] §4.4) — the structural factor
-does the work, and the interpretive verdict is particle-dependent. -/
+interpretively excluded. For PRT-RSP the structural factor does the work,
+while only "some RSP-particle verbs are additionally also ruled out
+semantically" (§4.4). -/
 theorem prt_rsp_interpretation_particle_dependent :
     structurallyCompatible .prt .rsp = false ∧
     interpretivelyCompatible .prt .rsp = true := ⟨rfl, rfl⟩
 
-/-- PRT-pfx is the unique allowed combination — "much more widely attested
-than any of the others" ([benz-2025] (84): *aus-er-wählen*, *an-ver-trauen*,
-*vor-ent-halten*, *um-ent-scheiden*, *ab-er-kennen*). -/
+/-- PRT-pfx is the unique allowed combination ((84) *aus-er-wählen*,
+*an-ver-trauen*, *vor-ent-halten*, *um-ent-scheiden*, *ab-er-kennen*). -/
 theorem prt_pfx_uniquely_allowed :
     (cooccurrenceTable.filter (·.allowed)).map (λ r => (r.outers, r.inner)) =
       [([.prt], .pfx)] := by decide
 
-/-- Neither factor alone predicts the paradigm: structure alone misses the
-double-delimitation rows (pfx-pfx, RSP-pfx), and interpretation alone misses
+/-- Neither factor alone predicts the paradigm — structure alone misses the
+double-delimitation rows (pfx-pfx, RSP-pfx) and interpretation alone misses
 the phrase-structure rows (pfx-PRT, PRT-PRT, RSP-PRT). -/
 theorem two_factors_needed :
     (cooccurrenceTable.any (λ r => r.structureVerdict.possible && !r.allowed)) = true ∧
     (cooccurrenceTable.any (λ r => r.interpretationVerdict.possible && !r.allowed)) = true := by
   constructor <;> decide
 
-/-! ### Blocking derivations
-
-The two principles as a derivation system: a combination is blocked iff a
-derivation exists. Soundness and completeness against `predictedAllowed` show
-the two principles exactly generate the paradigm. -/
+/-! ### Blocking derivations -/
 
 /-- A proof that a preverbal-element combination violates one of the two
-principles.
-
-**`byPhrasalInner`**: a phrasal element cannot occupy the inner position —
-a head outside it cannot form a complex head with the root, and a phrasal
-outer competes for the verb's single complement position ([benz-2025] §4.4).
-
-**`bySingleDelimiting`**: two obligatory result-state specifiers conflict —
-the end state of a complex event can only be specified once ([tenny-1994]
-p. 79's Single Delimiting Constraint, [benz-2025] (159)). -/
+principles. Soundness and completeness against `predictedAllowed` show the
+two principles exactly generate the paradigm. -/
 inductive Blocked : PreverbalElement → PreverbalElement → Prop where
+  /-- A phrasal element cannot occupy the inner position, since a head
+  outside it cannot form a complex head with the root and a phrasal outer
+  competes for the verb's single complement position (§4.4). -/
   | byPhrasalInner {o i : PreverbalElement} :
       i.synLevel = .phrase → Blocked o i
+  /-- Two obligatory result-state specifiers conflict, since the end state of
+  a complex event can only be specified once ([tenny-1994]'s Single
+  Delimiting Constraint, (159)). -/
   | bySingleDelimiting {o i : PreverbalElement} :
       o.resultSpec = .specifies → i.resultSpec = .specifies → Blocked o i
 
-/-- **Soundness**: every blocking derivation corresponds to a predicted-blocked
-combination — the theory does not over-generate. -/
+/-- Every blocking derivation corresponds to a predicted-blocked combination —
+the theory does not over-generate. -/
 theorem blocked_sound {o i : PreverbalElement} (h : Blocked o i) :
     predictedAllowed o i = false := by
   cases h with
@@ -399,8 +401,8 @@ theorem blocked_sound {o i : PreverbalElement} (h : Blocked o i) :
   | bySingleDelimiting ho _ =>
       cases o <;> cases i <;> first | rfl | exact absurd ho (by decide)
 
-/-- **Completeness**: every blocked combination has a derivation — the two
-principles account for all restrictions. -/
+/-- Every blocked combination has a derivation — the two principles account
+for all restrictions. -/
 theorem blocked_complete {o i : PreverbalElement}
     (h : predictedAllowed o i = false) : Blocked o i := by
   cases o <;> cases i <;>
@@ -409,8 +411,8 @@ theorem blocked_complete {o i : PreverbalElement}
     | exact .bySingleDelimiting rfl rfl
     | exact absurd h (by decide)
 
-/-- The allowed combination has no derivation: the prefix is a head, and the
-particle is result-neutral. -/
+/-- The allowed combination has no derivation, since the prefix is a head and
+the particle is result-neutral. -/
 theorem prt_pfx_no_derivation : ¬ Blocked .prt .pfx := by
   intro h
   cases h with
@@ -438,15 +440,15 @@ neither cites the other). In this file's terms that configuration is exactly
 the banned phrasal-inner cell: the structural principle rejects what the
 constructionist analysis licenses (cf. `GoldbergShirtz2025.pal_load_bearing`). -/
 
-/-- A CxG bar level in `SynLevel` terms: zero-level positions are head sites;
-bar- and phrase-level positions are phrasal. -/
+/-- A CxG bar level in `SynLevel` terms, where zero-level positions are head
+sites and bar- and phrase-level positions are phrasal. -/
 def SynLevel.ofBarLevel : ConstructionGrammar.BarLevel → SynLevel
   | .zero => .head
   | .bar => .phrase
   | .phrase => .phrase
 
-/-- The `SynLevel` of a CxG slot filler: word fillers are heads, phrasal
-fillers (with or without a fixed head) are phrases; SEM+ fillers are
+/-- The `SynLevel` of a CxG slot filler. Word fillers are heads, phrasal
+fillers (with or without a fixed head) are phrases, and SEM+ fillers are
 level-unspecified. -/
 def _root_.ConstructionGrammar.SlotFiller.synLevel :
     ConstructionGrammar.SlotFiller String → Option SynLevel
@@ -456,8 +458,8 @@ def _root_.ConstructionGrammar.SlotFiller.synLevel :
   | .phrasal => some .phrase
   | .semantic _ => none
 
-/-- A phrase in a word-level slot occupies the banned cell: its site is a
-head, its filler a phrase, and `incorporationAllowed` rejects the pair. The
+/-- A phrase in a word-level slot occupies the banned cell — its site is a
+head and its filler a phrase, so `incorporationAllowed` rejects the pair. The
 standing counterexample class is the PAL construction, which licenses exactly
 this configuration. -/
 theorem phraseInWordSlot_incorporation_banned
@@ -472,220 +474,120 @@ theorem phraseInWordSlot_incorporation_banned
 
 /-! ### German resultative data (§4.2)
 
-Complex predicate semantics after [williams-2015], adopted at [benz-2025]
-(158): ⟦v⟧ = λx λe₁ ∃e₂ ∃s. Means(e₁,e₂) & Pred₁(e₂) & Theme(e₁,x) &
-End(e₁,s) & Pred₂(s). The M(eans) predicate is the verb, the R(esult)
-predicate the RSP; the End Theme Postulate (108) links the Theme of the
-complex event to the end state. See `Causation.Resultatives` for the
-complementary causal-dynamics analysis. -/
+Complex predicate semantics after [williams-2015], adopted at (158):
+⟦v⟧ = λx λe₁ ∃e₂ ∃s. Means(e₁,e₂) & Pred₁(e₂) & Theme(e₁,x) & End(e₁,s) &
+Pred₂(s), where the M(eans) predicate is the verb, the R(esult) predicate the
+RSP, and the End Theme Postulate (108) links the complex event's Theme to the
+end state. See `Causation.Resultatives` for the complementary causal-dynamics
+analysis. -/
 
-/-- A German resultative datum with gloss and judgment. -/
-structure GermanResultativeDatum where
-  sentence : String
-  gloss : String
-  translation : String
-  judgment : Acceptability
-  verbClass : String
-  deriving Repr, BEq
+/-- The resultative stimulus rows ((89), (115); the (115) rows are due to
+[creemers-2020]). -/
+def rspRows : List LinguisticExample :=
+  [Examples.ex89a, Examples.ex89b, Examples.ex115a, Examples.ex115e, Examples.ex115f]
 
-/-- German RSP data ([benz-2025] (89), (115); (115a,e,f) after
-[creemers-2020] and Rapp). German allows obligatorily transitive,
-unaccusative, and inherently reflexive M predicates in resultatives. -/
-def germanRSPData : List GermanResultativeDatum := [
-  { sentence := "Er hämmerte das Metall platt"
-  , gloss := "he hammered the.ACC metal flat"
-  , translation := "He hammered the metal flat"
-  , judgment := .ok
-  , verbClass := "transitive" },
-  { sentence := "Er schießt seinen Gegner tot"
-  , gloss := "he shoots his.ACC opponent dead"
-  , translation := "He shoots his opponent dead"
-  , judgment := .ok
-  , verbClass := "transitive" },
-  { sentence := "Hans hat den Stock kaputt gebrochen"
-  , gloss := "Hans has the.ACC stick broken broken.PTCP"
-  , translation := "Hans broke the stick"
-  , judgment := .ok
-  , verbClass := "obligatorily transitive" },
-  { sentence := "Das Wasser fror fest"
-  , gloss := "the.NOM water froze solid"
-  , translation := "The water froze solid"
-  , judgment := .ok
-  , verbClass := "unaccusative" },
-  { sentence := "Sie haben sich krank/tot geschämt"
-  , gloss := "they have REFL sick/dead shamed.PTCP"
-  , translation := "They were embarrassed sick/dead"
-  , judgment := .ok
-  , verbClass := "inherently reflexive" }
-]
-
-/-- German allows non-unergative M predicates in resultatives ([benz-2025]
-(115)) — against weak-resultative reanalyses of the whole class. -/
+/-- German allows non-unergative M predicates in resultatives ((115)),
+against weak-resultative reanalyses of the whole class. -/
 theorem german_allows_non_unergative_M :
-    (germanRSPData.any (·.verbClass == "obligatorily transitive")) = true ∧
-    (germanRSPData.any (·.verbClass == "unaccusative")) = true ∧
-    (germanRSPData.any (·.verbClass == "inherently reflexive")) = true := by
-  refine ⟨?_, ?_, ?_⟩ <;> decide
+    [Examples.ex115a, Examples.ex115e, Examples.ex115f].map (·.feature? "verb_class") =
+      [some "obligatorily transitive", some "unaccusative", some "inherently reflexive"] ∧
+    rspRows.all (·.judgment == .acceptable) = true := ⟨rfl, rfl⟩
 
 /-! ### RSP co-occurrence contrasts (§4.1) -/
 
-/-- RSPs are incompatible with prefixed verbs; the same RSP with the simplex
-verb is fine ([benz-2025] (87), from [creemers-2020]). The *ge-* in the
-grammatical examples is participial, not a prefix in the relevant sense. -/
-def rsp_pfx_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) := [
-  ( { sentence := "*Sie haben uns arm be-raubt"
-    , gloss := "they have us.ACC poor BE-robbed.PTCP"
-    , translation := "They robbed us poor"
-    , judgment := .unacceptable
-    , verbClass := "prefix verb (be-)" },
-    { sentence := "Sie haben uns arm geraubt"
-    , gloss := "they have us.ACC poor robbed.PTCP"
-    , translation := "They robbed us poor"
-    , judgment := .ok
-    , verbClass := "simplex verb" } ),
-  ( { sentence := "*Sie haben ihn tot er-schossen"
-    , gloss := "they have him.ACC dead ER-shot.PTCP"
-    , translation := "They shot him dead"
-    , judgment := .unacceptable
-    , verbClass := "prefix verb (er-)" },
-    { sentence := "Sie haben ihn tot geschossen"
-    , gloss := "they have him.ACC dead shot.PTCP"
-    , translation := "They shot him dead"
-    , judgment := .ok
-    , verbClass := "simplex verb" } ),
-  ( { sentence := "*Hans hat den Stock kaputt zer-brochen"
-    , gloss := "Hans has the.ACC stick broken ZER-broken.PTCP"
-    , translation := "Hans broke the stick broken"
-    , judgment := .unacceptable
-    , verbClass := "prefix verb (zer-)" },
-    { sentence := "Hans hat den Stock kaputt gebrochen"
-    , gloss := "Hans has the.ACC stick broken.ADJ broken.PTCP"
-    , translation := "Hans broke the stick broken"
-    , judgment := .ok
-    , verbClass := "simplex verb" } )
-]
-
-/-- Every RSP + prefix-verb contrast: prefixed verb out, simplex fine. -/
+/-- RSPs are incompatible with prefixed verbs, while the same RSP with the
+simplex verb is fine ((87), from [creemers-2020]). Each row's grammatical
+baseline carries its ungrammatical prefixed alternative, and the *ge-* of the
+baselines is participial, not a prefix in the relevant sense. -/
 theorem rsp_pfx_contrast_pattern :
-    rsp_pfx_contrasts.all (λ (bad, good) =>
-      bad.judgment == .unacceptable && good.judgment == .ok) = true := by
-  decide
+    [Examples.ex87ab, Examples.ex87cd, Examples.ex87ef].all (λ e =>
+      e.feature? "blocker_type" == some "prefix" &&
+      e.judgment == .acceptable &&
+      !e.alternatives.isEmpty &&
+      e.alternatives.all (·.2 == .ungrammatical)) = true := by decide
 
-/-- RSPs are likewise incompatible with particle verbs ([benz-2025] (88)) —
-including particles not characterizable as resultative, like *an-* in
-(88d). -/
-def rsp_prt_contrasts : List (GermanResultativeDatum × GermanResultativeDatum) := [
-  ( { sentence := "*Sie hat den Tisch trocken ab-gewischt"
-    , gloss := "she has the.ACC table dry AB-wiped.PTCP"
-    , translation := "She wiped the table off dry"
-    , judgment := .unacceptable
-    , verbClass := "particle verb (ab-)" },
-    { sentence := "Sie hat den Tisch trocken gewischt"
-    , gloss := "she has the.ACC table dry wiped.PTCP"
-    , translation := "She wiped the table dry"
-    , judgment := .ok
-    , verbClass := "simplex verb" } ),
-  ( { sentence := "*Das Baby hat mich nass an-gespuckt"
-    , gloss := "the baby has me.ACC wet AN-spit.PTCP"
-    , translation := "The baby spat up on me and I was wet as a result"
-    , judgment := .unacceptable
-    , verbClass := "particle verb (an-)" },
-    { sentence := "Das Baby hat mich nass gespuckt"
-    , gloss := "the baby has me.ACC wet spit.PTCP"
-    , translation := "The baby spat up on me"
-    , judgment := .ok
-    , verbClass := "simplex verb" } )
-]
-
-/-- Every RSP + particle-verb contrast: particle verb out, simplex fine. -/
+/-- RSPs are likewise incompatible with particle verbs ((88)), including
+particles not characterizable as resultative, like *an-* in (88d). -/
 theorem rsp_prt_contrast_pattern :
-    rsp_prt_contrasts.all (λ (bad, good) =>
-      bad.judgment == .unacceptable && good.judgment == .ok) = true := by
-  decide
+    [Examples.ex88ab, Examples.ex88cd].all (λ e =>
+      e.feature? "blocker_type" == some "particle" &&
+      e.judgment == .acceptable &&
+      !e.alternatives.isEmpty &&
+      e.alternatives.all (·.2 == .ungrammatical)) = true := by decide
 
 /-! ### Interpretive transparency -/
 
-/-- Whether the element can receive a non-transparent (idiosyncratic)
-interpretation with the verb. Prefixes and particles can (*an-fangen* 'start',
-[benz-2025] (161)); RSPs "are always interpreted transparently, in contrast to
-particles" (*platt klopfen* 'pound flat', (162)) — RSPs sit outside the
-locality domain for allosemy, while particles, though phrasal, are bare
-complements not dominated by functional material. -/
+/-- Whether the element can receive a non-transparent interpretation with the
+verb ((161) *an-fangen* 'start' vs. (162) *platt klopfen* 'pound flat'). RSPs
+are always interpreted transparently since they sit outside the locality
+domain for allosemy, while particles are bare phrasal complements local
+enough for it. -/
 def PreverbalElement.canBeNonTransparent : PreverbalElement → Bool
   | .pfx => true
   | .prt => true
   | .rsp => false
 
-/-- Transparency cross-cuts the structural classification: particles pattern
-with RSPs structurally (both phrasal) but with prefixes interpretively (both
-can be non-transparent). This is the evidence that particles are phrasal yet
-local enough for allosemy ([benz-2025] §4.3). -/
+/-- Particles pattern with RSPs structurally (both phrasal) but with prefixes
+interpretively (both can be non-transparent) — the evidence that particles
+are phrasal yet local enough for allosemy (§4.3). -/
 theorem transparency_crosscuts_synLevel :
     PreverbalElement.prt.synLevel = PreverbalElement.rsp.synLevel ∧
     PreverbalElement.prt.canBeNonTransparent ≠ PreverbalElement.rsp.canBeNonTransparent :=
   ⟨rfl, by decide⟩
 
-/-! ## Part III: Prefixes in nominalizations (Ch. 5) -/
+/-! ## Prefixes in nominalizations (Ch. 5) -/
 
 /-! ### Nominalization types and the structure problem -/
 
-/-- German nominalization types discussed in [benz-2025] Ch. 5:
-*-ung* suffixation (*Beobachtung*), *Ge-...-e* circumfixation (*Gerede*),
-and the nominalized infinitive (*das Beobachten*). -/
+/-- The three German nominalization types discussed in Ch. 5. -/
 inductive NominalizationType where
-  | ung           -- -ung suffixation
-  | ge_e          -- Ge-...-e circumfixation
-  | nomInfinitive -- nominalized infinitive (das V-en)
+  | ung           -- -ung suffixation (Beobachtung)
+  | ge_e          -- Ge-...-e circumfixation (Gerede)
+  | nomInfinitive -- nominalized infinitive (das Beobachten)
   deriving DecidableEq, Repr
 
-/-- A solution to the particle "structure problem" ([luedeling-2001]): how can
-a phrasal particle end up inside a derived nominal? [benz-2025] Ch. 5 argues
-the three nominalization types favor *different* solutions — reinforcing "the
-strange status of particles in the grammar". -/
+/-- A solution to the particle "structure problem" ([luedeling-2001]) — how a
+phrasal particle can end up inside a derived nominal. Ch. 5 argues the three
+nominalization types favor different solutions, reinforcing "the strange
+status of particles in the grammar". -/
 inductive StructureSolution where
   | phrasalInput    -- the nominalizer takes phrasal structure
   | particleAsHead  -- the particle attaches low, as a head
   | outerAttachment -- the particle attaches outside the nominalizer
   deriving DecidableEq, Repr
 
-/-- The solution each nominalization type favors ([benz-2025] §5.2–5.4):
-nominalized infinitives take phrasal inputs (even *das
-Durch-den-Wald-Reiten*); *-ung* favors particles-as-heads (particles but not
-resultatives occur, and *-ung* needs its input identifiable as complex
-change-of-state); *Ge-...-e* favors outer attachment (particles and RSPs
-attach outside *Ge-*, (223), while prefixes cannot, and its
-no-internal-argument eventive semantics conflicts with prefix verbs'
-argument-structural demands). -/
+/-- The solution each nominalization type favors (§5.2–5.4). Nominalized
+infinitives take phrasal inputs (even *das Durch-den-Wald-Reiten*), *-ung*
+favors particles-as-heads, and *Ge-...-e* favors outer attachment ((223)),
+since its no-internal-argument eventive semantics conflicts with prefix
+verbs' argument-structural demands. -/
 def NominalizationType.solution : NominalizationType → StructureSolution
   | .nomInfinitive => .phrasalInput
   | .ung => .particleAsHead
   | .ge_e => .outerAttachment
 
-/-- Whether the element can attach as a (non-phrasal) head: prefixes always
-do; particles can attach low as heads ([benz-2025] §5.3's particles-as-heads
-solution); RSPs, "unlike particles, ... cannot be attached non-phrasally"
-((205)–(206)). -/
+/-- Whether the element can attach as a non-phrasal head. Prefixes always do,
+particles can attach low as heads (§5.3), and RSPs cannot be attached
+non-phrasally ((205)–(206)). -/
 def PreverbalElement.canAttachAsHead : PreverbalElement → Bool
   | .pfx => true
   | .prt => true
   | .rsp => false
 
-/-- Which preverbal elements a structure-problem solution admits: phrasal
-inputs admit everything; particles-as-heads admits exactly the head-attachers;
-outer attachment admits exactly the phrasal elements (prefixes are verbal
-heads and cannot attach outside a noun). -/
+/-- The preverbal elements a structure-problem solution accommodates. Phrasal
+inputs admit everything, particles-as-heads admits the head-attachers, and
+outer attachment admits the phrasal elements, since prefixes are verbal heads
+and cannot attach outside a noun. -/
 def StructureSolution.admits : StructureSolution → PreverbalElement → Bool
   | .phrasalInput, _ => true
   | .particleAsHead, pe => pe.canAttachAsHead
   | .outerAttachment, pe => pe.synLevel == .phrase
 
-/-- The observed distribution ([benz-2025] Ch. 5): *-ung* takes prefixes
-(197d–f) and particles (197a–c) but not RSPs ((204) **Platt-hämmer-ung*,
-**Wach-küss-ung*); *Ge-...-e* takes particles (212) and (a subset of) RSPs
-((216) *das Wach-ge-küss-e*, restricted to non-obligatorily-transitive bases
-by its no-internal-argument semantics) but not prefixes ((218) **Ge-be-such-e*,
-**Be-ge-such-e*, in either order); nominalized infinitives take all three
-((193) *das Ver-kaufen*, *das Ein-führen*, *das Wach-küssen*). -/
+/-- The observed Ch. 5 distribution. *-ung* takes prefixes and particles but
+not RSPs ((197), (204) **Platt-hämmer-ung*). *Ge-...-e* takes particles
+((212)) and a subset of RSPs ((216) *das Wach-ge-küss-e*, restricted to
+non-obligatorily-transitive bases) but not prefixes ((218) **Ge-be-such-e*,
+in either affix order). Nominalized infinitives take all three ((193)). -/
 def peAcceptable : NominalizationType → PreverbalElement → Bool
   | .ung,           .pfx => true
   | .ung,           .prt => true
@@ -695,16 +597,16 @@ def peAcceptable : NominalizationType → PreverbalElement → Bool
   | .ge_e,          .rsp => true
   | .nomInfinitive, _    => true
 
-/-- **The Ch. 5 distribution is derived**: each nominalization type admits
-exactly the elements its structure-problem solution can accommodate. The
-distribution is a projection of the same head/phrase classification that
-drives the Ch. 4 co-occurrence paradigm. -/
+/-- Each nominalization type admits exactly the elements its
+structure-problem solution accommodates — the Ch. 5 distribution projects the
+same head/phrase classification that drives the Ch. 4 paradigm. -/
 theorem peAcceptable_from_solutions (nt : NominalizationType) (pe : PreverbalElement) :
     peAcceptable nt pe = nt.solution.admits pe := by
   cases nt <;> cases pe <;> rfl
 
 /-- Prefixes and RSPs are in complementary distribution across *-ung* and
-*Ge-...-e*: head-attachment and outer attachment make opposite demands. -/
+*Ge-...-e*, since head attachment and outer attachment make opposite
+demands. -/
 theorem pfx_rsp_complementary_ung_ge :
     peAcceptable .ung .pfx = true ∧ peAcceptable .ung .rsp = false ∧
     peAcceptable .ge_e .pfx = false ∧ peAcceptable .ge_e .rsp = true :=
@@ -715,33 +617,31 @@ options (head or phrase) that constitute the structure problem. -/
 theorem prt_accepted_in_both :
     peAcceptable .ung .prt = true ∧ peAcceptable .ge_e .prt = true := ⟨rfl, rfl⟩
 
-/-- Nominalized infinitives accept all three element types ([benz-2025]
-(193)). -/
+/-- Nominalized infinitives accept all three element types ((193)). -/
 theorem nom_inf_maximally_permissive (pe : PreverbalElement) :
     peAcceptable .nomInfinitive pe = true := by
   cases pe <;> rfl
 
 /-! ### *-ung* and event structure -/
 
-/-- Whether a verb can undergo *-ung* nominalization. [rossdeutscher-kamp-2010]
-(endorsed at [benz-2025] §5.3.1): *-ung* requires complex ("bi-eventive")
-change-of-state event structure. Over this fragment's entries, the bi-eventive
-verbs are the accomplishments (prefix/particle change-of-state verbs); the
-simplex deadjectival cases ([benz-2025] (199), *Klär-ung*) are not
-represented. -/
+/-- Whether a verb can undergo *-ung* nominalization, which requires complex
+("bi-eventive") change-of-state event structure ([rossdeutscher-kamp-2010],
+endorsed at §5.3.1). Over this fragment's entries the bi-eventive verbs are
+the accomplishments (the simplex deadjectival cases of (199) are not
+represented). -/
 def canUngNominalize : Option VendlerClass → Bool
   | some .accomplishment => true
   | _ => false
 
-/-- The (198c) minimal pair: **Mal-ung* vs *Be-mal-ung* — the prefix supplies
-the complex change-of-state structure *-ung* needs, derived here from the
-fragment entries' Vendler classes. -/
+/-- In the (198c) minimal pair **Mal-ung* vs *Be-mal-ung*, the prefix
+supplies the complex change-of-state structure *-ung* needs, derived here
+from the fragment entries' Vendler classes. -/
 theorem malen_bemalen_ung_contrast :
     canUngNominalize malen.vendlerClass = false ∧
     canUngNominalize bemalen.vendlerClass = true := ⟨rfl, rfl⟩
 
-/-- Simplex activity verbs cannot form *-ung* nominalizations ([benz-2025]
-(198): **Mal-ung*, **Arbeit-ung*, **Schieß-ung*; the other fragment activities
+/-- Simplex activity verbs cannot form *-ung* nominalizations ((198)
+**Mal-ung*, **Arbeit-ung*, **Schieß-ung*; the other fragment activities
 pattern identically). -/
 theorem simplex_activity_no_ung :
     canUngNominalize haemmern.vendlerClass = false ∧
@@ -752,7 +652,7 @@ theorem simplex_activity_no_ung :
   ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Prefix and particle verbs with complex event structure form *-ung*
-nominalizations ([benz-2025] (197): *Ein-führ-ung*, *Ver-bind-ung*; Ch. 3:
+nominalizations ((197) *Ein-führ-ung*, *Ver-bind-ung*; Ch. 3
 *Beobacht-ung*). -/
 theorem complex_change_of_state_ung :
     canUngNominalize beobachten.vendlerClass = true ∧
@@ -762,19 +662,22 @@ theorem complex_change_of_state_ung :
 
 /-! ### Fragment grounding -/
 
-/-- Transitivity derived from fragment fields (not from a raw string). -/
+/-- Transitivity derived from the fragment entry's typed fields. -/
 def isTransitiveVerb (v : GermanVerbEntry) : Bool :=
   v.complementType == .np && !v.unaccusative
 
-/-- The verb classifications in the RSP data are derivable from the fragment
-entries' typed fields: changing *frieren*'s `unaccusative` field or
-*hämmern*'s `complementType` would break this theorem without touching the
-RSP data. -/
+/-- The stimulus rows' `verb_class` labels are derivable from the fragment
+entries their `m_predicate` features name, so changing *frieren*'s
+`unaccusative` field or *hämmern*'s `complementType` would break this theorem
+without touching the rows. -/
 theorem rsp_data_grounded_in_fragments :
-    isTransitiveVerb haemmern = true ∧
-    isTransitiveVerb brechen = true ∧
-    frieren.unaccusative = true ∧
-    isTransitiveVerb frieren = false := ⟨rfl, rfl, rfl, rfl⟩
+    (Examples.ex89a.feature? "m_predicate" = some haemmern.form ∧
+      isTransitiveVerb haemmern = true) ∧
+    (Examples.ex115a.feature? "m_predicate" = some brechen.form ∧
+      isTransitiveVerb brechen = true) ∧
+    (Examples.ex115e.feature? "m_predicate" = some frieren.form ∧
+      frieren.unaccusative = true ∧ isTransitiveVerb frieren = false) :=
+  ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, rfl, rfl, rfl⟩
 
 /-- *brechen* (result root) and *frieren* (property-concept root) yield
 opposite canonical v allosemes, connecting the fragment's `rootType` to
@@ -786,16 +689,16 @@ theorem rootType_alloseme_divergence :
     frieren.rootType.map (VAlloseme.fromRootType · |>.introducesEvent) = some false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
-/-- End-to-end for *brechen*: result root → eventive v → with vacuous n, the
+/-- A result root selects eventive v, which with vacuous n yields *brechen*'s
 complex event reading. -/
 theorem brechen_cen_path :
     brechen.rootType.bind
       (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .zero) =
       some .complexEvent := rfl
 
-/-- End-to-end for *frieren*: property-concept root → vacuous v → with entity
-n, the simple entity reading. Allosemy makes the eventive v available too —
-the canonical alloseme is a default, not a constraint. -/
+/-- A property-concept root selects vacuous v, which with entity n yields
+*frieren*'s simple entity reading. Allosemy leaves the eventive v available
+too, since the canonical alloseme is a default rather than a constraint. -/
 theorem frieren_entity_path :
     frieren.rootType.bind
       (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .entity) =


### PR DESCRIPTION
Follow-up to #2227 (merged while this pass was in flight).

- Mathlib register pass: module docstring to flowing study prose, anchor citations to bare §/(N) refs, colon-opener and bold-label docstrings rewritten, constructor docs moved onto constructors.
- Stimuli ((32), (87)–(89), (115)) migrated to Data/Examples/Benz2025.json (13 rows; contrast pairs via `alternatives`, Creemers provenance via `reportedIn`); the ad hoc NominalizationDatum/GermanResultativeDatum structs are dissolved.
- Reading derivation grounded in the DM engine: `AllosemicHead.licensed` (substrate) + `availableReadings` derive the reading inventory from licensed allosemes, `fromRootType_is_selectBy_winner` derives the canonical v alloseme as the Elsewhere winner, and `adopted_unique` characterizes the adopted analysis by economy instead of restating tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)