### PR TITLE
refactor(Features/Case): dissolve companion enums into owning APIs

### DIFF
--- a/Linglib/Features/Case/Basic.lean
+++ b/Linglib/Features/Case/Basic.lean
@@ -6,7 +6,7 @@ import Linglib.Data.UD.Basic
 
 /-!
 # Case — the canonical inventory
-[blake-1994] [de-marneffe-zeman-2021] [stassen-1985]
+[blake-1994] [de-marneffe-zeman-2021]
 
 The root-namespace `Case` type is the canonical, analytical case
 inventory: the values languages' case systems distinguish. All
@@ -37,8 +37,6 @@ inventory at root namespace, UD demoted to realization.
 * `Case.IsValidInventory` — inventory contiguity on the hierarchy,
   decidable, with the order-theoretic characterization
   `isValidInventory_iff_ordConnected`
-* `Features.AlignmentFamily`, `Features.CaseAssignment`,
-  `Features.FixedCaseEncoding` — small per-entry companion enums
 -/
 
 set_option autoImplicit false
@@ -317,28 +315,3 @@ example : InventoryAdjacent ({.erg, .abs, .inst} : Finset Case) .erg .inst := by
   decide
 
 end Case
-
-namespace Features
-
-/-! ### Companion per-entry enums -/
-
-/-- The two major morphosyntactic alignment families. -/
-inductive AlignmentFamily where
-  | accusative
-  | ergative
-  deriving DecidableEq, Repr
-
-/-- How case is assigned to an NP in a given construction
-    ([stassen-1985], §2.2.1). -/
-inductive CaseAssignment where
-  | derived
-  | fixed
-  deriving DecidableEq, Repr
-
-/-- For fixed-case NPs, what syntactic role the NP occupies. -/
-inductive FixedCaseEncoding where
-  | directObject
-  | adverbial
-  deriving DecidableEq, Repr
-
-end Features

--- a/Linglib/Fragments/Dargwa/Case.lean
+++ b/Linglib/Fragments/Dargwa/Case.lean
@@ -1,5 +1,5 @@
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
+import Linglib.Syntax.Case.Alignment
 /-!
 # Dargwa (Tanti) Case Inventory [sumbatova-2021]
 
@@ -57,7 +57,7 @@ theorem inventory_not_strictly_contiguous :
 /-- Dargwa alignment: consistently ergative — no tense/aspect split.
     Transitive A-arguments always take ergative *-li*;
     S and P arguments take unmarked absolutive. -/
-def alignment : Features.AlignmentFamily := .ergative
+def alignment : Alignment.AlignmentFamily := .ergative
 
 /-- Case of the transitive agent (A-argument): always ergative. -/
 def agentCase : Case := .erg

--- a/Linglib/Fragments/Icelandic/Case.lean
+++ b/Linglib/Fragments/Icelandic/Case.lean
@@ -1,5 +1,4 @@
 import Linglib.Features.Case.Basic
-import Linglib.Features.Case.Basic
 /-!
 # Icelandic Case Inventory
 [thrainsson-2007]
@@ -12,8 +11,6 @@ Case frames, quirky subjects, verb data, and agreement are in
 -/
 
 namespace Icelandic.Case
-
-open Features
 
 /-- Icelandic 4-case inventory ([thrainsson-2007] §4.1). -/
 def caseInventory : Finset Case := {.nom, .acc, .gen, .dat}

--- a/Linglib/Fragments/Icelandic/Verbs.lean
+++ b/Linglib/Fragments/Icelandic/Verbs.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Case.Source
 import Linglib.Fragments.Icelandic.Case
 
 /-!
@@ -40,16 +41,14 @@ NAG (~20), NAA (~2).
 
 ## Case Assignment ([zaenen-maling-thrainsson-1985])
 
-Quirky case is **fixed** (lexical): it is preserved under raising and is
-not affected by passivization. Structural case (NOM, ACC in standard
-frames) is **derived**: it changes under passivization (ACC object →
-NOM subject in passive). This distinction is encoded via `CaseAssignment`
-from `Case`.
+Quirky case is **lexical**: it is preserved under raising and is not
+affected by passivization. Structural case (NOM, ACC in standard frames)
+changes under passivization (ACC object → NOM subject in passive). The
+distinction is the subject's case provenance, encoded as `Case.Source`
+(`.inherent` vs `.structural`).
 -/
 
 namespace Icelandic.Verbs
