### PR TITLE
refactor(Features/Prominence): overhaul; rehome ArgumentRole to Syntax

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2772,6 +2772,7 @@ import Linglib.Syntax.Agreement.Profile
 import Linglib.Syntax.Agreement.Target
 import Linglib.Syntax.Anaphora.Basic
 import Linglib.Syntax.Anaphora.Diagnostic
+import Linglib.Syntax.ArgumentRole
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Binding.Semantics
 import Linglib.Syntax.Binding.SpecificityCondition

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -5,59 +5,41 @@ import Linglib.Core.Order.Markedness
 import Linglib.Features.Person.Basic
 
 /-!
-# Prominence Scales and Differential Argument Marking [just-2024] [haspelmath-2021]
-[aissen-2003] [haspelmath-2019]
+# Referential prominence
 
-Framework-agnostic prominence hierarchies for referential properties. These
-scales underlie both **differential flagging** (case marking: DOM, DSM) and
-**differential indexing** (verbal agreement), as argued by [just-2024] and
-building on [aissen-2003].
+The referential-prominence scales that condition differential argument
+marking, and the marking grids over them.
 
-## Scales
+## Main declarations
 
-Three independently motivated prominence hierarchies:
+- `AnimacyLevel`, `DefinitenessLevel` — the animacy and definiteness
+  scales, as `LinearOrder`s; `AnimacyRank` — the fine-grained
+  plural-marking hierarchy, with the coarsening
+  `AnimacyRank.toAnimacyLevel`.
+- `Person.prominence` — graded person prominence over the canonical
+  `Person` inventory.
+- `MarkingPattern` — which cells of the animacy × definiteness grid are
+  marked; the `MonotoneP`/`MonotoneA` staircases, cutoff constructors, and
+  `monotoneP_iff_isUpperSet`.
 
-- **Animacy**: Human > Animate > Inanimate
-- **Definiteness**: Personal Pronoun > Proper Name > Definite NP >
-  Indefinite Specific > Non-specific
-- **Person**: 1st > 2nd > 3rd
+Paper-specific apparatus lives with its papers: the scenario machinery and
+frequency proxies in `Studies/Haspelmath2021.lean`, the OT typology in
+`Studies/Aissen2003.lean`, the indexing survey in `Studies/Just2024.lean`.
 
-These are the same scales for all argument roles (A, P, R, T),
-but the **polarity** of differential marking depends on argument role:
+## References
 
-- P/T marking targets **prominent** referents (departures from low default)
-- A/R marking targets **non-prominent** referents (departures from high default)
-
-## Argument Roles ([haspelmath-2021], §2–5)
-
-Five roles span monotransitive and ditransitive clauses:
-
-- **S**: sole argument of intransitive (reference point for alignment)
-- **A**: agent-like argument of monotransitive
-- **P**: patient-like argument of monotransitive
-- **R**: recipient-like argument of ditransitive (higher role rank, like A)
-- **T**: theme-like argument of ditransitive (lower role rank, like P)
-
-## Marking Channels
-
-Differential argument marking has two independent realization channels:
-
-- **Flagging**: morphological case on the NP
-- **Indexing**: verbal agreement / cross-referencing
-
-These serve different functions — flagging disambiguates roles, indexing
-tracks referents through discourse — but both are governed by the same
-prominence scales.
-
+* [aissen-2003]
+* [corbett-2000]
+* [haspelmath-2021]
+* [just-2024]
+* [smith-stark-1974]
 -/
 
 namespace Features.Prominence
 
--- ============================================================================
--- § 1: Animacy Scale ([aissen-2003], §2)
--- ============================================================================
+/-! ### The animacy scale -/
 
-/-- Levels of the animacy prominence scale.
+/-- The animacy prominence scale, [aissen-2003]'s (4a):
     Human > Animate > Inanimate. -/
 inductive AnimacyLevel where
   /-- Most prominent: human referents -/
@@ -79,26 +61,20 @@ instance : LinearOrder AnimacyLevel :=
   LinearOrder.lift' AnimacyLevel.rank
     (fun a b h => by cases a <;> cases b <;> simp_all [AnimacyLevel.rank])
 
-/-- All animacy levels (exhaustive enumeration for finite verification). -/
+/-- All animacy levels, most prominent first. -/
 def AnimacyLevel.all : List AnimacyLevel := [.human, .animate, .inanimate]
 
-theorem AnimacyLevel.all_length : AnimacyLevel.all.length = 3 := by decide
+/-! ### The fine-grained animacy hierarchy -/
 
--- ============================================================================
--- § 1b: Fine-Grained Animacy Hierarchy ([corbett-2000], [smith-stark-1974])
--- ============================================================================
-
-/-- Fine-grained animacy hierarchy for nominal plural marking and agreement
-    ([smith-stark-1974], [corbett-2000]).
-
-    Languages mark plural on nouns according to an implicational scale:
+/-- The fine-grained animacy hierarchy conditioning nominal plural marking
+    ([smith-stark-1974], as presented by [corbett-2000]):
 
       speaker > addressee > 3rd person > kin > human > higher animals >
       lower animals > discrete inanimates > nondiscrete inanimates
 
-    If a language marks plural at a given point on the scale, it marks
-    plural at all higher points. This refines the coarser `AnimacyLevel`
-    (human/animate/inanimate) used for differential argument marking. -/
+    A language marking plural at a point on the scale marks it at all
+    higher points. Refines the coarser `AnimacyLevel` via
+    `toAnimacyLevel`. -/
 inductive AnimacyRank where
   | speaker
   | addressee
@@ -109,9 +85,9 @@ inductive AnimacyRank where
   | lowerAnimal
   | discreteInanimate
   | nondiscreteInanimate
-  deriving DecidableEq, Repr
+  deriving DecidableEq, Repr, Inhabited, Fintype
 
-/-- Numeric rank for comparison (higher = more likely to be plural-marked). -/
+/-- Numeric rank (higher = more likely to be plural-marked). -/
 def AnimacyRank.toNat : AnimacyRank → Nat
   | .speaker => 8
   | .addressee => 7
@@ -123,48 +99,34 @@ def AnimacyRank.toNat : AnimacyRank → Nat
   | .discreteInanimate => 1
   | .nondiscreteInanimate => 0
 
-/-- Coarsen the 9-level animacy hierarchy to the 3-level scale used for
-    differential argument marking. The mapping:
-    - speaker/addressee/thirdPerson/kin/human → `.human`
-    - higherAnimal/lowerAnimal → `.animate`
-    - discreteInanimate/nondiscreteInanimate → `.inanimate` -/
+/-- Nondiscrete inanimate < ... < speaker (ordered by rank). -/
+instance : LinearOrder AnimacyRank :=
+  LinearOrder.lift' AnimacyRank.toNat
+    (fun a b h => by cases a <;> cases b <;> simp_all [AnimacyRank.toNat])
+
+/-- All fine-grained ranks, most prominent first. -/
+def AnimacyRank.all : List AnimacyRank :=
+  [.speaker, .addressee, .thirdPerson, .kin, .human, .higherAnimal,
+   .lowerAnimal, .discreteInanimate, .nondiscreteInanimate]
+
+/-- Coarsen the fine-grained hierarchy to the three-level scale:
+    speaker through human → `.human`, the animal ranks → `.animate`,
+    the inanimate ranks → `.inanimate`. -/
 def AnimacyRank.toAnimacyLevel : AnimacyRank → AnimacyLevel
   | .speaker | .addressee | .thirdPerson | .kin | .human => .human
   | .higherAnimal | .lowerAnimal => .animate
   | .discreteInanimate | .nondiscreteInanimate => .inanimate
 
-/-- Coarsening is monotone: higher rank implies ≥ level. -/
-theorem AnimacyRank.toAnimacyLevel_monotone (r₁ r₂ : AnimacyRank)
-    (h : r₁.toNat ≥ r₂.toNat) : r₁.toAnimacyLevel.rank ≥ r₂.toAnimacyLevel.rank := by
-  cases r₁ <;> cases r₂ <;> simp only [toNat, toAnimacyLevel, AnimacyLevel.rank] at * <;> omega
+/-- Coarsening preserves the scale order. -/
+theorem AnimacyRank.toAnimacyLevel_monotone : Monotone AnimacyRank.toAnimacyLevel :=
+  fun a b h =>
+    (by decide : ∀ a b : AnimacyRank, a ≤ b → a.toAnimacyLevel ≤ b.toAnimacyLevel) a b h
 
-/-- The hierarchy is consistent: speaker outranks addressee outranks
-    third person, and so forth down the scale. -/
-theorem AnimacyRank.hierarchy_ordering :
-    AnimacyRank.speaker.toNat > AnimacyRank.addressee.toNat ∧
-    AnimacyRank.addressee.toNat > AnimacyRank.thirdPerson.toNat ∧
-    AnimacyRank.thirdPerson.toNat > AnimacyRank.kin.toNat ∧
-    AnimacyRank.kin.toNat > AnimacyRank.human.toNat ∧
-    AnimacyRank.human.toNat > AnimacyRank.higherAnimal.toNat ∧
-    AnimacyRank.higherAnimal.toNat > AnimacyRank.lowerAnimal.toNat ∧
-    AnimacyRank.lowerAnimal.toNat > AnimacyRank.discreteInanimate.toNat ∧
-    AnimacyRank.discreteInanimate.toNat > AnimacyRank.nondiscreteInanimate.toNat := by
-  decide
+/-! ### The definiteness scale -/
 
