### PR TITLE
chore(Core): adopt Std relation classes and sdiff names for deprecated aliases

### DIFF
--- a/Linglib/Core/Data/List/EqOn.lean
+++ b/Linglib/Core/Data/List/EqOn.lean
@@ -62,7 +62,7 @@ theorem dependsOn_iff_forall_dependsAt {g : List α → γ} {K : Set ℕ} :
 /-- `g` factors through the input's length and its restriction to `K`. -/
 theorem dependsOn_iff_factorsThrough :
     DependsOn g K ↔
-      Function.FactorsThrough g (fun u : List α => (u.length, K.restrict (u[·]?))) := by
+      Function.FactorsThrough g (fun u : List α => (u.length, K.domRestrict (u[·]?))) := by
   constructor
   · intro h u v huv
     rw [Prod.mk.injEq] at huv

--- a/Linglib/Core/Order/ComparativeProbability/Cancellation.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Cancellation.lean
@@ -263,11 +263,11 @@ private lemma ge_empty_of_all_null {n : ℕ} (sys : EpistemicSystemFA (Fin n))
   | empty => simp only [Finset.coe_empty]; exact sys.refl ∅
   | @insert a S' haS' ih =>
     have h1 : (↑S' : Set (Fin n)) \ ({a} ∪ ↑S') = ∅ := by
