### PR TITLE
refactor(Pragmatics/NeoGricean): epistemic propositions via Set.Iic

### DIFF
--- a/Linglib/Pragmatics/NeoGricean/Basic.lean
+++ b/Linglib/Pragmatics/NeoGricean/Basic.lean
@@ -1,33 +1,38 @@
-import Mathlib.Data.Set.Insert
+import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Neo-Gricean pragmatics: secondary implicatures and the Standard Recipe
 
-This file defines [sauerland-2004]'s consistency-gated derivation of secondary implicatures
-and the Standard Recipe of [geurts-2010]. A speaker's epistemic state is a set of worlds
-`s : Set W` — the same object as the `ContextSet` of `Discourse/CommonGround.lean` — and a
-proposition is a `Set W`, so the speaker knows `φ` iff `s ⊆ φ`, knows `¬φ` iff `s ⊆ φᶜ`, and
-is competent about `φ` iff `s ⊆ φ ∨ s ⊆ φᶜ`; consistency of the speaker is the hypothesis
-`s.Nonempty` (the `Filter.NeBot` convention).
-Asserting `φ` yields the primary implicature `¬Kψ` for each stronger alternative `ψ`; the
-secondary implicature `K¬ψ` arises only when it is consistent with the assertion and all
-primary implicatures, and the Standard Recipe obtains it from `¬Kψ` under competence.
+This file defines [sauerland-2004]'s derivation of secondary implicatures and the Standard
+Recipe of [geurts-2010]. A speaker's epistemic state is a set of worlds `s : Set W` (the same
+object as the `ContextSet` of `Discourse/CommonGround.lean`), and an *epistemic proposition* —
+what an utterance implicates about the speaker — is a set of states `Set (Set W)`. Knowledge
+`Kφ` is the principal down-set `Set.Iic φ` (the states `s ⊆ φ`), so the primary implicature
+`¬Kψ` is `(Iic ψ)ᶜ`, the secondary implicature `K¬ψ` is `Iic ψᶜ`, competence `Kψ ∨ K¬ψ` is
+`Iic ψ ∪ Iic ψᶜ`, and the empty state, a member of every `Iic`, is the inconsistent speaker.
+Asserting `φ` against alternatives `alts` commits the speaker to `Kφ` and the primary
+implicatures; `K¬ψ` is a secondary implicature iff it is consistent with that commitment.
 
 ## Main definitions
 
-* `SatisfiesPrimaries`, `SecondaryLicensed`: the commitment set after an assertion and the
-  consistency condition licensing a secondary implicature.
+* `primaryImplicature`, `secondaryImplicature`, `competent`: the epistemic propositions
+  `¬Kψ`, `K¬ψ`, `Kψ ∨ K¬ψ`.
+* `commitment`: `Kφ` together with the primary implicatures of the alternatives.
+* `Consistent`: an epistemic proposition holds of some nonempty state.
+* `IsSecondaryImplicature`: [sauerland-2004]'s condition for `K¬ψ`.
 
 ## Main results
 
-* `secondaryLicensed_iff`: licensing decomposes over the alternatives, so a blocked secondary
-  implicature is always blocked by a single primary; the disjunction case (K¬(A∧B) licensed,
-  K¬A blocked) is `Studies/Sauerland2004.lean`.
-* `secondaryLicensed_of_ssubset`: a lone asymmetrically stronger alternative always licenses
+* `isSecondaryImplicature_iff`: `K¬ψ` is a secondary implicature iff the strengthened meaning
+  `φ \ ψ` is consistent and entails no alternative — `φ \ ψ` itself is the canonical witness,
+  so a blocked secondary implicature is always blocked by a single primary; the disjunction
+  case (K¬(A∧B) arises, K¬A is blocked) is `Studies/Sauerland2004.lean`.
+* `isSecondaryImplicature_of_ssubset`: a lone asymmetrically stronger alternative always yields
   its secondary implicature.
-* `subset_compl_iff_not_subset`: the Standard Recipe — for a competent speaker, the strong
-  implicature `K¬ψ` is exactly the weak implicature `¬Kψ`.
+* `primaryImplicature_inter_competent`: the Standard Recipe as an identity — on consistent
+  states, the weak implicature plus competence is the strong implicature.
 
 ## References
 
