### PR TITLE
refactor(Morphology/DistributedMorphology): VI items over neighborhoods

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1257,6 +1257,7 @@ import Linglib.Morphology.DistributedMorphology.Fission
 import Linglib.Morphology.DistributedMorphology.Fusion
 import Linglib.Morphology.DistributedMorphology.Impoverishment
 import Linglib.Morphology.DistributedMorphology.Merger
+import Linglib.Morphology.DistributedMorphology.Neighborhood
 import Linglib.Morphology.DistributedMorphology.NominalSpine
 import Linglib.Morphology.DistributedMorphology.Root
 import Linglib.Morphology.DistributedMorphology.Spellout

--- a/Linglib/Morphology/DistributedMorphology/Allosemy.lean
+++ b/Linglib/Morphology/DistributedMorphology/Allosemy.lean
@@ -1,5 +1,5 @@
 import Mathlib.Algebra.Group.WithOne.Defs
-import Linglib.Morphology.DistributedMorphology.Basic
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.Exponence.Select
 import Linglib.Morphology.Realization
@@ -54,12 +54,13 @@ immaterial for the result and content readings.
 
 ## Implementation notes
 
-`AllosemicEntry` is a `Morphology.Exponence.Rule` instance, just as
-`VocabularyItem` is, so DM's List 2 (form) and List 3 (meaning) run on one
-selection engine: `Exponence.selectBy` on the non-wildcard-field score
-(`selectBy_score_isElsewhereWinner`). `Voice.Alloseme.fromComplement` is
-a worked List-3 competition on that engine; `readingFromAllosemes` is a
-different object — the composition of two already-selected allosemes.
+An alloseme is a `VocabularyItem` whose exponent is a denotation, so DM's
+List 2 (form) and List 3 (meaning) run on one selection engine
+(`subsetPrinciple`, `winner?_isElsewhereWinner`); its specification
+conditions on the neighboring terminals, not on features of its own head.
+`Voice.Alloseme.fromComplement` is a worked List-3 competition on that
+engine; `readingFromAllosemes` is a different object — the composition of
+two already-selected allosemes.
 Existing infrastructure this module retroactively classifies as
 allosemy: `Minimalist.Voice.Flavor` (Voice) and root change-type
 conditioning of v.
@@ -76,6 +77,7 @@ conditioning of v.
 namespace DistributedMorphology.Allosemy
 
 open DistributedMorphology (Categorizer Categorizer.Head)
+open scoped DistributedMorphology.VocabularyItem
 open Minimalist.Voice (Flavor Head)
 
 /-! ### The alloseme carrier
@@ -168,24 +170,53 @@ def Verbalizer.Alloseme.introducesEvent : Verbalizer.Alloseme → Bool
   | .eventive => true
   | .zero     => false
 
+/-! ### Allosemic entries
+
+An alloseme is a Vocabulary Item whose exponent is a denotation. Its
+specification mentions no feature of its own head — the vocabulary is the
+head's — and conditions on the neighbors: the complement below, toward the
+root, and the embedding head above ([benz-2025] §2.4: allosemy is
+conditioned by the interpreted domain below and the features of the next
+head above; the exact locality is open). -/
+
+/-- What an alloseme may require of a neighboring terminal: its category,
+or that it denotes an event or a state ([kratzer-1996] §2.3 for the
+stative–dynamic split conditioning Voice). -/
+inductive Feature where
+  | cat (c : Categorizer)
+  | eventive
+  | stative
+  deriving DecidableEq, Repr
+
+/-- A specification on the complement, the terminal below the head. -/
+def complement (fs : List Feature) : Neighborhood (List Feature) := ⟨[], [fs], []⟩
+
+/-- A specification on the embedding head, the terminal above. -/
+def embedding (fs : List Feature) : Neighborhood (List Feature) := ⟨[], [], [fs]⟩
+
+/-- The denotations a vocabulary licenses in a context — the exponents of
+its applicable entries. Ambiguity in a context is non-singleton licensing;
+the canonical default among the licensed entries is the Elsewhere winner
+(`winner?_isElsewhereWinner`). -/
+def licensed {Sem : Type*} (v : List (VocabularyItem Feature Sem))
+    (n : Neighborhood (List Feature)) : List Sem :=
+  (Morphology.Exponence.applicable v n).map (·.exponent)
+
 /-- v's alloseme vocabulary: the eventive alloseme requires an eventive
 complement, while the zero alloseme is the unconditioned elsewhere
 option, available trivially in any context ([benz-2025] §2.2). Engine
 selection picks the more specific eventive alloseme in eventive
 contexts; `licensed` keeps both (`Verbalizer.ambiguity`). -/
-def Verbalizer.vocabulary : List (AllosemicEntry Verbalizer.Alloseme) :=
-  [ { denotation := .eventive, context := { complementIsEventive := true } },
-    { denotation := .zero, context := {} } ]
+def Verbalizer.vocabulary : List (VocabularyItem Feature Verbalizer.Alloseme) :=
+  [⟨complement [.eventive], .eventive⟩, [] ⟷ .zero]
 
 /-- Both v allosemes are licensed under an eventive complement — the
 zero alloseme is the elsewhere option — so an *observation*-type
 nominalization supports the eventive and the referential reading from
 one structure ([benz-2025] §2.2's symmetric proposal). -/
 theorem Verbalizer.ambiguity :
-    Verbalizer.Alloseme.eventive
-        ∈ licensed Verbalizer.vocabulary { complementIsEventive := true }
-      ∧ Verbalizer.Alloseme.zero
-        ∈ licensed Verbalizer.vocabulary { complementIsEventive := true } := by
+    Verbalizer.Alloseme.eventive ∈ licensed Verbalizer.vocabulary (complement [.eventive])
+      ∧ Verbalizer.Alloseme.zero ∈ licensed Verbalizer.vocabulary (complement [.eventive]) := by
   constructor <;> decide
 
 /-- Root change-type conditions v alloseme selection: result roots,
@@ -254,28 +285,23 @@ end Nominalizer.Alloseme
 unconditioned (all-wildcard contexts), the deverbal ones require a
 verbal complement, with the CEN and result allosemes further demanding
 an eventive one. -/
-def Nominalizer.vocabulary : List (AllosemicEntry Nominalizer.Alloseme) :=
-  [ { denotation := .relational, context := { belowCat := none } },
-    { denotation := .sortal, context := { belowCat := none } },
-    { denotation := .alienator, context := { belowCat := none } },
-    { denotation := .content, context := { belowCat := some .v } },
-    { denotation := .zero
-    , context := { belowCat := some .v, complementIsEventive := true } },
-    { denotation := .simpleEvent, context := { belowCat := some .v } },
-    { denotation := .result
-    , context := { belowCat := some .v, complementIsEventive := true } },
-    { denotation := .state, context := { belowCat := some .v } },
-    { denotation := .entity, context := { belowCat := some .v } } ]
+def Nominalizer.vocabulary : List (VocabularyItem Feature Nominalizer.Alloseme) :=
+  [[] ⟷ .relational, [] ⟷ .sortal, [] ⟷ .alienator,
+    ⟨complement [.cat .v], .content⟩,
+    ⟨complement [.cat .v, .eventive], .zero⟩,
+    ⟨complement [.cat .v], .simpleEvent⟩,
+    ⟨complement [.cat .v, .eventive], .result⟩,
+    ⟨complement [.cat .v], .state⟩,
+    ⟨complement [.cat .v], .entity⟩]
 
 /-- One eventive deverbal context licenses several n allosemes at once —
 the CEN reading (zero n) and the result reading among them. The
 ambiguity of a nominalization is non-singleton licensing, not structural
 ambiguity ([benz-2025], [wood-2023]). -/
 theorem Nominalizer.cen_result_ambiguity :
-    Nominalizer.Alloseme.zero ∈ licensed Nominalizer.vocabulary
-        { belowCat := some .v, complementIsEventive := true }
-      ∧ Nominalizer.Alloseme.result ∈ licensed Nominalizer.vocabulary
-        { belowCat := some .v, complementIsEventive := true } := by
+    Nominalizer.Alloseme.zero ∈ licensed Nominalizer.vocabulary (complement [.cat .v, .eventive])
+      ∧ Nominalizer.Alloseme.result
+        ∈ licensed Nominalizer.vocabulary (complement [.cat .v, .eventive]) := by
   constructor <;> decide
 
 /-! ### Voice allosemy -/
@@ -329,11 +355,9 @@ instance : DecidablePred Voice.Alloseme.AssignsTheta :=
     ([myler-2016]): engineer for a saturated eventive VoiceP complement
     (most specified), holder for a stative one, expletive elsewhere (the
     all-wildcard default). -/
-def Voice.vocabulary : List (AllosemicEntry Voice.Alloseme) :=
-  [ { denotation := .engineer
-    , context := { belowCat := some .v, complementIsEventive := true } },
-    { denotation := .holder, context := { complementIsStative := true } },
-    { denotation := .expletive, context := {} } ]
+def Voice.vocabulary : List (VocabularyItem Feature Voice.Alloseme) :=
+  [⟨complement [.cat .v, .eventive], .engineer⟩, ⟨complement [.stative], .holder⟩,
+    [] ⟷ .expletive]
 
 /-- Voice alloseme selection from complement properties: Elsewhere
     competition over `Voice.vocabulary`, resolved by the shared exponence
@@ -342,12 +366,9 @@ def Voice.vocabulary : List (AllosemicEntry Voice.Alloseme) :=
 def Voice.Alloseme.fromComplement
     (complementIsEventiveVoiceP : Prop) [Decidable complementIsEventiveVoiceP]
     (complementIsStative : Prop) [Decidable complementIsStative] : Voice.Alloseme :=
-  let q : SyntacticContext :=
-    { belowCat := if complementIsEventiveVoiceP then some .v else none
-      complementIsEventive := decide complementIsEventiveVoiceP
-      complementIsStative := decide complementIsStative }
-  ((Morphology.Exponence.selectBy AllosemicEntry.score Voice.vocabulary q).map
-    AllosemicEntry.denotation).getD .expletive
+  (subsetPrinciple Voice.vocabulary (complement
+    ((if complementIsEventiveVoiceP then [.cat .v, .eventive] else []) ++
+      if complementIsStative then [.stative] else []))).getD .expletive
 
 /-- Eventive-VoiceP complement selects engineer ([myler-2016]). -/
 example : Voice.Alloseme.fromComplement True False = .engineer := by decide
@@ -610,18 +631,14 @@ allosemy is meaning-only. Contextual meaning variation, Benz's core
 claim that allosemy is allomorphy's LF analogue, is then literally
 `Realization.Interpreted.IsAllosemous`. -/
 
-open Morphology.Exponence in
 /-- The allosemy engine as a `Realization.Interpreted` view: one
-abstract head whose contextual interpretation is the alloseme `selectBy`
-picks from the vocabulary (a singleton, `∅` at a semantic gap), with an
-empty List-2 form side. -/
-def toInterpreted {Sem : Type} (v : List (AllosemicEntry Sem)) :
-    Morphology.Realization.Interpreted Unit SyntacticContext Unit Sem where
+abstract head whose contextual interpretation is the alloseme the Subset
+Principle picks from the vocabulary (a singleton, `∅` at a semantic gap),
+with an empty List-2 form side. -/
+def toInterpreted {Sem : Type} (v : List (VocabularyItem Feature Sem)) :
+    Morphology.Realization.Interpreted Unit (Neighborhood (List Feature)) Unit Sem where
   realize _ _ := ∅
-  interp _ c :=
-    match selectBy AllosemicEntry.score v c with
-    | some e => {e.denotation}
-    | none => ∅
+  interp _ n := (subsetPrinciple v n).elim ∅ ({·})
 
 /-- The verbal categorizer's meaning varies with context — eventive
 under an eventive complement, zero elsewhere — so v is `IsAllosemous` on
@@ -629,7 +646,6 @@ the shared carrier: contextual meaning variation as non-constancy of the
 `interp` map ([benz-2025]). -/
 theorem Verbalizer.isAllosemous :
     (toInterpreted Verbalizer.vocabulary).IsAllosemous () :=
-  ⟨{ complementIsEventive := true }, { complementIsEventive := false },
-   .eventive, by decide, .zero, by decide, by decide⟩
+  ⟨complement [.eventive], ∅, .eventive, by decide, .zero, by decide, by decide⟩
 
 end DistributedMorphology.Allosemy

--- a/Linglib/Morphology/DistributedMorphology/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Basic.lean
@@ -3,150 +3,53 @@ import Linglib.Morphology.Exponence.Select
 import Mathlib.Data.Finset.Card
 
 /-!
-# Vocabulary items and allosemes as exponence rules
+# Vocabulary items as exponence rules
 
-A `VocabularyItem` and an `Allosemy.AllosemicEntry` each expose the shared
-exponence interface (`Morphology.Exponence.Rule`), so DM's List 2 (form) and
-List 3 (meaning) are resolved by one `Exponence.selectBy` competition, whose
-winner is the Elsewhere winner. This file holds the two `Rule` instances and
-the specificity laws they rest on.
+A `VocabularyItem` exposes the shared exponence interface
+(`Morphology.Exponence.Rule`) over neighborhoods: it applies where its
+specification is included in the neighborhood, and its specificity — the
+number of positioned features it mentions — is strictly antitone in the
+engine's order, so score selection is Elsewhere selection.
 -/
 
-namespace DistributedMorphology
+namespace DistributedMorphology.VocabularyItem
 
 open Morphology.Exponence
 
-namespace Allosemy
-
-@[simp] theorem SyntacticContext.matches_self (c : SyntacticContext) : c.matches c = true := by
-  simp [SyntacticContext.matches]
-
-/-- A broader specification (matched by every query the narrower one is)
-has no more non-wildcard fields: the score reflects applicability-set
-inclusion contravariantly. -/
-theorem SyntacticContext.specificity_le_of_matches_subset {r s : SyntacticContext}
-    (h : ∀ q, s.matches q = true → r.matches q = true) :
-    r.specificity ≤ s.specificity := by
-  have hrs : r.matches s = true := h s (SyntacticContext.matches_self s)
-  simp only [SyntacticContext.matches, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq] at hrs
-  obtain ⟨⟨⟨hb, ha⟩, he⟩, hst⟩ := hrs
-  simp only [SyntacticContext.specificity]
-  have b : (if r.belowCat.isSome then 1 else 0) ≤ (if s.belowCat.isSome then (1 : ℕ) else 0) := by
-    rcases hb with hb | hb <;> simp [hb]
-  have a : (if r.aboveCat.isSome then 1 else 0) ≤ (if s.aboveCat.isSome then (1 : ℕ) else 0) := by
-    rcases ha with ha | ha <;> simp [ha]
-  have e : (if r.complementIsEventive then 1 else 0) ≤
-      (if s.complementIsEventive then (1 : ℕ) else 0) := by
-    cases hr : r.complementIsEventive <;> cases hsc : s.complementIsEventive <;> simp_all
-  have t : (if r.complementIsStative then 1 else 0) ≤
-      (if s.complementIsStative then (1 : ℕ) else 0) := by
-    cases hr : r.complementIsStative <;> cases hsc : s.complementIsStative <;> simp_all
-  omega
-
-/-- Equal-score inclusion is equality: if every query matching `s` also
-matches `r` and the two carry the same number of non-wildcard fields, the
-specifications coincide. -/
-theorem SyntacticContext.eq_of_matches_subset_of_specificity_eq {r s : SyntacticContext}
-    (h : ∀ q, s.matches q = true → r.matches q = true)
-    (hs : r.specificity = s.specificity) : r = s := by
-  have hrs : r.matches s = true := h s (SyntacticContext.matches_self s)
-  simp only [SyntacticContext.matches, Bool.and_eq_true, Bool.or_eq_true, beq_iff_eq] at hrs
-  obtain ⟨⟨⟨hb, ha⟩, he⟩, hst⟩ := hrs
-  simp only [SyntacticContext.specificity] at hs
-  have b : (if r.belowCat.isSome then 1 else 0) ≤ (if s.belowCat.isSome then (1 : ℕ) else 0) := by
-    rcases hb with h | h <;> simp [h]
-  have a : (if r.aboveCat.isSome then 1 else 0) ≤ (if s.aboveCat.isSome then (1 : ℕ) else 0) := by
-    rcases ha with h | h <;> simp [h]
-  have e : (if r.complementIsEventive then 1 else 0) ≤
-      (if s.complementIsEventive then (1 : ℕ) else 0) := by
-    cases hr : r.complementIsEventive <;> cases hsc : s.complementIsEventive <;> simp_all
-  have t : (if r.complementIsStative then 1 else 0) ≤
-      (if s.complementIsStative then (1 : ℕ) else 0) := by
-    cases hr : r.complementIsStative <;> cases hsc : s.complementIsStative <;> simp_all
-  obtain ⟨rb, ra, rc, rd⟩ := r
-  obtain ⟨sb, sa, sc, sd⟩ := s
-  have eqb : rb = sb := by cases rb <;> cases sb <;> simp_all; all_goals omega
-  have eqa : ra = sa := by cases ra <;> cases sa <;> simp_all; all_goals omega
-  have eqc : rc = sc := by cases rc <;> cases sc <;> simp_all; all_goals omega
-  have eqd : rd = sd := by cases rd <;> cases sd <;> simp_all
-  subst eqb eqa eqc eqd; rfl
-
-section Exponence
-
-variable {Sem : Type}
-
-/-- An `AllosemicEntry` exposes the shared exponence interface: contexts
-are `SyntacticContext`s, applicability is `matches`, the exponent is the
-denotation. -/
-instance : Morphology.Exponence.Rule (AllosemicEntry Sem) SyntacticContext Sem :=
-  ⟨AllosemicEntry.denotation, fun e c => e.context.matches c = true⟩
-
-instance : Preorder (AllosemicEntry Sem) := Morphology.Exponence.toPreorder
-
-instance : DecidableRel (Applies : AllosemicEntry Sem → SyntacticContext → Prop) :=
-  fun e c => inferInstanceAs (Decidable (e.context.matches c = true))
-
-/-- The specificity score of an alloseme: the non-wildcard-field count of
-its conditioning context. -/
-def AllosemicEntry.score (e : AllosemicEntry Sem) : Nat := e.context.specificity
-
-/-- The score is strictly antitone in specificity: a strictly broader
-alloseme scores strictly lower. -/
-theorem score_strictAnti : StrictAnti (AllosemicEntry.score (Sem := Sem)) := by
-  intro s r hlt
-  have hsub : ∀ q, s.context.matches q = true → r.context.matches q = true := hlt.le
-  refine lt_of_le_of_ne (SyntacticContext.specificity_le_of_matches_subset hsub)
-    fun heq => not_le_of_gt hlt ?_
-  have hctx : r.context = s.context :=
-    SyntacticContext.eq_of_matches_subset_of_specificity_eq hsub heq
-  show ∀ q, r.context.matches q = true → s.context.matches q = true
-  rw [hctx]; exact fun _ h => h
-
-/-- Score selection over an alloseme vocabulary is Elsewhere selection:
-the winner is `≤`-minimal among the applicable allosemes. -/
-theorem selectBy_score_isElsewhereWinner {v : List (AllosemicEntry Sem)}
-    {c : SyntacticContext} {r : AllosemicEntry Sem}
-    (h : selectBy AllosemicEntry.score v c = some r) : IsElsewhereWinner v c r :=
-  selectBy_isElsewhereWinner (score_strictAnti.strictAntiOn _) h
-
-end Exponence
-
-end Allosemy
-
-namespace VocabularyItem
-
-variable {F E : Type*} {i j : VocabularyItem F E} {t : List F}
+variable {F E : Type*} {i j : VocabularyItem F E} {n : Neighborhood (List F)}
 
 /-- A Vocabulary Item exposes the shared exponence interface: contexts are
-feature bundles, applicability is feature inclusion. -/
-instance : Rule (VocabularyItem F E) (List F) E := ⟨exponent, fun i t => i.features ⊆ t⟩
+neighborhoods, applicability is inclusion of the specification. -/
+instance : Rule (VocabularyItem F E) (Neighborhood (List F)) E := ⟨exponent, fun i n => i.spec ⊆ n⟩
 
 instance : Preorder (VocabularyItem F E) := toPreorder
 
-theorem applies_iff : Applies i t ↔ i.features ⊆ t := Iff.rfl
+theorem applies_iff : Applies i n ↔ i.spec ⊆ n := Iff.rfl
 
-/-- An item with no features applies at every bundle. -/
-theorem elsewhere_applies (e : E) (t : List F) : Applies (⟨[], e⟩ : VocabularyItem F E) t :=
+/-- The Elsewhere item applies at every neighborhood. -/
+theorem elsewhere_applies (e : E) (n : Neighborhood (List F)) :
+    Applies (⟨∅, e⟩ : VocabularyItem F E) n :=
   List.nil_subset _
 
-theorem le_iff_applies : i ≤ j ↔ ∀ ⦃t : List F⦄, i.features ⊆ t → j.features ⊆ t := Iff.rfl
+theorem le_iff_applies : i ≤ j ↔ ∀ ⦃n : Neighborhood (List F)⦄, i.spec ⊆ n → j.spec ⊆ n :=
+  Iff.rfl
 
-/-- The engine's specificity order is reverse feature inclusion. -/
-theorem le_iff : i ≤ j ↔ j.features ⊆ i.features :=
-  ⟨fun h => le_iff_applies.mp h (List.Subset.refl _),
-    fun h => le_iff_applies.mpr fun _ ht => List.Subset.trans h ht⟩
+/-- The engine's specificity order is reverse inclusion of specifications. -/
+theorem le_iff : i ≤ j ↔ j.spec ⊆ i.spec :=
+  ⟨fun h => le_iff_applies.mp h (Neighborhood.Subset.refl _),
+    fun h => le_iff_applies.mpr fun _ hn => Neighborhood.Subset.trans h hn⟩
 
 variable [DecidableEq F]
 
-instance : DecidableRel (Applies : VocabularyItem F E → List F → Prop) :=
-  fun i t => decidable_of_iff (∀ f ∈ i.features, f ∈ t) Iff.rfl
+instance : DecidableRel (Applies : VocabularyItem F E → Neighborhood (List F) → Prop) :=
+  fun i n => inferInstanceAs (Decidable (i.spec ⊆ n))
 
-/-- The number of distinct features an item specifies — the Subset
-Principle's specificity score. -/
-def specificity (i : VocabularyItem F E) : ℕ := i.features.toFinset.card
+/-- The number of distinct positioned features an item mentions — the
+Subset Principle's specificity score. -/
+def specificity (i : VocabularyItem F E) : ℕ := i.spec.positioned.toFinset.card
 
 theorem toFinset_subset_toFinset :
-    i.features.toFinset ⊆ j.features.toFinset ↔ i.features ⊆ j.features :=
+    i.spec.positioned.toFinset ⊆ j.spec.positioned.toFinset ↔ i.spec ⊆ j.spec :=
   Multiset.toFinset_subset.trans Multiset.coe_subset
 
 theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E → ℕ) :=
