### PR TITLE
refactor(Syntax/Voice): rename TRRole to TermRole

### DIFF
--- a/Linglib/Studies/Chierchia1984.lean
+++ b/Linglib/Studies/Chierchia1984.lean
@@ -406,7 +406,7 @@ open Voice
     Subject control: A is the controller (the subject has property P).
     Object control: P is the controller (the object has property P).
     Raising/none: no semantic controller (the CP does not apply). -/
-def controllerRole : ControlType → Option TRRole
+def controllerRole : ControlType → Option TermRole
   | .subjectControl => some .A
   | .objectControl  => some .P
   | .raising        => none

--- a/Linglib/Studies/Creissels2025.lean
+++ b/Linglib/Studies/Creissels2025.lean
@@ -415,7 +415,7 @@ open FreeMonoid (lift of)
 /-- A term's coding status in a construction (a *state*; `ParticipantFate` is the
     *transition*, derived below via `fateOf`). -/
 inductive Coding
-  | core (r : TRRole)
+  | core (r : TermRole)
   | oblique
   | suppressed
   deriving DecidableEq
@@ -448,31 +448,31 @@ def normalizeFrame (f : CodingFrame) : CodingFrame :=
 
 def freshId (f : CodingFrame) : Nat := f.foldl (fun m t => Nat.max m (t.id + 1)) 0
 
-def setFirstCore (r : TRRole) (c : Coding) : CodingFrame → Option CodingFrame
+def setFirstCore (r : TermRole) (c : Coding) : CodingFrame → Option CodingFrame
   | [] => none
   | t :: ts =>
     if t.coding = .core r then some (⟨t.id, c⟩ :: ts)
     else (setFirstCore r c ts).map (t :: ·)
 
-def removeFirstCore (r : TRRole) : CodingFrame → Option CodingFrame
+def removeFirstCore (r : TermRole) : CodingFrame → Option CodingFrame
   | [] => none
   | t :: ts =>
     if t.coding = .core r then some ts
     else (removeFirstCore r ts).map (t :: ·)
 
 /-- Some core term in the frame bears role `r`. -/
-def HasCore (r : TRRole) (f : CodingFrame) : Prop := ∃ t ∈ f, t.coding = .core r
+def HasCore (r : TermRole) (f : CodingFrame) : Prop := ∃ t ∈ f, t.coding = .core r
 
-instance (r : TRRole) (f : CodingFrame) : Decidable (HasCore r f) :=
+instance (r : TermRole) (f : CodingFrame) : Decidable (HasCore r f) :=
   inferInstanceAs (Decidable (∃ t ∈ f, t.coding = .core r))
 
 /-- The atomic voice operations: Creissels's nucleativization /
     denucleativization (§8.1.3) plus cumulation (reflexivization, §8.3.3). -/
 inductive Atom
-  | nucleativize (target : TRRole)  -- a non-core participant becomes core   (+1)
-  | denucleativize (role : TRRole)  -- core role → oblique (kept)             (−1)
-  | suppress (role : TRRole)        -- core role → suppressed (removed)       (−1)
-  | cumulate (r1 r2 : TRRole)       -- merge two cores into one               (−1)
+  | nucleativize (target : TermRole)  -- a non-core participant becomes core   (+1)
+  | denucleativize (role : TermRole)  -- core role → oblique (kept)             (−1)
+  | suppress (role : TermRole)        -- core role → suppressed (removed)       (−1)
+  | cumulate (r1 r2 : TermRole)       -- merge two cores into one               (−1)
   deriving DecidableEq
 
 /-- An alternation as a word over atoms; composition = the free-monoid product
@@ -543,7 +543,7 @@ def fateOf : Coding → Coding → ParticipantFate
   | _, _ => .maintained
 
 /-- Id of the participant currently in core role `r` (frame-relative). -/