@@ -39,83 +44,108 @@ primary implicatures, and the Standard Recipe obtains it from `¬Kψ` under comp
 
 namespace NeoGricean
 
-variable {W : Type*} {s φ ψ χ : Set W} {alts : List (Set W)}
+open Set
 
-/-! ### The Sauerland derivation
+variable {W : Type*} {s φ ψ χ : Set W} {alts : Set (Set W)}
 
-Asserting `φ` against scalar alternatives `alts` commits the speaker to `Kφ` plus, for each
-alternative, the primary implicature `¬Kψ` ([sauerland-2004] (42), verified p. 383). A
-secondary implicature `K¬ψ` arises exactly when it is *consistent* with that commitment set
-([sauerland-2004] (43)): when some nonempty epistemic state realizes the commitments together
-with `K¬ψ`. -/
+/-! ### Epistemic propositions -/
 
-/-- The speaker commitment after asserting `φ` against `alts`: `Kφ` and the primary implicature
-`¬Kψ` for each alternative. Per [sauerland-2004], the caller supplies only the asymmetrically
-stronger alternatives (`ψ ⊂ φ`); the definition does not enforce the filter. -/
-def SatisfiesPrimaries (s φ : Set W) (alts : List (Set W)) : Prop :=
-  s ⊆ φ ∧ ∀ ψ ∈ alts, ¬ s ⊆ ψ
+/-- The primary implicature `¬Kψ`: the states that do not know `ψ`. -/
+def primaryImplicature (ψ : Set W) : Set (Set W) := (Iic ψ)ᶜ
 
-/-- [sauerland-2004]'s consistency condition: the secondary implicature `K¬ψ` is licensed iff
-some nonempty epistemic state realizes the assertion, all primary implicatures, and `K¬ψ`
-jointly. -/
-def SecondaryLicensed (φ : Set W) (alts : List (Set W)) (ψ : Set W) : Prop :=
-  ∃ s : Set W, s.Nonempty ∧ SatisfiesPrimaries s φ alts ∧ s ⊆ ψᶜ
+/-- The secondary implicature `K¬ψ`: the states that know `¬ψ`. -/
+def secondaryImplicature (ψ : Set W) : Set (Set W) := Iic ψᶜ
 
-/-- Licensing decomposes over the alternatives: `K¬ψ` is consistent with the commitments iff
-the strengthened meaning `φ \ ψ` is realizable and, for each alternative `χ`, realizable
-outside `ψ ∪ χ`. A blocked secondary implicature is thus always blocked by a single primary. -/
-theorem secondaryLicensed_iff :
-    SecondaryLicensed φ alts ψ ↔ (φ \ ψ).Nonempty ∧ ∀ χ ∈ alts, (φ \ (ψ ∪ χ)).Nonempty := by
+/-- Competence about `ψ`, `Kψ ∨ K¬ψ`: the states that know whether `ψ`. -/
+def competent (ψ : Set W) : Set (Set W) := Iic ψ ∪ Iic ψᶜ
+
+@[simp] theorem mem_primaryImplicature : s ∈ primaryImplicature ψ ↔ ¬ s ⊆ ψ := Iff.rfl
+
+@[simp] theorem mem_secondaryImplicature : s ∈ secondaryImplicature ψ ↔ s ⊆ ψᶜ := Iff.rfl
+
+@[simp] theorem mem_competent : s ∈ competent ψ ↔ s ⊆ ψ ∨ s ⊆ ψᶜ := Iff.rfl
+
+/-- An epistemic proposition is consistent iff some nonempty state satisfies it. -/
+def Consistent (E : Set (Set W)) : Prop := ∃ s ∈ E, s.Nonempty
+
+/-! ### Primary and secondary implicatures
+
+Asserting `φ` against scalar alternatives `alts` commits the speaker to `Kφ` plus the primary
+implicature `¬Kψ` for each alternative ([sauerland-2004] (42), verified p. 383); `K¬ψ` is a
+secondary implicature exactly when it is *consistent* with that commitment
+([sauerland-2004] (43)). -/
+
+/-- The speaker's commitment after asserting `φ` against `alts`: `Kφ` and the primary
+implicature of each alternative. Per [sauerland-2004] the alternatives are the asymmetrically
+stronger ones (`ψ ⊂ φ`); the definition does not enforce the filter. -/
+def commitment (φ : Set W) (alts : Set (Set W)) : Set (Set W) :=
+  Iic φ ∩ ⋂ χ ∈ alts, primaryImplicature χ
+
+@[simp] theorem mem_commitment : s ∈ commitment φ alts ↔ s ⊆ φ ∧ ∀ χ ∈ alts, ¬ s ⊆ χ := by
+  simp [commitment]
+
+/-- `K¬ψ` is a secondary implicature of asserting `φ` against `alts` iff it is consistent with
+the commitment. -/
+def IsSecondaryImplicature (φ : Set W) (alts : Set (Set W)) (ψ : Set W) : Prop :=
+  Consistent (commitment φ alts ∩ secondaryImplicature ψ)
+
+/-- The strengthened meaning `φ \ ψ` is the canonical witness: `K¬ψ` is a secondary
+implicature iff `φ \ ψ` is consistent and entails no alternative. A blocked secondary
+implicature is thus always blocked by a single primary. -/
+theorem isSecondaryImplicature_iff :
+    IsSecondaryImplicature φ alts ψ ↔ (φ \ ψ).Nonempty ∧ ∀ χ ∈ alts, ¬ φ \ ψ ⊆ χ := by
   constructor
