### PR TITLE
refactor(Fragments/Mayan): drop ergCase/accCase projections; name the aspect

### DIFF
--- a/Linglib/Fragments/Mayan/Chol/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Chol/Agreement.lean
@@ -18,8 +18,8 @@ intransitive subjects in non-perfective. The formal-syntactic analyses of
 
 ## Main declarations
 
-* Case assignment over `ArgumentRole` via `Mayan.ergCaseChol`
-  (perfective, ergative) and `Mayan.accCaseChol` (non-perfective,
+* Case assignment over `ArgumentRole` via `(Mayan.caseChol .Perf)`
+  (perfective, ergative) and `(Mayan.caseChol .Imp)` (non-perfective,
   extended-ergative).
 * `Chol.absPosition`: LOW-ABS morpheme placement.
 * `Chol.setAExponent`, `Chol.setBExponent`: the Set A (ERG/GEN) and Set B

--- a/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kaqchikel/Agreement.lean
@@ -24,8 +24,8 @@ collapse to a single marker drawn from the Set B paradigm.
 * `Kaqchikel.setAExponent`, `Kaqchikel.setBExponent`: the Set A (ERG)
   and Set B (ABS) exponent tables ([preminger-2014] table (29)).
 * `Kaqchikel.absPosition`: HIGH-ABS morpheme placement.
-* Case assignment over `ArgumentRole` via `Mayan.ergCaseKaqchikel` and
-  `Mayan.accCaseKaqchikel`; `IsPhiAgreed` records the (non-differential)
+* Case assignment over `ArgumentRole` via `(Mayan.caseKaqchikel .Perf)` and
+  `(Mayan.caseKaqchikel .Prog)`; `IsPhiAgreed` records the (non-differential)
   φ-agreement status of each position.
 * `Kaqchikel.caseInventory`: the {ERG, ABS} case inventory, validated
   against [blake-1994]'s hierarchy.
@@ -40,10 +40,10 @@ is blocked in transitives and the patient goes unagreed ([scott-2023];
 see `Mam/Agreement.lean`) — the non-differential/differential pair
 consumed by `Studies/Just2024.lean`. The AF agreement table
 ([preminger-2014] §3.2, table (22)) and the choice rule that predicts
-it live in `Studies/Preminger2014.lean`. The non-perfective `accCase`
-records [imanishi-2014]'s analysis of the progressive *ajin*
-construction — an analysis, not consensus typology; the derivation
-lives with `Mayan.accCaseKaqchikel` in `Fragments/Mayan/Params.lean`.
+it live in `Studies/Preminger2014.lean`. The non-perfective case pattern
+(`Mayan.caseKaqchikel .Prog`) records [imanishi-2014]'s analysis of the
+progressive *ajin* construction — an analysis, not consensus typology;
+the derivation lives in `Fragments/Mayan/Params.lean`.
 Parenthesized exponent segments drop in certain phonological contexts.
 Person-number cells come from the canonical `Agreement.Cell`
 (`Syntax/Agreement/Paradigm.lean`).
@@ -106,19 +106,19 @@ family-level statement is
 `CoonMateoPedroPreminger2014.mayan_perfective_ergative`. -/
 
 /-- Agent gets ERG (from Voice). -/
-theorem A_case : Mayan.ergCaseKaqchikel .A = .erg := Alignment.ergative.assignCase_A
+theorem A_case : (Mayan.caseKaqchikel .Perf) .A = .erg := Alignment.ergative.assignCase_A
 
 /-- Patient gets ABS (from Infl). -/
-theorem P_case : Mayan.ergCaseKaqchikel .P = .abs := Alignment.ergative.assignCase_P
+theorem P_case : (Mayan.caseKaqchikel .Perf) .P = .abs := Alignment.ergative.assignCase_P
 
 /-- Intransitive S gets ABS (from Infl). -/
-theorem S_case : Mayan.ergCaseKaqchikel .S = .abs := Alignment.ergative.assignCase_S
+theorem S_case : (Mayan.caseKaqchikel .Perf) .S = .abs := Alignment.ergative.assignCase_S
 
 /-- Ergative-absolutive alignment: the agent is distinguished (ERG)
     while patient and intranS share a case value (ABS). -/
 theorem erg_abs_alignment :
-    Mayan.ergCaseKaqchikel .A ≠ Mayan.ergCaseKaqchikel .P ∧
-    Mayan.ergCaseKaqchikel .P = Mayan.ergCaseKaqchikel .S :=
+    (Mayan.caseKaqchikel .Perf) .A ≠ (Mayan.caseKaqchikel .Perf) .P ∧
+    (Mayan.caseKaqchikel .Perf) .P = (Mayan.caseKaqchikel .Perf) .S :=
   Alignment.ergative_distinguishes_A
 
 /-- All core argument positions trigger φ-agreement. -/
@@ -129,12 +129,12 @@ theorem all_positions_agreed (p : ArgumentRole) (_ : p ∈ ArgumentRole.core) :
 /-! ### Case inventory ([blake-1994]) -/
 
 /-- The case inventory realized by the core positions: {ERG, ABS}. -/
-def caseInventory : Finset Case := (ArgumentRole.core.map Mayan.ergCaseKaqchikel).toFinset
+def caseInventory : Finset Case := (ArgumentRole.core.map (Mayan.caseKaqchikel .Perf)).toFinset
 
 /-- The inventory covers all argument positions: every position's case
     is in the inventory. -/
 theorem inventory_covers_positions :
-    ∀ p ∈ ArgumentRole.core, Mayan.ergCaseKaqchikel p ∈ caseInventory := by decide
+    ∀ p ∈ ArgumentRole.core, (Mayan.caseKaqchikel .Perf) p ∈ caseInventory := by decide
 
 -- Kaqchikel's {ERG, ABS} inventory is valid per Blake's case hierarchy
 -- (both are core cases at the top `hierarchyRank`, trivially no gaps).

--- a/Linglib/Fragments/Mayan/Kiche/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Kiche/Agreement.lean
@@ -28,7 +28,7 @@ inverted alignment.
 * `Kiche.setBMarker`, `Kiche.setAPreC`, `Kiche.setAPreV`: the Set B
   (absolutive) and Set A (ergative, pre-consonantal / pre-vocalic)
   exponents.
-* `Kiche.agreementSet`, `Kiche.Mayan.ergCaseKiche`: the
+* `Kiche.agreementSet`, `Kiche.(Mayan.caseKiche .Perf)`: the
   agreement set and case each argument position triggers.
 * `Kiche.independentPronoun`: the free personal pronouns.
 * `Kiche.setAExponent`, `Kiche.setBExponent`: canonical φ-cell exponent
@@ -42,7 +42,7 @@ which is morphologically tripartite (S, A, P each distinct;
 [scott-2023]). K'iche' has two 2nd-person formality levels; the formal
 forms (laal SG, alaq PL) are syntactically postverbal and pattern
 outside the prefix paradigm. K'iche' is HIGH-ABS (Set B pre-stem on
-Infl), and its case wiring reuses `Mayan.ergCaseKiche` (from
+Infl), and its case wiring reuses `(Mayan.caseKiche .Perf)` (from
 `Alignment.ergative`); the canonical φ-cell exponent tables key on
 `Agreement.Cell` for cross-Mayan consumption. Extraction marking (AF
 and *wi*) lives in `Kiche/Extraction.lean`.
@@ -189,8 +189,8 @@ theorem ergative_absolutive_alignment :
 /-- A receives ERG while P and S share a case (ABS) — the ergative
     partition, re-exported from `Alignment.ergative_distinguishes_A`. -/
 theorem erg_abs_pattern :
-    Mayan.ergCaseKiche .A ≠ Mayan.ergCaseKiche .P ∧
-    Mayan.ergCaseKiche .P = Mayan.ergCaseKiche .S :=
+    (Mayan.caseKiche .Perf) .A ≠ (Mayan.caseKiche .Perf) .P ∧
+    (Mayan.caseKiche .Perf) .P = (Mayan.caseKiche .Perf) .S :=
   Alignment.ergative_distinguishes_A
 
 /-- K'iche' alignment contrast with Mam: K'iche' is ergative-absolutive
@@ -198,7 +198,7 @@ theorem erg_abs_pattern :
     receive distinct cases). In K'iche', both P and S trigger Set B;
     in Mam, P triggers no agreement at all. -/
 theorem kiche_not_tripartite :
