### PR TITLE
refactor(Studies/Anderson2006): cut restatements and edit-history docstrings

### DIFF
--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -16,98 +16,42 @@ import Linglib.Data.Examples.Anderson2006
 
 /-!
 # Anderson (2006): Auxiliary Verb Constructions
-[anderson-2006] [heine-1993]
 
-Cross-linguistic typology of auxiliary verb constructions (AVCs):
-classification by inflectional distribution between auxiliary and
-lexical verb, with diachronic grounding in [heine-1993]'s
-grammaticalization framework.
+An auxiliary verb construction pairs an auxiliary with a lexical verb, and
+languages differ in where the inflection lands: on the auxiliary (English
+*have eaten*), on the lexical verb (Doyayo), on both (Gorum), split between
+them (Jakaltek puts absolutive agreement on the auxiliary and ergative on
+the lexical verb), or split with some categories doubled (Pipil, Hemba).
+The lexical verb stays the semantic head throughout, and that mismatch
+between where meaning sits and where inflection sits is what makes AVCs
+typologically distinctive. Chapter 7 places the constructions on
+[heine-1993]'s grammaticalization cline.
 
-## Key contributions formalized
+Formalized here: nine datums across seven languages covering all five
+patterns, each recording which categories the auxiliary and the lexical
+verb host; the chapter 5 generalization that subject agreement doubles
+while object agreement stays on the lexical verb; negative auxiliaries as
+AVCs, with Kwerba as the counterexample to the verbal-negator
+tendency; and the compositions with [sorace-2000]'s auxiliary selection
+and [miestamo-2005]'s morpheme typology.
 
-1. **Inflectional pattern typology** (`InflPattern` from substrate):
-   auxHeaded, lexHeaded, doubled, split, splitDoubled — defined in
-   `Typology/AuxiliaryVerbs.lean`, verified per-datum here.
-2. **Semantic head invariant** (Anderson p. 23, Table 3.1 p. 116):
-   the lexical verb is always the semantic head, regardless of where
-   inflection sits.
-3. **Typed inflectional distribution**: `InflDistribution`
-   (study-local) records which `MorphCategory` values each
-   element hosts.
-4. **Grammaticalization grounding**: Anderson ch. 7 traces AVCs
-   onto Heine 1993's cline (Anderson p. 5: *"According to Heine
-   (1993: 48ff.)..."*). The cline lives in
-   `Features/Grammaticalization.lean`, anchored on
-   [heine-1993] ch. 3.
+## References
 
-## Coverage
-
-Sample of 9 AVC datums across 7 languages, covering all 5 patterns:
-
-- English *have eaten* (aux-headed) — Anderson ch. 2 canonical example
-- Doyayo lex-headed (Anderson ch. 3 ex. 15a, p. 121)
-- Doyayo split/doubled (Anderson ch. 5 ex. 129, p. 223)
-- Gorum (doubled)
-- Jakaltek (split, abs/erg)
-- Pipil split/doubled (Anderson ch. 5 ex. 133, p. 224)
-- Pipil lex-headed (Anderson ch. 3 ex. 49, p. 130, with *weli*)
-- Finnish split (negative auxiliary *ei*) [karlsson-2017]
-- Hemba split/doubled
-
-## 2026-04-30 audit fixes
-
-PDF-verified against Anderson 2006 (book pp. 5, 114, 116, 121, 224)
-and Heine 1993 (book p. 48ff. via Anderson p. 5):
-
-- **Doyayo `.split` → `.lexHeaded`** (Ch 3 ex. 15a) + new
-  `doyayoSplitDoubled` (Ch 5 ex. 129). Anderson never classifies
-  Doyayo as plain split.
-- **Pipil `.split` → `.splitDoubled`** (Ch 5 ex. 133, with subjects
-  doubly marked). Fragment `splitDistribution` corrected to put
-  `.agreement` on AUX (matches the gloss `1-AUX 1-2PL-show`).
-- **Cline reattributed to [heine-1993]** (Anderson p. 5
-  explicitly cites Heine 1993:48ff.).
-- **`negStrategyStage`** is now `Strategy.toGramStage :
-  Strategy → Option GramStage` (in `Syntax/Negation.lean`), with
-  `.negParticle => none` (not on the verbal cline) — fixes the
-  earlier formaliser-introduced collapse of [miestamo-2005]'s
-  particle-vs-verb distinction.
-- **Dropped Table 2.3 reference**: Anderson's Table 2.3 (p. 114)
-  catalogs *non-finite forms within AUX-headed AVCs* (a single-
-  pattern grid of language exemplars), not a cross-pattern
-  prediction. The pattern→LV-form prediction lives in Ch 2-5
-  prose, not in any single table.
-- **English exemplar**: switched from *will go* (modal) to *have
-  eaten* (perfect) as Anderson's canonical Ch 2 AUX-headed
-  example; gloss corrected from FUT (non-Andersonian for *will*)
-  to AUX.PRS + PTCP.
-- **9× `native_decide` → `decide`**: structural reduction is
-  tractable; native_decide bypasses the kernel.
-- **`finnish_form_from_paradigm`**: paired with
-  `finnish_1sg_in_paradigm` witness lemma, now provably
-  grounded in the Fragment paradigm rather than passing through
-  the dead `none` fallback branch.
-- **Sorace bridge** chains through [sorace-2000]'s
-  `vendlerClassToTypicalTransitivity` for a 2-step Vendler
-  → TransitivityClass derivation.
-- **Cross-framework theorem** `anderson_miestamo_agree_on_neg_morphology`
-  documents the corrected mapping that preserves Miestamo's
-  particle-vs-verb distinction.
+* [anderson-2006], §1.4, §1.7.2, chs. 2–5, ch. 7
+* [heine-1993], ch. 3
+* [karlsson-2017], §19.5
 -/
-
 namespace Anderson2006
 
 open AuxiliaryVerbs
 open ArgumentStructure.AuxiliarySelection
 open Syntax.Negation (Strategy)
 
-/-! ## Inflectional distribution (study-local apparatus)
+/-! ### Inflectional distribution
 
