### PR TITLE
feat(Syntax): verb argument slots; dissolve Extraction.MacroRole

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2809,6 +2809,7 @@ import Linglib.Syntax.Category.Pronoun.Indefinite
 import Linglib.Syntax.Category.Pronoun.IndefiniteParadigm
 import Linglib.Syntax.Category.Pronoun.Logophoric
 import Linglib.Syntax.Category.Pronoun.WALS
+import Linglib.Syntax.Category.Verb.Argument
 import Linglib.Syntax.Category.Verb.Basic
 import Linglib.Syntax.Category.Verb.Complement.Basic
 import Linglib.Syntax.Category.Verb.Complement.Takes

--- a/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Extraction.lean
@@ -67,8 +67,8 @@ def StatusSuffix.form : StatusSuffix → String
   | .tv  => "-V'"
 
 -- The substantive claim "A-extraction is banned without AF" is expressed
--- as `Extraction.Marked Extraction.realize .subject` (subject = .agent's
--- default position per `Extraction.MacroRole.defaultPosition`).
+-- as `Extraction.Marked Extraction.realize .subject` (the agent's position
+-- in the basic transitive clause).
 
 /-! ### Agent Focus construction -/
 

--- a/Linglib/Fragments/TobaBatak/Basic.lean
+++ b/Linglib/Fragments/TobaBatak/Basic.lean
@@ -47,7 +47,7 @@ inductive Voice where
   deriving Repr, DecidableEq
 
 /-- Which argument role is the pivot for a given voice? -/
-def Voice.pivotRole : Voice → Extraction.MacroRole
+def Voice.pivotRole : Voice → ThetaRole
   | .av => .agent
   | .ov => .patient
 
@@ -98,11 +98,6 @@ def avPatientExtraction : ExtractionDatum :=
   { voice := .av, extracted := .dpArg .patient, judgment := .ungrammatical
     description := "AV + patient (non-pivot): *'Aha man-uhor si Poltak?' (*What did Poltak buy?) [= (1a)/(8a)]" }
 
