### PR TITLE
feat(Studies/Arad2005): binyanim as the spell-out of v and Voice

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2949,3 +2949,4 @@ import Linglib.Data.Examples.Embick2021
 import Linglib.Data.Examples.Embick2010
 import Linglib.Data.Examples.HarleyRitter2002
 import Linglib.Data.Examples.McGinnis2013
+import Linglib.Data.Examples.Arad2005

--- a/Linglib/Data/Examples/Arad2005.json
+++ b/Linglib/Data/Examples/Arad2005.json
@@ -1,0 +1,156 @@
+[
+  {
+    "id": "arad2005_p1",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "lamad",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["lamad", "learn"]
+    ],
+    "translation": "learn",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "lmd"],
+      ["pattern", "1"],
+      ["binyan", "cvcvc"],
+      ["voice", "active"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "arad2005_p2",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "nilmad",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["nilmad", "learn (passive)"]
+    ],
+    "translation": "learn",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "lmd"],
+      ["pattern", "2"],
+      ["binyan", "nvccvc"],
+      ["voice", "active"]
+    ],
+    "comment": "Binyan 2 is the passive of binyan 1 by rewriting of the binyan (footnote 13); its own vowels are the [+active] exponent in the context nVCCVC of (25)."
+  },
+  {
+    "id": "arad2005_p3",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "siper",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["siper", "tell"]
+    ],
+    "translation": "tell",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "spr"],
+      ["pattern", "3"],
+      ["binyan", "cvccvc"],
+      ["voice", "active"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "arad2005_p4",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "supar",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["supar", "tell (passive)"]
+    ],
+    "translation": "tell",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "spr"],
+      ["pattern", "4"],
+      ["binyan", "cvccvc"],
+      ["voice", "passive"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "arad2005_p5",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "hiqlit",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["hiqlit", "record"]
+    ],
+    "translation": "record",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "qlt"],
+      ["pattern", "5"],
+      ["binyan", "hvccvc"],
+      ["voice", "active"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "arad2005_p6",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "huqlat",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["huqlat", "record (passive)"]
+    ],
+    "translation": "record",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "qlt"],
+      ["pattern", "6"],
+      ["binyan", "hvccvc"],
+      ["voice", "passive"]
+    ],
+    "comment": ""
+  },
+  {
+    "id": "arad2005_p7",
+    "source": {"bibkey": "arad-2005", "paperLabel": "(3)"},
+    "language": "hebr1245",
+    "primaryText": "hitpalel",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["hitpalel", "pray"]
+    ],
+    "translation": "pray",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["root", "pll"],
+      ["pattern", "7"],
+      ["binyan", "hitcvccvc"],
+      ["voice", "active"]
+    ],
+    "comment": ""
+  }
+]

