### PR TITLE
refactor(Studies/MarcoRasin2026): JTA paradigms on the Optimal Paradigms engine

### DIFF
--- a/Linglib/Studies/MarcoRasin2026.lean
+++ b/Linglib/Studies/MarcoRasin2026.lean
@@ -1,408 +1,157 @@
-import Linglib.Phonology.Constraints.Lift
-import Linglib.Phonology.Constraints.Basic
-import Linglib.Phonology.OptimalityTheory.Tableau
-import Linglib.Phonology.Segmental.Basic
-import Linglib.Phonology.OptimalityTheory.TableauSystem
+import Linglib.Studies.McCarthy2005
 
 /-!
-# Marco & Rasin (2026): Optimal Paradigms — A Challenge from JTA
-[marco-rasin-2026] [mccarthy-2005]
+# [marco-rasin-2026] — Optimal Paradigms and Judeo-Tripolitanian Arabic
 
-Formalizes the argument that Optimal Paradigms (OP) cannot simultaneously
-predict the distribution of schwa in verbs, nouns, and adjectives in
-Judeo-Tripolitanian Arabic (JTA). The core paradox:
+[mccarthy-2005] derived the Moroccan Arabic noun–verb asymmetry in the position of schwa —
+verbs CCəC regardless of sonority, nouns CəCC when C₂ is more sonorous than C₃ — from
+paradigm structure: most verbal suffixes are C-initial, so OP-MAX-V draws the unsuffixed
+verb to CCəC by majority rules, whereas the one-member noun paradigm is left to SONCON.
+The prediction (11) is that a CCəC stem with C₂ more sonorous than C₃ appears before more
+C-initial than V-initial suffixes. In Judeo-Tripolitanian Arabic verbs and nouns pattern as
+in Moroccan (13)–(14), but adjectives are CCəC regardless of sonority (15)–(16) while
+inflecting, like nouns, with V-initial suffixes only (18): under McCarthy's ranking OP selects
+the levelled CəCC paradigm (19), and treating the adjective as a paradigm of one selects CəCC
+as well (20). A category-specific template {CCəC}_{Verb, Adj} (22) derives the pattern (23), against
+the thesis of category-neutral phonology ([bobaljik-2008]).
 
-- **Verbs**: schwa always between C₂ and C₃ (CCəC), regardless of sonority
-- **Adjectives**: same as verbs — CCəC regardless of sonority
-- **Nouns**: sonority-sensitive — CəCC when C₂ > C₃, CCəC otherwise
-
-Adjectives share phonological behavior with verbs but paradigm structure
-with nouns (only V-initial suffixes). OP predicts phonological behavior
-should track paradigm structure, so it wrongly predicts adjectives should
-behave like nouns.
-
-## Modeling note
-
-In OP, candidates are **whole paradigms** where each member independently
-chooses a stem shape. Markedness constraints (*CCC, *ə]σ) determine the
-shapes of suffixed members: C-initial suffixed forms must be CCəC (to
-avoid tri-consonantal clusters), V-initial suffixed forms must be CəCC
-(to avoid schwa in an open syllable). Only the suffix-less bare form
-is free — its shape is determined by OP-MAX-V (paradigm uniformity).
-
-For verbs, we enumerate the 4 candidates from tableau (10) in the paper.
-For adjectives, we enumerate all 2³ = 8 possible paradigms exhaustively.
-The main result (`adj_always_initial`) proves that the uniform CəCC
-paradigm has 0 violations on all four constraints and thus wins under
-every ranking — contradicting the attested CCəC pattern.
-
-The paper considers two scenarios for adjectives: with a paradigm
-(tableau (19)) and without (tableau (20)). Both fail — `op_wrong_adjectives`
-covers (19) and `op_wrong_adj_bare` covers (20), formalizing the paper's
-argument that OP fails "regardless of what constitutes a paradigm."
+The paradigms, constraints and ranking are those of the [mccarthy-2005] study, run on the
+JTA data; schwa is epenthetic (fn. 5), so the input is the bare root.
 -/
 
 namespace MarcoRasin2026
 
-open Core.Optimization Constraints OptimalityTheory
-open OptimalityTheory
-open Phonology (Sonority)
+open Constraints OptimalityTheory McCarthy2005 McCarthy2005.Arabic
 
--- ============================================================================
--- § 1: Data Types
--- ============================================================================
+/-- The CCəC realisation of the root /C₁C₂C₃/ in a cell, the schwa epenthetic. -/
+def schwaMedial (c₁ c₂ c₃ : Seg) (suffix : List Seg) : Member Seg (List Seg) :=
+  ⟨suffix, [c₁, c₂, .schwa, c₃], [(0, 0), (1, 1), (2, 3)]⟩
 