-      ext x; simp only [Set.mem_diff, Set.mem_union, Finset.mem_coe,
+      ext x; simp only [Set.mem_sdiff, Set.mem_union, Finset.mem_coe,
         Set.mem_empty_iff_false, iff_false, not_and, Decidable.not_not]
       intro hx; exact Or.inr hx
     have h2 : ({a} ∪ ↑S' : Set (Fin n)) \ ↑S' = {a} := by
-      ext x; simp only [Set.mem_diff, Set.mem_union, Set.mem_singleton_iff, Finset.mem_coe]
+      ext x; simp only [Set.mem_sdiff, Set.mem_union, Set.mem_singleton_iff, Finset.mem_coe]
       constructor
       · rintro ⟨hx | hx, hnx⟩ <;> [exact hx; exact absurd hx hnx]
       · rintro rfl; exact ⟨Or.inl rfl, fun h => haS' (Finset.mem_coe.mp h)⟩

--- a/Linglib/Core/Order/ComparativeProbability/Completeness.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Completeness.lean
@@ -192,7 +192,7 @@ theorem exists_dominationLift_repr {W : Type*} [Fintype W]
     `A \ B` unchanged: `(A ∪ C) \ (B ∪ C) = A \ B`. -/
 private theorem union_diff_union_disjoint {W : Type*} (A B C : Set W)
     (hAC : ∀ x, x ∈ A → x ∉ C) : (A ∪ C) \ (B ∪ C) = A \ B := by
-  ext x; simp only [Set.mem_diff, Set.mem_union]
+  ext x; simp only [Set.mem_sdiff, Set.mem_union]
   refine ⟨fun h => h.1.elim (fun hx => ⟨hx, fun hb => h.2 (Or.inl hb)⟩)
     (fun hx => absurd (Or.inr hx) h.2), fun ⟨hxA, hxnB⟩ =>
     ⟨Or.inl hxA, fun h => h.elim hxnB (hAC x hxA)⟩⟩
@@ -211,7 +211,7 @@ theorem axiomA_iff_fa {W : Type*} (ge : Set W → Set W → Prop) :
   · intro hFA A B
     have h := hFA (A \ B) (B \ A) (A ∩ B)
       (fun x ⟨_, hxnB⟩ ⟨_, hxB⟩ => hxnB hxB) (fun x ⟨_, hxnA⟩ ⟨hxA, _⟩ => hxnA hxA)
-    rw [Set.diff_union_inter A B, Set.inter_comm A B, Set.diff_union_inter B A] at h
+    rw [Set.sdiff_union_inter A B, Set.inter_comm A B, Set.sdiff_union_inter B A] at h
     exact h.symm
 
 end ComparativeProbability

--- a/Linglib/Core/Order/ComparativeProbability/Conditional.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Conditional.lean
@@ -197,7 +197,7 @@ theorem bayesian_is_jeffrey {W : Type*} (m : CondMeasure W) (B A : Set W) :
     for each fixed B. -/
 theorem condMeasure_reflexive_per_evidence {W : Type*}
     (m : CondMeasure W) (B : Set W) :
-    Reflexive (fun A C => m.condGe A C B) :=
+    ∀ A, m.condGe A A B :=
   fun _ => le_refl _
 
 end ComparativeProbability

--- a/Linglib/Core/Order/ComparativeProbability/Entailments.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Entailments.lean
@@ -267,7 +267,7 @@ theorem dominationLift_not_V13 :
       (∀ w, ge_w w w) ∧ ¬patternV13 (dominationLift ge_w) := by
   refine ⟨Fin 2, fun _ _ => True, fun _ => trivial, fun h => ?_⟩
   have hA : ({0} : Set (Fin 2)) \ {1} = {0} := by
-    ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]; omega
+    ext x; simp only [Set.mem_sdiff, Set.mem_singleton_iff]; omega
   have hstrict : Strict (dominationLift (fun (_ _ : Fin 2) => True)) ({0} \ {1}) ∅ :=
     ⟨fun b hb => hb.elim, fun hge => by
       obtain ⟨a, ha, _⟩ := hge (0 : Fin 2) (by rw [hA]; rfl); exact ha.elim⟩

--- a/Linglib/Core/Order/ComparativeProbability/Representability.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Representability.lean
@@ -93,7 +93,7 @@ private theorem toFS_empty : toFS (∅ : Set (Fin 5)) = ∅ := by
 
 private theorem toFS_diff (A B : Set (Fin 5)) :
     toFS (A \ B) = toFS A \ toFS B := by
-  ext x; simp only [toFS_mem, Set.mem_diff, Finset.mem_sdiff]
+  ext x; simp only [toFS_mem, Set.mem_sdiff, Finset.mem_sdiff]
 
 private theorem toFS_subset (A B : Set (Fin 5)) :
     A ⊆ B ↔ toFS A ⊆ toFS B :=
@@ -213,30 +213,30 @@ theorem null_removal_disjoint {W : Type*} (sys : EpistemicSystemFA W)
     by_cases hj_in : j ∈ S
     · rw [sys.additive (S \ {j}) S,
         show (S \ {j}) \ S = ∅ by
-          ext x; simp only [Set.mem_diff, Set.mem_empty_iff_false, iff_false]; tauto,
+          ext x; simp only [Set.mem_sdiff, Set.mem_empty_iff_false, iff_false]; tauto,
         show S \ (S \ {j}) = {j} by
-          ext x; simp only [Set.mem_diff, Set.mem_singleton_iff]
+          ext x; simp only [Set.mem_sdiff, Set.mem_singleton_iff]
           exact ⟨fun ⟨hx, hn⟩ => by by_contra hne; exact hn ⟨hx, hne⟩,
             by rintro rfl; exact ⟨hj_in, fun ⟨_, h⟩ => h rfl⟩⟩]
       exact hj
-    · rw [Set.diff_singleton_eq_self hj_in]; exact sys.refl S
+    · rw [Set.sdiff_singleton_eq_self hj_in]; exact sys.refl S
   by_cases hjC : j ∈ C
   · have hjnD : j ∉ D := Set.disjoint_left.mp hdisj hjC
-    rw [Set.diff_singleton_eq_self hjnD]
+    rw [Set.sdiff_singleton_eq_self hjnD]
     exact ⟨fun h => sys.trans _ _ _ (null_sub C) h,
-           fun h => sys.trans _ _ _ (sys.mono _ _ Set.diff_subset) h⟩
-  · rw [Set.diff_singleton_eq_self hjC]
+           fun h => sys.trans _ _ _ (sys.mono _ _ Set.sdiff_subset) h⟩
+  · rw [Set.sdiff_singleton_eq_self hjC]
     by_cases hjD : j ∈ D
-    · exact ⟨fun h => sys.trans _ _ _ h (sys.mono _ _ Set.diff_subset),
+    · exact ⟨fun h => sys.trans _ _ _ h (sys.mono _ _ Set.sdiff_subset),
              fun h => sys.trans _ _ _ h (null_sub D)⟩
-    · rw [Set.diff_singleton_eq_self hjD]
+    · rw [Set.sdiff_singleton_eq_self hjD]
 
 /-- `Fin.succ '' (Fin.succ ⁻¹' S) = S \ {0}` for `S : Set (Fin (n+1))`. -/
 private theorem succ_image_preimage {n : ℕ} (S : Set (Fin (n + 1))) :
     Fin.succ '' (Fin.succ ⁻¹' S) = S \ {(0 : Fin (n + 1))} := by
   rw [Set.image_preimage_eq_range_inter, Fin.range_succ]
   ext x; simp only [Set.mem_inter_iff, Set.mem_compl_iff, Set.mem_singleton_iff,
-    Set.mem_diff]; exact And.comm
+    Set.mem_sdiff]; exact And.comm
 
 /-- Pull back an FA system along an injection: `α`-propositions compare via their
     images. Non-triviality requires a witness and must be supplied. -/
@@ -256,7 +256,7 @@ def comapFA {α W : Type*} (f : α → W) (hf : Function.Injective f)
   trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
   additive A B := by
     show sys.ge (f '' A) (f '' B) ↔ sys.ge (f '' (A \ B)) (f '' (B \ A))
-    rw [Set.image_diff hf, Set.image_diff hf]; exact sys.additive _ _
+    rw [Set.image_sdiff hf, Set.image_sdiff hf]; exact sys.additive _ _
 
 /-- Null element reduction: if atom 0 is null in an FA system on `Fin (n+2)` and
     some atom is not, representability reduces along `Fin.succ` to `Fin (n+1)`. -/
@@ -371,7 +371,7 @@ private theorem not_both_null_fin2 (sys : EpistemicSystemFA (Fin 2)) :
   intro ⟨h0, h1⟩
   have hd1 : ({(0 : Fin 2)} : Set _) \ Set.univ = ∅ := by ext x; simp
   have hd2 : Set.univ \ ({(0 : Fin 2)} : Set _) = {(1 : Fin 2)} := by
-    ext x; simp only [Set.mem_diff, Set.mem_univ, Set.mem_singleton_iff, true_and, Fin.ext_iff]
+    ext x; simp only [Set.mem_sdiff, Set.mem_univ, Set.mem_singleton_iff, true_and, Fin.ext_iff]
     omega
   exact sys.nonTrivial (sys.trans _ _ _ h0
     ((sys.additive {0} Set.univ).mpr (hd1 ▸ hd2 ▸ h1)))
@@ -553,7 +553,7 @@ def padFA {n : ℕ} (sys : EpistemicSystemFA (Fin n)) : EpistemicSystemFA (Fin (
   trans _ _ _ h1 h2 := sys.trans _ _ _ h1 h2
   additive A B := by
     show sys.ge _ _ ↔ sys.ge _ _
-    rw [Set.preimage_diff, Set.preimage_diff]; exact sys.additive _ _
+    rw [Set.preimage_sdiff, Set.preimage_sdiff]; exact sys.additive _ _
 
 /-- The padded atom is null. -/
 theorem padFA_last_null {n : ℕ} (sys : EpistemicSystemFA (Fin n)) :

--- a/Linglib/Core/Order/ComparativeProbability/Systems.lean
+++ b/Linglib/Core/Order/ComparativeProbability/Systems.lean
@@ -86,7 +86,7 @@ structure EpistemicSystemW (W : Type*) where
   /-- The "at least as likely as" relation on propositions. -/
   ge : Set W → Set W → Prop
   /-- Reflexivity. -/
-  refl : Reflexive ge
+  refl : ∀ A, ge A A
   /-- Monotonicity: supersets are at least as likely. -/
   mono : ∀ A B : Set W, A ⊆ B → ge B A
 
@@ -330,7 +330,7 @@ def matchingLift (ge_w : W → W → Prop) (A B : Set W) : Prop :=
     (∀ b₁ b₂, b₁ ∈ B → b₂ ∈ B → f b₁ = f b₂ → b₁ = b₂)
 
 /-- The l-lifting of a reflexive relation is reflexive. -/
-theorem dominationLift_axiomR (hRefl : ∀ w, ge_w w w) : Reflexive (dominationLift ge_w) :=
+theorem dominationLift_axiomR (hRefl : ∀ w, ge_w w w) : ∀ A, dominationLift ge_w A A :=
   fun _ b hb => ⟨b, hb, hRefl b⟩
 
 /-- The l-lifting of a reflexive relation is monotone. -/
@@ -412,7 +412,7 @@ theorem dominationLift_axiomDS : DeterminedBySingletons (dominationLift ge_w) :=
     ⟨a, ha, fun _b' hb' => ⟨a, rfl, hb' ▸ hab⟩⟩
 
 /-- The m-lifting of a reflexive relation is reflexive. -/
-theorem matchingLift_axiomR (hRefl : ∀ w, ge_w w w) : Reflexive (matchingLift ge_w) :=
+theorem matchingLift_axiomR (hRefl : ∀ w, ge_w w w) : ∀ A, matchingLift ge_w A A :=
   fun _ => ⟨id, fun b hb => ⟨hb, hRefl b⟩, fun _ _ _ _ h => h⟩
 
 /-- The m-lifting of a reflexive relation is monotone. -/

--- a/Linglib/Logic/BeliefRevision.lean
+++ b/Linglib/Logic/BeliefRevision.lean
@@ -115,7 +115,7 @@ private lemma filter_sublist_of_imp {α : Type*} (l : List α)
     by_cases hpa : p a
     · have hqa : q a := h a List.mem_cons_self hpa
       rw [if_pos (by simpa using hpa), if_pos (by simpa using hqa)]
-      exact ih'.cons₂ a
+      exact ih'.cons_cons a
     · rw [if_neg (by simpa using hpa)]
       by_cases hqa : q a
       · rw [if_pos (by simpa using hqa)]; exact ih'.cons a
@@ -238,7 +238,7 @@ private theorem mu_diff_eq_zero_of_condMu {W : Type*}
   rw [m.cond_univ, m.cond_univ] at hchain
   rw [hpsic, zero_mul] at hchain
   have : φ \ ψ = ψᶜ ∩ φ := by
-    ext x; simp [Set.mem_diff, Set.mem_compl_iff, Set.mem_inter_iff, and_comm]
+    ext x; simp [Set.mem_sdiff, Set.mem_compl_iff, Set.mem_inter_iff, and_comm]
   rw [this]; exact hchain
 
 open ComparativeProbability in

--- a/Linglib/Studies/Kratzer1977.lean
+++ b/Linglib/Studies/Kratzer1977.lean
@@ -224,25 +224,25 @@ lemma not_q_and_negQ {B : List (Fin 4 → Prop)} (hCons : isConsistent B)
 lemma pq_sublist_A : ([p, q] : List (Fin 4 → Prop)) ∈ A.sublists := by
   rw [List.mem_sublists]
   -- Build [p, q].Sublist [p, q, negQ]: keep p, keep q, drop negQ.
-  exact ((List.nil_sublist [negQ]).cons₂ q).cons₂ p
+  exact ((List.nil_sublist [negQ]).cons_cons q).cons_cons p
 
 /-- `[p, negQ]` is a sublist of `[p, q, negQ]` (drop `q`). -/
 lemma pnegQ_sublist_A : ([p, negQ] : List (Fin 4 → Prop)) ∈ A.sublists := by
   rw [List.mem_sublists]
   -- Build [p, negQ].Sublist [p, q, negQ]: keep p, drop q, keep negQ.
-  exact ((List.Sublist.refl ([negQ] : List (Fin 4 → Prop))).cons q).cons₂ p
+  exact ((List.Sublist.refl ([negQ] : List (Fin 4 → Prop))).cons q).cons_cons p
 
 /-- `[p]` is a sublist of `[p, q, negQ]`. -/
 lemma p_sublist_A : ([p] : List (Fin 4 → Prop)) ∈ A.sublists := by
   rw [List.mem_sublists]
   -- Build [p].Sublist [p, q, negQ]: keep p, drop q, drop negQ.
-  exact ((List.nil_sublist [negQ]).cons q).cons₂ p
+  exact ((List.nil_sublist [negQ]).cons q).cons_cons p
 
 /-- `[q]` is a sublist of `[p, q, negQ]`. -/
 lemma q_sublist_A : ([q] : List (Fin 4 → Prop)) ∈ A.sublists := by
   rw [List.mem_sublists]
   -- Build [q].Sublist [p, q, negQ]: drop p, keep q, drop negQ.
-  exact (((List.nil_sublist [negQ]).cons₂ q).cons p)
+  exact (((List.nil_sublist [negQ]).cons_cons q).cons p)
 
 /-- `[negQ]` is a sublist of `[p, q, negQ]`. -/
 lemma negQ_sublist_A : ([negQ] : List (Fin 4 → Prop)) ∈ A.sublists := by


### PR DESCRIPTION
Pin-bump adoption sweep for mathlib deprecations: `Reflexive` (→ explicit `∀ A, ge A A`, the `Setoid.iseqv` shape, in `EpistemicSystemW` and the lifting theorems), `Set.restrict` → `Set.domRestrict`, `Set.mem_diff`/`Set.diff_*` → the `sdiff` names, `List.Sublist.cons₂` → `cons_cons`. The only term-level `Symmetric` was removed in #2355; every other hit is prose.