### PR TITLE
refactor(Syntax/Clause): rehome ArgumentRole; clause-token codingRole

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2772,7 +2772,6 @@ import Linglib.Syntax.Agreement.Profile
 import Linglib.Syntax.Agreement.Target
 import Linglib.Syntax.Anaphora.Basic
 import Linglib.Syntax.Anaphora.Diagnostic
-import Linglib.Syntax.ArgumentRole
 import Linglib.Syntax.Binding.Basic
 import Linglib.Syntax.Binding.Semantics
 import Linglib.Syntax.Binding.SpecificityCondition
@@ -2817,6 +2816,7 @@ import Linglib.Syntax.Category.Verb.Defs
 import Linglib.Syntax.Category.Verb.Reciprocal
 import Linglib.Syntax.Category.Verb.Stem
 import Linglib.Syntax.Category.Verb.Symmetric
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Syntax.Clause.Arguments
 import Linglib.Syntax.Clause.Basic
 import Linglib.Syntax.Clause.Chaining

--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -3,7 +3,7 @@ import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Chol Agreement and Case Fragment

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -2,7 +2,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 /-!

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -5,7 +5,7 @@ import Linglib.Features.Number.Capabilities
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Extraction
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 /-!

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -5,7 +5,7 @@ import Linglib.Fragments.Mayan.Mam.Pronouns
 import Linglib.Fragments.Mayan.Params
 import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Syntax.Extraction
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 /-!

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -7,7 +7,7 @@ import Linglib.Syntax.Agreement.Paradigm
 import Linglib.Morphology.Morph
 import Linglib.Morphology.Word.Basic
 import Linglib.Morphology.Morphotactics.Template
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 open Morphology (Word)

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -1,7 +1,7 @@
 import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Q'anjob'al Agreement and Case Fragment

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -2,7 +2,7 @@ import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Tseltal Agreement Fragment

--- a/Linglib/Fragments/Mayan/Tseltalan.lean
+++ b/Linglib/Fragments/Mayan/Tseltalan.lean
@@ -1,6 +1,6 @@
 import Linglib.Fragments.Mayan.Params
 import Linglib.Features.Prominence
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Shared Tseltalan Infrastructure

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -2,7 +2,7 @@ import Linglib.Fragments.Mayan.Tseltalan
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Reflex
 import Linglib.Syntax.Extraction
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Tsotsil Agreement Fragment

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -2,7 +2,7 @@ import Linglib.Features.Case.Basic
 import Linglib.Phonology.Segmental.Defs
 import Linglib.Features.Prominence
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Yucatec Maya Agreement Fragment

--- a/Linglib/Semantics/ArgumentStructure/Valency.lean
+++ b/Linglib/Semantics/ArgumentStructure/Valency.lean
@@ -2,7 +2,7 @@ import Linglib.Features.Prominence
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Powerset
 import Mathlib.Tactic.DeriveFintype
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Valency

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -6,7 +6,7 @@ import Linglib.Fragments.Hindi.Case
 import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Mayan.Chol.Agreement
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Baker (2015) — Case: Its Principles and Its Parameters

--- a/Linglib/Studies/Comrie1989.lean
+++ b/Linglib/Studies/Comrie1989.lean
@@ -5,7 +5,7 @@ import Linglib.Syntax.Case.Alignment
 import Linglib.Studies.Dixon1994
 import Linglib.Studies.Aissen2003
 import Linglib.Fragments.Dargwa.ComplexPredicates
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 /-!

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -14,7 +14,7 @@ import Linglib.Fragments.Mayan.Mam.Extraction
 import Linglib.Fragments.Mayan.Kiche.Agreement
 import Linglib.Fragments.Mayan.Kiche.Extraction
 import Linglib.Fragments.Mayan.Yukatek.Agreement
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Coon, Mateo Pedro & Preminger (2014) [coon-mateo-pedro-preminger-2014]

--- a/Linglib/Studies/Dixon1994.lean
+++ b/Linglib/Studies/Dixon1994.lean
@@ -4,7 +4,7 @@ import Linglib.Syntax.Case.Alignment
 import Linglib.Fragments.Dargwa.Case
 import Linglib.Fragments.Japanese.Case
 import Linglib.Fragments.Hindi.Case
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Dixon (1994): Ergativity — typology + Silverstein hierarchy + ditransitives

--- a/Linglib/Studies/Haspelmath2021.lean
+++ b/Linglib/Studies/Haspelmath2021.lean
@@ -5,7 +5,7 @@ import Linglib.Studies.Aissen2003
 import Linglib.Studies.DeHoopMalchukov2008
 import Linglib.Studies.Marantz1991
 import Linglib.Syntax.Case.Alignment
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # [haspelmath-2021]: Role-reference associations and the explanation of argument coding splits

--- a/Linglib/Studies/Imanishi2014.lean
+++ b/Linglib/Studies/Imanishi2014.lean
@@ -1,6 +1,6 @@
 import Linglib.Syntax.Case.Alignment
 import Linglib.Fragments.Mayan.Params
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Imanishi 2014 — Default Ergative [imanishi-2014]

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -4,7 +4,7 @@ import Linglib.Fragments.Mayan.Kaqchikel.Agreement
 import Linglib.Fragments.Basque.Agreement
 import Linglib.Fragments.Georgian.Agreement
 import Linglib.Fragments.Hungarian.Predicates
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Features.Person.Basic
 
 /-!