-/-- The two possible schwa positions in a tri-consonantal stem C₁C₂C₃.
-    `medial` = CCəC (schwa between C₂ and C₃); `initial` = CəCC (schwa
-    between C₁ and C₂). -/
-inductive SchwaPos where
-  | medial   -- CCəC: schwa between C₂ and C₃
-  | initial  -- CəCC: schwa between C₁ and C₂
-  deriving DecidableEq, Repr, BEq, Inhabited
+/-- The CəCC realisation. -/
+def schwaInitial (c₁ c₂ c₃ : Seg) (suffix : List Seg) : Member Seg (List Seg) :=
+  ⟨suffix, [c₁, .schwa, c₂, c₃], [(0, 0), (1, 2), (2, 3)]⟩
 
-/-- Suffix onset type, determining the phonological environment. -/
-inductive SuffixOnset where
-  | cInit  -- C-initial suffix (e.g., -t, -na, -ti, -tu)
-  | vInit  -- V-initial suffix (e.g., -ət, -u; -a, -in)
-  | bare   -- No suffix (bare form)
-  deriving DecidableEq, Repr, BEq
+/-- The candidate paradigms of a root over the bare cell, the C-initial and the V-initial
+suffixes (10): the bare stem CCəC or CəCC with the suffixed stems fixed by the phonotactics,
+or levelled to CCəC or to CəCC. -/
+def paradigms (c₁ c₂ c₃ : Seg) (cInitial vInitial : List (List Seg)) :
+    Cand → Paradigm Seg (List Seg)
+  | .a => ⟨root, ([] :: cInitial).map medial ++ vInitial.map initial⟩
+  | .b => ⟨root, initial [] :: cInitial.map medial ++ vInitial.map initial⟩
+  | .c => ⟨root, ([] :: cInitial ++ vInitial).map medial⟩
+  | _ => ⟨root, ([] :: cInitial ++ vInitial).map initial⟩
+where
+  root : List Seg := [c₁, c₂, c₃]
+  medial := schwaMedial c₁ c₂ c₃
+  initial := schwaInitial c₁ c₂ c₃
 
-/-- A single paradigm member: schwa position + suffix type. -/
-structure JTAForm where
-  schwa : SchwaPos
-  suffix : SuffixOnset
-  deriving DecidableEq, Repr, BEq
+/-- The constraints (8) in McCarthy's ranking: \*ə]σ, \*CCC >> OP-MAX-V >> SONCON. -/
+def ranking : List (Constraint (Paradigm Seg (List Seg))) :=
+  [markedness λ suf s => schwaOpen (s ++ suf), markedness λ suf s => ccc (s ++ suf),
+   opFaith (Correspondence.maxViolOn IsVowel), markedness λ suf s => sonCon (s ++ suf)]
 
--- ============================================================================
--- § 2: McCarthy's Constraints
--- ============================================================================
+/-! ### Moroccan Arabic (§2) -/
 
-/-- *CCC: assign * for every sequence of three consonants.
-    Violated by CəCC (initial) stems before C-initial suffixes:
-    C₁əC₂C₃ + C → C₂C₃C = tri-consonantal cluster. -/
-def starCCC : Constraint (List JTAForm) :=
-  liftPerMember fun f =>
-    if f.schwa == .initial && f.suffix == .cInit then 1 else 0
+/-- The Moroccan perfective suffixes (6). -/
+def moroccan : Cand → Paradigm Seg (List Seg) :=
+  paradigms .sh .r .b [[.t], [.n, .a], [.t, .i], [.t, .u]] [[.schwa, .t], [.u]]
 
