### PR TITLE
refactor(Studies/DelPinalBassiSauerland2024): state the embedded puzzles as theorems

### DIFF
--- a/Linglib/Pragmatics/Implicature/Diagnostics.lean
+++ b/Linglib/Pragmatics/Implicature/Diagnostics.lean
@@ -20,11 +20,6 @@ redundancy diagnostic. Calculability and detachability are properties of
 a *derivation*, not of an (assertion, content) pair, so they are stated
 where the derivations live, not here.
 
-The headline consumer is `Studies/DelPinalBassiSauerland2024.lean`: pex
-outputs fail cancellability via
-`IsCancellable.false_of_assertion_implies_content` because the pex
-assertion entails its presupposed content.
-
 Magri-style obligatory SI ([magri-2009]) is **not** an `IsCancellable`
 failure, even common-ground-relativized: for "#Some Italians come from a
 warm country" with CK restricting to all-warm worlds, "in fact all" is a

--- a/Linglib/Studies/BarLevFox2020.lean
+++ b/Linglib/Studies/BarLevFox2020.lean
@@ -276,7 +276,7 @@ private theorem permB_not_ie :
 because adjoining `permAandBᶜ` to any MC-set is consistent (witnessed at
 `onlyA` whenever the MC-set itself is consistent), so maximality forces
 inclusion. -/
-private theorem permAandB_is_ie :
+theorem permAandB_is_ie :
     IsInnocentlyExcludable fcALT fcPrejacent permAandB := by
   refine ⟨by simp [fcALT], ?_⟩
   intro E hE

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -1,896 +1,174 @@
 import Linglib.Semantics.Exhaustification.Presuppositional
-import Linglib.Pragmatics.Implicature.Diagnostics
-import Linglib.Semantics.Presupposition.Quantified
 import Linglib.Semantics.Presupposition.BeliefEmbedding
-import Linglib.Semantics.Presupposition.Accommodation
 import Linglib.Studies.BarLevFox2020
-import Mathlib.Data.Set.Basic
 
 /-!
-# [delpinal-bassi-sauerland-2024] — Free Choice and Presuppositional Exhaustification
-[delpinal-bassi-sauerland-2024] [bassi-delpinal-sauerland-2021]
+# Del Pinal, Bassi & Sauerland (2024): free choice and presuppositional exhaustification
 
-"Free choice and presuppositional exhaustification"
-Semantics & Pragmatics 17, Article 3: 1–52.
-
-## Core Contribution
-
-**pex^{IE+II}** (presuppositional exhaustification) derives free choice by
-splitting the output of exhaustification into assertive and presuppositional
-components:
-
-- **asserts**: the prejacent φ
-- **presupposes**: negation of IE alternatives + homogeneity over II alternatives
-
-This structural split solves embedded FC puzzles that flat exh cannot:
-1. **§2**: Basic FC, double prohibition, negative FC (from local pex)
-2. **§3**: Presupposed FC under negative factives ("Noah is unaware...")
-3. **§4**: Filtering FC in disjunction ("Either Maria can't... or she can...")
-4. **§5**: FC under universal, existential, and non-monotonic quantifiers
-
-## Architecture
-
-The core operator `pexIEII` is defined in
-`Semantics/Exhaustification/Presuppositional.lean`.
-This file connects pex to empirical free choice data and formalizes the
-embedding puzzles from §3–§5.
+[delpinal-bassi-sauerland-2024] derive free choice with `pex^{IE+II}`
+(`Exhaustification.Presuppositional.pexIEII`), which asserts its prejacent and
+*presupposes* the negation of the innocently excludable alternatives together with
+homogeneity over the innocently includable ones. On `◇(p ∨ q)` this is (14): the
+presupposed `◇p ↔ ◇q` with the asserted disjunction entails `◇p ∧ ◇q` (`pex_fc`), and the
+same structure gives double prohibition under negation (16) (`pex_double_prohibition`) and,
+with the necessity alternatives relabelled, negative free choice (19a)–(20)
+(`pex_negative_fc`, `pex_double_requirement`). The split is what flat `exh^{IE+II}`
+lacks, and the paper's embedded puzzles turn on it. Under a negative factive (§3), the
+factive presupposes the whole `pex` output, so free choice is presupposed
+(`fc_presupposed_under_neg_factive`), while the assertion denies belief in the bare
+prejacent, which denies belief in either disjunct (`pex_unaware_target`); a flat `exh`
+complement yields only denial of belief in the exhaustified conjunction, which a believer
+in free choice can satisfy (`exh_unaware_too_weak`). In a disjunction (§4) the homogeneity
+presupposition of the second disjunct is filtered in its local context
+([schlenker-2009]) and free choice follows there (`filtering_fc`), whereas flat `exh`
+leaves nothing to project (`exh_filtering_trivial`). Under quantifiers (§5.1) universal
+projection of the presupposition gives universal, universal-negative, and existential
+free choice, (62), (63), (75) (`universal_fc`, `universal_negative_fc`, `existential_fc`),
+and under *exactly one* (§5.2) the salient readings of (76)–(77) of
+[gotzner-romoli-santorio-2020] (`exactly_one_fc`, `exactly_one_double_prohibition`).
+The five-world model and alternative set are [bar-lev-fox-2020]'s.
 -/
-
-set_option autoImplicit false
 
 namespace DelPinalBassiSauerland2024
 
 open Semantics.Presupposition (PartialProp)
 open CommonGround (ContextSet)
-open Exhaustification.Presuppositional
-open BarLevFox2020
-open Exhaustification
+open Exhaustification Exhaustification.Presuppositional BarLevFox2020 ModalLogic
 open Semantics.Presupposition.Context (presupSatisfied localCtxSecondDisjunct)
-open Semantics.Presupposition.BeliefEmbedding
-open Semantics.Presupposition.Accommodation
 
--- ============================================================================
--- §1. Bridge: pex Predicts FC Data
--- ============================================================================
+/-! ### `pex^{IE+II}` on `◇(p ∨ q)` (§2) -/
 
-/-!
-## Bridge to the Free Choice Data
-
-pex predicts that free choice is a pragmatic inference (derived by the
-covert operator pex), not a semantic entailment — consistent with the observed
-cancellability of FC ("... but I don't know which").
--/
-
--- ============================================================================
--- §1b. The pex output for free choice over FCWorld
--- ============================================================================
-
-/-!
-## §2.2: pex Applied to ◇(p ∨ q)
-
-Instantiating `pexIEII_full` on the five-world FC toy from
-`BarLevFox2020`:
-
-- φ = ◇(p ∨ q) = `permAorB` = `fcPrejacent`
-- ALT = {◇(p ∨ q), ◇p, ◇q, ◇(p ∧ q)} = `fcALT`
-- IE = {◇(p ∧ q)}
-- II = {◇p, ◇q}
-
-**pex^{IE+II}[◇(p ∨ q)]**:
-  asserts: ◇(p ∨ q)
-  presupposes: ¬◇(p ∧ q) ∧ (◇p ↔ ◇q)
-
-Since ◇(p ∨ q) ∧ (◇p ↔ ◇q) entails ◇p ∧ ◇q, pex derives FC.
--/
-
-/-- The pex output for free choice: pex^{IE+II}[◇(p ∨ q)]. -/
+/-- (14): `pex^{IE+II}[◇(p ∨ q)]` on the five-world model. -/
 def pexFC : PartialProp FCWorld := pexIEII_full fcALT fcPrejacent
 
