### PR TITLE
refactor(Morphology/DistributedMorphology): CatHead to Categorizer.Head

### DIFF
--- a/Linglib/Fragments/Hausa/Gender.lean
+++ b/Linglib/Fragments/Hausa/Gender.lean
@@ -52,7 +52,7 @@ of [+FEM] on n, NOT phonological *assignment*. Aligns with Newman's
 synchronic view.
 
 The cross-framework theorems live in `Studies/Kramer2020.lean`.
-Spanish/Russian/German Fragment Gender files still bake in DM `CatHead`
+Spanish/Russian/German Fragment Gender files still bake in DM `Categorizer.Head`
 fields; Hausa is the pilot for theory-neutral Fragment-layer encoding.
 -/
 

--- a/Linglib/Fragments/Spanish/Binominals.lean
+++ b/Linglib/Fragments/Spanish/Binominals.lean
@@ -21,6 +21,7 @@ namespace Spanish.Binominals
 
 open Quantification.Binominal
 open DistributedMorphology
+open DistributedMorphology.Categorizer (Head)
 
 /-- A Spanish binominal noun entry, with gender encoded via the DM
     categorizing head on n ([kramer-2015]). -/
@@ -28,7 +29,7 @@ structure BinominalNoun where
   /-- The noun form -/
   form : String
   /-- Categorizing head (encodes gender structurally) -/
-  nHead : CatHead
+  nHead : Head
   /-- Binominal class -/
   binominalType : BinominalType
   /-- Gloss in English -/
@@ -36,19 +37,19 @@ structure BinominalNoun where
   deriving Repr
 
 -- Group nouns (pseudo-partitive)
-def grupo     : BinominalNoun := ⟨"grupo",     CatHead.n_plain, .pseudoPartitive,  "group"⟩
-def conjunto  : BinominalNoun := ⟨"conjunto",  CatHead.n_plain, .pseudoPartitive,  "set"⟩
-def serie     : BinominalNoun := ⟨"serie",     CatHead.n_uFem,  .pseudoPartitive,  "series"⟩
+def grupo     : BinominalNoun := ⟨"grupo",     Head.n_plain, .pseudoPartitive,  "group"⟩
+def conjunto  : BinominalNoun := ⟨"conjunto",  Head.n_plain, .pseudoPartitive,  "set"⟩
+def serie     : BinominalNoun := ⟨"serie",     Head.n_uFem,  .pseudoPartitive,  "series"⟩
 
 -- Quantity nouns (quantificational)
-def montón    : BinominalNoun := ⟨"montón",    CatHead.n_plain, .quantificational, "heap/lot"⟩
-def pila      : BinominalNoun := ⟨"pila",      CatHead.n_uFem,  .quantificational, "pile"⟩
-def cantidad  : BinominalNoun := ⟨"cantidad",  CatHead.n_uFem,  .quantificational, "quantity"⟩
+def montón    : BinominalNoun := ⟨"montón",    Head.n_plain, .quantificational, "heap/lot"⟩
+def pila      : BinominalNoun := ⟨"pila",      Head.n_uFem,  .quantificational, "pile"⟩
+def cantidad  : BinominalNoun := ⟨"cantidad",  Head.n_uFem,  .quantificational, "quantity"⟩
 
 -- Expressive nouns (qualitative)
-def mierda    : BinominalNoun := ⟨"mierda",    CatHead.n_uFem,  .qualitative,      "shit"⟩
-def maravilla : BinominalNoun := ⟨"maravilla", CatHead.n_uFem,  .qualitative,      "wonder"⟩
-def desastre  : BinominalNoun := ⟨"desastre",  CatHead.n_plain, .qualitative,      "disaster"⟩
+def mierda    : BinominalNoun := ⟨"mierda",    Head.n_uFem,  .qualitative,      "shit"⟩
+def maravilla : BinominalNoun := ⟨"maravilla", Head.n_uFem,  .qualitative,      "wonder"⟩
+def desastre  : BinominalNoun := ⟨"desastre",  Head.n_plain, .qualitative,      "disaster"⟩
 
 /-- All binominal noun entries. -/
 def allNouns : List BinominalNoun :=

--- a/Linglib/Fragments/Teop/Nouns.lean
+++ b/Linglib/Fragments/Teop/Nouns.lean
@@ -162,32 +162,32 @@ def Gender.toGender : Gender → _root_.Gender
 open DistributedMorphology in
 /-- Map Teop gender classes to their DM categorizing heads.
     Gender I (animates) ↔ n i[+ANIM]; Gender II (inanimates) ↔ plain n. -/
-def Gender.toCatHead : Gender → CatHead
-  | .gI  => CatHead.n_iAnim
-  | .gII => CatHead.n_plain
+def Gender.toHead : Gender → Categorizer.Head
+  | .gI  => Categorizer.Head.n_iAnim
+  | .gII => Categorizer.Head.n_plain
 
 open DistributedMorphology in
 /-- Gender I maps to a natural (interpretable) gender feature. -/
 theorem gI_natural_gender :
-    Gender.gI.toCatHead.phi.gender = some ⟨.i, ⟨.anim, .pos⟩⟩ := rfl
+    Gender.gI.toHead.phi.gender = some ⟨.i, ⟨.anim, .pos⟩⟩ := rfl
 
 open DistributedMorphology in
 /-- Gender II maps to plain n (no gender feature). -/
 theorem gII_no_gender :
-    Gender.gII.toCatHead.phi.gender = none := rfl
+    Gender.gII.toHead.phi.gender = none := rfl
 
 open DistributedMorphology in
 /-- Body-part nouns when iPossessed switch to n with u[+ANIM]
     ([adamson-2024] §3.1). -/
-def iPossessedCatHead (n : Noun) : CatHead :=
-  if n.isBodyPart then CatHead.n_uAnim else n.gender.toCatHead
+def iPossessedHead (n : Noun) : Categorizer.Head :=
+  if n.isBodyPart then Categorizer.Head.n_uAnim else n.gender.toHead
 
 open DistributedMorphology in
 theorem spleen_ipossessed_cathead :
-    iPossessedCatHead bina = CatHead.n_uAnim := rfl
+    iPossessedHead bina = Categorizer.Head.n_uAnim := rfl
 
 open DistributedMorphology in
 theorem spleen_free_cathead :
-    bina.gender.toCatHead = CatHead.n_plain := rfl
+    bina.gender.toHead = Categorizer.Head.n_plain := rfl
 
 end Teop

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -55,7 +55,7 @@ allosemes (v ⊕ n), not a single-head competition — so it stays a table.
 
 namespace DistributedMorphology.Allosemy
 
-open DistributedMorphology (Categorizer CatHead)
+open DistributedMorphology (Categorizer Categorizer.Head)
 open DistributedMorphology.CategorizerSemantics (NSemanticType)
 open Minimalist.Voice (Flavor Head)
 

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Basic.lean
@@ -19,7 +19,7 @@ and layered derivation are facts about leaves rather than stipulations.
 
 * `Categorizer` — the closed inventory n, v, a
 * `WordStructure` — word-internal structure over a head alphabet:
-  `Categorizer` for the bare theory, `CatHead`
+  `Categorizer` for the bare theory, `Categorizer.Head`
   (`Categorizer/Gender.lean`) when heads carry φ-content
 * `categorize`, `roots`, `heads`, `Headed` — head merger, the two leaf
   projections, and outermost headedness

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
@@ -18,11 +18,11 @@ the head inventory is `Gender.KramerN`.
 
 * `GenderVal`, `GenderFeature`, `Interpretability`, `Contrastivity` —
   gender features on n and their LF status
-* `CatHead` — a categorizer with phi-features and the selectional feature
-  {D}; canonical heads `CatHead.n_iFem` … `CatHead.n_uMasc`
-* `CatHead.surfaceGenderSet1`/`Set2`/`Three`/`Animacy` — the attested
+* `Categorizer.Head` — a categorizer with phi-features and the selectional feature
+  {D}; canonical heads `Categorizer.Head.n_iFem` … `Categorizer.Head.n_uMasc`
+* `Categorizer.Head.surfaceGenderSet1`/`Set2`/`Three`/`Animacy` — the attested
   Vocabulary-Insertion maps from features to surface gender
-* `RootLicense`, `CatHead.licensesIntrusion` — root–n licensing and
+* `RootLicense`, `Categorizer.Head.licensesIntrusion` — root–n licensing and
   gender-conditioned templatic t-intrusion
 
 ## Main statements
@@ -169,12 +169,12 @@ instance : Inhabited PhiBundle := ⟨{}⟩
 /-- A categorizing head with its phi-features and the selectional feature
 {D}, which creates a specifier position for an iPossessor DP in Spec,nP
 ([adamson-2024], following [myler-2016]'s convention). A functional
-morpheme is a feature bundle: `CatHead` is the head-leaf label of
-`WordStructure CatHead`, the φ-enriched instance of word-internal
+morpheme is a feature bundle: `Categorizer.Head` is the head-leaf label of
+`WordStructure Categorizer.Head`, the φ-enriched instance of word-internal
 structure. -/
-structure CatHead where
+structure Categorizer.Head where
   /-- The categorizer n, v, or a. -/
-  cat : Categorizer
+  categorizer : Categorizer
   /-- The gender and number content ([kramer-2015]). -/
   phi : PhiBundle := {}
   /-- The selectional feature {D} licensing an iPossessor. -/
@@ -182,20 +182,20 @@ structure CatHead where
   deriving DecidableEq, Repr
 
 /-- The syntactic category of a phi-enriched categorizer head. -/
-def CatHead.toCategory (ch : CatHead) : Cat :=
-  ch.cat.toCategory
+def Categorizer.Head.toCategory (ch : Categorizer.Head) : Cat :=
+  ch.categorizer.toCategory
 
 /-- An iPossessable n head — {D} by construction, with the phi-bundle
 supplying any gender (Teop's body-part n carries u[+ANIM], Jarawara's is
 bare). -/
-def CatHead.iPoss (phi : PhiBundle := {}) : CatHead where
-  cat := .n
+def Categorizer.Head.iPoss (phi : PhiBundle := {}) : Categorizer.Head where
+  categorizer := .n
   phi := phi
   selectsD := true
 
 /-- iPossessable n-heads always have selectsD = true, by construction. -/
-theorem CatHead.iPoss_selectsD (phi : PhiBundle) :
-    (CatHead.iPoss phi).selectsD = true := rfl
+theorem Categorizer.Head.iPoss_selectsD (phi : PhiBundle) :
+    (Categorizer.Head.iPoss phi).selectsD = true := rfl
 
 /-! ### Kramer's Four Types of n ([kramer-2015] Ch 3) -/
 
@@ -204,59 +204,59 @@ theorem CatHead.iPoss_selectsD (phi : PhiBundle) :
 /-- The n bearing interpretable [+FEM] — female natural gender. In
 Amharic the female member of a same-root pair can carry the suffix *-it*
 ([kramer-2015] (10)). -/
-def CatHead.n_iFem : CatHead where
-  cat := .n
+def Categorizer.Head.n_iFem : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.i, ⟨.fem, .pos⟩⟩ }
 
 /-- The n bearing interpretable [−FEM] — male natural gender. The name
 gives the resulting gender: the feature is negative-polarity FEM, not the
 MASC dimension of Jarawara (`n_uMasc`). -/
