### PR TITLE
refactor(Morphology/DistributedMorphology): VI into Gender.System

### DIFF
--- a/Linglib/Features/Gender/Decomposition.lean
+++ b/Linglib/Features/Gender/Decomposition.lean
@@ -21,8 +21,11 @@ study can adopt or refute.
   mismatch zoo: committee-type collectives for number, Russian
   profession nouns for gender, Hebrew be'alim, Chichewa heroes) are
   exactly what the special cases cannot represent.
-* **Kramer's gender calculus** ([kramer-2015]): gender features on the
-  nominalizing head n, drawn from `KramerN` = {plain, i[±FEM], u[±FEM]}.
+* **Kramer's gender calculus** ([kramer-2015]): valued gender features
+  are signed binary dimensions (`Signed` over `Dimension` — FEM, ANIM,
+  and [adamson-2024]'s MASC), whose `surface` labels underdetermine them
+  (`Signed.surface_femNeg_eq_mascPos`). The interpretability-annotated
+  FEM slice is `KramerN` = {plain, i[±FEM], u[±FEM]}.
   Natural and arbitrary gender differ only in interpretability and receive
   the same exponence at PF (`KramerN.exponence`), which yields the
   calculus's signature limit, here a theorem
@@ -219,6 +222,78 @@ def Features.fromGender : Gender → Option Features
 theorem roundtrip_fromGender_toGender :
     [neuterF, feminineF, masculineF].all
       (λ f => f.toGender.bind Features.fromGender == some f) = true := by
+  decide
+
+/-! ### Dimensions and signed features
+
+Kramer's calculus ranges over language-particular binary dimensions:
+[±FEM] (Amharic, Spanish, Maa), [±ANIM] (Lealao Chinantec, Algonquian,
+Teop), and [adamson-2024]'s [±MASC] (Jarawara). A signed dimension is a
+valued gender feature, and its `surface` is the comparative label of the
+chosen pole. `KramerN` below is the interpretability-annotated FEM
+slice. -/
+
+/-- A binary gender dimension: the contrast a language's gender features
+are drawn over ([kramer-2015]; [adamson-2024] for MASC). -/
+inductive Dimension where
+  | fem   -- [±FEM]: Amharic, Spanish, Maa
+  | masc  -- [±MASC]: Jarawara
+  | anim  -- [±ANIM]: Lealao Chinantec, Algonquian, Teop
+  deriving DecidableEq, Repr, Fintype
+
+/-- The sign of a valued binary feature. Neither sign is inherently
+marked: which one a language's arbitrary gender carries is the Set 1 vs
+Set 2 parameter ([kramer-2015] Ch 6). -/
+inductive Pole where
+  | pos  -- [+VAL]
+  | neg  -- [−VAL]
+  deriving DecidableEq, Repr, Fintype
+
+/-- The comparative label at a dimension's positive pole. -/
+def Dimension.positive : Dimension → Gender
+  | .fem  => .feminine
+  | .masc => .masculine
+  | .anim => .animate
+
+/-- The comparative label at a dimension's negative pole. -/
+def Dimension.negative : Dimension → Gender
+  | .fem  => .masculine
+  | .masc => .feminine
+  | .anim => .inanimate
+
+/-- A valued gender feature: a dimension with a sign — [+FEM], [−FEM],
+[+ANIM], and so on. -/
+structure Signed where
+  dim : Dimension
+  pole : Pole
+  deriving DecidableEq, Repr, Fintype
+
+/-- The comparative label a valued feature denotes: the pole its sign
+picks. -/
+def Signed.surface (v : Signed) : Gender :=
+  match v.pole with
+  | .pos => v.dim.positive
+  | .neg => v.dim.negative
+
+/-- Surface labels underdetermine features: Maa's [−FEM] and Jarawara's
+[+MASC] both surface masculine ([kramer-2015] §6.3 vs [adamson-2024]
+§3.2) — drawing the featural distinction is what the dimension inventory
+is for. -/
+theorem Signed.surface_femNeg_eq_mascPos :
+    (Signed.mk .fem .neg).surface = (Signed.mk .masc .pos).surface := rfl
+
+/-- The canonical numbering of the six valued features — the encoding
+consumers with numeral gender slots (the Minimalist φ-interface) use. -/
+def Signed.toNat : Signed → Nat
+  | ⟨.fem, .pos⟩  => 0  -- [+FEM]
+  | ⟨.fem, .neg⟩  => 1  -- [−FEM]
+  | ⟨.masc, .pos⟩ => 2  -- [+MASC]
+  | ⟨.masc, .neg⟩ => 3  -- [−MASC]
+  | ⟨.anim, .pos⟩ => 4  -- [+ANIM]
+  | ⟨.anim, .neg⟩ => 5  -- [−ANIM]
+
+/-- The numbering is faithful. -/
+theorem Signed.toNat_injective : Function.Injective Signed.toNat := by
   decide
 
 /-! ### Kramer's gender calculus and its three-gender bound -/

--- a/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
+++ b/Linglib/Morphology/DistributedMorphology/Categorizer/Gender.lean
@@ -6,32 +6,33 @@ import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 # Gender on the nominal categorizer
 
 The nominal categorizer is the locus of grammatical gender: an n may
-carry an interpretable (natural) or uninterpretable (arbitrary) gender
-feature over a language-particular dimension, and language-particular
-Vocabulary Insertion maps the resulting inventory to surface genders.
-The apparatus is grounded in the general gender machinery of
-`Features/Gender/` — dimensions are poles over `Gender`, DM features are
-the non-hybrid fragment of `Gender.SplitFeature`, and the FEM slice of
-the head inventory is `Gender.KramerN`.
+carry a valued gender feature (`Gender.Signed`), interpretable (natural)
+or uninterpretable (arbitrary), and Vocabulary Insertion realizes the
+result in the language's own gender system (`Gender.System`), falling
+back to the system's morphosyntactic default. The attested realization
+patterns — Set 1, Set 2, three-gender, animacy-based — differ only in
+their system, and PF is blind to interpretability. DM features are the
+non-hybrid fragment of `Gender.SplitFeature`, and the FEM slice of the
+head inventory is `Gender.KramerN`.
 
 ## Main definitions
 
-* `GenderVal`, `GenderFeature`, `Interpretability`, `Contrastivity` —
-  gender features on n and their LF status
-* `Categorizer.Head` — a categorizer with phi-features and the selectional feature
-  {D}; canonical heads `Categorizer.Head.n_iFem` … `Categorizer.Head.n_uMasc`
-* `Categorizer.Head.surfaceGenderSet1`/`Set2`/`Three`/`Animacy` — the attested
-  Vocabulary-Insertion maps from features to surface gender
-* `RootLicense`, `Categorizer.Head.licensesIntrusion` — root–n licensing and
-  gender-conditioned templatic t-intrusion
+* `GenderFeature`, `Interpretability`, `Contrastivity` — gender features
+  on n and their LF status
+* `Categorizer.Head` — a categorizer with phi-features and the
+  selectional feature {D}; `Categorizer.Head.gendered` builds the
+  canonical inventory `n_iFem` … `n_uMasc`
+* `Categorizer.Head.realizeGender` — Vocabulary Insertion into a
+  `Gender.System`; `IsSet1` … `IsAnimacyBased` — the attested patterns
+* `Categorizer.Head.LicensesIntrusion` — gender-conditioned templatic
+  t-intrusion
 
 ## Main statements
 
 * `toSplitFeature_not_isHybrid` — the DM calculus generates no hybrid
   features
-* `surfaceGenderSet1_eq_surface` (and kin) — each insertion map realizes
-  a valued feature at its `GenderVal.surface` pole, differing only in the
-  default for plain n
+* `realizeGender_congr` — PF is blind to interpretability
+* `not_isSet1_and_isSet2` — the Set 1 vs Set 2 parameter is exclusive
 
 ## References
 
@@ -50,55 +51,6 @@ open Minimalist Minimalist.Voice
 Grammatical gender lives on n, as an interpretable (natural) or
 uninterpretable (arbitrary) feature over a language-particular dimension
 ([kramer-2015]; [adamson-2024] for MASC and Teop). -/
-
-/-- The binary feature dimension a language's gender system distinguishes
-on n. -/
-inductive GenderDimension where
-  | fem   -- [±FEM]: Amharic, Spanish, Maa, and kin ([kramer-2015])
-  | masc  -- [±MASC]: Jarawara ([adamson-2024] (58))
-  | anim  -- [±ANIM]: Lealao Chinantec, Algonquian, Teop
-  deriving DecidableEq, Repr
-
-/-- The sign of a binary gender feature value. Neither sign is inherently
-marked — which one the uninterpretable feature carries is the Set 1 vs.
-Set 2 parameter ([kramer-2015] Ch 6). -/
-inductive Polarity where
-  | pos  -- [+VAL]: positive polarity
-  | neg  -- [−VAL]: negative polarity
-  deriving DecidableEq, Repr
-
-/-- A gender feature value pairs a dimension with a sign — [+FEM],
-[−FEM], [+ANIM], and so on. -/
-structure GenderVal where
-  dim : GenderDimension
-  pol : Polarity
-  deriving DecidableEq, Repr
-
-/-- The descriptive gender at a dimension's positive pole. -/
-def GenderDimension.positive : GenderDimension → Gender
-  | .fem  => .feminine
-  | .masc => .masculine
-  | .anim => .animate
-
-/-- The descriptive gender at a dimension's negative pole. -/
-def GenderDimension.negative : GenderDimension → Gender
-  | .fem  => .masculine
-  | .masc => .feminine
-  | .anim => .inanimate
-
-/-- The descriptive gender a valued feature denotes — the dimension's pole
-picked by the sign. -/
-def GenderVal.surface (v : GenderVal) : Gender :=
-  match v.pol with
-  | .pos => v.dim.positive
-  | .neg => v.dim.negative
-
-/-- Surface gender underdetermines the feature: Maa's [−FEM] and
-Jarawara's [+MASC] both surface as masculine, and drawing that featural
-distinction is what the dimension inventory is for ([kramer-2015] §6.3
-vs. [adamson-2024] §3.2). -/
-theorem surface_femNeg_eq_mascPos :
-    (GenderVal.mk .fem .neg).surface = (GenderVal.mk .masc .pos).surface := rfl
 
 /-- Whether a gender feature is legible at LF ([kramer-2015] §3.4.2).
 Interpretable gender is natural gender, restricting the denotation and
@@ -126,12 +78,13 @@ def Contrastivity.obligatory : Contrastivity → Bool
   | .contrastive => true
   | .nonContrastive => false
 
-/-- A gender feature value annotated for interpretability. Per dimension
-this yields the four attested gendered ns of [kramer-2015] Ch 3 —
-i[+VAL], i[−VAL], u[+VAL], u[−VAL] — beside plain n with no feature. -/
+/-- A valued gender feature (`Gender.Signed`) annotated for
+interpretability. Per dimension this yields the four attested gendered
+ns of [kramer-2015] Ch 3 — i[+VAL], i[−VAL], u[+VAL], u[−VAL] — beside
+plain n with no feature. -/
 structure GenderFeature where
   interp : Interpretability
-  val : GenderVal
+  val : Gender.Signed
   deriving DecidableEq, Repr
 
 /-- Whether a gender feature is interpretable (natural). -/
@@ -197,79 +150,73 @@ def Categorizer.Head.iPoss (phi : PhiBundle := {}) : Categorizer.Head where
 theorem Categorizer.Head.iPoss_selectsD (phi : PhiBundle) :
     (Categorizer.Head.iPoss phi).selectsD = true := rfl
 
-/-! ### Kramer's Four Types of n ([kramer-2015] Ch 3) -/
+/-! ### The canonical head inventory ([kramer-2015] Ch 3)
 
-/-! ### FEM dimension (Amharic, Spanish, Romance; [kramer-2015] Chs 3, 6) -/
+FEM dimension: Amharic, Spanish, Romance ([kramer-2015] Chs 3, 6). ANIM:
+Teop, Algonquian, Lealao Chinantec (Chs 5–6; [adamson-2024] §3.1). MASC:
+Jarawara only ([adamson-2024] §3.2) — Maa's arbitrary masculine is
+negative-polarity FEM, not MASC. -/
+
+/-- The gendered nominal categorizer: n bearing the valued feature `v`
+with interpretability `interp`. -/
+def Categorizer.Head.gendered (interp : Interpretability)
+    (v : Gender.Signed) : Categorizer.Head where
+  categorizer := .n
+  phi := { gender := some ⟨interp, v⟩ }
+
+/-- Distinct feature content gives distinct heads — every pairwise
+contrast in the inventory below, in one statement. -/
+theorem Categorizer.Head.gendered_inj {i₁ i₂ : Interpretability}
+    {v₁ v₂ : Gender.Signed} :
+    gendered i₁ v₁ = gendered i₂ v₂ ↔ i₁ = i₂ ∧ v₁ = v₂ := by
+  simp [Categorizer.Head.gendered, PhiBundle.mk.injEq]
 
 /-- The n bearing interpretable [+FEM] — female natural gender. In
 Amharic the female member of a same-root pair can carry the suffix *-it*
 ([kramer-2015] (10)). -/
-def Categorizer.Head.n_iFem : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.i, ⟨.fem, .pos⟩⟩ }
+def Categorizer.Head.n_iFem : Categorizer.Head := .gendered .i ⟨.fem, .pos⟩
 
 /-- The n bearing interpretable [−FEM] — male natural gender. The name
 gives the resulting gender: the feature is negative-polarity FEM, not the
 MASC dimension of Jarawara (`n_uMasc`). -/