-/-- *ə]σ: assign * for every schwa in an open syllable.
-    Violated by CCəC (medial) stems before V-initial suffixes:
-    C₁C₂ə.C₃V → schwa in open syllable. -/
-def starSchwaOpen : Constraint (List JTAForm) :=
-  liftPerMember fun f =>
-    if f.schwa == .medial && f.suffix == .vInit then 1 else 0
-
-/-- SONCON: assign * for a CCəC (medial) form when C₂ > C₃ in sonority.
-    Parametrized over the sonority ranks of C₂ and C₃, using the
-    `LinearOrder Sonority` instance from `Syllable`. -/
-def sonCon (c2 c3 : Phonology.Sonority) :
-    Constraint (List JTAForm) :=
-  liftPerMember fun f =>
-    if c2 > c3 && f.schwa == .medial then 1 else 0
-
-/-- OP-MAX-V: assign * for each ordered pair of paradigm members with
-    different schwa positions. Each positional mismatch = 1 violation.
-    For n₁ medial and n₂ initial members: n₁·n₂ + n₂·n₁ = 2·n₁·n₂
-    total violations (matching [mccarthy-2005]'s counting). -/
-def opMaxV : Constraint (List JTAForm) :=
-  liftPairwise fun f1 f2 =>
-    if f1.schwa != f2.schwa then 1 else 0
-
--- ============================================================================
--- § 3: Verbal Paradigm — 4 Candidates (Tableau 10)
--- ============================================================================
-
-/-- JTA verbal suffixes: bare + 4 C-initial + 2 V-initial = 7 members. -/
-def vSuf : List SuffixOnset :=
-  [.bare, .cInit, .cInit, .cInit, .cInit, .vInit, .vInit]
-
-/-- Helper: build a paradigm from a list of schwa positions and suffix list. -/
-def mkP (shapes : List SchwaPos) (suffixes : List SuffixOnset) : List JTAForm :=
-  (shapes.zip suffixes).map fun (s, suf) => ⟨s, suf⟩
-
--- The 4 candidates from tableau (10):
--- Markedness determines suffixed forms; only bare form varies.
--- C-init suffixed → medial (avoids *CCC), V-init suffixed → initial (avoids *ə]σ)
-
-/-- (10a) ☞ Bare=medial: 5 medial, 2 initial. OP-MAX-V = 20. -/
-def vA := mkP [.medial, .medial, .medial, .medial, .medial, .initial, .initial] vSuf
-/-- (10b) Bare=initial: 4 medial, 3 initial. OP-MAX-V = 24. -/
-def vB := mkP [.initial, .medial, .medial, .medial, .medial, .initial, .initial] vSuf
-/-- (10c) Uniform medial: *ə]σ violated twice. -/
-def vC := mkP [.medial, .medial, .medial, .medial, .medial, .medial, .medial] vSuf
-/-- (10d) Uniform initial: *CCC violated four times. -/
-def vD := mkP [.initial, .initial, .initial, .initial, .initial, .initial, .initial] vSuf
-
-def verbCands : List (List JTAForm) := [vA, vB, vC, vD]
-theorem verbCands_ne : verbCands ≠ [] := by simp [verbCands]
-
--- ============================================================================
--- § 4: Nominal Paradigm — 2 Candidates (Tableau 12)
--- ============================================================================
-
-/-- Nouns: bare singular only (1 member). -/
-def nM := mkP [.medial] [.bare]   -- CCəC
-def nI := mkP [.initial] [.bare]  -- CəCC
-
-def nounCands : List (List JTAForm) := [nM, nI]
-theorem nounCands_ne : nounCands ≠ [] := by simp [nounCands]
-
--- ============================================================================
--- § 5: Adjectival Paradigm — All 8 Candidates (Exhaustive)
--- ============================================================================
-
-/-- Adjective suffixes: bare (MSG) + 2 V-initial (-a FSG, -in PL). -/
-def aSuf : List SuffixOnset := [.bare, .vInit, .vInit]
-
-/-- All 2³ = 8 possible adjective paradigms. Exhaustive enumeration
-    ensures the negative result holds for ALL candidates, not just
-    selected ones. -/
-def adjCands : List (List JTAForm) :=
-  [ mkP [.medial,  .medial,  .medial]  aSuf   -- MMM
-  , mkP [.medial,  .medial,  .initial] aSuf   -- MMI
-  , mkP [.medial,  .initial, .medial]  aSuf   -- MIM
-  , mkP [.medial,  .initial, .initial] aSuf   -- MII (attested)
-  , mkP [.initial, .medial,  .medial]  aSuf   -- IMM
-  , mkP [.initial, .medial,  .initial] aSuf   -- IMI
-  , mkP [.initial, .initial, .medial]  aSuf   -- IIM
-  , mkP [.initial, .initial, .initial] aSuf ] -- III (OP prediction)
-theorem adjCands_ne : adjCands ≠ [] := by simp [adjCands]
-
-/-- The attested adjective paradigm: bare=medial, V-init=initial. -/
-def adjAttested := mkP [.medial, .initial, .initial] aSuf
-/-- The OP-predicted paradigm: uniform initial. -/
-def adjOPpred := mkP [.initial, .initial, .initial] aSuf
-
--- ============================================================================
--- § 6: OP Analysis — McCarthy's Ranking
--- ============================================================================
-
-/-- McCarthy's ranking: *ə]σ, *CCC ≫ OP-MAX-V ≫ SONCON (for C₂ > C₃). -/
-def mccarthyRanking : List (Constraint (List JTAForm)) :=
-  [starSchwaOpen, starCCC, opMaxV, sonCon .liquid .stop]
-
-set_option maxHeartbeats 800000 in
-/-- OP correctly selects the attested verbal paradigm (10a): bare=medial.
-    Majority Rules in action — the bare form aligns with the C-initial
-    majority (5 medial vs 2 initial members). -/
-theorem op_correct_verbs :
-    (Tableau.ofRanking verbCands mccarthyRanking verbCands_ne).optimal =
-      {vA} := by decide
-
-/-- OP correctly selects CəCC for nouns (when C₂ > C₃). Single-member
-    paradigm, so OP-MAX-V is vacuous; SONCON decides. -/
-theorem op_correct_nouns :
-    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal =
-      {nI} := by decide
-
-set_option maxHeartbeats 800000 in
-/-- OP wrongly selects uniform-initial for adjectives (tableau (19)).
-    Adjectives have only V-initial suffixes (like nouns), so OP-MAX-V
-    cannot force medial schwa in the bare form. SONCON then favors
-    initial. -/
-theorem op_wrong_adjectives :
-    (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne).optimal =
-      {adjOPpred} := by decide
-
-set_option maxHeartbeats 800000 in
-/-- The attested adjective paradigm (bare=CCəC) is NOT selected by OP. -/
-theorem op_fails_adjectives :
-    (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne).optimal ≠
-      {adjAttested} := by decide
-
--- ============================================================================
--- § 7: No Ranking Works for Adjectives (Main Negative Result)
--- ============================================================================
-
-/-- The four constraints used in McCarthy's OP analysis. -/
-def opConstraints : List (Constraint (List JTAForm)) :=
-  [starSchwaOpen, starCCC, opMaxV, sonCon .liquid .stop]
-
-/-- The uniform-initial adjective paradigm has **zero violations on all
-    four OP constraints**. This is the structural reason it wins under
-    every ranking — not a coincidence of McCarthy's particular ranking.
-
-    - *ə]σ: 0 — initial schwa (CəCC) is never in an open syllable
-    - *CCC: 0 — no C-initial suffixes in the adjective paradigm
-    - OP-MAX-V: 0 — uniform paradigm, no positional mismatches
-    - SONCON: 0 — no medial (CCəC) forms to violate sonority
-
-    A candidate with profile [0,0,...,0] is the minimum of any
-    lexicographic order on Nat-valued profiles (`ViolationProfile.zero_le`),
-    so permuting the ranking cannot change the outcome. -/
-theorem adjOPpred_zero_viols :
-    ∀ con ∈ opConstraints, con adjOPpred = 0 := by decide
-
-/-- Structural consequence of `adjOPpred_zero_viols`: the uniform-initial
-    paradigm is optimal under **every** permutation of the four OP
-    constraints. Uses `Tableau.ofRanking_zero_optimal_allRankings` from the
-    general OT infrastructure — no finitary enumeration needed. -/
-private theorem adjOPpred_mem : adjOPpred ∈ adjCands := by
-  simp only [adjCands, adjOPpred, List.mem_cons]; tauto
-
-theorem adjOPpred_always_optimal :
-    ∀ ranking ∈ opConstraints.permutations',
-      adjOPpred ∈ (Tableau.ofRanking adjCands ranking adjCands_ne).optimal :=
-  fun _ hrk => Tableau.ofRanking_zero_mem_optimal_allRankings adjOPpred_mem
-    adjOPpred_zero_viols hrk
-
-set_option maxHeartbeats 4000000 in
-/-- **Main result.** No ranking of the four OP constraints selects the
-    attested adjective paradigm (bare=CCəC).
-
-    The uniform-initial paradigm has **zero violations on all four
-    constraints** (`adjOPpred_zero_viols`), making it the lexicographic
-    minimum under any permutation (`adjOPpred_always_optimal`). Moreover,
-    it is the **unique** winner — no other candidate also has a zero
-    profile (verified by `decide`).
-
-    Since [0,0,0,0] is the lexicographic minimum regardless of constraint
-    permutation, uniform-initial wins under **every** ranking. The attested
-    paradigm (bare=medial, V-init=initial) always loses because it incurs
-    OP-MAX-V and SONCON violations.
-
-    This formalizes [marco-rasin-2026]'s central challenge: OP cannot
-    derive category-distinct phonological behavior when two categories share
-    paradigm structure but differ phonologically. -/
-theorem adj_always_initial :
-    ∀ ranking ∈ opConstraints.permutations',
-      (Tableau.ofRanking adjCands ranking adjCands_ne).optimal = {adjOPpred} := by
+/-- (10): majority rules — the unsuffixed *ʃrəb* joins the C-suffixed CCəC stems, twenty
+OP-MAX-V marks against twenty-four. -/
+theorem moroccan_verb : (tableau moroccan [.a, .b, .c, .d] ranking).optimal = {.a} := by
   decide
 
