### PR TITLE
refactor(Syntax/Negation): drop WALS relabels and dead enums; cut data checks

### DIFF
--- a/Linglib/Features/NegativeConcord.lean
+++ b/Linglib/Features/NegativeConcord.lean
@@ -6,11 +6,10 @@ Lightweight, Fragment-importable types for negative concord: the item-level n-wo
 status, the NC subtype, and the clausal-position parameter the strict/non-strict
 contrast turns on.
 
-Kept separate from `Typology/Negation.lean` (the WALS-based negation survey) so that
-`Typology/PolarityItem.lean` and Fragment lexicons can import the n-word classification
-without pulling in the WALS datapoint files. `Negation.lean` imports *this* file to
-bridge the item-level status to its language-level WALS 115A `NegIndefiniteStrategy`
-(`NegIndefiniteStrategy.hasNegativeConcord` / `.admits`).
+Kept separate from `Syntax/Negation.lean` (the WALS-based negation survey) so that
+`Semantics/Polarity/Item.lean` and Fragment lexicons can import the n-word classification
+without pulling in the WALS datapoint files. `Studies/VanDerAuweraVanAlsenoy2016.lean`
+bridges the item-level status to a language's WALS Ch 115A value.
 
 ## Main declarations
 

--- a/Linglib/Fragments/Italian/Negation.lean
+++ b/Linglib/Fragments/Italian/Negation.lean
@@ -67,30 +67,30 @@ DOUBT (*dubitare*) but, unlike French, no FEAR class.
 
 /-- EN trigger-negator pairings from [jin-koenig-2021] Table 3
     (Italic section). -/
-def enTriggerNegators : List ENTriggerNegator :=
+def enTriggerNegators : List ExpletiveTrigger :=
   [ { triggerClass := "BEFORE", triggerForm := "prima che"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "DOUBT", triggerForm := "dubitare"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "HARDLY", triggerForm := "appena"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "NEARLY", triggerForm := "per poco"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "THAN", triggerForm := "di quanto"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "UNLESS", triggerForm := "a meno che"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
   , { triggerClass := "UNTIL", triggerForm := "finché, fino a"
-    , enNegatorForm := "non" }
+    , negatorForm := "non" }
     -- J&K Table 3 prints the WITHOUT trigger as "senza que" (a typo
     -- carried from their source, per their fn. 5); *senza che* is the
     -- Italian form.
   , { triggerClass := "WITHOUT", triggerForm := "senza che"
-    , enNegatorForm := "non" } ]
+    , negatorForm := "non" } ]
 
 /-- Every Italian EN environment uses the standard negator: the EN
     negator form coincides with the `non` marker entry. -/
 theorem en_negator_is_standard :
-    enTriggerNegators.all (·.enNegatorForm == non.form) = true := by decide
+    enTriggerNegators.all (·.negatorForm == non.form) = true := by decide
 
 end Italian.Negation

--- a/Linglib/Fragments/Mandarin/Negation.lean
+++ b/Linglib/Fragments/Mandarin/Negation.lean
@@ -181,21 +181,21 @@ def bugaiParticle : String := "bùgāi"
 
 /-- EN trigger-negator pairings (pinyin forms) from [jin-koenig-2021],
     Table 5 and §6.1–6.4. -/
-def enTriggerNegators : List ENTriggerNegator :=
+def enTriggerNegators : List ExpletiveTrigger :=
   [ { triggerClass := "FEAR", triggerForm := "pà"
-    , enNegatorForm := "bié", enNegatorGloss := some "don't (imperative)" }
+    , negatorForm := "bié", negatorGloss := some "don't (imperative)" }
   , { triggerClass := "AVOID", triggerForm := "bìmiǎn"
-    , enNegatorForm := "bù/méi(yǒu)", enNegatorGloss := some "NEG (general/perfective)" }
+    , negatorForm := "bù/méi(yǒu)", negatorGloss := some "NEG (general/perfective)" }
   , { triggerClass := "REGRET", triggerForm := "hòuhuǐ"
-    , enNegatorForm := "bùgāi", enNegatorGloss := some "shouldn't (deontic)" }
+    , negatorForm := "bùgāi", negatorGloss := some "shouldn't (deontic)" }
   , { triggerClass := "COMPLAIN", triggerForm := "bàoyuan"
-    , enNegatorForm := "bùgāi", enNegatorGloss := some "shouldn't (deontic)" }
+    , negatorForm := "bùgāi", negatorGloss := some "shouldn't (deontic)" }
   , { triggerClass := "DENY", triggerForm := "fǒurèn"
-    , enNegatorForm := "bù", enNegatorGloss := some "NEG (general)" }
+    , negatorForm := "bù", negatorGloss := some "NEG (general)" }
   , { triggerClass := "BEFORE", triggerForm := "yǐqián"
-    , enNegatorForm := "bù", enNegatorGloss := some "NEG (general)" }
+    , negatorForm := "bù", negatorGloss := some "NEG (general)" }
   , { triggerClass := "ALMOST", triggerForm := "chàdiǎnr"
-    , enNegatorForm := "méi", enNegatorGloss := some "NEG (perfective)" } ]
+    , negatorForm := "méi", negatorGloss := some "NEG (perfective)" } ]
 
 /-- FEAR triggers use imperative negators, not the standard
     *bù* or *méi*. This connects to the desiderative semantics:
@@ -203,7 +203,7 @@ def enTriggerNegators : List ENTriggerNegator :=
     prohibition ([jin-koenig-2021], §6.1.1, ex. 14). -/
 theorem fear_uses_imperative_neg :
     (enTriggerNegators.filter (·.triggerClass == "FEAR")).all
-      (·.enNegatorForm == "bié") = true := by decide
+      (·.negatorForm == "bié") = true := by decide
 
 /-- REGRET/COMPLAIN triggers use the deontic negator *bùgāi* 'shouldn't'.
     This connects to the behavioral-standards semantics: ¬p is consistent
@@ -212,6 +212,6 @@ theorem fear_uses_imperative_neg :
 theorem regret_uses_deontic_neg :
     (enTriggerNegators.filter (fun e =>
       e.triggerClass == "REGRET" || e.triggerClass == "COMPLAIN")).all
-      (·.enNegatorForm == "bùgāi") = true := by decide
+      (·.negatorForm == "bùgāi") = true := by decide
 
 end Mandarin.Negation

--- a/Linglib/Fragments/Romance/French/Negation.lean
+++ b/Linglib/Fragments/Romance/French/Negation.lean
@@ -146,29 +146,29 @@ def enMarker : String := neClitic
 
 /-- EN trigger-negator pairings from [jin-koenig-2021], Table 5
     and §6.1–6.4. -/
