### PR TITLE
refactor(Pragmatics/NeoGricean): Set W states, derived competence

### DIFF
--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -2,24 +2,22 @@ import Mathlib.Data.Set.Insert
 import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
-# Neo-Gricean pragmatics: epistemic states and the Standard Recipe
+# Neo-Gricean pragmatics: secondary implicatures and the Standard Recipe
 
 This file defines [sauerland-2004]'s consistency-gated derivation of secondary implicatures
-and the three-way belief-state classification over which the Standard Recipe of
-[geurts-2010] runs. A speaker's epistemic state is a set of worlds `s : Set W` — the same
-object as the `ContextSet` of `Discourse/CommonGround.lean` — and a proposition is a `Set W`,
-so the speaker knows `φ` iff `s ⊆ φ`, knows `¬φ` iff `s ⊆ φᶜ`, and considers `φ` possible iff
-`(s ∩ φ).Nonempty`; consistency of the speaker is the hypothesis `s.Nonempty` (the
-`Filter.NeBot` convention), not part of a bundled type. Asserting `φ` yields the primary
-implicature `¬Kψ` for each stronger alternative `ψ`; the secondary implicature `K¬ψ` arises
-only when it is consistent with the assertion and all primary implicatures, and the Standard
-Recipe obtains it from `¬Kψ` under the competence assumption `Kψ ∨ K¬ψ`.
+and the Standard Recipe of [geurts-2010]. A speaker's epistemic state is a set of worlds
+`s : Set W` — the same object as the `ContextSet` of `Discourse/CommonGround.lean` — and a
+proposition is a `Set W`, so the speaker knows `φ` iff `s ⊆ φ`, knows `¬φ` iff `s ⊆ φᶜ`, and
+is competent about `φ` iff `s ⊆ φ ∨ s ⊆ φᶜ`; consistency of the speaker is the hypothesis
+`s.Nonempty` (the `Filter.NeBot` convention).
+Asserting `φ` yields the primary implicature `¬Kψ` for each stronger alternative `ψ`; the
+secondary implicature `K¬ψ` arises only when it is consistent with the assertion and all
+primary implicatures, and the Standard Recipe obtains it from `¬Kψ` under competence.
 
 ## Main definitions
 
 * `SatisfiesPrimaries`, `SecondaryLicensed`: the commitment set after an assertion and the
   consistency condition licensing a secondary implicature.
-* `BeliefState`, `beliefState`: belief, disbelief, or no opinion about an alternative.
 
 ## Main results
 
@@ -28,7 +26,7 @@ Recipe obtains it from `¬Kψ` under the competence assumption `Kψ ∨ K¬ψ`.
   K¬A blocked) is `Studies/Sauerland2004.lean`.
 * `secondaryLicensed_of_ssubset`: a lone asymmetrically stronger alternative always licenses
   its secondary implicature.
-* `subset_compl_iff_not_subset`: the Standard Recipe — under competence, the strong
+* `subset_compl_iff_not_subset`: the Standard Recipe — for a competent speaker, the strong
   implicature `K¬ψ` is exactly the weak implicature `¬Kψ`.
 
 ## References
@@ -104,53 +102,20 @@ theorem secondaryLicensed_singleton_self : SecondaryLicensed φ [ψ] ψ ↔ (φ 
 theorem secondaryLicensed_of_ssubset (h : ψ ⊂ φ) : SecondaryLicensed φ [ψ] ψ :=
   secondaryLicensed_singleton_self.2 (Set.sdiff_nonempty.2 h.2)
 
-/-! ### The three-way belief-state classification
+/-! ### Competence and the Standard Recipe
 
-`BeliefState` is the knows-whether trichotomy for one alternative `ψ`, and `beliefState`
-grounds it in the epistemic state. The Standard Recipe is `subset_compl_iff_not_subset`: for
-a consistent, competent speaker, knowing `¬ψ` is exactly not knowing `ψ`. -/
-
-/-- A speaker's attitude toward an alternative `ψ`: belief `Bel_S(ψ)`, disbelief `Bel_S(¬ψ)`,
-or no opinion. -/
-inductive BeliefState where
-  | belief
-  | disbelief
-  | noOpinion
-  deriving DecidableEq, Repr
+Competence about `ψ` is [sauerland-2004]'s `Kψ ∨ K¬ψ`, `s ⊆ ψ ∨ s ⊆ ψᶜ` — the speaker *knows
+whether* `ψ`, which is support of the polar question `Question.polar ψ` by
+`Question.mem_polar`. -/
 
 /-- A consistent speaker cannot both know `ψ` and know `¬ψ`. -/
 theorem not_subset_compl_of_subset (hs : s.Nonempty) (h : s ⊆ ψ) : ¬ s ⊆ ψᶜ :=
   fun h' => hs.elim fun _ hw => h' hw (h hw)
 
-/-- The Standard Recipe: for a consistent speaker competent about `ψ` (`Kψ ∨ K¬ψ`), the strong
-implicature `K¬ψ` is exactly the weak implicature `¬Kψ`. -/
+/-- The Standard Recipe: for a consistent speaker competent about `ψ`, the strong implicature
+`K¬ψ` is exactly the weak implicature `¬Kψ`. -/
 theorem subset_compl_iff_not_subset (hs : s.Nonempty) (hc : s ⊆ ψ ∨ s ⊆ ψᶜ) :
     s ⊆ ψᶜ ↔ ¬ s ⊆ ψ :=
   ⟨fun h h' => not_subset_compl_of_subset hs h' h, hc.resolve_left⟩
-
-variable [Decidable (s ⊆ ψ)] [Decidable (s ⊆ ψᶜ)]
-
-/-- Classify an epistemic state by its attitude toward `ψ`: `Kψ` is belief, `K¬ψ` disbelief,
-anything else no opinion. -/
-def beliefState (s ψ : Set W) [Decidable (s ⊆ ψ)] [Decidable (s ⊆ ψᶜ)] : BeliefState :=
-  if s ⊆ ψ then .belief else if s ⊆ ψᶜ then .disbelief else .noOpinion
-
-@[simp] theorem beliefState_eq_belief_iff : beliefState s ψ = .belief ↔ s ⊆ ψ := by
-  unfold beliefState
-  split_ifs <;> simp [*]
-
-/-- Disbelief is `K¬ψ`; the `Kψ` branch is excluded by consistency. -/
-theorem beliefState_eq_disbelief_iff (hs : s.Nonempty) :
-    beliefState s ψ = .disbelief ↔ s ⊆ ψᶜ := by
-  unfold beliefState
-  split_ifs with h₁ h₂
-  · exact iff_of_false (by decide) (not_subset_compl_of_subset hs h₁)
-  · exact iff_of_true rfl h₂
-  · exact iff_of_false (by decide) h₂
-
-@[simp] theorem beliefState_eq_noOpinion_iff :
-    beliefState s ψ = .noOpinion ↔ ¬ s ⊆ ψ ∧ ¬ s ⊆ ψᶜ := by
-  unfold beliefState
-  split_ifs <;> simp [*]
 
 end NeoGricean

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -1,17 +1,16 @@
 import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Fintype.Basic
 import Linglib.Semantics.Alternatives.AsymStronger
 import Linglib.Logic.Modal.Defs
 
 /-!
 # Neo-Gricean pragmatics: epistemic states and the Standard Recipe
-[sauerland-2004] [geurts-2010]
 
-The epistemic layer of Neo-Gricean implicature: an `EpistemicState` (the
-worlds compatible with the speaker's knowledge) with `knows` (K) and
-`possible` (P) realized as `box`/`diamond` over a serial accessibility
-from `Modal`, and the Standard Recipe run over the derived
-three-way `BeliefState` classification.
+The epistemic layer of Neo-Gricean implicature: a speaker's
+`EpistemicState` (the nonempty finite set of worlds compatible with
+what the speaker knows) with the operators `knows` (K) and `possible`
+(P), [sauerland-2004]'s consistency-gated derivation of secondary
+implicatures, and the three-way `BeliefState` classification over
+which [geurts-2010]'s Standard Recipe runs.
 
 [sauerland-2004] distinguishes **primary implicatures** ¬Kψ from
 **secondary implicatures** K¬ψ, a secondary arising only when K¬ψ is
@@ -21,19 +20,29 @@ The epistemic modalization ¬Kψ goes back to [soames-1982] and
 secondaries is formalized by [sauerland-2004], [vanrooij-schulz-2004],
 and [spector-2006]; [geurts-2010] is the textbook presentation.
 
-This file provides the modal substrate, the consistency-gated
-derivation (`SatisfiesPrimaries`, `SecondaryLicensed`), and the recipe
-over the belief-state classification. `secondary_blocked_if_possible`
-and `primary_possibility` are instances of K/P duality; the flagship
-multi-alternative blocking case is exercised in
-`Studies/Sauerland2004.lean`.
+## Main definitions
 
-The asymmetric-entailment primitive characterizing primary-implicature
-alternatives is `asymStrongerOn` in `Semantics/Alternatives/AsymStronger.lean`;
-a consumer writes `alts.filter (asymStrongerOn e.possible · φ)` directly.
-For the graded counterpart of competence (the RSA knowledgeability
-parameter) see `Pragmatics/RSA/`; `Studies/Franke2011/RSABridge.lean`
-relates RSA speakers to IBR argmax behaviour.
+* `EpistemicState`: a nonempty finite set of worlds, with `SetLike` membership.
+* `EpistemicState.knows`, `EpistemicState.possible`: the K and P operators, `box`/`diamond`
+  over the epistemic accessibility `EpistemicState.access`.
+* `SatisfiesPrimaries`, `SecondaryLicensed`: [sauerland-2004]'s commitment set after an
+  assertion and the consistency condition licensing a secondary implicature.
+* `BeliefState`, `EpistemicState.beliefState`: belief, disbelief, or no opinion about an
+  alternative, with the Standard Recipe's predicates `BeliefState.Competent`,
+  `BeliefState.WeakImplicature`, `BeliefState.StrongImplicature`.
+
+## Main results
+
+* `secondaryLicensed_iff`: licensing decomposes over the alternatives, so a blocked secondary
+  implicature is always blocked by a single primary.
+* `secondaryLicensed_of_asymStrongerOn`: a lone asymmetrically stronger alternative always
+  licenses its secondary implicature.
+* `BeliefState.strongImplicature_iff`: the strong implicature is exactly the weak implicature
+  plus competence.
+
+The flagship multi-alternative case (K¬(A∧B) licensed but K¬A blocked for *A or B*) is
+`Studies/Sauerland2004.lean`; the graded counterpart of competence is the RSA
+knowledgeability parameter in `Pragmatics/RSA/`.
 -/
 
 namespace NeoGricean
@@ -44,255 +53,218 @@ variable {W : Type*}
 
 /-! ### Epistemic states and the K/P operators -/
 
-/-- An epistemic state: the (nonempty, finite) set of worlds compatible
-with the speaker's knowledge. -/
+/-- A speaker's epistemic state: the nonempty finite set of worlds compatible with what the
+speaker knows. Nonemptiness makes K serial (`EpistemicState.possible_of_knows`). -/
 structure EpistemicState (W : Type*) where
-  /-- Worlds compatible with speaker's knowledge -/
-  possible : Finset W
-  /-- Non-empty (speaker knows something is true) -/
-  nonempty : possible.Nonempty
+  /-- The worlds compatible with the speaker's knowledge. -/
+  carrier : Finset W
+  nonempty : carrier.Nonempty
 
-/-- K operator: the speaker knows φ iff φ holds in all epistemically
-possible worlds. -/
-def knows (e : EpistemicState W) (φ : W → Prop) : Prop :=
-  ∀ w ∈ e.possible, φ w
+namespace EpistemicState
 
-instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] :
-    Decidable (knows e φ) :=
-  inferInstanceAs (Decidable (∀ w ∈ e.possible, φ w))
+instance : SetLike (EpistemicState W) W where
+  coe e := e.carrier
+  coe_injective e₁ e₂ h := by cases e₁; cases e₂; congr; exact Finset.coe_injective h
 
-/-- P operator: the speaker considers φ possible. -/
-def possible (e : EpistemicState W) (φ : W → Prop) : Prop :=
-  ∃ w ∈ e.possible, φ w
+@[simp] theorem mem_carrier {e : EpistemicState W} {w : W} : w ∈ e.carrier ↔ w ∈ e := Iff.rfl
 
-instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] :
-    Decidable (possible e φ) :=
-  inferInstanceAs (Decidable (∃ w ∈ e.possible, φ w))
+@[simp] theorem mem_mk {s : Finset W} {h : s.Nonempty} {w : W} : w ∈ mk s h ↔ w ∈ s := Iff.rfl
 
-/-! ### `K`/`P` as restricted modality
+@[ext] theorem ext {e₁ e₂ : EpistemicState W} (h : ∀ w, w ∈ e₁ ↔ w ∈ e₂) : e₁ = e₂ :=
+  SetLike.ext h
 
-`knows`/`possible` are `box`/`diamond` over the (world-independent)
-epistemic accessibility `accessFrom e`, serial because `e.possible` is
-nonempty. The epistemic square of opposition is
-`ModalLogic.modalSquare (accessFrom e)` with `modalSquare_relations`
-discharged by this `IsSerial` instance. -/
+/-- The K operator: the speaker knows `φ` iff `φ` holds throughout the epistemic state. -/
+def knows (e : EpistemicState W) (φ : W → Prop) : Prop := ∀ w ∈ e, φ w
+
+/-- The P operator: the speaker considers `φ` possible iff some world in the epistemic state
+satisfies `φ`. -/
+def possible (e : EpistemicState W) (φ : W → Prop) : Prop := ∃ w ∈ e, φ w
+
+instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] : Decidable (e.knows φ) :=
+  inferInstanceAs (Decidable (∀ w ∈ e.carrier, φ w))
+
+instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] : Decidable (e.possible φ) :=
+  inferInstanceAs (Decidable (∃ w ∈ e.carrier, φ w))
+
+/-! ### K and P as restricted modality
+
+`knows` and `possible` are `box` and `diamond` over the world-independent epistemic
+accessibility `access`, serial because the state is nonempty; the duality and consistency
+lemmas below are the corresponding instances of `ModalLogic.not_box`, `ModalLogic.not_diamond`,
+and `ModalLogic.box_D`. -/
 
 /-- Epistemic accessibility: from any world, the speaker's live possibilities. -/
