### PR TITLE
refactor(Morphology/DistributedMorphology): dissolve opaque VocabItem

### DIFF
--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -56,7 +56,7 @@ immaterial for the result and content readings.
 ## Implementation notes
 
 `AllosemicEntry` is a `Morphology.Exponence.Rule` instance, just as
-`VocabItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
+`VocabularyItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
 selection engine: `Exponence.selectBy` on the non-wildcard-field score
 (`selectBy_score_isElsewhereWinner`). `Voice.Alloseme.fromComplement` is
 a worked List-3 competition on that engine; `readingFromAllosemes` is a

--- a/Linglib/Morphology/DistributedMorphology/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Basic.lean
@@ -1,10 +1,11 @@
 import Linglib.Morphology.DistributedMorphology.Defs
 import Linglib.Morphology.Exponence.Select
+import Mathlib.Data.Finset.Card
 
 /-!
 # Vocabulary items and allosemes as exponence rules
 
-A `VocabItem` and an `Allosemy.AllosemicEntry` each expose the shared
+A `VocabularyItem` and an `Allosemy.AllosemicEntry` each expose the shared
 exponence interface (`Morphology.Exponence.Rule`), so DM's List 2 (form) and
 List 3 (meaning) are resolved by one `Exponence.selectBy` competition, whose
 winner is the Elsewhere winner. This file holds the two `Rule` instances and
@@ -112,17 +113,47 @@ end Exponence
 
 end Allosemy
 
-variable {Ctx Root : Type*}
+namespace VocabularyItem
 
-/-- A Vocabulary Item exposes the shared exponence core interface
-(`Morphology.Exponence.Rule`): contexts are (feature-context, root)
-pairs, applicability is `matches`. -/
-instance : Morphology.Exponence.Rule (VocabItem Ctx Root) (Ctx × Root) String :=
-  ⟨VocabItem.exponent, fun vi cr => vi.matches cr.1 cr.2 = true⟩
+variable {F E : Type*} {i j : VocabularyItem F E} {t : List F}
 
-instance : DecidableRel (Applies : VocabItem Ctx Root → Ctx × Root → Prop) :=
-  fun vi cr => inferInstanceAs (Decidable (vi.matches cr.1 cr.2 = true))
+/-- A Vocabulary Item exposes the shared exponence interface: contexts are
+feature bundles, applicability is feature inclusion. -/
+instance : Rule (VocabularyItem F E) (List F) E := ⟨exponent, fun i t => i.features ⊆ t⟩
 
-instance : Preorder (VocabItem Ctx Root) := Morphology.Exponence.toPreorder
+instance : Preorder (VocabularyItem F E) := toPreorder
+
+theorem applies_iff : Applies i t ↔ i.features ⊆ t := Iff.rfl
+
+/-- An item with no features applies at every bundle. -/
+theorem elsewhere_applies (e : E) (t : List F) : Applies (⟨[], e⟩ : VocabularyItem F E) t :=
+  List.nil_subset _
+
+theorem le_iff_applies : i ≤ j ↔ ∀ ⦃t : List F⦄, i.features ⊆ t → j.features ⊆ t := Iff.rfl
+
+/-- The engine's specificity order is reverse feature inclusion. -/
+theorem le_iff : i ≤ j ↔ j.features ⊆ i.features :=
+  ⟨fun h => le_iff_applies.mp h (List.Subset.refl _),
+    fun h => le_iff_applies.mpr fun _ ht => List.Subset.trans h ht⟩
+
+variable [DecidableEq F]
+
+instance : DecidableRel (Applies : VocabularyItem F E → List F → Prop) :=
+  fun i t => decidable_of_iff (∀ f ∈ i.features, f ∈ t) Iff.rfl
+
+/-- The number of distinct features an item specifies — the Subset
+Principle's specificity score. -/
+def specificity (i : VocabularyItem F E) : ℕ := i.features.toFinset.card
+
+theorem toFinset_subset_toFinset :
+    i.features.toFinset ⊆ j.features.toFinset ↔ i.features ⊆ j.features :=
+  Multiset.toFinset_subset.trans Multiset.coe_subset
+
+theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E → ℕ) :=
+  fun _ _ h => Finset.card_lt_card <| Finset.ssubset_def.mpr
+    ⟨toFinset_subset_toFinset.mpr (le_iff.mp h.le),
+      fun hc => (lt_iff_le_not_ge.mp h).2 (le_iff.mpr (toFinset_subset_toFinset.mp hc))⟩
+
+end VocabularyItem
 
 end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -4,8 +4,8 @@ import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
 # Vocabulary items and allosemes
 
 The rule types of Distributed Morphology's two interpretive lists:
-`VocabItem` pairs a phonological exponent with the context that
-licenses it (List 2), and `Allosemy.AllosemicEntry` pairs a meaning with
+`VocabularyItem` pairs a feature specification with the exponent that
+spells it out (List 2), and `Allosemy.AllosemicEntry` pairs a meaning with
 the conditioning `Allosemy.SyntacticContext` (List 3). The shared
 selection-engine instances live in `DistributedMorphology/Basic.lean`.
 
@@ -18,38 +18,14 @@ selection-engine instances live in `DistributedMorphology/Basic.lean`.
 
 namespace DistributedMorphology
 
-/-- A Vocabulary Item: a rule mapping morphosyntactic context to a
-    phonological exponent.
-
-    - `Ctx`: the type of morphosyntactic contexts (e.g., feature bundles)
-    - `Root`: the type of root identifiers (for root-specific rules)
-
-    The `specificity` field encodes the Elsewhere Condition: when
-    multiple rules match, the highest-specificity rule wins. In
-    practice, specificity equals the number of features the context
-    checks — a rule conditioned on [ACC, +animate] (specificity 2) beats
-    a default rule with no feature requirements (specificity 0). -/
-structure VocabItem (Ctx Root : Type*) where
-  /-- The phonological exponent inserted at the terminal. -/
-  exponent : String
-  /-- Context check: does the terminal's feature bundle match? -/
-  contextMatch : Ctx → Bool
-  /-- Root restriction: which roots this rule applies to.
-      `none` means the rule is unrestricted (default/elsewhere). -/
-  rootMatch : Option (Root → Bool) := none
-  /-- Specificity for Elsewhere Condition resolution. Higher = more
-      specific. When two rules both match, the higher-specificity
-      rule wins. -/
-  specificity : Nat := 0
-
-/-- Does a Vocabulary Item match at a given terminal node?
-    Checks both the morphosyntactic context and the root restriction. -/
-def VocabItem.matches {Ctx Root : Type*}
-    (vi : VocabItem Ctx Root) (ctx : Ctx) (root : Root) : Bool :=
-  vi.contextMatch ctx &&
-  match vi.rootMatch with
-  | none => true
-  | some f => f root
+/-- A Vocabulary Item: a feature specification paired with an exponent,
+applicable at any bundle containing every specified feature. -/
+structure VocabularyItem (F E : Type*) where
+  /-- The features the item spells out. -/
+  features : List F
+  /-- The exponent the item inserts. -/
+  exponent : E
+  deriving DecidableEq, Repr
 
 namespace Allosemy
 

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
@@ -1,7 +1,5 @@
-import Mathlib.Data.Finset.Card
 import Linglib.Morphology.DistributedMorphology.Basic
 import Linglib.Morphology.Exponence.Select
