### PR TITLE
refactor(Morphology/DistributedMorphology): fission by scansion, fusion

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2207,6 +2207,7 @@ import Linglib.Studies.GoldbergShirtz2025
 import Linglib.Studies.GoldszmidtPearl1996
 import Linglib.Studies.GoldwaterJohnson2003
 import Linglib.Studies.Gong2022
+import Linglib.Studies.GonzalezPootMcGinnis2006
 import Linglib.Studies.GoodmanStuhlmuller2013
 import Linglib.Studies.Graf2019
 import Linglib.Studies.Grano2024
@@ -2934,3 +2935,4 @@ import Linglib.Data.Examples.Benz2025
 import Linglib.Data.Examples.HalleMarantz1993
 import Linglib.Data.Examples.Myler2016
 import Linglib.Data.Examples.Scott2021
+import Linglib.Data.Examples.GonzalezPootMcGinnis2006

--- a/Linglib/Data/Examples/GonzalezPootMcGinnis2006.json
+++ b/Linglib/Data/Examples/GonzalezPootMcGinnis2006.json
@@ -1,0 +1,1011 @@
+[
+  {
+    "id": "gpm2006_19",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(19)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -a w- áːnt -ik -oʔon -éːʃ",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-a",
+        "2ERG"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-oʔon",
+        "1NOMpl"
+      ],
+      [
+        "-éːʃ",
+        "2ERGpl"
+      ]
+    ],
+    "translation": "You (pl) help us.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "2"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "1"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "a"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        "oʔon"
+      ],
+      [
+        "suffix2",
+        "éːʃ"
+      ]
+    ],
+    "comment": "Object-before-subject order, as the template (18) predicts.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_20",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(20)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u j- áːnt -ik -éːʃ -oʔob",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "j-",
+        "3ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-éːʃ",
+        "2NOMpl"
+      ],
+      [
+        "-oʔob",
+        "3ERGpl"
+      ]
+    ],
+    "translation": "They help you (pl).",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "2"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        "éːʃ"
+      ],
+      [
+        "suffix2",
+        "oʔob"
+      ]
+    ],
+    "comment": "Also (2) and (28a).",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_21",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(21)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -a w- áːnt -ik -oʔob -éːʃ",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-a",
+        "2ERG"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-oʔob",
+        "3NOMpl"
+      ],
+      [
+        "-éːʃ",
+        "2ERGpl"
+      ]
+    ],
+    "translation": "You (pl) help them.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "2"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "3"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "a"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        "oʔob"
+      ],
+      [
+        "suffix2",
+        "éːʃ"
+      ]
+    ],
+    "comment": "The object–subject order the template (18) imposes is ungrammatical here.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_22",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(22)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -a w- áːnt -ik -éːʃ -oʔob",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-a",
+        "2ERG"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-éːʃ",
+        "2ERGpl"
+      ],
+      [
+        "-oʔob",
+        "3NOMpl"
+      ]
+    ],
+    "translation": "You (pl) help them.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "2"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "3"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "a"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        "éːʃ"
+      ],
+      [
+        "suffix2",
+        "oʔob"
+      ]
+    ],
+    "comment": "Subject agreement precedes object agreement; also (29a).",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_23",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(23)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u j- áːnt -ik -oʔob -oʔob",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "j-",
+        "3ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-oʔob",
+        "3NOMpl"
+      ],
+      [
+        "-oʔob",
+        "3ERGpl"
+      ]
+    ],
+    "translation": "They help them.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "3"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        "oʔob"
+      ],
+      [
+        "suffix2",
+        "oʔob"
+      ]
+    ],
+    "comment": "Overt agreement for both arguments is impossible.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_24",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(24)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u j- áːnt -ik -oʔob -Ø",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "j-",
+        "3ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-oʔob",
+        "3NOMpl"
+      ],
+      [
+        "-Ø",
+        "3ERGpl"
+      ]
+    ],
+    "translation": "They help them.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "objPerson",
+        "3"
+      ],
+      [
+        "objNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        "oʔob"
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "One overt suffix; also (1) and (30a).",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_16ex",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(16)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u j- áːnt -ik -en",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "j-",
+        "3ERG"
+      ],
+      [
+        "áːnt",
+        "help"
+      ],
+      [
+        "-ik",
+        "INCOMPL"
+      ],
+      [
+        "-en",
+        "1NOMsg"
+      ]
+    ],
+    "translation": "S/he helps me.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "transitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "sg"
+      ],
+      [
+        "objPerson",
+        "1"
+      ],
+      [
+        "objNumber",
+        "sg"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        "en"
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "The example under the nominative marker table (16).",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_3",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(3)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -in w- ok -ol",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-in",
+        "1ERGsg"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ]
+    ],
+    "translation": "I enter.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "1"
+      ],
+      [
+        "subjNumber",
+        "sg"
+      ],
+      [
+        "aux",
+        "in"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        ""
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_4",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(4)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -k ok -ol",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-k",
+        "1ERGpl"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ]
+    ],
+    "translation": "We enter.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "1"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "k"
+      ],
+      [
+        "prefix",
+        ""
+      ],
+      [
+        "suffix1",
+        ""
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "First-person plural: person and number both on the auxiliary, no prefix, no verbal suffix.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_5",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(5)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -a w- ok -ol",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-a",
+        "2ERG"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ]
+    ],
+    "translation": "You (sg) enter.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "2"
+      ],
+      [
+        "subjNumber",
+        "sg"
+      ],
+      [
+        "aux",
+        "a"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        ""
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_6",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(6)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -a w- ok -ol -éːʃ",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-a",
+        "2ERG"
+      ],
+      [
+        "w-",
+        "PSE.ERG"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ],
+      [
+        "-éːʃ",
+        "2ERGpl"
+      ]
+    ],
+    "translation": "You (pl) enter.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "2"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "a"
+      ],
+      [
+        "prefix",
+        "w"
+      ],
+      [
+        "suffix1",
+        "éːʃ"
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "Second person: person on the auxiliary, number on the verb.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_7",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(7)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u y- ok -ol",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "y-",
+        "3ERG"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ]
+    ],
+    "translation": "He/she enters.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "sg"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        ""
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "The prefix surfaces as y- before a vowel; the item is j-.",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  },
+  {
+    "id": "gpm2006_8",
+    "source": {
+      "bibkey": "gonzalez-poot-mcginnis-2006",
+      "paperLabel": "(8)"
+    },
+    "language": "yuca1254",
+    "primaryText": "k -u y- ok -ol -oʔob",
+    "discourseSegments": [],
+    "glossedTokens": [
+      [
+        "k",
+        "IMPERF"
+      ],
+      [
+        "-u",
+        "3ERG"
+      ],
+      [
+        "y-",
+        "3ERG"
+      ],
+      [
+        "ok",
+        "enter"
+      ],
+      [
+        "-ol",
+        "INCOMPL"
+      ],
+      [
+        "-oʔob",
+        "3ERGpl"
+      ]
+    ],
+    "translation": "They enter.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      [
+        "construction",
+        "intransitive"
+      ],
+      [
+        "subjPerson",
+        "3"
+      ],
+      [
+        "subjNumber",
+        "pl"
+      ],
+      [
+        "aux",
+        "u"
+      ],
+      [
+        "prefix",
+        "j"
+      ],
+      [
+        "suffix1",
+        "oʔob"
+      ],
+      [
+        "suffix2",
+        ""
+      ]
+    ],
+    "comment": "",
+    "lgrConformance": "MORPHEME_ALIGNED"
+  }
+]

