### PR TITLE
feat(Morphology/DistributedMorphology): spell-out pipeline + retreat

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1259,6 +1259,7 @@ import Linglib.Morphology.DistributedMorphology.Fusion
 import Linglib.Morphology.DistributedMorphology.Impoverishment
 import Linglib.Morphology.DistributedMorphology.Merger
 import Linglib.Morphology.DistributedMorphology.NominalStructure
+import Linglib.Morphology.DistributedMorphology.Spellout
 import Linglib.Morphology.DistributedMorphology.VocabSimple
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
 import Linglib.Morphology.Exponence.Basic

--- a/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
+++ b/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
@@ -40,21 +40,22 @@ open Minimalist
 
 /-- The local context a postsyntactic rule may inspect. The `focus` bundle
     is the terminal targeted for deletion; `leftCtx` and `rightCtx` are
-    the bundles of immediately adjacent terminals (left- and right-adjacent
-    in the morphological structure).
+    the bundles of the surrounding terminals, nearest first (so the head
+    of each list is the immediately adjacent terminal). The zipper view
+    of a whole spell-out domain is `Spellout.lean`'s `mapNeighborhoods`.
 
     Splitting `focus` from context is what makes the
     paradigmatic/syntagmatic distinction structural. A condition that
     only inspects `focus` is paradigmatic by construction; one that
     reads `leftCtx` or `rightCtx` is syntagmatic. -/
-structure Neighborhood where
-  focus    : FeatureBundle
-  leftCtx  : List FeatureBundle := []
-  rightCtx : List FeatureBundle := []
+structure Neighborhood (Bundle : Type*) where
+  focus    : Bundle
+  leftCtx  : List Bundle := []
+  rightCtx : List Bundle := []
   deriving Repr
 
 /-- A bundle, viewed as a context-free neighborhood. -/
-def Neighborhood.ofBundle (fb : FeatureBundle) : Neighborhood :=
+def Neighborhood.ofBundle {Bundle : Type*} (fb : Bundle) : Neighborhood Bundle :=
   { focus := fb }
 
 -- ============================================================================
@@ -70,7 +71,7 @@ def Neighborhood.ofBundle (fb : FeatureBundle) : Neighborhood :=
     `applyImpoverishment` reduces by `decide` on concrete inputs. -/
 structure ImpoverishmentRule where
   /-- Does this rule apply at the given neighborhood? -/
-  condition : Neighborhood → Prop
+  condition : Neighborhood FeatureBundle → Prop
   /-- Decidability witness, exposed as an instance (see below). -/
   decCond : DecidablePred condition
   /-- Which feature type is deleted from the focus bundle. -/
@@ -78,7 +79,7 @@ structure ImpoverishmentRule where
 
 /-- Expose the rule's decidability as an instance so that
     `if rule.condition n then ... else ...` elaborates. -/