-def CatHead.n_iMasc : CatHead where
-  cat := .n
+def Categorizer.Head.n_iMasc : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.i, ⟨.fem, .neg⟩⟩ }
 
 /-- The plain n with no gender feature — the default nominal
 categorizer. -/
-def CatHead.n_plain : CatHead where
-  cat := .n
+def Categorizer.Head.n_plain : Categorizer.Head where
+  categorizer := .n
 
 /-- The n bearing uninterpretable [+FEM] — the arbitrary feminine of
 Set 1 languages (Amharic, Spanish), leaving masculine as the default.
 Amharic assigns it to a handful of inanimates such as *car*, *earth*,
 *sun*, and *church* ([kramer-2015] (9), Ch 6). -/
-def CatHead.n_uFem : CatHead where
-  cat := .n
+def Categorizer.Head.n_uFem : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.u, ⟨.fem, .pos⟩⟩ }
 
 /-- The n bearing uninterpretable [−FEM] — the arbitrary masculine of
 Set 2, leaving feminine as the default (Maa, [kramer-2015] §6.3). -/
-def CatHead.n_uNegFem : CatHead where
-  cat := .n
+def Categorizer.Head.n_uNegFem : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.u, ⟨.fem, .neg⟩⟩ }
 
 /-- u[+FEM] and u[−FEM] are distinct n heads: Set 1 vs Set 2. -/
 theorem u_fem_polarity_contrast :
-    CatHead.n_uFem ≠ CatHead.n_uNegFem := by decide
+    Categorizer.Head.n_uFem ≠ Categorizer.Head.n_uNegFem := by decide
 
 /-! ### ANIM dimension (Teop, Algonquian, Lealao Chinantec;
     [kramer-2015] Chs 5-6; [adamson-2024] §3.1) -/
 
 /-- The n bearing interpretable [+ANIM] — Teop gender I nouns, taking
 the article *a*. -/
-def CatHead.n_iAnim : CatHead where
-  cat := .n
+def Categorizer.Head.n_iAnim : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.i, ⟨.anim, .pos⟩⟩ }
 
 /-- The n bearing interpretable [−ANIM] — Teop gender II nouns, taking
 the article *o*. -/
-def CatHead.n_iInanim : CatHead where
-  cat := .n
+def Categorizer.Head.n_iInanim : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.i, ⟨.anim, .neg⟩⟩ }
 
 /-- The n bearing uninterpretable [+ANIM] — Teop's body-part n when
 iPossessed ([adamson-2024] §3.1). -/
-def CatHead.n_uAnim : CatHead where
-  cat := .n
+def Categorizer.Head.n_uAnim : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.u, ⟨.anim, .pos⟩⟩ }
 
 /-! ### MASC dimension (Jarawara; [adamson-2024] §3.2)
@@ -267,22 +267,22 @@ arbitrary masculine is negative-polarity FEM, not MASC. -/
 /-- The n bearing uninterpretable [+MASC] — Jarawara's marked masculine,
 with feminine as the unmarked plain n. [adamson-2024] (58) also allows the
 interpretable variant, not modeled here. -/
-def CatHead.n_uMasc : CatHead where
-  cat := .n
+def Categorizer.Head.n_uMasc : Categorizer.Head where
+  categorizer := .n
   phi := { gender := some ⟨.u, ⟨.masc, .pos⟩⟩ }
 
 /-- The verbal categorizer, with no phi-features. -/
-def CatHead.v_plain : CatHead where
-  cat := .v
+def Categorizer.Head.v_plain : Categorizer.Head where
+  categorizer := .v
 
 /-- The adjectival categorizer, with no phi-features. -/
-def CatHead.a_plain : CatHead where
-  cat := .a
+def Categorizer.Head.a_plain : Categorizer.Head where
+  categorizer := .a
 
 /-- In the categorization configuration [n √], all φ-content sits on the
 single head leaf and the single root leaf carries none: gender enters
 nominal structure only through n ([kramer-2015]). -/
-theorem heads_roots_categorize_ofRoot (ch : CatHead) (r : Root) :
+theorem heads_roots_categorize_ofRoot (ch : Categorizer.Head) (r : Root) :
     heads (categorize ch (ofRoot r)) = {ch}
       ∧ roots (categorize ch (ofRoot r)) = {r} := by
   constructor
@@ -311,8 +311,8 @@ structure RootLicense (RootIdx : Type) where
   /-- Semantic or arbitrary licensing. -/
   licensingType : LicensingType
 
-/-- Whether a CatHead satisfies a licensing condition's gender requirement. -/
-def CatHead.satisfiesLicense (ch : CatHead) (req : Option GenderFeature) : Bool :=
+/-- Whether a Categorizer.Head satisfies a licensing condition's gender requirement. -/
+def Categorizer.Head.satisfiesLicense (ch : Categorizer.Head) (req : Option GenderFeature) : Bool :=
   match req with
   | none => ch.phi.gender.isNone
   | some gf => ch.phi.gender == some gf
@@ -322,58 +322,58 @@ nominal categorizer bearing a gender feature, whose exponent the bound
 root hosts ([faust-2026] (11), [lowenstamm-2014]). Verbal stems are
 blocked because gender is realized on the higher Agr head
 ([kramer-2020]). -/
-def CatHead.licensesIntrusion (ch : CatHead) : Bool :=
-  decide (ch.cat = .n) && ch.phi.gender.isSome
+def Categorizer.Head.licensesIntrusion (ch : Categorizer.Head) : Bool :=
+  decide (ch.categorizer = .n) && ch.phi.gender.isSome
 
 /-! #### Intrusion licensing across the canonical heads -/
 
 /-- u[+FEM] n licenses intrusion (canonical Set 1 feminine — Hebrew /t/
     exponent of taQTiL nouns, Amharic /t/ exponent of gerunds and INFs). -/
 theorem n_uFem_licenses_intrusion :
-    CatHead.n_uFem.licensesIntrusion = true := rfl
+    Categorizer.Head.n_uFem.licensesIntrusion = true := rfl
 
 /-- i[+FEM] n licenses intrusion (interpretable feminine). -/
 theorem n_iFem_licenses_intrusion :
-    CatHead.n_iFem.licensesIntrusion = true := rfl
+    Categorizer.Head.n_iFem.licensesIntrusion = true := rfl
 
 /-- i[−FEM] n licenses intrusion (interpretable masculine — Faust's
     argument is feature-symmetric: any [+gen] specification on n
     licenses an inherent exponent). -/
 theorem n_iMasc_licenses_intrusion :
-    CatHead.n_iMasc.licensesIntrusion = true := rfl
+    Categorizer.Head.n_iMasc.licensesIntrusion = true := rfl
 
 /-- Plain n (no gender feature) does NOT license intrusion. -/
 theorem n_plain_blocks_intrusion :
-    CatHead.n_plain.licensesIntrusion = false := rfl
+    Categorizer.Head.n_plain.licensesIntrusion = false := rfl
 
 /-- The verbal categorizer never licenses intrusion, since gender is
 realized on Agr rather than v ([faust-2026] (11)). -/
 theorem v_plain_blocks_intrusion :
-    CatHead.v_plain.licensesIntrusion = false := rfl
+    Categorizer.Head.v_plain.licensesIntrusion = false := rfl
 
 /-- The adjectival categorizer has no inherent gender exponent. -/
 theorem a_plain_blocks_intrusion :
-    CatHead.a_plain.licensesIntrusion = false := rfl
+    Categorizer.Head.a_plain.licensesIntrusion = false := rfl
 
 /-- Intrusion is well-formed iff the categorizer is n and carries a
 gender feature ([faust-2026] (11)). -/
-theorem licensesIntrusion_iff_n_and_gen (ch : CatHead) :
-    ch.licensesIntrusion = true ↔ ch.cat = .n ∧ ch.phi.gender.isSome = true := by
-  simp only [CatHead.licensesIntrusion, Bool.and_eq_true, decide_eq_true_eq]
+theorem licensesIntrusion_iff_n_and_gen (ch : Categorizer.Head) :
+    ch.licensesIntrusion = true ↔ ch.categorizer = .n ∧ ch.phi.gender.isSome = true := by
+  simp only [Categorizer.Head.licensesIntrusion, Bool.and_eq_true, decide_eq_true_eq]
 
 /-! ### Phi-Feature Verification -/
 
 /-- The four Amharic n types are pairwise distinct. -/
 theorem four_n_types_distinct :
-    CatHead.n_iFem ≠ CatHead.n_iMasc ∧
-    CatHead.n_iFem ≠ CatHead.n_plain ∧
-    CatHead.n_iFem ≠ CatHead.n_uFem ∧
-    CatHead.n_iMasc ≠ CatHead.n_plain ∧
-    CatHead.n_iMasc ≠ CatHead.n_uFem ∧
-    CatHead.n_plain ≠ CatHead.n_uFem := by decide
+    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_iMasc ∧
+    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_plain ∧
+    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_uFem ∧
+    Categorizer.Head.n_iMasc ≠ Categorizer.Head.n_plain ∧
+    Categorizer.Head.n_iMasc ≠ Categorizer.Head.n_uFem ∧
+    Categorizer.Head.n_plain ≠ Categorizer.Head.n_uFem := by decide
 
 /-- Plain n has no gender feature — it is the default/unmarked case. -/
-theorem plain_n_no_gender : CatHead.n_plain.phi.gender = none := rfl
+theorem plain_n_no_gender : Categorizer.Head.n_plain.phi.gender = none := rfl
 
 /-- Natural and arbitrary gender are mutually exclusive on any feature. -/
 theorem natural_arbitrary_exclusive (gf : GenderFeature) :
@@ -462,7 +462,7 @@ theorem genderSplit_isAbsent_iff (phi : PhiBundle) :
 
 /-- [kramer-2015]'s FEM-dimension calculus embeds into the head
 inventory. -/
-def CatHead.ofKramerN : Gender.KramerN → CatHead
+def Categorizer.Head.ofKramerN : Gender.KramerN → Categorizer.Head
   | .plain => .n_plain
   | .iFem  => .n_iFem
   | .iMasc => .n_iMasc
