### PR TITLE
refactor(Studies/Santorio2018): compose truthmakers with the conditional

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1554,6 +1554,7 @@ import Linglib.Semantics.Composition.Writer
 import Linglib.Semantics.Conditionals.Basic
 import Linglib.Semantics.Conditionals.ConditionalType
 import Linglib.Semantics.Conditionals.Counterfactual
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
 import Linglib.Semantics.Conditionals.Counterfactual.Implicature
 import Linglib.Semantics.Conditionals.Counterfactual.Lumping
 import Linglib.Semantics.Conditionals.Counterfactual.QuantifierEmbedding

--- a/Linglib/Semantics/Alternatives/Structural.lean
+++ b/Linglib/Semantics/Alternatives/Structural.lean
@@ -51,7 +51,7 @@ parameterized over the category type `C`, so they work with UD-grounded
 - **Horn scales subsumed**: Lexical substitution of same-category items
   is a special case of structural alternatives (§8)
 - **Fills truthmaker gap**: `Studies/Santorio2018.lean`'s
-  `IsTruthmaker` requires ALT_S computed via structural alternative generation
+  `truthmakers` takes ALT_S computed via structural alternative generation
 - **Economy connection**: [katzir-singh-2015]'s complexity ordering
   in `KatzirSingh2015.lean` is based on structural complexity (def 19)
 -/

--- a/Linglib/Semantics/Conditionals/Counterfactual/Alternatives.lean
+++ b/Linglib/Semantics/Conditionals/Counterfactual/Alternatives.lean
@@ -1,0 +1,74 @@
+import Linglib.Semantics.Conditionals.Counterfactual
+import Linglib.Logic.Duality
+
+/-!
+# Counterfactuals over sets of antecedent propositions
+
+A conditional whose antecedent denotes a set of propositions `S` rather than a single one —
+the disjuncts of a disjunctive antecedent ([alonso-ovalle-2009]) or the antecedent's
+truthmakers ([santorio-2018]) — can be read distributively or collectively. `Distributive`
+requires the counterfactual of each proposition in `S` ([alonso-ovalle-2009]'s universal
+quantification over alternatives, the assertion of [santorio-2018]'s `DIST_π`) and so
+validates Simplification of Disjunctive Antecedents by construction; `would` lets the modal
+extract the disjunctive closure `⋁S` ([santorio-2018]), which is [lewis-1973]'s
+counterfactual on the disjunction and does not. `homogeneity` is the all-or-nothing verdict —
+`.true` when every proposition's counterfactual holds, `.false` when none does, `.indet`
+otherwise — the presupposition of `DIST_π` and the trivalent conditional of
+[cariani-goldstein-2020].
+-/
+
+namespace Semantics.Conditionals.Counterfactual
+
+variable {W : Type*} [DecidableEq W] [Fintype W] (sim : SimilarityOrdering W)
+  (S : List (Finset W)) (C : W → Prop) [DecidablePred C] (w : W)
+
+/-- The disjunctive closure `⋁S`. -/
+def disjunctiveClosure : Finset W := S.foldr (· ∪ ·) ∅
+
+omit [Fintype W] in
+@[simp] theorem mem_disjunctiveClosure {x : W} :
+    x ∈ disjunctiveClosure S ↔ ∃ A ∈ S, x ∈ A := by
+  induction S with
+  | nil => simp [disjunctiveClosure]
+  | cons A S ih =>
+    rw [disjunctiveClosure, List.foldr_cons, Finset.mem_union, List.exists_mem_cons_iff]
+    exact or_congr_right ih
+
+/-- The modal over `S` quantifies over the closest worlds of its disjunctive closure. -/
+def would : Prop := universalCounterfactual sim (· ∈ disjunctiveClosure S) C w
+
+/-- The distributive reading: the counterfactual holds of each proposition in `S`. -/
+def Distributive : Prop := ∀ A ∈ S, universalCounterfactual sim (· ∈ A) C w
+
+/-- The all-or-nothing verdict over `S`. -/
+def homogeneity : Trivalent :=
+  Trivalent.distList S fun A => universalCounterfactual sim (· ∈ A) C w
+
+instance : Decidable (would sim S C w) :=
+  inferInstanceAs (Decidable (universalCounterfactual sim (· ∈ disjunctiveClosure S) C w))
+
+instance : Decidable (Distributive sim S C w) :=
+  inferInstanceAs (Decidable (∀ A ∈ S, universalCounterfactual sim (· ∈ A) C w))
+
+theorem distributive_iff_homogeneity_eq_true :
+    Distributive sim S C w ↔ homogeneity sim S C w = .true := by
+  unfold homogeneity Trivalent.distList
+  by_cases h : ∀ A ∈ S, universalCounterfactual sim (· ∈ A) C w
+  · rw [if_pos h]; exact ⟨fun _ => rfl, fun _ => h⟩
+  · rw [if_neg h]
+    refine ⟨fun h' => (h h').elim, fun h' => ?_⟩
+    split_ifs at h'
+
+/-- On a singleton the modal quantifies over the closest worlds of its one proposition. -/
+theorem would_singleton (A : Finset W) :
+    would sim [A] C w ↔ universalCounterfactual sim (· ∈ A) C w := by
+  simp only [would, disjunctiveClosure, List.foldr, Finset.union_empty]
+
+/-- A proposition given as a predicate and as the finset of its worlds yield the same
+counterfactual. -/
+theorem universalCounterfactual_mem_filter (A : W → Prop) [DecidablePred A] :
+    universalCounterfactual sim (· ∈ Finset.univ.filter A) C w ↔
+      universalCounterfactual sim A C w := by
+  simp [universalCounterfactual]
+
+end Semantics.Conditionals.Counterfactual

--- a/Linglib/Semantics/Truthmaker/Entailment.lean
+++ b/Linglib/Semantics/Truthmaker/Entailment.lean
@@ -30,14 +30,11 @@ This file:
 
 ## Cross-framework convergence
 
-`Santorio2018.IsTruthmaker p S` is the
-**world-extensional** truthmaker of [santorio-2018]. It is now
-defined as an `abbrev` for `ExactEntails` on the Bool extension:
-`IsTruthmaker p S := (p · = true) ⊨ₑ (S · = true)`. It does **not**
-correspond to `IsContentPart` (= `AnalyticEntails`); the Up clause and
-mereological parthood are exactly what the world-extensional notion
-drops. This non-equivalence is theorematised in
-`santorio_truthmaker_neq_fine_content_part` in the same study file.
+[santorio-2018]'s truthmakers (`Studies/Santorio2018.lean`, `truthmakers`) are
+**world-extensional**: a truthmaker `p` of `S` is a finset of worlds with `p ⊆ S`, i.e.
+`ExactEntails` on indicator propositions. It does **not** correspond to `IsContentPart`
+(= `AnalyticEntails`); the Up clause and mereological parthood are exactly what the
+world-extensional notion drops.
 
 `Semantics/Attitudes/Doxastic.lean`'s Hintikka `BoxAt` is
 ∀-over-accessible-worlds; truthmaker `attHolds` (`Basic.lean`) is

--- a/Linglib/Studies/AlonsoOvalle2009.lean
+++ b/Linglib/Studies/AlonsoOvalle2009.lean
@@ -1,4 +1,5 @@
-import Linglib.Studies.Santorio2018
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
+import Linglib.Studies.McKayVanInwagen1977
 import Linglib.Syntax.Category.Coordinator
 
 /-!
@@ -31,12 +32,12 @@ without abandoning minimal change. Two refinements:
    ⟦if A, would C⟧ = `λw. ∀p ∈ Alt(A): f_{≤,w}(p) ⊆ ⟦C⟧`
 
 Equivalently: every disjunct alternative's closest worlds satisfy the
-consequent. **This is structurally [santorio-2018]'s `sdaEval`** —
+consequent. **This is structurally [santorio-2018]'s `Distributive`** —
 universal-over-per-alternative-conditionals (Simplification reading).
 
 ## Connection to linglib substrate
 
-`aoConditional` IS [santorio-2018]'s `sdaEval`
+`aoConditional` IS [santorio-2018]'s `Distributive`
 (`Studies/Santorio2018.lean`); the bridge is
 `rfl`. The frameworks DIFFER in their treatment of the **alternative
 set**, not the per-alternative evaluation:
@@ -57,7 +58,7 @@ namespace AlonsoOvalle2009
 
 open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
-open Santorio2018 (DecAlt sdaEval sdaEval_iff_forall)
+open Semantics.Conditionals.Counterfactual (Distributive universalCounterfactual_mem_filter)
 open McKayVanInwagen1977 (CropWorld cropSim goodWeather sunCold bumperCrop
   bumperCrop_lewis_true bumperCrop_conjunction_false)
 
@@ -79,24 +80,24 @@ substrate. -/
     antecedent (eqn 25–26 p. 217): every disjunct alternative's
     closest worlds satisfy the consequent.
 
