### PR TITLE
refactor(Syntax/Case): make the neutral case API actually neutral

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2783,7 +2783,6 @@ import Linglib.Syntax.CCG.Intonation
 import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Case.Assigner
 import Linglib.Syntax.Case.Dependent
-import Linglib.Syntax.Case.Filter
 import Linglib.Syntax.Case.Licensing
 import Linglib.Syntax.Case.Order
 import Linglib.Syntax.Category.Adjective.Basic
@@ -2862,6 +2861,7 @@ import Linglib.Syntax.Minimalist.Ellipsis
 import Linglib.Syntax.Minimalist.ExtendedProjection.Basic
 import Linglib.Syntax.Minimalist.ExtendedProjection.ClauseSpine
 import Linglib.Syntax.Minimalist.ExtendedProjection.Properties
+import Linglib.Syntax.Minimalist.Case
 import Linglib.Syntax.Minimalist.Features
 import Linglib.Syntax.Minimalist.LateMerger
 import Linglib.Syntax.Minimalist.LeftPeriphery

--- a/Linglib/Features/Case/Source.lean
+++ b/Linglib/Features/Case/Source.lean
@@ -9,10 +9,10 @@ dimension on which the formalized assignment accounts agree that a case
 "comes from" somewhere. It is **not** a theory-neutral universal: it is the
 common quotient that Marantz dependent case (`Syntax/Case/Dependent.lean`'s
 `CaseSource`) and Kalin hybrid licensing (`Syntax/Case/Licensing.lean`'s
-`LicensingOutcome`) both map *into* (`toNeutral`), so a cross-theory
-comparison can ask whether two accounts agree on *provenance*, not merely on
-the surface case. Each account keeps its own finer source enum; `Source` is
-where they become commensurable.
+`LicensingOutcome`) both map into, so a cross-theory comparison can ask
+whether two accounts agree on *provenance*, not merely on the surface case.
+Each account keeps its own finer source enum; `Source` is where they become
+commensurable.
 
 Living in `Features/` — below the assignment theories — lets both theories
 project into it (and lets a future pooled comparison name it). The
@@ -32,17 +32,14 @@ namespace Case
       Chomskyan `agree`, Kalin primary/secondary licensing);
     * `inherent` — lexical/quirky, θ-associated (Marantz `lexical`, Kalin
       `byLexical`);
-    * `default` — elsewhere / last-resort unmarked case;
-    * `uncased` — no source valued the nominal: the crash (Kalin
-      `unlicensed`, a Case-Filter violation).
+    * `default` — elsewhere / last-resort unmarked case.
 
-    A *total* assignment account never produces `uncased`; a licensing
-    account can. -/
+    Failure to assign is not a provenance and is not a cell here: an account
+    that can fail reports it as `Syntax.Case.Assignment.unassigned`. -/
 inductive Source where
   | structural
   | inherent
   | default
-  | uncased
   deriving DecidableEq, Repr, Inhabited
 
 /-- The case was valued by configuration or Agree. The structural-vs-inherent
@@ -51,12 +48,5 @@ def Source.IsStructural (s : Source) : Prop := s = .structural
 
 instance (s : Source) : Decidable s.IsStructural :=
   inferInstanceAs (Decidable (s = .structural))
-
-/-- The derivation crashed: no source valued the nominal. Distinguishes a
-    licensing account (which can fail) from a total assignment account. -/
-def Source.IsCrash (s : Source) : Prop := s = .uncased
-
-instance (s : Source) : Decidable s.IsCrash :=
-  inferInstanceAs (Decidable (s = .uncased))
 
 end Case

--- a/Linglib/Studies/Kalin2018.lean
+++ b/Linglib/Studies/Kalin2018.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Case.Assigner
+import Linglib.Syntax.Minimalist.Case
 
 /-!
 # Kalin (2018) — Licensing and Differential Object Marking
@@ -36,7 +37,8 @@ namespace Kalin2018
 
 open Syntax.Case
 open Syntax.Case.Licensing (ClauseLicensers Licenser LicensingOutcome LicensedNP
-  licenseNPs getOutcomeOf)
+  LicensedResult licenseNPs getOutcomeOf)
+open Minimalist (DPFeatures satisfiesCaseFilter caseFilterHolds)
 
 /-! ### Senaya clause configurations
 
