### PR TITLE
refactor(Studies/Miestamo2005, Syntax/Negation): cut tautologies, stipulated counts, and the unread system bundle

### DIFF
--- a/Linglib/Studies/Miestamo2005.lean
+++ b/Linglib/Studies/Miestamo2005.lean
@@ -20,62 +20,50 @@ import Linglib.Fragments.Quechua.Negation
 
 /-!
 # Miestamo (2005): Standard Negation
-[miestamo-2005]
 
-[miestamo-2005] refines the WALS symmetric/asymmetric classification
-(Ch 113-114) with the orthogonal distinction between **constructional**
-and **paradigmatic** asymmetry:
+Negating a declarative verbal main clause may do nothing but add a marker,
+or it may restructure the clause as well. [miestamo-2005] splits that
+second case along two orthogonal dimensions. **Constructional** asymmetry
+changes the structure of the negative clause — Finnish adds a finite
+negative auxiliary and demotes the lexical verb to a nonfinite
+connegative (A/Fin), Turkish replaces the aorist suffix (A/Cat).
+**Paradigmatic** asymmetry changes which distinctions remain available —
+Burmese collapses three TAM distinctions to one, English loses the
+periphrastic emphatic (A/Emph), Imbabura Quechua forces the *-chu*
+validator and thereby displaces the others (A/NonReal). The dimensions
+cross: Finnish is constructional only, Imbabura Quechua paradigmatic
+only, Burmese both.
 
-- **Constructional**: the *structure* of the negative clause differs from
-  the affirmative beyond adding the negation marker — added finite
-  elements (Finnish neg aux + connegative, A/Fin) and marker
-  *replacement* (Turkish aorist `-(I)r` → `-z`; replacement asymmetry is
-  constructional A/Cat).
+Formalized here: the book's Appendix III coding for fifteen languages,
+its agreement with the later WALS chapters, and the Fragment paradigms
+that witness each asymmetry. In the 179-language representative sample
+symmetric negation is the more common (Table 3: Sym 72, SymAsy 76, Asy
+31), and among subtypes A/Cat leads and A/Emph trails (Table 5: A/Cat
+59, A/Fin 45, A/NonReal 23, A/Emph 4).
 
-- **Paradigmatic**: the *paradigm* of available distinctions differs in
-  the negative — neutralization (Burmese *-bu* collapses three TAM
-  distinctions to one; English negatives lack the periphrastic emphatic,
-  A/Emph/Neutr) or displacement (Imbabura Quechua negatives require the
-  validator *-chu*, A/NonReal/Displc).
+A language showing several asymmetries may have one *derived* from
+another rather than from negation directly — Imbabura Quechua's ban on
+other validators follows from its *-chu* requirement, since only one
+validator may occur per clause. Derivedness relates asymmetries to each
+other, so it is noted per datum rather than carried as a field.
 
-The dimensions are orthogonal: Finnish is constructional-only, Imbabura
-Quechua paradigmatic-only, Burmese both.
-
-## Derived vs independent asymmetry
-
-When a language shows multiple asymmetries, one may be **derived** from
-another rather than being a direct consequence of negation: Maung's TAM
-neutralization follows from its obligatory irrealis-marking (A/NonReal),
-and Imbabura Quechua's ban on other validators follows from the
-A/NonReal validator *-chu*. Derivedness relates asymmetries *to each
-other*, not asymmetries to marker types; it is noted in datum docstrings
-where relevant rather than carried as a field (no sample language here
-has an independent multiple asymmetry).
-
-## WALS consistency
-
-Datum codings follow the book's Appendix III analyses. They agree with
-the (later, same-author) WALS Ch 112A-114A codings for every sample
-language except English: the book analyses English SN as symmetric
-AUX+*not* with paradigmatic A/Emph/Neutr asymmetry, where WALS Ch 114A
-codes English A/Cat (`english_subtype_diverges_from_wals`). Czech is
-absent from the book's sample and from WALS Ch 113A-115A; its datum
+Codings follow Appendix III and agree with the later, same-author WALS
+chapters everywhere except English, which the book analyses as symmetric
+AUX+*not* with paradigmatic A/Emph where WALS Ch 114A codes A/Cat. Czech
+is in neither the book's sample nor the WALS negation chapters; its row
 applies the book's criteria.
 
