### PR TITLE
chore(Studies/AbramskySadrzadeh2014): drop two transitive imports

### DIFF
--- a/Linglib/Studies/AbramskySadrzadeh2014.lean
+++ b/Linglib/Studies/AbramskySadrzadeh2014.lean
@@ -1,8 +1,6 @@
 import Mathlib.CategoryTheory.Sites.IsSheafFor
 import Mathlib.ModelTheory.Basic
 import Mathlib.Data.Fin.VecNotation
-import Mathlib.Data.Fintype.Pi
-import Mathlib.Data.Fintype.Sigma
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Tactic.DeriveFintype


### PR DESCRIPTION
`Data.Fintype.Pi` and `Data.Fintype.Sigma` already arrive via `Sites.IsSheafFor`/`Finsupp`; the remaining imports are each load-bearing.