--- a/Linglib/Data/Examples/Arad2005.lean
+++ b/Linglib/Data/Examples/Arad2005.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `Arad2005` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/Arad2005.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace Arad2005.Examples`.
+-/
+
+namespace Arad2005.Examples
+
+open Data.Examples
+
+def p1 : LinguisticExample :=
+  { id := "arad2005_p1"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "lamad"
+    discourseSegments := []
+    glossedTokens := [("lamad", "learn")]
+    translation := "learn"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "lmd"), ("pattern", "1"), ("binyan", "cvcvc"), ("voice", "active")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p2 : LinguisticExample :=
+  { id := "arad2005_p2"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "nilmad"
+    discourseSegments := []
+    glossedTokens := [("nilmad", "learn (passive)")]
+    translation := "learn"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "lmd"), ("pattern", "2"), ("binyan", "nvccvc"), ("voice", "active")]
+    comment := "Binyan 2 is the passive of binyan 1 by rewriting of the binyan (footnote 13); its own vowels are the [+active] exponent in the context nVCCVC of (25)."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p3 : LinguisticExample :=
+  { id := "arad2005_p3"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "siper"
+    discourseSegments := []
+    glossedTokens := [("siper", "tell")]
+    translation := "tell"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "spr"), ("pattern", "3"), ("binyan", "cvccvc"), ("voice", "active")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p4 : LinguisticExample :=
+  { id := "arad2005_p4"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "supar"
+    discourseSegments := []
+    glossedTokens := [("supar", "tell (passive)")]
+    translation := "tell"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "spr"), ("pattern", "4"), ("binyan", "cvccvc"), ("voice", "passive")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p5 : LinguisticExample :=
+  { id := "arad2005_p5"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "hiqlit"
+    discourseSegments := []
+    glossedTokens := [("hiqlit", "record")]
+    translation := "record"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "qlt"), ("pattern", "5"), ("binyan", "hvccvc"), ("voice", "active")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p6 : LinguisticExample :=
+  { id := "arad2005_p6"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "huqlat"
+    discourseSegments := []
+    glossedTokens := [("huqlat", "record (passive)")]
+    translation := "record"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "qlt"), ("pattern", "6"), ("binyan", "hvccvc"), ("voice", "passive")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def p7 : LinguisticExample :=
+  { id := "arad2005_p7"
+    source := ⟨"arad-2005", "(3)"⟩
+    reportedIn := none
+    language := "hebr1245"
+    primaryText := "hitpalel"
+    discourseSegments := []
+    glossedTokens := [("hitpalel", "pray")]
+    translation := "pray"
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("root", "pll"), ("pattern", "7"), ("binyan", "hitcvccvc"), ("voice", "active")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [p1, p2, p3, p4, p5, p6, p7]
+
+end Arad2005.Examples

--- a/Linglib/Fragments/Hebrew/ConsonantalRoots.lean
+++ b/Linglib/Fragments/Hebrew/ConsonantalRoots.lean
@@ -87,4 +87,21 @@ theorem klt_final_is_t : klt.finalSegment = some "t" := rfl
     spreading the final /l/ to template-final is legitimate. -/
 theorem kll_final_is_l : kll.finalSegment = some "l" := rfl
 
+-- ============================================================================
+-- § 3: The binyan roots of [arad-2005] (3)
+-- ============================================================================
+
+/-- √lmd — *lamad* 'learn' (P1), *nilmad* 'learn (passive)' (P2) ([arad-2005] (3)). -/
+def lmd : ConsonantalRoot String := ⟨["l", "m", "d"]⟩
+
+/-- √spr — *siper* 'tell' (P3), *supar* 'tell (passive)' (P4) ([arad-2005] (3)). -/
+def spr : ConsonantalRoot String := ⟨["s", "p", "r"]⟩
+
+/-- √qlt — *hiqlit* 'record' (P5), *huqlat* 'record (passive)' (P6)
+([arad-2005] (3)). -/
+def qlt : ConsonantalRoot String := ⟨["q", "l", "t"]⟩
+
+/-- √pll — *hitpalel* 'pray' (P7) ([arad-2005] (3)). -/
+def pll : ConsonantalRoot String := ⟨["p", "l", "l"]⟩
+
 end Hebrew

--- a/Linglib/Studies/Arad2005.lean
+++ b/Linglib/Studies/Arad2005.lean
@@ -1,10 +1,26 @@
 import Linglib.Morphology.Realization
+import Linglib.Morphology.Morphotactics.CVTemplate
+import Linglib.Morphology.DistributedMorphology.VocabularyInsertion.Basic
+import Linglib.Fragments.Hebrew.ConsonantalRoots
+import Linglib.Data.Examples.Arad2005
+import Mathlib.Data.List.Destutter
 import Mathlib.Tactic.DeriveFintype
 
 /-!
-# Arad 2005: root-derived vs word-derived, and the locality of root
-interpretation
+# Arad 2005: binyanim as the spell-out of v and Voice, and the locality of
+root interpretation
 [arad-2005]
+
+The seven verbal patterns are five CV templates with vowel slots but no
+vowels (her (24b)) — CVCVC, nVCCVC, CVCCVC, hVCCVC, hitCVCCVC — inserted
+under v and associated with the root by the book's subscripts
+(C₁iC₂C₂eC₃, her (3)); the vowels are the exponent of Voice, a
+morphosyntactic feature that must be spelled out, by the rule (25) whose
+context is the binyan v received — contextual allomorphy on the exponent of
+the next head in. Nominal patterns carry their vowels (her (24a)), which is
+her noun–verb asymmetry: a verb needs the template for Voice to have slots
+to fill. §2.5 is formalized below as `Binyan`, `voiceSpellout`, and
+`verb`, reproducing the seven forms of (3).
 
 The √sgr family (her (5) in Ch. 7): one root, six listed formations across
 verbal and nominal patterns — *sagar* 'close', *hisgir* 'extradite',
@@ -31,6 +47,12 @@ interpretation is carried along thereafter.
 
 ## Main results
 
+* `table3_derived` — the forms of (3) from v's binyan and Voice's vowels by
+  (25).
+* `voice_obligatory`, `active_many_to_one` — every binyan has an active
+  vocalism, the passive ones only CVCCVC and hVCCVC; one feature, five
+  exponents.
+* `binyanim_vowel_slots`, `mishqalim_no_vowel_slots` — the asymmetry (24).
 * `sgr_mcm`, `qlt_mcm` — Multiple Contextualized Meaning as root allosemy.
 * `no_strict_merger` — no two sgr-lexemes strict-merge into any target.
 * `direct_lax_merger` — the root-derived lexemes lax-merge into the root.
@@ -42,7 +64,161 @@ interpretation is carried along thereafter.
 
 namespace Arad2005
 
-open Morphology Morphology.Realization
+open Morphology Morphology.Realization DistributedMorphology Data.Examples
+
+/-! ### Binyanim as the spell-out of v and Voice (§2.5) -/
+
+/-- A position of a pattern skeleton in the book's subscripted notation: a
+root radical by index, an open vowel slot, or a fixed segment. -/
+inductive Skel where
+  | radical (i : ℕ)
+  | vowel
+  | fixed (s : String) (slot : CVSlot)
+  deriving DecidableEq, Repr
+
+/-- A fixed vowel of a pattern. -/
+def Skel.isFixedVowel : Skel → Bool
+  | .fixed _ .V => true
+  | _ => false
+
+/-- The template slot a skeleton position occupies. -/
+def Skel.slot : Skel → CVSlot
+  | .radical _ => .C
+  | .vowel => .V
+  | .fixed _ c => c
+
+/-- The five binyan templates ((24b)): vowel slots without vowels, the
+prefixes *n-*, *h-*, *hit-*, and in CVCCVC the geminate slot of the middle
+radical. -/
+inductive Binyan where
+  | cvcvc
+  | nvccvc
+  | cvccvc
+  | hvccvc
+  | hitcvccvc
+  deriving DecidableEq, Repr, Fintype
+
+/-- The skeletons of (3) and (24b). -/
+def Binyan.skeleton : Binyan → List Skel
+  | .cvcvc => [.radical 0, .vowel, .radical 1, .vowel, .radical 2]
+  | .nvccvc => [.fixed "n" .C, .vowel, .radical 0, .radical 1, .vowel, .radical 2]
+  | .cvccvc => [.radical 0, .vowel, .radical 1, .radical 1, .vowel, .radical 2]
+  | .hvccvc => [.fixed "h" .C, .vowel, .radical 0, .radical 1, .vowel, .radical 2]
+  | .hitcvccvc =>
+    [.fixed "h" .C, .fixed "i" .V, .fixed "t" .C, .radical 0, .vowel, .radical 1, .radical 1,
+      .vowel, .radical 2]
+
+/-- Nominal patterns carry their vowels ((24a)). -/
+def mishqalim : List (List Skel) :=
+  [[.fixed "m" .C, .fixed "i" .V, .radical 0, .radical 1, .fixed "a" .V, .radical 2],
+    [.fixed "m" .C, .fixed "i" .V, .radical 0, .radical 1, .fixed "o" .V, .radical 2],
+    [.fixed "m" .C, .fixed "a" .V, .radical 0, .radical 1, .fixed "e" .V, .radical 2],
+    [.fixed "t" .C, .fixed "a" .V, .radical 0, .radical 1, .fixed "i" .V, .radical 2],
+    [.radical 0, .radical 1, .fixed "a" .V, .radical 2],
+    [.radical 0, .fixed "a" .V, .radical 1, .fixed "i" .V, .radical 2]]
+
+/-- The association lines a skeleton dictates: radicals and fixed segments at
+their positions, vowels left to right into the vowel slots. -/
+def Skel.associations : List Skel → ℕ → ℕ → ℕ → List Association
+  | [], _, _, _ => []
+  | .radical k :: rest, i, nv, nf => ⟨.root, k, i⟩ :: associations rest (i + 1) nv nf
+  | .vowel :: rest, i, nv, nf => ⟨.vocalism, nv, i⟩ :: associations rest (i + 1) (nv + 1) nf
+  | .fixed _ _ :: rest, i, nv, nf => ⟨.affix, nf, i⟩ :: associations rest (i + 1) nv (nf + 1)
+
+/-- Fill a skeleton with a root and a vocalism: association by the subscripts. -/
+def fill (sk : List Skel) (r : ConsonantalRoot String) (voc : List String) :
+    TemplateMatch String where
+  root := r
+  vocalism := voc
+  affix := sk.filterMap fun | .fixed s _ => some s | _ => none
+  template := ⟨sk.map Skel.slot⟩
+  associations := Skel.associations sk 0 0 0
+
+/-- The features of Voice and of the v exponent it sees. -/
+inductive VoiceFeature where
+  | active
+  | passive
+  | binyan (b : Binyan)
+  deriving DecidableEq, Repr
+
+/-- The Voice spell-out (25): a vocalism in the context of the binyan inserted
+under v. -/
+def voiceSpellout : List (VocabularyItem VoiceFeature (List String)) :=
+  [⟨⟨[.active], [[.binyan .cvcvc]], []⟩, ["a", "a"]⟩,
+    ⟨⟨[.active], [[.binyan .nvccvc]], []⟩, ["i", "a"]⟩,
+    ⟨⟨[.active], [[.binyan .cvccvc]], []⟩, ["i", "e"]⟩,
+    ⟨⟨[.active], [[.binyan .hvccvc]], []⟩, ["i", "i"]⟩,
+    ⟨⟨[.active], [[.binyan .hitcvccvc]], []⟩, ["a", "e"]⟩,
+    ⟨⟨[.passive], [[.binyan .cvccvc]], []⟩, ["u", "a"]⟩,
+    ⟨⟨[.passive], [[.binyan .hvccvc]], []⟩, ["u", "a"]⟩]
+
+/-- The Voice node once v has been realized: its feature, with the binyan as
+the inner neighbor. -/
+def voiceNode (b : Binyan) (active : Bool) : Neighborhood (List VoiceFeature) :=
+  ⟨[if active then .active else .passive], [[.binyan b]], []⟩
+
+/-- The surface string, with Modern Hebrew degemination. -/
+def surface (m : TemplateMatch String) : String := String.join (m.spellout.destutter (· ≠ ·))
+
+/-- A verb: the binyan under v, Voice's vowels by (25) in its context, the
+root associated by the skeleton. `none` where Voice has no exponent. -/
+def verb (r : ConsonantalRoot String) (b : Binyan) (active : Bool) : Option String :=
+  (subsetPrinciple voiceSpellout (voiceNode b active)).map fun voc =>
+    surface (fill b.skeleton r voc)
+
+def Binyan.ofLabel : String → Option Binyan
+  | "cvcvc" => some .cvcvc
+  | "nvccvc" => some .nvccvc
+  | "cvccvc" => some .cvccvc
+  | "hvccvc" => some .hvccvc
+  | "hitcvccvc" => some .hitcvccvc
+  | _ => none
+
+def rootOfLabel : String → Option (ConsonantalRoot String)
+  | "lmd" => some Hebrew.lmd
+  | "spr" => some Hebrew.spr
+  | "qlt" => some Hebrew.qlt
+  | "pll" => some Hebrew.pll
+  | _ => none
+
+/-- The seven forms of (3): root, binyan, Voice value, and form. -/
+def table3 : List (ConsonantalRoot String × Binyan × Bool × String) :=
+  Examples.all.filterMap fun ex => do
+    let r ← ex.feature? "root" >>= rootOfLabel
+    let b ← ex.feature? "binyan" >>= Binyan.ofLabel
+    let v ← ex.feature? "voice"
+    pure (r, b, v = "active", ex.primaryText)
+
+theorem table3_length : table3.length = 7 := by decide
+
+/-- The forms of (3) are derived: the binyan under v, Voice's vowels in the
+binyan's context, degemination at the surface. -/
+theorem table3_derived : ∀ t ∈ table3, verb t.1 t.2.1 t.2.2.1 = some t.2.2.2 := by decide
+
+/-- Voice must be spelled out ((22a)): every binyan has an active vocalism,
+and a passive one exactly in CVCCVC and hVCCVC. -/
+theorem voice_obligatory :
+    (∀ b : Binyan, (subsetPrinciple voiceSpellout (voiceNode b true)).isSome) ∧
+      ∀ b : Binyan, (subsetPrinciple voiceSpellout (voiceNode b false)).isSome ↔
+        (b = .cvccvc ∨ b = .hvccvc) := by
+  decide
+
+/-- One feature, five exponents: [+active] is realized five ways, the choice
+fixed by the binyan ((25)). -/
+theorem active_many_to_one :
+    ((voiceSpellout.filter (·.site.focus = [.active])).map (·.exponent)).Nodup ∧
+      (voiceSpellout.filter (·.site.focus = [.active])).length = 5 := by
+  decide
+
+/-- Every binyan has two vowel slots and no vowels of its own; the prefix of
+hitCVCCVC is its only fixed vowel ((24b)). -/
+theorem binyanim_vowel_slots :
+    ∀ b : Binyan, b.skeleton.count .vowel = 2 ∧
+      ∀ p ∈ b.skeleton, p.isFixedVowel → b = .hitcvccvc := by
+  decide
+
+/-- Nominal patterns have no vowel slots: their vowels are their own ((24a)). -/
+theorem mishqalim_no_vowel_slots : ∀ p ∈ mishqalim, p.count .vowel = 0 := by decide
 
 /-! ### The √sgr family -/
 


### PR DESCRIPTION
Root-and-pattern morphology wired into the Vocabulary engine on Arad 2005 §2.5: the five binyan templates are skeletons with vowel slots and no vowels ((24b)), filled with the root by the book's subscripts into a `TemplateMatch`; Voice's vowels are ordinary `VocabularyItem`s whose exponent is a vocalism and whose context is the binyan v received — the spell-out rule (25) as contextual allomorphy on the inner head's exponent; Modern Hebrew degemination by `List.destutter`. `table3_derived` reproduces the seven forms of (3) from a 7-row pool; `voice_obligatory`, `active_many_to_one`, and the vowel-slot theorems state the noun–verb asymmetry (24). Four roots added to the Hebrew Fragment.