### PR TITLE
refactor(Studies/LittleMoroneyRoyer2022): ground roots in substrate

### DIFF
--- a/Linglib/Features/NounCategorization/Basic.lean
+++ b/Linglib/Features/NounCategorization/Basic.lean
@@ -199,7 +199,7 @@ def collectSemantics (cls : List ClassifierEntry) : List SemanticParameter :=
 /-- The semantic strategy a theoretical framework attributes to classifier
     constructions. Three competing positions are represented:
 
-    - **forNumeral** (CLF-for-NUM): [krifka-1995], [bale-coon-2014],
+    - **forNumeral** (CLF-for-NUM): [krifka-1995b], [bale-coon-2014],
       [little-moroney-royer-2022]. The classifier is a measure function
       required by the numeral. The numeral takes the classifier as its first
       argument: ⟦TWO⟧ = λm⟨e,n⟩λPλx.[P(x) ∧ m(x) = 2]. Predicts: numeral

--- a/Linglib/Semantics/Classifier.lean
+++ b/Linglib/Semantics/Classifier.lean
@@ -22,7 +22,7 @@ correct, for different languages:
   `⟦CLF⟧ = λPλx.[P(x) ∧ Atom(x)]`. This is `Mereology.atomize`.
   Languages: Shan, Mandarin, Japanese.
 
-- **CLF-for-NUM** ([krifka-1995]; [bale-coon-2014]): the
+- **CLF-for-NUM** ([krifka-1995b]; [bale-coon-2014]): the
   classifier is a measure function required by the numeral.
   `⟦TWO⟧ = λmλPλx.[P(x) ∧ m(x) = 2]`. This is `Mereology.QMOD`.
   Languages: Ch'ol.
@@ -79,7 +79,7 @@ theorem clfForNoun_sub {α : Type*} [PartialOrder α]
   atomize_sub h
 
 -- ============================================================================
--- §2: CLF-for-NUM — Measure Modification ([krifka-1995])
+-- §2: CLF-for-NUM — Measure Modification ([krifka-1995b])
 -- ============================================================================
 
 /-- CLF-for-NUM denotation: the classifier is a measure function, and

--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -1,207 +1,217 @@
-import Linglib.Features.NounCategorization.Basic
-import Linglib.Syntax.Tree.Cat
-import Linglib.Logic.Assignment
-import Linglib.Semantics.Intensional.Defs
+import Linglib.Semantics.Classifier
 import Linglib.Semantics.Composition.Tree
 import Linglib.Studies.Chierchia1998
+import Linglib.Studies.IoninMatushansky2006
 import Linglib.Fragments.Mayan.Chol.ClassifierSystem
 import Linglib.Fragments.Shan.ClassifierSystem
 
 /-!
 # Little, Moroney & Royer (2022)
-[little-moroney-royer-2022]
 
-Classifiers can be for numerals *or* nouns: Two strategies for numeral
-modification. *Glossa* 7(1). 1–35.
+Numeral classifiers are not one thing. In a classifier-for-numeral
+language the classifier is the measure function the numeral demands; in a
+classifier-for-noun language it atomizes the noun so that a partition
+numeral can count. Ch'ol takes the first path and Shan the second, with
+constituency `[[Num Clf] N]` versus `[Num [Clf N]]`, yet both reach the
+same denotation for *two dogs*.
 
-Numeral classifiers form a heterogeneous class. Ch'ol (CLF-for-NUM, the
-classifier is a measure function required by the numeral) and Shan
-(CLF-for-N, the classifier atomizes the noun denotation) take different
-compositional paths to the same denotation for "two dogs". This file
-exercises that claim against linglib's type-driven composition
-machinery: two `Tree String` derivations, distinct lexicons, identical
-extension at the root.
+The two lexicons `cholLex` and `shanLex` are driven through
+`Semantics.Composition.Tree.interp` over the substrate's own classifier
+denotations: the Ch'ol root is `Semantics.Classifier.clfForNum`
+(`cholTree_interp`), the Shan root is `IoninMatushansky2006.cardMod` over
+`Semantics.Classifier.clfForNoun` (`shanTree_interp`), and the two agree
+(`forNumeral_iff_forNoun`). The distributional diagnostics of the paper's
+§4 then follow from the lexical types alone — what composes without a noun
+(`chol_numClf_composes`, `shan_numClf_fails`) and what composes without a
+numeral (`shan_clfNoun_composes`, `chol_clfNoun_fails`, `chol_ocho`).
 
