### PR TITLE
refactor(Morphology/DistributedMorphology): categorization as trees

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
@@ -1,35 +1,43 @@
+import Linglib.Core.Data.RoseTree.Leaves
 import Linglib.Morphology.DistributedMorphology.Root
-import Linglib.Semantics.ArgumentStructure.Root.Classification
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
 /-!
 # Categorization
 
-The categorizing heads n, v, a of Distributed Morphology merge with an
-acategorial root to give it a syntactic category — the categorization
-assumption. The same root index survives categorization and
-re-categorization, which is what makes √HAMMER one root across *hammer*
-and *to hammer*. Complement selection is a property of the root, and the
-domain of idiosyncratic interpretation is bounded by Voice, not by the
-categorizer.
+Word formation is syntactic: a categorizing head n, v, or a merges with
+an acategorial root — the categorization assumption — and layered
+derivation is more of the same merger, [v [n √SHELF]] for *to shelve*
+beside [n √SHELF] for *shelf*. Word-internal structure is a nonplanar
+tree over root and head leaves, the same carrier shape as syntactic and
+morphological objects elsewhere in the library, so the root's survival
+across (re)categorization and the structural difference between direct
+and layered derivation are facts about leaves rather than stipulations.
 
 ## Main definitions
 
 * `Categorizer` — the closed inventory n, v, a
-* `Categorizer.toCategory` — the syntactic category of n, v, a
-* `CategorizedRoot`, `Recategorization` — roots under a categorizer and
-  layered derivation
+* `WordStructure` — word-internal structure over a head alphabet:
+  `Categorizer` for the bare theory, `CatHead`
+  (`Categorizer/Gender.lean`) when heads carry φ-content
+* `categorize`, `roots`, `heads`, `Headed` — head merger, the two leaf
+  projections, and outermost headedness
 
 ## Main statements
 
-* `same_root_different_category`, `recategorize_preserves_root` — one
-  root index across categories, threaded unchanged through derivation
+* `roots_categorize` — categorization does not touch root leaves: one
+  root index across categories and layers
+* `categorize_ne_of_ne`, `categorize_categorize_ne` — distinct heads
+  build distinct structures, and layered derivation differs from direct
+  derivation even when the outermost head agrees
 * `agentive_voice_is_phase` — Voice, not the categorizer, bounds special
   interpretation
 
 ## References
 
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
 * [A. Marantz, *No escape from syntax*][marantz-1997]
 * [H. Harley, *On the identity of roots*][harley-2014]
 * [D. Embick and A. Marantz, *Architecture and blocking*][embick-marantz-2008]
@@ -37,8 +45,7 @@ categorizer.
 
 namespace DistributedMorphology
 
-open Minimalist Minimalist.Voice
-open Verb Verb.Root
+open Minimalist Minimalist.Voice RoseTree
 
 /-! ### The categorizer inventory -/
 
@@ -61,134 +68,113 @@ def Categorizer.toCategory : Categorizer → Cat
   | .v => .V
   | .a => .A
 
-/-! ### CategorizedRoot -/
+/-! ### Word-internal structure
 
-/-- A root merged with a categorizing head, yielding a syntactically
-    projectable unit ([harley-2014] §2). The `root` atom is what survives
-    (re)categorization (`recategorize_preserves_root`) and so what makes
-    √HAMMER one root across *hammer* and *to hammer*; the `classification`
-    is c-selection content ([harley-2014] §3) that unrelated roots may
-    share, so it cannot individuate. -/
-structure CategorizedRoot where
-  /-- The acategorial root. -/
-  root : DistributedMorphology.Root
-  /-- The root's c-selection content (arity, change-type). -/
-  classification : Classification
-  /-- The categorizing head that gives it syntactic category. -/
-  categorizer : Categorizer
-  deriving DecidableEq, Repr
+Distributed Morphology builds words with the same binary structure
+building as sentences ([halle-marantz-1993]): a categorized root is the
+configuration [x √], not a kind of object, and re-categorization is
+merger of a further head. The carrier is a nonplanar tree whose leaves
+are acategorial roots or categorizing heads and whose internal vertices
+are bare. -/
 
