### PR TITLE
refactor(Morphology/DistributedMorphology): kernel-decidable VI engine

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Basic.lean
@@ -122,6 +122,9 @@ pairs, applicability is `matches`. -/
 instance : Morphology.Exponence.Rule (VocabItem Ctx Root) (Ctx × Root) String :=
   ⟨VocabItem.exponent, fun vi cr => vi.matches cr.1 cr.2 = true⟩
 
+instance : DecidableRel (Applies : VocabItem Ctx Root → Ctx × Root → Prop) :=
+  fun vi cr => inferInstanceAs (Decidable (vi.matches cr.1 cr.2 = true))
+
 instance : Preorder (VocabItem Ctx Root) := Morphology.Exponence.toPreorder
 
 end VI

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
@@ -48,19 +48,14 @@ namespace DistributedMorphology.VI
 -- § 1: Vocabulary Insertion
 -- ============================================================================
 
-/-- Insert a Vocabulary Item at a terminal node. Tries all rules in
-    specificity order (highest first); returns the exponent of the
-    first matching rule. Returns `none` if no rule matches.
-
-    This implements the **Subset Principle** / **Elsewhere Condition**
-    ([halle-marantz-1993]): among all matching rules, the most
-    specific one wins. -/
+/-- Insert a Vocabulary Item at a terminal node: the exponent of the
+highest-`specificity` matching rule (the shared engine's `realize`; ties go
+to the earlier rule), `none` if no rule matches — the **Elsewhere
+Condition** of [halle-marantz-1993]. -/
 def vocabularyInsert {Ctx Root : Type*}
     (rules : List (VocabItem Ctx Root))
     (ctx : Ctx) (root : Root) : Option String :=
-  let sorted := rules.mergeSort (λ a b => a.specificity ≥ b.specificity)
-  sorted.findSome? λ vi =>
-    if vi.matches ctx root then some vi.exponent else none
+  Morphology.Exponence.realize VocabItem.specificity rules (ctx, root)
 
 /-- Simplified insertion when rules are not root-specific. -/
 def vocabularyInsertSimple {Ctx : Type*}
@@ -294,60 +289,17 @@ Prop is the obligation the stipulation incurs, and
 def SpecificityFaithful (rules : List (VocabItem Ctx Root)) : Prop :=
   ∀ a ∈ rules, ∀ b ∈ rules, a ≤ b → ¬ b ≤ a → b.specificity < a.specificity
 
-private theorem findSome?_pairwise_max {l : List (VocabItem Ctx Root)}
-    (hs : l.Pairwise (λ a b => b.specificity ≤ a.specificity))
-    {ctx : Ctx} {root : Root} {e : String}
-    (h : (l.findSome? λ vi =>
-      if vi.matches ctx root then some vi.exponent else none) = some e) :
-    ∃ vi ∈ l, vi.matches ctx root = true ∧ vi.exponent = e ∧
-      ∀ b ∈ l, b.matches ctx root = true → b.specificity ≤ vi.specificity := by
-  induction l with
-  | nil => simp at h
-  | cons x l ih =>
-    rw [List.findSome?_cons] at h
-    obtain ⟨hx, hl⟩ := List.pairwise_cons.mp hs
-    by_cases hm : x.matches ctx root
-    · rw [if_pos hm] at h
-      refine ⟨x, List.mem_cons_self .., hm, Option.some.inj h, ?_⟩
-      intro b hb
-      rcases List.mem_cons.mp hb with rfl | hb'
-      · exact λ _ => Nat.le_refl _
-      · exact λ _ => hx b hb'
-    · rw [if_neg hm] at h
-      obtain ⟨vi, hvi, hvm, hve, hmax⟩ := ih hl h
-      refine ⟨vi, List.mem_cons_of_mem _ hvi, hvm, hve, ?_⟩
-      intro b hb
-      rcases List.mem_cons.mp hb with rfl | hb'
-      · exact λ hbm => absurd hbm (by simpa using hm)
-      · exact hmax b hb'
-
 /-- Under a faithful specificity stipulation, the engine's selection is
 an Elsewhere winner of the shared core. -/
 theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
     {ctx : Ctx} {root : Root} {e : String}
     (h : vocabularyInsert rules ctx root = some e)
     (hf : SpecificityFaithful rules) :
-    ∃ vi ∈ rules, vi.exponent = e ∧
-      IsElsewhereWinner rules (ctx, root) vi := by
-  unfold vocabularyInsert at h
-  have hsort : (rules.mergeSort (λ a b => a.specificity ≥ b.specificity)).Pairwise
-      (λ a b => b.specificity ≤ a.specificity) := by
-    have := List.pairwise_mergeSort
-      (le := λ a b : VocabItem Ctx Root => decide (a.specificity ≥ b.specificity))
-      (λ a b c hab hbc => by
-        simp only [decide_eq_true_eq] at *; omega)
-      (λ a b => by simp only [Bool.or_eq_true, decide_eq_true_eq]; omega)
-      rules
-    exact this.imp (λ hab => by simpa using hab)
-  obtain ⟨vi, hvi, hvm, hve, hmax⟩ := findSome?_pairwise_max hsort h
-  rw [List.mem_mergeSort] at hvi
-  refine ⟨vi, hvi, hve, ⟨hvi, hvm⟩, ?_⟩
-  rintro s ⟨hs, happ⟩ hspec
-  by_contra hns
-  have hlt : vi.specificity < s.specificity := hf s hs vi hvi hspec hns
-  have hble : s.specificity ≤ vi.specificity :=
-    hmax s (List.mem_mergeSort.mpr hs) happ
-  omega
+    ∃ vi ∈ rules, vi.exponent = e ∧ IsElsewhereWinner rules (ctx, root) vi := by
+  obtain ⟨vi, hvi, hve⟩ := Option.map_eq_some_iff.mp h
+  exact ⟨vi, selectBy_mem hvi, hve, selectBy_isElsewhereWinner
+    (λ a ha b hb hab => hf a (mem_applicable.mp ha).1 b (mem_applicable.mp hb).1
+      (lt_iff_le_not_ge.mp hab).1 (lt_iff_le_not_ge.mp hab).2) hvi⟩
 
 end ExponenceCore
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -160,25 +160,25 @@ def teopArticleRules : List (VocabItem Teop.ArticleCtx Unit) :=
   ]
 
 theorem teop_ipossessed_body_part_article :
-    vocabularyInsert teopArticleRules ⟨.gI, false, false⟩ () = some "a" := by native_decide
+    vocabularyInsert teopArticleRules ⟨.gI, false, false⟩ () = some "a" := by decide
 theorem teop_unpossessed_body_part_article :
-    vocabularyInsert teopArticleRules ⟨.gII, false, false⟩ () = some "o" := by native_decide
+    vocabularyInsert teopArticleRules ⟨.gII, false, false⟩ () = some "o" := by decide
 theorem teop_proprial_article :
-    vocabularyInsert teopArticleRules ⟨.gI, false, true⟩ () = some "e" := by native_decide
+    vocabularyInsert teopArticleRules ⟨.gI, false, true⟩ () = some "e" := by decide
 theorem teop_plural_gI_article :
-    vocabularyInsert teopArticleRules ⟨.gI, true, false⟩ () = some "ra" := by native_decide
+    vocabularyInsert teopArticleRules ⟨.gI, true, false⟩ () = some "ra" := by decide
 theorem teop_plural_gII_article :
-    vocabularyInsert teopArticleRules ⟨.gII, true, false⟩ () = some "ro" := by native_decide
+    vocabularyInsert teopArticleRules ⟨.gII, true, false⟩ () = some "ro" := by decide
 
 /-- End-to-end: body-part root + n_{body-part{D}} → gender I → article *a*. -/
 theorem teop_end_to_end_ipossessed :
     vocabularyInsert teopArticleRules
-      ⟨teopGenderFromN teopBodyPartN, false, false⟩ () = some "a" := by native_decide
+      ⟨teopGenderFromN teopBodyPartN, false, false⟩ () = some "a" := by decide
 
 /-- End-to-end: body-part root + n_{alienator} → gender II → article *o*. -/
 theorem teop_end_to_end_unpossessed :
     vocabularyInsert teopArticleRules
-      ⟨teopGenderFromN teopAlienatorN, false, false⟩ () = some "o" := by native_decide
+      ⟨teopGenderFromN teopAlienatorN, false, false⟩ () = some "o" := by decide
 
 /-! ### Bridge to Fragment Data
 
@@ -330,7 +330,7 @@ theorem jarawara_no_impoverishment_when_inactive :
 
 theorem jarawara_fragment_total :
     (Jarawara.allClasses.map (·.memberCount)).foldl (· + ·) 0 = 175 := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 4: Inherited Gender — Yanyuwa & Coastal Marind ([adamson-2024] §4)
@@ -404,7 +404,7 @@ def coastalMarindInheritingNouns : List InheritedGenderNoun :=
     for Probe-Goal agreement with the iPossessor. -/
 theorem coastalMarind_inheriting_prerequisites :
     coastalMarindInheritingNouns.all (λ n => n.selectsD && n.hasUnvaluedGender) = true := by
-  native_decide
+  decide
 
 /-- Inherited gender is consistent with the GLH: the possessor whose
     gender is inherited occupies Spec,nP (nP-internal). -/
@@ -440,18 +440,18 @@ theorem amharic_three_surface_genders :
     let classes :=
       [Head.n_iFem, Head.n_iMasc, Head.n_plain, Head.n_uFem].map
         surfaceGenderClass
-    classes.eraseDups.length = 3 := by native_decide
+    classes.eraseDups.length = 3 := by decide
 
 /-- A two-gender system (e.g., Jarawara [±MASC]) uses only two n types:
     marked (u[+MASC]) and plain. -/
 theorem two_gender_system :
     let classes := [Head.n_uMasc, Head.n_plain].map surfaceGenderClass
-    classes.eraseDups.length = 2 := by native_decide
+    classes.eraseDups.length = 2 := by decide
 
 /-- The Teop two-gender system uses the ANIM dimension. -/
 theorem teop_two_gender_system :
     let classes := [Head.n_uAnim, Head.n_plain].map surfaceGenderClass
