### PR TITLE
refactor(Morphology/DistributedMorphology): VocabularyItem on the engine

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -56,7 +56,7 @@ immaterial for the result and content readings.
 ## Implementation notes
 
 `AllosemicEntry` is a `Morphology.Exponence.Rule` instance, just as
-`VI.VocabItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
+`VocabItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
 selection engine: `Exponence.selectBy` on the non-wildcard-field score
 (`selectBy_score_isElsewhereWinner`). `Voice.Alloseme.fromComplement` is
 a worked List-3 competition on that engine; `readingFromAllosemes` is a

--- a/Linglib/Morphology/DistributedMorphology/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Basic.lean
@@ -4,7 +4,7 @@ import Linglib.Morphology.Exponence.Select
 /-!
 # Vocabulary items and allosemes as exponence rules
 
-A `VI.VocabItem` and an `Allosemy.AllosemicEntry` each expose the shared
+A `VocabItem` and an `Allosemy.AllosemicEntry` each expose the shared
 exponence interface (`Morphology.Exponence.Rule`), so DM's List 2 (form) and
 List 3 (meaning) are resolved by one `Exponence.selectBy` competition, whose
 winner is the Elsewhere winner. This file holds the two `Rule` instances and
@@ -112,8 +112,6 @@ end Exponence
 
 end Allosemy
 
-namespace VI
-
 variable {Ctx Root : Type*}
 
 /-- A Vocabulary Item exposes the shared exponence core interface
@@ -126,7 +124,5 @@ instance : DecidableRel (Applies : VocabItem Ctx Root → Ctx × Root → Prop) 
   fun vi cr => inferInstanceAs (Decidable (vi.matches cr.1 cr.2 = true))
 
 instance : Preorder (VocabItem Ctx Root) := Morphology.Exponence.toPreorder
-
-end VI
 
 end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -4,7 +4,7 @@ import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 # Vocabulary items and allosemes
 
 The rule types of Distributed Morphology's two interpretive lists:
-`VI.VocabItem` pairs a phonological exponent with the context that
+`VocabItem` pairs a phonological exponent with the context that
 licenses it (List 2), and `Allosemy.AllosemicEntry` pairs a meaning with
 the conditioning `Allosemy.SyntacticContext` (List 3). The shared
 selection-engine instances live in `DistributedMorphology/Basic.lean`.
@@ -17,8 +17,6 @@ selection-engine instances live in `DistributedMorphology/Basic.lean`.
 -/
 
 namespace DistributedMorphology
-
-namespace VI
 
 /-- A Vocabulary Item: a rule mapping morphosyntactic context to a
     phonological exponent.
@@ -52,8 +50,6 @@ def VocabItem.matches {Ctx Root : Type*}
   match vi.rootMatch with
   | none => true
   | some f => f root
-
-end VI
 
 namespace Allosemy
 

--- a/Linglib/Morphology/DistributedMorphology/Fusion.lean
+++ b/Linglib/Morphology/DistributedMorphology/Fusion.lean
@@ -93,24 +93,18 @@ end FusionRule
 
 section Portmanteau
 
-open VI
-
-variable {F E : Type*} [BEq F]
+variable {F E : Type*} [DecidableEq F]
 
 /-- A portmanteau exponent needs fusion: when every vocabulary item
 carrying the exponent draws on features missing from each unfused bundle,
 the Subset Principle can select it at neither unfused node — only the
 fused bundle contains its item's features (`subsetPrinciple_winner_mem`). -/
-theorem portmanteau_needs_fusion {items : List (FeatureVI F E)}
-    {p q : List F} {e : E}
-    (he : ∀ i ∈ items, i.exponent = e →
-      i.features.all (p.contains ·) = false ∧
-      i.features.all (q.contains ·) = false) :
+theorem portmanteau_needs_fusion {items : List (VocabularyItem F E)} {p q : List F} {e : E}
+    (he : ∀ i ∈ items, i.exponent = e → ¬ i.features ⊆ p ∧ ¬ i.features ⊆ q) :
     subsetPrinciple items p ≠ some e ∧ subsetPrinciple items q ≠ some e := by
-  refine ⟨fun h => ?_, fun h => ?_⟩ <;>
-    obtain ⟨i, hi, rfl, happ⟩ := subsetPrinciple_winner_mem h
-  · simp [(he i hi rfl).1] at happ
-  · simp [(he i hi rfl).2] at happ
+  refine ⟨fun h => ?_, fun h => ?_⟩ <;> obtain ⟨i, hi, rfl, happ⟩ := subsetPrinciple_winner_mem h
+  · exact (he i hi rfl).1 happ
+  · exact (he i hi rfl).2 happ
 
 end Portmanteau
 

--- a/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
+++ b/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
@@ -14,7 +14,7 @@ factors through the focus is paradigmatic as a theorem about the rule,
 not an annotation. Deletion only removes: every dimension of the output
 is the input's value or absent (`chain_pointwise`), which is what makes
 the post-impoverishment VI winner the retreat-to-the-general exponent
-(`VI.winner?_retreat`).
+(`winner?_retreat`).
 
 ## Main definitions
 

--- a/Linglib/Morphology/DistributedMorphology/Spellout.lean
+++ b/Linglib/Morphology/DistributedMorphology/Spellout.lean
@@ -17,7 +17,7 @@ Each operation carries its position-count law, so terminal/exponent
 misalignment is arithmetic: neighborhood rewriting and terminal
 metathesis preserve the count, obliteration and fusion decrease it, and
 `Spellout.length_pf` says exponent slots equal terminals after the
-modules. `winner?_retreat` (`VocabularyInsertion.lean`) supplies the
+modules. `winner?_retreat` (`VocabularyInsertion/Basic.lean`) supplies the
 insertion-side ordering law.
 
 Consumers: `Studies/Middleton2026.lean` (Basque whole-terminal rules and

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
@@ -1,299 +1,197 @@
-import Mathlib.Tactic.TypeStar
+import Mathlib.Data.Finset.Card
 import Linglib.Morphology.DistributedMorphology.Basic
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.Realization
 
 /-!
-# Vocabulary Insertion (Distributed Morphology)
+# Vocabulary insertion
 
-Vocabulary Insertion is the mechanism by which syntactic terminal nodes
-receive phonological exponents in Distributed Morphology. It is the
-formal realization of DM's **List 2**: a set of Vocabulary Items (VI
-rules) that compete for insertion at each terminal.
+Vocabulary Insertion is the operation that supplies syntactic terminals with
+phonological exponents in Distributed Morphology: the Vocabulary Items of
+List 2 compete for insertion at each terminal, and the Subset Principle of
+[halle-marantz-1993] picks the item whose feature specification is the
+largest subset of the terminal's bundle. This file specializes the shared
+exponence engine (`Morphology.Exponence.selectBy`) to that competition.
 
-## Architecture
+## Main definitions
 
