### PR TITLE
refactor(Fragments/Mayan): drop ArgPosition aliases; call real case API

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -18,8 +18,9 @@ intransitive subjects in non-perfective. The formal-syntactic analyses of
 
 ## Main declarations
 
-* `Chol.ArgPosition` with `.case`, `.accCase`: argument positions and
-  their perfective (ergative) and non-perfective (extended-ergative) case.
+* Case assignment over `ArgumentRole` via `Mayan.ergCaseChol`
+  (perfective, ergative) and `Mayan.accCaseChol` (non-perfective,
+  extended-ergative).
 * `Chol.absPosition`: LOW-ABS morpheme placement.
 * `Chol.setAExponent`, `Chol.setBExponent`: the Set A (ERG/GEN) and Set B
   (ABS) exponent tables ([vazquez-alvarez-2011] Table 10).
@@ -97,8 +98,8 @@ Per [vazquez-alvarez-2011] §1.9.4, Chol exhibits all
 four Dixon alignment types: ergative-absolutive, nominative-accusative, **Split-S**
 (some intransitives obligatorily Sa = Set A on light verb *cha'l*; others
 obligatorily So = Set B), and **Fluid-S** (verbs like *wäy* 'sleep' that
-take either Set A or Set B). The current `ArgPosition.intranS` collapses
-Sa/So/fluid-S into a single intransitive subject category — sufficient
+take either Set A or Set B). The single S cell of `ArgumentRole` collapses
+Sa/So/fluid-S into one intransitive subject category — sufficient
 for the perfective↔non-perfective split formalization but undermodels
 the agentive split. Future refinement: split into `intranSAgentive` /
 `intranSPatientive` / `intranSFluid`.
@@ -111,18 +112,6 @@ namespace Chol
 open Mayan (ExponentTable)
 
 /-! ### Argument positions -/
-
-/-- Argument positions in a Chol clause, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Perfective (ergative) case assignment: `Mayan.ergCaseChol`
-    (A → ERG, S/P → ABS). -/
-abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseChol
-
-/-- Non-perfective (extended-ergative) case assignment: `Mayan.accCaseChol`
-    (S/A → GEN, P → ABS), shared with Q'anjob'al. -/
-abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseChol
 
 /-! ### Absolutive position (LOW-ABS) -/
 

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -24,8 +24,8 @@ collapse to a single marker drawn from the Set B paradigm.
 * `Kaqchikel.setAExponent`, `Kaqchikel.setBExponent`: the Set A (ERG)
   and Set B (ABS) exponent tables ([preminger-2014] table (29)).
 * `Kaqchikel.absPosition`: HIGH-ABS morpheme placement.
-* `Kaqchikel.ArgPosition` with `.case`, `.accCase`, `.IsPhiAgreed`:
-  argument positions, their case wiring, and the (non-differential)
+* Case assignment over `ArgumentRole` via `Mayan.ergCaseKaqchikel` and
+  `Mayan.accCaseKaqchikel`; `IsPhiAgreed` records the (non-differential)
   φ-agreement status of each position.
 * `Kaqchikel.caseInventory`: the {ERG, ABS} case inventory, validated
   against [blake-1994]'s hierarchy.
@@ -89,27 +89,13 @@ def setBExponent : ExponentTable :=
 
 /-! ### Argument positions -/
 
-/-- Argument positions, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Perfective (ergative) case assignment: `Mayan.ergCaseKaqchikel`
-    (A → ERG, S/P → ABS). -/
-abbrev ArgPosition.case : ArgPosition → Case :=
-  Mayan.ergCaseKaqchikel
-
-/-- Non-perfective (PROG *ajin*) case assignment: `Mayan.accCaseKaqchikel`
-    (S/A → ABS, P → ERG/GEN, per [imanishi-2014]). -/
-abbrev ArgPosition.accCase : ArgPosition → Case :=
-  Mayan.accCaseKaqchikel
-
 /-- Every position triggers φ-agreement — Kaqchikel is non-differential
-    (contrast `Mam.ArgPosition.IsPhiAgreed`); R/T default to
+    (contrast `Mam.IsPhiAgreed`); R/T default to
     participating. -/
-def ArgPosition.IsPhiAgreed : ArgPosition → Prop
+def IsPhiAgreed : ArgumentRole → Prop
   | .A | .P | .S | .R | .T => True
 
-instance : DecidablePred ArgPosition.IsPhiAgreed := fun p =>
+instance : DecidablePred IsPhiAgreed := fun p =>
   match p with
   | .A | .P | .S | .R | .T => isTrue trivial
 
@@ -120,35 +106,35 @@ family-level statement is
 `CoonMateoPedroPreminger2014.mayan_perfective_ergative`. -/
 
 /-- Agent gets ERG (from Voice). -/
-theorem A_case : ArgPosition.case .A = .erg := Alignment.ergative.assignCase_A
+theorem A_case : Mayan.ergCaseKaqchikel .A = .erg := Alignment.ergative.assignCase_A
 
 /-- Patient gets ABS (from Infl). -/
-theorem P_case : ArgPosition.case .P = .abs := Alignment.ergative.assignCase_P
+theorem P_case : Mayan.ergCaseKaqchikel .P = .abs := Alignment.ergative.assignCase_P
 
 /-- Intransitive S gets ABS (from Infl). -/
-theorem S_case : ArgPosition.case .S = .abs := Alignment.ergative.assignCase_S
+theorem S_case : Mayan.ergCaseKaqchikel .S = .abs := Alignment.ergative.assignCase_S
 
 /-- Ergative-absolutive alignment: the agent is distinguished (ERG)
     while patient and intranS share a case value (ABS). -/
 theorem erg_abs_alignment :
-    ArgPosition.case .A ≠ ArgPosition.case .P ∧
-    ArgPosition.case .P = ArgPosition.case .S :=
+    Mayan.ergCaseKaqchikel .A ≠ Mayan.ergCaseKaqchikel .P ∧
+    Mayan.ergCaseKaqchikel .P = Mayan.ergCaseKaqchikel .S :=
   Alignment.ergative_distinguishes_A
 
 /-- All core argument positions trigger φ-agreement. -/