-  · rintro ⟨s, hs, ⟨hφ, hprim⟩, hψ⟩
-    refine ⟨hs.mono fun w hw => ⟨hφ hw, hψ hw⟩, fun χ hχ => ?_⟩
-    obtain ⟨w, hw, hχ⟩ := Set.not_subset.1 (hprim χ hχ)
-    exact ⟨w, hφ hw, fun h => h.elim (hψ hw) hχ⟩
-  · rintro ⟨⟨w₀, hw₀⟩, h⟩
-    induction alts with
-    | nil =>
-      exact ⟨{w₀}, Set.singleton_nonempty w₀, ⟨Set.singleton_subset_iff.2 hw₀.1, by simp⟩,
-        Set.singleton_subset_iff.2 hw₀.2⟩
-    | cons χ alts ih =>
-      obtain ⟨s, hs, ⟨hφ, hprim⟩, hψ⟩ := ih fun χ' hχ' => h χ' (List.mem_cons_of_mem χ hχ')
-      obtain ⟨w, hφw, hw⟩ := h χ List.mem_cons_self
-      obtain ⟨hψw, hχw⟩ := not_or.1 hw
-      refine ⟨insert w s, Set.insert_nonempty w s,
-        ⟨Set.insert_subset_iff.2 ⟨hφw, hφ⟩, List.forall_mem_cons.2 ⟨?_, ?_⟩⟩,
-        Set.insert_subset_iff.2 ⟨hψw, hψ⟩⟩
-      · exact fun hk => hχw (hk (Set.mem_insert w s))
-      · exact fun χ' hχ' hk => hprim χ' hχ' ((Set.subset_insert w s).trans hk)
+  · rintro ⟨s, ⟨hcom, hψ⟩, hs⟩
+    obtain ⟨hφ, hprim⟩ := mem_commitment.1 hcom
+    have hsub : s ⊆ φ \ ψ := fun w hw => ⟨hφ hw, hψ hw⟩
+    exact ⟨hs.mono hsub, fun χ hχ h => hprim χ hχ (hsub.trans h)⟩
+  · rintro ⟨hne, h⟩
+    exact ⟨φ \ ψ, ⟨mem_commitment.2 ⟨sdiff_subset, h⟩, fun _ hw => hw.2⟩, hne⟩
 
-/-- For a lone alternative `χ`, `K¬ψ` is licensed iff `φ` is realizable outside `ψ ∪ χ`. -/
-theorem secondaryLicensed_singleton :
-    SecondaryLicensed φ [χ] ψ ↔ (φ \ (ψ ∪ χ)).Nonempty := by
-  rw [secondaryLicensed_iff, List.forall_mem_singleton]
-  exact and_iff_right_of_imp fun h => h.mono (Set.sdiff_subset_sdiff_right Set.subset_union_left)
+/-- For a lone alternative `χ`, `K¬ψ` is a secondary implicature iff `φ \ ψ` is consistent
+and does not entail `χ`. -/
+theorem isSecondaryImplicature_singleton :
+    IsSecondaryImplicature φ {χ} ψ ↔ (φ \ ψ).Nonempty ∧ ¬ φ \ ψ ⊆ χ := by
+  simp [isSecondaryImplicature_iff]
 