-    Mayan.ergCaseKiche .S = Mayan.ergCaseKiche .P := rfl
+    (Mayan.caseKiche .Perf) .S = (Mayan.caseKiche .Perf) .P := rfl
 
 /-! ### Set B per-cell verification -/
 

--- a/Linglib/Fragments/Mayan/Mam/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Mam/Agreement.lean
@@ -27,7 +27,7 @@ as a more formal variant ([scott-2023] ch. 3, ex. 156).
 
 * `Mam.setAExponent`, `Mam.setBExponent`: the Set A (ERG) and Set B
   (ABS) exponent tables ([scott-2023] Tables 2.8, 3.5).
-* Tripartite case assignment via `Mayan.ergCaseMam`; `IsPhiAgreed` and
+* Tripartite case assignment via `(Mayan.caseMam .Perf)`; `IsPhiAgreed` and
   `CanBeReduced` classify each `ArgumentRole` by φ-agreement status and
   reduction eligibility.
 * `Mam.PhiDimension` with `.Copied`, `agreedDimensions`,
@@ -150,20 +150,20 @@ instance : DecidablePred CanBeReduced := fun pos => by
 -- is a re-export of the substrate lemma.
 
 /-- Agent gets ERG (inherent, from Voice). -/
-theorem A_case : Mayan.ergCaseMam .A = .erg := Alignment.tripartite.assignCase_A
+theorem A_case : (Mayan.caseMam .Perf) .A = .erg := Alignment.tripartite.assignCase_A
 
 /-- Patient gets ACC (structural, from Voice). -/
-theorem P_case : Mayan.ergCaseMam .P = .acc := Alignment.tripartite.assignCase_P
+theorem P_case : (Mayan.caseMam .Perf) .P = .acc := Alignment.tripartite.assignCase_P
 
 /-- Intransitive S gets ABS (structural, from Infl). -/