@@ -522,14 +522,14 @@ theorem n_uFem_unvalued :
 
 /-- Animacy-dimension n types are distinct from FEM-dimension types. -/
 theorem anim_n_types_distinct :
-    CatHead.n_iAnim ≠ CatHead.n_iFem ∧
-    CatHead.n_iAnim ≠ CatHead.n_iMasc ∧
-    CatHead.n_uAnim ≠ CatHead.n_uFem := by decide
+    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_iFem ∧
+    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_iMasc ∧
+    Categorizer.Head.n_uAnim ≠ Categorizer.Head.n_uFem := by decide
 
 /-- Animacy-dimension n types are distinct from plain n. -/
 theorem anim_not_plain :
-    CatHead.n_iAnim ≠ CatHead.n_plain ∧
-    CatHead.n_uAnim ≠ CatHead.n_plain := by decide
+    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_plain ∧
+    Categorizer.Head.n_uAnim ≠ Categorizer.Head.n_plain := by decide
 
 /-! ### Surface Gender Bridge ([kramer-2020]; [kramer-2015] Chs 5-7) -/
 
@@ -542,7 +542,7 @@ across languages; the four attested patterns follow
 /-- The Set 1 Vocabulary Insertion of Amharic and Spanish — [+FEM]
 realizes feminine and everything else masculine, so the default is
 masculine ([kramer-2015] Ch 6). -/
-def CatHead.surfaceGenderSet1 (ch : CatHead) : Gender :=
+def Categorizer.Head.surfaceGenderSet1 (ch : Categorizer.Head) : Gender :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .pos⟩ then .feminine else .masculine
   | none    => .masculine
@@ -550,7 +550,7 @@ def CatHead.surfaceGenderSet1 (ch : CatHead) : Gender :=
 /-- The Set 2 Vocabulary Insertion of Maa — [−FEM] realizes masculine
 and everything else feminine, so the default is feminine
 ([kramer-2015] §6.3). -/
-def CatHead.surfaceGenderSet2 (ch : CatHead) : Gender :=
+def Categorizer.Head.surfaceGenderSet2 (ch : Categorizer.Head) : Gender :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .neg⟩ then .masculine else .feminine
   | none    => .feminine
@@ -558,7 +558,7 @@ def CatHead.surfaceGenderSet2 (ch : CatHead) : Gender :=
 /-- The three-gender Vocabulary Insertion of Mangarayi — [+FEM] feminine,
 [−FEM] masculine, no feature neuter ([kramer-2015] §7.2; the other Ch 7
 case studies add uninterpretable features to this inventory). -/
-def CatHead.surfaceGenderThree (ch : CatHead) : Gender :=
+def Categorizer.Head.surfaceGenderThree (ch : Categorizer.Head) : Gender :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .pos⟩ then .feminine else .masculine
   | none    => .neuter
@@ -566,7 +566,7 @@ def CatHead.surfaceGenderThree (ch : CatHead) : Gender :=
 /-- The animacy Vocabulary Insertion of Lealao Chinantec
 ([kramer-2015] §5.3), Algonquian (§6.4), and Teop ([adamson-2024]) —
 [+ANIM] realizes animate and everything else inanimate. -/
-def CatHead.surfaceGenderAnimacy (ch : CatHead) : Gender :=
+def Categorizer.Head.surfaceGenderAnimacy (ch : Categorizer.Head) : Gender :=
   match ch.phi.gender with
   | some gf => if gf.val.dim == .anim && gf.val.pol == .pos
                then .animate else .inanimate
@@ -575,29 +575,29 @@ def CatHead.surfaceGenderAnimacy (ch : CatHead) : Gender :=
 -- Verification: canonical n heads produce expected surface genders
 
 theorem set1_verification :
-    CatHead.n_iFem.surfaceGenderSet1 = .feminine ∧
-    CatHead.n_iMasc.surfaceGenderSet1 = .masculine ∧
-    CatHead.n_uFem.surfaceGenderSet1 = .feminine ∧
-    CatHead.n_plain.surfaceGenderSet1 = .masculine := ⟨rfl, rfl, rfl, rfl⟩
+    Categorizer.Head.n_iFem.surfaceGenderSet1 = .feminine ∧
+    Categorizer.Head.n_iMasc.surfaceGenderSet1 = .masculine ∧
+    Categorizer.Head.n_uFem.surfaceGenderSet1 = .feminine ∧
+    Categorizer.Head.n_plain.surfaceGenderSet1 = .masculine := ⟨rfl, rfl, rfl, rfl⟩
 
 theorem set2_verification :
-    CatHead.n_iFem.surfaceGenderSet2 = .feminine ∧
-    CatHead.n_iMasc.surfaceGenderSet2 = .masculine ∧
-    CatHead.n_uNegFem.surfaceGenderSet2 = .masculine ∧
-    CatHead.n_plain.surfaceGenderSet2 = .feminine := ⟨rfl, rfl, rfl, rfl⟩
+    Categorizer.Head.n_iFem.surfaceGenderSet2 = .feminine ∧
+    Categorizer.Head.n_iMasc.surfaceGenderSet2 = .masculine ∧
+    Categorizer.Head.n_uNegFem.surfaceGenderSet2 = .masculine ∧
+    Categorizer.Head.n_plain.surfaceGenderSet2 = .feminine := ⟨rfl, rfl, rfl, rfl⟩
 
 theorem three_gender_verification :
-    CatHead.n_iFem.surfaceGenderThree = .feminine ∧
-    CatHead.n_iMasc.surfaceGenderThree = .masculine ∧
-    CatHead.n_uFem.surfaceGenderThree = .feminine ∧
-    CatHead.n_uNegFem.surfaceGenderThree = .masculine ∧
-    CatHead.n_plain.surfaceGenderThree = .neuter := ⟨rfl, rfl, rfl, rfl, rfl⟩
+    Categorizer.Head.n_iFem.surfaceGenderThree = .feminine ∧
+    Categorizer.Head.n_iMasc.surfaceGenderThree = .masculine ∧
+    Categorizer.Head.n_uFem.surfaceGenderThree = .feminine ∧
+    Categorizer.Head.n_uNegFem.surfaceGenderThree = .masculine ∧
+    Categorizer.Head.n_plain.surfaceGenderThree = .neuter := ⟨rfl, rfl, rfl, rfl, rfl⟩
 
 theorem animacy_verification :
-    CatHead.n_iAnim.surfaceGenderAnimacy = .animate ∧
-    CatHead.n_iInanim.surfaceGenderAnimacy = .inanimate ∧
-    CatHead.n_uAnim.surfaceGenderAnimacy = .animate ∧
-    CatHead.n_plain.surfaceGenderAnimacy = .inanimate := ⟨rfl, rfl, rfl, rfl⟩
+    Categorizer.Head.n_iAnim.surfaceGenderAnimacy = .animate ∧
+    Categorizer.Head.n_iInanim.surfaceGenderAnimacy = .inanimate ∧
+    Categorizer.Head.n_uAnim.surfaceGenderAnimacy = .animate ∧
+    Categorizer.Head.n_plain.surfaceGenderAnimacy = .inanimate := ⟨rfl, rfl, rfl, rfl⟩
 
 /-! Each insertion map realizes a valued feature of its home dimension at
 its `GenderVal.surface` pole — the four patterns differ only in the
@@ -605,100 +605,100 @@ default for plain n. -/
 
 /-- On FEM-dimension bundles, Set 1 is surface realization with a
 masculine default. -/
