### PR TITLE
refactor(Syntax/Negation): delete the unread NegationSystem bundle

### DIFF
--- a/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
+++ b/Linglib/Fragments/Arabic/ModernStandard/Negation.lean
@@ -5,21 +5,19 @@ import Linglib.Syntax.Negation
 
 The MSA standard-negation inventory — four preverbal particles (*laa*, *lam*,
 *lan*, *maa*) plus the inflecting copular verb *lays-a* 'to not be' — typed
-against `Syntax.Negation` and bundled into a `NegationSystem`.
+against `Syntax.Negation`.
 
 ## Main definitions
 
 * `negMarkers` — the five sentential negators.
-* `negationSystem` — markers plus WALS Ch 112A/143A/144A datapoints (`ofISO "arb"`).
 
 ## Implementation notes
 
 *lam* / *lan* condition a mood shift (jussive / subjunctive) on an otherwise
 finite verb, and *lays-a* supplies a finite copula where the affirmative is
 verbless. MSA (`arb`) is absent from [miestamo-2005] and from WALS
-Ch 113A/114A (which carry only Egyptian `arz`), so no symmetric/asymmetric
-coding is recorded here; the position fields (Ch 143A/144A) are WALS-pulled
-by `NegationSystem.ofISO`.
+Ch 113A/114A, which carry only Egyptian `arz`, so no symmetric/asymmetric
+coding is recorded here.
 
 ## References
 
@@ -49,10 +47,5 @@ def negMarkers : List Marker :=
   , { morphs := [.free "lays-a"]
     , gloss := "NEG.COP" }
   ]
-
-/-- Bundled `NegationSystem` (markers + WALS Ch 112A/143A/144A datapoints
-    pulled from `Data.WALS` by ISO code `arb`). -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "arb" negMarkers
 
 end Arabic.ModernStandard.Negation

--- a/Linglib/Fragments/Burmese/Negation.lean
+++ b/Linglib/Fragments/Burmese/Negation.lean
@@ -46,10 +46,6 @@ def negSuffix : String := "-bu"
 def circumfix : Marker :=
   { morphs := [.pref "ma", .suff "bu"] }
 
-/-- The Burmese negation system: a single bipartite circumfix. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "mya" [circumfix]
-
 /-- A Burmese negation paradigm entry showing TAM neutralization. -/
 structure NegParadigmEntry where
   tamLabel : String

--- a/Linglib/Fragments/English/Negation.lean
+++ b/Linglib/Fragments/English/Negation.lean
@@ -40,10 +40,6 @@ def not : Marker :=
     treat *not* as the canonical entry. -/
 def negContracted : String := "n't"
 
-/-- The English negation system: a single preverbal particle. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "eng" [not]
-
 /-- An English negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Finnish/Negation.lean
+++ b/Linglib/Fragments/Finnish/Negation.lean
@@ -47,14 +47,6 @@ open Syntax.Negation
 def ei : Marker :=
   { morphs := [.free "ei"] }
 
-/-- The Finnish negation system: a single negative auxiliary with a
-    person/number paradigm. Multiple paradigm-form *surface* realizations
-    (`negParadigm`) are not multiple *markers* — they're inflectional
-    variants of one auxiliary, captured cross-linguistically by the single
-    `Marker`. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "fin" [ei]
-
 /-! ### Negative auxiliary paradigm -/
 
 /-- Person–number features for the Finnish negative auxiliary. -/

--- a/Linglib/Fragments/German/Negation.lean
+++ b/Linglib/Fragments/German/Negation.lean
@@ -44,10 +44,6 @@ def nicht : Marker :=
     non-NC languages is a separate axis from the operator. -/
 def negDeterminer : String := "kein"
 
-/-- The German negation system: a single particle. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "deu" [nicht]
-
 /-- A negation example showing symmetric structure. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Greek/StandardModern/Negation.lean
+++ b/Linglib/Fragments/Greek/StandardModern/Negation.lean
@@ -86,12 +86,6 @@ def dhenMarker : Syntax.Negation.Marker :=
 def minMarker : Syntax.Negation.Marker :=
   { morphs := [.free "min"] }
 
