### PR TITLE
refactor(Studies/Moon2026): recipe witness over an ordered field, cut tables

### DIFF
--- a/Linglib/Studies/Moon2026.lean
+++ b/Linglib/Studies/Moon2026.lean
@@ -1,776 +1,231 @@
-import Linglib.Semantics.Mereology
 import Linglib.Studies.Borer2005
-import Linglib.Semantics.Aspect.Incremental
 import Linglib.Studies.Filip2012
 import Mathlib.Topology.Connected.Basic
-import Mathlib.Algebra.Order.Ring.Unbundled.Rat
-import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
 
 /-!
-# Moon 2026: Countability and Measured Parts in Mixed Drink Nouns
-[moon-2026] [filip-2012] [casati-varzi-1999] [krifka-2021]
+# Moon (2026): countability and measured parts in mixed drink nouns
 
-Mixed drink nouns (*martini*, *cappuccino*) are count despite denoting
-liquids. Moon proposes that their countability derives from a MEASURED
-PART — an ingredient part (the shot of liquor/espresso) that provides
-a unit for individuation. This contrasts with standard mass drink nouns
-(*wine*, *coffee*) which lack such a part.
+Mixed drink nouns (*martini*, *cappuccino*) are count nouns that denote liquids.
+[moon-2026] derives their countability from their part structure: a mixed drink is a
+mereological sum of ingredient parts standing in a fixed ratio of measures (`Recipe`,
+`RatioHolds`), one of which — the shot of liquor or espresso, the MEASURED PART — supplies
+the unit of individuation, and the whole is a connected liquid in the mereotopological
+sense of [casati-varzi-1999] (`ConnectedLiquid`, with spatial structure a
+`TopologicalSpace` independent of parthood). The denotation `mixedDrinkDen` packages
+Moon's final formula as the existence of a `MixedDrinkWitness`.
 
-## Connection to Filip 2012's three-way classification
+Two consequences carry the countability argument. The sum of two spatially separate drinks
+is not a connected liquid, so the denotation is not cumulative
+(`not_mixedDrinkDen_of_not_selfConnected`) — a topological route to non-cumulativity that
+a bare semilattice lacks, where it comes only from quantization (`connectivity_breaks_cum`).
+And a mixed drink has proper parts, so it is not a mereological atom (`mixedDrink_not_atom`)
+and [borer-2005]'s individuation operator excludes it (`div_excludes_mixed_drinks`), while
+half a drink with its ratios preserved is still a drink, so the denotation is not quantized
+either (`mixedDrink_not_qua`). Mixed drinks thus occupy the ¬CUM ∧ ¬QUA middle ground of
+[filip-2012] (`mixedDrink_middle_ground`), and the gap propagates to drinking VPs through
+`Filip2012.middle_ground_stable` (`mixedDrink_VP_propagation_gap`). Multipliers such as
+*double* rescale the measured part's ratio constant rather than the whole (`doubleRecipe`,
+[wagiel-2021]'s subatomic quantification), and *dry* rescales another ingredient's
+(`modifyRatio`).
 
-Mixed drink predicates instantiate the ¬CUM ∧ ¬QUA middle ground that
-[filip-2012] identifies as a third class beyond CUM (atelic) and
-QUA (telic). The topological non-cumulativity proved here
-(`not_cum_of_disconnected`) plus the algebraic non-quantization
-(`mixedDrink_not_qua`) jointly witness Filip's middle ground at the
-NP level. The propositional substrate for the gap propagating to VPs
-under SINC + UP + CumTheta verbs lives in
-`Studies/Filip2012.lean` as the typeclass-form
-public API `not_cum_vp_of_witnesses` and `middle_ground_stable`
-(both `[IsSincVerb θ]`-parametric per mathlib discipline); the bridge
-in §12 below invokes them directly. Moon's mixed-drink case is the
-*concrete topological witness* that Filip's *algebraic propagation*
-machinery is designed to consume.
+Moon's corpus and judgment data stay in prose: in her COCA counts (Appendix A) cocktail
+nouns pattern with count nouns on bare plurals and numerals while non-count drink nouns
+take bare singulars and containers; countability survives coercion contexts such as
+*pitcher of martinis*; and *who drank more americanos?* is ambiguous between volume,
+portions, and measured parts.
 
-## Core Proposal (formula 28)
+## References
 
-⟦mixed drink⟧ = λx ∃ȳ₀ⁿ ∃P̄₀ⁿ [x = ⊕ȳ ∧ ∀yᵢ∀Pᵢ[Pᵢ(yᵢ)]
-  ∧ ∃r̄₀ⁿ ∀ȳ₀ⁿ [μ(yᵢ)/rᵢ = μ(yⱼ)/rⱼ]
-  ∧ MEASURED PART(y₀) ∧ CONNECTED LIQUID(x)]
-
-This is built from:
-1. **Parts in mereological sum** — `SemilatticeSup` (⊔)
-2. **Ratio constraint** — `ExtMeasure.μ` (extensive measure)
-3. **Measured part** — a distinguished countable ingredient
-4. **Connected liquid** — `IsConnected` from Mathlib topology
-
-## Grounding
-
-| Moon concept | Linglib/Mathlib |
-|---|---|
-| ⊕ (sum) | `⊔` (`SemilatticeSup`) |
-| O (overlap) | `Mereology.Overlap` |
-| μ (measure) | `ExtMeasure.μ` |
-| SC (self-connection) | `SelfConnected` (§ 0) = `IsConnected (Set.Iic x)` |
-| CONNECTED LIQUID | `ConnectedLiquid` (§ 0) |
-| QUA/CUM | `Mereology.QUA` / `Mereology.CUM` |
-
-## Key Empirical Claims
-
-1. Mixed drink nouns are syntactically count: pluralize, take numerals,
-   combine with *many* (not *much*), accept distributive predicates
-2. This is NOT Universal Packager coercion: countability persists in
-   *pitcher of martinis*, *bottomless mimosas* (Moon §3.5)
-3. Multiplier *double* targets the MEASURED PART (*double americano*
-   = double espresso, not double volume), following [wagiel-2021]
-4. Quantity judgments are ambiguous between volume, number of portions,
-   and number of measured parts (Moon §4.3.2)
+* [moon-2026]
+* [borer-2005], [casati-varzi-1999], [filip-2012], [krifka-2021], [wagiel-2021]
 -/
 
 namespace Moon2026
 
 open Mereology
+open Semantics.Aspect.Incremental (IsSincVerb)
+open Semantics.Aspect.Cumulativity (VP)
 
--- ════════════════════════════════════════════════════
--- § 0. Mereotopological Substrate
--- ════════════════════════════════════════════════════
+/-! ### Mereotopology -/
 