-    classes.eraseDups.length = 2 := by native_decide
+    classes.eraseDups.length = 2 := by decide
 
 -- ============================================================================
 -- § 6: Regression: iPossessable n-heads must have selectsD
@@ -514,9 +514,9 @@ def canTakePossessorSem (nh : Head) (mediatesAPoss : Bool := false) : Bool :=
   semType.toBarker.canTakePossessor
 
 -- PF pipeline: body-part n → gender I → article *a*
-theorem pf_body_part : teopPFDerive teopBodyPartN = some "a" := by native_decide
+theorem pf_body_part : teopPFDerive teopBodyPartN = some "a" := by decide
 -- PF pipeline: alienator n → gender II → article *o*
-theorem pf_alienator : teopPFDerive teopAlienatorN = some "o" := by native_decide
+theorem pf_alienator : teopPFDerive teopAlienatorN = some "o" := by decide
 
 -- Semantic pipeline: body-part n (selectsD) → relational → can take possessor
 theorem sem_body_part : canTakePossessorSem teopBodyPartN = true := rfl
@@ -624,7 +624,7 @@ open Italian.NumberGender
 theorem italian_fragment_bridge :
     allNouns.all (fun n =>
       n.genderChanges == n.pluralClass.canAffectGender) = true := by
-  native_decide
+  decide
 
 /-- Cross-linguistic convergence: the -a plural class is dominated by
     body parts (6 of 9). Body parts drive gender interaction in ALL
@@ -636,6 +636,6 @@ theorem italian_fragment_bridge :
 theorem italian_body_part_dominance :
     (aPluralNouns.filter (fun n =>
       ["arm", "finger", "knee", "lip", "bone", "eyebrow"].contains n.gloss)).length = 6 := by
-  native_decide
+  decide
 
 end Adamson2024

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -291,43 +291,43 @@ private abbrev gkIN : AnnotatedFeatures GenderNode :=
 
 /-- (25) Uniform humans resolve to their shared gender. -/
 theorem gk_uniform_fem :
-    resolve gkHF gkHF = some [cls, masc, fem] := by native_decide
+    resolve gkHF gkHF = some [cls, masc, fem] := by decide
 
 theorem gk_uniform_masc :
-    resolve gkHM gkHM = some [cls, masc] := by native_decide
+    resolve gkHM gkHM = some [cls, masc] := by decide
 
 /-- (22a) Mismatched humans → {CLASS, MASC} → masculine plural.
     Intersection: {CLASS,MASC,FEM} ∩ {CLASS,MASC} = {CLASS,MASC}.
     FEM is eliminated because only one conjunct bears it. -/
 theorem gk_human_mismatch :
-    resolve gkHF gkHM = some [cls, masc] := by native_decide
+    resolve gkHF gkHM = some [cls, masc] := by decide
 
 theorem gk_human_mismatch_vi :
-    greekVI [cls, masc] = .masc := by native_decide
+    greekVI [cls, masc] = .masc := by decide
 
 /-- (22b, 40a-c) All inanimate mismatch combinations → {CLASS} → neuter.
     Percolation extracts only iCLASS from each conjunct (uFs excluded).
     This is NOT default insertion — it is the result of intersecting
     the iF sets, which contain only iCLASS for all inanimates. -/
 theorem gk_inanim_MF :
-    resolve gkIM gkIF = some [cls] := by native_decide
+    resolve gkIM gkIF = some [cls] := by decide
 
 theorem gk_inanim_NF :
-    resolve gkIN gkIF = some [cls] := by native_decide
+    resolve gkIN gkIF = some [cls] := by decide
 
 theorem gk_inanim_NM :
-    resolve gkIN gkIM = some [cls] := by native_decide
+    resolve gkIN gkIM = some [cls] := by decide
 
 theorem gk_inanim_mismatch_vi :
-    greekVI [cls] = .neut := by native_decide
+    greekVI [cls] = .neut := by decide
 
 /-- Mismatch Resolution Hypothesis (24): no default feature insertion.
     All resolution outcomes have non-empty intersection (matching). -/
 theorem gk_no_default_human :
-    (resolve gkHF gkHM).isSome = true := by native_decide
+    (resolve gkHF gkHM).isSome = true := by decide
 
 theorem gk_no_default_inanim :
-    (resolve gkIM gkIF).isSome = true := by native_decide
+    (resolve gkIM gkIF).isSome = true := by decide
 
 -- ============================================================================
 -- § 5: Greek — Fixed-Gender Humans
@@ -357,21 +357,21 @@ private abbrev gkFixedNeutFemale : AnnotatedFeatures GenderNode :=
     Despite both being grammatically feminine, iF resolution
     yields {CLASS,MASC} ∩ {CLASS,MASC,FEM} = {CLASS,MASC} → MASC. -/
 theorem gk_fixed_genius_sister :
-    resolve gkFixedFemMale gkHF = some [cls, masc] := by native_decide
+    resolve gkFixedFemMale gkHF = some [cls, masc] := by decide
 
 theorem gk_fixed_genius_sister_vi :
-    (resolve gkFixedFemMale gkHF).map greekVI = some .masc := by native_decide
+    (resolve gkFixedFemMale gkHF).map greekVI = some .masc := by decide
 
 /-- (37) *thima* (female referent) + her mother → feminine (N♀ + F♀ = F).
     Neuter noun's iFs are feminine (referent is female):
     {CLASS,MASC,FEM} ∩ {CLASS,MASC,FEM} = {CLASS,MASC,FEM} → FEM. -/
 theorem gk_fixed_victim_mother :
     resolve gkFixedNeutFemale gkHF = some [cls, masc, fem] := by
-  native_decide
+  decide
 
 theorem gk_fixed_victim_mother_vi :
     (resolve gkFixedNeutFemale gkHF).map greekVI = some .fem := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 6: Greek — [H + I] Coordination
@@ -396,26 +396,26 @@ def gkHIConverges (humanIFs inanimUFs : List GenderNode) : Bool :=
 /-- (54a) M♂ + M■ → grammatical: both map to MASC.
     *kleftis* 'thief' (M) + *pinakas* 'painting' (M). -/
 theorem gk_hi_matched_masc :
-    gkHIConverges [cls, masc] [cls, masc] = true := by native_decide
+    gkHIConverges [cls, masc] [cls, masc] = true := by decide
 
 /-- (54b) F♀ + F■ → grammatical: both map to FEM.
     *gineka* 'woman' (F) + *ombrela* 'umbrella' (F). -/
 theorem gk_hi_matched_fem :
     gkHIConverges [cls, masc, fem] [cls, masc, fem] = true := by
-  native_decide
+  decide
 
 /-- (47) M♂ + N■ → ineffable: MASC ≠ NEUT → PF crash.
     *kleftis* 'thief' (M♂) + *daxtilidi* 'ring' (N■).
     Human iFs → MASC; inanimate uFs → NEUT. No single exponent. -/
 theorem gk_hi_crash :
-    gkHIConverges [cls, masc] [cls] = false := by native_decide
+    gkHIConverges [cls, masc] [cls] = false := by decide
 
 /-- (56) Fixed-gender F♂ + M■ → grammatical: iFs match.
     *megalofiia* 'genius' (iF = M♂) + *pinakas* 'painting' (uF = M■).
     Human's iFs = {CLASS,MASC} → MASC; inanimate's uFs = {CLASS,MASC} → MASC.
     PF converges despite different grammatical genders. -/
 theorem gk_hi_fixed_converge :
-    gkHIConverges [cls, masc] [cls, masc] = true := by native_decide
+    gkHIConverges [cls, masc] [cls, masc] = true := by decide
 
 -- ============================================================================
 -- § 7: Greek — Fixed-Gender + Inanimate [H + I]
@@ -432,7 +432,7 @@ theorem gk_hi_fixed_converge :
     iFs of victim (male) = {CLASS, MASC}; uFs of painting = {CLASS, MASC}.
     VI match: MASC = MASC → PF converges. -/
 theorem gk_hi_fixed_victim_male :
-    gkHIConverges [cls, masc] [cls, masc] = true := by native_decide
+    gkHIConverges [cls, masc] [cls, masc] = true := by decide
 
 /-- (57b) *thima* (N♀ victim, female referent) + *fotografia* (F■) → FEM.
     iFs of victim (female) = {CLASS, MASC, FEM};
@@ -440,14 +440,14 @@ theorem gk_hi_fixed_victim_male :
     VI match: FEM = FEM → PF converges. -/
 theorem gk_hi_fixed_victim_female :
     gkHIConverges [cls, masc, fem] [cls, masc, fem] = true := by
-  native_decide
+  decide
 
 /-- (57a corollary) *thima* (N♀, male ref) + *fotografia* (F■) → PF crash.
     iFs of victim (male) = {CLASS, MASC} → VI → MASC.
     uFs of picture = {CLASS, MASC, FEM} → VI → FEM.
     MASC ≠ FEM → crash. -/
 theorem gk_hi_fixed_victim_male_fem_crash :
-    gkHIConverges [cls, masc] [cls, masc, fem] = false := by native_decide
+    gkHIConverges [cls, masc] [cls, masc, fem] = false := by decide
 
 -- ============================================================================
 -- § 8: Greek — Inanimate Uniform Patterns
@@ -463,15 +463,15 @@ theorem gk_hi_fixed_victim_male_fem_crash :
 
 /-- (38a) F■ + F■ = F: *fusta* 'skirt' + *bluza* 'T-shirt'. -/
 theorem gk_uniform_inanim_fem :
-    greekVI [cls, masc, fem] = .fem := by native_decide
+    greekVI [cls, masc, fem] = .fem := by decide
 
 /-- (38b) M■ + M■ = M: *anaptiras* 'lighter' + *fakos* 'torch'. -/
 theorem gk_uniform_inanim_masc :
