### PR TITLE
refactor(Syntax): spell out GrammaticalFunction; drop dead Basque enum

### DIFF
--- a/Linglib/Fragments/Basque/Agreement.lean
+++ b/Linglib/Fragments/Basque/Agreement.lean
@@ -31,20 +31,6 @@ open Features.Prominence
 open _root_.Agreement
 
 -- ============================================================================
--- § 1: Argument Positions
--- ============================================================================
-
-/-- Argument positions in a Basque clause. -/
-inductive ArgPosition where
-  /-- A: transitive agent (ERG) -/
-  | agent
-  /-- P: transitive patient (ABS) -/
-  | patient
-  /-- S: intransitive subject (ABS) -/
-  | intranS
-  deriving DecidableEq, Repr
-
--- ============================================================================
 -- § 2: Differential P Indexing
 -- ============================================================================
 

--- a/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tseltal/Agreement.lean
@@ -46,7 +46,7 @@ open Mayan (MarkerSet MarkerLinearity ExponentTable)
 open Agreement
 
 -- Re-export shared Tseltalan types
-export Mayan.Tseltalan (GramFunction)
+export Mayan.Tseltalan (GrammaticalFunction)
 
 /-! ### Argument positions -/
 

--- a/Linglib/Fragments/Mayan/Tseltalan.lean
+++ b/Linglib/Fragments/Mayan/Tseltalan.lean
@@ -13,7 +13,7 @@ Tseltal consistently suffixal).
 
 ## Main declarations
 
-* `Mayan.Tseltalan.GramFunction` with `.markerSet` and `.toArgumentRole?`:
+* `Mayan.Tseltalan.GrammaticalFunction` with `.markerSet` and `.toArgumentRole?`:
   the shared Split-S grammatical functions, their Set A / Set B assignment,
   and projection to the canonical `ArgumentRole`.
 * `Mayan.Tseltalan.absPosition`: the subgroup-level LOW-ABS constant.
@@ -37,7 +37,7 @@ open Mayan (MarkerSet)
 /-- Grammatical functions in Tseltalan — traditional Mayanist descriptive
     categories (footnote 9 of [aissen-polian-2025]) — determining which
     agreement marker set cross-references each argument. -/
-inductive GramFunction where
+inductive GrammaticalFunction where
   | A    -- transitive subject (agent)
   | S_A  -- intransitive subject (agentive)
   | S_O  -- intransitive subject (patientive)
@@ -49,7 +49,7 @@ inductive GramFunction where
 /-- The marker set cross-referencing each grammatical function (Set A =
     ergative/genitive, Set B = absolutive); shared across Tseltalan
     ([aissen-polian-2025], [polian-2013]). -/
-def GramFunction.markerSet : GramFunction → MarkerSet
+def GrammaticalFunction.markerSet : GrammaticalFunction → MarkerSet
   | .A   => .setA
   | .S_A => .setB
   | .S_O => .setB
@@ -62,14 +62,14 @@ def GramFunction.markerSet : GramFunction → MarkerSet
 /-- Ergative-genitive homophony: Set A cross-references both transitive
     agents and possessors. A pan-Mayan pattern. -/
 theorem erg_gen_homophonous :
-    GramFunction.A.markerSet = GramFunction.psr.markerSet := rfl
+    GrammaticalFunction.A.markerSet = GrammaticalFunction.psr.markerSet := rfl
 
 /-- All absolutive arguments (S_A, S_O, O, G) use Set B. -/
 theorem abs_uniform :
-    GramFunction.S_A.markerSet = .setB ∧
-    GramFunction.S_O.markerSet = .setB ∧
-    GramFunction.O.markerSet = .setB ∧
-    GramFunction.G.markerSet = .setB := ⟨rfl, rfl, rfl, rfl⟩
+    GrammaticalFunction.S_A.markerSet = .setB ∧
+    GrammaticalFunction.S_O.markerSet = .setB ∧
+    GrammaticalFunction.O.markerSet = .setB ∧
+    GrammaticalFunction.G.markerSet = .setB := ⟨rfl, rfl, rfl, rfl⟩
 
 /-! ### Absolutive position (LOW-ABS) -/
 
