### PR TITLE
refactor(Morphology/DistributedMorphology): parametric Impoverishment

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
+++ b/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
@@ -1,53 +1,71 @@
 import Linglib.Syntax.Minimalist.Features
 
 /-!
-# Impoverishment (Distributed Morphology)
+# Impoverishment
 
-Impoverishment is a postsyntactic operation that deletes features from
-a terminal node before Vocabulary Insertion. It is the DM mechanism for
-deriving syncretism: when two morphosyntactic contexts share an exponent,
-this can be explained by one context losing a distinguishing feature,
-making it fall together with the other at VI.
+Impoverishment deletes features from a terminal before Vocabulary
+Insertion — the Distributed Morphology mechanism for syncretism: a
+context that loses a distinguishing feature falls together with its
+neighbor at VI, forcing retreat to the more general exponent. A rule is
+evaluated against a `Neighborhood` — the focus terminal plus its
+adjacent terminals — and the focus/context split makes the
+paradigmatic/syntagmatic distinction structural: a rule whose condition
+factors through the focus is paradigmatic as a theorem about the rule,
+not an annotation. Deletion only removes: every dimension of the output
+is the input's value or absent (`chain_pointwise`), which is what makes
+the post-impoverishment VI winner the retreat-to-the-general exponent
+(`VI.winner?_retreat`).
 
-## Architecture
+## Main definitions
 
-A rule is evaluated against a `Neighborhood` — the focus terminal plus
-its immediately adjacent terminals — and a `Prop`-valued condition.
-The `focus`/context split is what licenses the
-**paradigmatic / syntagmatic** distinction structurally: a rule whose
-condition factors through `Neighborhood.focus` is *paradigmatic* (refers
-to one node only); otherwise it is *syntagmatic*. This is a
-**theorem about the rule**, not a stipulation, so paradigmatic-vs-
-syntagmatic claims can be discharged by proof rather than annotation.
+* `Neighborhood` — the local context a postsyntactic rule inspects
+* `ImpoverishmentRule` — a conditioned feature deletion, parametric in
+  the bundle and target types; `ImpoverishmentRule.apply` instantiates
+  it with a deletion operation
+* `Paradigmatic`, `Syntagmatic` — condition factors through the focus,
+  or genuinely reads context
+* `deleteFeature`, `chain` — the Minimalist-bundle instantiation and
+  its rule chains
 
-## Connection to Mam
+## Main statements
 
-[scott-2023] (ch. 4) analyzes pronoun reduction in SJA Mam as
-deletion of the pronominal base morpheme when its features are
-redundantly expressed by agreement. This is structurally parallel to
-Impoverishment: features on the pronoun node are deleted (at PF) when
-they are recoverable from agreement, yielding a reduced form. Mam's
-rule is paradigmatic — see `Studies/Scott2023.lean`.
+* `paradigmatic_isParadigmatic` — rules built focus-only are
+  paradigmatic by construction
+* `chain_pointwise` — impoverishment only deletes: chains never
+  introduce or alter feature values
+* `runChain_append` — chains compose sequentially (the ground for the
+  strict-vs-interleaved equivalence in `Middleton2026`)
+
+## Implementation notes
+
+The rule is parametric so that non-Minimalist bundle types (a future
+DM `Terminal`) instantiate it; the deletion operation is a parameter of
+`apply`, not of the rule, since it is shared across a rule system.
+`Middleton2026`'s `MetathesisRule` follows the same template with a
+different rewrite. On the tree carrier, impoverishment is derivable
+from fission and the coproduct (`Studies/SenturiaMarcolli2025.lean`).
+
+## References
+
+* [K. Arregi and A. Nevins, *Morphotactics*][arregi-nevins-2012]
+* [G. Scott, *Pronoun reduction in Mam*][scott-2023]
 -/
 
 namespace DistributedMorphology.Impoverishment
 
 open Minimalist
 
--- ============================================================================
--- § 1: Neighborhoods
--- ============================================================================
+/-! ### Neighborhoods -/
 