-    greekVI [cls, masc] = .masc := by native_decide
+    greekVI [cls, masc] = .masc := by decide
 
 /-- (38c) N■ + N■ = N: *piruni* 'fork' + *kutali* 'spoon'. -/
 theorem gk_uniform_inanim_neut :
-    greekVI [cls] = .neut := by native_decide
+    greekVI [cls] = .neut := by decide
 
 -- ============================================================================
 -- § 9: Greek — Clausal Subjects
@@ -480,7 +480,7 @@ theorem gk_uniform_inanim_neut :
 /-- (2a, 58) Clausal subjects lack gender features entirely.
     No features to percolate → no vocabulary item matches → neuter
     (the elsewhere exponent, least specified). -/
-theorem gk_clausal_default : greekVI [] = .neut := by native_decide
+theorem gk_clausal_default : greekVI [] = .neut := by decide
 
 -- ============================================================================
 -- § 10: Icelandic
@@ -526,17 +526,17 @@ private abbrev isIN : AnnotatedFeatures GenderNode :=
     {CLASS,MASC} ∩ {CLASS,FEM} = {CLASS}. Because MASC and FEM are
     independent siblings, only CLASS survives intersection. -/
 theorem is_human_mismatch :
-    resolve isHM isHF = some [cls] := by native_decide
+    resolve isHM isHF = some [cls] := by decide
 
 theorem is_human_mismatch_vi :
-    icelandicVI [cls] = .neut := by native_decide
+    icelandicVI [cls] = .neut := by decide
 
 /-- (59) Mismatched inanimates → {CLASS} → neuter.
     *frægð* 'fame' (F) + *frami* 'success' (M) → neuter plural.
     All Icelandic inanimates share iFs = {iCLASS} regardless of
     grammatical gender — uFs (uFEM, uMASC) are excluded from resolution. -/
 theorem is_inanim_mismatch :
-    resolve isIF isIM = some [cls] := by native_decide
+    resolve isIF isIM = some [cls] := by decide
 
 /-- The geometry contrast: same labels, different geometry, different outcome.
     Greek {CLASS,MASC,FEM} ∩ {CLASS,MASC} = some {CLASS,MASC}.
@@ -544,7 +544,7 @@ theorem is_inanim_mismatch :
     Same mechanism, different input → different result. -/
 theorem geometry_drives_variation :
     resolve gkHF gkHM ≠ resolve isHF isHM := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 11: BCS (Bosnian/Croatian/Serbian)
@@ -604,16 +604,16 @@ private abbrev bcsN : AnnotatedFeatures GenderNode :=
     = {CLASS,INDIV,MASC,ANIM}. -/
 theorem bcs_human_mismatch :
     resolve bcsHF bcsHM =
-    some [cls, indiv, masc, anim] := by native_decide
+    some [cls, indiv, masc, anim] := by decide
 
 theorem bcs_human_mismatch_vi :
-    bcsVI [cls, indiv, masc, anim] = .masc := by native_decide
+    bcsVI [cls, indiv, masc, anim] = .masc := by decide
 
 /-- Mismatched M + F inanimates → {CLASS, INDIV, MASC} → masculine.
     Both conjuncts share {CLASS, INDIV, MASC} as iFs;
     ANIM + FEM on the feminine noun are uFs, excluded from resolution. -/
 theorem bcs_inanim_MF :
-    resolve bcsIM bcsIF = some [cls, indiv, masc] := by native_decide
+    resolve bcsIM bcsIF = some [cls, indiv, masc] := by decide
 
 /-- (69) Mismatched N + F inanimates → masculine.
     *znanje* 'knowledge' (N) + *intuicija* 'intuition' (F).
@@ -626,15 +626,15 @@ theorem bcs_inanim_MF :
     resolution itself yields {CLASS}, and the coordinate structure's
     INDIV (from GRP/plural) independently ensures masculine VI. -/
 theorem bcs_inanim_NF_resolved :
-    resolve bcsN bcsIF = some [cls] := by native_decide
+    resolve bcsN bcsIF = some [cls] := by decide
 
 /-- After coordination introduces INDIV, the combined features
     ({CLASS} from resolution + {INDIV} from GRP) map to masculine. -/
 theorem bcs_inanim_NF_vi :
-    bcsVI [cls, indiv] = .masc := by native_decide
+    bcsVI [cls, indiv] = .masc := by decide
 
 theorem bcs_inanim_mismatch_vi :
-    bcsVI [cls, indiv, masc] = .masc := by native_decide
+    bcsVI [cls, indiv, masc] = .masc := by decide
 
 /-- (70) Even matched neuters → masculine when coordinated.
     *selo* 'village' (N) + *brdo* 'hill' (N).
@@ -643,10 +643,10 @@ theorem bcs_inanim_mismatch_vi :
     (entailing INDIV). The combined {CLASS, INDIV} at &P maps to
     masculine via VI — INDIV is present → masculine. -/
 theorem bcs_neut_resolved :
-    resolve bcsN bcsN = some [cls] := by native_decide
+    resolve bcsN bcsN = some [cls] := by decide
 
 theorem bcs_neut_coord_masc :
-    bcsVI [cls, indiv] = .masc := by native_decide
+    bcsVI [cls, indiv] = .masc := by decide
 
 -- ============================================================================
 -- § 12: Cross-Linguistic Summary (Table 2)
@@ -654,22 +654,22 @@ theorem bcs_neut_coord_masc :
 
 /-- Table 2 verified: all six cells derived from geometry + intersection. -/
 theorem table2_greek_humans :
-    (resolve gkHF gkHM).map greekVI = some .masc := by native_decide
+    (resolve gkHF gkHM).map greekVI = some .masc := by decide
 
 theorem table2_greek_inanimates :
-    (resolve gkIM gkIF).map greekVI = some .neut := by native_decide
+    (resolve gkIM gkIF).map greekVI = some .neut := by decide
 
 theorem table2_icelandic_humans :
-    (resolve isHM isHF).map icelandicVI = some .neut := by native_decide
+    (resolve isHM isHF).map icelandicVI = some .neut := by decide
 
 theorem table2_icelandic_inanimates :
-    (resolve isIF isIM).map icelandicVI = some .neut := by native_decide
+    (resolve isIF isIM).map icelandicVI = some .neut := by decide
 
 theorem table2_bcs_humans :
-    (resolve bcsHF bcsHM).map bcsVI = some .masc := by native_decide
+    (resolve bcsHF bcsHM).map bcsVI = some .masc := by decide
 
 theorem table2_bcs_inanimates :
-    (resolve bcsIM bcsIF).map bcsVI = some .masc := by native_decide
+    (resolve bcsIM bcsIF).map bcsVI = some .masc := by decide
 
 -- ============================================================================
 -- § 13: Redundancy Rule
@@ -686,12 +686,12 @@ def redundancyRule (iFs uFs : List GenderNode) : List GenderNode :=
 /-- Human feminine: uFs empty → redundancy fills from iFs. -/
 theorem redundancy_human :
     redundancyRule [cls, masc, fem] [] = [cls, masc, fem] := by
-  native_decide
+  decide
 
 /-- Arbitrary feminine: uFs already filled → preserved. -/
 theorem redundancy_arbitrary :
     redundancyRule [cls] [cls, masc, fem] = [cls, masc, fem] := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 14: ABA Syncretism Prediction
@@ -708,7 +708,7 @@ theorem redundancy_arbitrary :
     This rules out N = F ≠ M syncretism patterns. -/
 theorem no_aba_syncretism :
     ¬(greekVI [] = greekVI [cls, masc, fem] ∧
-      greekVI [] ≠ greekVI [cls, masc]) := by native_decide
+      greekVI [] ≠ greekVI [cls, masc]) := by decide
 
 -- ============================================================================
 -- § 15: Feature Geometry Functions
@@ -746,27 +746,27 @@ def icelandicGeometry : GenderNode → AnnotatedFeatures GenderNode
     (FEM entails MASC). -/
 theorem greek_geometry_human_mismatch :
     resolve (greekGeometry .fem) (greekGeometry .masc) =
-    some [cls, masc] := by native_decide
+    some [cls, masc] := by decide
 
 /-- The independent geometry means human mismatch loses both
     MASC and FEM — only CLASS survives intersection. -/
 theorem icelandic_geometry_human_mismatch :
     resolve (icelandicGeometry .fem) (icelandicGeometry .masc) =
-    some [cls] := by native_decide
+    some [cls] := by decide
 
 /-- Geometry determines resolution outcome: same mechanism + same
     feature labels → different VI output, entirely from geometry. -/
 theorem geometry_determines_resolution :
     (resolve (greekGeometry .fem) (greekGeometry .masc)).map greekVI = some .masc ∧
     (resolve (icelandicGeometry .fem) (icelandicGeometry .masc)).map icelandicVI = some .neut := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 /-- The geometry functions reconstruct the noun data: Greek nouns
     are exactly the geometry applied to their most specific iF. -/
-theorem greek_geometry_faithful_fem : greekGeometry .fem = gkHF := by native_decide
-theorem greek_geometry_faithful_masc : greekGeometry .masc = gkHM := by native_decide
-theorem icelandic_geometry_faithful_fem : icelandicGeometry .fem = isHF := by native_decide
-theorem icelandic_geometry_faithful_masc : icelandicGeometry .masc = isHM := by native_decide
+theorem greek_geometry_faithful_fem : greekGeometry .fem = gkHF := by decide
+theorem greek_geometry_faithful_masc : greekGeometry .masc = gkHM := by decide
+theorem icelandic_geometry_faithful_fem : icelandicGeometry .fem = isHF := by decide
+theorem icelandic_geometry_faithful_masc : icelandicGeometry .masc = isHM := by decide
 
 /-- Entailment asymmetry: in the linear chain (Greek), FEM's iFs
     are a superset of MASC's iFs. In the independent geometry
@@ -774,11 +774,11 @@ theorem icelandic_geometry_faithful_masc : icelandicGeometry .masc = isHM := by 
     This is WHY the intersection outcomes differ. -/
 theorem greek_fem_entails_masc :
     (percolateI (greekGeometry .masc)).all
