### PR TITLE
refactor(Syntax/Category/Auxiliary): drop constant-function invariant and readbacks

### DIFF
--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -39,7 +39,7 @@ open AuxiliaryVerbs
 open ArgumentStructure.AuxiliarySelection
 open Syntax.Negation (Strategy)
 
-/-! ### Inflectional distribution
+/-! ### Where the inflection is marked
 
 Possessing a distribution is neutral on periphrasis-hood
 ([spencer-popova-2015] pp. 200, 204); the data is the raw material for
@@ -48,10 +48,10 @@ the distributed-exponence criterion. -/
 open Morphology (MorphCategory)
 
 /-- Which inflectional categories each element of an auxiliary verb
-construction hosts. The category vocabulary is `MorphCategory`
-([bybee-1985]'s relevance hierarchy); which pattern a distribution
-realizes is `InflPattern`. -/
-structure InflDistribution where
+construction carries. The category vocabulary is `MorphCategory`
+([bybee-1985]'s relevance hierarchy); the coarse question of which element
+is the inflectional head is `InflPattern.inflHost`. -/
+structure InflectionalMarking where
   onAux : Finset MorphCategory
   onLex : Finset MorphCategory
   deriving DecidableEq
@@ -59,42 +59,42 @@ structure InflDistribution where
 /-- Doyayo lex-headed (`Examples.doyayo_lexheaded`): the auxiliary
 "partially encodes person of the subject through the tone" (p. 120), the
 lexical verb carries TAM. -/
-def doyayoLexHeadedDist : InflDistribution :=
+def doyayoLexHeaded : InflectionalMarking :=
   { onAux := {.agreement .subj}, onLex := {.tense} }
 
 /-- Doyayo split/doubled (`Examples.doyayo_splitdoubled`): the subject is
 marked on both elements, the object only on the lexical verb. -/
-def doyayoSplitDoubledDist : InflDistribution :=
+def doyayoSplitDoubled : InflectionalMarking :=
   { onAux := {.agreement .subj}
   , onLex := {.agreement .subj, .agreement .obj} }
 
 /-- Gorum doubled (`Examples.gorum_tiger`, `Examples.gorum_vigorously`):
 subject agreement, tense and affectedness on both elements. -/
-def gorumDist : InflDistribution :=
+def gorumDoubled : InflectionalMarking :=
   { onAux := {.agreement .subj, .tense, .voice}
   , onLex := {.agreement .subj, .tense, .voice} }
 
 /-- Hemba split/doubled (`Examples.hemba_progressive`): agreement on both
 elements, tense on the auxiliary, mood on the lexical verb. -/
-def hembaDist : InflDistribution :=
+def hembaSplitDoubled : InflectionalMarking :=
   { onAux := {.agreement .subj, .tense}
   , onLex := {.agreement .subj, .mood} }
 
 /-- Jakaltek split (`Examples.jakaltek_completive`): aspect and absolutive
 agreement on the auxiliary, ergative agreement on the lexical verb. -/
-def jakaltekDist : InflDistribution :=
+def jakaltekSplit : InflectionalMarking :=
   { onAux := {.aspect, .agreement .obj}
   , onLex := {.agreement .subj} }
 
 /-- Pipil lex-headed (`Examples.pipil_capability`): the capability
 auxiliary *weli* is uninflected. -/
-def pipilLexHeadedDist : InflDistribution :=
+def pipilLexHeaded : InflectionalMarking :=
   { onAux := ∅, onLex := {.agreement .subj} }
 
 /-- Pipil split/doubled (`Examples.pipil_progressive`): "Subjects are doubly
 marked… while objects occur only on lexical verbs". The auxiliary root *yu*
 carries prospective TAM lexically, so no tense morpheme sits on it. -/
-def pipilSplitDoubledDist : InflDistribution :=
+def pipilSplitDoubled : InflectionalMarking :=
   { onAux := {.agreement .subj}
   , onLex := {.agreement .subj, .agreement .obj} }
 
@@ -104,7 +104,7 @@ hosts negation, tense and agreement, the main verb the stem and aspect
 auxiliaries with connegative-marked lexical verbs without assigning
 Finnish a pattern label; the split reading follows [karlsson-2017] §19.5,
 where the connegative suffix is the diagnostic. -/
-def finnishNegDist : InflDistribution :=
+def finnishNegative : InflectionalMarking :=
   { onAux := {.negation, .tense, .agreement .subj}
   , onLex := {.stem, .aspect} }
 
@@ -140,7 +140,7 @@ agreement is doubled over both elements, while object agreement stays on
 the lexical verb ("Subjects are doubly marked… while objects occur only on
 lexical verbs", p. 224). -/
 theorem splitDoubled_subj_doubled_obj_lex_only :
-    ∀ d ∈ [doyayoSplitDoubledDist, pipilSplitDoubledDist],
+    ∀ d ∈ [doyayoSplitDoubled, pipilSplitDoubled],
       MorphCategory.agreement .subj ∈ d.onAux ∧
       MorphCategory.agreement .subj ∈ d.onLex ∧
       MorphCategory.agreement .obj ∈ d.onLex ∧

--- a/Linglib/Syntax/Category/Auxiliary/Constructions.lean
+++ b/Linglib/Syntax/Category/Auxiliary/Constructions.lean
@@ -3,151 +3,73 @@ Copyright (c) 2026 Robert Hawkins. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Hawkins
 -/
-import Linglib.Data.UD.Basic
 
 /-!
-# Auxiliary verb constructions: inflection-locus typology
+# Auxiliary verb constructions: the inflectional patterns
 
-[anderson-2006]
+An auxiliary verb construction pairs an auxiliary with a lexical verb, and
+languages differ in which of the two carries the inflection. The lexical
+verb is the semantic head whichever way that goes, and it is exactly that
+mismatch between where the content sits and where the inflection sits that
+makes the constructions typologically distinctive.
 
-The auxiliary-verb-construction (AVC) inflection typology of [anderson-2006]:
-the **semantic head is always the lexical verb**, but the **inflectional host**
-varies across five macro-patterns. Graduated from the dissolved `Typology/`
-drawer (the orthogonal be/have-selection typology split off to
-`Semantics/ArgumentStructure/AuxiliarySelection.lean`).
-
-## The five patterns
-
-| Pattern        | Infl host  | Example                                   |
-|----------------|------------|-------------------------------------------|
-| Aux-headed     | AUX        | English *have eaten*, *is eating*         |
-| Lex-headed     | LEX        | Pipil *weli ni-nehnemi*                    |
-| Doubled        | AUX+LEX    | Gorum *miŋ ne-gaʔ-ru ne-laʔ-ru*           |
-| Split          | AUX or LEX | Jakaltek (abs/erg), Finnish neg-aux *ei*  |
-| Split/doubled  | AUX+LEX    | Pipil, Doyayo (Ch 5), Hemba               |
+Five macro-patterns exhaust the possibilities: the auxiliary hosts the
+inflection, the lexical verb does, both carry the same categories, the
+categories divide between them, or they divide with some doubled.
 
 ## Main definitions
 
-* `InflPattern` — the five-way inflectional-distribution macro-classification.
-* `AVCElement` — which element(s) of an AVC bear a given property.
-* `InflPattern.semanticHead` / `inflHost` / `inflOnlyOnPhrasalHead` / `lvVerbForm`.
+* `InflPattern` — the five patterns.
+* `AVCElement` — which element of a construction bears a property.
+* `InflPattern.inflHost` — the element hosting inflection.
 
-Per-language `AVCDatum` instances + Fragment-grounding verification theorems
-live in `Studies/Anderson2006.lean` (paper-anchored data).
+## References
+
+* [anderson-2006], §1.4, chs. 2-5
 -/
 
 namespace AuxiliaryVerbs
 
-/-! ### Core types -/
+/-- Which element of an auxiliary verb construction bears a property. -/
+inductive AVCElement where
+  | aux
+  | lex
+  | both
+  deriving DecidableEq, Repr
 
-/-- Anderson's 5-way inflectional pattern typology for AVCs. -/
+/-- The five inflectional patterns of auxiliary verb constructions. -/
 inductive InflPattern where
-  /-- Inflection hosted on auxiliary; lexical verb is nonfinite.
-      E.g., English *will go*, French *va manger*. -/
+  /-- The auxiliary hosts the inflection and the lexical verb is nonfinite:
+      English *have eaten*, French *va manger*. -/
   | auxHeaded
-  /-- Inflection hosted on lexical verb; auxiliary is grammaticalized.
-      E.g., Pipil *weli ni-nehnemi* (AUX uninflected, LV carries person);
-      Doyayo *mi¹ (gi²) kpel¹-ko¹* (Ch 3 ex 15a). -/
+  /-- The lexical verb hosts the inflection and the auxiliary is
+      grammaticalized: Pipil *weli ni-nehnemi*. -/
   | lexHeaded
-  /-- Inflection appears on both auxiliary and lexical verb.
-      E.g., Gorum *miŋ ne-gaʔ-ru ne-laʔ-ru* (subject + TAM on both). -/
+  /-- Both elements carry the same categories: Gorum *miŋ ne-gaʔ-ru
+      ne-laʔ-ru*, subject and TAM on each. -/
   | doubled
-  /-- Inflection split between AUX and LV (different features on each
-      element, with no overlap). E.g., Jakaltek *šk-ach w-ila*
-      (absolutive on AUX, ergative on LV); Finnish neg-aux *ei*
-      (person/number on AUX, connegative + aspect on LV). -/
+  /-- The categories divide between the elements with no overlap: Jakaltek
+      *šk-ach w-ila*, absolutive on the auxiliary and ergative on the
+      lexical verb. -/
   | split
-  /-- Some categories on both AUX and LV (doubled), others exclusive
-      to one element (split). [anderson-2006] ch. 5 §5.2 dedicates
-      ~30 pages to this pattern with 30+ language exemplars across
-      §§5.2.1–5.2.3 (Limbu, Manam, Kuot, Doyayo, Mbay, Lamba, Pipil,
-      Persian, Swahili, Panyjima, Kemantney, Oshikwanyama, Shambala,
-      Vinmavis, Nambiquara, Baure, Luganda, Nasioi, Os, Xhosa, ...).
-      Common, not marginal. -/
+  /-- The categories divide, but some are carried by both elements.
+      [anderson-2006] ch. 5 §5.2 gives thirty-odd exemplars, so this is a
+      common pattern rather than a marginal one. -/
   | splitDoubled
   deriving DecidableEq, Repr, Inhabited
 
-/-- Which element(s) of an AVC bear a given property. -/
-inductive AVCElement where
-  | aux   -- auxiliary only
-  | lex   -- lexical verb only
-  | both  -- both auxiliary and lexical verb
-  deriving DecidableEq, Repr
-
-/-! ### Key functions -/
-
-/-- The semantic head is always the lexical verb (Anderson's invariant). -/
-def InflPattern.semanticHead (_ : InflPattern) : AVCElement := .lex
-
-/-- Which element hosts inflection in each pattern. -/
+/-- The element hosting inflection. The three patterns that put material on
+both elements are distinguished by *which* categories go where, not by the
+host, so they share a value here. -/
 def InflPattern.inflHost : InflPattern → AVCElement
-  | .auxHeaded    => .aux
-  | .lexHeaded    => .lex
-  | .doubled      => .both
-  | .split        => .both
-  | .splitDoubled => .both
+  | .auxHeaded => .aux
+  | .lexHeaded => .lex
+  | .doubled | .split | .splitDoubled => .both
 
-/-- Whether inflection is hosted exclusively on the phrasal head (= AUX).
-    Only aux-headed AVCs have this property: the AUX hosts all inflection
-    and the LV is fully nonfinite. In doubled AVCs, both elements carry
-    inflection, so the phrasal head is not the sole inflectional host. -/
-def InflPattern.inflOnlyOnPhrasalHead : InflPattern → Bool
-  | .auxHeaded    => true
-  | .lexHeaded    => false
-  | .doubled      => false
-  | .split        => false
-  | .splitDoubled => false
-
-/-- Expected verb form of the lexical verb in each AVC pattern.
-    Aux-headed: LV is nonfinite (infinitive/participle).
-    Lex-headed: LV is finite (carries TAM).
-    Doubled/split/splitDoubled: LV is finite (carries at least some inflection). -/
-def InflPattern.lvVerbForm : InflPattern → UD.VerbForm
-  | .auxHeaded    => .Inf
-  | .lexHeaded    => .Fin
-  | .doubled      => .Fin
-  | .split        => .Fin
-  | .splitDoubled => .Fin
-
-/-! ### Invariant theorems
-
-About `InflPattern` itself. Anderson distinguishes inflectional, phrasal and
-semantic heads (§1.4, pp. 22-24; Table 3.1 tabulates the lex-headed
-assignment): the semantic head is always the lexical verb, while the
-inflectional host varies by pattern, and that mismatch is what makes AVCs
-typologically distinctive. -/
-
-/-- Anderson's key insight: the semantic head is always the lexical verb,
-    regardless of inflectional pattern. -/
-theorem semantic_head_always_lex (p : InflPattern) :
-    p.semanticHead = .lex := rfl
-
-/-- In aux-headed AVCs, inflection is exclusively on the phrasal head (AUX). -/
-theorem auxHeaded_infl_on_phrasal_head :
-    InflPattern.auxHeaded.inflOnlyOnPhrasalHead = true := rfl
-
-/-- In lex-headed AVCs, inflection is not on the phrasal head. -/
-theorem lexHeaded_infl_not_on_phrasal_head :
-    InflPattern.lexHeaded.inflOnlyOnPhrasalHead = false := rfl
-
-/-- In doubled AVCs, inflection appears on both elements, so the phrasal
-    head is not the sole host. -/
-theorem doubled_infl_not_only_on_phrasal_head :
-    InflPattern.doubled.inflOnlyOnPhrasalHead = false := rfl
-
-/-- In aux-headed AVCs, the lexical verb is nonfinite. -/
-theorem auxHeaded_lv_nonfinite :
-    InflPattern.auxHeaded.lvVerbForm = UD.VerbForm.Inf := rfl
-
-/-- In lex-headed AVCs, the lexical verb is finite. -/
-theorem lexHeaded_lv_finite :
-    InflPattern.lexHeaded.lvVerbForm = UD.VerbForm.Fin := rfl
-
-/-- The semantic head and the inflectional host coincide only in lex-headed
-    constructions; in every other pattern the lexical verb supplies the
-    content while inflection sits elsewhere. -/
-theorem heads_coincide_iff_lexHeaded (p : InflPattern) :
-    (p.semanticHead == p.inflHost) = (p == .lexHeaded) := by
-  cases p <;> rfl
+/-- The inflectional host is the lexical verb — the element that is the
+semantic head anyway — only in the lex-headed pattern. -/
+theorem inflHost_eq_lex_iff (p : InflPattern) :
+    p.inflHost = .lex ↔ p = .lexHeaded := by
+  cases p <;> simp [InflPattern.inflHost]
 
 end AuxiliaryVerbs


### PR DESCRIPTION
Follow-on to #2347, cleansing the AVC substrate (153 → 75 lines) and finishing a rename in the study.

`InflPattern.semanticHead` was `fun _ => .lex` — a constant function whose only purpose was to let `semantic_head_always_lex` prove it by `rfl`. That is the invariant stipulated and then read back, and nothing outside the file called either. The claim is a fact about language, so it belongs in the docstring; what is left in Lean is the non-trivial half, restated without the constant: `inflHost_eq_lex_iff : p.inflHost = .lex ↔ p = .lexHeaded`.

Also removed, all with no consumers anywhere: `inflOnlyOnPhrasalHead` (a `Bool` predicate that was definitionally `p = .auxHeaded`) with its three readback theorems, and `lvVerbForm` with its two — the study's copies of those same five facts went in #2346. The module docstring shed its "Graduated from the dissolved `Typology/` drawer" history and a pointer to `AVCDatum`, deleted two PRs ago, and the pattern table's example column now duplicated the JSON rows.

The study's `InflDistribution` becomes `InflectionalMarking`: it records which categories each element carries, so `Infl` misread as the INFL head, and `Distribution` sat oddly next to the probability sense. Anderson's own wording for the coarse question is "morphosyntactic locus of inflection" (his 12a), and his recurring description of the fine one is that a category is "doubly marked". Instances lose their `Dist` suffix and take the pattern name they exemplify (`gorumDoubled`, `jakaltekSplit`).