-theorem all_positions_agreed (p : ArgPosition) (_ : p ∈ ArgumentRole.core) :
-    ArgPosition.IsPhiAgreed p := by
+theorem all_positions_agreed (p : ArgumentRole) (_ : p ∈ ArgumentRole.core) :
+    IsPhiAgreed p := by
   cases p <;> trivial
 
 /-! ### Case inventory ([blake-1994]) -/
 
 /-- The case inventory realized by the core positions: {ERG, ABS}. -/
-def caseInventory : Finset Case := (ArgumentRole.core.map ArgPosition.case).toFinset
+def caseInventory : Finset Case := (ArgumentRole.core.map Mayan.ergCaseKaqchikel).toFinset
 
 /-- The inventory covers all argument positions: every position's case
     is in the inventory. -/
 theorem inventory_covers_positions :
-    ∀ p ∈ ArgumentRole.core, ArgPosition.case p ∈ caseInventory := by decide
+    ∀ p ∈ ArgumentRole.core, Mayan.ergCaseKaqchikel p ∈ caseInventory := by decide
 
 -- Kaqchikel's {ERG, ABS} inventory is valid per Blake's case hierarchy
 -- (both are core cases at the top `hierarchyRank`, trivially no gaps).

--- a/Linglib/Fragments/Mayan/Kaqchikel/Focus.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Focus.lean
@@ -56,14 +56,14 @@ inductive FocusSite where
     S fronts like A but intransitive verbs have no AF form. Ditransitive
     R/T focus is unattested in the source and falls to the A-less
     default. -/
-def focusRealize : ArgPosition → Marking FocusSite
+def focusRealize : ArgumentRole → Marking FocusSite
   | .A => ⟨.focusPhrase,
            [.displacement .focusPhrase, .morpheme .focusPhrase, .morpheme .verb]⟩
   | _  => ⟨.focusPhrase, [.displacement .focusPhrase, .morpheme .focusPhrase]⟩
 
 /-- The verb-hosted reflex (AF) appears under transitive-subject focus
     only. -/
-theorem af_reflex_iff (p : ArgPosition) :
+theorem af_reflex_iff (p : ArgumentRole) :
     Reflex.morpheme FocusSite.verb ∈ (focusRealize p).reflexes ↔ p = .A := by
   cases p <;> decide
 

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -28,7 +28,7 @@ inverted alignment.
 * `Kiche.setBMarker`, `Kiche.setAPreC`, `Kiche.setAPreV`: the Set B
   (absolutive) and Set A (ergative, pre-consonantal / pre-vocalic)
   exponents.
-* `Kiche.ArgPosition.agreementSet`, `Kiche.ArgPosition.case`: the
+* `Kiche.agreementSet`, `Kiche.Mayan.ergCaseKiche`: the
   agreement set and case each argument position triggers.
 * `Kiche.independentPronoun`: the free personal pronouns.
 * `Kiche.setAExponent`, `Kiche.setBExponent`: canonical φ-cell exponent
@@ -160,12 +160,6 @@ instance (φ : PhiFeatures) : Decidable (SetAIsPrefix φ) :=
 
 /-! ### Argument positions and alignment -/
 
-/-- Argument positions in a K'iche' clause. Aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T) so cross-Mayan and
-    cross-framework code shares one inventory. Use the canonical
-    constructor names `.A` / `.P` / `.S` directly. -/
-abbrev ArgPosition := ArgumentRole
-
 /-- Which agreement set cross-references each argument position? -/
 inductive AgreementSet where
   | setA  -- Ergative markers
@@ -177,32 +171,26 @@ inductive AgreementSet where
     S and P both trigger Set B (= absolutive grouping).
     A triggers Set A (= ergative). Ditransitive R/T default to `.none`
     (not modeled in this fragment). -/
-def ArgPosition.agreementSet : ArgPosition → AgreementSet
+def agreementSet : ArgumentRole → AgreementSet
   | .A => .setA  -- A → Set A (ergative)
   | .P => .setB  -- P → Set B (absolutive)
   | .S => .setB  -- S → Set B (absolutive)
   | .R | .T => .none
-
-/-- The case associated with each argument position. Definitionally
-    equal to `Mayan.ergCaseKiche`, which derives from
-    `Alignment.ergative.assignCase` in `Syntax/Case/Alignment.lean`. -/
-abbrev ArgPosition.case : ArgPosition → Case :=
-  Mayan.ergCaseKiche
 
 /-! ### Alignment theorems -/
 
 /-- K'iche' groups S and P together (both trigger Set B):
     ergative-absolutive alignment. -/
 theorem ergative_absolutive_alignment :
-    ArgPosition.agreementSet .S = ArgPosition.agreementSet .P ∧
-    ArgPosition.agreementSet .A ≠ ArgPosition.agreementSet .P :=
+    agreementSet .S = agreementSet .P ∧
+    agreementSet .A ≠ agreementSet .P :=
   ⟨rfl, by decide⟩
 
 /-- A receives ERG while P and S share a case (ABS) — the ergative
     partition, re-exported from `Alignment.ergative_distinguishes_A`. -/
 theorem erg_abs_pattern :
-    ArgPosition.case .A ≠ ArgPosition.case .P ∧
-    ArgPosition.case .P = ArgPosition.case .S :=
+    Mayan.ergCaseKiche .A ≠ Mayan.ergCaseKiche .P ∧
+    Mayan.ergCaseKiche .P = Mayan.ergCaseKiche .S :=
   Alignment.ergative_distinguishes_A
 
 /-- K'iche' alignment contrast with Mam: K'iche' is ergative-absolutive
@@ -210,7 +198,7 @@ theorem erg_abs_pattern :
     receive distinct cases). In K'iche', both P and S trigger Set B;
     in Mam, P triggers no agreement at all. -/
 theorem kiche_not_tripartite :
-    ArgPosition.case .S = ArgPosition.case .P := rfl
+    Mayan.ergCaseKiche .S = Mayan.ergCaseKiche .P := rfl
 
 /-! ### Set B per-cell verification -/
 

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -27,9 +27,9 @@ as a more formal variant ([scott-2023] ch. 3, ex. 156).
 
 * `Mam.setAExponent`, `Mam.setBExponent`: the Set A (ERG) and Set B
   (ABS) exponent tables ([scott-2023] Tables 2.8, 3.5).
