### PR TITLE
refactor(Studies/Veltman1996): derive §4 frames from rule updates, decide the verdicts

### DIFF
--- a/Linglib/Logic/TweetyNixon.lean
+++ b/Linglib/Logic/TweetyNixon.lean
@@ -2,11 +2,11 @@ import Mathlib.Data.Fintype.Basic
 
 /-!
 # Tweety Triangle and Nixon Diamond
-[veltman-1996] [goldszmidt-pearl-1996] [asher-pelletier-2013]
+[goldszmidt-pearl-1996] [asher-pelletier-2013]
 
 The two classic default-reasoning testbeds, as finite world types shared
-by the rival accounts in `Studies/Veltman1996`, `Studies/GoldszmidtPearl1996`,
-and `Studies/AsherPelletier2013`:
+by the rival accounts in `Studies/GoldszmidtPearl1996` and
+`Studies/AsherPelletier2013`:
 
 1. **Tweety Triangle** (specificity): birds normally fly; penguins are
    birds; penguins normally don't fly. The more specific default wins.

--- a/Linglib/Studies/GoldszmidtPearl1996.lean
+++ b/Linglib/Studies/GoldszmidtPearl1996.lean
@@ -1,7 +1,6 @@
 import Linglib.Logic.SystemZ
 import Linglib.Logic.TweetyNixon
 import Linglib.Core.Probability.SoftmaxLimits
-import Linglib.Studies.Veltman1996
 import Mathlib.Algebra.Tropical.BigOperators
 
 /-!
@@ -32,10 +31,6 @@ from a set of defaults, using tolerance-based stratification.
 3. **Specificity**: More specific defaults automatically override
    general ones — penguinNoFly outranks penguinFlies because the
    penguin-specific rule has higher Z-priority.
-
-4. **Bridge to Veltman**: The κ^z ranking derives the same specificity
-   result that [veltman-1996] obtains by stipulating orderings.
-   We prove the agreement directly.
 
 ## Ranking Functions as RSA Limits
 
@@ -203,7 +198,7 @@ theorem birds_fly :
   cases w <;> simp_all [isBird, flies]
   all_goals exact ⟨.birdFlies, trivial, trivial, by decide⟩
 
-/-! ### Specificity: κ^z Derives What Veltman Stipulates -/
+/-! ### Specificity -/
 
 /-- The κ^z ranking makes penguinNoFly strictly more plausible than
     penguinFlies. -/
@@ -220,34 +215,6 @@ theorem general_default_preserved :
 theorem κz_connected :
     Core.Order.Normality.connected κ_z.toPlausibilityOrder.toPreorder :=
   κ_z.ranking_connected
-
-/-! ### Bridge to Veltman 1996
-
-[veltman-1996] manually stipulates subdomain orderings to
-resolve the Tweety Triangle: `birdOrd` promotes flying,
-`penguinOrd` promotes not-flying. The key result is
-`penguinFlies_not_normal_in_birds` — penguinFlies fails the
-normality test because the penguin subdomain ordering demotes it.
-
-G&P's System Z *derives* the same specificity result from the
-rules alone, without any stipulated orderings. The following
-theorem makes this derivation-vs-stipulation relationship explicit
-by combining both papers' conclusions. -/
-
-open Veltman1996 in
-
-/-- What [veltman-1996] stipulates about penguin normality,
-    [goldszmidt-pearl-1996]'s System Z derives:
-    - Veltman: penguinFlies is not normal among birds (via stipulated
-      penguin subdomain ordering)
-    - G&P: penguinFlies has strictly higher κ^z rank than birdFlies
-      (derived from tolerance stratification alone)
-    Both reach the same conclusion: flying penguins are less normal
-    than non-flying penguins in a bird context. -/
-theorem gp_derives_veltman_specificity :
-    TweetyWorld.penguinFlies ∉ tweetyFrame.normal birdDomain ∧
-    κ_z.rank .penguinFlies > κ_z.rank .birdFlies :=
-  ⟨penguinFlies_not_normal_in_birds, by decide⟩
 
 /-! ### RSA Bridge Substrate: Rankings as Softmax Limits
 

--- a/Linglib/Studies/Veltman1996.lean
+++ b/Linglib/Studies/Veltman1996.lean
@@ -1,75 +1,59 @@
-import Linglib.Logic.TweetyNixon
-import Linglib.Core.Order.Normality
-import Linglib.Semantics.Dynamic.UpdateSemantics.Basic
 import Linglib.Semantics.Dynamic.UpdateSemantics.Default
-import Linglib.Semantics.Dynamic.State
+import Mathlib.Data.Fintype.Powerset
 
 /-!
-# [veltman-1996] — Full Study
+# Veltman (1996): defaults in update semantics
 
-[veltman-1996]
+[veltman-1996] treats *normally φ* as an update of an agent's expectations rather than a
+sentence about them: a state is a pair of an expectation pattern (a preorder on worlds) and
+the agent's knowledge of the facts, *normally φ* refines the pattern in favour of `φ`-worlds,
+and *presumably φ* tests whether `φ` holds in the optimal worlds of the state. That §3
+system is `Semantics/Dynamic/UpdateSemantics/Default.lean`; the first section checks its
+Examples 3.10 on the paper's four worlds, the rain-or-snow contrast that shows *normally
+(p ∨ q)* to be stronger than *normally p*, and `normally_not_normally_or`.
 
-Regression tests for [veltman-1996]'s update semantics with defaults,
-together with the §4 expectation-frame apparatus they run on.
+The heart of the paper (§4) adds *restricted* rules *if φ, then normally ψ* (`φ ⇝ ψ`): an
+**expectation frame** assigns a pattern to every domain `d` of worlds (Definition 4.2), a
+world is **normal** in `d` when it is top-ranked in every subdomain containing it
+(Definition 4.3), a frame is **coherent** when every nonempty domain has a normal world,
+accepting `φ ⇝ ψ` refines the pattern at `⟦φ⟧` and crashes when the result is incoherent
+(Definitions 4.5–4.6), and a set of defaults **applies within** `s` when every domain
+extending `s` has a normal world complying with them (Definition 4.9). The optimal worlds
+of a state comply with a maximal applicable set of defaults (Definition 4.13), which
+Proposition 4.14 lets one compute over the explicitly accepted rules. Since every frame an
+agent reaches from the minimal state is the refinement of the total frame by the rules it
+has accepted, a frame is presented here by its list of rules (`Frame.ofRules`): that makes
+coherence, normality, applicability and the optimal worlds decidable, so each verdict of
+the paper is checked by `decide` on Veltman's eight worlds over the atoms `p`, `q`, `r`.
+Validity is his validity₁ (§1.2): the minimal state updated with the premises in order
+accepts the conclusion (`Valid`).
 
-## §3 Examples (Examples 3.10)
-
-Finite verification of the key properties of "normally" and "presumably"
-over a 4-world type with atoms p, q.
-
-## §4 Expectation Frames
-
-Where §3 uses a single normality ordering for all domains, §4 (Veltman's
-"heart of the paper") assigns a *per-domain* ordering via an **expectation
-frame**, enabling conditional defaults "if φ then normally ψ". A world is
-*normal* in a domain (Definition 4.3) when it is top-ranked in *every*
-subdomain containing it — this is how a specific exception overrides a
-general default without the general default knowing about it. Refinement
-(`ExpFrame.refineAt`, Definition 4.5) modifies only the pattern at the
-target domain; the effect on superdomains flows through the subdomain-
-checking `normal`. For a constant frame with a connected ordering, §4
-`normal` reduces to §3 `optimal`.
-
-## §4 Specificity (Tweety Triangle & Nixon Diamond)
-
-Expectation frames resolve specificity (Tweety) and conflicting
-defaults (Nixon) using the subdomain-indexed normality check.
-
-## §5 Inference Patterns
-
-Conjunction of Consequents (CC) is valid for the default conditional ⇝.
-Contraposition and Strengthening the Antecedent fail (counterexamples).
-
-## §5–6 Generics Bridge
-
-The normality ordering in update semantics plays the same role as
-the normalcy predicate in the GEN operator for generic sentences.
+Proved in general: Definition 4.5's refinement clause as theorems about the presentation
+(`ofRules_cons_self`, `ofRules_cons_of_ne`), Proposition 4.7 as the equivalence of
+coherent acceptance with the new rule's applicability within its own domain
+(`coherent_cons_iff`), Conditional Identity and Conjunction of Consequents (`rule_self`,
+`conjConsequents`), and the §5 observation that Weakening the Consequent never crashes a
+state (`weakenConsequent_coherent`). Checked on the model: Examples 4.8 and 4.11, the §5
+benchmarks (the Nixon diamond, the student–adult–employment argument, Independence), the
+validity of defeasible Modus Tollens and of Modus Ponens over Modus Tollens on a cyclic
+net, the failure of Hypothetical Syllogism, Contraposition and Strengthening the Antecedent
+together with their defeasible versions, and the near-validity of Strengthening with a
+Consequent and Disjunction of Antecedents.
 -/
 
 namespace Veltman1996
 
-open TweetyNixon
-open UpdateSemantics.Default
-open Core.Order
-open Classical
+open Core.Order UpdateSemantics.Default
 
+/-! ### Rules with exceptions (§3) -/
 
--- ═══════════════════════════════════════════════════════════════════════
--- PQ WORLDS (shared across sections)
--- ═══════════════════════════════════════════════════════════════════════
-
-/-- Four worlds determined by atoms p, q. -/
-inductive PQWorld : Type where
-  | w₀  -- ¬p, ¬q
-  | w₁  -- p, ¬q
-  | w₂  -- ¬p, q
-  | w₃  -- p, q
-  deriving DecidableEq, Repr
+/-- Veltman's four worlds over the atoms `p`, `q`: `w₀ = ∅`, `w₁ = {p}`, `w₂ = {q}`,
+`w₃ = {p, q}`. -/
+inductive PQWorld where
+  | w₀ | w₁ | w₂ | w₃
+  deriving DecidableEq
 
 open PQWorld
-
-instance : Fintype PQWorld :=
-  ⟨⟨[w₀, w₁, w₂, w₃], by decide⟩, fun w => by cases w <;> decide⟩
 
 def atomP : PQWorld → Prop
   | .w₁ | .w₃ => True
@@ -79,856 +63,449 @@ def atomQ : PQWorld → Prop
   | .w₂ | .w₃ => True
   | _ => False
 
--- Atom truth values
 private theorem atomP_w₀ : ¬atomP w₀ := id
-private theorem atomP_w₁ : atomP w₁ := True.intro
+private theorem atomP_w₁ : atomP w₁ := trivial
 private theorem atomP_w₂ : ¬atomP w₂ := id
-private theorem atomP_w₃ : atomP w₃ := True.intro
+private theorem atomP_w₃ : atomP w₃ := trivial
 private theorem atomQ_w₀ : ¬atomQ w₀ := id
 private theorem atomQ_w₁ : ¬atomQ w₁ := id