@@ -124,5 +126,37 @@ theorem perfective_object_verdicts :
 theorem dependentCase_vs_licensing_diverge_on_perfective_object :
     ¬ AgreesOnCase (dependentAssigner .accusative)
         (kalinAssigner perfectiveClause) specificObjectClause := by decide
+
+/-! ### The Case Filter as a theorem of licensing -/
+
+/-! [kalin-2018] takes licensing to subsume the Case Filter: a nominal
+converges exactly when some licenser valued it. Stated against the
+Agree-based formulation of `Syntax/Minimalist/Case.lean`, the two convergence
+conditions coincide, so the filter need not be stipulated alongside licensing.
+-/
+
+/-- The DP feature bundle a licensing outcome induces: any valued outcome
+    gives a DP with valued [Case], the crash gives one with [uCase]. -/
+def dpFeaturesOf : LicensingOutcome → DPFeatures
+  | .byPrimary _ c   => DPFeatures.withCase [] c
+  | .bySecondary _ c => DPFeatures.withCase [] c
+  | .byLexical c     => DPFeatures.withCase [] c
+  | .unlicensed      => DPFeatures.withUnvaluedCase []
+
+/-- A nominal is licensed iff it satisfies the Case Filter. -/
+theorem isLicensed_iff_satisfiesCaseFilter (o : LicensingOutcome) :
+    o.IsLicensed ↔ satisfiesCaseFilter (dpFeaturesOf o) := by
+  cases o <;>
+    simp [satisfiesCaseFilter, dpFeaturesOf, HasCase.caseOf,
+      DPFeatures.withCase, DPFeatures.withUnvaluedCase]
+
+/-- A derivation converges under licensing iff its DPs satisfy the Case
+    Filter. -/
+theorem all_isLicensed_iff_caseFilterHolds (results : List LicensedResult) :
+    (∀ r ∈ results, r.outcome.IsLicensed) ↔
+      caseFilterHolds (results.map λ r => dpFeaturesOf r.outcome) := by
+  simp only [caseFilterHolds, List.all_eq_true, List.mem_map,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
+    isLicensed_iff_satisfiesCaseFilter]
 
 end Kalin2018

--- a/Linglib/Studies/Kalin2018.lean
+++ b/Linglib/Studies/Kalin2018.lean
@@ -106,13 +106,13 @@ theorem subject_always_licensed :
 
 /-- On the perfective object, the two accounts assign **incompatible
     verdicts**: a Marantz-style total configurational account gives it a
-    structural accusative, while Kalin licensing crashes it (`uncased`,
-    caseless). This is the witness behind the divergence. -/
+    structural accusative, while Kalin licensing assigns it nothing. This is
+    the witness behind the divergence. -/
 theorem perfective_object_verdicts :
     dependentAssigner .accusative specificObjectClause "obj"
-      = some ⟨.structural, some .acc⟩ ∧
+      = some (.assigned .acc .structural) ∧
     kalinAssigner perfectiveClause specificObjectClause "obj"
-      = some ⟨.uncased, none⟩ := by
+      = some .unassigned := by
   exact ⟨by decide, by decide⟩
 
 /-- **Licensing diverges from total configurational case assignment**

--- a/Linglib/Studies/Poole2024.lean
+++ b/Linglib/Studies/Poole2024.lean
@@ -51,12 +51,12 @@ def agreeAssigner : Assigner := fun nps label =>
   | none => none
   | some np =>
     match np.lexicalCase with
-    | some c => some ⟨.inherent, some c⟩
+    | some c => some (.assigned c .inherent)
     | none =>
       let caseless := (nps.filter (·.lexicalCase.isNone)).map (·.label)
       match caseless.findIdx (· == np.label) with
-      | 1 => some ⟨.structural, some .acc⟩   -- second probe: dependent ACC
-      | _ => some ⟨.default, some .nom⟩      -- unlocker / lone DP: unmarked
+      | 1 => some (.assigned .acc .structural)   -- second probe: dependent ACC
+      | _ => some (.assigned .nom .default)      -- unlocker / lone DP: unmarked
   /- (`findIdx` is total — `np` is caseless and present, so its label is in
      `caseless`; index 0 is the unlocker, ≥2 are post-discharge.) -/
 