-/-! ### Mereotopological substrate
+section Mereotopology
 
-[casati-varzi-1999] take connection as a mereotopological *primitive*.
-Here spatial structure is instead a `TopologicalSpace` *independent* of
-the parthood order (contra `OrderTopology`), respecting their position
-that spatial arrangement is irreducible to parthood: entities may share
-parts without being adjacent, and may touch without sharing parts.
-Self-connection is `IsConnected` of the principal downset `Set.Iic x` —
-the parts of x, viewed as the region x occupies.
+variable {α : Type*} [TopologicalSpace α]
 
-The payoff is a category invisible to pure mereology. In a bare
-`SemilatticeSup`, ¬CUM for non-singleton predicates comes from QUA
-(`qua_cum_incompatible`). With independent topology the two decouple:
-join can disconnect two connected entities placed apart
-(`connectivity_breaks_cum`), while proper parts can stay connected, so
-**¬CUM ∧ ¬QUA** predicates exist (`connectivity_middle_ground`). Mixed
-drink nouns live in exactly this gap: disconnected margaritas are not a
-margarita (¬CUM), but half a margarita with preserved ratios still is
-one (¬QUA).
--/
+/-- Self-connected ([casati-varzi-1999]): the parts of `x`, the principal downset
+`Set.Iic x`, form a connected set. -/
+def SelfConnected [Preorder α] (x : α) : Prop := IsConnected (Set.Iic x)
 
-/-- Self-connected ([casati-varzi-1999] def 20b): the parts of `x` — the
-    principal downset `Set.Iic x` — form a topologically connected set.
-    An atom is trivially self-connected; a scattered aggregate (separate
-    shots of tequila and lime juice at a bar) is not. -/
-def SelfConnected {α : Type*} [Preorder α] [TopologicalSpace α] (x : α) : Prop :=
-  IsConnected (Set.Iic x)
-
-/-- Phase of matter, [krifka-2021]'s trichotomy: solids retain shape,
-    granulars are aggregates of discrete solid pieces (rice, sand),
-    liquids have parts in constant internal motion. The distinction
-    drives count/mass behavior of substance nouns: solids and granulars
-    individuate by shape or grain boundaries; liquids lack internal
-    boundaries except via ingredient structure (mixed drinks). -/
+/-- Phase of matter ([krifka-2021]): solids retain shape, granulars are aggregates of
+discrete pieces, liquids have parts in constant internal motion. -/
 inductive Phase where
   | solid
   | granular
   | liquid
-  deriving DecidableEq, Repr, BEq
+  deriving DecidableEq, Repr
 