-/-- The local context a postsyntactic rule may inspect. The `focus` bundle
-    is the terminal targeted for deletion; `leftCtx` and `rightCtx` are
-    the bundles of the surrounding terminals, nearest first (so the head
-    of each list is the immediately adjacent terminal). The zipper view
-    of a whole spell-out domain is `Spellout.lean`'s `mapNeighborhoods`.
+/-- The local context a postsyntactic rule may inspect. The `focus`
+bundle is the terminal targeted for rewriting; `leftCtx` and `rightCtx`
+are the surrounding terminals, nearest first. The zipper view of a
+whole spell-out domain is `Spellout.lean`'s `mapNeighborhoods`.
 
-    Splitting `focus` from context is what makes the
-    paradigmatic/syntagmatic distinction structural. A condition that
-    only inspects `focus` is paradigmatic by construction; one that
-    reads `leftCtx` or `rightCtx` is syntagmatic. -/
+Splitting `focus` from context makes the paradigmatic/syntagmatic
+distinction structural: a condition that only inspects `focus` is
+paradigmatic by construction; one that reads `leftCtx` or `rightCtx` is
+syntagmatic. -/
 structure Neighborhood (Bundle : Type*) where
   focus    : Bundle
   leftCtx  : List Bundle := []
@@ -58,174 +76,211 @@ structure Neighborhood (Bundle : Type*) where
 def Neighborhood.ofBundle {Bundle : Type*} (fb : Bundle) : Neighborhood Bundle :=
   { focus := fb }
 
--- ============================================================================
--- § 2: Impoverishment Rule
--- ============================================================================
+/-! ### Impoverishment rules -/
 
-/-- An Impoverishment rule deletes `target` from the focus terminal when
-    `condition` holds over the neighborhood.
+variable {Bundle Target : Type*}
 
-    `condition` is `Prop`-valued (the mathlib idiom — see CHANGELOG entry
-    for `GroszJoshiWeinstein1995.lean` and the OT/Conditionals migrations);
-    a `DecidablePred` witness is carried alongside so that
-    `applyImpoverishment` reduces by `decide` on concrete inputs. -/
-structure ImpoverishmentRule where
+/-- An Impoverishment rule: delete `target` from the focus terminal when
+`condition` holds over the neighborhood. The condition is `Prop`-valued
+with a `DecidablePred` witness carried alongside, so applications reduce
+by `decide` on concrete inputs; the deletion operation itself is
+supplied to `ImpoverishmentRule.apply`. -/
+structure ImpoverishmentRule (Bundle Target : Type*) where
   /-- Does this rule apply at the given neighborhood? -/
-  condition : Neighborhood FeatureBundle → Prop
+  condition : Neighborhood Bundle → Prop
   /-- Decidability witness, exposed as an instance (see below). -/
   decCond : DecidablePred condition
-  /-- Which feature type is deleted from the focus bundle. -/
-  target : FeatureVal
+  /-- What is deleted from the focus bundle. -/
+  target : Target
 
 /-- Expose the rule's decidability as an instance so that
