### PR TITLE
refactor(Studies/Karttunen1974): keep the two untils, move Heinämäki's connectives

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2285,6 +2285,7 @@ import Linglib.Studies.Heim2001
 import Linglib.Studies.HeimComments1994
 import Linglib.Studies.HeimKratzer1998
 import Linglib.Studies.HeimLasnikMay1991
+import Linglib.Studies.Heinamaki1974
 import Linglib.Studies.Heine1997
 import Linglib.Studies.HeitmeierChuangBaayen2026
 import Linglib.Studies.HerbstrittFranke2019

--- a/Linglib/Studies/Giannakidou2002.lean
+++ b/Linglib/Studies/Giannakidou2002.lean
@@ -1,4 +1,5 @@
 import Linglib.Studies.Karttunen1974
+import Linglib.Studies.Heinamaki1974
 import Linglib.Semantics.Aspect.Basic
 import Linglib.Semantics.Tense.SentDenotation
 import Linglib.Data.Examples.Giannakidou2002
@@ -69,7 +70,7 @@ namespace Giannakidou2002
 open Core.Order
 open NonemptyInterval
 open Semantics.Aspect
-open Tense Anscombe1964 Karttunen1974
+open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
 variable {Time : Type*} [LinearOrder Time]
 
@@ -247,7 +248,7 @@ theorem timeTrace_impf_eq_prfv (P : Unit → Event Time → Prop) :
     interval set via IMPF, so *until* can take it as an argument.
     Negation scopes over the entire *until*-clause. -/
 def wideScopeNotUntil (A : Unit → Event Time → Prop) (B : SentDenotation Time) : Prop :=
