### PR TITLE
chore(Morphology/DistributedMorphology): NominalSpine → NominalProjection

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1261,7 +1261,7 @@ import Linglib.Morphology.DistributedMorphology.Impoverishment
 import Linglib.Morphology.DistributedMorphology.Locality
 import Linglib.Morphology.DistributedMorphology.Merger
 import Linglib.Morphology.DistributedMorphology.Neighborhood
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Morphology.DistributedMorphology.Root
 import Linglib.Morphology.DistributedMorphology.Spellout
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic

--- a/Linglib/Fragments/Greek/StandardModern/Possession.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Possession.lean
@@ -27,7 +27,7 @@ the possessor (per [kampanarou-alexiadou-2026] §7, citing
 of the possessee NP, alienable possessors in the specifier of a dedicated
 PossP). The structural distinction is not visible in these
 typological-surface values; it lives in
-`Morphology/DistributedMorphology/NominalSpine.lean::PossessionType`.
+`Morphology/DistributedMorphology/NominalProjection.lean::PossessionType`.
 
 The `apo`-PP variant of the genitive (e.g., *to vivlio apo ton ðimarxo*
 'the book of the mayor') is a partitive-coerced alternative to inflectional

--- a/Linglib/Fragments/Italian/NumberGender.lean
+++ b/Linglib/Fragments/Italian/NumberGender.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Fragments.Italian.Nouns
 
 /-!
@@ -46,7 +46,7 @@ def PluralClass.toNumberPosition : PluralClass → NumberPosition
 /-- Can this plural class's number feature interact with gender?
     Derived from the number position via the GLH — not stipulated. -/
 def PluralClass.canAffectGender (pc : PluralClass) : Bool :=
-  genderLocalityHypothesis pc.toNumberPosition.toNominalPosition
+  genderLocalityHypothesis pc.toNumberPosition.toPosition
 
 -- ============================================================================
 -- § 2: Number–Gender Nouns
@@ -157,11 +157,11 @@ theorem casa_pl_fem : casaNG.plGender = .feminine := rfl
 -- ============================================================================
 
 /-- The GLH pipeline for number–gender interaction:
-    PluralClass → NumberPosition → NominalPosition → GLH evaluation.
+    PluralClass → NumberPosition → NominalProjection.Position → GLH evaluation.
     Each stage feeds the next. -/
 def numberGenderPipeline (pc : PluralClass) : Bool :=
   let numPos := pc.toNumberPosition
-  let nomPos := numPos.toNominalPosition
+  let nomPos := numPos.toPosition
   genderLocalityHypothesis nomPos
 
 -- -a plurals: low number → within nP → CAN affect gender

--- a/Linglib/Fragments/Jarawara/PossessedNouns.lean
+++ b/Linglib/Fragments/Jarawara/PossessedNouns.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Features.Possession
 import Linglib.Data.UD.Basic
 import Linglib.Features.Number.Capabilities

--- a/Linglib/Fragments/Teop/Nouns.lean
+++ b/Linglib/Fragments/Teop/Nouns.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Gender.Basic
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 
 /-!

--- a/Linglib/Morphology/DistributedMorphology/NominalProjection.lean
+++ b/Linglib/Morphology/DistributedMorphology/NominalProjection.lean
@@ -2,11 +2,11 @@ import Mathlib.Order.WithBot
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# The nominal spine
+# The extended nominal projection
 
-The extended nominal projection as a spine order — √ROOT < n < Poss <
-Num < D — with the positions of the nominal domain classified by where
-they attach. Locality to n is then geometry: a position is within nP
+The extended nominal projection — the nominal spine √ROOT < n < Poss <
+Num < D — as an order of heads, with the positions of the nominal domain
+classified by where they attach. Locality to n is then geometry: a position is within nP
 exactly when its attachment site is at or below n, which is what
 [adamson-2024]'s Gender Locality Hypothesis (gender features on n are
 valued only within nP) quantifies over. The inalienable/alienable
@@ -16,10 +16,10 @@ number likewise ([adamson-2024]).
 
 ## Main definitions
 
-* `SpineHead` — the heads of the extended nominal projection, linearly
-  ordered by height
-* `NominalPosition`, `NominalPosition.attachmentSite`, `isWithinNP` —
-  the positions of the nominal domain and their spine geometry
+* `NominalProjection.Head` — the heads of the extended nominal projection,
+  linearly ordered by height
+* `NominalProjection.Position`, `Position.attachmentSite`, `isWithinNP` —
+  the positions of the nominal domain and their place on the projection
 * `PossessionType`, `NumberPosition` — the possession and number
   contrasts as attachment contrasts
 * `ExternalFeature` — features attached above nP, clausal ones outside
@@ -54,12 +54,14 @@ which this substrate does not represent.
 
 namespace DistributedMorphology
 