-/-- Against its own alternative alone, `K¬ψ` is licensed iff the strengthened meaning `φ \ ψ`
-is realizable. -/
-theorem secondaryLicensed_singleton_self : SecondaryLicensed φ [ψ] ψ ↔ (φ \ ψ).Nonempty := by
-  simp [secondaryLicensed_singleton]
+/-- Against its own alternative alone, `K¬ψ` is a secondary implicature iff the strengthened
+meaning `φ \ ψ` is consistent. -/
+theorem isSecondaryImplicature_singleton_self :
+    IsSecondaryImplicature φ {ψ} ψ ↔ (φ \ ψ).Nonempty := by
+  rw [isSecondaryImplicature_singleton]
+  exact and_iff_left_of_imp fun ⟨_, hw⟩ h => hw.2 (h hw)
 
 /-- A lone asymmetrically stronger alternative always yields its secondary implicature: the
 *some ⇝ not all* case. -/
-theorem secondaryLicensed_of_ssubset (h : ψ ⊂ φ) : SecondaryLicensed φ [ψ] ψ :=
-  secondaryLicensed_singleton_self.2 (Set.sdiff_nonempty.2 h.2)
+theorem isSecondaryImplicature_of_ssubset (h : ψ ⊂ φ) : IsSecondaryImplicature φ {ψ} ψ :=
+  isSecondaryImplicature_singleton_self.2 (sdiff_nonempty.2 h.2)
 
 /-! ### Competence and the Standard Recipe
 
-Competence about `ψ` is [sauerland-2004]'s `Kψ ∨ K¬ψ`, `s ⊆ ψ ∨ s ⊆ ψᶜ` — the speaker *knows
-whether* `ψ`, which is support of the polar question `Question.polar ψ` by
-`Question.mem_polar`. -/
+Competence about `ψ` is [sauerland-2004]'s `Kψ ∨ K¬ψ` — the speaker *knows whether* `ψ`, which
+is support of the polar question `Question.polar ψ` by `Question.mem_polar`. -/
 
 /-- A consistent speaker cannot both know `ψ` and know `¬ψ`. -/
 theorem not_subset_compl_of_subset (hs : s.Nonempty) (h : s ⊆ ψ) : ¬ s ⊆ ψᶜ :=
   fun h' => hs.elim fun _ hw => h' hw (h hw)
 
-/-- The Standard Recipe: for a consistent speaker competent about `ψ`, the strong implicature
-`K¬ψ` is exactly the weak implicature `¬Kψ`. -/
+/-- The Standard Recipe, pointwise: for a consistent speaker competent about `ψ`, the strong
+implicature `K¬ψ` is exactly the weak implicature `¬Kψ`. -/
 theorem subset_compl_iff_not_subset (hs : s.Nonempty) (hc : s ⊆ ψ ∨ s ⊆ ψᶜ) :
     s ⊆ ψᶜ ↔ ¬ s ⊆ ψ :=
   ⟨fun h h' => not_subset_compl_of_subset hs h' h, hc.resolve_left⟩
+
+/-- The Standard Recipe: on consistent states, the weak implicature plus competence is the
+strong implicature. -/
+theorem primaryImplicature_inter_competent (ψ : Set W) :
+    primaryImplicature ψ ∩ competent ψ = secondaryImplicature ψ \ {∅} := by
+  ext s
+  simp only [mem_inter_iff, mem_primaryImplicature, mem_competent, mem_sdiff,
+    mem_secondaryImplicature, mem_singleton_iff]
+  constructor
+  · rintro ⟨h, hc⟩
+    exact ⟨hc.resolve_left h, fun he => h (he ▸ empty_subset ψ)⟩
+  · rintro ⟨hψ, hs⟩
+    exact ⟨fun h => not_subset_compl_of_subset (nonempty_iff_ne_empty.2 hs) h hψ, Or.inr hψ⟩
 
 end NeoGricean