-def Categorizer.Head.n_iMasc : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.i, ⟨.fem, .neg⟩⟩ }
+def Categorizer.Head.n_iMasc : Categorizer.Head := .gendered .i ⟨.fem, .neg⟩
 
 /-- The plain n with no gender feature — the default nominal
 categorizer. -/
 def Categorizer.Head.n_plain : Categorizer.Head where
   categorizer := .n
 
+/-- A gendered head is never the plain n. -/
+theorem Categorizer.Head.gendered_ne_n_plain (interp : Interpretability)
+    (v : Gender.Signed) : gendered interp v ≠ n_plain := by
+  simp [Categorizer.Head.gendered, Categorizer.Head.n_plain]
+
 /-- The n bearing uninterpretable [+FEM] — the arbitrary feminine of
 Set 1 languages (Amharic, Spanish), leaving masculine as the default.
 Amharic assigns it to a handful of inanimates such as *car*, *earth*,
 *sun*, and *church* ([kramer-2015] (9), Ch 6). -/
-def Categorizer.Head.n_uFem : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.u, ⟨.fem, .pos⟩⟩ }
+def Categorizer.Head.n_uFem : Categorizer.Head := .gendered .u ⟨.fem, .pos⟩
 
 /-- The n bearing uninterpretable [−FEM] — the arbitrary masculine of
 Set 2, leaving feminine as the default (Maa, [kramer-2015] §6.3). -/
-def Categorizer.Head.n_uNegFem : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.u, ⟨.fem, .neg⟩⟩ }
-
-/-- u[+FEM] and u[−FEM] are distinct n heads: Set 1 vs Set 2. -/
-theorem u_fem_polarity_contrast :
-    Categorizer.Head.n_uFem ≠ Categorizer.Head.n_uNegFem := by decide
-
-/-! ### ANIM dimension (Teop, Algonquian, Lealao Chinantec;
-    [kramer-2015] Chs 5-6; [adamson-2024] §3.1) -/
+def Categorizer.Head.n_uNegFem : Categorizer.Head := .gendered .u ⟨.fem, .neg⟩
 
 /-- The n bearing interpretable [+ANIM] — Teop gender I nouns, taking
 the article *a*. -/
-def Categorizer.Head.n_iAnim : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.i, ⟨.anim, .pos⟩⟩ }
+def Categorizer.Head.n_iAnim : Categorizer.Head := .gendered .i ⟨.anim, .pos⟩
 
 /-- The n bearing interpretable [−ANIM] — Teop gender II nouns, taking
 the article *o*. -/
-def Categorizer.Head.n_iInanim : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.i, ⟨.anim, .neg⟩⟩ }
+def Categorizer.Head.n_iInanim : Categorizer.Head := .gendered .i ⟨.anim, .neg⟩
 
 /-- The n bearing uninterpretable [+ANIM] — Teop's body-part n when
 iPossessed ([adamson-2024] §3.1). -/
-def Categorizer.Head.n_uAnim : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.u, ⟨.anim, .pos⟩⟩ }
-
-/-! ### MASC dimension (Jarawara; [adamson-2024] §3.2)
-
-Only Jarawara uses this dimension in the current coverage — Maa's
-arbitrary masculine is negative-polarity FEM, not MASC. -/
+def Categorizer.Head.n_uAnim : Categorizer.Head := .gendered .u ⟨.anim, .pos⟩
 
 /-- The n bearing uninterpretable [+MASC] — Jarawara's marked masculine,
 with feminine as the unmarked plain n. [adamson-2024] (58) also allows the
 interpretable variant, not modeled here. -/
-def Categorizer.Head.n_uMasc : Categorizer.Head where
-  categorizer := .n
-  phi := { gender := some ⟨.u, ⟨.masc, .pos⟩⟩ }
+def Categorizer.Head.n_uMasc : Categorizer.Head := .gendered .u ⟨.masc, .pos⟩
 
 /-- The verbal categorizer, with no phi-features. -/
 def Categorizer.Head.v_plain : Categorizer.Head where
@@ -300,84 +247,22 @@ inductive LicensingType where
   | arbitrary  -- PF / List 2
   deriving DecidableEq, Repr
 
-/-- A root–n licensing condition — which gender the n combining with a
-given root must bear, and whether the licensing is semantic or
-arbitrary. -/
-structure RootLicense (RootIdx : Type) where
-  /-- The licensed root. -/
-  rootIdx : RootIdx
-  /-- The gender requirement on n (`none` = plain n). -/
-  requiredGender : Option GenderFeature
-  /-- Semantic or arbitrary licensing. -/
-  licensingType : LicensingType
+/-- The head licenses templatic [t]-intrusion: it is a nominal
+categorizer bearing a gender feature, whose exponent the bound root
+hosts ([faust-2026] (11), [lowenstamm-2014]) — canonically Set 1
+feminine, the Hebrew /t/ of taQTiL nouns and the Amharic /t/ of gerunds
+and infinitives. Verbal stems are blocked because gender is realized on
+the higher Agr head ([kramer-2020]). -/
+def Categorizer.Head.LicensesIntrusion (ch : Categorizer.Head) : Prop :=
+  ch.categorizer = .n ∧ ch.phi.gender.isSome
 
-/-- Whether a Categorizer.Head satisfies a licensing condition's gender requirement. -/
-def Categorizer.Head.satisfiesLicense (ch : Categorizer.Head) (req : Option GenderFeature) : Bool :=
-  match req with
-  | none => ch.phi.gender.isNone
-  | some gf => ch.phi.gender == some gf
+instance : DecidablePred Categorizer.Head.LicensesIntrusion :=
+  fun _ => inferInstanceAs (Decidable (_ ∧ _))
 
