### PR TITLE
refactor(Semantics/Conditionals): move SimilarityOrdering out of Core

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -258,7 +258,6 @@ import Linglib.Core.Order.Relation
 import Linglib.Core.Order.Satisfaction
 import Linglib.Core.Order.SetPreimage
 import Linglib.Core.Order.SignVectors
-import Linglib.Core.Order.SimilarityOrdering
 import Linglib.Core.Order.StrictBounds
 import Linglib.Core.Order.SuccPred.Tree
 import Linglib.Core.Order.TotalPreorder
@@ -1565,6 +1564,7 @@ import Linglib.Semantics.Conditionals.Presupposition
 import Linglib.Semantics.Conditionals.Probabilistic
 import Linglib.Semantics.Conditionals.Restrictor
 import Linglib.Semantics.Conditionals.SelectionFunction
+import Linglib.Semantics.Conditionals.SimilarityOrdering
 import Linglib.Semantics.Conditionals.Stalnaker
 import Linglib.Semantics.Conditionals.Sweetser
 import Linglib.Semantics.Conditionals.WillConditional

--- a/Linglib/Semantics/Attitudes/Desire/Conditional.lean
+++ b/Linglib/Semantics/Attitudes/Desire/Conditional.lean
@@ -1,4 +1,4 @@
-import Linglib.Core.Order.SimilarityOrdering
+import Linglib.Semantics.Conditionals.SimilarityOrdering
 import Mathlib.Data.Set.Finite.Basic
 
 /-!
@@ -22,7 +22,7 @@ desirability relation cannot make both `p` and `¬p` wanted (`Want.not_compl`).
 
 namespace Desire.Conditional
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 
 variable {W : Type*}
 

--- a/Linglib/Semantics/Causation/PsychLink.lean
+++ b/Linglib/Semantics/Causation/PsychLink.lean
@@ -37,7 +37,7 @@ The fourth uses `universalCounterfactual` from `Counterfactual.lean`.
 namespace Causation.PsychLink
 
 open Causation.Psych (CausalSource)
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
 /-! ### PsychCausalLink -/

--- a/Linglib/Semantics/Conditionals/Basic.lean
+++ b/Linglib/Semantics/Conditionals/Basic.lean
@@ -1,5 +1,5 @@
 import Mathlib.Data.Set.Basic
-import Linglib.Core.Order.SimilarityOrdering
+import Linglib.Semantics.Conditionals.SimilarityOrdering
 
 /-!
 # Conditional operators
@@ -46,7 +46,7 @@ bridges to `strictImp` via `conditionalNecessity_iff_mem_strictImp`.
 
 namespace Semantics.Conditionals
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 
 variable {I W : Type*} {access : I → Set W} {p p' q q' : Set W} {i : I} {w : W}
 
@@ -125,7 +125,7 @@ theorem strict_implies_material {R : W → Set W} (h_refl : w ∈ R w)
 vacuously true if the domain has no antecedent worlds; otherwise true iff
 some antecedent world settles the consequent throughout all antecedent
 worlds at least as close. (`SimilarityOrdering` and its constructors live in
-`Core.Order.SimilarityOrdering`.) -/
+`Semantics.Conditionals.SimilarityOrdering`.) -/
 def variablyStrictImp (sim : SimilarityOrdering W) (allWorlds p q : Set W) :
     Set W :=
   {w | allWorlds ∩ p = ∅ ∨

--- a/Linglib/Semantics/Conditionals/Counterfactual.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual.lean
@@ -46,7 +46,7 @@ open Semantics.Conditionals
 open Trivalent (ProjectionType dist)
 
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 
 
 /-!

--- a/Linglib/Semantics/Conditionals/Presupposition.lean
+++ b/Linglib/Semantics/Conditionals/Presupposition.lean
@@ -43,7 +43,7 @@ in `Counterfactual.closestWorlds`.
 namespace Semantics.Conditionals.Presupposition
 
 open Semantics.Conditionals
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Presupposition
 
 variable {W : Type*}

--- a/Linglib/Semantics/Conditionals/SimilarityOrdering.lean
+++ b/Linglib/Semantics/Conditionals/SimilarityOrdering.lean
@@ -27,7 +27,7 @@ The closest worlds are mathlib's `Minimal`, and the Limit Assumption is
   similar to `w₀` as `w₂` is".
 -/
 
-namespace Core.Order
+namespace Semantics.Conditionals
 
 /-! ## Structure -/
 
@@ -176,4 +176,4 @@ def candidateSelections {W : Type*} (sim : SimilarityOrdering W)
 notation:50 w₁ " ≤[" sim "," w₀ "] " w₂ =>
   SimilarityOrdering.closer sim w₀ w₁ w₂
 
-end Core.Order
+end Semantics.Conditionals

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -1,7 +1,7 @@
 import Linglib.Semantics.Conditionals.Basic
 import Linglib.Semantics.Conditionals.SelectionFunction
 import Linglib.Semantics.Mood.Defs
-import Linglib.Core.Order.SimilarityOrdering
+import Linglib.Semantics.Conditionals.SimilarityOrdering
 import Linglib.Discourse.CommonGround
 
 /-!
@@ -39,7 +39,7 @@ A selection function `s` determines a pairwise preference:
 `success`) and total (by definition); transitivity requires
 `s.isCoherent` — rationalizability by a total preorder. The
 `coherentSelectionToSimilarity` constructor turns a coherent `s` into
-a `Core.Order.SimilarityOrdering`.
+a `Semantics.Conditionals.SimilarityOrdering`.
 
 ## Stalnakerian indicative/subjunctive split ([stalnaker-1975])
 