-private theorem atomQ_w₂ : atomQ w₂ := True.intro
-private theorem atomQ_w₃ : atomQ w₃ := True.intro
+private theorem atomQ_w₂ : atomQ w₂ := trivial
+private theorem atomQ_w₃ : atomQ w₃ := trivial
 
-/-- Initial expectation state: all worlds possible, all equally normal. -/
+/-- The minimal state `0`. -/
 private def σ₀ : ExpState PQWorld := ExpState.init
 
+/-- Rules can have exceptions: after *normally p*, learning `¬p` does not crash (3.10(i)). -/
+theorem ex310_exception : ((σ₀.promote atomP).assert (¬atomP ·)).info.Nonempty :=
+  ⟨w₀, Set.mem_univ _, atomP_w₀⟩
 
--- ═══════════════════════════════════════════════════════════════════════
--- §3 EXAMPLES (Examples 3.10)
--- ═══════════════════════════════════════════════════════════════════════
-
-section Examples310
-
--- ─── Example 3.10(i): Rules can have exceptions ───
-
-/-- After "normally p", learning ¬p doesn't crash — the info state
-    still has ¬p-worlds. Rules can have exceptions. -/
-theorem ex310_i_exception :
-    ((σ₀.promote atomP).assert (fun w => ¬atomP w)).info.Nonempty :=
-  ⟨w₀, ⟨Set.mem_univ _, atomP_w₀⟩⟩
-
-/-- After "normally p", the globally optimal worlds are exactly the
-    p-worlds. So "normally ¬p" is unacceptable: no optimal world
-    satisfies ¬p. This is [veltman-1996]'s coherence check
-    (Definition 3.9). -/
-theorem ex310_i_conflict :
+/-- But the opposite rule is then unacceptable: no optimal world of `0[normally p]` is a
+`¬p`-world (3.10(i)). -/
+theorem ex310_conflict :
     ¬∃ w ∈ Normality.optimal (σ₀.promote atomP).order Set.univ, ¬atomP w := by
-  intro ⟨w, hw_opt, hnp⟩
-  have hex : ∃ v ∈ (Set.univ : Set PQWorld), atomP v :=
-    ⟨w₁, Set.mem_univ _, atomP_w₁⟩
-  simp only [ExpState.promote, σ₀, ExpState.init] at hw_opt
-  rw [Normality.refine_total_optimal atomP Set.univ hex] at hw_opt
-  exact hnp hw_opt.2
+  rintro ⟨w, hw, hnp⟩
+  have hw' : w ∈ Normality.optimal (Normality.refine Normality.total atomP) Set.univ := hw
+  rw [Normality.refine_total_optimal atomP Set.univ ⟨w₁, Set.mem_univ _, atomP_w₁⟩] at hw'
+  exact hnp hw'.2
 
--- ─── Example 3.10(ii): Exceptions defeat presumptions ───
+private theorem w₀_optimal : w₀ ∈ ((σ₀.promote atomP).assert (¬atomP ·)).optimal :=
+  ⟨⟨Set.mem_univ _, atomP_w₀⟩, fun _ ⟨_, hnpv⟩ _ => ⟨trivial, fun hpv => absurd hpv hnpv⟩⟩
 
-/-- After "normally p" then learning ¬p, "presumably p" fails.
-    The optimal worlds in {w | ¬p w} are all ¬p-worlds (mutually
-    equivalent under the p-biased ordering).
+/-- Exceptions defeat presumptions: *normally p, ¬p ⊮ presumably p* (3.10(ii)). -/
+theorem ex310_defeat :
+    ¬∀ w ∈ ((σ₀.promote atomP).assert (¬atomP ·)).optimal, atomP w :=
+  fun h => atomP_w₀ (h w₀ w₀_optimal)
 
-    [veltman-1996], Examples 3.10(ii): normally p, ¬p ⊬ presumably p. -/
-theorem ex310_ii_defeat :
-    ¬∀ w ∈ ((σ₀.promote atomP).assert (fun w => ¬atomP w)).optimal,
-      atomP w := by
-  intro h
-  apply h w₀
-  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
-    Normality.optimal]
-  refine ⟨⟨Set.mem_univ _, atomP_w₀⟩, fun v ⟨_, hnpv⟩ _ => ?_⟩
-  exact ⟨True.intro, fun hpv => absurd hpv hnpv⟩
-
-/-- But exceptions don't destroy the rule: "normally p" still holds.
-
-    [veltman-1996], Examples 3.10(ii): normally p, ¬p ⊩ normally p. -/
-theorem ex310_ii_rule_persists :
-    Normality.respects ((σ₀.promote atomP).assert (fun w => ¬atomP w)).order atomP :=
+/-- But not the rule: *normally p, ¬p ⊩ normally p* (3.10(ii)). -/
+theorem ex310_rule_persists :
+    Normality.respects ((σ₀.promote atomP).assert (¬atomP ·)).order atomP :=
   persistence_assert (σ₀.promote atomP) atomP _ (normally_creates_respect σ₀ atomP)
 
--- ─── Example 3.10(iii): Irrelevant information ───
-
-/-- Irrelevant information doesn't block presumptions: after
-    "normally p" and learning q, "presumably p" still succeeds.
-
-    [veltman-1996], Examples 3.10(iii): normally p, q ⊩ presumably p. -/
-theorem ex310_iii_irrelevant :
-    ∀ w ∈ ((σ₀.promote atomP).assert atomQ).optimal, atomP w := by
-  intro w ⟨⟨_, hqw⟩, hopt⟩
-  simp only [ExpState.promote, σ₀, ExpState.init] at hopt
+/-- Irrelevant information does not block a presumption: *normally p, q ⊩ presumably p*
+(3.10(iii)). -/
+theorem ex310_irrelevant : ∀ w ∈ ((σ₀.promote atomP).assert atomQ).optimal, atomP w := by
+  rintro w ⟨_, hopt⟩
   by_contra hnpw
-  have hle : (Normality.refine Normality.total atomP).le w₃ w :=
-    ⟨True.intro, fun _ => atomP_w₃⟩
-  have hw₃_mem : w₃ ∈ ({w ∈ Set.univ | atomQ w} : Set PQWorld) :=
-    ⟨Set.mem_univ _, atomQ_w₃⟩
-  exact hnpw ((hopt hw₃_mem hle).2 atomP_w₃)
+  exact hnpw ((hopt ⟨Set.mem_univ _, atomQ_w₃⟩ ⟨trivial, fun _ => atomP_w₃⟩).2 atomP_w₃)
 
--- ─── Example 3.10(iv): Independent defaults ───
-
-/-- One default being defeated doesn't affect unrelated defaults.
-
-    [veltman-1996], Examples 3.10(iv):
-    normally p, normally q, ¬p ⊩ presumably q. -/
-theorem ex310_iv_independence :
-    ∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬atomP w)).optimal,
-      atomQ w := by
-  intro w ⟨⟨_, hnpw⟩, hopt⟩
-  simp only [ExpState.promote, σ₀, ExpState.init] at hopt
+/-- Independence: *normally p, normally q, ¬p ⊩ presumably q* (3.10(iv)). -/
+theorem ex310_independence :
+    ∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (¬atomP ·)).optimal, atomQ w := by
+  rintro w ⟨⟨_, hnpw⟩, hopt⟩
   by_contra hnqw
-  -- w₂ (¬p, q) dominates any ¬p ∧ ¬q world
-  have hle : (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₂ w :=
-    ⟨⟨True.intro, fun hpw => absurd hpw hnpw⟩, fun hqw => absurd hqw hnqw⟩
-  have hw₂_mem : w₂ ∈ ({w ∈ Set.univ | ¬atomP w} : Set PQWorld) :=
-    ⟨Set.mem_univ _, atomP_w₂⟩
-  exact hnqw ((hopt hw₂_mem hle).2 atomQ_w₂)
+  exact hnqw ((hopt ⟨Set.mem_univ _, atomP_w₂⟩
+    ⟨⟨trivial, fun hpw => absurd hpw hnpw⟩, fun hqw => absurd hqw hnqw⟩).2 atomQ_w₂)
 
--- ─── Example 3.10(v): Ambiguity ───
+/-- Ambiguity: *normally p, normally q, ¬(p ∧ q)* presumes neither `p` nor `q`
+(3.10(v)). -/
+theorem ex310_ambiguity :
+    let σ := ((σ₀.promote atomP).promote atomQ).assert fun w => ¬(atomP w ∧ atomQ w)
+    ¬(∀ w ∈ σ.optimal, atomP w) ∧ ¬(∀ w ∈ σ.optimal, atomQ w) := by
+  refine ⟨fun h => atomP_w₂ (h w₂ ⟨⟨Set.mem_univ _, fun ⟨hp, _⟩ => atomP_w₂ hp⟩, ?_⟩),
+    fun h => atomQ_w₁ (h w₁ ⟨⟨Set.mem_univ _, fun ⟨_, hq⟩ => atomQ_w₁ hq⟩, ?_⟩)⟩
+  · rintro v ⟨_, hnpq⟩ ⟨⟨_, _⟩, hqv⟩
+    exact ⟨⟨trivial, fun hpv => absurd ⟨hpv, hqv atomQ_w₂⟩ hnpq⟩, fun _ => atomQ_w₂⟩
+  · rintro v ⟨_, hnpq⟩ ⟨⟨_, hpv⟩, _⟩
+    exact ⟨⟨trivial, fun _ => atomP_w₁⟩, fun hqv => absurd ⟨hpv atomP_w₁, hqv⟩ hnpq⟩
 
-/-- When two defaults conflict with the facts, neither presumption
-    goes through. w₂ (¬p, q) is optimal but ¬p, so "presumably p" fails.
+/-- *Normally it rains; it is not raining; so presumably it snows* is invalid, but
+*normally it rains or snows; it is not raining; so presumably it snows* is valid (§3): a
+rule *normally (p ∨ q)* says what to expect when `p` fails. -/
+theorem rain_or_snow :
+    ¬(∀ w ∈ ((σ₀.promote atomP).assert (¬atomP ·)).optimal, atomQ w) ∧
+      ∀ w ∈ ((σ₀.promote fun w => atomP w ∨ atomQ w).assert (¬atomP ·)).optimal, atomQ w := by
+  refine ⟨fun h => atomQ_w₀ (h w₀ w₀_optimal), ?_⟩
+  rintro w ⟨⟨_, hnpw⟩, hopt⟩
+  by_contra hnqw
+  exact ((hopt ⟨Set.mem_univ _, atomP_w₂⟩ ⟨trivial, fun _ => Or.inr atomQ_w₂⟩).2
+    (Or.inr atomQ_w₂)).elim hnpw hnqw
 
-    [veltman-1996], Examples 3.10(v):
-    normally p, normally q, ¬(p ∧ q) ⊬ presumably p. -/
-theorem ex310_v_ambiguity_p :
-    ¬∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬(atomP w ∧ atomQ w))).optimal,
-      atomP w := by
+/-- Hence *normally p ⊮ normally (p ∨ q)*: the second rule further refines the pattern. -/
+theorem normally_not_normally_or :
+    (σ₀.promote atomP).promote (fun w => atomP w ∨ atomQ w) ≠ σ₀.promote atomP := by
   intro h