@@ -76,7 +76,7 @@ private def stim2 (sc oc : Option Case) (sn on : Bool) : List LicensedNP :=
 
 /-- **m1 = m2 on every transitive clause.** For *any* case content (`sc`, `oc`)
     and licensing status of the two arguments, the Agree probe stack and
-    configurational dependent case assign the identical verdict — case *and*
+    configurational dependent case assign the identical result — case *and*
     provenance — to each argument. This is [poole-2024]'s extensional
     equivalence as a statement about the two *functions*, not a finite sample:
     on the configurations a single low-dependent stack covers, m2 ≤ m1. -/
@@ -89,7 +89,7 @@ theorem agree_eq_dependent_two_args (sc oc : Option Case) (sn on : Bool) :
   rcases hnp with rfl | rfl <;> cases sc <;> cases oc <;> rfl
 
 /-- **m1 ≈ m2 through the harness, over the whole paradigm.** A corollary of
-    the verdict identity: the two accounts `AgreesOnCase` *and* `AgreesOnSource`
+    the assignment identity: the two accounts `AgreesOnCase` *and* `AgreesOnSource`
     on every transitive — the convergence dual of `Kalin2018`'s
     `dependentCase_vs_licensing_diverge_on_perfective_object` (`¬ AgreesOnCase`).
     The harness compares outcomes, so this is exactly the extensional
@@ -120,8 +120,9 @@ private def threeCaseless : List LicensedNP :=
     single probe stack leaves it unmarked (`nom`), whereas configurational case
     marks it accusative (it is c-commanded by a caseless DP). -/
 theorem agree_diverges_dependent_three_caseless :
-    agreeAssigner threeCaseless "c" = some ⟨.default, some .nom⟩ ∧
-    dependentAssigner .accusative threeCaseless "c" = some ⟨.structural, some .acc⟩ := by
+    agreeAssigner threeCaseless "c" = some (.assigned .nom .default) ∧
+    dependentAssigner .accusative threeCaseless "c"
+      = some (.assigned .acc .structural) := by
   exact ⟨by decide, by decide⟩
 
 end Poole2024

--- a/Linglib/Syntax/Case/Assigner.lean
+++ b/Linglib/Syntax/Case/Assigner.lean
@@ -36,43 +36,61 @@ namespace Syntax.Case
 
 open Licensing (LicensedNP ClauseLicensers Licenser licenseNPs LicensingOutcome)
 
-/-- What a case account predicts for one nominal: its surface case (`none`
-    exactly when the provenance is the crash `uncased`) and its neutral
-    `Case.Source` provenance. -/
-structure Verdict where
-  source : _root_.Case.Source
-  surfaceCase : Option _root_.Case
+/-- What a case account assigns one nominal: a case together with its neutral
+    provenance, or nothing at all. An account that cannot fail simply never
+    produces `unassigned`. -/
+inductive Assignment where
+  | assigned (case : _root_.Case) (source : _root_.Case.Source)
+  | unassigned
   deriving DecidableEq, Repr
 
+/-- The surface case, absent exactly when nothing was assigned. -/
+def Assignment.surfaceCase : Assignment → Option _root_.Case
+  | .assigned c _ => some c
+  | .unassigned => none
+
+/-- The provenance, absent exactly when nothing was assigned. -/
+def Assignment.provenance : Assignment → Option _root_.Case.Source
+  | .assigned _ s => some s
+  | .unassigned => none
+
 /-- A case-assignment account as a function from the shared stimulus to a
-    per-label verdict (`none` = no nominal with that label). The signature
+    per-label assignment (`none` = no nominal with that label). The signature
     that makes rival theories runnable on one input. -/
-abbrev Assigner := List LicensedNP → String → Option Verdict
+abbrev Assigner := List LicensedNP → String → Option Assignment
 
 /-- Marantz dependent case as an `Assigner`: it reads the configural
     projection (`needsLicensing` ignored) and is total, so it never produces
-    the crash `uncased`. -/
+    `unassigned`. -/
 def dependentAssigner (lang : CaseLanguageType) : Assigner := fun nps label =>
   ((assignCases lang (nps.map (·.toNPInDomain))).find? (·.label == label)).map