--- a/Linglib/Studies/BaleEtAl2025.lean
+++ b/Linglib/Studies/BaleEtAl2025.lean
@@ -67,9 +67,8 @@ def speakerState : SpeakerKnowledge → Set WorldState
 theorem speakerState_nonempty (k : SpeakerKnowledge) : (speakerState k).Nonempty := by
   cases k <;> exact ⟨.s2, by simp [speakerState]; decide⟩
 
-/-- Competence (7): the speaker knows whether *all*. -/
-def Competent (k : SpeakerKnowledge) : Prop :=
-  speakerState k ⊆ all ∨ speakerState k ⊆ allᶜ
+/-- Competence (7): the speaker's state knows whether *all*. -/
+def Competent (k : SpeakerKnowledge) : Prop := speakerState k ∈ competent all
 
 /-- The weak implicature (6) holds for both speakers: neither knows *all*. -/
 theorem not_speakerState_subset_all (k : SpeakerKnowledge) : ¬ speakerState k ⊆ all := by
@@ -77,11 +76,13 @@ theorem not_speakerState_subset_all (k : SpeakerKnowledge) : ¬ speakerState k �
 
 /-- The knowledgeable speaker is competent: he knows *not all*. -/
 theorem fk_competent : Competent .fullKnowledge :=
