### PR TITLE
refactor(Studies/Adamson2024): articles (32), two nominalizers, Table 6

### DIFF
--- a/Linglib/Fragments/Teop/Nouns.lean
+++ b/Linglib/Fragments/Teop/Nouns.lean
@@ -8,9 +8,12 @@ import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 Gender I and gender II nouns in Teop (Austronesian, Oceanic), drawn from
 [adamson-2024] Table 1 (sampled from Mosel & Spriggs 2000:336–40).
 
-Teop has two genders distinguished by article form:
-- **Gender I** (article *a*): animates — encoded via [±ANIM] on n
-- **Gender II** (article *o*): inanimates — plain n
+Teop has two genders distinguished by article form, with a "cross-identity"
+between gender and number ([adamson-2024] (25)–(26)): gender I takes *a* in
+the singular and *o* in the plural, gender II *o* in the singular and *a* in
+the plural; proprial nouns of gender I take *e* in the singular.
+- **Gender I**: animates — encoded via [animate] on n
+- **Gender II**: inanimates — plain n
 
 Body-part nouns appear in **both** genders depending on possession:
 iPossessed (with n_{body-part{D}}) → gender I; unpossessed or
@@ -27,8 +30,8 @@ open DistributedMorphology
 
 /-- Teop gender: two classes (Mosel & Spriggs 2000, Mosel 2014). -/
 inductive Gender where
-  | gI   -- article *a/ra*; animates
-  | gII  -- article *o/ro*; inanimates
+  | gI   -- article *a* (sg) ~ *o* (pl); animates
+  | gII  -- article *o* (sg) ~ *a* (pl); inanimates
   deriving DecidableEq, Repr
 
 /-- A Teop noun with its gloss and gender assignment. -/
@@ -98,9 +101,9 @@ def iPossessedGender (n : Noun) : Gender :=
 -- § 5: Article Paradigm (Mosel & Spriggs 2000)
 -- ============================================================================
 
-/-- Teop articles, conditioned by gender and number.
-    Gender Ie (proprial *e*) is treated as gender I with a proprial
-    feature, following [adamson-2024] §3.1. -/
+/-- Teop articles, conditioned by gender and number. Gender Ie (proprial
+    *e*) is treated as gender I with a proprial feature, following
+    [adamson-2024] §3.1; the plural neutralizes it ([adamson-2024] (29)). -/
 structure ArticleCtx where
   gender : Gender
   plural : Bool
@@ -108,11 +111,11 @@ structure ArticleCtx where
   deriving DecidableEq, Repr
 
 def articleForm : ArticleCtx → String
-  | ⟨.gI,  _, true⟩      => "e"
-  | ⟨.gI,  false, false⟩  => "a"
-  | ⟨.gI,  true,  false⟩  => "ra"
-  | ⟨.gII, false, _⟩      => "o"
-  | ⟨.gII, true,  _⟩      => "ro"
+  | ⟨.gI,  false, true⟩  => "e"
+  | ⟨.gI,  false, false⟩ => "a"
+  | ⟨.gI,  true,  _⟩     => "o"
+  | ⟨.gII, false, _⟩     => "o"
+  | ⟨.gII, true,  _⟩     => "a"
 
 -- ============================================================================
 -- § 6: Verification

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -1,641 +1,248 @@
 import Linglib.Morphology.DistributedMorphology.NominalSpine
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
-import Linglib.Morphology.DistributedMorphology.Categorizer.Semantics
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
+import Linglib.Morphology.DistributedMorphology.Impoverishment
 import Linglib.Fragments.Teop.Nouns
 import Linglib.Fragments.Jarawara.PossessedNouns
 import Linglib.Fragments.Italian.NumberGender
 
 /-!
-# Adamson 2024: Gender Assignment Is Local [adamson-2024]
+# Gender assignment is local
 
-[adamson-2024] "Gender Assignment Is Local: On the Relation between
-Grammatical Gender and Inalienable Possession." *Language* 100(2): 218–264.
+[adamson-2024]'s Gender Locality Hypothesis — gender features on n are valued
+within nP ((15)) — lets an inalienable possessor, introduced in Spec,nP,
+bear on a noun's gender while an alienable possessor, in Spec,PossP, cannot
+((16)). The hypothesis is `DistributedMorphology.genderLocalityHypothesis`;
+this file derives the paper's case studies from it and from the shared
+Vocabulary Insertion and Impoverishment engines.
 
-## Core claim
+## Main definitions
 
-The **Gender Locality Hypothesis** (GLH): gender features on n must be
-valued only within nP. This restricts the conditioning factors
-for gender assignment to elements extremely local to the noun.
+* `Teop.relationalN`, `Teop.alienatorN`, `Teop.outerGender`: the two
+  nominalizers of body-part and kinship roots ((36), (43)) and the gender of
+  a head stack, that of its highest n.
+* `Teop.articles`, `Teop.article`: the article vocabulary (32).
+* `Jarawara.impoverish`, `Jarawara.decl`, `Jarawara.mano`: the gender
+  impoverishment (63) feeding the declarative items (59) and the possessed
+  noun *mano*~*mani* (A7).
+* `possesseeGender`: what fixes a possessee's gender under each of the two
+  mechanisms, possessee gender and inherited gender.
 
-## Key consequence for possession
+## Main results
 
-Inalienable possessors are introduced nP-internally (specifier of n with
-selectional feature {D}, following Myler 2016), while alienable possessors
-are introduced outside nP (specifier of PossP). The GLH therefore predicts:
+* `Teop.article_eq_articleForm`: the Subset Principle over (32) yields the
+  Fragment's article paradigm, cross-identities included ((25)–(26)).
+* `Teop.switch`: a body-part root is gender I under the {D} nominalizer and
+  gender II under the alienator ((39)–(40)).
+* `Jarawara.mano_eq_manoForm`: impoverishment then insertion derives the
+  paradigm of Table 6 cell by cell.
+* `Italian.aPlural_changes_gender`: only number on n changes gender ((99)).
 
-- **Inalienable possession CAN affect gender** (nP-internal)
-- **Alienable possession CANNOT affect gender** (outside nP)
+## Implementation notes
 