-  apply h w₂
-  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
-    Normality.optimal]
-  refine ⟨⟨Set.mem_univ _, fun ⟨hp, _⟩ => atomP_w₂ hp⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
-  -- hle gives atomQ v (via the atomQ-refinement component evaluated at w₂)
-  obtain ⟨⟨_, _⟩, hqv_imp⟩ := hle
-  have hqv : atomQ v := hqv_imp atomQ_w₂
-  show (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₂ v
-  exact ⟨⟨True.intro, fun hpv => absurd ⟨hpv, hqv⟩ hnpq⟩, fun _ => atomQ_w₂⟩
+  have h' : Normality.refine (Normality.refine Normality.total atomP)
+      (fun w => atomP w ∨ atomQ w) = Normality.refine Normality.total atomP :=
+    congrArg ExpState.order h
+  have hle : (Normality.refine (Normality.refine Normality.total atomP)
+      fun w => atomP w ∨ atomQ w).le w₀ w₂ := by
+    rw [h']; exact ⟨trivial, fun hp => absurd hp atomP_w₂⟩
+  exact (hle.2 (Or.inr atomQ_w₂)).elim atomP_w₀ atomQ_w₀
 
-/-- Symmetric: w₁ (p, ¬q) is optimal but ¬q, so "presumably q" fails.
-
-    [veltman-1996], Examples 3.10(v):
-    normally p, normally q, ¬(p ∧ q) ⊬ presumably q. -/
-theorem ex310_v_ambiguity_q :
-    ¬∀ w ∈ (((σ₀.promote atomP).promote atomQ).assert (fun w => ¬(atomP w ∧ atomQ w))).optimal,
-      atomQ w := by
-  intro h
-  apply h w₁
-  simp only [ExpState.optimal, ExpState.assert, ExpState.promote, σ₀, ExpState.init,
-    Normality.optimal]
-  refine ⟨⟨Set.mem_univ _, fun ⟨_, hq⟩ => atomQ_w₁ hq⟩, fun v ⟨_, hnpq⟩ hle => ?_⟩
-  -- hle gives atomP v (via the atomP-refinement component evaluated at w₁)
-  obtain ⟨⟨_, hpv_imp⟩, _⟩ := hle
-  have hpv : atomP v := hpv_imp atomP_w₁
-  show (Normality.refine (Normality.refine Normality.total atomP) atomQ).le w₁ v
-  exact ⟨⟨True.intro, fun _ => atomP_w₁⟩, fun hqv => absurd ⟨hpv, hqv⟩ hnpq⟩
-
-end Examples310
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §4 EXPECTATION FRAMES (apparatus)
--- ═══════════════════════════════════════════════════════════════════════
-
-section ExpectationFrames
+/-! ### Rules for exceptions (§4) -/
 
 variable {W : Type*}
 
-/-! ### Expectation frames -/
+/-- A restricted rule `φ ⇝ ψ`: `default` is a default in the domain `domain`. -/
+structure Rule (W : Type*) where
+  domain : Finset W
+  default : Finset W
+  deriving DecidableEq
 
-/-- An **expectation frame**: a function assigning a normality ordering
-    to each domain (subset of worlds).
+/-- An expectation frame assigns to every domain `d` a pattern on `d` (Definition 4.2). -/
+abbrev Frame (W : Type*) := (d : Finset W) → Preorder d
 
-    [veltman-1996], Definition 4.2: π assigns to every d ⊆ W an
-    expectation pattern πd. Different domains may have different
-    orderings — this is what enables conditional defaults. -/
-structure ExpFrame (W : Type*) where
-  /-- The per-domain normality ordering -/
-  pattern : Set W → Preorder W
+/-- The frame presented by a list of rules: the pattern at `d` is the total pattern refined
+by the defaults of the rules with domain `d` (Proposition 4.14). -/
+@[reducible] def Frame.ofRules (R : List (Rule W)) : Frame W := fun d =>
+  Preorder.ofCriteria (fun (w : d) (r : Rule W) => w.1 ∈ r.default) {r | r ∈ R ∧ r.domain = d}
 
-/-- Extensionality for frames: two frames are equal iff they assign
-    the same ordering to every domain. -/
-@[ext]
-theorem ExpFrame.ext {π₁ π₂ : ExpFrame W}
-    (h : ∀ d, π₁.pattern d = π₂.pattern d) : π₁ = π₂ := by
-  cases π₁; cases π₂; congr; funext d; exact h d
+/-- Refinement at the rule's own domain (Definition 4.5(ii)(b)): the pattern at
+`r.domain` is the old one refined with `r.default`. -/
+theorem Frame.ofRules_cons_self (r : Rule W) (R : List (Rule W)) :
+    Frame.ofRules (r :: R) r.domain =
+      Normality.refine (Frame.ofRules R r.domain) (fun w => w.1 ∈ r.default) :=
+  Preorder.ext fun w v =>
+    ⟨fun h => ⟨fun c hc => h c ⟨List.mem_cons_of_mem _ hc.1, hc.2⟩, h r ⟨List.mem_cons_self, rfl⟩⟩,
+     fun h c hc => by
+      rcases List.mem_cons.1 hc.1 with rfl | hc' <;> [exact h.2; exact h.1 c ⟨hc', hc.2⟩]⟩
 
-/-- The **normal worlds** in a domain under the frame.
+/-- Other domains are untouched (Definition 4.5(ii)(a)). -/
+theorem Frame.ofRules_cons_of_ne (r : Rule W) (R : List (Rule W)) {d : Finset W}
+    (h : d ≠ r.domain) : Frame.ofRules (r :: R) d = Frame.ofRules R d :=
+  Preorder.ext fun _ _ =>
+    ⟨fun h' c hc => h' c ⟨List.mem_cons_of_mem _ hc.1, hc.2⟩, fun h' c hc => by
+      rcases List.mem_cons.1 hc.1 with rfl | hc'
+      · exact absurd hc.2 h.symm
+      · exact h' c ⟨hc', hc.2⟩⟩
 
-    [veltman-1996], Definition 4.3(i–ii): w is normal in πd iff w ∈ d
-    and for every subdomain d' ⊆ d such that w ∈ d', w is at least as
-    normal as every v ∈ d' under πd'.
+/-- `w` is normal in `πd` (Definition 4.3(i)): `w ∈ d` and `w` is at least as normal as every
+world of every subdomain of `d` containing it, under that subdomain's pattern. -/
+def Normal (π : Frame W) (d : Finset W) (w : W) : Prop :=
+  w ∈ d ∧ ∀ d' ⊆ d, ∀ hw : w ∈ d', ∀ v, ∀ hv : v ∈ d', (π d').le ⟨w, hw⟩ ⟨v, hv⟩
 