-/-- Whether the head licenses templatic [t]-intrusion — the head is a
-nominal categorizer bearing a gender feature, whose exponent the bound
-root hosts ([faust-2026] (11), [lowenstamm-2014]). Verbal stems are
-blocked because gender is realized on the higher Agr head
-([kramer-2020]). -/
-def Categorizer.Head.licensesIntrusion (ch : Categorizer.Head) : Bool :=
-  decide (ch.categorizer = .n) && ch.phi.gender.isSome
-
-/-! #### Intrusion licensing across the canonical heads -/
-
-/-- u[+FEM] n licenses intrusion (canonical Set 1 feminine — Hebrew /t/
-    exponent of taQTiL nouns, Amharic /t/ exponent of gerunds and INFs). -/
-theorem n_uFem_licenses_intrusion :
-    Categorizer.Head.n_uFem.licensesIntrusion = true := rfl
-
-/-- i[+FEM] n licenses intrusion (interpretable feminine). -/
-theorem n_iFem_licenses_intrusion :
-    Categorizer.Head.n_iFem.licensesIntrusion = true := rfl
-
-/-- i[−FEM] n licenses intrusion (interpretable masculine — Faust's
-    argument is feature-symmetric: any [+gen] specification on n
-    licenses an inherent exponent). -/
-theorem n_iMasc_licenses_intrusion :
-    Categorizer.Head.n_iMasc.licensesIntrusion = true := rfl
-
-/-- Plain n (no gender feature) does NOT license intrusion. -/
-theorem n_plain_blocks_intrusion :
-    Categorizer.Head.n_plain.licensesIntrusion = false := rfl
-
-/-- The verbal categorizer never licenses intrusion, since gender is
-realized on Agr rather than v ([faust-2026] (11)). -/
-theorem v_plain_blocks_intrusion :
-    Categorizer.Head.v_plain.licensesIntrusion = false := rfl
-
-/-- The adjectival categorizer has no inherent gender exponent. -/
-theorem a_plain_blocks_intrusion :
-    Categorizer.Head.a_plain.licensesIntrusion = false := rfl
-
-/-- Intrusion is well-formed iff the categorizer is n and carries a
-gender feature ([faust-2026] (11)). -/
-theorem licensesIntrusion_iff_n_and_gen (ch : Categorizer.Head) :
-    ch.licensesIntrusion = true ↔ ch.categorizer = .n ∧ ch.phi.gender.isSome = true := by
-  simp only [Categorizer.Head.licensesIntrusion, Bool.and_eq_true, decide_eq_true_eq]
-
-/-! ### Phi-Feature Verification -/
-
-/-- The four Amharic n types are pairwise distinct. -/
-theorem four_n_types_distinct :
-    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_iMasc ∧
-    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_plain ∧
-    Categorizer.Head.n_iFem ≠ Categorizer.Head.n_uFem ∧
-    Categorizer.Head.n_iMasc ≠ Categorizer.Head.n_plain ∧
-    Categorizer.Head.n_iMasc ≠ Categorizer.Head.n_uFem ∧
-    Categorizer.Head.n_plain ≠ Categorizer.Head.n_uFem := by decide
-
-/-- Plain n has no gender feature — it is the default/unmarked case. -/
-theorem plain_n_no_gender : Categorizer.Head.n_plain.phi.gender = none := rfl
-
-/-- Natural and arbitrary gender are mutually exclusive on any feature. -/
-theorem natural_arbitrary_exclusive (gf : GenderFeature) :
-    ¬(gf.IsNatural ∧ gf.IsArbitrary) := by
+/-- Arbitrary gender is exactly the failure of natural gender: the two
+interpretability classes partition the features. -/
+theorem GenderFeature.isArbitrary_iff_not_isNatural (gf : GenderFeature) :
+    gf.IsArbitrary ↔ ¬ gf.IsNatural := by
   cases gf with | mk interp val =>
   cases interp <;> simp [GenderFeature.IsNatural, GenderFeature.IsArbitrary]
 
@@ -387,17 +272,11 @@ def GenderFeature.licensingType : GenderFeature → LicensingType
   | ⟨.i, _⟩ => .semantic
   | ⟨.u, _⟩ => .arbitrary
 
-/-- Natural gender → semantic licensing. -/
-theorem natural_semantic_licensing (gf : GenderFeature) (h : gf.IsNatural) :
-    gf.licensingType = .semantic := by
-  cases gf with | mk interp val =>
-  cases interp <;> simp_all [GenderFeature.IsNatural, GenderFeature.licensingType]
+@[simp] theorem GenderFeature.licensingType_i (v : Gender.Signed) :
+    (GenderFeature.mk .i v).licensingType = .semantic := rfl
 
-/-- Arbitrary gender → arbitrary licensing. -/
-theorem arbitrary_arbitrary_licensing (gf : GenderFeature) (h : gf.IsArbitrary) :
-    gf.licensingType = .arbitrary := by
-  cases gf with | mk interp val =>
-  cases interp <;> simp_all [GenderFeature.IsArbitrary, GenderFeature.licensingType]
+@[simp] theorem GenderFeature.licensingType_u (v : Gender.Signed) :
+    (GenderFeature.mk .u v).licensingType = .arbitrary := rfl
 
 /-! ### The split-feature reading
 
@@ -411,14 +290,14 @@ the morphological one. The FEM slice of the head inventory is
 `Gender.SplitFeature`) — interpretable gender values both halves,
 uninterpretable gender only the morphological one. -/
 def GenderFeature.toSplitFeature (gf : GenderFeature) :
-    Gender.SplitFeature GenderVal :=
+    Gender.SplitFeature Gender.Signed :=
   match gf.interp with
   | .i => ⟨some gf.val, some gf.val⟩
   | .u => ⟨some gf.val, none⟩
 
 /-- The gender half of a phi-bundle as a split feature, absent for plain
 heads. -/
-def PhiBundle.genderSplit (phi : PhiBundle) : Gender.SplitFeature GenderVal :=
+def PhiBundle.genderSplit (phi : PhiBundle) : Gender.SplitFeature Gender.Signed :=
   (phi.gender.map GenderFeature.toSplitFeature).getD ⟨none, none⟩
 
 /-- Natural gender in the DM sense is natural gender in the split-feature
@@ -471,22 +350,6 @@ def Categorizer.Head.ofKramerN : Gender.KramerN → Categorizer.Head
 
 /-! ### DM Gender → Minimalist Feature System -/
 
-/-- The encoding of gender values into the Minimalist
-`PhiFeature.gender` numeral. -/
-def GenderVal.toNat : GenderVal → Nat
-  | ⟨.fem, .pos⟩  => 0  -- [+FEM]
-  | ⟨.fem, .neg⟩  => 1  -- [−FEM]
-  | ⟨.masc, .pos⟩ => 2  -- [+MASC]
-  | ⟨.masc, .neg⟩ => 3  -- [−MASC]
-  | ⟨.anim, .pos⟩ => 4  -- [+ANIM]
-  | ⟨.anim, .neg⟩ => 5  -- [−ANIM]
-
-/-- The encoding sends distinct gender values to distinct numerals. -/
-theorem genderVal_toNat_injective (v1 v2 : GenderVal) (h : v1.toNat = v2.toNat) :
-    v1 = v2 := by
-  cases v1 with | mk d1 p1 => cases v2 with | mk d2 p2 =>
-  cases d1 <;> cases p1 <;> cases d2 <;> cases p2 <;> simp_all [GenderVal.toNat]
-
 /-- A DM gender feature as a Minimalist phi-feature. -/
 def GenderFeature.toPhiFeature (gf : GenderFeature) : PhiFeature :=
   .gender gf.val.toNat
