### PR TITLE
feat(Semantics/Intensional): degree scale parameter; lattice valuations

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -260,6 +260,7 @@ import Linglib.Core.Order.SetPreimage
 import Linglib.Core.Order.SignVectors
 import Linglib.Core.Order.StrictBounds
 import Linglib.Core.Order.SuccPred.Tree
+import Linglib.Core.Order.Valuation
 import Linglib.Core.Order.TotalPreorder
 import Linglib.Core.Order.Tree
 import Linglib.Core.Order.TreePath

--- a/Linglib/Core/Order/Valuation.lean
+++ b/Linglib/Core/Order/Valuation.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Robert Hawkins. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Hawkins
+-/
+import Mathlib.Algebra.Group.Defs
+import Mathlib.Algebra.Group.Nat.Defs
+import Mathlib.Data.Finset.Card
+import Mathlib.Order.Disjoint
+import Mathlib.Order.ModularLattice
+import Mathlib.Order.Monotone.Defs
+
+/-!
+# Valuations on lattices
+
+A *valuation* on a lattice is a function `v` into an additive commutative
+monoid satisfying the modular law `v (a ⊔ b) + v (a ⊓ b) = v a + v b`; it is
+*positive* when it is strictly monotone. Cardinality of finite sets is the
+model example (`Finset.card`), and finitely additive set functions —
+`MeasureTheory.AddContent` on a ring of sets, a measure on the measurable
+sets — are the set-lattice instances. Mathlib states the modular law per
+instance (`Finset.card_union_add_card_inter`, `Set.ncard_union_add_ncard_inter`,
+`MeasureTheory.measure_union_add_inter`) with no common structure; this file
+supplies it, together with Birkhoff's theorem that a lattice carrying a
+positive valuation is modular. `[UPSTREAM]` candidate.
+
+## Main declarations
+
+* `IsLatticeValuation v` — the modular law; additive on disjoint pairs once
+  `v ⊥ = 0` (`IsLatticeValuation.map_sup_of_disjoint`).
+* `IsPositiveValuation v` — a strictly monotone valuation.
+* `IsPositiveValuation.isModularLattice` — a lattice with a positive
+  valuation into a cancellative monoid is modular.
+* `Finset.card` is a positive valuation.
+
+## References
+
+* [birkhoff-1967], Chapter X
+-/
+
+variable {α M : Type*}
+
+/-- A lattice valuation: `v (a ⊔ b) + v (a ⊓ b) = v a + v b`. -/
+class IsLatticeValuation [Lattice α] [AddCommMonoid M] (v : α → M) : Prop where
+  map_sup_add_map_inf (a b : α) : v (a ⊔ b) + v (a ⊓ b) = v a + v b
+
+export IsLatticeValuation (map_sup_add_map_inf)
+
+/-- A positive valuation: a strictly monotone lattice valuation. -/
+class IsPositiveValuation [Lattice α] [AddCommMonoid M] [Preorder M] (v : α → M) : Prop
+    extends IsLatticeValuation v where
+  strictMono : StrictMono v
+
+namespace IsLatticeValuation
+
+variable [Lattice α] [OrderBot α] [AddCommMonoid M] (v : α → M) [IsLatticeValuation v]
+  {a b : α}
+
+/-- A valuation vanishing at `⊥` is additive on disjoint pairs. -/
+theorem map_sup_of_disjoint (h0 : v ⊥ = 0) (h : Disjoint a b) : v (a ⊔ b) = v a + v b := by
+  simpa [h.eq_bot, h0] using map_sup_add_map_inf (v := v) a b
+
+end IsLatticeValuation
+
+namespace IsPositiveValuation
+
+variable [Lattice α] [AddCommMonoid M] [Preorder M]
+
+/-- A lattice carrying a positive valuation into a cancellative monoid is
+modular: for `x ≤ z`, the elements `x ⊔ y ⊓ z ≤ (x ⊔ y) ⊓ z` have the same join
+and meet with `y`, hence the same valuation, hence coincide. -/
+theorem isModularLattice [IsRightCancelAdd M] (v : α → M) [IsPositiveValuation v] :
+    IsModularLattice α where
+  sup_inf_le_assoc_of_le {x} y {z} hxz := by
+    have hab : x ⊔ y ⊓ z ≤ (x ⊔ y) ⊓ z :=
+      sup_le (le_inf le_sup_left hxz) (inf_le_inf_right z le_sup_right)
+    have h₁ : (x ⊔ y ⊓ z) ⊔ y = ((x ⊔ y) ⊓ z) ⊔ y :=
+      le_antisymm (sup_le_sup_right hab y)
+        (sup_le (inf_le_left.trans (sup_le (le_sup_left.trans le_sup_left) le_sup_right))
+          le_sup_right)
+    have h₂ : (x ⊔ y ⊓ z) ⊓ y = ((x ⊔ y) ⊓ z) ⊓ y :=
+      le_antisymm (inf_le_inf_right y hab)
+        (le_inf ((le_inf inf_le_right (inf_le_left.trans inf_le_right)).trans le_sup_right)
+          inf_le_right)
+    have h := map_sup_add_map_inf (v := v) (x ⊔ y ⊓ z) y
+    rw [h₁, h₂] at h
+    have hv : v (x ⊔ y ⊓ z) = v ((x ⊔ y) ⊓ z) :=
+      add_right_cancel (h.symm.trans (map_sup_add_map_inf (v := v) ((x ⊔ y) ⊓ z) y))
+    exact hab.lt_or_eq.elim (fun hlt => absurd hv (strictMono (v := v) hlt).ne) fun heq => heq.ge
+
+end IsPositiveValuation
+
+instance [DecidableEq α] : IsPositiveValuation (Finset.card : Finset α → ℕ) where
+  map_sup_add_map_inf := Finset.card_union_add_card_inter
+  strictMono := Finset.card_strictMono
+
+example [DecidableEq α] {s t : Finset α} (h : Disjoint s t) : (s ∪ t).card = s.card + t.card :=
+  IsLatticeValuation.map_sup_of_disjoint Finset.card Finset.card_empty h

