### PR TITLE
refactor(Morphology/DistributedMorphology): Allosemy typed denotations

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -7,50 +7,60 @@ import Linglib.Semantics.ArgumentStructure.Root.Classification
 import Linglib.Syntax.Minimalist.Verbal.Voice
 
 /-!
-# Allosemy: Contextual Meaning Variation of Functional Heads
+# Allosemy
 
-[benz-2025] "Structure and Interpretation Across Categories" examines allosemy — the
-meaning-side analog of allomorphy in Distributed Morphology. Where
-allomorphy concerns contextually conditioned variation in *form* (PF),
-allosemy concerns contextually conditioned variation in *meaning* (LF).
+Allosemy is contextual meaning variation of a single functional head —
+the LF analogue of allomorphy. The heads v, n, and Voice each carry
+several allosemes, selected by the syntactic context rather than tracked
+by morphosyntactic features, and the ambiguity of deverbal
+nominalizations between event, result, state, entity, and content
+readings is the visible trace of that selection. The alloseme
+inventories here compose: the typed denotations of `VAlloseme.denote`
+and `NAlloseme.denote` derive the reading typology, and the analytical
+choice of where the eventive component lives — v or n — is provably
+immaterial for the result and content readings.
 
-The key claim: several functional heads (v, n, Voice, α) systematically
-receive different interpretations depending on their syntactic context,
-and these meaning alternations are **not tracked by morphosyntactic
-features**. The syntax does not distinguish Voice_Agent from Voice_Holder
-featurally; the distinction is resolved at LF by the semantics of the
-VP complement.
+## Main definitions
 
-## Existing infrastructure as allosemy instances
+* `VAlloseme`, `NAlloseme`, `VoiceAlloseme` — the alloseme inventories
+  of v, n, and Voice
+* `vAllosemic`, `nAllosemic` — v and n as `AllosemicHead`s over the
+  shared selection engine
+* `NominalizationReading`, `readingFromAllosemes` — the reading typology
+  of deverbal nominalizations and its alloseme table
+* `NominalizationModel`, `VAlloseme.denote`, `NAlloseme.denote` — typed
+  alloseme denotations and their composition
 
-linglib already formalizes several cases of allosemy without naming them:
+## Main statements
 
-- `CategorizerSemantics.NSemanticType`: n has three allosemes
-  (relational/sortal/alienator), selected by `selectsD` and context
-- `Minimalist.Voice.Flavor`: Voice has six flavors (agentive/causer/
-  nonThematic/expletive/impersonal/passive), each with different semantics
-- `Verb.Root.ChangeType` / `Verb.Root.Classification.changeType`: roots vary in
-  whether they entail change, conditioning the semantics of the v that embeds them
+* `result_options_agree`, `content_options_agree` — the two analytical
+  options for the result and content readings compose to the same
+  denotation: the event and result readings are mirror images
+* `readingFromAllosemes_isSome_iff_denote` — the reading table has a
+  reading exactly where the composed denotation is defined
+* `cen_result_ambiguity` — one deverbal context licenses several n
+  allosemes: nominalization ambiguity as non-singleton licensing
+* `vAllosemic_isAllosemous` — v's contextual meaning variation on the
+  shared `Realization.Interpreted` carrier
 
-The general abstraction — `AllosemicEntry` and `AllosemicHead`, a single
-morpheme with multiple context-dependent meanings — lives in
-`DistributedMorphology/Defs.lean`, with its selection-engine instances in
-`Basic.lean`. This module instantiates it for v (critical for [benz-2025]
-Ch. 3 on nominalizations) and retroactively classifies existing n and
-Voice types as allosemy.
+## Implementation notes
 
