### PR TITLE
refactor(Studies/AckemaNeeleman2018): person space substrate, Maximal Encoding

### DIFF
--- a/Linglib.lean
+++ b/Linglib.lean
@@ -2869,6 +2869,7 @@ import Linglib.Syntax.Minimalist.Phase.Basic
 import Linglib.Syntax.Minimalist.Phase.Domain
 import Linglib.Syntax.Minimalist.Phi.Geometry
 import Linglib.Syntax.Minimalist.Phi.Lattice
+import Linglib.Syntax.Minimalist.Phi.PersonSpace
 import Linglib.Syntax.Minimalist.Phi.Recursion
 import Linglib.Syntax.Minimalist.Position
 import Linglib.Syntax.Minimalist.Probe.Basic
@@ -2945,3 +2946,4 @@ import Linglib.Data.Examples.Ginzburg2012
 import Linglib.Data.Examples.KeshetAbney2024
 import Linglib.Data.Examples.AbneyKeshet2025
 import Linglib.Data.Examples.AbramskySadrzadeh2014
+import Linglib.Data.Examples.AckemaNeeleman2018

--- a/Linglib/Data/Examples/AckemaNeeleman2018.json
+++ b/Linglib/Data/Examples/AckemaNeeleman2018.json
@@ -1,0 +1,165 @@
+[
+  {
+    "id": "ackemaneeleman2018_2a",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (2a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "It seems that Mary has left for Paris.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "It seems that Mary has left for Paris.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "expletive"],
+      ["person", "third"]
+    ],
+    "comment": "Expletive pronouns are third person: only DIST can deliver an empty output set.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_2b",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (2b)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "It is raining again in Edinburgh.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "It is raining again in Edinburgh.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "expletive"],
+      ["person", "third"]
+    ],
+    "comment": "",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_20a",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (20a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "I can't believe your luck!",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "I can't believe your luck!",
+    "context": "John discovers he has a winning lottery ticket and talks to himself.",
+    "judgment": "acceptable",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "self-talk"],
+      ["roles", "i and u co-incide"]
+    ],
+    "comment": "The same individual bears the speaker and addressee roles; possible because the features carry no negative values.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_21a",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (21a)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "I can't believe your luck! If we hurry, we can still collect the money today.",
+    "discourseSegments": [
+      "I can't believe your luck!",
+      "If we hurry, we can still collect the money today."
+    ],
+    "glossedTokens": [],
+    "translation": "I can't believe your luck! If we hurry, we can still collect the money today.",
+    "context": "John discovers he has a winning lottery ticket and talks to himself.",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "self-talk"],
+      ["person", "first plural"]
+    ],
+    "comment": "A first person plural cannot refer to the speaker and the addressee-guise of the same individual.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_24",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (24)"},
+    "reportedIn": null,
+    "language": "stan1293",
+    "primaryText": "It seems that Vitesse won.",
+    "discourseSegments": [],
+    "glossedTokens": [],
+    "translation": "It seems that Vitesse won.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "It seem that Vitesse won.", "judgment": "ungrammatical"},
+      {"form": "I seem that Vitesse won.", "judgment": "ungrammatical"},
+      {"form": "You seem that Vitesse won.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "expletive"],
+      ["person", "third singular"]
+    ],
+    "comment": "Expletives are third person singular: plural is undefined on the empty set.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_25",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (25)"},
+    "reportedIn": null,
+    "language": "dutc1256",
+    "primaryText": "Nog jaren is naar een oplossing gezocht.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Nog", "still"], ["jaren", "years"], ["is", "be.3SG"], ["naar", "for"], ["een", "a"],
+      ["oplossing", "solution"], ["gezocht", "searched"]
+    ],
+    "translation": "People searched for a solution for many years.",
+    "context": "",
+    "judgment": "acceptable",
+    "alternatives": [
+      {"form": "Nog jaren ben naar een oplossing gezocht.", "judgment": "ungrammatical"},
+      {"form": "Nog jaren bent naar een oplossing gezocht.", "judgment": "ungrammatical"},
+      {"form": "Nog jaren zijn naar een oplossing gezocht.", "judgment": "ungrammatical"}
+    ],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "default agreement"],
+      ["construction", "impersonal passive"]
+    ],
+    "comment": "Default agreement in the absence of an agreeing argument is third person singular.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  },
+  {
+    "id": "ackemaneeleman2018_30",
+    "source": {"bibkey": "ackema-neeleman-2018", "paperLabel": "ch. 2 (30)"},
+    "reportedIn": null,
+    "language": "dutc1256",
+    "primaryText": "Men schijnt dat men regent.",
+    "discourseSegments": [],
+    "glossedTokens": [
+      ["Men", "one"], ["schijnt", "seems"], ["dat", "that"], ["men", "one"], ["regent", "rains"]
+    ],
+    "translation": "It seems that it rains.",
+    "context": "",
+    "judgment": "ungrammatical",
+    "alternatives": [],
+    "readings": [],
+    "paperFeatures": [
+      ["phenomenon", "expletive"],
+      ["pronoun", "featureless impersonal"]
+    ],
+    "comment": "The featureless pronoun refers to the whole input set, which has two obligatory members, so it cannot be a dummy.",
+    "metaLanguage": "stan1293",
+    "lgrConformance": ""
+  }
+]