-* `Mam.ArgPosition` with `.case`, `.IsPhiAgreed`, `.CanBeReduced`:
-  argument positions, their tripartite case values, φ-agreement status,
-  and reduction eligibility.
+* Tripartite case assignment via `Mayan.ergCaseMam`; `IsPhiAgreed` and
+  `CanBeReduced` classify each `ArgumentRole` by φ-agreement status and
+  reduction eligibility.
 * `Mam.PhiDimension` with `.Copied`, `agreedDimensions`,
   `baseDimensions`, `encliticDimensions`: the φ-feature redundancy
   calculus behind pronoun reduction.
@@ -111,28 +111,18 @@ def defaultSetB : List Morphology.Morph := [.procl "tz'"]
 
 /-! ### Argument positions and agreement status -/
 
-/-- Argument positions, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T) ([scott-2023] ch. 3). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Tripartite case assignment: `Mayan.ergCaseMam` (A → ERG inherent
-    from Voice, P → ACC structural from Voice, S → ABS structural from
-    Infl; [scott-2023] ch. 3 §3.4). -/
-abbrev ArgPosition.case : ArgPosition → Case :=
-  Mayan.ergCaseMam
-
 /-- Whether a position triggers φ-Agree. A is probed by Voice (→ Set A),
     S by Infl (→ Set B); the transitive patient is not, because Infl's
     φ-probe has a disjunctive satisfaction condition [SAT: φ or Voice_TR]
     and stops at transitive Voice before copying features, so default Set
     B surfaces. R/T default to participating (not modeled). -/
-def ArgPosition.IsPhiAgreed : ArgPosition → Prop
+def IsPhiAgreed : ArgumentRole → Prop
   | .A => True   -- φ-Agreed by Voice → Set A
   | .P => False  -- NOT φ-Agreed: Infl probe blocked by Voice_TR
   | .S | .R | .T => True   -- S φ-Agreed by Infl → Set B; R/T default
 
-instance : DecidablePred ArgPosition.IsPhiAgreed := fun p => by
-  cases p <;> unfold ArgPosition.IsPhiAgreed <;> infer_instance
+instance : DecidablePred IsPhiAgreed := fun p => by
+  cases p <;> unfold IsPhiAgreed <;> infer_instance
 
 /-! ### Pronoun reduction eligibility -/
 
@@ -146,11 +136,11 @@ instance : DecidablePred ArgPosition.IsPhiAgreed := fun p => by
     ([scott-2023] Table 4.25, p. 200). Only agreed-with positions are
     eligible; whether reduction actually applies depends on person (see
     `realizedPronoun`). -/
-def ArgPosition.CanBeReduced (pos : ArgPosition) : Prop :=
-  pos.IsPhiAgreed
+def CanBeReduced (pos : ArgumentRole) : Prop :=
+  IsPhiAgreed pos
 
-instance : DecidablePred ArgPosition.CanBeReduced := fun pos => by
-  unfold ArgPosition.CanBeReduced; exact inferInstance
+instance : DecidablePred CanBeReduced := fun pos => by
+  unfold CanBeReduced; exact inferInstance
 
 /-! ### Per-position verification -/
 
@@ -160,36 +150,36 @@ instance : DecidablePred ArgPosition.CanBeReduced := fun pos => by
 -- is a re-export of the substrate lemma.
 
 /-- Agent gets ERG (inherent, from Voice). -/
-theorem A_case : ArgPosition.case .A = .erg := Alignment.tripartite.assignCase_A
+theorem A_case : Mayan.ergCaseMam .A = .erg := Alignment.tripartite.assignCase_A
 
 /-- Patient gets ACC (structural, from Voice). -/
-theorem P_case : ArgPosition.case .P = .acc := Alignment.tripartite.assignCase_P
+theorem P_case : Mayan.ergCaseMam .P = .acc := Alignment.tripartite.assignCase_P
 
 /-- Intransitive S gets ABS (structural, from Infl). -/
-theorem S_case : ArgPosition.case .S = .abs := Alignment.tripartite.assignCase_S
+theorem S_case : Mayan.ergCaseMam .S = .abs := Alignment.tripartite.assignCase_S
 
 /-- Three distinct underlying cases (morphologically tripartite),
     inherited from `Alignment.tripartite_distinguishes_all`. -/
 theorem tripartite_alignment :
-    ArgPosition.case .A ≠ ArgPosition.case .P ∧
-    ArgPosition.case .A ≠ ArgPosition.case .S ∧
-    ArgPosition.case .P ≠ ArgPosition.case .S :=
+    Mayan.ergCaseMam .A ≠ Mayan.ergCaseMam .P ∧
+    Mayan.ergCaseMam .A ≠ Mayan.ergCaseMam .S ∧
+    Mayan.ergCaseMam .P ≠ Mayan.ergCaseMam .S :=
   Alignment.tripartite_distinguishes_all
 
 /-- Reduction eligibility coincides with φ-agreement — reflexivity,
     since `CanBeReduced := IsPhiAgreed`. -/
-theorem reduction_eligible_iff_phi_agreed (pos : ArgPosition) :
-    pos.CanBeReduced ↔ pos.IsPhiAgreed :=
+theorem reduction_eligible_iff_phi_agreed (pos : ArgumentRole) :
+    CanBeReduced pos ↔ IsPhiAgreed pos :=
   Iff.rfl
 
 /-! ### Case inventory ([blake-1994]) -/
 
 /-- The case inventory realized by the core positions: {ERG, ACC, ABS}. -/
-def caseInventory : Finset Case := (ArgumentRole.core.map ArgPosition.case).toFinset
+def caseInventory : Finset Case := (ArgumentRole.core.map Mayan.ergCaseMam).toFinset
 
 /-- The inventory covers all argument positions. -/
 theorem inventory_covers_positions :
-    ∀ p ∈ ArgumentRole.core, ArgPosition.case p ∈ caseInventory := by decide
+    ∀ p ∈ ArgumentRole.core, Mayan.ergCaseMam p ∈ caseInventory := by decide
 
 -- Mam's {ERG, ACC, ABS} inventory is valid per Blake's case hierarchy
 -- (all are core cases at rank 6, trivially no gaps).
@@ -246,8 +236,8 @@ theorem enclitic_survives : ¬ (∀ d ∈ encliticDimensions, d.Copied) := by de
     everything else keeps its independent form. Realization selects among
     the shared `PersonalPronoun` entries, not a separate form
     classification. -/