-import Linglib.Morphology.Realization
 
 /-!
 # Vocabulary insertion
@@ -15,93 +13,27 @@ exponence engine (`Morphology.Exponence.selectBy`) to that competition.
 
 ## Main definitions
 
-* `VocabularyItem F E`: a feature specification with an exponent, applicable
-  at a bundle containing every specified feature.
-* `VocabularyItem.specificity`: the number of distinct specified features.
 * `winner?`, `subsetPrinciple`: the Subset Principle's winning item and its
   exponent.
-* `vocabularyInsert`: selection over `VocabItem`s, whose applicability is an
-  opaque predicate and whose rank is stipulated.
 
 ## Main results
 
-* `VocabularyItem.le_iff`: the engine's specificity order on vocabulary items
-  is reverse feature inclusion, so `specificity` is strictly antitone and
-  `winner?_isElsewhereWinner` needs no faithfulness hypothesis.
+* `winner?_isElsewhereWinner`: the winner is an Elsewhere winner of the
+  shared core, with no faithfulness hypothesis — over feature
+  specifications the engine's specificity order is reverse feature
+  inclusion (`VocabularyItem.le_iff`).
 * `winner?_retreat`: deleting features from the target can only make the
   winner less specific — retreat to the general case.
-* `vocabularyInsert_isElsewhereWinner`: under `SpecificityFaithful`, the
-  opaque engine also selects an Elsewhere winner.
-
-## Implementation notes
-
-A `VocabItem` carries an arbitrary decidable context predicate, an optional
-root restriction (the root-conditioned allomorphy that [bobaljik-2000]'s
-root-out insertion makes available inward), and a stipulated rank; with
-opaque predicates the derived specificity order is not computable, so
-`SpecificityFaithful` is the obligation the stipulation incurs. Over
-`VocabularyItem`s no such obligation arises.
 
 ## References
 
 * [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
   inflection*][halle-marantz-1993]
-* [J. D. Bobaljik, *The ins and outs of contextual allomorphy*][bobaljik-2000]
 -/
 
 namespace DistributedMorphology
 
 open Morphology.Exponence
-
-/-! ### Vocabulary items -/
-
-/-- A Vocabulary Item: a feature specification paired with an exponent,
-applicable at any bundle containing every specified feature. -/
-structure VocabularyItem (F E : Type*) where
-  /-- The features the item spells out. -/
-  features : List F
-  /-- The exponent the item inserts. -/
-  exponent : E
-  deriving DecidableEq, Repr
-
-namespace VocabularyItem
-
-variable {F E : Type*} [DecidableEq F] {i j : VocabularyItem F E} {t : List F}
-
-instance : Rule (VocabularyItem F E) (List F) E := ⟨exponent, fun i t => i.features ⊆ t⟩
-
-instance : DecidableRel (Applies : VocabularyItem F E → List F → Prop) :=
-  fun i t => decidable_of_iff (∀ f ∈ i.features, f ∈ t) Iff.rfl
-
-instance : Preorder (VocabularyItem F E) := toPreorder
-
-theorem applies_iff : Applies i t ↔ i.features ⊆ t := Iff.rfl
-
-/-- An item with no features applies at every bundle. -/
-theorem elsewhere_applies (e : E) (t : List F) : Applies (⟨[], e⟩ : VocabularyItem F E) t :=
-  List.nil_subset _
-
-theorem le_iff_applies : i ≤ j ↔ ∀ ⦃t : List F⦄, i.features ⊆ t → j.features ⊆ t := Iff.rfl
-
-/-- The engine's specificity order is reverse feature inclusion. -/
-theorem le_iff : i ≤ j ↔ j.features ⊆ i.features :=
-  ⟨fun h => le_iff_applies.mp h (List.Subset.refl _),
-    fun h => le_iff_applies.mpr fun _ ht => List.Subset.trans h ht⟩
-
-/-- The number of distinct features an item specifies — the Subset
-Principle's specificity score. -/
-def specificity (i : VocabularyItem F E) : ℕ := i.features.toFinset.card
-
-theorem toFinset_subset_toFinset :
-    i.features.toFinset ⊆ j.features.toFinset ↔ i.features ⊆ j.features :=
-  Multiset.toFinset_subset.trans Multiset.coe_subset
-
-theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E → ℕ) :=
-  fun _ _ h => Finset.card_lt_card <| Finset.ssubset_def.mpr
-    ⟨toFinset_subset_toFinset.mpr (le_iff.mp h.le),
-      fun hc => (lt_iff_le_not_ge.mp h).2 (le_iff.mpr (toFinset_subset_toFinset.mp hc))⟩
-
-end VocabularyItem
 
 /-! ### The Subset Principle -/
 
@@ -166,53 +98,5 @@ theorem winner?_retreat (hsub : t' ⊆ t) (h' : winner? items t' = some i') :
   exact ⟨i, hi, winner?_max hi _ hmem⟩
 
 end SubsetPrinciple
-
-/-! ### Opaque-context items -/
-
-section VocabItem
-
-variable {Ctx Root : Type*} {rules : List (VocabItem Ctx Root)} {ctx : Ctx} {root : Root}
-  {e : String}
-
-/-- Insert a Vocabulary Item at a terminal node: the exponent of the
-highest-`specificity` matching rule (ties go to the earlier rule), `none` if
-no rule matches — the **Elsewhere Condition** of [halle-marantz-1993]. -/
-def vocabularyInsert (rules : List (VocabItem Ctx Root)) (ctx : Ctx) (root : Root) :
-    Option String :=
-  realize VocabItem.specificity rules (ctx, root)
-
-/-- Insertion over rules with no root restriction. -/
-def vocabularyInsertSimple (rules : List (VocabItem Ctx Unit)) (ctx : Ctx) : Option String :=
-  vocabularyInsert rules ctx ()
-
-/-- The stipulated `specificity` rank is **faithful** when it refines the
-engine's specificity order: a strictly more specific item always outranks. -/
-def SpecificityFaithful (rules : List (VocabItem Ctx Root)) : Prop :=
-  ∀ a ∈ rules, ∀ b ∈ rules, a ≤ b → ¬ b ≤ a → b.specificity < a.specificity
-
-/-- Under a faithful rank, `vocabularyInsert` selects an Elsewhere winner. -/
-theorem vocabularyInsert_isElsewhereWinner (h : vocabularyInsert rules ctx root = some e)
-    (hf : SpecificityFaithful rules) :
-    ∃ vi ∈ rules, vi.exponent = e ∧ IsElsewhereWinner rules (ctx, root) vi := by
-  obtain ⟨vi, hvi, hve⟩ := Option.map_eq_some_iff.mp h
-  exact ⟨vi, selectBy_mem hvi, hve, selectBy_isElsewhereWinner
-    (λ a ha b hb hab => hf a (mem_applicable.mp ha).1 b (mem_applicable.mp hb).1
-      (lt_iff_le_not_ge.mp hab).1 (lt_iff_le_not_ge.mp hab).2) hvi⟩
-
-/-- Vocabulary Insertion as a `Realization`: roots as indices, contexts as
-contexts, `none` as non-licensing. -/
-def VocabItem.toRealization (rules : List (VocabItem Ctx Root)) :
-    Morphology.Realization Root Ctx String :=
-  ⟨fun r c => match vocabularyInsert rules c r with
-    | some f => {f}
-    | none => ∅⟩
-
-theorem VocabItem.toRealization_isUnivalent (rules : List (VocabItem Ctx Root)) :
-    (toRealization rules).IsUnivalent :=
-  fun r c => by
-    simp only [toRealization]
-    cases vocabularyInsert rules c r <;> simp
-
-end VocabItem
 
 end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