-    Definitionally equal to [santorio-2018]'s `sdaEval` — the
+    Definitionally equal to [santorio-2018]'s `Distributive` — the
     Simplification reading. The two accounts diverge in how the
     alternative SET is generated (see module docstring), not in this
     per-alternative evaluation rule. -/
 def aoConditional {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (alts : List (DecAlt W))
+    (sim : SimilarityOrdering W) (alts : List (Finset W))
     (C : W → Prop) [DecidablePred C] (w : W) : Prop :=
-  sdaEval sim alts C w
+  Distributive sim alts C w
 
-/-- **Bridge: AO = Santorio's `sdaEval`.** Definitionally equal; the
+/-- **Bridge: AO = Santorio's `Distributive`.** Definitionally equal; the
     two formalisations of the per-alternative-conditional reading
     coincide. The substantive difference between
     [alonso-ovalle-2009] and [santorio-2018] is the
     alternative-set construction, not this evaluation rule. -/
-theorem aoConditional_eq_sdaEval {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (alts : List (DecAlt W))
+theorem aoConditional_eq_distributive {W : Type*} [DecidableEq W] [Fintype W]
+    (sim : SimilarityOrdering W) (alts : List (Finset W))
     (C : W → Prop) [DecidablePred C] (w : W) :
-    aoConditional sim alts C w = sdaEval sim alts C w := rfl
+    aoConditional sim alts C w = Distributive sim alts C w := rfl
 
 /-- **Disjunct-only alternative set construction** (Hamblin Or Rule,
     eqn 13 p. 213). For a disjunctive antecedent `A or B`,
@@ -105,10 +106,7 @@ theorem aoConditional_eq_sdaEval {W : Type*} [DecidableEq W] [Fintype W]
     decidability. No conjunction, no disjunctive closure, no
     Katzir-generated structural alternatives. This is the locality
     [santorio-2018] §III argues against. -/
-def aoAlternatives {W : Type*}
-    (A B : W → Prop) [DecidablePred A] [DecidablePred B] :
-    List (DecAlt W) :=
-  [⟨A, inferInstance⟩, ⟨B, inferInstance⟩]
+def aoAlternatives {W : Type*} (A B : Finset W) : List (Finset W) := [A, B]
 
 
 /-! ## §2.2.3 Universal force
@@ -124,15 +122,10 @@ inference (27a) ⊨ (27b) ∧ (27c). The Lean witness below uses
     derives from universal force over alternatives. Consequence of
     `sdaEval_iff_forall`. -/
 theorem ao_conjunction_inference {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (A B : W → Prop)
-    [DecidablePred A] [DecidablePred B] (C : W → Prop) [DecidablePred C]
-    (w : W) :
-    aoConditional sim (aoAlternatives A B) C w →
-    universalCounterfactual sim A C w ∧ universalCounterfactual sim B C w := by
-  intro h
-  have h' := (sdaEval_iff_forall sim (aoAlternatives A B) C w).mp h
-  exact ⟨h' ⟨A, inferInstance⟩ (by simp [aoAlternatives]),
-         h' ⟨B, inferInstance⟩ (by simp [aoAlternatives])⟩
+    (sim : SimilarityOrdering W) (A B : Finset W) (C : W → Prop) [DecidablePred C] (w : W)
+    (h : aoConditional sim (aoAlternatives A B) C w) :
+    universalCounterfactual sim (· ∈ A) C w ∧ universalCounterfactual sim (· ∈ B) C w :=
+  ⟨h A (by simp [aoAlternatives]), h B (by simp [aoAlternatives])⟩
 
 
 /-! ## §1 The divergence: Boolean `or` (`Coordinator.op .disj`) is the wrong meaning
@@ -161,9 +154,13 @@ theorem op_disj_eq_union :
     the meaning of `or` in a disjunctive antecedent: the alternatives must stay separate. -/
 theorem op_disj_overgenerates_disjunctive_counterfactual :
     universalCounterfactual cropSim (fun w => goodWeather w ∨ sunCold w) bumperCrop .actual ∧
-    ¬ aoConditional cropSim (aoAlternatives goodWeather sunCold) bumperCrop .actual := by
+    ¬ aoConditional cropSim
+      (aoAlternatives (Finset.univ.filter goodWeather) (Finset.univ.filter sunCold))
+      bumperCrop .actual := by
   refine ⟨bumperCrop_lewis_true, fun h => ?_⟩
+  have ⟨h₁, h₂⟩ := ao_conjunction_inference cropSim _ _ bumperCrop .actual h
   exact bumperCrop_conjunction_false
-    (ao_conjunction_inference cropSim goodWeather sunCold bumperCrop .actual h)
+    ⟨(universalCounterfactual_mem_filter _ _ _ _).1 h₁,
+     (universalCounterfactual_mem_filter _ _ _ _).1 h₂⟩
 
 end AlonsoOvalle2009

--- a/Linglib/Studies/BarLevFox2020.lean
+++ b/Linglib/Studies/BarLevFox2020.lean
@@ -2,7 +2,7 @@ import Linglib.Semantics.Exhaustification.Operators.Basic
 import Linglib.Semantics.Exhaustification.Operators.InnocentInclusion
 import Linglib.Semantics.Exhaustification.Operators.Decidable
 import Linglib.Semantics.Conditionals.Counterfactual
-import Linglib.Studies.Santorio2018
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
 
 /-!
 # Bar-Lev & Fox (2020) — Free Choice via Innocent Inclusion
@@ -760,14 +760,14 @@ theorem bar_lev_fox_sda :
 end SDA
 
 -- ============================================================================
--- §7. Cross-framework agreement: Bar-Lev/Fox SDA vs Santorio's `sdaEval`
+-- §7. Cross-framework agreement: Bar-Lev/Fox SDA vs Santorio's `Distributive`
 -- ============================================================================
 
 /-!
 ## The central debate Zani-Ciardelli-Sanfelici 2026 frames
 
 [santorio-2018] derives SDA via per-alternative homogeneity
-(`sdaEval` = universal over per-disjunct counterfactuals).
+(`Distributive` = universal over per-disjunct counterfactuals).
 [bar-lev-fox-2020] derives SDA via Innocent Inclusion
 (`exhIEII` over disjunct-replacement alternatives, asserting the
 non-IE conditional alternatives). The two mechanisms are RIVAL but
@@ -782,34 +782,34 @@ The cross-mechanism agreement theorem below makes this Lean-checkable.
 
 Bar-Lev/Fox's full verdict additionally entails `¬((p∧q)□→r)` (the
 IE-driven negation of the conjunctive alternative); Santorio's
-`sdaEval` does not entail this. So Bar-Lev/Fox is STRICTLY STRONGER
+`Distributive` does not entail this. So Bar-Lev/Fox is STRICTLY STRONGER
 than Santorio on this scenario — they agree on SDA, diverge on the
 extra negative conjunct.
 -/
 
-open Santorio2018
+open Semantics.Conditionals.Counterfactual (Distributive universalCounterfactual_mem_filter)
 
 /-- The SDA alternatives as `DecAlt SDAWorld`s for use in
-    [santorio-2018]'s `sdaEval` apparatus. -/
-def sdaSantorioAlts : List (DecAlt SDAWorld) :=
-  [⟨sdaP, inferInstance⟩, ⟨sdaQ, inferInstance⟩]
+    [santorio-2018]'s `Distributive` apparatus. -/
+def sdaSantorioAlts : List (Finset SDAWorld) :=
+  [Finset.univ.filter sdaP, Finset.univ.filter sdaQ]
 
 /-- **Cross-framework agreement on the SDA inference.**
     [bar-lev-fox-2020]'s `Exh^{IE+II}` verdict on the SDA prejacent
-    entails [santorio-2018]'s `sdaEval` verdict on the same scenario.
+    entails [santorio-2018]'s `Distributive` verdict on the same scenario.
 
     Direct application of the substrate-level multi-target cell-witness
     factorization `exhIEII_implies_cell_witnessed_alts` to the list of
     Santorio-style disjunct conditionals `[sdaPbox, sdaQbox]`. The
     factorization captures the abstract structural fact (any
     cell-witnessed alternatives are jointly entailed by `Exh^{IE+II}`);
-    the bridge to `sdaEval` is mechanical via `sdaEval_iff_forall`.
+    the bridge to `Distributive` is mechanical via `sdaEval_iff_forall`.
     Santorio is silent on the negative conjunct
     `¬((p∧q)□→r)` that Bar-Lev/Fox additionally derives — they coincide
     on the SDA inference proper, diverge on the negative component. -/
 theorem bar_lev_fox_sda_implies_santorio_sda_inference :
     ∀ w, exhIEII sdaALT sdaPrejacent w →
-      sdaEval sdaSim sdaSantorioAlts sdaR w := by
+      Distributive sdaSim sdaSantorioAlts sdaR w := by
   intro w h
   have h_targets := exhIEII_implies_cell_witnessed_alts sdaALT sdaPrejacent
     [sdaPbox, sdaQbox]
@@ -823,11 +823,10 @@ theorem bar_lev_fox_sda_implies_santorio_sda_inference :
         · exact sdaPbox_at_actual
         · exact sdaQbox_at_actual)
     w h
-  rw [sdaEval_iff_forall]
   intro a ha
   simp only [sdaSantorioAlts, List.mem_cons, List.not_mem_nil, or_false] at ha
   rcases ha with rfl | rfl
-  · exact h_targets sdaPbox (by simp)
+  · exact (universalCounterfactual_mem_filter _ _ _ _).2 (h_targets sdaPbox (by simp))
   · exact h_targets sdaQbox (by simp)
 
 -- ============================================================================

--- a/Linglib/Studies/CarianiGoldstein2020.lean
+++ b/Linglib/Studies/CarianiGoldstein2020.lean
@@ -1,4 +1,4 @@
-import Linglib.Studies.Santorio2018
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
 
 /-!
 # Cariani & Goldstein 2020 — "Conditional Heresies"
@@ -16,7 +16,7 @@ homogeneity accounts of the conditional. [zani-ciardelli-sanfelici-2026]
                 = 0   if ∀p ∈ Alt(A) : min_w(p) ⊆ ¬C
                 = undef otherwise
 
-This is **literally** Santorio 2018's `homogeneityEval` truth-table:
+This is **literally** Santorio 2018's `homogeneity` truth-table:
 TRUE iff every alternative simplification holds, FALSE iff every
 alternative simplification fails, GAP otherwise. The two accounts
 coincide on truth-conditional content and diverge primarily on
@@ -28,7 +28,7 @@ algorithm).
 
 This file establishes the truth-conditional coincidence as a
 near-`rfl` bridge: the C&G conditional verdict on a DAC equals
-Santorio's `homogeneityEval`. Worked examples that differentiate the
+Santorio's `homogeneity`. Worked examples that differentiate the
 two accounts (e.g., scope-of-`undef` for embedded conditionals, or the
 projection-vs-stability mechanism distinction) require infrastructure
 not yet present in linglib and are left as future work.
@@ -37,7 +37,7 @@ not yet present in linglib and are left as future work.
 namespace CarianiGoldstein2020
 
 open Semantics.Conditionals (SimilarityOrdering)
-open Santorio2018 (DecAlt homogeneityEval)
+open Semantics.Conditionals.Counterfactual (homogeneity)
 
 
 -- ════════════════════════════════════════════════════