--- a/Linglib/Semantics/Composition/LexEntry.lean
+++ b/Linglib/Semantics/Composition/LexEntry.lean
@@ -21,17 +21,17 @@ open Intensional
 
 /-- A typed lexical entry whose denotation carries the effect `M`
 (default `Id` = pure H&K). -/
-structure LexEntry (E W : Type) (M : Type → Type := Id) where
+structure LexEntry (E W : Type) (M : Type → Type := Id) (D : Type := ℝ) where
   ty : Ty
-  denot : M (Denot E W ty)
+  denot : M (Denot E W ty D)
 
 /-- String-keyed lexicon of `M`-effectful entries (default `Id`). -/
-def Lexicon (E W : Type) (M : Type → Type := Id) :=
-  String → Option (LexEntry E W M)
+def Lexicon (E W : Type) (M : Type → Type := Id) (D : Type := ℝ) :=
+  String → Option (LexEntry E W M D)
 
 /-- Embed a pure lexicon into effect `M` by `pure`-lifting every entry. -/
-def Lexicon.lift {E W : Type} (M : Type → Type) [Pure M] (lex : Lexicon E W) :
-    Lexicon E W M :=
+def Lexicon.lift {E W D : Type} (M : Type → Type) [Pure M] (lex : Lexicon E W Id D) :
+    Lexicon E W M D :=
   λ w => (lex w).map λ e => ⟨e.ty, pure e.denot⟩
 
 end Semantics.Montague

--- a/Linglib/Semantics/Composition/Reduction.lean
+++ b/Linglib/Semantics/Composition/Reduction.lean
@@ -341,7 +341,7 @@ private theorem interpBinary_t_tt (p : Denot E W .t) (F : Denot E W (.t ⇒ .t))
     interpBinary (M := Id) ⟨.t, p⟩ ⟨.t ⇒ .t, F⟩ = some ⟨.t, F p⟩ := rfl
 
 private theorem predAbs_id_dist :
-    PredAbs.dist? (M := Id) (E := E) (W := W) = some (fun _ f => f) := rfl
+    PredAbs.dist? (M := Id) (E := E) (W := W) (D := ℝ) = some (fun _ f => f) := rfl
 
 /-- Congruence for truth-valued results: an `Iff` lifts through
 `some ⟨.t, ·⟩`. -/

--- a/Linglib/Semantics/Composition/Tree.lean
+++ b/Linglib/Semantics/Composition/Tree.lean
@@ -49,9 +49,9 @@ open Semantics.Montague (Lexicon)
 /-- A typed denotation: a linguistic type together with an `M`-computation
 over its denotation domain. The default `M := Id` recovers the
 [heim-kratzer-1998] carrier; effectful values supply `M` explicitly. -/
-structure TypedDenot (E W : Type) (M : Type → Type := Id) where
+structure TypedDenot (E W : Type) (M : Type → Type := Id) (D : Type := ℝ) where
   ty : Ty
-  val : M (Denot E W ty)
+  val : M (Denot E W ty D)
 
 /-- Capability for Predicate Abstraction under effect `M`: an
 **entity-distributor** commuting `M` over entity-indexed families.
@@ -63,10 +63,10 @@ simultaneously — so binding under such effects arises from `bind`-order
 or the W ⊣ R adjunction instead (`Studies/BumfordCharlow2024.lean`). Making
 the distributor optional turns the QR/PA-vs-effect-sequencing rivalry
 into a fact checked by instance resolution. -/
-class PredAbs (M : Type → Type) (E W : Type) where
-  dist? : Option (∀ ty : Ty, (E → M (Denot E W ty)) → M (E → Denot E W ty))
+class PredAbs (M : Type → Type) (E W : Type) (D : Type := ℝ) where
+  dist? : Option (∀ ty : Ty, (E → M (Denot E W ty D)) → M (E → Denot E W ty D))
 
-instance (E W : Type) : PredAbs Id E W := ⟨some λ _ f => f⟩
+instance (E W D : Type) : PredAbs Id E W D := ⟨some λ _ f => f⟩
 
 def canApply (funTy argTy : Ty) : Option Ty :=
   match funTy with
@@ -74,41 +74,41 @@ def canApply (funTy argTy : Ty) : Option Ty :=
   | _ => none
 
 /-- TN: lexical lookup. -/
-def interpTerminal (E W : Type) {M : Type → Type} (lex : Lexicon E W M)
-    (word : String) : Option (TypedDenot E W M) :=
+def interpTerminal (E W : Type) {M : Type → Type} {D : Type} (lex : Lexicon E W M D)
+    (word : String) : Option (TypedDenot E W M D) :=
   (lex word).map λ entry => ⟨entry.ty, entry.denot⟩
 
 /-- NN: identity. -/
-def interpNonBranching {E W : Type} {M : Type → Type}
-    (daughter : TypedDenot E W M) : TypedDenot E W M :=
+def interpNonBranching {E W D : Type} {M : Type → Type}
+    (daughter : TypedDenot E W M D) : TypedDenot E W M D :=
   daughter
 
 /-- FA: `⟦β⟧(⟦γ⟧)` -/
-def interpFA {E W : Type} {σ τ : Ty}
-    (f : Denot E W (σ ⇒ τ)) (x : Denot E W σ) : Denot E W τ :=
+def interpFA {E W D : Type} {σ τ : Ty}
+    (f : Denot E W (σ ⇒ τ) D) (x : Denot E W σ D) : Denot E W τ D :=
   f x
 
 /-- Forward FA: the function is the left daughter `df`, the argument `da`. -/
