### PR TITLE
refactor(Discourse/CommonGround): common ground as Filter W

### DIFF
--- a/Linglib/Discourse/Commitment/Basic.lean
+++ b/Linglib/Discourse/Commitment/Basic.lean
@@ -312,11 +312,10 @@ end IndexedCommitment
 
 end Commitment
 
-/-! ### HasContextSet Instance -/
+/-! ### HasCommonGround instance -/
 
-open CommonGround in
-/-- A commitment slate projects to a context set. -/
-instance {W : Type*} : HasContextSet (Commitment.CommitmentSlate W) W where
-  toContextSet s := λ w => s.toContextSet w
+/-- A commitment slate's common ground: the principal filter of its context set. -/
+instance {W : Type*} : HasCommonGround (Commitment.CommitmentSlate W) W where
+  commonGround s := Filter.principal {w | s.toContextSet w}
 
 end Discourse

--- a/Linglib/Discourse/Commitment/SourceMarked.lean
+++ b/Linglib/Discourse/Commitment/SourceMarked.lean
@@ -36,7 +36,6 @@ Source determines who can challenge:
 namespace Discourse.Gunlogson
 
 open Discourse.Commitment
-open CommonGround (ContextSet)
 open Discourse (DiscourseRole)
 open Semantics.Questions.Bias (ContextualEvidence)
 
@@ -94,7 +93,7 @@ def assert (s : GunlogsonState W) (p : Set W) : GunlogsonState W :=
 /-- Context set: intersection of both participants' commitment contexts.
     Only propositions that both participants are committed to (regardless
     of source) contribute to the shared context. -/
-def contextSet (s : GunlogsonState W) : ContextSet W :=
+def contextSet (s : GunlogsonState W) : Set W :=
   λ w => s.speakerSlate.toContextSet w ∧ s.addresseeSlate.toContextSet w
 
 /-- Stability: stable when neither participant has unresolved
@@ -334,17 +333,15 @@ theorem confirm_still_unstable {W : Type*} (p : Set W) :
   exact Nat.succ_ne_zero _ h
 
 -- ════════════════════════════════════════════════════
--- HasContextSet instance
+-- HasCommonGround instance
 -- ════════════════════════════════════════════════════
 
-open CommonGround in
-/-- Gunlogson states project to a context set via `contextSet` —
+/-- Gunlogson states project to the principal common ground of `contextSet` —
     the intersection of both participants' commitment contexts
     (regardless of source). -/
-instance {W : Type*} : HasContextSet (GunlogsonState W) W where
-  toContextSet := GunlogsonState.contextSet
+instance {W : Type*} : HasCommonGround (GunlogsonState W) W where
+  commonGround s := Filter.principal s.contextSet
 
-open CommonGround in
 /-- Gunlogson's state instantiates `HasAssertion`: a falling declarative
     commits only the speaker, but because the context set is the
     intersection of both participants' commitment contexts, the
@@ -354,14 +351,20 @@ open CommonGround in
     [stalnaker-1978] on the projected observable while
     [farkas-bruce-2010]'s proposal model does not instantiate. -/
 instance instHasAssertion {W : Type*} :
-    CommonGround.HasAssertion (GunlogsonState W) W where
+    HasAssertion (GunlogsonState W) W where
   initial := GunlogsonState.empty
   assert s p := s.assert p
-  toContextSet_initial :=
-    Set.eq_univ_of_forall fun _ =>
-      ⟨fun _ hq => absurd hq List.not_mem_nil,
-       fun _ hq => absurd hq List.not_mem_nil⟩
-  toContextSet_assert s p := by
+  commonGround_initial := by
+    have h : (GunlogsonState.empty : GunlogsonState W).contextSet = Set.univ :=
+      Set.eq_univ_of_forall fun _ =>
+        ⟨fun _ hq => absurd hq List.not_mem_nil,
+         fun _ hq => absurd hq List.not_mem_nil⟩
+    show Filter.principal (GunlogsonState.empty : GunlogsonState W).contextSet = ⊤
+    rw [h, Filter.principal_univ]
+  commonGround_assert s p := by
+    show Filter.principal (s.assert p).contextSet = Filter.principal s.contextSet ⊓ _
+    rw [Filter.inf_principal]
+    refine congrArg _ ?_
     ext w
     rw [Set.mem_inter_iff]
     constructor

--- a/Linglib/Discourse/Commitment/Space.lean
+++ b/Linglib/Discourse/Commitment/Space.lean
@@ -76,7 +76,6 @@ open Discourse.Commitment
   (CommitmentSlate IndexedCommitment IndexedWeightedCommitment CommitmentForce
    HasSupport CommitmentGrade)
 open Discourse (DiscourseRole)
-open CommonGround (ContextSet)
 open Mood (Illocutionary)
 
 -- ════════════════════════════════════════════════════
@@ -360,7 +359,7 @@ def negatedQuestionLow [CommitmentGrade G] (cs : CommitmentSpace W G)
     two attitudes (per [condoravdi-lauer-2012]), use
     `toDoxasticContextSet` / `toPreferentialContextSet`. -/
 def toContextSet [HasSupport G] (cs : CommitmentSpace W G) :
-    ContextSet W :=
+    Set W :=
   fun w => ∀ ic ∈ cs.root, IndexedWeightedCommitment.toCommitment ic w
 
 /-- Doxastic-only context set: worlds compatible with the root's
@@ -371,7 +370,7 @@ def toContextSet [HasSupport G] (cs : CommitmentSpace W G) :
     public BELIEFS the speaker is committed to". A declarative assertion
     contributes here; an imperative utterance does not. -/
 def toDoxasticContextSet [HasSupport G] (cs : CommitmentSpace W G) :
-    ContextSet W :=
+    Set W :=
   fun w => ∀ ic ∈ cs.root,
     ic.force = .doxastic → IndexedWeightedCommitment.toCommitment ic w
 
@@ -386,7 +385,7 @@ def toDoxasticContextSet [HasSupport G] (cs : CommitmentSpace W G) :
     closure (5.33b) `pep(p) ∈ PB ⟺ p ∈ PEP` is a HIGHER-ORDER
     interaction not modeled by these flat projections). -/
 def toPreferentialContextSet [HasSupport G] (cs : CommitmentSpace W G) :
-    ContextSet W :=
+    Set W :=
   fun w => ∀ ic ∈ cs.root,
     ic.force = .preferential → IndexedWeightedCommitment.toCommitment ic w
 
@@ -539,7 +538,7 @@ def rejectContinuation (s : KrifkaState W) : KrifkaState W :=
 
 /-- Context set: from the commitment space root (= CommonGround), via
     `IndexedCommitment.toCommitment` projection. -/
-def contextSet (s : KrifkaState W) : ContextSet W :=
+def contextSet (s : KrifkaState W) : Set W :=
   s.space.toContextSet
 
 /-- The space has no open continuations. -/
@@ -754,27 +753,24 @@ def applyComplex (s : KrifkaState W) : ComplexSpeechAct W → KrifkaState W
 end KrifkaState
 
 -- ════════════════════════════════════════════════════
--- § 5. HasContextSet Instances
+-- § 5. HasCommonGround Instances
 -- ════════════════════════════════════════════════════
 
-open CommonGround in
-/-- A polymorphic commitment space projects to a context set via its root,
-    using the `[HasSupport G]` typeclass's `support` projection. Recovers
-    the binary case at `G = Prop` definitionally (via `support := id` in
-    the `Prop` instance). -/
+/-- A polymorphic commitment space projects to the principal common ground of
+    its root, using the `[HasSupport G]` typeclass's `support` projection.
+    Recovers the binary case at `G = Prop` definitionally (via `support := id`
+    in the `Prop` instance). -/
 instance {W G : Type*} [HasSupport G] :
-    HasContextSet (CommitmentSpace W G) W where
-  toContextSet := CommitmentSpace.toContextSet
+    HasCommonGround (CommitmentSpace W G) W where
+  commonGround cs := Filter.principal {w | cs.toContextSet w}
 
-open CommonGround in
-/-- A Krifka state projects to a context set via the commitment space root. -/
-instance {W : Type*} : HasContextSet (KrifkaState W) W where
-  toContextSet := KrifkaState.contextSet
+/-- A Krifka state projects via the commitment space root. -/
+instance {W : Type*} : HasCommonGround (KrifkaState W) W where
+  commonGround s := Filter.principal {w | s.contextSet w}
 
-open CommonGround in
-/-- KrifkaState context set agrees with CommitmentSpace context set. -/
-theorem krifkaState_contextSet_eq_space {W : Type*} (s : KrifkaState W) :
-    HasContextSet.toContextSet s = HasContextSet.toContextSet s.space := rfl
+/-- KrifkaState common ground agrees with CommitmentSpace common ground. -/
+theorem krifkaState_commonGround_eq_space {W : Type*} (s : KrifkaState W) :
+    commonGround s = commonGround s.space := rfl
 
 open Discourse.Commitment (IndexedWeightedCommitment)
 
@@ -782,12 +778,19 @@ open Discourse.Commitment (IndexedWeightedCommitment)
     `commit speaker doxastic φ` to the root, whose projection through
     `HasSupport` narrows the context set by exactly `φ`. -/
 instance instHasAssertion {W : Type*} :
-    CommonGround.HasAssertion (KrifkaState W) W where
+    HasAssertion (KrifkaState W) W where
   initial := KrifkaState.empty
   assert s φ := s.assert φ
-  toContextSet_initial :=
-    Set.eq_univ_of_forall fun _ _ hic => absurd hic List.not_mem_nil
-  toContextSet_assert s φ := by
+  commonGround_initial := by
+    have h : {w | (KrifkaState.empty : KrifkaState W).contextSet w} = Set.univ :=
+      Set.eq_univ_of_forall fun _ _ hic => absurd hic List.not_mem_nil
+    show Filter.principal {w | (KrifkaState.empty : KrifkaState W).contextSet w} = ⊤
+    rw [h, Filter.principal_univ]
+  commonGround_assert s φ := by
+    show Filter.principal {w | (s.assert φ).contextSet w} =
+      Filter.principal {w | s.contextSet w} ⊓ _
+    rw [Filter.inf_principal]
+    refine congrArg _ ?_
     ext w
     rw [Set.mem_inter_iff]
     constructor

--- a/Linglib/Discourse/Commitment/Table.lean
+++ b/Linglib/Discourse/Commitment/Table.lean
@@ -26,7 +26,6 @@ commitment slates, and a common ground.
 namespace Discourse.Commitment.Table
 
 open Discourse.Commitment (TaggedSlate CommitmentSource CommitmentForce)
-open CommonGround (HasContextSet)
 open Mood (Illocutionary)
 
 /-- An at-issue item on the conversational table. -/
@@ -49,14 +48,14 @@ structure DiscourseState (A W I : Type*) where
   /-- Per-agent discourse commitments. -/
   dc : A → TaggedSlate W
   /-- The common ground. -/
-  cg : CommonGround W
+  cg : Filter W
 
 namespace DiscourseState
 variable {A W I : Type*}
 
 /-- Initial state: empty table, empty commitments, trivial CommonGround. -/
 def empty : DiscourseState A W I :=
-  ⟨[], fun _ => TaggedSlate.empty, CommonGround.empty⟩
+  ⟨[], fun _ => TaggedSlate.empty, ⊤⟩
 
 instance : Inhabited (DiscourseState A W I) := ⟨empty⟩
 
@@ -67,7 +66,7 @@ instance (s : DiscourseState A W I) : Decidable s.IsStable :=
   inferInstanceAs (Decidable (_ = _))
 
 /-- Worlds compatible with the common ground. -/
-def contextSet (s : DiscourseState A W I) : Set W := s.cg.contextSet
+def contextSet (s : DiscourseState A W I) : Set W := s.cg.ker
 
 /-! ### Commitment accessors
 
@@ -82,10 +81,6 @@ def doxasticOf (s : DiscourseState A W I) (a : A) : List (W → Prop) :=
 def Commits (s : DiscourseState A W I) (a : A) (p : W → Prop) : Prop :=
   p ∈ s.doxasticOf a
 
-/-- The common-ground propositions. -/
-def cgPropositions (s : DiscourseState A W I) : List (Set W) :=
-  s.cg.propositions
-
 /-! ### Primitive updates -/
 
 def pushItem (s : DiscourseState A W I) (i : I) : DiscourseState A W I :=
@@ -95,7 +90,7 @@ def popItem (s : DiscourseState A W I) : DiscourseState A W I :=
   { s with table := s.table.tail }
 
 def addToCG (s : DiscourseState A W I) (p : W → Prop) : DiscourseState A W I :=
-  { s with cg := s.cg.add p }
+  { s with cg := s.cg ⊓ Filter.principal {w | p w} }
 
 /-- Add `(p, src, force)` to agent `a`'s slate. Defaults: self-generated,
     doxastic — the standard assertion-driven cell. -/
@@ -110,7 +105,7 @@ def addCommit [DecidableEq A] (s : DiscourseState A W I) (a : A)
 @[simp] theorem empty_table : (empty : DiscourseState A W I).table = [] := rfl
 @[simp] theorem empty_dc (a : A) :
     (empty : DiscourseState A W I).dc a = TaggedSlate.empty := rfl
-@[simp] theorem empty_cg : (empty : DiscourseState A W I).cg = CommonGround.empty := rfl
+@[simp] theorem empty_cg : (empty : DiscourseState A W I).cg = ⊤ := rfl
 @[simp] theorem empty_isStable : (empty : DiscourseState A W I).IsStable := rfl
 
 @[simp] theorem pushItem_table (s : DiscourseState A W I) (i : I) :
@@ -126,7 +121,7 @@ def addCommit [DecidableEq A] (s : DiscourseState A W I) (a : A)
 @[simp] theorem popItem_cg (s : DiscourseState A W I) : s.popItem.cg = s.cg := rfl
 
 @[simp] theorem addToCG_cg (s : DiscourseState A W I) (p : W → Prop) :
-    (s.addToCG p).cg = s.cg.add p := rfl
+    (s.addToCG p).cg = s.cg ⊓ Filter.principal {w | p w} := rfl
 @[simp] theorem addToCG_table (s : DiscourseState A W I) (p : W → Prop) :
     (s.addToCG p).table = s.table := rfl
 @[simp] theorem addToCG_dc (s : DiscourseState A W I) (p : W → Prop) :
@@ -169,27 +164,25 @@ def addCommit [DecidableEq A] (s : DiscourseState A W I) (a : A)
 @[simp] theorem doxasticOf_popItem (s : DiscourseState A W I) (a : A) :
     s.popItem.doxasticOf a = s.doxasticOf a := rfl
 
-@[simp] theorem cgPropositions_popItem (s : DiscourseState A W I) :
-    s.popItem.cgPropositions = s.cgPropositions := rfl
+
 
 @[simp] theorem doxasticOf_addToCG (s : DiscourseState A W I) (p : W → Prop) (a : A) :
     (s.addToCG p).doxasticOf a = s.doxasticOf a := rfl
 
-@[simp] theorem cgPropositions_addToCG (s : DiscourseState A W I) (p : W → Prop) :
-    (s.addToCG p).cgPropositions = p :: s.cgPropositions := rfl
+theorem mem_cg_addToCG (s : DiscourseState A W I) (p : W → Prop) :
+    {w | p w} ∈ (s.addToCG p).cg :=
+  Filter.le_principal_iff.1 inf_le_right
 
-@[simp] theorem cgPropositions_addCommit [DecidableEq A] (s : DiscourseState A W I)
+@[simp] theorem cg_addCommit [DecidableEq A] (s : DiscourseState A W I)
     (a : A) (p : W → Prop) (src : CommitmentSource) (force : CommitmentForce) :
-    (s.addCommit a p src force).cgPropositions = s.cgPropositions := rfl
+    (s.addCommit a p src force).cg = s.cg := rfl
 
-@[simp] theorem cgPropositions_pushItem (s : DiscourseState A W I) (i : I) :
-    (s.pushItem i).cgPropositions = s.cgPropositions := rfl
+
 
 @[simp] theorem empty_doxasticOf (a : A) :
     (empty : DiscourseState A W I).doxasticOf a = [] := rfl
 
-@[simp] theorem empty_cgPropositions :
-    (empty : DiscourseState A W I).cgPropositions = [] := rfl
+
 
 theorem pushItem_not_isStable (s : DiscourseState A W I) (i : I) :
     ¬ (s.pushItem i).IsStable := by
@@ -197,8 +190,8 @@ theorem pushItem_not_isStable (s : DiscourseState A W I) (i : I) :
 
 end DiscourseState
 
-instance {A W I : Type*} : HasContextSet (DiscourseState A W I) W where
-  toContextSet := DiscourseState.contextSet
+instance {A W I : Type*} : HasCommonGround (DiscourseState A W I) W where
+  commonGround s := s.cg
 
 /-- The full Farkas-Bruce model: the table holds rich speech-act `Item`s. -/
 abbrev ItemState (A W : Type*) := DiscourseState A W (Item A W)