-def realizedPronoun (pos : ArgPosition) (c : PronCell) : Option PersonalPronoun :=
-  if pos.IsPhiAgreed then subjPoss c else independent c
+def realizedPronoun (pos : ArgumentRole) (c : PronCell) : Option PersonalPronoun :=
+  if IsPhiAgreed pos then subjPoss c else independent c
 
 /-- 1SG agent: reduced to the bare disagreement enclitic (base bled by
     impoverishment). -/

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -22,10 +22,9 @@ England 1992:21, Kaufman 1974) — alongside the Cholan-Tzeltalan branch
   markers by following-segment environment (pre-consonantal vs
   pre-vocalic variant shapes) and the Set B absolutive suffixes
   ([coon-mateo-pedro-preminger-2014] table (13)).
-* `Qanjobal.ArgPosition` with `.case`, `.accCase`: argument positions
-  and their canonical-ergative and split (extended-ergative) case,
-  shared with Chol via `Mayan.ergCaseQanjobalan` /
-  `Mayan.accCaseQanjobalan`.
+* Case assignment over `ArgumentRole` via `Mayan.ergCaseQanjobalan`
+  (canonical ergative) and `Mayan.accCaseQanjobalan` (split,
+  extended-ergative), shared with Chol.
 * `Qanjobal.absPosition`: HIGH-ABS morpheme placement.
 
 ## Implementation notes
@@ -61,21 +60,6 @@ namespace Qanjobal
 open Mayan (ExponentTable)
 
 /-! ### Argument positions -/
-
-/-- Argument positions, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Canonical ergative case assignment (clauses with an overt preverbal
-    aspect marker), shared with Chol via `Mayan.ergCaseQanjobalan`
-    (= `Alignment.ergative.assignCase`). -/
-abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseQanjobalan
-
-/-- Split (extended-ergative) case assignment in aspectless contexts,
-    via the `.Prog` projection `Mayan.accCaseQanjobalan`
-    (= `Alignment.extendedErgative.assignCase`) — making the
-    accusative-side parallel with Chol true by construction. -/
-abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseQanjobalan
 
 /-! ### Absolutive position (HIGH-ABS) -/
 

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -14,8 +14,8 @@ syntactic properties relevant to possessor extraction ([aissen-polian-2025];
 
 ## Main declarations
 
-* `Tseltal.ArgPosition` with `.case`, `.accCase`: argument positions and
-  their case (ergative-absolutive, no aspect split).
+* Case assignment over `ArgumentRole` via `Mayan.caseTseltalan`
+  (ergative-absolutive, no aspect split).
 * `Tseltal.setALinearity`, `Tseltal.setBLinearity`: prefixal Set A,
   consistently suffixal Set B.
 * `Tseltal.setAExponent`, `Tseltal.setBExponent`: Oxchuc Tseltal exponent
@@ -49,22 +49,6 @@ open Agreement
 export Mayan.Tseltalan (GramFunction)
 
 /-! ### Argument positions -/
-
-/-- Argument positions in a Tseltal clause, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Case assignment for Tseltal: `Mayan.caseTseltalan .Perf`
-    (A → ERG, S/P → ABS). No aspect-conditioned split, so a single function
-    covers perfective and non-perfective. -/
-abbrev ArgPosition.case : ArgPosition → Case :=
-  Mayan.caseTseltalan .Perf
-
-/-- Non-perfective case assignment for Tseltal: identical to perfective
-    (no aspect split, [polian-2013]); provided for cross-Mayan
-    shape-uniformity. -/
-abbrev ArgPosition.accCase : ArgPosition → Case :=
-  Mayan.caseTseltalan .Imp
 
 /-! ### Absolutive position (LOW-ABS) -/
 

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -12,8 +12,8 @@ Agreement morphology for Zinacantec Tsotsil (Tseltalan, Mayan)
 
 ## Main declarations
 
-* `Tsotsil.ArgPosition` with `.case`, `.accCase`: argument positions and
-  their case (ergative-absolutive, no aspect split).
+* Case assignment over `ArgumentRole` via `Mayan.caseTseltalan`
+  (ergative-absolutive, no aspect split).
 * `Tsotsil.setALinearity`, `Tsotsil.setBLinearity`: prefixal Set A,
   prefixal-or-suffixal Set B.
 * `Tsotsil.setAExponent`, `Tsotsil.setBExponent`: Zinacantec Tsotsil
@@ -47,20 +47,6 @@ open Agreement
 export Mayan.Tseltalan (GramFunction)
 
 /-! ### Argument positions -/
-
-/-- Argument positions in a Tsotsil clause, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Case assignment for Tsotsil: `Mayan.caseTseltalan .Perf`
-    (A → ERG, S/P → ABS); Tseltalan has no aspect-conditioned split. -/
-abbrev ArgPosition.case : ArgPosition → Case :=
-  Mayan.caseTseltalan .Perf
-
-/-- Non-perfective case assignment for Tsotsil: identical to perfective
-    (no aspect split, [polian-2013]). -/
-abbrev ArgPosition.accCase : ArgPosition → Case :=
-  Mayan.caseTseltalan .Imp
 
 /-! ### Absolutive position (LOW-ABS) -/
 

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -24,8 +24,9 @@ burying me', [hofling-2017] Table 24.15): Yucatec is LOW-ABS.
 * `Yukatek.setAExponent`, `Yukatek.setBExponent`: the Set A and Set B
   exponent tables ([hofling-2017] Tables 24.8, 24.12).
 * `Yukatek.absPosition`: LOW-ABS morpheme placement.
-* `Yukatek.ArgPosition` with `.case`, `.accCase`: argument positions and
-  their completive (ergative) and incompletive (extended-ergative) case.
+* Case assignment over `ArgumentRole` via `Mayan.ergCaseYukatek`
+  (completive, ergative) and `Mayan.accCaseYukatek` (incompletive,
+  extended-ergative).
 
 ## Implementation notes
 
@@ -79,18 +80,5 @@ def setBExponent : ExponentTable :=
 theorem p3sg_abs_null : setBExponent.realize (.pn .third .Sing) = some [] := rfl
 
 /-! ### Argument positions -/
-
-/-- Argument positions, aliased to the canonical
-    `ArgumentRole` (S/A/P/R/T). -/
-abbrev ArgPosition := ArgumentRole
-
-/-- Completive (ergative) case assignment: `Mayan.ergCaseYukatek`
-    (A → ERG, S/P → ABS). -/
-abbrev ArgPosition.case : ArgPosition → Case := Mayan.ergCaseYukatek
-
-/-- Incompletive (extended-ergative) case assignment:
-    `Mayan.accCaseYukatek` (S/A → Set A, P → Set B; [hofling-2017]
-    p. 692). -/
-abbrev ArgPosition.accCase : ArgPosition → Case := Mayan.accCaseYukatek
 
 end Yukatek

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -421,16 +421,16 @@ theorem dependent_source_distinct_from_inherent :
   refine ⟨by decide, by decide⟩
 
 /-- The Chol fragment's case table (Phase 3) inherits the equivalence
-    automatically: since `Chol.ArgPosition.agent.ergCase` is definitionally
+    automatically: since `ArgumentRole.agent.ergCase` is definitionally
     equal to `Alignment.ergative.assignCase .A` (via the Phase-3 substrate
     chain), the equivalence theorem above immediately yields
     `getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)`
-    `= some Chol.ArgPosition.agent.ergCase`. We state this
+    `= some ArgumentRole.agent.ergCase`. We state this
     one Chol-specific corollary explicitly so downstream Mayan consumers
     can cite it directly. -/
 theorem chol_perfective_ergCase_matches_dependent :
     getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)