-## Main declarations
+Pluralities are `Finset α`, the atoms and their sums with `∅` excluded by
+`Finset.Nonempty`, so the measure function μ# is `Finset.card` at type
+`⟨e,d⟩`. Prediction 2 of §4 (nouns that need no classifier) rests on
+Vietnamese rather than Ch'ol or Shan data and is not formalized.
 
-* `cholStrategy`, `shanStrategy` — LMR's per-language assignments
-* `Predictions` — LMR's four-diagnostic battery (Table 8)
-* `cholTree`, `cholLex`, `shanTree`, `shanLex` — derivations (51), (52)
-  driven through `Semantics.Composition.Tree.interp`
-* `cholTree_interprets`, `shanTree_interprets` — `rfl` witnesses that
-  Heim-Kratzer FA composes the lexicons through the trees
-* `section5_extensionally_equal` — LMR §5 main result: the two trees
-  evaluate to extensionally-equal predicates of type `⟨e,t⟩`
+## References
 
-## Implementation notes
-
-The semantic carrier is `Finset Dog` (atomic powerset model with `∅`
-excluded by `.Nonempty`). The Heim-Kratzer Ty system (`e`, `t`, `fn`,
-`intens`) lacks a number type, so LMR's measure function `μ_# : ⟨e,n⟩`
-is folded into the numeral's denotation as a `Finset.card`-via-`Prop`
-constraint rather than realized as a stand-alone constituent of type
-`⟨e,n⟩`. The constituency contrast — `[[Num Clf] N]` vs `[Num [Clf N]]`
-— is faithful; only the type of the measure is encoded indirectly.
+* [little-moroney-royer-2022], §2.3 (6)–(13), §3.4, §4, §4.5 (51)–(52)
+* [ionin-matushansky-2006]
+* [chierchia-1998]
+* [bale-coon-2014]
+* [borer-2005]
+* [krifka-1995b]
 -/
 
 namespace LittleMoroneyRoyer2022
 
-open NounCategorization
-open Intensional (Ty)
-open Semantics.Montague (LexEntry Lexicon)
+open Intensional (Ty Denot)
+open Semantics.Classifier (clfForNum clfForNoun)
 open Semantics.Composition.Tree (interp)
+open Semantics.Montague (Lexicon)
 open Syntax (Tree)
+open IoninMatushansky2006 (cardMod IsAtomOf cardMod_atoms_iff)
+open NounCategorization (ClassifierStrategy)
 
-abbrev chol := Chol.classifierSystem
-abbrev shan := Shan.classifierSystem
+/-! ### The two strategies -/
 
-/-! ### Predictions (Table 8) -/
-
-structure Predictions where
-  numeralIdiosyncrasies : Prop
-  nounIdiosyncrasies : Prop
-  clfBeyondNumerals : Prop
-  clfInCounting : Prop
-
-def clfForNumPredictions : Predictions where
-  numeralIdiosyncrasies := True
-  nounIdiosyncrasies := False
-  clfBeyondNumerals := False
-  clfInCounting := True
-
-def clfForNounPredictions : Predictions where
-  numeralIdiosyncrasies := False
-  nounIdiosyncrasies := True
-  clfBeyondNumerals := True
-  clfInCounting := False
-
+/-- Ch'ol is classifier-for-numeral (Table 8). -/
 def cholStrategy : ClassifierStrategy := .forNumeral
+
+/-- Shan is classifier-for-noun (Table 8). -/
 def shanStrategy : ClassifierStrategy := .forNoun
 
-theorem profiles_distinct : clfForNumPredictions ≠ clfForNounPredictions := fun h =>
-  cast (congrArg Predictions.numeralIdiosyncrasies h) trivial
+variable {α : Type} (g : Assignment (Finset α))
 
-/-! ### Plural co-occurrence (§3.4)
+/-! ### Count nouns, measured and atomized -/
 
-[little-moroney-royer-2022] §3.4 refines [borer-2005]'s
-complementarity intuition: CLF and PL share a functional projection in
-CLF-for-N languages, separate projections in CLF-for-NUM languages. -/
+/-- A count noun denotes the atoms and their sums ((6)). -/
+def dogs (x : Finset α) : Prop := x.Nonempty
 
-theorem complementarity_refined_by_strategy :
-    cholStrategy = .forNumeral ∧ chol.PluralClfCooccur ∧
-      shanStrategy = .forNoun ∧ ¬ shan.PluralClfCooccur := by decide
+/-- μ#, the atom-counting measure ((8)). -/
+def atomMeasure (x : Finset α) : ℚ := x.card
 
