### PR TITLE
refactor(Morphology/Paradigm): DomainLocality to Paradigm/DomainContiguity

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1254,7 +1254,6 @@ import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.DistributedMorphology.Categorizer.Semantics
 import Linglib.Morphology.DistributedMorphology.Defs
-import Linglib.Morphology.DistributedMorphology.DomainLocality
 import Linglib.Morphology.DistributedMorphology.Fission
 import Linglib.Morphology.DistributedMorphology.Fusion
 import Linglib.Morphology.DistributedMorphology.Impoverishment
@@ -1289,6 +1288,7 @@ import Linglib.Morphology.Paradigm.Case
 import Linglib.Morphology.Paradigm.Complexity
 import Linglib.Morphology.Paradigm.Contiguity
 import Linglib.Morphology.Paradigm.Degree
+import Linglib.Morphology.Paradigm.DomainContiguity
 import Linglib.Morphology.Paradigm.Function
 import Linglib.Morphology.Paradigm.Linkage
 import Linglib.Morphology.Paradigm.Morphome

--- a/Linglib/Morphology/DistributedMorphology/Merger.lean
+++ b/Linglib/Morphology/DistributedMorphology/Merger.lean
@@ -1,5 +1,5 @@
 import Linglib.Morphology.Exponence.Containment.Contiguity
-import Linglib.Morphology.DistributedMorphology.DomainLocality
+import Linglib.Morphology.Paradigm.DomainContiguity
 import Mathlib.Logic.Relation
 
 /-!
@@ -29,7 +29,7 @@ book's generalizations are theorems about the reachable regions:
 
 The merged region also induces a two-block domain partition of the
 grades (`Synthesis.domainPartition`) — [bobaljik-2012]'s structural
-adjacency as one source of `Morphology/DistributedMorphology/DomainLocality.lean`'s
+adjacency as one source of `Morphology/Paradigm/DomainContiguity.lean`'s
 domain-relativized contiguity, alongside the accessibility-domain
 refinements of [moskal-2015] and [smith-moskal-xu-kang-bobaljik-2019].
 
@@ -46,7 +46,7 @@ refinements of [moskal-2015] and [smith-moskal-xu-kang-bobaljik-2019].
 
 namespace DistributedMorphology
 
-open Morphology (Paradigm IsContiguous)
+open Morphology (Paradigm IsContiguous DomainPartition SameDomain)
 open Morphology.Containment
 
 variable {n : ℕ} {F : Type*}