-## Quantitative data
+## References
 
-The book's representative sample (RS) covers **179 languages** (Table 3,
-p. 171): Sym 72 (40%), SymAsy 76 (42%), Asy 31 (17%). The WALS Ch 113
-sample (also by Miestamo) covers 297 languages with different numbers;
-those live in `Data.WALS.F113A`.
+* [miestamo-2005], Ch 4, Tables 3 and 5, Appendix III
+* [miestamo-2013], WALS Ch 113A, 114A
 -/
-
 namespace Miestamo2005
 
 open Syntax.Negation (asymmetrySubtypeOfISO)
 open Data.WALS
 
-/-! ## Miestamo's asymmetry dimensions (beyond WALS) -/
+/-! ### Asymmetry dimensions and subtypes -/
 
 /-- The domain an asymmetric negative construction departs in
 ([miestamo-2005] Table 2). WALS Ch 114A codes the same distinctions
@@ -121,7 +109,7 @@ inductive AsymmetryDimension where
   | paradigmatic
   deriving DecidableEq, BEq, Repr
 
-/-! ## Datum -/
+/-! ### The Appendix III coding -/
 
 /-- A Miestamo-style negation datum: the WALS-chapter classification plus
     the book's constructional/paradigmatic dimension coding (Appendix III). -/
@@ -137,16 +125,11 @@ structure MiestamoDatum where
   asymmetrySubtype : AsymmetrySubtype
   /-- Which dimensions of asymmetry are present (Appendix III C/P columns) -/
   asymmetryDimensions : List AsymmetryDimension
-  /-- Negation marker form(s), derived from Fragment where available -/
+  /-- The negation marker forms, read off the language's Fragment. -/
   negMarkers : List String
-  /-- Brief description of the asymmetry (if any) -/
-  asymmetryDescription : String := ""
   deriving Repr, BEq
 
-/-! ## Per-language data (Fragment-derived where possible)
-
-Codings follow the book's Appendix III rows; deviations from WALS or
-gaps in the book's sample are flagged in the datum docstrings. -/
+/-! ### Per-language rows -/
 
 /-- Finnish: constructional A/Fin/NegVerb. The negative auxiliary is the
     finite element; the lexical verb appears as a nonfinite connegative.
@@ -158,9 +141,7 @@ def finnish : MiestamoDatum :=
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , negMarkers := Finnish.Negation.negParadigm.map (·.form)
-  , asymmetryDescription := "A/Fin/NegVerb: the negative auxiliary carries " ++
-      "finiteness; the lexical verb is a nonfinite connegative." }
+  , negMarkers := Finnish.Negation.negParadigm.map (·.form) }
 
 /-- German: symmetric. Particle *nicht*.
     Form derived from `German.Negation.nicht.form`. -/
@@ -171,9 +152,7 @@ def german : MiestamoDatum :=
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , negMarkers := [German.Negation.nicht.form]
-  , asymmetryDescription := "Symmetric: adding nicht introduces no " ++
-      "structural or paradigmatic changes." }
+  , negMarkers := [German.Negation.nicht.form] }
 
 /-- Japanese: constructional A/Fin + A/Cat. Plain *-nai* adjectivalizes
     the verb (A/Fin/Neg-LV); the polite nonpast replaces TAM material
@@ -187,10 +166,7 @@ def japanese : MiestamoDatum :=
   , symmetry := .asymmetric
   , asymmetrySubtype := .finAndCat
   , asymmetryDimensions := [.constructional]
-  , negMarkers := [Japanese.Negation.negSuffix.form]
-  , asymmetryDescription := "A/Fin/Neg-LV: -nai turns the verb into an " ++
-      "i-adjective; A/Cat/TAM: the polite nonpast replaces TAM material. " ++
-      "All constructional in Appendix III." }
+  , negMarkers := [Japanese.Negation.negSuffix.form] }
 
 /-- Turkish: SymAsy with constructional A/Cat/TAM in the aorist only.
     The aorist suffix changes to *-z* in the 2nd/3rd persons and is