-Demoted from the former `Morphology/Periphrasis.lean` at the
-single-consumer bar: this study is the sole terminal of every
-distribution value. Possessing a distribution is neutral on
-periphrasis-hood ([spencer-popova-2015] pp. 200, 204); the data is the
-raw material for the distributed-exponence criterion. -/
+Possessing a distribution is neutral on periphrasis-hood
+([spencer-popova-2015] pp. 200, 204); the data is the raw material for
+the distributed-exponence criterion. -/
 
 open Morphology (MorphCategory)
 
@@ -166,21 +110,9 @@ def finnishNegDist : InflDistribution :=
   { onAux := [.negation, .tense, .agreement .subj]
   , onLex := [.stem, .aspect] }
 
-/-- Hemba: agreement doubled, tense split to AUX, mood split to LV —
-    the split/doubled pattern read directly off the distribution. -/
-theorem hemba_split_doubled_shape :
-    hembaDist.onAux.contains (.agreement .subj) = true ∧
-    hembaDist.onLex.contains (.agreement .subj) = true ∧
-    hembaDist.onAux.contains .tense = true ∧
-    hembaDist.onLex.contains .tense = false ∧
-    hembaDist.onAux.contains .mood = false ∧
-    hembaDist.onLex.contains .mood = true := by
-  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
-
 /-- The Finnish distribution is consistent with [miestamo-2005]'s
     constructional A/Fin coding: categories split across the negative
-    auxiliary and the main verb (moved here from the Miestamo file —
-    the cross-paper comparison belongs to the later study). -/
+    auxiliary and the main verb. -/
 theorem finnish_split_confirms_constructional :
     finnishNegDist.onAux.length > 0 ∧ finnishNegDist.onLex.length > 0 ∧
     Miestamo2005.finnish.asymmetryDimensions.contains .constructional := by
@@ -193,11 +125,10 @@ structure AVCDatum where
   language : String
   form : String
   inflPattern : InflPattern
-  distribution : Option InflDistribution := none
   gloss : String := ""
   deriving Repr, BEq
 
-/-! ## Per-language AVC data
+/-! ### Per-language AVC data
 
 The 9 sample datums (7 languages) covering all 5 of Anderson's
 inflectional patterns. Per-datum verification theorems below ensure
@@ -226,7 +157,6 @@ def doyayo : AVCDatum :=
   { language := "Doyayo"
   , form := Doyayo.AuxiliaryVerbs.lexHeadedForm
   , inflPattern := .lexHeaded
-  , distribution := some doyayoLexHeadedDist
   , gloss := Doyayo.AuxiliaryVerbs.lexHeadedGloss }
 
 /-- Doyayo split/doubled (Anderson Ch 5 ex. 129, p. 223).
@@ -237,7 +167,6 @@ def doyayoSplitDoubled : AVCDatum :=
   { language := "Doyayo"
   , form := Doyayo.AuxiliaryVerbs.splitDoubledForm
   , inflPattern := .splitDoubled
-  , distribution := some doyayoSplitDoubledDist
   , gloss := Doyayo.AuxiliaryVerbs.splitDoubledGloss }
 
 /-- Gorum (doubled): subject + TAM on both AUX and LV.
@@ -246,7 +175,6 @@ def gorum : AVCDatum :=
   { language := "Gorum"
   , form := Gorum.AuxiliaryVerbs.form
   , inflPattern := .doubled
-  , distribution := some gorumDist
   , gloss := Gorum.AuxiliaryVerbs.gloss }
 
 /-- Jakaltek (split): absolutive on AUX, ergative on LV.
@@ -255,7 +183,6 @@ def jakaltek : AVCDatum :=
   { language := "Jakaltek"
   , form := Jakaltek.AuxiliaryVerbs.form
   , inflPattern := .split
-  , distribution := some jakaltekDist
   , gloss := Jakaltek.AuxiliaryVerbs.gloss }
 
 /-- Pipil split/doubled (Anderson Ch 5 ex. 133b, p. 224).
@@ -268,7 +195,6 @@ def pipilSplitDoubled : AVCDatum :=
   { language := "Pipil"
   , form := Pipil.AuxiliaryVerbs.splitDoubledForm
   , inflPattern := .splitDoubled
-  , distribution := some pipilSplitDoubledDist
   , gloss := Pipil.AuxiliaryVerbs.splitDoubledGloss }
 
 /-- Pipil lex-headed (Anderson ch. 3 ex. 49, p. 130; Campbell 1985: 139).
@@ -281,7 +207,6 @@ def pipilLexHeaded : AVCDatum :=
   { language := "Pipil"
   , form := Pipil.AuxiliaryVerbs.lexHeadedForm
   , inflPattern := .lexHeaded
-  , distribution := some pipilLexHeadedDist
   , gloss := Pipil.AuxiliaryVerbs.lexHeadedGloss }
 
 /-- Finnish negative auxiliary *ei* (split): person/number on aux,
@@ -297,18 +222,13 @@ def pipilLexHeaded : AVCDatum :=
     The split nature derives from `finnishNegDist`:
     the negative auxiliary hosts negation, tense, and agreement, while
     the lexical verb retains stem and aspect.
-    The 1sg neg-aux form derives from `negParadigm`; see the
-    `finnish_1sg_form_eq` witness lemma for the strong pinning of
-    the form-construction. Gloss style follows Anderson's Uralic
-    convention (`Neg-1 read-conneg`). -/
+    The 1sg form is read out of `negParadigm`; gloss style follows
+    Anderson's Uralic convention (`Neg-1 read-conneg`). -/
 def finnish : AVCDatum :=
   { language := "Finnish"
-  , form := match Finnish.Negation.negParadigm.find?
-      (fun f => f.person == 1 && f.number == "sg") with
-    | some f => f.form ++ " lue"
-    | none => "en lue"
+  , form := (Finnish.Negation.negParadigm.find?
+      (fun f => f.person == 1 && f.number == "sg")).elim "" (·.form ++ " lue")
   , inflPattern := .split
-  , distribution := some finnishNegDist
   , gloss := "Neg-1 read-conneg" }
 
 /-- Hemba split/doubled: subject doubled on both AUX and LV; tense