@@ -508,210 +371,137 @@ theorem uninterpretable_gender_unvalued (gf : GenderFeature) (h : gf.interp = .u
     gf.toGramFeature = .unvalued (.phi (.gender gf.val.toNat)) := by
   simp [GenderFeature.toGramFeature, h, GenderFeature.toPhiFeature]
 
-/-- Amharic n i[+FEM] produces a valued gender feature. -/
-theorem n_iFem_valued :
-    (GenderFeature.mk .i ⟨.fem, .pos⟩).toGramFeature =
-    .valued (.phi (.gender 0)) := rfl
+/-! ### Vocabulary Insertion into a gender system
 
-/-- Amharic n u[+FEM] produces an unvalued gender feature (probe). -/
-theorem n_uFem_unvalued :
-    (GenderFeature.mk .u ⟨.fem, .pos⟩).toGramFeature =
-    .unvalued (.phi (.gender 0)) := rfl
+The bridge from features on n to a language's genders is Vocabulary
+Insertion into that language's own `Gender.System` — the carrier
+discipline of `Features/Gender/Basic.lean`. One map covers the attested
+patterns of [kramer-2015] Chs 5–7, which differ only in their system:
+the valued feature is realized by `value`, and a bare n falls back to
+the system's morphosyntactic default. -/
 
-/-! ### Cross-dimensional verification -/
+variable {G : Type*}
 
-/-- Animacy-dimension n types are distinct from FEM-dimension types. -/
-theorem anim_n_types_distinct :
-    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_iFem ∧
-    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_iMasc ∧
-    Categorizer.Head.n_uAnim ≠ Categorizer.Head.n_uFem := by decide
+/-- Vocabulary Insertion of gender: realize the head's valued feature in
+the language's own system, falling back to the system's default. -/
+def Categorizer.Head.realizeGender (sys : Gender.System G)
+    (value : Gender.Signed → G) (ch : Categorizer.Head) : G :=
+  (ch.phi.gender.map fun gf => value gf.val).getD sys.default
 
-/-- Animacy-dimension n types are distinct from plain n. -/
-theorem anim_not_plain :
-    Categorizer.Head.n_iAnim ≠ Categorizer.Head.n_plain ∧
-    Categorizer.Head.n_uAnim ≠ Categorizer.Head.n_plain := by decide
+@[simp] theorem realizeGender_gendered (sys : Gender.System G)
+    (value : Gender.Signed → G) (interp : Interpretability)
+    (v : Gender.Signed) :
+    (Categorizer.Head.gendered interp v).realizeGender sys value = value v :=
+  rfl
 
-/-! ### Surface Gender Bridge ([kramer-2020]; [kramer-2015] Chs 5-7) -/
+@[simp] theorem realizeGender_n_plain (sys : Gender.System G)
+    (value : Gender.Signed → G) :
+    Categorizer.Head.n_plain.realizeGender sys value = sys.default := rfl
 
-/-! The bridge from phi-features on n to descriptive `Gender` is
-Vocabulary Insertion, so the same feature inventory surfaces differently
-across languages; the four attested patterns follow
-([kramer-2015] Chs 5–7). -/
+/-- PF is blind to interpretability: heads carrying the same valued
+feature realize alike, whatever their LF status — natural and arbitrary
+gender receive the same Vocabulary Item ([kramer-2015]). -/
+theorem realizeGender_congr (sys : Gender.System G)
+    (value : Gender.Signed → G) {ch₁ ch₂ : Categorizer.Head}
+    (h : ch₁.phi.gender.map (·.val) = ch₂.phi.gender.map (·.val)) :
+    ch₁.realizeGender sys value = ch₂.realizeGender sys value := by
+  have e : ∀ o : Option GenderFeature,
+      o.map (fun gf => value gf.val) = (o.map (·.val)).map value := by
+    intro o; cases o <;> rfl
+  rw [Categorizer.Head.realizeGender, Categorizer.Head.realizeGender, e, e, h]
 
-
-/-- The Set 1 Vocabulary Insertion of Amharic and Spanish — [+FEM]
-realizes feminine and everything else masculine, so the default is
-masculine ([kramer-2015] Ch 6). -/
-def Categorizer.Head.surfaceGenderSet1 (ch : Categorizer.Head) : Gender :=
-  match ch.phi.gender with
-  | some gf => if gf.val == ⟨.fem, .pos⟩ then .feminine else .masculine
-  | none    => .masculine
-
-/-- The Set 2 Vocabulary Insertion of Maa — [−FEM] realizes masculine
-and everything else feminine, so the default is feminine
-([kramer-2015] §6.3). -/
-def Categorizer.Head.surfaceGenderSet2 (ch : Categorizer.Head) : Gender :=
-  match ch.phi.gender with
-  | some gf => if gf.val == ⟨.fem, .neg⟩ then .masculine else .feminine
-  | none    => .feminine
-
-/-- The three-gender Vocabulary Insertion of Mangarayi — [+FEM] feminine,
-[−FEM] masculine, no feature neuter ([kramer-2015] §7.2; the other Ch 7
-case studies add uninterpretable features to this inventory). -/
-def Categorizer.Head.surfaceGenderThree (ch : Categorizer.Head) : Gender :=
-  match ch.phi.gender with
-  | some gf => if gf.val == ⟨.fem, .pos⟩ then .feminine else .masculine
-  | none    => .neuter
-
-/-- The animacy Vocabulary Insertion of Lealao Chinantec
-([kramer-2015] §5.3), Algonquian (§6.4), and Teop ([adamson-2024]) —
-[+ANIM] realizes animate and everything else inanimate. -/
-def Categorizer.Head.surfaceGenderAnimacy (ch : Categorizer.Head) : Gender :=
-  match ch.phi.gender with
-  | some gf => if gf.val.dim == .anim && gf.val.pol == .pos
-               then .animate else .inanimate
-  | none    => .inanimate
-
--- Verification: canonical n heads produce expected surface genders
-
-theorem set1_verification :
-    Categorizer.Head.n_iFem.surfaceGenderSet1 = .feminine ∧
-    Categorizer.Head.n_iMasc.surfaceGenderSet1 = .masculine ∧
-    Categorizer.Head.n_uFem.surfaceGenderSet1 = .feminine ∧
-    Categorizer.Head.n_plain.surfaceGenderSet1 = .masculine := ⟨rfl, rfl, rfl, rfl⟩
-
-theorem set2_verification :
-    Categorizer.Head.n_iFem.surfaceGenderSet2 = .feminine ∧
-    Categorizer.Head.n_iMasc.surfaceGenderSet2 = .masculine ∧
-    Categorizer.Head.n_uNegFem.surfaceGenderSet2 = .masculine ∧
-    Categorizer.Head.n_plain.surfaceGenderSet2 = .feminine := ⟨rfl, rfl, rfl, rfl⟩
-
-theorem three_gender_verification :
-    Categorizer.Head.n_iFem.surfaceGenderThree = .feminine ∧
-    Categorizer.Head.n_iMasc.surfaceGenderThree = .masculine ∧
-    Categorizer.Head.n_uFem.surfaceGenderThree = .feminine ∧
-    Categorizer.Head.n_uNegFem.surfaceGenderThree = .masculine ∧
-    Categorizer.Head.n_plain.surfaceGenderThree = .neuter := ⟨rfl, rfl, rfl, rfl, rfl⟩
-
-theorem animacy_verification :
-    Categorizer.Head.n_iAnim.surfaceGenderAnimacy = .animate ∧
-    Categorizer.Head.n_iInanim.surfaceGenderAnimacy = .inanimate ∧
-    Categorizer.Head.n_uAnim.surfaceGenderAnimacy = .animate ∧
-    Categorizer.Head.n_plain.surfaceGenderAnimacy = .inanimate := ⟨rfl, rfl, rfl, rfl⟩
-
-/-! Each insertion map realizes a valued feature of its home dimension at
-its `GenderVal.surface` pole — the four patterns differ only in the
-default for plain n. -/
-
-/-- On FEM-dimension bundles, Set 1 is surface realization with a
-masculine default. -/
-theorem surfaceGenderSet1_eq_surface (ch : Categorizer.Head)
-    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
-    ch.surfaceGenderSet1 = (ch.phi.gender.map (·.val.surface)).getD .masculine := by
-  cases hg : ch.phi.gender with
-  | none => simp [Categorizer.Head.surfaceGenderSet1, hg]
-  | some gf =>
-    obtain ⟨itp, d, pol⟩ := gf
-    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
-      rw [hg]; rfl
-    obtain rfl : d = .fem := h _ hmem
-    cases pol <;>
-      simp [Categorizer.Head.surfaceGenderSet1, hg, GenderVal.surface,
-        GenderDimension.positive, GenderDimension.negative]
-
-/-- On FEM-dimension bundles, Set 2 is surface realization with a
-feminine default. -/
-theorem surfaceGenderSet2_eq_surface (ch : Categorizer.Head)
-    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
-    ch.surfaceGenderSet2 = (ch.phi.gender.map (·.val.surface)).getD .feminine := by
-  cases hg : ch.phi.gender with
-  | none => simp [Categorizer.Head.surfaceGenderSet2, hg]
-  | some gf =>
-    obtain ⟨itp, d, pol⟩ := gf
-    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
-      rw [hg]; rfl
-    obtain rfl : d = .fem := h _ hmem
-    cases pol <;>
-      simp [Categorizer.Head.surfaceGenderSet2, hg, GenderVal.surface,
-        GenderDimension.positive, GenderDimension.negative]
-
-/-- On FEM-dimension bundles, the three-gender pattern is surface
-realization with a neuter default. -/
-theorem surfaceGenderThree_eq_surface (ch : Categorizer.Head)
-    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .fem) :
-    ch.surfaceGenderThree = (ch.phi.gender.map (·.val.surface)).getD .neuter := by
-  cases hg : ch.phi.gender with
-  | none => simp [Categorizer.Head.surfaceGenderThree, hg]
-  | some gf =>
-    obtain ⟨itp, d, pol⟩ := gf
-    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
-      rw [hg]; rfl
-    obtain rfl : d = .fem := h _ hmem
-    cases pol <;>
-      simp [Categorizer.Head.surfaceGenderThree, hg, GenderVal.surface,
-        GenderDimension.positive, GenderDimension.negative]
-
-/-- On ANIM-dimension bundles, the animacy pattern is surface realization
-with an inanimate default. -/
-theorem surfaceGenderAnimacy_eq_surface (ch : Categorizer.Head)
-    (h : ∀ gf ∈ ch.phi.gender, gf.val.dim = .anim) :
-    ch.surfaceGenderAnimacy =
-      (ch.phi.gender.map (·.val.surface)).getD .inanimate := by
-  cases hg : ch.phi.gender with
-  | none => simp [Categorizer.Head.surfaceGenderAnimacy, hg]
-  | some gf =>
-    obtain ⟨itp, d, pol⟩ := gf
-    have hmem : (⟨itp, d, pol⟩ : GenderFeature) ∈ ch.phi.gender := by
-      rw [hg]; rfl
-    obtain rfl : d = .anim := h _ hmem
-    cases pol <;>
-      simp [Categorizer.Head.surfaceGenderAnimacy, hg, GenderVal.surface,
-        GenderDimension.positive, GenderDimension.negative]
-
-/-- Set 1 surface gender sees only what `Gender.KramerN.exponence` sees —
-interpretability is invisible at PF. -/
-theorem surfaceGenderSet1_ofKramerN (k₁ k₂ : Gender.KramerN)
+/-- Realization sees only what `Gender.KramerN.exponence` sees. -/
+theorem realizeGender_ofKramerN (sys : Gender.System G)
+    (value : Gender.Signed → G) (k₁ k₂ : Gender.KramerN)
     (h : k₁.exponence = k₂.exponence) :
-    (Categorizer.Head.ofKramerN k₁).surfaceGenderSet1 =
-      (Categorizer.Head.ofKramerN k₂).surfaceGenderSet1 := by
+    (Categorizer.Head.ofKramerN k₁).realizeGender sys value =
+      (Categorizer.Head.ofKramerN k₂).realizeGender sys value := by
+  refine realizeGender_congr sys value ?_
   cases k₁ <;> cases k₂ <;> first | rfl | exact absurd h (by decide)
 