@@ -203,10 +179,7 @@ def turkish : MiestamoDatum :=
   , symmetry := .both
   , asymmetrySubtype := .otherCategories
   , asymmetryDimensions := [.constructional]
-  , negMarkers := [Turkish.Negation.negSuffix.form]
-  , asymmetryDescription := "Constructional A/Cat/TAM: aorist -(I)r → -z " ++
-      "under negation (2nd/3rd persons; omitted in the 1st). " ++
-      "Most other TAM constructions are symmetric." }
+  , negMarkers := [Turkish.Negation.negSuffix.form] }
 
 /-- French: symmetric. Bipartite *ne...pas* introduces no structural change.
     Forms derived from `French.Negation`. -/
@@ -218,10 +191,7 @@ def french : MiestamoDatum :=
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
   , negMarkers := [French.Negation.neClitic,
-                    French.Negation.pasReinforcer]
-  , asymmetryDescription := "Symmetric: ne...pas adds negation without " ++
-      "changing clause structure or paradigm. " ++
-      "Jespersen cycle: ne dropping in colloquial speech." }
+                    French.Negation.pasReinforcer] }
 
 /-- Burmese: constructional + paradigmatic A/Cat, in one construction
     (Appendix III type B): the circumfix replaces the TAM slot and
@@ -235,9 +205,7 @@ def burmese : MiestamoDatum :=
   , asymmetrySubtype := .otherCategories
   , asymmetryDimensions := [.constructional, .paradigmatic]
   , negMarkers := [Burmese.Negation.negPrefix,
-                    Burmese.Negation.negSuffix]
-  , asymmetryDescription := "Constructional: ma-...-bu replaces the TAM slot. " ++
-      "Paradigmatic: -bu neutralizes TAM distinctions (A/Cat/TAM/Neutr)." }
+                    Burmese.Negation.negSuffix] }
 
 /-- Italian: symmetric. Particle *non*, no structural change.
     Form derived from `Italian.Negation.non.form`. -/
@@ -248,9 +216,7 @@ def italian : MiestamoDatum :=
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , negMarkers := [Italian.Negation.non.form]
-  , asymmetryDescription := "Symmetric: non adds negation without " ++
-      "structural or paradigmatic change." }
+  , negMarkers := [Italian.Negation.non.form] }
 
 /-- Spanish: symmetric. Particle *no*, no structural change.
     Form derived from `Spanish.Negation.no.form`. -/
@@ -261,10 +227,7 @@ def spanish : MiestamoDatum :=
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , negMarkers := [Spanish.Negation.no.form]
-  , asymmetryDescription := "Symmetric: no adds negation without " ++
-      "structural or paradigmatic change. " ++
-      "Position-dependent n-word concord (parallels Italian)." }
+  , negMarkers := [Spanish.Negation.no.form] }
 
 /-- Mandarin Chinese: SymAsy with constructional A/Fin.
     Non-perfectives negated by *bù* (symmetric). Perfectives negated by
@@ -280,11 +243,7 @@ def mandarin : MiestamoDatum :=
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
   , negMarkers := [Mandarin.Negation.bu.form,
-                    Mandarin.Negation.mei.form]
-  , asymmetryDescription := "Constructional: méi(yǒu) introduces the " ++
-      "existential verb yǒu as the finite element (A/Fin/Neg-FE); " ++
-      "méi alone is a negative existential verb (A/Fin/NegVerb). " ++
-      "bù constructions are symmetric." }
+                    Mandarin.Negation.mei.form] }
 
 /-- English: SymAsy with paradigmatic A/Emph/Neutr. Appendix III codes
     AUX+*not* as symmetric (with *do* as the finite AUX host) and locates
@@ -299,10 +258,7 @@ def english : MiestamoDatum :=
   , symmetry := .both
   , asymmetrySubtype := .emphasis
   , asymmetryDimensions := [.paradigmatic]
-  , negMarkers := [English.Negation.not.form]
-  , asymmetryDescription := "Paradigmatic A/Emph/Neutr: the periphrastic " ++
-      "emphatic is unavailable in negatives (simple tenses). " ++
-      "AUX+not constructions themselves are symmetric." }
+  , negMarkers := [English.Negation.not.form] }
 
 /-- Russian: symmetric. Particle *не* (*ne*), no structural change.
     Form derived from `Russian.Negation.ne.form`. -/
