### PR TITLE
refactor(Morphology/DistributedMorphology): Categorizer directory

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1250,8 +1250,9 @@ import Linglib.Morphology.Construction.Schema
 import Linglib.Morphology.Construction.Sister
 import Linglib.Morphology.DistributedMorphology.Allosemy
 import Linglib.Morphology.DistributedMorphology.Basic
-import Linglib.Morphology.DistributedMorphology.Categorizer
-import Linglib.Morphology.DistributedMorphology.CategorizerSemantics
+import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
+import Linglib.Morphology.DistributedMorphology.Categorizer.Semantics
 import Linglib.Morphology.DistributedMorphology.Defs
 import Linglib.Morphology.DistributedMorphology.DomainLocality
 import Linglib.Morphology.DistributedMorphology.Fission

--- a/Linglib/Fragments/Spanish/Binominals.lean
+++ b/Linglib/Fragments/Spanish/Binominals.lean
@@ -1,5 +1,5 @@
 import Linglib.Semantics.Quantification.BinominalDefs
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 
 /-!
 # Spanish Binominal Nouns [saab-2026]

--- a/Linglib/Fragments/Teop/Nouns.lean
+++ b/Linglib/Fragments/Teop/Nouns.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Gender.Basic
 import Linglib.Morphology.DistributedMorphology.NominalStructure
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 
 /-!
 # Teop Noun Inventory [adamson-2024]

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -1,6 +1,6 @@
 import Linglib.Morphology.DistributedMorphology.Basic