-    fun r => ⟨r.source.toNeutral, some r.case⟩
+    fun r => .assigned r.case r.source.toNeutral
 
-/-- Kalin hybrid licensing as an `Assigner`: an unlicensed nominal crashes to
-    `⟨uncased, none⟩`. -/
+/-- A licensing outcome as a neutral assignment: primary and secondary
+    licensing are structural, lexical pre-licensing inherent, and the crash
+    assigns nothing. -/
+def Licensing.LicensingOutcome.toAssignment : LicensingOutcome → Assignment
+  | .byPrimary _ c   => .assigned c .structural
+  | .bySecondary _ c => .assigned c .structural
+  | .byLexical c     => .assigned c .inherent
+  | .unlicensed      => .unassigned
+
+/-- Kalin hybrid licensing as an `Assigner`: an unlicensed nominal is
+    `unassigned`. -/
 def kalinAssigner (cl : ClauseLicensers) : Assigner := fun nps label =>
-  ((licenseNPs cl nps).find? (·.label == label)).map
-    fun r => ⟨r.outcome.toNeutral, r.outcome.assignedCase⟩
+  ((licenseNPs cl nps).find? (·.label == label)).map (·.outcome.toAssignment)
 
 /-- Two accounts agree on the **surface case** of every nominal in the
     stimulus. -/
 def AgreesOnCase (a b : Assigner) (nps : List LicensedNP) : Prop :=
-  ∀ np ∈ nps, (a nps np.label).map Verdict.surfaceCase
-            = (b nps np.label).map Verdict.surfaceCase
+  ∀ np ∈ nps, (a nps np.label).map Assignment.surfaceCase
+            = (b nps np.label).map Assignment.surfaceCase
 
 /-- Two accounts agree on the **provenance** of every nominal in the
     stimulus. Two accounts can agree on case yet diverge here. -/
 def AgreesOnSource (a b : Assigner) (nps : List LicensedNP) : Prop :=
-  ∀ np ∈ nps, (a nps np.label).map Verdict.source
-            = (b nps np.label).map Verdict.source
+  ∀ np ∈ nps, (a nps np.label).map Assignment.provenance
+            = (b nps np.label).map Assignment.provenance
 
 instance (a b : Assigner) (nps : List LicensedNP) : Decidable (AgreesOnCase a b nps) := by
   unfold AgreesOnCase; infer_instance
@@ -99,10 +117,10 @@ private def turkishLikeClause : ClauseLicensers :=
   , secondaries := [{ kind := .secondary, head := "AGRO", assignedCase := .acc }] }
 
 example : dependentAssigner .accusative transitiveStimulus "obj"
-    = some ⟨.structural, some .acc⟩ := by decide
+    = some (.assigned .acc .structural) := by decide
 
 example : kalinAssigner turkishLikeClause transitiveStimulus "obj"
-    = some ⟨.structural, some .acc⟩ := by decide
+    = some (.assigned .acc .structural) := by decide
 
 example : AgreesOnCase (dependentAssigner .accusative)
     (kalinAssigner turkishLikeClause) transitiveStimulus := by decide

--- a/Linglib/Syntax/Case/Assigner.lean
+++ b/Linglib/Syntax/Case/Assigner.lean
@@ -25,7 +25,7 @@ them requires. This file gives them one shared signature.
   `agree_on_…`/`diverge_on_…` pattern of `Studies/Woolford1997.lean` and
   `Studies/Baker2015.lean`.
 
-The Chomskyan Case Filter (`Syntax/Case/Filter.lean`) is a *checker*, not an
+The Chomskyan Case Filter (`Syntax/Minimalist/Case.lean`) is a *checker*, not an
 assigner, and is bridged separately. The paper-anchored dependent-case ⟺
 licensing DOM divergence belongs in the later paper's study file
 (`Studies/Kalin2018.lean`); the `example`s here only validate that the harness

--- a/Linglib/Syntax/Case/Dependent.lean
+++ b/Linglib/Syntax/Case/Dependent.lean
@@ -26,7 +26,8 @@ formalisations.
 ## Main definitions
 
 * `CaseSource`: how a case was assigned; `CaseSource.toNeutral` projects it