-/-! ### The nominal spine -/
+namespace NominalProjection
 
-/-- The heads of the extended nominal projection, in spine order:
+/-! ### The heads -/
+
+/-- The heads of the extended nominal projection, in order of height:
 √ROOT < n < Poss < Num < D ([adamson-2024]; the Poss layer after
 [alexiadou-2003], [myler-2016]). -/
-inductive SpineHead where
+inductive Head where
   | root
   | n
   | poss
@@ -67,16 +69,16 @@ inductive SpineHead where
   | d
   deriving DecidableEq, Repr, Fintype
 
-/-- The height of a head on the spine. -/
-def SpineHead.height : SpineHead → Nat
+/-- The height of a head on the projection. -/
+def Head.height : Head → Nat
   | .root => 0
   | .n    => 1
   | .poss => 2
   | .num  => 3
   | .d    => 4
 
-instance : LinearOrder SpineHead :=
-  LinearOrder.lift' SpineHead.height (by decide)
+instance : LinearOrder Head :=
+  LinearOrder.lift' Head.height (by decide)
 
 /-! ### Positions and their attachment sites -/
 
@@ -84,8 +86,8 @@ instance : LinearOrder SpineHead :=
 
     [DP D [NumP Num [PossP DP Poss [nP DP [n √ROOT n]]]]]
 
-heads of the spine together with the two possessor specifiers. -/
-inductive NominalPosition where
+heads of the projection together with the two possessor specifiers. -/
+inductive Position where
   | root         -- √ROOT: the acategorial root itself
   | nHead        -- n: the categorizing head bearing gender features
   | specN        -- Spec,nP: inalienable possessor position
@@ -95,9 +97,9 @@ inductive NominalPosition where
   | d            -- D head: definiteness
   deriving DecidableEq, Repr, Fintype
 
-/-- Where each position attaches on the spine: a specifier attaches at
-its head's projection. -/
-def NominalPosition.attachmentSite : NominalPosition → SpineHead
+/-- Where each position attaches: a specifier attaches at its head's
+projection. -/
+def Position.attachmentSite : Position → Head
   | .root     => .root
   | .nHead    => .n
   | .specN    => .n
@@ -106,14 +108,18 @@ def NominalPosition.attachmentSite : NominalPosition → SpineHead
   | .num      => .num
   | .d        => .d
 
-/-- Within-nP is spine geometry: the position attaches at or below n. -/
-def NominalPosition.isWithinNP (p : NominalPosition) : Bool :=
-  decide (p.attachmentSite ≤ SpineHead.n)
+/-- Within-nP is geometry: the position attaches at or below n. -/
+def Position.isWithinNP (p : Position) : Bool :=
+  decide (p.attachmentSite ≤ Head.n)
+
+end NominalProjection
+
+open NominalProjection
 
 /-- The Gender Locality Hypothesis ([adamson-2024]): gender features on
 n are valued only within nP, so a position can condition gender exactly
 when its attachment site is at or below n. -/
-def genderLocalityHypothesis (pos : NominalPosition) : Bool :=
+def genderLocalityHypothesis (pos : Position) : Bool :=
   pos.isWithinNP
 
 /-! ### Possession -/
@@ -131,7 +137,7 @@ inductive PossessionType where
   deriving DecidableEq, Repr, Fintype
 
 /-- The possessor's position. -/
-def PossessionType.possessorPosition : PossessionType → NominalPosition
+def PossessionType.possessorPosition : PossessionType → Position
   | .inalienable => .specN
   | .alienable   => .specPoss
 
@@ -152,7 +158,7 @@ inductive NumberPosition where
   deriving DecidableEq, Repr, Fintype
 
 /-- The position a number feature occupies. -/
-def NumberPosition.toNominalPosition : NumberPosition → NominalPosition
+def NumberPosition.toPosition : NumberPosition → Position
   | .onN   => .nHead
   | .onNum => .num
 
@@ -170,8 +176,8 @@ inductive ExternalFeature where
   deriving DecidableEq, Repr, Fintype
 
 /-- Where an external feature attaches: case and definiteness at D,
-the clausal features outside the nominal spine altogether. -/
-def ExternalFeature.attachmentSite : ExternalFeature → WithTop SpineHead
+the clausal features outside the nominal projection altogether. -/
+def ExternalFeature.attachmentSite : ExternalFeature → WithTop Head
   | .case         => some .d
   | .definiteness => some .d
   | .tense        => ⊤
@@ -180,7 +186,7 @@ def ExternalFeature.attachmentSite : ExternalFeature → WithTop SpineHead
 
 /-- No external feature attaches within nP. -/
 theorem ExternalFeature.not_withinNP (f : ExternalFeature) :
