### PR TITLE
refactor(Studies/Aissen2003): re-anchor to the paper; drop profile bundle

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -1328,6 +1328,7 @@ import Linglib.Phonology.Hiatus
 import Linglib.Phonology.OptimalityTheory.PartiallyOrderedConstraints
 import Linglib.Phonology.Constraints.Harmony
 import Linglib.Phonology.HarmonicGrammar.Separability
+import Linglib.Studies.Just2024
 import Linglib.Studies.Riggle2009
 import Linglib.Phonology.Harmony.Basic
 import Linglib.Phonology.Harmony.TongueRoot
@@ -1874,7 +1875,6 @@ import Linglib.Studies.AhnZhu2025
 import Linglib.Studies.Aikhenvald2000
 import Linglib.Studies.Aikhenvald2004
 import Linglib.Studies.Aissen2003
-import Linglib.Studies.Aissen2003Agreement
 import Linglib.Studies.AissenPolian2025
 import Linglib.Studies.Aitha2026
 import Linglib.Studies.AkinboFwangwar2026

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -1,4 +1,5 @@
 import Mathlib.Order.Nat
+import Mathlib.Order.UpperLower.Basic
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Core.Order.Markedness
 import Linglib.Features.Person.Basic
@@ -355,201 +356,82 @@ def isDefaultZone (role : ArgumentRole) (a : AnimacyLevel) (d : DefinitenessLeve
   | .T => prominenceRank a d ≤ 2  -- T args expected to be non-prominent (like P)
 
 -- ============================================================================
--- § 7: Differential Marking Profiles
+-- § 7: Differential marking patterns
 -- ============================================================================
 
-/-- A differential marking profile: which cells in the animacy × definiteness
-    grid receive overt differential marking for a given argument role and
-    channel.
+/-- A differential-marking pattern: which cells in the animacy × definiteness
+    grid receive overt differential marking, for whatever argument role and
+    channel a consumer pairs the pattern with ([aissen-2003] flagging,
+    [just-2024] indexing). A `def`, not an `abbrev`, so the checkers below
+    are dot-accessible. -/
+def MarkingPattern := AnimacyLevel → DefinitenessLevel → Bool
 
-    Covers all four combinations of role × channel: P flagging, A flagging,
-    P indexing, A indexing. -/
-structure DifferentialMarkingProfile where
-  /-- Language name -/
-  name : String
-  /-- Which argument role: A or P -/
-  role : ArgumentRole
-  /-- Realization channel: flagging (case) or indexing (agreement) -/
-  channel : MarkingChannel
-  /-- Whether cell (a, d) receives differential marking -/
-  marks : AnimacyLevel → DefinitenessLevel → Bool
+namespace MarkingPattern
 
-/-- Monotonicity for P marking (upper set): if a cell is marked, all more
-    prominent cells are also marked. This is [aissen-2003]'s staircase
-    prediction, extended to P indexing by [just-2024]. -/
-def DifferentialMarkingProfile.isMonotoneP (p : DifferentialMarkingProfile) : Bool :=
-  AnimacyLevel.all.all λ a =>
-    DefinitenessLevel.all.all λ d =>
-      if p.marks a d then
-        AnimacyLevel.all.all λ a' =>
-          DefinitenessLevel.all.all λ d' =>
-            if a'.rank ≥ a.rank && d'.rank ≥ d.rank then p.marks a' d'
-            else true
-      else true
+/-- Marking is closed under moving up both scales — the upper-set staircase
+    of [aissen-2003]'s (33b), appropriate to P/T marking and extended to
+    P indexing by [just-2024]. -/
+def MonotoneP (p : MarkingPattern) : Prop :=
+  ∀ a a' d d', a ≤ a' → d ≤ d' → p a d = true → p a' d' = true
 
-/-- Anti-monotonicity for A marking (lower set): if a cell is marked, all
-    less prominent cells are also marked. This is the "mirror image"
-    predicted by [just-2024]: A indexing marks non-prominent As. -/
-def DifferentialMarkingProfile.isMonotoneA (p : DifferentialMarkingProfile) : Bool :=
-  AnimacyLevel.all.all λ a =>
-    DefinitenessLevel.all.all λ d =>
-      if p.marks a d then
-        AnimacyLevel.all.all λ a' =>
-          DefinitenessLevel.all.all λ d' =>
-            if a'.rank ≤ a.rank && d'.rank ≤ d.rank then p.marks a' d'
-            else true
-      else true
+/-- Marking closed downward — the mirror image appropriate to A/R marking
+    ([just-2024]). -/
+def MonotoneA (p : MarkingPattern) : Prop :=
+  ∀ a a' d d', a' ≤ a → d' ≤ d → p a d = true → p a' d' = true
 
-/-- **Wiring to the scale order**: pointwise monotonicity (marking closed under
-    moving *up* both scales) yields the `isMonotoneP` staircase. A
-    one-dimensional cutoff discharges the hypothesis with `le_trans` on the
-    scale's `LinearOrder` (`Core.Order.atOrAbove_isUpperSet`), so cutoff
-    profiles inherit monotonicity from the order rather than `decide`. -/
-theorem DifferentialMarkingProfile.isMonotoneP_of (p : DifferentialMarkingProfile)
-    (h : ∀ {a a' : AnimacyLevel} {d d' : DefinitenessLevel},
-      a ≤ a' → d ≤ d' → p.marks a d = true → p.marks a' d' = true) :
-    p.isMonotoneP = true := by
-  simp only [isMonotoneP, List.all_eq_true]
-  intro a _ d _
-  split
-  · next hm =>
-    simp only [List.all_eq_true]
-    intro a' _ d' _
-    split
-    · next hcond =>
-      simp only [Bool.and_eq_true, decide_eq_true_eq, ge_iff_le] at hcond
-      exact h hcond.1 hcond.2 hm
-    · rfl
-  · rfl
+/-- The pattern depends only on animacy. -/
+def AnimacyOnly (p : MarkingPattern) : Prop :=
+  ∀ a d d', p a d = p a d'
 
-/-- Anti-monotone (lower-set) counterpart of `isMonotoneP_of`, for A/R roles. -/
-theorem DifferentialMarkingProfile.isMonotoneA_of (p : DifferentialMarkingProfile)
-    (h : ∀ {a a' : AnimacyLevel} {d d' : DefinitenessLevel},
-      a' ≤ a → d' ≤ d → p.marks a d = true → p.marks a' d' = true) :
-    p.isMonotoneA = true := by
-  simp only [isMonotoneA, List.all_eq_true]
-  intro a _ d _
-  split
-  · next hm =>
-    simp only [List.all_eq_true]
-    intro a' _ d' _
-    split
-    · next hcond =>
-      simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
-      exact h hcond.1 hcond.2 hm
-    · rfl
-  · rfl
+/-- The pattern depends only on definiteness. -/
+def DefinitenessOnly (p : MarkingPattern) : Prop :=
+  ∀ a a' d, p a d = p a' d
 
-/-- Role-appropriate monotonicity: low-default roles (P, T) must be monotone
-    (upper set), high-default roles (A, R) must be anti-monotone (lower set).
-    S profiles are vacuously monotone. -/
-def DifferentialMarkingProfile.isMonotone (p : DifferentialMarkingProfile) : Bool :=
-  match p.role with
-  | .P => p.isMonotoneP
-  | .T => p.isMonotoneP  -- T behaves like P ([haspelmath-2021], §3)
-  | .A => p.isMonotoneA
-  | .R => p.isMonotoneA  -- R behaves like A ([haspelmath-2021], §3)
-  | .S => true            -- S is the reference point
+instance : DecidablePred MonotoneP := λ p => by unfold MonotoneP; infer_instance
+instance : DecidablePred MonotoneA := λ p => by unfold MonotoneA; infer_instance
+instance : DecidablePred AnimacyOnly := λ p => by unfold AnimacyOnly; infer_instance
+instance : DecidablePred DefinitenessOnly := λ p => by
+  unfold DefinitenessOnly; infer_instance
 
-/-- Whether a marking profile depends only on animacy (definiteness is irrelevant). -/
-def DifferentialMarkingProfile.isAnimacyOnly (p : DifferentialMarkingProfile) : Bool :=
-  DefinitenessLevel.all.all λ d₁ =>
-    DefinitenessLevel.all.all λ d₂ =>
-      AnimacyLevel.all.all λ a =>
-        p.marks a d₁ == p.marks a d₂
-
-/-- Whether a marking profile depends only on definiteness (animacy is irrelevant). -/
-def DifferentialMarkingProfile.isDefinitenessOnly (p : DifferentialMarkingProfile) : Bool :=
-  AnimacyLevel.all.all λ a₁ =>
-    AnimacyLevel.all.all λ a₂ =>
-      DefinitenessLevel.all.all λ d =>
-        p.marks a₁ d == p.marks a₂ d
+/-- **The transfer equation**: `MonotoneP` is upper-set closure of the marked
+    zone in the product prominence order — [aissen-2003]'s (33b), with the
+    product order of the paper's fn. 23. -/
+theorem monotoneP_iff_isUpperSet (p : MarkingPattern) :
+    p.MonotoneP ↔
+      IsUpperSet {c : AnimacyLevel × DefinitenessLevel | p c.1 c.2 = true} :=
+  ⟨λ h _ _ hle hm => h _ _ _ _ hle.1 hle.2 hm,
+    λ h _ _ _ _ ha hd hm => h (Prod.mk_le_mk.mpr ⟨ha, hd⟩) hm⟩
 
 -- ============================================================================
--- § 8: Constructors for One-Dimensional Profiles
+-- § 8: One-dimensional cutoff patterns
 -- ============================================================================
 
-/-- Construct a one-dimensional animacy-based P-marking profile: P arguments
-    at or above the cutoff are marked. (For A marking, use `animacyCutoffA`.)
-    The cutoff is the scale's `LinearOrder` (`Core.Order.atOrAbove`), not a
-    raw rank comparison. -/
-def DifferentialMarkingProfile.animacyCutoffP
-    (name : String) (channel : MarkingChannel) (cutoff : AnimacyLevel)
-    : DifferentialMarkingProfile :=
-  { name, role := .P, channel, marks := λ a _ => decide (cutoff ≤ a) }
+/-- Mark the cells at or above an animacy cutoff — P/T-type marking; the
+    marked zone is `Core.Order.atOrAbove` on the animacy axis. -/
+def animacyAtLeast (cutoff : AnimacyLevel) : MarkingPattern :=
+  λ a _ => decide (cutoff ≤ a)
 
-/-- Construct a one-dimensional definiteness-based P-marking profile. -/
-def DifferentialMarkingProfile.definitenessCutoffP
-    (name : String) (channel : MarkingChannel) (cutoff : DefinitenessLevel)
-    : DifferentialMarkingProfile :=
-  { name, role := .P, channel, marks := λ _ d => decide (cutoff ≤ d) }
+/-- Mark the cells at or above a definiteness cutoff (P/T-type marking). -/
+def definitenessAtLeast (cutoff : DefinitenessLevel) : MarkingPattern :=
+  λ _ d => decide (cutoff ≤ d)
 
-/-- Construct a one-dimensional animacy-based A-marking profile: A arguments
-    at or below the cutoff are marked (anti-monotone / lower set). -/
-def DifferentialMarkingProfile.animacyCutoffA
-    (name : String) (channel : MarkingChannel) (cutoff : AnimacyLevel)
-    : DifferentialMarkingProfile :=
-  { name, role := .A, channel, marks := λ a _ => decide (a ≤ cutoff) }
+/-- Mark the cells at or below an animacy cutoff — A/R-type marking; the
+    marked zone is the complementary lower set. -/
+def animacyAtMost (cutoff : AnimacyLevel) : MarkingPattern :=
+  λ a _ => decide (a ≤ cutoff)
 
-/-- Construct a one-dimensional definiteness-based A-marking profile. -/
-def DifferentialMarkingProfile.definitenessCutoffA
-    (name : String) (channel : MarkingChannel) (cutoff : DefinitenessLevel)
-    : DifferentialMarkingProfile :=
-  { name, role := .A, channel, marks := λ _ d => decide (d ≤ cutoff) }
+/-- Mark the cells at or below a definiteness cutoff (A/R-type marking). -/
+def definitenessAtMost (cutoff : DefinitenessLevel) : MarkingPattern :=
+  λ _ d => decide (d ≤ cutoff)
 
--- ============================================================================
--- § 9: One-Dimensional Monotonicity Theorems
--- ============================================================================
+/-- [just-2024]'s mirror image: the P-type and A-type cutoffs at the same
+    level jointly cover the grid — every cell is marked by at least one,
+    both exactly at the cutoff row. -/
+theorem animacy_mirror_image (cutoff a : AnimacyLevel) (d : DefinitenessLevel) :
+    (animacyAtLeast cutoff a d || animacyAtMost cutoff a d) = true := by
+  simpa [animacyAtLeast, animacyAtMost] using le_total cutoff a
 
-/-- Animacy-cutoff P profiles are always monotone — the marked region is the
-    upper set `Core.Order.atOrAbove cutoff` on the animacy axis, lifted through
-    `isMonotoneP_of` by `le_trans`. -/
-theorem animacyCutoffP_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
-    (DifferentialMarkingProfile.animacyCutoffP "" ch cutoff).isMonotone = true := by
-  apply DifferentialMarkingProfile.isMonotoneP_of
-  intro a a' _ _ haa' _ hm
-  simp only [DifferentialMarkingProfile.animacyCutoffP, decide_eq_true_eq] at hm ⊢
-  exact Core.Order.atOrAbove_isUpperSet cutoff haa' hm
-
-/-- Definiteness-cutoff P profiles are always monotone — same `isMonotoneP_of`
-    + `le_trans`, now on the definiteness axis. -/
-theorem definitenessCutoffP_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
-    (DifferentialMarkingProfile.definitenessCutoffP "" ch cutoff).isMonotone = true := by
-  apply DifferentialMarkingProfile.isMonotoneP_of
-  intro _ _ d d' _ hdd' hm
-  simp only [DifferentialMarkingProfile.definitenessCutoffP, decide_eq_true_eq] at hm ⊢
-  exact Core.Order.atOrAbove_isUpperSet cutoff hdd' hm
-
-/-- Animacy-cutoff A profiles are always anti-monotone (lower set). -/
-theorem animacyCutoffA_monotone (ch : MarkingChannel) (cutoff : AnimacyLevel) :
-    (DifferentialMarkingProfile.animacyCutoffA "" ch cutoff).isMonotone = true := by
-  apply DifferentialMarkingProfile.isMonotoneA_of
-  intro a a' _ _ ha'a _ hm
-  simp only [DifferentialMarkingProfile.animacyCutoffA, decide_eq_true_eq] at hm ⊢
-  exact Core.Order.atOrBelow_isLowerSet cutoff ha'a hm
-
-/-- Definiteness-cutoff A profiles are always anti-monotone (lower set). -/
-theorem definitenessCutoffA_monotone (ch : MarkingChannel) (cutoff : DefinitenessLevel) :
-    (DifferentialMarkingProfile.definitenessCutoffA "" ch cutoff).isMonotone = true := by
-  apply DifferentialMarkingProfile.isMonotoneA_of
-  intro _ _ d d' _ hd'd hm
-  simp only [DifferentialMarkingProfile.definitenessCutoffA, decide_eq_true_eq] at hm ⊢
-  exact Core.Order.atOrBelow_isLowerSet cutoff hd'd hm
-
--- ============================================================================
--- § 10: Mirror Image Theorem ([just-2024], §3)
--- ============================================================================
-
-/-- For any one-dimensional animacy cutoff, P marking at level `c` and A
-    marking at level `c` produce complementary profiles: every cell is
-    marked by exactly one of them (except the cutoff row itself, marked
-    by both). -/
-theorem animacy_mirror_image (cutoff : AnimacyLevel) :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        (DifferentialMarkingProfile.animacyCutoffP "" .indexing cutoff).marks a d ||
-        (DifferentialMarkingProfile.animacyCutoffA "" .indexing cutoff).marks a d)) = true := by
-  cases cutoff <;> decide
+end MarkingPattern
 
 -- ============================================================================
 -- § 11: Scenarios ([haspelmath-2021], §6)

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -36,7 +36,7 @@ high-abs analysis (consistent with [preminger-2014] and
 argument, in contrast with San Juan Atitán Mam, where Infl's φ-probe
 is blocked in transitives and the patient goes unagreed ([scott-2023];
 see `Mam/Agreement.lean`) — the non-differential/differential pair
-consumed by `Studies/Aissen2003Agreement.lean`. The AF agreement table
+consumed by `Studies/Just2024.lean`. The AF agreement table
 ([preminger-2014] §3.2, table (22)) and the choice rule that predicts
 it live in `Studies/Preminger2014.lean`. The non-perfective `accCase`
 records [imanishi-2014]'s analysis of the progressive *ajin*

--- a/Linglib/Studies/Aissen2003.lean
+++ b/Linglib/Studies/Aissen2003.lean
@@ -1,42 +1,45 @@
 import Linglib.Features.Prominence
 import Linglib.Phonology.Constraints.Basic
 import Linglib.Phonology.OptimalityTheory.Tableau
-import Linglib.Syntax.Case.Dependent
 
 /-!
-# [aissen-2003]: Differential Object Marking [aissen-2003]
+# Aissen 2003: Differential Object Marking
+[aissen-2003]
 
-Differential Object Marking: Iconicity vs. Economy.
-Natural Language & Linguistic Theory 21(3): 435–483.
+Differential Object Marking: Iconicity vs. Economy. Natural Language &
+Linguistic Theory 21(3), 435–483.
 
-Formalizes the core OT analysis: Harmonic Alignment of prominence scales
-with the relational scale (Subj > Obj) derives two constraint families:
+The higher in prominence a direct object, the more likely it is to be overtly
+case-marked. [aissen-2003] derives this in OT: harmonic alignment of the
+animacy and definiteness scales with the relational scale, locally conjoined
+with \*Ø_C, yields a fixed subhierarchy of iconicity constraints \*Oj/X & \*Ø_C
+("penalize a zero-marked object at prominence X"), and a single economy
+constraint \*STRUC_C ("penalize overt case morphology") interpolates into it.
+The interpolation point is the grammar: an object is obligatorily marked iff
+its iconicity constraint outranks \*STRUC_C, so each of the n + 1 points on an
+n-level scale is a language type, and every type marks an upward-closed
+segment of the scale. The subhierarchies' derivation by harmonic alignment
+(the paper's §§2–3) is taken as given; the constraint lists below are written
+directly in their derived ranking.
 
-- **Iconicity** (*Ø/X): penalizes zero-marked objects at prominence level X.
-  Fixed ranking: *Ø most prominent >>... >> *Ø least prominent.
-- **Economy** (*!/X): penalizes marked objects at prominence level X.
-  Fixed ranking: *!/least prominent >>... >> *!/most prominent.
+Language grids (`Features.Prominence.MarkingPattern`) record *obligatory*
+marking — the zone whose constraints strictly dominate \*STRUC_C. The paper's
+optional zones (constraints that rerank with \*STRUC_C, stochastically in
+Boersma's sense) are noted in docstrings but not represented.
 
-Rankings are fixed within each family but free between families. The factorial
-typology over all consistent interleavings predicts exactly the attested DOM
-patterns.
+## Main results
 
-## Key Results
-
-| Scale Size | Consistent Rankings | Language Types | Impossible Patterns |
-|------------|-------------------|---------------|-------------------|
-| 2 elements | 6 | 3 | Mark low without high |
-| 3 elements | 20 | 4 | Any non-monotone pattern |
-
-For the 3-element animacy scale {Hu > An > In}, 4 of 8 logically possible
-patterns are generated — exactly the monotone ones (Table 17, p. 476).
-
-## Connection to Existing Infrastructure
-
-The predicted DOM profiles are matched against the `DOMProfile` language data
-in §0 below, verifying that every attested pattern corresponds
-to a possible OT grammar.
-
+- `dom_monotonicity_universal`, `dom_obligatory_zone_upperSet` — the paper's
+  (33b): every attested obligatory-marking zone is an upper set in Figure 4's
+  product prominence order.
+- `tableaux_1_2` — the Hebrew/Turkish minimal pair on specific indefinites.
+- `figure2_typology` / `figure2_languages` — the six interpolation points on
+  the definiteness subhierarchy generate exactly the six cutoff systems,
+  matched type-for-type to Kalkatungu, Catalan, Pitjantjatjara, Hebrew,
+  Turkish, and Written Japanese.
+- `figure3_typology` / `figure3_languages` — likewise for the animacy scale.
+- `two_dimensional_systems` — Hindi and both stages of Spanish need both
+  scales.
 -/
 
 namespace Aissen2003
@@ -44,614 +47,213 @@ namespace Aissen2003
 open Features.Prominence
 open Constraints OptimalityTheory
 
-open Core.Optimization.Evaluation (Finset.checkAll Finset.checkAny)
+/-! ### The DOM systems of the paper
 
--- ============================================================================
--- §0. DOM language profiles (Aissen 2003 empirical core)
--- ============================================================================
---
--- The 8 DOM language profiles plus monotonicity / 1D-classification /
--- scale-dominance / extreme-cell theorems were dissolved here from a
--- former case-typology mash-up file (which mixed WALS Iggesen
--- substrate with Aissen DOM data). DOM data empirically belongs to Aissen
--- 2003 — it is the empirical input the OT factorial typology (§§1–8 below)
--- predicts. The substrate type `DifferentialMarkingProfile` lives in
--- `Features/Prominence.lean`; consumers Comrie1989, DeHoopMalchukov2008,
--- and Grimm2011 read these profiles from this file. `noDOMProfile` is
--- included in `allDOMProfiles` because it corresponds to OT Type 4 (no
--- marking) — see `nodom_matches_type4` in §6.
-
-/-- A DOM (Differential Object Marking) profile: a `DifferentialMarkingProfile`
-    specialized to role P + channel flagging.
-
-    Each cell `(a, d)` records whether an object with animacy level `a`
-    and definiteness level `d` obligatorily receives an overt DOM marker
-    (e.g., Spanish `a`, Turkish `-(y)I`, Hindi `-ko`).
-
-    DOM is the P-flagging instance of [just-2024]'s general differential
-    marking framework. Monotonicity (`isMonotone`), `isAnimacyOnly`, and
-    `isDefinitenessOnly` are all inherited from `DifferentialMarkingProfile`. -/
-abbrev DOMProfile := DifferentialMarkingProfile
+The one-dimensional definiteness systems are the six interpolation types of
+Figure 2, one cited language each; Ritharngu and Dhargari instantiate the
+clean animacy types of Figure 3 (Yiddish and Sinhalese sit at its
+optional-zone points). Hindi, Persian, and the two stages of Spanish are the
+two-dimensional systems of §5. -/
 
 section DOMLanguages
 
-/-- Spanish: `a`-marking for human direct objects regardless of definiteness.
-    One-dimensional (animacy-based), cutoff between human and animate. -/
-def spanishDOM : DOMProfile :=
-  .animacyCutoffP "Spanish" .flagging .human
+/-- Catalan: only (strong) personal-pronoun objects are marked with *a*
+    (Figure 2, §4.1). -/
+def catalanDOM : MarkingPattern := .definitenessAtLeast .personalPronoun
 
-/-- Russian: animate accusative (genitive form used as accusative for
-    animate nouns). One-dimensional (animacy-based), cutoff between animate
-    and inanimate. -/
-def russianDOM : DOMProfile :=
-  .animacyCutoffP "Russian" .flagging .animate
+/-- Pitjantjatjara: only pronoun and proper-name objects are case-marked
+    (Figure 2). -/
+def pitjantjatjaraDOM : MarkingPattern := .definitenessAtLeast .properName
 
-/-- Turkish: `-(y)I` marking for definite direct objects regardless of
-    animacy. One-dimensional (definiteness-based), cutoff between definite
-    and indefinite specific. -/
-def turkishDOM : DOMProfile :=
-  .definitenessCutoffP "Turkish" .flagging .definite
+/-- Hebrew: *ʔet* is obligatory on pronoun, proper-name, and definite
+    objects (Figure 2, §4.1). -/
+def hebrewDOM : MarkingPattern := .definitenessAtLeast .definite
 
-/-- Hebrew: `ʔet` marking for definite direct objects regardless of
-    animacy. Same one-dimensional definiteness cutoff as Turkish. -/
-def hebrewDOM : DOMProfile :=
-  .definitenessCutoffP "Hebrew" .flagging .definite
+/-- Turkish: *-(y)I* marks all objects except non-specifics — unlike Hebrew,
+    specific indefinites are obligatorily marked (Figure 2, Tableaux 1–2). -/
+def turkishDOM : MarkingPattern := .definitenessAtLeast .indefiniteSpecific
 
-/-- Persian: `-rā` marking for definite direct objects. One-dimensional
-    (definiteness-based) for obligatory marking; optional extension to
-    specific indefinite animates. -/
-def persianDOM : DOMProfile :=
-  .definitenessCutoffP "Persian" .flagging .definite
+/-- Persian: *-rā* is obligatory on all definites regardless of animacy and,
+    exactly as in Turkish, on specific indefinites (§5.3). Animacy enters
+    only in the optional zone (non-specific indefinites), so the obligatory
+    grid is one-dimensional. -/
+def persianDOM : MarkingPattern := .definitenessAtLeast .indefiniteSpecific
 
-/-- Catalan: `a`-marking restricted to personal pronouns. The most
-    restrictive DOM pattern attested. -/
-def catalanDOM : DOMProfile :=
-  .definitenessCutoffP "Catalan" .flagging .personalPronoun
+/-- Written Japanese: all objects are case-marked — DOM extended to the whole
+    scale, "thereby ceasing to be differential" (Figures 2–3, fn. 33). -/
+def writtenJapaneseDOM : MarkingPattern := .definitenessAtLeast .nonSpecific
 
-/-- Hindi-Urdu: `-ko` marking conditioned by BOTH animacy and definiteness.
-    Two-dimensional DOM with a staircase cutoff. -/
-def hindiDOM : DOMProfile :=
-  { name := "Hindi-Urdu", role := .P, channel := .flagging
-    marks := λ a d =>
-      match a with
-      | .human     => d.rank ≥ DefinitenessLevel.indefiniteSpecific.rank
-      | .animate   => d.rank ≥ DefinitenessLevel.definite.rank
-      | .inanimate => false }
+/-- Ritharngu: all human objects obligatorily case-marked; the "some
+    animates" spillover the paper reports is optional-zone (Figure 3). -/
+def ritharnguDOM : MarkingPattern := .animacyAtLeast .human
 
-/-- No DOM: trivially monotone. Included in `allDOMProfiles` to match OT
-    Type 4 (no marking) via `nodom_matches_type4` in §6. -/
-def noDOMProfile : DOMProfile :=
-  { name := "No DOM", role := .P, channel := .flagging, marks := λ _ _ => false }
+/-- Dhargari: all animate objects case-marked (Figure 3). -/
+def dhargariDOM : MarkingPattern := .animacyAtLeast .animate
+
+/-- No DOM: no object is case-marked — Kalkatungu in Figures 2–3, where
+    \*STRUC_C dominates the whole subhierarchy. Kept as the neutral
+    no-marking baseline other studies consume. -/
+def noDOM : MarkingPattern := λ _ _ => false
+
+/-- Hindi: *-ko* (§5.2, Figure 7). Obligatory: human objects down to specific
+    indefinites, plus animate pronouns and proper names (which "assimilate to
+    the human class"). Optional: human non-specifics, animate definites and
+    below, inanimate definites. Excluded: other inanimates. -/
+def hindiDOM : MarkingPattern := λ a d =>
+  match a with
+  | .human     => decide (DefinitenessLevel.indefiniteSpecific ≤ d)
+  | .animate   => decide (DefinitenessLevel.properName ≤ d)
+  | .inanimate => false
+
+/-- Spanish of the Cantar de Mio Cid: *a* obligatory exactly on the personal
+    pronouns and proper names of humans and animals (§5.1, Figure 5).
+    Optional: human common NPs and geographic proper names. -/
+def cmcSpanishDOM : MarkingPattern := λ a d =>
+  decide (AnimacyLevel.animate ≤ a) && decide (DefinitenessLevel.properName ≤ d)
+
+/-- Modern Spanish: the CMC system with \*STRUC_C demoted below the
+    human-definite and human-specific constraints, so *a* is now also
+    obligatory with definite and specific human objects (§5.4, Figure 9).
+    The obligatory grid coincides with Hindi's; the two differ in their
+    optional zones (Figure 7 vs. Figure 9). -/
+def spanishDOM : MarkingPattern := λ a d =>
+  match a with
+  | .human     => decide (DefinitenessLevel.indefiniteSpecific ≤ d)
+  | .animate   => decide (DefinitenessLevel.properName ≤ d)
+  | .inanimate => false
 
 end DOMLanguages
 
-/-- All DOM profiles in the sample (7 attested + 1 no-marking baseline). -/
-def allDOMProfiles : List DOMProfile :=
-  [spanishDOM, russianDOM, turkishDOM, hebrewDOM, persianDOM,
-   catalanDOM, hindiDOM, noDOMProfile]
+/-- The DOM systems cited in the paper. -/
+def allDOMPatterns : List MarkingPattern :=
+  [catalanDOM, pitjantjatjaraDOM, hebrewDOM, turkishDOM, persianDOM,
+   writtenJapaneseDOM, ritharnguDOM, dhargariDOM, hindiDOM, cmcSpanishDOM,
+   spanishDOM, noDOM]
 
-theorem allDOMProfiles_count : allDOMProfiles.length = 8 := by decide
+/-! ### Monotonicity: the (33b) universal -/
 
--- §0.1 Per-language monotonicity (Aissen's central prediction: every DOM
--- pattern forms an upper set in the bidimensional animacy × definiteness
--- grid). The one-dimensional cutoff languages inherit it directly from the
--- generic `animacyCutoffP_monotone`/`definitenessCutoffP_monotone` (proved
--- once over the scale's `LinearOrder`), rather than re-deciding per language.
-
-theorem spanish_monotone : spanishDOM.isMonotone = true :=
-  animacyCutoffP_monotone .flagging .human
-theorem russian_monotone : russianDOM.isMonotone = true :=
-  animacyCutoffP_monotone .flagging .animate
-theorem turkish_monotone : turkishDOM.isMonotone = true :=
-  definitenessCutoffP_monotone .flagging .definite
-theorem hebrew_monotone : hebrewDOM.isMonotone = true :=
-  definitenessCutoffP_monotone .flagging .definite
-theorem persian_monotone : persianDOM.isMonotone = true :=
-  definitenessCutoffP_monotone .flagging .definite
-theorem catalan_monotone : catalanDOM.isMonotone = true :=
-  definitenessCutoffP_monotone .flagging .personalPronoun
-theorem hindi_monotone : hindiDOM.isMonotone = true := by decide
-theorem no_dom_monotone : noDOMProfile.isMonotone = true := by decide
-
-/-- **Aissen's DOM monotonicity universal**: all attested DOM patterns in
-    the sample form upper sets in the bidimensional animacy × definiteness
-    grid. No language marks a less-prominent object while leaving a
-    more-prominent one unmarked. -/
+/-- Every attested DOM system is monotone: no language obligatorily marks a
+    less prominent object while leaving a more prominent one unmarked. -/
 theorem dom_monotonicity_universal :
-    allDOMProfiles.all (·.isMonotone) = true := by decide
-
--- §0.2 One-dimensional classification
-
-theorem spanish_animacy_only : spanishDOM.isAnimacyOnly = true := by native_decide
-theorem russian_animacy_only : russianDOM.isAnimacyOnly = true := by native_decide
-theorem turkish_definiteness_only : turkishDOM.isDefinitenessOnly = true := by native_decide
-theorem hebrew_definiteness_only : hebrewDOM.isDefinitenessOnly = true := by native_decide
-theorem persian_definiteness_only : persianDOM.isDefinitenessOnly = true := by native_decide
-theorem catalan_definiteness_only : catalanDOM.isDefinitenessOnly = true := by native_decide
-
-/-- Hindi DOM depends on both animacy and definiteness — it cannot be
-    reduced to a single scale. -/
-theorem hindi_not_animacy_only : hindiDOM.isAnimacyOnly = false := by native_decide
-theorem hindi_not_definiteness_only : hindiDOM.isDefinitenessOnly = false := by native_decide
-
--- §0.3 Scale-dominance consequences of monotonicity
-
-/-- In all sample languages, human objects are never less marked than
-    animate objects at the same definiteness level. -/
-theorem human_dominates_animate :
-    allDOMProfiles.all (λ p =>
-      DefinitenessLevel.all.all (λ d =>
-        if p.marks .animate d then p.marks .human d else true)) = true := by
-  native_decide
-
-/-- In all sample languages, animate objects are never less marked than
-    inanimate objects at the same definiteness level. -/
-theorem animate_dominates_inanimate :
-    allDOMProfiles.all (λ p =>
-      DefinitenessLevel.all.all (λ d =>
-        if p.marks .inanimate d then p.marks .animate d else true)) = true := by
-  native_decide
-
-/-- In all sample languages, pronouns are never less marked than proper
-    names at the same animacy level. -/
-theorem pronoun_dominates_properName :
-    allDOMProfiles.all (λ p =>
-      AnimacyLevel.all.all (λ a =>
-        if p.marks a .properName then p.marks a .personalPronoun else true)) = true := by
-  native_decide
-
-/-- In all sample languages, definite NPs are never less marked than
-    indefinite specific NPs at the same animacy level. -/
-theorem definite_dominates_indefiniteSpecific :
-    allDOMProfiles.all (λ p =>
-      AnimacyLevel.all.all (λ a =>
-        if p.marks a .indefiniteSpecific then p.marks a .definite else true)) = true := by
-  native_decide
-
--- §0.4 Extreme-cell theorems
-
-/-- If any cell is marked, the most prominent cell (human, pronoun)
-    is also marked. -/
-theorem top_cell_marked_if_any :
-    allDOMProfiles.all (λ p =>
-      if AnimacyLevel.all.any (λ a =>
-           DefinitenessLevel.all.any (λ d => p.marks a d))
-      then p.marks .human .personalPronoun
-      else true) = true := by native_decide
-
-/-- The least prominent cell (inanimate, non-specific) is unmarked in
-    all DOM languages in the sample. -/
-theorem bottom_cell_unmarked :
-    allDOMProfiles.all (λ p =>
-      p.marks .inanimate .nonSpecific == false) = true := by native_decide
-
--- §0.5 Grid size + total marked cells
-
-/-- The bidimensional grid has 3 × 5 = 15 cells per language. -/
-theorem grid_size :
-    AnimacyLevel.all.length * DefinitenessLevel.all.length = 15 := by native_decide
-
-/-- Total marked cells across all sample languages. -/
-def totalMarkedCells : Nat :=
-  allDOMProfiles.foldl (λ acc p =>
-    acc + (AnimacyLevel.all.foldl (λ acc₂ a =>
-      acc₂ + (DefinitenessLevel.all.filter (p.marks a)).length) 0)) 0
-
-/-- Marked cells: Spanish (5) + Russian (10) + Turkish (9) + Hebrew (9) +
-    Persian (9) + Catalan (3) + Hindi (7) + NoDOM (0) = 52. -/
-theorem total_marked_cells_value : totalMarkedCells = 52 := by native_decide
-
--- ============================================================================
--- § 1: Interleavings
--- ============================================================================
-
-/-- All interleavings of two lists, preserving internal order of each.
-
-    Given two constraint families with fixed internal rankings, this generates
-    all total orders consistent with both. The number of
-    interleavings of lists of lengths m and n is C(m+n, m). -/
-def interleavings {α : Type} : List α → List α → List (List α)
-  | [], ys => [ys]
-  | xs, [] => [xs]
-  | x :: xs, y :: ys =>
-    (interleavings xs (y :: ys)).map (x :: ·) ++
-    (interleavings (x :: xs) ys).map (y :: ·)
-
--- ============================================================================
--- § 2: Two-Element Scale (Table 14, p. 473)
--- ============================================================================
-
-/-- DOM candidate for a 2-element prominence scale {High > Low}.
-    `true` = overtly case-marked; `false` = zero-marked. -/
-structure Scale2Cand where
-  high : Bool
-  low : Bool
-  deriving DecidableEq, Repr
-
-def scale2Cands : List Scale2Cand :=
-  [⟨true, true⟩, ⟨true, false⟩, ⟨false, true⟩, ⟨false, false⟩]
-
-/-- *Ø/High: penalize unmarked High objects. -/
-def starZeroHigh : Constraint Scale2Cand :=
-  Constraint.binary fun c => c.high = false
-
-/-- *Ø/Low: penalize unmarked Low objects. -/
-def starZeroLow : Constraint Scale2Cand :=
-  Constraint.binary fun c => c.low = false
-
-/-- *!/Low: penalize marked Low objects (economy). -/
-def starBangLow : Constraint Scale2Cand :=
-  Constraint.binary fun c => c.low = true
-
-/-- *!/High: penalize marked High objects (economy). -/
-def starBangHigh : Constraint Scale2Cand :=
-  Constraint.binary fun c => c.high = true
-
-/-- Iconicity family (fixed: *Ø/High >> *Ø/Low). -/
-def iconicity2 : List (Constraint Scale2Cand) := [starZeroHigh, starZeroLow]
-
-/-- Economy family (fixed: *!/Low >> *!/High). -/
-def economy2 : List (Constraint Scale2Cand) := [starBangLow, starBangHigh]
-
-/-- All consistent rankings: interleavings of the two families. -/
-def rankings2 : List (List (Constraint Scale2Cand)) :=
-  interleavings iconicity2 economy2
-
-/-- There are exactly 6 consistent rankings (C(4,2) = 6). -/
-theorem rankings2_count : rankings2.length = 6 := by native_decide
-
-/-- Compute optima for each consistent ranking. -/
-def optima2 : List (Finset Scale2Cand) :=
-  rankings2.map λ ranking =>
-    (Tableau.ofRanking scale2Cands ranking).optimal
-
-/-- Distinct language types. -/
-def types2 : List (Finset Scale2Cand) := optima2.eraseDups
-
-/-- The 2-element scale yields exactly 3 language types, not 4
-    (Table 14, p. 473). -/
-theorem two_element_three_types : types2.length = 3 := by native_decide
-
-/-- The impossible pattern — mark Low without High — is never optimal. -/
-theorem no_low_without_high :
-    optima2.all (λ opts =>
-      opts.checkAll (λ c => !(c.low && !c.high))) = true := by native_decide
-
--- ============================================================================
--- § 3: Three-Element Animacy Scale (Table 17, p. 476)
--- ============================================================================
-
-/-- DOM candidate for the 3-element animacy scale {Hu > An > In}.
-    `true` = overtly case-marked; `false` = zero-marked. -/
-structure AnimCand where
-  hu : Bool
-  an : Bool
-  inan : Bool
-  deriving DecidableEq, Repr
-
-def animCands : List AnimCand :=
-  [⟨true, true, true⟩, ⟨true, true, false⟩,
-   ⟨true, false, true⟩, ⟨true, false, false⟩,
-   ⟨false, true, true⟩, ⟨false, true, false⟩,
-   ⟨false, false, true⟩, ⟨false, false, false⟩]
-
-/-- Iconicity: *Ø/Hu >> *Ø/An >> *Ø/In. -/
-def starZeroHu : Constraint AnimCand :=
-  Constraint.binary fun c => c.hu = false
-
-def starZeroAn : Constraint AnimCand :=
-  Constraint.binary fun c => c.an = false
-
-def starZeroIn : Constraint AnimCand :=
-  Constraint.binary fun c => c.inan = false
-
-/-- Economy: *!/In >> *!/An >> *!/Hu. -/
-def starBangIn : Constraint AnimCand :=
-  Constraint.binary fun c => c.inan = true
-
-def starBangAn : Constraint AnimCand :=
-  Constraint.binary fun c => c.an = true
-
-def starBangHu : Constraint AnimCand :=
-  Constraint.binary fun c => c.hu = true
-
-/-- Iconicity family (fixed: *Ø/Hu >> *Ø/An >> *Ø/In). -/
-def animIconicity : List (Constraint AnimCand) :=
-  [starZeroHu, starZeroAn, starZeroIn]
-
-/-- Economy family (fixed: *!/In >> *!/An >> *!/Hu). -/
-def animEconomy : List (Constraint AnimCand) :=
-  [starBangIn, starBangAn, starBangHu]
-
-/-- All consistent rankings for the 3-element scale. -/
-def animRankings : List (List (Constraint AnimCand)) :=
-  interleavings animIconicity animEconomy
-
-/-- There are exactly 20 consistent rankings (C(6,3) = 20). -/
-theorem anim_rankings_count : animRankings.length = 20 := by native_decide
-
-/-- Compute optima for each consistent ranking. -/
-def animOptima : List (Finset AnimCand) :=
-  animRankings.map λ ranking =>
-    (Tableau.ofRanking animCands ranking).optimal
-
-/-- Distinct language types. -/
-def animTypes : List (Finset AnimCand) := animOptima.eraseDups
-
-/-- The 3-element animacy scale yields exactly 4 language types, not 8
-    (Table 17, p. 476). -/
-theorem animacy_four_types : animTypes.length = 4 := by native_decide
-
-/-- Every generated type is monotone: if An is marked then Hu is too;
-    if In is marked then An is too (Aissen's central prediction). -/
-theorem animacy_all_monotone :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c =>
-        (if c.an then c.hu else true) &&
-        (if c.inan then c.an else true))) = true := by native_decide
-
--- ============================================================================
--- § 4: Type Identification
--- ============================================================================
-
-/-- Type 1: mark all (Hu + An + In). Extreme iconicity. -/
-theorem anim_type_all :
-    animTypes.any (λ opts =>
-      opts.checkAny (λ c => c.hu && c.an && c.inan)) = true := by native_decide
-
-/-- Type 2: mark Hu + An only. Russian pattern (animate accusative). -/
-theorem anim_type_hu_an :
-    animTypes.any (λ opts =>
-      opts.checkAny (λ c => c.hu && c.an && !c.inan)) = true := by native_decide
-
-/-- Type 3: mark Hu only. Spanish pattern (personal `a`). -/
-theorem anim_type_hu_only :
-    animTypes.any (λ opts =>
-      opts.checkAny (λ c => c.hu && !c.an && !c.inan)) = true := by native_decide
-
-/-- Type 4: mark none. No DOM (economy dominates). -/
-theorem anim_type_none :
-    animTypes.any (λ opts =>
-      opts.checkAny (λ c => !c.hu && !c.an && !c.inan)) = true := by native_decide
-
--- ============================================================================
--- § 5: Impossible Patterns
--- ============================================================================
-
-/-- Mark In without An: never generated. -/
-theorem no_in_without_an :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c => !(c.inan && !c.an))) = true := by native_decide
-
-/-- Mark An without Hu: never generated. -/
-theorem no_an_without_hu :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c => !(c.an && !c.hu))) = true := by native_decide
-
-/-- Mark In without Hu: never generated. -/
-theorem no_in_without_hu :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c => !(c.inan && !c.hu))) = true := by native_decide
-
-/-- Mark In only (without An or Hu): never generated. -/
-theorem no_in_only :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c => !(c.inan && !c.an && !c.hu))) = true := by native_decide
-
--- ============================================================================
--- § 6: Bridge to DOMProfiles
--- ============================================================================
-
-/-- Convert an AnimCand to a one-dimensional animacy DOMProfile. -/
-def animCandToDOM (c : AnimCand) : DOMProfile :=
-  { name := "OT-predicted", role := .P, channel := .flagging
-    marks := λ a _ =>
-      match a with
-      | .human => c.hu
-      | .animate => c.an
-      | .inanimate => c.inan }
-
-/-- Every OT-generated animacy type produces a monotone DOMProfile. -/
-theorem ot_types_are_monotone_dom :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c => (animCandToDOM c).isMonotone)) = true := by native_decide
-
-/-- Spanish DOM (human only) matches OT Type 3 (Hu only). -/
-theorem spanish_matches_type3 :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        spanishDOM.marks a d == (animCandToDOM ⟨true, false, false⟩).marks a d)) = true := by
-  native_decide
-
-/-- Russian DOM (animate+) matches OT Type 2 (Hu + An). -/
-theorem russian_matches_type2 :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        russianDOM.marks a d == (animCandToDOM ⟨true, true, false⟩).marks a d)) = true := by
-  native_decide
-
-/-- No-DOM profile matches OT Type 4 (none marked). -/
-theorem nodom_matches_type4 :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        noDOMProfile.marks a d == (animCandToDOM ⟨false, false, false⟩).marks a d)) = true := by
-  native_decide
-
--- ============================================================================
--- § 7: Definiteness Scale (2-Element: Pro > D)
--- ============================================================================
-
-/-! The 2-element definiteness scale {Pro > D} from §4 of the paper,
-    where "D" covers definite NPs (including proper names). This gives
-    the same 3-type factorial typology as any 2-element scale. -/
-
-/-- Convert a Scale2Cand to a definiteness-based DOMProfile.
-    High = personalPronoun, Low = properName + definite (i.e., ≥ definite). -/
-def defCandToDOM (c : Scale2Cand) : DOMProfile :=
-  { name := "OT-predicted", role := .P, channel := .flagging
-    marks := λ _ d =>
-      if d.rank ≥ DefinitenessLevel.personalPronoun.rank then c.high
-      else if d.rank ≥ DefinitenessLevel.definite.rank then c.low
-      else false }
-
-/-- Catalan DOM (pronouns only) matches 2-element Type 2 (High only). -/
-theorem catalan_matches_high_only :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        catalanDOM.marks a d == (defCandToDOM ⟨true, false⟩).marks a d)) = true := by
-  native_decide
-
-/-- Turkish DOM (definite+) matches 2-element Type 1 (both marked). -/
-theorem turkish_matches_both :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        turkishDOM.marks a d == (defCandToDOM ⟨true, true⟩).marks a d)) = true := by
-  native_decide
-
-/-- Hebrew DOM (definite+) also matches 2-element Type 1. -/
-theorem hebrew_matches_both :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        hebrewDOM.marks a d == (defCandToDOM ⟨true, true⟩).marks a d)) = true := by
-  native_decide
-
--- ============================================================================
--- § 8: Counting Argument (§4.1, p. 473)
--- ============================================================================
-
-/-- Of 8 logically possible 3-element patterns, OT generates exactly 4. -/
-theorem animacy_excludes_half : animCands.length = 8 ∧ animTypes.length = 4 := by
-  constructor <;> native_decide
-
-/-- Of 4 logically possible 2-element patterns, OT generates exactly 3. -/
-theorem two_element_excludes_one : scale2Cands.length = 4 ∧ types2.length = 3 := by
-  constructor <;> native_decide
-
-/-- The number of consistent rankings grows as C(2n, n).
-    For n=2: C(4,2) = 6. For n=3: C(6,3) = 20. -/
-theorem ranking_counts :
-    rankings2.length = 6 ∧ animRankings.length = 20 := by
-  constructor <;> native_decide
-
--- ============================================================================
--- Part II: Dependent Case → DOM Pipeline
--- ============================================================================
-
-open Syntax.Case
-
--- ============================================================================
--- § Prominence-Annotated NPs
--- ============================================================================
-
-/-- An NP enriched with referential prominence properties.
-
-    Structural case assignment (dependent case) is blind to these properties —
-    it cares only about c-command and lexical case. DOM then consults prominence
-    to decide overt realization. -/
-structure ProminentNP where
-  label : String
-  lexicalCase : Option Case
-  animacy : AnimacyLevel
-  definiteness : DefinitenessLevel
-  deriving DecidableEq, Repr
-
-/-- Strip prominence, yielding the NP that the case algorithm sees. -/
-def ProminentNP.toNP (pnp : ProminentNP) : NPInDomain :=
-  ⟨pnp.label, pnp.lexicalCase⟩
-
--- ============================================================================
--- § Transitive Pipeline
--- ============================================================================
-
-/-- A transitive clause: subject c-commands object. -/
-structure TransClause where
-  subject : ProminentNP
-  object  : ProminentNP
-  deriving DecidableEq, Repr
-
-/-- Run the dependent case algorithm on a transitive clause. -/
-def derivation (lang : CaseLanguageType) (tc : TransClause) : List CasedNP :=
-  assignCases lang [tc.subject.toNP, tc.object.toNP]
-
-/-- Abstract case assigned to the object. -/
-def objectCase (lang : CaseLanguageType) (tc : TransClause) : Option Case :=
-  getCaseOf tc.object.label (derivation lang tc)
-
-/-- Whether the object receives overt case morphology.
-
-    Two conditions:
-    1. The dependent case algorithm assigns ACC (syntax).
-    2. The DOM profile marks this prominence cell (morphology). -/
-def objectOvert (lang : CaseLanguageType) (dom : DOMProfile)
-    (tc : TransClause) : Bool :=
-  objectCase lang tc == some .acc &&
-  dom.marks tc.object.animacy tc.object.definiteness
-
--- ============================================================================
--- § Standard Transitive Template
--- ============================================================================
-
-/-- A standard transitive clause with a fixed subject (human pronoun)
-    and a variable-prominence object. Both lack lexical case. -/
-def mkTrans (a : AnimacyLevel) (d : DefinitenessLevel) : TransClause :=
-  { subject := ⟨"subj", none, .human, .personalPronoun⟩
-    object  := ⟨"obj",  none, a, d⟩ }
-
--- ============================================================================
--- § Layer 1 — Object Always Gets ACC
--- ============================================================================
-
-/-- In accusative transitives, the object receives abstract ACC regardless
-    of its animacy or definiteness. Dependent case is prominence-blind. -/
-theorem object_always_acc :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        objectCase .accusative (mkTrans a d) == some .acc)) = true := by
-  native_decide
-
-/-- The subject always gets NOM (unmarked case). -/
-theorem subject_always_nom :
-    AnimacyLevel.all.all (λ a =>
-      DefinitenessLevel.all.all (λ d =>
-        getCaseOf "subj" (derivation .accusative (mkTrans a d)) == some .nom)) = true := by
-  native_decide
-
--- ============================================================================
--- § Layer 3 — OT Constrains the Pipeline
--- ============================================================================
-
-/-- The overt marking profile produced by running the full pipeline
-    (dependent case + DOM filter). -/
-def overtProfile (lang : CaseLanguageType) (dom : DOMProfile) : DOMProfile :=
-  { name := dom.name ++ " (pipeline)", role := .P, channel := .flagging
-    marks := λ a d => objectOvert lang dom (mkTrans a d) }
-
-/-- Every OT-predicted animacy type, run through the full pipeline,
-    produces a monotone overt marking profile. -/
-theorem ot_pipeline_monotone :
-    animOptima.all (λ opts =>
-      opts.checkAll (λ c =>
-        (overtProfile .accusative (animCandToDOM c)).isMonotone)) = true := by
-  native_decide
-
-/-- The pipeline preserves monotonicity for all attested DOM languages. -/
-theorem attested_pipeline_monotone :
-    allDOMProfiles.all (λ dom =>
-      (overtProfile .accusative dom).isMonotone) = true := by native_decide
-
--- ============================================================================
--- § End-to-End Summary
--- ============================================================================
-
-/-- All 8 attested DOM profiles, run through the accusative case pipeline,
-    produce overt marking that is faithful to the DOM input AND monotone. -/
-theorem full_pipeline_faithful_and_monotone :
-    allDOMProfiles.all (λ dom =>
-      -- Faithful: pipeline output = DOM input
-      AnimacyLevel.all.all (λ a =>
-        DefinitenessLevel.all.all (λ d =>
-          (overtProfile .accusative dom).marks a d = dom.marks a d)) &&
-      -- Monotone: overt marking pattern is an upper set
-      (overtProfile .accusative dom).isMonotone) = true := by native_decide
+    ∀ p ∈ allDOMPatterns, p.MonotoneP := by decide
+
+/-- (33b), order-theoretically: in every attested system the obligatorily
+    marked cells form an upper set in the product prominence order of
+    Figure 4. -/
+theorem dom_obligatory_zone_upperSet :
+    ∀ p ∈ allDOMPatterns,
+      IsUpperSet {c : AnimacyLevel × DefinitenessLevel | p c.1 c.2 = true} :=
+  λ p hp => p.monotoneP_iff_isUpperSet.mp (dom_monotonicity_universal p hp)
+
+/-- The Figure 2 and §5.3 systems are animacy-blind. -/
+theorem definiteness_systems_one_dimensional :
+    ∀ p ∈ [catalanDOM, pitjantjatjaraDOM, hebrewDOM, turkishDOM, persianDOM,
+      writtenJapaneseDOM], p.DefinitenessOnly := by decide
+
+/-- The Figure 3 systems are definiteness-blind. -/
+theorem animacy_systems_one_dimensional :
+    ∀ p ∈ [ritharnguDOM, dhargariDOM], p.AnimacyOnly := by decide
+
+/-- Hindi and both stages of Spanish are genuinely two-dimensional (§5):
+    neither scale alone determines the obligatory zone. -/
+theorem two_dimensional_systems :
+    ∀ p ∈ [hindiDOM, cmcSpanishDOM, spanishDOM],
+      ¬ p.AnimacyOnly ∧ ¬ p.DefinitenessOnly := by decide
+
+/-! ### The interpolation engine
+
+The paper evaluates candidates per input: for an object at prominence level
+`ℓ`, GEN offers a case-marked and a zero-marked parse. \*Oj/ℓ & \*Ø_C
+penalizes the zero-marked parse; \*STRUC_C penalizes the case-marked one. A
+grammar linearizes the fixed subhierarchy with \*STRUC_C interpolated, and
+the winner at `ℓ` is the marked parse iff `ℓ`'s iconicity constraint
+outranks \*STRUC_C. -/
+
+variable {L : Type} [DecidableEq L]
+
+/-- \*STRUC_C: penalizes overt case morphology — violated by the case-marked
+    parse. Candidates are level–marking pairs; `true` is the marked parse. -/
+def starStruc : Constraint (L × Bool) := Constraint.binary (·.2 = true)
+
+/-- \*Oj/ℓ & \*Ø_C: violated by a zero-marked object at level `ℓ`. -/
+def starZero (ℓ : L) : Constraint (L × Bool) :=
+  Constraint.binary (λ c => c.1 = ℓ ∧ c.2 = false)
+
+/-- The iconicity subhierarchy of a scale (most prominent level first) with
+    \*STRUC_C interpolated at position `k`. -/
+def interpolation (levels : List L) (k : Nat) : List (Constraint (L × Bool)) :=
+  (levels.map starZero).insertIdx k starStruc
+
+/-- Whether the case-marked parse wins for an object at level `ℓ`. -/
+def markedWins (ranking : List (Constraint (L × Bool))) (ℓ : L) : Bool :=
+  decide ((Tableau.ofRanking [(ℓ, true), (ℓ, false)] ranking (by simp)).optimal
+    = {(ℓ, true)})
+
+/-- Tableaux 1–2: a specific indefinite object. In Hebrew \*STRUC_C outranks
+    \*Oj/Spec & \*Ø_C and the zero parse wins; in Turkish the ranking is
+    reversed and the marked parse wins. -/
+theorem tableaux_1_2 :
+    markedWins (interpolation DefinitenessLevel.all 3) .indefiniteSpecific = false ∧
+    markedWins (interpolation DefinitenessLevel.all 4) .indefiniteSpecific = true := by
+  constructor <;> decide
+
+/-- Figure 2: the six interpolation points on the definiteness subhierarchy
+    generate exactly the six cutoff systems — no non-monotone pattern
+    arises. -/
+theorem figure2_typology :
+    (List.range 6).map
+        (λ k => DefinitenessLevel.all.map (markedWins (interpolation DefinitenessLevel.all k)))
+      = [[false, false, false, false, false],
+         [true,  false, false, false, false],
+         [true,  true,  false, false, false],
+         [true,  true,  true,  false, false],
+         [true,  true,  true,  true,  false],
+         [true,  true,  true,  true,  true]] := by decide
+
+/-- Figure 2 cites "one language for each of the possible DOM types": each
+    cited language's obligatory grid is its interpolation type's predicted
+    pattern. -/
+theorem figure2_languages :
+    (∀ a d, noDOM a d = markedWins (interpolation DefinitenessLevel.all 0) d) ∧
+    (∀ a d, catalanDOM a d = markedWins (interpolation DefinitenessLevel.all 1) d) ∧
+    (∀ a d, pitjantjatjaraDOM a d = markedWins (interpolation DefinitenessLevel.all 2) d) ∧
+    (∀ a d, hebrewDOM a d = markedWins (interpolation DefinitenessLevel.all 3) d) ∧
+    (∀ a d, turkishDOM a d = markedWins (interpolation DefinitenessLevel.all 4) d) ∧
+    (∀ a d, writtenJapaneseDOM a d = markedWins (interpolation DefinitenessLevel.all 5) d) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+
+/-- Persian's obligatory grid realizes the same interpolation type as
+    Turkish's (§5.3: specific indefinites "require the suffix -rā, exactly as
+    ... the accusative suffix in Turkish"). -/
+theorem persian_same_type_as_turkish :
+    ∀ a d, persianDOM a d = turkishDOM a d := by decide
+
+/-- Figure 3: the four interpolation points on the animacy subhierarchy
+    generate exactly the four cutoff systems. -/
+theorem figure3_typology :
+    (List.range 4).map
+        (λ k => AnimacyLevel.all.map (markedWins (interpolation AnimacyLevel.all k)))
+      = [[false, false, false],
+         [true,  false, false],
+         [true,  true,  false],
+         [true,  true,  true]] := by decide
+
+/-- Figure 3's cleanly cutoff languages, type-for-type: Kalkatungu (none),
+    Ritharngu (humans), Dhargari (animates), Written Japanese and Dhalandji
+    (all). -/
+theorem figure3_languages :
+    (∀ a d, noDOM a d = markedWins (interpolation AnimacyLevel.all 0) a) ∧
+    (∀ a d, ritharnguDOM a d = markedWins (interpolation AnimacyLevel.all 1) a) ∧
+    (∀ a d, dhargariDOM a d = markedWins (interpolation AnimacyLevel.all 2) a) ∧
+    (∀ a d, writtenJapaneseDOM a d = markedWins (interpolation AnimacyLevel.all 3) a) := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
+
+/-- "This account predicts that the reverse is not found, e.g., languages in
+    which only inanimates are case-marked": every interpolation grammar marks
+    an upward-closed segment of the scale. -/
+theorem no_reversed_system :
+    ∀ k < 4, ∀ a a' : AnimacyLevel, a ≤ a' →
+      markedWins (interpolation AnimacyLevel.all k) a = true →
+      markedWins (interpolation AnimacyLevel.all k) a' = true := by decide
 
 end Aissen2003

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -496,8 +496,14 @@ The critical structural point: the **same** prominence hierarchies
 connection is built in by construction — both import `Features.Prominence`. -/
 
 open Features.Prominence (DefinitenessLevel)