-This asymmetry is confirmed in four unrelated languages:
-
-1. **Teop** (Austronesian, Oceanic; §3.1): body-part nouns combine with
-   two different n heads — n_{body-part{D}} bearing u[+ANIM] yields
-   gender I when iPossessed; n_{alienator} (plain) yields gender II
-2. **Jarawara** (Arawan; §3.2): iPossessable roots are licensed only by
-   plain n (feminine = unmarked in the [±MASC] system)
-3. **Yanyuwa** (Western Pama-Nyungan; §4.1): unvalued gender on n is
-   valued by Probe-Goal agreement with the iPossessor DP
-4. **Coastal Marind** (Anim; §4.2): *igih* 'name' and *nanVh* 'face'
-   inherit possessor's gender via agreement
-
-## Predictions beyond possession (§5)
-
-The GLH predicts that number features on Num (high number) cannot interact
-with gender, while number on n (low/derivational number) can. Features
-introduced on D (definiteness), T (tense), etc. are all outside nP and
-cannot affect gender assignment.
-
-## Connection to Linglib
-
-This module uses types from `Morphology/DistributedMorphology/NominalSpine.lean`
-(the GLH, `NominalPosition`, `PossessionType`), `Head` and `PhiBundle`
-from `Morphology/DistributedMorphology/Categorizer.lean` ([kramer-2015]),
-`VocabularyItem` from `Morphology/DistributedMorphology/Defs.lean`,
-and Fragment data from `Fragments/Teop/Nouns.lean` and
-`Fragments/Jarawara/PossessedNouns.lean`.
+Nominal structure is a head stack, innermost first, and gender is read off
+the highest n, the paper's rule for denominal nominalization under (43). The
+alienator's two further effects — existential closure of the possessor slot
+and the allomorph *-na* — are in `Categorizer/Semantics.lean` and prose here.
+Jarawara's privative `[masc]`, `[pl]`, `[participant]` are the paper's own;
+(A7)'s secondary feature `[marked]` is spelled out as one item per marked
+feature.
 -/
 
 namespace Adamson2024
 
-open DistributedMorphology
+open DistributedMorphology DistributedMorphology.Impoverishment
 open DistributedMorphology.Categorizer (Head)
-open Minimalist
 
--- ============================================================================
--- § 1: GLH + Head Bridge
--- ============================================================================
+/-! ### The Gender Locality Hypothesis -/
 
-/-- An n head with selectsD licenses an iPossessor in Spec,nP.
-    This connects `Head.selectsD` to the GLH: the {D} feature
-    places the possessor nP-internally, making it gender-relevant. -/
-theorem selectsD_implies_local_possessor :
-    PossessionType.inalienable.possessorPosition = .specN ∧
-    genderLocalityHypothesis .specN = true := ⟨rfl, rfl⟩
-
-/-- Gender features live on the nominal categorizer (n), as established
-    by [kramer-2015] and confirmed by [adamson-2024]. -/
-theorem categorizer_has_gender_locus :
-    Head.n_iFem.phi.gender.isSome = true ∧
-    Head.n_iMasc.phi.gender.isSome = true ∧
-    Head.n_uFem.phi.gender.isSome = true ∧
-    Head.n_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl, rfl⟩
-
-/-- The ANIM-dimension types also carry gender features on n. -/
-theorem anim_categorizer_has_gender :
-    Head.n_iAnim.phi.gender.isSome = true ∧
-    Head.n_iInanim.phi.gender.isSome = true ∧
-    Head.n_uAnim.phi.gender.isSome = true := ⟨rfl, rfl, rfl⟩
-
-/-- The GLH targets the nominal categorizer specifically. Verbal and
-    adjectival categorizers do not host gender features. -/
-theorem glh_targets_nominal_categorizer :
-    Head.n_plain.categorizer = .n ∧
-    Head.v_plain.phi.gender.isNone = true ∧
-    Head.a_plain.phi.gender.isNone = true := ⟨rfl, rfl, rfl⟩
-
-
--- ============================================================================
--- § 2: Teop — Possessee Gender ([adamson-2024] §3.1)
--- ============================================================================
-
-/-- Teop body-part n: bears u[+ANIM] and selectional feature {D}.
-    When a body-part root combines with this n, the {D} feature creates
-    a specifier position for an iPossessor DP. The u[+ANIM] feature
-    results in gender I (animate article *a*). -/
-def teopBodyPartN : Head :=
-  .iPoss { gender := some ⟨.u, ⟨.anim, .pos⟩⟩ }
-
-/-- Teop alienator n: plain n with no gender feature and no iPossessor. -/
-def teopAlienatorN : Head := Head.n_plain
-
-/-- Determine gender from the n head's feature content.
-    If n has any [ANIM]-dimension gender feature → gender I;
-    otherwise → gender II. -/
-def teopGenderFromN (nh : Head) : Teop.Gender :=
-  match nh.phi.gender with
-  | some gf => if gf.val.dim == .anim then .gI else .gII
-  | none    => .gII
-
-/-- Body-part nouns switch gender because they combine with two different
-    n heads. -/
-theorem teop_body_part_two_n_heads :
-    teopGenderFromN teopBodyPartN = .gI ∧
-    teopGenderFromN teopAlienatorN = .gII := ⟨rfl, rfl⟩
-
-/-- The body-part n licenses an iPossessor (has {D}); the alienator n does not. -/
-theorem teop_body_part_selectsD :
-    teopBodyPartN.selectsD = true ∧
-    teopAlienatorN.selectsD = false := ⟨rfl, rfl⟩
-
-/-- The Teop gender alternation is consistent with the GLH. -/
-theorem teop_consistent_with_glh :
+/-- The asymmetry of (16): an inalienable possessor can bear on gender, an
+alienable one cannot. -/
+theorem possession_asymmetry :
     PossessionType.inalienable.canAffectGender = true ∧
-    PossessionType.alienable.canAffectGender = false := ⟨rfl, rfl⟩
+      PossessionType.alienable.canAffectGender = false := by
+  decide
 