-/-! ### Compositional derivation (§2.3, §5)
+theorem clfForNum_dogs_iff (x : Finset α) : clfForNum dogs atomMeasure 2 x ↔ x.card = 2 := by
+  simp only [clfForNum, Mereology.QMOD, dogs, atomMeasure, ← Finset.card_pos]
+  norm_cast
+  omega
 
-Worked example on three dogs. The two trees compose under
-`Semantics.Composition.Tree.interp` against per-language lexicons; the
-§5 main result is established as extensional equivalence of the root
-denotations. -/
+/-- Atomizing a count noun yields its atoms, `IoninMatushansky2006.IsAtomOf`. -/
+theorem clfForNoun_dogs : (clfForNoun dogs : Finset α → Prop) = IsAtomOf (λ _ => True) := by
+  funext x
+  simp only [clfForNoun, Mereology.atomize, minimal_iff, IsAtomOf, true_and, dogs, eq_iff_iff]
+  constructor
+  · rintro ⟨⟨a, ha⟩, h⟩
+    exact ⟨a, h (Finset.singleton_nonempty a) (Finset.singleton_subset_iff.2 ha)⟩
+  · rintro ⟨a, rfl⟩
+    refine ⟨Finset.singleton_nonempty a, λ y hy hle => ?_⟩
+    rcases Finset.subset_singleton_iff.1 hle with rfl | rfl
+    · exact absurd hy Finset.not_nonempty_empty
+    · rfl
 
-inductive Dog | a | b | c
-  deriving DecidableEq, Repr, Fintype
+/-! ### Ch'ol: classifier-for-numeral -/
 
-/-! LMR's semantic carrier is `Finset Dog` (Link-style sums of dog-atoms with
-`∅` excluded downstream by `.Nonempty`), with `Unit` indices (extensional). -/
+/-- *cha'* 'two' takes a measure function and then a predicate ((7)), the
+classifier *-kojty* is μ# ((8)) keyed on `Chol.Classifiers.kojty`, the
+Spanish loan *ocho* 'eight' has its measure built in ((34b)), and *ts'i'*
+is 'dog'. -/
+def cholLex : Lexicon (Finset α) Unit := λ w =>
+  if w = "cha'" then some ⟨(.e ⇒ .d) ⇒ (.e ⇒ .t) ⇒ .e ⇒ .t,
+    show (Finset α → ℚ) → (Finset α → Prop) → Finset α → Prop from
+      λ m P x => P x ∧ m x = 2⟩
+  else if w = Chol.Classifiers.kojty.form then some ⟨.e ⇒ .d, atomMeasure⟩
+  else if w = "ocho" then some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t,
+    show (Finset α → Prop) → Finset α → Prop from λ P x => P x ∧ atomMeasure x = 8⟩
+  else if w = "ts'i'" then some ⟨.e ⇒ .t, dogs⟩
+  else none
 
-/-- Empty variable assignment; the §2.3 trees contain no traces. -/
-def emptyAssign : Assignment (Finset Dog) := fun _ => ∅
+/-- *cha'-kojty*: numeral and classifier form a constituent ((23a)). -/
+def cholNumClf : Tree Unit String := .bin (.leaf "cha'") (.leaf Chol.Classifiers.kojty.form)
 
-/-- Ch'ol lexicon. cha' is the measure-loaded numeral
-`λκ λP λx. P x ∧ κ x ∧ |x| = 2`; kojty contributes a (semantically
-vacuous) sortal restriction; ts'i' is the dog predicate. The
-`⟨e,n⟩` measure type is folded into cha'. -/
-def cholLex : Lexicon (Finset Dog) Unit
-  | "cha'" => some
-      { ty := .fn (.fn .e .t) (.fn (.fn .e .t) (.fn .e .t))
-        denot := fun (κ : Finset Dog → Prop) (P : Finset Dog → Prop)
-                     (x : Finset Dog) => P x ∧ κ x ∧ x.card = 2 }
-  | "kojty" => some
-      { ty := .fn .e .t
-        denot := fun (_ : Finset Dog) => True }
-  | "ts'i'" => some
-      { ty := .fn .e .t
-        denot := fun (x : Finset Dog) => x.Nonempty }
-  | _ => none
+/-- `[[cha' -kojty] ts'i']` ((51)). -/
+def cholTree : Tree Unit String := .bin cholNumClf (.leaf "ts'i'")
 