@@ -313,10 +269,7 @@ def russian : MiestamoDatum :=
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , negMarkers := [Russian.Negation.ne.form]
-  , asymmetryDescription := "Symmetric: не adds negation without " ++
-      "structural or paradigmatic change. " ++
-      "Obligatory negative concord (Slavic pattern)." }
+  , negMarkers := [Russian.Negation.ne.form] }
 
 /-- Czech: symmetric. Prefix *ne-*, no structural change. Not in the
     book's RS (nor the WALS Ch 113A-115A samples); coded here by applying
@@ -329,10 +282,7 @@ def czech : MiestamoDatum :=
   , symmetry := .symmetric
   , asymmetrySubtype := .nonAssignable
   , asymmetryDimensions := []
-  , negMarkers := [Czech.Negation.negPrefix]
-  , asymmetryDescription := "Symmetric: ne- prefix adds negation without " ++
-      "structural or paradigmatic change. " ++
-      "Obligatory negative concord (Slavic pattern)." }
+  , negMarkers := [Czech.Negation.negPrefix] }
 
 /-- Maori: constructional A/Fin/NegVerb. *Kāhore* is the finite element
     and the lexical clause is subordinated. WALS Ch 112A codes the
@@ -345,9 +295,7 @@ def maori : MiestamoDatum :=
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , negMarkers := [Maori.Negation.kahore.form]
-  , asymmetryDescription := "Constructional A/Fin/NegVerb: kāhore takes the " ++
-      "TAM position, the verb appears in nominalized form." }
+  , negMarkers := [Maori.Negation.kahore.form] }
 
 /-- Hixkaryana: constructional A/Fin/Neg-LV. Suffix *-hɨra* deverbalizes
     the verb; a copula becomes the finite element.
@@ -359,9 +307,7 @@ def hixkaryana : MiestamoDatum :=
   , symmetry := .asymmetric
   , asymmetrySubtype := .finiteness
   , asymmetryDimensions := [.constructional]
-  , negMarkers := [Hixkaryana.Negation.hira.form]
-  , asymmetryDescription := "Constructional A/Fin/Neg-LV: -hira deverbalizes " ++
-      "the verb, a copula becomes the finite element." }
+  , negMarkers := [Hixkaryana.Negation.hira.form] }
 
 /-- Imbabura Quechua: SymAsy with paradigmatic A/NonReal/Displc.
     *Mana* constructions are symmetric; negatives require the validator
@@ -376,27 +322,19 @@ def imbaburaQuechua : MiestamoDatum :=
   , symmetry := .both
   , asymmetrySubtype := .realityStatus
   , asymmetryDimensions := [.paradigmatic]
-  , negMarkers := [Quechua.Negation.mana.form]
-  , asymmetryDescription := "Paradigmatic A/NonReal/Displc: negatives require " ++
-      "the -chu validator, a category shared with interrogatives; other " ++
-      "validators are displaced (derived asymmetry). " ++
-      "Clause structure is preserved." }
+  , negMarkers := [Quechua.Negation.mana.form] }
 
 def allData : List MiestamoDatum :=
   [finnish, german, japanese, turkish, french, burmese, italian, spanish,
    mandarin, english, russian, czech, maori, hixkaryana, imbaburaQuechua]
 
-/-! ## WALS consistency
-
-The book's codings against the (later, same-author) WALS chapter rows,
-read via the `Syntax.Negation` per-ISO accessors. Languages absent from
-a chapter's WALS sample (Czech throughout) pass vacuously. -/
+/-! ### Agreement with WALS -/
 
 /-- English is the sample's only book-vs-atlas disagreement: WALS Ch 114A
     is Miestamo's own chapter, so the two codings otherwise coincide. -/
 theorem subtype_matches_wals_except_english :
     allData.all (fun d =>
-      d.language == "English" ||
+      d.iso == "eng" ||
       ((asymmetrySubtypeOfISO d.iso).map AsymmetrySubtype.ofWALS114A).all
         (· == d.asymmetrySubtype)) = true := by
   decide