-def enTriggerNegators : List ENTriggerNegator :=
+def enTriggerNegators : List ExpletiveTrigger :=
   [ { triggerClass := "FEAR", triggerForm := "avoir peur"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "AVOID", triggerForm := "éviter"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "BEFORE", triggerForm := "avant que"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "UNLESS", triggerForm := "à moins que"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "DENY", triggerForm := "nier"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "COMPARATIVES", triggerForm := "que (than)"
-    , enNegatorForm := "ne", highEntrenchment := some true }
+    , negatorForm := "ne", highEntrenchment := some true }
   , { triggerClass := "REGRET", triggerForm := "regretter"
-    , enNegatorForm := "ne (pas)", highEntrenchment := some false }
+    , negatorForm := "ne (pas)", highEntrenchment := some false }
   , { triggerClass := "FORGET", triggerForm := "oublier"
-    , enNegatorForm := "ne pas", highEntrenchment := some false } ]
+    , negatorForm := "ne pas", highEntrenchment := some false } ]
 
 /-- High-entrenchment EN uses the dedicated *ne* alone;
     low-entrenchment EN uses *ne...pas* (the standard negator). -/
 theorem high_entrenchment_uses_ne_alone :
     (enTriggerNegators.filter (·.highEntrenchment == some true)).all
-      (·.enNegatorForm == "ne") = true := by decide
+      (·.negatorForm == "ne") = true := by decide
 
 /-- French EN marker = preverbal *ne* = same clitic as in standard
     *ne...pas*, but without the reinforcer. -/

--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -67,8 +67,8 @@ and Heine 1993 (book p. 48ff. via Anderson p. 5):
   `.agreement` on AUX (matches the gloss `1-AUX 1-2PL-show`).
 - **Cline reattributed to [heine-1993]** (Anderson p. 5
   explicitly cites Heine 1993:48ff.).
-- **`negStrategyStage`** is now `NegStrategy.toGramStage :
-  NegStrategy → Option GramStage` (in `Syntax/Negation.lean`), with
+- **`negStrategyStage`** is now `Strategy.toGramStage :
+  Strategy → Option GramStage` (in `Syntax/Negation.lean`), with
   `.negParticle => none` (not on the verbal cline) — fixes the
   earlier formaliser-introduced collapse of [miestamo-2005]'s
   particle-vs-verb distinction.
@@ -99,7 +99,7 @@ namespace Anderson2006
 
 open AuxiliaryVerbs
 open ArgumentStructure.AuxiliarySelection
-open Syntax.Negation (NegStrategy)
+open Syntax.Negation (Strategy)
 
 /-! ## Inflectional distribution (study-local apparatus)
 
@@ -518,8 +518,8 @@ Kokota; lex-headed in Kwerba; doubled in 'Iipay. The example rows
 live in `Data/Examples/Anderson2006.json` (Komi (47a,b), Udihe (49),
 Kwerba (52a,b), all verified against the book); each row's
 `infl_pattern` feature records the book's classification where it
-states one. The NegStrategy → InflPattern mapping lives in
-`Typology/Negation.lean`: `NegStrategy.expectedInflPattern` encodes
+states one. The Strategy → InflPattern mapping lives in
+`Syntax/Negation.lean`: `Strategy.expectedInflPattern` encodes
 the most common verbal-negator → aux-headed mapping, and the Kwerba
 rows witness below that it is a tendency, not a law. -/
 
@@ -527,16 +527,16 @@ rows witness below that it is a tendency, not a law. -/
     and the strategy-level projection expects exactly that. -/
 theorem udihe_negVerb_expects_auxHeaded :
     Examples.udihe_neg.feature? "infl_pattern" = some "auxHeaded" ∧
-    NegStrategy.negVerb.expectedInflPattern = some .auxHeaded :=
+    Strategy.negVerb.expectedInflPattern = some .auxHeaded :=
   ⟨rfl, rfl⟩
 
 /-- Kwerba (52a,b) shows a negative auxiliary in a *lex-headed* AVC
     (the lexical verb hosts the inflection), so the aux-headed
-    expectation of `NegStrategy.expectedInflPattern` is defeasible —
+    expectation of `Strategy.expectedInflPattern` is defeasible —
     Anderson's own four-pattern list is the counterexample source. -/
 theorem kwerba_negVerb_lexHeaded_counterexample :
     Examples.kwerba_neg_fut.feature? "infl_pattern" = some "lexHeaded" ∧
-    NegStrategy.negVerb.expectedInflPattern ≠ some .lexHeaded :=
+    Strategy.negVerb.expectedInflPattern ≠ some .lexHeaded :=
   ⟨rfl, by decide⟩
 
 /-- The Komi tense alternation (47a,b) sits entirely on the negative
@@ -613,20 +613,20 @@ theorem sorace_canonical_chain (v : Features.VendlerClass) :
 /-! ## Cross-framework: Miestamo 2005 (negation morpheme classification)
 
 [miestamo-2005] classifies negation strategies by morpheme
-type (`NegMorphemeType`: `.auxVerb`, `.affix`, `.particle`, ...);
+type (WALS Ch 112A: negative auxiliary verb, affix, particle, ...);
 [anderson-2006] via [heine-1993]'s grammaticalization
 framework places verbal negators on the cline at `.auxiliary` and
 non-verbal negators off the cline (Anderson §1.7.2 covers only
 verbal negators). The two frameworks classify by independently-
 motivated criteria but, for the strategies linglib's
-`NegStrategy` enum exposes, AGREE on which strategies are
+`Strategy` enum exposes, AGREE on which strategies are
 "verbal": Anderson's `.toGramStage = some .auxiliary` is exactly
-Miestamo's `.toNegMorphemeType = .auxVerb`.
+Miestamo's `.morphemeType = .negativeAuxiliaryVerb`.
 
 Composition with [miestamo-2005]'s
 `afin_verbal_implies_constructional` (in
 `Linglib/Studies/Miestamo2005.lean`) then
-yields: any `NegStrategy` Anderson places at the auxiliary cline
+yields: any `Strategy` Anderson places at the auxiliary cline
 stage, in any Miestamo A/Fin datum, shows constructional
 asymmetry — a falsifiable empirical prediction whose chain
 runs Anderson's cline → Miestamo's morpheme type → Miestamo's
@@ -639,15 +639,15 @@ the quantified-equivalence shape below. -/
 
 /-- Cross-framework equivalence: Anderson's grammaticalization-cline
     placement at `.auxiliary` and Miestamo's morpheme-type
-    classification as `.auxVerb` partition the `NegStrategy` enum
+    classification as `.auxVerb` partition the `Strategy` enum
     *identically*. Both frameworks classify exactly `.negVerb`
     (Finnish *ei*-style inflecting negators) as the verbal subtype.
     Falsifiable by changing either projection: a future split of
-    `NegStrategy.negVerb` into Miestamo-style auxVerb-vs-doubleNeg
+    `Strategy.negVerb` into Miestamo-style auxVerb-vs-doubleNeg
     subtypes would break this without breaking either projection
     individually. -/
-theorem auxiliary_stage_iff_aux_verb_morpheme (s : NegStrategy) :
-    s.toGramStage = some .auxiliary ↔ s.toNegMorphemeType = .auxVerb := by
+theorem auxiliary_stage_iff_aux_verb_morpheme (s : Strategy) :
+    s.toGramStage = some .auxiliary ↔ s.morphemeType = .negativeAuxiliaryVerb := by
   cases s <;> decide
 
 end Anderson2006

--- a/Linglib/Studies/Miestamo2005.lean
+++ b/Linglib/Studies/Miestamo2005.lean
@@ -1,4 +1,7 @@
 import Linglib.Syntax.Negation