-/-- The Greek negation system: two mood-conditioned preverbal particles.
-    *dhen* (indicative, default-context) listed first, *min* (subjunctive/
-    modal) second. -/
-def negationSystem : Syntax.Negation.NegationSystem :=
-  Syntax.Negation.NegationSystem.ofISO "ell" [dhenMarker, minMarker]
-
 /-! ### Semantics -/
 
 /-- Semantics of *dhen*: standard truth-functional negation.

--- a/Linglib/Fragments/Hixkaryana/Negation.lean
+++ b/Linglib/Fragments/Hixkaryana/Negation.lean
@@ -30,10 +30,6 @@ open Syntax.Negation
 def hira : Marker :=
   { morphs := [.suff "hira"] }
 
-/-- The Hixkaryana negation system: a single deverbalizing suffix. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "hix" [hira]
-
 /-- A Hixkaryana negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Italian/Negation.lean
+++ b/Linglib/Fragments/Italian/Negation.lean
@@ -3,9 +3,8 @@ import Linglib.Syntax.Negation
 /-! # Italian Negation Fragment
 [haspelmath-2013] [dryer-2013-wals] [zanuttini-1997] [cinque-1999]
 
-Italian sentential negation: the standard preverbal negation particle *non*
-and its packaging as a `NegationSystem`. The marker is a free particle
-in preverbal position; WALS Ch 143A classifies Italian as `.negv`.
+Italian sentential negation: the standard preverbal negation particle *non*,
+a free particle in preverbal position; WALS Ch 143A classifies Italian as `.negv`.
 Italian object clitics attach between *non* and the verb (*non lo vedo*,
 not **lo non vedo*) — the canonical syntactic analysis is
 [zanuttini-1997]'s NegP cartography, refined by [cinque-1999]'s
@@ -44,12 +43,6 @@ open Syntax.Negation
     A free word, not a clitic; syntactically immediately preverbal. -/
 def non : Marker :=
   { morphs := [.free "non"] }
-
-/-- The Italian negation system: a single preverbal particle.
-    WALS classifications are pulled from `Data/WALS/Features/F112A.lean`
-    et al. via `NegationSystem.ofISO` — never hand-encoded. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "ita" [non]
 
 /-! ## Expletive Negation
 [jin-koenig-2021]

--- a/Linglib/Fragments/Januubi/Negation.lean
+++ b/Linglib/Fragments/Januubi/Negation.lean
@@ -57,12 +57,6 @@ def maa : Marker :=
 /-- The standard sentential negation marker in Januubi Arabic. -/
 def standardNeg : String := maa.form
 
-/-- The Januubi negation system: a single particle.
-    No WALS datapoint for Januubi-specific dialect; the lookup returns
-    `none` and the WALS fields stay unset. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "" [maa]
-
 /-! ### Expletive negation markers -/
 
 /-- An expletive negation marker used in a specific trigger context. -/

--- a/Linglib/Fragments/Japanese/Negation.lean
+++ b/Linglib/Fragments/Japanese/Negation.lean
@@ -47,11 +47,6 @@ open Syntax.Negation
 def negSuffix : Marker :=
   { morphs := [.suff "nai"] }
 
-/-- The Japanese negation system: a single verbal affix with rich
-    morphological redistribution (see `japaneseNegDistribution`). -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "jpn" [negSuffix]
-
 /-- A Japanese negation paradigm entry. -/
 structure NegParadigmEntry where
   formLabel : String

--- a/Linglib/Fragments/Mandarin/Negation.lean
+++ b/Linglib/Fragments/Mandarin/Negation.lean
@@ -50,12 +50,6 @@ def bu : Marker :=
 def mei : Marker :=
   { morphs := [.free "méi"] }
 
-/-- The Mandarin negation system: two aspect-conditioned markers.
-    *bù* (default, non-perfective) listed first per the ordering
-    convention in `NegationSystem`; *méi* second. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "cmn" [bu, mei]
-
 /-- A Mandarin negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Maori/Negation.lean
+++ b/Linglib/Fragments/Maori/Negation.lean
@@ -37,10 +37,6 @@ open Syntax.Negation
 def kahore : Marker :=
   { morphs := [.free "kāhore"] }
 
-/-- The Maori negation system: a single quasi-auxiliary word. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "mri" [kahore]
-
 /-- A Maori negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Quechua/Negation.lean
