### PR TITLE
refactor(Logic/PIP): one kind-indexed inductive in place of mutual blocks

### DIFF
--- a/Linglib/Logic/PIP/Felicity.lean
+++ b/Linglib/Logic/PIP/Felicity.lean
@@ -15,7 +15,7 @@ assignment.
 
 ## Main definitions
 
-* `Term.Felicitous`, `Formula.Felicitous` — the felicity operator `F`.
+* `Expr.Felicitous` — the felicity operator `F`.
 * `Value`, `Formula.value` — the PIP-value of a formula.
 
 ## Main statements
@@ -23,7 +23,7 @@ assignment.
 * `Formula.felicitous_atom`, `Formula.felicitous_conj`, … — the clauses of
   felicity, as simp lemmas; `Formula.felicitous_disj`, …,
   `Formula.felicitous_some` — the derived connectives.
-* `Formula.felicitous_of_presupFree` — every infelicity traces to a
+* `Expr.felicitous_of_presupFree` — every infelicity traces to a
   presupposition.
 * `Term.felicitous_sigma_conj_of_felicitous` — felicity of a discourse
   extended by a sentence reduces to the earlier discourse strictly implying
@@ -44,173 +44,162 @@ variable {V : Type u} {L : Type v} {P : ℕ → Type w} {α : Type*}
 
 section Felicity
 
-variable [DecidableEq V] (M : Model P α) (g : V → Set α)
+variable [DecidableEq V]
 
-mutual
-/-- Felicity of a term: `τ|ψ` needs `τ` and `ψ` felicitous and `ψ` true;
-abstraction and summation need their bodies felicitous for every value. -/
-def Term.Felicitous (M : Model P α) (g : V → Set α) : Term V L P → Prop
-  | .var _ => True
-  | .bvar _ => True
-  | .abs x φ => ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g'
-  | .sigma x φ => ∀ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} → φ.Felicitous M g'
-  | .inter s t => s.Felicitous M g ∧ t.Felicitous M g
-  | .empty => True
-  | .presup t ψ => t.Felicitous M g ∧ ψ.Felicitous M g ∧ ψ.Realize M g
-/-- Felicity of a formula: the operator `F`, with asymmetric conjunction — the
-first conjunct may satisfy the presuppositions of the second. -/
-def Formula.Felicitous (M : Model P α) (g : V → Set α) : Formula V L P → Prop
-  | .top => True
-  | .atom _ w ts => w.Felicitous M g ∧ ∀ i, (ts i).Felicitous M g
-  | .eq s t => s.Felicitous M g ∧ t.Felicitous M g
-  | .subset s t => s.Felicitous M g ∧ t.Felicitous M g
-  | .mem s t => s.Felicitous M g ∧ t.Felicitous M g
-  | .sg t => t.Felicitous M g
-  | .pl t => t.Felicitous M g
-  | .neg φ => φ.Felicitous M g
-  | .conj φ ψ => φ.Felicitous M g ∧ (φ.Realize M g → ψ.Felicitous M g)
-  | .exists_ x φ => ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g'
-  | .presup φ ψ => φ.Felicitous M g ∧ ψ.Felicitous M g ∧ ψ.Realize M g
-  | .labelDef _ _ => True
-  | .label _ => False
-end
+/-- Felicity: `e|ψ` needs `e` and `ψ` felicitous and `ψ` true; abstraction,
+summation and quantification need their bodies felicitous for every value; a
+conjunction needs its first conjunct felicitous and, if it is true, its second
+— the first conjunct may satisfy the presuppositions of the second. -/
+def Expr.Felicitous (M : Model P α) (g : V → Set α) : ∀ {k : Kind}, Expr V L P k → Prop
+  | _, .var _ => True
+  | _, .bvar _ => True
+  | _, .abs x φ => ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g'
+  | _, .sigma x φ => ∀ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} → φ.Felicitous M g'
+  | _, .inter s t => s.Felicitous M g ∧ t.Felicitous M g
+  | _, .empty => True
+  | _, .top => True
+  | _, .atom _ w ts => w.Felicitous M g ∧ ∀ i, (ts i).Felicitous M g
+  | _, .eq s t => s.Felicitous M g ∧ t.Felicitous M g
+  | _, .subset s t => s.Felicitous M g ∧ t.Felicitous M g
+  | _, .mem s t => s.Felicitous M g ∧ t.Felicitous M g
+  | _, .sg t => t.Felicitous M g
+  | _, .pl t => t.Felicitous M g
+  | _, .neg φ => φ.Felicitous M g
+  | _, .conj φ ψ => φ.Felicitous M g ∧ (Formula.Realize M g φ → ψ.Felicitous M g)
+  | _, .exists_ x φ => ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g'
+  | _, .labelDef _ _ => True
+  | _, .label _ => False
+  | _, .presup e ψ => e.Felicitous M g ∧ ψ.Felicitous M g ∧ Formula.Realize M g ψ
 
-@[simp] theorem Term.felicitous_var (x : V) : (Term.var x : Term V L P).Felicitous M g :=
+variable (M : Model P α) (g : V → Set α)
+
+@[simp] theorem Term.felicitous_var (x : V) : Expr.Felicitous M g (.var x : Term V L P) :=
   trivial
 
-@[simp] theorem Term.felicitous_bvar (x : V) : (Term.bvar x : Term V L P).Felicitous M g :=
+@[simp] theorem Term.felicitous_bvar (x : V) : Expr.Felicitous M g (.bvar x : Term V L P) :=
   trivial
 
-@[simp] theorem Term.felicitous_empty : (Term.empty : Term V L P).Felicitous M g := trivial
+@[simp] theorem Term.felicitous_empty : Expr.Felicitous M g (.empty : Term V L P) := trivial
 
 @[simp] theorem Term.felicitous_inter (s t : Term V L P) :
-    (Term.inter s t).Felicitous M g ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.inter s t) ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
 
-@[simp] theorem Term.felicitous_presup (t : Term V L P) (ψ : Formula V L P) :
-    (Term.presup t ψ).Felicitous M g ↔
-      t.Felicitous M g ∧ ψ.Felicitous M g ∧ ψ.Realize M g := Iff.rfl
+@[simp] theorem Expr.felicitous_presup {k : Kind} (e : Expr V L P k) (ψ : Formula V L P) :
+    Expr.Felicitous M g (.presup e ψ) ↔
+      e.Felicitous M g ∧ ψ.Felicitous M g ∧ Formula.Realize M g ψ := Iff.rfl
 
 theorem Term.felicitous_abs (x : V) (φ : Formula V L P) :
-    (Term.abs x φ).Felicitous M g ↔ ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g' := Iff.rfl
+    Expr.Felicitous M g (.abs x φ) ↔ ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g' := Iff.rfl
 
 theorem Term.felicitous_sigma (x : V) (φ : Formula V L P) :
-    (Term.sigma x φ).Felicitous M g ↔
+    Expr.Felicitous M g (.sigma x φ) ↔
       ∀ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} → φ.Felicitous M g' := Iff.rfl
 
 theorem Term.felicitous_abs_of_forall {x : V} {φ : Formula V L P}
-    (h : ∀ g, φ.Felicitous M g) : (Term.abs x φ).Felicitous M g := fun _ _ => h _
+    (h : ∀ g, φ.Felicitous M g) : Expr.Felicitous M g (.abs x φ) := fun _ _ => h _
 
 theorem Term.felicitous_sigma_of_forall {x : V} {φ : Formula V L P}
-    (h : ∀ g, φ.Felicitous M g) : (Term.sigma x φ).Felicitous M g := fun _ _ => h _
+    (h : ∀ g, φ.Felicitous M g) : Expr.Felicitous M g (.sigma x φ) := fun _ _ => h _
 
-@[simp] theorem Formula.felicitous_top : (Formula.top : Formula V L P).Felicitous M g := trivial
+theorem Term.felicitous_sgPronoun (x : V) (φ : Formula V L P) :
+    Expr.Felicitous M g (Term.sgPronoun x φ) ↔
+      Expr.Felicitous M g (.sigma x φ) ∧ ∃ a, Term.realize M g (.sigma x φ) = {a} := by
+  show Expr.Felicitous M g (.sigma x φ) ∧ Expr.Felicitous M g (.sigma x φ) ∧
+    (∃ a, Term.realize M g (.sigma x φ) = {a}) ↔ _
+  exact ⟨fun ⟨a, _, c⟩ => ⟨a, c⟩, fun ⟨a, c⟩ => ⟨a, a, c⟩⟩
+
+@[simp] theorem Formula.felicitous_top : Expr.Felicitous M g (.top : Formula V L P) := trivial
 
 @[simp] theorem Formula.felicitous_atom {n : ℕ} (r : P n) (w : Term V L P)
     (ts : Fin n → Term V L P) :
-    (Formula.atom r w ts).Felicitous M g ↔ w.Felicitous M g ∧ ∀ i, (ts i).Felicitous M g :=
+    Expr.Felicitous M g (.atom r w ts) ↔ w.Felicitous M g ∧ ∀ i, (ts i).Felicitous M g :=
   Iff.rfl
 
 @[simp] theorem Formula.felicitous_eq (s t : Term V L P) :
-    (Formula.eq s t).Felicitous M g ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.eq s t) ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_subset (s t : Term V L P) :
-    (Formula.subset s t).Felicitous M g ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.subset s t) ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_mem (s t : Term V L P) :
-    (Formula.mem s t).Felicitous M g ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.mem s t) ↔ s.Felicitous M g ∧ t.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_sg (t : Term V L P) :
-    (Formula.sg t).Felicitous M g ↔ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.sg t) ↔ t.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_pl (t : Term V L P) :
-    (Formula.pl t).Felicitous M g ↔ t.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.pl t) ↔ t.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_neg (φ : Formula V L P) :
-    (Formula.neg φ).Felicitous M g ↔ φ.Felicitous M g := Iff.rfl
+    Expr.Felicitous M g (.neg φ) ↔ φ.Felicitous M g := Iff.rfl
 
 @[simp] theorem Formula.felicitous_conj (φ ψ : Formula V L P) :
-    (Formula.conj φ ψ).Felicitous M g ↔
-      φ.Felicitous M g ∧ (φ.Realize M g → ψ.Felicitous M g) := Iff.rfl
+    Expr.Felicitous M g (.conj φ ψ) ↔
+      φ.Felicitous M g ∧ (Formula.Realize M g φ → ψ.Felicitous M g) := Iff.rfl
 
 theorem Formula.felicitous_exists (x : V) (φ : Formula V L P) :
-    (Formula.exists_ x φ).Felicitous M g ↔
+    Expr.Felicitous M g (.exists_ x φ) ↔
       ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g' := Iff.rfl
 
-@[simp] theorem Formula.felicitous_presup (φ ψ : Formula V L P) :
-    (Formula.presup φ ψ).Felicitous M g ↔
-      φ.Felicitous M g ∧ ψ.Felicitous M g ∧ ψ.Realize M g := Iff.rfl
-
 @[simp] theorem Formula.felicitous_labelDef (X : L) (φ : Formula V L P) :
-    (Formula.labelDef X φ).Felicitous M g := trivial
+    Expr.Felicitous M g (.labelDef X φ) := trivial
 
 @[simp] theorem Formula.felicitous_label (X : L) :
-    (Formula.label X : Formula V L P).Felicitous M g ↔ False := Iff.rfl
+    Expr.Felicitous M g (.label X : Formula V L P) ↔ False := Iff.rfl
 
-mutual
-/-- A term without presuppositions is felicitous. -/
-theorem Term.felicitous_of_presupFree :
-    ∀ (g : V → Set α) (t : Term V L P), t.PresupFree → t.Felicitous M g
-  | _, .var _, _ => trivial
-  | _, .bvar _, _ => trivial
-  | _, .abs _ φ, h => fun g' _ => Formula.felicitous_of_presupFree g' φ h
-  | _, .sigma _ φ, h => fun g' _ => Formula.felicitous_of_presupFree g' φ h
-  | g, .inter s t, h =>
-      ⟨Term.felicitous_of_presupFree g s h.1, Term.felicitous_of_presupFree g t h.2⟩
-  | _, .empty, _ => trivial
-  | _, .presup _ _, h => h.elim
-/-- Every infelicity traces to a presupposition: a formula without
+/-- Every infelicity traces to a presupposition: an expression without
 presuppositions is felicitous. -/
