### PR TITLE
feat(Morphology/DistributedMorphology): Fusion rule + portmanteau theorem

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1255,6 +1255,7 @@ import Linglib.Morphology.DistributedMorphology.CategorizerSemantics
 import Linglib.Morphology.DistributedMorphology.Defs
 import Linglib.Morphology.DistributedMorphology.DomainLocality
 import Linglib.Morphology.DistributedMorphology.Fission
+import Linglib.Morphology.DistributedMorphology.Fusion
 import Linglib.Morphology.DistributedMorphology.Impoverishment
 import Linglib.Morphology.DistributedMorphology.Merger
 import Linglib.Morphology.DistributedMorphology.NominalStructure

--- a/Linglib/Morphology/DistributedMorphology/Fusion.lean
+++ b/Linglib/Morphology/DistributedMorphology/Fusion.lean
@@ -1,0 +1,117 @@
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
+
+/-!
+# Fusion (Distributed Morphology)
+
+Fusion is the postsyntactic DM operation that merges two adjacent terminal
+nodes into a single terminal bearing both feature bundles, which a single
+Vocabulary Item then spells out ([halle-marantz-1993]'s Tns+Agr fusion in
+English; French *du* = P[de] fused with D[le] is the portmanteau case,
+[kalin-bjorkman-etal-2026] §4.4). It is the inverse misalignment from
+Fission: fission yields more positions of exponence than syntactic
+terminals, fusion fewer.
+
+A `FusionRule` follows the `FissionRule`/`ImpoverishmentRule` template —
+`Prop`-valued conditions with carried decidability witnesses. Unlike
+fission's opaque realization output, fusion's output is a bundle that
+continues to Vocabulary Insertion, and `portmanteau_needs_fusion` is the
+payoff: an exponent whose vocabulary items all draw on both input bundles
+is insertable only at the fused node.
+
+## Main declarations
+
+* `FusionRule Bundle Ctx` — the generic rule structure
+* `FusionRule.apply` — partial application returning `Option Bundle`, with
+  the `apply_eq_some_iff`/`apply_eq_none_iff`/`isSome_apply`
+  characterization API
+* `portmanteau_needs_fusion` — a cross-terminal exponent wins at neither
+  unfused node
+-/
+
+namespace DistributedMorphology
+
+/-- A Fusion rule is parameterized over:
+* `Bundle` — the morphological feature bundles of the fusing terminals;
+* `Ctx`    — the structural context licensing Fusion (adjacency of the
+  two terminals under one head).
+
+Both conditions are `Prop`-valued with carried decidability witnesses,
+matching the `FissionRule`/`ImpoverishmentRule` template. -/
+structure FusionRule (Bundle Ctx : Type*) where
+  /-- The structural condition licensing Fusion. -/
+  contextOk : Ctx → Prop
+  /-- Decidability witness for `contextOk`. -/
+  decContext : DecidablePred contextOk
+  /-- The condition on the two fusing bundles (structurally higher first). -/
+  bundlesOk : Bundle → Bundle → Prop
+  /-- Decidability witness for `bundlesOk`. -/
+  decBundles : ∀ p, DecidablePred (bundlesOk p)
+  /-- The fused bundle — the union of the inputs in the intended instances. -/
+  fuse : Bundle → Bundle → Bundle
+
+namespace FusionRule
+
+variable {Bundle Ctx : Type*} {rule : FusionRule Bundle Ctx}
+  {p q out : Bundle} {c : Ctx}
+
+instance (rule : FusionRule Bundle Ctx) (c : Ctx) :
+    Decidable (rule.contextOk c) := rule.decContext c
+
+instance (rule : FusionRule Bundle Ctx) (p q : Bundle) :
+    Decidable (rule.bundlesOk p q) := rule.decBundles p q
+
+/-- Apply Fusion: yield the fused bundle when both the structural and
+bundle conditions hold; otherwise `none`. -/
+def apply (rule : FusionRule Bundle Ctx) (p q : Bundle) (c : Ctx) :
+    Option Bundle :=
+  if rule.contextOk c ∧ rule.bundlesOk p q then some (rule.fuse p q) else none
+
+theorem apply_pos (hc : rule.contextOk c) (hb : rule.bundlesOk p q) :
+    rule.apply p q c = some (rule.fuse p q) :=
+  if_pos ⟨hc, hb⟩
+
+theorem apply_neg (h : ¬(rule.contextOk c ∧ rule.bundlesOk p q)) :
+    rule.apply p q c = none :=
+  if_neg h
+
+@[simp]
+theorem apply_eq_some_iff :
+    rule.apply p q c = some out ↔
+      (rule.contextOk c ∧ rule.bundlesOk p q) ∧ rule.fuse p q = out := by
+  unfold apply; split <;> simp_all
+
+@[simp]
+theorem apply_eq_none_iff :
+    rule.apply p q c = none ↔ ¬(rule.contextOk c ∧ rule.bundlesOk p q) := by
+  unfold apply; split <;> simp_all
+
+theorem isSome_apply :
+    (rule.apply p q c).isSome ↔ rule.contextOk c ∧ rule.bundlesOk p q := by
+  unfold apply; split <;> simp_all
+
+end FusionRule
+
+section Portmanteau
+
+open VI
+
+variable {F E : Type*} [BEq F]
+
+/-- A portmanteau exponent needs fusion: when every vocabulary item
+carrying the exponent draws on features missing from each unfused bundle,
+the Subset Principle can select it at neither unfused node — only the
+fused bundle contains its item's features (`subsetPrinciple_winner_mem`). -/
+theorem portmanteau_needs_fusion {items : List (FeatureVI F E)}
+    {p q : List F} {e : E}
+    (he : ∀ i ∈ items, i.exponent = e →
+      i.features.all (p.contains ·) = false ∧
+      i.features.all (q.contains ·) = false) :
+    subsetPrinciple items p ≠ some e ∧ subsetPrinciple items q ≠ some e := by
+  refine ⟨fun h => ?_, fun h => ?_⟩ <;>
+    obtain ⟨i, hi, rfl, happ⟩ := subsetPrinciple_winner_mem h
+  · simp [(he i hi rfl).1] at happ
+  · simp [(he i hi rfl).2] at happ
+
+end Portmanteau
+
+end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
@@ -110,6 +110,43 @@ theorem elsewhere_always_matches {F E : Type*} [BEq F]
     (FeatureVI.mk ([] : List F) e).features.all (target.contains ·) = true := by
   simp [List.all_nil]
 