-/-- Connected liquid (Moon's def 23, following [krifka-2021]):
-    self-connected with every part in liquid phase. The temporal
-    parameter of the paper's definition is omitted (static
-    mereotopology). -/
-def ConnectedLiquid {α : Type*} [PartialOrder α] [TopologicalSpace α]
-    (phase : α → Phase) (x : α) : Prop :=
+/-- Connected liquid (Moon's definition (23), without its temporal parameter):
+self-connected with every part liquid. -/
+def ConnectedLiquid [PartialOrder α] (phase : α → Phase) (x : α) : Prop :=
   SelfConnected x ∧ ∀ y ≤ x, phase y = .liquid
 
-theorem ConnectedLiquid.selfConnected {α : Type*} [PartialOrder α]
-    [TopologicalSpace α] {phase : α → Phase} {x : α}
+theorem ConnectedLiquid.selfConnected [PartialOrder α] {phase : α → Phase} {x : α}
     (h : ConnectedLiquid phase x) : SelfConnected x :=
   h.1
 
-/-- Any predicate entailing self-connectivity fails CUM when two
-    instances have a disconnected join — the *topological* source of
-    non-cumulativity, orthogonal to the algebraic one (QUA,
-    `qua_cum_incompatible`). -/
-theorem connectivity_breaks_cum {α : Type*} [SemilatticeSup α]
-    [TopologicalSpace α] {P : α → Prop}
-    (hConn : ∀ x, P x → SelfConnected x)
-    {x y : α} (hx : P x) (hy : P y)
-    (hDisc : ¬ SelfConnected (x ⊔ y)) :
-    ¬ CUM P :=
+variable [SemilatticeSup α] {P : α → Prop}
+
+/-- A predicate entailing self-connection is not cumulative once two instances have a
+disconnected sum: non-cumulativity from topology rather than from quantization
+(`qua_cum_incompatible`). -/
+theorem connectivity_breaks_cum (hConn : ∀ x, P x → SelfConnected x) {x y : α} (hx : P x)
+    (hy : P y) (hDisc : ¬ SelfConnected (x ⊔ y)) : ¬ CUM P :=
   fun hCum => hDisc (hConn _ (hCum hx hy))
 
-/-- ¬CUM ∧ ¬QUA from connectivity: the middle ground between mass and
-    standard count that pure mereology cannot express. -/
-theorem connectivity_middle_ground {α : Type*} [SemilatticeSup α]
-    [TopologicalSpace α] {P : α → Prop}
-    (hConn : ∀ x, P x → SelfConnected x)
-    {a b : α} (ha : P a) (hb : P b)
-    (hDisc : ¬ SelfConnected (a ⊔ b))
-    {x y : α} (hx : P x) (hy : P y) (hlt : y < x) :
-    ¬ CUM P ∧ ¬ QUA P :=
+/-- With a proper part that is also an instance, such a predicate is neither cumulative
+nor quantized. -/
+theorem connectivity_middle_ground (hConn : ∀ x, P x → SelfConnected x) {a b : α} (ha : P a)
+    (hb : P b) (hDisc : ¬ SelfConnected (a ⊔ b)) {x y : α} (hx : P x) (hy : P y)
+    (hlt : y < x) : ¬ CUM P ∧ ¬ QUA P :=
   ⟨connectivity_breaks_cum hConn ha hb hDisc, fun hQ => hQ hy hx hlt.ne hlt.le⟩
 
--- ════════════════════════════════════════════════════
--- § 1. Mixed Drink Recipe
--- ════════════════════════════════════════════════════
+end Mereotopology
 
-variable {α : Type*} [SemilatticeSup α] [TopologicalSpace α]
+/-! ### Recipes and the mixed-drink denotation -/
 
-/-- A mixed drink recipe: ingredient predicates, ratio constants, and
-    an index identifying which ingredient is the MEASURED PART.
-
-    Example: a margarita has 3 ingredients (tequila, triple sec, lime juice)
-    in ratio 5:2:1.5, and the measured part is the tequila (index 0). -/
-structure Recipe (α : Type*) (n : ℕ) where
-  /-- Ingredient predicates (e.g., TEQUILA, TRIPLE_SEC, LIME_JUICE) -/
+/-- A mixed drink recipe: ingredient predicates, positive ratio constants, and the index of
+the measured part. -/
+structure Recipe (α K : Type*) [Zero K] [LT K] (n : ℕ) where
+  /-- The ingredient predicates. -/
   ingredients : Fin n → α → Prop
-  /-- Ratio constants (e.g., 5, 2, 3/2 for a margarita). All positive. -/
-  ratios : Fin n → ℚ
-  /-- All ratio constants are positive. -/
+  /-- The ratio constants. -/
+  ratios : Fin n → K
   ratios_pos : ∀ i, 0 < ratios i
-  /-- Index of the measured part (the individuating ingredient). -/
+  /-- The index of the measured part, the ingredient that supplies the unit. -/
   measuredPart : Fin n
 
--- ════════════════════════════════════════════════════
--- § 2. Ratio Constraint
--- ════════════════════════════════════════════════════
+variable {α K : Type*} [SemilatticeSup α] [TopologicalSpace α] [Field K] [LinearOrder K] {n : ℕ}
 
-/-- The ratio constraint between parts of a mixed drink:
-    μ(yᵢ)/rᵢ = μ(yⱼ)/rⱼ for all pairs of parts.
-
-    This captures that it is the *ratio* between ingredients that
-    defines the drink, not the absolute measurements. A margarita
-    is 5:2:1.5 whether made with 50ml, 20ml, 15ml or with 100ml,
-    40ml, 30ml of the respective ingredients.
-
-    Uses `ExtMeasure.μ` from `Semantics/Mereology.lean`. -/
-def RatioHolds {n : ℕ} (μ : α → ℚ) (recipe : Recipe α n)
-    (parts : Fin n → α) : Prop :=
+/-- Moon's ratio constraint, `μ yᵢ / rᵢ = μ yⱼ / rⱼ` for all ingredient parts, in
+cross-multiplied form. -/
+def RatioHolds (μ : α → K) (recipe : Recipe α K n) (parts : Fin n → α) : Prop :=
   ∀ i j, μ (parts i) * recipe.ratios j = μ (parts j) * recipe.ratios i
 
--- Cross-multiply form avoids division; equivalent to μ(yᵢ)/rᵢ = μ(yⱼ)/rⱼ
--- when all ratios are positive.
-
--- ════════════════════════════════════════════════════
--- § 3. Mixed Drink Denotation (Formula 28)
--- ════════════════════════════════════════════════════
-
-/-- Witness structure for a mixed drink: the ingredient parts that
-    compose the drink, satisfying all constraints. -/
-structure MixedDrinkWitness {n : ℕ} (recipe : Recipe α n)
-    (μ : α → ℚ) (phase : α → Phase) (x : α) where
-  /-- Assignment of entities to ingredient slots -/
+/-- A witness that `x` is a mixed drink under `recipe`: non-null, pairwise non-overlapping
+ingredient parts of `x` that exhaust it, satisfy their ingredient predicates and the ratio
+constraint, with `x` a connected liquid. -/
+structure MixedDrinkWitness (recipe : Recipe α K n) (μ : α → K) (phase : α → Phase)
+    (x : α) where
+  /-- The entity filling each ingredient slot. -/
   assign : Fin n → α
-  /-- Each part is a part of the whole -/
   part_le : ∀ i, assign i ≤ x
-  /-- Each ingredient slot is filled by something. -/
   present : ∀ i, ¬ IsBot (assign i)
-  /-- Each part satisfies its ingredient predicate -/
   satisfies : ∀ i, recipe.ingredients i (assign i)
-  /-- Ratio constraint holds between all parts -/
   ratio : RatioHolds μ recipe assign
-  /-- Parts don't overlap pairwise (they are distinct ingredients) -/
   disjoint : ∀ i j, i ≠ j → ¬ Overlap (assign i) (assign j)
-  /-- The parts exhaust the whole: every part of x overlaps some ingredient.
-      Moon's x = ⊕ȳ requires the ingredients to cover x completely — no
-      extra material beyond the recipe components. -/
   covers : ∀ z, z ≤ x → ∃ i, Overlap z (assign i)
-  /-- The whole is a connected liquid -/
   connected : ConnectedLiquid phase x
 
-/-- The denotation of a mixed drink noun, following Moon's formula (28).
-
-    An entity x is a mixed drink if:
-    1. It has ingredient parts satisfying the recipe predicates
-    2. The parts stand in the correct ratio (via μ)
-    3. The parts are pairwise non-overlapping
-    4. The whole is a connected liquid (self-connected, all parts liquid)
-
-    The MEASURED PART is the ingredient at `recipe.measuredPart` — it
-    provides the unit for individuation and is what *double* targets
-    ([wagiel-2021]).
-
-    TODO: formula (28)'s `MEASURED PART(y₀)` conjunct is not imposed as a
-    truth condition — `recipe.measuredPart` only records *which* index is
-    the measured part (consumed by `doubleRecipe`); no `MixedDrinkWitness`
-    field asserts it is individuable. So this denotation is Moon's earlier
-    formula (19) plus CONNECTED LIQUID, and [moon-2026] notes (19)
-    over-generates to ratio-structured mass mixtures like *lemonade*. The
-    ¬CUM and ¬QUA results below are unaffected (they use only connectivity
-    and the witness), but the denotation does not yet separate a margarita
-    from ratioed lemonade. Encoding it needs truth conditions for MEASURED
-    PART, which [moon-2026] leaves informal. -/
-def mixedDrinkDen {n : ℕ} (recipe : Recipe α n)
-    (μ : α → ℚ) (phase : α → Phase) (x : α) : Prop :=
+/-- The denotation of a mixed drink noun, Moon's final formula: ratio-related ingredient
+parts forming a connected liquid. The MEASURED PART conjunct, which Moon leaves informal,
+is recorded only as the recipe's `measuredPart` index and not imposed as a truth
+condition, so this is her ratio formula (19) plus CONNECTED LIQUID; she notes that (19)
+alone also covers ratio-structured non-count drinks such as *lemonade*. -/
+def mixedDrinkDen (recipe : Recipe α K n) (μ : α → K) (phase : α → Phase) (x : α) : Prop :=
   Nonempty (MixedDrinkWitness recipe μ phase x)
 
--- ════════════════════════════════════════════════════
--- § 4. CUM/DIV Failure (Source of Countability)
--- ════════════════════════════════════════════════════
+variable {recipe : Recipe α K n} {μ : α → K} {phase : α → Phase}
 
-/-- CUM fails for mixed drink denotations because the join of two
-    disconnected mixed drinks is not a connected liquid.
+theorem selfConnected_of_mixedDrinkDen {x : α} (hx : mixedDrinkDen recipe μ phase x) :
+    SelfConnected x :=
+  hx.some.connected.selfConnected
 
-    If m₁ and m₂ are two separate margaritas (in different glasses),
-    their mereological sum m₁ ⊔ m₂ is not self-connected: the set
-    `{y | y ≤ m₁ ⊔ m₂}` has a non-trivial open partition separating
-    the two glasses. Therefore `ConnectedLiquid phase (m₁ ⊔ m₂)` fails,
-    so `m₁ ⊔ m₂` does not satisfy the mixed drink denotation.
+/-- Two margaritas in separate glasses do not sum to a margarita: the sum is not a
+connected liquid. -/
+theorem not_mixedDrinkDen_of_not_selfConnected {x : α} (hDisc : ¬ SelfConnected x) :
+    ¬ mixedDrinkDen recipe μ phase x :=
+  fun hx => hDisc (selfConnected_of_mixedDrinkDen hx)
 
-    This is the key asymmetry with mass nouns like *wine*: wine does
-    not require self-connection, so pouring two wines together yields
-    more wine (CUM holds). -/
-theorem not_cum_of_disconnected {n : ℕ} (recipe : Recipe α n)
-    (μ : α → ℚ) (phase : α → Phase)
-    {m₁ m₂ : α}
-    (_hm₁ : mixedDrinkDen recipe μ phase m₁)
-    (_hm₂ : mixedDrinkDen recipe μ phase m₂)
-    (hDisc : ¬ SelfConnected (m₁ ⊔ m₂)) :
-    ¬ mixedDrinkDen recipe μ phase (m₁ ⊔ m₂) := by
-  intro ⟨w⟩
-  exact hDisc w.connected.selfConnected
+/-- A single ingredient is not the drink: with at least two ingredients whose extensions
+are exclusive of one another's parts, an entity all of whose parts are ingredient `i`
+fills no other slot. -/
+theorem not_mixedDrinkDen_of_exclusive {recipe : Recipe α K (n + 2)} {y : α} (i : Fin (n + 2))
+    (hExcl : ∀ j ≠ i, ∀ z ≤ y, ¬ recipe.ingredients j z) :
+    ¬ mixedDrinkDen recipe μ phase y :=
+  fun ⟨w⟩ => let ⟨j, hj⟩ := exists_ne i; hExcl j hj _ (w.part_le j) (w.satisfies j)
 
-/-- DIV fails for mixed drink denotations because a single ingredient
-    part does not satisfy the full recipe (it lacks the other ingredients).
-
-    For example, just the tequila in a margarita is not itself a margarita:
-    it satisfies TEQUILA but not TRIPLE_SEC or LIME_JUICE. With n ≥ 2
-    ingredients, no single part can fill all ingredient slots.
-
-    This is why mixed drinks are count: proper parts fail the predicate
-    (QUA-like behavior). -/
--- TODO: Full proof requires an ingredient exclusivity axiom —
--- that if y satisfies ingredient i, then no part of y satisfies
--- ingredient j ≠ i. This is implicit in Moon's setup (tequila-stuff
--- is not triple-sec-stuff).
-theorem single_ingredient_not_mixed_drink {n : ℕ}
-    (recipe : Recipe α (n + 2))
-    (μ : α → ℚ) (phase : α → Phase)
-    {y : α} (i : Fin (n + 2))
-    (_hIngr : recipe.ingredients i y)
-    (hExcl : ∀ j, j ≠ i → ∀ z, z ≤ y → ¬ recipe.ingredients j z) :
-    ¬ mixedDrinkDen recipe μ phase y := by
-  intro ⟨w⟩
-  -- With n + 2 ≥ 2 ingredients, there exists j ≠ i
-  have ⟨j, hj⟩ : ∃ j : Fin (n + 2), j ≠ i := by
-    by_cases h : (⟨0, by omega⟩ : Fin (n + 2)) = i
-    · exact ⟨⟨1, by omega⟩, by intro heq; rw [← heq] at h; exact absurd h (by simp)⟩
-    · exact ⟨⟨0, by omega⟩, h⟩
-  -- w.assign j is a part of y (w.part_le j) and satisfies ingredient j
-  exact hExcl j hj (w.assign j) (w.part_le j) (w.satisfies j)
-
--- ════════════════════════════════════════════════════
--- § 5. Multiplier Modification ([wagiel-2021])
--- ════════════════════════════════════════════════════
-
-/-- The multiplier reading of *double*: scales the measured part.
-
-    *Double americano* = an americano with 2× the measured part (espresso).
-    The multiplier targets `recipe.measuredPart`, not the whole drink.
-    Following [wagiel-2021]'s subatomic quantification: multipliers
-    access semantically salient parts of an entity.
-
-    A *double* mixed drink has the same recipe but with the measured
-    part's ratio constant doubled — changing the ratio between parts
-    while keeping the recipe structure. -/
-def doubleRecipe {n : ℕ} (recipe : Recipe α n) : Recipe α n where
-  ingredients := recipe.ingredients
-  ratios := fun i =>
-    if i = recipe.measuredPart
-    then 2 * recipe.ratios i
-    else recipe.ratios i
-  ratios_pos := by
-    intro i
-    show 0 < (if i = recipe.measuredPart then 2 * recipe.ratios i else recipe.ratios i)
-    split
-    · exact mul_pos (by norm_num : (0:ℚ) < 2) (recipe.ratios_pos _)
-    · exact recipe.ratios_pos i
-  measuredPart := recipe.measuredPart
-
-/-- *Dry* martini: reduces the non-measured-part ratio (vermouth).
-    Moon (27b): a modifier that changes the ratio relationship
-    between parts. This is a recipe-level operation, not an
-    entity-level one. -/
-def modifyRatio {n : ℕ} (recipe : Recipe α n)
-    (target : Fin n) (factor : ℚ) (hPos : 0 < factor) :
-    Recipe α n where
-  ingredients := recipe.ingredients
-  ratios := fun i => if i = target then factor * recipe.ratios i else recipe.ratios i
-  ratios_pos := by
-    intro i
-    show 0 < (if i = target then factor * recipe.ratios i else recipe.ratios i)
-    split
-    · exact mul_pos hPos (recipe.ratios_pos _)
-    · exact recipe.ratios_pos i
-  measuredPart := recipe.measuredPart
-
--- ════════════════════════════════════════════════════
--- § 6. Empirical Data
--- ════════════════════════════════════════════════════
-
-/-- Countability diagnostic contexts for nouns.
-    Moon §3: mixed drink nouns pattern with count nouns across all tests.
-    Table 1 (Appendix A): COCA corpus percentages. -/
-inductive CountabilityContext where
-  /-- Bare singular (*a margarita, *milk) -/
-  | bareSg
-  /-- Bare plural (margaritas, *milks) -/
-  | barePl
-  /-- With unit/numeral (two martinis, *two milks) -/
-  | unit
-  /-- Container/measure singular (a glass of wine, a bottle of beer) -/
-  | containerSg
-  /-- Container/measure plural -/
-  | containerPl
-  deriving DecidableEq, Repr
-
-/-- Corpus distribution for a noun across countability contexts.
-    Percentages from Moon 2026, Table 1 (COCA data). -/
-structure CorpusDistribution where
-  noun : String
-  bareSg : Float
-  barePl : Float
-  unit : Float
-  containerSg : Float
-  containerPl : Float
-  deriving Repr
-
-/-- Cocktail noun group averages (Moon Table 1). -/
-def cocktailAvg : CorpusDistribution :=
-  { noun := "cocktail_avg", bareSg := 2.17, barePl := 31.65,
-    unit := 31.97, containerSg := 0.22, containerPl := 1.25 }
-
-/-- Non-count drink noun group averages (Moon Table 1). -/
-def nonCountDrinkAvg : CorpusDistribution :=
-  { noun := "noncount_drink_avg", bareSg := 45.73, barePl := 1.94,
-    unit := 5.15, containerSg := 14.96, containerPl := 0.0 }
-
-/-- The key distributional asymmetry: cocktails have high bare-plural
-    and unit/numeral rates (count behavior), while non-count drinks
-    have high bare-singular and container rates (mass behavior).
-    χ²(3, N = 1361) = 858.29, p < .001, V = .79 -/
-def distributionalAsymmetry : Prop :=
-  cocktailAvg.barePl > nonCountDrinkAvg.barePl ∧
-  cocktailAvg.unit > nonCountDrinkAvg.unit ∧
-  nonCountDrinkAvg.bareSg > cocktailAvg.bareSg ∧
-  nonCountDrinkAvg.containerSg > cocktailAvg.containerSg
-
--- ════════════════════════════════════════════════════
--- § 7. Quantity Judgment Ambiguity (§4.3.2)
--- ════════════════════════════════════════════════════
-
-/-- Dimensions along which "who has more margaritas?" can be judged.
-
-    Moon §4.3.2: Traditional quantity judgment tests assume two
-    dimensions (number vs volume). Mixed drink nouns reveal a third:
-    number of measured parts (shots of alcohol/espresso). -/
-inductive QuantityDimension where
-  /-- Total volume of liquid -/
-  | volume
-  /-- Number of standard portions (glasses) -/
-  | portions
-  /-- Number of measured parts (shots of base spirit/espresso) -/
-  | measuredParts
-  deriving DecidableEq, Repr
-
-/-- Moon's scenario: person A drinks two single-shot 16oz americanos,
-    person B drinks two quadruple-shot 12oz americanos.
-
-    - By volume: A drank more (32oz > 24oz)
-    - By portions: tied (2 each)
-    - By measured parts: B drank more (8 shots > 2 shots)
-
-    "Who drank more americanos?" is genuinely ambiguous. -/
-structure AmericanoScenario where
-  personA_portions : ℕ := 2
-  personA_shots_per : ℕ := 1
-  personA_oz_per : ℕ := 16
-  personB_portions : ℕ := 2
-  personB_shots_per : ℕ := 4
-  personB_oz_per : ℕ := 12
-
-def americanoExample : AmericanoScenario := {}
-
-theorem americano_volume_A_more :
-    americanoExample.personA_portions * americanoExample.personA_oz_per >
-    americanoExample.personB_portions * americanoExample.personB_oz_per := by
-  decide
-
-theorem americano_portions_tied :
-    americanoExample.personA_portions =
-    americanoExample.personB_portions := by
-  decide
-
-theorem americano_shots_B_more :
-    americanoExample.personB_portions * americanoExample.personB_shots_per >
-    americanoExample.personA_portions * americanoExample.personA_shots_per := by
-  decide
-
--- ════════════════════════════════════════════════════
--- § 8. Example: Margarita Recipe
--- ════════════════════════════════════════════════════
-
-/-- Margarita recipe: tequila (ratio 5), triple sec (ratio 2),
-    lime juice (ratio 3/2). Measured part = tequila (index 0).
-    IBA specification: 50ml tequila, 20ml triple sec, 15ml lime juice. -/
-def margaritaRecipe (α : Type*) (tequila tripleSec limeJuice : α → Prop) :
-    Recipe α 3 where
-  ingredients := ![tequila, tripleSec, limeJuice]
-  ratios := ![5, 2, 3/2]
-  ratios_pos := by
-    intro i; fin_cases i <;>
-      (simp_all [Matrix.cons_val_zero, Matrix.cons_val_one]; try norm_num)
-  measuredPart := 0
-
--- ════════════════════════════════════════════════════
--- § 9. Substance Nouns: the CUM Contrast
--- ════════════════════════════════════════════════════
-
-/-- Substance noun denotation (wine, coffee, water): the predicate holds
-    of any portion of the substance, with no recipe, ratio, or connectivity
-    constraint.
-
-    This is the key contrast with mixed drink nouns. Wine-stuff satisfies
-    WINE regardless of shape, contiguity, or internal structure. Two
-    disconnected puddles of wine are still wine. This makes the denotation
-    cumulative: combining wine with wine gives wine. -/
-abbrev substanceNounDen (substancePred : α → Prop) := substancePred
-
-section SubstanceNounCum
-variable {β : Type*} [SemilatticeSup β]
-
-/-- Substance noun denotations are CUM when the underlying substance
-    predicate is CUM. This is trivially true because the denotation IS
-    the substance predicate — no additional constraints to break closure.
-
-    Contrast with `not_cum_of_disconnected`: mixed drink denotations fail
-    CUM because `ConnectedLiquid` rejects disconnected sums.
-
-    Since [chierchia-1998]'s `IsMass` implies CUM (via `isMass_cum`
-    in `Semantics/Lexical/Noun/Kind/NMP.lean`), this
-    means substance nouns can be mass. Mixed drink nouns cannot — their
-    denotation fails CUM, hence fails `IsMass`. -/
-theorem substanceNoun_cum (substancePred : β → Prop)
-    (hCum : CUM substancePred) :
-    CUM (substanceNounDen substancePred) :=
-  hCum
-
-end SubstanceNounCum
-
-/-- The core mass/count asymmetry from Moon 2026:
-
-    - **Substance nouns** (wine, coffee): CUM holds, QUA fails →
-      mass behavior (bare singular OK, *two wines needs coercion)
-    - **Mixed drink nouns** (martini, americano): CUM fails (via
-      ConnectedLiquid), QUA-like behavior → count (pluralizes,
-      takes numerals, *much martini)
-
-    The only structural difference is the ConnectedLiquid + recipe
-    constraint. Both denote liquids. The measured part provides the
-    individuation unit that makes mixed drinks countable. -/
-theorem mass_count_asymmetry
-    (substancePred : α → Prop) (hCum : CUM substancePred)
-    {n : ℕ} (recipe : Recipe α n) (μ : α → ℚ) (phase : α → Phase)
-    {m₁ m₂ : α}
-    (_hm₁ : mixedDrinkDen recipe μ phase m₁)
-    (_hm₂ : mixedDrinkDen recipe μ phase m₂)
-    (hDisc : ¬ SelfConnected (m₁ ⊔ m₂)) :
-    CUM (substanceNounDen substancePred) ∧
-    ¬ mixedDrinkDen recipe μ phase (m₁ ⊔ m₂) :=
-  ⟨substanceNoun_cum substancePred hCum,
-   not_cum_of_disconnected recipe μ phase _hm₁ _hm₂ hDisc⟩
-
--- ════════════════════════════════════════════════════
--- § 10. Bridge to Borer 2005: Individuation Without Atomicity
--- ════════════════════════════════════════════════════
-
-/-! ### Why Div fails for mixed drinks
-
-[borer-2005]'s individuation operator `Div(P) = {x ∈ P | Atom(x)}`
-produces count readings by restricting a cumulative root to mereological
-atoms — entities with no proper parts. This works for standard count
-nouns: "a beer" is an atomic portion of beer-stuff, "a cat" is an
-atomic cat-individual.
-
-Mixed drink nouns break this pattern. A margarita is NOT a mereological
-atom: it has proper parts (the tequila, the triple sec, the lime juice).
-These ingredient parts are strictly below the whole in the parthood
-ordering, so `Atom x` fails. Borer's standard `Div` therefore excludes
-mixed drinks from the individuated extension.
-
-Moon's recipe semantics provides an **alternative individuation mechanism**
-that fills the same structural role (Borer's Q head) but operates through
-topological connectivity rather than mereological atomicity:
-
-| Mechanism | Q-head content | Source of ¬CUM |
-|-----------|---------------|----------------|
-| Borer Div | `P ∧ Atom` | Atoms have no proper parts → QUA |
-| Moon recipe | `MixedDrinkWitness` | ConnectedLiquid rejects disconnected sums |
-
-Both break cumulativity of the root predicate (the universal semantic
-role of Q), but through orthogonal properties of the parthood lattice:
-the algebraic (atomicity) versus the topological (connectivity).
--/
-
-open Borer2005 (Div div_qua)
-
-/-- Mixed drinks are not mereological atoms: they have proper parts
-    (their ingredient components).
-
-    A `MixedDrinkWitness` for a recipe with n + 2 ≥ 2 ingredients
-    assigns at least two disjoint parts (assign 0, assign 1) below x.
-    If x were an atom, both would equal x — but then they would
-    overlap, contradicting `disjoint`. -/
-theorem mixedDrink_not_atom {n : ℕ}
-    (recipe : Recipe α (n + 2))
-    (μ : α → ℚ) (phase : α → Phase)
-    {x : α} (hx : mixedDrinkDen recipe μ phase x) :
-    ¬ Atom x := by
+/-- A mixed drink has at least two disjoint non-null parts, so it is not an atom. -/
+theorem mixedDrink_not_atom {recipe : Recipe α K (n + 2)} {x : α}
+    (hx : mixedDrinkDen recipe μ phase x) : ¬ Atom x := by
   intro hAtom
   obtain ⟨w⟩ := hx
   have h0 : w.assign 0 = x := Atom.eq hAtom (w.part_le 0) (w.present 0)
   have h1 : w.assign 1 = x := Atom.eq hAtom (w.part_le 1) (w.present 1)
-  have hne : (0 : Fin (n + 2)) ≠ 1 := by simp
-  have hDisj := w.disjoint 0 1 hne
+  have hDisj := w.disjoint 0 1 Fin.zero_ne_one
   rw [h0, h1] at hDisj
   exact hDisj (Overlap.refl hAtom.not_isBot)
 
-/-- Borer's standard `Div` excludes mixed drinks from the individuated
-    extension. Since mixed drinks are not atoms (`mixedDrink_not_atom`),
-    no mixed drink entity satisfies `Div(DRINK)` for any predicate DRINK.
+/-- [borer-2005]'s individuation operator, which restricts to atoms, excludes mixed drinks:
+their unit of individuation is not atomicity but the measured part. -/
+theorem div_excludes_mixed_drinks {recipe : Recipe α K (n + 2)} (DRINK : α → Prop) {x : α}
+    (hx : mixedDrinkDen recipe μ phase x) : ¬ Borer2005.Div DRINK x :=
+  fun ⟨_, hAtom⟩ => mixedDrink_not_atom hx hAtom
 
-    This is not a bug in Borer's theory — it reveals that the Q head
-    for mixed drink nouns must be filled with a DIFFERENT individuation
-    mechanism than standard Div. Moon's recipe structure provides this. -/
-theorem div_excludes_mixed_drinks {n : ℕ}
-    (recipe : Recipe α (n + 2))
-    (μ : α → ℚ) (phase : α → Phase)
-    (DRINK : α → Prop)
-    {x : α} (hx : mixedDrinkDen recipe μ phase x) :
-    ¬ Div DRINK x := by
-  intro ⟨_, hAtom⟩
-  exact mixedDrink_not_atom recipe μ phase hx hAtom
-
-/-- Both Borer's Div and Moon's recipe semantics break cumulativity
-    of the root predicate — the universal semantic role of Borer's Q head.
-
-    - `Div(P)` is QUA (stronger: no proper part satisfies the predicate)
-    - `mixedDrinkDen` fails CUM (weaker: disconnected sums are rejected)
-
-    The asymmetry in strength reflects the different mechanisms:
-    atomicity is a STRONGER individuation than connectivity. Atoms have
-    no proper parts at all; connected liquids can have proper parts
-    (the ingredients) but cannot be merged across spatial gaps.
-
-    This means mixed drink nouns are "less quantized" than standard
-    count nouns — a prediction that aligns with Moon's observation
-    that quantity judgments for mixed drinks are genuinely ambiguous
-    across volume, portions, and measured parts (§4.3.2). Standard
-    count nouns like "cat" admit no such ambiguity. -/
-theorem both_break_cum
-    {n : ℕ} (recipe : Recipe α n) (μ : α → ℚ) (phase : α → Phase)
-    (P : α → Prop) :
-    -- Div produces QUA (stronger than ¬CUM)
-    QUA (Div P) ∧
-    -- Recipe semantics blocks CUM (given disconnected instances)
-    (∀ m₁ m₂ : α,
-      mixedDrinkDen recipe μ phase m₁ →
-      mixedDrinkDen recipe μ phase m₂ →
-      ¬ SelfConnected (m₁ ⊔ m₂) →
-      ¬ mixedDrinkDen recipe μ phase (m₁ ⊔ m₂)) :=
-  ⟨div_qua P,
-   fun _ _ h₁ h₂ hDisc => not_cum_of_disconnected recipe μ phase h₁ h₂ hDisc⟩
-
-/-- Mixed drinks are divisible: a proper part of a mixed drink can
-    itself be a mixed drink (half a margarita is still a margarita,
-    if the ratios and connectivity are preserved).
-
-    This means mixed drink predicates are NOT QUA — unlike Div-based
-    count nouns, which are QUA by `div_qua`. Mixed drinks occupy a
-    middle ground: ¬CUM (from ConnectedLiquid) but also ¬QUA (from
-    divisibility). This is the formal content of Moon's claim that
-    mixed drinks require a novel individuation mechanism beyond
-    standard mereological atomicity.
-
-    Compare Borer's `div_qua`: the root √BEER is CUM and Div(√BEER) is
-    QUA. For mixed drinks: the recipe denotation
-    is ¬CUM ∧ ¬QUA — neither mass nor count in Borer's strict sense,
-    but count in DISTRIBUTIONAL behavior (pluralizes, takes numerals). -/
-theorem mixedDrink_not_qua {n : ℕ}
-    (recipe : Recipe α (n + 2))
-    (μ : α → ℚ) (phase : α → Phase)
-    {x y : α}
-    (hx : mixedDrinkDen recipe μ phase x)
-    (hy : mixedDrinkDen recipe μ phase y)
-    (hlt : y < x) :
-    -- NOT a counterexample to QUA — this is satisfiable when a proper
-    -- part of a mixed drink is also a mixed drink (e.g., half a
-    -- margarita with preserved ratios and connectivity)
-    ¬ QUA (mixedDrinkDen recipe μ phase) :=
+/-- Half a margarita with its ratios and connectivity preserved is a margarita, so the
+denotation is not quantized. -/
+theorem mixedDrink_not_qua {x y : α} (hx : mixedDrinkDen recipe μ phase x)
+    (hy : mixedDrinkDen recipe μ phase y) (hlt : y < x) : ¬ QUA (mixedDrinkDen recipe μ phase) :=
   fun hQ => hQ hy hx hlt.ne hlt.le
 
--- ════════════════════════════════════════════════════
--- § 11. Instantiating the General Principle
--- ════════════════════════════════════════════════════
+/-- Mixed drinks occupy [filip-2012]'s middle ground, neither cumulative nor quantized,
+as an instance of `connectivity_middle_ground`. -/
+theorem mixedDrink_middle_ground {a b : α} (ha : mixedDrinkDen recipe μ phase a)
+    (hb : mixedDrinkDen recipe μ phase b) (hDisc : ¬ SelfConnected (a ⊔ b)) {x y : α}
+    (hx : mixedDrinkDen recipe μ phase x) (hy : mixedDrinkDen recipe μ phase y) (hlt : y < x) :
+    ¬ CUM (mixedDrinkDen recipe μ phase) ∧ ¬ QUA (mixedDrinkDen recipe μ phase) :=
+  connectivity_middle_ground (fun _ => selfConnected_of_mixedDrinkDen) ha hb hDisc hx hy hlt
 
-/-! ### Mixed drinks as an instance of topological non-cumulativity
-
-The general principle (`connectivity_middle_ground`, § 0)
-states that ANY predicate entailing self-connectivity occupies the
-¬CUM ∧ ¬QUA middle ground given appropriate witnesses. Mixed drink
-denotations are an instance: `ConnectedLiquid` entails `SelfConnected`,
-providing the connectivity constraint.
-
-This shows Moon's result is not ad hoc — it follows from a structural
-theorem about the interaction of semilattice join and topological
-connectivity. Any predicate that requires spatial contiguity of its
-instances will exhibit the same pattern: non-cumulativity from
-topology rather than atomicity.
--/
-
-/-- The connectivity constraint on mixed drink denotations: any mixed
-    drink is self-connected (extracted from `ConnectedLiquid` in the
-    witness). This is the hypothesis that feeds the general
-    `connectivity_breaks_cum` principle. -/
-theorem mixedDrinkDen_selfConnected {n : ℕ}
-    (recipe : Recipe α n) (μ : α → ℚ) (phase : α → Phase)
-    (x : α) (hx : mixedDrinkDen recipe μ phase x) :
-    SelfConnected x := by
-  obtain ⟨w⟩ := hx
-  exact w.connected.selfConnected
-
-/-- Mixed drinks are in the ¬CUM ∧ ¬QUA middle ground: an instance
-    of the general `connectivity_middle_ground` theorem.
-
-    The general principle requires:
-    1. A connectivity constraint (`mixedDrinkDen_selfConnected`)
-    2. Two instances with a disconnected join (CUM failure witnesses)
-    3. An instance with a proper part also satisfying P (QUA failure)
-
-    Moon's empirical contribution is establishing that mixed drinks
-    satisfy all three conditions. The formal contribution of
-    `connectivity_middle_ground` is showing this pattern is necessary
-    — not contingent on the specific recipe structure but a consequence
-    of ANY predicate that requires topological connectivity. -/
-theorem mixedDrink_middle_ground {n : ℕ}
-    (recipe : Recipe α (n + 2))
-    (μ : α → ℚ) (phase : α → Phase)
-    -- CUM failure: two mixed drinks with a disconnected join
-    {a b : α}
-    (ha : mixedDrinkDen recipe μ phase a)
-    (hb : mixedDrinkDen recipe μ phase b)
-    (hDisc : ¬ SelfConnected (a ⊔ b))
-    -- QUA failure: a mixed drink with a proper part also a mixed drink
-    {x y : α}
-    (hx : mixedDrinkDen recipe μ phase x)
-    (hy : mixedDrinkDen recipe μ phase y)
-    (hlt : y < x) :
-    ¬ CUM (mixedDrinkDen recipe μ phase) ∧
-    ¬ QUA (mixedDrinkDen recipe μ phase) :=
-  connectivity_middle_ground
-    (mixedDrinkDen_selfConnected recipe μ phase)
-    ha hb hDisc hx hy hlt
-
--- ════════════════════════════════════════════════════
--- § 12. Bridge to Filip 2012's VP-level Gap (Typeclass)
--- ════════════════════════════════════════════════════
-
-/-! ### From NP-level gap to VP-level gap
-
-Sections 4 and 10–11 establish that mixed-drink predicates occupy the
-NP-level ¬CUM ∧ ¬QUA middle ground that [filip-2012] identifies.
-[krifka-1998]'s CUM/QUA propagation machinery (§3.3, formalised in
-`Studies/Filip2012.lean`'s `middle_ground_stable`) shows the gap
-propagates to VPs under SINC + UP + CumTheta verbs.
-
-The bridge below directly invokes Filip2012's typeclass-form
-`middle_ground_stable` on mixed-drink denotations. The ¬CUM and ¬QUA
-witnesses on `OBJ` are exactly what `not_cum_of_disconnected` and
-`mixedDrink_not_qua` produce in this file — Moon's empirical
-contribution feeds Filip's algebraic machinery in a single Lean term. -/
-
-open Semantics.Aspect.Incremental (IsSincVerb)
-open Semantics.Aspect.Cumulativity (VP)
-open Filip2012 (middle_ground_stable)
-
-section MoonFilipBridge
-
-variable {β : Type*} [SemilatticeSup β]
-
-/-- Mixed-drink denotations (Moon 2026) instantiate the ¬CUM ∧ ¬QUA
-    middle ground that [filip-2012] identifies. When a SINC
-    drinking verb (typeclass `IsSincVerb`) takes a mixed-drink object,
-    the resulting drinking-mixed-drink VP inherits the gap.
-
-    The `α`-side witnesses (`ha, hb, hSum, hx, hy, hlt`) are produced by
-    `not_cum_of_disconnected` and `mixedDrink_not_qua` together with
-    Moon's recipe semantics. The `β`-side hypotheses (`hθ_a, hθ_b,
-    hθ_x`) are existential closures of the verb's incremental theme
-    over concrete drinking events.
-
-    Direct invocation of substrate's typeclass-form
-    `middle_ground_stable`. -/
-theorem mixedDrink_VP_propagation_gap
-    {n : ℕ} (recipe : Recipe α n) (μ : α → ℚ) (phase : α → Phase)
-    (drinkTheme : α → β → Prop) [IsSincVerb drinkTheme]
-    -- ¬CUM witnesses on OBJ (from `not_cum_of_disconnected`)
-    {a b : α} {e_a e_b : β}
-    (ha : mixedDrinkDen recipe μ phase a)
-    (hb : mixedDrinkDen recipe μ phase b)
-    (hθ_a : drinkTheme a e_a) (hθ_b : drinkTheme b e_b)
-    (hSum : ¬ mixedDrinkDen recipe μ phase (a ⊔ b))
-    -- ¬QUA witnesses on OBJ (from `mixedDrink_not_qua`)
-    {x y : α} {e_x : β}
-    (hx : mixedDrinkDen recipe μ phase x)
-    (hy : mixedDrinkDen recipe μ phase y) (hlt : y < x)
+/-- The middle ground propagates to VPs: a strictly incremental drinking verb with a
+mixed-drink object is neither cumulative nor quantized (`Filip2012.middle_ground_stable`). -/
+theorem mixedDrink_VP_propagation_gap {β : Type*} [SemilatticeSup β] (drinkTheme : α → β → Prop)
+    [IsSincVerb drinkTheme] {a b : α} {e_a e_b : β} (ha : mixedDrinkDen recipe μ phase a)
+    (hb : mixedDrinkDen recipe μ phase b) (hθ_a : drinkTheme a e_a) (hθ_b : drinkTheme b e_b)
+    (hSum : ¬ mixedDrinkDen recipe μ phase (a ⊔ b)) {x y : α} {e_x : β}
+    (hx : mixedDrinkDen recipe μ phase x) (hy : mixedDrinkDen recipe μ phase y) (hlt : y < x)
     (hθ_x : drinkTheme x e_x) :
     ¬ CUM (VP drinkTheme (mixedDrinkDen recipe μ phase)) ∧
-    ¬ QUA (VP drinkTheme (mixedDrinkDen recipe μ phase)) :=
-  middle_ground_stable ha hb hθ_a hθ_b hSum hx hy hlt hθ_x
+      ¬ QUA (VP drinkTheme (mixedDrinkDen recipe μ phase)) :=
+  Filip2012.middle_ground_stable ha hb hθ_a hθ_b hSum hx hy hlt hθ_x
 
-end MoonFilipBridge
+/-! ### Modifying the ratios -/
+
+variable [IsStrictOrderedRing K]
+
+/-- Rescaling one ingredient's ratio constant: *dry martini* (Moon's (27b)) lowers the
+vermouth relative to the gin. -/
+def modifyRatio (recipe : Recipe α K n) (target : Fin n) (factor : K) (hPos : 0 < factor) :
+    Recipe α K n where
+  ingredients := recipe.ingredients
+  ratios i := if i = target then factor * recipe.ratios i else recipe.ratios i
+  ratios_pos i := by
+    split_ifs
+    exacts [mul_pos hPos (recipe.ratios_pos i), recipe.ratios_pos i]
+  measuredPart := recipe.measuredPart
+
+/-- The multiplier *double* targets the measured part ([wagiel-2021]): a double americano
+has twice the espresso, not twice the volume. -/
+def doubleRecipe (recipe : Recipe α K n) : Recipe α K n :=
+  modifyRatio recipe recipe.measuredPart 2 two_pos
+
+/-- A margarita: tequila, triple sec and lime juice in ratio `5 : 2 : 3/2`, with the tequila
+as measured part. -/
+def margaritaRecipe (α K : Type*) [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+    (tequila tripleSec limeJuice : α → Prop) : Recipe α K 3 where
+  ingredients := ![tequila, tripleSec, limeJuice]
+  ratios := ![5, 2, 3 / 2]
+  ratios_pos i := by fin_cases i <;> norm_num
+  measuredPart := 0
 
 end Moon2026

--- a/references.bib
+++ b/references.bib
@@ -28072,9 +28072,12 @@
   year      = {2026},
   title     = {Countability and measured parts in mixed drink nouns},
   journal   = {Glossa: a journal of general linguistics},
+  volume    = {11},
+  number    = {1},
+  doi       = {10.16995/glossa.23419},
   subfield  = {semantics/lexical},
   role      = {formalized},
-  validated = {false},
+  validated = {true},
   sources   = {Fragments/English/Nouns.lean;Studies/Moon2026.lean}
 }
 @book{casati-varzi-1999,


### PR DESCRIPTION
Deep cleanse of `Studies/Moon2026.lean`: measures and ratio constants over an ordered field instead of ℚ, `doubleRecipe` derived from `modifyRatio`, unused hypotheses and the decorative conjunction theorems dropped, and the `Float`/`String` COCA table, the unproved `distributionalAsymmetry : Prop` and the `decide`-arithmetic americano scenario replaced by prose. Locators and claims checked against the paper; bib entry gains volume/DOI.