-def accessFrom (e : EpistemicState W) : W → W → Prop := fun _ w' => w' ∈ e.possible
+def access (e : EpistemicState W) : W → W → Prop := fun _ w => w ∈ e
 
-instance (e : EpistemicState W) : IsSerial (accessFrom e) := ⟨fun _ => e.nonempty⟩
+instance (e : EpistemicState W) : IsSerial e.access := ⟨fun _ => e.nonempty⟩
 
-/-- `K` is `□` over epistemic accessibility. -/
-theorem knows_eq_box (e : EpistemicState W) (φ : W → Prop) (w : W) :
-    knows e φ = box (accessFrom e) φ w := rfl
+@[simp] theorem box_access (e : EpistemicState W) (φ : W → Prop) (w : W) :
+    box e.access φ w ↔ e.knows φ := Iff.rfl
 
-/-- `P` is `◇` over epistemic accessibility. -/
-theorem possible_eq_diamond (e : EpistemicState W) (φ : W → Prop) (w : W) :
-    possible e φ = diamond (accessFrom e) φ w := rfl
+@[simp] theorem diamond_access (e : EpistemicState W) (φ : W → Prop) (w : W) :
+    diamond e.access φ w ↔ e.possible φ := Iff.rfl
 
-/-- Epistemic duality: ¬K¬φ ↔ Pφ — the box–diamond duality underlying
-the modal square of opposition (`ModalLogic.modalSquare_relations`). -/
-theorem duality (e : EpistemicState W) (φ : W → Prop) :
-    ¬ knows e (fun w => ¬ φ w) ↔ possible e φ := by
-  simp only [knows, possible, not_forall, not_not, exists_prop]
+/-- K/P duality: `¬Kφ ↔ P¬φ`. -/
+@[simp] theorem not_knows (e : EpistemicState W) (φ : W → Prop) :
+    ¬ e.knows φ ↔ e.possible fun w => ¬ φ w :=
+  e.nonempty.elim fun w _ => ModalLogic.not_box e.access φ w
 
-/-- Secondary implicature: the speaker knows the alternative is false. -/
-def hasSecondaryImplicature (e : EpistemicState W) (ψ : W → Prop) : Prop :=
-  knows e (fun w => ¬ ψ w)
+/-- K/P duality: `¬Pφ ↔ K¬φ`. -/
+@[simp] theorem not_possible (e : EpistemicState W) (φ : W → Prop) :
+    ¬ e.possible φ ↔ e.knows fun w => ¬ φ w :=
+  e.nonempty.elim fun w _ => ModalLogic.not_diamond e.access φ w
 
-instance (e : EpistemicState W) (ψ : W → Prop) [DecidablePred ψ] :
-    Decidable (hasSecondaryImplicature e ψ) :=
-  inferInstanceAs (Decidable (∀ w ∈ e.possible, ¬ ψ w))
+/-- Knowledge is consistent, `Kφ → Pφ` (the D axiom over a nonempty state). -/
+theorem possible_of_knows {e : EpistemicState W} {φ : W → Prop} (h : e.knows φ) :
+    e.possible φ :=
+  e.nonempty.elim fun w _ => ModalLogic.box_D (R := e.access) (w := w) h
 
-/-- If ψ is epistemically possible, K¬ψ fails. An instance of `duality`;
-the substrate fact used when checking a candidate secondary implicature
-against the speaker's state. -/
-theorem secondary_blocked_if_possible (e : EpistemicState W) (ψ : W → Prop) :
-    possible e ψ → ¬ hasSecondaryImplicature e ψ := by
-  rintro ⟨w, hw, hψ⟩ hknow
-  exact hknow w hw hψ
-
-/-- A primary implicature ¬Kψ entails that ¬ψ is epistemically possible.
-An instance of `duality`. -/
-theorem primary_possibility (e : EpistemicState W) (ψ : W → Prop) :
-    ¬ knows e ψ → possible e (fun w => ¬ ψ w) := by
-  intro h
-  simp only [knows, not_forall] at h
-  obtain ⟨w, hw⟩ := h
-  exact ⟨w, hw.1, hw.2⟩
+end EpistemicState
 
 /-! ### The Sauerland derivation
 
-Asserting φ against scalar alternatives `alts` commits the speaker to
-Kφ plus, for each alternative, the primary implicature ¬Kψ
-([sauerland-2004] (42), verified p. 383). A secondary implicature K¬ψ
-arises exactly when it is *consistent* with that commitment set
-([sauerland-2004] (43)): here, when some epistemic state realizes the
-commitments together with K¬ψ. `secondaryLicensed_iff_reinforceable`
-identifies the single-alternative case with the reinforceability
-diagnostic; the flagship multi-alternative blocking case (K¬A blocked
-for a disjunction because it forces KB) is `Studies/Sauerland2004.lean`. -/
+Asserting `φ` against scalar alternatives `alts` commits the speaker to `Kφ` plus, for each
+alternative, the primary implicature `¬Kψ` ([sauerland-2004] (42), verified p. 383). A
+secondary implicature `K¬ψ` arises exactly when it is *consistent* with that commitment set
+([sauerland-2004] (43)): when some epistemic state realizes the commitments together with
+`K¬ψ`. -/
 
-/-- The speaker commitment after asserting φ against `alts`: the
-assertion is known (Kφ) and every primary implicature holds (¬Kψ for
-each alternative). Per [sauerland-2004] (42), the caller supplies only
-the asymmetrically-stronger alternatives (ψ ⇒ φ but not φ ⇒ ψ, e.g. via
-`asymStrongerOn`); the definition itself does not enforce the filter. -/
-def SatisfiesPrimaries (e : EpistemicState W) (φ : W → Prop)
-    (alts : List (W → Prop)) : Prop :=
-  knows e φ ∧ ∀ ψ ∈ alts, ¬ knows e ψ
+/-- The speaker commitment after asserting `φ` against `alts`: `Kφ` and the primary implicature
+`¬Kψ` for each alternative. Per [sauerland-2004], the caller supplies only the asymmetrically
+stronger alternatives (e.g. via `Entailment.asymStrongerOn`); the definition does not enforce
+the filter. -/
+def SatisfiesPrimaries (e : EpistemicState W) (φ : W → Prop) (alts : List (W → Prop)) : Prop :=
+  e.knows φ ∧ ∀ ψ ∈ alts, ¬ e.knows ψ
 
-/-- Sauerland's consistency condition: the secondary implicature K¬ψ is
-licensed iff some epistemic state realizes the assertion, all primary
-implicatures, and K¬ψ jointly. -/
-def SecondaryLicensed (φ : W → Prop) (alts : List (W → Prop))
-    (ψ : W → Prop) : Prop :=
-  ∃ e : EpistemicState W, SatisfiesPrimaries e φ alts ∧ hasSecondaryImplicature e ψ
+/-- [sauerland-2004]'s consistency condition: the secondary implicature `K¬ψ` is licensed iff
+some epistemic state realizes the assertion, all primary implicatures, and `K¬ψ` jointly. -/
+def SecondaryLicensed (φ : W → Prop) (alts : List (W → Prop)) (ψ : W → Prop) : Prop :=
+  ∃ e : EpistemicState W, SatisfiesPrimaries e φ alts ∧ e.knows fun w => ¬ ψ w
 