@@ -154,6 +57,4 @@ theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E �
     ⟨toFinset_subset_toFinset.mpr (le_iff.mp h.le),
       fun hc => (lt_iff_le_not_ge.mp h).2 (le_iff.mpr (toFinset_subset_toFinset.mp hc))⟩
 
-end VocabularyItem
-
-end DistributedMorphology
+end DistributedMorphology.VocabularyItem

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -1,95 +1,45 @@
-import Linglib.Morphology.DistributedMorphology.Categorizer.Basic
+import Linglib.Morphology.DistributedMorphology.Neighborhood
 
 /-!
-# Vocabulary items and allosemes
+# Vocabulary items
 
-The rule types of Distributed Morphology's two interpretive lists:
-`VocabularyItem` pairs a feature specification with the exponent that
-spells it out (List 2), and `Allosemy.AllosemicEntry` pairs a meaning with
-the conditioning `Allosemy.SyntacticContext` (List 3). The shared
-selection-engine instances live in `DistributedMorphology/Basic.lean`.
-
-## References
-
-* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
-  inflection*][halle-marantz-1993]
-* [J. Benz, *Structure and interpretation across categories*][benz-2025]
+A Vocabulary Item pairs a specification with the exponent that realizes it
+([halle-marantz-1993]): the features of the terminal it spells out, together
+with the features it requires of the neighboring terminals — its contextual
+environment, `/ __ ]X]`. Form and meaning share the type: an alloseme is an
+item whose exponent is a denotation (`DistributedMorphology/Allosemy.lean`).
+The selection-engine instance lives in `DistributedMorphology/Basic.lean`.
 -/
 
 namespace DistributedMorphology
 
-/-- A Vocabulary Item: a feature specification paired with an exponent,
-applicable at any bundle containing every specified feature. -/
+/-- A Vocabulary Item: a specification paired with an exponent, applicable at
+any neighborhood containing every feature it mentions. -/
 structure VocabularyItem (F E : Type*) where
-  /-- The features the item spells out. -/
-  features : List F
+  /-- The features the item spells out, with those it requires of the
+  adjacent terminals. -/
+  spec : Neighborhood (List F)
   /-- The exponent the item inserts. -/
   exponent : E
   deriving DecidableEq, Repr
 
-namespace Allosemy
+variable {F E : Type*}
 
-/-- A syntactic context that conditions alloseme selection.
+namespace VocabularyItem
 
-    §2.4 of [benz-2025]: allosemy is conditioned by the semantics of a
-    previously interpreted domain (below) or the syntactic features of the
-    next higher head (above). Both cyclic locality and linear adjacency
-    play a role, but the exact locality conditions are an open question.
+/-- The features the item spells out at its own terminal. -/
+def features (i : VocabularyItem F E) : List F := i.spec.focus
 
-    We represent context minimally as what is structurally below and
-    above the allosemic head. -/
-structure SyntacticContext where
-  /-- Category of the complement (below). `none` = no complement. -/
-  belowCat : Option Categorizer := none
-  /-- Category of the embedding head (above). `none` = root context. -/
-  aboveCat : Option Categorizer := none
-  /-- Does the complement denote an event? -/
-  complementIsEventive : Bool := false
-  /-- Does the complement denote a state? ([kratzer-1996] §2.3: the
-      stative-vs-dynamic split conditions the Voice alloseme.) -/
-  complementIsStative : Bool := false
-  deriving DecidableEq, Repr
+/-- A context-free item: the features it spells out and its exponent. -/
+def ofFeatures (fs : List F) (e : E) : VocabularyItem F E := ⟨fs, e⟩
 
-/-- A partial context specification `spec` **matches** a fully-specified
-query context `c` when every non-wildcard field of `spec` agrees with
-`c`. A field at its default (`none` / `false`) is a **wildcard**,
-constraining nothing; a set field must agree. More specified contexts
-match strictly fewer queries — the applicability-set inclusion that
-orders exponence rules ([kiparsky-1973]). -/
-def SyntacticContext.matches (spec c : SyntacticContext) : Bool :=
-  (spec.belowCat == none || spec.belowCat == c.belowCat) &&
-  (spec.aboveCat == none || spec.aboveCat == c.aboveCat) &&
-  (!spec.complementIsEventive || c.complementIsEventive) &&
-  (!spec.complementIsStative || c.complementIsStative)
+/-- `fs ⟷ e`: the context-free Vocabulary Item spelling out `fs` as `e`. -/
+scoped infixr:25 " ⟷ " => ofFeatures
 
-/-- The specificity **score**: the number of non-wildcard fields. Higher
-score = more specified = strictly smaller applicability set, so the score
-reflects the specificity preorder contravariantly
-(`SyntacticContext.specificity_le_of_matches_subset`). -/
-def SyntacticContext.specificity (c : SyntacticContext) : Nat :=
-  (if c.belowCat.isSome then 1 else 0) + (if c.aboveCat.isSome then 1 else 0)
-    + (if c.complementIsEventive then 1 else 0) + (if c.complementIsStative then 1 else 0)
+@[simp] theorem spec_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).spec = ↑fs := rfl
 
-/-- A single alloseme: a meaning available in a particular context. A
-head's List-3 inventory is its alloseme *vocabulary*, a bare
-`List (AllosemicEntry Sem)` — any functional morpheme can carry one
-(the categorizers, Voice, prefixes), so no head type is baked in. -/
-structure AllosemicEntry (Sem : Type) where
-  /-- The semantic contribution. -/
-  denotation : Sem
-  /-- The conditioning context. -/
-  context : SyntacticContext
-  deriving BEq, Repr
+@[simp] theorem exponent_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).exponent = e := rfl
 