-/-- Shan lexicon. tǒ atomizes the noun predicate (`λP λx. P x ∧ |x| = 1`);
-sǒŋ selects 2-element joins of distinct atoms from an atomized predicate;
-mǎa is the dog predicate. -/
-def shanLex : Lexicon (Finset Dog) Unit
-  | "sǒŋ" => some
-      { ty := .fn (.fn .e .t) (.fn .e .t)
-        denot := fun (P : Finset Dog → Prop) (x : Finset Dog) =>
-          ∃ d₁ d₂ : Dog, d₁ ≠ d₂ ∧ P {d₁} ∧ P {d₂} ∧ x = {d₁, d₂} }
-  | "tǒ" => some
-      { ty := .fn (.fn .e .t) (.fn .e .t)
-        denot := fun (P : Finset Dog → Prop) (x : Finset Dog) =>
-          P x ∧ x.card = 1 }
-  | "mǎa" => some
-      { ty := .fn .e .t
-        denot := fun (x : Finset Dog) => x.Nonempty }
-  | _ => none
+/-- The Ch'ol root is the measure-modified noun `λx. dogs x ∧ μ# x = 2` ((51)). -/
+theorem cholTree_interp :
+    interp (Finset α) Unit cholLex g cholTree = some ⟨.e ⇒ .t, clfForNum dogs atomMeasure 2⟩ :=
+  rfl
 
-/-- Ch'ol derivation (51): `[[cha' kojty] ts'i']`. Num+CLF form a
-constituent that then applies to the noun. -/
-def cholTree : Tree Unit String :=
-  .bin (.bin (.leaf "cha'") (.leaf "kojty")) (.leaf "ts'i'")
+/-- Numeral and classifier compose without a noun, into the measure phrase
+`λP λx. P x ∧ μ# x = 2` ((45)–(46), Prediction 4). -/
+theorem chol_numClf_composes :
+    interp (Finset α) Unit cholLex g cholNumClf =
+      some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t, λ P => clfForNum P atomMeasure 2⟩ :=
+  rfl
 
-/-- Shan derivation (52): `[sǒŋ [tǒ mǎa]]`. CLF+N form a constituent
-that the numeral then selects from. -/
-def shanTree : Tree Unit String :=
-  .bin (.leaf "sǒŋ") (.bin (.leaf "tǒ") (.leaf "mǎa"))
+/-- The classifier, a measure of type `⟨e,d⟩`, cannot compose with the noun
+without the numeral ((43a)). -/
+theorem chol_clfNoun_fails :
+    interp (Finset α) Unit cholLex g (.bin (.leaf Chol.Classifiers.kojty.form) (.leaf "ts'i'")) =
+      none :=
+  rfl
 