-open Aissen2003
-  (DOMProfile spanishDOM russianDOM turkishDOM hindiDOM noDOMProfile)
+open Features.Prominence (MarkingPattern)
+open Aissen2003 (spanishDOM turkishDOM hindiDOM noDOM)
+
+/-- Russian: the accusative of animates is realized by the genitive form —
+    animacy-based differential marking of P. Not part of [aissen-2003]'s
+    sample; formalized here for [comrie-1989]'s alignment–DOM consistency
+    check. -/
+def russianDOM : MarkingPattern := .animacyAtLeast .animate
 open Dixon1994 (russian turkish dyirbalSplit)
 open Alignment (AlignmentFamily Aspect hindiSplit)
 
@@ -524,11 +530,12 @@ theorem acc_dom_erg_dsm :
     domExpected .accusative ∧ ¬ dsmExpected .accusative ∧
     ¬ domExpected .ergative ∧ dsmExpected .ergative := by decide
 
-/-- Whether a DOMProfile has any differential marking (at least one
-    prominence cell is overtly marked). -/
-def hasAnyMarking (dom : DOMProfile) : Bool :=
-  AnimacyLevel.all.any (λ a =>
-    DefinitenessLevel.all.any (λ d => dom.marks a d))
+/-- The pattern marks at least one prominence cell. -/
+def HasAnyMarking (dom : MarkingPattern) : Prop :=
+  ∃ a d, dom a d = true
+
+instance : DecidablePred HasAnyMarking := λ dom => by
+  unfold HasAnyMarking; infer_instance
 
 -- ============================================================================
 -- § 7a: Per-Language DOM × Alignment Consistency