+++ b/Linglib/Fragments/Quechua/Negation.lean
@@ -45,10 +45,6 @@ def mana : Marker :=
     ([miestamo-2005] p. 158). -/
 def chuSuffix : String := "-chu"
 
-/-- The Imbabura Quechua negation system: a single preverbal particle. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "qvi" [mana]
-
 /-- An Imbabura Quechua negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Romance/French/Negation.lean
+++ b/Linglib/Fragments/Romance/French/Negation.lean
@@ -55,12 +55,6 @@ def pasReinforcer : String := "pas"
 def bipartite : Marker :=
   { morphs := [.procl "ne", .free "pas"] }
 
-/-- The French negation system: a single bipartite construction.
-    *Length-1* `markers` list — *ne* and *pas* are not alternative
-    markers but two morphemes of one bipartite construction. The -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "fra" [bipartite]
-
 /-- A French negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Slavic/Czech/Negation.lean
+++ b/Linglib/Fragments/Slavic/Czech/Negation.lean
@@ -33,10 +33,6 @@ open Syntax.Negation
 def ne : Marker :=
   { morphs := [.pref "ne"] }
 
-/-- The Czech negation system: a single verbal prefix. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "ces" [ne]
-
 /-- Legacy String accessor for the prefix. Kept for back-compat with
     `Studies/Miestamo2005.lean`. New consumers should
     use `ne.form`. -/

--- a/Linglib/Fragments/Slavic/Russian/Negation.lean
+++ b/Linglib/Fragments/Slavic/Russian/Negation.lean
@@ -32,10 +32,6 @@ open Syntax.Negation
 def ne : Marker :=
   { morphs := [.free "не"] }
 
-/-- The Russian negation system: a single preverbal particle. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "rus" [ne]
-
 /-- A Russian negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Spanish/Negation.lean
+++ b/Linglib/Fragments/Spanish/Negation.lean
@@ -44,10 +44,6 @@ open Syntax.Negation
 def no : Marker :=
   { morphs := [.free "no"] }
 
-/-- The Spanish negation system: a single preverbal particle. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "spa" [no]
-
 /-- A Spanish negation example. -/
 structure NegExample where
   affirmative : String

--- a/Linglib/Fragments/Tigrinya/Negation.lean
+++ b/Linglib/Fragments/Tigrinya/Negation.lean
@@ -36,7 +36,4 @@ def n : Morph := .suff "n"
 def circumfix : Marker where
   morphs := [aj, n]
 
-/-- Tigrinya standard negation: the single bipartite marker. -/
-def negationSystem : NegationSystem := .ofISO "tir" [circumfix]
-
 end Tigrinya.Negation

--- a/Linglib/Fragments/Turkish/Negation.lean
+++ b/Linglib/Fragments/Turkish/Negation.lean
@@ -42,13 +42,6 @@ open Syntax.Negation
 def negSuffix : Marker :=
   { morphs := [.suff "mA"] }
 
-/-- Turkish standard (verbal) negation: a single verbal affix.
-    Nonverbal predication negates with copular *değil* and the
-    existential with suppletive *yok* (for *var*), both outside
-    standard negation in [miestamo-2005]'s sense. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "tur" [negSuffix]
-
 /-- A Turkish negation paradigm entry. -/
 structure NegParadigmEntry where
   formLabel : String

--- a/Linglib/Fragments/ZarmaSonrai/Negation.lean
+++ b/Linglib/Fragments/ZarmaSonrai/Negation.lean
@@ -58,12 +58,6 @@ def mana : Marker :=
 def batu : Marker :=
   { morphs := [.free "batu"] }
 
-/-- The Zarma-Sonrai negation system: three aspect-conditioned markers.
-    *si* (imperfective) listed first per ordering convention; the two
-    perfective variants follow. -/
-def negationSystem : NegationSystem :=
-  NegationSystem.ofISO "dje" [si, mana, batu]
-
 /-- Legacy String accessors (used by `enNegatorForAspect` in this file). -/
 def ipfvNeg : String := si.form
 def pfvNeg : String := mana.form

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -1,8 +1,5 @@
-import Linglib.Data.WALS.Datapoint
 import Linglib.Data.WALS.Features.F112A
 import Linglib.Data.WALS.Features.F114A