-      = some (Chol.ArgPosition.case .A) := by decide
+      = some (Mayan.ergCaseChol .A) := by decide
 
 /-- **Dependent case is INSUFFICIENT for extended ergative.** The Chol
     non-perfective S/A → GEN, P → ABS pattern is a fourth typological

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -322,21 +322,21 @@ theorem chol_no_syntactic_ergativity :
 /-- Q'anjob'al's ergative alignment matches the standard pattern:
     transitive agent = ERG, transitive object = ABS. -/
 theorem qanjobal_erg_alignment :
-    Qanjobal.ArgPosition.case .A = .erg ∧
-    Qanjobal.ArgPosition.case .P = .abs := ⟨rfl, rfl⟩
+    Mayan.ergCaseQanjobalan .A = .erg ∧
+    Mayan.ergCaseQanjobalan .P = .abs := ⟨rfl, rfl⟩
 
 /-- Chol's ergative alignment matches the same standard pattern. -/
 theorem chol_erg_alignment :
-    Chol.ArgPosition.case .A = .erg ∧
-    Chol.ArgPosition.case .P = .abs := ⟨rfl, rfl⟩
+    Mayan.ergCaseChol .A = .erg ∧
+    Mayan.ergCaseChol .P = .abs := ⟨rfl, rfl⟩
 
 /-- Despite sharing ergative morphology, Q'anjob'al and Chol differ in
     whether agent extraction is banned. The difference traces to their
     distinct case loci, not to properties of the ergative NP. -/
 theorem shared_morphology_different_syntax :
     -- Same ergative case on agent
-    Qanjobal.ArgPosition.case .A =
-      Chol.ArgPosition.case .A ∧
+    Mayan.ergCaseQanjobalan .A =
+      Mayan.ergCaseChol .A ∧
     -- But different syntactic ergativity predictions
     hasSyntacticErgativity .absNom ≠ hasSyntacticErgativity .absDef :=
   ⟨rfl, by decide⟩

--- a/Linglib/Studies/Imanishi2020.lean
+++ b/Linglib/Studies/Imanishi2020.lean
@@ -239,29 +239,29 @@ theorem anticausative_ron_compatible :
     fragment: A = ERG, S = P = ABS. Confirms the ergative side is
     shared across all three languages. -/
 theorem kaqchikel_perfective_bridge :
-    Kaqchikel.ArgPosition.case .A = .erg ∧
-    Kaqchikel.ArgPosition.case .P = .abs ∧
-    Kaqchikel.ArgPosition.case .S = .abs :=
+    Mayan.ergCaseKaqchikel .A = .erg ∧
+    Mayan.ergCaseKaqchikel .P = .abs ∧
+    Mayan.ergCaseKaqchikel .S = .abs :=
   ⟨Kaqchikel.A_case, Kaqchikel.P_case, Kaqchikel.S_case⟩
 
 /-- Chol's perfective alignment matches the same ergative pattern. -/
 theorem chol_perfective_bridge :
-    Chol.ArgPosition.case .A = .erg ∧
-    Chol.ArgPosition.case .P = .abs ∧
-    Chol.ArgPosition.case .S = .abs := ⟨rfl, rfl, rfl⟩
+    Mayan.ergCaseChol .A = .erg ∧
+    Mayan.ergCaseChol .P = .abs ∧
+    Mayan.ergCaseChol .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- Q'anjob'al's perfective alignment matches the same ergative pattern. -/
 theorem qanjobal_perfective_bridge :
-    Qanjobal.ArgPosition.case .A = .erg ∧
-    Qanjobal.ArgPosition.case .P = .abs ∧
-    Qanjobal.ArgPosition.case .S = .abs := ⟨rfl, rfl, rfl⟩
+    Mayan.ergCaseQanjobalan .A = .erg ∧
+    Mayan.ergCaseQanjobalan .P = .abs ∧
+    Mayan.ergCaseQanjobalan .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- All three languages share ergative alignment in the perfective. -/
 theorem shared_ergative :
-    Kaqchikel.ArgPosition.case .A =
-      Chol.ArgPosition.case .A ∧
-    Chol.ArgPosition.case .A =
-      Qanjobal.ArgPosition.case .A := ⟨rfl, rfl⟩
+    Mayan.ergCaseKaqchikel .A =
+      Mayan.ergCaseChol .A ∧
+    Mayan.ergCaseChol .A =
+      Mayan.ergCaseQanjobalan .A := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 9: Case-to-Marker Bridge
@@ -284,49 +284,49 @@ theorem erg_gen_homophonous :
 /-- Chol's fragment case values, mapped through the Mayan marker bridge,
     yield the predicted accusative-side pattern. -/
 theorem chol_case_to_marker_bridge :
-    caseToMarker (Chol.ArgPosition.accCase .A) = cholPattern.sMarker ∧
-    caseToMarker (Chol.ArgPosition.accCase .P) = cholPattern.oMarker :=
+    caseToMarker (Mayan.accCaseChol .A) = cholPattern.sMarker ∧
+    caseToMarker (Mayan.accCaseChol .P) = cholPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- Q'anjob'al's fragment case values yield the same pattern as Chol. -/
 theorem qanjobal_case_to_marker_bridge :