@@ -537,7 +544,7 @@ def hasAnyMarking (dom : DOMProfile) : Bool :=
 /-! ### Testing the alignment–DOM prediction against language data
 
 Languages with both an `AlignmentProfile` (from `Alignment.Typology`)
-and a `DOMProfile` (from `Case.Typology`) can be tested: accusative
+and a DOM `MarkingPattern` can be tested: accusative
 alignment predicts DOM; ergative predicts DSM instead.
 
 - **Turkish**: accusative + DOM (definiteness-based) → consistent
@@ -548,19 +555,19 @@ alignment predicts DOM; ergative predicts DSM instead.
 
 /-- Turkish: accusative alignment → DOM expected; DOM present. -/
 theorem turkish_dom_consistent :
-    domExpected turkish.npAlignment ∧
-    hasAnyMarking turkishDOM = true := ⟨by decide, by native_decide⟩
+    domExpected turkish.npAlignment ∧ HasAnyMarking turkishDOM :=
+  ⟨by decide, by decide⟩
 
 /-- Russian: accusative alignment → DOM expected; DOM present. -/
 theorem russian_dom_consistent :
-    domExpected russian.npAlignment ∧
-    hasAnyMarking russianDOM = true := ⟨by decide, by native_decide⟩
+    domExpected russian.npAlignment ∧ HasAnyMarking russianDOM :=
+  ⟨by decide, by decide⟩
 
 /-- No-DOM languages with neutral alignment: DOM not expected,
     and no DOM exists. Doubly consistent. -/
 theorem neutral_no_dom :