-def applyForward {E W : Type} {M : Type → Type} [Applicative M]
-    (df da : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def applyForward {E W D : Type} {M : Type → Type} [Applicative M]
+    (df da : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   match hf : df.ty with
   | .fn σ τ =>
     if ha : σ = da.ty then
-      let f : M (Denot E W (σ ⇒ τ)) := hf ▸ df.val
-      let a : M (Denot E W σ) := ha ▸ da.val
+      let f : M (Denot E W (σ ⇒ τ) D) := hf ▸ df.val
+      let a : M (Denot E W σ D) := ha ▸ da.val
       some ⟨τ, f <*> a⟩
     else none
   | _ => none
 
 /-- Backward FA: the function is the right daughter `df`, the argument `da`. The
 left daughter `da` sequences first, hence the `(λ x g => g x)` combinator. -/
-def applyBackward {E W : Type} {M : Type → Type} [Applicative M]
-    (da df : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def applyBackward {E W D : Type} {M : Type → Type} [Applicative M]
+    (da df : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   match hf : df.ty with
   | .fn σ τ =>
     if ha : σ = da.ty then
-      let f : M (Denot E W (σ ⇒ τ)) := hf ▸ df.val
-      let a : M (Denot E W σ) := ha ▸ da.val
+      let f : M (Denot E W (σ ⇒ τ) D) := hf ▸ df.val
+      let a : M (Denot E W σ D) := ha ▸ da.val
       some ⟨τ, (λ x g => g x) <$> a <*> f⟩
     else none
   | _ => none
@@ -116,8 +116,8 @@ def applyBackward {E W : Type} {M : Type → Type} [Applicative M]
 /-- Try FA in both orders, sequencing effects in linear order (the left daughter's
 effects fire first regardless of which daughter is the function): function on the
 left (`applyForward`), else on the right (`applyBackward`). -/
-def tryFA {E W : Type} {M : Type → Type} [Applicative M]
-    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def tryFA {E W D : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   applyForward d1 d2 <|> applyBackward d1 d2
 
 /-- IFA: Intensional Functional Application ([von-fintel-heim-2011] Step 10).
@@ -128,20 +128,20 @@ def tryFA {E W : Type} {M : Type → Type} [Applicative M]
     take the intension of their sister as argument via type-driven composition.
 
     Tries both orders (β,γ) and (γ,β); effects sequence in linear order. -/
-def tryIFA {E W : Type} {M : Type → Type} [Applicative M]
-    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def tryIFA {E W D : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   match hf : d1.ty with
   | .fn (.intens σ) τ =>
     if ha : σ = d2.ty then
-      let f : M (Denot E W (.fn (.intens σ) τ)) := hf ▸ d1.val
-      let a : M (Denot E W σ) := ha ▸ d2.val
+      let f : M (Denot E W (.fn (.intens σ) τ) D) := hf ▸ d1.val
+      let a : M (Denot E W σ D) := ha ▸ d2.val
       some ⟨τ, (λ fv av => fv (up av)) <$> f <*> a⟩
     else
       match hf' : d2.ty with
       | .fn (.intens σ') τ' =>
         if ha' : σ' = d1.ty then
-          let f : M (Denot E W (.fn (.intens σ') τ')) := hf' ▸ d2.val
-          let a : M (Denot E W σ') := ha' ▸ d1.val
+          let f : M (Denot E W (.fn (.intens σ') τ') D) := hf' ▸ d2.val
+          let a : M (Denot E W σ' D) := ha' ▸ d1.val
           some ⟨τ', (λ av fv => fv (up av)) <$> a <*> f⟩
         else none
       | _ => none
@@ -149,19 +149,19 @@ def tryIFA {E W : Type} {M : Type → Type} [Applicative M]
     match hf : d2.ty with
     | .fn (.intens σ) τ =>
       if ha : σ = d1.ty then
-        let f : M (Denot E W (.fn (.intens σ) τ)) := hf ▸ d2.val
-        let a : M (Denot E W σ) := ha ▸ d1.val
+        let f : M (Denot E W (.fn (.intens σ) τ) D) := hf ▸ d2.val
+        let a : M (Denot E W σ D) := ha ▸ d1.val
         some ⟨τ, (λ av fv => fv (up av)) <$> a <*> f⟩
       else none
     | _ => none
 
 /-- PM: combine two `⟨e,t⟩` predicates. -/
-def tryPM {E W : Type} {M : Type → Type} [Applicative M]
-    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def tryPM {E W D : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   match h1 : d1.ty, h2 : d2.ty with
   | .fn .e .t, .fn .e .t =>
-    let p1 : M (Denot E W (.e ⇒ .t)) := h1 ▸ d1.val
-    let p2 : M (Denot E W (.e ⇒ .t)) := h2 ▸ d2.val
+    let p1 : M (Denot E W (.e ⇒ .t) D) := h1 ▸ d1.val
+    let p2 : M (Denot E W (.e ⇒ .t) D) := h2 ▸ d2.val
     some ⟨.fn .e .t, Modifier.intersective <$> p1 <*> p2⟩
   | _, _ => none
 
@@ -169,22 +169,22 @@ def tryPM {E W : Type} {M : Type → Type} [Applicative M]
 combines with an eventuality predicate `⟨e,t⟩`, conjoining the predicate
 onto the head's event argument — `λx.λe. f(x)(e) ∧ g(e)`. Tried in both
 orders; effects sequence in linear order. -/
-def tryEI {E W : Type} {M : Type → Type} [Applicative M]
-    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def tryEI {E W D : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   match h1 : d1.ty, h2 : d2.ty with
   | .fn .e (.fn .e .t), .fn .e .t =>
-    let f : M (Denot E W (.e ⇒ .e ⇒ .t)) := h1 ▸ d1.val
-    let p : M (Denot E W (.e ⇒ .t)) := h2 ▸ d2.val
+    let f : M (Denot E W (.e ⇒ .e ⇒ .t) D) := h1 ▸ d1.val
+    let p : M (Denot E W (.e ⇒ .t) D) := h2 ▸ d2.val
     some ⟨.e ⇒ .e ⇒ .t, (λ fv pv => λ x e => fv x e ∧ pv e) <$> f <*> p⟩
   | .fn .e .t, .fn .e (.fn .e .t) =>
-    let p : M (Denot E W (.e ⇒ .t)) := h1 ▸ d1.val
-    let f : M (Denot E W (.e ⇒ .e ⇒ .t)) := h2 ▸ d2.val
+    let p : M (Denot E W (.e ⇒ .t) D) := h1 ▸ d1.val
+    let f : M (Denot E W (.e ⇒ .e ⇒ .t) D) := h2 ▸ d2.val
     some ⟨.e ⇒ .e ⇒ .t, (λ pv fv => λ x e => fv x e ∧ pv e) <$> p <*> f⟩
   | _, _ => none
 
 /-- Binary node: try FA, then IFA, then PM, then EI. -/
-def interpBinary {E W : Type} {M : Type → Type} [Applicative M]
-    (d1 d2 : TypedDenot E W M) : Option (TypedDenot E W M) :=
+def interpBinary {E W D : Type} {M : Type → Type} [Applicative M]
+    (d1 d2 : TypedDenot E W M D) : Option (TypedDenot E W M D) :=
   tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2 <|> tryEI d1 d2
 
 /-! ### Tree interpretation -/
@@ -217,9 +217,9 @@ The category parameter `C` is ignored during interpretation — composition
 is type-driven, not category-driven. This means the same function works
 for `Tree Cat String` (UD-grounded), `Tree Unit String` (category-free),
 or any other category system. -/
-def interp (E W : Type) {M : Type → Type} [Applicative M] [PredAbs M E W]
-    (lex : Lexicon E W M) (g : Assignment E)
-    : Tree C String → Option (TypedDenot E W M)
+def interp (E W : Type) {M : Type → Type} [Applicative M] {D : Type} [PredAbs M E W D]
+    (lex : Lexicon E W M D) (g : Assignment E)
+    : Tree C String → Option (TypedDenot E W M D)
   | .terminal _ w => interpTerminal E W lex w
   | .node _ (t :: []) => (interp E W lex g t).map interpNonBranching
   | .node _ (t1 :: t2 :: []) => do
@@ -229,7 +229,7 @@ def interp (E W : Type) {M : Type → Type} [Applicative M] [PredAbs M E W]
   | .node _ _ => none
   | .trace n _ => some ⟨.e, pure (g n)⟩
   | .bind n _ body => do
-    let dist ← PredAbs.dist? (M := M) (E := E) (W := W)
+    let dist ← PredAbs.dist? (M := M) (E := E) (W := W) (D := D)
     let ⟨bodyTy, probeVal⟩ ← interp E W lex g body
     some ⟨.fn .e bodyTy, dist bodyTy λ (x : E) =>
       match interp E W lex (g[n ↦ x]) body with
@@ -239,8 +239,8 @@ def interp (E W : Type) {M : Type → Type} [Applicative M] [PredAbs M E W]
 /-- Extract truth value from (pure) tree interpretation. Effectful roots
 discharge through per-effect handlers instead (`handleScope` and kin in
 `Studies/BumfordCharlow2024.lean`). -/
-def evalTree {E W : Type} [∀ (p : Denot E W .t), Decidable p]
-    (lex : Lexicon E W) (g : Assignment E) (t : Tree C String)
+def evalTree {E W D : Type} [∀ (p : Denot E W .t D), Decidable p]
+    (lex : Lexicon E W Id D) (g : Assignment E) (t : Tree C String)
     : Option Bool :=
   match interp E W lex g t with
   | some ⟨.t, b⟩ => some (decide b)
@@ -252,8 +252,8 @@ def evalTree {E W : Type} [∀ (p : Denot E W .t), Decidable p]
     rather than a bare truth value — e.g., trees containing EXH
     or other propositional operators. Evaluate the result at a
     specific world to get a truth value. -/
-def evalTreeProp {E W : Type} [∀ (p : Denot E W .t), Decidable p]
-    (lex : Lexicon E W) (g : Assignment E) (t : Tree C String)
+def evalTreeProp {E W D : Type} [∀ (p : Denot E W .t D), Decidable p]
+    (lex : Lexicon E W Id D) (g : Assignment E) (t : Tree C String)
     : Option (W → Bool) :=
   match interp E W lex g t with
   | some ⟨.intens .t, p⟩ => some (λ w => decide (p w))
@@ -274,14 +274,14 @@ section Properties
 
 variable {M : Type → Type}
 
-theorem interpNonBranching_id {E W : Type} (d : TypedDenot E W M) :
+theorem interpNonBranching_id {E W D : Type} (d : TypedDenot E W M D) :
     interpNonBranching d = d := rfl
 
-theorem interpFA_type {E W : Type} {σ τ : Ty}
-    (f : Denot E W (σ ⇒ τ)) (x : Denot E W σ)
-    : (interpFA f x : Denot E W τ) = f x := rfl
+theorem interpFA_type {E W D : Type} {σ τ : Ty}
+    (f : Denot E W (σ ⇒ τ) D) (x : Denot E W σ D)
+    : (interpFA f x : Denot E W τ D) = f x := rfl
 
-theorem tryPM_preserves_type {E W : Type} [Applicative M] (d1 d2 : TypedDenot E W M)
+theorem tryPM_preserves_type {E W D : Type} [Applicative M] (d1 d2 : TypedDenot E W M D)
     (h1 : d1.ty = .fn .e .t) (h2 : d2.ty = .fn .e .t)
     : ∃ d, tryPM d1 d2 = some d ∧ d.ty = .fn .e .t := by
   cases d1 with | mk ty1 val1 =>
@@ -290,7 +290,7 @@ theorem tryPM_preserves_type {E W : Type} [Applicative M] (d1 d2 : TypedDenot E 
   subst h1 h2
   exact ⟨_, rfl, rfl⟩
 
-theorem interpBinary_eq {E W : Type} [Applicative M] (d1 d2 : TypedDenot E W M) :
+theorem interpBinary_eq {E W D : Type} [Applicative M] (d1 d2 : TypedDenot E W M D) :
     interpBinary d1 d2 =
     (tryFA d1 d2 <|> tryIFA d1 d2 <|> tryPM d1 d2 <|> tryEI d1 d2) := rfl
 
@@ -305,33 +305,33 @@ complementary layer, and is type-shape-specific because the modes case on `Ty`. 
 
 section Reduction
 
-variable {C : Type} {E W : Type} {M : Type → Type} [Applicative M] [PredAbs M E W]
+variable {C : Type} {E W D : Type} {M : Type → Type} [Applicative M] [PredAbs M E W D]
 
-@[simp] theorem interp_terminal (lex : Lexicon E W M) (g : Assignment E)
+@[simp] theorem interp_terminal (lex : Lexicon E W M D) (g : Assignment E)
     (c : C) (w : String) :
     interp E W lex g (.terminal c w : Tree C String) = interpTerminal E W lex w := rfl
 
-@[simp] theorem interp_node_binary (lex : Lexicon E W M) (g : Assignment E)
+@[simp] theorem interp_node_binary (lex : Lexicon E W M D) (g : Assignment E)
     (c : C) (t₁ t₂ : Tree C String) :
     interp E W lex g (.node c (t₁ :: t₂ :: []))
       = ((interp E W lex g t₁).bind fun d₁ =>
           (interp E W lex g t₂).bind fun d₂ => interpBinary d₁ d₂) := rfl
 
-omit [Applicative M] [PredAbs M E W] in
-@[simp] theorem interpTerminal_lookup (lex : Lexicon E W M) (w : String) :
+omit [Applicative M] [PredAbs M E W D] in
+@[simp] theorem interpTerminal_lookup (lex : Lexicon E W M D) (w : String) :
     interpTerminal E W lex w = (lex w).map fun e => ⟨e.ty, e.denot⟩ := rfl
 
-omit [PredAbs M E W] in
+omit [PredAbs M E W D] in
 /-- Forward FA reduces generally (abstract `σ τ`). Backward FA stays
 type-shape-specific, since forward fires first when the left daughter is itself a
 function. -/
-@[simp] theorem applyForward_fn {σ τ : Ty} (f : M (Denot E W (σ ⇒ τ))) (x : M (Denot E W σ)) :
-    applyForward (⟨σ ⇒ τ, f⟩ : TypedDenot E W M) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
+@[simp] theorem applyForward_fn {σ τ : Ty} (f : M (Denot E W (σ ⇒ τ) D)) (x : M (Denot E W σ D)) :
+    applyForward (⟨σ ⇒ τ, f⟩ : TypedDenot E W M D) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
   simp only [applyForward, ↓reduceDIte]
 
-omit [PredAbs M E W] in
-@[simp] theorem tryFA_forward {σ τ : Ty} (f : M (Denot E W (σ ⇒ τ))) (x : M (Denot E W σ)) :
-    tryFA (⟨σ ⇒ τ, f⟩ : TypedDenot E W M) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
+omit [PredAbs M E W D] in
+@[simp] theorem tryFA_forward {σ τ : Ty} (f : M (Denot E W (σ ⇒ τ) D)) (x : M (Denot E W σ D)) :
+    tryFA (⟨σ ⇒ τ, f⟩ : TypedDenot E W M D) ⟨σ, x⟩ = some ⟨τ, f <*> x⟩ := by
   simp only [tryFA, applyForward_fn]; rfl
 
 end Reduction

--- a/Linglib/Semantics/Intensional/Algebra.lean
+++ b/Linglib/Semantics/Intensional/Algebra.lean
@@ -237,16 +237,16 @@ With these in scope, [partee-rooth-1983]'s `genConj`/`genDisj` are `⊓`/`⊔` a
 *every* conjoinable type (not just the `t` base case proved above), so the bespoke
 recursion is provably the pointwise lattice operation. -/
 
-instance instBooleanAlgebraDenotT : BooleanAlgebra (Denot E W .t) :=
+instance instBooleanAlgebraDenotT {D : Type} : BooleanAlgebra (Denot E W .t D) :=
   inferInstanceAs (BooleanAlgebra Prop)
 
-instance instBooleanAlgebraDenotFn (a b : Ty) [BooleanAlgebra (Denot E W b)] :
-    BooleanAlgebra (Denot E W (a ⇒ b)) :=
-  inferInstanceAs (BooleanAlgebra (Denot E W a → Denot E W b))
+instance instBooleanAlgebraDenotFn {D : Type} (a b : Ty) [BooleanAlgebra (Denot E W b D)] :
+    BooleanAlgebra (Denot E W (a ⇒ b) D) :=
+  inferInstanceAs (BooleanAlgebra (Denot E W a D → Denot E W b D))
 
-instance instBooleanAlgebraDenotIntens (a : Ty) [BooleanAlgebra (Denot E W a)] :
-    BooleanAlgebra (Denot E W (.intens a)) :=
-  inferInstanceAs (BooleanAlgebra (W → Denot E W a))
+instance instBooleanAlgebraDenotIntens {D : Type} (a : Ty) [BooleanAlgebra (Denot E W a D)] :
+    BooleanAlgebra (Denot E W (.intens a) D) :=
+  inferInstanceAs (BooleanAlgebra (W → Denot E W a D))
 
 open Conjunction in
 /-- Generalized conjunction is `⊓` at `⟨e,t⟩` — the inductive step, where the

--- a/Linglib/Semantics/Intensional/Defs.lean
+++ b/Linglib/Semantics/Intensional/Defs.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Rat.Defs
+import Mathlib.Data.Real.Basic
 
 /-!
 # Intensional Logic: Types and Denotations
@@ -45,13 +46,15 @@ inductive Ty where
   | e : Ty
   | t : Ty
   /-- Degrees (type `d`): the scale sort of degree semantics
-      ([heim-2001], [wellwood-2015]). Denoted by ℚ, the repo's exact
-      degree carrier. -/
+      ([heim-2001], [wellwood-2015]). Denoted by the model's scale `D`,
+      `Denot`'s trailing parameter (default `ℝ`): a degree is a value of a
+      measure on the part structure, and the number system is only its
+      representation. -/
   | d : Ty
   /-- Numbers (type `n`): the cardinality sort — [sudo-2016]'s type-n
       numerals, [scontras-2014]'s CARD, the measure-function codomain
       ⟨e,n⟩ of [little-moroney-royer-2022]. Denoted by ℕ; distinct from
-      degrees `d` (ℚ), into which cardinality embeds by `Nat.cast`. -/
+      degrees `d`, into whose scale cardinality embeds by `Nat.cast`. -/
   | n : Ty
   /-- Events (type `v`): the neo-Davidsonian event sort ([davidson-1967],
       [parsons-1990]). -/
@@ -131,7 +134,7 @@ def Ty.isConjoinable : Ty → Bool
 
     D_e = E
     D_t = Prop
-    D_d = ℚ
+    D_d = D   (the degree scale, a model parameter like `E` and `W`; default ℝ)
     D_n = ℕ
     D_⟨a,b⟩ = D_a → D_b
     D_⟨s,a⟩ = W → D_a
@@ -142,22 +145,23 @@ def Ty.isConjoinable : Ty → Bool
     interpretation is the extension point — a carrier-parametric
     variant of `Denot` supplying event and state domains — and lands
     with the first study that composes event-typed denotations. -/
-def Denot (E W : Type) : Ty → Type
+def Denot (E W : Type) (ty : Ty) (D : Type := ℝ) : Type :=
+  match ty with
   | .e => E
   | .t => Prop
-  | .d => ℚ
+  | .d => D
   | .n => ℕ
   | .v => Empty
   | .s => Empty
-  | .fn a b => Denot E W a → Denot E W b
-  | .intens a => W → Denot E W a
+  | .fn a b => Denot E W a D → Denot E W b D
+  | .intens a => W → Denot E W a D
 
 /-- Soundness of type-level application: when `apply` succeeds, the
     denotation domain of the function type is exactly the function space
     from the argument's domain to the value's. -/
-theorem Denot.apply_sound {E W : Type} {f x c : Ty}
+theorem Denot.apply_sound {E W D : Type} {f x c : Ty}
     (h : f.apply x = some c) :
-    Denot E W f = (Denot E W x → Denot E W c) := by
+    Denot E W f D = (Denot E W x D → Denot E W c D) := by
   rw [Ty.apply_eq_some_iff] at h; subst h; rfl
 
 -- ════════════════════════════════════════════════════════════════
@@ -167,17 +171,17 @@ theorem Denot.apply_sound {E W : Type} {f x c : Ty}
 /-- ^α — form the rigid intension of an expression.
     Maps a denotation to the constant function over indices.
     Definitionally equal to `Intensional.Intension.rigid`. -/
-def up {E W : Type} {a : Ty} (x : Denot E W a) : Denot E W (.intens a) :=
+def up {E W D : Type} {a : Ty} (x : Denot E W a D) : Denot E W (.intens a) D :=
   λ _ => x
 
 /-- ˇα — extract the extension at index i.
     Evaluates an intension at a given index.
     Definitionally equal to `Intensional.Intension.evalAt`. -/
-def down {E W : Type} {a : Ty} (s : Denot E W (.intens a)) (i : W) : Denot E W a :=
+def down {E W D : Type} {a : Ty} (s : Denot E W (.intens a) D) (i : W) : Denot E W a D :=
   s i
 
 /-- Down-up cancellation: ˇ(^α) = α at any index. DWP Theorem 1. -/
-theorem down_up {E W : Type} {a : Ty} (x : Denot E W a) (i : W) :
+theorem down_up {E W D : Type} {a : Ty} (x : Denot E W a D) (i : W) :
     down (up x) i = x := rfl
 
 -- ════════════════════════════════════════════════════════════════

--- a/Linglib/Studies/BumfordCharlow2024.lean
+++ b/Linglib/Studies/BumfordCharlow2024.lean
@@ -464,12 +464,12 @@ effects, so scope and binding must come from effect sequencing instead
 `(Entity → Cont R α) → Cont R (Entity → α)` would have to run one
 continuation at every entity simultaneously. Binding under scope arises
 from `bind`-order instead (§7). -/
-instance {R E W : Type} : Tree.PredAbs (Cont R) E W := ⟨none⟩
+instance {R E W D : Type} : Tree.PredAbs (Cont R) E W D := ⟨none⟩
 
 /-- CI effects do not support Predicate Abstraction: the log of
 `⟦β⟧^{g[n↦x]}` may vary with `x`, so no log-respecting distributor
 exists. CI content composes around abstraction, not through it. -/
-instance {ω E W : Type} : Tree.PredAbs (Writer ω) E W := ⟨none⟩
+instance {ω E W D : Type} : Tree.PredAbs (Writer ω) E W D := ⟨none⟩
 
 end PredAbsInstances
 

--- a/Linglib/Studies/LittleMoroneyRoyer2022.lean
+++ b/Linglib/Studies/LittleMoroneyRoyer2022.lean
@@ -1,3 +1,5 @@
+import Mathlib.Data.Finset.Grade
+import Linglib.Core.Order.Valuation
 import Linglib.Semantics.Classifier
 import Linglib.Semantics.Composition.Tree
 import Linglib.Studies.Chierchia1998
@@ -27,8 +29,10 @@ numeral (`shan_clfNoun_composes`, `chol_clfNoun_fails`, `chol_ocho`).
 
 Pluralities are `Finset α`, the atoms and their sums with `∅` excluded by
 `Finset.Nonempty`, so the measure function μ# is `Finset.card` at type
-`⟨e,d⟩`. Prediction 2 of §4 (nouns that need no classifier) rests on
-Vietnamese rather than Ch'ol or Shan data and is not formalized.
+`⟨e,n⟩` — the grade of the plurality lattice (`Finset.grade_eq`) and a
+positive valuation on it, which is all quantization needs
+(`clfForNum_dogs_qua`). Prediction 2 of §4 (nouns that need no classifier)
+rests on Vietnamese rather than Ch'ol or Shan data and is not formalized.
 
 ## References
 
@@ -65,26 +69,19 @@ variable {α : Type} (g : Assignment (Finset α))
 /-- A count noun denotes the atoms and their sums ((6)). -/
 def dogs (x : Finset α) : Prop := x.Nonempty
 
-/-- μ#, the atom-counting measure ((8)). -/
-def atomMeasure (x : Finset α) : ℚ := x.card
-
-theorem clfForNum_dogs_iff (x : Finset α) : clfForNum dogs atomMeasure 2 x ↔ x.card = 2 := by
-  simp only [clfForNum, Mereology.QMOD, dogs, atomMeasure, ← Finset.card_pos]
-  norm_cast
+theorem clfForNum_dogs_iff (x : Finset α) : clfForNum dogs Finset.card 2 x ↔ x.card = 2 := by
+  simp only [clfForNum, Mereology.QMOD, dogs, ← Finset.card_pos]
   omega
 
-/-- Atomizing a count noun yields its atoms, `IoninMatushansky2006.IsAtomOf`. -/
+/-- Atomizing a count noun yields the atoms of the plurality lattice
+(`Mereology.atomize_ne_bot`), the singletons `IoninMatushansky2006.IsAtomOf`. -/
 theorem clfForNoun_dogs : (clfForNoun dogs : Finset α → Prop) = IsAtomOf (λ _ => True) := by
+  have h : (dogs : Finset α → Prop) = (· ≠ ⊥) :=
+    funext λ _ => propext Finset.nonempty_iff_ne_empty
+  rw [show (clfForNoun dogs : Finset α → Prop) = Mereology.atomize (· ≠ ⊥) from
+    congrArg Mereology.atomize h, Mereology.atomize_ne_bot]
   funext x
-  simp only [clfForNoun, Mereology.atomize, minimal_iff, IsAtomOf, true_and, dogs, eq_iff_iff]
-  constructor
-  · rintro ⟨⟨a, ha⟩, h⟩
-    exact ⟨a, h (Finset.singleton_nonempty a) (Finset.singleton_subset_iff.2 ha)⟩
-  · rintro ⟨a, rfl⟩
-    refine ⟨Finset.singleton_nonempty a, λ y hy hle => ?_⟩
-    rcases Finset.subset_singleton_iff.1 hle with rfl | rfl
-    · exact absurd hy Finset.not_nonempty_empty
-    · rfl
+  simp [Finset.isAtom_iff, IsAtomOf]
 
 /-! ### Ch'ol: classifier-for-numeral -/
 
@@ -93,12 +90,12 @@ classifier *-kojty* is μ# ((8)) keyed on `Chol.Classifiers.kojty`, the
 Spanish loan *ocho* 'eight' has its measure built in ((34b)), and *ts'i'*
 is 'dog'. -/
 def cholLex : Lexicon (Finset α) Unit := λ w =>
-  if w = "cha'" then some ⟨(.e ⇒ .d) ⇒ (.e ⇒ .t) ⇒ .e ⇒ .t,
-    show (Finset α → ℚ) → (Finset α → Prop) → Finset α → Prop from
+  if w = "cha'" then some ⟨(.e ⇒ .n) ⇒ (.e ⇒ .t) ⇒ .e ⇒ .t,
+    show (Finset α → ℕ) → (Finset α → Prop) → Finset α → Prop from
       λ m P x => P x ∧ m x = 2⟩
-  else if w = Chol.Classifiers.kojty.form then some ⟨.e ⇒ .d, atomMeasure⟩
+  else if w = Chol.Classifiers.kojty.form then some ⟨.e ⇒ .n, Finset.card⟩
   else if w = "ocho" then some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t,
-    show (Finset α → Prop) → Finset α → Prop from λ P x => P x ∧ atomMeasure x = 8⟩
+    show (Finset α → Prop) → Finset α → Prop from λ P x => P x ∧ x.card = 8⟩
   else if w = "ts'i'" then some ⟨.e ⇒ .t, dogs⟩
   else none
 
@@ -110,17 +107,17 @@ def cholTree : Tree Unit String := .bin cholNumClf (.leaf "ts'i'")
 
 /-- The Ch'ol root is the measure-modified noun `λx. dogs x ∧ μ# x = 2` ((51)). -/
 theorem cholTree_interp :
-    interp (Finset α) Unit cholLex g cholTree = some ⟨.e ⇒ .t, clfForNum dogs atomMeasure 2⟩ :=
+    interp (Finset α) Unit cholLex g cholTree = some ⟨.e ⇒ .t, clfForNum dogs Finset.card 2⟩ :=
   rfl
 
 /-- Numeral and classifier compose without a noun, into the measure phrase
 `λP λx. P x ∧ μ# x = 2` ((45)–(46), Prediction 4). -/
 theorem chol_numClf_composes :
     interp (Finset α) Unit cholLex g cholNumClf =
-      some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t, λ P => clfForNum P atomMeasure 2⟩ :=
+      some ⟨(.e ⇒ .t) ⇒ .e ⇒ .t, λ P => clfForNum P Finset.card 2⟩ :=
   rfl
 
-/-- The classifier, a measure of type `⟨e,d⟩`, cannot compose with the noun
+/-- The classifier, a measure of type `⟨e,n⟩`, cannot compose with the noun
 without the numeral ((43a)). -/
 theorem chol_clfNoun_fails :
     interp (Finset α) Unit cholLex g (.bin (.leaf Chol.Classifiers.kojty.form) (.leaf "ts'i'")) =
@@ -131,7 +128,7 @@ theorem chol_clfNoun_fails :
 ((33)–(34), Prediction 1). -/
 theorem chol_ocho :
     interp (Finset α) Unit cholLex g (.bin (.leaf "ocho") (.leaf "ts'i'")) =
-        some ⟨.e ⇒ .t, clfForNum dogs atomMeasure 8⟩ ∧
+        some ⟨.e ⇒ .t, clfForNum dogs Finset.card 8⟩ ∧
       interp (Finset α) Unit cholLex g (.bin (.leaf "ocho") (.leaf Chol.Classifiers.kojty.form)) =
         none :=
   ⟨rfl, rfl⟩
@@ -180,10 +177,16 @@ theorem shan_numClf_fails :
 
 /-! ### One denotation for *two dogs* -/
 
+/-- Measure modification by the atom count is quantized: `Finset.card` is a
+positive valuation, and strict monotonicity is all `qua_pullback` needs. -/
+theorem clfForNum_dogs_qua : Mereology.QUA (clfForNum dogs Finset.card 2 : Finset α → Prop) := by
+  refine (Mereology.qua_pullback ?_ (Mereology.singleton_qua 2)).subset λ _ h => h.2
+  exact IsPositiveValuation.strictMono (v := (Finset.card : Finset α → ℕ))
+
 /-- Derivationally distinct, the two strategies denote the same two-dog
 pluralities (§4.5). -/
 theorem forNumeral_iff_forNoun (x : Finset α) :
-    clfForNum dogs atomMeasure 2 x ↔ cardMod 2 (clfForNoun dogs) x := by
+    clfForNum dogs Finset.card 2 x ↔ cardMod 2 (clfForNoun dogs) x := by
   simp [clfForNum_dogs_iff, clfForNoun_dogs, cardMod_atoms_iff]
 
 /-- Three dogs ((6)). -/
@@ -192,9 +195,9 @@ inductive Dog | a | b | c
 
 -- *two dogs* denotes `{ab, ac, bc}` ((51)–(52)).
 example (x : Finset Dog) :
-    clfForNum dogs atomMeasure 2 x ↔
-      x ∈ ({{.a, .b}, {.a, .c}, {.b, .c}} : Finset (Finset Dog)) := by
-  rw [clfForNum_dogs_iff]; revert x; decide
+    clfForNum dogs Finset.card 2 x ↔
+      x ∈ ({{.a, .b}, {.a, .c}, {.b, .c}} : Finset (Finset Dog)) :=
+  (clfForNum_dogs_iff x).trans (by revert x; decide)
 
 end
 

--- a/Linglib/Studies/Rooth1992.lean
+++ b/Linglib/Studies/Rooth1992.lean
@@ -453,7 +453,7 @@ application. -/
 
 /-- Alternatives do not distribute through predicate abstraction —
     the honest `none`. -/
-instance (E W : Type) : PredAbs AltMeaning E W := ⟨none⟩
+instance (E W D : Type) : PredAbs AltMeaning E W D := ⟨none⟩
 
 /-- The focus lexicon at `M = AltMeaning`: every entry `pure`-lifts
     except focused *[Mary]F*, whose entry carries the subject

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -183,17 +183,17 @@ abbrev Dom (Ent α : Type) : Type := Ent ⊕ α
 /-- Wellwood's lexicon over the engine: `much` is the assignment-supplied
     measure (eqs. 7/28), `-er` the strict and `ABS` (38.ii) the weak
     degree head, `role` a [kratzer-1996] role head composing by EI. -/
-def lexicon (role : Ent → α → Prop) (P : α → Prop) (μ0 : α → ℚ)
-    (subj : Ent) (δ : ℚ) : Lexicon (Dom Ent α) Unit := fun w =>
+def lexicon {D : Type} [LinearOrder D] [Zero D] (role : Ent → α → Prop) (P : α → Prop)
+    (μ0 : α → D) (subj : Ent) (δ : D) : Lexicon (Dom Ent α) Unit Id D := fun w =>
   match w with
-  | "much" => some ⟨.e ⇒ .d, show Dom Ent α → ℚ from fun x => match x with
+  | "much" => some ⟨.e ⇒ .d, show Dom Ent α → D from fun x => match x with
       | .inr e => μ0 e
       | .inl _ => 0⟩
   | "er" => some ⟨(.e ⇒ .d) ⇒ .d ⇒ .e ⇒ .t,
-      show (Dom Ent α → ℚ) → ℚ → Dom Ent α → Prop from fun m d x => m x > d⟩
+      show (Dom Ent α → D) → D → Dom Ent α → Prop from fun m d x => m x > d⟩
   | "ABS" => some ⟨(.e ⇒ .d) ⇒ .d ⇒ .e ⇒ .t,
-      show (Dom Ent α → ℚ) → ℚ → Dom Ent α → Prop from fun m d x => m x ≥ d⟩
-  | "δ" => some ⟨.d, show ℚ from δ⟩
+      show (Dom Ent α → D) → D → Dom Ent α → Prop from fun m d x => m x ≥ d⟩
+  | "δ" => some ⟨.d, show D from δ⟩
   | "pred" => some ⟨.e ⇒ .t, fun x => match x with
       | .inr e => P e
       | .inl _ => False⟩

--- a/references.bib
+++ b/references.bib
@@ -39329,3 +39329,17 @@
   role      = {formalized},
   sources   = {Studies/Embick2015.lean;Morphology/DistributedMorphology/ComplexHead.lean}
 }
+% REF: Birkhoff, G. (1967). Lattice Theory, 3rd ed. AMS Colloquium Publications 25.
+@book{birkhoff-1967,
+  author    = {Birkhoff, Garrett},
+  year      = {1967},
+  title     = {Lattice Theory},
+  edition   = {3},
+  series    = {American Mathematical Society Colloquium Publications},
+  volume    = {25},
+  publisher = {American Mathematical Society},
+  address   = {Providence, RI},
+  subfield  = {mathematical foundations/order theory},
+  role      = {formalized},
+  sources   = {Core/Order/Valuation.lean}
+}


### PR DESCRIPTION
Degrees denote a model-supplied scale: `Denot (E W : Type) (ty : Ty) (D : Type := ℝ)`, with `LexEntry`/`Lexicon`/`TypedDenot`/`PredAbs` carrying the same defaulted parameter and the composition engine generic in it. ℚ was a computability convenience no measure-function tradition uses (Kennedy, Sassoon, Solt, Lassiter, Wellwood, Krifka, Champollion are all ℝ- or scale-valued); the number system is a representation of the scale, not the scale.

- `Core/Order/Valuation.lean` (`[UPSTREAM]`): Birkhoff's lattice valuations — `IsLatticeValuation` (modular law), `IsPositiveValuation` (strictly monotone), disjoint-additivity from `v ⊥ = 0`, and the theorem that a lattice with a positive valuation into a cancellative monoid is modular; `Finset.card` instance. Not in mathlib (modular law exists only per instance: `Finset.card_union_add_card_inter`, `measure_union_add_inter`, …).
- `Wellwood2015`'s lexicon becomes the first scale-generic one (`[LinearOrder D] [Zero D]`); `Intensional/Algebra`'s Boolean-algebra instances on `Denot` generalize over the scale.
- `LittleMoroneyRoyer2022`: μ# is `Finset.card` at `⟨e,n⟩`, *tǒ* is `IsAtom` via `Mereology.atomize_ne_bot`, and quantization follows from the valuation's strict monotonicity alone (`clfForNum_dogs_qua`) — no extensive-measure axiom.