-    This is stronger than just being optimal in d under πd: w must be
-    top-ranked in *every* subdomain's pattern, not just the top-level
-    one. This is how specificity works — a more specific exception
-    (governing a subdomain) overrides a general default by making the
-    world non-normal at the subdomain level. -/
-def ExpFrame.normal (π : ExpFrame W) (d : Set W) : Set W :=
-  { w ∈ d | ∀ d', d' ⊆ d → w ∈ d' → ∀ v ∈ d', (π.pattern d').le w v }
+/-- In a presented frame, only the rules' own domains can disqualify a world. -/
+theorem normal_ofRules_iff (R : List (Rule W)) (d : Finset W) (w : W) :
+    Normal (Frame.ofRules R) d w ↔ w ∈ d ∧ ∀ r ∈ R, r.domain ⊆ d → w ∈ r.domain →
+      ∀ v ∈ r.domain, v ∈ r.default → w ∈ r.default :=
+  and_congr_right fun _ =>
+    ⟨fun h r hr hsub hw v hv => h r.domain hsub hw v hv r ⟨hr, rfl⟩,
+     fun h d' hsub hw v hv r ⟨hr, hd⟩ => by subst hd; exact h r hr hsub hw v hv⟩
 
-/-- A frame is **coherent** if every non-empty domain has at least
-    one normal world.
+/-- A world normal in a domain is normal in every subdomain containing it. -/
+theorem Normal.mono {π : Frame W} {d d' : Finset W} {w : W} (h : Normal π d w) (hw : w ∈ d')
+    (hd : d' ⊆ d) : Normal π d' w :=
+  ⟨hw, fun _ hsub => h.2 _ (hsub.trans hd)⟩
 
-    [veltman-1996], Definition 4.3(iii). -/
-def ExpFrame.coherent (π : ExpFrame W) : Prop :=
-  ∀ d : Set W, d.Nonempty → (π.normal d).Nonempty
+/-- Accepting a rule can only remove normal worlds. -/
+theorem Normal.of_cons {r : Rule W} {R : List (Rule W)} {d : Finset W} {w : W}
+    (h : Normal (Frame.ofRules (r :: R)) d w) : Normal (Frame.ofRules R) d w :=
+  (normal_ofRules_iff ..).2 ⟨h.1, fun r' hr' =>
+    ((normal_ofRules_iff ..).1 h).2 r' (List.mem_cons_of_mem _ hr')⟩
 
-/-- e is a **default in πd** iff d ∩ e ≠ ∅ and πd already respects e.
+variable [DecidableEq W]
 
-    [veltman-1996], Definition 4.2(ii): e is a default in πd iff
-    d ∩ e ≠ ∅ and πd ∘ e = πd. Since `refine_of_respects` gives
-    the latter iff `respects`, we use `respects` directly. -/
-def ExpFrame.isDefault (π : ExpFrame W) (d : Set W) (e : W → Prop) :
-    Prop :=
-  (∃ w ∈ d, e w) ∧ Normality.respects (π.pattern d) e
+instance (R : List (Rule W)) (d : Finset W) : DecidableRel (Frame.ofRules R d).le := fun w v =>
+  decidable_of_iff (∀ r ∈ R, r.domain = d → v.1 ∈ r.default → w.1 ∈ r.default)
+    ⟨fun h c ⟨hc, hd⟩ => h c hc hd, fun h c hc hd => h c ⟨hc, hd⟩⟩
 
-/-- The **constant frame**: assigns the same ordering to every domain.
-    This embeds §3's single-ordering setup into the §4 framework. -/
-def ExpFrame.const (no : Preorder W) : ExpFrame W :=
-  ⟨fun _ => no⟩
+instance (R : List (Rule W)) (d : Finset W) : DecidablePred (Normal (Frame.ofRules R) d) :=
+  fun w => decidable_of_iff _ (normal_ofRules_iff R d w).symm
 
-/-- The **total frame**: assigns the total ordering to every domain.
-    The initial state before any defaults have been processed. -/
-def ExpFrame.total : ExpFrame W :=
-  ExpFrame.const Normality.total
+/-- The normal worlds `nπd` (Definition 4.3(ii)). -/
+def normal (π : Frame W) (d : Finset W) [DecidablePred (Normal π d)] : Finset W :=
+  d.filter (Normal π d)
 
-/-! ### Frame refinement -/
+/-- `w` complies with the defaults `D` (Definition 4.9(i)). -/
+def Complies (w : W) (D : List (Rule W)) : Prop := ∀ r ∈ D, w ∈ r.domain → w ∈ r.default
 
-/-- **Frame refinement**: refine the ordering at domain d only.
+instance (w : W) (D : List (Rule W)) : Decidable (Complies w D) :=
+  inferInstanceAs (Decidable (∀ r ∈ D, w ∈ r.domain → w ∈ r.default))
 
-    [veltman-1996], Definition 4.5(ii):
-    - π_{d∘e}(d') = πd' if d' ≠ d
-    - π_{d∘e}(d) = πd ∘ e
+/-- `e` is a default in `πd` (Definition 4.2(ii)): `d ∩ e ≠ ∅` and `πd ∘ e = πd`, i.e. `πd`
+already respects `e` (`Normality.refine_of_respects`). -/
+def IsDefault (π : Frame W) (d e : Finset W) : Prop :=
+  (d ∩ e).Nonempty ∧ Normality.respects (π d) (fun w => w.1 ∈ e)
 
-    Unlike our earlier (incorrect) version that refined all d' ⊇ d,
-    this modifies *only* the pattern at d. The effect on superdomains
-    comes automatically through the `normal` computation, which checks
-    all subdomains — so a refinement at d changes which worlds count as
-    normal in any d' ⊇ d. -/
-noncomputable def ExpFrame.refineAt (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) : ExpFrame W :=
-  ⟨fun d' => if d' = d then Normality.refine (π.pattern d) e else π.pattern d'⟩
+/-- Every accepted rule with a nonempty domain-default intersection is a default of the
+presented frame. -/
+theorem isDefault_of_mem {R : List (Rule W)} {r : Rule W} (hr : r ∈ R)
+    (hne : (r.domain ∩ r.default).Nonempty) : IsDefault (Frame.ofRules R) r.domain r.default :=
+  ⟨hne, fun _ _ h hv => h r ⟨hr, rfl⟩ hv⟩
 
-/-- Domains other than d are unchanged by refinement. -/
-theorem ExpFrame.refineAt_unchanged (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) (d' : Set W) (h : d' ≠ d) :
-    (π.refineAt d e).pattern d' = π.pattern d' := by
-  unfold refineAt; exact if_neg h
+/-- Conjunction of Consequents: once `φ ⇝ ψ` and `φ ⇝ χ` have been accepted, the pattern
+at `⟦φ⟧` respects `ψ ∧ χ`, so `φ ⇝ (ψ ∧ χ)` refines nothing. -/
+theorem conjConsequents {R : List (Rule W)} {φ ψ χ : Finset W}
+    (hψ : ⟨φ, ψ⟩ ∈ R) (hχ : ⟨φ, χ⟩ ∈ R) :
+    Frame.ofRules (⟨φ, ψ ∩ χ⟩ :: R) = Frame.ofRules R := by
+  refine funext fun d => Preorder.ext fun w v =>
+    ⟨fun h c hc => h c ⟨List.mem_cons_of_mem _ hc.1, hc.2⟩, fun h c hc => ?_⟩
+  rcases List.mem_cons.1 hc.1 with rfl | hc'
+  · exact fun hv => Finset.mem_inter.2
+      ⟨h _ ⟨hψ, hc.2⟩ (Finset.mem_inter.1 hv).1, h _ ⟨hχ, hc.2⟩ (Finset.mem_inter.1 hv).2⟩
+  · exact h c ⟨hc', hc.2⟩
 
-/-- The target domain gets its ordering refined. -/
-theorem ExpFrame.refineAt_target (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) :
-    (π.refineAt d e).pattern d = Normality.refine (π.pattern d) e := by
-  unfold refineAt; exact if_pos rfl
+/-- A frame is coherent when every nonempty domain has a normal world (Definition 4.3(iii)). -/
+def Coherent (π : Frame W) [∀ d, DecidablePred (Normal π d)] : Prop :=
+  ∀ d : Finset W, d.Nonempty → (normal π d).Nonempty
 
-/-! ### Frame state -/
+/-- The defaults `D` jointly apply within `s` (Definition 4.9(ii)): every domain extending
+`s` has a normal world complying with them. -/
+def Applies (π : Frame W) [∀ d, DecidablePred (Normal π d)] (D : List (Rule W))
+    (s : Finset W) : Prop :=
+  ∀ d : Finset W, s ⊆ d → ∃ w ∈ normal π d, Complies w D
 
-/-- An **expectation state with frame**: an information state paired
-    with an expectation frame.
-
-    Veltman's §4 notation: σ = ⟨π, s⟩ where π is a frame and
-    s ⊆ W is the information state. This generalizes `ExpState`
-    from §3 (which uses a single ordering). -/
-structure FrameState (W : Type*) where
-  /-- The information state -/
-  info : Set W
-  /-- The expectation frame -/
-  frame : ExpFrame W
-
-/-- Normal worlds in the current state: the most normal worlds
-    in the info state according to the frame. -/
-def FrameState.normal (σ : FrameState W) : Set W :=
-  σ.frame.normal σ.info
-
-/-- The initial frame state: all worlds possible, total frame. -/
-def FrameState.init : FrameState W where
-  info := Set.univ
-  frame := ExpFrame.total
-
-/-- Embed a §3 `ExpState` as a `FrameState` with constant frame. -/
-def FrameState.ofExpState (σ : ExpState W) : FrameState W :=
-  ⟨σ.info, ExpFrame.const σ.order⟩
-
-/-! ### Conditional default update -/
-
-/-- **Conditional default update**: "if φ then normally ψ".
-
-    [veltman-1996], Definition 4.6. Given σ = ⟨π, s⟩:
-    - Let d = ‖φ‖ — the set of *all* φ-worlds (not just those in s)
-    - If d ∩ ‖ψ‖ = ∅, crash (the default is vacuous)
-    - If π_{d∘ψ} is incoherent, crash
-    - Otherwise, result is ⟨π_{d∘ψ}, s⟩
-
-    Note: d = ‖φ‖ over all of W, not ‖φ‖ ∩ s. The frame is about the
-    space of possible worlds; the info state restricts which are
-    epistemically accessible but doesn't determine the default domain. -/
-noncomputable def condDefault (φ ψ : W → Prop) (σ : FrameState W) :
-    FrameState W :=
-  let d : Set W := { w | φ w }
-  let π' := σ.frame.refineAt d ψ
-  if ¬(∃ w, φ w ∧ ψ w) then
-    ⟨∅, σ.frame⟩  -- crash: d ∩ ‖ψ‖ = ∅
-  else if ¬π'.coherent then
-    ⟨∅, σ.frame⟩  -- crash: refined frame incoherent
-  else
-    ⟨σ.info, π'⟩
-
-/-- **Unconditional default**: "normally ψ" = "(ψ ∨ ¬ψ) ⇝ ψ".
-
-    Refines the frame at d = W (all worlds). -/
-noncomputable def normallyFrame (ψ : W → Prop) (σ : FrameState W) :
-    FrameState W :=
-  condDefault (fun _ => True) ψ σ
-
-/-- **Assertion** in the frame setting: eliminate non-φ-worlds. -/
-def assertFrame (φ : W → Prop) (σ : FrameState W) : FrameState W :=
-  ⟨{ w ∈ σ.info | φ w }, σ.frame⟩
-
-/-- **Presumably test** in the frame setting: passes iff all normal
-    worlds satisfy φ. -/
-noncomputable def presumablyFrame (φ : W → Prop) (σ : FrameState W) :
-    FrameState W :=
-  if ∀ w ∈ σ.normal, φ w then σ else ⟨∅, σ.frame⟩
-
-/-! ### Basic properties -/
-
-/-- Assertion preserves the frame. -/
-theorem assertFrame_preserves_frame (φ : W → Prop) (σ : FrameState W) :
-    (assertFrame φ σ).frame = σ.frame := rfl
-
-/-- Normal worlds are in the domain. -/
-theorem ExpFrame.normal_subset (π : ExpFrame W) (d : Set W) :
-    π.normal d ⊆ d := fun _ hw => hw.1
-
-/-! ### Frame refinement properties -/
-
-/-- **Commutativity at one domain**: refining by e₁ then e₂ at the same
-    domain gives the same result as the reverse order. -/
-theorem ExpFrame.refineAt_comm_same (π : ExpFrame W) (d : Set W)
-    (e₁ e₂ : W → Prop) :
-    (π.refineAt d e₁).refineAt d e₂ =
-    (π.refineAt d e₂).refineAt d e₁ := by
-  apply ExpFrame.ext; intro d'
-  by_cases hd : d' = d
-  · subst hd
-    simp only [refineAt_target]
-    exact Normality.refine_comm _ _ _
-  · simp only [refineAt_unchanged _ d _ d' hd]
-
-/-- **Commutativity at different domains**: refinements at da ≠ db
-    commute trivially — they modify different entries. -/
-theorem ExpFrame.refineAt_comm_diff (π : ExpFrame W) (da db : Set W)
-    (ea eb : W → Prop) (h : da ≠ db) :
-    (π.refineAt da ea).refineAt db eb =
-    (π.refineAt db eb).refineAt da ea := by
-  apply ExpFrame.ext; intro d'
-  simp only [refineAt]
-  by_cases hda : d' = da <;> by_cases hdb : d' = db
-  · exact absurd (hda ▸ hdb) h
-  · simp only [hda, h, Ne.symm h, if_true, if_false]
-  · simp only [hdb, h, Ne.symm h, if_true, if_false]
-  · simp only [hda, hdb, if_false]
-
-/-- **Idempotency at frame level**: refining at d by e twice is the
-    same as refining once. -/
-theorem ExpFrame.refineAt_idempotent (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) :
-    (π.refineAt d e).refineAt d e = π.refineAt d e := by
-  apply ExpFrame.ext; intro d'
-  by_cases hd : d' = d
-  · subst hd
-    simp only [refineAt_target]
-    exact Normality.refine_idempotent _ _
-  · simp only [refineAt_unchanged _ d _ d' hd]
-
-/-- If πd already respects e, refinement at d is a no-op. -/
-theorem ExpFrame.refineAt_of_respects (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) (h : Normality.respects (π.pattern d) e) :
-    π.refineAt d e = π := by
-  apply ExpFrame.ext; intro d'
-  by_cases hd : d' = d
-  · subst hd
-    rw [refineAt_target]
-    exact Normality.refine_of_respects _ _ h
-  · exact refineAt_unchanged _ d _ d' hd
-
-/-- After refinement at d, the pattern at d respects e. -/
-theorem ExpFrame.refineAt_creates_respect (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) :
-    Normality.respects ((π.refineAt d e).pattern d) e := by
-  rw [refineAt_target]
-  exact Normality.refine_respects _ _
-
-/-! ### Coherence preservation -/
-
-/-- Refinement can only remove normal worlds, never add them.
-    Because `refineAt` either preserves or strengthens the ordering
-    at each subdomain, the normal condition is harder to satisfy. -/
-theorem ExpFrame.refineAt_normal_mono (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) (d₀ : Set W) :
-    (π.refineAt d e).normal d₀ ⊆ π.normal d₀ := by
-  intro w ⟨hwd₀, hdom⟩
-  refine ⟨hwd₀, fun d' hd' hwd' v hv => ?_⟩
-  have h := hdom d' hd' hwd' v hv
-  by_cases hd'_eq : d' = d
-  · subst hd'_eq; rw [refineAt_target] at h; exact h.1
-  · rw [refineAt_unchanged _ _ _ _ hd'_eq] at h; exact h
-
-/-- **Coherence characterization** (Proposition 4.7): given coherent π
-    with d ∩ e ≠ ∅, the refined frame π_{d∘e} is coherent iff there is
-    no d' ⊇ d such that nπd' ⊆ d \ e.
-
-    The condition "nπd' ⊆ d \ e" means all normal d'-worlds are in d
-    but fail e. If this holds, refinement at d makes those worlds
-    non-top (they don't satisfy e), potentially leaving no normals in
-    the refined frame.
-
-    Note: nπd' here uses the *original* frame π's normals, not the
-    refined frame's. -/
-theorem ExpFrame.refineAt_coherent_iff (π : ExpFrame W) (d : Set W)
-    (e : W → Prop) (hcoh : π.coherent)
-    (hne : ∃ w ∈ d, e w) :
-    (π.refineAt d e).coherent ↔
-    ¬∃ d', d ⊆ d' ∧ π.normal d' ⊆ { w ∈ d | ¬e w } := by
-  obtain ⟨v₀, hv₀d, hev₀⟩ := hne
+/-- Proposition 4.7: a coherent frame stays coherent under a new rule `r` with
+`r.domain ∩ r.default ≠ ∅` iff `r` applies within its own domain — no domain extending
+`r.domain` has all its normal worlds in `r.domain \ r.default`. -/
+theorem coherent_cons_iff {R : List (Rule W)} (hR : Coherent (Frame.ofRules R)) {r : Rule W}
+    (hne : (r.domain ∩ r.default).Nonempty) :
+    Coherent (Frame.ofRules (r :: R)) ↔ Applies (Frame.ofRules R) [r] r.domain := by
+  obtain ⟨v₀, hv₀⟩ := hne
+  rw [Finset.mem_inter] at hv₀
   constructor
-  · -- →: refined coherent → no bad superdomain
-    intro hcoh_ref ⟨d₀, hd_sub, hnorm_sub⟩
-    have hd₀_ne : d₀.Nonempty := ⟨v₀, hd_sub hv₀d⟩
-    obtain ⟨w, hw_ref⟩ := hcoh_ref d₀ hd₀_ne
-    -- w is also normal in π (monotonicity), so w ∈ d ∧ ¬e w
-    obtain ⟨hwd, hne_w⟩ := hnorm_sub (refineAt_normal_mono π d e d₀ hw_ref)
-    -- But the refined pattern at d forces e w (using the e-witness v₀)
-    have h := hw_ref.2 d hd_sub hwd v₀ hv₀d
-    rw [refineAt_target, Normality.refine_le] at h
-    exact hne_w (h.2 hev₀)
-  · -- ←: no bad superdomain → refined coherent
-    intro hno_bad d₀ hd₀_ne
-    by_cases hd_sub : d ⊆ d₀
-    · -- d ⊆ d₀: find a surviving normal world
-      -- nπd₀ ⊄ d \ e, so ∃ w ∈ nπd₀ with w ∉ d \ e
-      have ⟨w, hw_norm, hw_ok⟩ :
-          ∃ w ∈ π.normal d₀, w ∉ ({ w ∈ d | ¬e w } : Set W) := by
-        by_contra h
-        exact hno_bad ⟨d₀, hd_sub, fun x hx => by_contra fun hx' => h ⟨x, hx, hx'⟩⟩
-      -- hw_ok : ¬(w ∈ d ∧ ¬e w), i.e., w ∉ d ∨ e w
-      refine ⟨w, hw_norm.1, fun d' hd' hwd' v hv => ?_⟩
-      by_cases hd'_eq : d' = d
-      · -- d' = d: refined pattern demands (πd).le ∧ (e v → e w)
-        rw [hd'_eq, refineAt_target, Normality.refine_le]
-        constructor
-        · have := hw_norm.2 d' hd' hwd' v hv; rwa [hd'_eq] at this
-        · intro _; by_contra hne_w; rw [hd'_eq] at hwd'; exact hw_ok ⟨hwd', hne_w⟩
-      · rw [refineAt_unchanged _ _ _ _ hd'_eq]
-        exact hw_norm.2 d' hd' hwd' v hv
-    · -- d ⊄ d₀: all subdomains ≠ d, patterns unchanged
-      obtain ⟨w, hw⟩ := hcoh d₀ hd₀_ne
-      refine ⟨w, hw.1, fun d' hd' hwd' v hv => ?_⟩
-      have hd'_ne : d' ≠ d := fun heq => hd_sub (heq ▸ hd')
-      rw [refineAt_unchanged _ _ _ _ hd'_ne]
-      exact hw.2 d' hd' hwd' v hv
-
-/-! ### Connection to §3 -/
-
-/-- For a constant frame with a connected ordering, the §4 normal
-    worlds in d coincide with §3's optimal worlds. This is because
-    for connected orderings, "top in every subdomain" reduces to
-    "optimal in d" — since optimal = top when the ordering is total
-    or connected. -/
-theorem ExpFrame.const_normal_of_connected (no : Preorder W)
-    (d : Set W) (hconn : Normality.connected no) :
-    (ExpFrame.const no).normal d = Normality.optimal no d := by
-  ext w
-  simp only [normal, Set.mem_ofPred_eq, Normality.optimal]
-  constructor
-  · -- normal → optimal: weaker condition
-    intro ⟨hwd, hsub⟩
-    exact ⟨hwd, fun v hv hle => hsub d Set.Subset.rfl hwd v hv⟩
-  · -- optimal → normal (using connectedness)
-    intro ⟨hwd, hopt⟩
-    refine ⟨hwd, fun d' hd'd hwd' v hv => ?_⟩
-    -- w, v ∈ d and the ordering is the same (constant frame)
-    -- By connectedness: either le w v (done) or le v w
-    rcases hconn w v with hwv | hvw
-    · exact hwv
-    · -- le v w, and v ∈ d' ⊆ d, so v ∈ d
-      -- By optimality of w in d: le w v
-      exact hopt (hd'd hv) hvw
-
-/-! ### Applicability -/
-
-/-- **Applicability**: a default e applies to s within frame π.
-
-    [veltman-1996], Definition 4.9: the d-default e applies to s iff
-    there is no d' ⊇ s such that nπd' ⊆ d and the normal d'-worlds
-    all fail e. Simplified for a single default: e applies to s if
-    the frame can be coherently refined by e at d (from s's
-    perspective). -/
-def ExpFrame.applies (π : ExpFrame W) (d : Set W) (e : W → Prop)
-    (s : Set W) : Prop :=
-  s ⊆ d → ¬∃ d', s ⊆ d' ∧ π.normal d' ⊆ { w ∈ d | ¬e w }
-
-end ExpectationFrames
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §4 SPECIFICITY: TWEETY TRIANGLE
--- ═══════════════════════════════════════════════════════════════════════
-
-section Tweety
-
-open TweetyWorld
-
-def birdDomain : Set TweetyWorld := { w | isBird w }
-def penguinDomain : Set TweetyWorld := { w | isPenguin w }
-
-/-- Ordering for the bird domain: promotes flying. -/
-@[reducible] private def birdOrd : Preorder TweetyWorld :=
-  Preorder.ofLE (fun w v => flies v → flies w) (fun _ => id)
-    (fun _ _ _ huv hvw h => huv (hvw h))
-
-/-- Ordering for the penguin domain: promotes ¬flying. -/
-@[reducible] private def penguinOrd : Preorder TweetyWorld :=
-  Preorder.ofLE (fun w v => ¬flies v → ¬flies w) (fun _ => id)
-    (fun _ _ _ huv hvw h => huv (hvw h))
-
-@[reducible] private noncomputable def tweetyPattern (d : Set TweetyWorld) :
-    Preorder TweetyWorld :=
-  if d = penguinDomain then penguinOrd
-  else if d = birdDomain then birdOrd
-  else Normality.total
-
-noncomputable def tweetyFrame : ExpFrame TweetyWorld :=
-  ⟨tweetyPattern⟩
-
-private theorem pen_ne_bird : penguinDomain ≠ birdDomain := by
-  intro h
-  have : birdFlies ∈ penguinDomain :=
-    h ▸ (show birdFlies ∈ birdDomain from True.intro)
-  exact this
-
-private theorem penguin_sub_bird : penguinDomain ⊆ birdDomain :=
-  fun w hw => penguin_is_bird w hw
-
-private theorem pat_penguin : tweetyPattern penguinDomain = penguinOrd :=
-  if_pos rfl
-
-private theorem pat_bird : tweetyPattern birdDomain = birdOrd := by
-  unfold tweetyPattern
-  rw [if_neg (Ne.symm pen_ne_bird), if_pos rfl]
-
-private theorem pat_other (d : Set TweetyWorld)
-    (hp : d ≠ penguinDomain) (hb : d ≠ birdDomain) :
-    tweetyPattern d = Normality.total := by
-  unfold tweetyPattern; rw [if_neg hp, if_neg hb]
-
-private theorem sub_penguin_ne_bird (d : Set TweetyWorld)
-    (h : d ⊆ penguinDomain) : d ≠ birdDomain := by
-  intro heq; subst heq
-  exact pen_ne_bird.symm (Set.Subset.antisymm h penguin_sub_bird)
-
-/-- birdFlies is normal among birds. -/
-theorem birdFlies_normal_in_birds :
-    birdFlies ∈ tweetyFrame.normal birdDomain := by
-  refine ⟨True.intro, fun d' hd' hwd' v _ => ?_⟩
-  change (tweetyPattern d').le birdFlies v
-  by_cases hp : d' = penguinDomain
-  · subst hp; exact absurd hwd' id
-  · by_cases hb : d' = birdDomain
-    · subst hb; rw [pat_bird]; exact fun _ => True.intro
-    · rw [pat_other d' hp hb]; exact True.intro
-
-/-- penguinFlies is NOT normal among birds — specificity. -/
-theorem penguinFlies_not_normal_in_birds :
-    penguinFlies ∉ tweetyFrame.normal birdDomain := by
-  intro ⟨_, hsub⟩
-  have h := hsub penguinDomain penguin_sub_bird
-    (show penguinFlies ∈ penguinDomain from True.intro)
-    penguinNoFly (show penguinNoFly ∈ penguinDomain from True.intro)
-  change (tweetyPattern penguinDomain).le penguinFlies penguinNoFly at h
-  rw [pat_penguin] at h
-  exact h id True.intro
-
-/-- penguinNoFly is normal among penguins. -/
-theorem penguinNoFly_normal_in_penguins :
-    penguinNoFly ∈ tweetyFrame.normal penguinDomain := by
-  refine ⟨True.intro, fun d' hd' hwd' v hv => ?_⟩
-  change (tweetyPattern d').le penguinNoFly v
-  by_cases hp : d' = penguinDomain
-  · subst hp; rw [pat_penguin]; exact fun _ h => h
-  · have hb : d' ≠ birdDomain := sub_penguin_ne_bird d' (hd'.trans (fun x h => h))
-    rw [pat_other d' hp hb]; exact True.intro
-
-end Tweety
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §4 CONFLICTING DEFAULTS: NIXON DIAMOND
--- ═══════════════════════════════════════════════════════════════════════
-
-section Nixon
-
-open NixonWorld
-
-def quakerDomain : Set NixonWorld := { w | isQuaker w }
-def repDomain : Set NixonWorld := { w | isRepublican w }
-
-@[reducible] private def quakerOrd : Preorder NixonWorld :=
-  Preorder.ofLE (fun w v => isPacifist v → isPacifist w) (fun _ => id)
-    (fun _ _ _ huv hvw h => huv (hvw h))
-
-@[reducible] private def repOrd : Preorder NixonWorld :=
-  Preorder.ofLE (fun w v => ¬isPacifist v → ¬isPacifist w) (fun _ => id)
-    (fun _ _ _ huv hvw h => huv (hvw h))
-
-@[reducible] private noncomputable def nixonPattern (d : Set NixonWorld) :
-    Preorder NixonWorld :=
-  if d = quakerDomain then quakerOrd
-  else if d = repDomain then repOrd
-  else Normality.total
-
-noncomputable def nixonFrame : ExpFrame NixonWorld :=
-  ⟨nixonPattern⟩
-
-private theorem quaker_ne_rep : quakerDomain ≠ repDomain := by
-  intro h
-  have : quakerPacifist ∈ repDomain :=
-    h ▸ (show quakerPacifist ∈ quakerDomain from True.intro)
-  exact this
-
-private theorem npat_quaker : nixonPattern quakerDomain = quakerOrd :=
-  if_pos rfl
-
-private theorem npat_rep : nixonPattern repDomain = repOrd := by
-  unfold nixonPattern; rw [if_neg (Ne.symm quaker_ne_rep), if_pos rfl]
-
-/-- quakerPacifist is normal among Quakers. -/
-theorem quakerPacifist_normal :
-    quakerPacifist ∈ nixonFrame.normal quakerDomain := by
-  refine ⟨True.intro, fun d' hd' hwd' v _ => ?_⟩
-  change (nixonPattern d').le quakerPacifist v
-  by_cases hq : d' = quakerDomain
-  · subst hq; rw [npat_quaker]; exact fun _ => True.intro
-  · by_cases hr : d' = repDomain
-    · subst hr; exfalso; exact hwd'
-    · unfold nixonPattern; rw [if_neg hq, if_neg hr]; exact True.intro
-
-/-- repNotPacifist is normal among Republicans. -/
-theorem repNotPacifist_normal :
-    repNotPacifist ∈ nixonFrame.normal repDomain := by
-  refine ⟨True.intro, fun d' hd' hwd' v _ => ?_⟩
-  change (nixonPattern d').le repNotPacifist v
-  by_cases hr : d' = repDomain
-  · subst hr; rw [npat_rep]; exact fun _ h => h
-  · by_cases hq : d' = quakerDomain
-    · subst hq; exfalso; exact hwd'
-    · unfold nixonPattern; rw [if_neg hq, if_neg hr]; exact True.intro
-
-/-- quakerPacifist is NOT normal among Republicans (disjoint domains). -/
-theorem quakerPacifist_not_normal_rep :
-    quakerPacifist ∉ nixonFrame.normal repDomain := by
-  intro ⟨hmem, _⟩; exact hmem
-
-end Nixon
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §5 INFERENCE PATTERNS
--- ═══════════════════════════════════════════════════════════════════════
-
-section InferencePatterns
-
-variable {W : Type*}
-
--- ─── Valid: Conjunction of Consequents (CC) ───
-
-/-- **Conjunction of Consequents (CC)**: after processing "if φ then
-    normally ψ" and "if φ then normally χ", the ordering at the
-    φ-domain already respects (ψ ∧ χ).
-
-    This is the mathematical core of CC: sequential refinement by ψ
-    and χ produces an ordering that promotes (ψ ∧ χ)-worlds.
-
-    [veltman-1996], §5 (p.256): CC is valid. -/
-theorem conjConsequents_respects (no : Preorder W)
-    (ψ χ : W → Prop) :
-    Normality.respects (Normality.refine (Normality.refine no ψ) χ)
-      (fun w => ψ w ∧ χ w) := by
-  intro w v ⟨⟨_, hψ⟩, hχ⟩ ⟨hψv, hχv⟩
-  exact ⟨hψ hψv, hχ hχv⟩
-
-/-- CC at the frame level: after two refinements at the same domain,
-    further refinement by the conjunction is a no-op. -/
-theorem conjConsequents_frame (π : ExpFrame W) (d : Set W)
-    (ψ χ : W → Prop) :
-    ((π.refineAt d ψ).refineAt d χ).refineAt d (fun w => ψ w ∧ χ w) =
-    (π.refineAt d ψ).refineAt d χ := by
-  apply ExpFrame.ext; intro d'
-  by_cases hd : d' = d
-  · subst hd
-    simp only [ExpFrame.refineAt_target]
-    exact Normality.refine_of_respects _ _ (conjConsequents_respects _ ψ χ)
-  · simp only [ExpFrame.refineAt_unchanged _ _ _ _ hd]
-
--- ─── Invalid: Contraposition (counterexample) ───
-
-/-- **Contraposition fails**: after "if p then normally q", w₁ (p, ¬q)
-    is still normal among ¬q-worlds — the frame at d_¬q is untouched.
-
-    If contraposition held, all normal ¬q-worlds would satisfy ¬p.
-    But w₁ is a normal ¬q-world that satisfies p.
-
-    [veltman-1996], §5 (p.255). -/
-theorem contraposition_fails :
-    let d_p := { w : PQWorld | atomP w }
-    let d_nq := { w : PQWorld | ¬atomQ w }
-    let π := (ExpFrame.total (W := PQWorld)).refineAt d_p atomQ
-    -- w₁ is normal among ¬q-worlds but satisfies p
-    w₁ ∈ π.normal d_nq ∧ atomP w₁ := by
-  refine ⟨⟨atomQ_w₁, fun d' hd' hwd' v hv => ?_⟩, atomP_w₁⟩
-  -- d' ⊆ d_nq, so d' ≠ d_p (w₃ ∈ d_p but w₃ ∉ d_nq since atomQ w₃)
-  have hd'_ne : d' ≠ { w : PQWorld | atomP w } := by
-    intro heq
-    have h3 : w₃ ∈ d' := by rw [heq]; exact atomP_w₃
-    exact absurd atomQ_w₃ (hd' h3)
-  have heq := ExpFrame.refineAt_unchanged (ExpFrame.total (W := PQWorld))
-    { w : PQWorld | atomP w } atomQ d' hd'_ne
-  rw [heq]; exact True.intro
-
--- ─── Invalid: Strengthening the Antecedent (counterexample) ───
-
-/-- **Strengthening the Antecedent fails**: after "if p then normally q",
-    the frame at d_{p∧q} is untouched (since d_{p∧q} ≠ d_p).
-
-    [veltman-1996], §5 (p.256). -/
-theorem strengtheningAntecedent_fails :
-    -- The domains are different: w₁ ∈ d_p but w₁ ∉ d_pq
-    ({ w : PQWorld | atomP w } : Set PQWorld) ≠ { w | atomP w ∧ atomQ w } := by
-  intro h
-  have h1 : w₁ ∈ ({ w : PQWorld | atomP w } : Set PQWorld) := atomP_w₁
-  rw [h] at h1
-  exact atomQ_w₁ h1.2
-
--- ─── Defeasible Modus Tollens does NOT hold at the frame level ───
-
-/-- **Defeasible Modus Tollens fails** for `ExpFrame.normal`:
-    after "if p then normally q" and learning ¬q, w₁ (a p-world)
-    is still normal among ¬q-worlds. No subdomain of d_nq = {w₀, w₁}
-    equals d_p = {w₁, w₃}, so the refined ordering is never consulted.
-
-    This shows that DMT requires the full dynamic derivation
-    (processing the conditional, then asserting ¬q, then testing
-    presumably ¬p) rather than a single `ExpFrame.normal` check. -/
-theorem defeasible_modus_tollens_fails :
-    let d_p := { w : PQWorld | atomP w }
-    let π := (ExpFrame.total (W := PQWorld)).refineAt d_p atomQ
-    -- w₁ is normal among ¬q-worlds despite being a p-world
-    w₁ ∈ π.normal { w | ¬atomQ w } ∧ atomP w₁ := by
-  refine ⟨⟨atomQ_w₁, fun d' hd' hwd' v hv => ?_⟩, atomP_w₁⟩
-  -- d' ⊆ d_nq = {w₀, w₁}, so d' ≠ d_p = {w₁, w₃} (w₃ ∈ d_p \ d_nq)
-  have hd'_ne : d' ≠ { w : PQWorld | atomP w } := by
-    intro heq
-    have h3 : w₃ ∈ d' := by rw [heq]; exact atomP_w₃
-    exact absurd atomQ_w₃ (hd' h3)
-  have heq := ExpFrame.refineAt_unchanged (ExpFrame.total (W := PQWorld))
-    { w : PQWorld | atomP w } atomQ d' hd'_ne
-  rw [heq]; exact True.intro
-
-end InferencePatterns
-
-
--- ═══════════════════════════════════════════════════════════════════════
--- §5–6 GENERICS BRIDGE
--- ═══════════════════════════════════════════════════════════════════════
-
-section GenericsBridge
-
-variable {W : Type*}
-
-/-- **Generics as defaults** ([veltman-1996], §5–6).
-
-    The truth conditions of the GEN operator ("P's are normally Q"):
-        ∀w ∈ optimal(d). scope(w)
-    are exactly the conditions for the "presumably" test to pass
-    in update semantics.
-
-    This theorem witnesses the structural identity: "all optimal worlds
-    in a domain satisfy the scope" is just the definition of optimality
-    restated. The substantive bridge is that `Normality.optimal`
-    provides the normalcy predicate for GEN, and `Normality.refine`
-    provides the dynamic mechanism for learning new generic rules. -/
-theorem optimal_as_normalcy (no : Preorder W) (d : Set W)
-    (scope : W → Prop) :
-    (∀ w ∈ Normality.optimal no d, scope w) ↔
-    ∀ w, w ∈ d → (∀ v ∈ d, no.le v w → no.le w v) → scope w := by
-  constructor
-  · intro h w hwd hopt; exact h w ⟨hwd, hopt⟩
-  · intro h w ⟨hwd, hopt⟩; exact h w hwd hopt
-
-end GenericsBridge
-
-/-! ### Update-semantics states as the referent-free stratum
-
-Veltman's information states are bare sets of worlds. In the substrate
-they are exactly the uniform states at the empty context:
-`toIndexedState` embeds them constructively — no choice, no inhabitant
-of `M`, unlike under the total-assignment rendering — the embedding
-reverses into the informativeness order `≤`, and propositional update
-transports to point filtering. -/
-
-section IndexedFiber
-
-open DynamicSemantics UpdateSemantics
-
-variable {W V M : Type*} {s t : Set W}
-
-/-- A Veltman state as the referent-free state: its worlds, with nothing
-yet introduced. -/
-def toIndexedState (V M : Type*) (s : Set W) :
-    DynamicSemantics.State W V M :=
-  {p | p.world ∈ s ∧ ∀ v, p.assignment v = ⊥}
-
-@[simp] theorem mem_toIndexedState {p : Possibility W V (Part M)} :
-    p ∈ toIndexedState V M s ↔
-      p.world ∈ s ∧ ∀ v, p.assignment v = ⊥ := Iff.rfl
-
-/-- The embedding lands in the empty stratum. -/
-theorem uniformAt_toIndexedState :
-    State.UniformAt ∅ (toIndexedState V M s) := fun _ hp =>
-  Possibility.domain_eq_empty_iff.mpr hp.2
-
-/-- The embedding is faithful on worldly content. -/
-@[simp] theorem world_image_toIndexedState :
-    Possibility.world '' toIndexedState V M s = s := by
-  ext w
-  constructor
-  · rintro ⟨p, hp, rfl⟩
-    exact hp.1
-  · intro hw
-    exact ⟨⟨w, fun _ => ⊥⟩, ⟨hw, fun _ => rfl⟩, rfl⟩
-
-/-- Eliminating worlds is gaining information: the embedding reverses
-into `≤`. -/
-theorem toIndexedState_le_iff :
-    toIndexedState V M s ≤ toIndexedState V M t ↔ t ⊆ s := by
-  rw [State.le_def]
-  constructor
-  · intro h w hw
-    obtain ⟨p, hp, hpq⟩ := h ⟨w, fun _ => ⊥⟩ ⟨hw, fun _ => rfl⟩
-    have hs := hp.1
-    rwa [hpq.1] at hs
-  · rintro h q ⟨hq, hnone⟩
-    exact ⟨q, ⟨h hq, hnone⟩, le_refl q⟩
-
-/-- Propositional update ([veltman-1996]'s elimination) transports to
-point filtering. -/
-theorem toIndexedState_update_prop (φ : W → Prop) :
-    toIndexedState V M (UpdateSemantics.Update.prop φ s) =
-      {p ∈ toIndexedState V M s | φ p.world} :=
-  Set.ext fun p => by
-    constructor
-    · rintro ⟨⟨hw, hφ⟩, hnone⟩
-      exact ⟨⟨hw, hnone⟩, hφ⟩
-    · rintro ⟨⟨hw, hnone⟩, hφ⟩
-      exact ⟨⟨hw, hφ⟩, hnone⟩
-
-end IndexedFiber
+  · intro h d hd
+    obtain ⟨w, hw⟩ := h d ⟨v₀, hd hv₀.1⟩
+    rw [normal, Finset.mem_filter] at hw
+    refine ⟨w, Finset.mem_filter.2 ⟨hw.1, hw.2.of_cons⟩, fun _ hr' => ?_⟩
+    rcases List.mem_singleton.1 hr' with rfl
+    exact fun hwd => ((normal_ofRules_iff ..).1 hw.2).2 _ List.mem_cons_self hd hwd v₀ hv₀.1 hv₀.2
+  · intro h d hd
+    by_cases hsub : r.domain ⊆ d
+    · obtain ⟨w, hw, hc⟩ := h d hsub
+      rw [normal, Finset.mem_filter] at hw
+      refine ⟨w, Finset.mem_filter.2 ⟨hw.1, (normal_ofRules_iff ..).2 ⟨hw.1, fun r' hr' => ?_⟩⟩⟩
+      rcases List.mem_cons.1 hr' with rfl | hr'
+      · exact fun _ hwd _ _ _ => hc r' (List.mem_singleton_self _) hwd
+      · exact ((normal_ofRules_iff ..).1 hw.2).2 r' hr'
+    · obtain ⟨w, hw⟩ := hR d hd
+      rw [normal, Finset.mem_filter] at hw
+      refine ⟨w, Finset.mem_filter.2 ⟨hw.1, (normal_ofRules_iff ..).2 ⟨hw.1, fun r' hr' => ?_⟩⟩⟩
+      rcases List.mem_cons.1 hr' with rfl | hr'
+      · exact fun h => absurd h hsub
+      · exact ((normal_ofRules_iff ..).1 hw.2).2 r' hr'
+
+/-- Weakening the Consequent is "almost valid" (§5): a state that has accepted `φ ⇝ ψ` never
+crashes on `φ ⇝ (ψ ∨ χ)`, since any normal world of a domain extending `⟦φ⟧` that lies in
+`⟦φ⟧` already satisfies `ψ`. -/
+theorem weakenConsequent_applies {R : List (Rule W)} (hR : Coherent (Frame.ofRules R))
+    {φ ψ χ : Finset W} (hψ : ⟨φ, ψ⟩ ∈ R) (hne : (φ ∩ ψ).Nonempty) :
+    Applies (Frame.ofRules R) [⟨φ, ψ ∪ χ⟩] φ := by
+  obtain ⟨v₀, hv₀⟩ := hne
+  rw [Finset.mem_inter] at hv₀
+  intro d hd
+  obtain ⟨w, hw⟩ := hR d ⟨v₀, hd hv₀.1⟩
+  refine ⟨w, hw, fun _ hr' => ?_⟩
+  rcases List.mem_singleton.1 hr' with rfl
+  rw [normal, Finset.mem_filter] at hw
+  exact fun hwφ => Finset.mem_union_left _
+    (((normal_ofRules_iff ..).1 hw.2).2 _ hψ hd hwφ v₀ hv₀.1 hv₀.2)
+
+theorem weakenConsequent_coherent {R : List (Rule W)} (hR : Coherent (Frame.ofRules R))
+    {φ ψ χ : Finset W} (hψ : ⟨φ, ψ⟩ ∈ R) (hne : (φ ∩ ψ).Nonempty) :
+    Coherent (Frame.ofRules (⟨φ, ψ ∪ χ⟩ :: R)) :=
+  (coherent_cons_iff hR (hne.mono (Finset.inter_subset_inter_left Finset.subset_union_left))).2
+    (weakenConsequent_applies hR hψ hne)
+
+variable [Fintype W]
+
+instance (R R' : List (Rule W)) : Decidable (Frame.ofRules R = Frame.ofRules R') :=
+  decidable_of_iff (∀ d : Finset W, ∀ w v : d, (Frame.ofRules R d).le w v ↔
+      (Frame.ofRules R' d).le w v)
+    ⟨fun h => funext fun d => Preorder.ext (h d), fun h _ _ _ => h ▸ Iff.rfl⟩
+
+instance (π : Frame W) [∀ d, DecidablePred (Normal π d)] : Decidable (Coherent π) :=
+  inferInstanceAs (Decidable (∀ d : Finset W, d.Nonempty → (normal π d).Nonempty))
+
+instance (π : Frame W) [∀ d, DecidablePred (Normal π d)] (D : List (Rule W)) (s : Finset W) :
+    Decidable (Applies π D s) :=
+  inferInstanceAs (Decidable (∀ d : Finset W, s ⊆ d → ∃ w ∈ normal π d, Complies w D))
+
+/-- A state `(π, s)`: the frame, presented by the accepted rules, and the agent's knowledge
+of the facts (Definition 4.4). -/
+structure State (W : Type*) where
+  rules : List (Rule W)
+  info : Finset W
+  deriving DecidableEq
+
+namespace State
+
+/-- The minimal state `0`: the total frame, every world possible. -/
+def init : State W := ⟨[], Finset.univ⟩
+
+/-- The absurd state `1`. -/
+def absurd : State W := ⟨[], ∅⟩
+
+variable (σ : State W)
+
+/-- The frame of a state. -/
+abbrev frame : Frame W := Frame.ofRules σ.rules
+
+/-- `D` is a maximal applicable set of defaults in `σ` (Definition 4.13(i)), over the
+accepted rules (Proposition 4.14). -/
+def MaximalApplicable (D : List (Rule W)) : Prop :=
+  Applies σ.frame D σ.info ∧ ∀ r ∈ σ.rules, Applies σ.frame (r :: D) σ.info → r ∈ D
+
+instance (D : List (Rule W)) : Decidable (σ.MaximalApplicable D) :=
+  inferInstanceAs (Decidable (_ ∧ ∀ r ∈ σ.rules, Applies σ.frame (r :: D) σ.info → r ∈ D))
+
+/-- The optimal worlds `mσ` (Definition 4.13(ii)): the worlds of `s` complying with a maximal
+applicable set of defaults. -/
+def optimal : Finset W :=
+  σ.info.filter fun w => ∃ D ∈ σ.rules.sublists, σ.MaximalApplicable D ∧ Complies w D
+
+/-- `σ ⊩ φ`: `σ[φ]` is `σ` — the same facts and the same frame. -/
+def Accepts (φ : State W → State W) : Prop := (φ σ).info = σ.info ∧ (φ σ).frame = σ.frame
+
+instance (φ : State W → State W) : Decidable (σ.Accepts φ) :=
+  inferInstanceAs (Decidable (_ ∧ Frame.ofRules _ = Frame.ofRules _))
+
+end State
+
+/-- `σ[φ ⇝ ψ]` (Definition 4.6): refine the frame at `⟦φ⟧` with `⟦ψ⟧`, crashing if
+`⟦φ⟧ ∩ ⟦ψ⟧ = ∅` or the refined frame is incoherent. -/
+def rule (φ ψ : Finset W) (σ : State W) : State W :=
+  if (φ ∩ ψ).Nonempty ∧ Coherent (Frame.ofRules (⟨φ, ψ⟩ :: σ.rules)) ∧ σ.info.Nonempty
+  then ⟨⟨φ, ψ⟩ :: σ.rules, σ.info⟩ else .absurd
+
+/-- *Normally ψ* is `(ψ ∨ ¬ψ) ⇝ ψ` (Definition 4.1). -/
+def normally (ψ : Finset W) : State W → State W := rule (ψ ∪ ψᶜ) ψ
+
+/-- `σ[φ]` for a factual `φ`: eliminate the `¬φ`-worlds, crashing if none remain. -/
+def fact (φ : Finset W) (σ : State W) : State W :=
+  if (σ.info ∩ φ).Nonempty then ⟨σ.rules, σ.info ∩ φ⟩ else .absurd
+
+/-- `σ[presumably φ]` (Definition 4.13(iii)): a test passing iff `φ` holds in every optimal
+world. -/
+def presumably (φ : Finset W) (σ : State W) : State W :=
+  if σ.optimal ⊆ φ then σ else .absurd
+
+/-- Validity₁ (§1.2): the minimal state updated with the premises in order accepts the
+conclusion. -/
+def Valid (prems : List (State W → State W)) (concl : State W → State W) : Prop :=
+  (prems.foldl (fun σ φ => φ σ) State.init).Accepts concl
+
+instance (prems : List (State W → State W)) (concl : State W → State W) :
+    Decidable (Valid prems concl) :=
+  inferInstanceAs (Decidable (State.Accepts _ _))
+
+/-- Conditional Identity: `φ ⇝ φ` is accepted in the minimal state for nonempty `φ` — the
+rule refines nothing. -/
+theorem rule_self {φ : Finset W} (hφ : φ.Nonempty) : Valid [] (rule φ φ) := by
+  have hco : Coherent (Frame.ofRules [(⟨φ, φ⟩ : Rule W)]) := fun d ⟨w, hw⟩ =>
+    ⟨w, Finset.mem_filter.2 ⟨hw, (normal_ofRules_iff ..).2 ⟨hw, fun r hr => by
+      rcases List.mem_singleton.1 hr with rfl; exact fun _ hw _ _ _ => hw⟩⟩⟩
+  have h : rule φ φ ⟨[], Finset.univ⟩ = ⟨[⟨φ, φ⟩], Finset.univ⟩ := by
+    rw [rule, if_pos ⟨by rwa [Finset.inter_self], hco, hφ.elim fun w _ => ⟨w, Finset.mem_univ w⟩⟩]
+  show State.Accepts ⟨[], Finset.univ⟩ (rule φ φ)
+  rw [State.Accepts, h]
+  refine ⟨rfl, funext fun d => Preorder.ext fun w v => ⟨fun _ c hc => by simp at hc, ?_⟩⟩
+  rintro _ c ⟨hc, rfl⟩
+  rcases List.mem_singleton.1 hc with rfl
+  exact fun _ => w.2
+
+/-! ### Veltman's eight worlds -/
+
+/-- `wᵢ` is the set of atoms whose bits are set in `i`: `w₀ = ∅`, `w₁ = {p}`, `w₂ = {q}`,
+`w₃ = {p, q}`, `w₄ = {r}`, …, `w₇ = {p, q, r}`. -/
+abbrev World := Fin 8
+
+def p : Finset World := Finset.univ.filter (·.val % 2 = 1)
+def q : Finset World := Finset.univ.filter (·.val / 2 % 2 = 1)
+def r : Finset World := Finset.univ.filter (·.val / 4 % 2 = 1)
+
+/-- Examples 4.8(i)–(iii): an exception to *normally p* for `q` is acceptable, but not a
+further exception for `¬q` (too many exceptions), nor *normally q* on top of it. -/
+theorem ex48 :
+    (State.init |> normally p |> rule q pᶜ) ≠ State.absurd ∧
+      (State.init |> normally p |> rule q pᶜ |> rule qᶜ pᶜ) = State.absurd ∧
+      (State.init |> normally p |> rule q pᶜ |> normally q) = State.absurd := by
+  decide +kernel
+
+/-- Examples 4.11(i)–(iii), the verdicts of §4: the more specific rule takes precedence, and
+an exception to an exception restores the general verdict. -/
+theorem ex411_specificity :
+    Valid [normally p, rule q pᶜ, fact q] (presumably pᶜ) ∧
+      Valid [normally p, rule q pᶜ, fact (q ∩ r)] (presumably pᶜ) ∧
+      Valid [normally p, rule q pᶜ, rule (q ∩ r) p, fact (q ∩ r)] (presumably p) := by
+  decide +kernel
+
+/-- Example 4.11(iv): neither rule is more specific, yet in the context `p ∧ q` only
+`q ⇝ (p ∧ ¬r)` applies. -/
+theorem ex411_iv : Valid [rule p r, rule q (p ∩ rᶜ), fact (p ∩ q)] (presumably rᶜ) := by
+  decide +kernel
+
+/-- Example 4.11(v), the Nixon diamond (§5): `p ⇝ r`, `q ⇝ ¬r`, `p ∧ q` presume neither `r`
+nor `¬r` — the two defaults apply separately but not jointly. -/
+theorem nixon :
+    ¬Valid [rule p r, rule q rᶜ, fact (p ∩ q)] (presumably r) ∧
+      ¬Valid [rule p r, rule q rᶜ, fact (p ∩ q)] (presumably rᶜ) := by
+  decide +kernel
+
+/-- Example 4.11(vi): `q ⇝ p`, `p ⇝ r`, `q ⊩ presumably r` — the defeasible Hypothetical
+Syllogism (§5's `(*)`). -/
+theorem ex411_vi : Valid [rule q p, rule p r, fact q] (presumably r) := by
+  decide +kernel
+
+/-! ### Comparisons (§5) -/
+
+/-- Students are normally adults (`q ⇝ p`), students are normally not employed
+(`q ⇝ ¬r`), adults are normally employed (`p ⇝ r`): John, a student, is presumably an
+unemployed adult — `q ⇝ ¬r` overrides `p ⇝ r` in the presence of `q ⇝ p`. -/
+theorem students : Valid [rule p r, rule q rᶜ, rule q p, fact q] (presumably (p ∩ rᶜ)) := by
+  decide +kernel
+
+/-- Independence: an exception in one respect is not an exception in others — a student
+who is employed is still presumably an adult. -/
+theorem independence : Valid [rule q p, rule q rᶜ, fact q, fact r] (presumably p) := by
+  decide +kernel
+
+/-- Defeasible Modus Tollens is valid: `p ⇝ q`, `¬q ⊩ presumably ¬p`. -/
+theorem defeasibleModusTollens : Valid [rule p q, fact qᶜ] (presumably pᶜ) := by
+  decide +kernel
+
+/-- On the cyclic net `p ⇝ q`, `q ⇝ ¬p`, Modus Ponens takes precedence over Modus Tollens:
+`p ⊩ presumably q`. -/
+theorem modusPonens_over_modusTollens :
+    Valid [rule p q, rule q pᶜ, fact p] (presumably q) := by
+  decide +kernel
+
+/-- Validity₁ is not closed under substitution: `(*)` holds for independent predicates,
+but substituting `¬q` for `r` defeats it. -/
+theorem substitution_fails : ¬Valid [rule q p, rule p qᶜ, fact q] (presumably qᶜ) := by
+  decide +kernel
+
+/-- Hypothetical Syllogism fails although its defeasible version `(*)` holds: the rule
+`q ⇝ r` is not accepted. -/
+theorem hypotheticalSyllogism_fails : ¬Valid [rule q p, rule p r] (rule q r) := by
+  decide +kernel
+
+/-- Defeasible Modus Tollens holds but Contraposition fails. -/
+theorem contraposition_fails : ¬Valid [rule p q] (rule qᶜ pᶜ) := by
+  decide +kernel
+
+/-- `p ⇝ q`, `p ∧ r ⊩ presumably q`, but Strengthening the Antecedent fails. -/
+theorem strengthening :
+    Valid [rule p q, fact (p ∩ r)] (presumably q) ∧ ¬Valid [rule p q] (rule (p ∩ r) q) := by
+  decide +kernel
+
+/-- Strengthening with a Consequent and Disjunction of Antecedents are almost valid: the
+derived rule never crashes the state, though it is not accepted. -/
+theorem nearValid :
+    (State.init |> rule p q |> rule p r |> rule (p ∩ q) r) ≠ State.absurd ∧
+      ¬Valid [rule p q, rule p r] (rule (p ∩ q) r) ∧
+      (State.init |> rule p r |> rule q r |> rule (p ∪ q) r) ≠ State.absurd ∧
+      ¬Valid [rule p r, rule q r] (rule (p ∪ q) r) := by
+  decide +kernel
 
 end Veltman1996


### PR DESCRIPTION
934 → ~515 lines. The §4 expectation-frame apparatus is rebuilt so that frames are *derived* from the rules an agent accepts (Proposition 4.14's presentation), instead of hand-stipulated per-domain orderings; Definition 4.5's refinement clauses become theorems (`Frame.ofRules_cons_self`/`_of_ne`), Proposition 4.7 becomes `coherent_cons_iff` (coherent acceptance ⟺ the new rule applies within its own domain), and Definitions 4.9/4.13 (applicability, maximal applicable sets, optimal worlds, *presumably*) and validity₁ are defined and decidable, so every verdict of Examples 4.8 and 4.11 and of §5 is a `decide +kernel` on Veltman's eight worlds.
- Fidelity fixes: the Tweety triangle is not in the paper and its stipulated `tweetyFrame`/`nixonFrame` are cut (GP1996's "Veltman stipulates, System Z derives" theorem and docstring go with them); `defeasible_modus_tollens_fails` inverted the paper — defeasible Modus Tollens is *valid* (`defeasibleModusTollens`), as are Modus Ponens over Modus Tollens on the cyclic net, the student/adult/employment argument and Independence; `strengtheningAntecedent_fails` (which proved `{p} ≠ {p ∧ q}`) and `contraposition_fails` are now genuine validity₁ failures, alongside Hypothetical Syllogism and the near-validity of CW/ASC/AD (`weakenConsequent_coherent` in general).
- Cut consumer-less bridges (`optimal_as_normalcy`, the `toIndexedState` stratum section) and the narration; §3 Examples 3.10 golfed, plus the rain-or-snow contrast and `normally_not_normally_or` from §3.