@@ -19,9 +19,8 @@ Selection and realization are the shared exponence engine
 (`Exponence.selectBy`, `Exponence.realize`), so the Elsewhere Condition
 is inherited, not reproved. Over concrete feature bundles the intensional
 subset order is provably the engine's specificity order
-(`VocabEntry.le_iff`), with no faithfulness stipulation — contrast the
-opaque-predicate engine (`VocabularyInsertion/Basic.lean`), which must
-assume it.
+(`VocabEntry.le_iff`), as for `DistributedMorphology.VocabularyItem.le_iff`,
+with the category restriction as an extra conjunct.
 
 ## Main definitions
 
@@ -139,9 +138,7 @@ theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
 /-- The engine's specificity order, characterized: `e ≤ e'` iff `e'`'s
 features are included in `e`'s and `e'`'s context restriction is
 compatible. Over feature bundles the intensional inclusion order IS the
-specificity order, with no faithfulness assumption — contrast
-`DistributedMorphology.SpecificityFaithful`, which the
-opaque-predicate engine must stipulate. -/
+specificity order, as in `DistributedMorphology.VocabularyItem.le_iff`. -/
 theorem VocabEntry.le_iff {e e' : VocabEntry} :
     e ≤ e' ↔
       FeatureBundle.toGramFeatures e'.features ⊆

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -51,7 +51,7 @@ cannot affect gender assignment.
 This module uses types from `Morphology/DistributedMorphology/NominalSpine.lean`
 (the GLH, `NominalPosition`, `PossessionType`), `Head` and `PhiBundle`
 from `Morphology/DistributedMorphology/Categorizer.lean` ([kramer-2015]),
-`VocabItem` from `Morphology/DistributedMorphology/VocabularyInsertion.lean`,
+`VocabularyItem` from `Morphology/DistributedMorphology/Defs.lean`,
 and Fragment data from `Fragments/Teop/Nouns.lean` and
 `Fragments/Jarawara/PossessedNouns.lean`.
 -/
@@ -139,45 +139,46 @@ theorem teop_uses_anim_dimension :
 
 /-! ### Teop Vocabulary Insertion -/
 
-/-- Teop article VI rules, ordered by specificity. -/
-def teopArticleRules : List (VocabItem Teop.ArticleCtx Unit) :=
-  [ { exponent := "e"
-      contextMatch := λ c => c.gender == .gI && c.proprial
-      specificity := 3 }
-  , { exponent := "a"
-      contextMatch := λ c => c.gender == .gI && !c.plural && !c.proprial
-      specificity := 2 }
-  , { exponent := "ra"
-      contextMatch := λ c => c.gender == .gI && c.plural
-      specificity := 2 }
-  , { exponent := "o"
-      contextMatch := λ c => c.gender == .gII && !c.plural
-      specificity := 1 }
-  , { exponent := "ro"
-      contextMatch := λ c => c.gender == .gII && c.plural
-      specificity := 1 }
-  ]
+/-- Features of the Teop article's agreement bundle: the noun's gender and
+number, and proprial status. -/
+inductive ArticleFeature where
+  | gI | gII | plural | proprial
+  deriving DecidableEq, Repr
 
-theorem teop_ipossessed_body_part_article :
-    vocabularyInsert teopArticleRules ⟨.gI, false, false⟩ () = some "a" := by decide
+/-- The article's bundle for a Fragment `Teop.ArticleCtx`. -/
+def articleFeatures (c : Teop.ArticleCtx) : List ArticleFeature :=
+  (match c.gender with | .gI => [.gI] | .gII => [.gII]) ++
+    (if c.plural then [.plural] else []) ++ (if c.proprial then [.proprial] else [])
+
+/-- Teop article items: proprial *e*, plural *ra*/*ro*, and the singular
+defaults *a*/*o* per gender. -/
+def teopArticleRules : List (VocabularyItem ArticleFeature String) :=
+  [⟨[.gI, .proprial], "e"⟩, ⟨[.gI, .plural], "ra"⟩, ⟨[.gI], "a"⟩,
+   ⟨[.gII, .plural], "ro"⟩, ⟨[.gII], "o"⟩]
+
+/-- The article the Subset Principle inserts for a context. -/
+def teopArticle (c : Teop.ArticleCtx) : Option String :=
+  subsetPrinciple teopArticleRules (articleFeatures c)
+
+theorem teop_ipossessed_body_part_article : teopArticle ⟨.gI, false, false⟩ = some "a" := by decide
 theorem teop_unpossessed_body_part_article :
-    vocabularyInsert teopArticleRules ⟨.gII, false, false⟩ () = some "o" := by decide
-theorem teop_proprial_article :
-    vocabularyInsert teopArticleRules ⟨.gI, false, true⟩ () = some "e" := by decide
-theorem teop_plural_gI_article :
-    vocabularyInsert teopArticleRules ⟨.gI, true, false⟩ () = some "ra" := by decide
-theorem teop_plural_gII_article :
-    vocabularyInsert teopArticleRules ⟨.gII, true, false⟩ () = some "ro" := by decide
+    teopArticle ⟨.gII, false, false⟩ = some "o" := by decide
+theorem teop_proprial_article : teopArticle ⟨.gI, false, true⟩ = some "e" := by decide
+theorem teop_plural_gI_article : teopArticle ⟨.gI, true, false⟩ = some "ra" := by decide
+theorem teop_plural_gII_article : teopArticle ⟨.gII, true, false⟩ = some "ro" := by decide
+
+/-- Vocabulary Insertion reproduces the Fragment's article table. -/
+theorem teopArticle_eq_articleForm (c : Teop.ArticleCtx) :
+    teopArticle c = some (Teop.articleForm c) := by
+  rcases c with ⟨g, p, q⟩; cases g <;> cases p <;> cases q <;> decide
 
 /-- End-to-end: body-part root + n_{body-part{D}} → gender I → article *a*. -/
 theorem teop_end_to_end_ipossessed :
-    vocabularyInsert teopArticleRules
-      ⟨teopGenderFromN teopBodyPartN, false, false⟩ () = some "a" := by decide
+    teopArticle ⟨teopGenderFromN teopBodyPartN, false, false⟩ = some "a" := by decide
 
 /-- End-to-end: body-part root + n_{alienator} → gender II → article *o*. -/
 theorem teop_end_to_end_unpossessed :
-    vocabularyInsert teopArticleRules
-      ⟨teopGenderFromN teopAlienatorN, false, false⟩ () = some "o" := by decide
+    teopArticle ⟨teopGenderFromN teopAlienatorN, false, false⟩ = some "o" := by decide
 
 /-! ### Bridge to Fragment Data
 
@@ -485,7 +486,7 @@ Head ──┤
 ```
 
 The PF pipeline genuinely threads: `teopGenderFromN` computes the gender,