-/-- The syntactic category of a categorized root, derived from its categorizer. -/
-def CategorizedRoot.category (cr : CategorizedRoot) : Cat :=
-  cr.categorizer.toCategory
+/-- Word-internal syntactic structure over head labels `H`: a nonplanar
+tree whose leaves are acategorial roots or heads and whose internal
+vertices are bare. -/
+abbrev WordStructure (H : Type*) :=
+  Nonplanar ((Root ⊕ H) ⊕ Unit)
 
-/-! ### Cross-categorial identity and root complement selection
+variable {H : Type*}
 
-[harley-2014] §3's evidence that roots select their complements directly:
-*one*-replacement (§3.1 — *this student of chemistry* rejects *that one of
-physics* because the root selects the PP and projects √P, which *one*
-targets), verb-object idioms (§3.2, after [kratzer-1996] — special
-meanings arise for verb-object pairs while the agentive subject composes
-freely), and morphological ergative splits (§3.3). Hiaki suppletion
-conditioned by the object's number is the §2.1 sisterhood evidence. -/
+/-- The structure consisting of a bare root. -/
+def ofRoot (r : Root) : WordStructure H :=
+  Nonplanar.leaf (.inl (.inl r))
 
-/-- Same root + different categorizer → different syntactic category.
-    This is the formal content of the claim that √HAMMER can surface as
-    either a noun (hammer) or a verb (to hammer) — same root, different
-    category, determined entirely by the categorizer ([harley-2014] §2). -/
-theorem same_root_different_category (i : DistributedMorphology.Root) (r : Classification)
-    (c1 c2 : Categorizer) (h : c1 ≠ c2) :
-    (CategorizedRoot.mk i r c1).category ≠ (CategorizedRoot.mk i r c2).category := by
-  simp only [CategorizedRoot.category, Categorizer.toCategory]
-  cases c1 <;> cases c2 <;> simp_all
+/-- The structure consisting of a bare head. -/
+def ofHead (h : H) : WordStructure H := Nonplanar.leaf (.inl (.inr h))
 
-/-- Complement valency is a root-level property, unaltered by the
-categorizer ([harley-2014] §3). This covers c-selection, not l-selection,
-which [hewett-2026] shows can vary by verbal template (`Hewett2026`). -/
-theorem complement_selection_at_root_level (i : DistributedMorphology.Root) (r : Classification)
-    (c1 c2 : Categorizer) :
-    (CategorizedRoot.mk i r c1).classification.valency
-      = (CategorizedRoot.mk i r c2).classification.valency := rfl
+/-- Merge a categorizing head with a structure: the configuration [h T].
+Categorization is `categorize h (ofRoot r)`; re-categorization is
+another `categorize` on top — *to shelve* is
+`categorize .v (categorize .n (ofRoot shelf))` — and every further
+derivation (*happi-ness* a → n, *boy-ish* n → a) is simply another
+instance, with no inventory of re-categorization types to extend. -/
+noncomputable def categorize (h : H) (T : WordStructure H) : WordStructure H :=
+  Nonplanar.node (.inr ()) (ofHead h ::ₘ {T})
 
-/-! ### Layered Derivation (Denominal, Deadjectival, Deverbal) -/
+/-- The root leaves: the List-1 content of a word structure. -/
+def roots (T : WordStructure H) : Multiset Root :=
+  T.leaves.filterMap fun x => x.getLeft?.bind Sum.getLeft?
 
