### PR TITLE
docs(Discourse/CommonGround): cite Lederman 2014 and the SEP survey

### DIFF
--- a/Linglib/Discourse/CommonGround.lean
+++ b/Linglib/Discourse/CommonGround.lean
@@ -24,12 +24,13 @@ the absurd context is `⊥`.
 
 ## Implementation notes
 
-The filter axioms are the body-of-information view of the common ground and deliberately
-carry no epistemology: whether what grounds them is iterated common belief
-([stalnaker-2002]) or common acceptance as a primitive ([stalnaker-2014]) is stated
-separately, as `Filter.GroundedIn` in `Logic/Modal/Epistemic.lean` — the epistemology, and
-in particular closure of acceptance under conjunction (the filter's `inter_sets`), is the
-contested idealization in that debate, not a commitment every consumer inherits.
+The filter axioms are the body-of-information view of the common ground ([geurts-2024]'s
+survey) and deliberately carry no epistemology: whether what grounds them is iterated
+common belief ([stalnaker-2002]), common acceptance as a primitive ([stalnaker-2014]), or
+[lederman-2014]'s non-iterated minimal theory is stated separately, as `Filter.GroundedIn`
+in `Logic/Modal/Epistemic.lean` — the epistemology, and in particular closure of acceptance
+under conjunction (the filter's `inter_sets`, [lederman-2014] §2.C's contested axiom), is
+the disputed idealization in that debate, not a commitment every consumer inherits.
 Proposal-based ([farkas-bruce-2010]) and graded non-monotonic ([anderson-2021]) assertion
 models are deliberate non-instances of `HasAssertion`; see
 `FarkasBruce2010.assert_not_narrowing` and `Anderson2021.graded_update_keeps_false_world`.

--- a/Linglib/Logic/Modal/Epistemic.lean
+++ b/Linglib/Logic/Modal/Epistemic.lean
@@ -9,8 +9,9 @@ This file defines the group knowledge operators of [fagin-halpern-moses-vardi-19
 agent-indexed accessibility relations `Rs : E → W → W → Prop`: individual knowledge `Kᵢ` is
 `box (Rs i)`, everyone-knows `E_G` is `box` over the union `⨆ i ∈ G, Rs i`, distributed
 knowledge `D_G` is `box` over the intersection `⨅ i ∈ G, Rs i`, and common knowledge `C_G` is
-`box` over the transitive closure of the union — `φ` holds at every world reachable by a chain
-of members' accessibility. The infinite-conjunction form `E_G φ ∧ E_G (E_G φ) ∧ ⋯` is the
+`box` over the transitive closure of the union — `φ` holds at every world reachable by a
+chain of members' accessibility ([lederman-2014] Appendix 2.B's construction). The
+infinite-conjunction form `E_G φ ∧ E_G (E_G φ) ∧ ⋯` is the
 theorem `commonKnowledge_iff_forall_iterate`, an instance of `ModalLogic.box_transGen_iff`.
 Belief is the same operator over a KD45 frame (`ModalLogic.IsKD45Frame`), with the D, 4, and
 5 laws `ModalLogic.box_D`, `ModalLogic.box_four`, and `ModalLogic.box_five`.

--- a/references.bib
+++ b/references.bib
@@ -1785,6 +1785,31 @@
   validated = {true},
   sources   = {Core/Order/Comparison.lean;Semantics/Degree/Predicate.lean;Semantics/Quantification/Numerals/Basic.lean}
 }
+@incollection{geurts-2024,
+  author    = {Geurts, Bart},
+  year      = {2024},
+  title     = {Common Ground in Pragmatics},
+  booktitle = {The Stanford Encyclopedia of Philosophy},
+  editor    = {Zalta, Edward N. and Nodelman, Uri},
+  publisher = {Metaphysics Research Lab, Stanford University},
+  note      = {First published October 3, 2024},
+  url       = {https://plato.stanford.edu/entries/common-ground-pragmatics/},
+  subfield  = {pragmatics/discourse},
+  role      = {cited},
+  sources   = {Discourse/CommonGround.lean}
+}
+
+@unpublished{lederman-2014,
+  author    = {Lederman, Harvey},
+  year      = {2014},
+  title     = {A Theory of Common Ground},
+  note      = {Chapter 2 of \emph{Uncommon Knowledge} (2014). PhilArchive: LEDATO-2},
+  url       = {https://philarchive.org/rec/LEDATO-2},
+  subfield  = {pragmatics/discourse},
+  role      = {cited},
+  sources   = {Discourse/CommonGround.lean;Logic/Modal/Epistemic.lean}
+}
+
 @incollection{geurts-beaver-maier-2024,
   author    = {Geurts, Bart and Beaver, David I. and Maier, Emar},
   year      = {2024},


### PR DESCRIPTION
Follow-up to #2308, adding the epistemology-of-common-ground anchors (both verified against the documents).

- `lederman-2014` (*A Theory of Common Ground*, PhilArchive LEDATO-2): the non-iterated minimal theory, §2.C's identification of acceptance-closure-under-∩ (the filter's `inter_sets`) as the contested axiom, and Appendix 2.B's transitive-closure-of-union construction — now cited from `Epistemic.commonKnowledge`, which implements it verbatim.
- `geurts-2024` (SEP, *Common Ground in Pragmatics*) as the survey anchor for the body-of-information view.