### PR TITLE
refactor(Semantics/Degree): measure functions take the model scale

### DIFF
--- a/Linglib/Semantics/Degree/Aggregation.lean
+++ b/Linglib/Semantics/Degree/Aggregation.lean
@@ -24,7 +24,7 @@ available aggregation functions:
 - **Weighted** (§2): x is F iff Σᵢ wᵢ·fᵢ(x) ≥ θ (utilitarian aggregation).
   Subsumes Waldon et al.'s eq. 8.
 - **Spatially-normalized weighted** (§2): x is F iff (Σᵢ wᵢ·fᵢ(x)) / s(x) ≥ θ,
-  where s : α → ℚ is a host-extent measure. Tham 2025's eq. 47b for
+  where s : α → K is a host-extent measure on an ordered field `K`. Tham 2025's eq. 47b for
   physical disturbance adjectives.
 - **Multiplicative** (§4): x is F iff Πᵢ fᵢ(x) ≥ θ (Cobb-Douglas aggregation).
   Sassoon-Fadlon argue natural kinds compose multiplicatively.
@@ -35,7 +35,7 @@ reduce to counting aggregation.
 
 namespace Degree.Aggregation
 
-variable {α : Type*}
+variable {α K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
 
 /-! ### Counting Aggregation -/
 
@@ -56,31 +56,31 @@ def countBinding (k : Nat) (dims : List (α → Bool)) (x : α) : Bool :=
 def majorityBinding (dims : List (α → Bool)) (x : α) : Bool :=
   decide (2 * (dims.filter (fun d => d x)).length > dims.length)
 
-/-! ### Weighted Aggregation (Unified ℚ) -/
+/-! ### Weighted Aggregation (over an ordered field) -/
 
-/-- Lift Bool dimension predicates to ℚ-valued measure functions.
+/-- Lift Bool dimension predicates to `K`-valued measure functions.
     Each `d : α → Bool` becomes `fun x => if d x then 1 else 0`. -/
-def boolMeasures (dims : List (α → Bool)) : List (α → ℚ) :=
+def boolMeasures (dims : List (α → Bool)) : List (α → K) :=
   dims.map (fun d x => if d x then 1 else 0)
 
-/-- Weighted score: Σᵢ wᵢ · fᵢ(x), where each fᵢ : α → ℚ is a
+/-- Weighted score: Σᵢ wᵢ · fᵢ(x), where each fᵢ : α → K is a
     measure function along one dimension.
 
     This is the unified core: [waldon-etal-2023]'s eq. (8) uses
-    ℚ-valued measures directly; [dambrosio-hedden-2024]'s Bool
+    `K`-valued measures directly; [dambrosio-hedden-2024]'s Bool
     dimensions are the special case via `boolMeasures`. -/
-def weightedScore (weights : List ℚ) (measures : List (α → ℚ)) (x : α) : ℚ :=
+def weightedScore (weights : List K) (measures : List (α → K)) (x : α) : K :=
   (weights.zip measures).foldl (fun acc (w, f) => acc + w * f x) 0
 
 /-- Weighted binding (Bool dimensions): x is F iff its weighted score
     over Bool-lifted measures exceeds threshold θ. -/
-def weightedBinding (weights : List ℚ) (θ : ℚ)
+def weightedBinding (weights : List K) (θ : K)
     (dims : List (α → Bool)) (x : α) : Bool :=
   decide (weightedScore weights (boolMeasures dims) x ≥ θ)
 
-/-- Weighted binding over continuous ℚ-valued measures. -/
-def weightedBindingQ (weights : List ℚ) (θ : ℚ)
-    (measures : List (α → ℚ)) (x : α) : Bool :=
+/-- Weighted binding over continuous `K`-valued measures. -/
+def weightedBindingQ (weights : List K) (θ : K)
+    (measures : List (α → K)) (x : α) : Bool :=
   decide (weightedScore weights measures x ≥ θ)
 
 /-- Spatially-normalized weighted score: (Σᵢ wᵢ·fᵢ(x)) / s(x).
@@ -93,15 +93,15 @@ def weightedBindingQ (weights : List ℚ) (θ : ℚ)
     of the scale comes from the denominator, not from any single
     dimension. Returns `0` when `spatial x = 0` (avoiding division by
     zero); callers should ensure `spatial x ≠ 0` for meaningful results. -/
-def spatialNormalizedScore (weights : List ℚ) (measures : List (α → ℚ))
-    (spatial : α → ℚ) (x : α) : ℚ :=
+def spatialNormalizedScore (weights : List K) (measures : List (α → K))
+    (spatial : α → K) (x : α) : K :=
   if spatial x = 0 then 0 else weightedScore weights measures x / spatial x
 
 /-- Spatially-normalized weighted binding (Bool dimensions): x is F iff
     its spatially-normalized weighted score over Bool-lifted measures
     exceeds threshold θ. -/
-def spatialNormalizedBinding (weights : List ℚ) (θ : ℚ)
-    (dims : List (α → Bool)) (spatial : α → ℚ) (x : α) : Bool :=
+def spatialNormalizedBinding (weights : List K) (θ : K)
+    (dims : List (α → Bool)) (spatial : α → K) (x : α) : Bool :=
   decide (spatialNormalizedScore weights (boolMeasures dims) spatial x ≥ θ)
 
 /-! ### Properties -/
@@ -114,7 +114,7 @@ theorem countBinding_zero (dims : List (α → Bool)) (x : α) :
 /-- The spatial-normalization reduces to plain weighted score when
     `spatial x = 1` (constant unit host extent). -/
 @[simp]
-theorem spatialNormalizedScore_unit (weights : List ℚ) (measures : List (α → ℚ))
+theorem spatialNormalizedScore_unit (weights : List K) (measures : List (α → K))
     (x : α) :
     spatialNormalizedScore weights measures (fun _ => 1) x =
       weightedScore weights measures x := by
@@ -123,12 +123,13 @@ theorem spatialNormalizedScore_unit (weights : List ℚ) (measures : List (α �
   · exact absurd h one_ne_zero
   · exact div_one _
 
+omit [IsStrictOrderedRing K] in
 /-- Spatial normalization at a zero-extent host returns 0. Documents the
     edge-case convention: a host with no spatial extent cannot exhibit a
     physical disturbance, so the predicate is vacuously not satisfied. -/
 @[simp]
-theorem spatialNormalizedScore_zero (weights : List ℚ) (measures : List (α → ℚ))
-    (spatial : α → ℚ) (x : α) (h : spatial x = 0) :
+theorem spatialNormalizedScore_zero (weights : List K) (measures : List (α → K))
+    (spatial : α → K) (x : α) (h : spatial x = 0) :
     spatialNormalizedScore weights measures spatial x = 0 := by
   simp [spatialNormalizedScore, h]
 
@@ -138,8 +139,8 @@ theorem spatialNormalizedScore_zero (weights : List ℚ) (measures : List (α �
     2025's "boundedness from spatial extent" claim (§3.4) into a
     structural theorem rather than a stipulation. -/
 theorem spatialNormalizedScore_le_one
-    (weights : List ℚ) (measures : List (α → ℚ))
-    (spatial : α → ℚ) (x : α)
+    (weights : List K) (measures : List (α → K))
+    (spatial : α → K) (x : α)
     (hsum : weightedScore weights measures x ≤ spatial x)
     (hpos : 0 < spatial x) :
     spatialNormalizedScore weights measures spatial x ≤ 1 := by
@@ -153,8 +154,8 @@ theorem spatialNormalizedScore_le_one
     this places the score in `[0, 1]` — the "fraction of the totality"
     intuition Tham 2025 §3.4 and Solt 2018 eq. 21 both require. -/
 theorem spatialNormalizedScore_nonneg
-    (weights : List ℚ) (measures : List (α → ℚ))
-    (spatial : α → ℚ) (x : α)
+    (weights : List K) (measures : List (α → K))
+    (spatial : α → K) (x : α)
     (hnum : 0 ≤ weightedScore weights measures x)
     (hspatial : 0 ≤ spatial x) :
     0 ≤ spatialNormalizedScore weights measures spatial x := by
@@ -169,7 +170,7 @@ theorem spatialNormalizedScore_nonneg
     [sassoon-fadlon-2017] argue natural kind nouns compose
     multiplicatively: failure on ANY single dimension kills membership.
     Contrast with additive `weightedScore` for artifact nouns. -/
-def multiplicativeScore (measures : List (α → ℚ)) (x : α) : ℚ :=
+def multiplicativeScore (measures : List (α → K)) (x : α) : K :=
   measures.foldl (fun acc f => acc * f x) 1
 
 /-! ### Classification -/

--- a/Linglib/Semantics/Degree/Measure/Basic.lean
+++ b/Linglib/Semantics/Degree/Measure/Basic.lean
@@ -1,3 +1,4 @@
+import Mathlib.Data.Real.Basic
 import Linglib.Semantics.Mereology
 
 /-!
@@ -62,7 +63,7 @@ theorem admissibleMeasure_of_mereoDim
 /-! ### Dimensional restriction -/
 
 /-- A domain is dimensionally restricted when any two admissible measure
-    functions (`StrictMono` maps to ℚ) agree on the comparative ordering
+    functions (`StrictMono` maps into the scale `D`, default `ℝ`) agree on the comparative ordering
     of all elements: the comparative is determined by the background
     ordering alone, not by the choice of measure.
 
@@ -70,32 +71,32 @@ theorem admissibleMeasure_of_mereoDim
     forward direction is `linearOrder_dimensionallyRestricted`; the
     converse is witnessed by incomparable elements with disagreeing
     measures (`prod_not_dimensionallyRestricted`). -/
-def DimensionallyRestricted (α : Type*) [Preorder α] : Prop :=
-  ∀ (μ₁ μ₂ : α → ℚ), StrictMono μ₁ → StrictMono μ₂ →
+def DimensionallyRestricted (α : Type*) [Preorder α] (D : Type := ℝ) [Preorder D] : Prop :=
+  ∀ (μ₁ μ₂ : α → D), StrictMono μ₁ → StrictMono μ₂ →
     ∀ (a b : α), μ₁ a < μ₁ b ↔ μ₂ a < μ₂ b
 
 /-- Linear orders are dimensionally restricted: the comparative ordering
     is uniquely determined by the ambient order, regardless of which
     admissible measure function is chosen. -/
-theorem linearOrder_dimensionallyRestricted {α : Type*} [LinearOrder α] :
-    DimensionallyRestricted α :=
+theorem linearOrder_dimensionallyRestricted {α : Type*} [LinearOrder α] {D : Type} [Preorder D] :
+    DimensionallyRestricted α D :=
   fun _ _ hμ₁ hμ₂ _ _ => hμ₁.lt_iff_lt.trans hμ₂.lt_iff_lt.symm
 
 /-- If two admissible measures disagree on some pair, the domain is NOT
     dimensionally restricted. -/
-theorem not_restricted_of_disagreement {α : Type*} [Preorder α]
-    {μ₁ μ₂ : α → ℚ} (hμ₁ : StrictMono μ₁) (hμ₂ : StrictMono μ₂)
+theorem not_restricted_of_disagreement {α : Type*} [Preorder α] {D : Type} [Preorder D]
+    {μ₁ μ₂ : α → D} (hμ₁ : StrictMono μ₁) (hμ₂ : StrictMono μ₂)
     {a b : α} (h₁ : μ₁ a < μ₁ b) (h₂ : ¬ μ₂ a < μ₂ b) :
-    ¬ DimensionallyRestricted α :=
+    ¬ DimensionallyRestricted α D :=
   fun hDR => h₂ ((hDR μ₁ μ₂ hμ₁ hμ₂ a b).mp h₁)
 
-/-- The converse witness: on the componentwise-ordered `ℚ × ℚ` (weight ×
+/-- The converse witness: on the componentwise-ordered `D × D` (weight ×
     volume), the admissible measures `2·w + v` and `w + v` order the
     incomparable elements `(0, 1)` and `(1, 0)` differently — the
     multi-dimensional signature of entity/event domains. -/
-theorem prod_not_dimensionallyRestricted :
-    ¬ DimensionallyRestricted (ℚ × ℚ) := by
-  have hmono : ∀ c : ℚ, 0 < c → StrictMono (fun p : ℚ × ℚ => c * p.1 + p.2) := by
+theorem prod_not_dimensionallyRestricted {D : Type} [Field D] [LinearOrder D]
+    [IsStrictOrderedRing D] : ¬ DimensionallyRestricted (D × D) D := by
+  have hmono : ∀ c : D, 0 < c → StrictMono (fun p : D × D => c * p.1 + p.2) := by
     intro c hc p q hpq
     rcases Prod.lt_iff.mp hpq with ⟨h1, h2⟩ | ⟨h1, h2⟩
     · have := mul_lt_mul_of_pos_left h1 hc

--- a/Linglib/Semantics/Degree/Measure/Dimensioned.lean
+++ b/Linglib/Semantics/Degree/Measure/Dimensioned.lean
@@ -26,10 +26,11 @@ terms (`one kilo` vs. `two kilos`).
 
 ### Measure Functions
 
-A **measure function** μ maps individuals to non-negative rationals along a
+A **measure function** μ maps individuals to magnitudes on a scale `D` —
+the model's degree scale, default `ℝ` as for `Intensional.Denot` — along a
 specific physical dimension:
 
-    μ : Entity → ℚ≥0
+    μ : Entity → D
 
 The dimension tag (mass, volume, distance, time, cardinality, ...) lives in
 `Features/Dimension.lean`; this module imports it and exposes `DimensionedMeasure`,
@@ -87,25 +88,25 @@ open Features.Dimension (Dimension)
 -- § 1. Measure Functions
 -- ============================================================================
 
-/-- A measure function maps entities to non-negative rational magnitudes
-along a specific dimension.
+/-- A measure function maps entities to magnitudes on the scale `D` along a
+specific dimension.
 
 [scontras-2014]: degrees are pairs ⟨μ, n⟩ where μ is the measure
 function and n is the numerical value. A measure function is individuated
 by its dimension: μ_kg measures mass, μ_L measures volume, μ_CARD counts.
-
-We use ℚ rather than ℝ to match the library's exact-arithmetic convention
-for computational semantics. -/
-structure DimensionedMeasure (E : Type*) where
+Non-negativity and additivity are properties of a measure
+(`DimensionedMeasure.IsExtensive`), not fields; studies that compute
+instantiate the scale at `ℚ`. -/
+structure DimensionedMeasure (E : Type*) (D : Type := ℝ) where
   /-- Which dimension this function measures. -/
   dimension : Dimension
   /-- The measure function itself: maps an entity to its magnitude. -/
-  apply : E → ℚ
-  /-- Measure values are non-negative. -/
-  nonneg : ∀ e, apply e ≥ 0
+  apply : E → D
+
+variable {D : Type}
 
 /-- Apply a measure function to an entity. -/
-instance {E : Type*} : CoeFun (DimensionedMeasure E) (fun _ => E → ℚ) where
+instance {E : Type*} : CoeFun (DimensionedMeasure E D) (fun _ => E → D) where
   coe μ := μ.apply
 
 -- ============================================================================
@@ -122,15 +123,17 @@ predicate. This is the **exact (`=`) case of the shared comparison-over-a-
 measure primitive** `Core.Order.Comparison.over`: `⟦kilo⟧(n)` is
 `Comparison.eq.over μ_kg n`. Modified readings (`> n`, `≥ n`, …) are the other
 `Comparison`s over the same `μ`. -/
-def DimensionedMeasure.applyNumeral {E : Type*} (μ : DimensionedMeasure E) (n : ℚ) (x : E) : Prop :=
+def DimensionedMeasure.applyNumeral {E : Type*} [Preorder D] (μ : DimensionedMeasure E D) (n : D)
+    (x : E) : Prop :=
   x ∈ Core.Order.Comparison.eq.over μ.apply n
 
 /-- `applyNumeral` is exact measure predication: `μ(x) = n` (definitionally,
     the `.eq` interval-membership). -/
-@[simp] theorem DimensionedMeasure.applyNumeral_iff {E : Type*} (μ : DimensionedMeasure E) (n : ℚ) (x : E) :
+@[simp] theorem DimensionedMeasure.applyNumeral_iff {E : Type*} [Preorder D]
+    (μ : DimensionedMeasure E D) (n : D) (x : E) :
     μ.applyNumeral n x ↔ μ.apply x = n := Iff.rfl
 
-instance {E : Type*} (μ : DimensionedMeasure E) (n : ℚ) (x : E) :
+instance {E : Type*} [Preorder D] [DecidableEq D] (μ : DimensionedMeasure E D) (n : D) (x : E) :
     Decidable (μ.applyNumeral n x) :=
   inferInstanceAs (Decidable (μ.apply x = n))
 
@@ -150,8 +153,8 @@ aligning it with measure terms whose intransitive form (eq. (33)) is
 ⟦kilo⟧ = λn. λx. μ_kg(x) = n. This file exposes the underlying μ_CARD as
 a `DimensionedMeasure`; the CARD Num-head itself (which composes with a kind) lives
 at the syntactic level. -/
-def cardMeasure (E : Type*) (cardFn : E → ℚ) (h : ∀ e, cardFn e ≥ 0) : DimensionedMeasure E :=
-  { dimension := .cardinality, apply := cardFn, nonneg := h }
+def cardMeasure (E : Type*) [NatCast D] (cardFn : E → ℕ) : DimensionedMeasure E D :=
+  { dimension := .cardinality, apply := fun e => (cardFn e : D) }
 
 -- ============================================================================
 -- § 4. Quantity-Uniform Property
@@ -173,7 +176,7 @@ is QU under some relevant μ, with that μ supplying the "1-ness" presupposition
 of singular morphology (eq. (54), p. 48). Predicates fail QU when they are
 not measure-modified — e.g. bare `boy` is not QU under μ_CARD because two
 distinct boys can have different cardinalities (one vs. plural). -/
-def IsQuantityUniform {E : Type*} (P : E → Prop) (μ : DimensionedMeasure E) : Prop :=
+def IsQuantityUniform {E : Type*} (P : E → Prop) (μ : DimensionedMeasure E D) : Prop :=
   ∀ x y, P x → P y → μ.apply x = μ.apply y
 
 -- ============================================================================
@@ -305,13 +308,14 @@ nouns realize only n ∈ ℕ. -/
 open Core.Order (Comparison)
 open Entailment (IsMaxInf HasMaxInf)
 
-/-- For a measure function μ on ℚ: when n is realized by some entity, the
+/-- For a measure function μ into a linear scale: when n is realized by some entity, the
 MIP applied to the at-least degree property at n yields μ(x) = n.
 
 *Formalization-internal observation* — not stated by Scontras or Kennedy.
 Bridges Scontras's exact measure-term meaning with the `max{n | ...} = n`
 form of Kennedy's de-Fregean analysis. -/
-theorem scontras_kennedy_dense {E : Type*} (μ : DimensionedMeasure E) (n : ℚ) (x : E)
+theorem scontras_kennedy_dense {E : Type*} [LinearOrder D] (μ : DimensionedMeasure E D) (n : D)
+    (x : E)
     (hHit : ∃ e, μ.apply e = n) :
     IsMaxInf (Comparison.ge.over μ.apply) n x ↔ μ.apply x = n :=
   Entailment.isMaxInf_atLeast_of_hit μ.apply n x hHit
@@ -340,8 +344,8 @@ order; the formalism traces to [krifka-1989]'s cumulative/quantized
 distinction). Definitionally `Mereology.ExtMeasure E μ.apply`; declared as
 `abbrev` so the underlying class instance elaborates through it without manual
 unfolding. -/
-abbrev DimensionedMeasure.IsExtensive {E : Type*} [SemilatticeSup E]
-    (μ : DimensionedMeasure E) : Prop :=
+abbrev DimensionedMeasure.IsExtensive {E : Type*} [SemilatticeSup E] [AddCommMonoid D]
+    [PartialOrder D] (μ : DimensionedMeasure E D) : Prop :=
   Mereology.ExtMeasure E μ.apply
 
 /-- A `DimensionedMeasure` is **admissible** (in [wellwood-2015]'s /
@@ -350,8 +354,8 @@ function is `StrictMono` on the part-whole order. Definitionally equal to
 `Degree.admissibleMeasure μ.apply` — both are
 `StrictMono μ.apply` — so consumers can prove the equivalence by `Iff.rfl`
 when both abbrevs are in scope. -/
-abbrev DimensionedMeasure.IsAdmissible {E : Type*} [Preorder E]
-    (μ : DimensionedMeasure E) : Prop :=
+abbrev DimensionedMeasure.IsAdmissible {E : Type*} [Preorder E] [Preorder D]
+    (μ : DimensionedMeasure E D) : Prop :=
   admissibleMeasure μ.apply
 
 /-- **Scontras-Krifka bridge.** When a `DimensionedMeasure` is extensive, applying
@@ -359,18 +363,18 @@ abbrev DimensionedMeasure.IsAdmissible {E : Type*} [Preorder E]
 produces a QUA predicate. Measure terms ("three kilos of rice") yield
 quantized predicates because their measure function is extensive. -/
 theorem extensive_measureFn_qmod_qua
-    {E : Type*} [inst : SemilatticeSup E]
-    {μ : DimensionedMeasure E}
+    {E : Type*} [SemilatticeSup E] [AddCommMonoid D] [PartialOrder D]
+    {μ : DimensionedMeasure E D}
     (hExt : DimensionedMeasure.IsExtensive μ)
-    {R : E → Prop} {n : ℚ} (_hn : 0 < n) :
+    {R : E → Prop} {n : D} (_hn : 0 < n) :
     Mereology.QUA (Mereology.QMOD R μ.apply n) := by
-  haveI : Mereology.ExtMeasure E μ.apply := hExt
+  have : Mereology.ExtMeasure E μ.apply := hExt
   exact Mereology.qmod_qua R n
 
 /-- **Bridge to QMOD.** Scontras's `applyNumeral` and Krifka's `QMOD` check the
 same condition `μ(x) = n` when QMOD's restrictor is taken to be trivial. -/
-theorem DimensionedMeasure.applyNumeral_iff_qmod {E : Type*}
-    (μ : DimensionedMeasure E) (n : ℚ) (x : E) :
+theorem DimensionedMeasure.applyNumeral_iff_qmod {E : Type*} [Preorder D]
+    (μ : DimensionedMeasure E D) (n : D) (x : E) :
     μ.applyNumeral n x ↔ Mereology.QMOD (fun _ => True) μ.apply n x := by
   simp [DimensionedMeasure.applyNumeral_iff, Mereology.QMOD]
 

--- a/Linglib/Studies/BaleSchwarz2022.lean
+++ b/Linglib/Studies/BaleSchwarz2022.lean
@@ -71,7 +71,7 @@ def perDivision (r q : ℚ) : ℚ := q / r
 Takes a unit quantity q and an entity x, returns a pure number:
 the entity's measure in q's dimension, divided by q. The entity
 argument is supplied by a covert pronoun *pro* (eq. 17). -/
-def perAnaphoric {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) : ℚ :=
+def perAnaphoric {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ) (x : E) : ℚ :=
   μ.apply x / q
 
 -- ============================================================================
@@ -83,7 +83,7 @@ def perAnaphoric {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) : ℚ
 A measurement verb maps a quantity to a predicate over entities. The verb's
 measure function determines which simplex dimension is measured:
 μ_WT for *weigh*, μ_VOL for *contain* (in measure readings). -/
-def measureVerbSem {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) : Bool :=
+def measureVerbSem {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ) (x : E) : Bool :=
   decide (μ.apply x = q)
 
 -- ============================================================================
@@ -207,7 +207,7 @@ No dimension mismatch arises. -/
 
 /-- Truth conditions under the anaphoric theory (eq. 22):
 μ_WT(sample) = numeral * (μ_VOL(sample) / perUnit). -/
-def anaphoricTC {E : Type*} (μ_wt μ_vol : DimensionedMeasure E)
+def anaphoricTC {E : Type*} (μ_wt μ_vol : DimensionedMeasure E ℚ)
     (sample : E) (numeral perUnit : ℚ) : Prop :=
   μ_wt.apply sample = numeral * perAnaphoric μ_vol perUnit sample
 
@@ -223,7 +223,7 @@ composed values in simplex dimensions. This matters because the anaphoric
 theory can then add the unit sensitivity presupposition (eq. 43), while the
 division theory cannot (the per-unit is structurally inaccessible). -/
 theorem anaphoric_tc_equivalent {E : Type*}
-    (μ_wt μ_vol : DimensionedMeasure E) (sample : E) (numeral perUnit : ℚ) :
+    (μ_wt μ_vol : DimensionedMeasure E ℚ) (sample : E) (numeral perUnit : ℚ) :
     -- The anaphoric TC unfolds to: μ_wt(sample) = numeral * (μ_vol(sample) / perUnit)
     anaphoricTC μ_wt μ_vol sample numeral perUnit ↔
       μ_wt.apply sample = numeral * (μ_vol.apply sample / perUnit) := by
@@ -256,17 +256,17 @@ underspecified — resolved contextually to the appropriate dimension.
 After the substrate refactor, the measure-term layer collapses into
 `DimensionedMeasure` itself, so MUCH is just the identity at the type level;
 the def survives as the linguistic name for the construct. -/
-def MUCH {E : Type*} (μ : DimensionedMeasure E) : DimensionedMeasure E := μ
+def MUCH {E : Type*} (μ : DimensionedMeasure E ℚ) : DimensionedMeasure E ℚ := μ
 
 /-- MUCH's denotation matches measure term semantics by construction:
 ⟦MUCH⟧(q)(x) ↔ (μ(x) = q) = DimensionedMeasure.applyNumeral(q)(x). -/
-theorem MUCH_is_measureTerm {E : Type*} (μ : DimensionedMeasure E) (n : ℚ) (x : E) :
+theorem MUCH_is_measureTerm {E : Type*} (μ : DimensionedMeasure E ℚ) (n : ℚ) (x : E) :
     (MUCH μ).applyNumeral n x ↔ μ.apply x = n := Iff.rfl
 
 /-- The measure verb semantics (eq. 5) is used in the anaphoric derivation:
 the truth conditions are stated as measureVerbSem μ_wt q sample = true,
 where q is the composed quantity from the anaphoric per-phrase. -/
-theorem measureVerb_applied {E : Type*} (μ_wt : DimensionedMeasure E) (q : ℚ) (x : E) :
+theorem measureVerb_applied {E : Type*} (μ_wt : DimensionedMeasure E ℚ) (q : ℚ) (x : E) :
     measureVerbSem μ_wt q x = decide (μ_wt.apply x = q) := rfl
 
 -- ============================================================================
@@ -423,32 +423,32 @@ theorem text_unit_sensitivity :
 This is the canonical use case for `PartialValue`: the at-issue content is
 a pure number (ℚ), not a truth value (Bool). `PartialProp` cannot represent
 this directly — it only handles presupposed propositions. -/
-def perAnaphoricWithPresup {E : Type*} (μ : DimensionedMeasure E) (q : ℚ)
+def perAnaphoricWithPresup {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ)
     (x : E) : PartialValue Unit ℚ where
   presup := fun _ => μ.apply x ≥ q
   value := fun _ => perAnaphoric μ q x
 
 /-- The unit sensitivity presupposition (eq. 43): μ_{dim(q)}(x) ≥ q. -/
-def perPresup {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) : Prop :=
+def perPresup {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ) (x : E) : Prop :=
   μ.apply x ≥ q
 
 /-- The presupposition is satisfied iff the entity's measure ≥ the unit. -/
-theorem presup_satisfied_iff {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) :
+theorem presup_satisfied_iff {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ) (x : E) :
     (perAnaphoricWithPresup μ q x).presup () ↔ μ.apply x ≥ q := Iff.rfl
 
 /-- The at-issue value is the pure number μ(x)/q. -/
-theorem perValue_eq {E : Type*} (μ : DimensionedMeasure E) (q : ℚ) (x : E) :
+theorem perValue_eq {E : Type*} (μ : DimensionedMeasure E ℚ) (q : ℚ) (x : E) :
     (perAnaphoricWithPresup μ q x).value () = perAnaphoric μ q x := rfl
 
 /-- At the sentence level, `PartialValue ℚ` composes with a measurement verb
 to produce a `PartialProp` — presupposition projects, assertion is boolean. -/
-def perSentenceWithPresup {E : Type*} (μ_wt μ_vol : DimensionedMeasure E)
+def perSentenceWithPresup {E : Type*} (μ_wt μ_vol : DimensionedMeasure E ℚ)
     (perUnit : ℚ) (numeral : ℚ) (x : E) : PartialProp Unit where
   presup := fun _ => perPresup μ_vol perUnit x
   assertion := fun _ => measureVerbSem μ_wt (numeral * perAnaphoric μ_vol perUnit x) x
 
 /-- The sentence-level assertion matches `anaphoricTC`. -/
-theorem assertion_matches_tc {E : Type*} (μ_wt μ_vol : DimensionedMeasure E)
+theorem assertion_matches_tc {E : Type*} (μ_wt μ_vol : DimensionedMeasure E ℚ)
     (perUnit numeral : ℚ) (x : E) :
     (perSentenceWithPresup μ_wt μ_vol perUnit numeral x).assertion () = true ↔
       anaphoricTC μ_wt μ_vol x numeral perUnit := by
@@ -472,7 +472,7 @@ theorem presup_predicts_felicity :
 
 /-- The anaphoric theory distinguishes "per milliliter" from "per liter"
 via different presuppositions, even when the ratios are numerically equal. -/
-theorem anaphoric_distinguishes_units {E : Type*} (μ : DimensionedMeasure E) (x : E)
+theorem anaphoric_distinguishes_units {E : Type*} (μ : DimensionedMeasure E ℚ) (x : E)
     (h : μ.apply x = 5) :
     -- per milliliter: presup μ(x) ≥ 1 — satisfied (5 ≥ 1)
     decide (μ.apply x ≥ 1) = true ∧
@@ -627,12 +627,12 @@ def quantityTimesNumber (q : Quantity) (n : ℚ) : Quantity :=
 /-- ⟦per milliliter⟧ = λx. μ_VOL(x) / mL (eq. 15).
 Instance of eq. (16): ⟦per⟧ = λq. λx. μ_{dim(q)}(x) / q.
 Output type: E → ℚ (entity to **pure number**). -/
-def step_perMilliliter (μ_vol : DimensionedMeasure E) (mL : Quantity) : E → ℚ :=
+def step_perMilliliter (μ_vol : DimensionedMeasure E ℚ) (mL : Quantity) : E → ℚ :=
   fun x => μ_vol.apply x / mL.value
 
 /-- ⟦[PP pro [per milliliter]]⟧ = μ_VOL(pro) / mL (FA).
 *pro* is resolved to the subject. Result: a **pure number**. -/
-def step_PP (μ_vol : DimensionedMeasure E) (mL : Quantity) (pro : E) : ℚ :=
+def step_PP (μ_vol : DimensionedMeasure E ℚ) (mL : Quantity) (pro : E) : ℚ :=
   step_perMilliliter μ_vol mL pro
 
 /-- ⟦[MP 0.9 grams]⟧ = 0.9 * g = 0.9g.
@@ -643,19 +643,19 @@ def step_innerMP (numeral : ℚ) (unit : Quantity) : Quantity :=
 /-- ⟦[MP [MP 0.9 grams] [PP pro per mL]]⟧ = 0.9g * (μ_VOL(pro)/mL) (eq. 18).
 Quantity × pure number → **quantity in dimension WT** (eq. 19).
 The dimension is STILL .mass — no quotient dimension arises. -/
-def step_fullMP (μ_vol : DimensionedMeasure E) (pro : E) (numeral : ℚ)
+def step_fullMP (μ_vol : DimensionedMeasure E ℚ) (pro : E) (numeral : ℚ)
     (unit mL : Quantity) : Quantity :=
   quantityTimesNumber (step_innerMP numeral unit) (step_PP μ_vol mL pro)
 
 /-- ⟦weighs⟧ = λq. λx. μ_WT(x) = q (eq. 5).
 Takes a **quantity** and returns a predicate. The verb's measure
 function must match the quantity's dimension. -/
-def step_weighs (μ_wt : DimensionedMeasure E) (q : Quantity) (x : E) : Bool :=
+def step_weighs (μ_wt : DimensionedMeasure E ℚ) (q : Quantity) (x : E) : Bool :=
   decide (μ_wt.apply x = q.value)
 
 /-- ⟦[S [the sample] [VP weighs [MP]]]⟧ — the full sentence (eq. 22).
 Applies the VP to the subject entity. -/
-def step_sentence (μ_wt μ_vol : DimensionedMeasure E) (sample : E)
+def step_sentence (μ_wt μ_vol : DimensionedMeasure E ℚ) (sample : E)
     (numeral : ℚ) (unit mL : Quantity) : Bool :=
   step_weighs μ_wt (step_fullMP μ_vol sample numeral unit mL) sample
 
@@ -677,13 +677,13 @@ theorem innerMP_dimension :
 This is the paper's key claim: the anaphoric theory never forms a
 quotient dimension. The *per*-PP contributes a dimensionless scalar,
 and multiplication preserves the original dimension. -/
-theorem fullMP_dimension (μ_vol : DimensionedMeasure E) (pro : E) :
+theorem fullMP_dimension (μ_vol : DimensionedMeasure E ℚ) (pro : E) :
     (step_fullMP μ_vol pro (9/10) gram_unit mL_unit).dim = .mass := rfl
 
 /-- `weigh`'s measure function is in dimension WT. When the composed
 quantity is also in WT, dimensions match — no type error. -/
-theorem dimensions_match (μ_wt : DimensionedMeasure E) (hwt : μ_wt.dimension = .mass)
-    (μ_vol : DimensionedMeasure E) (pro : E) :
+theorem dimensions_match (μ_wt : DimensionedMeasure E ℚ) (hwt : μ_wt.dimension = .mass)
+    (μ_vol : DimensionedMeasure E ℚ) (pro : E) :
     μ_wt.dimension = (step_fullMP μ_vol pro (9/10) gram_unit mL_unit).dim :=
   hwt
 
@@ -701,12 +701,12 @@ theorem division_theory_mismatch :
 /-- The derivation yields eq. (22): μ_WT(sample) = (0.9 * μ_VOL(sample)/mL) g.
 The numerical content is: μ_WT(sample) = 0.9 * 1 * (μ_VOL(sample) / 1),
 which simplifies to μ_WT(sample) = 0.9 * μ_VOL(sample). -/
-theorem derivation_eq22 (μ_wt μ_vol : DimensionedMeasure E) (sample : E) :
+theorem derivation_eq22 (μ_wt μ_vol : DimensionedMeasure E ℚ) (sample : E) :
     step_sentence μ_wt μ_vol sample (9/10) gram_unit mL_unit =
       decide (μ_wt.apply sample = 9 / 10 * 1 * (μ_vol.apply sample / 1)) := rfl
 
 /-- The derivation matches `anaphoricTC` (modulo unit normalization). -/
-theorem derivation_matches_tc (μ_wt μ_vol : DimensionedMeasure E) (sample : E)
+theorem derivation_matches_tc (μ_wt μ_vol : DimensionedMeasure E ℚ) (sample : E)
     (numeral : ℚ) :
     (step_sentence μ_wt μ_vol sample numeral gram_unit mL_unit = true) ↔
       anaphoricTC μ_wt μ_vol sample numeral 1 := by
@@ -719,11 +719,11 @@ theorem derivation_matches_tc (μ_wt μ_vol : DimensionedMeasure E) (sample : E)
 -- Concrete verification
 -- ════════════════════════════════════════════════════
 
-private def μ_wt_concrete : DimensionedMeasure Unit where
-  dimension := .mass; apply := fun _ => 9; nonneg := fun _ => by norm_num
+private def μ_wt_concrete : DimensionedMeasure Unit ℚ where
+  dimension := .mass; apply := fun _ => 9
 
-private def μ_vol_concrete : DimensionedMeasure Unit where
-  dimension := .volume; apply := fun _ => 10; nonneg := fun _ => by norm_num
+private def μ_vol_concrete : DimensionedMeasure Unit ℚ where
+  dimension := .volume; apply := fun _ => 10
 
 /-- A sample with μ_WT = 9g, μ_VOL = 10mL: "weighs 0.9 grams per
 milliliter" is TRUE. 9 = 0.9 * 1 * (10 / 1) = 9 ✓ -/
@@ -763,7 +763,7 @@ is that MUCH applies this quantity as a predicate, rather than *weigh*. -/
 /-- MUCH applied to the composed quantity (eq. 25 + eq. 42).
 ⟦MUCH⟧(q)(x) = (μ(x) = q.value), where μ is contextually resolved
 to μ_WT for "grams of salt". -/
-def step_MUCH (μ : DimensionedMeasure E) (q : Quantity) (x : E) : Bool :=
+def step_MUCH (μ : DimensionedMeasure E ℚ) (q : Quantity) (x : E) : Bool :=
   decide (μ.apply x = q.value)
 
 /-- Pseudo-partitive truth conditions (eq. 32):
@@ -772,7 +772,7 @@ def step_MUCH (μ : DimensionedMeasure E) (q : Quantity) (x : E) : Bool :=
 We represent the existential as a check over a domain list, matching the
 paper's eq. (26). -/
 def step_pseudoPartitive (salt : E → Bool) (contain : E → E → Bool)
-    (μ_wt μ_vol : DimensionedMeasure E) (mixture : E)
+    (μ_wt μ_vol : DimensionedMeasure E ℚ) (mixture : E)
     (numeral : ℚ) (unit mL : Quantity) (domain : List E) : Bool :=
   domain.any fun x =>
     salt x && step_MUCH μ_wt (step_fullMP μ_vol mixture numeral unit mL) x
@@ -781,7 +781,7 @@ def step_pseudoPartitive (salt : E → Bool) (contain : E → E → Bool)
 /-- The pseudo-partitive MP has the same dimension as the measurement
 verb MP — mass in both cases. This confirms that the anaphoric theory
 uses the same derivation mechanism for both environments. -/
-theorem pseudoPartitive_same_dimension (μ_vol : DimensionedMeasure E) (mixture : E) :
+theorem pseudoPartitive_same_dimension (μ_vol : DimensionedMeasure E ℚ) (mixture : E) :
     (step_fullMP μ_vol mixture (1/10) gram_unit mL_unit).dim =
     (step_fullMP μ_vol mixture (9/10) gram_unit mL_unit).dim := rfl
 
@@ -790,13 +790,13 @@ with the composed quantity, where `x` is the salt entity and `mixture`
 is the container (pro's referent). These are DIFFERENT entities — unlike
 the measurement verb case where the same entity is both subject and
 pro's referent. -/
-theorem pseudoPartitive_eq32 (μ_wt μ_vol : DimensionedMeasure E) (mixture x : E) :
+theorem pseudoPartitive_eq32 (μ_wt μ_vol : DimensionedMeasure E ℚ) (mixture x : E) :
     step_MUCH μ_wt (step_fullMP μ_vol mixture (1/10) gram_unit mL_unit) x =
       decide (μ_wt.apply x = 1 / 10 * 1 * (μ_vol.apply mixture / 1)) := rfl
 
 /-- In the measurement verb case, pro = subject, so the pseudo-partitive
 machinery specializes to `anaphoricTC` when we set mixture = x. -/
-theorem pseudoPartitive_specializes_to_measureVerb (μ_wt μ_vol : DimensionedMeasure E)
+theorem pseudoPartitive_specializes_to_measureVerb (μ_wt μ_vol : DimensionedMeasure E ℚ)
     (sample : E) (numeral : ℚ) :
     (step_MUCH μ_wt (step_fullMP μ_vol sample numeral gram_unit mL_unit)
       sample = true) ↔ anaphoricTC μ_wt μ_vol sample numeral 1 := by

--- a/Linglib/Studies/BaleSchwarz2026.lean
+++ b/Linglib/Studies/BaleSchwarz2026.lean
@@ -306,7 +306,7 @@ theorem simplex_is_compositional_2022 :
 extends to the 2026 analysis: the simplex examples here predict
 that the entity's volume must meet the per-unit threshold. -/
 theorem unit_sensitivity_carries_forward {E : Type*}
-    (μ : Degree.DimensionedMeasure E) (x : E)
+    (μ : Degree.DimensionedMeasure E ℚ) (x : E)
     (h : μ.apply x = 5) :
     perPresup μ 1 x = true ∧ perPresup μ 1000 x = false := by
   simp [perPresup, h]; decide

--- a/Linglib/Studies/DAmbrosioHedden2024.lean
+++ b/Linglib/Studies/DAmbrosioHedden2024.lean
@@ -98,6 +98,12 @@ theorem fullArrow_all_enabled :
 inductive Person where | alice | bob
   deriving Repr, DecidableEq
 
+/-- Speed-heavy weights `[3, 1, 1]` over (speed, agility, endurance). -/
+def speedHeavy : List ℚ := [3, 1, 1]
+
+/-- Endurance-heavy weights `[1, 1, 3]`. -/
+def enduranceHeavy : List ℚ := [1, 1, 3]
+
 /-- Dimensional profiles for *athletic*:
     - Alice: fast, agile, not enduring
     - Bob: not fast, not agile, enduring -/
@@ -117,18 +123,18 @@ theorem bob_not_athletic_majority :
 /-- Under speed-heavy weights [3, 1, 1] with θ = 3, Alice IS athletic
     (score = 3 + 1 + 0 = 4 ≥ 3) but Bob is NOT (score = 0 + 0 + 1 = 1). -/
 theorem alice_athletic_speed_heavy :
-    weightedBinding [3, 1, 1] 3 athleticDims .alice = true := by native_decide
+    weightedBinding speedHeavy 3 athleticDims .alice = true := by native_decide
 
 theorem bob_not_athletic_speed_heavy :
-    weightedBinding [3, 1, 1] 3 athleticDims .bob = false := by native_decide
+    weightedBinding speedHeavy 3 athleticDims .bob = false := by native_decide
 
 /-- Under endurance-heavy weights [1, 1, 3] with θ = 3, Alice is NOT
     athletic (score = 1 + 1 + 0 = 2 < 3) but Bob IS (0 + 0 + 3 = 3 ≥ 3). -/
 theorem alice_not_athletic_endurance_heavy :
-    weightedBinding [1, 1, 3] 3 athleticDims .alice = false := by native_decide
+    weightedBinding enduranceHeavy 3 athleticDims .alice = false := by native_decide
 
 theorem bob_athletic_endurance_heavy :
-    weightedBinding [1, 1, 3] 3 athleticDims .bob = true := by native_decide
+    weightedBinding enduranceHeavy 3 athleticDims .bob = true := by native_decide
 
 -- ════════════════════════════════════════════════════
 -- § 3. Comparative Vagueness
@@ -143,24 +149,24 @@ theorem bob_athletic_endurance_heavy :
 
 /-- Under speed-heavy weights, Alice outscores Bob. -/
 theorem speed_heavy_alice_wins :
-    weightedScore [3, 1, 1] (boolMeasures athleticDims) .alice >
-    weightedScore [3, 1, 1] (boolMeasures athleticDims) .bob := by native_decide
+    weightedScore speedHeavy (boolMeasures athleticDims) .alice >
+    weightedScore speedHeavy (boolMeasures athleticDims) .bob := by native_decide
 
 /-- Under endurance-heavy weights, Bob outscores Alice. -/
 theorem endurance_heavy_bob_wins :
-    weightedScore [1, 1, 3] (boolMeasures athleticDims) .bob >
-    weightedScore [1, 1, 3] (boolMeasures athleticDims) .alice := by native_decide
+    weightedScore enduranceHeavy (boolMeasures athleticDims) .bob >
+    weightedScore enduranceHeavy (boolMeasures athleticDims) .alice := by native_decide
 
 /-- Comparative vagueness: when both weight vectors are admissible,
     "Alice is more athletic than Bob" is **indeterminate** — one
     aggregation function says yes, the other says no. -/
 theorem comparative_vagueness :
     -- Speed-heavy: Alice > Bob
-    weightedScore [3, 1, 1] (boolMeasures athleticDims) .alice >
-    weightedScore [3, 1, 1] (boolMeasures athleticDims) .bob ∧
+    weightedScore speedHeavy (boolMeasures athleticDims) .alice >
+    weightedScore speedHeavy (boolMeasures athleticDims) .bob ∧
     -- Endurance-heavy: Bob > Alice
-    weightedScore [1, 1, 3] (boolMeasures athleticDims) .bob >
-    weightedScore [1, 1, 3] (boolMeasures athleticDims) .alice :=
+    weightedScore enduranceHeavy (boolMeasures athleticDims) .bob >
+    weightedScore enduranceHeavy (boolMeasures athleticDims) .alice :=
   ⟨speed_heavy_alice_wins, endurance_heavy_bob_wins⟩
 
 -- ════════════════════════════════════════════════════

--- a/Linglib/Studies/Wellwood2015.lean
+++ b/Linglib/Studies/Wellwood2015.lean
@@ -383,20 +383,20 @@ theorem qua_measures_vacuously_admissible {α : Type*} [PartialOrder α]
     entity and event domains have incomparable parts (weight × volume,
     distance × duration). -/
 abbrev MeasuredDomain.Model : MeasuredDomain → Type
-  | .state  => ℚ
-  | .entity => ℚ × ℚ
-  | .event  => ℚ × ℚ
+  | .state  => ℝ
+  | .entity => ℝ × ℝ
+  | .event  => ℝ × ℝ
 
 instance : (m : MeasuredDomain) → Preorder m.Model
-  | .state  => inferInstanceAs (Preorder ℚ)
-  | .entity => inferInstanceAs (Preorder (ℚ × ℚ))
-  | .event  => inferInstanceAs (Preorder (ℚ × ℚ))
+  | .state  => inferInstanceAs (Preorder ℝ)
+  | .entity => inferInstanceAs (Preorder (ℝ × ℝ))
+  | .event  => inferInstanceAs (Preorder (ℝ × ℝ))
 
 /-- §3.4 as order theory: exactly the state domain is dimensionally
     restricted. -/
 theorem model_restricted_iff : ∀ m : MeasuredDomain,
     DimensionallyRestricted m.Model ↔ m = .state
-  | .state  => iff_of_true (linearOrder_dimensionallyRestricted (α := ℚ)) rfl
+  | .state  => iff_of_true (linearOrder_dimensionallyRestricted (α := ℝ)) rfl
   | .entity => iff_of_false prod_not_dimensionallyRestricted (by decide)
   | .event  => iff_of_false prod_not_dimensionallyRestricted (by decide)
 


### PR DESCRIPTION
Follow-through of #2330 in the degree layer: measure-function codomains follow the model scale instead of pinning ℚ.

- `DimensionedMeasure E (D := ℝ)`; non-negativity is no longer a field (nothing consumed it; positivity is `IsExtensive`'s job), `cardMeasure` counts in ℕ and casts into the scale.
- `DimensionallyRestricted α (D := ℝ)`, with the product counterexample over any ordered field and Wellwood 2015's domain models on ℝ.
- `Aggregation` over an ordered field `K`; D'Ambrosio–Hedden's weight vectors become named `List ℚ` constants so `K` infers. Bale–Schwarz 2022/2026 pin `ℚ` explicitly since they `decide`.
- Left at ℚ on purpose: Bale 2008's Ω (`relativeRank`), Nouwen 2024's numeric model (`Intensification`), and the ∃-witness statements in `Hom`/`MeasurePhrase`.