-theorem Formula.felicitous_of_presupFree :
-    ∀ (g : V → Set α) (φ : Formula V L P), φ.PresupFree → φ.Felicitous M g
-  | _, .top, _ => trivial
-  | g, .atom _ w ts, h =>
-      ⟨Term.felicitous_of_presupFree g w h.1,
-        fun i => Term.felicitous_of_presupFree g (ts i) (h.2 i (List.mem_finRange i))⟩
-  | g, .eq s t, h =>
-      ⟨Term.felicitous_of_presupFree g s h.1, Term.felicitous_of_presupFree g t h.2⟩
-  | g, .subset s t, h =>
-      ⟨Term.felicitous_of_presupFree g s h.1, Term.felicitous_of_presupFree g t h.2⟩
-  | g, .mem s t, h =>
-      ⟨Term.felicitous_of_presupFree g s h.1, Term.felicitous_of_presupFree g t h.2⟩
-  | g, .sg t, h => Term.felicitous_of_presupFree g t h
-  | g, .pl t, h => Term.felicitous_of_presupFree g t h
-  | g, .neg φ, h => Formula.felicitous_of_presupFree g φ h
-  | g, .conj φ ψ, h =>
-      ⟨Formula.felicitous_of_presupFree g φ h.1,
-        fun _ => Formula.felicitous_of_presupFree g ψ h.2⟩
-  | _, .exists_ _ φ, h => fun g' _ => Formula.felicitous_of_presupFree g' φ h
-  | _, .presup _ _, h => h.elim
-  | _, .labelDef _ _, _ => trivial
-  | _, .label _, h => h.elim
-end
-
-theorem Term.felicitous_sgPronoun (x : V) (φ : Formula V L P) :
-    (Term.sgPronoun x φ).Felicitous M g ↔
-      (Term.sigma x φ).Felicitous M g ∧ ∃ a, (Term.sigma x φ).realize M g = {a} := by
-  simp only [Term.sgPronoun, Term.felicitous_presup, Formula.felicitous_sg, Formula.realize_sg,
-    and_self_left]
+theorem Expr.felicitous_of_presupFree :
+    ∀ {k : Kind} (e : Expr V L P k), e.PresupFree → ∀ g, e.Felicitous M g
+  | _, .var _, _, _ => trivial
+  | _, .bvar _, _, _ => trivial
+  | _, .abs _ φ, h, _ => fun g' _ => Expr.felicitous_of_presupFree φ h g'
+  | _, .sigma _ φ, h, _ => fun g' _ => Expr.felicitous_of_presupFree φ h g'
+  | _, .inter s t, h, g =>
+      ⟨Expr.felicitous_of_presupFree s h.1 g, Expr.felicitous_of_presupFree t h.2 g⟩
+  | _, .empty, _, _ => trivial
+  | _, .top, _, _ => trivial
+  | _, .atom _ w ts, h, g =>
+      ⟨Expr.felicitous_of_presupFree w h.1 g,
+        fun i => Expr.felicitous_of_presupFree (ts i) (h.2 i (List.mem_finRange i)) g⟩
+  | _, .eq s t, h, g =>
+      ⟨Expr.felicitous_of_presupFree s h.1 g, Expr.felicitous_of_presupFree t h.2 g⟩
+  | _, .subset s t, h, g =>
+      ⟨Expr.felicitous_of_presupFree s h.1 g, Expr.felicitous_of_presupFree t h.2 g⟩
+  | _, .mem s t, h, g =>
+      ⟨Expr.felicitous_of_presupFree s h.1 g, Expr.felicitous_of_presupFree t h.2 g⟩
+  | _, .sg t, h, g => Expr.felicitous_of_presupFree t h g
+  | _, .pl t, h, g => Expr.felicitous_of_presupFree t h g
+  | _, .neg φ, h, g => Expr.felicitous_of_presupFree φ h g
+  | _, .conj φ ψ, h, g =>
+      ⟨Expr.felicitous_of_presupFree φ h.1 g, fun _ => Expr.felicitous_of_presupFree ψ h.2 g⟩
+  | _, .exists_ _ φ, h, _ => fun g' _ => Expr.felicitous_of_presupFree φ h g'
+  | _, .labelDef _ _, _, _ => trivial
+  | _, .label _, h, _ => h.elim
+  | _, .presup _ _, h, _ => h.elim
 
 /-! ### Derived clauses -/
 
 /-- `F(φ ∨ ψ)` iff `Fφ ∧ (¬φ → Fψ)`. -/
 theorem Formula.felicitous_disj (φ ψ : Formula V L P) :
-    (φ.disj ψ).Felicitous M g ↔ φ.Felicitous M g ∧ (¬ φ.Realize M g → ψ.Felicitous M g) :=
-  Iff.rfl
+    Expr.Felicitous M g (φ.disj ψ) ↔
+      φ.Felicitous M g ∧ (¬ Formula.Realize M g φ → ψ.Felicitous M g) := Iff.rfl
 
 /-- `F(φ → ψ)` iff `Fφ ∧ (φ → Fψ)`. -/
 theorem Formula.felicitous_impl (φ ψ : Formula V L P) :
-    (φ.impl ψ).Felicitous M g ↔ φ.Felicitous M g ∧ (φ.Realize M g → ψ.Felicitous M g) :=
-  Iff.rfl
+    Expr.Felicitous M g (φ.impl ψ) ↔
+      φ.Felicitous M g ∧ (Formula.Realize M g φ → ψ.Felicitous M g) := Iff.rfl
 
 /-- `F(φ ↔ ψ)` iff `Fφ ∧ Fψ`. -/
 theorem Formula.felicitous_iff (φ ψ : Formula V L P) :
-    (φ.iff_ ψ).Felicitous M g ↔ φ.Felicitous M g ∧ ψ.Felicitous M g := by
-  show (φ.impl ψ).Felicitous M g ∧ ((φ.impl ψ).Realize M g → (ψ.impl φ).Felicitous M g) ↔ _
+    Expr.Felicitous M g (φ.iff_ ψ) ↔ φ.Felicitous M g ∧ ψ.Felicitous M g := by
+  show Expr.Felicitous M g (φ.impl ψ) ∧
+    (Formula.Realize M g (φ.impl ψ) → Expr.Felicitous M g (ψ.impl φ)) ↔ _
   rw [Formula.felicitous_impl, Formula.felicitous_impl, Formula.realize_impl]
   constructor
   · rintro ⟨⟨hφ, h₁⟩, h₂⟩
     refine ⟨hφ, ?_⟩
-    by_cases hp : φ.Realize M g
+    by_cases hp : Formula.Realize M g φ
     · exact h₁ hp
     · exact (h₂ fun h => absurd h hp).1
   · rintro ⟨hφ, hψ⟩
@@ -218,29 +207,29 @@ theorem Formula.felicitous_iff (φ ψ : Formula V L P) :
 
 /-- `F(∀xφ)` iff `∀x Fφ`. -/
 theorem Formula.felicitous_forall (x : V) (φ : Formula V L P) :
-    (Formula.forall_ x φ).Felicitous M g ↔ ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g' :=
-  Iff.rfl
+    Expr.Felicitous M g (Formula.forall_ x φ) ↔
+      ∀ g', Set.EqOn g' g {x}ᶜ → φ.Felicitous M g' := Iff.rfl
 
 /-- `F(some(s, t))` iff `Fs ∧ Ft`. -/
 theorem Formula.felicitous_some (s t : Term V L P) :
-    (Formula.some_ s t).Felicitous M g ↔ s.Felicitous M g ∧ t.Felicitous M g :=
+    Expr.Felicitous M g (Formula.some_ s t) ↔ s.Felicitous M g ∧ t.Felicitous M g :=
   show (s.Felicitous M g ∧ t.Felicitous M g) ∧ True ↔ _ from (and_true _).to_iff
 
 /-- Felicity of a discourse extended by a sentence: `F Σw(γ ∧ φ)` iff, for every
 assignment of the world and the local variables, `Fγ ∧ (γ → Fφ)`. -/
 theorem Term.felicitous_sigma_conj (w : V) (γ φ : Formula V L P) :
-    (Term.sigma w (γ.conj φ)).Felicitous M g ↔
-      ∀ g', Set.EqOn g' g {y | y ∉ (γ.conj φ).locals ∧ y ≠ w} →
-        γ.Felicitous M g' ∧ (γ.Realize M g' → φ.Felicitous M g') := Iff.rfl
+    Expr.Felicitous M g (.sigma w (.conj γ φ)) ↔
+      ∀ g', Set.EqOn g' g {y | y ∉ (Expr.conj γ φ).locals ∧ y ≠ w} →
+        γ.Felicitous M g' ∧ (Formula.Realize M g' γ → φ.Felicitous M g') := Iff.rfl
 
 /-- Given that the discourse so far is felicitous for all values of the local
 variables, the extended discourse is felicitous iff the discourse so far
 strictly implies the felicity of the new sentence. -/
 theorem Term.felicitous_sigma_conj_of_felicitous (w : V) (γ φ : Formula V L P)
