### PR TITLE
refactor(Morphology/DistributedMorphology): per-head Allosemy APIs

### DIFF
--- a/Linglib/Fragments/German/Predicates.lean
+++ b/Linglib/Fragments/German/Predicates.lean
@@ -396,7 +396,7 @@ def rauben : GermanVerbEntry where
 /-! ### Change-of-state verbs
 
 These verbs have inherent result states. Their root type determines the
-canonical v alloseme via `VerbalizerAlloseme.fromRootType`. -/
+canonical v alloseme via `Verbalizer.Alloseme.fromRootType`. -/
 
 /-- *brechen* — "break": achievement with result root. The broken state
     entails prior change (you can't be broken without having been broken).

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -15,20 +15,20 @@ several allosemes, selected by the syntactic context rather than tracked
 by morphosyntactic features, and the ambiguity of deverbal
 nominalizations between event, result, state, entity, and content
 readings is the visible trace of that selection. The alloseme
-inventories here compose: the typed denotations of `VerbalizerAlloseme.denote`
-and `NominalizerAlloseme.denote` derive the reading typology, and the analytical
+inventories here compose: the typed denotations of `Verbalizer.Alloseme.denote`
+and `Nominalizer.Alloseme.denote` derive the reading typology, and the analytical
 choice of where the eventive component lives — v or n — is provably
 immaterial for the result and content readings.
 
 ## Main definitions
 
-* `VerbalizerAlloseme`, `NominalizerAlloseme`, `VoiceAlloseme` — the alloseme inventories
-  of v, n, and Voice
-* `verbalizer`, `nominalizer` — v and n as `AllosemicHead`s over the
-  shared selection engine
+* `Verbalizer.Alloseme`, `Nominalizer.Alloseme`, `Voice.Alloseme` —
+  each head's alloseme inventory under its own API
+* `Verbalizer.head`, `Nominalizer.head` — v and n as `AllosemicHead`s
+  over the shared selection engine
 * `NominalizationReading`, `readingFromAllosemes` — the reading typology
   of deverbal nominalizations and its alloseme table
-* `NominalizationModel`, `VerbalizerAlloseme.denote`, `NominalizerAlloseme.denote` — typed
+* `NominalizationModel`, `Verbalizer.Alloseme.denote`, `Nominalizer.Alloseme.denote` — typed
   alloseme denotations and their composition
 
 ## Main statements
@@ -38,10 +38,10 @@ immaterial for the result and content readings.
   denotation: the event and result readings are mirror images
 * `readingFromAllosemes_isSome_iff_denote` — the reading table has a
   reading exactly where the composed denotation is defined
-* `verbalizer_ambiguity`, `cen_result_ambiguity` — one deverbal context licenses
+* `Verbalizer.ambiguity`, `Nominalizer.cen_result_ambiguity` — one deverbal context licenses
   both v allosemes and several n allosemes: nominalization ambiguity as
   non-singleton licensing
-* `verbalizer_isAllosemous` — v's contextual meaning variation on the
+* `Verbalizer.isAllosemous` — v's contextual meaning variation on the
   shared `Realization.Interpreted` carrier
 
 ## Implementation notes
@@ -49,7 +49,7 @@ immaterial for the result and content readings.
 `AllosemicEntry` is a `Morphology.Exponence.Rule` instance, just as
 `VI.VocabItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
 selection engine: `Exponence.selectBy` on the non-wildcard-field score
-(`selectBy_score_isElsewhereWinner`). `VoiceAlloseme.fromComplement` is
+(`selectBy_score_isElsewhereWinner`). `Voice.Alloseme.fromComplement` is
 a worked List-3 competition on that engine; `readingFromAllosemes` is a
 different object — the composition of two already-selected allosemes.
 Existing infrastructure this module retroactively classifies as
@@ -79,13 +79,13 @@ open Minimalist.Voice (Flavor Head)
     eventive when v is interpreted and n vacuous, referential when n is
     interpreted and v vacuous: one root, one structure, the readings
     differing in which head's alloseme is contentful. -/
-inductive VerbalizerAlloseme where
+inductive Verbalizer.Alloseme where
   | eventive   -- introduces an event variable (CEN contexts)
   | zero       -- semantically Ø / identity (SEN/RN contexts)
   deriving DecidableEq, Repr
 
 /-- Does this v alloseme introduce an event variable? -/
-def VerbalizerAlloseme.introducesEvent : VerbalizerAlloseme → Bool
+def Verbalizer.Alloseme.introducesEvent : Verbalizer.Alloseme → Bool
   | .eventive => true
   | .zero     => false
 
@@ -93,8 +93,8 @@ def VerbalizerAlloseme.introducesEvent : VerbalizerAlloseme → Bool
 eventive complement, while the zero alloseme is the unconditioned
 elsewhere option, available trivially in any context ([benz-2025] §2.2).
 Engine selection picks the more specific eventive alloseme in eventive
-contexts; `licensed` keeps both (`verbalizer_ambiguity`). -/
-def verbalizer : AllosemicHead VerbalizerAlloseme where
+contexts; `licensed` keeps both (`Verbalizer.ambiguity`). -/
+def Verbalizer.head : AllosemicHead Verbalizer.Alloseme where
   morpheme := .v
   entries := [
     { label := "v_eventive"
@@ -109,23 +109,23 @@ def verbalizer : AllosemicHead VerbalizerAlloseme where
 zero alloseme is the elsewhere option — so an *observation*-type
 nominalization supports the eventive and the referential reading from
 one structure ([benz-2025] §2.2's symmetric proposal). -/
-theorem verbalizer_ambiguity :
-    VerbalizerAlloseme.eventive ∈ verbalizer.licensed { complementIsEventive := true }
-      ∧ VerbalizerAlloseme.zero ∈ verbalizer.licensed { complementIsEventive := true } := by
+theorem Verbalizer.ambiguity :
+    Verbalizer.Alloseme.eventive ∈ Verbalizer.head.licensed { complementIsEventive := true }
+      ∧ Verbalizer.Alloseme.zero ∈ Verbalizer.head.licensed { complementIsEventive := true } := by
   constructor <;> decide
 
 /-- Root change-type conditions v alloseme selection: result roots,
     which entail a prior change, demand the event variable; property
     concept roots do not ([beavers-etal-2021]'s root typology feeding v
     allosemy). -/
-def VerbalizerAlloseme.fromRootType : Verb.Root.ChangeType → VerbalizerAlloseme
+def Verbalizer.Alloseme.fromRootType : Verb.Root.ChangeType → Verbalizer.Alloseme
   | .result          => .eventive
   | .propertyConcept => .zero
 
 /-- The bridge preserves the change entailment: eventive v iff the root
 entails change. -/
-theorem fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
-    (VerbalizerAlloseme.fromRootType rt).introducesEvent = rt.entailsChange := by
+theorem Verbalizer.fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
+    (Verbalizer.Alloseme.fromRootType rt).introducesEvent = rt.entailsChange := by
   cases rt <;> rfl
 
 /-! ### n allosemy -/
@@ -133,8 +133,8 @@ theorem fromRootType_iff_entailsChange (rt : Verb.Root.ChangeType) :
 /-- Allosemes of the nominal categorizer n: the three non-deverbal types
     of `CategorizerSemantics.NSemanticType`, [benz-2025]'s content
     alloseme for content nominalizations, and [wood-2023]'s deverbal
-    inventory. The deverbal denotations live in `NominalizerAlloseme.denote`. -/
-inductive NominalizerAlloseme where
+    inventory. The deverbal denotations live in `Nominalizer.Alloseme.denote`. -/
+inductive Nominalizer.Alloseme where
   | relational    -- introduces a relation (body-part-of)
   | sortal        -- bare categorization
   | alienator     -- existentially closes a possessor
@@ -147,7 +147,7 @@ inductive NominalizerAlloseme where
   deriving DecidableEq, Repr
 
 /-- The non-deverbal allosemes are `NSemanticType` under another name. -/
-def NominalizerAlloseme.ofNSemanticType : NSemanticType → NominalizerAlloseme
+def Nominalizer.Alloseme.ofNSemanticType : NSemanticType → Nominalizer.Alloseme
   | .relational => .relational
   | .sortal     => .sortal
   | .alienator  => .alienator
@@ -156,7 +156,7 @@ def NominalizerAlloseme.ofNSemanticType : NSemanticType → NominalizerAlloseme
 unconditioned (all-wildcard contexts), the deverbal ones require a
 verbal complement, with the CEN and result allosemes further demanding
 an eventive one. -/
-def nominalizer : AllosemicHead NominalizerAlloseme where
+def Nominalizer.head : AllosemicHead Nominalizer.Alloseme where
   morpheme := .n
   entries := [
     { label := "n_relational"
@@ -192,10 +192,10 @@ def nominalizer : AllosemicHead NominalizerAlloseme where
 the CEN reading (zero n) and the result reading among them. The
 ambiguity of a nominalization is non-singleton licensing, not structural
 ambiguity ([benz-2025], [wood-2023]). -/
-theorem cen_result_ambiguity :
-    NominalizerAlloseme.zero ∈ nominalizer.licensed
+theorem Nominalizer.cen_result_ambiguity :
+    Nominalizer.Alloseme.zero ∈ Nominalizer.head.licensed
         { belowCat := some .v, complementIsEventive := true }
-      ∧ NominalizerAlloseme.result ∈ nominalizer.licensed
+      ∧ Nominalizer.Alloseme.result ∈ Nominalizer.head.licensed
         { belowCat := some .v, complementIsEventive := true } := by
   constructor <;> decide
 
@@ -209,7 +209,7 @@ theorem cen_result_ambiguity :
     by the head. [myler-2016] extends the inventory to four, adding the
     engineer role for ECM *have* and an expletive identity alloseme for
     relational and light-verb *have*, where Voice assigns no θ-role. -/
-inductive VoiceAlloseme where
+inductive Voice.Alloseme where
   | agent     -- combines with dynamic action complements
   | holder    -- combines with stative complements
   | engineer  -- ECM *have*: saturated eventive VoiceP complement
@@ -218,17 +218,17 @@ inductive VoiceAlloseme where
 
 /-- The alloseme assigns a thematic role to the external argument;
 only the expletive identity does not. -/
-def VoiceAlloseme.AssignsTheta (a : VoiceAlloseme) : Prop :=
+def Voice.Alloseme.AssignsTheta (a : Voice.Alloseme) : Prop :=
   a ≠ .expletive
 
-instance : DecidablePred VoiceAlloseme.AssignsTheta :=
+instance : DecidablePred Voice.Alloseme.AssignsTheta :=
   fun _ => inferInstanceAs (Decidable (_ ≠ _))
 
 /-- The Voice allosemes as a competing exponence vocabulary
     ([myler-2016]): engineer for a saturated eventive VoiceP complement
     (most specified), holder for a stative one, expletive elsewhere (the
     all-wildcard default). -/
-def voiceVocabulary : List (AllosemicEntry VoiceAlloseme) :=
+def Voice.vocabulary : List (AllosemicEntry Voice.Alloseme) :=
   [ { label := "Voice_engineer", denotation := .engineer
     , context := { belowCat := some .v, complementIsEventive := true } },
     { label := "Voice_holder", denotation := .holder
@@ -237,33 +237,33 @@ def voiceVocabulary : List (AllosemicEntry VoiceAlloseme) :=
     , context := {} } ]
 
 /-- Voice alloseme selection from complement properties: Elsewhere
-    competition over `voiceVocabulary`, resolved by the shared exponence
+    competition over `Voice.vocabulary`, resolved by the shared exponence
     engine ([myler-2016]'s conditioning of the alloseme on the nature of
     *have*'s complement). -/
-def VoiceAlloseme.fromComplement
+def Voice.Alloseme.fromComplement
     (complementIsEventiveVoiceP : Prop) [Decidable complementIsEventiveVoiceP]
-    (complementIsStative : Prop) [Decidable complementIsStative] : VoiceAlloseme :=
+    (complementIsStative : Prop) [Decidable complementIsStative] : Voice.Alloseme :=
   let q : SyntacticContext :=
     { belowCat := if complementIsEventiveVoiceP then some .v else none
       complementIsEventive := decide complementIsEventiveVoiceP
       complementIsStative := decide complementIsStative }
-  ((Morphology.Exponence.selectBy AllosemicEntry.score voiceVocabulary q).map
+  ((Morphology.Exponence.selectBy AllosemicEntry.score Voice.vocabulary q).map
     AllosemicEntry.denotation).getD .expletive
 
 /-- Eventive-VoiceP complement selects engineer ([myler-2016]). -/
-example : VoiceAlloseme.fromComplement True False = .engineer := by decide
+example : Voice.Alloseme.fromComplement True False = .engineer := by decide
 
 /-- Stative complement selects holder ([kratzer-1996]). -/
-example : VoiceAlloseme.fromComplement False True = .holder := by decide
+example : Voice.Alloseme.fromComplement False True = .holder := by decide
 
 /-- Neither condition met selects the elsewhere expletive. -/
-example : VoiceAlloseme.fromComplement False False = .expletive := by decide
+example : Voice.Alloseme.fromComplement False False = .expletive := by decide
 
 /-- Bridge to the syntactic `Flavor` inventory. Syntactically all four
     allosemes realize the same Voice with a DP specifier; the θ-role
     distinction is resolved at LF ([myler-2016]). The map picks the
     flavor matching each alloseme's syntactic behavior. -/
-def VoiceAlloseme.toFlavor : VoiceAlloseme → Flavor
+def Voice.Alloseme.toFlavor : Voice.Alloseme → Flavor
   | .agent    => .agentive
   | .holder   => .experiencer
   | .engineer => .agentive
@@ -271,9 +271,9 @@ def VoiceAlloseme.toFlavor : VoiceAlloseme → Flavor
 
 /-- The bridge respects θ-assignment: an alloseme assigns a thematic
 role iff its syntactic flavor does. -/
-theorem voice_alloseme_theta_consistent (a : VoiceAlloseme) :
+theorem Voice.theta_consistent (a : Voice.Alloseme) :
     a.AssignsTheta ↔ Head.AssignsTheta { flavor := a.toFlavor, hasD := true } := by
-  cases a <;> simp [VoiceAlloseme.AssignsTheta, VoiceAlloseme.toFlavor] <;> decide
+  cases a <;> simp [Voice.Alloseme.AssignsTheta, Voice.Alloseme.toFlavor] <;> decide
 
 /-! ### Nominalization readings -/
 
@@ -307,7 +307,7 @@ inductive NominalizationReading where
     referential readings could instead involve no v at all, a
     root-attached n — a different structure rather than a different
     alloseme, outside this table. -/
-def readingFromAllosemes : VerbalizerAlloseme → NominalizerAlloseme → Option NominalizationReading
+def readingFromAllosemes : Verbalizer.Alloseme → Nominalizer.Alloseme → Option NominalizationReading
   | .eventive, .zero        => some .complexEvent
   | .eventive, .result      => some .result   -- both-heads-interpreted option
   | .eventive, .content     => some .content  -- both-heads-interpreted option
@@ -361,12 +361,13 @@ structure RootMeaning (E S : Type*) where
 
 /-- What v hands to n: verbal event content under the eventive alloseme,
 the untouched root under the zero alloseme. -/
-inductive VerbalizerDenotation (E S : Type*) where
+inductive Verbalizer.Denotation (E S : Type*) where
   | eventive (p : S → Prop)
   | zero (ρ : RootMeaning E S)
 
 /-- The v alloseme applied to the root. -/
-def VerbalizerAlloseme.denote (ρ : RootMeaning E S) : VerbalizerAlloseme → VerbalizerDenotation E S
+def Verbalizer.Alloseme.denote (ρ : RootMeaning E S) :
+    Verbalizer.Alloseme → Verbalizer.Denotation E S
   | .eventive => .eventive ρ.onEvents
   | .zero     => .zero ρ
 
@@ -378,8 +379,8 @@ event of the root's kind produced ([benz-2025]'s denotation, taken over
 from [wood-2023]); the content alloseme ignores the verbal layer
 entirely. The non-deverbal allosemes have their semantics in
 `Categorizer/Semantics.lean`. -/
-def NominalizerAlloseme.denote (m : NominalizationModel E S) :
-    VerbalizerDenotation E S → NominalizerAlloseme → Option (E → Prop)
+def Nominalizer.Alloseme.denote (m : NominalizationModel E S) :
+    Verbalizer.Denotation E S → Nominalizer.Alloseme → Option (E → Prop)
   | .eventive p, .zero        => some fun x => ∃ e, x = m.ev e ∧ p e
   | .eventive p, .result      => some fun x => ∃ e, p e ∧ m.result x e
   | .eventive _, .content     => some m.hasContent
@@ -396,32 +397,32 @@ vacuous v with the same — compose to the same denotation, so the choice
 of where the eventive component lives is immaterial ([benz-2025] §3.5,
 crediting [wood-2023]). -/
 theorem result_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
-    NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .result
-      = NominalizerAlloseme.denote m (VerbalizerAlloseme.zero.denote ρ) .result := rfl
+    Nominalizer.Alloseme.denote m (Verbalizer.Alloseme.eventive.denote ρ) .result
+      = Nominalizer.Alloseme.denote m (Verbalizer.Alloseme.zero.denote ρ) .result := rfl
 
 /-- The content reading likewise ignores the verbal layer: both v
 options compose to `hasContent`, which is how simple content nouns can
 have the reading with no verbal source at all ([benz-2025] §3.5). -/
 theorem content_options_agree (m : NominalizationModel E S) (ρ : RootMeaning E S) :
-    NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .content
-      = NominalizerAlloseme.denote m (VerbalizerAlloseme.zero.denote ρ) .content := rfl
+    Nominalizer.Alloseme.denote m (Verbalizer.Alloseme.eventive.denote ρ) .content
+      = Nominalizer.Alloseme.denote m (Verbalizer.Alloseme.zero.denote ρ) .content := rfl
 
 /-- The reading typology tracks denotational definedness: a (v, n) pair
 has a reading exactly when its composed denotation is defined. -/
 theorem readingFromAllosemes_isSome_iff_denote (m : NominalizationModel E S)
-    (ρ : RootMeaning E S) (v : VerbalizerAlloseme) (n : NominalizerAlloseme) :
+    (ρ : RootMeaning E S) (v : Verbalizer.Alloseme) (n : Nominalizer.Alloseme) :
     (readingFromAllosemes v n).isSome
-      ↔ (NominalizerAlloseme.denote m (v.denote ρ) n).isSome := by
+      ↔ (Nominalizer.Alloseme.denote m (v.denote ρ) n).isSome := by
   cases v <;> cases n <;>
-    simp [readingFromAllosemes, VerbalizerAlloseme.denote, NominalizerAlloseme.denote]
+    simp [readingFromAllosemes, Verbalizer.Alloseme.denote, Nominalizer.Alloseme.denote]
 
 /-- A complex event nominal holds only of event-entities: the ground of
 its event reading (temporal modification, aspectual behavior). -/
 theorem cen_denotes_events (m : NominalizationModel E S) (ρ : RootMeaning E S)
     {p : E → Prop}
-    (h : NominalizerAlloseme.denote m (VerbalizerAlloseme.eventive.denote ρ) .zero = some p) :
+    (h : Nominalizer.Alloseme.denote m (Verbalizer.Alloseme.eventive.denote ρ) .zero = some p) :
     ∀ x, p x → ∃ e, x = m.ev e := by
-  simp only [VerbalizerAlloseme.denote, NominalizerAlloseme.denote, Option.some.injEq] at h
+  simp only [Verbalizer.Alloseme.denote, Nominalizer.Alloseme.denote, Option.some.injEq] at h
   subst h
   rintro x ⟨e, rfl, -⟩
   exact ⟨e, rfl⟩
@@ -453,7 +454,7 @@ def AllosemicHead.toInterpreted {Sem : Type} (h : AllosemicHead Sem) :
 under an eventive complement, zero elsewhere — so v is `IsAllosemous` on
 the shared carrier: contextual meaning variation as non-constancy of the
 `interp` map ([benz-2025]). -/
-theorem verbalizer_isAllosemous : verbalizer.toInterpreted.IsAllosemous () :=
+theorem Verbalizer.isAllosemous : Verbalizer.head.toInterpreted.IsAllosemous () :=
   ⟨{ complementIsEventive := true }, { complementIsEventive := false },
    .eventive, by decide, .zero, by decide, by decide⟩
 

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -73,7 +73,7 @@ theorem beobachtung_diagnostics :
 is semantically vacuous on all readings but the CEN (§3.5, following
 [wood-2023]). By `adopted_roundtrip` and `adopted_unique`, this is the unique
 derivation of each reading in which the two heads are not both contentful. -/
-def adoptedAllosemes : NominalizationReading → VerbalizerAlloseme × NominalizerAlloseme
+def adoptedAllosemes : NominalizationReading → Verbalizer.Alloseme × Nominalizer.Alloseme
   | .complexEvent => (.eventive, .zero)
   | .simpleEvent  => (.zero, .simpleEvent)
   | .result       => (.zero, .result)
@@ -89,8 +89,8 @@ theorem adopted_roundtrip (r : NominalizationReading) :
 /-- Among derivations in which the two heads are not both contentful, the
 adopted pair is the only one deriving the reading — economy of interpretation
 pins the analysis. -/
-theorem adopted_unique (r : NominalizationReading) (v : VerbalizerAlloseme)
-    (n : NominalizerAlloseme) (hr : readingFromAllosemes v n = some r)
+theorem adopted_unique (r : NominalizationReading) (v : Verbalizer.Alloseme)
+    (n : Nominalizer.Alloseme) (hr : readingFromAllosemes v n = some r)
     (h : v.introducesEvent = false ∨ n = .zero) :
     (v, n) = adoptedAllosemes r := by
   cases v <;> cases n <;> cases r <;>
@@ -103,7 +103,7 @@ theorem adopted_unique (r : NominalizationReading) (v : VerbalizerAlloseme)
 §3.5): an event reading arises only from contentful v with vacuous n, while
 a result or content reading forces the corresponding contentful n, whatever
 v contributes. -/
-theorem reading_determines_contentful_head (v : VerbalizerAlloseme) (n : NominalizerAlloseme) :
+theorem reading_determines_contentful_head (v : Verbalizer.Alloseme) (n : Nominalizer.Alloseme) :
     (readingFromAllosemes v n = some .complexEvent →
       v.introducesEvent = true ∧ n = .zero) ∧
     (readingFromAllosemes v n = some .result → n = .result) ∧
@@ -134,25 +134,25 @@ def nContext (eventive : Bool) : SyntacticContext :=
 /-- The readings derivable in the nominalization structure: any licensed v
 alloseme composed with any licensed n alloseme. -/
 def availableReadings (eventive : Bool) : List NominalizationReading :=
-  (verbalizer.licensed (vContext eventive)).flatMap (λ v =>
-    (nominalizer.licensed (nContext eventive)).filterMap (readingFromAllosemes v))
+  (Verbalizer.head.licensed (vContext eventive)).flatMap (λ v =>
+    (Nominalizer.head.licensed (nContext eventive)).filterMap (readingFromAllosemes v))
 
 /-- Over an event-entailing root both v allosemes are licensed — the premise
 of the reading ambiguity — while a non-eventive root licenses only vacuous
 v. -/
 theorem v_allosemes_licensed :
-    verbalizer.licensed (vContext true) = [.eventive, .zero] ∧
-    verbalizer.licensed (vContext false) = [.zero] := ⟨rfl, rfl⟩
+    Verbalizer.head.licensed (vContext true) = [.eventive, .zero] ∧
+    Verbalizer.head.licensed (vContext false) = [.zero] := ⟨rfl, rfl⟩
 
 open Morphology.Exponence in
 /-- The canonical v alloseme of the root typology is the engine's Elsewhere
 winner: the more specified eventive entry beats vacuous v exactly when the
-root entails an event, so `VerbalizerAlloseme.fromRootType` is derived, not
+root entails an event, so `Verbalizer.Alloseme.fromRootType` is derived, not
 stipulated. -/
 theorem fromRootType_is_selectBy_winner (rt : Verb.Root.ChangeType) :
-    (selectBy AllosemicEntry.score verbalizer.entries
+    (selectBy AllosemicEntry.score Verbalizer.head.entries
         (vContext rt.entailsChange)).map (·.denotation) =
-      some (VerbalizerAlloseme.fromRootType rt) := by
+      some (Verbalizer.Alloseme.fromRootType rt) := by
   cases rt <;> rfl
 
 /-- Every attested *Beobachtung* reading is available in the single
@@ -681,19 +681,19 @@ theorem rsp_data_grounded_in_fragments :
 
 /-- *brechen* (result root) and *frieren* (property-concept root) yield
 opposite canonical v allosemes, connecting the fragment's `rootType` to
-`VerbalizerAlloseme.fromRootType` and `VerbalizerAlloseme.introducesEvent`. -/
+`Verbalizer.Alloseme.fromRootType` and `Verbalizer.Alloseme.introducesEvent`. -/
 theorem rootType_alloseme_divergence :
-    brechen.rootType.map VerbalizerAlloseme.fromRootType = some .eventive ∧
-    frieren.rootType.map VerbalizerAlloseme.fromRootType = some .zero ∧
-    brechen.rootType.map (VerbalizerAlloseme.fromRootType · |>.introducesEvent) = some true ∧
-    frieren.rootType.map (VerbalizerAlloseme.fromRootType · |>.introducesEvent) = some false :=
+    brechen.rootType.map Verbalizer.Alloseme.fromRootType = some .eventive ∧
+    frieren.rootType.map Verbalizer.Alloseme.fromRootType = some .zero ∧
+    brechen.rootType.map (Verbalizer.Alloseme.fromRootType · |>.introducesEvent) = some true ∧
+    frieren.rootType.map (Verbalizer.Alloseme.fromRootType · |>.introducesEvent) = some false :=
   ⟨rfl, rfl, rfl, rfl⟩
 
 /-- A result root selects eventive v, which with vacuous n yields *brechen*'s
 complex event reading. -/
 theorem brechen_cen_path :
     brechen.rootType.bind
-      (λ rt => readingFromAllosemes (VerbalizerAlloseme.fromRootType rt) .zero) =
+      (λ rt => readingFromAllosemes (Verbalizer.Alloseme.fromRootType rt) .zero) =
       some .complexEvent := rfl
 
 /-- A property-concept root selects vacuous v, which with entity n yields
@@ -701,7 +701,7 @@ theorem brechen_cen_path :
 too, since the canonical alloseme is a default rather than a constraint. -/
 theorem frieren_entity_path :
     frieren.rootType.bind
-      (λ rt => readingFromAllosemes (VerbalizerAlloseme.fromRootType rt) .entity) =
+      (λ rt => readingFromAllosemes (Verbalizer.Alloseme.fromRootType rt) .entity) =
       some .simpleEntity := rfl
 
 end Benz2025

--- a/Linglib/Studies/Wood2023.lean
+++ b/Linglib/Studies/Wood2023.lean
@@ -96,7 +96,7 @@ theorem wood_state_derivation :
 theorem cen_sen_v_difference :
     (readingFromAllosemes .eventive .zero).isSome = true ∧
     (readingFromAllosemes .zero .simpleEvent).isSome = true ∧
-    VerbalizerAlloseme.eventive ≠ VerbalizerAlloseme.zero := by decide
+    Verbalizer.Alloseme.eventive ≠ Verbalizer.Alloseme.zero := by decide
 
 /-- The five reading types from [wood-2023] Ch. 1 (1.18) are
     pairwise distinct. -/
@@ -388,14 +388,14 @@ open McNallyDeSwart2011
 open DistributedMorphology.Allosemy
 
 /-- Wood's framework requires every `n`-headed nominalisation to commit
-    to an `NominalizerAlloseme` (one of the 9 cases). Panagiotidis's framework
+    to an `Nominalizer.Alloseme` (one of the 9 cases). Panagiotidis's framework
     requires no such commitment — `n` is uniformly [N].
 
     For the [mcnally-deswart-2011] `hetAsCap` analysis (where M&deS
     posit a *trope* interpretation, an entity correlate of a property
     uniquely instantiated in one bearer per [moltmann-2004]), Wood's
     framework would need to specify which alloseme `het` selects. None
-    of the 9 NominalizerAlloseme cases is "trope":
+    of the 9 Nominalizer.Alloseme cases is "trope":
 
     * `relational, sortal, alienator, content` — semantically wrong type
       (relational arguments / kind sortation / possessor closure /
@@ -407,14 +407,14 @@ open DistributedMorphology.Allosemy
     * `entity` — closest fit, but M&deS distinguish tropes from
       ordinary entities (§3.4 + cite of [moltmann-2004] ontology)
 
-    So Wood's framework would require **extending NominalizerAlloseme** to model
+    So Wood's framework would require **extending Nominalizer.Alloseme** to model
     M&deS's trope analysis. Panagiotidis's framework would not. -/
-def woodAllosemeForRival : InflectedAnalysis → Option NominalizerAlloseme
+def woodAllosemeForRival : InflectedAnalysis → Option Nominalizer.Alloseme
   | .nominalisation => some .entity   -- closest fit; not exact
   | .ellipsis       => none           -- no n at surface; elided
-  | .hetAsCap       => none           -- no NominalizerAlloseme is "trope"; gap
+  | .hetAsCap       => none           -- no Nominalizer.Alloseme is "trope"; gap
 
-instance : DecidableEq (Option NominalizerAlloseme) := inferInstance
+instance : DecidableEq (Option Nominalizer.Alloseme) := inferInstance
 
 /-- The Panagiotidis-side prediction: for any rival, what does
     Panagiotidis say `n` does interpretively? Answer (from
@@ -436,7 +436,7 @@ theorem wood_panagiotidis_alloseme_divergence (a : InflectedAnalysis) :
     woodRequiresAllosemeChoice a ≠ panagiotidisRequiresAllosemeChoice a := by
   cases a <;> decide
 
-/-- **The substantive gap on `hetAsCap`.** Wood's NominalizerAlloseme inventory
+/-- **The substantive gap on `hetAsCap`.** Wood's Nominalizer.Alloseme inventory
     has no case obviously fitting M&deS's trope analysis. Wood's
     framework would need extension; Panagiotidis's framework would not.
     Concrete: `woodAllosemeForRival .hetAsCap = none`, recording the
@@ -448,7 +448,7 @@ theorem wood_no_trope_alloseme_for_hetAsCap :
     zero, simpleEvent, result, state, entity. None of these is "trope".
     The bridge documents this as a substantive limitation of Wood's
     inventory when applied to M&deS's adjectival nominalisation data. -/
-theorem nAlloseme_cases_count : nominalizer.allosemeCount = 9 := rfl
+theorem nAlloseme_cases_count : Nominalizer.head.allosemeCount = 9 := rfl
 
 /-! ## Three-way framework dialogue
 
@@ -461,7 +461,7 @@ dialogue on Dutch nominalisation morphology:
   geometrically; agrees with M&deS on each rival's predictions
   (shared Ackema & Neeleman 2004 lineage).
 * `Wood2023`: requires alloseme commitment per rival; identifies a
-  framework gap (no "trope" NominalizerAlloseme), making the divergence with
+  framework gap (no "trope" Nominalizer.Alloseme), making the divergence with
   Panagiotidis (uniform [N], no allosemes) substantive.
 
 Each framework's distinctive theoretical primitives generate distinct


### PR DESCRIPTION
Embeds each head's allosemy apparatus under its own API, per the owner-relative naming rule: `Verbalizer.Alloseme`/`.head`/`.ambiguity`/`.Denotation`/`.Alloseme.denote`, `Nominalizer.Alloseme`/`.head`/`.cen_result_ambiguity`/`.Alloseme.denote`, `Voice.Alloseme`/`.vocabulary`/`.theta_consistent`. Cross-head objects (`readingFromAllosemes`, `NominalizationModel`, the options-agree theorems) stay at the `Allosemy` level.