-      ((percolateI (greekGeometry .fem)).contains ·) = true := by native_decide
+      ((percolateI (greekGeometry .fem)).contains ·) = true := by decide
 
 theorem icelandic_fem_not_entails_masc :
     (percolateI (icelandicGeometry .masc)).all
-      ((percolateI (icelandicGeometry .fem)).contains ·) = false := by native_decide
+      ((percolateI (icelandicGeometry .fem)).contains ·) = false := by decide
 
 -- ============================================================================
 -- § 16: Subset Principle — Formal Vocabulary Items
@@ -810,20 +810,20 @@ def bcsVocabItems : List (FeatureVI GenderNode Infl) :=
 
 /-- Subset Principle agrees with ad-hoc `greekVI` for human mismatch. -/
 theorem sp_greek_human_mismatch :
-    subsetPrinciple greekVocabItems [cls, masc] = some .masc := by native_decide
+    subsetPrinciple greekVocabItems [cls, masc] = some .masc := by decide
 
 /-- Subset Principle agrees with `greekVI` for inanimate mismatch. -/
 theorem sp_greek_inanim_mismatch :
-    subsetPrinciple greekVocabItems [cls] = some .neut := by native_decide
+    subsetPrinciple greekVocabItems [cls] = some .neut := by decide
 
 /-- Subset Principle agrees with `greekVI` for uniform feminine. -/
 theorem sp_greek_uniform_fem :
-    subsetPrinciple greekVocabItems [cls, masc, fem] = some .fem := by native_decide
+    subsetPrinciple greekVocabItems [cls, masc, fem] = some .fem := by decide
 
 /-- Subset Principle agrees with `bcsVI` for human mismatch. -/
 theorem sp_bcs_human_mismatch :
     subsetPrinciple bcsVocabItems [cls, indiv, masc, anim] = some .masc := by
-  native_decide
+  decide
 
 /-- Same vocabulary + different geometry → different outcome.
     Greek and Icelandic share the vocabulary (both use `greekVocabItems`),
@@ -832,7 +832,7 @@ theorem sp_bcs_human_mismatch :
 theorem sp_same_vocab_different_geometry :
     subsetPrinciple greekVocabItems [cls, masc] = some .masc ∧
     subsetPrinciple greekVocabItems [cls] = some .neut := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 -- ============================================================================
 -- § 17: Feature Geometry as FeatureOrder
@@ -857,19 +857,19 @@ def icelandicOrder : FeatureOrder GenderNode :=
 
 /-- Greek entailment: FEM entails MASC (FEM's bundle ⊇ MASC's bundle). -/
 theorem greek_order_fem_entails_masc :
-    greekOrder.entails fem masc = true := by native_decide
+    greekOrder.entails fem masc = true := by decide
 
 /-- Icelandic: FEM does NOT entail MASC (independent siblings). -/
 theorem icelandic_order_fem_not_entails_masc :
-    icelandicOrder.entails fem masc = false := by native_decide
+    icelandicOrder.entails fem masc = false := by decide
 
 /-- Greek: MASC entails CLASS. -/
 theorem greek_order_masc_entails_cls :
-    greekOrder.entails masc cls = true := by native_decide
+    greekOrder.entails masc cls = true := by decide
 
 /-- Greek: CLASS does NOT entail MASC (entailment is asymmetric). -/
 theorem greek_order_cls_not_entails_masc :
-    greekOrder.entails cls masc = false := by native_decide
+    greekOrder.entails cls masc = false := by decide
 
 -- ============================================================================
 -- § 18: Mismatch Resolution Hypothesis — Geometry Property
@@ -886,20 +886,20 @@ theorem greek_order_cls_not_entails_masc :
 
 /-- Greek satisfies MRH: all pairwise resolutions succeed. -/
 theorem greek_satisfies_mrh :
-    greekOrder.satisfiesMRH' = true := by native_decide
+    greekOrder.satisfiesMRH' = true := by decide
 
 /-- Icelandic satisfies MRH: all pairwise resolutions succeed.
     Despite different outcomes (neuter for humans instead of masculine),
     no resolution yields an empty intersection. -/
 theorem icelandic_satisfies_mrh :
-    icelandicOrder.satisfiesMRH' = true := by native_decide
+    icelandicOrder.satisfiesMRH' = true := by decide
 
 /-- Both satisfy MRH — this is the paper's "no default insertion"
     claim: the difference between Greek and Icelandic is the
     *content* of the intersection, not whether it exists. -/
 theorem both_satisfy_mrh :
     greekOrder.satisfiesMRH' = true ∧ icelandicOrder.satisfiesMRH' = true := by
-  constructor <;> native_decide
+  constructor <;> decide
 
 -- ============================================================================
 -- § 19: N-ary Coordination
@@ -913,27 +913,27 @@ theorem both_satisfy_mrh :
 
 /-- Greek: three human feminines → {CLASS,MASC,FEM}. -/
 theorem gk_ternary_uniform_fem :
-    resolveN [gkHF, gkHF, gkHF] = some [cls, masc, fem] := by native_decide
+    resolveN [gkHF, gkHF, gkHF] = some [cls, masc, fem] := by decide
 
 /-- Greek: three mismatched humans → {CLASS,MASC} (FEM eliminated).
     FEM + MASC + FEM: FEM present in first and third but not second. -/
 theorem gk_ternary_human_mismatch :
-    resolveN [gkHF, gkHM, gkHF] = some [cls, masc] := by native_decide
+    resolveN [gkHF, gkHM, gkHF] = some [cls, masc] := by decide
 
 /-- Greek: three inanimates → {CLASS} → neuter. -/
 theorem gk_ternary_inanim :
-    resolveN [gkIF, gkIM, gkIN] = some [cls] := by native_decide
+    resolveN [gkIF, gkIM, gkIN] = some [cls] := by decide
 
 /-- Icelandic: three mismatched humans → {CLASS} → neuter.
     Because MASC and FEM are independent, any mismatch loses both. -/
 theorem is_ternary_human_mismatch :
-    resolveN [isHF, isHM, isHF] = some [cls] := by native_decide
+    resolveN [isHF, isHM, isHF] = some [cls] := by decide
 
 /-- BCS: three mismatched humans → {CLASS,INDIV,MASC,ANIM} → masculine.
     INDIV guarantees masculine even with mismatched FEM. -/
 theorem bcs_ternary_human_mismatch :
     resolveN [bcsHF, bcsHM, bcsHF]
-    = some [cls, indiv, masc, anim] := by native_decide
+    = some [cls, indiv, masc, anim] := by decide
 
 /-- N-ary subsumes binary: resolveN [fs1, fs2] = resolve fs1 fs2. -/
 theorem nary_subsumes_binary_greek :

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -201,39 +201,39 @@ def mkNContext (rc : StrongClass) (c : TeluguCase) : NContext :=
 
 theorem vi_luTi_nom :
     vocabularyInsertSimple strongVIRules (mkNContext .luTi .nom)
-      = some "lu" := by native_decide
+      = some "lu" := by decide
 
 theorem vi_luTi_acc :
     vocabularyInsertSimple strongVIRules (mkNContext .luTi .acc)
-      = some "ṭi" := by native_decide
+      = some "ṭi" := by decide
 
 theorem vi_luTi_gen :
     vocabularyInsertSimple strongVIRules (mkNContext .luTi .gen)
-      = some "ṭi" := by native_decide
+      = some "ṭi" := by decide
 
 theorem vi_luTi_dat :
     vocabularyInsertSimple strongVIRules (mkNContext .luTi .dat)
-      = some "ṭi" := by native_decide
+      = some "ṭi" := by decide
 
 theorem vi_uI_nom :
     vocabularyInsertSimple strongVIRules (mkNContext .uI .nom)
-      = some "u" := by native_decide
+      = some "u" := by decide
 
 theorem vi_uI_acc :
     vocabularyInsertSimple strongVIRules (mkNContext .uI .acc)
-      = some "i" := by native_decide
+      = some "i" := by decide
 
 /-- VI produces the correct strong paradigm for -lu∼-ṭi nouns. -/
 theorem vi_matches_strong_luTi (c : TeluguCase) :
     vocabularyInsertSimple strongVIRules (mkNContext .luTi c)
       = some (strongSurface luTiParadigm c) := by
-  cases c <;> native_decide
+  cases c <;> decide
 
 /-- VI produces the correct strong paradigm for -u∼-i nouns. -/
 theorem vi_matches_strong_uI (c : TeluguCase) :
     vocabularyInsertSimple strongVIRules (mkNContext .uI c)
       = some (strongSurface uIParadigm c) := by
-  cases c <;> native_decide
+  cases c <;> decide
 
 -- ============================================================================
 -- § 3: Weak Alternation — *ABA Violation
@@ -285,7 +285,7 @@ theorem weak_pattern_from_paradigm :
       { nom := (weakParadigm .nom).toNat
       , acc := (weakParadigm .acc).toNat
       , gen := (weakParadigm .gen).toNat
-      , dat := (weakParadigm .dat).toNat } := by native_decide
+      , dat := (weakParadigm .dat).toNat } := by decide
 
 -- ────────────────────────────────────────────────────────────────────
 -- Agreement suffixes trigger the weak alternation
@@ -589,7 +589,7 @@ theorem wordNomCands_ne : wordNomCands ≠ [] := by decide
     Surface: *samudr-am* (short form). -/
 theorem wordNom_optimal :
     (Tableau.ofRanking wordNomCands wordNomRanking wordNomCands_ne).optimal
-      = {.deleteNi} := by native_decide
+      = {.deleteNi} := by decide
 
 -- ────────────────────────────────────────────────────────────────────
 -- § 5.2: DAT — light -ki follows within Word
@@ -643,7 +643,7 @@ theorem wordDatCands_ne : wordDatCands ≠ [] := by decide
     Surface: *samudr-āni-ki* (long form). -/
 theorem wordDat_optimal :
     (Tableau.ofRanking wordDatCands (wordDatRanking.map (·.2)) wordDatCands_ne).optimal