-which feeds into `vocabularyInsert` as the article context. The semantic
+which feeds into `teopArticle` as the article context. The semantic
 pipeline threads similarly: `catHeadSemanticType` computes the semantic
 type, which feeds into `.toBarker.canTakePossessor`.
 
@@ -502,7 +503,7 @@ open DistributedMorphology.CategorizerSemantics
     into VI as part of the article context. -/
 def teopPFDerive (nh : Head) (pl proprial : Bool := false) : Option String :=
   let gender := teopGenderFromN nh
-  vocabularyInsert teopArticleRules ⟨gender, pl, proprial⟩ ()
+  teopArticle ⟨gender, pl, proprial⟩
 
 /-- The semantic derivation pipeline: n-head → semantic type → possessor capability.
     The semantic type is an intermediate value, fed into Barker's type classification

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -153,85 +153,60 @@ def weakParadigm : TeluguCase → WeakStemForm
 -- § 2: Strong Alternation — VI Rules and Elsewhere Condition
 -- ============================================================================
 
-/-- Morphosyntactic context for VI at the *n* head in Telugu.
-    Carries the root class and the Telugu case directly; nonnominativity
-    is derived from `case.IsNonnom` rather than stored as a Bool — so
-    the McFadden 2018 / Caha 2009 containment substrate is the source of
-    truth at every VI use site. -/
-structure NContext where
-  rootClass : StrongClass
-  case : TeluguCase
+/-- Features at the Telugu *n* head: the root class, and nonnominativity —
+derived from `case.IsNonnom` rather than stored, so the McFadden 2018 /
+Caha 2009 containment substrate is the source of truth at every VI use
+site. -/
+inductive NFeature where
+  | rootClass (c : StrongClass)
+  | nonnom
   deriving DecidableEq, Repr
 
-/-- VI rule for NOM *n* of the -lu∼-ṭi class.
-    No nonnominative requirement → this is the elsewhere/default rule. -/
-def viLuNom : VocabItem NContext Unit :=
-  { exponent := "lu"
-  , contextMatch := λ ctx => ctx.rootClass == .luTi
-  , specificity := 1 }
+/-- The *n* head's bundle for a root class in a case. -/
+def nFeatures (rc : StrongClass) (c : TeluguCase) : List NFeature :=
+  .rootClass rc :: if c.IsNonnom then [.nonnom] else []
 
-/-- VI rule for oblique *n* of the -lu∼-ṭi class.
-    Requires `case.IsNonnom` → more specific, wins over `viLuNom` in non-NOM. -/
-def viLuObl : VocabItem NContext Unit :=
-  { exponent := "ṭi"
-  , contextMatch := λ ctx => ctx.rootClass == .luTi && decide ctx.case.IsNonnom
-  , specificity := 2 }
-
-/-- VI rule for NOM *n* of the -u∼-i class. -/
-def viUNom : VocabItem NContext Unit :=
-  { exponent := "u"
-  , contextMatch := λ ctx => ctx.rootClass == .uI
-  , specificity := 1 }
-
-/-- VI rule for oblique *n* of the -u∼-i class. -/
-def viUObl : VocabItem NContext Unit :=
-  { exponent := "i"
-  , contextMatch := λ ctx => ctx.rootClass == .uI && decide ctx.case.IsNonnom
-  , specificity := 2 }
-
-/-- All VI rules for strong noun *n*-exponents. -/
-def strongVIRules : List (VocabItem NContext Unit) :=
-  [viLuNom, viLuObl, viUNom, viUObl]
-
-/-- Build the morphosyntactic context for VI from Telugu case + root class. -/
-def mkNContext (rc : StrongClass) (c : TeluguCase) : NContext :=
-  ⟨rc, c⟩
+/-- Strong-noun *n* items: per class, the NOM form as the class default and
+the oblique form on the nonnominative bundle ([aitha-2026]). -/
+def strongVIRules : List (VocabularyItem NFeature String) :=
+  [⟨[.rootClass .luTi], "lu"⟩, ⟨[.rootClass .luTi, .nonnom], "ṭi"⟩,
+   ⟨[.rootClass .uI], "u"⟩, ⟨[.rootClass .uI, .nonnom], "i"⟩]
 
 -- Elsewhere Condition: oblique rules override default in non-NOM contexts
 
 theorem vi_luTi_nom :
-    vocabularyInsertSimple strongVIRules (mkNContext .luTi .nom)
+    subsetPrinciple strongVIRules (nFeatures .luTi .nom)
       = some "lu" := by decide
 
 theorem vi_luTi_acc :
-    vocabularyInsertSimple strongVIRules (mkNContext .luTi .acc)
+    subsetPrinciple strongVIRules (nFeatures .luTi .acc)
       = some "ṭi" := by decide
 
 theorem vi_luTi_gen :
-    vocabularyInsertSimple strongVIRules (mkNContext .luTi .gen)
+    subsetPrinciple strongVIRules (nFeatures .luTi .gen)
       = some "ṭi" := by decide
 
 theorem vi_luTi_dat :
-    vocabularyInsertSimple strongVIRules (mkNContext .luTi .dat)
+    subsetPrinciple strongVIRules (nFeatures .luTi .dat)
       = some "ṭi" := by decide
 
 theorem vi_uI_nom :
-    vocabularyInsertSimple strongVIRules (mkNContext .uI .nom)
+    subsetPrinciple strongVIRules (nFeatures .uI .nom)
       = some "u" := by decide
 
 theorem vi_uI_acc :
-    vocabularyInsertSimple strongVIRules (mkNContext .uI .acc)
+    subsetPrinciple strongVIRules (nFeatures .uI .acc)
       = some "i" := by decide
 
 /-- VI produces the correct strong paradigm for -lu∼-ṭi nouns. -/
 theorem vi_matches_strong_luTi (c : TeluguCase) :
-    vocabularyInsertSimple strongVIRules (mkNContext .luTi c)
+    subsetPrinciple strongVIRules (nFeatures .luTi c)
       = some (strongSurface luTiParadigm c) := by
   cases c <;> decide
 
 /-- VI produces the correct strong paradigm for -u∼-i nouns. -/
 theorem vi_matches_strong_uI (c : TeluguCase) :
-    vocabularyInsertSimple strongVIRules (mkNContext .uI c)
+    subsetPrinciple strongVIRules (nFeatures .uI c)
       = some (strongSurface uIParadigm c) := by
   cases c <;> decide
 

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -78,7 +78,7 @@ inductive EngInflFeature where
   | past
   | participle
   | sg3