-  onto the account-neutral `Case.Source`.
+  onto the account-neutral `Case.Source`. Dependent case is total, which the
+  projection's totality records by construction.
 * `CaseLanguageType`: the alignment parameter fixing the dependent and
   unmarked cases.
 * `NPInDomain`, `CasedNP`: an NP before and after case assignment.
@@ -84,12 +85,6 @@ def CaseSource.toNeutral : CaseSource → _root_.Case.Source
   | .dependent => .structural
   | .unmarked => .default
   | .agree => .structural
-
-/-- Dependent case is total: no source it produces is the crash `uncased`,
-    unlike the hybrid licensing of `Licensing.LicensingOutcome`. -/
-theorem CaseSource.toNeutral_ne_uncased (s : CaseSource) :
-    s.toNeutral ≠ _root_.Case.Source.uncased := by
-  cases s <;> decide
 
 /-! ### Alignment types -/
 

--- a/Linglib/Syntax/Case/Licensing.lean
+++ b/Linglib/Syntax/Case/Licensing.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Case.Basic
 import Linglib.Features.Case.Source
 import Linglib.Syntax.Case.Dependent
-import Linglib.Syntax.Case.Filter
 
 /-!
 # Hybrid licensing
@@ -42,9 +41,6 @@ primitive.
 * `licenseActive_no_crash_when_enough_secondaries`,
   `no_need_means_no_secondaries_used`: with enough secondaries nothing
   crashes, and with nothing needing licensing no secondary activates.
-* `isLicensed_iff_satisfiesCaseFilter`: a nominal is licensed iff it
-  satisfies the Case Filter of `Syntax/Case/Filter.lean`, so the filter is a
-  theorem of hybrid licensing rather than a separate stipulation.
 
 ## References
 
@@ -55,7 +51,6 @@ namespace Syntax.Case.Licensing
 
 -- `Case` is qualified throughout: a different `Case` (UD.Case) is aliased at
 -- root scope.
-open Minimalist (DPFeatures satisfiesCaseFilter)
 
 /-! ### Licensers -/
 
@@ -388,45 +383,6 @@ theorem no_need_means_no_secondaries_used (cl : ClauseLicensers)
   obtain ⟨h_need, h_lex⟩ := h np hnp_mem
   rw [← hr_eq]
   simp [h_lex, h_need]
-
-/-! ### The Case Filter -/
-
-/-! Connects `LicensingOutcome` to the Chomskyan Case Filter
-formalized in `Minimalism/CaseFilter.lean`: an outcome valued by
-*any* mechanism (primary, secondary, or lexical) satisfies the Case
-Filter; only `.unlicensed` violates it. Kalin's framework thus
-*derives* the Case Filter as the convergence condition on hybrid
-licensing — not a separate stipulation. -/
-
-/-- Translate a licensing outcome into the DP feature bundle that
-    `Minimalist.satisfiesCaseFilter` consumes. Any valued outcome
-    becomes a DP with valued [Case]; `.unlicensed` becomes a DP with
-    unvalued [Case]. -/
-def LicensingOutcome.toDPFeatures : LicensingOutcome → DPFeatures
-  | .byPrimary _ c   => DPFeatures.withCase [] c
-  | .bySecondary _ c => DPFeatures.withCase [] c
-  | .byLexical c     => DPFeatures.withCase [] c
-  | .unlicensed      => DPFeatures.withUnvaluedCase []
-
-/-- **Bridge: licensing convergence ⟺ Case Filter satisfied.** A
-    nominal's [Case] is valued by some hybrid-licensing mechanism iff
-    it satisfies the Chomskyan Case Filter. The two convergence
-    conditions are extensionally equivalent — making the Case Filter a
-    theorem of hybrid licensing rather than an independent axiom. -/
-theorem isLicensed_iff_satisfiesCaseFilter (o : LicensingOutcome) :
-    o.IsLicensed ↔ satisfiesCaseFilter o.toDPFeatures := by
-  cases o <;>
-    simp [satisfiesCaseFilter, LicensingOutcome.toDPFeatures, HasCase.caseOf,
-      DPFeatures.withCase, DPFeatures.withUnvaluedCase]
-
-/-- A list of licensing results converges (no `.unlicensed`) iff every
-    induced DP satisfies the Case Filter. -/
-theorem all_isLicensed_iff_caseFilterHolds (results : List LicensedResult) :
-    (∀ r ∈ results, r.outcome.IsLicensed) ↔
-      Minimalist.caseFilterHolds (results.map λ r => r.outcome.toDPFeatures) := by
-  simp only [Minimalist.caseFilterHolds, List.all_eq_true, List.mem_map,
-    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
-    isLicensed_iff_satisfiesCaseFilter]
 
 /-! ### Differential marking requires an available secondary -/
 