--- a/Linglib/Data/Examples/AckemaNeeleman2018.lean
+++ b/Linglib/Data/Examples/AckemaNeeleman2018.lean
@@ -1,0 +1,144 @@
+import Linglib.Data.Examples.Schema
+
+/-!
+# `AckemaNeeleman2018` — typed example data
+
+Auto-generated from `Linglib/Data/Examples/AckemaNeeleman2018.json` by
+`scripts/gen_examples.py`. Do not edit by hand; edit the JSON and re-run
+the generator. Consumers (the paper's study file, test-suite hubs) import
+this module; declarations live in `namespace AckemaNeeleman2018.Examples`.
+-/
+
+namespace AckemaNeeleman2018.Examples
+
+open Data.Examples
+
+def ex_2a : LinguisticExample :=
+  { id := "ackemaneeleman2018_2a"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (2a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "It seems that Mary has left for Paris."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "It seems that Mary has left for Paris."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "expletive"), ("person", "third")]
+    comment := "Expletive pronouns are third person: only DIST can deliver an empty output set."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_2b : LinguisticExample :=
+  { id := "ackemaneeleman2018_2b"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (2b)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "It is raining again in Edinburgh."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "It is raining again in Edinburgh."
+    context := ""
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "expletive"), ("person", "third")]
+    comment := ""
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_20a : LinguisticExample :=
+  { id := "ackemaneeleman2018_20a"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (20a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I can't believe your luck!"
+    discourseSegments := []
+    glossedTokens := []
+    translation := "I can't believe your luck!"
+    context := "John discovers he has a winning lottery ticket and talks to himself."
+    judgment := .acceptable
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "self-talk"), ("roles", "i and u co-incide")]
+    comment := "The same individual bears the speaker and addressee roles; possible because the features carry no negative values."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_21a : LinguisticExample :=
+  { id := "ackemaneeleman2018_21a"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (21a)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "I can't believe your luck! If we hurry, we can still collect the money today."
+    discourseSegments := ["I can't believe your luck!", "If we hurry, we can still collect the money today."]
+    glossedTokens := []
+    translation := "I can't believe your luck! If we hurry, we can still collect the money today."
+    context := "John discovers he has a winning lottery ticket and talks to himself."
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "self-talk"), ("person", "first plural")]
+    comment := "A first person plural cannot refer to the speaker and the addressee-guise of the same individual."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_24 : LinguisticExample :=
+  { id := "ackemaneeleman2018_24"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (24)"⟩
+    reportedIn := none
+    language := "stan1293"
+    primaryText := "It seems that Vitesse won."
+    discourseSegments := []
+    glossedTokens := []
+    translation := "It seems that Vitesse won."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("It seem that Vitesse won.", .ungrammatical), ("I seem that Vitesse won.", .ungrammatical), ("You seem that Vitesse won.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("phenomenon", "expletive"), ("person", "third singular")]
+    comment := "Expletives are third person singular: plural is undefined on the empty set."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_25 : LinguisticExample :=
+  { id := "ackemaneeleman2018_25"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (25)"⟩
+    reportedIn := none
+    language := "dutc1256"
+    primaryText := "Nog jaren is naar een oplossing gezocht."
+    discourseSegments := []
+    glossedTokens := [("Nog", "still"), ("jaren", "years"), ("is", "be.3SG"), ("naar", "for"), ("een", "a"), ("oplossing", "solution"), ("gezocht", "searched")]
+    translation := "People searched for a solution for many years."
+    context := ""
+    judgment := .acceptable
+    alternatives := [("Nog jaren ben naar een oplossing gezocht.", .ungrammatical), ("Nog jaren bent naar een oplossing gezocht.", .ungrammatical), ("Nog jaren zijn naar een oplossing gezocht.", .ungrammatical)]
+    readings := []
+    paperFeatures := [("phenomenon", "default agreement"), ("construction", "impersonal passive")]
+    comment := "Default agreement in the absence of an agreeing argument is third person singular."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def ex_30 : LinguisticExample :=
+  { id := "ackemaneeleman2018_30"
+    source := ⟨"ackema-neeleman-2018", "ch. 2 (30)"⟩
+    reportedIn := none
+    language := "dutc1256"
+    primaryText := "Men schijnt dat men regent."
+    discourseSegments := []
+    glossedTokens := [("Men", "one"), ("schijnt", "seems"), ("dat", "that"), ("men", "one"), ("regent", "rains")]
+    translation := "It seems that it rains."
+    context := ""
+    judgment := .ungrammatical
+    alternatives := []
+    readings := []
+    paperFeatures := [("phenomenon", "expletive"), ("pronoun", "featureless impersonal")]
+    comment := "The featureless pronoun refers to the whole input set, which has two obligatory members, so it cannot be a dummy."
+    metaLanguage := "stan1293"
+    lgrConformance := "" }
+
+def all : List LinguisticExample := [ex_2a, ex_2b, ex_20a, ex_21a, ex_24, ex_25, ex_30]
+
+end AckemaNeeleman2018.Examples

--- a/Linglib/Studies/AckemaNeeleman2018.lean
+++ b/Linglib/Studies/AckemaNeeleman2018.lean
@@ -1,211 +1,214 @@
+import Linglib.Syntax.Minimalist.Phi.PersonSpace
+import Linglib.Morphology.Exponence.Select
 import Linglib.Features.Person.Decomposition
+import Linglib.Data.Examples.AckemaNeeleman2018
 
 /-!
-# Ackema & Neeleman (2018): Features of Person
-[ackema-neeleman-2018] [harbour-2016] [cysouw-2009]
+# Features of person
 
-Formalizes the person-feature system of Ch 2 ("Person Features: Deriving the
-Inventory of Persons"): two privative features `PROX` and `DIST`, interpreted as
-*functions* on a nested person space, derive exactly the attested inventory of
-persons (three singular, four plural) and the inclusive/exclusive distinction —
-with no negative features and without generating nonattested persons.
+Ackema and Neeleman derive the inventory of persons from two privative features acting as
+functions on a nested person space (`Minimalist.Phi.PersonSpace`): `DIST` selects the others
+layer for the third person, `PROX` then `DIST` the addressee layer for the second, `PROX` twice the
+innermost set for the first, and a single `PROX` the set of speaker and addressee for the
+inclusive (`eval_third`, `eval_second`, `eval_first`, `eval_inclusive`). The reverse order is
+incoherent and `PROX` cannot apply to the innermost set (`eval_incoherent`), so with number added
+above person the seven attested pronouns are the structures the system generates; they map onto
+Cysouw's categories with the inclusive undivided (`toCategory_inventory`), the inclusive has no
+singular because `Sᵢ₊ᵤ` has two obligatory members (`inclusive_not_singular`), and every
+number-blind spell-out rule treats the exclusive exactly as the first singular while one mentioning
+two `PROX` separates them from the inclusive (`applies_exclusive_iff_first`,
+`exists_applies_first_not_inclusive`).
 
-## Opt-in, bridged to the neutral inventory
+Third person is a default without being featureless: `DIST` alone can deliver the empty set, so
+only third person pronouns can be expletives (`exists_third_empty`, `first_second_nonempty`), and
+plural is undefined on the empty set, so expletives are singular (`expletive_singular`); the
+featureless pronoun denotes the whole space, whose two obligatory members keep it from being a
+dummy and force number to apply above person (`whole_space_nontrivial`). Spell-out is governed by
+Maximal Encoding — the applicable rule mentioning the most features wins (`realize`, through
+`Morphology.Exponence.selectBy`): Dutch's strong subject pronouns realize the paradigm with one
+form for both readings of the first plural (`dutch_paradigm`), whereas a vocabulary with a rule
+mentioning two `PROX` splits the exclusive from the inclusive (`clusive_split`).
 
-This is a *framework-specific* (DM/Minimalist) account and is **not** machinery
-the pronoun object or its consumers are committed to. A&N's PROX/DIST geometry
-is one of several competing decompositions (cf. [harbour-2016]'s
-`Studies/Harbour2016.lean`); the widely-adopted, framework-neutral
-representation is person + number + clusivity, encapsulated typologically by
-[cysouw-2009]'s `Person.Category`. The deliverable here is
-therefore `specToCategory`: a *converter* from an A&N feature structure to that
-neutral inventory. A consumer that wants the feature geometry imports it;
-everyone else uses the neutral category.
+## References
 
-## The person space (§2.2, (4))
-
-A nested family of sets of atoms `S_i ⊂ S_{i+u} ⊂ S_{i+u+o}`, where `S_i` has the
-speaker (`i`) as obligatory member, `S_{i+u}` adds an addressee (`u`), and
-`S_{i+u+o} = PRS` (the full input) adds others (`o`). `DIST` delivers a *layer*
-(a difference), which is unstructured and terminal.
-
-## The features as functions (§2.2, (6))
-
-* `PROX S = Pred S` — discards the outermost layer.
-* `DIST S = S − Pred S` — selects the outermost layer.
-
-applied to `PRS`, with later-applied features dominated by earlier-applied ones
-(the geometry of §2.2 (9)/(11)). Both require a *layered* input — on `S_i` and
-on a layer they are undefined, which is what bounds the inventory.
-
-## Main results
-
-* `eval_third`/`eval_second`/`eval_first`/`eval_incl` — the canonical structures
-  `[DIST]`, `[PROX,DIST]`, `[PROX,PROX]`, `[PROX]` derive 3/2/1/inclusive.
-* `excl_eq_first_singular` — first-person *exclusive* and first-person singular
-  share the structure `[PROX,PROX]`, deriving [cysouw-2009]'s homophony
-  observation; inclusive (`[PROX]`) is distinct.
-* `reverse_order_incoherent` / `output_bounded` — `DIST` then `PROX` is
-  incoherent and the output space is finite, so no nonattested person is
-  generated.
-* `specToCategory` + `inventory_distinct` — the converter to the neutral
-  `Person.Category`, faithful on the seven attested persons.
+* [ackema-neeleman-2018]
+* [cysouw-2009]
+* [harbour-2016]
+* [bobaljik-2008]
 -/
 
 namespace AckemaNeeleman2018
 
+open Minimalist.Phi Minimalist.Phi.PersonSpace Morphology.Exponence
 open Person (Category)
 
-/-! ### The person space and the two features -/
+variable {α : Type*}
 
-/-- A privative person feature (§2.2), interpreted below as a function on the
-    nested person space. The names reflect the speaker/addressee proximity
-    intuition; the content is the function semantics in `PFeature.apply`. -/
-inductive PFeature where
-  | prox
-  | dist
-  deriving DecidableEq, Repr
+/-! ### The inventory of persons -/
 
-/-- A point in the person space (§2.2, (4)): a nested *level*
-    (`S_i ⊂ S_{i+u} ⊂ S_{i+u+o}`) or a *layer* that `DIST` selects. Levels are
-    layered (have a predecessor, so further features can apply); layers are
-    unstructured and terminal. -/
-inductive PSet where
-  /-- `S_i`: speaker (and any associates) obligatory. -/
-  | si
-  /-- `S_{i+u}`: additionally an addressee obligatory. -/
-  | siu
-  /-- `S_{i+u+o} = PRS`: the full input set. -/
-  | siuo
-  /-- `S_{i+u} − S_i`: the addressee layer (the output of `DIST` on `S_{i+u}`). -/
-  | uLayer
-  /-- `S_{i+u+o} − S_{i+u}`: the others layer (the output of `DIST` on `PRS`). -/
-  | oLayer
-  deriving DecidableEq, Repr
+/-- Third person `[DIST]`. -/
+def third : Spec := [.dist]
 
-/-- `Pred` (§2.2, (5)): the predecessor in the nesting. Defined only on the two
-    non-minimal levels; `none` for `S_i` (minimal) and for layers (unstructured). -/
-def PSet.pred : PSet → Option PSet
-  | .siuo => some .siu
-  | .siu  => some .si
-  | _     => none
+/-- Second person `[PROX–DIST]`. -/
+def second : Spec := [.prox, .dist]
 
-/-- Apply a person feature (§2.2, (6)). `PROX` discards the outermost layer
-    (`= Pred`); `DIST` selects it (`= S − Pred S`). Both require a layered input,
-    so both are `none` on `S_i` and on a layer. -/
-def PFeature.apply (f : PFeature) (s : PSet) : Option PSet :=
-  match f with
-  | .prox => s.pred
-  | .dist =>
-    match s with
-    | .siuo => some .oLayer
-    | .siu  => some .uLayer
-    | _     => none
+/-- First person `[PROX–PROX]`. -/
+def first : Spec := [.prox, .prox]
 
-/-- A person feature structure: the sequence of features, host (applied first)
-    at the head — the geometry of §2.2 (9)/(11). -/
-abbrev PSpec := List PFeature
+/-- First person inclusive `[PROX]`. -/
+def inclusive : Spec := [.prox]
 
-/-- Evaluate a feature structure on `PRS = S_{i+u+o}`. Host-first: `[PROX, DIST]`
-    is `DIST (PROX PRS)`. `none` if any application is incoherent — i.e. the
-    structure is not generable by the system. -/
-def PSpec.eval (fs : PSpec) : Option PSet :=
-  fs.foldl (fun acc f => acc.bind f.apply) (some .siuo)
+theorem eval_third : third.eval = some .others := rfl
 
-/-! ### The canonical structures and their derivations (§2.2) -/
+theorem eval_second : second.eval = some .addressees := rfl
 
-/-- Third person: `[DIST]` selects the others layer. -/
-def third : PSpec := [.dist]
-/-- Second person: `[PROX, DIST]` selects the addressee layer. -/
-def second : PSpec := [.prox, .dist]
-/-- First person (singular / exclusive): `[PROX, PROX]` reaches `S_i`, whose
-    only obligatory member is the speaker. -/
-def first : PSpec := [.prox, .prox]
-/-- First person inclusive: `[PROX]` reaches `S_{i+u}` (speaker + addressee);
-    singular-incompatible, so attested only in the plural. -/
-def incl : PSpec := [.prox]
-
-theorem eval_third : third.eval = some .oLayer := rfl
-theorem eval_second : second.eval = some .uLayer := rfl
 theorem eval_first : first.eval = some .si := rfl
-theorem eval_incl : incl.eval = some .siu := rfl
 
-/-! ### Clusivity is derived (§2.2)
+theorem eval_inclusive : inclusive.eval = some .siu := rfl
 
-First-person exclusive and first-person singular share the *same* feature
-structure `[PROX, PROX]`; the inclusive has a distinct structure `[PROX]`. This
-derives [cysouw-2009]'s observation that the exclusive is regularly
-homophonous with the first-person singular while the inclusive is hardly ever. -/
+/-- `DIST` before `PROX` is incoherent, and `PROX` cannot apply to `Sᵢ`. -/
+theorem eval_incoherent :
+    Spec.eval [.dist, .prox] = none ∧ Spec.eval [.prox, .prox, .prox] = none :=
+  ⟨rfl, rfl⟩
 
-/-- First-person exclusive *is* the first-person singular structure. -/
-theorem excl_eq_first_singular : first = first := rfl
+/-- `[PROX]` has no singular reading: `Sᵢ₊ᵤ` has two obligatory members. -/
+theorem inclusive_not_singular (S : PersonSpace α) : ¬ (S.denote .siu).Subsingleton :=
+  S.nontrivial_denote_siu.not_subsingleton
 
-/-- The inclusive output contains the addressee (`S_{i+u}`); the exclusive output
-    does not (`S_i`). Clusivity is read off the output set, not stipulated. -/
-theorem incl_excl_distinct :
-    incl.eval = some .siu ∧ first.eval = some .si := ⟨rfl, rfl⟩
+/-- A pronoun: a person structure under a number node, plural or not. -/
+structure Pronoun where
+  /-- The person feature structure. -/
+  person : Spec
+  /-- Whether the number node carries `PL`. -/
+  plural : Bool
+  deriving DecidableEq
 
-/-! ### No nonattested persons (§2.2, p. 28–29)
+/-- The seven attested pronouns: three singular, four plural. -/
+def inventory : List Pronoun :=
+  [⟨first, false⟩, ⟨second, false⟩, ⟨third, false⟩, ⟨inclusive, true⟩, ⟨first, true⟩,
+    ⟨second, true⟩, ⟨third, true⟩]
 
-The opposite order of application is incoherent (`DIST` delivers an unstructured
-layer, to which `PROX`/`DIST` cannot apply), and the output space is finite — so
-the system generates exactly the attested structures and no others. -/
+/-- The typological category of a pronoun: Cysouw's inventory with the inclusive undivided,
+its minimal/augmented split being a matter of number. -/
+def Pronoun.toCategory (p : Pronoun) : Option Category :=
+  p.person.eval.bind fun r =>
+    match r, p.plural with
+    | .si, false => some .s1
+    | .si, true => some .excl
+    | .siu, true => some .augIncl
+    | .addressees, false => some .s2
+    | .addressees, true => some .secondGrp
+    | .others, false => some .s3
+    | .others, true => some .thirdGrp
+    | _, _ => none
 
-/-- `DIST` then `PROX` is incoherent, and `PROX` cannot iterate past `S_i`. -/
-theorem reverse_order_incoherent :
-    PSpec.eval [.dist, .prox] = none ∧
-    PSpec.eval [.prox, .prox, .prox] = none := ⟨rfl, rfl⟩
+/-- The inventory realizes every category but the minimal inclusive. -/
+theorem toCategory_inventory :
+    ∀ c ∈ Category.all, c ≠ .minIncl ↔ ∃ p ∈ inventory, p.toCategory = some c := by
+  decide
 
-/-- Every evaluation lands in the finite output space: `none`, the bare input
-    `S_{i+u+o}`, or one of the four attested person sets. There is no room for a
-    fourth singular person or any nonattested category. -/
-theorem output_bounded (fs : PSpec) :
-    fs.eval = none ∨ fs.eval = some .siuo ∨ fs.eval = some .si ∨
-    fs.eval = some .siu ∨ fs.eval = some .uLayer ∨ fs.eval = some .oLayer := by
-  rcases h : fs.eval with _ | s
-  · exact .inl rfl
-  · cases s <;> simp
+theorem toCategory_inclusive_singular : (⟨inclusive, false⟩ : Pronoun).toCategory = none := rfl
 
-/-! ### Bridge to the neutral inventory ([cysouw-2009] `Category`) -/
+/-! ### Third person as default -/
 
-/-- Map an output set together with its number (`plural`) to the neutral
-    [cysouw-2009] person category. `S_i` is first-singular / exclusive
-    depending on number; `S_{i+u}` is the (augmented) inclusive — A&N's basic
-    system does not split minimal vs augmented inclusive, which is a number
-    matter (their ch. 3), so it maps to `.augIncl`. `none` for the
-    singular-incompatible inclusive and for the bare input. -/
-def outputToCategory : PSet → Bool → Option Category
-  | .si,     false => some .s1
-  | .si,     true  => some .excl
-  | .siu,    true  => some .augIncl
-  | .uLayer, false => some .s2
-  | .uLayer, true  => some .secondGrp
-  | .oLayer, false => some .s3
-  | .oLayer, true  => some .thirdGrp
-  | _,       _     => none
+/-- `DIST` may deliver the empty set: expletives are third person. -/
+theorem exists_third_empty : ∃ S : PersonSpace Bool, S.denote .others = ∅ :=
+  exists_denote_others_eq_empty Bool.false_ne_true
 
-/-- Converter from an A&N feature structure (plus number) to the neutral
-    [cysouw-2009] `Category`. This is the opt-in bridge: the pronoun object
-    and its consumers stay on the neutral category; this is how a consumer that
-    has reasoned in A&N's geometry rejoins them. -/
-def specToCategory (fs : PSpec) (plural : Bool) : Option Category :=
-  (fs.eval).bind (outputToCategory · plural)
+/-- First and second person never denote the empty set. -/
+theorem first_second_nonempty (S : PersonSpace α) :
+    (S.denote .si).Nonempty ∧ (S.denote .addressees).Nonempty :=
+  ⟨S.denote_nonempty (by decide), S.denote_nonempty (by decide)⟩
 
-/-- The seven attested persons map onto seven distinct neutral categories,
-    covering all of [cysouw-2009]'s inventory except `.minIncl` (the
-    minimal inclusive — a number refinement A&N defer to their ch. 3). -/
-theorem inventory_distinct :
-    specToCategory first false = some .s1 ∧
-    specToCategory second false = some .s2 ∧
-    specToCategory third false = some .s3 ∧
-    specToCategory first true = some .excl ∧
-    specToCategory incl true = some .augIncl ∧
-    specToCategory second true = some .secondGrp ∧
-    specToCategory third true = some .thirdGrp := by
-  refine ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+/-- Expletives are singular: plural is undefined on the empty set. -/
+theorem expletive_singular (S : PersonSpace α) (h : S.denote .others = ∅) :
+    ¬ S.PluralDefined .others :=
+  S.not_pluralDefined_of_eq_empty h
 
-/-- The singular-incompatible inclusive (`[PROX]` with no number) has no
-    category — A&N's reason the inclusive surfaces only in the plural. -/
-theorem incl_singular_undefined : specToCategory incl false = none := rfl
+theorem eval_nil : Spec.eval [] = some .siuo := rfl
+
+/-- The featureless pronoun denotes the whole space, which has two obligatory members: it cannot
+be a dummy, and number applied before person would always find a plurality, so plural is
+undefined there. -/
+theorem whole_space_nontrivial (S : PersonSpace α) :
+    (S.denote .siuo).Nontrivial ∧ ¬ S.PluralDefined .siuo :=
+  ⟨S.nontrivial_denote_siuo, S.not_pluralDefined_siuo⟩
+
+/-! ### Spell-out and Maximal Encoding -/
+
+/-- A spell-out rule: the person features it mentions, with multiplicity, whether it mentions
+`PL`, and its form. -/
+structure SpellOut (E : Type*) where
+  /-- The person features mentioned. -/
+  features : List Feature
+  /-- Whether `PL` is mentioned. -/
+  plural : Bool
+  /-- The form inserted. -/
+  form : E
+
+variable {E : Type*}
+
+/-- A rule applies to a pronoun whose structure contains every feature it mentions. -/
+instance : Rule (SpellOut E) Pronoun E where
+  exponent r := r.form
+  Applies r p := (∀ f, r.features.count f ≤ p.person.count f) ∧ (r.plural = true → p.plural = true)
+
+instance : DecidableRel (Applies : SpellOut E → Pronoun → Prop) := fun _ _ =>
+  inferInstanceAs (Decidable (_ ∧ _))
+
+/-- Every number-blind rule applies to the exclusive exactly when it applies to the first
+singular: the two share their person structure. -/
+theorem applies_exclusive_iff_first (r : SpellOut E) (h : r.plural = false) :
+    Applies r (⟨first, true⟩ : Pronoun) ↔ Applies r ⟨first, false⟩ := by
+  simp [Applies, h]
+
+/-- A rule mentioning two `PROX` applies to the first singular but not to the inclusive. -/
+theorem exists_applies_first_not_inclusive (e : E) :
+    ∃ r : SpellOut E, Applies r (⟨first, false⟩ : Pronoun) ∧ ¬ Applies r ⟨inclusive, true⟩ :=
+  ⟨⟨[.prox, .prox], false, e⟩, ⟨fun _ => le_rfl, fun h => Bool.noConfusion h⟩, fun ⟨h, _⟩ =>
+    absurd (h .prox) (show ¬ ([Feature.prox, .prox].count .prox ≤ inclusive.count .prox) by decide)⟩
+
+/-- Maximal Encoding: the applicable rule mentioning the most features is used. -/
+def realize (v : List (SpellOut E)) (p : Pronoun) : Option E :=
+  Morphology.Exponence.realize (fun r => r.features.length + r.plural.toNat) v p
+
+/-- The Dutch strong subject pronouns. -/
+inductive DutchForm
+  | ik
+  | jij
+  | hij
+  | wij
+  | jullie
+  | zij
+  deriving DecidableEq
+
+/-- The Dutch spell-out rules: no rule mentions two `PROX`. -/
+def dutch : List (SpellOut DutchForm) :=
+  [⟨[.prox], false, .ik⟩, ⟨[.prox, .dist], false, .jij⟩, ⟨[.dist], false, .hij⟩,
+    ⟨[.prox], true, .wij⟩, ⟨[.prox, .dist], true, .jullie⟩, ⟨[.dist], true, .zij⟩]
+
+/-- The Dutch paradigm: the more specific rule blocks the less specific one, and one form
+realizes both the inclusive and the exclusive. -/
+theorem dutch_paradigm :
+    inventory.map (realize dutch) =
+      [some .ik, some .jij, some .hij, some .wij, some .wij, some .jullie, some .zij] := by
+  decide
+
+/-- A vocabulary distinguishing the readings of the first plural. -/
+inductive ClusiveForm
+  | exclusive
+  | inclusive
+  deriving DecidableEq
+
+/-- Rules mentioning two and one `PROX` under `PL`. -/
+def clusive : List (SpellOut ClusiveForm) :=
+  [⟨[.prox, .prox], true, .exclusive⟩, ⟨[.prox], true, .inclusive⟩]
+
+/-- The rule mentioning two `PROX` blocks the other on the exclusive and cannot apply to the
+inclusive. -/
+theorem clusive_split :
+    realize clusive ⟨first, true⟩ = some .exclusive ∧
+      realize clusive ⟨inclusive, true⟩ = some .inclusive := by
+  decide
 
 end AckemaNeeleman2018

--- a/Linglib/Syntax/Minimalist/Phi/PersonSpace.lean
+++ b/Linglib/Syntax/Minimalist/Phi/PersonSpace.lean
@@ -1,0 +1,173 @@
+import Mathlib.Data.Set.Subsingleton
+import Mathlib.Tactic.DeriveFintype
+
+/-!
+# The person space and function-valued person features
+
+This file defines the person space of Ackema and Neeleman: a nested chain of sets of atoms
+`Sᵢ ⊆ Sᵢ₊ᵤ ⊆ Sᵢ₊ᵤ₊ₒ` in which the speaker is an obligatory member of the innermost set and an
+addressee of the middle one, together with two privative person features interpreted as partial
+functions on it — `PROX` discards the outermost layer of a layered set and `DIST` selects it — and
+the feature structures built by applying them in sequence to the whole space. Third person selects
+the others layer, second person the addressee layer, first person the innermost set, and the
+inclusive the middle set; neither feature applies to a layer or to the innermost set, which bounds
+the inventory. Plural is defined only on an output of the person system with more than one member.
+
+## Main definitions
+
+* `Minimalist.Phi.PersonSpace`: the nested person space over a type of atoms.
+* `PersonSpace.Region`, `PersonSpace.denote`: the sets a feature structure can select and their
+  denotations.
+* `PersonSpace.Feature`, `Feature.apply`, `PersonSpace.Spec`, `Spec.eval`: the features as partial
+  functions on regions, and feature structures evaluated on the whole space.
+* `PersonSpace.PluralDefined`: the definedness condition of plural.
+
+## Main statements
+
+* `PersonSpace.Spec.eval_mem`: every feature structure evaluates to one of the five regions or is
+  incoherent.
+* `PersonSpace.denote_nonempty`, `PersonSpace.exists_denote_others_eq_empty`: only the others
+  layer can be empty.
+* `PersonSpace.nontrivial_denote_siu`, `PersonSpace.nontrivial_denote_siuo`: the middle set and
+  the whole space have two obligatory members.
+
+## References
+
+* [ackema-neeleman-2018]
+-/
+
+namespace Minimalist.Phi
+
+/-- The person space: nested sets of atoms with the speaker an obligatory member of `Sᵢ` and an
+addressee of `Sᵢ₊ᵤ`; the remaining members are associates and others. -/
+structure PersonSpace (α : Type*) where
+  /-- The speaker `i`. -/
+  speaker : α
+  /-- The addressee `u`. -/
+  addressee : α
+  /-- `Sᵢ`: the speaker and any associates or co-speakers. -/
+  Si : Set α
+  /-- `Sᵢ₊ᵤ`: additionally an addressee and any associates or co-addressees. -/
+  Siu : Set α
+  /-- `Sᵢ₊ᵤ₊ₒ`: additionally the others. -/
+  Siuo : Set α
+  speaker_mem : speaker ∈ Si
+  addressee_mem : addressee ∈ Siu
+  addressee_notMem : addressee ∉ Si
+  Si_subset : Si ⊆ Siu
+  Siu_subset : Siu ⊆ Siuo
+
+namespace PersonSpace
+
+variable {α : Type*} (S : PersonSpace α)
+
+/-- The regions a feature structure can select: the three nested sets and the two layers between
+them. -/
+inductive Region
+  | si
+  | siu
+  | siuo
+  | addressees
+  | others
+  deriving DecidableEq, Repr, Fintype
+
+/-- The predecessor of a layered set: `Pred Sᵢ₊ᵤ = Sᵢ`, `Pred Sᵢ₊ᵤ₊ₒ = Sᵢ₊ᵤ`. -/
+def Region.pred : Region → Option Region
+  | .siuo => some .siu
+  | .siu => some .si
+  | _ => none
+
+/-- The two privative person features. -/
+inductive Feature
+  | prox
+  | dist
+  deriving DecidableEq, Repr, Fintype
+
+/-- `PROX S = Pred S` discards, and `DIST S = S − Pred S` selects, the outermost layer of a
+layered set; neither applies to an unlayered one. -/
+def Feature.apply : Feature → Region → Option Region
+  | .prox, r => r.pred
+  | .dist, .siuo => some .others
+  | .dist, .siu => some .addressees
+  | .dist, _ => none
+
+/-- A person feature structure: the features in order of application. -/
+abbrev Spec := List Feature
+
+/-- Apply the features in order to `Sᵢ₊ᵤ₊ₒ`; `none` when a feature meets an unlayered set. -/
+def Spec.eval (fs : Spec) : Option Region :=
+  fs.foldl (fun acc f => acc.bind f.apply) (some .siuo)
+
+/-- Every feature structure is incoherent or selects one of the five regions. -/
+theorem Spec.eval_mem (fs : Spec) :
+    fs.eval = none ∨ fs.eval = some .siuo ∨ fs.eval = some .si ∨ fs.eval = some .siu ∨
+      fs.eval = some .addressees ∨ fs.eval = some .others := by
+  rcases h : fs.eval with _ | r
+  · exact .inl rfl
+  · cases r <;> simp
+
+/-- The set of atoms a region denotes. -/
+def denote : Region → Set α
+  | .si => S.Si
+  | .siu => S.Siu
+  | .siuo => S.Siuo
+  | .addressees => S.Siu \ S.Si
+  | .others => S.Siuo \ S.Siu
+
+theorem speaker_ne_addressee : S.speaker ≠ S.addressee := fun h =>
+  S.addressee_notMem (h ▸ S.speaker_mem)
+
+theorem speaker_mem_denote_si : S.speaker ∈ S.denote .si := S.speaker_mem
+
+theorem speaker_mem_denote_siu : S.speaker ∈ S.denote .siu := S.Si_subset S.speaker_mem
+
+theorem speaker_mem_denote_siuo : S.speaker ∈ S.denote .siuo :=
+  S.Siu_subset S.speaker_mem_denote_siu
+
+theorem addressee_mem_denote_addressees : S.addressee ∈ S.denote .addressees :=
+  ⟨S.addressee_mem, S.addressee_notMem⟩
+
+theorem speaker_notMem_denote_addressees : S.speaker ∉ S.denote .addressees := fun h =>
+  h.2 S.speaker_mem
+
+theorem speaker_notMem_denote_others : S.speaker ∉ S.denote .others := fun h =>
+  h.2 S.speaker_mem_denote_siu
+
+theorem addressee_notMem_denote_others : S.addressee ∉ S.denote .others := fun h =>
+  h.2 S.addressee_mem
+
+/-- Every region but the others layer contains the speaker or the addressee. -/
+theorem denote_nonempty {r : Region} (h : r ≠ .others) : (S.denote r).Nonempty := by
+  cases r with
+  | addressees => exact ⟨_, S.addressee_mem_denote_addressees⟩
+  | others => exact absurd rfl h
+  | si => exact ⟨_, S.speaker_mem_denote_si⟩
+  | siu => exact ⟨_, S.speaker_mem_denote_siu⟩
+  | siuo => exact ⟨_, S.speaker_mem_denote_siuo⟩
+
+/-- The others layer can be empty. -/
+theorem exists_denote_others_eq_empty {a b : α} (hab : a ≠ b) :
+    ∃ S : PersonSpace α, S.denote .others = ∅ :=
+  ⟨⟨a, b, {a}, {a, b}, {a, b}, rfl, by simp, by simpa using hab.symm, by simp, subset_rfl⟩,
+    by simp [denote]⟩
+
+/-- `Sᵢ₊ᵤ` has two obligatory members, the speaker and an addressee. -/
+theorem nontrivial_denote_siu : (S.denote .siu).Nontrivial :=
+  ⟨_, S.speaker_mem_denote_siu, _, S.addressee_mem, S.speaker_ne_addressee⟩
+
+/-- The whole space has two obligatory members. -/
+theorem nontrivial_denote_siuo : (S.denote .siuo).Nontrivial :=
+  ⟨_, S.speaker_mem_denote_siuo, _, S.Siu_subset S.addressee_mem, S.speaker_ne_addressee⟩
+
+/-- Plural is defined on an output of the person system with more than one member, and not on
+the whole space. -/
+def PluralDefined (r : Region) : Prop := r ≠ .siuo ∧ (S.denote r).Nontrivial
+
+theorem not_pluralDefined_siuo : ¬ S.PluralDefined .siuo := fun h => h.1 rfl
+
+theorem not_pluralDefined_of_eq_empty {r : Region} (h : S.denote r = ∅) : ¬ S.PluralDefined r :=
+  fun ⟨_, ⟨_, ha, _⟩⟩ => by simp [h] at ha
+
+end PersonSpace
+
+end Minimalist.Phi

--- a/references.bib
+++ b/references.bib
@@ -25501,8 +25501,8 @@
   isbn      = {9780262038195},
   subfield  = {syntax},
   validated = {true},
-  role      = {cited},
-  sources   = {Studies/AckemaNeeleman2018.lean}
+  role      = {formalized},
+  sources   = {Syntax/Minimalist/Phi/PersonSpace.lean;Studies/AckemaNeeleman2018.lean}
 }
 @inproceedings{giorgolo-asudeh-2012,
   author    = {Giorgolo, Gianluca and Asudeh, Ash},


### PR DESCRIPTION
Deep cleanse against the book (ch. 2). Moves the person space and function-valued `PROX`/`DIST` features to `Syntax/Minimalist/Phi/PersonSpace.lean` with set-level theorems (only the others layer can be empty; `Sᵢ₊ᵤ` and the whole space have two obligatory members; plural definedness), and recuts the study on the paper's derivations, the third-person-default argument, and §5's Maximal Encoding spell-out through the `Morphology.Exponence` API (Dutch paradigm, inclusive/exclusive as a spell-out parameter). Fixes wrong locators, drops the vacuous `first = first` theorem, adds the examples JSON.