-## The List-2 / List-3 symmetry, by construction
+`AllosemicEntry` is a `Morphology.Exponence.Rule` instance, just as
+`VI.VocabItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
+selection engine: `Exponence.selectBy` on the non-wildcard-field score
+(`selectBy_score_isElsewhereWinner`). `VoiceAlloseme.fromComplement` is
+a worked List-3 competition on that engine; `readingFromAllosemes` is a
+different object — the composition of two already-selected allosemes.
+Existing infrastructure this module retroactively classifies as
+allosemy: `CategorizerSemantics.NSemanticType` (n), `Minimalist.Voice.Flavor`
+(Voice), and root change-type conditioning of v.
 
-`AllosemicEntry` is a `Morphology.Exponence.Rule` instance
-(`SyntacticContext.matches` as applicability, denotation as exponent),
-just as `DistributedMorphology.VI.VocabItem` is. So DM's List 2 (form) and List 3 (meaning)
-are resolved by **one** selection engine: `Exponence.selectBy` on the
-non-wildcard-field score, whose winner is the Elsewhere winner
-(`selectBy_score_isElsewhereWinner`). `VoiceAlloseme.fromComplement` is a
-worked List-3 competition over that engine. `readingFromAllosemes` is a
-different object — the List-3 *composition* of two already-selected
-allosemes (v ⊕ n), not a single-head competition — so it stays a table.
+## References
 
+* [I. Benz, *Structure and interpretation across categories*][benz-2025]
+* [J. Wood, *Icelandic nominalizations and allosemy*][wood-2023]
+* [A. Kratzer, *Severing the external argument from its verb*][kratzer-1996]
+* [N. Myler, *Building and interpreting possession sentences*][myler-2016]
 -/
 
 namespace DistributedMorphology.Allosemy
@@ -59,32 +69,16 @@ open DistributedMorphology (Categorizer Categorizer.Head)
 open DistributedMorphology.CategorizerSemantics (NSemanticType)
 open Minimalist.Voice (Flavor Head)
 
--- ════════════════════════════════════════════════════
--- § 1. v Allosemy (Ch. 3)
--- ════════════════════════════════════════════════════
+/-! ### v allosemy -/
 
-/-- Allosemes of the verbal categorizer v.
-
-    [benz-2025] §2.2 / [wood-2023] Ch. 5: v can be semantically
-    null (identity function) or contribute eventive semantics, depending
-    on its syntactic context. This distinction drives the nominalization
-    reading typology:
-
-    - `eventive`: v introduces an event variable and contributes the
-      normal verbal interpretation. Yields CEN reading in nominalizations
-      ("the frequent observation of the sky").
-    - `zero`: v is semantically Ø (identity function). The root combines
-      directly with n, yielding SEN or RN readings depending on n's
-      alloseme. [wood-2023] Ch. 5: "When n is semantically zero and
-      v gets its ordinary verbal interpretation" (CEN); "when the v head
-      is Ø" the root interacts directly with n (SEN/RN).
-
-    In nominalization contexts, both allosemes are available for the
-    same root — the ambiguity between CEN and RN/SEN readings arises
-    from v's alloseme varying, not from the root changing. -/
+/-- Allosemes of the verbal categorizer v ([benz-2025] §2.2;
+    [wood-2023]): v either contributes eventive semantics or is
+    semantically null, and in nominalization contexts both are available
+    for the same root — the CEN vs SEN/RN ambiguity arises from v's
+    alloseme, not from the root. -/
 inductive VAlloseme where
   | eventive   -- introduces an event variable (CEN contexts)
-  | zero       -- semantically Ø / identity function (SEN/RN contexts)
+  | zero       -- semantically Ø / identity (SEN/RN contexts)
   deriving DecidableEq, Repr
 
 /-- Does this v alloseme introduce an event variable? -/
@@ -92,7 +86,8 @@ def VAlloseme.introducesEvent : VAlloseme → Bool
   | .eventive => true
   | .zero     => false
 
-/-- v allosemy as an `AllosemicHead`. -/
+/-- v allosemy as an `AllosemicHead`: eventive under an eventive
+complement, zero elsewhere. -/
 def vAllosemic : AllosemicHead VAlloseme where
   morpheme := .v
   entries := [
@@ -104,89 +99,48 @@ def vAllosemic : AllosemicHead VAlloseme where
     , context := { complementIsEventive := false } }
   ]
 
-/-- v has exactly two allosemes. -/
-theorem v_has_two_allosemes : vAllosemic.allosemeCount = 2 := rfl
-
-/-- Root change-type conditions v alloseme selection.
-
-    Result roots (entailing prior change) yield eventive v — the change
-    entailed by the root requires an event variable in v.
-    Property concept roots yield stative v — no inherent change event.
-
-    This connects [beavers-etal-2021]'s root typology to
-    v allosemy: the root's lexical semantics
-    determines which v alloseme is selected. -/
+/-- Root change-type conditions v alloseme selection: result roots,
+    which entail a prior change, demand the event variable; property
+    concept roots do not ([beavers-etal-2021]'s root typology feeding v
+    allosemy). -/
 def VAlloseme.fromRootType : Verb.Root.ChangeType → VAlloseme
   | .result          => .eventive
   | .propertyConcept => .zero
 
-/-- Result roots yield eventive v. -/
-theorem result_root_eventive :
-    VAlloseme.fromRootType .result = .eventive := rfl
-
-/-- PC roots yield zero v. -/
-theorem pc_root_zero :
-    VAlloseme.fromRootType .propertyConcept = .zero := rfl
-
-/-- The bridge preserves the change entailment information:
-    eventive v iff the root entails change. -/
+/-- The bridge preserves the change entailment: eventive v iff the root
+entails change. -/
 theorem fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
     (VAlloseme.fromRootType rt).introducesEvent = rt.entailsChange := by
   cases rt <;> rfl
 
--- ════════════════════════════════════════════════════
--- § 2. n Allosemy (retroactive classification)
--- ════════════════════════════════════════════════════
+/-! ### n allosemy -/
 
-/-- n allosemy: the three semantic types from `CategorizerSemantics`
-    are allosemes of n conditioned by morphosyntactic features.
-
-    [benz-2025] Ch. 3 adds a `content` possibility for content
-    nominalizations. [wood-2023] Ch. 5 adds `zero` (identity
-    function, yielding CEN reading) and `simpleEvent` (yielding SEN).
-
-    The full inventory:
-    - `relational`: introduces a relation (body-part-of); type ⟨e,⟨e,t⟩⟩
-    - `sortal`: bare categorization; type ⟨e,t⟩
-    - `alienator`: existentially closes possessor; type ⟨e,t⟩
-    - `content`: selects CP complement (CCN reading, [benz-2025])
-    - `zero`: semantically Ø (identity), noun = verb meaning (CEN,
-      [wood-2023] Ch. 5 (5.4e))
-    - `simpleEvent`: λP⟨e,t⟩λx∃e. P(x) & x = e — picks out entities
-      equal to an event (SEN, [wood-2023] Ch. 5 (5.4c))
-    - `result`: λP⟨s,t⟩λx∃e. P(e) & result(x)(e) — picks out entity
-      created as result of event ([wood-2023] Ch. 6 (6.30))
-    - `state`: λP⟨e,t⟩λx∃e. P(x) & x = e — picks out states
-      ([wood-2023] Ch. 1 (1.18), Ch. 6 §6.2)
-    - `entity`: λP⟨e,t⟩λx. P(x) — picks out entities described by the
-      root, no event connection ([wood-2023] Ch. 5 (5.4d)) -/
+/-- Allosemes of the nominal categorizer n: the three non-deverbal types
+    of `CategorizerSemantics.NSemanticType`, [benz-2025]'s content
+    alloseme for content nominalizations, and [wood-2023]'s deverbal
+    inventory. The deverbal denotations live in `NAlloseme.denote`. -/
 inductive NAlloseme where
-  | relational    -- introduces a relation (body-part-of); type ⟨e,⟨e,t⟩⟩
-  | sortal        -- bare categorization; type ⟨e,t⟩
-  | alienator     -- existentially closes possessor; type ⟨e,t⟩
-  | content       -- selects CP complement (CCN reading); type ⟨e,t⟩
-  | zero          -- Ø / identity function (CEN: noun = verb meaning)
-  | simpleEvent   -- λP.λx∃e. P(x) & x = e (SEN reading)
-  | result        -- λP.λx∃e. P(e) & result(x)(e) (result/product entity)
-  | state         -- picks out states (simple state reading)
-  | entity        -- λP.λx. P(x) (simple entity, no event connection)
+  | relational    -- introduces a relation (body-part-of)
+  | sortal        -- bare categorization
+  | alienator     -- existentially closes a possessor
+  | content       -- propositional content (CCN reading)
+  | zero          -- Ø / identity: noun inherits the verb meaning (CEN)
+  | simpleEvent   -- picks out entities equal to an event (SEN)
+  | result        -- picks out the entity an event produced
+  | state         -- picks out states
+  | entity        -- picks out entities, no event connection
   deriving DecidableEq, Repr
 
-/-- Bridge: `NSemanticType` from CategorizerSemantics maps to `NAlloseme`. -/
+/-- The non-deverbal allosemes are `NSemanticType` under another name. -/
 def NAlloseme.ofNSemanticType : NSemanticType → NAlloseme
   | .relational => .relational
   | .sortal     => .sortal
   | .alienator  => .alienator
 
-/-- The content alloseme is genuinely new — it has no pre-existing
-    `NSemanticType` counterpart. -/
-theorem content_is_new : ∀ (t : NSemanticType),
-    NAlloseme.ofNSemanticType t ≠ .content := by
-  intro t; cases t <;> simp [NAlloseme.ofNSemanticType]
-
-/-- n has nine allosemes (extending the three from CategorizerSemantics
-    with content from [benz-2025] and zero/simpleEvent/result/state/
-    entity from [wood-2023]). -/
+/-- n allosemy as an `AllosemicHead`: the non-deverbal allosemes are
+unconditioned (all-wildcard contexts), the deverbal ones require a
+verbal complement, with the CEN and result allosemes further demanding
+an eventive one. -/
 def nAllosemic : AllosemicHead NAlloseme where
   morpheme := .n
   entries := [
@@ -219,51 +173,46 @@ def nAllosemic : AllosemicHead NAlloseme where
     , context := { belowCat := some .v } }
   ]
 
-theorem n_has_nine_allosemes : nAllosemic.allosemeCount = 9 := rfl
+/-- One eventive deverbal context licenses several n allosemes at once —
+the CEN reading (zero n) and the result reading among them. The
+ambiguity of a nominalization is non-singleton licensing, not structural
+ambiguity ([benz-2025], [wood-2023]). -/
+theorem cen_result_ambiguity :
+    NAlloseme.zero ∈ nAllosemic.licensed
+        { belowCat := some .v, complementIsEventive := true }
+      ∧ NAlloseme.result ∈ nAllosemic.licensed
+        { belowCat := some .v, complementIsEventive := true } := by
+  constructor <;> decide
 
--- ════════════════════════════════════════════════════
--- § 3. Voice Allosemy ([kratzer-1996]; §2.3)
--- ════════════════════════════════════════════════════
+/-! ### Voice allosemy -/
 
-/-- Voice allosemy: the thematic interpretation of the external argument
-    depends on the semantics of the VP it combines with.
-
-    [kratzer-1996]: "What we cannot do, however, is combine the
-    holder function with the denotation of an action predicate or the
-    agent function with the denotation of a stative predicate."
-
-    §2.3: while Voice_{D} must introduce a DP argument,
-    the thematic interpretation of that argument can be left to allosemy.
-    The denotations in [kratzer-1996] correspond not to separate
-    syntactic heads, but to allosemes of a single Voice head.
-
-    [myler-2016] Ch. 4 extends this to four allosemes, adding
-    the engineer role (for ECM *have*) and the expletive/identity
-    alloseme (for relational and light-verb *have* where Voice assigns
-    no θ-role). The conditioning environments (98a–d):
-
-    - `agent`:    ⟦Voice⟧ = λx.λe. Agent(x,e)     / ___(agentive, dynamic event)
-    - `holder`:   ⟦Voice⟧ = λx.λe. Holder(x,e)    / ___(stative eventuality)
-    - `engineer`: ⟦Voice⟧ = λx.λe. Engineer(x,e)  / ___v_BE Eventive-VoiceP⟨s,t⟩
-    - `expletive`:⟦Voice⟧ = λx.x                  / ___(elsewhere) -/
+/-- Allosemes of Voice: the thematic interpretation of the external
+    argument depends on the semantics of the complement.
+    [kratzer-1996]'s severing argument observes that the holder function
+    cannot combine with an action predicate, nor the agent function with
+    a stative one — so the thematic role is fixed by the complement, not
+    by the head. [myler-2016] extends the inventory to four, adding the
+    engineer role for ECM *have* and an expletive identity alloseme for
+    relational and light-verb *have*, where Voice assigns no θ-role. -/
 inductive VoiceAlloseme where
-  | agent     -- λx.λe. Agent(x,e) — combines with action VPs
-  | holder    -- λx.λe. Holder(x,e) — combines with stative VPs (includes causer, experiencer)
-  | engineer  -- λx.λe. Engineer(x,e) — ECM *have*: complement is saturated eventive VoiceP
-  | expletive -- λx.x — type-neutral identity; no θ-role (relational *have*, light-verb *have*)
+  | agent     -- combines with dynamic action complements
+  | holder    -- combines with stative complements
+  | engineer  -- ECM *have*: saturated eventive VoiceP complement
+  | expletive -- identity; no θ-role (relational and light-verb *have*)
   deriving DecidableEq, Repr
 
-/-- Does this Voice alloseme assign a thematic role to the external argument? -/
-def VoiceAlloseme.assignsTheta : VoiceAlloseme → Bool
-  | .agent    => true
-  | .holder   => true
-  | .engineer => true
-  | .expletive => false
+/-- The alloseme assigns a thematic role to the external argument;
+only the expletive identity does not. -/
+def VoiceAlloseme.AssignsTheta (a : VoiceAlloseme) : Prop :=
+  a ≠ .expletive
+
+instance : DecidablePred VoiceAlloseme.AssignsTheta :=
+  fun _ => inferInstanceAs (Decidable (_ ≠ _))
 
 /-- The Voice allosemes as a competing exponence vocabulary
-    ([myler-2016] (98a–d)): engineer for a saturated eventive VoiceP
-    complement (most specified), holder for a stative one, expletive
-    elsewhere (the all-wildcard, `⊥`-specificity default). -/
+    ([myler-2016]): engineer for a saturated eventive VoiceP complement
+    (most specified), holder for a stative one, expletive elsewhere (the
+    all-wildcard default). -/
 def voiceVocabulary : List (AllosemicEntry VoiceAlloseme) :=
   [ { label := "Voice_engineer", denotation := .engineer
     , context := { belowCat := some .v, complementIsEventive := true } },
@@ -272,14 +221,10 @@ def voiceVocabulary : List (AllosemicEntry VoiceAlloseme) :=
     { label := "Voice_expletive", denotation := .expletive
     , context := {} } ]
 
-/-- Voice alloseme selection from complement properties.
-
-    [myler-2016] table (100): the alloseme is determined by the nature of
-    *have*'s complement and whether the VP is eventive. This is Elsewhere
+/-- Voice alloseme selection from complement properties: Elsewhere
     competition over `voiceVocabulary`, resolved by the shared exponence
-    engine (`Exponence.selectBy` on the non-wildcard-field score): engineer
-    is most specific (saturated eventive VoiceP), expletive is the elsewhere
-    default. -/
+    engine ([myler-2016]'s conditioning of the alloseme on the nature of
+    *have*'s complement). -/
 def VoiceAlloseme.fromComplement
     (complementIsEventiveVoiceP : Prop) [Decidable complementIsEventiveVoiceP]
     (complementIsStative : Prop) [Decidable complementIsStative] : VoiceAlloseme :=
@@ -293,88 +238,57 @@ def VoiceAlloseme.fromComplement
 /-- Eventive-VoiceP complement selects engineer ([myler-2016]). -/
 example : VoiceAlloseme.fromComplement True False = .engineer := by decide
 
-/-- Stative complement (non-eventive) selects holder ([kratzer-1996]). -/
+/-- Stative complement selects holder ([kratzer-1996]). -/
 example : VoiceAlloseme.fromComplement False True = .holder := by decide
 
 /-- Neither condition met selects the elsewhere expletive. -/
 example : VoiceAlloseme.fromComplement False False = .expletive := by decide
 
-/-- Bridge: Voice allosemes to syntactic `Flavor`.
-
-    [myler-2016]: syntactically, all four allosemes realize
-    the same Voice_{D} — transitive Voice with a DP specifier.
-    The θ-role distinction is resolved at LF, not in the syntax.
-    We map to the flavor that best captures the syntactic behavior:
-    agent/engineer → agentive (phase head, assigns θ);
-    holder → experiencer (assigns θ, stative);
-    expletive → expletive (no θ, no semantics). -/
+/-- Bridge to the syntactic `Flavor` inventory. Syntactically all four
+    allosemes realize the same Voice with a DP specifier; the θ-role
+    distinction is resolved at LF ([myler-2016]). The map picks the
+    flavor matching each alloseme's syntactic behavior. -/
 def VoiceAlloseme.toFlavor : VoiceAlloseme → Flavor
   | .agent    => .agentive
   | .holder   => .experiencer
   | .engineer => .agentive
   | .expletive => .expletive
 
-/-- All θ-assigning Voice allosemes map to θ-assigning syntactic flavors;
-    the non-θ expletive maps to a non-θ flavor. -/
+/-- The bridge respects θ-assignment: an alloseme assigns a thematic
+role iff its syntactic flavor does. -/
 theorem voice_alloseme_theta_consistent (a : VoiceAlloseme) :
-    a.assignsTheta = true ↔
-      Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
-  cases a <;> decide
+    a.AssignsTheta ↔ Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
+  cases a <;> simp [VoiceAlloseme.AssignsTheta, VoiceAlloseme.toFlavor] <;> decide
 
--- ════════════════════════════════════════════════════
--- § 4. Nominalization Reading Derivation (Ch. 3)
--- ════════════════════════════════════════════════════
+/-! ### Nominalization readings -/
 
-/-- Reading types for deverbal nominalizations.
-
-    [wood-2023] Ch. 1 (1.18) identifies five terminal reading types;
-    [benz-2025] Ch. 3 adds the CCN for German, yielding six:
-
-    - **CEN** (Complex Event Nominal): v eventive + n zero. Noun inherits
-      full verb meaning including event variable and argument structure.
-    - **SEN** (Simple Event Nominal): v zero + n simpleEvent. Event reading
-      without full argument structure; event comes from n's alloseme.
-    - **Result/Product Nominal**: v eventive + n result. Entity whose
-      existence is the result of an event (e.g. *prentun* 'printing' = the
-      printed object). Built off verbal meaning, retains event variable.
-    - **Simple State Nominal**: v zero + n state. State reading
-      (e.g. *aðdáun* 'admiration' as a lasting state, *þrælkun* 'slavery').
-    - **Simple Entity Nominal**: v zero + n entity. Entity reading with
-      no event connection (e.g. *þvottur* 'laundry' = the clothes).
-    - **CCN** (Complex Content Nominal): v eventive + n content. Takes
-      CP complement ([benz-2025]). -/
+/-- Reading types for deverbal nominalizations: [wood-2023]'s five
+    terminal readings plus [benz-2025]'s complex content nominal. -/
 inductive NominalizationReading where
-  | complexEvent   -- CEN: event reading (takes temporal modifiers, telicity PPs)
-  | simpleEvent    -- SEN: event reading without full arg structure
-  | result         -- RN: result/product entity (existence results from event)
-  | simpleState    -- state reading (e.g. admiration, slavery)
-  | simpleEntity   -- simple entity reading, no event connection (e.g. laundry)
-  | content        -- CCN: content reading (takes CP complement)
+  | complexEvent   -- CEN: full verbal event reading with argument structure
+  | simpleEvent    -- SEN: event reading without argument structure
+  | result         -- entity whose existence results from an event
+  | simpleState    -- state reading
+  | simpleEntity   -- entity reading, no event connection
+  | content        -- CCN: propositional content, takes a CP complement
   deriving DecidableEq, Repr
 
-/-- Derive the nominalization reading from the allosemes of v and n.
+/-- The reading of a nominalization from the allosemes of v and n.
 
-    Integrates [benz-2025] Ch. 3 and [wood-2023] Ch. 5–6:
-
-    - v_eventive + n_zero → CEN (n is identity, noun = verb meaning)
-    - v_zero + n_simpleEvent → SEN (v vacuous, n picks out event-entity)
-    - v_zero + n_state → simple state (v vacuous, n picks out state)
-    - v_zero + n_entity → simple entity RN (no event connection)
-    - v_zero + n_result → result/product RN
-    - v_zero + n_content → CCN
-
-    For the result and content readings, [benz-2025] §3.5 notes two
-    analytical options (both already noted by [wood-2023]): either v is
-    semantically vacuous on all readings but the CEN — so the event and
-    result readings are "mirror images" (only v vs. only n interpreted),
-    the option the dissertation's denotations adopt — or the eventive
-    component always comes from v, so both heads are interpreted. Both
-    derivations are admitted here (the eventive-v cells alongside the
-    zero-v cells). Content does *not* require an eventive verbal source:
-    simple content nouns (*Gerücht* 'rumor', *fact*, *idea*) have a
-    content reading with no corresponding verb at all ([benz-2025]
-    Table 2, §3.5). Bare categorization (n_sortal) yields a plain noun,
-    not a deverbal reading — its semantics lives in CategorizerSemantics. -/
+    The CEN pairs eventive v with zero n (the noun inherits the verb
+    meaning); the simple readings pair zero v with the event, state, and
+    entity allosemes of n. For the result and content readings
+    [benz-2025] §3.5 notes two analytical options, both already in
+    [wood-2023]: either v is vacuous everywhere but the CEN — the option
+    the dissertation's denotations adopt, on which the event and result
+    readings are mirror images — or the eventive component always comes
+    from v. Both derivations are admitted, and `result_options_agree`
+    shows the choice is denotationally immaterial. Content does not
+    require a verbal source at all: simple content nouns (*Gerücht*
+    'rumor', *fact*, *idea*) have the reading with no corresponding verb
+    ([benz-2025] §3.5, Table 2). The non-deverbal allosemes yield no
+    nominalization reading — their semantics lives in
+    `Categorizer/Semantics.lean`. -/
 def readingFromAllosemes : VAlloseme → NAlloseme → Option NominalizationReading
   | .eventive, .zero        => some .complexEvent
   | .eventive, .result      => some .result   -- both-heads-interpreted option
@@ -382,111 +296,131 @@ def readingFromAllosemes : VAlloseme → NAlloseme → Option NominalizationRead
   | .zero,     .simpleEvent => some .simpleEvent
   | .zero,     .state       => some .simpleState
   | .zero,     .entity      => some .simpleEntity
-  | .zero,     .result      => some .result   -- v-vacuous option ([benz-2025] §3.5)
-  | .zero,     .content     => some .content  -- v-vacuous option; simple content nouns
-  | _,         .sortal      => none   -- bare categorization: plain noun, not deverbal
-  | _,         .relational  => none   -- relational n yields possessive
-  | _,         .alienator   => none   -- alienator yields alienated noun
-  | .zero,     .zero        => none   -- both vacuous: no reading
-  | .eventive, .simpleEvent => none   -- SEN requires v = Ø
-  | .eventive, .state       => none   -- state requires v = Ø
-  | .eventive, .entity      => none   -- entity-n requires v = Ø
+  | .zero,     .result      => some .result   -- v-vacuous option
+  | .zero,     .content     => some .content  -- v-vacuous option
+  | _,         .sortal      => none
+  | _,         .relational  => none
+  | _,         .alienator   => none
+  | .zero,     .zero        => none
+  | .eventive, .simpleEvent => none
+  | .eventive, .state       => none
+  | .eventive, .entity      => none
 
-/-- CEN from eventive v + zero n ([wood-2023] Ch. 5). -/
-theorem cen_from_zero_n :
-    readingFromAllosemes .eventive .zero = some .complexEvent := rfl
+/-! ### Typed alloseme denotations
 
-/-- Result/product RN from eventive v + result n ([wood-2023] Ch. 6 (6.30)). -/
-theorem result_from_eventive_v :
-    readingFromAllosemes .eventive .result = some .result := rfl
+The denotations of the deverbal allosemes, after [wood-2023] as taken
+over by [benz-2025] Ch. 3: nominalization semantics happens over a
+domain in which eventualities are entities, and each n alloseme builds
+an entity predicate from what v hands it. The reading typology is then
+derived, not tabulated: readings exist exactly where the composition is
+defined (`readingFromAllosemes_isSome_iff_denote`), and the analytical
+options for the result and content readings compose to identical
+denotations (`result_options_agree`, `content_options_agree`). -/
 
-/-- Result/product RN with vacuous v: on the option the dissertation's
-    denotations adopt, only n is interpreted in the result reading —
-    the event and result readings are "mirror images" ([benz-2025] §3.5). -/
-theorem result_from_zero_v :
-    readingFromAllosemes .zero .result = some .result := rfl
+variable {E S : Type*}
 
-/-- SEN from zero v + simpleEvent n ([wood-2023] Ch. 5). -/
-theorem sen_from_zero_v :
-    readingFromAllosemes .zero .simpleEvent = some .simpleEvent := rfl
+/-- A model for nominalization denotations: eventualities embed into the
+entity domain (a nominal can describe an event as an entity), split into
+stative and dynamic, with `result` relating an entity to the eventuality
+that produced it and `hasContent` picking out the entities with
+propositional content. -/
+structure NominalizationModel (E S : Type*) where
+  /-- Eventualities as entities. -/
+  ev : S → E
+  ev_injective : Function.Injective ev
+  /-- Stative eventualities. -/
+  stative : S → Prop
+  /-- The entity is the result of the eventuality. -/
+  result : E → S → Prop
+  /-- The entity has propositional content (*rumor*, *idea*, *claim*). -/
+  hasContent : E → Prop
 
-/-- Simple state from zero v + state n ([wood-2023] Ch. 1 (1.18)). -/
-theorem state_from_zero_v :
-    readingFromAllosemes .zero .state = some .simpleState := rfl
+/-- A root's contribution to nominalization semantics: what it says of
+entities and of eventualities. -/
+structure RootMeaning (E S : Type*) where
+  onEntities : E → Prop
+  onEvents : S → Prop
 
-/-- Simple entity from zero v + entity n ([wood-2023] Ch. 5). -/
-theorem simpleEntity_from_entity_n :
-    readingFromAllosemes .zero .entity = some .simpleEntity := rfl
+/-- What v hands to n: verbal event content under the eventive alloseme,
+the untouched root under the zero alloseme. -/
+inductive VDenotation (E S : Type*) where
+  | eventive (p : S → Prop)
+  | zero (ρ : RootMeaning E S)
 
-/-- CCN from content n with eventive v (both-heads-interpreted option). -/
-theorem content_from_eventive_v :
-    readingFromAllosemes .eventive .content = some .content := rfl
+/-- The v alloseme applied to the root. -/
+def VAlloseme.denote (ρ : RootMeaning E S) : VAlloseme → VDenotation E S
+  | .eventive => .eventive ρ.onEvents
+  | .zero     => .zero ρ
 
-/-- CCN from content n with vacuous v: the content interpretation "depends
-    on an alloseme of n, not v", and simple content nouns (*Gerücht*,
-    *rumor*, *idea*) have it with no verbal source at all ([benz-2025]
-    Table 2, §3.5). -/
-theorem content_from_zero_v :
-    readingFromAllosemes .zero .content = some .content := rfl
+/-- The n alloseme applied to v's output: the nominal's entity
+predicate, `none` where the combination is uninterpretable. The CEN
+describes the events the verb describes; the SEN predicates the root's
+entity content of an event-entity; the result alloseme picks out what an
+event of the root's kind produced ([benz-2025]'s denotation, taken over
+from [wood-2023]); the content alloseme ignores the verbal layer
+entirely. The non-deverbal allosemes have their semantics in
+`Categorizer/Semantics.lean`. -/
+def NAlloseme.denote (m : NominalizationModel E S) :
+    VDenotation E S → NAlloseme → Option (E → Prop)
+  | .eventive p, .zero        => some fun x => ∃ e, x = m.ev e ∧ p e
+  | .eventive p, .result      => some fun x => ∃ e, p e ∧ m.result x e
+  | .eventive _, .content     => some m.hasContent
+  | .zero ρ,     .simpleEvent => some fun x => ρ.onEntities x ∧ ∃ e, x = m.ev e
+  | .zero ρ,     .state       => some fun x => ∃ e, x = m.ev e ∧ m.stative e ∧ ρ.onEvents e
+  | .zero ρ,     .result      => some fun x => ∃ e, ρ.onEvents e ∧ m.result x e
+  | .zero ρ,     .entity      => some ρ.onEntities
+  | .zero _,     .content     => some m.hasContent
+  | _,           _            => none
 
-/-- The six readings are pairwise distinct. -/
-theorem readings_distinct :
-    NominalizationReading.complexEvent ≠ .simpleEvent ∧
-    NominalizationReading.complexEvent ≠ .result ∧
-    NominalizationReading.complexEvent ≠ .simpleState ∧
-    NominalizationReading.complexEvent ≠ .simpleEntity ∧
-    NominalizationReading.complexEvent ≠ .content ∧
-    NominalizationReading.simpleEvent ≠ .result ∧
-    NominalizationReading.simpleEvent ≠ .simpleState ∧
-    NominalizationReading.simpleEvent ≠ .simpleEntity ∧
-    NominalizationReading.simpleEvent ≠ .content ∧
-    NominalizationReading.result ≠ .simpleState ∧
-    NominalizationReading.result ≠ .simpleEntity ∧
-    NominalizationReading.result ≠ .content ∧
-    NominalizationReading.simpleState ≠ .simpleEntity ∧
-    NominalizationReading.simpleState ≠ .content ∧
-    NominalizationReading.simpleEntity ≠ .content := by decide
+/-- The event and result readings are mirror images: the two analytical
+options for the result reading — eventive v with n's result alloseme, or
+vacuous v with the same — compose to the same denotation, so the choice
+of where the eventive component lives is immaterial ([benz-2025] §3.5,
+crediting [wood-2023]). -/
+theorem result_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
+    NAlloseme.denote m (VAlloseme.eventive.denote ρ) .result
+      = NAlloseme.denote m (VAlloseme.zero.denote ρ) .result := rfl
 
--- ════════════════════════════════════════════════════
--- § 5. The Allomorphy Analogy (§2.5)
--- ════════════════════════════════════════════════════
+/-- The content reading likewise ignores the verbal layer: both v
+options compose to `hasContent`, which is how simple content nouns can
+have the reading with no verbal source at all ([benz-2025] §3.5). -/
+theorem content_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
+    NAlloseme.denote m (VAlloseme.eventive.denote ρ) .content
+      = NAlloseme.denote m (VAlloseme.zero.denote ρ) .content := rfl
 
-/-- Ch. 2 evaluates three positions on the relationship
-    between allosemy and allomorphy:
+/-- The reading typology tracks denotational definedness: a (v, n) pair
+has a reading exactly when its composed denotation is defined. -/
+theorem readingFromAllosemes_isSome_iff_denote (m : NominalizationModel E S)
+    (ρ : RootMeaning E S) (v : VAlloseme) (n : NAlloseme) :
+    (readingFromAllosemes v n).isSome
+      ↔ (NAlloseme.denote m (v.denote ρ) n).isSome := by
+  cases v <;> cases n <;>
+    simp [readingFromAllosemes, VAlloseme.denote, NAlloseme.denote]
 
-    1. The allomorphy analogy is deeply flawed and should be abandoned.
-    2. Only phenomena that closely mirror allomorphy count as allosemy.
-    3. The analogy holds in some respects but the relationship is
-       fundamentally different.
+/-- A complex event nominal holds only of event-entities: the ground of
+its event reading (temporal modification, aspectual behavior). -/
+theorem cen_denotes_events (m : NominalizationModel E S) (ρ : RootMeaning E S)
+    {p : E → Prop}
+    (h : NAlloseme.denote m (VAlloseme.eventive.denote ρ) .zero = some p) :
+    ∀ x, p x → ∃ e, x = m.ev e := by
+  simp only [VAlloseme.denote, NAlloseme.denote, Option.some.injEq] at h
+  subst h
+  rintro x ⟨e, rfl, -⟩
+  exact ⟨e, rfl⟩
 
-    Benz favors position 3: allosemy shares locality properties with
-    allomorphy (cyclic domains, adjacency effects) but Roots are far
-    more flexible in meaning than in form. -/
-inductive AllomorphyAnalogyPosition where
-  | abandoned       -- position 1: analogy is flawed
-  | strictParallel  -- position 2: only strict mirror cases
-  | partialAnalogy  -- position 3: some respects hold, others don't
-  deriving DecidableEq, Repr
+/-! ### The `Realization.Interpreted` view
 
-/-- Benz's position. -/
-def benzPosition : AllomorphyAnalogyPosition := .partialAnalogy
-
--- ════════════════════════════════════════════════════
--- § 6. The `Realization.Interpreted` view (List 3 on the shared carrier)
--- ════════════════════════════════════════════════════
-
-/-! An allosemic head is a List-3 object: a single morpheme whose
-*interpretation* is resolved in context by the shared exponence engine.
-`Realization.Interpreted` is exactly that carrier — an opaque index with a
-contextual `interp` map — so the engine slots in as a view. The form side
-(`realize`) is empty (`Unit`, `∅`): allosemy is meaning-only, the List-2
-form having been resolved separately. Contextual meaning variation — Benz's
-core claim that allosemy is allomorphy's LF analogue — is then literally
+An allosemic head is a List-3 object: a single morpheme whose
+interpretation is resolved in context by the shared exponence engine.
+`Realization.Interpreted` is exactly that carrier — an opaque index with
+a contextual `interp` map — with an empty List-2 form side, since
+allosemy is meaning-only. Contextual meaning variation, Benz's core
+claim that allosemy is allomorphy's LF analogue, is then literally
 `Realization.Interpreted.IsAllosemous`. -/
 
 open Morphology.Exponence in
-/-- The allosemy engine as a `Realization.Interpreted` view: one abstract
-head (`Unit`) whose contextual interpretation is the alloseme `selectBy`
+/-- The allosemy engine as a `Realization.Interpreted` view: one
+abstract head whose contextual interpretation is the alloseme `selectBy`
 picks (a singleton, `∅` at a semantic gap), with an empty List-2 form
 side. -/
 def AllosemicHead.toInterpreted {Sem : Type} (h : AllosemicHead Sem) :
@@ -497,10 +431,10 @@ def AllosemicHead.toInterpreted {Sem : Type} (h : AllosemicHead Sem) :
     | some e => {e.denotation}
     | none => ∅
 
-/-- The verbal categorizer's meaning varies with context — eventive under
-an eventive complement, zero elsewhere — so v is `IsAllosemous` on the
-shared carrier: contextual meaning variation as non-constancy of the
-`interp` map ([benz-2025], the LF analogue of allomorphy). -/
+/-- The verbal categorizer's meaning varies with context — eventive
+under an eventive complement, zero elsewhere — so v is `IsAllosemous` on
+the shared carrier: contextual meaning variation as non-constancy of the
+`interp` map ([benz-2025]). -/
 theorem vAllosemic_isAllosemous : vAllosemic.toInterpreted.IsAllosemous () :=
   ⟨{ complementIsEventive := true }, { complementIsEventive := false },
    .eventive, by decide, .zero, by decide, by decide⟩


### PR DESCRIPTION
Deep cleanse of `Allosemy.lean`: typed alloseme denotations derive the reading typology, and the editorial/table apparatus goes.

- New: `NominalizationModel`/`RootMeaning`/`VDenotation` with `VAlloseme.denote`/`NAlloseme.denote` (Wood's denotations as taken over by Benz). `result_options_agree` and `content_options_agree` prove Benz §3.5's mirror-image observation as equations (both analytical options compose identically, `rfl`); `readingFromAllosemes_isSome_iff_denote` derives the table's support; `cen_denotes_events` grounds the CEN's event behavior; `cen_result_ambiguity` states nominalization ambiguity as non-singleton licensing.
- Deleted: `AllomorphyAnalogyPosition`/`benzPosition` (debate-position enum, meta-content), both alloseme-count theorems, the 15-conjunct `readings_distinct` table, eight per-cell rfl restatements of `readingFromAllosemes`, `content_is_new`, and two `fromRootType` case-unpacks.
- Register: colon-title fixed, banners → section headers, verbatim Kratzer/Wood quote blocks paraphrased, unverifiable Wood/Myler example numbers (inconsistent with `Studies/Wood2023.lean`'s own cites) demoted to content descriptions, References section added; `VoiceAlloseme.assignsTheta` → Prop `AssignsTheta`.