--- a/Linglib/Syntax/Case/Licensing.lean
+++ b/Linglib/Syntax/Case/Licensing.lean
@@ -28,9 +28,7 @@ primitive.
 * `Licenser`, `ClauseLicensers`: a licenser and a clause's inventory of them,
   exactly one of which is primary.
 * `LicensedNP`: a nominal together with its licensing requirement.
-* `LicensingOutcome`: which licenser valued a nominal, or the crash;
-  `LicensingOutcome.toNeutral` projects it onto the account-neutral
-  `Case.Source`.
+* `LicensingOutcome`: which licenser valued a nominal, or the crash.
 * `licenseNPs`: the licensing algorithm over a clause.
 * `isDOMMarked`: a nominal is DOM-marked exactly when a secondary licensed it.
 
@@ -166,25 +164,6 @@ def LicensingOutcome.assignedCase : LicensingOutcome → Option Case
   | .bySecondary _ c  => some c
   | .byLexical c      => some c
   | .unlicensed       => none
-
-/-- The neutral provenance (`Case.Source`) of a licensing outcome: primary
-    and secondary licensing are `structural` (Agree-valued), lexical
-    pre-licensing is `inherent`, and the crash `unlicensed` is `uncased` —
-    the only account in the library that produces it. -/
-def LicensingOutcome.toNeutral : LicensingOutcome → _root_.Case.Source
-  | .byPrimary _ _   => .structural
-  | .bySecondary _ _ => .structural
-  | .byLexical _     => .inherent
-  | .unlicensed      => .uncased
-
-/-- The neutral source faithfully records licensing **failure**: an outcome
-    is `uncased` iff it is unlicensed. With `CaseSource.toNeutral_ne_uncased`
-    (dependent case is total), this is the foundational provenance-level
-    contrast between the two rival accounts — one can crash, the other
-    cannot. -/
-theorem LicensingOutcome.toNeutral_uncased_iff (o : LicensingOutcome) :
-    o.toNeutral = _root_.Case.Source.uncased ↔ ¬ o.IsLicensed := by
-  cases o <;> simp [LicensingOutcome.toNeutral]
 
 /-- The result of licensing a single NP. -/
 structure LicensedResult where

--- a/Linglib/Syntax/Minimalist/Agree/Basic.lean
+++ b/Linglib/Syntax/Minimalist/Agree/Basic.lean
@@ -22,7 +22,7 @@ exposes its projecting head's bundle through selection-driven labeling
 (`headBundle`). The feature *types* live in `Features.lean`; the search
 kernel and failure model ([preminger-2014] Ch. 5) in `Probe/Basic.lean`;
 richer satisfaction conditions ([deal-2024], [keine-2019]) in
-`Probe/Satisfaction.lean`; the Case Filter in `Syntax/Case/Filter.lean`.
+`Probe/Satisfaction.lean`; the Case Filter in `Syntax/Minimalist/Case.lean`.
 -/
 
 namespace Minimalist

--- a/Linglib/Syntax/Minimalist/Case.lean
+++ b/Linglib/Syntax/Minimalist/Case.lean
@@ -2,32 +2,37 @@ import Linglib.Features.Case.Capabilities
 import Linglib.Syntax.Minimalist.Features
 
 /-!
-# The Case Filter
-[baker-2015] [chomsky-2001] [marantz-1991] [woolford-2006]
+# Case in the Minimalist feature system
 
-Every DP must receive Case. In Minimalist terms:
-- Every DP has [uCase] (unvalued Case feature)
-- [uCase] must be valued by Agree with a Case-assigning head
-- Failure to value [uCase] causes the derivation to crash
+This file gives the Agree-based account of structural case its feature-level
+form: T, v and P carry a valued Case feature they assign to the closest DP
+([chomsky-2001]), a DP carries [uCase] until some head values it, and the Case
+Filter is the convergence condition that no DP reach the interfaces unvalued.
 