+import Linglib.Data.WALS.Features.F112A
+import Linglib.Data.WALS.Features.F113A
+import Linglib.Data.WALS.Features.F114A
 import Linglib.Fragments.Finnish.Negation
 import Linglib.Fragments.Italian.Negation
 import Linglib.Fragments.German.Negation
@@ -69,11 +72,39 @@ those live in `Data.WALS.F113A`.
 
 namespace Miestamo2005
 
-open Syntax.Negation
-  (NegSymmetry AsymmetrySubtype NegMorphemeType
-   morphemeTypeOfISO symmetryOfISO asymmetrySubtypeOfISO)
+open Syntax.Negation (asymmetrySubtypeOfISO)
+open Data.WALS
 
 /-! ## Miestamo's asymmetry dimensions (beyond WALS) -/
+
+/-- The domain an asymmetric negative construction departs in
+([miestamo-2005] Table 2). WALS Ch 114A codes the same distinctions
+except A/Emph, which the book separates and the atlas folds into
+A/Cat. -/
+inductive AsymmetrySubtype where
+  | finiteness
+  | realityStatus
+  | emphasis
+  | otherCategories
+  | finAndNonReal
+  | finAndEmph
+  | finAndCat
+  | nonRealAndCat
+  | emphAndCat
+  /-- The language has only symmetric negation. -/
+  | nonAssignable
+  deriving DecidableEq, BEq, Repr
+
+/-- The book's subtype recorded by a WALS Ch 114A value. -/
+def AsymmetrySubtype.ofWALS114A :
+    F114A.AsymmetricNegationSubtype → AsymmetrySubtype
+  | .aFin => .finiteness
+  | .aNonreal => .realityStatus
+  | .aCat => .otherCategories
+  | .aFinAndANonreal => .finAndNonReal
+  | .aFinAndACat => .finAndCat
+  | .aNonrealAndACat => .nonRealAndCat
+  | .nonAssignable => .nonAssignable
 
 /-- [miestamo-2005]'s two dimensions of asymmetry. WALS Ch 113 collapses
     these into a single symmetric/asymmetric distinction; Miestamo decomposes
@@ -99,9 +130,9 @@ structure MiestamoDatum where
   /-- ISO 639-3 code; the key for the WALS-consistency checks. -/
   iso : String
   /-- WALS Ch 112: morpheme type -/
-  morphemeType : NegMorphemeType
+  morphemeType : F112A.NegativeMorphemeType
   /-- WALS Ch 113: symmetric/asymmetric/both -/
-  symmetry : NegSymmetry
+  symmetry : F113A.NegationSymmetry
   /-- WALS Ch 114: asymmetry subtype -/
   asymmetrySubtype : AsymmetrySubtype
   /-- Which dimensions of asymmetry are present (Appendix III C/P columns) -/