-/-- A re-categorization further categorizes an already categorized root,
-as in √SHELF + n (*shelf*) + v (*to shelve*). Idiosyncratic
-interpretation can survive the inner categorizer ([harley-2014] §4). -/
-inductive Recategorization where
-  | denominal    -- n → v (to hammer, to shelve)
-  | deadjectival -- a → v (to flatten, to widen)
-  | deverbal_n   -- v → n (a build, a throw)
-  | deverbal_a   -- v → a (broken, flattened)
-  deriving DecidableEq, Repr
+/-- The head leaves: the functional content of a word structure. -/
+def heads (T : WordStructure H) : Multiset H :=
+  T.leaves.filterMap fun x => x.getLeft?.bind Sum.getRight?
 
-/-- The source categorizer of a re-categorization. -/
-def Recategorization.source : Recategorization → Categorizer
-  | .denominal    => .n
-  | .deadjectival => .a
-  | .deverbal_n   => .v
-  | .deverbal_a   => .v
+@[simp] theorem roots_ofRoot (r : Root) :
+    roots (ofRoot r : WordStructure H) = {r} := rfl
 
-/-- The target categorizer of a re-categorization. -/
-def Recategorization.target : Recategorization → Categorizer
-  | .denominal    => .v
-  | .deadjectival => .v
-  | .deverbal_n   => .n
-  | .deverbal_a   => .a
+@[simp] theorem roots_ofHead (h : H) :
+    roots (ofHead h : WordStructure H) = 0 := rfl
 
-/-- Apply a re-categorization to a categorized root. Returns `none` if the
-    root's current categorizer doesn't match the expected source. -/
-def CategorizedRoot.recategorize (cr : CategorizedRoot)
-    (rc : Recategorization) : Option CategorizedRoot :=
-  if cr.categorizer = rc.source then
-    some { root := cr.root, classification := cr.classification, categorizer := rc.target }
-  else
-    none
+@[simp] theorem heads_ofHead (h : H) :
+    heads (ofHead h : WordStructure H) = {h} := rfl
 