@@ -318,7 +238,6 @@ def hemba : AVCDatum :=
   { language := "Hemba"
   , form := Hemba.AuxiliaryVerbs.form
   , inflPattern := .splitDoubled
-  , distribution := some hembaDist
   , gloss := Hemba.AuxiliaryVerbs.gloss }
 
 /-- All 9 AVC datums (covering all 5 of Anderson's patterns). -/
@@ -326,72 +245,16 @@ def allData : List AVCDatum :=
   [english, doyayo, doyayoSplitDoubled, gorum, jakaltek,
    pipilSplitDoubled, pipilLexHeaded, finnish, hemba]
 
-/-! ## Per-datum InflPattern verification
+/-- The sample instantiates every one of Anderson's five patterns. -/
+theorem all_patterns_attested (p : InflPattern) :
+    ∃ d ∈ allData, d.inflPattern = p := by
+  cases p <;> decide
 
-Each theorem below is a structural drift sentry: changing a
-Fragment entry's underlying analysis breaks exactly one theorem. -/
-
-theorem english_is_auxHeaded : english.inflPattern = .auxHeaded := rfl
-theorem doyayo_is_lexHeaded : doyayo.inflPattern = .lexHeaded := rfl
-theorem doyayoSplitDoubled_is_splitDoubled :
-    doyayoSplitDoubled.inflPattern = .splitDoubled := rfl
-theorem gorum_is_doubled : gorum.inflPattern = .doubled := rfl
-theorem jakaltek_is_split : jakaltek.inflPattern = .split := rfl
-theorem pipilSplitDoubled_is_splitDoubled :
-    pipilSplitDoubled.inflPattern = .splitDoubled := rfl
-theorem pipilLexHeaded_is_lexHeaded : pipilLexHeaded.inflPattern = .lexHeaded := rfl
-theorem finnish_is_split : finnish.inflPattern = .split := rfl
-theorem hemba_is_splitDoubled : hemba.inflPattern = .splitDoubled := rfl
-
-/-! ## Per-datum form/distribution Fragment grounding -/
-
-theorem doyayo_form_from_fragment :
-    doyayo.form = Doyayo.AuxiliaryVerbs.lexHeadedForm := rfl
-theorem doyayoSplitDoubled_form_from_fragment :
-    doyayoSplitDoubled.form = Doyayo.AuxiliaryVerbs.splitDoubledForm := rfl
-theorem gorum_form_from_fragment :
-    gorum.form = Gorum.AuxiliaryVerbs.form := rfl
-theorem jakaltek_form_from_fragment :
-    jakaltek.form = Jakaltek.AuxiliaryVerbs.form := rfl
-theorem pipilSplitDoubled_form_from_fragment :
-    pipilSplitDoubled.form = Pipil.AuxiliaryVerbs.splitDoubledForm := rfl
-theorem pipilLexHeaded_form_from_fragment :
-    pipilLexHeaded.form = Pipil.AuxiliaryVerbs.lexHeadedForm := rfl
-theorem hemba_form_from_fragment :
-    hemba.form = Hemba.AuxiliaryVerbs.form := rfl
-
-/-! ## Finnish form construction grounding
-
-The Finnish form construction uses `negParadigm.find?`, which is
-`Option`-typed. The fallback `| none => "en lue"` was historically
-chosen to coincide with the success-branch result, making
-`finnish.form = "en lue"` pass by `rfl` even when the lookup
-*would* return `none`. The witness theorem below grounds the
-construction in the actual paradigm content. -/
-
-/-- The Finnish 1sg negative-auxiliary entry exists in `negParadigm`. -/
-theorem finnish_1sg_in_paradigm :
-    (Finnish.Negation.negParadigm.find?
-      (fun f => f.person == 1 && f.number == "sg")).isSome = true := by
-  decide
-
-/-- Strong pinning: the 1sg paradigm entry's form is exactly `"en"`.
-    Together with `finnish_1sg_in_paradigm`, this pins `finnish.form`
-    to the Fragment's actual paradigm content. A future change to
-    `negParadigm` that altered the 1sg form (or removed the entry
-    entirely) would break this theorem; the dead-branch `| none =>
-    "en lue"` fallback in `finnish.form` cannot mask the change. -/
-theorem finnish_1sg_form_eq :
-    (Finnish.Negation.negParadigm.find?
-      (fun f => f.person == 1 && f.number == "sg")).map (·.form)
-      = some "en" := by
-  decide
-
-/-- The Finnish form is the 1sg `negParadigm` entry's form
-    concatenated with `" lue"`. -/
+/-- The 1sg entry of `negParadigm` builds the form: a change to that
+    entry leaves `finnish.form` empty and breaks this. -/
 theorem finnish_form_from_paradigm : finnish.form = "en lue" := rfl
 
-/-! ## Connection to Finnish Fragment -/
+/-! ### The Finnish negative AVC -/
 
 /-- The Finnish negative auxiliary construction is a split AVC: the
     auxiliary hosts some inflectional categories and the lexical
@@ -401,23 +264,7 @@ theorem finnish_split_from_fragment :
     dist.onAux ≠ [] ∧ dist.onLex ≠ [] := by
   exact ⟨by decide, by decide⟩
 
-/-! ## Pattern coverage (named witnesses)
-
-All five of Anderson's inflectional patterns are attested in the
-sample. Each pattern is witnessed by a *named* datum (existence by
-witness, not aggregate `.any`-scan). Adding a new datum doesn't
-break this theorem; changing one of the named witnesses' patterns
-does. -/
-
-theorem five_patterns_attested :
-    english.inflPattern = .auxHeaded ∧
-    doyayo.inflPattern = .lexHeaded ∧
-    gorum.inflPattern = .doubled ∧
-    jakaltek.inflPattern = .split ∧
-    hemba.inflPattern = .splitDoubled := by
-  exact ⟨rfl, rfl, rfl, rfl, rfl⟩
-
-/-! ## Structural theorems on distribution -/
+/-! ### Where the inflection sits -/
 
 /-- In Gorum's doubled AVC, aux and lex host exactly the same categories. -/
 theorem gorum_doubled_same_categories :
@@ -431,11 +278,9 @@ theorem doyayo_lexHeaded_aux_agreement_only :
     doyayoLexHeadedDist.onLex = [.tense] := by
   exact ⟨rfl, rfl⟩
 
-/-- **Anderson Ch 5 §5.2 payoff (Doyayo)**: subject agreement is
-    doubled across AUX and LV; object agreement appears on LV only.
-    Now Lean-checkable directly via `Controller`-typed `.agreement`,
-    rather than via the fragile list-length encoding the 0.230.578
-    workaround used. -/
+/-- Chapter 5 (Doyayo): subject agreement is doubled across auxiliary
+    and lexical verb, while object agreement appears on the lexical verb
+    only. -/
 theorem doyayo_splitDoubled_subj_doubled_obj_lex_only :
     let dist := doyayoSplitDoubledDist
     dist.onAux.contains (.agreement .subj) = true ∧
@@ -444,10 +289,9 @@ theorem doyayo_splitDoubled_subj_doubled_obj_lex_only :
     dist.onAux.contains (.agreement .obj) = false := by
   exact ⟨by decide, by decide, by decide, by decide⟩
 
-/-- **Anderson Ch 5 §5.2 payoff (Pipil)**: same generalization as
-    Doyayo — subject doubled across AUX and LV, object on LV only.
-    The AUX root *yu* itself encodes TAM lexically (no separate
-    `.tense` morpheme on AUX). -/
+/-- Chapter 5 (Pipil): the same generalization as Doyayo. The auxiliary
+    root *yu* encodes TAM lexically, so no `.tense` morpheme sits on the
+    auxiliary. -/
 theorem pipil_splitDoubled_subj_doubled_obj_lex_only :
     let dist := pipilSplitDoubledDist
     dist.onAux.contains (.agreement .subj) = true ∧
@@ -466,10 +310,8 @@ theorem finnish_split_disjoint :
     let dist := finnishNegDist
     dist.onAux.all (fun c => !dist.onLex.contains c) = true := by decide
 
-/-- **Anderson Ch 5 abs/erg payoff (Jakaltek)**: with role-typed
-    agreement, the absolutive-on-AUX / ergative-on-LV split is now
-    a category-level distinction (`.agreement .obj` vs `.agreement .subj`),
-    not just a within-category meta-comment. -/
+/-- Chapter 5 (Jakaltek): absolutive agreement on the auxiliary,
+    ergative on the lexical verb. -/
 theorem jakaltek_abs_on_aux_erg_on_lex :
     let dist := jakaltekDist
     dist.onAux.contains (.agreement .obj) = true ∧
@@ -492,7 +334,7 @@ theorem hemba_splitDoubled_agreement_doubled :
   exact ⟨by decide, by decide, by decide,
          by decide, by decide, by decide⟩
 
-/-! ## Dual headedness
+/-! ### Dual headedness
 
 Anderson distinguishes three notions of head — inflectional,
 phrasal/syntactic, and semantic (§1.4, pp. 22-24; Table 3.1 on
@@ -510,7 +352,7 @@ theorem heads_coincide_iff_lexHeaded (p : InflPattern) :
     (p.semanticHead == p.inflHost) = (p == .lexHeaded) := by
   cases p <;> rfl
 
-/-! ## Negative auxiliaries as AVCs
+/-! ### Negative auxiliaries as AVCs
 
 [anderson-2006] §1.7.2 (p. 33-34) treats negative auxiliaries
 across multiple AVC patterns: aux-headed in Udihe, Neyo; split in
@@ -547,36 +389,9 @@ theorem komi_tense_on_aux :
     Examples.komi_neg_pres.primaryText ≠ Examples.komi_neg_past.primaryText :=
   ⟨rfl, by decide⟩
 
-/-! ## LV form predictions across patterns
+/-! ### Auxiliary selection
 
-Anderson predicts the verb form of the lexical verb from the
-inflectional pattern. AUX-headed AVCs have a nonfinite LV
-(infinitive/participle/etc.; Anderson Table 2.3 on p. 114
-catalogs the LV non-finite-form types within AUX-headed AVCs
-specifically — the table is a one-pattern grid of language
-exemplars, not a cross-pattern prediction). All other patterns
-have a finite LV (carrying at least some inflection, per Anderson
-chs. 3-5 prose). The pattern→LV-form prediction is formalized in
-`Typology.lvVerbForm`. -/
-
-theorem auxHeaded_predicts_nonfinite_lv :
-    InflPattern.auxHeaded.lvVerbForm = UD.VerbForm.Inf := rfl
-
-theorem lexHeaded_predicts_finite_lv :
-    InflPattern.lexHeaded.lvVerbForm = UD.VerbForm.Fin := rfl
-
-theorem doubled_predicts_finite_lv :
-    InflPattern.doubled.lvVerbForm = UD.VerbForm.Fin := rfl
-
-theorem split_predicts_finite_lv :
-    InflPattern.split.lvVerbForm = UD.VerbForm.Fin := rfl
-
-theorem splitDoubled_predicts_finite_lv :
-    InflPattern.splitDoubled.lvVerbForm = UD.VerbForm.Fin := rfl
-
-/-! ## Bridge to Sorace 2000 (auxiliary selection)
-
-Be/have auxiliary selection (`Typology/AuxiliaryVerbs.lean`) operates
+Be/have auxiliary selection (`Syntax/Category/Auxiliary/Constructions.lean`) operates
 within aux-headed AVCs: the question of *which* auxiliary appears
 presupposes the auxiliary hosts inflection. [sorace-2000]'s
 sister study `Studies/Sorace2000.lean` provides
@@ -610,7 +425,7 @@ theorem sorace_canonical_chain (v : Features.VendlerClass) :
         | _ => .have := by
   cases v <;> rfl
 
-/-! ## Cross-framework: Miestamo 2005 (negation morpheme classification)
+/-! ### Cross-framework: Miestamo's morpheme typology
 
 [miestamo-2005] classifies negation strategies by morpheme
 type (WALS Ch 112A: negative auxiliary verb, affix, particle, ...);
@@ -631,11 +446,7 @@ stage, in any Miestamo A/Fin datum, shows constructional
 asymmetry — a falsifiable empirical prediction whose chain
 runs Anderson's cline → Miestamo's morpheme type → Miestamo's
 asymmetry dimension.
-
-The earlier `anderson_miestamo_agree_on_neg_morphology` theorem
-in this slot (0.230.573) was a stapled conjunction of three
-independent facts; the meta-audit at 0.230.576 replaced it with
-the quantified-equivalence shape below. -/
+ -/
 
 /-- Cross-framework equivalence: Anderson's grammaticalization-cline
     placement at `.auxiliary` and Miestamo's morpheme-type

--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -1,12 +1,7 @@
+import Mathlib.Data.Finset.Basic
 import Linglib.Syntax.Category.Auxiliary.Constructions
 import Linglib.Semantics.ArgumentStructure.AuxiliarySelection
-import Linglib.Fragments.English.Auxiliaries
 import Linglib.Fragments.Finnish.Negation
-import Linglib.Fragments.Doyayo.AuxiliaryVerbs
-import Linglib.Fragments.Gorum.AuxiliaryVerbs
-import Linglib.Fragments.Hemba.AuxiliaryVerbs
-import Linglib.Fragments.Mayan.Jakaltek.AuxiliaryVerbs
-import Linglib.Fragments.Pipil.AuxiliaryVerbs
 import Linglib.Syntax.Negation
 import Linglib.Studies.Sorace2000
 import Linglib.Studies.Miestamo2005
@@ -55,204 +50,86 @@ the distributed-exponence criterion. -/
 
 open Morphology (MorphCategory)
 
-/-- Distribution of inflectional categories between the two elements of an
-    auxiliary verb construction. The category vocabulary is
-    `MorphCategory` ([bybee-1985]'s relevance hierarchy); the pattern
-    taxonomy is [anderson-2006]'s AVC classification (see `InflPattern`). -/
+/-- Which inflectional categories each element of an auxiliary verb
+construction hosts. The category vocabulary is `MorphCategory`
+([bybee-1985]'s relevance hierarchy); which pattern a distribution
+realizes is `InflPattern`. -/
 structure InflDistribution where
-  onAux : List MorphCategory
-  onLex : List MorphCategory
-  deriving Repr, DecidableEq
+  onAux : Finset MorphCategory
+  onLex : Finset MorphCategory
+  deriving DecidableEq
 
-/-- Doyayo lex-headed: AUX carries tonal subject agreement (Anderson
-    p. 120: "partially encodes person of the subject through the tone");
-    LV carries TAM. -/
+/-- Doyayo lex-headed (ch. 3 ex. 15a, p. 121), *mi¹ (gi²) kpel¹-ko¹* 'I'm
+going to pour': the auxiliary "partially encodes person of the subject
+through the tone" (p. 120), the lexical verb carries TAM. -/
 def doyayoLexHeadedDist : InflDistribution :=
-  { onAux := [.agreement .subj], onLex := [.tense] }
+  { onAux := {.agreement .subj}, onLex := {.tense} }
 
-/-- Doyayo split/doubled (Anderson Ch 5 ex. 129, p. 223): subject doubled
-    on AUX and LV; object only on LV. -/
+/-- Doyayo split/doubled (ch. 5 ex. 129, p. 223), *hi¹-za¹ hi¹-zaa¹³
+hi¹-lɔ-mɔ* 'they might come bite you': the subject is marked on both
+elements, the object only on the lexical verb. -/
 def doyayoSplitDoubledDist : InflDistribution :=
-  { onAux := [.agreement .subj]
-  , onLex := [.agreement .subj, .agreement .obj] }
+  { onAux := {.agreement .subj}
+  , onLex := {.agreement .subj, .agreement .obj} }
 
-/-- Gorum doubled: both AUX and LV marked for subject agreement, tense,
-    and affectedness (version/voice). -/
+/-- Gorum doubled: subject agreement, tense and affectedness on both
+elements. -/
 def gorumDist : InflDistribution :=
-  { onAux := [.agreement .subj, .tense, .voice]
-  , onLex := [.agreement .subj, .tense, .voice] }
+  { onAux := {.agreement .subj, .tense, .voice}
+  , onLex := {.agreement .subj, .tense, .voice} }
 
-/-- Hemba split/doubled: agreement doubled, tense on AUX, mood on LV. -/
+/-- Hemba split/doubled: agreement on both elements, tense on the
+auxiliary, mood on the lexical verb. -/
 def hembaDist : InflDistribution :=
-  { onAux := [.agreement .subj, .tense]
-  , onLex := [.agreement .subj, .mood] }
+  { onAux := {.agreement .subj, .tense}
+  , onLex := {.agreement .subj, .mood} }
 
-/-- Jakaltek split: aspect and absolutive (object) agreement on AUX,
-    ergative (subject) agreement on LV. -/
+/-- Jakaltek split: aspect and absolutive agreement on the auxiliary,
+ergative agreement on the lexical verb. -/
 def jakaltekDist : InflDistribution :=
-  { onAux := [.aspect, .agreement .obj]
-  , onLex := [.agreement .subj] }
+  { onAux := {.aspect, .agreement .obj}
+  , onLex := {.agreement .subj} }
 
-/-- Pipil lex-headed: AUX uninflected, LV hosts subject agreement. -/
+/-- Pipil lex-headed (ch. 3 ex. 49, p. 130; Campbell 1985: 139), *weli
+ni-nehnemi wehka* 'I can walk far': the auxiliary *weli* is uninflected. -/
 def pipilLexHeadedDist : InflDistribution :=
-  { onAux := [], onLex := [.agreement .subj] }
+  { onAux := ∅, onLex := {.agreement .subj} }
 
-/-- Pipil split/doubled (Anderson Ch 5 ex. 133b, p. 224): subject doubled,
-    object only on LV. -/
+/-- Pipil split/doubled (ch. 5 ex. 133b, p. 224), *n-yu ni-mitsin-ilwitia*
+'I'm going to show you': "Subjects are doubly marked… while objects occur
+only on lexical verbs". The auxiliary root *yu* carries prospective TAM
+lexically, so no tense morpheme sits on it. -/
 def pipilSplitDoubledDist : InflDistribution :=
-  { onAux := [.agreement .subj]
-  , onLex := [.agreement .subj, .agreement .obj] }
+  { onAux := {.agreement .subj}
+  , onLex := {.agreement .subj, .agreement .obj} }
 
-/-- Finnish negative AVC: the negative auxiliary hosts negation, tense,
-    and agreement; the main verb retains stem and aspect (via participle
-    choice). [karlsson-2017] -/
+/-- Finnish negative AVC, *en lue* 'I do not read': the negative auxiliary
+hosts negation, tense and agreement, the main verb the stem and aspect
+(through the connegative). [anderson-2006] §1.7.2 presents Uralic negative
+auxiliaries with connegative-marked lexical verbs without assigning
+Finnish a pattern label; the split reading follows [karlsson-2017] §19.5,
+where the connegative suffix is the diagnostic. -/
 def finnishNegDist : InflDistribution :=
-  { onAux := [.negation, .tense, .agreement .subj]
-  , onLex := [.stem, .aspect] }
+  { onAux := {.negation, .tense, .agreement .subj}
+  , onLex := {.stem, .aspect} }
+
+/-- The 1sg negative auxiliary with the connegative *lue*, read out of
+`Finnish.Negation.negParadigm`; gloss `Neg-1 read-conneg`. -/
+def finnishNegForm : String :=
+  (Finnish.Negation.negParadigm.find?
+    (fun f => f.person == 1 && f.number == "sg")).elim "" (·.form ++ " lue")
+
+/-- The 1sg paradigm entry builds the form: a change to that entry leaves
+`finnishNegForm` empty and breaks this. -/
+theorem finnishNegForm_eq : finnishNegForm = "en lue" := rfl
 
 /-- The Finnish distribution is consistent with [miestamo-2005]'s
     constructional A/Fin coding: categories split across the negative
     auxiliary and the main verb. -/
 theorem finnish_split_confirms_constructional :
-    finnishNegDist.onAux.length > 0 ∧ finnishNegDist.onLex.length > 0 ∧
+    finnishNegDist.onAux ≠ ∅ ∧ finnishNegDist.onLex ≠ ∅ ∧
     Miestamo2005.finnish.asymmetryDimensions.contains .constructional := by
   refine ⟨?_, ?_, ?_⟩ <;> decide
-
-/-- A cross-linguistic AVC datum. Study-local: the `AuxiliaryVerbs` substrate
-    classifies over `InflPattern`; this paper's per-language rows bundle the
-    form/distribution/gloss with it. -/
-structure AVCDatum where
-  language : String
-  form : String
-  inflPattern : InflPattern
-  gloss : String := ""
-  deriving Repr, BEq
-
-/-! ### Per-language AVC data
-
-The 9 sample datums (7 languages) covering all 5 of Anderson's
-inflectional patterns. Per-datum verification theorems below ensure
-each datum's `inflPattern` and `form`/`distribution` derive from
-the Fragment files (changing a Fragment entry breaks exactly one
-theorem). -/
-
-/-- English *have eaten* — aux-headed (AUX *have* carries tense and
-    agreement, LV *eaten* is a past participle). Anderson ch. 2
-    (p. 40) describes the English perfect as AUX *have* with the LV
-    in the *-ed* ~ *-en* form;
-    the specific *have eaten* form is this file's instantiation of
-    that pattern, not a verbatim Anderson example. -/
-def english : AVCDatum :=
-  { language := "English"
-  , form := "have eaten"
-  , inflPattern := .auxHeaded
-  , gloss := "AUX.PRS eat.PTCP" }
-
-/-- Doyayo lex-headed (Anderson Ch 3 ex. 15a, p. 121).
-    *mi¹ (gi²) kpel¹-ko¹* 'I'm going to pour'. Auxiliary `gi²`
-    parenthesized in Anderson's example, carrying only tonal subject
-    person (Anderson p. 120); LV carries proximate TAM. Form derived from
-    `Doyayo.AuxiliaryVerbs.lexHeadedForm`. -/
-def doyayo : AVCDatum :=
-  { language := "Doyayo"
-  , form := Doyayo.AuxiliaryVerbs.lexHeadedForm
-  , inflPattern := .lexHeaded
-  , gloss := Doyayo.AuxiliaryVerbs.lexHeadedGloss }
-
-/-- Doyayo split/doubled (Anderson Ch 5 ex. 129, p. 223).
-    *hi¹-za¹ hi¹-zaa¹³ hi¹-lɔ-mɔ* 'they might come bite you'.
-    Subject `hi¹` doubly marked on AUX and LV; object `-mɔ` only
-    on LV. Anderson p. 223: "this pattern... is common in Doyayo." -/
-def doyayoSplitDoubled : AVCDatum :=
-  { language := "Doyayo"
-  , form := Doyayo.AuxiliaryVerbs.splitDoubledForm
-  , inflPattern := .splitDoubled
-  , gloss := Doyayo.AuxiliaryVerbs.splitDoubledGloss }
-
-/-- Gorum (doubled): subject + TAM on both AUX and LV.
-    Form derived from `Gorum.AuxiliaryVerbs`. -/
-def gorum : AVCDatum :=
-  { language := "Gorum"
-  , form := Gorum.AuxiliaryVerbs.form
-  , inflPattern := .doubled
-  , gloss := Gorum.AuxiliaryVerbs.gloss }
-
-/-- Jakaltek (split): absolutive on AUX, ergative on LV.
-    Form derived from `Jakaltek.AuxiliaryVerbs`. -/
-def jakaltek : AVCDatum :=
-  { language := "Jakaltek"
-  , form := Jakaltek.AuxiliaryVerbs.form
-  , inflPattern := .split
-  , gloss := Jakaltek.AuxiliaryVerbs.gloss }
-
-/-- Pipil split/doubled (Anderson Ch 5 ex. 133b, p. 224).
-    *n-yu ni-mitsin-ilwitia* 'I'm going to show you'. Subject `1`
-    doubly marked (`n-` on AUX, `ni-` on LV); object `-mitsin-`
-    only on LV. AUX root *yu* lexically encodes prospective TAM.
-    Anderson p. 224: "Subjects are doubly marked... while objects
-    occur only on lexical verbs." -/
-def pipilSplitDoubled : AVCDatum :=
-  { language := "Pipil"
-  , form := Pipil.AuxiliaryVerbs.splitDoubledForm
-  , inflPattern := .splitDoubled
-  , gloss := Pipil.AuxiliaryVerbs.splitDoubledGloss }
-
-/-- Pipil lex-headed (Anderson ch. 3 ex. 49, p. 130; Campbell 1985: 139).
-    *weli ni-nehnemi wehka* 'CAP 1-walk far' 'I can walk far'.
-    AUX *weli* uninflected; LV carries subject agreement. Anderson's
-    fn. 6 (p. 221) separately documents lex-headed/split-doubled
-    variation in the Pipil *progressive* — a different AVC from
-    this capability construction. -/
-def pipilLexHeaded : AVCDatum :=
-  { language := "Pipil"
-  , form := Pipil.AuxiliaryVerbs.lexHeadedForm
-  , inflPattern := .lexHeaded
-  , gloss := Pipil.AuxiliaryVerbs.lexHeadedGloss }
-
-/-- Finnish negative auxiliary *ei* (split): person/number on aux,
-    TAM on lexical verb (connegative form). Anderson §1.7.2 (p. 33-34)
-    presents negative auxiliaries as a family-level Uralic trait
-    (with connegative-marked LV, exx. 44-48) and, across other
-    families, as spanning multiple AVC patterns — Udihe and Neyo
-    aux-headed, Kokota split, Kwerba lex-headed, 'Iipay doubled.
-    Finnish *ei* itself is
-    not classified by Anderson in §1.7.2 with a specific pattern label;
-    the split classification here follows [karlsson-2017] §19.5
-    where the connegative suffix on the LV is the load-bearing diagnostic.
-    The split nature derives from `finnishNegDist`:
-    the negative auxiliary hosts negation, tense, and agreement, while
-    the lexical verb retains stem and aspect.
-    The 1sg form is read out of `negParadigm`; gloss style follows
-    Anderson's Uralic convention (`Neg-1 read-conneg`). -/
-def finnish : AVCDatum :=
-  { language := "Finnish"
-  , form := (Finnish.Negation.negParadigm.find?
-      (fun f => f.person == 1 && f.number == "sg")).elim "" (·.form ++ " lue")
-  , inflPattern := .split
-  , gloss := "Neg-1 read-conneg" }
-
-/-- Hemba split/doubled: subject doubled on both AUX and LV; tense
-    on AUX only; mood on LV only. Form derived from
-    `Hemba.AuxiliaryVerbs`. -/
-def hemba : AVCDatum :=
-  { language := "Hemba"
-  , form := Hemba.AuxiliaryVerbs.form
-  , inflPattern := .splitDoubled
-  , gloss := Hemba.AuxiliaryVerbs.gloss }
-
-/-- All 9 AVC datums (covering all 5 of Anderson's patterns). -/
-def allData : List AVCDatum :=
-  [english, doyayo, doyayoSplitDoubled, gorum, jakaltek,
-   pipilSplitDoubled, pipilLexHeaded, finnish, hemba]
-
-/-- The sample instantiates every one of Anderson's five patterns. -/
-theorem all_patterns_attested (p : InflPattern) :
-    ∃ d ∈ allData, d.inflPattern = p := by
-  cases p <;> decide
-
-/-- The 1sg entry of `negParadigm` builds the form: a change to that
-    entry leaves `finnish.form` empty and breaks this. -/
-theorem finnish_form_from_paradigm : finnish.form = "en lue" := rfl
 
 /-! ### The Finnish negative AVC -/
 
@@ -260,79 +137,65 @@ theorem finnish_form_from_paradigm : finnish.form = "en lue" := rfl
     auxiliary hosts some inflectional categories and the lexical
     verb hosts others, with neither element hosting all categories. -/
 theorem finnish_split_from_fragment :
-    let dist := finnishNegDist
-    dist.onAux ≠ [] ∧ dist.onLex ≠ [] := by
-  exact ⟨by decide, by decide⟩
+    finnishNegDist.onAux ≠ ∅ ∧ finnishNegDist.onLex ≠ ∅ := ⟨by decide, by decide⟩
 
 /-! ### Where the inflection sits -/
 
-/-- In Gorum's doubled AVC, aux and lex host exactly the same categories. -/
-theorem gorum_doubled_same_categories :
-    let dist := gorumDist
-    dist.onAux == dist.onLex = true := by decide
+/-- Doubled: the two elements host exactly the same categories. -/
+theorem gorum_doubled_same_categories : gorumDist.onAux = gorumDist.onLex := by decide
 
 /-- In Doyayo's lex-headed AVC, the auxiliary hosts ONLY tonal subject
     agreement (per Anderson p. 120), and the LV carries TAM. -/
 theorem doyayo_lexHeaded_aux_agreement_only :
-    doyayoLexHeadedDist.onAux = [.agreement .subj] ∧
-    doyayoLexHeadedDist.onLex = [.tense] := by
-  exact ⟨rfl, rfl⟩
+    doyayoLexHeadedDist.onAux = {.agreement .subj} ∧
+    doyayoLexHeadedDist.onLex = {.tense} := ⟨rfl, rfl⟩
 
 /-- Chapter 5 (Doyayo): subject agreement is doubled across auxiliary
     and lexical verb, while object agreement appears on the lexical verb
     only. -/
 theorem doyayo_splitDoubled_subj_doubled_obj_lex_only :
     let dist := doyayoSplitDoubledDist
-    dist.onAux.contains (.agreement .subj) = true ∧
-    dist.onLex.contains (.agreement .subj) = true ∧
-    dist.onLex.contains (.agreement .obj) = true ∧
-    dist.onAux.contains (.agreement .obj) = false := by
-  exact ⟨by decide, by decide, by decide, by decide⟩
+    MorphCategory.agreement .subj ∈ dist.onAux ∧
+    MorphCategory.agreement .subj ∈ dist.onLex ∧
+    MorphCategory.agreement .obj ∈ dist.onLex ∧
+    MorphCategory.agreement .obj ∉ dist.onAux := by decide
 
 /-- Chapter 5 (Pipil): the same generalization as Doyayo. The auxiliary
     root *yu* encodes TAM lexically, so no `.tense` morpheme sits on the
     auxiliary. -/
 theorem pipil_splitDoubled_subj_doubled_obj_lex_only :
     let dist := pipilSplitDoubledDist
-    dist.onAux.contains (.agreement .subj) = true ∧
-    dist.onLex.contains (.agreement .subj) = true ∧
-    dist.onLex.contains (.agreement .obj) = true ∧
-    dist.onAux.contains (.agreement .obj) = false := by
-  exact ⟨by decide, by decide, by decide, by decide⟩
+    MorphCategory.agreement .subj ∈ dist.onAux ∧
+    MorphCategory.agreement .subj ∈ dist.onLex ∧
+    MorphCategory.agreement .obj ∈ dist.onLex ∧
+    MorphCategory.agreement .obj ∉ dist.onAux := by decide
 
 /-- In Pipil's lex-headed AVC, the auxiliary hosts no inflection. -/
-theorem pipil_lexHeaded_aux_empty :
-    pipilLexHeadedDist.onAux = [] := rfl
+theorem pipil_lexHeaded_aux_empty : pipilLexHeadedDist.onAux = ∅ := rfl
 
-/-- In Finnish's split AVC, aux and lex host disjoint category types.
-    (`.stem` on the lex side is a base, not an inflectional overlap.) -/
-theorem finnish_split_disjoint :
-    let dist := finnishNegDist
-    dist.onAux.all (fun c => !dist.onLex.contains c) = true := by decide
+/-- Split: the two elements host disjoint categories. (`.stem` on the
+    lexical side is a base, not an inflectional overlap.) -/
+theorem finnish_split_disjoint : Disjoint finnishNegDist.onAux finnishNegDist.onLex := by
+  decide
 
 /-- Chapter 5 (Jakaltek): absolutive agreement on the auxiliary,
     ergative on the lexical verb. -/
 theorem jakaltek_abs_on_aux_erg_on_lex :
     let dist := jakaltekDist
-    dist.onAux.contains (.agreement .obj) = true ∧
-    dist.onLex.contains (.agreement .subj) = true ∧
-    dist.onAux.contains (.agreement .subj) = false ∧
-    dist.onLex.contains (.agreement .obj) = false := by
-  exact ⟨by decide, by decide, by decide, by decide⟩
+    MorphCategory.agreement .obj ∈ dist.onAux ∧
+    MorphCategory.agreement .subj ∈ dist.onLex ∧
+    MorphCategory.agreement .subj ∉ dist.onAux ∧
+    MorphCategory.agreement .obj ∉ dist.onLex := by decide
 
 /-- In Hemba's split/doubled AVC, subject agreement is doubled (on both
     elements), tense is AUX-only, mood is LV-only. No object agreement
     in this construction. -/
 theorem hemba_splitDoubled_agreement_doubled :
     let dist := hembaDist
-    dist.onAux.contains (.agreement .subj) = true ∧
-    dist.onLex.contains (.agreement .subj) = true ∧
-    dist.onAux.contains .tense = true ∧
-    dist.onLex.contains .tense = false ∧
-    dist.onAux.contains .mood = false ∧
-    dist.onLex.contains .mood = true := by
-  exact ⟨by decide, by decide, by decide,
-         by decide, by decide, by decide⟩
+    MorphCategory.agreement .subj ∈ dist.onAux ∧
+    MorphCategory.agreement .subj ∈ dist.onLex ∧
+    MorphCategory.tense ∈ dist.onAux ∧ MorphCategory.tense ∉ dist.onLex ∧
+    MorphCategory.mood ∉ dist.onAux ∧ MorphCategory.mood ∈ dist.onLex := by decide
 
 /-! ### Dual headedness
 


### PR DESCRIPTION
Deep audit of `Studies/Anderson2006.lean` (653 → 327 lines). Every page and table citation was checked against the book PDF and all hold — p. 23's "It is the lexical verb", Table 3.1's lex-headed scope, Table 2.3's aux-headed-only scope, §1.7.2's Udihe/Neyo/Kokota/Kwerba/'Iipay list, ex. 129 and 133. The problems were bloat, narration, and two type choices.

- Removed the module docstring's `## 2026-04-30 audit fixes` changelog and the inline edit history (`the 0.230.578 workaround`, `the meta-audit at 0.230.576 replaced it`, `moved here from the Miestamo file`, `Demoted from the former Morphology/Periphrasis.lean`). The header also advertised `anderson_miestamo_agree_on_neg_morphology`, which that same history records as deleted.
- Cut 22 restatement theorems: nine `x.inflPattern = .y := rfl`, seven `x.form = Fragment.form := rfl` (the definition read back), `five_patterns_attested`, `hemba_split_doubled_shape` (character-identical to `hemba_splitDoubled_agreement_doubled`), and five `lvVerbForm` facts already proved in `Syntax/Category/Auxiliary/Constructions.lean`.
- `InflDistribution` now holds `Finset MorphCategory` rather than `List`. Every operation on these was already a set operation — membership, disjointness, emptiness, and equality — so `List` was contributing an order that no theorem respected but `==` was silently sensitive to: reordering Gorum's `onLex` would have falsified `gorum_doubled_same_categories`. The theorems now read `=`, `Disjoint`, `∈`, `∉`, `= ∅`, and still close by `decide`.
- Dropped `AVCDatum`. It bundled three `String` fields with a pattern label, two of them (`language`, `gloss`) read by nothing once the restatements went, and `form` only by the tautologies. Each language's example and locator now sits in its distribution's docstring, where the analysis already was.
- `finnish.form` had a `| none => "en lue"` fallback chosen to match the success branch, so a broken lookup passed `rfl` silently; it now yields `""`, and one theorem pins it instead of two witnesses plus a paragraph explaining the hazard.

Kept the distribution generalizations, dual headedness, the negative-auxiliary section with its Kwerba counterexample, and the Sorace and Miestamo bridges.

Side effect worth noting: the five `Fragments/*/AuxiliaryVerbs.lean` files this study used to quote forms from now have no importer. They remain lexical data, but nothing consumes them.