-/-- Set 1 and Set 2 agree on natural gender but differ on the default
-for plain n ([kramer-2015] Ch 6). -/
-theorem set1_set2_default_contrast :
-    Categorizer.Head.n_plain.surfaceGenderSet1 ≠ Categorizer.Head.n_plain.surfaceGenderSet2 := by
-  decide
+/-! ### The attested realization patterns ([kramer-2015] Chs 5–7)
 
-/-! ### Discourse-level gender
+Each pattern is a constraint on the system's comparative labels: which
+label the valued feature realizes and which label the default carries.
+Set 1 and Set 2 share a feature inventory and differ only here. -/
 
-The composites `Categorizer.Head → Gender → GenderInfo` connect the structural
-encoding of gender on n with what discourse participants know about a
-referent's gender, one composite per Vocabulary-Insertion schema. -/
+/-- A Set 1 system: [+FEM] realizes the feminine-labeled gender and the
+default is masculine-labeled (Amharic, Spanish; [kramer-2015] Ch 6). -/
+def IsSet1 (sys : Gender.System G) (value : Gender.Signed → G) : Prop :=
+  sys.label (value ⟨.fem, .pos⟩) = some .feminine
+    ∧ sys.label sys.default = some .masculine
 
-/-- The discourse-level gender a head determines under Set 1 insertion. -/
-def Categorizer.Head.toGenderInfoSet1 (ch : Categorizer.Head) : GenderInfo :=
-  ch.surfaceGenderSet1.toGenderInfo
+/-- A Set 2 system: [−FEM] realizes the masculine-labeled gender and the
+default is feminine-labeled (Maa; [kramer-2015] §6.3). -/
+def IsSet2 (sys : Gender.System G) (value : Gender.Signed → G) : Prop :=
+  sys.label (value ⟨.fem, .neg⟩) = some .masculine
+    ∧ sys.label sys.default = some .feminine
 
-def Categorizer.Head.toGenderInfoSet2 (ch : Categorizer.Head) : GenderInfo :=
-  ch.surfaceGenderSet2.toGenderInfo
+/-- A three-gender system: both FEM poles are realized and the default
+is neuter-labeled (Mangarayi; [kramer-2015] §7.2 — the other Ch 7 case
+studies add uninterpretable features to this inventory). -/
+def IsThreeGender (sys : Gender.System G) (value : Gender.Signed → G) : Prop :=
+  sys.label (value ⟨.fem, .pos⟩) = some .feminine
+    ∧ sys.label (value ⟨.fem, .neg⟩) = some .masculine
+    ∧ sys.label sys.default = some .neuter
 
-def Categorizer.Head.toGenderInfoThree (ch : Categorizer.Head) : GenderInfo :=
-  ch.surfaceGenderThree.toGenderInfo
+/-- An animacy system: [+ANIM] realizes the animate-labeled gender and
+the default is inanimate-labeled (Lealao Chinantec, [kramer-2015] §5.3;
+Algonquian, §6.4; Teop, [adamson-2024]). -/
+def IsAnimacyBased (sys : Gender.System G) (value : Gender.Signed → G) : Prop :=
+  sys.label (value ⟨.anim, .pos⟩) = some .animate
+    ∧ sys.label sys.default = some .inanimate
 
-def Categorizer.Head.toGenderInfoAnimacy (ch : Categorizer.Head) : GenderInfo :=
-  ch.surfaceGenderAnimacy.toGenderInfo
+/-- The Set 1 vs Set 2 parameter is exclusive: their defaults carry
+different labels. -/
+theorem not_isSet1_and_isSet2 (sys : Gender.System G)
+    (value : Gender.Signed → G) : ¬ (IsSet1 sys value ∧ IsSet2 sys value) :=
+  fun ⟨h₁, h₂⟩ => by have := h₁.2.symm.trans h₂.2; simp at this
 
-/-- The composition always yields `.known _` — a DM categorizer head
-    always determines a concrete surface gender, so gender is never
-    unspecified at the discourse level when the morphosyntax is fully
-    resolved. Gender underspecification ([arnold-2026]) arises
-    from the discourse, not from the grammar. -/
-theorem catHead_gender_always_known_set1 (ch : Categorizer.Head) :
-    ∃ g, ch.toGenderInfoSet1 = .known g := by
-  exact ⟨ch.surfaceGenderSet1, rfl⟩
+/-- In a Set 1 system, arbitrary-feminine n realizes the
+feminine-labeled gender and plain n the masculine-labeled default. -/
+theorem IsSet1.realize_labels {sys : Gender.System G}
+    {value : Gender.Signed → G} (h : IsSet1 sys value) :
+    sys.label (Categorizer.Head.n_uFem.realizeGender sys value)
+        = some .feminine
+      ∧ sys.label (Categorizer.Head.n_plain.realizeGender sys value)
+        = some .masculine :=
+  ⟨h.1, h.2⟩
 
-theorem catHead_gender_always_known_three (ch : Categorizer.Head) :
-    ∃ g, ch.toGenderInfoThree = .known g := by
-  exact ⟨ch.surfaceGenderThree, rfl⟩
+/-- In a Set 2 system, arbitrary-masculine n realizes the
+masculine-labeled gender and plain n the feminine-labeled default. -/
+theorem IsSet2.realize_labels {sys : Gender.System G}
+    {value : Gender.Signed → G} (h : IsSet2 sys value) :
+    sys.label (Categorizer.Head.n_uNegFem.realizeGender sys value)
+        = some .masculine
+      ∧ sys.label (Categorizer.Head.n_plain.realizeGender sys value)
+        = some .feminine :=
+  ⟨h.1, h.2⟩
+
+/-- Set 1 is realizable: the two-gender system over `Bool` with `true`
+the feminine-labeled class. -/
+example : IsSet1 (G := Bool)
+    ⟨fun b => some (if b then .feminine else .masculine), false⟩
+    (fun v => v == ⟨.fem, .pos⟩) := by
+  constructor <;> rfl
+
+/-! ### Discourse-level gender -/
+
+/-- The discourse-level gender information a head determines: the
+comparative label of its realized gender, unspecified where the system
+leaves the class unlabeled. -/
+def Categorizer.Head.genderInfo (sys : Gender.System G)
+    (value : Gender.Signed → G) (ch : Categorizer.Head) : GenderInfo :=
+  (sys.label (ch.realizeGender sys value)).elim .unspecified .known
+
+/-- In a fully labeled system the grammar always determines a concrete
+discourse gender: underspecification ([arnold-2026]) arises from the
+discourse, not from a resolved morphosyntax. -/
+theorem genderInfo_known (sys : Gender.System G)
+    (value : Gender.Signed → G) (hlab : ∀ g, (sys.label g).isSome)
+    (ch : Categorizer.Head) :
+    ∃ g, ch.genderInfo sys value = .known g := by
+  obtain ⟨g, hg⟩ := Option.isSome_iff_exists.mp (hlab (ch.realizeGender sys value))
+  exact ⟨g, by simp [Categorizer.Head.genderInfo, hg]⟩
 
 end DistributedMorphology

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -274,7 +274,7 @@ inductive ImpoverishmentContext where
     exponent, so the unmarked feminine surfaces. -/
 structure GenderImpoverishmentRule where
   /-- The feature to be deleted. -/
-  targetGender : GenderVal
+  targetGender : Gender.Signed
   /-- The conditioning context (feature that triggers deletion). -/
   context : ImpoverishmentContext
   deriving DecidableEq, Repr
@@ -430,7 +430,7 @@ Two-gender systems arise when only one marked value + plain are attested. -/
     Two n heads produce the same surface gender iff they have the same
     gender feature content (ignoring interpretability, which is only
     visible at LF vs PF). -/
-def surfaceGenderClass (nh : Head) : Option GenderVal :=
+def surfaceGenderClass (nh : Head) : Option Gender.Signed :=
   nh.phi.gender.map (·.val)
 
 /-- The four Amharic n-types yield exactly 3 surface genders:

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -187,13 +187,11 @@ inductive GenderNode where
   | anim   -- animate (BCS: under MASC)
   deriving DecidableEq, Repr
 
-open DistributedMorphology (GenderDimension)
-
 /-- Partial bridge from privative geometry nodes to DM gender dimensions.
     `.cls`, `.indiv`, and `.grp` are structural organizing nodes with no