-theorem S_case : Mayan.ergCaseMam .S = .abs := Alignment.tripartite.assignCase_S
+theorem S_case : (Mayan.caseMam .Perf) .S = .abs := Alignment.tripartite.assignCase_S
 
 /-- Three distinct underlying cases (morphologically tripartite),
     inherited from `Alignment.tripartite_distinguishes_all`. -/
 theorem tripartite_alignment :
-    Mayan.ergCaseMam .A ≠ Mayan.ergCaseMam .P ∧
-    Mayan.ergCaseMam .A ≠ Mayan.ergCaseMam .S ∧
-    Mayan.ergCaseMam .P ≠ Mayan.ergCaseMam .S :=
+    (Mayan.caseMam .Perf) .A ≠ (Mayan.caseMam .Perf) .P ∧
+    (Mayan.caseMam .Perf) .A ≠ (Mayan.caseMam .Perf) .S ∧
+    (Mayan.caseMam .Perf) .P ≠ (Mayan.caseMam .Perf) .S :=
   Alignment.tripartite_distinguishes_all
 
 /-- Reduction eligibility coincides with φ-agreement — reflexivity,
@@ -175,11 +175,11 @@ theorem reduction_eligible_iff_phi_agreed (pos : ArgumentRole) :
 /-! ### Case inventory ([blake-1994]) -/
 
 /-- The case inventory realized by the core positions: {ERG, ACC, ABS}. -/
-def caseInventory : Finset Case := (ArgumentRole.core.map Mayan.ergCaseMam).toFinset
+def caseInventory : Finset Case := (ArgumentRole.core.map (Mayan.caseMam .Perf)).toFinset
 
 /-- The inventory covers all argument positions. -/
 theorem inventory_covers_positions :
-    ∀ p ∈ ArgumentRole.core, Mayan.ergCaseMam p ∈ caseInventory := by decide
+    ∀ p ∈ ArgumentRole.core, (Mayan.caseMam .Perf) p ∈ caseInventory := by decide
 
 -- Mam's {ERG, ACC, ABS} inventory is valid per Blake's case hierarchy
 -- (all are core cases at rank 6, trivially no gaps).

--- a/Linglib/Fragments/Mayan/Params.lean
+++ b/Linglib/Fragments/Mayan/Params.lean
@@ -180,27 +180,6 @@ def caseQanjobalan : UD.Aspect → ArgumentRole → Case
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.ergative.assignCase r
 