--- ============================================================================
--- § 8: OP Fails Without a Paradigm Too (Tableau (20))
--- ============================================================================
+/-- (12): the one-member noun paradigm is left to SONCON, *ʃərb*. -/
+theorem moroccan_noun : (tableau (paradigms .sh .r .b [] []) [.a, .b] ranking).optimal = {.b} := by
+  decide
 
-/-- If adjectives have no inflectional paradigm (single bare form, like
-    nouns), SONCON wrongly favors CəCC (initial). This is tableau (20)
-    in the paper: the single-member adjective case. Combined with
-    `op_wrong_adjectives` (tableau (19)), this shows OP fails
-    **regardless of what constitutes a paradigm** for JTA adjectives. -/
-theorem op_wrong_adj_bare :
-    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal =
-      {nI} := op_correct_nouns
+/-! ### Judeo-Tripolitanian Arabic verbs and nouns (§3.1) -/
 
-/-- The attested adjective form (CCəC = medial) is NOT selected when
-    adjectives are treated as having no paradigm. -/
-theorem op_wrong_adj_bare_not_attested :
-    (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne).optimal ≠
-      {nM} := by decide
+/-- The JTA perfective suffixes (13): five C-initial, two V-initial. -/
+def jtaVerb (c₁ c₂ c₃ : Seg) : Cand → Paradigm Seg (List Seg) :=
+  paradigms c₁ c₂ c₃ [[.ch], [.n, .a], [.ch], [.ch, .i], [.ch, .u]] [[.schwa, .ch], [.u]]
 