-    caseToMarker (Qanjobal.ArgPosition.accCase .A) = cholPattern.sMarker ∧
-    caseToMarker (Qanjobal.ArgPosition.accCase .P) = cholPattern.oMarker :=
+    caseToMarker (Mayan.accCaseQanjobalan .A) = cholPattern.sMarker ∧
+    caseToMarker (Mayan.accCaseQanjobalan .P) = cholPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- Kaqchikel's fragment accusative-side case values, mapped through the
     Mayan marker bridge, yield the predicted Kaqchikel alignment pattern. -/
 theorem kaqchikel_case_to_marker_bridge :
-    caseToMarker (Kaqchikel.ArgPosition.accCase .A) = kaqchikelPattern.sMarker ∧
-    caseToMarker (Kaqchikel.ArgPosition.accCase .P) = kaqchikelPattern.oMarker :=
+    caseToMarker (Mayan.accCaseKaqchikel .A) = kaqchikelPattern.sMarker ∧
+    caseToMarker (Mayan.accCaseKaqchikel .P) = kaqchikelPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- The accusative-side case contrast between Kaqchikel and Chol is a
     true mirror image: agent and patient cases are swapped. -/
 theorem acc_case_mirror :
-    Kaqchikel.ArgPosition.accCase .A =
-      Chol.ArgPosition.accCase .P ∧
-    Kaqchikel.ArgPosition.accCase .P =
-      Chol.ArgPosition.accCase .A := ⟨rfl, rfl⟩
+    Mayan.accCaseKaqchikel .A =
+      Mayan.accCaseChol .P ∧
+    Mayan.accCaseKaqchikel .P =
+      Mayan.accCaseChol .A := ⟨rfl, rfl⟩
 
 /-- End-to-end: for all three languages, the fragment case data (mapped
     through the marker bridge) matches the parametrically derived pattern.
     This closes the argumentation chain from parameters → alignment → case → markers. -/
 theorem end_to_end_all_languages :
     -- Kaqchikel: fragment cases match derived pattern
-    (caseToMarker (Kaqchikel.ArgPosition.accCase .A) =
+    (caseToMarker (Mayan.accCaseKaqchikel .A) =
       (deriveAccPattern kaqchikelParams).sMarker ∧
-     caseToMarker (Kaqchikel.ArgPosition.accCase .P) =
+     caseToMarker (Mayan.accCaseKaqchikel .P) =
       (deriveAccPattern kaqchikelParams).oMarker) ∧
     -- Chol: fragment cases match derived pattern
-    (caseToMarker (Chol.ArgPosition.accCase .A) =
+    (caseToMarker (Mayan.accCaseChol .A) =
       (deriveAccPattern cholParams).sMarker ∧
-     caseToMarker (Chol.ArgPosition.accCase .P) =
+     caseToMarker (Mayan.accCaseChol .P) =
       (deriveAccPattern cholParams).oMarker) ∧
     -- Q'anjob'al: fragment cases match derived pattern
-    (caseToMarker (Qanjobal.ArgPosition.accCase .A) =
+    (caseToMarker (Mayan.accCaseQanjobalan .A) =
       (deriveAccPattern qanjobalParams).sMarker ∧
-     caseToMarker (Qanjobal.ArgPosition.accCase .P) =
+     caseToMarker (Mayan.accCaseQanjobalan .P) =
       (deriveAccPattern qanjobalParams).oMarker) :=
   ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
 

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -631,16 +631,16 @@ theorem personLevel_rank_matches_probe_rank :
 
 /-- Kaqchikel indexes all three argument positions (agent, patient, intranS).
     This makes it non-differential: no prominence condition gates indexing. -/
-theorem kaqchikel_indexes_all (p : ArgPosition)
+theorem kaqchikel_indexes_all (p : ArgumentRole)
     (h : p ∈ ArgumentRole.core) :
-    ArgPosition.IsPhiAgreed p :=
+    IsPhiAgreed p :=
   Kaqchikel.all_positions_agreed p h
 
 /-- Both A (agent) and P (patient) are indexed in Kaqchikel:
     agent via Set A on Voice/v, patient via Set B on Infl/T. -/
 theorem kaqchikel_A_and_P_indexed :
-    ArgPosition.IsPhiAgreed .A ∧
-    ArgPosition.IsPhiAgreed .P := ⟨trivial, trivial⟩
+    IsPhiAgreed .A ∧
+    IsPhiAgreed .P := ⟨trivial, trivial⟩
 
 /-- The A marker paradigm (Set A) and P marker paradigm (Set B) are
     distinct: every person-number combination gets a unique marker in
@@ -656,11 +656,10 @@ theorem kaqchikel_dual_paradigms :
 -- § 19: Kaqchikel Argument Roles ↔ Just's ArgumentRole
 -- ============================================================================
 
-/-- Map Kaqchikel argument positions to Just's A/P roles. The
-    absolutive collapse: S patterns with P, A stays distinct;
-    ditransitive R/T default to P (consistent with absolutive
+/-- The absolutive collapse on coding roles: S patterns with P, A stays
+    distinct; ditransitive R/T default to P (consistent with absolutive
     grouping). -/
-def kaqArgToRole : ArgPosition → ArgumentRole
+def kaqArgToRole : ArgumentRole → ArgumentRole
   | .A => .A
   | .S | .P | .R | .T => .P  -- S patterns with P (absolutive alignment)
 
@@ -674,8 +673,8 @@ theorem kaqArg_role_mapping :
 /-- Ergative-absolutive alignment: A is distinguished (ERG) while P and S
     pattern together (ABS). This parallels Just's A/P split. -/
 theorem erg_abs_matches_AP :
-    ArgPosition.case .A ≠ ArgPosition.case .P ∧
-    ArgPosition.case .P = ArgPosition.case .S :=
+    Mayan.ergCaseKaqchikel .A ≠ Mayan.ergCaseKaqchikel .P ∧
+    Mayan.ergCaseKaqchikel .P = Mayan.ergCaseKaqchikel .S :=
   Kaqchikel.erg_abs_alignment
 
 -- ============================================================================

--- a/Linglib/Studies/Preminger2014.lean
+++ b/Linglib/Studies/Preminger2014.lean
@@ -219,7 +219,7 @@ instance : DecidableRel PersonRestrictionOk := fun subj obj =>
     arguments cannot both be licensed and the derivation crashes. -/
 theorem personRestrictionOk_iff_plc (s o : Agreement.Cell) :
     PersonRestrictionOk s o ↔
-      PLC Prod.snd ([(.A, s), (.P, o)] : List (ArgPosition × Agreement.Cell)) := by
+      PLC Prod.snd ([(.A, s), (.P, o)] : List (ArgumentRole × Agreement.Cell)) := by
   unfold PersonRestrictionOk PLC
   rw [Probe.allLicensed_iff]
   constructor
@@ -245,7 +245,7 @@ theorem ch4_relativization_contrast :
     ¬ BejarRezac2003.PLCOk [[⟨.third, true⟩, ⟨.first, false⟩]]
         [⟨.third, true⟩, ⟨.first, false⟩] ∧
     PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :
-        List (ArgPosition × Agreement.Cell)) := by
+        List (ArgumentRole × Agreement.Cell)) := by
   decide
 
 /-- π⁰: the person probe — the denotation of the substrate's
@@ -275,7 +275,7 @@ def afAgreementTarget (subj obj : Agreement.Cell) : Option Agreement.Cell :=
     fails on the clause's goal tokens (equivalently, when the surface
     person restriction is violated: `personRestrictionOk_iff_plc`). -/
 def afMarker (subj obj : Agreement.Cell) : Option String :=
-  if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgPosition × Agreement.Cell)) then
+  if PLC Prod.snd ([(.A, subj), (.P, obj)] : List (ArgumentRole × Agreement.Cell)) then
     ((afAgreementTarget subj obj).bind
       (fun t => (setBExponent.realize t).map toString)) <|>
       spellout setBVocab ⊥