-    ¬ f.attachmentSite ≤ (SpineHead.n : WithTop SpineHead) := by
+    ¬ f.attachmentSite ≤ (Head.n : WithTop Head) := by
   cases f <;> decide
 
 /-! ### Possession–gender mechanisms -/
@@ -199,7 +205,7 @@ inductive PossessionGenderMechanism where
 
 /-- Both mechanisms involve an iPossessor in Spec,nP. -/
 def PossessionGenderMechanism.possessorPosition :
-    PossessionGenderMechanism → NominalPosition
+    PossessionGenderMechanism → Position
   | .possesseeGender => .specN
   | .inheritedGender => .specN
 

--- a/Linglib/Studies/Adamson2024.lean
+++ b/Linglib/Studies/Adamson2024.lean
@@ -1,4 +1,4 @@
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Morphology.DistributedMorphology.Categorizer.Gender
 import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
 import Linglib.Morphology.DistributedMorphology.Impoverishment

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -1,5 +1,5 @@
 import Linglib.Fragments.Mayan.Tseltalan
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Syntax.Minimalist.Agree.Basic
 import Linglib.Syntax.Minimalist.Probe.Profile
 import Linglib.Syntax.Binding.SpecificityCondition
@@ -84,7 +84,7 @@ alongside Tz'utujil, Chickasaw, Sinitic double-unaccusative).
 
 ## Integration Points
 
-- `NominalPosition` / `PossessionType` from `NominalSpine.lean`
+- `NominalProjection.Position` / `PossessionType` from `NominalProjection.lean`
 - `SpecificityCondition` from `Core/SpecificityCondition.lean`
 - `JudgmentType` — [kuroda-1972]'s categorical/thetic distinction, defined in §9
 - `GramFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
@@ -111,7 +111,7 @@ open DistributedMorphology
     definites project to DP; non-specific indefinites project only to
     nP (if non-possessive) or PossP (if possessive).
 
-    Derived from the nominal spine in `NominalSpine.lean`:
+    Derived from the nominal spine in `NominalProjection.lean`:
     √ROOT < n < (Poss) < D. -/
 inductive NominalSize where
   | dp    -- projects to D: specific nominals
@@ -124,7 +124,7 @@ inductive NominalSize where
     from external D-probes). For non-specific nominals, the highest
     position IS the possessor's specifier position, making the
     possessor directly accessible. -/
-def NominalSize.highestProjection : NominalSize → NominalPosition
+def NominalSize.highestProjection : NominalSize → NominalProjection.Position
   | .dp    => .d       -- D head shields possessor
   | .possP => .specPoss -- possessor directly accessible
   | .nP    => .specN    -- possessor directly accessible
@@ -377,7 +377,7 @@ theorem extracted_always_external : ¬ CanĀSubextract :=
 -- § 7: Bridge to the nominal spine
 -- ============================================================================
 
-/-- Map nominal size to possession type from `NominalSpine.lean`.
+/-- Map nominal size to possession type from `NominalProjection.lean`.
 
     - nP-internal possessors (Spec,nP) → inalienable
     - PossP-level possessors (Spec,PossP) → alienable
@@ -395,7 +395,7 @@ theorem alienable_at_possP :
 
 /-- For non-specific nominals, the highest projection IS the possessor's
     position, agreeing with PossessionType.possessorPosition from
-    NominalSpine.lean. For DPs, the highest projection is D (the
+    NominalProjection.lean. For DPs, the highest projection is D (the
     possessor is shielded below). -/
 theorem highest_agrees_inalienable :
     NominalSize.nP.highestProjection =

--- a/Linglib/Studies/KampanarouAlexiadou2026.lean
+++ b/Linglib/Studies/KampanarouAlexiadou2026.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Possession
-import Linglib.Morphology.DistributedMorphology.NominalSpine
+import Linglib.Morphology.DistributedMorphology.NominalProjection
 import Linglib.Morphology.DistributedMorphology.Allosemy
 import Linglib.Syntax.Minimalist.Verbal.SmallClause
 import Linglib.Syntax.Minimalist.Verbal.Applicative
@@ -61,7 +61,8 @@ set_option autoImplicit false
 namespace KampanarouAlexiadou2026
 
 open Possession (Notion InalienabilityRank)
-open DistributedMorphology (PossessionType NominalPosition)
+open DistributedMorphology (PossessionType)
+open DistributedMorphology.NominalProjection (Position)
 open DistributedMorphology.Allosemy (NominalizationReading)
 open Minimalist (SmallClause SCPredCategory ApplType)
 


### PR DESCRIPTION
Rename the extended-nominal-projection template so it no longer collides with the word-level `Spine` of `Locality.lean`: `SpineHead` → `NominalProjection.Head`, `NominalPosition` → `NominalProjection.Position`, `NumberPosition.toNominalPosition` → `toPosition`, module `NominalSpine` → `NominalProjection`; seven consumers repointed, no content change.