-  deriving DecidableEq, BEq, Repr
+  deriving DecidableEq, Repr
 
 /-- Context-free VI entries for English verbal inflection.
     [halle-marantz-1993]. -/
@@ -161,8 +161,9 @@ Condition applied to root-conditioned entries) selects the most
 specific matching entry: a root-restricted rule overrides the
 unrestricted default when the root matches.
 
-This section uses `VocabItem` (which supports root restrictions via
-`rootMatch`) rather than `VocabularyItem` (which is context-free). -/
+Root conditioning is a contextual feature on the Tns terminal's bundle —
+the identity of the adjacent root — and a root class contributes one item
+per member, as the paper's set-valued context does. -/
 
 section ConditionedAllomorphy
 
@@ -171,68 +172,56 @@ inductive SampleVerb where
   | walk | play
   | dwell | buy | send
   | put | beat | hit
-  deriving DecidableEq, BEq, Repr
+  deriving DecidableEq, Repr
 
-/-- Root-conditioned past tense VI rules.
+/-- Features visible at the past-tense Tns terminal: its own [+past] and
+the identity of the adjacent root ([halle-marantz-1993]'s contextual
+specification). -/
+inductive PastContext where
+  | past
+  | root (v : SampleVerb)
+  deriving DecidableEq, Repr
 
-    All three entries share [+past] context (modeled as `Bool`);
-    they differ in root restriction and specificity.
-    [halle-marantz-1993]. -/
-def conditionedPastVI : List (VocabItem Bool SampleVerb) :=
-  [-- /-t/ for specific roots (specificity 2: context + root)
-   { exponent := "-t"
-     contextMatch := id
-     rootMatch := some ([SampleVerb.dwell, .buy, .send].contains ·)
-     specificity := 2 },
-   -- /∅/ for specific roots (specificity 2: context + root)
-   { exponent := "∅"
-     contextMatch := id
-     rootMatch := some ([SampleVerb.put, .beat, .hit].contains ·)
-     specificity := 2 },
-   -- /-d/ default (specificity 1: context only, no root restriction)
-   { exponent := "-d"
-     contextMatch := id
-     rootMatch := none
-     specificity := 1 }]
+/-- A root class's items: `e` for [+past] next to each listed root. -/
+def rootClass (roots : List SampleVerb) (e : String) :
+    List (VocabularyItem PastContext String) :=
+  roots.map fun v => ⟨[.past, .root v], e⟩
 
-/-- Regular verbs get `-d`: no root-specific entry matches. -/
-theorem walk_gets_d :
-    vocabularyInsert conditionedPastVI true .walk = some "-d" := by
+/-- Root-conditioned past tense items: `-t` and `∅` for their root classes,
+`-d` for [+past] elsewhere ([halle-marantz-1993]). -/
+def conditionedPastVI : List (VocabularyItem PastContext String) :=
+  rootClass [.dwell, .buy, .send] "-t" ++ rootClass [.put, .beat, .hit] "∅" ++ [⟨[.past], "-d"⟩]
+
+/-- Regular verbs get `-d`: no root-specific item applies. -/
+theorem walk_gets_d : subsetPrinciple conditionedPastVI [.past, .root .walk] = some "-d" := by
   decide
 
-theorem play_gets_d :
-    vocabularyInsert conditionedPastVI true .play = some "-d" := by
+theorem play_gets_d : subsetPrinciple conditionedPastVI [.past, .root .play] = some "-d" := by
   decide
 
-/-- Verbs in the `-t` class: root restriction overrides default. -/
-theorem dwell_gets_t :
-    vocabularyInsert conditionedPastVI true .dwell = some "-t" := by
+/-- Verbs in the `-t` class: the root-conditioned item beats the default. -/
+theorem dwell_gets_t : subsetPrinciple conditionedPastVI [.past, .root .dwell] = some "-t" := by
   decide
 
-theorem buy_gets_t :
-    vocabularyInsert conditionedPastVI true .buy = some "-t" := by
+theorem buy_gets_t : subsetPrinciple conditionedPastVI [.past, .root .buy] = some "-t" := by
   decide
 
 /-- Verbs in the `∅` class: no overt past tense marking. -/
-theorem put_gets_null :
-    vocabularyInsert conditionedPastVI true .put = some "∅" := by
+theorem put_gets_null : subsetPrinciple conditionedPastVI [.past, .root .put] = some "∅" := by
   decide
 
-theorem beat_gets_null :
-    vocabularyInsert conditionedPastVI true .beat = some "∅" := by
+theorem beat_gets_null : subsetPrinciple conditionedPastVI [.past, .root .beat] = some "∅" := by
   decide
 
-/-- The Paninian principle: root-restricted entries override the
-    default for matching roots. -/
+/-- The Paninian principle: root-conditioned items override the default for
+their roots. -/
 theorem root_restriction_overrides_default :
-    vocabularyInsert conditionedPastVI true .dwell ≠
-    vocabularyInsert conditionedPastVI true .walk := by
+    subsetPrinciple conditionedPastVI [.past, .root .dwell] ≠
+      subsetPrinciple conditionedPastVI [.past, .root .walk] := by
   decide
 
-/-- Non-past context: no entry matches (all require [+past]). -/
-theorem nonpast_no_match :
-    vocabularyInsert conditionedPastVI false .walk = none := by
-  decide
+/-- Non-past context: no item applies (all require [+past]). -/
+theorem nonpast_no_match : subsetPrinciple conditionedPastVI [.root .walk] = none := by decide
 
 end ConditionedAllomorphy
 

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -35,8 +35,8 @@ indices are distinct roots — which is exactly what lets `√tenne` block
 ## This file
 
 * `vocabulary` — the Hiaki suppletive List-2 entries ([harley-2014] (3),
-  (26), (27)), keyed by `RootIndex`, resolved by the shared DM engine
-  `DistributedMorphology.vocabularyInsert`.
+  (26), (27)), keyed by `RootIndex`, resolved by the Subset Principle
+  (`DistributedMorphology.subsetPrinciple`).
 * Selection theorems — the engine picks the attested form per context.
 * `suppletion_ignores_ergative` — the §3.3 ergative-absolutive
   generalization: suppletion tracks the **internal (absolutive)**
@@ -112,63 +112,69 @@ structure Ctx where
 
 /-! ### List 2: the suppletive Vocabulary Items
 
-Each root index has a singular-conditioned entry (specificity 1) and an
-Elsewhere entry (specificity 0); the DM engine's Elsewhere resolution
-(`vocabularyInsert`) selects the more specific matching rule. -/
+Each root index has a singular-conditioned item and an Elsewhere item; the
+Subset Principle selects the more specific applicable one. -/
 
-/-- A singular-conditioned suppletive entry for `idx`. -/
-private def sgEntry (form : String) (idx : RootIndex) : VocabItem Ctx RootIndex where
-  exponent := form
-  contextMatch := fun c => decide (c.absNumber = Number.sg)
-  rootMatch := some (· == idx)
-  specificity := 1
+/-- Features at a suppletive root's insertion site: the root's index and the
+number of its absolutive argument. -/
+inductive SiteFeature where
+  | root (idx : RootIndex)
+  | abs (n : Number)
+  deriving DecidableEq, Repr
 