-
-open Features (CaseAssignment)
 
 -- ============================================================================
 -- § 1: Verb Case Frames
@@ -75,11 +74,11 @@ structure VerbCaseFrame where
   firstObject : Option Case := none
   /-- Case of the second post-verbal argument, if any -/
   secondObject : Option Case := none
-  /-- How the subject's case is assigned: `.derived` (structural — changes
-      under passivization/raising) or `.fixed` (lexical/quirky — preserved
-      under raising). Default: NOM → derived, all others → fixed. -/
-  subjectCaseAssignment : CaseAssignment :=
-    if subjectCase == .nom then .derived else .fixed
+  /-- Provenance of the subject's case: `.structural` (changes under
+      passivization/raising) or `.inherent` (lexical/quirky — preserved
+      under raising). Default: NOM → structural, all others → inherent. -/
+  subjectCaseSource : Case.Source :=
+    if subjectCase == .nom then .structural else .inherent
   deriving Repr, BEq
 
 /-- Is the subject non-nominative (quirky)?
@@ -380,15 +379,15 @@ theorem nom_verbs_not_quirky :
 
 -- § 9.2: Case assignment
 
-/-- Quirky subjects have fixed (lexical) case assignment. -/
-theorem quirky_subjects_are_fixed :
+/-- Quirky subjects bear inherent (lexical) case. -/
+theorem quirky_subjects_inherent :
     quirkySubjectVerbs.all
-      (fun v => v.subjectCaseAssignment == .fixed) = true := by decide
+      (fun v => v.subjectCaseSource == .inherent) = true := by decide
 
-/-- Nominative subjects have derived (structural) case assignment. -/
-theorem nom_subjects_are_derived :
+/-- Nominative subjects bear structural case. -/
+theorem nom_subjects_structural :
     nomSubjectVerbs.all
-      (fun v => v.subjectCaseAssignment == .derived) = true := by decide
+      (fun v => v.subjectCaseSource == .structural) = true := by decide
 
 -- § 9.3: Agreement
 
@@ -476,6 +475,6 @@ theorem leidast_is_quirky_dn :
     leidastCF.subjectCase = .dat ∧
     leidastCF.firstObject = some .nom ∧
     leidastCF.quirkySubject = true ∧
-    leidastCF.subjectCaseAssignment = .fixed := ⟨rfl, rfl, rfl, rfl⟩
+    leidastCF.subjectCaseSource = .inherent := ⟨rfl, rfl, rfl, rfl⟩
 
 end Icelandic.Verbs

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -499,8 +499,7 @@ open Features.Prominence (DefinitenessLevel)
 open Aissen2003
   (DOMProfile spanishDOM russianDOM turkishDOM hindiDOM noDOMProfile)
 open Dixon1994 (russian turkish dyirbalSplit)
-open Features (AlignmentFamily)
-open Alignment (Aspect hindiSplit)
+open Alignment (AlignmentFamily Aspect hindiSplit)
 
 /-- Whether DOM (differential P marking) is expected given alignment.
     Structurally identical to `AlignmentType.marksPatient`: exactly

--- a/Linglib/Studies/Dixon1994.lean
+++ b/Linglib/Studies/Dixon1994.lean
@@ -495,14 +495,9 @@ section SilversteinSplit
 
 open Features.Prominence (AnimacyLevel)
 
-/-- Map the binary Core alignment family to the full alignment type. -/
-private def toAlignmentType : Features.AlignmentFamily → AlignmentType
-  | .accusative => .accusative
-  | .ergative   => .ergative
-
 /-- Silverstein's hierarchy: NPs at or above the prominence threshold get
     accusative alignment; those below get ergative. -/
-def silverstein (threshold : Nat) (npProminence : Nat) : Features.AlignmentFamily :=
+def silverstein (threshold : Nat) (npProminence : Nat) : AlignmentFamily :=
   if npProminence ≥ threshold then .accusative else .ergative
 
 /-- Silverstein is monotone: if prominence p₁ ≥ p₂ and p₂ gets accusative,