@@ -241,15 +241,13 @@ theorem rsg {s : Synthesis 3} {v : List (SpanRule 3 F)} {g g' : Fin 3}
 
 /-! ### The induced domain partition -/
 
-open Morphology.DomainLocality in
 /-- The two-block domain partition induced by Merger: word-internal
 grades vs periphrastic ones — [bobaljik-2012]'s structural adjacency
 as a source of domain partitions for
-`Morphology/DistributedMorphology/DomainLocality.lean`. -/
+`Morphology/Paradigm/DomainContiguity.lean`. -/
 def Synthesis.domainPartition (s : Synthesis n) : DomainPartition n Bool :=
   λ g => decide (s.SyntheticAt g)
 
-open Morphology.DomainLocality in
 theorem Synthesis.sameDomain_domainPartition_iff {s : Synthesis n} {i j : Fin n} :
     SameDomain s.domainPartition i j ↔ (s.SyntheticAt i ↔ s.SyntheticAt j) := by
   simp [SameDomain, domainPartition, decide_eq_decide]

--- a/Linglib/Morphology/Paradigm/DomainContiguity.lean
+++ b/Linglib/Morphology/Paradigm/DomainContiguity.lean
@@ -11,54 +11,43 @@ ABA-shaped recurrences are admitted.
 
 ## Motivation
 
-`Morphology.Containment.realize_const_of_terminal_adjacent` (the
-structural-adjacency derivation, [bobaljik-2012]) predicts CMPR-cell =
-SPRL-cell for any generable root pattern. Lifted to case (Wardaman
-3SG: ABS=*narnaj*, ERG=*narnaj-(j)i*, DAT=*gunga*;
-[smith-moskal-xu-kang-bobaljik-2019] §3.6) and number (Yagua 2:
-SG=*jiy*, PL=*jiryéy*, DL=*sááda*;
-[smith-moskal-xu-kang-bobaljik-2019] §4.2 Table 46), the prediction is
-empirically falsified — AAB patterns are attested in both case and
-number suppletion.
-
-[smith-moskal-xu-kang-bobaljik-2019] §3.7 attribute the gap to
-*locality*: structural adjacency ([bobaljik-2012]) and linear
-adjacency ([embick-2010]) are too strict once AAB is admitted (Tamil
-dative suppletion across the plural morpheme is "neither linearly nor
-structurally adjacent to the root"). They adopt the
-[moskal-2015a-dissertation] theory of **accessibility domains (AD)**:
-a category-defining node has a delimiting effect that puts
-more-distant material outside the AD of the root, blocking it from
-conditioning suppletion. Lexical material has such a node (so case
-cannot reach the root); pronouns lack it (so case and number can both
-condition pronominal suppletion).
+Structural adjacency ([bobaljik-2012]) predicts no ABA-shaped
+recurrences anywhere in a containment hierarchy, but AAB patterns
+attested in case and number suppletion falsify the universal form of
+the prediction (Wardaman case, Yagua number;
+[smith-moskal-xu-kang-bobaljik-2019], whose study file carries the
+data). [smith-moskal-xu-kang-bobaljik-2019] attribute the gap to
+locality, adopting [moskal-2015a-dissertation]'s accessibility domains:
+a category-defining node delimits the material that can condition root
+suppletion, so *ABA holds within a domain and ABA shapes across a
+domain boundary are admitted.
 
 ## What this substrate models, and what it doesn't
 
-This file represents the **output** of an AD computation projected
-onto the grades of a hierarchy: a `DomainPartition` saying, for each
-grade, which locality unit it belongs to. The AD theory itself is
-*trigger-relative* — a bound on which heads may condition root
-suppletion, formalized at rule level as
-`SmithMoskalEtAl2019.DomainLocal` on
-`Morphology.Containment.SpanRule` vocabularies. The substrate is
-theory-neutral about how the partition is computed:
-[moskal-2015a-dissertation]'s AD is one source, [embick-2010]'s linear
-adjacency another (every grade its own one-cell domain),
-[bobaljik-2012]'s structural adjacency a third. Consumers state which
-projection they want; the substrate doesn't pick.
+A `DomainPartition` is the **output** of a locality computation
+projected onto the grades: which locality unit each grade belongs to.
+The substrate is theory-neutral about the source —
+[moskal-2015a-dissertation]'s accessibility domains cut the hierarchy
+at a delimiting node (`DomainPartition.threshold`), [embick-2010]'s
+linear adjacency puts every grade in its own one-cell domain,
+[bobaljik-2012]'s structural adjacency uses the trivial partition.
+Consumers state which projection they want. The trigger-relative rule
+side is `SmithMoskalEtAl2019.DomainLocal`.
 
 ## Main declarations
 
-* `DomainPartition n Tag` — domain tag per grade
+* `DomainPartition n Tag` — domain tag per grade;
+  `DomainPartition.IsConvex`, `DomainPartition.threshold` — the
+  interval-shaped partitions locality theories generate
 * `ViolatesABAWithin`, `IsContiguousWithin` — *ABA relativized to
   same-domain triples, over `Morphology.Paradigm`
 * `isContiguousWithin_trivial_iff` — under the trivial partition this
   is exactly `Morphology.IsContiguous`
+* `violatesABAWithin_iff_of_convex` — for convex partitions the check
+  needs only the outer grades to share a domain
 -/
 
-namespace Morphology.DomainLocality
-
+namespace Morphology
 
 variable {n : ℕ} {Tag F : Type*}
 
@@ -78,6 +67,29 @@ instance [DecidableEq Tag] (π : DomainPartition n Tag) (i j : Fin n) :
 /-- The trivial partition: every grade in one domain. -/
 abbrev DomainPartition.trivial (n : ℕ) : DomainPartition n Unit := λ _ => ()
 
+/-- A partition is convex when its domains are intervals of the
+hierarchy: anything between two same-domain grades lies in their
+domain. Locality theories generate convex partitions — an accessibility
+domain is the initial segment below the delimiting node
+([moskal-2015a-dissertation]). -/
+def DomainPartition.IsConvex (π : DomainPartition n Tag) : Prop :=
+  ∀ ⦃i j k : Fin n⦄, i ≤ j → j ≤ k → SameDomain π i k → SameDomain π i j
+
+/-- The threshold partition: grades below `t` inside the root's domain,
+grades from `t` up outside it — the shape of an accessibility-domain
+cut at a category-defining node ([moskal-2015a-dissertation]). -/
+def DomainPartition.threshold (n t : ℕ) : DomainPartition n Bool :=
+  λ i => decide ((i : ℕ) < t)
+
+/-- Threshold partitions are convex. -/
+theorem DomainPartition.threshold_isConvex (n t : ℕ) :
+    (threshold n t).IsConvex := by
+  intro i j k hij hjk h
+  simp only [SameDomain, threshold, decide_eq_decide] at h ⊢
+  have hij' : (i : ℕ) ≤ j := hij
+  have hjk' : (j : ℕ) ≤ k := hjk
+  omega
+
 /-- A pattern violates the domain-relativized *ABA constraint: some
 form recurs across a distinct intervening form, with all three grades
 in the same domain. -/
@@ -96,6 +108,20 @@ def IsContiguousWithin (π : DomainPartition n Tag) (p : Paradigm n F) : Prop :=
 instance [DecidableEq Tag] [DecidableEq F] (π : DomainPartition n Tag)
     (p : Paradigm n F) : Decidable (IsContiguousWithin π p) :=
   inferInstanceAs (Decidable (¬ _))
+
+/-- For a convex partition the within-domain *ABA check needs only the
+outer grades to share a domain: the intervener is trapped between
+them. -/
+theorem violatesABAWithin_iff_of_convex {π : DomainPartition n Tag}
+    (hπ : π.IsConvex) (p : Paradigm n F) :
+    ViolatesABAWithin π p ↔
+      ∃ i j k : Fin n, i < j ∧ j < k ∧ SameDomain π i k
+        ∧ p i = p k ∧ p i ≠ p j := by
+  constructor
+  · rintro ⟨i, j, k, hij, hjk, -, hik, heq, hne⟩
+    exact ⟨i, j, k, hij, hjk, hik, heq, hne⟩
+  · rintro ⟨i, j, k, hij, hjk, hik, heq, hne⟩
+    exact ⟨i, j, k, hij, hjk, hπ hij.le hjk.le hik, hik, heq, hne⟩
 
 /-- Under the trivial partition, domain-relativized contiguity is
 exactly the universal contiguity predicate. -/
@@ -134,4 +160,4 @@ reject this pattern; the domain-relativized one permits it. -/
 example : IsContiguousWithin (![false, false, true] : DomainPartition 3 Bool)
     (![0, 1, 0] : Paradigm 3 ℕ) := by decide
 
-end Morphology.DomainLocality
+end Morphology

--- a/Linglib/Studies/SmithMoskalEtAl2019.lean
+++ b/Linglib/Studies/SmithMoskalEtAl2019.lean
@@ -1,7 +1,7 @@
 import Linglib.Morphology.Paradigm.Degree
 import Linglib.Syntax.Case.Order
 import Linglib.Morphology.Exponence.Containment.Contiguity
-import Linglib.Morphology.DistributedMorphology.DomainLocality
+import Linglib.Morphology.Paradigm.DomainContiguity
 
 /-!
 # Smith, Moskal, Xu, Kang & Bobaljik (2019) — Case and Number Suppletion in Pronouns
@@ -63,12 +63,13 @@ AD-local vocabulary. (3) remains a substrate-addition TODO.
 - Accessibility-domain locality (`§ 4`): `DomainLocal` (rule-level,
   trigger-relative, per the paper's actual formulation), the
   relativized plateau, and the AAB-generability converse; the
-  cell-level projection lives in `Morphology/DistributedMorphology/DomainLocality.lean`.
+  cell-level projection lives in `Morphology/Paradigm/DomainContiguity.lean`.
 -/
 
 namespace SmithMoskalEtAl2019
 
 open Morphology.Degree
+open Morphology (DomainPartition SameDomain IsContiguousWithin ViolatesABAWithin)
 open Morphology.Containment
 
 -- ============================================================================
@@ -401,7 +402,7 @@ theorem wardaman_realize_contiguous :
 -- ============================================================================
 
 /-! The cell-level projection of the AD computation
-(`Morphology/DistributedMorphology/DomainLocality.lean`: `DomainPartition`, `SameDomain`,
+(`Morphology/Paradigm/DomainContiguity.lean`: `DomainPartition`, `SameDomain`,
 `IsContiguousWithin`), instantiated for the case and number domains
 the paper discusses:
 
@@ -419,7 +420,6 @@ the paper discusses:
   substrate (the paper's §4.3.3 markedness-relativized containment)
   is deferred. -/
 
-open Morphology.DomainLocality
 
 /-- The 3-cell ergative case paradigm SMSE 2019 analyses: position 0
     is ABS, position 1 is ERG, position 2 is DAT. -/


### PR DESCRIPTION
Rehomes `DistributedMorphology/DomainLocality.lean` as `Paradigm/DomainContiguity.lean`, resolving the long-flagged namespace wart: the file is a partition-refinement of `Paradigm/Contiguity.lean`'s `IsContiguous` with nothing DM-specific in it (its only import is the Paradigm API), so it joins the Paradigm object API under plain `namespace Morphology`.

- New convexity layer: `DomainPartition.IsConvex` (domains as intervals — the shape locality theories generate), `DomainPartition.threshold` with convexity (Moskal's accessibility-domain cut at a category-defining node), and `violatesABAWithin_iff_of_convex` (for convex partitions the check needs only the outer grades to share a domain).
- Module doc slimmed: the Wardaman/Yagua data and section apparatus live in `Studies/SmithMoskalEtAl2019.lean`, which this file now points to rather than duplicates.