-/-- For a lone alternative, Sauerland licensing reduces to consistency
-of the strengthened meaning: K¬ψ is compatible with the commitments
-Kφ ∧ ¬Kψ exactly when φ ∧ ¬ψ is realizable at some world — the same
-condition under which the content ¬ψ is a non-redundant strengthening
-of φ (`Implicature.IsReinforceable φ ψ` in the diagnostics' pair
-form). -/
-theorem secondaryLicensed_iff_strengthening_consistent [Fintype W]
-    (φ ψ : W → Prop) [DecidablePred φ] [DecidablePred ψ] :
-    SecondaryLicensed φ [ψ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w := by
+/-- Licensing decomposes over the alternatives: `K¬ψ` is consistent with the commitments iff
+the strengthened meaning `φ ∧ ¬ψ` is realizable and, for each alternative `χ`, realizable at
+a `¬χ`-world. A blocked secondary implicature is thus always blocked by a single primary. -/
+theorem secondaryLicensed_iff {φ ψ : W → Prop} {alts : List (W → Prop)} :
+    SecondaryLicensed φ alts ψ ↔
+      (∃ w, φ w ∧ ¬ ψ w) ∧ ∀ χ ∈ alts, ∃ w, φ w ∧ ¬ ψ w ∧ ¬ χ w := by
   constructor
-  · rintro ⟨e, ⟨hφ, _⟩, hψ⟩
-    obtain ⟨w, hw⟩ := e.nonempty
-    exact ⟨w, hφ w hw, hψ w hw⟩
-  · rintro ⟨w, hφw, hψw⟩
-    have hmem : w ∈ Finset.univ.filter (fun v => φ v ∧ ¬ ψ v) :=
-      Finset.mem_filter.2 ⟨Finset.mem_univ w, hφw, hψw⟩
-    refine ⟨⟨Finset.univ.filter (fun v => φ v ∧ ¬ ψ v), ⟨w, hmem⟩⟩, ⟨?_, ?_⟩, ?_⟩
-    · exact fun v hv => ((Finset.mem_filter.1 hv).2).1
-    · simp only [List.mem_singleton, forall_eq]
-      exact fun hk => hψw (hk w hmem)
-    · exact fun v hv => ((Finset.mem_filter.1 hv).2).2
+  · rintro ⟨e, ⟨hφ, hprim⟩, hψ⟩
+    refine ⟨e.nonempty.imp fun w hw => ⟨hφ w hw, hψ w hw⟩, fun χ hχ => ?_⟩
+    obtain ⟨w, hw, hχ⟩ := (e.not_knows χ).1 (hprim χ hχ)
+    exact ⟨w, hφ w hw, hψ w hw, hχ⟩
+  · classical
+    rintro ⟨⟨w₀, hφ₀, hψ₀⟩, h⟩
+    induction alts with
+    | nil =>
+      refine ⟨⟨{w₀}, Finset.singleton_nonempty w₀⟩, ⟨?_, by simp⟩, ?_⟩ <;>
+        simpa [EpistemicState.knows]
+    | cons χ alts ih =>
+      obtain ⟨e, ⟨hφ, hprim⟩, hψ⟩ := ih fun χ' hχ' => h χ' (List.mem_cons_of_mem χ hχ')
+      obtain ⟨w, hφw, hψw, hχw⟩ := h χ List.mem_cons_self
+      refine ⟨⟨insert w e.carrier, Finset.insert_nonempty w _⟩,
+        ⟨(Finset.forall_mem_insert ..).2 ⟨hφw, hφ⟩, List.forall_mem_cons.2 ⟨?_, ?_⟩⟩,
+        (Finset.forall_mem_insert ..).2 ⟨hψw, hψ⟩⟩
+      · exact fun hk => hχw (hk w (Finset.mem_insert_self w _))
+      · exact fun χ' hχ' hk => hprim χ' hχ' fun v hv => hk v (Finset.mem_insert_of_mem hv)
+
+/-- For a lone alternative `χ`, `K¬ψ` is licensed iff `φ ∧ ¬ψ ∧ ¬χ` is realizable. -/
+theorem secondaryLicensed_singleton {φ ψ χ : W → Prop} :
+    SecondaryLicensed φ [χ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w ∧ ¬ χ w := by
+  rw [secondaryLicensed_iff, List.forall_mem_singleton]
+  exact and_iff_right_of_imp fun ⟨w, h⟩ => ⟨w, h.1, h.2.1⟩
+
+/-- Against its own alternative alone, `K¬ψ` is licensed iff the strengthened meaning
+`φ ∧ ¬ψ` is consistent. -/
+theorem secondaryLicensed_singleton_self {φ ψ : W → Prop} :
+    SecondaryLicensed φ [ψ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w := by
+  simp only [secondaryLicensed_singleton, and_self]
+
+/-- A lone asymmetrically stronger alternative always yields its secondary implicature: the
+*some ⇝ not all* case. -/
+theorem secondaryLicensed_of_asymStrongerOn {s : Finset W} {φ ψ : W → Prop} [DecidablePred φ]
+    [DecidablePred ψ] (h : Entailment.asymStrongerOn s ψ φ) : SecondaryLicensed φ [ψ] ψ :=
+  secondaryLicensed_singleton_self.2 <| h.2.imp fun _ hw => hw.2
 
 /-! ### The three-way belief-state classification
 
-`BeliefState` is the decidable classification of a speaker's attitude
-toward one alternative ψ: `Bel_S(ψ)`, `Bel_S(¬ψ)`, or no opinion.
-`EpistemicState.beliefState` grounds the enum in the modal substrate, so
-the Standard Recipe below is a projection of K/P reasoning, not a
-parallel encoding. -/
+`BeliefState` is the decidable classification of a speaker's attitude toward one alternative
+`ψ`; `EpistemicState.beliefState` grounds it in the K operator, so the Standard Recipe's
+predicates are projections of K/P reasoning (`competent_beliefState_iff` and its siblings). -/
 
-/-- Speaker's belief state about a proposition ψ: belief `Bel_S(ψ)`,
-disbelief `Bel_S(¬ψ)`, or no opinion `¬Bel_S(ψ) ∧ ¬Bel_S(¬ψ)`. -/
+/-- A speaker's attitude toward an alternative `ψ`: belief `Bel_S(ψ)`, disbelief `Bel_S(¬ψ)`,
+or no opinion. -/
 inductive BeliefState where
   | belief
   | disbelief
   | noOpinion
   deriving DecidableEq, Repr
 
-/-- Classify an epistemic state by its attitude toward ψ: `Kψ` is
-belief, `K¬ψ` disbelief, anything else no opinion. -/
-def EpistemicState.beliefState (e : EpistemicState W) (ψ : W → Prop)
-    [DecidablePred ψ] : BeliefState :=
-  if knows e ψ then .belief
-  else if hasSecondaryImplicature e ψ then .disbelief
-  else .noOpinion
+namespace BeliefState
 
-/-- Competence: the speaker knows whether ψ, `Bel_S(ψ) ∨ Bel_S(¬ψ)`. -/
-def competent : BeliefState → Bool
-  | .belief => true
-  | .disbelief => true
-  | .noOpinion => false
+/-- Competence: the speaker knows whether `ψ`, `Bel_S(ψ) ∨ Bel_S(¬ψ)`. -/
+def Competent : BeliefState → Prop
+  | .belief | .disbelief => True
+  | .noOpinion => False
 
-/-- Non-belief `¬Bel_S(ψ)` — the weak (primary) implicature. -/
-def nonBelief : BeliefState → Bool
-  | .belief => false
-  | .disbelief => true
-  | .noOpinion => true
+/-- The weak (primary) implicature `¬Bel_S(ψ)`. -/
+def WeakImplicature : BeliefState → Prop
+  | .belief => False
+  | .disbelief | .noOpinion => True
 
-/-- Strong (secondary) implicature `Bel_S(¬ψ)`. -/
-def strongImpl : BeliefState → Bool
-  | .belief => false
-  | .disbelief => true
-  | .noOpinion => false
+/-- The strong (secondary) implicature `Bel_S(¬ψ)`. -/
+def StrongImplicature : BeliefState → Prop
+  | .disbelief => True
+  | .belief | .noOpinion => False
 
-/-- The classification is faithful: `disbelief` holds exactly when the
-secondary implicature K¬ψ does. -/
-theorem beliefState_disbelief_iff (e : EpistemicState W) (ψ : W → Prop)
-    [DecidablePred ψ] (h : ¬ knows e ψ) :
-    e.beliefState ψ = .disbelief ↔ hasSecondaryImplicature e ψ := by
-  simp only [EpistemicState.beliefState, if_neg h]
-  by_cases hs : hasSecondaryImplicature e ψ <;> simp [hs]
+instance : DecidablePred Competent
+  | .belief | .disbelief => isTrue trivial
+  | .noOpinion => isFalse id
 
-/-- Competence strengthening: `¬Bel_S(ψ) ∧ (Bel_S(ψ) ∨ Bel_S(¬ψ)) → Bel_S(¬ψ)`. -/
-theorem competence_strengthening {b : BeliefState}
-    (hweak : nonBelief b = true) (hcomp : competent b = true) :
-    strongImpl b = true := by
-  cases b <;> simp_all [nonBelief, competent, strongImpl]
+instance : DecidablePred WeakImplicature
+  | .belief => isFalse id
+  | .disbelief | .noOpinion => isTrue trivial
 
-/-- A weak implicature can hold without the strong one (incompetent speaker). -/
-theorem weak_without_strong :
-    ∃ b : BeliefState, nonBelief b = true ∧ strongImpl b = false :=
-  ⟨.noOpinion, by decide⟩
+instance : DecidablePred StrongImplicature
+  | .disbelief => isTrue trivial
+  | .belief | .noOpinion => isFalse id
 
-/-- `Bel_S(¬ψ) → ¬Bel_S(ψ)`. -/
-theorem strong_implies_weak {b : BeliefState} (h : strongImpl b = true) :
-    nonBelief b = true := by
-  cases b <;> simp_all [strongImpl, nonBelief]
+/-- The Standard Recipe: the strong implicature is exactly the weak implicature plus
+competence, `Bel_S(¬ψ) ↔ ¬Bel_S(ψ) ∧ (Bel_S(ψ) ∨ Bel_S(¬ψ))`. -/
+theorem strongImplicature_iff {b : BeliefState} :
+    b.StrongImplicature ↔ b.WeakImplicature ∧ b.Competent := by
+  cases b <;> decide
 
-/-- `Bel_S(¬ψ) → Bel_S(ψ) ∨ Bel_S(¬ψ)`. -/
-theorem strong_implies_competent {b : BeliefState} (h : strongImpl b = true) :
-    competent b = true := by
-  cases b <;> simp_all [strongImpl, competent]
+end BeliefState
 
-/-! ### Running the recipe
+namespace EpistemicState
 
-`processAlternative` applies the Standard Recipe to one alternative,
-gated by whether the hearer assumes competence. The three `outcome_*`
-theorems are [geurts-2010]'s outcome typology. -/
+variable (e : EpistemicState W) (ψ : W → Prop) [DecidablePred ψ]
 
-/-- Outcome of processing one alternative: the inferred belief state,
-whether the weak implicature holds, whether competence was assumed
-(and consistent), and whether the strong implicature was derived. -/
-structure ImplicatureProcessing where
-  /-- The belief state inferred -/
-  beliefState : BeliefState
-  /-- Whether weak implicature ¬Bel_S(ψ) holds -/
-  weakHolds : Bool
-  /-- Whether competence was assumed -/
-  competenceAssumed : Bool
-  /-- Whether strong implicature Bel_S(¬ψ) was derived -/
-  strongDerived : Bool
-  deriving Repr
+/-- Classify an epistemic state by its attitude toward `ψ`: `Kψ` is belief, `K¬ψ` disbelief,
+anything else no opinion. -/
+def beliefState : BeliefState :=
+  if e.knows ψ then .belief else if e.knows (fun w => ¬ ψ w) then .disbelief else .noOpinion
 
-/-- Run the Standard Recipe on one alternative under a competence
-assumption. -/
-def processAlternative (assumeCompetence : Bool) (b : BeliefState) :
-    ImplicatureProcessing :=
-  { beliefState := b
-  , weakHolds := nonBelief b
-  , competenceAssumed := assumeCompetence && competent b
-  , strongDerived := assumeCompetence && strongImpl b
-  }
+/-- Competence is knowing whether `ψ`. -/
+theorem competent_beliefState_iff :
+    (e.beliefState ψ).Competent ↔ e.knows ψ ∨ e.knows fun w => ¬ ψ w := by
+  unfold beliefState
+  split_ifs with h₁ h₂ <;> simp [BeliefState.Competent, *]
 
-/-- Outcome i (undecided): without the competence assumption, only the
-weak implicature arises. -/
-theorem outcome_i_undecided {b : BeliefState} (hne : b ≠ .belief) :
-    (processAlternative false b).weakHolds = true ∧
-    (processAlternative false b).strongDerived = false := by
-  cases b <;> simp_all [processAlternative, nonBelief]
+/-- The weak implicature is `¬Kψ`. -/
+theorem weakImplicature_beliefState_iff : (e.beliefState ψ).WeakImplicature ↔ ¬ e.knows ψ := by
+  unfold beliefState
+  split_ifs with h₁ h₂ <;> simp [BeliefState.WeakImplicature, h₁]
 
-/-- Outcome ii (strong): competence assumed and consistent — the strong
-implicature is derived. -/
-theorem outcome_ii_strong :
-    (processAlternative true .disbelief).weakHolds = true ∧
-    (processAlternative true .disbelief).competenceAssumed = true ∧
-    (processAlternative true .disbelief).strongDerived = true := by
-  decide
+/-- The strong implicature is `K¬ψ`; the `Kψ` branch is excluded by consistency. -/
+theorem strongImplicature_beliefState_iff :
+    (e.beliefState ψ).StrongImplicature ↔ e.knows fun w => ¬ ψ w := by
+  unfold beliefState
+  split_ifs with h₁ h₂
+  · exact iff_of_false id ((e.not_possible ψ).not.1 (not_not_intro (possible_of_knows h₁)))
+  · exact iff_of_true trivial h₂
+  · exact iff_of_false id h₂
 
-/-- Outcome iii (incompetent): the speaker has no opinion, so the
-competence assumption fails and only the weak implicature survives. -/
-theorem outcome_iii_incompetent :
-    (processAlternative true .noOpinion).weakHolds = true ∧
-    (processAlternative true .noOpinion).competenceAssumed = false ∧
-    (processAlternative true .noOpinion).strongDerived = false := by
-  decide
+end EpistemicState
 
 end NeoGricean

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -5,28 +5,21 @@ import Linglib.Logic.Modal.Defs
 /-!
 # Neo-Gricean pragmatics: epistemic states and the Standard Recipe
 
-The epistemic layer of Neo-Gricean implicature: a speaker's
-`EpistemicState` (the nonempty finite set of worlds compatible with
-what the speaker knows) with the operators `knows` (K) and `possible`
-(P), [sauerland-2004]'s consistency-gated derivation of secondary
-implicatures, and the three-way `BeliefState` classification over
-which [geurts-2010]'s Standard Recipe runs.
-
-[sauerland-2004] distinguishes **primary implicatures** ¬Kψ from
-**secondary implicatures** K¬ψ, a secondary arising only when K¬ψ is
-consistent with the assertion together with all primary implicatures.
-The epistemic modalization ¬Kψ goes back to [soames-1982] and
-[horn-1989]; the competence step Kψ ∨ K¬ψ strengthening primaries to
-secondaries is formalized by [sauerland-2004], [vanrooij-schulz-2004],
-and [spector-2006]; [geurts-2010] is the textbook presentation.
+This file defines a speaker's epistemic state as a nonempty finite set of worlds, the
+knowledge and possibility operators K and P over it, the consistency-gated derivation of
+secondary implicatures of [sauerland-2004], and the three-way belief-state classification
+over which the Standard Recipe of [geurts-2010] runs. Asserting `φ` yields the primary
+implicature `¬Kψ` for each stronger alternative `ψ`; the secondary implicature `K¬ψ` arises
+only when it is consistent with the assertion and all primary implicatures, and the Standard
+Recipe obtains it from `¬Kψ` under the competence assumption `Kψ ∨ K¬ψ`.
 
 ## Main definitions
 
 * `EpistemicState`: a nonempty finite set of worlds, with `SetLike` membership.
 * `EpistemicState.knows`, `EpistemicState.possible`: the K and P operators, `box`/`diamond`
   over the epistemic accessibility `EpistemicState.access`.
-* `SatisfiesPrimaries`, `SecondaryLicensed`: [sauerland-2004]'s commitment set after an
-  assertion and the consistency condition licensing a secondary implicature.
+* `SatisfiesPrimaries`, `SecondaryLicensed`: the commitment set after an assertion and the
+  consistency condition licensing a secondary implicature.
 * `BeliefState`, `EpistemicState.beliefState`: belief, disbelief, or no opinion about an
   alternative, with the Standard Recipe's predicates `BeliefState.Competent`,
   `BeliefState.WeakImplicature`, `BeliefState.StrongImplicature`.
@@ -34,15 +27,19 @@ and [spector-2006]; [geurts-2010] is the textbook presentation.
 ## Main results
 
 * `secondaryLicensed_iff`: licensing decomposes over the alternatives, so a blocked secondary
-  implicature is always blocked by a single primary.
+  implicature is always blocked by a single primary; the disjunction case (K¬(A∧B) licensed,
+  K¬A blocked) is `Studies/Sauerland2004.lean`.
 * `secondaryLicensed_of_asymStrongerOn`: a lone asymmetrically stronger alternative always
   licenses its secondary implicature.
 * `BeliefState.strongImplicature_iff`: the strong implicature is exactly the weak implicature
   plus competence.
 
-The flagship multi-alternative case (K¬(A∧B) licensed but K¬A blocked for *A or B*) is
-`Studies/Sauerland2004.lean`; the graded counterpart of competence is the RSA
-knowledgeability parameter in `Pragmatics/RSA/`.
+## References
+
+* [sauerland-2004] — primary vs secondary implicatures and the consistency condition
+* [geurts-2010] — the Standard Recipe; textbook presentation
+* [soames-1982], [horn-1989] — the epistemic modalization `¬Kψ`
+* [vanrooij-schulz-2004], [spector-2006] — the competence step `Kψ ∨ K¬ψ`
 -/
 
 namespace NeoGricean

--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -1,38 +1,35 @@
-import Mathlib.Data.Finset.Basic
-import Linglib.Semantics.Alternatives.AsymStronger
-import Linglib.Logic.Modal.Defs
+import Mathlib.Data.Set.Insert
+import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Neo-Gricean pragmatics: epistemic states and the Standard Recipe
 
-This file defines a speaker's epistemic state as a nonempty finite set of worlds, the
-knowledge and possibility operators K and P over it, the consistency-gated derivation of
-secondary implicatures of [sauerland-2004], and the three-way belief-state classification
-over which the Standard Recipe of [geurts-2010] runs. Asserting `φ` yields the primary
+This file defines [sauerland-2004]'s consistency-gated derivation of secondary implicatures
+and the three-way belief-state classification over which the Standard Recipe of
+[geurts-2010] runs. A speaker's epistemic state is a set of worlds `s : Set W` — the same
+object as the `ContextSet` of `Discourse/CommonGround.lean` — and a proposition is a `Set W`,
+so the speaker knows `φ` iff `s ⊆ φ`, knows `¬φ` iff `s ⊆ φᶜ`, and considers `φ` possible iff
+`(s ∩ φ).Nonempty`; consistency of the speaker is the hypothesis `s.Nonempty` (the
+`Filter.NeBot` convention), not part of a bundled type. Asserting `φ` yields the primary
 implicature `¬Kψ` for each stronger alternative `ψ`; the secondary implicature `K¬ψ` arises
 only when it is consistent with the assertion and all primary implicatures, and the Standard
 Recipe obtains it from `¬Kψ` under the competence assumption `Kψ ∨ K¬ψ`.
 
 ## Main definitions
 
-* `EpistemicState`: a nonempty finite set of worlds, with `SetLike` membership.
-* `EpistemicState.knows`, `EpistemicState.possible`: the K and P operators, `box`/`diamond`
-  over the epistemic accessibility `EpistemicState.access`.
 * `SatisfiesPrimaries`, `SecondaryLicensed`: the commitment set after an assertion and the
   consistency condition licensing a secondary implicature.
-* `BeliefState`, `EpistemicState.beliefState`: belief, disbelief, or no opinion about an
-  alternative, with the Standard Recipe's predicates `BeliefState.Competent`,
-  `BeliefState.WeakImplicature`, `BeliefState.StrongImplicature`.
+* `BeliefState`, `beliefState`: belief, disbelief, or no opinion about an alternative.
 
 ## Main results
 
 * `secondaryLicensed_iff`: licensing decomposes over the alternatives, so a blocked secondary
   implicature is always blocked by a single primary; the disjunction case (K¬(A∧B) licensed,
   K¬A blocked) is `Studies/Sauerland2004.lean`.
-* `secondaryLicensed_of_asymStrongerOn`: a lone asymmetrically stronger alternative always
-  licenses its secondary implicature.
-* `BeliefState.strongImplicature_iff`: the strong implicature is exactly the weak implicature
-  plus competence.
+* `secondaryLicensed_of_ssubset`: a lone asymmetrically stronger alternative always licenses
+  its secondary implicature.
+* `subset_compl_iff_not_subset`: the Standard Recipe — under competence, the strong
+  implicature `K¬ψ` is exactly the weak implicature `¬Kψ`.
 
 ## References
 
@@ -44,149 +41,74 @@ Recipe obtains it from `¬Kψ` under the competence assumption `Kψ ∨ K¬ψ`.
 
 namespace NeoGricean
 
-open ModalLogic (box diamond IsSerial)
-
-variable {W : Type*}
-
-/-! ### Epistemic states and the K/P operators -/
-
-/-- A speaker's epistemic state: the nonempty finite set of worlds compatible with what the
-speaker knows. Nonemptiness makes K serial (`EpistemicState.possible_of_knows`). -/
-structure EpistemicState (W : Type*) where
-  /-- The worlds compatible with the speaker's knowledge. -/
-  carrier : Finset W
-  nonempty : carrier.Nonempty
-
-namespace EpistemicState
-
-instance : SetLike (EpistemicState W) W where
-  coe e := e.carrier
-  coe_injective e₁ e₂ h := by cases e₁; cases e₂; congr; exact Finset.coe_injective h
-
-@[simp] theorem mem_carrier {e : EpistemicState W} {w : W} : w ∈ e.carrier ↔ w ∈ e := Iff.rfl
-
-@[simp] theorem mem_mk {s : Finset W} {h : s.Nonempty} {w : W} : w ∈ mk s h ↔ w ∈ s := Iff.rfl
-
-@[ext] theorem ext {e₁ e₂ : EpistemicState W} (h : ∀ w, w ∈ e₁ ↔ w ∈ e₂) : e₁ = e₂ :=
-  SetLike.ext h
-
-/-- The K operator: the speaker knows `φ` iff `φ` holds throughout the epistemic state. -/
-def knows (e : EpistemicState W) (φ : W → Prop) : Prop := ∀ w ∈ e, φ w
-
-/-- The P operator: the speaker considers `φ` possible iff some world in the epistemic state
-satisfies `φ`. -/
-def possible (e : EpistemicState W) (φ : W → Prop) : Prop := ∃ w ∈ e, φ w
-
-instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] : Decidable (e.knows φ) :=
-  inferInstanceAs (Decidable (∀ w ∈ e.carrier, φ w))
-
-instance (e : EpistemicState W) (φ : W → Prop) [DecidablePred φ] : Decidable (e.possible φ) :=
-  inferInstanceAs (Decidable (∃ w ∈ e.carrier, φ w))
-
-/-! ### K and P as restricted modality
-
-`knows` and `possible` are `box` and `diamond` over the world-independent epistemic
-accessibility `access`, serial because the state is nonempty; the duality and consistency
-lemmas below are the corresponding instances of `ModalLogic.not_box`, `ModalLogic.not_diamond`,
-and `ModalLogic.box_D`. -/
-
-/-- Epistemic accessibility: from any world, the speaker's live possibilities. -/
-def access (e : EpistemicState W) : W → W → Prop := fun _ w => w ∈ e
-
-instance (e : EpistemicState W) : IsSerial e.access := ⟨fun _ => e.nonempty⟩
-
-@[simp] theorem box_access (e : EpistemicState W) (φ : W → Prop) (w : W) :
-    box e.access φ w ↔ e.knows φ := Iff.rfl
-
-@[simp] theorem diamond_access (e : EpistemicState W) (φ : W → Prop) (w : W) :
-    diamond e.access φ w ↔ e.possible φ := Iff.rfl
-
-/-- K/P duality: `¬Kφ ↔ P¬φ`. -/
-@[simp] theorem not_knows (e : EpistemicState W) (φ : W → Prop) :
-    ¬ e.knows φ ↔ e.possible fun w => ¬ φ w :=
-  e.nonempty.elim fun w _ => ModalLogic.not_box e.access φ w
-
-/-- K/P duality: `¬Pφ ↔ K¬φ`. -/
-@[simp] theorem not_possible (e : EpistemicState W) (φ : W → Prop) :
-    ¬ e.possible φ ↔ e.knows fun w => ¬ φ w :=
-  e.nonempty.elim fun w _ => ModalLogic.not_diamond e.access φ w
-
-/-- Knowledge is consistent, `Kφ → Pφ` (the D axiom over a nonempty state). -/
-theorem possible_of_knows {e : EpistemicState W} {φ : W → Prop} (h : e.knows φ) :
-    e.possible φ :=
-  e.nonempty.elim fun w _ => ModalLogic.box_D (R := e.access) (w := w) h
-
-end EpistemicState
+variable {W : Type*} {s φ ψ χ : Set W} {alts : List (Set W)}
 
 /-! ### The Sauerland derivation
 
 Asserting `φ` against scalar alternatives `alts` commits the speaker to `Kφ` plus, for each
 alternative, the primary implicature `¬Kψ` ([sauerland-2004] (42), verified p. 383). A
 secondary implicature `K¬ψ` arises exactly when it is *consistent* with that commitment set
-([sauerland-2004] (43)): when some epistemic state realizes the commitments together with
-`K¬ψ`. -/
+([sauerland-2004] (43)): when some nonempty epistemic state realizes the commitments together
+with `K¬ψ`. -/
 
 /-- The speaker commitment after asserting `φ` against `alts`: `Kφ` and the primary implicature
 `¬Kψ` for each alternative. Per [sauerland-2004], the caller supplies only the asymmetrically
-stronger alternatives (e.g. via `Entailment.asymStrongerOn`); the definition does not enforce
-the filter. -/
-def SatisfiesPrimaries (e : EpistemicState W) (φ : W → Prop) (alts : List (W → Prop)) : Prop :=
-  e.knows φ ∧ ∀ ψ ∈ alts, ¬ e.knows ψ
+stronger alternatives (`ψ ⊂ φ`); the definition does not enforce the filter. -/
+def SatisfiesPrimaries (s φ : Set W) (alts : List (Set W)) : Prop :=
+  s ⊆ φ ∧ ∀ ψ ∈ alts, ¬ s ⊆ ψ
 
 /-- [sauerland-2004]'s consistency condition: the secondary implicature `K¬ψ` is licensed iff
-some epistemic state realizes the assertion, all primary implicatures, and `K¬ψ` jointly. -/
-def SecondaryLicensed (φ : W → Prop) (alts : List (W → Prop)) (ψ : W → Prop) : Prop :=
-  ∃ e : EpistemicState W, SatisfiesPrimaries e φ alts ∧ e.knows fun w => ¬ ψ w
+some nonempty epistemic state realizes the assertion, all primary implicatures, and `K¬ψ`
+jointly. -/
+def SecondaryLicensed (φ : Set W) (alts : List (Set W)) (ψ : Set W) : Prop :=
+  ∃ s : Set W, s.Nonempty ∧ SatisfiesPrimaries s φ alts ∧ s ⊆ ψᶜ
 
 /-- Licensing decomposes over the alternatives: `K¬ψ` is consistent with the commitments iff
-the strengthened meaning `φ ∧ ¬ψ` is realizable and, for each alternative `χ`, realizable at
-a `¬χ`-world. A blocked secondary implicature is thus always blocked by a single primary. -/
-theorem secondaryLicensed_iff {φ ψ : W → Prop} {alts : List (W → Prop)} :
-    SecondaryLicensed φ alts ψ ↔
-      (∃ w, φ w ∧ ¬ ψ w) ∧ ∀ χ ∈ alts, ∃ w, φ w ∧ ¬ ψ w ∧ ¬ χ w := by
+the strengthened meaning `φ \ ψ` is realizable and, for each alternative `χ`, realizable
+outside `ψ ∪ χ`. A blocked secondary implicature is thus always blocked by a single primary. -/
+theorem secondaryLicensed_iff :
+    SecondaryLicensed φ alts ψ ↔ (φ \ ψ).Nonempty ∧ ∀ χ ∈ alts, (φ \ (ψ ∪ χ)).Nonempty := by
   constructor
-  · rintro ⟨e, ⟨hφ, hprim⟩, hψ⟩
-    refine ⟨e.nonempty.imp fun w hw => ⟨hφ w hw, hψ w hw⟩, fun χ hχ => ?_⟩
-    obtain ⟨w, hw, hχ⟩ := (e.not_knows χ).1 (hprim χ hχ)
-    exact ⟨w, hφ w hw, hψ w hw, hχ⟩
-  · classical
-    rintro ⟨⟨w₀, hφ₀, hψ₀⟩, h⟩
+  · rintro ⟨s, hs, ⟨hφ, hprim⟩, hψ⟩
+    refine ⟨hs.mono fun w hw => ⟨hφ hw, hψ hw⟩, fun χ hχ => ?_⟩
+    obtain ⟨w, hw, hχ⟩ := Set.not_subset.1 (hprim χ hχ)
+    exact ⟨w, hφ hw, fun h => h.elim (hψ hw) hχ⟩
+  · rintro ⟨⟨w₀, hw₀⟩, h⟩
     induction alts with
     | nil =>
-      refine ⟨⟨{w₀}, Finset.singleton_nonempty w₀⟩, ⟨?_, by simp⟩, ?_⟩ <;>
-        simpa [EpistemicState.knows]
+      exact ⟨{w₀}, Set.singleton_nonempty w₀, ⟨Set.singleton_subset_iff.2 hw₀.1, by simp⟩,
+        Set.singleton_subset_iff.2 hw₀.2⟩
     | cons χ alts ih =>
-      obtain ⟨e, ⟨hφ, hprim⟩, hψ⟩ := ih fun χ' hχ' => h χ' (List.mem_cons_of_mem χ hχ')
-      obtain ⟨w, hφw, hψw, hχw⟩ := h χ List.mem_cons_self
-      refine ⟨⟨insert w e.carrier, Finset.insert_nonempty w _⟩,
-        ⟨(Finset.forall_mem_insert ..).2 ⟨hφw, hφ⟩, List.forall_mem_cons.2 ⟨?_, ?_⟩⟩,
-        (Finset.forall_mem_insert ..).2 ⟨hψw, hψ⟩⟩
-      · exact fun hk => hχw (hk w (Finset.mem_insert_self w _))
-      · exact fun χ' hχ' hk => hprim χ' hχ' fun v hv => hk v (Finset.mem_insert_of_mem hv)
+      obtain ⟨s, hs, ⟨hφ, hprim⟩, hψ⟩ := ih fun χ' hχ' => h χ' (List.mem_cons_of_mem χ hχ')
+      obtain ⟨w, hφw, hw⟩ := h χ List.mem_cons_self
+      obtain ⟨hψw, hχw⟩ := not_or.1 hw
+      refine ⟨insert w s, Set.insert_nonempty w s,
+        ⟨Set.insert_subset_iff.2 ⟨hφw, hφ⟩, List.forall_mem_cons.2 ⟨?_, ?_⟩⟩,
+        Set.insert_subset_iff.2 ⟨hψw, hψ⟩⟩
+      · exact fun hk => hχw (hk (Set.mem_insert w s))
+      · exact fun χ' hχ' hk => hprim χ' hχ' ((Set.subset_insert w s).trans hk)
 