-Case assigners (Agree-based):
-- T assigns nominative to its specifier (subject)
-- v assigns accusative to its complement (object)
-- P assigns oblique to its complement
+`DPFeatures` is the DP-side bundle — φ-features plus one Case feature, valued
+or not — and `satisfiesCaseFilter` is the predicate on it. The configural
+alternative, on which case is read off the arrangement of nominals rather than
+assigned by a head, is `Syntax/Case/Dependent.lean` ([marantz-1991],
+[baker-2015]).
 
-For the competing dependent-case approach,
-see `Syntax/Case/Dependent.lean`. For inherent/Voice-based case,
-see `Voice.lean` and `Mam.Agreement`.
+## Main definitions
 
+* `DPFeatures`: a DP's φ-features together with its Case feature.
+* `satisfiesCaseFilter`, `caseFilterHolds`: the Case Filter on one DP and on a
+  derivation's DPs.
+* `tAssignsNominative`, `vAssignsAccusative`, `dpNeedsCase`: the assigner and
+  goal feature bundles.
+
+## References
+
+* [chomsky-2001]
+* [woolford-2006]
 -/
-
 namespace Minimalist
 
 open Features.Prominence
 
--- ============================================================================
--- § 1: Case Assignment Bundles (Agree-based)
--- ============================================================================
+/-! ### Assigner feature bundles -/
 
 /-- Nominative Case is assigned by T.
     T has [uCase:nom], assigns to closest DP in Spec-TP. -/
@@ -46,9 +51,7 @@ def vAssignsAccusative : FeatureBundle :=
 def dpNeedsCase : FeatureBundle :=
   .ofGramFeatures [.unvalued (.case .dat)]
 
--- ============================================================================
--- § 2: DP Feature Structures
--- ============================================================================
+/-! ### DP feature structures -/
 
 /-- A DP's features (with unvalued Case). -/
 structure DPFeatures where
@@ -82,9 +85,7 @@ def satisfiesCaseFilter (dp : DPFeatures) : Bool :=
 def DPFeatures.toBundle (dp : DPFeatures) : FeatureBundle :=
   .ofGramFeatures (dp.phi.map (λ p => .valued (.phi p)) ++ [dp.caseFeature])
 
--- ============================================================================
--- § 3: Case Filter Predicate
--- ============================================================================
+/-! ### The Case Filter -/
 
 /-- The Case Filter: a derivation converges only if all DPs have valued Case.
     This is stated as: for all DPs in the structure, their Case feature


### PR DESCRIPTION
Two related cuts that between them remove every framework dependency from `Syntax/Case/`.

**Rehome the Case Filter.** `Syntax/Case/Filter.lean` declared `DPFeatures` in `namespace Minimalist`, imported `Minimalist.Features`, and was consumed by nobody in Minimalist — so `Licensing.lean` had to `open Minimalist (...)` to reach a namespace its own directory-sibling invented. It moves to `Syntax/Minimalist/Case.lean` (named for its topic, like `Economy.lean`/`Position.lean`, rather than for one predicate in it), and the licensing-implies-Case-Filter bridge moves to `Studies/Kalin2018.lean`, which is the paper that draws it.

Import closure of the neutral harness `Assigner.lean`: 19 modules → 10, Minimalist modules 1 → 0. `Poole2024` no longer pulls Minimalist feature machinery to get a stimulus type.

**Drop `Case.Source.uncased`.** The cell existed only to keep `toNeutral` total for an account that can fail, at the cost of a constructor that answers a different question than the other three. It forced two theorems whose only job was policing it (`toNeutral_ne_uncased`, `toNeutral_uncased_iff`) and an invariant `Verdict` could not enforce (`⟨.uncased, some .acc⟩` typechecked). Failure is also not a per-entry feature, so it did not belong in `Features/`.

`Verdict` becomes `Assignment`, a sum:

    inductive Assignment
      | assigned (case : Case) (source : Case.Source)
      | unassigned

Both policing theorems and the dead `Source.IsCrash` are deleted; totality of dependent case is now a typing fact.