--- a/Linglib/Data/Examples/GonzalezPootMcGinnis2006.lean
+++ b/Linglib/Data/Examples/GonzalezPootMcGinnis2006.lean
@@ -1,0 +1,252 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `GonzalezPootMcGinnis2006` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/GonzalezPootMcGinnis2006.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace GonzalezPootMcGinnis2006.Examples`.
+-/
+
+namespace GonzalezPootMcGinnis2006.Examples
+
+open Data.Examples
+
+def gpm2006_19 : LinguisticExample :=
+  { id := "gpm2006_19"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(19)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -a w- áːnt -ik -oʔon -éːʃ"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-a", "2ERG"), ("w-", "PSE.ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-oʔon", "1NOMpl"), ("-éːʃ", "2ERGpl")]
+    translation := "You (pl) help us."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "2"), ("subjNumber", "pl"), ("objPerson", "1"), ("objNumber", "pl"), ("aux", "a"), ("prefix", "w"), ("suffix1", "oʔon"), ("suffix2", "éːʃ")]
+    comment := "Object-before-subject order, as the template (18) predicts."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_20 : LinguisticExample :=
+  { id := "gpm2006_20"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(20)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u j- áːnt -ik -éːʃ -oʔob"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("j-", "3ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-éːʃ", "2NOMpl"), ("-oʔob", "3ERGpl")]
+    translation := "They help you (pl)."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "3"), ("subjNumber", "pl"), ("objPerson", "2"), ("objNumber", "pl"), ("aux", "u"), ("prefix", "j"), ("suffix1", "éːʃ"), ("suffix2", "oʔob")]
+    comment := "Also (2) and (28a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_21 : LinguisticExample :=
+  { id := "gpm2006_21"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(21)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -a w- áːnt -ik -oʔob -éːʃ"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-a", "2ERG"), ("w-", "PSE.ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-oʔob", "3NOMpl"), ("-éːʃ", "2ERGpl")]
+    translation := "You (pl) help them."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "2"), ("subjNumber", "pl"), ("objPerson", "3"), ("objNumber", "pl"), ("aux", "a"), ("prefix", "w"), ("suffix1", "oʔob"), ("suffix2", "éːʃ")]
+    comment := "The object–subject order the template (18) imposes is ungrammatical here."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_22 : LinguisticExample :=
+  { id := "gpm2006_22"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(22)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -a w- áːnt -ik -éːʃ -oʔob"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-a", "2ERG"), ("w-", "PSE.ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-éːʃ", "2ERGpl"), ("-oʔob", "3NOMpl")]
+    translation := "You (pl) help them."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "2"), ("subjNumber", "pl"), ("objPerson", "3"), ("objNumber", "pl"), ("aux", "a"), ("prefix", "w"), ("suffix1", "éːʃ"), ("suffix2", "oʔob")]
+    comment := "Subject agreement precedes object agreement; also (29a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_23 : LinguisticExample :=
+  { id := "gpm2006_23"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(23)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u j- áːnt -ik -oʔob -oʔob"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("j-", "3ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-oʔob", "3NOMpl"), ("-oʔob", "3ERGpl")]
+    translation := "They help them."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "3"), ("subjNumber", "pl"), ("objPerson", "3"), ("objNumber", "pl"), ("aux", "u"), ("prefix", "j"), ("suffix1", "oʔob"), ("suffix2", "oʔob")]
+    comment := "Overt agreement for both arguments is impossible."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_24 : LinguisticExample :=
+  { id := "gpm2006_24"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(24)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u j- áːnt -ik -oʔob -Ø"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("j-", "3ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-oʔob", "3NOMpl"), ("-Ø", "3ERGpl")]
+    translation := "They help them."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "3"), ("subjNumber", "pl"), ("objPerson", "3"), ("objNumber", "pl"), ("aux", "u"), ("prefix", "j"), ("suffix1", "oʔob"), ("suffix2", "")]
+    comment := "One overt suffix; also (1) and (30a)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_16ex : LinguisticExample :=
+  { id := "gpm2006_16ex"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(16)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u j- áːnt -ik -en"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("j-", "3ERG"), ("áːnt", "help"), ("-ik", "INCOMPL"), ("-en", "1NOMsg")]
+    translation := "S/he helps me."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "transitive"), ("subjPerson", "3"), ("subjNumber", "sg"), ("objPerson", "1"), ("objNumber", "sg"), ("aux", "u"), ("prefix", "j"), ("suffix1", "en"), ("suffix2", "")]
+    comment := "The example under the nominative marker table (16)."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_3 : LinguisticExample :=
+  { id := "gpm2006_3"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(3)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -in w- ok -ol"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-in", "1ERGsg"), ("w-", "PSE.ERG"), ("ok", "enter"), ("-ol", "INCOMPL")]
+    translation := "I enter."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "1"), ("subjNumber", "sg"), ("aux", "in"), ("prefix", "w"), ("suffix1", ""), ("suffix2", "")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_4 : LinguisticExample :=
+  { id := "gpm2006_4"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(4)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -k ok -ol"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-k", "1ERGpl"), ("ok", "enter"), ("-ol", "INCOMPL")]
+    translation := "We enter."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "1"), ("subjNumber", "pl"), ("aux", "k"), ("prefix", ""), ("suffix1", ""), ("suffix2", "")]
+    comment := "First-person plural: person and number both on the auxiliary, no prefix, no verbal suffix."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_5 : LinguisticExample :=
+  { id := "gpm2006_5"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(5)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -a w- ok -ol"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-a", "2ERG"), ("w-", "PSE.ERG"), ("ok", "enter"), ("-ol", "INCOMPL")]
+    translation := "You (sg) enter."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "2"), ("subjNumber", "sg"), ("aux", "a"), ("prefix", "w"), ("suffix1", ""), ("suffix2", "")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_6 : LinguisticExample :=
+  { id := "gpm2006_6"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(6)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -a w- ok -ol -éːʃ"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-a", "2ERG"), ("w-", "PSE.ERG"), ("ok", "enter"), ("-ol", "INCOMPL"), ("-éːʃ", "2ERGpl")]
+    translation := "You (pl) enter."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "2"), ("subjNumber", "pl"), ("aux", "a"), ("prefix", "w"), ("suffix1", "éːʃ"), ("suffix2", "")]
+    comment := "Second person: person on the auxiliary, number on the verb."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_7 : LinguisticExample :=
+  { id := "gpm2006_7"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(7)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u y- ok -ol"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("y-", "3ERG"), ("ok", "enter"), ("-ol", "INCOMPL")]
+    translation := "He/she enters."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "3"), ("subjNumber", "sg"), ("aux", "u"), ("prefix", "j"), ("suffix1", ""), ("suffix2", "")]
+    comment := "The prefix surfaces as y- before a vowel; the item is j-."
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def gpm2006_8 : LinguisticExample :=
+  { id := "gpm2006_8"
+    source := ⟨"gonzalez-poot-mcginnis-2006", "(8)"⟩
+    reportedIn := none
+    language := "yuca1254"
+    primaryText := "k -u y- ok -ol -oʔob"
+    discourseSegments := []
+    glossedTokens := [("k", "IMPERF"), ("-u", "3ERG"), ("y-", "3ERG"), ("ok", "enter"), ("-ol", "INCOMPL"), ("-oʔob", "3ERGpl")]
+    translation := "They enter."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("construction", "intransitive"), ("subjPerson", "3"), ("subjNumber", "pl"), ("aux", "u"), ("prefix", "j"), ("suffix1", "oʔob"), ("suffix2", "")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "MORPHEME_ALIGNED" }
+
+def all : List LinguisticExample := [gpm2006_19, gpm2006_20, gpm2006_21, gpm2006_22, gpm2006_23, gpm2006_24, gpm2006_16ex, gpm2006_3, gpm2006_4, gpm2006_5, gpm2006_6, gpm2006_7, gpm2006_8]
+
+end GonzalezPootMcGinnis2006.Examples

--- a/Linglib/Morphology/DistributedMorphology/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/Basic.lean
@@ -7,7 +7,7 @@ import Mathlib.Data.Finset.Card
 
 A `VocabularyItem` exposes the shared exponence interface
 (`Morphology.Exponence.Rule`) over neighborhoods: it applies where its
-specification is included in the neighborhood, and its specificity — the
+site is included in the neighborhood, and its specificity — the
 number of positioned features it mentions — is strictly antitone in the
 engine's order, so score selection is Elsewhere selection.
 -/
@@ -19,37 +19,37 @@ open Morphology.Exponence
 variable {F E : Type*} {i j : VocabularyItem F E} {n : Neighborhood (List F)}
 
 /-- A Vocabulary Item exposes the shared exponence interface: contexts are
-neighborhoods, applicability is inclusion of the specification. -/
-instance : Rule (VocabularyItem F E) (Neighborhood (List F)) E := ⟨exponent, fun i n => i.spec ⊆ n⟩
+neighborhoods, applicability is inclusion of the item's site. -/
+instance : Rule (VocabularyItem F E) (Neighborhood (List F)) E := ⟨exponent, fun i n => i.site ⊆ n⟩
 
 instance : Preorder (VocabularyItem F E) := toPreorder
 
-theorem applies_iff : Applies i n ↔ i.spec ⊆ n := Iff.rfl
+theorem applies_iff : Applies i n ↔ i.site ⊆ n := Iff.rfl
 
 /-- The Elsewhere item applies at every neighborhood. -/
 theorem elsewhere_applies (e : E) (n : Neighborhood (List F)) :
     Applies (⟨∅, e⟩ : VocabularyItem F E) n :=
   List.nil_subset _
 
-theorem le_iff_applies : i ≤ j ↔ ∀ ⦃n : Neighborhood (List F)⦄, i.spec ⊆ n → j.spec ⊆ n :=
+theorem le_iff_applies : i ≤ j ↔ ∀ ⦃n : Neighborhood (List F)⦄, i.site ⊆ n → j.site ⊆ n :=
   Iff.rfl
 
-/-- The engine's specificity order is reverse inclusion of specifications. -/
-theorem le_iff : i ≤ j ↔ j.spec ⊆ i.spec :=
+/-- The engine's specificity order is reverse inclusion of sites. -/
+theorem le_iff : i ≤ j ↔ j.site ⊆ i.site :=
   ⟨fun h => le_iff_applies.mp h (Neighborhood.Subset.refl _),
     fun h => le_iff_applies.mpr fun _ hn => Neighborhood.Subset.trans h hn⟩
 
 variable [DecidableEq F]
 
 instance : DecidableRel (Applies : VocabularyItem F E → Neighborhood (List F) → Prop) :=
-  fun i n => inferInstanceAs (Decidable (i.spec ⊆ n))
+  fun i n => inferInstanceAs (Decidable (i.site ⊆ n))
 
 /-- The number of distinct positioned features an item mentions — the
 Subset Principle's specificity score. -/
-def specificity (i : VocabularyItem F E) : ℕ := i.spec.positioned.toFinset.card
+def specificity (i : VocabularyItem F E) : ℕ := i.site.positioned.toFinset.card
 
 theorem toFinset_subset_toFinset :
-    i.spec.positioned.toFinset ⊆ j.spec.positioned.toFinset ↔ i.spec ⊆ j.spec :=
+    i.site.positioned.toFinset ⊆ j.site.positioned.toFinset ↔ i.site ⊆ j.site :=
   Multiset.toFinset_subset.trans Multiset.coe_subset
 
 theorem specificity_strictAnti : StrictAnti (specificity : VocabularyItem F E → ℕ) :=

--- a/Linglib/Morphology/DistributedMorphology/Defs.lean
+++ b/Linglib/Morphology/DistributedMorphology/Defs.lean
@@ -3,22 +3,28 @@ import Linglib.Morphology.DistributedMorphology.Neighborhood
 /-!
 # Vocabulary items
 
-A Vocabulary Item pairs a specification with the exponent that realizes it
-([halle-marantz-1993]): the features of the terminal it spells out, together
-with the features it requires of the neighboring terminals — its contextual
-environment, `/ __ ]X]`. Form and meaning share the type: an alloseme is an
-item whose exponent is a denotation (`DistributedMorphology/Allosemy.lean`).
-The selection-engine instance lives in `DistributedMorphology/Basic.lean`.
+A Vocabulary Item pairs its insertion site with the exponent that realizes
+it: the features of the terminal it spells out, together with the features
+it requires of the neighboring terminals — its contextual environment,
+`/ __ ]X]`. Form and meaning share the type: an alloseme is an item whose
+exponent is a denotation (`DistributedMorphology/Allosemy.lean`). The
+selection-engine instance lives in `DistributedMorphology/Basic.lean`.
+
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
 -/
 
 namespace DistributedMorphology
 
-/-- A Vocabulary Item: a specification paired with an exponent, applicable at
-any neighborhood containing every feature it mentions. -/
+/-- A Vocabulary Item: the site it is inserted at — the features it spells out
+and those it requires of the adjacent terminals — paired with its exponent;
+applicable at any neighborhood containing every feature it mentions. -/
 structure VocabularyItem (F E : Type*) where
   /-- The features the item spells out, with those it requires of the
   adjacent terminals. -/
-  spec : Neighborhood (List F)
+  site : Neighborhood (List F)
   /-- The exponent the item inserts. -/
   exponent : E
   deriving DecidableEq, Repr
@@ -28,7 +34,7 @@ variable {F E : Type*}
 namespace VocabularyItem
 
 /-- The features the item spells out at its own terminal. -/
-def features (i : VocabularyItem F E) : List F := i.spec.focus
+def features (i : VocabularyItem F E) : List F := i.site.focus
 
 /-- A context-free item: the features it spells out and its exponent. -/
 def ofFeatures (fs : List F) (e : E) : VocabularyItem F E := ⟨fs, e⟩
@@ -36,7 +42,7 @@ def ofFeatures (fs : List F) (e : E) : VocabularyItem F E := ⟨fs, e⟩
 /-- `fs ⟷ e`: the context-free Vocabulary Item spelling out `fs` as `e`. -/
 scoped infixr:25 " ⟷ " => ofFeatures
 
-@[simp] theorem spec_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).spec = ↑fs := rfl
+@[simp] theorem site_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).site = ↑fs := rfl
 
 @[simp] theorem exponent_ofFeatures (fs : List F) (e : E) : (fs ⟷ e).exponent = e := rfl
 

--- a/Linglib/Morphology/DistributedMorphology/Fission.lean
+++ b/Linglib/Morphology/DistributedMorphology/Fission.lean
@@ -1,116 +1,143 @@
-import Mathlib.Tactic.TypeStar
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 
 /-!
-# Fission (Distributed Morphology)
+# Fission
 
-Fission is the postsyntactic DM operation that splits a single terminal
-node into multiple positions of exponence, each independently subject
-to Vocabulary Insertion ([noyer-1992], [halle-1997]; adopted in
-[halle-marantz-1993]). The classical motivation is [noyer-1992]'s
-analysis of Afro-Asiatic prefix-conjugation agreement, where a single
-AGR node surfaces as one, two, or three separate affixes.
-[arregi-nevins-2012]'s Plural Fission splits the number feature
-[−singular] off the person features of second/third-person plural
-pronominal clitics in Basque auxiliaries (their §3.3.4), yielding the
-plural exponent at a second terminal-of-exponence.
+Fission lets one syntactic node be realized in several adjacent positions
+of exponence: a Vocabulary Item inserted at the node discharges only the
+features it spells out, and the remaining features fission off to a
+subsidiary position where insertion continues. The procedure here is strict
+scansion: the Vocabulary is scanned once, top to bottom; an item whose site
+one of the node's feature matrices contains is inserted and its features are
+discharged from that matrix; the residue stays available to the items
+below, and scansion halts at the bottom of the list — so no item is
+inserted twice, with no stipulation about elsewhere items.
 
-A `FissionRule` is parameterized over the fissioned feature bundle, the
-structural context licensing Fission, and the realization output.
-Conditions are `Prop`-valued with carried `DecidablePred` witnesses,
-matching the `ImpoverishmentRule` shape in
-`Linglib/Morphology/DistributedMorphology/Impoverishment.lean`.
+A node may bear several matrices, one per argument it agrees with (the
+Yucatec Agr3 agrees with both the ergative subject and the nominative
+object), and the matrices are kept apart: an item's features must all come
+from one of them. Features carry multiplicity (`List.diff`), so two
+arguments' shared features are discharged one at a time.
 
-## Main declarations
+## Main definitions
 
-* `FissionRule Bundle Ctx Out` — the generic rule structure
-* `FissionRule.apply` — partial application returning `Option Out`
-* `FissionRule.apply_eq_some_iff`, `FissionRule.apply_eq_none_iff`,
-  `FissionRule.isSome_apply` — the characterization API
+* `discharge`: remove an item's features from the first matrix containing
+  its site.
+* `scansion`: the exponents a node's matrices receive under strict
+  scansion with local Fission.
 
-## Implementation notes
+## Main results
 
-The realization output `Out` is opaque: this interface stipulates the
-fissioned exponents via `realize` rather than deriving them from
-iterated Vocabulary Insertion discharging features against a residue,
-as in [noyer-1992]'s original mechanism. Consumed by
-`Studies/MunozPerez2026.lean` (Chilean Spanish stylistic applicatives).
+* `scansion_sublist`: the exponents are a subsequence of the Vocabulary's
+  — each item at most once, in list order.
+* `scansion_nil`: a node with no matrix receives nothing.
+* `head?_scansion_singleton`: on a Vocabulary ordered by specificity, the
+  first insertion at a single matrix is the Subset Principle's winner.
 
-## Todo
+## References
 
-* Derive `realize` from a vocabulary: iterate insertion over the
-  feature residue so the number of exponents is a theorem, not a
-  parameter. Noyer's Tamazight Berber prefix conjugation (one-to-three
-  affix fission) is the canonical stress test.
-* Toward a second consumer: [arregi-nevins-2012]'s Plural Fission is a
-  feature-pair split with the residue copied into *both* output nodes
-  (their §3.3.4), so hosting it needs a two-node output and a computed
-  residue rather than an opaque `realize`. (Their Ergative/Dative
-  Doubling is not Fission: a post-Linearization Generalized-Reduplication
-  repair of the T-Noninitiality constraint.)
+* [R. Noyer, *Features, positions and affixes in autonomous morphological
+  structure*][noyer-1992]
+* [M. Halle, *Distributed Morphology: Impoverishment and Fission*][halle-1997]
+* [A. González Poot and M. McGinnis, *Local versus long-distance Fission in
+  Distributed Morphology*][gonzalez-poot-mcginnis-2006]
 -/
 
 namespace DistributedMorphology
 
-/-- A Fission rule is parameterized over:
-* `Bundle` — the fissioned morphological feature bundle (e.g., φ-features);
-* `Ctx`    — the structural context licensing Fission;
-* `Out`    — the realization output.
+open Morphology.Exponence
 
-Both `contextOk` and `bundleOk` are `Prop`-valued with carried
-`DecidablePred` witnesses, matching the `ImpoverishmentRule` template
-(see `Impoverishment.lean`). -/
-structure FissionRule (Bundle Ctx Out : Type*) where
-  /-- The structural condition licensing Fission. -/
-  contextOk : Ctx → Prop
-  /-- Decidability witness for `contextOk`. -/
-  decContext : DecidablePred contextOk
-  /-- The condition on the fissioned bundle (e.g., [+PART, +SING]). -/
-  bundleOk : Bundle → Prop
-  /-- Decidability witness for `bundleOk`. -/
-  decBundle : DecidablePred bundleOk
-  /-- Realization: map each licensed bundle to its output. -/
-  realize : Bundle → Out
+variable {F E : Type*} [DecidableEq F]
 
-namespace FissionRule
+/-- Discharge the item's features from the first of the matrices containing
+its site, in the environment `env` (whose focus is ignored); `none` when no
+matrix does. -/
+def discharge (i : VocabularyItem F E) (env : Neighborhood (List F)) :
+    List (List F) → Option (List (List F))
+  | [] => none
+  | m :: ms =>
+    if i.site ⊆ ({ env with focus := m } : Neighborhood (List F)) then
+      some (m.diff i.site.focus :: ms)
+    else (discharge i env ms).map (m :: ·)
 
-variable {Bundle Ctx Out : Type*} {rule : FissionRule Bundle Ctx Out}
-  {p : Bundle} {c : Ctx} {out : Out}
+/-- Strict scansion with local Fission: the exponents received by a node
+bearing the matrices `ms` in the environment `env`. -/
+def scansion (items : List (VocabularyItem F E)) (env : Neighborhood (List F)) :
+    List (List F) → List E
+  | ms => go items ms
+where
+  /-- Scan the remaining items against the remaining matrices. -/
+  go : List (VocabularyItem F E) → List (List F) → List E
+    | [], _ => []
+    | i :: rest, ms =>
+      match discharge i env ms with
+      | some ms' => i.exponent :: go rest ms'
+      | none => go rest ms
 
-instance (rule : FissionRule Bundle Ctx Out) (c : Ctx) :
-    Decidable (rule.contextOk c) := rule.decContext c
+variable {items : List (VocabularyItem F E)} {env : Neighborhood (List F)}
 
-instance (rule : FissionRule Bundle Ctx Out) (p : Bundle) :
-    Decidable (rule.bundleOk p) := rule.decBundle p
+@[simp] theorem discharge_nil (i : VocabularyItem F E) : discharge i env [] = none := rfl
 
-/-- Apply Fission: yield the realization when both the structural and
-bundle conditions hold; otherwise `none`. -/
-def apply (rule : FissionRule Bundle Ctx Out) (p : Bundle) (c : Ctx) :
-    Option Out :=
-  if rule.contextOk c ∧ rule.bundleOk p then some (rule.realize p) else none
+theorem scansion_go_nil : ∀ items : List (VocabularyItem F E), scansion.go env items [] = []
+  | [] => rfl
+  | _ :: rest => by simp [scansion.go, scansion_go_nil rest]
 
-theorem apply_pos (hc : rule.contextOk c) (hb : rule.bundleOk p) :
-    rule.apply p c = some (rule.realize p) :=
-  if_pos ⟨hc, hb⟩
+/-- A node with no matrix receives nothing. -/
+@[simp] theorem scansion_nil : scansion items env [] = [] := scansion_go_nil items
 
-theorem apply_neg (h : ¬(rule.contextOk c ∧ rule.bundleOk p)) :
-    rule.apply p c = none :=
-  if_neg h
+/-- Each item is inserted at most once, in Vocabulary order. -/
+theorem scansion_go_sublist :
+    ∀ (items : List (VocabularyItem F E)) (ms : List (List F)),
+      (scansion.go env items ms).Sublist (items.map (·.exponent))
+  | [], _ => List.Sublist.refl _
+  | i :: rest, ms => by
+    simp only [scansion.go, List.map_cons]
+    split
+    · exact (scansion_go_sublist rest _).cons_cons _
+    · exact (scansion_go_sublist rest ms).cons _
 
-@[simp]
-theorem apply_eq_some_iff :
-    rule.apply p c = some out ↔
-      (rule.contextOk c ∧ rule.bundleOk p) ∧ rule.realize p = out := by
-  unfold apply; split <;> simp_all
+theorem scansion_sublist (ms : List (List F)) :
+    (scansion items env ms).Sublist (items.map (·.exponent)) :=
+  scansion_go_sublist items ms
 
-@[simp]
-theorem apply_eq_none_iff :
-    rule.apply p c = none ↔ ¬(rule.contextOk c ∧ rule.bundleOk p) := by
-  unfold apply; split <;> simp_all
+theorem length_scansion_le (ms : List (List F)) :
+    (scansion items env ms).length ≤ items.length := by
+  simpa using (scansion_sublist (items := items) (env := env) ms).length_le
 
-theorem isSome_apply :
-    (rule.apply p c).isSome ↔ rule.contextOk c ∧ rule.bundleOk p := by
-  unfold apply; split <;> simp_all
+/-- At a single matrix, an item discharges iff it applies there. -/
+theorem discharge_singleton (i : VocabularyItem F E) (m : List F) :
+    discharge i env [m] =
+      if i.site ⊆ ({ env with focus := m } : Neighborhood (List F))
+        then some [m.diff i.site.focus] else none := by
+  simp [discharge]
 
-end FissionRule
+/-- On a Vocabulary ordered by decreasing specificity, the first insertion at
+a single matrix is the Subset Principle's winner: scansion agrees with
+Elsewhere competition where both apply. -/
+theorem head?_scansion_singleton (m : List F)
+    (hsorted : items.Pairwise fun i j => j.specificity ≤ i.specificity) :
+    (scansion items env [m]).head? =
+      (winner? items ({ env with focus := m } : Neighborhood (List F))).map (·.exponent) := by
+  induction items with
+  | nil => simp [scansion, scansion.go, winner?, selectBy, applicable]
+  | cons i rest ih =>
+    rw [List.pairwise_cons] at hsorted
+    simp only [scansion, scansion.go, discharge_singleton]
+    by_cases h : i.site ⊆ ({ env with focus := m } : Neighborhood (List F))
+    · rw [if_pos h]
+      simp only [List.head?_cons, winner?, selectBy, applicable, List.filter_cons,
+        decide_eq_true (show Applies i _ from h), if_true]
+      rw [List.argmax_cons]
+      rcases hc : List.argmax VocabularyItem.specificity
+        (rest.filter fun r =>
+          decide (Applies r ({ env with focus := m } : Neighborhood (List F)))) with _ | c
+      · rfl
+      · have hle : c.specificity ≤ i.specificity :=
+          hsorted.1 c (List.mem_of_mem_filter (List.argmax_mem hc))
+        simp [not_lt.mpr hle]
+    · rw [if_neg h]
+      have := ih hsorted.2
+      simpa [scansion, winner?, selectBy, applicable, List.filter_cons,
+        decide_eq_false (show ¬ Applies i _ from h)] using this
 
 end DistributedMorphology

--- a/Linglib/Morphology/DistributedMorphology/Fusion.lean
+++ b/Linglib/Morphology/DistributedMorphology/Fusion.lean
@@ -1,107 +1,84 @@
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 
 /-!
-# Fusion (Distributed Morphology)
+# Fusion
 
-Fusion is the postsyntactic DM operation that merges two adjacent terminal
-nodes into a single terminal bearing both feature bundles, which a single
-Vocabulary Item then spells out ([halle-marantz-1993]'s Tns+Agr fusion in
-English; French *du* = P[de] fused with D[le] is the portmanteau case,
-[kalin-bjorkman-etal-2026] §4.4). It is the inverse misalignment from
-Fission: fission yields more positions of exponence than syntactic
-terminals, fusion fewer.
+Fusion merges two adjacent terminal nodes into a single terminal bearing
+both feature bundles, which a single Vocabulary Item then spells out — the
+Tns+Agr fusion of English finite verbs; French *du* = P[de] fused with
+D[le] is the portmanteau case. It is the inverse misalignment from Fission:
+fission yields more positions of exponence than syntactic terminals, fusion
+fewer. The fused bundle is the two bundles together; a rule contributes
+only the condition under which the two terminals fuse.
 
-A `FusionRule` follows the `FissionRule`/`ImpoverishmentRule` template —
-`Prop`-valued conditions with carried decidability witnesses. Unlike
-fission's opaque realization output, fusion's output is a bundle that
-continues to Vocabulary Insertion, and `portmanteau_needs_fusion` is the
-payoff: an exponent whose vocabulary items all draw on both input bundles
-is insertable only at the fused node.
+## Main definitions
 
-## Main declarations
+* `FusionRule`: the licensing condition on two adjacent bundles.
+* `FusionRule.apply`: the fused bundle when the condition holds.
 
-* `FusionRule Bundle Ctx` — the generic rule structure
-* `FusionRule.apply` — partial application returning `Option Bundle`, with
-  the `apply_eq_some_iff`/`apply_eq_none_iff`/`isSome_apply`
-  characterization API
-* `portmanteau_needs_fusion` — a cross-terminal exponent wins at neither
-  unfused node
+## Main results
+
+* `portmanteau_needs_fusion`: an exponent whose items all draw on both
+  bundles is insertable at neither unfused node.
+
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
+* [L. Kalin, B. Bjorkman et al.][kalin-bjorkman-etal-2026] §4.4
 -/
 
 namespace DistributedMorphology
 
-/-- A Fusion rule is parameterized over:
-* `Bundle` — the morphological feature bundles of the fusing terminals;
-* `Ctx`    — the structural context licensing Fusion (adjacency of the
-  two terminals under one head).
+variable {F E : Type*}
 
-Both conditions are `Prop`-valued with carried decidability witnesses,
-matching the `FissionRule`/`ImpoverishmentRule` template. -/
-structure FusionRule (Bundle Ctx : Type*) where
-  /-- The structural condition licensing Fusion. -/
-  contextOk : Ctx → Prop
-  /-- Decidability witness for `contextOk`. -/
-  decContext : DecidablePred contextOk
-  /-- The condition on the two fusing bundles (structurally higher first). -/
-  bundlesOk : Bundle → Bundle → Prop
-  /-- Decidability witness for `bundlesOk`. -/
-  decBundles : ∀ p, DecidablePred (bundlesOk p)
-  /-- The fused bundle — the union of the inputs in the intended instances. -/
-  fuse : Bundle → Bundle → Bundle
+/-- A Fusion rule: the condition under which two adjacent terminals, the
+structurally higher first, fuse into one bearing both bundles. -/
+structure FusionRule (F : Type*) where
+  /-- The condition on the two fusing bundles. -/
+  condition : List F → List F → Prop
+  /-- Decidability witness for `condition`. -/
+  decCond : ∀ p q, Decidable (condition p q)
 
 namespace FusionRule
 
-variable {Bundle Ctx : Type*} {rule : FusionRule Bundle Ctx}
-  {p q out : Bundle} {c : Ctx}
+variable {rule : FusionRule F} {p q out : List F}
 
-instance (rule : FusionRule Bundle Ctx) (c : Ctx) :
-    Decidable (rule.contextOk c) := rule.decContext c
+instance (rule : FusionRule F) (p q : List F) : Decidable (rule.condition p q) :=
+  rule.decCond p q
 
-instance (rule : FusionRule Bundle Ctx) (p q : Bundle) :
-    Decidable (rule.bundlesOk p q) := rule.decBundles p q
+/-- Apply Fusion: the two bundles together when the condition holds;
+otherwise `none`. -/
+def apply (rule : FusionRule F) (p q : List F) : Option (List F) :=
+  if rule.condition p q then some (p ++ q) else none
 
-/-- Apply Fusion: yield the fused bundle when both the structural and
-bundle conditions hold; otherwise `none`. -/
-def apply (rule : FusionRule Bundle Ctx) (p q : Bundle) (c : Ctx) :
-    Option Bundle :=
-  if rule.contextOk c ∧ rule.bundlesOk p q then some (rule.fuse p q) else none
+theorem apply_pos (h : rule.condition p q) : rule.apply p q = some (p ++ q) := if_pos h
 
-theorem apply_pos (hc : rule.contextOk c) (hb : rule.bundlesOk p q) :
-    rule.apply p q c = some (rule.fuse p q) :=
-  if_pos ⟨hc, hb⟩
+theorem apply_neg (h : ¬ rule.condition p q) : rule.apply p q = none := if_neg h
 
-theorem apply_neg (h : ¬(rule.contextOk c ∧ rule.bundlesOk p q)) :
-    rule.apply p q c = none :=
-  if_neg h
-
-@[simp]
-theorem apply_eq_some_iff :
-    rule.apply p q c = some out ↔
-      (rule.contextOk c ∧ rule.bundlesOk p q) ∧ rule.fuse p q = out := by
+@[simp] theorem apply_eq_some_iff :
+    rule.apply p q = some out ↔ rule.condition p q ∧ p ++ q = out := by
   unfold apply; split <;> simp_all
 
-@[simp]
-theorem apply_eq_none_iff :
-    rule.apply p q c = none ↔ ¬(rule.contextOk c ∧ rule.bundlesOk p q) := by
+@[simp] theorem apply_eq_none_iff : rule.apply p q = none ↔ ¬ rule.condition p q := by
   unfold apply; split <;> simp_all
 
-theorem isSome_apply :
-    (rule.apply p q c).isSome ↔ rule.contextOk c ∧ rule.bundlesOk p q := by
+theorem isSome_apply : (rule.apply p q).isSome ↔ rule.condition p q := by
   unfold apply; split <;> simp_all
 
 end FusionRule
 
 section Portmanteau
 
-variable {F E : Type*} [DecidableEq F]
+variable [DecidableEq F]
 
-/-- A portmanteau exponent needs fusion: when every vocabulary item
-carrying the exponent draws on features missing from each unfused bundle,
-the Subset Principle can select it at neither unfused node — only the
-fused bundle contains its item's features (`subsetPrinciple_winner_mem`). -/
+/-- A portmanteau exponent needs fusion: when every item carrying the
+exponent draws on features missing from each unfused bundle, the Subset
+Principle can select it at neither unfused node — only the fused bundle
+contains its item's features (`subsetPrinciple_winner_mem`). -/
 theorem portmanteau_needs_fusion {items : List (VocabularyItem F E)}
     {p q : Neighborhood (List F)} {e : E}
-    (he : ∀ i ∈ items, i.exponent = e → ¬ i.spec ⊆ p ∧ ¬ i.spec ⊆ q) :
+    (he : ∀ i ∈ items, i.exponent = e → ¬ i.site ⊆ p ∧ ¬ i.site ⊆ q) :
     subsetPrinciple items p ≠ some e ∧ subsetPrinciple items q ≠ some e := by
   refine ⟨fun h => ?_, fun h => ?_⟩ <;> obtain ⟨i, hi, rfl, happ⟩ := subsetPrinciple_winner_mem h
   · exact (he i hi rfl).1 happ

--- a/Linglib/Morphology/DistributedMorphology/Neighborhood.lean
+++ b/Linglib/Morphology/DistributedMorphology/Neighborhood.lean
@@ -6,7 +6,7 @@ import Mathlib.Data.List.Basic
 The local environment a postsyntactic rule inspects: a focus terminal with
 the terminals to either side, nearest first. Vocabulary Items and
 Impoverishment rules are stated over the same neighborhoods — an item's
-specification is itself a neighborhood of feature lists, and it applies
+site is itself a neighborhood of feature lists, and it applies
 where every feature it mentions, at the focus or on a neighbor, is present
 (`Neighborhood.positioned`, `⊆`).
 
@@ -20,7 +20,7 @@ where every feature it mentions, at the focus or on a neighbor, is present
 ## Implementation notes
 
 A bare bundle coerces to the context-free neighborhood and `∅` is the
-empty specification, so a context-free Vocabulary Item is written
+empty site, so a context-free Vocabulary Item is written
 `⟨[f₁, f₂], e⟩` and the Elsewhere item `⟨∅, e⟩`. Positions count outward
 from the focus: `left` toward the root, `right` toward the clause.
 -/
@@ -71,9 +71,9 @@ def positioned (n : Neighborhood (List F)) : List (Position × F) :=
     n.leftCtx.zipIdx.flatMap (fun p => p.1.map (Position.left p.2, ·)) ++
     n.rightCtx.zipIdx.flatMap (fun p => p.1.map (Position.right p.2, ·))
 
-/-- A specification is included in a neighborhood when every positioned
-feature it mentions is present; a terminal it does not mention is
-unconstrained — the Subset Principle over neighborhoods. -/
+/-- A site is included in a neighborhood when every positioned feature it
+mentions is present; a terminal it does not mention is unconstrained — the
+Subset Principle over neighborhoods. -/
 instance : HasSubset (Neighborhood (List F)) := ⟨fun s n => s.positioned ⊆ n.positioned⟩
 
 theorem subset_def {s n : Neighborhood (List F)} : s ⊆ n ↔ s.positioned ⊆ n.positioned :=
@@ -99,7 +99,7 @@ instance : Trans (· ⊆ · : Neighborhood (List F) → Neighborhood (List F) �
 
 @[simp] theorem positioned_empty : (∅ : Neighborhood (List F)).positioned = [] := rfl
 
-/-- Context-free specifications compare by feature inclusion. -/
+/-- Context-free sites compare by feature inclusion. -/
 theorem ofBundle_subset_ofBundle {s t : List F} :
     (ofBundle s : Neighborhood (List F)) ⊆ ofBundle t ↔ s ⊆ t := by
   rw [subset_def, positioned_ofBundle, positioned_ofBundle]

--- a/Linglib/Morphology/DistributedMorphology/Spellout.lean
+++ b/Linglib/Morphology/DistributedMorphology/Spellout.lean
@@ -7,9 +7,8 @@ import Linglib.Morphology.DistributedMorphology.Impoverishment
 The PF branch of the Y-model at the domain level: a spell-out domain is
 the sequence of terminals the syntax hands over, the postsyntactic modules
 transform it, and Vocabulary Insertion realizes what survives, each
-position in its neighborhood
-([halle-marantz-1993]; module inventory and ordering per
-[arregi-nevins-2012]). The focus-level rule types
+position in its neighborhood; the module inventory and its ordering follow
+the Basque morphotactics. The focus-level rule types
 (`ImpoverishmentRule` and kin) rewrite one terminal inside
 its `Neighborhood`; the operations here move, remove, and merge the
 terminals themselves, which no focus-level rule can express.
@@ -17,8 +16,9 @@ terminals themselves, which no focus-level rule can express.
 Each operation carries its position-count law, so terminal/exponent
 misalignment is arithmetic: neighborhood rewriting and terminal
 metathesis preserve the count, obliteration and fusion decrease it, and
-`Spellout.length_pf` says exponent slots equal terminals after the
-modules. `winner?_retreat` (`VocabularyInsertion/Basic.lean`) supplies the
+`Spellout.length_pf` says insertion positions equal terminals after the
+modules — Fission multiplies exponents within a position (`scansion`),
+not positions. `winner?_retreat` (`VocabularyInsertion/Basic.lean`) supplies the
 insertion-side ordering law.
 
 Consumers: `Studies/Middleton2026.lean` (Basque whole-terminal rules and
@@ -30,8 +30,8 @@ fusion feeding one insertion).
 * `SpelloutDomain`, `mapNeighborhoods` — the domain and the zipper lift
   of focus-level rewriting
 * `ObliterationRule`, `TerminalMetathesisRule` — whole-terminal deletion
-  ([arregi-nevins-2012]'s Obliteration) and adjacent-terminal swap, with
-  first-match applicators and count laws
+  (Obliteration) and adjacent-terminal swap, with first-match applicators
+  and count laws
 * `FusionRule.applyFirstAdjacent` — the domain lift of Fusion
 * `Spellout` — the module sequence plus insertion in context; `run`, `pf`,
   `runModules_append`
@@ -41,10 +41,15 @@ fusion feeding one insertion).
 * The LF branch: an `Interpreted` extension whose interpretation reads
   the input domain (the Y-model separation by type), seeded by the
   domain-level allosemy licensing of `Studies/Benz2025.lean`.
-* A Fission lift, once `FissionRule` derives its positions of exponence
-  from the vocabulary rather than an opaque `realize`.
 * Stratifying the module list by linearization — Lowering before,
-  Local Dislocation after ([embick-noyer-2001]).
+  Local Dislocation after.
+
+## References
+
+* [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
+  inflection*][halle-marantz-1993]
+* [K. Arregi and A. Nevins, *Morphotactics*][arregi-nevins-2012]
+* [D. Embick and R. Noyer, *Movement operations after syntax*][embick-noyer-2001]
 -/
 
 namespace DistributedMorphology
@@ -191,27 +196,28 @@ end TerminalMetathesisRule
 
 namespace FusionRule
 
+variable {F : Type*}
+
 /-- The domain lift of Fusion: fuse the first adjacent pair the rule
-licenses in context `c`; otherwise the domain is unchanged. -/
-def applyFirstAdjacent (rule : FusionRule Bundle Ctx) (c : Ctx) :
-    SpelloutDomain Bundle → SpelloutDomain Bundle
+licenses; otherwise the domain is unchanged. -/
+def applyFirstAdjacent (rule : FusionRule F) :
+    SpelloutDomain (List F) → SpelloutDomain (List F)
   | [] => []
   | [b] => [b]
   | b₁ :: b₂ :: rest =>
-    if rule.contextOk c ∧ rule.bundlesOk b₁ b₂ then rule.fuse b₁ b₂ :: rest
-    else b₁ :: applyFirstAdjacent rule c (b₂ :: rest)
+    if rule.condition b₁ b₂ then (b₁ ++ b₂) :: rest
+    else b₁ :: applyFirstAdjacent rule (b₂ :: rest)
 
 /-- Fusion never increases the number of terminals. -/
-theorem length_applyFirstAdjacent_le (rule : FusionRule Bundle Ctx) (c : Ctx) :
-    ∀ d : SpelloutDomain Bundle,
-      (rule.applyFirstAdjacent c d).length ≤ d.length
+theorem length_applyFirstAdjacent_le (rule : FusionRule F) :
+    ∀ d : SpelloutDomain (List F), (rule.applyFirstAdjacent d).length ≤ d.length
   | [] => by simp [applyFirstAdjacent]
   | [b] => by simp [applyFirstAdjacent]
   | b₁ :: b₂ :: rest => by
     rw [applyFirstAdjacent]
     split
     · simp
-    · have := length_applyFirstAdjacent_le rule c (b₂ :: rest)
+    · have := length_applyFirstAdjacent_le rule (b₂ :: rest)
       simp only [List.length_cons] at this ⊢
       omega
 
@@ -242,9 +248,9 @@ position, in its neighborhood. -/
 structure Spellout (Bundle F : Type*) where
   /-- The ordered postsyntactic module sequence. -/
   modules : List (SpelloutDomain Bundle → SpelloutDomain Bundle)
-  /-- Vocabulary Insertion at a position, seeing its neighbors; `none` is a
-  non-licensed position. -/
-  insert : Neighborhood Bundle → Option F
+  /-- The exponents inserted at a position, seeing its neighbors: one,
+  several under Fission (`scansion`), none at a non-licensed position. -/
+  insert : Neighborhood Bundle → List F
 
 namespace Spellout
 
@@ -257,7 +263,7 @@ def run (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
 
 /-- The PF output: one insertion slot per surviving position. -/
 def pf (s : Spellout Bundle F) (d : SpelloutDomain Bundle) :
-    List (Option F) :=
+    List (List F) :=
   mapNeighborhoods s.insert (s.run d)
 
 /-- Exponent slots equal terminals after the modules: the exponent count

--- a/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
+++ b/Linglib/Morphology/DistributedMorphology/VocabularyInsertion/Basic.lean
@@ -6,8 +6,8 @@ import Linglib.Morphology.Exponence.Select
 
 Vocabulary Insertion supplies syntactic terminals with phonological
 exponents: the Vocabulary Items of List 2 compete for insertion at each
-terminal, and the Subset Principle of [halle-marantz-1993] picks the item
-whose specification is the largest one the terminal's neighborhood contains —
+terminal, and the Subset Principle picks the item whose site is the largest
+one the terminal's neighborhood contains —
 its own features and, for a contextual item, the features of the adjacent
 terminals. This file specializes the shared exponence engine
 (`Morphology.Exponence.selectBy`) to that competition.
@@ -21,7 +21,7 @@ terminals. This file specializes the shared exponence engine
 
 * `winner?_isElsewhereWinner`: the winner is an Elsewhere winner of the
   shared core, with no faithfulness hypothesis — the engine's specificity
-  order is reverse inclusion of specifications (`VocabularyItem.le_iff`).
+  order is reverse inclusion of sites (`VocabularyItem.le_iff`).
 * `winner?_retreat`: deleting features from the neighborhood can only make
   the winner less specific — retreat to the general case.
 
@@ -29,6 +29,7 @@ terminals. This file specializes the shared exponence engine
 
 * [M. Halle and A. Marantz, *Distributed Morphology and the pieces of
   inflection*][halle-marantz-1993]
+* [K. Arregi and A. Nevins, *Morphotactics*][arregi-nevins-2012]
 -/
 
 namespace DistributedMorphology
@@ -48,22 +49,21 @@ def winner? (items : List (VocabularyItem F E)) (n : Neighborhood (List F)) :
     Option (VocabularyItem F E) :=
   selectBy VocabularyItem.specificity items n
 
-/-- The **Subset Principle** ([halle-marantz-1993]): the exponent of the most
-specific item whose specification the neighborhood contains; `none` iff no
-item applies. -/
+/-- The **Subset Principle**: the exponent of the most specific item whose
+site the neighborhood contains; `none` iff no item applies. -/
 def subsetPrinciple (items : List (VocabularyItem F E)) (n : Neighborhood (List F)) : Option E :=
   realize VocabularyItem.specificity items n
 
 theorem winner?_mem (h : winner? items n = some i) : i ∈ applicable items n :=
   List.argmax_mem h
 
-theorem winner?_spec (h : winner? items n = some i) : i ∈ items ∧ i.spec ⊆ n :=
+theorem winner?_spec (h : winner? items n = some i) : i ∈ items ∧ i.site ⊆ n :=
   mem_applicable.mp (winner?_mem h)
 
 /-- The Subset Principle's exponent comes from an applicable item — the
 selection never draws on features the neighborhood does not bear. -/
 theorem subsetPrinciple_winner_mem (h : subsetPrinciple items n = some e) :
-    ∃ i ∈ items, i.exponent = e ∧ i.spec ⊆ n := by
+    ∃ i ∈ items, i.exponent = e ∧ i.site ⊆ n := by
   obtain ⟨i, hi, rfl⟩ := Option.map_eq_some_iff.mp h
   exact ⟨i, (winner?_spec hi).1, rfl, (winner?_spec hi).2⟩
 
@@ -91,8 +91,7 @@ theorem applicable_mono (hsub : n' ⊆ n) : applicable items n' ⊆ applicable i
 /-- **Retreat to the general case**: shrinking the neighborhood — deleting
 features by Impoverishment — can only make the winner weakly less specific,
 which is why impoverishment yields syncretism with a more general exponent
-rather than a different specific one ([halle-marantz-1993],
-[arregi-nevins-2012]). -/
+rather than a different specific one. -/
 theorem winner?_retreat (hsub : n' ⊆ n) (h' : winner? items n' = some i') :
     ∃ i, winner? items n = some i ∧ i'.specificity ≤ i.specificity := by
   have hmem := applicable_mono hsub (winner?_mem h')

--- a/Linglib/Studies/GonzalezPootMcGinnis2006.lean
+++ b/Linglib/Studies/GonzalezPootMcGinnis2006.lean
@@ -1,0 +1,193 @@
+import Linglib.Morphology.DistributedMorphology.Fission
+import Linglib.Data.Examples.GonzalezPootMcGinnis2006
+
+/-!
+# Local versus long-distance Fission in Distributed Morphology
+
+[gonzalez-poot-mcginnis-2006]: the verbal agreement suffixes of Yucatec
+Maya come from one node, Agr3, which agrees with both the ergative subject
+and the nominative object and is realized by strict scansion of the
+Vocabulary (27) with local Fission — an item discharges its features from
+one of the node's two matrices and the residue stays available to the
+items below. The second- and third-person plural suffixes *-éːʃ* and
+*-oʔob* are unspecified for case, so their order is fixed by specificity,
+*-éːʃ* before *-oʔob* whatever the grammatical roles ((19)–(22)), and one
+scansion never inserts *-oʔob* twice ((23)–(24)); the object–subject
+template (18) gets both wrong. Long-distance Fission is rejected: the
+split of ergative person onto the auxiliary (Agr1, (43)) and number onto
+the verb runs across a word boundary, and first-person number is a person
+distinction ((42), on the feature-geometric treatment of first person).
+
+## Main definitions
+
+* `Feature`, `matrix`, `ergMatrix`: the binary features of (26) with case,
+  and an argument's matrix.
+* `agr3`, `agr1`, `agr2`: the Vocabularies (27), (43), (44).
+* `suffixes`: Agr3's exponents for a subject and an object, by `scansion`.
+* `templateSuffixes`: the rival template (18), one node per argument.
+
+## Main results
+
+* `suffixes_rows`: every row of the pool is grammatical iff its suffixes are
+  `suffixes`' output.
+* `template_predicts_starred`, `template_fails_grammatical`: the template
+  predicts the starred orders of (21) and (23) and fails (22) and (24).
+* `aux_prefix_rows`: (43) and (44) recover the auxiliary suffix and the
+  verbal prefix of every row.
+* `first_person_no_verbal_number`: a first-person ergative argument takes no
+  verbal number suffix ((3)–(4)), since its number is not [+Pl].
+
+## Implementation notes
+
+Agr3's list (27) needs the nominative first-person plural to carry [+PSE]
+and the singular not to, the reverse of the assignment (42) gives the
+ergative auxiliary; the paper does not reconcile the two, so `matrix` follows
+(27) for nominative first person and (42) otherwise. The elsewhere *-Ø* is
+inserted but not counted among a row's overt suffixes.
+
+## References
+
+* [H. Harley and E. Ritter, *Person and number in pronouns*][harley-ritter-2002]
+-/
+
+namespace GonzalezPootMcGinnis2006
+
+open DistributedMorphology Data.Examples
+open scoped DistributedMorphology.VocabularyItem
+
+/-! ### Features and matrices (§3–4) -/
+
+/-- Case of an agreeing argument. -/
+inductive Case where
+  | nom
+  | erg
+  deriving DecidableEq, Repr
+
+/-- The binary person features of (26), number as [±Pl], and case. -/
+inductive Feature where
+  | pse (b : Bool)
+  | auth (b : Bool)
+  | pl (b : Bool)
+  | case (c : Case)
+  deriving DecidableEq, Repr
+
+/-- Grammatical person. -/
+inductive Person where
+  | first
+  | second
+  | third
+  deriving DecidableEq, Repr
+
+/-- An ergative argument's matrix ((42)): first-person number is a person
+distinction — singular [+PSE, +Auth], plural [+Auth]. -/
+def ergMatrix : Person → Bool → List Feature
+  | .first, false => [.pse true, .auth true, .case .erg]
+  | .first, true => [.auth true, .case .erg]
+  | .second, pl => [.pse true, .auth false, .pl pl, .case .erg]
+  | .third, pl => [.pse false, .auth false, .pl pl, .case .erg]
+
+/-- An argument's matrix for Agr3: (42) for ergative arguments and for
+second and third person; for nominative first person the assignment (27)
+presupposes — *-oʔon* 1pl [+PSE, +Auth, NOM], *-en* 1sg [+Auth, NOM]. -/
+def matrix : Person → Bool → Case → List Feature
+  | .first, false, .nom => [.auth true, .case .nom]
+  | .first, true, .nom => [.pse true, .auth true, .case .nom]
+  | p, pl, .erg => ergMatrix p pl
+  | .second, pl, .nom => [.pse true, .auth false, .pl pl, .case .nom]
+  | .third, pl, .nom => [.pse false, .auth false, .pl pl, .case .nom]
+
+/-! ### The Vocabularies (27), (43), (44) -/
+
+/-- The Agr3 Vocabulary Items (27), in scansion order. -/
+def agr3 : List (VocabularyItem Feature String) :=
+  [[.pse true, .auth true, .case .nom] ⟷ "oʔon", [.pse true, .pl false, .case .nom] ⟷ "etʃ",
+    [.auth true, .case .nom] ⟷ "en", [.pse true, .pl true] ⟷ "éːʃ", [.pl true] ⟷ "oʔob",
+    [] ⟷ "Ø"]
+
+/-- The Agr1 Vocabulary Items (43): the ergative auxiliary suffix. -/
+def agr1 : List (VocabularyItem Feature String) :=
+  [[.pse true, .auth true] ⟷ "in", [.auth true] ⟷ "k", [.pse true] ⟷ "a", [] ⟷ "u"]
+
+/-- The Agr2 Vocabulary Items (44): the ergative verbal prefix. -/
+def agr2 : List (VocabularyItem Feature String) :=
+  [[.pse true] ⟷ "w", [.pse false] ⟷ "j", [] ⟷ ""]
+
+/-- The overt verbal suffixes of a clause: Agr3 bears the subject's matrix
+and, in a transitive clause, the object's ((25), (28b)); strict scansion of
+(27) realizes them, and the elsewhere *-Ø* is not overt. -/
+def suffixes (subj : Person × Bool) (obj : Option (Person × Bool)) : List String :=
+  (scansion agr3 ∅ (matrix subj.1 subj.2 .erg :: (obj.map fun o => [matrix o.1 o.2 .nom]).getD []))
+    |>.filter (· ≠ "Ø")
+
+/-- The rival template (18): object agreement then subject agreement, each a
+node of its own realized by the Subset Principle over (27). -/
+def templateSuffixes (subj obj : Person × Bool) : List String :=
+  ((subsetPrinciple agr3 (matrix obj.1 obj.2 .nom)).toList ++
+    (subsetPrinciple agr3 (matrix subj.1 subj.2 .erg)).toList).filter (· ≠ "Ø")
+
+/-! ### The data pool -/
+
+/-- A row of the pool: the arguments, the auxiliary suffix, the verbal
+prefix, the overt verbal suffixes, and the judgment. -/
+structure Row where
+  subj : Person × Bool
+  obj : Option (Person × Bool)
+  aux : String
+  prefix_ : String
+  suffixes : List String
+  accepted : Bool
+  deriving DecidableEq, Repr
+
+def Person.ofString : String → Option Person
+  | "1" => some .first | "2" => some .second | "3" => some .third | _ => none
+
+def Row.ofExample (ex : LinguisticExample) : Option Row := do
+  let fs := ex.paperFeatures
+  let sp ← fs.lookup "subjPerson" >>= Person.ofString
+  let sn ← fs.lookup "subjNumber"
+  let obj ← match fs.lookup "objPerson", fs.lookup "objNumber" with
+    | some p, some n => (Person.ofString p).map fun op => some (op, decide (n = "pl"))
+    | _, _ => some none
+  let aux ← fs.lookup "aux"
+  let prefix_ ← fs.lookup "prefix"
+  let s₁ ← fs.lookup "suffix1"
+  let s₂ ← fs.lookup "suffix2"
+  pure ⟨(sp, sn = "pl"), obj, aux, prefix_, [s₁, s₂].filter (· ≠ ""), ex.judgment = .acceptable⟩
+
+theorem row_ofExample_isSome : ∀ ex ∈ Examples.all, (Row.ofExample ex).isSome := by decide
+
+def rows : List Row := Examples.all.filterMap Row.ofExample
+
+/-- **Local Fission** ((19)–(24), (16)): a row is grammatical iff its overt
+verbal suffixes are what strict scansion of (27) inserts — *-éːʃ* before
+*-oʔob* in both (20) and (22), *-oʔob* once in (24). -/
+theorem suffixes_rows : ∀ r ∈ rows, r.accepted = (suffixes r.subj r.obj = r.suffixes) := by
+  decide
+
+/-- The template (18) predicts every starred form — *-oʔob-éːʃ* for (21),
+*-oʔob-oʔob* for (23). -/
+theorem template_predicts_starred :
+    ∀ r ∈ rows, ∀ o ∈ r.obj, r.accepted = false → templateSuffixes r.subj o = r.suffixes := by
+  decide
+
+/-- The template (18) fails a grammatical row — (22) and (24), whose orders
+it reverses or doubles — while fitting (19) and (20). -/
+theorem template_fails_grammatical :
+    ∃ r ∈ rows, r.accepted ∧ ∃ o ∈ r.obj, templateSuffixes r.subj o ≠ r.suffixes := by
+  decide
+
+/-- Agr1 (43) and Agr2 (44) recover the auxiliary suffix and verbal prefix of
+every row ((17), (39)). -/
+theorem aux_prefix_rows :
+    ∀ r ∈ rows, subsetPrinciple agr1 (ergMatrix r.subj.1 r.subj.2) = some r.aux ∧
+      subsetPrinciple agr2 (ergMatrix r.subj.1 r.subj.2) = some r.prefix_ := by
+  decide
+
+/-- A first-person ergative argument takes no verbal number suffix ((3)–(4)):
+its number is a person distinction, so no item of (27) matches beyond the
+elsewhere. -/
+theorem first_person_no_verbal_number (pl : Bool) :
+    suffixes (.first, pl) none = [] := by
+  cases pl <;> decide
+
+end GonzalezPootMcGinnis2006

--- a/Linglib/Studies/HalleMarantz1993.lean
+++ b/Linglib/Studies/HalleMarantz1993.lean
@@ -70,21 +70,17 @@ def agr (sg3 : Bool) : List Feature :=
 
 /-- Agr fuses with a `[−participle]` Tns node into one terminal bearing both
 bundles. -/
-def tnsAgrFusion : FusionRule (List Feature) Unit where
-  contextOk _ := True
-  decContext _ := inferInstanceAs (Decidable True)
-  bundlesOk p _ := .participle false ∈ p
-  decBundles _ _ := inferInstanceAs (Decidable (_ ∈ _))
-  fuse := (· ++ ·)
+def tnsAgrFusion : FusionRule Feature where
+  condition p _ := .participle false ∈ p
+  decCond _ _ := inferInstanceAs (Decidable (_ ∈ _))
 
 /-- The fused node of a finite form. -/
-def tnsAgr (v : Verb) (past sg3 : Bool) : List Feature :=
-  tnsAgrFusion.fuse (tns v past false) (agr sg3)
+def tnsAgr (v : Verb) (past sg3 : Bool) : List Feature := tns v past false ++ agr sg3
 
 /-- Agr is added only to `[−participle]` nodes: Fusion rejects a participial
 Tns. -/
 theorem agr_only_on_finite (v : Verb) (past sg3 : Bool) :
-    tnsAgrFusion.apply (tns v past true) (agr sg3) () = none := by
+    tnsAgrFusion.apply (tns v past true) (agr sg3) = none := by
   simp [FusionRule.apply, tnsAgrFusion, tns]
 
 /-! ### The Vocabulary (8) -/
@@ -201,12 +197,12 @@ theorem past_precedes_agreement :
 
 /-- Fusion of adjacent Tns and Agr, then insertion by the Subset Principle. -/
 def tnsAgrSpellout : Spellout (List Feature) String where
-  modules := [tnsAgrFusion.applyFirstAdjacent ()]
-  insert := subsetPrinciple vocabulary
+  modules := [tnsAgrFusion.applyFirstAdjacent]
+  insert n := (subsetPrinciple vocabulary n).toList
 
 /-- *play-s*: the domain `[Tns, Agr]` spells out as the single exponent
 `-z`. -/
-theorem plays_pf : tnsAgrSpellout.pf [tns .play false false, agr true] = [some "-z"] := by
+theorem plays_pf : tnsAgrSpellout.pf [tns .play false false, agr true] = [["-z"]] := by
   decide
 
 /-- Two terminals enter, one exponent slot leaves: the misalignment is

--- a/Linglib/Studies/MunozPerez2026.lean
+++ b/Linglib/Studies/MunozPerez2026.lean
@@ -1,5 +1,4 @@
 import Linglib.Features.Acceptability
-import Linglib.Morphology.DistributedMorphology.Fission
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Fragments.Spanish.PersonFeatures
 import Linglib.Fragments.Spanish.Predicates
@@ -16,8 +15,10 @@ A lens into the nature of anticausative SE" (*Glossa* 11(1)).
 ## Main declarations
 
 * `Judgment`, `CliticPattern`, `DativeCliticPerson` — empirical data types
-* `spanishFissionRule` — instantiation of the generic
-  `DistributedMorphology.FissionRule` with Chilean-Spanish-specific data
+* `ApplicativeFission`, `spanishFissionRule` — the paper's structural
+  Fission rule (55), study-local: the paper lists the two positions'
+  forms rather than a Vocabulary for the residue-driven
+  `DistributedMorphology.scansion`
 * `voice_semantically_vacuous` — re-export of
   `Minimalist.Voice.nonThematic_no_semantics`
 * `three_way_synonymy_from_vacuity`,
@@ -244,7 +245,6 @@ theorem negative_controls_unacceptable :
 /-! ### Spanish Fission instantiation -/
 
 open Minimalist Minimalist.Voice
-open DistributedMorphology
 open Spanish.PersonFeatures
 open Spanish.Predicates
 open Spanish.Clitics
@@ -260,15 +260,38 @@ structure FissionOutput where
   cl2Form : String
   deriving Repr, DecidableEq
 
-/-- The stylistic applicative Fission rule for Chilean Spanish
-    ([munoz-perez-2026] rule 55).
+/-- A structural Fission rule with listed outputs: under its context and
+    bundle conditions the clitic node splits into the two positions whose
+    forms `realize` gives. -/
+structure ApplicativeFission where
+  /-- The structural condition licensing Fission. -/
+  contextOk : List VerbHead → Prop
+  /-- Decidability witness for `contextOk`. -/
+  decContext : DecidablePred contextOk
+  /-- The condition on the fissioned bundle. -/
+  bundleOk : Category → Prop
+  /-- Decidability witness for `bundleOk`. -/
+  decBundle : DecidablePred bundleOk
+  /-- The two positions' forms. -/
+  realize : Category → FissionOutput
 
-    Instantiates the generic `DistributedMorphology.FissionRule` with
-    Spanish-specific data:
+instance (rule : ApplicativeFission) (c : List VerbHead) : Decidable (rule.contextOk c) :=
+  rule.decContext c
+
+instance (rule : ApplicativeFission) (p : Category) : Decidable (rule.bundleOk p) :=
+  rule.decBundle p
+
+/-- Apply the rule: the two positions when both conditions hold. -/
+def ApplicativeFission.apply (rule : ApplicativeFission) (p : Category) (c : List VerbHead) :
+    Option FissionOutput :=
+  if rule.contextOk c ∧ rule.bundleOk p then some (rule.realize p) else none
+
+/-- The stylistic applicative Fission rule for Chilean Spanish
+    ([munoz-perez-2026] rule 55):
     - Context: inchoative verbal-head sequence (vGO ⌒ vBE)
     - Bundle: [+PART, +SING] person (1SG or 2SG)
     - Realization: Cl₁ = me/te (from [±AUTHOR]), Cl₂ = le (invariable) -/
-def spanishFissionRule : FissionRule Category (List VerbHead) FissionOutput where
+def spanishFissionRule : ApplicativeFission where
   contextOk := fun heads => isInchoative heads = true
   decContext := fun heads => inferInstanceAs (Decidable (isInchoative heads = true))
   bundleOk := IsFissionApplicable

--- a/references.bib
+++ b/references.bib
@@ -28670,6 +28670,19 @@
   sources   = {Morphology/DistributedMorphology/Impoverishment.lean}
 }
 
+@incollection{gonzalez-poot-mcginnis-2006,
+  author    = {Gonz\'{a}lez Poot, Antonio and McGinnis, Martha},
+  year      = {2006},
+  title     = {Local versus long-distance {F}ission in {D}istributed {M}orphology},
+  booktitle = {Proceedings of the 2005 Annual Conference of the Canadian Linguistic Association},
+  editor    = {Gurski, Claire},
+  publisher = {Canadian Linguistic Association},
+  url       = {http://westernlinguistics.ca/Publications/CLA-ACL/GonzalezPoot_McGinnis.pdf},
+  subfield  = {morphology},
+  validated = {true},
+  role      = {formalized},
+  sources   = {Studies/GonzalezPootMcGinnis2006.lean;Morphology/DistributedMorphology/Fission.lean}
+}
 @incollection{halle-1997,
   author    = {Halle, Morris},
   year      = {1997},


### PR DESCRIPTION
Fission is now strict scansion with residue discharge (González-Poot & McGinnis 2006, after Halle 1997): the Vocabulary is scanned once, an item whose site one of the node's matrices contains is inserted and discharges its features from that matrix, and the residue stays available to the items below — so `scansion` is a subsequence of the Vocabulary and its first insertion at a single matrix is the Subset Principle's winner on a specificity-ordered list (`head?_scansion_singleton`). Fusion keeps only its licensing condition; the fused bundle is the two bundles together. `Spellout.insert` yields the exponents of a position.

- New `Studies/GonzalezPootMcGinnis2006.lean` + 13-row Yucatec pool: `suffixes_rows` (grammatical iff scansion's output), the template (18) predicting the starred (21)/(23) and failing (22)/(24), Agr1/Agr2 (43)/(44), no first-person verbal number.
- Muñoz Pérez's listed-output Fission becomes study-local `ApplicativeFission` (the paper gives outputs, not a Vocabulary); `VocabularyItem.spec` renamed `site`; substrate module docstrings move citations to `## References`.