### PR TITLE
refactor(Syntax/Category/Auxiliary): delete dead AVCElement API; InflPattern to InflectionPattern

### DIFF
--- a/Linglib/Studies/Anderson2006.lean
+++ b/Linglib/Studies/Anderson2006.lean
@@ -49,8 +49,8 @@ open Morphology (MorphCategory)
 
 /-- Which inflectional categories each element of an auxiliary verb
 construction carries. The category vocabulary is `MorphCategory`
-([bybee-1985]'s relevance hierarchy); the coarse question of which element
-is the inflectional head is `InflPattern.inflHost`. -/
+([bybee-1985]'s relevance hierarchy); which of the five patterns the
+marking realizes is `InflectionPattern`. -/
 structure InflectionalMarking where
   onAux : Finset MorphCategory
   onLex : Finset MorphCategory
@@ -119,7 +119,7 @@ def finnishNegForm : String :=
 theorem finnishNegForm_eq : finnishNegForm = "en lue" := rfl
 
 /-- The inflectional pattern Anderson assigns an example. -/
-def parseInflPattern : String → Option InflPattern
+def parseInflectionPattern : String → Option InflectionPattern
   | "auxHeaded" => some .auxHeaded
   | "lexHeaded" => some .lexHeaded
   | "doubled" => some .doubled
@@ -128,11 +128,11 @@ def parseInflPattern : String → Option InflPattern
   | _ => none
 
 /-- The patterns Anderson's examples are classified as. -/
-def attestedPatterns : List InflPattern :=
-  Examples.all.filterMap fun e => (e.feature? "infl_pattern").bind parseInflPattern
+def attestedPatterns : List InflectionPattern :=
+  Examples.all.filterMap fun e => (e.feature? "infl_pattern").bind parseInflectionPattern
 
 /-- Anderson's examples instantiate every one of his five patterns. -/
-theorem all_patterns_attested (p : InflPattern) : p ∈ attestedPatterns := by
+theorem all_patterns_attested (p : InflectionPattern) : p ∈ attestedPatterns := by
   cases p <;> decide
 
 /-- Chapter 5's generalization across the split/doubled languages: subject
@@ -154,8 +154,8 @@ Kokota; lex-headed in Kwerba; doubled in 'Iipay. The example rows
 live in `Data/Examples/Anderson2006.json` (Komi (47a,b), Udihe (49),
 Kwerba (52a,b), all verified against the book); each row's
 `infl_pattern` feature records the book's classification where it
-states one. The Strategy → InflPattern mapping lives in
-`Syntax/Negation.lean`: `Strategy.expectedInflPattern` encodes
+states one. The Strategy → InflectionPattern mapping lives in
+`Syntax/Negation.lean`: `Strategy.expectedInflectionPattern` encodes
 the most common verbal-negator → aux-headed mapping, and the Kwerba
 rows witness below that it is a tendency, not a law. -/
 
@@ -163,16 +163,16 @@ rows witness below that it is a tendency, not a law. -/
     and the strategy-level projection expects exactly that. -/
 theorem udihe_negVerb_expects_auxHeaded :
     Examples.udihe_neg.feature? "infl_pattern" = some "auxHeaded" ∧
-    Strategy.negVerb.expectedInflPattern = some .auxHeaded :=
+    Strategy.negVerb.expectedInflectionPattern = some .auxHeaded :=
   ⟨rfl, rfl⟩
 
 /-- Kwerba (52a,b) shows a negative auxiliary in a *lex-headed* AVC
     (the lexical verb hosts the inflection), so the aux-headed
-    expectation of `Strategy.expectedInflPattern` is defeasible —
+    expectation of `Strategy.expectedInflectionPattern` is defeasible —
     Anderson's own four-pattern list is the counterexample source. -/
 theorem kwerba_negVerb_lexHeaded_counterexample :
     Examples.kwerba_neg_fut.feature? "infl_pattern" = some "lexHeaded" ∧
-    Strategy.negVerb.expectedInflPattern ≠ some .lexHeaded :=
+    Strategy.negVerb.expectedInflectionPattern ≠ some .lexHeaded :=
   ⟨rfl, by decide⟩
 
 /-- The Komi tense alternation (47a,b) sits entirely on the negative
@@ -185,7 +185,7 @@ theorem komi_tense_on_aux :
 
 /-! ### Auxiliary selection
 
-Be/have auxiliary selection (`Syntax/Category/Auxiliary/Constructions.lean`) operates
+Be/have auxiliary selection (`Semantics/ArgumentStructure/AuxiliarySelection.lean`) operates
 within aux-headed AVCs: the question of *which* auxiliary appears
 presupposes the auxiliary hosts inflection. [sorace-2000]'s
 sister study `Studies/Sorace2000.lean` provides

--- a/Linglib/Studies/Storment2026.lean
+++ b/Linglib/Studies/Storment2026.lean
@@ -133,7 +133,8 @@ theorem arrive_unaccusative : arrive.unaccusative = true := rfl
 /-! ## §3. TransitivityClass derivation
 
 Maps a `Verb` to the three-way transitivity classification used by
-the auxiliary-selection substrate (`Typology/AuxiliaryVerbs.lean`). -/
+the auxiliary-selection substrate
+(`Semantics/ArgumentStructure/AuxiliarySelection.lean`). -/
 
 /-- Derive `TransitivityClass` from `Verb` fields. -/
 def deriveTransitivityClass (v : Verb) : TransitivityClass :=

--- a/Linglib/Syntax/Category/Auxiliary/Constructions.lean
+++ b/Linglib/Syntax/Category/Auxiliary/Constructions.lean
@@ -5,7 +5,7 @@ Authors: Robert Hawkins
 -/
 
 /-!
-# Auxiliary verb constructions: the inflectional patterns
+# The inflectional patterns of auxiliary verb constructions
 
 An auxiliary verb construction pairs an auxiliary with a lexical verb, and
 languages differ in which of the two carries the inflection. The lexical
@@ -15,13 +15,9 @@ makes the constructions typologically distinctive.
 
 Five macro-patterns exhaust the possibilities: the auxiliary hosts the
 inflection, the lexical verb does, both carry the same categories, the
-categories divide between them, or they divide with some doubled.
-
-## Main definitions
-
-* `InflPattern` — the five patterns.
-* `AVCElement` — which element of a construction bears a property.
-* `InflPattern.inflHost` — the element hosting inflection.
+categories divide between them, or they divide with some doubled. Which
+categories land where is finer-grained than the pattern and is recorded by
+the analysis that needs it, as in `Studies/Anderson2006.lean`.
 
 ## References
 
@@ -30,15 +26,8 @@ categories divide between them, or they divide with some doubled.
 
 namespace AuxiliaryVerbs
 
-/-- Which element of an auxiliary verb construction bears a property. -/
-inductive AVCElement where
-  | aux
-  | lex
-  | both
-  deriving DecidableEq, Repr
-
 /-- The five inflectional patterns of auxiliary verb constructions. -/
-inductive InflPattern where
+inductive InflectionPattern where
   /-- The auxiliary hosts the inflection and the lexical verb is nonfinite:
       English *have eaten*, French *va manger*. -/
   | auxHeaded
@@ -57,19 +46,5 @@ inductive InflPattern where
       common pattern rather than a marginal one. -/
   | splitDoubled
   deriving DecidableEq, Repr, Inhabited
-
-/-- The element hosting inflection. The three patterns that put material on
-both elements are distinguished by *which* categories go where, not by the
-host, so they share a value here. -/
-def InflPattern.inflHost : InflPattern → AVCElement
-  | .auxHeaded => .aux
-  | .lexHeaded => .lex
-  | .doubled | .split | .splitDoubled => .both
-
-/-- The inflectional host is the lexical verb — the element that is the
-semantic head anyway — only in the lex-headed pattern. -/
-theorem inflHost_eq_lex_iff (p : InflPattern) :
-    p.inflHost = .lex ↔ p = .lexHeaded := by
-  cases p <;> simp [InflPattern.inflHost]
 
 end AuxiliaryVerbs

--- a/Linglib/Syntax/Negation.lean
+++ b/Linglib/Syntax/Negation.lean
@@ -109,7 +109,7 @@ loses (Finnish *ei mene* 'NEG.3SG go'), making negation a special case of
 the aux-headed auxiliary-verb construction; an affix or a particle does
 not. `Strategy` classifies negation at that grain. -/
 
-open AuxiliaryVerbs (InflPattern)
+open AuxiliaryVerbs (InflectionPattern)
 open Grammaticalization (GramStage)
 
 /-- How a language expresses sentential negation. -/
@@ -125,7 +125,7 @@ inductive Strategy where
 /-- A negative verb heads an auxiliary-verb construction, so it is
 expected to host the inflection; affixes and particles form no
 construction to head. -/
-def Strategy.expectedInflPattern : Strategy → Option InflPattern
+def Strategy.expectedInflectionPattern : Strategy → Option InflectionPattern
   | .negVerb => some .auxHeaded
   | .negAffix | .negParticle => none
 


### PR DESCRIPTION
A Fable reviewer went over the auxiliary API. Its block-merge finding: `AVCElement`, `InflPattern.inflHost` and `inflHost_eq_lex_iff` are dead spec-API and should all go.

`AVCElement` is `aux | lex | both`, but a value ranging over "the auxiliary, the lexical verb, or both" is not an element of anything — it is a nonempty subset of a genuine two-element type, i.e. a powerset-minus-empty inlined as three constructors. `.both` was constructed on exactly one line and matched nowhere. `inflHost` is its only user, and is itself lossy (three of the five patterns collapse to `.both`) with no code consumer anywhere: the two mentions outside the file are docstrings. `inflHost_eq_lex_iff` existed only to say something about `inflHost`. So the file keeps `InflectionPattern` and nothing else — the one declaration anything outside it actually uses.

The reviewer explicitly advised *against* the refactor I had been considering, replacing the study's `InflectionalMarking` with `Element → Finset MorphCategory`: the two slots are semantically asymmetric, mathlib's shape for that is a structure with named projections (`Complex.re`/`im`), every theorem addresses the sides by name, and nothing quantifies over elements. Left alone. It also flagged that deriving the pattern label from the marking is not possible as encoded — Doyayo lex-headed has a nonempty `onAux` — so the current split, label from the paper's data and categories in the record, is correct.

`InflPattern` becomes `InflectionPattern` (with `parseInflectionPattern`, `expectedInflectionPattern`): "Infl" reads as the generative INFL head, which is not what is meant, and the study already spells `InflectionalMarking` in full.

Also fixes two stale cross-references the reviewer caught: `Studies/Anderson2006.lean` pointed be/have selection at this file rather than `Semantics/ArgumentStructure/AuxiliarySelection.lean`, and `Studies/Storment2026.lean` still cited the dissolved `Typology/AuxiliaryVerbs.lean`.