-/-- Perfective projection of `caseChol`. Equals
-    `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseChol : ArgumentRole → Case := caseChol .Perf
-
-/-- Non-perfective (imperfective-and-up) projection of `caseChol`. Equals
-    `Alignment.extendedErgative.assignCase` by definition. Reflects
-    Chol's pattern of split in all non-perfective aspects. -/
-abbrev accCaseChol : ArgumentRole → Case := caseChol .Imp
-
-/-- Perfective projection of `caseQanjobalan`. Equals
-    `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseQanjobalan : ArgumentRole → Case :=
-  caseQanjobalan .Perf
-
-/-- Progressive projection of `caseQanjobalan`. Equals
-    `Alignment.extendedErgative.assignCase` by definition. Reflects
-    Q'anjob'al's `lanan`-construction trigger; other non-perfective
-    aspects in Q'anjob'al keep canonical ergative. -/
-abbrev accCaseQanjobalan : ArgumentRole → Case :=
-  caseQanjobalan .Prog
-
 /-- Kaqchikel (K'ichean-Mamean = Eastern Mayan) aspect-driven case
     assignment. Per [imanishi-2014] §3.3.1 ("Kaqchikel: ERG=OBJ", p. 122)
     and [imanishi-2020] §2.2, Kaqchikel shows a cross-linguistically rare
@@ -223,20 +202,6 @@ def caseKaqchikel : UD.Aspect → ArgumentRole → Case
   | .Perf, r | .Imp, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.ergative.assignCase r
 
-/-- Perfective projection of `caseKaqchikel`. Equals
-    `Alignment.ergative.assignCase` by definition. Kaqchikel perfective
-    is canonical ergative (A → ERG, S/P → ABS). -/
-abbrev ergCaseKaqchikel : ArgumentRole → Case :=
-  caseKaqchikel .Perf
-
-/-- Progressive projection of `caseKaqchikel`. Equals
-    `Alignment.invertedErgative.assignCase` by definition. The
-    construction-specific inverted pattern (S/A → ABS, P → ERG/GEN)
-    documented by Imanishi 2014/2020 for Kaqchikel `ajin`-progressive
-    sentences. -/
-abbrev accCaseKaqchikel : ArgumentRole → Case :=
-  caseKaqchikel .Prog
-
 /-- K'iche' (K'ichean) case assignment. Per [mondloch-2017] (Lessons 9,
     15), K'iche' is uniformly ergative-absolutive with no aspect-conditioned
     split — Set A (ERG) cross-references A across all aspects, Set B (ABS)
@@ -248,11 +213,6 @@ abbrev accCaseKaqchikel : ArgumentRole → Case :=
     map to canonical ergative. -/
 def caseKiche : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.ergative.assignCase r
-
-/-- K'iche' ergative-absolutive case (uniform across aspects). Equals
-    `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseKiche : ArgumentRole → Case :=
-  caseKiche .Perf
 
 /-- San Juan Atitán Mam (K'ichean-Mamean / Eastern Mayan) case assignment.
     Per [scott-2023] ch. 3, SJA Mam is morphologically tripartite — A → ERG
@@ -270,11 +230,6 @@ abbrev ergCaseKiche : ArgumentRole → Case :=
 def caseMam : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.tripartite.assignCase r
 
-/-- SJA Mam tripartite case (uniform across aspects). Equals
-    `Alignment.tripartite.assignCase` by definition. -/
-abbrev ergCaseMam : ArgumentRole → Case :=
-  caseMam .Perf
-
 /-- Tseltalan (Tseltal, Tsotsil) case assignment.
 
     Per [polian-2013] and [aissen-polian-2025]: Tseltalan
@@ -285,11 +240,6 @@ abbrev ergCaseMam : ArgumentRole → Case :=
 def caseTseltalan : UD.Aspect → ArgumentRole → Case
   | _, r => Alignment.ergative.assignCase r
 
-/-- Tseltalan ergative-absolutive case (uniform across aspects). Equals
-    `Alignment.ergative.assignCase` by definition. -/
-abbrev ergCaseTseltalan : ArgumentRole → Case :=
-  caseTseltalan .Perf
-
 /-- Yucatecan aspect/status-driven case assignment ([hofling-2017] p. 692:
     Set A marks transitive subjects and incompletive intransitive
     subjects; Set B marks transitive objects and completive intransitive
@@ -299,14 +249,6 @@ def caseYukatek : UD.Aspect → ArgumentRole → Case
   | .Perf, r => Alignment.ergative.assignCase r
   | .Imp, r | .Prog, r | .Prosp, r | .Hab, r | .Iter, r =>
     Alignment.extendedErgative.assignCase r
-
-/-- Yucatec completive ergative-absolutive case. -/
-abbrev ergCaseYukatek : ArgumentRole → Case :=
-  caseYukatek .Perf
-
-/-- Yucatec incompletive extended-ergative case. -/
-abbrev accCaseYukatek : ArgumentRole → Case :=
-  caseYukatek .Imp
 
 /-! ### Person-number paradigm
 

--- a/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Qanjobal/Agreement.lean
@@ -22,8 +22,8 @@ England 1992:21, Kaufman 1974) — alongside the Cholan-Tzeltalan branch
   markers by following-segment environment (pre-consonantal vs
   pre-vocalic variant shapes) and the Set B absolutive suffixes
   ([coon-mateo-pedro-preminger-2014] table (13)).
-* Case assignment over `ArgumentRole` via `Mayan.ergCaseQanjobalan`
-  (canonical ergative) and `Mayan.accCaseQanjobalan` (split,
+* Case assignment over `ArgumentRole` via `(Mayan.caseQanjobalan .Perf)`
+  (canonical ergative) and `(Mayan.caseQanjobalan .Prog)` (split,
   extended-ergative), shared with Chol.
 * `Qanjobal.absPosition`: HIGH-ABS morpheme placement.
 

--- a/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Yukatek/Agreement.lean
@@ -24,8 +24,8 @@ burying me', [hofling-2017] Table 24.15): Yucatec is LOW-ABS.
 * `Yukatek.setAExponent`, `Yukatek.setBExponent`: the Set A and Set B
   exponent tables ([hofling-2017] Tables 24.8, 24.12).
 * `Yukatek.absPosition`: LOW-ABS morpheme placement.
-* Case assignment over `ArgumentRole` via `Mayan.ergCaseYukatek`
-  (completive, ergative) and `Mayan.accCaseYukatek` (incompletive,
+* Case assignment over `ArgumentRole` via `(Mayan.caseYukatek .Perf)`
+  (completive, ergative) and `(Mayan.caseYukatek .Imp)` (incompletive,
   extended-ergative).
 
 ## Implementation notes

--- a/Linglib/Studies/Baker2015.lean
+++ b/Linglib/Studies/Baker2015.lean
@@ -320,8 +320,8 @@ theorem georgian_present_in_inventory :
 
     The agreement at the table level is provable here: both Baker's
     `Alignment.ergative.assignCase` (the Phase-4 typological ground truth) and
-    the Chol fragment's `ergCase` (which derives from the same function via
-    `Mayan.ergCaseExtErg`) produce identical case for A/S/P. The disagreement
+    the Chol fragment's perfective pattern (`Mayan.caseChol .Perf`, the
+    same function by definition) produce identical case for A/S/P. The disagreement
     is invisible at this level — it shows up only when one asks *why* a given
     case appears, not *which* case appears.
 
@@ -421,7 +421,7 @@ theorem dependent_source_distinct_from_inherent :
   refine ⟨by decide, by decide⟩
 
 /-- The Chol fragment's case table (Phase 3) inherits the equivalence
-    automatically: since `ArgumentRole.agent.ergCase` is definitionally
+    automatically: since `Mayan.caseChol .Perf .A` is definitionally
     equal to `Alignment.ergative.assignCase .A` (via the Phase-3 substrate
     chain), the equivalence theorem above immediately yields
     `getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)`
@@ -430,7 +430,7 @@ theorem dependent_source_distinct_from_inherent :
     can cite it directly. -/
 theorem chol_perfective_ergCase_matches_dependent :
     getCaseOf "agent" (assignCases .ergative transitiveMonoNPs)
-      = some (Mayan.ergCaseChol .A) := by decide
+      = some ((Mayan.caseChol .Perf) .A) := by decide
 
 /-- **Dependent case is INSUFFICIENT for extended ergative.** The Chol
     non-perfective S/A → GEN, P → ABS pattern is a fourth typological

--- a/Linglib/Studies/CoonMateoPedroPreminger2014.lean
+++ b/Linglib/Studies/CoonMateoPedroPreminger2014.lean
@@ -322,21 +322,21 @@ theorem chol_no_syntactic_ergativity :
 /-- Q'anjob'al's ergative alignment matches the standard pattern:
     transitive agent = ERG, transitive object = ABS. -/
 theorem qanjobal_erg_alignment :
-    Mayan.ergCaseQanjobalan .A = .erg ∧
-    Mayan.ergCaseQanjobalan .P = .abs := ⟨rfl, rfl⟩
+    (Mayan.caseQanjobalan .Perf) .A = .erg ∧
+    (Mayan.caseQanjobalan .Perf) .P = .abs := ⟨rfl, rfl⟩
 
 /-- Chol's ergative alignment matches the same standard pattern. -/
 theorem chol_erg_alignment :
-    Mayan.ergCaseChol .A = .erg ∧
-    Mayan.ergCaseChol .P = .abs := ⟨rfl, rfl⟩
+    (Mayan.caseChol .Perf) .A = .erg ∧
+    (Mayan.caseChol .Perf) .P = .abs := ⟨rfl, rfl⟩
 
 /-- Despite sharing ergative morphology, Q'anjob'al and Chol differ in
     whether agent extraction is banned. The difference traces to their
     distinct case loci, not to properties of the ergative NP. -/
 theorem shared_morphology_different_syntax :
     -- Same ergative case on agent
-    Mayan.ergCaseQanjobalan .A =
-      Mayan.ergCaseChol .A ∧
+    (Mayan.caseQanjobalan .Perf) .A =
+      (Mayan.caseChol .Perf) .A ∧
     -- But different syntactic ergativity predictions
     hasSyntacticErgativity .absNom ≠ hasSyntacticErgativity .absDef :=
   ⟨rfl, by decide⟩

--- a/Linglib/Studies/Imanishi2014.lean
+++ b/Linglib/Studies/Imanishi2014.lean
@@ -18,7 +18,7 @@ This study file consumes the substrate primitives in
 `Syntax/Case/Alignment.lean`
 (`Alignment.invertedErgative.assignCase`,
 `Alignment.ergative.assignCase`) and `Fragments/Mayan/Params.lean`
-(`caseKaqchikel`, `ergCaseKaqchikel`, `accCaseKaqchikel`,
+(`caseKaqchikel`, `(Mayan.caseKaqchikel .Perf)`, `(Mayan.caseKaqchikel .Prog)`,
 `caseChol`, `caseQanjobalan`) and verifies that the substrate
 faithfully encodes Imanishi's analysis.
 
@@ -119,35 +119,35 @@ def qanjobalURN : URN := .optional
     `Fragments/Mayan/Params.lean:246`); this theorem verifies the
     derived case values match Imanishi's Kaqchikel-type table (87). -/
 theorem kaqchikel_progressive_matches_imanishi :
-    Mayan.accCaseKaqchikel .A = .abs ∧
-    Mayan.accCaseKaqchikel .P = .gen ∧
-    Mayan.accCaseKaqchikel .S = .abs := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseKaqchikel .Prog) .A = .abs ∧
+    (Mayan.caseKaqchikel .Prog) .P = .gen ∧
+    (Mayan.caseKaqchikel .Prog) .S = .abs := ⟨rfl, rfl, rfl⟩
 
-/-- The substrate's `accCaseKaqchikel` is exactly
+/-- The substrate's `(Mayan.caseKaqchikel .Prog)` is exactly
     `invertedErgative.assignCase` — the Phase F load-bearing theorem.
-    Holds by definitional equality (`accCaseKaqchikel := caseKaqchikel
+    Holds by definitional equality (`(Mayan.caseKaqchikel .Prog) := caseKaqchikel
     .Prog := invertedErgative.assignCase`). -/
 theorem invertedErgative_matches_kaqchikel_progressive :