-theorem surfaceGenderSet1_eq_surface (ch : CatHead)
+theorem surfaceGenderSet1_eq_surface (ch : Categorizer.Head)
     (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
     ch.surfaceGenderSet1 = (ch.phi.gender.map (·.val.surface)).getD .masculine := by
   cases hg : ch.phi.gender with
-  | none => simp [CatHead.surfaceGenderSet1, hg]
+  | none => simp [Categorizer.Head.surfaceGenderSet1, hg]
   | some gf =>
     obtain ⟨itp, d, pol⟩ := gf
     have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
       rw [hg]; rfl
     obtain rfl : d = .fem := h _ hmem
     cases pol <;>
-      simp [CatHead.surfaceGenderSet1, hg, GenderVal.surface,
+      simp [Categorizer.Head.surfaceGenderSet1, hg, GenderVal.surface,
         GenderDimension.positive, GenderDimension.negative]
 
 /-- On FEM-dimension bundles, Set 2 is surface realization with a
 feminine default. -/
-theorem surfaceGenderSet2_eq_surface (ch : CatHead)
+theorem surfaceGenderSet2_eq_surface (ch : Categorizer.Head)
     (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
     ch.surfaceGenderSet2 = (ch.phi.gender.map (·.val.surface)).getD .feminine := by
   cases hg : ch.phi.gender with
-  | none => simp [CatHead.surfaceGenderSet2, hg]
+  | none => simp [Categorizer.Head.surfaceGenderSet2, hg]
   | some gf =>
     obtain ⟨itp, d, pol⟩ := gf
     have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
       rw [hg]; rfl
     obtain rfl : d = .fem := h _ hmem
     cases pol <;>
-      simp [CatHead.surfaceGenderSet2, hg, GenderVal.surface,
+      simp [Categorizer.Head.surfaceGenderSet2, hg, GenderVal.surface,
         GenderDimension.positive, GenderDimension.negative]
 
 /-- On FEM-dimension bundles, the three-gender pattern is surface
 realization with a neuter default. -/
-theorem surfaceGenderThree_eq_surface (ch : CatHead)
+theorem surfaceGenderThree_eq_surface (ch : Categorizer.Head)
     (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
     ch.surfaceGenderThree = (ch.phi.gender.map (·.val.surface)).getD .neuter := by
   cases hg : ch.phi.gender with
-  | none => simp [CatHead.surfaceGenderThree, hg]
+  | none => simp [Categorizer.Head.surfaceGenderThree, hg]
   | some gf =>
     obtain ⟨itp, d, pol⟩ := gf
     have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
       rw [hg]; rfl
     obtain rfl : d = .fem := h _ hmem
     cases pol <;>
-      simp [CatHead.surfaceGenderThree, hg, GenderVal.surface,
+      simp [Categorizer.Head.surfaceGenderThree, hg, GenderVal.surface,
         GenderDimension.positive, GenderDimension.negative]
 
 /-- On ANIM-dimension bundles, the animacy pattern is surface realization
 with an inanimate default. -/
-theorem surfaceGenderAnimacy_eq_surface (ch : CatHead)
+theorem surfaceGenderAnimacy_eq_surface (ch : Categorizer.Head)
     (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .anim) :
     ch.surfaceGenderAnimacy =
       (ch.phi.gender.map (·.val.surface)).getD .inanimate := by
   cases hg : ch.phi.gender with
-  | none => simp [CatHead.surfaceGenderAnimacy, hg]
+  | none => simp [Categorizer.Head.surfaceGenderAnimacy, hg]
   | some gf =>
     obtain ⟨itp, d, pol⟩ := gf
     have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
       rw [hg]; rfl
     obtain rfl : d = .anim := h _ hmem
     cases pol <;>
-      simp [CatHead.surfaceGenderAnimacy, hg, GenderVal.surface,
+      simp [Categorizer.Head.surfaceGenderAnimacy, hg, GenderVal.surface,
         GenderDimension.positive, GenderDimension.negative]
 
 /-- Set 1 surface gender sees only what `Gender.KramerN.exponence` sees —
 interpretability is invisible at PF. -/
 theorem surfaceGenderSet1_ofKramerN (k₁ k₂ : Gender.KramerN)
     (h : k₁.exponence = k₂.exponence) :
-    (CatHead.ofKramerN k₁).surfaceGenderSet1 =
-      (CatHead.ofKramerN k₂).surfaceGenderSet1 := by
+    (Categorizer.Head.ofKramerN k₁).surfaceGenderSet1 =
+      (Categorizer.Head.ofKramerN k₂).surfaceGenderSet1 := by
   cases k₁ <;> cases k₂ <;> first | rfl | exact absurd h (by decide)
 
 /-- Set 1 and Set 2 agree on natural gender but differ on the default
 for plain n ([kramer-2015] Ch 6). -/
 theorem set1_set2_default_contrast :
-    CatHead.n_plain.surfaceGenderSet1 ≠ CatHead.n_plain.surfaceGenderSet2 := by
+    Categorizer.Head.n_plain.surfaceGenderSet1 ≠ Categorizer.Head.n_plain.surfaceGenderSet2 := by
   decide
 
 /-! ### Discourse-level gender
 
-The composites `CatHead → Gender → GenderInfo` connect the structural
+The composites `Categorizer.Head → Gender → GenderInfo` connect the structural
 encoding of gender on n with what discourse participants know about a
 referent's gender, one composite per Vocabulary-Insertion schema. -/
 
 /-- The discourse-level gender a head determines under Set 1 insertion. -/
-def CatHead.toGenderInfoSet1 (ch : CatHead) : GenderInfo :=
+def Categorizer.Head.toGenderInfoSet1 (ch : Categorizer.Head) : GenderInfo :=
   ch.surfaceGenderSet1.toGenderInfo
 
-def CatHead.toGenderInfoSet2 (ch : CatHead) : GenderInfo :=
+def Categorizer.Head.toGenderInfoSet2 (ch : Categorizer.Head) : GenderInfo :=
   ch.surfaceGenderSet2.toGenderInfo
 
-def CatHead.toGenderInfoThree (ch : CatHead) : GenderInfo :=
+def Categorizer.Head.toGenderInfoThree (ch : Categorizer.Head) : GenderInfo :=
   ch.surfaceGenderThree.toGenderInfo
 
-def CatHead.toGenderInfoAnimacy (ch : CatHead) : GenderInfo :=
+def Categorizer.Head.toGenderInfoAnimacy (ch : Categorizer.Head) : GenderInfo :=
   ch.surfaceGenderAnimacy.toGenderInfo
 
 /-- The composition always yields `.known _` — a DM categorizer head
@@ -706,11 +706,11 @@ def CatHead.toGenderInfoAnimacy (ch : CatHead) : GenderInfo :=
     unspecified at the discourse level when the morphosyntax is fully
     resolved. Gender underspecification ([arnold-2026]) arises
     from the discourse, not from the grammar. -/
-theorem catHead_gender_always_known_set1 (ch : CatHead) :
+theorem catHead_gender_always_known_set1 (ch : Categorizer.Head) :
     ∃ g, ch.toGenderInfoSet1 = .known g := by
   exact ⟨ch.surfaceGenderSet1, rfl⟩
 
-theorem catHead_gender_always_known_three (ch : CatHead) :
+theorem catHead_gender_always_known_three (ch : Categorizer.Head) :
     ∃ g, ch.toGenderInfoThree = .known g := by
   exact ⟨ch.surfaceGenderThree, rfl⟩
 

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Semantics.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Semantics.lean
@@ -19,7 +19,7 @@ stated over `Semantics/Possessive/`.
 * `NSemanticType` — relational, sortal, alienator
 * `nBodyPartDenot`, `nSortalDenot`, `nAlienatorDenot` — the three head
   denotations
-* `catHeadSemanticType` — the semantic type read off a `CatHead`
+* `catHeadSemanticType` — the semantic type read off a `Categorizer.Head`
 
 ## Main statements
 
@@ -53,7 +53,7 @@ inductive NSemanticType where
   deriving DecidableEq, Repr
 
 /-- The semantic type read off a head's features. -/
-def catHeadSemanticType (ch : CatHead) (mediatesAPossession : Bool := false)
+def catHeadSemanticType (ch : Categorizer.Head) (mediatesAPossession : Bool := false)
     : NSemanticType :=
   if ch.selectsD then .relational
   else if mediatesAPossession then .alienator
@@ -98,7 +98,7 @@ theorem nAlienatorDenot_is_ex_flipped {E S : Type}
   simp only [nAlienatorDenot, Ex]
 
 /-- An n head has {D} iff its semantic type is relational. -/
-theorem selectsD_iff_relational (ch : CatHead) :
+theorem selectsD_iff_relational (ch : Categorizer.Head) :
     ch.selectsD = true ↔
     catHeadSemanticType ch = .relational := by
   unfold catHeadSemanticType
@@ -157,7 +157,7 @@ end TeopExample
 
 /-! The Barker–Adamson correspondence:
 
-| CatHead feature           | Semantic type | Barker operation |
+| Categorizer.Head feature           | Semantic type | Barker operation |
 |----------------------------|---------------|------------------|
 | selectsD = true            | relational    | π                |
 | selectsD = false (regular) | sortal        | bare             |

--- a/Linglib/Morphology/DistributedMorphology/NominalStructure.lean
+++ b/Linglib/Morphology/DistributedMorphology/NominalStructure.lean
@@ -114,7 +114,7 @@ theorem glh_root_and_n_local :
     ([adamson-2024], following [myler-2016]).
 
     - **Inalienable** (iPossession): possessor introduced in Spec,nP.
-      The n head bears a selectional feature {D} (`CatHead.selectsD`).
+      The n head bears a selectional feature {D} (`Categorizer.Head.selectsD`).
       Semantically introduces a body-part-of / part-whole relation.
     - **Alienable** (aPossession): possessor introduced in Spec,PossP,
       mediated by a Poss head. Requires additional morphological marking

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -49,7 +49,7 @@ cannot affect gender assignment.
 ## Connection to Linglib
 
 This module uses types from `Morphology/DistributedMorphology/NominalStructure.lean`
-(the GLH, `NominalPosition`, `PossessionType`), `CatHead` and `PhiBundle`
+(the GLH, `NominalPosition`, `PossessionType`), `Head` and `PhiBundle`
 from `Morphology/DistributedMorphology/Categorizer.lean` ([kramer-2015]),
 `VocabItem` from `Morphology/DistributedMorphology/VocabularyInsertion.lean`,
 and Fragment data from `Fragments/Teop/Nouns.lean` and
@@ -59,15 +59,16 @@ and Fragment data from `Fragments/Teop/Nouns.lean` and
 namespace Adamson2024
 
 open DistributedMorphology
+open DistributedMorphology.Categorizer (Head)
 open DistributedMorphology.VI
 open Minimalist
 
 -- ============================================================================
--- § 1: GLH + CatHead Bridge
+-- § 1: GLH + Head Bridge
 -- ============================================================================
 
 /-- An n head with selectsD licenses an iPossessor in Spec,nP.
-    This connects `CatHead.selectsD` to the GLH: the {D} feature
+    This connects `Head.selectsD` to the GLH: the {D} feature
     places the possessor nP-internally, making it gender-relevant. -/
 theorem selectsD_implies_local_possessor :
     PossessionType.inalienable.possessorPosition = .specN ∧
@@ -76,23 +77,23 @@ theorem selectsD_implies_local_possessor :
 /-- Gender features live on the nominal categorizer (n), as established
     by [kramer-2015] and confirmed by [adamson-2024]. -/
 theorem categorizer_has_gender_locus :
-    CatHead.n_iFem.phi.gender.isSome = true ∧
-    CatHead.n_iMasc.phi.gender.isSome = true ∧
-    CatHead.n_uFem.phi.gender.isSome = true ∧
-    CatHead.n_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl, rfl⟩
+    Head.n_iFem.phi.gender.isSome = true ∧
+    Head.n_iMasc.phi.gender.isSome = true ∧
+    Head.n_uFem.phi.gender.isSome = true ∧
+    Head.n_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- The ANIM-dimension types also carry gender features on n. -/
 theorem anim_categorizer_has_gender :
-    CatHead.n_iAnim.phi.gender.isSome = true ∧
-    CatHead.n_iInanim.phi.gender.isSome = true ∧
-    CatHead.n_uAnim.phi.gender.isSome = true := ⟨rfl, rfl, rfl⟩
+    Head.n_iAnim.phi.gender.isSome = true ∧
+    Head.n_iInanim.phi.gender.isSome = true ∧
+    Head.n_uAnim.phi.gender.isSome = true := ⟨rfl, rfl, rfl⟩
 
 /-- The GLH targets the nominal categorizer specifically. Verbal and
     adjectival categorizers do not host gender features. -/
 theorem glh_targets_nominal_categorizer :
-    CatHead.n_plain.cat = .n ∧
-    CatHead.v_plain.phi.gender.isNone = true ∧
-    CatHead.a_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl⟩
+    Head.n_plain.categorizer = .n ∧
+    Head.v_plain.phi.gender.isNone = true ∧
+    Head.a_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl⟩
 
 
 -- ============================================================================
@@ -103,16 +104,16 @@ theorem glh_targets_nominal_categorizer :
     When a body-part root combines with this n, the {D} feature creates
     a specifier position for an iPossessor DP. The u[+ANIM] feature
     results in gender I (animate article *a*). -/
-def teopBodyPartN : CatHead :=
+def teopBodyPartN : Head :=
   .iPoss { gender := some ⟨.u, ⟨.anim, .pos⟩⟩ }
 
 /-- Teop alienator n: plain n with no gender feature and no iPossessor. -/
-def teopAlienatorN : CatHead := CatHead.n_plain
+def teopAlienatorN : Head := Head.n_plain
 
 /-- Determine gender from the n head's feature content.
     If n has any [ANIM]-dimension gender feature → gender I;
     otherwise → gender II. -/
-def teopGenderFromN (nh : CatHead) : Teop.Gender :=
+def teopGenderFromN (nh : Head) : Teop.Gender :=
   match nh.phi.gender with
   | some gf => if gf.val.dim == .anim then .gI else .gII
   | none    => .gII
@@ -229,27 +230,27 @@ theorem teop_prediction_kinship_alienator :
 -- ============================================================================
 
 /-- Jarawara gender from the n head's feature content. -/
-def jarawaraGenderFromN (nh : CatHead) : Bool :=  -- true = masculine
+def jarawaraGenderFromN (nh : Head) : Bool :=  -- true = masculine
   match nh.phi.gender with
   | some gf => gf.val.dim == .masc
   | none    => false  -- feminine (unmarked)
 
 /-- The n head for Jarawara iPossessable nouns: has {D} (licenses iPossessor
     in Spec,nP) but no gender feature (feminine = unmarked in the [±MASC]
-    system). This is distinct from `CatHead.n_plain` (which has selectsD = false). -/
-def jarawaraIPossN : CatHead := .iPoss
+    system). This is distinct from `Head.n_plain` (which has selectsD = false). -/
+def jarawaraIPossN : Head := .iPoss
 
 /-- iPossessable roots in Jarawara are feminine: their n has no marked gender. -/
 theorem jarawara_ipossessable_always_fem :
     jarawaraGenderFromN jarawaraIPossN = false := rfl
 
-/-- iPossessable n in Jarawara has {D} — by construction via `CatHead.iPoss`. -/
+/-- iPossessable n in Jarawara has {D} — by construction via `Head.iPoss`. -/
 theorem jarawara_ipossessable_selectsD :
     jarawaraIPossN.selectsD = true := rfl
 
 /-- Masculine nouns in Jarawara bear [+MASC] on n. -/
 theorem jarawara_masc_has_feature :
-    jarawaraGenderFromN CatHead.n_uMasc = true := rfl
+    jarawaraGenderFromN Head.n_uMasc = true := rfl
 
 /-! ### Jarawara impoverishment ([adamson-2024] ex. 63)
 
@@ -362,7 +363,7 @@ structure InheritedGenderNoun where
     dimension or polarity. Its value (including dimension) comes entirely
     from the iPossessor DP via Probe-Goal Agree ([adamson-2024] (90)).
     We represent this as `phi := {}` (no valued gender on n itself). -/
-def inheritedGenderN : CatHead := .iPoss
+def inheritedGenderN : Head := .iPoss
 
 /-- Yanyuwa: seven gender classes (Kirton 1971a,b).
 
@@ -429,7 +430,7 @@ Two-gender systems arise when only one marked value + plain are attested. -/
     Two n heads produce the same surface gender iff they have the same
     gender feature content (ignoring interpretability, which is only
     visible at LF vs PF). -/
-def surfaceGenderClass (nh : CatHead) : Option GenderVal :=
+def surfaceGenderClass (nh : Head) : Option GenderVal :=
   nh.phi.gender.map (·.val)
 
 /-- The four Amharic n-types yield exactly 3 surface genders:
@@ -437,19 +438,19 @@ def surfaceGenderClass (nh : CatHead) : Option GenderVal :=
     the same surface class [+FEM]. -/
 theorem amharic_three_surface_genders :
     let classes :=
-      [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain, CatHead.n_uFem].map
+      [Head.n_iFem, Head.n_iMasc, Head.n_plain, Head.n_uFem].map
         surfaceGenderClass
     classes.eraseDups.length = 3 := by native_decide
 
 /-- A two-gender system (e.g., Jarawara [±MASC]) uses only two n types:
     marked (u[+MASC]) and plain. -/
 theorem two_gender_system :
-    let classes := [CatHead.n_uMasc, CatHead.n_plain].map surfaceGenderClass
+    let classes := [Head.n_uMasc, Head.n_plain].map surfaceGenderClass
     classes.eraseDups.length = 2 := by native_decide
 
 /-- The Teop two-gender system uses the ANIM dimension. -/
 theorem teop_two_gender_system :
-    let classes := [CatHead.n_uAnim, CatHead.n_plain].map surfaceGenderClass
+    let classes := [Head.n_uAnim, Head.n_plain].map surfaceGenderClass
     classes.eraseDups.length = 2 := by native_decide
 
 -- ============================================================================
@@ -460,13 +461,13 @@ theorem teop_two_gender_system :
 Without this, the n-head cannot license an iPossessor in Spec,nP, and the
 semantic pipeline (`catHeadSemanticType`) will compute sortal instead of
 relational. This invariant was violated before 0.229.208 (Jarawara used
-`CatHead.n_plain` which has selectsD = false). -/
+`Head.n_plain` which has selectsD = false). -/
 
 /-- All iPossessable n-heads across all four languages have selectsD = true.
     Regression test: adding a new iPossessable n-head? Add it to the
     disjunction here. If it fails, the n-head is missing {D}. -/
 theorem ipossessable_n_heads_have_selectsD
-    (nh : CatHead) (h : nh = teopBodyPartN ∨ nh = jarawaraIPossN ∨ nh = inheritedGenderN) :
+    (nh : Head) (h : nh = teopBodyPartN ∨ nh = jarawaraIPossN ∨ nh = inheritedGenderN) :
     nh.selectsD = true := by
   rcases h with rfl | rfl | rfl <;> rfl
 
@@ -476,11 +477,11 @@ theorem ipossessable_n_heads_have_selectsD
 
 /-! ### Two derivation pipelines from a single n-head
 
-A CatHead determines two things in parallel:
+A Head determines two things in parallel:
 
 ```
            ┌──→ gender ──→ article form   (PF pipeline)
-CatHead ──┤
+Head ──┤
            └──→ NSemanticType ──→ can take possessor?   (semantic pipeline)
 ```
 
@@ -500,15 +501,15 @@ open DistributedMorphology.CategorizerSemantics
 /-- The PF derivation pipeline: n-head → gender → article.
     Gender is an intermediate value computed from φ-features, then fed
     into VI as part of the article context. -/
-def teopPFDerive (nh : CatHead) (pl proprial : Bool := false) : Option String :=
+def teopPFDerive (nh : Head) (pl proprial : Bool := false) : Option String :=
   let gender := teopGenderFromN nh
   vocabularyInsert teopArticleRules ⟨gender, pl, proprial⟩ ()
 
 /-- The semantic derivation pipeline: n-head → semantic type → possessor capability.
     The semantic type is an intermediate value, fed into Barker's type classification
     to determine whether the noun can directly take a possessor.
-    Generic over any CatHead — not Teop-specific despite the examples below. -/
-def canTakePossessorSem (nh : CatHead) (mediatesAPoss : Bool := false) : Bool :=
+    Generic over any Head — not Teop-specific despite the examples below. -/
+def canTakePossessorSem (nh : Head) (mediatesAPoss : Bool := false) : Bool :=
   let semType := catHeadSemanticType nh (mediatesAPossession := mediatesAPoss)
   semType.toBarker.canTakePossessor
 
@@ -531,7 +532,7 @@ theorem sem_alienator : canTakePossessorSem teopAlienatorN = false := rfl
     consequences of the same structural feature (selectsD on n).
 
     Stated as a Bool identity: "is gender I" = "can take possessor". -/
-theorem pf_semantic_correlation (nh : CatHead)
+theorem pf_semantic_correlation (nh : Head)
     (h : nh = teopBodyPartN ∨ nh = teopAlienatorN) :
     (teopGenderFromN nh == .gI) = canTakePossessorSem nh := by
   rcases h with rfl | rfl <;> rfl

--- a/Linglib/Studies/AkinboFwangwar2026.lean
+++ b/Linglib/Studies/AkinboFwangwar2026.lean
@@ -663,24 +663,24 @@ theorem mwaghavul_is_tonal_hyman :
 open DistributedMorphology
 
 /-- The verbaliser produces verbal category. -/
-def verbalizerCat : CatHead := CatHead.v_plain
+def verbalizer : Categorizer.Head := Categorizer.Head.v_plain
 
-theorem verbalizer_is_verbal : verbalizerCat.cat = .v := rfl
+theorem verbalizer_is_verbal : verbalizer.categorizer = .v := rfl
 
 /-- Denominal verb derivation (n → v): the ideophonic base categorized
     by n, recategorized by the tonal verbalizer — [v [n √]] is v-headed
     over an n-headed inner layer, with the base root untouched. -/
 theorem denominal_ideophone_verb (r : DistributedMorphology.Root) :
-    Headed (categorize verbalizerCat (categorize CatHead.n_plain (ofRoot r)))
-      verbalizerCat ∧
-    roots (categorize verbalizerCat (categorize CatHead.n_plain (ofRoot r)))
+    Headed (categorize verbalizer (categorize Categorizer.Head.n_plain (ofRoot r)))
+      verbalizer ∧
+    roots (categorize verbalizer (categorize Categorizer.Head.n_plain (ofRoot r)))
       = {r} :=
   ⟨.categorize .., by rw [roots_categorize, roots_categorize, roots_ofRoot]⟩
 
 /-- Deadjectival verb derivation (a → v): [v [a √]]. -/
 theorem deadjectival_ideophone_verb (r : DistributedMorphology.Root) :
-    Headed (categorize verbalizerCat (categorize CatHead.a_plain (ofRoot r)))
-      verbalizerCat :=
+    Headed (categorize verbalizer (categorize Categorizer.Head.a_plain (ofRoot r)))
+      verbalizer :=
   .categorize ..
 
 -- ============================================================================

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -901,7 +901,7 @@ intruder is morphosyntactically available to fill the templatic slot.
 Sections 1–11 verify the prosodic side of the analysis (intrusion
 satisfies the template without violating \*Misalignment). This
 section verifies the *morphological* side by formalizing the Faust
-claim as a predicate on Kramer's `CatHead`:
+claim as a predicate on Kramer's `Categorizer.Head`:
 
 > Intrusion is licensed iff the categorizer is `n` and carries a
 > gender feature.
@@ -909,21 +909,21 @@ claim as a predicate on Kramer's `CatHead`:
 Once that predicate is in place, the verbal/nominal asymmetry is no
 longer a docstring stipulation — it falls out by `rfl` from
 `TemplateMatch.intrusionLicensed` applied to the per-template
-`CatHead` tags, and breaks if either Faust's morphological claim or
-Kramer's `CatHead` taxonomy changes. -/
+`Categorizer.Head` tags, and breaks if either Faust's morphological claim or
+Kramer's `Categorizer.Head` taxonomy changes. -/
 
-open DistributedMorphology (CatHead)
+open DistributedMorphology (Categorizer.Head)
 
-/-! The morphological-licensing predicate `CatHead.licensesIntrusion`
+/-! The morphological-licensing predicate `Categorizer.Head.licensesIntrusion`
 itself lives in `Morphology/DistributedMorphology/Categorizer.lean` (alongside
 the Kramer taxonomy it ranges over), together with its per-canonical-
 head verification theorems (`n_uFem_licenses_intrusion`,
 `v_plain_blocks_intrusion`, etc.) and the iff characterization
 `DistributedMorphology.licensesIntrusion_iff_n_and_gen`. The Faust-specific
-content of §12 is the *per-template `CatHead` tagging* and the
+content of §12 is the *per-template `Categorizer.Head` tagging* and the
 per-derivation verdicts below. -/
 
-/-! #### Per-template `CatHead` tags
+/-! #### Per-template `Categorizer.Head` tags
 
 Faust's analysis assigns each templatic morphology slot to a specific
 categorizer head. These are the morphosyntactic claims; the
@@ -932,31 +932,31 @@ intrusion-licensing predictions follow mechanically. -/
 /-- Hebrew PST.3MSG `CaCaC[+c]` is realized at v (verbal categorizer);
     gender lives on the Agr head outside the template, so v itself
     has no gender-bearing exponent to intrude. -/
-def hebrewPst3msg_locus : CatHead := CatHead.v_plain
+def hebrewPst3msg_locus : Categorizer.Head := Categorizer.Head.v_plain
 
 /-- Hebrew passive participle `CaCuC` is also v-realized. -/
-def hebrewPassPrtcpl_locus : CatHead := CatHead.v_plain
+def hebrewPassPrtcpl_locus : Categorizer.Head := Categorizer.Head.v_plain
 
 /-- Hebrew taQTiL[+c] is a feminine deverbal noun realized at n[+gen]
     (the u[+FEM] head in Kramer's Set 1 taxonomy — the source of the
     intruding /t/). -/
-def hebrewTaQTiL_locus : CatHead := CatHead.n_uFem
+def hebrewTaQTiL_locus : Categorizer.Head := Categorizer.Head.n_uFem
 
 /-- Amharic PFV.3MSG `CäC.CäC[+c]` is v-realized. -/
-def amharicPfv3msg_locus : CatHead := CatHead.v_plain
+def amharicPfv3msg_locus : Categorizer.Head := Categorizer.Head.v_plain
 
 /-- Amharic gerund `CäC.C[+c]-o` is a deverbal nominal at n[+gen]. -/
-def amharicGrnd_locus : CatHead := CatHead.n_uFem
+def amharicGrnd_locus : Categorizer.Head := Categorizer.Head.n_uFem
 
 /-- Amharic infinitive `mä-CVCVC[+c]` is also a deverbal nominal at
     n[+gen] — confirmed by the (13a) [t]-intrusion in [mäsmat].
     [faust-2026]'s analysis treats Amharic infinitives as
     nominalizations whose template is hosted on n. -/
-def amharicInf_locus : CatHead := CatHead.n_uFem
+def amharicInf_locus : Categorizer.Head := Categorizer.Head.n_uFem
 
 /-! #### Universal licensing structure (Faust + Kramer)
 
-The Faust-`CatHead` interaction is governed by a single structural
+The Faust-`Categorizer.Head` interaction is governed by a single structural
 fact, derivable by composing `intrusionLicensed_iff`
 (the template section above) with `licensesIntrusion_iff_n_and_gen`
 (Categorizer.lean). The per-derivation `decide` theorems below and the
@@ -964,7 +964,7 @@ end-of-section `verbal_nominal_asymmetry_from_kramer` bundle are all
 instances of this universal claim. -/
 
 /-- **The Faust+Kramer integration theorem.** A `TemplateMatch`
-    passes intrusion-licensing under a `CatHead` iff either the match
+    passes intrusion-licensing under a `Categorizer.Head` iff either the match
     is intruder-free OR the head is a gender-bearing nominal (n[+gen],
     in [kramer-2020]'s sense).
 
@@ -972,9 +972,9 @@ instances of this universal claim. -/
     every per-derivation verdict in §12 reduces to checking which
     disjunct holds for the specific (match, head) pair. -/
 theorem intrusion_wellformed_iff_no_intruder_or_n_with_gen
-    (m : TemplateMatch String) (ch : CatHead) :
+    (m : TemplateMatch String) (ch : Categorizer.Head) :
     m.intrusionLicensed ch.licensesIntrusion ↔
-      ¬ m.hasIntruder ∨ (ch.cat = .n ∧ ch.phi.gender.isSome = true) := by
+      ¬ m.hasIntruder ∨ (ch.categorizer = .n ∧ ch.phi.gender.isSome = true) := by
   rw [intrusionLicensed_iff]
   constructor
   · rintro (hlic | hno)
@@ -990,7 +990,7 @@ theorem intrusion_wellformed_iff_no_intruder_or_n_with_gen
     to be morphologically licensed — the spreading and empty-slot
     strategies are the only options open to v. -/
 theorem v_plain_licenses_iff_no_intruder (m : TemplateMatch String) :
-    m.intrusionLicensed CatHead.v_plain.licensesIntrusion ↔
+    m.intrusionLicensed Categorizer.Head.v_plain.licensesIntrusion ↔
       ¬ m.hasIntruder := by
   rw [intrusion_wellformed_iff_no_intruder_or_n_with_gen]
   constructor
@@ -1005,14 +1005,14 @@ theorem v_plain_licenses_iff_no_intruder (m : TemplateMatch String) :
     like Hebrew taQTiL and Amharic gerunds/INFs — the Kramer-2020
     structure makes the n[+gen] exponent morphosyntactically present. -/
 theorem n_uFem_licenses_universally (m : TemplateMatch String) :
-    m.intrusionLicensed CatHead.n_uFem.licensesIntrusion := by
+    m.intrusionLicensed Categorizer.Head.n_uFem.licensesIntrusion := by
   rw [intrusion_wellformed_iff_no_intruder_or_n_with_gen]
   exact Or.inr ⟨rfl, rfl⟩
 
 /-! #### Per-derivation licensing theorems
 
 For every match, the predicate `TemplateMatch.intrusionLicensed`
-applied to the corresponding template's `CatHead.licensesIntrusion`
+applied to the corresponding template's `Categorizer.Head.licensesIntrusion`
 gives the well-formedness verdict. The proofs are `decide` — the
 disjunction reduces by `rfl` once the predicates evaluate. -/
 
@@ -1107,7 +1107,7 @@ theorem hebrew_pst3msg_intrusion_morphologically_blocked :
 /-! #### The cross-paper integration theorem -/
 
 /-- The verbal/nominal asymmetry of [faust-2026] (11), derived
-    from [kramer-2020]'s `CatHead` taxonomy:
+    from [kramer-2020]'s `Categorizer.Head` taxonomy:
 
     1. **Intrusion is licensed at n[+gen] (here `n_uFem`).** Both
        Hebrew taQTiL [tadmit] and the hypothetical verbal-template
@@ -1125,7 +1125,7 @@ theorem hebrew_pst3msg_intrusion_morphologically_blocked :
 
     The asymmetry is therefore *derived* — not stipulated — from the
     composition of two independent claims: Faust's licensing
-    predicate (only n with [+gen]) and Kramer's `CatHead` structure
+    predicate (only n with [+gen]) and Kramer's `Categorizer.Head` structure
     (n vs. v). -/
 theorem verbal_nominal_asymmetry_from_kramer :
     -- Nominal locus licenses intrusion candidates

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -44,7 +44,7 @@ set_option autoImplicit false
 namespace KonnellyCowper2020
 
 open DistributedMorphology (Contrastivity GenderFeature GenderVal GenderDimension
-  Polarity Interpretability CatHead PhiBundle)
+  Polarity Interpretability Categorizer.Head PhiBundle)
 open DistributedMorphology.VI (FeatureVI subsetPrinciple)
 
 -- ============================================================================
@@ -346,7 +346,7 @@ theorem stage1_they_restricted :
     independent [MASC] and [FEM], while [kramer-2015] uses [±FEM]
     with polarity. For English pronoun VI, these are equivalent: K&C's
     [FEM] = Kramer's [+FEM], K&C's [MASC] = Kramer's [−FEM]. -/
-def catHeadToPronFeatures (ch : CatHead) : List PronFeature :=
+def catHeadToPronFeatures (ch : Categorizer.Head) : List PronFeature :=
   match ch.phi.gender with
   | some gf =>
     match gf.val with
@@ -361,19 +361,19 @@ def catHeadToPronFeatures (ch : CatHead) : List PronFeature :=
     Elsewhere Condition. -/
 theorem iFem_singular_yields_she :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures CatHead.n_iFem) = some "she" := by
+      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iFem) = some "she" := by
   decide
 
 /-- n i[−FEM] (masculine natural gender) → "he". -/
 theorem iMasc_singular_yields_he :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures CatHead.n_iMasc) = some "he" := by
+      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iMasc) = some "he" := by
   decide
 
 /-- n i[−ANIM] (inanimate) → "it". -/
 theorem iInanim_singular_yields_it :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures CatHead.n_iInanim) = some "it" := by