-/-- The denotations an alloseme vocabulary licenses in context `c` — the
-entries whose conditioning context matches `c`. Alloseme ambiguity in a
-context is non-singleton licensing, and the canonical default among the
-licensed entries is the Elsewhere winner
-(`selectBy_score_isElsewhereWinner`). -/
-def licensed {Sem : Type} (v : List (AllosemicEntry Sem))
-    (c : SyntacticContext) : List Sem :=
-  (v.filter (·.context.matches c)).map (·.denotation)
-
-end Allosemy
+end VocabularyItem
 
 end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Fusion.lean
+++ b/Linglib/Morphology/DistributedMorphology/Fusion.lean
@@ -99,8 +99,9 @@ variable {F E : Type*} [DecidableEq F]
 carrying the exponent draws on features missing from each unfused bundle,
 the Subset Principle can select it at neither unfused node — only the
 fused bundle contains its item's features (`subsetPrinciple_winner_mem`). -/
-theorem portmanteau_needs_fusion {items : List (VocabularyItem F E)} {p q : List F} {e : E}
-    (he : ∀ i ∈ items, i.exponent = e → ¬ i.features ⊆ p ∧ ¬ i.features ⊆ q) :
+theorem portmanteau_needs_fusion {items : List (VocabularyItem F E)}
+    {p q : Neighborhood (List F)} {e : E}
+    (he : ∀ i ∈ items, i.exponent = e → ¬ i.spec ⊆ p ∧ ¬ i.spec ⊆ q) :
     subsetPrinciple items p ≠ some e ∧ subsetPrinciple items q ≠ some e := by
   refine ⟨fun h => ?_, fun h => ?_⟩ <;> obtain ⟨i, hi, rfl, happ⟩ := subsetPrinciple_winner_mem h
   · exact (he i hi rfl).1 happ

--- a/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
+++ b/Linglib/Morphology/DistributedMorphology/Impoverishment.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Minimalist.Features
+import Linglib.Morphology.DistributedMorphology.Neighborhood
 
 /-!
 # Impoverishment
@@ -7,8 +8,8 @@ Impoverishment deletes features from a terminal before Vocabulary
 Insertion — the Distributed Morphology mechanism for syncretism: a
 context that loses a distinguishing feature falls together with its
 neighbor at VI, forcing retreat to the more general exponent. A rule is
-evaluated against a `Neighborhood` — the focus terminal plus its
-adjacent terminals — and the focus/context split makes the
+evaluated against a `Neighborhood` (`DistributedMorphology/Neighborhood.lean`)
+— the focus terminal plus its adjacent terminals — and the focus/context split makes the
 paradigmatic/syntagmatic distinction structural: a rule whose condition
 factors through the focus is paradigmatic as a theorem about the rule,
 not an annotation. Deletion only removes: every dimension of the output
@@ -18,7 +19,6 @@ the post-impoverishment VI winner the retreat-to-the-general exponent
 
 ## Main definitions
 
-* `Neighborhood` — the local context a postsyntactic rule inspects
 * `ImpoverishmentRule` — a conditioned feature deletion, parametric in
   the bundle and target types; `ImpoverishmentRule.apply` instantiates
   it with a deletion operation
@@ -54,27 +54,6 @@ from fission and the coproduct (`Studies/SenturiaMarcolli2025.lean`).
 namespace DistributedMorphology
 
 open Minimalist
-
-/-! ### Neighborhoods -/
-
-/-- The local context a postsyntactic rule may inspect. The `focus`
-bundle is the terminal targeted for rewriting; `leftCtx` and `rightCtx`
-are the surrounding terminals, nearest first. The zipper view of a
-whole spell-out domain is `Spellout.lean`'s `mapNeighborhoods`.
-
-Splitting `focus` from context makes the paradigmatic/syntagmatic
-distinction structural: a condition that only inspects `focus` is
-paradigmatic by construction; one that reads `leftCtx` or `rightCtx` is
-syntagmatic. -/
-structure Neighborhood (Bundle : Type*) where
-  focus    : Bundle
-  leftCtx  : List Bundle := []
-  rightCtx : List Bundle := []
-  deriving Repr
-
-/-- A bundle, viewed as a context-free neighborhood. -/
-def Neighborhood.ofBundle {Bundle : Type*} (fb : Bundle) : Neighborhood Bundle :=
-  { focus := fb }
 
 /-! ### Impoverishment rules -/
 

--- a/Linglib/Morphology/DistributedMorphology/Neighborhood.lean
+++ b/Linglib/Morphology/DistributedMorphology/Neighborhood.lean
@@ -1,0 +1,110 @@
+import Mathlib.Data.List.Basic
+
+/-!
+# Neighborhoods
+
+The local environment a postsyntactic rule inspects: a focus terminal with
+the terminals to either side, nearest first. Vocabulary Items and
+Impoverishment rules are stated over the same neighborhoods — an item's
+specification is itself a neighborhood of feature lists, and it applies
+where every feature it mentions, at the focus or on a neighbor, is present
+(`Neighborhood.positioned`, `⊆`).
+
+## Main definitions
+
+* `Neighborhood` — focus, left context, right context.
+* `Neighborhood.positioned` — the features of a neighborhood of feature
+  lists, each tagged with its `Position`.
+* `⊆` on `Neighborhood (List F)` — inclusion of positioned features.
+
+## Implementation notes
+
+A bare bundle coerces to the context-free neighborhood and `∅` is the
+empty specification, so a context-free Vocabulary Item is written
+`⟨[f₁, f₂], e⟩` and the Elsewhere item `⟨∅, e⟩`. Positions count outward
+from the focus: `left` toward the root, `right` toward the clause.
+-/
+
+namespace DistributedMorphology
+
+variable {Bundle F : Type*}
+
+/-- The local context a postsyntactic rule may inspect: the `focus` terminal
+and the terminals to either side, nearest first. A condition that only
+inspects `focus` is paradigmatic; one that reads `leftCtx` or `rightCtx` is
+syntagmatic. -/
+structure Neighborhood (Bundle : Type*) where
+  focus    : Bundle
+  leftCtx  : List Bundle := []
+  rightCtx : List Bundle := []
+  deriving Repr, DecidableEq
+
+namespace Neighborhood
+
+/-- A bundle, viewed as a context-free neighborhood. -/
+def ofBundle (fb : Bundle) : Neighborhood Bundle := { focus := fb }
+
+instance : Coe Bundle (Neighborhood Bundle) := ⟨ofBundle⟩
+
+instance [EmptyCollection Bundle] : EmptyCollection (Neighborhood Bundle) := ⟨{ focus := ∅ }⟩
+
+@[simp] theorem focus_ofBundle (fb : Bundle) : (ofBundle fb).focus = fb := rfl
+
+@[simp] theorem leftCtx_ofBundle (fb : Bundle) : (ofBundle fb).leftCtx = [] := rfl
+
+@[simp] theorem rightCtx_ofBundle (fb : Bundle) : (ofBundle fb).rightCtx = [] := rfl
+
+/-! ### Positioned features -/
+
+/-- A position in a neighborhood: the focus, or the `i`-th terminal to a
+side, nearest first. -/
+inductive Position where
+  | focus
+  | left (i : ℕ)
+  | right (i : ℕ)
+  deriving DecidableEq, Repr
+
+/-- The features of a neighborhood of feature lists, each tagged with the
+position it sits at. -/
+def positioned (n : Neighborhood (List F)) : List (Position × F) :=
+  n.focus.map (Position.focus, ·) ++
+    n.leftCtx.zipIdx.flatMap (fun p => p.1.map (Position.left p.2, ·)) ++
+    n.rightCtx.zipIdx.flatMap (fun p => p.1.map (Position.right p.2, ·))
+
+/-- A specification is included in a neighborhood when every positioned
+feature it mentions is present; a terminal it does not mention is
+unconstrained — the Subset Principle over neighborhoods. -/
+instance : HasSubset (Neighborhood (List F)) := ⟨fun s n => s.positioned ⊆ n.positioned⟩
+
+theorem subset_def {s n : Neighborhood (List F)} : s ⊆ n ↔ s.positioned ⊆ n.positioned :=
+  Iff.rfl
+
+instance [DecidableEq F] :
+    DecidableRel (· ⊆ · : Neighborhood (List F) → Neighborhood (List F) → Prop) :=
+  fun s n => inferInstanceAs (Decidable (s.positioned ⊆ n.positioned))
+
+theorem Subset.refl (n : Neighborhood (List F)) : n ⊆ n := List.Subset.refl _
+
+theorem Subset.trans {a b c : Neighborhood (List F)} (h₁ : a ⊆ b) (h₂ : b ⊆ c) : a ⊆ c :=
+  List.Subset.trans h₁ h₂
+
+instance : Std.Refl (· ⊆ · : Neighborhood (List F) → Neighborhood (List F) → Prop) := ⟨Subset.refl⟩
+
+instance : Trans (· ⊆ · : Neighborhood (List F) → Neighborhood (List F) → Prop) (· ⊆ ·) (· ⊆ ·) :=
+  ⟨Subset.trans⟩
+
+@[simp] theorem positioned_ofBundle (fs : List F) :
+    (ofBundle fs : Neighborhood (List F)).positioned = fs.map (Position.focus, ·) := by
+  simp [positioned, ofBundle]
+
+@[simp] theorem positioned_empty : (∅ : Neighborhood (List F)).positioned = [] := rfl
+
+/-- Context-free specifications compare by feature inclusion. -/
+theorem ofBundle_subset_ofBundle {s t : List F} :
+    (ofBundle s : Neighborhood (List F)) ⊆ ofBundle t ↔ s ⊆ t := by
+  rw [subset_def, positioned_ofBundle, positioned_ofBundle]
+  exact List.map_subset_iff _ fun _ _ h => (Prod.mk.inj h).2
+
+end Neighborhood
+
+end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Spellout.lean
+++ b/Linglib/Morphology/DistributedMorphology/Spellout.lean
@@ -6,7 +6,8 @@ import Linglib.Morphology.DistributedMorphology.Impoverishment
 
 The PF branch of the Y-model at the domain level: a spell-out domain is
 the sequence of terminals the syntax hands over, the postsyntactic modules
-transform it, and pointwise Vocabulary Insertion realizes what survives
+transform it, and Vocabulary Insertion realizes what survives, each
+position in its neighborhood
 ([halle-marantz-1993]; module inventory and ordering per
 [arregi-nevins-2012]). The focus-level rule types
 (`ImpoverishmentRule` and kin) rewrite one terminal inside