-/-- AV + oblique extraction: ungrammatical (oblique is never pivot). -/
-def avObliqueExtraction : ExtractionDatum :=
-  { voice := .av, extracted := .dpArg .oblique, judgment := .ungrammatical
-    description := "AV + oblique (non-pivot) [predicted, not directly tested in §2]" }
-
 /-- OV + patient extraction: grammatical (patient is pivot in OV). -/
 def ovPatientExtraction : ExtractionDatum :=
   { voice := .ov, extracted := .dpArg .patient, judgment := .grammatical
@@ -112,11 +107,6 @@ def ovPatientExtraction : ExtractionDatum :=
 def ovAgentExtraction : ExtractionDatum :=
   { voice := .ov, extracted := .dpArg .agent, judgment := .ungrammatical
     description := "OV + agent (non-pivot): *'Ise di-tuhor buku i?' (*Who bought the book?) [= (7b)]" }
-
-/-- OV + oblique extraction: ungrammatical (oblique is never pivot). -/
-def ovObliqueExtraction : ExtractionDatum :=
-  { voice := .ov, extracted := .dpArg .oblique, judgment := .ungrammatical
-    description := "OV + oblique (non-pivot) [predicted, not directly tested in §2]" }
 
 /-- AV + adjunct extraction: grammatical (adjuncts don't need Case). -/
 def avAdjunctExtraction : ExtractionDatum :=
@@ -130,8 +120,8 @@ def ovAdjunctExtraction : ExtractionDatum :=
 
 /-- All monoclausal extraction data. -/
 def extractionData : List ExtractionDatum :=
-  [ avAgentExtraction, avPatientExtraction, avObliqueExtraction
-  , ovPatientExtraction, ovAgentExtraction, ovObliqueExtraction
+  [ avAgentExtraction, avPatientExtraction
+  , ovPatientExtraction, ovAgentExtraction
   , avAdjunctExtraction, ovAdjunctExtraction ]
 
 -- ============================================================================

--- a/Linglib/Syntax/Category/Verb/Argument.lean
+++ b/Linglib/Syntax/Category/Verb/Argument.lean
@@ -1,0 +1,79 @@
+import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Category.Verb.Basic
+import Linglib.Semantics.ArgumentStructure.Linking
+
+/-!
+# Verb arguments
+
+`Verb.Argument`: an argument slot of a verb entry — core or oblique, with
+its proto-role entailment profile — read off the citation frame by
+`Verb.arguments`. The slots are the primitive; role labels are derived
+classifications of them: `Argument.thetaLabel` gives the Dowty cluster
+label, and `Verb.codingRoles` gives the comparative S/A/P/R/T
+classification, which is a function of the frame (A is *defined* as the
+more agent-like core argument of a two-place frame), never a stored
+feature.
+
+## References
+
+* [comrie-1978]
+* [dowty-1991]
+* [haspelmath-2021]
+-/
+
+open ArgumentStructure
+
+namespace Verb
+
+/-- An argument slot of a verb entry: whether the citation frame realizes
+    it as a core nominal or an oblique, and its proto-role entailment
+    profile (`none` when the entry leaves it unspecified). -/
+structure Argument where
+  /-- Core nominal (`true`) vs oblique/adpositional realization. -/
+  core : Bool
+  /-- Proto-role entailment profile. -/
+  entailments : Option EntailmentProfile := none
+  deriving Repr, BEq
+
+/-- Derived semantic-role label: the cluster label of the slot's
+    entailment profile (`EntailmentProfile.toRole`). -/
+def Argument.thetaLabel (a : Argument) : Option ThetaRole :=
+  a.entailments.bind EntailmentProfile.toRole
+
+/-- The argument slots of the entry's citation frame: the subject, the
+    nominal objects, then one oblique slot per adpositional position, with
+    entailments read from the entry (object entailments sit on the theme —
+    the sole object of a monotransitive, the second object of a
+    double-object frame). Clausal complements are not argument slots here;
+    they stay in the `frames`/`readings` API. -/
+def arguments (v : Verb) : List Argument :=
+  let frame := v.frames.head?.getD []
+  let nominals := frame.countP (· == Complement.Position.nominal)
+  let subj : Argument := ⟨true, v.effectiveSubjectEntailments⟩
+  let objects : List Argument :=
+    match nominals with
+    | 0 => []
+    | 1 => [⟨true, v.effectiveObjectEntailments⟩]
+    | _ => [⟨true, none⟩, ⟨true, v.effectiveObjectEntailments⟩]
+  let obliques : List Argument :=
+    (frame.filter (· == Complement.Position.adpositional)).map
+      (fun _ => ⟨false, none⟩)
+  subj :: objects ++ obliques
+
+/-- The core argument slots of the citation frame. -/
+def coreArguments (v : Verb) : List Argument :=
+  v.arguments.filter (·.core)
+
+/-- The derived comparative classification of the core slots, positionally
+    parallel to `coreArguments` ([comrie-1978]): the sole core argument of
+    a one-place frame is S; a two-place frame has A and P; a double-object
+    frame has A, R, and T. A function of the frame's arity — coding roles
+    are read off argument structure, not assigned to it. -/
+def codingRoles (v : Verb) : List ArgumentRole :=
+  match v.coreArguments.length with
+  | 0 => []
+  | 1 => [.S]
+  | 2 => [.A, .P]
+  | _ => [.A, .R, .T]
+
+end Verb

--- a/Linglib/Syntax/Extraction.lean
+++ b/Linglib/Syntax/Extraction.lean
@@ -1,4 +1,5 @@
 import Linglib.Features.Reflex
+import Linglib.Semantics.ArgumentStructure.Linking
 
 /-!
 # Extraction Morphology
@@ -86,40 +87,15 @@ inductive ExtractionTarget where
   | possessor
   deriving DecidableEq, Repr
 
-/-- The thematic category of an argument being extracted: agent
-    (external argument), patient (internal argument), or oblique.
-
-    Coarser than `ThetaRole` (which distinguishes agent/experiencer/
-    causer, patient/theme, goal/source/instrument). Used when the
-    relevant distinction is which macro-role is extracted, not fine-
-    grained thematic relations or structural positions.
-
-    Complements `ExtractionTarget` (structural position): MacroRole
-    identifies *what* is extracted; ExtractionTarget identifies *where*
-    it was extracted. The two coincide in simple active clauses
-    (agent = subject, patient = object) but diverge under voice
-    alternation (in OV, the patient becomes the subject). -/
-inductive MacroRole where
-  | agent    -- external argument (agent, experiencer, causer)
-  | patient  -- internal argument (patient, theme)
-  | oblique  -- oblique argument (instrument, goal, source, etc.)
-  deriving DecidableEq, Repr
-
-/-- Default structural position for a given argument role (active voice). -/
-def MacroRole.defaultPosition : MacroRole → ExtractionTarget
-  | .agent => .subject
-  | .patient => .directObject
-  | .oblique => .oblique
-
-/-- What is being extracted: a DP argument (which has a thematic role
-    and needs Case licensing) or a non-DP adjunct (which has no
-    thematic role and is Case-exempt).
+/-- What is being extracted: a DP argument, identified by its
+    `ThetaRole` label (it needs Case licensing), or a
+    non-DP adjunct (no thematic role, Case-exempt).
 
     This distinction drives the DP/non-DP extraction asymmetry: in
     predicate-fronting languages like Toba Batak, only DP extraction
     is restricted to the pivot; adjuncts extract freely. -/
 inductive Extractee where
-  | dpArg : MacroRole → Extractee
+  | dpArg : ThetaRole → Extractee
   | adjunct : Extractee
   deriving DecidableEq, Repr
 

--- a/Linglib/Syntax/Voice/Basic.lean
+++ b/Linglib/Syntax/Voice/Basic.lean
@@ -17,7 +17,7 @@ operate on the voice list.
 
 ## Main definitions
 
-* `PivotTarget` : the role a voice promotes to pivot (finer than `Extraction.MacroRole`).
+* `PivotTarget` : the role a voice promotes to pivot.
 * `VoiceEntry`, `VoiceSystemSymmetry` : one voice (name + promoted role); system symmetry.
 * `Voice.voiceCount` / `promotesRole` / `distinguishesObliques` / `isActivePassive`
   / `promotableRoles` : queries over a language's `List VoiceEntry`.
@@ -27,9 +27,9 @@ namespace Voice
 
 /-! ### Pivot target -/
 
-/-- Which argument role a voice promotes to pivot. Finer-grained than
-    `Extraction.MacroRole`: Philippine-type systems distinguish locative,
-    instrumental, benefactive, and circumstantial pivots, all collapsing to oblique. -/
+/-- Which argument a voice promotes to pivot. Philippine-type systems
+    distinguish locative, instrumental, benefactive, and circumstantial
+    pivots alongside agent and patient voices. -/
 inductive PivotTarget where
   | agent
   | patient
@@ -38,15 +38,6 @@ inductive PivotTarget where
   | benefactive
   | circumstantial
   deriving DecidableEq, Repr
-
-/-- Coarsen a `PivotTarget` to an `Extraction.MacroRole` (obliques collapse). -/
-def PivotTarget.toMacroRole : PivotTarget → Extraction.MacroRole
-  | .agent => .agent
-  | .patient => .patient
-  | .locative => .oblique
-  | .instrumental => .oblique
-  | .benefactive => .oblique
-  | .circumstantial => .oblique
 
 /-! ### Voice entry and symmetry -/
 


### PR DESCRIPTION
The argument-structure consolidation carrier, with the first selector-enum dissolution riding along (supersedes #2319).

- `Verb.Argument` (`Syntax/Category/Verb/Argument.lean`): core-or-oblique slots with entailment profiles, read off the citation frame by `Verb.arguments`. Role labels are *derived* classifications — `Argument.thetaLabel` (Dowty cluster), `Verb.codingRoles` (comparative S/A/P/R/T as a function of frame arity) — mirroring Linking.lean's profile-primitive/label-derived split; nothing stores a role feature.
- `Extraction.MacroRole` dissolved: `Extractee.dpArg` now carries a `ThetaRole` label; the unused `defaultPosition` and `PivotTarget` coarsening hom die; Toba Batak's two "[predicted, not directly tested]" oblique rows are cut rather than given fabricated labels.