-    `if rule.condition n then ... else ...` elaborates. -/
-instance (rule : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
+`if rule.condition n then ... else ...` elaborates. -/
+instance (rule : ImpoverishmentRule Bundle Target) (n : Neighborhood Bundle) :
     Decidable (rule.condition n) := rule.decCond n
 
--- ============================================================================
--- § 3: Paradigmatic / Syntagmatic — a Theorem, not a Label
--- ============================================================================
+/-- Apply a rule at a neighborhood, deleting with `delete`: when the
+condition holds, the focus loses the target; otherwise it is
+unchanged. -/
+def ImpoverishmentRule.apply (delete : Bundle → Target → Bundle)
+    (rule : ImpoverishmentRule Bundle Target) (n : Neighborhood Bundle) : Bundle :=
+  if rule.condition n then delete n.focus rule.target else n.focus
+
+/-! ### Paradigmatic and syntagmatic rules
+
+The structural counterpart of [arregi-nevins-2012]'s distinction
+between rules conditioned by a single node and rules conditioned by the
+node's surroundings — a theorem about a rule, not a flag. -/
 
 /-- A rule is **paradigmatic** iff its condition factors through the
-    focus bundle: any two neighborhoods with the same focus agree on
-    the condition. This is the structural counterpart of
-    [arregi-nevins-2012]'s "rule conditioned by the features of
-    only one node."
-
-    Crucially, this is a **theorem about a rule**, not a flag. Smart
-    constructors below (`paradigmatic`, `syntagmatic`) discharge it
-    automatically when the condition is built focus-only. -/
-def Paradigmatic (r : ImpoverishmentRule) : Prop :=
-  ∀ n₁ n₂ : Neighborhood FeatureBundle,
+focus bundle: any two neighborhoods with the same focus agree on the
+condition. -/
+def Paradigmatic (r : ImpoverishmentRule Bundle Target) : Prop :=
+  ∀ n₁ n₂ : Neighborhood Bundle,
     n₁.focus = n₂.focus → (r.condition n₁ ↔ r.condition n₂)
 
-/-- A rule is **syntagmatic** iff it is not paradigmatic — i.e., there
-    exist neighborhoods agreeing on focus that disagree on the condition,
-    so the condition genuinely depends on context. -/
-def Syntagmatic (r : ImpoverishmentRule) : Prop := ¬ Paradigmatic r
+/-- A rule is **syntagmatic** iff it is not paradigmatic: some
+neighborhoods agree on focus but disagree on the condition, so the
+condition genuinely depends on context. -/
+def Syntagmatic (r : ImpoverishmentRule Bundle Target) : Prop := ¬ Paradigmatic r
 
--- ============================================================================
--- § 4: Smart Constructors
--- ============================================================================
-
-/-- Build a paradigmatic rule from a focus-only Boolean check. The
-    `Paradigmatic` proof is automatic via `paradigmatic_isParadigmatic`. -/
-def paradigmatic (focusCheck : FeatureBundle → Bool) (target : FeatureVal) :
-    ImpoverishmentRule where
+/-- Build a paradigmatic rule from a focus-only Boolean check; the
+`Paradigmatic` proof is `paradigmatic_isParadigmatic`. -/
+def paradigmatic (focusCheck : Bundle → Bool) (target : Target) :
+    ImpoverishmentRule Bundle Target where
   condition n := focusCheck n.focus = true
   decCond n := inferInstanceAs (Decidable (focusCheck n.focus = true))
   target := target
 
 /-- A rule built by `paradigmatic` is paradigmatic by construction. -/
-theorem paradigmatic_isParadigmatic
-    (focusCheck : FeatureBundle → Bool) (target : FeatureVal) :
+theorem paradigmatic_isParadigmatic (focusCheck : Bundle → Bool) (target : Target) :
     Paradigmatic (paradigmatic focusCheck target) := by
   intro n₁ n₂ hfoc
   simp only [paradigmatic, hfoc]
 
 /-- Build a (potentially) syntagmatic rule from a full-neighborhood
-    Boolean check. Whether the result is genuinely syntagmatic depends
-    on `cond` — verify with a separate `Syntagmatic` proof if needed. -/
-def syntagmatic (cond : Neighborhood FeatureBundle → Bool) (target : FeatureVal) :
-    ImpoverishmentRule where
+Boolean check. Whether the result is genuinely syntagmatic depends on
+`cond` — verify with a separate `Syntagmatic` proof if needed. -/
+def syntagmatic (cond : Neighborhood Bundle → Bool) (target : Target) :
+    ImpoverishmentRule Bundle Target where
   condition n := cond n = true
   decCond n := inferInstanceAs (Decidable (cond n = true))
   target := target
 
--- ============================================================================
--- § 5: Applying Impoverishment
--- ============================================================================
+/-! ### Rule chains -/
 
-/-- Delete all features matching `target` from a bundle: set its dimension's
-slot to `absent`. -/
-def deleteFeature (fb : FeatureBundle) (target : FeatureVal) : FeatureBundle :=
-  Function.update fb target.dimension .absent
-
-/-- Apply an Impoverishment rule at a neighborhood: when the condition
-    holds, return the focus with `target` deleted; otherwise return the
-    focus unchanged. -/
-def applyImpoverishment (rule : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
-    FeatureBundle :=
-  if rule.condition n then deleteFeature n.focus rule.target else n.focus
-
-/-- Generic postsyntactic chain: apply a list of rules to a neighborhood,
-    threading the *focus* bundle through each step while holding the
-    surrounding context fixed. This is the shared shape of one cycle of
-    Impoverishment and one cycle of Metathesis (and any other focus-rewriting
-    rule class). -/
-def runChain {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
-    (rules : List R) (n : Neighborhood FeatureBundle) : FeatureBundle :=
+/-- Generic postsyntactic chain: apply a list of rules to a
+neighborhood, threading the *focus* bundle through each step while
+holding the surrounding context fixed. One cycle of Impoverishment and
+one cycle of Metathesis (`Middleton2026`) share this shape. -/
+def runChain {R : Type*} (apply : R → Neighborhood Bundle → Bundle)
+    (rules : List R) (n : Neighborhood Bundle) : Bundle :=
   rules.foldl (init := n.focus)
     (λ focusAcc rule => apply rule { n with focus := focusAcc })
 
-/-- Concatenating two chains is the same as running them sequentially:
-    the second chain starts where the first left off. The proof is
-    `List.foldl_append`. This lemma underwrites the
-    strict-vs-interleaved equivalence
-    (`Middleton2026.runStrict_eq_interleaved_paraSyn`). -/
-theorem runChain_append {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
-    (rs₁ rs₂ : List R) (n : Neighborhood FeatureBundle) :
+/-- Concatenated chains run sequentially: the second chain starts where
+the first left off. This underwrites the strict-vs-interleaved
+equivalence (`Middleton2026.runStrict_eq_interleaved_paraSyn`). -/
+theorem runChain_append {R : Type*} (apply : R → Neighborhood Bundle → Bundle)
+    (rs₁ rs₂ : List R) (n : Neighborhood Bundle) :
     runChain apply (rs₁ ++ rs₂) n =
       runChain apply rs₂ { n with focus := runChain apply rs₁ n } := by
   simp only [runChain, List.foldl_append]
 
 /-- The empty chain is the identity on the focus. -/
-@[simp] theorem runChain_nil {R : Type} (apply : R → Neighborhood FeatureBundle → FeatureBundle)
-    (n : Neighborhood FeatureBundle) : runChain apply [] n = n.focus := rfl
+@[simp] theorem runChain_nil {R : Type*} (apply : R → Neighborhood Bundle → Bundle)
+    (n : Neighborhood Bundle) : runChain apply [] n = n.focus := rfl
+
+/-! ### The Minimalist-bundle instantiation
+
+Deletion on `Minimalist.FeatureBundle` zeroes the target's dimension
+slot. A rule whose focus might carry a different value of that
+dimension should guard in its `condition`: deletion is by dimension,
+not by value match. -/
+
+/-- Delete the target's dimension from a bundle: set its slot to
+`absent`. -/
+def deleteFeature (fb : FeatureBundle) (target : FeatureVal) : FeatureBundle :=
+  Function.update fb target.dimension .absent
+
+/-- Apply an Impoverishment rule at a neighborhood of Minimalist
+bundles. -/
+def applyImpoverishment (rule : ImpoverishmentRule FeatureBundle FeatureVal)
+    (n : Neighborhood FeatureBundle) : FeatureBundle :=
+  rule.apply deleteFeature n
 
 /-- Apply a sequence of impoverishment rules. Specializes `runChain`. -/
-def applyImpoverishmentChain (rules : List ImpoverishmentRule)
+def applyImpoverishmentChain (rules : List (ImpoverishmentRule FeatureBundle FeatureVal))
     (n : Neighborhood FeatureBundle) : FeatureBundle :=
   runChain applyImpoverishment rules n
 
 /-- `applyImpoverishmentChain` distributes over list concatenation. -/
-theorem applyImpoverishmentChain_append (rs₁ rs₂ : List ImpoverishmentRule)
+theorem applyImpoverishmentChain_append
+    (rs₁ rs₂ : List (ImpoverishmentRule FeatureBundle FeatureVal))
     (n : Neighborhood FeatureBundle) :
     applyImpoverishmentChain (rs₁ ++ rs₂) n =
       applyImpoverishmentChain rs₂
         { n with focus := applyImpoverishmentChain rs₁ n } :=
   runChain_append _ _ _ _
 
-/-- Convenience: apply a rule to a bare focus bundle with no surrounding
-    context. Useful for paradigmatic rules where context is irrelevant. -/
-def ImpoverishmentRule.applyToBundle (rule : ImpoverishmentRule)
+/-- Convenience: apply a rule to a bare focus bundle with no
+surrounding context, for paradigmatic rules where context is
+irrelevant. -/
+def ImpoverishmentRule.applyToBundle
+    (rule : ImpoverishmentRule FeatureBundle FeatureVal)
     (fb : FeatureBundle) : FeatureBundle :=
   applyImpoverishment rule (Neighborhood.ofBundle fb)
 
--- ============================================================================
--- § 6: Redundancy-Based Impoverishment
--- ============================================================================
+/-! ### Impoverishment only deletes
 
-/-- A feature is redundant when it is recoverable from another source
-    (e.g., agreement morphology on the verb). This is the mechanism
-    underlying pronoun reduction in Mam ([scott-2023], ch. 4):
-    when all features of the pronominal base are also expressed by
-    agreement, the base is deleted at PF. -/
+Each dimension of an impoverished bundle is the input's value or
+absent: rules and chains never introduce or alter feature content —
+the monotone destructiveness that forces retreat to the more general
+exponent at VI. -/
+
+/-- Deletion leaves every dimension as it was, or absent. -/
+theorem deleteFeature_pointwise (fb : FeatureBundle) (target : FeatureVal)
+    (d : FeatureType) :
+    deleteFeature fb target d = fb d ∨ deleteFeature fb target d = .absent := by
+  by_cases h : d = target.dimension
+  · subst h; right; simp [deleteFeature]
+  · left; simp [deleteFeature, Function.update_of_ne h]
+
+/-- One rule application leaves every dimension as it was, or absent. -/
+theorem applyImpoverishment_pointwise
+    (rule : ImpoverishmentRule FeatureBundle FeatureVal)
+    (n : Neighborhood FeatureBundle) (d : FeatureType) :
+    applyImpoverishment rule n d = n.focus d
+      ∨ applyImpoverishment rule n d = .absent := by
+  unfold applyImpoverishment ImpoverishmentRule.apply
+  split
+  · exact deleteFeature_pointwise n.focus rule.target d
+  · exact .inl rfl
+
+/-- A chain leaves every dimension as it was, or absent. -/
+theorem chain_pointwise (rules : List (ImpoverishmentRule FeatureBundle FeatureVal))
+    (n : Neighborhood FeatureBundle) (d : FeatureType) :
+    applyImpoverishmentChain rules n d = n.focus d
+      ∨ applyImpoverishmentChain rules n d = .absent := by
+  induction rules generalizing n with
+  | nil => exact .inl rfl
+  | cons r rs ih =>
+    have hstep := applyImpoverishment_pointwise r n d
+    have htail := ih { n with focus := applyImpoverishment r n }
+    rcases htail with h | h <;> rw [applyImpoverishmentChain] at h ⊢ <;>
+      simp only [runChain, List.foldl_cons] at h ⊢
+    · rcases hstep with h' | h'
+      · exact .inl (h.trans h')
+      · exact .inr (h.trans h')
+    · exact .inr h
+
+/-- Deleting a feature twice is deleting it once. -/
+theorem deleteFeature_idempotent (fb : FeatureBundle) (target : FeatureVal) :
+    deleteFeature (deleteFeature fb target) target = deleteFeature fb target := by
+  simp only [deleteFeature, Function.update_idem]
+
+/-! ### Redundancy-based impoverishment -/
+
+/-- A feature is redundant when it is recoverable from another source,
+such as agreement morphology on the verb. This is the mechanism
+underlying pronoun reduction in Mam ([scott-2023]): when all features
+of the pronominal base are also expressed by agreement, the base is
+deleted at PF. -/
 def allRecoverable (recoverable pronFeatures : List FeatureVal) : Bool :=
   pronFeatures.all (λ f => recoverable.any (f.sameType ·))
 
 /-- Build a redundancy-based Impoverishment rule. The condition only
-    inspects the focus bundle, so the rule is paradigmatic by
-    construction. -/
+inspects the focus bundle, so the rule is paradigmatic by
+construction. -/
 def redundancyRule (source : List FeatureVal) (target : FeatureVal) :
-    ImpoverishmentRule :=
+    ImpoverishmentRule FeatureBundle FeatureVal :=
   paradigmatic
-    (λ fb => allRecoverable source ((FeatureBundle.toGramFeatures fb).map GramFeature.featureType))
+    (λ fb => allRecoverable source
+      ((FeatureBundle.toGramFeatures fb).map GramFeature.featureType))
     target
 
 /-- Redundancy rules are paradigmatic. -/
 theorem redundancyRule_isParadigmatic (source : List FeatureVal)
     (target : FeatureVal) : Paradigmatic (redundancyRule source target) :=
   paradigmatic_isParadigmatic _ _
-
--- ============================================================================
--- § 7: Verification
--- ============================================================================
-
-/-- Deleting a feature then deleting it again is the same as deleting once.
-    (Filter is idempotent when the predicate is stable.) -/
-theorem deleteFeature_idempotent (fb : FeatureBundle) (target : FeatureVal) :
-    deleteFeature (deleteFeature fb target) target = deleteFeature fb target := by
-  simp only [deleteFeature, Function.update_idem]
 
 end DistributedMorphology.Impoverishment

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -186,8 +186,8 @@ block ordering ([middleton-2026] §4.2.5).
     Morphological Concord are abstracted away — their internal ordering
     is not at issue in [middleton-2026]. -/
 structure ModularPostsyntax where
-  paradigmatic : List ImpoverishmentRule
-  syntagmatic  : List ImpoverishmentRule
+  paradigmatic : List (ImpoverishmentRule FeatureBundle FeatureVal)
+  syntagmatic  : List (ImpoverishmentRule FeatureBundle FeatureVal)
   metathesis   : List MetathesisRule
 
 /-- A&N's strict pipeline: para-block, then syn-block, then metathesis. -/
@@ -200,7 +200,7 @@ def runStrict (M : ModularPostsyntax) (n : Neighborhood FeatureBundle) : Feature
     (whose entries may be paradigmatic or syntagmatic in any order),
     then metathesis. -/
 structure InterleavedPostsyntax where
-  impoverishment : List ImpoverishmentRule
+  impoverishment : List (ImpoverishmentRule FeatureBundle FeatureVal)
   metathesis     : List MetathesisRule
 
 def runInterleaved (M : InterleavedPostsyntax) (n : Neighborhood FeatureBundle) :
@@ -227,7 +227,7 @@ theorem runStrict_eq_interleaved_paraSyn
 
 /-- A two-rule strict pipeline (one paradigmatic, one syntagmatic, no
     metathesis) reduces to applying `[p, s]` in order. -/
-@[simp] theorem runStrict_singleton (p s : ImpoverishmentRule)
+@[simp] theorem runStrict_singleton (p s : ImpoverishmentRule FeatureBundle FeatureVal)
     (n : Neighborhood FeatureBundle) :
     runStrict ⟨[p], [s], []⟩ n = applyImpoverishmentChain [p, s] n := by
   simp only [runStrict, applyImpoverishmentChain, runChain,
@@ -235,7 +235,8 @@ theorem runStrict_eq_interleaved_paraSyn
 
 /-- An interleaved pipeline with no metathesis reduces to the
     impoverishment chain. -/
-@[simp] theorem runInterleaved_no_metathesis (rs : List ImpoverishmentRule)
+@[simp] theorem runInterleaved_no_metathesis
+    (rs : List (ImpoverishmentRule FeatureBundle FeatureVal))
     (n : Neighborhood FeatureBundle) :
     runInterleaved ⟨rs, []⟩ n = applyImpoverishmentChain rs n := by
   simp only [runInterleaved, applyMetathesisChain, runChain, List.foldl_nil]
@@ -251,14 +252,14 @@ theorem runStrict_eq_interleaved_paraSyn
     §4.2.1–§4.2.4 require precisely the syn-before-para derivation that
     `runStrict` excludes by construction. -/
 theorem runStrict_forces_paraSyn_order
-    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
+    (p s : ImpoverishmentRule FeatureBundle FeatureVal) (n : Neighborhood FeatureBundle) :
     runStrict ⟨[p], [s], []⟩ n = applyImpoverishmentChain [p, s] n :=
   runStrict_singleton p s n
 
 /-- The interleaved pipeline can deliver the syn-first derivation that
     `runStrict` cannot. -/
 theorem runInterleaved_admits_synPara
-    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle) :
+    (p s : ImpoverishmentRule FeatureBundle FeatureVal) (n : Neighborhood FeatureBundle) :
     runInterleaved ⟨[s, p], []⟩ n = applyImpoverishmentChain [s, p] n :=
   runInterleaved_no_metathesis _ _
 
@@ -266,7 +267,7 @@ theorem runInterleaved_admits_synPara
     at `n`, then the strict pipeline ⟨[p], [s], []⟩ cannot match the
     interleaved pipeline ⟨[s, p], []⟩ at `n`. -/
 theorem runStrict_neq_runInterleaved_of_diverges
-    (p s : ImpoverishmentRule) (n : Neighborhood FeatureBundle)
+    (p s : ImpoverishmentRule FeatureBundle FeatureVal) (n : Neighborhood FeatureBundle)
     (h : applyImpoverishmentChain [p, s] n ≠ applyImpoverishmentChain [s, p] n) :
     runStrict ⟨[p], [s], []⟩ n ≠ runInterleaved ⟨[s, p], []⟩ n := by
   rw [runStrict_singleton, runInterleaved_no_metathesis]
@@ -274,14 +275,16 @@ theorem runStrict_neq_runInterleaved_of_diverges
 
 /-- A two-step pipeline that runs impoverishment then metathesis at a
     neighborhood (the order both A&N and Middleton endorse). -/
-def runImpovThenMeta (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
+def runImpovThenMeta (rs : List (ImpoverishmentRule FeatureBundle FeatureVal))
+    (ms : List MetathesisRule)
     (n : Neighborhood FeatureBundle) : FeatureBundle :=
   applyMetathesisChain ms { n with focus := applyImpoverishmentChain rs n }
 
 /-- The reversed two-step pipeline: metathesis first, then impoverishment
     (the order both A&N and Middleton reject — supported by Basque in §3.1
     and by Taos in §3.2 of [middleton-2026]). -/
-def runMetaThenImpov (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
+def runMetaThenImpov (rs : List (ImpoverishmentRule FeatureBundle FeatureVal))
+    (ms : List MetathesisRule)
     (n : Neighborhood FeatureBundle) : FeatureBundle :=
   applyImpoverishmentChain rs { n with focus := applyMetathesisChain ms n }
 
@@ -291,7 +294,8 @@ def runMetaThenImpov (rs : List ImpoverishmentRule) (ms : List MetathesisRule)
     and `runMetaThenImpov` differ — i.e., the architectural choice has
     empirical content. -/
 theorem runImpov_neq_runMeta_of_diverges
-    (r : ImpoverishmentRule) (m : MetathesisRule) (n : Neighborhood FeatureBundle)
+    (r : ImpoverishmentRule FeatureBundle FeatureVal) (m : MetathesisRule)
+    (n : Neighborhood FeatureBundle)
     (h : applyMetathesisChain [m] { n with focus := applyImpoverishment r n } ≠
          applyImpoverishment r { n with focus := applyMetathesis m n }) :
     runImpovThenMeta [r] [m] n ≠ runMetaThenImpov [r] [m] n := by
@@ -311,7 +315,7 @@ theorem runImpov_neq_runMeta_of_diverges
     This is a minimal stand-in for the paradigmatic rules involved in
     [middleton-2026] §4.2.1–§4.2.4 — it is not a transcription of
     any specific paper rule. -/
-def paraAtomicRule : ImpoverishmentRule :=
+def paraAtomicRule : ImpoverishmentRule FeatureBundle FeatureVal :=
   paradigmatic
     (λ fb =>
       (FeatureBundle.toGramFeatures fb).any (λ f => f.featureType.sameType (fAuthor true)) &&
@@ -328,9 +332,10 @@ theorem paraAtomicRule_isParadigmatic : Paradigmatic paraAtomicRule :=
     interaction the paper diagnoses). The dependence on `rightCtx`
     is what makes the rule syntagmatic, and `synMinimalRule_isSyntagmatic`
     proves it. -/
-def synMinimalRule : ImpoverishmentRule where
+def synMinimalRule : ImpoverishmentRule FeatureBundle FeatureVal where
   condition n :=
-    ((FeatureBundle.toGramFeatures n.focus).any (λ f => f.featureType.sameType (fAtomic true)) = true)
+    ((FeatureBundle.toGramFeatures n.focus).any
+        (λ f => f.featureType.sameType (fAtomic true)) = true)
     ∧ (n.rightCtx.length > 0)
   decCond _ := inferInstance
   target := fMinimal true
@@ -495,7 +500,7 @@ def applyMetathesisExp (rule : MetathesisRule) (l : List GramFeature) :
 /-- Apply an impoverishment rule to an ordered exponent string in the
     witness context: when the rule fires, drop every exponent of the
     target's dimension, preserving the order of the survivors. -/
-def applyImpovExp (rule : ImpoverishmentRule) (l : List GramFeature) :
+def applyImpovExp (rule : ImpoverishmentRule FeatureBundle FeatureVal) (l : List GramFeature) :
     List GramFeature :=
   if rule.condition { witness with focus := .ofGramFeatures l } then
     l.filter (λ f => ! f.featureType.sameType rule.target)

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -736,7 +736,9 @@ theorem searchOutcome_valued_but_unvalued (rest : List Encounter) :
     Built via the `paradigmatic` smart constructor — the F-diacritic
     condition only inspects the focus bundle (the agreed-with pronoun's
     own features), so the rule is paradigmatic by construction. -/
-def mamImpoverishmentRule : DistributedMorphology.Impoverishment.ImpoverishmentRule :=
+def mamImpoverishmentRule :
+    DistributedMorphology.Impoverishment.ImpoverishmentRule
+      Minimalist.FeatureBundle Minimalist.FeatureVal :=
   DistributedMorphology.Impoverishment.paradigmatic
     -- Check for [+author] (= valued first person): the F diacritic
     -- condition is modeled by this rule only being applied in


### PR DESCRIPTION
Deep cleanse of `Impoverishment.lean`.

- `ImpoverishmentRule (Bundle Target)` is now parametric like its `FissionRule`/`FusionRule` siblings, with the deletion operation a parameter of `ImpoverishmentRule.apply` (shared across a rule system, not per-rule); the Minimalist-bundle instantiation keeps every existing name.
- New deletion-law theorems: `deleteFeature_pointwise`/`applyImpoverishment_pointwise`/`chain_pointwise` — impoverishment only deletes: every dimension of a chain's output is the input's value or absent, the monotone destructiveness that grounds retreat-to-the-general at VI (`winner?_retreat`).
- Register: banners → section headers; stale CHANGELOG cross-reference deleted; duplicated Mam section folded into `redundancyRule`'s docstring; `deleteFeature`'s by-dimension (not by-value) semantics documented; References section added; SenturiaMarcolli fission-derivation cross-referenced.