### PR TITLE
refactor(Semantics/ArgumentStructure): Linking GramFunction; drop dead enum

### DIFF
--- a/Linglib/Fragments/Basque/Agreement.lean
+++ b/Linglib/Fragments/Basque/Agreement.lean
@@ -31,20 +31,6 @@ open Features.Prominence
 open _root_.Agreement
 
 -- ============================================================================
--- § 1: Argument Positions
--- ============================================================================
-
-/-- Argument positions in a Basque clause. -/
-inductive ArgPosition where
-  /-- A: transitive agent (ERG) -/
-  | agent
-  /-- P: transitive patient (ABS) -/
-  | patient
-  /-- S: intransitive subject (ABS) -/
-  | intranS
-  deriving DecidableEq, Repr
-
--- ============================================================================
 -- § 2: Differential P Indexing
 -- ============================================================================
 

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -245,11 +245,11 @@ theorem canonical_profiles_wellformed (r : ThetaRole) :
 
 namespace ArgumentStructure.Linking
 
-/-- Which argument position in the clause we're asking about.
+/-- The grammatical function a linking theory's output targets.
     Theory-neutral: expressed as grammatical functions, not structural
     positions (Spec-vP, Comp-VP, etc.), so that theories with different
     structural vocabularies can all target the same output. -/
-inductive ArgPosition where
+inductive GramFunction where
   | subject         -- Grammatical subject (external or raised)
   | directObject    -- Direct object
   | indirectObject  -- Indirect object / dative
@@ -290,7 +290,7 @@ structure LinkingTheory (Verb Ctx : Type) where
   compatible : Verb → List Ctx
   /-- Predict each argument's theta role in a given context.
       Returns `none` for positions the theory is silent about. -/
-  predict : Verb → Ctx → ArgPosition → Option ThetaRole
+  predict : Verb → Ctx → GramFunction → Option ThetaRole
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 7. Testing predictions against fragment data
@@ -303,7 +303,7 @@ structure LinkingTheory (Verb Ctx : Type) where
     if ANY context produces the correct prediction — the fragment entry
     records one use of the verb, not all possible uses. -/
 def LinkingTheory.matchesAt {Verb Ctx : Type} [BEq Ctx]
-    (th : LinkingTheory Verb Ctx) (v : Verb) (pos : ArgPosition)
+    (th : LinkingTheory Verb Ctx) (v : Verb) (pos : GramFunction)
     (actual : Option ThetaRole) : Bool :=
   (th.compatible v).any fun ctx => th.predict v ctx pos == actual
 

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -60,7 +60,7 @@ two-feature simplification).
 
 namespace AndersonJM2006
 
-open ArgumentStructure.Linking (LinkingTheory ArgPosition)
+open ArgumentStructure.Linking (LinkingTheory GramFunction)
 open ArgumentStructure
 open English.Predicates.Verbal
 
@@ -224,7 +224,7 @@ theorem Case.acc_abs_same_relation :
 namespace AndersonJM2006
 
 open ArgumentStructure
-open ArgumentStructure.Linking (LinkingTheory ArgPosition)
+open ArgumentStructure.Linking (LinkingTheory GramFunction)
 open English.Predicates.Verbal
 
 -- ============================================================================


### PR DESCRIPTION
Two entries from the `ArgPosition` naming ledger:

- `Linking.ArgPosition` → `Linking.GramFunction`: its cells (subject/DO/IO/oblique/applied) and its own docstring are grammatical functions, not positions; the name now mirrors `CxG.GramFunction` owner-relatively.
- `Basque.Agreement.ArgPosition` ({agent, patient, intranS} — a third S/A/P encoding) had zero uses; deleted.

Remaining `ArgPosition`s are sanctioned: `Valency.ArgPosition` (tier-3 positions), the Data-layer `ProtoRoles.Schema` local (Data can't import theory), and the study-local `ChujArgPosition`.