@@ -496,7 +496,7 @@ theorem ch7_arg4_form_distinctness :
 theorem ch7_arg5_zulu_parallel :
     -- Kichean: π⁰ skips a 3SG subject and licenses a 1SG object
     PLC Prod.snd ([(.A, .pn .third .Sing), (.P, .pn .first .Sing)] :
-      List (ArgPosition × Agreement.Cell)) ∧
+      List (ArgumentRole × Agreement.Cell)) ∧
     -- Zulu: an augmented subject intervenes; the augmentless object
     -- is unlicensed
     ¬ Halpert2012.LicensingOk [⟨1, true⟩, ⟨5, false⟩] ∧

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -84,21 +84,21 @@ open Syntax.Case
     the assignment fixed by θ-position rather than by Agree or by NP
     configuration. -/
 theorem voice_assigns_case_by_position :
-    Mam.ArgPosition.case .A = .erg ∧
-    Mam.ArgPosition.case .P = .acc ∧
-    Mam.ArgPosition.case .S = .abs := ⟨rfl, rfl, rfl⟩
+    Mayan.ergCaseMam .A = .erg ∧
+    Mayan.ergCaseMam .P = .acc ∧
+    Mayan.ergCaseMam .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- The three argument positions receive three distinct cases — a
     tripartite underlying system (ERG ≠ ACC ≠ ABS) at the case-assignment
     layer, prior to any morphological syncretism. Inherits from
     `Alignment.tripartite_distinguishes_all` via the substrate connection. -/
 theorem voice_based_tripartite :
-    Mam.ArgPosition.case .A ≠
-      Mam.ArgPosition.case .P ∧
-    Mam.ArgPosition.case .A ≠
-      Mam.ArgPosition.case .S ∧
-    Mam.ArgPosition.case .P ≠
-      Mam.ArgPosition.case .S :=
+    Mayan.ergCaseMam .A ≠
+      Mayan.ergCaseMam .P ∧
+    Mayan.ergCaseMam .A ≠
+      Mayan.ergCaseMam .S ∧
+    Mayan.ergCaseMam .P ≠
+      Mayan.ergCaseMam .S :=
   Alignment.tripartite_distinguishes_all
 
 -- ============================================================================
@@ -199,7 +199,7 @@ def setBVocab : List (VocabularyItem GramFeature String) :=
 
 /-- Which Minimalist head φ-Agrees with each argument position.
     Ditransitive R/T default to none (not modeled). -/
-def agreeProbe : ArgPosition → Option Cat
+def agreeProbe : ArgumentRole → Option Cat
   | .A => some .v   -- Voice probes, A in Spec,VoiceP
   | .P => none      -- Infl probe blocked by Voice_TR
   | .S => some .T   -- Infl probes, S in its domain
@@ -409,7 +409,7 @@ theorem full_pipeline_3sg_transitive :
     -- Step 3-4: Infl probe blocked → default Set B
     spellout setBVocab (⊥ : FeatureBundle) = some "tz'=" ∧
     -- Step 5: patient is not eligible for reduction → overt pronoun
-    ¬ ArgPosition.CanBeReduced .P := by
+    ¬ CanBeReduced .P := by
   refine ⟨?_, ?_, ?_, ?_⟩
   · decide
   · decide
@@ -418,8 +418,8 @@ theorem full_pipeline_3sg_transitive :
 
 /-- The pipeline generalizes: for every argument position, reduction
     eligibility ≡ φ-agreement (definitionally — `CanBeReduced := IsPhiAgreed`). -/
-theorem all_positions_match (pos : ArgPosition) :
-    pos.CanBeReduced ↔ pos.IsPhiAgreed :=
+theorem all_positions_match (pos : ArgumentRole) :
+    CanBeReduced pos ↔ IsPhiAgreed pos :=
   Iff.rfl
 
 -- ============================================================================
@@ -437,13 +437,13 @@ theorem all_positions_match (pos : ArgPosition) :
     assigned by different heads (Voice for ERG/ACC, Infl for ABS). -/
 theorem agreement_is_tripartite :
     -- Agreed-with positions: A (ERG, by Voice) and S (ABS, by Infl)
-    ArgPosition.IsPhiAgreed .A ∧
-    ArgPosition.case .A = .erg ∧
-    ArgPosition.IsPhiAgreed .S ∧
-    ArgPosition.case .S = .abs ∧
+    IsPhiAgreed .A ∧
+    Mayan.ergCaseMam .A = .erg ∧
+    IsPhiAgreed .S ∧
+    Mayan.ergCaseMam .S = .abs ∧
     -- Not agreed-with: P (ACC, from Voice but no φ-Agree)