@@ -409,94 +347,7 @@ theorem english_subtype_diverges_from_wals :
     asymmetrySubtypeOfISO english.iso = some .aCat :=
   ⟨rfl, by decide⟩
 
-/-! ## Structural sanity of the coding -/
-
-/-- Symmetric languages have no asymmetry dimensions. -/
-theorem symmetric_no_dimensions :
-    (allData.filter (·.symmetry == .symmetric)).all
-      (fun d => d.asymmetryDimensions.isEmpty) = true := by
-  decide
-
-/-- Asymmetric languages have at least one asymmetry dimension. -/
-theorem asymmetric_has_dimensions :
-    (allData.filter (·.symmetry == .asymmetric)).all
-      (fun d => !d.asymmetryDimensions.isEmpty) = true := by
-  decide
-
-/-- SymAsy languages have at least one asymmetry dimension
-    (for their asymmetric constructions). -/
-theorem symasy_has_dimensions :
-    (allData.filter (·.symmetry == .both)).all
-      (fun d => !d.asymmetryDimensions.isEmpty) = true := by
-  decide
-
-/-- Symmetric-only (WALS) implies nonAssignable asymmetry subtype. -/
-theorem symmetric_implies_nonassignable :
-    (allData.filter (·.symmetry == .symmetric)).all
-      (fun d => d.asymmetrySubtype == .nonAssignable) = true := by
-  decide
-
-/-- A/Fin with a *verbal* negator implies constructional asymmetry:
-    the negative verb takes over the finite verb slot, necessarily
-    restructuring the clause. -/
-theorem afin_verbal_implies_constructional :
-    (allData.filter (fun d =>
-      (d.asymmetrySubtype == .finiteness ||
-       d.asymmetrySubtype == .finAndCat ||
-       d.asymmetrySubtype == .finAndNonReal) &&
-      d.morphemeType == .negativeAuxiliaryVerb)).all
-      (fun d => d.asymmetryDimensions.contains .constructional) = true := by
-  decide
-
-/-- All A/Fin languages in our sample have constructional asymmetry,
-    regardless of negation marker type — matching Table 5, where A/Fin
-    is constructional in 44 of 45 RS languages. -/
-theorem afin_always_constructional_in_sample :
-    (allData.filter (fun d =>
-      d.asymmetrySubtype == .finiteness ||
-      d.asymmetrySubtype == .finAndCat ||
-      d.asymmetrySubtype == .finAndNonReal)).all
-      (fun d => d.asymmetryDimensions.contains .constructional) = true := by
-  decide
-
-/-! ## Theoretical predictions -/
-
-/-- Particles that are symmetric-only have no asymmetry dimensions.
-    Mandarin and English are SymAsy particles with asymmetry elsewhere
-    (méi(yǒu) introduces A/Fin; the emphatic paradigm is neutralized). -/
-theorem symmetric_particles_no_dimensions :
-    (allData.filter (fun d => d.morphemeType == .negativeParticle &&
-      d.symmetry == .symmetric)).all
-      (fun d => d.asymmetryDimensions.isEmpty) = true := by
-  decide
-
-/-- Affixes can produce symmetric, asymmetric, or SymAsy negation. -/
-theorem affixes_variable :
-    (allData.filter (·.morphemeType == .negativeAffix)).map (·.symmetry) =
-      [.asymmetric, .both, .symmetric, .asymmetric] := rfl
-
-/-- Constructional asymmetry (only) implies the paradigm is maintained:
-    Finnish has A/Fin constructional asymmetry but no paradigmatic gaps. -/
-theorem finnish_no_paradigmatic_asymmetry :
-    finnish.asymmetryDimensions = [.constructional] := rfl
-
-/-- Burmese has both dimensions of asymmetry: the circumfix changes
-    structure (constructional) and neutralizes TAM (paradigmatic). -/
-theorem burmese_both_dimensions :
-    burmese.asymmetryDimensions = [.constructional, .paradigmatic] := rfl
-
-/-- Turkish has constructional-only asymmetry: the aorist marker is
-    replaced (or omitted), but no distinctions are neutralized. -/
-theorem turkish_constructional_only :
-    turkish.asymmetryDimensions = [.constructional] := rfl
-
-/-- Imbabura Quechua has paradigmatic-only asymmetry: the validator
-    requirement changes the paradigm, not the clause structure. -/
-theorem quechua_paradigmatic_only :
-    imbaburaQuechua.asymmetryDimensions = [.paradigmatic] := rfl
-
-/-! ## Fragment cross-validation -/
-
+/-! ### The Fragment paradigms behind the codings -/
 
 /-- Japanese Fragment distribution shows the tense shift from stem to
     suffix that Appendix III codes as constructional replacement