-      = {.compLengthen} := by native_decide
+      = {.compLengthen} := by decide
 
 -- ────────────────────────────────────────────────────────────────────
 -- § 5.3: Core result — same constraints, different outputs
@@ -748,7 +748,7 @@ theorem phrasePostpCands_ne : phrasePostpCands ≠ [] := by decide
     is tolerated rather than repaired. Surface: *samudram nunci*. -/
 theorem phrasePostp_optimal :
     (Tableau.ofRanking phrasePostpCands (phrasePostpRanking.map (·.2)) phrasePostpCands_ne).optimal
-      = {.faithful} := by native_decide
+      = {.faithful} := by decide
 
 end PhraseLevel
 
@@ -987,7 +987,7 @@ theorem vi_derives_strong_pattern :
      if strongSurface luTiParadigm .acc == strongSurface luTiParadigm .nom then 0 else 1,
      if strongSurface luTiParadigm .gen == strongSurface luTiParadigm .nom then 0 else 1,
      if strongSurface luTiParadigm .dat == strongSurface luTiParadigm .nom then 0 else 1)
-    = (0, 1, 1, 1) := by native_decide
+    = (0, 1, 1, 1) := by decide
 
 /-- End-to-end argumentation chain:
     1. Strong alternation: VI derives ABB → contiguous → valid case allomorphy

--- a/Linglib/Studies/Carstens2026.lean
+++ b/Linglib/Studies/Carstens2026.lean
@@ -88,7 +88,7 @@ def statusToBundle (s : GenderStatus) : AnnotatedFeatures SemanticCore :=
 theorem interpretable_self_nonempty (c : SemanticCore) :
     resolve (statusToBundle (.interpretable c)) (statusToBundle (.interpretable c))
     = some [c] := by
-  cases c <;> native_decide
+  cases c <;> decide
 
 /-- Uninterpretable genders yield empty intersection with themselves. -/
 theorem uninterpretable_self_empty :
@@ -116,7 +116,7 @@ theorem mismatched_cores_empty (c1 c2 : SemanticCore) (h : c1 ≠ c2) :
 theorem bantu_matching_iff_interpretable (s : GenderStatus) :
     (resolve (statusToBundle s) (statusToBundle s)).isSome = s.isInterpretable := by
   cases s with
-  | interpretable c => cases c <;> native_decide
+  | interpretable c => cases c <;> decide
   | uninterpretable => rfl
 
 -- ============================================================================
@@ -130,14 +130,14 @@ theorem bantu_matching_iff_interpretable (s : GenderStatus) :
 theorem xhosa_1and1_matching :
     resolve (statusToBundle (Xhosa.Gender.genderA).status)
            (statusToBundle (Xhosa.Gender.genderA).status)
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- [7&7] inanimate conjuncts: intersection = [inanimate] → matching cl 8.
     [carstens-2026] Table 13: 100% zi- for non-human [7&7]. -/
 theorem xhosa_7and7_matching :
     resolve (statusToBundle (Xhosa.Gender.genderD).status)
            (statusToBundle (Xhosa.Gender.genderD).status)
-    = some [.inanimate] := by native_decide
+    = some [.inanimate] := by decide
 
 /-- [9&9] animal conjuncts: intersection = [animal] → matching cl 10.
     [carstens-2026] Table 13: 50% zi- matching + 40% ba- default
@@ -145,7 +145,7 @@ theorem xhosa_7and7_matching :
 theorem xhosa_9and9_matching :
     resolve (statusToBundle (Xhosa.Gender.genderE).status)
            (statusToBundle (Xhosa.Gender.genderE).status)
-    = some [.animal] := by native_decide
+    = some [.animal] := by decide
 
 /-! ### Matching agreement unavailable (uninterpretable genders) -/
 
@@ -171,7 +171,7 @@ theorem xhosa_5and5_no_matching :
 theorem xhosa_matching_iff_interpretable (g : Xhosa.Gender) :
     (resolve (statusToBundle g.status) (statusToBundle g.status)).isSome
     = g.status.isInterpretable := by
-  cases g <;> native_decide
+  cases g <;> decide
 
 -- ============================================================================
 -- § 3: Xhosa Predictions — Mismatched Conjoined Singulars
@@ -183,7 +183,7 @@ theorem xhosa_matching_iff_interpretable (g : Xhosa.Gender) :
 theorem xhosa_mismatched_human :
     resolve (statusToBundle (.interpretable .human))
            (statusToBundle (.interpretable .human))
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- Mismatched [inanimate] conjuncts (e.g. [3&5] carrot + egg):
     both have [inanimate] core from stacking → intersection = [inanimate].
@@ -191,7 +191,7 @@ theorem xhosa_mismatched_human :
 theorem xhosa_mismatched_inanimate :
     resolve (statusToBundle (.interpretable .inanimate))
            (statusToBundle (.interpretable .inanimate))
-    = some [.inanimate] := by native_decide
+    = some [.inanimate] := by decide
 
 /-- Human + inanimate (e.g. [9&1a] girl + train):
     [human] ∩ [inanimate] = ∅ → ineffable.
@@ -200,7 +200,7 @@ theorem xhosa_mismatched_inanimate :
 theorem xhosa_human_inanimate_ineffable :
     resolve (statusToBundle (.interpretable .human))
            (statusToBundle (.interpretable .inanimate))
-    = none := by native_decide
+    = none := by decide
 
 -- ============================================================================
 -- § 4: Default Agreement Classes
@@ -228,14 +228,14 @@ theorem default_animal_is_class8 :
 theorem shona_1and1_matching :
     resolve (statusToBundle (Shona.Gender.genderA).status)
            (statusToBundle (Shona.Gender.genderA).status)
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- Shona [7&7]: class 8 zvi- (non-human matching/default).
     [carstens-2026] (62): zvi- for non-human [7&7] (consistent across speakers). -/
 theorem shona_7and7_matching :
     resolve (statusToBundle (Shona.Gender.genderD).status)
            (statusToBundle (Shona.Gender.genderD).status)
-    = some [.nonhuman] := by native_decide
+    = some [.nonhuman] := by decide
 
 /-- Shona [3&3]: no matching → default only.
     [carstens-2026] (59): zvi- (class 8 default) for non-human. -/
@@ -284,7 +284,7 @@ theorem shona_12and12_no_matching :
 theorem shona_matching_iff_interpretable (g : Shona.Gender) :
     (resolve (statusToBundle g.status) (statusToBundle g.status)).isSome
     = g.status.isInterpretable := by
-  cases g <;> native_decide
+  cases g <;> decide
 
 -- ============================================================================
 -- § 6: Cross-linguistic Comparison
@@ -308,7 +308,7 @@ theorem shona_matching_is_minority :
     ([Shona.Gender.genderA, .genderB, .genderC, .genderD,
      .genderE, .genderF, .genderG, .genderH].filter
       (λ g => !(resolve (statusToBundle g.status) (statusToBundle g.status)).isSome)).length = 6 := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 7: nP Stacking Verification
@@ -424,7 +424,7 @@ theorem mismatched_3and5_human :
     resolveStacks
       ⟨3, 1, .interpretable .human⟩
       ⟨5, 1, .interpretable .human⟩
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- Carrot (cl3) + egg (cl5): both [inanimate] core → class 8 zi-.
     [carstens-2026] (85)b, (86)b. -/
@@ -432,7 +432,7 @@ theorem mismatched_3and5_inanimate :
     resolveStacks
       ⟨3, 7, .interpretable .inanimate⟩
       ⟨5, 7, .interpretable .inanimate⟩
-    = some [.inanimate] := by native_decide
+    = some [.inanimate] := by decide
 
 /-- Medium (cl7, human) + girl (cl9, human): both have [human] core
     from nP stacking → [human] ∩ [human] = {[human]} → class 2 ba-.
@@ -442,7 +442,7 @@ theorem mismatched_7and9_both_human :
     resolveStacks
       ⟨7, 1, .interpretable .human⟩
       ⟨9, 1, .interpretable .human⟩
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- Backpack (cl1a, inanimate) + book (cl9, inanimate): both have
     [inanimate] core → [inanimate] ∩ [inanimate] = {[inanimate]} → class 8 zi-.
@@ -451,7 +451,7 @@ theorem mismatched_1aand9_both_inanimate :
     resolveStacks
       ⟨1, 7, .interpretable .inanimate⟩
       ⟨9, 7, .interpretable .inanimate⟩
-    = some [.inanimate] := by native_decide
+    = some [.inanimate] := by decide
 
 -- ============================================================================
 -- § 11: Swahili General Animate Concords Connection
@@ -530,7 +530,7 @@ def elephantBundle := nP .animal
     Chain: canonical class 1 → i[human] percolates → {human} ∩ {human}
     = {human} → matching → class 2 ba-. -/
 theorem derivation_1and1_human :
-    resolve citizenBundle citizenBundle = some [.human] := by native_decide
+    resolve citizenBundle citizenBundle = some [.human] := by decide
 
 /-- End-to-end derivation: gangster.3 & policeman.5 → matching [human].
     [carstens-2026] (86)a: class 2 ba- agreement.
@@ -539,7 +539,7 @@ theorem derivation_1and1_human :
     u excluded, {human} percolates from each →
     {human} ∩ {human} = {human} → matching → class 2 ba-. -/
 theorem derivation_3and5_human :
-    resolve gangsterBundle policemanBundle = some [.human] := by native_decide
+    resolve gangsterBundle policemanBundle = some [.human] := by decide
 
 /-- End-to-end derivation: carrot.3 & egg.5 → matching [inanimate].
     [carstens-2026] (86)b: class 8 zi- agreement.
@@ -547,7 +547,7 @@ theorem derivation_3and5_human :
     Chain: u-outer + i[inanimate]-inner →
     {inanimate} ∩ {inanimate} = {inanimate} → matching → class 8 zi-. -/
 theorem derivation_3and5_inanimate :
-    resolve carrotBundle eggBundle = some [.inanimate] := by native_decide
+    resolve carrotBundle eggBundle = some [.inanimate] := by decide
 
 /-- End-to-end derivation: hat.3 & gun.3 → default.
     [carstens-2026] (77)a, (38)a: class 8 zi- (default for non-human).