+      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iInanim) = some "it" := by
   decide
 
 /-- Plain n (no gender feature) → "they" (elsewhere).
@@ -381,7 +381,7 @@ theorem iInanim_singular_yields_it :
     what VI produces when the n-head lacks a gender feature. -/
 theorem plain_n_singular_yields_they :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures CatHead.n_plain) = some "they" := by
+      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_plain) = some "they" := by
   decide
 
 -- ============================================================================
@@ -411,7 +411,7 @@ open Minimalist (fValue allCategoryConsistent allFMonotone catFamily)
     [borer-2005]'s full nominal spine N → n → Q → Num → D. -/
 structure PronDP where
   /-- The categorizing head n, bearing gender and animacy features. -/
-  nHead : CatHead
+  nHead : Categorizer.Head
   /-- Whether the Num head bears [SG] (singular number). -/
   singular : Bool
   /-- Whether D hosts a quantifier (relevant for bound-variable pronouns
@@ -441,36 +441,36 @@ def PronDP.spellout (ns : PronDP) : Option String :=
 
 /-- A singular feminine nominal (n i[+FEM], Num [SG]) → "she". -/
 theorem singular_feminine_spellout :
-    ({ nHead := CatHead.n_iFem, singular := true : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_iFem, singular := true : PronDP }).spellout
       = some "she" := by decide
 
 /-- A singular masculine nominal (n i[−FEM], Num [SG]) → "he". -/
 theorem singular_masculine_spellout :
-    ({ nHead := CatHead.n_iMasc, singular := true : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_iMasc, singular := true : PronDP }).spellout
       = some "he" := by decide
 
 /-- A singular inanimate nominal (n i[−ANIM], Num [SG]) → "it". -/
 theorem singular_inanimate_spellout :
-    ({ nHead := CatHead.n_iInanim, singular := true : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_iInanim, singular := true : PronDP }).spellout
       = some "it" := by decide
 
 /-- A singular nominal with plain n (no gender, Num [SG]) → "they".
     The DP structure DETERMINES the elsewhere outcome — plain n projects
     no gender feature, so the Subset Principle selects the elsewhere VI. -/
 theorem singular_ungendered_spellout :
-    ({ nHead := CatHead.n_plain, singular := true : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_plain, singular := true : PronDP }).spellout
       = some "they" := by decide
 
 /-- A plural nominal (no [SG]) → "they" (elsewhere). -/
 theorem plural_spellout :
-    ({ nHead := CatHead.n_plain, singular := false : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_plain, singular := false : PronDP }).spellout
       = some "they" := by decide
 
 /-- A quantifier-bound singular nominal with plain n → "they".
     The `isQuantifier` flag records the D-head status but does not
     affect VI: feature projection reads n and Num, not D content. -/
 theorem quantifier_bound_spellout :
-    ({ nHead := CatHead.n_plain, singular := true,
+    ({ nHead := Categorizer.Head.n_plain, singular := true,
        isQuantifier := true : PronDP }).spellout
       = some "they" := by decide
 
@@ -513,7 +513,7 @@ theorem kc14_spine_nominal :
     contexts, not the syntactic architecture itself. -/
 theorem stage3_they_from_structure (ctx : ReferentContext) :
     genderObligatoryFor ctx .stage3 = false ∧
-    ({ nHead := CatHead.n_plain, singular := true : PronDP }).spellout
+    ({ nHead := Categorizer.Head.n_plain, singular := true : PronDP }).spellout
       = some "they" :=
   ⟨by cases ctx <;> rfl, by decide⟩
 

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -462,7 +462,7 @@ structure SameRootNominal where
   /-- Language -/
   language : String
   /-- Possible gender assignments (> 1 for same-root nominals) -/
-  possibleNHeads : List CatHead
+  possibleNHeads : List Categorizer.Head
   deriving Repr
 
 /-- Whether this is a genuine same-root nominal (multiple n options). -/
@@ -474,7 +474,7 @@ def SameRootNominal.isSameRoot (n : SameRootNominal) : Bool :=
 def amharicHakim : SameRootNominal :=
   { form := "hakim"
     language := "Amharic"
-    possibleNHeads := [CatHead.n_iFem, CatHead.n_iMasc] }
+    possibleNHeads := [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc] }
 
 theorem hakim_is_same_root : amharicHakim.isSameRoot = true := rfl
 
@@ -486,7 +486,7 @@ theorem same_root_two_n_heads :
 
 /-- The two n heads for *hakim* are distinct gender features. -/
 theorem hakim_distinct_genders :
-    CatHead.n_iFem ≠ CatHead.n_iMasc := by decide
+    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_iMasc := by decide
 
 -- ============================================================================
 -- § 7: Hybrid Nouns ([kramer-2020] §2.2.3, §3.3.2)
@@ -558,7 +558,7 @@ theorem hybrid_nouns_favor_structural :
     Mangarayi 3). -/
 structure NInventory where
   language : String
-  nHeads : List CatHead
+  nHeads : List Categorizer.Head
   surfaceGenders : Nat
   deriving Repr
 
@@ -574,48 +574,48 @@ def NInventory.purelySemanticGender (inv : NInventory) : Bool :=
 -- 3-n languages: no u-feature ([kramer-2015] Ch 5)
 
 def dieriNs : NInventory :=
-  ⟨"Dieri", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain], 2⟩
+  ⟨"Dieri", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain], 2⟩
 
 def mangarayiNs : NInventory :=