-    ¬ domExpected .neutral ∧
-    hasAnyMarking noDOMProfile = false := ⟨by decide, by native_decide⟩
+    ¬ domExpected .neutral ∧ ¬ HasAnyMarking noDOM :=
+  ⟨by decide, by decide⟩
 
 -- ============================================================================
 -- § 7b: Split Ergativity × DOM Interaction
@@ -604,7 +611,7 @@ theorem hindi_pfv_no_dom :
     aspects. The empirical profile exceeds the per-zone prediction:
     ko operates on top of the case system, not within it. -/
 theorem hindi_has_dom_across_aspects :
-    hasAnyMarking hindiDOM = true := by native_decide
+    HasAnyMarking hindiDOM := by decide
 
 /-- Dyirbal's animacy-based split creates analogous zones: inanimates
     get ergative alignment (DOM not expected), animates get accusative
@@ -626,7 +633,8 @@ The animacy hierarchy operates in two independent grammatical systems:
    which NPs get ergative vs accusative alignment. In Dyirbal,
    `inanimate → ergative`, `human/animate → accusative`.
 2. **DOM** ([aissen-2003]): `AnimacyLevel` determines which objects get
-   overt marking. In Spanish, `human → marked`, `non-human → unmarked`.
+   overt marking. In Spanish, definite human objects are marked, inanimates
+   unmarked.
 
 Both are monotone cutoffs on the **same** linearly ordered type. A change
 to `AnimacyLevel` propagates automatically to both systems. This is
