### PR TITLE
refactor(Morphology/DistributedMorphology): spell out alloseme owners

### DIFF
--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -396,7 +396,7 @@ def rauben : GermanVerbEntry where
 /-! ### Change-of-state verbs
 
 These verbs have inherent result states. Their root type determines the
-canonical v alloseme via `VAlloseme.fromRootType`. -/
+canonical v alloseme via `VerbalizerAlloseme.fromRootType`. -/
 
 /-- *brechen* — "break": achievement with result root. The broken state
     entails prior change (you can't be broken without having been broken).

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -15,20 +15,20 @@ several allosemes, selected by the syntactic context rather than tracked
 by morphosyntactic features, and the ambiguity of deverbal
 nominalizations between event, result, state, entity, and content
 readings is the visible trace of that selection. The alloseme
-inventories here compose: the typed denotations of `VAlloseme.denote`
-and `NAlloseme.denote` derive the reading typology, and the analytical
+inventories here compose: the typed denotations of `VerbalizerAlloseme.denote`
+and `NominalizerAlloseme.denote` derive the reading typology, and the analytical
 choice of where the eventive component lives — v or n — is provably
 immaterial for the result and content readings.
 
 ## Main definitions
 
-* `VAlloseme`, `NAlloseme`, `VoiceAlloseme` — the alloseme inventories
+* `VerbalizerAlloseme`, `NominalizerAlloseme`, `VoiceAlloseme` — the alloseme inventories
   of v, n, and Voice
-* `vAllosemic`, `nAllosemic` — v and n as `AllosemicHead`s over the
+* `verbalizer`, `nominalizer` — v and n as `AllosemicHead`s over the
   shared selection engine
 * `NominalizationReading`, `readingFromAllosemes` — the reading typology
   of deverbal nominalizations and its alloseme table
-* `NominalizationModel`, `VAlloseme.denote`, `NAlloseme.denote` — typed
+* `NominalizationModel`, `VerbalizerAlloseme.denote`, `NominalizerAlloseme.denote` — typed
   alloseme denotations and their composition
 
 ## Main statements
@@ -38,10 +38,10 @@ immaterial for the result and content readings.
   denotation: the event and result readings are mirror images
 * `readingFromAllosemes_isSome_iff_denote` — the reading table has a
   reading exactly where the composed denotation is defined
-* `v_ambiguity`, `cen_result_ambiguity` — one deverbal context licenses
+* `verbalizer_ambiguity`, `cen_result_ambiguity` — one deverbal context licenses
   both v allosemes and several n allosemes: nominalization ambiguity as
   non-singleton licensing
-* `vAllosemic_isAllosemous` — v's contextual meaning variation on the
+* `verbalizer_isAllosemous` — v's contextual meaning variation on the
   shared `Realization.Interpreted` carrier
 
 ## Implementation notes
@@ -79,13 +79,13 @@ open Minimalist.Voice (Flavor Head)
     eventive when v is interpreted and n vacuous, referential when n is
     interpreted and v vacuous: one root, one structure, the readings
     differing in which head's alloseme is contentful. -/
-inductive VAlloseme where
+inductive VerbalizerAlloseme where
   | eventive   -- introduces an event variable (CEN contexts)
   | zero       -- semantically Ø / identity (SEN/RN contexts)
   deriving DecidableEq, Repr
 
 /-- Does this v alloseme introduce an event variable? -/
-def VAlloseme.introducesEvent : VAlloseme → Bool
+def VerbalizerAlloseme.introducesEvent : VerbalizerAlloseme → Bool
   | .eventive => true
   | .zero     => false
 
@@ -93,8 +93,8 @@ def VAlloseme.introducesEvent : VAlloseme → Bool
 eventive complement, while the zero alloseme is the unconditioned
 elsewhere option, available trivially in any context ([benz-2025] §2.2).
 Engine selection picks the more specific eventive alloseme in eventive
-contexts; `licensed` keeps both (`v_ambiguity`). -/
-def vAllosemic : AllosemicHead VAlloseme where
+contexts; `licensed` keeps both (`verbalizer_ambiguity`). -/
+def verbalizer : AllosemicHead VerbalizerAlloseme where
   morpheme := .v
   entries := [
     { label := "v_eventive"
@@ -109,23 +109,23 @@ def vAllosemic : AllosemicHead VAlloseme where
 zero alloseme is the elsewhere option — so an *observation*-type
 nominalization supports the eventive and the referential reading from
 one structure ([benz-2025] §2.2's symmetric proposal). -/
-theorem v_ambiguity :
-    VAlloseme.eventive ∈ vAllosemic.licensed { complementIsEventive := true }
-      ∧ VAlloseme.zero ∈ vAllosemic.licensed { complementIsEventive := true } := by
+theorem verbalizer_ambiguity :
+    VerbalizerAlloseme.eventive ∈ verbalizer.licensed { complementIsEventive := true }
+      ∧ VerbalizerAlloseme.zero ∈ verbalizer.licensed { complementIsEventive := true } := by
   constructor <;> decide
 
 /-- Root change-type conditions v alloseme selection: result roots,
     which entail a prior change, demand the event variable; property
     concept roots do not ([beavers-etal-2021]'s root typology feeding v
     allosemy). -/
-def VAlloseme.fromRootType : Verb.Root.ChangeType → VAlloseme
+def VerbalizerAlloseme.fromRootType : Verb.Root.ChangeType → VerbalizerAlloseme
   | .result          => .eventive
   | .propertyConcept => .zero
 
 /-- The bridge preserves the change entailment: eventive v iff the root
 entails change. -/
 theorem fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
-    (VAlloseme.fromRootType rt).introducesEvent = rt.entailsChange := by
+    (VerbalizerAlloseme.fromRootType rt).introducesEvent = rt.entailsChange := by
   cases rt <;> rfl
 
 /-! ### n allosemy -/
@@ -133,8 +133,8 @@ theorem fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
 /-- Allosemes of the nominal categorizer n: the three non-deverbal types
     of `CategorizerSemantics.NSemanticType`, [benz-2025]'s content
     alloseme for content nominalizations, and [wood-2023]'s deverbal
-    inventory. The deverbal denotations live in `NAlloseme.denote`. -/
-inductive NAlloseme where
+    inventory. The deverbal denotations live in `NominalizerAlloseme.denote`. -/
+inductive NominalizerAlloseme where
   | relational    -- introduces a relation (body-part-of)
   | sortal        -- bare categorization
   | alienator     -- existentially closes a possessor
@@ -147,7 +147,7 @@ inductive NAlloseme where
   deriving DecidableEq, Repr
 
 /-- The non-deverbal allosemes are `NSemanticType` under another name. -/
-def NAlloseme.ofNSemanticType : NSemanticType → NAlloseme
+def NominalizerAlloseme.ofNSemanticType : NSemanticType → NominalizerAlloseme
   | .relational => .relational
   | .sortal     => .sortal
   | .alienator  => .alienator
@@ -156,7 +156,7 @@ def NAlloseme.ofNSemanticType : NSemanticType → NAlloseme
 unconditioned (all-wildcard contexts), the deverbal ones require a
 verbal complement, with the CEN and result allosemes further demanding
 an eventive one. -/
-def nAllosemic : AllosemicHead NAlloseme where
+def nominalizer : AllosemicHead NominalizerAlloseme where
   morpheme := .n
   entries := [
     { label := "n_relational"
@@ -193,9 +193,9 @@ the CEN reading (zero n) and the result reading among them. The
 ambiguity of a nominalization is non-singleton licensing, not structural
 ambiguity ([benz-2025], [wood-2023]). -/
 theorem cen_result_ambiguity :
-    NAlloseme.zero ∈ nAllosemic.licensed
+    NominalizerAlloseme.zero ∈ nominalizer.licensed
         { belowCat := some .v, complementIsEventive := true }
-      ∧ NAlloseme.result ∈ nAllosemic.licensed
+      ∧ NominalizerAlloseme.result ∈ nominalizer.licensed
         { belowCat := some .v, complementIsEventive := true } := by
   constructor <;> decide
 
@@ -307,7 +307,7 @@ inductive NominalizationReading where
     referential readings could instead involve no v at all, a
     root-attached n — a different structure rather than a different
     alloseme, outside this table. -/
-def readingFromAllosemes : VAlloseme → NAlloseme → Option NominalizationReading
+def readingFromAllosemes : VerbalizerAlloseme → NominalizerAlloseme → Option NominalizationReading
   | .eventive, .zero        => some .complexEvent
   | .eventive, .result      => some .result   -- both-heads-interpreted option
   | .eventive, .content     => some .content  -- both-heads-interpreted option
@@ -361,12 +361,12 @@ structure RootMeaning (E S : Type*) where
 
 /-- What v hands to n: verbal event content under the eventive alloseme,
 the untouched root under the zero alloseme. -/
-inductive VDenotation (E S : Type*) where
+inductive VerbalizerDenotation (E S : Type*) where
   | eventive (p : S → Prop)
   | zero (ρ : RootMeaning E S)
 
 /-- The v alloseme applied to the root. -/
-def VAlloseme.denote (ρ : RootMeaning E S) : VAlloseme → VDenotation E S
+def VerbalizerAlloseme.denote (ρ : RootMeaning E S) : VerbalizerAlloseme → VerbalizerDenotation E S
   | .eventive => .eventive ρ.onEvents
   | .zero     => .zero ρ
 
@@ -378,8 +378,8 @@ event of the root's kind produced ([benz-2025]'s denotation, taken over
 from [wood-2023]); the content alloseme ignores the verbal layer
 entirely. The non-deverbal allosemes have their semantics in
 `Categorizer/Semantics.lean`. -/
-def NAlloseme.denote (m : NominalizationModel E S) :
-    VDenotation E S → NAlloseme → Option (E → Prop)
+def NominalizerAlloseme.denote (m : NominalizationModel E S) :
+    VerbalizerDenotation E S → NominalizerAlloseme → Option (E → Prop)
   | .eventive p, .zero        => some fun x => ∃ e, x = m.ev e ∧ p e
   | .eventive p, .result      => some fun x => ∃ e, p e ∧ m.result x e
   | .eventive _, .content     => some m.hasContent
@@ -396,32 +396,32 @@ vacuous v with the same — compose to the same denotation, so the choice
 of where the eventive component lives is immaterial ([benz-2025] §3.5,
 crediting [wood-2023]). -/
 theorem result_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
-    NAlloseme.denote m (VAlloseme.eventive.denote ρ) .result
-      = NAlloseme.denote m (VAlloseme.zero.denote ρ) .result := rfl
+    NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .result
+      = NominalizerAlloseme.denote m (VerbalizerAlloseme.zero.denote ρ) .result := rfl
 
 /-- The content reading likewise ignores the verbal layer: both v
 options compose to `hasContent`, which is how simple content nouns can
 have the reading with no verbal source at all ([benz-2025] §3.5). -/
 theorem content_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
-    NAlloseme.denote m (VAlloseme.eventive.denote ρ) .content
-      = NAlloseme.denote m (VAlloseme.zero.denote ρ) .content := rfl
+    NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .content
+      = NominalizerAlloseme.denote m (VerbalizerAlloseme.zero.denote ρ) .content := rfl
 
 /-- The reading typology tracks denotational definedness: a (v, n) pair
 has a reading exactly when its composed denotation is defined. -/
 theorem readingFromAllosemes_isSome_iff_denote (m : NominalizationModel E S)
-    (ρ : RootMeaning E S) (v : VAlloseme) (n : NAlloseme) :
+    (ρ : RootMeaning E S) (v : VerbalizerAlloseme) (n : NominalizerAlloseme) :
     (readingFromAllosemes v n).isSome
-      ↔ (NAlloseme.denote m (v.denote ρ) n).isSome := by
+      ↔ (NominalizerAlloseme.denote m (v.denote ρ) n).isSome := by
   cases v <;> cases n <;>
-    simp [readingFromAllosemes, VAlloseme.denote, NAlloseme.denote]
+    simp [readingFromAllosemes, VerbalizerAlloseme.denote, NominalizerAlloseme.denote]
 
 /-- A complex event nominal holds only of event-entities: the ground of
 its event reading (temporal modification, aspectual behavior). -/
 theorem cen_denotes_events (m : NominalizationModel E S) (ρ : RootMeaning E S)
     {p : E → Prop}
-    (h : NAlloseme.denote m (VAlloseme.eventive.denote ρ) .zero = some p) :
+    (h : NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .zero = some p) :
     ∀ x, p x → ∃ e, x = m.ev e := by
-  simp only [VAlloseme.denote, NAlloseme.denote, Option.some.injEq] at h
+  simp only [VerbalizerAlloseme.denote, NominalizerAlloseme.denote, Option.some.injEq] at h
   subst h
   rintro x ⟨e, rfl, -⟩
   exact ⟨e, rfl⟩
@@ -453,7 +453,7 @@ def AllosemicHead.toInterpreted {Sem : Type} (h : AllosemicHead Sem) :
 under an eventive complement, zero elsewhere — so v is `IsAllosemous` on
 the shared carrier: contextual meaning variation as non-constancy of the
 `interp` map ([benz-2025]). -/
-theorem vAllosemic_isAllosemous : vAllosemic.toInterpreted.IsAllosemous () :=
+theorem verbalizer_isAllosemous : verbalizer.toInterpreted.IsAllosemous () :=
   ⟨{ complementIsEventive := true }, { complementIsEventive := false },
    .eventive, by decide, .zero, by decide, by decide⟩
 

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -73,7 +73,7 @@ theorem beobachtung_diagnostics :
 is semantically vacuous on all readings but the CEN (§3.5, following
 [wood-2023]). By `adopted_roundtrip` and `adopted_unique`, this is the unique
 derivation of each reading in which the two heads are not both contentful. -/
-def adoptedAllosemes : NominalizationReading → VAlloseme × NAlloseme
+def adoptedAllosemes : NominalizationReading → VerbalizerAlloseme × NominalizerAlloseme
   | .complexEvent => (.eventive, .zero)
   | .simpleEvent  => (.zero, .simpleEvent)
   | .result       => (.zero, .result)
@@ -89,8 +89,8 @@ theorem adopted_roundtrip (r : NominalizationReading) :
 /-- Among derivations in which the two heads are not both contentful, the
 adopted pair is the only one deriving the reading — economy of interpretation
 pins the analysis. -/
-theorem adopted_unique (r : NominalizationReading) (v : VAlloseme) (n : NAlloseme)
-    (hr : readingFromAllosemes v n = some r)
+theorem adopted_unique (r : NominalizationReading) (v : VerbalizerAlloseme)
+    (n : NominalizerAlloseme) (hr : readingFromAllosemes v n = some r)
     (h : v.introducesEvent = false ∨ n = .zero) :
     (v, n) = adoptedAllosemes r := by
   cases v <;> cases n <;> cases r <;>
@@ -103,7 +103,7 @@ theorem adopted_unique (r : NominalizationReading) (v : VAlloseme) (n : NAllosem
 §3.5): an event reading arises only from contentful v with vacuous n, while
 a result or content reading forces the corresponding contentful n, whatever
 v contributes. -/
-theorem reading_determines_contentful_head (v : VAlloseme) (n : NAlloseme) :
+theorem reading_determines_contentful_head (v : VerbalizerAlloseme) (n : NominalizerAlloseme) :
     (readingFromAllosemes v n = some .complexEvent →
       v.introducesEvent = true ∧ n = .zero) ∧
     (readingFromAllosemes v n = some .result → n = .result) ∧
@@ -134,25 +134,25 @@ def nContext (eventive : Bool) : SyntacticContext :=
 /-- The readings derivable in the nominalization structure: any licensed v
 alloseme composed with any licensed n alloseme. -/
 def availableReadings (eventive : Bool) : List NominalizationReading :=
-  (vAllosemic.licensed (vContext eventive)).flatMap (λ v =>
-    (nAllosemic.licensed (nContext eventive)).filterMap (readingFromAllosemes v))
+  (verbalizer.licensed (vContext eventive)).flatMap (λ v =>
+    (nominalizer.licensed (nContext eventive)).filterMap (readingFromAllosemes v))
 
 /-- Over an event-entailing root both v allosemes are licensed — the premise
 of the reading ambiguity — while a non-eventive root licenses only vacuous
 v. -/
 theorem v_allosemes_licensed :
-    vAllosemic.licensed (vContext true) = [.eventive, .zero] ∧
-    vAllosemic.licensed (vContext false) = [.zero] := ⟨rfl, rfl⟩
+    verbalizer.licensed (vContext true) = [.eventive, .zero] ∧
+    verbalizer.licensed (vContext false) = [.zero] := ⟨rfl, rfl⟩
 
 open Morphology.Exponence in
 /-- The canonical v alloseme of the root typology is the engine's Elsewhere
 winner: the more specified eventive entry beats vacuous v exactly when the
-root entails an event, so `VAlloseme.fromRootType` is derived, not
+root entails an event, so `VerbalizerAlloseme.fromRootType` is derived, not
 stipulated. -/
 theorem fromRootType_is_selectBy_winner (rt : Verb.Root.ChangeType) :
-    (selectBy AllosemicEntry.score vAllosemic.entries
+    (selectBy AllosemicEntry.score verbalizer.entries
         (vContext rt.entailsChange)).map (·.denotation) =
-      some (VAlloseme.fromRootType rt) := by
+      some (VerbalizerAlloseme.fromRootType rt) := by
   cases rt <;> rfl
 
 /-- Every attested *Beobachtung* reading is available in the single
@@ -681,19 +681,19 @@ theorem rsp_data_grounded_in_fragments :
 
 /-- *brechen* (result root) and *frieren* (property-concept root) yield
 opposite canonical v allosemes, connecting the fragment's `rootType` to
-`VAlloseme.fromRootType` and `VAlloseme.introducesEvent`. -/
+`VerbalizerAlloseme.fromRootType` and `VerbalizerAlloseme.introducesEvent`. -/
 theorem rootType_alloseme_divergence :
-    brechen.rootType.map VAlloseme.fromRootType = some .eventive ∧
-    frieren.rootType.map VAlloseme.fromRootType = some .zero ∧
-    brechen.rootType.map (VAlloseme.fromRootType · |>.introducesEvent) = some true ∧
-    frieren.rootType.map (VAlloseme.fromRootType · |>.introducesEvent) = some false :=
+    brechen.rootType.map VerbalizerAlloseme.fromRootType = some .eventive ∧
+    frieren.rootType.map VerbalizerAlloseme.fromRootType = some .zero ∧
+    brechen.rootType.map (VerbalizerAlloseme.fromRootType · |>.introducesEvent) = some true ∧
+    frieren.rootType.map (VerbalizerAlloseme.fromRootType · |>.introducesEvent) = some false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-- A result root selects eventive v, which with vacuous n yields *brechen*'s
 complex event reading. -/
 theorem brechen_cen_path :
     brechen.rootType.bind
-      (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .zero) =
+      (λ rt => readingFromAllosemes (VerbalizerAlloseme.fromRootType rt) .zero) =
       some .complexEvent := rfl
 
 /-- A property-concept root selects vacuous v, which with entity n yields
@@ -701,7 +701,7 @@ theorem brechen_cen_path :
 too, since the canonical alloseme is a default rather than a constraint. -/
 theorem frieren_entity_path :
     frieren.rootType.bind
-      (λ rt => readingFromAllosemes (VAlloseme.fromRootType rt) .entity) =
+      (λ rt => readingFromAllosemes (VerbalizerAlloseme.fromRootType rt) .entity) =
       some .simpleEntity := rfl
 
 end Benz2025

--- a/Linglib/Studies/Wood2023.lean
+++ b/Linglib/Studies/Wood2023.lean
@@ -96,7 +96,7 @@ theorem wood_state_derivation :
 theorem cen_sen_v_difference :
     (readingFromAllosemes .eventive .zero).isSome = true ∧
     (readingFromAllosemes .zero .simpleEvent).isSome = true ∧
-    VAlloseme.eventive ≠ VAlloseme.zero := by decide
+    VerbalizerAlloseme.eventive ≠ VerbalizerAlloseme.zero := by decide
 
 /-- The five reading types from [wood-2023] Ch. 1 (1.18) are
     pairwise distinct. -/
@@ -388,14 +388,14 @@ open McNallyDeSwart2011
 open DistributedMorphology.Allosemy
 
 /-- Wood's framework requires every `n`-headed nominalisation to commit
-    to an `NAlloseme` (one of the 9 cases). Panagiotidis's framework
+    to an `NominalizerAlloseme` (one of the 9 cases). Panagiotidis's framework
     requires no such commitment — `n` is uniformly [N].
 
     For the [mcnally-deswart-2011] `hetAsCap` analysis (where M&deS
     posit a *trope* interpretation, an entity correlate of a property
     uniquely instantiated in one bearer per [moltmann-2004]), Wood's
     framework would need to specify which alloseme `het` selects. None
-    of the 9 NAlloseme cases is "trope":
+    of the 9 NominalizerAlloseme cases is "trope":
 
     * `relational, sortal, alienator, content` — semantically wrong type
       (relational arguments / kind sortation / possessor closure /
@@ -407,14 +407,14 @@ open DistributedMorphology.Allosemy
     * `entity` — closest fit, but M&deS distinguish tropes from
       ordinary entities (§3.4 + cite of [moltmann-2004] ontology)
 
-    So Wood's framework would require **extending NAlloseme** to model
+    So Wood's framework would require **extending NominalizerAlloseme** to model
     M&deS's trope analysis. Panagiotidis's framework would not. -/
-def woodAllosemeForRival : InflectedAnalysis → Option NAlloseme
+def woodAllosemeForRival : InflectedAnalysis → Option NominalizerAlloseme
   | .nominalisation => some .entity   -- closest fit; not exact
   | .ellipsis       => none           -- no n at surface; elided
-  | .hetAsCap       => none           -- no NAlloseme is "trope"; gap
+  | .hetAsCap       => none           -- no NominalizerAlloseme is "trope"; gap
 
-instance : DecidableEq (Option NAlloseme) := inferInstance
+instance : DecidableEq (Option NominalizerAlloseme) := inferInstance
 
 /-- The Panagiotidis-side prediction: for any rival, what does
     Panagiotidis say `n` does interpretively? Answer (from
@@ -436,7 +436,7 @@ theorem wood_panagiotidis_alloseme_divergence (a : InflectedAnalysis) :
     woodRequiresAllosemeChoice a ≠ panagiotidisRequiresAllosemeChoice a := by
   cases a <;> decide
 
-/-- **The substantive gap on `hetAsCap`.** Wood's NAlloseme inventory
+/-- **The substantive gap on `hetAsCap`.** Wood's NominalizerAlloseme inventory
     has no case obviously fitting M&deS's trope analysis. Wood's
     framework would need extension; Panagiotidis's framework would not.
     Concrete: `woodAllosemeForRival .hetAsCap = none`, recording the
@@ -448,7 +448,7 @@ theorem wood_no_trope_alloseme_for_hetAsCap :
     zero, simpleEvent, result, state, entity. None of these is "trope".
     The bridge documents this as a substantive limitation of Wood's
     inventory when applied to M&deS's adjectival nominalisation data. -/
-theorem nAlloseme_cases_count : nAllosemic.allosemeCount = 9 := rfl
+theorem nAlloseme_cases_count : nominalizer.allosemeCount = 9 := rfl
 
 /-! ## Three-way framework dialogue
 
@@ -461,7 +461,7 @@ dialogue on Dutch nominalisation morphology:
   geometrically; agrees with M&deS on each rival's predictions
   (shared Ackema & Neeleman 2004 lineage).
 * `Wood2023`: requires alloseme commitment per rival; identifies a
-  framework gap (no "trope" NAlloseme), making the divergence with
+  framework gap (no "trope" NominalizerAlloseme), making the divergence with
   Panagiotidis (uniform [N], no allosemes) substantive.
 
 Each framework's distinctive theoretical primitives generate distinct


### PR DESCRIPTION
Renames `VAlloseme` → `VerbalizerAlloseme`, `NAlloseme` → `NominalizerAlloseme`, `VDenotation` → `VerbalizerDenotation`, and the `AllosemicHead` bundles `vAllosemic`/`nAllosemic` → `verbalizer`/`nominalizer` (with `v_ambiguity` → `verbalizer_ambiguity`), matching the `VoiceAlloseme` owner-spelled pattern. Capital `V`/`N` prefixes read as the categories V/N — the very v/V distinction `Categorizer.toCategory` maintains.