@@ -533,13 +384,6 @@ theorem mandarin_fragment_confirms_symasy :
     mandarin.symmetry == .both := by
   refine ⟨?_, ?_, rfl⟩ <;> decide
 
-/-- Mandarin méi-yǒu connects to AspectComparison: the same particle is
-    formalized as a cross-domain negative perfective there. -/
-theorem mandarin_meiyou_cross_module :
-    Mandarin.AspectComparison.meiyou.hanzi = "没有" ∧
-    Mandarin.AspectComparison.meiyou.pinyin = "méi-yǒu" :=
-  ⟨rfl, rfl⟩
-
 /-- English do-support is exactly the asymmetric constructions in the
     Fragment's construction-level coding. The book instead treats AUX+not
     as symmetric and locates English asymmetry in the emphatic paradigm
@@ -571,105 +415,7 @@ theorem imbaburaQuechua_chu_is_asymmetry :
     imbaburaQuechua.symmetry == .both := by
   refine ⟨?_, ?_, rfl⟩ <;> decide
 
-/-! ## Miestamo's 179-language survey distribution (Table 3) -/
-
-/-- Distribution from [miestamo-2005]'s 179-language representative
-    sample (RS). These are the headline empirical results of Ch 4's
-    typological survey. Note: the WALS Ch 113 sample (also by Miestamo)
-    covers 297 languages with different numbers; those are captured
-    separately via `Data.WALS.F113A`. -/
-structure SurveyDistribution where
-  totalLanguages : Nat
-  symmetricOnly : Nat
-  asymmetricOnly : Nat
-  symAsy : Nat
-  /-- Proportion check: parts sum to whole. -/
-  complete : symmetricOnly + asymmetricOnly + symAsy = totalLanguages
-  deriving Repr
-
-/-- The 179-language RS distribution from [miestamo-2005] Table 3
-    (p. 171). Sym = 72 (40%), SymAsy = 76 (42%), Asy = 31 (17%). -/
-def miestamo179 : SurveyDistribution :=
-  { totalLanguages := 179
-  , symmetricOnly := 72
-  , asymmetricOnly := 31
-  , symAsy := 76
-  , complete := by omega }
-
-/-- SymAsy is the most common type in the RS (76 > 72 > 31).
-    [miestamo-2005] Table 3 (p. 171). -/
-theorem symasy_plurality :
-    miestamo179.symAsy > miestamo179.symmetricOnly ∧
-    miestamo179.symAsy > miestamo179.asymmetricOnly := by
-  exact ⟨by decide, by decide⟩
-
-/-- Purely asymmetric negation (type Asy) is the least common type.
-    [miestamo-2005] p. 171: "symmetric negation is more common in
-    the world's languages than asymmetric negation." -/
-theorem asymmetric_minority :
-    miestamo179.asymmetricOnly < miestamo179.symmetricOnly ∧
-    miestamo179.asymmetricOnly < miestamo179.symAsy := by
-  exact ⟨by decide, by decide⟩
-
-/-- Languages with any symmetric construction (S column in Table 3:
-    Sym + SymAsy = 148, 83%) greatly outnumber purely asymmetric. -/
-theorem symmetric_constructions_common :
-    miestamo179.symmetricOnly + miestamo179.symAsy > miestamo179.asymmetricOnly := by
-  decide
-
-/-- Asymmetry subtype frequencies from [miestamo-2005] Table 5
-    (p. 173). A/Cat is most common, A/Emph least common.
-    Frequency order: A/Cat (59) > A/Fin (45) > A/NonReal (23) > A/Emph (4). -/
-structure SubtypeDistribution where
-  aFin : Nat
-  aNonReal : Nat
-  aEmph : Nat
-  aCat : Nat
-  deriving Repr
-
-/-- Table 5 totals (across SymAsy + Asy). Languages can show
-    multiple subtypes, so these sum to more than 107. -/
-def subtypeDist : SubtypeDistribution :=
-  { aFin := 45, aNonReal := 23, aEmph := 4, aCat := 59 }
-
-theorem acat_most_common : subtypeDist.aCat > subtypeDist.aFin := by decide
-
-theorem aemph_least_common :
-    subtypeDist.aEmph < subtypeDist.aNonReal ∧
-    subtypeDist.aEmph < subtypeDist.aFin ∧
-    subtypeDist.aEmph < subtypeDist.aCat := by
-  exact ⟨by decide, by decide, by decide⟩
-
-/-! ## Implicational universals -/
-
-/-- A/NonReal asymmetry in our sample is paradigmatic. -/
-theorem anonreal_implies_paradigmatic :
-    (allData.filter (fun d =>
-      d.asymmetrySubtype == .realityStatus ||
-      d.asymmetrySubtype == .finAndNonReal ||
-      d.asymmetrySubtype == .nonRealAndCat)).all
-      (fun d => d.asymmetryDimensions.contains .paradigmatic) = true := by
-  decide
-
-/-- A/NonReal asymmetry in our sample is never constructional.
-    Note: this is a sample limitation (we have only 1 A/NonReal language).
-    [miestamo-2005] (p. 96) reports that "both constructional and
-    paradigmatic asymmetry is commonly found in type A/NonReal", with 8 of
-    23 A/NonReal languages showing constructional asymmetry (Table 5). -/
-theorem anonreal_never_constructional :
-    (allData.filter (fun d =>
-      d.asymmetrySubtype == .realityStatus)).all
-      (fun d => !d.asymmetryDimensions.contains .constructional) = true := by
-  decide
-
-/-- Symmetric-only negation never has paradigmatic asymmetry.
-    By definition: if the paradigm is unchanged, negation is symmetric. -/
-theorem symmetric_no_paradigmatic :
-    (allData.filter (·.symmetry == .symmetric)).all
-      (fun d => !d.asymmetryDimensions.contains .paradigmatic) = true := by
-  decide
-
-/-! ## Bridge to auxiliary verb literature -/
+/-! ### The negative auxiliary -/
 
 section NegAuxBridge
 

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -63,11 +63,9 @@ marker-side data; they live in `Fragments/{Lang}/PolarityItems.lean`.
 * [jin-koenig-2021]
 -/
 