@@ -49,9 +49,9 @@ open Santorio2018 (DecAlt homogeneityEval)
     p. 8: TRUE iff all alternative simplifications hold, FALSE iff all
     fail, undefined otherwise. -/
 def cgConditional {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (alts : List (DecAlt W))
+    (sim : SimilarityOrdering W) (alts : List (Finset W))
     (C : W → Prop) [DecidablePred C] (w : W) : Trivalent :=
-  homogeneityEval sim alts C w
+  homogeneity sim alts C w
 
 
 -- ════════════════════════════════════════════════════
@@ -59,16 +59,16 @@ def cgConditional {W : Type*} [DecidableEq W] [Fintype W]
 -- ════════════════════════════════════════════════════
 
 /-- **C&G ↔ Santorio coincidence.** [cariani-goldstein-2020]'s
-    trivalent conditional and [santorio-2018]'s `homogeneityEval`
+    trivalent conditional and [santorio-2018]'s `homogeneity`
     deliver the same verdict on every alternative set. The two accounts
     diverge on **mechanism** (projection vs. truthmaker stability) but
     agree on **truth-conditional content** — a load-bearing fact for
     the [zani-ciardelli-sanfelici-2026] acquisition study, which
     treats both as members of the homogeneity-of-DACs family. -/
-theorem cgConditional_eq_santorioHomogeneityEval {W : Type*}
+theorem cgConditional_eq_homogeneity {W : Type*}
     [DecidableEq W] [Fintype W] (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C] (w : W) :
-    cgConditional sim alts C w = homogeneityEval sim alts C w := rfl
+    (alts : List (Finset W)) (C : W → Prop) [DecidablePred C] (w : W) :
+    cgConditional sim alts C w = homogeneity sim alts C w := rfl
 
 
 end CarianiGoldstein2020

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -1,762 +1,213 @@
-import Mathlib.Data.List.Sublists
-import Linglib.Semantics.Conditionals.Counterfactual
-import Linglib.Core.Data.Trivalent
-import Linglib.Logic.Duality
-import Linglib.Semantics.Truthmaker.Inexact
-import Linglib.Semantics.Truthmaker.Basic
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
 import Linglib.Studies.McKayVanInwagen1977
+import Mathlib.Data.List.Sublists
 
 /-!
-# Santorio 2018 — Alternative-Sensitive Conditional Semantics
-[santorio-2018]
+# Santorio (2018): alternatives and truthmakers in conditional semantics
 
-Self-contained formalization of *Alternatives and truthmakers in
-conditional semantics*, *The Journal of Philosophy* 115(10): 513–549.
+[santorio-2018] starts from a trilemma: counterfactuals invalidate Antecedent
+Strengthening, validate Simplification of Disjunctive Antecedents, and validate
+Substitution of Logical Equivalents in the antecedent, yet with Boolean disjunction the
+last two entail the first. The paper keeps the first and gives up the other two by letting
+an *if*-clause denote the set of *truthmakers* of its antecedent: the conjunctive closures
+of the minimal stable subsets of the antecedent's alternatives that entail it, where a
+subset is stable when it is consistent with the negation of every alternative outside it
+(§5: `Stable`, `MinimalStable`, `truthmakers`). The conditional is a description of that
+set (§6): with the optional distributivity operator `DIST_π` it holds of each truthmaker,
+which is Simplification (`distributiveConditional`), and without it the modal *would*
+extracts the disjunctive closure, which is not (`collectiveConditional`); `DIST_π` carries
+the all-or-nothing homogeneity presupposition (`homogeneityPresup`). The readings are
+those of `Semantics/Conditionals/Counterfactual/Alternatives.lean` over the truthmakers.
 
-## Substrate consumption
-
-Built on `Conditionals.Counterfactual.universalCounterfactual` (the
-canonical [lewis-1973]/Kratzer universal counterfactual operator)
-and on `Truthmaker.ExactEntails` (= `≤` on `TMProp`,
-`Truthmaker/Inexact.lean`). Predicates are typed `Prop` with
-`DecidablePred` instances throughout — no Bool-vs-Prop adapters. The
-per-alternative apparatus uses `DecAlt W := Σ' A : W → Prop,
-DecidablePred A` to bundle decidability with each alternative
-predicate.
-
-## Sections
-
-- §1 Per-alternative evaluation (`altConditionalResults`)
-- §2 DIST_π and its resolutions (`homogeneityEval`, `sdaEval`,
-  `disjunctiveCounterfactual` = "would" extracts ⋁S, p. 547)
-- §3 Structural theorems
-- §4 Lewis bridge (alias to `universalCounterfactual` on disjunctive
-  closure)
-- §5 Truthmakers (`IsTruthmaker := ExactEntails` directly)
-- §6 Stability algorithm (§IV.2 p. 540): `isConsistent`, `isStable`,
-  `isMinimalStable`, `conjunctiveClosure`, `IsTruthmakerOf`
-- §7 Generic truthmaker lemmas
-- §8 Hyperintensionality / SLE failure (§VI)
-- §9 Otto/Anna stability worked example (pp. 535–537)
-- §10 Spain analysis on top of [mckay-vaninwagen-1977] data
-- §11 Cross-framework: Santorio classical truthmaker ≠ [jago-2026]
-  Fine-style content parthood
-
-## Faithfulness notes
-
-1. **DIST_π trivalent rendering.** Santorio's own DIST_π is
-   bivalent-with-presupposition (p. 547). Footnote 52 p. 545 explicitly
-   declines the trivalent collapse: "To switch to a Križ-style
-   framework, we would need to divorce homogeneity from the
-   distributivity operator and move to a trivalent semantics." We
-   render DIST_π via `Trivalent.Trivalent` / `distList` because it is
-   ergonomic and faithful on the all/none/mixed verdicts; the
-   divergence is in how the homogeneity failure is *typed* (gap vs.
-   presupposition failure).
-
-2. **Two readings, not three.** Santorio's binary architecture is SDA
-   (with DIST_π) vs. asymmetric/Lewis (without DIST_π — modal extracts
-   the disjunctive closure, p. 547). The "DCR" (Disjunctive Conditional
-   Reading) is **not** Santorio's term; it is named in
-   [zani-ciardelli-sanfelici-2026] (p. 10) and lives in that file.
-
-3. **Stability non-emptiness.** Santorio's definition (p. 540) does not
-   include a non-empty clause; he discharges the empty-σ case via the
-   entailment condition (ii) of the truthmaker definition (since
-   `⋀∅ = ⊤` does not entail typical S). The `σ.length > 0` clause in
-   `isMinimalStable` here is a Lean-side convenience yielding the same
-   truthmaker set.
-
-4. **Fox–Santorio relationship (footnote 40 p. 540).** Santorio
-   observes that minimal stability is "something like the converse" of
-   [fox-2007]'s **maximal exclusion** (note: not innocent
-   exclusion, which is the intersection of maximals). He does not say
-   "dual" and hedges. The general theorem
-   `santorio_minimal_stable_dual_to_fox_maximal_exclusion` is not
-   formalised; it requires either a witness-typed `IsMaximalExclusion`
-   predicate in `Semantics/Exhaustification/Innocent.lean`
-   (which currently exposes `IE` / `innocentlyExcludable` over
-   `Finset (Finset W)`) or a `Finset Nat ↔ List Nat` reflection.
-
-5. **Stability terminology.** Santorio writes `σ ∪ (ALT_S − σ)⁻ ⊭ ⊥`
-   ("consistent with the negation of every alternative", p. 540); this
-   file inlines the consistency check directly into `isStable` rather
-   than expose a separate `isConsistent` predicate.
-
-6. **`disjunctiveCounterfactual` and `would` (p. 547).** The
-   DIST_π-absent reading is named for the modal `would`, which "extracts
-   the disjunctive closure" `⋁S` of the alternative set. We name the
-   operator `disjunctiveCounterfactual` rather than `lewisDAC` because
-   p. 547 places this move in the lexical entry of `would`, not in
-   Lewis's metatheory.
-
-## Future work (load-bearing Santorio content not yet formalized)
-
-- **§II.2 Raffle / probability-operator argument (pp. 525–527)** —
-  Santorio's central anti-scalar argument. Requires a probability
-  operator scoping over a counterfactual; `Semantics/Conditionals/`
-  has no such operator at present.
-- **§II.3 Otto/Anna/Waldo non-closest-worlds (pp. 527–530)** —
-  refutes minimal-change. Requires a `WaldoWorld` enum with a tied-
-  closest-worlds similarity ordering.
-- **§IV.3 Karenina/W&P 8-alternative example (p. 538)** — shows
-  Santorio's stability algorithm is global (not local), distinguishing
-  it from Alonso-Ovalle 2009 (no bib entry yet).
-- **§V full lexical entries (p. 547)** — typed entries for `if`,
-  `would`, DIST_π. Requires typed-LF infrastructure.
-
-## Citations engaged in the formalization
-
-[lewis-1973] (universal counterfactual substrate),
-[kratzer-1981] / [kratzer-1991] / [kratzer-2012]
-(premise/restrictor semantics, sibling no-SDA tradition),
-[katzir-2007] (structural alternative generation, source of ALT_S),
-[kriz-spector-2021] (homogeneity-style trivalent option declined
-by fn 52 p. 545), [chierchia-2013] (domain alternatives, fn 40
-p. 540), [cariani-goldstein-2020] (sibling homogeneity account,
-see `CarianiGoldstein2020.lean`), [mckay-vaninwagen-1977] (Spain
-data, §10), [jago-2026] (Fine-style truthmaker contrast, §11).
-Santorio also engages Alonso-Ovalle 2009 (§III precursor, no bib
-entry yet), Klinedinst (scalar account refuted in §II, no bib entry
-yet), Schlenker 2004 ("Conditionals as Definite Descriptions" — the
-fn 24/47 descriptions analogy), and van Fraassen 1969 (truthmaker
-ancestor, fn 41) — adding these to `references.bib` is a bib-hygiene
-follow-up.
+On *Otto or Anna went to the party* (44) the truthmakers are *Otto went* and *Anna went*
+(`party_truthmakers`). On (35) *every student read War and Peace or Anna Karenina* the
+global algorithm finds the mixed truthmaker *some read Anna Karenina and some read War and
+Peace* that [alonso-ovalle-2009]'s disjunct alternatives cannot (`karenina_truthmakers`,
+`karenina_mixed_not_alonsoOvalle`), predicting the infelicity of (39). On
+[mckay-vaninwagen-1977]'s Spain case, the paper's (8), the collective parsing is true and
+the distributive one is not, so Antecedent Strengthening fails and Simplification is not
+validated (`spain_collective`, `spain_not_distributive`, `spain_homogeneity`); and on
+(57)–(58), logically equivalent antecedents whose *if*-clauses denote different sets
+receive different distributive verdicts (`substitution_fails`).
 -/
 
 namespace Santorio2018
 