-  ⟨"Mangarayi", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain], 3⟩
+  ⟨"Mangarayi", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain], 3⟩
 
 -- 4-n languages, Set 1: u[+FEM] ([kramer-2015] Ch 6)
 
 def amharicNs : NInventory :=
-  ⟨"Amharic", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-               CatHead.n_uFem], 2⟩
+  ⟨"Amharic", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+               Categorizer.Head.n_uFem], 2⟩
 
 def spanishNs : NInventory :=
-  ⟨"Spanish", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-               CatHead.n_uFem], 2⟩
+  ⟨"Spanish", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+               Categorizer.Head.n_uFem], 2⟩
 
 def hausaNs : NInventory :=
-  ⟨"Hausa", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-             CatHead.n_uFem], 2⟩
+  ⟨"Hausa", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+             Categorizer.Head.n_uFem], 2⟩
 
 -- 4-n languages, Set 2: u[−FEM] ([kramer-2015] Ch 6)
 
 def maaNs : NInventory :=
-  ⟨"Maa", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-           CatHead.n_uNegFem], 2⟩
+  ⟨"Maa", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+           Categorizer.Head.n_uNegFem], 2⟩
 
 -- 3-n languages with animacy features ([kramer-2015] Ch 5, §5.3)
 
 def lealaoNs : NInventory :=