-  Or.inr <| by simp only [speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
+  Or.inr <| by
+    simp only [speakerState, all, Set.mem_Iic, Set.compl_ofPred, Set.ofPred_subset_ofPred]; decide
 
 /-- The ignorant speaker is not competent about *all*. -/
 theorem pk_not_competent : ¬ Competent .partialKnowledge := by
-  simp only [Competent, speakerState, all, Set.compl_ofPred, Set.ofPred_subset_ofPred]
+  simp only [Competent, mem_competent, speakerState, all, Set.compl_ofPred,
+    Set.ofPred_subset_ofPred]
   decide
 
 /-- The strong implicature (8) for the knowledgeable speaker, by the Standard Recipe from

--- a/Linglib/Studies/Sauerland2004.lean
+++ b/Linglib/Studies/Sauerland2004.lean
@@ -9,14 +9,13 @@ Sauerland, U. (2004). Scalar implicatures in complex sentences.
 *Linguistics and Philosophy* 27(3): 367–391.
 
 The paper's derivation for disjunction, run through the consistency-gated
-algorithm in `Pragmatics/NeoGricean/Basic.lean` (`SecondaryLicensed`,
+algorithm in `Pragmatics/NeoGricean/Basic.lean` (`IsSecondaryImplicature`,
 implementing the paper's (42)/(43), verified p. 383): asserting *A or B*
 against the alternatives {A, B, A∧B} yields the primary implicatures
 ¬KA, ¬KB, ¬K(A∧B). Of the candidate secondary implicatures, K¬(A∧B)
-is consistent with the commitments and licensed
-(`conj_secondary_licensed`), while K¬A is **blocked**
-(`disjunct_secondary_blocked`): K¬A together with K(A∨B) forces KB,
-contradicting the primary ¬KB. (The paper frames the same block dually:
+is consistent with the commitments and arises (`conj_secondary`),
+while K¬A is **blocked** (`disjunct_blocked`): K¬A together with
+K(A∨B) forces KB, contradicting the primary ¬KB. (The paper frames the same block dually:
 K¬A contradicts the possibility implicature PA entailed by the
 assertion plus ¬KB.) This asymmetry — "not both" arises but
 "not A" does not — is the paper's signature prediction for disjunction,
@@ -59,31 +58,33 @@ open DisjWorld
 
 /-- The scalar alternatives to *A or B*: each disjunct and the
 conjunction. -/
-def orAlts : List (Set DisjWorld) := [propA, propB, conj]
+def orAlts : Set (Set DisjWorld) := {propA, propB, conj}
 
-/-- **The licensed secondary implicature**: K¬(A∧B) is consistent with
-the assertion and all primary implicatures — witnessed by the state
-considering exactly `onlyA` and `onlyB` possible. This is the "not
-both" inference of *A or B*. -/
-theorem conj_secondary_licensed : SecondaryLicensed disj orAlts conj :=
-  ⟨{.onlyA, .onlyB}, Set.insert_nonempty _ _,
-    by simp [SatisfiesPrimaries, orAlts, disj, propA, propB, conj, Set.insert_subset_iff],
-    by simp [conj]⟩
+/-- **The secondary implicature that arises**: K¬(A∧B) is consistent with
+the assertion and all primary implicatures — witnessed by the
+strengthened meaning `disj \ conj`, the state considering exactly
+`onlyA` and `onlyB` possible. This is the "not both" inference of
+*A or B*. -/
+theorem conj_secondary : IsSecondaryImplicature disj orAlts conj := by
+  rw [isSecondaryImplicature_iff]
+  refine ⟨⟨.onlyA, by simp [disj, conj]⟩, ?_⟩
+  simp only [orAlts, Set.forall_mem_insert, Set.mem_singleton_iff, forall_eq, Set.subset_def,
+    Set.mem_sdiff, disj, conj, propA, propB]
+  decide
 
 /-- **The blocked secondary implicature**: K¬A is inconsistent with the
-commitments. From K(A∨B) and K¬A every possible world satisfies B, so
-KB holds — contradicting the primary implicature ¬KB: by
-`secondaryLicensed_iff`, the single primary ¬KB blocks K¬A because no
-world realizes A∨B, ¬A, and ¬B together. The disjuncts therefore yield
-only ignorance inferences, never "not A". -/
-theorem disjunct_secondary_blocked : ¬ SecondaryLicensed disj orAlts propA := fun h =>
-  absurd ((secondaryLicensed_iff.1 h).2 propB (by simp [orAlts]))
-    (by simp [Set.Nonempty, disj, propA, propB])
+commitments. The strengthened meaning `disj \ propA` entails B, so K¬A
+together with K(A∨B) forces KB — contradicting the primary implicature
+¬KB (`isSecondaryImplicature_iff`: the single primary ¬KB blocks K¬A).
+The disjuncts therefore yield only ignorance inferences, never "not A". -/
+theorem disjunct_blocked : ¬ IsSecondaryImplicature disj orAlts propA := fun h =>
+  (isSecondaryImplicature_iff.1 h).2 propB (by simp [orAlts])
+    (by simp only [Set.subset_def, Set.mem_sdiff, disj, propA, propB]; decide)
 
 /-- By the A↔B symmetry of the model, K¬B is blocked identically, by ¬KA. -/
-theorem disjunct_secondary_blocked' : ¬ SecondaryLicensed disj orAlts propB := fun h =>
-  absurd ((secondaryLicensed_iff.1 h).2 propA (by simp [orAlts]))
-    (by simp [Set.Nonempty, disj, propA, propB])
+theorem disjunct_blocked' : ¬ IsSecondaryImplicature disj orAlts propB := fun h =>
+  (isSecondaryImplicature_iff.1 h).2 propA (by simp [orAlts])
+    (by simp only [Set.subset_def, Set.mem_sdiff, disj, propA, propB]; decide)
 
 /-- The strengthened reading of *A or B* the algorithm predicts:
 assertion plus the licensed "not both", realizable at exactly the


### PR DESCRIPTION
Follow-up to #2303: implicatures become epistemic propositions `Set (Set W)` with `Kφ = Set.Iic φ`.

- `primaryImplicature ψ = (Iic ψ)ᶜ`, `secondaryImplicature ψ = Iic ψᶜ`, `competent ψ = Iic ψ ∪ Iic ψᶜ`, `commitment φ alts`, `Consistent`, and `IsSecondaryImplicature` replace `SatisfiesPrimaries`/`SecondaryLicensed`; alternatives are a `Set (Set W)`.
- `isSecondaryImplicature_iff`: `φ \ ψ` is the canonical witness — `K¬ψ` arises iff the strengthened meaning is consistent and entails no alternative (no list induction, no choice). `primaryImplicature_inter_competent` states the Standard Recipe as a set identity.
- Sauerland2004 proofs go through the characterization; BaleEtAl2025's `Competent` is membership in `competent all`.