@@ -563,7 +563,7 @@ theorem derivation_3and3_default :
     Chain: canonical class 9 → i[animal] percolates →
     {animal} ∩ {animal} = {animal} → matching → class 10 zi-. -/
 theorem derivation_9and9_animal :
-    resolve elephantBundle elephantBundle = some [.animal] := by native_decide
+    resolve elephantBundle elephantBundle = some [.animal] := by decide
 
 /-- End-to-end derivation: human + inanimate → default (generally ineffable).
     [carstens-2026] (91)–(92): *girl.9 & train.1a → no agreement.
@@ -573,7 +573,7 @@ theorem derivation_9and9_animal :
     But no default class satisfies both cores → ineffable. -/
 theorem derivation_human_inanimate_default :
     resolve citizenBundle (nP .inanimate)
-    = none := by native_decide
+    = none := by decide
 
 -- ============================================================================
 -- § 13: Two Grammars — Highest Wins vs Best Semantic Match
@@ -619,13 +619,13 @@ def divinerFeatures : AnnotatedFeatures TwoGrammarFeature :=
     [carstens-2026] (79)a: &P {1, {7}} ∩ {1, {7}} = {1, {7}}. -/
 theorem train_intersection :
     resolve trainFeatures trainFeatures
-    = some [⟨1, false⟩, ⟨7, true⟩] := by native_decide
+    = some [⟨1, false⟩, ⟨7, true⟩] := by decide
 
 /-- Intersection for diviner.7 & scholar.7: both layers survive.
     [carstens-2026] (79)b: &P {7, {1}} ∩ {7, {1}} = {7, {1}}. -/
 theorem diviner_intersection :
     resolve divinerFeatures divinerFeatures
-    = some [⟨7, false⟩, ⟨1, true⟩] := by native_decide
+    = some [⟨7, false⟩, ⟨1, true⟩] := by decide
 
 /-- Highest Wins for train.1a & machine.1a: outermost = class 1 → cl 2 ba-.
     [carstens-2026] (79)a. -/
@@ -817,8 +817,8 @@ theorem bantu_aa_self_matching_consistent :
     (∀ f : GenderNode,
       (resolve [⟨f, .interpretable⟩] [⟨f, .interpretable⟩]).isSome = true) := by
   constructor
-  · intro c; cases c <;> native_decide
-  · intro f; cases f <;> native_decide
+  · intro c; cases c <;> decide
+  · intro f; cases f <;> decide
 
 -- ============================================================================
 -- § 16: Mismatch Resolution Hypothesis — Bantu
@@ -838,7 +838,7 @@ theorem bantu_fails_mrh :
                   statusToBundle (.interpretable .inanimate),
                   statusToBundle (.interpretable .animal),
                   statusToBundle .uninterpretable]
-    = false := by native_decide
+    = false := by decide
 
 /-- Restricted to interpretable-only, MRH still fails:
     mismatched cores (human ≠ inanimate) yield empty intersection. -/
@@ -846,14 +846,14 @@ theorem bantu_interpretable_fails_mrh :
     satisfiesMRH [statusToBundle (.interpretable .human),
                   statusToBundle (.interpretable .inanimate),
                   statusToBundle (.interpretable .animal)]
-    = false := by native_decide
+    = false := by decide
 
 /-- But uniform cores satisfy MRH trivially (self-matching). -/
 theorem bantu_uniform_satisfies_mrh (c : SemanticCore) :
     satisfiesMRH [statusToBundle (.interpretable c),
                   statusToBundle (.interpretable c)]
     = true := by
-  cases c <;> native_decide
+  cases c <;> decide
 
 -- ============================================================================
 -- § 17: N-ary Bantu Resolution
@@ -870,14 +870,14 @@ theorem nary_three_humans :
     resolveN [statusToBundle (.interpretable .human),
               statusToBundle (.interpretable .human),
               statusToBundle (.interpretable .human)]
-    = some [.human] := by native_decide
+    = some [.human] := by decide
 
 /-- Three [inanimate] conjuncts → matching [inanimate]. -/
 theorem nary_three_inanimates :
     resolveN [statusToBundle (.interpretable .inanimate),
               statusToBundle (.interpretable .inanimate),
               statusToBundle (.interpretable .inanimate)]
-    = some [.inanimate] := by native_decide
+    = some [.inanimate] := by decide
 
 /-- Three uninterpretable conjuncts → default (none). -/
 theorem nary_three_uninterpretable :
@@ -892,7 +892,7 @@ theorem nary_mixed_fails :
     resolveN [statusToBundle (.interpretable .human),
               statusToBundle (.interpretable .human),
               statusToBundle (.interpretable .inanimate)]
-    = none := by native_decide
+    = none := by decide
 
 /-- Mixed: two [human] + one uninterpretable → default (none).
     Uninterpretable conjuncts block matching even with uniform cores. -/

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -523,7 +523,7 @@ private def voiceOblProbe : FeatureBundle := mamVoice.features
 theorem both_probes_unvalued :
     (Minimalist.FeatureBundle.toGramFeatures voiceProbe).all GramFeature.isUnvalued = true ∧
     (Minimalist.FeatureBundle.toGramFeatures voiceOblProbe).all GramFeature.isUnvalued = true := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 /-- φ-Agree (Scott 2023) and oblique-Agree (this paper) are parallel
     instances of the same operation, differing only in which features
@@ -537,7 +537,7 @@ theorem phi_and_oblique_agree_parallel :
     applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) .oblique =
       some (.ofGramFeatures [.valued (.oblique true)]) ∧
     spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
-  exact ⟨by native_decide, by native_decide, by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide, by decide, by decide⟩
 
 end UnifiedAgree
 

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -95,33 +95,33 @@ def englishTnsVI : List (FeatureVI EngInflFeature String) :=
     [halle-marantz-1993]. -/
 theorem past_participle_gets_n :
     subsetPrinciple englishTnsVI [.past, .participle] = some "-n" := by
-  native_decide
+  decide
 
 /-- Past finite: [+past] → `-d`.
     `-n` does not match because [+participle] ⊄ {past}.
     [halle-marantz-1993]. -/
 theorem past_finite_gets_d :
     subsetPrinciple englishTnsVI [.past] = some "-d" := by
-  native_decide
+  decide
 
 /-- Non-finite participle: [+participle] → `-ing`.
     [halle-marantz-1993]. -/
 theorem nonpast_participle_gets_ing :
     subsetPrinciple englishTnsVI [.participle] = some "-ing" := by
-  native_decide
+  decide
 
 /-- Third singular present: [3sg] → `-z`.
     [halle-marantz-1993]. -/
 theorem sg3_present_gets_z :
     subsetPrinciple englishTnsVI [.sg3] = some "-z" := by
-  native_decide
+  decide
 
 /-- Elsewhere (bare stem): [] → `∅`.
     When no features are present, the elsewhere entry wins.
     [halle-marantz-1993]. -/
 theorem elsewhere_gets_null :
     subsetPrinciple englishTnsVI [] = some "∅" := by
-  native_decide
+  decide
 
 /-- The Subset Principle resolves `-n` vs `-d` competition: for a
     [+past, +participle] target, `-n` (2 features) beats `-d`
@@ -129,7 +129,7 @@ theorem elsewhere_gets_null :
 theorem n_beats_d_for_past_participle :
     subsetPrinciple englishTnsVI [.past, .participle] ≠
     subsetPrinciple englishTnsVI [.past] := by
-  native_decide
+  decide
 
 /-- The paradigm is total: every possible feature combination
     receives an exponent (thanks to the elsewhere entry). -/
@@ -198,41 +198,41 @@ def conditionedPastVI : List (VocabItem Bool SampleVerb) :=
 /-- Regular verbs get `-d`: no root-specific entry matches. -/
 theorem walk_gets_d :
     vocabularyInsert conditionedPastVI true .walk = some "-d" := by
-  native_decide
+  decide
 
 theorem play_gets_d :
     vocabularyInsert conditionedPastVI true .play = some "-d" := by
-  native_decide
+  decide
 
 /-- Verbs in the `-t` class: root restriction overrides default. -/
 theorem dwell_gets_t :
     vocabularyInsert conditionedPastVI true .dwell = some "-t" := by
-  native_decide
+  decide
 
 theorem buy_gets_t :
     vocabularyInsert conditionedPastVI true .buy = some "-t" := by
-  native_decide
+  decide
 
 /-- Verbs in the `∅` class: no overt past tense marking. -/
 theorem put_gets_null :
     vocabularyInsert conditionedPastVI true .put = some "∅" := by
-  native_decide
+  decide
 
 theorem beat_gets_null :
     vocabularyInsert conditionedPastVI true .beat = some "∅" := by
-  native_decide
+  decide
 
 /-- The Paninian principle: root-restricted entries override the
     default for matching roots. -/
 theorem root_restriction_overrides_default :
     vocabularyInsert conditionedPastVI true .dwell ≠
     vocabularyInsert conditionedPastVI true .walk := by
-  native_decide
+  decide
 
 /-- Non-past context: no entry matches (all require [+past]). -/
 theorem nonpast_no_match :
     vocabularyInsert conditionedPastVI false .walk = none := by
-  native_decide
+  decide
 
 end ConditionedAllomorphy
 
@@ -297,35 +297,35 @@ def fusedFeatures (tPast tPart : Bool) (aSg3 : Bool) : List EngInflFeature :=
     One exponent realizes both heads. -/
 theorem fusion_3sg_present :
     subsetPrinciple englishTnsVI (fusedFeatures false false true) = some "-z" := by
-  native_decide
+  decide
 
 /-- Past finite: Tns[+past] fused with Agr[−3sg] → [past] → `-d`. -/
 theorem fusion_past :
     subsetPrinciple englishTnsVI (fusedFeatures true false false) = some "-d" := by