--- ============================================================================
--- § 9: Category-Specific Alternative
--- ============================================================================
+/-- (13): the paradigms of *ʃrəb* 'drink', *gdəm* 'bite' and *ktʃəb* 'write' — CCəC in the
+bare form and before C-initial suffixes, CəCC before V-initial ones, whatever the sonority
+of the root — are OP's optima. -/
+theorem jta_verbs :
+    ∀ r ∈ [(Seg.sh, Seg.r, Seg.b), (.g, .d, .m), (.k, .ch, .b)],
+      (tableau (jtaVerb r.1 r.2.1 r.2.2) [.a, .b, .c, .d] ranking).optimal = {.a} := by
+  decide
 
-/-- Morphosyntactic category, used for category-indexed constraints. -/
-inductive MorphCat where
-  | verb | adj | noun
-  deriving DecidableEq, Repr, BEq
+/-- The roots of the nouns (14): CəCC with C₂ more sonorous than C₃ — *kəlb, bəntʃ, wəld,
+səms, məlħ, tʃəlʒ* — and CCəC otherwise — *xʃəm, ħbəq, lħəm, sdər, bsəl, fħəm*. -/
+def nouns : List (Seg × Seg × Seg) × List (Seg × Seg × Seg) :=
+  ([(.k, .l, .b), (.b, .n, .ch), (.w, .l, .d), (.s, .m, .s), (.m, .l, .hh), (.ch, .l, .zh)],
+   [(.x, .sh, .m), (.hh, .b, .q), (.l, .hh, .m), (.s, .d, .r), (.b, .s, .l), (.f, .hh, .m)])
 
-/-- {CCəC}_{Verb, Adj}: template constraint applying to verbs and
-    adjectives but not nouns. Penalizes initial (CəCC) forms in verbs
-    and adjectives. Directly references morphosyntactic categories,
-    violating the TCNP ([bobaljik-2008]). -/
-def templateMedial (cat : MorphCat) : Constraint (List JTAForm) :=
-  liftPerMember fun f =>
-    match cat with
-    | .verb | .adj => if f.schwa == .initial then 1 else 0
-    | .noun => 0
+/-- (14): the one-member noun paradigms follow SONCON. -/
+theorem jta_nouns :
+    (∀ r ∈ nouns.1, (tableau (paradigms r.1 r.2.1 r.2.2 [] []) [.a, .b] ranking).optimal = {.b}) ∧
+    ∀ r ∈ nouns.2, (tableau (paradigms r.1 r.2.1 r.2.2 [] []) [.a, .b] ranking).optimal = {.a} := by
+  decide
 
-/-- Category-specific ranking: {CCəC}_{V,A} ≫ SONCON. -/
-def templateRanking (cat : MorphCat) : List (Constraint (List JTAForm)) :=
-  [templateMedial cat, sonCon .liquid .stop]
+/-! ### The challenge from adjectives (§3.2–3.3)
 
-/-- Template correctly selects medial (CCəC) for verbs.
-    (Using uniform candidates since template forces all members to medial.) -/
-def verbUnifM := mkP [.medial, .medial, .medial, .medial, .medial, .medial, .medial] vSuf
-def verbUnifI := mkP [.initial, .initial, .initial, .initial, .initial, .initial, .initial] vSuf
-def verbTemplateCands : List (List JTAForm) := [verbUnifM, verbUnifI]
-theorem verbTemplateCands_ne : verbTemplateCands ≠ [] := by simp [verbTemplateCands]
+Adjectives with C₂ more sonorous than C₃ — *bjəd* 'white', *zrəq* 'blue', *trəʃ* 'deaf',
+*ħwəl* 'cross-eyed' (15), the comparatives *qrəb*, *zjən* (16) — are CCəC like verbs, but
+inflect with the V-initial suffixes *-a*, *-in* alone (18). -/
 
-theorem template_correct_verbs :
-    (Tableau.ofRanking verbTemplateCands (templateRanking .verb) verbTemplateCands_ne).optimal =
-      {verbUnifM} := by decide
+/-- The adjectival paradigm of a root (18): bare, feminine *-a*, plural *-in*. -/
+def adjective (c₁ c₂ c₃ : Seg) : Cand → Paradigm Seg (List Seg) :=
+  paradigms c₁ c₂ c₃ [] [[.a], [.i, .n]]
 