-instance (rule : ImpoverishmentRule) (n : Neighborhood) :
+instance (rule : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
     Decidable (rule.condition n) := rule.decCond n
 
 -- ============================================================================
@@ -95,7 +96,8 @@ instance (rule : ImpoverishmentRule) (n : Neighborhood) :
     constructors below (`paradigmatic`, `syntagmatic`) discharge it
     automatically when the condition is built focus-only. -/
 def Paradigmatic (r : ImpoverishmentRule) : Prop :=
-  ∀ n₁ n₂ : Neighborhood, n₁.focus = n₂.focus → (r.condition n₁ ↔ r.condition n₂)
+  ∀ n₁ n₂ : Neighborhood FeatureBundle,
+    n₁.focus = n₂.focus → (r.condition n₁ ↔ r.condition n₂)
 
 /-- A rule is **syntagmatic** iff it is not paradigmatic — i.e., there
     exist neighborhoods agreeing on focus that disagree on the condition,
@@ -124,7 +126,7 @@ theorem paradigmatic_isParadigmatic
 /-- Build a (potentially) syntagmatic rule from a full-neighborhood
     Boolean check. Whether the result is genuinely syntagmatic depends
     on `cond` — verify with a separate `Syntagmatic` proof if needed. -/
-def syntagmatic (cond : Neighborhood → Bool) (target : FeatureVal) :
+def syntagmatic (cond : Neighborhood FeatureBundle → Bool) (target : FeatureVal) :
     ImpoverishmentRule where
   condition n := cond n = true
   decCond n := inferInstanceAs (Decidable (cond n = true))
@@ -142,7 +144,7 @@ def deleteFeature (fb : FeatureBundle) (target : FeatureVal) : FeatureBundle :=
 /-- Apply an Impoverishment rule at a neighborhood: when the condition
     holds, return the focus with `target` deleted; otherwise return the
     focus unchanged. -/
-def applyImpoverishment (rule : ImpoverishmentRule) (n : Neighborhood) :
+def applyImpoverishment (rule : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
     FeatureBundle :=
   if rule.condition n then deleteFeature n.focus rule.target else n.focus
 
@@ -151,34 +153,34 @@ def applyImpoverishment (rule : ImpoverishmentRule) (n : Neighborhood) :
     surrounding context fixed. This is the shared shape of one cycle of
     Impoverishment and one cycle of Metathesis (and any other focus-rewriting
     rule class). -/
-def runChain {R : Type} (apply : R → Neighborhood → FeatureBundle)
-    (rules : List R) (n : Neighborhood) : FeatureBundle :=
+def runChain {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
+    (rules : List R) (n : Neighborhood FeatureBundle) : FeatureBundle :=
   rules.foldl (init := n.focus)
     (λ focusAcc rule => apply rule { n with focus := focusAcc })
 
 /-- Concatenating two chains is the same as running them sequentially:
     the second chain starts where the first left off. The proof is
     `List.foldl_append`. This lemma underwrites the
-    strict-vs-interleaved equivalence in
-    `Morphology/DistributedMorphology/PostsyntacticDerivation.lean`. -/
-theorem runChain_append {R : Type} (apply : R → Neighborhood → FeatureBundle)
-    (rs₁ rs₂ : List R) (n : Neighborhood) :
+    strict-vs-interleaved equivalence
+    (`Middleton2026.runStrict_eq_interleaved_paraSyn`). -/
+theorem runChain_append {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
+    (rs₁ rs₂ : List R) (n : Neighborhood FeatureBundle) :
     runChain apply (rs₁ ++ rs₂) n =
       runChain apply rs₂ { n with focus := runChain apply rs₁ n } := by
   simp only [runChain, List.foldl_append]
 
 /-- The empty chain is the identity on the focus. -/
-@[simp] theorem runChain_nil {R : Type} (apply : R → Neighborhood → FeatureBundle)
-    (n : Neighborhood) : runChain apply [] n = n.focus := rfl
+@[simp] theorem runChain_nil {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
+    (n : Neighborhood FeatureBundle) : runChain apply [] n = n.focus := rfl
 
 /-- Apply a sequence of impoverishment rules. Specializes `runChain`. -/
 def applyImpoverishmentChain (rules : List ImpoverishmentRule)
-    (n : Neighborhood) : FeatureBundle :=
+    (n : Neighborhood FeatureBundle) : FeatureBundle :=
   runChain applyImpoverishment rules n
 
 /-- `applyImpoverishmentChain` distributes over list concatenation. -/
 theorem applyImpoverishmentChain_append (rs₁ rs₂ : List ImpoverishmentRule)
-    (n : Neighborhood) :
+    (n : Neighborhood FeatureBundle) :
     applyImpoverishmentChain (rs₁ ++ rs₂) n =
       applyImpoverishmentChain rs₂
         { n with focus := applyImpoverishmentChain rs₁ n } :=

--- a/Linglib/Morphology/DistributedMorphology/Spellout.lean
+++ b/Linglib/Morphology/DistributedMorphology/Spellout.lean
@@ -1,0 +1,269 @@
+import Linglib.Morphology.DistributedMorphology.Fusion
+import Linglib.Morphology.DistributedMorphology.Impoverishment
+
+/-!
+# The spell-out pipeline
+
+The PF branch of the Y-model at the domain level: a spell-out domain is
+the sequence of terminals the syntax hands over, the postsyntactic modules
+transform it, and pointwise Vocabulary Insertion realizes what survives
+([halle-marantz-1993]; module inventory and ordering per
+[arregi-nevins-2012]). The focus-level rule types
+(`Impoverishment.ImpoverishmentRule` and kin) rewrite one terminal inside
+its `Neighborhood`; the operations here move, remove, and merge the
+terminals themselves, which no focus-level rule can express.
+
+Each operation carries its position-count law, so terminal/exponent
+misalignment is arithmetic: neighborhood rewriting and terminal
+metathesis preserve the count, obliteration and fusion decrease it, and
+`Spellout.length_pf` says exponent slots equal terminals after the
+modules. `winner?_retreat` (`VocabularyInsertion.lean`) supplies the
+insertion-side ordering law.
+
+Consumers: `Studies/Middleton2026.lean` (Basque whole-terminal rules and
+the Ondarru ordering witness), `Studies/HalleMarantz1993.lean` (Tns+Agr
+fusion feeding one insertion).
+
+## Main declarations
+
+* `SpelloutDomain`, `mapNeighborhoods` — the domain and the zipper lift
+  of focus-level rewriting
+* `ObliterationRule`, `TerminalMetathesisRule` — whole-terminal deletion
+  ([arregi-nevins-2012]'s Obliteration) and adjacent-terminal swap, with
+  first-match applicators and count laws
+* `FusionRule.applyFirstAdjacent` — the domain lift of Fusion
+* `Spellout` — the module sequence plus pointwise insertion; `run`, `pf`,
+  `runModules_append`
+
+## Todo
+
+* The LF branch: an `Interpreted` extension whose interpretation reads
+  the input domain (the Y-model separation by type), seeded by the
+  domain-level allosemy licensing of `Studies/Benz2025.lean`.
+* A Fission lift, once `FissionRule` derives its positions of exponence
+  from the vocabulary rather than an opaque `realize`.
+* Stratifying the module list by linearization — Lowering before,
+  Local Dislocation after ([embick-noyer-2001]).
+-/
+
+namespace DistributedMorphology
+
+open Impoverishment (Neighborhood)
+
+/-- A spell-out domain: the linear sequence of terminals handed over by
+the syntax at spell-out. -/
+abbrev SpelloutDomain (Bundle : Type*) := List Bundle
+
+variable {Bundle Ctx : Type*}
+
+/-- Rewrite every terminal in its neighborhood: position `i` sees the
+earlier terminals as `leftCtx` and the later ones as `rightCtx`, nearest
+first. The domain lift of a focus-level rule such as Impoverishment. -/
+def mapNeighborhoods (f : Neighborhood Bundle → Bundle)
+    (d : SpelloutDomain Bundle) : SpelloutDomain Bundle :=
+  d.mapIdx fun i b => f ⟨b, (d.take i).reverse, d.drop (i + 1)⟩
+
+/-- Neighborhood rewriting preserves the number of terminals. -/
+@[simp] theorem length_mapNeighborhoods (f : Neighborhood Bundle → Bundle)
+    (d : SpelloutDomain Bundle) :
+    (mapNeighborhoods f d).length = d.length := by
+  simp [mapNeighborhoods]
+
+/-- A whole-terminal deletion rule — [arregi-nevins-2012]'s Obliteration:
+the terminal whose neighborhood satisfies `condition` is removed
+outright. The focus-level `ImpoverishmentRule` deletes a feature inside a
+terminal; this rule deletes the terminal. -/
+structure ObliterationRule (Bundle : Type*) where
+  /-- Does the rule fire at this neighborhood? -/
+  condition : Neighborhood Bundle → Prop
+  /-- Decidability witness for `condition`. -/
+  decCond : DecidablePred condition
+
+namespace ObliterationRule
+
+instance (rule : ObliterationRule Bundle) (n : Neighborhood Bundle) :
+    Decidable (rule.condition n) := rule.decCond n
+
+/-- Build an obliteration rule from a Boolean condition. -/
+def ofBool (cond : Neighborhood Bundle → Bool) : ObliterationRule Bundle where
+  condition n := cond n = true
+  decCond n := inferInstanceAs (Decidable (cond n = true))
+
+/-- Apply the rule, scanning left to right: the first terminal whose
+neighborhood fires is dropped; otherwise the domain is unchanged.
+`leftCtx` is accumulated nearest first. -/
+def apply (rule : ObliterationRule Bundle) (d : SpelloutDomain Bundle) :
+    SpelloutDomain Bundle :=
+  go [] d
+where
+  /-- Scan with the already-passed terminals in `left`, nearest first. -/
+  go : List Bundle → SpelloutDomain Bundle → SpelloutDomain Bundle
+  | left, [] => left.reverse
+  | left, t :: rest =>
+    if rule.condition ⟨t, left, rest⟩ then left.reverse ++ rest
+    else go (t :: left) rest
+
+private theorem length_go_le (rule : ObliterationRule Bundle) :
+    ∀ (rest left : List Bundle),
+      (apply.go rule left rest).length ≤ left.length + rest.length := by
+  intro rest
+  induction rest with
+  | nil => intro left; simp [apply.go]
+  | cons t rest ih =>
+    intro left
+    rw [apply.go]
+    split
+    · simp only [List.length_append, List.length_reverse, List.length_cons]
+      omega
+    · have := ih (t :: left)
+      simp only [List.length_cons] at this ⊢
+      omega
+
+/-- Obliteration never increases the number of terminals. -/
+theorem length_apply_le (rule : ObliterationRule Bundle)
+    (d : SpelloutDomain Bundle) : (rule.apply d).length ≤ d.length := by
+  simpa [apply] using length_go_le rule d []
+
+end ObliterationRule
+
+/-- An adjacent-terminal swap rule — the terminal-order metathesis of
+[arregi-nevins-2012]'s Metathesis module (Basque Ergative Metathesis,
+[middleton-2026] (13)). `condition` sees the terminals left of the pair
+(nearest first), the pair itself, and the terminals to its right. -/
+structure TerminalMetathesisRule (Bundle : Type*) where
+  /-- Does the rule swap the pair `t₁ t₂` in this context? -/
+  condition : List Bundle → Bundle → Bundle → List Bundle → Prop
+  /-- Decidability witness for `condition`. -/
+  decCond : ∀ left t₁ t₂ right, Decidable (condition left t₁ t₂ right)
+
+namespace TerminalMetathesisRule
+
+instance (rule : TerminalMetathesisRule Bundle) (left) (t₁ t₂ : Bundle)
+    (right) : Decidable (rule.condition left t₁ t₂ right) :=
+  rule.decCond left t₁ t₂ right
+
+/-- Build a terminal-metathesis rule from a Boolean condition. -/
+def ofBool (cond : List Bundle → Bundle → Bundle → List Bundle → Bool) :
+    TerminalMetathesisRule Bundle where
+  condition left t₁ t₂ right := cond left t₁ t₂ right = true
+  decCond left t₁ t₂ right :=
+    inferInstanceAs (Decidable (cond left t₁ t₂ right = true))
+
+/-- Apply the rule, scanning left to right: the first adjacent pair whose
+context fires is swapped; otherwise the domain is unchanged. -/
+def apply (rule : TerminalMetathesisRule Bundle)
+    (d : SpelloutDomain Bundle) : SpelloutDomain Bundle :=
+  go [] d
+where
+  /-- Scan with the already-passed terminals in `left`, nearest first. -/
+  go : List Bundle → SpelloutDomain Bundle → SpelloutDomain Bundle
+  | left, [] => left.reverse
+  | left, [t] => left.reverse ++ [t]
+  | left, t₁ :: t₂ :: rest =>
+    if rule.condition left t₁ t₂ rest then left.reverse ++ t₂ :: t₁ :: rest
+    else go (t₁ :: left) (t₂ :: rest)
+
+private theorem length_go (rule : TerminalMetathesisRule Bundle) :
+    ∀ (rest left : List Bundle),
+      (apply.go rule left rest).length = left.length + rest.length := by
+  intro rest
+  induction rest with
+  | nil => intro left; simp [apply.go]
+  | cons t rest ih =>
+    intro left
+    cases rest with
+    | nil => simp [apply.go]
+    | cons t₂ rest' =>
+      rw [apply.go]
+      split
+      · simp
+      · have := ih (t :: left)
+        simp only [List.length_cons] at this ⊢
+        omega
+
+/-- Terminal metathesis preserves the number of terminals. -/
+@[simp] theorem length_apply (rule : TerminalMetathesisRule Bundle)
+    (d : SpelloutDomain Bundle) : (rule.apply d).length = d.length := by
+  simpa [apply] using length_go rule d []
+
+end TerminalMetathesisRule
+
+namespace FusionRule
+
+/-- The domain lift of Fusion: fuse the first adjacent pair the rule
+licenses in context `c`; otherwise the domain is unchanged. -/
+def applyFirstAdjacent (rule : FusionRule Bundle Ctx) (c : Ctx) :
+    SpelloutDomain Bundle → SpelloutDomain Bundle
+  | [] => []
+  | [b] => [b]
+  | b₁ :: b₂ :: rest =>
+    if rule.contextOk c ∧ rule.bundlesOk b₁ b₂ then rule.fuse b₁ b₂ :: rest
+    else b₁ :: applyFirstAdjacent rule c (b₂ :: rest)
+
+/-- Fusion never increases the number of terminals. -/
+theorem length_applyFirstAdjacent_le (rule : FusionRule Bundle Ctx) (c : Ctx) :
+    ∀ d : SpelloutDomain Bundle,
+      (rule.applyFirstAdjacent c d).length ≤ d.length
+  | [] => by simp [applyFirstAdjacent]
+  | [b] => by simp [applyFirstAdjacent]
+  | b₁ :: b₂ :: rest => by
+    rw [applyFirstAdjacent]
+    split
+    · simp
+    · have := length_applyFirstAdjacent_le rule c (b₂ :: rest)
+      simp only [List.length_cons] at this ⊢
+      omega
+
+end FusionRule
+
+/-- Run an ordered module sequence over a domain. The order of the list
+is the theory's architectural claim ([arregi-nevins-2012]'s strict
+sequence; the Basque ordering witness in `Studies/Middleton2026.lean`
+shows reordering it has empirical content). -/
+def runModules (modules : List (SpelloutDomain Bundle → SpelloutDomain Bundle))
+    (d : SpelloutDomain Bundle) : SpelloutDomain Bundle :=
+  modules.foldl (fun d m => m d) d
+
+/-- Module sequences compose by concatenation. -/
+theorem runModules_append
+    (m₁ m₂ : List (SpelloutDomain Bundle → SpelloutDomain Bundle))
+    (d : SpelloutDomain Bundle) :
+    runModules (m₁ ++ m₂) d = runModules m₂ (runModules m₁ d) := by
+  simp [runModules, List.foldl_append]
+
+@[simp] theorem runModules_nil (d : SpelloutDomain Bundle) :
+    runModules ([] : List (SpelloutDomain Bundle → SpelloutDomain Bundle)) d
+      = d := rfl
+
+/-- A PF-branch pipeline over a spell-out domain: the ordered
+postsyntactic modules, then pointwise Vocabulary Insertion at each
+surviving position. -/
+structure Spellout (Bundle F : Type*) where
+  /-- The ordered postsyntactic module sequence. -/
+  modules : List (SpelloutDomain Bundle → SpelloutDomain Bundle)
+  /-- Pointwise Vocabulary Insertion; `none` is a non-licensed position. -/
+  insert : Bundle → Option F
+
+namespace Spellout
+
+variable {F : Type*}
+
+/-- The domain after the module sequence. -/
+def run (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
+    SpelloutDomain Bundle :=
+  runModules s.modules d
+
+/-- The PF output: one insertion slot per surviving position. -/
+def pf (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
+    List (Option F) :=
+  (s.run d).map s.insert
+
+/-- Exponent slots equal terminals after the modules: the exponent count
+diverges from the syntactic terminal count only through the modules. -/
+@[simp] theorem length_pf (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
+    (s.pf d).length = (s.run d).length := by
+  simp [pf]
+
+end Spellout
+
+end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
@@ -85,30 +85,53 @@ structure FeatureVI (F E : Type*) where
   exponent : E
   deriving DecidableEq, Repr
 
+/-- The vocabulary items applicable at a target: those whose feature
+specification is a subset of the target bundle. -/
+def applicable {F E : Type*} [BEq F]
+    (items : List (FeatureVI F E)) (target : List F) : List (FeatureVI F E) :=
+  items.filter (·.features.all (target.contains ·))
+
+/-- Longest-specification choice step for `winner?`; earlier items win
+ties. -/
+private def pickLonger {F E : Type*}
+    (acc : Option (FeatureVI F E)) (item : FeatureVI F E) :
+    Option (FeatureVI F E) :=
+  match acc with
+  | none => some item
+  | some prev =>
+    if item.features.length > prev.features.length then some item else some prev
+
+/-- The Subset Principle's winning item: the longest-specification
+applicable item (the earliest, under ties). -/
+def winner? {F E : Type*} [BEq F]
+    (items : List (FeatureVI F E)) (target : List F) :
+    Option (FeatureVI F E) :=
+  (applicable items target).foldl pickLonger none
+
 /-- The **Subset Principle** ([halle-marantz-1993]): among vocabulary
     items whose feature specification is a subset of the target, select
     the most specific (longest feature list).
 
-    Returns `none` only if `items` is empty. When items include an
+    Returns `none` only if no item is applicable. When items include an
     elsewhere entry (empty feature list), `subsetPrinciple` always
     succeeds — the elsewhere item matches any target. -/
 def subsetPrinciple {F E : Type*} [BEq F]
     (items : List (FeatureVI F E)) (target : List F) : Option E :=
-  let matching := items.filter (·.features.all (target.contains ·))
-  (matching.foldl (init := none) fun acc item =>
-    match acc with
-    | none => some item
-    | some prev =>
-      if item.features.length > prev.features.length
-      then some item
-      else some prev
-  ).map (·.exponent)
+  (winner? items target).map (·.exponent)
 
 /-- An elsewhere item (empty features) matches any target. -/
 theorem elsewhere_always_matches {F E : Type*} [BEq F]
     (e : E) (target : List F) :
     (FeatureVI.mk ([] : List F) e).features.all (target.contains ·) = true := by
   simp [List.all_nil]
+
+private theorem pickLonger_cases {F E : Type*} (acc : Option (FeatureVI F E))
+    (x : FeatureVI F E) : pickLonger acc x = some x ∨ pickLonger acc x = acc := by
+  cases acc with
+  | none => exact .inl rfl
+  | some prev =>
+    by_cases hlen : x.features.length > prev.features.length <;>
+      simp [pickLonger, hlen]
 
 private theorem foldl_choice_mem {α : Type*} {pick : Option α → α → Option α}
     (hpick : ∀ acc x, pick acc x = some x ∨ pick acc x = acc) :
@@ -127,25 +150,130 @@ private theorem foldl_choice_mem {α : Type*} {pick : Option α → α → Optio
         exact .inl (List.mem_cons_self ..)
       · exact .inr (hkeep ▸ hacc)
 
-/-- The Subset Principle's winner is an item of the vocabulary whose
-features are all present in the target — the selected exponent never
-draws on features the node does not bear. -/
+private theorem foldl_pickLonger_ne_none {F E : Type*} :
+    ∀ (l : List (FeatureVI F E)) (a : FeatureVI F E),
+      l.foldl pickLonger (some a) ≠ none := by
+  intro l
+  induction l with
+  | nil => exact fun a h => by simp at h
+  | cons x xs ih =>
+    intro a h
+    rw [List.foldl_cons] at h
+    rcases pickLonger_cases (some a) x with hx | hkeep
+    · rw [hx] at h; exact ih x h
+    · rw [hkeep] at h; exact ih a h
+
+private theorem foldl_pickLonger_max {F E : Type*} :
+    ∀ (l : List (FeatureVI F E)) (acc : Option (FeatureVI F E))
+      (i : FeatureVI F E), l.foldl pickLonger acc = some i →
+      (∀ j ∈ l, j.features.length ≤ i.features.length) ∧
+        ∀ a, acc = some a → a.features.length ≤ i.features.length := by
+  intro l
+  induction l with
+  | nil =>
+    intro acc i h
+    refine ⟨by simp, fun a ha => ?_⟩
+    rw [ha] at h
+    obtain rfl := Option.some.inj h
+    exact Nat.le_refl _
+  | cons x xs ih =>
+    intro acc i h
+    rw [List.foldl_cons] at h
+    obtain ⟨hxs, hstep⟩ := ih (pickLonger acc x) i h
+    have hx : x.features.length ≤ i.features.length := by
+      cases acc with
+      | none => exact hstep x rfl
+      | some prev =>
+        by_cases hlen : x.features.length > prev.features.length
+        · exact hstep x (by simp [pickLonger, hlen])
+        · have := hstep prev (by simp [pickLonger, hlen])
+          omega
+    refine ⟨fun j hj => ?_, fun a ha => ?_⟩
+    · rcases List.mem_cons.mp hj with rfl | hj'
+      · exact hx
+      · exact hxs j hj'
+    · subst ha
+      by_cases hlen : x.features.length > a.features.length
+      · omega
+      · have := hstep a (by simp [pickLonger, hlen])
+        omega
+
+/-- The winner is an applicable item. -/
+theorem winner?_mem {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
+    (h : winner? items target = some i) : i ∈ applicable items target := by
+  rcases foldl_choice_mem pickLonger_cases h with hmem | hnone
+  · exact hmem
+  · exact absurd hnone (by simp)
+
+/-- The winner belongs to the vocabulary and draws only on features the
+target bears. -/
+theorem winner?_spec {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
+    (h : winner? items target = some i) :
+    i ∈ items ∧ i.features.all (target.contains ·) = true := by
+  have := List.mem_filter.mp (winner?_mem h)
+  exact ⟨this.1, this.2⟩
+
+/-- The Subset Principle's exponent comes from an applicable vocabulary
+item — the selection never draws on features the node does not bear. -/
 theorem subsetPrinciple_winner_mem {F E : Type*} [BEq F]
     {items : List (FeatureVI F E)} {target : List F} {e : E}
     (h : subsetPrinciple items target = some e) :
     ∃ i ∈ items, i.exponent = e ∧ i.features.all (target.contains ·) = true := by
-  unfold subsetPrinciple at h
-  obtain ⟨i, hfold, rfl⟩ := Option.map_eq_some_iff.mp h
-  have hmem := foldl_choice_mem (fun acc x => by
-    cases acc with
-    | none => exact .inl rfl
-    | some prev =>
-      by_cases hlen : x.features.length > prev.features.length <;>
-        simp [hlen]) hfold
-  rcases hmem with hmem | hnone
-  · have := List.mem_filter.mp hmem
-    exact ⟨i, this.1, rfl, this.2⟩
-  · exact absurd hnone (by simp)
+  obtain ⟨i, hw, rfl⟩ := Option.map_eq_some_iff.mp h
+  obtain ⟨hi, happ⟩ := winner?_spec hw
+  exact ⟨i, hi, rfl, happ⟩
+
+/-- `winner?` succeeds iff some item is applicable. -/
+theorem winner?_isSome_iff {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {target : List F} :
+    (winner? items target).isSome ↔ applicable items target ≠ [] := by
+  unfold winner?
+  cases hl : applicable items target with
+  | nil => simp
+  | cons x xs =>
+    simp only [List.foldl_cons, ne_eq, reduceCtorEq, not_false_eq_true,
+      iff_true]
+    have hstep : pickLonger (none : Option (FeatureVI F E)) x = some x := rfl
+    rw [hstep, Option.isSome_iff_ne_none]
+    exact foldl_pickLonger_ne_none xs x
+
+/-- The winner is maximally specific among the applicable items. -/
+theorem winner?_max {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
+    (h : winner? items target = some i) :
+    ∀ j ∈ applicable items target, j.features.length ≤ i.features.length :=
+  (foldl_pickLonger_max _ _ _ h).1
+
+/-- Applicability is monotone in the target bundle. -/
+theorem applicable_mono {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {t t' : List F}
+    (hsub : ∀ x, t'.contains x = true → t.contains x = true) :
+    ∀ i ∈ applicable items t', i ∈ applicable items t := by
+  intro i hi
+  obtain ⟨him, hall⟩ := List.mem_filter.mp hi
+  refine List.mem_filter.mpr ⟨him, ?_⟩
+  rw [List.all_eq_true] at hall ⊢
+  exact fun x hx => hsub x (hall x hx)
+
+/-- **Retreat to the general case**: shrinking the target — deleting
+features by Impoverishment — can only make the Subset-Principle winner
+weakly less specific, which is why impoverishment yields syncretism with
+a more general exponent rather than a different specific one
+([halle-marantz-1993], [arregi-nevins-2012]). -/
+theorem winner?_retreat {F E : Type*} [BEq F]
+    {items : List (FeatureVI F E)} {t t' : List F} {i' : FeatureVI F E}
+    (hsub : ∀ x, t'.contains x = true → t.contains x = true)
+    (h' : winner? items t' = some i') :
+    ∃ i, winner? items t = some i ∧
+      i'.features.length ≤ i.features.length := by
+  have hmem : i' ∈ applicable items t :=
+    applicable_mono hsub _ (winner?_mem h')
+  have hne : applicable items t ≠ [] := fun hnil => by simp [hnil] at hmem
+  obtain ⟨i, hi⟩ :=
+    Option.isSome_iff_exists.mp (winner?_isSome_iff.mpr hne)
+  exact ⟨i, hi, winner?_max hi _ hmem⟩
 
 -- ============================================================================
 -- § 3: The shared exponence core

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.Fusion
+import Linglib.Morphology.DistributedMorphology.Spellout
 import Linglib.Morphology.Morphotactics.MirrorPrinciple
 
 /-!
@@ -326,6 +326,31 @@ theorem fusion_elsewhere :
 theorem fusion_always_spellable (tPast tPart aSg3 : Bool) :
     (subsetPrinciple englishTnsVI (fusedFeatures tPast tPart aSg3)).isSome = true := by
   cases tPast <;> cases tPart <;> cases aSg3 <;> native_decide
+
+/-- The Tns+Agr pipeline over a spell-out domain: the fusion module,
+    then pointwise insertion by the Subset Principle. -/
+def tnsAgrSpellout :
+    DistributedMorphology.Spellout (List EngInflFeature) String where
+  modules := [tnsAgrFusion.applyFirstAdjacent ()]
+  insert := subsetPrinciple englishTnsVI
+
+/-- *walk-s*: the domain [Tns[−past,−part], Agr[3sg]] spells out as the
+    single exponent `-z`. -/
+theorem walks_pf :
+    tnsAgrSpellout.pf
+        [(InflHead.tns false false).features, (InflHead.agr true).features]
+      = [some "-z"] := by native_decide
+
+/-- Two syntactic terminals enter, one exponent slot leaves — the
+    terminal/exponent misalignment is carried entirely by the fusion
+    module. -/
+theorem walks_terminal_exponent_misalignment :
+    [(InflHead.tns false false).features,
+      (InflHead.agr true).features].length = 2 ∧
+    (tnsAgrSpellout.pf
+        [(InflHead.tns false false).features,
+          (InflHead.agr true).features]).length = 1 := by
+  exact ⟨rfl, by rw [walks_pf]; rfl⟩
 
 end TnsAgrFusion
 

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.DistributedMorphology.Impoverishment
+import Linglib.Morphology.DistributedMorphology.Spellout
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
 import Linglib.Fragments.Taos.Agreement
 import Linglib.Fragments.Basque.Postsyntax
@@ -45,11 +46,11 @@ re-derive the entire paradigm. What lives here:
 * The Basque half of the paper requires *whole terminal* deletion
   (Participant Dissimilation, rule 16) and *adjacent terminal* swap
   (Ergative Metathesis, rule 13) — operations the focus-level Taos
-  sections cannot express. The framework lift — `MorphPhrase`,
-  `TermImpovRule`, `TermMetaRule` with their applicators — is
-  inlined at the end of the file; the bundles live in
-  `Fragments/Basque/Postsyntax.lean`; the rules and the Ondarru
-  `s-endu-n` (17a) divergence witness are stated here.
+  sections cannot express. The domain-level rule shapes are
+  `DistributedMorphology.ObliterationRule` and
+  `DistributedMorphology.TerminalMetathesisRule` (`Spellout.lean`);
+  the bundles live in `Fragments/Basque/Postsyntax.lean`; the rules
+  and the Ondarru `s-endu-n` (17a) divergence witness are stated here.
 
 What is **not** modeled:
 
@@ -63,12 +64,13 @@ What is **not** modeled:
 
 namespace Middleton2026
 
-open Minimalist DistributedMorphology.Impoverishment DistributedMorphology.VI
+open Minimalist DistributedMorphology DistributedMorphology.Impoverishment
+  DistributedMorphology.VI
      Taos.Agreement Basque.Postsyntax
 
 /-! ### Metathesis Rule
 
-`MetathesisRule` parallels `ImpoverishmentRule`: keyed on a `Neighborhood`,
+`MetathesisRule` parallels `ImpoverishmentRule`: keyed on a `Neighborhood FeatureBundle`,
 carries a decidable condition. The structural change is to swap two
 distinguished feature *types* in the focus bundle — the rule names a pair
 of feature types and exchanges the positions of the first occurrences of
@@ -77,12 +79,12 @@ each. The directionality matches [arregi-nevins-2012]'s
 -/
 
 structure MetathesisRule where
-  condition : Neighborhood → Prop
+  condition : Neighborhood FeatureBundle → Prop
   decCond : DecidablePred condition
   swapFst : FeatureVal
   swapSnd : FeatureVal
 
-instance (rule : MetathesisRule) (n : Neighborhood) :
+instance (rule : MetathesisRule) (n : Neighborhood FeatureBundle) :
     Decidable (rule.condition n) := rule.decCond n
 
 /-- Build a metathesis rule from a Boolean condition over the focus
@@ -130,7 +132,7 @@ def swapInBundle (fb : FeatureBundle) (swapFst swapSnd : FeatureVal) :
     only ever carry an empty metathesis chain). The empirically contentful,
     order-sensitive focus-level metathesis of [middleton-2026] is stated on
     the exponent-string view directly (`derivIM`/`derivMI`). -/
-def applyMetathesis (rule : MetathesisRule) (n : Neighborhood) :
+def applyMetathesis (rule : MetathesisRule) (n : Neighborhood FeatureBundle) :
     FeatureBundle :=
   if rule.condition n then
     FeatureBundle.ofGramFeatures (swapInBundle n.focus rule.swapFst rule.swapSnd)
@@ -139,13 +141,13 @@ def applyMetathesis (rule : MetathesisRule) (n : Neighborhood) :
 /-- Apply a sequence of metathesis rules left-to-right. Each rule sees
     the focus as updated by prior rules; surrounding context is held
     fixed (one cycle of metathesis). Specializes `runChain`. -/
-def applyMetathesisChain (rules : List MetathesisRule) (n : Neighborhood) :
+def applyMetathesisChain (rules : List MetathesisRule) (n : Neighborhood FeatureBundle) :
     FeatureBundle :=
   runChain applyMetathesis rules n
 
 /-- `applyMetathesisChain` distributes over list concatenation. -/
 theorem applyMetathesisChain_append (rs₁ rs₂ : List MetathesisRule)
-    (n : Neighborhood) :
+    (n : Neighborhood FeatureBundle) :
     applyMetathesisChain (rs₁ ++ rs₂) n =
       applyMetathesisChain rs₂
         { n with focus := applyMetathesisChain rs₁ n } :=
@@ -189,7 +191,7 @@ structure ModularPostsyntax where
   metathesis   : List MetathesisRule
 
 /-- A&N's strict pipeline: para-block, then syn-block, then metathesis. -/
-def runStrict (M : ModularPostsyntax) (n : Neighborhood) : FeatureBundle :=
+def runStrict (M : ModularPostsyntax) (n : Neighborhood FeatureBundle) : FeatureBundle :=
   let afterPara := applyImpoverishmentChain M.paradigmatic n
   let afterSyn  := applyImpoverishmentChain M.syntagmatic { n with focus := afterPara }
   applyMetathesisChain M.metathesis { n with focus := afterSyn }
@@ -201,7 +203,7 @@ structure InterleavedPostsyntax where
   impoverishment : List ImpoverishmentRule
   metathesis     : List MetathesisRule
 
-def runInterleaved (M : InterleavedPostsyntax) (n : Neighborhood) :
+def runInterleaved (M : InterleavedPostsyntax) (n : Neighborhood FeatureBundle) :
     FeatureBundle :=
   let afterImp := applyImpoverishmentChain M.impoverishment n
   applyMetathesisChain M.metathesis { n with focus := afterImp }
@@ -218,7 +220,7 @@ def ModularPostsyntax.toInterleaved (M : ModularPostsyntax) :
     strictly *less expressive* than `runInterleaved`: anything strict
     can derive, interleaved can derive too (with the same rules). -/
 theorem runStrict_eq_interleaved_paraSyn
-    (M : ModularPostsyntax) (n : Neighborhood) :
+    (M : ModularPostsyntax) (n : Neighborhood FeatureBundle) :
     runStrict M n = runInterleaved M.toInterleaved n := by
   simp only [runStrict, runInterleaved, ModularPostsyntax.toInterleaved,
              applyImpoverishmentChain_append]
@@ -226,7 +228,7 @@ theorem runStrict_eq_interleaved_paraSyn
 /-- A two-rule strict pipeline (one paradigmatic, one syntagmatic, no
     metathesis) reduces to applying `[p, s]` in order. -/
 @[simp] theorem runStrict_singleton (p s : ImpoverishmentRule)
-    (n : Neighborhood) :
+    (n : Neighborhood FeatureBundle) :
     runStrict ⟨[p], [s], []⟩ n = applyImpoverishmentChain [p, s] n := by
   simp only [runStrict, applyImpoverishmentChain, runChain,
              applyMetathesisChain, List.foldl_nil, List.foldl_cons]
@@ -234,7 +236,7 @@ theorem runStrict_eq_interleaved_paraSyn
 /-- An interleaved pipeline with no metathesis reduces to the
     impoverishment chain. -/
 @[simp] theorem runInterleaved_no_metathesis (rs : List ImpoverishmentRule)
-    (n : Neighborhood) :
+    (n : Neighborhood FeatureBundle) :
     runInterleaved ⟨rs, []⟩ n = applyImpoverishmentChain rs n := by
   simp only [runInterleaved, applyMetathesisChain, runChain, List.foldl_nil]
 
@@ -249,14 +251,14 @@ theorem runStrict_eq_interleaved_paraSyn
     §4.2.1–§4.2.4 require precisely the syn-before-para derivation that
     `runStrict` excludes by construction. -/
 theorem runStrict_forces_paraSyn_order
-    (p s : ImpoverishmentRule) (n : Neighborhood) :
+    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
     runStrict ⟨[p], [s], []⟩ n = applyImpoverishmentChain [p, s] n :=
   runStrict_singleton p s n
 
 /-- The interleaved pipeline can deliver the syn-first derivation that
     `runStrict` cannot. -/
 theorem runInterleaved_admits_synPara
-    (p s : ImpoverishmentRule) (n : Neighborhood) :
+    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
     runInterleaved ⟨[s, p], []⟩ n = applyImpoverishmentChain [s, p] n :=
   runInterleaved_no_metathesis _ _
 
@@ -264,7 +266,7 @@ theorem runInterleaved_admits_synPara
     at `n`, then the strict pipeline ⟨[p], [s], []⟩ cannot match the
     interleaved pipeline ⟨[s, p], []⟩ at `n`. -/
 theorem runStrict_neq_runInterleaved_of_diverges
-    (p s : ImpoverishmentRule) (n : Neighborhood)
+    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle)
     (h : applyImpoverishmentChain [p, s] n ≠ applyImpoverishmentChain [s, p] n) :
     runStrict ⟨[p], [s], []⟩ n ≠ runInterleaved ⟨[s, p], []⟩ n := by
   rw [runStrict_singleton, runInterleaved_no_metathesis]
@@ -273,14 +275,14 @@ theorem runStrict_neq_runInterleaved_of_diverges
 /-- A two-step pipeline that runs impoverishment then metathesis at a
     neighborhood (the order both A&N and Middleton endorse). -/
 def runImpovThenMeta (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
-    (n : Neighborhood) : FeatureBundle :=
+    (n : Neighborhood FeatureBundle) : FeatureBundle :=
   applyMetathesisChain ms { n with focus := applyImpoverishmentChain rs n }
 
 /-- The reversed two-step pipeline: metathesis first, then impoverishment
     (the order both A&N and Middleton reject — supported by Basque in §3.1
     and by Taos in §3.2 of [middleton-2026]). -/
 def runMetaThenImpov (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
-    (n : Neighborhood) : FeatureBundle :=
+    (n : Neighborhood FeatureBundle) : FeatureBundle :=
   applyImpoverishmentChain rs { n with focus := applyMetathesisChain ms n }
 
 /-- **Metathesis-after-impoverishment is non-trivial.** If a single
@@ -289,7 +291,7 @@ def runMetaThenImpov (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
     and `runMetaThenImpov` differ — i.e., the architectural choice has
     empirical content. -/
 theorem runImpov_neq_runMeta_of_diverges
-    (r : ImpoverishmentRule) (m : MetathesisRule) (n : Neighborhood)
+    (r : ImpoverishmentRule) (m : MetathesisRule) (n : Neighborhood FeatureBundle)
     (h : applyMetathesisChain [m] { n with focus := applyImpoverishment r n } ≠
          applyImpoverishment r { n with focus := applyMetathesis m n }) :
     runImpovThenMeta [r] [m] n ≠ runMetaThenImpov [r] [m] n := by
@@ -341,9 +343,9 @@ theorem synMinimalRule_isSyntagmatic : Syntagmatic synMinimalRule := by
   intro hPara
   let fb : FeatureBundle :=
     .ofGramFeatures [.valued (fAtomic true), .valued (fMinimal true)]
-  let n₁ : Neighborhood :=
+  let n₁ : Neighborhood FeatureBundle :=
     { focus := fb, leftCtx := [], rightCtx := [argBundle person3 numSg] }
-  let n₂ : Neighborhood := { focus := fb, leftCtx := [], rightCtx := [] }
+  let n₂ : Neighborhood FeatureBundle := { focus := fb, leftCtx := [], rightCtx := [] }
   have hfoc : n₁.focus = n₂.focus := rfl
   have h := hPara n₁ n₂ hfoc
   have h₁ : synMinimalRule.condition n₁ := by decide
@@ -363,7 +365,7 @@ def witnessFocus : FeatureBundle :=
 /-- Witness neighborhood: the 1s-style focus, with a real 3s
     bundle to the right standing in for the Taos object slot
     that conditions `synMinimalRule`. -/
-def witness : Neighborhood :=
+def witness : Neighborhood FeatureBundle :=
   { focus := witnessFocus,
     leftCtx := [],
     rightCtx := [argBundle person3 numSg] }
@@ -585,108 +587,30 @@ theorem arregiNevins_vs_middleton_surface :
 /-! ### Basque — Whole-Terminal Postsyntax (Middleton §3.1)
 
 The Basque half of the paper operates on whole terminals, not features
-within a terminal. We lift the focus-level `Neighborhood`-based machinery
-of `Impoverishment.lean` / `Metathesis.lean` to phrase-level scans, then
-state Participant Dissimilation, Ergative Metathesis, and the Ondarru
-divergence witness.
+within a terminal. The domain-level rule shapes are
+`DistributedMorphology.ObliterationRule` (whole-terminal deletion) and
+`DistributedMorphology.TerminalMetathesisRule` (adjacent-terminal swap)
+from `Spellout.lean`; this section instantiates them as Participant
+Dissimilation and Ergative Metathesis and states the Ondarru divergence
+witness. Embick & Noyer 2001 call rules of the terminal-metathesis shape
+"Local Dislocation". -/
 
-Embick & Noyer 2001 call rules of `TermMetaRule`'s shape "Local
-Dislocation". `TermMetaRule` is the `FeatureBundle`-typed
-instantiation with the applicator. -/
-
-/-- A Basque morphological phrase: a linear sequence of terminal
-    `FeatureBundle`s, head-leftmost in linear (post-linearisation)
-    order. -/
-abbrev MorphPhrase := List FeatureBundle
-
-/-- A **terminal-level Impoverishment** rule: deletes a whole terminal
-    when its `Neighborhood` (focus = the candidate terminal,
-    `leftCtx`/`rightCtx` = its phrase-mates) satisfies `condition`.
-    Parallel to the focus-level `ImpoverishmentRule` whose target is a
-    feature within one terminal; here the target is the terminal
-    itself. Motivating case: Basque Participant Dissimilation,
-    [middleton-2026] (16). -/
-structure TermImpovRule where
-  condition : Neighborhood → Prop
-  decCond : DecidablePred condition
-
-instance (rule : TermImpovRule) (n : Neighborhood) :
-    Decidable (rule.condition n) := rule.decCond n
-
-/-- Build a `TermImpovRule` from a Boolean predicate over the
-    neighborhood. -/
-private def termImpov (cond : Neighborhood → Bool) : TermImpovRule where
-  condition n := cond n = true
-  decCond _ := inferInstanceAs (Decidable (cond _ = true))
-
-/-- Apply a `TermImpovRule`, scanning the phrase left-to-right. The
-    first terminal whose neighborhood satisfies the rule is dropped;
-    if no terminal matches, the phrase is returned unchanged. -/
-def applyTermImpov (rule : TermImpovRule) (phrase : MorphPhrase) :
-    MorphPhrase :=
-  let rec go (left rest : List FeatureBundle) : List FeatureBundle :=
-    match rest with
-    | [] => left
-    | t :: rest' =>
-      let n : Neighborhood :=
-        { focus := t, leftCtx := left, rightCtx := rest' }
-      if rule.condition n then left ++ rest'
-      else go (left ++ [t]) rest'
-  go [] phrase
-
-/-- A **terminal-level Metathesis** rule: swaps two adjacent terminals
-    when the condition holds at their joint context. By convention `t1`
-    is the immediate left of `t2`. Motivating case: Basque Ergative
-    Metathesis, [middleton-2026] (13). -/
-structure TermMetaRule where
-  condition : List FeatureBundle → FeatureBundle → FeatureBundle →
-              List FeatureBundle → Prop
-  decCond : ∀ left t1 t2 right, Decidable (condition left t1 t2 right)
-
-instance (rule : TermMetaRule) (left t1 t2 right) :
-    Decidable (rule.condition left t1 t2 right) :=
-  rule.decCond left t1 t2 right
-
-/-- Build a `TermMetaRule` from a Boolean predicate. -/
-private def termMeta
-    (cond : List FeatureBundle → FeatureBundle → FeatureBundle →
-            List FeatureBundle → Bool) :
-    TermMetaRule where
-  condition left t1 t2 right := cond left t1 t2 right = true
-  decCond _ _ _ _ :=
-    inferInstanceAs (Decidable (cond _ _ _ _ = true))
-
-/-- Apply a `TermMetaRule`, scanning the phrase left-to-right. Swap the
-    first adjacent pair whose joint context satisfies the condition. -/
-def applyTermMeta (rule : TermMetaRule) (phrase : MorphPhrase) :
-    MorphPhrase :=
-  let rec go (left rest : List FeatureBundle) : List FeatureBundle :=
-    match rest with
-    | [] => left
-    | [t] => left ++ [t]
-    | t1 :: t2 :: rest' =>
-      if rule.condition left t1 t2 rest' then
-        left ++ (t2 :: t1 :: rest')
-      else
-        go (left ++ [t1]) (t2 :: rest')
-  go [] phrase
-
-/-- Run impoverishment first, then metathesis — the endorsed pipeline
-    of both [arregi-nevins-2012] and [middleton-2026]. -/
+/-- Run obliteration first, then terminal metathesis — the endorsed
+    pipeline of both [arregi-nevins-2012] and [middleton-2026]. -/
 def runPhraseImpovThenMeta
-    (impovs : List TermImpovRule) (metas : List TermMetaRule)
-    (phrase : MorphPhrase) : MorphPhrase :=
-  metas.foldl (λ p r => applyTermMeta r p)
-    (impovs.foldl (λ p r => applyTermImpov r p) phrase)
+    (impovs : List (ObliterationRule FeatureBundle))
+    (metas : List (TerminalMetathesisRule FeatureBundle))
+    (phrase : SpelloutDomain FeatureBundle) : SpelloutDomain FeatureBundle :=
+  runModules (impovs.map (·.apply) ++ metas.map (·.apply)) phrase
 
-/-- Run metathesis first, then impoverishment — the order both authors
-    reject; the Basque Ondarru `*s-endu-s-n` form [middleton-2026]
-    (17b) is the diagnostic witness. -/
+/-- Run terminal metathesis first, then obliteration — the order both
+    authors reject; the Basque Ondarru `*s-endu-s-n` form
+    [middleton-2026] (17b) is the diagnostic witness. -/
 def runPhraseMetaThenImpov
-    (impovs : List TermImpovRule) (metas : List TermMetaRule)
-    (phrase : MorphPhrase) : MorphPhrase :=
-  impovs.foldl (λ p r => applyTermImpov r p)
-    (metas.foldl (λ p r => applyTermMeta r p) phrase)
+    (impovs : List (ObliterationRule FeatureBundle))
+    (metas : List (TerminalMetathesisRule FeatureBundle))
+    (phrase : SpelloutDomain FeatureBundle) : SpelloutDomain FeatureBundle :=
+  runModules (metas.map (·.apply) ++ impovs.map (·.apply)) phrase
 
 /-- **Participant Dissimilation** ([middleton-2026] (16),
     [arregi-nevins-2012] §4.6). Delete a 1p absolutive clitic
@@ -694,8 +618,8 @@ def runPhraseMetaThenImpov
     clitic somewhere to the right in the same auxiliary. The rule
     operates at the terminal level — it deletes a whole bundle, not a
     feature within one. -/
-def participantDissimilation : TermImpovRule :=
-  termImpov (λ n =>
+def participantDissimilation : ObliterationRule FeatureBundle :=
+  .ofBool (λ n =>
     isAbsParticipantAuthor n.focus &&
     n.rightCtx.any isErgParticipant)
 
@@ -705,14 +629,14 @@ def participantDissimilation : TermImpovRule :=
     The leftmost requirement (`left.isEmpty`) is what lets
     Participant Dissimilation *feed* Ergative Metathesis: only
     after PD deletes the absolutive clitic does T become leftmost. -/
-def ergativeMetathesis : TermMetaRule :=
-  termMeta (λ left t1 t2 _ =>
+def ergativeMetathesis : TerminalMetathesisRule FeatureBundle :=
+  .ofBool (λ left t1 t2 _ =>
     left.isEmpty && isT t1 && isErgClitic t2)
 
 /-- The Ondarru witness phrase from [middleton-2026] (17a):
     `s-endu-n` `[1pABS, T:past, 2sERG]`. The complementizer is
     suppressed — it does not participate in either rule. -/
-def basqueWitnessPhrase : MorphPhrase :=
+def basqueWitnessPhrase : SpelloutDomain FeatureBundle :=
   [abs1pAuthor, tPast, erg2s]
 
 /-- **PD-then-Meta surface form (the grammatical s-endu-n order).**


### PR DESCRIPTION
Arc 2 of the DM deepening: the PF branch at the domain level.

- `Spellout.lean`: `SpelloutDomain`, the zipper lift `mapNeighborhoods`, `ObliterationRule` (A&N Obliteration) and `TerminalMetathesisRule` with first-match applicators and position-count laws, the Fusion domain lift, and `Spellout`/`runModules` with the composition law — graduating Studies/Middleton2026's study-local whole-terminal machinery (its confessed bundle-level metathesis workaround included).
- `Neighborhood` parametrized over the bundle type; consumers migrated.
- `VocabularyInsertion.lean`: `winner?` refactor exposing the Subset-Principle winner, with membership, maximality, and `winner?_retreat` — retreat to the general case under feature deletion, the impoverishment-feeds-VI ordering argument.
- Middleton2026's Basque section now runs on the framework ops (Ondarru witness theorems unchanged); HalleMarantz1993 gains the Tns+Agr `Spellout` with the two-terminals-one-exponent misalignment theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)