-A Vocabulary Item specifies:
-1. A **phonological exponent** (the surface form)
-2. A **morphosyntactic context** (the features the terminal must bear)
-3. A **root context** (optional: which roots the rule applies to)
+* `VocabularyItem F E`: a feature specification with an exponent, applicable
+  at a bundle containing every specified feature.
+* `VocabularyItem.specificity`: the number of distinct specified features.
+* `winner?`, `subsetPrinciple`: the Subset Principle's winning item and its
+  exponent.
+* `vocabularyInsert`: selection over `VocabItem`s, whose applicability is an
+  opaque predicate and whose rank is stipulated.
 
-When multiple VI rules match a terminal, the **Elsewhere Condition**
-([halle-marantz-1993]) resolves the competition: the most specific
-matching rule wins. A rule is more specific if its context is a proper
-superset of another matching rule's context.
+## Main results
 
-## Root-Out Insertion
+* `VocabularyItem.le_iff`: the engine's specificity order on vocabulary items
+  is reverse feature inclusion, so `specificity` is strictly antitone and
+  `winner?_isElsewhereWinner` needs no faithfulness hypothesis.
+* `winner?_retreat`: deleting features from the target can only make the
+  winner less specific — retreat to the general case.
+* `vocabularyInsert_isElsewhereWinner`: under `SpecificityFaithful`, the
+  opaque engine also selects an Elsewhere winner.
 
-[bobaljik-2000] argues that VI proceeds **root-out**: the root is
-inserted first, then inflectional affixes outward. This means VI for
-outer morphemes can only be phonologically conditioned by material
-already inserted (inward) — it cannot "look ahead" to morphemes not yet
-inserted. This is the basis for the claim that outward-sensitive
-phonologically conditioned suppletive allomorphy (OS-PCSA) should not
-exist.
+## Implementation notes
 
-## Connection to Linglib
+A `VocabItem` carries an arbitrary decidable context predicate, an optional
+root restriction (the root-conditioned allomorphy that [bobaljik-2000]'s
+root-out insertion makes available inward), and a stipulated rank; with
+opaque predicates the derived specificity order is not computable, so
+`SpecificityFaithful` is the obligation the stipulation incurs. Over
+`VocabularyItem`s no such obligation arises.
 
-This module provides the generic VI framework. Language-specific VI
-rules live in `Fragments/` or in phenomenon-specific `Studies/` files.
-The `Categorizer` type and the `WordStructure` trees from
-`Morphology/DistributedMorphology/Categorizer/Basic.lean` provide the
-syntax-side terminals and configurations that VI targets.
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
+* [J. D. Bobaljik, *The ins and outs of contextual allomorphy*][bobaljik-2000]
 -/
 