-/-- An Elsewhere suppletive entry for `idx` (matches any context). -/
-private def elseEntry (form : String) (idx : RootIndex) : VocabItem Ctx RootIndex where
-  exponent := form
-  contextMatch := fun _ => true
-  rootMatch := some (· == idx)
-  specificity := 0
+/-- The insertion bundle for root `idx` in context `c` — the ergative
+argument's number is not part of it (§3.3). -/
+def siteFeatures (c : Ctx) (idx : RootIndex) : List SiteFeature :=
+  [.root idx, .abs c.absNumber]
+
+/-- A singular-conditioned suppletive item for `idx`. -/
+private def sgEntry (form : String) (idx : RootIndex) : VocabularyItem SiteFeature String :=
+  ⟨[.root idx, .abs .sg], form⟩
+
+/-- An Elsewhere suppletive item for `idx`. -/
+private def elseEntry (form : String) (idx : RootIndex) : VocabularyItem SiteFeature String :=
+  ⟨[.root idx], form⟩
 
 /-- The Hiaki suppletive vocabulary ([harley-2014] (3), (26), (27)): three
 suppletive roots, each an sg-conditioned form competing with an Elsewhere
 form, all keyed by `RootIndex`. -/
-def vocabulary : List (VocabItem Ctx RootIndex) :=
+def vocabulary : List (VocabularyItem SiteFeature String) :=
   [ sgEntry "vuite" runRoot,  elseEntry "tenne" runRoot,
     sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
     sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
 
-instance : DecidableRel
-    (Morphology.Exponence.Applies : VocabItem Ctx RootIndex → Ctx × RootIndex → Prop) :=
-  fun vi c => inferInstanceAs (Decidable (vi.matches c.1 c.2 = true))
+/-- Spell out root `idx` in context `c` by the Subset Principle over
+`vocabulary`. -/
+def spellout (c : Ctx) (idx : RootIndex) : Option String :=
+  subsetPrinciple vocabulary (siteFeatures c idx)
 
 /-! ### Selection: the engine picks the attested form -/
 
 /-- Singular subject → `vuite` ([harley-2014] (1a)). -/
-theorem run_sg : vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot = some "vuite" := by decide
+theorem run_sg : spellout ⟨.sg, none⟩ runRoot = some "vuite" := by decide
 
 /-- Plural subject → `tenne` ([harley-2014] (1b)). -/
-theorem run_pl : vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot = some "tenne" := by decide
+theorem run_pl : spellout ⟨.pl, none⟩ runRoot = some "tenne" := by decide
 
 /-- Number-unspecified (impersonal passive) → `tenne`, the true Elsewhere
 form ([harley-2014] fn. 16): the diagnostic that `tenne`, not `vuite`, is
 Elsewhere. -/
 theorem run_impersonal :
-    vocabularyInsert vocabulary ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
+    spellout ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
 
 /-- Singular subject → `weye` ([harley-2014] (26a)). -/
-theorem walk_sg : vocabularyInsert vocabulary ⟨.sg, none⟩ walkRoot = some "weye" := by decide
+theorem walk_sg : spellout ⟨.sg, none⟩ walkRoot = some "weye" := by decide
 
 /-- Plural subject → `kaate` ([harley-2014] (26b)). -/
-theorem walk_pl : vocabularyInsert vocabulary ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
+theorem walk_pl : spellout ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
 
 /-- Singular object → `mea`, regardless of the (plural) subject
 ([harley-2014] (27a)). -/
-theorem kill_sgObj : vocabularyInsert vocabulary ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
+theorem kill_sgObj : spellout ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
 
 /-- Plural object → `sua`, regardless of the (singular) subject
 ([harley-2014] (27b)). -/
-theorem kill_plObj : vocabularyInsert vocabulary ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
+theorem kill_plObj : spellout ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
 
 /-! ### §3.3 The ergative-absolutive conditioning generalization -/
 
@@ -178,7 +184,7 @@ the external (ergative) argument's number is never consulted. This is the
 ergative-absolutive distribution of suppletive agreement — the challenge to
 [bobaljik-2008]'s marked-case generalization the paper raises. -/
 theorem suppletion_ignores_ergative (n : Number) (e e' : Option Number) (i : RootIndex) :
-    vocabularyInsert vocabulary ⟨n, e⟩ i = vocabularyInsert vocabulary ⟨n, e'⟩ i := rfl
+    spellout ⟨n, e⟩ i = spellout ⟨n, e'⟩ i := rfl
 
 /-! ### §2.1 Individuation is not phonological -/
 
@@ -187,8 +193,8 @@ phonologically unrelated exponents (`vuite` vs `tenne`). Any identification
 of the root by its phonological form would split it in two, making
 suppletion incoherent ([harley-2014] §2.2, contra Borer 2009). -/
 theorem run_index_two_forms :
-    vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot ≠
-      vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot := by decide
+    spellout ⟨.sg, none⟩ runRoot ≠
+      spellout ⟨.pl, none⟩ runRoot := by decide
 
 /-- **The suppletive rule is index-local** ([harley-2014] §2.1, Marantz's
 thought experiment): `tenne` competes only at `√322`, so it does not block
@@ -196,7 +202,7 @@ insertion at a different intransitive root — a non-suppletive `√500`
 (*bwiika* 'sing') gets no exponent from this vocabulary. This is why List-1
 roots must be individuated (as indices) before spell-out. -/
 theorem suppletive_rule_index_local (n : Number) :
-    vocabularyInsert vocabulary ⟨n, none⟩ singRoot = none := by
+    spellout ⟨n, none⟩ singRoot = none := by
   cases n <;> decide
 
 /-! ### §2.3 Individuation is not semantic: the cran-morph on the LF side
@@ -241,15 +247,15 @@ empty `interp` fiber outside the cran-morph's frame, via
 `Allosemy.toInterpreted`). The vocabulary of §2.1 is the List-2 map,
 `cahootLF` the List-3 map.
 
-The form side is `VocabItem.toRealization vocabulary` — the shared
-Exponence engine (`Exponence.realize`, argmax) as a `Realization`, whose
-fibers compute, so the same theorem lands on the same data. -/
+The form side wraps `spellout` — the shared Exponence engine
+(`Exponence.realize`, argmax) — as a `Realization`, whose fibers compute, so
+the same theorem lands on the same data. -/
 
 /-- The Hiaki suppletive vocabulary as a `Realization`: index `→` its
 Elsewhere-selected exponent as a singleton fiber, `∅` at an unlicensed
 index — the univalent stratum ([marantz-1997]'s List 2). -/
 def realization : Morphology.Realization RootIndex Ctx String :=
-  VocabItem.toRealization vocabulary
+  ⟨fun r c => (spellout c r).elim ∅ ({·})⟩
 
 /-- **Phonological individuation fails, on the carrier** ([harley-2014]
 §2.1–2.2): the Hiaki √322 realizes two nonempty, distinct fibers
@@ -258,13 +264,11 @@ the exact √GO case the predicate names. A root identified by its form would
 split here. -/
 theorem run_isProperlySuppletive : realization.IsProperlySuppletive runRoot := by
   have hsg : realization.realize runRoot ⟨.sg, none⟩ = {"vuite"} := by
-    show (match vocabularyInsert vocabulary ⟨.sg, none⟩ runRoot with
-      | some f => ({f} : Finset String) | none => ∅) = _
-    rw [run_sg]
+    show (spellout ⟨.sg, none⟩ runRoot).elim ∅ ({·}) = _
+    simp [run_sg]
   have hpl : realization.realize runRoot ⟨.pl, none⟩ = {"tenne"} := by
-    show (match vocabularyInsert vocabulary ⟨.pl, none⟩ runRoot with
-      | some f => ({f} : Finset String) | none => ∅) = _
-    rw [run_pl]
+    show (spellout ⟨.pl, none⟩ runRoot).elim ∅ ({·}) = _
+    simp [run_pl]
   refine ⟨⟨.sg, none⟩, ⟨.pl, none⟩, hsg ▸ Finset.singleton_nonempty _,
     hpl ▸ Finset.singleton_nonempty _, ?_⟩
   rw [hsg, hpl, ne_eq, Finset.singleton_inj]; decide

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -46,25 +46,30 @@ def copulaVI (voice : Head) : CopulaForm :=
   if voice.hasD && voice.flavor != .nonThematic && voice.flavor != .passive
   then .have else .be
 
-open DistributedMorphology in
-/-- The copula VI as competing `VocabItem`s (HAVE specificity 2, BE elsewhere). -/
-def copulaVIRules : List (VocabItem Head Unit) :=
-  [ { exponent := "have"
-    , contextMatch := λ v => v.hasD && v.flavor != .nonThematic && v.flavor != .passive
-    , specificity := 2 }
-  , { exponent := "be", contextMatch := λ _ => true, specificity := 0 } ]
+/-- The Voice features the copula's insertion context exposes: [D] and a
+thematic, non-passive flavor — Voice_{D},φ of [myler-2016] (89). -/
+inductive VoiceFeature where
+  | d
+  | thematic
+  deriving DecidableEq, Repr
+
+/-- The copula's context bundle for a Voice head. -/
+def voiceFeatures (v : Head) : List VoiceFeature :=
+  (if v.hasD then [.d] else []) ++
+    (if v.flavor ≠ .nonThematic ∧ v.flavor ≠ .passive then [.thematic] else [])
 
 open DistributedMorphology in
-/-- The `VocabItem` formulation agrees with `copulaVI`. -/
+/-- The copula items: HAVE for transitive Voice, BE elsewhere. -/
+def copulaVIRules : List (VocabularyItem VoiceFeature String) :=
+  [⟨[.d, .thematic], "have"⟩, ⟨[], "be"⟩]
+
+open DistributedMorphology in
+/-- The Subset Principle over `copulaVIRules` agrees with `copulaVI`. -/
 theorem copulaVI_agrees_vocabItem (v : Head) :
-    vocabularyInsertSimple copulaVIRules v =
-    some (if copulaVI v = .have then "have" else "be") := by
-  cases v with | mk flavor hasD _ checksCase features =>
-  cases flavor <;> cases hasD <;> cases checksCase <;>
-  simp [copulaVI, copulaVIRules, vocabularyInsertSimple, vocabularyInsert,
-    VocabItem.matches, Morphology.Exponence.realize, Morphology.Exponence.selectBy,
-    Morphology.Exponence.applicable, Morphology.Exponence.Applies,
-    Morphology.Exponence.exponent, List.argmax, List.argAux]
+    subsetPrinciple copulaVIRules (voiceFeatures v) =
+      some (if copulaVI v = .have then "have" else "be") := by
+  cases v with | mk flavor hasD _ _ _ =>
+  cases flavor <;> cases hasD <;> rfl
 
 /-- HAVE ↔ Voice is transitive (external argument, not PF-only, not passive). -/
 theorem vi_characterization (v : Head) :
@@ -150,38 +155,32 @@ theorem hafa_iff_pred (dp : IcelandicPossDP) :
     icelandicHaveVI dp = .hafa ↔ dp.hasPredP = true := by
   cases dp with | mk p pp => cases p <;> simp [icelandicHaveVI]
 
--- ─── VocabItem formulation (parallel to copulaVIRules) ───
+-- ─── Vocabulary-item formulation (parallel to copulaVIRules) ───
+
+/-- The DP-internal feature the Icelandic HAVE items see: a PredP. -/
+inductive PossDPFeature where
+  | predP
+  deriving DecidableEq, Repr
+
+/-- The insertion bundle for a possessive DP; the PP-possessor option is
+never consulted. -/
+def possDPFeatures (dp : IcelandicPossDP) : List PossDPFeature :=
+  if dp.hasPredP then [.predP] else []
 
 open DistributedMorphology in
-
-/-- Icelandic HAVE VI as proper `VocabItem`s from the DM framework.
-
-    Two items compete via the Elsewhere Condition:
-    - *hafa*: specificity 1 (checks hasPredP = true)
-    - *eiga*: specificity 0 (elsewhere — matches any transitive context)
-
-    This parallels `copulaVIRules` for the English HAVE/BE alternation,
-    but applies within the HAVE domain: both *hafa* and *eiga* realize
-    transitive Voice, differing only in the DP-internal structure. -/
-def icelandicHaveVIRules : List (VocabItem IcelandicPossDP Unit) :=
-  [ { exponent := "hafa"
-    , contextMatch := fun dp => dp.hasPredP
-    , specificity := 1 }
-  , { exponent := "eiga"
-    , contextMatch := fun _ => true
-    , specificity := 0 } ]
+/-- Icelandic HAVE items: *hafa* on a PredP, *eiga* elsewhere — parallel to
+`copulaVIRules` but within the HAVE domain, where both realize transitive
+Voice and differ only in DP-internal structure. -/
+def icelandicHaveVIRules : List (VocabularyItem PossDPFeature String) :=
+  [⟨[.predP], "hafa"⟩, ⟨[], "eiga"⟩]
 
 open DistributedMorphology in
-
-/-- The VocabItem formulation agrees with the direct `icelandicHaveVI`. -/
+/-- The Subset Principle over `icelandicHaveVIRules` agrees with
+`icelandicHaveVI`. -/
 theorem icelandicVI_agrees_vocabItem (dp : IcelandicPossDP) :
-    vocabularyInsertSimple icelandicHaveVIRules dp =
-    some (if icelandicHaveVI dp = .hafa then "hafa" else "eiga") := by
-  cases dp with | mk p pp => cases p <;> cases pp <;>
-  simp [icelandicHaveVI, icelandicHaveVIRules, vocabularyInsertSimple,
-    vocabularyInsert, VocabItem.matches, Morphology.Exponence.realize,
-    Morphology.Exponence.selectBy, Morphology.Exponence.applicable,
-    Morphology.Exponence.Applies, Morphology.Exponence.exponent, List.argmax, List.argAux]
+    subsetPrinciple icelandicHaveVIRules (possDPFeatures dp) =
+      some (if icelandicHaveVI dp = .hafa then "hafa" else "eiga") := by
+  cases dp with | mk p pp => cases p <;> cases pp <;> rfl
 
 -- ════════════════════════════════════════════════════
 -- § 2. The Two Puzzles, Solved

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -1,7 +1,7 @@
 import Linglib.Syntax.RelativeClause.Basic
 import Linglib.Syntax.Tree.Cat
 import Linglib.Fragments.Swahili.Relativization
-import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.FeatureBundle
 import Linglib.Syntax.Minimalist.Features
 
 /-!
@@ -47,7 +47,7 @@ categories (D, Num, n, Pers).
 
 ## Vocabulary Insertion (FeatureBundle-Based)
 
-Uses `Minimalist.FeatureBundle` and `DistributedMorphology.vocabularyInsertSimple`
+Uses `Minimalist.FeatureBundle` and `Minimalist.spellout`
 from the DM theory module. The Elsewhere Condition is structural: person-
 specified rules (specificity 3) beat personless defaults (specificity 2).
 Chain reduction removes person features from the bundle, so only the
@@ -235,12 +235,6 @@ def hasPerson (fb : FeatureBundle) : Bool :=
     | .valued (.phi (.person _)) => true
     | _ => false
 
-/-- Helper: extract the person level if present. -/
-def getPerson (fb : FeatureBundle) : Option Person :=
-  (Minimalist.FeatureBundle.toGramFeatures fb).findSome? fun f => match f with
-    | .valued (.phi (.person p)) => some p
-    | _ => none
-
 /-- Helper: is the number singular? -/
 def isSg (fb : FeatureBundle) : Bool :=
   (Minimalist.FeatureBundle.toGramFeatures fb).any fun f => match f with
@@ -253,42 +247,26 @@ def isAnim (fb : FeatureBundle) : Bool :=
     | .valued (.phi (.gender 1)) => true
     | _ => false
 
-/-- Swahili resumptive VI rules using the DM `VocabItem` type.
-    [scott-2021]. Person-specified rules have specificity 3
-    (checking 3 features); personless defaults have specificity 2.
-    The Elsewhere Condition in `vocabularyInsertSimple` picks the most
-    specific matching rule. -/
-def resumptiveVIRules : List (DistributedMorphology.VocabItem FeatureBundle Unit) :=
-  [ -- [PERS: 1, GEN: ANIM, NUM: SG] ↔ -mi
-    { exponent := "-mi"
-    , contextMatch := fun fb => getPerson fb == some .first && isAnim fb && isSg fb
-    , specificity := 3 }
-  , -- [PERS: 1, GEN: ANIM, NUM: PL] ↔ -si
-    { exponent := "-si"
-    , contextMatch := fun fb => getPerson fb == some .first && isAnim fb && !isSg fb
-    , specificity := 3 }
-  , -- [PERS: 2, GEN: ANIM, NUM: SG] ↔ -we
-    { exponent := "-we"
-    , contextMatch := fun fb => getPerson fb == some .second && isAnim fb && isSg fb
-    , specificity := 3 }
-  , -- [PERS: 2, GEN: ANIM, NUM: PL] ↔ -nyi
-    { exponent := "-nyi"
-    , contextMatch := fun fb => getPerson fb == some .second && isAnim fb && !isSg fb
-    , specificity := 3 }
-  , -- [GEN: ANIM, NUM: SG] ↔ -ye (default animate sg)
-    { exponent := "-ye"
-    , contextMatch := fun fb => isAnim fb && isSg fb
-    , specificity := 2 }
-  , -- [GEN: ANIM, NUM: PL] ↔ -o (default animate pl)
-    { exponent := "-o"
-    , contextMatch := fun fb => isAnim fb && !isSg fb
-    , specificity := 2 }
-  ]
+/-- Swahili resumptive Vocabulary Items ([scott-2021]): person-specified
+entries and personless animate defaults, competing by the Subset Principle. -/
+def resumptiveVocab : Minimalist.Vocabulary :=
+  let entry (fs : List Minimalist.GramFeature) (e : String) : Minimalist.VocabEntry :=
+    { features := Minimalist.FeatureBundle.ofGramFeatures fs, exponent := e }
+  [ entry [.valued (.phi (.person .first)), .valued (.phi (.gender 1)),
+      .valued (.phi (.number .singular))] "-mi",
+    entry [.valued (.phi (.person .first)), .valued (.phi (.gender 1)),
+      .valued (.phi (.number .plural))] "-si",
+    entry [.valued (.phi (.person .second)), .valued (.phi (.gender 1)),
+      .valued (.phi (.number .singular))] "-we",
+    entry [.valued (.phi (.person .second)), .valued (.phi (.gender 1)),
+      .valued (.phi (.number .plural))] "-nyi",
+    entry [.valued (.phi (.gender 1)), .valued (.phi (.number .singular))] "-ye",
+    entry [.valued (.phi (.gender 1)), .valued (.phi (.number .plural))] "-o" ]
 
-/-- Insert the correct resumptive exponent for a feature bundle
-    using the DM Elsewhere Condition. -/
+/-- Insert the resumptive exponent for a feature bundle by the Subset
+Principle, defaulting to *-ye*. -/
 def insertResumptive (fb : FeatureBundle) : String :=
-  (DistributedMorphology.vocabularyInsertSimple resumptiveVIRules fb).getD "-ye"
+  (Minimalist.spellout resumptiveVocab fb none).getD "-ye"
 
 -- ============================================================================
 -- § 6: Chain Reduction Pipeline

--- a/Linglib/Syntax/Minimalist/MinimalPronoun.lean
+++ b/Linglib/Syntax/Minimalist/MinimalPronoun.lean
@@ -71,9 +71,9 @@ inductive BVAContext where
     Vocabulary items are ordered by specificity. When multiple items could
     apply, the most specific (first in the list) wins.
 
-    This is a specialization of the general DM `DistributedMorphology.VocabItem`
-    in `Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean`, restricted to
-    `BVAContext` matching with a parameterized `Form` type. -/
+    This is a specialization of DM's `DistributedMorphology.VocabularyItem`: a
+    single `BVAContext` feature matched exactly, with a parameterized `Form`
+    type. -/
 structure VocabItem (Form : Type) where
   /-- The syntactic context this item is restricted to -/
   context : BVAContext


### PR DESCRIPTION
The opaque-predicate `VocabItem` (`String` exponent, `Bool` context and root predicates, hand-stipulated rank) is deleted; every consumer now states its Vocabulary Items as `VocabularyItem`s over a paper-specific feature alphabet, so one engine remains and the Elsewhere winner is derived rather than assumed.

- `VocabularyItem` moves to `Defs.lean` and its `Exponence.Rule` instance, `le_iff`, and `specificity_strictAnti` to `Basic.lean`, mirroring `AllosemicEntry`; `VocabularyInsertion/Basic.lean` keeps only the Subset Principle.
- HalleMarantz1993 (root classes as contextual features), Adamson2024 (Teop article bundle, now proved to reproduce the Fragment's `articleForm` table), Aitha2026, Myler2016, Harley2014 migrate; Scott2021's Swahili resumptives become `Minimalist.VocabEntry`s.