-/-- Denominal verbs start from n-categorized roots. -/
-theorem denominal_requires_n (cr : CategorizedRoot) (cr' : CategorizedRoot)
-    (h : cr.recategorize .denominal = some cr') :
-    cr.categorizer = .n := by
-  unfold CategorizedRoot.recategorize at h
-  simp only [Recategorization.source] at h
-  split at h <;> simp_all
+@[simp] theorem heads_ofRoot (r : Root) :
+    heads (ofRoot r : WordStructure H) = 0 := rfl
 
-/-- Re-categorization yields the target categorizer. -/
-theorem recategorization_changes_category (cr : CategorizedRoot)
-    (rc : Recategorization) (cr' : CategorizedRoot)
-    (h : cr.recategorize rc = some cr') :
-    cr'.categorizer = rc.target := by
-  unfold CategorizedRoot.recategorize at h
-  split at h
-  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
-  case isFalse => simp at h
+/-- Categorization does not touch root leaves: the same root index
+survives categorization and re-categorization — √HAMMER is one root
+across *hammer* and *to hammer* ([harley-2014] §2, §4) — and with it
+every piece of root-level lexical content. C-selection is therefore
+untouched by the categorizer ([harley-2014] §3: *one*-replacement,
+verb-object idioms, ergative splits), in contrast with l-selection,
+which varies with the functional structure (`Hewett2026`). -/
+theorem roots_categorize (h : H) (T : WordStructure H) :
+    roots (categorize h T) = roots T := by
+  rw [categorize, roots, Nonplanar.leaves_node_cons, Multiset.filterMap_add,
+    show Multiset.filterMap (fun x => x.getLeft?.bind Sum.getLeft?)
+      (ofHead h : WordStructure H).leaves
+      = (0 : Multiset Root) from rfl]
+  simp [roots]
 
-/-- The acategorial root survives (re)categorization, so *shelf* (n) and
-    *to shelve* (v) share one List-1 root ([harley-2014] §2, §4). -/
-theorem recategorize_preserves_root (cr cr' : CategorizedRoot)
-    (rc : Recategorization) (h : cr.recategorize rc = some cr') :
-    cr'.root = cr.root := by
-  unfold CategorizedRoot.recategorize at h
-  split at h
-  case isTrue => simp only [Option.some.injEq] at h; rw [← h]
-  case isFalse => simp at h
+/-- Each categorization contributes exactly its head. -/
+theorem heads_categorize (h : H) (T : WordStructure H) :
+    heads (categorize h T) = h ::ₘ heads T := by
+  rw [categorize, heads, Nonplanar.leaves_node_cons, Multiset.filterMap_add]
+  rw [show Multiset.filterMap (fun x => x.getLeft?.bind Sum.getRight?)
+      (ofHead h : WordStructure H).leaves = {h} from rfl]
+  simp [heads, Multiset.singleton_add]
 
-/-- A denominal verb and a directly verbal root yield the same syntactic
-    category (V), but have different internal structure. √HAMMER + v gives
-    V directly; √HAMMER + n + v also gives V but via layered derivation.
-    This structural ambiguity is invisible at the category level
-    ([harley-2014] §2). -/
-theorem denominal_yields_verbal (i : DistributedMorphology.Root) (r : Classification) :
-    ∃ cr, (CategorizedRoot.mk i r .n).recategorize .denominal = some cr ∧
-          cr.category = Cat.V :=
-  ⟨⟨i, r, .v⟩, rfl, rfl⟩
+/-- Each categorization adds one leaf. -/
+theorem numLeaves_categorize (h : H) (T : WordStructure H) :
+    (categorize h T).numLeaves = T.numLeaves + 1 := by
+  rw [← Nonplanar.card_leaves, categorize, Nonplanar.leaves_node_cons,
+    Multiset.card_add]
+  simp [ofHead, Nonplanar.card_leaves, Nat.add_comm]
 
-/-- Deadjectival derivation (a → v) connects to [embick-2004]'s result-stative
-    structure ([AspP AspR [vP DP v_become √ROOT]]): in DM terms, a root first
-    categorized by a, then further categorized by v. -/
-theorem deadjectival_source_target :
-    Recategorization.deadjectival.source = .a ∧
-    Recategorization.deadjectival.target = .v := ⟨rfl, rfl⟩
+/-- Outermost headedness: the structure is the head itself, or was built
+by merging it last. -/
+inductive Headed : WordStructure H → H → Prop
+  | ofHead (h : H) : Headed (ofHead h) h
+  | categorize (h : H) (T : WordStructure H) : Headed (categorize h T) h
+
+/-- Same base, different categorizer, different structure: √HAMMER under
+n (*hammer*) and under v (*to hammer*) are distinct objects
+([marantz-1997], [harley-2014] §2). -/
+theorem categorize_ne_of_ne {h h' : H} (hne : h ≠ h') (T : WordStructure H) :
+    categorize h T ≠ categorize h' T := fun he => by
+  have hh := congrArg heads he
+  rw [heads_categorize, heads_categorize] at hh
+  exact hne ((Multiset.cons_inj_left _).mp hh)
+
+/-- Layered derivation is structurally distinct from direct derivation
+even when the outermost head agrees: [v [n √SHELF]] (*to shelve*) is not
+[v √SHELF], though both are `Headed` by v — the ambiguity a bare
+category label hides ([harley-2014] §2, §4). -/
+theorem categorize_categorize_ne (h₁ h₂ h₃ : H) (T : WordStructure H) :
+    categorize h₁ (categorize h₂ T) ≠ categorize h₃ T := fun he => by
+  have := congrArg Nonplanar.numLeaves he
+  rw [numLeaves_categorize, numLeaves_categorize, numLeaves_categorize] at this
+  omega
 
 /-! ### VoiceP as phase boundary
 

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
@@ -44,7 +44,6 @@ the head inventory is `Gender.KramerN`.
 namespace DistributedMorphology
 
 open Minimalist Minimalist.Voice
-open Verb Verb.Root
 
 /-! ### Phi-features on categorizing heads
 
@@ -169,7 +168,10 @@ instance : Inhabited PhiBundle := ⟨{}⟩
 
 /-- A categorizing head with its phi-features and the selectional feature
 {D}, which creates a specifier position for an iPossessor DP in Spec,nP
-([adamson-2024], following [myler-2016]'s convention). -/
+([adamson-2024], following [myler-2016]'s convention). A functional
+morpheme is a feature bundle: `CatHead` is the head-leaf label of
+`WordStructure CatHead`, the φ-enriched instance of word-internal
+structure. -/
 structure CatHead where
   /-- The categorizer n, v, or a. -/
   cat : Categorizer
@@ -276,6 +278,16 @@ def CatHead.v_plain : CatHead where
 /-- The adjectival categorizer, with no phi-features. -/
 def CatHead.a_plain : CatHead where
   cat := .a
+
+/-- In the categorization configuration [n √], all φ-content sits on the
+single head leaf and the single root leaf carries none: gender enters
+nominal structure only through n ([kramer-2015]). -/
+theorem heads_roots_categorize_ofRoot (ch : CatHead) (r : Root) :
+    heads (categorize ch (ofRoot r)) = {ch}
+      ∧ roots (categorize ch (ofRoot r)) = {r} := by
+  constructor
+  · rw [heads_categorize, heads_ofRoot, Multiset.cons_zero]
+  · rw [roots_categorize, roots_ofRoot]
 
 /-! ### Licensing Conditions ([kramer-2015] §3.4) -/
 

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion.lean
@@ -37,9 +37,9 @@ exist.
 
 This module provides the generic VI framework. Language-specific VI
 rules live in `Fragments/` or in phenomenon-specific `Studies/` files.
-The `Categorizer` and `CategorizedRoot` types from
-`Morphology/DistributedMorphology/Categorizer.lean` provide the syntax-side
-terminal nodes that VI targets.
+The `Categorizer` type and the `WordStructure` trees from
+`Morphology/DistributedMorphology/Categorizer/Basic.lean` provide the
+syntax-side terminals and configurations that VI targets.
 -/
 
 namespace DistributedMorphology.VI

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -667,15 +667,21 @@ def verbalizerCat : CatHead := CatHead.v_plain
 
 theorem verbalizer_is_verbal : verbalizerCat.cat = .v := rfl
 
-/-- Denominal verb derivation (n → v): `Recategorization.denominal`. -/
-theorem denominal_ideophone_verb :
-    Recategorization.denominal.source = .n ∧
-    Recategorization.denominal.target = .v := ⟨rfl, rfl⟩
+/-- Denominal verb derivation (n → v): the ideophonic base categorized
+    by n, recategorized by the tonal verbalizer — [v [n √]] is v-headed
+    over an n-headed inner layer, with the base root untouched. -/
+theorem denominal_ideophone_verb (r : DistributedMorphology.Root) :
+    Headed (categorize verbalizerCat (categorize CatHead.n_plain (ofRoot r)))
+      verbalizerCat ∧
+    roots (categorize verbalizerCat (categorize CatHead.n_plain (ofRoot r)))
+      = {r} :=
+  ⟨.categorize .., by rw [roots_categorize, roots_categorize, roots_ofRoot]⟩
 
-/-- Deadjectival verb derivation (a → v). -/
-theorem deadjectival_ideophone_verb :
-    Recategorization.deadjectival.source = .a ∧
-    Recategorization.deadjectival.target = .v := ⟨rfl, rfl⟩
+/-- Deadjectival verb derivation (a → v): [v [a √]]. -/
+theorem deadjectival_ideophone_verb (r : DistributedMorphology.Root) :
+    Headed (categorize verbalizerCat (categorize CatHead.a_plain (ofRoot r)))
+      verbalizerCat :=
+  .categorize ..
 
 -- ============================================================================
 -- §9: Expressiveness Preservation (after [potts-2007])

--- a/Linglib/Studies/Clark1983.lean
+++ b/Linglib/Studies/Clark1983.lean
@@ -54,9 +54,8 @@ as a request projects to `prepCondition := some .knowledge` — the same
 substrate `Studies/FrancikClark1985.lean` and
 `Studies/RuytenbeekEtAl2017.lean` consume.
 
-The DM bridge in `§I` consumes `DistributedMorphology.Categorizer`'s
-`Recategorization.denominal` for the syntactic operation underlying nonce
-verbs. The LU-RSA bridge in `§H` consumes
+The DM bridge in `§I` consumes `DistributedMorphology.categorize` for
+the word syntax [v [n √]] underlying nonce verbs. The LU-RSA bridge in `§H` consumes
 `RSA.Lexicon`.
 
 The shared mechanism Clark posits in `§K` is operationalized as a typed
@@ -71,8 +70,7 @@ namespace Clark1983
 
 open CommonGround
 open RSA (Lexicon)
-open DistributedMorphology (Categorizer Recategorization CategorizedRoot
-  denominal_requires_n recategorization_changes_category)
+open DistributedMorphology (Categorizer WordStructure ofRoot categorize Headed)
 
 /-! ## §A. Sense and reference: fixed vs shifting (Table 9.1, p. 300) -/
 
@@ -466,9 +464,9 @@ def teapotConvention : DenominalVerbConvention TeapotWorld where
   rolesDistinct := by decide
 
 /-- The full DM + Convention bundle for *to teapot* in this context.
-    The DM-side `recategorized` step (n → v) is satisfied by some
-    underlying `CategorizedRoot`; for downstream studies the `convention`
-    field is the Clark-side substantive content. -/
+    The DM-side derivation (n → v) is the word structure [v [n √]] over
+    any root index; for downstream studies the `convention` field is the
+    Clark-side substantive content. -/
 def teapotDenominalConvention :
     DenominalVerbConvention TeapotWorld := teapotConvention
 
@@ -538,34 +536,39 @@ theorem sense_creation_strictly_generalizes
 
 /-! ## §I. Bridge to DM recategorization
 
-DM's `Recategorization.denominal` captures the syntactic n → v step. The
-hard part — what the resulting verb *means* — is what Clark's convention
-(`§G`) and the goal hierarchy (`§F`) provide. -/
+DM's word syntax captures the n → v step: the denominal verb is the
+configuration [v [n √]]. The hard part — what the resulting verb
+*means* — is what Clark's convention (`§G`) and the goal hierarchy
+(`§F`) provide. -/
 
-/-- A denominal verb has a syntactic component (DM recategorization) and a
-    pragmatic component (Clark's convention). -/
+/-- A denominal verb has a syntactic component (the root, categorized
+    [v [n √]]) and a pragmatic component (Clark's convention). -/
 structure DenominalVerb (W : Type*) where
-  nominalRoot : CategorizedRoot
-  recategorized : CategorizedRoot
-  recatProof : nominalRoot.recategorize .denominal = some recategorized
+  root : DistributedMorphology.Root
   convention : DenominalVerbConvention W
 
+/-- The word syntax of a denominal verb: the layered derivation [v [n √]]. -/
+noncomputable def DenominalVerb.wordStructure {W : Type*} (dv : DenominalVerb W) :
+    WordStructure Categorizer :=
+  categorize .v (categorize .n (ofRoot dv.root))
+
 theorem denominal_verb_is_verbal {W : Type*} (dv : DenominalVerb W) :
-    dv.recategorized.categorizer = .v :=
-  recategorization_changes_category
-    dv.nominalRoot .denominal dv.recategorized dv.recatProof
+    Headed dv.wordStructure .v :=
+  .categorize ..
 
 theorem denominal_verb_source_is_nominal {W : Type*} (dv : DenominalVerb W) :
-    dv.nominalRoot.categorizer = .n :=
-  denominal_requires_n dv.nominalRoot dv.recategorized dv.recatProof
+    Headed (categorize Categorizer.n (ofRoot dv.root)) Categorizer.n :=
+  .categorize ..
 
-/-- DM tells us denominal verbs exist (recategorization succeeds) but says
-    nothing about what they mean. Two denominal verbs from the same root
-    always produce the same syntactic result yet can have arbitrarily
-    different meanings — Clark's convention fills that gap. -/
-theorem dm_underdetermines_meaning {W : Type*} (dv₁ dv₂ : DenominalVerb W) :
-    dv₁.recategorized.categorizer = dv₂.recategorized.categorizer := by
-  rw [denominal_verb_is_verbal dv₁, denominal_verb_is_verbal dv₂]
+/-- DM tells us what denominal verbs are (the layered structure over the
+    root) but nothing about what they mean: the word structure is
+    determined by the root alone, so two denominal verbs from the same
+    root are syntactically identical yet can have arbitrarily different
+    meanings — Clark's convention fills that gap. -/
+theorem dm_underdetermines_meaning {W : Type*} (dv₁ dv₂ : DenominalVerb W)
+    (h : dv₁.root = dv₂.root) :
+    dv₁.wordStructure = dv₂.wordStructure := by
+  rw [DenominalVerb.wordStructure, DenominalVerb.wordStructure, h]
 
 /-! ## §J. The *stereos* example (paper pp. 326–327)
 

--- a/Linglib/Studies/Hewett2026.lean
+++ b/Linglib/Studies/Hewett2026.lean
@@ -1,4 +1,5 @@
 import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
+import Linglib.Semantics.ArgumentStructure.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Applicative
 import Linglib.Syntax.Minimalist.Agree.Checking
 import Linglib.Syntax.Minimalist.Verbal.Voice
@@ -50,7 +51,7 @@ namespace Hewett2026
 
 open Minimalist (VerbHead Cat FeatureStatus ActivationIndex ApplHead applHigh applLowRecipient isCausative low_licensed_with_any high_licensed_of_assignsTheta)
 open Minimalist.Voice (Flavor Head buildDecomposition agentive causer passive anticausative)
-open DistributedMorphology (CategorizedRoot Categorizer)
+open DistributedMorphology (Categorizer)
 open Morphology.MirrorPrinciple (MorphDomain)
 open Wood2015 (Construction)
 
@@ -263,24 +264,27 @@ theorem Hkm_not_templateInvariant : ¬ templateInvariant .Hkm :=
   fun h => absurd (h .XaYaZ .XaYYaZ) (by decide)
 
 /-- C-selection (valency) is root-level ([harley-2014]; see
-    `complement_selection_at_root_level` in `Categorizer.lean`) but l-selection is
-    not: the two kinds of selection factor differently in the grammar. -/
+    `roots_categorize` in `Categorizer/Basic.lean`) but l-selection is not:
+    categorization leaves the root leaves — and with them all root-level
+    selectional content — untouched, while l-selection varies by template. -/
 theorem cSelection_vs_lSelection :
-    (∀ (i : DistributedMorphology.Root) (r : Verb.Root.Classification)
-        (c1 c2 : Categorizer),
-      (CategorizedRoot.mk i r c1).classification.valency
-        = (CategorizedRoot.mk i r c2).classification.valency) ∧
+    (∀ (x : Categorizer) (T : DistributedMorphology.WordStructure Categorizer),
+      DistributedMorphology.roots (DistributedMorphology.categorize x T)
+        = DistributedMorphology.roots T) ∧
     (∃ r : RootLabel, ¬ templateInvariant r) :=
-  ⟨fun _ _ _ _ => rfl, ⟨.krh, krh_not_templateInvariant⟩⟩
+  ⟨DistributedMorphology.roots_categorize, ⟨.krh, krh_not_templateInvariant⟩⟩
 
 /-! ### Verbalized roots -/
 
 /-- A root that has been categorized as a verb and placed in a template — the
-    structure that jointly determines l-selection. Bridges `CategorizedRoot`
-    (categorizer side) and the template's Voice contribution. -/
+    structure that jointly determines l-selection. The verbalizer is fixed:
+    the word syntax is [v √], and the template contributes the Voice head
+    above it. -/
 structure VerbalizedRoot where
-  /-- The root with its categorizer. -/
-  categorized : CategorizedRoot
+  /-- The acategorial root. -/
+  root : DistributedMorphology.Root
+  /-- The root's c-selection content (arity, change-type). -/
+  classification : Verb.Root.Classification
   /-- The Semitic template (functional head bundle). -/
   template : SemiticTemplate
   /-- The root label for l-selection lookup. -/
@@ -297,10 +301,11 @@ def VerbalizedRoot.voiceFlavor (vr : VerbalizedRoot) : Flavor :=
 
 /-- Valency is template-invariant (root-level), unlike l-selection: c-selection
     and l-selection factor differently in the grammar. -/
-theorem valency_template_invariant (cr : CategorizedRoot) (rl : RootLabel)
+theorem valency_template_invariant (rt : DistributedMorphology.Root)
+    (cls : Verb.Root.Classification) (rl : RootLabel)
     (t1 t2 : SemiticTemplate) :
-    (VerbalizedRoot.mk cr t1 rl).categorized.classification.valency =
-      (VerbalizedRoot.mk cr t2 rl).categorized.classification.valency := rfl
+    (VerbalizedRoot.mk rt cls t1 rl).classification.valency =
+      (VerbalizedRoot.mk rt cls t2 rl).classification.valency := rfl
 
 /-! ### Template-to-Voice correspondence
 
@@ -331,11 +336,12 @@ theorem voice_distinguishes_templates :
 
 /-- [kratzer-1996]'s severing instantiated for Semitic: root-level valency is
     template-invariant while the Voice contribution varies by template. -/
-theorem severing_instantiated (cr : CategorizedRoot) (rl : RootLabel) :
-    (VerbalizedRoot.mk cr .XaYaZ rl).categorized.classification.valency =
-      (VerbalizedRoot.mk cr .XaYYaZ rl).categorized.classification.valency ∧
+theorem severing_instantiated (rt : DistributedMorphology.Root)
+    (cls : Verb.Root.Classification) (rl : RootLabel) :
+    (VerbalizedRoot.mk rt cls .XaYaZ rl).classification.valency =
+      (VerbalizedRoot.mk rt cls .XaYYaZ rl).classification.valency ∧
     SemiticTemplate.toVoiceFlavor .XaYaZ ≠ SemiticTemplate.toVoiceFlavor .XaYYaZ :=
-  ⟨valency_template_invariant cr rl .XaYaZ .XaYYaZ, voice_distinguishes_templates⟩
+  ⟨valency_template_invariant rt cls rl .XaYaZ .XaYYaZ, voice_distinguishes_templates⟩
 
 /-! ### Cross-linguistic Voice coverage
 


### PR DESCRIPTION
Dissolves the configuration structs onto the word-internal tree carrier: a categorized root is the configuration [x √], not a kind of object.

- `CategorizedRoot` and `Recategorization` DELETED. `WordStructure H` (nonplanar trees over root/head leaves, same carrier shape as syntactic and morphological objects), `categorize` (total — the a→n *-ness* and n→a *-ish* derivations the enum couldn't express come free), `roots`/`heads` projections, `Headed`.
- `roots_categorize` replaces `recategorize_preserves_root` as a fact about leaves; `categorize_categorize_ne` states the direct-vs-layered distinction the old encoding confessed was invisible.
- `CatHead` stays as what it is — a feature-bundle terminal label — instantiating `WordStructure CatHead`; Kramer's gender-on-n locus stated configurationally (`heads_roots_categorize_ofRoot`).
- Consumers migrated: Clark1983 (`DenominalVerb` = root + convention, word syntax derived), Hewett2026 (`VerbalizedRoot` recut, c- vs l-selection via `roots_categorize`), AkinboFwangwar2026 (ideophone derivations as headed structures).