-open Trivalent (distList)
 open Semantics.Conditionals (SimilarityOrdering)
-open Semantics.Conditionals.Counterfactual (universalCounterfactual)
-
-
-/-! ## Decidability-bundled alternatives -/
-
-/-- A propositional alternative on `W` paired with its decidability
-    witness. Used as the element type of alternative lists (`List (DecAlt W)`)
-    so that per-alternative `decide` calls compose without per-element
-    typeclass synthesis. -/
-abbrev DecAlt (W : Type*) := Σ' A : W → Prop, DecidablePred A
-
-namespace DecAlt
-variable {W : Type*}
-
-/-- Underlying predicate of a decidability-bundled alternative. -/
-def pred (a : DecAlt W) : W → Prop := a.1
-
-instance (a : DecAlt W) : DecidablePred a.pred := a.2
-
-end DecAlt
-
+open Semantics.Conditionals.Counterfactual
 
 variable {W : Type*} [DecidableEq W] [Fintype W]
 
+/-! ### The stability algorithm (§5) -/
 
--- ════════════════════════════════════════════════════
--- § 1. Per-Alternative Evaluation
--- ════════════════════════════════════════════════════
+/-- `σ` is stable with respect to the alternatives `alts`: some world verifies every member
+of `σ` and falsifies every other alternative. -/
+def Stable (alts σ : List (Finset W)) : Prop :=
+  ∃ w, (∀ A ∈ σ, w ∈ A) ∧ ∀ A ∈ alts, A ∉ σ → w ∉ A
 
-/-- Evaluate each alternative antecedent separately against closest
-    worlds via `universalCounterfactual`. Returns one Bool per
-    alternative: true iff all closest worlds for that alternative
-    satisfy the consequent. -/
-def altConditionalResults (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
-    (w : W) : List Bool :=
-  alts.map λ a => decide (universalCounterfactual sim a.pred C w)
+instance (alts σ : List (Finset W)) : Decidable (Stable alts σ) :=
+  inferInstanceAs (Decidable (∃ w, (∀ A ∈ σ, w ∈ A) ∧ ∀ A ∈ alts, A ∉ σ → w ∉ A))
 
+/-- A nonempty stable sublist of `alts` none of whose nonempty proper sublists is stable.
+(The empty set, stable whenever some world falsifies every alternative, is excluded.) -/
+def MinimalStable (alts σ : List (Finset W)) : Prop :=
+  σ ≠ [] ∧ σ.Sublist alts ∧ Stable alts σ ∧
+    ∀ τ ∈ σ.sublists, τ ≠ [] → τ ≠ σ → ¬ Stable alts τ
 
--- ════════════════════════════════════════════════════
--- § 2. DIST_π and Its Resolutions
--- ════════════════════════════════════════════════════
+instance (alts σ : List (Finset W)) : Decidable (MinimalStable alts σ) :=
+  inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ ∀ τ ∈ σ.sublists, _ → _ → ¬ Stable alts τ))
 