-/-- FC via pex: when presupposition and assertion hold, we get ◇p ∧ ◇q.
+theorem permA_mem_II : IsInnocentlyIncludable fcALT fcPrejacent permA :=
+  mem_II_of_cell_witness fcALT fcPrejacent (by simp [fcALT]) .separatelyAB separatelyAB_in_cell
+    trivial
 
-    This is the paper's (14)–(15):
-    ⟦pex^{IE+II}[◇[p ∨ q]]⟧ = ◇(p ∨ q)_{◇p↔◇q} ⊨ ◇p ∧ ◇q
+theorem permB_mem_II : IsInnocentlyIncludable fcALT fcPrejacent permB :=
+  mem_II_of_cell_witness fcALT fcPrejacent (by simp [fcALT]) .separatelyAB separatelyAB_in_cell
+    trivial
 
-    The proof uses `mem_II_of_cell_witness`: `separatelyAB` is the cell
-    witness for `fcALT` (verified in `BarLevFox2020.separatelyAB_in_cell`),
-    and both `permA` and `permB` hold at `separatelyAB`. -/
-theorem pex_fc :
-    ∀ w, pexFC.holds w → permA w ∧ permB w := by
-  intro w ⟨hpresup, hassert⟩
-  simp only [pexFC, pexIEII_full, pexIEII] at hpresup hassert
-  obtain ⟨_, hHomog⟩ := hpresup
-  -- We need: permA and permB are in II ∩ fcALT
-  have hA_II : IsInnocentlyIncludable fcALT fcPrejacent permA :=
-    mem_II_of_cell_witness fcALT fcPrejacent
-      (by simp [fcALT]) .separatelyAB separatelyAB_in_cell trivial
-  have hB_II : IsInnocentlyIncludable fcALT fcPrejacent permB :=
-    mem_II_of_cell_witness fcALT fcPrejacent
-      (by simp [fcALT]) .separatelyAB separatelyAB_in_cell trivial
-  have hA_in : permA ∈ ({α | α ∈ II fcALT fcPrejacent ∧ α ∈ fcALT} : Set _) :=
-    ⟨hA_II, by simp [fcALT]⟩
-  have hB_in : permB ∈ ({α | α ∈ II fcALT fcPrejacent ∧ α ∈ fcALT} : Set _) :=
-    ⟨hB_II, by simp [fcALT]⟩
-  -- Homogeneity gives: permA w ↔ permB w
-  have hiff : permA w ↔ permB w := hHomog permA hA_in permB hB_in
-  -- From fcPrejacent w: at least one of permA, permB holds
-  have hAtLeastOne : permA w ∨ permB w := by
-    cases w <;> simp_all [fcPrejacent, permAorB, permA, permB]
-  rcases hAtLeastOne with hA | hB
-  · exact ⟨hA, hiff.mp hA⟩
-  · exact ⟨hiff.mpr hB, hB⟩
+theorem permAorB_iff (w : FCWorld) : permAorB w ↔ permA w ∨ permB w := by
+  cases w <;> simp [permAorB, permA, permB]
 
-/-- Negation of pex FC: ¬pex^{IE+II}[◇(p ∨ q)]. -/
-def negPexFC : PartialProp FCWorld := pexFC.neg
+variable {w : FCWorld}
 
-/-- Double prohibition: the negated pex output entails ¬◇p ∧ ¬◇q.
+/-- (14): the presupposed homogeneity `◇p ↔ ◇q` with the asserted `◇(p ∨ q)` gives free
+choice. -/
+theorem pex_fc (h : pexFC.holds w) : permA w ∧ permB w := by
+  have hiff : permA w ↔ permB w :=
+    h.1.2 permA ⟨permA_mem_II, by simp [fcALT]⟩ permB ⟨permB_mem_II, by simp [fcALT]⟩
+  rcases (permAorB_iff w).1 h.2 with hA | hB
+  exacts [⟨hA, hiff.1 hA⟩, ⟨hiff.2 hB, hB⟩]
 
-    This is the paper's (16):
-    ⟦¬[pex^{IE+II}[◇[T ∨ B]]]⟧ = ¬◇(T ∨ B)_{◇T↔◇B} ⊨ ¬◇T ∧ ¬◇B -/
-theorem pex_double_prohibition :
-    ∀ w, negPexFC.holds w → ¬permA w ∧ ¬permB w := by
-  intro w ⟨hpresup, hassert⟩
-  simp only [negPexFC, PartialProp.neg,
-             pexFC, pexIEII_full, pexIEII] at hpresup hassert
-  -- hassert : ¬fcPrejacent w, i.e., ¬permAorB w
-  -- ¬permAorB w → ¬permA w ∧ ¬permB w
-  constructor
-  · intro hA; exact hassert (by cases w <;> simp_all [fcPrejacent, permAorB, permA])
-  · intro hB; exact hassert (by cases w <;> simp_all [fcPrejacent, permAorB, permB])
+/-- (16): negation denies the prejacent and leaves the presupposition, so `¬pex[◇(p ∨ q)]`
+is double prohibition. -/
+theorem pex_double_prohibition (h : pexFC.neg.holds w) : ¬ permA w ∧ ¬ permB w :=
+  ⟨fun hA => h.2 ((permAorB_iff w).2 (.inl hA)), fun hB => h.2 ((permAorB_iff w).2 (.inr hB))⟩
 
-/-!
-## Negative FC via pex: the ¬□ ↔ ◇ duality
+/-- `¬□T`, read on the five-world model: the alternatives to `¬□(T ∧ B)` — `¬□T`, `¬□B`,
+`¬□(T ∨ B)` — have the same innocent-exclusion/inclusion structure as those to `◇(p ∨ q)`,
+with `¬□T` in the place of `◇q` and `¬□B` in the place of `◇p`. -/
+abbrev notReqT : Set FCWorld := permB
 
-The alternative set for ¬□(p∧q) is {¬□(p∧q), ¬□p, ¬□q, ¬□(p∨q)}, which
-is **isomorphic** to the ◇∨ alternative set under the mapping:
-
-| ¬□ world | ◇ world | Reinterpretation |
-|----------|---------|------------------|
-| ¬□(p∧q)  | ◇(a∨b)  | notReqAandB = fcPrejacent |
-| ¬□p      | ◇b      | notReqA = permB |
-| ¬□q      | ◇a      | notReqB = permA |
-| ¬□(p∨q)  | ◇(a∧b)  | notReqAorB = permAandB |
-
-Consequently, `pexFC` simultaneously derives both positive FC (◇a ∧ ◇b)
-and negative FC (¬□p ∧ ¬□q) under reinterpretation.
--/
-
-/-- ¬□p: p is not required (= ◇¬p by duality). Under the isomorphism, this
-    is `permB` on `FCWorld`. -/
-abbrev notReqA : Set FCWorld := permB
-
-/-- ¬□q: q is not required. Under the isomorphism, this is `permA`. -/
+/-- `¬□B` on the five-world model. -/
 abbrev notReqB : Set FCWorld := permA
 
-/-- ¬□(p∧q): not both required. Under the isomorphism, this is
-    `permAorB` = `fcPrejacent`. -/
-abbrev notReqAandB : Set FCWorld := permAorB
+/-- (19a): `pex^{IE+II}[¬□(T ∧ B)]` gives negative free choice. -/
+theorem pex_negative_fc (h : pexFC.holds w) : notReqT w ∧ notReqB w := (pex_fc h).symm
 
-/-- ¬□(p∨q): neither required. Under the isomorphism, this is
-    `permAandB`. -/
-abbrev notReqAorB : Set FCWorld := permAandB
+/-- (20): `¬pex^{IE+II}[□(T ∧ B)]` gives double requirement. -/
+theorem pex_double_requirement (h : pexFC.neg.holds w) : ¬ notReqT w ∧ ¬ notReqB w :=
+  (pex_double_prohibition h).symm
 