@@ -123,7 +154,7 @@ gaps in the book's sample are flagged in the datum docstrings. -/
 def finnish : MiestamoDatum :=
   { language := "Finnish"
   , iso := "fin"
-  , morphemeType := .auxVerb
+  , morphemeType := .negativeAuxiliaryVerb
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
@@ -136,7 +167,7 @@ def finnish : MiestamoDatum :=
 def german : MiestamoDatum :=
   { language := "German"
   , iso := "deu"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -152,7 +183,7 @@ def german : MiestamoDatum :=
 def japanese : MiestamoDatum :=
   { language := "Japanese"
   , iso := "jpn"
-  , morphemeType := .affix
+  , morphemeType := .negativeAffix
   , symmetry := .asymmetric
   , asymmetrySubtype := .finAndCat
   , asymmetryDimensions := [.constructional]
@@ -168,7 +199,7 @@ def japanese : MiestamoDatum :=
 def turkish : MiestamoDatum :=
   { language := "Turkish"
   , iso := "tur"
-  , morphemeType := .affix
+  , morphemeType := .negativeAffix
   , symmetry := .both
   , asymmetrySubtype := .otherCategories
   , asymmetryDimensions := [.constructional]
@@ -182,7 +213,7 @@ def turkish : MiestamoDatum :=
 def french : MiestamoDatum :=
   { language := "French"
   , iso := "fra"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -199,7 +230,7 @@ def french : MiestamoDatum :=
 def burmese : MiestamoDatum :=
   { language := "Burmese"
   , iso := "mya"
-  , morphemeType := .doubleNeg
+  , morphemeType := .doubleNegation
   , symmetry := .asymmetric
   , asymmetrySubtype := .otherCategories
   , asymmetryDimensions := [.constructional, .paradigmatic]
@@ -213,7 +244,7 @@ def burmese : MiestamoDatum :=
 def italian : MiestamoDatum :=
   { language := "Italian"
   , iso := "ita"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -226,7 +257,7 @@ def italian : MiestamoDatum :=
 def spanish : MiestamoDatum :=
   { language := "Spanish"
   , iso := "spa"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -244,7 +275,7 @@ def spanish : MiestamoDatum :=
 def mandarin : MiestamoDatum :=
   { language := "Mandarin Chinese"
   , iso := "cmn"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .both
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
@@ -264,7 +295,7 @@ def mandarin : MiestamoDatum :=
 def english : MiestamoDatum :=
   { language := "English"
   , iso := "eng"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .both
   , asymmetrySubtype := .emphasis
   , asymmetryDimensions := [.paradigmatic]
@@ -278,7 +309,7 @@ def english : MiestamoDatum :=
 def russian : MiestamoDatum :=
   { language := "Russian"
   , iso := "rus"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -294,7 +325,7 @@ def russian : MiestamoDatum :=
 def czech : MiestamoDatum :=
   { language := "Czech"
   , iso := "ces"
-  , morphemeType := .affix
+  , morphemeType := .negativeAffix
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
@@ -310,7 +341,7 @@ def czech : MiestamoDatum :=
 def maori : MiestamoDatum :=
   { language := "Maori"
   , iso := "mri"
-  , morphemeType := .wordUnclear
+  , morphemeType := .negativeWordUnclearIfVerbOrParticle
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
@@ -324,7 +355,7 @@ def maori : MiestamoDatum :=
 def hixkaryana : MiestamoDatum :=
   { language := "Hixkaryana"
   , iso := "hix"
-  , morphemeType := .affix
+  , morphemeType := .negativeAffix
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
@@ -341,7 +372,7 @@ def hixkaryana : MiestamoDatum :=
 def imbaburaQuechua : MiestamoDatum :=
   { language := "Quechua (Imbabura)"
   , iso := "qvi"
-  , morphemeType := .particle
+  , morphemeType := .negativeParticle
   , symmetry := .both
   , asymmetrySubtype := .realityStatus
   , asymmetryDimensions := [.paradigmatic]
@@ -361,27 +392,13 @@ The book's codings against the (later, same-author) WALS chapter rows,
 read via the `Syntax.Negation` per-ISO accessors. Languages absent from
 a chapter's WALS sample (Czech throughout) pass vacuously. -/
 
-set_option maxRecDepth 8192 in
-/-- Datum morpheme types agree with WALS Ch 112A wherever coded.
-    (Scoped `maxRecDepth`: kernel evaluation recurses through the
-    1157-row Ch 112A table.) -/
-theorem morphemeType_matches_wals :
-    allData.all (fun d =>
-      (morphemeTypeOfISO d.iso).all (· == d.morphemeType)) = true := by
-  decide
-
-/-- Datum symmetry codings agree with WALS Ch 113A wherever coded. -/
-theorem symmetry_matches_wals :
-    allData.all (fun d =>
-      (symmetryOfISO d.iso).all (· == d.symmetry)) = true := by
-  decide
-
-/-- Datum subtype codings agree with WALS Ch 114A wherever coded — except
-    English, where the book's A/Emph analysis diverges from WALS's A/Cat. -/
+/-- English is the sample's only book-vs-atlas disagreement: WALS Ch 114A
+    is Miestamo's own chapter, so the two codings otherwise coincide. -/
 theorem subtype_matches_wals_except_english :
     allData.all (fun d =>
       d.language == "English" ||
-      (asymmetrySubtypeOfISO d.iso).all (· == d.asymmetrySubtype)) = true := by
+      ((asymmetrySubtypeOfISO d.iso).map AsymmetrySubtype.ofWALS114A).all
+        (· == d.asymmetrySubtype)) = true := by
   decide
 
 /-- The book vs WALS on English: Appendix III codes English SN as
@@ -389,7 +406,7 @@ theorem subtype_matches_wals_except_english :
     Ch 114A codes English A/Cat. -/
 theorem english_subtype_diverges_from_wals :
     english.asymmetrySubtype = .emphasis ∧
-    asymmetrySubtypeOfISO english.iso = some .otherCategories :=
+    asymmetrySubtypeOfISO english.iso = some .aCat :=
   ⟨rfl, by decide⟩
 
 /-! ## Structural sanity of the coding -/
@@ -427,7 +444,7 @@ theorem afin_verbal_implies_constructional :
       (d.asymmetrySubtype == .finiteness ||
        d.asymmetrySubtype == .finAndCat ||
        d.asymmetrySubtype == .finAndNonReal) &&
-      d.morphemeType == .auxVerb)).all
+      d.morphemeType == .negativeAuxiliaryVerb)).all
       (fun d => d.asymmetryDimensions.contains .constructional) = true := by
   decide
 
@@ -448,14 +465,14 @@ theorem afin_always_constructional_in_sample :
     Mandarin and English are SymAsy particles with asymmetry elsewhere
     (méi(yǒu) introduces A/Fin; the emphatic paradigm is neutralized). -/
 theorem symmetric_particles_no_dimensions :
-    (allData.filter (fun d => d.morphemeType == .particle &&
+    (allData.filter (fun d => d.morphemeType == .negativeParticle &&
       d.symmetry == .symmetric)).all
       (fun d => d.asymmetryDimensions.isEmpty) = true := by
   decide
 
 /-- Affixes can produce symmetric, asymmetric, or SymAsy negation. -/
 theorem affixes_variable :
-    (allData.filter (·.morphemeType == .affix)).map (·.symmetry) =
+    (allData.filter (·.morphemeType == .negativeAffix)).map (·.symmetry) =
       [.asymmetric, .both, .symmetric, .asymmetric] := rfl
 
 /-- Constructional asymmetry (only) implies the paradigm is maintained:
@@ -656,22 +673,21 @@ theorem symmetric_no_paradigmatic :
 
 section NegAuxBridge
 
-open Syntax.Negation (NegStrategy)
+open Syntax.Negation (Strategy)
 
-/-- The NegStrategy→NegMorphemeType mapping is consistent with Finnish's
-    classification: the auxiliary literature's negVerb strategy and this
-    study's auxVerb morpheme type refer to the same phenomenon — the
-    negative element is an inflecting auxiliary verb. -/
+/-- The auxiliary literature's negative-verb strategy and this study's
+    auxiliary-verb morpheme type pick out the same Finnish phenomenon: an
+    inflecting negative auxiliary. -/
 theorem finnish_strategy_morpheme_consistent :
-    NegStrategy.negVerb.toNegMorphemeType = finnish.morphemeType := rfl
+    Strategy.negVerb.morphemeType = finnish.morphemeType := rfl
 
 /-- Verbal negation strategy implies constructional asymmetry in both
     the auxiliary literature (creates an AVC) and the negation typology
     (A/Fin). -/
 theorem neg_verb_implies_avc_and_afin :
-    NegStrategy.negVerb.isVerbal = true ∧
-    finnish.asymmetryDimensions.contains .constructional := by
-  exact ⟨rfl, by decide⟩
+    Strategy.negVerb.IsVerbal ∧
+    finnish.asymmetryDimensions.contains .constructional :=
+  ⟨trivial, by decide⟩
 
 end NegAuxBridge
 

--- a/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
+++ b/Linglib/Studies/VanDerAuweraVanAlsenoy2016.lean
@@ -5,6 +5,7 @@ Authors: Robert Hawkins
 -/
 import Linglib.Syntax.Negation
 import Linglib.Features.NegativeConcord
+import Linglib.Data.WALS.Features.F115A
 
 /-!
 # [van-der-auwera-van-alsenoy-2016] — negative concord ↔ n-word status
@@ -28,21 +29,22 @@ paper-specific prediction with no other consumer; keeping it study-local lets
 
 namespace VanDerAuweraVanAlsenoy2016
 
-open Syntax.Negation (NegIndefiniteStrategy)
+open Data.WALS
 open Features.NegativeConcord (NWordStatus)
 
 /-- Whether the negative-indefinite system shows negative concord
-    ([van-der-auwera-van-alsenoy-2016]): WALS 115A `cooccur` (concord) and `mixed`
-    (position-dependent) do; `preclude` (double negation) and `negExistential` do not. -/
-def hasNegativeConcord : NegIndefiniteStrategy → Bool
-  | .cooccur | .mixed => true
-  | .preclude | .negExistential => false
+    ([van-der-auwera-van-alsenoy-2016]): WALS Ch 115A's predicate-negation-also-present (concord)
+    and mixed-behaviour (position-dependent) do; no-predicate-negation (double
+    negation) and the negative-existential construction do not. -/
+def hasNegativeConcord : F115A.NegativeIndefiniteType → Bool
+  | .predicateNegationAlsoPresent | .mixedBehaviour => true
+  | .noPredicateNegation | .negativeExistentialConstruction => false
 
 /-- Whether an item-level n-word status is consistent with a language's WALS 115A
     negative-indefinite strategy: an n-word needs a concord system, an inherently
     negative quantifier a non-concord (double-negation / neg-existential) one, an NPI
     any ([van-der-auwera-van-alsenoy-2016]). -/
-def admits : NegIndefiniteStrategy → NWordStatus → Bool
+def admits : F115A.NegativeIndefiniteType → NWordStatus → Bool
   | strat, .nWord => hasNegativeConcord strat
   | strat, .negQuantifier => !hasNegativeConcord strat
   | _, .npi => true
@@ -50,8 +52,8 @@ def admits : NegIndefiniteStrategy → NWordStatus → Bool
 /-- N-words live in negative-concord systems, inherently negative quantifiers in
     double-negation ones ([van-der-auwera-van-alsenoy-2016]). -/
 theorem nWord_vs_negQuantifier :
-    admits .cooccur .nWord = true ∧
-    admits .preclude .nWord = false ∧
-    admits .preclude .negQuantifier = true := by decide
+    admits .predicateNegationAlsoPresent .nWord = true ∧
+    admits .noPredicateNegation .nWord = false ∧
+    admits .noPredicateNegation .negQuantifier = true := by decide
 
 end VanDerAuweraVanAlsenoy2016

--- a/Linglib/Syntax/Category/ExpressiveModifier.lean
+++ b/Linglib/Syntax/Category/ExpressiveModifier.lean
@@ -21,7 +21,7 @@ parameters, formalized here.
 Moved from `Core/Lexical/ExpressiveModifier.lean` in the cleanup that
 dissolved `Core/Lexical/`. The file's per-language entry-schema +
 abstract-licensing-predicate shape (Fragment-importable, syntax-framework-
-neutral) matches `Typology/PolarityMarking.lean` and `Typology/Negation.lean`,
+neutral) matches `Semantics/Polarity/Marking.lean` and `Syntax/Negation.lean`,
 not the framework-agnostic substrate shape `Core/` is for.
 
 **Framework commitment.** The parasitic/independent dichotomy

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -1,8 +1,6 @@
 import Linglib.Data.WALS.Datapoint
 import Linglib.Data.WALS.Features.F112A
-import Linglib.Data.WALS.Features.F113A
 import Linglib.Data.WALS.Features.F114A
-import Linglib.Data.WALS.Features.F115A
 import Linglib.Data.WALS.Features.F143A
 import Linglib.Data.WALS.Features.F144A
 import Linglib.Syntax.Category.Auxiliary.Constructions
@@ -10,58 +8,59 @@ import Linglib.Features.Grammaticalization
 import Linglib.Morphology.Morph
 
 /-!
-# Typology.Negation
-[dryer-2013-wals] [haspelmath-2013] [miestamo-2005]
+# Standard negation
 
-Per-language typological substrate for the standard sentential negation
-marker of a language: its exponent as morphs, symmetric/
-asymmetric status, asymmetry subtype, and negative-indefinite strategy.
+A language negates a declarative verbal main clause with an affix on the
+verb, a free particle, or an inflecting negative auxiliary, and some
+languages use two morphemes at once (French *ne … pas*). Beyond adding a
+marker, negation may restructure the clause — imposing a nonfinite verb
+form, neutralizing tense distinctions — which is the symmetric/asymmetric
+divide of [miestamo-2005]. Expletive negation is a separate use of the
+same morphemes, semantically vacuous under triggers like 'fear' and
+'before'.
 
-Mirrors the `Linglib/Features/Possession.lean` (Possession), `Question.lean`
-(Question), and `Case.lean` (Case) substrate-extension pattern: the
-substrate carries (a) the marker schema (`Marker`,
-`NegationSystem`), (b) WALS converters and per-ISO accessors.
+This file records a language's negation marker(s) and the strategy
+classifying them, with per-ISO access to the WALS negation chapters.
 
-## What lives here
+## Main declarations
 
-- `NegMorphemeType` — direct projection from WALS Ch 112A's 6-way
-  classification (`negativeAffix`, `negativeParticle`, `negativeAuxiliaryVerb`,
-  `negativeWordUnclearIfVerbOrParticle`, `variationBetweenNegativeWordAndAffix`,
-  `doubleNegation`). This is **Dryer's WALS Ch 112 morpheme typology**, NOT
-  [miestamo-2005]'s construction-level typology — Miestamo classifies
-  *constructions*, not morphemes. The substrate carries Dryer's classification
-  for cross-linguistic indexing; Miestamo's framework lives in
-  `Studies/Miestamo2005.lean`.
-- `Marker` — a standard sentential negation marker.
-- `NegationSystem` — bundles markers + WALS Ch 112A/143A/144A datapoints.
-  The Fragment-side joint: every `Fragments/{Lang}/Negation.lean` exposes
-  `def negationSystem : NegationSystem`.
-- `NegSymmetry`, `AsymmetrySubtype`, `NegIndefiniteStrategy`,
-  `NegVerbPosition`, `NegMorphemePosition` — WALS Ch 113-115/143A
-  feature enums.
-- `NegStrategy` — AVC-oriented classification of the negation strategy
-  ([anderson-2006], [heine-1993]), with bridges to Anderson's AVC
-  patterns (`expectedInflPattern`), Heine's grammaticalization cline
-  (`toGramStage`), and WALS Ch 112 (`toNegMorphemeType`).
-- `ofWALS112A`/`fromWALS113A`/`114A`/`115A`/`143A` converters, and the
-  per-ISO accessors `morphemeTypeOfISO`/`symmetryOfISO`/
-  `asymmetrySubtypeOfISO`/`negIndefiniteOfISO` (study-consumed; `none`
-  when the language is not in the chapter's WALS sample).
+* `Marker`: a standard negation marker, as the morphs exponing it.
+* `NegationSystem`: a language's markers keyed by ISO 639-3 code, with
+  its WALS Ch 112A/143A/144A values derived from that key.
+* `Strategy`: negative verb, affix, or particle — the grain at which
+  negation meets auxiliary-verb constructions and the
+  grammaticalization cline.
+* `ExpletiveTrigger`: a lexical trigger of expletive negation with the
+  negator it licenses.
+* `asymmetrySubtypeOfISO`: a language's WALS Ch 114A value.
 
-## Theory-laden caveats
+## Implementation notes
 
-`NegSymmetry` and `AsymmetrySubtype` are **WALS Ch 113/114** values
-([dryer-haspelmath-2013]). [miestamo-2005]'s richer
-two-dimension framework (constructional vs paradigmatic asymmetry)
-lives in `Studies/Miestamo2005.lean` because it goes beyond what
-WALS encodes.
+The WALS chapters are the source of truth for the typological values, so
+the accessors return the `Data.WALS` enums rather than re-labelled
+copies, and `NegationSystem` derives its datapoints from the ISO code
+rather than storing them. An analysis reaching beyond WALS keeps its own
+vocabulary in its study: [miestamo-2005]'s asymmetry subtypes, which
+separate an emphasis subtype the atlas does not encode, live in
+`Studies/Miestamo2005.lean`.
 
-## Out of scope
+Polarity-sensitive items (n-words, NPIs, free-choice items) are not
+marker-side data; they live in `Fragments/{Lang}/PolarityItems.lean`.
 
-Polarity-sensitive items (n-words, NPIs, FCIs) are NOT marker-side data;
-they live in each language's `Fragments/{Lang}/PolarityItems.lean`. Cross-linguistic theorems consuming
-Fragment per-language data live in `Studies/Miestamo2005.lean`
-(Ch 113-115 grounding).
+## TODO
+
+* `ExpletiveTrigger.triggerClass` is free text. The taxonomy it
+  approximates is `JinKoenig2021.TriggerSubclass`, whose cases the
+  Fragment labels do not currently match.
+
+## References
+
+* [dryer-2013-wals], Ch 112A, 143A
+* [miestamo-2013], Ch 114A
+* [miestamo-2005]
+* [anderson-2006], §1.7.2
+* [heine-1993]
+* [jin-koenig-2021]
 -/
 
 set_option autoImplicit false
@@ -69,111 +68,6 @@ set_option autoImplicit false
 open Morphology (Morph)
 
 namespace Syntax.Negation
-
-/-! ### Substrate enums -/
-
-/-- Type of the standard negation morpheme [dryer-2013-wals].
-
-    Six categories anchored on WALS Ch 112A (negative morpheme classification).
-    Direct projection from `Data.WALS.F112A.NegativeMorphemeType` via
-    `ofWALS112A`; the substrate enum exists for ergonomic pattern-matching
-    in Fragment files. -/
-inductive NegMorphemeType where
-  /-- Negative affix on the verb (e.g., Kolyma Yukaghir `el-jaqa-te-je`
-      'NEG-achieve-FUT-1SG'). -/
-  | affix
-  /-- Free negative particle, no verbal inflection (e.g., English `not`,
-      Italian `non`). -/
-  | particle
-  /-- Negative auxiliary verb inflecting for verbal categories (e.g.,
-      Finnish `e-n` 'NEG-1SG'). -/
-  | auxVerb
-  /-- Negative word whose status as verb or particle is unclear, typically
-      in isolating languages (e.g., Maori `kaahore`). -/
-  | wordUnclear
-  /-- Language uses both negative word and negative affix in different
-      constructions (e.g., Rama). -/
-  | variation
-  /-- Bipartite negation: two co-occurring morphemes flanking the verb
-      (e.g., French `ne...pas`, Izi `to-...-du`). -/
-  | doubleNeg
-  deriving DecidableEq, BEq, Repr
-
-/-- WALS Ch 113A: whether negation changes clause structure beyond adding
-    the negative marker. Symmetric: no structural change. Asymmetric: changes
-    in finiteness, verb paradigm, or TAM marking. -/
-inductive NegSymmetry where
-  | symmetric
-  | asymmetric
-  /-- Both symmetric and asymmetric (Type SymAsy): some constructions
-      symmetric, others asymmetric. -/
-  | both
-  deriving DecidableEq, BEq, Repr
-
-/-- WALS Ch 114A: which grammatical domain is affected by asymmetric
-    negation. The four primary subtypes correspond to [miestamo-2005]'s
-    A/Fin (finiteness), A/NonReal (reality status), A/Emph (emphasis),
-    A/Cat (other categories) plus combined codings.
-
-    Note: WALS Ch 114 does not encode A/Emph as a separate value
-    ([miestamo-2005] Table 2 distinguishes it; WALS collapses it). -/
-inductive AsymmetrySubtype where
-  | finiteness
-  | realityStatus
-  | emphasis
-  | otherCategories
-  | finAndNonReal
-  | finAndEmph
-  | finAndCat
-  | nonRealAndCat
-  | emphAndCat
-  /-- Non-assignable: language has only symmetric negation. -/
-  | nonAssignable
-  deriving DecidableEq, BEq, Repr
-
-/-- WALS Ch 115A: how negative indefinites interact with predicate negation. -/
-inductive NegIndefiniteStrategy where
-  /-- Negative indefinites co-occur with predicate negation (negative concord).
-      Dominant pattern worldwide. -/
-  | cooccur
-  /-- Negative indefinites preclude predicate negation. -/
-  | preclude
-  /-- Mixed (position-dependent or different indefinite series). -/
-  | mixed
-  /-- Negative existential construction. -/
-  | negExistential
-  deriving DecidableEq, BEq, Repr
-
-/-- WALS Ch 143A: position of negative morpheme relative to verb.
-    Single-negation types (`NegV`/`VNeg`/`[Neg-V]`/`[V-Neg]`) plus
-    multi-negation types (obligatory/optional double, optional triple). -/
-inductive NegVerbPosition where
-  /-- Preverbal negative particle: `NegV`. -/
-  | preverbalParticle
-  /-- Postverbal negative particle: `VNeg`. -/
-  | postverbalParticle
-  /-- Preverbal negative affix: `[Neg-V]`. -/
-  | preverbalAffix
-  /-- Postverbal negative affix: `[V-Neg]`. -/
-  | postverbalAffix
-  | negativeTone
-  | mixedSingle
-  | obligDoublNeg
-  | optDoubleNeg
-  | tripleNeg
-  | optSingleNeg
-  deriving DecidableEq, BEq, Repr
-
-/-- WALS Ch 143E/F: whether a language has preverbal and/or postverbal
-    negative morphemes. -/
-inductive NegMorphemePosition where
-  | preverbalOnly
-  | postverbalOnly
-  | preverbalAffixOnly
-  | postverbalAffixOnly
-  | both
-  | none
-  deriving DecidableEq, BEq, Repr
 
 /-! ### Markers and negation systems -/
 
@@ -183,7 +77,7 @@ structure Marker where
       pieces (Burmese *ma-…-bu*). Affixal alternants are recorded by an
       abstract citation form (Turkish *-mA-* for *-ma-* ~ *-me-*). -/
   morphs : List Morph
-  /-- Standard interlinear gloss. Defaults to the WALS-style "NEG". -/
+  /-- Standard interlinear gloss. -/
   gloss : String := "NEG"
   deriving Repr
 
@@ -191,205 +85,113 @@ structure Marker where
 discontinuous pieces separated by `…`. -/
 def Marker.form (m : Marker) : String := toString m.morphs
 
-/-- A language's standard negation system.
+/-- A language's standard negation system: the marker or markers, keyed
+by ISO 639-3 code.
 
-    The Fragment-side joint: every `Fragments/{Lang}/Negation.lean` exposes
-    `def negationSystem : NegationSystem`. Multiple markers handle languages
-    with mood/aspect/lexical-class alternation (Greek, Mandarin, Korean).
-    Length-1 for most languages.
-
-    WALS datapoints are bundled at the system level — in WALS coding,
-    F112A/F143A/F144A take one value per language regardless of how many
-    markers the language has. -/
+Several markers handle mood-, aspect- or lexical-class-conditioned
+alternation (Greek, Mandarin, Korean); most languages have one. -/
 structure NegationSystem where
-  /-- ISO 639-3 code; populated by `NegationSystem.ofISO` and the key
-      for the per-ISO WALS accessors below. -/
+  /-- ISO 639-3 code, the key for the language's WALS values. -/
   iso : String := ""
-  /-- Standard negation marker(s). Order is editorial; Fragment files
-      should put the unmarked / default-context marker first. -/
+  /-- The negation marker(s), unmarked context first. -/
   markers : List Marker
-  /-- WALS Ch 112A: morpheme classification. Should not be hand-encoded
-      in Fragment files — use `NegationSystem.ofISO` to populate from the
-      `Data.WALS` data, which is the single source of truth. -/
-  wals112A : Option Data.WALS.F112A.NegativeMorphemeType := none
-  /-- WALS Ch 143A: NegV / VNeg / double-negation pattern. Populated by
-      `NegationSystem.ofISO`. -/
-  wals143A : Option Data.WALS.F143A.NegVerbOrder := none
-  /-- WALS Ch 144A: full S/O/V positional classification. Populated by
-      `NegationSystem.ofISO`. -/
-  wals144A :
-    Option Data.WALS.F144A.PositionOfNegativeWordWithRespectToSubjectObjectAndVerb
-    := none
   deriving Repr
 
-/-! ### Expletive negation triggers -/
+/-- WALS Ch 112A: the language's negative-morpheme classification. -/
+def NegationSystem.wals112A (s : NegationSystem) :
+    Option Data.WALS.F112A.NegativeMorphemeType :=
+  (Data.WALS.F112A.lookupISO s.iso).map (·.value)
 
-/-- An expletive-negation trigger and the negator it licenses.
+/-- WALS Ch 143A: the order of negative morpheme and verb. -/
+def NegationSystem.wals143A (s : NegationSystem) :
+    Option Data.WALS.F143A.NegVerbOrder :=
+  (Data.WALS.F143A.lookupISO s.iso).map (·.value)
 
-    Trigger classes are the [jin-koenig-2021] Table 5 labels (FEAR,
-    BEFORE, UNLESS, THAN, ...). The Fragment-side joint: EN-attesting
-    `Fragments/{Lang}/Negation.lean` files expose
-    `def enTriggerNegators : List ENTriggerNegator`. -/
-structure ENTriggerNegator where
-  /-- The trigger class label (from [jin-koenig-2021] Table 5). -/
+/-- WALS Ch 144A: the negative word's position relative to subject,
+object and verb. -/
+def NegationSystem.wals144A (s : NegationSystem) :
+    Option Data.WALS.F144A.PositionOfNegativeWordWithRespectToSubjectObjectAndVerb :=
+  (Data.WALS.F144A.lookupISO s.iso).map (·.value)
+
+/-- The negation system of the language with the given ISO 639-3 code. -/
+def NegationSystem.ofISO (iso : String) (markers : List Marker) : NegationSystem :=
+  { iso, markers }
+
+/-! ### Per-language WALS values -/
+
+/-- WALS Ch 114A: which domain the language's asymmetric negation
+affects. -/
+def asymmetrySubtypeOfISO (iso : String) :
+    Option Data.WALS.F114A.AsymmetricNegationSubtype :=
+  (Data.WALS.F114A.lookupISO iso).map (·.value)
+
+/-! ### Expletive negation -/
+
+/-- A lexical trigger of expletive negation together with the negator it
+licenses: Italian *prima che … non*, Mandarin *pà … bié*. -/
+structure ExpletiveTrigger where
+  /-- The trigger's semantic class. -/
   triggerClass : String
-  /-- The language's lexical trigger. -/
+  /-- The triggering lexical item. -/
   triggerForm : String
-  /-- The EN negator form. -/
-  enNegatorForm : String
-  /-- Gloss for the EN negator, when it differs from standard negation. -/
-  enNegatorGloss : Option String := none
-  /-- Whether the EN use is highly entrenched (grammaticalized),
-      when the source classifies it. -/
+  /-- The negator appearing under the trigger. -/
+  negatorForm : String
+  /-- Gloss for that negator, when it differs from standard negation. -/
+  negatorGloss : Option String := none
+  /-- Whether the use is entrenched, when the source classifies it. -/
   highEntrenchment : Option Bool := none
   deriving Repr, BEq, DecidableEq
 
-/-! ### WALS converters -/
+/-! ### Negation strategy
 
-/-- WALS Ch 112A → `NegMorphemeType`. -/
-def ofWALS112A : Data.WALS.F112A.NegativeMorphemeType → NegMorphemeType
-  | .negativeAffix => .affix
-  | .negativeParticle => .particle
-  | .negativeAuxiliaryVerb => .auxVerb
-  | .negativeWordUnclearIfVerbOrParticle => .wordUnclear
-  | .variationBetweenNegativeWordAndAffix => .variation
-  | .doubleNegation => .doubleNeg
-
-/-- WALS Ch 113A → `NegSymmetry`. -/
-def fromWALS113A : Data.WALS.F113A.NegationSymmetry → NegSymmetry
-  | .symmetric  => .symmetric
-  | .asymmetric => .asymmetric
-  | .both       => .both
-
-/-- WALS Ch 114A → `AsymmetrySubtype`. -/
-def fromWALS114A :
-    Data.WALS.F114A.AsymmetricNegationSubtype → AsymmetrySubtype
-  | .aFin           => .finiteness
-  | .aNonreal       => .realityStatus
-  | .aCat           => .otherCategories
-  | .aFinAndANonreal => .finAndNonReal
-  | .aFinAndACat    => .finAndCat
-  | .aNonrealAndACat => .nonRealAndCat
-  | .nonAssignable  => .nonAssignable
-
-/-- WALS Ch 115A → `NegIndefiniteStrategy`. -/
-def fromWALS115A :
-    Data.WALS.F115A.NegativeIndefiniteType → NegIndefiniteStrategy
-  | .predicateNegationAlsoPresent      => .cooccur
-  | .noPredicateNegation               => .preclude
-  | .mixedBehaviour                    => .mixed
-  | .negativeExistentialConstruction   => .negExistential
-
-/-- WALS Ch 143A → `NegVerbPosition`. -/
-def fromWALS143A : Data.WALS.F143A.NegVerbOrder → NegVerbPosition
-  | .negv => .preverbalParticle
-  | .vneg => .postverbalParticle
-  | .negV => .preverbalAffix
-  | .vNeg => .postverbalAffix
-  | .negativeTone => .negativeTone
-  | .type1Type2 => .mixedSingle
-  | .type1Type3 => .mixedSingle
-  | .type1Type4 => .mixedSingle
-  | .type2Type3 => .mixedSingle
-  | .type2Type4 => .mixedSingle
-  | .type3Type4 => .mixedSingle
-  | .type3NegativeInfix => .mixedSingle
-  | .optsingleneg => .optSingleNeg
-  | .obligdoubleneg => .obligDoublNeg
-  | .optdoubleneg => .optDoubleNeg
-  | .opttriplenegObligdoubleneg => .tripleNeg
-  | .opttriplenegOptdoubleneg => .tripleNeg
-
-/-- Build a `NegationSystem` for a language identified by ISO 639-3 code,
-    pulling F112A / F143A / F144A values from the `Data.WALS` data. -/
-def NegationSystem.ofISO (iso : String) (markers : List Marker) :
-    NegationSystem :=
-  { iso
-  , markers
-  , wals112A := (Data.WALS.F112A.lookupISO iso).map (·.value)
-  , wals143A := (Data.WALS.F143A.lookupISO iso).map (·.value)
-  , wals144A := (Data.WALS.F144A.lookupISO iso).map (·.value)
-  }
-
-/-! ### Per-ISO WALS accessors (study-consumed) -/
-
-/-- WALS Ch 112A value for a language, as `NegMorphemeType`. -/
-def morphemeTypeOfISO (iso : String) : Option NegMorphemeType :=
-  (Data.WALS.F112A.lookupISO iso).map (ofWALS112A ·.value)
-
-/-- WALS Ch 113A value for a language, as `NegSymmetry`. -/
-def symmetryOfISO (iso : String) : Option NegSymmetry :=
-  (Data.WALS.F113A.lookupISO iso).map (fromWALS113A ·.value)
-
-/-- WALS Ch 114A value for a language, as `AsymmetrySubtype`. -/
-def asymmetrySubtypeOfISO (iso : String) : Option AsymmetrySubtype :=
-  (Data.WALS.F114A.lookupISO iso).map (fromWALS114A ·.value)
-
-/-- WALS Ch 115A value for a language, as `NegIndefiniteStrategy`. -/
-def negIndefiniteOfISO (iso : String) : Option NegIndefiniteStrategy :=
-  (Data.WALS.F115A.lookupISO iso).map (fromWALS115A ·.value)
-
-/-! ### Negation strategy and the AVC bridge
-[anderson-2006] [heine-1993] [miestamo-2005]
-
-Some languages express sentential negation through a **negative auxiliary
-verb** that hosts inflection (tense, agreement) while the lexical verb
-appears in a nonfinite form (Finnish *ei mene* 'NEG.3SG go') — a special
-case of the aux-headed AVC pattern of `AuxiliaryVerbs`.
-`NegStrategy` classifies negation strategies at this AVC-relevant grain
-and bridges them to Anderson's inflectional patterns, Heine's
-grammaticalization cline, and the WALS Ch 112 morpheme typology. -/
+A **negative auxiliary verb** hosts the inflection its lexical verb
+loses (Finnish *ei mene* 'NEG.3SG go'), making negation a special case of
+the aux-headed auxiliary-verb construction; an affix or a particle does
+not. `Strategy` classifies negation at that grain. -/
 
 open AuxiliaryVerbs (InflPattern)
 open Grammaticalization (GramStage)
 
-/-- Strategy for expressing sentential negation. -/
-inductive NegStrategy where
-  /-- Negative auxiliary verb that inflects (Finnish *ei*, Komi *oz*). -/
+/-- How a language expresses sentential negation. -/
+inductive Strategy where
+  /-- An inflecting negative auxiliary (Finnish *ei*, Komi *oz*). -/
   | negVerb
-  /-- Bound negative morpheme (e.g., Turkish *-mA-*). -/
+  /-- A bound negative morpheme (Turkish *-mA-*). -/
   | negAffix
-  /-- Free negative particle (English *not*, Italian *non*). -/
+  /-- A free negative particle (English *not*, Italian *non*). -/
   | negParticle
   deriving DecidableEq, Repr
 
-/-- A negative verb creates an AVC and therefore has an expected inflectional
-    pattern: aux-headed (the neg verb hosts inflection). Affixes and particles
-    do not create AVCs. -/
-def NegStrategy.expectedInflPattern : NegStrategy → Option InflPattern
-  | .negVerb     => some .auxHeaded
-  | .negAffix    => none
+/-- A negative verb heads an auxiliary-verb construction, so it is
+expected to host the inflection; affixes and particles form no
+construction to head. -/
+def Strategy.expectedInflPattern : Strategy → Option InflPattern
+  | .negVerb => some .auxHeaded
+  | .negAffix | .negParticle => none
+
+/-- The strategy is verbal: its negator is itself a verb. -/
+def Strategy.IsVerbal : Strategy → Prop
+  | .negVerb => True
+  | .negAffix | .negParticle => False
+
+instance : DecidablePred Strategy.IsVerbal
+  | .negVerb => isTrue trivial
+  | .negAffix | .negParticle => isFalse id
+
+/-- The strategy's stage on the grammaticalization cline ([heine-1993];
+[anderson-2006] ch. 7): a negative verb is an auxiliary, a negative affix
+one stage further. A particle is not a bleached verb, so it is off the
+cline entirely. -/
+def Strategy.toGramStage : Strategy → Option GramStage
+  | .negVerb => some .auxiliary
+  | .negAffix => some .affix
   | .negParticle => none
 
-/-- Is this strategy verbal (i.e., does it create an AVC)? -/
-def NegStrategy.isVerbal : NegStrategy → Bool
-  | .negVerb => true
-  | _        => false
-
-/-- Project a negation strategy onto its grammaticalization-cline
-    stage ([heine-1993], [anderson-2006] ch. 7). A negative
-    *verb* (Finnish *ei*, Komi *oz*) sits at the auxiliary stage; a
-    negative *affix* (bound morpheme) is one stage further along the
-    cline. A free negative *particle* (English *not*, Italian *non*)
-    is not on the verbal cline at all — particles are not bleached
-    verbs and don't have a "stage" of grammaticalization in
-    Heine's/Anderson's verbal sense. Returning `none` for `.negParticle`
-    rather than collapsing it onto `.auxiliary` (an earlier
-    formaliser shorthand) preserves [miestamo-2005]'s
-    particle-vs-verb morphological distinction; the cross-framework
-    equivalence theorem `auxiliary_stage_iff_aux_verb_morpheme` in
-    `Studies/Anderson2006.lean` makes the
-    Anderson-cline / Miestamo-morpheme-type agreement Lean-checkable. -/
-def NegStrategy.toGramStage : NegStrategy → Option GramStage
-  | .negVerb     => some .auxiliary
-  | .negAffix    => some .affix
-  | .negParticle => none
-
-/-- Map from AVC-oriented `NegStrategy` to WALS-oriented `NegMorphemeType`:
-    both classify the morphological status of the negative marker. -/
-def NegStrategy.toNegMorphemeType : NegStrategy → NegMorphemeType
-  | .negVerb     => .auxVerb
-  | .negAffix    => .affix
-  | .negParticle => .particle
+/-- The strategy's negative morpheme in the WALS Ch 112A
+classification. -/
+def Strategy.morphemeType : Strategy → Data.WALS.F112A.NegativeMorphemeType
+  | .negVerb => .negativeAuxiliaryVerb
+  | .negAffix => .negativeAffix
+  | .negParticle => .negativeParticle
 
 end Syntax.Negation


### PR DESCRIPTION
Deep audit of `Syntax/Negation.lean` (395 → 197 lines).

- Four of its six enums were case-for-case relabels of the `Data.WALS` enums reached through converters; consumers now use the WALS types directly. `AsymmetrySubtype` is not a relabel — it separates Miestamo's A/Emph subtype, which the atlas folds into A/Cat — so it moves to `Studies/Miestamo2005.lean`, its only consumer.
- Deleted outright: `NegVerbPosition` + `fromWALS143A` and `NegMorphemePosition` (no consumers, and the latter had no converter and a `none` case shadowing `Option.none`).
- `NegationSystem` derives its three WALS datapoints from its ISO key instead of storing copies of them; `NegStrategy` → `Strategy` and `isVerbal : Bool` → `IsVerbal : Prop`; `ENTriggerNegator` → `ExpletiveTrigger` (the EN acronym is paper jargon).
- Cut `morphemeType_matches_wals` and `symmetry_matches_wals`: WALS Ch 113A/114A are Miestamo's own chapters drawn from the book being formalized, so agreement is not a finding, and the checks cost a `maxRecDepth 8192` kernel walk over the 1157-row table. The English divergence, which is a finding, keeps its theorem.
- Fixed: the title named the dissolved `Typology/` directory, the module doc claimed to mirror two deleted files, and WALS Ch 113/114 were credited to the atlas editors rather than to Miestamo.