-    ¬ ArgPosition.IsPhiAgreed .P ∧
-    ArgPosition.case .P = .acc :=
+    ¬ IsPhiAgreed .P ∧
+    Mayan.ergCaseMam .P = .acc :=
   ⟨trivial, rfl, trivial, rfl, by decide, rfl⟩
 
 /-- Agreement probes are on different heads: Voice for Set A, Infl for
@@ -496,7 +496,7 @@ theorem intransitive_is_real_agreement :
 theorem satisfaction_derives_patient_no_agree :
     mamInflSatisfaction.isSatisfied ⊥ (some .v) = true ∧
     mamInflSatisfaction.copiedFeatures ⊥ (some .v) = false ∧
-    ¬ ArgPosition.IsPhiAgreed .P :=
+    ¬ IsPhiAgreed .P :=
   ⟨by decide, by decide, by decide⟩
 
 /-- In an intransitive clause, `mamInflSatisfaction` is satisfied by
@@ -506,7 +506,7 @@ theorem satisfaction_derives_intranS_agree :
       [.valued (.phi (.person .first)), .valued (.phi (.number .singular))]
     mamInflSatisfaction.isSatisfied dp1sg none = true ∧
     mamInflSatisfaction.copiedFeatures dp1sg none = true ∧
-    ArgPosition.IsPhiAgreed .S :=
+    IsPhiAgreed .S :=
   ⟨by decide, by decide, trivial⟩
 
 /-- The satisfaction condition's `copiedFeatures` Bool aligns with
@@ -515,12 +515,12 @@ theorem satisfaction_derives_intranS_agree :
     - intranS (intransitive): copiedFeatures = true ↔ IsPhiAgreed .S -/
 theorem satisfaction_matches_fragment :
     (mamInflSatisfaction.copiedFeatures ⊥ (some .v) = true ↔
-      ArgPosition.IsPhiAgreed .P) ∧
+      IsPhiAgreed .P) ∧
     (mamInflSatisfaction.copiedFeatures
       (.ofGramFeatures
         [.valued (.phi (.person .first)), .valued (.phi (.number .singular))])
       none = true ↔
-      ArgPosition.IsPhiAgreed .S) := by
+      IsPhiAgreed .S) := by
   refine ⟨?_, ?_⟩
   · constructor <;> intro h <;> first | (decide) | trivial
   · exact ⟨fun _ => trivial, fun _ => by decide⟩
@@ -546,7 +546,7 @@ linearizations per clause type, not computed from a `SyntacticObject`
     DP goals). The `(FeatureBundle, Option Cat)` pair is exactly the
     argument signature of `SatisfactionCond.isSatisfied`. -/
 structure Encounter where
-  pos : Option ArgPosition
+  pos : Option ArgumentRole
   feats : FeatureBundle
   cat : Option Cat
 
@@ -562,7 +562,7 @@ def satProbe (cond : SatisfactionCond) : Probe Encounter :=
     — the probe agrees with the found element only if satisfaction
     copied features (feature match, not head encounter). -/
 def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
-    Option ArgPosition :=
+    Option ArgumentRole :=
   ((satProbe cond).agree goals).bind (·.pos)
 
 /-- Transitive Voice as an encounter: a head of category `.v`, no
@@ -570,7 +570,7 @@ def agreesWith (cond : SatisfactionCond) (goals : List Encounter) :
 def voiceTR : Encounter := ⟨none, ⊥, some .v⟩
 
 /-- A DP goal realizing position `p` with φ-bundle `φ`. -/
-def dpGoal (p : ArgPosition) (φ : FeatureBundle) : Encounter := ⟨some p, φ, none⟩
+def dpGoal (p : ArgumentRole) (φ : FeatureBundle) : Encounter := ⟨some p, φ, none⟩
 
 /-- Voice's probe: standard φ feature-match (no head-encounter disjunct). -/
 def voiceSat : SatisfactionCond := .featureMatch .person
@@ -581,7 +581,7 @@ theorem agreesWith_nil (cond : SatisfactionCond) :
 
 /-- Voice's goal sequence in the clause containing position `p`:
     Voice probes only in transitives; the agent is closest. -/
-def voiceGoals (φA φP : FeatureBundle) : ArgPosition → List Encounter
+def voiceGoals (φA φP : FeatureBundle) : ArgumentRole → List Encounter
   | .A | .P => [dpGoal .A φA, dpGoal .P φP]
   | _ => []
 
@@ -590,7 +590,7 @@ def voiceGoals (φA φP : FeatureBundle) : ArgPosition → List Encounter
     downward search encounters is the Voice_TR head, before either DP.
     In an intransitive there is no transitive Voice; the search reaches
     S directly. -/
-def inflGoals (φA φP φS : FeatureBundle) : ArgPosition → List Encounter
+def inflGoals (φA φP φS : FeatureBundle) : ArgumentRole → List Encounter
   | .A | .P => [voiceTR, dpGoal .A φA, dpGoal .P φP]
   | .S => [dpGoal .S φS]
   | .R | .T => []
@@ -624,7 +624,7 @@ theorem voice_finds_A (φA φP : FeatureBundle)
 /-- DERIVED probe table: which head φ-agrees with position `p`,
     computed by running each probe's `Probe.search` over the goal
     sequence of the clause containing `p`. -/
-def derivedAgreeProbe (φA φP φS : FeatureBundle) (p : ArgPosition) :
+def derivedAgreeProbe (φA φP φS : FeatureBundle) (p : ArgumentRole) :
     Option Cat :=
   if agreesWith voiceSat (voiceGoals φA φP p) = some p then some .v
   else if agreesWith mamInflSatisfaction (inflGoals φA φP φS p) = some p


### PR DESCRIPTION
The eight `abbrev ArgPosition := ArgumentRole` aliases and their `.case`/`.accCase` members (aliases of `Mayan.ergCase*`/`Mayan.caseTseltalan`) die; call sites use the real API directly. Genuine per-language content (`IsPhiAgreed`, `CanBeReduced`, `agreementSet`) becomes plain local defs. Consumers updated: Scott2023, Just2024, Preminger2014, CoonMateoPedroPreminger2014, Imanishi2020, Kaqchikel/Focus.

Unrelated same-named types (`Basque.ArgPosition`, `Linking.ArgPosition`, `Valency.ArgPosition`, `ChujArgPosition`) are untouched — flagged for the naming ledger.