@@ -635,29 +643,30 @@ recur across grammatical domains. -/
 
 /-- The animacy hierarchy governs both split ergativity and DOM.
     Dyirbal uses it for the ergative split; Spanish uses it for DOM.
-    Both are monotone cutoffs on the same ordered type. -/
+    Both are monotone in the same ordered type. -/
 theorem animacy_governs_split_and_dom :
     -- Split ergativity: inanimate below threshold (ergative)
     dyirbalSplit.alignment .inanimate = .ergative ∧
     -- Split ergativity: human above threshold (accusative)
     dyirbalSplit.alignment .human = .accusative ∧
-    -- DOM: human above marking threshold (marked)
-    spanishDOM.marks .human .nonSpecific = true ∧
-    -- DOM: inanimate below marking threshold (unmarked)
-    spanishDOM.marks .inanimate .nonSpecific = false := ⟨rfl, rfl, rfl, rfl⟩
+    -- DOM: definite human objects obligatorily marked
+    spanishDOM .human .definite = true ∧
+    -- DOM: inanimate objects never obligatorily marked
+    spanishDOM .inanimate .definite = false := ⟨rfl, rfl, rfl, rfl⟩
 
 /-- Hindi-Urdu's bidimensional DOM uses BOTH prominence scales:
-    human objects need only indefinite-specific status for ko-marking,
-    while animate objects require definite status. The staircase cutoff
-    operates jointly on `AnimacyLevel × DefinitenessLevel`. -/
+    human objects need only indefinite-specific status for obligatory
+    ko-marking, while animates must be pronouns or proper names. The
+    staircase cutoff operates jointly on
+    `AnimacyLevel × DefinitenessLevel`. -/
 theorem hindi_bidimensional_dom :
     -- Human + indefinite specific: marked