-namespace DistributedMorphology.VI
-
--- ============================================================================
--- § 1: Vocabulary Insertion
--- ============================================================================
-
-/-- Insert a Vocabulary Item at a terminal node: the exponent of the
-highest-`specificity` matching rule (the shared engine's `realize`; ties go
-to the earlier rule), `none` if no rule matches — the **Elsewhere
-Condition** of [halle-marantz-1993]. -/
-def vocabularyInsert {Ctx Root : Type*}
-    (rules : List (VocabItem Ctx Root))
-    (ctx : Ctx) (root : Root) : Option String :=
-  Morphology.Exponence.realize VocabItem.specificity rules (ctx, root)
-
-/-- Simplified insertion when rules are not root-specific. -/
-def vocabularyInsertSimple {Ctx : Type*}
-    (rules : List (VocabItem Ctx Unit))
-    (ctx : Ctx) : Option String :=
-  vocabularyInsert rules ctx ()
-
--- ============================================================================
--- § 2: Feature-Set Vocabulary Items (Subset Principle)
--- ============================================================================
-
-/-- A feature-set vocabulary item for the Subset Principle.
-    Simpler than the full `VocabItem`: a feature specification paired
-    with an exponent. The **Subset Principle** selects the most specific
-    item whose features are all present in the target.
-
-    Used when VI is purely determined by feature-subset matching
-    (e.g., gender agreement class selection in
-    [adamson-anagnostopoulou-2025]). -/
-structure FeatureVI (F E : Type*) where
-  features : List F
-  exponent : E
-  deriving DecidableEq, Repr
-
-/-- The vocabulary items applicable at a target: those whose feature
-specification is a subset of the target bundle. -/
-def applicable {F E : Type*} [BEq F]
-    (items : List (FeatureVI F E)) (target : List F) : List (FeatureVI F E) :=
-  items.filter (·.features.all (target.contains ·))
-
-/-- Longest-specification choice step for `winner?`; earlier items win
-ties. -/
-private def pickLonger {F E : Type*}
-    (acc : Option (FeatureVI F E)) (item : FeatureVI F E) :
-    Option (FeatureVI F E) :=
-  match acc with
-  | none => some item
-  | some prev =>
-    if item.features.length > prev.features.length then some item else some prev
-
-/-- The Subset Principle's winning item: the longest-specification
-applicable item (the earliest, under ties). -/
-def winner? {F E : Type*} [BEq F]
-    (items : List (FeatureVI F E)) (target : List F) :
-    Option (FeatureVI F E) :=
-  (applicable items target).foldl pickLonger none
-
-/-- The **Subset Principle** ([halle-marantz-1993]): among vocabulary
-    items whose feature specification is a subset of the target, select
-    the most specific (longest feature list).
-
-    Returns `none` only if no item is applicable. When items include an
-    elsewhere entry (empty feature list), `subsetPrinciple` always
-    succeeds — the elsewhere item matches any target. -/
-def subsetPrinciple {F E : Type*} [BEq F]
-    (items : List (FeatureVI F E)) (target : List F) : Option E :=
-  (winner? items target).map (·.exponent)
-
-/-- An elsewhere item (empty features) matches any target. -/
-theorem elsewhere_always_matches {F E : Type*} [BEq F]
-    (e : E) (target : List F) :
-    (FeatureVI.mk ([] : List F) e).features.all (target.contains ·) = true := by
-  simp [List.all_nil]
-
-private theorem pickLonger_cases {F E : Type*} (acc : Option (FeatureVI F E))
-    (x : FeatureVI F E) : pickLonger acc x = some x ∨ pickLonger acc x = acc := by
-  cases acc with
-  | none => exact .inl rfl
-  | some prev =>
-    by_cases hlen : x.features.length > prev.features.length <;>
-      simp [pickLonger, hlen]
-
-private theorem foldl_choice_mem {α : Type*} {pick : Option α → α → Option α}
-    (hpick : ∀ acc x, pick acc x = some x ∨ pick acc x = acc) :
-    ∀ {l : List α} {acc : Option α} {i : α},
-      l.foldl pick acc = some i → i ∈ l ∨ acc = some i := by
-  intro l
-  induction l with
-  | nil => exact fun h => .inr h
-  | cons x xs ih =>
-    intro acc i h
-    rcases ih h with hmem | hacc
-    · exact .inl (List.mem_cons_of_mem _ hmem)
-    · rcases hpick acc x with hx | hkeep
-      · rw [hx] at hacc
-        obtain rfl := Option.some.inj hacc
-        exact .inl (List.mem_cons_self ..)
-      · exact .inr (hkeep ▸ hacc)
-
-private theorem foldl_pickLonger_ne_none {F E : Type*} :
-    ∀ (l : List (FeatureVI F E)) (a : FeatureVI F E),
-      l.foldl pickLonger (some a) ≠ none := by
-  intro l
-  induction l with
-  | nil => exact fun a h => by simp at h
-  | cons x xs ih =>
-    intro a h
-    rw [List.foldl_cons] at h
-    rcases pickLonger_cases (some a) x with hx | hkeep
-    · rw [hx] at h; exact ih x h
-    · rw [hkeep] at h; exact ih a h
-
-private theorem foldl_pickLonger_max {F E : Type*} :
-    ∀ (l : List (FeatureVI F E)) (acc : Option (FeatureVI F E))
-      (i : FeatureVI F E), l.foldl pickLonger acc = some i →
-      (∀ j ∈ l, j.features.length ≤ i.features.length) ∧
-        ∀ a, acc = some a → a.features.length ≤ i.features.length := by
-  intro l
-  induction l with
-  | nil =>
-    intro acc i h
-    refine ⟨by simp, fun a ha => ?_⟩
-    rw [ha] at h
-    obtain rfl := Option.some.inj h
-    exact Nat.le_refl _
-  | cons x xs ih =>
-    intro acc i h
-    rw [List.foldl_cons] at h
-    obtain ⟨hxs, hstep⟩ := ih (pickLonger acc x) i h
-    have hx : x.features.length ≤ i.features.length := by
-      cases acc with
-      | none => exact hstep x rfl
-      | some prev =>
-        by_cases hlen : x.features.length > prev.features.length
-        · exact hstep x (by simp [pickLonger, hlen])
-        · have := hstep prev (by simp [pickLonger, hlen])
-          omega
-    refine ⟨fun j hj => ?_, fun a ha => ?_⟩
-    · rcases List.mem_cons.mp hj with rfl | hj'
-      · exact hx
-      · exact hxs j hj'
-    · subst ha
-      by_cases hlen : x.features.length > a.features.length
-      · omega
-      · have := hstep a (by simp [pickLonger, hlen])
-        omega
-
-/-- The winner is an applicable item. -/
-theorem winner?_mem {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
-    (h : winner? items target = some i) : i ∈ applicable items target := by
-  rcases foldl_choice_mem pickLonger_cases h with hmem | hnone
-  · exact hmem
-  · exact absurd hnone (by simp)
-
-/-- The winner belongs to the vocabulary and draws only on features the
-target bears. -/
-theorem winner?_spec {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
-    (h : winner? items target = some i) :
-    i ∈ items ∧ i.features.all (target.contains ·) = true := by
-  have := List.mem_filter.mp (winner?_mem h)
-  exact ⟨this.1, this.2⟩
-
-/-- The Subset Principle's exponent comes from an applicable vocabulary
-item — the selection never draws on features the node does not bear. -/
-theorem subsetPrinciple_winner_mem {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {target : List F} {e : E}
-    (h : subsetPrinciple items target = some e) :
-    ∃ i ∈ items, i.exponent = e ∧ i.features.all (target.contains ·) = true := by
-  obtain ⟨i, hw, rfl⟩ := Option.map_eq_some_iff.mp h
-  obtain ⟨hi, happ⟩ := winner?_spec hw
-  exact ⟨i, hi, rfl, happ⟩
-
-/-- `winner?` succeeds iff some item is applicable. -/
-theorem winner?_isSome_iff {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {target : List F} :
-    (winner? items target).isSome ↔ applicable items target ≠ [] := by
-  unfold winner?
-  cases hl : applicable items target with
-  | nil => simp
-  | cons x xs =>
-    simp only [List.foldl_cons, ne_eq, reduceCtorEq, not_false_eq_true,
-      iff_true]
-    have hstep : pickLonger (none : Option (FeatureVI F E)) x = some x := rfl
-    rw [hstep, Option.isSome_iff_ne_none]
-    exact foldl_pickLonger_ne_none xs x
-
-/-- The winner is maximally specific among the applicable items. -/
-theorem winner?_max {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {target : List F} {i : FeatureVI F E}
-    (h : winner? items target = some i) :
-    ∀ j ∈ applicable items target, j.features.length ≤ i.features.length :=
-  (foldl_pickLonger_max _ _ _ h).1
-
-/-- Applicability is monotone in the target bundle. -/
-theorem applicable_mono {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {t t' : List F}
-    (hsub : ∀ x, t'.contains x = true → t.contains x = true) :
-    ∀ i ∈ applicable items t', i ∈ applicable items t := by
-  intro i hi
-  obtain ⟨him, hall⟩ := List.mem_filter.mp hi
-  refine List.mem_filter.mpr ⟨him, ?_⟩
-  rw [List.all_eq_true] at hall ⊢
-  exact fun x hx => hsub x (hall x hx)
-
-/-- **Retreat to the general case**: shrinking the target — deleting
-features by Impoverishment — can only make the Subset-Principle winner
-weakly less specific, which is why impoverishment yields syncretism with
-a more general exponent rather than a different specific one
-([halle-marantz-1993], [arregi-nevins-2012]). -/
-theorem winner?_retreat {F E : Type*} [BEq F]
-    {items : List (FeatureVI F E)} {t t' : List F} {i' : FeatureVI F E}
-    (hsub : ∀ x, t'.contains x = true → t.contains x = true)
-    (h' : winner? items t' = some i') :
-    ∃ i, winner? items t = some i ∧
-      i'.features.length ≤ i.features.length := by
-  have hmem : i' ∈ applicable items t :=
-    applicable_mono hsub _ (winner?_mem h')
-  have hne : applicable items t ≠ [] := fun hnil => by simp [hnil] at hmem
-  obtain ⟨i, hi⟩ :=
-    Option.isSome_iff_exists.mp (winner?_isSome_iff.mpr hne)
-  exact ⟨i, hi, winner?_max hi _ hmem⟩
-
--- ============================================================================
--- § 3: The shared exponence core
--- ============================================================================
-
-section ExponenceCore
+namespace DistributedMorphology
 
 open Morphology.Exponence
 
-variable {Ctx Root : Type*}
+/-! ### Vocabulary items -/
 
-/-- The stipulated `specificity` rank is **faithful** when it refines
-the derived specificity of the shared core: a strictly more specific
-item always outranks. With opaque `contextMatch` predicates the derived
-order is not computable, so this engine must stipulate a rank — this
-Prop is the obligation the stipulation incurs, and
-`vocabularyInsert_isElsewhereWinner` is what discharging it buys. -/
+/-- A Vocabulary Item: a feature specification paired with an exponent,
+applicable at any bundle containing every specified feature. -/
+structure VocabularyItem (F E : Type*) where
+  /-- The features the item spells out. -/
+  features : List F
+  /-- The exponent the item inserts. -/
+  exponent : E
+  deriving DecidableEq, Repr
+
+namespace VocabularyItem
+
+variable {F E : Type*} [DecidableEq F] {i j : VocabularyItem F E} {t : List F}
+
+instance : Rule (VocabularyItem F E) (List F) E := ⟨exponent, fun i t => i.features ⊆ t⟩
+
+instance : DecidableRel (Applies : VocabularyItem F E → List F → Prop) :=
+  fun i t => decidable_of_iff (∀ f ∈ i.features, f ∈ t) Iff.rfl
+
+instance : Preorder (VocabularyItem F E) := toPreorder
+
+theorem applies_iff : Applies i t ↔ i.features ⊆ t := Iff.rfl
+
+/-- An item with no features applies at every bundle. -/
+theorem elsewhere_applies (e : E) (t : List F) : Applies (⟨[], e⟩ : VocabularyItem F E) t :=
+  List.nil_subset _
+
+theorem le_iff_applies : i ≤ j ↔ ∀ ⦃t : List F⦄, i.features ⊆ t → j.features ⊆ t := Iff.rfl
+
+/-- The engine's specificity order is reverse feature inclusion. -/
+theorem le_iff : i ≤ j ↔ j.features ⊆ i.features :=
+  ⟨fun h => le_iff_applies.mp h (List.Subset.refl _),
+    fun h => le_iff_applies.mpr fun _ ht => List.Subset.trans h ht⟩
+
+/-- The number of distinct features an item specifies — the Subset
+Principle's specificity score. -/
+def specificity (i : VocabularyItem F E) : ℕ := i.features.toFinset.card
+
+theorem toFinset_subset_toFinset :
+    i.features.toFinset ⊆ j.features.toFinset ↔ i.features ⊆ j.features :=
+  Multiset.toFinset_subset.trans Multiset.coe_subset
+
+theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E → ℕ) :=
+  fun _ _ h => Finset.card_lt_card <| Finset.ssubset_def.mpr
+    ⟨toFinset_subset_toFinset.mpr (le_iff.mp h.le),
+      fun hc => (lt_iff_le_not_ge.mp h).2 (le_iff.mpr (toFinset_subset_toFinset.mp hc))⟩
+
+end VocabularyItem
+
+/-! ### The Subset Principle -/
+
+section SubsetPrinciple
+
+variable {F E : Type*} [DecidableEq F] {items : List (VocabularyItem F E)} {t t' : List F}
+  {i i' : VocabularyItem F E} {e : E}
+
+/-- The Subset Principle's winning item: the applicable item of greatest
+`specificity` (the earliest, under ties). -/
+def winner? (items : List (VocabularyItem F E)) (t : List F) : Option (VocabularyItem F E) :=
+  selectBy VocabularyItem.specificity items t
+
+/-- The **Subset Principle** ([halle-marantz-1993]): the exponent of the most
+specific item whose features the target bears; `none` iff no item applies. -/
+def subsetPrinciple (items : List (VocabularyItem F E)) (t : List F) : Option E :=
+  realize VocabularyItem.specificity items t
+
+theorem winner?_mem (h : winner? items t = some i) : i ∈ applicable items t :=
+  List.argmax_mem h
+
+theorem winner?_spec (h : winner? items t = some i) : i ∈ items ∧ i.features ⊆ t :=
+  mem_applicable.mp (winner?_mem h)
+
+/-- The Subset Principle's exponent comes from an applicable item — the
+selection never draws on features the node does not bear. -/
+theorem subsetPrinciple_winner_mem (h : subsetPrinciple items t = some e) :
+    ∃ i ∈ items, i.exponent = e ∧ i.features ⊆ t := by
+  obtain ⟨i, hi, rfl⟩ := Option.map_eq_some_iff.mp h
+  exact ⟨i, (winner?_spec hi).1, rfl, (winner?_spec hi).2⟩
+
+theorem winner?_isSome_iff : (winner? items t).isSome ↔ applicable items t ≠ [] := by
+  rw [Option.isSome_iff_ne_none]; exact not_congr selectBy_eq_none_iff
+
+theorem winner?_max (h : winner? items t = some i) :
+    ∀ j ∈ applicable items t, j.specificity ≤ i.specificity :=
+  fun _ hj => List.le_of_mem_argmax hj h
+
+/-- The winner is an Elsewhere winner of the shared core — with no
+faithfulness hypothesis, since `VocabularyItem.specificity` is strictly
+antitone outright. -/
+theorem winner?_isElsewhereWinner (h : winner? items t = some i) : IsElsewhereWinner items t i :=
+  selectBy_isElsewhereWinner (VocabularyItem.specificity_strictAnti.strictAntiOn _) h
+
+theorem subsetPrinciple_realizes (h : subsetPrinciple items t = some e) : Realizes items t e :=
+  realize_realizes (VocabularyItem.specificity_strictAnti.strictAntiOn _) h
+
+/-- Applicability is monotone in the target bundle. -/
+theorem applicable_mono (hsub : t' ⊆ t) : applicable items t' ⊆ applicable items t :=
+  fun _ hi => mem_applicable.mpr
+    ⟨(mem_applicable.mp hi).1, List.Subset.trans (mem_applicable.mp hi).2 hsub⟩
+
+/-- **Retreat to the general case**: shrinking the target — deleting features
+by Impoverishment — can only make the winner weakly less specific, which is
+why impoverishment yields syncretism with a more general exponent rather than
+a different specific one ([halle-marantz-1993], [arregi-nevins-2012]). -/
+theorem winner?_retreat (hsub : t' ⊆ t) (h' : winner? items t' = some i') :
+    ∃ i, winner? items t = some i ∧ i'.specificity ≤ i.specificity := by
+  have hmem := applicable_mono hsub (winner?_mem h')
+  obtain ⟨i, hi⟩ :=
+    Option.isSome_iff_exists.mp (winner?_isSome_iff.mpr (List.ne_nil_of_mem hmem))
+  exact ⟨i, hi, winner?_max hi _ hmem⟩
+
+end SubsetPrinciple
+
+/-! ### Opaque-context items -/
+
+section VocabItem
+
+variable {Ctx Root : Type*} {rules : List (VocabItem Ctx Root)} {ctx : Ctx} {root : Root}
+  {e : String}
+
+/-- Insert a Vocabulary Item at a terminal node: the exponent of the
+highest-`specificity` matching rule (ties go to the earlier rule), `none` if
+no rule matches — the **Elsewhere Condition** of [halle-marantz-1993]. -/
+def vocabularyInsert (rules : List (VocabItem Ctx Root)) (ctx : Ctx) (root : Root) :
+    Option String :=
+  realize VocabItem.specificity rules (ctx, root)
+
+/-- Insertion over rules with no root restriction. -/
+def vocabularyInsertSimple (rules : List (VocabItem Ctx Unit)) (ctx : Ctx) : Option String :=
+  vocabularyInsert rules ctx ()
+
+/-- The stipulated `specificity` rank is **faithful** when it refines the
+engine's specificity order: a strictly more specific item always outranks. -/
 def SpecificityFaithful (rules : List (VocabItem Ctx Root)) : Prop :=
   ∀ a ∈ rules, ∀ b ∈ rules, a ≤ b → ¬ b ≤ a → b.specificity < a.specificity
 
-/-- Under a faithful specificity stipulation, the engine's selection is
-an Elsewhere winner of the shared core. -/
-theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
-    {ctx : Ctx} {root : Root} {e : String}
-    (h : vocabularyInsert rules ctx root = some e)
+/-- Under a faithful rank, `vocabularyInsert` selects an Elsewhere winner. -/
+theorem vocabularyInsert_isElsewhereWinner (h : vocabularyInsert rules ctx root = some e)
     (hf : SpecificityFaithful rules) :
     ∃ vi ∈ rules, vi.exponent = e ∧ IsElsewhereWinner rules (ctx, root) vi := by
   obtain ⟨vi, hvi, hve⟩ := Option.map_eq_some_iff.mp h
@@ -301,23 +199,20 @@ theorem vocabularyInsert_isElsewhereWinner {rules : List (VocabItem Ctx Root)}
     (λ a ha b hb hab => hf a (mem_applicable.mp ha).1 b (mem_applicable.mp hb).1
       (lt_iff_le_not_ge.mp hab).1 (lt_iff_le_not_ge.mp hab).2) hvi⟩
 
-end ExponenceCore
-
-/-! ### The realization view -/
-
-/-- Vocabulary Insertion as a realization: roots as opaque indices,
-syntactic
-contexts as contexts, `none` as non-licensing — the univalent stratum. -/
-def toRealization {Ctx Root : Type*} (rules : List (VocabItem Ctx Root)) :
+/-- Vocabulary Insertion as a `Realization`: roots as indices, contexts as
+contexts, `none` as non-licensing. -/
+def VocabItem.toRealization (rules : List (VocabItem Ctx Root)) :
     Morphology.Realization Root Ctx String :=
   ⟨fun r c => match vocabularyInsert rules c r with
     | some f => {f}
     | none => ∅⟩
 
-theorem toRealization_isUnivalent {Ctx Root : Type*}
-    (rules : List (VocabItem Ctx Root)) : (toRealization rules).IsUnivalent :=
+theorem VocabItem.toRealization_isUnivalent (rules : List (VocabItem Ctx Root)) :
+    (toRealization rules).IsUnivalent :=
   fun r c => by
     simp only [toRealization]
     cases vocabularyInsert rules c r <;> simp
 
-end DistributedMorphology.VI
+end VocabItem
+
+end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
@@ -2,7 +2,6 @@ import Linglib.Syntax.Minimalist.Defs
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Exponence.Select
-import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Mathlib.Data.List.MinMax
 
 /-!
@@ -38,18 +37,14 @@ assume it.
 * `VocabEntry.le_iff` — the engine's specificity order is feature-list
   inclusion plus context compatibility
 * `bestMatch_isElsewhereWinner` — inherited from the engine
-* `VocabEntry.toVocabItem_le_iff` — the embedding into the
-  opaque-predicate engine preserves specificity
 
 ## Implementation notes
 
-This is the ergonomic specialization of the parametric
-`VI.VocabItem (Ctx Root)` in `VocabularyInsertion/Basic.lean` — same
-late insertion and Elsewhere Condition ([halle-marantz-1993]),
-concretized to Minimalist bundles so consumers need not instantiate the
-parameters; `VocabEntry.toVocabItem` is the faithfulness-preserving
-embedding. The namespace is `Minimalist`, since the entry's vocabulary
-is the Minimalist feature system's PF interface.
+This is the Minimalist-bundle specialization of Vocabulary Insertion
+(`VocabularyInsertion/Basic.lean`) — same late insertion and Elsewhere
+Condition ([halle-marantz-1993]), concretized so consumers need not
+instantiate the parameters. The namespace is `Minimalist`, since the
+entry's vocabulary is the Minimalist feature system's PF interface.
 
 ## References
 
@@ -145,7 +140,7 @@ theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
 features are included in `e`'s and `e'`'s context restriction is
 compatible. Over feature bundles the intensional inclusion order IS the
 specificity order, with no faithfulness assumption — contrast
-`DistributedMorphology.VI.SpecificityFaithful`, which the
+`DistributedMorphology.SpecificityFaithful`, which the
 opaque-predicate engine must stipulate. -/
 theorem VocabEntry.le_iff {e e' : VocabEntry} :
     e ≤ e' ↔
@@ -192,43 +187,6 @@ theorem bestMatch_isElsewhereWinner {vocab : Vocabulary}
     (h : bestMatch vocab target ctx = some e) :
     IsElsewhereWinner vocab (target, ctx) e :=
   selectBy_isElsewhereWinner hf h
-
-/-! ### Bridge to the opaque-predicate engine -/
-
-/-- Embed a vocabulary entry into the opaque-predicate engine
-(`DistributedMorphology.VI.VocabItem`): the context check is feature
-matching, the root check is the category restriction, and the
-stipulated rank is the feature count. -/
-def VocabEntry.toVocabItem (e : VocabEntry) :
-    DistributedMorphology.VI.VocabItem FeatureBundle (Option Cat) where
-  exponent := e.exponent
-  contextMatch := λ t => decide (e.MatchesFeatures t)
-  rootMatch := some (λ c => decide (e.context = none ∨ e.context = c))
-  specificity := (FeatureBundle.toGramFeatures e.features).length
-
-/-- The embedding tracks applicability: the opaque engine's `matches`
-agrees with `Matches`. -/
-theorem VocabEntry.toVocabItem_matches (e : VocabEntry)
-    (t : FeatureBundle) (c : Option Cat) :
-    e.toVocabItem.matches t c = true ↔ e.Matches t c := by
-  simp [DistributedMorphology.VI.VocabItem.matches, VocabEntry.toVocabItem,
-    VocabEntry.Matches]
-
-/-- The two engines' interfaces agree: the embedded item applies exactly
-where the entry does. -/
-theorem VocabEntry.toVocabItem_applies (e : VocabEntry)
-    (tc : FeatureBundle × Option Cat) :
-    Morphology.Exponence.Applies e.toVocabItem tc ↔
-      Morphology.Exponence.Applies e tc :=
-  e.toVocabItem_matches tc.1 tc.2
-
-/-- Specificity transfers along the embedding — the cross-engine
-translation is faithful to the shared core's order. -/
-theorem VocabEntry.toVocabItem_le_iff {e f : VocabEntry} :
-    e.toVocabItem ≤ f.toVocabItem ↔ e ≤ f := by
-  constructor <;> intro h c hc
-  · exact (f.toVocabItem_applies c).mp (h ((e.toVocabItem_applies c).mpr hc))
-  · exact (f.toVocabItem_applies c).mpr (h ((e.toVocabItem_applies c).mp hc))
 
 end ExponenceCore
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -60,7 +60,6 @@ namespace Adamson2024
 
 open DistributedMorphology
 open DistributedMorphology.Categorizer (Head)
-open DistributedMorphology.VI
 open Minimalist
 
 -- ============================================================================

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -784,26 +784,26 @@ theorem icelandic_fem_not_entails_masc :
 -- § 16: Subset Principle — Formal Vocabulary Items
 -- ============================================================================
 
-/-! ### Vocabulary as FeatureVI items
+/-! ### Vocabulary as VocabularyItem items
 
     The ad-hoc `greekVI` function above implements the Subset Principle
-    procedurally. Here we define the same vocabulary as `FeatureVI` items
+    procedurally. Here we define the same vocabulary as `VocabularyItem` items
     ([halle-marantz-1993]) and prove that `subsetPrinciple` selects
     the same exponents. This connects the gender resolution mechanism to
     the formal DM vocabulary insertion framework. -/
 
-open DistributedMorphology.VI (FeatureVI subsetPrinciple)
+open DistributedMorphology (VocabularyItem subsetPrinciple)
 
-/-- Greek vocabulary items as `FeatureVI` entries (schema 21).
+/-- Greek vocabulary items as `VocabularyItem` entries (schema 21).
     Most specific first: {FEM,MASC} → F, {MASC} → M, {} → N. -/
-def greekVocabItems : List (FeatureVI GenderNode Infl) :=
+def greekVocabItems : List (VocabularyItem GenderNode Infl) :=
   [ ⟨[fem, masc], .fem⟩,
     ⟨[masc], .masc⟩,
     ⟨[], .neut⟩ ]
 
-/-- BCS vocabulary items as `FeatureVI` entries (schema 75).
+/-- BCS vocabulary items as `VocabularyItem` entries (schema 75).
     {FEM,ANIM} → F, {INDIV} → M, {} → N. -/
-def bcsVocabItems : List (FeatureVI GenderNode Infl) :=
+def bcsVocabItems : List (VocabularyItem GenderNode Infl) :=
   [ ⟨[fem, anim], .fem⟩,
     ⟨[indiv], .masc⟩,
     ⟨[], .neut⟩ ]

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -55,7 +55,7 @@ namespace Aitha2026
 
 
 open Core Constraints OptimalityTheory Core.Optimization Core.Optimization.Evaluation
-open DistributedMorphology.VI
+open DistributedMorphology
 open Prosody
 
 -- ============================================================================

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -12,7 +12,7 @@ Chapter 3 of *The View from Building 20* (Hale & Keyser, eds.).
 ## Structure
 
 - **§1**: English Verb Inflection — the context-free Tns/Agr paradigm,
-  formalized using `FeatureVI` and `subsetPrinciple`, demonstrating
+  formalized using `VocabularyItem` and `subsetPrinciple`, demonstrating
   Elsewhere Condition competition
 - **§2**: Conditioned Allomorphy — root-specific past tense exponents
   (`-t`, `∅`) illustrating the Paninian principle (most specific wins)
@@ -42,7 +42,7 @@ derive syncretism (§4) and fusion on the Tns/Agr pair (§3).
 
 namespace HalleMarantz1993
 
-open DistributedMorphology.VI
+open DistributedMorphology
 open Morphology.MirrorPrinciple
 open Morphology (MorphCategory)
 
@@ -82,7 +82,7 @@ inductive EngInflFeature where
 
 /-- Context-free VI entries for English verbal inflection.
     [halle-marantz-1993]. -/
-def englishTnsVI : List (FeatureVI EngInflFeature String) :=
+def englishTnsVI : List (VocabularyItem EngInflFeature String) :=
   [⟨[.past, .participle], "-n"⟩,
    ⟨[.past],              "-d"⟩,
    ⟨[.participle],        "-ing"⟩,
@@ -162,7 +162,7 @@ specific matching entry: a root-restricted rule overrides the
 unrestricted default when the root matches.
 
 This section uses `VocabItem` (which supports root restrictions via
-`rootMatch`) rather than `FeatureVI` (which is context-free). -/
+`rootMatch`) rather than `VocabularyItem` (which is context-free). -/
 
 section ConditionedAllomorphy
 

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -36,7 +36,7 @@ indices are distinct roots — which is exactly what lets `√tenne` block
 
 * `vocabulary` — the Hiaki suppletive List-2 entries ([harley-2014] (3),
   (26), (27)), keyed by `RootIndex`, resolved by the shared DM engine
-  `DistributedMorphology.VI.vocabularyInsert`.
+  `DistributedMorphology.vocabularyInsert`.
 * Selection theorems — the engine picks the attested form per context.
 * `suppletion_ignores_ergative` — the §3.3 ergative-absolutive
   generalization: suppletion tracks the **internal (absolutive)**
@@ -61,7 +61,7 @@ number-unspecified).
 
 namespace Harley2014
 
-open DistributedMorphology.VI
+open DistributedMorphology
 open DistributedMorphology.Allosemy (SyntacticContext AllosemicEntry toInterpreted)
 open Morphology.Exponence (selectBy realize)
 
@@ -142,39 +142,33 @@ instance : DecidableRel
     (Morphology.Exponence.Applies : VocabItem Ctx RootIndex → Ctx × RootIndex → Prop) :=
   fun vi c => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
 
-/-- Spell out root `idx` in context `ctx` by Elsewhere competition over
-`vocabulary`, resolved by the shared exponence engine (`Exponence.realize`
-on the `VocabItem` specificity score) — the same selection engine as the
-allosemy LF side below. -/
-def insert (ctx : Ctx) (idx : RootIndex) : Option String :=
-  realize VocabItem.specificity vocabulary (ctx, idx)
-
 /-! ### Selection: the engine picks the attested form -/
 
 /-- Singular subject → `vuite` ([harley-2014] (1a)). -/
-theorem run_sg : insert ⟨.sg, none⟩ runRoot = some "vuite" := by decide
+theorem run_sg : vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot = some "vuite" := by decide
 
 /-- Plural subject → `tenne` ([harley-2014] (1b)). -/
-theorem run_pl : insert ⟨.pl, none⟩ runRoot = some "tenne" := by decide
+theorem run_pl : vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot = some "tenne" := by decide
 
 /-- Number-unspecified (impersonal passive) → `tenne`, the true Elsewhere
 form ([harley-2014] fn. 16): the diagnostic that `tenne`, not `vuite`, is
 Elsewhere. -/
-theorem run_impersonal : insert ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
+theorem run_impersonal :
+    vocabularyInsert vocabulary ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
 
 /-- Singular subject → `weye` ([harley-2014] (26a)). -/
-theorem walk_sg : insert ⟨.sg, none⟩ walkRoot = some "weye" := by decide
+theorem walk_sg : vocabularyInsert vocabulary ⟨.sg, none⟩ walkRoot = some "weye" := by decide
 
 /-- Plural subject → `kaate` ([harley-2014] (26b)). -/
-theorem walk_pl : insert ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
+theorem walk_pl : vocabularyInsert vocabulary ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
 
 /-- Singular object → `mea`, regardless of the (plural) subject
 ([harley-2014] (27a)). -/
-theorem kill_sgObj : insert ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
+theorem kill_sgObj : vocabularyInsert vocabulary ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
 
 /-- Plural object → `sua`, regardless of the (singular) subject
 ([harley-2014] (27b)). -/
-theorem kill_plObj : insert ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
+theorem kill_plObj : vocabularyInsert vocabulary ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
 
 /-! ### §3.3 The ergative-absolutive conditioning generalization -/
 
@@ -184,7 +178,7 @@ the external (ergative) argument's number is never consulted. This is the
 ergative-absolutive distribution of suppletive agreement — the challenge to
 [bobaljik-2008]'s marked-case generalization the paper raises. -/
 theorem suppletion_ignores_ergative (n : Number) (e e' : Option Number) (i : RootIndex) :
-    insert ⟨n, e⟩ i = insert ⟨n, e'⟩ i := rfl
+    vocabularyInsert vocabulary ⟨n, e⟩ i = vocabularyInsert vocabulary ⟨n, e'⟩ i := rfl
 
 /-! ### §2.1 Individuation is not phonological -/
 
@@ -193,7 +187,8 @@ phonologically unrelated exponents (`vuite` vs `tenne`). Any identification
 of the root by its phonological form would split it in two, making
 suppletion incoherent ([harley-2014] §2.2, contra Borer 2009). -/
 theorem run_index_two_forms :
-    insert ⟨.sg, none⟩ runRoot ≠ insert ⟨.pl, none⟩ runRoot := by decide
+    vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot ≠
+      vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot := by decide
 
 /-- **The suppletive rule is index-local** ([harley-2014] §2.1, Marantz's
 thought experiment): `tenne` competes only at `√322`, so it does not block
@@ -201,7 +196,7 @@ insertion at a different intransitive root — a non-suppletive `√500`
 (*bwiika* 'sing') gets no exponent from this vocabulary. This is why List-1
 roots must be individuated (as indices) before spell-out. -/
 theorem suppletive_rule_index_local (n : Number) :
-    insert ⟨n, none⟩ singRoot = none := by
+    vocabularyInsert vocabulary ⟨n, none⟩ singRoot = none := by
   cases n <;> decide
 
 /-! ### §2.3 Individuation is not semantic: the cran-morph on the LF side
@@ -246,17 +241,15 @@ empty `interp` fiber outside the cran-morph's frame, via
 `Allosemy.toInterpreted`). The vocabulary of §2.1 is the List-2 map,
 `cahootLF` the List-3 map.
 
-The form side wraps this file's `insert` — the shared Exponence engine
-(`Exponence.realize`, argmax) — as a `Realization`. `VI.toRealization`
-wraps the equivalent DM `vocabularyInsert`, whose `List.mergeSort` is
-well-founded-recursive and so kernel-opaque; `insert` computes, so the
-fibers reduce and the same theorem lands on the same data. -/
+The form side is `VocabItem.toRealization vocabulary` — the shared
+Exponence engine (`Exponence.realize`, argmax) as a `Realization`, whose
+fibers compute, so the same theorem lands on the same data. -/
 
 /-- The Hiaki suppletive vocabulary as a `Realization`: index `→` its
-Elsewhere-selected exponent (`insert`) as a singleton fiber, `∅` at an
-unlicensed index — the univalent stratum ([marantz-1997]'s List 2). -/
+Elsewhere-selected exponent as a singleton fiber, `∅` at an unlicensed
+index — the univalent stratum ([marantz-1997]'s List 2). -/
 def realization : Morphology.Realization RootIndex Ctx String :=
-  ⟨fun r c => match insert c r with | some f => {f} | none => ∅⟩
+  VocabItem.toRealization vocabulary
 
 /-- **Phonological individuation fails, on the carrier** ([harley-2014]
 §2.1–2.2): the Hiaki √322 realizes two nonempty, distinct fibers
@@ -265,11 +258,11 @@ the exact √GO case the predicate names. A root identified by its form would
 split here. -/
 theorem run_isProperlySuppletive : realization.IsProperlySuppletive runRoot := by
   have hsg : realization.realize runRoot ⟨.sg, none⟩ = {"vuite"} := by
-    show (match insert ⟨.sg, none⟩ runRoot with
+    show (match vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot with
       | some f => ({f} : Finset String) | none => ∅) = _
     rw [run_sg]
   have hpl : realization.realize runRoot ⟨.pl, none⟩ = {"tenne"} := by
-    show (match insert ⟨.pl, none⟩ runRoot with
+    show (match vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot with
       | some f => ({f} : Finset String) | none => ∅) = _
     rw [run_pl]
   refine ⟨⟨.sg, none⟩, ⟨.pl, none⟩, hsg ▸ Finset.singleton_nonempty _,

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -33,7 +33,7 @@ Condition yields *they* as the default singular animate pronoun.
 
 ## Formalization
 
-We define the pronoun VI rules using `FeatureVI` from
+We define the pronoun VI rules using `VocabularyItem` from
 `DistributedMorphology.VocabularyInsertion`, parameterize the three
 stages via `Contrastivity` from `DistributedMorphology.Categorizer`,
 and prove the Elsewhere-Condition predictions across the three stages.
@@ -45,7 +45,7 @@ namespace KonnellyCowper2020
 
 open DistributedMorphology (Contrastivity GenderFeature
   Interpretability Categorizer.Head PhiBundle)
-open DistributedMorphology.VI (FeatureVI subsetPrinciple)
+open DistributedMorphology (VocabularyItem subsetPrinciple)
 
 -- ============================================================================
 -- § 1: Morphosyntactic Features for English Pronouns
@@ -79,22 +79,22 @@ inductive PronFeature where
          b. [SG] [MASC]  ↔ *he*
          c. [SG, INANIM] ↔ *it*
          d. Elsewhere     ↔ *they*  -/
-def vi_she : FeatureVI PronFeature String :=
+def vi_she : VocabularyItem PronFeature String :=
   ⟨[.sg, .fem], "she"⟩
 
-def vi_he : FeatureVI PronFeature String :=
+def vi_he : VocabularyItem PronFeature String :=
   ⟨[.sg, .masc], "he"⟩
 
-def vi_it : FeatureVI PronFeature String :=
+def vi_it : VocabularyItem PronFeature String :=
   ⟨[.sg, .inanim], "it"⟩
 
-def vi_they : FeatureVI PronFeature String :=
+def vi_they : VocabularyItem PronFeature String :=
   ⟨[], "they"⟩
 
 /-- The complete VI rule set for English 3rd-person pronouns.
     Order does not matter — the Subset Principle selects by specificity
     (feature-list length). -/
-def pronounVIs : List (FeatureVI PronFeature String) :=
+def pronounVIs : List (VocabularyItem PronFeature String) :=
   [vi_she, vi_he, vi_it, vi_they]
 
 -- ============================================================================

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -65,7 +65,6 @@ What is **not** modeled:
 namespace Middleton2026
 
 open Minimalist DistributedMorphology DistributedMorphology.Impoverishment
-  DistributedMorphology.VI
      Taos.Agreement Basque.Postsyntax
 
 /-! ### Metathesis Rule
@@ -550,7 +549,7 @@ def middletonOutput : FeatureBundle :=
     matching entry. We use `Morpheme.surface` for the exponents to
     keep the connection to the Taos morpheme inventory in the
     Fragment. -/
-def viSet : List (FeatureVI FeatureVal String) :=
+def viSet : List (VocabularyItem FeatureVal String) :=
   [ -- specific: 1st-person + minimal (surfaces with `n` per [middleton-2026] rule 21)
     ⟨[fAuthor true, fMinimal true], Morpheme.n.surface⟩
   , -- specific: 1st-person + atomic

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -46,7 +46,7 @@ def copulaVI (voice : Head) : CopulaForm :=
   if voice.hasD && voice.flavor != .nonThematic && voice.flavor != .passive
   then .have else .be
 
-open DistributedMorphology.VI in
+open DistributedMorphology in
 /-- The copula VI as competing `VocabItem`s (HAVE specificity 2, BE elsewhere). -/
 def copulaVIRules : List (VocabItem Head Unit) :=
   [ { exponent := "have"
@@ -54,7 +54,7 @@ def copulaVIRules : List (VocabItem Head Unit) :=
     , specificity := 2 }
   , { exponent := "be", contextMatch := λ _ => true, specificity := 0 } ]
 
-open DistributedMorphology.VI in
+open DistributedMorphology in
 /-- The `VocabItem` formulation agrees with `copulaVI`. -/
 theorem copulaVI_agrees_vocabItem (v : Head) :
     vocabularyInsertSimple copulaVIRules v =
@@ -152,7 +152,7 @@ theorem hafa_iff_pred (dp : IcelandicPossDP) :
 
 -- ─── VocabItem formulation (parallel to copulaVIRules) ───
 
-open DistributedMorphology.VI in
+open DistributedMorphology in
 
 /-- Icelandic HAVE VI as proper `VocabItem`s from the DM framework.
 
@@ -171,7 +171,7 @@ def icelandicHaveVIRules : List (VocabItem IcelandicPossDP Unit) :=
     , contextMatch := fun _ => true
     , specificity := 0 } ]
 
-open DistributedMorphology.VI in
+open DistributedMorphology in
 
 /-- The VocabItem formulation agrees with the direct `icelandicHaveVI`. -/
 theorem icelandicVI_agrees_vocabItem (dp : IcelandicPossDP) :

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -47,7 +47,7 @@ categories (D, Num, n, Pers).
 
 ## Vocabulary Insertion (FeatureBundle-Based)
 
-Uses `Minimalist.FeatureBundle` and `DistributedMorphology.VI.vocabularyInsertSimple`
+Uses `Minimalist.FeatureBundle` and `DistributedMorphology.vocabularyInsertSimple`
 from the DM theory module. The Elsewhere Condition is structural: person-
 specified rules (specificity 3) beat personless defaults (specificity 2).
 Chain reduction removes person features from the bundle, so only the
@@ -258,7 +258,7 @@ def isAnim (fb : FeatureBundle) : Bool :=
     (checking 3 features); personless defaults have specificity 2.
     The Elsewhere Condition in `vocabularyInsertSimple` picks the most
     specific matching rule. -/
-def resumptiveVIRules : List (DistributedMorphology.VI.VocabItem FeatureBundle Unit) :=
+def resumptiveVIRules : List (DistributedMorphology.VocabItem FeatureBundle Unit) :=
   [ -- [PERS: 1, GEN: ANIM, NUM: SG] ↔ -mi
     { exponent := "-mi"
     , contextMatch := fun fb => getPerson fb == some .first && isAnim fb && isSg fb
@@ -288,7 +288,7 @@ def resumptiveVIRules : List (DistributedMorphology.VI.VocabItem FeatureBundle U
 /-- Insert the correct resumptive exponent for a feature bundle
     using the DM Elsewhere Condition. -/
 def insertResumptive (fb : FeatureBundle) : String :=
-  (DistributedMorphology.VI.vocabularyInsertSimple resumptiveVIRules fb).getD "-ye"
+  (DistributedMorphology.vocabularyInsertSimple resumptiveVIRules fb).getD "-ye"
 
 -- ============================================================================
 -- § 6: Chain Reduction Pipeline

--- a/Linglib/Syntax/Minimalist/MinimalPronoun.lean
+++ b/Linglib/Syntax/Minimalist/MinimalPronoun.lean
@@ -71,8 +71,8 @@ inductive BVAContext where
     Vocabulary items are ordered by specificity. When multiple items could
     apply, the most specific (first in the list) wins.
 
-    This is a specialization of the general DM `DistributedMorphology.VI.VocabItem`
-    in `Morphology/DistributedMorphology/VocabularyInsertion.lean`, restricted to
+    This is a specialization of the general DM `DistributedMorphology.VocabItem`
+    in `Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean`, restricted to
     `BVAContext` matching with a parameterized `Form` type. -/
 structure VocabItem (Form : Type) where
   /-- The syntactic context this item is restricted to -/


### PR DESCRIPTION
Deep cleanse of `VocabularyInsertion/Basic.lean`: `FeatureVI` becomes `VocabularyItem`, an `Exponence.Rule` instance whose applicability is feature inclusion, so `winner?`/`subsetPrinciple` are the shared engine's `selectBy`/`realize` and the hand-rolled `pickLonger` fold with its private lemmas is gone.

- `VocabularyItem.le_iff`: the engine's specificity order is reverse feature inclusion, so the distinct-feature score is strictly antitone and `winner?_isElsewhereWinner` carries no faithfulness hypothesis.
- The acronym namespace `DistributedMorphology.VI` is flattened; the consumerless `VocabEntry.toVocabItem` bridge is deleted; `Harley2014`'s study-local `insert`/`realization` now call `vocabularyInsert`/`VocabItem.toRealization`.