### PR TITLE
refactor(Syntax): argument-role tier cleanup

### DIFF
--- a/Linglib/Features/Person/Basic.lean
+++ b/Linglib/Features/Person/Basic.lean
@@ -26,8 +26,8 @@ capability mixin (`Features/Person/Capabilities.lean`), unified
 resolution (`Features/Person/Resolve.lean`), feature decomposition and
 the Cysouw categories (`Features/Person/Decomposition.lean`).
 
-The prominence scale over this inventory (`Person.prominence`, the
-dissolved `Person`'s role) lives in `Features/Prominence.lean`.
+`Person.prominence` is the graded prominence scale over this
+inventory, consumed by person-hierarchy and scenario-split accounts.
 -/
 
 set_option autoImplicit false
@@ -157,6 +157,17 @@ structure System where
   /-- The person values the system distinguishes. -/
   values : List Person
   deriving DecidableEq, Repr
+
+/-- Graded person prominence: 1st (2) > 2nd (1) > 3rd (0). The
+    load-bearing cut is locuphoric (1st/2nd) > aliophoric (3rd) —
+    [haspelmath-2021]'s person scale (8a); the ranking of 1st over 2nd
+    within the locuphoric zone follows the person-hierarchy tradition and
+    varies across languages. Clusivity-marked firsts rank with `first`;
+    the impersonal `zero` is `[−participant]` and ranks with third. -/
+def prominence : Person → Nat
+  | .first | .firstInclusive | .firstExclusive => 2
+  | .second => 1
+  | .third | .zero => 0
 
 namespace System
 

--- a/Linglib/Features/Prominence.lean
+++ b/Linglib/Features/Prominence.lean
@@ -2,7 +2,6 @@ import Mathlib.Order.Nat
 import Mathlib.Order.UpperLower.Basic
 import Mathlib.Tactic.DeriveFintype
 import Linglib.Core.Order.Markedness
-import Linglib.Features.Person.Basic
 
 /-!
 # Referential prominence
@@ -16,8 +15,6 @@ marking, and the marking grids over them.
   scales, as `LinearOrder`s; `AnimacyRank` — the fine-grained
   plural-marking hierarchy, with the coarsening
   `AnimacyRank.toAnimacyLevel`.
-- `Person.prominence` — graded person prominence over the canonical
-  `Person` inventory.
 - `MarkingPattern` — which cells of the animacy × definiteness grid are
   marked; the `MonotoneP`/`MonotoneA` staircases, cutoff constructors, and
   `monotoneP_iff_isUpperSet`.
@@ -158,20 +155,6 @@ instance : LinearOrder DefinitenessLevel :=
 /-- All definiteness levels, most prominent first. -/
 def DefinitenessLevel.all : List DefinitenessLevel :=
   [.personalPronoun, .properName, .definite, .indefiniteSpecific, .nonSpecific]
-
-/-! ### Person prominence -/
-
-/-- Graded person prominence over the canonical `Person` inventory:
-    1st (2) > 2nd (1) > 3rd (0). The load-bearing cut is locuphoric
-    (1st/2nd) > aliophoric (3rd) — [haspelmath-2021]'s person scale (8a);
-    the ranking of 1st over 2nd within the locuphoric zone follows the
-    person-hierarchy tradition and varies across languages.
-    Clusivity-marked firsts rank with `first`; the impersonal `zero` is
-    `[−participant]` and ranks with third. -/
-def _root_.Person.prominence : Person → Nat
-  | .first | .firstInclusive | .firstExclusive => 2
-  | .second => 1
-  | .third | .zero => 0
 
 /-! ### Differential marking patterns -/
 

--- a/Linglib/Fragments/Dargwa/Agreement.lean
+++ b/Linglib/Fragments/Dargwa/Agreement.lean
@@ -1,6 +1,7 @@
 import Linglib.Features.Prominence
 import Linglib.Data.UD.Basic
 import Linglib.Features.Gender.Basic
+import Linglib.Features.Person.Basic
 
 /-!
 # Dargwa (Tanti) Agreement [sumbatova-2021]

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -3,6 +3,7 @@ import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 /-!
 # Kaqchikel Agreement Fragment

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -6,6 +6,7 @@ import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 /-!
 # K'iche' Agreement Fragment

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -6,6 +6,7 @@ import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 /-!
 # Mam Agreement Fragment

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -8,6 +8,7 @@ import Linglib.Morphology.Morph
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Morphotactics.Template
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 open Morphology (Word)
 

--- a/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
@@ -3,7 +3,6 @@ import Linglib.Features.Reflex
 import Linglib.Syntax.Minimalist.Verbal.Voice
 import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
 
 /-!
 # Q'anjob'al Agent Focus and Extraction Fragment
@@ -69,7 +68,7 @@ def StatusSuffix.form : StatusSuffix → String
 
 -- The substantive claim "A-extraction is banned without AF" is expressed
 -- as `Extraction.Marked Extraction.realize .subject` (subject = .agent's
--- default position per `Extraction.ArgumentRole.defaultPosition`).
+-- default position per `Extraction.MacroRole.defaultPosition`).
 
 /-! ### Agent Focus construction -/
 