-    Mayan.accCaseKaqchikel .A = Alignment.invertedErgative.assignCase .A ∧
-    Mayan.accCaseKaqchikel .P = Alignment.invertedErgative.assignCase .P ∧
-    Mayan.accCaseKaqchikel .S = Alignment.invertedErgative.assignCase .S :=
+    (Mayan.caseKaqchikel .Prog) .A = Alignment.invertedErgative.assignCase .A ∧
+    (Mayan.caseKaqchikel .Prog) .P = Alignment.invertedErgative.assignCase .P ∧
+    (Mayan.caseKaqchikel .Prog) .S = Alignment.invertedErgative.assignCase .S :=
   ⟨rfl, rfl, rfl⟩
 
 /-- [imanishi-2014] eq. (88) Chol/Q'anjob'al-type: in their
     non-perfective, S/A → ERG, P → ABS (extended ergative). The
-    substrate's `accCaseChol` returns `extendedErgative.assignCase`. -/
+    substrate's `(Mayan.caseChol .Imp)` returns `extendedErgative.assignCase`. -/
 theorem chol_nonperfective_matches_imanishi :
-    Mayan.accCaseChol .A = .gen ∧
-    Mayan.accCaseChol .P = .abs ∧
-    Mayan.accCaseChol .S = .gen := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseChol .Imp) .A = .gen ∧
+    (Mayan.caseChol .Imp) .P = .abs ∧
+    (Mayan.caseChol .Imp) .S = .gen := ⟨rfl, rfl, rfl⟩
 
 /-- Q'anjob'alan non-perfective matches the same extended-ergative
     pattern as Chol. (Q'anjob'alan only triggers split in PROG, so
-    `accCaseQanjobalan` is `caseQanjobalan .Prog`.) -/
+    `(Mayan.caseQanjobalan .Prog)` is `caseQanjobalan .Prog`.) -/
 theorem qanjobalan_progressive_matches_imanishi :