-/-- Ch'ol composition: `cha'(kojty)(ts'i')` = `λx. ts'i'(x) ∧ kojty(x) ∧
-|x| = 2` after two rounds of FA. -/
-def cholDenot : Finset Dog → Prop :=
-  fun x => x.Nonempty ∧ True ∧ x.card = 2
-
-/-- Shan composition: `sǒŋ(tǒ(mǎa))` = `λx. ∃ d₁ d₂, d₁ ≠ d₂ ∧
-(tǒ(mǎa)) {d₁} ∧ (tǒ(mǎa)) {d₂} ∧ x = {d₁,d₂}` after two rounds of FA. -/
-def shanDenot : Finset Dog → Prop :=
-  fun x => ∃ d₁ d₂ : Dog, d₁ ≠ d₂ ∧
-    (({d₁} : Finset Dog).Nonempty ∧ ({d₁} : Finset Dog).card = 1) ∧
-    (({d₂} : Finset Dog).Nonempty ∧ ({d₂} : Finset Dog).card = 1) ∧
-    x = {d₁, d₂}
-
-/-- The Ch'ol tree interprets to `cholDenot` via two FA steps under the
-Ch'ol lexicon. -/
-theorem cholTree_interprets :
-    interp (Finset Dog) Unit cholLex emptyAssign cholTree =
-      some ⟨.fn .e .t, cholDenot⟩ := rfl
-
-/-- The Shan tree interprets to `shanDenot` via two FA steps under the
-Shan lexicon. -/
-theorem shanTree_interprets :
-    interp (Finset Dog) Unit shanLex emptyAssign shanTree =
-      some ⟨.fn .e .t, shanDenot⟩ := rfl
-
-/-- LMR §5 main result: despite different constituency and different
-per-word lexical entries, the two derivations yield extensionally
-equivalent root denotations on the count-noun case. The proof discharges
-the trivial conjuncts and reduces to `Finset.card_eq_two`. -/
-theorem section5_extensionally_equal (x : Finset Dog) :
-    cholDenot x ↔ shanDenot x := by
-  simp only [cholDenot, shanDenot]
-  refine ⟨?_, ?_⟩
-  · rintro ⟨_, _, hcard⟩
-    obtain ⟨d₁, d₂, hne, rfl⟩ := Finset.card_eq_two.mp hcard
-    refine ⟨d₁, d₂, hne, ?_, ?_, rfl⟩
-    · exact ⟨⟨d₁, Finset.mem_singleton.mpr rfl⟩, Finset.card_singleton d₁⟩
-    · exact ⟨⟨d₂, Finset.mem_singleton.mpr rfl⟩, Finset.card_singleton d₂⟩
-  · rintro ⟨d₁, d₂, hne, _, _, rfl⟩
-    exact ⟨⟨d₁, Finset.mem_insert_self d₁ {d₂}⟩, trivial, Finset.card_pair hne⟩
-
-/-! ### Cross-paper consistency with Chierchia 1998 -/
-
-/-- Shan agrees with [chierchia-1998]'s NMP prediction for
-Mandarin/Japanese — all three are CLF-for-N. -/
-theorem shan_agrees_with_chierchia :
-    shanStrategy = NMP.mandarinStrategy ∧ shanStrategy = NMP.japaneseStrategy :=
+/-- *ocho* composes with the noun directly and rejects the classifier
+((33)–(34), Prediction 1). -/
+theorem chol_ocho :
+    interp (Finset α) Unit cholLex g (.bin (.leaf "ocho") (.leaf "ts'i'")) =
+        some ⟨.e ⇒ .t, clfForNum dogs atomMeasure 8⟩ ∧
+      interp (Finset α) Unit cholLex g (.bin (.leaf "ocho") (.leaf Chol.Classifiers.kojty.form)) =
+        none :=
   ⟨rfl, rfl⟩
 
-/-- Ch'ol is CLF-for-NUM, *not* the CLF-for-N predicted for
-Mandarin/Japanese under NMP. -/
-theorem chol_differs_from_chierchia : cholStrategy ≠ NMP.mandarinStrategy := by decide
+section
+
+variable [DecidableEq α]
+
+/-! ### Shan: classifier-for-noun -/
+
+/-- *sɔ̌ŋ* 'two' is the partition numeral ((10), `IoninMatushansky2006.cardMod`),
+the classifier *tǒ* atomizes ((13), `Semantics.Classifier.clfForNoun`) keyed
+on `Shan.Classifiers.to`, and *mǎa* is 'dog'. -/
+def shanLex : Lexicon (Finset α) Unit := λ w =>
+  if w = "sɔ̌ŋ" then some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t, cardMod 2⟩
+  else if w = Shan.Classifiers.to.form then some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t,
+    show (Finset α → Prop) → Finset α → Prop from clfForNoun⟩
+  else if w = "mǎa" then some ⟨.e ⇒ .t, dogs⟩
+  else none
+
+/-- *tǒ mǎa*: classifier and noun form a constituent ((23b)). -/
+def shanClfNoun : Tree Unit String := .bin (.leaf Shan.Classifiers.to.form) (.leaf "mǎa")
+
+/-- `[sɔ̌ŋ [tǒ mǎa]]` ((52)), abstracting from the surface order *mǎa sɔ̌ŋ tǒ*
+((25)) as the paper does. -/
+def shanTree : Tree Unit String := .bin (.leaf "sɔ̌ŋ") shanClfNoun
+
+/-- The Shan root is the partition numeral over the atomized noun ((52)). -/
+theorem shanTree_interp :
+    interp (Finset α) Unit shanLex g shanTree = some ⟨.e ⇒ .t, cardMod 2 (clfForNoun dogs)⟩ :=
+  rfl
+
+/-- Classifier and noun compose without a numeral, yielding the atoms
+((42), Prediction 3). -/
+theorem shan_clfNoun_composes :
+    interp (Finset α) Unit shanLex g shanClfNoun =
+      some ⟨.e ⇒ .t, (clfForNoun dogs : Finset α → Prop)⟩ :=
+  rfl
+
+/-- Numeral and classifier, both `⟨⟨e,t⟩,⟨e,t⟩⟩`, do not compose without the
+noun ((48)–(49)). -/
+theorem shan_numClf_fails :
+    interp (Finset α) Unit shanLex g (.bin (.leaf "sɔ̌ŋ") (.leaf Shan.Classifiers.to.form)) =
+      none :=
+  rfl
+
+/-! ### One denotation for *two dogs* -/
+
+/-- Derivationally distinct, the two strategies denote the same two-dog
+pluralities (§4.5). -/
+theorem forNumeral_iff_forNoun (x : Finset α) :
+    clfForNum dogs atomMeasure 2 x ↔ cardMod 2 (clfForNoun dogs) x := by
+  simp [clfForNum_dogs_iff, clfForNoun_dogs, cardMod_atoms_iff]
+
+/-- Three dogs ((6)). -/
+inductive Dog | a | b | c
+  deriving DecidableEq, Fintype
+
+-- *two dogs* denotes `{ab, ac, bc}` ((51)–(52)).
+example (x : Finset Dog) :
+    clfForNum dogs atomMeasure 2 x ↔
+      x ∈ ({{.a, .b}, {.a, .c}, {.b, .c}} : Finset (Finset Dog)) := by
+  rw [clfForNum_dogs_iff]; revert x; decide
+
+end
+
+/-! ### Plural marking -/
+
+/-- [borer-2005]'s classifier–plural complementarity holds in Shan, where
+both occupy one projection, and lifts in Ch'ol ((30), §3.4). -/
+theorem plural_cooccurrence :
+    Chol.classifierSystem.PluralClfCooccur ∧ ¬ Shan.classifierSystem.PluralClfCooccur := by
+  decide
+
+/-! ### Against a uniform classifier semantics -/
+
+/-- [chierchia-1998]'s classifier-for-noun analysis of Mandarin extends to
+Shan but not to Ch'ol. -/
+theorem chierchia_covers_shan_not_chol :
+    shanStrategy = NMP.mandarinStrategy ∧ cholStrategy ≠ NMP.mandarinStrategy := by
+  decide
 
 end LittleMoroneyRoyer2022

--- a/Linglib/Studies/Sudo2016.lean
+++ b/Linglib/Studies/Sudo2016.lean
@@ -43,9 +43,7 @@ but the semantics of numerals. His core proposal:
 noun) and `Sudo2016.japaneseStrategy = .sudoBlocking` (CLF blocks the
 silent ∪-operator on numerals) commit to incompatible analyses of the
 same empirical fact (Japanese requires classifiers). The disagreement is
-proved structurally in `sudo_disagrees_with_chierchia_on_japanese` below
-and propagates to divergent empirical predictions through LMR's
-diagnostic battery (`LittleMoroneyRoyer2022.predictionsOf`).
+proved structurally in `sudo_disagrees_with_chierchia_on_japanese` below.
 
 ## What is formalized
 
@@ -599,11 +597,7 @@ def japaneseStrategy : NounCategorization.ClassifierStrategy := .sudoBlocking
 /-- Sudo and Chierchia disagree about which strategy Japanese exhibits:
     Chierchia's analysis assigns `.forNoun` (CLF atomizes a kind-denoting
     noun); Sudo's assigns `.sudoBlocking` (CLF blocks the silent ∪-operator
-    on numerals). The disagreement is structural, not editorial.
-
-    The two also disagree on the *empirical predictions* this generates
-    under [little-moroney-royer-2022]'s diagnostic battery — see
-    `LittleMoroneyRoyer2022.predictionsOf` for the per-strategy profiles. -/
+    on numerals). The disagreement is structural, not editorial. -/
 theorem sudo_disagrees_with_chierchia_on_japanese :
     japaneseStrategy ≠ NMP.japaneseStrategy := by decide
 


### PR DESCRIPTION
Rework the LMR 2022 study so its derivations run over the substrate's own classifier denotations and its §4 diagnostics are derived rather than stipulated.

- μ# is a genuine `⟨e,d⟩` classifier entry (`Ty.d` exists; the old note claiming no number type was false), (13) is `Semantics.Classifier.clfForNoun`, (10) is `IoninMatushansky2006.cardMod`; classifier leaves are keyed on the Fragment forms.
- Predictions 1, 3, 4 of §4 fall out of the lexical types via `interp` (compose/fail pairs), replacing the hand-set `Predictions` record that nothing consumed.
- Fix the dangling `[krifka-1995]` keys and Sudo2016's reference to a nonexistent `predictionsOf`.