-/-- **DIST_π** (§V): distribute the consequent over antecedent
-    alternatives with a homogeneity presupposition. Rendered as `dist`
-    over per-alternative conditional results (faithfulness note 1). -/
-def homogeneityEval (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
-    (w : W) : Trivalent :=
-  distList (altConditionalResults sim alts C w) (· = true)
+/-- `⋀σ`. -/
+def conjunctiveClosure (σ : List (Finset W)) : Finset W := σ.foldr (· ∩ ·) Finset.univ
 
-/-- **SDA reading** (Simplification of Disjunctive Antecedents):
-    universal resolution of DIST_π. "If A or B, C" is true iff every
-    alternative simplification (if A, C) holds. -/
-def sdaEval (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
-    (w : W) : Prop :=
-  (altConditionalResults sim alts C w).all id = true
+/-- The truthmakers of `S` relative to `alts`: the conjunctive closures of the minimal stable
+subsets of `alts` that entail `S` — the denotation of the *if*-clause. -/
+def truthmakers (alts : List (Finset W)) (S : Finset W) : List (Finset W) :=
+  ((alts.sublists.filter fun σ => decide (MinimalStable alts σ)).map conjunctiveClosure).filter
+    fun p => decide (p ⊆ S)
 
-instance (sim : SimilarityOrdering W) (alts : List (DecAlt W))
-    (C : W → Prop) [DecidablePred C] (w : W) :
-    Decidable (sdaEval sim alts C w) :=
-  inferInstanceAs (Decidable (_ = true))
+theorem subset_of_mem_truthmakers {alts : List (Finset W)} {S p : Finset W}
+    (h : p ∈ truthmakers alts S) : p ⊆ S := by
+  simpa using (List.mem_filter.1 h).2
 
-/-- `sdaEval` unfolds to universal quantification over per-alternative
-    conditionals — Santorio's intended Simplification reading. -/
-theorem sdaEval_iff_forall (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C] (w : W) :
-    sdaEval sim alts C w ↔
-    ∀ a ∈ alts, universalCounterfactual sim a.pred C w := by
-  unfold sdaEval altConditionalResults
-  simp [List.all_map, List.all_eq_true, decide_eq_true_eq]
+/-- The disjunctive closure of the truthmakers is at most the antecedent. -/
+theorem disjunctiveClosure_truthmakers_subset (alts : List (Finset W)) (S : Finset W) :
+    disjunctiveClosure (truthmakers alts S) ⊆ S := fun _ hx =>
+  let ⟨_, hp, hxp⟩ := (mem_disjunctiveClosure _).1 hx
+  subset_of_mem_truthmakers hp hxp
 
-/-- **Disjunctive closure** of an alternative set: `⋁S = λw. ∃A ∈ S, A w`.
-    Per §V p. 547, the lexical entry for `would` extracts this when
-    DIST_π is absent. -/
-def disjunctiveClosure (alts : List (DecAlt W)) (w : W) : Prop :=
-  ∃ a ∈ alts, a.pred w
+/-! ### Conditionals as descriptions (§6) -/
 
-instance (alts : List (DecAlt W)) (w : W) :
-    Decidable (disjunctiveClosure alts w) :=
-  inferInstanceAs (Decidable (∃ a ∈ alts, _))
+variable (sim : SimilarityOrdering W) (alts : List (Finset W)) (S : Finset W) (C : W → Prop)
+  [DecidablePred C] (w : W)
 
-instance (alts : List (DecAlt W)) :
-    DecidablePred (disjunctiveClosure alts) :=
-  fun _ => inferInstance
+/-- `[if φ] DIST_π [would ψ]`: the counterfactual holds of every truthmaker of `φ`. -/
+def distributiveConditional : Prop := Distributive sim (truthmakers alts S) C w
 
-/-- **DIST_π-absent reading** (§V p. 547): the modal `would` extracts
-    the disjunctive closure of the alternatives, evaluating min_w(⋁S)
-    against C. Reduces to [lewis-1973]'s universal counterfactual
-    on the disjunctive closure. -/
-def disjunctiveCounterfactual (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
-    (w : W) : Prop :=
-  universalCounterfactual sim (disjunctiveClosure alts) C w
+/-- The homogeneity presupposition of `DIST_π`: every truthmaker's counterfactual holds, or
+none does. -/
+def homogeneityPresup : Trivalent := homogeneity sim (truthmakers alts S) C w
 
+/-- `[if φ] would ψ` without `DIST_π`: the modal extracts the disjunctive closure of the
+truthmakers. -/
+def collectiveConditional : Prop := would sim (truthmakers alts S) C w
 
--- ════════════════════════════════════════════════════
--- § 3. Structural Theorems
--- ════════════════════════════════════════════════════
+instance : Decidable (distributiveConditional sim alts S C w) :=
+  inferInstanceAs (Decidable (Distributive sim (truthmakers alts S) C w))
 
-/-- SDA = homogeneity resolves to TRUE. -/
-theorem sda_iff_homogeneity_true (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C] (w : W) :
-    sdaEval sim alts C w ↔ homogeneityEval sim alts C w = .true := by
-  unfold sdaEval homogeneityEval Trivalent.distList
-  generalize altConditionalResults sim alts C w = rs
-  refine ⟨fun h => ?_, fun h => ?_⟩
-  · have hall : ∀ b ∈ rs, b = true := by
-      intro b hb
-      have := List.all_eq_true.mp h b hb
-      simpa using this
-    rw [if_pos hall]
-  · by_contra hc
-    have hnall : ¬ (∀ b ∈ rs, b = true) := by
-      intro hall
-      apply hc
-      exact List.all_eq_true.mpr hall
-    rw [if_neg hnall] at h
-    split_ifs at h <;> cases h
+instance : Decidable (collectiveConditional sim alts S C w) :=
+  inferInstanceAs (Decidable (would sim (truthmakers alts S) C w))
 
+/-! ### Otto and Anna (44) -/
 
--- ════════════════════════════════════════════════════
--- § 4. Lewis Bridge
--- ════════════════════════════════════════════════════
+/-- Who went to the party. -/
+inductive Party where
+  | ottoOnly
+  | annaOnly
+  | both
+  | neither
+  deriving DecidableEq, Fintype
 
-/-- `disjunctiveCounterfactual` IS [lewis-1973]'s universal
-    counterfactual on the disjunctive closure of the alternatives.
-    Definitionally true; named for explicit cross-framework consumption. -/
-theorem disjunctiveCounterfactual_eq_universalCounterfactual_disjunctiveClosure
-    (sim : SimilarityOrdering W) (alts : List (DecAlt W))
-    (C : W → Prop) [DecidablePred C] (w : W) :
-    disjunctiveCounterfactual sim alts C w =
-    universalCounterfactual sim (disjunctiveClosure alts) C w := rfl
+abbrev otto : Finset Party := {.ottoOnly, .both}
+abbrev anna : Finset Party := {.annaOnly, .both}
 
+/-- (45): the alternatives to *Otto or Anna went to the party*. -/
+def partyAlts : List (Finset Party) := [otto ∪ anna, otto, anna, otto ∩ anna]
 
--- ════════════════════════════════════════════════════
--- § 5. Truthmakers (§IV.2 p. 540)
--- ════════════════════════════════════════════════════
+/-- The truthmakers of (44) are *Otto went* and *Anna went*: the minimal stable subsets are
+`{O ∨ A, O}` and `{O ∨ A, A}`. -/
+theorem party_truthmakers : (truthmakers partyAlts (otto ∪ anna)).toFinset = {otto, anna} := by
+  decide
 
-/-- Entailment condition for truthmakers: p entails S.
+/-! ### Every student read War and Peace or Anna Karenina (35) -/
 
-    Defined directly as `Truthmaker.ExactEntails` from
-    `Truthmaker/Inexact.lean` (= `≤` on `TMProp`). Santorio is explicit
-    (p. 515) that his truthmakers are "cognitive rather than
-    metaphysical" and determined by syntactic alternatives, so the
-    classical world-extensional formulation is faithful.
+/-- Which of the two books the students read. -/
+inductive Reading where
+  | none
+  | everyAK
+  | everyWP
+  | mixed
+  | everyBoth
+  deriving DecidableEq, Fintype
 
-    The Up clause that distinguishes Fine's `IsContentPart` from this
-    Down-only relation is **not** part of Santorio's notion; the
-    inequivalence with Fine is refuted in
-    `santorio_truthmaker_neq_fine_content_part` below. -/
-abbrev IsTruthmaker {W : Type*} (p S : W → Prop) : Prop :=
-  Semantics.Truthmaker.ExactEntails p S
+abbrev everyA : Finset Reading := {.everyAK, .everyBoth}
+abbrev everyW : Finset Reading := {.everyWP, .everyBoth}
+abbrev everyAorW : Finset Reading := {.everyAK, .everyWP, .mixed, .everyBoth}
+abbrev someA : Finset Reading := {.everyAK, .mixed, .everyBoth}
+abbrev someW : Finset Reading := {.everyWP, .mixed, .everyBoth}
+/-- `∃(A ∨ W)`, which coincides with `∀(A ∨ W)` on these five worlds. -/
+abbrev someAorW : Finset Reading := everyAorW
 
+/-- The alternatives to (35): the universal and existential claims over `A ∧ W`, `A`, `W`,
+`A ∨ W`. -/
+def readingAlts : List (Finset Reading) :=
+  [everyA ∩ everyW, everyA, everyW, everyAorW, someA ∩ someW, someA, someW, someAorW]
 
--- ════════════════════════════════════════════════════
--- § 6. Stability Algorithm (§IV.2 p. 540)
--- ════════════════════════════════════════════════════
+/-- (35) has three truthmakers: *every student read AK*, *every student read W&P*, and the
+mixed *some read AK and some read W&P*. -/
+theorem karenina_truthmakers :
+    (truthmakers readingAlts everyAorW).toFinset = {everyA, everyW, someA ∩ someW} := by
+  decide
 
-/-- Stability (p. 540): a subset σ (given by indices into `alts`) is
-    stable iff some world satisfies every in-σ alternative AND falsifies
-    every out-of-σ alternative. (Santorio's `σ ∪ (ALT_S − σ)⁻ ⊭ ⊥`,
-    "consistent" in his prose p. 540.) -/
-def isStable (alts : List (DecAlt W)) (σ : List Nat) : Prop :=
-  ∃ w : W,
-    (∀ i, ∀ h : i < alts.length, i ∈ σ → (alts[i]'h).pred w) ∧
-    (∀ i, ∀ h : i < alts.length, i ∉ σ → ¬ (alts[i]'h).pred w)
+/-- The mixed truthmaker is realized where no universal alternative is: [alonso-ovalle-2009]'s
+disjunct alternatives `{∀A, ∀W}` miss the way for (35) to be true that makes (39) infelicitous. -/
+theorem karenina_mixed_not_alonsoOvalle :
+    Reading.mixed ∈ someA ∩ someW ∧ Reading.mixed ∉ everyA ∧ Reading.mixed ∉ everyW := by
+  decide
 
-instance (alts : List (DecAlt W)) (σ : List Nat) :
-    Decidable (isStable alts σ) := by
-  unfold isStable; exact inferInstance
+/-! ### Spain (8), on [mckay-vaninwagen-1977] -/
 
-/-- Minimal stability (p. 540): non-empty (Lean-side, faithfulness
-    note 3), stable, and no non-empty proper subset is stable. -/
-def isMinimalStable (alts : List (DecAlt W)) (σ : List Nat) : Prop :=
-  σ.length > 0 ∧
-  isStable alts σ ∧
-  ∀ τ ∈ σ.sublists,
-    τ.length = 0 ∨ τ.length = σ.length ∨ ¬ isStable alts τ
+section Spain
 
-instance (alts : List (DecAlt W)) (σ : List Nat) :
-    Decidable (isMinimalStable alts σ) := by
-  unfold isMinimalStable; exact inferInstance
+open McKayVanInwagen1977 (SpainWorld spainSim foughtAxis foughtAllies)
 
-/-- Conjunctive closure: ⋀σ = λw. ∀i ∈ σ, alts[i](w). -/
-def conjunctiveClosure (alts : List (DecAlt W)) (σ : List Nat) :
-    W → Prop :=
-  fun w => ∀ i, ∀ h : i < alts.length, i ∈ σ → (alts[i]'h).pred w
+abbrev axis : Finset SpainWorld := Finset.univ.filter foughtAxis
+abbrev allies : Finset SpainWorld := Finset.univ.filter foughtAllies
 
-instance (alts : List (DecAlt W)) (σ : List Nat) :
-    DecidablePred (conjunctiveClosure alts σ) := fun _ =>
-  inferInstanceAs (Decidable (∀ _, _))
+/-- The alternatives to *Spain fought with the Axis or the Allies*. -/
+def spainAlts : List (Finset SpainWorld) := [axis ∪ allies, axis, allies, axis ∩ allies]
 
-/-- Full truthmaker definition (p. 540): σ witnesses that its
-    conjunctive closure is a truthmaker of S iff (i) σ is a minimal
-    stable subset of ALT_S, and (ii) ⋀σ entails S. -/
-structure IsTruthmakerOf (alts : List (DecAlt W)) (S : W → Prop)
-    (σ : List Nat) : Prop where
-  /-- Condition (i): σ is a minimal stable subset of ALT_S. -/
-  minimal_stable : isMinimalStable alts σ
-  /-- Condition (ii): ⋀σ entails S (the truthmaker entailment). -/
-  closure_entails : IsTruthmaker (conjunctiveClosure alts σ) S
+/-- Collectively, (8) is true: the closest world where Spain fought with either is the Axis
+world. Strengthening the antecedent to *the Allies* makes it false — Antecedent
+Strengthening fails. -/
+theorem spain_collective :
+    collectiveConditional spainSim spainAlts (axis ∪ allies) foughtAxis .actual ∧
+      ¬ universalCounterfactual spainSim (· ∈ allies) foughtAxis .actual := by
+  decide
 
+/-- Distributively, (8) is false: the Allies truthmaker's counterfactual fails, so
+Simplification is not validated by the collective parsing. -/
+theorem spain_not_distributive :
+    ¬ distributiveConditional spainSim spainAlts (axis ∪ allies) foughtAxis .actual := by
+  decide
 
--- ════════════════════════════════════════════════════
--- § 7. Generic Truthmaker Lemmas
--- ════════════════════════════════════════════════════
+/-- The homogeneity presupposition of the distributive parsing fails on (8). -/
+theorem spain_homogeneity :
+    homogeneityPresup spainSim spainAlts (axis ∪ allies) foughtAxis .actual = .indet := by
+  decide
 
-/-- Each disjunct is a truthmaker of the disjunction. -/
-theorem disjunct_is_truthmaker {W : Type*} (A B : W → Prop) :
-    IsTruthmaker A (fun w => A w ∨ B w) :=
-  fun _ => Or.inl
+end Spain
 
-/-- Conjunction of disjuncts is a truthmaker of the disjunction. -/
-theorem conj_disjuncts_is_truthmaker {W : Type*} (A B : W → Prop) :
-    IsTruthmaker (fun w => A w ∧ B w) (fun w => A w ∨ B w) :=
-  fun _ ⟨hA, _⟩ => Or.inl hA
+/-! ### Substitution of Logical Equivalents (57)–(58) -/
 
-
--- ════════════════════════════════════════════════════
--- § 8. Hyperintensionality (§VI — SLE Failure)
--- ════════════════════════════════════════════════════
-
-/-!
-Logically equivalent antecedents can yield different conditional truth
-values because they generate different alternatives. This drops
-**Substitution of Logical Equivalents (SLE)** (Constraint #3 p. 514).
--/
-
-section Hyperintensional
-
-private inductive PartyW where | actual | annaOnly | both | ottoOnly
-  deriving Repr, DecidableEq
-
-private instance : Fintype PartyW where
-  elems := {.actual, .annaOnly, .both, .ottoOnly}
-  complete x := by cases x <;> simp
-
-private def partySim : SimilarityOrdering PartyW := .ofBool
-  (fun _ w₁ w₂ => w₁ == w₂ ||
-    (w₁ == .annaOnly && w₂ != .actual) ||
+/-- Closeness for the party: the Anna-only world is closest to the actual world, then the
+world where both came, then Otto's. -/
+def partySim : SimilarityOrdering Party := .ofBool
+  (fun _ w₁ w₂ => w₁ == w₂ || (w₁ == .annaOnly && w₂ != .neither) ||
     (w₁ == .both && w₂ == .ottoOnly))
   (by decide) (by decide)
 
-private def annaCame (w : PartyW) : Prop := w = .annaOnly ∨ w = .both
-private def ottoAndAnnaCame (w : PartyW) : Prop := w = .both
-private def partyFun (w : PartyW) : Prop := w = .annaOnly
+/-- *The party was fun*: only when Anna came alone. -/
+abbrev partyFun : Finset Party := {.annaOnly}
 
-private instance : DecidablePred annaCame := fun w => by
-  unfold annaCame; exact inferInstance
-private instance : DecidablePred ottoAndAnnaCame := fun w => decEq w .both
-private instance : DecidablePred partyFun := fun w => decEq w .annaOnly
-
-private def annaCameAlt : DecAlt PartyW := ⟨annaCame, inferInstance⟩
-private def ottoAndAnnaCameAlt : DecAlt PartyW := ⟨ottoAndAnnaCame, inferInstance⟩
-
-theorem antecedents_equivalent :
-    ∀ w : PartyW, annaCame w ↔ (annaCame w ∨ ottoAndAnnaCame w) := by
-  intro w; cases w <;> simp [annaCame, ottoAndAnnaCame]
-
-theorem simple_antecedent_true :
-    sdaEval partySim [annaCameAlt] partyFun .actual := by decide
-
-theorem disjunctive_antecedent_false :
-    ¬ sdaEval partySim [annaCameAlt, ottoAndAnnaCameAlt] partyFun .actual := by
+/-- (57) *If Anna came, the party would be fun* and (58) *If Anna, or Otto and Anna, came,
+the party would be fun* have logically equivalent antecedents, yet with the *if*-clauses
+denoting `{Anna came}` and `{Anna came, Otto and Anna came}` the distributive parsing makes
+(57) true and (58) false. -/
+theorem substitution_fails :
+    anna = anna ∪ (otto ∩ anna) ∧
+      Distributive partySim [anna] (· ∈ partyFun) .neither ∧
+      ¬ Distributive partySim [anna, otto ∩ anna] (· ∈ partyFun) .neither := by
   decide
-
-/-- **Hyperintensionality** / **SLE Failure** (Constraint #3 p. 514). -/
-theorem sle_fails :
-    (∀ w : PartyW, annaCame w ↔ (annaCame w ∨ ottoAndAnnaCame w)) ∧
-    (sdaEval partySim [annaCameAlt] partyFun .actual ∧
-     ¬ sdaEval partySim [annaCameAlt, ottoAndAnnaCameAlt] partyFun .actual) :=
-  ⟨antecedents_equivalent, ⟨simple_antecedent_true, disjunctive_antecedent_false⟩⟩
-
-end Hyperintensional
-
-
--- ════════════════════════════════════════════════════
--- § 9. Otto/Anna Stability Worked Example (pp. 535–537)
--- ════════════════════════════════════════════════════
-
-/-!
-S = "Otto or Anna went to the party" = O ∨ A.
-ALT_S = {O∨A, O, A, O∧A} (p. 536).
-Stable: {O∨A, O}, {O∨A, A}, ALT_S. Minimal stable: {O∨A, O}, {O∨A, A}.
-Truthmakers: O and A (p. 537).
--/
-
-section OttoAnna
-
-private inductive OAWorld where
-  | ottoOnly | annaOnly | both | neither
-  deriving Repr, DecidableEq
-
-private instance : Fintype OAWorld where
-  elems := {.ottoOnly, .annaOnly, .both, .neither}
-  complete x := by cases x <;> simp
-
-private def ottoWent (w : OAWorld) : Prop := w = .ottoOnly ∨ w = .both
-private def annaWent (w : OAWorld) : Prop := w = .annaOnly ∨ w = .both
-private def ottoOrAnna (w : OAWorld) : Prop := w ≠ .neither
-private def ottoAndAnna (w : OAWorld) : Prop := w = .both
-
-private instance : DecidablePred ottoWent := fun w => by
-  unfold ottoWent; exact inferInstance
-private instance : DecidablePred annaWent := fun w => by
-  unfold annaWent; exact inferInstance
-private instance : DecidablePred ottoOrAnna := fun w => by
-  unfold ottoOrAnna; exact inferInstance
-private instance : DecidablePred ottoAndAnna := fun w => decEq w .both
-
-private def oaAlts : List (DecAlt OAWorld) :=
-  [⟨ottoOrAnna, inferInstance⟩,
-   ⟨ottoWent, inferInstance⟩,
-   ⟨annaWent, inferInstance⟩,
-   ⟨ottoAndAnna, inferInstance⟩]
-
-theorem oa_singleton_not_stable :
-    ¬ isStable oaAlts [0] := by decide
-
-theorem oa_otto_stable :
-    isStable oaAlts [0, 1] := by decide
-
-theorem oa_anna_stable :
-    isStable oaAlts [0, 2] := by decide
-
-theorem oa_conj_not_stable :
-    ¬ isStable oaAlts [0, 3] := by decide
-
-theorem oa_otto_minimal :
-    isMinimalStable oaAlts [0, 1] := by decide
-
-theorem oa_anna_minimal :
-    isMinimalStable oaAlts [0, 2] := by decide
-
-end OttoAnna
-
-
--- ════════════════════════════════════════════════════
--- § 10. Spain Analysis on Top of McKay & Van Inwagen 1977
--- ════════════════════════════════════════════════════
-
-/-!
-Per CLAUDE.md "chronological dependency": this 2018 study consumes
-[mckay-vaninwagen-1977]'s 1977 data (worlds, similarity
-ordering, disjunct predicates).
--/
-
-private def spainAlts : List (DecAlt McKayVanInwagen1977.SpainWorld) :=
-  [⟨McKayVanInwagen1977.foughtAxis, inferInstance⟩,
-   ⟨McKayVanInwagen1977.foughtAllies, inferInstance⟩]
-
-/-- [santorio-2018]'s homogeneity verdict on the
-    [mckay-vaninwagen-1977] Spain scenario: `.indet` (mixed
-    results across the two alternatives), demonstrating the `Trivalent`
-    middle column. -/
-theorem spain_homogeneity_gap :
-    homogeneityEval McKayVanInwagen1977.spainSim
-      spainAlts McKayVanInwagen1977.foughtAxis .actual = .indet := by decide
-
-/-- [santorio-2018]'s SDA verdict on the same scenario: FALSE
-    (the Allies simplification fails). -/
-theorem spain_sda_false :
-    ¬ sdaEval McKayVanInwagen1977.spainSim
-      spainAlts McKayVanInwagen1977.foughtAxis .actual := by decide
-
-
--- ════════════════════════════════════════════════════
--- § 11. Santorio Truthmaker ≠ Fine Content Parthood
--- ════════════════════════════════════════════════════
-
-/-!
-[santorio-2018]'s `IsTruthmaker` is `ExactEntails` from
-`Truthmaker/Inexact.lean` (the Down clause only). Fine-style
-`IsContentPart` adds the Up clause: every part of the truthmade
-proposition extends to a part of the truthmaker. The two relations are
-non-equivalent.
--/
-
-/-- **Santorio truthmaker ≠ Fine content parthood**: there exist
-    propositions `p`, `S` such that Santorio's classical truthmaker
-    relation (= `ExactEntails`) holds but Fine's `IsContentPart` (Down
-    + Up) fails. Witness: over `Nat` with the usual order, take
-    `p = (· = 5)` and `S = (· < 10)`. -/
-theorem santorio_truthmaker_neq_fine_content_part :
-    ∃ (p S : Semantics.Truthmaker.TMProp Nat),
-      Semantics.Truthmaker.ExactEntails p S ∧
-      ¬ Semantics.Truthmaker.IsContentPart p S := by
-  refine ⟨(· = 5), (· < 10), ?_, ?_⟩
-  · intro s hs; subst hs; decide
-  · intro ⟨hsub, _⟩
-    obtain ⟨t, ht, hle⟩ := hsub 0 (by decide)
-    omega
-
-
--- ════════════════════════════════════════════════════
--- § 12. The Three Constraints (pp. 513-514)
--- ════════════════════════════════════════════════════
-
-/-!
-[santorio-2018]'s introduction (pp. 513–514) lists three
-constraints on classical counterfactual logic that the paper refutes:
-
-- **Constraint #1**: Antecedent Strengthening — `(A □→ C) ⊨ (A ∧ B) □→ C`
-- **Constraint #2**: Simplification of Disjunctive Antecedents (SDA) —
-  `(A ∨ B) □→ C ⊨ A □→ C ∧ B □→ C`
-- **Constraint #3**: Substitution of Logical Equivalents (SLE)
-
-The Spain analysis (§10) refutes Constraint #1 via
-[mckay-vaninwagen-1977] data; `sle_fails` (§8) refutes
-Constraint #3. Constraint #2 is engaged throughout (it IS the central
-phenomenon under DIST_π) — the theorem below states it as a structural
-witness anchored to the named constraint.
--/
-
-/-- **Constraint #2 = SDA**: under DIST_π, the alternative-sensitive
-    semantics validates SDA. If the per-alternative SDA-evaluation
-    holds, then each individual simplification holds. Direct
-    consequence of `sdaEval_iff_forall`. -/
-theorem santorio_constraint_2_sda (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C] (w : W)
-    (h : sdaEval sim alts C w) :
-    ∀ a ∈ alts, universalCounterfactual sim a.pred C w :=
-  (sdaEval_iff_forall sim alts C w).mp h
-
-
--- ════════════════════════════════════════════════════
--- § 13. Cross-Framework Divergences
--- ════════════════════════════════════════════════════
-
-/-!
-Per CLAUDE.md "no bridge files": cross-framework contrasts go inside
-the chronologically-later study. Santorio 2018 is the latest of
-{Lewis 1973, Stalnaker 1968, Kratzer 1981, McKay & Van Inwagen 1977}
-that this file engages, so the divergence theorems live here.
--/
-
-open Semantics.Conditionals.Counterfactual (homogeneityCounterfactual PresupResult PresupStatus)
-
-section KareninaWP
-
-/-! ### Santorio vs. Alonso-Ovalle on Karenina/W&P (§IV.3 pp. 537–539)
-
-For the prejacent **(35)** "Every student read War and Peace or
-Anna Karenina", [santorio-2018]'s stability algorithm (running
-on Katzir-generated 8-alternative ALT_S, eqn (48) p. 538) identifies
-**three** minimal-stable subsets, each yielding one truthmaker:
-
-- σ₁ = {∀(A), ∀(A∨W), ∃(A), ∃(A∨W)} → "every student read AK"
-- σ₂ = {∀(W), ∀(A∨W), ∃(W), ∃(A∨W)} → "every student read W&P"
-- σ₃ = {∀(A∨W), ∃(A), ∃(W), ∃(A∨W)} → "**some** students read AK
-  and **some** students read W&P" (the **mixed truthmaker**)
-
-[alonso-ovalle-2009]'s pointwise computation (running only on
-the disjunct alternatives `{∀(A), ∀(W)}` per his Or Rule (10) p. 212)
-identifies only **two** truthmakers (the universals); the mixed
-truthmaker is invisible to AO's local algorithm.
-
-[santorio-2018]'s example (39) p. 539:
-"If every student read AK or W&P, the world would be a better place.
- **But if some students read AK and some read W&P, the world would
- not be a better place.**"
-is felicitous ONLY if the second clause's antecedent is a truthmaker
-of the first clause's antecedent — which it is on Santorio's
-algorithm but not on AO's. Hence Santorio: "a theory based on the
-stability algorithm has an empirical advantage over Hamblin-style
-semantics" (p. 539).
-
-`KareninaWorld` enumerates the 5 worlds needed to evaluate the 8
-alternatives. The mixed truthmaker is realized at `.mixed`. -/
-
-private inductive KareninaWorld where
-  | actual     -- no student reads any book
-  | everyAK    -- every student reads (only) AK
-  | everyWP    -- every student reads (only) W&P
-  | mixed      -- some students read AK only, others read W&P only (no overlap)
-  | everyBoth  -- every student reads both AK and W&P
-  deriving Repr, DecidableEq
-
-private instance : Fintype KareninaWorld where
-  elems := {.actual, .everyAK, .everyWP, .mixed, .everyBoth}
-  complete x := by cases x <;> simp
-
-/-! ### Alternative predicates per [santorio-2018] (48) p. 538 -/
-
-/-- ∀(A∧W) — every student read both AK and W&P. -/
-private def everyReadAandW (w : KareninaWorld) : Prop := w = .everyBoth
-/-- ∀(A) — every student read AK. -/
-private def everyReadA (w : KareninaWorld) : Prop :=
-  w = .everyAK ∨ w = .everyBoth
-/-- ∀(W) — every student read W&P. -/
-private def everyReadW (w : KareninaWorld) : Prop :=
-  w = .everyWP ∨ w = .everyBoth
-/-- ∀(A∨W) — the prejacent: every student read at least one of {AK, W&P}. -/
-private def everyReadAorW (w : KareninaWorld) : Prop := w ≠ .actual
-/-- ∃(A∧W) — some student read both. -/
-private def someReadAandW (w : KareninaWorld) : Prop := w = .everyBoth
-/-- ∃(A) — some student read AK. -/
-private def someReadA (w : KareninaWorld) : Prop :=
-  w = .everyAK ∨ w = .mixed ∨ w = .everyBoth
-/-- ∃(W) — some student read W&P. -/
-private def someReadW (w : KareninaWorld) : Prop :=
-  w = .everyWP ∨ w = .mixed ∨ w = .everyBoth
-/-- ∃(A∨W) — some student read at least one. -/
-private def someReadAorW (w : KareninaWorld) : Prop := w ≠ .actual
-
-private instance : DecidablePred everyReadAandW := fun w => decEq w .everyBoth
-private instance : DecidablePred everyReadA := fun w => by
-  unfold everyReadA; exact inferInstance
-private instance : DecidablePred everyReadW := fun w => by
-  unfold everyReadW; exact inferInstance
-private instance : DecidablePred everyReadAorW := fun w => by
-  unfold everyReadAorW; exact inferInstance
-private instance : DecidablePred someReadAandW := fun w => decEq w .everyBoth
-private instance : DecidablePred someReadA := fun w => by
-  unfold someReadA; exact inferInstance
-private instance : DecidablePred someReadW := fun w => by
-  unfold someReadW; exact inferInstance
-private instance : DecidablePred someReadAorW := fun w => by
-  unfold someReadAorW; exact inferInstance
-
-/-- ALT_S per [santorio-2018] (48) p. 538: the 8 Katzir-
-    generated structural alternatives for "every student read AK or
-    W&P". Index map: 0=∀(A∧W), 1=∀(A), 2=∀(W), 3=∀(A∨W) [prejacent],
-    4=∃(A∧W), 5=∃(A), 6=∃(W), 7=∃(A∨W). -/
-private def kareninaAlts : List (DecAlt KareninaWorld) :=
-  [⟨everyReadAandW, inferInstance⟩,
-   ⟨everyReadA, inferInstance⟩,
-   ⟨everyReadW, inferInstance⟩,
-   ⟨everyReadAorW, inferInstance⟩,
-   ⟨someReadAandW, inferInstance⟩,
-   ⟨someReadA, inferInstance⟩,
-   ⟨someReadW, inferInstance⟩,
-   ⟨someReadAorW, inferInstance⟩]
-
-/-- σ₁ = {∀(A), ∀(A∨W), ∃(A), ∃(A∨W)} — the AK-truthmaker subset. -/
-private def kareninaSigmaAK : List Nat := [1, 3, 5, 7]
-/-- σ₂ = {∀(W), ∀(A∨W), ∃(W), ∃(A∨W)} — the W&P-truthmaker subset. -/
-private def kareninaSigmaWP : List Nat := [2, 3, 6, 7]
-/-- σ₃ = {∀(A∨W), ∃(A), ∃(W), ∃(A∨W)} — the **mixed** truthmaker
-    subset. The conjunctive closure characterises worlds where every
-    student reads at least one book AND some students read AK AND
-    some students read W&P. -/
-private def kareninaSigmaMixed : List Nat := [3, 5, 6, 7]
-
-/-! ### The three minimal-stable subsets (p. 539) -/
-
-theorem karenina_sigmaAK_minimal :
-    isMinimalStable kareninaAlts kareninaSigmaAK := by decide
-
-theorem karenina_sigmaWP_minimal :
-    isMinimalStable kareninaAlts kareninaSigmaWP := by decide
-
-theorem karenina_sigmaMixed_minimal :
-    isMinimalStable kareninaAlts kareninaSigmaMixed := by decide
-
-/-! ### Truthmaker realizations -/
-
-/-- The AK-truthmaker is realized at `.everyAK` (and at `.everyBoth`). -/
-theorem karenina_sigmaAK_realized_at_everyAK :
-    conjunctiveClosure kareninaAlts kareninaSigmaAK .everyAK := by decide
-
-/-- The W&P-truthmaker is realized at `.everyWP` (and at `.everyBoth`). -/
-theorem karenina_sigmaWP_realized_at_everyWP :
-    conjunctiveClosure kareninaAlts kareninaSigmaWP .everyWP := by decide
-
-/-- **The mixed truthmaker is realized at `.mixed`** — the load-bearing
-    fact distinguishing [santorio-2018] from
-    [alonso-ovalle-2009]. At `.mixed`, every student reads at
-    least one book, some students read AK, some students read W&P, and
-    no student reads both. -/
-theorem karenina_sigmaMixed_realized_at_mixed :
-    conjunctiveClosure kareninaAlts kareninaSigmaMixed .mixed := by decide
-
-/-! ### The cross-framework theorem -/
-
-/-- **Santorio finds the mixed truthmaker; Alonso-Ovalle 2009 cannot.**
-
-    [alonso-ovalle-2009]'s alternative set for the prejacent
-    "every student read AK or W&P" is just the two disjunct universals
-    `{∀(A), ∀(W)}` (from the Hamblin Or Rule (10) p. 212 plus the
-    universal force §2.2.3 p. 218). At the `.mixed` world neither AO
-    alternative holds. But [santorio-2018]'s `kareninaSigmaMixed`
-    truthmaker IS realized at `.mixed`. AO's pointwise alternative
-    generation thus undergenerates the truthmaker set: the mixed-
-    reading way for the antecedent to be true is invisible to AO but
-    visible to Santorio. This is the empirical advantage Santorio
-    claims at p. 539. -/
-theorem santorio_finds_mixed_truthmaker_ao_misses_it :
-    -- Santorio's algorithm finds the mixed truthmaker
-    isMinimalStable kareninaAlts kareninaSigmaMixed ∧
-    conjunctiveClosure kareninaAlts kareninaSigmaMixed .mixed ∧
-    -- But AO's alternative set has neither universal true at .mixed
-    ¬ everyReadA .mixed ∧
-    ¬ everyReadW .mixed := by
-  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
-
-end KareninaWP
-
-
-/-- **Santorio vs. von Fintel/Križ on Spain.** The two homogeneity
-    moves differ on cross-alternative aggregation:
-
-    - Santorio per-alternative homogeneity over `[foughtAxis,
-      foughtAllies]` yields `.indet` (mixed verdicts: Axis simplification
-      true, Allies simplification false).
-    - Von Fintel/Križ-style `homogeneityCounterfactual` on the
-      disjunctive antecedent `(foughtAxis ∨ foughtAllies)` finds the
-      closest such world (the Axis-world, by `spainSim`'s priority),
-      checks foughtAxis-homogeneity over closest worlds (trivially
-      satisfied — single closest world), and returns
-      `presupposition := .satisfied`.
-
-    The two operators thus deliver different verdicts on the same
-    scenario: Santorio's homogeneity gap is **at the cross-alternative
-    level**, von Fintel/Križ's is **at the within-closest-world level**.
-    Both are "homogeneity," but at different scopes. -/
-theorem santorio_vs_homogeneityCounterfactual_spain :
-    -- Santorio: cross-alternative gap
-    homogeneityEval McKayVanInwagen1977.spainSim
-      spainAlts McKayVanInwagen1977.foughtAxis .actual = .indet ∧
-    -- von Fintel/Križ: closest-world homogeneity satisfied
-    (homogeneityCounterfactual McKayVanInwagen1977.spainSim
-      (fun w => McKayVanInwagen1977.foughtAxis w ∨
-                McKayVanInwagen1977.foughtAllies w)
-      McKayVanInwagen1977.foughtAxis .actual).presupposition =
-      PresupStatus.satisfied :=
-  ⟨spain_homogeneity_gap, by decide⟩
-
 
 end Santorio2018

--- a/Linglib/Studies/Santorio2018.lean
+++ b/Linglib/Studies/Santorio2018.lean
@@ -46,7 +46,8 @@ def Stable (alts σ : List (Finset W)) : Prop :=
   ∃ w, (∀ A ∈ σ, w ∈ A) ∧ ∀ A ∈ alts, A ∉ σ → w ∉ A
 
 instance (alts σ : List (Finset W)) : Decidable (Stable alts σ) :=
-  inferInstanceAs (Decidable (∃ w, (∀ A ∈ σ, w ∈ A) ∧ ∀ A ∈ alts, A ∉ σ → w ∉ A))
+  inferInstanceAs
+    (Decidable (∃ w, (∀ A ∈ σ, w ∈ A) ∧ ∀ A ∈ alts, A ∉ σ → w ∉ A))
 
 /-- A nonempty stable sublist of `alts` none of whose nonempty proper sublists is stable.
 (The empty set, stable whenever some world falsifies every alternative, is excluded.) -/
@@ -55,7 +56,8 @@ def MinimalStable (alts σ : List (Finset W)) : Prop :=
     ∀ τ ∈ σ.sublists, τ ≠ [] → τ ≠ σ → ¬ Stable alts τ
 
 instance (alts σ : List (Finset W)) : Decidable (MinimalStable alts σ) :=
-  inferInstanceAs (Decidable (_ ∧ _ ∧ _ ∧ ∀ τ ∈ σ.sublists, _ → _ → ¬ Stable alts τ))
+  inferInstanceAs
+    (Decidable (_ ∧ _ ∧ _ ∧ ∀ τ ∈ σ.sublists, _ → _ → ¬ Stable alts τ))
 
 /-- `⋀σ`. -/
 def conjunctiveClosure (σ : List (Finset W)) : Finset W := σ.foldr (· ∩ ·) Finset.univ
@@ -149,10 +151,12 @@ theorem karenina_truthmakers :
     (truthmakers readingAlts everyAorW).toFinset = {everyA, everyW, someA ∩ someW} := by
   decide
 
-/-- The mixed truthmaker is realized where no universal alternative is: [alonso-ovalle-2009]'s
-disjunct alternatives `{∀A, ∀W}` miss the way for (35) to be true that makes (39) infelicitous. -/
+/-- The mixed truthmaker is realized where no universal alternative is:
+[alonso-ovalle-2009]'s disjunct alternatives `{∀A, ∀W}` miss the way for (35) to be true that
+makes (39) infelicitous. -/
 theorem karenina_mixed_not_alonsoOvalle :
-    Reading.mixed ∈ someA ∩ someW ∧ Reading.mixed ∉ everyA ∧ Reading.mixed ∉ everyW := by
+    Reading.mixed ∈ someA ∩ someW ∧ Reading.mixed ∉ everyA ∧
+      Reading.mixed ∉ everyW := by
   decide
 
 /-! ### Spain (8), on [mckay-vaninwagen-1977] -/

--- a/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
+++ b/Linglib/Studies/ZaniCiardelliSanfelici2026.lean
@@ -1,4 +1,4 @@
-import Linglib.Studies.Santorio2018
+import Linglib.Semantics.Conditionals.Counterfactual.Alternatives
 import Linglib.Studies.BarLevFox2020
 import Linglib.Studies.TieuKrizChemla2019
 import Mathlib.Data.Rat.Defs
@@ -39,7 +39,7 @@ The DCR→SDA trajectory supports homogeneity-based accounts
 
 - DAC readings use the alternative-sensitive conditional semantics from
   `Studies/Santorio2018.lean`:
-  `homogeneityEval`, `sdaEval`
+  `homogeneity`, `Distributive`
 - The DCR (Disjunctive Conditional Reading) operator `dcrEval` is
   defined in this file. **DCR is named here in [zani-ciardelli-sanfelici-2026] (p. 10),
   not in [santorio-2018]** — Santorio's two readings are SDA (with
@@ -55,7 +55,7 @@ namespace ZaniCiardelliSanfelici2026
 open Trivalent (ProjectionType)
 open Semantics.Conditionals (SimilarityOrdering)
 open Semantics.Conditionals.Counterfactual (universalCounterfactual)
-open Santorio2018
+open Semantics.Conditionals.Counterfactual (Distributive homogeneity)
 
 
 -- ============================================================
@@ -72,12 +72,12 @@ open Santorio2018
     because DCR is not part of Santorio's framework. -/
 def dcrEval {W : Type*} [DecidableEq W] [Fintype W]
     (sim : SimilarityOrdering W)
-    (alts : List (DecAlt W)) (C : W → Prop) [DecidablePred C]
+    (alts : List (Finset W)) (C : W → Prop) [DecidablePred C]
     (w : W) : Prop :=
-  ∃ a ∈ alts, universalCounterfactual sim a.pred C w
+  ∃ a ∈ alts, universalCounterfactual sim (· ∈ a) C w
 
 instance {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (alts : List (DecAlt W))
+    (sim : SimilarityOrdering W) (alts : List (Finset W))
     (C : W → Prop) [DecidablePred C] (w : W) :
     Decidable (dcrEval sim alts C w) :=
   inferInstanceAs (Decidable (∃ a ∈ alts, _))
@@ -105,9 +105,9 @@ theorem ar_entails_dcr : DACReading.ar.strength ≥ DACReading.dcr.strength := b
 -- SECTION 2: DAC Readings ↔ Projection Types
 -- ============================================================
 
--- Alternative-sensitive conditional semantics (altConditionalResults,
--- sdaEval, homogeneityEval, lewisDAC) are imported from
--- Studies/Santorio2018.lean. `dcrEval` is
+-- The distributive, collective, and homogeneity readings over a set of
+-- antecedent propositions are `Semantics/Conditionals/Counterfactual/Alternatives.lean`;
+-- `dcrEval` is
 -- defined locally above because DCR is a Zani-Ciardelli-Sanfelici 2026
 -- coinage, not part of Santorio's framework.
 
@@ -124,13 +124,12 @@ def dacProjection : DACReading → ProjectionType
     "if {A,B}, C" ≡ ∀p ∈ {A,B}. min_w(p) ⊆ C ≡ (if A, C) ∧ (if B, C).
     Under Lewis, SDA is only contingently valid. -/
 theorem alt_semantics_validates_sda {W : Type*} [DecidableEq W] [Fintype W]
-    (sim : SimilarityOrdering W) (A B : DecAlt W)
+    (sim : SimilarityOrdering W) (A B : Finset W)
     (C : W → Prop) [DecidablePred C] (w : W) :
-    sdaEval sim [A, B] C w ↔
-    universalCounterfactual sim A.pred C w ∧
-    universalCounterfactual sim B.pred C w := by
-  rw [sdaEval_iff_forall]
-  simp
+    Distributive sim [A, B] C w ↔
+    universalCounterfactual sim (· ∈ A) C w ∧
+    universalCounterfactual sim (· ∈ B) C w := by
+  simp [Distributive]
 
 
 -- ============================================================
@@ -517,7 +516,7 @@ predicted **pre-SDA stage** as a stipulation. The two SDA-deriving
 mature accounts (homogeneity / exhaustification) themselves coincide on
 the SDA inference proper — verifiable at the Lean substrate level via:
 
-- [santorio-2018]'s `Santorio2018.sdaEval` (per-alternative
+- [santorio-2018]'s `Distributive` (per-alternative
   homogeneity, `Studies/Santorio2018.lean`)
 - [bar-lev-fox-2020]'s `BarLevFox2020.bar_lev_fox_sda` (Innocent
   Inclusion derivation, `Studies/BarLevFox2020.lean`)
@@ -525,7 +524,7 @@ the SDA inference proper — verifiable at the Lean substrate level via:
 The cross-mechanism agreement
 `BarLevFox2020.bar_lev_fox_sda_implies_santorio_sda_inference` proves
 that on the shared 4-world `SDAWorld` model, Bar-Lev/Fox's
-`Exh^{IE+II}` verdict entails Santorio's `sdaEval` verdict on the SDA
+`Exh^{IE+II}` verdict entails Santorio's distributive verdict on the SDA
 inference proper. Bar-Lev/Fox is **strictly stronger** (also derives
 `¬((p∧q)□→r)`); Santorio is silent on the conjunctive negation. They
 **agree on the SDA inference itself** — the empirical pattern this
@@ -542,14 +541,14 @@ the two only at the developmental level, not the mature-grammar level.
 /-- **Substrate witness for the mature-grammar agreement**: on the
     shared 4-world `SDAWorld` model from
     `BarLevFox2020.lean`, Bar-Lev/Fox's `Exh^{IE+II}` verdict at
-    `.actual` entails Santorio's `sdaEval` verdict on the SDA
+    `.actual` entails Santorio's distributive verdict on the SDA
     inference. Direct re-export of the cross-framework theorem
     proved in `BarLevFox2020.lean §7`. -/
 theorem bar_lev_fox_and_santorio_agree_on_mature_sda :
     ∀ w, Exhaustification.exhIEII
             BarLevFox2020.sdaALT
             BarLevFox2020.sdaPrejacent w →
-      Santorio2018.sdaEval
+      Distributive
         BarLevFox2020.sdaSim
         BarLevFox2020.sdaSantorioAlts
         BarLevFox2020.sdaR w :=


### PR DESCRIPTION
The study defined Santorio's stability algorithm and, separately, per-alternative conditional readings, but never composed them: the conditional quantified over raw alternatives rather than over the truthmakers the algorithm computes, which is the paper's semantics (§6: `⟦if φ⟧` is the set of truthmakers; `would` extracts their disjunctive closure; optional `DIST_π` distributes with a homogeneity presupposition). Rewritten (762 → ~210 lines): `truthmakers` is computable and the Otto/Anna and Karenina truthmaker sets are kernel-`decide`d in full (the mixed truthmaker Alonso-Ovalle's disjunct alternatives miss); `distributiveConditional`/`collectiveConditional`/`homogeneityPresup` evaluate over them; the trilemma facts — Antecedent Strengthening failure and non-Simplification on McKay–van Inwagen's Spain case, Substitution failure on (57)–(58) — are stated as the paper states them.
- The per-alternative readings were consumed by `AlonsoOvalle2009`, `BarLevFox2020`, `CarianiGoldstein2020`, `ZaniCiardelliSanfelici2026` (a 2009 study importing a 2018 one): extracted to `Semantics/Conditionals/Counterfactual/Alternatives.lean` (`Distributive`, `would`, `homogeneity`, `disjunctiveClosure`) over plain `Finset W` alternatives, replacing the Σ'-bundled `DecAlt`; consumers rewired.
- Cut: the Jago-2026 contrast theorem (later paper; chronology), the `IsTruthmaker := ExactEntails` alias, rfl/alias theorems, banners, and the faithfulness/future-work narration.