-    hindiDOM.marks .human .indefiniteSpecific = true ∧
+    hindiDOM .human .indefiniteSpecific = true ∧
     -- Animate + indefinite specific: NOT marked
-    hindiDOM.marks .animate .indefiniteSpecific = false ∧
-    -- Animate + definite: marked
-    hindiDOM.marks .animate .definite = true ∧
-    -- Inanimate: never marked regardless of definiteness
-    hindiDOM.marks .inanimate .personalPronoun = false := ⟨rfl, rfl, rfl, rfl⟩
+    hindiDOM .animate .indefiniteSpecific = false ∧
+    -- Animate + proper name: marked
+    hindiDOM .animate .properName = true ∧
+    -- Inanimate: never obligatorily marked regardless of definiteness
+    hindiDOM .inanimate .personalPronoun = false := ⟨rfl, rfl, rfl, rfl⟩
 
 end Comrie1989

--- a/Linglib/Studies/Grimm2011.lean
+++ b/Linglib/Studies/Grimm2011.lean
@@ -2,6 +2,7 @@ import Linglib.Semantics.ArgumentStructure.CaseRegion
 import Linglib.Semantics.ArgumentStructure.Projection
 import Linglib.Semantics.ArgumentStructure.RoleList
 import Linglib.Studies.Aissen2003