-    counterpart in the DM `GenderDimension` type (which tracks only
+    counterpart in the DM `Gender.Dimension` type (which tracks only
     semantic gender dimensions). -/
-def GenderNode.toGenderDimension : GenderNode → Option GenderDimension
+def GenderNode.toGenderDimension : GenderNode → Option Gender.Dimension
   | .masc => some .masc
   | .fem  => some .fem
   | .anim => some .anim

--- a/Linglib/Studies/Faust2026.lean
+++ b/Linglib/Studies/Faust2026.lean
@@ -117,14 +117,15 @@ in any morphosyntactic context, intruder-bearing ones require external
 licensing — see `intrusionLicensed`. -/
 abbrev hasIntruder : Prop := ∃ a ∈ m.associations, a.source = .affix
 
-/-- A match is *intrusion-licensed* under an external licensing flag iff
-either the morphosyntactic context licenses an intruding sister bound root
-([lowenstamm-2014]) or the match contains no intruders. For [faust-2026]'s
-analysis the flag is `true` iff the template is realized at an n[+gen]
-head in [kramer-2020]'s sense; verbal templates, whose gender lives on a
-higher Agr head, evaluate to `false` and admit no intrusion. -/
-abbrev intrusionLicensed (licensed : Bool) : Prop :=
-  licensed = true ∨ ¬ m.hasIntruder
+/-- A match is *intrusion-licensed* under an external licensing condition
+iff either the morphosyntactic context licenses an intruding sister bound
+root ([lowenstamm-2014]) or the match contains no intruders. For
+[faust-2026]'s analysis the condition holds iff the template is realized
+at an n[+gen] head in [kramer-2020]'s sense
+(`Categorizer.Head.LicensesIntrusion`); verbal templates, whose gender
+lives on a higher Agr head, admit no intrusion. -/
+abbrev intrusionLicensed (licensed : Prop) : Prop :=
+  licensed ∨ ¬ m.hasIntruder
 
 end Morphology.TemplateMatch
 
@@ -156,20 +157,20 @@ theorem not_isMisaligned_of_all_intruder (r : ConsonantalRoot α) (t : CVTemplat
 licensing iff either the external predicate licenses intrusion or the
 match is intruder-free — the formal content of the verbal/nominal
 asymmetry. -/
-theorem intrusionLicensed_iff (m : TemplateMatch α) (licensed : Bool) :
+theorem intrusionLicensed_iff (m : TemplateMatch α) (licensed : Prop) :
     m.intrusionLicensed licensed ↔
-      licensed = true ∨ ¬ m.hasIntruder := Iff.rfl
+      licensed ∨ ¬ m.hasIntruder := Iff.rfl
 
 /-- Intruder-free matches are licensed in any morphosyntactic context. -/
 theorem intrusionLicensed_of_no_intruder (m : TemplateMatch α)
-    (h : ¬ m.hasIntruder) (licensed : Bool) :
+    (h : ¬ m.hasIntruder) (licensed : Prop) :
     m.intrusionLicensed licensed := Or.inr h
 
-/-- An intruder-bearing match is licensed iff the external predicate is
-`true` — the contrapositive that delivers the verbal/nominal split. -/
+/-- An intruder-bearing match is licensed iff the external condition
+holds — the contrapositive that delivers the verbal/nominal split. -/
 theorem intrusionLicensed_with_intruder (m : TemplateMatch α)
-    (h : m.hasIntruder) (licensed : Bool) :
-    m.intrusionLicensed licensed ↔ licensed = true := by
+    (h : m.hasIntruder) (licensed : Prop) :
+    m.intrusionLicensed licensed ↔ licensed := by
   simp [TemplateMatch.intrusionLicensed, h]
 
 /-! ### *Misalignment as an alignment constraint -/
@@ -914,12 +915,12 @@ Kramer's `Categorizer.Head` taxonomy changes. -/
 
 open DistributedMorphology (Categorizer.Head)
 
-/-! The morphological-licensing predicate `Categorizer.Head.licensesIntrusion`
+/-! The morphological-licensing predicate `Categorizer.Head.LicensesIntrusion`
 itself lives in `Morphology/DistributedMorphology/Categorizer.lean` (alongside
 the Kramer taxonomy it ranges over), together with its per-canonical-
 head verification theorems (`n_uFem_licenses_intrusion`,
 `v_plain_blocks_intrusion`, etc.) and the iff characterization
-`DistributedMorphology.licensesIntrusion_iff_n_and_gen`. The Faust-specific
+`DistributedMorphology.LicensesIntrusion_iff_n_and_gen`. The Faust-specific
 content of §12 is the *per-template `Categorizer.Head` tagging* and the
 per-derivation verdicts below. -/
 
@@ -973,16 +974,10 @@ instances of this universal claim. -/
     disjunct holds for the specific (match, head) pair. -/
 theorem intrusion_wellformed_iff_no_intruder_or_n_with_gen
     (m : TemplateMatch String) (ch : Categorizer.Head) :
-    m.intrusionLicensed ch.licensesIntrusion ↔
-      ¬ m.hasIntruder ∨ (ch.categorizer = .n ∧ ch.phi.gender.isSome = true) := by
+    m.intrusionLicensed ch.LicensesIntrusion ↔
+      ¬ m.hasIntruder ∨ (ch.categorizer = .n ∧ ch.phi.gender.isSome) := by
   rw [intrusionLicensed_iff]
-  constructor
-  · rintro (hlic | hno)
-    · exact Or.inr ((DistributedMorphology.licensesIntrusion_iff_n_and_gen ch).mp hlic)
-    · exact Or.inl hno
-  · rintro (hno | hgen)
-    · exact Or.inr hno
-    · exact Or.inl ((DistributedMorphology.licensesIntrusion_iff_n_and_gen ch).mpr hgen)
+  exact or_comm
 
 /-- **Corollary (verbal half).** Under a verbal locus (`v_plain`, with
     no gender feature), licensing reduces to intruder-freeness. This is
@@ -990,7 +985,7 @@ theorem intrusion_wellformed_iff_no_intruder_or_n_with_gen
     to be morphologically licensed — the spreading and empty-slot
     strategies are the only options open to v. -/
 theorem v_plain_licenses_iff_no_intruder (m : TemplateMatch String) :
-    m.intrusionLicensed Categorizer.Head.v_plain.licensesIntrusion ↔
+    m.intrusionLicensed Categorizer.Head.v_plain.LicensesIntrusion ↔
       ¬ m.hasIntruder := by
   rw [intrusion_wellformed_iff_no_intruder_or_n_with_gen]
   constructor
@@ -1005,14 +1000,14 @@ theorem v_plain_licenses_iff_no_intruder (m : TemplateMatch String) :
     like Hebrew taQTiL and Amharic gerunds/INFs — the Kramer-2020
     structure makes the n[+gen] exponent morphosyntactically present. -/
 theorem n_uFem_licenses_universally (m : TemplateMatch String) :
-    m.intrusionLicensed Categorizer.Head.n_uFem.licensesIntrusion := by
+    m.intrusionLicensed Categorizer.Head.n_uFem.LicensesIntrusion := by
   rw [intrusion_wellformed_iff_no_intruder_or_n_with_gen]
   exact Or.inr ⟨rfl, rfl⟩
 
 /-! #### Per-derivation licensing theorems
 
 For every match, the predicate `TemplateMatch.intrusionLicensed`
-applied to the corresponding template's `Categorizer.Head.licensesIntrusion`
+applied to the corresponding template's `Categorizer.Head.LicensesIntrusion`
 gives the well-formedness verdict. The proofs are `decide` — the
 disjunction reduces by `rfl` once the predicates evaluate. -/
 
@@ -1020,23 +1015,23 @@ disjunction reduces by `rfl` once the predicates evaluate. -/
 
 theorem kalat_licensed_at_v :
     hebrewKlt_kalat.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion := by decide
+      hebrewPst3msg_locus.LicensesIntrusion := by decide
 
 theorem kalal_kll_licensed_at_v :
     hebrewKll_kalal.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion := by decide
+      hebrewPst3msg_locus.LicensesIntrusion := by decide
 
 theorem kala_licensed_at_v :
     hebrewKlj_kala.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion := by decide
+      hebrewPst3msg_locus.LicensesIntrusion := by decide
 
 theorem kalal_klj_licensed_at_v :
     hebrewKlj_kalal.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion := by decide
+      hebrewPst3msg_locus.LicensesIntrusion := by decide
 
 theorem kaluj_licensed_at_v :
     hebrewKlj_kaluj.intrusionLicensed
-      hebrewPassPrtcpl_locus.licensesIntrusion := by decide
+      hebrewPassPrtcpl_locus.LicensesIntrusion := by decide
 
 /-! ##### Hebrew nominal taQTiL (intrusion possible) -/
 
@@ -1046,29 +1041,29 @@ theorem kaluj_licensed_at_v :
     morphological licensing — a useful separation. -/
 theorem dmj_illicit_licensed_at_n :
     hebrewDmj_illicit.intrusionLicensed
-      hebrewTaQTiL_locus.licensesIntrusion := by decide
+      hebrewTaQTiL_locus.LicensesIntrusion := by decide
 
 theorem tadmit_licensed_at_n :
     hebrewDmj_tadmit.intrusionLicensed
-      hebrewTaQTiL_locus.licensesIntrusion := by decide
+      hebrewTaQTiL_locus.LicensesIntrusion := by decide
 
 /-! ##### Amharic verbal vs nominal -/
 
 theorem fdj_pfv_licensed_at_v :
     amharicFdj_pfv.intrusionLicensed
-      amharicPfv3msg_locus.licensesIntrusion := by decide
+      amharicPfv3msg_locus.LicensesIntrusion := by decide
 
 theorem wd_pfv_licensed_at_v :
     amharicWd_pfv.intrusionLicensed
-      amharicPfv3msg_locus.licensesIntrusion := by decide
+      amharicPfv3msg_locus.LicensesIntrusion := by decide
 
 theorem fdj_grnd_licensed_at_n :
     amharicFdj_grnd.intrusionLicensed
-      amharicGrnd_locus.licensesIntrusion := by decide
+      amharicGrnd_locus.LicensesIntrusion := by decide
 
 theorem sma_inf_licensed_at_n :
     amharicSma_inf.intrusionLicensed
-      amharicInf_locus.licensesIntrusion := by decide
+      amharicInf_locus.LicensesIntrusion := by decide
 
 /-! #### The verbal-intrusion blocking theorem
 
@@ -1102,7 +1097,7 @@ theorem hebrew_pst3msg_intrusion_prosodically_satisfies :
     it fails: v-locus does not license n[+gen]'s /t/ exponent. -/
 theorem hebrew_pst3msg_intrusion_morphologically_blocked :
     ¬ hebrewDmj_pst3msg_intrusion.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion := by decide
+      hebrewPst3msg_locus.LicensesIntrusion := by decide
 
 /-! #### The cross-paper integration theorem -/
 
@@ -1130,20 +1125,20 @@ theorem hebrew_pst3msg_intrusion_morphologically_blocked :
 theorem verbal_nominal_asymmetry_from_kramer :
     -- Nominal locus licenses intrusion candidates
     hebrewDmj_tadmit.intrusionLicensed
-      hebrewTaQTiL_locus.licensesIntrusion ∧
+      hebrewTaQTiL_locus.LicensesIntrusion ∧
     amharicFdj_grnd.intrusionLicensed
-      amharicGrnd_locus.licensesIntrusion ∧
+      amharicGrnd_locus.LicensesIntrusion ∧
     -- Verbal locus blocks intrusion candidates
     ¬ hebrewDmj_pst3msg_intrusion.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion ∧
+      hebrewPst3msg_locus.LicensesIntrusion ∧
     -- The verbal candidate's prosodic satisfaction is irrelevant —
     -- it satisfies the template but fails the morphological licensing
     hebrewDmj_pst3msg_intrusion.satisfies ∧
     -- Intruder-free verbal forms always pass
     hebrewKlj_kala.intrusionLicensed
-      hebrewPst3msg_locus.licensesIntrusion ∧
+      hebrewPst3msg_locus.LicensesIntrusion ∧
     amharicFdj_pfv.intrusionLicensed
-      amharicPfv3msg_locus.licensesIntrusion := by
+      amharicPfv3msg_locus.LicensesIntrusion := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
 
 end Faust2026

--- a/Linglib/Studies/HalpertHammerly2026.lean
+++ b/Linglib/Studies/HalpertHammerly2026.lean
@@ -417,7 +417,7 @@ open DistributedMorphology
     `GenderFeature` on the categorizing head n.
 
     H&H's `AnimacyFeatures` encode core noun class via [±Animate, ±Human].
-    Kramer's framework uses `GenderDimension.anim` with interpretability.
+    Kramer's framework uses `Gender.Dimension.anim` with interpretability.
     The bridge maps:
     - [+Animate] (human or animal) → i[+ANIM] (interpretable animate)
     - [−Animate] (inanimate) → i[−ANIM] (interpretable inanimate)
@@ -425,12 +425,12 @@ open DistributedMorphology
     Both systems agree that the n-head bears gender features and that
     interpretability distinguishes natural from arbitrary gender. -/
 def toGenderFeature (af : AnimacyFeatures) : GenderFeature :=
-  { interp := .i, val := { dim := .anim, pol := if af.isAnimate then .pos else .neg } }
+  { interp := .i, val := { dim := .anim, pole := if af.isAnimate then .pos else .neg } }
 
 private def iAnimPos : GenderFeature :=
-  { interp := .i, val := { dim := .anim, pol := .pos } }
+  { interp := .i, val := { dim := .anim, pole := .pos } }
 private def iAnimNeg : GenderFeature :=
-  { interp := .i, val := { dim := .anim, pol := .neg } }
+  { interp := .i, val := { dim := .anim, pole := .neg } }
 
 theorem human_is_iAnimPos :
     toGenderFeature AnimacyFeatures.human = iAnimPos := rfl
@@ -455,7 +455,7 @@ theorem interpretability_alignment :
     GenderStatus.isInterpretable (.interpretable .human) = true ∧
     GenderStatus.isInterpretable .uninterpretable = false ∧
     GenderFeature.IsNatural iAnimPos ∧
-    GenderFeature.IsArbitrary { interp := .u, val := { dim := .anim, pol := .pos } } :=
+    GenderFeature.IsArbitrary { interp := .u, val := { dim := .anim, pole := .pos } } :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 end KramerBridge

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -43,8 +43,8 @@ set_option autoImplicit false
 
 namespace KonnellyCowper2020
 
-open DistributedMorphology (Contrastivity GenderFeature GenderVal GenderDimension
-  Polarity Interpretability Categorizer.Head PhiBundle)
+open DistributedMorphology (Contrastivity GenderFeature
+  Interpretability Categorizer.Head PhiBundle)
 open DistributedMorphology.VI (FeatureVI subsetPrinciple)
 
 -- ============================================================================

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -31,7 +31,7 @@ assignment. Three main results:
 
 - **Typology ↔ DM bridge**: `SemanticBasis.toGenderDimension` connects the
   typological `SemanticBasis` (from `Studies/Corbett1991.lean`) to
-  the DM `GenderDimension` (from `Morphology/DistributedMorphology/Categorizer.lean`),
+  the DM `Gender.Dimension` (from `Morphology/DistributedMorphology/Categorizer.lean`),
   making explicit that the semantic core properties are the *same things*
   parameterized as feature dimensions in the structural approach.
 
@@ -45,10 +45,10 @@ assignment. Three main results:
 -/
 
 -- ============================================================================
--- § 2: SemanticBasis ↔ GenderDimension Bridge (in source namespaces)
+-- § 2: SemanticBasis ↔ Gender.Dimension Bridge (in source namespaces)
 -- ============================================================================
 
-/-! The typological `SemanticBasis` and the DM `GenderDimension` describe the
+/-! The typological `SemanticBasis` and the DM `Gender.Dimension` describe the
 same underlying distinction from different perspectives: typology asks *what
 semantic property organizes the system*, while DM asks *what binary feature
 sits on n*. [kramer-2020] makes this connection explicit by analyzing
@@ -97,7 +97,7 @@ instance : DecidablePred Profile.SatisfiesSemanticCore := fun p =>
     The `.humanness` → `.anim` mapping reflects a gap in [kramer-2015]'s
     feature inventory: no [±HUMAN] dimension is posited, so humanness-based
     systems are approximated by [±ANIM]. -/
-def SemanticBasis.toGenderDimension : SemanticBasis → Option GenderDimension
+def SemanticBasis.toGenderDimension : SemanticBasis → Option Gender.Dimension
   | .sex         => some .fem   -- default: feminine as marked value
   | .animacy     => some .anim
   | .humanness   => some .anim  -- no [±HUMAN] in Kramer 2015; closest is [±ANIM]
@@ -112,7 +112,7 @@ open Corbett1991
 
 /-- Inverse direction: map a DM gender dimension to its typological basis.
     ([kramer-2020] §3) -/
-def GenderDimension.toSemanticBasis : GenderDimension → Corbett1991.SemanticBasis
+def Gender.Dimension.toSemanticBasis : Gender.Dimension → Corbett1991.SemanticBasis
   | .fem  => .sex
   | .masc => .sex
   | .anim => .animacy
@@ -166,7 +166,7 @@ theorem roundtrip_sex_fem :
 
 /-- Round-trip: `.anim` → `.animacy` → `.anim`. -/
 theorem roundtrip_anim :
-    GenderDimension.anim.toSemanticBasis.toGenderDimension = some .anim := rfl
+    Gender.Dimension.anim.toSemanticBasis.toGenderDimension = some .anim := rfl
 
 -- ============================================================================
 -- § 3: Cross-Linguistic Variation in Arbitrary Assignment (Table 2)
@@ -260,7 +260,7 @@ structure LexicalGenderRule where
   /-- Semantic trigger (e.g. sex → social gender triggers the rule) -/
   semanticBasis : SemanticBasis
   /-- DM gender dimension assigned (e.g. fem) -/
-  targetDimension : GenderDimension
+  targetDimension : Gender.Dimension
   /-- Context restriction (e.g. humanness) -/
   context : SemanticBasis
   deriving DecidableEq, Repr
@@ -519,9 +519,9 @@ structure HybridNoun where
   /-- Language -/
   language : String
   /-- Morphosyntactic gender (from n head) -/
-  morphGender : GenderVal
+  morphGender : Gender.Signed
   /-- Semantic gender (from social-gender projection, triggered by referent) -/
-  semGender : GenderVal
+  semGender : Gender.Signed
   /-- The two genders must differ for hybrid agreement to arise. -/
   distinct : morphGender ≠ semGender
   deriving Repr
@@ -964,67 +964,113 @@ In Set 2 languages (Maa, Wari'), the same logic yields feminine as default:
 The polarity of the u-feature determines which gender is arbitrary vs default. -/
 
 
--- Set 1 (Spanish) derivation chain — uses DM bridge (Categorizer.Head.surfaceGenderSet1)
+-- Set 1 (Spanish) derivation chain: Vocabulary Insertion into the Spanish
+-- fragment's own gender system (`Fragments/Spanish/Gender.lean`)
+
+/-- The Spanish valuation: [+FEM] realizes the feminine class, everything
+    else the masculine. -/
+def spanishValue : Gender.Signed → Spanish.Gender.Value
+  | ⟨.fem, .pos⟩ => .fem
+  | _            => .masc
+
+/-- Spanish is a Set 1 system: [+FEM] realizes the feminine-labeled class
+    and the default is masculine-labeled. -/
+theorem spanish_isSet1 : IsSet1 Spanish.Gender.system spanishValue := ⟨rfl, rfl⟩
 
 /-- Plain n → masculine (the default). -/
 theorem set1_plain_n_masculine :
-    Categorizer.Head.n_plain.surfaceGenderSet1 = .masculine := rfl
+    Categorizer.Head.n_plain.realizeGender Spanish.Gender.system spanishValue
+      = .masc := rfl
 
 /-- i[+FEM] → feminine (natural female). -/
 theorem set1_iFem_feminine :
-    Categorizer.Head.n_iFem.surfaceGenderSet1 = .feminine := rfl
+    Categorizer.Head.n_iFem.realizeGender Spanish.Gender.system spanishValue
+      = .fem := rfl
 
 /-- i[−FEM] → masculine (natural male). -/
 theorem set1_iMasc_masculine :
-    Categorizer.Head.n_iMasc.surfaceGenderSet1 = .masculine := rfl
+    Categorizer.Head.n_iMasc.realizeGender Spanish.Gender.system spanishValue
+      = .masc := rfl
 
 /-- u[+FEM] → feminine (arbitrary feminine). -/
 theorem set1_uFem_feminine :
-    Categorizer.Head.n_uFem.surfaceGenderSet1 = .feminine := rfl
+    Categorizer.Head.n_uFem.realizeGender Spanish.Gender.system spanishValue
+      = .fem := rfl
 
--- Set 2 (Maa) derivation chain — uses DM bridge (Categorizer.Head.surfaceGenderSet2)
+-- Set 2 (Maa) derivation chain: a study-local Maa system
+
+/-- Maa's two controller genders ([kramer-2015] §6.3). -/
+inductive MaaValue where
+  | masc
+  | fem
+  deriving DecidableEq, Repr
+
+/-- The Maa system: full comparative labelling, feminine default. -/
+def maaSystem : Gender.System MaaValue where
+  label := fun g => match g with
+    | .masc => some .masculine
+    | .fem  => some .feminine
+  default := .fem
+
+/-- The Maa valuation: [−FEM] realizes the masculine class. -/
+def maaValue : Gender.Signed → MaaValue
+  | ⟨.fem, .neg⟩ => .masc
+  | _            => .fem
+
+/-- Maa is a Set 2 system: [−FEM] realizes the masculine-labeled class
+    and the default is feminine-labeled. -/
+theorem maa_isSet2 : IsSet2 maaSystem maaValue := ⟨rfl, rfl⟩
 
 /-- Plain n → feminine (the default in Set 2). -/
 theorem set2_plain_n_feminine :
-    Categorizer.Head.n_plain.surfaceGenderSet2 = .feminine := rfl
+    Categorizer.Head.n_plain.realizeGender maaSystem maaValue = .fem := rfl
 
 /-- u[−FEM] → masculine (arbitrary masculine in Set 2). -/
 theorem set2_uNegFem_masculine :
-    Categorizer.Head.n_uNegFem.surfaceGenderSet2 = .masculine := rfl
+    Categorizer.Head.n_uNegFem.realizeGender maaSystem maaValue = .masc := rfl
 
 /-- i[−FEM] → masculine (natural male, same in both sets). -/
 theorem set2_iMasc_masculine :
-    Categorizer.Head.n_iMasc.surfaceGenderSet2 = .masculine := rfl
+    Categorizer.Head.n_iMasc.realizeGender maaSystem maaValue = .masc := rfl
 
 /-- i[+FEM] → feminine (natural female, same in both sets). -/
 theorem set2_iFem_feminine :
-    Categorizer.Head.n_iFem.surfaceGenderSet2 = .feminine := rfl
+    Categorizer.Head.n_iFem.realizeGender maaSystem maaValue = .fem := rfl
 
 /-- Verify the full derivation chain for Spanish fragment nouns: the
-    surface gender computed via `Spanish.nHead` projection then Set 1 VI
-    matches the entry's `attestedGender`. -/
+    controller gender computed via `Spanish.nHead` projection then Set 1
+    VI into the fragment's system. -/
 theorem spanish_derivation_chain :
-    (Spanish.nHead Spanish.Gender.mujer).surfaceGenderSet1 = .feminine ∧
-    (Spanish.nHead Spanish.Gender.hombre).surfaceGenderSet1 = .masculine ∧
-    (Spanish.nHead Spanish.Gender.mesa).surfaceGenderSet1 = .feminine ∧
-    (Spanish.nHead Spanish.Gender.libro).surfaceGenderSet1 = .masculine ∧
-    (Spanish.nHead Spanish.Gender.persona).surfaceGenderSet1 = .feminine ∧
-    (Spanish.nHead Spanish.Gender.ángel).surfaceGenderSet1 = .masculine :=
+    (Spanish.nHead Spanish.Gender.mujer).realizeGender
+        Spanish.Gender.system spanishValue = .fem ∧
+    (Spanish.nHead Spanish.Gender.hombre).realizeGender
+        Spanish.Gender.system spanishValue = .masc ∧
+    (Spanish.nHead Spanish.Gender.mesa).realizeGender
+        Spanish.Gender.system spanishValue = .fem ∧
+    (Spanish.nHead Spanish.Gender.libro).realizeGender
+        Spanish.Gender.system spanishValue = .masc ∧
+    (Spanish.nHead Spanish.Gender.persona).realizeGender
+        Spanish.Gender.system spanishValue = .fem ∧
+    (Spanish.nHead Spanish.Gender.ángel).realizeGender
+        Spanish.Gender.system spanishValue = .masc :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 /-- Stronger meta-theorem: for every Spanish entry, the projection
-    composed with Set 1 VI recovers the entry's attestedGender. The
-    Fragment-side empirical fact (`attestedGender`) and the Studies-side
-    structural derivation (Spanish.nHead + Set 1 VI) agree. -/
+    composed with Set 1 VI recovers the entry's controller gender — the
+    Fragment-side empirical fact and the Studies-side structural
+    derivation agree, entirely inside the fragment's own carrier. -/
 theorem spanish_projection_round_trips :
     Spanish.Gender.allNouns.all (fun n =>
-      (Spanish.nHead n).surfaceGenderSet1 == n.attestedGender) := by decide
+      (Spanish.nHead n).realizeGender Spanish.Gender.system spanishValue
+        == n.controllerGender) := by decide
 
-/-- Fixed-gender nouns: *persona* surfaces as feminine despite denoting
-    persons of any sex; *ángel* surfaces as masculine. -/
+/-- Fixed-gender nouns: *persona* surfaces in the feminine class despite
+    denoting persons of any sex; *ángel* in the masculine. -/
 theorem fixed_gender_from_n_head :
-    (Spanish.nHead Spanish.Gender.persona).surfaceGenderSet1 = .feminine ∧
-    (Spanish.nHead Spanish.Gender.ángel).surfaceGenderSet1 = .masculine :=
+    (Spanish.nHead Spanish.Gender.persona).realizeGender
+        Spanish.Gender.system spanishValue = .fem ∧
+    (Spanish.nHead Spanish.Gender.ángel).realizeGender
+        Spanish.Gender.system spanishValue = .masc :=
   ⟨rfl, rfl⟩
 
 -- ============================================================================
@@ -1087,21 +1133,36 @@ theorem vrač_matches_hybrid :
     (Russian.nHead Russian.Gender.vrač).phi.gender =
       some ⟨.u, russianVrac.morphGender⟩ := ⟨rfl, rfl⟩
 
-/-- Projection-derived: *zakon* (Class I) surfaces as masculine via 3-gender VI. -/
-theorem zakon_fragment_masculine :
-    (Russian.nHead Russian.Gender.zakon).surfaceGenderThree =
-      .masculine := rfl
+/-- The Russian valuation: [+FEM] realizes the feminine class, [−FEM]
+    the masculine; the neuter default covers plain n. -/
+def russianValue : Gender.Signed → Russian.Gender.Value
+  | ⟨.fem, .pos⟩ => .fem
+  | _            => .masc
 
-/-- Projection-derived: *vino* (default) surfaces as neuter via 3-gender VI. -/
+/-- Russian is a three-gender system: both FEM poles realized, neuter
+    default. -/
+theorem russian_isThreeGender :
+    IsThreeGender Russian.Gender.system russianValue := ⟨rfl, rfl, rfl⟩
+
+/-- Projection-derived: *zakon* (Class I) surfaces in the masculine class
+    via 3-gender VI. -/
+theorem zakon_fragment_masculine :
+    (Russian.nHead Russian.Gender.zakon).realizeGender
+      Russian.Gender.system russianValue = .masc := rfl
+
+/-- Projection-derived: *vino* (default) surfaces in the neuter class via
+    3-gender VI. -/
 theorem vino_fragment_neuter :
-    (Russian.nHead Russian.Gender.vino).surfaceGenderThree =
-      .neuter := rfl
+    (Russian.nHead Russian.Gender.vino).realizeGender
+      Russian.Gender.system russianValue = .neut := rfl
 
 /-- Russian projection round-trip: every Russian entry's projection,
-    composed with 3-gender VI, recovers the entry's `attestedGender`. -/
+    composed with 3-gender VI into the fragment's system, recovers the
+    entry's controller gender. -/
 theorem russian_projection_round_trips :
     Russian.Gender.allNouns.all (fun n =>
-      (Russian.nHead n).surfaceGenderThree == n.attestedGender) := by decide
+      (Russian.nHead n).realizeGender Russian.Gender.system russianValue
+        == Russian.Gender.Value.ofLabel n.attestedGender) := by decide
 
 /-- Projection-derived: Russian Fragment covers all 5 n-types. -/
 theorem russian_fragment_covers_inventory :


### PR DESCRIPTION
Regrounds DM gender realization on the upstream carrier discipline: Vocabulary Insertion lands in the language's own `Gender.System`, not in the comparative labels.

- The dimension calculus (`Gender.Dimension`/`Pole`/`Signed` with `surface` and the Maa/Jarawara underdetermination theorem) moves to `Features/Gender/Decomposition.lean`, beside `SplitFeature` and `KramerN`.
- The four `surfaceGender*` maps, their verification tables, and the `_eq_surface` scaffolding collapse into one `realizeGender (sys : Gender.System G) value` with `sys.default` as the Set 1/Set 2 parameter; the attested patterns become label constraints `IsSet1` … `IsAnimacyBased` with `not_isSet1_and_isSet2`; `realizeGender_congr` states PF-blindness to interpretability.
- Head zoo via `Categorizer.Head.gendered` + `gendered_inj` (three distinctness decide-tables deleted); `LicensesIntrusion` is now a Prop (six per-head rfl instances deleted, Faust2026's `intrusionLicensed` goes Prop-native); `RootLicense`/`satisfiesLicense` deleted as consumerless.
- Kramer2020's derivation chains now run through the Spanish and Russian fragments' own systems (carrier-level round-trips) plus a study-local Maa system.