@@ -61,7 +61,7 @@ namespace Semantics.Conditionals
 open CommonGround (ContextSet)
 open Mood (Grammatical)
 open _root_.Semantics.Conditionals (SelectionFunction selectionPrefers)
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 
 /-! ## Coherent selection ⇒ similarity ordering -/
 

--- a/Linglib/Studies/AlonsoOvalle2009.lean
+++ b/Linglib/Studies/AlonsoOvalle2009.lean
@@ -55,7 +55,7 @@ The differential prediction lives in [santorio-2018] §IV.3
 
 namespace AlonsoOvalle2009
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 open Santorio2018 (DecAlt sdaEval sdaEval_iff_forall)
 open McKayVanInwagen1977 (CropWorld cropSim goodWeather sunCold bumperCrop

--- a/Linglib/Studies/BarLevFox2020.lean
+++ b/Linglib/Studies/BarLevFox2020.lean
@@ -472,7 +472,7 @@ instance : DecidablePred sdaR := fun w => by cases w <;> unfold sdaR <;> infer_i
     `wpq`. From `wp`, `wp` itself is closer than `wpq` (so closest
     p-worlds from wp are just {wp}). Symmetric for `wq`. The minimal
     structure needed for the cell-witness analysis at `actual`. -/
-def sdaSim : Core.Order.SimilarityOrdering SDAWorld := .ofBool
+def sdaSim : Semantics.Conditionals.SimilarityOrdering SDAWorld := .ofBool
   (fun w₀ w₁ w₂ => w₁ == w₂ ||
     (w₀ == .actual && (w₁ == .wp || w₁ == .wq) && w₂ == .wpq) ||
     (w₀ == .wp && w₁ == .wp && w₂ == .wpq) ||
@@ -551,7 +551,7 @@ theorem sdaPandQbox_always_false (u : SDAWorld) : ¬ sdaPandQbox u := by
     ext v; cases v <;> simp [sdaP, sdaQ]
   rw [hfilter] at h
   have hwpq_in : SDAWorld.wpq ∈ sdaSim.closestWorlds u {SDAWorld.wpq} := by
-    rw [Core.Order.SimilarityOrdering.mem_closestWorlds]
+    rw [Semantics.Conditionals.SimilarityOrdering.mem_closestWorlds]
     refine ⟨Finset.mem_singleton.mpr rfl, ?_⟩
     intro w'' hw''
     rw [Finset.mem_singleton] at hw''; subst hw''

--- a/Linglib/Studies/CarianiGoldstein2020.lean
+++ b/Linglib/Studies/CarianiGoldstein2020.lean
@@ -36,7 +36,7 @@ not yet present in linglib and are left as future work.
 
 namespace CarianiGoldstein2020
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Santorio2018 (DecAlt homogeneityEval)
 
 

--- a/Linglib/Studies/CiardelliZhangChampollion2018.lean
+++ b/Linglib/Studies/CiardelliZhangChampollion2018.lean
@@ -94,7 +94,7 @@ combined with inquisitive lifting (§4) — and §6.4's SNCA derivation
 
 namespace CiardelliZhangChampollion2018
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
   (universalCounterfactual selectionalCounterfactual homogeneityCounterfactual
    PresupStatus PresupResult)

--- a/Linglib/Studies/Heim1992.lean
+++ b/Linglib/Studies/Heim1992.lean
@@ -166,8 +166,8 @@ false under the belief state `sick`, since `w2` is believed and not recovered. -
 theorem not_sick_subset_recovered : ¬ sick ⊆ recovered := λ h => @h .w2 trivial
 
 /-- Every world is equally similar to every other. -/
-def trivialSim : Core.Order.SimilarityOrdering HealthWorld := by
-  refine Core.Order.SimilarityOrdering.ofBool (λ _ _ _ => true) ?_ ?_
+def trivialSim : Semantics.Conditionals.SimilarityOrdering HealthWorld := by
+  refine Semantics.Conditionals.SimilarityOrdering.ofBool (λ _ _ _ => true) ?_ ?_
   · intros; rfl
   · intros; rfl
 

--- a/Linglib/Studies/McKayVanInwagen1977.lean
+++ b/Linglib/Studies/McKayVanInwagen1977.lean
@@ -43,7 +43,7 @@ instances are auto-derived from `DecidableEq` on the world enums.
 
 namespace McKayVanInwagen1977
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
 

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -127,7 +127,7 @@ follow-up.
 namespace Santorio2018
 
 open Trivalent (distList)
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 
 

--- a/Linglib/Studies/Stalnaker1981.lean
+++ b/Linglib/Studies/Stalnaker1981.lean
@@ -31,7 +31,7 @@ A Defense of Conditional Excluded Middle. In Harper, Stalnaker & Pearce
 
 namespace Stalnaker1981
 
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
+++ b/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
@@ -53,7 +53,7 @@ The DCR→SDA trajectory supports homogeneity-based accounts
 namespace ZaniCiardelliSanfelici2026
 
 open Trivalent (ProjectionType)
-open Core.Order (SimilarityOrdering)
+open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
 open Santorio2018
 


### PR DESCRIPTION
`Core/Order/SimilarityOrdering.lean` is Lewis–Stalnaker apparatus (centering, the Limit Assumption, both cited to [lewis-1973]) and every consumer is a conditionals or desire file, so it moves to `Semantics/Conditionals/SimilarityOrdering.lean` under `namespace Semantics.Conditionals`; 16 consumers rewired, no content change. The `atCenter : W → Preorder W` field (class-valued, the pattern ruled untenable elsewhere) is left for a separate pass since `Conditionals/Counterfactual.lean` leans on it heavily.