-/-- The Teop body-part n uses the ANIM dimension, not the FEM dimension. -/
-theorem teop_uses_anim_dimension :
-    teopBodyPartN.phi.gender.map (·.val.dim) = some .anim := rfl
+/-- What fixes a possessee's gender under each mechanism of §2.3: its own
+nominalizer (possessee gender, Teop and Jarawara) or its iPossessor's gender
+(inherited gender, Yanyuwa and Coastal Marind, the probe of (90)). -/
+def possesseeGender {G : Type*} : PossessionGenderMechanism → G → G → G
+  | .possesseeGender, own, _ => own
+  | .inheritedGender, _, possessor => possessor
 
-/-! ### Teop Vocabulary Insertion -/
+/-- Under inherited gender the possessee matches its possessor (fn. 8). -/
+theorem inheritedGender_eq_possessor {G : Type*} (own possessor : G) :
+    possesseeGender .inheritedGender own possessor = possessor := rfl
 
-/-- Features of the Teop article's agreement bundle: the noun's gender and
-number, and proprial status. -/
+/-! ### Teop: possessee gender (§3.1) -/
+
+namespace Teop
+
+open _root_.Teop (ArticleCtx articleForm)
+
+/-- The nominalizer of a body-part or kinship root: it introduces the
+relation and bears u[animate], with or without the selectional feature {D}
+that licenses an iPossessor ((36), (43)). -/
+def relationalN (selectsD : Bool) : Head where
+  categorizer := .n
+  phi := { gender := some ⟨.u, ⟨.anim, .pos⟩⟩ }
+  selectsD := selectsD
+
+/-- The alienator, a further n of gender II that closes the possessor slot
+((43)). -/
+def alienatorN : Head := Head.n_plain
+
+/-- A head bears the gender I feature [animate] ((24)). -/
+def Animate (h : Head) : Prop := h.phi.gender.map (·.val.dim) = some .anim
+
+instance : DecidablePred Animate :=
+  fun h => inferInstanceAs (Decidable (h.phi.gender.map (·.val.dim) = some .anim))
+
+/-- The gender of a nominal, read off its highest n: gender II is the absence
+of [animate]. -/
+def outerGender (stack : List Head) : _root_.Teop.Gender :=
+  match stack.getLast? with
+  | some h => if Animate h then .gI else .gII
+  | none => .gII
+
+/-- The iPossessed body-part noun: the root under the {D} nominalizer ((36)). -/
+def ipossessed : List Head := [relationalN true]
+
+/-- The free (or aPossessed, or compounded) body-part noun: the {D}-less
+nominalizer under the alienator ((43), (44)–(47)). -/
+def free : List Head := [relationalN false, alienatorN]
+
+/-- The gender switch of (39)–(40): *a bina-naa* 'my spleen' is gender I,
+*o bina* 'the spleen' gender II. -/
+theorem switch : outerGender ipossessed = .gI ∧ outerGender free = .gII := by decide
+
+/-- The article vocabulary (32), features percolated to D by concord:
+`[animate]` is gender I, `[proper]` the proprial class. -/
 inductive ArticleFeature where
-  | gI | gII | plural | proprial
+  | animate | pl | proper
   deriving DecidableEq, Repr
 
-/-- The article's bundle for a Fragment `Teop.ArticleCtx`. -/
-def articleFeatures (c : Teop.ArticleCtx) : List ArticleFeature :=
-  (match c.gender with | .gI => [.gI] | .gII => [.gII]) ++
-    (if c.plural then [.plural] else []) ++ (if c.proprial then [.proprial] else [])
+/-- The items of (32), in the paper's order. -/
+def articles : List (VocabularyItem ArticleFeature String) :=
+  [⟨[.animate, .pl], "o"⟩, ⟨[.pl], "a"⟩, ⟨[.animate, .proper], "e"⟩, ⟨[.animate], "a"⟩,
+    ⟨[], "o"⟩]
 
-/-- Teop article items: proprial *e*, plural *ra*/*ro*, and the singular
-defaults *a*/*o* per gender. -/
-def teopArticleRules : List (VocabularyItem ArticleFeature String) :=
-  [⟨[.gI, .proprial], "e"⟩, ⟨[.gI, .plural], "ra"⟩, ⟨[.gI], "a"⟩,
-   ⟨[.gII, .plural], "ro"⟩, ⟨[.gII], "o"⟩]
+/-- The article's bundle for a Fragment `ArticleCtx`. -/
+def articleFeatures (c : ArticleCtx) : List ArticleFeature :=
+  (if c.gender = .gI then [.animate] else []) ++ (if c.plural then [.pl] else []) ++
+    (if c.proprial then [.proper] else [])
 
-/-- The article the Subset Principle inserts for a context. -/
-def teopArticle (c : Teop.ArticleCtx) : Option String :=
-  subsetPrinciple teopArticleRules (articleFeatures c)
+/-- The article the Subset Principle inserts. -/
+def article (c : ArticleCtx) : Option String := subsetPrinciple articles (articleFeatures c)
 
-theorem teop_ipossessed_body_part_article : teopArticle ⟨.gI, false, false⟩ = some "a" := by decide
-theorem teop_unpossessed_body_part_article :
-    teopArticle ⟨.gII, false, false⟩ = some "o" := by decide
-theorem teop_proprial_article : teopArticle ⟨.gI, false, true⟩ = some "e" := by decide
-theorem teop_plural_gI_article : teopArticle ⟨.gI, true, false⟩ = some "ra" := by decide
-theorem teop_plural_gII_article : teopArticle ⟨.gII, true, false⟩ = some "ro" := by decide
-
-/-- Vocabulary Insertion reproduces the Fragment's article table. -/
-theorem teopArticle_eq_articleForm (c : Teop.ArticleCtx) :
-    teopArticle c = some (Teop.articleForm c) := by
+/-- (32) derives the Fragment's paradigm, including the cross-identities of
+(25)–(26) and the neutralization of the proprial article in the plural
+(29). -/
+theorem article_eq_articleForm (c : ArticleCtx) : article c = some (articleForm c) := by
   rcases c with ⟨g, p, q⟩; cases g <;> cases p <;> cases q <;> decide
 