@@ -32,7 +33,7 @@ fusion feeding one insertion).
   ([arregi-nevins-2012]'s Obliteration) and adjacent-terminal swap, with
   first-match applicators and count laws
 * `FusionRule.applyFirstAdjacent` — the domain lift of Fusion
-* `Spellout` — the module sequence plus pointwise insertion; `run`, `pf`,
+* `Spellout` — the module sequence plus insertion in context; `run`, `pf`,
   `runModules_append`
 
 ## Todo
@@ -55,15 +56,16 @@ abbrev SpelloutDomain (Bundle : Type*) := List Bundle
 
 variable {Bundle Ctx : Type*}
 
-/-- Rewrite every terminal in its neighborhood: position `i` sees the
+/-- Apply `f` to every terminal in its neighborhood: position `i` sees the
 earlier terminals as `leftCtx` and the later ones as `rightCtx`, nearest
-first. The domain lift of a focus-level rule such as Impoverishment. -/
-def mapNeighborhoods (f : Neighborhood Bundle → Bundle)
-    (d : SpelloutDomain Bundle) : SpelloutDomain Bundle :=
+first. The domain lift of a focus-level rule such as Impoverishment, and of
+Vocabulary Insertion. -/
+def mapNeighborhoods {C : Type*} (f : Neighborhood Bundle → C)
+    (d : SpelloutDomain Bundle) : List C :=
   d.mapIdx fun i b => f ⟨b, (d.take i).reverse, d.drop (i + 1)⟩
 
 /-- Neighborhood rewriting preserves the number of terminals. -/
-@[simp] theorem length_mapNeighborhoods (f : Neighborhood Bundle → Bundle)
+@[simp] theorem length_mapNeighborhoods {C : Type*} (f : Neighborhood Bundle → C)
     (d : SpelloutDomain Bundle) :
     (mapNeighborhoods f d).length = d.length := by
   simp [mapNeighborhoods]
@@ -235,13 +237,14 @@ theorem runModules_append
       = d := rfl
 
 /-- A PF-branch pipeline over a spell-out domain: the ordered
-postsyntactic modules, then pointwise Vocabulary Insertion at each
-surviving position. -/
+postsyntactic modules, then Vocabulary Insertion at each surviving
+position, in its neighborhood. -/
 structure Spellout (Bundle F : Type*) where
   /-- The ordered postsyntactic module sequence. -/
   modules : List (SpelloutDomain Bundle → SpelloutDomain Bundle)
-  /-- Pointwise Vocabulary Insertion; `none` is a non-licensed position. -/
-  insert : Bundle → Option F
+  /-- Vocabulary Insertion at a position, seeing its neighbors; `none` is a
+  non-licensed position. -/
+  insert : Neighborhood Bundle → Option F
 
 namespace Spellout
 
@@ -255,7 +258,7 @@ def run (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
 /-- The PF output: one insertion slot per surviving position. -/
 def pf (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
     List (Option F) :=
-  (s.run d).map s.insert
+  mapNeighborhoods s.insert (s.run d)
 
 /-- Exponent slots equal terminals after the modules: the exponent count
 diverges from the syntactic terminal count only through the modules. -/

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
@@ -4,12 +4,13 @@ import Linglib.Morphology.Exponence.Select
 /-!
 # Vocabulary insertion
 
-Vocabulary Insertion is the operation that supplies syntactic terminals with
-phonological exponents in Distributed Morphology: the Vocabulary Items of
-List 2 compete for insertion at each terminal, and the Subset Principle of
-[halle-marantz-1993] picks the item whose feature specification is the
-largest subset of the terminal's bundle. This file specializes the shared
-exponence engine (`Morphology.Exponence.selectBy`) to that competition.
+Vocabulary Insertion supplies syntactic terminals with phonological
+exponents: the Vocabulary Items of List 2 compete for insertion at each
+terminal, and the Subset Principle of [halle-marantz-1993] picks the item
+whose specification is the largest one the terminal's neighborhood contains —
+its own features and, for a contextual item, the features of the adjacent
+terminals. This file specializes the shared exponence engine
+(`Morphology.Exponence.selectBy`) to that competition.
 
 ## Main definitions
 
@@ -19,11 +20,10 @@ exponence engine (`Morphology.Exponence.selectBy`) to that competition.
 ## Main results
 
 * `winner?_isElsewhereWinner`: the winner is an Elsewhere winner of the
-  shared core, with no faithfulness hypothesis — over feature
-  specifications the engine's specificity order is reverse feature
-  inclusion (`VocabularyItem.le_iff`).
-* `winner?_retreat`: deleting features from the target can only make the
-  winner less specific — retreat to the general case.
+  shared core, with no faithfulness hypothesis — the engine's specificity
+  order is reverse inclusion of specifications (`VocabularyItem.le_iff`).
+* `winner?_retreat`: deleting features from the neighborhood can only make
+  the winner less specific — retreat to the general case.
 
 ## References
 
@@ -39,59 +39,62 @@ open Morphology.Exponence
 
 section SubsetPrinciple
 
-variable {F E : Type*} [DecidableEq F] {items : List (VocabularyItem F E)} {t t' : List F}
-  {i i' : VocabularyItem F E} {e : E}
+variable {F E : Type*} [DecidableEq F] {items : List (VocabularyItem F E)}
+  {n n' : Neighborhood (List F)} {i i' : VocabularyItem F E} {e : E}
 
 /-- The Subset Principle's winning item: the applicable item of greatest
 `specificity` (the earliest, under ties). -/
-def winner? (items : List (VocabularyItem F E)) (t : List F) : Option (VocabularyItem F E) :=
-  selectBy VocabularyItem.specificity items t
+def winner? (items : List (VocabularyItem F E)) (n : Neighborhood (List F)) :
+    Option (VocabularyItem F E) :=
+  selectBy VocabularyItem.specificity items n
 
 /-- The **Subset Principle** ([halle-marantz-1993]): the exponent of the most
-specific item whose features the target bears; `none` iff no item applies. -/
-def subsetPrinciple (items : List (VocabularyItem F E)) (t : List F) : Option E :=
-  realize VocabularyItem.specificity items t
+specific item whose specification the neighborhood contains; `none` iff no
+item applies. -/
+def subsetPrinciple (items : List (VocabularyItem F E)) (n : Neighborhood (List F)) : Option E :=
+  realize VocabularyItem.specificity items n
 
-theorem winner?_mem (h : winner? items t = some i) : i ∈ applicable items t :=
+theorem winner?_mem (h : winner? items n = some i) : i ∈ applicable items n :=
   List.argmax_mem h
 
-theorem winner?_spec (h : winner? items t = some i) : i ∈ items ∧ i.features ⊆ t :=
+theorem winner?_spec (h : winner? items n = some i) : i ∈ items ∧ i.spec ⊆ n :=
   mem_applicable.mp (winner?_mem h)
 
 /-- The Subset Principle's exponent comes from an applicable item — the
-selection never draws on features the node does not bear. -/
-theorem subsetPrinciple_winner_mem (h : subsetPrinciple items t = some e) :
-    ∃ i ∈ items, i.exponent = e ∧ i.features ⊆ t := by
+selection never draws on features the neighborhood does not bear. -/
+theorem subsetPrinciple_winner_mem (h : subsetPrinciple items n = some e) :
+    ∃ i ∈ items, i.exponent = e ∧ i.spec ⊆ n := by
   obtain ⟨i, hi, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨i, (winner?_spec hi).1, rfl, (winner?_spec hi).2⟩
 
-theorem winner?_isSome_iff : (winner? items t).isSome ↔ applicable items t ≠ [] := by
+theorem winner?_isSome_iff : (winner? items n).isSome ↔ applicable items n ≠ [] := by
   rw [Option.isSome_iff_ne_none]; exact not_congr selectBy_eq_none_iff
 
-theorem winner?_max (h : winner? items t = some i) :
-    ∀ j ∈ applicable items t, j.specificity ≤ i.specificity :=
+theorem winner?_max (h : winner? items n = some i) :
+    ∀ j ∈ applicable items n, j.specificity ≤ i.specificity :=
   fun _ hj => List.le_of_mem_argmax hj h
 
 /-- The winner is an Elsewhere winner of the shared core — with no
 faithfulness hypothesis, since `VocabularyItem.specificity` is strictly
 antitone outright. -/
-theorem winner?_isElsewhereWinner (h : winner? items t = some i) : IsElsewhereWinner items t i :=
+theorem winner?_isElsewhereWinner (h : winner? items n = some i) : IsElsewhereWinner items n i :=
   selectBy_isElsewhereWinner (VocabularyItem.specificity_strictAnti.strictAntiOn _) h
 
-theorem subsetPrinciple_realizes (h : subsetPrinciple items t = some e) : Realizes items t e :=
+theorem subsetPrinciple_realizes (h : subsetPrinciple items n = some e) : Realizes items n e :=
   realize_realizes (VocabularyItem.specificity_strictAnti.strictAntiOn _) h
 
-/-- Applicability is monotone in the target bundle. -/
-theorem applicable_mono (hsub : t' ⊆ t) : applicable items t' ⊆ applicable items t :=
+/-- Applicability is monotone in the neighborhood. -/
+theorem applicable_mono (hsub : n' ⊆ n) : applicable items n' ⊆ applicable items n :=
   fun _ hi => mem_applicable.mpr
-    ⟨(mem_applicable.mp hi).1, List.Subset.trans (mem_applicable.mp hi).2 hsub⟩
+    ⟨(mem_applicable.mp hi).1, Neighborhood.Subset.trans (mem_applicable.mp hi).2 hsub⟩
 
-/-- **Retreat to the general case**: shrinking the target — deleting features
-by Impoverishment — can only make the winner weakly less specific, which is
-why impoverishment yields syncretism with a more general exponent rather than
-a different specific one ([halle-marantz-1993], [arregi-nevins-2012]). -/
-theorem winner?_retreat (hsub : t' ⊆ t) (h' : winner? items t' = some i') :
-    ∃ i, winner? items t = some i ∧ i'.specificity ≤ i.specificity := by
+/-- **Retreat to the general case**: shrinking the neighborhood — deleting
+features by Impoverishment — can only make the winner weakly less specific,
+which is why impoverishment yields syncretism with a more general exponent
+rather than a different specific one ([halle-marantz-1993],
+[arregi-nevins-2012]). -/
+theorem winner?_retreat (hsub : n' ⊆ n) (h' : winner? items n' = some i') :
+    ∃ i, winner? items n = some i ∧ i'.specificity ≤ i.specificity := by
   have hmem := applicable_mono hsub (winner?_mem h')
   obtain ⟨i, hi⟩ :=
     Option.isSome_iff_exists.mp (winner?_isSome_iff.mpr (List.ne_nil_of_mem hmem))

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean
@@ -1,203 +1,41 @@
-import Linglib.Syntax.Minimalist.Defs
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Agreement.Paradigm
-import Linglib.Morphology.Exponence.Select
-import Mathlib.Data.List.MinMax
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 
 /-!
 # Vocabulary insertion over Minimalist bundles
 
-The Minimalist specialization of Vocabulary Insertion: a `VocabEntry`
-pairs a `FeatureBundle` with an exponent and an optional category
-restriction, matching by feature-list inclusion, and `spellout` realizes
-a valued bundle as the most specific matching exponent. This is the
-bridge from Agree, which values features in narrow syntax, to PF —
-Mam *=(y)a'* surfaces only when Voice bears [+oblique], while a less
-specific entry yields the default exponent.
-
-Selection and realization are the shared exponence engine
-(`Exponence.selectBy`, `Exponence.realize`), so the Elsewhere Condition
-is inherited, not reproved. Over concrete feature bundles the intensional
-subset order is provably the engine's specificity order
-(`VocabEntry.le_iff`), as for `DistributedMorphology.VocabularyItem.le_iff`,
-with the category restriction as an extra conjunct.
+The bridge from Agree, which values features in narrow syntax, to PF: a
+valued `FeatureBundle` is spelled out by the Subset Principle over Vocabulary
+Items on `GramFeature`s, and a vocabulary is built from a paradigm's cells.
 
 ## Main definitions
 
-* `VocabEntry`, `Vocabulary` — Vocabulary Items over `FeatureBundle`
-  with optional category restriction
-* `bestMatch`, `spellout` — Elsewhere selection and realization, as
-  instances of the shared engine
-* `Agreement.Cell.toPhiFeatures`, `makePersonVocab` — building
-  vocabularies from paradigm cells
-
-## Main statements
-
-* `VocabEntry.le_iff` — the engine's specificity order is feature-list
-  inclusion plus context compatibility
-* `bestMatch_isElsewhereWinner` — inherited from the engine
-
-## Implementation notes
-
-This is the Minimalist-bundle specialization of Vocabulary Insertion
-(`VocabularyInsertion/Basic.lean`) — same late insertion and Elsewhere
-Condition ([halle-marantz-1993]), concretized so consumers need not
-instantiate the parameters. The namespace is `Minimalist`, since the
-entry's vocabulary is the Minimalist feature system's PF interface.
-
-## References
-
-* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
-  inflection*][halle-marantz-1993]
+* `Minimalist.spellout` — the Subset Principle over a bundle's features.
+* `Agreement.Cell.toPhiFeatures`, `Minimalist.vocabularyOfCells` — a
+  vocabulary from paradigm cells.
 -/
 
 /-- The φ-feature list of a person-number cell, in the shape
-`makePersonVocab` consumes. -/
+`Minimalist.vocabularyOfCells` consumes. -/
 def Agreement.Cell.toPhiFeatures (c : Agreement.Cell) : List Minimalist.PhiFeature :=
   [.person c.toPerson, .number (if c.isPlural then .plural else .singular)]
 
 namespace Minimalist
 
-/-! ### Vocabulary entries -/
+open DistributedMorphology
 
-/-- A Vocabulary Item: a feature set paired with a phonological
-exponent, optionally restricted to the category of the terminal being
-spelled out. Vocabulary Insertion inserts the most specific matching
-entry. -/
-structure VocabEntry where
-  /-- Features this entry matches (must be included in the target). -/
-  features : FeatureBundle
-  /-- The phonological exponent. -/
-  exponent : String
-  /-- Optional context restriction: the category of the host head;
-  `none` is unrestricted. -/
-  context : Option Cat := none
-  deriving Repr
-
-/-- The entry's features are included in the target bundle's: subset
-matching, so an entry need not specify all features of the target. -/
-def VocabEntry.MatchesFeatures (entry : VocabEntry) (target : FeatureBundle) : Prop :=
-  FeatureBundle.toGramFeatures entry.features ⊆
-    FeatureBundle.toGramFeatures target
-
-instance (entry : VocabEntry) (target : FeatureBundle) :
-    Decidable (entry.MatchesFeatures target) :=
-  decidable_of_iff
-    (∀ f ∈ FeatureBundle.toGramFeatures entry.features,
-      f ∈ FeatureBundle.toGramFeatures target)
-    Iff.rfl
-
-/-- The entry matches the target bundle in the given syntactic context:
-feature inclusion plus the optional context restriction. -/
-def VocabEntry.Matches (entry : VocabEntry) (target : FeatureBundle)
-    (ctx : Option Cat) : Prop :=
-  entry.MatchesFeatures target ∧
-  (entry.context = none ∨ entry.context = ctx)
-
-instance (entry : VocabEntry) (target : FeatureBundle) (ctx : Option Cat) :
-    Decidable (entry.Matches target ctx) :=
-  inferInstanceAs (Decidable (_ ∧ _))
-
-/-- The number of features an entry specifies — the score for Elsewhere
-ordering. -/
-def VocabEntry.specificity (entry : VocabEntry) : Nat :=
-  (FeatureBundle.toGramFeatures entry.features).length
-
-/-- A vocabulary: the list of entries competing for insertion. -/
-abbrev Vocabulary := List VocabEntry
-
-/-! ### The shared exponence core -/
-
-section ExponenceCore
-
-open Morphology Morphology.Exponence
-
-/-- A vocabulary entry exposes the shared exponence interface: contexts
-are (target bundle, syntactic context) pairs, applicability is
-`Matches`. -/
-instance : Morphology.Exponence.Rule VocabEntry (FeatureBundle × Option Cat) String :=
-  ⟨VocabEntry.exponent, fun e tc => e.Matches tc.1 tc.2⟩
-
-instance : Preorder VocabEntry := Morphology.Exponence.toPreorder
-
-instance : DecidableRel (Applies : VocabEntry → FeatureBundle × Option Cat → Prop) :=
-  fun e tc => inferInstanceAs (Decidable (e.Matches tc.1 tc.2))
-
-/-- The engine's specificity order, unfolded: `e ≤ e'` iff `e'` matches
-wherever `e` does. -/
-theorem VocabEntry.le_iff_matches {e e' : VocabEntry} :
-    e ≤ e' ↔ ∀ ⦃tc : FeatureBundle × Option Cat⦄,
-      e.Matches tc.1 tc.2 → e'.Matches tc.1 tc.2 :=
-  Iff.rfl
-
-/-- Every entry matches its own feature bundle. -/
-theorem VocabEntry.matchesFeatures_self (e : VocabEntry) :
-    e.MatchesFeatures e.features :=
-  List.Subset.refl _
-
-/-- The engine's specificity order, characterized: `e ≤ e'` iff `e'`'s
-features are included in `e`'s and `e'`'s context restriction is
-compatible. Over feature bundles the intensional inclusion order IS the
-specificity order, as in `DistributedMorphology.VocabularyItem.le_iff`. -/
-theorem VocabEntry.le_iff {e e' : VocabEntry} :
-    e ≤ e' ↔
-      FeatureBundle.toGramFeatures e'.features ⊆
-          FeatureBundle.toGramFeatures e.features
-        ∧ (e'.context = none ∨ e'.context = e.context) := by
-  constructor
-  · intro h
-    obtain ⟨hm', hctx'⟩ :=
-      VocabEntry.le_iff_matches.mp h (tc := (e.features, e.context))
-        ⟨e.matchesFeatures_self, Or.inr rfl⟩
-    exact ⟨hm', hctx'⟩
-  · rintro ⟨hf, hc⟩
-    rw [VocabEntry.le_iff_matches]
-    rintro ⟨t, c⟩ ⟨hm, hctx⟩
-    refine ⟨List.Subset.trans hf hm, ?_⟩
-    rcases hc with h | h
-    · exact Or.inl h
-    · rcases hctx with h2 | h2
-      · exact Or.inl (h.trans h2)
-      · exact Or.inr (h.trans h2)
-
-/-! ### Selection and realization -/
-
-/-- The most specific matching entry: the shared engine's `selectBy` on
-the feature-count score. -/
-def bestMatch (vocab : Vocabulary) (target : FeatureBundle) (ctx : Option Cat) :
-    Option VocabEntry :=
-  selectBy VocabEntry.specificity vocab (target, ctx)
-
-/-- Spell out a feature bundle as the best matching entry's exponent —
-the shared engine's `realize`. `none` is the zero/null exponent. -/
-def spellout (vocab : Vocabulary) (target : FeatureBundle) (ctx : Option Cat) :
+/-- Spell out a valued bundle: the Subset Principle over its features;
+`none` is the zero exponent. -/
+def spellout (vocab : List (VocabularyItem GramFeature String)) (target : FeatureBundle) :
     Option String :=
-  Morphology.Exponence.realize VocabEntry.specificity vocab (target, ctx)
+  subsetPrinciple vocab target.toGramFeatures
 
-/-- With the feature-count score strictly antitone on the applicable
-entries, `bestMatch` returns an Elsewhere winner — inherited from the
-engine (`selectBy_isElsewhereWinner`). -/
-theorem bestMatch_isElsewhereWinner {vocab : Vocabulary}
-    {target : FeatureBundle} {ctx : Option Cat} {e : VocabEntry}
-    (hf : StrictAntiOn VocabEntry.specificity
-      {r | r ∈ applicable vocab (target, ctx)})
-    (h : bestMatch vocab target ctx = some e) :
-    IsElsewhereWinner vocab (target, ctx) e :=
-  selectBy_isElsewhereWinner hf h
-
-end ExponenceCore
-
-/-! ### Vocabulary builders -/
-
-/-- Build a Vocabulary from a paradigm cell type: for each cell, one
-entry with the cell's φ-features as valued features, its exponent, and
-the given context. Elsewhere entries (no features) are appended by the
-caller — this covers only the regular cells. -/
-def makePersonVocab {PN : Type*} (cells : List PN) (toPhi : PN → List PhiFeature)
-    (exponentOf : PN → String) (ctx : Option Cat := none) : Vocabulary :=
-  cells.map λ pn =>
-    { features := .ofGramFeatures ((toPhi pn).map (λ p => .valued (.phi p)))
-    , exponent := exponentOf pn
-    , context := ctx }
+/-- One item per paradigm cell: the cell's φ-features as valued features and
+its exponent. Elsewhere items are appended by the caller. -/
+def vocabularyOfCells {PN : Type*} (cells : List PN) (toPhi : PN → List PhiFeature)
+    (exponentOf : PN → String) : List (VocabularyItem GramFeature String) :=
+  cells.map fun pn =>
+    ⟨((toPhi pn).map fun p => GramFeature.valued (.phi p) : List GramFeature), exponentOf pn⟩
 
 end Minimalist

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -57,6 +57,7 @@ per marked feature.
 namespace Adamson2024
 
 open DistributedMorphology
+open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology.Categorizer (Head)
 
 /-! ### The Gender Locality Hypothesis -/
@@ -129,8 +130,8 @@ inductive ArticleFeature where
 
 /-- The items of (32), in the paper's order. -/
 def articles : List (VocabularyItem ArticleFeature String) :=
-  [⟨[.animate, .pl], "o"⟩, ⟨[.pl], "a"⟩, ⟨[.animate, .proper], "e"⟩, ⟨[.animate], "a"⟩,
-    ⟨[], "o"⟩]
+  [[.animate, .pl] ⟷ "o", [.pl] ⟷ "a", [.animate, .proper] ⟷ "e", [.animate] ⟷ "a",
+    [] ⟷ "o"]
 
 /-- The article's bundle for a Fragment `ArticleCtx`. -/
 def articleFeatures (c : ArticleCtx) : List ArticleFeature :=
@@ -223,7 +224,7 @@ def impoverish (φ : List Phi) : List Phi :=
   runChain (ImpoverishmentRule.apply List.erase) impoverishment (Neighborhood.ofBundle φ)
 
 /-- The declarative marker's items (59): `decl[masc] ↔ ka`, `decl ↔ ke`. -/
-def declarative : List (VocabularyItem Phi String) := [⟨[.masc], "ka"⟩, ⟨[], "ke"⟩]
+def declarative : List (VocabularyItem Phi String) := [[.masc] ⟷ "ka", [] ⟷ "ke"]
 
 /-- The declarative marker agreeing with a nominal of features `φ`. -/
 def decl (φ : List Phi) : Option String := subsetPrinciple declarative (impoverish φ)
@@ -238,7 +239,7 @@ theorem decl_masc_only :
 /-- The possessed noun *mano* 'arm' (A7): *mano* for a marked feature —
 `[participant]` or a surviving `[masc]` — and *mani* elsewhere. -/
 def manV : List (VocabularyItem Phi String) :=
-  [⟨[.participant], "mano"⟩, ⟨[.masc], "mano"⟩, ⟨[], "mani"⟩]
+  [[.participant] ⟷ "mano", [.masc] ⟷ "mano", [] ⟷ "mani"]
 
 /-- The form of *mano* agreeing with possessor `p`. -/
 def mano (p : Possessor) : Option String := subsetPrinciple manV (impoverish (possessorPhi p))

--- a/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
+++ b/Linglib/Studies/AdamsonAnagnostopoulou2025.lean
@@ -793,20 +793,21 @@ theorem icelandic_fem_not_entails_masc :
     the formal DM vocabulary insertion framework. -/
 
 open DistributedMorphology (VocabularyItem subsetPrinciple)
+open scoped DistributedMorphology.VocabularyItem
 
 /-- Greek vocabulary items as `VocabularyItem` entries (schema 21).
     Most specific first: {FEM,MASC} → F, {MASC} → M, {} → N. -/
 def greekVocabItems : List (VocabularyItem GenderNode Infl) :=
-  [ ⟨[fem, masc], .fem⟩,
-    ⟨[masc], .masc⟩,
-    ⟨[], .neut⟩ ]
+  [ [fem, masc] ⟷ .fem,
+    [masc] ⟷ .masc,
+    [] ⟷ .neut ]
 
 /-- BCS vocabulary items as `VocabularyItem` entries (schema 75).
     {FEM,ANIM} → F, {INDIV} → M, {} → N. -/
 def bcsVocabItems : List (VocabularyItem GenderNode Infl) :=
-  [ ⟨[fem, anim], .fem⟩,
-    ⟨[indiv], .masc⟩,
-    ⟨[], .neut⟩ ]
+  [ [fem, anim] ⟷ .fem,
+    [indiv] ⟷ .masc,
+    [] ⟷ .neut ]
 
 /-- Subset Principle agrees with ad-hoc `greekVI` for human mismatch. -/
 theorem sp_greek_human_mismatch :

--- a/Linglib/Studies/Aitha2026.lean
+++ b/Linglib/Studies/Aitha2026.lean
@@ -56,6 +56,7 @@ in the text layer.
 namespace Aitha2026
 
 open Morphology.Case.Allomorphy DistributedMorphology Prosody Data.Examples
+open scoped DistributedMorphology.VocabularyItem
 open Core Constraints OptimalityTheory Core.Optimization Core.Optimization.Evaluation
 
 /-! ### Case -/
@@ -111,7 +112,7 @@ def site (r : Root) (c : TeluguCase) : List Feature :=
 of [ACC] when `acc`. -/
 def forRoots (roots : List Root) (e : String) (acc : Bool := false) :
     List (VocabularyItem Feature String) :=
-  roots.map fun r => ⟨.root r :: if acc then [.acc] else [], e⟩
+  roots.map fun r => (.root r :: if acc then [.acc] else []) ⟷ e
 
 /-- The Vocabulary Items of (4) for the roots of (2): the nominative exponents
 next to their roots, and the oblique exponents next to the same roots and
@@ -266,11 +267,11 @@ inductive NumContext where
 
 /-- The Vocabulary Items of Num in the singular ((40)): *-ni* after *-am*,
 null elsewhere — conditioned inward, as root-out insertion allows. -/
-def numItems : List (VocabularyItem NumContext String) := [⟨[.afterAm], "ni"⟩, ⟨[], "ø"⟩]
+def numItems : List (VocabularyItem NumContext String) := [[.afterAm] ⟷ "ni", [] ⟷ "ø"]
 
 /-- The singular exponent of Num after an n exponent. -/
 def numSg (nExponent : String) : Option String :=
-  subsetPrinciple numItems (if nExponent = "am" then [.afterAm] else [])
+  subsetPrinciple numItems (if nExponent = "am" then [.afterAm] else [] : List NumContext)
 
 /-- Weak nouns take *-ni*, strong nouns the null singular: the underlying weak
 singular is *samudr-am-ni-K* ((41)). -/

--- a/Linglib/Studies/Allotey2021.lean
+++ b/Linglib/Studies/Allotey2021.lean
@@ -38,6 +38,7 @@ need phrase-structure substrate and are not formalized.
 namespace Allotey2021
 
 open Minimalist Minimalist.MinimalPronoun Control Ga
+open scoped DistributedMorphology.VocabularyItem
 open Landau2015 (Tier)
 open Semantics.Composition.TypeShifting (ComplementDenotation)
 
@@ -338,7 +339,7 @@ theorem null_pro_impossible (inv : MinPronInventory PronForm)
     [ostrove-2026]'s syncretism row for Gã; UNVERIFIED — [allotey-2021]
     never discusses Gã reflexives, check [campbell-2017].) -/
 def gaInventory : MinPronInventory PronForm where
-  items := [⟨.locallyBound, .reflexive⟩]
+  items := [[.locallyBound] ⟷ .reflexive]
   elsewhere := .pronoun
 
 /-- The Gã inventory meets the tone-hosting requirement. -/

--- a/Linglib/Studies/Benz2025.lean
+++ b/Linglib/Studies/Benz2025.lean
@@ -30,7 +30,8 @@ distribution from the structure-problem solutions.
 
 namespace Benz2025
 
-open DistributedMorphology.Allosemy Data.Examples German.Predicates ArgumentStructure
+open DistributedMorphology DistributedMorphology.Allosemy Data.Examples German.Predicates
+  ArgumentStructure
 open Features (VendlerClass)
 
 /-! ## Content nominalizations (Ch. 3) -/
@@ -109,19 +110,19 @@ theorem reading_determines_contentful_head (v : Verbalizer.Alloseme) (n : Nomina
 /-! ### Alloseme selection in the nominalization structure
 
 The selection side is DM's own engine, not a further table: allosemes are
-vocabulary entries over `SyntacticContext`, applicability is context
-matching, and canonical defaults are Elsewhere competition
-(`Exponence.selectBy`). The readings available in the (66)/(68) structure
-[n [v √]] are whatever the licensed allosemes compose to. -/
+Vocabulary Items over neighborhoods, applicability is the Subset Principle,
+and canonical defaults are Elsewhere competition (`winner?`). The readings
+available in the (66)/(68) structure [n [v √]] are whatever the licensed
+allosemes compose to. -/
 
 /-- v's context in the nominalization structure [n [v √]] — its complement is
 the root, event-entailing or not, and it is embedded under n. -/
-def vContext (eventive : Bool) : SyntacticContext :=
-  { aboveCat := some .n, complementIsEventive := eventive }
+def vContext (eventive : Bool) : Neighborhood (List Feature) :=
+  ⟨[], [if eventive then [.eventive] else []], [[.cat .n]]⟩
 
 /-- n's context in [n [v √]] — a verbal complement, eventive or not. -/
-def nContext (eventive : Bool) : SyntacticContext :=
-  { belowCat := some .v, complementIsEventive := eventive }
+def nContext (eventive : Bool) : Neighborhood (List Feature) :=
+  complement (.cat .v :: if eventive then [.eventive] else [])
 
 /-- The readings derivable in the nominalization structure: any licensed v
 alloseme composed with any licensed n alloseme. -/
@@ -143,8 +144,7 @@ winner: the more specified eventive entry beats vacuous v exactly when the
 root entails an event, so `Verbalizer.Alloseme.fromRootType` is derived, not
 stipulated. -/
 theorem fromRootType_is_selectBy_winner (rt : Verb.Root.ChangeType) :
-    (selectBy AllosemicEntry.score Verbalizer.vocabulary
-        (vContext rt.entailsChange)).map (·.denotation) =
+    (winner? Verbalizer.vocabulary (vContext rt.entailsChange)).map (·.exponent) =
       some (Verbalizer.Alloseme.fromRootType rt) := by
   cases rt <;> rfl
 

--- a/Linglib/Studies/CoonKeine2021.lean
+++ b/Linglib/Studies/CoonKeine2021.lean
@@ -645,14 +645,14 @@ theorem mefirst_diverges_from_pConstraint :
 For morphological agreement (vs. clitics), gluttony is fatal only at
 PF: the probe carries one value per agreed goal (their (16)/(58)),
 each value *demands* a Vocabulary item (the most specific compatible
-one — the Elsewhere Condition, as in `Minimalist.bestMatch`), and
+one — the Elsewhere Condition, as in `DistributedMorphology.winner?`), and
 only one VI can be inserted. Conflicting demands → ineffability
 (their (83)); syncretic demands → grammatical despite gluttony
 (their (85)) — the signature prediction separating this account from
 licensing: "gluttony and gluttonous probes do not by themselves give
 rise to ungrammaticality". The VI type is study-local because its
-context slot is the number value, not a syntactic category
-(`Minimalist.VocabEntry`'s `context : Option Cat` does not fit).
+context slot is the number value rather than the neighborhood a
+`DistributedMorphology.VocabularyItem` conditions on.
 
 Scope: person effects only. The German number hierarchy (*SG>PL,
 their (52)/(64)) and Icelandic number effects (their fn. 35) need
@@ -691,7 +691,7 @@ structure VI where
 
 /-- The VI a single person value demands in a number context: the
     most specific compatible item (Elsewhere Condition; ties by list
-    order, as in `Minimalist.bestMatch`). -/
+    order, as in `DistributedMorphology.winner?`). -/
 def demand (vocab : List VI) (plural : Bool) (value : List Segment) :
     Option VI :=
   (vocab.filter (fun vi =>

--- a/Linglib/Studies/ElkinsTorrenceBrown2026.lean
+++ b/Linglib/Studies/ElkinsTorrenceBrown2026.lean
@@ -130,6 +130,8 @@ theorem different_mechanisms :
 -- ============================================================================
 
 open Minimalist SyntacticObject
+open DistributedMorphology (VocabularyItem)
+open scoped DistributedMorphology.VocabularyItem
 
 /-! ### Mam Voice substrate (Minimalist)
 
@@ -191,14 +193,11 @@ def dirCis : MamDirHead := { cislocative := true, hasUOblique := true }
 /-- Translocative directional with [uOblique]. -/
 def dirTrans : MamDirHead := { cislocative := false, hasUOblique := true }
 
-/-- Vocabulary entry for =(y)a': maps [+oblique] on Voice⁰ to "=(y)a'". -/
-def eqYaVocab : VocabEntry :=
-  { features := .ofGramFeatures [.valued (.oblique true)]
-  , exponent := "=(y)a'"
-  , context := some .Voice }
+/-- The Vocabulary Item for =(y)a': [+oblique] on Voice⁰ spells out as "=(y)a'". -/
+def eqYaVocab : VocabularyItem GramFeature String := [.valued (.oblique true)] ⟷ "=(y)a'"
 
-/-- The Mam Voice vocabulary: just the =(y)a' entry. -/
-def mamVoiceVocab : Vocabulary := [eqYaVocab]
+/-- The items Voice⁰ consults in Mam: just =(y)a'. -/
+def mamVoiceVocab : List (VocabularyItem GramFeature String) := [eqYaVocab]
 
 /-- Mam passive Voice head: carries [uOblique] just like agentive Voice.
     [elkins-torrence-brown-2026] §7.2: =(y)a' co-occurs with
@@ -275,18 +274,12 @@ theorem antipassive_vs_agentive :
 
 /-- Valued [+oblique] on Voice spells out as =(y)a'. -/
 theorem spellout_oblique_voice :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
   decide
 
 /-- Without [+oblique], Voice has no exponent from this vocabulary. -/
 theorem spellout_no_oblique :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique false)]) (some .Voice) = none := by
-  decide
-
-/-- [+oblique] on a non-Voice head does not yield =(y)a'
-    (context restriction blocks insertion). -/
-theorem spellout_oblique_wrong_context :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .T) = none := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique false)]) = none := by
   decide
 
 -- ============================================================================
@@ -434,7 +427,7 @@ theorem dir_probe_matches_voice :
 
 /-- Dir⁰ with valued [+oblique] also spells out as =(y)a'. -/
 theorem dir_spellout_eqya :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
   decide
 
 -- ============================================================================
@@ -481,14 +474,14 @@ theorem voice_agree_values_oblique :
 
 /-- Spellout: valued [+oblique] on Voice maps to "=(y)a'". -/
 theorem voice_spellout_eqya :
-    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) =
+    spellout mamVoiceVocab (.ofGramFeatures [.valued (.oblique true)]) =
     some "=(y)a'" := by
   decide
 
 /-- Full derivation pipeline: Agree then Spellout → "=(y)a'". -/
 theorem full_derivation_pipeline :
     (applyAgree mamVoice.features oblique_goal_features .oblique).bind
-      (λ fb => spellout mamVoiceVocab fb (some .Voice)) = some "=(y)a'" := by
+      (λ fb => spellout mamVoiceVocab fb) = some "=(y)a'" := by
   decide
 
 end Derivation
@@ -532,11 +525,11 @@ theorem phi_and_oblique_agree_parallel :
     -- φ-Agree pipeline: value person, then number, then spellout
     (applyAgree voiceProbe dp3sg .person).bind
       (λ fb => applyAgree fb dp3sg .number) = some voiceFullyAgreed ∧
-    spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
+    spellout setAVocab voiceFullyAgreed = some "t-" ∧
     -- Oblique-Agree pipeline: value oblique, then spellout
     applyAgree voiceOblProbe (.ofGramFeatures [.valued (.oblique true)]) .oblique =
       some (.ofGramFeatures [.valued (.oblique true)]) ∧
-    spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) (some .Voice) = some "=(y)a'" := by
+    spellout [eqYaVocab] (.ofGramFeatures [.valued (.oblique true)]) = some "=(y)a'" := by
   exact ⟨by decide, by decide, by decide, by decide⟩
 
 end UnifiedAgree

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -42,6 +42,7 @@ paper's separate rule system and is outside this file.
 namespace HalleMarantz1993
 
 open DistributedMorphology Data.Examples
+open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The fused Tns–Agr node -/
 
@@ -101,7 +102,7 @@ def tPast : List Verb := [.dwell]
 disjunctive list in a contextual feature. -/
 def forStems (features : List Feature) (e : String) (stems : List Verb) :
     List (VocabularyItem Feature String) :=
-  stems.map fun v => ⟨features ++ [.stem v], e⟩
+  stems.map fun v => (features ++ [.stem v]) ⟷ e
 
 /-- The seven suffixes of (8): the past block (`-n`, the unordered `∅` and
 `-t`, default `-d`), then `[3sg]` `-z`, `[+participle]` `-ing`, and
@@ -109,7 +110,7 @@ the Elsewhere `∅`. -/
 def vocabulary : List (VocabularyItem Feature String) :=
   forStems [.past true, .participle true] "-n" strongParticiple ++
     forStems [.past true] "∅" strongPast ++ forStems [.past true] "-t" tPast ++
-    [⟨[.past true], "-d"⟩, ⟨[.sg3], "-z"⟩, ⟨[.participle true], "-ing"⟩, ⟨[], "∅"⟩]
+    [[.past true] ⟷ "-d", [.sg3] ⟷ "-z", [.participle true] ⟷ "-ing", [] ⟷ "∅"]
 
 /-- The `∅` and `-t` pasts "are not ordered by complexity" and need no
 ordering: their stem lists are disjoint. -/
@@ -179,7 +180,7 @@ theorem participle_eq_past_of_not_strong (v : Verb) (hv : v ∉ strongParticiple
 /-- The stem-conditioned past `∅` (*put*) blocks the default `-d`: the
 winner is the stem-listed item. -/
 theorem zero_past_blocks_default :
-    winner? vocabulary (Part.pastFinite.node .put) = some ⟨[.past true, .stem .put], "∅"⟩ := by
+    winner? vocabulary (Part.pastFinite.node .put) = some ([.past true, .stem .put] ⟷ "∅") := by
   decide
 
 /-- The paper's two zero morphemes are different items: the stem-conditioned

--- a/Linglib/Studies/Harley2014.lean
+++ b/Linglib/Studies/Harley2014.lean
@@ -24,7 +24,7 @@ both keyed.
 
 ## Main definitions
 
-* `siteFeatures`: a suppletive root's insertion site in a clause
+* `site`: a suppletive root's insertion site in a clause
   (`Clause.Arguments Number`) — its index and the number of the internal
   argument, the local conditioning environment of §3.3.
 * `vocabulary`: the Hiaki items of (3a), (3f), (3g): a singular-conditioned
@@ -62,7 +62,8 @@ categorizing head.
 namespace Harley2014
 
 open DistributedMorphology
-open DistributedMorphology.Allosemy (SyntacticContext AllosemicEntry toInterpreted)
+open scoped DistributedMorphology.VocabularyItem
+open DistributedMorphology.Allosemy (toInterpreted embedding)
 open Morphology.Exponence (selectBy)
 open Clause (Arguments)
 open Clause.Arguments (unaccusative unergative transitive empty)
@@ -84,24 +85,25 @@ def sing : Root := ⟨500⟩
 
 /-! ### The insertion site -/
 
-/-- Features at a suppletive root's insertion site: its index and the number
-of the internal argument. -/
+/-- What a root's Vocabulary Items may mention: its index, and the number
+of the internal argument on the terminal below. -/
 inductive SiteFeature where
   | root (r : Root)
   | internal (n : Number)
   deriving DecidableEq, Repr
 
-/-- The insertion bundle for root `r` in a clause bearing the numbers `c`: the
-external argument is not in the local environment (§3.3). -/
-def siteFeatures (c : Arguments Number) (r : Root) : List SiteFeature :=
-  .root r :: ((c .internal).map .internal).toList
+/-- The neighborhood of root `r` in a clause bearing the numbers `c`: the
+internal argument is the terminal below; the external argument is not in the
+local environment (§3.3). -/
+def site (c : Arguments Number) (r : Root) : Neighborhood (List SiteFeature) :=
+  ⟨[.root r], ((c .internal).map fun n => ([.internal n] : List SiteFeature)).toList, []⟩
 
 /-! ### List 2: the suppletive Vocabulary Items -/
 
-/-- A suppletive root's two items: the form conditioned by a singular
-internal argument and the Elsewhere form ((14), fn. 16). -/
+/-- A suppletive root's two items ((14), fn. 16): the form conditioned by a
+singular internal argument below, and the Elsewhere form. -/
 def suppletive (r : Root) (sgForm elseForm : String) : List (VocabularyItem SiteFeature String) :=
-  [⟨[.root r, .internal .singular], sgForm⟩, ⟨[.root r], elseForm⟩]
+  [⟨⟨[.root r], [[.internal .singular]], []⟩, sgForm⟩, [.root r] ⟷ elseForm]
 
 /-- The Hiaki suppletive vocabulary of (3a), (3f), (3g). -/
 def vocabulary : List (VocabularyItem SiteFeature String) :=
@@ -110,7 +112,7 @@ def vocabulary : List (VocabularyItem SiteFeature String) :=
 /-- Spell out root `r` in clause `c` by the Subset Principle over
 `vocabulary`. -/
 def spellout (c : Arguments Number) (r : Root) : Option String :=
-  subsetPrinciple vocabulary (siteFeatures c r)
+  subsetPrinciple vocabulary (site c r)
 
 /-- Singular subject → *vuite* ((6a)). -/
 theorem run_sg : spellout (unaccusative .singular) run = some "vuite" := by decide
@@ -146,7 +148,7 @@ theorem run_two_forms :
 intransitive root receives no exponent from `vocabulary` — why List-1 roots
 must be distinct before spell-out (§2.1). -/
 theorem index_local (c : Arguments Number) : spellout c sing = none := by
-  unfold spellout siteFeatures
+  unfold spellout site
   rcases h : c .internal with _ | n
   · rfl
   · cases n <;> rfl
@@ -195,13 +197,13 @@ def cahoot : Root := ⟨548⟩
 
 /-- The List-3 entry of √548: "a conspiracy" in the frame of (16), recorded by
 its categorizing head, and no Elsewhere. -/
-def cahootLF : List (AllosemicEntry String) :=
-  [{ denotation := "a conspiracy", context := { aboveCat := some .n } }]
+def cahootLF : List (VocabularyItem Allosemy.Feature String) :=
+  [⟨embedding [.cat .n], "a conspiracy"⟩]
 
 /-- Outside its frame the caboodle item has no interpretation. The paper adds
 that no List-3 entry could be a true Elsewhere, since an interpretation must
 compose with its sister's type; caboodle items make the absence visible. -/
-theorem cahoot_no_elsewhere : selectBy AllosemicEntry.score cahootLF {} = none := by decide
+theorem cahoot_no_elsewhere : winner? cahootLF ∅ = none := by decide
 
 /-! ### Both flanks on the `Realization` carrier
 
@@ -236,15 +238,16 @@ theorem run_hasSuppletiveCore : Morphology.Root.HasSuppletiveCore realization (f
     (realization.isSuppletive_iff.mpr (Or.inr run_isProperlySuppletive))
 
 /-- √548 as a List-3 `Realization.Interpreted` view. -/
-def cahootHead : Morphology.Realization.Interpreted Unit SyntacticContext Unit String :=
+def cahootHead :
+    Morphology.Realization.Interpreted Unit (Neighborhood (List Allosemy.Feature)) Unit String :=
   toInterpreted cahootLF
 
 /-- The caboodle item is interpreted inside its frame and has an empty
 `interp` fiber elsewhere — a gap, the meaning-side analogue of an empty
 realization fiber, so a licensing failure rather than allosemy (§2.3). -/
 theorem cahoot_interp_gap :
-    cahootHead.interp () { aboveCat := some .n } = {"a conspiracy"} ∧
-      cahootHead.interp () {} = ∅ := by
+    cahootHead.interp () (embedding [.cat .n]) = {"a conspiracy"} ∧
+      cahootHead.interp () ∅ = ∅ := by
   refine ⟨?_, ?_⟩ <;> decide
 
 end Harley2014

--- a/Linglib/Studies/KonnellyCowper2020.lean
+++ b/Linglib/Studies/KonnellyCowper2020.lean
@@ -46,6 +46,7 @@ namespace KonnellyCowper2020
 open DistributedMorphology (Contrastivity GenderFeature
   Interpretability Categorizer.Head PhiBundle)
 open DistributedMorphology (VocabularyItem subsetPrinciple)
+open scoped DistributedMorphology.VocabularyItem
 
 -- ============================================================================
 -- § 1: Morphosyntactic Features for English Pronouns
@@ -80,16 +81,16 @@ inductive PronFeature where
          c. [SG, INANIM] ↔ *it*
          d. Elsewhere     ↔ *they*  -/
 def vi_she : VocabularyItem PronFeature String :=
-  ⟨[.sg, .fem], "she"⟩
+  [.sg, .fem] ⟷ "she"
 
 def vi_he : VocabularyItem PronFeature String :=
-  ⟨[.sg, .masc], "he"⟩
+  [.sg, .masc] ⟷ "he"
 
 def vi_it : VocabularyItem PronFeature String :=
-  ⟨[.sg, .inanim], "it"⟩
+  [.sg, .inanim] ⟷ "it"
 
 def vi_they : VocabularyItem PronFeature String :=
-  ⟨[], "they"⟩
+  [] ⟷ "they"
 
 /-- The complete VI rule set for English 3rd-person pronouns.
     Order does not matter — the Subset Principle selects by specificity
@@ -103,14 +104,14 @@ def pronounVIs : List (VocabularyItem PronFeature String) :=
 
 /-- A plural bundle (no [SG]) → *they* (elsewhere). -/
 theorem plural_yields_they :
-    subsetPrinciple pronounVIs [] = some "they" := by decide
+    subsetPrinciple pronounVIs ∅ = some "they" := by decide
 
 /-- A singular bundle with both [MASC] and [FEM] → the VI system is
     well-defined even for this impossible configuration (no nominal
     bears both features). FEM wins by being listed first among
     equal-length matches. -/
 theorem masc_fem_overlap_resolves :
-    (subsetPrinciple pronounVIs [.sg, .masc, .fem]).isSome = true := by decide
+    (subsetPrinciple pronounVIs ([.sg, .masc, .fem] : List PronFeature)).isSome = true := by decide
 
 -- ============================================================================
 -- § 4: The Three Stages
@@ -361,19 +362,19 @@ def catHeadToPronFeatures (ch : Categorizer.Head) : List PronFeature :=
     Elsewhere Condition. -/
 theorem iFem_singular_yields_she :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iFem) = some "she" := by
+      (.sg :: catHeadToPronFeatures Categorizer.Head.n_iFem : List PronFeature) = some "she" := by
   decide
 
 /-- n i[−FEM] (masculine natural gender) → "he". -/
 theorem iMasc_singular_yields_he :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iMasc) = some "he" := by
+      (.sg :: catHeadToPronFeatures Categorizer.Head.n_iMasc : List PronFeature) = some "he" := by
   decide
 
 /-- n i[−ANIM] (inanimate) → "it". -/
 theorem iInanim_singular_yields_it :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_iInanim) = some "it" := by
+      (.sg :: catHeadToPronFeatures Categorizer.Head.n_iInanim : List PronFeature) = some "it" := by
   decide
 
 /-- Plain n (no gender feature) → "they" (elsewhere).
@@ -381,7 +382,7 @@ theorem iInanim_singular_yields_it :
     what VI produces when the n-head lacks a gender feature. -/
 theorem plain_n_singular_yields_they :
     subsetPrinciple pronounVIs
-      ([.sg] ++ catHeadToPronFeatures Categorizer.Head.n_plain) = some "they" := by
+      (.sg :: catHeadToPronFeatures Categorizer.Head.n_plain : List PronFeature) = some "they" := by
   decide
 
 -- ============================================================================

--- a/Linglib/Studies/Kramer2020.lean
+++ b/Linglib/Studies/Kramer2020.lean
@@ -57,6 +57,7 @@ semantic core from the structural account alone.
 namespace Kramer2020
 
 open Corbett1991 (SemanticBasis Profile allProfiles)
+open scoped DistributedMorphology.VocabularyItem
 open DistributedMorphology
 open Spanish.Gender (SpanishNoun)
 open Russian.Gender (DeclClass)
@@ -277,7 +278,7 @@ def determinerFeatures (ch : Categorizer.Head) : List DetFeature :=
 /-- The Spanish definite determiners (25): *la* with [+fem], *el*
 underspecified. -/
 def determiners : List (VocabularyItem DetFeature String) :=
-  [⟨[.d, .definite, .gender ⟨.fem, .pos⟩], "la"⟩, ⟨[.d, .definite], "el"⟩]
+  [[.d, .definite, .gender ⟨.fem, .pos⟩] ⟷ "la", [.d, .definite] ⟷ "el"]
 
 /-- The determiner a head takes, by the Subset Principle. -/
 def determiner (ch : Categorizer.Head) : Option String :=

--- a/Linglib/Studies/Middleton2026.lean
+++ b/Linglib/Studies/Middleton2026.lean
@@ -66,6 +66,7 @@ namespace Middleton2026
 
 open Minimalist DistributedMorphology
      Taos.Agreement Basque.Postsyntax
+open scoped DistributedMorphology.VocabularyItem
 
 /-! ### Metathesis Rule
 
@@ -551,11 +552,11 @@ def middletonOutput : FeatureBundle :=
     Fragment. -/
 def viSet : List (VocabularyItem FeatureVal String) :=
   [ -- specific: 1st-person + minimal (surfaces with `n` per [middleton-2026] rule 21)
-    ⟨[fAuthor true, fMinimal true], Morpheme.n.surface⟩
+    [fAuthor true, fMinimal true] ⟷ Morpheme.n.surface
   , -- specific: 1st-person + atomic
-    ⟨[fAuthor true, fAtomic true], Morpheme.o.surface⟩
+    [fAuthor true, fAtomic true] ⟷ Morpheme.o.surface
   , -- elsewhere: empty feature spec, matches anything
-    ⟨[], Morpheme.ô.surface⟩ ]
+    [] ⟷ Morpheme.ô.surface ]
 
 /-- A&N's output feeds VI as `[+author, +minimal]`; the Subset
     Principle selects the `[+author, +minimal]` entry over the

--- a/Linglib/Studies/Myler2016.lean
+++ b/Linglib/Studies/Myler2016.lean
@@ -45,6 +45,7 @@ syntactic ({D} and φ, the transitive configuration of (24)), and relational
 namespace Myler2016
 
 open DistributedMorphology DistributedMorphology.Allosemy Data.Examples
+open scoped DistributedMorphology.VocabularyItem
 
 /-! ### The copula's context and form -/
 
@@ -73,12 +74,12 @@ def Context.Transitive (c : Context) : Prop := c.voiceD = true ∧ c.voicePhi = 
 instance (c : Context) : Decidable c.Transitive := inferInstanceAs (Decidable (_ ∧ _))
 
 /-- English ((89) of chapter 1): *have* in a transitive context, *be* elsewhere. -/
-def englishItems : List (VocabularyItem Feature String) := [⟨[.d, .phi], "have"⟩, ⟨[], "be"⟩]
+def englishItems : List (VocabularyItem Feature String) := [[.d, .phi] ⟷ "have", [] ⟷ "be"]
 
 /-- Icelandic ((89) of chapter 4): *hafa* in a transitive context over a PredP,
 *eiga* in a transitive context otherwise, and the copula *vera* elsewhere. -/
 def icelandicItems : List (VocabularyItem Feature String) :=
-  [⟨[.d, .phi, .pred], "hafa"⟩, ⟨[.d, .phi], "eiga"⟩, ⟨[], "vera"⟩]
+  [[.d, .phi, .pred] ⟷ "hafa", [.d, .phi] ⟷ "eiga", [] ⟷ "vera"]
 
 /-- The form of v in a context, by the Subset Principle over a language's
 items. -/

--- a/Linglib/Studies/Ostrove2026.lean
+++ b/Linglib/Studies/Ostrove2026.lean
@@ -66,6 +66,7 @@ infinitival classification.
 namespace Ostrove2026
 
 open Minimalist.MinimalPronoun
+open scoped DistributedMorphology.VocabularyItem
 open Control
 open Minimalist (InfinitivalTenseClass)
 open Mixtec.SMPM (EmbeddedClauseType clauseProperties)
@@ -233,8 +234,8 @@ theorem landau_predicts_control (c : Control.ClauseClass) :
     pronoun elsewhere. English distinguishes all three non-free BVA
     contexts morphologically. -/
 def englishInventory : MinPronInventory PronForm where
-  items := [ ⟨.controlledSubject, .null⟩,      -- (94a) D[πφ] → ∅ / controlled
-             ⟨.locallyBound, .reflexive⟩ ]      -- (94b) D[πφ] → -self / locally bound
+  items := [ [.controlledSubject] ⟷ .null,      -- (94a) D[πφ] → ∅ / controlled
+             [.locallyBound] ⟷ .reflexive ]      -- (94b) D[πφ] → -self / locally bound
   elsewhere := .pronoun                          -- (94c) D[πφ] → pronoun
 
 /-- Haitian vocabulary items (96a–b).
@@ -243,7 +244,7 @@ def englishInventory : MinPronInventory PronForm where
     LACKS a reflexive allomorph — reflexives and bound variables
     are both realized as pronouns ([dechaine-manfredi-1994]). -/
 def haitianInventory : MinPronInventory PronForm where
-  items := [ ⟨.controlledSubject, .null⟩ ]      -- (96a) D[πφ] → ∅ / controlled
+  items := [ [.controlledSubject] ⟷ .null ]      -- (96a) D[πφ] → ∅ / controlled
   elsewhere := .pronoun                          -- (96b) D[πφ] → pronoun
 
 /-- SMPM vocabulary items (98a–b).
@@ -252,7 +253,7 @@ def haitianInventory : MinPronInventory PronForm where
     LACKS a null allomorph — controlled subjects and bound variables
     are both realized as overt clitic pronouns (=rà, =ñá, etc.). -/
 def smpmInventory : MinPronInventory PronForm where
-  items := [ ⟨.locallyBound, .reflexive⟩ ]      -- (98a) D[πφ] → mí + pronoun / locally bound
+  items := [ [.locallyBound] ⟷ .reflexive ]      -- (98a) D[πφ] → mí + pronoun / locally bound
   elsewhere := .pronoun                          -- (98b) D[πφ] → pronoun
 
 /-- Quiegolani Zapotec: no context-specific items at all

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -113,7 +113,7 @@ gives five arguments against hierarchy accounts:
   the derivations below consume. Failed Agree = an `unvalued` probe outcome
   that is *tolerated* (no crash) and spells out as the Elsewhere entry.
 - `Morphology/DistributedMorphology/VocabularyInsertion/FeatureBundle.lean` —
-  `Vocabulary`, `Agreement.Cell.toPhiFeatures`, `makePersonVocab`, `spellout`.
+  `Agreement.Cell.toPhiFeatures`, `vocabularyOfCells`, `spellout`.
 - `Studies/Scott2023.lean` — the same DM/Agree machinery applied to
   Mam (where Infl's φ-probe is blocked in transitives).
 - `Studies/CoonMateoPedroPreminger2014.lean` — Voice/case-flavor
@@ -124,6 +124,8 @@ namespace Preminger2014
 
 open Kaqchikel
 open Minimalist
+open DistributedMorphology (VocabularyItem)
+open scoped DistributedMorphology.VocabularyItem
 open Agreement
 
 /-! ### Feature decomposition (grounded in `Phi/Geometry.lean`) -/
@@ -161,21 +163,19 @@ private def cellBundle (c : Agreement.Cell) : FeatureBundle :=
 
 /-- Set A as DM Vocabulary entries, contextualized to Voice/v.
     All six cells have overt exponents. -/
-def setAVocab : Vocabulary :=
-  makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
-    (fun c => (((setAExponent .consonant).realize c).map
-      toString).getD "") (some .v)
+def setAVocab : List (VocabularyItem GramFeature String) :=
+  vocabularyOfCells Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
+    (fun c => (((setAExponent .consonant).realize c).map toString).getD "")
 
 /-- Set B as DM Vocabulary entries, contextualized to Infl/T: specific
     entries for the five overt cells, plus the Elsewhere ∅ entry
     realizing 3SG and failed agreement (see the module docstring on
     this DM rendering vs. Preminger's own formulation). -/
-def setBVocab : Vocabulary :=
-  makePersonVocab (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
+def setBVocab : List (VocabularyItem GramFeature String) :=
+  vocabularyOfCells (Agreement.Cell.pnCells.filter (· != .pn .third .Sing))
     Agreement.Cell.toPhiFeatures
-    (fun c => ((setBExponent.realize c).map
-      toString).getD "") (some .T) ++
-  [{ features := ⊥, exponent := "∅", context := some .T }]
+    (fun c => ((setBExponent.realize c).map toString).getD "") ++
+  [[] ⟷ "∅"]
 
 /-- Vocabulary insertion recovers the fragment's paradigms: spelling
     out each cell's valued bundle yields the fragment's exponent — for
@@ -183,9 +183,9 @@ def setBVocab : Vocabulary :=
     specific entries. -/
 theorem spellout_matches_paradigm :
     ∀ c ∈ Agreement.Cell.pnCells,
-      spellout setAVocab (cellBundle c) (some .v) =
+      spellout setAVocab (cellBundle c) =
         ((setAExponent .consonant).realize c).map toString ∧
-      spellout setBVocab (cellBundle c) (some .T) =
+      spellout setBVocab (cellBundle c) =
         (setBExponent.realize c).map toString := by
   decide
 
@@ -278,7 +278,7 @@ def afMarker (subj obj : Agreement.Cell) : Option String :=
   if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
     ((afAgreementTarget subj obj).bind
       (fun t => (setBExponent.realize t).map toString)) <|>
-      spellout setBVocab ⊥ (some .T)
+      spellout setBVocab ⊥
   else none
 
 /-- The rank encoding (`probeResolutionRank`, [bejar-rezac-2003]
@@ -436,7 +436,7 @@ theorem failed_agree_tolerated :
     piOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
     numOutcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
     afProbe.Outcome (.pn .third .Sing) (.pn .third .Sing) = .unvalued ∧
-    spellout setBVocab ⊥ (some .T) = some "∅" ∧
+    spellout setBVocab ⊥ = some "∅" ∧
     afMarker (.pn .third .Sing) (.pn .third .Sing) = some "∅" := by
   decide
 

--- a/Linglib/Studies/Scott2021.lean
+++ b/Linglib/Studies/Scott2021.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Tree.Basic
 import Linglib.Fragments.Swahili.Relativization
-import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.FeatureBundle
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Data.Examples.Scott2021
 
@@ -52,8 +52,9 @@ derive it.
 
 namespace Scott2021
 
-open Swahili Syntax Data.Examples
-open Minimalist (FeatureBundle FeatureVal PhiFeature GramFeature Vocabulary VocabEntry)
+open Swahili Syntax DistributedMorphology Data.Examples
+open scoped DistributedMorphology.VocabularyItem
+open Minimalist (FeatureVal PhiFeature GramFeature)
 
 /-! ### The structure of pronouns (§5.1) -/
 
@@ -101,17 +102,12 @@ private def featureListAll : List (Tree DPCat String) → List GramFeature
   | t :: ts => featureList t ++ featureListAll ts
 end
 
-/-- The feature bundle of a tree. -/
-def features (t : Tree DPCat String) : FeatureBundle :=
-  Minimalist.FeatureBundle.ofGramFeatures (featureList t)
-
 /-! ### Vocabulary Insertion (§3.4) -/
 
 /-- The Vocabulary Items of (28): person-specified animate entries and the
 personless animate defaults *-ye* and *-o*. -/
-def resumptiveVocab : Vocabulary :=
-  let entry (fs : List GramFeature) (e : String) : VocabEntry :=
-    { features := Minimalist.FeatureBundle.ofGramFeatures fs, exponent := e }
+def resumptiveVocab : List (VocabularyItem GramFeature String) :=
+  let entry (fs : List GramFeature) (e : String) : VocabularyItem GramFeature String := ⟨fs, e⟩
   [ entry [.valued (.phi (.person .first)), .valued (.phi (.gender 1)),
       .valued (.phi (.number .singular))] "mi",
     entry [.valued (.phi (.person .first)), .valued (.phi (.gender 1)),
@@ -125,7 +121,7 @@ def resumptiveVocab : Vocabulary :=
 
 /-- The exponent of a pronoun structure, by the Subset Principle over (28). -/
 def spellout (t : Tree DPCat String) : Option String :=
-  Minimalist.spellout resumptiveVocab (features t) none
+  subsetPrinciple resumptiveVocab (featureList t)
 
 /-- The Fragment's person cells as the structures' person: third person is the
 absence of PersP. -/

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -166,6 +166,8 @@ section AgreeSpellout
 
 open Minimalist Mam
 open Agreement
+open DistributedMorphology (VocabularyItem)
+open scoped DistributedMorphology.VocabularyItem
 
 -- ============================================================================
 -- § 0: Minimalism-Specific Vocabulary (Set A / Set B as VI entries)
@@ -174,16 +176,15 @@ open Agreement
 /-! These Vocabulary Insertion entries encode the Fragment's theory-neutral
     marker tables as Minimalism feature bundles, enabling the Agree → Spellout
     pipeline. The Fragment (`Agreement.lean`) stores the markers as simple
-    person × number → string tables; here they are parameterized by
-    `FeatureBundle` and `Cat` for use with `spellout`. -/
+    person × number → string tables; here they are Vocabulary Items over
+    `GramFeature`s for use with `spellout`. -/
 
 /-- Set A (ERG) vocabulary entries: φ-features on Voice (.v)
     yield the morphological exponent ([scott-2023] Table 2.8).
     All six cells have specific entries. -/
-def setAVocab : Vocabulary :=
-  makePersonVocab Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
-    (fun c => (((setAExponent .consonant).realize c).map
-      toString).getD "") (some .v)
+def setAVocab : List (VocabularyItem GramFeature String) :=
+  vocabularyOfCells Agreement.Cell.pnCells Agreement.Cell.toPhiFeatures
+    (fun c => (((setAExponent .consonant).realize c).map toString).getD "")
 
 /-- Set B (ABS) vocabulary entries: φ-features on Infl (.T)
     yield the morphological exponent ([scott-2023] Table 3.5).
@@ -191,11 +192,10 @@ def setAVocab : Vocabulary :=
     entries; 2SG and 3SG fall through to the Elsewhere entry
     (no features, tz'=) which surfaces when no specific entry
     matches — also catching the blocked-Infl-probe case in transitives. -/
-def setBVocab : Vocabulary :=
-  makePersonVocab setBSpecificCells Agreement.Cell.toPhiFeatures
-    (fun c => ((setBExponent.realize c).map
-      toString).getD "") (some .T) ++
-    [{ features := ⊥, exponent := toString defaultSetB, context := some .T }]
+def setBVocab : List (VocabularyItem GramFeature String) :=
+  vocabularyOfCells setBSpecificCells Agreement.Cell.toPhiFeatures
+    (fun c => ((setBExponent.realize c).map toString).getD "") ++
+    [[] ⟷ toString defaultSetB]
 
 /-- Which Minimalist head φ-Agrees with each argument position.
     Ditransitive R/T default to none (not modeled). -/
@@ -267,7 +267,7 @@ theorem voice_agree_pipeline :
 
 /-- Set A spellout: Voice's valued [Person:3, Number:sg] yields "t-" (A2/3SG). -/
 theorem setA_spellout_3sg :
-    spellout setAVocab voiceFullyAgreed (some .v) = some "t-" := by
+    spellout setAVocab voiceFullyAgreed = some "t-" := by
   decide
 
 /-- Set A spellout for 1SG: Voice with [Person:1, Number:sg] yields the
@@ -276,7 +276,7 @@ theorem setA_spellout_3sg :
 theorem setA_spellout_1sg :
     let v1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-    spellout setAVocab v1sg (some .v) = some "n-" := by
+    spellout setAVocab v1sg = some "n-" := by
   decide
 
 -- ============================================================================
@@ -290,7 +290,7 @@ theorem setA_spellout_1sg :
 theorem setB_intransitive_3sg :
     let inflAgreed : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
-    spellout setBVocab inflAgreed (some .T) = some "tz'=" := by
+    spellout setBVocab inflAgreed = some "tz'=" := by
   decide
 
 /-- **Transitive path**: Infl's probe is blocked by Voice_TR → no
@@ -302,7 +302,7 @@ theorem setB_intransitive_3sg :
     the object's person/number features. -/
 theorem setB_transitive_default :
     let inflBlocked : FeatureBundle := ⊥
-    spellout setBVocab inflBlocked (some .T) = some "tz'=" := by
+    spellout setBVocab inflBlocked = some "tz'=" := by
   decide
 
 /-- The two paths produce the same exponent — the surface form is
@@ -312,8 +312,8 @@ theorem setB_same_surface :
     let inflAgreed3sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .third)), .valued (.phi (.number .singular))]
     let inflBlocked : FeatureBundle := ⊥
-    spellout setBVocab inflAgreed3sg (some .T) =
-    spellout setBVocab inflBlocked (some .T) := by
+    spellout setBVocab inflAgreed3sg =
+    spellout setBVocab inflBlocked := by
   decide
 
 /-- Set B spellout for 1SG intransitive: Infl copies [Person:1, Number:sg]
@@ -322,7 +322,7 @@ theorem setB_same_surface :
 theorem setB_intransitive_1sg :
     let t1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-    spellout setBVocab t1sg (some .T) = some "chin" := by
+    spellout setBVocab t1sg = some "chin" := by
   decide
 
 /-- In a transitive with a 1SG object, the default "tz'=" still appears —
@@ -331,11 +331,11 @@ theorem setB_intransitive_1sg :
 theorem setB_transitive_ignores_object :
     -- Even though the object is 1SG, Infl shows default "tz'=", not "chin"
     let inflBlocked : FeatureBundle := ⊥
-    spellout setBVocab inflBlocked (some .T) = some "tz'=" ∧
+    spellout setBVocab inflBlocked = some "tz'=" ∧
     -- Compare: a 1SG intransitive S would trigger "chin"
     let inflAgreed1sg : FeatureBundle := .ofGramFeatures
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
-    spellout setBVocab inflAgreed1sg (some .T) = some "chin" := by
+    spellout setBVocab inflAgreed1sg = some "chin" := by
   exact ⟨by decide, by decide⟩
 
 -- ============================================================================
@@ -358,12 +358,11 @@ theorem setB_transitive_ignores_object :
     table below for the search-level statement). -/
 theorem probe_restriction_yields_default :
     -- Transitive: probe blocked → empty → Elsewhere
-    spellout setBVocab (⊥ : FeatureBundle) (some .T) = some "tz'=" ∧
+    spellout setBVocab (⊥ : FeatureBundle) = some "tz'=" ∧
     -- Intransitive 1SG: probe succeeds → "chin" (not default)
     spellout setBVocab
       (.ofGramFeatures
-        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
-      (some .T) = some "chin" := by
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) = some "chin" := by
   exact ⟨by decide, by decide⟩
 
 -- ============================================================================
@@ -388,8 +387,7 @@ theorem intransitive_pipeline_1sg :
     -- Spells out as "chin" (not default "tz'=")
     spellout setBVocab
       (.ofGramFeatures
-        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
-      (some .T) = some "chin" := by
+        [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]) = some "chin" := by
   exact ⟨by decide, by decide⟩
 
 -- ============================================================================
@@ -407,9 +405,9 @@ theorem full_pipeline_3sg_transitive :
     -- Step 1-2: Voice Agrees and spells out as Set A
     (applyAgree voiceProbe dp3sg .person).bind
       (λ fb => applyAgree fb dp3sg .number) = some voiceFullyAgreed ∧
-    spellout setAVocab voiceFullyAgreed (some .v) = some "t-" ∧
+    spellout setAVocab voiceFullyAgreed = some "t-" ∧
     -- Step 3-4: Infl probe blocked → default Set B
-    spellout setBVocab (⊥ : FeatureBundle) (some .T) = some "tz'=" ∧
+    spellout setBVocab (⊥ : FeatureBundle) = some "tz'=" ∧
     -- Step 5: patient is not eligible for reduction → overt pronoun
     ¬ ArgPosition.CanBeReduced .P := by
   refine ⟨?_, ?_, ?_, ?_⟩
@@ -423,30 +421,6 @@ theorem full_pipeline_3sg_transitive :
 theorem all_positions_match (pos : ArgPosition) :
     pos.CanBeReduced ↔ pos.IsPhiAgreed :=
   Iff.rfl
-
--- ============================================================================
--- § 9: Cross-Paradigm Spellout
--- ============================================================================
-
-/-- Set A and Set B have different contexts: Set A on Voice (.v), Set B
-    on Infl (.T). The same valued features produce different exponents
-    depending on which head hosts them. -/
-theorem setA_setB_differ_by_context :
-    spellout setAVocab voiceFullyAgreed (some .v) ≠
-    spellout setBVocab voiceFullyAgreed (some .v) := by
-  decide
-
-/-- Set A vocabulary does NOT match Infl context. -/
-theorem setA_wrong_context :
-    spellout setAVocab voiceFullyAgreed (some .T) = none := by
-  decide
-
-/-- Set B vocabulary does NOT match Voice context (for specified entries).
-    Only the Elsewhere entry could match (it has no features), but it
-    requires Infl context. -/
-theorem setB_wrong_context :
-    spellout setBVocab voiceFullyAgreed (some .v) = none := by
-  decide
 
 -- ============================================================================
 -- § 10: The Tripartite Agreement Pattern

--- a/Linglib/Syntax/Minimalist/MinimalPronoun.lean
+++ b/Linglib/Syntax/Minimalist/MinimalPronoun.lean
@@ -1,3 +1,5 @@
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
+
 /-!
 # Minimal Pronoun Theory
 [kratzer-1998] [kratzer-2009] [safir-2014] [landau-2015]
@@ -17,8 +19,7 @@ item inventory.
 ## Key Definitions
 
 - `BVAContext`: The four licensing contexts for bound variable anaphora
-- `VocabItem`: A context-sensitive realization rule (D[uφ] → Form / context)
-- `MinPronInventory`: A language's vocabulary item inventory + elsewhere default
+- `MinPronInventory`: A language's Vocabulary Items (D[uφ] → Form / context) + elsewhere default
 - `PronForm`: Standard surface form categories (null, pronoun, reflexive)
 
 ## Core Claims
@@ -64,43 +65,24 @@ inductive BVAContext where
 
 /-! ### Vocabulary Items and the Elsewhere Condition -/
 
-/-- A vocabulary item: a context-specific realization rule for a minimal pronoun.
-
-    In DM terms: D[uφ] → `form` / `context` ...
-
-    Vocabulary items are ordered by specificity. When multiple items could
-    apply, the most specific (first in the list) wins.
-
-    This is a specialization of DM's `DistributedMorphology.VocabularyItem`: a
-    single `BVAContext` feature matched exactly, with a parameterized `Form`
-    type. -/
-structure VocabItem (Form : Type) where
-  /-- The syntactic context this item is restricted to -/
-  context : BVAContext
-  /-- The surface form this item realizes -/
-  form : Form
-
-/-- A language's inventory of vocabulary items for minimal pronouns.
-
-    The `items` list is ordered by specificity (most specific first).
-    The `elsewhere` form applies when no context-specific item matches.
+/-- A language's inventory of Vocabulary Items for minimal pronouns: each
+    item realizes D[uφ] as a form in one `BVAContext` — D[uφ] → `form` /
+    `context` — and the `elsewhere` form applies when no item matches.
 
     [safir-2014]: "from this single element, all anaphoric diversity
     is morphological" -/
 structure MinPronInventory (Form : Type) where
-  /-- Context-specific vocabulary items, ordered by specificity -/
-  items : List (VocabItem Form)
+  /-- Context-specific Vocabulary Items. -/
+  items : List (DistributedMorphology.VocabularyItem BVAContext Form)
   /-- Default exponence: applies when no specific item matches.
       Crosslinguistically, this is the pronoun form ([safir-2014]). -/
   elsewhere : Form
 
-/-- The Elsewhere Condition: find the first vocabulary item whose context
-    matches; if none does, use the elsewhere (default pronoun) form. -/
+/-- The Elsewhere Condition: the Subset Principle over the items at the
+    context, falling back to the elsewhere (default pronoun) form. -/
 def MinPronInventory.realize {Form : Type}
     (inv : MinPronInventory Form) (ctx : BVAContext) : Form :=
-  match inv.items.find? (·.context == ctx) with
-  | some item => item.form
-  | none => inv.elsewhere
+  (DistributedMorphology.subsetPrinciple inv.items [ctx]).getD inv.elsewhere
 
 /-- A language's realized form for controlled subjects specifically.
     This is the function that distinguishes null-PRO from overt-PRO languages. -/


### PR DESCRIPTION
A Vocabulary Item's specification is now a `Neighborhood (List F)` — its own features plus the features it requires of the adjacent terminals — and the Subset Principle is inclusion of positioned features (`Neighborhood.positioned`, `⊆`); `specificity` counts them, so the Elsewhere laws carry over unchanged. Context-free items are written `[f₁, f₂] ⟷ e` (scoped notation) or coerce from a bare list; the Elsewhere item is `[] ⟷ e`.

- Dissolves the three parallel context carriers: `Minimalist.VocabEntry` (+ `Option Cat` tag) and `Allosemy.SyntacticContext`/`AllosemicEntry` (Bool matcher + ad-hoc score lemmas) are now `VocabularyItem` over `GramFeature` / `Allosemy.Feature`, with `complement`/`embedding` specs; `MinimalPronoun`'s private `VocabItem` likewise.
- `Spellout.insert` sees the neighborhood; `Neighborhood` moves to its own file under the Impoverishment/VI split.
- Harley2014's Hiaki suppletion is stated as the book's `√12 → weye / [−pl]` (internal argument on the terminal below) instead of smuggling the number into "site features"; Scott2021 drops the bundle round-trip. Three Scott2023/Elkins theorems that only exercised the old category tag are removed.