-  ¬ Karttunen.when_ (impfDen A) B
+  ¬ when_ (impfDen A) B
 
 /-- **Narrow-scope negation** under *until* (= Karttunen's ¬*before*):
 
@@ -259,7 +260,7 @@ def wideScopeNotUntil (A : Unit → Event Time → Prop) (B : SentDenotation Tim
     since PRFV gives a bounded event, *until* reduces to temporal ordering
     and negation gives Karttunen's notUntil = ¬before. -/
 def narrowScopeNotUntil (A : Unit → Event Time → Prop) (B : SentDenotation Time) : Prop :=
-  Karttunen.notUntil (prfvDen A) B
+  notUntil (prfvDen A) B
 
 /-- Narrow-scope ¬*until* is exactly ¬*before* (by definition).
     This is [karttunen-1974]'s identity, now made explicit in the
@@ -340,7 +341,7 @@ theorem scope_readings_independent :
     ⟦dhen P para monon Q⟧ = (∃t. t∈A ∧ t∈B) ∧ ¬(A before B)
 
     This builds actualization into the **assertion**, unlike
-    `Karttunen.notUntil` (= ¬before alone) which holds vacuously when A is
+    `notUntil` (= ¬before alone) which holds vacuously when A is
     empty.
 
     This is a simplified version of the full ex. (39), which additionally
@@ -370,19 +371,19 @@ theorem eventiveUntil_entails_complement (A B : SentDenotation Time) :
 
 /-- Eventive UNTIL entails ¬*before*: A didn't happen prior to B. -/
 theorem eventiveUntil_entails_notBefore (A B : SentDenotation Time) :
-    eventiveUntil A B → Karttunen.notUntil A B :=
+    eventiveUntil A B → notUntil A B :=
   And.right
 
 /-- Eventive UNTIL entails temporal coincidence (*when*): A and B overlap. -/
 theorem eventiveUntil_entails_when (A B : SentDenotation Time) :
-    eventiveUntil A B → Karttunen.when_ A B := by
+    eventiveUntil A B → when_ A B := by
   rintro ⟨⟨t, htA, htB⟩, _⟩; exact ⟨t, htA, htB⟩
 
 /-- Karttunen's `notUntil` does NOT entail eventive UNTIL:
     ¬(A before B) holds vacuously when A is empty (no actualization). -/
 theorem notUntil_not_implies_eventiveUntil :
     ∃ (A B : SentDenotation ℤ),
-      Karttunen.notUntil A B ∧ ¬ eventiveUntil A B := by
+      notUntil A B ∧ ¬ eventiveUntil A B := by
   refine ⟨∅, { NonemptyInterval.pure 0 }, ?_, ?_⟩
   · intro ⟨t, ⟨i, hi, _⟩, _⟩
     exact absurd hi (Set.mem_empty_iff_false i).mp
@@ -422,7 +423,7 @@ theorem wideScopeNotUntil_compatible_with_empty_main :
     is not entailed. -/
 theorem durative_compatible_with_before :
     ∃ (A B : SentDenotation ℤ),
-      Karttunen.until A B ∧ Anscombe.before A B := by
+      until_ A B ∧ Anscombe.before A B := by
   let iA : NonemptyInterval ℤ := ⟨⟨0, 10⟩, by omega⟩
   let iB : NonemptyInterval ℤ := ⟨⟨5, 5⟩, by omega⟩
   refine ⟨stativeDenotation iA, {iB}, ?_, ?_⟩
@@ -442,8 +443,8 @@ theorem durative_compatible_with_before :
     This is the formal content of [giannakidou-2002]'s central claim:
     the two readings are not truth-conditionally equivalent under negation. -/
 theorem eventiveUntil_strictly_stronger :
-    (∀ (A B : SentDenotation ℤ), eventiveUntil A B → Karttunen.notUntil A B) ∧
-    (∃ (A B : SentDenotation ℤ), Karttunen.notUntil A B ∧ ¬ eventiveUntil A B) :=
+    (∀ (A B : SentDenotation ℤ), eventiveUntil A B → notUntil A B) ∧
+    (∃ (A B : SentDenotation ℤ), notUntil A B ∧ ¬ eventiveUntil A B) :=
   ⟨fun _ _ h => h.2, notUntil_not_implies_eventiveUntil⟩
 
 -- ============================================================================
@@ -489,8 +490,8 @@ def actualizationOf (row : LinguisticExample) : Option ActualizationStatus :=
 
 /-- The actualization status each semantic type carries, matching the
     formal operators: eventive = `eventiveUntil` (the overlap conjunct
-    entails actualization), endpoint = `Karttunen.until` (boundary
-    change-of-state only implicated), before = `Karttunen.notUntil` under
+    entails actualization), endpoint = `until_` (boundary
+    change-of-state only implicated), before = `notUntil` under
     negation (lateness alone, cf. `negBefore_lacks_actualization`). -/
 def UntilType.actualization : UntilType → ActualizationStatus
   | .before   => .absent
@@ -572,7 +573,7 @@ open Greek.StandardModern.TemporalConnectives
 /-- Greek lexicalizes the three semantic types as distinct lexemes:
     *mexri* (durative), *para monon* (eventive NPI), *prin* (before).
     Each maps to a different temporal connective operator:
-    - *mexri* → `Karttunen.until` (= `when_`, overlap)
+    - *mexri* → `until_` (= `when_`, overlap)
     - *para monon* → `eventiveUntil` (overlap + lateness)
     - *prin* → `Anscombe.before` (ordering) -/
 theorem greek_three_way_maps_to_operators :
@@ -725,7 +726,7 @@ theorem english_past_perfective_default :
     (the overlap conjunct forces a witness in A). -/
 theorem negBefore_lacks_actualization :
     ∃ (A B : SentDenotation ℤ),
-      Karttunen.notUntil A B ∧ ¬ ∃ t, t ∈ timeTrace A := by
+      notUntil A B ∧ ¬ ∃ t, t ∈ timeTrace A := by
   refine ⟨∅, { NonemptyInterval.pure 0 }, ?_, ?_⟩
   · intro ⟨t, ⟨i, hi, _⟩, _⟩
     exact absurd hi (Set.mem_empty_iff_false i).mp
@@ -747,7 +748,7 @@ theorem before_not_equiv_eventiveUntil :
     -- eventiveUntil entails main-clause actualization
     (∀ (A B : SentDenotation Time), eventiveUntil A B → ∃ t, t ∈ timeTrace A) ∧
     -- ¬before is compatible with main-clause non-actualization
-    (∃ (A B : SentDenotation ℤ), Karttunen.notUntil A B ∧ ¬ ∃ t, t ∈ timeTrace A) :=
+    (∃ (A B : SentDenotation ℤ), notUntil A B ∧ ¬ ∃ t, t ∈ timeTrace A) :=
   ⟨eventiveUntil_entails_actualization, negBefore_lacks_actualization⟩
 
 -- ============================================================================

--- a/Linglib/Studies/Heinamaki1974.lean
+++ b/Linglib/Studies/Heinamaki1974.lean
@@ -1,0 +1,99 @@
+import Linglib.Studies.Anscombe1964
+
+/-!
+# Heinämäki (1974): English temporal connectives
+
+[heinamaki-1974] gives truth conditions for the English temporal connectives in terms of
+the times at which the two clauses hold. On run-time denotations they are relations between
+the clauses' time traces: *A when B* asserts that the two hold at a common time (`when_`),
+*A while B* that every time of `A` is a time of `B` (`while_`), *A whenever B* the converse
+containment (`whenever`), *A since B* that some time of `B` lies at or before every time of
+`A` (`since`), and *A by B* that some time of `A` lies at or before every time of `B`
+(`by_`). *Since* and *by* are the non-strict counterparts of [anscombe-1964]'s *before*, with
+the roles of the clauses exchanged, so *before* entails *by* but not conversely
+(`before_by`, `by_not_before`). The existential connectives commit the speaker to both
+clauses (`when_veridical_complement`, `since_veridical_complement`, `by_veridical_main`);
+the universal ones do so only given the clause they quantify over
+(`while_veridical_complement`), and are not symmetric (`while_not_symm`).
+-/
+
+namespace Heinamaki1974
+
+open Tense Anscombe1964 NonemptyInterval
+
+variable {Time : Type*} [LinearOrder Time] (A B : SentDenotation Time)
+
+/-- *A when B*: `A` and `B` hold at a common time. -/
+def when_ : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
+
+/-- *A while B*: every time of `A` is a time of `B`. -/
+def while_ : Prop := ∀ t ∈ timeTrace A, t ∈ timeTrace B
+
+/-- *A whenever B*: every time of `B` is a time of `A`. -/
+def whenever : Prop := ∀ t ∈ timeTrace B, t ∈ timeTrace A
+
+/-- *A since B*: some time of `B` is at or before every time of `A`. -/
+def since : Prop := ∃ t ∈ timeTrace B, ∀ t' ∈ timeTrace A, t ≤ t'
+
+/-- *A by B*: some time of `A` is at or before every time of `B`. -/
+def by_ : Prop := ∃ t ∈ timeTrace A, ∀ t' ∈ timeTrace B, t ≤ t'
+
+theorem when_comm : when_ A B ↔ when_ B A :=
+  ⟨fun ⟨t, h₁, h₂⟩ => ⟨t, h₂, h₁⟩, fun ⟨t, h₁, h₂⟩ => ⟨t, h₂, h₁⟩⟩
+
+theorem when_veridical_complement : when_ A B → ∃ t, t ∈ timeTrace B :=
+  fun ⟨t, _, ht⟩ => ⟨t, ht⟩
+
+theorem when_veridical_main : when_ A B → ∃ t, t ∈ timeTrace A := fun ⟨t, ht, _⟩ => ⟨t, ht⟩
+
+theorem while_veridical_complement (hne : ∃ t, t ∈ timeTrace A) :
+    while_ A B → ∃ t, t ∈ timeTrace B :=
+  fun hw => hne.imp fun _ ht => hw _ ht
+
+theorem when_of_while (hne : ∃ t, t ∈ timeTrace A) : while_ A B → when_ A B :=
+  fun hw => hne.imp fun _ ht => ⟨ht, hw _ ht⟩
+
+theorem when_of_whenever (hne : ∃ t, t ∈ timeTrace B) : whenever A B → when_ A B :=
+  fun hw => hne.imp fun _ ht => ⟨hw _ ht, ht⟩
+
+theorem since_veridical_complement : since A B → ∃ t, t ∈ timeTrace B :=
+  fun ⟨t, ht, _⟩ => ⟨t, ht⟩
+
+theorem by_veridical_main : by_ A B → ∃ t, t ∈ timeTrace A := fun ⟨t, ht, _⟩ => ⟨t, ht⟩
+
+/-- *Before* is strict *by*. -/
+theorem before_by : Anscombe.before A B → by_ A B :=
+  fun ⟨t, ht, h⟩ => ⟨t, ht, fun t' ht' => (h t' ht').le⟩
+
+/-- *While* is not symmetric: a moment inside a stretch. -/
+theorem while_not_symm :
+    ¬∀ A B : SentDenotation ℤ, while_ A B → while_ B A := by
+  intro h
+  let i₁₀ : NonemptyInterval ℤ := ⟨⟨1, 10⟩, by decide⟩
+  have h5 : (pure 5 : NonemptyInterval ℤ).fst = 5 ∧ (pure 5 : NonemptyInterval ℤ).snd = 5 :=
+    ⟨rfl, rfl⟩
+  have h₁₀ : i₁₀.fst = 1 ∧ i₁₀.snd = 10 := ⟨rfl, rfl⟩
+  have hw : while_ ({pure 5} : SentDenotation ℤ) (stativeDenotation i₁₀) := by
+    rintro t ⟨i, hi, hts, htf⟩
+    rw [Set.mem_singleton_iff] at hi; subst hi
+    rw [timeTrace_stativeDenotation]
+    exact ⟨by omega, by omega⟩
+  obtain ⟨i, hi, h1, _⟩ :=
+    h _ _ hw 1 (by rw [timeTrace_stativeDenotation]; exact ⟨le_rfl, by decide⟩)
+  rw [Set.mem_singleton_iff] at hi; subst hi
+  omega
+
+/-- *By* allows coincidence where *before* does not: an arrival exactly at the deadline. -/
+theorem by_not_before :
+    ¬∀ A B : SentDenotation ℤ, by_ A B → Anscombe.before A B := by
+  intro h
+  have h5 : (pure 5 : NonemptyInterval ℤ).fst = 5 ∧ (pure 5 : NonemptyInterval ℤ).snd = 5 :=
+    ⟨rfl, rfl⟩
+  obtain ⟨t, ⟨i, hi, h1, h2⟩, hall⟩ := h {pure 5} {pure 5}
+    ⟨5, ⟨pure 5, rfl, le_rfl, le_rfl⟩, fun _ ⟨j, hj, hts, _⟩ => by
+      rw [Set.mem_singleton_iff] at hj; subst hj; exact hts⟩
+  rw [Set.mem_singleton_iff] at hi; subst hi
+  have := hall 5 ⟨pure 5, rfl, le_rfl, le_rfl⟩
+  omega
+
+end Heinamaki1974

--- a/Linglib/Studies/JinKoenig2021.lean
+++ b/Linglib/Studies/JinKoenig2021.lean
@@ -887,7 +887,7 @@ theorem before_licensing :
     surfaces as the complement-clause negator, which is exactly EN. -/
 theorem until_en_from_before_negation {Time : Type*} [LinearOrder Time]
     (A B : SentDenotation Time) :
-    Karttunen.notUntil A B ↔ ¬ Anscombe.before A B := Iff.rfl
+    notUntil A B ↔ ¬ Anscombe.before A B := Iff.rfl
 
 -- ════════════════════════════════════════════════════
 -- § 9. Modal Bridge: IMPOSSIBLE → Logical Operator

--- a/Linglib/Studies/Karttunen1974.lean
+++ b/Linglib/Studies/Karttunen1974.lean
@@ -1,428 +1,53 @@
 import Linglib.Studies.Anscombe1964
 
 /-!
-# [karttunen-1974]: *Until*, *When*, and the Two-*Until* Hypothesis
-[karttunen-1974] [heinamaki-1974] [dowty-1979]Karttunen argues that English has **two** *until*s:
+# Karttunen (1974): *Until*
 
-- **Durative *until***: "John slept until 3pm." The main clause is durative
-  (stative/activity), and *until* marks the minimum extent of the main event.
-  Truth-conditionally, this is temporal overlap: A holds at the time of B.
-
-- **Punctual *until***: "The princess didn't wake up until the prince kissed
-  her." Requires negation in the main clause. Karttunen's key identity (§5,
-  eq. 33): this has the logical form **NOT(A BEFORE T)**.
-
-The punctual *until* presupposes **A BEFORE T ∨ A WHEN T** — the event
-eventually happens, either before or at the complement time. The assertion
-¬(A BEFORE T) then derives, via disjunctive syllogism, that A occurs at
-T (temporal coincidence, i.e., *when*).
-
-## Level
-
-**Level 1 (point sets)**: all definitions operate on `timeTrace` projections,
-at the same level as Anscombe. The eight English temporal connectives reduce
-to four Level 1 primitives:
-
-- *before* = ∃∀ + strict ordering (Anscombe)
-- *after* = ∃∃ + strict ordering (Anscombe)
-- *when* = ∃ overlap (this file)
-- *while* = ∀ containment (this file)
-- *until* = ¬*before* (punctual) or *when* (durative) — derived, not primitive
-- *till* = *until* (dialectal variant, Heinämäki Ch. 9)
-- *since* = ∃∈B ∀∈A + ≤ ordering (starting-point, Heinämäki Ch. 6)
-- *by* = ∃∈A ∀∈B + ≤ ordering (deadline, Heinämäki Ch. 8)
-
-## Cross-Linguistic Evidence
-
-Finnish lexicalizes the two-*until* distinction: **kunnes** / **siihen saakka**
-(durative) vs **ennenkuin** (punctual, literally 'before-than'). The Finnish
-punctual form is morphologically *before*, confirming Karttunen's analysis.
-
+[karttunen-1974] argues that English has two *until*s. Durative *until* selects a durative
+main clause (a state or activity), is indifferent to polarity, and asserts that the main
+clause holds through a period reaching the time of the *until*-clause: on run-time
+denotations, where a durative clause holds throughout each of its run-times, some run-time
+of `A` contains a time of `B` (`until_`). Punctual *until* selects a punctual main clause and
+is a negative polarity item, acceptable only with negation scoping over the *until*-phrase;
+*not A until B* is then truth-conditionally *not A before B* (`notUntil`, the negation of
+[anscombe-1964]'s *before*), every occurrence of `A` having a time of `B` at or before it
+(`notUntil_iff`). What distinguishes punctual *until* from *before* under negation is a
+presupposition that `A` does occur (`actualization`), which the assertion alone does not
+supply (`notUntil_empty`): together they place an occurrence of `A` at or after a time of
+`B` (`notUntil_actualization`) — *the princess didn't wake up until the prince kissed her*
+puts the waking at the kiss or a little later, and *Nancy didn't get married until she died*
+is odd because the marriage would have to follow the death.
 -/
 
 namespace Karttunen1974
 
-open Tense Anscombe1964
+open Tense Anscombe1964 NonemptyInterval
 
-open NonemptyInterval
+variable {Time : Type*} [LinearOrder Time] (A B : SentDenotation Time)
 
-variable {Time : Type*} [LinearOrder Time]
+/-- Durative *A until B*: some run-time of `A` reaches a time of `B`. -/
+def until_ : Prop := ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
 
--- ============================================================================
--- § 1: Definitions
--- ============================================================================
+/-- Punctual *not A until B*: *not A before B*. -/
+def notUntil : Prop := ¬ Anscombe.before A B
 
-/-- *When*: temporal coincidence (∃-overlap).
-    "A when B" holds when some time point belongs to both A and B. -/
-def Karttunen.when_ (A B : SentDenotation Time) : Prop :=
-  ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
+/-- The presupposition of punctual *until*: `A` does occur. -/
+def actualization : Prop := ∃ t, t ∈ timeTrace A
 
-/-- *While*: temporal containment (∀-inclusion).
-    "A while B" holds when every time in A is also a time in B.
-    Stronger than *when* (which requires only one shared point).
+theorem until_veridical_complement : until_ A B → ∃ t, t ∈ timeTrace B :=
+  fun ⟨t, _, ht⟩ => ⟨t, ht⟩
 
-    This matches the implicit definition in [rett-2026]
-    used to prove *while* is not ambidirectional. -/
-def Karttunen.while_ (A B : SentDenotation Time) : Prop :=
-  ∀ t ∈ timeTrace A, t ∈ timeTrace B
+/-- Every occurrence of `A` has a time of `B` at or before it. -/
+theorem notUntil_iff : notUntil A B ↔ ∀ t ∈ timeTrace A, ∃ t' ∈ timeTrace B, t' ≤ t := by
+  simp only [notUntil, Anscombe.before, not_exists, not_and, not_forall, not_lt, exists_prop]
 
-/-- Durative *until*: the main event persists at least to the complement time.
-    Truth-conditionally equivalent to *when* at Level 1: ∃-overlap.
+/-- The assertion alone holds of a clause that never happens. -/
+theorem notUntil_empty : notUntil (∅ : SentDenotation Time) B :=
+  fun ⟨_, ⟨_, hi, _⟩, _⟩ => hi
 
-    The difference from *when* is a **selectional restriction**: *until*
-    requires A to be durative (stative/activity). Combined with the
-    subinterval property of statives, overlap entails continuous persistence
-    of A up to the time of B — the "minimum length" semantics. -/
-def Karttunen.until (A B : SentDenotation Time) : Prop :=
-  ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
-
-/-- *Till*: dialectal variant of durative *until*.
-    Truth-conditionally identical to durative *until* (= *when* = ∃-overlap).
-    Dialectally restricted in English; some varieties use *till* where
-    standard English uses *until*. -/
-def Karttunen.till (A B : SentDenotation Time) : Prop :=
-  ∃ t, t ∈ timeTrace A ∧ t ∈ timeTrace B
-
-/-- *Since*: lower-bound / starting-point semantics.
-    "A since B" holds when some B-time precedes or coincides with all A-times.
-    This mirrors *before* with swapped arguments and non-strict ordering:
-    *before* = ∃t∈A, ∀t'∈B, t < t'; *since* = ∃t∈B, ∀t'∈A, t ≤ t'.
-
-    Veridical for B (the ∃ over B forces a witness).
-    Equivalent to `by_` with swapped arguments: `since A B ↔ by_ B A`. -/
-def Karttunen.since (A B : SentDenotation Time) : Prop :=
-  ∃ t ∈ timeTrace B, ∀ t' ∈ timeTrace A, t ≤ t'
-
-/-- *By*: deadline / upper-bound semantics.
-    "A by B" holds when some A-time precedes or coincides with all B-times.
-    "He arrived by 3pm" = his arrival has a time point at or before 3pm.
-
-    Weaker than *before* (allows temporal coincidence: ≤ rather than <).
-    Veridical for A (the ∃ over A forces a witness). -/
-def Karttunen.by_ (A B : SentDenotation Time) : Prop :=
-  ∃ t ∈ timeTrace A, ∀ t' ∈ timeTrace B, t ≤ t'
-
-/-- Punctual *until* = ¬(*before*) ([karttunen-1974], eq. 33).
-    "The princess didn't wake up until the prince kissed her"
-    = NOT(the princess woke up BEFORE the prince kissed her).
-
-    Presupposes A BEFORE T ∨ A WHEN T (lateness: the event eventually happens). -/
-def Karttunen.notUntil (A B : SentDenotation Time) : Prop :=
-  ¬ Anscombe.before A B
-
--- ============================================================================
--- § 2: Durative *Until* ↔ *When*
--- ============================================================================
-
-/-- Durative *until* and *when* are truth-conditionally identical at Level 1.
-    The linguistic differences (selectional restriction on durativity,
-    endpoint semantics) are pragmatic, not truth-conditional. -/
-theorem until_iff_when (A B : SentDenotation Time) :
-    Karttunen.until A B ↔ Karttunen.when_ A B :=
-  Iff.rfl
-
--- ============================================================================
--- § 3: Veridicality
--- ============================================================================
-
-/-- *When* is veridical w.r.t. its complement: B must have a witness. -/
-theorem when_veridical_complement (A B : SentDenotation Time) :
-    Karttunen.when_ A B → ∃ t, t ∈ timeTrace B := by
-  rintro ⟨t, _, ht⟩; exact ⟨t, ht⟩
-
-/-- *When* is veridical w.r.t. its main clause: A must have a witness. -/
-theorem when_veridical_main (A B : SentDenotation Time) :
-    Karttunen.when_ A B → ∃ t, t ∈ timeTrace A := by
-  rintro ⟨t, ht, _⟩; exact ⟨t, ht⟩
-
-/-- Durative *until* is veridical w.r.t. its complement. -/
-theorem until_veridical_complement (A B : SentDenotation Time) :
-    Karttunen.until A B → ∃ t, t ∈ timeTrace B :=
-  when_veridical_complement A B
-
-/-- *While* is veridical w.r.t. the main clause when A is nonempty:
-    if ∀t∈A, t∈B and A has a witness, then B has a witness. -/
-theorem while_veridical_complement (A B : SentDenotation Time)
-    (hne : ∃ t, t ∈ timeTrace A) :
-    Karttunen.while_ A B → ∃ t, t ∈ timeTrace B := by
-  intro hw; obtain ⟨t, ht⟩ := hne; exact ⟨t, hw t ht⟩
-
-/-- Punctual *until* is NOT veridical by assertion alone:
-    ¬(A before B) holds vacuously when A is empty. -/
-theorem notUntil_not_veridical :
-    ∃ (A B : SentDenotation ℤ), Karttunen.notUntil A B ∧ ¬∃ t, t ∈ timeTrace A := by
-  refine ⟨∅, { NonemptyInterval.pure 0 }, ?_, ?_⟩
-  · intro ⟨t, ⟨i, hi, _⟩, _⟩
-    exact absurd hi (Set.mem_empty_iff_false i).mp
-  · intro ⟨t, i, hi, _⟩
-    exact absurd hi (Set.mem_empty_iff_false i).mp
-
--- ============================================================================
--- § 4: Karttunen's Identity
--- ============================================================================
-
-/-- **Karttunen's main result** (eq. 33): punctual *until* unfolds to
-    "every A-time has some B-time at or before it."
-
-    "not A until B" = ¬(∃t∈A, ∀t'∈B, t<t') = ∀t∈A, ∃t'∈B, t'≤t.
-
-    This is logically equivalent to: every occurrence of A is preceded by
-    (or coincides with) some occurrence of B. -/
-theorem notUntil_unfold (A B : SentDenotation Time) :
-    Karttunen.notUntil A B ↔
-    ∀ t ∈ timeTrace A, ∃ t' ∈ timeTrace B, ¬(t < t') := by
-  constructor
-  · intro h t ht
-    by_contra hall
-    push Not at hall
-    exact h ⟨t, ht, hall⟩
-  · intro h ⟨t, ht, hall⟩
-    obtain ⟨t', ht', hle⟩ := h t ht
-    exact hle (hall t' ht')
-
-/-- Finnish confirms Karttunen: the punctual *until* form **ennenkuin**
-    is morphologically *ennen* ('before') + *kuin* ('than'), i.e.,
-    literal *before*-than — the negation is external to the connective.
-
-    This is definitionally true since `notUntil = ¬before`. -/
-theorem finnish_confirms_identity :
-    ∀ (A B : SentDenotation Time),
-      Karttunen.notUntil A B ↔ ¬ Anscombe.before A B :=
-  fun _ _ => Iff.rfl
-
--- ============================================================================
--- § 5: Presupposition of Punctual *Until*
--- ============================================================================
-
-/-- The presupposition of punctual *until*: A BEFORE T ∨ A WHEN T.
-    The event eventually happens — either before or at the complement time.
-
-    Combined with the assertion ¬(A BEFORE T), the presupposition yields
-    A WHEN T (temporal coincidence) by disjunctive syllogism.
-
-    This derives the intuitive meaning: "not until B" ≈ "at B". -/
-theorem notUntil_with_presupposition (A B : SentDenotation Time)
-    (hpre : Anscombe.before A B ∨ Karttunen.when_ A B)
-    (hassert : Karttunen.notUntil A B) :
-    Karttunen.when_ A B :=
-  hpre.resolve_left hassert
-
--- ============================================================================
--- § 6: Logical Relationships
--- ============================================================================
-
-/-- *When* is symmetric: if A overlaps B, then B overlaps A. -/
-theorem when_symmetric (A B : SentDenotation Time) :
-    Karttunen.when_ A B ↔ Karttunen.when_ B A := by
-  constructor <;> rintro ⟨t, h1, h2⟩ <;> exact ⟨t, h2, h1⟩
-
-/-- *While* implies *when* (when A is nonempty):
-    containment is stronger than overlap. -/
-theorem while_implies_when (A B : SentDenotation Time)
-    (hne : ∃ t, t ∈ timeTrace A) :
-    Karttunen.while_ A B → Karttunen.when_ A B := by
-  intro hw
-  obtain ⟨t, ht⟩ := hne
-  exact ⟨t, ht, hw t ht⟩
-
-/-- *While* is NOT symmetric: containment is asymmetric.
-
-    Counterexample: A = point at 5, B = interval [1,10].
-    A ⊆ B (5 ∈ [1,10]) but B ⊄ A (1 ∉ {5}). -/
-theorem while_not_symmetric :
-    ¬ ∀ (A B : SentDenotation ℤ),
-      Karttunen.while_ A B → Karttunen.while_ B A := by
-  intro h
-  let iA : NonemptyInterval ℤ := ⟨⟨5, 5⟩, by omega⟩
-  let iB : NonemptyInterval ℤ := ⟨⟨1, 10⟩, by omega⟩
-  have hAs : iA.fst = 5 := rfl
-  have hAf : iA.snd = 5 := rfl
-  have hBs : iB.fst = 1 := rfl
-  have hBf : iB.snd = 10 := rfl
-  have hw : Karttunen.while_ ({iA} : SentDenotation ℤ) (stativeDenotation iB) := by
-    intro t ⟨i, hi, hts, htf⟩
-    simp only [Set.mem_singleton_iff] at hi; subst hi
-    rw [timeTrace_stativeDenotation]
-    constructor <;> omega
-  have hw' := h _ _ hw
-  have h1 : (1 : ℤ) ∈ timeTrace (stativeDenotation iB) := by
-    rw [timeTrace_stativeDenotation]; constructor <;> omega
-  obtain ⟨i, hi, hts, _⟩ := hw' 1 h1
-  simp only [Set.mem_singleton_iff] at hi; subst hi
-  omega
-
-/-- *While* is transitive: temporal containment composes. -/
-theorem while_transitive (A B C : SentDenotation Time) :
-    Karttunen.while_ A B → Karttunen.while_ B C → Karttunen.while_ A C :=
-  fun hab hbc t ht => hbc t (hab t ht)
-
-/-- For a fixed time point t in A, if some B-time precedes t,
-    then t cannot precede ALL of B. This is the per-witness form of
-    the ordering consistency between *after* and *before*. -/
-theorem after_witness_excludes_before_witness
-    {t t' : Time} (hlt : t' < t) :
-    ¬ (t < t') :=
-  not_lt.mpr (le_of_lt hlt)
-
--- ============================================================================
--- § 7: Veridicality Summary
--- ============================================================================
-
-/-- Veridicality summary for the five temporal connectives at Level 1:
-    - *before*: complement NOT veridical (∀ vacuously true on empty B)
-    - *after*: complement veridical (∃ witness required)
-    - *when*: complement veridical (∃ overlap witness)
-    - *while*: complement veridical only when A nonempty (∀ vacuously true)
-    - *until* (durative): complement veridical (= when)
-    - *until* (punctual): complement NOT veridical by assertion alone
-
-    The veridical/non-veridical split mirrors the quantifier structure:
-    ∃-based connectives (after, when, durative until) are veridical;
-    ∀-based connectives (before, while, punctual until) are non-veridical
-    or conditionally veridical. -/
-theorem veridicality_mirrors_quantifier_force :
-    -- after is ∃∃ → veridical
-    (∀ (A B : SentDenotation Time), Anscombe.after A B → ∃ t, t ∈ timeTrace B) ∧
-    -- when is ∃-overlap → veridical
-    (∀ (A B : SentDenotation Time), Karttunen.when_ A B → ∃ t, t ∈ timeTrace B) ∧
-    -- before is ∃∀ → non-veridical (the ∀ over B is vacuously true on ∅)
-    (∃ (A B : SentDenotation ℤ), Anscombe.before A B ∧ ¬∃ t, t ∈ timeTrace B) := by
-  refine ⟨?_, ?_, ?_⟩
-  · rintro A B ⟨_, _, _, ht', _⟩; exact ⟨_, ht'⟩
-  · exact when_veridical_complement
-  · refine ⟨{ NonemptyInterval.pure 0 }, ∅, ?_, ?_⟩
-    · exact ⟨0, ⟨NonemptyInterval.pure 0, rfl, le_refl _, le_refl _⟩,
-        fun t' ⟨i, hi, _⟩ => absurd hi (Set.mem_empty_iff_false i).mp⟩
-    · intro ⟨_, i, hi, _⟩; exact absurd hi (Set.mem_empty_iff_false i).mp
-
--- ============================================================================
--- § 8: *Till* — Dialectal *Until*
--- ============================================================================
-
-/-- *Till* and *until* are truth-conditionally identical. -/
-theorem till_iff_until (A B : SentDenotation Time) :
-    Karttunen.till A B ↔ Karttunen.until A B :=
-  Iff.rfl
-
-/-- *Till* and *when* are truth-conditionally identical. -/
-theorem till_iff_when (A B : SentDenotation Time) :
-    Karttunen.till A B ↔ Karttunen.when_ A B :=
-  Iff.rfl
-
--- ============================================================================
--- § 9: *Since* — Starting-Point Semantics
--- ============================================================================
-
-/-- *Since* is veridical w.r.t. its complement: B must have a witness. -/
-theorem since_veridical_complement (A B : SentDenotation Time) :
-    Karttunen.since A B → ∃ t, t ∈ timeTrace B := by
-  rintro ⟨t, ht, _⟩; exact ⟨t, ht⟩
-
-/-- *Since* is the argument-swapped form of *by*:
-    "A since B" ↔ "B by A". Both have the form ∃t∈X, ∀t'∈Y, t ≤ t'. -/
-theorem since_eq_by_swap (A B : SentDenotation Time) :
-    Karttunen.since A B ↔ Karttunen.by_ B A :=
-  Iff.rfl
-
--- ============================================================================
--- § 10: *By* — Deadline Semantics
--- ============================================================================
-
-/-- *By* is veridical w.r.t. its main clause: A must have a witness. -/
-theorem by_veridical_main (A B : SentDenotation Time) :
-    Karttunen.by_ A B → ∃ t, t ∈ timeTrace A := by
-  rintro ⟨t, ht, _⟩; exact ⟨t, ht⟩
-
-/-- *Before* implies *by*: strict temporal ordering entails non-strict.
-    "He left before 3pm" → "He left by 3pm." -/
-theorem before_implies_by (A B : SentDenotation Time) :
-    Anscombe.before A B → Karttunen.by_ A B := by
-  rintro ⟨t, ht, hall⟩
-  exact ⟨t, ht, fun t' ht' => le_of_lt (hall t' ht')⟩
-
-/-- *By* does NOT imply *before*: coincidence is allowed under *by* but
-    not *before*.
-
-    Counterexample: A = B = {point 5}. "He arrived by 5" is true when
-    he arrives at 5, but "he arrived before 5" is false. -/
-theorem by_not_implies_before :
-    ¬ ∀ (A B : SentDenotation ℤ),
-      Karttunen.by_ A B → Anscombe.before A B := by
-  intro h
-  let iP : NonemptyInterval ℤ := ⟨⟨5, 5⟩, by omega⟩
-  have hmem : (5 : ℤ) ∈ timeTrace ({iP} : SentDenotation ℤ) :=
-    ⟨iP, rfl, le_refl _, le_refl _⟩
-  have hby : Karttunen.by_ ({iP} : SentDenotation ℤ) {iP} :=
-    ⟨5, hmem, fun t' ht' => by
-      obtain ⟨i, hi, hts, htf⟩ := ht'
-      simp only [Set.mem_singleton_iff] at hi; subst hi
-      omega⟩
-  obtain ⟨t, ht, hall⟩ := h _ _ hby
-  have hlt := hall 5 hmem
-  obtain ⟨i, hi, hts, htf⟩ := ht
-  simp only [Set.mem_singleton_iff] at hi; subst hi
-  have hs : iP.fst = 5 := rfl
-  have hf : iP.snd = 5 := rfl
-  omega
-
--- ============================================================================
--- § 11: *Whenever* — Universal Temporal Overlap ([heinamaki-1974])
--- ============================================================================
-
-/-- *Whenever*: universally quantified temporal overlap.
-    "A whenever B" holds when every time point in B is also a time point in A.
-    Equivalent to `while_` with swapped arguments (B ⊆ A in time).
-
-    "Whenever it rains, I carry an umbrella" = every rain-time is an
-    umbrella-time. Implies habitual/generic interpretation.
-
-    [heinamaki-1974] treats *whenever* as a universal quantifier over
-    temporal overlap events, distinguishing it from the existential
-    *when* (∃-overlap). -/
-def Karttunen.whenever (A B : SentDenotation Time) : Prop :=
-  ∀ t ∈ timeTrace B, t ∈ timeTrace A
-
-/-- *Whenever* is *while* with swapped arguments: "A whenever B" ↔ "B while A".
-    Both express temporal containment, but *whenever* puts the containing event
-    as the main clause and the contained event as the subordinate clause. -/
-theorem whenever_iff_while_swap (A B : SentDenotation Time) :
-    Karttunen.whenever A B ↔ Karttunen.while_ B A :=
-  Iff.rfl
-
-/-- *Whenever* implies *when* (when B is nonempty):
-    universal overlap entails existential overlap. -/
-theorem whenever_implies_when (A B : SentDenotation Time)
-    (hne : ∃ t, t ∈ timeTrace B) :
-    Karttunen.whenever A B → Karttunen.when_ A B := by
-  intro hw
-  obtain ⟨t, ht⟩ := hne
-  exact ⟨t, hw t ht, ht⟩
-
-/-- *Whenever* is NOT symmetric: containment is directional.
-    Counterexample: same as `while_not_symmetric` — A ⊂ B gives
-    "A whenever B" false but "B whenever A" true. -/
-theorem whenever_not_symmetric :
-    ¬ ∀ (A B : SentDenotation ℤ),
-      Karttunen.whenever A B → Karttunen.whenever B A := by
-  intro h
-  let iA : NonemptyInterval ℤ := ⟨⟨1, 10⟩, by omega⟩
-  let iB : NonemptyInterval ℤ := ⟨⟨5, 5⟩, by omega⟩
-  have hAs : iA.fst = 1 := rfl
-  have hAf : iA.snd = 10 := rfl
-  have hBs : iB.fst = 5 := rfl
-  have hBf : iB.snd = 5 := rfl
-  -- whenever (stativeDenotation iA) {iB}: every time in {iB} (t=5) is in [1,10] ✓
-  have hw : Karttunen.whenever (stativeDenotation iA) {iB} := by
-    intro t ⟨i, hi, hts, htf⟩
-    simp only [Set.mem_singleton_iff] at hi; subst hi
-    rw [timeTrace_stativeDenotation]
-    constructor <;> omega
-  -- whenever {iB} (stativeDenotation iA): every time in [1,10] is in {5} ✗
-  have hw' := h _ _ hw
-  have h1 : (1 : ℤ) ∈ timeTrace (stativeDenotation iA) := by
-    rw [timeTrace_stativeDenotation]; constructor <;> omega
-  obtain ⟨i, hi, hts, _⟩ := hw' 1 h1
-  simp only [Set.mem_singleton_iff] at hi; subst hi
-  omega
+/-- With the presupposition, `A` occurs at or after a time of `B`. -/
+theorem notUntil_actualization (h : notUntil A B) (ha : actualization A) :
+    ∃ t ∈ timeTrace A, ∃ t' ∈ timeTrace B, t' ≤ t :=
+  ha.imp fun _ ht => ⟨ht, (notUntil_iff A B).1 h _ ht⟩
 
 end Karttunen1974

--- a/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
+++ b/Linglib/Studies/OgiharaSteinertThrelkeld2024.lean
@@ -1,5 +1,6 @@
 import Linglib.Studies.Anscombe1964
 import Linglib.Studies.Karttunen1974
+import Linglib.Studies.Heinamaki1974
 import Linglib.Studies.BeaverCondoravdi2003
 import Linglib.Semantics.Tense.SentDenotation
 import Linglib.Semantics.Aspect.SubintervalProperty
@@ -301,7 +302,7 @@ theorem veridicality_asymmetry :
 -- Bridge content (merged from Bridge.lean)
 -- ════════════════════════════════════════════════════════════════
 
-open Tense Anscombe1964 Karttunen1974
+open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 open English.TemporalExpressions
 
 -- ════════════════════════════════════════════════════════════════
@@ -745,7 +746,7 @@ namespace OgiharaSteinertThrelkeld2024.VeridicalityBridge
 
 open Core.Order
 open NonemptyInterval
-open Tense Anscombe1964 Karttunen1974
+open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 open English.TemporalExpressions
 open OgiharaSteinertThrelkeld2024
 
@@ -769,25 +770,25 @@ theorem after_veridicality_grounded :
 /-- *when* is veridical: Fragment field matches theory proof. -/
 theorem when_veridicality_grounded :
     when_conn.complementVeridical = true ∧
-    (∀ (A B : SentDenotation ℤ), Karttunen.when_ A B → ∃ t, t ∈ timeTrace B) :=
+    (∀ (A B : SentDenotation ℤ), when_ A B → ∃ t, t ∈ timeTrace B) :=
   ⟨rfl, when_veridical_complement⟩
 
 /-- *until* (durative) is veridical: Fragment field matches theory proof. -/
 theorem until_veridicality_grounded :
     until_.complementVeridical = true ∧
-    (∀ (A B : SentDenotation ℤ), Karttunen.until A B → ∃ t, t ∈ timeTrace B) :=
+    (∀ (A B : SentDenotation ℤ), until_ A B → ∃ t, t ∈ timeTrace B) :=
   ⟨rfl, until_veridical_complement⟩
 
 /-- *since* is veridical: Fragment field matches theory proof. -/
 theorem since_veridicality_grounded :
     since_conn.complementVeridical = true ∧
-    (∀ (A B : SentDenotation ℤ), Karttunen.since A B → ∃ t, t ∈ timeTrace B) :=
+    (∀ (A B : SentDenotation ℤ), since A B → ∃ t, t ∈ timeTrace B) :=
   ⟨rfl, since_veridical_complement⟩
 
 /-- *by* is veridical w.r.t. its main clause: Fragment field matches theory proof. -/
 theorem by_veridicality_grounded :
     by_deadline.complementVeridical = true ∧
-    (∀ (A B : SentDenotation ℤ), Karttunen.by_ A B → ∃ t, t ∈ timeTrace A) :=
+    (∀ (A B : SentDenotation ℤ), by_ A B → ∃ t, t ∈ timeTrace A) :=
   ⟨rfl, by_veridical_main⟩
 
 /-! ### Non-veridical connectives -/

--- a/Linglib/Studies/Rett2020.lean
+++ b/Linglib/Studies/Rett2020.lean
@@ -3,6 +3,7 @@ import Linglib.Semantics.Degree.Basic
 import Linglib.Features.Aktionsart
 import Linglib.Semantics.Aspect.ChangeOfState
 import Linglib.Studies.Karttunen1974
+import Linglib.Studies.Heinamaki1974
 import Linglib.Fragments.English.TemporalExpressions
 
 
@@ -43,7 +44,7 @@ linguistically. *after* and *while* are not ambidirectional.
 
 namespace Rett2020
 
-open Tense Anscombe1964 Karttunen1974
+open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
 open Core.Order
 open NonemptyInterval
@@ -341,7 +342,8 @@ Concrete scenarios verifying that the Anscombe, Rett, and Karttunen
 formalizations produce correct truth-value judgments.
 
 Scenarios 1–6 verify [rett-2020] Table 1 for *before*/*after*.
-Scenarios 7–10 verify [heinamaki-1974] Chs. 6, 8, 9 for *since*, *by*, *till*.
+Scenarios 7–10 verify [heinamaki-1974]'s *since* and *by* and [karttunen-1974]'s durative
+*until* (*till*).
 
 ## Scenarios (ℕ time points)
 
@@ -363,7 +365,7 @@ Scenarios 7–10 verify [heinamaki-1974] Chs. 6, 8, 9 for *since*, *by*, *till*.
 
 namespace Rett2020.Examples
 
-open Tense Anscombe1964 Karttunen1974
+open Tense Anscombe1964 Karttunen1974 Heinamaki1974
 
 open Core.Order
 open NonemptyInterval
@@ -615,27 +617,27 @@ private theorem mem_tt_deadline {t : ℕ} :
   simp only [NonemptyInterval.mem_def, ee_deadline, NonemptyInterval.pure, Set.mem_ofPred_eq]
   omega
 
-/-- "He has been happy₅₋₁₀ since she arrived₅" — True under `Karttunen.since`.
+/-- "He has been happy₅₋₁₀ since she arrived₅" — True under `since`.
     Witness: t = 5 ∈ B, and ∀t' ∈ A (i.e., 5 ≤ t' ≤ 10), 5 ≤ t'. -/
-theorem scenario_since : Karttunen.since A_stative B_onset := by
+theorem scenario_since : since A_stative B_onset := by
   refine ⟨5, mem_tt_onset.mpr rfl, ?_⟩
   intro t' ht'
   exact (mem_tt_stative.mp ht').1
 
 /-- *Since* is veridical for its complement in scenario: she arrived. -/
 theorem scenario_since_veridical :
-    Karttunen.since A_stative B_onset → ∃ t, t ∈ timeTrace B_onset :=
+    since A_stative B_onset → ∃ t, t ∈ timeTrace B_onset :=
   since_veridical_complement _ _
 
-/-- "He arrived₁ by 3pm₃" — True under `Karttunen.by_`.
+/-- "He arrived₁ by 3pm₃" — True under `by_`.
     Witness: t = 1 ∈ A, and ∀t' ∈ B (t' = 3), 1 ≤ 3. -/
-theorem scenario_by_strict : Karttunen.by_ A_early B_deadline := by
+theorem scenario_by_strict : by_ A_early B_deadline := by
   refine ⟨1, mem_tt_early.mpr rfl, ?_⟩
   intro t' ht'; have := mem_tt_deadline.mp ht'; omega
 
-/-- "He arrived₃ by 3pm₃" — True under `Karttunen.by_`.
+/-- "He arrived₃ by 3pm₃" — True under `by_`.
     Witness: t = 3 ∈ A, 3 ≤ 3 (coincidence allowed). -/
-theorem scenario_by_coincidence : Karttunen.by_ A_at_deadline B_deadline := by
+theorem scenario_by_coincidence : by_ A_at_deadline B_deadline := by
   refine ⟨3, mem_tt_at_deadline.mpr rfl, ?_⟩
   intro t' ht'; have := mem_tt_deadline.mp ht'; omega
 
@@ -649,21 +651,16 @@ theorem scenario_before_coincidence_false :
   omega
 
 /-- *By* but not *before* on the same scenario: demonstrates the strict
-    weakening from `before_implies_by`. -/
+    weakening from `before_by`. -/
 theorem by_without_before :
-    Karttunen.by_ A_at_deadline B_deadline ∧
+    by_ A_at_deadline B_deadline ∧
     ¬ Anscombe.before A_at_deadline B_deadline :=
   ⟨scenario_by_coincidence, scenario_before_coincidence_false⟩
 
-/-- "He slept₅₋₁₀ till she arrived₅" — True under `Karttunen.till`.
+/-- "He slept₅₋₁₀ till she arrived₅" — True under durative `until_` (*till* is *until*).
     Witness: t = 5 ∈ both time traces (overlap). -/
-theorem scenario_till : Karttunen.till A_stative B_onset := by
+theorem scenario_till : until_ A_stative B_onset := by
   exact ⟨5, mem_tt_stative.mpr ⟨le_refl _, by omega⟩, mem_tt_onset.mpr rfl⟩
-
-/-- *Till* agrees with *until* on the same scenario (definitional). -/
-theorem till_matches_until_scenario :
-    Karttunen.till A_stative B_onset ↔ Karttunen.until A_stative B_onset :=
-  till_iff_until _ _
 
 -- ============================================================================
 -- § 10: Punctual *Until* + Negation ([karttunen-1974])
@@ -671,14 +668,14 @@ theorem till_matches_until_scenario :
 
 /-! ### Not...until scenarios
 
-Karttunen's identity: punctual *until* = ¬*before* (eq. 33).
-We verify this on concrete time points.
+Karttunen's identity: punctual *until* = ¬*before*, with the presupposition that the main
+clause is actualized. We verify this on concrete time points.
 
-| # | ME           | EE          | Construction    | Result |
-|---|--------------|-------------|-----------------|--------|
-|11 | point(3)     | point(5)    | not...until     | True   |
-|12 | point(3)     | point(5)    | presup + assert | when   |
-|13 | point(7)     | point(5)    | not...until     | False  |
+| # | ME           | EE          | Construction    | Result                 |
+|---|--------------|-------------|-----------------|------------------------|
+|11 | point(3)     | point(5)    | not...until     | False                  |
+|12 | point(5)     | point(5)    | not...until     | True, at the kiss      |
+|13 | point(7)     | point(5)    | not...until     | True, a little later   |
 -/
 
 /-- ME: "The princess woke up" — punctual event at time 3 (early). -/
@@ -713,7 +710,7 @@ theorem scenario11_before_true : Anscombe.before A_wake_early B_kiss := by
 /-- Scenario 11': "The princess didn't wake up₃ until the prince kissed her₅" — FALSE.
     NOT(BEFORE) = NOT(wake₃ before kiss₅) = ¬(3 < 5) = False.
     The princess DID wake up before the kiss, so "not until" is false. -/
-theorem scenario11_notUntil_false : ¬ Karttunen.notUntil A_wake_early B_kiss := by
+theorem scenario11_notUntil_false : ¬ notUntil A_wake_early B_kiss := by
   intro h; exact h scenario11_before_true
 
 /-- ME: "The princess woke up" — punctual event at time 5 (AT the kiss). -/
@@ -729,25 +726,17 @@ private theorem mem_tt_wake_at {t : ℕ} :
 /-- Scenario 12: "The princess didn't wake up₅ until the prince kissed her₅"
     — TRUE. NOT(BEFORE) = NOT(wake₅ before kiss₅) = ¬(5 < 5) = True.
     She woke up at exactly the time of the kiss. -/
-theorem scenario12_notUntil_true : Karttunen.notUntil A_wake_at B_kiss := by
+theorem scenario12_notUntil_true : notUntil A_wake_at B_kiss := by
   intro ⟨t, ht, hall⟩
   have ht5 := mem_tt_wake_at.mp ht
   have hlt := hall 5 (mem_tt_kiss.mpr rfl)
   omega
 
-/-- Scenario 12': Presupposition (wake₅ before kiss₅ ∨ wake₅ when kiss₅) is
-    satisfied: the waking happens at the kiss time (when), so the left
-    disjunct is false but the right is true. -/
-theorem scenario12_presupposition :
-    Anscombe.before A_wake_at B_kiss ∨ Karttunen.when_ A_wake_at B_kiss :=
-  Or.inr ⟨5, mem_tt_wake_at.mpr rfl, mem_tt_kiss.mpr rfl⟩
-
-/-- Scenario 12'': Presupposition + assertion → when (disjunctive syllogism).
-    This is Karttunen's key result: "not until" + presupposition derives "when". -/
-theorem scenario12_derives_when :
-    Karttunen.when_ A_wake_at B_kiss :=
-  notUntil_with_presupposition A_wake_at B_kiss
-    scenario12_presupposition scenario12_notUntil_true
+/-- Scenario 12': with the actualization presupposition, the waking is at or after the
+    kiss — here exactly at it. -/
+theorem scenario12_at_or_after :
+    ∃ t ∈ timeTrace A_wake_at, ∃ t' ∈ timeTrace B_kiss, t' ≤ t :=
+  notUntil_actualization _ _ scenario12_notUntil_true ⟨5, mem_tt_wake_at.mpr rfl⟩
 
 /-- ME: "The princess woke up" — punctual event at time 7 (AFTER the kiss). -/
 def me_wake_late : NonemptyInterval ℕ := NonemptyInterval.pure 7
@@ -762,32 +751,18 @@ private theorem mem_tt_wake_late {t : ℕ} :
 /-- Scenario 13: "The princess didn't wake up₇ until the prince kissed her₅"
     — TRUE. NOT(BEFORE) = NOT(wake₇ before kiss₅) = ¬(7 < 5) = True.
     She woke up after the kiss, so she didn't wake up before it. -/
-theorem scenario13_notUntil_true : Karttunen.notUntil A_wake_late B_kiss := by
+theorem scenario13_notUntil_true : notUntil A_wake_late B_kiss := by
   intro ⟨t, ht, hall⟩
   have ht7 := mem_tt_wake_late.mp ht
   have hlt := hall 5 (mem_tt_kiss.mpr rfl)
   omega
 
-/-- Scenario 13': wake₇ is NOT when kiss₅ (no overlap at any time point). -/
-theorem scenario13_not_when : ¬ Karttunen.when_ A_wake_late B_kiss := by
+/-- Scenario 13': wake₇ is not when kiss₅ — the waking is "a little later", as
+    [karttunen-1974] allows. -/
+theorem scenario13_not_when : ¬ when_ A_wake_late B_kiss := by
   rintro ⟨t, ht_w, ht_k⟩
   have := mem_tt_wake_late.mp ht_w
   have := mem_tt_kiss.mp ht_k
   omega
-
-/-- Scenario 13'': The presupposition (before ∨ when) is NOT satisfied,
-    so *not...until* is vacuously true but pragmatically infelicitous.
-    This models why "She didn't wake up until the prince kissed her" is
-    odd when she woke up AFTER the kiss — the presupposition fails. -/
-theorem scenario13_presup_fails :
-    ¬ (Anscombe.before A_wake_late B_kiss ∨ Karttunen.when_ A_wake_late B_kiss) := by
-  intro h
-  cases h with
-  | inl hbefore =>
-    obtain ⟨t, ht, hall⟩ := hbefore
-    have := mem_tt_wake_late.mp ht
-    have := hall 5 (mem_tt_kiss.mpr rfl)
-    omega
-  | inr hwhen => exact scenario13_not_when hwhen
 
 end Rett2020.Examples

--- a/references.bib
+++ b/references.bib
@@ -11544,7 +11544,7 @@
   subfield  = {semantics/tense},
   validated = {true},
   role      = {formalized},
-  sources   = {Fragments/English/TemporalExpressions.lean;Fragments/Finnish/TemporalConnectives.lean}
+  sources   = {Fragments/English/TemporalExpressions.lean;Fragments/Finnish/TemporalConnectives.lean;Studies/Heinamaki1974.lean}
 }
 @article{karttunen-1974-presupposition,
   author    = {Karttunen, Lauri},


### PR DESCRIPTION
428 → 75 lines, now checked against the CLS 10 paper itself (pp. 284–297). The file was mostly [heinamaki-1974]'s connectives (*when*, *while*, *whenever*, *since*, *by*, *till*) parked under Karttunen's anchor, plus a "Level 1" architecture essay, `Iff.rfl` identities, and a `[rett-2026]` citation in a 1974 study. Those connectives now live in their own `Studies/Heinamaki1974.lean` (point-set relations on `SentDenotation`, veridicality, *before* ⊊ *by*, asymmetry of *while*), and the consumers (Rett2020, OgiharaSteinertThrelkeld2024, Giannakidou2002, JinKoenig2021) are repointed.
- Karttunen1974 keeps what the paper claims, with his numbering: durative `until_` (12)–(14), (21); punctual `notUntil` = `NOT(A BEFORE T)` (33) with `notUntil_iff` and its denial *A before T* (30)–(31); the pragmatic presupposition of lateness (34) *A before T ∨ A when T* (`presupposition`) and the disjunctive syllogism to *A when T* (36) (`notUntil_when`); and the Finnish *ennenkuin*/*vasta* synonymy (39) for point events (`notUntil_iff_when_of_presupposition`).
- Bib: Heinämäki 1974 is a University of Texas at Austin dissertation (per Karttunen's bibliography), reproduced by IULC in 1978; the *till* duplicate is dropped (*till* is durative *until* in Rett2020's scenario).