-/-- End-to-end: body-part root + n_{body-part{D}} → gender I → article *a*. -/
-theorem teop_end_to_end_ipossessed :
-    teopArticle ⟨teopGenderFromN teopBodyPartN, false, false⟩ = some "a" := by decide
-
-/-- End-to-end: body-part root + n_{alienator} → gender II → article *o*. -/
-theorem teop_end_to_end_unpossessed :
-    teopArticle ⟨teopGenderFromN teopAlienatorN, false, false⟩ = some "o" := by decide
-
-/-! ### Bridge to Fragment Data
-
-    The study-level `teopGenderFromN` agrees with the Fragment-level
-    `iPossessedGender` for body-part nouns: both predict gender I
-    when iPossessed, gender II when free. -/
-
-theorem teop_fragment_bridge :
-    teopGenderFromN teopBodyPartN = Teop.iPossessedGender Teop.bina ∧
-    teopGenderFromN teopAlienatorN = Teop.bina.gender := ⟨rfl, rfl⟩
-
-/-! ### Five Teop Predictions ([adamson-2024] §3.1)
-
-The two-n analysis generates five testable predictions (p.234–235): -/
-
-/-- Prediction 1: aPossessed body parts → gender II.
-    When a body-part root combines with the alienator n (aPossession),
-    the result is gender II, not gender I. -/
-theorem teop_prediction_apossessed_gII :
-    teopGenderFromN teopAlienatorN = .gII := rfl
-
-/-- Prediction 2: the iPossessor's own gender is immaterial.
-    The body-part n bears u[+ANIM] regardless of the possessor's features.
-    This is *possessee* gender (determined by WHETHER iPossessed), not
-    *inherited* gender (determined by possessor's gender value). -/
-theorem teop_prediction_possessor_gender_immaterial :
-    teopBodyPartN.phi.gender = some ⟨.u, ⟨.anim, .pos⟩⟩ := rfl
-
-/-- Prediction 3: the alienator n has no gender feature and no {D}.
-    aPossession is mediated by PossP, not Spec,nP. -/
-theorem teop_prediction_alienator_properties :
-    teopAlienatorN.phi.gender.isNone = true ∧
-    teopAlienatorN.selectsD = false := ⟨rfl, rfl⟩
-
-/-- Prediction 4: any noun combining with n_{body-part{D}} gets gender I,
-    not just canonical body parts. Relational nouns with the same structural
-    profile (orientation terms, place nouns) also show the alternation. -/
-theorem teop_prediction_relational_nouns :
-    teopGenderFromN teopBodyPartN = .gI := rfl
-
-/-- Prediction 5: kinship nouns use the alienator n (aPossession),
-    so they are always gender II regardless of possession. -/
-theorem teop_prediction_kinship_alienator :
-    teopGenderFromN teopAlienatorN = .gII ∧
-    teopAlienatorN.selectsD = false := ⟨rfl, rfl⟩
-
--- ============================================================================
--- § 3: Jarawara — Possessee Gender ([adamson-2024] §3.2)
--- ============================================================================
-
-/-- Jarawara gender from the n head's feature content. -/
-def jarawaraGenderFromN (nh : Head) : Bool :=  -- true = masculine
-  match nh.phi.gender with
-  | some gf => gf.val.dim == .masc
-  | none    => false  -- feminine (unmarked)
-
-/-- The n head for Jarawara iPossessable nouns: has {D} (licenses iPossessor
-    in Spec,nP) but no gender feature (feminine = unmarked in the [±MASC]
-    system). This is distinct from `Head.n_plain` (which has selectsD = false). -/
-def jarawaraIPossN : Head := .iPoss
-
-/-- iPossessable roots in Jarawara are feminine: their n has no marked gender. -/
-theorem jarawara_ipossessable_always_fem :
-    jarawaraGenderFromN jarawaraIPossN = false := rfl
-
-/-- iPossessable n in Jarawara has {D} — by construction via `Head.iPoss`. -/
-theorem jarawara_ipossessable_selectsD :
-    jarawaraIPossN.selectsD = true := rfl
-
-/-- Masculine nouns in Jarawara bear [+MASC] on n. -/
-theorem jarawara_masc_has_feature :
-    jarawaraGenderFromN Head.n_uMasc = true := rfl
-
-/-! ### Jarawara impoverishment ([adamson-2024] ex. 63)
-
-Two separate impoverishment rules delete [MASC] in different contexts:
-- [MASC] → ∅ / [PL]
-- [MASC] → ∅ / [PARTICIPANT]
--/
-
-/-- A morphosyntactic context triggering the paper's gender impoverishment
-    (ex. 63; on impoverishment generally see Bonet 1991 and
-    [embick-noyer-2007], the paper's own citations). Each context is a
-    separate rule. -/
-inductive ImpoverishmentContext where
-  | plural       -- [PL]: number feature
-  | participant  -- [PARTICIPANT]: 1st/2nd person (speech act participants)
-  deriving DecidableEq, Repr
-
-/-- A gender-impoverishment rule (ex. 63): delete `targetGender` from the
-    phi-bundle when the conditioning context is active. Postsyntactic,
-    feeding Vocabulary Insertion — impoverishment bleeds the more specific
-    exponent, so the unmarked feminine surfaces. -/
-structure GenderImpoverishmentRule where
-  /-- The feature to be deleted. -/
-  targetGender : Gender.Signed
-  /-- The conditioning context (feature that triggers deletion). -/
-  context : ImpoverishmentContext
-  deriving DecidableEq, Repr
-
-/-- Apply impoverishment: if the rule matches, delete the gender feature. -/
-def GenderImpoverishmentRule.apply (rule : GenderImpoverishmentRule)
-    (phi : PhiBundle) (contextActive : Bool) : PhiBundle :=
-  if contextActive then
-    match phi.gender with
-    | some gf => if gf.val == rule.targetGender
-                 then { phi with gender := none }
-                 else phi
-    | none => phi
-  else phi
-
-/-- Impoverishment rule 1: [MASC] → ∅ / [PL]. -/
-def jarawaraImpoverishPL : GenderImpoverishmentRule where
-  targetGender := ⟨.masc, .pos⟩
-  context := .plural
-
-/-- Impoverishment rule 2: [MASC] → ∅ / [PARTICIPANT]. -/
-def jarawaraImpoverishParticipant : GenderImpoverishmentRule where
-  targetGender := ⟨.masc, .pos⟩
-  context := .participant
-
-/-- Both rules from ex. 63. -/
-def jarawaraImpoverishmentRules : List GenderImpoverishmentRule :=
-  [jarawaraImpoverishPL, jarawaraImpoverishParticipant]
-
-/-- Impoverishment deletes [MASC] when [PL] is active. -/
-theorem jarawara_impoverishment_pl :
-    let mascPhi : PhiBundle := { gender := some ⟨.u, ⟨.masc, .pos⟩⟩ }
-    let result := jarawaraImpoverishPL.apply mascPhi true
-    result.gender = none := rfl
-
-/-- Impoverishment deletes [MASC] when [PARTICIPANT] is active. -/
-theorem jarawara_impoverishment_participant :
-    let mascPhi : PhiBundle := { gender := some ⟨.u, ⟨.masc, .pos⟩⟩ }
-    let result := jarawaraImpoverishParticipant.apply mascPhi true
-    result.gender = none := rfl
-
-/-- Impoverishment does not apply when context is inactive. -/
-theorem jarawara_no_impoverishment_when_inactive :
-    let mascPhi : PhiBundle := { gender := some ⟨.u, ⟨.masc, .pos⟩⟩ }
-    let result := jarawaraImpoverishPL.apply mascPhi false
-    result.gender = some ⟨.u, ⟨.masc, .pos⟩⟩ := rfl
-
-/-! ### Bridge to Fragment Data
-
-    The 175 iPossessable nouns in 12 semantic classes from `Jarawara`
-    are drawn from the upper tiers of the inalienability hierarchy,
-    confirming the cross-linguistic prediction. -/
-
-theorem jarawara_fragment_total :
-    (Jarawara.allClasses.map (·.memberCount)).foldl (· + ·) 0 = 175 := by
+/-- The cross-identity: i.sg and ii.pl share *a*, i.pl and ii.sg share *o*. -/
+theorem cross_identity :
+    article ⟨.gI, false, false⟩ = article ⟨.gII, true, false⟩ ∧
+      article ⟨.gI, true, false⟩ = article ⟨.gII, false, false⟩ := by
   decide
 
--- ============================================================================
--- § 4: Inherited Gender — Yanyuwa & Coastal Marind ([adamson-2024] §4)
--- ============================================================================
-
-/-! ### Inherited gender via Probe-Goal agreement
-
-[adamson-2024] §4: in Yanyuwa and Coastal Marind, a small class of
-iPossessed nouns (*igih* 'name', *nanVh* 'face' in Coastal Marind; body parts
-and 'name' in Yanyuwa) "inherit" the gender of their iPossessor.
-
-In Minimalist terms: the nominalizing head n has an **unvalued** gender
-feature. Because the iPossessor DP is in Spec,nP (nP-internal), Probe-Goal
-Agree can copy the possessor's valued gender onto n. The GLH permits
-this because the goal (iPossessor) is within nP. -/
-
-/-- A gender-inheriting noun: the n head bears an unvalued gender probe
-    that is valued by Agree with the iPossessor DP's gender. -/
-structure InheritedGenderNoun where
-  /-- The root (e.g., √IGIH 'name', √NANVH 'face'). -/
-  rootGloss : String
-  /-- The n head has {D} (selects an iPossessor). -/
-  selectsD : Bool := true
-  /-- The n head has an unvalued gender feature (probe). -/
-  hasUnvaluedGender : Bool := true
-  deriving DecidableEq, Repr
-
-/-- The n head for an inherited-gender noun: has {D} and an unvalued
-    gender probe. The probe is dimension-agnostic — it has no pre-specified
-    dimension or polarity. Its value (including dimension) comes entirely
-    from the iPossessor DP via Probe-Goal Agree ([adamson-2024] (90)).
-    We represent this as `phi := {}` (no valued gender on n itself). -/
-def inheritedGenderN : Head := .iPoss
-
-/-- Yanyuwa: seven gender classes (Kirton 1971a,b).
-
-    FEMALE, MALE, FEMININE (nonhuman female), MASCULINE (nonhuman male),
-    FOOD, ARBOREAL, ABSTRACT. Body parts and 'name' take possessor
-    prefixes expressing the possessor's φ-features. -/
-inductive YanyuwaGender where
-  | female | male | feminine | masculine | food | arboreal | abstract
-  deriving DecidableEq, Repr
-
-/-- All seven Yanyuwa gender values. -/
-def YanyuwaGender.all : List YanyuwaGender :=
-  [.female, .male, .feminine, .masculine, .food, .arboreal, .abstract]
-
-theorem yanyuwa_seven_genders : YanyuwaGender.all.length = 7 := rfl
-
-/-- Coastal Marind: four genders (Olsson 2017).
-
-    I (human men, e.g., *yasti* 'old man'), II (human women + animals,
-    e.g., *gomna* 'male pig'), III (some inanimates, e.g., *aliki* 'river'),
-    IV (other inanimates, e.g., *himbu* 'feathered headdress'). -/
-inductive CoastalMarindGender where
-  | gI | gII | gIII | gIV
-  deriving DecidableEq, Repr
-
-/-- All four Coastal Marind gender values. -/
-def CoastalMarindGender.all : List CoastalMarindGender := [.gI, .gII, .gIII, .gIV]
-
-theorem coastalMarind_four_genders :
-    CoastalMarindGender.all.length = 4 := rfl
-
-/-- Coastal Marind inherited-gender nouns (Olsson 2017:187). -/
-def coastalMarindInheritingNouns : List InheritedGenderNoun :=
-  [ ⟨"igih (name)", true, true⟩
-  , ⟨"nanVh (face)", true, true⟩ ]
-
-/-- Both inheriting nouns have {D} and unvalued gender — prerequisites
-    for Probe-Goal agreement with the iPossessor. -/
-theorem coastalMarind_inheriting_prerequisites :
-    coastalMarindInheritingNouns.all (λ n => n.selectsD && n.hasUnvaluedGender) = true := by
+/-- The body-part noun's article follows its nominalizer: *a* iPossessed, *o*
+free ((39)). -/
+theorem bodyPart_article :
+    article ⟨outerGender ipossessed, false, false⟩ = some "a" ∧
+      article ⟨outerGender free, false, false⟩ = some "o" := by
   decide
 
-/-- Inherited gender is consistent with the GLH: the possessor whose
-    gender is inherited occupies Spec,nP (nP-internal). -/
-theorem inherited_gender_glh_consistent :
-    genderLocalityHypothesis
-      PossessionGenderMechanism.inheritedGender.possessorPosition = true := rfl
+/-- The iPossessor's own gender is immaterial ((48)–(49)): possessee gender
+reads the nominalizer, not the possessor. -/
+theorem possessor_gender_immaterial (possessor : _root_.Teop.Gender) :
+    possesseeGender .possesseeGender (outerGender ipossessed) possessor = .gI := rfl
 
--- ============================================================================
--- § 5: n-Type System ↔ Surface Gender Counts
--- ============================================================================
-
-/-! ### Bridge: Kramer's n-types and WALS gender counts
-
-[kramer-2015] Ch 3: for a single gender dimension [±VAL], there are
-four types of n: i[+VAL], i[−VAL], plain, u[+VAL]. The fourth combination
-u[−VAL] is the unmarked default (plain n).
-
-The maximum number of **surface genders** from one dimension is 3:
-the positive value, the negative value, and the default (plain).
-Two-gender systems arise when only one marked value + plain are attested. -/
-
-/-- Count distinct surface genders from a set of n heads.
-    Two n heads produce the same surface gender iff they have the same
-    gender feature content (ignoring interpretability, which is only
-    visible at LF vs PF). -/
-def surfaceGenderClass (nh : Head) : Option Gender.Signed :=
-  nh.phi.gender.map (·.val)
-
-/-- The four Amharic n-types yield exactly 3 surface genders:
-    [+FEM], [−FEM], and ∅ (plain). Both i[+FEM] and u[+FEM] map to
-    the same surface class [+FEM]. -/
-theorem amharic_three_surface_genders :
-    let classes :=
-      [Head.n_iFem, Head.n_iMasc, Head.n_plain, Head.n_uFem].map
-        surfaceGenderClass
-    classes.eraseDups.length = 3 := by decide
-
-/-- A two-gender system (e.g., Jarawara [±MASC]) uses only two n types:
-    marked (u[+MASC]) and plain. -/
-theorem two_gender_system :
-    let classes := [Head.n_uMasc, Head.n_plain].map surfaceGenderClass
-    classes.eraseDups.length = 2 := by decide
-
-/-- The Teop two-gender system uses the ANIM dimension. -/
-theorem teop_two_gender_system :
-    let classes := [Head.n_uAnim, Head.n_plain].map surfaceGenderClass
-    classes.eraseDups.length = 2 := by decide
-
--- ============================================================================
--- § 6: Regression: iPossessable n-heads must have selectsD
--- ============================================================================
-
-/-! Every n-head used for inalienable possession must have `selectsD = true`.
-Without this, the n-head cannot license an iPossessor in Spec,nP, and the
-semantic pipeline (`catHeadSemanticType`) will compute sortal instead of
-relational. This invariant was violated before 0.229.208 (Jarawara used
-`Head.n_plain` which has selectsD = false). -/
-
-/-- All iPossessable n-heads across all four languages have selectsD = true.
-    Regression test: adding a new iPossessable n-head? Add it to the
-    disjunction here. If it fails, the n-head is missing {D}. -/
-theorem ipossessable_n_heads_have_selectsD
-    (nh : Head) (h : nh = teopBodyPartN ∨ nh = jarawaraIPossN ∨ nh = inheritedGenderN) :
-    nh.selectsD = true := by
-  rcases h with rfl | rfl | rfl <;> rfl
-
--- ============================================================================
--- § 7: Morphosyntax → Semantics Bridge ([adamson-2024] §3.1 + [barker-2011])
--- ============================================================================
-
-/-! ### Two derivation pipelines from a single n-head
-
-A Head determines two things in parallel:
-
-```
-           ┌──→ gender ──→ article form   (PF pipeline)
-Head ──┤
-           └──→ NSemanticType ──→ can take possessor?   (semantic pipeline)
-```
-
-The PF pipeline genuinely threads: `teopGenderFromN` computes the gender,
-which feeds into `teopArticle` as the article context. The semantic
-pipeline threads similarly: `catHeadSemanticType` computes the semantic
-type, which feeds into `.toBarker.canTakePossessor`.
-
-The non-trivial claim is that these two pipelines produce correlated
-outputs: gender I co-occurs with relational semantics (possessor slot),
-and gender II co-occurs with non-relational (no possessor slot). The
-correlation is structural — both paths read `selectsD` from the same
-n-head. -/
-
-open DistributedMorphology.CategorizerSemantics
-
-/-- The PF derivation pipeline: n-head → gender → article.
-    Gender is an intermediate value computed from φ-features, then fed
-    into VI as part of the article context. -/
-def teopPFDerive (nh : Head) (pl proprial : Bool := false) : Option String :=
-  let gender := teopGenderFromN nh
-  teopArticle ⟨gender, pl, proprial⟩
-
-/-- The semantic derivation pipeline: n-head → semantic type → possessor capability.
-    The semantic type is an intermediate value, fed into Barker's type classification
-    to determine whether the noun can directly take a possessor.
-    Generic over any Head — not Teop-specific despite the examples below. -/
-def canTakePossessorSem (nh : Head) (mediatesAPoss : Bool := false) : Bool :=
-  let semType := catHeadSemanticType nh (mediatesAPossession := mediatesAPoss)
-  semType.toBarker.canTakePossessor
-
--- PF pipeline: body-part n → gender I → article *a*
-theorem pf_body_part : teopPFDerive teopBodyPartN = some "a" := by decide
--- PF pipeline: alienator n → gender II → article *o*
-theorem pf_alienator : teopPFDerive teopAlienatorN = some "o" := by decide
-
--- Semantic pipeline: body-part n (selectsD) → relational → can take possessor
-theorem sem_body_part : canTakePossessorSem teopBodyPartN = true := rfl
--- Semantic pipeline: alienator n → alienator type → cannot take possessor
-theorem sem_alienator : canTakePossessorSem teopAlienatorN = false := rfl
-
-/-- The two pipelines produce correlated results: the PF pipeline yields
-    gender I exactly when the semantic pipeline yields possessor capability.
-
-    This is the Adamson–Barker correspondence. The gender alternation
-    (gender I vs II) and the semantic type alternation (relational vs
-    non-relational) are not independent — they are both downstream
-    consequences of the same structural feature (selectsD on n).
-
-    Stated as a Bool identity: "is gender I" = "can take possessor". -/
-theorem pf_semantic_correlation (nh : Head)
-    (h : nh = teopBodyPartN ∨ nh = teopAlienatorN) :
-    (teopGenderFromN nh == .gI) = canTakePossessorSem nh := by
-  rcases h with rfl | rfl <;> rfl
-
-/-! ### Jarawara: PF pipeline via manoForm
-
-Jarawara doesn't have articles, but it DOES have a PF pipeline: possessor
-features → impoverishment → MARKED feature check → possessed noun form
-(mano vs mani). This is the `manoForm` function from `Jarawara`.
-
-The semantic pipeline parallels Teop: the iPossessable n has {D} →
-relational semantic type → can take possessor. The gender is feminine
-because n has no marked gender feature, not because it lacks {D}. -/
-
-/-- Jarawara PF pipeline: possessor features → impoverishment →
-    MARKED feature check → possessed form (mano/mani).
-    The possessor's features thread through each stage. -/
-def jarawaraPFDerive (poss : Jarawara.Possessor) : Jarawara.PossessedForm :=
-  Jarawara.manoForm poss
-
--- PF pipeline: 1SG possessor → [PARTICIPANT] is MARKED → mano
-theorem jarawara_pf_1sg : jarawaraPFDerive ⟨.first, .Sing, none⟩ = .mascForm := rfl
--- PF pipeline: 3.M.SG → [MASC] survives → mano
-theorem jarawara_pf_3msg : jarawaraPFDerive ⟨.third, .Sing, some .masc⟩ = .mascForm := rfl
--- PF pipeline: 3.M.PL → [MASC] impoverished by [PL] → mani
-theorem jarawara_pf_3mpl : jarawaraPFDerive ⟨.third, .Plur, some .masc⟩ = .femForm := rfl
-
-/-- Jarawara iPossessable n has {D} → relational semantic type.
-    The n head licenses an iPossessor AND yields relational (π) semantics. -/
-theorem jarawara_ipossessable_is_relational :
-    catHeadSemanticType jarawaraIPossN = .relational := rfl
-
-/-- Jarawara PF–semantic correlation: iPossessable n yields feminine gender
-    (no marked feature) AND relational semantics (has {D}). The correlation
-    shows that Jarawara iPossessable nouns CAN take possessors despite
-    being feminine — femininity reflects the absence of a gender feature,
-    not the absence of a possessor slot. -/
-theorem jarawara_pf_semantic :
-    jarawaraGenderFromN jarawaraIPossN = false ∧
-    canTakePossessorSem jarawaraIPossN = true := ⟨rfl, rfl⟩
-
-/-! ### Inherited gender: the GLH contrast
-
-For Yanyuwa and Coastal Marind, the n-head has {D} → relational semantics.
-The key GLH prediction is a contrast: iPossessors (specN) can affect gender,
-aPossessors (specPoss) cannot. The contrast is captured by the GLH function
-applied to two different positions — not a chain, just two evaluations of
-the same predicate on different inputs. -/
-
-/-- The inherited-gender n head has {D} → relational semantic type.
-    Gender is unvalued on n and comes from the iPossessor via Agree. -/
-theorem inherited_gender_is_relational :
-    catHeadSemanticType inheritedGenderN = .relational := rfl
-
-/-- The GLH contrast: iPossessors can affect gender, aPossessors cannot.
-    This is not a derivation — it's two evaluations of `genderLocalityHypothesis`
-    on the two possessor positions. The function does the work. -/
-theorem glh_contrast :
-    genderLocalityHypothesis PossessionType.inalienable.possessorPosition = true ∧
-    genderLocalityHypothesis PossessionType.alienable.possessorPosition = false := ⟨rfl, rfl⟩
-
--- ============================================================================
--- § 8: Italian Low-Number Gender Interaction ([adamson-2024] §5.1)
--- ============================================================================
-
-/-! ### Beyond possession: number position and gender
-
-[adamson-2024] §5.1 extends the GLH beyond possession: if gender
-features sit on n, then OTHER features on n should also interact with
-gender. Number features on n (low/derivational number) are within nP
-and can interact with gender; number features on Num (high/inflectional)
-are outside nP and cannot.
-
-Standard Italian confirms this: the -a plural class (*braccio* → *braccia*
-'arm → arms') changes gender from masculine to feminine. These are low-number
-plurals (number on n). Regular -i plurals (*libro* → *libri*) preserve
-gender — they involve high number (on Num).
-
-The same function (`genderLocalityHypothesis`) that predicts possession–gender
-interaction in Teop and Jarawara also predicts number–gender interaction in
-Italian. The GLH is a single principle applied to different feature types. -/
-
-open Italian.NumberGender
-
-/-- The Italian data confirms the GLH prediction: gender changes in the
-    plural track the number position. Verified over the full noun inventory.
-    The pipeline (`numberGenderPipeline`) composes
-    PluralClass → NumberPosition → NominalPosition → GLH. -/
-theorem italian_fragment_bridge :
-    allNouns.all (fun n =>
-      n.genderChanges == n.pluralClass.canAffectGender) = true := by
+/-- Kinship roots take the proprial article when iPossessed ((41), (50)) and
+switch to gender II under the alienator *-na* ((51)). -/
+theorem kinship :
+    article ⟨outerGender ipossessed, false, true⟩ = some "e" ∧
+      article ⟨outerGender free, false, false⟩ = some "o" := by
   decide
 
-/-- Cross-linguistic convergence: the -a plural class is dominated by
-    body parts (6 of 9). Body parts drive gender interaction in ALL
-    four languages examined:
-    - Teop: body parts switch gender I/II with iPossession
-    - Jarawara: body parts are always iPossessable (feminine)
-    - Yanyuwa/Coastal Marind: body parts inherit possessor's gender
-    - Italian: body parts show the -a plural gender alternation -/
-theorem italian_body_part_dominance :
-    (aPluralNouns.filter (fun n =>
-      ["arm", "finger", "knee", "lip", "bone", "eyebrow"].contains n.gloss)).length = 6 := by
+end Teop
+
+/-! ### Jarawara: possessee gender and agreement (§3.2) -/
+
+namespace Jarawara
+
+open _root_.Jarawara (Possessor PossessedForm manoForm)
+
+/-- The privative φ-features of §3.2: `[masc]` ((58)), `[pl]`, and
+`[participant]` for first and second person. -/
+inductive Phi where
+  | masc | pl | participant
+  deriving DecidableEq, Repr
+
+/-- The features a possessor contributes to agreement. -/
+def possessorPhi (p : Possessor) : List Phi :=
+  (if p.isParticipant then [.participant] else []) ++ (if p.number = .Plur then [.pl] else []) ++
+    (if p.gender = some .masc then [.masc] else [])
+
+/-- Gender impoverishment (63): `[masc]` is deleted next to `[pl]` and next to
+`[participant]`, two paradigmatic rules on the shared engine. -/
+def impoverishment : List (ImpoverishmentRule (List Phi) Phi) :=
+  [paradigmatic (·.contains .pl) .masc, paradigmatic (·.contains .participant) .masc]
+
+/-- The φ-bundle after (63). -/
+def impoverish (φ : List Phi) : List Phi :=
+  runChain (ImpoverishmentRule.apply List.erase) impoverishment (Neighborhood.ofBundle φ)
+
+/-- The declarative marker's items (59): `decl[masc] ↔ ka`, `decl ↔ ke`. -/
+def declarative : List (VocabularyItem Phi String) := [⟨[.masc], "ka"⟩, ⟨[], "ke"⟩]
+
+/-- The declarative marker agreeing with a nominal of features `φ`. -/
+def decl (φ : List Phi) : Option String := subsetPrinciple declarative (impoverish φ)
+
+/-- Masculine singular takes *ka*, everything else *ke* ((54), (60)–(62)):
+impoverishment bleeds the specific exponent. -/
+theorem decl_masc_only :
+    decl [.masc] = some "ka" ∧ decl [] = some "ke" ∧ decl [.participant] = some "ke" ∧
+      decl [.masc, .pl] = some "ke" := by
   decide
+
+/-- The possessed noun *mano* 'arm' (A7): *mano* for a marked feature —
+`[participant]` or a surviving `[masc]` — and *mani* elsewhere. -/
+def manV : List (VocabularyItem Phi String) :=
+  [⟨[.participant], "mano"⟩, ⟨[.masc], "mano"⟩, ⟨[], "mani"⟩]
+
+/-- The form of *mano* agreeing with possessor `p`. -/
+def mano (p : Possessor) : Option String := subsetPrinciple manV (impoverish (possessorPhi p))
+
+/-- The cells of Table 6. -/
+def tableSix : List Possessor :=
+  [⟨.first, .Sing, none⟩, ⟨.second, .Sing, none⟩, ⟨.first, .Plur, none⟩, ⟨.second, .Plur, none⟩,
+    ⟨.third, .Sing, some .masc⟩, ⟨.third, .Sing, some .fem⟩, ⟨.third, .Plur, some .masc⟩,
+    ⟨.third, .Plur, some .fem⟩]
+
+/-- Impoverishment then insertion derives the Fragment's paradigm of Table 6:
+the 3.m.pl *mani* is the one cell where (63) does the work. -/
+theorem mano_eq_manoForm :
+    ∀ p ∈ tableSix,
+      mano p = some (match manoForm p with | .mascForm => "mano" | .femForm => "mani") := by
+  decide
+
+end Jarawara
+
+/-! ### Number on n (§5.1) -/
+
+namespace Italian
+
+open _root_.Italian.NumberGender
+
+/-- The *-a* plurals of (99) carry number on n, within the GLH's reach, and
+change gender; regular plurals carry number on Num and do not. -/
+theorem aPlural_changes_gender :
+    (∀ n ∈ aPluralNouns, n.pluralClass.canAffectGender = true ∧ n.genderChanges = true) ∧
+      ∀ n ∈ regularNouns, n.pluralClass.canAffectGender = false ∧ n.genderChanges = false := by
+  decide
+
+end Italian
 
 end Adamson2024

--- a/references.bib
+++ b/references.bib
@@ -16006,7 +16006,7 @@
   subfield  = {morphology},
   validated = {true},
   role      = {formalized},
-  sources   = {Morphology/DistributedMorphology/NominalStructure.lean;Fragments/Teop/Nouns.lean;Fragments/Jarawara/PossessedNouns.lean;Studies/Adamson2024.lean}
+  sources   = {Morphology/DistributedMorphology/NominalSpine.lean;Morphology/DistributedMorphology/Categorizer/Gender.lean;Morphology/DistributedMorphology/Categorizer/Semantics.lean;Features/Gender/Decomposition.lean;Fragments/Teop/Nouns.lean;Fragments/Jarawara/PossessedNouns.lean;Fragments/Italian/NumberGender.lean;Studies/Adamson2024.lean}
 }
 @incollection{anagnostopoulou-2017a,
   author    = {Anagnostopoulou, Elena},


### PR DESCRIPTION
Deep cleanse against the paper (Zotero full text). The Teop article vocabulary is now the paper's (32) over privative [animate]/[pl]/[proper], and it derives the Fragment's paradigm — whose plural cells were wrong (*ra*/*ro* for the attested cross-identity *o*/*a*, and *e* for proprial plurals where (29) shows *o*); the body-part alternation is the paper's two-nominalizer structure (u[animate] n with or without {D}, the alienator stacked above), so kinship/proprial nouns come out right ((41), (50)–(51)).

- Jarawara runs on the shared engines: (63) as two `ImpoverishmentRule`s, (59) and (A7) as Vocabulary Items, and `mano_eq_manoForm` derives the Fragment's Table 6 cell by cell.
- Deleted: the rfl-unpack and count theorems, the version-regression section, the Kramer surface-gender counts, the vacuous inherited-gender records, and three of the file's "five predictions" that the paper does not make.
- `possesseeGender` states the paper's two mechanisms; bib `sources` updated to current paths.