+import Linglib.Syntax.Case.Dependent
 import Linglib.Studies.Dowty1991
 
 /-!
@@ -23,7 +24,7 @@ referential-property treatment the paper attributes to [grimm-2005].
 - `russian_dom_matches_lattice` / `spanish_dom_within_lattice` /
   `animate_dom_object_is_dative_node`: the lattice predicts DOM for exactly
   {animate, human}, and the animate DOM object is literally the dative node.
-- `domPredicted_monotone`, `latticeDOM_isMonotone`,
+- `domPredicted_monotone`, `latticeDOM_monotoneP`,
   `latticeDOM_matches_aissen_type2`: the lattice derives [aissen-2003]'s
   monotonicity universal and reproduces OT Type 2.
 - `genitive_requires_entailment_free`: only the entailment-free object
@@ -34,8 +35,8 @@ referential-property treatment the paper attributes to [grimm-2005].
   loses, and the ASP re-derived from dominance
   (`outranks_of_lattice_dominance`) rather than checked per verb.
 - `lattice_diverges_from_dependent_case`: the semantic-case vs
-  structural-case fault line on animate objects, made explicit against the
-  dependent-case pipeline in `Studies/Aissen2003.lean`.
+  structural-case fault line on animate objects, made explicit against a
+  dependent-case pipeline over prominence-annotated clauses.
 -/
 
 namespace Grimm2011
@@ -320,50 +321,51 @@ theorem domPredicted_monotone (p : PersistenceLevel) :
 
 /-! #### Checking attested DOM languages -/
 
+/-- Russian animate accusative: the genitive form realizes the accusative of
+    animates — an animacy-cutoff marking pattern. Not part of
+    [aissen-2003]'s sample; instantiated here for the lattice check. -/
+def russianDOM : MarkingPattern := .animacyAtLeast .animate
+
 /-- Russian (animate accusative) marks exactly the lattice-predicted
     cells. -/
 theorem russian_dom_matches_lattice :
-    ∀ a, russianDOM.marks a .definite = true ↔
+    ∀ a, russianDOM a .definite = true ↔
       DomPredictedByLattice a .quPersBeginning := by decide
 
-/-- Spanish (human `a`) is a proper subset of the lattice prediction: it
-    under-marks the predicted animate cell. -/
+/-- Spanish *a* on definite objects is a proper subset of the lattice
+    prediction: it under-marks the predicted animate cell. -/
 theorem spanish_dom_within_lattice :
-    (∀ a, spanishDOM.marks a .definite = true →
+    (∀ a, spanishDOM a .definite = true →
       DomPredictedByLattice a .quPersBeginning) ∧
-    spanishDOM.marks .animate .definite = false ∧
+    spanishDOM .animate .definite = false ∧
     DomPredictedByLattice .animate .quPersBeginning := by decide
 
 /-- Hindi agrees on the animacy boundary: inanimate never marked,
     animate/human marked at some definiteness level. -/
 theorem hindi_dom_consistent_on_animacy :
-    (∀ d, hindiDOM.marks .inanimate d = false) ∧
-    (∃ d, hindiDOM.marks .animate d = true) ∧
-    (∃ d, hindiDOM.marks .human d = true) := by decide
+    (∀ d, hindiDOM .inanimate d = false) ∧
+    (∃ d, hindiDOM .animate d = true) ∧
+    (∃ d, hindiDOM .human d = true) := by decide
 
 /-! #### The lattice-derived profile against [aissen-2003]'s OT typology -/
 
 /-- The lattice's DOM prediction at a fixed persistence level, as a
-    [just-2024]-style differential marking profile. -/
-def latticeDOM (p : PersistenceLevel) : DOMProfile :=
-  { name := "Lattice-derived"
-    role := .P
-    channel := .flagging
-    marks := λ a _ => decide (DomPredictedByLattice a p) }
+    differential marking pattern. -/
+def latticeDOM (p : PersistenceLevel) : MarkingPattern :=
+  λ a _ => decide (DomPredictedByLattice a p)
 
-/-- Lattice-derived profiles satisfy [aissen-2003]'s monotonicity
-    universal, structurally via `isMonotoneP_of`. -/
-theorem latticeDOM_isMonotone (p : PersistenceLevel) :
-    (latticeDOM p).isMonotone = true :=
-  (latticeDOM p).isMonotoneP_of fun ha _ hm =>
+/-- Lattice-derived patterns satisfy [aissen-2003]'s monotonicity universal,
+    structurally via `domPredicted_monotone`. -/
+theorem latticeDOM_monotoneP (p : PersistenceLevel) : (latticeDOM p).MonotoneP :=
+  λ _ _ _ _ ha _ hm =>
     decide_eq_true (domPredicted_monotone p _ _ ha (of_decide_eq_true hm))
 
 /-- At `quPersBeginning` the lattice-derived profile coincides with
-    [aissen-2003]'s OT Type 2 (Hu + An; `Aissen2003.anim_type_hu_an`) —
-    two frameworks, independent premises, same prediction. -/
+    [aissen-2003]'s animate-cutoff interpolation type (Dhargari's, Figure 3;
+    `Aissen2003.figure3_languages`) — two frameworks, independent premises,
+    same prediction. -/
 theorem latticeDOM_matches_aissen_type2 :
-    ∀ a d, (latticeDOM .quPersBeginning).marks a d =
-      (animCandToDOM ⟨true, true, false⟩).marks a d := by decide
+    ∀ a d, latticeDOM .quPersBeginning a d = dhargariDOM a d := by decide
 
 /-! #### Limitation: total-persistence objects
 
@@ -504,10 +506,43 @@ theorem kiss_flat_count_from_lattice :
 
 /-! ### Grimm vs dependent case
 
-`Studies/Aissen2003.lean` Part II assigns abstract ACC to every transitive
-object, with DOM a realization filter; Grimm assigns the case *category* by
-lattice position. On Grimm's line Spanish *a* is dative, not flagged ACC —
-the fault line between structural and semantic case. -/
+The dependent-case algorithm ([marantz-1991], `Syntax/Case/Dependent.lean`)
+assigns abstract ACC to every transitive object — case assignment is
+prominence-blind, with DOM a realization filter over it ([aissen-2003]).
+Grimm instead assigns the case *category* by lattice position: on his line
+Spanish *a* is dative, not flagged ACC — the fault line between structural
+and semantic case. The pipeline below runs the dependent-case algorithm on a
+prominence-annotated clause to make the divergence explicit. -/
+
+open Syntax.Case
+
+/-- An NP annotated with referential prominence. Dependent case ignores the
+    annotation; the lattice reads it. -/
+structure ProminentNP where
+  label : String
+  lexicalCase : Option Case
+  animacy : AnimacyLevel
+  definiteness : DefinitenessLevel
+  deriving DecidableEq, Repr
+
+/-- The NP as the dependent-case algorithm sees it. -/
+def ProminentNP.toNP (pnp : ProminentNP) : NPInDomain := ⟨pnp.label, pnp.lexicalCase⟩
+
+/-- A transitive clause: subject c-commands object. -/
+structure TransClause where
+  subject : ProminentNP
+  object : ProminentNP
+  deriving DecidableEq, Repr
+
+/-- Abstract case assigned to the object by the dependent-case algorithm. -/
+def objectCase (lang : CaseLanguageType) (tc : TransClause) : Option Case :=
+  getCaseOf tc.object.label (assignCases lang [tc.subject.toNP, tc.object.toNP])
+
+/-- A transitive clause with a fixed human-pronoun subject and a
+    variable-prominence object, both without lexical case. -/
+def mkTrans (a : AnimacyLevel) (d : DefinitenessLevel) : TransClause :=
+  { subject := ⟨"subj", none, .human, .personalPronoun⟩
+    object := ⟨"obj", none, a, d⟩ }
 
 /-- Animate definite object of a canonical transitive: dependent case says
     ACC, the lattice says DAT — different categories, not different

--- a/Linglib/Studies/Haspelmath2021.lean
+++ b/Linglib/Studies/Haspelmath2021.lean
@@ -277,21 +277,21 @@ theorem universal3_single_argument_flagging (r : ArgumentRole) :
     > flagging depending on some prominence scale, then the special
     > flag is used on the prominent P-argument.
 
-    Re-exported from [aissen-2003]'s OT factorial typology, which
+    Re-exported from [aissen-2003]'s OT interpolation typology, which
     *predicts* this universal: the typology generates only monotone DOM
     patterns. -/
 