-/-- Template correctly selects initial (CəCC) for nouns (template inactive). -/
-theorem template_correct_nouns :
-    (Tableau.ofRanking nounCands (templateRanking .noun) nounCands_ne).optimal =
-      {nI} := by decide
+/-- The roots of the adjectives with C₂ more sonorous than C₃, (15a) and (16). -/
+def adjectives : List (Seg × Seg × Seg) :=
+  [(.b, .j, .d), (.z, .r, .q), (.t, .r, .sh), (.hh, .w, .l), (.q, .r, .b), (.z, .j, .n)]
 
-/-- Template correctly selects the attested adjective paradigm — the case
-    where OP fails. The template forces medial (CCəC) for both verb and
-    adjective categories, overriding SONCON. -/
-def adjTemplateCands : List (List JTAForm) :=
-  [ mkP [.medial,  .medial,  .medial]  aSuf
-  , mkP [.initial, .initial, .initial] aSuf ]
-theorem adjTemplateCands_ne : adjTemplateCands ≠ [] := by simp [adjTemplateCands]
+/-- (19): OP fails — the attested ⟨trəʃ, tərʃa, tərʃin⟩ draws four OP-MAX-V marks and one
+of SONCON, and the levelled ⟨tərʃ, tərʃa, tərʃin⟩ none. -/
+theorem adjective_paradigm :
+    ∀ r ∈ adjectives, (tableau (adjective r.1 r.2.1 r.2.2) [.a, .b] ranking).optimal = {.b} := by
+  decide
 
-theorem template_correct_adjectives :
-    (Tableau.ofRanking adjTemplateCands (templateRanking .adj) adjTemplateCands_ne).optimal =
-      {mkP [.medial, .medial, .medial] aSuf} := by decide
+/-- (20): OP fails regardless of what constitutes a paradigm — as a paradigm of one, the
+adjective is left to SONCON, *tərʃ*. -/
+theorem adjective_bare :
+    ∀ r ∈ adjectives,
+      (tableau (paradigms r.1 r.2.1 r.2.2 [] []) [.a, .b] ranking).optimal = {.b} := by
+  decide
 
--- ============================================================================
--- § 10: Generic ConstraintSystem Predictions
--- ============================================================================
+/-! ### Category-specific templates (§3.3) -/
 
-/-! Each unique-winner tableau lifts to a generic `ConstraintSystem` via
-`tableauSystem`. For McCarthy's OP ranking this exposes the correct
-predictions for verbs and nouns, and the *wrong* prediction for adjectives —
-the empirical content of [marco-rasin-2026]'s argument. -/
+inductive Category
+  | verb | adjective | noun
+  deriving DecidableEq, Repr
 
-section PredictAPI
-open Core.Optimization Constraints
+/-- {CCəC}_{Verb, Adj} (22): the stem of a verb or an adjective surfaces as CCəC. -/
+def template : Category → List Seg → ℕ
+  | .noun, _ => 0
+  | _, [_, .schwa, _, _] => 1
+  | _, _ => 0
 
-/-- Verbal paradigm under McCarthy's OP ranking. -/
-noncomputable def verbSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (Tableau.ofRanking verbCands mccarthyRanking verbCands_ne)
+/-- The ranking (23): \*ə]σ, \*CCC >> {CCəC}_{Verb, Adj} >> SONCON. -/
+def templateRanking (cat : Category) : List (Constraint (Paradigm Seg (List Seg))) :=
+  [markedness λ suf s => schwaOpen (s ++ suf), markedness λ suf s => ccc (s ++ suf),
+   markedness λ _ s => template cat s, markedness λ suf s => sonCon (s ++ suf)]
 
-/-- OP correctly predicts the attested bare-medial verbal paradigm (10a). -/
-theorem verbSystem_predict_vA : verbSystem.predict vA = 1 :=
-  tableauSystem_predict_unique_winner _ _ op_correct_verbs
+/-- (23): the template selects the attested adjectival paradigms against SONCON. -/
+theorem template_adjective :
+    ∀ r ∈ adjectives,
+      (tableau (adjective r.1 r.2.1 r.2.2) [.a, .b] (templateRanking .adjective)).optimal =
+        {.a} := by
+  decide
 