@@ -536,12 +531,12 @@ theorem dyirbal_inanimate_erg :
 /-- Dyirbal split matches the Dyirbal alignment profile: inanimate NPs get
     ergative alignment. -/
 theorem dyirbal_split_matches_np :
-    toAlignmentType (dyirbalSplit.alignment .inanimate)
+    (dyirbalSplit.alignment .inanimate).toAlignmentType
     = dyirbal.npAlignment := rfl
 
 /-- Human/animate arguments get accusative alignment. -/
 theorem dyirbal_split_matches_pron :
-    toAlignmentType (dyirbalSplit.alignment .human)
+    (dyirbalSplit.alignment .human).toAlignmentType
     = dyirbal.pronAlignment := rfl
 
 end SilversteinSplit
@@ -621,7 +616,7 @@ theorem dargwa_fragment_bridge :
 /-- Dargwa: Fragment alignment family is ergative → Typology profile is
     consistently ergative. -/
 theorem dargwa_alignment_family_bridge :
-    toAlignmentType Dargwa.Case.alignment
+    Dargwa.Case.alignment.toAlignmentType
     = dargwa.npAlignment := rfl
 
 /-- Japanese: Fragment case inventory contains NOM and ACC → Typology says
@@ -635,14 +630,14 @@ theorem japanese_fragment_bridge :
     Typology's ergative NP alignment. -/
 theorem hindi_fragment_bridge :
     Alignment.hindiSplit.alignment .perfective = .ergative ∧
-    toAlignmentType (Alignment.hindiSplit.alignment .perfective)
+    (Alignment.hindiSplit.alignment .perfective).toAlignmentType
       = hindiUrdu.npAlignment := ⟨rfl, rfl⟩
 
 /-- Hindi: Fragment imperfective → ACC matches Typology's accusative
     pronoun alignment. -/
 theorem hindi_split_bridge :
     Alignment.hindiSplit.alignment .imperfective = .accusative ∧
-    toAlignmentType (Alignment.hindiSplit.alignment .imperfective)
+    (Alignment.hindiSplit.alignment .imperfective).toAlignmentType
       = hindiUrdu.pronAlignment := ⟨rfl, rfl⟩
 
 -- ============================================================================

--- a/Linglib/Studies/Marantz1991.lean
+++ b/Linglib/Studies/Marantz1991.lean
@@ -1,3 +1,4 @@
+import Linglib.Syntax.Case.Alignment
 import Linglib.Syntax.Case.Dependent
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Fragments.Georgian.Agreement
@@ -295,7 +296,7 @@ open Georgian.Agreement
 /-- Map alignment family to dependent case language type.
     Bridges the typological description (`Alignment.SplitErgativity`) to
     the case algorithm (`Syntax/Case/Dependent.lean`). -/
-def alignmentToLangType : Features.AlignmentFamily → CaseLanguageType
+def alignmentToLangType : Alignment.AlignmentFamily → CaseLanguageType
   | .accusative => .accusative
   | .ergative   => .ergative
 

--- a/Linglib/Studies/Stassen1985.lean
+++ b/Linglib/Studies/Stassen1985.lean
@@ -65,7 +65,6 @@ set_option autoImplicit false
 namespace Stassen1985
 
 open Comparative
-open Features (CaseAssignment FixedCaseEncoding)
 
 -- ════════════════════════════════════════════════════
 -- § 0. The Stassen 1985 six-way typology

--- a/Linglib/Syntax/Case/Alignment.lean
+++ b/Linglib/Syntax/Case/Alignment.lean
@@ -338,6 +338,19 @@ def AlignmentType.marksPatient (a : AlignmentType) : Prop := a = .accusative ∨
 instance (a : AlignmentType) : Decidable a.marksPatient := by
   unfold AlignmentType.marksPatient; infer_instance
 