-  ⟨"Lealao Chinantec", [CatHead.n_iAnim, CatHead.n_iInanim,
-                         CatHead.n_plain], 2⟩
+  ⟨"Lealao Chinantec", [Categorizer.Head.n_iAnim, Categorizer.Head.n_iInanim,
+                         Categorizer.Head.n_plain], 2⟩
 
 -- 4-n languages, animacy dimension ([kramer-2015] Ch 6, §6.4)
 
 def ojibweNs : NInventory :=
-  ⟨"Ojibwe", [CatHead.n_iAnim, CatHead.n_iInanim, CatHead.n_plain,
-              CatHead.n_uAnim], 2⟩
+  ⟨"Ojibwe", [Categorizer.Head.n_iAnim, Categorizer.Head.n_iInanim, Categorizer.Head.n_plain,
+              Categorizer.Head.n_uAnim], 2⟩
 
 -- 5-n languages ([kramer-2015] Ch 7)
 
 def lavukaleveNs : NInventory :=
-  ⟨"Lavukaleve", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-                  CatHead.n_uFem, CatHead.n_uNegFem], 3⟩
+  ⟨"Lavukaleve", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+                  Categorizer.Head.n_uFem, Categorizer.Head.n_uNegFem], 3⟩
 
 /-- Same n inventory, different surface genders: Dieri (2) vs Mangarayi (3).
     This demonstrates that surface gender count depends on VI, not the
@@ -673,7 +673,7 @@ open Spanish.Gender (SpanishNoun SameRootEntry)
     (Spanish is the canonical Set 1 language per [kramer-2015]
     Ch. 6, alongside Amharic). The four cells of (attestedGender ×
     isNaturalGender) cover the four Set-1 n-heads. -/
-def nHead (n : SpanishNoun) : CatHead :=
+def nHead (n : SpanishNoun) : Categorizer.Head :=
   match n.attestedGender, n.isNaturalGender with
   | .feminine,  true  => .n_iFem
   | .masculine, true  => .n_iMasc
@@ -684,8 +684,8 @@ def nHead (n : SpanishNoun) : CatHead :=
 /-- Same-root nominals project to BOTH possible n-heads (the polymorphic
     same-root pattern [kramer-2015] §3.4 / [kramer-2020]
     §2.2.3). The framework decision lives here, not in the Fragment. -/
-def sameRootNHeads (_ : SameRootEntry) : List CatHead :=
-  [CatHead.n_iFem, CatHead.n_iMasc]
+def sameRootNHeads (_ : SameRootEntry) : List Categorizer.Head :=
+  [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc]
 
 end Spanish
 
@@ -698,7 +698,7 @@ open Russian.Gender (RussianNoun)
     binary), so the (attestedGender × isNaturalGender) cells project to
     five n-heads: i[+FEM], i[−FEM], u[+FEM], u[−FEM], plain n.
     Verified against [kramer-2015] Ch. 7. -/
-def nHead (n : RussianNoun) : CatHead :=
+def nHead (n : RussianNoun) : Categorizer.Head :=
   match n.attestedGender, n.isNaturalGender with
   | .feminine,  true  => .n_iFem
   | .masculine, true  => .n_iMasc
@@ -758,10 +758,10 @@ theorem spanish_four_n_types :
 
 /-- The fragment inventory covers all four Set-1 n-types via projection. -/
 theorem spanish_fragment_covers_inventory :
-    Spanish.Gender.allNouns.any (Spanish.nHead · == CatHead.n_iFem) ∧
-    Spanish.Gender.allNouns.any (Spanish.nHead · == CatHead.n_iMasc) ∧
-    Spanish.Gender.allNouns.any (Spanish.nHead · == CatHead.n_uFem) ∧
-    Spanish.Gender.allNouns.any (Spanish.nHead · == CatHead.n_plain) := by
+    Spanish.Gender.allNouns.any (Spanish.nHead · == Categorizer.Head.n_iFem) ∧
+    Spanish.Gender.allNouns.any (Spanish.nHead · == Categorizer.Head.n_iMasc) ∧
+    Spanish.Gender.allNouns.any (Spanish.nHead · == Categorizer.Head.n_uFem) ∧
+    Spanish.Gender.allNouns.any (Spanish.nHead · == Categorizer.Head.n_plain) := by
   decide
 
 -- ============================================================================
@@ -799,12 +799,12 @@ inductive RootClass where
   deriving DecidableEq, Repr
 
 /-- The n head each root class is licensed to combine with. -/
-def RootClass.licensedNHead : RootClass → CatHead
-  | .femaleReferent => CatHead.n_iFem
-  | .maleReferent   => CatHead.n_iMasc
-  | .arbitraryFem   => CatHead.n_uFem
-  | .arbitraryMasc  => CatHead.n_uNegFem
-  | .default        => CatHead.n_plain
+def RootClass.licensedNHead : RootClass → Categorizer.Head
+  | .femaleReferent => Categorizer.Head.n_iFem
+  | .maleReferent   => Categorizer.Head.n_iMasc
+  | .arbitraryFem   => Categorizer.Head.n_uFem
+  | .arbitraryMasc  => Categorizer.Head.n_uNegFem
+  | .default        => Categorizer.Head.n_plain
 
 /-- The licensing type for each root class. -/
 def RootClass.licensing : RootClass → LicensingType
@@ -859,16 +859,16 @@ theorem spanish_licensing_libro :
     the `GenderFeature.licensingType` (defined in `Categorizer.lean`) produces
     the same result as `RootClass.licensing`. -/
 theorem licensing_bridge_femaleReferent :
-    (CatHead.n_iFem.phi.gender.get (by rfl)).licensingType =
+    (Categorizer.Head.n_iFem.phi.gender.get (by rfl)).licensingType =
       RootClass.femaleReferent.licensing := rfl
 theorem licensing_bridge_maleReferent :