-set_option autoImplicit false
+namespace Syntax.Negation
 
 open Morphology (Morph)
-
-namespace Syntax.Negation
 
 /-! ### Markers and negation systems -/
 


### PR DESCRIPTION
Deep audit of `Studies/Miestamo2005.lean` (694 → 440 lines), plus the substrate finding it turned up. Every locator was checked against the book PDF and all hold (Table 3's 179/72/76/31, Table 5's 45/23/4/59, the 44-of-45 and 8-of-23 figures, Mandarin ex. 51) — what was wrong is the theorem inventory.

- Cut six "structural sanity" theorems that `decide` over the file's own hand-typed table: they check the typist, not the theory, and one docstring conceded it held "by definition".
- Cut four sample-artifact universals. `anonreal_never_constructional` was the worst: its own docstring records that the book reports 8 of 23 A/NonReal languages *are* constructional, so the theorem asserted what the source denies, from a one-language sample.
- Cut the stipulated survey counts (`SurveyDistribution`, `SubtypeDistribution`) and the arithmetic proved over them — `76 > 72` from constants the file wrote down. The verified figures are now prose in the module docstring.
- Cut five per-language `rfl` restatements of table rows, a cross-module string check, and `asymmetryDescription`, which repeated each datum's docstring.
- Deleted `NegationSystem`: twenty fragments constructed one and nothing ever read it, so the type, `ofISO`, and its three WALS lookups were ceremony. Markers stay; a study that wants a language's WALS values calls `Data.WALS` directly. `Syntax/Negation.lean` is down to 157 lines.

Kept in the study: the Appendix III rows, the WALS divergence on English, the eight Fragment cross-validation theorems, and the AVC bridge.