@@ -274,7 +267,7 @@ theorem polarQuestion_not_isStable (ds : State W) (p : W → Prop) :
   DiscourseState.pushItem_not_isStable _ _
 
 theorem accept_after_assert_cg (ds : State W) (p : W → Prop) :
-    (acceptTop (assert ds p)).cg = ds.cg.add p := by
+    (acceptTop (assert ds p)).cg = ds.cg ⊓ Filter.principal {w | p w} := by
   show (acceptTop (assert ds p)).cg = _
   unfold acceptTop
   rw [show (assert ds p).table =
@@ -288,8 +281,7 @@ theorem accept_after_assert_cg (ds : State W) (p : W → Prop) :
     (assert ds p).dcS = p :: ds.dcS := rfl
 @[simp] theorem assert_dcL (ds : State W) (p : W → Prop) :
     (assert ds p).dcL = ds.dcL := rfl
-@[simp] theorem assert_cgPropositions (ds : State W) (p : W → Prop) :
-    (assert ds p).cgPropositions = ds.cgPropositions := rfl
+
 @[simp] theorem polarQuestion_dcS (ds : State W) (p : W → Prop) :
     (polarQuestion ds p).dcS = ds.dcS := rfl
 @[simp] theorem polarQuestion_dcL (ds : State W) (p : W → Prop) :
@@ -300,13 +292,10 @@ theorem accept_after_assert_cg (ds : State W) (p : W → Prop) :
     (ds.pushItem i).dcL = ds.dcL := rfl
 
 /-- After asserting `p` and accepting it, `p` reaches the common ground. -/
-@[simp] theorem accept_after_assert_cgPropositions (ds : State W) (p : W → Prop) :
-    (acceptTop (assert ds p)).cgPropositions = p :: ds.cgPropositions := by
-  show (acceptTop (assert ds p)).cg.propositions = _
-  unfold acceptTop
-  rw [show (assert ds p).table =
-      ⟨.speaker, .addressee, .declarative, [p]⟩ :: ds.table from rfl]
-  rfl
+theorem accept_after_assert_mem_cg (ds : State W) (p : W → Prop) :
+    {w | p w} ∈ (acceptTop (assert ds p)).cg := by
+  rw [accept_after_assert_cg]
+  exact Filter.le_principal_iff.1 inf_le_right
 
 /-- Acceptance adds `p` to the addressee's commitments. -/
 @[simp] theorem accept_after_assert_dcL (ds : State W) (p : W → Prop) :

--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -1,244 +1,148 @@
-import Mathlib.Data.Set.Basic
-import Mathlib.Data.List.Perm.Basic
+import Mathlib.Order.Filter.Ker
 
 /-!
-# Common Ground
+# Common ground
 
-Stalnakerian context management ([stalnaker-1973], [stalnaker-1974],
-[stalnaker-1978], [stalnaker-2002]): context sets and their update, common
-ground as proposition lists, and the interfaces connecting discourse-state
-representations to both.
+The common ground of a conversation is the **filter** of propositions the interlocutors
+mutually accept ([stalnaker-1978], [stalnaker-2002]; independently
+[karttunen-1974-presupposition]): acceptance is closed under entailment
+and finite conjunction and contains the trivial proposition, which are exactly the filter
+axioms (in modal-logic terms: "every augmented model is a filter", [chellas-1980] §7.3;
+in belief-revision terms, a deductively closed belief set, [gardenfors-1988]). Stalnaker's
+**context set** — the worlds compatible with everything accepted — is the kernel
+`Filter.ker`, [chellas-1980]'s smallest proposition `⋂ Nα`, and a bare context set
+`cs : Set W` is the principal common ground `𝓟 cs`, with acceptance `p ∈ 𝓟 cs ↔ cs ⊆ p`
+(`Filter.mem_principal`); `Filter.giPrincipalKer` is the two-sidedness of this duality, and
+the principal (augmented) case is exactly the Kripke case ([chellas-1980] Theorem 7.9).
+**Assertion** of `φ` is `· ⊓ 𝓟 φ` ([stalnaker-1978]):
+intersective update of the context set is `Filter.ker_inf`, and commutativity and
+idempotence of assertion are lattice laws. A **consistent** context is a `Filter.NeBot`;
+the absurd context is `⊥`.
+
+`HasCommonGround` and `HasAssertion` connect richer discourse-state representations
+(commitment slates, gameboards, probabilistic states) to this projection.
+
+## Implementation notes
+
+The filter axioms are the body-of-information view of the common ground and deliberately
+carry no epistemology: whether what grounds them is iterated common belief
+([stalnaker-2002]) or common acceptance as a primitive ([stalnaker-2014]) is stated
+separately, as `Filter.GroundedIn` in `Logic/Modal/Epistemic.lean` — the epistemology, and
+in particular closure of acceptance under conjunction (the filter's `inter_sets`), is the
+contested idealization in that debate, not a commitment every consumer inherits.
+Proposal-based ([farkas-bruce-2010]) and graded non-monotonic ([anderson-2021]) assertion
+models are deliberate non-instances of `HasAssertion`; see
+`FarkasBruce2010.assert_not_narrowing` and `Anderson2021.graded_update_keeps_false_world`.
 
 ## Main definitions
 
-* `ContextSet W` — worlds compatible with the context (a synonym for
-  `Set W`), with `ContextSet.update`.
-* `CommonGround W` — common ground as a list of propositions.
-* `CommonGround.HasContextSet` — extraction of a context set from a
-  discourse state.
-* `CommonGround.HasAssertion` — discourse states whose assertion operation
-  projects onto `ContextSet.update` ([stalnaker-1973] p. 455); a played
-  history lands on the free model (`toContextSet_play`) and its projection
-  is permutation-invariant (`toContextSet_play_perm`).
+* `HasCommonGround`: discourse states projecting to a common ground `Filter W`, with the
+  derived `contextSet`.
+* `HasAssertion`: discourse states with a Stalnakerian `assert`, projecting to `· ⊓ 𝓟 φ`,
+  and assertion histories `HasAssertion.play`.
 
-Proposal-based ([farkas-bruce-2010]) and graded non-monotonic
-([anderson-2021]) assertion models are deliberate non-instances; see
-`FarkasBruce2010.assert_not_narrowing` and
-`Anderson2021.graded_update_keeps_false_world`.
+## Main results
+
+* `HasAssertion.contextSet_assert`: assertion intersects the context set by exactly the
+  asserted proposition ([stalnaker-1973] p. 455).
+* `HasAssertion.commonGround_play`: a played history lands on the principal filter of the
+  history's intersection ([stalnaker-1973] p. 450's duality map), so the projection is
+  permutation-invariant (`commonGround_play_perm`) — states may record assertion order,
+  but the common ground cannot.
 -/
 
-/-- Common ground as a list of mutually believed propositions. -/
-structure CommonGround (W : Type*) where
-  /-- The propositions in the common ground. -/
-  propositions : List (Set W)
-
-namespace CommonGround
+open Filter Set
 
 variable {W : Type*}
 
-/-- The set of worlds compatible with the common ground. -/
-abbrev ContextSet (W : Type*) := Set W
+/-! ### Discourse states and their common ground -/
 
-namespace ContextSet
+/-- A discourse state projecting to a common ground: the filter of propositions the
+interlocutors mutually accept at that state. -/
+class HasCommonGround (S : Type*) (W : outParam Type*) where
+  /-- The common ground of the state. -/
+  commonGround : S → Filter W
 
-/-- The trivial context: all worlds possible. Alias for `Set.univ`. -/
-abbrev trivial : ContextSet W := Set.univ
+export HasCommonGround (commonGround)
 
-/-- Entailment: every world in the context satisfies the proposition. -/
-abbrev entails (c : ContextSet W) (p : Set W) : Prop := c ⊆ p
+/-- The context set of a discourse state: the worlds compatible with everything accepted. -/
+def HasCommonGround.contextSet {S : Type*} [HasCommonGround S W] (s : S) : Set W :=
+  (commonGround s).ker
 
-/-- Compatibility: some world in the context satisfies the proposition. -/
-abbrev compatible (c : ContextSet W) (p : Set W) : Prop := (c ∩ p).Nonempty
+/-- A filter is its own common ground. -/
+instance : HasCommonGround (Filter W) W := ⟨id⟩
 
-/-- Update: keep only worlds where the proposition holds. Alias for `(· ∩ ·)`. -/
-abbrev update (c : ContextSet W) (p : Set W) : ContextSet W := c ∩ p
-
-/-- Updated context is contained in the original. -/
-theorem update_restricts (c : ContextSet W) (p : Set W) : update c p ⊆ c :=
-  Set.inter_subset_left
-
-/-- Successive updates commute: assertion order is irrelevant. -/
-theorem update_comm (c p q : Set W) :
-    update (update c p) q = update (update c q) p :=
-  Set.inter_right_comm c p q
-
-/-- Updating twice with the same proposition is updating once. -/
-theorem update_idem (c p : Set W) : update (update c p) p = update c p := by
-  simp [update, Set.inter_assoc]
-
-end ContextSet
-
-/-- The context set determined by a common ground: intersection of its propositions. -/
-def contextSet (cg : CommonGround W) : ContextSet W :=
-  cg.propositions.foldr (· ∩ ·) Set.univ
-
-/-- Add a proposition to the common ground. -/
-def add (cg : CommonGround W) (p : Set W) : CommonGround W :=
-  { propositions := p :: cg.propositions }
-
-/-- Empty common ground (no shared beliefs). -/
-def empty : CommonGround W := { propositions := [] }
-
-instance : Inhabited (CommonGround W) := ⟨empty⟩
-
-/-- Empty common ground gives the trivial (universal) context set. -/
-@[simp] theorem empty_contextSet : (empty : CommonGround W).contextSet = Set.univ := rfl
-
-/-- Adding a proposition intersects it into the context set. -/
-@[simp] theorem contextSet_add (cg : CommonGround W) (p : Set W) :
-    (cg.add p).contextSet = p ∩ cg.contextSet := rfl
-
-/-- Adding a proposition restricts the context set. -/
-theorem add_restricts (cg : CommonGround W) (p : Set W) :
-    (cg.add p).contextSet ⊆ cg.contextSet :=
-  Set.inter_subset_right
-
-instance : LeftCommutative (α := Set W) (· ∩ ·) := ⟨Set.inter_left_comm⟩
-
-/-- The context set is invariant under permutation of the propositions:
-    the common ground is order-indifferent on its worlds-side projection. -/
-theorem contextSet_perm {l₁ l₂ : List (Set W)} (p : l₁.Perm l₂) :
-    contextSet ⟨l₁⟩ = contextSet ⟨l₂⟩ :=
-  p.foldr_eq Set.univ
-
-/-! ### Uniform context-set extraction -/
-
-/-- A discourse state from which a context set can be extracted. -/
-class HasContextSet (S : Type*) (W : outParam Type*) where
-  toContextSet : S → ContextSet W
-
-namespace HasContextSet
-
-variable {S : Type*} [HasContextSet S W]
-
-/-- A discourse state entails a proposition if its context set does. -/
-abbrev entails (s : S) (p : Set W) : Prop := toContextSet s ⊆ p
-
-/-- Updating a discourse state's context set with a proposition. -/
-abbrev updateCS (s : S) (p : Set W) : ContextSet W := toContextSet s ∩ p
-
-end HasContextSet
-
-/-! ### Canonical instances -/
-
-instance : HasContextSet (ContextSet W) W where
-  toContextSet := id
-
-instance : HasContextSet (CommonGround W) W where
-  toContextSet := contextSet
-
-/-- The `CommonGround` instance agrees with `CommonGround.contextSet`. -/
-@[simp] theorem hasContextSet_commonGround_eq (cg : CommonGround W) :
-    HasContextSet.toContextSet cg = cg.contextSet := rfl
-
-/-- Adding to the common ground restricts the `HasContextSet` extraction. -/
-theorem hasContextSet_add_restricts (cg : CommonGround W) (p : Set W) :
-    HasContextSet.toContextSet (cg.add p) ⊆ HasContextSet.toContextSet cg :=
-  add_restricts cg p
+@[simp] theorem HasCommonGround.commonGround_filter (f : Filter W) : commonGround f = f := rfl
 
 /-! ### Stalnakerian assertion -/
 
-/-- A discourse state with a Stalnakerian `assert`: the projected context
-    set updates by exactly the asserted proposition ([stalnaker-1978]). -/
-class HasAssertion (S : Type*) (W : outParam Type*)
-    extends HasContextSet S W where
+/-- A discourse state with a Stalnakerian `assert`: the projected common ground grows by
+exactly the asserted proposition ([stalnaker-1978]). -/
+class HasAssertion (S : Type*) (W : outParam Type*) extends HasCommonGround S W where
   /-- The initial dialogue state. -/
   initial : S
-  /-- Assert φ. -/
+  /-- Assert `φ`. -/
   assert : S → Set W → S
-  /-- Nothing is presupposed initially: every world is live. -/
-  toContextSet_initial : toContextSet initial = ContextSet.trivial
-  /-- Assertion narrows the projected context set by exactly `φ`. -/
-  toContextSet_assert : ∀ (s : S) (φ : Set W),
-    toContextSet (assert s φ) = ContextSet.update (toContextSet s) φ
+  /-- Nothing is presupposed initially. -/
+  commonGround_initial : commonGround initial = ⊤
+  /-- Assertion adds exactly `φ` to the common ground. -/
+  commonGround_assert : ∀ (s : S) (φ : Set W), commonGround (assert s φ) = commonGround s ⊓ 𝓟 φ
+
+/-- The regular model: a common ground asserted-into by `· ⊓ 𝓟 φ`. Every `HasAssertion`
+state projects onto this flow. -/
+instance : HasAssertion (Filter W) W where
+  initial := ⊤
+  assert f φ := f ⊓ 𝓟 φ
+  commonGround_initial := rfl
+  commonGround_assert _ _ := rfl
 
 namespace HasAssertion
 
-open HasContextSet (toContextSet)
+open HasCommonGround (contextSet)
 
 variable {S : Type*} [HasAssertion S W] (s : S) (φ ψ : Set W)
 
-/-- Contraction: assertion only removes worlds. -/
-theorem assert_subset_prior :
-    toContextSet (assert s φ) ⊆ toContextSet s :=
-  toContextSet_assert s φ ▸ ContextSet.update_restricts _ φ
+attribute [simp] commonGround_initial commonGround_assert
 
-/-- Narrowing: every surviving world satisfies the asserted proposition. -/
-theorem assert_narrows :
-    toContextSet (assert s φ) ⊆ φ :=
-  toContextSet_assert s φ ▸ Set.inter_subset_right
+/-- The asserted proposition is accepted. -/
+theorem mem_commonGround_assert : φ ∈ commonGround (assert s φ) := by
+  simp [le_principal_iff.1 inf_le_right]
 
-/-- Membership in the post-assertion context set, characterized. -/
-theorem mem_assert {s : S} {φ : Set W} {w : W} :
-    w ∈ toContextSet (assert s φ) ↔ w ∈ toContextSet s ∧ w ∈ φ := by
-  rw [toContextSet_assert]; exact Set.mem_inter_iff ..
+/-- Assertion strengthens the common ground. -/
+theorem commonGround_assert_le : commonGround (assert s φ) ≤ commonGround s := by
+  simp [inf_le_left]
 
-/-- Asserting φ in the initial context yields exactly φ. -/
-@[simp] theorem assert_initial :
-    toContextSet (assert (initial : S) φ) = φ := by
-  rw [toContextSet_assert, toContextSet_initial]
-  exact Set.univ_inter φ
+/-- Assertion intersects the context set by exactly the asserted proposition
+([stalnaker-1973] p. 455). -/
+@[simp] theorem contextSet_assert : contextSet (assert s φ) = contextSet s ∩ φ := by
+  simp [contextSet, HasCommonGround.contextSet]
 
-/-- Assertion order is irrelevant on the projected context set. -/
-theorem assert_comm :
-    toContextSet (assert (assert s φ) ψ) =
-      toContextSet (assert (assert s ψ) φ) := by
-  simp only [toContextSet_assert]
-  exact ContextSet.update_comm _ φ ψ
+/-- Asserting in the initial state yields the principal common ground. -/
+@[simp] theorem commonGround_assert_initial :
+    commonGround (assert (initial : S) φ) = 𝓟 φ := by simp
 
-/-- Re-asserting φ does not change the projected context set. -/
-theorem assert_idem :
-    toContextSet (assert (assert s φ) φ) =
-      toContextSet (assert s φ) := by
-  simp only [toContextSet_assert]
-  exact ContextSet.update_idem _ φ
+/-- Two consecutive assertions add the conjunction. -/
+theorem commonGround_assert_assert :
+    commonGround (assert (assert s φ) ψ) = commonGround s ⊓ 𝓟 (φ ∩ ψ) := by
+  simp [inf_assoc, inf_principal]
 
-/-- Asserting what the state already entails is a no-op on the projected
-    context set ([stalnaker-1973] p. 454). -/
-theorem assert_of_entails (h : toContextSet s ⊆ φ) :
-    toContextSet (assert s φ) = toContextSet s := by
-  rw [toContextSet_assert]
-  exact Set.inter_eq_left.mpr h
+/-- Assertion order is irrelevant on the common ground. -/
+theorem commonGround_assert_comm :
+    commonGround (assert (assert s φ) ψ) = commonGround (assert (assert s ψ) φ) := by
+  simp only [commonGround_assert_assert, inter_comm]
 
-/-- Two consecutive assertions narrow the context set by the conjunction. -/
-theorem assert_twice :
-    toContextSet (assert (assert s φ) ψ) =
-      toContextSet s ∩ φ ∩ ψ := by
-  rw [toContextSet_assert, toContextSet_assert]
+/-- Re-assertion is a no-op on the common ground. -/
+theorem commonGround_assert_idem :
+    commonGround (assert (assert s φ) φ) = commonGround (assert s φ) := by
+  simp
 
-/-- Two consecutive assertions land inside the conjunction. -/
-theorem assert_twice_narrows :
-    toContextSet (assert (assert s φ) ψ) ⊆ φ ∩ ψ := by
-  rw [assert_twice]
-  exact Set.subset_inter (Set.inter_subset_left.trans Set.inter_subset_right)
-    Set.inter_subset_right
-
-end HasAssertion
-
-/-- The regular model: the context set itself, asserted-into by `update`.
-    Every `HasAssertion` state projects onto this flow. -/
-instance : HasAssertion (ContextSet W) W where
-  initial := ContextSet.trivial
-  assert := ContextSet.update
-  toContextSet_initial := rfl
-  toContextSet_assert _ _ := rfl
-
-/-- The free model: proposition lists, asserted-into by `add`; the
-    projection is `contextSet` ([stalnaker-1973] p. 450's duality map).
-    This IS the bare Stalnakerian framework ([stalnaker-1978]). -/
-instance : HasAssertion (CommonGround W) W where
-  initial := empty
-  assert cg φ := cg.add φ
-  toContextSet_initial := rfl
-  toContextSet_assert _ φ := Set.inter_comm φ _
+/-- Asserting what is already accepted is a no-op on the common ground
+([stalnaker-1973] p. 454). -/
+theorem commonGround_assert_of_mem (h : φ ∈ commonGround s) :
+    commonGround (assert s φ) = commonGround s := by
+  simp [inf_eq_left.2 (le_principal_iff.2 h)]
 
 /-! ### Assertion histories -/
-
-namespace HasAssertion
-
-open HasContextSet (toContextSet)
-
-variable {S : Type*} [HasAssertion S W]
 
 /-- Play a history of assertions from a state. -/
 def play (s : S) (h : List (Set W)) : S :=
@@ -249,31 +153,29 @@ def play (s : S) (h : List (Set W)) : S :=
 @[simp] theorem play_cons (s : S) (φ : Set W) (t : List (Set W)) :
     play s (φ :: t) = play (assert s φ) t := rfl
 
-/-- The context set of a played history is the common ground of that
-    history: `play` from `initial` lands on the free model
-    ([stalnaker-1973] p. 450). -/
-theorem toContextSet_play (h : List (Set W)) :
-    toContextSet (play (initial : S) h) = contextSet ⟨h⟩ := by
-  suffices key : ∀ s : S,
-      toContextSet (play s h) = toContextSet s ∩ contextSet ⟨h⟩ by
-    rw [key, toContextSet_initial]
-    exact Set.univ_inter _
-  induction h with
-  | nil => intro s; exact (Set.inter_univ _).symm
+/-- A played history adds the principal filter of the history's intersection. -/
+theorem commonGround_play (h : List (Set W)) (s : S) :
+    commonGround (play s h) = commonGround s ⊓ 𝓟 {w | ∀ p ∈ h, w ∈ p} := by
+  induction h generalizing s with
+  | nil => simp
   | cons φ t ih =>
-    intro s
-    rw [play_cons, ih, toContextSet_assert]
-    exact Set.inter_assoc ..
+    have h : φ ∩ {w | ∀ p ∈ t, w ∈ p} = {w | ∀ p ∈ φ :: t, w ∈ p} := by
+      ext w
+      simp
+    rw [play_cons, ih, commonGround_assert, inf_assoc, inf_principal, h]
 
-/-- Assertion order is irrelevant: permuted histories project to the
-    same context set. States may differ — frameworks can record order —
-    but the projection cannot. -/
-theorem toContextSet_play_perm {h₁ h₂ : List (Set W)} (p : h₁.Perm h₂) :
-    toContextSet (play (initial : S) h₁) =
-      toContextSet (play (initial : S) h₂) := by
-  rw [toContextSet_play, toContextSet_play]
-  exact contextSet_perm p
+/-- From the initial state, a played history *is* its common ground: the free model of
+Stalnakerian assertion ([stalnaker-1973] p. 450). -/
+theorem commonGround_play_initial (h : List (Set W)) :
+    commonGround (play (initial : S) h) = 𝓟 {w | ∀ p ∈ h, w ∈ p} := by
+  simp [commonGround_play]
+
+/-- Assertion order is irrelevant: permuted histories project to the same common ground.
+States may differ — frameworks can record order — but the projection cannot. -/
+theorem commonGround_play_perm {h₁ h₂ : List (Set W)} (p : h₁.Perm h₂) :
+    commonGround (play (initial : S) h₁) = commonGround (play (initial : S) h₂) := by
+  simp only [commonGround_play_initial]
+  exact congrArg _ (Set.ext fun w => ⟨fun h q hq => h q (p.mem_iff.2 hq),
+    fun h q hq => h q (p.mem_iff.1 hq)⟩)
 
 end HasAssertion
-
-end CommonGround

--- a/Linglib/Discourse/Gameboard/Basic.lean
+++ b/Linglib/Discourse/Gameboard/Basic.lean
@@ -8,7 +8,7 @@ import Linglib.Semantics.Questions.Support
 
 Operations on the Dialogue Gameboard: pushing onto QUD, downdating
 resolved questions, recording moves, asserting facts. Plus the
-`HasContextSet` bridge connecting DGB facts to the standard common
+`HasCommonGround` bridge connecting DGB facts to the standard common
 ground type, the `non-resolve-cond` well-formedness check, and the
 partition-based answerhood predicate `PropResolvesQUD`.
 
@@ -17,7 +17,7 @@ partition-based answerhood predicate `PropResolvesQUD`.
 - §1. DGB structural lemmas (initial state)
 - §2. DGB update operations: pushQud, downdateQud, addFact, recordMove, assertFact
 - §3. DGB content mapping: mapFacts, mapQud
-- §4. HasContextSet bridge to CommonGround
+- §4. HasCommonGround bridge to the common ground
 - §5. QUD downdate properties + non-resolve-cond well-formedness
 - §6. Partition-based answerhood (`PropResolvesQUD`)
 
@@ -100,27 +100,24 @@ def DGB.assertFact {P Fact QContent : Type*} {Cont : Type} [DecidableSupport Fac
   (dgb.addFact p).downdateQud
 
 -- ════════════════════════════════════════════════════
--- § 3. HasContextSet Bridge
+-- § 3. HasCommonGround Bridge
 -- ════════════════════════════════════════════════════
 
-open CommonGround in
-/-- DGB with `Set W` facts projects to a context set.
+/-- DGB with `Set W` facts projects to a common ground.
     [ginzburg-2012] Ch. 4: the DGB's FACTS field IS the common ground. -/
 instance {W Participant QContent : Type*} {Cont : Type} :
-    HasContextSet (DGB Participant (Set W) QContent Cont) W where
-  toContextSet dgb := λ w => ∀ p ∈ dgb.facts, p w
+    HasCommonGround (DGB Participant (Set W) QContent Cont) W where
+  commonGround dgb := Filter.principal fun w => ∀ p ∈ dgb.facts, p w
 
-open CommonGround in
-/-- TIS with `Set W` facts inherits the DGB's context set. -/
+/-- TIS with `Set W` facts inherits the DGB's common ground. -/
 instance {W Participant QContent : Type*} {Cont : Type} :
-    HasContextSet (TIS Participant (Set W) QContent Cont) W where
-  toContextSet tis := λ w => ∀ p ∈ tis.dgb.facts, p w
+    HasCommonGround (TIS Participant (Set W) QContent Cont) W where
+  commonGround tis := Filter.principal fun w => ∀ p ∈ tis.dgb.facts, p w
 
-open CommonGround in
-/-- TIS context set is extracted from the DGB. -/
-theorem tis_contextSet_eq_dgb {W Participant QContent : Type*} {Cont : Type}
+/-- TIS common ground is extracted from the DGB. -/
+theorem tis_commonGround_eq_dgb {W Participant QContent : Type*} {Cont : Type}
     (tis : TIS Participant (Set W) QContent Cont) :
-    HasContextSet.toContextSet tis = HasContextSet.toContextSet tis.dgb := rfl
+    commonGround tis = commonGround tis.dgb := rfl
 
 -- ════════════════════════════════════════════════════
 -- § 4. QUD Downdate Properties + Non-Resolve-Cond

--- a/Linglib/Discourse/QUD/Issue.lean
+++ b/Linglib/Discourse/QUD/Issue.lean
@@ -6,7 +6,7 @@ import Linglib.Semantics.Questions.Basic
 [ciardelli-groenendijk-roelofsen-2018]
 
 The issue-side observable on discourse states: `HasIssue` extracts the
-current issue (a `Question W`) the way `CommonGround.HasContextSet`
+current issue (a `Question W`) the way `HasCommonGround`
 extracts the context set. In inquisitive pragmatics the context is an
 issue and the context set is its informative content
 ([ciardelli-groenendijk-roelofsen-2018]); frameworks tracking both

--- a/Linglib/Logic/Modal/Epistemic.lean
+++ b/Linglib/Logic/Modal/Epistemic.lean
@@ -19,7 +19,7 @@ Belief is the same operator over a KD45 frame (`ModalLogic.IsKD45Frame`), with t
 
 * `knows`, `everyoneKnows`, `distributedKnowledge`, `commonKnowledge`: `Kᵢ`, `E_G`, `D_G`,
   `C_G`.
-* `CommonGround.GroundedIn`: a common ground whose context set is exactly what is common
+* `Filter.GroundedIn`: a common ground whose context set is exactly what is common
   knowledge ([stalnaker-2002]).
 
 ## Main results
@@ -91,14 +91,14 @@ theorem commonKnowledge_iff_forall_iterate :
 
 end ModalLogic.Epistemic
 
-namespace CommonGround
+namespace Filter
 
 variable {W E : Type*}
 
-/-- A common ground is grounded in common knowledge when its context set is exactly the set
-of worlds where each of its propositions is common knowledge among `G` ([stalnaker-2002]). -/
-def GroundedIn (cg : CommonGround W) (Rs : E → W → W → Prop) (G : Set E) : Prop :=
-  ∀ w, w ∈ cg.contextSet ↔
-    ∀ p ∈ cg.propositions, ModalLogic.Epistemic.commonKnowledge Rs G (· ∈ p) w
+/-- A common ground `cg : Filter W` is grounded in common knowledge when its context set
+`cg.ker` is exactly the set of worlds where each accepted proposition is common knowledge
+among `G` ([stalnaker-2002]). -/
+def GroundedIn (cg : Filter W) (Rs : E → W → W → Prop) (G : Set E) : Prop :=
+  ∀ w, w ∈ cg.ker ↔ ∀ p ∈ cg, ModalLogic.Epistemic.commonKnowledge Rs G (· ∈ p) w
 
-end CommonGround
+end Filter

--- a/Linglib/Semantics/Conditionals/ConditionalType.lean
+++ b/Linglib/Semantics/Conditionals/ConditionalType.lean
@@ -89,7 +89,7 @@ antecedent grounded in prior discourse.
 def echoesDiscourse {W : Type*} (ds : State W) (p : Set W)
     (worlds : List W) : Prop :=
   (∃ q ∈ ds.dcS, ∀ w ∈ worlds, q w → p w) ∨
-  (∃ q ∈ ds.cgPropositions,  ∀ w ∈ worlds, q w → p w)
+  (∃ q ∈ ds.cg, ∀ w ∈ worlds, w ∈ q → p w)
 
 /--
 Weaker echo check: proposition is merely consistent with discourse.

--- a/Linglib/Semantics/Conditionals/Stalnaker.lean
+++ b/Linglib/Semantics/Conditionals/Stalnaker.lean
@@ -58,7 +58,6 @@ equivalence within an appropriate context (the
 
 namespace Semantics.Conditionals
 
-open CommonGround (ContextSet)
 open Mood (Grammatical)
 open _root_.Semantics.Conditionals (SelectionFunction selectionPrefers)
 open Semantics.Conditionals (SimilarityOrdering)
@@ -102,7 +101,7 @@ The central new contribution of [stalnaker-1975]: it makes
 indicative inference forms behave the way they do, without changing
 the semantic clause. -/
 def pragmaticConstraint {W : Type*} (s : SelectionFunction W)
-    (C : ContextSet W) : Prop :=
+    (C : Set W) : Prop :=
   ∀ w (A : Set W), C w → (∃ w' ∈ A, C w') → C (s.sel w A)
 
 /-- **Mooded conditional** ([stalnaker-1975]): the truth-conditional
@@ -139,19 +138,19 @@ This makes "indicative vs subjunctive" a property of the
 *selection-function / context pairing*, not a separate semantic
 operator. -/
 def Mood.admissibleSelection {W : Type*} (m : Grammatical) (s : SelectionFunction W)
-    (C : ContextSet W) : Prop :=
+    (C : Set W) : Prop :=
   match m with
   | .indicative  => pragmaticConstraint s C
   | .subjunctive => True
 
 /-- Indicative admissibility unfolds to the pragmatic constraint. -/
 theorem admissibleSelection_indicative {W : Type*} (s : SelectionFunction W)
-    (C : ContextSet W) :
+    (C : Set W) :
     Mood.admissibleSelection .indicative s C = pragmaticConstraint s C := rfl
 
 /-- Subjunctive admissibility imposes no constraint. -/
 theorem admissibleSelection_subjunctive {W : Type*} (s : SelectionFunction W)
-    (C : ContextSet W) :
+    (C : Set W) :
     Mood.admissibleSelection .subjunctive s C = True := rfl
 
 /-- **Mood is irrelevant to the truth-conditional clause**
@@ -180,7 +179,7 @@ Hypotheses encode the "appropriate context" conditions:
 - `h_constraint`: `s` obeys the pragmatic constraint relative to `C`;
 - `h_C_imp`: in the context, the material conditional holds. -/
 theorem selectionConditional_eq_material_within_context {W : Type*}
-    (s : SelectionFunction W) (C : ContextSet W) (p q : W → Prop) (w : W)
+    (s : SelectionFunction W) (C : Set W) (p q : W → Prop) (w : W)
     (hC_w : C w)
     (h_open_p : ∃ w' ∈ {w' | p w'}, C w')
     (h_constraint : pragmaticConstraint s C)
@@ -200,7 +199,7 @@ theorem selectionConditional_eq_material_within_context {W : Type*}
 the selection function is admissible, the mooded conditional reduces
 to the material conditional within the context. -/
 theorem moodedConditional_indicative_eq_material_within_context {W : Type*}
-    (s : SelectionFunction W) (C : ContextSet W) (p q : W → Prop) (w : W)
+    (s : SelectionFunction W) (C : Set W) (p q : W → Prop) (w : W)
     (hC_w : C w)
     (h_open_p : ∃ w' ∈ {w' | p w'}, C w')
     (h_admissible : Mood.admissibleSelection .indicative s C)

--- a/Linglib/Semantics/Focus/Control.lean
+++ b/Linglib/Semantics/Focus/Control.lean
@@ -34,7 +34,7 @@ over finite models `decide`-friendly; the inquisitive layer plugs in
 via `Antecedent.ofQuestion` and `Question.alt`, with
 `alt_which_singleton` identifying the two Hamblin constructions. The
 `assertion` payload is a raw prior proposition; the
-`Discourse.CommonGround.HasAssertion` hookup (a correction/denial
+`HasAssertion` hookup (a correction/denial
 move) is deferred.
 -/
 

--- a/Linglib/Semantics/Presupposition/Accommodation.lean
+++ b/Linglib/Semantics/Presupposition/Accommodation.lean
@@ -39,7 +39,6 @@ namespace Semantics.Presupposition.Accommodation
 
 open Classical
 open Semantics.Presupposition
-open CommonGround
 open Semantics.Presupposition.Context
 
 variable {W : Type*}
@@ -65,7 +64,7 @@ inductive AccommodationLevel where
  [lewis-1979]: "presupposition P comes into existence."
 
  Delegates to `Semantics.Presupposition.Context.accommodate`. -/
-abbrev globalAccommodate (c : ContextSet W) (presup : Set W) : ContextSet W :=
+abbrev globalAccommodate (c : Set W) (presup : Set W) : Set W :=
  accommodate c presup
 
 /-! ### Accommodation constraints -/
@@ -86,7 +85,7 @@ instance (bindingDepth : Nat) : DecidablePred (isTrapped bindingDepth) := fun l 
 
 /-- All constraints bundled together.
  Uses canonical operations from `Semantics.Presupposition.Context`. -/
-structure AccommodationOK (c : ContextSet W) (presup : Set W) : Prop where
+structure AccommodationOK (c : Set W) (presup : Set W) : Prop where
  informative : accommodationInformative c presup
  consistent : accommodationConsistent c presup
 
@@ -100,7 +99,7 @@ structure AccommodationOK (c : ContextSet W) (presup : Set W) : Prop where
  for global over local accommodation, we recapture the effect of
  Gazdar's assumption that presupposition cancellation occurs only
  under the threat of inconsistency." -/
-noncomputable def heimSelect (c : ContextSet W) (presup : Set W) :
+noncomputable def heimSelect (c : Set W) (presup : Set W) :
  AccommodationLevel :=
  if Set.Nonempty (globalAccommodate c presup)
  then .global
@@ -118,14 +117,14 @@ noncomputable def heimSelect (c : ContextSet W) (presup : Set W) :
  [beaver-2001] Ch. 5.8.1: "with one short remark buried in a
  terse paper, Heim offers a simple synthesis between the two antitheses
  of 1970s presupposition theory." -/
-theorem heim_cancellation_equivalence (c : ContextSet W) (presup : Set W)
+theorem heim_cancellation_equivalence (c : Set W) (presup : Set W)
  (h_inconsistent : ¬Set.Nonempty (globalAccommodate c presup)) :
  heimSelect c presup = .local := by
  simp only [heimSelect, h_inconsistent, ↓reduceIte]
 
 /-- When global accommodation IS consistent, Heim's strategy projects
  the presupposition globally — matching Karttunen's projection. -/
-theorem heim_projection_when_consistent (c : ContextSet W) (presup : Set W)
+theorem heim_projection_when_consistent (c : Set W) (presup : Set W)
  (h_consistent : Set.Nonempty (globalAccommodate c presup)) :
  heimSelect c presup = .global := by
  simp only [heimSelect, h_consistent, ↓reduceIte]
@@ -140,7 +139,7 @@ theorem heim_projection_when_consistent (c : ContextSet W) (presup : Set W)
 
  This is formalized as: the Heim preference strategy never selects
  intermediate accommodation. -/
-theorem heim_never_intermediate (c : ContextSet W) (presup : Set W) :
+theorem heim_never_intermediate (c : Set W) (presup : Set W) :
  ∀ d, heimSelect c presup ≠ .intermediate d := by
  intro d
  by_cases h : Set.Nonempty (globalAccommodate c presup)

--- a/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
+++ b/Linglib/Semantics/Presupposition/BeliefEmbedding.lean
@@ -24,7 +24,6 @@ the attitude holder).
 namespace Semantics.Presupposition.BeliefEmbedding
 
 open Semantics.Presupposition
-open CommonGround
 open Semantics.Presupposition.Context
 
 variable {W : Type*} {Agent : Type*}
@@ -43,7 +42,7 @@ Following [schlenker-2009] Section 3.1.2, this is a function from
 -/
 structure BeliefLocalCtx (W : Type*) (Agent : Type*) where
   /-- The global context set -/
-  globalCtx : ContextSet W
+  globalCtx : Set W
   /-- The doxastic accessibility relation -/
   dox : Agent → W → W → Prop
   /-- The attitude holder -/
@@ -54,7 +53,7 @@ Get the local context at a specific world of utterance.
 
 This is Schlenker's λw* λw(w* ∈ C and w ∈ DoxJ(w*))
 -/
-def BeliefLocalCtx.atWorld (blc : BeliefLocalCtx W Agent) (w_star : W) : ContextSet W :=
+def BeliefLocalCtx.atWorld (blc : BeliefLocalCtx W Agent) (w_star : W) : Set W :=
   λ w => blc.globalCtx w_star ∧ blc.dox blc.agent w_star w
 
 /--
@@ -65,7 +64,7 @@ This is the OLE=yes case: the presupposition becomes part of the
 attitude holder's beliefs.
 -/
 def presupAttributedToHolder (blc : BeliefLocalCtx W Agent) (p : PartialProp W) : Prop :=
-  ∀ w_star, blc.globalCtx w_star → ContextSet.entails (blc.atWorld w_star) p.presup
+  ∀ w_star, blc.globalCtx w_star → blc.atWorld w_star ⊆ {w | p.presup w}
 
 /-!
 ### Opaque vs Transparent Presupposition Projection
@@ -95,8 +94,8 @@ variable {W : Type*} {Agent : Type*}
     the complement *holds* in the actual world.
 
     [delpinal-bassi-sauerland-2024] §3.2 -/
-def transparentProjection (globalCtx : ContextSet W) (p : PartialProp W) : Prop :=
-  ContextSet.entails globalCtx p.presup
+def transparentProjection (globalCtx : Set W) (p : PartialProp W) : Prop :=
+  globalCtx ⊆ {w | p.presup w}
 
 /-- `PartialProp.negFactive` subsumes transparent projection: its presupposition
     (complement holds = presup ∧ assertion) entails transparent projection of
@@ -105,8 +104,8 @@ def transparentProjection (globalCtx : ContextSet W) (p : PartialProp W) : Prop 
     This grounds the `negFactive` combinator in the projection theory.
     [heim-1992], [delpinal-bassi-sauerland-2024] §3.2 -/
 theorem negFactive_entails_transparent (complement : PartialProp W)
-    (believes : Set W → Set W) (globalCtx : ContextSet W)
-    (h : ContextSet.entails globalCtx (PartialProp.negFactive complement believes).presup) :
+    (believes : Set W → Set W) (globalCtx : Set W)
+    (h : globalCtx ⊆ {w | (PartialProp.negFactive complement believes).presup w}) :
     transparentProjection globalCtx complement := by
   intro w hw
   exact (h hw).1

--- a/Linglib/Semantics/Presupposition/Context.lean
+++ b/Linglib/Semantics/Presupposition/Context.lean
@@ -6,7 +6,7 @@ import Linglib.Discourse.CommonGround
 [stalnaker-1974] [heim-1983] [lewis-1979]
 
 Canonical operations connecting presuppositions (`PartialProp W`) to contexts
-(`ContextSet W`): the shared vocabulary for projection, filtering,
+(`Set W`): the shared vocabulary for projection, filtering,
 accommodation, and conceivability.
 
 ## Main declarations
@@ -27,7 +27,6 @@ world in the context set satisfying it.
 namespace Semantics.Presupposition.Context
 
 open Semantics.Presupposition
-open CommonGround
 
 variable {W : Type*}
 
@@ -37,7 +36,7 @@ variable {W : Type*}
     entails it: every world in the context satisfies the presupposition.
 
     This is Karttunen's filtering condition and Schlenker's local satisfaction. -/
-abbrev presupSatisfied (c : ContextSet W) (p : PartialProp W) : Prop := c ⊆ p.presup
+abbrev presupSatisfied (c : Set W) (p : PartialProp W) : Prop := c ⊆ p.presup
 
 /-- A presupposition is **satisfiable** (conceivable) in context `c` iff some
     world in the context satisfies it.
@@ -45,66 +44,66 @@ abbrev presupSatisfied (c : ContextSet W) (p : PartialProp W) : Prop := c ⊆ p.
     This is Enguehard's conceivability condition: a singular indefinite's number
     presupposition is conceivable iff the common ground contains a world where
     the witness set has the right cardinality. -/
-abbrev presupSatisfiable (c : ContextSet W) (p : PartialProp W) : Prop :=
+abbrev presupSatisfiable (c : Set W) (p : PartialProp W) : Prop :=
   (c ∩ p.presup).Nonempty
 
 /-- A presupposition **projects** from context `c` iff it is NOT satisfied
     (not filtered). Projection is the complement of filtering. -/
-abbrev presupProjects (c : ContextSet W) (p : PartialProp W) : Prop :=
+abbrev presupProjects (c : Set W) (p : PartialProp W) : Prop :=
   ¬ presupSatisfied c p
 
 /-- **Accommodate** a presupposition: restrict the context to worlds where
     the presupposition holds.
 
     [lewis-1979]: "presupposition P comes into existence." -/
-abbrev accommodate (c : ContextSet W) (presup : Set W) : ContextSet W := c ∩ presup
+abbrev accommodate (c : Set W) (presup : Set W) : Set W := c ∩ presup
 
 /-- Accommodation is **informative** iff the presupposition is not already
     entailed — accommodation actually changes the context. -/
-abbrev accommodationInformative (c : ContextSet W) (presup : Set W) : Prop :=
+abbrev accommodationInformative (c : Set W) (presup : Set W) : Prop :=
   ¬ c ⊆ presup
 
 /-- Accommodation is **consistent** iff the restricted context is non-empty —
     the presupposition is compatible with the context. -/
-abbrev accommodationConsistent (c : ContextSet W) (presup : Set W) : Prop :=
+abbrev accommodationConsistent (c : Set W) (presup : Set W) : Prop :=
   (accommodate c presup).Nonempty
 
 /-! ### Theorems -/
 
 /-- Satisfaction implies satisfiability (when the context is non-empty). -/
-theorem satisfied_implies_satisfiable (c : ContextSet W) (p : PartialProp W)
+theorem satisfied_implies_satisfiable (c : Set W) (p : PartialProp W)
     (hne : c.Nonempty) (hsat : presupSatisfied c p) : presupSatisfiable c p := by
   obtain ⟨w, hw⟩ := hne
   exact ⟨w, hw, hsat hw⟩
 
 /-- If the presupposition is not even satisfiable, it projects. -/
-theorem not_satisfiable_implies_projects (c : ContextSet W) (p : PartialProp W)
+theorem not_satisfiable_implies_projects (c : Set W) (p : PartialProp W)
     (hne : c.Nonempty) (h : ¬ presupSatisfiable c p) : presupProjects c p :=
   fun hsat => h (satisfied_implies_satisfiable c p hne hsat)
 
 /-- After accommodation, the presupposition is satisfied. -/
-theorem accommodate_entails_presup (c : ContextSet W) (presup : Set W) :
+theorem accommodate_entails_presup (c : Set W) (presup : Set W) :
     accommodate c presup ⊆ presup :=
   Set.inter_subset_right
 
 /-- Accommodation is idempotent: accommodating what's already satisfied
     doesn't change the context. -/
-theorem accommodate_idempotent (c : ContextSet W) (presup : Set W)
+theorem accommodate_idempotent (c : Set W) (presup : Set W)
     (h : c ⊆ presup) : accommodate c presup = c :=
   Set.inter_eq_left.mpr h
 
 /-- Accommodation strengthens the context: fewer worlds survive. -/
-theorem accommodate_strengthens (c : ContextSet W) (presup : Set W) :
+theorem accommodate_strengthens (c : Set W) (presup : Set W) :
     accommodate c presup ⊆ c :=
   Set.inter_subset_left
 
 /-- Accommodation consistency = presupposition satisfiable in context. -/
-theorem accommodationConsistent_iff_satisfiable (c : ContextSet W) (p : PartialProp W) :
+theorem accommodationConsistent_iff_satisfiable (c : Set W) (p : PartialProp W) :
     accommodationConsistent c p.presup ↔ presupSatisfiable c p := Iff.rfl
 
 /-- Accommodation via `PartialProp.defined`: accommodating `p.presup` restricts
     to worlds where `p.defined` holds. -/
-theorem accommodate_eq_defined (c : ContextSet W) (p : PartialProp W) (w : W) :
+theorem accommodate_eq_defined (c : Set W) (p : PartialProp W) (w : W) :
     w ∈ accommodate c p.presup ↔ w ∈ c ∧ PartialProp.defined w p :=
   Iff.rfl
 
@@ -124,22 +123,22 @@ satisfies it (`presupSatisfied`), and projects otherwise
 
     This is why "If the king exists, the king is bald" doesn't presuppose
     king exists: the local context at "the king is bald" already entails it. -/
-def localCtxConsequent (c : ContextSet W) (antecedent : PartialProp W) : ContextSet W :=
-  ContextSet.update c antecedent.assertion
+def localCtxConsequent (c : Set W) (antecedent : PartialProp W) : Set W :=
+  c ∩ {w | antecedent.assertion w}
 
 /-- Local context for the second disjunct: "P or Q" gives Q the local
     context c + ¬P.assertion ([schlenker-2009], reconstructing
     [karttunen-1973]'s asymmetric disjunction rule). -/
-def localCtxSecondDisjunct (c : ContextSet W) (first : PartialProp W) : ContextSet W :=
+def localCtxSecondDisjunct (c : Set W) (first : PartialProp W) : Set W :=
   λ w => c w ∧ ¬first.assertion w
 
 /-- Local context under negation: unchanged — negation is a hole
     ([karttunen-1973]). -/
-def localCtxNegation (c : ContextSet W) : ContextSet W := c
+def localCtxNegation (c : Set W) : Set W := c
 
 /-- Presupposition of the consequent is filtered when the antecedent's
     assertion entails the presupposition throughout the context. -/
-theorem conditional_filters_when_entailed (c : ContextSet W) (p q : PartialProp W)
+theorem conditional_filters_when_entailed (c : Set W) (p q : PartialProp W)
     (h : ∀ w, c w → p.assertion w → q.presup w) :
     presupSatisfied (localCtxConsequent c p) q := by
   intro w hw
@@ -148,7 +147,7 @@ theorem conditional_filters_when_entailed (c : ContextSet W) (p q : PartialProp 
 
 /-- If the antecedent's assertion doesn't entail the consequent's
     presupposition somewhere in the context, it projects. -/
-theorem conditional_projects_when_not_entailed (c : ContextSet W) (p q : PartialProp W)
+theorem conditional_projects_when_not_entailed (c : Set W) (p q : PartialProp W)
     (h : ∃ w, c w ∧ p.assertion w ∧ ¬q.presup w) :
     presupProjects (localCtxConsequent c p) q := by
   obtain ⟨w, hw_in, hp_true, hq_false⟩ := h
@@ -157,7 +156,7 @@ theorem conditional_projects_when_not_entailed (c : ContextSet W) (p q : Partial
 
 /-- The stipulated local-context computation agrees with the Karttunen
     filtering implication formula ([karttunen-1973], [peters-1979]). -/
-theorem local_context_matches_impFilter (c : ContextSet W) (p q : PartialProp W) :
+theorem local_context_matches_impFilter (c : Set W) (p q : PartialProp W) :
     (∀ w, c w → (PartialProp.impFilter p q).presup w) ↔
     (∀ w, c w → p.presup w ∧ (p.assertion w → q.presup w)) :=
   Iff.rfl
@@ -172,7 +171,7 @@ theorem local_context_matches_impFilter (c : ContextSet W) (p q : PartialProp W)
     These are the same condition (currying/uncurrying the conjunction).
     Analogous to `local_context_matches_impFilter` for conditionals.
     [schlenker-2009], [karttunen-1973] -/
-theorem local_context_matches_disjFilterLeft (c : ContextSet W)
+theorem local_context_matches_disjFilterLeft (c : Set W)
     (firstDisjunct : PartialProp W) (second : PartialProp W) :
     presupSatisfied (localCtxSecondDisjunct c firstDisjunct) second ↔
     (∀ w, c w → (PartialProp.disjFilterLeft firstDisjunct.assertion second).presup w) := by

--- a/Linglib/Semantics/Questions/Basic.lean
+++ b/Linglib/Semantics/Questions/Basic.lean
@@ -1017,7 +1017,7 @@ declaratives can be genuinely inquisitive
 (`exists_isInquisitive_ofSet_sup`) — inquisitive content enters
 the algebra exactly at `⊔`. The classical context-set picture of
 `Discourse/CommonGround.lean` (its scoped meet monoid and
-`CommonGround.HasAssertion`) is the declarative fragment of the
+`HasAssertion`) is the declarative fragment of the
 inquisitive one along this embedding. -/
 
 @[simp] theorem ofSet_univ : ofSet (Set.univ : Set W) = ⊤ := by

--- a/Linglib/Studies/Anderson2021.lean
+++ b/Linglib/Studies/Anderson2021.lean
@@ -51,7 +51,6 @@ can regain probability (fn. 7); intersection update survives only at
 lr = 1. -/
 namespace Discourse
 
-open CommonGround (ContextSet HasContextSet)
 
 variable {W : Type*}
 
@@ -63,13 +62,15 @@ success criterion — and `PMF.toRealFn` (the ℝ-valued masses every RSA
 consumer reads) already on the carrier. The classical context set is the
 support. -/
 
-/-- A distribution projects to [stalnaker-2002]'s context set: the
-    positive-mass worlds. -/
-instance : HasContextSet (PMF W) W := ⟨fun p w => w ∈ p.support⟩
+/-- A distribution's common ground is principal on [stalnaker-2002]'s context
+    set, the positive-mass worlds (the a.e. filter of the induced measure). -/
+instance : HasCommonGround (PMF W) W := ⟨fun p => Filter.principal {w | w ∈ p.support}⟩
 
-@[simp] theorem pmf_toContextSet (p : PMF W) (w : W) :
-    HasContextSet.toContextSet p w ↔ 0 < p.toRealFn w :=
-  (PMF.mem_support_iff p w).trans
+@[simp] theorem pmf_contextSet (p : PMF W) (w : W) :
+    w ∈ HasCommonGround.contextSet p ↔ 0 < p.toRealFn w := by
+  show w ∈ Filter.ker (Filter.principal {w | w ∈ p.support}) ↔ _
+  rw [Filter.ker_principal]
+  exact (PMF.mem_support_iff p w).trans
     ⟨fun h => ENNReal.toReal_pos h (p.apply_ne_top w),
      fun h => pos_iff_ne_zero.mp (ENNReal.toReal_pos_iff.mp h).1⟩
 
@@ -77,7 +78,6 @@ end Discourse
 
 namespace Anderson2021
 
-open CommonGround (ContextSet)
 open scoped ENNReal NNReal NNRat
 
 /-! ### MutualFriends Domain -/
@@ -555,9 +555,8 @@ lr = 1 limit: with the prior discarded, a zero-posterior world leaves
 the context set. -/
 theorem lr_one_excludes_false_worlds (cg post : PMF MFWorld)
     (w : MFWorld) (h : post.toRealFn w = 0) :
-    ¬CommonGround.HasContextSet.toContextSet
-      (updateCG cg post 1 zero_le_one (le_refl 1)) w := by
-  rw [Discourse.pmf_toContextSet, updateCG_lr_one, h]
+    w ∉ HasCommonGround.contextSet (updateCG cg post 1 zero_le_one (le_refl 1)) := by
+  rw [Discourse.pmf_contextSet, updateCG_lr_one, h]
   exact lt_irrefl 0
 
 /-- The graded divergence (fn. 7: "worlds can regain probability"): at
@@ -565,8 +564,8 @@ any lr < 1 the prior keeps a ruled-out world alive with mass
 `(1 − lr)·cg w` — the update never deletes a world the prior supports. -/
 theorem graded_update_keeps_false_world (cg post : PMF MFWorld)
     (w : MFWorld) (hcg : 0 < cg.toRealFn w) (lr : ℝ) (h0 : 0 ≤ lr) (h1 : lr < 1) :
-    CommonGround.HasContextSet.toContextSet (updateCG cg post lr h0 h1.le) w := by
-  rw [Discourse.pmf_toContextSet, updateCG_eq]
+    w ∈ HasCommonGround.contextSet (updateCG cg post lr h0 h1.le) := by
+  rw [Discourse.pmf_contextSet, updateCG_eq]
   have : 0 < (1 - lr) * cg.toRealFn w := mul_pos (by linarith) hcg
   have : 0 ≤ lr * post.toRealFn w :=
     mul_nonneg h0 (PMF.toRealFn_nonneg _ _)

--- a/Linglib/Studies/Brandom1994.lean
+++ b/Linglib/Studies/Brandom1994.lean
@@ -38,7 +38,6 @@ inferential role.
 namespace Brandom1994
 
 open Discourse.Commitment (CommitmentSlate)
-open CommonGround (ContextSet)
 
 -- ════════════════════════════════════════════════════
 -- § 1. Normative Status
@@ -150,7 +149,7 @@ def assert (s : BrandomState W) (p : Set W) : BrandomState W :=
     model has strictly more structure (entitlements, disagreement
     between scorekeepers), but for the `AssertionTheory` interface
     we need a single `ContextSet`. -/
-def effectiveContextSet (s : BrandomState W) : ContextSet W :=
+def effectiveContextSet (s : BrandomState W) : Set W :=
   λ w =>
     -- Intersection: w must be compatible with all commitments
     -- that both agents agree the speaker has
@@ -218,17 +217,16 @@ theorem scorekeepers_can_disagree :
     else NormativeStatus.empty⟩, by decide⟩
 
 -- ════════════════════════════════════════════════════
--- § 7. HasContextSet instance
+-- § 7. HasCommonGround instance
 -- ════════════════════════════════════════════════════
 
-open CommonGround in
-/-- Brandom states project to a context set via `effectiveContextSet`
-    (the lossy Brandom → Stalnaker projection: intersection of all
-    self-attributed commitments). The lossy projection is the price of
-    the typeclass — Brandom's per-scorekeeper disagreement is
-    invisible at the `HasContextSet` API level (cf.
+/-- Brandom states project to the principal common ground of
+    `effectiveContextSet` (the lossy Brandom → Stalnaker projection:
+    intersection of all self-attributed commitments). The lossy projection
+    is the price of the typeclass — Brandom's per-scorekeeper disagreement
+    is invisible at the `HasCommonGround` API level (cf.
     `scorekeepers_can_disagree`). -/
-instance {W : Type*} : HasContextSet (BrandomState W) W where
-  toContextSet := BrandomState.effectiveContextSet
+instance {W : Type*} : HasCommonGround (BrandomState W) W where
+  commonGround s := Filter.principal s.effectiveContextSet
 
 end Brandom1994

--- a/Linglib/Studies/Caie2023.lean
+++ b/Linglib/Studies/Caie2023.lean
@@ -47,7 +47,7 @@ sequential update = single conjunctive update — apply directly.
 
 ## Relationship to Existing Infrastructure
 
-- `ContextSet.update c p` in `CommonGround.lean` is the special case where
+- intersective update `c ∩ p` (`CommonGround.lean`) is the special case where
   every world gets the same interpretation (no context sensitivity).
   See `disjunctiveUpdate_constant`.
 
@@ -61,7 +61,6 @@ sequential update = single conjunctive update — apply directly.
 
 namespace Caie2023
 
-open CommonGround (ContextSet)
 
 -- ════════════════════════════════════════════════════════════════
 -- § 0. Parameterized Update (general substrate)
@@ -497,14 +496,14 @@ theorem disjunctiveUpdate_mono_interp (cs : Set W)
 
 
 -- ════════════════════════════════════════════════════════════════
--- § 7. Connection to ContextSet.update
+-- § 7. Connection to intersective update
 -- ════════════════════════════════════════════════════════════════
 
 /-- When there is a single fixed interpretation for all worlds, disjunctive
-    updating reduces to propositional filtering — the mechanism formalized
-    as `ContextSet.update` in `CommonGround.lean`.
+    updating reduces to propositional filtering — intersective update of the
+    context set (`Discourse/CommonGround.lean`).
 
-    This witnesses the fact that `ContextSet.update` is the degenerate case
+    This witnesses the fact that intersective update is the degenerate case
     of Disjunctive Updating where context sensitivity plays no role: the
     same proposition is expressed at every world. -/
 theorem disjunctiveUpdate_constant (cs : Set W) (c₀ : C)
@@ -517,15 +516,14 @@ theorem disjunctiveUpdate_constant (cs : Set W) (c₀ : C)
     λ ⟨hw, _, hc, hs⟩ => by subst hc; exact ⟨hw, hs⟩,
     λ ⟨hw, hs⟩ => ⟨hw, _, rfl, hs⟩⟩
 
-/-- Disjunctive updating with a fixed context reduces to `ContextSet.update`.
+/-- Disjunctive updating with a fixed context reduces to intersective update.
 
     This explicitly connects the general framework to the infrastructure in
     `CommonGround.lean`: context-insensitive assertions (same proposition at
     every world) update via ordinary propositional filtering. -/
-theorem disjunctiveUpdate_eq_contextSet_update (cs : Set W) (c₀ : C)
+theorem disjunctiveUpdate_eq_inter (cs : Set W) (c₀ : C)
     (sem : C → W → Prop) :
-    disjunctiveUpdate cs (λ _ c => c = c₀) sem =
-    ContextSet.update cs (sem c₀) := by
+    disjunctiveUpdate cs (λ _ c => c = c₀) sem = cs ∩ {w | sem c₀ w} := by
   exact disjunctiveUpdate_constant cs c₀ sem
 
 

--- a/Linglib/Studies/Clark1983.lean
+++ b/Linglib/Studies/Clark1983.lean
@@ -68,7 +68,6 @@ level rather than a vacuous law-of-excluded-middle.
 namespace Clark1983
 
 
-open CommonGround
 open RSA (Lexicon)
 open DistributedMorphology (Categorizer WordStructure ofRoot categorize Headed)
 
@@ -300,7 +299,7 @@ structure GoalHierarchy (W : Type*) where
   /-- Subgoal (1): the intended meaning on this occasion. -/
   intendedMeaning : W → Prop
   /-- The common ground used for the inference. -/
-  commonGround : CommonGround W
+  commonGround : Filter W
   /-- Subgoal (2): the meta-recognition that the speaker invokes a
       convention licensing the direct → intended inference. For
       conventional uses this is `True` (no specific convention required).
@@ -355,12 +354,12 @@ structure DenominalVerbConvention (W : Type*) where
   /-- The conventional denotation of the parent noun. -/
   nounDenotation : W → Prop
   /-- (e) The common ground of speaker and listener. -/
-  commonGround : CommonGround W
+  commonGround : Filter W
   /-- (b–d) The speaker has good reason to believe the listener can
       readily compute the situation uniquely from mutual knowledge.
       Operationalized as: every CommonGround-compatible world satisfies the
       situation. -/
-  cgDeterminesSituation : ∀ w, commonGround.contextSet w → situation w
+  cgDeterminesSituation : ∀ w, w ∈ commonGround.ker → situation w
   /-- (f, extensional) The noun's denotation is realized in every
       situation-world — there is a teapot wherever a teapotting happens. -/
   nounParticipates : ∀ w, situation w → nounDenotation w
@@ -390,7 +389,7 @@ def DenominalVerbConvention.toGoalHierarchy {W : Type*}
     -- (b–d): CommonGround uniquely determines the situation
     -- (f, extensional): noun denotation realized in every situation-world
     -- (f, role-distinctness): parent noun role differs from other surface args' roles
-    (∀ w, conv.commonGround.contextSet w → conv.situation w) ∧
+    (∀ w, w ∈ conv.commonGround.ker → conv.situation w) ∧
       (∀ w, conv.situation w → conv.nounDenotation w) ∧
       conv.parentNounRole ∉ conv.otherArgRoles
 
@@ -443,8 +442,8 @@ def teapotNoun (w : TeapotWorld) : Prop := w.teapot = true
     rubbing-with-teapot situation; in a fuller formalization the CommonGround
     would entail the relevant odd-habit knowledge from which the
     listener derives the situation. -/
-def teapotCG : CommonGround TeapotWorld :=
-  CommonGround.empty.add { w | w.rubbing = true ∧ w.teapot = true }
+def teapotCG : Filter TeapotWorld :=
+  Filter.principal { w | w.rubbing = true ∧ w.teapot = true }
 
 /-- The Innovative Denominal Verb Convention (paper p. 321) instantiated
     for *Max teapotted a policeman* (paper pp. 320–321, 325–326).
@@ -592,12 +591,12 @@ def stereosDirectMeaning : StereosWorld → Prop := λ w => w.phonographsCommon 
 def arlenesGoalHierarchy : GoalHierarchy StereosWorld where
   directMeaning := stereosDirectMeaning
   intendedMeaning := stereosDirectMeaning
-  commonGround := .empty
+  commonGround := ⊤
   invokesConvention := True
 
 /-- Bombeck's CommonGround: discourse context establishes "owners are common." -/
-def bombecksCG : CommonGround StereosWorld :=
-  CommonGround.empty.add { w | w.ownersCommon = true }
+def bombecksCG : Filter StereosWorld :=
+  Filter.principal { w | w.ownersCommon = true }
 
 /-- Bombeck's goal hierarchy: innovative use. The intended meaning is the
     nonce reading (owners are common). `invokesConvention` is left at `True`
@@ -650,7 +649,7 @@ structure IndirectAct (W : Type*) where
       condition). -/
   prepCondition : Option PreparatoryCondition
   /-- Common ground licensing the inference. -/
-  commonGround : CommonGround W
+  commonGround : Filter W
 
 /-- Project an indirect act to a goal hierarchy.
 
@@ -687,7 +686,7 @@ def timeQuestionExample : IndirectAct Unit where
   directContent := λ _ => True   -- literal: "do you know X?" — toy stand-in
   intendedContent := λ _ => False -- intended: "tell me X" — distinct
   prepCondition := some .knowledge
-  commonGround := .empty
+  commonGround := ⊤
 
 /-- The time-question example projects via the `.knowledge` preparatory
     condition, exactly the substrate `Studies/FrancikClark1985.lean`
@@ -754,7 +753,7 @@ def amexQuestion : IndirectAct Unit where
   directContent := λ _ => True   -- "Do you accept AmEx?" — toy stand-in
   intendedContent := λ _ => True  -- intended = direct (4-subgoal hierarchy collapses to (4))
   prepCondition := none           -- Clark-style goal-hierarchy mechanism, not Searle-prep
-  commonGround := .empty
+  commonGround := ⊤
 
 /-- Credit cards case: the question carries BOTH a direct interpretation
     AND an indirect request for the list of acceptable cards (paper
@@ -768,7 +767,7 @@ def creditCardsQuestion : IndirectAct Unit where
   directContent := λ _ => True    -- "Do you accept credit cards?"
   intendedContent := λ _ => False -- intended ≠ direct (5-subgoal hierarchy: (5) + indirect (4))
   prepCondition := none
-  commonGround := .empty
+  commonGround := ⊤
 
 /-- The AmEx and credit-cards questions are surface-identical in their
     direct content (both "Do you accept X?") but diverge in intended
@@ -841,14 +840,14 @@ of `§F` is what you get by **evaluating** this function at a specific CommonGro
     maps a CommonGround to the **intended** meaning on a given occasion. -/
 structure ContextualMeaning (W : Type*) where
   directMeaning : W → Prop
-  compute : CommonGround W → (W → Prop)
+  compute : Filter W → (W → Prop)
 
 /-- Evaluate a contextual meaning at a specific CommonGround, producing a goal
     hierarchy. The convention-recognition is left at `True` here — the
     fuller treatment exposes a CommonGround-dependence witness via the source-class
     projections (`DenominalVerbConvention.toGoalHierarchy` etc.). -/
 def ContextualMeaning.evaluate {W : Type*}
-    (cm : ContextualMeaning W) (cg : CommonGround W) : GoalHierarchy W where
+    (cm : ContextualMeaning W) (cg : Filter W) : GoalHierarchy W where
   directMeaning := cm.directMeaning
   intendedMeaning := cm.compute cg
   commonGround := cg
@@ -858,17 +857,17 @@ def ContextualMeaning.evaluate {W : Type*}
     difference. This is sense-selection. -/
 def ContextualMeaning.isCGIndependent {W : Type*}
     (cm : ContextualMeaning W) : Prop :=
-  ∀ cg : CommonGround W, cm.compute cg = cm.directMeaning
+  ∀ cg : Filter W, cm.compute cg = cm.directMeaning
 
 /-- A contextual meaning is **CommonGround-dependent** when there exists a CommonGround that
     shifts the intended meaning away from the direct meaning. This is
     sense-creation. -/
 def ContextualMeaning.isCGDependent {W : Type*}
     (cm : ContextualMeaning W) : Prop :=
-  ∃ cg : CommonGround W, cm.compute cg ≠ cm.directMeaning
+  ∃ cg : Filter W, cm.compute cg ≠ cm.directMeaning
 
 theorem cg_independent_conventional {W : Type*}
-    (cm : ContextualMeaning W) (h : cm.isCGIndependent) (cg : CommonGround W) :
+    (cm : ContextualMeaning W) (h : cm.isCGIndependent) (cg : Filter W) :
     (cm.evaluate cg).isConventional := h cg
 
 theorem cg_dependent_innovative {W : Type*}
@@ -891,25 +890,25 @@ open Classical
 def stereosMeaning : ContextualMeaning StereosWorld where
   directMeaning := stereosDirectMeaning
   compute := λ cg =>
-    if ∀ w, cg.contextSet w → w.ownersCommon = true
+    if ∀ w ∈ cg.ker, w.ownersCommon = true
     then λ w => w.ownersCommon = true
     else stereosDirectMeaning
 
 end
 
 private theorem bombecksCG_entails_owners :
-    ∀ w, bombecksCG.contextSet w → w.ownersCommon = true := by
+    ∀ w ∈ bombecksCG.ker, w.ownersCommon = true := by
   intro w h
-  exact h.1
+  rwa [bombecksCG, Filter.ker_principal] at h
 
 private theorem emptyCG_not_entails_owners :
-    ¬ ∀ w, (CommonGround.empty : CommonGround StereosWorld).contextSet w → w.ownersCommon = true := by
+    ¬ ∀ w ∈ (⊤ : Filter StereosWorld).ker, w.ownersCommon = true := by
   intro h
-  have := h ⟨true, false⟩ (by trivial)
+  have := h ⟨true, false⟩ (by simp)
   exact absurd this (by decide)
 
 theorem stereos_arlene :
-    stereosMeaning.evaluate .empty = arlenesGoalHierarchy := by
+    stereosMeaning.evaluate ⊤ = arlenesGoalHierarchy := by
   unfold stereosMeaning ContextualMeaning.evaluate
   simp only [if_neg emptyCG_not_entails_owners, arlenesGoalHierarchy]
 

--- a/Linglib/Studies/DelPinalBassiSauerland2024.lean
+++ b/Linglib/Studies/DelPinalBassiSauerland2024.lean
@@ -32,7 +32,6 @@ The five-world model and alternative set are [bar-lev-fox-2020]'s.
 namespace DelPinalBassiSauerland2024
 
 open Semantics.Presupposition (PartialProp)
-open CommonGround (ContextSet)
 open Exhaustification Exhaustification.Presuppositional BarLevFox2020 ModalLogic
 open Semantics.Presupposition.Context (presupSatisfied localCtxSecondDisjunct)
 
@@ -115,14 +114,14 @@ theorem exh_unaware_too_weak :
 
 /-- In `A or pex[◇(p ∨ q)]` the homogeneity presupposition is satisfied in the second
 disjunct's local context `c ∧ ¬A`, and free choice follows there. -/
-theorem filtering_fc (c : ContextSet FCWorld) (A : PartialProp FCWorld) (hc : w ∈ c)
+theorem filtering_fc (c : Set FCWorld) (A : PartialProp FCWorld) (hc : w ∈ c)
     (hA : ¬ A.assertion w) (hf : presupSatisfied (localCtxSecondDisjunct c A) pexFC)
     (hassert : pexFC.assertion w) : permA w ∧ permB w :=
   pex_fc ⟨hf ⟨hc, hA⟩, hassert⟩
 
 /-- A flat `exh` second disjunct has nothing to filter: its free-choice content is
 assertive and stays inside the disjunct (§4.1). -/
-theorem exh_filtering_trivial (c : ContextSet FCWorld) (A : PartialProp FCWorld) :
+theorem exh_filtering_trivial (c : Set FCWorld) (A : PartialProp FCWorld) :
     presupSatisfied (localCtxSecondDisjunct c A) (PartialProp.ofProp flatExhFC) :=
   fun _ _ => trivial
 

--- a/Linglib/Studies/Enguehard2024.lean
+++ b/Linglib/Studies/Enguehard2024.lean
@@ -664,7 +664,7 @@ categorical judgments in examples (5)–(6).
     world — there is no middle ground. -/
 theorem constant_presup_satisfied_iff_satisfiable
     {W : Type*} (witnessCard : W → Nat) (conceivable : W → Prop)
-    (c : CommonGround.ContextSet W)
+    (c : Set W)
     (hne : c.Nonempty) :
     Semantics.Presupposition.Context.presupSatisfied c
       (sgIndefPresup witnessCard conceivable) ↔

--- a/Linglib/Studies/FarkasBruce2010.lean
+++ b/Linglib/Studies/FarkasBruce2010.lean
@@ -29,11 +29,11 @@ theorem assert_preserves_cg (ds : State W) (p : W → Prop) :
     survive the assertion of `p` without satisfying `p`, because assertion
     only proposes (`dcS` + table) and the context set moves at acceptance.
     This is the formal witness for the non-instance advertised at
-    `CommonGround.HasAssertion` — `State W` does not instantiate it via
+    `HasAssertion` — `State W` does not instantiate it via
     F&B's own `assert`. -/
 theorem assert_not_narrowing :
     ∃ (ds : State Bool) (p : Bool → Prop) (w : Bool),
       w ∈ (assert ds p).contextSet ∧ ¬ p w :=
-  ⟨.empty, (· = true), false, trivial, Bool.false_ne_true⟩
+  ⟨.empty, (· = true), false, by simp [DiscourseState.contextSet], Bool.false_ne_true⟩
 
 end FarkasBruce2010

--- a/Linglib/Studies/Ginzburg2012/Basic.lean
+++ b/Linglib/Studies/Ginzburg2012/Basic.lean
@@ -556,7 +556,7 @@ The contrasts below make the architectural disagreements Lean-checkable.
 
 section CrossFrameworkContrasts
 
-/-- A simple two-world scenario for HasContextSet contrasts. -/
+/-- A simple two-world scenario for common-ground contrasts. -/
 inductive RainW where
   | rainy | sunny
   deriving DecidableEq, Repr
@@ -592,9 +592,8 @@ def kosSpeakerDGB : DGB String (Set RainW) String String :=
 def kosAddresseeDGB : DGB String (Set RainW) String String :=
   DGB.initial
 
-open CommonGround in
 /-- KOS-vs-Stalnaker architectural contrast: KOS's two DGBs project to
-*different* `ContextSet`s after one-sided assertion. Stalnaker's
+*different* common grounds after one-sided assertion. Stalnaker's
 framework has a single CommonGround that cannot represent this divergence —
 the contrast is structural, not a matter of degree.
 
@@ -603,15 +602,14 @@ requires `isRaining sunny = True` (i.e. `sunny = rainy`), which is
 False; the addressee's CS at sunny is vacuously True (empty universal
 over an empty `facts` list). -/
 theorem kos_vs_stalnaker_per_dgb_divergence :
-    HasContextSet.toContextSet kosSpeakerDGB ≠
-    HasContextSet.toContextSet kosAddresseeDGB := by
+    commonGround kosSpeakerDGB ≠ commonGround kosAddresseeDGB := by
   intro h
-  -- Apply both sides at .sunny
-  have hsunny := congrFun h RainW.sunny
+  -- Apply both context sets at .sunny
+  have hsunny := congrFun (Filter.principal_eq_iff_eq.1 h) RainW.sunny
   -- Speaker side: ∀ p ∈ [isRaining], p .sunny  ≡  isRaining .sunny  ≡  False
   -- Addressee side: ∀ p ∈ [], p .sunny         ≡  True
   -- So hsunny : False = True, contradiction
-  simp only [HasContextSet.toContextSet, kosSpeakerDGB, kosAddresseeDGB,
+  simp only [kosSpeakerDGB, kosAddresseeDGB,
              DGB.addFact, DGB.initial, isRaining,
              List.mem_singleton, forall_eq, List.not_mem_nil,
              IsEmpty.forall_iff, forall_const, eq_iff_iff, iff_true] at hsunny
@@ -643,7 +641,7 @@ theorem kos_vs_farkasbruce_architecture_differs
     -- F&B: a single discourse state keeps speaker/listener commitments and
     -- the common ground as separate per-agent slates
     let fb : State RainW := DiscourseState.empty.addCommit .speaker p
-    p ∈ fb.dcS ∧ fb.cgPropositions = [] ∧ fb.dcL = [] :=
+    p ∈ fb.dcS ∧ fb.cg = ⊤ ∧ fb.dcL = [] :=
   ⟨List.mem_cons_self, rfl, rfl⟩
 
 /-- The deeper architectural disagreement: **F&B can model retraction**
@@ -665,7 +663,7 @@ open Discourse.Commitment.Table in
 by re-introducing to dcS. The substrate-level disagreement: KOS's
 type-level commitment to monotonicity. -/
 theorem farkasbruce_cg_can_be_emptied :
-    (DiscourseState.empty : State RainW).cgPropositions = [] := rfl
+    (DiscourseState.empty : State RainW).cg = ⊤ := rfl
 
 /-! ### vs Roberts 1996/2012 (partition-stack QUD)
 

--- a/Linglib/Studies/Krifka2015.lean
+++ b/Linglib/Studies/Krifka2015.lean
@@ -494,14 +494,14 @@ theorem krifka_eager_vs_farkasBruce_lazy_intermediate :
       [IndexedCommitment.commit .speaker isRaining] ∧
     -- F&B: assert leaves cg untouched; commitment is on
     -- speaker's slate + table only
-    (assert (DiscourseState.empty : State Weather) isRaining).cgPropositions = [] ∧
+    (assert (DiscourseState.empty : State Weather) isRaining).cg = ⊤ ∧
     (assert (DiscourseState.empty : State Weather) isRaining).dcS = [isRaining] ∧
     (assert (DiscourseState.empty : State Weather) isRaining).table.length = 1 := by
   refine ⟨rfl, ?_, ?_, ?_⟩ <;> simp
 
 /-- Bridge at the completed-trace state: after the addressee accepts the
     assertion, both frameworks have φ in the joint CommonGround (modulo Krifka's
-    speaker indexing on the root entries; F&B's `cg` is bare `Set W`).
+    speaker indexing on the root entries; F&B's `cg` is a bare filter).
 
     Krifka's "addressee accepts" pathway is `assert φ .addressee`
     (the `Yes` reaction, paper p. 334 eq. 21). F&B's pathway is
@@ -518,11 +518,11 @@ theorem krifka_double_assert_eq_farkasBruce_assert_accept :
       [IndexedCommitment.commit .addressee isRaining,
        IndexedCommitment.commit .speaker isRaining] ∧
     -- F&B: assertion has migrated from table → cg, with dcS/dcL also updated
-    fbState.cgPropositions = [isRaining] ∧
+    {w | isRaining w} ∈ fbState.cg ∧
     fbState.dcS   = [isRaining] ∧
     fbState.dcL   = [isRaining] ∧
     fbState.table = [] := by
-  refine ⟨rfl, rfl, rfl, ?_, ?_, ?_, ?_⟩ <;> simp
+  refine ⟨rfl, rfl, rfl, accept_after_assert_mem_cg _ _, ?_, ?_, ?_⟩ <;> simp
 
 /-- The headline observation: at a completed assertion+acceptance trace,
     the two frameworks agree on the **context-set projection** —

--- a/Linglib/Studies/Mihoc2019.lean
+++ b/Linglib/Studies/Mihoc2019.lean
@@ -452,7 +452,7 @@ Assertions carry a null epistemic necessity modal `□_S`; `O` applies above
 it, negating pre-exhaustified domain alternatives
 (`Exhaustification.preExh`) and the stronger σA. Her running model: the CMN
 *less than three* / SMN *at most two*, worlds = candidate maxima 0–3,
-`□_S` = `ContextSet.entails` over a nonempty epistemic state
+`□_S` = context-set entailment (`⊆`) over a nonempty epistemic state
 (`boxS_iff_entails`). The DA are the value-regions inside the prejacent set
 {0, 1, 2}: singletons and doubletons.
 
@@ -469,7 +469,7 @@ namespace Ignorance
 /-- Worlds: the candidate maximum, values 0–3. -/
 abbrev EWorld := Fin 4
 
-/-- `□_S` over a finite epistemic state — `ContextSet.entails` in
+/-- `□_S` over a finite epistemic state — `⊆` in
 computable clothing (`boxS_iff_entails`). -/
 def boxS (E : Finset EWorld) (p : EWorld → Prop) : Prop := ∀ w ∈ E, p w
 
@@ -478,8 +478,8 @@ instance (E : Finset EWorld) (p : EWorld → Prop) [DecidablePred p] :
   inferInstanceAs (Decidable (∀ w ∈ E, p w))
 
 theorem boxS_iff_entails (E : Finset EWorld) (p : EWorld → Prop) :
-    boxS E p ↔ CommonGround.ContextSet.entails (↑E : Set EWorld) {w | p w} := by
-  simp [boxS, CommonGround.ContextSet.entails, Set.subset_def]
+    boxS E p ↔ (↑E : Set EWorld) ⊆ {w | p w} := by
+  simp [boxS, Set.subset_def]
 
 /-- The asserted prejacent: `□_S`(*less than three*). -/
 def prejacent (E : Finset EWorld) : Prop :=

--- a/Linglib/Studies/Ney2026.lean
+++ b/Linglib/Studies/Ney2026.lean
@@ -68,7 +68,7 @@ The §3 prima-facie challenge is formalized abstractly:
 hypothesis on the conception. Substantive Ney soundness — that the
 resolution holds under a *realistic* CommonGround operator derived from
 `commonBelief` ([stalnaker-2002]) — requires a `CommonGround.toAgentAccess :
-CommonGround W → E → W → W → Prop` bridge in `Discourse/CommonGround.lean`
+Filter W → E → W → W → Prop` bridge in `Discourse/CommonGround.lean`
 that does not yet exist. Until that bridge lands, the resolution
 theorems are witnessed by toy operators (a degenerate `inCG := · = True`
 that distinguishes intersection-CommonGround-transparency from union-CommonGround-transparency
@@ -138,7 +138,7 @@ the §5 conclusion proposes the broader "insinuative speech" terminology.
 
 namespace Ney2026
 
-open Semantics.Reference.Basic CommonGround
+open Semantics.Reference.Basic
 
 /-! ## §1. Metasemantic apparatus -/
 
@@ -189,7 +189,7 @@ abbrev ConceptionOfReasonableness (C W E : Type*) :=
 /-- A *metasemantics of demonstratives*: a recipe assigning each
 speaker intention a success Prop.
 
-`Account` is intentionally CommonGround-free (no `CommonGround W` parameter): in
+`Account` is intentionally CommonGround-free (no `Filter W` parameter): in
 [ney-2026]'s argument the CommonGround-availability of the success-fact is
 the load-bearing modal claim, formalized via the abstract `inCG`
 operator on the `prima_facie_challenge` theorem rather than threaded

--- a/Linglib/Studies/RitchieSchiller2024.lean
+++ b/Linglib/Studies/RitchieSchiller2024.lean
@@ -779,7 +779,6 @@ speaker and hearer derive the same DDRP. Different perceptual access yields
 different DDRPs, motivating R&S's requirement of perceptual co-presence. -/
 
 open Core
-open CommonGround
 
 /-- The DDRP generative model as a BToM instance over ℝ≥0∞: percept and
 belief are veridical deltas ([baker-jara-ettinger-saxe-tenenbaum-2017]'s

--- a/Linglib/Studies/RomeroHan2004.lean
+++ b/Linglib/Studies/RomeroHan2004.lean
@@ -59,18 +59,18 @@ open ModalLogic (box)
 open Question (polar polar_compl)
 open Set (Iic)
 
-variable {W : Type*} (epi conv : W → W → Prop) (cg : W → CommonGround W) (p q : Set W)
+variable {W : Type*} (epi conv : W → W → Prop) (cg : W → Filter W) (p q : Set W)
 
 /-! ### VERUM -/
 
 /-- The VERUM operator `FOR-SURE-CG_x p` ((43)): `p` is in the common ground at every world
 compatible with the conversational goals of every world compatible with `x`'s knowledge. -/
 def verum : Set W :=
-  {w | ∀ w', epi w w' → ∀ w'', conv w' w'' → p ∈ (cg w'').propositions}
+  {w | ∀ w', epi w w' → ∀ w'', conv w' w'' → p ∈ cg w''}
 
 /-- VERUM is a necessity nested in a necessity. -/
 theorem verum_eq_box_box :
-    verum epi conv cg p = box epi (box conv fun w => p ∈ (cg w).propositions) := rfl
+    verum epi conv cg p = box epi (box conv fun w => p ∈ cg w) := rfl
 
 /-! ### The four VERUM questions -/
 

--- a/Linglib/Studies/Rudin2025.lean
+++ b/Linglib/Studies/Rudin2025.lean
@@ -30,7 +30,6 @@ predicates carry `[DecidablePred p]` constraints.
 
 namespace Rudin2025
 
-open CommonGround
 
 abbrev World := Fin 4
 
@@ -224,7 +223,7 @@ theorem nsfUpdateMust_eq_nonEpistemic (p : (W → Prop)) [DecidablePred p] (c : 
     parameter, the NSF update is intersection with the proposition —
     exactly [stalnaker-1978]'s original formalization.
 
-    Bridges `nsfUpdateNonEpistemic` to `ContextSet.update` from CommonGround:
+    Bridges `nsfUpdateNonEpistemic` to intersective context-set update:
     both compute c ∩ p (filter c to p-worlds). -/
 theorem nsf_recovers_stalnaker (p : (W → Prop)) [DecidablePred p] (c : List W) (w : W) :
     w ∈ nsfUpdateNonEpistemic p c ↔ w ∈ c ∧ p w := by

--- a/Linglib/Studies/RudolphKocurek2024.lean
+++ b/Linglib/Studies/RudolphKocurek2024.lean
@@ -34,7 +34,7 @@ delineation bridge, and the degree theory.
   (supplement §B) semantics.
 * `AssertoricContent`, `MetalinguisticCG` — acceptance and the common ground:
   the substrate's `ContextSet` at the ordering-world index, with assertion as
-  `ContextSet.update` and the Stalnaker laws inherited.
+  intersective update and the Stalnaker laws inherited.
 * `DistanceFunction`, `EvalVery`, `EvalSorta`, `EvalMostly`, `EvalMCond` —
   degree modifiers (§6.1) and metalinguistic conditionals (§6.3).
 * `degreeEquiv`, `strictlyBetter`, `MetaDegree` — the supplement's §C degree
@@ -48,7 +48,7 @@ delineation bridge, and the degree theory.
   l-liftings ([holliday-icard-2013]), extending the substrate's grounding of
   ≻; the distance-function axioms are exactly totality of "not far below".
 * `evalMCond_iff_entails` — for an MC-free consequent the conditional is
-  Stalnakerian `ContextSet.entails` of the consequent by the antecedent-cone.
+  Stalnakerian entailment (`⊆`) of the consequent by the antecedent-cone.
 * `eval_mc_iff_delineation_of_noReversal` — under No Reversal (§7) the MC is
   [klein-1980]'s `Delineation.comparativeSem`.
 * `mc_iff_degree_gt`, `me_iff_same_degree` — Facts 9–10: ≻ and ≈ are degree
@@ -556,14 +556,13 @@ instance [Fintype E] [DecidableEq E] [DecidableAtoms interp]
 omit [Fintype I] in
 /-- **Grounding in the common-ground substrate**: for an MC-free consequent —
 strictly weaker than the paper's reduction, which also assumes the antecedent
-MC-free — the metalinguistic conditional is Stalnakerian entailment
-(`ContextSet.entails`) of the consequent by the ranked antecedent-cone. The
+MC-free — the metalinguistic conditional is Stalnakerian entailment (`⊆`)
+of the consequent by the ranked antecedent-cone. The
 antecedent may contain ≻ freely: it is always evaluated at the full ordering,
 and an MC-free consequent never consults the restricted one. -/
 theorem evalMCond_iff_entails (hB : B.ComparativeFree) :
     EvalMCond interp A B ord i w ↔
-    CommonGround.ContextSet.entails
-      {x | ord.le x i ∧ ComparativeFormula.Realize interp A ord.le x w}
+    {x | ord.le x i ∧ ComparativeFormula.Realize interp A ord.le x w} ⊆
       {x | ComparativeFormula.Realize interp B ord.le x w} := by
   constructor
   · rintro h x ⟨hx1, hx2⟩
@@ -577,7 +576,6 @@ end Framework
 
 /-! ### Connection to Common Ground -/
 
-open CommonGround (ContextSet HasContextSet)
 
 /-- An ordering-world pair: the enriched index for the metalinguistic common
 ground — a Stalnakerian world that fixes interpretive as well as factual
@@ -586,9 +584,10 @@ structure OrderingWorldPair (I W : Type*) where
   ord : SemanticOrdering I
   world : W
 
-/-- The metalinguistic common ground IS the substrate's `ContextSet`, taken at
-the enriched index type: the Stalnaker generalization is "same object, richer worlds", so `ContextSet.update` and its laws apply unchanged. -/
-abbrev MetalinguisticCG (I W : Type*) := ContextSet (OrderingWorldPair I W)
+/-- The metalinguistic common ground IS the substrate's context set, taken at
+the enriched index type: the Stalnaker generalization is "same object, richer
+worlds", so intersective update and its laws apply unchanged. -/
+abbrev MetalinguisticCG (I W : Type*) := Set (OrderingWorldPair I W)
 
 namespace MetalinguisticCG
 
@@ -597,7 +596,7 @@ variable {I W : Type*}
 /-- Project to a classical context set: forget the ordering coordinate
 (`Set.image` of the world projection). A world survives iff some ordering
 paired with it does. -/
-def toContextSet (cg : MetalinguisticCG I W) : ContextSet W :=
+def toContextSet (cg : MetalinguisticCG I W) : Set W :=
   OrderingWorldPair.world '' cg
 
 variable {L : Language} {E : Type*} [Fintype I] [Fintype E] [DecidableEq E]
@@ -608,34 +607,34 @@ ordering-world pairs at which its assertoric content holds. -/
 def assertoricProp (φ : L.ComparativeFormula E) : Set (OrderingWorldPair I W) :=
   {pair | AssertoricContent interp φ pair.ord pair.world}
 
-/-- Assertion is the substrate's `ContextSet.update` with the assertoric
-proposition — not a new operation. -/
+/-- Assertion is intersective update with the assertoric proposition — not a
+new operation. -/
 def updateAssertoric (cg : MetalinguisticCG I W) (φ : L.ComparativeFormula E) :
     MetalinguisticCG I W :=
-  ContextSet.update cg (assertoricProp interp φ)
+  cg ∩ assertoricProp interp φ
 
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
 /-- Stalnaker's law at the enriched type: assertion restricts the common
-ground (inherited from `ContextSet.update_restricts`). -/
+ground. -/
 theorem updateAssertoric_restricts (cg : MetalinguisticCG I W)
     (φ : L.ComparativeFormula E) : updateAssertoric interp cg φ ⊆ cg :=
-  ContextSet.update_restricts _ _
+  Set.inter_subset_left
 
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
-/-- Assertion order is irrelevant (inherited from `ContextSet.update_comm`). -/
+/-- Assertion order is irrelevant. -/
 theorem updateAssertoric_comm (cg : MetalinguisticCG I W)
     (φ ψ : L.ComparativeFormula E) :
     updateAssertoric interp (updateAssertoric interp cg φ) ψ =
       updateAssertoric interp (updateAssertoric interp cg ψ) φ :=
-  ContextSet.update_comm _ _ _
+  Set.inter_right_comm _ _ _
 
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
-/-- Reassertion is idempotent (inherited from `ContextSet.update_idem`). -/
+/-- Reassertion is idempotent. -/
 theorem updateAssertoric_idem (cg : MetalinguisticCG I W)
     (φ : L.ComparativeFormula E) :
     updateAssertoric interp (updateAssertoric interp cg φ) φ =
-      updateAssertoric interp cg φ :=
-  ContextSet.update_idem _ _
+      updateAssertoric interp cg φ := by
+  simp [updateAssertoric, Set.inter_assoc]
 
 omit [Fintype E] [DecidableEq E] [DecidableAtoms interp] in
 /-- The projection is monotone, so assertion restricts the projected classical
@@ -649,9 +648,9 @@ theorem toContextSet_updateAssertoric_subset (cg : MetalinguisticCG I W)
 
 end MetalinguisticCG
 
-/-- MetalinguisticCG projects to a ContextSet via HasContextSet. -/
-instance {I W : Type*} : HasContextSet (MetalinguisticCG I W) W where
-  toContextSet := MetalinguisticCG.toContextSet
+/-- MetalinguisticCG projects to a classical common ground. -/
+instance {I W : Type*} : HasCommonGround (MetalinguisticCG I W) W where
+  commonGround cg := Filter.principal cg.toContextSet
 
 noncomputable section DegreeTheory
 

--- a/Linglib/Studies/Schlenker2009.lean
+++ b/Linglib/Studies/Schlenker2009.lean
@@ -28,7 +28,6 @@ per-connective local contexts are substrate
 
 namespace Schlenker2009
 
-open CommonGround
 open Semantics.Presupposition
 open Semantics.Presupposition.Context
 open Semantics.Presupposition.BeliefEmbedding
@@ -39,14 +38,14 @@ variable {W : Type*} {Agent : Type*}
 /-- **Negation projects**: "not φ" has the same local context at φ as the
 unembedded sentence (the matrix local context being the global context
 itself), so φ's presupposition projects unless globally entailed. -/
-theorem negation_projects (c : ContextSet W) (p : PartialProp W) :
+theorem negation_projects (c : Set W) (p : PartialProp W) :
     presupProjects (localCtxNegation c) p ↔ presupProjects c p :=
   Iff.rfl
 
 /-- **Conditionals filter**: in "if φ then ψ", the antecedent's assertion
 enters ψ's local context; when it entails ψ's presupposition, the
 presupposition is filtered. -/
-theorem conditional_filters (c : ContextSet W) (p q : PartialProp W)
+theorem conditional_filters (c : Set W) (p q : PartialProp W)
     (h : ∀ w, c w → p.assertion w → q.presup w) :
     presupSatisfied (localCtxConsequent c p) q :=
   conditional_filters_when_entailed c p q h
@@ -54,7 +53,7 @@ theorem conditional_filters (c : ContextSet W) (p q : PartialProp W)
 /-- "If the king exists, the king is bald": the local context at
 "the king is bald" is `c` + [king exists], which entails the existence
 presupposition, so it is filtered. -/
-theorem king_conditional_filters (c : ContextSet KingWorld) :
+theorem king_conditional_filters (c : Set KingWorld) :
     presupSatisfied (localCtxConsequent c kingExists) kingBald := by
   intro w hw
   obtain ⟨-, hw_assert⟩ := hw
@@ -65,7 +64,7 @@ theorem king_conditional_filters (c : ContextSet KingWorld) :
 /-- On the king example, the local-context account and the Karttunen
 filtering connective agree: both pronounce the conditional
 presuppositionless. -/
-theorem king_accounts_agree (c : ContextSet KingWorld) :
+theorem king_accounts_agree (c : Set KingWorld) :
     presupSatisfied (localCtxConsequent c kingExists) kingBald ∧
     ifKingThenBald.presup = (λ _ => True) :=
   ⟨king_conditional_filters c, ifKingThenBald_no_presup⟩

--- a/Linglib/Studies/SolstadBott2024.lean
+++ b/Linglib/Studies/SolstadBott2024.lean
@@ -63,7 +63,6 @@ open SolstadBott2022
 open German.Predicates
 open Semantics.Presupposition
 open Semantics.Presupposition.Context
-open CommonGround
 open Generalizations.Projectivity
 
 /-! ### Filtering direction and context resolution -/
@@ -195,7 +194,7 @@ theorem occasion_presup_projects {W : Type*}
     "If the judge punishes Peter, he was convicted": at "punishes" the
     presupposition is not entailed → projects. -/
 theorem heim_antecedent_projects {W : Type*}
-    (c : ContextSet W) (trigger _consequence : PartialProp W)
+    (c : Set W) (trigger _consequence : PartialProp W)
     (h : ∃ w, c w ∧ ¬trigger.presup w) :
     presupProjects c trigger := by
   obtain ⟨w, hw_in, hpresup_false⟩ := h
@@ -207,13 +206,13 @@ theorem heim_antecedent_projects {W : Type*}
 /-- Symmetric filtering makes the consequent's assertion available to the local
     context at the antecedent. -/
 def symmetricLocalCtxAntecedent {W : Type*}
-    (c : ContextSet W) (consequent : PartialProp W) : ContextSet W :=
-  ContextSet.update c consequent.assertion
+    (c : Set W) (consequent : PartialProp W) : Set W :=
+  c ∩ {w | consequent.assertion w}
 
 /-- When the consequent entails the occasion presupposition, symmetric filtering
     predicts it is filtered. -/
 theorem symmetric_filters_when_consequent_entails {W : Type*}
-    (c : ContextSet W) (trigger consequent : PartialProp W)
+    (c : Set W) (trigger consequent : PartialProp W)
     (h : ∀ w, c w → consequent.assertion w → trigger.presup w) :
     presupSatisfied (symmetricLocalCtxAntecedent c consequent) trigger := by
   intro w hw

--- a/Linglib/Studies/Stalnaker1975.lean
+++ b/Linglib/Studies/Stalnaker1975.lean
@@ -33,7 +33,7 @@ import Linglib.Discourse.CommonGround
    the formal point is that constructive dilemma is valid only for
    entailments, not for reasonable inferences.
 
-6. **Polymorphic lift via `CommonGround.HasAssertion`** (§ 4 below): the
+6. **Polymorphic lift via `HasAssertion`** (§ 4 below): the
    Stalnaker-1975 change-function calculus is shown to be the
    Stalnaker-instance projection of the framework-generic
    `HasAssertion.assert`. The direct-argument theorem then lifts
@@ -83,7 +83,7 @@ The formal apparatus is a triple `(⟦·⟧, A, g)`:
 * `A(P, k)`: the **appropriateness** relation — whether asserting `P` in
   context `k` is appropriate;
 * `g(P, k) = k ∩ ⟦P⟧_k`: the **change function** — the new context after
-  asserting `P`. This is exactly `CommonGround.ContextSet.update`.
+  asserting `P`. This is exactly intersective update of the context set.
 
 This module defines `Appropriateness`, sequential appropriateness `A*`,
 sequential update `g*`, and the `reasonableInference` predicate.
@@ -96,7 +96,6 @@ exhibits the gap.
 
 namespace Discourse.ReasonableInference
 
-open CommonGround
 
 /--
 **Appropriateness** of a sentence in a context. Stalnaker leaves this
@@ -104,24 +103,24 @@ maximally schematic; concrete theories of conditionals, disjunction,
 presupposition fill it in. Two universal constraints from the Appendix
 are captured below as `compatible_of_appropriate` and the change-function
 identity. -/
-abbrev Appropriateness (W : Type*) := Set W → ContextSet W → Prop
+abbrev Appropriateness (W : Type*) := Set W → Set W → Prop
 
 /--
-The **change function** `g(P, k) = k ∩ ⟦P⟧_k`. Already exists as
-`ContextSet.update`; this is the Stalnakerian alias. -/
-def changeFn {W : Type*} (P : Set W) (k : ContextSet W) : ContextSet W :=
-  ContextSet.update k P
+The **change function** `g(P, k) = k ∩ ⟦P⟧_k`: intersective update of the
+context set. -/
+def changeFn {W : Type*} (P : Set W) (k : Set W) : Set W :=
+  k ∩ P
 
 /-- Sequential update along a list of asserted sentences. -/
-def changeFnSeq {W : Type*} (σ : List (Set W)) (k : ContextSet W) :
-    ContextSet W :=
+def changeFnSeq {W : Type*} (σ : List (Set W)) (k : Set W) :
+    Set W :=
   σ.foldl (λ acc P => changeFn P acc) k
 
 /-- Sequential appropriateness: each `Pᵢ` is appropriate in the context
     obtained by updating with `P₁, …, Pᵢ₋₁`. Stalnaker's `A(σ, k) = ⋀ᵢ
     A(Pᵢ, kᵢ)`. -/
 def appropriateSeq {W : Type*} (A : Appropriateness W)
-    (σ : List (Set W)) (k : ContextSet W) : Prop :=
+    (σ : List (Set W)) (k : Set W) : Prop :=
   match σ with
   | [] => True
   | P :: rest => A P k ∧ appropriateSeq A rest (changeFn P k)
@@ -132,16 +131,16 @@ def appropriateSeq {W : Type*} (A : Appropriateness W)
 `σ ⊨ᵣ Q` (reasonable-in-`A`) iff in every context `k` in which the premise
 sequence is appropriate, the post-update context entails the conclusion.
 
-This is **distinct from** `ContextSet.entails (changeFnSeq σ k) ⟦Q⟧` for
+This is **distinct from** `changeFnSeq σ k ⊆ ⟦Q⟧` for
 *arbitrary* `k`: reasonable inference quantifies only over contexts in
 which the premises can be asserted in sequence. The premise filter is
 exactly what lets pragmatic information (e.g., the disjunction-
 appropriateness condition) feed into the inference. -/
 def reasonableInference {W : Type*} (A : Appropriateness W)
     (σ : List (Set W)) (Q : Set W) : Prop :=
-  ∀ k : ContextSet W,
+  ∀ k : Set W,
     appropriateSeq A σ k →
-    ContextSet.entails (changeFnSeq σ k) Q
+    changeFnSeq σ k ⊆ Q
 
 /-- **Entailment ⇒ reasonable inference** for any appropriateness relation:
     if a single premise semantically entails the conclusion, the inference
@@ -160,22 +159,21 @@ theorem entailment_implies_reasonable {W : Type*}
 theorem reasonable_nil {W : Type*} (A : Appropriateness W) (Q : Set W) :
     reasonableInference A [] Q ↔ ∀ w, Q w := by
   unfold reasonableInference changeFnSeq appropriateSeq
-  refine ⟨λ h w => h ContextSet.trivial trivial (Set.mem_univ w),
+  refine ⟨λ h w => h Set.univ trivial (Set.mem_univ w),
           λ h _ _ _ hw => h _⟩
 
 /-- **Stalnaker's first universal constraint** ([stalnaker-1975]
     Appendix, postulate 1): one cannot appropriately assert a proposition
     in a context incompatible with it. Any concrete `A` should satisfy this. -/
 def respectsCompatibility {W : Type*} (A : Appropriateness W) : Prop :=
-  ∀ P k, A P k → ContextSet.compatible k P
+  ∀ P k, A P k → (k ∩ P).Nonempty
 
 /-- **Stalnaker's second universal constraint** ([stalnaker-1975]
     Appendix, postulate 2): the change function commutes with the
     interpretation — `g(P, k) = k ∩ ⟦P⟧_k`. This holds by construction
     of `changeFn`. -/
-theorem changeFn_eq {W : Type*} (P : Set W) (k : ContextSet W) (w : W) :
-    changeFn P k w ↔ k w ∧ P w := by
-  unfold changeFn ContextSet.update; rfl
+theorem changeFn_eq {W : Type*} (P : Set W) (k : Set W) (w : W) :
+    changeFn P k w ↔ k w ∧ P w := Iff.rfl
 
 end Discourse.ReasonableInference
 
@@ -183,7 +181,6 @@ end Discourse.ReasonableInference
 namespace Stalnaker1975
 
 open Mood (Grammatical)
-open CommonGround (ContextSet)
 open _root_.Semantics.Conditionals (SelectionFunction)
 open Semantics.Conditionals
 open Discourse.ReasonableInference
@@ -208,7 +205,7 @@ Stalnaker's appropriateness condition for disjunction (§III, end) — that
 asserting `A or B` requires both `¬A∧B` and `A∧¬B` to be open in the prior
 context — is what guarantees `h_open_notA` after the update. -/
 theorem direct_argument_reasonable {W : Type*}
-    (s : SelectionFunction W) (C : ContextSet W)
+    (s : SelectionFunction W) (C : Set W)
     (notA B AorB : W → Prop)
     (h_constraint : pragmaticConstraint s C)
     (h_C_AorB : ∀ w, C w → AorB w)
@@ -343,14 +340,14 @@ theorem direct_argument_holds_under_indicative_selection :
 
 /-! Stalnaker 1975's change-function calculus uses `changeFn p k`
 (set intersection) as the post-assertion update operator. The
-`CommonGround.HasAssertion` typeclass abstracts over
+`HasAssertion` typeclass abstracts over
 *any* dialogue-state representation that admits Stalnakerian
 narrowing. This section shows that:
 
 1. The `changeFn` operator IS the projection of
    `HasAssertion.assert` in EVERY `HasAssertion` framework — the
-   typeclass's `toContextSet_assert` law restated through
-   `changeFn = ContextSet.update`.
+   typeclass's `commonGround_assert` law restated through
+   `changeFn` = intersective update.
 2. The direct-argument theorem lifts to be polymorphic over
    `[HasAssertion S W]` — Stalnaker's "reasonable inference" claim
    doesn't depend on Stalnaker's particular state representation.
@@ -359,25 +356,24 @@ narrowing. This section shows that:
    commitment-space representation with a radically different
    internal structure but the same projected context-set behavior).
 
-This is the consumer that earns the `CommonGround.HasAssertion`
+This is the consumer that earns the `HasAssertion`
 typeclass's existence: a substantive philosophical claim
 (reasonable inference is framework-generic) given a
 substrate-level proof (the typeclass's update law is
 sufficient). -/
 
-open CommonGround (HasAssertion)
-open CommonGround (HasContextSet)
+open HasCommonGround (contextSet)
 
 /-- **Bridge theorem**: Stalnaker's `changeFn` operator equals the
-    `HasContextSet`-projection of `HasAssertion.assert` — in any
+    context-set projection of `HasAssertion.assert` — in any
     `HasAssertion` framework, since `changeFn p k` is definitionally
-    `ContextSet.update k p` (Stalnaker 1975 Appendix postulate 2) and
-    the typeclass's update law demands exactly that projection. -/
+    `k ∩ p` (Stalnaker 1975 Appendix postulate 2) and the typeclass's
+    update law projects to exactly that (`HasAssertion.contextSet_assert`). -/
 theorem assert_eq_changeFn {S W : Type*} [HasAssertion S W]
     (s : S) (p : Set W) :
-    HasContextSet.toContextSet (HasAssertion.assert s p) =
-    changeFn p (HasContextSet.toContextSet s) :=
-  HasAssertion.toContextSet_assert s p
+    contextSet (HasAssertion.assert s p) =
+    changeFn p (contextSet s) :=
+  HasAssertion.contextSet_assert s p
 
 /-- **Polymorphic direct argument**: for ANY `HasAssertion` framework,
     asserting `A∨B` yields a context set in which the indicative
@@ -387,7 +383,7 @@ theorem assert_eq_changeFn {S W : Type*} [HasAssertion S W]
     (`direct_argument_reasonable`) because the HasAssertion typeclass
     provides one of the hypotheses for free: every world surviving
     the assertion satisfies `AorB` (the typeclass law
-    `assert_narrows`). Compare with the Stalnaker-specific
+    `contextSet_assert`). Compare with the Stalnaker-specific
     version, which had to take this as a hypothesis (`h_C_AorB`). -/
 theorem direct_argument_reasonable_polymorphic
     {S W : Type*} [HasAssertion S W]
@@ -395,29 +391,30 @@ theorem direct_argument_reasonable_polymorphic
     (notA B AorB : W → Prop)
     (h_AorB_decomp : ∀ w, AorB w → notA w → B w)
     (h_constraint : pragmaticConstraint sel
-      (HasContextSet.toContextSet (HasAssertion.assert s AorB)))
+      (contextSet (HasAssertion.assert s AorB)))
     (h_open_notA : ∃ w' ∈ {w' | notA w'},
-      HasContextSet.toContextSet (HasAssertion.assert s AorB) w') :
-    ∀ w, HasContextSet.toContextSet (HasAssertion.assert s AorB) w →
+      contextSet (HasAssertion.assert s AorB) w') :
+    ∀ w, contextSet (HasAssertion.assert s AorB) w →
       moodedConditional .indicative sel notA B w := by
   apply direct_argument_reasonable sel _ notA B AorB h_constraint
     _ h_AorB_decomp h_open_notA
   -- The post-assertion context set ⊆ {w | AorB w}, by the typeclass law.
   intro w hw
-  exact HasAssertion.assert_narrows s AorB hw
+  rw [HasAssertion.contextSet_assert] at hw
+  exact hw.2
 
 /-- **Stalnaker instance application**: the polymorphic lift fires on
     the Stalnaker framework. Recovers the framework-specific
     `direct_argument_reasonable` for the post-assertion context. -/
 theorem direct_argument_reasonable_stalnaker {W : Type*}
-    (s : CommonGround W) (sel : SelectionFunction W)
+    (s : Filter W) (sel : SelectionFunction W)
     (notA B AorB : W → Prop)
     (h_AorB_decomp : ∀ w, AorB w → notA w → B w)
     (h_constraint : pragmaticConstraint sel
-      (HasContextSet.toContextSet (HasAssertion.assert s AorB)))
+      (contextSet (HasAssertion.assert s AorB)))
     (h_open_notA : ∃ w' ∈ {w' | notA w'},
-      HasContextSet.toContextSet (HasAssertion.assert s AorB) w') :
-    ∀ w, HasContextSet.toContextSet (HasAssertion.assert s AorB) w →
+      contextSet (HasAssertion.assert s AorB) w') :
+    ∀ w, contextSet (HasAssertion.assert s AorB) w →
       moodedConditional .indicative sel notA B w :=
   direct_argument_reasonable_polymorphic s sel notA B AorB
     h_AorB_decomp h_constraint h_open_notA
@@ -433,10 +430,10 @@ theorem direct_argument_reasonable_krifka {W : Type*}
     (notA B AorB : W → Prop)
     (h_AorB_decomp : ∀ w, AorB w → notA w → B w)
     (h_constraint : pragmaticConstraint sel
-      (HasContextSet.toContextSet (HasAssertion.assert s AorB)))
+      (contextSet (HasAssertion.assert s AorB)))
     (h_open_notA : ∃ w' ∈ {w' | notA w'},
-      HasContextSet.toContextSet (HasAssertion.assert s AorB) w') :
-    ∀ w, HasContextSet.toContextSet (HasAssertion.assert s AorB) w →
+      contextSet (HasAssertion.assert s AorB) w') :
+    ∀ w, contextSet (HasAssertion.assert s AorB) w →
       moodedConditional .indicative sel notA B w :=
   direct_argument_reasonable_polymorphic s sel notA B AorB
     h_AorB_decomp h_constraint h_open_notA

--- a/Linglib/Studies/TonhauserEtAl2013.lean
+++ b/Linglib/Studies/TonhauserEtAl2013.lean
@@ -27,40 +27,40 @@ substrate's own rendering of that theory, `Context.presupSatisfied` at the matri
 
 namespace TonhauserEtAl2013
 
-open CommonGround Semantics.Presupposition Semantics.Presupposition.Context
+open Semantics.Presupposition Semantics.Presupposition.Context
   Semantics.Presupposition.BeliefEmbedding Semantics.Presupposition.ProjectiveContent
 
-variable {W E : Type*} (m : Set W) (c : ContextSet W)
+variable {W E : Type*} (m : Set W) (c : Set W)
 
 /-- (10): the context entails `m`. -/
-def MPositive : Prop := ContextSet.entails c m
+def MPositive : Prop := c ⊆ m
 
 /-- (10): the context entails neither `m` nor `¬m`. -/
-def MNeutral : Prop := ¬ ContextSet.entails c m ∧ ¬ ContextSet.entails c mᶜ
+def MNeutral : Prop := ¬ c ⊆ m ∧ ¬ c ⊆ mᶜ
 
 /-- (11): uttering the trigger's sentence, acceptable in the contexts `Acc`, is acceptable
 only in `m`-positive contexts. -/
-def StrongContextualFelicity (Acc : ContextSet W → Prop) : Prop := ∀ c, Acc c → MPositive m c
+def StrongContextualFelicity (Acc : Set W → Prop) : Prop := ∀ c, Acc c → MPositive m c
 
 /-- (12i): acceptability in an `m`-neutral context refutes the constraint. -/
-theorem not_scf_of_acceptable_neutral {Acc : ContextSet W → Prop} (h : Acc c)
+theorem not_scf_of_acceptable_neutral {Acc : Set W → Prop} (h : Acc c)
     (hn : MNeutral m c) : ¬ StrongContextualFelicity m Acc :=
   fun hs => hn.1 (hs c h)
 
 /-- §5: under `a believes S` at `w`, `m` has local effect when it is part of `a`'s belief
 state. -/
 def LocalEffect (Dox : E → W → W → Prop) (a : E) (w : W) : Prop :=
-  ContextSet.entails (Dox a w) m
+  {v | Dox a w v} ⊆ m
 
 /-- Obligatory local effect: wherever the belief report is acceptable, `m` has local effect. -/
-def ObligatoryLocalEffect (Dox : E → W → W → Prop) (a : E) (Acc : ContextSet W → Prop) :
+def ObligatoryLocalEffect (Dox : E → W → W → Prop) (a : E) (Acc : Set W → Prop) :
     Prop :=
   ∀ c, Acc c → ∀ w ∈ c, LocalEffect m Dox a w
 
 /-- (41i): acceptability of the report with the holder ignorant of `m` refutes obligatory
 local effect. -/
 theorem not_ole_of_acceptable_ignorant {Dox : E → W → W → Prop} {a : E}
-    {Acc : ContextSet W → Prop} (h : Acc c) {w : W} (hw : w ∈ c) (hig : MNeutral m (Dox a w)) :
+    {Acc : Set W → Prop} (h : Acc c) {w : W} (hw : w ∈ c) (hig : MNeutral m (Dox a w)) :
     ¬ ObligatoryLocalEffect m Dox a Acc :=
   fun ho => hig.1 (ho c h w hw)
 

--- a/Linglib/Studies/Wang2025.lean
+++ b/Linglib/Studies/Wang2025.lean
@@ -184,7 +184,6 @@ theorem additive_deRe_available : ye_deRe.accepted = true := rfl
 -- ============================================================================
 
 open Semantics.Presupposition (PartialProp)
-open CommonGround (ContextSet)
 
 /-- Local Bool-valued accessibility used by Wang2025 for `List.all` evaluation
 of the speaker-K operator. The Prop-valued canonical version lives in
@@ -246,7 +245,7 @@ FP (Felicity Presupposition): the common ground entails the presupposition.
 Standard Stalnakerian presupposition satisfaction. When the CommonGround only partially
 entails the presupposition, FP is violated but may be tolerated.
 -/
-def satisfiesFP (cg : ContextSet W) (p : PartialProp W) : Prop :=
+def satisfiesFP (cg : Set W) (p : PartialProp W) : Prop :=
   ∀ w, cg w → PartialProp.defined w p
 
 /--
@@ -256,7 +255,7 @@ but not fully entailed.
 [wang-2025] Ch. 2-3: some triggers tolerate partial satisfaction (ye, you, reng)
 while others don't (jiu, zhidao).
 -/
-def partialFP (cg : ContextSet W) (p : PartialProp W) : Prop :=
+def partialFP (cg : Set W) (p : PartialProp W) : Prop :=
   (∃ w, cg w ∧ PartialProp.defined w p) ∧ ¬satisfiesFP cg p
 
 /--
@@ -266,7 +265,7 @@ form is more informative and the CommonGround supports its presupposition.
 MP is violated when the non-presuppositional alternative S is used despite
 the CommonGround supporting S_p's presupposition.
 -/
-def mpPrefers (cg : ContextSet W) (sp : PartialProp W) : Prop :=
+def mpPrefers (cg : Set W) (sp : PartialProp W) : Prop :=
   satisfiesFP cg sp ∧ satisfiesIC sp
 
 

--- a/references.bib
+++ b/references.bib
@@ -8184,6 +8184,29 @@
   role      = {cited},
   sources   = {Semantics/Presupposition/TriggerTypology.lean}
 }
+@book{chellas-1980,
+  author    = {Chellas, Brian F.},
+  year      = {1980},
+  title     = {Modal Logic: An Introduction},
+  publisher = {Cambridge University Press},
+  address   = {Cambridge},
+  doi       = {10.1017/CBO9780511621192},
+  subfield  = {semantics/modality},
+  role      = {cited},
+  sources   = {Discourse/CommonGround.lean}
+}
+
+@book{gardenfors-1988,
+  author    = {G{\"a}rdenfors, Peter},
+  year      = {1988},
+  title     = {Knowledge in Flux: Modeling the Dynamics of Epistemic States},
+  publisher = {MIT Press},
+  address   = {Cambridge, MA},
+  subfield  = {pragmatics/discourse},
+  role      = {cited},
+  sources   = {Discourse/CommonGround.lean}
+}
+
 @book{halpern-2003,
   author    = {Halpern, Joseph Y.},
   year      = {2003},
@@ -14465,6 +14488,18 @@
   validated = {true},
   sources   = {Discourse/CommonGround.lean}
 }
+@book{stalnaker-2014,
+  author    = {Stalnaker, Robert C.},
+  year      = {2014},
+  title     = {Context},
+  publisher = {Oxford University Press},
+  address   = {Oxford},
+  doi       = {10.1093/acprof:oso/9780199645169.001.0001},
+  subfield  = {pragmatics/discourse},
+  role      = {cited},
+  sources   = {Discourse/CommonGround.lean}
+}
+
 @incollection{stalnaker-1974,
   author    = {Stalnaker, Robert C.},
   year      = {1974},


### PR DESCRIPTION
The common ground becomes mathlib's `Filter W`: acceptance closed under entailment and finite conjunction with the trivial proposition — the filter axioms ([chellas-1980] §7.3: "every augmented model is a filter", verified against the book; independently Karttunen 1974's notion). The context set is `Filter.ker` (Chellas' smallest proposition; `𝓟 ⊣ ker` is Stalnaker's duality, and the principal/augmented case is exactly Kripke, Thm 7.9); assertion is `· ⊓ 𝓟 φ`, so commutativity/idempotence are lattice laws; consistency is `NeBot`.

- `ContextSet` + its `entails`/`compatible`/`update` aliases and the `List`-backed `CommonGround` structure dissolve; `HasContextSet` → filter-valued `HasCommonGround`; `HasAssertion` laws become `commonGround initial = ⊤` and `commonGround (assert s φ) = commonGround s ⊓ 𝓟 φ`; histories via `commonGround_play` (permutation-invariance from the set-builder). The iterated-attitude epistemology stays quarantined in `Filter.GroundedIn` (Implementation notes say why).
- 36 files migrated: the Commitment stack (Gunlogson/Krifka `HasAssertion` instances re-derive their laws via `congrArg 𝓟`), F&B `DiscourseState.cg : Filter W` with `cgPropositions` bookkeeping replaced by membership, Gameboard/Ginzburg via `principal_eq_iff_eq`, Anderson2021's PMF instance as `𝓟 support`, Stalnaker1975's polymorphic direct argument shortened by the substrate's `contextSet_assert`.
- Bib: chellas-1980, gardenfors-1988, stalnaker-2014. Full library build clean.