### PR TITLE
refactor(Syntax/Negation): NegMarkerEntry to Marker; dissolve English CompEntry

### DIFF
--- a/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
@@ -37,7 +37,7 @@ open Syntax.Negation
     *lan* (future), *maa* (past, colloquial-leaning), *lays-a* (copular). The
     four particles precede the verb; *lays-a* is itself a verb inflecting for
     person / number / gender. -/
-def negMarkers : List NegMarkerEntry :=
+def negMarkers : List Marker :=
   [ { morphs := [.free "laa"]
     , gloss := "NEG.IPFV" }
   , { morphs := [.free "lam"]

--- a/Linglib/Fragments/Burmese/Negation.lean
+++ b/Linglib/Fragments/Burmese/Negation.lean
@@ -43,7 +43,7 @@ def negSuffix : String := "-bu"
     affirmative TAM markers (realis *-deh*, irrealis *-meh*, future
     *-laimeh*), neutralizing TAM distinctions. WALS classifies Burmese
     as `.doubleNegation` (Ch 112A). -/
-def circumfix : NegMarkerEntry :=
+def circumfix : Marker :=
   { morphs := [.pref "ma", .suff "bu"] }
 
 /-- The Burmese negation system: a single bipartite circumfix. -/

--- a/Linglib/Fragments/English/Complementizers.lean
+++ b/Linglib/Fragments/English/Complementizers.lean
@@ -5,10 +5,9 @@ open Morphology (Word)
 /-!
 # English Complementizers Lexicon Fragment
 
-Lexical entries for the English complementizers *that*, *if*, *whether*,
-as root `Complementizer` entries extended with the English-specific
-flags (`conditional`, `optional`). *if* is split between conditional and
-embedded-question uses; the single entry carries both.
+The English complementizers *that*, *if*, *whether* as `Complementizer`
+entries; *if* doubles as the conditional subordinator and *that* drops
+under most verbs.
 
 The adverbial subordinators *because*, *although*, *while* are not
 complementizers (adverbial subordination is outside complementation,
@@ -19,35 +18,26 @@ distinct preposition *to* and the infinitival particle *to* live in
 
 namespace English.Complementizers
 
+/-- *that* — declarative complementizer; omissible under most verbs
+(that-drop). -/
+def that : Complementizer where
+  morphs := [.free "that"]
+  coding := some .indicative
+  force := some .declarative
 
-/-- An English complementizer entry: the root schema plus the
-English-specific flags. -/
-structure CompEntry extends Complementizer where
-  /-- Introduces a conditional protasis (*if*)? -/
-  conditional : Bool := false
-  /-- Can be omitted (that-drop)? -/
-  optional : Bool := false
-  deriving Repr, BEq, DecidableEq
-
-/-- *that* — declarative complementizer, omissible (that-drop). -/
-def that : CompEntry :=
-  { morphs := [.free "that"],
-    coding := some .indicative, force := some .declarative,
-    optional := true }
-
-/-- *if* — conditional protasis marker and embedded polar-question
-complementizer. -/
-def if_ : CompEntry :=
-  { morphs := [.free "if"],
-    force := some .interrogative, conditional := true }
+/-- *if* — embedded polar-question complementizer; the same word
+introduces conditional protases. -/
+def if_ : Complementizer where
+  morphs := [.free "if"]
+  force := some .interrogative
 
 /-- *whether* — embedded polar-question complementizer. -/
-def whether : CompEntry :=
-  { morphs := [.free "whether"],
-    force := some .interrogative }
+def whether : Complementizer where
+  morphs := [.free "whether"]
+  force := some .interrogative
 
 /-- The complementizer inventory (adverbial subordinators excluded). -/
-def allComplementizers : List CompEntry := [that, if_, whether]
+def complementizers : List Complementizer := [that, if_, whether]
 
 /-! ### Adverbial subordinators
 

--- a/Linglib/Fragments/English/Negation.lean
+++ b/Linglib/Fragments/English/Negation.lean
@@ -31,7 +31,7 @@ open Syntax.Negation
     (*isn't*, *don't*, *won't*); see `negContracted` for the citation form
     of that allomorph. With lexical verbs, *do*-support is required:
     *He does not eat*, not **He not eats*. -/
-def not : NegMarkerEntry :=
+def not : Marker :=
   { morphs := [.free "not"] }
 
 /-- The contracted form *n't*. Phonologically a clitic on the auxiliary;

--- a/Linglib/Fragments/Finnish/Negation.lean
+++ b/Linglib/Fragments/Finnish/Negation.lean
@@ -44,14 +44,14 @@ open Syntax.Negation
     appears in the connegative form (tense-stripped: *e-n osta* 'I don't
     buy' loses the tense marking *osta-n* 'I buy' carries). The 6 surface
     forms (en/et/ei/emme/ette/eivät) are accessible via `negParadigm`. -/
-def ei : NegMarkerEntry :=
+def ei : Marker :=
   { morphs := [.free "ei"] }
 
 /-- The Finnish negation system: a single negative auxiliary with a
     person/number paradigm. Multiple paradigm-form *surface* realizations
     (`negParadigm`) are not multiple *markers* — they're inflectional
     variants of one auxiliary, captured cross-linguistically by the single
-    `NegMarkerEntry`. -/
+    `Marker`. -/
 def negationSystem : NegationSystem :=
   NegationSystem.ofISO "fin" [ei]
 

--- a/Linglib/Fragments/German/Negation.lean
+++ b/Linglib/Fragments/German/Negation.lean
@@ -35,7 +35,7 @@ open Syntax.Negation
     gelesen*). The V2/SOV alternation is why WALS Ch 143A classifies
     German as `.type1Type2` (mixed NegV / VNeg) rather than a single
     position. -/
-def nicht : NegMarkerEntry :=
+def nicht : Marker :=
   { morphs := [.free "nicht"] }
 
 /-- *kein* — negative determiner (fuses negation + indefinite article).

--- a/Linglib/Fragments/Greek/StandardModern/Negation.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Negation.lean
@@ -35,7 +35,7 @@ abbrev World := Fin 4
 /-- A Greek sentential negation marker, augmented with the mood/NCI
     properties from [tsiakmakis-2025]'s NEG₁/NEG₂ analysis.
 
-    Distinct from the cross-linguistic `Syntax.Negation.NegMarkerEntry`
+    Distinct from the cross-linguistic `Syntax.Negation.Marker`
     substrate (which carries only the exponent and gloss): this
     structure exposes the Tsiakmakis-specific paper apparatus that other
     languages don't have analogues for. The Core entries `dhenMarker` and
@@ -79,11 +79,11 @@ def min : MoodMarkerEntry :=
 /-- *dhen* in Core substrate form. Cross-linguistic typology face of the
     indicative negator; the paper-specific mood/NCI apparatus lives on
     `MoodMarkerEntry` above. -/
-def dhenMarker : Syntax.Negation.NegMarkerEntry :=
+def dhenMarker : Syntax.Negation.Marker :=
   { morphs := [.free "dhen"] }
 
 /-- *min* in Core substrate form. -/
-def minMarker : Syntax.Negation.NegMarkerEntry :=
+def minMarker : Syntax.Negation.Marker :=
   { morphs := [.free "min"] }
 
 /-- The Greek negation system: two mood-conditioned preverbal particles.

--- a/Linglib/Fragments/Hixkaryana/Negation.lean
+++ b/Linglib/Fragments/Hixkaryana/Negation.lean
@@ -27,7 +27,7 @@ open Syntax.Negation
 /-- *-hira* — Hixkaryana's standard negation suffix.
     Deverbalizes the lexical verb (A/Fin asymmetry); a copula then takes
     over as the finite element. -/
-def hira : NegMarkerEntry :=
+def hira : Marker :=
   { morphs := [.suff "hira"] }
 
 /-- The Hixkaryana negation system: a single deverbalizing suffix. -/

--- a/Linglib/Fragments/Italian/Negation.lean
+++ b/Linglib/Fragments/Italian/Negation.lean
@@ -42,7 +42,7 @@ open Syntax.Negation
 /-- *non* — Italian's standard preverbal negation particle.
     `Non ho visto nessuno` 'NEG have seen nobody' = "I didn't see anyone".
     A free word, not a clitic; syntactically immediately preverbal. -/
-def non : NegMarkerEntry :=
+def non : Marker :=
   { morphs := [.free "non"] }
 
 /-- The Italian negation system: a single preverbal particle.

--- a/Linglib/Fragments/Januubi/Negation.lean
+++ b/Linglib/Fragments/Januubi/Negation.lean
@@ -51,7 +51,7 @@ open Syntax.Negation
     Same form used as the EN marker across all attested EN-trigger
     classes (see § 2 below); Januubi shows no negator-trigger covariation
     unlike French and Mandarin. -/
-def maa : NegMarkerEntry :=
+def maa : Marker :=
   { morphs := [.free "maa"] }
 
 /-- The standard sentential negation marker in Januubi Arabic. -/

--- a/Linglib/Fragments/Japanese/Negation.lean
+++ b/Linglib/Fragments/Japanese/Negation.lean
@@ -44,7 +44,7 @@ open Syntax.Negation
     *tabe-naku-te* (GER). The shift of TAM marking from the stem to the
     *-nai* suffix is the A/Fin+A/Cat asymmetry captured by
     `japaneseNegDistribution` below. -/
-def negSuffix : NegMarkerEntry :=
+def negSuffix : Marker :=
   { morphs := [.suff "nai"] }
 
 /-- The Japanese negation system: a single verbal affix with rich

--- a/Linglib/Fragments/Mandarin/Negation.lean
+++ b/Linglib/Fragments/Mandarin/Negation.lean
@@ -40,14 +40,14 @@ open Syntax.Negation
     Used with imperfective, stative, modal, and future contexts;
     excluded from perfective and existential. Symmetric: simply adds
     to the verb without further structural change. -/
-def bu : NegMarkerEntry :=
+def bu : Marker :=
   { morphs := [.free "bù"] }
 
 /-- 没 *méi* (long form 没有 *méi-yǒu*) — the perfective/existential
     negation particle. Asymmetric: incompatible with the perfective
     aspect marker 了 *le*; required as the negator of 有 *yǒu* 'have'.
     The choice between *bù* and *méi* is aspect-conditioned. -/
-def mei : NegMarkerEntry :=
+def mei : Marker :=
   { morphs := [.free "méi"] }
 
 /-- The Mandarin negation system: two aspect-conditioned markers.

--- a/Linglib/Fragments/Maori/Negation.lean
+++ b/Linglib/Fragments/Maori/Negation.lean
@@ -34,7 +34,7 @@ open Syntax.Negation
     WALS Ch 112A classifies this as `.wordUnclear` — in Maori's isolating
     morphology, *kāhore* could be analyzed as a verb or a particle.
     Functions as a quasi-auxiliary that takes the TAM-particle position. -/
-def kahore : NegMarkerEntry :=
+def kahore : Marker :=
   { morphs := [.free "kāhore"] }
 
 /-- The Maori negation system: a single quasi-auxiliary word. -/

--- a/Linglib/Fragments/Quechua/Negation.lean
+++ b/Linglib/Fragments/Quechua/Negation.lean
@@ -35,7 +35,7 @@ open Syntax.Negation
     enclitic is a separate validator (also used in polar interrogatives)
     whose obligatory appearance under negation drives the WALS A/NonReal
     asymmetry classification. -/
-def mana : NegMarkerEntry :=
+def mana : Marker :=
   { morphs := [.free "mana"] }
 
 /-- The validator enclitic *-chu*, triggered in negative and interrogative

--- a/Linglib/Fragments/Romance/French/Negation.lean
+++ b/Linglib/Fragments/Romance/French/Negation.lean
@@ -46,13 +46,13 @@ def pasReinforcer : String := "pas"
 /-- *(ne) pas* — French's bipartite standard negation.
     The two morphemes flank the finite verb: *Je **ne** mange **pas***
     (formal), *Je mange **pas*** (colloquial, *ne*-drop). Encoded as a
-    single `NegMarkerEntry` with discontinuous position because *ne* and
+    single `Marker` with discontinuous position because *ne* and
     *pas* together constitute one logical negation construction (one
     WALS Ch 112A value, one Ch 143A value). The constituent forms
     `neClitic` and `pasReinforcer` are exposed separately for downstream
     consumers that need them (JinKoenig2021 uses *ne* alone as the EN
     marker; Miestamo2005 lists both as `negMarkers`). -/
-def bipartite : NegMarkerEntry :=
+def bipartite : Marker :=
   { morphs := [.procl "ne", .free "pas"] }
 
 /-- The French negation system: a single bipartite construction.

--- a/Linglib/Fragments/Slavic/Czech/Negation.lean
+++ b/Linglib/Fragments/Slavic/Czech/Negation.lean
@@ -30,7 +30,7 @@ open Syntax.Negation
 /-- *ne-* — Czech's standard negation prefix.
     Attaches directly to the verb stem: *nepřijde* 'will not come',
     *neviděl* 'didn't see'. Symmetric across the paradigm. -/
-def ne : NegMarkerEntry :=
+def ne : Marker :=
   { morphs := [.pref "ne"] }
 
 /-- The Czech negation system: a single verbal prefix. -/

--- a/Linglib/Fragments/Slavic/Russian/Negation.lean
+++ b/Linglib/Fragments/Slavic/Russian/Negation.lean
@@ -29,7 +29,7 @@ open Syntax.Negation
 
 /-- *не* — Russian's standard preverbal negation particle.
     A free word, syntactically immediately preverbal. -/
-def ne : NegMarkerEntry :=
+def ne : Marker :=
   { morphs := [.free "не"] }
 
 /-- The Russian negation system: a single preverbal particle. -/

--- a/Linglib/Fragments/Spanish/Negation.lean
+++ b/Linglib/Fragments/Spanish/Negation.lean
@@ -41,7 +41,7 @@ open Syntax.Negation
 /-- *no* — Spanish's standard preverbal negation particle.
     A free word, syntactically immediately preverbal:
     *Juan **no** come* 'Juan doesn't eat'. -/
-def no : NegMarkerEntry :=
+def no : Marker :=
   { morphs := [.free "no"] }
 
 /-- The Spanish negation system: a single preverbal particle. -/

--- a/Linglib/Fragments/Tigrinya/Negation.lean
+++ b/Linglib/Fragments/Tigrinya/Negation.lean
@@ -33,7 +33,7 @@ def ej : Morph := .pref "ɛj"
 def n : Morph := .suff "n"
 
 /-- *ʔaj-…-(ɨ)n* — the standard-negation circumfix. -/
-def circumfix : NegMarkerEntry where
+def circumfix : Marker where
   morphs := [aj, n]
 
 /-- Tigrinya standard negation: the single bipartite marker. -/

--- a/Linglib/Fragments/Turkish/Negation.lean
+++ b/Linglib/Fragments/Turkish/Negation.lean
@@ -39,7 +39,7 @@ open Syntax.Negation
     *gel-iyor* → *gel-m-iyor* (come-NEG-PROG). The form here is the
     abstract citation form; the harmony-conditioned alternants are
     captured by the language's morphology layer, not the marker entry. -/
-def negSuffix : NegMarkerEntry :=
+def negSuffix : Marker :=
   { morphs := [.suff "mA"] }
 
 /-- Turkish standard (verbal) negation: a single verbal affix.

--- a/Linglib/Fragments/ZarmaSonrai/Negation.lean
+++ b/Linglib/Fragments/ZarmaSonrai/Negation.lean
@@ -46,16 +46,16 @@ open Syntax.Negation
 
 /-- *si* — imperfective negation marker. Aspect-conditioned alternation
     with perfective *mana*/*batu*. Parallel to Mandarin's bù/méi split. -/
-def si : NegMarkerEntry :=
+def si : Marker :=
   { morphs := [.free "si"] }
 
 /-- *mana* — perfective negation marker (one of two variants). -/
-def mana : NegMarkerEntry :=
+def mana : Marker :=
   { morphs := [.free "mana"] }
 
 /-- *batu* — perfective negation marker (second variant; also surfaces
     as a verb 'wait/delay'). -/
-def batu : NegMarkerEntry :=
+def batu : Marker :=
   { morphs := [.free "batu"] }
 
 /-- The Zarma-Sonrai negation system: three aspect-conditioned markers.

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -19,7 +19,7 @@ asymmetric status, asymmetry subtype, and negative-indefinite strategy.
 
 Mirrors the `Linglib/Features/Possession.lean` (Possession), `Question.lean`
 (Question), and `Case.lean` (Case) substrate-extension pattern: the
-substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
+substrate carries (a) the marker schema (`Marker`,
 `NegationSystem`), (b) WALS converters and per-ISO accessors.
 
 ## What lives here
@@ -32,7 +32,7 @@ substrate carries (a) per-paradigm-entry schema (`NegMarkerEntry`,
   *constructions*, not morphemes. The substrate carries Dryer's classification
   for cross-linguistic indexing; Miestamo's framework lives in
   `Studies/Miestamo2005.lean`.
-- `NegMarkerEntry` — one language's standard sentential negation marker.
+- `Marker` — a standard sentential negation marker.
 - `NegationSystem` — bundles markers + WALS Ch 112A/143A/144A datapoints.
   The Fragment-side joint: every `Fragments/{Lang}/Negation.lean` exposes
   `def negationSystem : NegationSystem`.
@@ -175,10 +175,10 @@ inductive NegMorphemePosition where
   | none
   deriving DecidableEq, BEq, Repr
 
-/-! ### NegMarkerEntry / NegationSystem (Fragment marker-side joint) -/
+/-! ### Markers and negation systems -/
 
-/-- One language's standard sentential negation marker. -/
-structure NegMarkerEntry where
+/-- A standard sentential negation marker. -/
+structure Marker where
   /-- The exponent, in surface order; a bipartite marker lists both
       pieces (Burmese *ma-…-bu*). Affixal alternants are recorded by an
       abstract citation form (Turkish *-mA-* for *-ma-* ~ *-me-*). -/
@@ -189,7 +189,7 @@ structure NegMarkerEntry where
 
 /-- The surface form of a marker: its morphs with boundary notation,
 discontinuous pieces separated by `…`. -/
-def NegMarkerEntry.form (m : NegMarkerEntry) : String := toString m.morphs
+def Marker.form (m : Marker) : String := toString m.morphs
 
 /-- A language's standard negation system.
 
@@ -207,7 +207,7 @@ structure NegationSystem where
   iso : String := ""
   /-- Standard negation marker(s). Order is editorial; Fragment files
       should put the unmarked / default-context marker first. -/
-  markers : List NegMarkerEntry
+  markers : List Marker
   /-- WALS Ch 112A: morpheme classification. Should not be hand-encoded
       in Fragment files — use `NegationSystem.ofISO` to populate from the
       `Data.WALS` data, which is the single source of truth. -/
@@ -302,7 +302,7 @@ def fromWALS143A : Data.WALS.F143A.NegVerbOrder → NegVerbPosition
 
 /-- Build a `NegationSystem` for a language identified by ISO 639-3 code,
     pulling F112A / F143A / F144A values from the `Data.WALS` data. -/
-def NegationSystem.ofISO (iso : String) (markers : List NegMarkerEntry) :
+def NegationSystem.ofISO (iso : String) (markers : List Marker) :
     NegationSystem :=
   { iso
   , markers


### PR DESCRIPTION
`Entry` is formaliser packaging, not the field's word for the object: `Syntax.Negation.NegMarkerEntry` → `Syntax.Negation.Marker` (the namespace already says which markers), matching `RelativeClause.Marker`.

- 20 `Fragments/*/Negation.lean` files follow the rename; `Greek.MoodMarkerEntry` and the per-language `NegParadigmEntry` records are untouched for now.
- `English.Complementizers.CompEntry` dissolved: its `conditional`/`optional` flags had no reader, so the three entries are plain `Complementizer`s and `allComplementizers` becomes `complementizers`, matching every other complementizer fragment.