### PR TITLE
refactor(Studies/TonhauserEtAl2013): formalize the diagnostics and the §8 argument

### DIFF
--- a/Linglib/Semantics/Presupposition/ProjectiveContent.lean
+++ b/Linglib/Semantics/Presupposition/ProjectiveContent.lean
@@ -124,8 +124,6 @@ inductive ProjectiveTrigger where
   | only_prejacent
   /-- *almost*: polar content. -/
   | almost_polar
-  /-- Definite descriptions: existence and uniqueness. -/
-  | definite_description
   /-- Occasion verbs: prior occasioning eventuality
       ([solstad-bott-2024]). *Punish* presupposes a prior offense;
       *manage* presupposes a prior difficulty. SCF=no (can be
@@ -152,7 +150,6 @@ def ProjectiveTrigger.toClass : ProjectiveTrigger → ProjectiveClass
   | .know_complement => .classC
   | .only_prejacent => .classC
   | .almost_polar => .classC
-  | .definite_description => .classC
   | .occasion_verb => .classC
   | .too_salience => .classD
   | .demonstrative_indication => .classD

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -1,314 +1,93 @@
 import Linglib.Semantics.Presupposition.ProjectiveContent
-import Linglib.Studies.Schlenker2009
+import Linglib.Semantics.Presupposition.BeliefEmbedding
 
 /-!
-# Tonhauser, Beaver, Roberts & Simons (2013): Taxonomy from Local Contexts
-[tonhauser-beaver-roberts-simons-2013]
+# Tonhauser, Beaver, Roberts & Simons (2013): a taxonomy of projective content
 
-Derives the four-class projective-content taxonomy of
-[tonhauser-beaver-roberts-simons-2013] from [schlenker-2009]-style local
-contexts ([heim-1983], [lewis-1979]). The classes cross-classify two
-properties:
+[tonhauser-beaver-roberts-simons-2013] sort projective contents by two diagnosable
+properties. A trigger imposes a *strong contextual felicity constraint* with respect to its
+content `m` if it is acceptable only in `m`-positive contexts (11), where a context is
+`m`-positive if it entails `m` and `m`-neutral if it entails neither `m` nor `¬m` (10), so
+acceptability in an `m`-neutral context refutes the constraint (12i). Under a belief
+predicate, `m` has *local effect* when it is part of the attitude holder's belief state, and
+*obligatory* local effect when it always does (§5), so acceptability with the holder ignorant
+of `m` refutes it (41i). The two properties cross-classify the English and Guaraní triggers
+of Table 2 into classes A–D (`Semantics/Presupposition/ProjectiveContent.lean`), cutting
+across the traditional presuppositions: pronouns (A) and *stop* (C) are both classical
+presuppositions (`stop_pronoun_classes_differ`).
 
-| Class | SCF | OLE | Derived behavior |
-|-------|-----|-----|------------------|
-| A | yes | yes | Requires context + shifts under belief |
-| B | no  | no  | Informative + speaker-anchored |
-| C | no  | yes | Informative + shifts under belief |
-| D | yes | no  | Requires context + speaker-anchored |
-
-[tonhauser-beaver-roberts-simons-2013] object to satisfaction theories:
-
-> "In theories like those of [schlenker-2009], where it is assumed that a
-> presupposition is satisfied in its local context if it is entailed by it.
-> Since, in general, the relevant local context is the context set ('which
-> encodes what the speech act participants take for granted'), presuppositions
-> are predicted to project. The heterogeneity of projective content, in
-> particular the finding that many such contents are not associated with a
-> strong contextual felicity constraint, provides an argument against an
-> inclusive analysis of projection based on local satisfaction."
-
-The resolution formalized here: *projection* is uniform (the local-context
-machinery), while *accommodation* varies by trigger class. OLE is derived
-directly from belief local contexts; SCF is characterized as a constraint
-on accommodation, not built into local contexts (a full SCF derivation
-needs QUD/information-structure machinery).
-
-## Main declarations
-
-- `SCF_Requires` / `SCF_Allows`: Strong Contextual Felicity in
-  local-context terms.
-- `OLE_Obligatory` / `OLE_NotObligatory`: Obligatory Local Effect via
-  belief local contexts.
-- `belief_derives_ole`: belief embedding filters holder-attributed
-  presuppositions, deriving OLE=yes behavior.
-- `classes_partition`: the SCF × OLE feature space partitions triggers
-  into exactly the four classes.
-- `schlenker_derives_tonhauser`: the local-context theory reproduces the
-  taxonomy's structural predictions.
-- `traditional_crosscuts_classes`: the traditional presupposition/CI
-  labels cross-cut the SCF × OLE classes.
+§8 argues that a theory on which a presupposition is acceptable iff its local context entails
+it ([karttunen-1974-presupposition], [heim-1983], [schlenker-2009]) predicts every trigger
+to impose the constraint and to have obligatory local effect — to be class A. Against the
+substrate's own rendering of that theory, `Context.presupSatisfied` at the matrix and
+`BeliefEmbedding.presupAttributedToHolder` under belief, this is `scf_of_satisfaction` and
+`ole_of_satisfaction`; Table 2's classes B–D are the counterexamples
+(`exists_trigger_not_classA`).
 -/
 
 namespace TonhauserEtAl2013
 
-open CommonGround
-open Semantics.Presupposition
-open Semantics.Presupposition.Context
-open Semantics.Presupposition.BeliefEmbedding
-open Semantics.Presupposition.ProjectiveContent
+open CommonGround Semantics.Presupposition Semantics.Presupposition.Context
+  Semantics.Presupposition.BeliefEmbedding Semantics.Presupposition.ProjectiveContent
 
-variable {W : Type*} {Agent : Type*}
+variable {W E : Type*} (m : Set W) (c : ContextSet W)
 
--- ════════════════════════════════════════════════════════════════
--- § SCF and OLE in Local-Context Terms
--- ════════════════════════════════════════════════════════════════
+/-- (10): the context entails `m`. -/
+def MPositive : Prop := ContextSet.entails c m
 
-/--
-**SCF (Strong Contextual Felicity)** in local context terms.
+/-- (10): the context entails neither `m` nor `¬m`. -/
+def MNeutral : Prop := ¬ ContextSet.entails c m ∧ ¬ ContextSet.entails c mᶜ
 
-A trigger has SCF=yes iff its projective content MUST be entailed by the
-global context for felicitous use. Accommodation is blocked.
+/-- (11): uttering the trigger's sentence, acceptable in the contexts `Acc`, is acceptable
+only in `m`-positive contexts. -/
+def StrongContextualFelicity (Acc : ContextSet W → Prop) : Prop := ∀ c, Acc c → MPositive m c
 
-In Schlenker's terms: the local context at matrix level IS the global context,
-and the presupposition must be entailed (not just "could be accommodated").
+/-- (12i): acceptability in an `m`-neutral context refutes the constraint. -/
+theorem not_scf_of_acceptable_neutral {Acc : ContextSet W → Prop} (h : Acc c)
+    (hn : MNeutral m c) : ¬ StrongContextualFelicity m Acc :=
+  fun hs => hn.1 (hs c h)
 
-This is a marker structure. The constraint that accommodation is blocked
-is a property of the trigger class, not derivable from the content alone.
-Full derivation requires connecting to `Accommodation.AccommodationOK` and
-trigger-specific constraints (anaphoric binding, salience, etc.).
--/
-structure SCF_Requires (W : Type*) where
-  /-- The projective content that must be established -/
-  content : Set W
+/-- §5: under `a believes S` at `w`, `m` has local effect when it is part of `a`'s belief
+state. -/
+def LocalEffect (Dox : E → W → W → Prop) (a : E) (w : W) : Prop := ContextSet.entails (Dox a w) m
 
-/--
-**SCF=no** means accommodation is ALLOWED.
+/-- Obligatory local effect: wherever the belief report is acceptable, `m` has local effect. -/
+def ObligatoryLocalEffect (Dox : E → W → W → Prop) (a : E) (Acc : ContextSet W → Prop) : Prop :=
+  ∀ c, Acc c → ∀ w ∈ c, LocalEffect m Dox a w
 
-The projective content can be informative — it can update the context
-rather than being required to already hold.
+/-- (41i): acceptability of the report with the holder ignorant of `m` refutes obligatory
+local effect. -/
+theorem not_ole_of_acceptable_ignorant {Dox : E → W → W → Prop} {a : E}
+    {Acc : ContextSet W → Prop} (h : Acc c) {w : W} (hw : w ∈ c) (hig : MNeutral m (Dox a w)) :
+    ¬ ObligatoryLocalEffect m Dox a Acc :=
+  fun ho => hig.1 (ho c h w hw)
 
-Witness: there exist non-empty contexts where the content is NOT entailed
-yet the trigger's use is still felicitous (via accommodation).
--/
-structure SCF_Allows (W : Type*) where
-  /-- The projective content -/
-  content : Set W
-  /-- Accommodation is possible: there exist contexts where content is
-      informative (not entailed) yet use is felicitous -/
-  accommodable : ∃ (c : ContextSet W), Set.Nonempty c ∧
-    ¬ContextSet.entails c content
+/-! ### Against local satisfaction (§8) -/
 
-/--
-**OLE (Obligatory Local Effect)** in local context terms.
+variable (p : PartialProp W) (Dox : E → W → W → Prop) (a : E)
 
-OLE=yes means: under belief embedding, the local context is the attitude
-holder's belief state. The projective content is attributed to the holder.
--/
-def OLE_Obligatory (Dox : Agent → W → W → Prop)
-    (content : Set W) : Prop :=
-  ∀ (c : ContextSet W) (agent : Agent) (w_star : W),
-    c w_star →
-    let blc : BeliefLocalCtx W Agent := { globalCtx := c, dox := Dox, agent := agent }
-    -- Content is evaluated relative to holder's beliefs
-    ContextSet.entails (blc.atWorld w_star) content
+/-- A trigger acceptable exactly where its local context entails its presupposition imposes
+the strong contextual felicity constraint. -/
+theorem scf_of_satisfaction : StrongContextualFelicity p.presup (presupSatisfied · p) :=
+  fun _ h => h
 
-/--
-**OLE=no** means: under belief embedding, the projective content is still
-evaluated relative to the speaker's (global) context, not the holder's beliefs.
+/-- Under belief, local satisfaction is satisfaction in the holder's belief state, so the
+presupposition has obligatory local effect. -/
+theorem ole_of_satisfaction :
+    ObligatoryLocalEffect p.presup Dox a (presupAttributedToHolder ⟨·, Dox, a⟩ p) :=
+  fun _ h w hw _ hx => h w hw ⟨hw, hx⟩
 
-Formally: there exist doxastic contexts where the content holds globally
-but NOT in the attitude holder's beliefs. The content is "speaker-anchored"
-— it does not shift under belief embedding.
+/-- Local satisfaction thus predicts class A for every trigger; Table 2 has triggers of every
+other class. -/
+theorem exists_trigger_not_classA :
+    classFromProperties .requires .obligatory = .classA ∧
+      ∃ t : ProjectiveTrigger, t.toClass ≠ .classA :=
+  ⟨rfl, .expressive, by decide⟩
 
-Class B triggers (expressives) and Class D triggers exhibit this behavior.
--/
-def OLE_NotObligatory (Dox : Agent → W → W → Prop)
-    (content : Set W) : Prop :=
-  ∃ (c : ContextSet W) (agent : Agent) (w_star : W),
-    c w_star ∧
-    ContextSet.entails c content ∧
-    let blc : BeliefLocalCtx W Agent := { globalCtx := c, dox := Dox, agent := agent }
-    ¬ContextSet.entails (blc.atWorld w_star) content
-
-/--
-**OLE derivation**: belief embedding creates an attitude-holder context.
-
-Under "x believes φ", the local context at φ is x's belief state, so a
-presupposition attributed to the holder is filtered there. This derives
-OLE=yes behavior from [schlenker-2009]'s belief local contexts.
--/
-theorem belief_derives_ole (blc : BeliefLocalCtx W Agent) (p : PartialProp W)
-    (h : presupAttributedToHolder blc p) (w_star : W) (hw : blc.globalCtx w_star) :
-    presupSatisfied (blc.atWorld w_star) p :=
-  h w_star hw
-
--- ════════════════════════════════════════════════════════════════
--- § OLE as Shift Under Belief
--- ════════════════════════════════════════════════════════════════
-
-/--
-Determines whether a projective trigger's content shifts to the attitude
-holder's perspective under belief embedding.
-
-OLE = yes: Content shifts to attitude holder (computed from their beliefs)
-OLE = no: Content remains attributed to speaker (no perspective shift)
--/
-def shiftsUnderBelief : ProjectiveClass → Bool
-  | .classA => true   -- OLE = yes
-  | .classB => false  -- OLE = no
-  | .classC => true   -- OLE = yes
-  | .classD => false  -- OLE = no
-
-/--
-OLE status matches shift behavior.
--/
-theorem ole_matches_shift (c : ProjectiveClass) :
-    shiftsUnderBelief c = true ↔ c.ole = .obligatory := by
-  cases c <;> simp [shiftsUnderBelief, ProjectiveClass.ole]
-
-/--
-The Schlenker local context machinery derives the OLE
-predictions from [tonhauser-beaver-roberts-simons-2013].
-
-For any trigger:
-- If OLE=yes (Class A, C): Local context under belief = attitude holder's beliefs
-- If OLE=no (Class B, D): Local context under belief = global context (speaker)
-
-This explains why "stop" presuppositions shift to attitude holders but
-"damn" expressives don't.
--/
-theorem ole_from_local_contexts (trigger : ProjectiveTrigger) :
-    shiftsUnderBelief trigger.toClass = true ↔
-    trigger.toClass.ole = .obligatory :=
-  ole_matches_shift trigger.toClass
-
-/--
-Class C triggers (stop, know, only) have OLE=yes.
--/
-example : ProjectiveTrigger.stop_prestate.toClass.ole = .obligatory := rfl
-example : ProjectiveTrigger.know_complement.toClass.ole = .obligatory := rfl
-
-/--
-Class B triggers (expressives, appositives) have OLE=no.
--/
-example : ProjectiveTrigger.expressive.toClass.ole = .notObligatory := rfl
-example : ProjectiveTrigger.appositive.toClass.ole = .notObligatory := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § The Four-Class Taxonomy
--- ════════════════════════════════════════════════════════════════
-
-/-- A projective trigger's behavior characterized by SCF and OLE values. -/
-structure TriggerBehavior (W : Type*) (Agent : Type*) where
-  content : Set W
-  scf : StrongContextualFelicity
-  ole : ObligatoryLocalEffect
-
-def isClassA (tb : TriggerBehavior W Agent) : Prop :=
-  tb.scf = .requires ∧ tb.ole = .obligatory
-
-def isClassB (tb : TriggerBehavior W Agent) : Prop :=
-  tb.scf = .noRequires ∧ tb.ole = .notObligatory
-
-def isClassC (tb : TriggerBehavior W Agent) : Prop :=
-  tb.scf = .noRequires ∧ tb.ole = .obligatory
-
-def isClassD (tb : TriggerBehavior W Agent) : Prop :=
-  tb.scf = .requires ∧ tb.ole = .notObligatory
-
-/-- SCF-OLE correspondence with Tonhauser classes. -/
-theorem class_from_scf_ole (tb : TriggerBehavior W Agent) :
-    (isClassA tb ↔ (tb.scf = .requires ∧ tb.ole = .obligatory)) ∧
-    (isClassB tb ↔ (tb.scf = .noRequires ∧ tb.ole = .notObligatory)) ∧
-    (isClassC tb ↔ (tb.scf = .noRequires ∧ tb.ole = .obligatory)) ∧
-    (isClassD tb ↔ (tb.scf = .requires ∧ tb.ole = .notObligatory)) := by
-  unfold isClassA isClassB isClassC isClassD
-  exact ⟨Iff.rfl, Iff.rfl, Iff.rfl, Iff.rfl⟩
-
-/-- Classes partition the space. -/
-theorem classes_partition (tb : TriggerBehavior W Agent) :
-    (isClassA tb ∨ isClassB tb ∨ isClassC tb ∨ isClassD tb) ∧
-    ¬(isClassA tb ∧ isClassB tb) ∧
-    ¬(isClassA tb ∧ isClassC tb) ∧
-    ¬(isClassA tb ∧ isClassD tb) ∧
-    ¬(isClassB tb ∧ isClassC tb) ∧
-    ¬(isClassB tb ∧ isClassD tb) ∧
-    ¬(isClassC tb ∧ isClassD tb) := by
-  unfold isClassA isClassB isClassC isClassD
-  cases tb.scf <;> cases tb.ole <;> simp
-
--- Trigger classification
-
-theorem stop_is_classC : ProjectiveTrigger.stop_prestate.toClass = .classC := rfl
-theorem expressive_is_classB : ProjectiveTrigger.expressive.toClass = .classB := rfl
-theorem pronoun_is_classA : ProjectiveTrigger.pronoun_existence.toClass = .classA := rfl
-theorem demonstrative_is_classD :
-    ProjectiveTrigger.demonstrative_indication.toClass = .classD := rfl
-
--- Per-trigger phenomena
-
-theorem stop_allows_informativity :
-    ProjectiveTrigger.stop_prestate.toClass.scf = .noRequires := rfl
-
-theorem stop_shifts_under_belief :
-    ProjectiveTrigger.stop_prestate.toClass.ole = .obligatory := rfl
-
-theorem expressive_allows_informativity :
-    ProjectiveTrigger.expressive.toClass.scf = .noRequires := rfl
-
-theorem expressive_stays_with_speaker :
-    ProjectiveTrigger.expressive.toClass.ole = .notObligatory := rfl
-
-theorem pronoun_requires_antecedent :
-    ProjectiveTrigger.pronoun_existence.toClass.scf = .requires := rfl
-
-theorem pronoun_shifts_under_belief :
-    ProjectiveTrigger.pronoun_existence.toClass.ole = .obligatory := rfl
-
--- ════════════════════════════════════════════════════════════════
--- § Traditional Categories Don't Carve at the Joints
--- ════════════════════════════════════════════════════════════════
-
-/-- Traditional labels for projective content, predating the SCF/OLE
-taxonomy. -/
-inductive TraditionalCategory where
-  /-- Traditional "presupposition". -/
-  | presupposition
-  /-- Potts-style "conventional implicature". -/
-  | conventionalImplicature
-  /-- Supplementary/parenthetical content. -/
-  | supplementary
-  deriving DecidableEq, Repr
-
-/-- The traditional category conventionally assigned to each trigger.
-[tonhauser-beaver-roberts-simons-2013] argue this classification is
-inadequate: the SCF × OLE taxonomy cross-cuts it
-(`traditional_crosscuts_classes`). -/
-def traditionalCategory : ProjectiveTrigger → TraditionalCategory
-  | .pronoun_existence => .presupposition
-  | .definite_description => .presupposition
-  | .stop_prestate => .presupposition
-  | .know_complement => .presupposition
-  | .only_prejacent => .presupposition
-  | .almost_polar => .presupposition
-  | .too_existence => .presupposition
-  | .too_salience => .presupposition
-  | .occasion_verb => .presupposition
-  | .demonstrative_indication => .presupposition
-  | .focus_salience => .presupposition
-  | .expressive => .conventionalImplicature
-  | .appositive => .supplementary
-  | .nrrc => .supplementary
-  | .possessive_np => .supplementary
-
-/-- Traditional categories don't carve at the joints: pronouns and *stop*
-are both traditional "presuppositions" yet land in different projective
-classes (A vs C). -/
-theorem traditional_crosscuts_classes :
-    traditionalCategory .pronoun_existence = traditionalCategory .stop_prestate ∧
-    ProjectiveTrigger.toClass .pronoun_existence ≠
-      ProjectiveTrigger.toClass .stop_prestate :=
-  ⟨rfl, by decide⟩
+/-- The classes cut across the traditional presuppositions: pronouns and *stop* are both
+classical presuppositions, in classes A and C. -/
+theorem stop_pronoun_classes_differ :
+    ProjectiveTrigger.stop_prestate.toClass ≠ ProjectiveTrigger.pronoun_existence.toClass := by
+  decide
 
 end TonhauserEtAl2013

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -49,10 +49,12 @@ theorem not_scf_of_acceptable_neutral {Acc : ContextSet W → Prop} (h : Acc c)
 
 /-- §5: under `a believes S` at `w`, `m` has local effect when it is part of `a`'s belief
 state. -/
-def LocalEffect (Dox : E → W → W → Prop) (a : E) (w : W) : Prop := ContextSet.entails (Dox a w) m
+def LocalEffect (Dox : E → W → W → Prop) (a : E) (w : W) : Prop :=
+  ContextSet.entails (Dox a w) m
 
 /-- Obligatory local effect: wherever the belief report is acceptable, `m` has local effect. -/
-def ObligatoryLocalEffect (Dox : E → W → W → Prop) (a : E) (Acc : ContextSet W → Prop) : Prop :=
+def ObligatoryLocalEffect (Dox : E → W → W → Prop) (a : E) (Acc : ContextSet W → Prop) :
+    Prop :=
   ∀ c, Acc c → ∀ w ∈ c, LocalEffect m Dox a w
 
 /-- (41i): acceptability of the report with the holder ignorant of `m` refutes obligatory


### PR DESCRIPTION
The study claimed to *derive* the SCF × OLE taxonomy from Schlenker-style local contexts; the paper's §8 is an argument *against* local-satisfaction theories (they predict every trigger is class A). Rewritten to the paper: `m`-positive/`m`-neutral contexts (10), the strong contextual felicity constraint (11) with its refutation diagnostic (12i), local and obligatory local effect (§5) with (41i), and §8 made precise against the substrate — `scf_of_satisfaction` / `ole_of_satisfaction` show `Context.presupSatisfied` and `BeliefEmbedding.presupAttributedToHolder` force class A, while Table 2 populates B–D. The 14 `rfl` table restatements, the marker structures, a `Bool` duplicate of `ProjectiveClass.ole`, and the four-class partition re-proof (already `class_properties_roundtrip` in substrate) are cut.
- `ProjectiveContent`: `ProjectiveTrigger.definite_description` (class C) removed — it is not in the paper's Table 2, which mentions English definites only as *anaphoric* triggers; no consumers.