-/-- The alternative set for ¬□(p∧q) is the same set as fcALT. -/
-theorem negNecALT_eq_fcALT :
-    ({notReqAandB, notReqA, notReqB, notReqAorB} : Set (Set FCWorld)) = fcALT := by
-  simp only [notReqAandB, notReqA, notReqB, notReqAorB, fcALT]
-  ext x; simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
-  tauto
+/-! ### Free choice under negative factives (§3) -/
 
-/-- Negative FC via pex: pex^{IE+II}[¬□(p∧q)] ⊨ ¬□p ∧ ¬□q.
+variable (believes : (FCWorld → Prop) → FCWorld → Prop)
 
-    The paper's (19a): since pexFC on the ¬□-reinterpreted `FCWorld`
-    entails ◇b ∧ ◇a (= permB ∧ permA), and notReqA = permB,
-    notReqB = permA, we get ¬□p ∧ ¬□q. -/
-theorem pex_negative_fc :
-    ∀ w, pexFC.holds w → notReqA w ∧ notReqB w := by
-  intro w h
-  have ⟨hA, hB⟩ := pex_fc w h
-  exact ⟨hB, hA⟩
-
-/-- Double requirement for necessity: ¬pex^{IE+II}[¬□(p∧q)] gives
-    the negation of negative FC — i.e., both are required: □p ∧ □q.
-
-    This is the paper's (20):
-    ⟦¬ pex^{IE+II}[¬□[T ∧ B]]⟧ = ¬(¬□T ∨ ¬□B)_{¬□T↔¬□B} ⊨ □T ∧ □B -/
-theorem pex_neg_necessity_double_req :
-    ∀ w, negPexFC.holds w → ¬notReqA w ∧ ¬notReqB w := by
-  intro w h
-  have ⟨hA, hB⟩ := pex_double_prohibition w h
-  exact ⟨hB, hA⟩
-
-/-- Convenience re-export: exhIEII entails FC (proved as `BarLevFox2020.free_choice`). -/
-theorem exhIEII_fc : ∀ w, exhIEII fcALT fcPrejacent w → permA w ∧ permB w :=
-  free_choice
-
-/-- Convenience re-export: pexIEII entails FC. -/
-theorem pexIEII_fc : ∀ w, pexFC.holds w → permA w ∧ permB w :=
-  pex_fc
-
--- ============================================================================
--- §2. Presupposed FC Under Negative Factives (§3)
--- ============================================================================
-
-/-!
-## §3: The "Unaware" Puzzle
-
-Consider: "Noah is unaware that he may have tea or cake"
-
-**Intuition**: This presupposes that Noah may have tea AND may have cake
-(FC is presupposed, not asserted).
-
-### Analysis with pex
-
-1. pex applies locally to ◇(t∨c), producing:
-   - assertion: ◇(t∨c)
-   - presupposition: ¬◇(t∧c) ∧ (◇t ↔ ◇c)
-
-2. "Unaware" is a negative factive:
-   - presupposes: its complement (the full pex output holds)
-   - asserts: the subject doesn't believe it
-
-3. The factive presupposes that pex *holds* — both assertion and
-   presupposition. The homogeneity presupposition (◇t ↔ ◇c) combined
-   with ◇(t∨c) entails ◇t ∧ ◇c. FC is presupposed!
-
-### Why flat exh fails
-
-With flat exh: exh(◇(t∨c)) = ◇(t∨c) ∧ ◇t ∧ ◇c ∧ ¬◇(t∧c)
-Under "unaware": presupposes the flat conjunction, asserts ¬Bel(flat)
-
-The problem: the subject might fail to believe the conjunction for trivial
-reasons (not believing ¬◇(t∧c)), losing the FC presupposition.
-With pex, the FC-relevant content (homogeneity) is already presuppositional,
-so it projects independently.
--/
-
-/-- Key theorem (§3): FC is presupposed under a negative factive.
-
-    When pex(◇(p∨q)) is embedded under "unaware", the overall sentence
-    *presupposes* ◇p ∧ ◇q (free choice as presupposition).
-
-    Uses `PartialProp.negFactive` from `Semantics.Presupposition`. -/
+/-- Under a negative factive the whole `pex` output is presupposed, so free choice is
+presupposed, (21a). -/
 theorem fc_presupposed_under_neg_factive