-import Linglib.Morphology.DistributedMorphology.Categorizer
-import Linglib.Morphology.DistributedMorphology.CategorizerSemantics
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
+import Linglib.Morphology.DistributedMorphology.Categorizer.Semantics
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.Realization
 import Linglib.Semantics.ArgumentStructure.Root.Classification

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
@@ -1,0 +1,229 @@
+import Linglib.Semantics.ArgumentStructure.Root.Classification
+import Linglib.Syntax.Minimalist.Features
+import Linglib.Syntax.Minimalist.Verbal.Voice
+
+/-!
+# Roots and categorization
+
+The acategorial roots of Distributed Morphology, individuated by an
+arbitrary index alone, and the categorizing heads n, v, a that merge with
+them to give a syntactic category — the categorization assumption. The
+same root index survives categorization and re-categorization, which is
+what makes √HAMMER one root across *hammer* and *to hammer*. Complement
+selection is a property of the root, and the domain of idiosyncratic
+interpretation is bounded by Voice, not by the categorizer.
+
+## Main definitions
+
+* `Root`, `Categorizer` — the acategorial root and the heads n, v, a
+* `Categorizer.toCategory` — the syntactic category of n, v, a
+* `CategorizedRoot`, `Recategorization` — roots under a categorizer and
+  layered derivation
+
+## Main statements
+
+* `same_root_different_category`, `recategorize_preserves_index` — one
+  root index across categories, threaded unchanged through derivation
+* `agentive_voice_is_phase` — Voice, not the categorizer, bounds special
+  interpretation
+
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
+* [A. Marantz, *No escape from syntax*][marantz-1997]
+* [H. Harley, *On the identity of roots*][harley-2014]
+* [D. Embick and A. Marantz, *Architecture and blocking*][embick-marantz-2008]
+-/
+
+namespace DistributedMorphology
+
+open Minimalist Minimalist.Voice
+open Verb Verb.Root
+
+/-! ### Roots and categorizers -/
+
+/-- A Root terminal node, individuated by an arbitrary index alone — with
+deliberately no form or meaning fields, following [harley-2014]'s answer to
+what roots are. It receives its form at Vocabulary Insertion. A different
+object from the comparative-concept root of `Morphology/Root/Basic.lean`,
+which is a contentful morph. -/
+structure Root where
+  /-- The individuating index. -/
+  index : Nat
+  deriving DecidableEq, Repr
+
+/-- A categorizing head that merges with an acategorial root to project
+    syntactic structure. The three options correspond to the functional
+    heads n, v, a in Distributed Morphology ([marantz-1997], [harley-2014] §2). -/
+inductive Categorizer where
+  | n  -- nominal categorizer
+  | v  -- verbal categorizer
+  | a  -- adjectival categorizer
+  deriving DecidableEq, Repr
+
+/-- The syntactic category of a categorizer. -/
+def Categorizer.toCategory : Categorizer → Cat
+  | .n => .N
+  | .v => .V
+  | .a => .A
+
+/-! ### CategorizedRoot -/
+
+/-- A root that has been merged with a categorizing head, yielding a
+    syntactically projectable unit ([harley-2014] §2).
+
+    `index` is DM's List-1 individuator — the acategorial atom `DistributedMorphology.Root`,
+    an arbitrary tag carrying no form or meaning. It is what survives
+    (re)categorization (`recategorize_preserves_index`), so it, not the
+    `root` classification, is what makes √HAMMER *one* root across
+    *hammer*/*to hammer*. `root` is the c-selection content (arity,
+    change-type) the categorizer apparatus reads ([harley-2014] §3); unrelated roots may
+    share it, so it cannot individuate. -/
+structure CategorizedRoot where
+  /-- The acategorial root index — DM's List-1 individuator (`DistributedMorphology.Root`). -/
+  index : DistributedMorphology.Root
+  /-- The acategorial root's c-selection content (arity, change-type, etc.) -/
+  root : Classification
+  /-- The categorizing head that gives it syntactic category -/
+  categorizer : Categorizer
+  deriving BEq, Repr
+
+/-- The syntactic category of a categorized root, derived from its categorizer. -/
+def CategorizedRoot.category (cr : CategorizedRoot) : Cat :=
+  cr.categorizer.toCategory
+
+/-! ### Cross-categorial identity and root complement selection
+
+[harley-2014] §3's evidence that roots select their complements directly:
+*one*-replacement (§3.1 — *this student of chemistry* rejects *that one of
+physics* because the root selects the PP and projects √P, which *one*
+targets), verb-object idioms (§3.2, after [kratzer-1996] — special
+meanings arise for verb-object pairs while the agentive subject composes
+freely), and morphological ergative splits (§3.3). Hiaki suppletion
+conditioned by the object's number is the §2.1 sisterhood evidence. -/
+
+/-- Same root + different categorizer → different syntactic category.
+    This is the formal content of the claim that √HAMMER can surface as
+    either a noun (hammer) or a verb (to hammer) — same root, different
+    category, determined entirely by the categorizer ([harley-2014] §2). -/
+theorem same_root_different_category (i : DistributedMorphology.Root) (r : Classification)
+    (c1 c2 : Categorizer) (h : c1 ≠ c2) :
+    (CategorizedRoot.mk i r c1).category ≠ (CategorizedRoot.mk i r c2).category := by
+  simp only [CategorizedRoot.category, Categorizer.toCategory]
+  cases c1 <;> cases c2 <;> simp_all
+
+/-- Complement valency is a root-level property, unaltered by the
+categorizer ([harley-2014] §3). This covers c-selection, not l-selection,
+which [hewett-2026] shows can vary by verbal template (`Hewett2026`). -/
+theorem complement_selection_at_root_level (i : DistributedMorphology.Root) (r : Classification)
+    (c1 c2 : Categorizer) :
+    (CategorizedRoot.mk i r c1).root.valency = (CategorizedRoot.mk i r c2).root.valency := rfl
+
+/-! ### Layered Derivation (Denominal, Deadjectival, Deverbal) -/
+
+/-- A re-categorization further categorizes an already categorized root,
+as in √SHELF + n (*shelf*) + v (*to shelve*). Idiosyncratic
+interpretation can survive the inner categorizer ([harley-2014] §4). -/
+inductive Recategorization where
+  | denominal    -- n → v (to hammer, to shelve)
+  | deadjectival -- a → v (to flatten, to widen)
+  | deverbal_n   -- v → n (a build, a throw)
+  | deverbal_a   -- v → a (broken, flattened)
+  deriving DecidableEq, Repr
+
+/-- The source categorizer of a re-categorization. -/
+def Recategorization.source : Recategorization → Categorizer
+  | .denominal    => .n
+  | .deadjectival => .a
+  | .deverbal_n   => .v
+  | .deverbal_a   => .v
+
+/-- The target categorizer of a re-categorization. -/
+def Recategorization.target : Recategorization → Categorizer
+  | .denominal    => .v
+  | .deadjectival => .v
+  | .deverbal_n   => .n
+  | .deverbal_a   => .a
+
+/-- Apply a re-categorization to a categorized root. Returns `none` if the
+    root's current categorizer doesn't match the expected source. -/
+def CategorizedRoot.recategorize (cr : CategorizedRoot)
+    (rc : Recategorization) : Option CategorizedRoot :=
+  if cr.categorizer = rc.source then
+    some { index := cr.index, root := cr.root, categorizer := rc.target }
+  else
+    none
+
+/-- Denominal verbs start from n-categorized roots. -/
+theorem denominal_requires_n (cr : CategorizedRoot) (cr' : CategorizedRoot)
+    (h : cr.recategorize .denominal = some cr') :
+    cr.categorizer = .n := by
+  unfold CategorizedRoot.recategorize at h
+  simp only [Recategorization.source] at h
+  split at h <;> simp_all
+
+/-- Re-categorization yields the target categorizer. -/
+theorem recategorization_changes_category (cr : CategorizedRoot)
+    (rc : Recategorization) (cr' : CategorizedRoot)
+    (h : cr.recategorize rc = some cr') :
+    cr'.categorizer = rc.target := by
+  unfold CategorizedRoot.recategorize at h
+  split at h
+  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
+  case isFalse => simp at h
+
+/-- The acategorial index survives (re)categorization: the individuating
+    `DistributedMorphology.Root` atom is invariant under `recategorize`, so *shelf* (n) and
+    *to shelve* (v) share one List-1 root ([harley-2014] §2, §4). This is
+    the work DM's own individuator does that the `root` classification
+    cannot — valency/change-type is shared by unrelated roots, the index is
+    not — so it is the index, not the classification, that the derivational
+    history threads unchanged. -/
+theorem recategorize_preserves_index (cr cr' : CategorizedRoot)
+    (rc : Recategorization) (h : cr.recategorize rc = some cr') :
+    cr'.index = cr.index := by
+  unfold CategorizedRoot.recategorize at h
+  split at h
+  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
+  case isFalse => simp at h
+
+/-- A denominal verb and a directly verbal root yield the same syntactic
+    category (V), but have different internal structure. √HAMMER + v gives
+    V directly; √HAMMER + n + v also gives V but via layered derivation.
+    This structural ambiguity is invisible at the category level
+    ([harley-2014] §2). -/
+theorem denominal_yields_verbal (i : DistributedMorphology.Root) (r : Classification) :
+    ∃ cr, (CategorizedRoot.mk i r .n).recategorize .denominal = some cr ∧
+          cr.category = Cat.V :=
+  ⟨⟨i, r, .v⟩, rfl, rfl⟩
+
+/-- Deadjectival derivation (a → v) connects to [embick-2004]'s result-stative
+    structure ([AspP AspR [vP DP v_become √ROOT]]): in DM terms, a root first
+    categorized by a, then further categorized by v. -/
+theorem deadjectival_source_target :
+    Recategorization.deadjectival.source = .a ∧
+    Recategorization.deadjectival.target = .v := ⟨rfl, rfl⟩
+
+/-! ### VoiceP as phase boundary
+
+[harley-2014] §4: the phase head above the root is Voice, not the
+categorizer. Multiply derived words carry idiosyncratic senses above the
+first categorizer ((36) *editor-ial*, *classifi-eds*, *national-ize*),
+while the external argument that Voice introduces stays compositional. -/
+
+/-- Agentive Voice is a phase head — the boundary above which
+    interpretation must be compositional. [harley-2014] §4: "Voice is the
+    phase head, not v"; the categorizer inventory here accordingly carries
+    no phasal structure at all, so the special-interpretation domain
+    extends past n, v, a and closes only at Voice. -/
+theorem agentive_voice_is_phase : agentive.IsPhasal := by decide
+
+/-- Voice introduces the external argument ([harley-2014] §4, following
+    [kratzer-1996]). The categorizer does NOT introduce arguments —
+    complement selection is a root property ([harley-2014] §3). -/
+theorem voice_introduces_external_arg :
+    agentive.HasD ∧ agentive.AssignsTheta := by
+  refine ⟨?_, ?_⟩ <;> decide
+
+end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
@@ -1,21 +1,18 @@
 import Linglib.Features.Gender.Decomposition
 import Linglib.Features.Gender.Interp
-import Linglib.Morphology.DistributedMorphology.Defs
-import Linglib.Semantics.ArgumentStructure.Root.Classification
-import Linglib.Syntax.Minimalist.Features
-import Linglib.Syntax.Minimalist.Verbal.Voice
+import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 
 /-!
-# Categorizing heads
+# Gender on the nominal categorizer
 
-A categorizing head n, v, or a merges with an acategorial root to give it a
-syntactic category — the categorization assumption. The nominal categorizer
-is also the locus of grammatical gender: an n may carry an interpretable
-(natural) or uninterpretable (arbitrary) gender feature, and
-language-particular Vocabulary Insertion maps the resulting inventory to
-surface genders. Complement selection is a property of the root, and the
-domain of idiosyncratic interpretation is bounded by Voice, not by the
-categorizer.
+The nominal categorizer is the locus of grammatical gender: an n may
+carry an interpretable (natural) or uninterpretable (arbitrary) gender
+feature over a language-particular dimension, and language-particular
+Vocabulary Insertion maps the resulting inventory to surface genders.
+The apparatus is grounded in the general gender machinery of
+`Features/Gender/` — dimensions are poles over `Gender`, DM features are
+the non-hybrid fragment of `Gender.SplitFeature`, and the FEM slice of
+the head inventory is `Gender.KramerN`.
 
 ## Main definitions
 
@@ -27,37 +24,27 @@ categorizer.
   Vocabulary-Insertion maps from features to surface gender
 * `RootLicense`, `CatHead.licensesIntrusion` — root–n licensing and
   gender-conditioned templatic t-intrusion
-* `CategorizedRoot`, `Recategorization` — roots under a categorizer and
-  layered derivation
 
 ## Main statements
 
-* `same_root_different_category`, `recategorize_preserves_index` — one
-  root index across categories, threaded unchanged through derivation
-* `agentive_voice_is_phase` — Voice, not the categorizer, bounds special
-  interpretation
+* `toSplitFeature_not_isHybrid` — the DM calculus generates no hybrid
+  features
+* `surfaceGenderSet1_eq_surface` (and kin) — each insertion map realizes
+  a valued feature at its `GenderVal.surface` pole, differing only in the
+  default for plain n
 
 ## References
 
-* [H. Harley, *On the identity of roots*][harley-2014]
-* [D. Embick and A. Marantz, *Architecture and blocking*][embick-marantz-2008]
 * [R. Kramer, *The morphosyntax of gender*][kramer-2015]
 * [L. J. Adamson, *Gender assignment is local*][adamson-2024]
 * [L. Konnelly and E. Cowper, *Gender diversity and morphosyntax*][konnelly-cowper-2020]
+* [P. W. Smith, *Feature mismatches*][smith-2015]
 -/
 
 namespace DistributedMorphology
 
 open Minimalist Minimalist.Voice
 open Verb Verb.Root
-
-/-! ### Categorizer Type -/
-
-/-- The syntactic category of a categorizer. -/
-def Categorizer.toCategory : Categorizer → Cat
-  | .n => .N
-  | .v => .V
-  | .a => .A
 
 /-! ### Phi-features on categorizing heads
 
@@ -87,6 +74,32 @@ structure GenderVal where
   dim : GenderDimension
   pol : Polarity
   deriving DecidableEq, Repr
+
+/-- The descriptive gender at a dimension's positive pole. -/
+def GenderDimension.positive : GenderDimension → Gender
+  | .fem  => .feminine
+  | .masc => .masculine
+  | .anim => .animate
+
+/-- The descriptive gender at a dimension's negative pole. -/
+def GenderDimension.negative : GenderDimension → Gender
+  | .fem  => .masculine
+  | .masc => .feminine
+  | .anim => .inanimate
+
+/-- The descriptive gender a valued feature denotes — the dimension's pole
+picked by the sign. -/
+def GenderVal.surface (v : GenderVal) : Gender :=
+  match v.pol with
+  | .pos => v.dim.positive
+  | .neg => v.dim.negative
+
+/-- Surface gender underdetermines the feature: Maa's [−FEM] and
+Jarawara's [+MASC] both surface as masculine, and drawing that featural
+distinction is what the dimension inventory is for ([kramer-2015] §6.3
+vs. [adamson-2024] §3.2). -/
+theorem surface_femNeg_eq_mascPos :
+    (GenderVal.mk .fem .neg).surface = (GenderVal.mk .masc .pos).surface := rfl
 
 /-- Whether a gender feature is legible at LF ([kramer-2015] §3.4.2).
 Interpretable gender is natural gender, restricting the denotation and
@@ -506,164 +519,6 @@ theorem anim_not_plain :
     CatHead.n_iAnim ≠ CatHead.n_plain ∧
     CatHead.n_uAnim ≠ CatHead.n_plain := by decide
 
-/-! ### CategorizedRoot -/
-
-/-- A root that has been merged with a categorizing head, yielding a
-    syntactically projectable unit ([harley-2014] §2).
-
-    `index` is DM's List-1 individuator — the acategorial atom `DistributedMorphology.Root`,
-    an arbitrary tag carrying no form or meaning. It is what survives
-    (re)categorization (`recategorize_preserves_index`), so it, not the
-    `root` classification, is what makes √HAMMER *one* root across
-    *hammer*/*to hammer*. `root` is the c-selection content (arity,
-    change-type) the categorizer apparatus reads ([harley-2014] §3); unrelated roots may
-    share it, so it cannot individuate. -/
-structure CategorizedRoot where
-  /-- The acategorial root index — DM's List-1 individuator (`DistributedMorphology.Root`). -/
-  index : DistributedMorphology.Root
-  /-- The acategorial root's c-selection content (arity, change-type, etc.) -/
-  root : Classification
-  /-- The categorizing head that gives it syntactic category -/
-  categorizer : Categorizer
-  deriving BEq, Repr
-
-/-- The syntactic category of a categorized root, derived from its categorizer. -/
-def CategorizedRoot.category (cr : CategorizedRoot) : Cat :=
-  cr.categorizer.toCategory
-
-/-! ### Cross-categorial identity and root complement selection
-
-[harley-2014] §3's evidence that roots select their complements directly:
-*one*-replacement (§3.1 — *this student of chemistry* rejects *that one of
-physics* because the root selects the PP and projects √P, which *one*
-targets), verb-object idioms (§3.2, after [kratzer-1996] — special
-meanings arise for verb-object pairs while the agentive subject composes
-freely), and morphological ergative splits (§3.3). Hiaki suppletion
-conditioned by the object's number is the §2.1 sisterhood evidence. -/
-
-/-- Same root + different categorizer → different syntactic category.
-    This is the formal content of the claim that √HAMMER can surface as
-    either a noun (hammer) or a verb (to hammer) — same root, different
-    category, determined entirely by the categorizer ([harley-2014] §2). -/
-theorem same_root_different_category (i : DistributedMorphology.Root) (r : Classification)
-    (c1 c2 : Categorizer) (h : c1 ≠ c2) :
-    (CategorizedRoot.mk i r c1).category ≠ (CategorizedRoot.mk i r c2).category := by
-  simp only [CategorizedRoot.category, Categorizer.toCategory]
-  cases c1 <;> cases c2 <;> simp_all
-
-/-- Complement valency is a root-level property, unaltered by the
-categorizer ([harley-2014] §3). This covers c-selection, not l-selection,
-which [hewett-2026] shows can vary by verbal template (`Hewett2026`). -/
-theorem complement_selection_at_root_level (i : DistributedMorphology.Root) (r : Classification)
-    (c1 c2 : Categorizer) :
-    (CategorizedRoot.mk i r c1).root.valency = (CategorizedRoot.mk i r c2).root.valency := rfl
-
-/-! ### Layered Derivation (Denominal, Deadjectival, Deverbal) -/
-
-/-- A re-categorization further categorizes an already categorized root,
-as in √SHELF + n (*shelf*) + v (*to shelve*). Idiosyncratic
-interpretation can survive the inner categorizer ([harley-2014] §4). -/
-inductive Recategorization where
-  | denominal    -- n → v (to hammer, to shelve)
-  | deadjectival -- a → v (to flatten, to widen)
-  | deverbal_n   -- v → n (a build, a throw)
-  | deverbal_a   -- v → a (broken, flattened)
-  deriving DecidableEq, Repr
-
-/-- The source categorizer of a re-categorization. -/
-def Recategorization.source : Recategorization → Categorizer
-  | .denominal    => .n
-  | .deadjectival => .a
-  | .deverbal_n   => .v
-  | .deverbal_a   => .v
-
-/-- The target categorizer of a re-categorization. -/
-def Recategorization.target : Recategorization → Categorizer
-  | .denominal    => .v
-  | .deadjectival => .v
-  | .deverbal_n   => .n
-  | .deverbal_a   => .a
-
-/-- Apply a re-categorization to a categorized root. Returns `none` if the
-    root's current categorizer doesn't match the expected source. -/
-def CategorizedRoot.recategorize (cr : CategorizedRoot)
-    (rc : Recategorization) : Option CategorizedRoot :=
-  if cr.categorizer = rc.source then
-    some { index := cr.index, root := cr.root, categorizer := rc.target }
-  else
-    none
-
-/-- Denominal verbs start from n-categorized roots. -/
-theorem denominal_requires_n (cr : CategorizedRoot) (cr' : CategorizedRoot)
-    (h : cr.recategorize .denominal = some cr') :
-    cr.categorizer = .n := by
-  unfold CategorizedRoot.recategorize at h
-  simp only [Recategorization.source] at h
-  split at h <;> simp_all
-
-/-- Re-categorization yields the target categorizer. -/
-theorem recategorization_changes_category (cr : CategorizedRoot)
-    (rc : Recategorization) (cr' : CategorizedRoot)
-    (h : cr.recategorize rc = some cr') :
-    cr'.categorizer = rc.target := by
-  unfold CategorizedRoot.recategorize at h
-  split at h
-  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
-  case isFalse => simp at h
-
-/-- The acategorial index survives (re)categorization: the individuating
-    `DistributedMorphology.Root` atom is invariant under `recategorize`, so *shelf* (n) and
-    *to shelve* (v) share one List-1 root ([harley-2014] §2, §4). This is
-    the work DM's own individuator does that the `root` classification
-    cannot — valency/change-type is shared by unrelated roots, the index is
-    not — so it is the index, not the classification, that the derivational
-    history threads unchanged. -/
-theorem recategorize_preserves_index (cr cr' : CategorizedRoot)
-    (rc : Recategorization) (h : cr.recategorize rc = some cr') :
-    cr'.index = cr.index := by
-  unfold CategorizedRoot.recategorize at h
-  split at h
-  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
-  case isFalse => simp at h
-
-/-- A denominal verb and a directly verbal root yield the same syntactic
-    category (V), but have different internal structure. √HAMMER + v gives
-    V directly; √HAMMER + n + v also gives V but via layered derivation.
-    This structural ambiguity is invisible at the category level
-    ([harley-2014] §2). -/
-theorem denominal_yields_verbal (i : DistributedMorphology.Root) (r : Classification) :
-    ∃ cr, (CategorizedRoot.mk i r .n).recategorize .denominal = some cr ∧
-          cr.category = Cat.V :=
-  ⟨⟨i, r, .v⟩, rfl, rfl⟩
-
-/-- Deadjectival derivation (a → v) connects to [embick-2004]'s result-stative
-    structure ([AspP AspR [vP DP v_become √ROOT]]): in DM terms, a root first
-    categorized by a, then further categorized by v. -/
-theorem deadjectival_source_target :
-    Recategorization.deadjectival.source = .a ∧
-    Recategorization.deadjectival.target = .v := ⟨rfl, rfl⟩
-
-/-! ### VoiceP as phase boundary
-
-[harley-2014] §4: the phase head above the root is Voice, not the
-categorizer. Multiply derived words carry idiosyncratic senses above the
-first categorizer ((36) *editor-ial*, *classifi-eds*, *national-ize*),
-while the external argument that Voice introduces stays compositional. -/
-
-/-- Agentive Voice is a phase head — the boundary above which
-    interpretation must be compositional. [harley-2014] §4: "Voice is the
-    phase head, not v"; the categorizer inventory here accordingly carries
-    no phasal structure at all, so the special-interpretation domain
-    extends past n, v, a and closes only at Voice. -/
-theorem agentive_voice_is_phase : agentive.IsPhasal := by decide
-
-/-- Voice introduces the external argument ([harley-2014] §4, following
-    [kratzer-1996]). The categorizer does NOT introduce arguments —
-    complement selection is a root property ([harley-2014] §3). -/
-theorem voice_introduces_external_arg :
-    agentive.HasD ∧ agentive.AssignsTheta := by
-  refine ⟨?_, ?_⟩ <;> decide
-
 /-! ### Surface Gender Bridge ([kramer-2020]; [kramer-2015] Chs 5-7) -/
 
 /-! The bridge from phi-features on n to descriptive `Gender` is
@@ -731,6 +586,75 @@ theorem animacy_verification :
     CatHead.n_iInanim.surfaceGenderAnimacy = .inanimate ∧
     CatHead.n_uAnim.surfaceGenderAnimacy = .animate ∧
     CatHead.n_plain.surfaceGenderAnimacy = .inanimate := ⟨rfl, rfl, rfl, rfl⟩
+
+/-! Each insertion map realizes a valued feature of its home dimension at
+its `GenderVal.surface` pole — the four patterns differ only in the
+default for plain n. -/
+
+/-- On FEM-dimension bundles, Set 1 is surface realization with a
+masculine default. -/
+theorem surfaceGenderSet1_eq_surface (ch : CatHead)
+    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
+    ch.surfaceGenderSet1 = (ch.phi.gender.map (·.val.surface)).getD .masculine := by
+  cases hg : ch.phi.gender with
+  | none => simp [CatHead.surfaceGenderSet1, hg]
+  | some gf =>
+    obtain ⟨itp, d, pol⟩ := gf
+    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
+      rw [hg]; rfl
+    obtain rfl : d = .fem := h _ hmem
+    cases pol <;>
+      simp [CatHead.surfaceGenderSet1, hg, GenderVal.surface,
+        GenderDimension.positive, GenderDimension.negative]
+
+/-- On FEM-dimension bundles, Set 2 is surface realization with a
+feminine default. -/
+theorem surfaceGenderSet2_eq_surface (ch : CatHead)
+    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
+    ch.surfaceGenderSet2 = (ch.phi.gender.map (·.val.surface)).getD .feminine := by
+  cases hg : ch.phi.gender with
+  | none => simp [CatHead.surfaceGenderSet2, hg]
+  | some gf =>
+    obtain ⟨itp, d, pol⟩ := gf
+    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
+      rw [hg]; rfl
+    obtain rfl : d = .fem := h _ hmem
+    cases pol <;>
+      simp [CatHead.surfaceGenderSet2, hg, GenderVal.surface,
+        GenderDimension.positive, GenderDimension.negative]
+
+/-- On FEM-dimension bundles, the three-gender pattern is surface
+realization with a neuter default. -/
+theorem surfaceGenderThree_eq_surface (ch : CatHead)
+    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
+    ch.surfaceGenderThree = (ch.phi.gender.map (·.val.surface)).getD .neuter := by
+  cases hg : ch.phi.gender with
+  | none => simp [CatHead.surfaceGenderThree, hg]
+  | some gf =>
+    obtain ⟨itp, d, pol⟩ := gf
+    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
+      rw [hg]; rfl
+    obtain rfl : d = .fem := h _ hmem
+    cases pol <;>
+      simp [CatHead.surfaceGenderThree, hg, GenderVal.surface,
+        GenderDimension.positive, GenderDimension.negative]
+
+/-- On ANIM-dimension bundles, the animacy pattern is surface realization
+with an inanimate default. -/
+theorem surfaceGenderAnimacy_eq_surface (ch : CatHead)
+    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .anim) :
+    ch.surfaceGenderAnimacy =
+      (ch.phi.gender.map (·.val.surface)).getD .inanimate := by
+  cases hg : ch.phi.gender with
+  | none => simp [CatHead.surfaceGenderAnimacy, hg]
+  | some gf =>
+    obtain ⟨itp, d, pol⟩ := gf
+    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
+      rw [hg]; rfl
+    obtain rfl : d = .anim := h _ hmem
+    cases pol <;>
+      simp [CatHead.surfaceGenderAnimacy, hg, GenderVal.surface,
+        GenderDimension.positive, GenderDimension.negative]
 
 /-- Set 1 surface gender sees only what `Gender.KramerN.exponence` sees —
 interpretability is invisible at PF. -/

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Semantics.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Semantics.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Semantics.Possessive.Relational
 import Linglib.Semantics.Possessive.Basic
 

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -1,36 +1,22 @@
-import Mathlib.Tactic.TypeStar
+import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 
 /-!
-# Roots, categorizers, vocabulary items, and allosemes
+# Vocabulary items and allosemes
 
-The objects of Distributed Morphology ([halle-marantz-1993]): acategorial
-roots individuated by arbitrary indices, the categorizing heads n/v/a, and
-the rule types of the two interpretive lists — `VI.VocabItem` (List 2, form)
-and `Allosemy.AllosemicEntry` (List 3, meaning), the latter conditioned by
-`Allosemy.SyntacticContext`. The shared selection-engine instances live in
-`DistributedMorphology/Basic.lean`.
+The rule types of Distributed Morphology's two interpretive lists:
+`VI.VocabItem` pairs a phonological exponent with the context that
+licenses it (List 2), and `Allosemy.AllosemicEntry` pairs a meaning with
+the conditioning `Allosemy.SyntacticContext` (List 3). The shared
+selection-engine instances live in `DistributedMorphology/Basic.lean`.
+
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
+* [J. Benz, *Structure and interpretation across categories*][benz-2025]
 -/
 
 namespace DistributedMorphology
-
-/-- A Root terminal node, individuated by an arbitrary index alone — with
-deliberately no form or meaning fields, following [harley-2014]'s answer to
-what roots are. It receives its form at Vocabulary Insertion. A different
-object from the comparative-concept root of `Morphology/Root/Basic.lean`,
-which is a contentful morph. -/
-structure Root where
-  /-- The individuating index. -/
-  index : Nat
-  deriving DecidableEq, Repr
-
-/-- A categorizing head that merges with an acategorial root to project
-    syntactic structure. The three options correspond to the functional
-    heads n, v, a in Distributed Morphology ([marantz-1997], [harley-2014] §2). -/
-inductive Categorizer where
-  | n  -- nominal categorizer
-  | v  -- verbal categorizer
-  | a  -- adjectival categorizer
-  deriving DecidableEq, Repr
 
 namespace VI
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -1,6 +1,6 @@
 import Linglib.Morphology.DistributedMorphology.NominalStructure
-import Linglib.Morphology.DistributedMorphology.Categorizer
-import Linglib.Morphology.DistributedMorphology.CategorizerSemantics
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
+import Linglib.Morphology.DistributedMorphology.Categorizer.Semantics
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
 import Linglib.Fragments.Teop.Nouns
 import Linglib.Fragments.Jarawara.PossessedNouns

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Syntax.Minimalist.Features
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
 import Linglib.Features.Gender.Basic
 

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -1,6 +1,6 @@
 import Linglib.Fragments.Mwaghavul.Basic
 import Linglib.Pragmatics.Expressives.Basic
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.Word.Tree
 import Linglib.Studies.Rolle2018
 import Linglib.Phonology.Autosegmental.Floating

--- a/Linglib/Studies/Carstens2026.lean
+++ b/Linglib/Studies/Carstens2026.lean
@@ -2,7 +2,7 @@ import Linglib.Fragments.Bantu.Params
 import Linglib.Fragments.Xhosa.Basic
 import Linglib.Fragments.Shona.Basic
 import Linglib.Fragments.Swahili.Basic
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Studies.Kramer2020
 import Linglib.Features.Number.Resolve
 import Linglib.Features.Person.Resolve

--- a/Linglib/Studies/Clark1983.lean
+++ b/Linglib/Studies/Clark1983.lean
@@ -1,6 +1,6 @@
 import Linglib.Discourse.CommonGround
 import Linglib.Discourse.SpeechAct
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 import Linglib.Semantics.ArgumentStructure.Linking
 import Linglib.Pragmatics.RSA.LexicalUncertainty
 import Mathlib.Data.Fintype.BigOperators

--- a/Linglib/Studies/Coon2019.lean
+++ b/Linglib/Studies/Coon2019.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.ArgumentStructure.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.Paradigm.Morphome
 import Linglib.Fragments.Mayan.Chuj.RootClasses
 import Linglib.Fragments.Mayan.Chuj.VoiceSystem

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -1,7 +1,7 @@
 import Linglib.Morphology.Morphotactics.CVTemplate
 import Linglib.Phonology.Constraints.Basic
 import Linglib.Phonology.OptimalityTheory.Tableau
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Fragments.Hebrew.ConsonantalRoots
 import Linglib.Fragments.Amharic.ConsonantalRoots
 

--- a/Linglib/Studies/HalpertHammerly2026.lean
+++ b/Linglib/Studies/HalpertHammerly2026.lean
@@ -2,7 +2,7 @@ import Linglib.Fragments.Bantu.Params
 import Linglib.Fragments.Xhosa.Basic
 import Linglib.Fragments.Swahili.Basic
 import Linglib.Features.Person.Decomposition
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 
 /-!
 # Halpert & Hammerly 2026: Reconciling Animacy and Noun Class in Bantu

--- a/Linglib/Studies/HaninkKoontzGarboden2025.lean
+++ b/Linglib/Studies/HaninkKoontzGarboden2025.lean
@@ -1,6 +1,6 @@
 import Linglib.Semantics.ArgumentStructure.Root.Classification
 import Linglib.Studies.KoontzGarboden2009
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Semantics.Possessive.Relational
 
 /-!

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 import Linglib.Syntax.Minimalist.Verbal.Applicative
 import Linglib.Syntax.Minimalist.Agree.Checking
 import Linglib.Syntax.Minimalist.Verbal.Voice

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Fragments.English.Pronouns

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Gender.Basic
 import Linglib.Studies.Corbett1991
-import Linglib.Morphology.DistributedMorphology.Categorizer
+import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Fragments.Spanish.Gender
 import Linglib.Fragments.Slavic.Russian.Gender
 import Linglib.Fragments.Hausa.Gender


### PR DESCRIPTION
Splits the categorizer material into `Categorizer/{Basic,Gender,Semantics}.lean` and grounds the gender dimensions in `Features.Gender`.

- `Root` and `Categorizer` move from `Defs.lean` into `Categorizer/Basic.lean` with the Harley categorization API; `Defs.lean` shrinks to the two lists' rule types.
- `GenderDimension.positive/negative` and `GenderVal.surface` land in `Features.Gender` vocabulary; the four `surfaceGender*` VI maps factor through `surface` + a language default (`surfaceGenderSet1_eq_surface` etc.), with `surface_femNeg_eq_mascPos` recording why the feature can't just be a `Gender`.