-/-- [aissen-2003]'s OT factorial typology *predicts* Universal 4:
-    every animacy DOM pattern in `animOptima` is monotone (the prominent
-    end gets the marker first). Renamed from `universal4_split_P_flagging`
-    to clarify that this is a *model prediction* of U4, not the universal
-    itself: a model-internal lemma can support a typological universal
-    without being identical to it. -/
-theorem universal4_aissen_predicts : animOptima.all (λ opts =>
-    opts.checkAll (λ c =>
-      (if c.an then c.hu else true) &&
-      (if c.inan then c.an else true))) = true :=
-  animacy_all_monotone
+/-- [aissen-2003]'s OT typology *predicts* Universal 4: every grammar in
+    the animacy interpolation typology marks an upward-closed segment of
+    the scale, so the prominent end gets the marker first
+    (`Aissen2003.no_reversed_system`). This is a *model prediction* of U4,
+    not the universal itself: a model-internal lemma can support a
+    typological universal without being identical to it. -/
+theorem universal4_aissen_predicts :
+    ∀ k < 4, ∀ a a' : AnimacyLevel, a ≤ a' →
+      markedWins (interpolation AnimacyLevel.all k) a = true →
+      markedWins (interpolation AnimacyLevel.all k) a' = true :=
+  no_reversed_system
 
 -- ============================================================================
 -- § 5: Universal 5 — Scenario Coding Universal

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -6,12 +6,12 @@ import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Hungarian.Predicates
 
 /-!
-# Differential Indexing
-[aissen-2003] [just-2024] [haspelmath-2019] [siewierska-2004] [preminger-2014] [haspelmath-2021]
+# Just 2024: Differential A and P Indexing
+[just-2024] [aissen-2003] [haspelmath-2019] [siewierska-2004] [preminger-2014] [haspelmath-2021]
 
-Formalizes the typological survey of Just, E. (2024), *A structural and
+Formalizes the typological survey of [just-2024], *A structural and
 functional comparison of differential A and P indexing* (Linguistics 62(2):
-295–321), and connects it to [aissen-2003]'s DOM profiles
+295–321), and connects it to [aissen-2003]'s DOM patterns
 (`Features/Prominence`), [preminger-2014]'s φ-geometry
 (`Syntax/Minimalist/Phi/`), and the Kaqchikel, Basque, Georgian, and
 Hungarian fragments.
@@ -27,7 +27,7 @@ readily regardless of role; A defaults prominent, P does not.
 ## Main declarations
 
 - `IndexingFragment`: per-language differential-indexing profile,
-  extending `DifferentialMarkingProfile` (channel `.indexing`)
+  carrying a `Features.Prominence.MarkingPattern` grid
 - `pIndexingLanguages`, `aIndexingLanguages`: Just (2024) Tables 1–2
 - `mirror_image_universal`: every language targets the role-appropriate
   end of each conditioning scale
@@ -39,7 +39,7 @@ readily regardless of role; A defaults prominent, P does not.
   `hungarian_conjugation_split`: fragment paradigms ground the survey rows
 -/
 
-namespace Aissen2003
+namespace Just2024
 
 open Features.Prominence
 
@@ -79,12 +79,9 @@ theorem indexing_person_rank_injective (a b : IndexingPersonLevel)
 -- § 2: Indexing Fragment
 -- ============================================================================
 
-/-- A differential indexing fragment for a single language.
-
-    Extends `DifferentialMarkingProfile` with language metadata and
-    per-dimension marking predicates. The 2D `marks` predicate is computed
-    from `animacyIndexed` and `definitenessIndexed` by the `mk'` constructor,
-    and the channel is always `.indexing`.
+/-- A differential indexing fragment for a single language: language
+    metadata, the indexed argument role, and per-dimension marking
+    predicates.
 
     For P indexing: `true` at a level means "P arguments at this level
     ARE indexed." The expectation (Just §4.2) is that P indexing targets
@@ -93,11 +90,15 @@ theorem indexing_person_rank_injective (a b : IndexingPersonLevel)
     For A indexing: `true` at a level means "A arguments at this level
     ARE indexed." The expectation is that A indexing targets the
     non-prominent end. -/
-structure IndexingFragment extends DifferentialMarkingProfile where
+structure IndexingFragment where
+  /-- Language name -/
+  name : String
   /-- ISO 639-3 code -/
   iso639 : String
   /-- Language family -/
   family : String
+  /-- Which argument role is differentially indexed -/
+  role : ArgumentRole
   /-- Which person levels trigger indexing -/
   personIndexed : IndexingPersonLevel → Bool
   /-- Which animacy levels trigger indexing -/
@@ -105,16 +106,18 @@ structure IndexingFragment extends DifferentialMarkingProfile where
   /-- Which definiteness levels trigger indexing -/
   definitenessIndexed : DefinitenessLevel → Bool
 
-/-- Smart constructor for `IndexingFragment`.
-    Computes the 2D `marks` predicate as the product of
-    `animacyIndexed` and `definitenessIndexed`, and sets `channel :=.indexing`. -/
+/-- Positional constructor for `IndexingFragment`. -/
 def IndexingFragment.mk' (name iso639 family : String) (role : ArgumentRole)
     (personIndexed : IndexingPersonLevel → Bool)
     (animacyIndexed : AnimacyLevel → Bool)
     (definitenessIndexed : DefinitenessLevel → Bool) : IndexingFragment :=
-  { name, iso639, family, role, channel := .indexing
-    marks := λ a d => animacyIndexed a && definitenessIndexed d
-    personIndexed, animacyIndexed, definitenessIndexed }
+  { name, iso639, family, role, personIndexed, animacyIndexed,
+    definitenessIndexed }
+
+/-- The fragment's animacy × definiteness marking grid: the product of
+    `animacyIndexed` and `definitenessIndexed`. -/
+def IndexingFragment.marks (f : IndexingFragment) : MarkingPattern :=
+  λ a d => f.animacyIndexed a && f.definitenessIndexed d
 
 -- ============================================================================
 -- § 3: Derived Conditioning Factors
@@ -502,29 +505,29 @@ theorem mirror_image_universal :
 -- ============================================================================
 
 /-! For languages where animacy and/or definiteness condition indexing,
-    we verify monotonicity of the inherited `DifferentialMarkingProfile`
-    on the 2D grid. The `marks` predicate is derived from the fragment's
+    monotonicity of the role-appropriate direction holds on the 2D grid:
+    upper set for the P-indexing languages, lower set for A-indexing
+    Eastern Mansi. The `marks` grid is derived from the fragment's
     `animacyIndexed` and `definitenessIndexed` — no separate stipulation. -/
 
-/-- All animacy/definiteness-conditioned profiles are monotone. -/
-theorem hungarian_monotone : hungarian.isMonotone = true := by native_decide
-theorem swahili_monotone : swahili.isMonotone = true := by native_decide
-theorem kagulu_monotone : kagulu.isMonotone = true := by native_decide
-theorem easternMansi_monotone : easternMansi.isMonotone = true := by native_decide
+/-- All animacy/definiteness-conditioned patterns are monotone. -/
+theorem hungarian_monotone : hungarian.marks.MonotoneP := by decide
+theorem swahili_monotone : swahili.marks.MonotoneP := by decide
+theorem kagulu_monotone : kagulu.marks.MonotoneP := by decide
+theorem easternMansi_monotone : easternMansi.marks.MonotoneA := by decide
 
 /-- Swahili P indexing depends only on animacy (definiteness is irrelevant). -/
-theorem swahili_animacy_only : swahili.isAnimacyOnly = true := by native_decide
+theorem swahili_animacy_only : swahili.marks.AnimacyOnly := by decide
 
 /-- Kagulu P indexing depends only on animacy. -/
-theorem kagulu_animacy_only : kagulu.isAnimacyOnly = true := by native_decide
+theorem kagulu_animacy_only : kagulu.marks.AnimacyOnly := by decide
 
 /-- Hungarian P indexing depends only on definiteness (animacy is irrelevant). -/
-theorem hungarian_definiteness_only : hungarian.isDefinitenessOnly = true := by
-  native_decide
+theorem hungarian_definiteness_only : hungarian.marks.DefinitenessOnly := by decide
 
 /-- Eastern Mansi A indexing depends only on definiteness. -/
-theorem easternMansi_definiteness_only : easternMansi.isDefinitenessOnly = true := by
-  native_decide
+theorem easternMansi_definiteness_only : easternMansi.marks.DefinitenessOnly := by
+  decide
 
 -- ============================================================================
 -- § 14: Family Clustering ([just-2024], §2.2, §3.1)
@@ -572,15 +575,13 @@ theorem complement_differs_by_role :
   exact ⟨by native_decide, by native_decide⟩
 
 -- ============================================================================
--- § 16: DOM ↔ DifferentialMarkingProfile Structural Isomorphism
+-- § 16: DOM ↔ Differential Indexing on One Grid
 -- ============================================================================
 
-/-! `DOMProfile` is an abbreviation for `DifferentialMarkingProfile`
-    (specialized to role P + channel flagging), and `IndexingFragment`
-    extends `DifferentialMarkingProfile` (with channel = `.indexing`).
-    Both DOM profiles and indexing fragments inherit all DMP infrastructure
-    (monotonicity, dimensionality, cutoff constructors, mirror image)
-    directly — no conversion or bridge theorems needed. -/
+/-! [aissen-2003]'s DOM grids and `IndexingFragment.marks` are both
+    `Features.Prominence.MarkingPattern`s, so flagging and indexing share
+    the monotonicity, dimensionality, and cutoff infrastructure directly —
+    no conversion or bridge theorems needed. -/
 
 open Minimalist
 open Kaqchikel
@@ -784,4 +785,4 @@ theorem hungarian_definiteness_conditioned :
 theorem hungarian_not_person_conditioned :
     hungarian.personConditioned = false := by native_decide
 
-end Aissen2003
+end Just2024


### PR DESCRIPTION
Deep cleanse of the Aissen 2003 study against the paper (PDF in Zotero, all locators verified), plus the substrate dissolution it exposed.

- The file formalized a mechanism the paper doesn't use — interleavings of two constraint families, which fn. 12 explicitly rejects — under fabricated locators ("Table 14/17"; the paper has Figures 1–9). Rebuilt on the actual analysis: \*STRUC_C interpolation into the iconicity subhierarchy, per-input tableaux (Tableaux 1–2), Figure 2/3 typologies matched language-by-language, (33b) as upper-set closure. All 45 native_decides gone; kernel decide throughout.
- Grids corrected per the paper: Turkish and Persian cut at specific, not definite; Hindi's animate row at proper names (Figure 7); Spanish split into CMC (§5.1) and Modern (§5.4) two-dimensional systems; Pitjantjatjara, Written Japanese, Ritharngu, Dhargari added; Russian (absent from the paper) demoted to its consumers; the dependent-case pipeline (not Aissen content) moved to Grimm2011, its sole consumer.
- `Features/Prominence`: the `DifferentialMarkingProfile` bundle dissolves into bare `MarkingPattern` grids with Prop-valued decidable checkers and the `monotoneP_iff_isUpperSet` transfer equation.
- `Studies/Aissen2003Agreement.lean` → `Studies/Just2024.lean`: the file formalizes Just 2024's indexing survey, not Aissen.