-/-- Nominal paradigm under McCarthy's OP ranking. -/
-noncomputable def nounSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (Tableau.ofRanking nounCands mccarthyRanking nounCands_ne)
-
-/-- OP correctly predicts CəCC for nouns when C₂ > C₃. -/
-theorem nounSystem_predict_nI : nounSystem.predict nI = 1 :=
-  tableauSystem_predict_unique_winner _ _ op_correct_nouns
-
-/-- Adjectival paradigm under McCarthy's OP ranking. The probability-1
-    prediction here is the *wrong* uniform-initial paradigm — the formal
-    content of [marco-rasin-2026]'s challenge. -/
-noncomputable def adjSystem : ConstraintSystem (List JTAForm) (LexProfile Nat 4) :=
-  tableauSystem (Tableau.ofRanking adjCands mccarthyRanking adjCands_ne)
-
-/-- OP wrongly assigns probability 1 to the uniform-initial adjective
-    paradigm. The attested CCəC pattern receives probability 0 — the
-    formal sharpening of "OP fails for adjectives." -/
-theorem adjSystem_predict_OPpred : adjSystem.predict adjOPpred = 1 :=
-  tableauSystem_predict_unique_winner _ _ op_wrong_adjectives
-
-/-- Loser side: the attested adjective paradigm gets probability 0. -/
-theorem adjSystem_predict_attested_zero :
-    adjSystem.predict adjAttested = 0 :=
-  tableauSystem_predict_loser _ _ _
-    (by unfold adjAttested adjOPpred mkP; decide) op_wrong_adjectives
-
-/-- Verbal paradigm under the category-specific template ranking. -/
-noncomputable def verbTemplateSystem :
-    ConstraintSystem (List JTAForm) (LexProfile Nat 2) :=
-  tableauSystem (Tableau.ofRanking verbTemplateCands (templateRanking .verb) verbTemplateCands_ne)
-
-theorem verbTemplateSystem_predict_unifM :
-    verbTemplateSystem.predict verbUnifM = 1 :=
-  tableauSystem_predict_unique_winner _ _ template_correct_verbs
-
-/-- Adjectival paradigm under the category-specific template ranking —
-    now correctly predicting the attested medial pattern with probability 1. -/
-noncomputable def adjTemplateSystem :
-    ConstraintSystem (List JTAForm) (LexProfile Nat 2) :=
-  tableauSystem (Tableau.ofRanking adjTemplateCands (templateRanking .adj) adjTemplateCands_ne)
-
-theorem adjTemplateSystem_predict_medial :
-    adjTemplateSystem.predict (mkP [.medial, .medial, .medial] aSuf) = 1 :=
-  tableauSystem_predict_unique_winner _ _ template_correct_adjectives
-
-end PredictAPI
+/-- The template leaves the verbs (13) and the nouns (14) as they are. -/
+theorem template_verb_noun :
+    (∀ r ∈ [(Seg.sh, Seg.r, Seg.b), (.g, .d, .m), (.k, .ch, .b)],
+      (tableau (jtaVerb r.1 r.2.1 r.2.2) [.a, .b, .c, .d] (templateRanking .verb)).optimal
+        = {.a}) ∧
+    (∀ r ∈ nouns.1,
+      (tableau (paradigms r.1 r.2.1 r.2.2 [] []) [.a, .b] (templateRanking .noun)).optimal = {.b}) ∧
+    ∀ r ∈ nouns.2,
+      (tableau (paradigms r.1 r.2.1 r.2.2 [] []) [.a, .b] (templateRanking .noun)).optimal =
+        {.a} := by
+  decide
 
 end MarcoRasin2026

--- a/Linglib/Studies/McCarthy2005.lean
+++ b/Linglib/Studies/McCarthy2005.lean
@@ -157,12 +157,13 @@ syllable extrametrical, as the paper assumes; SWP marks a stressed light syllabl
 namespace Arabic
 
 inductive Seg
-  | f | ayn | l | s | sh | t | j | k | b | n | m | r | hh | a | aa | i | ii | u | schwa
+  | f | ayn | l | s | sh | t | j | k | b | n | m | r | hh | g | d | ch | x | q | w | z | zh
+  | a | aa | i | ii | u | schwa
   deriving DecidableEq, Repr
 
-def IsVowel (x : Seg) : Prop := x ∈ [Seg.a, .aa, .i, .ii, .u, .schwa]
+def IsVowel (c : Seg) : Prop := c ∈ [Seg.a, .aa, .i, .ii, .u, .schwa]
 
-instance : DecidablePred IsVowel := λ x => inferInstanceAs (Decidable (x ∈ _))
+instance : DecidablePred IsVowel := λ c => inferInstanceAs (Decidable (c ∈ _))
 
 /-- The weight of a vowel: long or short. -/
 def weight : Seg → Option Bool
@@ -188,9 +189,9 @@ def closeLast (coda : List Seg) : List Syllable → List Syllable
 before it but its onset close the previous one, and the final consonants close the last. -/
 def syllabifyRev : List Syllable → List Seg → List Seg → List Syllable
   | σs, pending, [] => closeLast pending σs
-  | σs, pending, x :: xs =>
-    if IsVowel x then syllabifyRev (⟨x, []⟩ :: closeLast pending.dropLast σs) [] xs
-    else syllabifyRev σs (pending ++ [x]) xs
+  | σs, pending, c :: rest =>
+    if IsVowel c then syllabifyRev (⟨c, []⟩ :: closeLast pending.dropLast σs) [] rest
+    else syllabifyRev σs (pending ++ [c]) rest
 
 def syllabify (w : List Seg) : List Syllable := (syllabifyRev [] [] w).reverse
 