+/-- The two major alignment families ([dixon-1994]): the binary
+    classification that split-ergative zones and prominence-based splits
+    project to. Coarser than `AlignmentType` — `toAlignmentType` embeds it. -/
+inductive AlignmentFamily where
+  | accusative
+  | ergative
+  deriving DecidableEq, Repr
+
+/-- Embed the binary family into the five-way observational type. -/
+def AlignmentFamily.toAlignmentType : AlignmentFamily → AlignmentType
+  | .accusative => .accusative
+  | .ergative   => .ergative
+
 /-! ### Split ergativity [blake-1994] [dixon-1994]
 
 A `SplitErgativity Factor` is parameterised by the conditioning factor (aspect,
@@ -345,8 +358,6 @@ person, animacy, …); `alignment` projects to the ergative or accusative family
 The Hindi aspect-conditioned split (`hindiSplit`) is the canonical worked
 example, used as the cross-linguistic reference point by the Yukatek/Hindi
 fragments and the Mayan/Silverstein studies. -/
-
-open Features (AlignmentFamily)
 
 /-- A split-ergative system ([blake-1994], [dixon-1994]): alignment varies by
     some conditioning factor. -/

--- a/Linglib/Syntax/Comparative.lean
+++ b/Linglib/Syntax/Comparative.lean
@@ -17,6 +17,9 @@ typology, superlative strategies, and the WALS Ch 121A lookup and aggregates.
 - `Comparative.type` : the WALS Ch 121 type, derived from the anatomy —
   derived-case constructions split on marker presence (particle vs conjoined),
   fixed-case constructions on encoding role (exceed vs locational).
+- `Comparative.CaseAssignment`, `Comparative.FixedCaseEncoding` :
+  [stassen-1985]'s standard-NP parameters (derived vs fixed case; object vs
+  adverbial encoding).
 - `DegreeWordType` ([beck-2009] 3-way), `SuperlativeStrategy` (6-way).
 - `ComparativeType.ofWALS` : WALS Ch 121A comparative type by ISO 639-3
   lookup; `none` for languages the chapter leaves uncoded.
@@ -29,7 +32,21 @@ chaining universals) lives in `Studies/Stassen1985.lean` (paper-anchored).
 
 set_option autoImplicit false
 
-open Features (CaseAssignment FixedCaseEncoding)
+/-- Case assignment to the standard NP of a comparative ([stassen-1985]
+    §2.2.1): `derived` — the standard NP derives its case from the comparee
+    NP's; `fixed` — one construction-determined case regardless of the
+    comparee's. -/
+inductive Comparative.CaseAssignment where
+  | derived
+  | fixed
+  deriving DecidableEq, Repr
+
+/-- Syntactic encoding of a fixed-case standard NP ([stassen-1985] §2.2.2):
+    direct object of a transitive (exceed) verb, or adverbial. -/
+inductive Comparative.FixedCaseEncoding where
+  | directObject
+  | adverbial
+  deriving DecidableEq, Repr
 
 /-- A comparative construction: how it encodes the standard of comparison in
     "X is more Adj than Y" — [stassen-1985]'s construction parameters. A
@@ -43,10 +60,10 @@ structure Comparative where
   standardMarker : Option String := none
   /-- Case assignment to the standard NP: derived from the comparee's case vs
       fixed by the construction ([stassen-1985]). -/
-  caseAssignment : CaseAssignment
+  caseAssignment : Comparative.CaseAssignment
   /-- For fixed-case constructions: the standard's syntactic role — direct
       object of an exceed verb, or adverbial. -/
-  fixedEncoding : Option FixedCaseEncoding := none
+  fixedEncoding : Option Comparative.FixedCaseEncoding := none
   /-- Case on an adverbially encoded standard (ablative for separatives,
       partitive for the Finnish secondary option). Adpositions with the
       corresponding semantics count (Japanese *yori*, Arabic *min* → `abl`). -/


### PR DESCRIPTION
Dissolves the `namespace Features` grab-bag appended to `Features/Case/Basic.lean`.

- `AlignmentFamily` → `Syntax/Case/Alignment.lean`, joining `AlignmentType` with the evident `toAlignmentType` embedding (was a private def in Dixon1994).
- `CaseAssignment`/`FixedCaseEncoding` → `Syntax/Comparative.lean` as `Comparative.*`: Stassen 1985's derived/fixed classifies co-variation with the comparee NP, not assignment mechanism (the exceed type is fixed-case yet its standard gets structural accusative), so it stays a comparative-construction parameter rather than folding into `Case.Source`.
- Icelandic quirky-subject frames switch to `Case.Source` (`.structural`/`.inherent`) — the ZMT structural-vs-lexical distinction they actually encode.