+private theorem foldl_choice_mem {α : Type*} {pick : Option α → α → Option α}
+    (hpick : ∀ acc x, pick acc x = some x ∨ pick acc x = acc) :
+    ∀ {l : List α} {acc : Option α} {i : α},
+      l.foldl pick acc = some i → i ∈ l ∨ acc = some i := by
+  intro l
+  induction l with
+  | nil => exact fun h => .inr h
+  | cons x xs ih =>
+    intro acc i h
+    rcases ih h with hmem | hacc
+    · exact .inl (List.mem_cons_of_mem _ hmem)
+    · rcases hpick acc x with hx | hkeep
+      · rw [hx] at hacc
+        obtain rfl := Option.some.inj hacc
+        exact .inl (List.mem_cons_self ..)
+      · exact .inr (hkeep ▸ hacc)
+
+/-- The Subset Principle's winner is an item of the vocabulary whose
+features are all present in the target — the selected exponent never
+draws on features the node does not bear. -/
+theorem subsetPrinciple_winner_mem {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {target : List F} {e : E}
+    (h : subsetPrinciple items target = some e) :
+    ∃ i ∈ items, i.exponent = e ∧ i.features.all (target.contains ·) = true := by
+  unfold subsetPrinciple at h
+  obtain ⟨i, hfold, rfl⟩ := Option.map_eq_some_iff.mp h
+  have hmem := foldl_choice_mem (fun acc x => by
+    cases acc with
+    | none => exact .inl rfl
+    | some prev =>
+      by_cases hlen : x.features.length > prev.features.length <;>
+        simp [hlen]) hfold
+  rcases hmem with hmem | hnone
+  · have := List.mem_filter.mp hmem
+    exact ⟨i, this.1, rfl, this.2⟩
+  · exact absurd hnone (by simp)
+
 -- ============================================================================
 -- § 3: The shared exponence core
 -- ============================================================================

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
+import Linglib.Morphology.DistributedMorphology.Fusion
 import Linglib.Morphology.Morphotactics.MirrorPrinciple
 
 /-!
@@ -33,11 +33,11 @@ until Vocabulary Insertion at MS — this is **Late Insertion**. The VI
 mechanism (`subsetPrinciple`) IS Late Insertion in action: it maps
 feature bundles to exponents, making DM realizational by construction.
 
-Impoverishment — also introduced in this paper — is formalized as a
-general mechanism in `Morphology/DistributedMorphology/Impoverishment.lean`.
-This study file instantiates impoverishment on the English paradigm
-to derive syncretism (§4). Fusion is defined inline (§3) since this
-file is its only consumer.
+Impoverishment and Fusion — both introduced in this paper — are
+formalized as general mechanisms in
+`Morphology/DistributedMorphology/Impoverishment.lean` and `Fusion.lean`.
+This study file instantiates impoverishment on the English paradigm to
+derive syncretism (§4) and fusion on the Tns/Agr pair (§3).
 -/
 
 namespace HalleMarantz1993
@@ -252,32 +252,10 @@ affixes) for Tns+Agr: *walk-s* realizes both non-past Tns and 3sg
 Agr in one exponent, because Fusion merges the two terminals before
 VI applies.
 