-/-- For a lone alternative `χ`, `K¬ψ` is licensed iff `φ ∧ ¬ψ ∧ ¬χ` is realizable. -/
-theorem secondaryLicensed_singleton {φ ψ χ : W → Prop} :
-    SecondaryLicensed φ [χ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w ∧ ¬ χ w := by
+/-- For a lone alternative `χ`, `K¬ψ` is licensed iff `φ` is realizable outside `ψ ∪ χ`. -/
+theorem secondaryLicensed_singleton :
+    SecondaryLicensed φ [χ] ψ ↔ (φ \ (ψ ∪ χ)).Nonempty := by
   rw [secondaryLicensed_iff, List.forall_mem_singleton]
-  exact and_iff_right_of_imp fun ⟨w, h⟩ => ⟨w, h.1, h.2.1⟩
+  exact and_iff_right_of_imp fun h => h.mono (Set.sdiff_subset_sdiff_right Set.subset_union_left)
 
-/-- Against its own alternative alone, `K¬ψ` is licensed iff the strengthened meaning
-`φ ∧ ¬ψ` is consistent. -/
-theorem secondaryLicensed_singleton_self {φ ψ : W → Prop} :
-    SecondaryLicensed φ [ψ] ψ ↔ ∃ w, φ w ∧ ¬ ψ w := by
-  simp only [secondaryLicensed_singleton, and_self]
+/-- Against its own alternative alone, `K¬ψ` is licensed iff the strengthened meaning `φ \ ψ`
+is realizable. -/
+theorem secondaryLicensed_singleton_self : SecondaryLicensed φ [ψ] ψ ↔ (φ \ ψ).Nonempty := by
+  simp [secondaryLicensed_singleton]
 
 /-- A lone asymmetrically stronger alternative always yields its secondary implicature: the
 *some ⇝ not all* case. -/
-theorem secondaryLicensed_of_asymStrongerOn {s : Finset W} {φ ψ : W → Prop} [DecidablePred φ]
-    [DecidablePred ψ] (h : Entailment.asymStrongerOn s ψ φ) : SecondaryLicensed φ [ψ] ψ :=
-  secondaryLicensed_singleton_self.2 <| h.2.imp fun _ hw => hw.2
+theorem secondaryLicensed_of_ssubset (h : ψ ⊂ φ) : SecondaryLicensed φ [ψ] ψ :=
+  secondaryLicensed_singleton_self.2 (Set.sdiff_nonempty.2 h.2)
 
 /-! ### The three-way belief-state classification
 
-`BeliefState` is the decidable classification of a speaker's attitude toward one alternative
-`ψ`; `EpistemicState.beliefState` grounds it in the K operator, so the Standard Recipe's
-predicates are projections of K/P reasoning (`competent_beliefState_iff` and its siblings). -/
+`BeliefState` is the knows-whether trichotomy for one alternative `ψ`, and `beliefState`
+grounds it in the epistemic state. The Standard Recipe is `subset_compl_iff_not_subset`: for
+a consistent, competent speaker, knowing `¬ψ` is exactly not knowing `ψ`. -/
 
 /-- A speaker's attitude toward an alternative `ψ`: belief `Bel_S(ψ)`, disbelief `Bel_S(¬ψ)`,
 or no opinion. -/
@@ -196,72 +118,39 @@ inductive BeliefState where
   | noOpinion
   deriving DecidableEq, Repr
 
-namespace BeliefState
+/-- A consistent speaker cannot both know `ψ` and know `¬ψ`. -/
+theorem not_subset_compl_of_subset (hs : s.Nonempty) (h : s ⊆ ψ) : ¬ s ⊆ ψᶜ :=
+  fun h' => hs.elim fun _ hw => h' hw (h hw)
 
-/-- Competence: the speaker knows whether `ψ`, `Bel_S(ψ) ∨ Bel_S(¬ψ)`. -/
-def Competent : BeliefState → Prop
-  | .belief | .disbelief => True
-  | .noOpinion => False
+/-- The Standard Recipe: for a consistent speaker competent about `ψ` (`Kψ ∨ K¬ψ`), the strong
+implicature `K¬ψ` is exactly the weak implicature `¬Kψ`. -/
+theorem subset_compl_iff_not_subset (hs : s.Nonempty) (hc : s ⊆ ψ ∨ s ⊆ ψᶜ) :
+    s ⊆ ψᶜ ↔ ¬ s ⊆ ψ :=
+  ⟨fun h h' => not_subset_compl_of_subset hs h' h, hc.resolve_left⟩
 
-/-- The weak (primary) implicature `¬Bel_S(ψ)`. -/
-def WeakImplicature : BeliefState → Prop
-  | .belief => False
-  | .disbelief | .noOpinion => True
-
-/-- The strong (secondary) implicature `Bel_S(¬ψ)`. -/
-def StrongImplicature : BeliefState → Prop
-  | .disbelief => True
-  | .belief | .noOpinion => False
-
-instance : DecidablePred Competent
-  | .belief | .disbelief => isTrue trivial
-  | .noOpinion => isFalse id
-
-instance : DecidablePred WeakImplicature
-  | .belief => isFalse id
-  | .disbelief | .noOpinion => isTrue trivial
-
-instance : DecidablePred StrongImplicature
-  | .disbelief => isTrue trivial
-  | .belief | .noOpinion => isFalse id
-
-/-- The Standard Recipe: the strong implicature is exactly the weak implicature plus
-competence, `Bel_S(¬ψ) ↔ ¬Bel_S(ψ) ∧ (Bel_S(ψ) ∨ Bel_S(¬ψ))`. -/
-theorem strongImplicature_iff {b : BeliefState} :
-    b.StrongImplicature ↔ b.WeakImplicature ∧ b.Competent := by
-  cases b <;> decide
-
-end BeliefState
-
-namespace EpistemicState
-
-variable (e : EpistemicState W) (ψ : W → Prop) [DecidablePred ψ]
+variable [Decidable (s ⊆ ψ)] [Decidable (s ⊆ ψᶜ)]
 
 /-- Classify an epistemic state by its attitude toward `ψ`: `Kψ` is belief, `K¬ψ` disbelief,
 anything else no opinion. -/
-def beliefState : BeliefState :=
-  if e.knows ψ then .belief else if e.knows (fun w => ¬ ψ w) then .disbelief else .noOpinion
+def beliefState (s ψ : Set W) [Decidable (s ⊆ ψ)] [Decidable (s ⊆ ψᶜ)] : BeliefState :=
+  if s ⊆ ψ then .belief else if s ⊆ ψᶜ then .disbelief else .noOpinion
 
-/-- Competence is knowing whether `ψ`. -/
-theorem competent_beliefState_iff :
-    (e.beliefState ψ).Competent ↔ e.knows ψ ∨ e.knows fun w => ¬ ψ w := by
+@[simp] theorem beliefState_eq_belief_iff : beliefState s ψ = .belief ↔ s ⊆ ψ := by
   unfold beliefState
-  split_ifs with h₁ h₂ <;> simp [BeliefState.Competent, *]
+  split_ifs <;> simp [*]
 
-/-- The weak implicature is `¬Kψ`. -/
-theorem weakImplicature_beliefState_iff : (e.beliefState ψ).WeakImplicature ↔ ¬ e.knows ψ := by
-  unfold beliefState
-  split_ifs with h₁ h₂ <;> simp [BeliefState.WeakImplicature, h₁]
-
-/-- The strong implicature is `K¬ψ`; the `Kψ` branch is excluded by consistency. -/
-theorem strongImplicature_beliefState_iff :
-    (e.beliefState ψ).StrongImplicature ↔ e.knows fun w => ¬ ψ w := by
+/-- Disbelief is `K¬ψ`; the `Kψ` branch is excluded by consistency. -/
+theorem beliefState_eq_disbelief_iff (hs : s.Nonempty) :
+    beliefState s ψ = .disbelief ↔ s ⊆ ψᶜ := by
   unfold beliefState
   split_ifs with h₁ h₂
-  · exact iff_of_false id ((e.not_possible ψ).not.1 (not_not_intro (possible_of_knows h₁)))
-  · exact iff_of_true trivial h₂
-  · exact iff_of_false id h₂
+  · exact iff_of_false (by decide) (not_subset_compl_of_subset hs h₁)
+  · exact iff_of_true rfl h₂
+  · exact iff_of_false (by decide) h₂
 
-end EpistemicState
+@[simp] theorem beliefState_eq_noOpinion_iff :
+    beliefState s ψ = .noOpinion ↔ ¬ s ⊆ ψ ∧ ¬ s ⊆ ψᶜ := by
+  unfold beliefState
+  split_ifs <;> simp [*]
 
 end NeoGricean

--- a/Linglib/Studies/BaleEtAl2025.lean
+++ b/Linglib/Studies/BaleEtAl2025.lean
@@ -1,4 +1,5 @@
 import Linglib.Pragmatics.NeoGricean.Basic
+import Linglib.Studies.GoodmanStuhlmuller2013
 
 /-!
 # [bale-etal-2025] — Competence by Default
@@ -222,52 +223,74 @@ theorem only_competenceByDefault_predicts_interaction :
     = [.competenceByDefault] := by decide
 
 
--- ============================================================================
--- Part II: NeoGricean Competence Bridge
--- ============================================================================
+/-! ### Speaker knowledge as observation access
 
-/-! Connects the experimental findings to the NeoGricean competence
-formalization in `Pragmatics.NeoGricean.Basic`. -/
+The cover story is [goodman-stuhlmuller-2013]'s access paradigm: the
+speaker inspects some of the three sections of the box and reports what
+she saw, so her epistemic state is the set of worlds compatible with the
+observation (`GoodmanStuhlmuller2013.obsCompatible`). Competence about
+the stronger alternative *all* is then derived, not stipulated: the
+full-knowledge state settles *whether all* and the partial-knowledge
+state does not, while both support the *some* assertion. -/
 
-open NeoGricean
+open GoodmanStuhlmuller2013 NeoGricean
 
-/-- Map speaker knowledge to NeoGricean belief state about the stronger
-    alternative ψ. FK speaker knows ¬ψ; PK speaker has no opinion. -/
-def toBeliefState : SpeakerKnowledge → BeliefState
-  | .fullKnowledge    => .disbelief
-  | .partialKnowledge => .noOpinion
+/-- The stronger alternative ψ: *all of the marbles are red*. -/
+def all : Set WorldState := {w | qMeaning .all w}
 
-/-- The default belief state: listeners assume speakers are competent. -/
-def defaultBeliefState : BeliefState := .disbelief
+/-- The speaker's epistemic state: the worlds compatible with inspecting
+all three sections and seeing two red marbles (FK), or inspecting two
+sections and seeing both red (PK). -/
+def speakerState : SpeakerKnowledge → Set WorldState
+  | .fullKnowledge    => {w | obsCompatible 3 2 w}
+  | .partialKnowledge => {w | obsCompatible 2 2 w}
 
-/-- Context integration: no load → yes; load → no. -/
-def canIntegrateContext : LoadCondition → Bool
-  | .noLoad => true
-  | .load   => false
+theorem speakerState_nonempty (k : SpeakerKnowledge) : (speakerState k).Nonempty := by
+  cases k <;> exact ⟨.s2, by simp [speakerState]; decide⟩
 
-/-- The effective belief state after (possibly failed) context integration. -/
-def effectiveBeliefState (k : SpeakerKnowledge) (l : LoadCondition) : BeliefState :=
-  if canIntegrateContext l then
-    toBeliefState k
-  else
-    defaultBeliefState
+/-- Competence about *all*, [sauerland-2004]'s `K all ∨ K¬all`: the speaker's state settles
+*whether all*. -/
+def Competent (k : SpeakerKnowledge) : Prop :=
+  speakerState k ⊆ all ∨ speakerState k ⊆ allᶜ
 
-theorem noLoad_fk_correct :
-    effectiveBeliefState .fullKnowledge .noLoad = .disbelief := rfl
-theorem noLoad_pk_correct :
-    effectiveBeliefState .partialKnowledge .noLoad = .noOpinion := rfl
-theorem load_fk_default :
-    effectiveBeliefState .fullKnowledge .load = .disbelief := rfl
-theorem load_pk_defaults_to_competent :
-    effectiveBeliefState .partialKnowledge .load = .disbelief := rfl
+/-- Neither speaker knows *all*: the weak implicature `¬K all` holds in
+both knowledge conditions. -/
+theorem not_speakerState_subset_all (k : SpeakerKnowledge) : ¬ speakerState k ⊆ all := by
+  cases k <;> simp only [speakerState, all, Set.ofPred_subset_ofPred] <;> decide
 
-/-- The crossover prediction: load flips PK from weak-only (10%) to the strong SI
-    (23.3%, the default competence) but leaves FK's strong SI in place. -/
-theorem crossover_prediction :
-    effectiveBeliefState .partialKnowledge .noLoad ≠ .disbelief ∧
-      effectiveBeliefState .partialKnowledge .load = .disbelief ∧
-      effectiveBeliefState .fullKnowledge .noLoad = .disbelief ∧
-      effectiveBeliefState .fullKnowledge .load = .disbelief := by
+/-- The full-knowledge speaker is competent: she knows `¬all`. -/
+theorem fk_competent : Competent .fullKnowledge :=
+  Or.inr <| by simp only [speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
+
+/-- The partial-knowledge speaker is not competent about *all*. -/
+theorem pk_not_competent : ¬ Competent .partialKnowledge := by
+  simp only [Competent, speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]
   decide
+
+/-- The Standard Recipe for the full-knowledge speaker: the weak
+implicature plus competence yields the strong SI `K¬all`. -/
+theorem fk_strong : speakerState .fullKnowledge ⊆ allᶜ :=
+  (subset_compl_iff_not_subset (speakerState_nonempty _) fk_competent).2
+    (not_speakerState_subset_all _)
+
+/-- The partial-knowledge speaker is ignorant: neither `K all` nor `K¬all`. -/
+theorem pk_ignorant : ¬ speakerState .partialKnowledge ⊆ allᶜ := by
+  simp only [speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
+
+/-! ### Competence by default -/
+
+/-- The competence-by-default hearer assumes the speaker is competent
+unless context can be integrated (no load) and shows otherwise. -/
+def AssumesCompetent (k : SpeakerKnowledge) : LoadCondition → Prop
+  | .load   => True
+  | .noLoad => Competent k
+
+/-- The crossover prediction: load flips the partial-knowledge speaker from
+weak-only (10%) to the strong SI (23.3%) but leaves the full-knowledge
+speaker's strong SI (65.6%, 56.7%) in place. -/
+theorem crossover_prediction :
+    ¬ AssumesCompetent .partialKnowledge .noLoad ∧ AssumesCompetent .partialKnowledge .load ∧
+      AssumesCompetent .fullKnowledge .noLoad ∧ AssumesCompetent .fullKnowledge .load :=
+  ⟨pk_not_competent, trivial, fk_competent, trivial⟩
 
 end BaleEtAl2025

--- a/Linglib/Studies/BaleEtAl2025.lean
+++ b/Linglib/Studies/BaleEtAl2025.lean
@@ -237,18 +237,6 @@ def toBeliefState : SpeakerKnowledge → BeliefState
   | .fullKnowledge    => .disbelief
   | .partialKnowledge => .noOpinion
 
-theorem fk_competent : (toBeliefState .fullKnowledge).Competent := trivial
-theorem pk_not_competent : ¬ (toBeliefState .partialKnowledge).Competent := id
-
-/-- FK speaker: the strong SI is derived. -/
-theorem fk_yields_strong : (toBeliefState .fullKnowledge).StrongImplicature := trivial
-
-/-- PK speaker (correctly identified): weak-only SI. -/
-theorem pk_yields_weak_only :
-    (toBeliefState .partialKnowledge).WeakImplicature ∧
-      ¬ (toBeliefState .partialKnowledge).StrongImplicature :=
-  ⟨trivial, id⟩
-
 /-- The default belief state: listeners assume speakers are competent. -/
 def defaultBeliefState : BeliefState := .disbelief
 
@@ -273,21 +261,13 @@ theorem load_fk_default :
 theorem load_pk_defaults_to_competent :
     effectiveBeliefState .partialKnowledge .load = .disbelief := rfl
 
-/-- Under load + PK, the default competence yields a strong SI (10% → 23.3%). -/
-theorem load_pk_yields_strong :
-    (effectiveBeliefState .partialKnowledge .load).StrongImplicature := by decide
-
-/-- Under no-load + PK, correct context integration yields weak-only (10%). -/
-theorem noLoad_pk_yields_weak :
-    ¬ (effectiveBeliefState .partialKnowledge .noLoad).StrongImplicature := by decide
-
-/-- The crossover prediction: load flips PK from weak to strong,
-    but leaves FK unchanged. -/
+/-- The crossover prediction: load flips PK from weak-only (10%) to the strong SI
+    (23.3%, the default competence) but leaves FK's strong SI in place. -/
 theorem crossover_prediction :
-    ¬ (effectiveBeliefState .partialKnowledge .noLoad).StrongImplicature ∧
-      (effectiveBeliefState .partialKnowledge .load).StrongImplicature ∧
-      (effectiveBeliefState .fullKnowledge .noLoad).StrongImplicature ∧
-      (effectiveBeliefState .fullKnowledge .load).StrongImplicature := by
+    effectiveBeliefState .partialKnowledge .noLoad ≠ .disbelief ∧
+      effectiveBeliefState .partialKnowledge .load = .disbelief ∧
+      effectiveBeliefState .fullKnowledge .noLoad = .disbelief ∧
+      effectiveBeliefState .fullKnowledge .load = .disbelief := by
   decide
 
 end BaleEtAl2025

--- a/Linglib/Studies/BaleEtAl2025.lean
+++ b/Linglib/Studies/BaleEtAl2025.lean
@@ -237,20 +237,17 @@ def toBeliefState : SpeakerKnowledge → BeliefState
   | .fullKnowledge    => .disbelief
   | .partialKnowledge => .noOpinion
 
-theorem fk_competent : competent (toBeliefState .fullKnowledge) = true := rfl
-theorem pk_not_competent : competent (toBeliefState .partialKnowledge) = false := rfl
+theorem fk_competent : (toBeliefState .fullKnowledge).Competent := trivial
+theorem pk_not_competent : ¬ (toBeliefState .partialKnowledge).Competent := id
 
-/-- FK speaker: `processAlternative` yields a strong SI. -/
-theorem fk_yields_strong :
-    let p := processAlternative true (toBeliefState .fullKnowledge)
-    p.weakHolds = true ∧ p.competenceAssumed = true ∧ p.strongDerived = true := by
-  decide
+/-- FK speaker: the strong SI is derived. -/
+theorem fk_yields_strong : (toBeliefState .fullKnowledge).StrongImplicature := trivial
 
 /-- PK speaker (correctly identified): weak-only SI. -/
 theorem pk_yields_weak_only :
-    let p := processAlternative true (toBeliefState .partialKnowledge)
-    p.weakHolds = true ∧ p.competenceAssumed = false ∧ p.strongDerived = false := by
-  decide
+    (toBeliefState .partialKnowledge).WeakImplicature ∧
+      ¬ (toBeliefState .partialKnowledge).StrongImplicature :=
+  ⟨trivial, id⟩
 
 /-- The default belief state: listeners assume speakers are competent. -/
 def defaultBeliefState : BeliefState := .disbelief
@@ -278,25 +275,19 @@ theorem load_pk_defaults_to_competent :
 
 /-- Under load + PK, the default competence yields a strong SI (10% → 23.3%). -/
 theorem load_pk_yields_strong :
-    let b := effectiveBeliefState .partialKnowledge .load
-    let p := processAlternative true b
-    p.strongDerived = true := by decide
+    (effectiveBeliefState .partialKnowledge .load).StrongImplicature := by decide
 
 /-- Under no-load + PK, correct context integration yields weak-only (10%). -/
 theorem noLoad_pk_yields_weak :
-    let b := effectiveBeliefState .partialKnowledge .noLoad
-    let p := processAlternative true b
-    p.strongDerived = false := by decide
+    ¬ (effectiveBeliefState .partialKnowledge .noLoad).StrongImplicature := by decide
 
 /-- The crossover prediction: load flips PK from weak to strong,
     but leaves FK unchanged. -/
 theorem crossover_prediction :
-    let pk_noLoad := processAlternative true (effectiveBeliefState .partialKnowledge .noLoad)
-    let pk_load   := processAlternative true (effectiveBeliefState .partialKnowledge .load)
-    let fk_noLoad := processAlternative true (effectiveBeliefState .fullKnowledge .noLoad)
-    let fk_load   := processAlternative true (effectiveBeliefState .fullKnowledge .load)
-    pk_noLoad.strongDerived = false ∧ pk_load.strongDerived = true ∧
-    fk_noLoad.strongDerived = true ∧ fk_load.strongDerived = true := by
+    ¬ (effectiveBeliefState .partialKnowledge .noLoad).StrongImplicature ∧
+      (effectiveBeliefState .partialKnowledge .load).StrongImplicature ∧
+      (effectiveBeliefState .fullKnowledge .noLoad).StrongImplicature ∧
+      (effectiveBeliefState .fullKnowledge .load).StrongImplicature := by
   decide
 
 end BaleEtAl2025

--- a/Linglib/Studies/BaleEtAl2025.lean
+++ b/Linglib/Studies/BaleEtAl2025.lean
@@ -2,245 +2,64 @@ import Linglib.Pragmatics.NeoGricean.Basic
 import Linglib.Studies.GoodmanStuhlmuller2013
 
 /-!
-# [bale-etal-2025] — Competence by Default
+# Bale, Noguchi, Rolland & Barner (2025): competence by default
 
-Bale, A. C., Noguchi, H., Rolland, M. & Barner, D. (2025). Competence by
-default: Do listeners assume that speakers are knowledgeable when computing
-conversational inferences? *Journal of Semantics* 42(1–2): 39–55.
+[bale-etal-2025] test whether listeners assume by default that a speaker is competent about
+unsaid alternatives — [geurts-2010]'s competence-by-default hypothesis — against contextual
+licensing, on which competence must be contextually established ([soames-1982],
+[horn-1989]). Farmer Brown looks into two or three of three boxes and says *Some of the boxes
+have red cubes* (4); the listener generates the alternative *all* (5), the weak implicature
+`¬K all` (6), and, if competence (7) `K all ∨ K¬all` is assumed, the strong implicature
+`K¬all` (8). Half the participants are under cognitive load (a dot-array memory task). If
+competence is a default that contextual integration must cancel, load should *raise* the
+strong-implicature ("No") rate when the speaker is ignorant, which it does (10% → 23.3%,
+P = .02), while the knowledgeable-speaker rate shows only the generalized load reduction of
+earlier studies (65.6% → 56.7%, P = .22; Knowledge × Load interaction β = 2.62, χ²(1) = 11.3,
+P < .001).
 
-## Core Contribution
+## Main definitions
 
-Tests whether the competence assumption in scalar implicature derivation
-(step 5 of [soames-1982] / [horn-1989] / [sauerland-2004]) is a cognitive default
-or must be contextually licensed. The 5-step derivation:
+* `speakerState`: Farmer Brown's epistemic state as a [goodman-stuhlmuller-2013] observation
+  state — all three boxes seen, two with red cubes (full knowledge), or two boxes seen, both
+  with red cubes (partial knowledge).
+* `Competent`: (7), derived from `speakerState`.
+* `AssumesCompetent`, `ContextuallyLicensed`: the two hearer models — competence as a default
+  cancelled only by contextual integration, which load blocks, versus competence only when
+  the context establishes it.
 
-1. Speaker said φ (e.g., "some of the marbles are red")
-2. There exists a stronger alternative ψ (e.g., "all of the marbles are red")
-3. Speaker didn't say ψ (Quantity)
-4. Therefore ¬Bel_S(ψ) — weak implicature
-5. With competence (Bel_S(ψ) ∨ Bel_S(¬ψ)), derive Bel_S(¬ψ) — strong SI
+## Main results
 
-Step 5 depends on the **competence assumption**: the listener assumes the
-speaker knows whether ψ. Three hypotheses about when this is applied:
-
-- **Competence-by-default**: competence is assumed by default;
-  cancellation requires effortful integration of contextual evidence
-- **SSI-by-default**: the entire SSI is a default; load
-  disrupts SI computation itself
-- **Contextual licensing**:
-  competence must be contextually justified; it is not a default
-
-## Experimental Design
-
-Dual-task paradigm with 2 × 2 design:
-- **Between-subjects**: cognitive load (load vs. no load), n = 30 per group
-- **Within-subjects**: speaker knowledge (full knowledge = FK vs. partial
-  knowledge = PK)
-- **Trials**: FK+All (control), FK+Some, PK+Some
-- **Response**: 3-way forced choice ("Yes" / "No" / "I don't know")
-- **Key DV**: proportion of "No" responses on *some* trials (= SSI computed)
-
-## Key Finding
-
-GLMM reveals a significant **Knowledge × Load interaction** (β = 2.62,
-SE = 0.86, χ²(1) = 11.3, P < .001): load increases SSI rate in the PK
-(ignorant) condition (10% → 23.3%) while non-significantly decreasing it
-in the FK (competent) condition (65.6% → 56.7%). This crossover supports
-competence-by-default: load impairs effortful cancellation of the default
-competence assumption.
+* `fk_competent`, `pk_not_competent`: competence is derived from the observation states.
+* `fk_strong`: the Standard Recipe runs (6) and (7) to (8) for the knowledgeable speaker.
+* `agree_of_fullKnowledge_or_noLoad`, `diverge_pk_load`: the hearer models agree except for
+  the ignorant speaker under load, where only competence by default predicts the strong
+  implicature — the observed rise.
 -/
 
 namespace BaleEtAl2025
 
-/-- Total participants (N = 60, n = 30 per load group). -/
-def nTotal : Nat := 60
+open GoodmanStuhlmuller2013 NeoGricean
 
-
-/-! ## Experimental Conditions -/
-
-/-- Speaker's epistemic state regarding the stronger alternative ψ.
-
-    Manipulated via cover story: speaker either looked in all sections of
-    a box (full knowledge) or only some sections (partial knowledge). -/
+/-- Whether Farmer Brown looked into the third box. -/
 inductive SpeakerKnowledge where
-  /-- Full Knowledge: speaker inspected all sections, knows whether ψ -/
   | fullKnowledge
-  /-- Partial Knowledge: speaker inspected only some sections, ignorant of ψ -/
   | partialKnowledge
   deriving DecidableEq, Repr
 
-/-- Cognitive load manipulation (between-subjects). -/
+/-- The between-subjects cognitive-load manipulation (dot-array memorization). -/
 inductive LoadCondition where
-  /-- No concurrent task -/
   | noLoad
-  /-- Dual-task: memorize a dot pattern while processing utterance -/
   | load
   deriving DecidableEq, Repr
 
-/-- A full experimental condition: speaker knowledge × cognitive load. -/
-structure ExperimentalCondition where
-  knowledge : SpeakerKnowledge
-  load : LoadCondition
-  deriving DecidableEq, Repr
+/-! ### Speaker knowledge as observation access -/
 
-
-/-! ## Observed SSI Rates
-
-    Rates are stored in tenths of a percent to preserve the one-decimal-place
-    precision reported in the paper (e.g., 233 = 23.3%). -/
-
-/-- Observed strong scalar implicature rate for one condition. -/
-structure SSIRate where
-  /-- The experimental condition -/
-  condition : ExperimentalCondition
-  /-- SSI rate in tenths of a percent (e.g., 233 = 23.3%) -/
-  rateTenths : Nat
-  /-- Number of participants in this load group -/
-  n : Nat
-  deriving Repr
-
-/-- FK + No Load: 65.6% SSI rate (baseline for competent speaker). -/
-def fk_noLoad : SSIRate :=
-  { condition := ⟨.fullKnowledge, .noLoad⟩
-  , rateTenths := 656
-  , n := 30 }
-
-/-- FK + Load: 56.7% SSI rate (non-significant decrease, P = .22). -/
-def fk_load : SSIRate :=
-  { condition := ⟨.fullKnowledge, .load⟩
-  , rateTenths := 567
-  , n := 30 }
-
-/-- PK + No Load: 10.0% SSI rate (competence properly canceled). -/
-def pk_noLoad : SSIRate :=
-  { condition := ⟨.partialKnowledge, .noLoad⟩
-  , rateTenths := 100
-  , n := 30 }
-
-/-- PK + Load: 23.3% SSI rate — the key finding.
-    Load impairs cancellation of the default competence assumption,
-    yielding more SSIs despite speaker ignorance. -/
-def pk_load : SSIRate :=
-  { condition := ⟨.partialKnowledge, .load⟩
-  , rateTenths := 233
-  , n := 30 }
-
-/-- All four conditions. -/
-def allConditions : List SSIRate :=
-  [fk_noLoad, fk_load, pk_noLoad, pk_load]
-
-
-/-! ## Interaction Test
-
-    The key statistical test: Knowledge × Load interaction in a GLMM. -/
-
-/-- Result of the Knowledge × Load interaction test (GLMM, logistic). -/
-structure InteractionTest where
-  /-- Interaction coefficient -/
-  beta : Float
-  /-- Standard error -/
-  se : Float
-  /-- Chi-squared statistic (likelihood ratio, 1 df) -/
-  chiSq : Float
-  /-- p-value -/
-  p : Float
-  deriving Repr
-
-/-- The observed interaction: β = 2.62, χ²(1) = 11.3, P < .001. -/
-def knowledgeLoadInteraction : InteractionTest :=
-  { beta := 2.62
-  , se := 0.86
-  , chiSq := 11.3
-  , p := 0.001 }
-
-/-- The interaction is significant (P < .05). -/
-theorem interaction_significant :
-    knowledgeLoadInteraction.p < 0.05 := by native_decide
-
-
-/-! ## Load Effects by Condition -/
-
-/-- Signed load effect in tenths of a percent.
-    Positive = load increases SSI rate; negative = load decreases. -/
-def loadEffect (k : SpeakerKnowledge) : Int :=
-  match k with
-  | .fullKnowledge    => (fk_load.rateTenths : Int) - fk_noLoad.rateTenths
-  | .partialKnowledge => (pk_load.rateTenths : Int) - pk_noLoad.rateTenths
-
-/-- The crossover interaction: load increases SSIs for PK speakers
-    but decreases SSIs for FK speakers. -/
-theorem crossover_interaction :
-    loadEffect .partialKnowledge > 0 ∧ loadEffect .fullKnowledge < 0 := by
-  simp only [loadEffect, fk_load, fk_noLoad, pk_load, pk_noLoad]
-  omega
-
-/-- Load increases SSI rate in PK condition by 13.3 percentage points. -/
-theorem pk_load_increase :
-    pk_load.rateTenths > pk_noLoad.rateTenths := by
-  simp only [pk_load, pk_noLoad]
-  omega
-
-/-- The interaction magnitude: the difference in load effects across
-    knowledge conditions is positive (PK effect > FK effect). -/
-theorem interaction_magnitude :
-    loadEffect .partialKnowledge - loadEffect .fullKnowledge > 0 := by
-  simp only [loadEffect, fk_load, fk_noLoad, pk_load, pk_noLoad]
-  omega
-
-
-/-! ## Competing Hypotheses -/
-
-/-- Three hypotheses about the status of the competence assumption. -/
-inductive CompetenceHypothesis where
-  /-- Competence is assumed by default; cancellation requires effortful
-      processing. Load impairs cancellation → more SSIs when speaker is
-      actually ignorant. -/
-  | competenceByDefault
-  /-- The entire SI derivation is a default; load disrupts SI computation
-      itself. Predicts load decreases SSI rates. -/
-  | ssiByDefault
-  /-- Competence must be contextually licensed; it is not a default.
-      Load should not increase SSI rates for ignorant speakers — competence
-      was never assumed, so there is nothing to fail to cancel. -/
-  | contextualLicensing
-  deriving DecidableEq, Repr
-
-/-- Whether a hypothesis predicts a positive Knowledge × Load interaction
-    (i.e., load increases SSI more — or decreases it less — in PK than FK).
-
-    This is the key discriminating prediction: only competence-by-default
-    predicts a positive interaction. -/
-def predictsPositiveInteraction : CompetenceHypothesis → Bool
-  | .competenceByDefault  => true   -- load prevents canceling default competence
-  | .ssiByDefault         => false  -- load disrupts SI uniformly
-  | .contextualLicensing  => false  -- no default to fail to cancel
-
-/-- Competence-by-default is the only hypothesis predicting a positive
-    interaction, matching the observed data. -/
-theorem only_competenceByDefault_predicts_interaction :
-    [CompetenceHypothesis.competenceByDefault, .ssiByDefault, .contextualLicensing].filter
-      predictsPositiveInteraction
-    = [.competenceByDefault] := by decide
-
-
-/-! ### Speaker knowledge as observation access
-
-The cover story is [goodman-stuhlmuller-2013]'s access paradigm: the
-speaker inspects some of the three sections of the box and reports what
-she saw, so her epistemic state is the set of worlds compatible with the
-observation (`GoodmanStuhlmuller2013.obsCompatible`). Competence about
-the stronger alternative *all* is then derived, not stipulated: the
-full-knowledge state settles *whether all* and the partial-knowledge
-state does not, while both support the *some* assertion. -/
-
-open GoodmanStuhlmuller2013 NeoGricean
-
-/-- The stronger alternative ψ: *all of the marbles are red*. -/
+/-- The alternative (5): *all of the boxes have red cubes*. -/
 def all : Set WorldState := {w | qMeaning .all w}
 
-/-- The speaker's epistemic state: the worlds compatible with inspecting
-all three sections and seeing two red marbles (FK), or inspecting two
-sections and seeing both red (PK). -/
+/-- Farmer Brown's epistemic state in the *some* trials: the worlds compatible with seeing
+all three boxes, two with red cubes (full knowledge), or two boxes, both with red cubes
+(partial knowledge). -/
 def speakerState : SpeakerKnowledge → Set WorldState
   | .fullKnowledge    => {w | obsCompatible 3 2 w}
   | .partialKnowledge => {w | obsCompatible 2 2 w}
@@ -248,49 +67,56 @@ def speakerState : SpeakerKnowledge → Set WorldState
 theorem speakerState_nonempty (k : SpeakerKnowledge) : (speakerState k).Nonempty := by
   cases k <;> exact ⟨.s2, by simp [speakerState]; decide⟩
 
-/-- Competence about *all*, [sauerland-2004]'s `K all ∨ K¬all`: the speaker's state settles
-*whether all*. -/
+/-- Competence (7): the speaker knows whether *all*. -/
 def Competent (k : SpeakerKnowledge) : Prop :=
   speakerState k ⊆ all ∨ speakerState k ⊆ allᶜ
 
-/-- Neither speaker knows *all*: the weak implicature `¬K all` holds in
-both knowledge conditions. -/
+/-- The weak implicature (6) holds for both speakers: neither knows *all*. -/
 theorem not_speakerState_subset_all (k : SpeakerKnowledge) : ¬ speakerState k ⊆ all := by
   cases k <;> simp only [speakerState, all, Set.ofPred_subset_ofPred] <;> decide
 
-/-- The full-knowledge speaker is competent: she knows `¬all`. -/
+/-- The knowledgeable speaker is competent: he knows *not all*. -/
 theorem fk_competent : Competent .fullKnowledge :=
   Or.inr <| by simp only [speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
 
-/-- The partial-knowledge speaker is not competent about *all*. -/
+/-- The ignorant speaker is not competent about *all*. -/
 theorem pk_not_competent : ¬ Competent .partialKnowledge := by
   simp only [Competent, speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]
   decide
 
-/-- The Standard Recipe for the full-knowledge speaker: the weak
-implicature plus competence yields the strong SI `K¬all`. -/
+/-- The strong implicature (8) for the knowledgeable speaker, by the Standard Recipe from
+(6) and (7). -/
 theorem fk_strong : speakerState .fullKnowledge ⊆ allᶜ :=
   (subset_compl_iff_not_subset (speakerState_nonempty _) fk_competent).2
     (not_speakerState_subset_all _)
 
-/-- The partial-knowledge speaker is ignorant: neither `K all` nor `K¬all`. -/
+/-- The ignorant speaker knows neither *all* nor *not all*. -/
 theorem pk_ignorant : ¬ speakerState .partialKnowledge ⊆ allᶜ := by
   simp only [speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
 
-/-! ### Competence by default -/
+/-! ### The two hearer models -/
 
-/-- The competence-by-default hearer assumes the speaker is competent
-unless context can be integrated (no load) and shows otherwise. -/
+/-- Competence by default: (7) is assumed and cancelled only when contextual information
+about the speaker is integrated, which load blocks. -/
 def AssumesCompetent (k : SpeakerKnowledge) : LoadCondition → Prop
   | .load   => True
   | .noLoad => Competent k
 
-/-- The crossover prediction: load flips the partial-knowledge speaker from
-weak-only (10%) to the strong SI (23.3%) but leaves the full-knowledge
-speaker's strong SI (65.6%, 56.7%) in place. -/
-theorem crossover_prediction :
-    ¬ AssumesCompetent .partialKnowledge .noLoad ∧ AssumesCompetent .partialKnowledge .load ∧
-      AssumesCompetent .fullKnowledge .noLoad ∧ AssumesCompetent .fullKnowledge .load :=
-  ⟨pk_not_competent, trivial, fk_competent, trivial⟩
+/-- Contextual licensing: (7) is adopted only when the context establishes it. -/
+def ContextuallyLicensed (k : SpeakerKnowledge) (_ : LoadCondition) : Prop := Competent k
+
+/-- Outside the ignorant-speaker-under-load cell the two hearer models agree. -/
+theorem agree_of_fullKnowledge_or_noLoad :
+    ∀ k l, k = .fullKnowledge ∨ l = .noLoad → (AssumesCompetent k l ↔ ContextuallyLicensed k l)
+  | .fullKnowledge, .load, _ => iff_of_true trivial fk_competent
+  | .fullKnowledge, .noLoad, _ => Iff.rfl
+  | .partialKnowledge, .noLoad, _ => Iff.rfl
+  | .partialKnowledge, .load, h => absurd h (by decide)
+
+/-- For the ignorant speaker under load, competence by default predicts the strong
+implicature and contextual licensing does not: the observed 10% → 23.3% rise. -/
+theorem diverge_pk_load :
+    AssumesCompetent .partialKnowledge .load ∧ ¬ ContextuallyLicensed .partialKnowledge .load :=
+  ⟨trivial, pk_not_competent⟩
 
 end BaleEtAl2025

--- a/Linglib/Studies/EvcenBaleBarner2026.lean
+++ b/Linglib/Studies/EvcenBaleBarner2026.lean
@@ -31,9 +31,10 @@ logistic mixed-effects regressions):
 The paper's ALT constraint — alternatives are QUD answers the speaker is
 competent about, `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}` — is
 `exhaustificationLicensed`; the competence half is
-`BaleEtAl2025.toBeliefState`, the same mapping [bale-etal-2025]'s
-scalar-implicature paradigm uses, so conditional perfection and scalar
-implicature share the competence gate by construction. Perfection is not a semantic entailment
+`BaleEtAl2025.Competent`, derived from the speaker's observation state,
+the same derivation [bale-etal-2025]'s scalar-implicature paradigm uses,
+so conditional perfection and scalar implicature share the competence
+gate by construction. Perfection is not a semantic entailment
 (`Semantics.Conditionals.perfection_not_entailed_variablyStrict`), and
 coverage without exclusion does not suffice
 (`VonFintel2001.coverage_without_exclusion_insufficient`).
@@ -54,7 +55,7 @@ coverage without exclusion does not suffice
 namespace EvcenBaleBarner2026
 
 open VonFintel2001 Semantics.Conditionals Exhaustification NeoGricean
-open BaleEtAl2025 (SpeakerKnowledge toBeliefState)
+open BaleEtAl2025 (SpeakerKnowledge Competent fk_competent pk_not_competent)
 
 /-! ### Experimental conditions and observed rates -/
 
@@ -107,10 +108,9 @@ def qudProvidesAlternatives (q : QUDType) : Prop := q = .antecedentFocused
 
 /-- Exhaustification is licensed when the QUD provides alternative
 antecedents and the speaker is competent about them — the paper's ALT
-constraint `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}`. Competence is
-`BaleEtAl2025.toBeliefState k ≠ .noOpinion`. -/
+constraint `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}`. -/
 def exhaustificationLicensed (k : SpeakerKnowledge) (q : QUDType) : Prop :=
-  qudProvidesAlternatives q ∧ toBeliefState k ≠ .noOpinion
+  qudProvidesAlternatives q ∧ Competent k
 
 /-- Exhaustification is licensed exactly under an antecedent-focused QUD
 with a fully knowledgeable speaker. -/
@@ -119,7 +119,7 @@ with a fully knowledgeable speaker. -/
     exhaustificationLicensed k q ↔
       q = .antecedentFocused ∧ k = .fullKnowledge := by
   cases k <;>
-    simp [exhaustificationLicensed, qudProvidesAlternatives, toBeliefState]
+    simp [exhaustificationLicensed, qudProvidesAlternatives, fk_competent, pk_not_competent]
 
 /-! ### Licensing predicts the observed rates -/
 

--- a/Linglib/Studies/EvcenBaleBarner2026.lean
+++ b/Linglib/Studies/EvcenBaleBarner2026.lean
@@ -108,9 +108,9 @@ def qudProvidesAlternatives (q : QUDType) : Prop := q = .antecedentFocused
 /-- Exhaustification is licensed when the QUD provides alternative
 antecedents and the speaker is competent about them — the paper's ALT
 constraint `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}`. Competence is
-`BaleEtAl2025.toBeliefState`'s mapping into `NeoGricean.BeliefState.Competent`. -/
+`BaleEtAl2025.toBeliefState k ≠ .noOpinion`. -/
 def exhaustificationLicensed (k : SpeakerKnowledge) (q : QUDType) : Prop :=
-  qudProvidesAlternatives q ∧ (toBeliefState k).Competent
+  qudProvidesAlternatives q ∧ toBeliefState k ≠ .noOpinion
 
 /-- Exhaustification is licensed exactly under an antecedent-focused QUD
 with a fully knowledgeable speaker. -/
@@ -119,8 +119,7 @@ with a fully knowledgeable speaker. -/
     exhaustificationLicensed k q ↔
       q = .antecedentFocused ∧ k = .fullKnowledge := by
   cases k <;>
-    simp [exhaustificationLicensed, qudProvidesAlternatives, toBeliefState,
-      BeliefState.Competent]
+    simp [exhaustificationLicensed, qudProvidesAlternatives, toBeliefState]
 
 /-! ### Licensing predicts the observed rates -/
 

--- a/Linglib/Studies/EvcenBaleBarner2026.lean
+++ b/Linglib/Studies/EvcenBaleBarner2026.lean
@@ -108,9 +108,9 @@ def qudProvidesAlternatives (q : QUDType) : Prop := q = .antecedentFocused
 /-- Exhaustification is licensed when the QUD provides alternative
 antecedents and the speaker is competent about them — the paper's ALT
 constraint `ALT(p) ⊆ ANS(QUD) ∩ {q : Kₛ(q) ∨ Kₛ(¬q)}`. Competence is
-`BaleEtAl2025.toBeliefState`'s mapping into `NeoGricean.competent`. -/
+`BaleEtAl2025.toBeliefState`'s mapping into `NeoGricean.BeliefState.Competent`. -/
 def exhaustificationLicensed (k : SpeakerKnowledge) (q : QUDType) : Prop :=
-  qudProvidesAlternatives q ∧ competent (toBeliefState k) = true
+  qudProvidesAlternatives q ∧ (toBeliefState k).Competent
 
 /-- Exhaustification is licensed exactly under an antecedent-focused QUD
 with a fully knowledgeable speaker. -/
@@ -120,7 +120,7 @@ with a fully knowledgeable speaker. -/
       q = .antecedentFocused ∧ k = .fullKnowledge := by
   cases k <;>
     simp [exhaustificationLicensed, qudProvidesAlternatives, toBeliefState,
-      competent]
+      BeliefState.Competent]
 
 /-! ### Licensing predicts the observed rates -/
 

--- a/Linglib/Studies/GeurtsPouscoulous2009.lean
+++ b/Linglib/Studies/GeurtsPouscoulous2009.lean
@@ -70,8 +70,8 @@ The paper uses different statistical tests at different points:
 The canonical *some*/*all* world model `SomeAllWorld` lives in
 `Pragmatics.Implicature.SomeAll`; this file uses it for the
 implicature-spine bridge. The §8 derivation routes through
-`NeoGricean.processAlternative` (Sauerland-style competence
-machinery). The `think` empirical condition is bridged to the
+`NeoGricean.BeliefState.strongImplicature_iff` (Sauerland-style
+competence machinery). The `think` empirical condition is bridged to the
 global/local distinction for attitude-embedded scalars
 (`AttitudeInterpretation`, defined in the bridge section below).
 
@@ -825,19 +825,13 @@ derivation of seemingly-embedded SIs that the §8 argument is built on:
 [spector-2006]. None of [russell-2006], [spector-2006],
 or [geurts-2006] are formalized in linglib yet. -/
 
-/-- The §8 derivation routed through the canonical Sauerland-style
-competence machinery in `NeoGricean`. The paper's claim is
-that *given* the speaker has a determinate negative stance about the
-alternative (here `.disbelief` — speaker believes ¬(Bob-believes-all))
-*and* the competence assumption (33), the strong implicature is
-derived. The spine's `processAlternative true .disbelief` produces the
-strong-derived flag exactly when these conditions hold; this theorem
-exhibits the spine's `outcome_ii_strong` machinery applied to the §8
-think-reading derivation. -/
-theorem competence_explains_think_via_processAlternative :
-    let p := NeoGricean.processAlternative true .disbelief
-    p.weakHolds = true ∧ p.competenceAssumed = true ∧ p.strongDerived = true :=
-  NeoGricean.outcome_ii_strong
+/-- The §8 derivation routed through the Sauerland-style competence
+machinery in `NeoGricean`: from the primary implicature (32) — the
+speaker does not believe the alternative — and the competence
+assumption (33), the strong implicature (34) follows. -/
+theorem competence_explains_think {b : NeoGricean.BeliefState}
+    (h₃₂ : b.WeakImplicature) (h₃₃ : b.Competent) : b.StrongImplicature :=
+  NeoGricean.BeliefState.strongImplicature_iff.2 ⟨h₃₂, h₃₃⟩
 
 /-- The same derivation chain *applied to universal quantifiers*
 (paper §8 (35)–(38)). For "All the customers shot at some of the

--- a/Linglib/Studies/GeurtsPouscoulous2009.lean
+++ b/Linglib/Studies/GeurtsPouscoulous2009.lean
@@ -70,8 +70,8 @@ The paper uses different statistical tests at different points:
 The canonical *some*/*all* world model `SomeAllWorld` lives in
 `Pragmatics.Implicature.SomeAll`; this file uses it for the
 implicature-spine bridge. The §8 derivation routes through
-`NeoGricean.BeliefState.strongImplicature_iff` (Sauerland-style
-competence machinery). The `think` empirical condition is bridged to the
+`NeoGricean.subset_compl_iff_not_subset` (Sauerland-style competence
+machinery). The `think` empirical condition is bridged to the
 global/local distinction for attitude-embedded scalars
 (`AttitudeInterpretation`, defined in the bridge section below).
 
@@ -830,8 +830,8 @@ machinery in `NeoGricean`: from the primary implicature (32) — the
 speaker does not believe the alternative — and the competence
 assumption (33), the strong implicature (34) follows. -/
 theorem competence_explains_think {b : NeoGricean.BeliefState}
-    (h₃₂ : b.WeakImplicature) (h₃₃ : b.Competent) : b.StrongImplicature :=
-  NeoGricean.BeliefState.strongImplicature_iff.2 ⟨h₃₂, h₃₃⟩
+    (h₃₂ : b ≠ .belief) (h₃₃ : b ≠ .noOpinion) : b = .disbelief := by
+  cases b <;> simp_all
 
 /-- The same derivation chain *applied to universal quantifiers*
 (paper §8 (35)–(38)). For "All the customers shot at some of the

--- a/Linglib/Studies/GeurtsPouscoulous2009.lean
+++ b/Linglib/Studies/GeurtsPouscoulous2009.lean
@@ -826,12 +826,12 @@ derivation of seemingly-embedded SIs that the §8 argument is built on:
 or [geurts-2006] are formalized in linglib yet. -/
 
 /-- The §8 derivation routed through the Sauerland-style competence
-machinery in `NeoGricean`: from the primary implicature (32) — the
-speaker does not believe the alternative — and the competence
-assumption (33), the strong implicature (34) follows. -/
-theorem competence_explains_think {b : NeoGricean.BeliefState}
-    (h₃₂ : b ≠ .belief) (h₃₃ : b ≠ .noOpinion) : b = .disbelief := by
-  cases b <;> simp_all
+machinery in `NeoGricean`: for Bob's (consistent) belief state `s`, the
+primary implicature (32) `¬K all` and the competence assumption (33)
+`K all ∨ K¬all` yield the strong implicature (34) `K¬all`. -/
+theorem competence_explains_think {W : Type*} {s all : Set W} (hs : s.Nonempty)
+    (h₃₂ : ¬ s ⊆ all) (h₃₃ : s ⊆ all ∨ s ⊆ allᶜ) : s ⊆ allᶜ :=
+  (NeoGricean.subset_compl_iff_not_subset hs h₃₃).2 h₃₂
 
 /-- The same derivation chain *applied to universal quantifiers*
 (paper §8 (35)–(38)). For "All the customers shot at some of the

--- a/Linglib/Studies/Sauerland2004.lean
+++ b/Linglib/Studies/Sauerland2004.lean
@@ -42,42 +42,16 @@ inductive DisjWorld where
 namespace DisjWorld
 
 /-- The first disjunct A. -/
-def propA : DisjWorld → Prop
-  | .onlyA => True
-  | .both => True
-  | _ => False
+def propA : Set DisjWorld := {.onlyA, .both}
 
 /-- The second disjunct B. -/
-def propB : DisjWorld → Prop
-  | .onlyB => True
-  | .both => True
-  | _ => False
+def propB : Set DisjWorld := {.onlyB, .both}
 
 /-- The assertion *A or B*. -/
-def disj : DisjWorld → Prop
-  | .neither => False
-  | _ => True
+def disj : Set DisjWorld := {.onlyA, .onlyB, .both}
 
 /-- The conjunctive alternative *A and B*. -/
-def conj : DisjWorld → Prop
-  | .both => True
-  | _ => False
-
-instance : DecidablePred propA
-  | .onlyA | .both => isTrue trivial
-  | .neither | .onlyB => isFalse not_false
-
-instance : DecidablePred propB
-  | .onlyB | .both => isTrue trivial
-  | .neither | .onlyA => isFalse not_false
-
-instance : DecidablePred disj
-  | .neither => isFalse not_false
-  | .onlyA | .onlyB | .both => isTrue trivial
-
-instance : DecidablePred conj
-  | .both => isTrue trivial
-  | .neither | .onlyA | .onlyB => isFalse not_false
+def conj : Set DisjWorld := {.both}
 
 end DisjWorld
 
@@ -85,17 +59,16 @@ open DisjWorld
 
 /-- The scalar alternatives to *A or B*: each disjunct and the
 conjunction. -/
-def orAlts : List (DisjWorld → Prop) := [propA, propB, conj]
+def orAlts : List (Set DisjWorld) := [propA, propB, conj]
 
 /-- **The licensed secondary implicature**: K¬(A∧B) is consistent with
 the assertion and all primary implicatures — witnessed by the state
 considering exactly `onlyA` and `onlyB` possible. This is the "not
 both" inference of *A or B*. -/
-theorem conj_secondary_licensed : SecondaryLicensed disj orAlts conj := by
-  refine ⟨⟨{.onlyA, .onlyB}, ⟨.onlyA, by decide⟩⟩, ⟨by decide, ?_⟩, by decide⟩
-  intro ψ hψ
-  simp only [orAlts, List.mem_cons, List.not_mem_nil, or_false] at hψ
-  rcases hψ with rfl | rfl | rfl <;> decide
+theorem conj_secondary_licensed : SecondaryLicensed disj orAlts conj :=
+  ⟨{.onlyA, .onlyB}, Set.insert_nonempty _ _,
+    by simp [SatisfiesPrimaries, orAlts, disj, propA, propB, conj, Set.insert_subset_iff],
+    by simp [conj]⟩
 
 /-- **The blocked secondary implicature**: K¬A is inconsistent with the
 commitments. From K(A∨B) and K¬A every possible world satisfies B, so
@@ -104,16 +77,18 @@ KB holds — contradicting the primary implicature ¬KB: by
 world realizes A∨B, ¬A, and ¬B together. The disjuncts therefore yield
 only ignorance inferences, never "not A". -/
 theorem disjunct_secondary_blocked : ¬ SecondaryLicensed disj orAlts propA := fun h =>
-  absurd ((secondaryLicensed_iff.1 h).2 propB (by simp [orAlts])) (by decide)
+  absurd ((secondaryLicensed_iff.1 h).2 propB (by simp [orAlts]))
+    (by simp [Set.Nonempty, disj, propA, propB])
 
 /-- By the A↔B symmetry of the model, K¬B is blocked identically, by ¬KA. -/
 theorem disjunct_secondary_blocked' : ¬ SecondaryLicensed disj orAlts propB := fun h =>
-  absurd ((secondaryLicensed_iff.1 h).2 propA (by simp [orAlts])) (by decide)
+  absurd ((secondaryLicensed_iff.1 h).2 propA (by simp [orAlts]))
+    (by simp [Set.Nonempty, disj, propA, propB])
 
 /-- The strengthened reading of *A or B* the algorithm predicts:
 assertion plus the licensed "not both", realizable at exactly the
 one-disjunct worlds. -/
-theorem strengthened_or_realizable :
-    ∃ w, disj w ∧ ¬ conj w := ⟨.onlyA, trivial, not_false⟩
+theorem strengthened_or_realizable : (disj \ conj).Nonempty :=
+  ⟨.onlyA, by simp [disj, conj]⟩
 
 end Sauerland2004

--- a/Linglib/Studies/Sauerland2004.lean
+++ b/Linglib/Studies/Sauerland2004.lean
@@ -99,22 +99,16 @@ theorem conj_secondary_licensed : SecondaryLicensed disj orAlts conj := by
 
 /-- **The blocked secondary implicature**: K¬A is inconsistent with the
 commitments. From K(A∨B) and K¬A every possible world satisfies B, so
-KB holds — contradicting the primary implicature ¬KB. The disjuncts
-therefore yield only ignorance inferences, never "not A". -/
-theorem disjunct_secondary_blocked : ¬ SecondaryLicensed disj orAlts propA := by
-  rintro ⟨e, ⟨hφ, hprim⟩, hsec⟩
-  refine hprim propB (by simp [orAlts]) (fun w hw => ?_)
-  have hd := hφ w hw
-  have hna := hsec w hw
-  cases w <;> simp_all [disj, propA, propB]
+KB holds — contradicting the primary implicature ¬KB: by
+`secondaryLicensed_iff`, the single primary ¬KB blocks K¬A because no
+world realizes A∨B, ¬A, and ¬B together. The disjuncts therefore yield
+only ignorance inferences, never "not A". -/
+theorem disjunct_secondary_blocked : ¬ SecondaryLicensed disj orAlts propA := fun h =>
+  absurd ((secondaryLicensed_iff.1 h).2 propB (by simp [orAlts])) (by decide)
 
-/-- By the A↔B symmetry of the model, K¬B is blocked identically. -/
-theorem disjunct_secondary_blocked' : ¬ SecondaryLicensed disj orAlts propB := by
-  rintro ⟨e, ⟨hφ, hprim⟩, hsec⟩
-  refine hprim propA (by simp [orAlts]) (fun w hw => ?_)
-  have hd := hφ w hw
-  have hnb := hsec w hw
-  cases w <;> simp_all [disj, propA, propB]
+/-- By the A↔B symmetry of the model, K¬B is blocked identically, by ¬KA. -/
+theorem disjunct_secondary_blocked' : ¬ SecondaryLicensed disj orAlts propB := fun h =>
+  absurd ((secondaryLicensed_iff.1 h).2 propA (by simp [orAlts])) (by decide)
 
 /-- The strengthened reading of *A or B* the algorithm predicts:
 assertion plus the licensed "not both", realizable at exactly the


### PR DESCRIPTION
Deep audit of `Pragmatics/NeoGricean/Basic.lean` and its consumers; supersedes #2302 (which landed an intermediate design and was left `BEHIND` by automerge).

- A speaker's epistemic state is `s : Set W` (the same object as `ContextSet`), K is `⊆`, consistency is an `s.Nonempty` hypothesis; `EpistemicState`, `BeliefState`, and the Bool recipe predicates are gone. New `secondaryLicensed_iff`: Sauerland licensing decomposes per alternative, so `Sauerland2004.disjunct_secondary_blocked` names the blocking primary. The Standard Recipe is `subset_compl_iff_not_subset`.
- `BaleEtAl2025` (paper re-read): speaker knowledge is a Goodman–Stuhlmüller observation state, so competence (7) is derived; the competence-by-default vs contextual-licensing contrast is two hearer models with `agree_of_fullKnowledge_or_noLoad`/`diverge_pk_load`. The `Float`/`native_decide` block, hand-typed rate table, and Bool hypothesis table are cut (rates in the docstring).