-  native_decide
+  decide
 
 /-- Past participle: Tns[+past,+part] fused with Agr[−3sg]
     → [past, participle] → `-n`. -/
 theorem fusion_past_participle :
     subsetPrinciple englishTnsVI (fusedFeatures true true false) = some "-n" := by
-  native_decide
+  decide
 
 /-- Present participle: Tns[−past,+part] fused with Agr[−3sg]
     → [participle] → `-ing`. -/
 theorem fusion_present_participle :
     subsetPrinciple englishTnsVI (fusedFeatures false true false) = some "-ing" := by
-  native_decide
+  decide
 
 /-- Elsewhere: Tns[−past,−part] fused with Agr[−3sg] → [] → `∅`. -/
 theorem fusion_elsewhere :
     subsetPrinciple englishTnsVI (fusedFeatures false false false) = some "∅" := by
-  native_decide
+  decide
 
 /-- Every Tns+Agr fusion produces a feature bundle that the VI
     paradigm can spell out — the paradigm is complete. -/
 theorem fusion_always_spellable (tPast tPart aSg3 : Bool) :
     (subsetPrinciple englishTnsVI (fusedFeatures tPast tPart aSg3)).isSome = true := by
-  cases tPast <;> cases tPart <;> cases aSg3 <;> native_decide
+  cases tPast <;> cases tPart <;> cases aSg3 <;> decide
 
 /-- The Tns+Agr pipeline over a spell-out domain: the fusion module,
     then pointwise insertion by the Subset Principle. -/
@@ -339,7 +339,7 @@ def tnsAgrSpellout :
 theorem walks_pf :
     tnsAgrSpellout.pf
         [(InflHead.tns false false).features, (InflHead.agr true).features]
-      = [some "-z"] := by native_decide
+      = [some "-z"] := by decide
 
 /-- Two syntactic terminals enter, one exponent slot leaves — the
     terminal/exponent misalignment is carried entirely by the fusion
@@ -406,20 +406,20 @@ theorem impoverish_produces_syncretism :
     subsetPrinciple englishTnsVI
       (deleteFeature [.past, .participle] .participle) =
     subsetPrinciple englishTnsVI [.past] := by
-  native_decide
+  decide
 
 /-- Without impoverishment, [+past, +participle] gets `-n`
     (*taken*, *eaten*). -/
 theorem without_impoverishment_gets_n :
     subsetPrinciple englishTnsVI [.past, .participle] = some "-n" := by
-  native_decide
+  decide
 
 /-- With impoverishment of [+participle], the same context gets `-d`
     (*walked* as both simple past and past participle). -/
 theorem with_impoverishment_gets_d :
     subsetPrinciple englishTnsVI
       (deleteFeature [.past, .participle] .participle) = some "-d" := by
-  native_decide
+  decide
 
 /-- Full DM pipeline: Fusion → Impoverishment → VI.
 
@@ -434,7 +434,7 @@ theorem with_impoverishment_gets_d :
 theorem pipeline_fusion_impoverishment_vi :
     subsetPrinciple englishTnsVI
       (deleteFeature (fusedFeatures true true false) .participle) = some "-d" := by
-  native_decide
+  decide
 
 end ImpoverishmentSyncretism
 

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -1219,41 +1219,41 @@ def viThreeGender (ch : Categorizer.Head) : Nat :=
 
 -- Set 1 verification
 theorem spanish_vi_derived :
-    spanishNs.computeGenders viSet1 = spanishNs.surfaceGenders := by native_decide
+    spanishNs.computeGenders viSet1 = spanishNs.surfaceGenders := by decide
 
 theorem amharic_vi_derived :
-    amharicNs.computeGenders viSet1 = amharicNs.surfaceGenders := by native_decide
+    amharicNs.computeGenders viSet1 = amharicNs.surfaceGenders := by decide
 
 theorem hausa_vi_derived :
-    hausaNs.computeGenders viSet1 = hausaNs.surfaceGenders := by native_decide
+    hausaNs.computeGenders viSet1 = hausaNs.surfaceGenders := by decide
 
 -- Set 2 verification
 theorem maa_vi_derived :
-    maaNs.computeGenders viSet2 = maaNs.surfaceGenders := by native_decide
+    maaNs.computeGenders viSet2 = maaNs.surfaceGenders := by decide
 
 -- 3-gender verification
 theorem russian_vi_derived :
-    russianNs.computeGenders viThreeGender = russianNs.surfaceGenders := by native_decide
+    russianNs.computeGenders viThreeGender = russianNs.surfaceGenders := by decide
 
 theorem mangarayi_vi_derived :
     mangarayiNs.computeGenders viThreeGender =
-      mangarayiNs.surfaceGenders := by native_decide
+      mangarayiNs.surfaceGenders := by decide
 
 theorem lavukaleve_vi_derived :
     lavukaleveNs.computeGenders viThreeGender =
-      lavukaleveNs.surfaceGenders := by native_decide
+      lavukaleveNs.surfaceGenders := by decide
 
 /-- Dieri: same 3-n inventory as Mangarayi but 2 surface genders under
     Set 1 VI (where plain n → masculine, not neuter). -/
 theorem dieri_vi_derived :
-    dieriNs.computeGenders viSet1 = dieriNs.surfaceGenders := by native_decide
+    dieriNs.computeGenders viSet1 = dieriNs.surfaceGenders := by decide
 
 /-- The Dieri vs Mangarayi contrast: same n-heads, different VI → different
     surface gender counts. This is now DERIVED, not stipulated. -/
 theorem dieri_mangarayi_vi_contrast :
     dieriNs.nHeads = mangarayiNs.nHeads ∧
     dieriNs.computeGenders viSet1 ≠
-      mangarayiNs.computeGenders viThreeGender := ⟨rfl, by native_decide⟩
+      mangarayiNs.computeGenders viThreeGender := ⟨rfl, by decide⟩
 
 -- ============================================================================
 -- § 15: Hausa Phonological-Assignment Refutation ([kramer-2020] §3.3.1)

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -62,7 +62,9 @@ theorem copulaVI_agrees_vocabItem (v : Head) :
   cases v with | mk flavor hasD _ checksCase features =>
   cases flavor <;> cases hasD <;> cases checksCase <;>
   simp [copulaVI, copulaVIRules, vocabularyInsertSimple, vocabularyInsert,
-    VocabItem.matches, List.mergeSort, List.findSome?]
+    VocabItem.matches, Morphology.Exponence.realize, Morphology.Exponence.selectBy,
+    Morphology.Exponence.applicable, Morphology.Exponence.Applies,
+    Morphology.Exponence.exponent, List.argmax, List.argAux]
 
 /-- HAVE ↔ Voice is transitive (external argument, not PF-only, not passive). -/
 theorem vi_characterization (v : Head) :
@@ -177,7 +179,9 @@ theorem icelandicVI_agrees_vocabItem (dp : IcelandicPossDP) :
     some (if icelandicHaveVI dp = .hafa then "hafa" else "eiga") := by
   cases dp with | mk p pp => cases p <;> cases pp <;>
   simp [icelandicHaveVI, icelandicHaveVIRules, vocabularyInsertSimple,
-    vocabularyInsert, VocabItem.matches, List.mergeSort, List.findSome?]
+    vocabularyInsert, VocabItem.matches, Morphology.Exponence.realize,
+    Morphology.Exponence.selectBy, Morphology.Exponence.applicable,
+    Morphology.Exponence.Applies, Morphology.Exponence.exponent, List.argmax, List.argAux]
 
 -- ════════════════════════════════════════════════════
 -- § 2. The Two Puzzles, Solved

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -315,17 +315,14 @@ def realize (tree : Tree DPCat String) (origin : PronOrigin) : String :=
 -- § 7: Core Predictions — Bound Resumptives
 -- ============================================================================
 
--- TODO: `decide` chokes on String equality through `DistributedMorphology.VI`;
--- restructure as compositional lemmas (extractFeatures + insertResumptive).
-
 /-- Bound 1SG in adjunct island → person-matching *-mi*. -/
-theorem island_bound_1sg : realize pronTree1sg .bound = "-mi" := by native_decide
+theorem island_bound_1sg : realize pronTree1sg .bound = "-mi" := by decide
 
 /-- Bound 2SG in adjunct island → person-matching *-we*. -/
-theorem island_bound_2sg : realize pronTree2sg .bound = "-we" := by native_decide
+theorem island_bound_2sg : realize pronTree2sg .bound = "-we" := by decide
 
 /-- Bound 1PL in adjunct island → person-matching *-si*. -/
-theorem island_bound_1pl : realize pronTree1pl .bound = "-si" := by native_decide
+theorem island_bound_1pl : realize pronTree1pl .bound = "-si" := by decide
 
 -- ============================================================================
 -- § 8: Core Predictions — Movement Resumptives
@@ -333,22 +330,22 @@ theorem island_bound_1pl : realize pronTree1pl .bound = "-si" := by native_decid
 
 /-- Movement copy 1SG in parasitic gap → personless *-ye*. -/
 theorem parasitic_movement_1sg : realize pronTree1sg .movementCopy = "-ye" := by
-  native_decide
+  decide
 
 /-- Movement copy 2SG in parasitic gap → also *-ye*. Person is irrelevant
     because chain reduction deletes PersP regardless. -/
 theorem parasitic_movement_2sg : realize pronTree2sg .movementCopy = "-ye" := by
-  native_decide
+  decide
 
 /-- Movement copy 1PL in parasitic gap → personless *-o*. -/
 theorem parasitic_movement_1pl : realize pronTree1pl .movementCopy = "-o" := by
-  native_decide
+  decide
 
 /-- Both 1SG and 2SG movement copies produce the same form — chain
     reduction erases the person distinction. -/
 theorem movement_erases_person_distinction :
     realize pronTree1sg .movementCopy = realize pronTree2sg .movementCopy := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 9: End-to-End Argumentation Chain
@@ -369,7 +366,7 @@ theorem end_to_end :
     realize pronTree1sg .movementCopy = "-ye" ∧
     -- Step 5: unreduced VI produces -mi
     realize pronTree1sg .bound = "-mi" := by