-import Linglib.Data.WALS.Features.F143A
-import Linglib.Data.WALS.Features.F144A
 import Linglib.Syntax.Category.Auxiliary.Constructions
 import Linglib.Features.Grammaticalization
 import Linglib.Morphology.Morph
@@ -25,8 +22,6 @@ classifying them, with per-ISO access to the WALS negation chapters.
 ## Main declarations
 
 * `Marker`: a standard negation marker, as the morphs exponing it.
-* `NegationSystem`: a language's markers keyed by ISO 639-3 code, with
-  its WALS Ch 112A/143A/144A values derived from that key.
 * `Strategy`: negative verb, affix, or particle — the grain at which
   negation meets auxiliary-verb constructions and the
   grammaticalization cline.
@@ -37,9 +32,8 @@ classifying them, with per-ISO access to the WALS negation chapters.
 ## Implementation notes
 
 The WALS chapters are the source of truth for the typological values, so
-the accessors return the `Data.WALS` enums rather than re-labelled
-copies, and `NegationSystem` derives its datapoints from the ISO code
-rather than storing them. An analysis reaching beyond WALS keeps its own
+the accessor returns the `Data.WALS` enum rather than a re-labelled
+copy. An analysis reaching beyond WALS keeps its own
 vocabulary in its study: [miestamo-2005]'s asymmetry subtypes, which
 separate an emphasis subtype the atlas does not encode, live in
 `Studies/Miestamo2005.lean`.
@@ -55,7 +49,7 @@ marker-side data; they live in `Fragments/{Lang}/PolarityItems.lean`.
 
 ## References
 
-* [dryer-2013-wals], Ch 112A, 143A
+* [dryer-2013-wals], Ch 112A
 * [miestamo-2013], Ch 114A
 * [miestamo-2005]
 * [anderson-2006], §1.7.2
@@ -82,38 +76,6 @@ structure Marker where
 /-- The surface form of a marker: its morphs with boundary notation,
 discontinuous pieces separated by `…`. -/
 def Marker.form (m : Marker) : String := toString m.morphs
-
-/-- A language's standard negation system: the marker or markers, keyed
-by ISO 639-3 code.
-
-Several markers handle mood-, aspect- or lexical-class-conditioned
-alternation (Greek, Mandarin, Korean); most languages have one. -/
-structure NegationSystem where
-  /-- ISO 639-3 code, the key for the language's WALS values. -/
-  iso : String := ""
-  /-- The negation marker(s), unmarked context first. -/
-  markers : List Marker
-  deriving Repr
-
-/-- WALS Ch 112A: the language's negative-morpheme classification. -/
-def NegationSystem.wals112A (s : NegationSystem) :
-    Option Data.WALS.F112A.NegativeMorphemeType :=
-  (Data.WALS.F112A.lookupISO s.iso).map (·.value)
-
-/-- WALS Ch 143A: the order of negative morpheme and verb. -/
-def NegationSystem.wals143A (s : NegationSystem) :
-    Option Data.WALS.F143A.NegVerbOrder :=
-  (Data.WALS.F143A.lookupISO s.iso).map (·.value)
-
-/-- WALS Ch 144A: the negative word's position relative to subject,
-object and verb. -/
-def NegationSystem.wals144A (s : NegationSystem) :
-    Option Data.WALS.F144A.PositionOfNegativeWordWithRespectToSubjectObjectAndVerb :=
-  (Data.WALS.F144A.lookupISO s.iso).map (·.value)
-
-/-- The negation system of the language with the given ISO 639-3 code. -/
-def NegationSystem.ofISO (iso : String) (markers : List Marker) : NegationSystem :=
-  { iso, markers }
 
 /-! ### Per-language WALS values -/
 


### PR DESCRIPTION
Twenty `Fragments/*/Negation.lean` files each built a `NegationSystem`, and nothing anywhere read one — not the type, not `ofISO`, not the three WALS lookups derived from its ISO key. A bundle with no laws and no readers, so it goes; the `Marker` defs it wrapped stay, and a study wanting a language's WALS negation values calls `Data.WALS` directly, as `Studies/Miestamo2005.lean` already does.

`Syntax/Negation.lean` drops to 157 lines and no longer needs the F143A/F144A/Datapoint imports. Fragment docstrings advertising the bundle are updated; one of them (Januubi) was passing an empty ISO string, so its lookups had always returned `none`.