### PR TITLE
feat(Studies/SenturiaMarcolli2025): morphological magma, fusion, fission

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2090,6 +2090,7 @@ import Linglib.Studies.DAmbrosioHedden2024
 import Linglib.Studies.DaleReiter1995
 import Linglib.Studies.DalrympleHaug2024
 import Linglib.Studies.DalrympleKaplan2000
+import Linglib.Studies.SenturiaMarcolli2025
 import Linglib.Studies.DarwichePearl1997
 import Linglib.Studies.DavidsonGagne2022
 import Linglib.Studies.Dayal2016

--- a/Linglib/Studies/SenturiaMarcolli2025.lean
+++ b/Linglib/Studies/SenturiaMarcolli2025.lean
@@ -1,0 +1,315 @@
+import Linglib.Core.Data.RoseTree.Leaves
+import Linglib.Core.Data.RoseTree.FilterMap
+import Linglib.Core.Data.RoseTree.DecEq
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Lattice.Basic
+
+/-!
+# The algebraic structure of morphosyntax
+
+[senturia-marcolli-2025] models Distributed Morphology inside the Merge
+algebra of [marcolli-chomsky-berwick-2025]: morphological objects are
+built by the same free non-associative commutative magma as syntactic
+objects, differing only in labeling — an internal vertex carries the
+union of its children's feature bundles, so a bundle is derived from the
+tree rather than stipulated. On this carrier fusion is the magma
+operation itself, fission restricts the tree along a partition of its
+bundle, and impoverishment is a fission component: the paper reduces the
+four DM operations to fusion and fission.
+
+## Main definitions
+
+* `bundle` — the feature bundle of a morphological object, the set of
+  features at its leaves
+* `fuse`, `restrict` — fusion as magma grafting, and the vertex-wise
+  restriction producing the two fission outputs
+
+## Main statements
+
+* `bundle_fuse` — the fused bundle is the union of the input bundles,
+  an instance of the labeling law: fusion needs nothing beyond the magma
+* `bundle_restrict` — a fission output's bundle is the input bundle
+  restricted to the kept features
+* `restrict_copies_shared` — features shared out to both sides of the
+  partition survive in both outputs
+* `bundle_fuse_restrict` — fission followed by fusion restores the
+  bundle, and `fuse_restrict_ne` — but not the tree
+
+## TODO
+
+Second slice: the operadic interface (the paper's colored correspondence
+between syntactic and morphosyntactic objects), the workspace Hopf
+algebra with obliteration via the coproduct, and the Distributed
+Morphology semigroup acting on assembly operations.
+
+## References
+
+* [I. Senturia and M. Marcolli, *The algebraic structure of
+  morphosyntax*][senturia-marcolli-2025]
+* [M. Marcolli, N. Chomsky and R. C. Berwick, *Mathematical structure of
+  syntactic Merge*][marcolli-chomsky-berwick-2025]
+-/
+
+namespace SenturiaMarcolli2025
+
+open RoseTree
+
+variable {F : Type*} [DecidableEq F]
+
+/-! ### Morphological objects and the derived bundle labeling
+
+A morphological object is a nonplanar tree with single features at the
+leaves and bare structural vertices elsewhere — the alphabet `F ⊕ Unit`,
+exactly the carrier shape of syntactic objects with features in place of
+the lexical items. Definition 2.1 of [senturia-marcolli-2025] labels
+each internal vertex with the union of its children's bundles, so every
+vertex label is determined by the leaves below it; `bundle` is the
+root's. -/
+
+/-- Features occur only at leaves: internal vertices are structural.
+Restriction can leave childless or non-branching structural vertices, so
+arity is not constrained (the extended morphological objects of
+[senturia-marcolli-2025] Definition 2.8). -/
+inductive IsMorphological : RoseTree (F ⊕ Unit) → Prop
+  | leaf (x : F ⊕ Unit) : IsMorphological (.node x [])
+  | node {cs : List (RoseTree (F ⊕ Unit))} (hne : cs ≠ [])
+      (h : ∀ c ∈ cs, IsMorphological c) : IsMorphological (.node (.inr ()) cs)
+
+/-- The multiset of leaf features of a planar tree. -/
+def leafFeatures (t : RoseTree (F ⊕ Unit)) : Multiset F :=
+  t.leaves.filterMap Sum.getLeft?
+
+/-- The feature bundle of a morphological object: the set of features at
+its leaves, the root label of [senturia-marcolli-2025] Definition 2.1. -/
+def bundle (S : Nonplanar (F ⊕ Unit)) : Finset F :=
+  (S.leaves.filterMap Sum.getLeft?).toFinset
+
+@[simp] theorem bundle_mk (t : RoseTree (F ⊕ Unit)) :
+    bundle (Nonplanar.mk t) = (leafFeatures t).toFinset := rfl
+
+@[simp] theorem bundle_leaf (f : F) :
+    bundle (Nonplanar.leaf (.inl f)) = {f} := by
+  rw [show bundle (Nonplanar.leaf (.inl f)) = ({f} : Multiset F).toFinset from rfl]
+  exact Multiset.toFinset_singleton f
+
+@[simp] theorem bundle_leaf_inr :
+    bundle (Nonplanar.leaf (.inr () : F ⊕ Unit)) = ∅ := rfl
+
+/-- A structural vertex contributes nothing to the bundle: the leaf
+features of a structural node are the concatenation of its children's,
+whether or not children remain. -/
+private theorem filterMap_list_sum {α β : Type*} (g : α → Option β)
+    (l : List (Multiset α)) :
+    Multiset.filterMap g l.sum = (l.map (Multiset.filterMap g)).sum := by
+  induction l with
+  | nil => rfl
+  | cons m l ih => simp [Multiset.filterMap_add, ih]
+
+omit [DecidableEq F] in
+theorem leafFeatures_node_inr (cs : List (RoseTree (F ⊕ Unit))) :
+    leafFeatures (.node (.inr ()) cs) = (cs.map leafFeatures).sum := by
+  cases cs with
+  | nil => rfl
+  | cons c cs =>
+    rw [leafFeatures, leaves_node_cons, filterMap_list_sum, List.map_map]
+    rfl
+
+/-! ### Fusion
+
+Fusion merges the bundles at two adjacent leaves of the syntactic tree
+into one ([senturia-marcolli-2025] §5.1, Swahili negation *si-* fusing
+NEG with first-singular agreement). On morphological objects it is the
+magma operation itself — grafting under a fresh structural root — which
+is why fusion is the one DM operation available inside syntax. -/
+
+/-- Fusion of two morphological objects: the magma product, grafting
+both under a structural root ([senturia-marcolli-2025] Definition 5.2). -/
+noncomputable def fuse (S₁ S₂ : Nonplanar (F ⊕ Unit)) : Nonplanar (F ⊕ Unit) :=
+  Nonplanar.node (.inr ()) {S₁, S₂}
+
+/-- The fused bundle is the union of the input bundles — the labeling
+law itself, so fusion needs nothing beyond the magma. -/
+theorem bundle_fuse (S₁ S₂ : Nonplanar (F ⊕ Unit)) :
+    bundle (fuse S₁ S₂) = bundle S₁ ∪ bundle S₂ := by
+  refine Quotient.inductionOn₂ S₁ S₂ fun p q => ?_
+  show bundle (Nonplanar.node (.inr ()) {Nonplanar.mk p, Nonplanar.mk q}) = _
+  rw [Nonplanar.node_pair_mk]
+  simp only [bundle_mk, leafFeatures_node_inr, List.map_cons, List.map_nil,
+    List.sum_cons, List.sum_nil, add_zero, Multiset.toFinset_add]
+  rfl
+
+/-! ### Fission
+
+Fission splits one bundle into two along a partition `B ∖ A = B₁ ⊔ B₂`,
+with the residue `A` copied into both outputs ([senturia-marcolli-2025]
+§5.2; Ṣanʕānī Arabic discontinuous agreement, where person and number of
+a single head surface as prefix and suffix). Each output is the input
+tree restricted vertex-wise to the kept features: leaves outside the
+kept set are deleted, structural vertices stay, and vanished subtrees
+may leave non-branching structural vertices behind — the extended
+morphological objects. -/
+
+/-- Keep a leaf feature iff it lies in `C`; structural vertices always
+survive. -/
+def keep (C : Finset F) : F ⊕ Unit → Option (F ⊕ Unit)
+  | .inl f => if f ∈ C then some (.inl f) else none
+  | .inr _ => some (.inr ())
+
+/-- Restriction of a morphological object to the features in `C`: the
+construction of a single fission output ([senturia-marcolli-2025]
+Definition 5.6, with `C = Bᵢ ∪ A`). `none` only for a single leaf
+outside `C`. -/
+def restrict (C : Finset F) (S : Nonplanar (F ⊕ Unit)) :
+    Option (Nonplanar (F ⊕ Unit)) :=
+  S.filterMap (keep C)
+
+private theorem sum_leafFeatures_filterMap (C : Finset F)
+    (cs : List (RoseTree (F ⊕ Unit)))
+    (ih : ∀ c ∈ cs, ((c.filterMap (keep C)).elim 0 leafFeatures)
+      = (leafFeatures c).filter (· ∈ C)) :
+    ((cs.filterMap (RoseTree.filterMap (keep C))).map leafFeatures).sum
+      = ((cs.map leafFeatures).sum).filter (· ∈ C) := by
+  induction cs with
+  | nil => simp
+  | cons c cs ihcs =>
+    have hc := ih c (List.mem_cons_self ..)
+    have hrest := ihcs fun d hd => ih d (List.mem_cons_of_mem _ hd)
+    cases hcc : RoseTree.filterMap (keep C) c with
+    | none =>
+      rw [hcc, Option.elim_none] at hc
+      rw [List.filterMap_cons_none hcc]
+      simp only [List.map_cons, List.sum_cons, Multiset.filter_add, ← hc,
+        hrest, zero_add]
+    | some c' =>
+      rw [hcc, Option.elim_some] at hc
+      rw [List.filterMap_cons_some hcc]
+      simp only [List.map_cons, List.sum_cons, Multiset.filter_add, ← hc, hrest]
+
+private theorem leafFeatures_filterMap_keep (C : Finset F)
+    {t : RoseTree (F ⊕ Unit)} (ht : IsMorphological t) :
+    ((t.filterMap (keep C)).elim 0 leafFeatures)
+      = (leafFeatures t).filter (· ∈ C) := by
+  induction ht with
+  | leaf x =>
+    cases x with
+    | inl f =>
+      have e : Multiset.filterMap Sum.getLeft? ({Sum.inl f} : Multiset (F ⊕ Unit))
+          = ({f} : Multiset F) := rfl
+      by_cases hf : f ∈ C <;>
+        simp [keep, hf, leafFeatures, e, Multiset.filter_singleton]
+    | inr u =>
+      have e : Multiset.filterMap Sum.getLeft? ({Sum.inr u} : Multiset (F ⊕ Unit))
+          = (0 : Multiset F) := rfl
+      simp [keep, leafFeatures, e]
+  | @node cs hne h ih =>
+    have hstep : RoseTree.filterMap (keep C) (.node (.inr ()) cs)
+        = some (.node (.inr ()) (RoseTree.filterMapList (keep C) cs)) := rfl
+    rw [hstep, Option.elim_some, leafFeatures_node_inr, leafFeatures_node_inr,
+      RoseTree.filterMapList_eq_filterMap]
+    exact sum_leafFeatures_filterMap C cs ih
+
+/-- The bundle of a fission output is the input bundle restricted to the
+kept features: the vertex law `B_w ∩ (Bᵢ ∪ A)` of
+[senturia-marcolli-2025] Definition 5.6, at the root. -/
+theorem bundle_restrict {C : Finset F} {t : RoseTree (F ⊕ Unit)}
+    (ht : IsMorphological t) {S' : Nonplanar (F ⊕ Unit)}
+    (h : restrict C (Nonplanar.mk t) = some S') :
+    bundle S' = bundle (Nonplanar.mk t) ∩ C := by
+  rw [restrict, Nonplanar.filterMap_mk] at h
+  cases hc : t.filterMap (keep C) with
+  | none => rw [hc, Option.map_none] at h; exact absurd h (by simp)
+  | some t' =>
+    rw [hc, Option.map_some, Option.some.injEq] at h
+    subst h
+    have key := leafFeatures_filterMap_keep C ht
+    rw [hc, Option.elim_some] at key
+    rw [bundle_mk, bundle_mk, key, Multiset.toFinset_filter,
+      Finset.filter_mem_eq_inter]
+
+/-- Features copied into both sides of the fission partition survive in
+both outputs: the residue of a discontinuously realized bundle is
+pronounced on both exponents. -/
+theorem restrict_copies_shared {A C₁ C₂ : Finset F}
+    (h₁ : A ⊆ C₁) (h₂ : A ⊆ C₂) {t : RoseTree (F ⊕ Unit)}
+    (ht : IsMorphological t) {S₁' S₂' : Nonplanar (F ⊕ Unit)}
+    (e₁ : restrict C₁ (Nonplanar.mk t) = some S₁')
+    (e₂ : restrict C₂ (Nonplanar.mk t) = some S₂') :
+    A ∩ bundle (Nonplanar.mk t) ⊆ bundle S₁' ∩ bundle S₂' := by
+  rw [bundle_restrict ht e₁, bundle_restrict ht e₂]
+  intro f hf
+  simp only [Finset.mem_inter] at hf ⊢
+  exact ⟨⟨hf.2, h₁ hf.1⟩, hf.2, h₂ hf.1⟩
+
+/-! ### Impoverishment as fission plus fusion
+
+[senturia-marcolli-2025] Propositions 5.20–5.21: impoverishment and
+obliteration are not independent operations. Discarding a subbundle is
+keeping one fission output (`bundle_restrict` with the kept part as
+`C`); the trace-maintaining variant fissions and refuses at the same
+vertex, restoring the bundle without restoring the tree. Obliteration
+replaces a whole morphological object by the unit of the workspace
+algebra, which lives in the second slice. -/
+
+/-- Fission followed by fusion restores the bundle: the trace-maintaining
+impoverishment composite leaves the feature content intact. -/
+theorem bundle_fuse_restrict {C₁ C₂ : Finset F} {t : RoseTree (F ⊕ Unit)}
+    (ht : IsMorphological t) (hcover : bundle (Nonplanar.mk t) ⊆ C₁ ∪ C₂)
+    {S₁' S₂' : Nonplanar (F ⊕ Unit)}
+    (e₁ : restrict C₁ (Nonplanar.mk t) = some S₁')
+    (e₂ : restrict C₂ (Nonplanar.mk t) = some S₂') :
+    bundle (fuse S₁' S₂') = bundle (Nonplanar.mk t) := by
+  rw [bundle_fuse, bundle_restrict ht e₁, bundle_restrict ht e₂,
+    ← Finset.inter_union_distrib_left, Finset.inter_eq_left.mpr hcover]
+
+/-! ### The tree is not restored
+
+Fission at a partition whose residue is copied into both outputs, then
+fusion, restores the bundle but not the tree: the copied feature now
+occupies a leaf on each side, so the composite has strictly more leaves.
+The witness is [senturia-marcolli-2025] Example 5.7: `[φ, α, β, γ]` with
+kept sets `[φ, γ]` and `[φ, α, β]`. -/
+
+private inductive Feat where
+  | phi | alpha | beta | gamma
+  deriving DecidableEq, Repr
+
+private def exTree : RoseTree (Feat ⊕ Unit) :=
+  .node (.inr ()) [.node (.inr ()) [.node (.inl .phi) [], .node (.inl .alpha) []],
+    .node (.inr ()) [.node (.inl .beta) [], .node (.inl .gamma) []]]
+
+/-- Restriction to `{φ, γ}` and `{φ, α, β}` followed by fusion yields a
+five-leaf object: `φ` is realized on both sides, so the composite is not
+the original four-leaf tree even though its bundle is
+(`bundle_fuse_restrict`). -/
+theorem fuse_restrict_ne (S₁' S₂' : Nonplanar (Feat ⊕ Unit))
+    (e₁ : restrict {.phi, .gamma} (Nonplanar.mk exTree) = some S₁')
+    (e₂ : restrict {.phi, .alpha, .beta} (Nonplanar.mk exTree) = some S₂') :
+    fuse S₁' S₂' ≠ Nonplanar.mk exTree := by
+  have c₁ : exTree.filterMap (keep {.phi, .gamma})
+      = some (.node (.inr ()) [.node (.inr ()) [.node (.inl .phi) []],
+          .node (.inr ()) [.node (.inl .gamma) []]]) := by decide
+  have c₂ : exTree.filterMap (keep {.phi, .alpha, .beta})
+      = some (.node (.inr ()) [.node (.inr ()) [.node (.inl .phi) [],
+          .node (.inl .alpha) []], .node (.inr ()) [.node (.inl .beta) []]]) := by
+    decide
+  rw [restrict, Nonplanar.filterMap_mk, c₁, Option.map_some,
+    Option.some.injEq] at e₁
+  rw [restrict, Nonplanar.filterMap_mk, c₂, Option.map_some,
+    Option.some.injEq] at e₂
+  subst e₁ e₂
+  rw [fuse, Nonplanar.node_pair_mk]
+  intro hcontra
+  have := congrArg Nonplanar.numLeaves hcontra
+  rw [Nonplanar.numLeaves_mk, Nonplanar.numLeaves_mk] at this
+  exact absurd this (by decide)
+
+/-! ### The economy of bivalent features
+
+[senturia-marcolli-2025] Remark 2.3: with `n` feature categories and
+three valuations (+, −, unvalued), the bivalent inventory has `n + 3`
+generating objects against the `3 n` features a privative encoding
+needs, strictly fewer for more than one category. -/
+
+theorem bivalent_economy {n : ℕ} (h : 1 < n) : n + 3 < 3 * n := by omega
+
+end SenturiaMarcolli2025

--- a/references.bib
+++ b/references.bib
@@ -17522,6 +17522,18 @@
   role      = {formalized},
   sources   = {Core/Algebra/RootedTree/Bud.lean}
 }
+@article{senturia-marcolli-2025,
+  author    = {Senturia, Isabella and Marcolli, Matilde},
+  year      = {2025},
+  title     = {The Algebraic Structure of Morphosyntax},
+  eprint    = {2507.00244},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CL},
+  url       = {https://arxiv.org/abs/2507.00244},
+  subfield  = {morphology},
+  role      = {formalized},
+  sources   = {Studies/SenturiaMarcolli2025.lean}
+}
 @article{marcolli-larson-2025,
   author    = {Marcolli, Matilde and Larson, Richard K.},
   year      = {2025},


### PR DESCRIPTION
First slice of Senturia & Marcolli 2025 (arXiv 2507.00244): Distributed Morphology inside the Merge algebra, on the existing `Nonplanar` carrier at a feature alphabet.

- `bundle` as the derived union labeling; `bundle_fuse` (fusion is magma-only), `bundle_restrict` (the fission vertex law), `restrict_copies_shared` (partition residue pronounced on both exponents), `bundle_fuse_restrict` + `fuse_restrict_ne` (fission∘fusion restores the bundle, not the tree — the paper's Example 5.7 witness).
- TODO'd second slice: operadic correspondence, workspace Hopf algebra with obliteration via the coproduct, the DM semigroup.