### PR TITLE
refactor(Studies/Harley2014): indices, local conditioning, caboodle frame

### DIFF
--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -6,298 +6,265 @@ Authors: Robert Hawkins
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Linglib.Morphology.DistributedMorphology.Allosemy
 import Linglib.Morphology.Root.Certificates
+import Linglib.Features.Number.Basic
+import Linglib.Semantics.ArgumentStructure.Valency
+import Linglib.Studies.Marantz1991
 
 /-!
-# Harley (2014): roots as abstract indices
-[harley-2014] [marantz-1997] [halle-marantz-1993] [bobaljik-2008]
+# On the identity of roots
 
-[harley-2014] "On the identity of roots" argues that a root terminal
-(DM's List 1) is neither phonologically nor semantically individuated: it
-is an **abstract index**, a syntactic atom identified only by its position
-in the vocabulary, with its form supplied by List 2 (Vocabulary Insertion)
-and its meaning by List 3 (the Encyclopedia). The argument is negative on
-both flanks:
+[harley-2014] argues that a root terminal of List 1 is individuated neither by
+its form nor by its meaning but by an index. Hiaki root suppletion (√322:
+*vuite*~*tenne* 'run') shows that roots must already be distinct when their
+Vocabulary Items compete, and that phonologically individuated roots would
+turn suppletion into rewriting; caboodle items (*cahoot*) show that List-3
+interpretation can be bound to one frame with no Elsewhere, so a root is not
+a concept either. What remains is the index, on which List 2 and List 3 are
+both keyed.
 
-* **Phonological identification fails** (§2.1–2.2). Hiaki has suppletive
-  roots — one root, two phonologically unrelated forms competing under the
-  Elsewhere Condition. If a root were identified by its phonology (√kæt),
-  root suppletion would be incoherent.
-* **Semantic identification fails** (§2.3–2.4). Cran-morphs (*cahoot*) have
-  a meaning only inside one licensing frame and none elsewhere, so a root
-  cannot be a Fodorian atomic concept either.
+## Main definitions
 
-What survives is the **index**: `RootIndex := ℕ` here, a `√322`-style
-meaningless tag. Distinctness of roots is then true by typing — distinct
-indices are distinct roots — which is exactly what lets `√tenne` block
-`√vuite` at *its* index without blocking a different intransitive root
-(§2.1, Marantz's thought experiment).
+* `Clause`, `siteFeatures`: the number at each core-argument position
+  (`ArgumentStructure.ArgPosition`), and a suppletive root's insertion site —
+  its index and the number of the internal argument, the local conditioning
+  environment of §3.3.
+* `vocabulary`: the Hiaki items of (3a), (3f), (3g): a singular-conditioned
+  form and an Elsewhere form per root ((14), fn. 16).
+* `cahootLF`: the List-3 entry of (16), one frame and no Elsewhere.
+* `realization`: List 2 as a `Morphology.Realization`.
 
-## This file
+## Main results
 
-* `vocabulary` — the Hiaki suppletive List-2 entries ([harley-2014] (3),
-  (26), (27)), keyed by `RootIndex`, resolved by the Subset Principle
-  (`DistributedMorphology.subsetPrinciple`).
-* Selection theorems — the engine picks the attested form per context.
-* `suppletion_ignores_ergative` — the §3.3 ergative-absolutive
-  generalization: suppletion tracks the **internal (absolutive)**
-  argument's number and is blind to the external (ergative) argument.
-* `run_index_two_forms` — one index, two exponents: phonological
-  individuation would split the root (§2.1–2.2).
-* `cahoot_no_elsewhere` — the cran-morph has an interpretation only in its
-  licensing context and none elsewhere (§2.3), stated on the LF side with
-  the allosemy exponence engine (`selectBy`, `no Elsewhere` = `none`).
+* `run_isProperlySuppletive`, `run_hasSuppletiveCore`: one index, two
+  unrelated forms — individuation is not phonological (§2.2).
+* `cahoot_interp_gap`: interpreted in its frame, uninterpreted elsewhere —
+  individuation is not semantic (§2.3).
+* `suppletion_not_agreement`: conditioning by the internal argument is an
+  ergative–absolutive pattern in a nominative–accusative language, which
+  [bobaljik-2008]'s generalization rules out for agreement, so it is local
+  Vocabulary-Item competition rather than agreement (§3.3).
+* `index_local`: a suppletive item blocks nothing at another index — the
+  thought experiment of §2.1.
+* `intransitive_isRootValency`: the conditioning argument of an intransitive
+  occupies the root's valency — the paper's prediction that the intransitive
+  suppletive verbs are unaccusative.
 
-## The `vuite`/`tenne` Elsewhere direction (fn. 16)
+## Implementation notes
 
-The paper's first pass (7) writes the plural `tenne` as the *conditioned*
-form (`/ [DP-pl]`) and `vuite` as Elsewhere. Footnote 16 corrects this: in
-the Hiaki impersonal passive the sole argument is syntactically absent and
-so number-unspecified, and the root then surfaces as `tenne`, **not** as
-singular `vuite`. So `tenne` is the true Elsewhere form and `vuite` is
-conditioned by a singular internal argument. We encode the considered (fn.
-16) analysis: `vuite / [absolutive-sg]`, `tenne` elsewhere (plural *and*
-number-unspecified).
+Footnote 16 settles the Elsewhere direction: the impersonal passive, whose
+argument is syntactically absent, surfaces as *tenne*, so *tenne* is the
+Elsewhere form and *vuite* is conditioned by a singular internal argument;
+(7) is the paper's first pass with the roles reversed. The paper indexes only
+√322 and √548; the other indices here are arbitrary distinct ones. The
+caboodle frame of (16), `[in [[√ n]nP -PL]DP]PP`, is recorded by its
+categorizing head.
 -/
 
 namespace Harley2014
 
-open DistributedMorphology
+open DistributedMorphology ArgumentStructure
 open DistributedMorphology.Allosemy (SyntacticContext AllosemicEntry toInterpreted)
-open Morphology.Exponence (selectBy realize)
+open Morphology.Exponence (selectBy)
 
-/-! ### List 1: roots as abstract indices -/
+/-! ### List 1: roots as indices -/
 
-/-- A List-1 root index: a meaningless `√`-style tag ([harley-2014] §2.4).
-Individuation is by index alone — distinct indices, distinct roots — so
-the phonological form (List 2) and the interpretation (List 3) are free to
-vary without identifying the root. -/
-abbrev RootIndex := ℕ
+/-- √322, realized *vuite*~*tenne* 'run' ((3a), (14)). -/
+def run : Root := ⟨322⟩
 
-/-- `√322`: the Hiaki root realized `vuite`/`tenne` 'run' ([harley-2014] (14)). -/
-def runRoot : RootIndex := 322
-/-- `√401`: the root realized `weye`/`kaate` 'walk' ([harley-2014] (26)). -/
-def walkRoot : RootIndex := 401
-/-- `√402`: the root realized `mea`/`sua` 'kill' ([harley-2014] (27)). -/
-def killRoot : RootIndex := 402
-/-- `√500`: a non-suppletive intransitive root ('sing', *bwiika*), used to
-show the suppletive rules do not block insertion at other indices. -/
-def singRoot : RootIndex := 500
+/-- The root realized *weye*~*kaate* 'walk' ((3f), (26)). -/
+def walk : Root := ⟨401⟩
 
-/-! ### The conditioning context
+/-- The root realized *mea*~*sua* 'kill' ((3g), (27)). -/
+def kill : Root := ⟨402⟩
 
-Suppletion is conditioned by number, but — crucially for §3.3 — by the
-number of the **absolutive** (internal) argument: the sole argument of an
-intransitive, the object of a transitive. The ergative (external) argument
-never conditions it. -/
+/-- A non-suppletive intransitive root, *bwiika* 'sing', at whose index the
+suppletive items must not compete (§2.1). -/
+def sing : Root := ⟨500⟩
 
-/-- Grammatical number of an argument. `unspecified` is the number-neutral
-case of [harley-2014] fn. 16 (the impersonal passive), which surfaces as
-the Elsewhere form. -/
-inductive Number where
-  | sg
-  | pl
-  | unspecified
-  deriving DecidableEq, Repr
+/-! ### The insertion site -/
 
-/-- The morphosyntactic context a suppletive root is spelled out in: the
-number of its absolutive (internal) argument, plus — for a transitive —
-the number of its ergative (external) argument, which is never consulted. -/
-structure Ctx where
-  /-- Number of the absolutive (internal) argument — the conditioning one. -/
-  absNumber : Number
-  /-- Number of the ergative (external) argument, `none` if intransitive.
-      Never conditions suppletion (§3.3). -/
-  ergNumber : Option Number := none
-  deriving DecidableEq, Repr
+/-- The number borne at each core-argument position of a clause, `none` where
+the position is unfilled. -/
+abbrev Clause := ArgPosition → Option Number
 
-/-! ### List 2: the suppletive Vocabulary Items
+/-- An intransitive clause whose sole argument, of number `n`, is internal. -/
+def intransitive (n : Number) : Clause
+  | .internal => some n
+  | .external => none
 
-Each root index has a singular-conditioned item and an Elsewhere item; the
-Subset Principle selects the more specific applicable one. -/
+/-- A transitive clause with an internal argument of number `obj` and an
+external one of number `subj`. -/
+def transitive (obj subj : Number) : Clause
+  | .internal => some obj
+  | .external => some subj
 
-/-- Features at a suppletive root's insertion site: the root's index and the
-number of its absolutive argument. -/
+/-- The impersonal passive: no number-bearing argument (fn. 16). -/
+def impersonal : Clause := fun _ => none
+
+/-- The positions a clause fills. -/
+def Clause.valency (c : Clause) : Valency := Finset.univ.filter fun p => (c p).isSome
+
+/-- Features at a suppletive root's insertion site: its index and the number
+of the internal argument. -/
 inductive SiteFeature where
-  | root (idx : RootIndex)
-  | abs (n : Number)
+  | root (r : Root)
+  | internal (n : Number)
   deriving DecidableEq, Repr
 
-/-- The insertion bundle for root `idx` in context `c` — the ergative
-argument's number is not part of it (§3.3). -/
-def siteFeatures (c : Ctx) (idx : RootIndex) : List SiteFeature :=
-  [.root idx, .abs c.absNumber]
+/-- The insertion bundle for root `r` in clause `c`: the external argument
+is not in the local environment (§3.3). -/
+def siteFeatures (c : Clause) (r : Root) : List SiteFeature :=
+  .root r :: ((c .internal).map .internal).toList
 
-/-- A singular-conditioned suppletive item for `idx`. -/
-private def sgEntry (form : String) (idx : RootIndex) : VocabularyItem SiteFeature String :=
-  ⟨[.root idx, .abs .sg], form⟩
+/-! ### List 2: the suppletive Vocabulary Items -/
 
-/-- An Elsewhere suppletive item for `idx`. -/
-private def elseEntry (form : String) (idx : RootIndex) : VocabularyItem SiteFeature String :=
-  ⟨[.root idx], form⟩
+/-- A suppletive root's two items: the form conditioned by a singular
+internal argument and the Elsewhere form ((14), fn. 16). -/
+def suppletive (r : Root) (sgForm elseForm : String) : List (VocabularyItem SiteFeature String) :=
+  [⟨[.root r, .internal .singular], sgForm⟩, ⟨[.root r], elseForm⟩]
 
-/-- The Hiaki suppletive vocabulary ([harley-2014] (3), (26), (27)): three
-suppletive roots, each an sg-conditioned form competing with an Elsewhere
-form, all keyed by `RootIndex`. -/
+/-- The Hiaki suppletive vocabulary of (3a), (3f), (3g). -/
 def vocabulary : List (VocabularyItem SiteFeature String) :=
-  [ sgEntry "vuite" runRoot,  elseEntry "tenne" runRoot,
-    sgEntry "weye"  walkRoot, elseEntry "kaate" walkRoot,
-    sgEntry "mea"   killRoot, elseEntry "sua"   killRoot ]
+  suppletive run "vuite" "tenne" ++ suppletive walk "weye" "kaate" ++ suppletive kill "mea" "sua"
 
-/-- Spell out root `idx` in context `c` by the Subset Principle over
+/-- Spell out root `r` in clause `c` by the Subset Principle over
 `vocabulary`. -/
-def spellout (c : Ctx) (idx : RootIndex) : Option String :=
-  subsetPrinciple vocabulary (siteFeatures c idx)
+def spellout (c : Clause) (r : Root) : Option String :=
+  subsetPrinciple vocabulary (siteFeatures c r)
 
-/-! ### Selection: the engine picks the attested form -/
+/-- Singular subject → *vuite* ((6a)). -/
+theorem run_sg : spellout (intransitive .singular) run = some "vuite" := by decide
 
-/-- Singular subject → `vuite` ([harley-2014] (1a)). -/
-theorem run_sg : spellout ⟨.sg, none⟩ runRoot = some "vuite" := by decide
+/-- Plural subject → *tenne* ((6b)). -/
+theorem run_pl : spellout (intransitive .plural) run = some "tenne" := by decide
 
-/-- Plural subject → `tenne` ([harley-2014] (1b)). -/
-theorem run_pl : spellout ⟨.pl, none⟩ runRoot = some "tenne" := by decide
+/-- No number-bearing argument (the impersonal passive) → *tenne*, the
+Elsewhere form (fn. 16). -/
+theorem run_impersonal : spellout impersonal run = some "tenne" := by decide
 
-/-- Number-unspecified (impersonal passive) → `tenne`, the true Elsewhere
-form ([harley-2014] fn. 16): the diagnostic that `tenne`, not `vuite`, is
-Elsewhere. -/
-theorem run_impersonal :
-    spellout ⟨.unspecified, none⟩ runRoot = some "tenne" := by decide
+/-- *weye*/*kaate* with a singular/plural subject ((26)). -/
+theorem walk_sg_pl :
+    spellout (intransitive .singular) walk = some "weye" ∧
+      spellout (intransitive .plural) walk = some "kaate" := by
+  decide
 
-/-- Singular subject → `weye` ([harley-2014] (26a)). -/
-theorem walk_sg : spellout ⟨.sg, none⟩ walkRoot = some "weye" := by decide
+/-- *mea*/*sua* with a singular/plural object, whatever the subject ((27)). -/
+theorem kill_sgObj_plObj :
+    spellout (transitive .singular .plural) kill = some "mea" ∧
+      spellout (transitive .plural .singular) kill = some "sua" := by
+  decide
 
-/-- Plural subject → `kaate` ([harley-2014] (26b)). -/
-theorem walk_pl : spellout ⟨.pl, none⟩ walkRoot = some "kaate" := by decide
+/-! ### §2.1–2.2 Individuation is not phonological -/
 
-/-- Singular object → `mea`, regardless of the (plural) subject
-([harley-2014] (27a)). -/
-theorem kill_sgObj : spellout ⟨.sg, some .pl⟩ killRoot = some "mea" := by decide
+/-- One index, two phonologically unrelated forms: a root identified by its
+form would split √322 in two (§2.2). -/
+theorem run_two_forms :
+    spellout (intransitive .singular) run ≠ spellout (intransitive .plural) run := by
+  decide
 
-/-- Plural object → `sua`, regardless of the (singular) subject
-([harley-2014] (27b)). -/
-theorem kill_plObj : spellout ⟨.pl, some .sg⟩ killRoot = some "sua" := by decide
+/-- The suppletive items compete only at their own index: a non-suppletive
+intransitive root receives no exponent from `vocabulary` — why List-1 roots
+must be distinct before spell-out (§2.1). -/
+theorem index_local (c : Clause) : spellout c sing = none := by
+  unfold spellout siteFeatures
+  rcases h : c .internal with _ | n
+  · rfl
+  · cases n <;> rfl
 
-/-! ### §3.3 The ergative-absolutive conditioning generalization -/
+/-! ### §3.3 Conditioning by the internal argument -/
 
-/-- **Suppletion tracks the absolutive argument** ([harley-2014] §3.3): the
-selected form depends only on the internal (absolutive) argument's number;
-the external (ergative) argument's number is never consulted. This is the
-ergative-absolutive distribution of suppletive agreement — the challenge to
-[bobaljik-2008]'s marked-case generalization the paper raises. -/
-theorem suppletion_ignores_ergative (n : Number) (e e' : Option Number) (i : RootIndex) :
-    spellout ⟨n, e⟩ i = spellout ⟨n, e'⟩ i := rfl
+/-- The external argument's number never conditions the form. -/
+theorem suppletion_ignores_external (obj subj subj' : Number) (r : Root) :
+    spellout (transitive obj subj) r = spellout (transitive obj subj') r := rfl
 
-/-! ### §2.1 Individuation is not phonological -/
+/-- The conditioning argument of an intransitive occupies the root's valency
+([coon-2019]'s division of labor): the intransitive suppletive verbs are
+unaccusative, the paper's prediction from locality. -/
+theorem intransitive_isRootValency (n : Number) : (intransitive n).valency.IsRootValency := by
+  revert n; decide
 
-/-- **One index, two forms.** The single root `√322` is realized by two
-phonologically unrelated exponents (`vuite` vs `tenne`). Any identification
-of the root by its phonological form would split it in two, making
-suppletion incoherent ([harley-2014] §2.2, contra Borer 2009). -/
-theorem run_index_two_forms :
-    spellout ⟨.sg, none⟩ runRoot ≠
-      spellout ⟨.pl, none⟩ runRoot := by decide
+/-- Which arguments condition Hiaki suppletion, read off `spellout`: the sole
+argument of an intransitive and the object of a transitive, not the
+transitive subject. -/
+def conditioningPattern : Minimalist.AgreementPattern where
+  sAgrees := spellout (intransitive .singular) run != spellout (intransitive .plural) run
+  aAgrees := spellout (transitive .singular .singular) kill !=
+    spellout (transitive .singular .plural) kill
+  pAgrees := spellout (transitive .singular .singular) kill !=
+    spellout (transitive .plural .singular) kill
 
-/-- **The suppletive rule is index-local** ([harley-2014] §2.1, Marantz's
-thought experiment): `tenne` competes only at `√322`, so it does not block
-insertion at a different intransitive root — a non-suppletive `√500`
-(*bwiika* 'sing') gets no exponent from this vocabulary. This is why List-1
-roots must be individuated (as indices) before spell-out. -/
-theorem suppletive_rule_index_local (n : Number) :
-    spellout ⟨n, none⟩ singRoot = none := by
-  cases n <;> decide
+/-- Suppletion follows an ergative–absolutive distribution. -/
+theorem conditioningPattern_isErgAbs : conditioningPattern.isErgAbs = true := by decide
 
-/-! ### §2.3 Individuation is not semantic: the cran-morph on the LF side
+/-- **Suppletion is not agreement**: Hiaki case is nominative–accusative
+((29)), and no agreement threshold over nominative–accusative case yields
+an ergative–absolutive pattern (`Minimalist.nomAcc_no_ergAbs_agreement`,
+[bobaljik-2008]'s generalization) — so the pattern is local Vocabulary-Item
+competition, conditioned by the internal argument. -/
+theorem suppletion_not_agreement (t : Minimalist.CaseAccessibility) :
+    Minimalist.agreementFromThreshold Minimalist.nomAcc t ≠ conditioningPattern := by
+  intro h
+  have := Minimalist.nomAcc_no_ergAbs_agreement t
+  rw [h, conditioningPattern_isErgAbs] at this
+  exact Bool.noConfusion this
 
-The mirror argument on List 3. A cran-morph (*cahoot*) has an interpretation
-only inside its licensing frame (`in [ [ √ n ] -PL ]`) and — unlike an
-ordinary root — **no Elsewhere interpretation** ([harley-2014] (16)). We
-state this with the allosemy exponence engine (`AllosemicEntry` as an
-`Morphology.Exponence.Rule` instance): `selectBy` returns a meaning in the
-licensed context and `none` outside it. -/
+/-! ### §2.3 Individuation is not semantic: the caboodle item -/
 
-/-- `√548` *cahoot*: a single LF entry, licensed only under `n` (the idiom
-frame), with no Elsewhere alloseme ([harley-2014] (16)). -/
+/-- √548 *cahoot* ((16)). -/
+def cahoot : Root := ⟨548⟩
+
+/-- The List-3 entry of √548: "a conspiracy" in the frame of (16), recorded by
+its categorizing head, and no Elsewhere. -/
 def cahootLF : List (AllosemicEntry String) :=
-  [ { denotation := "a conspiracy", context := { belowCat := some .n } } ]
+  [{ denotation := "a conspiracy", context := { aboveCat := some .n } }]
 
-/-- In its licensing context the cran-morph is interpreted. -/
-theorem cahoot_licensed :
-    (selectBy AllosemicEntry.score cahootLF { belowCat := some .n }).isSome = true := by decide
+/-- Outside its frame the caboodle item has no interpretation. The paper adds
+that no List-3 entry could be a true Elsewhere, since an interpretation must
+compose with its sister's type; caboodle items make the absence visible. -/
+theorem cahoot_no_elsewhere : selectBy AllosemicEntry.score cahootLF {} = none := by decide
 
-/-- **No Elsewhere interpretation** ([harley-2014] (16)): outside the
-licensing frame the cran-morph receives no meaning at all — the LF engine
-returns `none`, the semantic analogue of a phonological gap. A Fodorian
-atomic concept could not behave this way, so the root is not semantically
-individuated. -/
-theorem cahoot_no_elsewhere :
-    (selectBy AllosemicEntry.score cahootLF { }).isNone = true := by decide
+/-! ### Both flanks on the `Realization` carrier
 
-/-! ### The surviving individuation: the index -/
+Form varies across contexts (`IsProperlySuppletive`), meaning does not vary
+but gaps (an empty `interp` fiber outside the frame, via
+`Allosemy.toInterpreted`): `vocabulary` is the List-2 map, `cahootLF` the
+List-3 map. -/
 
-/-- Individuation by index is true by typing: distinct suppletive roots are
-distinct `RootIndex` values ([harley-2014] §2.4). Neither the shared
-Elsewhere-form shape nor the shared interpretation-frame identifies them. -/
-example : runRoot ≠ walkRoot ∧ walkRoot ≠ killRoot ∧ runRoot ≠ killRoot := by decide
-
-/-! ### Both individuation-failure arguments on the shared `Realization` carrier
-
-The two negative flanks (§2.1–2.2 phonological, §2.3 semantic) are the
-constancy pair of `Morphology.Realization` at one index: form varies across
-contexts (`IsProperlySuppletive`), meaning does not vary but *gaps* (an
-empty `interp` fiber outside the cran-morph's frame, via
-`Allosemy.toInterpreted`). The vocabulary of §2.1 is the List-2 map,
-`cahootLF` the List-3 map.
-
-The form side wraps `spellout` — the shared Exponence engine
-(`Exponence.realize`, argmax) — as a `Realization`, whose fibers compute, so
-the same theorem lands on the same data. -/
-
-/-- The Hiaki suppletive vocabulary as a `Realization`: index `→` its
-Elsewhere-selected exponent as a singleton fiber, `∅` at an unlicensed
-index — the univalent stratum ([marantz-1997]'s List 2). -/
-def realization : Morphology.Realization RootIndex Ctx String :=
+/-- List 2 as a `Realization`: a root's Elsewhere-selected exponent as a
+singleton fiber, `∅` at an index with no item. -/
+def realization : Morphology.Realization Root Clause String :=
   ⟨fun r c => (spellout c r).elim ∅ ({·})⟩
 
-/-- **Phonological individuation fails, on the carrier** ([harley-2014]
-§2.1–2.2): the Hiaki √322 realizes two nonempty, distinct fibers
-(`vuite` / `tenne`) across two licensed contexts — `IsProperlySuppletive`,
-the exact √GO case the predicate names. A root identified by its form would
-split here. -/
-theorem run_isProperlySuppletive : realization.IsProperlySuppletive runRoot := by
-  have hsg : realization.realize runRoot ⟨.sg, none⟩ = {"vuite"} := by
-    show (spellout ⟨.sg, none⟩ runRoot).elim ∅ ({·}) = _
+/-- √322 realizes two nonempty, distinct fibers across two licensed clauses —
+the *go*/*went* case the predicate names (§2.2). -/
+theorem run_isProperlySuppletive : realization.IsProperlySuppletive run := by
+  have hsg : realization.realize run (intransitive .singular) = {"vuite"} := by
+    show (spellout (intransitive .singular) run).elim ∅ ({·}) = _
     simp [run_sg]
-  have hpl : realization.realize runRoot ⟨.pl, none⟩ = {"tenne"} := by
-    show (spellout ⟨.pl, none⟩ runRoot).elim ∅ ({·}) = _
+  have hpl : realization.realize run (intransitive .plural) = {"tenne"} := by
+    show (spellout (intransitive .plural) run).elim ∅ ({·}) = _
     simp [run_pl]
-  refine ⟨⟨.sg, none⟩, ⟨.pl, none⟩, hsg ▸ Finset.singleton_nonempty _,
+  refine ⟨intransitive .singular, intransitive .plural, hsg ▸ Finset.singleton_nonempty _,
     hpl ▸ Finset.singleton_nonempty _, ?_⟩
   rw [hsg, hpl, ne_eq, Finset.singleton_inj]; decide
 
-/-- **√322 is a suppletive-core root, not merely affixally inflected**
-([harley-2014] §2.1): under the monomorphemic-form core extraction (a whole
-exponent is its own core), `vuite`/`tenne` alternate at the core itself — the
-`go`/`went` case of `Morphology.Root.HasSuppletiveCore`, the certificate axis
-that distinguishes true suppletion from `cat`/`cats` inflection. -/
-theorem run_hasSuppletiveCore :
-    Morphology.Root.HasSuppletiveCore realization (fun s => {s}) runRoot :=
-  (Morphology.Root.hasSuppletiveCore_singleton realization runRoot).mpr
+/-- Under the identity core-extraction, *vuite*/*tenne* alternate at the core
+itself — `Morphology.Root.HasSuppletiveCore`, suppletion proper rather than
+affixal inflection. -/
+theorem run_hasSuppletiveCore : Morphology.Root.HasSuppletiveCore realization (fun s => {s}) run :=
+  (Morphology.Root.hasSuppletiveCore_singleton realization run).mpr
     (realization.isSuppletive_iff.mpr (Or.inr run_isProperlySuppletive))
 
-/-- √548 *cahoot* as a List-3 `Realization.Interpreted` view: one head, the
-cran-morph's single alloseme. -/
-def cahootHead : Morphology.Realization.Interpreted Unit
-    DistributedMorphology.Allosemy.SyntacticContext Unit String :=
+/-- √548 as a List-3 `Realization.Interpreted` view. -/
+def cahootHead : Morphology.Realization.Interpreted Unit SyntacticContext Unit String :=
   toInterpreted cahootLF
 
-/-- **Semantic individuation fails, on the carrier** ([harley-2014] §2.3):
-the cran-morph is interpreted (`a conspiracy`) inside its licensing frame
-but has an empty `interp` fiber elsewhere — the meaning-side analogue of an
-empty realization fiber, a *gap* rather than contextual variation. So this
-is a licensing failure, not an `IsAllosemous` witness: unlike an ordinary
-root (whose meaning would merely vary), a Fodorian atom could not gap. -/
+/-- The caboodle item is interpreted inside its frame and has an empty
+`interp` fiber elsewhere — a gap, the meaning-side analogue of an empty
+realization fiber, so a licensing failure rather than allosemy (§2.3). -/
 theorem cahoot_interp_gap :
-    cahootHead.interp () { belowCat := some .n } = {"a conspiracy"} ∧
-    cahootHead.interp () { } = ∅ := by
+    cahootHead.interp () { aboveCat := some .n } = {"a conspiracy"} ∧
+      cahootHead.interp () {} = ∅ := by
   refine ⟨?_, ?_⟩ <;> decide
 
 end Harley2014

--- a/references.bib
+++ b/references.bib
@@ -20847,7 +20847,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Morphology/DistributedMorphology/Categorizer.lean;Studies/Harley2014.lean}
+  sources   = {Morphology/DistributedMorphology/Root.lean;Morphology/DistributedMorphology/Categorizer/Basic.lean;Studies/Harley2014.lean}
 }
 @article{hewett-2026,
   author    = {Hewett, Matthew},


### PR DESCRIPTION
Deep cleanse against the paper (LingBuzz text); supersedes #2260. Roots are `DistributedMorphology.Root` indices; a clause is a number assignment over `ArgumentStructure.ArgPosition` (`intransitive`/`transitive`/`impersonal`), so the impersonal passive is an absent internal argument rather than a third number value, and the paper's unaccusativity prediction is `intransitive_isRootValency`; the caboodle frame uses `aboveCat := some .n`.

- §3.3 as a theorem: `conditioningPattern` read off `spellout` is ergative–absolutive, and `Minimalist.nomAcc_no_ergAbs_agreement` (Marantz1991, Bobaljik 2008's gap) gives `suppletion_not_agreement`.
- Citations corrected: the run sentences are (6a,b), not (1a,b); `[bobaljik-2008]` is the unmarked-case generalization; Borer 2009 is an unpublished talk and is described rather than keyed; Harley's "no Elsewhere interpretation" claim is stated as she makes it.
- Bib `sources` updated to current paths.