-def roleHolder (r : TRRole) : CodingFrame → Option Nat
+def roleHolder (r : TermRole) : CodingFrame → Option Nat
   | [] => none
   | t :: ts => if t.coding = .core r then some t.id else roleHolder r ts
 

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -39,7 +39,7 @@ as *constructional* properties of nominal terms, not semantic roles. A is
 "the nominal term whose coding matches the agent of a prototypical transitive
 verb" — it's defined by coding (flagging, indexation, order), anchored to
 semantic prototypes. These are already captured by `ArgumentRole`
-(S, A, P, R, T). This file adds X (oblique) as a `TRRole` that extends
+(S, A, P, R, T). This file adds X (oblique) as a `TermRole` classifying
 `ArgumentRole` with the non-core case.
 
 ## Nucleativization and Denucleativization
@@ -68,25 +68,24 @@ namespace Voice
 open ArgumentStructure (DiathesisAlternation)
 
 -- ════════════════════════════════════════════════════
--- § 1. TR-Roles (§1.3.3)
+-- § 1. Nominal-term roles (§1.3.3)
 -- ════════════════════════════════════════════════════
 
-/-- Transitivity-Related role including obliques.
-
-    Extends `ArgumentRole` (S, A, P, R, T) with X for obliques.
+/-- Role of a nominal term of a verbal clause in [creissels-2025]'s binary
+    core-term system: the core roles S, A, P, plus X for obliques.
     §1.3.3: "OBLIQUE NOMINAL TERMS (or simply OBLIQUES),
     symbolized as X, are defined as nominal terms of verbal clauses that do
     not meet the definition of either A, P, or S." -/
-inductive TRRole where
+inductive TermRole where
   | S    -- sole core term of intransitive clause
   | A    -- agent-like core term of transitive clause
   | P    -- patient-like core term of transitive clause
   | X    -- oblique (non-core term)
   deriving DecidableEq, Repr
 
-/-- Convert `ArgumentRole` to `TRRole`. R and T map to P (both are
+/-- Convert `ArgumentRole` to `TermRole`. R and T map to P (both are
     P-like in Creissels' binary core-term system). -/
-def TRRole.ofArgumentRole : ArgumentRole → TRRole
+def TermRole.ofArgumentRole : ArgumentRole → TermRole
   | .S => .S
   | .A => .A
   | .P => .P
@@ -104,7 +103,7 @@ def TRRole.ofArgumentRole : ArgumentRole → TRRole
 inductive ParticipantFate where
   /-- Participant is nucleativized: becomes a core term in the derived
       construction. The `target` specifies which TR-role it acquires. -/
-  | nucleativized (target : TRRole)
+  | nucleativized (target : TermRole)
   /-- Participant is denucleativized: demoted from core term to oblique or
       unexpressed, but MAINTAINED IN PARTICIPANT STRUCTURE. The participant
       is still semantically present and may appear as an oblique phrase.
@@ -175,7 +174,7 @@ structure ValencyAlternation where
   fateOfS : ParticipantFate
   /-- Is a new participant introduced in the derived construction?
       If so, which TR-role does it receive? -/
-  newParticipant : Option TRRole
+  newParticipant : Option TermRole
   /-- Is the initial construction transitive, intransitive, or either? -/
   initialTransitive : Option Bool
   /-- Is the derived construction transitive? -/
@@ -443,7 +442,7 @@ structure VoiceMarkerProfile where
 -- ════════════════════════════════════════════════════
 
 /-- Look up what this alternation does to a given TR-role. -/
-def ValencyAlternation.fateOfRole (va : ValencyAlternation) : TRRole → ParticipantFate
+def ValencyAlternation.fateOfRole (va : ValencyAlternation) : TermRole → ParticipantFate
   | .A => va.fateOfA
   | .P => va.fateOfP
   | .S => va.fateOfS


### PR DESCRIPTION
Creissels's S/A/P/X classification of nominal terms keeps its anchoring (§1.3.3 quote, `ofArgumentRole` hom) but loses the project acronym: `TRRole` → `TermRole` across its three files.