-  refine ⟨rfl, ?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨rfl, ?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================
 -- § 10: Parasitic Gap Interspeaker Variation (Table 4)
@@ -419,7 +416,7 @@ theorem islands_are_syntactic :
     realize pronTree1sg .bound = "-mi" ∧
     realize pronTree1sg .movementCopy = "-ye" ∧
     realize pronTree1sg .bound ≠ realize pronTree1sg .movementCopy := by
-  refine ⟨?_, ?_, ?_⟩ <;> native_decide
+  refine ⟨?_, ?_, ?_⟩ <;> decide
 
 -- ============================================================================
 -- § 12: MaxElide Targets PersP
@@ -503,7 +500,7 @@ theorem fragment_consistency_1sg :
     resumptivePronounIsPersonMatching .first .sg = true ∧
     realize pronTree1sg .bound = resumptivePronoun .first .sg ∧
     realize pronTree1sg .movementCopy = resumptivePronoun .third .sg := by
-  refine ⟨rfl, ?_, ?_⟩ <;> native_decide
+  refine ⟨rfl, ?_, ?_⟩ <;> decide
 
 /-- The movement marker in the Fragment is correctly classified. -/
 theorem marker_classification :

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -238,7 +238,7 @@ theorem voice_agrees_person :
     applyAgree voiceProbe dp3sg .person =
     some (.ofGramFeatures
       [.valued (.phi (.person .third)), .unvalued (.phi (.number .singular))]) := by
-  native_decide
+  decide
 
 /-- After person agreement, Voice's [uNumber] is valued as [Number:sg].
     This is the second step of φ-Agree: person first, then number. -/
@@ -248,7 +248,7 @@ theorem voice_agrees_number :
     applyAgree afterPerson dp3sg .number =
     some (.ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]) := by
-  native_decide
+  decide
 
 /-- Full φ-valuation of Voice by a 3SG agent: both person and number valued. -/
 def voiceFullyAgreed : FeatureBundle :=
@@ -259,7 +259,7 @@ theorem voice_agree_pipeline :
     (applyAgree voiceProbe dp3sg .person).bind
       (λ fb => applyAgree fb dp3sg .number) =
     some voiceFullyAgreed := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 4: Set A Spellout — Voice → agreement morphology
@@ -268,7 +268,7 @@ theorem voice_agree_pipeline :
 /-- Set A spellout: Voice's valued [Person:3, Number:sg] yields "t-" (A2/3SG). -/
 theorem setA_spellout_3sg :
     spellout setAVocab voiceFullyAgreed (some .v) = some "t-" := by
-  native_decide
+  decide
 
 /-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields the
     A1SG marker (pre-consonantal citation form `n-`; the pre-vocalic
@@ -277,7 +277,7 @@ theorem setA_spellout_1sg :
     let v1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setAVocab v1sg (some .v) = some "n-" := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 5: Set B — Two Paths to "tz'="
@@ -291,7 +291,7 @@ theorem setB_intransitive_3sg :
     let inflAgreed : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed (some .T) = some "tz'=" := by
-  native_decide
+  decide
 
 /-- **Transitive path**: Infl's probe is blocked by Voice_TR → no
     φ-features are copied → the Infl node has an empty feature bundle.
@@ -303,7 +303,7 @@ theorem setB_intransitive_3sg :
 theorem setB_transitive_default :
     let inflBlocked : FeatureBundle := ⊥
     spellout setBVocab inflBlocked (some .T) = some "tz'=" := by
-  native_decide
+  decide
 
 /-- The two paths produce the same exponent — the surface form is
     identical even though the underlying mechanism differs (real agreement
@@ -314,7 +314,7 @@ theorem setB_same_surface :
     let inflBlocked : FeatureBundle := ⊥
     spellout setBVocab inflAgreed3sg (some .T) =
     spellout setBVocab inflBlocked (some .T) := by
-  native_decide
+  decide
 
 /-- Set B spellout for 1SG intransitive: Infl copies [Person:1, Number:sg]
     from S, yielding "chin" — NOT the Elsewhere form. This is real
@@ -323,7 +323,7 @@ theorem setB_intransitive_1sg :
     let t1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab t1sg (some .T) = some "chin" := by
-  native_decide
+  decide
 
 /-- In a transitive with a 1SG object, the default "tz'=" still appears —
     NOT "chin". This is because Infl's probe was blocked by Voice_TR,
@@ -336,7 +336,7 @@ theorem setB_transitive_ignores_object :
     let inflAgreed1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     spellout setBVocab inflAgreed1sg (some .T) = some "chin" := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 -- ============================================================================
 -- § 6: Probe Restriction — Why objects lack φ-agreement
@@ -364,7 +364,7 @@ theorem probe_restriction_yields_default :
       (.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (some .T) = some "chin" := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 -- ============================================================================
 -- § 7: Intransitive Pipeline — Infl Agrees with S
@@ -390,7 +390,7 @@ theorem intransitive_pipeline_1sg :
       (.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       (some .T) = some "chin" := by
-  exact ⟨by native_decide, by native_decide⟩
+  exact ⟨by decide, by decide⟩
 
 -- ============================================================================
 -- § 8: Transitive Pipeline — Voice Agrees, Infl Blocked
@@ -413,9 +413,9 @@ theorem full_pipeline_3sg_transitive :
     -- Step 5: patient is not eligible for reduction → overt pronoun
     ¬ ArgPosition.CanBeReduced .P := by
   refine ⟨?_, ?_, ?_, ?_⟩
-  · native_decide
-  · native_decide
-  · native_decide
+  · decide
+  · decide
+  · decide
   · decide
 
 /-- The pipeline generalizes: for every argument position, reduction
@@ -434,19 +434,19 @@ theorem all_positions_match (pos : ArgPosition) :
 theorem setA_setB_differ_by_context :
     spellout setAVocab voiceFullyAgreed (some .v) ≠
     spellout setBVocab voiceFullyAgreed (some .v) := by
-  native_decide
+  decide
 
 /-- Set A vocabulary does NOT match Infl context. -/
 theorem setA_wrong_context :
     spellout setAVocab voiceFullyAgreed (some .T) = none := by
-  native_decide
+  decide
 
 /-- Set B vocabulary does NOT match Voice context (for specified entries).
     Only the Elsewhere entry could match (it has no features), but it
     requires Infl context. -/
 theorem setB_wrong_context :
     spellout setBVocab voiceFullyAgreed (some .v) = none := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 10: The Tripartite Agreement Pattern
@@ -492,7 +492,7 @@ theorem different_probe_heads :
     observed in Mam transitives. -/
 theorem transitive_is_probe_failure :
     (phiProbe .person).outcome [⊥] = .unvalued := by
-  native_decide
+  decide
 
 /-- The intransitive case is real agreement: Infl's φ-probe finds S, so its
     outcome is `valued`. -/
@@ -501,7 +501,7 @@ theorem intransitive_is_real_agreement :
       [.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]]
       = .valued := by
-  native_decide
+  decide
 
 -- ============================================================================
 -- § 12: Deriving Probe Blocking from SatisfactionCond ([deal-2024])
@@ -523,7 +523,7 @@ theorem satisfaction_derives_patient_no_agree :
     mamInflSatisfaction.isSatisfied ⊥ (some .v) = true ∧
     mamInflSatisfaction.copiedFeatures ⊥ (some .v) = false ∧
     ¬ ArgPosition.IsPhiAgreed .P :=
-  ⟨by native_decide, by native_decide, by decide⟩
+  ⟨by decide, by decide, by decide⟩
 
 /-- In an intransitive clause, `mamInflSatisfaction` is satisfied by
     φ-features and DOES copy them — matching `IsPhiAgreed .S`. -/
@@ -533,7 +533,7 @@ theorem satisfaction_derives_intranS_agree :
     mamInflSatisfaction.isSatisfied dp1sg none = true ∧
     mamInflSatisfaction.copiedFeatures dp1sg none = true ∧
     ArgPosition.IsPhiAgreed .S :=
-  ⟨by native_decide, by native_decide, trivial⟩
+  ⟨by decide, by decide, trivial⟩
 
 /-- The satisfaction condition's `copiedFeatures` Bool aligns with
     the Fragment's `IsPhiAgreed` Prop for both Infl-probed positions:
@@ -548,8 +548,8 @@ theorem satisfaction_matches_fragment :
       none = true ↔
       ArgPosition.IsPhiAgreed .S) := by
   refine ⟨?_, ?_⟩
-  · constructor <;> intro h <;> first | (native_decide) | trivial
-  · exact ⟨fun _ => trivial, fun _ => by native_decide⟩
+  · constructor <;> intro h <;> first | (decide) | trivial
+  · exact ⟨fun _ => trivial, fun _ => by decide⟩
 
 /-! ### Deriving the probe table from relativized search (`Probe/Basic.lean`)
 
@@ -564,7 +564,7 @@ from the conclusion (the table) to independently motivated premises:
 order (Infl > Voice_TR > A > P). The goal lists are stipulated
 linearizations per clause type, not computed from a `SyntacticObject`
 — the tree-geometric derivation exists in `Agree.lean` but is
-`native_decide`-bound; this level matches `Probing.lean`'s altitude. -/
+`decide`-bound; this level matches `Probing.lean`'s altitude. -/
 
 /-- An element a probe encounters while walking its search domain:
     the argument position it realizes (`none` for non-DP heads like


### PR DESCRIPTION
`vocabularyInsert` now runs on the shared `Exponence.realize` engine instead of a hand-rolled `mergeSort` + `findSome?` (well-founded recursion the kernel could not unfold), so every DM study's `native_decide` becomes kernel `decide`.

- `vocabularyInsert_isElsewhereWinner` restated over `selectBy_isElsewhereWinner`; private `findSome?_pairwise_max` deleted.
- ~240 `native_decide` → `decide` across nine studies (HM93, Adamson2024, AA25, Aitha2026, Carstens2026, ETB2026, Kramer2020, Scott2021, Scott2023); Myler2016's agreement proofs re-simp'd over the engine.