-/-- The hierarchy predicts: if a language marks plural at rank r, it marks
-    plural at all ranks above r. -/
-def AnimacyRank.respectsHierarchy (markedRanks : List AnimacyRank) : Bool :=
-  markedRanks.all fun r =>
-    markedRanks.all fun r' =>
-      r'.toNat >= r.toNat || markedRanks.contains r' == false
-
--- ============================================================================
--- § 2: Definiteness Scale ([aissen-2003], §2)
--- ============================================================================
-
-/-- Levels of the definiteness prominence scale.
-    Personal Pronoun > Proper Name > Definite NP > Indefinite Specific NP >
-    Non-specific NP. -/
+/-- The definiteness prominence scale, [aissen-2003]'s (4b):
+    Personal Pronoun > Proper Name > Definite NP > Indefinite Specific >
+    Non-specific. -/
 inductive DefinitenessLevel where
   /-- Most prominent: personal pronouns -/
   | personalPronoun
@@ -193,171 +155,25 @@ instance : LinearOrder DefinitenessLevel :=
   LinearOrder.lift' DefinitenessLevel.rank
     (fun a b h => by cases a <;> cases b <;> simp_all [DefinitenessLevel.rank])
 
-/-- All definiteness levels (exhaustive enumeration). -/
+/-- All definiteness levels, most prominent first. -/
 def DefinitenessLevel.all : List DefinitenessLevel :=
   [.personalPronoun, .properName, .definite, .indefiniteSpecific, .nonSpecific]
 
-theorem DefinitenessLevel.all_length : DefinitenessLevel.all.length = 5 := by
-  decide
+/-! ### Person prominence -/
 