--- a/Linglib/Syntax/Case/Alignment.lean
+++ b/Linglib/Syntax/Case/Alignment.lean
@@ -6,7 +6,7 @@ Authors: Robert Hawkins
 import Linglib.Features.Case.Basic
 import Linglib.Features.Prominence
 import Mathlib.Data.Fintype.Prod
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Alignment Case-Assignment Functions

--- a/Linglib/Syntax/Category/Verb/Argument.lean
+++ b/Linglib/Syntax/Category/Verb/Argument.lean
@@ -1,4 +1,4 @@
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 import Linglib.Syntax.Category.Verb.Basic
 import Linglib.Semantics.ArgumentStructure.Linking
 
@@ -68,7 +68,10 @@ def coreArguments (v : Verb) : List Argument :=
     parallel to `coreArguments` ([comrie-1978]): the sole core argument of
     a one-place frame is S; a two-place frame has A and P; a double-object
     frame has A, R, and T. A function of the frame's arity — coding roles
-    are read off argument structure, not assigned to it. -/
+    are read off argument structure, not assigned to it. This classifies
+    the *citation clause*; the general clause-token classification is
+    `Clause.Arguments.codingRole` (a passive clause of the same verb has
+    an S). -/
 def codingRoles (v : Verb) : List ArgumentRole :=
   match v.coreArguments.length with
   | 0 => []

--- a/Linglib/Syntax/Clause/ArgumentRole.lean
+++ b/Linglib/Syntax/Clause/ArgumentRole.lean
@@ -2,10 +2,13 @@
 # Comparative argument roles
 
 `ArgumentRole`: the S/A/P/R/T comparative concepts for argument coding,
-neutral between case and agreement. `ArgumentRole.core` is the
-monotransitive core that alignment partitions quantify over;
-`IsHighDefault`/`IsLowDefault` classify the roles by their usual
-referential prominence (the role-reference association).
+neutral between case and agreement. The *clause* takes the classification
+— a passive clause's sole argument is S whatever the predicate calls it —
+so the label set lives with the clause vocabulary; `Clause.Arguments.codingRole`
+classifies clause tokens and `Verb.codingRoles` the citation clause.
+`ArgumentRole.core` is the monotransitive core that alignment partitions
+quantify over; `IsHighDefault`/`IsLowDefault` classify the roles by their
+usual referential prominence (the role-reference association).
 
 Distinct from the semantic tier (`ArgumentStructure.ThetaRole`, the Dowty
 proto-role profiles): S/A/P/R/T are construction-relative coding slots —

--- a/Linglib/Syntax/Clause/Arguments.lean
+++ b/Linglib/Syntax/Clause/Arguments.lean
@@ -1,4 +1,5 @@
 import Linglib.Semantics.ArgumentStructure.Valency
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Core arguments of a clause token
@@ -13,6 +14,9 @@ position. The filled positions are the clause's valency.
 * `Clause.Arguments.unaccusative`, `unergative`, `transitive`, `empty` — the
   clause shapes by which positions are filled.
 * `Clause.Arguments.valency` — the filled positions.
+* `Clause.Arguments.codingRole` — the comparative S/A/P classification of
+  a filled position; the clause, not the predicate, takes the
+  classification.
 
 ## Main results
 
@@ -54,6 +58,25 @@ def empty : Arguments α := fun _ => none
 
 /-- The filled positions. -/
 def valency (c : Arguments α) : Valency := Finset.univ.filter fun p => (c p).isSome
+
+/-- The comparative classification of a filled position — the *clause*
+    takes the classification: the sole argument of a one-place clause is S;
+    in a two-place clause the external argument is A and the internal P.
+    `Verb.codingRoles` is the special case classifying a verb entry's
+    citation clause. -/
+def codingRole (c : Arguments α) : ArgPosition → Option ArgumentRole
+  | .external => (c .external).map fun _ => if (c .internal).isSome then .A else .S
+  | .internal => (c .internal).map fun _ => if (c .external).isSome then .P else .S
+
+@[simp] theorem codingRole_unaccusative :
+    (unaccusative x).codingRole .internal = some .S := rfl
+
+@[simp] theorem codingRole_unergative :
+    (unergative x).codingRole .external = some .S := rfl
+
+@[simp] theorem codingRole_transitive :
+    (transitive obj subj).codingRole .external = some .A ∧
+    (transitive obj subj).codingRole .internal = some .P := ⟨rfl, rfl⟩
 
 @[simp] theorem valency_unaccusative : (unaccusative x).valency = {.internal} := by
   ext p; cases p <;> simp [valency, unaccusative]

--- a/Linglib/Syntax/Voice/Alternation.lean
+++ b/Linglib/Syntax/Voice/Alternation.lean
@@ -1,6 +1,6 @@
 import Linglib.Features.Prominence
 import Linglib.Semantics.ArgumentStructure.DiathesisAlternation
-import Linglib.Syntax.ArgumentRole
+import Linglib.Syntax.Clause.ArgumentRole
 
 /-!
 # Valency Alternation Typology


### PR DESCRIPTION
The clause, not the predicate, takes the S/A/P/R/T classification (a passive clause's sole argument is S whatever the predicate calls it), so the label set moves to `Syntax/Clause/ArgumentRole.lean` beside the clause-argument machinery.

- `Clause.Arguments.codingRole`: the primary clause-token classification (sole filled position → S; filled pair → A/P), with shape lemmas.
- `Verb.codingRoles` re-documented as the citation-clause special case.
- Move-PR: 22 import sites updated; local full build is green.