--- a/Linglib/Fragments/TobaBatak/Basic.lean
+++ b/Linglib/Fragments/TobaBatak/Basic.lean
@@ -1,7 +1,6 @@
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 import Linglib.Syntax.Voice.Basic
-import Linglib.Syntax.ArgumentRole
 
 /-!
 # Toba Batak Fragment [erlewine-2018]
@@ -48,7 +47,7 @@ inductive Voice where
   deriving Repr, DecidableEq
 
 /-- Which argument role is the pivot for a given voice? -/
-def Voice.pivotRole : Voice → Extraction.ArgumentRole
+def Voice.pivotRole : Voice → Extraction.MacroRole
   | .av => .agent
   | .ov => .patient
 

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -6,6 +6,7 @@ import Linglib.Studies.Dixon1994
 import Linglib.Studies.Aissen2003
 import Linglib.Fragments.Dargwa.ComplexPredicates
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 /-!
 # Comrie (1989) [comrie-1989]

--- a/Linglib/Studies/Haspelmath2021.lean
+++ b/Linglib/Studies/Haspelmath2021.lean
@@ -1,3 +1,4 @@
+import Linglib.Features.Person.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.Givenness
 import Linglib.Studies.Aissen2003

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -5,6 +5,7 @@ import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Hungarian.Predicates
 import Linglib.Syntax.ArgumentRole
+import Linglib.Features.Person.Basic
 
 /-!
 # Just 2024: Differential A and P Indexing

--- a/Linglib/Syntax/ArgumentRole.lean
+++ b/Linglib/Syntax/ArgumentRole.lean
@@ -7,6 +7,14 @@ monotransitive core that alignment partitions quantify over;
 `IsHighDefault`/`IsLowDefault` classify the roles by their usual
 referential prominence (the role-reference association).
 
+Distinct from the semantic tier (`ArgumentStructure.ThetaRole`, the Dowty
+proto-role profiles): S/A/P/R/T are construction-relative coding slots —
+the A of a transitive clause may be an instrument or experiencer, and S
+spans unergative agents and unaccusative patients, which is what lets
+alignment statements like "S groups with P" be expressed at all. The
+linking theories relating the two tiers live in
+`Semantics/ArgumentStructure/Linking.lean` and its studies.
+
 ## References
 
 * [comrie-1978]

--- a/Linglib/Syntax/Extraction.lean
+++ b/Linglib/Syntax/Extraction.lean
@@ -1,5 +1,4 @@
 import Linglib.Features.Reflex
-import Linglib.Syntax.ArgumentRole
 
 /-!
 # Extraction Morphology
@@ -95,19 +94,19 @@ inductive ExtractionTarget where
     relevant distinction is which macro-role is extracted, not fine-
     grained thematic relations or structural positions.
 
-    Complements `ExtractionTarget` (structural position): ArgumentRole
+    Complements `ExtractionTarget` (structural position): MacroRole
     identifies *what* is extracted; ExtractionTarget identifies *where*
     it was extracted. The two coincide in simple active clauses
     (agent = subject, patient = object) but diverge under voice
     alternation (in OV, the patient becomes the subject). -/
-inductive ArgumentRole where
+inductive MacroRole where
   | agent    -- external argument (agent, experiencer, causer)
   | patient  -- internal argument (patient, theme)
   | oblique  -- oblique argument (instrument, goal, source, etc.)
   deriving DecidableEq, Repr
 
 /-- Default structural position for a given argument role (active voice). -/
-def ArgumentRole.defaultPosition : ArgumentRole → ExtractionTarget
+def MacroRole.defaultPosition : MacroRole → ExtractionTarget
   | .agent => .subject
   | .patient => .directObject
   | .oblique => .oblique