-    Mayan.accCaseQanjobalan .A = .gen ∧
-    Mayan.accCaseQanjobalan .P = .abs ∧
-    Mayan.accCaseQanjobalan .S = .gen := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseQanjobalan .Prog) .A = .gen ∧
+    (Mayan.caseQanjobalan .Prog) .P = .abs ∧
+    (Mayan.caseQanjobalan .Prog) .S = .gen := ⟨rfl, rfl, rfl⟩
 
 -- ============================================================================
 -- § 3: Cross-Language Inversion — Kaqchikel inverts Chol on A/P axis
@@ -159,8 +159,8 @@ theorem qanjobalan_progressive_matches_imanishi :
     A → ABS and P → GEN. The two-element diff between the substrate
     cases makes the inversion structurally visible. -/
 theorem kaqchikel_inverts_chol_on_AP :
-    Mayan.accCaseKaqchikel .A = Mayan.accCaseChol .P ∧
-    Mayan.accCaseKaqchikel .P = Mayan.accCaseChol .A :=
+    (Mayan.caseKaqchikel .Prog) .A = (Mayan.caseChol .Imp) .P ∧
+    (Mayan.caseKaqchikel .Prog) .P = (Mayan.caseChol .Imp) .A :=
   ⟨rfl, rfl⟩
 
 /-- The S argument behaves identically in both language types: ABS in
@@ -168,7 +168,7 @@ theorem kaqchikel_inverts_chol_on_AP :
     Chol (D-assigned to nominalized-clause-internal subject). The
     inversion is on A and P; S is asymmetric. -/
 theorem S_does_not_invert :
-    Mayan.accCaseKaqchikel .S ≠ Mayan.accCaseChol .S := by
+    (Mayan.caseKaqchikel .Prog) .S ≠ (Mayan.caseChol .Imp) .S := by
   decide
 
 -- ============================================================================
@@ -211,12 +211,12 @@ def imanishiPredictedAccP (lang : URN) : Case :=
 
 /-- The substrate values match Imanishi's URN-driven predictions. -/
 theorem substrate_matches_URN_predictions :
-    Mayan.accCaseKaqchikel .A = imanishiPredictedAccA kaqchikelURN ∧
-    Mayan.accCaseKaqchikel .P = imanishiPredictedAccP kaqchikelURN ∧
-    Mayan.accCaseChol .A = imanishiPredictedAccA cholURN ∧
-    Mayan.accCaseChol .P = imanishiPredictedAccP cholURN ∧
-    Mayan.accCaseQanjobalan .A = imanishiPredictedAccA qanjobalURN ∧
-    Mayan.accCaseQanjobalan .P = imanishiPredictedAccP qanjobalURN :=
+    (Mayan.caseKaqchikel .Prog) .A = imanishiPredictedAccA kaqchikelURN ∧
+    (Mayan.caseKaqchikel .Prog) .P = imanishiPredictedAccP kaqchikelURN ∧
+    (Mayan.caseChol .Imp) .A = imanishiPredictedAccA cholURN ∧
+    (Mayan.caseChol .Imp) .P = imanishiPredictedAccP cholURN ∧
+    (Mayan.caseQanjobalan .Prog) .A = imanishiPredictedAccA qanjobalURN ∧
+    (Mayan.caseQanjobalan .Prog) .P = imanishiPredictedAccP qanjobalURN :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 end Imanishi2014

--- a/Linglib/Studies/Imanishi2020.lean
+++ b/Linglib/Studies/Imanishi2020.lean
@@ -239,29 +239,29 @@ theorem anticausative_ron_compatible :
     fragment: A = ERG, S = P = ABS. Confirms the ergative side is
     shared across all three languages. -/
 theorem kaqchikel_perfective_bridge :
-    Mayan.ergCaseKaqchikel .A = .erg ∧
-    Mayan.ergCaseKaqchikel .P = .abs ∧
-    Mayan.ergCaseKaqchikel .S = .abs :=
+    (Mayan.caseKaqchikel .Perf) .A = .erg ∧
+    (Mayan.caseKaqchikel .Perf) .P = .abs ∧
+    (Mayan.caseKaqchikel .Perf) .S = .abs :=
   ⟨Kaqchikel.A_case, Kaqchikel.P_case, Kaqchikel.S_case⟩
 
 /-- Chol's perfective alignment matches the same ergative pattern. -/
 theorem chol_perfective_bridge :