@@ -222,14 +223,14 @@ def superheavy (w : List Seg) : ℕ := ((syllabify w).filter λ σ => 3 ≤ σ.m
 
 /-- ALIGN-L(Stem, σ): a stem-initial consonant before another is never syllable-initial. -/
 def alignL : List Seg → ℕ
-  | x :: y :: _ => if ¬IsVowel x ∧ ¬IsVowel y then 1 else 0
+  | c₁ :: c₂ :: _ => if ¬IsVowel c₁ ∧ ¬IsVowel c₂ then 1 else 0
   | _ => 0
 
 /-- \*.CᵢV.CᵢV: identical consonants in the onsets of successive syllables. -/
 def identicalOnsets : List Seg → ℕ
-  | x :: v :: y :: v' :: rest =>
-    (if ¬IsVowel x ∧ IsVowel v ∧ x = y ∧ IsVowel v' then 1 else 0)
-      + identicalOnsets (v :: y :: v' :: rest)
+  | c :: v :: c' :: v' :: rest =>
+    (if ¬IsVowel c ∧ IsVowel v ∧ c = c' ∧ IsVowel v' then 1 else 0)
+      + identicalOnsets (v :: c' :: v' :: rest)
   | _ => 0
 
 /-- An inflectional cell of the Classical Arabic verb or noun: its affixes, and whether a
@@ -274,7 +275,7 @@ def ioDepV : Constraint (Paradigm Seg Cell) := ioFaith (Correspondence.depViolOn
 def ioMaxV : Constraint (Paradigm Seg Cell) := ioFaith (Correspondence.maxViolOn IsVowel)
 
 def ioMaxC : Constraint (Paradigm Seg Cell) :=
-  ioFaith (Correspondence.maxViolOn λ x => ¬IsVowel x)
+  ioFaith (Correspondence.maxViolOn λ c => ¬IsVowel c)
 
 def ioIdentWt : Constraint (Paradigm Seg Cell) :=
   ioFaith (Correspondence.identViolFeature weight)
@@ -462,23 +463,23 @@ def schwaOpen (w : List Seg) : ℕ :=
 
 /-- \*CCC. -/
 def ccc : List Seg → ℕ
-  | x :: y :: z :: rest =>
-    (if ¬IsVowel x ∧ ¬IsVowel y ∧ ¬IsVowel z then 1 else 0) + ccc (y :: z :: rest)
+  | c₁ :: c₂ :: c₃ :: rest =>
+    (if ¬IsVowel c₁ ∧ ¬IsVowel c₂ ∧ ¬IsVowel c₃ then 1 else 0) + ccc (c₂ :: c₃ :: rest)
   | _ => 0
 
 /-- Sonority: glide > liquid > nasal > fricative > stop. -/
 def sonority : Seg → ℕ
-  | .j => 5
+  | .j | .w => 5
   | .l | .r => 4
   | .n | .m => 3
-  | .f | .s | .sh | .hh | .ayn => 2
+  | .f | .s | .sh | .hh | .ayn | .x | .z | .zh => 2
   | _ => 1
 
 /-- SONCON (30), on a word of three consonants and a schwa: CəC₂C₃ wants C₂ more sonorous
 than C₃, CC₂əC₃ not. -/
 def sonCon : List Seg → ℕ
-  | [_, .schwa, y, z] => if sonority y > sonority z then 0 else 1
-  | [_, y, .schwa, z] => if sonority y > sonority z then 1 else 0
+  | [_, .schwa, c₂, c₃] => if sonority c₂ > sonority c₃ then 0 else 1
+  | [_, c₂, .schwa, c₃] => if sonority c₂ > sonority c₃ then 1 else 0
   | _ => 0
 
 /-- The ranking of (32): \*ə]σ, \*CCC >> OP-MAX-V >> SONCON >> IO-MAX-V, IO-DEP-V. -/

--- a/references.bib
+++ b/references.bib
@@ -23804,7 +23804,7 @@
   title     = {Optimal Paradigms: A Challenge from {J}udeo-{T}ripolitanian {A}rabic},
   year      = {2026},
   journal   = {Linguistic Inquiry},
-  doi       = {10.1162/ling_a_00575},
+  doi       = {10.1162/LING.a.575},
   subfield  = {phonology},
   role      = {formalized},
   sources   = {Studies/MarcoRasin2026.lean}


### PR DESCRIPTION
Rewrites the study on McCarthy2005's `Paradigm` engine and Moroccan constraints (\*ə]σ, \*CCC, OP-MAX-V, SONCON), replacing the λ-table constraints over abstract ⟨schwa position, suffix type⟩ pairs, the exhaustive-permutation theorem, the `maxHeartbeats` bumps and the `ConstraintSystem` scaffolding with the paper's own tableaux run on its segmental data: Moroccan (10)/(12), the three JTA verb paradigms (13), the twelve nouns (14), the adjectives of (15)–(16) under (19) and (20), and the category-specific template (22)–(23).

- McCarthy2005's Arabic segment inventory gains the JTA consonants (g, d, tʃ, x, q, w, z, ʒ) and their sonority; clashing local names renamed
- bib: the DOI is `10.1162/LING.a.575` (the old one 404s); the study was checked against the accepted lingbuzz/009759 version