### PR TITLE
docs(Logic/PIP): module docstrings in mathlib register

### DIFF
--- a/Linglib/Logic/PIP/Felicity.lean
+++ b/Linglib/Logic/PIP/Felicity.lean
@@ -1,16 +1,17 @@
 import Linglib.Logic.PIP.Semantics
 
 /-!
-# PIP: felicity
+# Felicity of PIP formulas
 
-Truth and felicity are independent: `φ|ψ` is true iff `φ` is, and felicitous
-iff `φ` and `ψ` are and `ψ` is true. The felicity operator `F` is defined on the
-presupposition operator and the primitive connectives, with asymmetric
-conjunction — the first conjunct may satisfy the presuppositions of the second
-— and universally over the values bound by quantification, abstraction and
-summation. The PIP-value of a formula bundles its truth, its felicity, its local
-variables and its label definitions; equality of PIP-values is
-intersubstitutability.
+This file defines the felicity operator `F` on the terms and formulas of PIP.
+A presupposition `φ|ψ` is felicitous iff `φ` and `ψ` are and `ψ` is true; a
+conjunction `φ ∧ ψ` iff `φ` is and, whenever `φ` is true, `ψ` is; a quantifier,
+abstraction or summation iff its body is for every value of the variables it
+binds; the other connectives and relations iff their parts are. Felicity is
+independent of truth. The PIP-value of a formula records its truth, its
+felicity, its local variables and its label definitions, and two formulas are
+intersubstitutable iff they have the same PIP-value in every model under every
+assignment.
 
 ## Main definitions
 

--- a/Linglib/Logic/PIP/Intensional.lean
+++ b/Linglib/Logic/PIP/Intensional.lean
@@ -1,13 +1,13 @@
 import Linglib.Logic.PIP.Semantics
 
 /-!
-# PIP: intensional models
+# Intensional models of PIP
 
-Models whose atoms are worlds and entities: a world is the singleton plurality
-of its atom, and a family of world-relative relations on atoms is lifted to
-relation symbols distributively — a symbol holds of a world and nonempty
-pluralities iff it holds at that world of every tuple of their members, and of
-nothing whose world argument is not a world.
+This file defines the models of PIP whose atoms are worlds and entities. A
+world is the singleton plurality of its atom, and a family of world-relative
+relations on atoms is lifted distributively to relation symbols: a symbol holds
+of a world and nonempty pluralities iff it holds at that world of every tuple
+of their members, and it holds of nothing whose world argument is not a world.
 
 ## Main definitions
 

--- a/Linglib/Logic/PIP/Semantics.lean
+++ b/Linglib/Logic/PIP/Semantics.lean
@@ -3,14 +3,15 @@ import Mathlib.Logic.Function.Basic
 import Linglib.Logic.PIP.Syntax
 
 /-!
-# PIP: truth
+# Semantics of PIP
 
-Pluralities are sets of atoms. A term denotes a plurality — a variable its
-assignment, `⋃{x : φ}` and `Σxφ` the union of the values of `x` over the
-assignments agreeing with the current one outside the bound variables (for
-summation, also outside the local variables of `φ`) that satisfy `φ` — and a
-formula is true or false classically, with presuppositions and label
-definitions transparent and an unexpanded label false. A discourse
+This file defines the value of a term and the truth of a formula of PIP in a
+model, relative to an assignment of pluralities to variables. Pluralities are
+sets of atoms. A variable denotes its assignment; set abstraction `⋃{x : φ}` and
+summation `Σxφ` denote the union of the values of `x` over the assignments that
+agree with the current one outside the bound variables (for summation, also
+outside the local variables of `φ`) and satisfy `φ`. Presuppositions and label
+definitions do not affect truth, and an unexpanded label is false. A discourse
 `φ₁, …, φₙ` means `Σw(φ₁ ∧ … ∧ φₙ)` and is true iff that plurality of worlds is
 nonempty.
 

--- a/Linglib/Logic/PIP/Syntax.lean
+++ b/Linglib/Logic/PIP/Syntax.lean
@@ -2,22 +2,20 @@ import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.List.FinRange
 
 /-!
-# PIP — Plural Intensional Presuppositional predicate calculus: syntax
+# Syntax of PIP
 
-PIP is first-order predicate calculus with set abstraction, equality and the
-set-theoretic relations `⊆`, `∈`, `∩`, `∅` and the cardinality predicates `SG`,
-`PL`, whose domain consists of pluralities (sets of atoms, worlds among them),
-supplemented by five eliminable constructs: bracketed *local* variables `[x]`
-slated for unselective closure, summation `Σxφ`, formula labels `X ≡ φ` and
-their uses `X`, world arguments on predicates, and presuppositions `φ|ψ`.
-Relation symbols are indexed by arity and take a world as a distinguished
-argument; summation and abstraction bind by name.
+This file defines the terms and formulas of PIP, a plural intensional
+presuppositional predicate calculus: first-order predicate calculus with set
+abstraction, equality, the set-theoretic relations `⊆`, `∈`, `∩`, `∅` and the
+cardinality predicates `SG` and `PL`, extended by bracketed *local* variables
+`[x]`, summation `Σxφ`, formula labels `X ≡ φ` with their uses `X`, world
+arguments on relation symbols, and presuppositions `φ|ψ`. Relation symbols are
+indexed by arity and take a world as a distinguished argument.
 
-This file defines the syntax: terms and formulas, the defined connectives, the
-local variables of an expression, substitution, presupposition-free
-expressions, formula labels and their expansion, and the translation
-eliminating the PIP constructs. Truth is `Semantics.lean`, felicity
-`Felicity.lean`.
+It also defines the local variables of an expression, substitution for a
+variable, the presupposition-free expressions, the expansion of formula labels
+by their definitions, and the translation eliminating the PIP constructs.
+Truth is defined in `Semantics.lean` and felicity in `Felicity.lean`.
 
 ## Main definitions
 


### PR DESCRIPTION
Plain noun-phrase titles (`Syntax of PIP`, `Semantics of PIP`, `Felicity of PIP formulas`, `Intensional models of PIP`) and "this file defines" prose in place of the colon-and-dash headers.