@@ -120,7 +119,7 @@ def ArgumentRole.defaultPosition : ArgumentRole → ExtractionTarget
     predicate-fronting languages like Toba Batak, only DP extraction
     is restricted to the pivot; adjuncts extract freely. -/
 inductive Extractee where
-  | dpArg : ArgumentRole → Extractee
+  | dpArg : MacroRole → Extractee
   | adjunct : Extractee
   deriving DecidableEq, Repr
 

--- a/Linglib/Syntax/Minimalist/Features.lean
+++ b/Linglib/Syntax/Minimalist/Features.lean
@@ -4,6 +4,7 @@ import Linglib.Data.UD.Basic
 import Linglib.Features.Prominence
 import Linglib.Features.Number.Basic
 import Linglib.Features.Slot
+import Linglib.Features.Person.Basic
 
 /-!
 # Feature Infrastructure for Minimalist Agree

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -38,7 +38,7 @@ syntax projects onto these operations via
 as *constructional* properties of nominal terms, not semantic roles. A is
 "the nominal term whose coding matches the agent of a prototypical transitive
 verb" — it's defined by coding (flagging, indexation, order), anchored to
-semantic prototypes. These are already captured by `Prominence.ArgumentRole`
+semantic prototypes. These are already captured by `ArgumentRole`
 (S, A, P, R, T). This file adds X (oblique) as a `TRRole` that extends
 `ArgumentRole` with the non-core case.
 
@@ -73,7 +73,7 @@ open ArgumentStructure (DiathesisAlternation)
 
 /-- Transitivity-Related role including obliques.
 
-    Extends `Prominence.ArgumentRole` (S, A, P, R, T) with X for obliques.
+    Extends `ArgumentRole` (S, A, P, R, T) with X for obliques.
     §1.3.3: "OBLIQUE NOMINAL TERMS (or simply OBLIQUES),
     symbolized as X, are defined as nominal terms of verbal clauses that do
     not meet the definition of either A, P, or S." -/

--- a/Linglib/Syntax/Voice/Basic.lean
+++ b/Linglib/Syntax/Voice/Basic.lean
@@ -1,5 +1,4 @@
 import Linglib.Syntax.Extraction
-import Linglib.Syntax.ArgumentRole
 
 /-!
 # Voice system typology
@@ -18,7 +17,7 @@ operate on the voice list.
 
 ## Main definitions
 
-* `PivotTarget` : the role a voice promotes to pivot (finer than `ArgumentRole`).
+* `PivotTarget` : the role a voice promotes to pivot (finer than `Extraction.MacroRole`).
 * `VoiceEntry`, `VoiceSystemSymmetry` : one voice (name + promoted role); system symmetry.
 * `Voice.voiceCount` / `promotesRole` / `distinguishesObliques` / `isActivePassive`
   / `promotableRoles` : queries over a language's `List VoiceEntry`.
@@ -29,7 +28,7 @@ namespace Voice
 /-! ### Pivot target -/
 
 /-- Which argument role a voice promotes to pivot. Finer-grained than
-    `Extraction.ArgumentRole`: Philippine-type systems distinguish locative,
+    `Extraction.MacroRole`: Philippine-type systems distinguish locative,
     instrumental, benefactive, and circumstantial pivots, all collapsing to oblique. -/
 inductive PivotTarget where
   | agent
@@ -40,8 +39,8 @@ inductive PivotTarget where
   | circumstantial
   deriving DecidableEq, Repr
 
-/-- Coarsen a `PivotTarget` to a `Extraction.ArgumentRole` (obliques collapse). -/
-def PivotTarget.toArgumentRole : PivotTarget → Extraction.ArgumentRole
+/-- Coarsen a `PivotTarget` to an `Extraction.MacroRole` (obliques collapse). -/
+def PivotTarget.toMacroRole : PivotTarget → Extraction.MacroRole
   | .agent => .agent
   | .patient => .patient
   | .locative => .oblique


### PR DESCRIPTION
Follow-up to #2317, resolving the collisions it exposed.

- `Extraction.ArgumentRole` → `Extraction.MacroRole` (its docstring's own term) — removes the second type named `ArgumentRole` in `Syntax/`; four stray imports of the new leaf dropped.
- `Syntax/ArgumentRole.lean` gains a tier-demarcation paragraph (coding slots vs `ArgumentStructure.ThetaRole`, pointing at the linking theories).
- `Person.prominence` rehomes to `Features/Person/Basic.lean` (the owning API; its docstring already anticipated it); `Features/Prominence.lean` drops the Person import, and seven files that consumed `Person` transitively now import it directly.