--- ============================================================================
--- § 3: Scale Ordering Verification
--- ============================================================================
-
-/-- Distinct animacy levels have distinct ranks — the rank function is injective. -/
-theorem animacy_rank_injective (a b : AnimacyLevel) (h : a.rank = b.rank) : a = b := by
-  cases a <;> cases b <;> simp_all [AnimacyLevel.rank]
-
-/-- Animacy ranks are bounded: 0 ≤ rank ≤ 2. -/
-theorem animacy_rank_bounded (a : AnimacyLevel) : a.rank ≤ 2 := by
-  cases a <;> simp [AnimacyLevel.rank]
-
-/-- Distinct definiteness levels have distinct ranks — the rank function is injective. -/
-theorem definiteness_rank_injective (a b : DefinitenessLevel) (h : a.rank = b.rank) : a = b := by
-  cases a <;> cases b <;> simp_all [DefinitenessLevel.rank]
-
-/-- Definiteness ranks are bounded: 0 ≤ rank ≤ 4. -/
-theorem definiteness_rank_bounded (d : DefinitenessLevel) : d.rank ≤ 4 := by
-  cases d <;> simp [DefinitenessLevel.rank]
-
--- ============================================================================
--- § 4: Person Scale ([haspelmath-2021], §6)
--- ============================================================================
-
-/-- Numeric rank on the person prominence scale: 1st (2) > 2nd (1) >
-    3rd (0) ([haspelmath-2021] §6). Stated over the canonical `Person`
-    inventory (the dissolved `Person`'s role): clusivity-marked
-    firsts rank with `first`; the impersonal `zero` is `[−participant]`
-    and is placed with third person (a linglib convention — the scale's
-    source does not discuss impersonals). -/
+/-- Graded person prominence over the canonical `Person` inventory:
+    1st (2) > 2nd (1) > 3rd (0). The load-bearing cut is locuphoric
+    (1st/2nd) > aliophoric (3rd) — [haspelmath-2021]'s person scale (8a);
+    the ranking of 1st over 2nd within the locuphoric zone follows the
+    person-hierarchy tradition and varies across languages.
+    Clusivity-marked firsts rank with `first`; the impersonal `zero` is
+    `[−participant]` and ranks with third. -/
 def _root_.Person.prominence : Person → Nat
   | .first | .firstInclusive | .firstExclusive => 2
   | .second => 1
   | .third | .zero => 0
 
-/-- The three-way prominence scale carrier: the tripartition values. -/
-abbrev personScaleLevels : List Person := Person.System.tripartition.values
-
-/-- Prominence separates the tripartition: on `first`/`second`/`third`
-    the rank function is injective. -/
-theorem person_prominence_injective :
-    ∀ a ∈ personScaleLevels, ∀ b ∈ personScaleLevels,
-      a.prominence = b.prominence → a = b := by decide
-
-/-- Person prominence ranks are bounded: 0 ≤ rank ≤ 2. -/
-theorem person_prominence_bounded (p : Person) : p.prominence ≤ 2 := by
-  cases p <;> simp [Person.prominence]
-
-/-- Prominence tracks SAP-hood: rank ≥ 1 iff speech-act participant. -/
-theorem prominence_pos_iff_sap (p : Person) :
-    1 ≤ p.prominence ↔ p.IsSAP := by
-  cases p <;> simp [Person.prominence, Person.IsSAP]
-
--- ============================================================================
--- § 5: Argument Role and Marking Channel ([haspelmath-2021], §2–5)
--- ============================================================================
-
-/-- Argument roles spanning monotransitive and ditransitive clauses.
-
-    Follows [comrie-1978] and [haspelmath-2021] in using S/A/P/R/T
-    (not subject/object) to avoid theory-dependent constituency assumptions.
-
-    Role rank determines the direction of differential marking:
-    - Higher-rank roles (A, R) default to high prominence; differential
-      marking targets the NON-prominent end (anti-monotone / lower set).
-    - Lower-rank roles (P, T) default to low prominence; differential
-      marking targets the PROMINENT end (monotone / upper set).
-    - S is the alignment reference point. -/
-inductive ArgumentRole where
-  /-- S: sole argument of an intransitive verb -/
-  | S
-  /-- A: the more agent-like argument of a transitive verb -/
-  | A
-  /-- P: the more patient-like argument of a transitive verb -/
-  | P
-  /-- R: the recipient-like argument of a ditransitive verb -/
-  | R
-  /-- T: the theme-like argument of a ditransitive verb -/
-  | T
-  deriving DecidableEq, Repr
-
-/-- The monotransitive core roles: A, P, and S (omits the ditransitive
-    scaffolding roles R/T). The domain over which alignment partitions
-    and per-language case/agreement coverage theorems quantify. -/
-def ArgumentRole.core : List ArgumentRole := [.A, .P, .S]
-
-/-- Role rank: A > P for monotransitives,
-    R > T for ditransitives. S is in between. Higher rank = higher
-    default prominence expectation. -/
-def ArgumentRole.roleRank : ArgumentRole → Nat
-  | .A => 4
-  | .R => 3
-  | .S => 2
-  | .T => 1
-  | .P => 0
-
-/-- Whether this role has high default prominence (A-like). Differential
-    marking for high-default roles targets non-prominent referents. -/
-def ArgumentRole.highDefault : ArgumentRole → Bool
-  | .A => true
-  | .R => true
-  | _  => false
-
-/-- Whether this role has low default prominence (P-like). Differential
-    marking for low-default roles targets prominent referents. -/
-def ArgumentRole.lowDefault : ArgumentRole → Bool
-  | .P => true
-  | .T => true
-  | _  => false
-
-/-- Two independent channels for marking argument properties on verbs or NPs
-    ([haspelmath-2019], [just-2024] §2).
-
-    - **Flagging**: morphological case on the NP (e.g., accusative suffix)
-    - **Indexing**: verbal agreement / cross-referencing (e.g., Set A/B markers)
-
-    These serve distinct functions: flagging disambiguates roles, indexing
-    tracks referents. Both are governed by the same prominence scales but
-    the two dimensions are logically independent. -/
-inductive MarkingChannel where
-  /-- Case morphology on the NP -/
-  | flagging
-  /-- Verbal agreement / cross-referencing -/
-  | indexing
-  deriving DecidableEq, Repr
-
--- ============================================================================
--- § 6: Default Prominence ([just-2024], §3; [haspelmath-2021], §7)
--- ============================================================================
-
-/-- Combined prominence rank for a cell in the animacy × definiteness grid.
-    Sum of the two individual ranks, giving a scalar from 0 (inanimate,
-    nonspecific) to 6 (human, personal pronoun). -/
-def prominenceRank (a : AnimacyLevel) (d : DefinitenessLevel) : Nat :=
-  a.rank + d.rank
-
-/-- Default prominence expectation per argument role.
-
-    High-default roles (A, R) are typically human, definite, topical.
-    Low-default roles (P, T) are typically inanimate, indefinite.
-    S is the reference point — no strong default.
-
-    Differential marking targets departures from these defaults:
-    - P/T marking targets *prominent* referents (high prominence, unexpected)
-    - A/R marking targets *non-prominent* referents (low prominence, unexpected)
-
-    Returns `true` when the cell represents the "expected" (unmarked) zone. -/
-def isDefaultZone (role : ArgumentRole) (a : AnimacyLevel) (d : DefinitenessLevel) : Bool :=
-  match role with
-  | .A => prominenceRank a d ≥ 3  -- A args expected to be prominent
-  | .R => prominenceRank a d ≥ 3  -- R args expected to be prominent (like A)
-  | .S => true                    -- S is the reference point, always "default"
-  | .P => prominenceRank a d ≤ 2  -- P args expected to be non-prominent
-  | .T => prominenceRank a d ≤ 2  -- T args expected to be non-prominent (like P)
-
--- ============================================================================
--- § 7: Differential marking patterns
--- ============================================================================
+/-! ### Differential marking patterns -/
 
 /-- A differential-marking pattern: which cells in the animacy × definiteness
     grid receive overt differential marking, for whatever argument role and
@@ -402,9 +218,7 @@ theorem monotoneP_iff_isUpperSet (p : MarkingPattern) :
   ⟨λ h _ _ hle hm => h _ _ _ _ hle.1 hle.2 hm,
     λ h _ _ _ _ ha hd hm => h (Prod.mk_le_mk.mpr ⟨ha, hd⟩) hm⟩
 
--- ============================================================================
--- § 8: One-dimensional cutoff patterns
--- ============================================================================
+/-! ### One-dimensional cutoff patterns -/
 
 /-- Mark the cells at or above an animacy cutoff — P/T-type marking; the
     marked zone is `Core.Order.atOrAbove` on the animacy axis. -/
@@ -424,139 +238,6 @@ def animacyAtMost (cutoff : AnimacyLevel) : MarkingPattern :=
 def definitenessAtMost (cutoff : DefinitenessLevel) : MarkingPattern :=
   λ _ d => decide (d ≤ cutoff)
 
-/-- [just-2024]'s mirror image: the P-type and A-type cutoffs at the same
-    level jointly cover the grid — every cell is marked by at least one,
-    both exactly at the cutoff row. -/
-theorem animacy_mirror_image (cutoff a : AnimacyLevel) (d : DefinitenessLevel) :
-    (animacyAtLeast cutoff a d || animacyAtMost cutoff a d) = true := by
-  simpa [animacyAtLeast, animacyAtMost] using le_total cutoff a
-
 end MarkingPattern
-
--- ============================================================================
--- § 11: Scenarios ([haspelmath-2021], §6)
--- ============================================================================
-
-/-- A monotransitive scenario: the person combination of A and P.
-
-    Scenario splits arise when argument coding depends not on a single
-    argument's prominence but on the *combination* of A-person and P-person.
-    E.g., 1→3 ("I see him") vs. 3→1 ("He sees me") may get different
-    flagging or indexing. -/
-structure Scenario where
-  /-- Person of the A argument -/
-  aPerson : Person
-  /-- Person of the P argument -/
-  pPerson : Person
-  deriving DecidableEq, Repr
-
-/-- Whether a scenario is "downstream": A has higher
-    person rank than P. This is the "usual" direction — the role-reference
-    association predicts high-rank roles (A) to have high-prominence referents.
-    Downstream scenarios tend to get the shortest coding. -/
-def Scenario.isDownstream (s : Scenario) : Bool :=
-  s.aPerson.prominence > s.pPerson.prominence
-
-/-- Whether a scenario is "upstream": P has higher
-    person rank than A. This is the "unusual" direction — against the
-    role-reference association. Upstream scenarios tend to get the longest
-    coding. -/
-def Scenario.isUpstream (s : Scenario) : Bool :=
-  s.aPerson.prominence < s.pPerson.prominence
-
-/-- Whether a scenario is "balanced": A and P have the same person rank
-    (e.g., 3→3). Intermediate coding predicted. -/
-def Scenario.isBalanced (s : Scenario) : Bool :=
-  s.aPerson.prominence == s.pPerson.prominence
-
-/-- Whether a scenario is "local": both arguments are SAP (1st or 2nd).
-    Local scenarios (1↔2) are frequent and tend to get short coding. -/
-def Scenario.isLocal (s : Scenario) : Bool :=
-  decide s.aPerson.IsSAP && decide s.pPerson.IsSAP
-
-/-- Whether a scenario is "direct": SAP acts on 3rd person.
-    A subtype of downstream scenarios. -/
-def Scenario.isDirect (s : Scenario) : Bool :=
-  decide s.aPerson.IsSAP && !decide s.pPerson.IsSAP
-
-/-- Whether a scenario is "inverse": 3rd person acts on SAP.
-    A subtype of upstream scenarios. -/
-def Scenario.isInverse (s : Scenario) : Bool :=
-  !decide s.aPerson.IsSAP && decide s.pPerson.IsSAP
-
-/-- Whether a scenario is "non-local": 3rd person acts on 3rd person.
-    A subtype of balanced scenarios. -/
-def Scenario.isNonlocal (s : Scenario) : Bool :=
-  !decide s.aPerson.IsSAP && !decide s.pPerson.IsSAP
-
-/-- All 9 person-pair scenarios. Explicit literal so `decide` reduces;
-    the equivalent map over `personScaleLevels` pairs
-    typechecks but defeats kernel-level `decide` over `Scenario.all.all (...)`. -/
-def Scenario.all : List Scenario :=
-  [⟨.first, .first⟩,  ⟨.first, .second⟩,  ⟨.first, .third⟩,
-   ⟨.second, .first⟩, ⟨.second, .second⟩, ⟨.second, .third⟩,
-   ⟨.third, .first⟩,  ⟨.third, .second⟩,  ⟨.third, .third⟩]
-
-theorem Scenario.all_length : Scenario.all.length = 9 := rfl
-
--- ============================================================================
--- § 12: Role-Reference Association ([haspelmath-2021], §2)
--- ============================================================================
-
-/-- The direction of differential marking: for a given role, does
-    differential coding target the prominent end (upper set) or the
-    non-prominent end (lower set)?
-
-    Returns `true` when differential marking targets the prominent end.
-    P and T → true (mark prominent referents); A and R → false (mark
-    non-prominent referents); S → false.
-
-    Definitionally `r.lowDefault` — the two functions agree pointwise
-    over all five argument roles. The aliasing makes U3, U7, U8 in
-    `Studies/Haspelmath2021.lean` `rfl` against the
-    substrate, rather than re-proving the equality in the study file. -/
-def differentialTargetsProminent (r : ArgumentRole) : Bool := r.lowDefault
-
-/-- R behaves like A: both have high default prominence and differential
-    marking targets the non-prominent end. -/
-theorem R_like_A_default : ArgumentRole.R.highDefault = ArgumentRole.A.highDefault := rfl
-
-/-- T behaves like P: both have low default prominence and differential
-    marking targets the prominent end. -/
-theorem T_like_P_default : ArgumentRole.T.lowDefault = ArgumentRole.P.lowDefault := rfl
-
-/-- Role rank ordering: A > R > S > T > P. -/
-theorem role_rank_ordering :
-    ArgumentRole.A.roleRank > ArgumentRole.R.roleRank ∧
-    ArgumentRole.R.roleRank > ArgumentRole.S.roleRank ∧
-    ArgumentRole.S.roleRank > ArgumentRole.T.roleRank ∧
-    ArgumentRole.T.roleRank > ArgumentRole.P.roleRank := by decide
-
--- ============================================================================
--- § 13: Scenario Frequency Class ([haspelmath-2021], §8)
--- ============================================================================
-
-/-- Frequency class for scenarios: downstream (usual) most frequent.
-    Downstream = 2, balanced = 1, upstream = 0. -/
-def Scenario.frequencyClass (s : Scenario) : Nat :=
-  if s.isDownstream then 2 else if s.isBalanced then 1 else 0
-
-/-- Gradient upstream degree: how far P's rank exceeds A's.
-    Uses Nat saturating subtraction (negative → 0). -/
-def Scenario.upstreamDegree (s : Scenario) : Nat :=
-  s.pPerson.prominence - s.aPerson.prominence
-
-theorem downstream_frequency_class :
-    (⟨.first, .third⟩ : Scenario).frequencyClass = 2 := rfl
-
-theorem upstream_frequency_class :
-    (⟨.third, .first⟩ : Scenario).frequencyClass = 0 := rfl
-
-/-- Frequency class is monotone: downstream > balanced > upstream. -/
-theorem frequency_class_monotone :
-    (⟨.first, .third⟩ : Scenario).frequencyClass >
-    (⟨.third, .third⟩ : Scenario).frequencyClass ∧
-    (⟨.third, .third⟩ : Scenario).frequencyClass >
-    (⟨.third, .first⟩ : Scenario).frequencyClass := by decide
 
 end Features.Prominence

--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -3,6 +3,7 @@ import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Chol Agreement and Case Fragment
@@ -112,8 +113,8 @@ open Mayan (ExponentTable)
 /-! ### Argument positions -/
 
 /-- Argument positions in a Chol clause, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Perfective (ergative) case assignment: `Mayan.ergCaseChol`
     (A → ERG, S/P → ABS). -/

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Kaqchikel Agreement Fragment
@@ -51,7 +52,6 @@ namespace Kaqchikel
 
 open Mayan (ExponentTable)
 open Agreement
-open Features.Prominence (ArgumentRole)
 
 /-! ### ABS position (HIGH-ABS) -/
 
@@ -89,8 +89,8 @@ def setBExponent : ExponentTable :=
 /-! ### Argument positions -/
 
 /-- Argument positions, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Perfective (ergative) case assignment: `Mayan.ergCaseKaqchikel`
     (A → ERG, S/P → ABS). -/

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -5,6 +5,7 @@ import Linglib.Features.Number.Capabilities
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Extraction
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # K'iche' Agreement Fragment
@@ -159,10 +160,10 @@ instance (φ : PhiFeatures) : Decidable (SetAIsPrefix φ) :=
 /-! ### Argument positions and alignment -/
 
 /-- Argument positions in a K'iche' clause. Aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) so cross-Mayan and