-    Mayan.ergCaseChol .A = .erg ∧
-    Mayan.ergCaseChol .P = .abs ∧
-    Mayan.ergCaseChol .S = .abs := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseChol .Perf) .A = .erg ∧
+    (Mayan.caseChol .Perf) .P = .abs ∧
+    (Mayan.caseChol .Perf) .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- Q'anjob'al's perfective alignment matches the same ergative pattern. -/
 theorem qanjobal_perfective_bridge :
-    Mayan.ergCaseQanjobalan .A = .erg ∧
-    Mayan.ergCaseQanjobalan .P = .abs ∧
-    Mayan.ergCaseQanjobalan .S = .abs := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseQanjobalan .Perf) .A = .erg ∧
+    (Mayan.caseQanjobalan .Perf) .P = .abs ∧
+    (Mayan.caseQanjobalan .Perf) .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- All three languages share ergative alignment in the perfective. -/
 theorem shared_ergative :
-    Mayan.ergCaseKaqchikel .A =
-      Mayan.ergCaseChol .A ∧
-    Mayan.ergCaseChol .A =
-      Mayan.ergCaseQanjobalan .A := ⟨rfl, rfl⟩
+    (Mayan.caseKaqchikel .Perf) .A =
+      (Mayan.caseChol .Perf) .A ∧
+    (Mayan.caseChol .Perf) .A =
+      (Mayan.caseQanjobalan .Perf) .A := ⟨rfl, rfl⟩
 
 -- ============================================================================
 -- § 9: Case-to-Marker Bridge
@@ -284,49 +284,49 @@ theorem erg_gen_homophonous :
 /-- Chol's fragment case values, mapped through the Mayan marker bridge,
     yield the predicted accusative-side pattern. -/
 theorem chol_case_to_marker_bridge :
-    caseToMarker (Mayan.accCaseChol .A) = cholPattern.sMarker ∧
-    caseToMarker (Mayan.accCaseChol .P) = cholPattern.oMarker :=
+    caseToMarker ((Mayan.caseChol .Imp) .A) = cholPattern.sMarker ∧
+    caseToMarker ((Mayan.caseChol .Imp) .P) = cholPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- Q'anjob'al's fragment case values yield the same pattern as Chol. -/
 theorem qanjobal_case_to_marker_bridge :
-    caseToMarker (Mayan.accCaseQanjobalan .A) = cholPattern.sMarker ∧
-    caseToMarker (Mayan.accCaseQanjobalan .P) = cholPattern.oMarker :=
+    caseToMarker ((Mayan.caseQanjobalan .Prog) .A) = cholPattern.sMarker ∧
+    caseToMarker ((Mayan.caseQanjobalan .Prog) .P) = cholPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- Kaqchikel's fragment accusative-side case values, mapped through the
     Mayan marker bridge, yield the predicted Kaqchikel alignment pattern. -/
 theorem kaqchikel_case_to_marker_bridge :
-    caseToMarker (Mayan.accCaseKaqchikel .A) = kaqchikelPattern.sMarker ∧
-    caseToMarker (Mayan.accCaseKaqchikel .P) = kaqchikelPattern.oMarker :=
+    caseToMarker ((Mayan.caseKaqchikel .Prog) .A) = kaqchikelPattern.sMarker ∧
+    caseToMarker ((Mayan.caseKaqchikel .Prog) .P) = kaqchikelPattern.oMarker :=
   ⟨rfl, rfl⟩
 
 /-- The accusative-side case contrast between Kaqchikel and Chol is a
     true mirror image: agent and patient cases are swapped. -/
 theorem acc_case_mirror :
-    Mayan.accCaseKaqchikel .A =
-      Mayan.accCaseChol .P ∧
-    Mayan.accCaseKaqchikel .P =
-      Mayan.accCaseChol .A := ⟨rfl, rfl⟩
+    (Mayan.caseKaqchikel .Prog) .A =
+      (Mayan.caseChol .Imp) .P ∧
+    (Mayan.caseKaqchikel .Prog) .P =
+      (Mayan.caseChol .Imp) .A := ⟨rfl, rfl⟩
 
 /-- End-to-end: for all three languages, the fragment case data (mapped
     through the marker bridge) matches the parametrically derived pattern.
     This closes the argumentation chain from parameters → alignment → case → markers. -/
 theorem end_to_end_all_languages :
     -- Kaqchikel: fragment cases match derived pattern