-    (CatHead.n_iMasc.phi.gender.get (by rfl)).licensingType =
+    (Categorizer.Head.n_iMasc.phi.gender.get (by rfl)).licensingType =
       RootClass.maleReferent.licensing := rfl
 theorem licensing_bridge_arbitraryFem :
-    (CatHead.n_uFem.phi.gender.get (by rfl)).licensingType =
+    (Categorizer.Head.n_uFem.phi.gender.get (by rfl)).licensingType =
       RootClass.arbitraryFem.licensing := rfl
 theorem licensing_bridge_arbitraryMasc :
-    (CatHead.n_uNegFem.phi.gender.get (by rfl)).licensingType =
+    (Categorizer.Head.n_uNegFem.phi.gender.get (by rfl)).licensingType =
       RootClass.arbitraryMasc.licensing := rfl
 
 /-- Russian fragment nouns project to their root classes via `Russian.nHead`. -/
@@ -964,41 +964,41 @@ In Set 2 languages (Maa, Wari'), the same logic yields feminine as default:
 The polarity of the u-feature determines which gender is arbitrary vs default. -/
 
 
--- Set 1 (Spanish) derivation chain — uses DM bridge (CatHead.surfaceGenderSet1)
+-- Set 1 (Spanish) derivation chain — uses DM bridge (Categorizer.Head.surfaceGenderSet1)
 
 /-- Plain n → masculine (the default). -/
 theorem set1_plain_n_masculine :
-    CatHead.n_plain.surfaceGenderSet1 = .masculine := rfl
+    Categorizer.Head.n_plain.surfaceGenderSet1 = .masculine := rfl
 
 /-- i[+FEM] → feminine (natural female). -/
 theorem set1_iFem_feminine :
-    CatHead.n_iFem.surfaceGenderSet1 = .feminine := rfl
+    Categorizer.Head.n_iFem.surfaceGenderSet1 = .feminine := rfl
 
 /-- i[−FEM] → masculine (natural male). -/
 theorem set1_iMasc_masculine :
-    CatHead.n_iMasc.surfaceGenderSet1 = .masculine := rfl
+    Categorizer.Head.n_iMasc.surfaceGenderSet1 = .masculine := rfl
 
 /-- u[+FEM] → feminine (arbitrary feminine). -/
 theorem set1_uFem_feminine :
-    CatHead.n_uFem.surfaceGenderSet1 = .feminine := rfl
+    Categorizer.Head.n_uFem.surfaceGenderSet1 = .feminine := rfl
 
--- Set 2 (Maa) derivation chain — uses DM bridge (CatHead.surfaceGenderSet2)
+-- Set 2 (Maa) derivation chain — uses DM bridge (Categorizer.Head.surfaceGenderSet2)
 
 /-- Plain n → feminine (the default in Set 2). -/
 theorem set2_plain_n_feminine :
-    CatHead.n_plain.surfaceGenderSet2 = .feminine := rfl
+    Categorizer.Head.n_plain.surfaceGenderSet2 = .feminine := rfl
 
 /-- u[−FEM] → masculine (arbitrary masculine in Set 2). -/
 theorem set2_uNegFem_masculine :
-    CatHead.n_uNegFem.surfaceGenderSet2 = .masculine := rfl
+    Categorizer.Head.n_uNegFem.surfaceGenderSet2 = .masculine := rfl
 
 /-- i[−FEM] → masculine (natural male, same in both sets). -/
 theorem set2_iMasc_masculine :
-    CatHead.n_iMasc.surfaceGenderSet2 = .masculine := rfl
+    Categorizer.Head.n_iMasc.surfaceGenderSet2 = .masculine := rfl
 
 /-- i[+FEM] → feminine (natural female, same in both sets). -/
 theorem set2_iFem_feminine :
-    CatHead.n_iFem.surfaceGenderSet2 = .feminine := rfl
+    Categorizer.Head.n_iFem.surfaceGenderSet2 = .feminine := rfl
 
 /-- Verify the full derivation chain for Spanish fragment nouns: the
     surface gender computed via `Spanish.nHead` projection then Set 1 VI
@@ -1036,8 +1036,8 @@ as Lavukaleve, supporting [kramer-2015]'s prediction that n-inventory
 size and surface gender count are independent (mediated by VI). -/
 
 def russianNs : NInventory :=
-  ⟨"Russian", [CatHead.n_iFem, CatHead.n_iMasc, CatHead.n_plain,
-               CatHead.n_uFem, CatHead.n_uNegFem], 3⟩
+  ⟨"Russian", [Categorizer.Head.n_iFem, Categorizer.Head.n_iMasc, Categorizer.Head.n_plain,
+               Categorizer.Head.n_uFem, Categorizer.Head.n_uNegFem], 3⟩
 
 /-- Russian and Lavukaleve share the same n-inventory (5 heads). -/
 theorem russian_lavukaleve_same_ns :
@@ -1106,15 +1106,15 @@ theorem russian_projection_round_trips :
 /-- Projection-derived: Russian Fragment covers all 5 n-types. -/
 theorem russian_fragment_covers_inventory :
     Russian.Gender.allNouns.any
-      (Russian.nHead · == CatHead.n_iFem) ∧
+      (Russian.nHead · == Categorizer.Head.n_iFem) ∧
     Russian.Gender.allNouns.any
-      (Russian.nHead · == CatHead.n_iMasc) ∧
+      (Russian.nHead · == Categorizer.Head.n_iMasc) ∧
     Russian.Gender.allNouns.any
-      (Russian.nHead · == CatHead.n_uFem) ∧
+      (Russian.nHead · == Categorizer.Head.n_uFem) ∧
     Russian.Gender.allNouns.any
-      (Russian.nHead · == CatHead.n_uNegFem) ∧
+      (Russian.nHead · == Categorizer.Head.n_uNegFem) ∧
     Russian.Gender.allNouns.any
-      (Russian.nHead · == CatHead.n_plain) := by decide
+      (Russian.nHead · == Categorizer.Head.n_plain) := by decide
 
 -- ============================================================================
 -- § 14: VI-Derived Surface Gender Count
@@ -1135,23 +1135,23 @@ The key VI patterns from [kramer-2015]:
     class (encoded as Nat). Two n-heads yielding the same Nat surface
     as the same gender. -/
 def NInventory.computeGenders (inv : NInventory)
-    (viMap : CatHead → Nat) : Nat :=
+    (viMap : Categorizer.Head → Nat) : Nat :=
   (inv.nHeads.map viMap).eraseDups.length
 
 /-- Set 1 VI: [+FEM] → 0 (feminine), everything else → 1 (masculine). -/
-def viSet1 (ch : CatHead) : Nat :=
+def viSet1 (ch : Categorizer.Head) : Nat :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .pos⟩ then 0 else 1
   | none    => 1
 
 /-- Set 2 VI: [−FEM] → 1 (masculine), everything else → 0 (feminine). -/
-def viSet2 (ch : CatHead) : Nat :=
+def viSet2 (ch : Categorizer.Head) : Nat :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .neg⟩ then 1 else 0
   | none    => 0
 
 /-- 3-gender VI: [+FEM] → 0, [−FEM] → 1, no feature → 2. -/
-def viThreeGender (ch : CatHead) : Nat :=
+def viThreeGender (ch : Categorizer.Head) : Nat :=
   match ch.phi.gender with
   | some gf => if gf.val == ⟨.fem, .pos⟩ then 0 else 1
   | none    => 2
@@ -1250,7 +1250,7 @@ open _root_.Hausa (Noun)
     UNVERIFIED: Hausa is not classified by [kramer-2015] (it
     appears only in introductory data examples in Ch. 1). The Set-1
     placement extrapolates from [kramer-2020] Table 3 (p. 56). -/
-def nHead (n : Noun) : CatHead :=
+def nHead (n : Noun) : Categorizer.Head :=
   match n.attestedGender, n.isNaturalGender with
   | .feminine,  true  => .n_iFem
   | .masculine, true  => .n_iMasc
@@ -1284,11 +1284,11 @@ end Hausa
 theorem hausa_nHead_projection_correct :
     Hausa.allNouns.all (fun n =>
       Hausa.nHead n == match n.attestedGender, n.isNaturalGender with
-        | .feminine,  true  => CatHead.n_iFem
-        | .masculine, true  => CatHead.n_iMasc
-        | .feminine,  false => CatHead.n_uFem
-        | .masculine, false => CatHead.n_plain
-        | _, _              => CatHead.n_plain) := by decide
+        | .feminine,  true  => Categorizer.Head.n_iFem
+        | .masculine, true  => Categorizer.Head.n_iMasc
+        | .feminine,  false => Categorizer.Head.n_uFem
+        | .masculine, false => Categorizer.Head.n_plain
+        | _, _              => Categorizer.Head.n_plain) := by decide
 
 /-- *yārinyā* 'girl' projects to natural feminine (i[+FEM]).
     Parallels `spanish_licensing_mujer` (§10). -/
@@ -1335,10 +1335,10 @@ theorem hausa_licensing_uba :
 /-- The Hausa Fragment covers all four Set-1 n-heads via its projection.
     Parallels `fragment_covers_inventory` for Spanish. -/
 theorem hausa_fragment_covers_inventory :
-    Hausa.allNouns.any (Hausa.nHead · == CatHead.n_iFem) ∧
-    Hausa.allNouns.any (Hausa.nHead · == CatHead.n_iMasc) ∧
-    Hausa.allNouns.any (Hausa.nHead · == CatHead.n_uFem) ∧
-    Hausa.allNouns.any (Hausa.nHead · == CatHead.n_plain) := by
+    Hausa.allNouns.any (Hausa.nHead · == Categorizer.Head.n_iFem) ∧
+    Hausa.allNouns.any (Hausa.nHead · == Categorizer.Head.n_iMasc) ∧
+    Hausa.allNouns.any (Hausa.nHead · == Categorizer.Head.n_uFem) ∧
+    Hausa.allNouns.any (Hausa.nHead · == Categorizer.Head.n_plain) := by
   decide
 
 -- § 15.2: §3.3.1 phonological-assignment refutation


### PR DESCRIPTION
Renames `CatHead` to `Categorizer.Head` — matching the `Minimalist.Voice.Head` precedent (a head record namespaced under its owning system) and dropping the `Cat` shorthand, which ambiguously suggested `Cat` (the category type) while the field held a `Categorizer`.

- Field `cat` → `categorizer`; Teop's `Gender.toCatHead` → `toHead`; Akinbo's `verbalizerCat` → `verbalizer`.
- 13 files swept; long table rows in Spanish/Binominals and Adamson2024 shortened via `open DistributedMorphology.Categorizer (Head)`.