### PR TITLE
docs: cite Karttunen 1974 presupposition paper with its own bib key

### DIFF
--- a/Linglib/Semantics/Dynamic/Partial.lean
+++ b/Linglib/Semantics/Dynamic/Partial.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Presupposition.Context
 
 Heim's context change potentials are *partial* functions on contexts: the
 domain condition IS the presupposition ([heim-1983]'s "c admits φ",
-[karttunen-1974]'s "c satisfies-the-presuppositions-of φ").
+[karttunen-1974-presupposition]'s "c satisfies-the-presuppositions-of φ").
 `CCP.Partial P := Set P →. Set P` grounds this in mathlib's
 `PFun`: `Part.Dom` is admittance, and the satisfaction law for conjunction —
 "c admits φ∧ψ iff c admits φ and c[φ] admits ψ" — is the domain condition
@@ -62,7 +62,7 @@ namespace CCP.Partial
 variable {P W : Type*}
 
 /-- `u.admits s`: the update is defined at `s` ([heim-1983]'s "s admits u",
-    [karttunen-1974]'s satisfaction). This is `Part.Dom`. -/
+    [karttunen-1974-presupposition]'s satisfaction). This is `Part.Dom`. -/
 def admits (u : CCP.Partial P) (s : Set P) : Prop := (u s).Dom
 
 /-- Total CCPs are partial CCPs with trivial presupposition. -/
@@ -141,7 +141,7 @@ theorem seq_eliminative {φ ψ : CCP.Partial P}
 
 /-! ### The satisfaction law -/
 
-/-- **The Karttunen satisfaction law** ([karttunen-1974]), by construction:
+/-- **The Karttunen satisfaction law** ([karttunen-1974-presupposition]), by construction:
     `s` admits `φ ∧ ψ` iff `s` admits `φ` and `s[φ]` admits `ψ`. The
     statement is the domain condition of `Part.bind`. -/
 theorem admits_seq (φ ψ : CCP.Partial P) (s : Set P) :
@@ -161,7 +161,7 @@ theorem admits_seq_iff (φ ψ : CCP.Partial P) (s : Set P)
 
 /-- Conditional admittance: `s` admits `if φ, ψ` iff `s` admits `φ` and
     `s[φ]` admits `ψ` — the same condition as conjunction
-    ([karttunen-1974]). -/
+    ([karttunen-1974-presupposition]). -/
 theorem admits_cond (φ ψ : CCP.Partial P) (s : Set P) :
     (cond φ ψ).admits s ↔ ∃ h : φ.admits s, ψ.admits ((φ s).get h) :=
   Iff.rfl

--- a/Linglib/Semantics/Presupposition/Context.lean
+++ b/Linglib/Semantics/Presupposition/Context.lean
@@ -111,7 +111,7 @@ theorem accommodate_eq_defined (c : ContextSet W) (p : PartialProp W) (w : W) :
 /-! ### Local contexts (satisfaction tradition)
 
 Per-connective local contexts, stipulated in the satisfaction tradition
-([karttunen-1974], [heim-1983]); [schlenker-2009]'s algorithm reconstructs
+([karttunen-1974-presupposition], [heim-1983]); [schlenker-2009]'s algorithm reconstructs
 these clauses from bivalent meanings plus incremental transparency. A
 presupposition is filtered at a position iff the local context there
 satisfies it (`presupSatisfied`), and projects otherwise

--- a/Linglib/Studies/Elbourne2013.lean
+++ b/Linglib/Studies/Elbourne2013.lean
@@ -12,7 +12,7 @@ import Linglib.Fragments.English.Nouns
 /-!
 # [elbourne-2013]: Situation-Semantic Definite Descriptions [elbourne-2013]
 [barwise-perry-1983] [elbourne-2005] [heim-1982] [postal-1966] [schwarz-2009] [kamp-1981] [stanley-szab-2000] [tonhauser-beaver-roberts-simons-2013] [roberts-2012]
-[donnellan-1966] [kripke-1977] [karttunen-1974]
+[donnellan-1966] [kripke-1977] [karttunen-1974-presupposition]
 
 Formalizes the core theoretical machinery and empirical predictions from:
 

--- a/Linglib/Studies/Heim1992.lean
+++ b/Linglib/Studies/Heim1992.lean
@@ -7,7 +7,7 @@ import Linglib.Semantics.Presupposition.BeliefEmbedding
 
 [heim-1992] derives Karttunen's generalization — if the complement of an
 attitude report presupposes `p`, the report presupposes that the attitude
-holder believes `p` ([karttunen-1974]) — from context change potentials for
+holder believes `p` ([karttunen-1974-presupposition]) — from context change potentials for
 the attitude predicates. The belief rule (18) makes `c + a believes φ`
 defined iff `Dox_a(w) + φ` is defined for every `w ∈ c`, and then keeps the
 worlds whose doxastic state `φ` maps to itself; `believes` is that rule as a

--- a/Linglib/Studies/Yagi2025.lean
+++ b/Linglib/Studies/Yagi2025.lean
@@ -33,7 +33,7 @@ co-developer, but it is formalised separately at
 `Studies/Aloni2022.lean` and not engaged here.
 
 Yagi's example (8) — "Either baldness is not hereditary, or all of Bill's
-children are bald" ([karttunen-1974]) — appears in §2.2 as a
+children are bald" ([karttunen-1974-presupposition]) — appears in §2.2 as a
 counterexample to the K&P modification `Π(φ ∨ ψ) := Π(φ) ∨ Π(ψ)` (eq. 7).
 This formula is exactly what `PartialProp.orFlex.presup` computes. The
 flexible-accommodation framework Yagi defends in §3.2 evades the eq. (7)
@@ -696,7 +696,7 @@ theorem neg_flex_truth_table :
 [yagi-2025] §2.2 (between Def 3 and §2.3) considers a modification
 to K&P, `Π(φ ∨ ψ) := Π(φ) ∨ Π(ψ)` (eq. (7)). This formula IS what
 `PartialProp.orFlex.presup` computes. Yagi shows it correctly predicts (1c)
-Buganda but is "too weak" for (8) [karttunen-1974]: "Either baldness
+Buganda but is "too weak" for (8) [karttunen-1974-presupposition]: "Either baldness
 is not hereditary, or all of Bill's children are bald." Eq. (7) predicts
 the tautological presupposition `⊤ ∨ Π(ψ) = ⊤`, but the empirical
 intuition is that (8) presupposes Bill has children.

--- a/references.bib
+++ b/references.bib
@@ -11546,6 +11546,20 @@
   role      = {formalized},
   sources   = {Fragments/English/TemporalExpressions.lean;Fragments/Finnish/TemporalConnectives.lean}
 }
+@article{karttunen-1974-presupposition,
+  author    = {Karttunen, Lauri},
+  year      = {1974},
+  title     = {Presupposition and Linguistic Context},
+  journal   = {Theoretical Linguistics},
+  volume    = {1},
+  number    = {1-3},
+  pages     = {181--194},
+  doi       = {10.1515/thli.1974.1.1-3.181},
+  subfield  = {semantics/presupposition},
+  validated = {true},
+  role      = {cited},
+  sources   = {Semantics/Dynamic/Partial.lean;Semantics/Presupposition/Context.lean;Studies/Heim1992.lean;Studies/Yagi2025.lean;Studies/Elbourne2013.lean}
+}
 @inproceedings{karttunen-1974,
   author    = {Karttunen, Lauri},
   year      = {1974},


### PR DESCRIPTION
The bib key `karttunen-1974` is Karttunen's *Until* (CLS 10); five presupposition files cited it meaning *Presupposition and Linguistic Context* (Theoretical Linguistics 1, DOI verified via Crossref). New key `karttunen-1974-presupposition`; the five cites repointed.