+    `ArgumentRole` (S/A/P/R/T) so cross-Mayan and
     cross-framework code shares one inventory. Use the canonical
     constructor names `.A` / `.P` / `.S` directly. -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+abbrev ArgPosition := ArgumentRole
 
 /-- Which agreement set cross-references each argument position? -/
 inductive AgreementSet where

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -5,6 +5,7 @@ import Linglib.Fragments.Mayan.Mam.Pronouns
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Extraction
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Mam Agreement Fragment
@@ -69,7 +70,6 @@ namespace Mam
 
 open Mayan (MarkerLinearity ExponentTable)
 open Agreement
-open Features.Prominence (ArgumentRole)
 
 /-! ### Agreement marker paradigms -/
 
@@ -111,8 +111,8 @@ def defaultSetB : List Morphology.Morph := [.procl "tz'"]
 /-! ### Argument positions and agreement status -/
 
 /-- Argument positions, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T) ([scott-2023] ch. 3). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T) ([scott-2023] ch. 3). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Tripartite case assignment: `Mayan.ergCaseMam` (A → ERG inherent
     from Voice, P → ACC structural from Voice, S → ABS structural from

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -7,6 +7,7 @@ import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Morph
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Morphotactics.Template
+import Linglib.Syntax.ArgumentRole
 
 open Morphology (Word)
 
@@ -160,7 +161,7 @@ choice — a descriptive-grammar implementation would return `.nom`.
     (accusative-like) in all non-perfective aspects. Used by Chol;
     presumably also Chontal, Ch'orti', Cholti per the Cholan-branch
     generalization ([aissen-england-zavala-2017]). -/
-def caseChol : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseChol : UD.Aspect → ArgumentRole → Case
   | .Perf, r => Alignment.ergative.assignCase r
   | .Imp, r | .Prog, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.extendedErgative.assignCase r
@@ -173,30 +174,30 @@ def caseChol : UD.Aspect → Features.Prominence.ArgumentRole → Case
     aspects (e.g. `.Imp` with the `chi-` marker) keep canonical ergative.
     Contrast Cholan, where the IMP `mi-` marker does trigger the accusative
     split. -/
-def caseQanjobalan : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseQanjobalan : UD.Aspect → ArgumentRole → Case
   | .Prog, r => Alignment.extendedErgative.assignCase r
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.ergative.assignCase r
 
 /-- Perfective projection of `caseChol`. Equals
     `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseChol : Features.Prominence.ArgumentRole → Case := caseChol .Perf
+abbrev ergCaseChol : ArgumentRole → Case := caseChol .Perf
 
 /-- Non-perfective (imperfective-and-up) projection of `caseChol`. Equals
     `Alignment.extendedErgative.assignCase` by definition. Reflects
     Chol's pattern of split in all non-perfective aspects. -/
-abbrev accCaseChol : Features.Prominence.ArgumentRole → Case := caseChol .Imp
+abbrev accCaseChol : ArgumentRole → Case := caseChol .Imp
 
 /-- Perfective projection of `caseQanjobalan`. Equals
     `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseQanjobalan : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseQanjobalan : ArgumentRole → Case :=
   caseQanjobalan .Perf
 
 /-- Progressive projection of `caseQanjobalan`. Equals
     `Alignment.extendedErgative.assignCase` by definition. Reflects
     Q'anjob'al's `lanan`-construction trigger; other non-perfective
     aspects in Q'anjob'al keep canonical ergative. -/
-abbrev accCaseQanjobalan : Features.Prominence.ArgumentRole → Case :=
+abbrev accCaseQanjobalan : ArgumentRole → Case :=
   caseQanjobalan .Prog
 
 /-- Kaqchikel (K'ichean-Mamean = Eastern Mayan) aspect-driven case
@@ -216,7 +217,7 @@ abbrev accCaseQanjobalan : Features.Prominence.ArgumentRole → Case :=
     (p. 141), some varieties/consultants reject patterns in
     [garcia-matzar-rodriguez-guajan-1997]; the claim rests on Imanishi's
     fieldwork on a specific variety. -/
-def caseKaqchikel : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseKaqchikel : UD.Aspect → ArgumentRole → Case
   | .Prog, r => Alignment.invertedErgative.assignCase r
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.ergative.assignCase r
@@ -224,7 +225,7 @@ def caseKaqchikel : UD.Aspect → Features.Prominence.ArgumentRole → Case
 /-- Perfective projection of `caseKaqchikel`. Equals
     `Alignment.ergative.assignCase` by definition. Kaqchikel perfective
     is canonical ergative (A → ERG, S/P → ABS). -/
-abbrev ergCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseKaqchikel : ArgumentRole → Case :=
   caseKaqchikel .Perf
 
 /-- Progressive projection of `caseKaqchikel`. Equals
@@ -232,7 +233,7 @@ abbrev ergCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
     construction-specific inverted pattern (S/A → ABS, P → ERG/GEN)
     documented by Imanishi 2014/2020 for Kaqchikel `ajin`-progressive
     sentences. -/
-abbrev accCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
+abbrev accCaseKaqchikel : ArgumentRole → Case :=
   caseKaqchikel .Prog
 
 /-- K'iche' (K'ichean) case assignment. Per [mondloch-2017] (Lessons 9,
@@ -244,12 +245,12 @@ abbrev accCaseKaqchikel : Features.Prominence.ArgumentRole → Case :=
     documents no analogous K'iche' split. The aspect parameter is retained
     for shape-uniformity with the other Mayan `case*` functions; all aspects
     map to canonical ergative. -/
-def caseKiche : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseKiche : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.ergative.assignCase r
 
 /-- K'iche' ergative-absolutive case (uniform across aspects). Equals
     `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseKiche : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseKiche : ArgumentRole → Case :=
   caseKiche .Perf
 
 /-- San Juan Atitán Mam (K'ichean-Mamean / Eastern Mayan) case assignment.
@@ -265,12 +266,12 @@ abbrev ergCaseKiche : Features.Prominence.ArgumentRole → Case :=
     encodes Scott's SJA Mam analysis. Mam shows no aspect-conditioned split
     (Scott ch. 3), so the aspect parameter is retained only for
     shape-uniformity; all aspects map to tripartite. -/
-def caseMam : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseMam : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.tripartite.assignCase r
 
 /-- SJA Mam tripartite case (uniform across aspects). Equals
     `Alignment.tripartite.assignCase` by definition. -/
-abbrev ergCaseMam : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseMam : ArgumentRole → Case :=
   caseMam .Perf
 
 /-- Tseltalan (Tseltal, Tsotsil) case assignment.
@@ -280,12 +281,12 @@ abbrev ergCaseMam : Features.Prominence.ArgumentRole → Case :=
     conditioned split (in contrast with their Cholan cousins). The
     aspect parameter is retained for shape-uniformity with the other
     Mayan `case*` functions. -/
-def caseTseltalan : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseTseltalan : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.ergative.assignCase r
 
 /-- Tseltalan ergative-absolutive case (uniform across aspects). Equals
     `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseTseltalan : ArgumentRole → Case :=
   caseTseltalan .Perf
 
 /-- Yucatecan aspect/status-driven case assignment ([hofling-2017] p. 692:
@@ -293,17 +294,17 @@ abbrev ergCaseTseltalan : Features.Prominence.ArgumentRole → Case :=
     subjects; Set B marks transitive objects and completive intransitive
     subjects): ergative in the completive (perfective),
     extended-ergative in the incompletive aspects. -/
-def caseYukatek : UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseYukatek : UD.Aspect → ArgumentRole → Case
   | .Perf, r => Alignment.ergative.assignCase r
   | .Imp, r | .Prog, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.extendedErgative.assignCase r
 
 /-- Yucatec completive ergative-absolutive case. -/
-abbrev ergCaseYukatek : Features.Prominence.ArgumentRole → Case :=
+abbrev ergCaseYukatek : ArgumentRole → Case :=
   caseYukatek .Perf
 
 /-- Yucatec incompletive extended-ergative case. -/
-abbrev accCaseYukatek : Features.Prominence.ArgumentRole → Case :=
+abbrev accCaseYukatek : ArgumentRole → Case :=
   caseYukatek .Imp
 
 /-! ### Person-number paradigm
@@ -419,7 +420,7 @@ def isStandard : Mayan → Bool
     existing per-branch `case*` substrate functions; the dispatcher is
     the consolidation point that lets cross-Mayan theorems quantify
     over `Mayan` rather than enumerate per-language `rfl` facts. -/
-def caseAt : Mayan → UD.Aspect → Features.Prominence.ArgumentRole → Case
+def caseAt : Mayan → UD.Aspect → ArgumentRole → Case
   | .Chol,      asp, r => caseChol asp r
   | .Qanjobal,  asp, r => caseQanjobalan asp r
   | .Kaqchikel, asp, r => caseKaqchikel asp r

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Q'anjob'al Agreement and Case Fragment
@@ -62,8 +63,8 @@ open Mayan (ExponentTable)
 /-! ### Argument positions -/
 
 /-- Argument positions, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Canonical ergative case assignment (clauses with an overt preverbal
     aspect marker), shared with Chol via `Mayan.ergCaseQanjobalan`

--- a/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
@@ -3,6 +3,7 @@ import Linglib.Features.Reflex
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Q'anjob'al Agent Focus and Extraction Fragment

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -2,6 +2,7 @@ import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Tseltal Agreement Fragment
@@ -50,8 +51,8 @@ export Mayan.Tseltalan (GramFunction)
 /-! ### Argument positions -/
 
 /-- Argument positions in a Tseltal clause, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Case assignment for Tseltal: `Mayan.caseTseltalan .Perf`
     (A → ERG, S/P → ABS). No aspect-conditioned split, so a single function

--- a/Linglib/Fragments/Mayan/Tseltalan.lean
+++ b/Linglib/Fragments/Mayan/Tseltalan.lean
@@ -1,5 +1,6 @@
 import Linglib.Fragments.Mayan.Params
 import Linglib.Features.Prominence
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Shared Tseltalan Infrastructure
@@ -89,7 +90,7 @@ def absPosition : Mayan.ABSPosition := .low
     with no `ArgumentRole` analog. Cross-Mayan consumers use this projection;
     the Aissen-Polian possessor-extraction analysis uses `GramFunction`
     directly for its DP-internal claims. -/
-def GramFunction.toArgumentRole? : GramFunction → Option Features.Prominence.ArgumentRole
+def GramFunction.toArgumentRole? : GramFunction → Option ArgumentRole
   | .A   => some .A
   | .S_A => some .S
   | .S_O => some .S

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -2,6 +2,7 @@ import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Tsotsil Agreement Fragment
@@ -48,8 +49,8 @@ export Mayan.Tseltalan (GramFunction)
 /-! ### Argument positions -/
 
 /-- Argument positions in a Tsotsil clause, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Case assignment for Tsotsil: `Mayan.caseTseltalan .Perf`
     (A → ERG, S/P → ABS); Tseltalan has no aspect-conditioned split. -/

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Yucatec Maya Agreement Fragment
@@ -80,8 +81,8 @@ theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 /-! ### Argument positions -/
 
 /-- Argument positions, aliased to the canonical
-    `Features.Prominence.ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := Features.Prominence.ArgumentRole
+    `ArgumentRole` (S/A/P/R/T). -/
+abbrev ArgPosition := ArgumentRole
 
 /-- Completive (ergative) case assignment: `Mayan.ergCaseYukatek`
     (A → ERG, S/P → ABS). -/

--- a/Linglib/Fragments/TobaBatak/Basic.lean
+++ b/Linglib/Fragments/TobaBatak/Basic.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.Voice.Basic
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Toba Batak Fragment [erlewine-2018]

--- a/Linglib/Semantics/ArgumentStructure/Valency.lean
+++ b/Linglib/Semantics/ArgumentStructure/Valency.lean
@@ -2,6 +2,7 @@ import Linglib.Features.Prominence
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Tactic.DeriveFintype
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Valency
@@ -22,7 +23,7 @@ valency `{.internal}`, `noTheme` ~ valency `∅`) was this lattice
 restricted by the thesis.
 
 `label` maps a valency to the comparative core-term labels of
-`Features.Prominence.ArgumentRole`: a lone position — internal or
+`ArgumentRole`: a lone position — internal or
 external alike — surfaces as S, both together as A and P. The labels
 are relational, so `label` is deliberately not monotone
 (`label_not_monotone`): adding a co-argument relabels S, which is why
@@ -37,7 +38,6 @@ alignment typology needs S as its own comparative concept.
 
 namespace ArgumentStructure
 
-open Features.Prominence (ArgumentRole)
 
 /-- A core-argument position of the verbal clause: the internal argument
     (complement of the lexical core) or the external argument (specifier
@@ -100,7 +100,7 @@ theorem isTransitive_union_iff :
 /-! ### Comparative core-term labels -/
 
 /-- The comparative core-term labels a valency's arguments surface with
-    (S ~ A ~ P, `Features.Prominence.ArgumentRole`): a lone position —
+    (S ~ A ~ P, `ArgumentRole`): a lone position —
     internal or external alike — is the S of an intransitive clause;
     both together are A and P. -/
 def label (v : Valency) : Finset ArgumentRole :=

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -6,6 +6,7 @@ import Linglib.Fragments.Hindi.Case
 import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Mayan.Chol.Agreement
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Baker (2015) — Case: Its Principles and Its Parameters

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -5,6 +5,7 @@ import Linglib.Syntax.Case.Alignment
 import Linglib.Studies.Dixon1994
 import Linglib.Studies.Aissen2003
 import Linglib.Fragments.Dargwa.ComplexPredicates
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Comrie (1989) [comrie-1989]
@@ -84,7 +85,7 @@ The same pattern holds for `DefinitenessLevel` and `Person` — all
 three prominence scales are defined once in `Features.Prominence` and
 imported by every downstream module. -/
 
-open Features.Prominence (AnimacyLevel ArgumentRole)
+open Features.Prominence (AnimacyLevel)
 open Alignment (AlignmentType)
 
 -- ============================================================================
@@ -191,10 +192,10 @@ theorem neutral_marks_neither :
     accusative systems differentially mark the low-default role (P),
     ergative systems differentially mark the high-default role (A).
     This mirrors the polarity of marking in `Features.Prominence`:
-    P is lowDefault, A is highDefault. -/
+    P is low-default, A is high-default. -/
 theorem marking_polarity_matches_alignment :
-    ArgumentRole.P.lowDefault = true ∧
-    ArgumentRole.A.highDefault = true := ⟨rfl, rfl⟩
+    ArgumentRole.P.IsLowDefault ∧
+    ArgumentRole.A.IsHighDefault := ⟨Or.inl rfl, Or.inl rfl⟩
 
 -- ============================================================================
 -- § 2a: Deriving Subject Properties from Alignment

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -14,6 +14,7 @@ import Linglib.Fragments.Mayan.Mam.Extraction
 import Linglib.Fragments.Mayan.Kiche.Agreement
 import Linglib.Fragments.Mayan.Kiche.Extraction
 import Linglib.Fragments.Mayan.Yukatek.Agreement
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Coon, Mateo Pedro & Preminger (2014) [coon-mateo-pedro-preminger-2014]
@@ -621,7 +622,7 @@ theorem attested_cells :
     `Mayan.isStandard` and `Studies/Scott2023.lean`). -/
 theorem mayan_perfective_ergative
     (lang : Mayan) (h : lang.isStandard = true)
-    (r : Features.Prominence.ArgumentRole) :
+    (r : ArgumentRole) :
     Mayan.caseAt lang .Perf r = Alignment.ergative.assignCase r := by
   cases lang <;> first | rfl | (simp [Mayan.isStandard] at h)
 

--- a/Linglib/Studies/Corbett2000.lean
+++ b/Linglib/Studies/Corbett2000.lean
@@ -217,21 +217,17 @@ structure AnimacyNumberProfile where
   /-- Marking status at each position on the hierarchy. -/
   status : AnimacyRank → MarkingStatus
 
-private def allRanks : List AnimacyRank :=
-  [.speaker, .addressee, .thirdPerson, .kin, .human,
-   .higherAnimal, .lowerAnimal, .discreteInanimate, .nondiscreteInanimate]
-
 /-- **Constraint I** (Corbett Ch 3): the sg–pl distinction must affect a
     top segment of the hierarchy. If any position has obligatory marking,
     then the topmost position (speaker) does too. -/
 def AnimacyNumberProfile.RespectsConstraintI (p : AnimacyNumberProfile) : Prop :=
-  (∃ r ∈ allRanks, (p.status r).toNat ≥ 2) → (p.status .speaker).toNat ≥ 2
+  (∃ r ∈ AnimacyRank.all, (p.status r).toNat ≥ 2) → (p.status .speaker).toNat ≥ 2
 
 /-- **Constraint III** (Corbett Ch 3): as we move rightward along the
     hierarchy, the likelihood of number being distinguished decreases
     monotonically — no intervening increase. -/
 def AnimacyNumberProfile.RespectsConstraintIII (p : AnimacyNumberProfile) : Prop :=
-  ∀ r1 ∈ allRanks, ∀ r2 ∈ allRanks,
+  ∀ r1 ∈ AnimacyRank.all, ∀ r2 ∈ AnimacyRank.all,
     r1.toNat ≤ r2.toNat ∨ (p.status r1).toNat ≥ (p.status r2).toNat
 
 instance (p : AnimacyNumberProfile) : Decidable p.RespectsConstraintI := by
@@ -413,15 +409,15 @@ structure IndividuationProfile where
 /-- **Constraint II** (Corbett Ch 4): if trial exists at position X, then dual
     exists at X and at all positions higher on the animacy hierarchy. -/
 def IndividuationProfile.RespectsConstraintII (p : IndividuationProfile) : Prop :=
-  ∀ r ∈ allRanks, .trial ∈ p.valuesAt r →
+  ∀ r ∈ AnimacyRank.all, .trial ∈ p.valuesAt r →
     .dual ∈ p.valuesAt r ∧
-    ∀ r' ∈ allRanks, r'.toNat ≤ r.toNat ∨ .dual ∈ p.valuesAt r'
+    ∀ r' ∈ AnimacyRank.all, r'.toNat ≤ r.toNat ∨ .dual ∈ p.valuesAt r'
 
 /-- **Monotonicity**: number value inventories never grow as we move rightward
     (down) the hierarchy. If a value exists at position X, it exists at all
     higher positions. -/
 def IndividuationProfile.RespectsMonotonicity (p : IndividuationProfile) : Prop :=
-  ∀ r1 ∈ allRanks, ∀ r2 ∈ allRanks,
+  ∀ r1 ∈ AnimacyRank.all, ∀ r2 ∈ AnimacyRank.all,
     r1.toNat ≤ r2.toNat ∨ ∀ v ∈ p.valuesAt r2, v ∈ p.valuesAt r1
 
 instance (p : IndividuationProfile) : Decidable p.RespectsConstraintII := by
@@ -622,7 +618,7 @@ def IndividuationProfile.RespectsConstraintVII (p : IndividuationProfile) : Prop
     at some animacy position, it must also exist at all higher positions.
     Minor numbers obey the same monotonicity as full number values. -/
 def IndividuationProfile.RespectsConstraintIV (p : IndividuationProfile) : Prop :=
-  ∀ v ∈ p.minorValues, ∀ r1 ∈ allRanks, ∀ r2 ∈ allRanks,
+  ∀ v ∈ p.minorValues, ∀ r1 ∈ AnimacyRank.all, ∀ r2 ∈ AnimacyRank.all,
     r1.toNat ≤ r2.toNat ∨ v ∉ p.valuesAt r2 ∨ v ∈ p.valuesAt r1
 
 instance (p : IndividuationProfile) : Decidable p.RespectsConstraintVII := by

--- a/Linglib/Studies/Dixon1994.lean
+++ b/Linglib/Studies/Dixon1994.lean
@@ -4,6 +4,7 @@ import Linglib.Syntax.Case.Alignment
 import Linglib.Fragments.Dargwa.Case
 import Linglib.Fragments.Japanese.Case
 import Linglib.Fragments.Hindi.Case
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Dixon (1994): Ergativity — typology + Silverstein hierarchy + ditransitives
@@ -653,7 +654,6 @@ theorem hindi_split_bridge :
 
 section BridgesToTheoriesAlignment
 
-open Features.Prominence (ArgumentRole)
 
 theorem ergative_function_marks_A :
     (_root_.Alignment.ergative.assignCase .A != _root_.Alignment.ergative.assignCase .S) =

--- a/Linglib/Studies/Haspelmath2021.lean
+++ b/Linglib/Studies/Haspelmath2021.lean
@@ -4,6 +4,7 @@ import Linglib.Studies.Aissen2003
 import Linglib.Studies.DeHoopMalchukov2008
 import Linglib.Studies.Marantz1991
 import Linglib.Syntax.Case.Alignment
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # [haspelmath-2021]: Role-reference associations and the explanation of argument coding splits
@@ -72,7 +73,7 @@ Haspelmath himself: "I do not focus on documenting the discourse frequencies
 in this paper... testing this claim more thoroughly is a topic for future
 comparative corpus research" (p. 126). Lean theorems committing the
 frequency-class function to specific Nat values would over-reify a
-tendency-claim. We use `Scenario.frequencyClass` from the substrate as a
+tendency-claim. We use `Scenario.frequencyClass` (co-located in §0) as a
 discrete proxy and clearly mark its theorems as proxy-checks, not empirical
 claims about token frequencies.
 
@@ -107,10 +108,76 @@ open Alignment
        longer (overt) coding.
 
     Previously housed in `Core/FormFrequency.lean` — demoted to this study
-    file at 0.230.551 when the consumer count was 1 (only Haspelmath2021
-    used any of the primitives) and four primitives in the substrate file
-    (`respectsFormFrequency`, `argumentCodingRespectsFrequency`,
-    `VoiceDirection`, `DitransitiveFrame`) were completely unused. -/
+    file at 0.230.551 when the consumer count was 1. The scenario machinery,
+    the `prominenceRank` proxy, and the default-zone classifier were likewise
+    demoted here from `Features/Prominence.lean` (sole consumer). -/
+
+/-- A monotransitive scenario: the person combination of A and P
+    ([haspelmath-2021] (10); the term is from Bickel and Zúñiga, fn. 4).
+    The paper's scenarios also range over nominality; this formalization
+    restricts to the person scale, the dimension its scenario universals
+    are checked on below. -/
+structure Scenario where
+  /-- Person of the A argument -/
+  aPerson : Person
+  /-- Person of the P argument -/
+  pPerson : Person
+  deriving DecidableEq, Repr
+
+/-- Downstream scenario ((11)): A outranks P in person prominence — the
+    usual direction, predicted to get the shortest coding. -/
+def Scenario.Downstream (s : Scenario) : Prop :=
+  s.pPerson.prominence < s.aPerson.prominence
+
+/-- Upstream scenario ((11)): P outranks A — the unusual direction,
+    predicted to get the longest coding. -/
+def Scenario.Upstream (s : Scenario) : Prop :=
+  s.aPerson.prominence < s.pPerson.prominence
+
+/-- Balanced scenario ((11)): A and P have equal person prominence. -/
+def Scenario.Balanced (s : Scenario) : Prop :=
+  s.aPerson.prominence = s.pPerson.prominence
+
+instance (s : Scenario) : Decidable s.Downstream :=
+  inferInstanceAs (Decidable (_ < _))
+instance (s : Scenario) : Decidable s.Upstream :=
+  inferInstanceAs (Decidable (_ < _))
+instance (s : Scenario) : Decidable s.Balanced :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- The 9 scenarios over the person tripartition. -/
+def Scenario.all : List Scenario :=
+  [⟨.first, .first⟩,  ⟨.first, .second⟩,  ⟨.first, .third⟩,
+   ⟨.second, .first⟩, ⟨.second, .second⟩, ⟨.second, .third⟩,
+   ⟨.third, .first⟩,  ⟨.third, .second⟩,  ⟨.third, .third⟩]
+
+/-- Frequency class: downstream (usual) 2 > balanced 1 > upstream 0 —
+    a discrete proxy for the paper's usualness claims, not a corpus
+    measurement. -/
+def Scenario.frequencyClass (s : Scenario) : Nat :=
+  if s.Downstream then 2 else if s.Balanced then 1 else 0
+
+/-- Combined prominence for a cell of the animacy × definiteness grid:
+    the sum of the two ranks, from 0 (inanimate non-specific) to 6 (human
+    pronoun). A representational proxy — the paper's own prominence order
+    on cells is the partial product order ([aissen-2003] Figure 4); the
+    additive scalar linearizes it for the frequency proxy below. -/
+def prominenceRank (a : AnimacyLevel) (d : DefinitenessLevel) : Nat :=
+  a.rank + d.rank
+
+/-- The cell lies in the role's usual zone ((6): A/R arguments are usually
+    prominent, P/T arguments usually non-prominent; S is the reference
+    point). The threshold at the scalar midpoint is representational. -/
+def IsDefaultZone (role : ArgumentRole) (a : AnimacyLevel)
+    (d : DefinitenessLevel) : Prop :=
+  match role with
+  | .A | .R => 3 ≤ prominenceRank a d
+  | .S => True
+  | .P | .T => prominenceRank a d ≤ 2
+
+instance (role : ArgumentRole) (a : AnimacyLevel) (d : DefinitenessLevel) :
+    Decidable (IsDefaultZone role a d) := by
+  cases role <;> simp only [IsDefaultZone] <;> infer_instance
 
 /-- Relative coding length of an argument expression. Haspelmath's claim
     is about *relative* length, not absolute morpheme counts. -/
@@ -144,12 +211,10 @@ def frequencyProxy (role : ArgumentRole)
     every default-zone cell has at least the median proxy value. -/
 theorem frequency_proxy_matches_default (role : ArgumentRole)
     (a : AnimacyLevel) (d : DefinitenessLevel) :
-    (isDefaultZone role a d = true) →
-    (frequencyProxy role a d ≥ 3) := by
+    IsDefaultZone role a d → frequencyProxy role a d ≥ 3 := by
   intro h
   cases role <;>
-    simp only [isDefaultZone, frequencyProxy, prominenceRank,
-               decide_eq_true_eq] at h ⊢ <;> omega
+    simp only [IsDefaultZone, frequencyProxy, prominenceRank] at h ⊢ <;> omega
 
 /-- Scenario-level form-frequency correspondence: higher frequency-class
     scenarios should get shorter-or-equal coding. -/
@@ -176,7 +241,7 @@ def scenarioRespectsFormFrequency
     specialization is Universal 3.
 
     Formalized as: for each argument role `r`, the "deviation zone" is
-    the negation of `r`'s default zone (`isDefaultZone r a d = false`),
+    the complement of `r`'s default zone (`¬ IsDefaultZone r a d`),
     and the meta-universal predicts non-default cells get longer coding.
     The cell-level corollary is captured by `frequency_proxy_matches_default`
     (co-located in §0): default cells have `frequencyProxy ≥ 3`, non-default
@@ -184,11 +249,11 @@ def scenarioRespectsFormFrequency
     Form-frequency correspondence (U68) then maps this to coding length. -/
 
 /-- Universal 1 (cell form): default-zone cells have at least the median
-    frequency proxy. Substrate lemma re-exported with the U1 framing. -/
+    frequency proxy — `frequency_proxy_matches_default` with the U1
+    framing. -/
 theorem universal1_role_reference_association
     (role : ArgumentRole) (a : AnimacyLevel) (d : DefinitenessLevel) :
-    (isDefaultZone role a d = true) →
-    (frequencyProxy role a d ≥ 3) :=
+    IsDefaultZone role a d → frequencyProxy role a d ≥ 3 :=
   frequency_proxy_matches_default role a d
 
 -- ============================================================================
@@ -204,8 +269,12 @@ theorem universal1_role_reference_association
     rank) tend to be human, definite, topical. P/T arguments (lower role
     rank) tend to be inanimate, indefinite, new-information.
 
-    Formalized via the substrate's `highDefault` (A, R) / `lowDefault`
-    (P, T) predicates. -/
+    Formalized via the substrate's `IsHighDefault` (A, R) / `IsLowDefault`
+    (P, T) classification, which also carries the paper's role-rank
+    vocabulary: (7) (p. 127) fixes only the monotransitive A > P and the
+    ditransitive R > T, and "the notion of role rank is not crucial"
+    (p. 127) — a total ordering over all five roles would over-formalize,
+    so none is stated. -/
 
 /-- Universal 2 (default-side): A and R have high-default-prominence
     expectations; P and T have low-default-prominence expectations.
@@ -213,27 +282,9 @@ theorem universal1_role_reference_association
     (Haspelmath fn. 15, p. 138 explicitly excludes intransitives from
     the analysis). -/
 theorem universal2_usual_associations :
-    ArgumentRole.A.highDefault = true ∧
-    ArgumentRole.R.highDefault = true ∧
-    ArgumentRole.P.lowDefault = true ∧
-    ArgumentRole.T.lowDefault = true := ⟨rfl, rfl, rfl, rfl⟩
-
-/-! Haspelmath on role rank, p. 127: "the notion of role rank is not
-    crucial. (Since some readers will be curious, I will make a few
-    remarks below in Section 11.2, but it should be kept in mind that
-    these considerations are not essential for this paper.)"
-
-    The only role-rank claims the paper commits to are the
-    monotransitive A > P (statement (7), p. 127) and the ditransitive
-    R > T. We do *not* state a total ordering A > R > S > T > P; that
-    would over-formalize. -/
-
-/-- Universal 2 (role-rank fragment): A > P (monotransitive) and R > T
-    (ditransitive). These are the only role-rank orderings the paper
-    commits to. -/
-theorem universal2_role_rank_committed_orderings :
-    ArgumentRole.A.roleRank > ArgumentRole.P.roleRank ∧
-    ArgumentRole.R.roleRank > ArgumentRole.T.roleRank := by decide
+    ArgumentRole.A.IsHighDefault ∧ ArgumentRole.R.IsHighDefault ∧
+    ArgumentRole.P.IsLowDefault ∧ ArgumentRole.T.IsLowDefault :=
+  ⟨Or.inl rfl, Or.inr rfl, Or.inl rfl, Or.inr rfl⟩
 
 -- ============================================================================
 -- § 3: Universal 3 — Single-Argument Flagging Universal
@@ -250,22 +301,25 @@ theorem universal2_role_rank_committed_orderings :
     follow as specific cases for each argument role. It applies to both
     flagging and indexing (statement (15)).
 
-    **Derived from U1 + U2.** Substrate-level: for any role `r`,
-    `differentialTargetsProminent r = lowDefault r` (the prominent end
-    is the "deviation" for low-default roles, and the non-prominent end
-    is the deviation for high-default roles). U3 asserts this equality
-    over the four core roles. -/
+    The direction claim is carried by the marking-grid vocabulary: a split
+    on a low-default role marks an upper set of the prominence grid
+    (prominent end = deviation), a split on a high-default role a lower
+    set. -/
 
-/-- Universal 3 derives from U1 + U2: for any argument role, the
-    differential-flagging direction is determined by whether the role is
-    low-default (prominent end = deviation) or high-default (non-prominent
-    end = deviation). Strictly stronger than the four-conjunct over
-    {A, P, R, T} since it ranges over all five roles, including S.
+/-- U3-compliance of a single-argument split: on a low-default role (P/T)
+    the marked zone is an upper set of the prominence grid; on a
+    high-default role (A/R), a lower set. -/
+def universal3Compliant (r : ArgumentRole)
+    (p : Features.Prominence.MarkingPattern) : Prop :=
+  (r.IsLowDefault → p.MonotoneP) ∧ (r.IsHighDefault → p.MonotoneA)
 
-    `rfl` because substrate `differentialTargetsProminent r := r.lowDefault`
-    is the alias — the equality holds by construction, not by enumeration. -/
-theorem universal3_single_argument_flagging (r : ArgumentRole) :
-    differentialTargetsProminent r = r.lowDefault := rfl
+/-- Universal 3, instantiated at role P over [aissen-2003]'s attested DOM
+    systems: every obligatory-marking grid in the sample is U3-compliant. -/
+theorem universal3_attested_dom_compliant :
+    ∀ p ∈ Aissen2003.allDOMPatterns, universal3Compliant .P p := by
+  intro p hp
+  exact ⟨λ _ => Aissen2003.dom_monotonicity_universal p hp,
+    λ h => absurd h (by decide)⟩
 
 -- ============================================================================
 -- § 4: Universal 4 — Split P Flagging (DOM)
@@ -318,13 +372,13 @@ def downstreamScenario : Scenario := ⟨.first, .third⟩
 def upstreamScenario : Scenario := ⟨.third, .first⟩
 def balancedScenario : Scenario := ⟨.third, .third⟩
 
-/-- Universal 5: the downstream/upstream/balanced trichotomy is exhaustive
-    for *every* `Scenario`, not just the 9 in `Scenario.all`. Strictly
-    stronger than the list-anchored form (which silently passes if
-    `Scenario.all` ever loses an inhabitant). -/
+/-- Universal 5: the downstream/balanced/upstream trichotomy is exhaustive
+    for *every* `Scenario` — it is `Nat.lt_trichotomy` on the person
+    prominences. -/
 theorem universal5_trichotomy_exhaustive (s : Scenario) :
-    (s.isDownstream || s.isUpstream || s.isBalanced) = true := by
-  obtain ⟨a, p⟩ := s; cases a <;> cases p <;> rfl
+    s.Downstream ∨ s.Balanced ∨ s.Upstream :=
+  (Nat.lt_trichotomy s.pPerson.prominence s.aPerson.prominence).imp
+    id (Or.imp Eq.symm id)
 
 /-- Universal 5: the frequency-class proxy is monotone in the "usualness"
     of the scenario — downstream > balanced > upstream. This is a
@@ -384,13 +438,17 @@ theorem universal6_dehoopmalchukov_predicts :
     to those about split A and P flagging seen earlier"). The parallelism
     IS Haspelmath's. -/
 
-/-- Universal 7: R targets the non-prominent end (like A). -/
-theorem universal7_R_like_A :
-    differentialTargetsProminent .R = differentialTargetsProminent .A := rfl
+/-- Universal 7: R targets the non-prominent end (like A) — R and A impose
+    the same compliance condition on a split. -/
+theorem universal7_R_like_A (p : Features.Prominence.MarkingPattern) :
+    universal3Compliant .R p ↔ universal3Compliant .A p := by
+  simp [universal3Compliant, ArgumentRole.IsLowDefault, ArgumentRole.IsHighDefault]
 
-/-- Universal 8: T targets the prominent end (like P). -/
-theorem universal8_T_like_P :
-    differentialTargetsProminent .T = differentialTargetsProminent .P := rfl
+/-- Universal 8: T targets the prominent end (like P) — T and P impose the
+    same compliance condition. -/
+theorem universal8_T_like_P (p : Features.Prominence.MarkingPattern) :
+    universal3Compliant .T p ↔ universal3Compliant .P p := by
+  simp [universal3Compliant, ArgumentRole.IsLowDefault, ArgumentRole.IsHighDefault]
 
 -- ============================================================================
 -- § 8: Universals 9a/9b — Ditransitive Person-Role
@@ -460,9 +518,9 @@ theorem universal10_relative_scenario :
 
     Upstream = unusual = lower frequency class = predicted longer by FFC.
     The direct/inverse distinction is captured at the scenario level via
-    `Scenario.isDownstream`/`isUpstream` (substrate `Features/Prominence.lean`);
-    a dedicated `VoiceDirection` enum was carried in `Core/FormFrequency.lean`
-    until 0.230.551 but never used and was demoted out. -/
+    `Scenario.Downstream`/`Upstream` (§0); a dedicated `VoiceDirection`
+    enum was carried in `Core/FormFrequency.lean` until 0.230.551 but
+    never used and was demoted out. -/
 
 theorem universal11_inverse :
     upstreamScenario.frequencyClass < downstreamScenario.frequencyClass := by decide
@@ -647,8 +705,8 @@ theorem alignment_correlation_deHoopMalchukov :
     scenarios, longest to upstream — exactly the gradient U10/U11
     predict. -/
 def usualnessCoding (s : Scenario) : CodingLength :=
-  if s.isDownstream then .zero
-  else if s.isBalanced then .short
+  if s.Downstream then .zero
+  else if s.Balanced then .short
   else .long
 
 /-- The `usualnessCoding` proxy respects the form-frequency correspondence
@@ -658,19 +716,6 @@ def usualnessCoding (s : Scenario) : CodingLength :=
     a hand-rolled all-pairs sweep. -/
 theorem universal68_scenario_form_frequency :
     scenarioRespectsFormFrequency Scenario.all usualnessCoding = true := by decide
-
--- ============================================================================
--- § 17: Form-Frequency Grounding (re-export)
--- ============================================================================
-
-/-- The cell-level form-frequency claim under U1: default cells have
-    `frequencyProxy ≥ 3`. Re-exported from substrate for direct citation
-    under the U1 framing. -/
-theorem universal1_frequency_grounding (role : ArgumentRole)
-    (a : AnimacyLevel) (d : DefinitenessLevel) :
-    (isDefaultZone role a d = true) →
-    (frequencyProxy role a d ≥ 3) :=
-  frequency_proxy_matches_default role a d
 
 -- ============================================================================
 -- § 18: Contrast with [marantz-1991] — Configurational Case

--- a/Linglib/Studies/Imanishi2014.lean
+++ b/Linglib/Studies/Imanishi2014.lean
@@ -1,5 +1,6 @@
 import Linglib.Syntax.Case.Alignment
 import Linglib.Fragments.Mayan.Params
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Imanishi 2014 — Default Ergative [imanishi-2014]
@@ -79,7 +80,6 @@ a different parameterization.
 
 namespace Imanishi2014
 
-open Features.Prominence (ArgumentRole)
 
 -- ============================================================================
 -- § 1: URN (Unaccusative Requirement on Nominalization)

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -4,6 +4,7 @@ import Linglib.Fragments.Mayan.Kaqchikel.Agreement
 import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Hungarian.Predicates
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Just 2024: Differential A and P Indexing
@@ -630,7 +631,7 @@ theorem personLevel_rank_matches_probe_rank :
 /-- Kaqchikel indexes all three argument positions (agent, patient, intranS).
     This makes it non-differential: no prominence condition gates indexing. -/
 theorem kaqchikel_indexes_all (p : ArgPosition)
-    (h : p ∈ Features.Prominence.ArgumentRole.core) :
+    (h : p ∈ ArgumentRole.core) :
     ArgPosition.IsPhiAgreed p :=
   Kaqchikel.all_positions_agreed p h
 

--- a/Linglib/Syntax/ArgumentRole.lean
+++ b/Linglib/Syntax/ArgumentRole.lean
@@ -1,0 +1,52 @@
+/-!
+# Comparative argument roles
+
+`ArgumentRole`: the S/A/P/R/T comparative concepts for argument coding,
+neutral between case and agreement. `ArgumentRole.core` is the
+monotransitive core that alignment partitions quantify over;
+`IsHighDefault`/`IsLowDefault` classify the roles by their usual
+referential prominence (the role-reference association).
+
+## References
+
+* [comrie-1978]
+* [haspelmath-2021]
+-/
+
+/-- Argument roles spanning monotransitive and ditransitive clauses,
+    following [comrie-1978] and [haspelmath-2021] in using S/A/P/R/T
+    (not subject/object) to avoid theory-dependent constituency
+    assumptions. -/
+inductive ArgumentRole where
+  /-- S: sole argument of an intransitive verb -/
+  | S
+  /-- A: the more agent-like argument of a transitive verb -/
+  | A
+  /-- P: the more patient-like argument of a transitive verb -/
+  | P
+  /-- R: the recipient-like argument of a ditransitive verb -/
+  | R
+  /-- T: the theme-like argument of a ditransitive verb -/
+  | T
+  deriving DecidableEq, Repr
+
+/-- The monotransitive core roles: A, P, and S (omits the ditransitive
+    scaffolding roles R/T). The domain over which alignment partitions
+    and per-language case/agreement coverage theorems quantify. -/
+def ArgumentRole.core : List ArgumentRole := [.A, .P, .S]
+
+/-- The role defaults to high referential prominence (A and R, which are
+    usually human, definite, topical) — so differential marking targets its
+    *non-prominent* end ([haspelmath-2021]'s (6)). -/
+def ArgumentRole.IsHighDefault (r : ArgumentRole) : Prop := r = .A ∨ r = .R
+
+instance (r : ArgumentRole) : Decidable r.IsHighDefault :=
+  inferInstanceAs (Decidable (_ ∨ _))
+
+/-- The role defaults to low referential prominence (P and T) — so
+    differential marking targets its *prominent* end. S is the alignment
+    reference point and is neither. -/
+def ArgumentRole.IsLowDefault (r : ArgumentRole) : Prop := r = .P ∨ r = .T
+
+instance (r : ArgumentRole) : Decidable r.IsLowDefault :=
+  inferInstanceAs (Decidable (_ ∨ _))

--- a/Linglib/Syntax/Case/Alignment.lean
+++ b/Linglib/Syntax/Case/Alignment.lean
@@ -6,6 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Features.Case.Basic
 import Linglib.Features.Prominence
 import Mathlib.Data.Fintype.Prod
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Alignment Case-Assignment Functions
@@ -13,7 +14,7 @@ import Mathlib.Data.Fintype.Prod
 
 The SAP-indexed counterpart to `Syntax/Case/Dependent.lean`'s
 configural algorithm. Each `Alignment.X.assignCase` is a function from
-`Features.Prominence.ArgumentRole` to `Case` capturing the canonical
+`ArgumentRole` to `Case` capturing the canonical
 case pattern of alignment type X. The configural derivations in
 `Dependent.lean` (Marantz/Baker) and the observational `AlignmentType` enum
 (WALS-style classification, below) are checked against the case-assignment
@@ -56,7 +57,6 @@ them as scaffolding subject to revision when ditransitive consumers arrive:
 
 namespace Alignment
 
-open Features.Prominence (ArgumentRole)
 
 namespace ergative
 

--- a/Linglib/Syntax/Extraction.lean
+++ b/Linglib/Syntax/Extraction.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Reflex
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Extraction Morphology

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -1,5 +1,6 @@
 import Linglib.Features.Prominence
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Valency Alternation Typology
@@ -64,7 +65,6 @@ verbal morphology). The `marking` field captures this.
 
 namespace Voice
 
-open Features.Prominence (ArgumentRole)
 open ArgumentStructure (DiathesisAlternation)
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Syntax/Voice/Basic.lean
+++ b/Linglib/Syntax/Voice/Basic.lean
@@ -1,4 +1,5 @@
 import Linglib.Syntax.Extraction
+import Linglib.Syntax.ArgumentRole
 
 /-!
 # Voice system typology


### PR DESCRIPTION
Deep cleanse of `Features/Prominence.lean` (562 → ~230 lines) against Haspelmath 2021 (PDF verified) and the consumer map.

- `ArgumentRole` moves to `Syntax/ArgumentRole.lean` as a root-level type (syntax owns coding roles); the Bool `highDefault`/`lowDefault` pair becomes `IsHighDefault`/`IsLowDefault` Props there.
- Single-consumer apparatus demotes into `Studies/Haspelmath2021.lean` §0: `Scenario` (Prop-ified trichotomy proved by `Nat.lt_trichotomy`), `frequencyClass`, `prominenceRank`, `IsDefaultZone`. The alias `differentialTargetsProminent := lowDefault` is deleted; U3/U7/U8 restate over a real `universal3Compliant` (instantiated by Aissen's DOM sample), and the fabricated total role order A > R > S > T > P is gone — the paper's (7) commits only to A > P and R > T.
- Cut dead/broken API: `AnimacyRank.respectsHierarchy` (wrong quantifier domain — even upward-closed sets failed it; zero consumers), `MarkingChannel`, the scenario local/direct/inverse/nonlocal quartet, `upstreamDegree`, and a dozen zero-consumer verification theorems (`*_bounded`, `*_injective`, `*_length`, `hierarchy_ordering`, `role_rank_ordering`).
- `AnimacyRank` gains its missing `LinearOrder`, `all`, and `Monotone toAnimacyLevel` (Corbett2000 drops its private rank list); banners → mathlib section headers; module docstrings get `## References` sections; the person-scale docstring no longer attributes the 1st > 2nd grading to Haspelmath (his (8a) is binary locuphoric > aliophoric).