-    (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PartialProp.negFactive pexFC believes).presup w → permA w ∧ permB w :=
-  fun w hpresup => pex_fc w hpresup
-
-/-- The assertion of the negative factive embedding is about belief, not FC. -/
-theorem neg_factive_asserts_nonbelief
-    (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PartialProp.negFactive pexFC believes).assertion w ↔
-         ¬(believes fcPrejacent w) :=
-  fun _ => Iff.rfl
-
--- ============================================================================
--- §3. Filtering FC (§4)
--- ============================================================================
-
-/-!
-## §4: Filtering FC in Disjunction
-
-Consider: "Either Maria can't study linguistics, or she can study syntax
-or semantics"
-
-**Intuition**: FC inference arises — Maria can study syntax AND semantics.
-
-### Analysis with pex
-
-The second disjunct contains pex(◇(syn ∨ sem)):
-  - assertion: ◇(syn ∨ sem)
-  - presupposition: ◇syn ↔ ◇sem (homogeneity)
-
-In disjunction "A ∨ B", the presupposition of B is *filtered* by ¬A
-([karttunen-1973]). Here:
-  - A = ¬◇ling
-  - ¬A = ◇ling (Maria CAN study linguistics)
-  - Under ◇ling, the presupposition ◇syn ↔ ◇sem is informative
-
-The homogeneity presupposition projects (after filtering), and combined
-with ◇(syn ∨ sem), derives FC.
-
-### Why flat exh fails
-
-With flat exh in the second disjunct: ◇(syn∨sem) ∧ ◇syn ∧ ◇sem ∧ ¬◇(syn∧sem)
-The FC content is asserted, not presupposed. In disjunction, only
-*presuppositions* project — assertions do not. So the FC inference is
-trapped inside the second disjunct and doesn't become part of the overall
-meaning.
--/
-
-/-- When the first disjunct is false, Karttunen filtering recovers full
-    satisfaction of the second disjunct.
-    Uses `PartialProp.disjFilterLeft` from `Semantics.Presupposition`. -/
-theorem filtering_recovers_pex {World : Type*}
-    (firstDisjunct : World → Prop) (sp : PartialProp World)
-    (w : World) (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct sp).holds w) :
-    sp.holds w :=
-  PartialProp.disjFilterLeft_recovers firstDisjunct sp w hFirst hFiltered
-
-/-- Corollary: filtering FC for the concrete FCWorld case.
-    When filtered pex holds and the first disjunct is false, FC follows. -/
-theorem filtering_fc (firstDisjunct : FCWorld → Prop) (w : FCWorld)
-    (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct pexFC).holds w) :
-    permA w ∧ permB w :=
-  pex_fc w (filtering_recovers_pex firstDisjunct pexFC w hFirst hFiltered)
-
--- ============================================================================
--- §4. Structural Comparison: pex vs exh
--- ============================================================================
-
-/-!
-## Why pex Solves Puzzles That exh Cannot
-
-The fundamental difference is **at-issue structure**:
-
-| | exh^{IE+II}(φ) | pex^{IE+II}(φ) |
-|---|---|---|
-| **Asserts** | φ ∧ ¬IE ∧ II | φ |
-| **Presupposes** | nothing | ¬IE ∧ homog(II) |
-
-This matters for embedding:
-
-1. **Under negation**: Negation targets assertions, not presuppositions.
-   - ¬exh(φ) = ¬(φ ∧ ¬IE ∧ II) — FC lost under negation
-   - ¬pex(φ) = ¬φ with presup intact — double prohibition
-
-2. **Under factives**: Factives presuppose their complement.
-   - aware(exh(φ)) presupposes the flat conjunction — muddled
-   - aware(pex(φ)) presupposes φ + homogeneity — clean FC projection
-
-3. **In disjunctions**: Only presuppositions project/filter.
-   - A ∨ exh(φ): FC trapped in assertion, doesn't project
-   - A ∨ pex(φ): homogeneity presupposition projects, FC derives
--/
-
-/-- Key structural fact: pex and exh agree on what they entail (both derive FC),
-    but disagree on at-issue structure (assert vs presuppose). -/
-theorem both_derive_fc :
-    (∀ w, pexFC.holds w → permA w ∧ permB w) ∧
-    (∀ w, exhIEII fcALT fcPrejacent w → permA w ∧ permB w) :=
-  ⟨pex_fc, free_choice⟩
-
-/-- pex's presupposition projects through negation (by construction). -/
-theorem presup_projects_through_negation :
-    pexFC.neg.presup = pexFC.presup := rfl
-
--- ============================================================================
--- §5. Negative FC and Presupposed Negative FC (§2.2, §3.3)
--- ============================================================================
-
-/-!
-## Negative FC
-
-The duality isomorphism (Presuppositional.lean §7b) gives
-negative FC from the same `FCWorld` computation. Here we verify the
-embedded predictions.
-
-### §3.3: Presupposed negative FC under negative factives
-
-"Noah is unaware that Olivia is not required to take Logic and Algebra"
-
-Presupposes: ¬□L ∧ ¬□A (negative FC). The solution parallels §3.2:
-pex applies locally, the negative factive presupposes the full pex output,
-and the homogeneity ¬□L ↔ ¬□A combined with ¬□(L∧A) entails ¬□L ∧ ¬□A.
--/
-
-/-- Presupposed negative FC: under a negative factive, pex presupposes
-    ¬□L ∧ ¬□A (negative free choice). -/
-theorem negative_fc_presupposed_under_neg_factive
-    (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    ∀ w, (PartialProp.negFactive pexFC believes).presup w → notReqA w ∧ notReqB w :=
-  fun w hpresup => pex_negative_fc w hpresup
-
-/-- Filtering negative FC: when the first disjunct is false, the filtered
-    presupposition of the second disjunct recovers negative FC. -/
-theorem filtering_negative_fc (firstDisjunct : FCWorld → Prop) (w : FCWorld)
-    (hFirst : ¬firstDisjunct w)
-    (hFiltered : (PartialProp.disjFilterLeft firstDisjunct pexFC).holds w) :
-    notReqA w ∧ notReqB w :=
-  pex_negative_fc w (filtering_recovers_pex firstDisjunct pexFC w hFirst hFiltered)
-
--- ============================================================================
--- §6. FC Under Quantifiers (§5.1)
--- ============================================================================
-
-/-!
-## §5.1: Universal, Existential, and Negative-Existential FC
-
-[chemla-2009] shows that ∀◇∨-sentences have universal FC readings
-and ¬∃□∧-sentences have universal negative FC readings.
-
-### Analysis with embedded pex
-
-The LFs with embedded pex^{IE+II}:
-- ∀x ∈ S[pex^{IE+II}[◇[Cx ∨ ICx]]]
-- ¬∃x ∈ S[pex^{IE+II}[□[Ax ∧ Bx]]]
-- ∃x ∈ S[pex^{IE+II}[◇[Cx ∨ ICx]]]
-
-pex triggers the homogeneity presupposition in the scope of the quantifier.
-Presuppositions project universally from the scope of universal quantifiers
-([chemla-2009-quantified], [fox-2013], [mayr-sauerland-2015]).
-Combined with the assertive content, (universal/existential) FC follows.
--/
-
-/-- Universal FC: universally projected homogeneity + universal assertion
-    entails universal FC. -/
-theorem universal_fc {Student : Type*}
-    (S : Student → Prop) (permC permIC : Student → Prop)
-    (hassert : ∀ x, S x → (permC x ∨ permIC x))
-    (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
-    (∀ x, S x → permC x) ∧ (∀ x, S x → permIC x) := by
-  constructor
-  · intro x hx
-    rcases hassert x hx with hC | hIC
-    · exact hC
-    · exact (hhomog x hx).mpr hIC
-  · intro x hx
-    rcases hassert x hx with hC | hIC
-    · exact (hhomog x hx).mp hC
-    · exact hIC
-
-/-- Universal negative FC: universally projected homogeneity + negated
-    existential assertion entails universal negative FC. -/
-theorem universal_negative_fc {Student : Type*}
-    (S : Student → Prop) (reqA reqB : Student → Prop)
-    (hassert : ¬∃ x, S x ∧ (reqA x ∧ reqB x))
-    (hhomog : ∀ x, S x → (reqA x ↔ reqB x)) :
-    (¬∃ x, S x ∧ reqA x) ∧ (¬∃ x, S x ∧ reqB x) := by
-  constructor
-  · intro ⟨x, hx, hA⟩
-    exact hassert ⟨x, hx, hA, (hhomog x hx).mp hA⟩
-  · intro ⟨x, hx, hB⟩
-    exact hassert ⟨x, hx, (hhomog x hx).mpr hB, hB⟩
-
-/-- Existential FC: universally projected homogeneity + existential assertion
-    entails existential FC.
-
-    ∃x ∈ S[pex^{IE+II}[◇[Cx ∨ ICx]]] yields:
-    - presupposes: ∀x ∈ S(◇Cx ↔ ◇ICx)  (universal projection)
-    - asserts: ∃x ∈ S(◇(Cx ∨ ICx))
-
-    Together: ∃x ∈ S(◇Cx ∧ ◇ICx). -/
-theorem existential_fc {Student : Type*}
-    (S : Student → Prop) (permC permIC : Student → Prop)
-    (hassert : ∃ x, S x ∧ (permC x ∨ permIC x))
-    (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
-    ∃ x, S x ∧ permC x ∧ permIC x := by
-  obtain ⟨x, hx, hDisj⟩ := hassert
-  exact ⟨x, hx, by
-    rcases hDisj with hC | hIC
-    · exact ⟨hC, (hhomog x hx).mp hC⟩
-    · exact ⟨(hhomog x hx).mpr hIC, hIC⟩⟩
-
-/-- Universal FC via `PartialProp.forallPartial`: when each student's pex output
-    holds (presupposition projected universally + assertion holds),
-    universal FC follows.
-
-    This connects the abstract entailment theorems above to the concrete
-    `forallPartial` combinator from `Semantics.Presupposition`. -/
-theorem forallPartial_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
-    (projA projB : Student → Set W)
-    (hFC : ∀ x, S x → (pexPerStudent x).holds w →
-      projA x w ∧ projB x w)
-    (hHolds : (PartialProp.forallPartial S pexPerStudent).holds w) :
-    (∀ x, S x → projA x w) ∧ (∀ x, S x → projB x w) := by
-  obtain ⟨hPresup, hAssert⟩ := hHolds
-  constructor
-  · intro x hx; exact (hFC x hx ⟨hPresup x hx, hAssert x hx⟩).1
-  · intro x hx; exact (hFC x hx ⟨hPresup x hx, hAssert x hx⟩).2
-
-/-- Existential FC via `PartialProp.existsPartialUniv`: with universal presupposition
-    projection from an existential quantifier, we get existential FC.
-
-    This connects the existential entailment theorem to the concrete
-    `existsPartialUniv` combinator from `Semantics.Presupposition`. -/
-theorem existsPartialUniv_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
-    (projA projB : Student → Set W)
-    (hFC : ∀ x, S x → (pexPerStudent x).holds w →
-      projA x w ∧ projB x w)
-    (hHolds : (PartialProp.existsPartialUniv S pexPerStudent).holds w) :
-    ∃ x, S x ∧ projA x w ∧ projB x w := by
-  obtain ⟨hPresup, ⟨x, hx, hAssert⟩⟩ := hHolds
-  exact ⟨x, hx, hFC x hx ⟨hPresup x hx, hAssert⟩⟩
-
-/-- Universal negative FC via `PartialProp.negExistsPartial`: with universal
-    presupposition projection and negated existential assertion,
-    universal negative FC follows.
-
-    This connects `universal_negative_fc` to the concrete
-    `negExistsPartial` combinator from `Semantics.Presupposition`,
-    completing the set of quantifier bridges alongside
-    `forallPartial_fc` and `existsPartialUniv_fc`.
-
-    The shape differs from the positive bridges: `forallPartial_fc` and
-    `existsPartialUniv_fc` use `hFC : holds → projA ∧ projB` (assertion
-    decomposes to FC). Here, the assertion is *negated*, so we need:
-    - `hAssertEq`: assertion ↔ reqA ∧ reqB (decomposition)
-    - `hHomog`: presup → reqA ↔ reqB (homogeneity)
-    These are exactly the inputs to `universal_negative_fc`. -/
-theorem negExistsPartial_negative_fc {Student W : Type*}
-    (S : Student → Prop) (pexPerStudent : Student → PartialProp W) (w : W)
-    (reqA reqB : Student → Set W)
-    (hAssertEq : ∀ x, S x → ((pexPerStudent x).assertion w ↔
-      (reqA x w ∧ reqB x w)))
-    (hHomog : ∀ x, S x → (pexPerStudent x).presup w →
-      (reqA x w ↔ reqB x w))
-    (hHolds : (PartialProp.negExistsPartial S pexPerStudent).holds w) :
-    (¬∃ x, S x ∧ reqA x w) ∧ (¬∃ x, S x ∧ reqB x w) := by
-  obtain ⟨hPresup, hNegAssert⟩ := hHolds
-  exact universal_negative_fc S (fun x => reqA x w) (fun x => reqB x w)
-    (fun ⟨x, hx, hAB⟩ => hNegAssert ⟨x, hx, (hAssertEq x hx).mpr hAB⟩)
-    (fun x hx => hHomog x hx (hPresup x hx))
-
--- ============================================================================
--- §6b. FC Under Non-Monotonic Quantifiers (§5.2)
--- ============================================================================
-
-/-!
-## §5.2: Non-Monotonic Quantifiers
-
-[gotzner-romoli-santorio-2020] show that "exactly one"-sentences have
-salient readings where one student has FC/double prohibition while all others
-have the opposite. pex handles these straightforwardly via universal
-homogeneity projection + the cardinality constraint.
-
-### (76): "Exactly one student can take Logic or Calculus"
-
-The LF: ∃!x ∈ S[pex^{IE+II}[◇[Lx ∨ Cx]]]
-
-pex triggers homogeneity ◇Lx ↔ ◇Cx universally (for all students).
-The assertive part says exactly one student satisfies ◇(Lx ∨ Cx).
-
-Combined:
-- The unique student has ◇(L ∨ C) ∧ (◇L ↔ ◇C) → ◇L ∧ ◇C (FC)
-- All other students have ¬◇(L ∨ C) ∧ (◇L ↔ ◇C) → ¬◇L ∧ ¬◇C (double prohibition)
-
-### (77): "Exactly one student can't take Logic or Calculus"
-
-The LF: ∃!x ∈ S[¬ pex^{IE+II}[◇[Lx ∨ Cx]]]
-
-Combined:
-- The unique student has ¬◇(L ∨ C) ∧ (◇L ↔ ◇C) → ¬◇L ∧ ¬◇C (double prohibition)
-- All other students have ◇(L ∨ C) ∧ (◇L ↔ ◇C) → ◇L ∧ ◇C (FC)
--/
-
-/-- Non-monotonic FC (76a): universal homogeneity + "exactly one has ◇∨"
-    entails that the unique student has FC and all others have double
-    prohibition.
-
-    [gotzner-romoli-santorio-2020], [delpinal-bassi-sauerland-2024] §5.2 -/
-theorem exactly_one_fc {Student : Type*}
-    (S : Student → Prop) (permL permC : Student → Prop)
-    (witness : Student) (hw : S witness)
-    (hassert_pos : permL witness ∨ permC witness)
-    (hassert_neg : ∀ x, S x → x ≠ witness → ¬(permL x ∨ permC x))
-    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
-    -- The witness has FC
-    (permL witness ∧ permC witness) ∧
-    -- All others have double prohibition
-    (∀ x, S x → x ≠ witness → ¬permL x ∧ ¬permC x) := by
-  constructor
-  · rcases hassert_pos with hL | hC
-    · exact ⟨hL, (hhomog witness hw).mp hL⟩
-    · exact ⟨(hhomog witness hw).mpr hC, hC⟩
-  · intro x hx hne
-    have hNotDisj := hassert_neg x hx hne
-    exact ⟨fun hL => hNotDisj (Or.inl hL), fun hC => hNotDisj (Or.inr hC)⟩
-
-/-- Non-monotonic FC (77a): universal homogeneity + "exactly one lacks ◇∨"
-    entails that the unique student has double prohibition and all others
-    have FC.
-
-    [gotzner-romoli-santorio-2020], [delpinal-bassi-sauerland-2024] §5.2 -/
-theorem exactly_one_double_prohibition {Student : Type*}
-    (S : Student → Prop) (permL permC : Student → Prop)
-    (witness : Student) (_hw : S witness)
-    (hassert_neg : ¬(permL witness ∨ permC witness))
-    (hassert_pos : ∀ x, S x → x ≠ witness → (permL x ∨ permC x))
-    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
-    -- The witness has double prohibition
-    (¬permL witness ∧ ¬permC witness) ∧
-    -- All others have FC
-    (∀ x, S x → x ≠ witness → permL x ∧ permC x) := by
-  constructor
-  · exact ⟨fun hL => hassert_neg (Or.inl hL),
-           fun hC => hassert_neg (Or.inr hC)⟩
-  · intro x hx hne
-    rcases hassert_pos x hx hne with hL | hC
-    · exact ⟨hL, (hhomog x hx).mp hL⟩
-    · exact ⟨(hhomog x hx).mpr hC, hC⟩
-
--- ============================================================================
--- §7. Why Flat exh Fails on Embedded Puzzles (§3.1, §4.1)
--- ============================================================================
-
-/-!
-## Why Flat exh Cannot Solve the Embedded FC Puzzles
-
-The paper's central argument is that flat **exh** (including exh^{IE+II})
-cannot solve the presupposed & filtering FC puzzles because its output
-is fully assertive. Here we formalize the specific failure modes.
-
-### Failure 1: exh under negative factives (§3.1)
-
-With exh^{IE+II}, the output for ◇(L∨A) is flat:
-  exh(◇(L∨A)) = ◇(L∨A) ∧ ◇L ∧ ◇A ∧ ¬◇(L∧A)
-
-Under "S is unaware that exh(◇(L∨A))":
-  - presupposes: ◇(L∨A) ∧ ◇L ∧ ◇A ∧ ¬◇(L∧A) (the flat conjunction)
-  - asserts: ¬B_S(◇(L∨A) ∧ ◇L ∧ ◇A ∧ ¬◇(L∧A))
-
-The problem: the assertion says S doesn't believe the *whole conjunction*.
-This is too weak — S might fail to believe ¬◇(L∧A) while still believing
-◇L ∧ ◇A. The target is that S doesn't believe Olivia can take *either*
-class individually (a stronger claim about S's beliefs).
-
-### Failure 2: exh in filtering disjunction (§4.1)
-
-For "Either Maria can't study linguistics, or she can study syntax or
-semantics": the FC content (◇syn ∧ ◇sem) is assertive in exh's output,
-so it's trapped inside the second disjunct. In disjunction, only
-*presuppositions* project/filter — assertions don't. So the FC inference
-cannot reach the overall sentence meaning.
-
-With pex, FC content is presuppositional, so it projects through
-disjunction via Karttunen filtering.
--/
-
-/-- **Flat exh output**: exh^{IE+II}(◇(p∨q)) is fully assertive —
-    no presuppositional component. -/
+    (h : (PartialProp.negFactive pexFC believes).presup w) : permA w ∧ permB w :=
+  pex_fc h
+
+/-- The factive's assertion denies belief in the prejacent `◇(p ∨ q)`, hence belief in either
+disjunct, (21b). -/
+theorem pex_unaware_target (R : FCWorld → FCWorld → Prop)
+    (h : (PartialProp.negFactive pexFC (box R)).assertion w) :
+    ¬ box R permA w ∧ ¬ box R permB w :=
+  ⟨fun hA => h (box_mono R (by intro v hv; exact (permAorB_iff v).2 (.inl hv)) w hA),
+   fun hB => h (box_mono R (by intro v hv; exact (permAorB_iff v).2 (.inr hv)) w hB)⟩
+
+/-- `exh^{IE+II}[◇(p ∨ q)]`, fully assertive. -/
 def flatExhFC : Set FCWorld := exhIEII fcALT fcPrejacent
 
-/-- Negative factive embedding of FLAT exh.
-    "S is unaware that exh(◇(L∨A))":
-    - presupposes: the flat conjunction holds
-    - asserts: S doesn't believe the flat conjunction -/
-def negFactiveOfFlatExh
-    (believes : (FCWorld → Prop) → FCWorld → Prop) : PartialProp FCWorld where
-  presup := flatExhFC
-  assertion := fun w => ¬(believes flatExhFC w)
+/-- With a flat `exh` complement the factive's assertion only denies belief in the
+exhaustified conjunction, which an attitude holder who believes free choice but not
+exclusivity satisfies (§3.1). -/
+theorem exh_unaware_too_weak :
+    ∃ R : FCWorld → FCWorld → Prop, (box R permA w ∧ box R permB w) ∧ ¬ box R flatExhFC w :=
+  ⟨fun _ v => v = .both, ⟨fun _ hv => hv ▸ trivial, fun _ hv => hv ▸ trivial⟩,
+   fun h => (h .both rfl).2.1 permAandB permAandB_is_ie trivial⟩
 
-/-- **Failure 1a**: Under flat exh, the factive asserts non-belief of the
-    *entire* flat conjunction (FC + exclusivity). S might fail to believe the
-    conjunction by not believing ¬◇(L∧A), while still believing ◇L ∧ ◇A. -/
-theorem exh_factive_asserts_flat_conjunction
-    (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    (negFactiveOfFlatExh believes).assertion =
-      (fun w => ¬(believes flatExhFC w)) := rfl
+/-! ### Filtering free choice (§4) -/
 
-/-- **Failure 1b**: In contrast, pex's factive asserts non-belief of just the
-    prejacent — the correct content for S's doxastic state. -/
-theorem pex_factive_asserts_prejacent
-    (believes : (FCWorld → Prop) → FCWorld → Prop) :
-    (PartialProp.negFactive pexFC believes).assertion =
-      (fun w => ¬(believes fcPrejacent w)) := rfl
+/-- In `A or pex[◇(p ∨ q)]` the homogeneity presupposition is satisfied in the second
+disjunct's local context `c ∧ ¬A`, and free choice follows there. -/
+theorem filtering_fc (c : ContextSet FCWorld) (A : PartialProp FCWorld) (hc : w ∈ c)
+    (hA : ¬ A.assertion w) (hf : presupSatisfied (localCtxSecondDisjunct c A) pexFC)
+    (hassert : pexFC.assertion w) : permA w ∧ permB w :=
+  pex_fc ⟨hf ⟨hc, hA⟩, hassert⟩
 
-/-- **Failure 2**: When flat exh is placed in a filtering disjunction,
-    the FC content is assertive and thus trapped inside the disjunct.
-    Only presuppositions can project/filter in disjunctions.
+/-- A flat `exh` second disjunct has nothing to filter: its free-choice content is
+assertive and stays inside the disjunct (§4.1). -/
+theorem exh_filtering_trivial (c : ContextSet FCWorld) (A : PartialProp FCWorld) :
+    presupSatisfied (localCtxSecondDisjunct c A) (PartialProp.ofProp flatExhFC) :=
+  fun _ _ => trivial
 
-    For "A ∨ exh(◇(p∨q))": the presupposition is trivial (True). -/
-theorem exh_filtering_no_presupposition (firstDisjunct : FCWorld → Prop) :
-    (PartialProp.disjFilterLeft firstDisjunct (PartialProp.ofProp flatExhFC)).presup =
-      (fun _ => True) := by
-  funext; simp [PartialProp.disjFilterLeft, PartialProp.ofProp]
+/-! ### Free choice under quantifiers (§5) -/
 
-/-- pex's filtering disjunction has a non-trivial presupposition (homogeneity
-    conditioned on ¬firstDisjunct). -/
-theorem pex_filtering_has_presupposition (firstDisjunct : FCWorld → Prop) :
-    (PartialProp.disjFilterLeft firstDisjunct pexFC).presup =
-      (fun w => ¬firstDisjunct w → pexFC.presup w) := rfl
+variable {Student : Type*} (S : Student → Prop)
 
--- ============================================================================
--- §8. Empirical Predictions Summary
--- ============================================================================
+/-- (62): universal projection of homogeneity and the universal assertion give universal free
+choice. -/
+theorem universal_fc (permC permIC : Student → Prop)
+    (hassert : ∀ x, S x → permC x ∨ permIC x) (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
+    (∀ x, S x → permC x) ∧ ∀ x, S x → permIC x :=
+  ⟨fun x hx => (hassert x hx).elim id (hhomog x hx).2,
+   fun x hx => (hassert x hx).elim (hhomog x hx).1 id⟩
 
-/-!
-## Empirical Predictions
+/-- (63): with a negated existential assertion, universal negative free choice. -/
+theorem universal_negative_fc (reqA reqB : Student → Prop)
+    (hassert : ¬ ∃ x, S x ∧ reqA x ∧ reqB x) (hhomog : ∀ x, S x → (reqA x ↔ reqB x)) :
+    (¬ ∃ x, S x ∧ reqA x) ∧ ¬ ∃ x, S x ∧ reqB x :=
+  ⟨fun ⟨x, hx, hA⟩ => hassert ⟨x, hx, hA, (hhomog x hx).1 hA⟩,
+   fun ⟨x, hx, hB⟩ => hassert ⟨x, hx, (hhomog x hx).2 hB, hB⟩⟩
 
-| Puzzle | exh | pex | Status |
-|--------|-----|-----|--------|
-| Basic FC: ◇(p∨q) → ◇p∧◇q | ✓ | ✓ | `pex_fc` |
-| Double prohibition: ¬◇(p∨q) → ¬◇p∧¬◇q | needs economy | ✓ | `pex_double_prohibition` |
-| Negative FC: ¬□(p∧q) → ¬□p∧¬□q | needs economy | ✓ | `pex_negative_fc` |
-| FC under neg. factive | ✗ | ✓ | `fc_presupposed_under_neg_factive` |
-| Filtering FC | ✗ | ✓ | `filtering_fc` |
-| Universal FC | ✓ (matrix exh) | ✓ | `universal_fc` |
-| Existential FC | ✗ (matrix exh) | ✓ | `existential_fc` |
-| Universal neg. FC | ✗ | ✓ | `universal_negative_fc` |
-| Non-monotonic FC | problematic | ✓ | `exactly_one_fc` |
-| Non-monotonic DP | problematic | ✓ | `exactly_one_double_prohibition` |
+/-- (75): with an existential assertion, existential free choice. -/
+theorem existential_fc (permC permIC : Student → Prop)
+    (hassert : ∃ x, S x ∧ (permC x ∨ permIC x)) (hhomog : ∀ x, S x → (permC x ↔ permIC x)) :
+    ∃ x, S x ∧ permC x ∧ permIC x :=
+  let ⟨x, hx, h⟩ := hassert
+  ⟨x, hx, h.elim (fun hC => ⟨hC, (hhomog x hx).1 hC⟩) fun hIC => ⟨(hhomog x hx).2 hIC, hIC⟩⟩
 
-pex is the mirror image of "only" ([horn-1969]): *only* presupposes its
-prejacent and asserts the negation of alternatives; *pex* asserts its
-prejacent and presupposes the alternative-derived content. Both split meaning
-into assertive and presuppositional components; they swap which goes where.
+/-- (76a): under *exactly one*, the witness has free choice and every other student double
+prohibition. -/
+theorem exactly_one_fc (permL permC : Student → Prop) (x₀ : Student) (hx₀ : S x₀)
+    (hpos : permL x₀ ∨ permC x₀) (hneg : ∀ x, S x → x ≠ x₀ → ¬ (permL x ∨ permC x))
+    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
+    (permL x₀ ∧ permC x₀) ∧ ∀ x, S x → x ≠ x₀ → ¬ permL x ∧ ¬ permC x :=
+  ⟨hpos.elim (fun h => ⟨h, (hhomog x₀ hx₀).1 h⟩) fun h => ⟨(hhomog x₀ hx₀).2 h, h⟩,
+   fun x hx hne => ⟨fun h => hneg x hx hne (.inl h), fun h => hneg x hx hne (.inr h)⟩⟩
 
-The key advantage of pex is that embedded FC puzzles are solved by
-**standard presupposition projection** — no new mechanisms needed.
--/
-
--- ============================================================================
--- §9. Grounding: pex Predictions ← Projection Theory
--- ============================================================================
-
-/-!
-## Grounding in Projection Theory
-
-[delpinal-bassi-sauerland-2024]'s central claim is that pex solves embedded
-FC puzzles using *standard presupposition projection* — no new mechanisms. We
-verify this by showing each embedding prediction is derived from independently
-formalized projection infrastructure:
-
-| Prediction | Infrastructure | Bridge |
-|---|---|---|
-| Filtering FC (§4) | `localCtxSecondDisjunct` | `local_context_matches_disjFilterLeft` |
-| Presupposed FC (§3) | `transparentProjection` | `negFactive_entails_transparent` |
-| Double prohibition (§2) | `localCtxNegation` | definitional (`PartialProp.neg`) |
-| Quantificational FC (§5.1) | `forallPartial`/`existsPartialUniv`/`negExistsPartial` | universal projection |
-| Non-monotonic FC (§5.2) | universal homogeneity + cardinality | `exactly_one_fc` |
-| Accommodation (§4.4) | `heimSelect` | `accommodation_grounded_in_heim` |
--/
-
-variable {Agent : Type*}
-
-/-- Filtering FC is grounded in Schlenker's local context algorithm.
-
-    `filtering_fc` uses `PartialProp.disjFilterLeft` as a combinator.
-    `local_context_matches_disjFilterLeft` proves this is equivalent to
-    filtering at Schlenker's local context for the second disjunct:
-    the presupposition ψ of the second disjunct is satisfied in
-    the local context c ∧ ¬A iff ∀w∈c, ¬A(w) → ψ(w). -/
-theorem filtering_grounded_in_schlenker (c : ContextSet FCWorld)
-    (firstDisjunct : PartialProp FCWorld) (w : FCWorld) (hc : c w)
-    (hFirst : ¬firstDisjunct.assertion w)
-    (hSchlenkerFiltered : presupSatisfied
-      (localCtxSecondDisjunct c firstDisjunct) pexFC)
-    (hassert : pexFC.assertion w) :
-    permA w ∧ permB w :=
-  pex_fc w ⟨hSchlenkerFiltered ⟨hc, hFirst⟩, hassert⟩
-
-/-- Presupposed FC is grounded in transparent projection.
-
-    `fc_presupposed_under_neg_factive` uses `PartialProp.negFactive` as a
-    combinator. Here we decompose this into two steps:
-    1. `negFactive_entails_transparent`: negFactive's presupposition
-       (complement holds) entails transparent projection of the presup.
-    2. Transparent projection + assertion → FC.
-
-    This shows that presupposed FC is an instance of Schlenker's
-    transparent projection, not a stipulated combinator. -/
-theorem presupposed_fc_grounded_in_transparent
-    (globalCtx : ContextSet FCWorld)
-    (believes : (FCWorld → Prop) → FCWorld → Prop) (w : FCWorld)
-    (hGlobal : globalCtx w)
-    (hNegFactive : ∀ v, globalCtx v →
-      (PartialProp.negFactive pexFC believes).presup v) :
-    permA w ∧ permB w := by
-  -- Step 1: negFactive → transparent projection (presup holds globally)
-  have hTransparent : transparentProjection globalCtx pexFC :=
-    negFactive_entails_transparent pexFC believes globalCtx hNegFactive
-  -- Step 2: transparent projection provides the presup; negFactive provides the assertion
-  exact pex_fc w ⟨hTransparent hGlobal, (hNegFactive w hGlobal).2⟩
-
-/-- Opaque FC under belief embedding: when pex's presupposition is attributed
-    to the attitude holder (opaque projection), the agent *believes* FC.
-
-    "Noah believes he may have tea or cake":
-    - pex applies locally: assertion = ◇(t∨c), presup = ◇t ↔ ◇c
-    - Opaque projection: Noah believes ◇t ↔ ◇c
-    - Combined with Noah believes ◇(t∨c): Noah believes ◇t ∧ ◇c
-
-    Both opaque and transparent projection yield FC — they differ in
-    *whose* context the inference is anchored to. -/
-theorem opaque_fc_under_belief
-    (blc : BeliefLocalCtx FCWorld Agent) (w_star : FCWorld)
-    (hw_star : blc.globalCtx w_star)
-    (hOpaque : presupAttributedToHolder blc pexFC)
-    (hassert : ∀ v, blc.atWorld w_star v → pexFC.assertion v) :
-    ∀ v, blc.atWorld w_star v → permA v ∧ permB v := by
-  intro v hv
-  exact pex_fc v ⟨hOpaque w_star hw_star hv, hassert v hv⟩
-
-/-- Double prohibition is grounded in negation transparency.
-
-    `PartialProp.neg` preserves presuppositions by construction (assertion negated,
-    presupposition unchanged). This matches `negation_preserves_projection`:
-    Schlenker's local context under negation has the same world set as the
-    parent context, so presuppositions project through negation unchanged. -/
-theorem negation_grounding :
-    pexFC.neg.presup = pexFC.presup := rfl
-
-/-- Accommodation is grounded in Heim's global preference.
-
-    [delpinal-bassi-sauerland-2024] §4.4: in standard cases, pex's
-    homogeneity presupposition is accommodated globally (added to the
-    common ground). This follows from `heimSelect` choosing global
-    accommodation whenever the result is consistent.
-
-    The bridge: when global accommodation of pex's presupposition is
-    consistent, Heim's strategy selects global accommodation, matching
-    the paper's prediction that homogeneity projects to the top level.
-
-    In "enemy territory" (§4.4), local ACC blocks global projection —
-    this corresponds to the case where `heimSelect` falls back to local
-    because global accommodation would be inconsistent. -/
-theorem accommodation_grounded_in_heim {W : Type*}
-    (c : ContextSet W) (pex_output : PartialProp W)
-    (h_consistent : Set.Nonempty
-      (globalAccommodate c pex_output.presup)) :
-    heimSelect c pex_output.presup = .global :=
-  heim_projection_when_consistent c pex_output.presup h_consistent
-
-/-- When global accommodation is inconsistent (enemy territory), Heim's
-    strategy falls back to local accommodation — blocking projection.
-    This models the ACC operator from §4.4 that prevents homogeneity
-    from projecting in hostile environments. -/
-theorem enemy_territory_blocks_projection {W : Type*}
-    (c : ContextSet W) (pex_output : PartialProp W)
-    (h_inconsistent : ¬Set.Nonempty
-      (globalAccommodate c pex_output.presup)) :
-    heimSelect c pex_output.presup = .local :=
-  heim_cancellation_equivalence c pex_output.presup h_inconsistent
-
--- ============================================================================
--- §11. Gricean diagnostics — BPS non-cancellability
--- ============================================================================
-
-/-! ## Non-cancellability of pex outputs
-
-The marquee BPS-style diagnostic results, stated over
-(assertion, content) pairs via `Pragmatics/Implicature/Diagnostics.lean`.
-For any pex output the inferred content is the presupposed component;
-two non-cancellability theorems track the structural-vs-substantive
-distinction: `bps_not_cancellable` follows from the choice to set the
-assertion to `holds`; `bps_neg_not_cancellable` follows from projection
-of the presupposition through `PartialProp.neg`, the formal counterpart
-to BPS's family-of-sentences test. The `pexFC_*` corollaries instantiate
-both on the free-choice inference (◇A ∧ ◇B from ◇(A ∨ B)). -/
-
-open Exhaustification.Presuppositional
-
-/-- **BPS non-cancellability — structural form.** For any pex output
-`p`, with assertion `p.holds` and inferred content `p.presup`,
-non-cancellability follows from the trivial direction of
-`holds := presup ∧ assertion`. The substantive content lives in the
-choice to use `holds` (not `assertion`) as the assertion. -/
-theorem bps_not_cancellable {W : Type*} (p : PartialProp W) :
-    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w p) p.presup :=
-  Implicature.IsCancellable.false_of_assertion_implies_content (fun _ h => h.1)
-
-/-- **BPS non-cancellability — substantive form (projection through
-negation).** Even when the speaker asserts the negation of the pex
-output (`p.neg.holds`), the inferred content (`p.presup`) survives. The
-load-bearing step is that `PartialProp.neg` projects the presupposition
-(`(neg p).presup = p.presup`) — a structural property of the
-construction, not a logical tautology. This formalizes the
-family-of-sentences projection test [bassi-delpinal-sauerland-2021]
-contrasts with flat-EXH grammaticalism; swapping `PartialProp.neg` for
-the external Bochvar negation `PartialProp.negExt` would falsify it. -/
-theorem bps_neg_not_cancellable {W : Type*} (p : PartialProp W) :
-    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w p.neg) p.presup :=
-  Implicature.IsCancellable.false_of_assertion_implies_content (fun _ h => h.1)
-
-/-- **Structural non-cancellability** for the FCWorld instance: when the
-assertion is the full pex output (`pexFC.holds`), no continuation
-cancels the free-choice content `pexFC.presup` (the negated IE
-alternatives plus homogeneity over II alternatives — the *non-at-issue*
-content BPS treats as projective). -/
-theorem pexFC_not_cancellable :
-    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w pexFC) pexFC.presup :=
-  bps_not_cancellable pexFC
-
-/-- **Substantive non-cancellability — projection through negation.**
-Even after asserting `¬pexFC`, the free-choice inference (`pexFC.presup`,
-which yields `permA w ∧ permB w` by `pex_fc`) survives — BPS's
-projection argument: the inference is not at-issue, so embedding under
-negation does not cancel it. -/
-theorem pexFC_neg_not_cancellable :
-    ¬ Implicature.IsCancellable (fun w => PartialProp.holds w pexFC.neg) pexFC.presup :=
-  bps_neg_not_cancellable pexFC
+/-- (77a): under *exactly one … can't*, the witness has double prohibition and every other
+student free choice. -/
+theorem exactly_one_double_prohibition (permL permC : Student → Prop) (x₀ : Student)
+    (hneg : ¬ (permL x₀ ∨ permC x₀)) (hpos : ∀ x, S x → x ≠ x₀ → permL x ∨ permC x)
+    (hhomog : ∀ x, S x → (permL x ↔ permC x)) :
+    (¬ permL x₀ ∧ ¬ permC x₀) ∧ ∀ x, S x → x ≠ x₀ → permL x ∧ permC x :=
+  ⟨⟨fun h => hneg (.inl h), fun h => hneg (.inr h)⟩,
+   fun x hx hne => (hpos x hx hne).elim (fun h => ⟨h, (hhomog x hx).1 h⟩)
+     fun h => ⟨(hhomog x hx).2 h, h⟩⟩
 
 end DelPinalBassiSauerland2024


### PR DESCRIPTION
896 → ~175 lines. Cut: essay-length section prose restating the paper, the predictions table, a "grounding" section of substrate aliases (`heim_projection_when_consistent`, `disjFilterLeft_recovers`, two identical `rfl`s for negation), the four `h.1`-trivial "BPS non-cancellability" theorems, convenience re-exports, and the `*Partial` quantifier bridges whose content was a hypothesis. Kept and golfed: `pex_fc` (now via `permAorB_iff` and the II-membership lemmas), double prohibition, negative FC (19a)/(20) by relabelling, presupposed FC under negative factives, local-context filtering FC, and the §5 quantifier derivations (62)/(63)/(75)/(76)/(77).
- Two of the paper's *arguments against flat exh* are now theorems rather than `rfl` restatements: `pex_unaware_target` (the `pex` factive assertion denies belief in either disjunct, by `box_mono`) and `exh_unaware_too_weak` (a believer in free choice but not exclusivity satisfies the flat-`exh` factive assertion — witnessed on the five-world model); `exh_filtering_trivial` for §4.1.
- `BarLevFox2020.permAandB_is_ie` un-`private`d (consumed here); `Implicature/Diagnostics` docstring no longer names this file as its headline consumer.