-    (hγ : ∀ g', Set.EqOn g' g {y | y ∉ (γ.conj φ).locals ∧ y ≠ w} → γ.Felicitous M g') :
-    (Term.sigma w (γ.conj φ)).Felicitous M g ↔
-      ∀ g', Set.EqOn g' g {y | y ∉ (γ.conj φ).locals ∧ y ≠ w} →
-        (γ.Realize M g' → φ.Felicitous M g') :=
+    (hγ : ∀ g', Set.EqOn g' g {y | y ∉ (Expr.conj γ φ).locals ∧ y ≠ w} → γ.Felicitous M g') :
+    Expr.Felicitous M g (.sigma w (.conj γ φ)) ↔
+      ∀ g', Set.EqOn g' g {y | y ∉ (Expr.conj γ φ).locals ∧ y ≠ w} →
+        (Formula.Realize M g' γ → φ.Felicitous M g') :=
   forall_congr' fun g' => imp_congr_right fun hg => and_iff_right (hγ g' hg)
 
 /-! ### Meanings -/
@@ -262,7 +251,7 @@ structure Value (V : Type u) (L : Type v) (P : ℕ → Type w) where
 have the same value in every model under every assignment; truth-equivalent
 formulas need not be. -/
 def Formula.value (φ : Formula V L P) : Value V L P :=
-  ⟨φ.Realize M g, φ.Felicitous M g, φ.locals, φ.defs⟩
+  ⟨Formula.Realize M g φ, φ.Felicitous M g, φ.locals, φ.defs⟩
 
 end Felicity
 

--- a/Linglib/Logic/PIP/Semantics.lean
+++ b/Linglib/Logic/PIP/Semantics.lean
@@ -15,11 +15,14 @@ definitions do not affect truth, and an unexpanded label is false. A discourse
 `φ₁, …, φₙ` means `Σw(φ₁ ∧ … ∧ φₙ)` and is true iff that plurality of worlds is
 nonempty.
 
+Both kinds of expression are realized by one recursion, `Expr.Realize`, as a
+relation to a point: an atom for a term, nothing for a formula.
+
 ## Main definitions
 
 * `Model` — the interpretation of relation symbols over pluralities.
-* `Term.Mem`, `Term.realize`, `Formula.Realize` — value and truth relative to
-  a model and an assignment.
+* `Expr.Realize`, `Term.realize`, `Formula.Realize` — value and truth relative
+  to a model and an assignment.
 
 ## Main statements
 
@@ -28,8 +31,8 @@ nonempty.
   derived connectives.
 * `Formula.realize_exists_iff_abs_nonempty` — `∃xφ` is true iff `⋃{x : φ}` is
   nonempty, when `φ` is false of the null plurality.
-* `Formula.realize_elim` — the PIP constructs are eliminable: the translation
-  preserves truth.
+* `Expr.realize_elim` — the PIP constructs are eliminable: the translation
+  preserves values and truth.
 
 ## References
 
@@ -49,142 +52,152 @@ structure Model (P : ℕ → Type w) (α : Type u) where
   /-- The interpretation of relation symbols. -/
   I : ∀ {n : ℕ}, P n → Set α → (Fin n → Set α) → Prop
 
+/-- The point at which an expression of a kind is realized: an atom, whose
+membership in a term's value is at stake, or nothing for a formula. -/
+def Kind.Point (α : Type u) : Kind → Type u
+  | .term => α
+  | .formula => PUnit
+
 section Semantics
 
 variable [DecidableEq V]
 
-mutual
-/-- Membership in the value of a term: a variable's assignment, the union of the
-abstracted values, the union of the summed values over assignments agreeing
-outside the summation variable and the local variables, intersection, the
-empty plurality, and the body of a presupposed term. -/
-def Term.Mem (M : Model P α) (g : V → Set α) : Term V L P → α → Prop
-  | .var x, a => a ∈ g x
-  | .bvar x, a => a ∈ g x
-  | .abs x φ, a => ∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ φ.Realize M g'
-  | .sigma x φ, a =>
-      ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ φ.Realize M g'
-  | .inter s t, a => s.Mem M g a ∧ t.Mem M g a
-  | .empty, _ => False
-  | .presup t _, a => t.Mem M g a
-/-- Truth of a formula: classical, with presuppositions and label definitions
-transparent and an unexpanded label false. -/
-def Formula.Realize (M : Model P α) (g : V → Set α) : Formula V L P → Prop
-  | .top => True
-  | .atom r w ts => M.I r {a | w.Mem M g a} fun i => {a | (ts i).Mem M g a}
-  | .eq s t => {a | s.Mem M g a} = {a | t.Mem M g a}
-  | .subset s t => {a | s.Mem M g a} ⊆ {a | t.Mem M g a}
-  | .mem s t => ∃ a, {b | s.Mem M g b} = {a} ∧ t.Mem M g a
-  | .sg t => ∃ a, {b | t.Mem M g b} = {a}
-  | .pl t => ∃ a b, a ≠ b ∧ t.Mem M g a ∧ t.Mem M g b
-  | .neg φ => ¬ φ.Realize M g
-  | .conj φ ψ => φ.Realize M g ∧ ψ.Realize M g
-  | .exists_ x φ => ∃ g', Set.EqOn g' g {x}ᶜ ∧ φ.Realize M g'
-  | .presup φ _ => φ.Realize M g
-  | .labelDef _ _ => True
-  | .label _ => False
-end
+/-- Realization: membership of an atom in the value of a term, and truth of a
+formula. A variable denotes its assignment, abstraction and summation the union
+of the values of the bound variable over assignments agreeing outside the bound
+variables; a formula is true classically, with presuppositions and label
+definitions transparent and an unexpanded label false. -/
+def Expr.Realize (M : Model P α) (g : V → Set α) :
+    ∀ {k : Kind}, Expr V L P k → Kind.Point α k → Prop
+  | _, .var x, a => a ∈ g x
+  | _, .bvar x, a => a ∈ g x
+  | _, .abs x φ, a => ∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ φ.Realize M g' .unit
+  | _, .sigma x φ, a =>
+      ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ φ.Realize M g' .unit
+  | _, .inter s t, a => s.Realize M g a ∧ t.Realize M g a
+  | _, .empty, _ => False
+  | _, .top, _ => True
+  | _, .atom r w ts, _ => M.I r {a | w.Realize M g a} fun i => {a | (ts i).Realize M g a}
+  | _, .eq s t, _ => {a | s.Realize M g a} = {a | t.Realize M g a}
+  | _, .subset s t, _ => {a | s.Realize M g a} ⊆ {a | t.Realize M g a}
+  | _, .mem s t, _ => ∃ a, {b | s.Realize M g b} = {a} ∧ t.Realize M g a
+  | _, .sg t, _ => ∃ a, {b | t.Realize M g b} = {a}
+  | _, .pl t, _ => ∃ a b, a ≠ b ∧ t.Realize M g a ∧ t.Realize M g b
+  | _, .neg φ, _ => ¬ φ.Realize M g .unit
+  | _, .conj φ ψ, _ => φ.Realize M g .unit ∧ ψ.Realize M g .unit
+  | _, .exists_ x φ, _ => ∃ g', Set.EqOn g' g {x}ᶜ ∧ φ.Realize M g' .unit
+  | _, .labelDef _ _, _ => True
+  | _, .label _, _ => False
+  | _, .presup e _, a => e.Realize M g a
 
 variable (M : Model P α) (g : V → Set α)
 
 /-- The value of a term. -/
-def Term.realize (t : Term V L P) : Set α := {a | t.Mem M g a}
+def Term.realize (t : Term V L P) : Set α := {a | t.Realize M g a}
 
-@[simp] theorem Term.mem_realize {t : Term V L P} {a : α} : a ∈ t.realize M g ↔ t.Mem M g a :=
-  Iff.rfl
+/-- Truth of a formula. -/
+def Formula.Realize (φ : Formula V L P) : Prop := Expr.Realize M g φ .unit
 
-@[simp] theorem Term.realize_var (x : V) : (Term.var x : Term V L P).realize M g = g x := rfl
+@[simp] theorem Term.mem_realize {t : Term V L P} {a : α} :
+    a ∈ Term.realize M g t ↔ t.Realize M g a := Iff.rfl
 
-@[simp] theorem Term.realize_bvar (x : V) : (Term.bvar x : Term V L P).realize M g = g x := rfl
+@[simp] theorem Term.realize_var (x : V) : Term.realize M g (.var x : Term V L P) = g x := rfl
+
+@[simp] theorem Term.realize_bvar (x : V) : Term.realize M g (.bvar x : Term V L P) = g x := rfl
 
 @[simp] theorem Term.realize_inter (s t : Term V L P) :
-    (Term.inter s t).realize M g = s.realize M g ∩ t.realize M g := rfl
+    Term.realize M g (.inter s t) = Term.realize M g s ∩ Term.realize M g t := rfl
 
-@[simp] theorem Term.realize_empty : (Term.empty : Term V L P).realize M g = ∅ := rfl
+@[simp] theorem Term.realize_empty : Term.realize M g (.empty : Term V L P) = ∅ := rfl
 
 @[simp] theorem Term.realize_presup (t : Term V L P) (ψ : Formula V L P) :
-    (Term.presup t ψ).realize M g = t.realize M g := rfl
+    Term.realize M g (.presup t ψ) = Term.realize M g t := rfl
 
 theorem Term.mem_realize_abs (x : V) (φ : Formula V L P) (a : α) :
-    a ∈ (Term.abs x φ).realize M g ↔ ∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ φ.Realize M g' :=
-  Iff.rfl
+    a ∈ Term.realize M g (.abs x φ) ↔
+      ∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ Formula.Realize M g' φ := Iff.rfl
 
 theorem Term.mem_realize_sigma (x : V) (φ : Formula V L P) (a : α) :
-    a ∈ (Term.sigma x φ).realize M g ↔
-      ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ φ.Realize M g' := Iff.rfl
+    a ∈ Term.realize M g (.sigma x φ) ↔
+      ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ Formula.Realize M g' φ :=
+  Iff.rfl
 
-@[simp] theorem Formula.realize_top : (Formula.top : Formula V L P).Realize M g ↔ True := Iff.rfl
+@[simp] theorem Formula.realize_top : Formula.Realize M g (.top : Formula V L P) ↔ True :=
+  Iff.rfl
 
 @[simp] theorem Formula.realize_atom {n : ℕ} (r : P n) (w : Term V L P)
     (ts : Fin n → Term V L P) :
-    (Formula.atom r w ts).Realize M g ↔ M.I r (w.realize M g) fun i => (ts i).realize M g :=
-  Iff.rfl
+    Formula.Realize M g (.atom r w ts) ↔
+      M.I r (Term.realize M g w) fun i => Term.realize M g (ts i) := Iff.rfl
 
 @[simp] theorem Formula.realize_eq (s t : Term V L P) :
-    (Formula.eq s t).Realize M g ↔ s.realize M g = t.realize M g := Iff.rfl
+    Formula.Realize M g (.eq s t) ↔ Term.realize M g s = Term.realize M g t := Iff.rfl
 
 @[simp] theorem Formula.realize_subset (s t : Term V L P) :
-    (Formula.subset s t).Realize M g ↔ s.realize M g ⊆ t.realize M g := Iff.rfl
+    Formula.Realize M g (.subset s t) ↔ Term.realize M g s ⊆ Term.realize M g t := Iff.rfl
 
 @[simp] theorem Formula.realize_mem (s t : Term V L P) :
-    (Formula.mem s t).Realize M g ↔ ∃ a, s.realize M g = {a} ∧ a ∈ t.realize M g := Iff.rfl
+    Formula.Realize M g (.mem s t) ↔
+      ∃ a, Term.realize M g s = {a} ∧ a ∈ Term.realize M g t := Iff.rfl
 
 @[simp] theorem Formula.realize_sg (t : Term V L P) :
-    (Formula.sg t).Realize M g ↔ ∃ a, t.realize M g = {a} := Iff.rfl
+    Formula.Realize M g (.sg t) ↔ ∃ a, Term.realize M g t = {a} := Iff.rfl
 
 @[simp] theorem Formula.realize_pl (t : Term V L P) :
-    (Formula.pl t).Realize M g ↔ ∃ a b, a ≠ b ∧ a ∈ t.realize M g ∧ b ∈ t.realize M g :=
-  Iff.rfl
+    Formula.Realize M g (.pl t) ↔
+      ∃ a b, a ≠ b ∧ a ∈ Term.realize M g t ∧ b ∈ Term.realize M g t := Iff.rfl
 
 @[simp] theorem Formula.realize_neg (φ : Formula V L P) :
-    (Formula.neg φ).Realize M g ↔ ¬ φ.Realize M g := Iff.rfl
+    Formula.Realize M g (.neg φ) ↔ ¬ Formula.Realize M g φ := Iff.rfl
 
 @[simp] theorem Formula.realize_conj (φ ψ : Formula V L P) :
-    (Formula.conj φ ψ).Realize M g ↔ φ.Realize M g ∧ ψ.Realize M g := Iff.rfl
+    Formula.Realize M g (.conj φ ψ) ↔ Formula.Realize M g φ ∧ Formula.Realize M g ψ := Iff.rfl
 
 theorem Formula.realize_exists (x : V) (φ : Formula V L P) :
-    (Formula.exists_ x φ).Realize M g ↔ ∃ g', Set.EqOn g' g {x}ᶜ ∧ φ.Realize M g' := Iff.rfl
+    Formula.Realize M g (.exists_ x φ) ↔
+      ∃ g', Set.EqOn g' g {x}ᶜ ∧ Formula.Realize M g' φ := Iff.rfl
 
 @[simp] theorem Formula.realize_presup (φ ψ : Formula V L P) :
-    (Formula.presup φ ψ).Realize M g ↔ φ.Realize M g := Iff.rfl
+    Formula.Realize M g (.presup φ ψ) ↔ Formula.Realize M g φ := Iff.rfl
 
 @[simp] theorem Formula.realize_labelDef (X : L) (φ : Formula V L P) :
-    (Formula.labelDef X φ).Realize M g ↔ True := Iff.rfl
+    Formula.Realize M g (.labelDef X φ) ↔ True := Iff.rfl
 
 @[simp] theorem Formula.realize_label (X : L) :
-    (Formula.label X : Formula V L P).Realize M g ↔ False := Iff.rfl
+    Formula.Realize M g (.label X : Formula V L P) ↔ False := Iff.rfl
 
 /-! ### Derived clauses -/
 
 theorem Formula.realize_disj (φ ψ : Formula V L P) :
-    (φ.disj ψ).Realize M g ↔ φ.Realize M g ∨ ψ.Realize M g :=
-  show ¬(¬φ.Realize M g ∧ ¬ψ.Realize M g) ↔ _ from or_iff_not_and_not.symm
+    Formula.Realize M g (φ.disj ψ) ↔ Formula.Realize M g φ ∨ Formula.Realize M g ψ :=
+  show ¬(¬Formula.Realize M g φ ∧ ¬Formula.Realize M g ψ) ↔ _ from or_iff_not_and_not.symm
 
 theorem Formula.realize_impl (φ ψ : Formula V L P) :
-    (φ.impl ψ).Realize M g ↔ (φ.Realize M g → ψ.Realize M g) :=
-  show ¬(φ.Realize M g ∧ ¬ψ.Realize M g) ↔ _ from not_and_not_right
+    Formula.Realize M g (φ.impl ψ) ↔ (Formula.Realize M g φ → Formula.Realize M g ψ) :=
+  show ¬(Formula.Realize M g φ ∧ ¬Formula.Realize M g ψ) ↔ _ from not_and_not_right
 
 theorem Formula.realize_iff (φ ψ : Formula V L P) :
-    (φ.iff_ ψ).Realize M g ↔ (φ.Realize M g ↔ ψ.Realize M g) := by
-  show (φ.impl ψ).Realize M g ∧ (ψ.impl φ).Realize M g ↔ _
+    Formula.Realize M g (φ.iff_ ψ) ↔ (Formula.Realize M g φ ↔ Formula.Realize M g ψ) := by
+  show Formula.Realize M g (φ.impl ψ) ∧ Formula.Realize M g (ψ.impl φ) ↔ _
   rw [Formula.realize_impl, Formula.realize_impl]
   exact iff_iff_implies_and_implies.symm
 
 theorem Formula.realize_forall (x : V) (φ : Formula V L P) :
-    (Formula.forall_ x φ).Realize M g ↔ ∀ g', Set.EqOn g' g {x}ᶜ → φ.Realize M g' :=
-  show ¬(∃ g', Set.EqOn g' g {x}ᶜ ∧ ¬φ.Realize M g') ↔ _ by
+    Formula.Realize M g (Formula.forall_ x φ) ↔
+      ∀ g', Set.EqOn g' g {x}ᶜ → Formula.Realize M g' φ :=
+  show ¬(∃ g', Set.EqOn g' g {x}ᶜ ∧ ¬Formula.Realize M g' φ) ↔ _ by
     simp only [not_exists, not_and, not_not]
 
 theorem Formula.realize_some (s t : Term V L P) :
-    (Formula.some_ s t).Realize M g ↔ (s.realize M g ∩ t.realize M g).Nonempty :=
-  show ¬(s.realize M g ∩ t.realize M g = ∅) ↔ _ from Set.nonempty_iff_ne_empty.symm
+    Formula.Realize M g (Formula.some_ s t) ↔ (Term.realize M g s ∩ Term.realize M g t).Nonempty :=
+  show ¬(Term.realize M g s ∩ Term.realize M g t = ∅) ↔ _ from Set.nonempty_iff_ne_empty.symm
 
 /-- `∃xφ` is true iff `⋃{x : φ}` is nonempty, provided `φ` is false when `x` is
 the null plurality — the standing assumption that predicates are false of the
 null individual. -/
 theorem Formula.realize_exists_iff_abs_nonempty (x : V) (φ : Formula V L P)
-    (h : ∀ g', g' x = ∅ → ¬ φ.Realize M g') :
-    (Formula.exists_ x φ).Realize M g ↔ ((Term.abs x φ).realize M g).Nonempty := by
+    (h : ∀ g', g' x = ∅ → ¬ Formula.Realize M g' φ) :
+    Formula.Realize M g (.exists_ x φ) ↔ (Term.realize M g (.abs x φ)).Nonempty := by
   constructor
   · rintro ⟨g', hg, hφ⟩
     obtain ⟨a, ha⟩ := Set.nonempty_iff_ne_empty.mpr fun he => h g' he hφ
@@ -195,8 +208,8 @@ theorem Formula.realize_exists_iff_abs_nonempty (x : V) (φ : Formula V L P)
 /-! ### Eliminability -/
 
 theorem Formula.realize_closeList (xs : List V) (φ : Formula V L P) :
-    ∀ g : V → Set α, (φ.closeList xs).Realize M g ↔
-      ∃ g', Set.EqOn g' g {y | y ∉ xs} ∧ φ.Realize M g' := by
+    ∀ g : V → Set α, Formula.Realize M g (φ.closeList xs) ↔
+      ∃ g', Set.EqOn g' g {y | y ∉ xs} ∧ Formula.Realize M g' φ := by
   induction xs with
   | nil =>
     refine fun g => ⟨fun h => ⟨g, fun _ _ => rfl, h⟩, ?_⟩
@@ -204,7 +217,7 @@ theorem Formula.realize_closeList (xs : List V) (φ : Formula V L P) :
     rwa [show g' = g from funext fun y => hg (by simp)] at h
   | cons x xs ih =>
     intro g
-    show (∃ g₁, Set.EqOn g₁ g {x}ᶜ ∧ (φ.closeList xs).Realize M g₁) ↔ _
+    show (∃ g₁, Set.EqOn g₁ g {x}ᶜ ∧ Formula.Realize M g₁ (φ.closeList xs)) ↔ _
     simp only [ih]
     constructor
     · rintro ⟨g₁, hg₁, g', hg', h⟩
@@ -219,20 +232,23 @@ theorem Formula.realize_closeList (xs : List V) (φ : Formula V L P) :
       · rw [Function.update_of_ne hyx]
         exact hg' (by simp only [Set.mem_ofPred_eq, List.mem_cons, not_or]; exact ⟨hyx, hy⟩)
 
-mutual
-/-- The translation preserves values. -/
-theorem Term.mem_elim : ∀ (g : V → Set α) (t : Term V L P) (a : α),
-    t.elim.Mem M g a ↔ t.Mem M g a
-  | _, .var _, _ => Iff.rfl
-  | _, .bvar _, _ => Iff.rfl
-  | g, .abs x φ, a =>
-      show (∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ φ.elim.Realize M g') ↔ ∃ g', _ from
+/-- The PIP constructs are eliminable: the translation preserves values and
+truth. -/
+theorem Expr.realize_elim :
+    ∀ {k : Kind} (e : Expr V L P k) (g : V → Set α) (a : Kind.Point α k),
+      e.elim.Realize M g a ↔ e.Realize M g a
+  | _, .var _, _, _ => Iff.rfl
+  | _, .bvar _, _, _ => Iff.rfl
+  | _, .abs x φ, g, a =>
+      show (∃ g', Set.EqOn g' g {x}ᶜ ∧ a ∈ g' x ∧ φ.elim.Realize M g' .unit) ↔ ∃ g', _ from
         exists_congr fun _ => and_congr_right fun _ => and_congr_right fun _ =>
-          Formula.realize_elim _ φ
-  | g, .sigma x φ, a => by
-      show (∃ g₁, Set.EqOn g₁ g {x}ᶜ ∧ a ∈ g₁ x ∧ (φ.elim.closeList _).Realize M g₁) ↔
-        ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ φ.Realize M g'
-      simp only [Formula.realize_closeList, Formula.realize_elim]
+          Expr.realize_elim φ _ .unit
+  | _, .sigma x φ, g, a => by
+      show (∃ g₁, Set.EqOn g₁ g {x}ᶜ ∧ a ∈ g₁ x ∧
+          Formula.Realize M g₁ (Formula.closeList _ φ.elim)) ↔
+        ∃ g', Set.EqOn g' g {y | y ∉ φ.locals ∧ y ≠ x} ∧ a ∈ g' x ∧ Formula.Realize M g' φ
+      simp only [Formula.realize_closeList]
+      simp only [Formula.Realize, Expr.realize_elim φ]
       constructor
       · rintro ⟨g₁, hg₁, ha, g', hg', h⟩
         refine ⟨g', fun y hy => ?_, ?_, h⟩
@@ -246,46 +262,44 @@ theorem Term.mem_elim : ∀ (g : V → Set α) (t : Term V L P) (a : α),
         · subst hyx; simp
         · rw [Function.update_of_ne hyx]
           exact hg' ⟨fun hl => hy (List.mem_filter.2 ⟨hl, by simpa using hyx⟩), hyx⟩
-  | g, .inter s t, a => and_congr (Term.mem_elim g s a) (Term.mem_elim g t a)
-  | _, .empty, _ => Iff.rfl
-  | g, .presup t _, a => Term.mem_elim g t a
-/-- The PIP constructs are eliminable: the translation preserves truth. -/
-theorem Formula.realize_elim : ∀ (g : V → Set α) (φ : Formula V L P),
-    φ.elim.Realize M g ↔ φ.Realize M g
-  | _, .top => Iff.rfl
-  | g, .atom r w ts => by
-      show M.I r {a | w.elim.Mem M g a} (fun i => {a | (ts i).elim.Mem M g a}) ↔ _
-      rw [Set.ext fun a => Term.mem_elim g w a,
-        show (fun i => {a | (ts i).elim.Mem M g a}) = fun i => {a | (ts i).Mem M g a} from
-          funext fun i => Set.ext fun a => Term.mem_elim g (ts i) a]
-      exact Iff.rfl
-  | g, .eq s t => by
-      show {a | s.elim.Mem M g a} = {a | t.elim.Mem M g a} ↔ _
-      rw [Set.ext fun a => Term.mem_elim g s a, Set.ext fun a => Term.mem_elim g t a]
-      exact Iff.rfl
-  | g, .subset s t => by
-      show {a | s.elim.Mem M g a} ⊆ {a | t.elim.Mem M g a} ↔ _
-      rw [Set.ext fun a => Term.mem_elim g s a, Set.ext fun a => Term.mem_elim g t a]
-      exact Iff.rfl
-  | g, .mem s t => by
-      show (∃ a, {b | s.elim.Mem M g b} = {a} ∧ t.elim.Mem M g a) ↔ _
-      rw [Set.ext fun a => Term.mem_elim g s a]
-      exact exists_congr fun a => and_congr_right fun _ => Term.mem_elim g t a
-  | g, .sg t => by
-      show (∃ a, {b | t.elim.Mem M g b} = {a}) ↔ _
-      rw [Set.ext fun a => Term.mem_elim g t a]
-      exact Iff.rfl
-  | g, .pl t =>
+  | _, .inter s t, g, a => and_congr (Expr.realize_elim s g a) (Expr.realize_elim t g a)
+  | _, .empty, _, _ => Iff.rfl
+  | _, .top, _, _ => Iff.rfl
+  | _, .atom r w ts, g, _ =>
+      iff_of_eq (congrArg₂ (M.I r) (Set.ext fun a => Expr.realize_elim w g a)
+        (funext fun i => Set.ext fun a => Expr.realize_elim (ts i) g a))
+  | _, .eq s t, g, _ =>
+      iff_of_eq (congrArg₂ (· = ·) (Set.ext fun a => Expr.realize_elim s g a)
+        (Set.ext fun a => Expr.realize_elim t g a))
+  | _, .subset s t, g, _ =>
+      iff_of_eq (congrArg₂ (· ⊆ ·) (Set.ext fun a => Expr.realize_elim s g a)
+        (Set.ext fun a => Expr.realize_elim t g a))
+  | _, .mem s t, g, _ =>
+      exists_congr fun a => and_congr
+        (iff_of_eq (congrArg (fun S : Set α => S = {a})
+          (Set.ext fun b => Expr.realize_elim s g b :
+            Term.realize M g s.elim = Term.realize M g s)))
+        (Expr.realize_elim t g a)
+  | _, .sg t, g, _ =>
+      exists_congr fun a => iff_of_eq (congrArg (fun S : Set α => S = {a})
+        (Set.ext fun b => Expr.realize_elim t g b : Term.realize M g t.elim = Term.realize M g t))
+  | _, .pl t, g, _ =>
       exists_congr fun a => exists_congr fun b => and_congr_right fun _ =>
-        and_congr (Term.mem_elim g t a) (Term.mem_elim g t b)
-  | g, .neg φ => not_congr (Formula.realize_elim g φ)
-  | g, .conj φ ψ => and_congr (Formula.realize_elim g φ) (Formula.realize_elim g ψ)
-  | g, .exists_ x φ =>
-      exists_congr fun _ => and_congr_right fun _ => Formula.realize_elim _ φ
-  | g, .presup φ _ => Formula.realize_elim g φ
-  | _, .labelDef _ _ => Iff.rfl
-  | _, .label _ => Iff.rfl
-end
+        and_congr (Expr.realize_elim t g a) (Expr.realize_elim t g b)
+  | _, .neg φ, g, _ => not_congr (Expr.realize_elim φ g .unit)
+  | _, .conj φ ψ, g, _ => and_congr (Expr.realize_elim φ g .unit) (Expr.realize_elim ψ g .unit)
+  | _, .exists_ _ φ, _, _ =>
+      exists_congr fun _ => and_congr_right fun _ => Expr.realize_elim φ _ .unit
+  | _, .labelDef _ _, _, _ => Iff.rfl
+  | _, .label _, _, _ => Iff.rfl
+  | _, .presup e _, g, a => Expr.realize_elim e g a
+
+theorem Term.realize_elim (t : Term V L P) : Term.realize M g t.elim = Term.realize M g t :=
+  Set.ext fun a => Expr.realize_elim M t g a
+
+theorem Formula.realize_elim (φ : Formula V L P) :
+    Formula.Realize M g φ.elim ↔ Formula.Realize M g φ :=
+  Expr.realize_elim M φ g .unit
 
 end Semantics
 

--- a/Linglib/Logic/PIP/Syntax.lean
+++ b/Linglib/Logic/PIP/Syntax.lean
@@ -10,7 +10,8 @@ abstraction, equality, the set-theoretic relations `⊆`, `∈`, `∩`, `∅` an
 cardinality predicates `SG` and `PL`, extended by bracketed *local* variables
 `[x]`, summation `Σxφ`, formula labels `X ≡ φ` with their uses `X`, world
 arguments on relation symbols, and presuppositions `φ|ψ`. Relation symbols are
-indexed by arity and take a world as a distinguished argument.
+indexed by arity and take a world as a distinguished argument. Terms and
+formulas are one inductive type indexed by their kind.
 
 It also defines the local variables of an expression, substitution for a
 variable, the presupposition-free expressions, the expansion of formula labels
@@ -19,18 +20,17 @@ Truth is defined in `Semantics.lean` and felicity in `Felicity.lean`.
 
 ## Main definitions
 
-* `Term`, `Formula` — the mutual syntax; `Formula.disj`, `Formula.impl`,
-  `Formula.iff_`, `Formula.forall_`, `Formula.some_` — the defined
-  connectives; `Term.sgPronoun` — a singular summation pronoun.
-* `Term.locals`, `Formula.locals` — the local variables; `Term.subst`,
-  `Formula.subst` — substitution for a variable.
-* `Term.PresupFree`, `Formula.PresupFree` — expressions without
-  presuppositions, decidably.
-* `Formula.substLabels`, `Formula.defs`, `assignment`, `Formula.expand`,
+* `Kind`, `Expr`, `Term`, `Formula` — the syntax; `Formula.disj`,
+  `Formula.impl`, `Formula.iff_`, `Formula.forall_`, `Formula.some_` — the
+  defined connectives; `Term.sgPronoun` — a singular summation pronoun.
+* `Expr.locals` — the local variables; `Expr.subst` — substitution for a
+  variable.
+* `Expr.PresupFree` — expressions without presuppositions, decidably.
+* `Expr.substLabels`, `Expr.defs`, `assignment`, `Formula.expand`,
   `Formula.expandSelf` — label assignment and expansion, as a bounded fixpoint
   of simultaneous substitution.
-* `Formula.closeList`, `Term.elim`, `Formula.elim` — the translation into
-  predicate calculus with set abstraction.
+* `Formula.closeList`, `Expr.elim` — the translation into predicate calculus
+  with set abstraction.
 
 ## References
 
@@ -42,39 +42,47 @@ namespace PIP
 
 universe u v w
 
-mutual
-/-- Terms: external variables, bracketed local variables `[x]`, set abstraction
-`⋃{x : φ}`, summation `Σxφ`, intersection, the empty plurality, and a term with
-a presupposition `τ|ψ`. -/
-inductive Term (V : Type u) (L : Type v) (P : ℕ → Type w)
-  | var (x : V)
-  | bvar (x : V)
-  | abs (x : V) (φ : Formula V L P)
-  | sigma (x : V) (φ : Formula V L P)
-  | inter (s t : Term V L P)
-  | empty
-  | presup (t : Term V L P) (ψ : Formula V L P)
-/-- Formulas: the constant `⊤`, predication `P_w(τ₁, …, τₙ)`, equality, inclusion,
-membership, the cardinality predicates `SG` and `PL`, negation, conjunction,
-selective existential quantification, presupposition `φ|ψ`, label definition
-`X ≡ φ`, and label use `X`. -/
-inductive Formula (V : Type u) (L : Type v) (P : ℕ → Type w)
-  | top
-  | atom {n : ℕ} (r : P n) (w : Term V L P) (ts : Fin n → Term V L P)
-  | eq (s t : Term V L P)
-  | subset (s t : Term V L P)
-  | mem (s t : Term V L P)
-  | sg (t : Term V L P)
-  | pl (t : Term V L P)
-  | neg (φ : Formula V L P)
-  | conj (φ ψ : Formula V L P)
-  | exists_ (x : V) (φ : Formula V L P)
-  | presup (φ ψ : Formula V L P)
-  | labelDef (X : L) (φ : Formula V L P)
-  | label (X : L)
-end
+/-- The kinds of PIP expressions. -/
+inductive Kind
+  | term
+  | formula
 
-variable {V : Type u} {L : Type v} {P : ℕ → Type w} {α : Type*}
+/-- PIP expressions. Terms: external variables, bracketed local variables `[x]`,
+set abstraction `⋃{x : φ}`, summation `Σxφ`, intersection and the empty
+plurality. Formulas: the constant `⊤`, predication `P_w(τ₁, …, τₙ)`, equality,
+inclusion, membership, the cardinality predicates `SG` and `PL`, negation,
+conjunction, selective existential quantification, label definition `X ≡ φ`
+and label use `X`. An expression of either kind with a presupposition,
+`e|ψ`. -/
+inductive Expr (V : Type u) (L : Type v) (P : ℕ → Type w) : Kind → Type (max u v w)
+  | var (x : V) : Expr V L P .term
+  | bvar (x : V) : Expr V L P .term
+  | abs (x : V) (φ : Expr V L P .formula) : Expr V L P .term
+  | sigma (x : V) (φ : Expr V L P .formula) : Expr V L P .term
+  | inter (s t : Expr V L P .term) : Expr V L P .term
+  | empty : Expr V L P .term
+  | top : Expr V L P .formula
+  | atom {n : ℕ} (r : P n) (w : Expr V L P .term) (ts : Fin n → Expr V L P .term) :
+      Expr V L P .formula
+  | eq (s t : Expr V L P .term) : Expr V L P .formula
+  | subset (s t : Expr V L P .term) : Expr V L P .formula
+  | mem (s t : Expr V L P .term) : Expr V L P .formula
+  | sg (t : Expr V L P .term) : Expr V L P .formula
+  | pl (t : Expr V L P .term) : Expr V L P .formula
+  | neg (φ : Expr V L P .formula) : Expr V L P .formula
+  | conj (φ ψ : Expr V L P .formula) : Expr V L P .formula
+  | exists_ (x : V) (φ : Expr V L P .formula) : Expr V L P .formula
+  | labelDef (X : L) (φ : Expr V L P .formula) : Expr V L P .formula
+  | label (X : L) : Expr V L P .formula
+  | presup {k : Kind} (e : Expr V L P k) (ψ : Expr V L P .formula) : Expr V L P k
+
+/-- Terms. -/
+abbrev Term (V : Type u) (L : Type v) (P : ℕ → Type w) := Expr V L P .term
+
+/-- Formulas. -/
+abbrev Formula (V : Type u) (L : Type v) (P : ℕ → Type w) := Expr V L P .formula
+
+variable {V : Type u} {L : Type v} {P : ℕ → Type w}
 
 /-- Disjunction, as `¬(¬φ ∧ ¬ψ)`. -/
 def Formula.disj (φ ψ : Formula V L P) : Formula V L P := .neg (.conj (.neg φ) (.neg ψ))
@@ -101,131 +109,109 @@ section Syntax
 
 variable [DecidableEq V]
 
-mutual
-/-- The local variables of a term: bracketed occurrences at top level, with
-summation and set abstraction binding theirs. -/
-def Term.locals : Term V L P → List V
-  | .var _ => []
-  | .bvar x => [x]
-  | .abs x φ => φ.locals.filter (· ≠ x)
-  | .sigma _ _ => []
-  | .inter s t => s.locals ++ t.locals
-  | .empty => []
-  | .presup t ψ => t.locals ++ ψ.locals
-/-- The local variables of a formula. -/
-def Formula.locals : Formula V L P → List V
-  | .top => []
-  | .atom _ w ts => w.locals ++ (List.finRange _).flatMap fun i => (ts i).locals
-  | .eq s t => s.locals ++ t.locals
-  | .subset s t => s.locals ++ t.locals
-  | .mem s t => s.locals ++ t.locals
-  | .sg t => t.locals
-  | .pl t => t.locals
-  | .neg φ => φ.locals
-  | .conj φ ψ => φ.locals ++ ψ.locals
-  | .exists_ x φ => φ.locals.filter (· ≠ x)
-  | .presup φ ψ => φ.locals ++ ψ.locals
-  | .labelDef _ _ => []
-  | .label _ => []
-end
+/-- The local variables of an expression: bracketed occurrences at top level,
+with summation, set abstraction and quantification binding theirs. -/
+def Expr.locals : ∀ {k : Kind}, Expr V L P k → List V
+  | _, .var _ => []
+  | _, .bvar x => [x]
+  | _, .abs x φ => φ.locals.filter (· ≠ x)
+  | _, .sigma _ _ => []
+  | _, .inter s t => s.locals ++ t.locals
+  | _, .empty => []
+  | _, .top => []
+  | _, .atom _ w ts => w.locals ++ (List.finRange _).flatMap fun i => (ts i).locals
+  | _, .eq s t => s.locals ++ t.locals
+  | _, .subset s t => s.locals ++ t.locals
+  | _, .mem s t => s.locals ++ t.locals
+  | _, .sg t => t.locals
+  | _, .pl t => t.locals
+  | _, .neg φ => φ.locals
+  | _, .conj φ ψ => φ.locals ++ ψ.locals
+  | _, .exists_ x φ => φ.locals.filter (· ≠ x)
+  | _, .labelDef _ _ => []
+  | _, .label _ => []
+  | _, .presup e ψ => e.locals ++ ψ.locals
 
 /-- Bracket a variable: `[x]` for `x`; other terms are unchanged. -/
 def Term.bracket : Term V L P → Term V L P
   | .var x => .bvar x
   | t => t
 
-mutual
 /-- Substitute `t` for the variable `x`, the β-reduction of `λx`: a bracketed
 occurrence `[x]` becomes the bracketed substitute, binders of `x` are skipped,
 and no capture check is made. -/
-def Term.subst (x : V) (t : Term V L P) : Term V L P → Term V L P
-  | .var y => if y = x then t else .var y
-  | .bvar y => if y = x then t.bracket else .bvar y
-  | .abs y φ => .abs y (if y = x then φ else Formula.subst x t φ)
-  | .sigma y φ => .sigma y (if y = x then φ else Formula.subst x t φ)
-  | .inter s u => .inter (Term.subst x t s) (Term.subst x t u)
-  | .empty => .empty
-  | .presup s ψ => .presup (Term.subst x t s) (Formula.subst x t ψ)
-/-- Substitute `t` for the variable `x`. -/
-def Formula.subst (x : V) (t : Term V L P) : Formula V L P → Formula V L P
-  | .top => .top
-  | .atom r w ts => .atom r (Term.subst x t w) fun i => Term.subst x t (ts i)
-  | .eq s u => .eq (Term.subst x t s) (Term.subst x t u)
-  | .subset s u => .subset (Term.subst x t s) (Term.subst x t u)
-  | .mem s u => .mem (Term.subst x t s) (Term.subst x t u)
-  | .sg s => .sg (Term.subst x t s)
-  | .pl s => .pl (Term.subst x t s)
-  | .neg φ => .neg (Formula.subst x t φ)
-  | .conj φ ψ => .conj (Formula.subst x t φ) (Formula.subst x t ψ)
-  | .exists_ y φ => .exists_ y (if y = x then φ else Formula.subst x t φ)
-  | .presup φ ψ => .presup (Formula.subst x t φ) (Formula.subst x t ψ)
-  | .labelDef X φ => .labelDef X (Formula.subst x t φ)
-  | .label X => .label X
-end
+def Expr.subst (x : V) (t : Term V L P) : ∀ {k : Kind}, Expr V L P k → Expr V L P k
+  | _, .var y => if y = x then t else .var y
+  | _, .bvar y => if y = x then t.bracket else .bvar y
+  | _, .abs y φ => .abs y (if y = x then φ else Expr.subst x t φ)
+  | _, .sigma y φ => .sigma y (if y = x then φ else Expr.subst x t φ)
+  | _, .inter s u => .inter (Expr.subst x t s) (Expr.subst x t u)
+  | _, .empty => .empty
+  | _, .top => .top
+  | _, .atom r w ts => .atom r (Expr.subst x t w) fun i => Expr.subst x t (ts i)
+  | _, .eq s u => .eq (Expr.subst x t s) (Expr.subst x t u)
+  | _, .subset s u => .subset (Expr.subst x t s) (Expr.subst x t u)
+  | _, .mem s u => .mem (Expr.subst x t s) (Expr.subst x t u)
+  | _, .sg s => .sg (Expr.subst x t s)
+  | _, .pl s => .pl (Expr.subst x t s)
+  | _, .neg φ => .neg (Expr.subst x t φ)
+  | _, .conj φ ψ => .conj (Expr.subst x t φ) (Expr.subst x t ψ)
+  | _, .exists_ y φ => .exists_ y (if y = x then φ else Expr.subst x t φ)
+  | _, .labelDef X φ => .labelDef X (Expr.subst x t φ)
+  | _, .label X => .label X
+  | _, .presup e ψ => .presup (Expr.subst x t e) (Expr.subst x t ψ)
 
 end Syntax
 
 /-! ### Expressions without presuppositions -/
 
-mutual
-/-- A term with no presupposition operator and no label use. -/
-def Term.PresupFree : Term V L P → Prop
-  | .var _ => True
-  | .bvar _ => True
-  | .abs _ φ => φ.PresupFree
-  | .sigma _ φ => φ.PresupFree
-  | .inter s t => s.PresupFree ∧ t.PresupFree
-  | .empty => True
-  | .presup _ _ => False
-/-- A formula with no presupposition operator and no label use. -/
-def Formula.PresupFree : Formula V L P → Prop
-  | .top => True
-  | .atom _ w ts => w.PresupFree ∧ ∀ i ∈ List.finRange _, (ts i).PresupFree
-  | .eq s t => s.PresupFree ∧ t.PresupFree
-  | .subset s t => s.PresupFree ∧ t.PresupFree
-  | .mem s t => s.PresupFree ∧ t.PresupFree
-  | .sg t => t.PresupFree
-  | .pl t => t.PresupFree
-  | .neg φ => φ.PresupFree
-  | .conj φ ψ => φ.PresupFree ∧ ψ.PresupFree
-  | .exists_ _ φ => φ.PresupFree
-  | .presup _ _ => False
-  | .labelDef _ φ => φ.PresupFree
-  | .label _ => False
-end
+/-- An expression with no presupposition operator and no label use. -/
+def Expr.PresupFree : ∀ {k : Kind}, Expr V L P k → Prop
+  | _, .var _ => True
+  | _, .bvar _ => True
+  | _, .abs _ φ => φ.PresupFree
+  | _, .sigma _ φ => φ.PresupFree
+  | _, .inter s t => s.PresupFree ∧ t.PresupFree
+  | _, .empty => True
+  | _, .top => True
+  | _, .atom _ w ts => w.PresupFree ∧ ∀ i ∈ List.finRange _, (ts i).PresupFree
+  | _, .eq s t => s.PresupFree ∧ t.PresupFree
+  | _, .subset s t => s.PresupFree ∧ t.PresupFree
+  | _, .mem s t => s.PresupFree ∧ t.PresupFree
+  | _, .sg t => t.PresupFree
+  | _, .pl t => t.PresupFree
+  | _, .neg φ => φ.PresupFree
+  | _, .conj φ ψ => φ.PresupFree ∧ ψ.PresupFree
+  | _, .exists_ _ φ => φ.PresupFree
+  | _, .labelDef _ φ => φ.PresupFree
+  | _, .label _ => False
+  | _, .presup _ _ => False
 
-mutual
-/-- Decidability of `Term.PresupFree`. -/
-def Term.decPresupFree : (t : Term V L P) → Decidable t.PresupFree
-  | .var _ => isTrue trivial
-  | .bvar _ => isTrue trivial
-  | .abs _ φ => φ.decPresupFree
-  | .sigma _ φ => φ.decPresupFree
-  | .inter s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
-  | .empty => isTrue trivial
-  | .presup _ _ => isFalse id
-/-- Decidability of `Formula.PresupFree`. -/
-def Formula.decPresupFree : (φ : Formula V L P) → Decidable φ.PresupFree
-  | .top => isTrue trivial
-  | .atom _ w ts =>
+/-- Decidability of `Expr.PresupFree`. -/
+def Expr.decPresupFree : ∀ {k : Kind} (e : Expr V L P k), Decidable e.PresupFree
+  | _, .var _ => isTrue trivial
+  | _, .bvar _ => isTrue trivial
+  | _, .abs _ φ => φ.decPresupFree
+  | _, .sigma _ φ => φ.decPresupFree
+  | _, .inter s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
+  | _, .empty => isTrue trivial
+  | _, .top => isTrue trivial
+  | _, .atom _ w ts =>
       @instDecidableAnd _ _ w.decPresupFree
         (@List.decidableBAll _ _ (fun i => (ts i).decPresupFree) _)
-  | .eq s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
-  | .subset s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
-  | .mem s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
-  | .sg t => t.decPresupFree
-  | .pl t => t.decPresupFree
-  | .neg φ => φ.decPresupFree
-  | .conj φ ψ => @instDecidableAnd _ _ φ.decPresupFree ψ.decPresupFree
-  | .exists_ _ φ => φ.decPresupFree
-  | .presup _ _ => isFalse id
-  | .labelDef _ φ => φ.decPresupFree
-  | .label _ => isFalse id
-end
+  | _, .eq s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
+  | _, .subset s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
+  | _, .mem s t => @instDecidableAnd _ _ s.decPresupFree t.decPresupFree
+  | _, .sg t => t.decPresupFree
+  | _, .pl t => t.decPresupFree
+  | _, .neg φ => φ.decPresupFree
+  | _, .conj φ ψ => @instDecidableAnd _ _ φ.decPresupFree ψ.decPresupFree
+  | _, .exists_ _ φ => φ.decPresupFree
+  | _, .labelDef _ φ => φ.decPresupFree
+  | _, .label _ => isFalse id
+  | _, .presup _ _ => isFalse id
 
-instance (t : Term V L P) : Decidable t.PresupFree := t.decPresupFree
-
-instance (φ : Formula V L P) : Decidable φ.PresupFree := φ.decPresupFree
+instance {k : Kind} (e : Expr V L P k) : Decidable e.PresupFree := e.decPresupFree
 
 /-! ### Labels -/
 
@@ -233,60 +219,50 @@ section Labels
 
 variable [DecidableEq L]
 
-mutual
 /-- Replace every label use by its definition under the assignment `A`, leaving
 undefined labels in place. -/
-def Term.substLabels (A : L → Option (Formula V L P)) : Term V L P → Term V L P
-  | .var x => .var x
-  | .bvar x => .bvar x
-  | .abs x φ => .abs x (Formula.substLabels A φ)
-  | .sigma x φ => .sigma x (Formula.substLabels A φ)
-  | .inter s t => .inter (Term.substLabels A s) (Term.substLabels A t)
-  | .empty => .empty
-  | .presup t χ => .presup (Term.substLabels A t) (Formula.substLabels A χ)
-/-- Replace every label use by its definition under the assignment `A`. -/
-def Formula.substLabels (A : L → Option (Formula V L P)) : Formula V L P → Formula V L P
-  | .top => .top
-  | .atom r w ts => .atom r (Term.substLabels A w) fun i => Term.substLabels A (ts i)
-  | .eq s t => .eq (Term.substLabels A s) (Term.substLabels A t)
-  | .subset s t => .subset (Term.substLabels A s) (Term.substLabels A t)
-  | .mem s t => .mem (Term.substLabels A s) (Term.substLabels A t)
-  | .sg t => .sg (Term.substLabels A t)
-  | .pl t => .pl (Term.substLabels A t)
-  | .neg φ => .neg (Formula.substLabels A φ)
-  | .conj φ χ => .conj (Formula.substLabels A φ) (Formula.substLabels A χ)
-  | .exists_ x φ => .exists_ x (Formula.substLabels A φ)
-  | .presup φ χ => .presup (Formula.substLabels A φ) (Formula.substLabels A χ)
-  | .labelDef X φ => .labelDef X (Formula.substLabels A φ)
-  | .label X => (A X).getD (.label X)
-end
+def Expr.substLabels (A : L → Option (Formula V L P)) : ∀ {k : Kind}, Expr V L P k → Expr V L P k
+  | _, .var x => .var x
+  | _, .bvar x => .bvar x
+  | _, .abs x φ => .abs x (φ.substLabels A)
+  | _, .sigma x φ => .sigma x (φ.substLabels A)
+  | _, .inter s t => .inter (s.substLabels A) (t.substLabels A)
+  | _, .empty => .empty
+  | _, .top => .top
+  | _, .atom r w ts => .atom r (w.substLabels A) fun i => (ts i).substLabels A
+  | _, .eq s t => .eq (s.substLabels A) (t.substLabels A)
+  | _, .subset s t => .subset (s.substLabels A) (t.substLabels A)
+  | _, .mem s t => .mem (s.substLabels A) (t.substLabels A)
+  | _, .sg t => .sg (t.substLabels A)
+  | _, .pl t => .pl (t.substLabels A)
+  | _, .neg φ => .neg (φ.substLabels A)
+  | _, .conj φ χ => .conj (φ.substLabels A) (χ.substLabels A)
+  | _, .exists_ x φ => .exists_ x (φ.substLabels A)
+  | _, .labelDef X φ => .labelDef X (φ.substLabels A)
+  | _, .label X => (A X).getD (.label X)
+  | _, .presup e χ => .presup (e.substLabels A) (χ.substLabels A)
 
-mutual
-/-- The label definitions occurring in a term. -/
-def Term.defs : Term V L P → List (L × Formula V L P)
-  | .var _ => []
-  | .bvar _ => []
-  | .abs _ φ => φ.defs
-  | .sigma _ φ => φ.defs
-  | .inter s t => s.defs ++ t.defs
-  | .empty => []
-  | .presup t ψ => t.defs ++ ψ.defs
-/-- The label definitions occurring in a formula. -/
-def Formula.defs : Formula V L P → List (L × Formula V L P)
-  | .top => []
-  | .atom _ w ts => w.defs ++ (List.finRange _).flatMap fun i => (ts i).defs
-  | .eq s t => s.defs ++ t.defs
-  | .subset s t => s.defs ++ t.defs
-  | .mem s t => s.defs ++ t.defs
-  | .sg t => t.defs
-  | .pl t => t.defs
-  | .neg φ => φ.defs
-  | .conj φ ψ => φ.defs ++ ψ.defs
-  | .exists_ _ φ => φ.defs
-  | .presup φ ψ => φ.defs ++ ψ.defs
-  | .labelDef X φ => (X, φ) :: φ.defs
-  | .label _ => []
-end
+/-- The label definitions occurring in an expression. -/
+def Expr.defs : ∀ {k : Kind}, Expr V L P k → List (L × Formula V L P)
+  | _, .var _ => []
+  | _, .bvar _ => []
+  | _, .abs _ φ => φ.defs
+  | _, .sigma _ φ => φ.defs
+  | _, .inter s t => s.defs ++ t.defs
+  | _, .empty => []
+  | _, .top => []
+  | _, .atom _ w ts => w.defs ++ (List.finRange _).flatMap fun i => (ts i).defs
+  | _, .eq s t => s.defs ++ t.defs
+  | _, .subset s t => s.defs ++ t.defs
+  | _, .mem s t => s.defs ++ t.defs
+  | _, .sg t => t.defs
+  | _, .pl t => t.defs
+  | _, .neg φ => φ.defs
+  | _, .conj φ ψ => φ.defs ++ ψ.defs
+  | _, .exists_ _ φ => φ.defs
+  | _, .labelDef X φ => (X, φ) :: φ.defs
+  | _, .label _ => []
+  | _, .presup e ψ => e.defs ++ ψ.defs
 
 /-- The label assignment determined by a list of definitions: the first
 definition of each label. -/
@@ -313,36 +289,31 @@ variable [DecidableEq V]
 
 /-- Existential closure over a list of variables, as syntax. -/
 def Formula.closeList (xs : List V) (φ : Formula V L P) : Formula V L P :=
-  xs.foldr Formula.exists_ φ
+  xs.foldr Expr.exists_ φ
 
-mutual
 /-- Translation into predicate calculus with set abstraction: brackets and
 presuppositions are dropped, summation becomes abstraction over the closure of
 the other local variables, label definitions become `⊤`. -/
-def Term.elim : Term V L P → Term V L P
-  | .var x => .var x
-  | .bvar x => .var x
-  | .abs x φ => .abs x φ.elim
-  | .sigma x φ => .abs x (φ.elim.closeList (φ.locals.filter (· ≠ x)))
-  | .inter s t => .inter s.elim t.elim
-  | .empty => .empty
-  | .presup t _ => t.elim
-/-- Translation into predicate calculus with set abstraction. -/
-def Formula.elim : Formula V L P → Formula V L P
-  | .top => .top
-  | .atom r w ts => .atom r w.elim fun i => (ts i).elim
-  | .eq s t => .eq s.elim t.elim
-  | .subset s t => .subset s.elim t.elim
-  | .mem s t => .mem s.elim t.elim
-  | .sg t => .sg t.elim
-  | .pl t => .pl t.elim
-  | .neg φ => .neg φ.elim
-  | .conj φ ψ => .conj φ.elim ψ.elim
-  | .exists_ x φ => .exists_ x φ.elim
-  | .presup φ _ => φ.elim
-  | .labelDef _ _ => .top
-  | .label X => .label X
-end
+def Expr.elim : ∀ {k : Kind}, Expr V L P k → Expr V L P k
+  | _, .var x => .var x
+  | _, .bvar x => .var x
+  | _, .abs x φ => .abs x φ.elim
+  | _, .sigma x φ => .abs x (Formula.closeList (φ.locals.filter (· ≠ x)) φ.elim)
+  | _, .inter s t => .inter s.elim t.elim
+  | _, .empty => .empty
+  | _, .top => .top
+  | _, .atom r w ts => .atom r w.elim fun i => (ts i).elim
+  | _, .eq s t => .eq s.elim t.elim
+  | _, .subset s t => .subset s.elim t.elim
+  | _, .mem s t => .mem s.elim t.elim
+  | _, .sg t => .sg t.elim
+  | _, .pl t => .pl t.elim
+  | _, .neg φ => .neg φ.elim
+  | _, .conj φ ψ => .conj φ.elim ψ.elim
+  | _, .exists_ x φ => .exists_ x φ.elim
+  | _, .labelDef _ _ => .top
+  | _, .label X => .label X
+  | _, .presup e _ => e.elim
 
 end Elim
 

--- a/Linglib/Studies/AbneyKeshet2025.lean
+++ b/Linglib/Studies/AbneyKeshet2025.lean
@@ -201,7 +201,7 @@ def PM (φ ψ : Tm → Fm) : Tm → Fm := fun a => .conj (φ a) (ψ a)
 
 /-- Predicate abstraction `λxφ`, reading through the labels `A` of the preceding
 discourse before substituting for `x` (123). -/
-def PA (A : List (Lab × Fm)) (v : Var) (φ : Fm) : Tm → Fm := fun t => (φ.expand A).subst v t
+def PA (A : List (Lab × Fm)) (v : Var) (φ : Fm) : Tm → Fm := fun t => Expr.subst v t (φ.expand A)
 
 /-- Summation with a label: `ΣxZ where Z ≡ φ`, the definition attached to the use. -/
 def SA (v : Var) (Z : Lab) (φ : Fm) : Tm := .sigma v (.conj (.label Z) (.labelDef Z φ))
@@ -268,7 +268,7 @@ def Word.sem : (α : Word) → Sem α.ty
   | .it => fun z => .presup z (.sg z)
   | .they => fun z => .presup z (.pl z)
   | .not _ => fun ψ => .neg (.mem (.var .w) ψ)
-  | .might _ => fun β ψ => .some_ β ψ
+  | .might _ => fun β ψ => Formula.some_ β ψ
   | .must _ => fun β ψ => .subset β ψ
   | .base => modalBase
 
@@ -376,7 +376,7 @@ theorem interp_aFarmerWhoOwnsADonkey :
           (restricted .o fun e => .conj (pred₁ .ownEvt e)
             (.conj (pred₂ .hasPatient e (.var .d)) (restricted .d (pred₁ .donkey))))) := by
   simp only [aFarmerWhoOwnsADonkey, interp, Word.sem, FA, FX, PM, PA, lift, restricted, pred₁,
-    pred₂, Formula.expand, List.foldl_nil, Formula.subst, Term.subst, Term.bracket,
+    pred₂, Formula.expand, List.foldl_nil, Expr.subst, Expr.subst, Term.bracket,
     Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq, reduceIte]
 
 /-- (66): "every girl wrote a paper", quantifier raising leaving a restricted-variable
@@ -437,8 +437,8 @@ theorem interp_mostOfThemUsedIt :
           (restricted .e fun e => .conj (pred₁ .useEvt e)
             (pred₂ .hasPatient e (.presup (.var .u) (.sg (.var .u))))))] := by
   simp only [mostOfThemUsedIt, interp, Word.sem, FA, FX, PM, PA, SA, lift, restricted, pred₁,
-    pred₂, defs118, Formula.expand, List.foldl_cons, List.foldl_nil, Formula.substLabels,
-    Term.substLabels, assignment, Formula.subst, Term.subst, Term.bracket, Matrix.comp_vecCons,
+    pred₂, defs118, Formula.expand, List.foldl_cons, List.foldl_nil, Expr.substLabels,
+    Expr.substLabels, assignment, Expr.subst, Expr.subst, Term.bracket, Matrix.comp_vecCons,
     Matrix.comp_vecEmpty, reduceCtorEq, reduceIte, Option.getD_some]
 
 /-! ### Scenarios -/
@@ -483,7 +483,7 @@ theorem felicitous_pred₂ (c : Lex 2) (s t : Tm) :
 
 /-- `w ∈ τ` at the world `w₀`. -/
 theorem realize_mem_world (hw : h .w = world w₀) (t : Tm) :
-    (Formula.mem (.var .w) t).Realize S.model h ↔ Sum.inl w₀ ∈ t.realize S.model h := by
+    Formula.Realize S.model h (.mem (.var .w) t) ↔ Sum.inl w₀ ∈ t.realize S.model h := by
   simp only [Formula.realize_mem, Term.realize_var, hw, world, Set.singleton_eq_singleton_iff,
     exists_eq_left']
 
@@ -516,7 +516,7 @@ variable (c₁ : Lex 1) (c₂ : Lex 2) {y : Var}
 theorem locals_indefOwned : (indefOwned c₁ c₂ y).locals = [y] := rfl
 
 theorem felicitous_indefOwned : (indefOwned c₁ c₂ y).Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (of_decide_eq_true rfl)
+  Expr.felicitous_of_presupFree _ _ (of_decide_eq_true rfl) _
 
 theorem realize_indefOwned (hx : h .x = {Sum.inr x₀}) :
     (indefOwned c₁ c₂ y).Realize S.model h ↔
@@ -543,7 +543,7 @@ theorem realize_indefOwned (hx : h .x = {Sum.inr x₀}) :
 paycheck pronoun `ΣdD` denotes the dioramas made by whatever `x` is (112). -/
 theorem realize_sigma_indefOwned (hw : h .w = world w₀) (hx : h .x = {Sum.inr x₀})
     (hyw : y ≠ .w) (hyx : y ≠ .x) :
-    (Term.sigma y (indefOwned c₁ c₂ y)).realize S.model h =
+    Term.realize S.model h (.sigma y (indefOwned c₁ c₂ y)) =
       {a | ∃ e, a = Sum.inr e ∧ S.rel₁ c₁ w₀ e ∧ S.rel₂ c₂ w₀ x₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -564,7 +564,7 @@ theorem realize_sigma_indefOwned (hw : h .w = world w₀) (hx : h .x = {Sum.inr 
 /-- The summation over worlds of the indefinite's description: the worlds where `x` has
 such a thing. -/
 theorem realize_sigmaW_indefOwned (hx : h .x = {Sum.inr x₀}) (hyw : y ≠ .w) (hyx : y ≠ .x) :
-    (Term.sigma .w (indefOwned c₁ c₂ y)).realize S.model h =
+    Term.realize S.model h (.sigma .w (indefOwned c₁ c₂ y)) =
       {a | ∃ w e, a = Sum.inl w ∧ S.rel₁ c₁ w e ∧ S.rel₂ c₂ w x₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -618,7 +618,7 @@ theorem expandSelf_shop139 :
         (.labelDef .O ownCar) := by
   rw [Formula.expandSelf, show shop139.defs = [(.O, ownCar)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, shop139, notOwn, Term.sgPronoun, pred₁, ownCar,
-    indefOwned, pred₂, Formula.substLabels, Term.substLabels, assignment, Matrix.comp_vecCons,
+    indefOwned, pred₂, Expr.substLabels, Expr.substLabels, assignment, Matrix.comp_vecCons,
     Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 theorem expandSelf_shop138 :
@@ -628,7 +628,7 @@ theorem expandSelf_shop138 :
         (.labelDef .O ownCar) := by
   rw [Formula.expandSelf, show shop138.defs = [(.O, ownCar)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, shop138, notOwn, Term.sgPronoun, pred₁, ownCar,
-    indefOwned, pred₂, Formula.substLabels, Term.substLabels, assignment, Matrix.comp_vecCons,
+    indefOwned, pred₂, Expr.substLabels, Expr.substLabels, assignment, Matrix.comp_vecCons,
     Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 /-- (139) is felicitous at `w₀` iff he owns a car there — iff its first sentence is false. -/
@@ -670,14 +670,14 @@ def bathroomX : Fm :=
 /-- (143): "Either there is no bathroom here or it's in a funny place",
 `(w ∉ ΣwX ∨ FUNNY-PLACE_w(ΣbX | SG(ΣbX))) ∧ X ≡ …`. -/
 def bathroom143 : Fm :=
-  .conj (.disj (.neg (.mem (.var .w) (.sigma .w (.label .X))))
+  .conj (Formula.disj (.neg (.mem (.var .w) (.sigma .w (.label .X))))
       (pred₁ .funnyPlace (Term.sgPronoun .b (.label .X))))
     (.labelDef .X bathroomX)
 
 theorem locals_bathroomX : bathroomX.locals = [.b] := rfl
 
 theorem felicitous_bathroomX : bathroomX.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem realize_bathroomX :
     bathroomX.Realize S.model h ↔
@@ -699,7 +699,7 @@ theorem realize_bathroomX :
       exact ⟨e, ha, by assumption⟩
 
 theorem realize_sigmaB_bathroomX (hw : h .w = world w₀) :
-    (Term.sigma .b bathroomX).realize S.model h =
+    Term.realize S.model h (.sigma .b bathroomX) =
       {a | ∃ e, a = Sum.inr e ∧ S.rel₁ .bathroom w₀ e ∧ S.rel₁ .here w₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -716,7 +716,7 @@ theorem realize_sigmaB_bathroomX (hw : h .w = world w₀) :
     rw [Function.update_of_ne (by decide), hw]
 
 theorem realize_sigmaW_bathroomX :
-    (Term.sigma .w bathroomX).realize S.model h =
+    Term.realize S.model h (.sigma .w bathroomX) =
       {a | ∃ w e, a = Sum.inl w ∧ S.rel₁ .bathroom w e ∧ S.rel₁ .here w e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -733,12 +733,12 @@ theorem realize_sigmaW_bathroomX :
 
 theorem expandSelf_bathroom143 :
     bathroom143.expandSelf =
-      .conj (.disj (.neg (.mem (.var .w) (.sigma .w bathroomX)))
+      .conj (Formula.disj (.neg (.mem (.var .w) (.sigma .w bathroomX)))
           (pred₁ .funnyPlace (Term.sgPronoun .b bathroomX)))
         (.labelDef .X bathroomX) := by
   rw [Formula.expandSelf, show bathroom143.defs = [(.X, bathroomX)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, bathroom143, Formula.disj, Term.sgPronoun, pred₁,
-    bathroomX, Formula.substLabels, Term.substLabels, assignment, Matrix.comp_vecCons,
+    bathroomX, Expr.substLabels, Expr.substLabels, assignment, Matrix.comp_vecCons,
     Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 /-- (145): the bathroom disjunction is felicitous at `w₀` iff, if there is a bathroom here,
@@ -767,7 +767,7 @@ def wolfE : Fm :=
 /-- (133): "A wolf might enter. It would eat Tasty Tim first.", `MIGHT(β_w, ΣwW) ∧
 MUST(β_w, ΣwW, ΣwE)` (129) with the second modal's restriction the first's nuclear scope. -/
 def wolfDiscourse : Fm :=
-  .conj (.conj (.some_ modalBase (.sigma .w (.label .W)))
+  .conj (.conj (Formula.some_ modalBase (.sigma .w (.label .W)))
       (.subset (.inter modalBase (.sigma .w (.label .W))) (.sigma .w (.label .E))))
     (.conj (.labelDef .W wolfW) (.labelDef .E wolfE))
 
@@ -776,13 +776,13 @@ def wolfE' : Fm := .conj wolfW (.conj (pred₁ .tim (.bvar .t)) (pred₂ .eats (
 
 theorem expandSelf_wolfDiscourse :
     wolfDiscourse.expandSelf =
-      .conj (.conj (.some_ modalBase (.sigma .w wolfW))
+      .conj (.conj (Formula.some_ modalBase (.sigma .w wolfW))
           (.subset (.inter modalBase (.sigma .w wolfW)) (.sigma .w wolfE')))
         (.conj (.labelDef .W wolfW) (.labelDef .E wolfE')) := by
   rw [Formula.expandSelf, show wolfDiscourse.defs = [(.W, wolfW), (.E, wolfE)] from rfl,
     Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, wolfDiscourse, wolfW, wolfE, wolfE', modalBase,
-    Formula.some_, pred₁, pred₂, Formula.substLabels, Term.substLabels, assignment,
+    Formula.some_, pred₁, pred₂, Expr.substLabels, Expr.substLabels, assignment,
     Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq, reduceIte, Option.getD_some]
 
 theorem locals_wolfW : wolfW.locals = [.x] := rfl
@@ -828,7 +828,7 @@ theorem realize_wolfE' :
     exact ⟨⟨w, hw, hne, H⟩, ⟨w, hw, hne', H₁⟩, w, hw, hne, hne', H₂⟩
 
 theorem realize_sigmaW_wolfW :
-    (Term.sigma .w wolfW).realize S.model h =
+    Term.realize S.model h (.sigma .w wolfW) =
       {a | ∃ w e, a = Sum.inl w ∧ S.rel₁ .wolf w e ∧ S.rel₁ .enters w e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -847,7 +847,7 @@ theorem realize_sigmaW_wolfW :
       exact ⟨e, ha, h₁, h₂⟩
 
 theorem realize_sigmaW_wolfE' :
-    (Term.sigma .w wolfE').realize S.model h =
+    Term.realize S.model h (.sigma .w wolfE') =
       {a | ∃ w e t, a = Sum.inl w ∧ (S.rel₁ .wolf w e ∧ S.rel₁ .enters w e) ∧
         S.rel₁ .tim w t ∧ S.rel₂ .eats w e t} := by
   ext a
@@ -922,8 +922,8 @@ theorem expandSelf_theyLoud :
           (.labelDef .B (.conj (pred₁ .dog (.bvar .d)) (pred₁ .barks (.var .d))))) := by
   rw [Formula.expandSelf, show theyLoud.defs = [(.D, pred₁ .dog (.bvar .d)),
     (.B, .conj (.label .D) (pred₁ .barks (.var .d)))] from rfl, Formula.expand]
-  simp only [List.foldl_cons, List.foldl_nil, theyLoud, pred₁, Formula.substLabels,
-    Term.substLabels, assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq,
+  simp only [List.foldl_cons, List.foldl_nil, theyLoud, pred₁, Expr.substLabels,
+    Expr.substLabels, assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq,
     reduceIte, Option.getD_some]
 
 /-! ### Presupposition under quantification -/
@@ -974,7 +974,7 @@ theorem expandSelf_everyMonarchy :
   rw [Formula.expandSelf, show everyMonarchy.defs =
     [(.R, monarchyR), (.K, monarchK), (.S, cherishBody .R)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, everyMonarchy, cherishBody, cherishBody', monarchyR,
-    monarchK, Term.sgPronoun, pred₁, pred₂, Formula.substLabels, Term.substLabels, assignment,
+    monarchK, Term.sgPronoun, pred₁, pred₂, Expr.substLabels, Expr.substLabels, assignment,
     Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq, reduceIte, Option.getD_some]
 
 theorem expandSelf_discourse150a :
@@ -987,12 +987,12 @@ theorem expandSelf_discourse150a :
     [(.C, countryC), (.M, monarchyM), (.K, monarchK), (.S, cherishBody .M)] from rfl,
     Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, discourse150a, cherishBody, cherishBody', countryC,
-    monarchyM, monarchyM', monarchK, Term.sgPronoun, pred₁, pred₂, Formula.substLabels,
-    Term.substLabels, assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq,
+    monarchyM, monarchyM', monarchK, Term.sgPronoun, pred₁, pred₂, Expr.substLabels,
+    Expr.substLabels, assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceCtorEq,
     reduceIte, Option.getD_some]
 
 theorem felicitous_monarchK : monarchK.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem realize_monarchK :
     monarchK.Realize S.model h ↔
@@ -1005,7 +1005,7 @@ theorem realize_monarchK :
 
 /-- "Its monarch" at a singular `m₀`: the monarchs of `m₀`. -/
 theorem realize_sigmaK_monarchK {m₀ : E} (hw : h .w = world w₀) (hm : h .m = {Sum.inr m₀}) :
-    (Term.sigma .k monarchK).realize S.model h =
+    Term.realize S.model h (.sigma .k monarchK) =
       {a | ∃ e, a = Sum.inr e ∧ S.rel₂ .monarchOf w₀ e m₀} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -1037,7 +1037,7 @@ theorem felicitous_sigmaM_cherishBody'_iff {ρ : Fm} {Q : E → Prop} (hw : h .w
     (hlw : Var.w ∉ ρ.locals) (hρf : ∀ g, ρ.Felicitous S.model g)
     (hρ : ∀ g : Var → Set (Atom W E), g .w = world w₀ →
       (ρ.Realize S.model g ↔ ∃ m₀, g .m = {Sum.inr m₀} ∧ Q m₀)) :
-    (Term.sigma .m (cherishBody' ρ)).Felicitous S.model h ↔
+    (Expr.sigma .m (cherishBody' ρ)).Felicitous S.model h ↔
       ∀ m₀, Q m₀ → ∃! e, S.rel₂ .monarchOf w₀ e m₀ := by
   rw [Term.felicitous_sigma]
   constructor
@@ -1060,7 +1060,7 @@ theorem felicitous_sigmaM_cherishBody'_iff {ρ : Fm} {Q : E → Prop} (hw : h .w
     exact (felicitous_sgPronoun_monarchK_iff S g' hw' hm).2 (H m₀ hq)
 
 theorem felicitous_monarchyR : monarchyR.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem realize_monarchyR_iff (hw : h .w = world w₀) :
     monarchyR.Realize S.model h ↔ ∃ m₀, h .m = {Sum.inr m₀} ∧ S.rel₁ .monarchy w₀ m₀ := by
@@ -1088,10 +1088,10 @@ theorem felicitous_everyMonarchy_iff (hw : h .w = world w₀) :
       (fun g hg => realize_monarchyR_iff S g hg)]
 
 theorem felicitous_countryC : countryC.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem felicitous_monarchyM' : monarchyM'.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem realize_countryC_iff (hw : h .w = world w₀) :
     countryC.Realize S.model h ↔ ∃ m₀, h .m = {Sum.inr m₀} ∧ S.rel₁ .country w₀ m₀ := by
@@ -1123,7 +1123,7 @@ theorem realize_monarchyM'_iff (hw : h .w = world w₀) :
       fun a ha => ⟨e, by rw [hm] at ha; exact ha, he'⟩⟩
 
 theorem realize_sigmaM_countryC (hw : h .w = world w₀) :
-    (Term.sigma .m countryC).realize S.model h =
+    Term.realize S.model h (.sigma .m countryC) =
       {a | ∃ e, a = Sum.inr e ∧ S.rel₁ .country w₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
@@ -1138,7 +1138,7 @@ theorem realize_sigmaM_countryC (hw : h .w = world w₀) :
         ⟨e, Function.update_self .., he⟩⟩
 
 theorem realize_sigmaM_monarchyM' (hw : h .w = world w₀) :
-    (Term.sigma .m monarchyM').realize S.model h =
+    Term.realize S.model h (.sigma .m monarchyM') =
       {a | ∃ e, a = Sum.inr e ∧ S.rel₁ .country w₀ e ∧ S.rel₁ .monarchy w₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]

--- a/Linglib/Studies/KeshetAbney2024.lean
+++ b/Linglib/Studies/KeshetAbney2024.lean
@@ -131,7 +131,7 @@ inductive Modal
 
 /-- A modal applied to its base and its prejacent. -/
 def Modal.apply : Modal → Tm → Tm → Fm
-  | .might, β, ψ => .some_ β ψ
+  | .might, β, ψ => Formula.some_ β ψ
   | .must, β, ψ => .subset β ψ
 
 /-- `cont_w(Σbφ | single(Σbφ))`: the continuation (82b), with the summation pronoun
@@ -156,28 +156,30 @@ def plain : Fm := .conj descE (.atom .cont (.var .w) ![.presup (.var .b) (.sg (.
 /-- (95): "Either there's no bathroom in this house or it's in a funny place.",
 `(¬∃bX ∨ cont_w(ΣbX | single(ΣbX))) ∧ X ≡ desc_w([b]) ∧ single(b)`. -/
 def bathroom : Fm :=
-  .conj (.disj (.neg (.exists_ .b (.label .X))) (continuation (.label .X))) (.labelDef .X descE)
+  .conj (Formula.disj (.neg (.exists_ .b (.label .X))) (continuation (.label .X)))
+    (.labelDef .X descE)
 
 /-! ### Label expansion -/
 
 theorem expandSelf_discourseMight : discourseMight.expandSelf = discourse .might descE := by
   rw [Formula.expandSelf, show discourseMight.defs = [(.E, descE)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, discourseMight, discourse, Modal.apply, Formula.some_,
-    continuation, Term.sgPronoun, descE, access, base, Formula.substLabels, Term.substLabels,
+    continuation, Term.sgPronoun, descE, access, base, Expr.substLabels, Expr.substLabels,
     assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 theorem expandSelf_discourseMust : discourseMust.expandSelf = discourse .must descE := by
   rw [Formula.expandSelf, show discourseMust.defs = [(.E, descE)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, discourseMust, discourse, Modal.apply,
-    continuation, Term.sgPronoun, descE, access, base, Formula.substLabels, Term.substLabels,
+    continuation, Term.sgPronoun, descE, access, base, Expr.substLabels, Expr.substLabels,
     assignment, Matrix.comp_vecCons, Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 theorem expandSelf_bathroom :
     bathroom.expandSelf =
-      .conj (.disj (.neg (.exists_ .b descE)) (continuation descE)) (.labelDef .X descE) := by
+      .conj (Formula.disj (.neg (.exists_ .b descE)) (continuation descE))
+        (.labelDef .X descE) := by
   rw [Formula.expandSelf, show bathroom.defs = [(.X, descE)] from rfl, Formula.expand]
   simp only [List.foldl_cons, List.foldl_nil, bathroom, Formula.disj, continuation, Term.sgPronoun,
-    descE, Formula.substLabels, Term.substLabels, assignment, Matrix.comp_vecCons,
+    descE, Expr.substLabels, Expr.substLabels, assignment, Matrix.comp_vecCons,
     Matrix.comp_vecEmpty, reduceIte, Option.getD_some]
 
 /-! ### Values and felicity at a world of evaluation -/
@@ -187,10 +189,10 @@ variable (S : Scenario W E) (h : Var → Set (Atom W E)) {w₀ : W}
 theorem locals_descE : descE.locals = [.b] := rfl
 
 theorem felicitous_descE : descE.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem felicitous_access : access.Felicitous S.model h :=
-  Formula.felicitous_of_presupFree _ _ _ (by decide)
+  Expr.felicitous_of_presupFree _ _ (by decide) _
 
 theorem realize_descE :
     descE.Realize S.model h ↔ ∃ w e, h .w = world w ∧ h .b = {Sum.inr e} ∧ S.desc w e := by
@@ -207,7 +209,7 @@ theorem realize_descE :
 
 /-- `ΣbE` at `w₀`: the satisfiers of the description there. -/
 theorem realize_sigmaB_descE (hw : h .w = world w₀) :
-    (Term.sigma .b descE).realize S.model h = {a | ∃ e, a = Sum.inr e ∧ S.desc w₀ e} := by
+    Term.realize S.model h (.sigma .b descE) = {a | ∃ e, a = Sum.inr e ∧ S.desc w₀ e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
   simp only [realize_descE]
@@ -224,7 +226,7 @@ theorem realize_sigmaB_descE (hw : h .w = world w₀) :
 
 /-- `ΣwE`: the worlds with a satisfier of the description. -/
 theorem realize_sigmaW_descE :
-    (Term.sigma .w descE).realize S.model h = {a | ∃ w e, a = Sum.inl w ∧ S.desc w e} := by
+    Term.realize S.model h (.sigma .w descE) = {a | ∃ w e, a = Sum.inl w ∧ S.desc w e} := by
   ext a
   rw [Term.mem_realize_sigma, Set.mem_ofPred_eq]
   simp only [realize_descE]
@@ -334,11 +336,11 @@ the assertion `single(b)` satisfying the pronoun's presupposition. -/
 theorem felicitous_plain : plain.Felicitous S.model h :=
   ⟨felicitous_descE S h, fun hd => ⟨trivial, Fin.forall_fin_one.2 ⟨trivial, trivial, hd.2⟩⟩⟩
 
-theorem felicitous_exists_descE : (Formula.exists_ .b descE).Felicitous S.model h :=
+theorem felicitous_exists_descE : (Expr.exists_ .b descE).Felicitous S.model h :=
   fun g' _ => felicitous_descE S g'
 
 theorem realize_exists_descE (hw : h .w = world w₀) :
-    (Formula.exists_ .b descE).Realize S.model h ↔ ∃ e, S.desc w₀ e := by
+    Formula.Realize S.model h (.exists_ .b descE) ↔ ∃ e, S.desc w₀ e := by
   rw [Formula.realize_exists]
   simp only [realize_descE]
   constructor


### PR DESCRIPTION
Terms and formulas become one inductive `Expr : Kind → Type` (mathlib's `SetTheory/Lists.lean` / `BoundedFormula` shape), with `Term`/`Formula` as its two fibres and a single `presup` for both kinds. Every former mutual pair — `locals`, `subst`, `PresupFree`, `substLabels`, `defs`, `elim`, `Felicitous`, `realize_elim`, `felicitous_of_presupFree` — is one structural recursion; truth is `Expr.Realize : Expr k → Kind.Point α k → Prop` (an atom for a term, nothing for a formula), with `Term.realize` and `Formula.Realize` as its fibres, removing the `Term.Mem` universe workaround. No `mutual` blocks remain; both studies re-derived unchanged in content.