-We model fusion using `FusionRule` (inlined below; this study is its
-only consumer in linglib) and show that the fused features feed
-directly into the VI paradigm from §1. -/
+We model fusion with `DistributedMorphology.FusionRule` and show that the
+fused features feed directly into the VI paradigm from §1. -/
 
 section TnsAgrFusion
-
-/-- Fusion ([halle-marantz-1993]): merges two adjacent terminal
-    nodes into a single terminal before Vocabulary Insertion. The fused
-    node bears the union of both terminals' features; a single VI then
-    spells out the fused bundle, yielding a portmanteau.
-
-    Canonical example: French *du* = Fusion of P[de] and D[le.MASC.SG].
-    [kalin-bjorkman-etal-2026] §4.4. -/
-structure FusionRule (Terminal : Type) where
-  /-- First terminal (structurally higher). -/
-  terminal1 : Terminal
-  /-- Second terminal (structurally lower / complement head). -/
-  terminal2 : Terminal
-
-/-- The result of Fusion: a single terminal bearing features from both
-    inputs, parameterized over a feature-union operation. -/
-def FusionRule.apply {Terminal Features : Type}
-    (r : FusionRule Terminal)
-    (getFeatures : Terminal → Features)
-    (union : Features → Features → Features) : Features :=
-  union (getFeatures r.terminal1) (getFeatures r.terminal2)
 
 /-- The two inflectional heads that fuse in English. -/
 inductive InflHead where
@@ -296,12 +274,24 @@ def InflHead.features : InflHead → List EngInflFeature
   | .agr true        => [.sg3]
   | .agr false       => []
 
-/-- Compute the fused feature bundle for a Tns+Agr combination.
-    Uses `FusionRule.apply` with list concatenation as the union
-    operation. -/
+/-- Tns+Agr fusion ([halle-marantz-1993]): the two heads are adjacent
+    sisters after head movement, so the structural condition is trivially
+    met here and the fused bundle is feature-list union. -/
+def tnsAgrFusion : DistributedMorphology.FusionRule (List EngInflFeature) Unit where
+  contextOk _ := True
+  decContext _ := inferInstanceAs (Decidable True)
+  bundlesOk _ _ := True
+  decBundles _ _ := inferInstanceAs (Decidable True)
+  fuse := (· ++ ·)
+
+/-- The conditioned application always succeeds for adjacent Tns/Agr. -/
+theorem tnsAgrFusion_apply (p q : List EngInflFeature) :
+    tnsAgrFusion.apply p q () = some (p ++ q) :=
+  DistributedMorphology.FusionRule.apply_pos trivial trivial
+
+/-- The fused feature bundle for a Tns+Agr combination. -/
 def fusedFeatures (tPast tPart : Bool) (aSg3 : Bool) : List EngInflFeature :=
-  (FusionRule.mk (.tns tPast tPart) (.agr aSg3) : FusionRule InflHead).apply
-    InflHead.features (· ++ ·)
+  tnsAgrFusion.fuse (InflHead.tns tPast tPart).features (InflHead.agr aSg3).features
 
 /-- 3sg present: Tns[−past,−part] fused with Agr[3sg] → [sg3] → `-z`.
     One exponent realizes both heads. -/


### PR DESCRIPTION
Arc 2a of the DM deepening: `Fusion.lean` graduates the FusionRule inlined in Studies/HalleMarantz1993 (its former sole consumer) to the framework layer, on the `FissionRule`/`ImpoverishmentRule` template.

- `subsetPrinciple_winner_mem` (VocabularyInsertion): the Subset Principle's winner is a vocabulary item whose features are all present at the node.
- `portmanteau_needs_fusion`: an exponent whose items all draw on both input bundles is insertable at neither unfused node — cross-terminal exponence requires fusion.
- HalleMarantz1993 §3 now instantiates the framework rule (`tnsAgrFusion`), with the conditioned application proved rather than stipulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)