@@ -88,9 +88,9 @@ def absPosition : Mayan.ABSPosition := .low
     agentivity distinction (lossy but expected for cross-Mayan theorems that
     don't track Split-S); `.psr → none`, since possessors are DP-internal
     with no `ArgumentRole` analog. Cross-Mayan consumers use this projection;
-    the Aissen-Polian possessor-extraction analysis uses `GramFunction`
+    the Aissen-Polian possessor-extraction analysis uses `GrammaticalFunction`
     directly for its DP-internal claims. -/
-def GramFunction.toArgumentRole? : GramFunction → Option ArgumentRole
+def GrammaticalFunction.toArgumentRole? : GrammaticalFunction → Option ArgumentRole
   | .A   => some .A
   | .S_A => some .S
   | .S_O => some .S

--- a/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
+++ b/Linglib/Fragments/Mayan/Tsotsil/Agreement.lean
@@ -44,7 +44,7 @@ open Mayan (MarkerSet MarkerLinearity ExponentTable)
 open Agreement
 
 -- Re-export shared Tseltalan types
-export Mayan.Tseltalan (GramFunction)
+export Mayan.Tseltalan (GrammaticalFunction)
 
 /-! ### Argument positions -/
 

--- a/Linglib/Semantics/ArgumentStructure/Linking.lean
+++ b/Linglib/Semantics/ArgumentStructure/Linking.lean
@@ -245,11 +245,11 @@ theorem canonical_profiles_wellformed (r : ThetaRole) :
 
 namespace ArgumentStructure.Linking
 
-/-- Which argument position in the clause we're asking about.
+/-- The grammatical function a linking theory's output targets.
     Theory-neutral: expressed as grammatical functions, not structural
     positions (Spec-vP, Comp-VP, etc.), so that theories with different
     structural vocabularies can all target the same output. -/
-inductive ArgPosition where
+inductive GrammaticalFunction where
   | subject         -- Grammatical subject (external or raised)
   | directObject    -- Direct object
   | indirectObject  -- Indirect object / dative
@@ -290,7 +290,7 @@ structure LinkingTheory (Verb Ctx : Type) where
   compatible : Verb → List Ctx
   /-- Predict each argument's theta role in a given context.
       Returns `none` for positions the theory is silent about. -/
-  predict : Verb → Ctx → ArgPosition → Option ThetaRole
+  predict : Verb → Ctx → GrammaticalFunction → Option ThetaRole
 
 -- ════════════════════════════════════════════════════════════════════════
 -- § 7. Testing predictions against fragment data
@@ -303,7 +303,7 @@ structure LinkingTheory (Verb Ctx : Type) where
     if ANY context produces the correct prediction — the fragment entry
     records one use of the verb, not all possible uses. -/
 def LinkingTheory.matchesAt {Verb Ctx : Type} [BEq Ctx]
-    (th : LinkingTheory Verb Ctx) (v : Verb) (pos : ArgPosition)
+    (th : LinkingTheory Verb Ctx) (v : Verb) (pos : GrammaticalFunction)
     (actual : Option ThetaRole) : Bool :=
   (th.compatible v).any fun ctx => th.predict v ctx pos == actual
 

--- a/Linglib/Studies/AissenPolian2025.lean
+++ b/Linglib/Studies/AissenPolian2025.lean
@@ -87,7 +87,7 @@ alongside Tz'utujil, Chickasaw, Sinitic double-unaccusative).
 - `NominalProjection.Position` / `PossessionType` from `NominalProjection.lean`
 - `SpecificityCondition` from `Core/SpecificityCondition.lean`
 - `JudgmentType` — [kuroda-1972]'s categorical/thetic distinction, defined in §9
-- `GramFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
+- `GrammaticalFunction`, `absPosition` from `Fragments/Mayan/Tseltalan.lean`
 - `ABSPosition` from `Fragments/Mayan/Params.lean`
 - `Probe.Profile` from `Syntax/Minimalist/Probe/Profile.lean`;
   `isClosestGoalIn`, `behindHorizonIn` from `Syntax/Minimalist/Agree/Basic.lean`;
@@ -459,11 +459,11 @@ instance (j : JudgmentType) : Decidable j.HasψSubject :=
 
     [aissen-polian-2025] §5, Table 1: all ψ-subject constructions
     are structurally unaccusative, so the ψ-subject is always S_O. -/
-def ψSubjectGramFunction : GramFunction := .S_O
+def ψSubjectGrammaticalFunction : GrammaticalFunction := .S_O
 
-/-- ψ-subject agreement is DERIVED from GramFunction.markerSet:
+/-- ψ-subject agreement is DERIVED from GrammaticalFunction.markerSet:
     ψ-subjects are S_O, and S_O maps to Set B (absolutive). -/
-def ψSubjectMarkerSet : MarkerSet := ψSubjectGramFunction.markerSet
+def ψSubjectMarkerSet : MarkerSet := ψSubjectGrammaticalFunction.markerSet
 
 /-- ψ-subjects receive Set B (absolutive) agreement — derived from
     the fact that they are S_O, and S_O maps to Set B. -/
@@ -598,7 +598,7 @@ theorem ψ_constructions_no_vP (c : ψConstruction) :
 /-- The ψ-subject grammatical function in every §5 construction is S_O
     ([aissen-polian-2025] §5: in all three, the ψ-subject raises
     from an unaccusative-internal-argument position). -/
-def ψConstruction.ψSubjectFunction (_ : ψConstruction) : GramFunction :=
+def ψConstruction.ψSubjectFunction (_ : ψConstruction) : GrammaticalFunction :=
   .S_O
 
 /-- Every §5 ψ-construction assigns S_O to its ψ-subject. -/
@@ -623,7 +623,7 @@ def ψPPConstruction.clauseType (_ : ψPPConstruction) : ArgumentStructureClass 
     (possessor of object of preposition). The §6.2 cases differ from §5
     in that the ψ-subject originates inside a PP rather than a PossP,
     but the grammatical function on the verb tracks the Theme not the
-    extracted possessor. We do not assign a `GramFunction` here for the
+    extracted possessor. We do not assign a `GrammaticalFunction` here for the
     extracted Psr-OP because Psr-OP has no per-verb agreement slot in
     the Tseltalan paradigm. -/
 theorem ψ_pp_constructions_unaccusative (c : ψPPConstruction) :

--- a/Linglib/Studies/AndersonJM2006.lean
+++ b/Linglib/Studies/AndersonJM2006.lean
@@ -60,7 +60,7 @@ two-feature simplification).
 
 namespace AndersonJM2006
 
-open ArgumentStructure.Linking (LinkingTheory ArgPosition)
+open ArgumentStructure.Linking (LinkingTheory GrammaticalFunction)
 open ArgumentStructure
 open English.Predicates.Verbal
 
@@ -224,7 +224,7 @@ theorem Case.acc_abs_same_relation :
 namespace AndersonJM2006
 
 open ArgumentStructure
-open ArgumentStructure.Linking (LinkingTheory ArgPosition)
+open ArgumentStructure.Linking (LinkingTheory GrammaticalFunction)
 open English.Predicates.Verbal
 
 -- ============================================================================

--- a/Linglib/Syntax/ConstructionGrammar/Basic.lean
+++ b/Linglib/Syntax/ConstructionGrammar/Basic.lean
@@ -120,7 +120,7 @@ def SlotFiller.isOpen {Lex : Type*} : SlotFiller Lex → Bool
 /-- Grammatical function of a valence member ([kay-fillmore-1999],
 Figure 12), distinct from semantic role: a subject can be an agent, a
 theme, or an experiencer. -/
-inductive GramFunction where
+inductive GrammaticalFunction where
   /-- Subject. -/
   | subj
   /-- Clausal or verbal complement. -/
@@ -158,7 +158,7 @@ structure Slot (Lex : Type*) where
   /-- Bar level of the position (`some .zero` = a word-level slot) -/
   level : Option BarLevel := none
   /-- Grammatical function (subj, comp, obj, pred) — [kay-fillmore-1999] -/
-  gf : Option GramFunction := none
+  gf : Option GrammaticalFunction := none
   /-- Coreference index: slots sharing an index have unified semantics -/
   refIdx : Option RefIndex := none
   /-- Syntactic constraints on this slot ([loc -], [neg -], [ref ∅]) -/


### PR DESCRIPTION
Supersedes #2324. All three `GramFunction`s become `GrammaticalFunction` (CxG's, Tseltalan's, and Linking's — the latter renamed from `ArgPosition`, whose cells and docstring are grammatical functions). `Basque.Agreement.ArgPosition` had zero uses and is deleted.