-    (caseToMarker (Mayan.accCaseKaqchikel .A) =
+    (caseToMarker ((Mayan.caseKaqchikel .Prog) .A) =
       (deriveAccPattern kaqchikelParams).sMarker ∧
-     caseToMarker (Mayan.accCaseKaqchikel .P) =
+     caseToMarker ((Mayan.caseKaqchikel .Prog) .P) =
       (deriveAccPattern kaqchikelParams).oMarker) ∧
     -- Chol: fragment cases match derived pattern
-    (caseToMarker (Mayan.accCaseChol .A) =
+    (caseToMarker ((Mayan.caseChol .Imp) .A) =
       (deriveAccPattern cholParams).sMarker ∧
-     caseToMarker (Mayan.accCaseChol .P) =
+     caseToMarker ((Mayan.caseChol .Imp) .P) =
       (deriveAccPattern cholParams).oMarker) ∧
     -- Q'anjob'al: fragment cases match derived pattern
-    (caseToMarker (Mayan.accCaseQanjobalan .A) =
+    (caseToMarker ((Mayan.caseQanjobalan .Prog) .A) =
       (deriveAccPattern qanjobalParams).sMarker ∧
-     caseToMarker (Mayan.accCaseQanjobalan .P) =
+     caseToMarker ((Mayan.caseQanjobalan .Prog) .P) =
       (deriveAccPattern qanjobalParams).oMarker) :=
   ⟨⟨rfl, rfl⟩, ⟨rfl, rfl⟩, ⟨rfl, rfl⟩⟩
 

--- a/Linglib/Studies/Just2024.lean
+++ b/Linglib/Studies/Just2024.lean
@@ -673,8 +673,8 @@ theorem kaqArg_role_mapping :
 /-- Ergative-absolutive alignment: A is distinguished (ERG) while P and S
     pattern together (ABS). This parallels Just's A/P split. -/
 theorem erg_abs_matches_AP :
-    Mayan.ergCaseKaqchikel .A ≠ Mayan.ergCaseKaqchikel .P ∧
-    Mayan.ergCaseKaqchikel .P = Mayan.ergCaseKaqchikel .S :=
+    (Mayan.caseKaqchikel .Perf) .A ≠ (Mayan.caseKaqchikel .Perf) .P ∧
+    (Mayan.caseKaqchikel .Perf) .P = (Mayan.caseKaqchikel .Perf) .S :=
   Kaqchikel.erg_abs_alignment
 
 -- ============================================================================

--- a/Linglib/Studies/Scott2023.lean
+++ b/Linglib/Studies/Scott2023.lean
@@ -84,21 +84,21 @@ open Syntax.Case
     the assignment fixed by θ-position rather than by Agree or by NP
     configuration. -/
 theorem voice_assigns_case_by_position :
-    Mayan.ergCaseMam .A = .erg ∧
-    Mayan.ergCaseMam .P = .acc ∧
-    Mayan.ergCaseMam .S = .abs := ⟨rfl, rfl, rfl⟩
+    (Mayan.caseMam .Perf) .A = .erg ∧
+    (Mayan.caseMam .Perf) .P = .acc ∧
+    (Mayan.caseMam .Perf) .S = .abs := ⟨rfl, rfl, rfl⟩
 
 /-- The three argument positions receive three distinct cases — a
     tripartite underlying system (ERG ≠ ACC ≠ ABS) at the case-assignment
     layer, prior to any morphological syncretism. Inherits from
     `Alignment.tripartite_distinguishes_all` via the substrate connection. -/
 theorem voice_based_tripartite :
-    Mayan.ergCaseMam .A ≠
-      Mayan.ergCaseMam .P ∧
-    Mayan.ergCaseMam .A ≠
-      Mayan.ergCaseMam .S ∧
-    Mayan.ergCaseMam .P ≠
-      Mayan.ergCaseMam .S :=
+    (Mayan.caseMam .Perf) .A ≠
+      (Mayan.caseMam .Perf) .P ∧
+    (Mayan.caseMam .Perf) .A ≠
+      (Mayan.caseMam .Perf) .S ∧
+    (Mayan.caseMam .Perf) .P ≠
+      (Mayan.caseMam .Perf) .S :=
   Alignment.tripartite_distinguishes_all
 
 -- ============================================================================
@@ -438,12 +438,12 @@ theorem all_positions_match (pos : ArgumentRole) :
 theorem agreement_is_tripartite :
     -- Agreed-with positions: A (ERG, by Voice) and S (ABS, by Infl)
     IsPhiAgreed .A ∧
-    Mayan.ergCaseMam .A = .erg ∧
+    (Mayan.caseMam .Perf) .A = .erg ∧
     IsPhiAgreed .S ∧
-    Mayan.ergCaseMam .S = .abs ∧
+    (Mayan.caseMam .Perf) .S = .abs ∧
     -- Not agreed-with: P (ACC, from Voice but no φ-Agree)
     ¬ IsPhiAgreed .P ∧
-    Mayan.ergCaseMam .P = .acc :=
+    (Mayan.caseMam .Perf) .P = .acc :=
   ⟨trivial, rfl, trivial, rfl, by decide, rfl⟩
 
 /-- Agreement probes are on different heads: Voice for Set A, Infl for


### PR DESCRIPTION
Answering the naming question from the ArgPosition cleanse: `Mayan.ergCaseChol` and kin were pure projections (`caseChol .Perf`, `caseQanjobalan .Prog`, …) of the real per-language data — the aspect-parameterized `Mayan.case<Lang>` rows of the family table. The eleven projection abbrevs die; call sites name the row and the aspect explicitly (`Mayan.caseChol .Perf`), which also surfaces the per-language split triggers (Cholan splits in all non-perfectives, Q'anjob'alan only under *lanan*, Kaqchikel under *ajin*) that the erg/acc names obscured.